### PR TITLE
Only consider a history host unhealthy in the health check if it has been gone more than 10 seconds

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -807,7 +807,12 @@ This config is EXPERIMENTAL and may be changed or removed in a later release.`,
 	HistoryHostSelfErrorProportion = NewGlobalFloatSetting(
 		"frontend.historyHostSelfErrorProportion",
 		0.05,
-		`HistoryHostStartingProportion is the proportion of hosts that have marked themselves as not ready -- this could due to waiting to acquire all shards on startup, or an internal health check failure`,
+		`HistoryHostSelfErrorProportion is the proportion of hosts that have marked themselves as not ready -- this could due to waiting to acquire all shards on startup, or an internal health check failure`,
+	)
+	HistoryHostFailureTimeThreshold = NewGlobalDurationSetting(
+		"frontend.historyHostFailureTimeThreshold",
+		10*time.Second,
+		`HistoryHostFailureTimeThreshold is the length of time a host must have failed before it is considered unhealthy`,
 	)
 	SendRawWorkflowHistory = NewNamespaceBoolSetting(
 		"frontend.sendRawWorkflowHistory",

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -807,7 +807,7 @@ This config is EXPERIMENTAL and may be changed or removed in a later release.`,
 	HistoryHostSelfErrorProportion = NewGlobalFloatSetting(
 		"frontend.historyHostSelfErrorProportion",
 		0.05,
-		`HistoryHostSelfErrorProportion is the proportion of hosts that have marked themselves as not ready -- this could due to waiting to acquire all shards on startup, or an internal health check failure`,
+		`HistoryHostSelfErrorProportion is the proportion of hosts that have marked themselves as not ready -- this could be due to waiting to acquire all shards on startup, or an internal health check failure`,
 	)
 	HistoryHostFailureTimeThreshold = NewGlobalDurationSetting(
 		"frontend.historyHostFailureTimeThreshold",

--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -176,6 +176,7 @@ func NewAdminHandler(
 		args.MembershipMonitor,
 		args.Config.HistoryHostErrorPercentage,
 		args.Config.HistoryHostSelfErrorProportion,
+		args.Config.HistoryHostFailureTimeThreshold,
 		func(ctx context.Context, hostAddress string) (*historyservice.DeepHealthCheckResponse, error) {
 			return args.HistoryClient.DeepHealthCheck(ctx, &historyservice.DeepHealthCheckRequest{HostAddress: hostAddress})
 		},
@@ -258,7 +259,7 @@ func (adh *AdminHandler) DeepHealthCheck(
 ) (_ *adminservice.DeepHealthCheckResponse, retError error) {
 	defer log.CapturePanic(adh.logger, &retError)
 
-	result, err := adh.historyHealthChecker.Check(ctx)
+	result, err := adh.historyHealthChecker.Check(ctx, time.Now())
 	if err != nil {
 		return nil, err
 	}

--- a/service/frontend/health_check.go
+++ b/service/frontend/health_check.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sync"
+	"time"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	healthspb "go.temporal.io/server/api/health/v1"
@@ -23,7 +25,7 @@ type (
 	}
 
 	HealthChecker interface {
-		Check(ctx context.Context) (HealthCheckResult, error)
+		Check(ctx context.Context, now time.Time) (HealthCheckResult, error)
 	}
 
 	healthCheckerImpl struct {
@@ -31,7 +33,9 @@ type (
 		membershipMonitor             membership.Monitor
 		hostFailurePercentage         dynamicconfig.FloatPropertyFn
 		hostDeclinedServingProportion dynamicconfig.FloatPropertyFn
+		hostFailureTimeThreshold      dynamicconfig.DurationPropertyFn
 		healthCheckFn                 func(ctx context.Context, hostAddress string) (*historyservice.DeepHealthCheckResponse, error)
+		recentUnhealthyHosts          *unhealthyHostTracker
 		logger                        log.Logger
 	}
 
@@ -39,13 +43,70 @@ type (
 		address  string
 		response *historyservice.DeepHealthCheckResponse
 	}
+	unhealthyHostTracker struct {
+		mu    sync.Mutex
+		hosts map[string]unhealthyHostRecord
+	}
+	unhealthyHostRecord struct {
+		address        string
+		lastSeenHealth enumsspb.HealthState
+		failedAt       time.Time
+	}
 )
+
+var _ HealthChecker = (*healthCheckerImpl)(nil)
+
+func (u *unhealthyHostTracker) trackUnhealthyHost(address string, now time.Time, state enumsspb.HealthState) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	if existing, present := u.hosts[address]; !present && existing.lastSeenHealth != state {
+		u.hosts[address] = unhealthyHostRecord{
+			address:        address,
+			lastSeenHealth: state,
+			failedAt:       now,
+		}
+	}
+}
+
+func (u *unhealthyHostTracker) clearStaleEntries(details []*healthspb.HostHealthDetail) {
+	validAddresses := make(map[string]struct{})
+	for _, detail := range details {
+		// Keep any addresses that are failing or declined serving.
+		if detail.GetState() == enumsspb.HEALTH_STATE_SERVING {
+			continue
+		}
+		validAddresses[detail.GetAddress()] = struct{}{}
+	}
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	for address := range u.hosts {
+		if _, present := validAddresses[address]; !present {
+			delete(u.hosts, address)
+		}
+	}
+}
+
+func (u *unhealthyHostTracker) unhealthyHosts(now time.Time, duration time.Duration) (declinedServing []unhealthyHostRecord, otherUnhealthy []unhealthyHostRecord) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	for _, record := range u.hosts {
+		if now.Sub(record.failedAt) >= duration {
+			if record.lastSeenHealth == enumsspb.HEALTH_STATE_DECLINED_SERVING {
+				declinedServing = append(declinedServing, record)
+			} else {
+				otherUnhealthy = append(otherUnhealthy, record)
+			}
+		}
+	}
+	return
+}
 
 func NewHealthChecker(
 	serviceName primitives.ServiceName,
 	membershipMonitor membership.Monitor,
 	hostFailurePercentage dynamicconfig.FloatPropertyFn,
 	hostDeclinedServingProportion dynamicconfig.FloatPropertyFn,
+	hostFailureTimeThreshold dynamicconfig.DurationPropertyFn,
 	healthCheckFn func(ctx context.Context, hostAddress string) (*historyservice.DeepHealthCheckResponse, error),
 	logger log.Logger,
 ) HealthChecker {
@@ -54,12 +115,14 @@ func NewHealthChecker(
 		membershipMonitor:             membershipMonitor,
 		hostFailurePercentage:         hostFailurePercentage,
 		hostDeclinedServingProportion: hostDeclinedServingProportion,
+		hostFailureTimeThreshold:      hostFailureTimeThreshold,
 		healthCheckFn:                 healthCheckFn,
+		recentUnhealthyHosts:          &unhealthyHostTracker{hosts: make(map[string]unhealthyHostRecord)},
 		logger:                        logger,
 	}
 }
 
-func (h *healthCheckerImpl) Check(ctx context.Context) (HealthCheckResult, error) {
+func (h *healthCheckerImpl) Check(ctx context.Context, now time.Time) (HealthCheckResult, error) {
 	resolver, err := h.membershipMonitor.GetResolver(h.serviceName)
 	if err != nil {
 		return HealthCheckResult{
@@ -104,8 +167,6 @@ func (h *healthCheckerImpl) Check(ctx context.Context) (HealthCheckResult, error
 		}(host.GetAddress())
 	}
 
-	var failedHostCount float64
-	var hostDeclinedServingCount float64
 	var hostDetails []*healthspb.HostHealthDetail
 	var exampleFailedHost *healthspb.HostHealthDetail
 	for range hosts {
@@ -119,14 +180,9 @@ func (h *healthCheckerImpl) Check(ctx context.Context) (HealthCheckResult, error
 		}
 		hostDetails = append(hostDetails, detail)
 
-		switch state {
-		case enumsspb.HEALTH_STATE_SERVING:
-			// Do nothing.
-		case enumsspb.HEALTH_STATE_DECLINED_SERVING:
-			hostDeclinedServingCount++
-		default:
+		if detail.State != enumsspb.HEALTH_STATE_SERVING {
 			// NOT_SERVING, UNSPECIFIED, INTERNAL_ERROR, or any unknown state.
-			failedHostCount++
+			h.recentUnhealthyHosts.trackUnhealthyHost(result.address, now, state)
 			if exampleFailedHost == nil {
 				exampleFailedHost = detail
 			}
@@ -134,27 +190,32 @@ func (h *healthCheckerImpl) Check(ctx context.Context) (HealthCheckResult, error
 	}
 	close(receiveCh)
 
+	h.recentUnhealthyHosts.clearStaleEntries(hostDetails)
+	declinedServing, otherUnhealthy := h.recentUnhealthyHosts.unhealthyHosts(now, h.hostFailureTimeThreshold())
+
 	// Make sure that at lease 2 hosts must be not ready to trigger this check.
 	proportionOfDeclinedServiceHosts := ensureMinimumProportionOfHosts(h.hostDeclinedServingProportion(), len(hosts))
 
-	var overallState enumsspb.HealthState
-	hostDeclinedServingProportion := hostDeclinedServingCount / float64(len(hosts))
+	overallState := enumsspb.HEALTH_STATE_SERVING
+	hostDeclinedServingProportion := float64(len(declinedServing)) / float64(len(hosts))
+	failedHostCountProportion := float64(len(otherUnhealthy)) / float64(len(hosts))
+
+	if failedHostCountProportion+hostDeclinedServingProportion > h.hostFailurePercentage() {
+		overallState = enumsspb.HEALTH_STATE_NOT_SERVING
+	}
 	if hostDeclinedServingProportion > proportionOfDeclinedServiceHosts {
-		h.logger.Warn("health check exceeded host declined serving proportion threshold", tag.Float64("host declined serving proportion threshold", proportionOfDeclinedServiceHosts))
 		overallState = enumsspb.HEALTH_STATE_DECLINED_SERVING
-	} else {
-		failedHostCountProportion := failedHostCount / float64(len(hosts))
-		if failedHostCountProportion+hostDeclinedServingProportion > h.hostFailurePercentage() {
-			h.logger.Warn("health check exceeded host failure percentage threshold",
-				tag.Float64("host failure percentage threshold", h.hostFailurePercentage()),
-				tag.Float64("host failure percentage", failedHostCountProportion),
-				tag.Float64("host declined serving percentage", hostDeclinedServingProportion),
-				tag.NewStringTag("example_failed_host", failedHostSummary(exampleFailedHost)),
-			)
-			overallState = enumsspb.HEALTH_STATE_NOT_SERVING
-		} else {
-			overallState = enumsspb.HEALTH_STATE_SERVING
-		}
+	}
+	if overallState != enumsspb.HEALTH_STATE_SERVING {
+		h.logger.Warn("Health check determined the service is unhealthy!",
+			tag.Int("host failure count", len(otherUnhealthy)),
+			tag.Float64("host failure percentage threshold", h.hostFailurePercentage()),
+			tag.Float64("host failure percentage", failedHostCountProportion),
+			tag.Int("host declined serving count", len(declinedServing)),
+			tag.Float64("host declined serving percentage", hostDeclinedServingProportion),
+			tag.Float64("host declined serving percentage threshold", proportionOfDeclinedServiceHosts),
+			tag.NewStringTag("example_failed_host", failedHostSummary(exampleFailedHost)),
+		)
 	}
 
 	return HealthCheckResult{

--- a/service/frontend/health_check.go
+++ b/service/frontend/health_check.go
@@ -57,9 +57,9 @@ type (
 
 var _ HealthChecker = (*healthCheckerImpl)(nil)
 
+// trackUnhealthyHost tracks the last time a host failed health check.
+// Must be called with mu held.
 func (u *unhealthyHostTracker) trackUnhealthyHost(address string, now time.Time, state enumsspb.HealthState) {
-	u.mu.Lock()
-	defer u.mu.Unlock()
 	if existing, present := u.hosts[address]; !present || existing.lastSeenHealth != state {
 		// Preserve the earliest time that the host failed, even if it changes states
 		var failedAt time.Time
@@ -76,17 +76,17 @@ func (u *unhealthyHostTracker) trackUnhealthyHost(address string, now time.Time,
 	}
 }
 
-func (u *unhealthyHostTracker) clearStaleEntries(details []*healthspb.HostHealthDetail) {
+// clearStaleEntries removes any entries from the tracker that are no longer in the list of hosts.
+// Must be called with mu held.
+func (u *unhealthyHostTracker) clearStaleEntries(hosts []*healthspb.HostHealthDetail) {
 	validAddresses := make(map[string]struct{})
-	for _, detail := range details {
+	for _, host := range hosts {
 		// Keep any addresses that are failing or declined serving.
-		if detail.GetState() == enumsspb.HEALTH_STATE_SERVING {
+		if host.GetState() == enumsspb.HEALTH_STATE_SERVING {
 			continue
 		}
-		validAddresses[detail.GetAddress()] = struct{}{}
+		validAddresses[host.GetAddress()] = struct{}{}
 	}
-	u.mu.Lock()
-	defer u.mu.Unlock()
 	for address := range u.hosts {
 		if _, present := validAddresses[address]; !present {
 			delete(u.hosts, address)
@@ -94,9 +94,9 @@ func (u *unhealthyHostTracker) clearStaleEntries(details []*healthspb.HostHealth
 	}
 }
 
+// unhealthyHosts returns a list of hosts that have failed health check recently.
+// Must be called with mu held.
 func (u *unhealthyHostTracker) unhealthyHosts(now time.Time, duration time.Duration) (declinedServing []unhealthyHostRecord, otherUnhealthy []unhealthyHostRecord) {
-	u.mu.Lock()
-	defer u.mu.Unlock()
 	for _, record := range u.hosts {
 		if now.Sub(record.failedAt) >= duration {
 			if record.lastSeenHealth == enumsspb.HEALTH_STATE_DECLINED_SERVING {
@@ -107,6 +107,18 @@ func (u *unhealthyHostTracker) unhealthyHosts(now time.Time, duration time.Durat
 		}
 	}
 	return
+}
+
+// filterUnhealthyHosts updates the local host health entries while holding mu, then returns the unhealthy hosts.
+func (u *unhealthyHostTracker) filterUnhealthyHosts(hostHealths []*healthspb.HostHealthDetail, now time.Time,
+	threshold time.Duration) (declinedServing []unhealthyHostRecord, otherUnhealthy []unhealthyHostRecord) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	for _, result := range hostHealths {
+		u.trackUnhealthyHost(result.Address, now, result.State)
+	}
+	u.clearStaleEntries(hostHealths)
+	return u.unhealthyHosts(now, threshold)
 }
 
 func NewHealthChecker(
@@ -155,49 +167,8 @@ func (h *healthCheckerImpl) Check(ctx context.Context, now time.Time) (HealthChe
 		}, nil
 	}
 
-	receiveCh := make(chan hostResult, len(hosts))
-	for _, host := range hosts {
-		go func(hostAddress string) {
-			resp, err := h.checkHost(ctx, hostAddress)
-			if err != nil {
-				resp = &historyservice.DeepHealthCheckResponse{
-					State: enumsspb.HEALTH_STATE_NOT_SERVING,
-					Checks: []*healthspb.HealthCheck{
-						{
-							CheckType: health.CheckTypeHostAvailability,
-							State:     enumsspb.HEALTH_STATE_NOT_SERVING,
-							Message:   fmt.Sprintf("failed to reach host for health check: %v", err),
-						},
-					},
-				}
-			}
-			receiveCh <- hostResult{address: hostAddress, response: resp}
-		}(host.GetAddress())
-	}
-
-	var hostDetails []*healthspb.HostHealthDetail
-	var exampleFailedHost *healthspb.HostHealthDetail
-	for range hosts {
-		result := <-receiveCh
-		state := result.response.GetState()
-
-		detail := &healthspb.HostHealthDetail{
-			Address: result.address,
-			State:   state,
-			Checks:  result.response.GetChecks(),
-		}
-		hostDetails = append(hostDetails, detail)
-
-		if detail.State != enumsspb.HEALTH_STATE_SERVING {
-			// NOT_SERVING, UNSPECIFIED, INTERNAL_ERROR, or any unknown state.
-			h.recentUnhealthyHosts.trackUnhealthyHost(result.address, now, state)
-			exampleFailedHost = detail
-		}
-	}
-	close(receiveCh)
-
-	h.recentUnhealthyHosts.clearStaleEntries(hostDetails)
-	declinedServing, otherUnhealthy := h.recentUnhealthyHosts.unhealthyHosts(now, h.hostFailureTimeThreshold())
+	hostDetails := h.collectHostHealth(ctx, hosts)
+	declinedServing, otherUnhealthy := h.recentUnhealthyHosts.filterUnhealthyHosts(hostDetails, now, h.hostFailureTimeThreshold())
 
 	// Make sure that at lease 2 hosts must be not ready to trigger this check.
 	proportionOfDeclinedServiceHosts := ensureMinimumProportionOfHosts(h.hostDeclinedServingProportion(), len(hosts))
@@ -213,6 +184,13 @@ func (h *healthCheckerImpl) Check(ctx context.Context, now time.Time) (HealthChe
 		overallState = enumsspb.HEALTH_STATE_DECLINED_SERVING
 	}
 	if overallState != enumsspb.HEALTH_STATE_SERVING {
+		var exampleFailedHost *healthspb.HostHealthDetail
+		for _, host := range hostDetails {
+			if host.State != enumsspb.HEALTH_STATE_SERVING {
+				exampleFailedHost = host
+				break
+			}
+		}
 		h.logger.Warn("Health check determined the service is unhealthy!",
 			tag.Int("host failure count", len(otherUnhealthy)),
 			tag.Float64("host failure percentage threshold", h.hostFailurePercentage()),
@@ -232,6 +210,43 @@ func (h *healthCheckerImpl) Check(ctx context.Context, now time.Time) (HealthChe
 			Hosts:   hostDetails,
 		},
 	}, nil
+}
+
+func (h *healthCheckerImpl) collectHostHealth(ctx context.Context, hosts []membership.HostInfo) []*healthspb.HostHealthDetail {
+	hostDetails := make([]*healthspb.HostHealthDetail, 0, len(hosts))
+	receiveCh := make(chan hostResult, len(hosts))
+	defer close(receiveCh)
+	for _, host := range hosts {
+		go func(hostAddress string) {
+			resp, err := h.checkHost(ctx, hostAddress)
+			if err != nil {
+				resp = &historyservice.DeepHealthCheckResponse{
+					State: enumsspb.HEALTH_STATE_NOT_SERVING,
+					Checks: []*healthspb.HealthCheck{
+						{
+							CheckType: health.CheckTypeHostAvailability,
+							State:     enumsspb.HEALTH_STATE_NOT_SERVING,
+							Message:   fmt.Sprintf("failed to reach host for health check: %v", err),
+						},
+					},
+				}
+			}
+			receiveCh <- hostResult{address: hostAddress, response: resp}
+		}(host.GetAddress())
+	}
+
+	for range hosts {
+		result := <-receiveCh
+		state := result.response.GetState()
+
+		detail := &healthspb.HostHealthDetail{
+			Address: result.address,
+			State:   state,
+			Checks:  result.response.GetChecks(),
+		}
+		hostDetails = append(hostDetails, detail)
+	}
+	return hostDetails
 }
 
 func (h *healthCheckerImpl) checkHost(ctx context.Context, hostAddress string) (resp *historyservice.DeepHealthCheckResponse, retErr error) {

--- a/service/frontend/health_check.go
+++ b/service/frontend/health_check.go
@@ -3,7 +3,6 @@ package frontend
 import (
 	"context"
 	"fmt"
-	"math"
 	"slices"
 	"sync"
 	"time"
@@ -55,6 +54,7 @@ type (
 	}
 )
 
+// Compile-time assert: healthCheckerImpl implements HealthChecker
 var _ HealthChecker = (*healthCheckerImpl)(nil)
 
 // trackUnhealthyHost tracks the last time a host failed health check.
@@ -109,13 +109,16 @@ func (u *unhealthyHostTracker) unhealthyHosts(now time.Time, duration time.Durat
 	return
 }
 
-// filterUnhealthyHosts updates the local host health entries while holding mu, then returns the unhealthy hosts.
-func (u *unhealthyHostTracker) filterUnhealthyHosts(hostHealths []*healthspb.HostHealthDetail, now time.Time,
+// updateUnhealthyHosts updates the local host health entries while holding mu, then returns the unhealthy hosts.
+func (u *unhealthyHostTracker) updateUnhealthyHosts(hostHealths []*healthspb.HostHealthDetail, now time.Time,
 	threshold time.Duration) (declinedServing []unhealthyHostRecord, otherUnhealthy []unhealthyHostRecord) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 	for _, result := range hostHealths {
-		u.trackUnhealthyHost(result.Address, now, result.State)
+		// Only track unhealthy hosts, healthy hosts will be cleaned up in clearStaleEntries
+		if result.GetState() != enumsspb.HEALTH_STATE_SERVING {
+			u.trackUnhealthyHost(result.Address, now, result.State)
+		}
 	}
 	u.clearStaleEntries(hostHealths)
 	return u.unhealthyHosts(now, threshold)
@@ -168,10 +171,7 @@ func (h *healthCheckerImpl) Check(ctx context.Context, now time.Time) (HealthChe
 	}
 
 	hostDetails := h.collectHostHealth(ctx, hosts)
-	declinedServing, otherUnhealthy := h.recentUnhealthyHosts.filterUnhealthyHosts(hostDetails, now, h.hostFailureTimeThreshold())
-
-	// Make sure that at lease 2 hosts must be not ready to trigger this check.
-	proportionOfDeclinedServiceHosts := ensureMinimumProportionOfHosts(h.hostDeclinedServingProportion(), len(hosts))
+	declinedServing, otherUnhealthy := h.recentUnhealthyHosts.updateUnhealthyHosts(hostDetails, now, h.hostFailureTimeThreshold())
 
 	overallState := enumsspb.HEALTH_STATE_SERVING
 	hostDeclinedServingProportion := float64(len(declinedServing)) / float64(len(hosts))
@@ -180,7 +180,7 @@ func (h *healthCheckerImpl) Check(ctx context.Context, now time.Time) (HealthChe
 	if failedHostCountProportion+hostDeclinedServingProportion > h.hostFailurePercentage() {
 		overallState = enumsspb.HEALTH_STATE_NOT_SERVING
 	}
-	if hostDeclinedServingProportion > proportionOfDeclinedServiceHosts {
+	if len(declinedServing) > 2 && hostDeclinedServingProportion > h.hostDeclinedServingProportion() {
 		overallState = enumsspb.HEALTH_STATE_DECLINED_SERVING
 	}
 	if overallState != enumsspb.HEALTH_STATE_SERVING {
@@ -197,7 +197,7 @@ func (h *healthCheckerImpl) Check(ctx context.Context, now time.Time) (HealthChe
 			tag.Float64("host failure percentage", failedHostCountProportion),
 			tag.Int("host declined serving count", len(declinedServing)),
 			tag.Float64("host declined serving percentage", hostDeclinedServingProportion),
-			tag.Float64("host declined serving percentage threshold", proportionOfDeclinedServiceHosts),
+			tag.Float64("host declined serving percentage threshold", h.hostDeclinedServingProportion()),
 			tag.NewStringTag("example_failed_host", failedHostSummary(exampleFailedHost)),
 		)
 	}
@@ -282,10 +282,4 @@ func failedHostSummary(host *healthspb.HostHealthDetail) string {
 		}
 	}
 	return fmt.Sprintf("%s: %s", host.GetAddress(), host.GetState().String())
-}
-
-func ensureMinimumProportionOfHosts(proportionOfDeclinedServingHosts float64, totalHosts int) float64 {
-	const minimumHostsFailed = 2.0 // We want to ensure that at least 2 fail before we notify the upstream.
-	minimumProportion := minimumHostsFailed / float64(totalHosts)
-	return math.Max(proportionOfDeclinedServingHosts, minimumProportion)
 }

--- a/service/frontend/health_check.go
+++ b/service/frontend/health_check.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 	"sync"
 	"time"
 
@@ -59,11 +60,18 @@ var _ HealthChecker = (*healthCheckerImpl)(nil)
 func (u *unhealthyHostTracker) trackUnhealthyHost(address string, now time.Time, state enumsspb.HealthState) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
-	if existing, present := u.hosts[address]; !present && existing.lastSeenHealth != state {
+	if existing, present := u.hosts[address]; !present || existing.lastSeenHealth != state {
+		// Preserve the earliest time that the host failed, even if it changes states
+		var failedAt time.Time
+		if present {
+			failedAt = slices.MinFunc([]time.Time{now, existing.failedAt}, time.Time.Compare)
+		} else {
+			failedAt = now
+		}
 		u.hosts[address] = unhealthyHostRecord{
 			address:        address,
 			lastSeenHealth: state,
-			failedAt:       now,
+			failedAt:       failedAt,
 		}
 	}
 }
@@ -183,9 +191,7 @@ func (h *healthCheckerImpl) Check(ctx context.Context, now time.Time) (HealthChe
 		if detail.State != enumsspb.HEALTH_STATE_SERVING {
 			// NOT_SERVING, UNSPECIFIED, INTERNAL_ERROR, or any unknown state.
 			h.recentUnhealthyHosts.trackUnhealthyHost(result.address, now, state)
-			if exampleFailedHost == nil {
-				exampleFailedHost = detail
-			}
+			exampleFailedHost = detail
 		}
 	}
 	close(receiveCh)

--- a/service/frontend/health_check_test.go
+++ b/service/frontend/health_check_test.go
@@ -151,6 +151,15 @@ func (s *healthCheckerSuite) Test_Unhealthy_Host_Tracker() {
 	s.Require().Empty(otherUnhealthy, "Should be no other unhealthy hosts. Instead found: %+v", otherUnhealthy)
 }
 
+func (s *healthCheckerSuite) Test_Unhealthy_Host_Tracker_Ignore_Healthy() {
+	tracker := &unhealthyHostTracker{hosts: make(map[string]unhealthyHostRecord)}
+	tracker.updateUnhealthyHosts([]*healthspb.HostHealthDetail{
+		{Address: "A", State: enumsspb.HEALTH_STATE_SERVING},
+		{Address: "B", State: enumsspb.HEALTH_STATE_SERVING},
+	}, time.Unix(2, 0), 1*time.Second)
+	s.Require().Empty(tracker.hosts)
+}
+
 func (s *healthCheckerSuite) Test_Check_Serving() {
 	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
 		membership.NewHostInfoFromAddress("servingA"),
@@ -422,45 +431,4 @@ func (s *healthCheckerSuite) Test_Check_HostChecks_Propagated() {
 	s.Equal(health.CheckTypeRPCLatency, host.Checks[0].CheckType)
 	s.InDelta(850.0, host.Checks[0].Value, 0.01)
 	s.InDelta(500.0, host.Checks[0].Threshold, 0.01)
-}
-
-func (s *healthCheckerSuite) Test_GetProportionOfNotReadyHosts() {
-	testCases := []struct {
-		name                             string
-		proportionOfDeclinedServingHosts float64
-		totalHosts                       int
-		expectedProportion               float64
-	}{
-		{
-			name:                             "zero proportion",
-			proportionOfDeclinedServingHosts: 0.0,
-			totalHosts:                       10,
-			expectedProportion:               0.2,
-		},
-		{
-			name:                             "small proportion with few hosts",
-			proportionOfDeclinedServingHosts: 0.1,
-			totalHosts:                       10,
-			expectedProportion:               0.2, // 2/10 = 0.2 since numHostsToFail < 2
-		},
-		{
-			name:                             "small proportion with many hosts",
-			proportionOfDeclinedServingHosts: 0.1,
-			totalHosts:                       100,
-			expectedProportion:               0.1, // 10 hosts > 2, so use original proportion
-		},
-		{
-			name:                             "large proportion",
-			proportionOfDeclinedServingHosts: 0.8,
-			totalHosts:                       10,
-			expectedProportion:               0.8, // 8 hosts > 2, so use original proportion
-		},
-	}
-
-	for _, tc := range testCases {
-		s.Run(tc.name, func() {
-			proportion := ensureMinimumProportionOfHosts(tc.proportionOfDeclinedServingHosts, tc.totalHosts)
-			s.Equal(tc.expectedProportion, proportion)
-		})
-	}
 }

--- a/service/frontend/health_check_test.go
+++ b/service/frontend/health_check_test.go
@@ -79,13 +79,16 @@ func (s *healthCheckerSuite) Test_Unique_Host_Health() {
 	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
 		membership.NewHostInfoFromAddress("servingA"),
 		membership.NewHostInfoFromAddress("errorB"),
-	}).Times(2)
+	}).Times(4)
 	result, err := s.checker.Check(context.Background(), time.Unix(1, 0))
 	s.Require().NoError(err)
 	s.Equal(enumsspb.HEALTH_STATE_SERVING, result.State)
-	result, err = s.checker.Check(context.Background(), time.Unix(2, 0))
-	s.Require().NoError(err)
-	s.Equal(enumsspb.HEALTH_STATE_NOT_SERVING, result.State)
+	// Make sure a consistent unhealthy host keeps the state in NOT_SERVING
+	for i := range 3 {
+		result, err = s.checker.Check(context.Background(), time.Unix(int64(i)+2, 0))
+		s.Require().NoError(err)
+		s.Equal(enumsspb.HEALTH_STATE_NOT_SERVING, result.State)
+	}
 	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
 		membership.NewHostInfoFromAddress("servingA"),
 		membership.NewHostInfoFromAddress("errorC"),
@@ -100,6 +103,52 @@ func (s *healthCheckerSuite) Test_Unique_Host_Health() {
 	result, err = s.checker.Check(context.Background(), time.Unix(4, 0))
 	s.Require().NoError(err)
 	s.Equal(enumsspb.HEALTH_STATE_SERVING, result.State)
+}
+
+func (s *healthCheckerSuite) Test_Unhealthy_Host_Tracker() {
+	tracker := &unhealthyHostTracker{hosts: make(map[string]unhealthyHostRecord)}
+	tracker.trackUnhealthyHost("A", time.Unix(1, 0), enumsspb.HEALTH_STATE_NOT_SERVING)
+	tracker.trackUnhealthyHost("B", time.Unix(1, 0), enumsspb.HEALTH_STATE_DECLINED_SERVING)
+	tracker.trackUnhealthyHost("C", time.Unix(1, 0), enumsspb.HEALTH_STATE_INTERNAL_ERROR)
+	declinedServing, otherUnhealthy := tracker.unhealthyHosts(time.Unix(2, 0), 1*time.Second)
+	s.Require().Len(declinedServing, 1, "Should be one declined host. Instead found: %+v", declinedServing)
+	s.Require().Len(otherUnhealthy, 2, "Should be two other unhealthy hosts. Instead found: %+v", otherUnhealthy)
+	declinedServing, otherUnhealthy = tracker.unhealthyHosts(time.Unix(1, 0), 1*time.Second)
+	s.Require().Len(declinedServing, 0, "Should be no declined hosts. Instead found: %+v", declinedServing)
+	s.Require().Len(otherUnhealthy, 0, "Should be no other unhealthy hosts. Instead found: %+v", otherUnhealthy)
+
+	// Demonstrate status updates to existing host
+	tracker.trackUnhealthyHost("A", time.Unix(2, 0), enumsspb.HEALTH_STATE_NOT_SERVING)
+	s.Require().Equal(tracker.hosts["A"].failedAt, time.Unix(1, 0), "Host A should keep original time, but was %v", tracker.hosts["A"].failedAt.Unix())
+	tracker.trackUnhealthyHost("A", time.Unix(3, 0), enumsspb.HEALTH_STATE_DECLINED_SERVING)
+	s.Require().Equal(tracker.hosts["A"].lastSeenHealth, enumsspb.HEALTH_STATE_DECLINED_SERVING, "Host A should now be DECLINED_SERVING, but was %s", tracker.hosts["A"].lastSeenHealth.String())
+	s.Require().Equal(tracker.hosts["A"].failedAt, time.Unix(1, 0), "Host A should keep original time, but was %v", tracker.hosts["A"].failedAt.Unix())
+
+	// Test stale entries
+	tracker.clearStaleEntries([]*healthspb.HostHealthDetail{
+		{Address: "A", State: enumsspb.HEALTH_STATE_DECLINED_SERVING},
+		{Address: "B", State: enumsspb.HEALTH_STATE_DECLINED_SERVING},
+		{Address: "C", State: enumsspb.HEALTH_STATE_INTERNAL_ERROR},
+	})
+	declinedServing, otherUnhealthy = tracker.unhealthyHosts(time.Unix(2, 0), 1*time.Second)
+	// No change
+	s.Require().Len(declinedServing, 2, "Should be two declined hosts. Instead found: %+v", declinedServing)
+	s.Require().Len(otherUnhealthy, 1, "Should be one other unhealthy host. Instead found: %+v", otherUnhealthy)
+	tracker.clearStaleEntries([]*healthspb.HostHealthDetail{
+		{Address: "A", State: enumsspb.HEALTH_STATE_DECLINED_SERVING},
+		{Address: "B", State: enumsspb.HEALTH_STATE_SERVING},
+		{Address: "C", State: enumsspb.HEALTH_STATE_INTERNAL_ERROR},
+	})
+	declinedServing, otherUnhealthy = tracker.unhealthyHosts(time.Unix(2, 0), 1*time.Second)
+	// Declined host is healthy now!
+	s.Require().Len(declinedServing, 1, "Should be one declined host. Instead found: %+v", declinedServing)
+	s.Require().Len(otherUnhealthy, 1, "Should be one other unhealthy host. Instead found: %+v", otherUnhealthy)
+
+	tracker.clearStaleEntries([]*healthspb.HostHealthDetail{})
+	// Host list empty -> No more unhealthy hosts
+	declinedServing, otherUnhealthy = tracker.unhealthyHosts(time.Unix(2, 0), 1*time.Second)
+	s.Require().Len(declinedServing, 0, "Should be no declined hosts. Instead found: %+v", declinedServing)
+	s.Require().Len(otherUnhealthy, 0, "Should be no other unhealthy hosts. Instead found: %+v", otherUnhealthy)
 }
 
 func (s *healthCheckerSuite) Test_Check_Serving() {

--- a/service/frontend/health_check_test.go
+++ b/service/frontend/health_check_test.go
@@ -3,7 +3,9 @@ package frontend
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -48,17 +50,18 @@ func (s *healthCheckerSuite) SetupTest() {
 		func() float64 {
 			return 0.15
 		},
+		func() time.Duration {
+			return 0 * time.Second
+		},
 		func(ctx context.Context, hostAddress string) (*historyservice.DeepHealthCheckResponse, error) {
-			switch hostAddress {
-			case "1", "3":
+			if strings.HasPrefix(hostAddress, "serving") {
 				return &historyservice.DeepHealthCheckResponse{State: enumsspb.HEALTH_STATE_SERVING}, nil
-			case "2":
+			} else if strings.HasPrefix(hostAddress, "error") {
 				return nil, errors.New("test")
-			case "4":
+			} else if strings.HasPrefix(hostAddress, "declined") {
 				return &historyservice.DeepHealthCheckResponse{State: enumsspb.HEALTH_STATE_DECLINED_SERVING}, nil
-			default:
-				return &historyservice.DeepHealthCheckResponse{State: enumsspb.HEALTH_STATE_NOT_SERVING}, nil
 			}
+			return &historyservice.DeepHealthCheckResponse{State: enumsspb.HEALTH_STATE_NOT_SERVING}, nil
 		},
 		log.NewNoopLogger(),
 	)
@@ -75,43 +78,43 @@ func (s *healthCheckerSuite) TearDownTest() {
 
 func (s *healthCheckerSuite) Test_Check_Serving() {
 	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
-		membership.NewHostInfoFromAddress("1"),
-		membership.NewHostInfoFromAddress("2"),
-		membership.NewHostInfoFromAddress("3"),
-		membership.NewHostInfoFromAddress("1"),
+		membership.NewHostInfoFromAddress("servingA"),
+		membership.NewHostInfoFromAddress("errorB"),
+		membership.NewHostInfoFromAddress("servingC"),
+		membership.NewHostInfoFromAddress("servingD"),
 	})
 
-	result, err := s.checker.Check(context.Background())
+	result, err := s.checker.Check(context.Background(), time.Now())
 	s.NoError(err)
 	s.Equal(enumsspb.HEALTH_STATE_SERVING, result.State)
 }
 
 func (s *healthCheckerSuite) Test_Check_Not_Serving() {
 	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
-		membership.NewHostInfoFromAddress("1"),
-		membership.NewHostInfoFromAddress("2"),
-		membership.NewHostInfoFromAddress("3"),
-		membership.NewHostInfoFromAddress("4"),
-		membership.NewHostInfoFromAddress("5"),
+		membership.NewHostInfoFromAddress("servingA"),
+		membership.NewHostInfoFromAddress("errorB"),
+		membership.NewHostInfoFromAddress("servingC"),
+		membership.NewHostInfoFromAddress("declinedD"),
+		membership.NewHostInfoFromAddress("E"), //not-serving
 	})
 
-	result, err := s.checker.Check(context.Background())
+	result, err := s.checker.Check(context.Background(), time.Now())
 	s.NoError(err)
 	s.Equal(enumsspb.HEALTH_STATE_NOT_SERVING, result.State)
 }
 
 func (s *healthCheckerSuite) Test_Check_Declined_Serving() {
 	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
-		membership.NewHostInfoFromAddress("1"),
-		membership.NewHostInfoFromAddress("2"),
-		membership.NewHostInfoFromAddress("4"),
-		membership.NewHostInfoFromAddress("4"),
-		membership.NewHostInfoFromAddress("4"),
-		membership.NewHostInfoFromAddress("4"),
-		membership.NewHostInfoFromAddress("7"),
+		membership.NewHostInfoFromAddress("servingA"),
+		membership.NewHostInfoFromAddress("errorB"),
+		membership.NewHostInfoFromAddress("declinedC"),
+		membership.NewHostInfoFromAddress("declinedD"),
+		membership.NewHostInfoFromAddress("declinedE"),
+		membership.NewHostInfoFromAddress("declinedF"),
+		membership.NewHostInfoFromAddress("G"),
 	})
 
-	result, err := s.checker.Check(context.Background())
+	result, err := s.checker.Check(context.Background(), time.Now())
 	s.NoError(err)
 	s.Equal(enumsspb.HEALTH_STATE_DECLINED_SERVING, result.State)
 }
@@ -119,7 +122,7 @@ func (s *healthCheckerSuite) Test_Check_Declined_Serving() {
 func (s *healthCheckerSuite) Test_Check_No_Available_Hosts() {
 	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{})
 
-	result, err := s.checker.Check(context.Background())
+	result, err := s.checker.Check(context.Background(), time.Now())
 	s.NoError(err)
 	s.Equal(enumsspb.HEALTH_STATE_NOT_SERVING, result.State)
 	s.NotNil(result.ServiceDetail)
@@ -136,13 +139,16 @@ func (s *healthCheckerSuite) Test_Check_GetResolver_Error() {
 		membershipMonitor,
 		func() float64 { return 0.25 },
 		func() float64 { return 0.15 },
+		func() time.Duration {
+			return 0 * time.Second
+		},
 		func(ctx context.Context, hostAddress string) (*historyservice.DeepHealthCheckResponse, error) {
 			return &historyservice.DeepHealthCheckResponse{State: enumsspb.HEALTH_STATE_SERVING}, nil
 		},
 		log.NewNoopLogger(),
 	)
 
-	result, err := checker.Check(context.Background())
+	result, err := checker.Check(context.Background(), time.Now())
 	s.Error(err)
 	s.Equal(enumsspb.HEALTH_STATE_INTERNAL_ERROR, result.State)
 	s.Contains(err.Error(), "resolver error")
@@ -155,13 +161,13 @@ func (s *healthCheckerSuite) Test_Check_Boundary_Failure_Percentage_Equals_Thres
 	// Test when failure percentage exactly equals the threshold (0.25)
 	// With 4 hosts, 1 failed = 0.25 (25%), should return SERVING since it's not > threshold
 	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
-		membership.NewHostInfoFromAddress("1"), // SERVING
-		membership.NewHostInfoFromAddress("2"), // NOT_SERVING (failed)
-		membership.NewHostInfoFromAddress("3"), // SERVING
-		membership.NewHostInfoFromAddress("1"), // SERVING
+		membership.NewHostInfoFromAddress("servingA"), // SERVING
+		membership.NewHostInfoFromAddress("errorB"),   // NOT_SERVING (failed)
+		membership.NewHostInfoFromAddress("servingC"), // SERVING
+		membership.NewHostInfoFromAddress("servingD"), // SERVING
 	})
 
-	result, err := s.checker.Check(context.Background())
+	result, err := s.checker.Check(context.Background(), time.Now())
 	s.NoError(err)
 	s.Equal(enumsspb.HEALTH_STATE_SERVING, result.State)
 }
@@ -174,22 +180,22 @@ func (s *healthCheckerSuite) Test_Check_Single_Host_Scenarios() {
 	}{
 		{
 			name:          "single host serving",
-			hostAddress:   "1", // SERVING
+			hostAddress:   "servingA", // SERVING
 			expectedState: enumsspb.HEALTH_STATE_SERVING,
 		},
 		{
 			name:          "single host failed",
-			hostAddress:   "2", // NOT_SERVING (failed)
+			hostAddress:   "errorA", // NOT_SERVING (failed)
 			expectedState: enumsspb.HEALTH_STATE_NOT_SERVING,
 		},
 		{
 			name:          "single host declined serving",
-			hostAddress:   "4",                               // DECLINED_SERVING
+			hostAddress:   "declinedA",                       // DECLINED_SERVING
 			expectedState: enumsspb.HEALTH_STATE_NOT_SERVING, // Combined logic: 0% failed + 100% declined = 100% > 25% threshold
 		},
 		{
 			name:          "single host not serving",
-			hostAddress:   "5", // NOT_SERVING
+			hostAddress:   "A", // NOT_SERVING
 			expectedState: enumsspb.HEALTH_STATE_NOT_SERVING,
 		},
 	}
@@ -200,7 +206,7 @@ func (s *healthCheckerSuite) Test_Check_Single_Host_Scenarios() {
 				membership.NewHostInfoFromAddress(tc.hostAddress),
 			})
 
-			result, err := s.checker.Check(context.Background())
+			result, err := s.checker.Check(context.Background(), time.Now())
 			s.NoError(err)
 			s.Equal(tc.expectedState, result.State)
 		})
@@ -209,8 +215,8 @@ func (s *healthCheckerSuite) Test_Check_Single_Host_Scenarios() {
 
 func (s *healthCheckerSuite) Test_Check_Context_Cancellation() {
 	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
-		membership.NewHostInfoFromAddress("1"),
-		membership.NewHostInfoFromAddress("2"),
+		membership.NewHostInfoFromAddress("servingA"),
+		membership.NewHostInfoFromAddress("errorB"),
 	})
 
 	// Create a cancelled context
@@ -223,6 +229,9 @@ func (s *healthCheckerSuite) Test_Check_Context_Cancellation() {
 		s.membershipMonitor,
 		func() float64 { return 0.25 },
 		func() float64 { return 0.15 },
+		func() time.Duration {
+			return 0 * time.Second
+		},
 		func(ctx context.Context, hostAddress string) (*historyservice.DeepHealthCheckResponse, error) {
 			select {
 			case <-ctx.Done():
@@ -234,7 +243,7 @@ func (s *healthCheckerSuite) Test_Check_Context_Cancellation() {
 		log.NewNoopLogger(),
 	)
 
-	result, err := checker.Check(ctx)
+	result, err := checker.Check(ctx, time.Now())
 	s.Require().NoError(err)                                 // Context cancellation in individual health checks should not fail the overall check
 	s.Equal(enumsspb.HEALTH_STATE_NOT_SERVING, result.State) // All hosts will return NOT_SERVING due to cancellation
 }
@@ -248,31 +257,31 @@ func (s *healthCheckerSuite) Test_Check_Mixed_Host_States_Edge_Cases() {
 	}{
 		{
 			name:          "edge case: 50% declined serving equals minimum threshold",
-			hosts:         []string{"4", "4", "1", "1"},      // 2 declined, 2 serving out of 4
-			expectedState: enumsspb.HEALTH_STATE_NOT_SERVING, // Combined: 0% failed + 50% declined = 50% > 25% threshold
+			hosts:         []string{"declinedA", "declinedB", "servingC", "servingD"}, // 2 declined, 2 serving out of 4
+			expectedState: enumsspb.HEALTH_STATE_NOT_SERVING,                          // Combined: 0% failed + 50% declined = 50% > 25% threshold
 			description:   "50% declined serving triggers combined failure threshold, returns NOT_SERVING",
 		},
 		{
 			name:          "edge case: 60% declined serving exceeds minimum threshold",
-			hosts:         []string{"4", "4", "4", "1", "1"},      // 3 declined, 2 serving out of 5
-			expectedState: enumsspb.HEALTH_STATE_DECLINED_SERVING, // 60% > 40% minimum threshold
+			hosts:         []string{"declinedA", "declinedB", "declinedC", "servingD", "servingE"}, // 3 declined, 2 serving out of 5
+			expectedState: enumsspb.HEALTH_STATE_DECLINED_SERVING,                                  // 60% > 40% minimum threshold
 			description:   "60% declined serving should trigger DECLINED_SERVING response",
 		},
 		{
 			name:          "edge case: mixed failures just under threshold",
-			hosts:         []string{"2", "1", "1", "1", "1"}, // 1 failed (20%), 4 serving (80%) out of 5
-			expectedState: enumsspb.HEALTH_STATE_SERVING,     // 20% < 25% threshold
+			hosts:         []string{"errorA", "servingB", "servingC", "servingD", "servingE"}, // 1 failed (20%), 4 serving (80%) out of 5
+			expectedState: enumsspb.HEALTH_STATE_SERVING,                                      // 20% < 25% threshold
 			description:   "20% failures should still return SERVING",
 		},
 		{
 			name:          "edge case: combined failures and declined just over threshold",
-			hosts:         []string{"2", "4", "1", "1"}, // 1 failed (25%) + 1 declined (25%) = 50% > 25% threshold
+			hosts:         []string{"errorA", "declinedB", "servingC", "servingD"}, // 1 failed (25%) + 1 declined (25%) = 50% > 25% threshold
 			expectedState: enumsspb.HEALTH_STATE_NOT_SERVING,
 			description:   "Combined 50% failures and declined serving should trigger NOT_SERVING",
 		},
 		{
 			name:          "edge case: all declined serving with many hosts",
-			hosts:         []string{"4", "4", "4", "4", "4"}, // All declined serving
+			hosts:         []string{"declinedA", "declinedB", "declinedC", "declinedD", "declinedE"}, // All declined serving
 			expectedState: enumsspb.HEALTH_STATE_DECLINED_SERVING,
 			description:   "100% declined serving should return DECLINED_SERVING",
 		},
@@ -286,7 +295,7 @@ func (s *healthCheckerSuite) Test_Check_Mixed_Host_States_Edge_Cases() {
 			}
 			s.resolver.EXPECT().AvailableMembers().Return(hostInfos)
 
-			result, err := s.checker.Check(context.Background())
+			result, err := s.checker.Check(context.Background(), time.Now())
 			s.NoError(err, tc.description)
 			s.Equal(tc.expectedState, result.State, tc.description)
 		})
@@ -295,11 +304,11 @@ func (s *healthCheckerSuite) Test_Check_Mixed_Host_States_Edge_Cases() {
 
 func (s *healthCheckerSuite) Test_Check_ServiceDetail_Populated() {
 	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
-		membership.NewHostInfoFromAddress("1"),
-		membership.NewHostInfoFromAddress("2"),
+		membership.NewHostInfoFromAddress("servingA"),
+		membership.NewHostInfoFromAddress("errorB"),
 	})
 
-	result, err := s.checker.Check(context.Background())
+	result, err := s.checker.Check(context.Background(), time.Now())
 	s.Require().NoError(err)
 	s.NotNil(result.ServiceDetail)
 	s.Equal("history", result.ServiceDetail.Service)
@@ -330,6 +339,9 @@ func (s *healthCheckerSuite) Test_Check_HostChecks_Propagated() {
 		membershipMonitor,
 		func() float64 { return 0.25 },
 		func() float64 { return 0.15 },
+		func() time.Duration {
+			return 0 * time.Second
+		},
 		func(ctx context.Context, hostAddress string) (*historyservice.DeepHealthCheckResponse, error) {
 			return &historyservice.DeepHealthCheckResponse{
 				State:  enumsspb.HEALTH_STATE_NOT_SERVING,
@@ -339,7 +351,7 @@ func (s *healthCheckerSuite) Test_Check_HostChecks_Propagated() {
 		log.NewNoopLogger(),
 	)
 
-	result, err := checker.Check(context.Background())
+	result, err := checker.Check(context.Background(), time.Now())
 	s.Require().NoError(err)
 	s.NotNil(result.ServiceDetail)
 	s.Require().Len(result.ServiceDetail.Hosts, 1)

--- a/service/frontend/health_check_test.go
+++ b/service/frontend/health_check_test.go
@@ -76,6 +76,36 @@ func (s *healthCheckerSuite) TearDownTest() {
 	s.controller.Finish()
 }
 
+func (s *healthCheckerSuite) Test_Health_Delay() {
+	s.checker.hostFailureTimeThreshold = func() time.Duration {
+		return 1 * time.Second
+	}
+	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
+		membership.NewHostInfoFromAddress("servingA"),
+		membership.NewHostInfoFromAddress("errorB"),
+	}).Times(2)
+	result, err := s.checker.Check(context.Background(), time.Unix(1, 0))
+	s.Require().NoError(err)
+	s.Equal(enumsspb.HEALTH_STATE_SERVING, result.State)
+	result, err = s.checker.Check(context.Background(), time.Unix(2, 0))
+	s.Require().NoError(err)
+	s.Equal(enumsspb.HEALTH_STATE_NOT_SERVING, result.State)
+	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
+		membership.NewHostInfoFromAddress("servingA"),
+		membership.NewHostInfoFromAddress("errorC"),
+	})
+	result, err = s.checker.Check(context.Background(), time.Unix(3, 0))
+	s.Require().NoError(err)
+	s.Equal(enumsspb.HEALTH_STATE_SERVING, result.State)
+	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
+		membership.NewHostInfoFromAddress("servingA"),
+		membership.NewHostInfoFromAddress("errorD"),
+	})
+	result, err = s.checker.Check(context.Background(), time.Unix(4, 0))
+	s.Require().NoError(err)
+	s.Equal(enumsspb.HEALTH_STATE_SERVING, result.State)
+}
+
 func (s *healthCheckerSuite) Test_Check_Serving() {
 	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
 		membership.NewHostInfoFromAddress("servingA"),
@@ -95,7 +125,7 @@ func (s *healthCheckerSuite) Test_Check_Not_Serving() {
 		membership.NewHostInfoFromAddress("errorB"),
 		membership.NewHostInfoFromAddress("servingC"),
 		membership.NewHostInfoFromAddress("declinedD"),
-		membership.NewHostInfoFromAddress("E"), //not-serving
+		membership.NewHostInfoFromAddress("E"), // not-serving
 	})
 
 	result, err := s.checker.Check(context.Background(), time.Now())

--- a/service/frontend/health_check_test.go
+++ b/service/frontend/health_check_test.go
@@ -65,18 +65,14 @@ func (s *healthCheckerSuite) SetupTest() {
 		},
 		log.NewNoopLogger(),
 	)
-	healthChecker, ok := checker.(*healthCheckerImpl)
-	if !ok {
-		s.Fail("The constructor did not return correct type")
-	}
-	s.checker = healthChecker
+	s.checker = checker.(*healthCheckerImpl)
 }
 
 func (s *healthCheckerSuite) TearDownTest() {
 	s.controller.Finish()
 }
 
-func (s *healthCheckerSuite) Test_Health_Delay() {
+func (s *healthCheckerSuite) Test_Unique_Host_Health() {
 	s.checker.hostFailureTimeThreshold = func() time.Duration {
 		return 1 * time.Second
 	}
@@ -185,21 +181,6 @@ func (s *healthCheckerSuite) Test_Check_GetResolver_Error() {
 	s.NotNil(result.ServiceDetail)
 	s.Equal(enumsspb.HEALTH_STATE_INTERNAL_ERROR, result.ServiceDetail.State)
 	s.Contains(result.ServiceDetail.Message, "failed to get membership resolver")
-}
-
-func (s *healthCheckerSuite) Test_Check_Boundary_Failure_Percentage_Equals_Threshold() {
-	// Test when failure percentage exactly equals the threshold (0.25)
-	// With 4 hosts, 1 failed = 0.25 (25%), should return SERVING since it's not > threshold
-	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
-		membership.NewHostInfoFromAddress("servingA"), // SERVING
-		membership.NewHostInfoFromAddress("errorB"),   // NOT_SERVING (failed)
-		membership.NewHostInfoFromAddress("servingC"), // SERVING
-		membership.NewHostInfoFromAddress("servingD"), // SERVING
-	})
-
-	result, err := s.checker.Check(context.Background(), time.Now())
-	s.NoError(err)
-	s.Equal(enumsspb.HEALTH_STATE_SERVING, result.State)
 }
 
 func (s *healthCheckerSuite) Test_Check_Single_Host_Scenarios() {

--- a/service/frontend/health_check_test.go
+++ b/service/frontend/health_check_test.go
@@ -114,14 +114,14 @@ func (s *healthCheckerSuite) Test_Unhealthy_Host_Tracker() {
 	s.Require().Len(declinedServing, 1, "Should be one declined host. Instead found: %+v", declinedServing)
 	s.Require().Len(otherUnhealthy, 2, "Should be two other unhealthy hosts. Instead found: %+v", otherUnhealthy)
 	declinedServing, otherUnhealthy = tracker.unhealthyHosts(time.Unix(1, 0), 1*time.Second)
-	s.Require().Len(declinedServing, 0, "Should be no declined hosts. Instead found: %+v", declinedServing)
-	s.Require().Len(otherUnhealthy, 0, "Should be no other unhealthy hosts. Instead found: %+v", otherUnhealthy)
+	s.Require().Empty(declinedServing, "Should be no declined hosts. Instead found: %+v", declinedServing)
+	s.Require().Empty(otherUnhealthy, "Should be no other unhealthy hosts. Instead found: %+v", otherUnhealthy)
 
 	// Demonstrate status updates to existing host
 	tracker.trackUnhealthyHost("A", time.Unix(2, 0), enumsspb.HEALTH_STATE_NOT_SERVING)
 	s.Require().Equal(tracker.hosts["A"].failedAt, time.Unix(1, 0), "Host A should keep original time, but was %v", tracker.hosts["A"].failedAt.Unix())
 	tracker.trackUnhealthyHost("A", time.Unix(3, 0), enumsspb.HEALTH_STATE_DECLINED_SERVING)
-	s.Require().Equal(tracker.hosts["A"].lastSeenHealth, enumsspb.HEALTH_STATE_DECLINED_SERVING, "Host A should now be DECLINED_SERVING, but was %s", tracker.hosts["A"].lastSeenHealth.String())
+	s.Require().Equal(enumsspb.HEALTH_STATE_DECLINED_SERVING, tracker.hosts["A"].lastSeenHealth, "Host A should now be DECLINED_SERVING, but was %s", tracker.hosts["A"].lastSeenHealth.String())
 	s.Require().Equal(tracker.hosts["A"].failedAt, time.Unix(1, 0), "Host A should keep original time, but was %v", tracker.hosts["A"].failedAt.Unix())
 
 	// Test stale entries
@@ -147,8 +147,8 @@ func (s *healthCheckerSuite) Test_Unhealthy_Host_Tracker() {
 	tracker.clearStaleEntries([]*healthspb.HostHealthDetail{})
 	// Host list empty -> No more unhealthy hosts
 	declinedServing, otherUnhealthy = tracker.unhealthyHosts(time.Unix(2, 0), 1*time.Second)
-	s.Require().Len(declinedServing, 0, "Should be no declined hosts. Instead found: %+v", declinedServing)
-	s.Require().Len(otherUnhealthy, 0, "Should be no other unhealthy hosts. Instead found: %+v", otherUnhealthy)
+	s.Require().Empty(declinedServing, "Should be no declined hosts. Instead found: %+v", declinedServing)
+	s.Require().Empty(otherUnhealthy, "Should be no other unhealthy hosts. Instead found: %+v", otherUnhealthy)
 }
 
 func (s *healthCheckerSuite) Test_Check_Serving() {

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -212,8 +212,9 @@ type Config struct {
 	MaskInternalErrorDetails dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
 	// Health check
-	HistoryHostErrorPercentage     dynamicconfig.FloatPropertyFn
-	HistoryHostSelfErrorProportion dynamicconfig.FloatPropertyFn
+	HistoryHostErrorPercentage      dynamicconfig.FloatPropertyFn
+	HistoryHostSelfErrorProportion  dynamicconfig.FloatPropertyFn
+	HistoryHostFailureTimeThreshold dynamicconfig.DurationPropertyFn
 
 	LogAllReqErrors dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
@@ -386,6 +387,7 @@ func NewConfig(
 
 		HistoryHostErrorPercentage:        dynamicconfig.HistoryHostErrorPercentage.Get(dc),
 		HistoryHostSelfErrorProportion:    dynamicconfig.HistoryHostSelfErrorProportion.Get(dc),
+		HistoryHostFailureTimeThreshold:   dynamicconfig.HistoryHostFailureTimeThreshold.Get(dc),
 		LogAllReqErrors:                   dynamicconfig.LogAllReqErrors.Get(dc),
 		EnableEagerWorkflowStart:          dynamicconfig.EnableEagerWorkflowStart.Get(dc),
 		WorkflowRulesAPIsEnabled:          dynamicconfig.WorkflowRulesAPIsEnabled.Get(dc),


### PR DESCRIPTION
## What changed?
Added a map to track whether each particular history host has been unhealthy for multiple checks. Only report history service unhealthy if each unhealthy host has been unhealthy for more than a configurable duration.

## Why?
The existing health check can fire during kube rollouts because the total proportion of recently-bounced hosts can exceed a low threshold for a long time. The aggregate health check should only fire when each unhealthy host has been unhealthy for a sustained period. 

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
This does reduce the ability for the DeepHealthCheck to detect a failure that rapidly spins the history pod addresses. The default time threshold is set low (10 seconds) to try to offset this.