### PR TITLE
Add per namespace rate limiter on history service

### DIFF
--- a/client/history/metric_client.go
+++ b/client/history/metric_client.go
@@ -101,7 +101,8 @@ func (c *metricClient) finishMetricsRecording(
 			*serviceerror.QueryFailed,
 			*serviceerror.NamespaceNotFound,
 			*serviceerror.WorkflowNotReady,
-			*serviceerror.WorkflowExecutionAlreadyStarted:
+			*serviceerror.WorkflowExecutionAlreadyStarted,
+			*serviceerror.ResourceExhausted:
 			// noop - not interest and too many logs
 		default:
 			c.throttledLogger.Info("history client encountered error", tag.Error(err), tag.ServiceErrorType(err))

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -739,7 +739,7 @@ be 1 or higher.`,
 	FrontendGlobalNamespaceRPS = NewNamespaceIntSetting(
 		"frontend.globalNamespaceRPS",
 		0,
-		`FrontendGlobalNamespaceRPS is workflow namespace rate limit per second for the whole cluster.
+		`FrontendGlobalNamespaceRPS is namespace rate limit per second for the whole cluster.
 The limit is evenly distributed among available frontend service instances.
 If this is set, it overwrites per instance limit "frontend.namespaceRPS".`,
 	)
@@ -1562,6 +1562,12 @@ execution is deleted. When enabled, workflow deletions on the active cluster wil
 		"history.rps",
 		3000,
 		`HistoryRPS is request rate per second for each history host`,
