### PR TITLE
pause: return serviceerror.FailedPrecondition when pausing a Paused activity

### DIFF
--- a/api/persistence/v1/executions.pb.go
+++ b/api/persistence/v1/executions.pb.go
@@ -4415,6 +4415,7 @@ type ActivityInfo_PauseInfo struct {
 	//	*ActivityInfo_PauseInfo_Manual_
 	//	*ActivityInfo_PauseInfo_RuleId
 	PausedBy      isActivityInfo_PauseInfo_PausedBy `protobuf_oneof:"paused_by"`
+	RequestId     string                            `protobuf:"bytes,4,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4477,6 +4478,13 @@ func (x *ActivityInfo_PauseInfo) GetRuleId() string {
 		if x, ok := x.PausedBy.(*ActivityInfo_PauseInfo_RuleId); ok {
 			return x.RuleId
 		}
+	}
+	return ""
+}
+
+func (x *ActivityInfo_PauseInfo) GetRequestId() string {
+	if x != nil {
+		return x.RequestId
 	}
 	return ""
 }
@@ -5089,7 +5097,7 @@ const file_temporal_server_api_persistence_v1_executions_proto_rawDesc = "" +
 	"\x17NexusInvocationTaskInfo\x12\x18\n" +
 	"\aattempt\x18\x01 \x01(\x05R\aattempt\"4\n" +
 	"\x18NexusCancelationTaskInfo\x12\x18\n" +
-	"\aattempt\x18\x01 \x01(\x05R\aattempt\"\xa9\x1c\n" +
+	"\aattempt\x18\x01 \x01(\x05R\aattempt\"\xc8\x1c\n" +
 	"\fActivityInfo\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\x03R\aversion\x127\n" +
 	"\x18scheduled_event_batch_id\x18\x02 \x01(\x03R\x15scheduledEventBatchId\x12A\n" +
@@ -5147,12 +5155,14 @@ const file_temporal_server_api_persistence_v1_executions_proto_rawDesc = "" +
 	"\rstarted_clock\x184 \x01(\v2).temporal.server.api.clock.v1.VectorClockR\fstartedClock\x1ay\n" +
 	"\x16UseWorkflowBuildIdInfo\x12+\n" +
 	"\x12last_used_build_id\x18\x01 \x01(\tR\x0flastUsedBuildId\x122\n" +
-	"\x15last_redirect_counter\x18\x02 \x01(\x03R\x13lastRedirectCounter\x1a\x89\x02\n" +
+	"\x15last_redirect_counter\x18\x02 \x01(\x03R\x13lastRedirectCounter\x1a\xa8\x02\n" +
 	"\tPauseInfo\x129\n" +
 	"\n" +
 	"pause_time\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\tpauseTime\x12[\n" +
 	"\x06manual\x18\x02 \x01(\v2A.temporal.server.api.persistence.v1.ActivityInfo.PauseInfo.ManualH\x00R\x06manual\x12\x19\n" +
-	"\arule_id\x18\x03 \x01(\tH\x00R\x06ruleId\x1a<\n" +
+	"\arule_id\x18\x03 \x01(\tH\x00R\x06ruleId\x12\x1d\n" +
+	"\n" +
+	"request_id\x18\x04 \x01(\tR\trequestId\x1a<\n" +
 	"\x06Manual\x12\x1a\n" +
 	"\bidentity\x18\x01 \x01(\tR\bidentity\x12\x16\n" +
 	"\x06reason\x18\x02 \x01(\tR\x06reasonB\v\n" +

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -772,7 +772,9 @@ func (a *Activity) handlePauseRequested(ctx chasm.MutableContext, req *activityp
 		return nil, serviceerror.NewFailedPrecondition("cannot pause an activity with a pending cancellation")
 	}
 	if a.PauseState != nil {
-		if a.PauseState.GetRequestId() == req.GetFrontendRequest().GetRequestId() {
+		newReqID := req.GetFrontendRequest().GetRequestId()
+		existingReqID := a.PauseState.GetRequestId()
+		if newReqID != "" && existingReqID == newReqID {
 			return &activitypb.PauseActivityExecutionResponse{}, nil
 		}
 		return &activitypb.PauseActivityExecutionResponse{}, serviceerror.NewFailedPrecondition("activity is already paused")

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -772,6 +772,9 @@ func (a *Activity) handlePauseRequested(ctx chasm.MutableContext, req *activityp
 		return nil, serviceerror.NewFailedPrecondition("cannot pause an activity with a pending cancellation")
 	}
 	if a.PauseState != nil {
+		if a.PauseState.GetRequestId() == req.GetFrontendRequest().GetRequestId() {
+			return &activitypb.PauseActivityExecutionResponse{}, nil
+		}
 		return &activitypb.PauseActivityExecutionResponse{}, serviceerror.NewFailedPrecondition("activity is already paused")
 	}
 
@@ -877,6 +880,7 @@ func (a *Activity) pause(
 		PauseTime: timestamppb.New(ctx.Now(a)),
 		Identity:  event.req.GetIdentity(),
 		Reason:    event.req.GetReason(),
+		RequestId: event.req.GetRequestId(),
 	}
 	a.emitOnPausedMetrics(event.metricsHandler)
 }

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -772,7 +772,7 @@ func (a *Activity) handlePauseRequested(ctx chasm.MutableContext, req *activityp
 		return nil, serviceerror.NewFailedPrecondition("cannot pause an activity with a pending cancellation")
 	}
 	if a.PauseState != nil {
-		return &activitypb.PauseActivityExecutionResponse{}, nil
+		return &activitypb.PauseActivityExecutionResponse{}, serviceerror.NewFailedPrecondition("activity is already paused")
 	}
 
 	metricsHandler, err := a.enrichMetricsHandler(ctx, metrics.ActivityPausedScope)

--- a/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
@@ -463,6 +463,7 @@ type ActivityPauseState struct {
 	PauseTime     *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=pause_time,json=pauseTime,proto3" json:"pause_time,omitempty"`
 	Identity      string                 `protobuf:"bytes,2,opt,name=identity,proto3" json:"identity,omitempty"`
 	Reason        string                 `protobuf:"bytes,3,opt,name=reason,proto3" json:"reason,omitempty"`
+	RequestId     string                 `protobuf:"bytes,4,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -514,6 +515,13 @@ func (x *ActivityPauseState) GetIdentity() string {
 func (x *ActivityPauseState) GetReason() string {
 	if x != nil {
 		return x.Reason
+	}
+	return ""
+}
+
+func (x *ActivityPauseState) GetRequestId() string {
+	if x != nil {
+		return x.RequestId
 	}
 	return ""
 }
@@ -1025,12 +1033,14 @@ const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawD
 	"\x06reason\x18\x04 \x01(\tR\x06reason\"7\n" +
 	"\x16ActivityTerminateState\x12\x1d\n" +
 	"\n" +
-	"request_id\x18\x01 \x01(\tR\trequestId\"\x83\x01\n" +
+	"request_id\x18\x01 \x01(\tR\trequestId\"\xa2\x01\n" +
 	"\x12ActivityPauseState\x129\n" +
 	"\n" +
 	"pause_time\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\tpauseTime\x12\x1a\n" +
 	"\bidentity\x18\x02 \x01(\tR\bidentity\x12\x16\n" +
-	"\x06reason\x18\x03 \x01(\tR\x06reason\"\xe8\x05\n" +
+	"\x06reason\x18\x03 \x01(\tR\x06reason\x12\x1d\n" +
+	"\n" +
+	"request_id\x18\x04 \x01(\tR\trequestId\"\xe8\x05\n" +
 	"\x14ActivityAttemptState\x12\x14\n" +
 	"\x05count\x18\x01 \x01(\x05R\x05count\x12O\n" +
 	"\x16current_retry_interval\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\x14currentRetryInterval\x12=\n" +

--- a/chasm/lib/activity/handler.go
+++ b/chasm/lib/activity/handler.go
@@ -347,9 +347,10 @@ func (h *handler) PauseActivityExecution(ctx context.Context, req *activitypb.Pa
 					WorkflowId: frontendReq.GetWorkflowId(),
 					RunId:      frontendReq.GetRunId(),
 				},
-				Activity: &workflowservice.PauseActivityRequest_Id{Id: frontendReq.GetActivityId()},
-				Reason:   frontendReq.GetReason(),
-				Identity: frontendReq.GetIdentity(),
+				Activity:  &workflowservice.PauseActivityRequest_Id{Id: frontendReq.GetActivityId()},
+				Reason:    frontendReq.GetReason(),
+				Identity:  frontendReq.GetIdentity(),
+				RequestId: frontendReq.GetRequestId(),
 			},
 		})
 		if err != nil {

--- a/chasm/lib/activity/proto/v1/activity_state.proto
+++ b/chasm/lib/activity/proto/v1/activity_state.proto
@@ -130,6 +130,7 @@ message ActivityPauseState {
   google.protobuf.Timestamp pause_time = 1;
   string identity = 2;
   string reason = 3;
+  string request_id = 4;
 }
 
 message ActivityAttemptState {

--- a/proto/internal/temporal/server/api/persistence/v1/executions.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/executions.proto
@@ -664,6 +664,8 @@ message ActivityInfo {
       // Id of the rule that paused the activity.
       string rule_id = 3;
     }
+
+    string request_id = 4;
   }
 
   PauseInfo pause_info = 46;

--- a/service/history/api/pauseactivity/api.go
+++ b/service/history/api/pauseactivity/api.go
@@ -59,6 +59,7 @@ func Invoke(
 						Reason:   frontendRequest.GetReason(),
 					},
 				},
+				RequestId: request.GetFrontendRequest().GetRequestId(),
 			}
 
 			for _, activityId := range activityIDs {

--- a/service/history/workflow/activity.go
+++ b/service/history/workflow/activity.go
@@ -267,8 +267,7 @@ func PauseActivity(
 	}
 
 	if ai.Paused {
-		// do nothing
-		return nil
+		return serviceerror.NewFailedPrecondition("activity is already paused")
 	}
 
 	return mutableState.UpdateActivity(ai.ScheduledEventId, func(activityInfo *persistencespb.ActivityInfo, _ historyi.MutableState) error {

--- a/service/history/workflow/activity.go
+++ b/service/history/workflow/activity.go
@@ -267,6 +267,9 @@ func PauseActivity(
 	}
 
 	if ai.Paused {
+		if ai.GetPauseInfo().GetRequestId() == pauseInfo.GetRequestId() {
+			return nil
+		}
 		return serviceerror.NewFailedPrecondition("activity is already paused")
 	}
 

--- a/tests/activity_api_pause_test.go
+++ b/tests/activity_api_pause_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
@@ -597,6 +598,129 @@ func TestActivityApiPauseClientTestSuite(t *testing.T) {
 				activityCompleteCn <- struct{}{}
 
 				// wait for workflow to finish
+				var out string
+				err = workflowRun.Get(ctx, &out)
+
+				s.NoError(err)
+			})
+
+			t.Run("TestActivityPauseApi_WhilePaused", func(t *testing.T) {
+				s := testcore.NewEnv(t, testcore.WithSdkWorker())
+
+				initialRetryInterval := 1 * time.Second
+				scheduleToCloseTimeout := 30 * time.Minute
+				startToCloseTimeout := 15 * time.Minute
+				activityRetryPolicy := &temporal.RetryPolicy{
+					InitialInterval:    initialRetryInterval,
+					BackoffCoefficient: 1,
+				}
+				makeWorkflowFunc := func(activityFunction ActivityFunctions) WorkflowFunction {
+					return func(ctx workflow.Context) error {
+						var ret string
+						err := workflow.ExecuteActivity(workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+							ActivityID:             "activity-id",
+							DisableEagerExecution:  true,
+							StartToCloseTimeout:    startToCloseTimeout,
+							ScheduleToCloseTimeout: scheduleToCloseTimeout,
+							RetryPolicy:            activityRetryPolicy,
+						}), activityFunction).Get(ctx, &ret)
+						return err
+					}
+				}
+
+				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+
+				activityPausedCn := make(chan struct{})
+				var startedActivityCount atomic.Int32
+				activityErr := errors.New("bad-luck-please-retry")
+
+				activityFunction := func() (string, error) {
+					startedActivityCount.Add(1)
+					if startedActivityCount.Load() == 1 {
+						s.WaitForChannel(ctx, activityPausedCn)
+						return "", activityErr
+					}
+					return "done!", nil
+				}
+
+				workflowFn := makeWorkflowFunc(activityFunction)
+
+				s.SdkWorker().RegisterWorkflow(workflowFn)
+				s.SdkWorker().RegisterActivity(activityFunction)
+
+				workflowOptions := sdkclient.StartWorkflowOptions{
+					ID:        testcore.RandomizeStr("wf_id-" + s.T().Name()),
+					TaskQueue: s.WorkerTaskQueue(),
+				}
+
+				workflowRun, err := s.SdkClient().ExecuteWorkflow(ctx, workflowOptions, workflowFn)
+				s.NoError(err)
+
+				// wait for activity to start
+				s.EventuallyWithT(func(t *assert.CollectT) {
+					description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
+					require.NoError(t, err)
+					require.Len(t, description.PendingActivities, 1)
+					require.Equal(t, int32(1), startedActivityCount.Load())
+				}, 5*time.Second, 500*time.Millisecond)
+
+				// pause activity
+				testIdentity := "test-identity"
+				testReason := "test-reason"
+				s.NoError(api.pause(ctx, s, workflowRun.GetID(), "activity-id", testIdentity, testReason))
+
+				// make sure activity is paused on server while running on worker
+				s.EventuallyWithT(func(t *assert.CollectT) {
+					description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
+					require.NoError(t, err)
+					require.Len(t, description.PendingActivities, 1)
+					require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_PAUSE_REQUESTED, description.PendingActivities[0].State)
+					require.Equal(t, int32(1), startedActivityCount.Load())
+				}, 5*time.Second, 500*time.Millisecond)
+
+				// send a second pause call which will return a serviceerror.FailedPrecondition
+				err = api.pause(ctx, s, workflowRun.GetID(), "activity-id", testIdentity, testReason)
+				var failedPreconditionErr *serviceerror.FailedPrecondition
+				s.ErrorAs(err, &failedPreconditionErr)
+
+				// unblock the activity
+				activityPausedCn <- struct{}{}
+				// make sure activity is paused on server and completed on the worker
+				s.EventuallyWithT(func(t *assert.CollectT) {
+					description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
+					require.NoError(t, err)
+					require.Len(t, description.PendingActivities, 1)
+					require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_PAUSED, description.PendingActivities[0].State)
+					require.Equal(t, int32(1), startedActivityCount.Load())
+				}, 5*time.Second, 500*time.Millisecond)
+
+				description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
+				s.NoError(err)
+				s.Len(description.PendingActivities, 1)
+				s.True(description.PendingActivities[0].Paused)
+
+				// wait long enough for activity to retry if pause is not working
+				// Note: because activity is retried we expect the attempts to be incremented
+				err = util.InterruptibleSleep(ctx, 2*time.Second)
+				s.NoError(err)
+
+				// make sure activity is not completed, and was not retried
+				description, err = s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
+				s.NoError(err)
+				s.Len(description.PendingActivities, 1)
+				s.True(description.PendingActivities[0].Paused)
+				s.Equal(int32(2), description.PendingActivities[0].Attempt)
+				s.NotNil(description.PendingActivities[0].LastFailure)
+				s.Equal(activityErr.Error(), description.PendingActivities[0].LastFailure.Message)
+				s.NotNil(description.PendingActivities[0].PauseInfo)
+				s.NotNil(description.PendingActivities[0].PauseInfo.GetManual())
+				s.Equal(testIdentity, description.PendingActivities[0].PauseInfo.GetManual().Identity)
+				s.Equal(testReason, description.PendingActivities[0].PauseInfo.GetManual().Reason)
+
+				// unpause the activity
+				s.NoError(api.unpause(ctx, s, workflowRun.GetID(), "activity-id", "", false))
+
 				var out string
 				err = workflowRun.Get(ctx, &out)
 

--- a/tests/activity_api_pause_test.go
+++ b/tests/activity_api_pause_test.go
@@ -25,7 +25,7 @@ import (
 // PauseActivityExecution/UnpauseActivityExecution API.
 type activityPauseAPI struct {
 	name    string
-	pause   func(ctx context.Context, s *testcore.TestEnv, wfID, actID, identity, reason string) error
+	pause   func(ctx context.Context, s *testcore.TestEnv, wfID, actID, identity, reason, requestID string) error
 	unpause func(ctx context.Context, s *testcore.TestEnv, wfID, actID, identity string, resetAttempts bool) error
 }
 
@@ -33,13 +33,14 @@ func pauseAPIs() []activityPauseAPI {
 	return []activityPauseAPI{
 		{
 			name: "legacy-api",
-			pause: func(ctx context.Context, s *testcore.TestEnv, wfID, actID, identity, reason string) error {
+			pause: func(ctx context.Context, s *testcore.TestEnv, wfID, actID, identity, reason, requestID string) error {
 				_, err := s.FrontendClient().PauseActivity(ctx, &workflowservice.PauseActivityRequest{
 					Namespace: s.Namespace().String(),
 					Execution: &commonpb.WorkflowExecution{WorkflowId: wfID},
 					Activity:  &workflowservice.PauseActivityRequest_Id{Id: actID},
 					Identity:  identity,
 					Reason:    reason,
+					RequestId: requestID,
 				})
 				return err
 			},
@@ -56,13 +57,14 @@ func pauseAPIs() []activityPauseAPI {
 		},
 		{
 			name: "execution-api",
-			pause: func(ctx context.Context, s *testcore.TestEnv, wfID, actID, identity, reason string) error {
+			pause: func(ctx context.Context, s *testcore.TestEnv, wfID, actID, identity, reason, requestID string) error {
 				_, err := s.FrontendClient().PauseActivityExecution(ctx, &workflowservice.PauseActivityExecutionRequest{
 					Namespace:  s.Namespace().String(),
 					WorkflowId: wfID,
 					ActivityId: actID,
 					Identity:   identity,
 					Reason:     reason,
+					RequestId:  requestID,
 				})
 				return err
 			},
@@ -152,7 +154,8 @@ func TestActivityApiPauseClientTestSuite(t *testing.T) {
 				// pause activity
 				testIdentity := "test-identity"
 				testReason := "test-reason"
-				s.NoError(api.pause(ctx, s, workflowRun.GetID(), "activity-id", testIdentity, testReason))
+				requestID := "test-request-id"
+				s.NoError(api.pause(ctx, s, workflowRun.GetID(), "activity-id", testIdentity, testReason, requestID))
 
 				// make sure activity is paused on server while running on worker
 				s.EventuallyWithT(func(t *assert.CollectT) {
@@ -281,7 +284,8 @@ func TestActivityApiPauseClientTestSuite(t *testing.T) {
 				// pause activity
 				testIdentity := "test-identity"
 				testReason := "test-reason"
-				s.NoError(api.pause(ctx, s, workflowRun.GetID(), "activity-id", testIdentity, testReason))
+				testRequestID := "test-request-id"
+				s.NoError(api.pause(ctx, s, workflowRun.GetID(), "activity-id", testIdentity, testReason, testRequestID))
 
 				// make sure activity is paused on server while running on worker
 				s.EventuallyWithT(func(t *assert.CollectT) {
@@ -393,7 +397,8 @@ func TestActivityApiPauseClientTestSuite(t *testing.T) {
 				// pause activity
 				testIdentity := "test-identity"
 				testReason := "test-reason"
-				s.NoError(api.pause(ctx, s, workflowRun.GetID(), "activity-id", testIdentity, testReason))
+				testRequestID := "test-request-id"
+				s.NoError(api.pause(ctx, s, workflowRun.GetID(), "activity-id", testIdentity, testReason, testRequestID))
 
 				// wait long enough for activity to retry if pause is not working
 				require.NoError(t, util.InterruptibleSleep(ctx, 2*time.Second))
@@ -486,7 +491,8 @@ func TestActivityApiPauseClientTestSuite(t *testing.T) {
 				}, 5*time.Second, 100*time.Millisecond)
 
 				// pause activity
-				s.NoError(api.pause(ctx, s, workflowRun.GetID(), "activity-id", "", ""))
+				testRequestID := "test-request-id"
+				s.NoError(api.pause(ctx, s, workflowRun.GetID(), "activity-id", "", "", testRequestID))
 
 				// unpause the activity
 				s.NoError(api.unpause(ctx, s, workflowRun.GetID(), "activity-id", "", false))
@@ -567,7 +573,8 @@ func TestActivityApiPauseClientTestSuite(t *testing.T) {
 				}, 5*time.Second, 100*time.Millisecond)
 
 				// pause activity
-				s.NoError(api.pause(ctx, s, workflowRun.GetID(), "activity-id", "", ""))
+				testRequestID := "test-request-id"
+				s.NoError(api.pause(ctx, s, workflowRun.GetID(), "activity-id", "", "", testRequestID))
 
 				// wait for activity to be in paused state and waiting for retry
 				s.EventuallyWithT(func(t *assert.CollectT) {
@@ -668,7 +675,8 @@ func TestActivityApiPauseClientTestSuite(t *testing.T) {
 				// pause activity
 				testIdentity := "test-identity"
 				testReason := "test-reason"
-				s.NoError(api.pause(ctx, s, workflowRun.GetID(), "activity-id", testIdentity, testReason))
+				testRequestID := "test-request-id"
+				s.NoError(api.pause(ctx, s, workflowRun.GetID(), "activity-id", testIdentity, testReason, testRequestID))
 
 				// make sure activity is paused on server while running on worker
 				s.EventuallyWithT(func(t *assert.CollectT) {
@@ -679,8 +687,10 @@ func TestActivityApiPauseClientTestSuite(t *testing.T) {
 					require.Equal(t, int32(1), startedActivityCount.Load())
 				}, 5*time.Second, 500*time.Millisecond)
 
-				// send a second pause call which will return a serviceerror.FailedPrecondition
-				err = api.pause(ctx, s, workflowRun.GetID(), "activity-id", testIdentity, testReason)
+				// A second pause with a different request ID must return FailedPrecondition.
+				// The first pause was issued without a request ID (stored as ""), so any
+				// non-empty request ID here is guaranteed to differ.
+				err = api.pause(ctx, s, workflowRun.GetID(), "activity-id", testIdentity, testReason, testRequestID+"-2")
 				var failedPreconditionErr *serviceerror.FailedPrecondition
 				s.ErrorAs(err, &failedPreconditionErr)
 
@@ -725,6 +735,68 @@ func TestActivityApiPauseClientTestSuite(t *testing.T) {
 				err = workflowRun.Get(ctx, &out)
 
 				s.NoError(err)
+			})
+
+			t.Run("TestActivityPauseApi_SameRequestID_IsIdempotent", func(t *testing.T) {
+				// Pausing an already-paused activity with the same request ID must succeed (no-op).
+				s := testcore.NewEnv(t, testcore.WithSdkWorker())
+
+				scheduleToCloseTimeout := 30 * time.Minute
+				startToCloseTimeout := 15 * time.Minute
+				activityRetryPolicy := &temporal.RetryPolicy{
+					InitialInterval:    30 * time.Second,
+					BackoffCoefficient: 1,
+				}
+				makeWorkflowFunc := func(activityFunction ActivityFunctions) WorkflowFunction {
+					return func(ctx workflow.Context) error {
+						var ret string
+						err := workflow.ExecuteActivity(workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+							ActivityID:             "activity-id",
+							DisableEagerExecution:  true,
+							StartToCloseTimeout:    startToCloseTimeout,
+							ScheduleToCloseTimeout: scheduleToCloseTimeout,
+							RetryPolicy:            activityRetryPolicy,
+						}), activityFunction).Get(ctx, &ret)
+						return err
+					}
+				}
+
+				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+
+				activityFunction := ActivityFunctions(func() (string, error) {
+					return "", errors.New("fail-to-trigger-retry")
+				})
+				workflowFn := makeWorkflowFunc(activityFunction)
+				s.SdkWorker().RegisterWorkflow(workflowFn)
+				s.SdkWorker().RegisterActivity(activityFunction)
+
+				workflowRun, err := s.SdkClient().ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
+					ID:        testcore.RandomizeStr("wf_id-" + s.T().Name()),
+					TaskQueue: s.WorkerTaskQueue(),
+				}, workflowFn)
+				s.NoError(err)
+
+				// Wait for the first attempt to fail and the activity to enter retry backoff (attempt 2).
+				s.EventuallyWithT(func(t *assert.CollectT) {
+					description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
+					require.NoError(t, err)
+					require.Len(t, description.PendingActivities, 1)
+					require.Equal(t, int32(2), description.PendingActivities[0].Attempt)
+				}, 5*time.Second, 100*time.Millisecond)
+
+				// First pause with an explicit request ID.
+				s.NoError(api.pause(ctx, s, workflowRun.GetID(), "activity-id", "identity", "reason", "my-pause-request-id"))
+
+				s.EventuallyWithT(func(t *assert.CollectT) {
+					description, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
+					require.NoError(t, err)
+					require.Len(t, description.PendingActivities, 1)
+					require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_PAUSED, description.PendingActivities[0].State)
+				}, 5*time.Second, 100*time.Millisecond)
+
+				// Second pause with the same request ID — must succeed (idempotent no-op).
+				s.NoError(api.pause(ctx, s, workflowRun.GetID(), "activity-id", "identity", "reason", "my-pause-request-id"))
 			})
 		})
 	}

--- a/tests/activity_api_pause_test.go
+++ b/tests/activity_api_pause_test.go
@@ -91,7 +91,7 @@ func TestActivityApiPauseClientTestSuite(t *testing.T) {
 			t.Parallel()
 
 			t.Run("TestActivityPauseApi_WhileRunning", func(t *testing.T) {
-				s := testcore.NewEnv(t, testcore.WithSdkWorker())
+				s := testcore.NewEnv(t)
 
 				initialRetryInterval := 1 * time.Second
 				scheduleToCloseTimeout := 30 * time.Minute
@@ -217,7 +217,7 @@ func TestActivityApiPauseClientTestSuite(t *testing.T) {
 				 * 4. Validate activity failed
 				 * 5. Validate number of activity attempts increased
 				 */
-				s := testcore.NewEnv(t, testcore.WithSdkWorker())
+				s := testcore.NewEnv(t)
 
 				initialRetryInterval := 1 * time.Second
 				scheduleToCloseTimeout := 30 * time.Minute
@@ -336,7 +336,7 @@ func TestActivityApiPauseClientTestSuite(t *testing.T) {
 				// In this case, pause happens when activity is in retry state.
 				// Make sure that activity is paused and then unpaused.
 				// Also check that activity will not be retried while unpaused.
-				s := testcore.NewEnv(t, testcore.WithSdkWorker())
+				s := testcore.NewEnv(t)
 
 				initialRetryInterval := 1 * time.Second
 				scheduleToCloseTimeout := 30 * time.Minute
@@ -432,7 +432,7 @@ func TestActivityApiPauseClientTestSuite(t *testing.T) {
 				// In this case, pause can happen when activity is in retry state.
 				// Make sure that activity is paused and then unpaused.
 				// Also tests noWait flag.
-				s := testcore.NewEnv(t, testcore.WithSdkWorker())
+				s := testcore.NewEnv(t)
 
 				initialRetryInterval := 30 * time.Second
 				scheduleToCloseTimeout := 30 * time.Minute
@@ -510,7 +510,7 @@ func TestActivityApiPauseClientTestSuite(t *testing.T) {
 
 			t.Run("TestActivityPauseApi_WithReset", func(t *testing.T) {
 				// pause/unpause the activity with reset option and noWait flag
-				s := testcore.NewEnv(t, testcore.WithSdkWorker())
+				s := testcore.NewEnv(t)
 
 				initialRetryInterval := 1 * time.Second
 				scheduleToCloseTimeout := 30 * time.Minute
@@ -612,7 +612,7 @@ func TestActivityApiPauseClientTestSuite(t *testing.T) {
 			})
 
 			t.Run("TestActivityPauseApi_WhilePaused", func(t *testing.T) {
-				s := testcore.NewEnv(t, testcore.WithSdkWorker())
+				s := testcore.NewEnv(t)
 
 				initialRetryInterval := 1 * time.Second
 				scheduleToCloseTimeout := 30 * time.Minute
@@ -739,7 +739,7 @@ func TestActivityApiPauseClientTestSuite(t *testing.T) {
 
 			t.Run("TestActivityPauseApi_SameRequestID_IsIdempotent", func(t *testing.T) {
 				// Pausing an already-paused activity with the same request ID must succeed (no-op).
-				s := testcore.NewEnv(t, testcore.WithSdkWorker())
+				s := testcore.NewEnv(t)
 
 				scheduleToCloseTimeout := 30 * time.Minute
 				startToCloseTimeout := 15 * time.Minute

--- a/tests/standalone_activity_test.go
+++ b/tests/standalone_activity_test.go
@@ -5667,7 +5667,7 @@ func (s *standaloneActivityTestSuite) TestPauseActivityExecution() {
 		}
 	})
 
-	t.Run("PauseIdempotent", func(t *testing.T) {
+	t.Run("PauseWhilePaused", func(t *testing.T) {
 		ctx := testcore.NewContext()
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
@@ -5685,9 +5685,10 @@ func (s *standaloneActivityTestSuite) TestPauseActivityExecution() {
 		_, err := s.FrontendClient().PauseActivityExecution(ctx, pauseReq)
 		require.NoError(t, err)
 
-		// Second pause should succeed with no error (idempotent).
+		// Second pause should fail with FailedPrecondition (activity is already paused).
 		_, err = s.FrontendClient().PauseActivityExecution(ctx, pauseReq)
-		require.NoError(t, err)
+		var failedPreconditionErr *serviceerror.FailedPrecondition
+		require.ErrorAs(t, err, &failedPreconditionErr)
 	})
 
 	t.Run("PauseNotFound", func(t *testing.T) {

--- a/tests/standalone_activity_test.go
+++ b/tests/standalone_activity_test.go
@@ -5691,6 +5691,30 @@ func (s *standaloneActivityTestSuite) TestPauseActivityExecution() {
 		require.ErrorAs(t, err, &failedPreconditionErr)
 	})
 
+	t.Run("PauseWhilePausedIdempotent", func(t *testing.T) {
+		ctx := testcore.NewContext()
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		runID := startResp.RunId
+
+		pauseReq := &workflowservice.PauseActivityExecutionRequest{
+			Namespace:  s.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+			Identity:   "test-identity",
+			Reason:     "test-pause",
+			RequestId:  "some-request-id",
+		}
+		_, err := s.FrontendClient().PauseActivityExecution(ctx, pauseReq)
+		require.NoError(t, err)
+
+		// Second pause with the same request ID should succeed (idempotent no-op).
+		_, err = s.FrontendClient().PauseActivityExecution(ctx, pauseReq)
+		require.NoError(t, err)
+	})
+
 	t.Run("PauseNotFound", func(t *testing.T) {
 		ctx := testcore.NewContext()
 


### PR DESCRIPTION
## What changed?
When calling `PauseActivityExecution` on an already paused activity a `serviceerror.FailedPrecondition` is returned to the user.

## Why?
If a user attempts to pause an already paused activity with an identity and reason and then inspects that activity it will show a different identity and reason which is a confusing behavior, returning an error is a better way to show that the request did not alter the activity.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [X] added new functional test(s)

## Potential risks
No, this is into a feature branch. After merging the feature branch into main the behavior will change for workflow activities which treat Pause on an already paused activity as a no-op.
