### PR TITLE
Add passwordCommand option for SQL datastore credentials

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -400,6 +400,18 @@ type (
 		SerialConsistency string `yaml:"serialConsistency"`
 	}
 
+	// PasswordCommandConfig configures an external command to fetch the datastore password.
+	// The command's stdout is used as the password.
+	PasswordCommandConfig struct {
+		// Command is the path to the executable to run.
+		Command string `yaml:"command"`
+		// Args is the list of arguments to pass to the command.
+		Args []string `yaml:"args"`
+		// Timeout is the maximum duration to wait for the command to complete.
+		// Defaults to 30 seconds if unset.
+		Timeout time.Duration `yaml:"timeout"`
+	}
+
 	// SQL is the configuration for connecting to a SQL backed datastore
 	SQL struct {
 		// Connect is a function that returns a sql db connection. String based configuration is ignored if this is provided.
@@ -408,6 +420,11 @@ type (
 		User string `yaml:"user"`
 		// Password is the password corresponding to the user name
 		Password string `yaml:"password"`
+		// PasswordCommand executes an external command and uses its stdout as the password.
+		// Mutually exclusive with Password.
+		// If the command returns an expiring token (e.g. cloud IAM), set MaxConnLifetime
+		// to ensure connections are recycled before the token expires.
+		PasswordCommand *PasswordCommandConfig `yaml:"passwordCommand"`
 		// PluginName is the name of SQL plugin
 		PluginName string `yaml:"pluginName" validate:"nonzero"`
 		// DatabaseName is the name of SQL database to connect to

--- a/common/config/persistence.go
+++ b/common/config/persistence.go
@@ -1,10 +1,14 @@
 package config
 
 import (
+	"bytes"
+	"context"
 	"errors"
 	"fmt"
+	"os/exec"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/gocql/gocql"
 	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
@@ -170,8 +174,13 @@ func (ds *DataStore) Validate() error {
 		)
 	}
 
-	if ds.SQL != nil && ds.SQL.TaskScanPartitions == 0 {
-		ds.SQL.TaskScanPartitions = 1
+	if ds.SQL != nil {
+		if ds.SQL.TaskScanPartitions == 0 {
+			ds.SQL.TaskScanPartitions = 1
+		}
+		if err := ds.SQL.validate(); err != nil {
+			return err
+		}
 	}
 	if ds.Cassandra != nil {
 		if err := ds.Cassandra.validate(); err != nil {
@@ -270,4 +279,45 @@ func parseSerialConsistency(serialConsistency string) (gocql.SerialConsistency, 
 	var s gocql.SerialConsistency
 	err := s.UnmarshalText([]byte(strings.ToUpper(serialConsistency)))
 	return s, err
+}
+
+func (c *SQL) validate() error {
+	if c.PasswordCommand != nil && c.Password != "" {
+		return errors.New("passwordCommand and password are mutually exclusive")
+	}
+	if c.PasswordCommand != nil && c.PasswordCommand.Command == "" {
+		return errors.New("passwordCommand.command must not be empty")
+	}
+	return nil
+}
+
+const (
+	defaultPasswordCommandTimeout = 30 * time.Second
+	passwordCommandWaitDelay      = 5 * time.Second
+)
+
+// ResolvePassword returns the database password, either from the static Password
+// field or by executing PasswordCommand. If neither is set, it returns an empty string.
+func (c *SQL) ResolvePassword() (string, error) {
+	if c.PasswordCommand == nil {
+		return c.Password, nil
+	}
+	timeout := c.PasswordCommand.Timeout
+	if timeout == 0 {
+		timeout = defaultPasswordCommandTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, c.PasswordCommand.Command, c.PasswordCommand.Args...) //nolint:gosec
+	// WaitDelay caps how long we block on the stdout pipe after the process is killed.
+	// Without it, a subprocess that inherits the pipe could keep it open indefinitely.
+	cmd.WaitDelay = passwordCommandWaitDelay
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("passwordCommand %q %v failed: %w (stderr: %s)",
+			c.PasswordCommand.Command, c.PasswordCommand.Args, err, stderr.String())
+	}
+	return strings.TrimRight(string(out), "\n\r"), nil
 }

--- a/common/config/persistence_test.go
+++ b/common/config/persistence_test.go
@@ -3,9 +3,111 @@ package config
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/gocql/gocql"
+	"github.com/stretchr/testify/require"
 )
+
+func TestSQLValidate_MutualExclusivity(t *testing.T) {
+	cfg := &SQL{
+		Password: "static",
+		PasswordCommand: &PasswordCommandConfig{
+			Command: "echo",
+			Args:    []string{"dynamic"},
+		},
+	}
+	err := cfg.validate()
+	require.ErrorContains(t, err, "mutually exclusive")
+}
+
+func TestSQLValidate_PasswordOnly(t *testing.T) {
+	cfg := &SQL{Password: "static"}
+	err := cfg.validate()
+	require.NoError(t, err)
+}
+
+func TestSQLValidate_PasswordCommandOnly(t *testing.T) {
+	cfg := &SQL{
+		PasswordCommand: &PasswordCommandConfig{
+			Command: "echo",
+			Args:    []string{"dynamic"},
+		},
+	}
+	err := cfg.validate()
+	require.NoError(t, err)
+}
+
+func TestSQLValidate_PasswordCommandEmptyCommand(t *testing.T) {
+	cfg := &SQL{
+		PasswordCommand: &PasswordCommandConfig{},
+	}
+	err := cfg.validate()
+	require.ErrorContains(t, err, "passwordCommand.command must not be empty")
+}
+
+func TestSQLResolvePassword_Static(t *testing.T) {
+	cfg := &SQL{Password: "static-pass"}
+	pw, err := cfg.ResolvePassword()
+	require.NoError(t, err)
+	require.Equal(t, "static-pass", pw)
+}
+
+func TestSQLResolvePassword_EmptyWhenNothingSet(t *testing.T) {
+	cfg := &SQL{}
+	pw, err := cfg.ResolvePassword()
+	require.NoError(t, err)
+	require.Empty(t, pw)
+}
+
+func TestSQLResolvePassword_Command(t *testing.T) {
+	cfg := &SQL{
+		PasswordCommand: &PasswordCommandConfig{
+			Command: "echo",
+			Args:    []string{"hello"},
+		},
+	}
+	pw, err := cfg.ResolvePassword()
+	require.NoError(t, err)
+	require.Equal(t, "hello", pw)
+}
+
+func TestSQLResolvePassword_CommandTrimsTrailingNewline(t *testing.T) {
+	cfg := &SQL{
+		PasswordCommand: &PasswordCommandConfig{
+			Command: "printf",
+			Args:    []string{"hello\n\n"},
+		},
+	}
+	pw, err := cfg.ResolvePassword()
+	require.NoError(t, err)
+	require.Equal(t, "hello", pw)
+}
+
+func TestSQLResolvePassword_CommandFailure(t *testing.T) {
+	cfg := &SQL{
+		PasswordCommand: &PasswordCommandConfig{
+			Command: "false",
+		},
+	}
+	_, err := cfg.ResolvePassword()
+	require.ErrorContains(t, err, "passwordCommand")
+}
+
+func TestSQLResolvePassword_CommandTimeout(t *testing.T) {
+	cfg := &SQL{
+		PasswordCommand: &PasswordCommandConfig{
+			Command: "sleep",
+			Args:    []string{"10"},
+			Timeout: 10 * time.Millisecond,
+		},
+	}
+	start := time.Now()
+	_, err := cfg.ResolvePassword()
+	elapsed := time.Since(start)
+	require.ErrorContains(t, err, "passwordCommand")
+	require.Less(t, elapsed, 5*time.Second, "command should have been killed by timeout")
+}
 
 func TestCassandraStoreConsistency_GetConsistency(t *testing.T) {
 	t.Parallel()

--- a/common/persistence/sql/sqlplugin/connector.go
+++ b/common/persistence/sql/sqlplugin/connector.go
@@ -1,0 +1,43 @@
+package sqlplugin
+
+import (
+	"context"
+	"database/sql/driver"
+)
+
+// RefreshingConnector is a driver.Connector that calls buildDSN on every
+// Connect, so each new physical connection gets a fresh credential. This is
+// used when passwordCommand is configured to fetch short-lived tokens.
+type RefreshingConnector struct {
+	buildDSN     func() (string, error)
+	newConnector func(dsn string) (driver.Connector, error)
+	driver       driver.Driver
+}
+
+func NewRefreshingConnector(
+	buildDSN func() (string, error),
+	newConnector func(dsn string) (driver.Connector, error),
+	d driver.Driver,
+) *RefreshingConnector {
+	return &RefreshingConnector{
+		buildDSN:     buildDSN,
+		newConnector: newConnector,
+		driver:       d,
+	}
+}
+
+func (c *RefreshingConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	dsn, err := c.buildDSN()
+	if err != nil {
+		return nil, err
+	}
+	connector, err := c.newConnector(dsn)
+	if err != nil {
+		return nil, err
+	}
+	return connector.Connect(ctx)
+}
+
+func (c *RefreshingConnector) Driver() driver.Driver {
+	return c.driver
+}

--- a/common/persistence/sql/sqlplugin/connector_test.go
+++ b/common/persistence/sql/sqlplugin/connector_test.go
@@ -1,0 +1,74 @@
+package sqlplugin
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fakeConn struct{}
+
+func (fakeConn) Prepare(string) (driver.Stmt, error) { return nil, nil }
+func (fakeConn) Close() error                        { return nil }
+func (fakeConn) Begin() (driver.Tx, error)           { return nil, nil }
+
+type fakeConnector struct{ dsn string }
+
+func (c *fakeConnector) Connect(context.Context) (driver.Conn, error) { return fakeConn{}, nil }
+func (c *fakeConnector) Driver() driver.Driver                        { return nil }
+
+func TestRefreshingConnector_CallsBuildDSNOnEachConnect(t *testing.T) {
+	callCount := 0
+	c := NewRefreshingConnector(
+		func() (string, error) {
+			callCount++
+			return "dsn-" + string(rune('0'+callCount)), nil
+		},
+		func(dsn string) (driver.Connector, error) {
+			return &fakeConnector{dsn: dsn}, nil
+		},
+		nil,
+	)
+
+	for range 3 {
+		_, err := c.Connect(context.Background())
+		require.NoError(t, err)
+	}
+	require.Equal(t, 3, callCount)
+}
+
+func TestRefreshingConnector_PropagatesBuildDSNError(t *testing.T) {
+	expectedErr := errors.New("token expired")
+	c := NewRefreshingConnector(
+		func() (string, error) {
+			return "", expectedErr
+		},
+		func(dsn string) (driver.Connector, error) {
+			t.Fatal("NewConnector should not be called when BuildDSN fails")
+			return nil, nil
+		},
+		nil,
+	)
+
+	_, err := c.Connect(context.Background())
+	require.ErrorIs(t, err, expectedErr)
+}
+
+func TestRefreshingConnector_PropagatesNewConnectorError(t *testing.T) {
+	expectedErr := errors.New("bad dsn")
+	c := NewRefreshingConnector(
+		func() (string, error) {
+			return "some-dsn", nil
+		},
+		func(dsn string) (driver.Connector, error) {
+			return nil, expectedErr
+		},
+		nil,
+	)
+
+	_, err := c.Connect(context.Background())
+	require.ErrorIs(t, err, expectedErr)
+}

--- a/common/persistence/sql/sqlplugin/mysql/session/session.go
+++ b/common/persistence/sql/sqlplugin/mysql/session/session.go
@@ -3,6 +3,8 @@ package session
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"database/sql"
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"os"
@@ -69,14 +71,32 @@ func createConnection(
 		return nil, err
 	}
 
-	dsn, err := buildDSN(dbKind, cfg, resolver)
-	if err != nil {
-		return nil, err
-	}
-
-	db, err := sqlx.Connect(driverName, dsn)
-	if err != nil {
-		return nil, err
+	var db *sqlx.DB
+	if cfg.PasswordCommand != nil {
+		c := sqlplugin.NewRefreshingConnector(
+			func() (string, error) {
+				return buildDSN(dbKind, cfg, resolver)
+			},
+			func(dsn string) (driver.Connector, error) {
+				return mysql.MySQLDriver{}.OpenConnector(dsn)
+			},
+			mysql.MySQLDriver{},
+		)
+		db = sqlx.NewDb(sql.OpenDB(c), driverName)
+		if err := db.Ping(); err != nil {
+			_ = db.Close()
+			return nil, err
+		}
+	} else {
+		var dsn string
+		dsn, err = buildDSN(dbKind, cfg, resolver)
+		if err != nil {
+			return nil, err
+		}
+		db, err = sqlx.Connect(driverName, dsn)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if cfg.MaxConns > 0 {
 		db.SetMaxOpenConns(cfg.MaxConns)
@@ -98,14 +118,18 @@ func buildDSN(
 	cfg *config.SQL,
 	r resolver.ServiceResolver,
 ) (string, error) {
+	password, err := cfg.ResolvePassword()
+	if err != nil {
+		return "", err
+	}
+
 	mysqlConfig := mysql.NewConfig()
 
 	mysqlConfig.User = cfg.User
-	mysqlConfig.Passwd = cfg.Password
+	mysqlConfig.Passwd = password
 	mysqlConfig.Addr = r.Resolve(cfg.ConnectAddr)[0]
 	mysqlConfig.DBName = cfg.DatabaseName
 	mysqlConfig.Net = cfg.ConnectProtocol
-	var err error
 	mysqlConfig.Params, err = buildDSNAttrs(dbKind, cfg)
 	if err != nil {
 		return "", err

--- a/common/persistence/sql/sqlplugin/postgresql/driver/interface.go
+++ b/common/persistence/sql/sqlplugin/postgresql/driver/interface.go
@@ -18,6 +18,10 @@ const (
 
 type Driver interface {
 	CreateConnection(dsn string) (*sqlx.DB, error)
+	// CreateRefreshableConnection creates a connection pool that calls buildDSN
+	// before opening each new physical connection, enabling per-connection
+	// credential refresh for short-lived tokens (e.g. from passwordCommand).
+	CreateRefreshableConnection(buildDSN func() (string, error)) (*sqlx.DB, error)
 	IsDupEntryError(error) bool
 	IsDupDatabaseError(error) bool
 	IsConnNeedsRefreshError(error) bool

--- a/common/persistence/sql/sqlplugin/postgresql/driver/pgx.go
+++ b/common/persistence/sql/sqlplugin/postgresql/driver/pgx.go
@@ -1,15 +1,42 @@
 package driver
 
 import (
+	"database/sql"
+	sqldriver "database/sql/driver"
+
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
-	_ "github.com/jackc/pgx/v5/stdlib" // register pgx driver for sqlx
+	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/jmoiron/sqlx"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 )
 
 type PGXDriver struct{}
 
+const pgxDriverName = "pgx"
+
 func (p *PGXDriver) CreateConnection(dsn string) (*sqlx.DB, error) {
-	return sqlx.Connect("pgx", dsn)
+	return sqlx.Connect(pgxDriverName, dsn)
+}
+
+func (p *PGXDriver) CreateRefreshableConnection(buildDSN func() (string, error)) (*sqlx.DB, error) {
+	c := sqlplugin.NewRefreshingConnector(
+		buildDSN,
+		func(dsn string) (sqldriver.Connector, error) {
+			cfg, err := pgx.ParseConfig(dsn)
+			if err != nil {
+				return nil, err
+			}
+			return stdlib.GetConnector(*cfg), nil
+		},
+		stdlib.GetDefaultDriver(),
+	)
+	db := sqlx.NewDb(sql.OpenDB(c), pgxDriverName)
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
 }
 
 func (p *PGXDriver) IsDupEntryError(err error) bool {

--- a/common/persistence/sql/sqlplugin/postgresql/driver/pq.go
+++ b/common/persistence/sql/sqlplugin/postgresql/driver/pq.go
@@ -1,14 +1,36 @@
 package driver
 
 import (
+	"database/sql"
+	sqldriver "database/sql/driver"
+
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 )
 
 type PQDriver struct{}
 
+const pqDriverName = "postgres"
+
 func (p *PQDriver) CreateConnection(dsn string) (*sqlx.DB, error) {
-	return sqlx.Connect("postgres", dsn)
+	return sqlx.Connect(pqDriverName, dsn)
+}
+
+func (p *PQDriver) CreateRefreshableConnection(buildDSN func() (string, error)) (*sqlx.DB, error) {
+	c := sqlplugin.NewRefreshingConnector(
+		buildDSN,
+		func(dsn string) (sqldriver.Connector, error) {
+			return pq.NewConnector(dsn)
+		},
+		&pq.Driver{},
+	)
+	db := sqlx.NewDb(sql.OpenDB(c), pqDriverName)
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
 }
 
 func (p *PQDriver) IsDupEntryError(err error) bool {

--- a/common/persistence/sql/sqlplugin/postgresql/plugin.go
+++ b/common/persistence/sql/sqlplugin/postgresql/plugin.go
@@ -86,15 +86,17 @@ func (p *plugin) createDBConnection(
 		return postgresqlSession.DB, nil
 	}
 
-	// database name not provided
-	// try defaults
-	defer func() { cfg.DatabaseName = "" }()
+	// Database name not provided, try defaults.
+	// Use a shallow copy so that the session's refreshable-connection closure
+	// (which captures the config pointer) sees the correct DatabaseName on
+	// reconnect
+	cfgCopy := *cfg
 
 	var errors []error
 	for _, databaseName := range defaultDatabaseNames {
-		cfg.DatabaseName = databaseName
+		cfgCopy.DatabaseName = databaseName
 		if postgresqlSession, err := session.NewSession(
-			cfg,
+			&cfgCopy,
 			p.driver,
 			resolver,
 		); err == nil {

--- a/common/persistence/sql/sqlplugin/postgresql/session/session.go
+++ b/common/persistence/sql/sqlplugin/postgresql/session/session.go
@@ -55,11 +55,21 @@ func createConnection(
 	d driver.Driver,
 	resolver resolver.ServiceResolver,
 ) (*sqlx.DB, error) {
-	dsn, err := buildDSN(cfg, resolver)
-	if err != nil {
-		return nil, err
+	var db *sqlx.DB
+	var err error
+
+	if cfg.PasswordCommand != nil {
+		db, err = d.CreateRefreshableConnection(func() (string, error) {
+			return buildDSN(cfg, resolver)
+		})
+	} else {
+		var dsn string
+		dsn, err = buildDSN(cfg, resolver)
+		if err != nil {
+			return nil, err
+		}
+		db, err = d.CreateConnection(dsn)
 	}
-	db, err := d.CreateConnection(dsn)
 	if err != nil {
 		return nil, err
 	}
@@ -82,6 +92,10 @@ func buildDSN(
 	cfg *config.SQL,
 	r resolver.ServiceResolver,
 ) (string, error) {
+	password, err := cfg.ResolvePassword()
+	if err != nil {
+		return "", err
+	}
 	tlsAttrs, err := buildDSNAttr(cfg)
 	if err != nil {
 		return "", err
@@ -90,7 +104,7 @@ func buildDSN(
 	return fmt.Sprintf(
 		dsnFmt,
 		cfg.User,
-		url.QueryEscape(cfg.Password),
+		url.QueryEscape(password),
 		resolvedAddr,
 		cfg.DatabaseName,
 		tlsAttrs.Encode(),


### PR DESCRIPTION
## What changed?
Add a `passwordCommand` config option for SQL datastores that executes an external command to fetch the database password instead of using a static `password` field. When configured, each new physical database connection re-executes the command to get a fresh credential via `RefreshingConnector`, enabling short-lived tokens (e.g. cloud IAM tokens) to be used as database passwords. Supported for MySQL, PostgreSQL (both pgx and pq drivers).

## Why?
Cloud-managed databases (e.g. AWS RDS, GCP Cloud SQL) authenticate using short-lived IAM tokens rather than static passwords. There was no way to integrate an external credential source into Temporal's SQL config without forking the code. `passwordCommand` lets operators plug in any token-fetching tool (e.g. `aws rds generate-db-auth-token`) via config.

This approach is vendor-agnostic: any command that writes a password to stdout works, with no SDK dependencies or provider-specific code in Temporal.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [ ] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

Tested with GCP, setting up a Postgres database and using it for the server backend

## Potential risks
- `passwordCommand` executes an arbitrary external command. Misconfiguration will cause connection failures
- If the command is slow or hangs, connection pool growth will stall until the timeout (default 30s) fires.
- Token expiry must be managed by the operator via `MaxConnLifetime`, there is no built-in mechanism to detect or handle expired credentials on existing connections. Richer integration (e.g. parsing expiry from the command output and automatically setting connection lifetime) is possible but intentionally omitted here as it would be vendor-specific. The good news, is that most cloud APIs return tokens with a known, fixed TTL (e.g. 15 minutes for AWS RDS, 1 hour for GCP Cloud SQL).
