### PR TITLE
Use original context for non-blocking path in DescribeActivityExecution

### DIFF
--- a/chasm/lib/activity/handler.go
+++ b/chasm/lib/activity/handler.go
@@ -119,6 +119,11 @@ func (h *handler) DescribeActivityExecution(
 		RunID:       req.GetFrontendRequest().GetRunId(),
 	})
 
+	token := req.GetFrontendRequest().GetLongPollToken()
+	if len(token) == 0 {
+		return chasm.ReadComponent(ctx, ref, (*Activity).buildDescribeActivityExecutionResponse, req)
+	}
+
 	// Below, we send an empty non-error response on context deadline expiry. Here we compute a
 	// deadline that causes us to send that response before the caller's own deadline (see
 	// chasm.activity.longPollBuffer). We also cap the caller's deadline at
@@ -131,10 +136,6 @@ func (h *handler) DescribeActivityExecution(
 	)
 	defer cancel()
 
-	token := req.GetFrontendRequest().GetLongPollToken()
-	if len(token) == 0 {
-		return chasm.ReadComponent(ctx, ref, (*Activity).buildDescribeActivityExecutionResponse, req)
-	}
 	response, _, err = chasm.PollComponent(ctx, ref, func(
 		a *Activity,
 		ctx chasm.Context,


### PR DESCRIPTION
## What changed?
Reorder code so that the non-blocking `ReadComponent` call uses the original context, and context with the altered deadline is used for the long-poll only 

## Why?
It looks like it was a mistake; the code state after this commit appears to be what was originally intended.

## How did you test it?
- [x] covered by existing tests

## Potential risks
Could break describe for standalone activity if this change was misconceived.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small control-flow reorder that only changes which context is used for the non-long-poll path, without altering long-poll semantics or data handling.
> 
> **Overview**
> Updates `DescribeActivityExecution` to **short-circuit before applying `WithDeadlineBuffer`** when no `LongPollToken` is provided, so the non-blocking `ReadComponent` path uses the caller’s original context.
> 
> Long-poll requests continue to use the deadline-buffered context and existing error/timeout behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff7e89892185d9b7af785bb73a0044db8289831a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->