### PR TITLE
MigrateWorkflowIdReusePolicyForRunningWorkflow

### DIFF
--- a/service/history/api/signalwithstartworkflow/api.go
+++ b/service/history/api/signalwithstartworkflow/api.go
@@ -59,6 +59,10 @@ func Invoke(
 	)
 	request := startRequest.StartRequest
 
+	api.MigrateWorkflowIdReusePolicyForRunningWorkflow(
+		&signalWithStartRequest.SignalWithStartRequest.WorkflowIdReusePolicy,
+		&signalWithStartRequest.SignalWithStartRequest.WorkflowIdConflictPolicy)
+
 	api.OverrideStartWorkflowExecutionRequest(request, metrics.HistorySignalWithStartWorkflowExecutionScope, shard, shard.GetMetricsHandler())
 
 	err = api.ValidateStartWorkflowExecutionRequest(ctx, request, shard, namespaceEntry, "SignalWithStartWorkflowExecution")

--- a/service/history/api/signalwithstartworkflow/api.go
+++ b/service/history/api/signalwithstartworkflow/api.go
@@ -59,7 +59,7 @@ func Invoke(
 	)
 	request := startRequest.StartRequest
 
-	api.MigrateWorkflowIdReusePolicyForRunningWorkflow(
+	api.MigrateWorkflowIDReusePolicyForRunningWorkflow(
 		&signalWithStartRequest.SignalWithStartRequest.WorkflowIdReusePolicy,
 		&signalWithStartRequest.SignalWithStartRequest.WorkflowIdConflictPolicy)
 

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -119,7 +119,7 @@ func NewStarter(
 func (s *Starter) prepare(ctx context.Context) error {
 	request := s.request.StartRequest
 
-	api.MigrateWorkflowIdReusePolicyForRunningWorkflow(
+	api.MigrateWorkflowIDReusePolicyForRunningWorkflow(
 		&request.WorkflowIdReusePolicy,
 		&request.WorkflowIdConflictPolicy)
 

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -119,6 +119,10 @@ func NewStarter(
 func (s *Starter) prepare(ctx context.Context) error {
 	request := s.request.StartRequest
 
+	api.MigrateWorkflowIdReusePolicyForRunningWorkflow(
+		&request.WorkflowIdReusePolicy,
+		&request.WorkflowIdConflictPolicy)
+
 	api.OverrideStartWorkflowExecutionRequest(
 		request,
 		metrics.HistoryStartWorkflowExecutionScope,

--- a/service/history/api/workflow_id_dedup.go
+++ b/service/history/api/workflow_id_dedup.go
@@ -248,7 +248,7 @@ func generateWorkflowAlreadyStartedError(
 	)
 }
 
-func MigrateWorkflowIdReusePolicyForRunningWorkflow(
+func MigrateWorkflowIDReusePolicyForRunningWorkflow(
 	wfIDReusePolicy *enumspb.WorkflowIdReusePolicy,
 	wfIDConflictPolicy *enumspb.WorkflowIdConflictPolicy,
 ) {

--- a/service/history/api/workflow_id_dedup.go
+++ b/service/history/api/workflow_id_dedup.go
@@ -247,3 +247,18 @@ func generateWorkflowAlreadyStartedError(
 		workflowKey.RunID,
 	)
 }
+
+func MigrateWorkflowIdReusePolicyForRunningWorkflow(
+	wfIDReusePolicy *enumspb.WorkflowIdReusePolicy,
+	wfIDConflictPolicy *enumspb.WorkflowIdConflictPolicy,
+) {
+	// workflow id reuse policy's Terminate-if-Running has been replaced by
+	// workflow id conflict policy's Terminate-Existing
+	//nolint:staticcheck // SA1019: intentional migration of deprecated policy
+	if *wfIDReusePolicy == enumspb.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING {
+		*wfIDConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING
+
+		// for *closed* workflows, its behavior is defined as ALLOW_DUPLICATE
+		*wfIDReusePolicy = enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE
+	}
+}

--- a/service/history/api/workflow_id_dedup_test.go
+++ b/service/history/api/workflow_id_dedup_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
@@ -79,12 +80,13 @@ func TestResolveDuplicateWorkflowStart(t *testing.T) {
 	}
 }
 
-func TestMigrateWorkflowIdReusePolicyForRunningWorkflow(t *testing.T) {
+func TestMigrateWorkflowIDReusePolicyForRunningWorkflow(t *testing.T) {
+	//nolint:staticcheck // SA1019: intentional migration coverage for deprecated policy
 	reusePolicy := enumspb.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING
 	conflictPolicy := enumspb.WORKFLOW_ID_CONFLICT_POLICY_UNSPECIFIED
 
-	MigrateWorkflowIdReusePolicyForRunningWorkflow(&reusePolicy, &conflictPolicy)
+	MigrateWorkflowIDReusePolicyForRunningWorkflow(&reusePolicy, &conflictPolicy)
 
-	assert.Equal(t, enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE, reusePolicy)
-	assert.Equal(t, enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING, conflictPolicy)
+	require.Equal(t, enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE, reusePolicy)
+	require.Equal(t, enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING, conflictPolicy)
 }

--- a/service/history/api/workflow_id_dedup_test.go
+++ b/service/history/api/workflow_id_dedup_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/clock"
@@ -76,4 +77,14 @@ func TestResolveDuplicateWorkflowStart(t *testing.T) {
 			assert.NoError(t, err)
 		}
 	}
+}
+
+func TestMigrateWorkflowIdReusePolicyForRunningWorkflow(t *testing.T) {
+	reusePolicy := enumspb.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING
+	conflictPolicy := enumspb.WORKFLOW_ID_CONFLICT_POLICY_UNSPECIFIED
+
+	MigrateWorkflowIdReusePolicyForRunningWorkflow(&reusePolicy, &conflictPolicy)
+
+	assert.Equal(t, enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE, reusePolicy)
+	assert.Equal(t, enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING, conflictPolicy)
 }

--- a/service/history/history_engine2_test.go
+++ b/service/history/history_engine2_test.go
@@ -1715,6 +1715,7 @@ func (s *engine2Suite) TestStartWorkflowExecution_Terminate_Existing() {
 func (s *engine2Suite) TestStartWorkflowExecution_Terminate_Running() {
 	s.setupStartWorkflowExecutionForTerminate()
 
+	//nolint:staticcheck // SA1019: intentional coverage for deprecated policy migration
 	startRequest := makeMockStartRequest(s.tv, enumspb.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING, enumspb.WORKFLOW_ID_CONFLICT_POLICY_UNSPECIFIED)
 
 	resp, err := s.historyEngine.StartWorkflowExecution(metrics.AddMetricsContext(context.Background()), startRequest)
@@ -1829,6 +1830,7 @@ func (s *engine2Suite) TestStartWorkflowExecution_Dedup() {
 
 				resp, err := s.historyEngine.StartWorkflowExecution(
 					metrics.AddMetricsContext(context.Background()),
+					//nolint:staticcheck // SA1019: intentional coverage for deprecated policy migration
 					makeStartRequest(enumspb.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING, enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL))
 
 				s.NoError(err)

--- a/service/history/history_engine2_test.go
+++ b/service/history/history_engine2_test.go
@@ -1712,6 +1712,18 @@ func (s *engine2Suite) TestStartWorkflowExecution_Terminate_Existing() {
 	s.NotEqual(s.tv.RunID(), resp.GetRunId())
 }
 
+func (s *engine2Suite) TestStartWorkflowExecution_Terminate_Running() {
+	s.setupStartWorkflowExecutionForTerminate()
+
+	startRequest := makeMockStartRequest(s.tv, enumspb.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING, enumspb.WORKFLOW_ID_CONFLICT_POLICY_UNSPECIFIED)
+
+	resp, err := s.historyEngine.StartWorkflowExecution(metrics.AddMetricsContext(context.Background()), startRequest)
+
+	s.NoError(err)
+	s.True(resp.Started)
+	s.NotEqual(s.tv.RunID(), resp.GetRunId())
+}
+
 func (s *engine2Suite) TestStartWorkflowExecution_Dedup() {
 	namespaceID := tests.NamespaceID
 	workflowID := "workflowID"
@@ -1803,6 +1815,21 @@ func (s *engine2Suite) TestStartWorkflowExecution_Dedup() {
 				resp, err := s.historyEngine.StartWorkflowExecution(
 					metrics.AddMetricsContext(context.Background()),
 					makeStartRequest(enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE, enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL))
+
+				s.NoError(err)
+				s.True(resp.Started)
+				s.NotEqual(prevRunID, resp.GetRunId())
+			})
+
+			s.Run("and id reuse policy is TERMINATE_IF_RUNNING", func() {
+				s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), brandNewExecutionRequest).
+					Return(nil, makeCurrentWorkflowConditionFailedError(prevRequestID))
+				s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), updateExecutionRequest).
+					Return(tests.CreateWorkflowExecutionResponse, nil)
+
+				resp, err := s.historyEngine.StartWorkflowExecution(
+					metrics.AddMetricsContext(context.Background()),
+					makeStartRequest(enumspb.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING, enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL))
 
 				s.NoError(err)
 				s.True(resp.Started)

--- a/tests/child_workflow_test.go
+++ b/tests/child_workflow_test.go
@@ -1039,6 +1039,124 @@ func (s *ChildWorkflowSuite) TestChildWorkflowExecution_AlreadyRunning_RecordsFa
 	s.Equal(tvChild.WorkflowType().GetName(), failedAttrs.GetWorkflowType().GetName())
 }
 
+func (s *ChildWorkflowSuite) TestChildWorkflowExecution_AlreadyRunning_TerminateIfRunningStartsNewChild() {
+	tvParent := testvars.New(testName(s.T().Name() + "/parent"))
+	tvChild := testvars.New(testName(s.T().Name() + "/child"))
+
+	// Pre-create the child workflow ID so the parent's StartChild transfer task has to resolve
+	// a duplicate child ID through the history StartWorkflowExecution path.
+	existingChildResp, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           tvChild.RequestID(),
+		Namespace:           s.Namespace().String(),
+		WorkflowId:          tvChild.WorkflowID(),
+		WorkflowType:        tvChild.WorkflowType(),
+		TaskQueue:           tvChild.TaskQueue(),
+		WorkflowRunTimeout:  durationpb.New(100 * time.Second),
+		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+		Identity:            tvParent.WorkerIdentity(),
+	})
+	s.NoError(err)
+
+	_, err = s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           tvParent.RequestID(),
+		Namespace:           s.Namespace().String(),
+		WorkflowId:          tvParent.WorkflowID(),
+		WorkflowType:        tvParent.WorkflowType(),
+		TaskQueue:           tvParent.TaskQueue(),
+		WorkflowRunTimeout:  durationpb.New(100 * time.Second),
+		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+		Identity:            tvParent.WorkerIdentity(),
+	})
+	s.NoError(err)
+
+	startedChild := false
+	var startedAttrs *historypb.ChildWorkflowExecutionStartedEventAttributes
+	var failedAttrs *historypb.StartChildWorkflowExecutionFailedEventAttributes
+	wtHandlerParent := func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
+		if !startedChild {
+			startedChild = true
+			// This deprecated policy is the compatibility case under test. Without the history-side
+			// migration, child start handling will not preserve the old terminate-and-restart behavior.
+			return []*commandpb.Command{{
+				CommandType: enumspb.COMMAND_TYPE_START_CHILD_WORKFLOW_EXECUTION,
+				Attributes: &commandpb.Command_StartChildWorkflowExecutionCommandAttributes{
+					StartChildWorkflowExecutionCommandAttributes: &commandpb.StartChildWorkflowExecutionCommandAttributes{
+						WorkflowId:          tvChild.WorkflowID(),
+						WorkflowType:        tvChild.WorkflowType(),
+						TaskQueue:           tvChild.TaskQueue(),
+						Input:               payloads.EncodeString("duplicate-child"),
+						WorkflowRunTimeout:  durationpb.New(100 * time.Second),
+						WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+						//nolint:staticcheck // SA1019: intentional compatibility coverage for deprecated policy
+						WorkflowIdReusePolicy: enumspb.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
+					},
+				},
+			}}, nil
+		}
+
+		for _, event := range task.History.Events[task.PreviousStartedEventId:] {
+			switch event.GetEventType() {
+			case enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED:
+				startedAttrs = event.GetChildWorkflowExecutionStartedEventAttributes()
+				return []*commandpb.Command{{
+					CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
+					Attributes: &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{
+						CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{
+							Result: payloads.EncodeString("Done"),
+						},
+					},
+				}}, nil
+			case enumspb.EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_FAILED:
+				failedAttrs = event.GetStartChildWorkflowExecutionFailedEventAttributes()
+				return []*commandpb.Command{{
+					CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
+					Attributes: &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{
+						CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{
+							Result: payloads.EncodeString("Done"),
+						},
+					},
+				}}, nil
+			default:
+			}
+		}
+
+		return nil, nil
+	}
+
+	pollerParent := taskpoller.New(s.T(), s.FrontendClient(), s.Namespace().String())
+
+	_, err = pollerParent.PollAndHandleWorkflowTask(tvParent, func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		cmds, err := wtHandlerParent(task)
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{Commands: cmds}, err
+	})
+	s.NoError(err)
+
+	_, err = pollerParent.PollAndHandleWorkflowTask(tvParent, func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		cmds, err := wtHandlerParent(task)
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{Commands: cmds}, err
+	})
+	s.NoError(err)
+
+	s.Nil(failedAttrs)
+	s.NotNil(startedAttrs)
+	s.Equal(tvChild.WorkflowID(), startedAttrs.GetWorkflowExecution().GetWorkflowId())
+	s.Equal(tvChild.WorkflowType().GetName(), startedAttrs.GetWorkflowType().GetName())
+	s.NotEqual(existingChildResp.GetRunId(), startedAttrs.GetWorkflowExecution().GetRunId())
+
+	// The old execution should be terminated once the child start is migrated to
+	// conflict=TERMINATE_EXISTING for the running-workflow case.
+	s.Eventually(func() bool {
+		resp, err := s.FrontendClient().DescribeWorkflowExecution(testcore.NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: s.Namespace().String(),
+			Execution: &commonpb.WorkflowExecution{
+				WorkflowId: tvChild.WorkflowID(),
+				RunId:      existingChildResp.GetRunId(),
+			},
+		})
+		return err == nil && resp.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED
+	}, 10*time.Second, 200*time.Millisecond)
+}
+
 func (s *ChildWorkflowSuite) TestStartChildWorkflowWithInternalTaskQueue_Blocked() {
 	parentID := testcore.RandomizeStr(s.T().Name())
 	childID := testcore.RandomizeStr(s.T().Name())


### PR DESCRIPTION
## What changed?

Partially reverts https://github.com/temporalio/temporal/pull/9728 in that it brings back `MigrateWorkflowIdReusePolicyForRunningWorkflow`.

## Why?

The migration code was effectively moved from history to the frontend but during a deployment (mixed brain) it is still needed as old frontends don't do the migration.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
