### PR TITLE
refactor: migrate WorkflowVisibilityTestSuite to testcore.NewEnv

### DIFF
--- a/tests/workflow_visibility_test.go
+++ b/tests/workflow_visibility_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestWorkflowVisibilityTestSuite(t *testing.T) {
-	t.Parallel()
 	s := testcore.NewEnv(t)
 	startTime := time.Now().UTC()
 

--- a/tests/workflow_visibility_test.go
+++ b/tests/workflow_visibility_test.go
@@ -19,13 +19,7 @@ import (
 
 func TestWorkflowVisibilityTestSuite(t *testing.T) {
 	t.Parallel()
-	t.Run("TestVisibility", func(t *testing.T) {
-		s := testcore.NewEnv(t)
-		wvTestVisibility(s)
-	})
-}
-
-func wvTestVisibility(s *testcore.TestEnv) {
+	s := testcore.NewEnv(t)
 	startTime := time.Now().UTC()
 
 	// Start 2 workflow executions

--- a/tests/workflow_visibility_test.go
+++ b/tests/workflow_visibility_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/suite"
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -18,16 +17,15 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-type WorkflowVisibilityTestSuite struct {
-	testcore.FunctionalTestBase
-}
-
 func TestWorkflowVisibilityTestSuite(t *testing.T) {
 	t.Parallel()
-	suite.Run(t, new(WorkflowVisibilityTestSuite))
+	t.Run("TestVisibility", func(t *testing.T) {
+		s := testcore.NewEnv(t)
+		wvTestVisibility(s)
+	})
 }
 
-func (s *WorkflowVisibilityTestSuite) TestVisibility() {
+func wvTestVisibility(s *testcore.TestEnv) {
 	startTime := time.Now().UTC()
 
 	// Start 2 workflow executions

--- a/tests/workflow_visibility_test.go
+++ b/tests/workflow_visibility_test.go
@@ -12,13 +12,22 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/common/payloads"
+	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+type WorkflowVisibilityTestSuite struct {
+	parallelsuite.Suite[*WorkflowVisibilityTestSuite]
+}
+
 func TestWorkflowVisibilityTestSuite(t *testing.T) {
-	s := testcore.NewEnv(t)
+	parallelsuite.Run(t, &WorkflowVisibilityTestSuite{})
+}
+
+func (s *WorkflowVisibilityTestSuite) TestVisibility() {
+	env := testcore.NewEnv(s.T())
 	startTime := time.Now().UTC()
 
 	// Start 2 workflow executions
@@ -30,7 +39,7 @@ func TestWorkflowVisibilityTestSuite(t *testing.T) {
 
 	startRequest := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:           uuid.NewString(),
-		Namespace:           s.Namespace().String(),
+		Namespace:           env.Namespace().String(),
 		WorkflowId:          id1,
 		WorkflowType:        &commonpb.WorkflowType{Name: wt},
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
@@ -40,7 +49,7 @@ func TestWorkflowVisibilityTestSuite(t *testing.T) {
 		Identity:            identity,
 	}
 
-	startResponse, err0 := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), startRequest)
+	startResponse, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), startRequest)
 	s.NoError(err0)
 
 	// Now complete one of the executions
@@ -54,13 +63,13 @@ func TestWorkflowVisibilityTestSuite(t *testing.T) {
 	}
 
 	poller := &testcore.TaskPoller{
-		Client:              s.FrontendClient(),
-		Namespace:           s.Namespace().String(),
+		Client:              env.FrontendClient(),
+		Namespace:           env.Namespace().String(),
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
 		WorkflowTaskHandler: wtHandler,
 		ActivityTaskHandler: nil,
-		Logger:              s.Logger,
+		Logger:              env.Logger,
 		T:                   s.T(),
 	}
 
@@ -71,7 +80,7 @@ func TestWorkflowVisibilityTestSuite(t *testing.T) {
 	var nextToken []byte
 	historyEventFilterType := enumspb.HISTORY_EVENT_FILTER_TYPE_CLOSE_EVENT
 	for {
-		historyResponse, historyErr := s.FrontendClient().GetWorkflowExecutionHistory(testcore.NewContext(), &workflowservice.GetWorkflowExecutionHistoryRequest{
+		historyResponse, historyErr := env.FrontendClient().GetWorkflowExecutionHistory(s.Context(), &workflowservice.GetWorkflowExecutionHistoryRequest{
 			Namespace: startRequest.Namespace,
 			Execution: &commonpb.WorkflowExecution{
 				WorkflowId: startRequest.WorkflowId,
@@ -91,7 +100,7 @@ func TestWorkflowVisibilityTestSuite(t *testing.T) {
 
 	startRequest = &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:           uuid.NewString(),
-		Namespace:           s.Namespace().String(),
+		Namespace:           env.Namespace().String(),
 		WorkflowId:          id2,
 		WorkflowType:        &commonpb.WorkflowType{Name: wt},
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
@@ -101,7 +110,7 @@ func TestWorkflowVisibilityTestSuite(t *testing.T) {
 		Identity:            identity,
 	}
 
-	_, err2 := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), startRequest)
+	_, err2 := env.FrontendClient().StartWorkflowExecution(s.Context(), startRequest)
 	s.NoError(err2)
 
 	startFilter := &filterpb.StartTimeFilter{}
@@ -114,8 +123,8 @@ func TestWorkflowVisibilityTestSuite(t *testing.T) {
 	var historyLength int64
 	s.Eventually(
 		func() bool {
-			resp, err3 := s.FrontendClient().ListClosedWorkflowExecutions(testcore.NewContext(), &workflowservice.ListClosedWorkflowExecutionsRequest{
-				Namespace:       s.Namespace().String(),
+			resp, err3 := env.FrontendClient().ListClosedWorkflowExecutions(s.Context(), &workflowservice.ListClosedWorkflowExecutionsRequest{
+				Namespace:       env.Namespace().String(),
 				MaximumPageSize: 100,
 				StartTimeFilter: startFilter,
 				Filters: &workflowservice.ListClosedWorkflowExecutionsRequest_TypeFilter{
@@ -131,7 +140,7 @@ func TestWorkflowVisibilityTestSuite(t *testing.T) {
 				s.Nil(resp.NextPageToken)
 				return true
 			}
-			s.Logger.Info("Closed WorkflowExecution is not yet visible")
+			env.Logger.Info("Closed WorkflowExecution is not yet visible")
 			return false
 		},
 		testcore.WaitForESToSettle,
@@ -142,8 +151,8 @@ func TestWorkflowVisibilityTestSuite(t *testing.T) {
 
 	s.Eventually(
 		func() bool {
-			resp, err4 := s.FrontendClient().ListOpenWorkflowExecutions(testcore.NewContext(), &workflowservice.ListOpenWorkflowExecutionsRequest{
-				Namespace:       s.Namespace().String(),
+			resp, err4 := env.FrontendClient().ListOpenWorkflowExecutions(s.Context(), &workflowservice.ListOpenWorkflowExecutionsRequest{
+				Namespace:       env.Namespace().String(),
 				MaximumPageSize: 100,
 				StartTimeFilter: startFilter,
 				Filters: &workflowservice.ListOpenWorkflowExecutionsRequest_TypeFilter{
@@ -158,7 +167,7 @@ func TestWorkflowVisibilityTestSuite(t *testing.T) {
 				s.Nil(resp.NextPageToken)
 				return true
 			}
-			s.Logger.Info("Open WorkflowExecution is not yet visible")
+			env.Logger.Info("Open WorkflowExecution is not yet visible")
 			return false
 		},
 		testcore.WaitForESToSettle,


### PR DESCRIPTION
Migrate `WorkflowVisibilityTestSuite` from testify suite + `FunctionalTestBase` to `testcore.NewEnv`.