### PR TITLE
Nexus Standalone: TerminatedFailureInfo identity

### DIFF
--- a/chasm/lib/nexusoperation/gen/nexusoperationpb/v1/operation.pb.go
+++ b/chasm/lib/nexusoperation/gen/nexusoperationpb/v1/operation.pb.go
@@ -440,7 +440,6 @@ func (x *OperationState) GetLinks() []*v11.Link {
 type NexusOperationTerminateState struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	RequestId     string                 `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
-	Identity      string                 `protobuf:"bytes,2,opt,name=identity,proto3" json:"identity,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -478,13 +477,6 @@ func (*NexusOperationTerminateState) Descriptor() ([]byte, []int) {
 func (x *NexusOperationTerminateState) GetRequestId() string {
 	if x != nil {
 		return x.RequestId
-	}
-	return ""
-}
-
-func (x *NexusOperationTerminateState) GetIdentity() string {
-	if x != nil {
-		return x.Identity
 	}
 	return ""
 }
@@ -882,11 +874,10 @@ const file_temporal_server_chasm_lib_nexusoperation_proto_v1_operation_proto_raw
 	"\x1anext_attempt_schedule_time\x18\x11 \x01(\v2\x1a.google.protobuf.TimestampR\x17nextAttemptScheduleTime\x12'\n" +
 	"\x0foperation_token\x18\x12 \x01(\tR\x0eoperationToken\x12x\n" +
 	"\x0fterminate_state\x18\x13 \x01(\v2O.temporal.server.chasm.lib.nexusoperation.proto.v1.NexusOperationTerminateStateR\x0eterminateState\x122\n" +
-	"\x05links\x18\x14 \x03(\v2\x1c.temporal.api.common.v1.LinkR\x05links\"Y\n" +
+	"\x05links\x18\x14 \x03(\v2\x1c.temporal.api.common.v1.LinkR\x05links\"=\n" +
 	"\x1cNexusOperationTerminateState\x12\x1d\n" +
 	"\n" +
-	"request_id\x18\x01 \x01(\tR\trequestId\x12\x1a\n" +
-	"\bidentity\x18\x02 \x01(\tR\bidentity\"\x82\x03\n" +
+	"request_id\x18\x01 \x01(\tR\trequestId\"\x82\x03\n" +
 	"\x10OperationOutcome\x12p\n" +
 	"\n" +
 	"successful\x18\x01 \x01(\v2N.temporal.server.chasm.lib.nexusoperation.proto.v1.OperationOutcome.SuccessfulH\x00R\n" +

--- a/chasm/lib/nexusoperation/operation_statemachine.go
+++ b/chasm/lib/nexusoperation/operation_statemachine.go
@@ -254,7 +254,6 @@ var TransitionTerminated = chasm.NewTransition(
 	func(o *Operation, ctx chasm.MutableContext, event EventTerminated) error {
 		o.TerminateState = &nexusoperationpb.NexusOperationTerminateState{
 			RequestId: event.RequestID,
-			Identity:  event.Identity,
 		}
 		o.ClosedTime = timestamppb.New(ctx.Now(o))
 		o.NextAttemptScheduleTime = nil
@@ -264,7 +263,9 @@ var TransitionTerminated = chasm.NewTransition(
 				Failure: &failurepb.Failure{
 					Message: event.Reason,
 					FailureInfo: &failurepb.Failure_TerminatedFailureInfo{
-						TerminatedFailureInfo: &failurepb.TerminatedFailureInfo{},
+						TerminatedFailureInfo: &failurepb.TerminatedFailureInfo{
+							Identity: event.Identity,
+						},
 					},
 				},
 			},

--- a/chasm/lib/nexusoperation/operation_statemachine_test.go
+++ b/chasm/lib/nexusoperation/operation_statemachine_test.go
@@ -568,7 +568,6 @@ func TestTransitionTerminated(t *testing.T) {
 			require.Equal(t, defaultTime, operation.ClosedTime.AsTime())
 			protorequire.ProtoEqual(t, &nexusoperationpb.NexusOperationTerminateState{
 				RequestId: "terminate-request-id",
-				Identity:  "test-identity",
 			}, operation.TerminateState)
 
 			// Verify outcome failure is set with terminated info and reason as message.
@@ -578,7 +577,9 @@ func TestTransitionTerminated(t *testing.T) {
 						Failure: &failurepb.Failure{
 							Message: "test reason",
 							FailureInfo: &failurepb.Failure_TerminatedFailureInfo{
-								TerminatedFailureInfo: &failurepb.TerminatedFailureInfo{},
+								TerminatedFailureInfo: &failurepb.TerminatedFailureInfo{
+									Identity: "test-identity",
+								},
 							},
 						},
 					},

--- a/chasm/lib/nexusoperation/proto/v1/operation.proto
+++ b/chasm/lib/nexusoperation/proto/v1/operation.proto
@@ -62,7 +62,6 @@ message OperationState {
 
 message NexusOperationTerminateState {
   string request_id = 1;
-  string identity = 2;
 }
 
 message OperationOutcome {

--- a/tests/nexus_standalone_test.go
+++ b/tests/nexus_standalone_test.go
@@ -689,6 +689,7 @@ func TestStandaloneNexusOperationCancel(t *testing.T) {
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
 			RequestId:   "terminate-request-id",
+			Identity:    "test-identity",
 			Reason:      "test termination",
 		})
 		s.NoError(err)
@@ -750,6 +751,7 @@ func TestTerminateStandaloneNexusOperation(t *testing.T) {
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
 			RequestId:   "terminate-request-id",
+			Identity:    "test-identity",
 			Reason:      "test termination",
 		})
 		s.NoError(err)
@@ -767,6 +769,7 @@ func TestTerminateStandaloneNexusOperation(t *testing.T) {
 		s.NotNil(failure)
 		s.Equal("test termination", failure.GetMessage())
 		s.NotNil(failure.GetTerminatedFailureInfo())
+		s.Equal("test-identity", failure.GetTerminatedFailureInfo().GetIdentity())
 	})
 
 	t.Run("AlreadyTerminated", func(t *testing.T) {


### PR DESCRIPTION
## What changed?

Add identity to `TerminatedFailureInfo`.

PS: `CanceledFailureInfo` will be a separate PR.

## Why?

Allow clients to access identity via API.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)
