### PR TITLE
[Scheduler] Make 'started schedule' log line log at Info level

### DIFF
--- a/chasm/lib/scheduler/generator_tasks.go
+++ b/chasm/lib/scheduler/generator_tasks.go
@@ -145,7 +145,7 @@ func (g *GeneratorTaskHandler) Execute(
 }
 
 func (g *GeneratorTaskHandler) logSchedule(logger log.Logger, msg string, sched *Scheduler) {
-	logger.Debug(msg,
+	logger.Info(msg,
 		tag.Stringer("spec", jsonStringer{sched.Schedule.Spec}),
 		tag.Stringer("policies", jsonStringer{sched.Schedule.Policies}))
 }


### PR DESCRIPTION
## What changed?
Title

## Why?
- Because we drop debug logs in prod by default, and this particular log statement tends to come in handy
