### PR TITLE
[do not merge] chasm scheduler feature test flag

### DIFF
--- a/.github/workflows/features-integration.yml
+++ b/.github/workflows/features-integration.yml
@@ -99,6 +99,8 @@ jobs:
           - value: true
         history.enableCHASMSchedulerCreation:
           - value: true
+        history.enableCHASMSchedulerRouting:
+          - value: true
 
   feature-tests-python:
     needs: build-docker-image

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -580,6 +580,17 @@ func testBasics(t *testing.T, newContext contextFactory) {
 	var notFoundErr *serviceerror.NotFound
 	s.ErrorAs(err, &notFoundErr)
 
+	// patch (trigger) on a deleted schedule should also error
+	_, err = s.FrontendClient().PatchSchedule(newContext(s.Context()), &workflowservice.PatchScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Patch: &schedulepb.SchedulePatch{
+			TriggerImmediately: &schedulepb.TriggerImmediatelyRequest{},
+		},
+		Identity: "test",
+	})
+	s.Error(err)
+
 	s.Eventually(func() bool { // wait for visibility
 		listResp, err := s.FrontendClient().ListSchedules(newContext(s.Context()), &workflowservice.ListSchedulesRequest{
 			Namespace:       s.Namespace().String(),


### PR DESCRIPTION
## Summary
- Add `ErrClosed` check in `Scheduler.Patch` so patching a deleted schedule returns an error instead of proceeding
- Add test case for triggering a deleted schedule
- Enable `EnableCHASMSchedulerRouting` in features integration CI to exercise the full CHASM scheduler path alongside creation