### PR TITLE
Fix visibility func test nil panic

### DIFF
--- a/common/persistence/visibility/store/query/converter_test.go
+++ b/common/persistence/visibility/store/query/converter_test.go
@@ -23,16 +23,6 @@ const (
 	testNamespaceID   = namespace.ID("test-namespace-id")
 )
 
-type identityMapper struct{}
-
-func (identityMapper) GetAlias(fieldName string, _ string) (string, error) {
-	return fieldName, nil
-}
-
-func (identityMapper) GetFieldName(alias string, _ string) (string, error) {
-	return alias, nil
-}
-
 func TestWithSearchAttributeInterceptor(t *testing.T) {
 	t.Parallel()
 	r := require.New(t)
@@ -1927,7 +1917,7 @@ func TestQueryConverter_ResolveSearchAttributeAlias(t *testing.T) {
 			)
 
 			if tc.useNoopMapper {
-				queryConverter.saMapper = identityMapper{}
+				queryConverter.saMapper = &searchattribute.NoopMapper{}
 			}
 
 			fn, ft, err := queryConverter.resolveSearchAttributeAlias(tc.in)

--- a/common/searchattribute/mapper.go
+++ b/common/searchattribute/mapper.go
@@ -22,6 +22,9 @@ type (
 		GetFieldName(alias string, namespace string) (string, error)
 	}
 
+	// NoopMapper is an identity mapper that returns all field names and aliases unchanged.
+	NoopMapper struct{}
+
 	// This mapper preserves legacy custom search attribute behavior by falling back
 	// to identity mapping when the wrapped mapper misses but cluster metadata still
 	// recognizes the name as a legacy custom search attribute.
@@ -42,9 +45,18 @@ type (
 	}
 )
 
+var _ Mapper = (*NoopMapper)(nil)
 var _ Mapper = (*backCompMapper)(nil)
 var _ Mapper = (*namespace.CustomSearchAttributesMapper)(nil)
 var _ MapperProvider = (*mapperProviderImpl)(nil)
+
+func (*NoopMapper) GetAlias(fieldName string, _ string) (string, error) {
+	return fieldName, nil
+}
+
+func (*NoopMapper) GetFieldName(alias string, _ string) (string, error) {
+	return alias, nil
+}
 
 func (m *backCompMapper) GetAlias(fieldName string, namespaceName string) (string, error) {
 	alias, firstErr := m.mapper.GetAlias(fieldName, namespaceName)

--- a/common/searchattribute/test_provider.go
+++ b/common/searchattribute/test_provider.go
@@ -145,6 +145,9 @@ func (t *TestMapper) GetFieldName(alias string, namespace string) (string, error
 }
 
 func NewTestMapperProvider(customMapper Mapper) MapperProvider {
+	if customMapper == nil {
+		customMapper = &NoopMapper{}
+	}
 	return &testMapperProvider{mapper: customMapper}
 }
 


### PR DESCRIPTION
## What changed?
Re-add noop mapper to fallback for visibility functional tests.

## Why?
Fix visibility func test nil panic. https://github.com/temporalio/temporal/pull/9664 introduced regressions, though somehow passed CI checks, where all visibility tests would panic upon checking the namespace mapper, which is a nil pointer. This change just points these to a noop mapper instance.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s).
