### PR TITLE
allow softassert in linter

### DIFF
--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -205,6 +205,9 @@ linters:
       - text: "use of `assert\\.CollectT`" # allowed for EventuallyWithT callbacks
         linters:
           - forbidigo
+      - text: "use of `softassert\\.\\w+`"
+        linters:
+          - forbidigo
       - path: _test\.go|tests/.+\.go|common/testing/
         text: "(cyclomatic|cognitive)" # false positives when using subtests
         linters:


### PR DESCRIPTION
## Why?

Existing linter is too aggressive; allow softassert.

