### PR TITLE
fix: validate namespace ID in MigrateScheduleToChasm

### DIFF
--- a/service/worker/scheduler/activities.go
+++ b/service/worker/scheduler/activities.go
@@ -375,6 +375,13 @@ func (r responseBuilder) makeResponse(result *commonpb.Payloads, failure *failur
 }
 
 func (a *activities) MigrateScheduleToChasm(ctx context.Context, req *schedulerpb.CreateFromMigrationStateRequest) error {
+	if req.GetNamespaceId() != a.namespaceID.String() {
+		return temporal.NewNonRetryableApplicationError(
+			fmt.Sprintf("MigrateScheduleToChasm: request namespace ID %q does not match activity namespace ID %q", req.GetNamespaceId(), a.namespaceID),
+			"namespace_mismatch",
+			nil,
+		)
+	}
 	_, err := a.SchedulerClient.CreateFromMigrationState(ctx, req)
 	if err != nil {
 		// Treat "already exists" as success (idempotency).

--- a/service/worker/scheduler/activities_test.go
+++ b/service/worker/scheduler/activities_test.go
@@ -10,6 +10,7 @@ import (
 	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
 	"google.golang.org/grpc"
 )
 
@@ -26,21 +27,26 @@ func (m *mockSchedulerClient) CreateFromMigrationState(
 	return &schedulerpb.CreateFromMigrationStateResponse{}, m.migrateErr
 }
 
-func newTestActivities(client schedulerpb.SchedulerServiceClient) *activities {
+func newTestActivities(client schedulerpb.SchedulerServiceClient, nsID namespace.ID) *activities {
 	return &activities{
 		activityDeps: activityDeps{
 			Logger:          log.NewNoopLogger(),
 			SchedulerClient: client,
 			MetricsHandler:  metrics.NoopMetricsHandler,
 		},
+		namespaceID: nsID,
 	}
 }
 
+const testNamespaceID = "test-namespace-id"
+
 func TestMigrateScheduleToChasm_Success(t *testing.T) {
 	client := &mockSchedulerClient{}
-	a := newTestActivities(client)
+	a := newTestActivities(client, testNamespaceID)
 
-	err := a.MigrateScheduleToChasm(context.Background(), &schedulerpb.CreateFromMigrationStateRequest{})
+	err := a.MigrateScheduleToChasm(context.Background(), &schedulerpb.CreateFromMigrationStateRequest{
+		NamespaceId: testNamespaceID,
+	})
 	require.NoError(t, err)
 }
 
@@ -48,9 +54,11 @@ func TestMigrateScheduleToChasm_AlreadyExists(t *testing.T) {
 	client := &mockSchedulerClient{
 		migrateErr: serviceerror.NewAlreadyExistsf("schedule %q is already registered", "test-schedule"),
 	}
-	a := newTestActivities(client)
+	a := newTestActivities(client, testNamespaceID)
 
-	err := a.MigrateScheduleToChasm(context.Background(), &schedulerpb.CreateFromMigrationStateRequest{})
+	err := a.MigrateScheduleToChasm(context.Background(), &schedulerpb.CreateFromMigrationStateRequest{
+		NamespaceId: testNamespaceID,
+	})
 	require.NoError(t, err, "already-exists should be treated as success")
 }
 
@@ -58,9 +66,11 @@ func TestMigrateScheduleToChasm_SentinelBlocked(t *testing.T) {
 	client := &mockSchedulerClient{
 		migrateErr: serviceerror.NewUnavailable("schedule is a sentinel; please retry after sentinel expires"),
 	}
-	a := newTestActivities(client)
+	a := newTestActivities(client, testNamespaceID)
 
-	err := a.MigrateScheduleToChasm(context.Background(), &schedulerpb.CreateFromMigrationStateRequest{})
+	err := a.MigrateScheduleToChasm(context.Background(), &schedulerpb.CreateFromMigrationStateRequest{
+		NamespaceId: testNamespaceID,
+	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "blocked by sentinel")
 }
@@ -69,9 +79,24 @@ func TestMigrateScheduleToChasm_OtherError(t *testing.T) {
 	client := &mockSchedulerClient{
 		migrateErr: errors.New("some transient error"),
 	}
-	a := newTestActivities(client)
+	a := newTestActivities(client, testNamespaceID)
 
-	err := a.MigrateScheduleToChasm(context.Background(), &schedulerpb.CreateFromMigrationStateRequest{})
+	err := a.MigrateScheduleToChasm(context.Background(), &schedulerpb.CreateFromMigrationStateRequest{
+		NamespaceId: testNamespaceID,
+	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "MigrateScheduleToChasm")
+}
+
+func TestMigrateScheduleToChasm_NamespaceMismatch(t *testing.T) {
+	client := &mockSchedulerClient{}
+	a := newTestActivities(client, testNamespaceID)
+
+	err := a.MigrateScheduleToChasm(context.Background(), &schedulerpb.CreateFromMigrationStateRequest{
+		NamespaceId: "different-namespace-id",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "namespace_mismatch")
+	require.Contains(t, err.Error(), "different-namespace-id")
+	require.Contains(t, err.Error(), testNamespaceID)
 }


### PR DESCRIPTION

## Why?
Security
Check namespaces in scheduler workflow [CVE-2026-5199](https://www.cve.org/cverecord?id=CVE-2026-5199)
