### PR TITLE
Handle duplicate err in apply snapshot

### DIFF
--- a/service/history/ndc/transaction_manager_new_workflow.go
+++ b/service/history/ndc/transaction_manager_new_workflow.go
@@ -71,7 +71,6 @@ func (r *nDCTransactionMgrForNewWorkflowImpl) dispatchForNewWorkflow(
 		return err
 	}
 	if currentRunID == targetRunID {
-		// Need to reload the mutable state to verify the duplication
 		return consts.ErrDuplicate
 	}
 

--- a/service/history/ndc/transaction_manager_new_workflow.go
+++ b/service/history/ndc/transaction_manager_new_workflow.go
@@ -71,6 +71,7 @@ func (r *nDCTransactionMgrForNewWorkflowImpl) dispatchForNewWorkflow(
 		return err
 	}
 	if currentRunID == targetRunID {
+		// Need to reload the mutable state to verify the duplication
 		return consts.ErrDuplicate
 	}
 

--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -807,7 +807,11 @@ func (r *WorkflowStateReplicatorImpl) applySnapshot(
 			true,
 			versionedTransition.IsCloseTransferTaskAcked && versionedTransition.IsForceReplication,
 		)
-		if errors.Is(err, consts.ErrDuplicate) {
+		if err != nil {
+			if !errors.Is(err, consts.ErrDuplicate) {
+				return err
+			}
+			// Handle duplicate error
 			ms, msErr := wfCtx.LoadMutableState(ctx, r.shardContext)
 			switch msErr.(type) {
 			case *serviceerror.NotFound:
@@ -817,12 +821,16 @@ func (r *WorkflowStateReplicatorImpl) applySnapshot(
 				// and this mutable state may update after acquire the workflow lock.
 				// Retry to apply snapshot with mutable state
 				localMutableState = ms
+				r.logger.Warn("duplicate error applying snapshot for new workflow; mutable state already exists, retrying with existing state",
+					tag.WorkflowNamespaceID(namespaceID.String()),
+					tag.WorkflowID(workflowID),
+					tag.WorkflowRunID(runID),
+					tag.ArchetypeID(archetypeID),
+					tag.Error(err),
+				)
 			default:
 				return err
 			}
-		}
-		if err != nil {
-			return err
 		}
 	}
 	return r.applySnapshotWhenWorkflowExist(

--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -793,7 +793,7 @@ func (r *WorkflowStateReplicatorImpl) applySnapshot(
 	}
 	snapshot := attribute.State
 	if localMutableState == nil {
-		return r.applySnapshotWhenWorkflowNotExist(
+		err := r.applySnapshotWhenWorkflowNotExist(
 			ctx,
 			namespaceID,
 			workflowID,
@@ -807,6 +807,23 @@ func (r *WorkflowStateReplicatorImpl) applySnapshot(
 			true,
 			versionedTransition.IsCloseTransferTaskAcked && versionedTransition.IsForceReplication,
 		)
+		if errors.Is(err, consts.ErrDuplicate) {
+			ms, msErr := wfCtx.LoadMutableState(ctx, r.shardContext)
+			switch msErr.(type) {
+			case *serviceerror.NotFound:
+				return err
+			case nil:
+				// The previous run may replicate the first batch of workflow
+				// and this mutable state may update after acquire the workflow lock.
+				// Retry to apply snapshot with mutable state
+				localMutableState = ms
+			default:
+				return err
+			}
+		}
+		if err != nil {
+			return err
+		}
 	}
 	return r.applySnapshotWhenWorkflowExist(
 		ctx,

--- a/service/history/replication/raw_task_converter.go
+++ b/service/history/replication/raw_task_converter.go
@@ -685,7 +685,7 @@ func (c *syncVersionedTransitionTaskConverter) convert(
 
 	progress := c.replicationCache.Get(taskInfo.RunID, targetClusterID)
 
-	if progress.VersionedTransitionSent(taskInfo.VersionedTransition) {
+	if progress != nil && progress.VersionedTransitionSent(taskInfo.VersionedTransition) {
 		return c.generateVerifyVersionedTransitionTask(taskInfo, mutableState)
 	}
 

--- a/service/history/replication/sequential_queue.go
+++ b/service/history/replication/sequential_queue.go
@@ -18,16 +18,6 @@ type (
 	}
 )
 
-func NewSequentialTaskQueue(task TrackableExecutableTask) ctasks.SequentialTaskQueue[TrackableExecutableTask] {
-	return &SequentialTaskQueue{
-		id: task.QueueID(),
-
-		taskQueue: collection.NewPriorityQueue[TrackableExecutableTask](
-			SequentialTaskQueueCompareLess,
-		),
-	}
-}
-
 func NewSequentialTaskQueueWithID(id any) ctasks.SequentialTaskQueue[TrackableExecutableTask] {
 	return &SequentialTaskQueue{
 		id: id,


### PR DESCRIPTION
## What changed?
Handle duplicate err in apply snapshot

## Why?
We cannot simply return duplication if the mutable state is null. We need to reload the mutable state and retry it. 

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Minor risk. This will retry one more to reload the mutable state.
