### PR TITLE
Add worker commands architecture doc

### DIFF
--- a/docs/architecture/worker-commands.md
+++ b/docs/architecture/worker-commands.md
@@ -2,57 +2,48 @@
 
 Worker commands are server-initiated instructions sent to workers via Nexus. Each worker process has a dedicated control task queue that it polls via Nexus RPC. A single control queue serves one or more workers running within the same process. This enables the server to push actions to workers without relying on heartbeats or long-poll cycles.
 
+To route a command, the server needs to know the target worker's control queue. For commands that target activities, this information is stored directly in the mutable state (`ActivityInfo`) when the activity was dispatched to the worker.
+
 ```mermaid
 graph LR
     subgraph History
-        A[Trigger] -->|1| B[Generate Task]
-        B -->|2| C[Outbound Queue]
-        C -->|3| D[Dispatch]
+        A[Create Task] -->|1| C[Outbound Queue]
+        C -->|2| D[Dispatch]
     end
     subgraph Matching
         E[Control Queue]
     end
-    D -->|4| E
-    E -->|8| D
+    D -->|3| E
+    E -->|7| D
     E ~~~ Worker
     subgraph Worker
-        G[Poller] -->|6| F[Execute]
+        G[Poller] -->|5| F[Execute]
     end
-    G -.->|5| E
-    F -.->|7| E
+    G -.->|4| E
+    F -.->|6| E
 ```
 
 ### History
 
