### PR TITLE
Allow dynamic configuration of ringpop replica points

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -174,6 +174,12 @@ config as the other services.`,
 		`RingpopApproximateMaxPropagationTime is used for timing certain startup and shutdown processes.
 (It is not and doesn't have to be a guarantee.)`,
 	)
+	RingpopReplicaPoints = NewGlobalIntSetting(
+		"system.ringpopReplicaPoints",
+		100,
+		`RingpopReplicaPoints is the number of virtual nodes (replica points) per physical host
+in the consistent hash ring used by ringpop. Changing it may cause service disruption during deployment.`,
+	)
 	EnableParentClosePolicyWorker = NewGlobalBoolSetting(
 		"system.enableParentClosePolicyWorker",
 		true,

--- a/common/membership/ringpop/factory.go
+++ b/common/membership/ringpop/factory.go
@@ -110,6 +110,7 @@ func (factory *factory) getMonitor() *monitor {
 		// Empirically, ringpop updates usually propagate in under a second even in relatively large clusters.
 		// 3 seconds is an over-estimate to be safer.
 		maxPropagationTime := dynamicconfig.RingpopApproximateMaxPropagationTime.Get(factory.DC)()
+		replicaPoints := dynamicconfig.RingpopReplicaPoints.Get(factory.DC)()
 
 		factory.monitor = newMonitor(
 			factory.ServiceName,
@@ -121,6 +122,7 @@ func (factory *factory) getMonitor() *monitor {
 			factory.Config.MaxJoinDuration,
 			maxPropagationTime,
 			factory.getJoinTime(maxPropagationTime),
+			replicaPoints,
 		)
 	})
 

--- a/common/membership/ringpop/monitor.go
+++ b/common/membership/ringpop/monitor.go
@@ -61,6 +61,7 @@ type monitor struct {
 	propagationTime           time.Duration
 	joinTime                  time.Time
 	rings                     map[primitives.ServiceName]*serviceResolver
+	replicaPoints             int
 	logger                    log.Logger
 	metadataManager           persistence.ClusterMetadataManager
 	broadcastHostPortResolver func() (string, error)
@@ -81,6 +82,7 @@ func newMonitor(
 	maxJoinDuration time.Duration,
 	propagationTime time.Duration,
 	joinTime time.Time,
+	replicaPoints int,
 ) *monitor {
 	lifecycleCtx, lifecycleCancel := context.WithCancel(context.Background())
 	lifecycleCtx = headers.SetCallerInfo(
@@ -100,6 +102,7 @@ func newMonitor(
 		services:                  services,
 		rp:                        rp,
 		rings:                     make(map[primitives.ServiceName]*serviceResolver),
+		replicaPoints:             replicaPoints,
 		logger:                    logger,
 		metadataManager:           metadataManager,
 		broadcastHostPortResolver: broadcastHostPortResolver,
@@ -110,7 +113,7 @@ func newMonitor(
 		joinTime:                  joinTime,
 	}
 	for service, port := range services {
-		rpo.rings[service] = newServiceResolver(service, port, rp, logger)
+		rpo.rings[service] = newServiceResolver(service, port, rp, replicaPoints, logger)
 	}
 	return rpo
 }

--- a/common/membership/ringpop/service_resolver.go
+++ b/common/membership/ringpop/service_resolver.go
@@ -47,7 +47,6 @@ const (
 
 	minRefreshInternal     = time.Second * 4
 	defaultRefreshInterval = time.Second * 10
-	replicaPoints          = 100
 )
 
 const (
@@ -59,13 +58,14 @@ const (
 
 type (
 	serviceResolver struct {
-		service     primitives.ServiceName
-		port        int
-		rp          *ringpop.Ringpop
-		refreshChan chan struct{}
-		shutdownCh  chan struct{}
-		shutdownWG  sync.WaitGroup
-		logger      log.Logger
+		service       primitives.ServiceName
+		port          int
+		rp            *ringpop.Ringpop
+		replicaPoints int
+		refreshChan   chan struct{}
+		shutdownCh    chan struct{}
+		shutdownWG    sync.WaitGroup
+		logger        log.Logger
 
 		ringAndHosts atomic.Value // holds a ringAndHosts
 
@@ -96,12 +96,14 @@ func newServiceResolver(
 	service primitives.ServiceName,
 	port int,
 	rp *ringpop.Ringpop,
+	replicaPoints int,
 	logger log.Logger,
 ) *serviceResolver {
 	resolver := &serviceResolver{
 		service:             service,
 		port:                port,
 		rp:                  rp,
+		replicaPoints:       replicaPoints,
 		refreshChan:         make(chan struct{}),
 		shutdownCh:          make(chan struct{}),
 		logger:              log.With(logger, tag.ComponentServiceResolver, tag.Service(service)),
@@ -109,13 +111,13 @@ func newServiceResolver(
 		listeners:           make(map[string]chan<- *membership.ChangedEvent),
 	}
 	resolver.ringAndHosts.Store(ringAndHosts{
-		ring:  newHashRing(),
+		ring:  newHashRing(replicaPoints),
 		hosts: make(map[string]*hostInfo),
 	})
 	return resolver
 }
 
-func newHashRing() *hashring.HashRing {
+func newHashRing(replicaPoints int) *hashring.HashRing {
 	return hashring.New(farm.Fingerprint32, replicaPoints)
 }
 
@@ -136,7 +138,7 @@ func (r *serviceResolver) Stop() {
 	defer r.listenerLock.Unlock()
 	r.rp.RemoveListener(r)
 	r.ringAndHosts.Store(ringAndHosts{
-		ring:  newHashRing(),
+		ring:  newHashRing(r.replicaPoints),
 		hosts: nil,
 	})
 	r.listeners = make(map[string]chan<- *membership.ChangedEvent)
@@ -293,7 +295,7 @@ func (r *serviceResolver) refreshLocked() (*membership.ChangedEvent, error) {
 		return nil, nil
 	}
 
-	ring := newHashRing()
+	ring := newHashRing(r.replicaPoints)
 	ring.AddMembers(util.MapSlice(hosts, func(h *hostInfo) rpmembership.Member { return h })...)
 
 	r.lastRefreshTime = time.Now().UTC()

--- a/common/membership/ringpop/test_cluster.go
+++ b/common/membership/ringpop/test_cluster.go
@@ -152,6 +152,7 @@ func newTestCluster(
 			2*time.Second,
 			3*time.Second,
 			joinTime,
+			100,
 		)
 		cluster.rings[i].Start()
 	}


### PR DESCRIPTION
## What changed?

Added a configurable `ReplicaPoints` variable to the ringpop service resolver. Instead of a hardcoded constant (`replicaPoints = 100`), the number of virtual nodes per host is now
  controlled by a `var ReplicaPoints func()` int that can be overridden.

When the value returned by `ReplicaPoints()` changes, the hash ring is rebuilt and a `ChangedEvent` is emitted -- even if membership itself hasn't changed.

## Why?

The default of 100 replica points is not optimal for all combinations of shard and history node counts and may lead to uneven shard distribution across history nodes.

For example, having 4096 shards with 9 history nodes with 100 replica points gives us std dev around 50 shards. Increasing replica points to 500 lowers std dev to around 30 shards. The optimal replica points is roughly `shards / nodes`, which equates the number of "shard points" and "node points" on the ring.

For 4096 shards and 9 history nodes, distribution got better as follows
* with 100 replica points: 370, 380, 408, 442, 452, 488, 510, 520, 526 (shards per node);
* with 500 replica points: 426, 444, 446, 446, 450, 452, 458, 474, 500.

This patch allows setting custom `ringpop.ReplicaPoints` (e.g. to dynamic config value getter) before starting the server, and gradually (to avoid reshuffling too many shards at once) increasing replica points to the desired value.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
None if `var ReplicaPoints func()` not modified.
If the server is built with overridden `ReplicaPoints`, it may cause ring inconsistency across cluster nodes during the deployment process.