### PR TITLE
refactor: migrate client_data_converter_test.go to testcore.NewEnv

### DIFF
--- a/tests/client_data_converter_test.go
+++ b/tests/client_data_converter_test.go
@@ -79,10 +79,10 @@ func testChildWorkflow(ctx workflow.Context, totalCount, runCount int) (string, 
 	return "", workflow.NewContinueAsNewError(ctx, testChildWorkflow, totalCount, runCount)
 }
 
-func clientDataConverterStartWorker(s *testcore.TestEnv, tl string, dataConverter converter.DataConverter) (sdkclient.Client, worker.Worker) {
+func (s *ClientDataConverterSuite) clientDataConverterStartWorker(env *testcore.TestEnv, tl string, dataConverter converter.DataConverter) (sdkclient.Client, worker.Worker) {
 	sdkClient, err := sdkclient.Dial(sdkclient.Options{
-		HostPort:      s.FrontendGRPCAddress(),
-		Namespace:     s.Namespace().String(),
+		HostPort:      env.FrontendGRPCAddress(),
+		Namespace:     env.Namespace().String(),
 		DataConverter: dataConverter,
 	})
 	s.NoError(err)
@@ -139,7 +139,7 @@ func (s *ClientDataConverterSuite) TestClientDataConverter() {
 	env.T().SkipNow() // need to figure out what is going on
 	tl := "client-func-data-converter-activity-taskqueue"
 	dc := testcore.NewTestDataConverter()
-	sdkClient, testWorker := clientDataConverterStartWorker(env, tl, dc)
+	sdkClient, testWorker := s.clientDataConverterStartWorker(env, tl, dc)
 	defer func() {
 		testWorker.Stop()
 		sdkClient.Close()
@@ -175,7 +175,7 @@ func (s *ClientDataConverterSuite) TestClientDataConverterFailed() {
 	env := testcore.NewEnv(s.T())
 	env.T().SkipNow()
 	tl := "client-func-data-converter-activity-failed-taskqueue"
-	sdkClient, newWorker := clientDataConverterStartWorker(env, tl, nil) // mismatch of data converter
+	sdkClient, newWorker := s.clientDataConverterStartWorker(env, tl, nil) // mismatch of data converter
 	defer func() {
 		newWorker.Stop()
 		sdkClient.Close()
@@ -225,7 +225,7 @@ func (s *ClientDataConverterSuite) TestClientDataConverterWithChild() {
 	env := testcore.NewEnv(s.T())
 	env.T().SkipNow()
 	dc := testcore.NewTestDataConverter()
-	sdkClient, testWorker := clientDataConverterStartWorker(env, childTaskQueue, dc)
+	sdkClient, testWorker := s.clientDataConverterStartWorker(env, childTaskQueue, dc)
 	defer func() {
 		testWorker.Stop()
 		sdkClient.Close()

--- a/tests/client_data_converter_test.go
+++ b/tests/client_data_converter_test.go
@@ -135,7 +135,7 @@ func testParentWorkflow(ctx workflow.Context) (string, error) {
 }
 
 func (s *ClientDataConverterSuite) TestClientDataConverter() {
-	env := testcore.NewEnv(s.T(), testcore.WithSdkWorker())
+	env := testcore.NewEnv(s.T())
 	env.T().SkipNow() // need to figure out what is going on
 	tl := "client-func-data-converter-activity-taskqueue"
 	dc := testcore.NewTestDataConverter()
@@ -172,7 +172,7 @@ func (s *ClientDataConverterSuite) TestClientDataConverter() {
 }
 
 func (s *ClientDataConverterSuite) TestClientDataConverterFailed() {
-	env := testcore.NewEnv(s.T(), testcore.WithSdkWorker())
+	env := testcore.NewEnv(s.T())
 	env.T().SkipNow()
 	tl := "client-func-data-converter-activity-failed-taskqueue"
 	sdkClient, newWorker := clientDataConverterStartWorker(env, tl, nil) // mismatch of data converter
@@ -222,7 +222,7 @@ func (s *ClientDataConverterSuite) TestClientDataConverterFailed() {
 }
 
 func (s *ClientDataConverterSuite) TestClientDataConverterWithChild() {
-	env := testcore.NewEnv(s.T(), testcore.WithSdkWorker())
+	env := testcore.NewEnv(s.T())
 	env.T().SkipNow()
 	dc := testcore.NewTestDataConverter()
 	sdkClient, testWorker := clientDataConverterStartWorker(env, childTaskQueue, dc)

--- a/tests/client_data_converter_test.go
+++ b/tests/client_data_converter_test.go
@@ -8,13 +8,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
 	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
 	"go.temporal.io/server/common/rpc"
+	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
 )
 
@@ -22,13 +22,12 @@ var (
 	ErrInvalidRunCount = errors.New("invalid run count")
 )
 
-type ClientDataConverterTestSuite struct {
-	testcore.FunctionalTestBase
+type ClientDataConverterSuite struct {
+	parallelsuite.Suite[*ClientDataConverterSuite]
 }
 
 func TestClientDataConverterTestSuite(t *testing.T) {
-	t.Parallel()
-	suite.Run(t, new(ClientDataConverterTestSuite))
+	parallelsuite.Run(t, &ClientDataConverterSuite{})
 }
 
 func testActivity(_ workflow.Context, msg string) (string, error) {
@@ -80,7 +79,7 @@ func testChildWorkflow(ctx workflow.Context, totalCount, runCount int) (string, 
 	return "", workflow.NewContinueAsNewError(ctx, testChildWorkflow, totalCount, runCount)
 }
 
-func (s *ClientDataConverterTestSuite) startWorkerWithDataConverter(tl string, dataConverter converter.DataConverter) (sdkclient.Client, worker.Worker) {
+func clientDataConverterStartWorker(s *testcore.TestEnv, tl string, dataConverter converter.DataConverter) (sdkclient.Client, worker.Worker) {
 	sdkClient, err := sdkclient.Dial(sdkclient.Options{
 		HostPort:      s.FrontendGRPCAddress(),
 		Namespace:     s.Namespace().String(),
@@ -135,11 +134,12 @@ func testParentWorkflow(ctx workflow.Context) (string, error) {
 	return res, nil
 }
 
-func (s *ClientDataConverterTestSuite) TestClientDataConverter() {
-	s.T().SkipNow() // need to figure out what is going on
+func (s *ClientDataConverterSuite) TestClientDataConverter() {
+	env := testcore.NewEnv(s.T(), testcore.WithSdkWorker())
+	env.T().SkipNow() // need to figure out what is going on
 	tl := "client-func-data-converter-activity-taskqueue"
 	dc := testcore.NewTestDataConverter()
-	sdkClient, testWorker := s.startWorkerWithDataConverter(tl, dc)
+	sdkClient, testWorker := clientDataConverterStartWorker(env, tl, dc)
 	defer func() {
 		testWorker.Stop()
 		sdkClient.Close()
@@ -148,33 +148,34 @@ func (s *ClientDataConverterTestSuite) TestClientDataConverter() {
 	id := "client-func-data-converter-workflow"
 	workflowOptions := sdkclient.StartWorkflowOptions{
 		ID:                 id,
-		TaskQueue:          s.TaskQueue(),
+		TaskQueue:          env.WorkerTaskQueue(),
 		WorkflowRunTimeout: time.Minute,
 	}
 	ctx, cancel := rpc.NewContextWithTimeoutAndVersionHeaders(time.Minute)
 	defer cancel()
-	s.SdkWorker().RegisterWorkflow(testDataConverterWorkflow)
-	s.SdkWorker().RegisterActivity(testActivity)
-	we, err := s.SdkClient().ExecuteWorkflow(ctx, workflowOptions, testDataConverterWorkflow, tl)
-	s.NoError(err)
-	s.NotNil(we)
-	s.NotEmpty(we.GetRunID())
+	env.SdkWorker().RegisterWorkflow(testDataConverterWorkflow)
+	env.SdkWorker().RegisterActivity(testActivity)
+	we, err := env.SdkClient().ExecuteWorkflow(ctx, workflowOptions, testDataConverterWorkflow, tl)
+	env.NoError(err)
+	env.NotNil(we)
+	env.NotEmpty(we.GetRunID())
 
 	var res string
 	err = we.Get(ctx, &res)
-	s.NoError(err)
-	s.Equal("hello_world,hello_world1", res)
+	env.NoError(err)
+	env.Equal("hello_world,hello_world1", res)
 
 	// to ensure custom data converter is used, this number might be different if client changed.
 	d := dc.(*testcore.TestDataConverter) //nolint:revive // unchecked-type-assertion
-	s.Equal(1, d.NumOfCallToPayloads)
-	s.Equal(1, d.NumOfCallFromPayloads)
+	env.Equal(1, d.NumOfCallToPayloads)
+	env.Equal(1, d.NumOfCallFromPayloads)
 }
 
-func (s *ClientDataConverterTestSuite) TestClientDataConverterFailed() {
-	s.T().SkipNow()
+func (s *ClientDataConverterSuite) TestClientDataConverterFailed() {
+	env := testcore.NewEnv(s.T(), testcore.WithSdkWorker())
+	env.T().SkipNow()
 	tl := "client-func-data-converter-activity-failed-taskqueue"
-	sdkClient, newWorker := s.startWorkerWithDataConverter(tl, nil) // mismatch of data converter
+	sdkClient, newWorker := clientDataConverterStartWorker(env, tl, nil) // mismatch of data converter
 	defer func() {
 		newWorker.Stop()
 		sdkClient.Close()
@@ -183,47 +184,48 @@ func (s *ClientDataConverterTestSuite) TestClientDataConverterFailed() {
 	id := "client-func-data-converter-failed-workflow"
 	workflowOptions := sdkclient.StartWorkflowOptions{
 		ID:                 id,
-		TaskQueue:          s.TaskQueue(),
+		TaskQueue:          env.WorkerTaskQueue(),
 		WorkflowRunTimeout: time.Minute,
 	}
 	ctx, cancel := rpc.NewContextWithTimeoutAndVersionHeaders(time.Minute)
 	defer cancel()
 
-	s.SdkWorker().RegisterWorkflow(testDataConverterWorkflow)
-	s.SdkWorker().RegisterActivity(testActivity)
-	we, err := s.SdkClient().ExecuteWorkflow(ctx, workflowOptions, testDataConverterWorkflow, tl)
-	s.NoError(err)
-	s.NotNil(we)
-	s.NotEmpty(we.GetRunID())
+	env.SdkWorker().RegisterWorkflow(testDataConverterWorkflow)
+	env.SdkWorker().RegisterActivity(testActivity)
+	we, err := env.SdkClient().ExecuteWorkflow(ctx, workflowOptions, testDataConverterWorkflow, tl)
+	env.NoError(err)
+	env.NotNil(we)
+	env.NotEmpty(we.GetRunID())
 
 	var res string
 	err = we.Get(ctx, &res)
-	s.Error(err)
+	env.Error(err)
 
 	// Get history to make sure only the 2nd activity is failed because of mismatch of data converter
-	iter := s.SdkClient().GetWorkflowHistory(ctx, id, we.GetRunID(), false, 0)
+	iter := env.SdkClient().GetWorkflowHistory(ctx, id, we.GetRunID(), false, 0)
 	completedAct := 0
 	failedAct := 0
 	for iter.HasNext() {
 		event, err := iter.Next()
-		s.NoError(err)
+		env.NoError(err)
 		if event.GetEventType() == enumspb.EVENT_TYPE_ACTIVITY_TASK_COMPLETED {
 			completedAct++
 		}
 		if event.GetEventType() == enumspb.EVENT_TYPE_ACTIVITY_TASK_FAILED {
 			failedAct++
-			s.NotNil(event.GetActivityTaskFailedEventAttributes().GetFailure().GetApplicationFailureInfo())
-			s.True(strings.HasPrefix(event.GetActivityTaskFailedEventAttributes().GetFailure().GetMessage(), "unable to decode the activity function input payload with error"))
+			env.NotNil(event.GetActivityTaskFailedEventAttributes().GetFailure().GetApplicationFailureInfo())
+			env.True(strings.HasPrefix(event.GetActivityTaskFailedEventAttributes().GetFailure().GetMessage(), "unable to decode the activity function input payload with error"))
 		}
 	}
-	s.Equal(1, completedAct)
-	s.Equal(1, failedAct)
+	env.Equal(1, completedAct)
+	env.Equal(1, failedAct)
 }
 
-func (s *ClientDataConverterTestSuite) TestClientDataConverterWithChild() {
-	s.T().SkipNow()
+func (s *ClientDataConverterSuite) TestClientDataConverterWithChild() {
+	env := testcore.NewEnv(s.T(), testcore.WithSdkWorker())
+	env.T().SkipNow()
 	dc := testcore.NewTestDataConverter()
-	sdkClient, testWorker := s.startWorkerWithDataConverter(childTaskQueue, dc)
+	sdkClient, testWorker := clientDataConverterStartWorker(env, childTaskQueue, dc)
 	defer func() {
 		testWorker.Stop()
 		sdkClient.Close()
@@ -232,26 +234,26 @@ func (s *ClientDataConverterTestSuite) TestClientDataConverterWithChild() {
 	id := "client-func-data-converter-with-child-workflow"
 	workflowOptions := sdkclient.StartWorkflowOptions{
 		ID:                 id,
-		TaskQueue:          s.TaskQueue(),
+		TaskQueue:          env.WorkerTaskQueue(),
 		WorkflowRunTimeout: time.Minute,
 	}
 	ctx, cancel := rpc.NewContextWithTimeoutAndVersionHeaders(time.Minute)
 	defer cancel()
-	s.SdkWorker().RegisterWorkflow(testParentWorkflow)
-	s.SdkWorker().RegisterWorkflow(testChildWorkflow)
+	env.SdkWorker().RegisterWorkflow(testParentWorkflow)
+	env.SdkWorker().RegisterWorkflow(testChildWorkflow)
 
-	we, err := s.SdkClient().ExecuteWorkflow(ctx, workflowOptions, testParentWorkflow)
-	s.NoError(err)
-	s.NotNil(we)
-	s.NotEmpty(we.GetRunID())
+	we, err := env.SdkClient().ExecuteWorkflow(ctx, workflowOptions, testParentWorkflow)
+	env.NoError(err)
+	env.NotNil(we)
+	env.NotEmpty(we.GetRunID())
 
 	var res string
 	err = we.Get(ctx, &res)
-	s.NoError(err)
-	s.Equal("Complete child1 3 times, complete child2 2 times", res)
+	env.NoError(err)
+	env.Equal("Complete child1 3 times, complete child2 2 times", res)
 
 	// to ensure custom data converter is used, this number might be different if client changed.
 	d := dc.(*testcore.TestDataConverter) //nolint:revive // unchecked-type-assertion
-	s.Equal(2, d.NumOfCallToPayloads)
-	s.Equal(2, d.NumOfCallFromPayloads)
+	env.Equal(2, d.NumOfCallToPayloads)
+	env.Equal(2, d.NumOfCallFromPayloads)
 }

--- a/tests/client_data_converter_test.go
+++ b/tests/client_data_converter_test.go
@@ -13,7 +13,6 @@ import (
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
-	"go.temporal.io/server/common/rpc"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
 )
@@ -135,8 +134,8 @@ func testParentWorkflow(ctx workflow.Context) (string, error) {
 }
 
 func (s *ClientDataConverterSuite) TestClientDataConverter() {
+	s.T().SkipNow() // need to figure out what is going on
 	env := testcore.NewEnv(s.T())
-	env.T().SkipNow() // need to figure out what is going on
 	tl := "client-func-data-converter-activity-taskqueue"
 	dc := testcore.NewTestDataConverter()
 	sdkClient, testWorker := s.clientDataConverterStartWorker(env, tl, dc)
@@ -151,29 +150,28 @@ func (s *ClientDataConverterSuite) TestClientDataConverter() {
 		TaskQueue:          env.WorkerTaskQueue(),
 		WorkflowRunTimeout: time.Minute,
 	}
-	ctx, cancel := rpc.NewContextWithTimeoutAndVersionHeaders(time.Minute)
-	defer cancel()
+	ctx := env.Context()
 	env.SdkWorker().RegisterWorkflow(testDataConverterWorkflow)
 	env.SdkWorker().RegisterActivity(testActivity)
 	we, err := env.SdkClient().ExecuteWorkflow(ctx, workflowOptions, testDataConverterWorkflow, tl)
-	env.NoError(err)
-	env.NotNil(we)
-	env.NotEmpty(we.GetRunID())
+	s.NoError(err)
+	s.NotNil(we)
+	s.NotEmpty(we.GetRunID())
 
 	var res string
 	err = we.Get(ctx, &res)
-	env.NoError(err)
-	env.Equal("hello_world,hello_world1", res)
+	s.NoError(err)
+	s.Equal("hello_world,hello_world1", res)
 
 	// to ensure custom data converter is used, this number might be different if client changed.
 	d := dc.(*testcore.TestDataConverter) //nolint:revive // unchecked-type-assertion
-	env.Equal(1, d.NumOfCallToPayloads)
-	env.Equal(1, d.NumOfCallFromPayloads)
+	s.Equal(1, d.NumOfCallToPayloads)
+	s.Equal(1, d.NumOfCallFromPayloads)
 }
 
 func (s *ClientDataConverterSuite) TestClientDataConverterFailed() {
+	s.T().SkipNow()
 	env := testcore.NewEnv(s.T())
-	env.T().SkipNow()
 	tl := "client-func-data-converter-activity-failed-taskqueue"
 	sdkClient, newWorker := s.clientDataConverterStartWorker(env, tl, nil) // mismatch of data converter
 	defer func() {
@@ -187,19 +185,18 @@ func (s *ClientDataConverterSuite) TestClientDataConverterFailed() {
 		TaskQueue:          env.WorkerTaskQueue(),
 		WorkflowRunTimeout: time.Minute,
 	}
-	ctx, cancel := rpc.NewContextWithTimeoutAndVersionHeaders(time.Minute)
-	defer cancel()
+	ctx := env.Context()
 
 	env.SdkWorker().RegisterWorkflow(testDataConverterWorkflow)
 	env.SdkWorker().RegisterActivity(testActivity)
 	we, err := env.SdkClient().ExecuteWorkflow(ctx, workflowOptions, testDataConverterWorkflow, tl)
-	env.NoError(err)
-	env.NotNil(we)
-	env.NotEmpty(we.GetRunID())
+	s.NoError(err)
+	s.NotNil(we)
+	s.NotEmpty(we.GetRunID())
 
 	var res string
 	err = we.Get(ctx, &res)
-	env.Error(err)
+	s.Error(err)
 
 	// Get history to make sure only the 2nd activity is failed because of mismatch of data converter
 	iter := env.SdkClient().GetWorkflowHistory(ctx, id, we.GetRunID(), false, 0)
@@ -207,23 +204,23 @@ func (s *ClientDataConverterSuite) TestClientDataConverterFailed() {
 	failedAct := 0
 	for iter.HasNext() {
 		event, err := iter.Next()
-		env.NoError(err)
+		s.NoError(err)
 		if event.GetEventType() == enumspb.EVENT_TYPE_ACTIVITY_TASK_COMPLETED {
 			completedAct++
 		}
 		if event.GetEventType() == enumspb.EVENT_TYPE_ACTIVITY_TASK_FAILED {
 			failedAct++
-			env.NotNil(event.GetActivityTaskFailedEventAttributes().GetFailure().GetApplicationFailureInfo())
-			env.True(strings.HasPrefix(event.GetActivityTaskFailedEventAttributes().GetFailure().GetMessage(), "unable to decode the activity function input payload with error"))
+			s.NotNil(event.GetActivityTaskFailedEventAttributes().GetFailure().GetApplicationFailureInfo())
+			s.True(strings.HasPrefix(event.GetActivityTaskFailedEventAttributes().GetFailure().GetMessage(), "unable to decode the activity function input payload with error"))
 		}
 	}
-	env.Equal(1, completedAct)
-	env.Equal(1, failedAct)
+	s.Equal(1, completedAct)
+	s.Equal(1, failedAct)
 }
 
 func (s *ClientDataConverterSuite) TestClientDataConverterWithChild() {
+	s.T().SkipNow()
 	env := testcore.NewEnv(s.T())
-	env.T().SkipNow()
 	dc := testcore.NewTestDataConverter()
 	sdkClient, testWorker := s.clientDataConverterStartWorker(env, childTaskQueue, dc)
 	defer func() {
@@ -237,23 +234,22 @@ func (s *ClientDataConverterSuite) TestClientDataConverterWithChild() {
 		TaskQueue:          env.WorkerTaskQueue(),
 		WorkflowRunTimeout: time.Minute,
 	}
-	ctx, cancel := rpc.NewContextWithTimeoutAndVersionHeaders(time.Minute)
-	defer cancel()
+	ctx := env.Context()
 	env.SdkWorker().RegisterWorkflow(testParentWorkflow)
 	env.SdkWorker().RegisterWorkflow(testChildWorkflow)
 
 	we, err := env.SdkClient().ExecuteWorkflow(ctx, workflowOptions, testParentWorkflow)
-	env.NoError(err)
-	env.NotNil(we)
-	env.NotEmpty(we.GetRunID())
+	s.NoError(err)
+	s.NotNil(we)
+	s.NotEmpty(we.GetRunID())
 
 	var res string
 	err = we.Get(ctx, &res)
-	env.NoError(err)
-	env.Equal("Complete child1 3 times, complete child2 2 times", res)
+	s.NoError(err)
+	s.Equal("Complete child1 3 times, complete child2 2 times", res)
 
 	// to ensure custom data converter is used, this number might be different if client changed.
 	d := dc.(*testcore.TestDataConverter) //nolint:revive // unchecked-type-assertion
-	env.Equal(2, d.NumOfCallToPayloads)
-	env.Equal(2, d.NumOfCallFromPayloads)
+	s.Equal(2, d.NumOfCallToPayloads)
+	s.Equal(2, d.NumOfCallFromPayloads)
 }


### PR DESCRIPTION
## What changed?
- Migrated `tests/client_data_converter_test.go` from testify suite pattern to `testcore.NewEnv`.
- Converted suite test methods into standalone package-level functions taking `*testcore.TestEnv` as the first argument.
- Updated `TaskQueue()` usage to `WorkerTaskQueue()` and removed suite scaffolding/imports.

## Why?
- Continue the piece-by-piece migration of functional tests to use `TestEnv` with minimal diff for easier review.

## How did you test it?
- `go test -tags disable_grpc_modules,test_dep -timeout 5m -run TestClientDataConverterTestSuite ./tests/...`

## Potential risks
- Tests only.