### PR TITLE
Add wait before writing task batch

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1214,6 +1214,11 @@ Note: this should be greater than matching.longPollExpirationInterval and matchi
 		100,
 		`MatchingMaxTaskBatchSize is max batch size for task writer`,
 	)
+	MatchingTaskWriterMinWait = NewTaskQueueDurationSetting(
+		"matching.taskWriterMinWait",
+		0,
+		`Minimum time to wait after receiving the first task before writing a batch, to try to collect more tasks in a batch.`,
+	)
 	MatchingMaxTaskDeleteBatchSize = NewTaskQueueIntSetting(
 		"matching.maxTaskDeleteBatchSize",
 		100,

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -105,6 +105,7 @@ type (
 		// taskWriter configuration
 		OutstandingTaskAppendsThreshold dynamicconfig.IntPropertyFnWithTaskQueueFilter
 		MaxTaskBatchSize                dynamicconfig.IntPropertyFnWithTaskQueueFilter
+		TaskWriterMinWait               dynamicconfig.DurationPropertyFnWithTaskQueueFilter
 
 		ThrottledLogRPS dynamicconfig.IntPropertyFn
 
@@ -182,6 +183,7 @@ type (
 		// taskWriter configuration
 		OutstandingTaskAppendsThreshold func() int
 		MaxTaskBatchSize                func() int
+		TaskWriterMinWait               func() time.Duration
 		NumWritePartitions              func() int
 		NumReadPartitions               func() int
 		NumReadPartitionsSub            func(func(int)) (int, func())
@@ -287,6 +289,7 @@ func NewConfig(
 		TaskDeleteInterval:                       dynamicconfig.MatchingTaskDeleteInterval.Get(dc),
 		OutstandingTaskAppendsThreshold:          dynamicconfig.MatchingOutstandingTaskAppendsThreshold.Get(dc),
 		MaxTaskBatchSize:                         dynamicconfig.MatchingMaxTaskBatchSize.Get(dc),
+		TaskWriterMinWait:                        dynamicconfig.MatchingTaskWriterMinWait.Get(dc),
 		ThrottledLogRPS:                          dynamicconfig.MatchingThrottledLogRPS.Get(dc),
 		NumTaskqueueWritePartitions:              dynamicconfig.MatchingNumTaskqueueWritePartitions.Get(dc),
 		NumTaskqueueReadPartitions:               dynamicconfig.MatchingNumTaskqueueReadPartitions.Get(dc),
@@ -451,6 +454,9 @@ func newTaskQueueConfig(tq *tqid.TaskQueue, config *Config, ns namespace.Name) *
 		},
 		MaxTaskBatchSize: func() int {
 			return config.MaxTaskBatchSize(ns.String(), taskQueueName, taskType)
+		},
+		TaskWriterMinWait: func() time.Duration {
+			return config.TaskWriterMinWait(ns.String(), taskQueueName, taskType)
 		},
 		NumWritePartitions: func() int {
 			return max(1, config.NumTaskqueueWritePartitions(ns.String(), taskQueueName, taskType))

--- a/service/matching/fair_task_writer.go
+++ b/service/matching/fair_task_writer.go
@@ -193,6 +193,7 @@ func (w *fairTaskWriter) taskWriterLoop() {
 }
 
 func (w *fairTaskWriter) getWriteBatch(reqs []*writeTaskRequest) []*writeTaskRequest {
+	time.Sleep(w.config.TaskWriterMinWait())
 	for range w.config.MaxTaskBatchSize() - 1 {
 		select {
 		case req := <-w.appendCh:

--- a/service/matching/fair_task_writer.go
+++ b/service/matching/fair_task_writer.go
@@ -193,7 +193,9 @@ func (w *fairTaskWriter) taskWriterLoop() {
 }
 
 func (w *fairTaskWriter) getWriteBatch(reqs []*writeTaskRequest) []*writeTaskRequest {
-	time.Sleep(w.config.TaskWriterMinWait())
+	if len(w.appendCh) == 0 {
+		time.Sleep(w.config.TaskWriterMinWait())
+	}
 	for range w.config.MaxTaskBatchSize() - 1 {
 		select {
 		case req := <-w.appendCh:

--- a/service/matching/pri_task_writer.go
+++ b/service/matching/pri_task_writer.go
@@ -180,7 +180,9 @@ func (w *priTaskWriter) taskWriterLoop() {
 }
 
 func (w *priTaskWriter) getWriteBatch(reqs []*writeTaskRequest) []*writeTaskRequest {
-	time.Sleep(w.config.TaskWriterMinWait())
+	if len(w.appendCh) == 0 {
+		time.Sleep(w.config.TaskWriterMinWait())
+	}
 	for range w.config.MaxTaskBatchSize() - 1 {
 		select {
 		case req := <-w.appendCh:

--- a/service/matching/pri_task_writer.go
+++ b/service/matching/pri_task_writer.go
@@ -180,6 +180,7 @@ func (w *priTaskWriter) taskWriterLoop() {
 }
 
 func (w *priTaskWriter) getWriteBatch(reqs []*writeTaskRequest) []*writeTaskRequest {
+	time.Sleep(w.config.TaskWriterMinWait())
 	for range w.config.MaxTaskBatchSize() - 1 {
 		select {
 		case req := <-w.appendCh:

--- a/service/matching/task_writer.go
+++ b/service/matching/task_writer.go
@@ -180,6 +180,7 @@ func (w *taskWriter) taskWriterLoop() {
 }
 
 func (w *taskWriter) getWriteBatch(reqs []*writeTaskRequest) []*writeTaskRequest {
+	time.Sleep(w.config.TaskWriterMinWait())
 readLoop:
 	for i := 0; i < w.config.MaxTaskBatchSize(); i++ {
 		select {

--- a/service/matching/task_writer.go
+++ b/service/matching/task_writer.go
@@ -180,7 +180,9 @@ func (w *taskWriter) taskWriterLoop() {
 }
 
 func (w *taskWriter) getWriteBatch(reqs []*writeTaskRequest) []*writeTaskRequest {
-	time.Sleep(w.config.TaskWriterMinWait())
+	if len(w.appendCh) == 0 {
+		time.Sleep(w.config.TaskWriterMinWait())
+	}
 readLoop:
 	for i := 0; i < w.config.MaxTaskBatchSize(); i++ {
 		select {


### PR DESCRIPTION
## What changed?

Add a config to enable a small wait before collecting the rest of a batch in task writer (all of them).

## Why?

A small wait increases the chances of getting another task to add to the batch, which reduces overall database operations, at the cost of a tiny bit of extra latency for tasks that need to be backlogged.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

Delaying writes could put more stress on the transfer queue.

