### PR TITLE
retry and error parsing

### DIFF
--- a/common/persistence/schema/version.go
+++ b/common/persistence/schema/version.go
@@ -15,7 +15,7 @@ func VerifyCompatibleVersion(
 
 	version, err := versionReader.ReadSchemaVersion(dbName)
 	if err != nil {
-		return fmt.Errorf("unable to read DB schema version keyspace/database: %s error: %v", dbName, err.Error())
+		return fmt.Errorf("unable to read DB schema version keyspace/database: %s error: %w", dbName, err)
 	}
 	// In most cases, the versions should match. However if after a schema upgrade there is a code
 	// rollback, the code version (expected version) would fall lower than the actual version in

--- a/common/persistence/sql/version_checker.go
+++ b/common/persistence/sql/version_checker.go
@@ -1,6 +1,11 @@
 package sql
 
 import (
+	"errors"
+	"time"
+
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
@@ -55,11 +60,22 @@ func checkCompatibleVersion(
 	dbKind sqlplugin.DbKind,
 	logger log.Logger,
 ) error {
-	db, err := NewSQLAdminDB(dbKind, cfg, r, logger, metrics.NoopMetricsHandler)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = db.Close() }()
-
-	return db.VerifyVersion()
+	policy := backoff.NewExponentialRetryPolicy(1 * time.Second).
+		WithMaximumInterval(10 * time.Second).
+		WithExpirationInterval(backoff.NoInterval)
+	return backoff.ThrottleRetry(
+		func() error {
+			db, err := NewSQLAdminDB(dbKind, cfg, r, logger, metrics.NoopMetricsHandler)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = db.Close() }()
+			return db.VerifyVersion()
+		},
+		policy,
+		func(err error) bool {
+			var unavailableErr *serviceerror.Unavailable
+			return errors.As(err, &unavailableErr)
+		},
+	)
 }

--- a/common/persistence/sql/version_checker.go
+++ b/common/persistence/sql/version_checker.go
@@ -8,6 +8,7 @@ import (
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/resolver"
@@ -70,7 +71,11 @@ func checkCompatibleVersion(
 				return err
 			}
 			defer func() { _ = db.Close() }()
-			return db.VerifyVersion()
+			if err := db.VerifyVersion(); err != nil {
+				logger.Warn("sql schema version check failed, retrying", tag.Error(err))
+				return err
+			}
+			return nil
 		},
 		policy,
 		func(err error) bool {


### PR DESCRIPTION
## What changed?

When the SQL persistence schema version check runs at startup (`verifyPersistenceCompatibleVersion`), it now retries automatically on transient `Unavailable` errors instead of failing immediately. The underlying error wrapping was also fixed to use `%w` so the error type is preserved through the chain and the retry predicate can actually detect it.

## Why?
when a node is replaced, the pod restarts before the network is fully ready. The DB might be reachable within seconds, but the one-shot startup check would fail hard and put the server into `CrashLoopBackOff` requiring a manual redeploy to recover.

## How did you test it?
- [x] built
- [x] covered by existing tests

## Potential risks

The retry has no expiration ([NoInterval](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)), so if the DB is permanently unreachable, the server will block at startup indefinitely rather than crashing
- Every failed attempt logs a Warn

#8202 