### PR TITLE
fix: Prevent data race in multi-cluster test setup.

### DIFF
--- a/service/history/workflow/fx.go
+++ b/service/history/workflow/fx.go
@@ -5,7 +5,7 @@ import (
 )
 
 var Module = fx.Options(
-	fx.Provide(func() TaskGeneratorProvider { return defaultTaskGeneratorProvider }),
+	fx.Provide(GetTaskGeneratorProvider),
 	fx.Invoke(populateTaskGeneratorProvider),
 	fx.Provide(RelocatableAttributesFetcherProvider),
 	fx.Invoke(RegisterStateMachine),

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -409,7 +409,7 @@ func NewMutableState(
 		s.bufferEventsInDB,
 		s.metricsHandler,
 	)
-	s.taskGenerator = taskGeneratorProvider.NewTaskGenerator(shard, s)
+	s.taskGenerator = GetTaskGeneratorProvider().NewTaskGenerator(shard, s)
 	s.workflowTaskManager = newWorkflowTaskStateMachine(s, s.metricsHandler)
 
 	s.mustInitHSM()

--- a/service/history/workflow/mutable_state_rebuilder.go
+++ b/service/history/workflow/mutable_state_rebuilder.go
@@ -89,7 +89,7 @@ func (b *MutableStateRebuilderImpl) ApplyEvents(
 	// TODO: There doesn't seem to be a good reason to generate tasks here since they'll be generated eventually when we
 	// close the transaction.
 	// Previously this comment was here: must generate the activity timer / user timer at the very end
-	taskGenerator := taskGeneratorProvider.NewTaskGenerator(b.shard, b.mutableState)
+	taskGenerator := GetTaskGeneratorProvider().NewTaskGenerator(b.shard, b.mutableState)
 	if err := taskGenerator.GenerateActivityTimerTasks(); err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 	firstEvent := history[0]
 	lastEvent := history[len(history)-1]
 
-	taskGenerator := taskGeneratorProvider.NewTaskGenerator(b.shard, b.mutableState)
+	taskGenerator := GetTaskGeneratorProvider().NewTaskGenerator(b.shard, b.mutableState)
 
 	// Need to clear the sticky task queue because workflow turned to passive.
 	b.mutableState.ClearStickyTaskQueue()

--- a/service/history/workflow/mutable_state_rebuilder_test.go
+++ b/service/history/workflow/mutable_state_rebuilder_test.go
@@ -126,10 +126,10 @@ func (s *stateBuilderSuite) SetupTest() {
 	s.mockMutableState.EXPECT().GetCurrentVersion().Return(int64(1)).AnyTimes()
 	s.mockMutableState.EXPECT().NextTransitionCount().Return(int64(2)).AnyTimes()
 
-	taskGeneratorProvider = &testTaskGeneratorProvider{
+	populateTaskGeneratorProvider(&testTaskGeneratorProvider{
 		mockMutableState:  s.mockMutableState,
 		mockTaskGenerator: s.mockTaskGenerator,
-	}
+	})
 	s.stateRebuilder = NewMutableStateRebuilder(
 		s.mockShard,
 		s.logger,

--- a/service/history/workflow/task_generator_provider.go
+++ b/service/history/workflow/task_generator_provider.go
@@ -1,38 +1,38 @@
 package workflow
 
 import (
+	"sync/atomic"
+
 	historyi "go.temporal.io/server/service/history/interfaces"
-)
-
-var (
-	// This is set as a global to avoid plumbing through many layers. The default
-	// implementation has no state so this is safe even though it bypasses DI.
-	// It's set to a default value statically so that we can avoid setting it in tests, which
-	// would trip the race detector when running multiple servers in a single process.
-	// Note that TaskGeneratorProvider still needs to be provided through fx even with this
-	// default value.
-	taskGeneratorProvider TaskGeneratorProvider = defaultTaskGeneratorProvider
-
-	defaultTaskGeneratorProvider TaskGeneratorProvider = &taskGeneratorProviderImpl{}
 )
 
 type (
 	TaskGeneratorProvider interface {
 		NewTaskGenerator(historyi.ShardContext, historyi.MutableState) TaskGenerator
 	}
-
 	taskGeneratorProviderImpl struct{}
 )
 
+var (
+	// This is set as a global to avoid plumbing through many layers. The default
+	// implementation has no state so this is safe even though it bypasses DI.
+	// It's set to a default value in the init func so that we can avoid setting it in tests.
+	// Note that TaskGeneratorProvider still needs to be provided through fx even with this
+	// default value.
+	_taskGeneratorProvider atomic.Pointer[TaskGeneratorProvider]
+)
+
+func init() {
+	var defaultProvider TaskGeneratorProvider = new(taskGeneratorProviderImpl)
+	populateTaskGeneratorProvider(defaultProvider)
+}
+
 func populateTaskGeneratorProvider(provider TaskGeneratorProvider) {
-	if provider == defaultTaskGeneratorProvider {
-		return // avoid setting default over default to eliminate racey writes during testing
-	}
-	taskGeneratorProvider = provider
+	_taskGeneratorProvider.Store(&provider)
 }
 
 func GetTaskGeneratorProvider() TaskGeneratorProvider {
-	return taskGeneratorProvider
+	return *_taskGeneratorProvider.Load()
 }
 
 func (p *taskGeneratorProviderImpl) NewTaskGenerator(

--- a/service/history/workflow/task_refresher.go
+++ b/service/history/workflow/task_refresher.go
@@ -55,11 +55,9 @@ type (
 func NewTaskRefresher(
 	shard historyi.ShardContext,
 ) *TaskRefresherImpl {
-
 	return &TaskRefresherImpl{
-		shard: shard,
-
-		taskGeneratorProvider: taskGeneratorProvider,
+		shard:                 shard,
+		taskGeneratorProvider: GetTaskGeneratorProvider(),
 	}
 }
 


### PR DESCRIPTION
## What changed?

This is not really a fix but rather a shim to prevent data races in callers when creating multiple clusters, each of which uses a fx decorator to supply a different provider.

The race occurs because the current check prevents it when the provider is the default provider, but doesn't when they are different. Integration tests which use multiple clusters each of which uses a provider at a different address trigger this.

This prevents the data race, but doesn't actually address the underlying issue which is that we end up having a singleton task generator provider when ideally we would thread this through the fx tree properly. In the scenario which triggered the race, functionally the providers are equivalent and the singleton is not necessarily incorrect, but would be if they diverged at some point.

## Why?

This was causing integration tests to periodically fail.


## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

I don't think so. This is just guarding the read/write of the package global with a mutex.