-1. **Trigger** -- The server decides whether to initiate a worker command based on a state change (e.g., a user requesting activity cancellation).
-2. **Generate Task** -- The trigger logic creates one or more `WorkerCommand` protos and calls `GenerateWorkerCommandsTasks`, which persists them as an outbound task.
-3. **Outbound Queue** -- The outbound queue executor picks up the task.
-4. **Dispatch** -- The dispatcher sends a `DispatchNexusTask` RPC to matching. This is synchronous — matching holds the request until a worker responds or the request times out.
+1. **Create Task** -- The server decides whether to initiate a worker command based on a state change (e.g., a user requesting activity cancellation). The trigger logic creates one or more `WorkerCommand` protos and calls `GenerateWorkerCommandsTasks`, which persists them as an outbound task. Serialization is command-agnostic ([`task_serializers.go`](https://github.com/temporalio/temporal/blob/f5246b3fddf565d9cbe96ff25d36731bd4374cd2/common/persistence/serialization/task_serializers.go#L1453-L1467)).
+2. **Outbound Queue** -- The outbound queue executor picks up the task and invokes the dispatcher configured in [`Execute`](https://github.com/temporalio/temporal/blob/856e276e58055867f3d852dd23a1ed9d48197c01/service/history/outbound_queue_active_task_executor.go#L100-L108).
+3. **Dispatch** -- The [`dispatcher`](https://github.com/temporalio/temporal/blob/856e276e58055867f3d852dd23a1ed9d48197c01/service/history/worker_commands_task_dispatcher.go#L112-L166) sends a `DispatchNexusTask` RPC to matching. This is synchronous — matching holds the request until a worker responds or the request times out.
 
 ### Matching
 
-5. **Control Queue** -- Matching holds the command on the control queue until a worker polls it. If no worker is polling, the request times out. There is currently no way to distinguish a permanently gone worker from a temporarily slow one, so the dispatcher simply retries up to a maximum number of attempts before dropping the task. This is acceptable because worker commands are best-effort.
+4. **Control Queue** -- Matching holds the command on the control queue until a worker polls it. If no worker is polling, the request times out. There is currently no way to distinguish a permanently gone worker from a temporarily slow one, so the dispatcher simply retries up to a maximum number of attempts before dropping the task. This is acceptable because worker commands are best-effort.
 
 ### Worker
 
-6. **Poller** -- The worker's poller picks up the command from the control queue.
-7. **Execute** -- The worker executes the command and sends the response back to matching.
-8. **Response** -- Matching forwards the response back to the dispatcher in history.
+5. **Poller** -- The worker's poller picks up the command from the control queue.
+6. **Execute** -- The worker executes the command and sends the response back to matching.
+
+### Matching
+
+7. **Response** -- Matching forwards the response back to the dispatcher in history.
 
 ## Adding a new command
 
 1. **Define the proto** -- Add a new variant to `WorkerCommand` in [`message.proto`](https://github.com/temporalio/api/blob/43b4618e84611e594929ac60c970ec163e85c17a/temporal/api/worker/v1/message.proto#L198-L207) (api repo).
 2. **Add a trigger** -- Add server-side logic to detect the condition, create the command, and call `GenerateWorkerCommandsTasks` (see [`task_generator.go`](https://github.com/temporalio/temporal/blob/c229fcb98ac88f62aec741212aa3797071057dff/service/history/workflow/task_generator.go#L582-L597)).
 3. **Handle in the SDK** -- Add a handler for the new command variant in the SDK's worker command executor.
-
-Dispatch ([`worker_commands_task_dispatcher.go`](../../service/history/worker_commands_task_dispatcher.go)) and serialization ([`task_serializers.go`](../../common/persistence/serialization/task_serializers.go)) are command-agnostic and do not require changes.
-
-## Examples
-
-### Activity cancellation
-
-When a user requests activity cancellation, the server generates a cancel command targeting the worker's control queue (stored in `ActivityInfo` at activity start). The worker receives the command and cancels the running activity directly.
-
-- **History**: Workflow task completed handler detects a pending cancellation, creates the command, and calls `GenerateWorkerCommandsTasks`.
-- **Matching**: Handled by existing infrastructure — no command-specific logic needed.
-- **Worker**: The worker's command executor matches the cancel command to the running activity and cancels it.

--- a/docs/architecture/worker-commands.md
+++ b/docs/architecture/worker-commands.md
@@ -41,7 +41,7 @@ graph LR
 
 ## Adding a new command
 
-1. **Define the proto** -- Add a new variant to `WorkerCommand` in [`message.proto`](https://github.com/temporalio/api/blob/master/temporal/api/worker/v1/message.proto) (api repo).
+1. **Define the proto** -- Add a new variant to `WorkerCommand` in [`message.proto`](https://github.com/temporalio/api/blob/43b4618e84611e594929ac60c970ec163e85c17a/temporal/api/worker/v1/message.proto#L198-L207) (api repo).
 2. **Add a trigger** -- Add server-side logic to detect the condition, create the command, and call `GenerateWorkerCommandsTasks` (see [`task_generator.go`](../../service/history/workflow/task_generator.go)).
 3. **Handle in the SDK** -- Add a handler for the new command variant in the SDK's worker command executor.
 

--- a/docs/architecture/worker-commands.md
+++ b/docs/architecture/worker-commands.md
@@ -42,7 +42,7 @@ graph LR
 ## Adding a new command
 
 1. **Define the proto** -- Add a new variant to `WorkerCommand` in [`message.proto`](https://github.com/temporalio/api/blob/43b4618e84611e594929ac60c970ec163e85c17a/temporal/api/worker/v1/message.proto#L198-L207) (api repo).
-2. **Add a trigger** -- Add server-side logic to detect the condition, create the command, and call `GenerateWorkerCommandsTasks` (see [`task_generator.go`](../../service/history/workflow/task_generator.go)).
+2. **Add a trigger** -- Add server-side logic to detect the condition, create the command, and call `GenerateWorkerCommandsTasks` (see [`task_generator.go`](https://github.com/temporalio/temporal/blob/c229fcb98ac88f62aec741212aa3797071057dff/service/history/workflow/task_generator.go#L582-L597)).
 3. **Handle in the SDK** -- Add a handler for the new command variant in the SDK's worker command executor.
 
 Dispatch ([`worker_commands_task_dispatcher.go`](../../service/history/worker_commands_task_dispatcher.go)) and serialization ([`task_serializers.go`](../../common/persistence/serialization/task_serializers.go)) are command-agnostic and do not require changes.

--- a/docs/architecture/worker-commands.md
+++ b/docs/architecture/worker-commands.md
@@ -22,22 +22,22 @@ graph LR
     F -.->|7| E
 ```
 
-### History (steps 1-4)
+### History
 
-- The server decides whether to initiate a worker command based on a state change (e.g., a user requesting activity cancellation).
-- The trigger logic creates one or more `WorkerCommand` protos and calls `GenerateWorkerCommandsTasks`, which persists them as an outbound task.
-- The outbound queue executor picks up the task and dispatches it to the worker's control queue via matching.
+1. **Trigger** -- The server decides whether to initiate a worker command based on a state change (e.g., a user requesting activity cancellation).
+2. **Generate Task** -- The trigger logic creates one or more `WorkerCommand` protos and calls `GenerateWorkerCommandsTasks`, which persists them as an outbound task.
+3. **Outbound Queue** -- The outbound queue executor picks up the task.
+4. **Dispatch** -- The dispatcher sends a `DispatchNexusTask` RPC to matching. This is synchronous — matching holds the request until a worker responds or the request times out.
 
-### Matching (steps 4-5)
+### Matching
 
-- The `DispatchNexusTask` RPC is synchronous — matching holds the request until a worker polls the control queue and responds.
-- If no worker is polling, the request times out.
-- There is currently no way to distinguish a permanently gone worker from a temporarily slow one, so the dispatcher simply retries up to a maximum number of attempts before dropping the task. This is acceptable because worker commands are best-effort.
+5. **Control Queue** -- Matching holds the command on the control queue until a worker polls it. If no worker is polling, the request times out. There is currently no way to distinguish a permanently gone worker from a temporarily slow one, so the dispatcher simply retries up to a maximum number of attempts before dropping the task. This is acceptable because worker commands are best-effort.
 
-### Worker (steps 6-8)
+### Worker
 
-- The worker's poller picks up the command from the control queue.
-- The worker executes the command and sends the response back through matching to the dispatcher.
+6. **Poller** -- The worker's poller picks up the command from the control queue.
+7. **Execute** -- The worker executes the command and sends the response back to matching.
+8. **Response** -- Matching forwards the response back to the dispatcher in history.
 
 ## Adding a new command
 

--- a/docs/architecture/worker-commands.md
+++ b/docs/architecture/worker-commands.md
@@ -1,0 +1,58 @@
+# Worker Commands
+
+Worker commands are server-initiated instructions sent to workers via Nexus. Each worker process has a dedicated control task queue that it polls via Nexus RPC. A single control queue serves one or more workers running within the same process. This enables the server to push actions to workers without relying on heartbeats or long-poll cycles.
+
+```mermaid
+graph LR
+    subgraph History
+        A[Trigger] -->|1| B[Generate Task]
+        B -->|2| C[Outbound Queue]
+        C -->|3| D[Dispatch]
+    end
+    subgraph Matching
+        E[Control Queue]
+    end
+    D -->|4| E
+    E -->|8| D
+    E ~~~ Worker
+    subgraph Worker
+        G[Poller] -->|6| F[Execute]
+    end
+    G -.->|5| E
+    F -.->|7| E
+```
+
+### History (steps 1-4)
+
+- The server decides whether to initiate a worker command based on a state change (e.g., a user requesting activity cancellation).
+- The trigger logic creates one or more `WorkerCommand` protos and calls `GenerateWorkerCommandsTasks`, which persists them as an outbound task.
+- The outbound queue executor picks up the task and dispatches it to the worker's control queue via matching.
+
+### Matching (steps 4-5)
+
+- The `DispatchNexusTask` RPC is synchronous — matching holds the request until a worker polls the control queue and responds.
+- If no worker is polling, the request times out.
+- There is currently no way to distinguish a permanently gone worker from a temporarily slow one, so the dispatcher simply retries up to a maximum number of attempts before dropping the task. This is acceptable because worker commands are best-effort.
+
+### Worker (steps 6-8)
+
+- The worker's poller picks up the command from the control queue.
+- The worker executes the command and sends the response back through matching to the dispatcher.
+
+## Adding a new command
+
+1. **Define the proto** -- Add a new variant to `WorkerCommand` in [`message.proto`](https://github.com/temporalio/api/blob/master/temporal/api/worker/v1/message.proto) (api repo).
+2. **Add a trigger** -- Add server-side logic to detect the condition, create the command, and call `GenerateWorkerCommandsTasks` (see [`task_generator.go`](../../service/history/workflow/task_generator.go)).
+3. **Handle in the SDK** -- Add a handler for the new command variant in the SDK's worker command executor.
+
+Dispatch ([`worker_commands_task_dispatcher.go`](../../service/history/worker_commands_task_dispatcher.go)) and serialization ([`task_serializers.go`](../../common/persistence/serialization/task_serializers.go)) are command-agnostic and do not require changes.
+
+## Examples
+
+### Activity cancellation
+
+When a user requests activity cancellation, the server generates a cancel command targeting the worker's control queue (stored in `ActivityInfo` at activity start). The worker receives the command and cancels the running activity directly.
+
+- **History**: Workflow task completed handler detects a pending cancellation, creates the command, and calls `GenerateWorkerCommandsTasks`.
+- **Matching**: Handled by existing infrastructure — no command-specific logic needed.
+- **Worker**: The worker's command executor matches the cancel command to the running activity and cancels it.


### PR DESCRIPTION
## What

Adds an architecture doc for the worker commands framework — how commands flow from history through matching to workers, and how to add new command types.