### PR TITLE
Support testify.m for parallelsuite

### DIFF
--- a/common/testing/parallelsuite/suite.go
+++ b/common/testing/parallelsuite/suite.go
@@ -1,8 +1,10 @@
 package parallelsuite
 
 import (
+	"flag"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -79,7 +81,7 @@ func (s *Suite[T]) Run(name string, fn func(T)) bool {
 func Run[T testingSuite](t *testing.T, s T, args ...any) {
 	t.Helper()
 
-	typ := reflect.TypeOf(s)
+	typ := reflect.TypeFor[T]()
 	if typ.Kind() != reflect.Ptr || typ.Elem().Kind() != reflect.Struct {
 		panic(fmt.Sprintf("parallelsuite.Run: suite must be a pointer to a struct, got %v", typ))
 	}
@@ -90,6 +92,11 @@ func Run[T testingSuite](t *testing.T, s T, args ...any) {
 	methods := discoverTestMethods(typ, structType, args)
 	if len(methods) == 0 {
 		panic(fmt.Sprintf("parallelsuite.Run: suite %s has no Test* methods", structType.Name()))
+	}
+
+	methods = applyTestifyMFilter(methods)
+	if len(methods) == 0 {
+		return // all methods filtered by -testify.m; nothing to run
 	}
 
 	argVals := make([]reflect.Value, len(args))
@@ -114,9 +121,9 @@ var inheritedMethods map[string]bool
 
 func init() {
 	type ds struct{ Suite[*ds] }
-	ptrType := reflect.TypeOf(&ds{})
+	ptrType := reflect.TypeFor[*ds]()
 	inheritedMethods = make(map[string]bool, ptrType.NumMethod())
-	for i := 0; i < ptrType.NumMethod(); i++ {
+	for i := range ptrType.NumMethod() {
 		inheritedMethods[ptrType.Method(i).Name] = true
 	}
 }
@@ -142,10 +149,36 @@ func validateSuiteStruct(structType reflect.Type) {
 	}
 }
 
+// applyTestifyMFilter filters methods by the -testify.m flag.
+//
+// The flag is registered by testify's suite package (imported above); we share
+// that registration via flag.Lookup rather than registering it a second time.
+func applyTestifyMFilter(methods []reflect.Method) []reflect.Method {
+	f := flag.Lookup("testify.m")
+	if f == nil {
+		return methods
+	}
+	pattern := f.Value.String()
+	if pattern == "" {
+		return methods
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		panic(fmt.Sprintf("parallelsuite: invalid regexp for -testify.m: %s", err))
+	}
+	var filtered []reflect.Method
+	for _, m := range methods {
+		if re.MatchString(m.Name) {
+			filtered = append(filtered, m)
+		}
+	}
+	return filtered
+}
+
 func discoverTestMethods(ptrType, structType reflect.Type, args []any) []reflect.Method {
 	expectedNumIn := 1 + len(args)
 
-	for i := 0; i < ptrType.NumMethod(); i++ {
+	for i := range ptrType.NumMethod() {
 		name := ptrType.Method(i).Name
 		if !strings.HasPrefix(name, "Test") && !inheritedMethods[name] {
 			panic(fmt.Sprintf(
@@ -157,7 +190,7 @@ func discoverTestMethods(ptrType, structType reflect.Type, args []any) []reflect
 	}
 
 	var methods []reflect.Method
-	for i := 0; i < ptrType.NumMethod(); i++ {
+	for i := range ptrType.NumMethod() {
 		method := ptrType.Method(i)
 		if !strings.HasPrefix(method.Name, "Test") {
 			continue

--- a/common/testing/parallelsuite/suite.go
+++ b/common/testing/parallelsuite/suite.go
@@ -149,7 +149,8 @@ func validateSuiteStruct(structType reflect.Type) {
 	}
 }
 
-// applyTestifyMFilter filters methods by the -testify.m flag.
+// applyTestifyMFilter filters methods by the -testify.m flag. This is helpful
+// for editor integrations like VSCode that take this suite for a testify suite.
 //
 // The flag is registered by testify's suite package (imported above); we share
 // that registration via flag.Lookup rather than registering it a second time.

--- a/common/testing/parallelsuite/suite_test.go
+++ b/common/testing/parallelsuite/suite_test.go
@@ -1,6 +1,8 @@
 package parallelsuite
 
 import (
+	"flag"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -106,6 +108,42 @@ func TestRun_RejectsSuite(t *testing.T) {
 	})
 	t.Run("SetupTest forbidden", func(t *testing.T) {
 		require.Panics(t, func() { Run(t, &setupTestSuite{}) })
+	})
+}
+
+type multiMethodSuite struct{ Suite[*multiMethodSuite] }
+
+func (s *multiMethodSuite) TestFoo() {}
+func (s *multiMethodSuite) TestBar() {}
+func (s *multiMethodSuite) TestBaz() {}
+
+func TestApplyTestifyMFilter(t *testing.T) {
+	typ := reflect.TypeFor[*multiMethodSuite]()
+	methods := discoverTestMethods(typ, typ.Elem(), nil)
+
+	setFlag := func(t *testing.T, pattern string) {
+		t.Helper()
+		require.NoError(t, flag.Set("testify.m", pattern))
+		t.Cleanup(func() { _ = flag.Set("testify.m", "") })
+	}
+
+	t.Run("no filter", func(t *testing.T) {
+		require.Equal(t, methods, applyTestifyMFilter(methods))
+	})
+	t.Run("exact match", func(t *testing.T) {
+		setFlag(t, "^TestBar$")
+		filtered := applyTestifyMFilter(methods)
+		require.Len(t, filtered, 1)
+		require.Equal(t, "TestBar", filtered[0].Name)
+	})
+	t.Run("prefix match", func(t *testing.T) {
+		setFlag(t, "^TestBa")
+		filtered := applyTestifyMFilter(methods)
+		require.Len(t, filtered, 2)
+	})
+	t.Run("no match", func(t *testing.T) {
+		setFlag(t, "^TestNope$")
+		require.Empty(t, applyTestifyMFilter(methods))
 	})
 }
 


### PR DESCRIPTION
## What changed?

Use `-testify.m` in parallelsuite to filter methods to execute.

## Why?

VSCode sets the `-testify.m` to run a single test in isolation. 

## How did you test it?
- [ ] built
- [x] run locally and tested manually in VSCode
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
