### PR TITLE
feat: add tdbg CLI command to get user data for a task queue partition

### DIFF
--- a/client/admin/client_gen.go
+++ b/client/admin/client_gen.go
@@ -339,6 +339,16 @@ func (c *clientImpl) MergeDLQTasks(
 	return c.client.MergeDLQTasks(ctx, request, opts...)
 }
 
+func (c *clientImpl) GetTaskQueueUserData(
+	ctx context.Context,
+	request *adminservice.GetTaskQueueUserDataRequest,
+	opts ...grpc.CallOption,
+) (*adminservice.GetTaskQueueUserDataResponse, error) {
+	ctx, cancel := c.createContext(ctx)
+	defer cancel()
+	return c.client.GetTaskQueueUserData(ctx, request, opts...)
+}
+
 func (c *clientImpl) MigrateSchedule(
 	ctx context.Context,
 	request *adminservice.MigrateScheduleRequest,

--- a/client/admin/client_gen.go
+++ b/client/admin/client_gen.go
@@ -339,16 +339,6 @@ func (c *clientImpl) MergeDLQTasks(
 	return c.client.MergeDLQTasks(ctx, request, opts...)
 }
 
-func (c *clientImpl) GetTaskQueueUserData(
-	ctx context.Context,
-	request *adminservice.GetTaskQueueUserDataRequest,
-	opts ...grpc.CallOption,
-) (*adminservice.GetTaskQueueUserDataResponse, error) {
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.GetTaskQueueUserData(ctx, request, opts...)
-}
-
 func (c *clientImpl) MigrateSchedule(
 	ctx context.Context,
 	request *adminservice.MigrateScheduleRequest,

--- a/tools/tdbg/task_queue_commands.go
+++ b/tools/tdbg/task_queue_commands.go
@@ -182,6 +182,50 @@ func AdminDescribeTaskQueuePartition(c *cli.Context, clientFactory ClientFactory
 	return nil
 }
 
+// AdminGetTaskQueueUserData returns the per-type user data for a task queue partition
+func AdminGetTaskQueueUserData(c *cli.Context, clientFactory ClientFactory) error {
+	namespace, err := getRequiredOption(c, FlagNamespace)
+	if err != nil {
+		return err
+	}
+
+	tqName, err := getRequiredOption(c, FlagTaskQueue)
+	if err != nil {
+		return err
+	}
+
+	tlTypeInt, err := StringToEnum(c.String(FlagTaskQueueType), enumspb.TaskQueueType_value)
+	if err != nil {
+		return fmt.Errorf("invalid task queue type: %w", err)
+	}
+	tqType := enumspb.TaskQueueType(tlTypeInt)
+	if tqType == enumspb.TASK_QUEUE_TYPE_UNSPECIFIED {
+		return errors.New("invalid task queue type") // nolint
+	}
+
+	partitionID := 0
+	if c.IsSet(FlagPartitionID) {
+		partitionID = c.Int(FlagPartitionID)
+	}
+
+	client := clientFactory.AdminClient(c)
+	req := &adminservice.GetTaskQueueUserDataRequest{
+		Namespace:     namespace,
+		TaskQueue:     tqName,
+		TaskQueueType: tqType,
+		PartitionId:   int32(partitionID),
+	}
+
+	ctx, cancel := newContext(c)
+	defer cancel()
+	if response, e := client.GetTaskQueueUserData(ctx, req); e != nil {
+		return fmt.Errorf("unable to get Task Queue User Data: %w", e)
+	} else {
+		prettyPrintJSONObject(c, response)
+	}
+	return nil
+}
+
 // AdminForceUnloadTaskQueuePartition forcefully unloads a task queue partition
 func AdminForceUnloadTaskQueuePartition(c *cli.Context, clientFactory ClientFactory) error {
 	// extracting the namespace

--- a/tools/tdbg/task_queue_commands.go
+++ b/tools/tdbg/task_queue_commands.go
@@ -200,7 +200,7 @@ func AdminGetTaskQueueUserData(c *cli.Context, clientFactory ClientFactory) erro
 	}
 	tqType := enumspb.TaskQueueType(tlTypeInt)
 	if tqType == enumspb.TASK_QUEUE_TYPE_UNSPECIFIED {
-		return errors.New("invalid task queue type") // nolint
+		tqType = enumspb.TASK_QUEUE_TYPE_WORKFLOW
 	}
 
 	partitionID := 0

--- a/tools/tdbg/task_queue_commands.go
+++ b/tools/tdbg/task_queue_commands.go
@@ -218,11 +218,11 @@ func AdminGetTaskQueueUserData(c *cli.Context, clientFactory ClientFactory) erro
 
 	ctx, cancel := newContext(c)
 	defer cancel()
-	if response, e := client.GetTaskQueueUserData(ctx, req); e != nil {
+	response, e := client.GetTaskQueueUserData(ctx, req)
+	if e != nil {
 		return fmt.Errorf("unable to get Task Queue User Data: %w", e)
-	} else {
-		prettyPrintJSONObject(c, response)
 	}
+	prettyPrintJSONObject(c, response)
 	return nil
 }
 

--- a/tools/tdbg/task_queue_commands_test.go
+++ b/tools/tdbg/task_queue_commands_test.go
@@ -19,6 +19,7 @@ type (
 		adminservice.AdminServiceClient
 		describeTaskQueuePartitionFn    func(request *adminservice.DescribeTaskQueuePartitionRequest) (*adminservice.DescribeTaskQueuePartitionResponse, error)
 		forceUnloadTaskQueuePartitionFn func(request *adminservice.ForceUnloadTaskQueuePartitionRequest) (*adminservice.ForceUnloadTaskQueuePartitionResponse, error)
+		getTaskQueueUserDataFn          func(request *adminservice.GetTaskQueueUserDataRequest) (*adminservice.GetTaskQueueUserDataResponse, error)
 	}
 )
 
@@ -82,6 +83,10 @@ func (t *testClient) ForceUnloadTaskQueuePartition(_ context.Context, request *a
 	return t.forceUnloadTaskQueuePartitionFn(request)
 }
 
+func (t *testClient) GetTaskQueueUserData(_ context.Context, request *adminservice.GetTaskQueueUserDataRequest, opts ...grpc.CallOption) (*adminservice.GetTaskQueueUserDataResponse, error) {
+	return t.getTaskQueueUserDataFn(request)
+}
+
 func (s *taskQueueCommandTestSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 	s.controller = gomock.NewController(s.T())
@@ -93,6 +98,9 @@ func (s *taskQueueCommandTestSuite) SetupTest() {
 		},
 		forceUnloadTaskQueuePartitionFn: func(request *adminservice.ForceUnloadTaskQueuePartitionRequest) (*adminservice.ForceUnloadTaskQueuePartitionResponse, error) {
 			return &adminservice.ForceUnloadTaskQueuePartitionResponse{}, nil
+		},
+		getTaskQueueUserDataFn: func(request *adminservice.GetTaskQueueUserDataRequest) (*adminservice.GetTaskQueueUserDataResponse, error) {
+			return &adminservice.GetTaskQueueUserDataResponse{}, nil
 		},
 	}
 	s.app = NewCliApp(func(params *Params) {
@@ -162,4 +170,41 @@ func (s *taskQueueCommandTestSuite) TestForceUnloadTaskQueuePartition() {
 			s.ErrorContainsf(resp, test.err.Error(), "error present")
 		}
 	}
+}
+
+// TestGetTaskQueueUserData tests that the cli accepts the various arguments for get-user-data.
+func (s *taskQueueCommandTestSuite) TestGetTaskQueueUserData() {
+	baseCommand := []string{"tdbg", "taskqueue", "get-user-data",
+		"--task-queue", "test"}
+
+	// Run shared test cases, skipping sticky-name (not a registered flag on this command).
+	for _, test := range testCases {
+		if len(test.inputFlags) > 0 && test.inputFlags[0] == "--sticky-name" {
+			continue
+		}
+		cliCommand := append(baseCommand, test.inputFlags...)
+		resp := s.app.Run(cliCommand)
+		if resp != nil {
+			s.ErrorContainsf(resp, test.err.Error(), "error present")
+		}
+	}
+
+	// Missing --task-queue is enforced by cli/v2 (Required: true) before the action runs.
+	s.Error(s.app.Run([]string{"tdbg", "taskqueue", "get-user-data"}))
+
+	// No --task-queue-type or --partition-id: both use their defaults and succeed.
+	s.NoError(s.app.Run([]string{"tdbg", "taskqueue", "get-user-data",
+		"--task-queue", "test"}))
+
+	// Matching client returns an error: CLI wraps and returns it.
+	errorClient := &testClient{
+		getTaskQueueUserDataFn: func(request *adminservice.GetTaskQueueUserDataRequest) (*adminservice.GetTaskQueueUserDataResponse, error) {
+			return nil, errors.New("matching unavailable")
+		},
+	}
+	errorApp := NewCliApp(func(params *Params) { params.ClientFactory = errorClient })
+	errorApp.ExitErrHandler = func(context *cli.Context, err error) {}
+	resp := errorApp.Run([]string{"tdbg", "taskqueue", "get-user-data",
+		"--task-queue", "test"})
+	s.ErrorContains(resp, "unable to get Task Queue User Data")
 }

--- a/tools/tdbg/task_queue_commands_test.go
+++ b/tools/tdbg/task_queue_commands_test.go
@@ -175,7 +175,7 @@ func (s *taskQueueCommandTestSuite) TestForceUnloadTaskQueuePartition() {
 // TestGetTaskQueueUserData tests that the cli accepts the various arguments for get-user-data.
 func (s *taskQueueCommandTestSuite) TestGetTaskQueueUserData() {
 	baseCommand := []string{"tdbg", "taskqueue", "get-user-data",
-		"--task-queue", "test"}
+		"--namespace", "default", "--task-queue", "test"}
 
 	// Run shared test cases, skipping sticky-name (not a registered flag on this command).
 	for _, test := range testCases {
@@ -184,17 +184,22 @@ func (s *taskQueueCommandTestSuite) TestGetTaskQueueUserData() {
 		}
 		cliCommand := append(baseCommand, test.inputFlags...)
 		resp := s.app.Run(cliCommand)
-		if resp != nil {
+		if test.err != nil {
 			s.ErrorContainsf(resp, test.err.Error(), "error present")
+		} else {
+			s.NoError(resp)
 		}
 	}
 
 	// Missing --task-queue is enforced by cli/v2 (Required: true) before the action runs.
-	s.Error(s.app.Run([]string{"tdbg", "taskqueue", "get-user-data"}))
+	s.Error(s.app.Run([]string{"tdbg", "taskqueue", "get-user-data", "--namespace", "default"}))
+
+	// Missing --namespace is enforced by cli/v2 (Required: true) before the action runs.
+	s.Error(s.app.Run([]string{"tdbg", "taskqueue", "get-user-data", "--task-queue", "test"}))
 
 	// No --task-queue-type or --partition-id: both use their defaults and succeed.
 	s.NoError(s.app.Run([]string{"tdbg", "taskqueue", "get-user-data",
-		"--task-queue", "test"}))
+		"--namespace", "default", "--task-queue", "test"}))
 
 	// Matching client returns an error: CLI wraps and returns it.
 	errorClient := &testClient{
@@ -205,6 +210,6 @@ func (s *taskQueueCommandTestSuite) TestGetTaskQueueUserData() {
 	errorApp := NewCliApp(func(params *Params) { params.ClientFactory = errorClient })
 	errorApp.ExitErrHandler = func(context *cli.Context, err error) {}
 	resp := errorApp.Run([]string{"tdbg", "taskqueue", "get-user-data",
-		"--task-queue", "test"})
+		"--namespace", "default", "--task-queue", "test"})
 	s.ErrorContains(resp, "unable to get Task Queue User Data")
 }

