### PR TITLE
Set RoutingConfigUpdateState to IN_PROGRESS on TQ registration

### DIFF
--- a/api/deployment/v1/message.pb.go
+++ b/api/deployment/v1/message.pb.go
@@ -669,8 +669,12 @@ type WorkerDeploymentLocalState struct {
 	PropagatingRevisions map[string]*PropagatingRevisions `protobuf:"bytes,8,rep,name=propagating_revisions,json=propagatingRevisions,proto3" json:"propagating_revisions,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// Request ID used to create this worker deployment.
 	CreateRequestId string `protobuf:"bytes,9,opt,name=create_request_id,json=createRequestId,proto3" json:"create_request_id,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// Tracks the number of in-flight task queue registration propagations for versions
+	// that are current or ramping. Used with propagating_revisions to derive
+	// RoutingConfigUpdateState.
+	PendingTqRegistrationPropagations int32 `protobuf:"varint,10,opt,name=pending_tq_registration_propagations,json=pendingTqRegistrationPropagations,proto3" json:"pending_tq_registration_propagations,omitempty"`
+	unknownFields                     protoimpl.UnknownFields
+	sizeCache                         protoimpl.SizeCache
 }
 
 func (x *WorkerDeploymentLocalState) Reset() {
@@ -764,6 +768,13 @@ func (x *WorkerDeploymentLocalState) GetCreateRequestId() string {
 		return x.CreateRequestId
 	}
 	return ""
+}
+
+func (x *WorkerDeploymentLocalState) GetPendingTqRegistrationPropagations() int32 {
+	if x != nil {
+		return x.PendingTqRegistrationPropagations
+	}
+	return 0
 }
 
 // Tracks revision numbers that are currently propagating for a specific build ID
@@ -4053,7 +4064,7 @@ const file_temporal_server_api_deployment_v1_message_proto_rawDesc = "" +
 	"\x0enamespace_name\x18\x01 \x01(\tR\rnamespaceName\x12!\n" +
 	"\fnamespace_id\x18\x02 \x01(\tR\vnamespaceId\x12'\n" +
 	"\x0fdeployment_name\x18\x03 \x01(\tR\x0edeploymentName\x12S\n" +
-	"\x05state\x18\x04 \x01(\v2=.temporal.server.api.deployment.v1.WorkerDeploymentLocalStateR\x05state\"\x82\a\n" +
+	"\x05state\x18\x04 \x01(\v2=.temporal.server.api.deployment.v1.WorkerDeploymentLocalStateR\x05state\"\xd3\a\n" +
 	"\x1aWorkerDeploymentLocalState\x12;\n" +
 	"\vcreate_time\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
 	"createTime\x12P\n" +
@@ -4064,7 +4075,9 @@ const file_temporal_server_api_deployment_v1_message_proto_rawDesc = "" +
 	"\x0fsync_batch_size\x18\x06 \x01(\x05R\rsyncBatchSize\x12)\n" +
 	"\x10manager_identity\x18\a \x01(\tR\x0fmanagerIdentity\x12\x8c\x01\n" +
 	"\x15propagating_revisions\x18\b \x03(\v2W.temporal.server.api.deployment.v1.WorkerDeploymentLocalState.PropagatingRevisionsEntryR\x14propagatingRevisions\x12*\n" +
-	"\x11create_request_id\x18\t \x01(\tR\x0fcreateRequestId\x1a~\n" +
+	"\x11create_request_id\x18\t \x01(\tR\x0fcreateRequestId\x12O\n" +
+	"$pending_tq_registration_propagations\x18\n" +
+	" \x01(\x05R!pendingTqRegistrationPropagations\x1a~\n" +
 	"\rVersionsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12W\n" +
 	"\x05value\x18\x02 \x01(\v2A.temporal.server.api.deployment.v1.WorkerDeploymentVersionSummaryR\x05value:\x028\x01\x1a\x80\x01\n" +

--- a/proto/internal/temporal/server/api/deployment/v1/message.proto
+++ b/proto/internal/temporal/server/api/deployment/v1/message.proto
@@ -183,6 +183,10 @@ message WorkerDeploymentLocalState {
   map<string, PropagatingRevisions> propagating_revisions = 8;
   // Request ID used to create this worker deployment.
   string create_request_id = 9;
+  // Tracks the number of in-flight task queue registration propagations for versions
+  // that are current or ramping. Used with propagating_revisions to derive
+  // RoutingConfigUpdateState.
+  int32 pending_tq_registration_propagations = 10;
 }
 
 // Tracks revision numbers that are currently propagating for a specific build ID

