### PR TITLE
fix: resolve race condition in TestTryActivityCancellationFromWorkflow

### DIFF
--- a/tests/activity_test.go
+++ b/tests/activity_test.go
@@ -982,9 +982,11 @@ func (s *ActivityTestSuite) TestTryActivityCancellationFromWorkflow() {
 	}
 
 	activityCanceled := false
+	activityStarted := make(chan struct{})
 	atHandler := func(task *workflowservice.PollActivityTaskQueueResponse) (*commonpb.Payloads, bool, error) {
 		s.Equal(id, task.WorkflowExecution.GetWorkflowId())
 		s.Equal(activityName, task.ActivityType.GetName())
+		close(activityStarted)
 		for i := range 10 {
 			s.Logger.Info("Heartbeating for activity", tag.ActivityID(task.ActivityId), tag.Counter(i))
 			response, err := s.FrontendClient().RecordActivityTaskHeartbeat(testcore.NewContext(),
@@ -1020,6 +1022,14 @@ func (s *ActivityTestSuite) TestTryActivityCancellationFromWorkflow() {
 	cancelCh := make(chan struct{})
 	go func() {
 		s.Logger.Info("Trying to cancel the task in a different thread")
+		// Wait for the activity to be started before sending the cancel signal.
+		// Otherwise the cancel can race ahead and cancel the activity before a
+		// worker picks it up, causing PollAndProcessActivityTask to block forever.
+		select {
+		case <-activityStarted:
+		case <-s.T().Context().Done():
+			return
+		}
 		// Send signal so that worker can send an activity cancel
 		_, err1 := s.FrontendClient().SignalWorkflowExecution(testcore.NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 			Namespace: s.Namespace().String(),
@@ -1045,7 +1055,11 @@ func (s *ActivityTestSuite) TestTryActivityCancellationFromWorkflow() {
 	s.True(err == nil || errors.Is(err, testcore.ErrNoTasks))
 
 	s.Logger.Info("Waiting for cancel to complete.", tag.WorkflowRunID(we.RunId))
-	<-cancelCh
+	select {
+	case <-cancelCh:
+	case <-s.T().Context().Done():
+		s.Fail("timed out waiting for activity cancellation")
+	}
 	s.True(activityCanceled, "Activity was not cancelled.")
 	s.Logger.Info("Activity cancelled.", tag.WorkflowRunID(we.RunId))
 }


### PR DESCRIPTION
## Summary
- Fix flaky `TestTryActivityCancellationFromWorkflow` that times out when the cancel goroutine races ahead of the activity poller
- Add `activityStarted` channel so the cancel signal is only sent after the activity is running
- Replace bare `<-chan` receives with `select` on `s.T().Context().Done()` so the test fails fast on timeout instead of hanging the entire suite

## Root Cause
The test starts two concurrent operations: polling for an activity task and sending a cancel signal. When the cancel goroutine wins the race, the activity is cancelled before a worker picks it up. The matching engine returns "Activity task not found" and `PollAndProcessActivityTask` retries long-polling (5x90s), exceeding the 5m test timeout. Observed in CI on `cass_os3` (1/12 backends).

## Test plan
- [x] `TestActivityTestSuite/TestTryActivityCancellationFromWorkflow` passes (0.03s)
- [x] Full `TestActivityTestSuite` passes (9/9 tests, 16s)