--- a/tools/tdbg/task_queue_commands_test.go
+++ b/tools/tdbg/task_queue_commands_test.go
@@ -172,9 +172,9 @@ func (s *taskQueueCommandTestSuite) TestForceUnloadTaskQueuePartition() {
 	}
 }
 
-// TestGetTaskQueueUserData tests that the cli accepts the various arguments for get-task-queue-user-data.
+// TestGetTaskQueueUserData tests that the cli accepts the various arguments for get-user-data.
 func (s *taskQueueCommandTestSuite) TestGetTaskQueueUserData() {
-	baseCommand := []string{"tdbg", "taskqueue", "get-task-queue-user-data",
+	baseCommand := []string{"tdbg", "taskqueue", "get-user-data",
 		"--namespace", "default", "--task-queue", "test"}
 
 	// Run shared test cases, skipping sticky-name (not a registered flag on this command)
@@ -194,18 +194,18 @@ func (s *taskQueueCommandTestSuite) TestGetTaskQueueUserData() {
 	}
 
 	// TASK_QUEUE_TYPE_UNSPECIFIED defaults to WORKFLOW (no error).
-	s.NoError(s.app.Run([]string{"tdbg", "taskqueue", "get-task-queue-user-data",
+	s.NoError(s.app.Run([]string{"tdbg", "taskqueue", "get-user-data",
 		"--namespace", "default", "--task-queue", "test",
 		"--task-queue-type", "TASK_QUEUE_TYPE_UNSPECIFIED"}))
 
 	// Missing --task-queue is enforced by cli/v2 (Required: true) before the action runs.
-	s.Error(s.app.Run([]string{"tdbg", "taskqueue", "get-task-queue-user-data", "--namespace", "default"}))
+	s.Error(s.app.Run([]string{"tdbg", "taskqueue", "get-user-data", "--namespace", "default"}))
 
 	// Missing --namespace is enforced by cli/v2 (Required: true) before the action runs.
-	s.Error(s.app.Run([]string{"tdbg", "taskqueue", "get-task-queue-user-data", "--task-queue", "test"}))
+	s.Error(s.app.Run([]string{"tdbg", "taskqueue", "get-user-data", "--task-queue", "test"}))
 
 	// No --task-queue-type or --partition-id: both use their defaults and succeed.
-	s.NoError(s.app.Run([]string{"tdbg", "taskqueue", "get-task-queue-user-data",
+	s.NoError(s.app.Run([]string{"tdbg", "taskqueue", "get-user-data",
 		"--namespace", "default", "--task-queue", "test"}))
 
 	// Matching client returns an error: CLI wraps and returns it.
@@ -216,7 +216,7 @@ func (s *taskQueueCommandTestSuite) TestGetTaskQueueUserData() {
 	}
 	errorApp := NewCliApp(func(params *Params) { params.ClientFactory = errorClient })
 	errorApp.ExitErrHandler = func(context *cli.Context, err error) {}
-	resp := errorApp.Run([]string{"tdbg", "taskqueue", "get-task-queue-user-data",
+	resp := errorApp.Run([]string{"tdbg", "taskqueue", "get-user-data",
 		"--namespace", "default", "--task-queue", "test"})
 	s.ErrorContains(resp, "unable to get Task Queue User Data")
 }

--- a/tools/tdbg/task_queue_commands_test.go
+++ b/tools/tdbg/task_queue_commands_test.go
@@ -172,14 +172,16 @@ func (s *taskQueueCommandTestSuite) TestForceUnloadTaskQueuePartition() {
 	}
 }
 
-// TestGetTaskQueueUserData tests that the cli accepts the various arguments for get-user-data.
+// TestGetTaskQueueUserData tests that the cli accepts the various arguments for get-task-queue-user-data.
 func (s *taskQueueCommandTestSuite) TestGetTaskQueueUserData() {
-	baseCommand := []string{"tdbg", "taskqueue", "get-user-data",
+	baseCommand := []string{"tdbg", "taskqueue", "get-task-queue-user-data",
 		"--namespace", "default", "--task-queue", "test"}
 
-	// Run shared test cases, skipping sticky-name (not a registered flag on this command).
+	// Run shared test cases, skipping sticky-name (not a registered flag on this command)
+	// and unspecified type (this command defaults to workflow instead of erroring).
 	for _, test := range testCases {
-		if len(test.inputFlags) > 0 && test.inputFlags[0] == "--sticky-name" {
+		if len(test.inputFlags) > 0 && (test.inputFlags[0] == "--sticky-name" ||
+			test.inputFlags[1] == "TASK_QUEUE_TYPE_UNSPECIFIED") {
 			continue
 		}
 		cliCommand := append(baseCommand, test.inputFlags...)
@@ -191,14 +193,19 @@ func (s *taskQueueCommandTestSuite) TestGetTaskQueueUserData() {
 		}
 	}
 
+	// TASK_QUEUE_TYPE_UNSPECIFIED defaults to WORKFLOW (no error).
+	s.NoError(s.app.Run([]string{"tdbg", "taskqueue", "get-task-queue-user-data",
+		"--namespace", "default", "--task-queue", "test",
+		"--task-queue-type", "TASK_QUEUE_TYPE_UNSPECIFIED"}))
+
 	// Missing --task-queue is enforced by cli/v2 (Required: true) before the action runs.
-	s.Error(s.app.Run([]string{"tdbg", "taskqueue", "get-user-data", "--namespace", "default"}))
+	s.Error(s.app.Run([]string{"tdbg", "taskqueue", "get-task-queue-user-data", "--namespace", "default"}))
 
 	// Missing --namespace is enforced by cli/v2 (Required: true) before the action runs.
-	s.Error(s.app.Run([]string{"tdbg", "taskqueue", "get-user-data", "--task-queue", "test"}))
+	s.Error(s.app.Run([]string{"tdbg", "taskqueue", "get-task-queue-user-data", "--task-queue", "test"}))
 
 	// No --task-queue-type or --partition-id: both use their defaults and succeed.
-	s.NoError(s.app.Run([]string{"tdbg", "taskqueue", "get-user-data",
+	s.NoError(s.app.Run([]string{"tdbg", "taskqueue", "get-task-queue-user-data",
 		"--namespace", "default", "--task-queue", "test"}))
 
 	// Matching client returns an error: CLI wraps and returns it.
@@ -209,7 +216,7 @@ func (s *taskQueueCommandTestSuite) TestGetTaskQueueUserData() {
 	}
 	errorApp := NewCliApp(func(params *Params) { params.ClientFactory = errorClient })
 	errorApp.ExitErrHandler = func(context *cli.Context, err error) {}
-	resp := errorApp.Run([]string{"tdbg", "taskqueue", "get-user-data",
+	resp := errorApp.Run([]string{"tdbg", "taskqueue", "get-task-queue-user-data",
 		"--namespace", "default", "--task-queue", "test"})
 	s.ErrorContains(resp, "unable to get Task Queue User Data")
 }

--- a/tools/tdbg/tdbg_commands.go
+++ b/tools/tdbg/tdbg_commands.go
@@ -682,6 +682,30 @@ func newAdminTaskQueueCommands(clientFactory ClientFactory) []*cli.Command {
 				return AdminForceUnloadTaskQueuePartition(c, clientFactory)
 			},
 		},
+		{
+			Name:  "get-user-data",
+			Usage: "Get per-type user data stored for a task queue",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     FlagTaskQueue,
+					Usage:    "Task Queue name",
+					Required: true,
+				},
+				&cli.StringFlag{
+					Name:  FlagTaskQueueType,
+					Value: "TASK_QUEUE_TYPE_WORKFLOW",
+					Usage: "Task Queue type: TASK_QUEUE_TYPE_WORKFLOW, TASK_QUEUE_TYPE_ACTIVITY, TASK_QUEUE_TYPE_NEXUS",
+				},
+				&cli.Int64Flag{
+					Name:  FlagPartitionID,
+					Usage: "Partition ID to fetch user data from (default 0 = root partition)",
+					Value: 0,
+				},
+			},
+			Action: func(c *cli.Context) error {
+				return AdminGetTaskQueueUserData(c, clientFactory)
+			},
+		},
 	}
 }
 

--- a/tools/tdbg/tdbg_commands.go
+++ b/tools/tdbg/tdbg_commands.go
@@ -683,7 +683,7 @@ func newAdminTaskQueueCommands(clientFactory ClientFactory) []*cli.Command {
 			},
 		},
 		{
-			Name:  "get-user-data",
+			Name:  "get-task-queue-user-data",
 			Usage: "Get per-type user data stored for a task queue",
 			Flags: []cli.Flag{
 				&cli.StringFlag{

--- a/tools/tdbg/tdbg_commands.go
+++ b/tools/tdbg/tdbg_commands.go
@@ -687,6 +687,11 @@ func newAdminTaskQueueCommands(clientFactory ClientFactory) []*cli.Command {
 			Usage: "Get per-type user data stored for a task queue",
 			Flags: []cli.Flag{
 				&cli.StringFlag{
+					Name:     FlagNamespace,
+					Usage:    "Namespace name",
+					Required: true,
+				},
+				&cli.StringFlag{
 					Name:     FlagTaskQueue,
 					Usage:    "Task Queue name",
 					Required: true,

--- a/tools/tdbg/tdbg_commands.go
+++ b/tools/tdbg/tdbg_commands.go
@@ -683,7 +683,7 @@ func newAdminTaskQueueCommands(clientFactory ClientFactory) []*cli.Command {
 			},
 		},
 		{
-			Name:  "get-task-queue-user-data",
+			Name:  "get-user-data",
 			Usage: "Get per-type user data stored for a task queue",
 			Flags: []cli.Flag{
 				&cli.StringFlag{
@@ -699,7 +699,7 @@ func newAdminTaskQueueCommands(clientFactory ClientFactory) []*cli.Command {
 				&cli.StringFlag{
 					Name:  FlagTaskQueueType,
 					Value: "TASK_QUEUE_TYPE_WORKFLOW",
-					Usage: "Task Queue type: TASK_QUEUE_TYPE_WORKFLOW, TASK_QUEUE_TYPE_ACTIVITY, TASK_QUEUE_TYPE_NEXUS",
+					Usage: "Task Queue type: TASK_QUEUE_TYPE_WORKFLOW, TASK_QUEUE_TYPE_ACTIVITY, TASK_QUEUE_TYPE_NEXUS (default TASK_QUEUE_TYPE_WORKFLOW)",
 				},
 				&cli.Int64Flag{
 					Name:  FlagPartitionID,


### PR DESCRIPTION
## What changed?                                                                                                                              
                                                                                                                                                
This PR adds a `tdbg taskqueue get-user-data` CLI command to `tdbg` to get the `TaskQueueUserData` for a particular task queue partition.

This PR depends on #9934. See #9934 for more context.
                                                                                                                                                
## Files changed
                                                                                                                                                
  | File | Change |                                         
  |---|---|
  | `tools/tdbg/tdbg_commands.go` | Registered `get-user-data` subcommand under `taskqueue` with `--namespace`, `--task-queue`,`--task-queue-type`, and `--partition-id` flags |                                                                                             
  | `tools/tdbg/task_queue_commands.go` | Implemented `AdminGetTaskQueueUserData`: reads flags, calls `AdminService.GetTaskQueueUserData`, pretty-prints response |                                                                                                                      
  | `tools/tdbg/task_queue_commands_test.go` | Added unit tests |
                                                                                                                                                
## How did you test it?                                   

  - [x] built
  - [x] run locally and tested manually
  - [x] added new unit test(s)
  - [x] added new integration test(s) — not applicable
  - [x] added new functional test(s) — not applicable (CLI change)                                                                                   
   
### Unit tests                                                                                                                                
                                                            
  | Test case | Input | Expected |
  |---|---|---|
  | Missing namespace | `--task-queue my-queue` only | Error before RPC is called |
  | Missing task queue | `--namespace default` only | Error before RPC is called |                                                              
  | Invalid task queue type | `--task-queue-type INVALID` | `StringToEnum` returns error before RPC is called |
  | Unspecified task queue type | `--task-queue-type TASK_QUEUE_TYPE_UNSPECIFIED` | Defaults to `TASK_QUEUE_TYPE_WORKFLOW`, succeeds |                   
  | Root partition (default) | Valid flags, no `--partition-id` | Calls RPC with `partition_id=0`, prints response |                            
  | Non-root partition | `--partition-id 1` | Calls RPC with `partition_id=1`, prints response |                                                
                                                                                                                                                                                                                                                                  
   
### Manual tests                                                                                                                              

  **Setup**
  ```
  make start-sqlite
  temporal operator namespace create -n default
  temporal task-queue versioning insert-assignment-rule --namespace default --task-queue my-queue --build-id "test-build-1" --rule-index 0 --yes
  temporal task-queue config set --namespace default --task-queue my-queue --task-queue-type activity --queue-rps-limit 50 --queue-rps-limit-reason "manual test"
  ```
   
  **Root partition, workflow type**                                                                                                             
  ```                                                       
  $ ./tdbg taskqueue get-user-data --namespace default --task-queue my-queue --task-queue-type TASK_QUEUE_TYPE_WORKFLOW
  {
    "version": "2"
  }                                                                                                                                             
  ```
  `version=2` reflects writes from the assignment rule; `user_data` absent as expected (versioning rules live in `versioning_data`, not         
  `per_type`).                                              

  **Root partition, activity type**
  ```
  $ ./tdbg taskqueue get-user-data --namespace default --task-queue my-queue --task-queue-type TASK_QUEUE_TYPE_ACTIVITY
  {                                                                                                                                             
    "version": "2",
    "user_data": {                                                                                                                              
      "config": {                                           
        "queueRateLimit": {
          "rateLimit": { "requestsPerSecond": 50 },                                                                                             
          "metadata": { "reason": "manual test", "updateTime": "..." }
        }                                                                                                                                       
      }                                                     
    }
  }
  ```
  `user_data` populated with the rate limit config set via `UpdateTaskQueueConfig`.
                                                                                                                                                
  **Non-root partition, workflow type**
  ```                                                                                                                                           
  $ ./tdbg taskqueue get-user-data --namespace default --task-queue my-queue --task-queue-type TASK_QUEUE_TYPE_WORKFLOW --partition-id 1
  {                                                                                                                                             
    "version": "2"
  }                                                                                                                                             
  ```                                                       
  Same version as root — replication is working.

  **Non-root partition, activity type**                                                                                                             
  ```                                                       
  $ ./tdbg taskqueue get-user-data --namespace default --task-queue my-queue --task-queue-type TASK_QUEUE_TYPE_ACTIVITY --partition-id 1
  {
    "userData": {
      "config": {
        "queueRateLimit": {
          "rateLimit": {
            "requestsPerSecond": 50
          },
          "metadata": {
            "reason": "manual test",
            "updateTime": "2026-04-13T21:40:39.888Z"
          }
        }
      }
    },
    "version": "2"
  }                                                                                                                                         
  ```

  **Unspecified type defaults to workflow**
  ```
  $ ./tdbg taskqueue get-user-data --namespace default --task-queue my-queue --task-queue-type TASK_QUEUE_TYPE_UNSPECIFIED
  {
    "version": "2"
  }
  ```
  Passing `TASK_QUEUE_TYPE_UNSPECIFIED` defaults to workflow type instead of erroring — output matches the workflow-type test above.