### PR TITLE
Exclude polling cases from get apis

### DIFF
--- a/common/rpc/interceptor/health_check.go
+++ b/common/rpc/interceptor/health_check.go
@@ -131,6 +131,14 @@ func (h *HealthCheckInterceptor) UnaryIntercept(
 		return resp, err
 	}
 
+	if IsLongPollGetWorkflowExecutionHistoryRequest(req) {
+		return resp, err
+	}
+
+	if IsLongPollDescribeActivityExecutionRequest(req) {
+		return resp, err
+	}
+
 	// Record health signal for standard APIs
 	h.healthSignalAggregator.Record(elapsed, err)
 	return resp, err


### PR DESCRIPTION
## What changed?
Exclude polling cases from get apis

## Why?
There are long polling cases in the Get APIs. We have trouble to identify those cases in regular Get APIs. 

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