--- a/service/worker/workerdeployment/client.go
+++ b/service/worker/workerdeployment/client.go
@@ -1749,7 +1749,7 @@ func (d *ClientImpl) deploymentStateToDeploymentInfo(deploymentName string, stat
 	workerDeploymentInfo.RoutingConfig = state.RoutingConfig
 	workerDeploymentInfo.LastModifierIdentity = state.LastModifierIdentity
 	workerDeploymentInfo.ManagerIdentity = state.ManagerIdentity
-	if len(state.PropagatingRevisions) > 0 {
+	if len(state.PropagatingRevisions) > 0 || state.PendingTqRegistrationPropagations > 0 {
 		workerDeploymentInfo.RoutingConfigUpdateState = enumspb.ROUTING_CONFIG_UPDATE_STATE_IN_PROGRESS
 	} else {
 		workerDeploymentInfo.RoutingConfigUpdateState = enumspb.ROUTING_CONFIG_UPDATE_STATE_COMPLETED

--- a/service/worker/workerdeployment/fx.go
+++ b/service/worker/workerdeployment/fx.go
@@ -31,6 +31,8 @@ const (
 	AsyncSetCurrentAndRamping
 	// Version Data has its own revision number with TaskQueue registration being async as well
 	VersionDataRevisionNumber
+	// TQ registration propagation is tracked in deployment workflow state
+	TqRegistrationPropagationTracking
 )
 
 type (

--- a/service/worker/workerdeployment/util.go
+++ b/service/worker/workerdeployment/util.go
@@ -62,7 +62,8 @@ const (
 	SyncDrainageSignalName      = "sync-drainage-status"
 	TerminateDrainageSignal     = "terminate-drainage"
 	SyncVersionSummarySignal    = "sync-version-summary"
-	PropagationCompleteSignal   = "propagation-complete"
+	PropagationCompleteSignal               = "propagation-complete"
+	TqRegistrationPropagationCompleteSignal = "tq-registration-propagation-complete"
 	ReactivateVersionSignalName = "reactivate-version" // for Worker Deployment Version wfs
 
 	// Queries
@@ -135,6 +136,16 @@ var (
 		},
 	}
 )
+
+// isVersionCurrentOrRamping checks if a version (identified by buildId and deploymentName)
+// is the current or ramping version in the given routing config.
+func isVersionCurrentOrRamping(rg *deploymentpb.RoutingConfig, buildId, deploymentName string) bool {
+	isCurrent := rg.GetCurrentDeploymentVersion().GetBuildId() == buildId &&
+		rg.GetCurrentDeploymentVersion().GetDeploymentName() == deploymentName
+	isRamping := rg.GetRampingDeploymentVersion().GetBuildId() == buildId &&
+		rg.GetRampingDeploymentVersion().GetDeploymentName() == deploymentName
+	return isCurrent || isRamping
+}
 
 // validateVersionWfParams is a helper that verifies if the fields used for generating
 // Worker Deployment Version related workflowID's are valid

--- a/service/worker/workerdeployment/version_workflow.go
+++ b/service/worker/workerdeployment/version_workflow.go
@@ -703,7 +703,12 @@ func (d *VersionWorkflowRunner) handleRegisterWorker(ctx workflow.Context, args 
 	}
 
 	if _, ok := d.VersionState.TaskQueueFamilies[args.TaskQueueName].TaskQueues[int32(args.TaskQueueType)]; ok {
-		// already registered, returning success so it is idempotent
+		// already registered, returning success so it is idempotent.
+		// Signal the deployment workflow to decrement its counter if it was tracking this registration.
+		if args.GetRoutingConfig() != nil && d.hasMinVersion(TqRegistrationPropagationTracking) &&
+			isVersionCurrentOrRamping(args.GetRoutingConfig(), d.VersionState.GetVersion().GetBuildId(), d.VersionState.GetVersion().GetDeploymentName()) {
+			d.signalTqRegistrationPropagationComplete(ctx)
+		}
 		return nil
 	}
 
@@ -1419,11 +1424,8 @@ func (d *VersionWorkflowRunner) hasMinVersion(version DeploymentWorkflowVersion)
 
 // syncRegisteredTaskQueueAsync syncs the routing config and version data to the new task queue.
 // This method does not increment version data revision number.
-// Note: task queue registration does not affect WorkerDeploymentInfo.RoutingConfigUpdateState hence we do not signal
-// the deployment workflow about propagation completion.
-// TODO: Set RoutingConfigUpdateState to IN_PROGRESS when the version is already ramping or current? It's OK to do it
-// later because it's not possible normally and user has to pass IgnoreMissingTaskQueues or AllowNoPollers for it to
-// happen, or the task queue needs to be a task queue that is added in this version.
+// If the version is current or ramping, it signals the deployment workflow upon completion so that
+// RoutingConfigUpdateState transitions back to COMPLETED.
 func (d *VersionWorkflowRunner) syncRegisteredTaskQueueAsync(ctx workflow.Context, args *deploymentspb.RegisterWorkerInVersionArgs) {
 	startTime := workflow.Now(ctx)
 
@@ -1437,6 +1439,10 @@ func (d *VersionWorkflowRunner) syncRegisteredTaskQueueAsync(ctx workflow.Contex
 		{Name: args.GetTaskQueueName(), Types: []enumspb.TaskQueueType{args.GetTaskQueueType()}},
 	}
 
+	// Determine if we need to signal the deployment workflow about propagation completion.
+	shouldSignalDeployment := args.GetRoutingConfig() != nil && d.hasMinVersion(TqRegistrationPropagationTracking) &&
+		isVersionCurrentOrRamping(args.GetRoutingConfig(), d.VersionState.GetVersion().GetBuildId(), d.VersionState.GetVersion().GetDeploymentName())
+
 	// This must be done in the main goroutine otherwise the wf may CaN before getting to it.
 	d.asyncPropagationsInProgress++
 
@@ -1446,8 +1452,30 @@ func (d *VersionWorkflowRunner) syncRegisteredTaskQueueAsync(ctx workflow.Contex
 		// the task queue partition initiating the registration itself is responsible to block until it sees the version in user data.
 		d.executePropagationBatch(gCtx, batch, args.GetRoutingConfig(), versionData)
 
+		// Signal deployment workflow that TQ registration propagation completed, so that
+		// RoutingConfigUpdateState can transition back to COMPLETED.
+		if shouldSignalDeployment {
+			d.signalTqRegistrationPropagationComplete(gCtx)
+		}
+
 		d.metrics.Timer(metrics.VersioningDataPropagationLatency.Name()).Record(workflow.Now(ctx).Sub(startTime))
 		// Decrement counter when propagation completes
 		d.asyncPropagationsInProgress--
 	})
+}
+
+// signalTqRegistrationPropagationComplete sends a signal to the deployment workflow when a
+// task queue registration propagation has completed for a current or ramping version.
+func (d *VersionWorkflowRunner) signalTqRegistrationPropagationComplete(ctx workflow.Context) {
+	err := workflow.SignalExternalWorkflow(
+		ctx,
+		GenerateDeploymentWorkflowID(d.VersionState.Version.DeploymentName),
+		"",
+		TqRegistrationPropagationCompleteSignal,
+		nil,
+	).Get(ctx, nil)
+
+	if err != nil {
+		d.logger.Error("could not signal TQ registration propagation completion", "error", err)
+	}
 }

--- a/service/worker/workerdeployment/version_workflow_test.go
+++ b/service/worker/workerdeployment/version_workflow_test.go
@@ -35,7 +35,7 @@ type VersionWorkflowSuite struct {
 
 func TestVersionWorkflowSuite(t *testing.T) {
 	t.Parallel()
-	suite.Run(t, &VersionWorkflowSuite{workflowVersion: VersionDataRevisionNumber})
+	suite.Run(t, &VersionWorkflowSuite{workflowVersion: TqRegistrationPropagationTracking})
 }
 
 func (s *VersionWorkflowSuite) SetupTest() {
@@ -1540,7 +1540,8 @@ func (s *VersionWorkflowSuite) Test_SyncState_SignalsPropagationComplete_WithCor
 }
 
 // Test_RegisterWorker_DoesNotSignalPropagationComplete tests that worker registration
-// doesn't signal the deployment workflow about propagation completion
+// doesn't signal the deployment workflow about propagation completion via PropagationCompleteSignal.
+// It does, however, signal via TqRegistrationPropagationCompleteSignal when the version is current or ramping.
 func (s *VersionWorkflowSuite) Test_RegisterWorker_DoesNotSignalPropagationComplete() {
 	tv := testvars.New(s.T())
 	now := timestamppb.New(time.Now())
@@ -1560,8 +1561,12 @@ func (s *VersionWorkflowSuite) Test_RegisterWorker_DoesNotSignalPropagationCompl
 	s.env.OnActivity(a.CheckWorkerDeploymentUserDataPropagation, mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	s.env.OnSignalExternalWorkflow(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-		s.Fail("Should not signal propagation complete for worker registration")
-	}).Maybe()
+		signalName := args.Get(3).(string)
+		if signalName == PropagationCompleteSignal {
+			s.Fail("Should not signal PropagationCompleteSignal for worker registration")
+		}
+		// TqRegistrationPropagationCompleteSignal is expected when version is current
+	}).Return(nil).Maybe()
 
 	s.env.RegisterDelayedCallback(func() {
 		routingConfig := &deploymentpb.RoutingConfig{
@@ -1605,6 +1610,85 @@ func (s *VersionWorkflowSuite) Test_RegisterWorker_DoesNotSignalPropagationCompl
 	})
 
 	s.True(s.env.IsWorkflowCompleted())
+}
+
+// Test_RegisterWorker_SignalsTqRegistrationPropagationComplete tests that worker registration
+// in a current version signals TqRegistrationPropagationCompleteSignal to the deployment workflow.
+func (s *VersionWorkflowSuite) Test_RegisterWorker_SignalsTqRegistrationPropagationComplete() {
+	s.skipBeforeVersion(TqRegistrationPropagationTracking)
+
+	tv := testvars.New(s.T())
+
+	var a *VersionActivities
+	s.env.RegisterActivity(a.StartWorkerDeploymentWorkflow)
+	s.env.OnActivity(a.StartWorkerDeploymentWorkflow, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	newTaskQueueName := tv.TaskQueue().Name + "_new"
+
+	s.env.OnActivity(a.SyncDeploymentVersionUserData, mock.Anything, mock.Anything).Return(
+		&deploymentspb.SyncDeploymentVersionUserDataResponse{
+			TaskQueueMaxVersions: map[string]int64{newTaskQueueName: 1},
+		}, nil,
+	).Maybe()
+
+	s.env.OnActivity(a.CheckWorkerDeploymentUserDataPropagation, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	signalSent := false
+	s.env.OnSignalExternalWorkflow(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		signalName := args.Get(3).(string)
+		s.Equal(TqRegistrationPropagationCompleteSignal, signalName,
+			"should signal TqRegistrationPropagationCompleteSignal, not PropagationCompleteSignal")
+		signalSent = true
+	}).Return(nil).Maybe()
+
+	s.env.RegisterDelayedCallback(func() {
+		routingConfig := &deploymentpb.RoutingConfig{
+			//nolint:staticcheck // SA1019: worker versioning v0.31
+			CurrentVersion:            tv.DeploymentVersionString(),
+			CurrentVersionChangedTime: timestamppb.Now(),
+			RevisionNumber:            5,
+			CurrentDeploymentVersion: &deploymentpb.WorkerDeploymentVersion{
+				DeploymentName: tv.DeploymentSeries(),
+				BuildId:        tv.BuildID(),
+			},
+		}
+
+		registerArgs := &deploymentspb.RegisterWorkerInVersionArgs{
+			TaskQueueName: newTaskQueueName,
+			TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW,
+			MaxTaskQueues: 100,
+			Version:       tv.DeploymentVersionString(),
+			RoutingConfig: routingConfig,
+		}
+
+		s.env.UpdateWorkflow(RegisterWorkerInDeploymentVersion, "", &testsuite.TestUpdateCallback{
+			OnReject: func(err error) {
+				s.Fail("register should not be rejected", err)
+			},
+			OnAccept: func() {},
+			OnComplete: func(result any, err error) {
+				s.Require().NoError(err)
+			},
+		}, registerArgs)
+	}, 1*time.Millisecond)
+
+	s.env.ExecuteWorkflow(WorkerDeploymentVersionWorkflowType, &deploymentspb.WorkerDeploymentVersionWorkflowArgs{
+		NamespaceName: tv.NamespaceName().String(),
+		NamespaceId:   tv.NamespaceID().String(),
+		VersionState: &deploymentspb.VersionLocalState{
+			Version: &deploymentspb.WorkerDeploymentVersion{
+				DeploymentName: tv.DeploymentSeries(),
+				BuildId:        tv.BuildID(),
+			},
+			TaskQueueFamilies:         map[string]*deploymentspb.VersionLocalState_TaskQueueFamilyData{},
+			RevisionNumber:            0,
+			SyncBatchSize:             int32(s.workerDeploymentClient.getSyncBatchSize()),
+			StartedDeploymentWorkflow: true,
+		},
+	})
+
+	s.True(s.env.IsWorkflowCompleted())
+	s.True(signalSent, "TqRegistrationPropagationCompleteSignal should have been sent")
 }
 
 // Test_BatchTaskQueuesForSync_SingleBatch tests batching when task queues fit in one batch

--- a/service/worker/workerdeployment/workflow.go
+++ b/service/worker/workerdeployment/workflow.go
@@ -129,6 +129,14 @@ func (d *WorkflowRunner) listenToSignals(ctx workflow.Context) {
 		d.handlePropagationComplete(completion)
 		d.setStateChanged()
 	})
+	tqRegistrationPropCompleteChannel := workflow.GetSignalChannel(ctx, TqRegistrationPropagationCompleteSignal)
+	d.signalHandler.signalSelector.AddReceive(tqRegistrationPropCompleteChannel, func(c workflow.ReceiveChannel, more bool) {
+		d.signalHandler.processingSignals++
+		defer func() { d.signalHandler.processingSignals-- }()
+		c.Receive(ctx, nil)
+		d.handleTqRegistrationPropagationComplete()
+		d.setStateChanged()
+	})
 
 	// Keep waiting for signals, when it's time to CaN the main goroutine will exit.
 	for {
@@ -195,6 +203,18 @@ func (d *WorkflowRunner) handlePropagationComplete(completion *deploymentspb.Pro
 	d.logger.Info("Propagation completed for revision",
 		"revision", revisionNumber,
 		"build_id", buildID)
+}
+
+// handleTqRegistrationPropagationComplete handles the signal from version workflows indicating
+// that a task queue registration propagation has completed.
+func (d *WorkflowRunner) handleTqRegistrationPropagationComplete() {
+	if d.State.PendingTqRegistrationPropagations <= 0 {
+		d.logger.Error("Received TQ registration propagation complete signal, but counter is already zero")
+		return
+	}
+	d.State.PendingTqRegistrationPropagations--
+	d.logger.Info("TQ registration propagation completed",
+		"remaining", d.State.PendingTqRegistrationPropagations)
 }
 
 func (d *WorkflowRunner) updateVersionSummary(summary *deploymentspb.WorkerDeploymentVersionSummary) {
@@ -675,6 +695,15 @@ func (d *WorkflowRunner) handleRegisterWorker(ctx workflow.Context, args *deploy
 		routingConfigToSync = d.GetState().GetRoutingConfig()
 	}
 
+	// Track registration propagation for current/ramping versions so that
+	// RoutingConfigUpdateState reflects the in-flight propagation.
+	trackingRegistrationPropagation := false
+	if d.hasMinVersion(TqRegistrationPropagationTracking) && routingConfigToSync != nil &&
+		isVersionCurrentOrRamping(routingConfigToSync, args.GetVersion().GetBuildId(), args.GetVersion().GetDeploymentName()) {
+		d.State.PendingTqRegistrationPropagations++
+		trackingRegistrationPropagation = true
+	}
+
 	// Register task-queue worker in version workflow.
 	activityCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
 	err = workflow.ExecuteActivity(activityCtx, d.a.RegisterWorkerInVersion, &deploymentspb.RegisterWorkerInVersionArgs{
@@ -685,6 +714,9 @@ func (d *WorkflowRunner) handleRegisterWorker(ctx workflow.Context, args *deploy
 		RoutingConfig: routingConfigToSync,
 	}).Get(ctx, nil)
 	if err != nil {
+		if trackingRegistrationPropagation {
+			d.State.PendingTqRegistrationPropagations--
+		}
 		var appError *temporal.ApplicationError
 		if errors.As(err, &appError) {
 			if appError.Type() == errMaxTaskQueuesInVersionType {
@@ -880,6 +912,9 @@ func (d *WorkflowRunner) handleSetRampingVersion(ctx workflow.Context, args *dep
 			pendingRoutingConfig.RevisionNumber++
 			// only setting it in the request if it's async mode
 			routingConfigToSync = pendingRoutingConfig
+			// Reset TQ registration propagation counter since any in-flight registration
+			// propagations are for the old routing config and will be superseded.
+			d.State.PendingTqRegistrationPropagations = 0
 		}
 
 		if newRampingVersion == "" {
@@ -1353,6 +1388,9 @@ func (d *WorkflowRunner) handleSetCurrent(ctx workflow.Context, args *deployment
 			pendingRoutingConfig.RevisionNumber++
 			// only setting it in the request if it's async mode
 			routingConfigToSync = pendingRoutingConfig
+			// Reset TQ registration propagation counter since any in-flight registration
+			// propagations are for the old routing config and will be superseded.
+			d.State.PendingTqRegistrationPropagations = 0
 		}
 
 		// Unset ramping if it's being promoted to current

--- a/service/worker/workerdeployment/workflow_test.go
+++ b/service/worker/workerdeployment/workflow_test.go
@@ -33,7 +33,7 @@ type WorkerDeploymentSuite struct {
 
 func TestWorkerDeploymentSuite(t *testing.T) {
 	t.Parallel()
-	suite.Run(t, &WorkerDeploymentSuite{workflowVersion: VersionDataRevisionNumber})
+	suite.Run(t, &WorkerDeploymentSuite{workflowVersion: TqRegistrationPropagationTracking})
 }
 
 func (s *WorkerDeploymentSuite) SetupTest() {
@@ -1855,4 +1855,319 @@ func (s *WorkerDeploymentSuite) Test_CreateWorkerDeploymentVersion_SyncSummaryPr
 	})
 
 	s.True(s.env.IsWorkflowCompleted())
+}
+
+// Test_RegisterWorker_IncrementsTqRegistrationCounter tests that registering a worker
+// in a current version increments the PendingTqRegistrationPropagations counter.
+func (s *WorkerDeploymentSuite) Test_RegisterWorker_IncrementsTqRegistrationCounter() {
+	s.skipBeforeVersion(TqRegistrationPropagationTracking)
+
+	tv := testvars.New(s.T())
+	s.env.OnUpsertMemo(mock.Anything).Return(nil)
+
+	var a *Activities
+	s.env.RegisterActivity(a.RegisterWorkerInVersion)
+	s.env.OnActivity(a.RegisterWorkerInVersion, mock.Anything, mock.Anything).Return(nil)
+
+	version1 := tv.DeploymentVersionString()
+
+	s.env.RegisterDelayedCallback(func() {
+		s.env.UpdateWorkflow(RegisterWorkerInWorkerDeployment, "", &testsuite.TestUpdateCallback{
+			OnReject: func(err error) {
+				s.Fail("RegisterWorker update should not have been rejected", err)
+			},
+			OnAccept: func() {},
+			OnComplete: func(result any, err error) {
+				s.Require().NoError(err)
+
+				queryResult, err := s.env.QueryWorkflow(QueryDescribeDeployment)
+				s.Require().NoError(err)
+				var state deploymentspb.QueryDescribeWorkerDeploymentResponse
+				s.Require().NoError(queryResult.Get(&state))
+
+				s.Equal(int32(1), state.State.PendingTqRegistrationPropagations,
+					"counter should be 1 after registering TQ in current version")
+			},
+		}, &deploymentspb.RegisterWorkerInWorkerDeploymentArgs{
+			TaskQueueName: "test-queue",
+			TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW,
+			Version: &deploymentspb.WorkerDeploymentVersion{
+				DeploymentName: tv.DeploymentSeries(),
+				BuildId:        tv.BuildID(),
+			},
+		})
+	}, 1*time.Millisecond)
+
+	s.env.ExecuteWorkflow(WorkerDeploymentWorkflowType, &deploymentspb.WorkerDeploymentWorkflowArgs{
+		NamespaceName:  tv.NamespaceName().String(),
+		NamespaceId:    tv.NamespaceID().String(),
+		DeploymentName: tv.DeploymentSeries(),
+		State: &deploymentspb.WorkerDeploymentLocalState{
+			Versions: map[string]*deploymentspb.WorkerDeploymentVersionSummary{
+				version1: {
+					Version: version1,
+				},
+			},
+			RoutingConfig: &deploymentpb.RoutingConfig{
+				RevisionNumber: 5,
+				//nolint:staticcheck // SA1019: worker versioning v0.31
+				CurrentVersion: version1,
+				CurrentDeploymentVersion: &deploymentpb.WorkerDeploymentVersion{
+					DeploymentName: tv.DeploymentSeries(),
+					BuildId:        tv.BuildID(),
+				},
+			},
+		},
+	})
+
+	s.True(s.env.IsWorkflowCompleted())
+}
+
+// Test_RegisterWorker_DoesNotIncrementForNonCurrentVersion tests that registering a worker
+// in a non-current/non-ramping version does NOT increment the counter.
+func (s *WorkerDeploymentSuite) Test_RegisterWorker_DoesNotIncrementForNonCurrentVersion() {
+	s.skipBeforeVersion(TqRegistrationPropagationTracking)
+
+	tv := testvars.New(s.T())
+	s.env.OnUpsertMemo(mock.Anything).Return(nil)
+
+	var a *Activities
+	s.env.RegisterActivity(a.RegisterWorkerInVersion)
+	s.env.OnActivity(a.RegisterWorkerInVersion, mock.Anything, mock.Anything).Return(nil)
+
+	version1 := tv.DeploymentVersionString()
+
+	s.env.RegisterDelayedCallback(func() {
+		s.env.UpdateWorkflow(RegisterWorkerInWorkerDeployment, "", &testsuite.TestUpdateCallback{
+			OnReject: func(err error) {
+				s.Fail("RegisterWorker update should not have been rejected", err)
+			},
+			OnAccept: func() {},
+			OnComplete: func(result any, err error) {
+				s.Require().NoError(err)
+
+				queryResult, err := s.env.QueryWorkflow(QueryDescribeDeployment)
+				s.Require().NoError(err)
+				var state deploymentspb.QueryDescribeWorkerDeploymentResponse
+				s.Require().NoError(queryResult.Get(&state))
+
+				s.Equal(int32(0), state.State.PendingTqRegistrationPropagations,
+					"counter should remain 0 for non-current/non-ramping version")
+			},
+		}, &deploymentspb.RegisterWorkerInWorkerDeploymentArgs{
+			TaskQueueName: "test-queue",
+			TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW,
+			Version: &deploymentspb.WorkerDeploymentVersion{
+				DeploymentName: tv.DeploymentSeries(),
+				BuildId:        tv.BuildID(),
+			},
+		})
+	}, 1*time.Millisecond)
+
+	s.env.ExecuteWorkflow(WorkerDeploymentWorkflowType, &deploymentspb.WorkerDeploymentWorkflowArgs{
+		NamespaceName:  tv.NamespaceName().String(),
+		NamespaceId:    tv.NamespaceID().String(),
+		DeploymentName: tv.DeploymentSeries(),
+		State: &deploymentspb.WorkerDeploymentLocalState{
+			Versions: map[string]*deploymentspb.WorkerDeploymentVersionSummary{
+				version1: {
+					Version: version1,
+				},
+			},
+			RoutingConfig: &deploymentpb.RoutingConfig{
+				RevisionNumber: 5,
+				// No current or ramping version set
+			},
+		},
+	})
+
+	s.True(s.env.IsWorkflowCompleted())
+}
+
+// Test_TqRegistrationPropagationComplete_DecrementsCounter tests that receiving the
+// TQ registration propagation complete signal decrements the counter.
+func (s *WorkerDeploymentSuite) Test_TqRegistrationPropagationComplete_DecrementsCounter() {
+	s.skipBeforeVersion(TqRegistrationPropagationTracking)
+
+	tv := testvars.New(s.T())
+	s.env.OnUpsertMemo(mock.Anything).Return(nil)
+
+	s.env.RegisterDelayedCallback(func() {
+		s.env.SignalWorkflow(TqRegistrationPropagationCompleteSignal, nil)
+	}, 1*time.Millisecond)
+
+	s.env.ExecuteWorkflow(WorkerDeploymentWorkflowType, &deploymentspb.WorkerDeploymentWorkflowArgs{
+		NamespaceName:  tv.NamespaceName().String(),
+		NamespaceId:    tv.NamespaceID().String(),
+		DeploymentName: tv.DeploymentSeries(),
+		State: &deploymentspb.WorkerDeploymentLocalState{
+			PendingTqRegistrationPropagations: 2,
+			RoutingConfig: &deploymentpb.RoutingConfig{
+				RevisionNumber: 10,
+			},
+		},
+	})
+
+	s.True(s.env.IsWorkflowCompleted())
+
+	queryResult, err := s.env.QueryWorkflow(QueryDescribeDeployment)
+	s.Require().NoError(err)
+	var state deploymentspb.QueryDescribeWorkerDeploymentResponse
+	s.Require().NoError(queryResult.Get(&state))
+
+	s.Equal(int32(1), state.State.PendingTqRegistrationPropagations,
+		"counter should be decremented from 2 to 1")
+}
+
+// Test_TqRegistrationPropagationComplete_FloorsAtZero tests that the counter doesn't
+// go below zero on stale signals.
+func (s *WorkerDeploymentSuite) Test_TqRegistrationPropagationComplete_FloorsAtZero() {
+	s.skipBeforeVersion(TqRegistrationPropagationTracking)
+
+	tv := testvars.New(s.T())
+	s.env.OnUpsertMemo(mock.Anything).Return(nil)
+
+	s.env.RegisterDelayedCallback(func() {
+		s.env.SignalWorkflow(TqRegistrationPropagationCompleteSignal, nil)
+	}, 1*time.Millisecond)
+
+	s.env.ExecuteWorkflow(WorkerDeploymentWorkflowType, &deploymentspb.WorkerDeploymentWorkflowArgs{
+		NamespaceName:  tv.NamespaceName().String(),
+		NamespaceId:    tv.NamespaceID().String(),
+		DeploymentName: tv.DeploymentSeries(),
+		State: &deploymentspb.WorkerDeploymentLocalState{
+			PendingTqRegistrationPropagations: 0,
+			RoutingConfig: &deploymentpb.RoutingConfig{
+				RevisionNumber: 10,
+			},
+		},
+	})
+
+	s.True(s.env.IsWorkflowCompleted())
+
+	queryResult, err := s.env.QueryWorkflow(QueryDescribeDeployment)
+	s.Require().NoError(err)
+	var state deploymentspb.QueryDescribeWorkerDeploymentResponse
+	s.Require().NoError(queryResult.Get(&state))
+
+	s.Equal(int32(0), state.State.PendingTqRegistrationPropagations,
+		"counter should remain at 0, not go negative")
+}
+
+// Test_SetCurrent_ResetsTqRegistrationCounter tests that changing the current version
+// resets the PendingTqRegistrationPropagations counter since in-flight propagations
+// are for the old routing config.
+func (s *WorkerDeploymentSuite) Test_SetCurrent_ResetsTqRegistrationCounter() {
+	s.skipBeforeVersion(TqRegistrationPropagationTracking)
+
+	tv := testvars.New(s.T())
+	s.env.OnUpsertMemo(mock.Anything).Return(nil)
+
+	var a *Activities
+	s.env.RegisterActivity(a.SyncWorkerDeploymentVersion)
+	s.env.OnActivity(a.SyncWorkerDeploymentVersion, mock.Anything, mock.Anything).Return(
+		func(ctx context.Context, args *deploymentspb.SyncVersionStateActivityArgs) (*deploymentspb.SyncVersionStateActivityResult, error) {
+			return &deploymentspb.SyncVersionStateActivityResult{
+				Summary: &deploymentspb.WorkerDeploymentVersionSummary{
+					Version: args.Version,
+				},
+			}, nil
+		},
+	)
+
+	version1 := tv.DeploymentVersionString()
+	version2 := tv.WithBuildIDNumber(2).DeploymentVersionString()
+
+	s.env.RegisterDelayedCallback(func() {
+		s.env.UpdateWorkflow(SetCurrentVersion, version2, &testsuite.TestUpdateCallback{
+			OnReject: func(err error) {
+				s.Fail("SetCurrentVersion update should not have failed", err)
+			},
+			OnAccept: func() {},
+			OnComplete: func(result any, err error) {
+				s.Require().NoError(err)
+
+				queryResult, err := s.env.QueryWorkflow(QueryDescribeDeployment)
+				s.Require().NoError(err)
+				var state deploymentspb.QueryDescribeWorkerDeploymentResponse
+				s.Require().NoError(queryResult.Get(&state))
+
+				s.Equal(int32(0), state.State.PendingTqRegistrationPropagations,
+					"counter should be reset to 0 after SetCurrent")
+			},
+		}, &deploymentspb.SetCurrentVersionArgs{
+			Identity:                tv.ClientIdentity(),
+			Version:                 version2,
+			IgnoreMissingTaskQueues: true,
+		})
+	}, 1*time.Millisecond)
+
+	s.env.ExecuteWorkflow(WorkerDeploymentWorkflowType, &deploymentspb.WorkerDeploymentWorkflowArgs{
+		NamespaceName:  tv.NamespaceName().String(),
+		NamespaceId:    tv.NamespaceID().String(),
+		DeploymentName: tv.DeploymentSeries(),
+		State: &deploymentspb.WorkerDeploymentLocalState{
+			Versions: map[string]*deploymentspb.WorkerDeploymentVersionSummary{
+				version1: {Version: version1},
+				version2: {Version: version2},
+			},
+			RoutingConfig: &deploymentpb.RoutingConfig{
+				RevisionNumber: 5,
+				//nolint:staticcheck // SA1019: worker versioning v0.31
+				CurrentVersion: version1,
+				CurrentDeploymentVersion: &deploymentpb.WorkerDeploymentVersion{
+					DeploymentName: tv.DeploymentSeries(),
+					BuildId:        tv.BuildID(),
+				},
+			},
+			PendingTqRegistrationPropagations: 3,
+			PropagatingRevisions:              make(map[string]*deploymentspb.PropagatingRevisions),
+		},
+	})
+
+	s.True(s.env.IsWorkflowCompleted())
+}
+
+// Test_RoutingConfigUpdateState_IncludesTqRegistrationCounter tests that
+// deploymentStateToDeploymentInfo correctly derives RoutingConfigUpdateState
+// from both PropagatingRevisions and PendingTqRegistrationPropagations.
+func (s *WorkerDeploymentSuite) Test_RoutingConfigUpdateState_IncludesTqRegistrationCounter() {
+	// Test with only TQ registration propagations pending
+	info, err := s.workerDeploymentClient.deploymentStateToDeploymentInfo("test-deployment",
+		&deploymentspb.WorkerDeploymentLocalState{
+			PendingTqRegistrationPropagations: 1,
+		})
+	s.Require().NoError(err)
+	s.Equal(enumspb.ROUTING_CONFIG_UPDATE_STATE_IN_PROGRESS, info.RoutingConfigUpdateState,
+		"should be IN_PROGRESS when TQ registration propagations are pending")
+
+	// Test with both empty
+	info, err = s.workerDeploymentClient.deploymentStateToDeploymentInfo("test-deployment",
+		&deploymentspb.WorkerDeploymentLocalState{})
+	s.Require().NoError(err)
+	s.Equal(enumspb.ROUTING_CONFIG_UPDATE_STATE_COMPLETED, info.RoutingConfigUpdateState,
+		"should be COMPLETED when both counters are zero")
+
+	// Test with only PropagatingRevisions
+	info, err = s.workerDeploymentClient.deploymentStateToDeploymentInfo("test-deployment",
+		&deploymentspb.WorkerDeploymentLocalState{
+			PropagatingRevisions: map[string]*deploymentspb.PropagatingRevisions{
+				"build-1": {RevisionNumbers: []int64{1}},
+			},
+		})
+	s.Require().NoError(err)
+	s.Equal(enumspb.ROUTING_CONFIG_UPDATE_STATE_IN_PROGRESS, info.RoutingConfigUpdateState,
+		"should be IN_PROGRESS when PropagatingRevisions are pending")
+
+	// Test with both
+	info, err = s.workerDeploymentClient.deploymentStateToDeploymentInfo("test-deployment",
+		&deploymentspb.WorkerDeploymentLocalState{
+			PendingTqRegistrationPropagations: 2,
+			PropagatingRevisions: map[string]*deploymentspb.PropagatingRevisions{
+				"build-1": {RevisionNumbers: []int64{1}},
+			},
+		})
+	s.Require().NoError(err)
+	s.Equal(enumspb.ROUTING_CONFIG_UPDATE_STATE_IN_PROGRESS, info.RoutingConfigUpdateState,
+		"should be IN_PROGRESS when both are pending")
 }


### PR DESCRIPTION
## Summary
- When a new task queue registers with a version that is already current or ramping, `RoutingConfigUpdateState` now correctly reflects `IN_PROGRESS` during the routing config propagation to that TQ
- Uses a separate `PendingTqRegistrationPropagations` counter (not `PropagatingRevisions`) to avoid race conditions with the bulk-removal logic in `handlePropagationComplete`
- Counter resets to 0 on `SetCurrent`/`SetRamping` since stale propagations are superseded by the new routing config propagation

## Test plan
- [ ] Unit tests: counter increment for current/ramping versions, no increment for inactive versions
- [ ] Unit tests: signal decrement, floor-at-zero behavior
- [ ] Unit tests: counter reset on SetCurrent
- [ ] Unit tests: RoutingConfigUpdateState derivation includes both PropagatingRevisions and counter
- [ ] Version workflow test: signals TqRegistrationPropagationCompleteSignal for current version
- [ ] Integration test: register new TQ in current version, verify COMPLETED (TODO)
- [ ] All existing unit tests pass
- [ ] All replay tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)