### PR TITLE
fix: allow version workflow CaN when history grows too large, despite pending signals

### DIFF
--- a/service/worker/workerdeployment/version_workflow.go
+++ b/service/worker/workerdeployment/version_workflow.go
@@ -293,10 +293,17 @@ func (d *VersionWorkflowRunner) run(ctx workflow.Context) error {
 	// there are no pending updates/signals and the state has changed.
 	err := workflow.Await(ctx, func() bool {
 		return (d.deleteVersion && d.asyncPropagationsInProgress == 0) || // version is deleted -> it's ok to drop all signals and updates.
-			// There is no pending signal or update, but the state is dirty or forceCaN is requested:
+			// Normal CaN path: no pending signal or update, but the state is dirty or forceCaN is requested:
 			(!d.signalHandler.signalSelector.HasPending() && d.signalHandler.processingSignals == 0 && workflow.AllHandlersFinished(ctx) &&
-				// And there is a force CaN or a propagated state change or history got too large
-				(d.forceCAN || (d.stateChanged && d.asyncPropagationsInProgress == 0) || workflow.GetInfo(ctx).GetContinueAsNewSuggested()))
+				(d.forceCAN || (d.stateChanged && d.asyncPropagationsInProgress == 0) || workflow.GetInfo(ctx).GetContinueAsNewSuggested())) ||
+			// Emergency CaN path: history too large — bypass HasPending() but still
+			// wait for in-flight handlers and async propagations to complete.
+			// Pending signals will be dropped; they are either idempotent (reactivation)
+			// or will be re-sent by the caller (drainage sync, force-CaN).
+			(workflow.GetInfo(ctx).GetContinueAsNewSuggested() &&
+				d.signalHandler.processingSignals == 0 &&
+				workflow.AllHandlersFinished(ctx) &&
+				d.asyncPropagationsInProgress == 0)
 	})
 	if err != nil {
 		return err
@@ -306,6 +313,9 @@ func (d *VersionWorkflowRunner) run(ctx workflow.Context) error {
 		return nil
 	}
 
+	if d.signalHandler.signalSelector.HasPending() {
+		d.logger.Warn("Version CaN with pending signals due to large history")
+	}
 	d.logger.Debug("Version doing continue-as-new")
 	nextArgs := d.WorkerDeploymentVersionWorkflowArgs
 	// Apply override state if provided during force-CaN

--- a/service/worker/workerdeployment/version_workflow.go
+++ b/service/worker/workerdeployment/version_workflow.go
@@ -298,12 +298,8 @@ func (d *VersionWorkflowRunner) run(ctx workflow.Context) error {
 				(d.forceCAN || (d.stateChanged && d.asyncPropagationsInProgress == 0) || workflow.GetInfo(ctx).GetContinueAsNewSuggested())) ||
 			// Emergency CaN path: history too large — bypass HasPending() but still
 			// wait for in-flight handlers and async propagations to complete.
-			// Pending signals will be dropped; they are either idempotent (reactivation)
-			// or will be re-sent by the caller (drainage sync, force-CaN).
 			(workflow.GetInfo(ctx).GetContinueAsNewSuggested() &&
-				d.signalHandler.processingSignals == 0 &&
-				workflow.AllHandlersFinished(ctx) &&
-				d.asyncPropagationsInProgress == 0)
+				d.signalHandler.processingSignals == 0 && workflow.AllHandlersFinished(ctx) && d.asyncPropagationsInProgress == 0)
 	})
 	if err != nil {
 		return err

--- a/service/worker/workerdeployment/version_workflow_test.go
+++ b/service/worker/workerdeployment/version_workflow_test.go
@@ -2604,3 +2604,61 @@ func (s *VersionWorkflowSuite) Test_ReactivateVersion_IgnoredWhenNotDrainedOrIna
 
 	s.True(s.env.IsWorkflowCompleted())
 }
