### PR TITLE
Fix query test

### DIFF
--- a/tests/query_workflow_test.go
+++ b/tests/query_workflow_test.go
@@ -399,17 +399,14 @@ func TestQueryWorkflow_NonStickyMultiPageHistory(t *testing.T) {
 		return err == nil && resp.GetWorkflowExecutionInfo().GetHistoryLength() > 10
 	}, 10*time.Second, 200*time.Millisecond)
 
-	// Stop worker so the query goes through the non-sticky path.
+	// Stop worker to clear sticky cache so the query goes through non-sticky path.
 	queryWorker.Stop()
 
 	// Terminate the workflow to prevent any further workflow tasks from being
-	// scheduled. This eliminates the race with stale WFTs from activity processing
-	// that can appear on the normal queue via sticky-queue fallback.
-	// Querying a terminated workflow works — it replays from the last completed WFT.
+	// scheduled. This eliminates the race with stale WFTs from activity processing.
 	err = env.SdkClient().TerminateWorkflow(ctx, id, "", "test cleanup")
 	env.NoError(err)
 
-	// Issue a query in background; we'll poll for the task manually below.
 	go func() { _, _ = env.SdkClient().QueryWorkflow(ctx, id, "", "test") }()
 
 	// Poll for the query task on the normal (non-sticky) task queue.

--- a/tests/query_workflow_test.go
+++ b/tests/query_workflow_test.go
@@ -399,19 +399,17 @@ func TestQueryWorkflow_NonStickyMultiPageHistory(t *testing.T) {
 		return err == nil && resp.GetWorkflowExecutionInfo().GetHistoryLength() > 10
 	}, 10*time.Second, 200*time.Millisecond)
 
-	// Stop worker to clear sticky cache so the query goes through non-sticky path.
+	// Stop worker so the query goes through the non-sticky path.
 	queryWorker.Stop()
 
-	// Clear stickiness so the query dispatches directly to the normal queue
-	// without waiting for StickyScheduleToStartTimeout (~5s).
-	_, err = env.FrontendClient().ResetStickyTaskQueue(ctx, &workflowservice.ResetStickyTaskQueueRequest{
-		Namespace: env.Namespace().String(),
-		Execution: &commonpb.WorkflowExecution{WorkflowId: id},
-	})
+	// Terminate the workflow to prevent any further workflow tasks from being
+	// scheduled. This eliminates the race with stale WFTs from activity processing
+	// that can appear on the normal queue via sticky-queue fallback.
+	// Querying a terminated workflow works — it replays from the last completed WFT.
+	err = env.SdkClient().TerminateWorkflow(ctx, id, "", "test cleanup")
 	env.NoError(err)
 
 	// Issue a query in background; we'll poll for the task manually below.
-	// Don't assert inside the goroutine — it would panic if the test completes first.
 	go func() { _, _ = env.SdkClient().QueryWorkflow(ctx, id, "", "test") }()
 
 	// Poll for the query task on the normal (non-sticky) task queue.

--- a/tests/query_workflow_test.go
+++ b/tests/query_workflow_test.go
@@ -396,14 +396,13 @@ func TestQueryWorkflow_NonStickyMultiPageHistory(t *testing.T) {
 			Namespace: env.Namespace().String(),
 			Execution: &commonpb.WorkflowExecution{WorkflowId: id},
 		})
-		return err == nil && resp.GetWorkflowExecutionInfo().GetHistoryLength() > 10
+		return err == nil && resp.GetWorkflowExecutionInfo().GetHistoryLength() > 30
 	}, 10*time.Second, 200*time.Millisecond)
 
 	// Stop worker to clear sticky cache so the query goes through non-sticky path.
 	queryWorker.Stop()
 
-	// Terminate the workflow to prevent any further workflow tasks from being
-	// scheduled. This eliminates the race with stale WFTs from activity processing.
+	// Terminate the workflow to prevent any further workflow tasks from being scheduled.
 	err = env.SdkClient().TerminateWorkflow(ctx, id, "", "test cleanup")
 	env.NoError(err)
 

--- a/tests/query_workflow_test.go
+++ b/tests/query_workflow_test.go
@@ -399,8 +399,16 @@ func TestQueryWorkflow_NonStickyMultiPageHistory(t *testing.T) {
 		return err == nil && resp.GetWorkflowExecutionInfo().GetHistoryLength() > 30
 	}, 10*time.Second, 200*time.Millisecond)
 
-	// Stop worker to clear sticky cache so the query goes through non-sticky path.
+	// Stop worker so the query goes through the non-sticky path.
 	queryWorker.Stop()
+
+	// Clear stickiness so the query dispatches directly to the normal queue
+	// without waiting for StickyScheduleToStartTimeout (~5s).
+	_, err = env.FrontendClient().ResetStickyTaskQueue(ctx, &workflowservice.ResetStickyTaskQueueRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: id},
+	})
+	env.NoError(err)
 
 	// Terminate the workflow to prevent any further workflow tasks from being scheduled.
 	err = env.SdkClient().TerminateWorkflow(ctx, id, "", "test cleanup")


### PR DESCRIPTION
## What changed?
Terminte the test workflow so that normal workflow tasks are not blocking query task.

## Why?
Fix flakiness

