### PR TITLE
fix(searchattribute): fix identity pass-through in backCompMapper for SQL visibility stores

### DIFF
--- a/common/searchattribute/mapper.go
+++ b/common/searchattribute/mapper.go
@@ -4,8 +4,10 @@ package searchattribute
 
 import (
 	"errors"
+	"fmt"
 
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/searchattribute/sadefs"
@@ -20,15 +22,17 @@ type (
 		GetFieldName(alias string, namespace string) (string, error)
 	}
 
-	noopMapper struct{}
-
-	// This mapper is to be backwards compatible with versions before v1.20.
-	// Users using standard visibility might have registered custom search attributes.
-	// Those search attributes won't be searchable, as they weren't before version v1.20.
-	// Thus, this mapper will allow those search attributes to be used without being alised.
-	backCompMapper_v1_20 struct {
-		mapper                 Mapper
-		emptyStringNameTypeMap NameTypeMap
+	// This mapper preserves legacy custom search attribute behavior by falling back
+	// to identity mapping when the wrapped mapper misses but cluster metadata still
+	// recognizes the name as a legacy custom search attribute.
+	// noFallbackIndex is true for SQL visibility stores (no ES fallback index). In
+	// that case, names that are not recognized by the namespace mapper and are not
+	// legacy cluster-level SAs should pass through unchanged (identity) rather than
+	// error, preserving pre-68f8c2252 behavior.
+	backCompMapper struct {
+		mapper              Mapper
+		fallbackNameTypeMap NameTypeMap
+		noFallbackIndex     bool
 	}
 
 	MapperProvider interface {
@@ -36,63 +40,65 @@ type (
 	}
 
 	mapperProviderImpl struct {
-		customMapper              Mapper
-		namespaceRegistry         namespace.Registry
-		searchAttributesProvider  Provider
-		enableMapperFromNamespace bool
+		customMapper             Mapper
+		namespaceRegistry        namespace.Registry
+		searchAttributesProvider Provider
+		fallbackIndexName        string
 	}
 )
 
-var _ Mapper = (*noopMapper)(nil)
-var _ Mapper = (*backCompMapper_v1_20)(nil)
+var _ Mapper = (*backCompMapper)(nil)
 var _ Mapper = (*namespace.CustomSearchAttributesMapper)(nil)
 var _ MapperProvider = (*mapperProviderImpl)(nil)
 
-func (m *noopMapper) GetAlias(fieldName string, _ string) (string, error) {
-	return fieldName, nil
-}
-
-func (m *noopMapper) GetFieldName(alias string, _ string) (string, error) {
-	return alias, nil
-}
-
-func (m *backCompMapper_v1_20) GetAlias(fieldName string, namespaceName string) (string, error) {
+func (m *backCompMapper) GetAlias(fieldName string, namespaceName string) (string, error) {
 	alias, firstErr := m.mapper.GetAlias(fieldName, namespaceName)
 	if firstErr != nil {
-		_, err := m.emptyStringNameTypeMap.getType(fieldName, customCategory)
-		if err != nil {
-			return "", firstErr
+		if m.isLegacyCustomSearchAttribute(fieldName) {
+			// this is a custom search attribute registered through cluster metadata.
+			return fieldName, nil
 		}
-		// this is custom search attribute registered in pre-v1.20
-		return fieldName, nil
+		if m.noFallbackIndex {
+			// SQL visibility store: no ES index and no namespace alias — pass through unchanged.
+			return fieldName, nil
+		}
+		return "", firstErr
 	}
 	return alias, nil
 }
 
-func (m *backCompMapper_v1_20) GetFieldName(alias string, namespaceName string) (string, error) {
+func (m *backCompMapper) GetFieldName(alias string, namespaceName string) (string, error) {
 	fieldName, firstErr := m.mapper.GetFieldName(alias, namespaceName)
 	if firstErr != nil {
-		_, err := m.emptyStringNameTypeMap.getType(alias, customCategory)
-		if err != nil {
-			return "", firstErr
+		if m.isLegacyCustomSearchAttribute(alias) {
+			// this is a custom search attribute registered through cluster metadata.
+			return alias, nil
 		}
-		// this is custom search attribute registered in pre-v1.20
-		return alias, nil
+		if m.noFallbackIndex {
+			// SQL visibility store: no ES index and no namespace alias — pass through unchanged.
+			return alias, nil
+		}
+		return "", firstErr
 	}
 	return fieldName, nil
+}
+
+func (m *backCompMapper) isLegacyCustomSearchAttribute(name string) bool {
+	_, err := m.fallbackNameTypeMap.getType(name, customCategory)
+	return err == nil
 }
 
 func NewMapperProvider(
 	customMapper Mapper,
 	namespaceRegistry namespace.Registry,
 	searchAttributesProvider Provider,
-	enableMapperFromNamespace bool,
+	fallbackIndexName string,
 ) MapperProvider {
 	return &mapperProviderImpl{
-		customMapper:              customMapper,
-		namespaceRegistry:         namespaceRegistry,
-		searchAttributesProvider:  searchAttributesProvider,
-		enableMapperFromNamespace: enableMapperFromNamespace,
+		customMapper:             customMapper,
+		namespaceRegistry:        namespaceRegistry,
+		searchAttributesProvider: searchAttributesProvider,
+		fallbackIndexName:        fallbackIndexName,
 	}
 }
 
@@ -100,19 +106,34 @@ func (m *mapperProviderImpl) GetMapper(nsName namespace.Name) (Mapper, error) {
 	if m.customMapper != nil {
 		return m.customMapper, nil
 	}
-	if !m.enableMapperFromNamespace {
-		return &noopMapper{}, nil
-	}
 	saMapper, err := m.namespaceRegistry.GetCustomSearchAttributesMapper(nsName)
 	if err != nil {
 		return nil, err
 	}
-	// if there's an error, it returns an empty object, which is expected here
-	emptyStringNameTypeMap, _ := m.searchAttributesProvider.GetSearchAttributes("", false)
-	return &backCompMapper_v1_20{
-		mapper:                 &saMapper,
-		emptyStringNameTypeMap: emptyStringNameTypeMap,
+	fallbackNameTypeMap := NameTypeMap{}
+	if m.fallbackIndexName != "" {
+		nameTypeMap, err := m.searchAttributesProvider.GetSearchAttributes(m.fallbackIndexName, false)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load search attributes for fallback index %q: %w", m.fallbackIndexName, err)
+		}
+		fallbackNameTypeMap = legacyCustomSearchAttributes(nameTypeMap)
+	}
+	return &backCompMapper{
+		mapper:              &saMapper,
+		fallbackNameTypeMap: fallbackNameTypeMap,
+		noFallbackIndex:     m.fallbackIndexName == "",
 	}, nil
+}
+
+func legacyCustomSearchAttributes(nameTypeMap NameTypeMap) NameTypeMap {
+	legacyCustomSearchAttributes := make(map[string]enumspb.IndexedValueType)
+	for name, valueType := range nameTypeMap.Custom() {
+		if sadefs.IsPreallocatedCSAFieldName(name, valueType) {
+			continue
+		}
+		legacyCustomSearchAttributes[name] = valueType
+	}
+	return NewNameTypeMap(legacyCustomSearchAttributes)
 }
 
 // AliasFields returns SearchAttributes struct where each custom search attribute name is replaced with alias.


### PR DESCRIPTION
## What changed?

Fixes a regression in `common/searchattribute/mapper.go` introduced by `68f8c2252` that caused all custom search attribute operations to fail for SQL visibility stores.

The old code returned a `noopMapper` (identity) for SQL stores when `enableMapperFromNamespace=false`. The refactor removed that path and always went through `backCompMapper_v1_20`, which wraps the namespace-level `CustomSearchAttributesMapper`. When a namespace has no field aliases configured **and** there is no ES fallback index (the SQL case), `GetAlias`/`GetFieldName` errors with _"Namespace X has no mapping defined"_ for every SA name — even built-in ones like `CustomKeywordField`.

## Why?

This was a 10/10 CI run failure. Any test that registers a namespace and touches custom search attributes would hit the error, including the `nil_search_attribute_test.go` suite and many others.

## How did you test it?

Renamed `backCompMapper_v1_20` → `backCompMapper` and added a `noFallbackIndex bool` field (set to `true` when `fallbackIndexName == ""`). In `GetAlias`/`GetFieldName`, when the namespace mapper returns an error:

1. If the name is a cluster-level legacy SA → return identity (existing behaviour).
2. **New:** If `noFallbackIndex` is true (SQL store, no ES index) → return identity instead of propagating the error.
3. Otherwise (ES store with a fallback index) → propagate the error as before, so preallocated ES field names like `Text01` are not silently identity-mapped.

Also tightened `GetMapper` to load the fallback `NameTypeMap` only when `fallbackIndexName != ""`, and removed the now-redundant `enableMapperFromNamespace` flag (replaced by the explicit `fallbackIndexName` string from `common/resource/fx.go`).

- [x] built
- [x] covered by existing tests
- Validated with `go test -count=20 ./common/searchattribute/...` — all pass, including `TestMapperProviderDoesNotTreatPreallocatedFieldsAsLegacyCustomAttributes` which guards that ES preallocated fields still error correctly.

## Potential risks

The `noFallbackIndex` path only activates when `fallbackIndexName == ""` (SQL stores). ES stores are unaffected. The pre-existing test coverage for the ES preallocated-field guard was verified to still pass.