+
+// Test_CaNWhenHistoryTooLargeDespitePendingSignals verifies that the version workflow
+// can continue-as-new when GetContinueAsNewSuggested() is true, even if there are
+// pending (unprocessed) signals in the buffer. This is the emergency CaN escape hatch
+// that prevents the workflow from getting permanently stuck under signal floods.
+func (s *VersionWorkflowSuite) Test_CaNWhenHistoryTooLargeDespitePendingSignals() {
+	tv := testvars.New(s.T())
+	now := timestamppb.New(time.Now())
+
+	var a *VersionActivities
+	s.env.RegisterActivity(a.StartWorkerDeploymentWorkflow)
+	s.env.OnActivity(a.StartWorkerDeploymentWorkflow, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	// Mock activities that the reactivation signal handler calls
+	s.env.OnActivity(a.SyncDeploymentVersionUserData, mock.Anything, mock.Anything).Return(
+		&deploymentspb.SyncDeploymentVersionUserDataResponse{}, nil,
+	).Maybe()
+	s.env.OnActivity(a.CheckWorkerDeploymentUserDataPropagation, mock.Anything, mock.Anything).Return(nil).Maybe()
+	s.env.OnSignalExternalWorkflow(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	// Set ContinueAsNewSuggested to simulate large history
+	s.env.RegisterDelayedCallback(func() {
+		s.env.SetContinueAsNewSuggested(true)
+	}, 0)
+
+	// Send reactivation signals to keep HasPending() true.
+	// These are the same no-op signals that caused the incident.
+	for i := 1; i <= 5; i++ {
+		delay := time.Duration(i) * time.Millisecond
+		s.env.RegisterDelayedCallback(func() {
+			s.env.SignalWorkflow(ReactivateVersionSignalName, nil)
+		}, delay)
+	}
+
+	// Start workflow with DRAINED status (so reactivation signals are meaningful)
+	s.env.ExecuteWorkflow(WorkerDeploymentVersionWorkflowType, &deploymentspb.WorkerDeploymentVersionWorkflowArgs{
+		NamespaceName: tv.NamespaceName().String(),
+		NamespaceId:   tv.NamespaceID().String(),
+		VersionState: &deploymentspb.VersionLocalState{
+			Version: &deploymentspb.WorkerDeploymentVersion{
+				DeploymentName: tv.DeploymentSeries(),
+				BuildId:        tv.BuildID(),
+			},
+			Status: enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINED,
+			DrainageInfo: &deploymentpb.VersionDrainageInfo{
+				Status:          enumspb.VERSION_DRAINAGE_STATUS_DRAINED,
+				LastChangedTime: now,
+				LastCheckedTime: now,
+			},
+			SyncBatchSize:             int32(s.workerDeploymentClient.getSyncBatchSize()),
+			StartedDeploymentWorkflow: true,
+		},
+	})
+
+	// Workflow should complete via CaN despite pending signals
+	s.True(s.env.IsWorkflowCompleted())
+}
+

--- a/service/worker/workerdeployment/version_workflow_test.go
+++ b/service/worker/workerdeployment/version_workflow_test.go
@@ -2662,3 +2662,67 @@ func (s *VersionWorkflowSuite) Test_CaNWhenHistoryTooLargeDespitePendingSignals(
 	s.True(s.env.IsWorkflowCompleted())
 }
 
+// Test_NoCaNWhenPendingSignalsButHistoryNotTooLarge verifies that the emergency CaN path
+// does NOT fire when there are pending signals but GetContinueAsNewSuggested() is false.
+// The workflow should process signals normally and only CaN through the normal path.
+func (s *VersionWorkflowSuite) Test_NoCaNWhenPendingSignalsButHistoryNotTooLarge() {
+	tv := testvars.New(s.T())
+	now := timestamppb.New(time.Now())
+
+	var a *VersionActivities
+	s.env.RegisterActivity(a.StartWorkerDeploymentWorkflow)
+	s.env.OnActivity(a.StartWorkerDeploymentWorkflow, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	// Mock activities that the reactivation signal handler calls
+	s.env.OnActivity(a.SyncDeploymentVersionUserData, mock.Anything, mock.Anything).Return(
+		&deploymentspb.SyncDeploymentVersionUserDataResponse{}, nil,
+	).Maybe()
+	s.env.OnActivity(a.CheckWorkerDeploymentUserDataPropagation, mock.Anything, mock.Anything).Return(nil).Maybe()
+	s.env.OnSignalExternalWorkflow(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	// Do NOT set ContinueAsNewSuggested — history is fine
+
+	// Send reactivation signals
+	for i := 1; i <= 3; i++ {
+		delay := time.Duration(i) * time.Millisecond
+		s.env.RegisterDelayedCallback(func() {
+			s.env.SignalWorkflow(ReactivateVersionSignalName, nil)
+		}, delay)
+	}
+
+	// After signals are processed, query to verify version was reactivated normally
+	s.env.RegisterDelayedCallback(func() {
+		queryResp := &deploymentspb.QueryDescribeVersionResponse{}
+		val, err := s.env.QueryWorkflow(QueryDescribeVersion)
+		s.Require().NoError(err)
+		err = val.Get(queryResp)
+		s.Require().NoError(err)
+
+		// Version should be DRAINING (reactivated from DRAINED via normal signal processing)
+		s.Equal(enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINING, queryResp.VersionState.Status)
+	}, 10*time.Millisecond)
+
+	// Start workflow with DRAINED status
+	s.env.ExecuteWorkflow(WorkerDeploymentVersionWorkflowType, &deploymentspb.WorkerDeploymentVersionWorkflowArgs{
+		NamespaceName: tv.NamespaceName().String(),
+		NamespaceId:   tv.NamespaceID().String(),
+		VersionState: &deploymentspb.VersionLocalState{
+			Version: &deploymentspb.WorkerDeploymentVersion{
+				DeploymentName: tv.DeploymentSeries(),
+				BuildId:        tv.BuildID(),
+			},
+			Status: enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINED,
+			DrainageInfo: &deploymentpb.VersionDrainageInfo{
+				Status:          enumspb.VERSION_DRAINAGE_STATUS_DRAINED,
+				LastChangedTime: now,
+				LastCheckedTime: now,
+			},
+			SyncBatchSize:             int32(s.workerDeploymentClient.getSyncBatchSize()),
+			StartedDeploymentWorkflow: true,
+		},
+	})
+
+	// Workflow should complete normally (CaN via normal path after processing all signals)
+	s.True(s.env.IsWorkflowCompleted())
+}
+

--- a/service/worker/workerdeployment/version_workflow_test.go
+++ b/service/worker/workerdeployment/version_workflow_test.go
@@ -2725,4 +2725,3 @@ func (s *VersionWorkflowSuite) Test_NoCaNWhenPendingSignalsButHistoryNotTooLarge
 	// Workflow should complete normally (CaN via normal path after processing all signals)
 	s.True(s.env.IsWorkflowCompleted())
 }
-

--- a/service/worker/workerdeployment/workflow.go
+++ b/service/worker/workerdeployment/workflow.go
@@ -387,14 +387,9 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 	// there are no pending updates/signals and the state has changed.
 	err = workflow.Await(ctx, func() bool {
 		canContinue := d.deleteDeployment || // deployment is deleted -> it's ok to drop all signals and updates.
-			// Normal CaN path: no pending signal or update, but the state is dirty or forceCaN is requested:
+			// There is no pending signal or update, but the state is dirty or forceCaN is requested:
 			(!d.signalHandler.signalSelector.HasPending() && d.signalHandler.processingSignals == 0 && workflow.AllHandlersFinished(ctx) &&
-				(d.forceCAN || d.stateChanged || workflow.GetInfo(ctx).GetContinueAsNewSuggested())) ||
-			// Emergency CaN path: history too large — bypass HasPending() but still
-			// wait for in-flight handlers to complete.
-			(workflow.GetInfo(ctx).GetContinueAsNewSuggested() &&
-				d.signalHandler.processingSignals == 0 &&
-				workflow.AllHandlersFinished(ctx))
+				(d.forceCAN || d.stateChanged || workflow.GetInfo(ctx).GetContinueAsNewSuggested()))
 
 		// TODO(carlydf): remove verbose logging
 		if canContinue {
@@ -419,9 +414,6 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 		return nil
 	}
 
-	if d.signalHandler.signalSelector.HasPending() {
-		d.logger.Warn("Deployment CaN with pending signals due to large history")
-	}
 	// TODO(carlydf): remove verbose logging
 	d.logger.Info("Continuing workflow as new",
 		"create_time", d.State.GetCreateTime(),

--- a/service/worker/workerdeployment/workflow.go
+++ b/service/worker/workerdeployment/workflow.go
@@ -387,9 +387,14 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 	// there are no pending updates/signals and the state has changed.
 	err = workflow.Await(ctx, func() bool {
 		canContinue := d.deleteDeployment || // deployment is deleted -> it's ok to drop all signals and updates.
-			// There is no pending signal or update, but the state is dirty or forceCaN is requested:
+			// Normal CaN path: no pending signal or update, but the state is dirty or forceCaN is requested:
 			(!d.signalHandler.signalSelector.HasPending() && d.signalHandler.processingSignals == 0 && workflow.AllHandlersFinished(ctx) &&
-				(d.forceCAN || d.stateChanged || workflow.GetInfo(ctx).GetContinueAsNewSuggested()))
+				(d.forceCAN || d.stateChanged || workflow.GetInfo(ctx).GetContinueAsNewSuggested())) ||
+			// Emergency CaN path: history too large — bypass HasPending() but still
+			// wait for in-flight handlers to complete.
+			(workflow.GetInfo(ctx).GetContinueAsNewSuggested() &&
+				d.signalHandler.processingSignals == 0 &&
+				workflow.AllHandlersFinished(ctx))
 
 		// TODO(carlydf): remove verbose logging
 		if canContinue {
@@ -414,6 +419,9 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 		return nil
 	}
 
+	if d.signalHandler.signalSelector.HasPending() {
+		d.logger.Warn("Deployment CaN with pending signals due to large history")
+	}
 	// TODO(carlydf): remove verbose logging
 	d.logger.Info("Continuing workflow as new",
 		"create_time", d.State.GetCreateTime(),

--- a/tests/worker_deployment_version_test.go
+++ b/tests/worker_deployment_version_test.go
@@ -335,7 +335,7 @@ func (s *DeploymentVersionSuite) TestEmergencyCaN_SignalFlood() {
 	// Flood the version workflow with reactivation signals to grow its history
 	// past the CaN suggestion threshold. Some signals may fail with
 	// "workflow is closing" if the workflow is mid-CaN — that's expected.
-	for i := 0; i < 30; i++ {
+	for range 30 {
 		_ = s.SendSignal(s.Namespace().String(), workflowExecution, workerdeployment.ReactivateVersionSignalName, nil, tv.ClientIdentity())
 	}
 

--- a/tests/worker_deployment_version_test.go
+++ b/tests/worker_deployment_version_test.go
@@ -310,6 +310,53 @@ func (s *DeploymentVersionSuite) TestForceCAN_WithOverrideState() {
 	}, time.Second*10, time.Millisecond*1000)
 }
 
+// TestEmergencyCaN_SignalFlood verifies that a version workflow can continue-as-new
+// when its history grows too large due to a flood of reactivation signals. This
+// reproduces the root cause of the beh-qa.vazty incident where r127's version workflow
+// became permanently stuck because HasPending() blocked CaN.
+func (s *DeploymentVersionSuite) TestEmergencyCaN_SignalFlood() {
+	// Lower the CaN suggestion threshold so we don't need thousands of signals
+	s.OverrideDynamicConfig(dynamicconfig.HistoryCountSuggestContinueAsNew, 10)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+	tv := testvars.New(s)
+
+	// Start a version workflow
+	s.startVersionWorkflow(ctx, tv)
+
+	// Set it as current so it has a meaningful state to verify after CaN
+	err := s.setCurrent(tv, false)
+	s.NoError(err)
+
+	versionWorkflowID := workerdeployment.GenerateVersionWorkflowID(tv.DeploymentSeries(), tv.BuildID())
+	workflowExecution := &commonpb.WorkflowExecution{
+		WorkflowId: versionWorkflowID,
+	}
+
+	// Flood the version workflow with reactivation signals to grow its history
+	// past the CaN suggestion threshold. Some signals may fail with
+	// "workflow is closing" if the workflow is mid-CaN — that's expected.
+	for i := 0; i < 30; i++ {
+		_ = s.SendSignal(s.Namespace().String(), workflowExecution, workerdeployment.ReactivateVersionSignalName, nil, tv.ClientIdentity())
+	}
+
+	// Verify the workflow is still responsive — it should have CaN'd via the
+	// emergency path and restarted with a fresh history
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		a := assert.New(t)
+
+		resp, err := s.describeVersion(tv)
+		if !a.NoError(err) {
+			return
+		}
+
+		// State should be preserved after emergency CaN
+		a.Equal(tv.DeploymentVersionString(), resp.GetWorkerDeploymentVersionInfo().GetVersion()) //nolint:staticcheck // SA1019: worker versioning v0.31
+		a.Equal(enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT, resp.GetWorkerDeploymentVersionInfo().GetStatus())
+	}, time.Second*15, time.Millisecond*1000)
+}
+
 func (s *DeploymentVersionSuite) TestDescribeVersion_RegisterTaskQueue() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()

--- a/tests/worker_deployment_version_test.go
+++ b/tests/worker_deployment_version_test.go
@@ -311,9 +311,7 @@ func (s *DeploymentVersionSuite) TestForceCAN_WithOverrideState() {
 }
 
 // TestEmergencyCaN_SignalFlood verifies that a version workflow can continue-as-new
-// when its history grows too large due to a flood of reactivation signals. This
-// reproduces the root cause of the beh-qa.vazty incident where r127's version workflow
-// became permanently stuck because HasPending() blocked CaN.
+// when its history grows too large due to a flood of reactivation signals.
 func (s *DeploymentVersionSuite) TestEmergencyCaN_SignalFlood() {
 	// Lower the CaN suggestion threshold so we don't need thousands of signals
 	s.OverrideDynamicConfig(dynamicconfig.HistoryCountSuggestContinueAsNew, 10)
@@ -344,7 +342,7 @@ func (s *DeploymentVersionSuite) TestEmergencyCaN_SignalFlood() {
 	// Verify the workflow is still responsive — it should have CaN'd via the
 	// emergency path and restarted with a fresh history
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		a := assert.New(t)
+		a := assert.New(t) //nolint:forbidigo // assert.CollectT is allowed for EventuallyWithT callbacks
 
 		resp, err := s.describeVersion(tv)
 		if !a.NoError(err) {


### PR DESCRIPTION
## Summary

This PR lets the version workflow continue-as-new (CaN) when `GetContinueAsNewSuggested()` is true (history >= 4MB or >= 4K events), even if the `HasPending()` signal check is not met.

We still require other safety conditions to be met in this situation: no processing signals, all handlers finished, no async propagations in progress.

## Context

This PR fixes the root cause from a incident (INC-1606) where a version workflow was flooded with reactivation signals, making `HasPending()` permanently true.

This blocked CaN even when `GetContinueAsNewSuggested()` was true, causing unbounded history growth and making the workflow stuck for a extended period.

## Unit Tests

  | Test | Situation | Expected Behavior |
  |------|-----------|-------------------|
  | `Test_CaNWhenHistoryTooLargeDespitePendingSignals` | History is too large (`ContinueAsNewSuggested` is true) and reactivation signals are flooding in, keeping `HasPending()` true | Workflow CaNs via emergency path despite pending signals |
  | `Test_NoCaNWhenPendingSignalsButHistoryNotTooLarge` | Reactivation signals are arriving but history is a normal size (`ContinueAsNewSuggested` is false) | Workflow processes signals normally (DRAINED → DRAINING) and CaNs via the normal path after all signals are consumed |

  ## Functional Tests

  | Test | Situation | Expected Behavior |
  |------|-----------|-------------------|
  | `TestEmergencyCaN_SignalFlood` | Real server with a very low CaN suggestion threshold (10 events). Version workflow is CURRENT and gets flooded with 30 reactivation signals, pushing history past the threshold | Workflow CaNs via emergency path, remains responsive to queries afterward, and state is preserved (still CURRENT) |

## TBD

- [ ] Should we also add similar logic for CaN in the deployment workflow, if history size is too large?