### PR TITLE
Fix dynamicConfigOverrides defaults getting tied to test's lifecycle

### DIFF
--- a/tests/testcore/dynamic_config_overrides.go
+++ b/tests/testcore/dynamic_config_overrides.go
@@ -25,7 +25,7 @@ var (
 	//        But that means tests in the same suite can't be run in parallel. This is not a problem because testify
 	//        doesn't allow parallel execution of tests in the same suite anyway. If one day, it is allowed,
 	//        unique namespaces with overrides per namespace should be used for tests that require overrides.
-	dynamicConfigOverrides = map[dynamicconfig.Key]any{
+	defaultDynamicConfigOverrides = map[dynamicconfig.Key]any{
 		dynamicconfig.FrontendRPS.Key():                                         3000,
 		dynamicconfig.FrontendMaxNamespaceVisibilityRPSPerInstance.Key():        50,
 		dynamicconfig.FrontendMaxNamespaceVisibilityBurstRatioPerInstance.Key(): 1,

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -633,7 +633,7 @@ func (s *FunctionalTestBase) DurationNear(value, target, tolerance time.Duration
 }
 
 func (s *FunctionalTestBase) OverrideDynamicConfig(setting dynamicconfig.GenericSetting, value any) (cleanup func()) {
-	return s.testCluster.host.overrideDynamicConfig(s.T(), setting.Key(), value)
+	return s.testCluster.host.overrideDynamicConfigForTest(s.T(), setting.Key(), value)
 }
 
 // InjectHook sets a test hook inside the cluster.

--- a/tests/testcore/onebox.go
+++ b/tests/testcore/onebox.go
@@ -231,11 +231,13 @@ func newTemporal(t *testing.T, params *TemporalParams) *TemporalImpl {
 	outputFile := fmt.Sprintf("/tmp/replication_stream_messages_%s.txt", clusterName)
 	impl.replicationStreamRecorder.SetOutputFile(outputFile)
 
-	for k, v := range dynamicConfigOverrides {
-		impl.overrideDynamicConfig(t, k, v)
+	// Global defaults: applied without cleanup so they persist across cluster reuse.
+	for k, v := range defaultDynamicConfigOverrides {
+		impl.dcClient.PartialOverrideValue(k, v)
 	}
+	// Per-test overrides: cleaned up when the creating test finishes.
 	for k, v := range params.DynamicConfigOverrides {
-		impl.overrideDynamicConfig(t, k, v)
+		impl.overrideDynamicConfigForTest(t, k, v)
 	}
 
 	return impl
@@ -966,7 +968,8 @@ func sdkClientFactoryProvider(
 	)
 }
 
-func (c *TemporalImpl) overrideDynamicConfig(t *testing.T, name dynamicconfig.Key, value any) func() {
+// overrideDynamicConfigForTest overrides a dynamic config value for the duration of the test.
+func (c *TemporalImpl) overrideDynamicConfigForTest(t *testing.T, name dynamicconfig.Key, value any) func() {
 	cleanup := c.dcClient.PartialOverrideValue(name, value)
 	t.Cleanup(cleanup)
 	return cleanup

--- a/tests/testcore/test_cluster.go
+++ b/tests/testcore/test_cluster.go
@@ -617,7 +617,7 @@ func (tc *TestCluster) GetTaskQueueRecorder() *TaskQueueRecorder {
 }
 
 func (tc *TestCluster) OverrideDynamicConfig(t *testing.T, key dynamicconfig.GenericSetting, value any) (cleanup func()) {
-	return tc.host.overrideDynamicConfig(t, key.Key(), value)
+	return tc.host.overrideDynamicConfigForTest(t, key.Key(), value)
 }
 
 var errCannotAddCACertToPool = errors.New("failed adding CA to pool")

--- a/tests/testcore/test_cluster_pool_test.go
+++ b/tests/testcore/test_cluster_pool_test.go
@@ -1,0 +1,27 @@
+package testcore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/dynamicconfig"
+)
+
+func TestGlobalOverridesSurviveTestCleanup(t *testing.T) {
+	var dcClient *dynamicconfig.MemoryClient
+
+	t.Run("create", func(t *testing.T) {
+		impl := newTemporal(t, &TemporalParams{
+			ClusterMetadataConfig: &cluster.Config{},
+		})
+		dcClient = impl.dcClient
+	})
+	// "create" subtest finished — its t.Cleanup has run
+	// but we expect global dynamic config overrides to still be in place.
+	for k, v := range defaultDynamicConfigOverrides {
+		got := dcClient.GetValue(k)
+		require.NotEmpty(t, got, "key %s missing after cleanup", k)
+		require.Equal(t, v, got[0].Value, "key %s wrong after cleanup", k)
+	}
+}

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -351,7 +351,7 @@ func (e *TestEnv) OverrideDynamicConfig(setting dynamicconfig.GenericSetting, va
 			}}
 		}
 	}
-	return e.cluster.host.overrideDynamicConfig(e.t, setting.Key(), value)
+	return e.cluster.host.overrideDynamicConfigForTest(e.t, setting.Key(), value)
 }
 
 // StartGlobalMetricCapture starts a cluster-global metrics capture for this test and automatically stops it during cleanup.


### PR DESCRIPTION
## What changed?

Changed onebox.go to set global `dynamicConfigOverrides` without binding cleanup to a test, and added unit test to verify behavior works -- reused test gets the same default `dynamicConfigOverrides`.

Also renamed the existing function `overrideDynamicConfig` -> `overrideTestLevelDynamicConfig` to make it clearer that that function's dynamic config override is bounded to the test's lifecycle.

## Why?

When onebox.go sets up a new Temporal cluster, [it applies some default overrides that is not set by the test.](https://github.com/temporalio/temporal/blob/main/tests/testcore/onebox.go#L234-L236)

However, these are set via [`overrideDynamicConfig(...)`, which ties the cleanup of these configs to a specific test's lifecycle.](https://github.com/temporalio/temporal/blob/main/tests/testcore/onebox.go#L969-L973)

As a result, if we have **Test1** that gets a fresh cluster, if some **Test2** later reuses this cluster after **Test1** ends, **Test2** will not have these default `dynamicConfigOverrides` -- in fact the dynamicConfig would be empty because we cleaned it up after **Test1** finished.

These defaults should not be bounded to the lifetime of the test that instantiated the fresh cluster. 

> [!NOTE]
> Existing tests that instantiate their `env` with `testcore.WithDynamicConfigOverrides(...)` options [already get a fresh cluster](https://github.com/temporalio/temporal/blob/main/tests/testcore/test_cluster_pool.go#L152-L172), so this bug impacted tests that don't override any dynamic config options when calling `testcore.NewEnv(...)`.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

I added a `test_cluster_pool_test.go` which deterministically repros this without the code change in `onebox.go`:

Expected failure without change in onebox.go:
```
$ go test ./tests/testcore/ -run TestDedicatedClusterReuseDropsGlobalOverrides -count=1
--- FAIL: TestDedicatedClusterReuseDropsGlobalOverrides (0.05s)
    --- FAIL: TestDedicatedClusterReuseDropsGlobalOverrides/SecondUse (0.00s)
        test_cluster_pool_test.go:42:
                Error Trace:    /Users/longtran/work/forks/temporal-wt/testcore-dedicated-cluster/tests/testcore/test_cluster_pool_test.go:57
                                                        /Users/longtran/work/forks/temporal-wt/testcore-dedicated-cluster/tests/testcore/test_cluster_pool_test.go:42
                Error:          Should NOT be empty, but was []
                Test:           TestDedicatedClusterReuseDropsGlobalOverrides/SecondUse
                Messages:       global override defaults should still be present on reused cluster: key frontend.maxconcurrentbatchoperationpernamespace missing
FAIL
FAIL    go.temporal.io/server/tests/testcore    1.175s
FAIL
```

With change, it passes:
```
$ go test ./tests/testcore/ -run TestDedicatedClusterReuseDropsGlobalOverrides -count=1
ok      go.temporal.io/server/tests/testcore    1.086s
```

## Potential risks

Might be breaking changes if some tests rely on the existing bug for some reason (?)