### PR TITLE
tests: add timeouts and retries to build-and-publish.yml github action

### DIFF
--- a/.github/actions/build-docker-images/action.yml
+++ b/.github/actions/build-docker-images/action.yml
@@ -161,7 +161,17 @@ runs:
           unset ALPINE_TAG
         fi
 
-        docker buildx bake \
-          --push \
-          -f docker/docker-bake.hcl \
-          server admin-tools
+        for attempt in 1 2 3; do
+          echo "Docker build/push attempt $attempt/3"
+          if timeout 1200 docker buildx bake \
+              --push \
+              -f docker/docker-bake.hcl \
+              server admin-tools; then
+            exit 0
+          fi
+          if [ "$attempt" -lt 3 ]; then
+            echo "Attempt $attempt failed, retrying in 30s..."
+            sleep 30
+          fi
+        done
+        exit 1

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   build-and-push-docker:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     # Only push for main, cloud, release branches (not feature)
     if: |
       github.ref == 'refs/heads/main' ||


### PR DESCRIPTION
## What changed?
Add 3 retries and a 20 minutes (1200s) timeout to the `docker buildx bake` step which has timed out and caused 2 CI failures in the past few days

https://github.com/temporalio/temporal/actions/runs/24521270445/job/71679369507
https://github.com/temporalio/temporal/actions/runs/24480998119/job/71545236952

## Why?
Durability in CI

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
NA
