### PR TITLE
Include CI breakers in ci-notify

### DIFF
--- a/tools/ci-notify/app_test.go
+++ b/tools/ci-notify/app_test.go
@@ -28,11 +28,13 @@ func TestBuildFailureMessage(t *testing.T) {
 				Name:       "test-job-1",
 				Conclusion: "failure",
 				URL:        "https://github.com/temporalio/temporal/actions/runs/123456/job/1",
+				CIBreakers: []string{"TestSuite/TestCaseA"},
 			},
 			{
 				Name:       "test-job-2",
 				Conclusion: "failure",
 				URL:        "https://github.com/temporalio/temporal/actions/runs/123456/job/2",
+				CIBreakers: []string{"TestSuite/TestCaseB"},
 			},
 		},
 		TotalJobs: 5,
@@ -63,7 +65,12 @@ func TestFormatMessageForDebug(t *testing.T) {
 			Author:   "Test Author",
 		},
 		FailedJobs: []Job{
-			{Name: "test-job-1", Conclusion: "failure"},
+			{
+				Name:       "test-job-1",
+				Conclusion: "failure",
+				URL:        "https://github.com/temporalio/temporal/actions/runs/123456/job/1",
+				CIBreakers: []string{"TestSuite/TestCaseA"},
+			},
 		},
 		TotalJobs: 5,
 	}
@@ -75,6 +82,7 @@ func TestFormatMessageForDebug(t *testing.T) {
 	assert.Contains(t, output, "abc1234")
 	assert.Contains(t, output, "Test Author")
 	assert.Contains(t, output, "test-job-1")
+	assert.Contains(t, output, "◦ `TestSuite/TestCaseA`")
 }
 
 func TestShortSHA(t *testing.T) {
@@ -140,6 +148,95 @@ func TestSlackMessageStructure(t *testing.T) {
 	// Verify the info block has 4 fields
 	infoBlock := msg.Blocks[1]
 	assert.Len(t, infoBlock.Fields, 4)
+}
+
+func TestBuildFailureMessageIncludesCIBreakers(t *testing.T) {
+	report := &FailureReport{
+		Workflow: WorkflowRun{
+			Name:       "All Tests",
+			HeadBranch: "main",
+			HeadSHA:    "abc1234567890",
+			URL:        "https://github.com/temporalio/temporal/actions/runs/123",
+		},
+		Commit: CommitInfo{
+			SHA:      "abc1234567890",
+			ShortSHA: "abc1234",
+			Author:   "Test",
+		},
+		FailedJobs: []Job{
+			{
+				Name:       "job1",
+				URL:        "http://example.com/job1",
+				CIBreakers: []string{"TestSuite/TestCaseA", "TestSuite/TestCaseB"},
+			},
+		},
+		TotalJobs: 3,
+	}
+
+	msg := BuildFailureMessage(report)
+
+	require.NotNil(t, msg)
+	require.NotNil(t, msg.Blocks[3].Text)
+	assert.Contains(t, msg.Blocks[3].Text.Text, "◦ `TestSuite/TestCaseA`")
+	assert.Contains(t, msg.Blocks[3].Text.Text, "◦ `TestSuite/TestCaseB`")
+}
+
+func TestBuildFailureMessageSkipsCIBreakersWhenTooManyForJob(t *testing.T) {
+	report := &FailureReport{
+		Workflow: WorkflowRun{
+			Name:       "All Tests",
+			HeadBranch: "main",
+			HeadSHA:    "abc1234567890",
+			URL:        "https://github.com/temporalio/temporal/actions/runs/123",
+		},
+		Commit: CommitInfo{
+			SHA:      "abc1234567890",
+			ShortSHA: "abc1234",
+			Author:   "Test",
+		},
+		FailedJobs: []Job{
+			{
+				Name: "job1",
+				URL:  "http://example.com/job1",
+				CIBreakers: []string{
+					"TestSuite/TestCase1",
+					"TestSuite/TestCase2",
+					"TestSuite/TestCase3",
+					"TestSuite/TestCase4",
+					"TestSuite/TestCase5",
+					"TestSuite/TestCase6",
+				},
+			},
+		},
+		TotalJobs: 3,
+	}
+
+	msg := BuildFailureMessage(report)
+
+	require.NotNil(t, msg)
+	require.NotNil(t, msg.Blocks[3].Text)
+	assert.Contains(t, msg.Blocks[3].Text.Text, "• <http://example.com/job1|job1>")
+	assert.NotContains(t, msg.Blocks[3].Text.Text, "◦ `TestSuite/TestCase1`")
+}
+
+func TestExtractCIBreakers(t *testing.T) {
+	logOutput := `
+some unrelated line
+- TestCallbacksSuite/TestWorkflowCallbacks_InvalidArgument (retry 1) (final)
+go.temporal.io/server/tests.TestQueryWorkflow_NonStickyMultiPageHistory (retry 2) (final)
+  * TestOtherSuite/TestSomething (final)
+duplicate TestOtherSuite/TestSomething (final)
+not a test line (final)
+`
+
+	assert.Equal(t,
+		[]string{
+			"TestCallbacksSuite/TestWorkflowCallbacks_InvalidArgument",
+			"go.temporal.io/server/tests.TestQueryWorkflow_NonStickyMultiPageHistory",
+			"TestOtherSuite/TestSomething",
+		},
+		extractCIBreakers(logOutput),
+	)
 }
 
 func TestFilterCompleted(t *testing.T) {

--- a/tools/ci-notify/github.go
+++ b/tools/ci-notify/github.go
@@ -5,10 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
 )
+
+var ciBreakerLinePattern = regexp.MustCompile(`(?:[[:alnum:]_./-]+\.)?Test[[:graph:][:space:]]*\(final\)`)
+var trailingTestSuffixPattern = regexp.MustCompile(`\s*\([^)]+\)$`)
 
 // GetWorkflowRun fetches workflow run details using gh CLI
 func GetWorkflowRun(runID string) (*WorkflowRun, error) {
@@ -76,10 +80,16 @@ func BuildFailureReport(runID string) (*FailureReport, error) {
 		Message:  run.DisplayTitle,
 	}
 
+	ciBreakersByJob, err := getCIBreakersByJob(runID, run.Jobs)
+	if err != nil {
+		return nil, err
+	}
+
 	// Identify failed jobs
 	var failedJobs []Job
 	for _, job := range run.Jobs {
 		if job.Conclusion == ConclusionFailure {
+			job.CIBreakers = ciBreakersByJob[job.ID]
 			failedJobs = append(failedJobs, job)
 		}
 	}
@@ -90,6 +100,65 @@ func BuildFailureReport(runID string) (*FailureReport, error) {
 		FailedJobs: failedJobs,
 		TotalJobs:  len(run.Jobs),
 	}, nil
+}
+
+func getCIBreakersByJob(runID string, jobs []Job) (map[int64][]string, error) {
+	ciBreakersByJob := make(map[int64][]string)
+	for _, job := range jobs {
+		if job.Conclusion != ConclusionFailure || job.ID == 0 {
+			continue
+		}
+
+		logOutput, err := getJobLog(runID, job.ID)
+		if err != nil {
+			return nil, err
+		}
+		ciBreakersByJob[job.ID] = extractCIBreakers(logOutput)
+	}
+	return ciBreakersByJob, nil
+}
+
+func getJobLog(runID string, jobID int64) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "gh", "run", "view", runID, "--job", fmt.Sprintf("%d", jobID), "--log-failed")
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("failed to get failed log for job %d: %w (stderr: %s)", jobID, err, string(exitErr.Stderr))
+		}
+		return "", fmt.Errorf("failed to get failed log for job %d: %w", jobID, err)
+	}
+	return string(output), nil
+}
+
+func extractCIBreakers(logOutput string) []string {
+	lines := strings.Split(logOutput, "\n")
+	seen := make(map[string]struct{})
+	var ciBreakers []string
+
+	for _, line := range lines {
+		match := ciBreakerLinePattern.FindString(line)
+		if match == "" {
+			continue
+		}
+		match = strings.TrimSpace(strings.TrimLeft(match, "-*+ "))
+		for {
+			stripped := trailingTestSuffixPattern.ReplaceAllString(match, "")
+			if stripped == match {
+				break
+			}
+			match = stripped
+		}
+		if _, ok := seen[match]; ok {
+			continue
+		}
+		seen[match] = struct{}{}
+		ciBreakers = append(ciBreakers, match)
+	}
+
+	return ciBreakers
 }
 
 // filterCompleted removes workflow runs that are not completed

