### PR TITLE
Enable external payloads by default

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2949,7 +2949,7 @@ instead of the previous HSM backed implementation.`,
 
 	ExternalPayloadsEnabled = NewNamespaceBoolSetting(
 		"history.externalPayloadsEnabled",
-		false,
+		true,
 		`ExternalPayloadsEnabled controls whether external payload features are enabled for a namespace.`,
 	)
 

--- a/service/history/visibility_queue_task_executor.go
+++ b/service/history/visibility_queue_task_executor.go
@@ -575,10 +575,12 @@ func (t *visibilityQueueTaskExecutor) getClosedVisibilityRequest(
 	if t.externalPayloadsEnabled(namespaceEntry.Name().String()) {
 		externalPayloadCount := executionInfo.GetExecutionStats().GetExternalPayloadCount()
 		externalPayloadSizeBytes := executionInfo.GetExecutionStats().GetExternalPayloadSize()
-		externalPayloadCountPayload, _ := payload.Encode(externalPayloadCount)
-		externalPayloadSizeBytesPayload, _ := payload.Encode(externalPayloadSizeBytes)
-		base.SearchAttributes.IndexedFields[sadefs.TemporalExternalPayloadCount] = externalPayloadCountPayload
-		base.SearchAttributes.IndexedFields[sadefs.TemporalExternalPayloadSizeBytes] = externalPayloadSizeBytesPayload
+		if externalPayloadCount > 0 {
+			externalPayloadCountPayload, _ := payload.Encode(externalPayloadCount)
+			externalPayloadSizeBytesPayload, _ := payload.Encode(externalPayloadSizeBytes)
+			base.SearchAttributes.IndexedFields[sadefs.TemporalExternalPayloadCount] = externalPayloadCountPayload
+			base.SearchAttributes.IndexedFields[sadefs.TemporalExternalPayloadSizeBytes] = externalPayloadSizeBytesPayload
+		}
 	}
 
 	return &manager.RecordWorkflowExecutionClosedRequest{

--- a/tests/xdc/visibility_test.go
+++ b/tests/xdc/visibility_test.go
@@ -175,9 +175,10 @@ func (s *VisibilityTestSuite) TestSearchAttributes() {
 				return false
 			}
 			fields := resp.GetExecutions()[0].SearchAttributes.GetIndexedFields()
-			if len(fields) != 3 {
+			if len(fields) < 3 {
 				return false
 			}
+			s.Len(fields, 3)
 
 			searchValBytes := fields["CustomTextField"]
 			var searchVal string


### PR DESCRIPTION
## What changed?
Enable server support for external payloads stats by default

## Why?
https://docs.temporal.io/external-storage is in pre-release and available to anyone who wants to try it out from SDK. The server support for collecting the stats is gated by history.externalPayloadsEnabled dynamic config. Enable it by default, as otherwise the executions stats won't be available. 

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
The change enables the collection of workflow execution stats for external storage, but it is only when the users try out the pre-release feature. So in the case of problems, they can turn the dynamic config off. 
