### PR TITLE
fix: Hopefully fixes some test flakiness in some matching test

### DIFF
--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -42,6 +42,7 @@ type TaskMatcher struct {
 	backlogTasksCreateTime map[int64]int   // task creation time (unix nanos) -> number of tasks with that time
 	backlogTasksLock       sync.Mutex
 	lastPoller             atomic.Int64 // unix nanos of most recent poll start time
+	waitingPollerCount     atomic.Int64
 }
 
 var (
@@ -469,6 +470,11 @@ func (tm *TaskMatcher) poll(
 	default:
 	}
 
+	// From here on the goroutine will block on taskC (in step 3 or 4), so it
+	// is ready to receive a sync-matched task.
+	tm.waitingPollerCount.Add(1)
+	defer tm.waitingPollerCount.Add(-1)
+
 	if tm.isBacklogNegligible() {
 		// 3. forwarding (and all other clauses repeated)
 		// We don't forward pollers if there is a non-negligible backlog in this partition.
@@ -617,6 +623,12 @@ func (tm *TaskMatcher) emitForwardedSourceStats(
 
 func (tm *TaskMatcher) timeSinceLastPoll() time.Duration {
 	return time.Since(time.Unix(0, tm.lastPoller.Load()))
+}
+
+// HasWaitingPoller returns true if it there's a poller ready and waiting
+// this is mostly useful in testing to avoid test races on setup
+func (tm *TaskMatcher) HasWaitingPoller() bool {
+	return tm.waitingPollerCount.Load() > 0
 }
 
 // contextWithCancelOnChannelClose returns a child Context and CancelFunc just like

--- a/service/matching/matcher_data.go
+++ b/service/matching/matcher_data.go
@@ -571,6 +571,20 @@ func (d *matcherData) TimeSinceLastPoll() time.Duration {
 	return time.Since(d.lastPoller)
 }
 
+// HasWaitingPoller returns if there's a normal (non forwarder)
+// poller waiting for a task. This is intended mostly for use in
+// testing to ensure test setup.
+func (d *matcherData) HasWaitingPoller() bool {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	for _, p := range d.pollers.heap {
+		if p.taskForwarderType == notTaskForwarder {
+			return true
+		}
+	}
+	return false
+}
+
 // waitable match result:
 
 type waitableMatchResult struct {

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -105,6 +105,7 @@ type (
 		OfferQuery(ctx context.Context, task *internalTask) (*matchingservice.QueryWorkflowResponse, error)
 		OfferNexusTask(ctx context.Context, task *internalTask) (*matchingservice.DispatchNexusTaskResponse, error)
 		ReprocessAllTasks()
+		HasWaitingPoller() bool
 	}
 )
 

--- a/service/matching/pri_matcher.go
+++ b/service/matching/pri_matcher.go
@@ -655,6 +655,10 @@ func (tm *priTaskMatcher) poll(
 	return task, nil
 }
 
+func (tm *priTaskMatcher) HasWaitingPoller() bool {
+	return tm.data.HasWaitingPoller()
+}
+
 func (tm *priTaskMatcher) isForwardingAllowed() bool {
 	return tm.fwdr != nil
 }

--- a/service/matching/task_queue_partition_manager_test.go
+++ b/service/matching/task_queue_partition_manager_test.go
@@ -1565,11 +1565,9 @@ func (s *PartitionManagerTestSuite) TestTaskAddHooks_AddHookSyncMatch() {
 		err  error
 	}
 	pollDone := make(chan pollResult, 1)
-	pollStarted := make(chan struct{})
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
-		close(pollStarted)
 		task, _, err := pm.PollTask(ctx, &pollMetadata{
 			workerVersionCapabilities: &commonpb.WorkerVersionCapabilities{
 				BuildId:       "",
@@ -1581,14 +1579,8 @@ func (s *PartitionManagerTestSuite) TestTaskAddHooks_AddHookSyncMatch() {
 			close(task.responseC)
 		}
 	}()
-	s.Require().Eventually(func() bool {
-		select {
-		case <-pollStarted:
-			return true
-		default:
-			return false
-		}
-	}, 2*time.Second, 1*time.Millisecond)
+	pq := pm.defaultQueue().(*physicalTaskQueueManagerImpl)
+	s.Require().Eventually(pq.matcher.HasWaitingPoller, 2*time.Second, time.Millisecond)
 
 	_, syncMatched, err := pm.AddTask(context.Background(), addTaskParams{
 		taskInfo: &persistencespb.TaskInfo{


### PR DESCRIPTION
## What changed?

A couple of unit tests were flaking nondeterministically in matching due to a race in the test setup. I think new folks using the fancy new m5 laptops are noticing it more. The tests are flicking for myself and at least one other person on the syncmatch assertion as sometimes the pollers aren't setup and it goes to async-match.

This change:
1. Adds a function on the matcher implementations to determine if a poller is registered
2. Adjusts a couple of tests to use this to setup, to avoid a race between add-tasks and poller setup.

## Why?

Killing off some flakiness makes everyone's day better. 

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [ ] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Not aware of any risks, this is unit-test functionality only, with the exception of adding a poller counter atomic. 