--- a/tools/ci-notify/slack.go
+++ b/tools/ci-notify/slack.go
@@ -9,6 +9,8 @@ import (
 	"time"
 )
 
+const maxRenderedCIBreakers = 5
+
 // SlackMessage represents a Slack Block Kit message
 type SlackMessage struct {
 	Text   string       `json:"text"`
@@ -76,8 +78,7 @@ func BuildFailureMessage(report *FailureReport) *SlackMessage {
 	// List of failed jobs
 	var failedJobNames []string
 	for _, job := range report.FailedJobs {
-		failedJobNames = append(failedJobNames,
-			fmt.Sprintf("• <%s|%s>", job.URL, job.Name))
+		failedJobNames = append(failedJobNames, formatFailedJob(job))
 	}
 
 	jobsBlock := SlackBlock{
@@ -120,9 +121,21 @@ func FormatMessageForDebug(report *FailureReport) string {
 	fmt.Fprintf(&sb, "Failed Jobs: %d of %d total jobs\n\n", len(report.FailedJobs), report.TotalJobs)
 	fmt.Fprintln(&sb, "Failed Jobs:")
 	for _, job := range report.FailedJobs {
-		fmt.Fprintf(&sb, "  • %s\n    %s\n", job.Name, job.URL)
+		fmt.Fprintln(&sb, formatFailedJob(job))
 	}
 	fmt.Fprintf(&sb, "\nView Full Workflow Run: %s\n", report.Workflow.URL)
+	return sb.String()
+}
+
+func formatFailedJob(job Job) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "• <%s|%s>", job.URL, job.Name)
+	if len(job.CIBreakers) > maxRenderedCIBreakers {
+		return sb.String()
+	}
+	for _, ciBreaker := range job.CIBreakers {
+		fmt.Fprintf(&sb, "\n    ◦ `%s`", ciBreaker)
+	}
 	return sb.String()
 }
 

--- a/tools/ci-notify/types.go
+++ b/tools/ci-notify/types.go
@@ -31,6 +31,8 @@ type Job struct {
 	StartedAt   string     `json:"startedAt"`
 	CompletedAt string     `json:"completedAt"`
 	URL         string     `json:"url"`
+	ID          int64      `json:"databaseId"`
+	CIBreakers  []string   `json:"-"`
 }
 
 // CommitInfo represents commit metadata


### PR DESCRIPTION
## What changed?

Show the name of the test that broke the CI.

## Why?

Make it easier to spot trends.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
