### PR TITLE
Update OSS Temporal to use Cassandra GoCQL v2.

### DIFF
--- a/common/config/persistence.go
+++ b/common/config/persistence.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
 )
 

--- a/common/config/persistence_test.go
+++ b/common/config/persistence_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	gocql "github.com/apache/cassandra-gocql-driver/v2"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSQLValidate_MutualExclusivity(t *testing.T) {

--- a/common/config/persistence_test.go
+++ b/common/config/persistence_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gocql/gocql"
 	"github.com/stretchr/testify/require"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 func TestSQLValidate_MutualExclusivity(t *testing.T) {

--- a/common/persistence/cassandra/cluster_metadata_store.go
+++ b/common/persistence/cassandra/cluster_metadata_store.go
@@ -64,8 +64,8 @@ func (m *ClusterMetadataStore) ListClusterMetadata(
 	ctx context.Context,
 	request *p.InternalListClusterMetadataRequest,
 ) (*p.InternalListClusterMetadataResponse, error) {
-	query := m.session.Query(templateListClusterMetadata, constMetadataPartition).WithContext(ctx)
-	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter()
+	query := m.session.Query(templateListClusterMetadata, constMetadataPartition)
+	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter(ctx)
 
 	response := &p.InternalListClusterMetadataResponse{}
 	for {
@@ -106,8 +106,8 @@ func (m *ClusterMetadataStore) GetClusterMetadata(
 	var encoding string
 	var version int64
 
-	query := m.session.Query(templateGetClusterMetadata, constMetadataPartition, request.ClusterName).WithContext(ctx)
-	err := query.Scan(&clusterMetadata, &encoding, &version)
+	query := m.session.Query(templateGetClusterMetadata, constMetadataPartition, request.ClusterName)
+	err := query.Scan(ctx, &clusterMetadata, &encoding, &version)
 	if err != nil {
 		return nil, gocql.ConvertError("GetClusterMetadata", err)
 	}
@@ -131,7 +131,7 @@ func (m *ClusterMetadataStore) SaveClusterMetadata(
 			request.ClusterMetadata.Data,
 			request.ClusterMetadata.EncodingType.String(),
 			1,
-		).WithContext(ctx)
+		)
 	} else {
 		query = m.session.Query(
 			templateUpdateClusterMetadata,
@@ -141,11 +141,11 @@ func (m *ClusterMetadataStore) SaveClusterMetadata(
 			constMetadataPartition,
 			request.ClusterName,
 			request.Version,
-		).WithContext(ctx)
+		)
 	}
 
 	previous := make(map[string]any)
-	applied, err := query.MapScanCAS(previous)
+	applied, err := query.MapScanCAS(ctx, previous)
 	if err != nil {
 		return false, gocql.ConvertError("SaveClusterMetadata", err)
 	}
@@ -159,8 +159,8 @@ func (m *ClusterMetadataStore) DeleteClusterMetadata(
 	ctx context.Context,
 	request *p.InternalDeleteClusterMetadataRequest,
 ) error {
-	query := m.session.Query(templateDeleteClusterMetadata, constMetadataPartition, request.ClusterName).WithContext(ctx)
-	if err := query.Exec(); err != nil {
+	query := m.session.Query(templateDeleteClusterMetadata, constMetadataPartition, request.ClusterName)
+	if err := query.Exec(ctx); err != nil {
 		return gocql.ConvertError("DeleteClusterMetadata", err)
 	}
 	return nil
@@ -202,9 +202,9 @@ func (m *ClusterMetadataStore) GetClusterMembers(
 	}
 
 	queryString.WriteString(templateAllowFiltering)
-	query := m.session.Query(queryString.String(), operands...).WithContext(ctx)
+	query := m.session.Query(queryString.String(), operands...)
 
-	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter()
+	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter(ctx)
 
 	var clusterMembers []*p.ClusterMember
 
@@ -257,8 +257,8 @@ func (m *ClusterMetadataStore) UpsertClusterMembership(
 		request.SessionStart,
 		time.Now().UTC(),
 		int64(request.RecordExpiry.Seconds()),
-	).WithContext(ctx)
-	err := query.Exec()
+	)
+	err := query.Exec(ctx)
 
 	if err != nil {
 		return gocql.ConvertError("UpsertClusterMembership", err)

--- a/common/persistence/cassandra/errors_test.go
+++ b/common/persistence/cassandra/errors_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/common/persistence/cassandra/factory.go
+++ b/common/persistence/cassandra/factory.go
@@ -3,7 +3,7 @@ package cassandra
 import (
 	"sync"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"

--- a/common/persistence/cassandra/helpers.go
+++ b/common/persistence/cassandra/helpers.go
@@ -1,6 +1,7 @@
 package cassandra
 
 import (
+	"context"
 	"fmt"
 
 	"go.temporal.io/server/common/log"
@@ -21,7 +22,7 @@ func CreateCassandraKeyspace(s gocql.Session, keyspace string, replicas int, ove
 		}
 	}
 	err = s.Query(fmt.Sprintf(`CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {
-		'class' : 'SimpleStrategy', 'replication_factor' : %d}`, keyspace, replicas)).Exec()
+		'class' : 'SimpleStrategy', 'replication_factor' : %d}`, keyspace, replicas)).Exec(context.Background())
 	if err != nil {
 		logger.Error("create keyspace error", tag.Error(err))
 		return
@@ -33,7 +34,7 @@ func CreateCassandraKeyspace(s gocql.Session, keyspace string, replicas int, ove
 
 // DropCassandraKeyspace drops the given keyspace, if it exists
 func DropCassandraKeyspace(s gocql.Session, keyspace string, logger log.Logger) (err error) {
-	err = s.Query(fmt.Sprintf("DROP KEYSPACE IF EXISTS %s", keyspace)).Exec()
+	err = s.Query(fmt.Sprintf("DROP KEYSPACE IF EXISTS %s", keyspace)).Exec(context.Background())
 	if err != nil {
 		logger.Error("drop keyspace error", tag.Error(err))
 		return

--- a/common/persistence/cassandra/history_store.go
+++ b/common/persistence/cassandra/history_store.go
@@ -77,15 +77,15 @@ func (h *HistoryStore) AppendHistoryNodes(
 			node.TransactionID,
 			node.Events.Data,
 			node.Events.EncodingType.String(),
-		).WithContext(ctx)
-		if err := query.Exec(); err != nil {
+		)
+		if err := query.Exec(ctx); err != nil {
 			return convertTimeoutError(gocql.ConvertError("AppendHistoryNodes", err))
 		}
 		return nil
 	}
 
 	treeInfoDataBlob := request.TreeInfo
-	batch := h.Session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
+	batch := h.Session.NewBatch(gocql.LoggedBatch)
 	batch.Query(v2templateInsertTree,
 		branchInfo.TreeId,
 		branchInfo.BranchId,
@@ -101,7 +101,7 @@ func (h *HistoryStore) AppendHistoryNodes(
 		node.Events.Data,
 		node.Events.EncodingType.String(),
 	)
-	if err := h.Session.ExecuteBatch(batch); err != nil {
+	if err := batch.Exec(ctx); err != nil {
 		return convertTimeoutError(gocql.ConvertError("AppendHistoryNodes", err))
 	}
 	return nil
@@ -129,8 +129,8 @@ func (h *HistoryStore) DeleteHistoryNodes(
 		branchID,
 		nodeID,
 		txnID,
-	).WithContext(ctx)
-	if err := query.Exec(); err != nil {
+	)
+	if err := query.Exec(ctx); err != nil {
 		return gocql.ConvertError("DeleteHistoryNodes", err)
 	}
 	return nil
@@ -166,9 +166,9 @@ func (h *HistoryStore) ReadHistoryBranch(
 		queryString = v2templateReadHistoryNode
 	}
 
-	query := h.Session.Query(queryString, treeID, branchID, request.MinNodeID, request.MaxNodeID).WithContext(ctx)
+	query := h.Session.Query(queryString, treeID, branchID, request.MinNodeID, request.MaxNodeID)
 
-	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter()
+	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter(ctx)
 	var pagingToken []byte
 	if len(iter.PageState()) > 0 {
 		pagingToken = iter.PageState()
@@ -255,8 +255,8 @@ func (h *HistoryStore) ForkHistoryBranch(
 	if err != nil {
 		return serviceerror.NewInternalf("ForkHistoryBranch - Gocql NewBranchID UUID cast failed. Error: %v", err)
 	}
-	query := h.Session.Query(v2templateInsertTree, cqlTreeID, cqlNewBranchID, datablob.Data, datablob.EncodingType.String()).WithContext(ctx)
-	err = query.Exec()
+	query := h.Session.Query(v2templateInsertTree, cqlTreeID, cqlNewBranchID, datablob.Data, datablob.EncodingType.String())
+	err = query.Exec(ctx)
 	if err != nil {
 		return gocql.ConvertError("ForkHistoryBranch", err)
 	}
@@ -270,7 +270,7 @@ func (h *HistoryStore) DeleteHistoryBranch(
 	request *p.InternalDeleteHistoryBranchRequest,
 ) error {
 
-	batch := h.Session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
+	batch := h.Session.NewBatch(gocql.LoggedBatch)
 	batch.Query(v2templateDeleteBranch, request.BranchInfo.TreeId, request.BranchInfo.BranchId)
 
 	// delete each branch range
@@ -278,7 +278,7 @@ func (h *HistoryStore) DeleteHistoryBranch(
 		h.deleteBranchRangeNodes(batch, request.BranchInfo.TreeId, br.BranchId, br.BeginNodeId)
 	}
 
-	err := h.Session.ExecuteBatch(batch)
+	err := batch.Exec(ctx)
 	if err != nil {
 		return gocql.ConvertError("DeleteHistoryBranch", err)
 	}
@@ -303,9 +303,9 @@ func (h *HistoryStore) GetAllHistoryTreeBranches(
 	request *p.GetAllHistoryTreeBranchesRequest,
 ) (*p.InternalGetAllHistoryTreeBranchesResponse, error) {
 
-	query := h.Session.Query(v2templateScanAllTreeBranches).WithContext(ctx)
+	query := h.Session.Query(v2templateScanAllTreeBranches)
 
-	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter()
+	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter(ctx)
 
 	var pagingToken []byte
 	if len(iter.PageState()) > 0 {
@@ -360,7 +360,7 @@ func (h *HistoryStore) GetHistoryTreeContainingBranch(
 	if err != nil {
 		return nil, serviceerror.NewInternalf("ReadHistoryBranch. Gocql TreeId UUID cast failed. Error: %v", err)
 	}
-	query := h.Session.Query(v2templateReadAllBranches, treeID).WithContext(ctx)
+	query := h.Session.Query(v2templateReadAllBranches, treeID)
 
 	pageSize := 100
 	var pagingToken []byte
@@ -368,7 +368,7 @@ func (h *HistoryStore) GetHistoryTreeContainingBranch(
 
 	var iter gocql.Iter
 	for {
-		iter = query.PageSize(pageSize).PageState(pagingToken).Iter()
+		iter = query.PageSize(pageSize).PageState(pagingToken).Iter(ctx)
 		pagingToken = iter.PageState()
 
 		branchUUID := ""

--- a/common/persistence/cassandra/matching_task_store_queue.go
+++ b/common/persistence/cassandra/matching_task_store_queue.go
@@ -134,10 +134,10 @@ func (d *taskQueueStore) CreateTaskQueue(
 		request.RangeID,
 		request.TaskQueueInfo.Data,
 		request.TaskQueueInfo.EncodingType.String(),
-	).WithContext(ctx)
+	)
 
 	previous := make(map[string]any)
-	applied, err := query.MapScanCAS(previous)
+	applied, err := query.MapScanCAS(ctx, previous)
 	if err != nil {
 		return gocql.ConvertError("CreateTaskQueue", err)
 	}
@@ -163,12 +163,12 @@ func (d *taskQueueStore) GetTaskQueue(
 		request.TaskType,
 		rowTypeTaskQueue,
 		taskQueueTaskID,
-	).WithContext(ctx)
+	)
 
 	var rangeID int64
 	var tlBytes []byte
 	var tlEncoding string
-	if err := query.Scan(&rangeID, &tlBytes, &tlEncoding); err != nil {
+	if err := query.Scan(ctx, &rangeID, &tlBytes, &tlEncoding); err != nil {
 		return nil, gocql.ConvertError("GetTaskQueue", err)
 	}
 
@@ -192,7 +192,7 @@ func (d *taskQueueStore) UpdateTaskQueue(
 			return nil, serviceerror.NewInternal("ExpiryTime cannot be nil for sticky task queue")
 		}
 		expiryTTL := min(convert.Int64Ceil(time.Until(timestamp.TimeValue(request.ExpiryTime)).Seconds()), maxCassandraTTL)
-		batch := d.Session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
+		batch := d.Session.NewBatch(gocql.LoggedBatch)
 
 		batch.Query(switchTasksTable(templateUpdateTaskQueueQueryWithTTLPart1, d.version),
 			request.NamespaceID,
@@ -215,7 +215,7 @@ func (d *taskQueueStore) UpdateTaskQueue(
 			taskQueueTaskID,
 			request.PrevRangeID,
 		)
-		applied, _, err = d.Session.MapExecuteBatchCAS(batch, previous)
+		applied, _, err = batch.MapExecCAS(ctx, previous)
 	} else {
 		// Regular update logic for both V1 and V2
 		query := d.Session.Query(switchTasksTable(templateUpdateTaskQueueQuery, d.version),
@@ -228,8 +228,8 @@ func (d *taskQueueStore) UpdateTaskQueue(
 			rowTypeTaskQueue,
 			taskQueueTaskID,
 			request.PrevRangeID,
-		).WithContext(ctx)
-		applied, err = query.MapScanCAS(previous)
+		)
+		applied, err = query.MapScanCAS(ctx, previous)
 	}
 
 	if err != nil {
@@ -269,10 +269,10 @@ func (d *taskQueueStore) DeleteTaskQueue(
 		rowTypeTaskQueue,
 		taskQueueTaskID,
 		request.RangeID,
-	).WithContext(ctx)
+	)
 
 	previous := make(map[string]any)
-	applied, err := query.MapScanCAS(previous)
+	applied, err := query.MapScanCAS(ctx, previous)
 	if err != nil {
 		return gocql.ConvertError("DeleteTaskQueue", err)
 	}

--- a/common/persistence/cassandra/matching_task_store_user_data.go
+++ b/common/persistence/cassandra/matching_task_store_user_data.go
@@ -48,11 +48,11 @@ func (d *userDataStore) GetTaskQueueUserData(
 	query := d.Session.Query(templateGetTaskQueueUserDataQuery,
 		request.NamespaceID,
 		request.TaskQueue,
-	).WithContext(ctx)
+	)
 	var version int64
 	var userDataBytes []byte
 	var encoding string
-	if err := query.Scan(&userDataBytes, &encoding, &version); err != nil {
+	if err := query.Scan(ctx, &userDataBytes, &encoding, &version); err != nil {
 		return nil, gocql.ConvertError("GetTaskQueueData", err)
 	}
 
@@ -66,7 +66,7 @@ func (d *userDataStore) UpdateTaskQueueUserData(
 	ctx context.Context,
 	request *p.InternalUpdateTaskQueueUserDataRequest,
 ) error {
-	batch := d.Session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
+	batch := d.Session.NewBatch(gocql.LoggedBatch)
 
 	for taskQueue, update := range request.Updates {
 		if update.Version == 0 {
@@ -95,7 +95,7 @@ func (d *userDataStore) UpdateTaskQueueUserData(
 	}
 
 	previous := make(map[string]any)
-	applied, iter, err := d.Session.MapExecuteBatchCAS(batch, previous)
+	applied, iter, err := batch.MapExecCAS(ctx, previous)
 	for _, update := range request.Updates {
 		if update.Applied != nil {
 			*update.Applied = applied
@@ -134,8 +134,8 @@ func (d *userDataStore) UpdateTaskQueueUserData(
 }
 
 func (d *userDataStore) ListTaskQueueUserDataEntries(ctx context.Context, request *p.ListTaskQueueUserDataEntriesRequest) (*p.InternalListTaskQueueUserDataEntriesResponse, error) {
-	query := d.Session.Query(templateListTaskQueueUserDataQuery, request.NamespaceID).WithContext(ctx)
-	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter()
+	query := d.Session.Query(templateListTaskQueueUserDataQuery, request.NamespaceID)
+	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter(ctx)
 
 	response := &p.InternalListTaskQueueUserDataEntriesResponse{}
 	row := make(map[string]any)
@@ -172,8 +172,8 @@ func (d *userDataStore) ListTaskQueueUserDataEntries(ctx context.Context, reques
 }
 
 func (d *userDataStore) GetTaskQueuesByBuildId(ctx context.Context, request *p.GetTaskQueuesByBuildIdRequest) ([]string, error) {
-	query := d.Session.Query(templateListTaskQueueNamesByBuildIdQuery, request.NamespaceID, request.BuildID).WithContext(ctx)
-	iter := query.PageSize(listTaskQueueNamesByBuildIdPageSize).Iter()
+	query := d.Session.Query(templateListTaskQueueNamesByBuildIdQuery, request.NamespaceID, request.BuildID)
+	iter := query.PageSize(listTaskQueueNamesByBuildIdPageSize).Iter(ctx)
 
 	var taskQueues []string
 	row := make(map[string]any)
@@ -207,7 +207,7 @@ func (d *userDataStore) GetTaskQueuesByBuildId(ctx context.Context, request *p.G
 
 func (d *userDataStore) CountTaskQueuesByBuildId(ctx context.Context, request *p.CountTaskQueuesByBuildIdRequest) (int, error) {
 	var count int
-	query := d.Session.Query(templateCountTaskQueueByBuildIdQuery, request.NamespaceID, request.BuildID).WithContext(ctx)
-	err := query.Scan(&count)
+	query := d.Session.Query(templateCountTaskQueueByBuildIdQuery, request.NamespaceID, request.BuildID)
+	err := query.Scan(ctx, &count)
 	return count, err
 }

--- a/common/persistence/cassandra/matching_task_store_v1.go
+++ b/common/persistence/cassandra/matching_task_store_v1.go
@@ -56,7 +56,7 @@ func (d *matchingTaskStoreV1) CreateTasks(
 	ctx context.Context,
 	request *p.InternalCreateTasksRequest,
 ) (*p.CreateTasksResponse, error) {
-	batch := d.Session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
+	batch := d.Session.NewBatch(gocql.LoggedBatch)
 	namespaceID := request.NamespaceID
 	taskQueue := request.TaskQueue
 	taskQueueType := request.TaskType
@@ -118,7 +118,7 @@ func (d *matchingTaskStoreV1) CreateTasks(
 	}
 
 	previous := make(map[string]any)
-	applied, _, err := d.Session.MapExecuteBatchCAS(batch, previous)
+	applied, _, err := batch.MapExecCAS(ctx, previous)
 	if err != nil {
 		return nil, gocql.ConvertError("CreateTasks", err)
 	}
@@ -150,8 +150,8 @@ func (d *matchingTaskStoreV1) GetTasks(
 		rowTypeTaskInSubqueue(request.Subqueue),
 		request.InclusiveMinTaskID,
 		request.ExclusiveMaxTaskID,
-	).WithContext(ctx)
-	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter()
+	)
+	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter(ctx)
 
 	response := &p.InternalGetTasksResponse{}
 	task := make(map[string]any)
@@ -212,8 +212,8 @@ func (d *matchingTaskStoreV1) CompleteTasksLessThan(
 		request.TaskType,
 		rowTypeTaskInSubqueue(request.Subqueue),
 		request.ExclusiveMaxTaskID,
-	).WithContext(ctx)
-	err := query.Exec()
+	)
+	err := query.Exec(ctx)
 	if err != nil {
 		return 0, gocql.ConvertError("CompleteTasksLessThan", err)
 	}

--- a/common/persistence/cassandra/matching_task_store_v2.go
+++ b/common/persistence/cassandra/matching_task_store_v2.go
@@ -63,7 +63,7 @@ func (d *matchingTaskStoreV2) CreateTasks(
 	ctx context.Context,
 	request *p.InternalCreateTasksRequest,
 ) (*p.CreateTasksResponse, error) {
-	batch := d.Session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
+	batch := d.Session.NewBatch(gocql.LoggedBatch)
 	namespaceID := request.NamespaceID
 	taskQueue := request.TaskQueue
 	taskQueueType := request.TaskType
@@ -112,7 +112,7 @@ func (d *matchingTaskStoreV2) CreateTasks(
 	}
 
 	previous := make(map[string]any)
-	applied, _, err := d.Session.MapExecuteBatchCAS(batch, previous)
+	applied, _, err := batch.MapExecCAS(ctx, previous)
 	if err != nil {
 		return nil, gocql.ConvertError("CreateTasks", err)
 	}
@@ -169,7 +169,7 @@ func (d *matchingTaskStoreV2) GetTasks(
 			int64(math.MaxInt64),
 		)
 	}
-	iter := query.WithContext(ctx).PageSize(request.PageSize).PageState(request.NextPageToken).Iter()
+	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter(ctx)
 
 	response := &p.InternalGetTasksResponse{}
 	task := make(map[string]any)
@@ -236,8 +236,8 @@ func (d *matchingTaskStoreV2) CompleteTasksLessThan(
 		rowType,
 		request.ExclusiveMaxPass,
 		request.ExclusiveMaxTaskID,
-	).WithContext(ctx)
-	err := query.Exec()
+	)
+	err := query.Exec(ctx)
 	if err != nil {
 		return 0, gocql.ConvertError("CompleteTasksLessThan", err)
 	}

--- a/common/persistence/cassandra/metadata_store.go
+++ b/common/persistence/cassandra/metadata_store.go
@@ -101,9 +101,9 @@ func (m *MetadataStore) CreateNamespace(
 	request *p.InternalCreateNamespaceRequest,
 ) (*p.CreateNamespaceResponse, error) {
 
-	query := m.session.Query(templateCreateNamespaceQuery, request.ID, request.Name).WithContext(ctx)
+	query := m.session.Query(templateCreateNamespaceQuery, request.ID, request.Name)
 	existingRow := make(map[string]any)
-	applied, err := query.MapScanCAS(existingRow)
+	applied, err := query.MapScanCAS(ctx, existingRow)
 	if err != nil {
 		return nil, gocql.ConvertError("CreateNamespace", err)
 	}
@@ -134,7 +134,7 @@ func (m *MetadataStore) CreateNamespaceInV2Table(
 		return nil, err
 	}
 
-	batch := m.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
+	batch := m.session.NewBatch(gocql.LoggedBatch)
 	batch.Query(templateCreateNamespaceByNameQueryWithinBatchV2,
 		constNamespacePartition,
 		request.ID,
@@ -147,14 +147,14 @@ func (m *MetadataStore) CreateNamespaceInV2Table(
 	m.updateMetadataBatch(batch, metadata.NotificationVersion)
 
 	previous := make(map[string]any)
-	applied, iter, err := m.session.MapExecuteBatchCAS(batch, previous)
+	applied, iter, err := batch.MapExecCAS(ctx, previous)
 	if err != nil {
 		return nil, gocql.ConvertError("CreateNamespace", err)
 	}
 	defer func() { _ = iter.Close() }()
 	deleteOrphanNamespace := func() {
 		// Delete namespace from `namespaces_by_id`
-		if errDelete := m.session.Query(templateDeleteNamespaceQuery, request.ID).WithContext(ctx).Exec(); errDelete != nil {
+		if errDelete := m.session.Query(templateDeleteNamespaceQuery, request.ID).Exec(ctx); errDelete != nil {
 			m.logger.Warn("Unable to delete orphan namespace record. Error", tag.Error(errDelete))
 		}
 	}
@@ -207,7 +207,7 @@ func (m *MetadataStore) UpdateNamespace(
 	ctx context.Context,
 	request *p.InternalUpdateNamespaceRequest,
 ) error {
-	batch := m.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
+	batch := m.session.NewBatch(gocql.LoggedBatch)
 	batch.Query(templateUpdateNamespaceByNameQueryWithinBatchV2,
 		request.Namespace.Data,
 		request.Namespace.EncodingType.String(),
@@ -219,7 +219,7 @@ func (m *MetadataStore) UpdateNamespace(
 	m.updateMetadataBatch(batch, request.NotificationVersion)
 
 	previous := make(map[string]any)
-	applied, iter, err := m.session.MapExecuteBatchCAS(batch, previous)
+	applied, iter, err := batch.MapExecCAS(ctx, previous)
 	if err != nil {
 		return gocql.ConvertError("UpdateNamespace", err)
 	}
@@ -251,12 +251,12 @@ func (m *MetadataStore) RenameNamespace(
 	if updateErr := m.session.Query(templateUpdateNamespaceByIdQuery,
 		request.Name,
 		request.Id,
-	).WithContext(ctx).Exec(); updateErr != nil {
+	).Exec(ctx); updateErr != nil {
 		return gocql.ConvertError("RenameNamespace", updateErr)
 	}
 
 	// Step 2.
-	batch := m.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
+	batch := m.session.NewBatch(gocql.LoggedBatch)
 	batch.Query(templateCreateNamespaceByNameQueryWithinBatchV2,
 		constNamespacePartition,
 		request.Id,
@@ -273,7 +273,7 @@ func (m *MetadataStore) RenameNamespace(
 	m.updateMetadataBatch(batch, request.NotificationVersion)
 
 	previous := make(map[string]any)
-	applied, iter, err := m.session.MapExecuteBatchCAS(batch, previous)
+	applied, iter, err := batch.MapExecCAS(ctx, previous)
 	if err != nil {
 		return gocql.ConvertError("RenameNamespace", err)
 	}
@@ -316,15 +316,16 @@ func (m *MetadataStore) GetNamespace(
 
 	namespace := request.Name
 	if len(request.ID) > 0 {
-		query = m.session.Query(templateGetNamespaceQuery, request.ID).WithContext(ctx)
-		err = query.Scan(&namespace)
+		query = m.session.Query(templateGetNamespaceQuery, request.ID)
+		err = query.Scan(ctx, &namespace)
 		if err != nil {
 			return nil, handleError(request.Name, request.ID, err)
 		}
 	}
 
-	query = m.session.Query(templateGetNamespaceByNameQueryV2, constNamespacePartition, namespace).WithContext(ctx)
+	query = m.session.Query(templateGetNamespaceByNameQueryV2, constNamespacePartition, namespace)
 	err = query.Scan(
+		ctx,
 		nil,
 		nil,
 		&detail,
@@ -352,13 +353,13 @@ func (m *MetadataStore) ListNamespaces(
 	ctx context.Context,
 	request *p.InternalListNamespacesRequest,
 ) (*p.InternalListNamespacesResponse, error) {
-	query := m.session.Query(templateListNamespaceQueryV2, constNamespacePartition).WithContext(ctx)
+	query := m.session.Query(templateListNamespaceQueryV2, constNamespacePartition)
 	pageSize := request.PageSize
 	nextPageToken := request.NextPageToken
 	response := &p.InternalListNamespacesResponse{}
 
 	for {
-		iter := query.PageSize(pageSize).PageState(nextPageToken).Iter()
+		iter := query.PageSize(pageSize).PageState(nextPageToken).Iter(ctx)
 		skippedRows := 0
 
 		for {
@@ -418,8 +419,8 @@ func (m *MetadataStore) DeleteNamespace(
 	request *p.DeleteNamespaceRequest,
 ) error {
 	var name string
-	query := m.session.Query(templateGetNamespaceQuery, request.ID).WithContext(ctx)
-	err := query.Scan(&name)
+	query := m.session.Query(templateGetNamespaceQuery, request.ID)
+	err := query.Scan(ctx, &name)
 	if err != nil {
 		if gocql.IsNotFoundError(err) {
 			return nil
@@ -439,8 +440,8 @@ func (m *MetadataStore) DeleteNamespaceByName(
 	request *p.DeleteNamespaceByNameRequest,
 ) error {
 	var ID []byte
-	query := m.session.Query(templateGetNamespaceByNameQueryV2, constNamespacePartition, request.Name).WithContext(ctx)
-	err := query.Scan(&ID, nil, nil, nil, nil, nil)
+	query := m.session.Query(templateGetNamespaceByNameQueryV2, constNamespacePartition, request.Name)
+	err := query.Scan(ctx, &ID, nil, nil, nil, nil, nil)
 	if err != nil {
 		if gocql.IsNotFoundError(err) {
 			return nil
@@ -454,8 +455,8 @@ func (m *MetadataStore) GetMetadata(
 	ctx context.Context,
 ) (*p.GetMetadataResponse, error) {
 	var notificationVersion int64
-	query := m.session.Query(templateGetMetadataQueryV2, constNamespacePartition, namespaceMetadataRecordName).WithContext(ctx)
-	err := query.Scan(&notificationVersion)
+	query := m.session.Query(templateGetMetadataQueryV2, constNamespacePartition, namespaceMetadataRecordName)
+	err := query.Scan(ctx, &notificationVersion)
 	if err != nil {
 		if gocql.IsNotFoundError(err) {
 			// this error can be thrown in the very beginning,
@@ -486,13 +487,13 @@ func (m *MetadataStore) updateMetadataBatch(
 }
 
 func (m *MetadataStore) deleteNamespace(ctx context.Context, name string, ID []byte) error {
-	query := m.session.Query(templateDeleteNamespaceByNameQueryV2, constNamespacePartition, name).WithContext(ctx)
-	if err := query.Exec(); err != nil {
+	query := m.session.Query(templateDeleteNamespaceByNameQueryV2, constNamespacePartition, name)
+	if err := query.Exec(ctx); err != nil {
 		return gocql.ConvertError("DeleteNamespaceByName", err)
 	}
 
-	query = m.session.Query(templateDeleteNamespaceQuery, ID).WithContext(ctx)
-	if err := query.Exec(); err != nil {
+	query = m.session.Query(templateDeleteNamespaceQuery, ID)
+	if err := query.Exec(ctx); err != nil {
 		return gocql.ConvertError("DeleteNamespace", err)
 	}
 

--- a/common/persistence/cassandra/mutable_state_store.go
+++ b/common/persistence/cassandra/mutable_state_store.go
@@ -384,7 +384,7 @@ func (d *MutableStateStore) CreateWorkflowExecution(
 	ctx context.Context,
 	request *p.InternalCreateWorkflowExecutionRequest,
 ) (*p.InternalCreateWorkflowExecutionResponse, error) {
-	batch := d.Session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
+	batch := d.Session.NewBatch(gocql.LoggedBatch)
 
 	shardID := request.ShardID
 	newWorkflow := request.NewWorkflowSnapshot
@@ -463,7 +463,7 @@ func (d *MutableStateStore) CreateWorkflowExecution(
 	)
 
 	conflictRecord := newConflictRecord()
-	applied, conflictIter, err := d.Session.MapExecuteBatchCAS(batch, conflictRecord)
+	applied, conflictIter, err := batch.MapExecCAS(ctx, conflictRecord)
 	if err != nil {
 		return nil, gocql.ConvertError("CreateWorkflowExecution", err)
 	}
@@ -504,10 +504,10 @@ func (d *MutableStateStore) GetWorkflowExecution(
 		request.RunID,
 		defaultVisibilityTimestamp,
 		rowTypeExecutionTaskID,
-	).WithContext(ctx)
+	)
 
 	result := make(map[string]any)
-	if err := query.MapScan(result); err != nil {
+	if err := query.MapScan(ctx, result); err != nil {
 		return nil, gocql.ConvertError("GetWorkflowExecution", err)
 	}
 
@@ -600,7 +600,7 @@ func (d *MutableStateStore) UpdateWorkflowExecution(
 	ctx context.Context,
 	request *p.InternalUpdateWorkflowExecutionRequest,
 ) error {
-	batch := d.Session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
+	batch := d.Session.NewBatch(gocql.LoggedBatch)
 
 	updateWorkflow := request.UpdateWorkflowMutation
 	newWorkflow := request.NewWorkflowSnapshot
@@ -712,7 +712,7 @@ func (d *MutableStateStore) UpdateWorkflowExecution(
 	)
 
 	conflictRecord := newConflictRecord()
-	applied, conflictIter, err := d.Session.MapExecuteBatchCAS(batch, conflictRecord)
+	applied, conflictIter, err := batch.MapExecCAS(ctx, conflictRecord)
 	if err != nil {
 		return gocql.ConvertError("UpdateWorkflowExecution", err)
 	}
@@ -744,7 +744,7 @@ func (d *MutableStateStore) ConflictResolveWorkflowExecution(
 	ctx context.Context,
 	request *p.InternalConflictResolveWorkflowExecutionRequest,
 ) error {
-	batch := d.Session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
+	batch := d.Session.NewBatch(gocql.LoggedBatch)
 
 	currentWorkflow := request.CurrentWorkflowMutation
 	resetWorkflow := request.ResetWorkflowSnapshot
@@ -844,7 +844,7 @@ func (d *MutableStateStore) ConflictResolveWorkflowExecution(
 	)
 
 	conflictRecord := newConflictRecord()
-	applied, conflictIter, err := d.Session.MapExecuteBatchCAS(batch, conflictRecord)
+	applied, conflictIter, err := batch.MapExecCAS(ctx, conflictRecord)
 	if err != nil {
 		return gocql.ConvertError("ConflictResolveWorkflowExecution", err)
 	}
@@ -930,9 +930,9 @@ func (d *MutableStateStore) DeleteWorkflowExecution(
 		request.RunID,
 		defaultVisibilityTimestamp,
 		rowTypeExecutionTaskID,
-	).WithContext(ctx)
+	)
 
-	err := query.Exec()
+	err := query.Exec(ctx)
 	return gocql.ConvertError("DeleteWorkflowExecution", err)
 }
 
@@ -949,9 +949,9 @@ func (d *MutableStateStore) DeleteCurrentWorkflowExecution(
 		defaultVisibilityTimestamp,
 		rowTypeExecutionTaskID,
 		request.RunID,
-	).WithContext(ctx)
+	)
 
-	err := query.Exec()
+	err := query.Exec(ctx)
 	return gocql.ConvertError("DeleteWorkflowCurrentRow", err)
 }
 
@@ -967,10 +967,10 @@ func (d *MutableStateStore) GetCurrentExecution(
 		d.getCurrentRecordRunID(request.ArchetypeID),
 		defaultVisibilityTimestamp,
 		rowTypeExecutionTaskID,
-	).WithContext(ctx)
+	)
 
 	result := make(map[string]any)
-	if err := query.MapScan(result); err != nil {
+	if err := query.MapScan(ctx, result); err != nil {
 		return nil, gocql.ConvertError("GetCurrentExecution", err)
 	}
 
@@ -996,7 +996,7 @@ func (d *MutableStateStore) SetWorkflowExecution(
 	ctx context.Context,
 	request *p.InternalSetWorkflowExecutionRequest,
 ) error {
-	batch := d.Session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
+	batch := d.Session.NewBatch(gocql.LoggedBatch)
 
 	shardID := request.ShardID
 	setSnapshot := request.SetWorkflowSnapshot
@@ -1019,7 +1019,7 @@ func (d *MutableStateStore) SetWorkflowExecution(
 	)
 
 	conflictRecord := newConflictRecord()
-	applied, conflictIter, err := d.Session.MapExecuteBatchCAS(batch, conflictRecord)
+	applied, conflictIter, err := batch.MapExecCAS(ctx, conflictRecord)
 	if err != nil {
 		return gocql.ConvertError("SetWorkflowExecution", err)
 	}
@@ -1056,8 +1056,8 @@ func (d *MutableStateStore) ListConcreteExecutions(
 		templateListWorkflowExecutionQuery,
 		request.ShardID,
 		rowTypeExecution,
-	).WithContext(ctx)
-	iter := query.PageSize(request.PageSize).PageState(request.PageToken).Iter()
+	)
+	iter := query.PageSize(request.PageSize).PageState(request.PageToken).Iter(ctx)
 
 	response := &p.InternalListConcreteExecutionsResponse{}
 	result := make(map[string]any)

--- a/common/persistence/cassandra/mutable_state_task_store.go
+++ b/common/persistence/cassandra/mutable_state_task_store.go
@@ -178,7 +178,7 @@ func (d *MutableStateTaskStore) AddHistoryTasks(
 	ctx context.Context,
 	request *p.InternalAddHistoryTasksRequest,
 ) error {
-	batch := d.Session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
+	batch := d.Session.NewBatch(gocql.LoggedBatch)
 
 	if err := applyTasks(
 		batch,
@@ -201,7 +201,7 @@ func (d *MutableStateTaskStore) AddHistoryTasks(
 	)
 
 	previous := make(map[string]any)
-	applied, iter, err := d.Session.MapExecuteBatchCAS(batch, previous)
+	applied, iter, err := batch.MapExecCAS(ctx, previous)
 	if err != nil {
 		return gocql.ConvertError("AddTasks", err)
 	}
@@ -296,8 +296,8 @@ func (d *MutableStateTaskStore) getTransferTasks(
 		defaultVisibilityTimestamp,
 		request.InclusiveMinTaskKey.TaskID,
 		request.ExclusiveMaxTaskKey.TaskID,
-	).WithContext(ctx)
-	iter := query.PageSize(request.BatchSize).PageState(request.NextPageToken).Iter()
+	)
+	iter := query.PageSize(request.BatchSize).PageState(request.NextPageToken).Iter(ctx)
 
 	response := &p.InternalGetHistoryTasksResponse{}
 	var taskID int64
@@ -337,9 +337,9 @@ func (d *MutableStateTaskStore) completeTransferTask(
 		rowTypeTransferRunID,
 		defaultVisibilityTimestamp,
 		request.TaskKey.TaskID,
-	).WithContext(ctx)
+	)
 
-	err := query.Exec()
+	err := query.Exec(ctx)
 	return gocql.ConvertError("CompleteTransferTask", err)
 }
 
@@ -356,9 +356,9 @@ func (d *MutableStateTaskStore) rangeCompleteTransferTasks(
 		defaultVisibilityTimestamp,
 		request.InclusiveMinTaskKey.TaskID,
 		request.ExclusiveMaxTaskKey.TaskID,
-	).WithContext(ctx)
+	)
 
-	err := query.Exec()
+	err := query.Exec(ctx)
 	return gocql.ConvertError("RangeCompleteTransferTask", err)
 }
 
@@ -377,8 +377,8 @@ func (d *MutableStateTaskStore) getTimerTasks(
 		rowTypeTimerRunID,
 		minTimestamp,
 		maxTimestamp,
-	).WithContext(ctx)
-	iter := query.PageSize(request.BatchSize).PageState(request.NextPageToken).Iter()
+	)
+	iter := query.PageSize(request.BatchSize).PageState(request.NextPageToken).Iter(ctx)
 
 	response := &p.InternalGetHistoryTasksResponse{}
 	var timestamp time.Time
@@ -421,9 +421,9 @@ func (d *MutableStateTaskStore) completeTimerTask(
 		rowTypeTimerRunID,
 		ts,
 		request.TaskKey.TaskID,
-	).WithContext(ctx)
+	)
 
-	err := query.Exec()
+	err := query.Exec(ctx)
 	return gocql.ConvertError("CompleteTimerTask", err)
 }
 
@@ -441,9 +441,9 @@ func (d *MutableStateTaskStore) rangeCompleteTimerTasks(
 		rowTypeTimerRunID,
 		start,
 		end,
-	).WithContext(ctx)
+	)
 
-	err := query.Exec()
+	err := query.Exec(ctx)
 	return gocql.ConvertError("RangeCompleteTimerTask", err)
 }
 
@@ -462,9 +462,9 @@ func (d *MutableStateTaskStore) getReplicationTasks(
 		defaultVisibilityTimestamp,
 		request.InclusiveMinTaskKey.TaskID,
 		request.ExclusiveMaxTaskKey.TaskID,
-	).WithContext(ctx).PageSize(request.BatchSize).PageState(request.NextPageToken)
+	).PageSize(request.BatchSize).PageState(request.NextPageToken)
 
-	return d.populateGetReplicationTasksResponse(query, "GetReplicationTasks")
+	return d.populateGetReplicationTasksResponse(ctx, query, "GetReplicationTasks")
 }
 
 func (d *MutableStateTaskStore) completeReplicationTask(
@@ -479,9 +479,9 @@ func (d *MutableStateTaskStore) completeReplicationTask(
 		rowTypeReplicationRunID,
 		defaultVisibilityTimestamp,
 		request.TaskKey.TaskID,
-	).WithContext(ctx)
+	)
 
-	err := query.Exec()
+	err := query.Exec(ctx)
 	return gocql.ConvertError("CompleteReplicationTask", err)
 }
 
@@ -498,9 +498,9 @@ func (d *MutableStateTaskStore) rangeCompleteReplicationTasks(
 		defaultVisibilityTimestamp,
 		request.InclusiveMinTaskKey.TaskID,
 		request.ExclusiveMaxTaskKey.TaskID,
-	).WithContext(ctx)
+	)
 
-	err := query.Exec()
+	err := query.Exec(ctx)
 	return gocql.ConvertError("RangeCompleteReplicationTask", err)
 }
 
@@ -525,9 +525,9 @@ func (d *MutableStateTaskStore) PutReplicationTaskToDLQ(
 		datablob.EncodingType.String(),
 		defaultVisibilityTimestamp,
 		task.GetTaskId(),
-	).WithContext(ctx)
+	)
 
-	err = query.Exec()
+	err = query.Exec(ctx)
 	if err != nil {
 		return gocql.ConvertError("PutReplicationTaskToDLQ", err)
 	}
@@ -549,9 +549,9 @@ func (d *MutableStateTaskStore) GetReplicationTasksFromDLQ(
 		defaultVisibilityTimestamp,
 		request.InclusiveMinTaskKey.TaskID,
 		request.ExclusiveMaxTaskKey.TaskID,
-	).WithContext(ctx).PageSize(request.BatchSize).PageState(request.NextPageToken)
+	).PageSize(request.BatchSize).PageState(request.NextPageToken)
 
-	return d.populateGetReplicationTasksResponse(query, "GetReplicationTasksFromDLQ")
+	return d.populateGetReplicationTasksResponse(ctx, query, "GetReplicationTasksFromDLQ")
 }
 
 func (d *MutableStateTaskStore) DeleteReplicationTaskFromDLQ(
@@ -567,9 +567,9 @@ func (d *MutableStateTaskStore) DeleteReplicationTaskFromDLQ(
 		rowTypeDLQRunID,
 		defaultVisibilityTimestamp,
 		request.TaskKey.TaskID,
-	).WithContext(ctx)
+	)
 
-	err := query.Exec()
+	err := query.Exec(ctx)
 	return gocql.ConvertError("DeleteReplicationTaskFromDLQ", err)
 }
 
@@ -587,9 +587,9 @@ func (d *MutableStateTaskStore) RangeDeleteReplicationTaskFromDLQ(
 		defaultVisibilityTimestamp,
 		request.InclusiveMinTaskKey.TaskID,
 		request.ExclusiveMaxTaskKey.TaskID,
-	).WithContext(ctx)
+	)
 
-	err := query.Exec()
+	err := query.Exec(ctx)
 	return gocql.ConvertError("RangeDeleteReplicationTaskFromDLQ", err)
 }
 
@@ -606,9 +606,9 @@ func (d *MutableStateTaskStore) IsReplicationDLQEmpty(
 		rowTypeDLQRunID,
 		defaultVisibilityTimestamp,
 		request.InclusiveMinTaskKey.TaskID,
-	).WithContext(ctx)
+	)
 
-	if err := query.Scan(nil); err != nil {
+	if err := query.Scan(ctx, nil); err != nil {
 		if gocql.IsNotFoundError(err) {
 			return true, nil
 		}
@@ -632,8 +632,8 @@ func (d *MutableStateTaskStore) getVisibilityTasks(
 		defaultVisibilityTimestamp,
 		request.InclusiveMinTaskKey.TaskID,
 		request.ExclusiveMaxTaskKey.TaskID,
-	).WithContext(ctx)
-	iter := query.PageSize(request.BatchSize).PageState(request.NextPageToken).Iter()
+	)
+	iter := query.PageSize(request.BatchSize).PageState(request.NextPageToken).Iter(ctx)
 
 	response := &p.InternalGetHistoryTasksResponse{}
 	var taskID int64
@@ -673,9 +673,9 @@ func (d *MutableStateTaskStore) completeVisibilityTask(
 		rowTypeVisibilityTaskRunID,
 		defaultVisibilityTimestamp,
 		request.TaskKey.TaskID,
-	).WithContext(ctx)
+	)
 
-	err := query.Exec()
+	err := query.Exec(ctx)
 	return gocql.ConvertError("CompleteVisibilityTask", err)
 }
 
@@ -692,17 +692,18 @@ func (d *MutableStateTaskStore) rangeCompleteVisibilityTasks(
 		defaultVisibilityTimestamp,
 		request.InclusiveMinTaskKey.TaskID,
 		request.ExclusiveMaxTaskKey.TaskID,
-	).WithContext(ctx)
+	)
 
-	err := query.Exec()
+	err := query.Exec(ctx)
 	return gocql.ConvertError("RangeCompleteVisibilityTask", err)
 }
 
 func (d *MutableStateTaskStore) populateGetReplicationTasksResponse(
+	ctx context.Context,
 	query gocql.Query,
 	operation string,
 ) (*p.InternalGetHistoryTasksResponse, error) {
-	iter := query.Iter()
+	iter := query.Iter(ctx)
 
 	response := &p.InternalGetHistoryTasksResponse{}
 	var taskID int64
@@ -760,9 +761,9 @@ func (d *MutableStateTaskStore) getHistoryImmedidateTasks(
 		defaultVisibilityTimestamp,
 		request.InclusiveMinTaskKey.TaskID,
 		request.ExclusiveMaxTaskKey.TaskID,
-	).WithContext(ctx)
+	)
 
-	iter := query.PageSize(request.BatchSize).PageState(request.NextPageToken).Iter()
+	iter := query.PageSize(request.BatchSize).PageState(request.NextPageToken).Iter(ctx)
 
 	response := &p.InternalGetHistoryTasksResponse{}
 	var taskID int64
@@ -807,9 +808,9 @@ func (d *MutableStateTaskStore) getHistoryScheduledTasks(
 		rowTypeHistoryTaskRunID,
 		minTimestamp,
 		maxTimestamp,
-	).WithContext(ctx)
+	)
 
-	iter := query.PageSize(request.BatchSize).PageState(request.NextPageToken).Iter()
+	iter := query.PageSize(request.BatchSize).PageState(request.NextPageToken).Iter(ctx)
 
 	response := &p.InternalGetHistoryTasksResponse{}
 	var timestamp time.Time
@@ -855,9 +856,9 @@ func (d *MutableStateTaskStore) completeHistoryTask(
 		rowTypeHistoryTaskRunID,
 		ts,
 		request.TaskKey.TaskID,
-	).WithContext(ctx)
+	)
 
-	err := query.Exec()
+	err := query.Exec(ctx)
 	return gocql.ConvertError("CompleteHistoryTask", err)
 }
 
@@ -877,7 +878,7 @@ func (d *MutableStateTaskStore) rangeCompleteHistoryTasks(
 			defaultVisibilityTimestamp,
 			request.InclusiveMinTaskKey.TaskID,
 			request.ExclusiveMaxTaskKey.TaskID,
-		).WithContext(ctx)
+		)
 	} else {
 		minTimestamp := p.UnixMilliseconds(request.InclusiveMinTaskKey.FireTime)
 		maxTimestamp := p.UnixMilliseconds(request.ExclusiveMaxTaskKey.FireTime)
@@ -889,9 +890,9 @@ func (d *MutableStateTaskStore) rangeCompleteHistoryTasks(
 			rowTypeHistoryTaskRunID,
 			minTimestamp,
 			maxTimestamp,
-		).WithContext(ctx)
+		)
 	}
 
-	err := query.Exec()
+	err := query.Exec(ctx)
 	return gocql.ConvertError("RangeCompleteHistoryTasks", err)
 }

--- a/common/persistence/cassandra/nexus_endpoint_store.go
+++ b/common/persistence/cassandra/nexus_endpoint_store.go
@@ -66,7 +66,7 @@ func (s *NexusEndpointStore) CreateOrUpdateNexusEndpoint(
 	ctx context.Context,
 	request *p.InternalCreateOrUpdateNexusEndpointRequest,
 ) error {
-	batch := s.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
+	batch := s.session.NewBatch(gocql.LoggedBatch)
 
 	if request.Endpoint.Version == 0 {
 		batch.Query(templateCreateEndpointQuery,
@@ -101,7 +101,7 @@ func (s *NexusEndpointStore) CreateOrUpdateNexusEndpoint(
 	}
 
 	row1 := make(map[string]any)
-	applied, iter, err := s.session.MapExecuteBatchCAS(batch, row1)
+	applied, iter, err := batch.MapExecCAS(ctx, row1)
 
 	if err != nil {
 		return gocql.ConvertError("CreateOrUpdateNexusEndpoint", err)
@@ -167,13 +167,13 @@ func (s *NexusEndpointStore) GetNexusEndpoint(
 	ctx context.Context,
 	request *p.GetNexusEndpointRequest,
 ) (*p.InternalNexusEndpoint, error) {
-	query := s.session.Query(templateGetEndpointByIdQuery, rowTypeNexusEndpoint, request.ID).WithContext(ctx)
+	query := s.session.Query(templateGetEndpointByIdQuery, rowTypeNexusEndpoint, request.ID)
 
 	var data []byte
 	var dataEncoding string
 	var version int64
 
-	err := query.Scan(&data, &dataEncoding, &version)
+	err := query.Scan(ctx, &data, &dataEncoding, &version)
 	if gocql.IsNotFoundError(err) {
 		return nil, serviceerror.NewNotFoundf("Nexus endpoint with ID `%v` not found", request.ID)
 	}
@@ -198,8 +198,8 @@ func (s *NexusEndpointStore) ListNexusEndpoints(
 
 	response := &p.InternalListNexusEndpointsResponse{}
 
-	query := s.session.Query(templateListEndpointsQuery, rowTypeNexusEndpoint).WithContext(ctx)
-	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter()
+	query := s.session.Query(templateListEndpointsQuery, rowTypeNexusEndpoint)
+	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter(ctx)
 
 	endpoints, err := s.getEndpointList(iter)
 	if err != nil {
@@ -240,7 +240,7 @@ func (s *NexusEndpointStore) DeleteNexusEndpoint(
 	ctx context.Context,
 	request *p.DeleteNexusEndpointRequest,
 ) error {
-	batch := s.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
+	batch := s.session.NewBatch(gocql.LoggedBatch)
 
 	// Table version update must be the first statement so it is returned as the first CAS result
 	// row. CAS result row ordering differs between Cassandra (clustering key order) and ScyllaDB
@@ -256,7 +256,7 @@ func (s *NexusEndpointStore) DeleteNexusEndpoint(
 		request.ID)
 
 	previousPartitionStatus := make(map[string]any)
-	applied, iter, err := s.session.MapExecuteBatchCAS(batch, previousPartitionStatus)
+	applied, iter, err := batch.MapExecCAS(ctx, previousPartitionStatus)
 
 	if err != nil {
 		return gocql.ConvertError("DeleteNexusEndpoint", err)
@@ -291,8 +291,8 @@ func (s *NexusEndpointStore) listFirstPageWithVersion(
 ) (*p.InternalListNexusEndpointsResponse, error) {
 	response := &p.InternalListNexusEndpointsResponse{}
 
-	query := s.session.Query(templateListEndpointsFirstPageQuery).WithContext(ctx)
-	iter := query.PageSize(request.PageSize + 1).PageState(nil).Iter() // Use PageSize+1 to account for partitionStatus row
+	query := s.session.Query(templateListEndpointsFirstPageQuery)
+	iter := query.PageSize(request.PageSize + 1).PageState(nil).Iter(ctx) // Use PageSize+1 to account for partitionStatus row
 
 	partitionStateRow := make(map[string]any)
 	found := iter.MapScan(partitionStateRow)
@@ -330,10 +330,10 @@ func (s *NexusEndpointStore) listFirstPageWithVersion(
 }
 
 func (s *NexusEndpointStore) getTableVersion(ctx context.Context) (int64, error) {
-	query := s.session.Query(templateGetTableVersion, rowTypePartitionStatus, tableVersionEndpointID).WithContext(ctx)
+	query := s.session.Query(templateGetTableVersion, rowTypePartitionStatus, tableVersionEndpointID)
 
 	var version int64
-	if err := query.Scan(&version); err != nil {
+	if err := query.Scan(ctx, &version); err != nil {
 		return 0, gocql.ConvertError("GetNexusEndpointsTableVersion", err)
 	}
 

--- a/common/persistence/cassandra/queue_store.go
+++ b/common/persistence/cassandra/queue_store.go
@@ -92,9 +92,9 @@ func (q *QueueStore) tryEnqueue(
 	messageID int64,
 	blob *commonpb.DataBlob,
 ) (int64, error) {
-	query := q.session.Query(templateEnqueueMessageQuery, queueType, messageID, blob.Data, blob.EncodingType.String()).WithContext(ctx)
+	query := q.session.Query(templateEnqueueMessageQuery, queueType, messageID, blob.Data, blob.EncodingType.String())
 	previous := make(map[string]any)
-	applied, err := query.MapScanCAS(previous)
+	applied, err := query.MapScanCAS(ctx, previous)
 	if err != nil {
 		return persistence.EmptyQueueMessageID, gocql.ConvertError("tryEnqueue", err)
 	}
@@ -111,9 +111,9 @@ func (q *QueueStore) getLastMessageID(
 	queueType persistence.QueueType,
 ) (int64, error) {
 
-	query := q.session.Query(templateGetLastMessageIDQuery, queueType).WithContext(ctx)
+	query := q.session.Query(templateGetLastMessageIDQuery, queueType)
 	result := make(map[string]any)
-	err := query.MapScan(result)
+	err := query.MapScan(ctx, result)
 	if err != nil {
 		if gocql.IsNotFoundError(err) {
 			return persistence.EmptyQueueMessageID, nil
@@ -133,9 +133,9 @@ func (q *QueueStore) ReadMessages(
 		q.queueType,
 		lastMessageID,
 		maxCount,
-	).WithContext(ctx)
+	)
 
-	iter := query.Iter()
+	iter := query.Iter(ctx)
 
 	var result []*persistence.QueueMessage
 	message := make(map[string]any)
@@ -165,8 +165,8 @@ func (q *QueueStore) ReadMessagesFromDLQ(
 		q.getDLQTypeFromQueueType(),
 		firstMessageID,
 		lastMessageID,
-	).WithContext(ctx)
-	iter := query.PageSize(pageSize).PageState(pageToken).Iter()
+	)
+	iter := query.PageSize(pageSize).PageState(pageToken).Iter(ctx)
 
 	var result []*persistence.QueueMessage
 	message := make(map[string]any)
@@ -192,8 +192,8 @@ func (q *QueueStore) DeleteMessagesBefore(
 	messageID int64,
 ) error {
 
-	query := q.session.Query(templateDeleteMessagesBeforeQuery, q.queueType, messageID).WithContext(ctx)
-	if err := query.Exec(); err != nil {
+	query := q.session.Query(templateDeleteMessagesBeforeQuery, q.queueType, messageID)
+	if err := query.Exec(ctx); err != nil {
 		return gocql.ConvertError("DeleteMessagesBefore", err)
 	}
 	return nil
@@ -205,8 +205,8 @@ func (q *QueueStore) DeleteMessageFromDLQ(
 ) error {
 
 	// Use negative queue type as the dlq type
-	query := q.session.Query(templateDeleteMessageQuery, q.getDLQTypeFromQueueType(), messageID).WithContext(ctx)
-	if err := query.Exec(); err != nil {
+	query := q.session.Query(templateDeleteMessageQuery, q.getDLQTypeFromQueueType(), messageID)
+	if err := query.Exec(ctx); err != nil {
 		return gocql.ConvertError("DeleteMessageFromDLQ", err)
 	}
 
@@ -220,8 +220,8 @@ func (q *QueueStore) RangeDeleteMessagesFromDLQ(
 ) error {
 
 	// Use negative queue type as the dlq type
-	query := q.session.Query(templateDeleteMessagesQuery, q.getDLQTypeFromQueueType(), firstMessageID, lastMessageID).WithContext(ctx)
-	if err := query.Exec(); err != nil {
+	query := q.session.Query(templateDeleteMessagesQuery, q.getDLQTypeFromQueueType(), firstMessageID, lastMessageID)
+	if err := query.Exec(ctx); err != nil {
 		return gocql.ConvertError("RangeDeleteMessagesFromDLQ", err)
 	}
 
@@ -280,8 +280,8 @@ func (q *QueueStore) insertInitialQueueMetadataRecord(
 		blob.Data,
 		blob.EncodingType.String(),
 		version,
-	).WithContext(ctx)
-	_, err := query.MapScanCAS(make(map[string]any))
+	)
+	_, err := query.MapScanCAS(ctx, make(map[string]any))
 	if err != nil {
 		return fmt.Errorf("failed to insert initial queue metadata record: %v, Type: %v", err, queueType)
 	}
@@ -294,9 +294,9 @@ func (q *QueueStore) getQueueMetadata(
 	queueType persistence.QueueType,
 ) (*persistence.InternalQueueMetadata, error) {
 
-	query := q.session.Query(templateGetQueueMetadataQuery, queueType).WithContext(ctx)
+	query := q.session.Query(templateGetQueueMetadataQuery, queueType)
 	message := make(map[string]any)
-	err := query.MapScan(message)
+	err := query.MapScan(ctx, message)
 	if err != nil {
 		return nil, err
 	}
@@ -323,8 +323,8 @@ func (q *QueueStore) updateAckLevel(
 		metadata.Version+1, // always increase version number on update
 		queueType,
 		metadata.Version, // condition update
-	).WithContext(ctx)
-	applied, err := query.MapScanCAS(make(map[string]any))
+	)
+	applied, err := query.MapScanCAS(ctx, make(map[string]any))
 	if err != nil {
 		return gocql.ConvertError("updateAckLevel", err)
 	}

--- a/common/persistence/cassandra/queue_v2_store.go
+++ b/common/persistence/cassandra/queue_v2_store.go
@@ -160,7 +160,7 @@ func (s *queueV2Store) ReadMessages(
 		0,
 		int(minMessageID),
 		request.PageSize,
-	).WithContext(ctx).Iter()
+	).Iter(ctx)
 
 	var (
 		messages []persistence.QueueV2Message
@@ -225,7 +225,7 @@ func (s *queueV2Store) CreateQueue(
 		bytes,
 		enumspb.ENCODING_TYPE_PROTO3.String(),
 		0,
-	).WithContext(ctx).MapScanCAS(make(map[string]any))
+	).MapScanCAS(ctx, make(map[string]any))
 	if err != nil {
 		return nil, gocql.ConvertError("QueueV2CreateQueue", err)
 	}
@@ -288,7 +288,7 @@ func (s *queueV2Store) RangeDeleteMessages(
 		0, // partition
 		deleteRange.MinMessageID,
 		deleteRange.MaxMessageID,
-	).WithContext(ctx).Exec()
+	).Exec(ctx)
 	if err != nil {
 		return nil, gocql.ConvertError("QueueV2RangeDeleteMessages", err)
 	}
@@ -320,7 +320,7 @@ func (s *queueV2Store) updateQueue(
 		queueType,
 		queueName,
 		version,
-	).WithContext(ctx).MapScanCAS(make(map[string]any))
+	).MapScanCAS(ctx, make(map[string]any))
 	if err != nil {
 		return gocql.ConvertError("QueueV2UpdateQueueMetadata", err)
 	}
@@ -350,7 +350,7 @@ func (s *queueV2Store) tryInsert(
 		messageID,
 		blob.Data,
 		blob.EncodingType.String(),
-	).WithContext(ctx).MapScanCAS(make(map[string]any))
+	).MapScanCAS(ctx, make(map[string]any))
 	if err != nil {
 		return gocql.ConvertError("QueueV2EnqueueMessage", err)
 	}
@@ -387,7 +387,8 @@ func GetQueue(
 		version          int64
 	)
 
-	err := session.Query(TemplateGetQueueQuery, queueType, queueName).WithContext(ctx).Scan(
+	err := session.Query(TemplateGetQueueQuery, queueType, queueName).Scan(
+		ctx,
 		&queueBytes,
 		&queueEncodingStr,
 		&version,
@@ -454,7 +455,7 @@ func (s *queueV2Store) getMessageCountAndLastID(
 func (s *queueV2Store) getMaxMessageID(ctx context.Context, queueType persistence.QueueV2Type, queueName string) (int64, bool, error) {
 	var maxMessageID int64
 
-	err := s.session.Query(TemplateGetMaxMessageIDQuery, queueType, queueName, 0).WithContext(ctx).Scan(&maxMessageID)
+	err := s.session.Query(TemplateGetMaxMessageIDQuery, queueType, queueName, 0).Scan(ctx, &maxMessageID)
 	if err != nil {
 		if gocql.IsNotFoundError(err) {
 			return 0, false, nil
@@ -484,7 +485,7 @@ func (s *queueV2Store) ListQueues(
 		iter := s.session.Query(
 			templateGetQueueNamesQuery,
 			request.QueueType,
-		).PageSize(remaining).PageState(pageToken).WithContext(ctx).Iter()
+		).PageSize(remaining).PageState(pageToken).Iter(ctx)
 
 		for {
 			var (

--- a/common/persistence/cassandra/schema_version_reader.go
+++ b/common/persistence/cassandra/schema_version_reader.go
@@ -1,6 +1,7 @@
 package cassandra
 
 import (
+	"context"
 	"fmt"
 
 	"go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
@@ -26,7 +27,7 @@ func NewSchemaVersionReader(session gocql.Session) *SchemaVersionReader {
 func (svr *SchemaVersionReader) ReadSchemaVersion(keyspace string) (string, error) {
 	query := svr.session.Query(readSchemaVersionCQL, keyspace)
 
-	iter := query.Iter()
+	iter := query.Iter(context.Background())
 	var version string
 	success := iter.Scan(&version)
 	err := iter.Close()

--- a/common/persistence/cassandra/shard_store.go
+++ b/common/persistence/cassandra/shard_store.go
@@ -69,11 +69,11 @@ func (d *ShardStore) GetOrCreateShard(
 		rowTypeShardRunID,
 		defaultVisibilityTimestamp,
 		rowTypeShardTaskID,
-	).WithContext(ctx)
+	)
 
 	var data []byte
 	var encoding string
-	err := query.Scan(&data, &encoding)
+	err := query.Scan(ctx, &data, &encoding)
 	if err == nil {
 		return &p.InternalGetOrCreateShardResponse{
 			ShardInfo: p.NewDataBlob(data, encoding),
@@ -99,10 +99,10 @@ func (d *ShardStore) GetOrCreateShard(
 		shardInfo.Data,
 		shardInfo.EncodingType.String(),
 		rangeID,
-	).WithContext(ctx)
+	)
 
 	previous := make(map[string]any)
-	applied, err := query.MapScanCAS(previous)
+	applied, err := query.MapScanCAS(ctx, previous)
 	if err != nil {
 		return nil, gocql.ConvertError("GetOrCreateShard", err)
 	}
@@ -132,10 +132,10 @@ func (d *ShardStore) UpdateShard(
 		defaultVisibilityTimestamp,
 		rowTypeShardTaskID,
 		request.PreviousRangeID,
-	).WithContext(ctx)
+	)
 
 	previous := make(map[string]any)
-	applied, err := query.MapScanCAS(previous)
+	applied, err := query.MapScanCAS(ctx, previous)
 	if err != nil {
 		return gocql.ConvertError("UpdateShard", err)
 	}

--- a/common/persistence/cassandra/test.go
+++ b/common/persistence/cassandra/test.go
@@ -1,11 +1,12 @@
 package cassandra
 
 import (
+	"context"
 	"path"
 	"strings"
 	"time"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/debug"
@@ -195,7 +196,7 @@ func (s *TestCluster) LoadSchema(schemaFile string) {
 		s.logger.Fatal("LoadSchema", tag.Error(err))
 	}
 	for _, stmt := range statements {
-		if err = s.session.Query(stmt).Exec(); err != nil {
+		if err = s.session.Query(stmt).Exec(context.Background()); err != nil {
 			s.logger.Fatal("LoadSchema", tag.Error(err))
 		}
 	}

--- a/common/persistence/cassandra/test.go
+++ b/common/persistence/cassandra/test.go
@@ -230,7 +230,7 @@ func (s *TestCluster) writeSchemaUpdateLog(oldVersion string, newVersion string,
 }
 
 func (s *TestCluster) execSchemaVersionQuery(stmt string, args ...any) {
-	if err := s.session.Query(stmt, args...).Exec(); err != nil {
+	if err := s.session.Query(stmt, args...).Exec(context.Background()); err != nil {
 		s.logger.Fatal("loadSchemaVersion", tag.Error(err))
 	}
 }

--- a/common/persistence/cassandra/version_checker.go
+++ b/common/persistence/cassandra/version_checker.go
@@ -1,7 +1,7 @@
 package cassandra
 
 import (
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/batch.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/batch.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 type (
@@ -36,8 +36,20 @@ func (b *Batch) Query(stmt string, args ...any) {
 	b.gocqlBatch.Query(stmt, args...)
 }
 
-func (b *Batch) WithContext(ctx context.Context) *Batch {
-	return newBatch(b.session, b.gocqlBatch.WithContext(ctx))
+func (b *Batch) Exec(ctx context.Context) (retError error) {
+	defer func() { b.session.handleError(retError) }()
+
+	return b.gocqlBatch.ExecContext(ctx)
+}
+
+func (b *Batch) MapExecCAS(ctx context.Context, dest map[string]any) (_ bool, _ Iter, retError error) {
+	defer func() { b.session.handleError(retError) }()
+
+	applied, iter, err := b.gocqlBatch.MapExecCASContext(ctx, dest)
+	if iter != nil {
+		return applied, newIter(b.session, iter), err
+	}
+	return applied, nil, err
 }
 
 func (b *Batch) WithTimestamp(timestamp int64) *Batch {

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/batch.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/batch.go
@@ -9,9 +9,9 @@ import (
 
 type (
 	Batch struct {
-		session *session
-
-		gocqlBatch *gocql.Batch
+		session       *session
+		gocqlBatch    *gocql.Batch
+		tracerFactory TracerFactory
 	}
 )
 
@@ -38,13 +38,13 @@ func (b *Batch) Query(stmt string, args ...any) {
 
 func (b *Batch) Exec(ctx context.Context) (retError error) {
 	defer func() { b.session.handleError(retError) }()
-
+	b.maybeTrace(ctx)
 	return b.gocqlBatch.ExecContext(ctx)
 }
 
 func (b *Batch) MapExecCAS(ctx context.Context, dest map[string]any) (_ bool, _ Iter, retError error) {
 	defer func() { b.session.handleError(retError) }()
-
+	b.maybeTrace(ctx)
 	applied, iter, err := b.gocqlBatch.MapExecCASContext(ctx, dest)
 	if iter != nil {
 		return applied, newIter(b.session, iter), err
@@ -57,8 +57,8 @@ func (b *Batch) WithTimestamp(timestamp int64) *Batch {
 	return newBatch(b.session, b.gocqlBatch)
 }
 
-func (b *Batch) WithTrace(tr gocql.Tracer) *Batch {
-	b.gocqlBatch.Trace(tr)
+func (b *Batch) WithTrace(tr TracerFactory) *Batch {
+	b.tracerFactory = tr
 	return newBatch(b.session, b.gocqlBatch)
 }
 
@@ -72,5 +72,14 @@ func mustConvertBatchType(batchType BatchType) gocql.BatchType {
 		return gocql.CounterBatch
 	default:
 		panic(fmt.Sprintf("Unknown gocql BatchType: %v", batchType))
+	}
+}
+
+func (b *Batch) maybeTrace(ctx context.Context) {
+	if b.tracerFactory != nil {
+		tr := b.tracerFactory.GetTracerWithContext(ctx)
+		if tr != nil {
+			b.gocqlBatch.Trace(tr)
+		}
 	}
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/batch.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/batch.go
@@ -57,6 +57,11 @@ func (b *Batch) WithTimestamp(timestamp int64) *Batch {
 	return newBatch(b.session, b.gocqlBatch)
 }
 
+func (b *Batch) WithTrace(tr gocql.Tracer) *Batch {
+	b.gocqlBatch.Trace(tr)
+	return newBatch(b.session, b.gocqlBatch)
+}
+
 func mustConvertBatchType(batchType BatchType) gocql.BatchType {
 	switch batchType {
 	case LoggedBatch:

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/batch.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/batch.go
@@ -77,7 +77,7 @@ func mustConvertBatchType(batchType BatchType) gocql.BatchType {
 
 func (b *Batch) maybeTrace(ctx context.Context) {
 	if b.tracerFactory != nil {
-		tr := b.tracerFactory.GetTracerWithContext(ctx)
+		tr := b.tracerFactory.GetTracerForBatch(ctx, b.gocqlBatch)
 		if tr != nil {
 			b.gocqlBatch.Trace(tr)
 		}

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 	"go.temporal.io/server/common/auth"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/debug"

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/client_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/client_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 	"github.com/stretchr/testify/assert"
 	"go.temporal.io/server/common/auth"
 	"go.temporal.io/server/common/config"

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/consistency.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/consistency.go
@@ -3,7 +3,7 @@ package gocql
 import (
 	"fmt"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 // Definition of all Consistency levels

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/errors.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/errors.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/persistence"

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/errors_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/errors_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	enumspb "go.temporal.io/api/enums/v1"

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/interfaces.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/interfaces.go
@@ -3,7 +3,7 @@ package gocql
 import (
 	"context"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 // Note: this file defines the minimal interface that is needed by Temporal's cassandra
@@ -16,23 +16,20 @@ type (
 	Session interface {
 		Query(string, ...any) Query
 		NewBatch(BatchType) *Batch
-		ExecuteBatch(*Batch) error
-		MapExecuteBatchCAS(*Batch, map[string]any) (bool, Iter, error)
 		AwaitSchemaAgreement(ctx context.Context) error
 		Close()
 	}
 
 	// Query is the interface for query object.
 	Query interface {
-		Exec() error
-		Scan(...any) error
-		ScanCAS(...any) (bool, error)
-		MapScan(map[string]any) error
-		MapScanCAS(map[string]any) (bool, error)
-		Iter() Iter
+		Exec(context.Context) error
+		Scan(context.Context, ...any) error
+		ScanCAS(context.Context, ...any) (bool, error)
+		MapScan(context.Context, map[string]any) error
+		MapScanCAS(context.Context, map[string]any) (bool, error)
+		Iter(context.Context) Iter
 		PageSize(int) Query
 		PageState([]byte) Query
-		WithContext(context.Context) Query
 		WithTimestamp(int64) Query
 		Consistency(Consistency) Query
 		Bind(...any) Query

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/interfaces.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/interfaces.go
@@ -21,7 +21,8 @@ type (
 	}
 
 	TracerFactory interface {
-		GetTracerWithContext(ctx context.Context) gocql.Tracer
+		GetTracerForQuery(context.Context, *gocql.Query) gocql.Tracer
+		GetTracerForBatch(context.Context, *gocql.Batch) gocql.Tracer
 	}
 
 	// Query is the interface for query object.

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/interfaces.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/interfaces.go
@@ -31,6 +31,7 @@ type (
 		PageSize(int) Query
 		PageState([]byte) Query
 		WithTimestamp(int64) Query
+		WithTrace(gocql.Tracer) Query
 		Consistency(Consistency) Query
 		Bind(...any) Query
 		Idempotent(bool) Query

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/interfaces.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/interfaces.go
@@ -20,6 +20,10 @@ type (
 		Close()
 	}
 
+	TracerFactory interface {
+		GetTracerWithContext(ctx context.Context) gocql.Tracer
+	}
+
 	// Query is the interface for query object.
 	Query interface {
 		Exec(context.Context) error
@@ -31,7 +35,7 @@ type (
 		PageSize(int) Query
 		PageState([]byte) Query
 		WithTimestamp(int64) Query
-		WithTrace(gocql.Tracer) Query
+		WithTrace(TracerFactory) Query
 		Consistency(Consistency) Query
 		Bind(...any) Query
 		Idempotent(bool) Query

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/iter.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/iter.go
@@ -1,7 +1,7 @@
 package gocql
 
 import (
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 type iter struct {

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/query.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/query.go
@@ -3,7 +3,7 @@ package gocql
 import (
 	"context"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 var _ Query = (*query)(nil)
@@ -25,46 +25,50 @@ func newQuery(
 	}
 }
 
-func (q *query) Exec() (retError error) {
+func (q *query) Exec(ctx context.Context) (retError error) {
 	defer func() { q.session.handleError(retError) }()
 
-	return q.gocqlQuery.Exec()
+	return q.gocqlQuery.ExecContext(ctx)
 }
 
 func (q *query) Scan(
+	ctx context.Context,
 	dest ...any,
 ) (retError error) {
 	defer func() { q.session.handleError(retError) }()
 
-	return q.gocqlQuery.Scan(dest...)
+	return q.gocqlQuery.ScanContext(ctx, dest...)
 }
 
 func (q *query) ScanCAS(
+	ctx context.Context,
 	dest ...any,
 ) (_ bool, retError error) {
 	defer func() { q.session.handleError(retError) }()
 
-	return q.gocqlQuery.ScanCAS(dest...)
+	return q.gocqlQuery.ScanCASContext(ctx, dest...)
 }
 
 func (q *query) MapScan(
+	ctx context.Context,
 	m map[string]any,
 ) (retError error) {
 	defer func() { q.session.handleError(retError) }()
 
-	return q.gocqlQuery.MapScan(m)
+	return q.gocqlQuery.MapScanContext(ctx, m)
 }
 
 func (q *query) MapScanCAS(
+	ctx context.Context,
 	dest map[string]any,
 ) (_ bool, retError error) {
 	defer func() { q.session.handleError(retError) }()
 
-	return q.gocqlQuery.MapScanCAS(dest)
+	return q.gocqlQuery.MapScanCASContext(ctx, dest)
 }
 
-func (q *query) Iter() Iter {
-	iter := q.gocqlQuery.Iter()
+func (q *query) Iter(ctx context.Context) Iter {
+	iter := q.gocqlQuery.IterContext(ctx)
 	return newIter(q.session, iter)
 }
 
@@ -86,14 +90,6 @@ func (q *query) Consistency(c Consistency) Query {
 func (q *query) WithTimestamp(timestamp int64) Query {
 	q.gocqlQuery.WithTimestamp(timestamp)
 	return newQuery(q.session, q.gocqlQuery)
-}
-
-func (q *query) WithContext(ctx context.Context) Query {
-	q2 := q.gocqlQuery.WithContext(ctx)
-	if q2 == nil {
-		return nil
-	}
-	return newQuery(q.session, q2)
 }
 
 func (q *query) Bind(v ...any) Query {

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/query.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/query.go
@@ -116,7 +116,7 @@ func (q *query) SetSpeculativeExecutionPolicy(policy SpeculativeExecutionPolicy)
 
 func (q *query) maybeTrace(ctx context.Context) {
 	if q.tracerFactory != nil {
-		tr := q.tracerFactory.GetTracerWithContext(ctx)
+		tr := q.tracerFactory.GetTracerForQuery(ctx, q.gocqlQuery)
 		if tr != nil {
 			q.gocqlQuery.Trace(tr)
 		}

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/query.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/query.go
@@ -15,6 +15,8 @@ type (
 	}
 )
 
+var _ Query = &query{}
+
 func newQuery(
 	session *session,
 	gocqlQuery *gocql.Query,
@@ -89,6 +91,11 @@ func (q *query) Consistency(c Consistency) Query {
 
 func (q *query) WithTimestamp(timestamp int64) Query {
 	q.gocqlQuery.WithTimestamp(timestamp)
+	return newQuery(q.session, q.gocqlQuery)
+}
+
+func (q *query) WithTrace(tr gocql.Tracer) Query {
+	q.gocqlQuery.Trace(tr)
 	return newQuery(q.session, q.gocqlQuery)
 }
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/query.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/query.go
@@ -10,8 +10,9 @@ var _ Query = (*query)(nil)
 
 type (
 	query struct {
-		session    *session
-		gocqlQuery *gocql.Query
+		session       *session
+		gocqlQuery    *gocql.Query
+		tracerFactory TracerFactory
 	}
 )
 
@@ -29,7 +30,7 @@ func newQuery(
 
 func (q *query) Exec(ctx context.Context) (retError error) {
 	defer func() { q.session.handleError(retError) }()
-
+	q.maybeTrace(ctx)
 	return q.gocqlQuery.ExecContext(ctx)
 }
 
@@ -38,7 +39,7 @@ func (q *query) Scan(
 	dest ...any,
 ) (retError error) {
 	defer func() { q.session.handleError(retError) }()
-
+	q.maybeTrace(ctx)
 	return q.gocqlQuery.ScanContext(ctx, dest...)
 }
 
@@ -47,7 +48,7 @@ func (q *query) ScanCAS(
 	dest ...any,
 ) (_ bool, retError error) {
 	defer func() { q.session.handleError(retError) }()
-
+	q.maybeTrace(ctx)
 	return q.gocqlQuery.ScanCASContext(ctx, dest...)
 }
 
@@ -56,7 +57,7 @@ func (q *query) MapScan(
 	m map[string]any,
 ) (retError error) {
 	defer func() { q.session.handleError(retError) }()
-
+	q.maybeTrace(ctx)
 	return q.gocqlQuery.MapScanContext(ctx, m)
 }
 
@@ -65,11 +66,12 @@ func (q *query) MapScanCAS(
 	dest map[string]any,
 ) (_ bool, retError error) {
 	defer func() { q.session.handleError(retError) }()
-
+	q.maybeTrace(ctx)
 	return q.gocqlQuery.MapScanCASContext(ctx, dest)
 }
 
 func (q *query) Iter(ctx context.Context) Iter {
+	q.maybeTrace(ctx)
 	iter := q.gocqlQuery.IterContext(ctx)
 	return newIter(q.session, iter)
 }
@@ -94,8 +96,8 @@ func (q *query) WithTimestamp(timestamp int64) Query {
 	return newQuery(q.session, q.gocqlQuery)
 }
 
-func (q *query) WithTrace(tr gocql.Tracer) Query {
-	q.gocqlQuery.Trace(tr)
+func (q *query) WithTrace(tr TracerFactory) Query {
+	q.tracerFactory = tr
 	return newQuery(q.session, q.gocqlQuery)
 }
 
@@ -110,4 +112,13 @@ func (q *query) Idempotent(value bool) Query {
 
 func (q *query) SetSpeculativeExecutionPolicy(policy SpeculativeExecutionPolicy) Query {
 	return newQuery(q.session, q.gocqlQuery.SetSpeculativeExecutionPolicy(policy))
+}
+
+func (q *query) maybeTrace(ctx context.Context) {
+	if q.tracerFactory != nil {
+		tr := q.tracerFactory.GetTracerWithContext(ctx)
+		if tr != nil {
+			q.gocqlQuery.Trace(tr)
+		}
+	}
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/session.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/session.go
@@ -42,8 +42,7 @@ func NewSession(
 	logger log.Logger,
 	metricsHandler metrics.Handler,
 ) (*session, error) {
-
-	gocqlSession, err := initSession(logger, newClusterConfigFunc, metricsHandler)
+	gocqlSession, err := initSession(newClusterConfigFunc, metricsHandler)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +75,7 @@ func (s *session) refresh() {
 		return
 	}
 
-	newSession, err := initSession(s.logger, s.newClusterConfigFunc, s.metricsHandler)
+	newSession, err := initSession(s.newClusterConfigFunc, s.metricsHandler)
 	if err != nil {
 		s.logger.Error("gocql wrapper: unable to refresh gocql session", tag.Error(err))
 		handler := s.metricsHandler.WithTags(metrics.FailureTag(refreshErrorTagValue))
@@ -92,11 +91,9 @@ func (s *session) refresh() {
 }
 
 func initSession(
-	logger log.Logger,
 	newClusterConfigFunc func() (*gocql.ClusterConfig, error),
 	metricsHandler metrics.Handler,
 ) (gs *gocql.Session, retErr error) {
-	defer log.CapturePanic(logger, &retErr)
 	cluster, err := newClusterConfigFunc()
 	if err != nil {
 		return nil, err

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/session.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/session.go
@@ -6,7 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -126,7 +126,7 @@ func (s *session) Query(
 func (s *session) NewBatch(
 	batchType BatchType,
 ) *Batch {
-	b := s.Value.Load().(*gocql.Session).NewBatch(mustConvertBatchType(batchType))
+	b := s.Value.Load().(*gocql.Session).Batch(mustConvertBatchType(batchType))
 	if b == nil {
 		return nil
 	}
@@ -134,24 +134,6 @@ func (s *session) NewBatch(
 		session:    s,
 		gocqlBatch: b,
 	}
-}
-
-func (s *session) ExecuteBatch(
-	b *Batch,
-) (retError error) {
-	defer func() { s.handleError(retError) }()
-
-	return s.Value.Load().(*gocql.Session).ExecuteBatch(b.gocqlBatch)
-}
-
-func (s *session) MapExecuteBatchCAS(
-	b *Batch,
-	previous map[string]any,
-) (_ bool, _ Iter, retError error) {
-	defer func() { s.handleError(retError) }()
-
-	applied, iter, err := s.Value.Load().(*gocql.Session).MapExecuteBatchCAS(b.gocqlBatch, previous)
-	return applied, iter, err
 }
 
 func (s *session) AwaitSchemaAgreement(

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/session_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/session_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	gocql "github.com/apache/cassandra-gocql-driver/v2"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
@@ -54,7 +54,7 @@ func TestInvalidHostGeneratesError(t *testing.T) {
 		return &gocql.ClusterConfig{Hosts: []string{"0.0.0.0"}}, nil
 	}, metrics.NoopMetricsHandler)
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	// This used to panic, but now should simply return an error.
-	assert.Contains(t, err.Error(), "invalid host address")
+	require.Contains(t, err.Error(), "invalid host address")
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/session_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/session_test.go
@@ -49,11 +49,12 @@ func TestSessionEmitsMetricOnRefreshThrottle(t *testing.T) {
 	controller.Finish()
 }
 
-func TestPanicCapture(t *testing.T) {
-	_, err := initSession(log.NewNoopLogger(), func() (*gocql.ClusterConfig, error) {
+func TestInvalidHostGeneratesError(t *testing.T) {
+	_, err := initSession(func() (*gocql.ClusterConfig, error) {
 		return &gocql.ClusterConfig{Hosts: []string{"0.0.0.0"}}, nil
 	}, metrics.NoopMetricsHandler)
 
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "panic:")
+	// This used to panic, but now should simply return an error.
+	assert.Contains(t, err.Error(), "invalid host address")
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/session_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/session_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 	"github.com/stretchr/testify/assert"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/uuid.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/uuid.go
@@ -3,7 +3,7 @@ package gocql
 import (
 	"encoding/binary"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 	"go.temporal.io/server/chasm"
 )
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/translator/fixed_address_translator.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/translator/fixed_address_translator.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 	"go.temporal.io/server/common/config"
 )
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/translator/translator_plugin.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/translator/translator_plugin.go
@@ -3,7 +3,7 @@ package translator
 import (
 	"errors"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 	"go.temporal.io/server/common/config"
 )
 

--- a/common/persistence/persistence-tests/metadata_persistence_v2.go
+++ b/common/persistence/persistence-tests/metadata_persistence_v2.go
@@ -85,19 +85,19 @@ func (m *MetadataPersistenceSuiteV2) createPartialNamespace(id string, name stri
 	const templateCreateNamespaceQuery = `INSERT INTO namespaces_by_id (` +
 		`id, name) ` +
 		`VALUES(?, ?) IF NOT EXISTS`
-	query := m.DefaultTestCluster.(*cassandra.TestCluster).GetSession().Query(templateCreateNamespaceQuery, id, name).WithContext(context.Background())
-	err := query.Exec()
+	query := m.DefaultTestCluster.(*cassandra.TestCluster).GetSession().Query(templateCreateNamespaceQuery, id, name)
+	err := query.Exec(context.Background())
 	m.NoError(err)
 
 }
 
 func (m *MetadataPersistenceSuiteV2) truncatePartialNamespace() {
-	query := m.DefaultTestCluster.(*cassandra.TestCluster).GetSession().Query("TRUNCATE namespaces_by_id").WithContext(context.Background())
-	err := query.Exec()
+	query := m.DefaultTestCluster.(*cassandra.TestCluster).GetSession().Query("TRUNCATE namespaces_by_id")
+	err := query.Exec(context.Background())
 	m.NoError(err)
 
-	query = m.DefaultTestCluster.(*cassandra.TestCluster).GetSession().Query("TRUNCATE namespaces").WithContext(context.Background())
-	err = query.Exec()
+	query = m.DefaultTestCluster.(*cassandra.TestCluster).GetSession().Query("TRUNCATE namespaces")
+	err = query.Exec(context.Background())
 	m.NoError(err)
 }
 

--- a/common/persistence/tests/cassandra_test.go
+++ b/common/persistence/tests/cassandra_test.go
@@ -99,7 +99,7 @@ func (q failingQuery) Iter(context.Context) gocql.Iter {
 	return failingIter{}
 }
 
-func (q failingQuery) Scan(...any) error {
+func (q failingQuery) Scan(context.Context, ...any) error {
 	return assert.AnError
 }
 
@@ -689,7 +689,7 @@ func testCassandraQueueV2ErrInvalidQueueMessageEncodingType(t *testing.T, cluste
 	assert.ErrorAs(t, err, new(*serialization.UnknownEncodingTypeError))
 }
 
-func (q failingQuery) MapScanCAS(map[string]any) (bool, error) {
+func (q failingQuery) MapScanCAS(context.Context, map[string]any) (bool, error) {
 	return false, assert.AnError
 }
 

--- a/common/persistence/tests/cassandra_test.go
+++ b/common/persistence/tests/cassandra_test.go
@@ -95,7 +95,7 @@ func (f failingIter) Close() error {
 	return assert.AnError
 }
 
-func (q failingQuery) Iter() gocql.Iter {
+func (q failingQuery) Iter(context.Context) gocql.Iter {
 	return failingIter{}
 }
 
@@ -103,7 +103,7 @@ func (q failingQuery) Scan(...any) error {
 	return assert.AnError
 }
 
-func (q failingQuery) Exec() error {
+func (q failingQuery) Exec(context.Context) error {
 	return assert.AnError
 }
 
@@ -662,6 +662,7 @@ func printResults(t *testing.T, results chan enqueueMessageResult) {
 func testCassandraQueueV2ErrInvalidQueueMessageEncodingType(t *testing.T, cluster *cassandra.TestCluster) {
 	session := cluster.GetSession()
 	q := newQueueV2Store(session)
+	ctx := context.Background()
 	queueType := persistence.QueueTypeHistoryNormal
 	queueName := "test-queue-" + t.Name()
 	_, err := q.CreateQueue(context.Background(), &persistence.InternalCreateQueueRequest{
@@ -677,7 +678,7 @@ func testCassandraQueueV2ErrInvalidQueueMessageEncodingType(t *testing.T, cluste
 		1, // messageID
 		[]byte("test"),
 		"bad-encoding-type",
-	).Exec()
+	).Exec(ctx)
 	require.NoError(t, err)
 	_, err = q.ReadMessages(context.Background(), &persistence.InternalReadMessagesRequest{
 		QueueType: queueType,
@@ -690,10 +691,6 @@ func testCassandraQueueV2ErrInvalidQueueMessageEncodingType(t *testing.T, cluste
 
 func (q failingQuery) MapScanCAS(map[string]any) (bool, error) {
 	return false, assert.AnError
-}
-
-func (q failingQuery) WithContext(context.Context) gocql.Query {
-	return q
 }
 
 func (f failingSession) Query(query string, args ...any) gocql.Query {
@@ -753,6 +750,7 @@ func testCassandraQueueV2ErrInvalidPayloadEncodingType(t *testing.T, cluster *ca
 
 	session := cluster.GetSession()
 	q := newQueueV2Store(session)
+	ctx := context.Background()
 	// Using a different QueueType so that ListQueue tests are not failing because of corrupt queue metadata.
 	queueType := persistence.QueueV2Type(3)
 	queueName := "test-queue-" + t.Name()
@@ -763,7 +761,7 @@ func testCassandraQueueV2ErrInvalidPayloadEncodingType(t *testing.T, cluster *ca
 		[]byte("test"),      // payload
 		"bad-encoding-type", // payload encoding type
 		0,                   // version
-	).Exec()
+	).Exec(ctx)
 	require.NoError(t, err)
 	_, err = q.ReadMessages(context.Background(), &persistence.InternalReadMessagesRequest{
 		QueueType: queueType,
@@ -793,6 +791,7 @@ func testCassandraQueueV2ErrInvalidPayload(t *testing.T, cluster *cassandra.Test
 
 	session := cluster.GetSession()
 	q := newQueueV2Store(session)
+	ctx := context.Background()
 	queueType := persistence.QueueTypeHistoryNormal
 	queueName := "test-queue-" + t.Name()
 	err := session.Query(
@@ -802,7 +801,7 @@ func testCassandraQueueV2ErrInvalidPayload(t *testing.T, cluster *cassandra.Test
 		[]byte("invalid-payload"),             // payload
 		enumspb.ENCODING_TYPE_PROTO3.String(), // payload encoding type
 		0,                                     // version
-	).Exec()
+	).Exec(ctx)
 	require.NoError(t, err)
 	_, err = q.ReadMessages(context.Background(), &persistence.InternalReadMessagesRequest{
 		QueueType: queueType,
@@ -1180,6 +1179,7 @@ func getNumMessages(
 	queueName string,
 	numMessages int,
 ) int {
+	ctx := context.Background()
 	// We query the database directly here to get the actual count of messages deleted. If we just rely on the store
 	// method to read messages, that would indicate that we're updating min_message_id correctly, but it wouldn't verify
 	// that any messages less than min_message_id are actually deleted from the database.
@@ -1191,7 +1191,7 @@ func getNumMessages(
 		0,                               // partition
 		persistence.FirstQueueMessageID, // minMessageID
 		numMessages,                     // limit
-	).Iter()
+	).Iter(ctx)
 	numRemainingMessages := 0
 	for iter.MapScan(map[string]any{}) {
 		numRemainingMessages++
@@ -1217,6 +1217,7 @@ func insertQueueMetadataWithMultiplePartitions(
 	queueName string,
 ) {
 	t.Helper()
+	ctx := context.Background()
 
 	queuePB := persistencespb.Queue{
 		Partitions: map[int32]*persistencespb.QueuePartition{
@@ -1232,7 +1233,7 @@ func insertQueueMetadataWithMultiplePartitions(
 		bytes,                                 // payload
 		enumspb.ENCODING_TYPE_PROTO3.String(), // payload encoding type
 		0,                                     // version
-	).Exec()
+	).Exec(ctx)
 	require.NoError(t, err)
 }
 

--- a/common/persistence/tests/cassandra_test_util.go
+++ b/common/persistence/tests/cassandra_test_util.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -10,8 +11,8 @@ import (
 	"testing"
 	"time"
 
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 	"github.com/blang/semver/v4"
-	"github.com/gocql/gocql"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
@@ -129,7 +130,7 @@ func ApplySchemaUpdate(t *testing.T, cfg *config.Cassandra, schemaFile string, l
 	}
 
 	for _, stmt := range statements {
-		if err = session.Query(stmt).Exec(); err != nil {
+		if err = session.Query(stmt).Exec(context.Background()); err != nil {
 			logger.Error(fmt.Sprintf("Unable to execute statement from file: %s\n  %s", schemaFile, stmt))
 			t.Fatal(err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -168,7 +168,6 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.15 // indirect
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 // indirect
-	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ retract (
 require (
 	cloud.google.com/go/storage v1.62.1
 	github.com/Masterminds/sprig/v3 v3.3.0
+	github.com/apache/cassandra-gocql-driver/v2 v2.1.0
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
@@ -25,7 +26,6 @@ require (
 	github.com/go-faker/faker/v4 v4.7.0
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-sql-driver/mysql v1.9.3
-	github.com/gocql/gocql v1.7.0
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ retract (
 require (
 	cloud.google.com/go/storage v1.62.1
 	github.com/Masterminds/sprig/v3 v3.3.0
-	github.com/apache/cassandra-gocql-driver/v2 v2.1.0
+	github.com/apache/cassandra-gocql-driver/v2 v2.1.2
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
@@ -106,6 +106,7 @@ require (
 	github.com/hashicorp/go-version v1.9.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.56.0 // indirect
 	golang.org/x/perf v0.0.0-20260709024250-82a0b07e230d // indirect
+	google.golang.org/genproto v0.0.0-20260420184626-e10c466a9529 // indirect
 )
 
 require (
@@ -162,7 +163,6 @@ require (
 	github.com/go-openapi/swag v0.26.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/mock v1.6.0 // indirect
-	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.15 // indirect
@@ -217,7 +217,6 @@ require (
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
-	google.golang.org/genproto v0.0.0-20260420184626-e10c466a9529 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260420184626-e10c466a9529 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -164,7 +164,6 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.15 // indirect
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 // indirect
-	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ retract (
 require (
 	cloud.google.com/go/storage v1.62.1
 	github.com/Masterminds/sprig/v3 v3.3.0
-	github.com/apache/cassandra-gocql-driver/v2 v2.1.0
+	github.com/apache/cassandra-gocql-driver/v2 v2.1.2
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
@@ -159,7 +159,6 @@ require (
 	github.com/go-openapi/swag/yamlutils v0.26.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/mock v1.6.0 // indirect
-	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.15 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ retract (
 require (
 	cloud.google.com/go/storage v1.62.1
 	github.com/Masterminds/sprig/v3 v3.3.0
+	github.com/apache/cassandra-gocql-driver/v2 v2.1.0
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
@@ -26,7 +27,6 @@ require (
 	github.com/go-faker/faker/v4 v4.7.0
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-sql-driver/mysql v1.9.3
-	github.com/gocql/gocql v1.7.0
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSC
 github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794 h1:xlwdaKcTNVW4PtpQb8aKA4Pjy0CdJHEqvFbAnvR5m2g=
 github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794/go.mod h1:7e+I0LQFUI9AXWxOfsQROs9xPhoJtbsyWcjJqDd4KPY=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
-github.com/apache/cassandra-gocql-driver/v2 v2.1.0 h1:VEbbeJ2ift4deKMZ6Fs55Vs3fq/RrkjCcxCnqUxhwf8=
-github.com/apache/cassandra-gocql-driver/v2 v2.1.0/go.mod h1:QH/asJjB3mHvY6Dot6ZKMMpTcOrWJ8i9GhsvG1g0PK4=
+github.com/apache/cassandra-gocql-driver/v2 v2.1.2 h1:lu/p0Db2av18enHJvWJQoChLssI0P+AR06STq4VdvCc=
+github.com/apache/cassandra-gocql-driver/v2 v2.1.2/go.mod h1:QH/asJjB3mHvY6Dot6ZKMMpTcOrWJ8i9GhsvG1g0PK4=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/apache/thrift v0.23.0 h1:wKR6YnefQSEnxpEfmgTPuJibNG4bF0p2TK34tHLWi3s=
 github.com/apache/thrift v0.23.0/go.mod h1:zPt6WxgvTOM6hF92y8C+MkEM5LMxZuk4JcQOiU4Esvs=

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,6 @@ github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 h1:B+8ClL/kCQkRiU82d9xajR
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3/go.mod h1:NbCUVmiS4foBGBHOYlCT25+YmGpJ32dZPi75pGEUpj4=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
-github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed h1:5upAirOpQc1Q53c0bnx2ufif5kANL7bfZWcc6VJWJd8=
-github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
 github.com/hashicorp/go-version v1.9.0 h1:CeOIz6k+LoN3qX9Z0tyQrPtiB1DFYRPfCIBtaXPSCnA=
 github.com/hashicorp/go-version v1.9.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSC
 github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794 h1:xlwdaKcTNVW4PtpQb8aKA4Pjy0CdJHEqvFbAnvR5m2g=
 github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794/go.mod h1:7e+I0LQFUI9AXWxOfsQROs9xPhoJtbsyWcjJqDd4KPY=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
+github.com/apache/cassandra-gocql-driver/v2 v2.1.0 h1:VEbbeJ2ift4deKMZ6Fs55Vs3fq/RrkjCcxCnqUxhwf8=
+github.com/apache/cassandra-gocql-driver/v2 v2.1.0/go.mod h1:QH/asJjB3mHvY6Dot6ZKMMpTcOrWJ8i9GhsvG1g0PK4=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/apache/thrift v0.23.0 h1:wKR6YnefQSEnxpEfmgTPuJibNG4bF0p2TK34tHLWi3s=
 github.com/apache/thrift v0.23.0/go.mod h1:zPt6WxgvTOM6hF92y8C+MkEM5LMxZuk4JcQOiU4Esvs=
@@ -97,12 +99,8 @@ github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz
 github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 h1:mXoPYz/Ul5HYEDvkta6I8/rnYM5gSdSV2tJ6XbZuEtY=
-github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
-github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
-github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b h1:AP/Y7sqYicnjGDfD5VcY4CIfh1hRXBUavxrvELjTiOE=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
 github.com/cactus/go-statsd-client/statsd v0.0.0-20191106001114-12b4e2b38748/go.mod h1:l/bIBLeOl9eX+wxJAzxS4TveKRtAqlyDpHjhkfO0MEI=
@@ -206,8 +204,6 @@ github.com/go-openapi/testify/v2 v2.4.2/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf4
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1aweo=
 github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
-github.com/gocql/gocql v1.7.0 h1:O+7U7/1gSN7QTEAaMEsJc1Oq2QHXvCWoF3DFK9HDHus=
-github.com/gocql/gocql v1.7.0/go.mod h1:vnlvXyFZeLBF0Wy+RS8hrOdbn0UWsWtdg07XJnFxZ+4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
@@ -218,7 +214,6 @@ github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
-github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v1.0.0 h1:Oy607GVXHs7RtbggtPBnr2RmDArIsAefDwvrdWvRhGs=
 github.com/golang/snappy v1.0.0/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/gnostic-models v0.7.1 h1:SisTfuFKJSKM5CPZkffwi6coztzzeYUhc3v4yxLWH8c=
@@ -337,6 +332,8 @@ github.com/olivere/elastic/v7 v7.0.32/go.mod h1:c7PVmLe3Fxq77PIfY/bZmxY/TAamBhCz
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
+github.com/pierrec/lz4/v4 v4.1.8 h1:ieHkV+i2BRzngO4Wd/3HGowuZStgq6QkPsD1eolNAO4=
+github.com/pierrec/lz4/v4 v4.1.8/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -367,6 +364,8 @@ github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzG
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
+github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/samuel/go-thrift v0.0.0-20190219015601-e8b6b52668fe/go.mod h1:Vrkh1pnjV9Bl8c3P9zH0/D4NlOHWP5d4/hF4YTULaec=

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSC
 github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794 h1:xlwdaKcTNVW4PtpQb8aKA4Pjy0CdJHEqvFbAnvR5m2g=
 github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794/go.mod h1:7e+I0LQFUI9AXWxOfsQROs9xPhoJtbsyWcjJqDd4KPY=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
-github.com/apache/cassandra-gocql-driver/v2 v2.1.0 h1:VEbbeJ2ift4deKMZ6Fs55Vs3fq/RrkjCcxCnqUxhwf8=
-github.com/apache/cassandra-gocql-driver/v2 v2.1.0/go.mod h1:QH/asJjB3mHvY6Dot6ZKMMpTcOrWJ8i9GhsvG1g0PK4=
+github.com/apache/cassandra-gocql-driver/v2 v2.1.2 h1:lu/p0Db2av18enHJvWJQoChLssI0P+AR06STq4VdvCc=
+github.com/apache/cassandra-gocql-driver/v2 v2.1.2/go.mod h1:QH/asJjB3mHvY6Dot6ZKMMpTcOrWJ8i9GhsvG1g0PK4=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/apache/thrift v0.24.0 h1:zy31L1a49QTNB2bG1BBfMXol3yJrTH975G3pPubQVLQ=
 github.com/apache/thrift v0.24.0/go.mod h1:zPt6WxgvTOM6hF92y8C+MkEM5LMxZuk4JcQOiU4Esvs=

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSC
 github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794 h1:xlwdaKcTNVW4PtpQb8aKA4Pjy0CdJHEqvFbAnvR5m2g=
 github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794/go.mod h1:7e+I0LQFUI9AXWxOfsQROs9xPhoJtbsyWcjJqDd4KPY=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
+github.com/apache/cassandra-gocql-driver/v2 v2.1.0 h1:VEbbeJ2ift4deKMZ6Fs55Vs3fq/RrkjCcxCnqUxhwf8=
+github.com/apache/cassandra-gocql-driver/v2 v2.1.0/go.mod h1:QH/asJjB3mHvY6Dot6ZKMMpTcOrWJ8i9GhsvG1g0PK4=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/apache/thrift v0.24.0 h1:zy31L1a49QTNB2bG1BBfMXol3yJrTH975G3pPubQVLQ=
 github.com/apache/thrift v0.24.0/go.mod h1:zPt6WxgvTOM6hF92y8C+MkEM5LMxZuk4JcQOiU4Esvs=
@@ -97,12 +99,8 @@ github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz
 github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 h1:mXoPYz/Ul5HYEDvkta6I8/rnYM5gSdSV2tJ6XbZuEtY=
-github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
-github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
-github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b h1:AP/Y7sqYicnjGDfD5VcY4CIfh1hRXBUavxrvELjTiOE=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
 github.com/cactus/go-statsd-client/statsd v0.0.0-20191106001114-12b4e2b38748/go.mod h1:l/bIBLeOl9eX+wxJAzxS4TveKRtAqlyDpHjhkfO0MEI=
@@ -206,8 +204,6 @@ github.com/go-openapi/testify/v2 v2.4.2/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf4
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1aweo=
 github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
-github.com/gocql/gocql v1.7.0 h1:O+7U7/1gSN7QTEAaMEsJc1Oq2QHXvCWoF3DFK9HDHus=
-github.com/gocql/gocql v1.7.0/go.mod h1:vnlvXyFZeLBF0Wy+RS8hrOdbn0UWsWtdg07XJnFxZ+4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
@@ -218,7 +214,6 @@ github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
-github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v1.0.0 h1:Oy607GVXHs7RtbggtPBnr2RmDArIsAefDwvrdWvRhGs=
 github.com/golang/snappy v1.0.0/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/gnostic-models v0.7.1 h1:SisTfuFKJSKM5CPZkffwi6coztzzeYUhc3v4yxLWH8c=
@@ -337,6 +332,8 @@ github.com/olivere/elastic/v7 v7.0.32/go.mod h1:c7PVmLe3Fxq77PIfY/bZmxY/TAamBhCz
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
+github.com/pierrec/lz4/v4 v4.1.8 h1:ieHkV+i2BRzngO4Wd/3HGowuZStgq6QkPsD1eolNAO4=
+github.com/pierrec/lz4/v4 v4.1.8/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -367,6 +364,8 @@ github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzG
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
+github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/samuel/go-thrift v0.0.0-20190219015601-e8b6b52668fe/go.mod h1:Vrkh1pnjV9Bl8c3P9zH0/D4NlOHWP5d4/hF4YTULaec=

--- a/tools/cassandra/cqlclient.go
+++ b/tools/cassandra/cqlclient.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 	"go.temporal.io/server/common/auth"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
@@ -172,7 +172,7 @@ func (client *cqlClient) CreateSchemaVersionTables() error {
 func (client *cqlClient) ReadSchemaVersion() (string, error) {
 	query := client.session.Query(readSchemaVersionCQL, client.keyspace)
 
-	iter := query.Iter()
+	iter := query.Iter(context.Background())
 	var version string
 	success := iter.Scan(&version)
 	err := iter.Close()
@@ -188,7 +188,7 @@ func (client *cqlClient) ReadSchemaVersion() (string, error) {
 // UpdateShemaVersion updates the schema version for the Keyspace
 func (client *cqlClient) UpdateSchemaVersion(newVersion string, minCompatibleVersion string) error {
 	query := client.session.Query(writeSchemaVersionCQL, client.keyspace, time.Now().UTC(), newVersion, minCompatibleVersion)
-	return query.Exec()
+	return query.Exec(context.Background())
 }
 
 // WriteSchemaUpdateLog adds an entry to the schema update history table
@@ -196,12 +196,12 @@ func (client *cqlClient) WriteSchemaUpdateLog(oldVersion string, newVersion stri
 	now := time.Now().UTC()
 	query := client.session.Query(writeSchemaUpdateHistoryCQL)
 	query.Bind(now.Year(), int(now.Month()), now, oldVersion, newVersion, manifestMD5, desc)
-	return query.Exec()
+	return query.Exec(context.Background())
 }
 
 // Exec executes a cql statement
 func (client *cqlClient) Exec(stmt string, args ...any) error {
-	if err := client.session.Query(stmt, args...).Exec(); err != nil {
+	if err := client.session.Query(stmt, args...).Exec(context.Background()); err != nil {
 		return err
 	}
 	return client.waitSchemaAgreement()
@@ -217,7 +217,7 @@ func (client *cqlClient) Close() {
 // ListTables lists the table names in a Keyspace
 func (client *cqlClient) ListTables() ([]string, error) {
 	query := client.session.Query(listTablesCQL, client.keyspace)
-	iter := query.Iter()
+	iter := query.Iter(context.Background())
 	var names []string
 	var name string
 	for iter.Scan(&name) {
@@ -232,7 +232,7 @@ func (client *cqlClient) ListTables() ([]string, error) {
 // listTypes lists the User defined types in a Keyspace
 func (client *cqlClient) listTypes() ([]string, error) {
 	qry := client.session.Query(listTypesCQL, client.keyspace)
-	iter := qry.Iter()
+	iter := qry.Iter(context.Background())
 	var names []string
 	var name string
 	for iter.Scan(&name) {


### PR DESCRIPTION
The Cassandra GoCQL driver library has been updated to v2, which comes with several API changes and improvements. This updates the Temporal service to use the new v2 API.

This change also cleans up deprecated calls to old APIs.

## What changed?

Changes Temporal Server to use v2 Cassandra GoCQL driver library.

## Why?

Cloud Temporal uses functionality that will hopefully soon be merged upstream. There is a dependency from Cloud Temporal on OSS Temporal, therefore we need to update callsites in OSS Temporal as well.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

There is some risk that the new API calls work differently than existing ones, or that other changes to the library introduced behavior changes that are either undocumented or not correctly accounted for in unit tests. However, looking over the [v1 to v2 migration document](https://github.com/apache/cassandra-gocql-driver/blob/trunk/UPGRADE_GUIDE.md) I do not foresee any hazards that are likely to affect us.

There is also some risk that the code changes in this PR incorrectly drop the Context object, thereby invoking operations with an incorrect context. However, I've guarded against this by changing the internal interfaces we use to require a Context wherever it might need to pass into the GoCQL library.