### PR TITLE
Enable new matcher in TestTransitionDuringTransientTask and refactor waitForDeploymentDataPropagation

### DIFF
--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -4402,9 +4402,10 @@ func (s *Versioning3Suite) waitForDeploymentDataPropagation(
 		}
 	}
 	f, err := tqid.NewTaskQueueFamily(s.NamespaceID().String(), tv.TaskQueue().GetName())
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		a := assert.New(t)
 		for pt := range remaining {
-			s.NoError(err)
+			a.NoError(err)
 			partition := f.TaskQueue(pt.tp).NormalPartition(pt.part)
 			// Use lower-level GetTaskQueueUserData instead of GetWorkerBuildIdCompatibility
 			// here so that we can target activity queues.
@@ -4415,7 +4416,7 @@ func (s *Versioning3Suite) waitForDeploymentDataPropagation(
 					TaskQueue:     partition.RpcName(),
 					TaskQueueType: partition.TaskType(),
 				})
-			s.NoError(err)
+			a.NoError(err)
 			perTypes := res.GetUserData().GetData().GetPerType()
 			if perTypes != nil {
 				deploymentsData := perTypes[int32(pt.tp)].GetDeploymentData().GetDeploymentsData()
@@ -4466,7 +4467,7 @@ func (s *Versioning3Suite) waitForDeploymentDataPropagation(
 				}
 			}
 		}
-		return len(remaining) == 0
+		a.Len(remaining, 0)
 	}, 30*time.Second, 100*time.Millisecond)
 }
 
@@ -5788,10 +5789,8 @@ func (s *Versioning3Suite) TestTransitionDuringTransientTask_WithSignal() {
 // is properly set when a workflow task fails and is retried, and that the transition completes
 // successfully after a signal is sent during the retry backoff period.
 func (s *Versioning3Suite) testTransitionDuringTransientTask(withSignal bool) {
-
 	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
 	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueWritePartitions, 1)
-	s.OverrideDynamicConfig(dynamicconfig.MatchingUseNewMatcher, false)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -4467,7 +4467,7 @@ func (s *Versioning3Suite) waitForDeploymentDataPropagation(
 				}
 			}
 		}
-		a.Len(remaining, 0)
+		a.Empty(remaining)
 	}, 30*time.Second, 100*time.Millisecond)
 }
 

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -4403,7 +4403,7 @@ func (s *Versioning3Suite) waitForDeploymentDataPropagation(
 	}
 	f, err := tqid.NewTaskQueueFamily(s.NamespaceID().String(), tv.TaskQueue().GetName())
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		a := assert.New(t)
+		a := require.New(t)
 		for pt := range remaining {
 			a.NoError(err)
 			partition := f.TaskQueue(pt.tp).NormalPartition(pt.part)


### PR DESCRIPTION
## What changed?
New matcher was disabled in this particular test, enabling it so it uses the global config.

## Why?
New matcher is enabled by default now.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
None
