### PR TITLE
Harden MergeStats against nil into parameter

### DIFF
--- a/common/taskqueue/stats.go
+++ b/common/taskqueue/stats.go
@@ -7,7 +7,7 @@ import (
 
 // MergeStats merges from into into. Mutates into.
 func MergeStats(into, from *taskqueuepb.TaskQueueStats) {
-	if from == nil {
+	if into == nil || from == nil {
 		return
 	}
 	into.ApproximateBacklogCount += from.ApproximateBacklogCount

--- a/common/taskqueue/stats_test.go
+++ b/common/taskqueue/stats_test.go
@@ -31,6 +31,17 @@ func TestMergeStats(t *testing.T) {
 	require.InDelta(t, 4, into.TasksDispatchRate, 1e-9)
 }
 
+func TestMergeStats_NilInto(t *testing.T) {
+	from := &taskqueuepb.TaskQueueStats{
+		ApproximateBacklogCount: 10,
+	}
+	require.NotPanics(t, func() { MergeStats(nil, from) })
+}
+
+func TestMergeStats_BothNil(t *testing.T) {
+	require.NotPanics(t, func() { MergeStats(nil, nil) })
+}
+
 func TestMergeStats_NilFrom(t *testing.T) {
 	into := &taskqueuepb.TaskQueueStats{
 		ApproximateBacklogCount: 10,


### PR DESCRIPTION
## Summary
- Guard against nil `into` in `MergeStats` to prevent panics
- Add test coverage for nil `into` and both-nil cases

`MergeStats` already guards against nil `from` but panics if `into` is nil. No existing callers pass nil today, but as a public API defensive nil handling is good practice.

## Test plan
- [x] `TestMergeStats_NilInto` — verifies no panic when `into` is nil
- [x] `TestMergeStats_BothNil` — verifies no panic when both are nil

🤖 Generated with [Claude Code](https://claude.com/claude-code)