+	)
+	HistoryNamespaceRPS = NewNamespaceIntSetting(
+		"history.namespaceRPS",
+		0,
+		`HistoryNamespaceRPS is namespace rate limit per second for each history host. 
+If value less or equal to 0, will fall back to HistoryRPS`,
 	)
 	HistoryPersistenceMaxQPS = NewGlobalIntSetting(
 		"history.persistenceMaxQPS",

--- a/common/quotas/priority.go
+++ b/common/quotas/priority.go
@@ -1,0 +1,6 @@
+package quotas
+
+const (
+	// OperatorPriority is used to give precedence to calls coming from web UI or tctl
+	OperatorPriority = 0
+)

--- a/common/quotas/priority_rate_limiter_impl.go
+++ b/common/quotas/priority_rate_limiter_impl.go
@@ -22,6 +22,33 @@ type (
 
 var _ RequestRateLimiter = (*PriorityRateLimiterImpl)(nil)
 
+func NewPriorityRateLimiterHelper(
+	rateBurstFn RateBurst,
+	operatorRPSRatio func() float64,
+	requestPriorityFn RequestPriorityFn,
+	prioritiesOrdered []int,
+) RequestRateLimiter {
+	rateLimiters := make(map[int]RequestRateLimiter)
+	for _, priority := range prioritiesOrdered {
+		if priority == OperatorPriority {
+			rateLimiters[priority] = NewRequestRateLimiterAdapter(
+				NewDynamicRateLimiter(
+					NewOperatorRateBurst(rateBurstFn, operatorRPSRatio),
+					defaultRefreshInterval,
+				),
+			)
+		} else {
+			rateLimiters[priority] = NewRequestRateLimiterAdapter(
+				NewDynamicRateLimiter(
+					rateBurstFn,
+					defaultRefreshInterval,
+				),
+			)
+		}
+	}
+	return NewPriorityRateLimiter(requestPriorityFn, rateLimiters)
+}
+
 // NewPriorityRateLimiter returns a new rate limiter that can handle dynamic
 // configuration updates
 func NewPriorityRateLimiter(

--- a/common/quotas/rate_burst.go
+++ b/common/quotas/rate_burst.go
@@ -202,5 +202,5 @@ func (c *OperatorRateBurstImpl) Rate() float64 {
 }
 
 func (c *OperatorRateBurstImpl) Burst() int {
-	return c.baseRateBurstFn.Burst()
+	return int(c.operatorRateRatio() * float64(c.baseRateBurstFn.Burst()))
 }

--- a/common/quotas/rate_burst.go
+++ b/common/quotas/rate_burst.go
@@ -5,6 +5,28 @@ import (
 	"sync/atomic"
 )
 
+var (
+	_ RateBurst = (*RateBurstImpl)(nil)
+	_ RateBurst = (*MutableRateBurstImpl)(nil)
+	_ RateBurst = (*NamespaceRateBurstImpl)(nil)
+	_ RateBurst = (*OperatorRateBurstImpl)(nil)
+)
+
+var (
+	DefaultIncomingBurstRatioFn = func() float64 {
+		return defaultIncomingRateBurstRatio
+	}
+	DefaultOutgoingBurstRatioFn = func() float64 {
+		return defaultOutgoingRateBurstRatio
+	}
+	DefaultIncomingNamespaceBurstRatioFn = func(_ string) float64 {
+		return defaultIncomingRateBurstRatio
+	}
+	DefaultOutgoingNamespaceBurstRatioFn = func(_ string) float64 {
+		return defaultOutgoingRateBurstRatio
+	}
+)
+
 type (
 	// RateFn returns a float64 as the RPS
 	RateFn func() float64
@@ -19,7 +41,10 @@ type (
 	BurstRatioFn func() float64
 
 	// NamespaceBurstFn returns an int as the burst / bucket size for the given namespace
-	NamespaceBurstFn func(namespace string) float64
+	NamespaceBurstFn func(namespace string) int
+
+	// NamespaceBurstRatioFn returns a float as the ratio of burst to rate for the given namespace
+	NamespaceBurstRatioFn func(namespace string) float64
 
 	// RateBurst returns rate & burst for rate limiter
 	RateBurst interface {
@@ -42,6 +67,17 @@ type (
 		SetRPS(rps float64)
 		SetBurst(burst int)
 		RateBurst
+	}
+
+	NamespaceRateBurstImpl struct {
+		namespaceName string
+		rateFn        NamespaceRateFn
+		burstFn       NamespaceBurstFn
+	}
+
+	OperatorRateBurstImpl struct {
+		operatorRateRatio func() float64
+		baseRateBurstFn   RateBurst
 	}
 )
 
@@ -127,4 +163,44 @@ func (d *MutableRateBurstImpl) Rate() float64 {
 
 func (d *MutableRateBurstImpl) Burst() int {
 	return int(d.burst.Load())
+}
+
+func NewNamespaceRateBurst(
+	namespaceName string,
+	rateFn NamespaceRateFn,
+	burstRatioFn NamespaceBurstRatioFn,
+) *NamespaceRateBurstImpl {
+	return &NamespaceRateBurstImpl{
+		namespaceName: namespaceName,
+		rateFn:        rateFn,
+		burstFn: func(namespace string) int {
+			return max(1, int(math.Ceil(rateFn(namespace)*burstRatioFn(namespace))))
+		},
+	}
+}
+
+func (n *NamespaceRateBurstImpl) Rate() float64 {
+	return n.rateFn(n.namespaceName)
+}
+
+func (n *NamespaceRateBurstImpl) Burst() int {
+	return n.burstFn(n.namespaceName)
+}
+
+func NewOperatorRateBurst(
+	baseRateBurstFn RateBurst,
+	operatorRateRatio func() float64,
+) *OperatorRateBurstImpl {
+	return &OperatorRateBurstImpl{
+		operatorRateRatio: operatorRateRatio,
+		baseRateBurstFn:   baseRateBurstFn,
+	}
+}
+
+func (c *OperatorRateBurstImpl) Rate() float64 {
+	return c.operatorRateRatio() * c.baseRateBurstFn.Rate()
+}
+
+func (c *OperatorRateBurstImpl) Burst() int {
+	return c.baseRateBurstFn.Burst()
 }

--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -1,7 +1,6 @@
 package configs
 
 import (
-	"math"
 	"time"
 
 	"go.temporal.io/server/common/dynamicconfig"
@@ -9,11 +8,6 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/quotas"
 	"go.temporal.io/server/common/quotas/calculator"
-)
-
-const (
-	// OperatorPriority is used to give precedence to calls coming from web UI or tctl
-	OperatorPriority = 0
 )
 
 const (
@@ -255,62 +249,6 @@ var (
 	}
 )
 
-type (
-	NamespaceRateBurstImpl struct {
-		namespaceName string
-		rateFn        quotas.NamespaceRateFn
-		burstFn       dynamicconfig.IntPropertyFnWithNamespaceFilter
-	}
-
-	operatorRateBurstImpl struct {
-		operatorRateRatio dynamicconfig.FloatPropertyFn
-		baseRateBurstFn   quotas.RateBurst
-	}
-)
-
-var _ quotas.RateBurst = (*NamespaceRateBurstImpl)(nil)
-var _ quotas.RateBurst = (*operatorRateBurstImpl)(nil)
-
-func NewNamespaceRateBurst(
-	namespaceName string,
-	rateFn quotas.NamespaceRateFn,
-	burstRatioFn dynamicconfig.FloatPropertyFnWithNamespaceFilter,
-) *NamespaceRateBurstImpl {
-	return &NamespaceRateBurstImpl{
-		namespaceName: namespaceName,
-		rateFn:        rateFn,
-		burstFn: func(namespace string) int {
-			return max(1, int(math.Ceil(rateFn(namespace)*burstRatioFn(namespace))))
-		},
-	}
-}
-
-func (c *NamespaceRateBurstImpl) Rate() float64 {
-	return c.rateFn(c.namespaceName)
-}
-
-func (c *NamespaceRateBurstImpl) Burst() int {
-	return c.burstFn(c.namespaceName)
-}
-
-func newOperatorRateBurst(
-	baseRateBurstFn quotas.RateBurst,
-	operatorRateRatio dynamicconfig.FloatPropertyFn,
-) *operatorRateBurstImpl {
-	return &operatorRateBurstImpl{
-		operatorRateRatio: operatorRateRatio,
-		baseRateBurstFn:   baseRateBurstFn,
-	}
-}
-
-func (c *operatorRateBurstImpl) Rate() float64 {
-	return c.operatorRateRatio() * c.baseRateBurstFn.Rate()
-}
-
-func (c *operatorRateBurstImpl) Burst() int {
-	return c.baseRateBurstFn.Burst()
-}
-
 func NewRequestToRateLimiter(
 	executionRateBurstFn quotas.RateBurst,
 	visibilityRateBurstFn quotas.RateBurst,
@@ -340,69 +278,60 @@ func NewExecutionPriorityRateLimiter(
 	rateBurstFn quotas.RateBurst,
 	operatorRPSRatio dynamicconfig.FloatPropertyFn,
 ) quotas.RequestRateLimiter {
-	rateLimiters := make(map[int]quotas.RequestRateLimiter)
-	for priority := range ExecutionAPIPrioritiesOrdered {
-		if priority == OperatorPriority {
-			rateLimiters[priority] = quotas.NewRequestRateLimiterAdapter(quotas.NewDynamicRateLimiter(newOperatorRateBurst(rateBurstFn, operatorRPSRatio), time.Minute))
-		} else {
-			rateLimiters[priority] = quotas.NewRequestRateLimiterAdapter(quotas.NewDynamicRateLimiter(rateBurstFn, time.Minute))
-		}
-	}
-	return quotas.NewPriorityRateLimiter(func(req quotas.Request) int {
-		if req.CallerType == headers.CallerTypeOperator {
-			return OperatorPriority
-		}
-		if priority, ok := APIToPriority[req.API]; ok {
-			return priority
-		}
-		return ExecutionAPIPrioritiesOrdered[len(ExecutionAPIPrioritiesOrdered)-1]
-	}, rateLimiters)
+	return quotas.NewPriorityRateLimiterHelper(
+		rateBurstFn,
+		operatorRPSRatio,
+		func(req quotas.Request) int {
+			if req.CallerType == headers.CallerTypeOperator {
+				return quotas.OperatorPriority
+			}
+			if priority, ok := APIToPriority[req.API]; ok {
+				return priority
+			}
+			return ExecutionAPIPrioritiesOrdered[len(ExecutionAPIPrioritiesOrdered)-1]
+		},
+		ExecutionAPIPrioritiesOrdered,
+	)
 }
 
 func NewVisibilityPriorityRateLimiter(
 	rateBurstFn quotas.RateBurst,
 	operatorRPSRatio dynamicconfig.FloatPropertyFn,
 ) quotas.RequestRateLimiter {
-	rateLimiters := make(map[int]quotas.RequestRateLimiter)
-	for priority := range VisibilityAPIPrioritiesOrdered {
-		if priority == OperatorPriority {
-			rateLimiters[priority] = quotas.NewRequestRateLimiterAdapter(quotas.NewDynamicRateLimiter(newOperatorRateBurst(rateBurstFn, operatorRPSRatio), time.Minute))
-		} else {
-			rateLimiters[priority] = quotas.NewRequestRateLimiterAdapter(quotas.NewDynamicRateLimiter(rateBurstFn, time.Minute))
-		}
-	}
-	return quotas.NewPriorityRateLimiter(func(req quotas.Request) int {
-		if req.CallerType == headers.CallerTypeOperator {
-			return OperatorPriority
-		}
-		if priority, ok := VisibilityAPIToPriority[req.API]; ok {
-			return priority
-		}
-		return VisibilityAPIPrioritiesOrdered[len(VisibilityAPIPrioritiesOrdered)-1]
-	}, rateLimiters)
+	return quotas.NewPriorityRateLimiterHelper(
+		rateBurstFn,
+		operatorRPSRatio,
+		func(req quotas.Request) int {
+			if req.CallerType == headers.CallerTypeOperator {
+				return quotas.OperatorPriority
+			}
+			if priority, ok := VisibilityAPIToPriority[req.API]; ok {
+				return priority
+			}
+			return VisibilityAPIPrioritiesOrdered[len(VisibilityAPIPrioritiesOrdered)-1]
+		},
+		VisibilityAPIPrioritiesOrdered,
+	)
 }
 
 func NewNamespaceReplicationInducingAPIPriorityRateLimiter(
 	rateBurstFn quotas.RateBurst,
 	operatorRPSRatio dynamicconfig.FloatPropertyFn,
 ) quotas.RequestRateLimiter {
-	rateLimiters := make(map[int]quotas.RequestRateLimiter)
-	for priority := range NamespaceReplicationInducingAPIPrioritiesOrdered {
-		if priority == OperatorPriority {
-			rateLimiters[priority] = quotas.NewRequestRateLimiterAdapter(quotas.NewDynamicRateLimiter(newOperatorRateBurst(rateBurstFn, operatorRPSRatio), time.Minute))
-		} else {
-			rateLimiters[priority] = quotas.NewRequestRateLimiterAdapter(quotas.NewDynamicRateLimiter(rateBurstFn, time.Minute))
-		}
-	}
-	return quotas.NewPriorityRateLimiter(func(req quotas.Request) int {
-		if req.CallerType == headers.CallerTypeOperator {
-			return OperatorPriority
-		}
-		if priority, ok := NamespaceReplicationInducingAPIToPriority[req.API]; ok {
-			return priority
-		}
-		return NamespaceReplicationInducingAPIPrioritiesOrdered[len(NamespaceReplicationInducingAPIPrioritiesOrdered)-1]
-	}, rateLimiters)
+	return quotas.NewPriorityRateLimiterHelper(
+		rateBurstFn,
+		operatorRPSRatio,
+		func(req quotas.Request) int {
+			if req.CallerType == headers.CallerTypeOperator {
+				return quotas.OperatorPriority
+			}
+			if priority, ok := NamespaceReplicationInducingAPIToPriority[req.API]; ok {
+				return priority
+			}
+			return NamespaceReplicationInducingAPIPrioritiesOrdered[len(NamespaceReplicationInducingAPIPrioritiesOrdered)-1]
+		},
+		NamespaceReplicationInducingAPIPrioritiesOrdered,
+	)
 }
 
 // NewGlobalNamespaceRateLimiter creates a namespace-aware rate limiter that uses

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -542,9 +542,21 @@ func NamespaceRateLimitInterceptorProvider(
 	namespaceRateLimiter := quotas.NewNamespaceRequestRateLimiter(
 		func(req quotas.Request) quotas.RequestRateLimiter {
 			return configs.NewRequestToRateLimiter(
-				configs.NewNamespaceRateBurst(req.Caller, namespaceRateFn, serviceConfig.MaxNamespaceBurstRatioPerInstance),
-				configs.NewNamespaceRateBurst(req.Caller, visibilityRateFn, serviceConfig.MaxNamespaceVisibilityBurstRatioPerInstance),
-				configs.NewNamespaceRateBurst(req.Caller, namespaceReplicationInducingRateFn, serviceConfig.MaxNamespaceNamespaceReplicationInducingAPIsBurstRatioPerInstance),
+				quotas.NewNamespaceRateBurst(
+					req.Caller,
+					namespaceRateFn,
+					quotas.NamespaceBurstRatioFn(serviceConfig.MaxNamespaceBurstRatioPerInstance),
+				),
+				quotas.NewNamespaceRateBurst(
+					req.Caller,
+					visibilityRateFn,
+					quotas.NamespaceBurstRatioFn(serviceConfig.MaxNamespaceVisibilityBurstRatioPerInstance),
+				),
+				quotas.NewNamespaceRateBurst(
+					req.Caller,
+					namespaceReplicationInducingRateFn,
+					quotas.NamespaceBurstRatioFn(serviceConfig.MaxNamespaceNamespaceReplicationInducingAPIsBurstRatioPerInstance),
+				),
 				serviceConfig.OperatorRPSRatio,
 			)
 		},

--- a/service/fx.go
+++ b/service/fx.go
@@ -58,10 +58,10 @@ var PersistenceLazyLoadedServiceResolverModule = fx.Options(
 			Value: &atomic.Value{},
 		}
 	}),
-	fx.Invoke(initLazyLoadedServiceResolver),
+	fx.Invoke(initPersistenceLazyLoadedServiceResolver),
 )
 
-func initLazyLoadedServiceResolver(
+func initPersistenceLazyLoadedServiceResolver(
 	serviceName primitives.ServiceName,
 	logger log.SnTaggedLogger,
 	serviceResolver membership.ServiceResolver,

--- a/service/fx.go
+++ b/service/fx.go
@@ -38,16 +38,17 @@ type (
 	GrpcServerOptionsParams struct {
 		fx.In
 
-		Logger                       log.Logger
-		RPCFactory                   common.RPCFactory
-		RetryableInterceptor         *interceptor.RetryableInterceptor
-		TelemetryInterceptor         *interceptor.TelemetryInterceptor
-		RateLimitInterceptor         *interceptor.RateLimitInterceptor
-		TracingStatsHandler          telemetry.ServerStatsHandler
-		MetricsStatsHandler          metrics.ServerStatsHandler
-		ContextMetadataInterceptor   *interceptor.ContextMetadataInterceptor `optional:"true"`
-		AdditionalInterceptors       []grpc.UnaryServerInterceptor           `optional:"true"`
-		AdditionalStreamInterceptors []grpc.StreamServerInterceptor          `optional:"true"`
+		Logger                        log.Logger
+		RPCFactory                    common.RPCFactory
+		RetryableInterceptor          *interceptor.RetryableInterceptor
+		TelemetryInterceptor          *interceptor.TelemetryInterceptor
+		NamespaceRateLimitInterceptor interceptor.NamespaceRateLimitInterceptor `optional:"true"`
+		RateLimitInterceptor          *interceptor.RateLimitInterceptor
+		TracingStatsHandler           telemetry.ServerStatsHandler
+		MetricsStatsHandler           metrics.ServerStatsHandler
+		ContextMetadataInterceptor    *interceptor.ContextMetadataInterceptor `optional:"true"`
+		AdditionalInterceptors        []grpc.UnaryServerInterceptor           `optional:"true"`
+		AdditionalStreamInterceptors  []grpc.StreamServerInterceptor          `optional:"true"`
 	}
 )
 
@@ -57,10 +58,10 @@ var PersistenceLazyLoadedServiceResolverModule = fx.Options(
 			Value: &atomic.Value{},
 		}
 	}),
-	fx.Invoke(initPersistenceLazyLoadedServiceResolver),
+	fx.Invoke(initLazyLoadedServiceResolver),
 )
 
-func initPersistenceLazyLoadedServiceResolver(
+func initLazyLoadedServiceResolver(
 	serviceName primitives.ServiceName,
 	logger log.SnTaggedLogger,
 	serviceResolver membership.ServiceResolver,
@@ -163,6 +164,10 @@ func getUnaryInterceptors(params GrpcServerOptionsParams) []grpc.UnaryServerInte
 	}
 
 	interceptors = append(interceptors, params.AdditionalInterceptors...)
+
+	if params.NamespaceRateLimitInterceptor != nil {
+		interceptors = append(interceptors, params.NamespaceRateLimitInterceptor.Intercept)
+	}
 
 	interceptors = append(interceptors, params.RateLimitInterceptor.Intercept)
 

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	HistoryReplicationDLQV2             dynamicconfig.BoolPropertyFn
 
 	RPS                                         dynamicconfig.IntPropertyFn
+	NamespaceRPS                                dynamicconfig.IntPropertyFnWithNamespaceFilter
 	OperatorRPSRatio                            dynamicconfig.FloatPropertyFn
 	MaxIDLengthLimit                            dynamicconfig.IntPropertyFn
 	PersistenceMaxQPS                           dynamicconfig.IntPropertyFn
@@ -439,6 +440,7 @@ func NewConfig(
 		HistoryReplicationDLQV2:             dynamicconfig.EnableHistoryReplicationDLQV2.Get(dc),
 
 		RPS:                                  dynamicconfig.HistoryRPS.Get(dc),
+		NamespaceRPS:                         dynamicconfig.HistoryNamespaceRPS.Get(dc),
 		OperatorRPSRatio:                     dynamicconfig.OperatorRPSRatio.Get(dc),
 		MaxIDLengthLimit:                     dynamicconfig.MaxIDLengthLimit.Get(dc),
 		PersistenceMaxQPS:                    dynamicconfig.HistoryPersistenceMaxQPS.Get(dc),

--- a/service/history/configs/quotas.go
+++ b/service/history/configs/quotas.go
@@ -30,7 +30,7 @@ func NewPriorityRateLimiter(
 	)
 }
 
-func NewNamespapceRateLimiter(
+func NewNamespaceRateLimiter(
 	namespaceRateFn quotas.NamespaceRateFn,
 	operatorRPSRatio dynamicconfig.FloatPropertyFn,
 ) quotas.RequestRateLimiter {

--- a/service/history/configs/quotas.go
+++ b/service/history/configs/quotas.go
@@ -6,49 +6,56 @@ import (
 	"go.temporal.io/server/common/quotas"
 )
 
-const (
-	// OperatorPriority is used to give precedence to calls coming from web UI or tctl
-	OperatorPriority = 0
-)
-
 var (
 	CallerTypeToPriority = map[string]int{
-		headers.CallerTypeOperator:       OperatorPriority,
+		headers.CallerTypeOperator:       quotas.OperatorPriority,
 		headers.CallerTypeAPI:            1,
 		headers.CallerTypeBackgroundHigh: 2,
 		headers.CallerTypeBackgroundLow:  3,
 		headers.CallerTypePreemptable:    4,
 	}
 
-	APIPrioritiesOrdered = []int{OperatorPriority, 1, 2, 3, 4}
+	APIPrioritiesOrdered = []int{quotas.OperatorPriority, 1, 2, 3, 4}
 )
 
 func NewPriorityRateLimiter(
 	rateFn quotas.RateFn,
 	operatorRPSRatio dynamicconfig.FloatPropertyFn,
 ) quotas.RequestRateLimiter {
-	rateLimiters := make(map[int]quotas.RequestRateLimiter)
-	for priority := range APIPrioritiesOrdered {
-		if priority == OperatorPriority {
-			rateLimiters[priority] = quotas.NewRequestRateLimiterAdapter(quotas.NewDefaultIncomingRateLimiter(operatorRateFn(rateFn, operatorRPSRatio)))
-		} else {
-			rateLimiters[priority] = quotas.NewRequestRateLimiterAdapter(quotas.NewDefaultIncomingRateLimiter(rateFn))
-		}
-	}
-	return quotas.NewPriorityRateLimiter(func(req quotas.Request) int {
-		if priority, ok := CallerTypeToPriority[req.CallerType]; ok {
-			return priority
-		}
-		// unknown caller type, default to api to be consistent with existing behavior
-		return CallerTypeToPriority[headers.CallerTypeAPI]
-	}, rateLimiters)
+	return quotas.NewPriorityRateLimiterHelper(
+		quotas.NewDefaultIncomingRateBurst(rateFn),
+		operatorRPSRatio,
+		RequestToPriority,
+		APIPrioritiesOrdered,
+	)
 }
 
-func operatorRateFn(
-	rateFn quotas.RateFn,
+func NewNamespapceRateLimiter(
+	namespaceRateFn quotas.NamespaceRateFn,
 	operatorRPSRatio dynamicconfig.FloatPropertyFn,
-) quotas.RateFn {
-	return func() float64 {
-		return operatorRPSRatio() * rateFn()
+) quotas.RequestRateLimiter {
+	return quotas.NewNamespaceRequestRateLimiter(
+		func(req quotas.Request) quotas.RequestRateLimiter {
+			return quotas.NewPriorityRateLimiterHelper(
+				quotas.NewNamespaceRateBurst(
+					req.Caller,
+					namespaceRateFn,
+					// TODO: We can consider adding a separate burst ratio dynamic config
+					// on namespace level rate limiter if needed.
+					quotas.DefaultIncomingNamespaceBurstRatioFn,
+				),
+				operatorRPSRatio,
+				RequestToPriority,
+				APIPrioritiesOrdered,
+			)
+		},
+	)
+}
+
+func RequestToPriority(req quotas.Request) int {
+	if priority, ok := CallerTypeToPriority[req.CallerType]; ok {
+		return priority
 	}
+	// unknown caller type, default to api to be consistent with existing behavior
+	return CallerTypeToPriority[headers.CallerTypeAPI]
 }

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -67,6 +67,7 @@ var Module = fx.Options(
 	fx.Provide(RetryableInterceptorProvider),
 	fx.Provide(ErrorHandlerProvider),
 	fx.Provide(TelemetryInterceptorProvider),
+	fx.Provide(NamespaceRateLimitInterceptorProvider),
 	fx.Provide(RateLimitInterceptorProvider),
 	fx.Provide(HealthSignalAggregatorProvider),
 	fx.Provide(HealthCheckInterceptorProvider),
@@ -263,6 +264,34 @@ func HistoryAdditionalInterceptorsProvider(
 	}
 }
 
+func NamespaceRateLimitInterceptorProvider(
+	serviceConfig *configs.Config,
+	namespaceRegistry namespace.Registry,
+	metricsHandler metrics.Handler,
+	logger log.SnTaggedLogger,
+) interceptor.NamespaceRateLimitInterceptor {
+
+	namespaceRateFn := func(namespace string) float64 {
+		if namespaceRPS := serviceConfig.NamespaceRPS(namespace); namespaceRPS > 0 {
+			return float64(namespaceRPS)
+		}
+		// This fallback to host level rps limit when NamespaceRPS is not configured (i.e. 0)
+		return float64(serviceConfig.RPS())
+	}
+
+	return interceptor.NewNamespaceRateLimitInterceptor(
+		namespaceRegistry,
+		configs.NewNamespapceRateLimiter(
+			namespaceRateFn,
+			serviceConfig.OperatorRPSRatio,
+		),
+		map[string]int{},      // no token overrides
+		map[string]struct{}{}, // no long poll methods
+		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false), // no long poll methods
+		metricsHandler,
+	)
+}
+
 func RateLimitInterceptorProvider(
 	serviceConfig *configs.Config,
 ) *interceptor.RateLimitInterceptor {
@@ -290,14 +319,14 @@ func ESProcessorConfigProvider(
 
 func PersistenceRateLimitingParamsProvider(
 	serviceConfig *configs.Config,
-	persistenceLazyLoadedServiceResolver service.PersistenceLazyLoadedServiceResolver,
+	lazyLoadedServiceResolver service.PersistenceLazyLoadedServiceResolver,
 	ownershipBasedQuotaScaler shard.LazyLoadedOwnershipBasedQuotaScaler,
 	logger log.SnTaggedLogger,
 ) service.PersistenceRateLimitingParams {
 	hostCalculator := calculator.NewLoggedCalculator(
 		shard.NewOwnershipAwareQuotaCalculator(
 			ownershipBasedQuotaScaler,
-			persistenceLazyLoadedServiceResolver,
+			lazyLoadedServiceResolver,
 			serviceConfig.PersistenceMaxQPS,
 			serviceConfig.PersistenceGlobalMaxQPS,
 		),
@@ -306,7 +335,7 @@ func PersistenceRateLimitingParamsProvider(
 	namespaceCalculator := calculator.NewLoggedNamespaceCalculator(
 		shard.NewOwnershipAwareNamespaceQuotaCalculator(
 			ownershipBasedQuotaScaler,
-			persistenceLazyLoadedServiceResolver,
+			lazyLoadedServiceResolver,
 			serviceConfig.PersistenceNamespaceMaxQPS,
 			serviceConfig.PersistenceGlobalNamespaceMaxQPS,
 		),

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -268,11 +268,10 @@ func NamespaceRateLimitInterceptorProvider(
 	serviceConfig *configs.Config,
 	namespaceRegistry namespace.Registry,
 	metricsHandler metrics.Handler,
-	logger log.SnTaggedLogger,
 ) interceptor.NamespaceRateLimitInterceptor {
 
-	namespaceRateFn := func(namespace string) float64 {
-		if namespaceRPS := serviceConfig.NamespaceRPS(namespace); namespaceRPS > 0 {
+	namespaceRateFn := func(namespaceName string) float64 {
+		if namespaceRPS := serviceConfig.NamespaceRPS(namespaceName); namespaceRPS > 0 {
 			return float64(namespaceRPS)
 		}
 		// This fallback to host level rps limit when NamespaceRPS is not configured (i.e. 0)
@@ -281,12 +280,12 @@ func NamespaceRateLimitInterceptorProvider(
 
 	return interceptor.NewNamespaceRateLimitInterceptor(
 		namespaceRegistry,
-		configs.NewNamespapceRateLimiter(
+		configs.NewNamespaceRateLimiter(
 			namespaceRateFn,
 			serviceConfig.OperatorRPSRatio,
 		),
 		map[string]int{},      // no token overrides
-		map[string]struct{}{}, // no long poll methods
+		map[string]struct{}{}, // no long polls on history service
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false), // no long poll methods
 		metricsHandler,
 	)
@@ -319,14 +318,14 @@ func ESProcessorConfigProvider(
 
 func PersistenceRateLimitingParamsProvider(
 	serviceConfig *configs.Config,
-	lazyLoadedServiceResolver service.PersistenceLazyLoadedServiceResolver,
+	persistenceLazyLoadedServiceResolver service.PersistenceLazyLoadedServiceResolver,
 	ownershipBasedQuotaScaler shard.LazyLoadedOwnershipBasedQuotaScaler,
 	logger log.SnTaggedLogger,
 ) service.PersistenceRateLimitingParams {
 	hostCalculator := calculator.NewLoggedCalculator(
 		shard.NewOwnershipAwareQuotaCalculator(
 			ownershipBasedQuotaScaler,
-			lazyLoadedServiceResolver,
+			persistenceLazyLoadedServiceResolver,
 			serviceConfig.PersistenceMaxQPS,
 			serviceConfig.PersistenceGlobalMaxQPS,
 		),
@@ -335,7 +334,7 @@ func PersistenceRateLimitingParamsProvider(
 	namespaceCalculator := calculator.NewLoggedNamespaceCalculator(
 		shard.NewOwnershipAwareNamespaceQuotaCalculator(
 			ownershipBasedQuotaScaler,
-			lazyLoadedServiceResolver,
+			persistenceLazyLoadedServiceResolver,
 			serviceConfig.PersistenceNamespaceMaxQPS,
 			serviceConfig.PersistenceGlobalNamespaceMaxQPS,
 		),


### PR DESCRIPTION
## What changed?
- Add per namespace rate limiter on history service

## Why?
- Noisy neighbor protection. Provide know for preventing one namespace from consuming all available history host rps. 

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
