### PR TITLE
Migrate testEnv suites to use parallelsuites

### DIFF
--- a/tests/activity_api_batch_reset_test.go
+++ b/tests/activity_api_batch_reset_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -16,52 +15,50 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/server/common/searchattribute/sadefs"
+	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/grpc/codes"
 )
 
-func TestActivityApiBatchResetClientTestSuite(t *testing.T) {
-	t.Parallel()
-	t.Run("TestActivityBatchReset_Success", testActivityBatchResetSuccess)
-	t.Run("TestActivityBatchReset_Success_Protobuf", testActivityBatchResetSuccessProtobuf)
-	t.Run("TestActivityBatchReset_DontResetAttempts", testActivityBatchResetDontResetAttempts)
-	t.Run("TestActivityBatchReset_Failed", testActivityBatchResetFailed)
+type ActivityAPIBatchResetClientTestSuite struct {
+	parallelsuite.Suite[*ActivityAPIBatchResetClientTestSuite]
 }
 
-func createBatchResetWorkflow(ctx context.Context, s *testcore.TestEnv, workflowFn WorkflowFunction) sdkclient.WorkflowRun {
+func TestActivityAPIBatchResetClientTestSuite(t *testing.T) {
+	parallelsuite.Run(t, &ActivityAPIBatchResetClientTestSuite{})
+}
+
+func (s *ActivityAPIBatchResetClientTestSuite) createBatchResetWorkflow(env *testcore.TestEnv, workflowFn WorkflowFunction) sdkclient.WorkflowRun {
 	workflowOptions := sdkclient.StartWorkflowOptions{
-		ID:        testcore.RandomizeStr("wf_id-" + s.T().Name()),
-		TaskQueue: s.WorkerTaskQueue(),
+		ID:        testcore.RandomizeStr("wf_id"),
+		TaskQueue: env.WorkerTaskQueue(),
 	}
-	workflowRun, err := s.SdkClient().ExecuteWorkflow(ctx, workflowOptions, workflowFn)
+	workflowRun, err := env.SdkClient().ExecuteWorkflow(env.Context(), workflowOptions, workflowFn)
 	s.NoError(err)
 	s.NotNil(workflowRun)
 
 	return workflowRun
 }
 
-func testActivityBatchResetSuccess(t *testing.T) {
-	s := testcore.NewEnv(t, testcore.WithSdkWorker())
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_Success() {
+	env := testcore.NewEnv(s.T())
 
 	internalWorkflow := newInternalWorkflow()
 
-	s.SdkWorker().RegisterWorkflow(internalWorkflow.WorkflowFunc)
-	s.SdkWorker().RegisterActivity(internalWorkflow.ActivityFunc)
+	env.SdkWorker().RegisterWorkflow(internalWorkflow.WorkflowFunc)
+	env.SdkWorker().RegisterActivity(internalWorkflow.ActivityFunc)
 
-	workflowRun1 := createBatchResetWorkflow(ctx, s, internalWorkflow.WorkflowFunc)
-	workflowRun2 := createBatchResetWorkflow(ctx, s, internalWorkflow.WorkflowFunc)
+	workflowRun1 := s.createBatchResetWorkflow(env, internalWorkflow.WorkflowFunc)
+	workflowRun2 := s.createBatchResetWorkflow(env, internalWorkflow.WorkflowFunc)
 
 	// wait for activity to start in both workflows
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun1.GetID(), workflowRun1.GetRunID())
+		description, err := env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.GetPendingActivities(), 1)
 		require.Positive(t, internalWorkflow.startedActivityCount.Load())
 
-		description, err = s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun2.GetID(), workflowRun2.GetRunID())
+		description, err = env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun2.GetID(), workflowRun2.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.GetPendingActivities(), 1)
 		require.Positive(t, internalWorkflow.startedActivityCount.Load())
@@ -69,24 +66,24 @@ func testActivityBatchResetSuccess(t *testing.T) {
 
 	// pause activities in both workflows
 	pauseRequest := &workflowservice.PauseActivityRequest{
-		Namespace: s.Namespace().String(),
+		Namespace: env.Namespace().String(),
 		Execution: &commonpb.WorkflowExecution{},
 		Activity:  &workflowservice.PauseActivityRequest_Id{Id: "activity-id"},
 	}
 
 	pauseRequest.Execution.WorkflowId = workflowRun1.GetID()
-	resp, err := s.FrontendClient().PauseActivity(ctx, pauseRequest)
+	resp, err := env.FrontendClient().PauseActivity(env.Context(), pauseRequest)
 	s.NoError(err)
 	s.NotNil(resp)
 
 	pauseRequest.Execution.WorkflowId = workflowRun2.GetID()
-	resp, err = s.FrontendClient().PauseActivity(ctx, pauseRequest)
+	resp, err = env.FrontendClient().PauseActivity(env.Context(), pauseRequest)
 	s.NoError(err)
 	s.NotNil(resp)
 
 	// wait for activities to be paused
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun1.GetID(), workflowRun1.GetRunID())
+		description, err := env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.GetPendingActivities(), 1)
 		require.True(t, description.PendingActivities[0].Paused)
