### PR TITLE
fix: cache ctx.Now() in NewSentinel to ensure idle task is scheduled

### DIFF
--- a/chasm/lib/scheduler/generator_tasks.go
+++ b/chasm/lib/scheduler/generator_tasks.go
@@ -57,9 +57,11 @@ func (g *GeneratorTaskHandler) Execute(
 	metricsHandler := newTaggedMetricsHandler(g.metricsHandler, scheduler)
 	invoker := scheduler.Invoker.Get(ctx)
 
+	now := ctx.Now(generator)
+
 	// If we have no last processed time, this is a new schedule.
 	if generator.LastProcessedTime == nil {
-		createdAt := timestamppb.New(ctx.Now(generator))
+		createdAt := timestamppb.New(now)
 		generator.LastProcessedTime = createdAt
 		scheduler.Info.CreateTime = createdAt
 
@@ -74,7 +76,7 @@ func (g *GeneratorTaskHandler) Execute(
 
 	// Process time range between last high water mark and system time.
 	t1 := generator.LastProcessedTime.AsTime()
-	t2 := ctx.Now(generator).UTC()
+	t2 := now.UTC()
 	if t2.Before(t1) {
 		logger.Error("time went backwards",
 			tag.Stringer("time", t1),

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -157,10 +157,11 @@ func NewSentinel(
 		},
 		cacheConflictToken: scheduler.InitialConflictToken,
 	}
-	s.Info.CreateTime = timestamppb.New(ctx.Now(s))
+	now := ctx.Now(s)
+	s.Info.CreateTime = timestamppb.New(now)
 
 	ctx.AddTask(s, chasm.TaskAttributes{
-		ScheduledTime: ctx.Now(s).Add(SentinelIdleTime),
+		ScheduledTime: now.Add(SentinelIdleTime),
 	}, &schedulerpb.SchedulerIdleTask{
 		IdleTimeTotal: durationpb.New(SentinelIdleTime),
 	})


### PR DESCRIPTION
## Summary

`ctx.Now()` delegates to `RealTimeSource.Now()` in production, which calls `time.Now()` on every invocation. Calling it multiple times in the same transaction produces slightly different timestamps, which can cause subtle bugs.

This PR fixes two instances of this pattern:

**`NewSentinel` (`scheduler.go`)**
- `ctx.Now(s)` was called twice: once to set `CreateTime` and once to compute `ScheduledTime` for the `SchedulerIdleTask`
- `SchedulerIdleTask.Validate` checks `idleExpiration == taskAttrs.ScheduledTime`, where `idleExpiration` is derived from `CreateTime` — the nanosecond drift meant they never matched
- The task was silently dropped during `closeTransactionHandleNewTasks`, so the sentinel never scheduled its idle close

**`GeneratorTaskHandler.Execute` (`generator_tasks.go`)**
- `ctx.Now(generator)` was called twice: once to set `CreateTime`/`LastProcessedTime` on a new schedule, and once as the upper bound `t2` of the time range to process
- On first execution this produced a non-zero range `[T, T+Δ]` instead of an empty range, potentially triggering an unintended immediate action

## Fix

Cache `ctx.Now()` in a local variable at the top of each scope and use it consistently.