### PR TITLE
Update postgresql.md version and username

### DIFF
--- a/docs/development/macos/postgresql.md
+++ b/docs/development/macos/postgresql.md
@@ -1,27 +1,27 @@
-# Run PostgreSQL v9.6 on macOS
+# Run PostgreSQL v18 on macOS
 
 ### Install
 ```bash
-brew install postgresql@9.6
+brew install postgresql@18
 ```
 
 ### Start
 ```bash
-brew services start postgresql@9.6
+brew services start postgresql@18
 ```
 
 ### Stop
 ```bash
-brew services stop postgresql@9.6
+brew services stop postgresql@18
 ```
 
 ### Post Installation
-Create a user `postgres`
+Create a user `root`
 ```bash
 createuser -s root
 ```
 
-Verify PostgreSQL v9.6 is running and accessible:
+Verify PostgreSQL v18 is running and accessible:
 ```bash
 psql -h 127.0.0.1 -p 5432 -U root -d postgres
 ```
@@ -36,7 +36,7 @@ ALTER USER temporal WITH SUPERUSER;
 
 Change the following file context:
 ```bash
-emacs /usr/local/var/postgresql@9.6/pg_hba.conf
+pico /opt/homebrew/var/postgresql@18/pg_hba.conf
 ```
 from
 ```
@@ -52,7 +52,7 @@ host    all             all             ::1/128                 md5
 ```
 then restart PostgreSQL:
 ```bash
-brew services restart postgresql@9.6
+brew services restart postgresql@18
 ```
 
 Verify password:
@@ -65,7 +65,7 @@ psql -h 127.0.0.1 -p 5432 -U temporal -d postgres
 [TLS Key / Cert Setup Guide](../tls/tls.md)
 
 ```bash
-emacs /usr/local/var/postgresql@9.6/postgresql.conf
+emacs /usr/local/var/postgresql@18/postgresql.conf
 ```
 
 setting the variables below to
@@ -77,7 +77,7 @@ ssl_ca_file=<path to the ca.pem>
 ```
 
 ```bash
-emacs /usr/local/var/postgresql@9.6/pg_hba.conf
+emacs /usr/local/var/postgresql@18/pg_hba.conf
 ```
 
 changes the configs like below
@@ -87,7 +87,7 @@ hostssl    all             all             ::1/128                 md5 clientcer
 ```
 then restart PostgreSQL:
 ```bash
-brew services restart postgresql@9.6
+brew services restart postgresql@18
 ```
 
 Verify TLS & password:


### PR DESCRIPTION
PostgreSQL 9.6 is no longer available through Homebrew. 18 is the latest and seems to work fine with Temporal. Updates instructions to specify current supported version.

Also, the text currently instructs you to create user `postgres` but the commandline actually creates user `root`, which is correct. Updates the text to match the command.

## What changed?

Documentation used for testing Temporal.

## Why?

Existing documentation is inaccurate and specifies a version of PostgreSQL that's no longer available through Homebrew nor supported.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

It's conceivable that PostgreSQL v18 suffers from some subtle incompatibility with Temporal that is not obvious from existing integration tests, though this is extremely unlikely.

Furthermore, this will not automatically keep documentation in sync with production Temporal deployments, nor will it keep us up to date in the future once v18 is no longer available. Documentation will need to be updated again in the future.