@@ -103,8 +100,8 @@ func testActivityBatchResetSuccess(t *testing.T) {
 	query := fmt.Sprintf("(WorkflowType='%s' AND %s)", workflowTypeName, resetCause)
 
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		listResp, err = s.FrontendClient().ListWorkflowExecutions(ctx, &workflowservice.ListWorkflowExecutionsRequest{
-			Namespace: s.Namespace().String(),
+		listResp, err = env.FrontendClient().ListWorkflowExecutions(env.Context(), &workflowservice.ListWorkflowExecutionsRequest{
+			Namespace: env.Namespace().String(),
 			PageSize:  10,
 			Query:     query,
 		})
@@ -115,8 +112,8 @@ func testActivityBatchResetSuccess(t *testing.T) {
 	}, 5*time.Second, 500*time.Millisecond)
 
 	// reset the activities in both workflows with batch reset
-	_, err = s.SdkClient().WorkflowService().StartBatchOperation(context.Background(), &workflowservice.StartBatchOperationRequest{
-		Namespace: s.Namespace().String(),
+	_, err = env.SdkClient().WorkflowService().StartBatchOperation(env.Context(), &workflowservice.StartBatchOperationRequest{
+		Namespace: env.Namespace().String(),
 		Operation: &workflowservice.StartBatchOperationRequest_ResetActivitiesOperation{
 			ResetActivitiesOperation: &batchpb.BatchOperationResetActivities{
 				Activity:   &batchpb.BatchOperationResetActivities_Type{Type: activityTypeName},
@@ -131,13 +128,13 @@ func testActivityBatchResetSuccess(t *testing.T) {
 
 	// make sure activities are restarted and still paused
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun1.GetID(), workflowRun1.GetRunID())
+		description, err := env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.PendingActivities, 1)
 		require.True(t, description.PendingActivities[0].Paused)
 		require.Equal(t, int32(1), description.PendingActivities[0].Attempt)
 
-		description, err = s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun2.GetID(), workflowRun2.GetRunID())
+		description, err = env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun2.GetID(), workflowRun2.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.PendingActivities, 1)
 		require.True(t, description.PendingActivities[0].Paused)
@@ -148,8 +145,8 @@ func testActivityBatchResetSuccess(t *testing.T) {
 	internalWorkflow.letActivitySucceed.Store(true)
 
 	// reset the activities in both workflows with batch reset
-	_, err = s.SdkClient().WorkflowService().StartBatchOperation(context.Background(), &workflowservice.StartBatchOperationRequest{
-		Namespace: s.Namespace().String(),
+	_, err = env.SdkClient().WorkflowService().StartBatchOperation(env.Context(), &workflowservice.StartBatchOperationRequest{
+		Namespace: env.Namespace().String(),
 		Operation: &workflowservice.StartBatchOperationRequest_ResetActivitiesOperation{
 			ResetActivitiesOperation: &batchpb.BatchOperationResetActivities{
 				Activity:   &batchpb.BatchOperationResetActivities_Type{Type: activityTypeName},
@@ -163,35 +160,32 @@ func testActivityBatchResetSuccess(t *testing.T) {
 	s.NoError(err)
 
 	var out string
-	err = workflowRun1.Get(ctx, &out)
+	err = workflowRun1.Get(env.Context(), &out)
 	s.NoError(err)
 
-	err = workflowRun2.Get(ctx, &out)
+	err = workflowRun2.Get(env.Context(), &out)
 	s.NoError(err)
 }
 
-func testActivityBatchResetSuccessProtobuf(t *testing.T) {
-	s := testcore.NewEnv(t, testcore.WithSdkWorker())
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_Success_Protobuf() {
+	env := testcore.NewEnv(s.T())
 
 	internalWorkflow := newInternalWorkflow()
 
-	s.SdkWorker().RegisterWorkflow(internalWorkflow.WorkflowFunc)
-	s.SdkWorker().RegisterActivity(internalWorkflow.ActivityFunc)
+	env.SdkWorker().RegisterWorkflow(internalWorkflow.WorkflowFunc)
+	env.SdkWorker().RegisterActivity(internalWorkflow.ActivityFunc)
 
-	workflowRun1 := createBatchResetWorkflow(ctx, s, internalWorkflow.WorkflowFunc)
-	workflowRun2 := createBatchResetWorkflow(ctx, s, internalWorkflow.WorkflowFunc)
+	workflowRun1 := s.createBatchResetWorkflow(env, internalWorkflow.WorkflowFunc)
+	workflowRun2 := s.createBatchResetWorkflow(env, internalWorkflow.WorkflowFunc)
 
 	// wait for activity to start in both workflows
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun1.GetID(), workflowRun1.GetRunID())
+		description, err := env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.GetPendingActivities(), 1)
 		require.Positive(t, internalWorkflow.startedActivityCount.Load())
 
-		description, err = s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun2.GetID(), workflowRun2.GetRunID())
+		description, err = env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun2.GetID(), workflowRun2.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.GetPendingActivities(), 1)
 		require.Positive(t, internalWorkflow.startedActivityCount.Load())
@@ -199,24 +193,24 @@ func testActivityBatchResetSuccessProtobuf(t *testing.T) {
 
 	// pause activities in both workflows
 	pauseRequest := &workflowservice.PauseActivityRequest{
-		Namespace: s.Namespace().String(),
+		Namespace: env.Namespace().String(),
 		Execution: &commonpb.WorkflowExecution{},
 		Activity:  &workflowservice.PauseActivityRequest_Id{Id: "activity-id"},
 	}
 
 	pauseRequest.Execution.WorkflowId = workflowRun1.GetID()
-	resp, err := s.FrontendClient().PauseActivity(ctx, pauseRequest)
+	resp, err := env.FrontendClient().PauseActivity(env.Context(), pauseRequest)
 	s.NoError(err)
 	s.NotNil(resp)
 
 	pauseRequest.Execution.WorkflowId = workflowRun2.GetID()
-	resp, err = s.FrontendClient().PauseActivity(ctx, pauseRequest)
+	resp, err = env.FrontendClient().PauseActivity(env.Context(), pauseRequest)
 	s.NoError(err)
 	s.NotNil(resp)
 
 	// wait for activities to be paused
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun1.GetID(), workflowRun1.GetRunID())
+		description, err := env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.GetPendingActivities(), 1)
 		require.True(t, description.PendingActivities[0].Paused)
@@ -233,8 +227,8 @@ func testActivityBatchResetSuccessProtobuf(t *testing.T) {
 	query := fmt.Sprintf("(WorkflowType='%s' AND %s)", workflowTypeName, resetCause)
 
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		listResp, err = s.FrontendClient().ListWorkflowExecutions(ctx, &workflowservice.ListWorkflowExecutionsRequest{
-			Namespace: s.Namespace().String(),
+		listResp, err = env.FrontendClient().ListWorkflowExecutions(env.Context(), &workflowservice.ListWorkflowExecutionsRequest{
+			Namespace: env.Namespace().String(),
 			PageSize:  10,
 			Query:     query,
 		})
@@ -245,8 +239,8 @@ func testActivityBatchResetSuccessProtobuf(t *testing.T) {
 	}, 5*time.Second, 500*time.Millisecond)
 
 	// reset the activities in both workflows with batch reset
-	_, err = s.SdkClient().WorkflowService().StartBatchOperation(context.Background(), &workflowservice.StartBatchOperationRequest{
-		Namespace: s.Namespace().String(),
+	_, err = env.SdkClient().WorkflowService().StartBatchOperation(env.Context(), &workflowservice.StartBatchOperationRequest{
+		Namespace: env.Namespace().String(),
 		Operation: &workflowservice.StartBatchOperationRequest_ResetActivitiesOperation{
 			ResetActivitiesOperation: &batchpb.BatchOperationResetActivities{
 				Activity:   &batchpb.BatchOperationResetActivities_Type{Type: activityTypeName},
@@ -261,13 +255,13 @@ func testActivityBatchResetSuccessProtobuf(t *testing.T) {
 
 	// make sure activities are restarted and still paused
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun1.GetID(), workflowRun1.GetRunID())
+		description, err := env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.PendingActivities, 1)
 		require.True(t, description.PendingActivities[0].Paused)
 		require.Equal(t, int32(1), description.PendingActivities[0].Attempt)
 
-		description, err = s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun2.GetID(), workflowRun2.GetRunID())
+		description, err = env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun2.GetID(), workflowRun2.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.PendingActivities, 1)
 		require.True(t, description.PendingActivities[0].Paused)
@@ -278,8 +272,8 @@ func testActivityBatchResetSuccessProtobuf(t *testing.T) {
 	internalWorkflow.letActivitySucceed.Store(true)
 
 	// reset the activities in both workflows with batch reset
-	_, err = s.SdkClient().WorkflowService().StartBatchOperation(context.Background(), &workflowservice.StartBatchOperationRequest{
-		Namespace: s.Namespace().String(),
+	_, err = env.SdkClient().WorkflowService().StartBatchOperation(env.Context(), &workflowservice.StartBatchOperationRequest{
+		Namespace: env.Namespace().String(),
 		Operation: &workflowservice.StartBatchOperationRequest_ResetActivitiesOperation{
 			ResetActivitiesOperation: &batchpb.BatchOperationResetActivities{
 				Activity:   &batchpb.BatchOperationResetActivities_Type{Type: activityTypeName},
@@ -293,35 +287,32 @@ func testActivityBatchResetSuccessProtobuf(t *testing.T) {
 	s.NoError(err)
 
 	var out string
-	err = workflowRun1.Get(ctx, &out)
+	err = workflowRun1.Get(env.Context(), &out)
 	s.NoError(err)
 
-	err = workflowRun2.Get(ctx, &out)
+	err = workflowRun2.Get(env.Context(), &out)
 	s.NoError(err)
 }
 
-func testActivityBatchResetDontResetAttempts(t *testing.T) {
-	s := testcore.NewEnv(t, testcore.WithSdkWorker())
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_DontResetAttempts() {
+	env := testcore.NewEnv(s.T())
 
 	internalWorkflow := newInternalWorkflow()
 
-	s.SdkWorker().RegisterWorkflow(internalWorkflow.WorkflowFunc)
-	s.SdkWorker().RegisterActivity(internalWorkflow.ActivityFunc)
+	env.SdkWorker().RegisterWorkflow(internalWorkflow.WorkflowFunc)
+	env.SdkWorker().RegisterActivity(internalWorkflow.ActivityFunc)
 
-	workflowRun1 := createBatchResetWorkflow(ctx, s, internalWorkflow.WorkflowFunc)
-	workflowRun2 := createBatchResetWorkflow(ctx, s, internalWorkflow.WorkflowFunc)
+	workflowRun1 := s.createBatchResetWorkflow(env, internalWorkflow.WorkflowFunc)
+	workflowRun2 := s.createBatchResetWorkflow(env, internalWorkflow.WorkflowFunc)
 
 	// wait for activity to start in both workflows
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun1.GetID(), workflowRun1.GetRunID())
+		description, err := env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.GetPendingActivities(), 1)
 		require.Positive(t, internalWorkflow.startedActivityCount.Load())
 
-		description, err = s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun2.GetID(), workflowRun2.GetRunID())
+		description, err = env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun2.GetID(), workflowRun2.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.GetPendingActivities(), 1)
 		require.Positive(t, internalWorkflow.startedActivityCount.Load())
@@ -329,24 +320,24 @@ func testActivityBatchResetDontResetAttempts(t *testing.T) {
 
 	// pause activities in both workflows
 	pauseRequest := &workflowservice.PauseActivityRequest{
-		Namespace: s.Namespace().String(),
+		Namespace: env.Namespace().String(),
 		Execution: &commonpb.WorkflowExecution{},
 		Activity:  &workflowservice.PauseActivityRequest_Id{Id: "activity-id"},
 	}
 
 	pauseRequest.Execution.WorkflowId = workflowRun1.GetID()
-	resp, err := s.FrontendClient().PauseActivity(ctx, pauseRequest)
+	resp, err := env.FrontendClient().PauseActivity(env.Context(), pauseRequest)
 	s.NoError(err)
 	s.NotNil(resp)
 
 	pauseRequest.Execution.WorkflowId = workflowRun2.GetID()
-	resp, err = s.FrontendClient().PauseActivity(ctx, pauseRequest)
+	resp, err = env.FrontendClient().PauseActivity(env.Context(), pauseRequest)
 	s.NoError(err)
 	s.NotNil(resp)
 
 	// wait for activities to be paused
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun1.GetID(), workflowRun1.GetRunID())
+		description, err := env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.GetPendingActivities(), 1)
 		require.True(t, description.PendingActivities[0].Paused)
@@ -363,8 +354,8 @@ func testActivityBatchResetDontResetAttempts(t *testing.T) {
 	query := fmt.Sprintf("(WorkflowType='%s' AND %s)", workflowTypeName, resetCause)
 
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		listResp, err = s.FrontendClient().ListWorkflowExecutions(ctx, &workflowservice.ListWorkflowExecutionsRequest{
-			Namespace: s.Namespace().String(),
+		listResp, err = env.FrontendClient().ListWorkflowExecutions(env.Context(), &workflowservice.ListWorkflowExecutionsRequest{
+			Namespace: env.Namespace().String(),
 			PageSize:  10,
 			Query:     query,
 		})
@@ -375,8 +366,8 @@ func testActivityBatchResetDontResetAttempts(t *testing.T) {
 	}, 5*time.Second, 500*time.Millisecond)
 
 	// reset the activities in both workflows with batch reset
-	_, err = s.SdkClient().WorkflowService().StartBatchOperation(context.Background(), &workflowservice.StartBatchOperationRequest{
-		Namespace: s.Namespace().String(),
+	_, err = env.SdkClient().WorkflowService().StartBatchOperation(env.Context(), &workflowservice.StartBatchOperationRequest{
+		Namespace: env.Namespace().String(),
 		Operation: &workflowservice.StartBatchOperationRequest_ResetActivitiesOperation{
 			ResetActivitiesOperation: &batchpb.BatchOperationResetActivities{
 				Activity:      &batchpb.BatchOperationResetActivities_Type{Type: activityTypeName},
@@ -392,12 +383,12 @@ func testActivityBatchResetDontResetAttempts(t *testing.T) {
 
 	// make sure activities are restarted and still paused
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun1.GetID(), workflowRun1.GetRunID())
+		description, err := env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.PendingActivities, 1)
 		require.NotEqual(t, int32(1), description.PendingActivities[0].Attempt)
 
-		description, err = s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun2.GetID(), workflowRun2.GetRunID())
+		description, err = env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun2.GetID(), workflowRun2.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.PendingActivities, 1)
 		require.NotEqual(t, int32(1), description.PendingActivities[0].Attempt)
@@ -407,8 +398,8 @@ func testActivityBatchResetDontResetAttempts(t *testing.T) {
 	internalWorkflow.letActivitySucceed.Store(true)
 
 	// reset the activities in both workflows with batch reset
-	_, err = s.SdkClient().WorkflowService().StartBatchOperation(context.Background(), &workflowservice.StartBatchOperationRequest{
-		Namespace: s.Namespace().String(),
+	_, err = env.SdkClient().WorkflowService().StartBatchOperation(env.Context(), &workflowservice.StartBatchOperationRequest{
+		Namespace: env.Namespace().String(),
 		Operation: &workflowservice.StartBatchOperationRequest_ResetActivitiesOperation{
 			ResetActivitiesOperation: &batchpb.BatchOperationResetActivities{
 				Activity:   &batchpb.BatchOperationResetActivities_Type{Type: activityTypeName},
@@ -422,19 +413,19 @@ func testActivityBatchResetDontResetAttempts(t *testing.T) {
 	s.NoError(err)
 
 	var out string
-	err = workflowRun1.Get(ctx, &out)
+	err = workflowRun1.Get(env.Context(), &out)
 	s.NoError(err)
 
-	err = workflowRun2.Get(ctx, &out)
+	err = workflowRun2.Get(env.Context(), &out)
 	s.NoError(err)
 }
 
-func testActivityBatchResetFailed(t *testing.T) {
-	s := testcore.NewEnv(t, testcore.WithSdkWorker())
+func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_Failed() {
+	env := testcore.NewEnv(s.T())
 
 	// neither activity type not "match all" is provided
-	_, err := s.SdkClient().WorkflowService().StartBatchOperation(context.Background(), &workflowservice.StartBatchOperationRequest{
-		Namespace: s.Namespace().String(),
+	_, err := env.SdkClient().WorkflowService().StartBatchOperation(env.Context(), &workflowservice.StartBatchOperationRequest{
+		Namespace: env.Namespace().String(),
 		Operation: &workflowservice.StartBatchOperationRequest_ResetActivitiesOperation{
 			ResetActivitiesOperation: &batchpb.BatchOperationResetActivities{},
 		},
@@ -447,8 +438,8 @@ func testActivityBatchResetFailed(t *testing.T) {
 	s.ErrorAs(err, new(*serviceerror.InvalidArgument))
 
 	// neither activity type not "match all" is provided
-	_, err = s.SdkClient().WorkflowService().StartBatchOperation(context.Background(), &workflowservice.StartBatchOperationRequest{
-		Namespace: s.Namespace().String(),
+	_, err = env.SdkClient().WorkflowService().StartBatchOperation(env.Context(), &workflowservice.StartBatchOperationRequest{
+		Namespace: env.Namespace().String(),
 		Operation: &workflowservice.StartBatchOperationRequest_ResetActivitiesOperation{
 			ResetActivitiesOperation: &batchpb.BatchOperationResetActivities{
 				Activity: &batchpb.BatchOperationResetActivities_Type{Type: ""},

--- a/tests/activity_api_update_test.go
+++ b/tests/activity_api_update_test.go
@@ -16,6 +16,7 @@ import (
 	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
@@ -56,367 +57,372 @@ func makeActivityUpdateWorkflowFunc(
 	}
 }
 
-func TestActivityApiUpdateClientTestSuite(t *testing.T) {
-	t.Parallel()
-	t.Run("TestActivityUpdateApi_ChangeRetryInterval", func(t *testing.T) {
-		s := testcore.NewEnv(t, testcore.WithSdkWorker())
+type ActivityAPIUpdateClientTestSuite struct {
+	parallelsuite.Suite[*ActivityAPIUpdateClientTestSuite]
+}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
+func TestActivityAPIUpdateClientTestSuite(t *testing.T) {
+	parallelsuite.Run(t, &ActivityAPIUpdateClientTestSuite{})
+}
 
-		activityUpdated := make(chan struct{})
+func (s *ActivityAPIUpdateClientTestSuite) TestActivityUpdateApi_ChangeRetryInterval() {
+	env := testcore.NewEnv(s.T())
 
-		var startedActivityCount atomic.Int32
-		activityFunction := func() (string, error) {
-			startedActivityCount.Add(1)
-			if startedActivityCount.Load() == 1 {
-				activityErr := errors.New("bad-luck-please-retry")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
-				return "", activityErr
-			}
+	activityUpdated := make(chan struct{})
 
-			s.WaitForChannel(ctx, activityUpdated)
-			return "done!", nil
+	var startedActivityCount atomic.Int32
+	activityFunction := func() (string, error) {
+		startedActivityCount.Add(1)
+		if startedActivityCount.Load() == 1 {
+			activityErr := errors.New("bad-luck-please-retry")
+
+			return "", activityErr
 		}
 
-		scheduleToCloseTimeout := 30 * time.Minute
-		retryTimeout := 10 * time.Minute
-		workflowFn := makeActivityUpdateWorkflowFunc(activityFunction, scheduleToCloseTimeout, retryTimeout)
+		env.WaitForChannel(ctx, activityUpdated)
+		return "done!", nil
+	}
 
-		s.SdkWorker().RegisterWorkflow(workflowFn)
-		s.SdkWorker().RegisterActivity(activityFunction)
+	scheduleToCloseTimeout := 30 * time.Minute
+	retryTimeout := 10 * time.Minute
+	workflowFn := makeActivityUpdateWorkflowFunc(activityFunction, scheduleToCloseTimeout, retryTimeout)
 
-		workflowOptions := sdkclient.StartWorkflowOptions{
-			ID:        activityUpdateWorkflowID,
-			TaskQueue: s.WorkerTaskQueue(),
-		}
+	env.SdkWorker().RegisterWorkflow(workflowFn)
+	env.SdkWorker().RegisterActivity(activityFunction)
 
-		workflowRun, err := s.SdkClient().ExecuteWorkflow(ctx, workflowOptions, workflowFn)
-		s.NoError(err)
+	workflowOptions := sdkclient.StartWorkflowOptions{
+		ID:        activityUpdateWorkflowID,
+		TaskQueue: env.WorkerTaskQueue(),
+	}
 
-		s.EventuallyWithT(func(t *assert.CollectT) {
-			description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
-			require.NoError(t, err)
-			require.Len(t, description.GetPendingActivities(), 1)
-			require.Equal(t, int32(1), startedActivityCount.Load())
-		}, 10*time.Second, 500*time.Millisecond)
+	workflowRun, err := env.SdkClient().ExecuteWorkflow(ctx, workflowOptions, workflowFn)
+	s.NoError(err)
 
-		updateRequest := &workflowservice.UpdateActivityOptionsRequest{
-			Namespace: s.Namespace().String(),
-			Execution: &commonpb.WorkflowExecution{
-				WorkflowId: workflowRun.GetID(),
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		description, err := env.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
+		require.NoError(t, err)
+		require.Len(t, description.GetPendingActivities(), 1)
+		require.Equal(t, int32(1), startedActivityCount.Load())
+	}, 10*time.Second, 500*time.Millisecond)
+
+	updateRequest := &workflowservice.UpdateActivityOptionsRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{
+			WorkflowId: workflowRun.GetID(),
+		},
+		Activity: &workflowservice.UpdateActivityOptionsRequest_Id{Id: "activity-id"},
+		ActivityOptions: &activitypb.ActivityOptions{
+			RetryPolicy: &commonpb.RetryPolicy{
+				InitialInterval: durationpb.New(1 * time.Second),
 			},
-			Activity: &workflowservice.UpdateActivityOptionsRequest_Id{Id: "activity-id"},
-			ActivityOptions: &activitypb.ActivityOptions{
-				RetryPolicy: &commonpb.RetryPolicy{
-					InitialInterval: durationpb.New(1 * time.Second),
-				},
-			},
-			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"retry_policy.initial_interval"}},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"retry_policy.initial_interval"}},
+	}
+	resp, err := env.FrontendClient().UpdateActivityOptions(ctx, updateRequest)
+	s.NoError(err)
+	s.NotNil(resp)
+
+	description, err := env.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
+	s.NoError(err)
+	s.Len(description.PendingActivities, 1)
+
+	activityUpdated <- struct{}{}
+
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		description, err = env.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
+		require.NoError(t, err)
+		require.Empty(t, description.GetPendingActivities())
+		require.Equal(t, int32(2), startedActivityCount.Load())
+	}, 3*time.Second, 100*time.Millisecond)
+
+	var out string
+	err = workflowRun.Get(ctx, &out)
+
+	s.NoError(err)
+}
+
+func (s *ActivityAPIUpdateClientTestSuite) TestActivityUpdateApi_ChangeScheduleToClose() {
+	env := testcore.NewEnv(s.T())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var startedActivityCount atomic.Int32
+	activityFunction := func() (string, error) {
+		startedActivityCount.Add(1)
+		if startedActivityCount.Load() == 1 {
+			activityErr := errors.New("bad-luck-please-retry")
+			return "", activityErr
 		}
-		resp, err := s.FrontendClient().UpdateActivityOptions(ctx, updateRequest)
-		s.NoError(err)
-		s.NotNil(resp)
+		return "done!", nil
+	}
 
-		description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
-		s.NoError(err)
-		s.Len(description.PendingActivities, 1)
+	scheduleToCloseTimeout := 30 * time.Minute
+	retryTimeout := 10 * time.Minute
 
-		activityUpdated <- struct{}{}
+	workflowFn := makeActivityUpdateWorkflowFunc(activityFunction, scheduleToCloseTimeout, retryTimeout)
 
-		s.EventuallyWithT(func(t *assert.CollectT) {
-			description, err = s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
-			require.NoError(t, err)
-			require.Empty(t, description.GetPendingActivities())
-			require.Equal(t, int32(2), startedActivityCount.Load())
-		}, 3*time.Second, 100*time.Millisecond)
+	env.SdkWorker().RegisterWorkflow(workflowFn)
+	env.SdkWorker().RegisterActivity(activityFunction)
 
-		var out string
-		err = workflowRun.Get(ctx, &out)
+	workflowOptions := sdkclient.StartWorkflowOptions{
+		ID:        activityUpdateWorkflowID,
+		TaskQueue: env.WorkerTaskQueue(),
+	}
 
-		s.NoError(err)
-	})
+	workflowRun, err := env.SdkClient().ExecuteWorkflow(ctx, workflowOptions, workflowFn)
+	s.NoError(err)
 
-	t.Run("TestActivityUpdateApi_ChangeScheduleToClose", func(t *testing.T) {
-		s := testcore.NewEnv(t, testcore.WithSdkWorker())
+	// wait for activity to start (and fail)
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		description, err := env.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
+		require.NoError(t, err)
+		require.Len(t, description.GetPendingActivities(), 1)
+		require.Equal(t, int32(1), startedActivityCount.Load())
 
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
+	}, 2*time.Second, 200*time.Millisecond)
 
-		var startedActivityCount atomic.Int32
-		activityFunction := func() (string, error) {
-			startedActivityCount.Add(1)
-			if startedActivityCount.Load() == 1 {
-				activityErr := errors.New("bad-luck-please-retry")
-				return "", activityErr
-			}
-			return "done!", nil
+	// update schedule_to_close_timeout
+	updateRequest := &workflowservice.UpdateActivityOptionsRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{
+			WorkflowId: workflowRun.GetID(),
+		},
+		Activity: &workflowservice.UpdateActivityOptionsRequest_Id{Id: "activity-id"},
+		ActivityOptions: &activitypb.ActivityOptions{
+			ScheduleToCloseTimeout: durationpb.New(1 * time.Second),
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"schedule_to_close_timeout"}},
+	}
+	resp, err := env.FrontendClient().UpdateActivityOptions(ctx, updateRequest)
+	s.NoError(err)
+	s.NotNil(resp)
+
+	// activity should fail immediately
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		description, err := env.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
+		require.NoError(t, err)
+		require.Empty(t, description.GetPendingActivities())
+		require.Equal(t, int32(1), startedActivityCount.Load())
+	}, 2*time.Second, 200*time.Millisecond)
+
+	var out string
+	err = workflowRun.Get(ctx, &out)
+	var activityError *temporal.ActivityError
+	s.ErrorAs(err, &activityError)
+	// SCHEDULE_TO_CLOSE timeout now returns RETRY_STATE_TIMEOUT instead of RETRY_STATE_NON_RETRYABLE_FAILURE
+	s.Equal(enumspb.RETRY_STATE_TIMEOUT, activityError.RetryState())
+	var timeoutError *temporal.TimeoutError
+	s.ErrorAs(activityError, &timeoutError)
+	s.Equal(enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, timeoutError.TimeoutType())
+	s.Equal(int32(1), startedActivityCount.Load())
+}
+
+func (s *ActivityAPIUpdateClientTestSuite) TestActivityUpdateApi_ChangeScheduleToCloseAndRetry() {
+	// change both schedule to close and retry policy
+	// initial values are chosen in such a way that activity will fail due to schedule to close timeout
+	// we change schedule to close to a longer value and retry policy to a shorter value
+	// after that activity should succeed
+	env := testcore.NewEnv(s.T())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var startedActivityCount atomic.Int32
+	activityFunction := func() (string, error) {
+		startedActivityCount.Add(1)
+		if startedActivityCount.Load() == 1 {
+			activityErr := errors.New("bad-luck-please-retry")
+
+			return "", activityErr
 		}
+		return "done!", nil
+	}
 
-		scheduleToCloseTimeout := 30 * time.Minute
-		retryTimeout := 10 * time.Minute
+	// make scheduleToClose shorter than retry 2nd retry interval
+	scheduleToCloseTimeout := 8 * time.Second
+	retryInterval := 5 * time.Second
 
-		workflowFn := makeActivityUpdateWorkflowFunc(activityFunction, scheduleToCloseTimeout, retryTimeout)
+	workflowFn := makeActivityUpdateWorkflowFunc(
+		activityFunction, scheduleToCloseTimeout, retryInterval)
 
-		s.SdkWorker().RegisterWorkflow(workflowFn)
-		s.SdkWorker().RegisterActivity(activityFunction)
+	env.SdkWorker().RegisterWorkflow(workflowFn)
+	env.SdkWorker().RegisterActivity(activityFunction)
 
-		workflowOptions := sdkclient.StartWorkflowOptions{
-			ID:        activityUpdateWorkflowID,
-			TaskQueue: s.WorkerTaskQueue(),
-		}
+	workflowOptions := sdkclient.StartWorkflowOptions{
+		ID:        activityUpdateWorkflowID,
+		TaskQueue: env.WorkerTaskQueue(),
+	}
 
-		workflowRun, err := s.SdkClient().ExecuteWorkflow(ctx, workflowOptions, workflowFn)
-		s.NoError(err)
+	workflowRun, err := env.SdkClient().ExecuteWorkflow(ctx, workflowOptions, workflowFn)
+	s.NoError(err)
 
-		// wait for activity to start (and fail)
-		s.EventuallyWithT(func(t *assert.CollectT) {
-			description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
-			require.NoError(t, err)
-			require.Len(t, description.GetPendingActivities(), 1)
-			require.Equal(t, int32(1), startedActivityCount.Load())
+	// wait for activity to start (and fail)
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		require.NotZero(t, startedActivityCount.Load())
+	}, 2*time.Second, 200*time.Millisecond)
 
-		}, 2*time.Second, 200*time.Millisecond)
-
-		// update schedule_to_close_timeout
-		updateRequest := &workflowservice.UpdateActivityOptionsRequest{
-			Namespace: s.Namespace().String(),
-			Execution: &commonpb.WorkflowExecution{
-				WorkflowId: workflowRun.GetID(),
-			},
-			Activity: &workflowservice.UpdateActivityOptionsRequest_Id{Id: "activity-id"},
-			ActivityOptions: &activitypb.ActivityOptions{
-				ScheduleToCloseTimeout: durationpb.New(1 * time.Second),
-			},
-			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"schedule_to_close_timeout"}},
-		}
-		resp, err := s.FrontendClient().UpdateActivityOptions(ctx, updateRequest)
-		s.NoError(err)
-		s.NotNil(resp)
-
-		// activity should fail immediately
-		s.EventuallyWithT(func(t *assert.CollectT) {
-			description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
-			require.NoError(t, err)
-			require.Empty(t, description.GetPendingActivities())
-			require.Equal(t, int32(1), startedActivityCount.Load())
-		}, 2*time.Second, 200*time.Millisecond)
-
-		var out string
-		err = workflowRun.Get(ctx, &out)
-		var activityError *temporal.ActivityError
-		s.ErrorAs(err, &activityError)
-		// SCHEDULE_TO_CLOSE timeout now returns RETRY_STATE_TIMEOUT instead of RETRY_STATE_NON_RETRYABLE_FAILURE
-		s.Equal(enumspb.RETRY_STATE_TIMEOUT, activityError.RetryState())
-		var timeoutError *temporal.TimeoutError
-		s.ErrorAs(activityError, &timeoutError)
-		s.Equal(enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, timeoutError.TimeoutType())
-		s.Equal(int32(1), startedActivityCount.Load())
-	})
-
-	t.Run("TestActivityUpdateApi_ChangeScheduleToCloseAndRetry", func(t *testing.T) {
-		// change both schedule to close and retry policy
-		// initial values are chosen in such a way that activity will fail due to schedule to close timeout
-		// we change schedule to close to a longer value and retry policy to a shorter value
-		// after that activity should succeed
-		s := testcore.NewEnv(t, testcore.WithSdkWorker())
-
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-
-		var startedActivityCount atomic.Int32
-		activityFunction := func() (string, error) {
-			startedActivityCount.Add(1)
-			if startedActivityCount.Load() == 1 {
-				activityErr := errors.New("bad-luck-please-retry")
-
-				return "", activityErr
-			}
-			return "done!", nil
-		}
-
-		// make scheduleToClose shorter than retry 2nd retry interval
-		scheduleToCloseTimeout := 8 * time.Second
-		retryInterval := 5 * time.Second
-
-		workflowFn := makeActivityUpdateWorkflowFunc(
-			activityFunction, scheduleToCloseTimeout, retryInterval)
-
-		s.SdkWorker().RegisterWorkflow(workflowFn)
-		s.SdkWorker().RegisterActivity(activityFunction)
-
-		workflowOptions := sdkclient.StartWorkflowOptions{
-			ID:        activityUpdateWorkflowID,
-			TaskQueue: s.WorkerTaskQueue(),
-		}
-
-		workflowRun, err := s.SdkClient().ExecuteWorkflow(ctx, workflowOptions, workflowFn)
-		s.NoError(err)
-
-		// wait for activity to start (and fail)
-		s.EventuallyWithT(func(t *assert.CollectT) {
-			require.NotZero(t, startedActivityCount.Load())
-		}, 2*time.Second, 200*time.Millisecond)
-
-		// update schedule_to_close_timeout, make it longer
-		// also update retry policy interval, make it shorter
-		newScheduleToCloseTimeout := 10 * time.Second
-		updateRequest := &workflowservice.UpdateActivityOptionsRequest{
-			Namespace: s.Namespace().String(),
-			Execution: &commonpb.WorkflowExecution{
-				WorkflowId: workflowRun.GetID(),
-			},
-			Activity: &workflowservice.UpdateActivityOptionsRequest_Id{Id: "activity-id"},
-			ActivityOptions: &activitypb.ActivityOptions{
-				ScheduleToCloseTimeout: durationpb.New(newScheduleToCloseTimeout),
-				RetryPolicy: &commonpb.RetryPolicy{
-					InitialInterval: durationpb.New(1 * time.Second),
-				},
-			},
-			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"schedule_to_close_timeout", "retry_policy.initial_interval"}},
-		}
-
-		resp, err := s.FrontendClient().UpdateActivityOptions(ctx, updateRequest)
-		s.NoError(err)
-		s.NotNil(resp)
-		// check that the update was successful
-		s.Equal(int64(newScheduleToCloseTimeout.Seconds()), resp.GetActivityOptions().ScheduleToCloseTimeout.GetSeconds())
-		// check that field we didn't update is the same
-		s.Equal(int64(scheduleToCloseTimeout.Seconds()), resp.GetActivityOptions().StartToCloseTimeout.GetSeconds())
-
-		// now activity should succeed
-		s.EventuallyWithT(func(t *assert.CollectT) {
-			description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
-			require.NoError(t, err)
-			require.Empty(t, description.GetPendingActivities())
-			require.Equal(t, int32(2), startedActivityCount.Load())
-		}, 5*time.Second, 200*time.Millisecond)
-
-		var out string
-		err = workflowRun.Get(ctx, &out)
-		s.NoError(err)
-	})
-
-	t.Run("TestActivityUpdateApi_ResetDefaultOptions", func(t *testing.T) {
-		// plan:
-		// 1. start the workflow, wait for activity to start and fail,
-		// 2. update activity options to change retry policy maximum attempts
-		// 3. reset activity options to default, verify that retry policy is reset to default
-		// 4. update activity options again, this time change schedule to close timeout and retry policy initial interval
-		// 5. let activity finish, verify that it finished with updated options
-		s := testcore.NewEnv(t, testcore.WithSdkWorker())
-
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-
-		activityUpdated := make(chan struct{})
-
-		var startedActivityCount atomic.Int32
-		activityFunction := func() (string, error) {
-			startedActivityCount.Add(1)
-			if startedActivityCount.Load() == 1 {
-				activityErr := errors.New("bad-luck-please-retry")
-
-				return "", activityErr
-			}
-
-			s.WaitForChannel(ctx, activityUpdated)
-			return "done!", nil
-		}
-
-		scheduleToCloseTimeout := 30 * time.Minute
-		retryTimeout := 10 * time.Minute
-		workflowFn := makeActivityUpdateWorkflowFunc(activityFunction, scheduleToCloseTimeout, retryTimeout)
-
-		s.SdkWorker().RegisterWorkflow(workflowFn)
-		s.SdkWorker().RegisterActivity(activityFunction)
-
-		workflowOptions := sdkclient.StartWorkflowOptions{
-			ID:        activityUpdateWorkflowID,
-			TaskQueue: s.WorkerTaskQueue(),
-		}
-
-		workflowRun, err := s.SdkClient().ExecuteWorkflow(ctx, workflowOptions, workflowFn)
-		s.NoError(err)
-
-		// wait for activity to start (and fail)
-		s.EventuallyWithT(func(t *assert.CollectT) {
-			description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
-			require.NoError(t, err)
-			require.Len(t, description.GetPendingActivities(), 1)
-			require.Equal(t, int32(1), startedActivityCount.Load())
-		}, 10*time.Second, 500*time.Millisecond)
-
-		// update activity options, set retry policy to 1000 attempts
-		updateRequest := &workflowservice.UpdateActivityOptionsRequest{
-			Namespace: s.Namespace().String(),
-			Execution: &commonpb.WorkflowExecution{
-				WorkflowId: workflowRun.GetID(),
-			},
-			Activity: &workflowservice.UpdateActivityOptionsRequest_Id{Id: "activity-id"},
-			ActivityOptions: &activitypb.ActivityOptions{
-				RetryPolicy: &commonpb.RetryPolicy{
-					MaximumAttempts: 1000,
-				},
-			},
-			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"retry_policy.maximum_attempts"}},
-		}
-		resp, err := s.FrontendClient().UpdateActivityOptions(ctx, updateRequest)
-		s.NoError(err)
-		s.NotNil(resp)
-
-		// check that the update was successful
-		s.EventuallyWithT(func(t *assert.CollectT) {
-			description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
-			require.NoError(t, err)
-			require.Len(t, description.PendingActivities, 1)
-			require.Equal(t, int32(1000), description.PendingActivities[0].GetActivityOptions().GetRetryPolicy().GetMaximumAttempts())
-		}, 3*time.Second, 200*time.Millisecond)
-
-		// reset activity options to default
-		updateRequest.ActivityOptions = nil
-		updateRequest.UpdateMask = &fieldmaskpb.FieldMask{Paths: []string{}}
-		updateRequest.RestoreOriginal = true
-		resp, err = s.FrontendClient().UpdateActivityOptions(ctx, updateRequest)
-		s.NoError(err)
-		s.NotNil(resp)
-
-		// check that the update was successful
-		s.EventuallyWithT(func(t *assert.CollectT) {
-			description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
-			require.NoError(t, err)
-			require.Len(t, description.PendingActivities, 1)
-			require.Equal(t, int32(defaultMaximumAttempts), description.PendingActivities[0].GetActivityOptions().GetRetryPolicy().GetMaximumAttempts())
-		}, 3*time.Second, 200*time.Millisecond)
-
-		// update activity options again, this time set retry interval to 1 second
-		newScheduleToCloseTimeout := 10 * time.Second
-		updateRequest.ActivityOptions = &activitypb.ActivityOptions{
+	// update schedule_to_close_timeout, make it longer
+	// also update retry policy interval, make it shorter
+	newScheduleToCloseTimeout := 10 * time.Second
+	updateRequest := &workflowservice.UpdateActivityOptionsRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{
+			WorkflowId: workflowRun.GetID(),
+		},
+		Activity: &workflowservice.UpdateActivityOptionsRequest_Id{Id: "activity-id"},
+		ActivityOptions: &activitypb.ActivityOptions{
 			ScheduleToCloseTimeout: durationpb.New(newScheduleToCloseTimeout),
 			RetryPolicy: &commonpb.RetryPolicy{
 				InitialInterval: durationpb.New(1 * time.Second),
 			},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"schedule_to_close_timeout", "retry_policy.initial_interval"}},
+	}
+
+	resp, err := env.FrontendClient().UpdateActivityOptions(ctx, updateRequest)
+	s.NoError(err)
+	s.NotNil(resp)
+	// check that the update was successful
+	s.Equal(int64(newScheduleToCloseTimeout.Seconds()), resp.GetActivityOptions().ScheduleToCloseTimeout.GetSeconds())
+	// check that field we didn't update is the same
+	s.Equal(int64(scheduleToCloseTimeout.Seconds()), resp.GetActivityOptions().StartToCloseTimeout.GetSeconds())
+
+	// now activity should succeed
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		description, err := env.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
+		require.NoError(t, err)
+		require.Empty(t, description.GetPendingActivities())
+		require.Equal(t, int32(2), startedActivityCount.Load())
+	}, 5*time.Second, 200*time.Millisecond)
+
+	var out string
+	err = workflowRun.Get(ctx, &out)
+	s.NoError(err)
+}
+
+func (s *ActivityAPIUpdateClientTestSuite) TestActivityUpdateApi_ResetDefaultOptions() {
+	// plan:
+	// 1. start the workflow, wait for activity to start and fail,
+	// 2. update activity options to change retry policy maximum attempts
+	// 3. reset activity options to default, verify that retry policy is reset to default
+	// 4. update activity options again, this time change schedule to close timeout and retry policy initial interval
+	// 5. let activity finish, verify that it finished with updated options
+	env := testcore.NewEnv(s.T())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	activityUpdated := make(chan struct{})
+
+	var startedActivityCount atomic.Int32
+	activityFunction := func() (string, error) {
+		startedActivityCount.Add(1)
+		if startedActivityCount.Load() == 1 {
+			activityErr := errors.New("bad-luck-please-retry")
+
+			return "", activityErr
 		}
-		updateRequest.UpdateMask = &fieldmaskpb.FieldMask{Paths: []string{"schedule_to_close_timeout", "retry_policy.initial_interval"}}
-		updateRequest.RestoreOriginal = false
-		resp, err = s.FrontendClient().UpdateActivityOptions(ctx, updateRequest)
-		s.NoError(err)
-		s.NotNil(resp)
 
-		// let activity finish
-		activityUpdated <- struct{}{}
+		env.WaitForChannel(ctx, activityUpdated)
+		return "done!", nil
+	}
 
-		// wait for activity to finish
-		s.EventuallyWithT(func(t *assert.CollectT) {
-			description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
-			require.NoError(t, err)
-			require.Empty(t, description.GetPendingActivities())
-			require.Equal(t, int32(2), startedActivityCount.Load())
-		}, 3*time.Second, 100*time.Millisecond)
+	scheduleToCloseTimeout := 30 * time.Minute
+	retryTimeout := 10 * time.Minute
+	workflowFn := makeActivityUpdateWorkflowFunc(activityFunction, scheduleToCloseTimeout, retryTimeout)
 
-		var out string
-		err = workflowRun.Get(ctx, &out)
+	env.SdkWorker().RegisterWorkflow(workflowFn)
+	env.SdkWorker().RegisterActivity(activityFunction)
 
-		s.NoError(err)
-	})
+	workflowOptions := sdkclient.StartWorkflowOptions{
+		ID:        activityUpdateWorkflowID,
+		TaskQueue: env.WorkerTaskQueue(),
+	}
+
+	workflowRun, err := env.SdkClient().ExecuteWorkflow(ctx, workflowOptions, workflowFn)
+	s.NoError(err)
+
+	// wait for activity to start (and fail)
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		description, err := env.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
+		require.NoError(t, err)
+		require.Len(t, description.GetPendingActivities(), 1)
+		require.Equal(t, int32(1), startedActivityCount.Load())
+	}, 10*time.Second, 500*time.Millisecond)
+
+	// update activity options, set retry policy to 1000 attempts
+	updateRequest := &workflowservice.UpdateActivityOptionsRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{
+			WorkflowId: workflowRun.GetID(),
+		},
+		Activity: &workflowservice.UpdateActivityOptionsRequest_Id{Id: "activity-id"},
+		ActivityOptions: &activitypb.ActivityOptions{
+			RetryPolicy: &commonpb.RetryPolicy{
+				MaximumAttempts: 1000,
+			},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"retry_policy.maximum_attempts"}},
+	}
+	resp, err := env.FrontendClient().UpdateActivityOptions(ctx, updateRequest)
+	s.NoError(err)
+	s.NotNil(resp)
+
+	// check that the update was successful
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		description, err := env.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
+		require.NoError(t, err)
+		require.Len(t, description.PendingActivities, 1)
+		require.Equal(t, int32(1000), description.PendingActivities[0].GetActivityOptions().GetRetryPolicy().GetMaximumAttempts())
+	}, 3*time.Second, 200*time.Millisecond)
+
+	// reset activity options to default
+	updateRequest.ActivityOptions = nil
+	updateRequest.UpdateMask = &fieldmaskpb.FieldMask{Paths: []string{}}
+	updateRequest.RestoreOriginal = true
+	resp, err = env.FrontendClient().UpdateActivityOptions(ctx, updateRequest)
+	s.NoError(err)
+	s.NotNil(resp)
+
+	// check that the update was successful
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		description, err := env.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
+		require.NoError(t, err)
+		require.Len(t, description.PendingActivities, 1)
+		require.Equal(t, int32(defaultMaximumAttempts), description.PendingActivities[0].GetActivityOptions().GetRetryPolicy().GetMaximumAttempts())
+	}, 3*time.Second, 200*time.Millisecond)
+
+	// update activity options again, this time set retry interval to 1 second
+	newScheduleToCloseTimeout := 10 * time.Second
+	updateRequest.ActivityOptions = &activitypb.ActivityOptions{
+		ScheduleToCloseTimeout: durationpb.New(newScheduleToCloseTimeout),
+		RetryPolicy: &commonpb.RetryPolicy{
+			InitialInterval: durationpb.New(1 * time.Second),
+		},
+	}
+	updateRequest.UpdateMask = &fieldmaskpb.FieldMask{Paths: []string{"schedule_to_close_timeout", "retry_policy.initial_interval"}}
+	updateRequest.RestoreOriginal = false
+	resp, err = env.FrontendClient().UpdateActivityOptions(ctx, updateRequest)
+	s.NoError(err)
+	s.NotNil(resp)
+
+	// let activity finish
+	activityUpdated <- struct{}{}
+
+	// wait for activity to finish
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		description, err := env.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
+		require.NoError(t, err)
+		require.Empty(t, description.GetPendingActivities())
+		require.Equal(t, int32(2), startedActivityCount.Load())
+	}, 3*time.Second, 100*time.Millisecond)
+
+	var out string
+	err = workflowRun.Get(ctx, &out)
+
+	s.NoError(err)
 }

--- a/tests/admin_test.go
+++ b/tests/admin_test.go
@@ -14,29 +14,37 @@ import (
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/common/testing/testvars"
 	"go.temporal.io/server/tests/testcore"
 )
 
-func TestAdminTestSuite(t *testing.T) {
-	t.Parallel()
-	t.Run("TestAdminRebuildMutableState_ChasmDisabled", func(t *testing.T) {
-		s := testcore.NewEnv(t, testcore.WithSdkWorker())
-		rebuildMutableStateWorkflowHelper(s, false)
-	})
-	t.Run("TestAdminRebuildMutableState_ChasmEnabled", func(t *testing.T) {
-		s := testcore.NewEnv(t, testcore.WithSdkWorker(), testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true))
+type AdminTestSuite struct {
+	parallelsuite.Suite[*AdminTestSuite]
+}
 
-		configValues := s.GetTestCluster().Host().DcClient().GetValue(dynamicconfig.EnableChasm.Key())
+func TestAdminRebuildMutableState_ChasmDisabled(t *testing.T) {
+	parallelsuite.Run(t, &AdminTestSuite{}, false)
+}
+
+func TestAdminRebuildMutableState_ChasmEnabled(t *testing.T) {
+	parallelsuite.Run(t, &AdminTestSuite{}, true)
+}
+
+func (s *AdminTestSuite) TestAdminRebuildMutableState(testWithChasm bool) {
+	var opts []testcore.TestOption
+	if testWithChasm {
+		opts = append(opts, testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true))
+	}
+	env := testcore.NewEnv(s.T(), opts...)
+
+	if testWithChasm {
+		configValues := env.GetTestCluster().Host().DcClient().GetValue(dynamicconfig.EnableChasm.Key())
 		s.NotEmpty(configValues, "EnableChasm config should be set")
 		configValue, _ := configValues[0].Value.(bool)
 		s.True(configValue, "EnableChasm config should be true")
-		rebuildMutableStateWorkflowHelper(s, true)
-	})
-}
+	}
 
-// common test helper
-func rebuildMutableStateWorkflowHelper(s *testcore.TestEnv, testWithChasm bool) {
 	tv := testvars.New(s.T())
 	workflowFn := func(ctx workflow.Context) error {
 		var randomUUID string
@@ -50,18 +58,18 @@ func rebuildMutableStateWorkflowHelper(s *testcore.TestEnv, testWithChasm bool) 
 		return nil
 	}
 
-	s.SdkWorker().RegisterWorkflow(workflowFn)
+	env.SdkWorker().RegisterWorkflow(workflowFn)
 
 	workflowID := tv.Any().String()
 	workflowOptions := sdkclient.StartWorkflowOptions{
 		ID:                 workflowID,
-		TaskQueue:          s.WorkerTaskQueue(),
+		TaskQueue:          env.WorkerTaskQueue(),
 		WorkflowRunTimeout: 20 * time.Second,
 	}
-	ctx, cancel := context.WithTimeout(s.Context(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(env.Context(), 30*time.Second)
 	defer cancel()
 
-	workflowRun, err := s.SdkClient().ExecuteWorkflow(s.Context(), workflowOptions, workflowFn)
+	workflowRun, err := env.SdkClient().ExecuteWorkflow(env.Context(), workflowOptions, workflowFn)
 	s.NoError(err)
 	runID := workflowRun.GetRunID()
 
@@ -77,8 +85,8 @@ func rebuildMutableStateWorkflowHelper(s *testcore.TestEnv, testWithChasm bool) 
 
 	var response1 *adminservice.DescribeMutableStateResponse
 	for {
-		response1, err = s.AdminClient().DescribeMutableState(ctx, &adminservice.DescribeMutableStateRequest{
-			Namespace: s.Namespace().String(),
+		response1, err = env.AdminClient().DescribeMutableState(ctx, &adminservice.DescribeMutableStateRequest{
+			Namespace: env.Namespace().String(),
 			Execution: &commonpb.WorkflowExecution{
 				WorkflowId: workflowID,
 				RunId:      runID,
@@ -97,8 +105,8 @@ func rebuildMutableStateWorkflowHelper(s *testcore.TestEnv, testWithChasm bool) 
 		time.Sleep(20 * time.Millisecond) //nolint:forbidigo
 	}
 
-	_, err = s.AdminClient().RebuildMutableState(ctx, &adminservice.RebuildMutableStateRequest{
-		Namespace: s.Namespace().String(),
+	_, err = env.AdminClient().RebuildMutableState(ctx, &adminservice.RebuildMutableStateRequest{
+		Namespace: env.Namespace().String(),
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: workflowID,
 			RunId:      runID,
@@ -106,8 +114,8 @@ func rebuildMutableStateWorkflowHelper(s *testcore.TestEnv, testWithChasm bool) 
 	})
 	s.NoError(err)
 
-	response2, err := s.AdminClient().DescribeMutableState(ctx, &adminservice.DescribeMutableStateRequest{
-		Namespace: s.Namespace().String(),
+	response2, err := env.AdminClient().DescribeMutableState(ctx, &adminservice.DescribeMutableStateRequest{
+		Namespace: env.Namespace().String(),
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: workflowID,
 			RunId:      runID,

--- a/tests/premature_eos_test.go
+++ b/tests/premature_eos_test.go
@@ -8,8 +8,17 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
 )
+
+type PrematureEosTestSuite struct {
+	parallelsuite.Suite[*PrematureEosTestSuite]
+}
+
+func TestPrematureEosTestSuite(t *testing.T) {
+	parallelsuite.Run(t, &PrematureEosTestSuite{})
+}
 
 // Test_SpeculativeWFTEventsLostAfterSignalMidHistoryPagination demonstrates the
 // "premature end of stream" bug in a scenario mimicking SDK workflow cache eviction:
@@ -34,7 +43,7 @@ import (
 //	  returns events 8 and 9; assembled history has 9 events (no premature EOS).
 //
 // This test asserts the FIXED behavior.
-func Test_SpeculativeWFTEventsLostAfterSignalMidHistoryPagination(t *testing.T) {
+func (s *PrematureEosTestSuite) Test_SpeculativeWFTEventsLostAfterSignalMidHistoryPagination() {
 	// MaximumPageSize controls the number of DB event batches per page, not individual
 	// events. The 7 persisted events are stored in 5 batches:
 	//   [1,2] StartWorkflow, [3] WFTStarted, [4,5] WFTCompleted+WFTScheduled,
@@ -43,9 +52,9 @@ func Test_SpeculativeWFTEventsLostAfterSignalMidHistoryPagination(t *testing.T) 
 	// leaving batches [6] and [7] for the second page.
 	const maxBatchesPerPage = 3
 
-	s := testcore.NewEnv(t, testcore.WithDedicatedCluster())
-	tv := s.Tv()
-	runID := mustStartWorkflow(s, tv)
+	env := testcore.NewEnv(s.T(), testcore.WithDedicatedCluster())
+	tv := env.Tv()
+	runID := mustStartWorkflow(env, tv)
 	wfExecution := &commonpb.WorkflowExecution{WorkflowId: tv.WorkflowID(), RunId: runID}
 
 	// Build 7 persisted events:
@@ -56,7 +65,7 @@ func Test_SpeculativeWFTEventsLostAfterSignalMidHistoryPagination(t *testing.T) 
 	//   5: WorkflowTaskScheduled  (force-created)
 	//   6: WorkflowTaskStarted
 	//   7: WorkflowTaskCompleted
-	_, err := s.TaskPoller().PollAndHandleWorkflowTask(tv,
+	_, err := env.TaskPoller().PollAndHandleWorkflowTask(tv,
 		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
 			return &workflowservice.RespondWorkflowTaskCompletedRequest{
 				ForceCreateNewWorkflowTask: true,
@@ -64,7 +73,7 @@ func Test_SpeculativeWFTEventsLostAfterSignalMidHistoryPagination(t *testing.T) 
 		})
 	s.NoError(err)
 
-	_, err = s.TaskPoller().PollAndHandleWorkflowTask(tv,
+	_, err = env.TaskPoller().PollAndHandleWorkflowTask(tv,
 		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
 			return &workflowservice.RespondWorkflowTaskCompletedRequest{}, nil
 		})
@@ -73,7 +82,7 @@ func Test_SpeculativeWFTEventsLostAfterSignalMidHistoryPagination(t *testing.T) 
 	// Send an update to create a speculative WFT (event 8 in memory, scheduled but not polled).
 	ctx, cancel := context.WithCancel(testcore.NewContext())
 	defer cancel()
-	updateCh := sendUpdate(ctx, s, tv)
+	updateCh := sendUpdate(ctx, env, tv)
 	defer func() { go func() { <-updateCh }() }()
 
 	// Wait until the speculative WFT is scheduled before fetching page 1.
@@ -84,9 +93,9 @@ func Test_SpeculativeWFTEventsLostAfterSignalMidHistoryPagination(t *testing.T) 
 	// would only add event 8 (SignalReceived) with freshNextEventId=9, producing 8 events
 	// instead of the expected 9 and causing a false test failure.
 	s.Eventually(func() bool {
-		desc, descErr := s.FrontendClient().DescribeWorkflowExecution(testcore.NewContext(),
+		desc, descErr := env.FrontendClient().DescribeWorkflowExecution(testcore.NewContext(),
 			&workflowservice.DescribeWorkflowExecutionRequest{
-				Namespace: s.Namespace().String(),
+				Namespace: env.Namespace().String(),
 				Execution: wfExecution,
 			})
 		return descErr == nil && desc.GetPendingWorkflowTask() != nil
@@ -99,10 +108,10 @@ func Test_SpeculativeWFTEventsLostAfterSignalMidHistoryPagination(t *testing.T) 
 	// batches are returned ([1,2]+[3]+[4,5] = events 1..5), leaving batches [6] and [7] for
 	// the next page. The continuation token encodes NextEventId=8 and PersistenceToken
 	// pointing to the next DB batch — this is the "stale token" that exercises the bug.
-	histPage1, err := s.FrontendClient().GetWorkflowExecutionHistory(
+	histPage1, err := env.FrontendClient().GetWorkflowExecutionHistory(
 		testcore.NewContext(),
 		&workflowservice.GetWorkflowExecutionHistoryRequest{
-			Namespace:       s.Namespace().String(),
+			Namespace:       env.Namespace().String(),
 			Execution:       wfExecution,
 			MaximumPageSize: maxBatchesPerPage,
 		},
@@ -110,7 +119,7 @@ func Test_SpeculativeWFTEventsLostAfterSignalMidHistoryPagination(t *testing.T) 
 	s.NoError(err)
 	s.NotNil(histPage1.NextPageToken,
 		"NextPageToken must be set: with maxBatchesPerPage=3 and 5 total batches, page 1 must not be the last page")
-	t.Logf("NEXTPAGETOKEN: %s", histPage1.NextPageToken)
+	s.T().Logf("NEXTPAGETOKEN: %s", histPage1.NextPageToken)
 
 	firstPageEvents := histPage1.History.Events
 	staleNextPageToken := histPage1.NextPageToken
@@ -120,9 +129,9 @@ func Test_SpeculativeWFTEventsLostAfterSignalMidHistoryPagination(t *testing.T) 
 	//   8: WorkflowTaskScheduled  (normal WFT scheduled to handle the pending update)
 	//   9: WorkflowExecutionSignaled  (flushed immediately: HasStartedWorkflowTask=false)
 	// After this transaction, freshNextEventId=10.
-	_, signalErr := s.FrontendClient().SignalWorkflowExecution(testcore.NewContext(),
+	_, signalErr := env.FrontendClient().SignalWorkflowExecution(testcore.NewContext(),
 		&workflowservice.SignalWorkflowExecutionRequest{
-			Namespace:         s.Namespace().String(),
+			Namespace:         env.Namespace().String(),
 			WorkflowExecution: wfExecution,
 			SignalName:        tv.Any().String(),
 		})
@@ -132,9 +141,9 @@ func Test_SpeculativeWFTEventsLostAfterSignalMidHistoryPagination(t *testing.T) 
 	allEvents := make([]*historypb.HistoryEvent, len(firstPageEvents))
 	copy(allEvents, firstPageEvents)
 	for nextPageToken := staleNextPageToken; nextPageToken != nil; {
-		histResp, histErr := s.FrontendClient().GetWorkflowExecutionHistory(testcore.NewContext(),
+		histResp, histErr := env.FrontendClient().GetWorkflowExecutionHistory(testcore.NewContext(),
 			&workflowservice.GetWorkflowExecutionHistoryRequest{
-				Namespace:       s.Namespace().String(),
+				Namespace:       env.Namespace().String(),
 				Execution:       wfExecution,
 				NextPageToken:   nextPageToken,
 				MaximumPageSize: maxBatchesPerPage,

--- a/tests/schedule_migration_test.go
+++ b/tests/schedule_migration_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	schedulepb "go.temporal.io/api/schedule/v1"
@@ -23,15 +22,24 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/sdk"
+	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/service/worker/scheduler"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func TestScheduleMigrationV2AlreadyExists(t *testing.T) {
+type ScheduleMigrationTestSuite struct {
+	parallelsuite.Suite[*ScheduleMigrationTestSuite]
+}
+
+func TestScheduleMigrationTestSuite(t *testing.T) {
+	parallelsuite.Run(t, &ScheduleMigrationTestSuite{})
+}
+
+func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2AlreadyExists() {
 	env := testcore.NewEnv(
-		t,
+		s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 	)
 
@@ -74,7 +82,7 @@ func TestScheduleMigrationV2AlreadyExists(t *testing.T) {
 			},
 		},
 	)
-	require.NoError(t, err)
+	s.NoError(err)
 
 	_, err = env.GetTestCluster().SchedulerClient().DescribeSchedule(
 		ctx,
@@ -83,7 +91,7 @@ func TestScheduleMigrationV2AlreadyExists(t *testing.T) {
 			FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: nsName, ScheduleId: sid},
 		},
 	)
-	require.NoError(t, err)
+	s.NoError(err)
 
 	// Directly calling CreateFromMigrationState when a CHASM schedule already
 	// exists should return AlreadyExists, matching CreateSchedule's behavior.
@@ -104,8 +112,8 @@ func TestScheduleMigrationV2AlreadyExists(t *testing.T) {
 		},
 	)
 	var alreadyExists *serviceerror.AlreadyExists
-	require.ErrorAs(t, err, &alreadyExists)
-	require.Contains(t, alreadyExists.Error(), sid)
+	s.ErrorAs(err, &alreadyExists)
+	s.Contains(alreadyExists.Error(), sid)
 
 	// Create the V1 (workflow-backed) scheduler directly
 	startArgs := &schedulespb.StartScheduleArgs{
@@ -118,7 +126,7 @@ func TestScheduleMigrationV2AlreadyExists(t *testing.T) {
 		},
 	}
 	inputPayloads, err := sdk.PreferProtoDataConverter.ToPayloads(startArgs)
-	require.NoError(t, err)
+	s.NoError(err)
 	v1WorkflowID := scheduler.WorkflowIDPrefix + sid
 	startReq := &workflowservice.StartWorkflowExecutionRequest{
 		Namespace:                nsName,
@@ -135,7 +143,7 @@ func TestScheduleMigrationV2AlreadyExists(t *testing.T) {
 		ctx,
 		common.CreateHistoryStartWorkflowRequest(nsID, startReq, nil, nil, time.Now().UTC()),
 	)
-	require.NoError(t, err)
+	s.NoError(err)
 
 	_, err = env.GetTestCluster().HistoryClient().DescribeWorkflowExecution(
 		ctx,
@@ -147,7 +155,7 @@ func TestScheduleMigrationV2AlreadyExists(t *testing.T) {
 			},
 		},
 	)
-	require.NoError(t, err)
+	s.NoError(err)
 
 	// Issue migration. The CHASM handler will return AlreadyStarted,
 	// and the V1 activity treats that as success (logs warning, returns nil).
@@ -160,9 +168,9 @@ func TestScheduleMigrationV2AlreadyExists(t *testing.T) {
 		Identity:   "test",
 		RequestId:  testcore.RandomizeStr("request-id"),
 	})
-	require.NoError(t, err)
+	s.NoError(err)
 
-	require.Eventually(t, func() bool {
+	s.Eventually(func() bool {
 		desc, err := env.GetTestCluster().HistoryClient().DescribeWorkflowExecution(
 			ctx,
 			&historyservice.DescribeWorkflowExecutionRequest{
@@ -187,12 +195,12 @@ func TestScheduleMigrationV2AlreadyExists(t *testing.T) {
 			FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: nsName, ScheduleId: sid},
 		},
 	)
-	require.NoError(t, err)
+	s.NoError(err)
 }
 
-func TestScheduleMigrationDynamicConfig(t *testing.T) {
+func (s *ScheduleMigrationTestSuite) TestScheduleMigrationDynamicConfig() {
 	env := testcore.NewEnv(
-		t,
+		s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerMigration, true),
 	)
@@ -233,7 +241,7 @@ func TestScheduleMigrationDynamicConfig(t *testing.T) {
 		},
 	}
 	inputPayloads, err := sdk.PreferProtoDataConverter.ToPayloads(startArgs)
-	require.NoError(t, err)
+	s.NoError(err)
 	v1WorkflowID := scheduler.WorkflowIDPrefix + sid
 	startReq := &workflowservice.StartWorkflowExecutionRequest{
 		Namespace:                nsName,
@@ -250,10 +258,10 @@ func TestScheduleMigrationDynamicConfig(t *testing.T) {
 		ctx,
 		common.CreateHistoryStartWorkflowRequest(nsID, startReq, nil, nil, time.Now().UTC()),
 	)
-	require.NoError(t, err)
+	s.NoError(err)
 
 	// Wait for the per-namespace worker to pick up the V1 workflow.
-	require.Eventually(t, func() bool {
+	s.Eventually(func() bool {
 		desc, err := env.GetTestCluster().HistoryClient().DescribeWorkflowExecution(
 			ctx,
 			&historyservice.DescribeWorkflowExecutionRequest{
@@ -271,7 +279,7 @@ func TestScheduleMigrationDynamicConfig(t *testing.T) {
 	}, 10*time.Second, 500*time.Millisecond)
 
 	// V1 workflow should automatically migrate due to dynamic config and complete.
-	require.Eventually(t, func() bool {
+	s.Eventually(func() bool {
 		desc, err := env.GetTestCluster().HistoryClient().DescribeWorkflowExecution(
 			ctx,
 			&historyservice.DescribeWorkflowExecutionRequest{
@@ -296,12 +304,12 @@ func TestScheduleMigrationDynamicConfig(t *testing.T) {
 			FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: nsName, ScheduleId: sid},
 		},
 	)
-	require.NoError(t, err)
+	s.NoError(err)
 }
 
-func TestScheduleMigrationV1ToV2(t *testing.T) {
+func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2() {
 	env := testcore.NewEnv(
-		t,
+		s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 	)
 
@@ -341,7 +349,7 @@ func TestScheduleMigrationV1ToV2(t *testing.T) {
 		},
 	}
 	inputPayloads, err := sdk.PreferProtoDataConverter.ToPayloads(startArgs)
-	require.NoError(t, err)
+	s.NoError(err)
 	v1WorkflowID := scheduler.WorkflowIDPrefix + sid
 	startReq := &workflowservice.StartWorkflowExecutionRequest{
 		Namespace:                nsName,
@@ -358,10 +366,10 @@ func TestScheduleMigrationV1ToV2(t *testing.T) {
 		ctx,
 		common.CreateHistoryStartWorkflowRequest(nsID, startReq, nil, nil, time.Now().UTC()),
 	)
-	require.NoError(t, err)
+	s.NoError(err)
 
 	// Wait for the per-namespace worker to pick up the V1 workflow.
-	require.Eventually(t, func() bool {
+	s.Eventually(func() bool {
 		desc, err := env.GetTestCluster().HistoryClient().DescribeWorkflowExecution(
 			ctx,
 			&historyservice.DescribeWorkflowExecutionRequest{
@@ -386,10 +394,10 @@ func TestScheduleMigrationV1ToV2(t *testing.T) {
 		Identity:   "test",
 		RequestId:  testcore.RandomizeStr("request-id"),
 	})
-	require.NoError(t, err)
+	s.NoError(err)
 
 	// Wait for V1 workflow to complete.
-	require.Eventually(t, func() bool {
+	s.Eventually(func() bool {
 		desc, err := env.GetTestCluster().HistoryClient().DescribeWorkflowExecution(
 			ctx,
 			&historyservice.DescribeWorkflowExecutionRequest{
@@ -414,12 +422,12 @@ func TestScheduleMigrationV1ToV2(t *testing.T) {
 			FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: nsName, ScheduleId: sid},
 		},
 	)
-	require.NoError(t, err)
+	s.NoError(err)
 }
 
-func TestScheduleMigrationV2ToV1(t *testing.T) {
+func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1() {
 	env := testcore.NewEnv(
-		t,
+		s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, false),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerRouting, false),
@@ -471,7 +479,7 @@ func TestScheduleMigrationV2ToV1(t *testing.T) {
 			},
 		},
 	)
-	require.NoError(t, err)
+	s.NoError(err)
 
 	// Describe the CHASM schedule before migration to capture its state.
 	v2Desc, err := env.GetTestCluster().SchedulerClient().DescribeSchedule(
@@ -481,7 +489,7 @@ func TestScheduleMigrationV2ToV1(t *testing.T) {
 			FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: nsName, ScheduleId: sid},
 		},
 	)
-	require.NoError(t, err)
+	s.NoError(err)
 	v2Schedule := v2Desc.GetFrontendResponse().GetSchedule()
 	v2ConflictToken := v2Desc.GetFrontendResponse().GetConflictToken()
 
@@ -493,11 +501,11 @@ func TestScheduleMigrationV2ToV1(t *testing.T) {
 		Identity:   "test",
 		RequestId:  testcore.RandomizeStr("request-id"),
 	})
-	require.NoError(t, err)
+	s.NoError(err)
 
 	// Wait for the CHASM scheduler to be closed after migration.
 	var failedPreconditionErr *serviceerror.FailedPrecondition
-	require.Eventually(t, func() bool {
+	s.Eventually(func() bool {
 		_, chasmErr := env.GetTestCluster().SchedulerClient().DescribeSchedule(
 			ctx,
 			&schedulerpb.DescribeScheduleRequest{
@@ -510,7 +518,7 @@ func TestScheduleMigrationV2ToV1(t *testing.T) {
 
 	// Wait for the V1 system scheduler workflow to be running.
 	sysWorkflowID := scheduler.WorkflowIDPrefix + sid
-	require.Eventually(t, func() bool {
+	s.Eventually(func() bool {
 		_, descErr := env.GetTestCluster().HistoryClient().DescribeWorkflowExecution(
 			ctx,
 			&historyservice.DescribeWorkflowExecutionRequest{
@@ -528,7 +536,7 @@ func TestScheduleMigrationV2ToV1(t *testing.T) {
 	// goes directly to the V1 path. The per-namespace worker must pick up
 	// the workflow and register query handlers before this succeeds.
 	var v1Desc *workflowservice.DescribeScheduleResponse
-	require.Eventually(t, func() bool {
+	s.Eventually(func() bool {
 		v1Desc, err = env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
 			Namespace:  nsName,
 			ScheduleId: sid,
@@ -539,8 +547,8 @@ func TestScheduleMigrationV2ToV1(t *testing.T) {
 	v1Schedule := v1Desc.GetSchedule()
 
 	// Validate the schedule spec is preserved across migration.
-	require.Len(t, v1Schedule.GetSpec().GetInterval(), len(v2Schedule.GetSpec().GetInterval()))
-	require.Equal(t,
+	s.Len(v1Schedule.GetSpec().GetInterval(), len(v2Schedule.GetSpec().GetInterval()))
+	s.Equal(
 		v2Schedule.GetSpec().GetInterval()[0].GetInterval().AsDuration(),
 		v1Schedule.GetSpec().GetInterval()[0].GetInterval().AsDuration(),
 	)
@@ -548,49 +556,49 @@ func TestScheduleMigrationV2ToV1(t *testing.T) {
 	// Validate the action is preserved.
 	v2Action := v2Schedule.GetAction().GetStartWorkflow()
 	v1Action := v1Schedule.GetAction().GetStartWorkflow()
-	require.Equal(t, v2Action.GetWorkflowId(), v1Action.GetWorkflowId())
-	require.Equal(t, v2Action.GetWorkflowType().GetName(), v1Action.GetWorkflowType().GetName())
-	require.Equal(t, v2Action.GetTaskQueue().GetName(), v1Action.GetTaskQueue().GetName())
+	s.Equal(v2Action.GetWorkflowId(), v1Action.GetWorkflowId())
+	s.Equal(v2Action.GetWorkflowType().GetName(), v1Action.GetWorkflowType().GetName())
+	s.Equal(v2Action.GetTaskQueue().GetName(), v1Action.GetTaskQueue().GetName())
 
 	// Validate policies are preserved.
-	require.Equal(t,
+	s.Equal(
 		v2Schedule.GetPolicies().GetOverlapPolicy(),
 		v1Schedule.GetPolicies().GetOverlapPolicy(),
 	)
-	require.Equal(t,
+	s.Equal(
 		v2Schedule.GetPolicies().GetCatchupWindow().AsDuration(),
 		v1Schedule.GetPolicies().GetCatchupWindow().AsDuration(),
 	)
 
 	// Validate the paused state is correctly restored (not the migration-imposed pause).
-	require.Equal(t, v2Schedule.GetState().GetPaused(), v1Schedule.GetState().GetPaused())
-	require.Equal(t, v2Schedule.GetState().GetNotes(), v1Schedule.GetState().GetNotes())
+	s.Equal(v2Schedule.GetState().GetPaused(), v1Schedule.GetState().GetPaused())
+	s.Equal(v2Schedule.GetState().GetNotes(), v1Schedule.GetState().GetNotes())
 
 	// Validate the conflict token value is preserved across migration.
 	// V2 (CHASM) serializes as LittleEndian, V1 (workflow) as BigEndian, so decode both to int64.
-	require.Len(t, v2ConflictToken, 8)
+	s.Len(v2ConflictToken, 8)
 	v2Token := int64(binary.LittleEndian.Uint64(v2ConflictToken))
 	v1ConflictToken := v1Desc.GetConflictToken()
-	require.Len(t, v1ConflictToken, 8)
+	s.Len(v1ConflictToken, 8)
 	v1Token := int64(binary.BigEndian.Uint64(v1ConflictToken))
-	require.Equal(t, v2Token, v1Token)
+	s.Equal(v2Token, v1Token)
 
 	// Validate ListSchedules returns exactly one entry once the V1 workflow
 	// has written its visibility records (no duplicates from V1+V2).
 	var listResp *workflowservice.ListSchedulesResponse
-	require.Eventually(t, func() bool {
+	s.Eventually(func() bool {
 		listResp, err = env.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
 			Namespace:       nsName,
 			MaximumPageSize: 10,
 		})
 		return err == nil && len(listResp.GetSchedules()) == 1
 	}, 30*time.Second, 500*time.Millisecond)
-	require.Equal(t, sid, listResp.GetSchedules()[0].GetScheduleId())
+	s.Equal(sid, listResp.GetSchedules()[0].GetScheduleId())
 }
 
-func TestScheduleMigrationV2ToV1Idempotent(t *testing.T) {
+func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1Idempotent() {
 	env := testcore.NewEnv(
-		t,
+		s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, false),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerRouting, false),
@@ -635,7 +643,7 @@ func TestScheduleMigrationV2ToV1Idempotent(t *testing.T) {
 			},
 		},
 	)
-	require.NoError(t, err)
+	s.NoError(err)
 
 	// First migration call.
 	_, err = env.AdminClient().MigrateSchedule(ctx, &adminservice.MigrateScheduleRequest{
@@ -645,7 +653,7 @@ func TestScheduleMigrationV2ToV1Idempotent(t *testing.T) {
 		Identity:   "test",
 		RequestId:  testcore.RandomizeStr("request-id"),
 	})
-	require.NoError(t, err)
+	s.NoError(err)
 
 	// Second migration call should also succeed (idempotent).
 	_, err = env.AdminClient().MigrateSchedule(ctx, &adminservice.MigrateScheduleRequest{
@@ -655,12 +663,12 @@ func TestScheduleMigrationV2ToV1Idempotent(t *testing.T) {
 		Identity:   "test",
 		RequestId:  testcore.RandomizeStr("request-id"),
 	})
-	require.NoError(t, err)
+	s.NoError(err)
 }
 
-func TestCHASMScheduleDescribeAfterDisablingCreationAndMigration(t *testing.T) {
+func (s *ScheduleMigrationTestSuite) TestCHASMScheduleDescribeAfterDisablingCreationAndMigration() {
 	env := testcore.NewEnv(
-		t,
+		s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerMigration, true),
@@ -697,15 +705,15 @@ func TestCHASMScheduleDescribeAfterDisablingCreationAndMigration(t *testing.T) {
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	})
-	require.NoError(t, err)
+	s.NoError(err)
 
 	firstDescribe, err := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
 		Namespace:  nsName,
 		ScheduleId: sid,
 	})
-	require.NoError(t, err)
-	require.NotNil(t, firstDescribe.GetSchedule())
-	require.Eventually(t, func() bool {
+	s.NoError(err)
+	s.NotNil(firstDescribe.GetSchedule())
+	s.Eventually(func() bool {
 		listResp, listErr := env.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{Namespace: nsName})
 		if listErr != nil {
 			return false
@@ -727,12 +735,12 @@ func TestCHASMScheduleDescribeAfterDisablingCreationAndMigration(t *testing.T) {
 			FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: nsName, ScheduleId: sid},
 		},
 	)
-	require.NoError(t, err)
+	s.NoError(err)
 
 	env.OverrideDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, false)
 	env.OverrideDynamicConfig(dynamicconfig.EnableCHASMSchedulerMigration, false)
 
-	require.Eventually(t, func() bool {
+	s.Eventually(func() bool {
 		describeResp, describeErr := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
 			Namespace:  nsName,
 			ScheduleId: sid,
@@ -759,9 +767,9 @@ func TestCHASMScheduleDescribeAfterDisablingCreationAndMigration(t *testing.T) {
 // TestScheduleMigrationV2ToV1RoutingFallback verifies that after migrating a
 // CHASM schedule to V1, frontend operations with CHASM routing enabled fall
 // through to the V1 workflow stack when the CHASM scheduler returns ErrClosed.
-func TestScheduleMigrationV2ToV1RoutingFallback(t *testing.T) {
+func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1RoutingFallback() {
 	env := testcore.NewEnv(
-		t,
+		s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerRouting, true),
@@ -806,7 +814,7 @@ func TestScheduleMigrationV2ToV1RoutingFallback(t *testing.T) {
 			},
 		},
 	)
-	require.NoError(t, err)
+	s.NoError(err)
 
 	// Migrate from V2 (CHASM) to V1 (workflow).
 	_, err = env.AdminClient().MigrateSchedule(ctx, &adminservice.MigrateScheduleRequest{
@@ -816,11 +824,11 @@ func TestScheduleMigrationV2ToV1RoutingFallback(t *testing.T) {
 		Identity:   "test",
 		RequestId:  testcore.RandomizeStr("request-id"),
 	})
-	require.NoError(t, err)
+	s.NoError(err)
 
 	// Wait for the CHASM scheduler to be closed after migration.
 	var failedPreconditionErr *serviceerror.FailedPrecondition
-	require.Eventually(t, func() bool {
+	s.Eventually(func() bool {
 		_, chasmErr := env.GetTestCluster().SchedulerClient().DescribeSchedule(
 			ctx,
 			&schedulerpb.DescribeScheduleRequest{
@@ -832,7 +840,7 @@ func TestScheduleMigrationV2ToV1RoutingFallback(t *testing.T) {
 	}, 10*time.Second, 500*time.Millisecond)
 
 	// Wait for the V1 workflow to be running and query handlers registered.
-	require.Eventually(t, func() bool {
+	s.Eventually(func() bool {
 		_, descErr := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
 			Namespace:  nsName,
 			ScheduleId: sid,
@@ -846,12 +854,12 @@ func TestScheduleMigrationV2ToV1RoutingFallback(t *testing.T) {
 		Namespace:  nsName,
 		ScheduleId: sid,
 	})
-	require.NoError(t, err)
-	require.NotNil(t, descResp.GetSchedule())
-	require.Equal(t, wt, descResp.GetSchedule().GetAction().GetStartWorkflow().GetWorkflowType().GetName())
+	s.NoError(err)
+	s.NotNil(descResp.GetSchedule())
+	s.Equal(wt, descResp.GetSchedule().GetAction().GetStartWorkflow().GetWorkflowType().GetName())
 	// The schedule was created unpaused; migration should preserve that state
 	// (not the temporary migration-imposed pause).
-	require.False(t, descResp.GetSchedule().GetState().GetPaused())
+	s.False(descResp.GetSchedule().GetState().GetPaused())
 
 	// ListScheduleMatchingTimes should also fall through to V1.
 	now := time.Now().UTC()
@@ -861,8 +869,8 @@ func TestScheduleMigrationV2ToV1RoutingFallback(t *testing.T) {
 		StartTime:  timestamppb.New(now),
 		EndTime:    timestamppb.New(now.Add(5 * time.Hour)),
 	})
-	require.NoError(t, err)
-	require.NotEmpty(t, matchResp.GetStartTime())
+	s.NoError(err)
+	s.NotEmpty(matchResp.GetStartTime())
 
 	// PatchSchedule (pause) should also fall through to V1.
 	_, err = env.FrontendClient().PatchSchedule(ctx, &workflowservice.PatchScheduleRequest{
@@ -873,11 +881,11 @@ func TestScheduleMigrationV2ToV1RoutingFallback(t *testing.T) {
 		},
 		Identity: "test",
 	})
-	require.NoError(t, err)
+	s.NoError(err)
 
 	// Verify the pause took effect on V1. The patch is delivered as a signal,
 	// so the workflow needs time to process it.
-	require.Eventually(t, func() bool {
+	s.Eventually(func() bool {
 		descResp, err = env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
 			Namespace:  nsName,
 			ScheduleId: sid,
@@ -891,12 +899,12 @@ func TestScheduleMigrationV2ToV1RoutingFallback(t *testing.T) {
 		ScheduleId: sid,
 		Identity:   "test",
 	})
-	require.NoError(t, err)
+	s.NoError(err)
 }
 
-func TestScheduleUpdateAfterDelete(t *testing.T) {
+func (s *ScheduleMigrationTestSuite) TestScheduleUpdateAfterDelete() {
 	env := testcore.NewEnv(
-		t,
+		s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerRouting, true),
@@ -942,7 +950,7 @@ func TestScheduleUpdateAfterDelete(t *testing.T) {
 			},
 		},
 	)
-	require.NoError(t, err)
+	s.NoError(err)
 
 	// Delete via scheduler client.
 	_, err = env.GetTestCluster().SchedulerClient().DeleteSchedule(
@@ -956,7 +964,7 @@ func TestScheduleUpdateAfterDelete(t *testing.T) {
 			},
 		},
 	)
-	require.NoError(t, err)
+	s.NoError(err)
 
 	// Update via scheduler client should fail on the closed schedule.
 	_, err = env.GetTestCluster().SchedulerClient().UpdateSchedule(
@@ -972,7 +980,7 @@ func TestScheduleUpdateAfterDelete(t *testing.T) {
 		},
 	)
 	var failedPreconditionErr *serviceerror.FailedPrecondition
-	require.ErrorAs(t, err, &failedPreconditionErr)
+	s.ErrorAs(err, &failedPreconditionErr)
 
 	// Patch via scheduler client should also fail on the closed schedule.
 	_, err = env.GetTestCluster().SchedulerClient().PatchSchedule(
@@ -987,7 +995,7 @@ func TestScheduleUpdateAfterDelete(t *testing.T) {
 			},
 		},
 	)
-	require.ErrorAs(t, err, &failedPreconditionErr)
+	s.ErrorAs(err, &failedPreconditionErr)
 
 	// Delete again is idempotent in CHASM — sets Closed=true again.
 	_, err = env.GetTestCluster().SchedulerClient().DeleteSchedule(
@@ -1001,12 +1009,12 @@ func TestScheduleUpdateAfterDelete(t *testing.T) {
 			},
 		},
 	)
-	require.NoError(t, err)
+	s.NoError(err)
 }
 
-func TestScheduleMigrationV1ToV2WithClosedV2(t *testing.T) {
+func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2WithClosedV2() {
 	env := testcore.NewEnv(
-		t,
+		s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 	)
 
@@ -1049,7 +1057,7 @@ func TestScheduleMigrationV1ToV2WithClosedV2(t *testing.T) {
 			},
 		},
 	)
-	require.NoError(t, err)
+	s.NoError(err)
 
 	_, err = env.GetTestCluster().SchedulerClient().DeleteSchedule(
 		ctx,
@@ -1062,7 +1070,7 @@ func TestScheduleMigrationV1ToV2WithClosedV2(t *testing.T) {
 			},
 		},
 	)
-	require.NoError(t, err)
+	s.NoError(err)
 
 	// Create a V1 (workflow-backed) scheduler with the same ID.
 	startArgs := &schedulespb.StartScheduleArgs{
@@ -1075,7 +1083,7 @@ func TestScheduleMigrationV1ToV2WithClosedV2(t *testing.T) {
 		},
 	}
 	inputPayloads, err := sdk.PreferProtoDataConverter.ToPayloads(startArgs)
-	require.NoError(t, err)
+	s.NoError(err)
 	v1WorkflowID := scheduler.WorkflowIDPrefix + sid
 	startReq := &workflowservice.StartWorkflowExecutionRequest{
 		Namespace:                nsName,
@@ -1092,10 +1100,10 @@ func TestScheduleMigrationV1ToV2WithClosedV2(t *testing.T) {
 		ctx,
 		common.CreateHistoryStartWorkflowRequest(nsID, startReq, nil, nil, time.Now().UTC()),
 	)
-	require.NoError(t, err)
+	s.NoError(err)
 
 	// Wait for the per-namespace worker to pick up the V1 workflow.
-	require.Eventually(t, func() bool {
+	s.Eventually(func() bool {
 		desc, err := env.GetTestCluster().HistoryClient().DescribeWorkflowExecution(
 			ctx,
 			&historyservice.DescribeWorkflowExecutionRequest{
@@ -1122,10 +1130,10 @@ func TestScheduleMigrationV1ToV2WithClosedV2(t *testing.T) {
 		Identity:   "test",
 		RequestId:  testcore.RandomizeStr("request-id"),
 	})
-	require.NoError(t, err)
+	s.NoError(err)
 
 	// Wait for the V1 workflow to complete (migration activity ran).
-	require.Eventually(t, func() bool {
+	s.Eventually(func() bool {
 		desc, err := env.GetTestCluster().HistoryClient().DescribeWorkflowExecution(
 			ctx,
 			&historyservice.DescribeWorkflowExecutionRequest{
@@ -1150,5 +1158,5 @@ func TestScheduleMigrationV1ToV2WithClosedV2(t *testing.T) {
 			FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: nsName, ScheduleId: sid},
 		},
 	)
-	require.NoError(t, err)
+	s.NoError(err)
 }

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -40,6 +40,7 @@ var (
 )
 
 type Env interface {
+	// T returns the *testing.T. Deprecated: use the suite's T() method instead.
 	T() *testing.T
 	Namespace() namespace.Name
 	NamespaceID() namespace.ID
@@ -225,6 +226,7 @@ func (e *TestEnv) TaskPoller() *taskpoller.TaskPoller {
 	return e.taskPoller
 }
 
+// T returns the *testing.T. Deprecated: use the suite's T() method instead.
 func (e *TestEnv) T() *testing.T {
 	return e.t
 }


### PR DESCRIPTION
## What changed?

Changing `s`s to `env`s.

ie migrates some of the tests that were already using testEnv but not yet parallelsuites.

**Tip: Use "Hide Whitespace" for review**

## Why?

Progress is inevitable.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

