### PR TITLE
Cover replication streaming endpoint with authorization

### DIFF
--- a/common/authorization/interceptor.go
+++ b/common/authorization/interceptor.go
@@ -92,6 +92,7 @@ type Interceptor struct {
 	exposeAuthorizerErrors       dynamicconfig.BoolPropertyFn
 	enableCrossNamespaceCommands dynamicconfig.BoolPropertyFn
 	enablePrincipalPropagation   dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	disableStreamingAuthorizer   dynamicconfig.BoolPropertyFn
 }
 
 // NewInterceptor creates an authorization interceptor.
@@ -107,6 +108,7 @@ func NewInterceptor(
 	exposeAuthorizerErrors dynamicconfig.BoolPropertyFn,
 	enableCrossNamespaceCommands dynamicconfig.BoolPropertyFn,
 	enablePrincipalPropagation dynamicconfig.BoolPropertyFnWithNamespaceFilter,
+	disableStreamingAuthorizer dynamicconfig.BoolPropertyFn,
 ) *Interceptor {
 	return &Interceptor{
 		claimMapper:                  claimMapper,
@@ -120,6 +122,7 @@ func NewInterceptor(
 		exposeAuthorizerErrors:       exposeAuthorizerErrors,
 		enableCrossNamespaceCommands: enableCrossNamespaceCommands,
 		enablePrincipalPropagation:   enablePrincipalPropagation,
+		disableStreamingAuthorizer:   disableStreamingAuthorizer,
 	}
 }
 
@@ -189,34 +192,41 @@ func (a *Interceptor) InterceptStream(
 	handler grpc.StreamHandler,
 ) error {
 	ctx := ss.Context()
-	tlsConnection := TLSInfoFromContext(ctx)
+	bypassAuth := a.disableStreamingAuthorizer()
+	if !bypassAuth {
+		tlsConnection := TLSInfoFromContext(ctx)
 
-	authInfo := a.GetAuthInfo(tlsConnection, headers.NewGRPCHeaderGetter(ctx), func() string {
-		// JWTAudienceMapper only supports UnaryServerInfo; no request is available at stream init.
-		return ""
-	})
+		authInfo := a.GetAuthInfo(tlsConnection, headers.NewGRPCHeaderGetter(ctx), func() string {
+			// JWTAudienceMapper only supports UnaryServerInfo; no request is available at stream init.
+			return ""
+		})
 
-	var claims *Claims
-	if authInfo != nil {
-		var err error
-		claims, err = a.GetClaims(authInfo)
-		if err != nil {
-			a.logger.Error("Authorization error", tag.Error(err))
-			return errUnauthorized
+		var claims *Claims
+		if authInfo != nil {
+			var err error
+			claims, err = a.GetClaims(authInfo)
+			if err != nil {
+				a.logger.Error("Authorization error", tag.Error(err))
+				return errUnauthorized
+			}
+			ctx = a.EnhanceContext(ctx, authInfo, claims)
 		}
-		ctx = a.EnhanceContext(ctx, authInfo, claims)
-	}
 
-	if a.authorizer != nil {
-		// Namespace is not available in the stream handshake (no initial request body).
-		ct := &CallTarget{
-			Namespace: "",
-			APIName:   info.FullMethod,
-			Request:   nil,
-		}
-		if err := a.Authorize(ctx, claims, ct); err != nil {
-			a.logger.Error("Authorization error", tag.Error(err))
-			return err
+		// Always strip inbound principal headers to prevent external callers from
+		// spoofing principal identity, regardless of whether the authorizer is enabled.
+		ctx = headers.StripPrincipal(ctx)
+
+		if a.authorizer != nil {
+			// Namespace is not available in the stream handshake (no initial request body).
+			ct := &CallTarget{
+				Namespace: "",
+				APIName:   info.FullMethod,
+				Request:   nil,
+			}
+			if _, err := a.Authorize(ctx, claims, ct); err != nil {
+				a.logger.Error("Authorization error", tag.Error(err))
+				return err
+			}
 		}
 	}
 

--- a/common/authorization/interceptor.go
+++ b/common/authorization/interceptor.go
@@ -181,6 +181,56 @@ func (a *Interceptor) Intercept(
 	return handler(ctx, req)
 }
 
+// InterceptStream is a gRPC stream server interceptor that enforces authorization.
+func (a *Interceptor) InterceptStream(
+	srv any,
+	ss grpc.ServerStream,
+	info *grpc.StreamServerInfo,
+	handler grpc.StreamHandler,
+) error {
+	ctx := ss.Context()
+	tlsConnection := TLSInfoFromContext(ctx)
+
+	authInfo := a.GetAuthInfo(tlsConnection, headers.NewGRPCHeaderGetter(ctx), func() string {
+		// JWTAudienceMapper only supports UnaryServerInfo; no request is available at stream init.
+		return ""
+	})
+
+	var claims *Claims
+	if authInfo != nil {
+		var err error
+		claims, err = a.GetClaims(authInfo)
+		if err != nil {
+			a.logger.Error("Authorization error", tag.Error(err))
+			return errUnauthorized
+		}
+		ctx = a.EnhanceContext(ctx, authInfo, claims)
+	}
+
+	if a.authorizer != nil {
+		// Namespace is not available in the stream handshake (no initial request body).
+		ct := &CallTarget{
+			Namespace: "",
+			APIName:   info.FullMethod,
+			Request:   nil,
+		}
+		if err := a.Authorize(ctx, claims, ct); err != nil {
+			a.logger.Error("Authorization error", tag.Error(err))
+			return err
+		}
+	}
+
+	return handler(srv, &wrappedServerStream{ServerStream: ss, ctx: ctx})
+}
+
+// wrappedServerStream wraps grpc.ServerStream to allow replacing the context.
+type wrappedServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (w *wrappedServerStream) Context() context.Context { return w.ctx }
+
 // GetAuthInfo extracts auth info from TLS info and headers.
 // Returns nil if either the policy's claimMapper or authorizer are nil or when there is no auth information in the
 // provided TLS info or headers.

--- a/common/authorization/interceptor_test.go
+++ b/common/authorization/interceptor_test.go
@@ -639,3 +639,150 @@ func (s *authorizerInterceptorSuite) TestMultipleTargetNamespaces() {
 	s.True(res.(bool))
 	s.NoError(err)
 }
+
+// mockServerStream is a minimal grpc.ServerStream for testing InterceptStream.
+type mockServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (m *mockServerStream) Context() context.Context { return m.ctx }
+
+var streamInfo = &grpc.StreamServerInfo{FullMethod: "/temporal.server.api.adminservice.v1.AdminService/StreamWorkflowReplicationMessages"}
+
+func (s *authorizerInterceptorSuite) TestInterceptStream_Authorized() {
+	streamTarget := &CallTarget{
+		Namespace: "",
+		APIName:   streamInfo.FullMethod,
+		Request:   nil,
+	}
+	s.mockMetricsHandler.EXPECT().WithTags(
+		metrics.OperationTag(metrics.AuthorizationScope),
+		metrics.NamespaceUnknownTag(),
+	).Return(s.mockMetricsHandler)
+	s.mockAuthorizer.EXPECT().Authorize(gomock.Any(), nil, streamTarget).
+		Return(Result{Decision: DecisionAllow}, nil)
+
+	handlerCalled := false
+	streamHandler := func(srv any, stream grpc.ServerStream) error {
+		handlerCalled = true
+		return nil
+	}
+
+	ss := &mockServerStream{ctx: ctx}
+	err := s.interceptor.InterceptStream(nil, ss, streamInfo, streamHandler)
+	s.NoError(err)
+	s.True(handlerCalled)
+}
+
+func (s *authorizerInterceptorSuite) TestInterceptStream_Unauthorized() {
+	streamTarget := &CallTarget{
+		Namespace: "",
+		APIName:   streamInfo.FullMethod,
+		Request:   nil,
+	}
+	s.mockMetricsHandler.EXPECT().WithTags(
+		metrics.OperationTag(metrics.AuthorizationScope),
+		metrics.NamespaceUnknownTag(),
+	).Return(s.mockMetricsHandler)
+	s.mockAuthorizer.EXPECT().Authorize(gomock.Any(), nil, streamTarget).
+		Return(Result{Decision: DecisionDeny}, nil)
+	s.mockMetricsHandler.EXPECT().Counter(metrics.ServiceErrUnauthorizedCounter.Name()).Return(metrics.NoopCounterMetricFunc)
+
+	handlerCalled := false
+	streamHandler := func(srv any, stream grpc.ServerStream) error {
+		handlerCalled = true
+		return nil
+	}
+
+	ss := &mockServerStream{ctx: ctx}
+	err := s.interceptor.InterceptStream(nil, ss, streamInfo, streamHandler)
+	s.Error(err)
+	s.False(handlerCalled)
+}
+
+func (s *authorizerInterceptorSuite) TestInterceptStream_AuthDisabled() {
+	// When claimMapper and authorizer are nil, the interceptor should be a passthrough.
+	interceptor := NewInterceptor(
+		nil, // claimMapper
+		nil, // authorizer
+		s.mockMetricsHandler,
+		log.NewNoopLogger(),
+		mockNamespaceChecker(testNamespace),
+		nil,
+		"",
+		"",
+		dynamicconfig.GetBoolPropertyFn(false),
+	)
+
+	handlerCalled := false
+	streamHandler := func(srv any, stream grpc.ServerStream) error {
+		handlerCalled = true
+		return nil
+	}
+
+	ss := &mockServerStream{ctx: ctx}
+	err := interceptor.InterceptStream(nil, ss, streamInfo, streamHandler)
+	s.NoError(err)
+	s.True(handlerCalled)
+}
+
+func (s *authorizerInterceptorSuite) TestInterceptStream_InvalidToken() {
+	interceptor := NewInterceptor(
+		s.mockClaimMapper,
+		s.mockAuthorizer,
+		s.mockMetricsHandler,
+		log.NewNoopLogger(),
+		mockNamespaceChecker(testNamespace),
+		nil,
+		"",
+		"",
+		dynamicconfig.GetBoolPropertyFn(false),
+	)
+
+	// Provide an incoming context with an auth token so GetAuthInfo returns non-nil.
+	inCtx := metadata.NewIncomingContext(ctx, metadata.Pairs("authorization", "bad-token"))
+	authInfo := &AuthInfo{AuthToken: "bad-token"}
+	claimErr := errors.New("invalid token")
+	s.mockClaimMapper.EXPECT().GetClaims(authInfo).Return(nil, claimErr)
+
+	handlerCalled := false
+	streamHandler := func(srv any, stream grpc.ServerStream) error {
+		handlerCalled = true
+		return nil
+	}
+
+	ss := &mockServerStream{ctx: inCtx}
+	err := interceptor.InterceptStream(nil, ss, streamInfo, streamHandler)
+	s.Error(err)
+	s.False(handlerCalled)
+}
+
+func (s *authorizerInterceptorSuite) TestInterceptStream_ContextPropagated() {
+	// Verify the handler receives a wrapped stream with the modified context.
+	streamTarget := &CallTarget{
+		Namespace: "",
+		APIName:   streamInfo.FullMethod,
+		Request:   nil,
+	}
+	s.mockMetricsHandler.EXPECT().WithTags(
+		metrics.OperationTag(metrics.AuthorizationScope),
+		metrics.NamespaceUnknownTag(),
+	).Return(s.mockMetricsHandler)
+	s.mockAuthorizer.EXPECT().Authorize(gomock.Any(), nil, streamTarget).
+		Return(Result{Decision: DecisionAllow}, nil)
+
+	// Inject a spoofed principal header; it must be stripped in the handler's context.
+	inCtx := metadata.NewIncomingContext(ctx, metadata.MD{})
+
+	var handlerCtx context.Context
+	streamHandler := func(srv any, stream grpc.ServerStream) error {
+		handlerCtx = stream.Context()
+		return nil
+	}
+
+	ss := &mockServerStream{ctx: inCtx}
+	err := s.interceptor.InterceptStream(nil, ss, streamInfo, streamHandler)
+	s.NoError(err)
+	s.NotNil(handlerCtx)
+}

--- a/common/authorization/interceptor_test.go
+++ b/common/authorization/interceptor_test.go
@@ -87,6 +87,7 @@ func (s *authorizerInterceptorSuite) SetupTest() {
 		dynamicconfig.GetBoolPropertyFn(false), // exposeAuthorizerErrors
 		dynamicconfig.GetBoolPropertyFn(false), // enableCrossNamespaceCommands
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false), // enablePrincipalPropagation
+		dynamicconfig.GetBoolPropertyFn(false),                    // disableStreamingAuthorizer
 	)
 	s.handler = func(ctx context.Context, req any) (any, error) { return true, nil }
 }
@@ -163,6 +164,7 @@ func (s *authorizerInterceptorSuite) TestAuthorizationFailedExposed() {
 		dynamicconfig.GetBoolPropertyFn(true),  // exposeAuthorizerErrors
 		dynamicconfig.GetBoolPropertyFn(false), // enableCrossNamespaceCommands
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false), // enablePrincipalPropagation
+		dynamicconfig.GetBoolPropertyFn(false),                    // disableStreamingAuthorizer
 	)
 
 	authErr := serviceerror.NewInternal("intentional test failure")
@@ -197,6 +199,7 @@ func (s *authorizerInterceptorSuite) TestNoopClaimMapperWithoutTLS() {
 		dynamicconfig.GetBoolPropertyFn(false), // exposeAuthorizerErrors
 		dynamicconfig.GetBoolPropertyFn(false), // enableCrossNamespaceCommands
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false), // enablePrincipalPropagation
+		dynamicconfig.GetBoolPropertyFn(false),                    // disableStreamingAuthorizer
 	)
 	_, err := interceptor.Intercept(ctx, describeNamespaceRequest, describeNamespaceInfo, s.handler)
 	s.NoError(err)
@@ -215,6 +218,7 @@ func (s *authorizerInterceptorSuite) TestAlternateHeaders() {
 		dynamicconfig.GetBoolPropertyFn(false), // exposeAuthorizerErrors
 		dynamicconfig.GetBoolPropertyFn(false), // enableCrossNamespaceCommands
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false), // enablePrincipalPropagation
+		dynamicconfig.GetBoolPropertyFn(false),                    // disableStreamingAuthorizer
 	)
 
 	cases := []struct {
@@ -325,6 +329,7 @@ func (s *authorizerInterceptorSuite) newCrossNamespaceInterceptor(namespaces ...
 		dynamicconfig.GetBoolPropertyFn(false), // exposeAuthorizerErrors
 		dynamicconfig.GetBoolPropertyFn(true),  // enableCrossNamespaceCommands
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false), // enablePrincipalPropagation
+		dynamicconfig.GetBoolPropertyFn(false),                    // disableStreamingAuthorizer
 	)
 }
 
@@ -545,6 +550,7 @@ func (s *authorizerInterceptorSuite) TestPrincipalPropagation_Enabled() {
 		dynamicconfig.GetBoolPropertyFn(false), // exposeAuthorizerErrors
 		dynamicconfig.GetBoolPropertyFn(false), // enableCrossNamespaceCommands
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true), // enablePrincipalPropagation
+		dynamicconfig.GetBoolPropertyFn(false),                   // disableStreamingAuthorizer
 	)
 
 	inCtx := metadata.NewIncomingContext(ctx, metadata.MD{})
@@ -713,6 +719,9 @@ func (s *authorizerInterceptorSuite) TestInterceptStream_AuthDisabled() {
 		"",
 		"",
 		dynamicconfig.GetBoolPropertyFn(false),
+		dynamicconfig.GetBoolPropertyFn(false),
+		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
+		dynamicconfig.GetBoolPropertyFn(false),
 	)
 
 	handlerCalled := false
@@ -737,6 +746,9 @@ func (s *authorizerInterceptorSuite) TestInterceptStream_InvalidToken() {
 		nil,
 		"",
 		"",
+		dynamicconfig.GetBoolPropertyFn(false),
+		dynamicconfig.GetBoolPropertyFn(false),
+		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
 		dynamicconfig.GetBoolPropertyFn(false),
 	)
 

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -150,6 +150,11 @@ for signal / start / signal with start API if namespace is not active`,
 		false,
 		`EnableCrossNamespaceCommands is the key to enable commands for external namespaces`,
 	)
+	DisableStreamingAuthorizer = NewGlobalBoolSetting(
+		"system.disableStreamingAuthorizer",
+		false,
+		`DisableStreamingAuthorizer is the key to disable the auth on streaming endpoint`,
+	)
 	ClusterMetadataRefreshInterval = NewGlobalDurationSetting(
 		"system.clusterMetadataRefreshInterval",
 		time.Minute,

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -184,6 +184,7 @@ func AuthorizationInterceptorProvider(
 		serviceConfig.ExposeAuthorizerErrors,
 		dynamicconfig.EnableCrossNamespaceCommands.Get(dc),
 		dynamicconfig.EnablePrincipalPropagation.Get(dc),
+		dynamicconfig.DisableStreamingAuthorizer.Get(dc),
 	)
 }
 

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -290,6 +290,7 @@ func GrpcServerOptionsProvider(
 	unaryInterceptors = append(unaryInterceptors, retryableInterceptor.Intercept)
 
 	streamInterceptor := []grpc.StreamServerInterceptor{
+		authInterceptor.InterceptStream,
 		telemetryInterceptor.StreamIntercept,
 	}
 	if len(customStreamInterceptors) > 0 {

--- a/service/frontend/nexus_handler_test.go
+++ b/service/frontend/nexus_handler_test.go
@@ -130,6 +130,7 @@ func newOperationContext(options contextOptions) *operationContext {
 		dynamicconfig.GetBoolPropertyFn(false), // exposeAuthorizerErrors
 		dynamicconfig.GetBoolPropertyFn(false), // enableCrossNamespaceCommands
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false), // enablePrincipalPropagation
+		dynamicconfig.GetBoolPropertyFn(false),                    // disableStreamingAuthorizer
 	)
 	oc.namespaceConcurrencyLimitInterceptor = interceptor.NewConcurrentRequestLimitInterceptor(
 		nil,


### PR DESCRIPTION
## What changed?
Cover replication streaming endpoint with authorization

## Why?
Cover replication streaming endpoint with authorization

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

