### PR TITLE
time-skipping propagation

### DIFF
--- a/api/historyservice/v1/request_response.pb.go
+++ b/api/historyservice/v1/request_response.pb.go
@@ -201,8 +201,12 @@ type StartWorkflowExecutionRequest struct {
 	// directly from the started event. Written onto the new run's
 	// WorkflowExecutionStartedEvent.
 	DeclinedTargetVersionUpgrade *v17.DeclinedTargetVersionUpgrade `protobuf:"bytes,17,opt,name=declined_target_version_upgrade,json=declinedTargetVersionUpgrade,proto3" json:"declined_target_version_upgrade,omitempty"`
-	unknownFields                protoimpl.UnknownFields
-	sizeCache                    protoimpl.SizeCache
+	// If a workflow execution is started by a previous execution (parent-child workflow or continue-as-new)
+	// that has already skipped some time, the accumulated skipped duration from that execution
+	// can be passed to the new workflow execution through this field.
+	InitialSkippedDuration *durationpb.Duration `protobuf:"bytes,18,opt,name=initial_skipped_duration,json=initialSkippedDuration,proto3" json:"initial_skipped_duration,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *StartWorkflowExecutionRequest) Reset() {
@@ -350,6 +354,13 @@ func (x *StartWorkflowExecutionRequest) GetInheritedAutoUpgradeInfo() *v16.Inher
 func (x *StartWorkflowExecutionRequest) GetDeclinedTargetVersionUpgrade() *v17.DeclinedTargetVersionUpgrade {
 	if x != nil {
 		return x.DeclinedTargetVersionUpgrade
+	}
+	return nil
+}
+
+func (x *StartWorkflowExecutionRequest) GetInitialSkippedDuration() *durationpb.Duration {
+	if x != nil {
+		return x.InitialSkippedDuration
 	}
 	return nil
 }
@@ -10448,7 +10459,7 @@ const file_temporal_server_api_historyservice_v1_request_response_proto_rawDesc 
 	"task_token\x18\x06 \x01(\tR\ttaskToken\x12\x1d\n" +
 	"\n" +
 	"task_infos\x18\a \x01(\tR\ttaskInfos\x12.\n" +
-	"\x13chasm_component_ref\x18\b \x01(\tR\x11chasmComponentRef\"\x81\f\n" +
+	"\x13chasm_component_ref\x18\b \x01(\tR\x11chasmComponentRef\"\xd6\f\n" +
 	"\x1dStartWorkflowExecutionRequest\x12!\n" +
 	"\fnamespace_id\x18\x01 \x01(\tR\vnamespaceId\x12c\n" +
 	"\rstart_request\x18\x02 \x01(\v2>.temporal.api.workflowservice.v1.StartWorkflowExecutionRequestR\fstartRequest\x12h\n" +
@@ -10467,7 +10478,8 @@ const file_temporal_server_api_historyservice_v1_request_response_proto_rawDesc 
 	"\x13child_workflow_only\x18\x0e \x01(\bR\x11childWorkflowOnly\x12m\n" +
 	"\x18inherited_pinned_version\x18\x0f \x01(\v23.temporal.api.deployment.v1.WorkerDeploymentVersionR\x16inheritedPinnedVersion\x12s\n" +
 	"\x1binherited_auto_upgrade_info\x18\x10 \x01(\v24.temporal.api.deployment.v1.InheritedAutoUpgradeInfoR\x18inheritedAutoUpgradeInfo\x12|\n" +
-	"\x1fdeclined_target_version_upgrade\x18\x11 \x01(\v25.temporal.api.history.v1.DeclinedTargetVersionUpgradeR\x1cdeclinedTargetVersionUpgrade:\x1f\x92\xc4\x03\x1b*\x19start_request.workflow_id\"\xfc\x02\n" +
+	"\x1fdeclined_target_version_upgrade\x18\x11 \x01(\v25.temporal.api.history.v1.DeclinedTargetVersionUpgradeR\x1cdeclinedTargetVersionUpgrade\x12S\n" +
+	"\x18initial_skipped_duration\x18\x12 \x01(\v2\x19.google.protobuf.DurationR\x16initialSkippedDuration:\x1f\x92\xc4\x03\x1b*\x19start_request.workflow_id\"\xfc\x02\n" +
 	"\x1eStartWorkflowExecutionResponse\x12\x15\n" +
 	"\x06run_id\x18\x01 \x01(\tR\x05runId\x12?\n" +
 	"\x05clock\x18\x02 \x01(\v2).temporal.server.api.clock.v1.VectorClockR\x05clock\x12n\n" +
@@ -11507,260 +11519,261 @@ var file_temporal_server_api_historyservice_v1_request_response_proto_depIdxs = 
 	179, // 10: temporal.server.api.historyservice.v1.StartWorkflowExecutionRequest.inherited_pinned_version:type_name -> temporal.api.deployment.v1.WorkerDeploymentVersion
 	180, // 11: temporal.server.api.historyservice.v1.StartWorkflowExecutionRequest.inherited_auto_upgrade_info:type_name -> temporal.api.deployment.v1.InheritedAutoUpgradeInfo
 	181, // 12: temporal.server.api.historyservice.v1.StartWorkflowExecutionRequest.declined_target_version_upgrade:type_name -> temporal.api.history.v1.DeclinedTargetVersionUpgrade
-	182, // 13: temporal.server.api.historyservice.v1.StartWorkflowExecutionResponse.clock:type_name -> temporal.server.api.clock.v1.VectorClock
-	183, // 14: temporal.server.api.historyservice.v1.StartWorkflowExecutionResponse.eager_workflow_task:type_name -> temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse
-	184, // 15: temporal.server.api.historyservice.v1.StartWorkflowExecutionResponse.status:type_name -> temporal.api.enums.v1.WorkflowExecutionStatus
-	185, // 16: temporal.server.api.historyservice.v1.StartWorkflowExecutionResponse.link:type_name -> temporal.api.common.v1.Link
-	186, // 17: temporal.server.api.historyservice.v1.GetMutableStateRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	187, // 18: temporal.server.api.historyservice.v1.GetMutableStateRequest.version_history_item:type_name -> temporal.server.api.history.v1.VersionHistoryItem
-	188, // 19: temporal.server.api.historyservice.v1.GetMutableStateRequest.versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	186, // 20: temporal.server.api.historyservice.v1.GetMutableStateResponse.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	189, // 21: temporal.server.api.historyservice.v1.GetMutableStateResponse.workflow_type:type_name -> temporal.api.common.v1.WorkflowType
-	190, // 22: temporal.server.api.historyservice.v1.GetMutableStateResponse.task_queue:type_name -> temporal.api.taskqueue.v1.TaskQueue
-	190, // 23: temporal.server.api.historyservice.v1.GetMutableStateResponse.sticky_task_queue:type_name -> temporal.api.taskqueue.v1.TaskQueue
-	175, // 24: temporal.server.api.historyservice.v1.GetMutableStateResponse.sticky_task_queue_schedule_to_start_timeout:type_name -> google.protobuf.Duration
-	191, // 25: temporal.server.api.historyservice.v1.GetMutableStateResponse.workflow_state:type_name -> temporal.server.api.enums.v1.WorkflowExecutionState
-	184, // 26: temporal.server.api.historyservice.v1.GetMutableStateResponse.workflow_status:type_name -> temporal.api.enums.v1.WorkflowExecutionStatus
-	192, // 27: temporal.server.api.historyservice.v1.GetMutableStateResponse.version_histories:type_name -> temporal.server.api.history.v1.VersionHistories
-	176, // 28: temporal.server.api.historyservice.v1.GetMutableStateResponse.most_recent_worker_version_stamp:type_name -> temporal.api.common.v1.WorkerVersionStamp
-	188, // 29: temporal.server.api.historyservice.v1.GetMutableStateResponse.transition_history:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	193, // 30: temporal.server.api.historyservice.v1.GetMutableStateResponse.versioning_info:type_name -> temporal.api.workflow.v1.WorkflowExecutionVersioningInfo
-	194, // 31: temporal.server.api.historyservice.v1.GetMutableStateResponse.transient_or_speculative_tasks:type_name -> temporal.server.api.history.v1.TransientWorkflowTaskInfo
-	186, // 32: temporal.server.api.historyservice.v1.PollMutableStateRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	187, // 33: temporal.server.api.historyservice.v1.PollMutableStateRequest.version_history_item:type_name -> temporal.server.api.history.v1.VersionHistoryItem
-	186, // 34: temporal.server.api.historyservice.v1.PollMutableStateResponse.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	189, // 35: temporal.server.api.historyservice.v1.PollMutableStateResponse.workflow_type:type_name -> temporal.api.common.v1.WorkflowType
-	190, // 36: temporal.server.api.historyservice.v1.PollMutableStateResponse.task_queue:type_name -> temporal.api.taskqueue.v1.TaskQueue
-	190, // 37: temporal.server.api.historyservice.v1.PollMutableStateResponse.sticky_task_queue:type_name -> temporal.api.taskqueue.v1.TaskQueue
-	175, // 38: temporal.server.api.historyservice.v1.PollMutableStateResponse.sticky_task_queue_schedule_to_start_timeout:type_name -> google.protobuf.Duration
-	192, // 39: temporal.server.api.historyservice.v1.PollMutableStateResponse.version_histories:type_name -> temporal.server.api.history.v1.VersionHistories
-	191, // 40: temporal.server.api.historyservice.v1.PollMutableStateResponse.workflow_state:type_name -> temporal.server.api.enums.v1.WorkflowExecutionState
-	184, // 41: temporal.server.api.historyservice.v1.PollMutableStateResponse.workflow_status:type_name -> temporal.api.enums.v1.WorkflowExecutionStatus
-	186, // 42: temporal.server.api.historyservice.v1.ResetStickyTaskQueueRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	160, // 43: temporal.server.api.historyservice.v1.ExecuteMultiOperationRequest.operations:type_name -> temporal.server.api.historyservice.v1.ExecuteMultiOperationRequest.Operation
-	161, // 44: temporal.server.api.historyservice.v1.ExecuteMultiOperationResponse.responses:type_name -> temporal.server.api.historyservice.v1.ExecuteMultiOperationResponse.Response
-	186, // 45: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedRequest.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	195, // 46: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedRequest.poll_request:type_name -> temporal.api.workflowservice.v1.PollWorkflowTaskQueueRequest
-	182, // 47: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedRequest.clock:type_name -> temporal.server.api.clock.v1.VectorClock
-	196, // 48: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedRequest.build_id_redirect_info:type_name -> temporal.server.api.taskqueue.v1.BuildIdRedirectInfo
-	197, // 49: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedRequest.scheduled_deployment:type_name -> temporal.api.deployment.v1.Deployment
-	198, // 50: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedRequest.version_directive:type_name -> temporal.server.api.taskqueue.v1.TaskVersionDirective
-	179, // 51: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedRequest.target_deployment_version:type_name -> temporal.api.deployment.v1.WorkerDeploymentVersion
-	189, // 52: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.workflow_type:type_name -> temporal.api.common.v1.WorkflowType
-	194, // 53: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.transient_workflow_task:type_name -> temporal.server.api.history.v1.TransientWorkflowTaskInfo
-	190, // 54: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.workflow_execution_task_queue:type_name -> temporal.api.taskqueue.v1.TaskQueue
-	171, // 55: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.scheduled_time:type_name -> google.protobuf.Timestamp
-	171, // 56: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.started_time:type_name -> google.protobuf.Timestamp
-	162, // 57: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.queries:type_name -> temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.QueriesEntry
-	182, // 58: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.clock:type_name -> temporal.server.api.clock.v1.VectorClock
-	199, // 59: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.messages:type_name -> temporal.api.protocol.v1.Message
-	200, // 60: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.history:type_name -> temporal.api.history.v1.History
-	200, // 61: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.raw_history:type_name -> temporal.api.history.v1.History
-	189, // 62: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponseWithRawHistory.workflow_type:type_name -> temporal.api.common.v1.WorkflowType
-	194, // 63: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponseWithRawHistory.transient_workflow_task:type_name -> temporal.server.api.history.v1.TransientWorkflowTaskInfo
-	190, // 64: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponseWithRawHistory.workflow_execution_task_queue:type_name -> temporal.api.taskqueue.v1.TaskQueue
-	171, // 65: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponseWithRawHistory.scheduled_time:type_name -> google.protobuf.Timestamp
-	171, // 66: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponseWithRawHistory.started_time:type_name -> google.protobuf.Timestamp
-	163, // 67: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponseWithRawHistory.queries:type_name -> temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponseWithRawHistory.QueriesEntry
-	182, // 68: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponseWithRawHistory.clock:type_name -> temporal.server.api.clock.v1.VectorClock
-	199, // 69: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponseWithRawHistory.messages:type_name -> temporal.api.protocol.v1.Message
-	200, // 70: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponseWithRawHistory.history:type_name -> temporal.api.history.v1.History
-	186, // 71: temporal.server.api.historyservice.v1.RecordActivityTaskStartedRequest.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	201, // 72: temporal.server.api.historyservice.v1.RecordActivityTaskStartedRequest.poll_request:type_name -> temporal.api.workflowservice.v1.PollActivityTaskQueueRequest
-	182, // 73: temporal.server.api.historyservice.v1.RecordActivityTaskStartedRequest.clock:type_name -> temporal.server.api.clock.v1.VectorClock
-	196, // 74: temporal.server.api.historyservice.v1.RecordActivityTaskStartedRequest.build_id_redirect_info:type_name -> temporal.server.api.taskqueue.v1.BuildIdRedirectInfo
-	197, // 75: temporal.server.api.historyservice.v1.RecordActivityTaskStartedRequest.scheduled_deployment:type_name -> temporal.api.deployment.v1.Deployment
-	198, // 76: temporal.server.api.historyservice.v1.RecordActivityTaskStartedRequest.version_directive:type_name -> temporal.server.api.taskqueue.v1.TaskVersionDirective
-	202, // 77: temporal.server.api.historyservice.v1.RecordActivityTaskStartedResponse.scheduled_event:type_name -> temporal.api.history.v1.HistoryEvent
-	171, // 78: temporal.server.api.historyservice.v1.RecordActivityTaskStartedResponse.started_time:type_name -> google.protobuf.Timestamp
-	171, // 79: temporal.server.api.historyservice.v1.RecordActivityTaskStartedResponse.current_attempt_scheduled_time:type_name -> google.protobuf.Timestamp
-	174, // 80: temporal.server.api.historyservice.v1.RecordActivityTaskStartedResponse.heartbeat_details:type_name -> temporal.api.common.v1.Payloads
-	189, // 81: temporal.server.api.historyservice.v1.RecordActivityTaskStartedResponse.workflow_type:type_name -> temporal.api.common.v1.WorkflowType
-	182, // 82: temporal.server.api.historyservice.v1.RecordActivityTaskStartedResponse.clock:type_name -> temporal.server.api.clock.v1.VectorClock
-	203, // 83: temporal.server.api.historyservice.v1.RecordActivityTaskStartedResponse.priority:type_name -> temporal.api.common.v1.Priority
-	204, // 84: temporal.server.api.historyservice.v1.RecordActivityTaskStartedResponse.retry_policy:type_name -> temporal.api.common.v1.RetryPolicy
-	205, // 85: temporal.server.api.historyservice.v1.RespondWorkflowTaskCompletedRequest.complete_request:type_name -> temporal.api.workflowservice.v1.RespondWorkflowTaskCompletedRequest
-	12,  // 86: temporal.server.api.historyservice.v1.RespondWorkflowTaskCompletedResponse.started_response:type_name -> temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse
-	206, // 87: temporal.server.api.historyservice.v1.RespondWorkflowTaskCompletedResponse.activity_tasks:type_name -> temporal.api.workflowservice.v1.PollActivityTaskQueueResponse
-	183, // 88: temporal.server.api.historyservice.v1.RespondWorkflowTaskCompletedResponse.new_workflow_task:type_name -> temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse
-	207, // 89: temporal.server.api.historyservice.v1.RespondWorkflowTaskFailedRequest.failed_request:type_name -> temporal.api.workflowservice.v1.RespondWorkflowTaskFailedRequest
-	186, // 90: temporal.server.api.historyservice.v1.IsWorkflowTaskValidRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	182, // 91: temporal.server.api.historyservice.v1.IsWorkflowTaskValidRequest.clock:type_name -> temporal.server.api.clock.v1.VectorClock
-	208, // 92: temporal.server.api.historyservice.v1.RecordActivityTaskHeartbeatRequest.heartbeat_request:type_name -> temporal.api.workflowservice.v1.RecordActivityTaskHeartbeatRequest
-	209, // 93: temporal.server.api.historyservice.v1.RespondActivityTaskCompletedRequest.complete_request:type_name -> temporal.api.workflowservice.v1.RespondActivityTaskCompletedRequest
-	210, // 94: temporal.server.api.historyservice.v1.RespondActivityTaskFailedRequest.failed_request:type_name -> temporal.api.workflowservice.v1.RespondActivityTaskFailedRequest
-	211, // 95: temporal.server.api.historyservice.v1.RespondActivityTaskCanceledRequest.cancel_request:type_name -> temporal.api.workflowservice.v1.RespondActivityTaskCanceledRequest
-	186, // 96: temporal.server.api.historyservice.v1.IsActivityTaskValidRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	182, // 97: temporal.server.api.historyservice.v1.IsActivityTaskValidRequest.clock:type_name -> temporal.server.api.clock.v1.VectorClock
-	212, // 98: temporal.server.api.historyservice.v1.SignalWorkflowExecutionRequest.signal_request:type_name -> temporal.api.workflowservice.v1.SignalWorkflowExecutionRequest
-	186, // 99: temporal.server.api.historyservice.v1.SignalWorkflowExecutionRequest.external_workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	213, // 100: temporal.server.api.historyservice.v1.SignalWithStartWorkflowExecutionRequest.signal_with_start_request:type_name -> temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest
-	186, // 101: temporal.server.api.historyservice.v1.RemoveSignalMutableStateRequest.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	214, // 102: temporal.server.api.historyservice.v1.TerminateWorkflowExecutionRequest.terminate_request:type_name -> temporal.api.workflowservice.v1.TerminateWorkflowExecutionRequest
-	186, // 103: temporal.server.api.historyservice.v1.TerminateWorkflowExecutionRequest.external_workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	186, // 104: temporal.server.api.historyservice.v1.DeleteWorkflowExecutionRequest.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	215, // 105: temporal.server.api.historyservice.v1.ResetWorkflowExecutionRequest.reset_request:type_name -> temporal.api.workflowservice.v1.ResetWorkflowExecutionRequest
-	216, // 106: temporal.server.api.historyservice.v1.RequestCancelWorkflowExecutionRequest.cancel_request:type_name -> temporal.api.workflowservice.v1.RequestCancelWorkflowExecutionRequest
-	186, // 107: temporal.server.api.historyservice.v1.RequestCancelWorkflowExecutionRequest.external_workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	186, // 108: temporal.server.api.historyservice.v1.ScheduleWorkflowTaskRequest.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	182, // 109: temporal.server.api.historyservice.v1.ScheduleWorkflowTaskRequest.child_clock:type_name -> temporal.server.api.clock.v1.VectorClock
-	182, // 110: temporal.server.api.historyservice.v1.ScheduleWorkflowTaskRequest.parent_clock:type_name -> temporal.server.api.clock.v1.VectorClock
-	186, // 111: temporal.server.api.historyservice.v1.VerifyFirstWorkflowTaskScheduledRequest.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	182, // 112: temporal.server.api.historyservice.v1.VerifyFirstWorkflowTaskScheduledRequest.clock:type_name -> temporal.server.api.clock.v1.VectorClock
-	186, // 113: temporal.server.api.historyservice.v1.RecordChildExecutionCompletedRequest.parent_execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	186, // 114: temporal.server.api.historyservice.v1.RecordChildExecutionCompletedRequest.child_execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	202, // 115: temporal.server.api.historyservice.v1.RecordChildExecutionCompletedRequest.completion_event:type_name -> temporal.api.history.v1.HistoryEvent
-	182, // 116: temporal.server.api.historyservice.v1.RecordChildExecutionCompletedRequest.clock:type_name -> temporal.server.api.clock.v1.VectorClock
-	186, // 117: temporal.server.api.historyservice.v1.VerifyChildExecutionCompletionRecordedRequest.parent_execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	186, // 118: temporal.server.api.historyservice.v1.VerifyChildExecutionCompletionRecordedRequest.child_execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	182, // 119: temporal.server.api.historyservice.v1.VerifyChildExecutionCompletionRecordedRequest.clock:type_name -> temporal.server.api.clock.v1.VectorClock
-	217, // 120: temporal.server.api.historyservice.v1.DescribeWorkflowExecutionRequest.request:type_name -> temporal.api.workflowservice.v1.DescribeWorkflowExecutionRequest
-	218, // 121: temporal.server.api.historyservice.v1.DescribeWorkflowExecutionResponse.execution_config:type_name -> temporal.api.workflow.v1.WorkflowExecutionConfig
-	219, // 122: temporal.server.api.historyservice.v1.DescribeWorkflowExecutionResponse.workflow_execution_info:type_name -> temporal.api.workflow.v1.WorkflowExecutionInfo
-	220, // 123: temporal.server.api.historyservice.v1.DescribeWorkflowExecutionResponse.pending_activities:type_name -> temporal.api.workflow.v1.PendingActivityInfo
-	221, // 124: temporal.server.api.historyservice.v1.DescribeWorkflowExecutionResponse.pending_children:type_name -> temporal.api.workflow.v1.PendingChildExecutionInfo
-	222, // 125: temporal.server.api.historyservice.v1.DescribeWorkflowExecutionResponse.pending_workflow_task:type_name -> temporal.api.workflow.v1.PendingWorkflowTaskInfo
-	223, // 126: temporal.server.api.historyservice.v1.DescribeWorkflowExecutionResponse.callbacks:type_name -> temporal.api.workflow.v1.CallbackInfo
-	224, // 127: temporal.server.api.historyservice.v1.DescribeWorkflowExecutionResponse.pending_nexus_operations:type_name -> temporal.api.workflow.v1.PendingNexusOperationInfo
-	225, // 128: temporal.server.api.historyservice.v1.DescribeWorkflowExecutionResponse.workflow_extended_info:type_name -> temporal.api.workflow.v1.WorkflowExecutionExtendedInfo
-	186, // 129: temporal.server.api.historyservice.v1.ReplicateEventsV2Request.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	187, // 130: temporal.server.api.historyservice.v1.ReplicateEventsV2Request.version_history_items:type_name -> temporal.server.api.history.v1.VersionHistoryItem
-	226, // 131: temporal.server.api.historyservice.v1.ReplicateEventsV2Request.events:type_name -> temporal.api.common.v1.DataBlob
-	226, // 132: temporal.server.api.historyservice.v1.ReplicateEventsV2Request.new_run_events:type_name -> temporal.api.common.v1.DataBlob
-	227, // 133: temporal.server.api.historyservice.v1.ReplicateEventsV2Request.base_execution_info:type_name -> temporal.server.api.workflow.v1.BaseExecutionInfo
-	228, // 134: temporal.server.api.historyservice.v1.ReplicateWorkflowStateRequest.workflow_state:type_name -> temporal.server.api.persistence.v1.WorkflowMutableState
-	171, // 135: temporal.server.api.historyservice.v1.SyncShardStatusRequest.status_time:type_name -> google.protobuf.Timestamp
-	171, // 136: temporal.server.api.historyservice.v1.SyncActivityRequest.scheduled_time:type_name -> google.protobuf.Timestamp
-	171, // 137: temporal.server.api.historyservice.v1.SyncActivityRequest.started_time:type_name -> google.protobuf.Timestamp
-	171, // 138: temporal.server.api.historyservice.v1.SyncActivityRequest.last_heartbeat_time:type_name -> google.protobuf.Timestamp
-	174, // 139: temporal.server.api.historyservice.v1.SyncActivityRequest.details:type_name -> temporal.api.common.v1.Payloads
-	173, // 140: temporal.server.api.historyservice.v1.SyncActivityRequest.last_failure:type_name -> temporal.api.failure.v1.Failure
-	229, // 141: temporal.server.api.historyservice.v1.SyncActivityRequest.version_history:type_name -> temporal.server.api.history.v1.VersionHistory
-	227, // 142: temporal.server.api.historyservice.v1.SyncActivityRequest.base_execution_info:type_name -> temporal.server.api.workflow.v1.BaseExecutionInfo
-	171, // 143: temporal.server.api.historyservice.v1.SyncActivityRequest.first_scheduled_time:type_name -> google.protobuf.Timestamp
-	171, // 144: temporal.server.api.historyservice.v1.SyncActivityRequest.last_attempt_complete_time:type_name -> google.protobuf.Timestamp
-	175, // 145: temporal.server.api.historyservice.v1.SyncActivityRequest.retry_initial_interval:type_name -> google.protobuf.Duration
-	175, // 146: temporal.server.api.historyservice.v1.SyncActivityRequest.retry_maximum_interval:type_name -> google.protobuf.Duration
-	64,  // 147: temporal.server.api.historyservice.v1.SyncActivitiesRequest.activities_info:type_name -> temporal.server.api.historyservice.v1.ActivitySyncInfo
-	171, // 148: temporal.server.api.historyservice.v1.ActivitySyncInfo.scheduled_time:type_name -> google.protobuf.Timestamp
-	171, // 149: temporal.server.api.historyservice.v1.ActivitySyncInfo.started_time:type_name -> google.protobuf.Timestamp
-	171, // 150: temporal.server.api.historyservice.v1.ActivitySyncInfo.last_heartbeat_time:type_name -> google.protobuf.Timestamp
-	174, // 151: temporal.server.api.historyservice.v1.ActivitySyncInfo.details:type_name -> temporal.api.common.v1.Payloads
-	173, // 152: temporal.server.api.historyservice.v1.ActivitySyncInfo.last_failure:type_name -> temporal.api.failure.v1.Failure
-	229, // 153: temporal.server.api.historyservice.v1.ActivitySyncInfo.version_history:type_name -> temporal.server.api.history.v1.VersionHistory
-	171, // 154: temporal.server.api.historyservice.v1.ActivitySyncInfo.first_scheduled_time:type_name -> google.protobuf.Timestamp
-	171, // 155: temporal.server.api.historyservice.v1.ActivitySyncInfo.last_attempt_complete_time:type_name -> google.protobuf.Timestamp
-	175, // 156: temporal.server.api.historyservice.v1.ActivitySyncInfo.retry_initial_interval:type_name -> google.protobuf.Duration
-	175, // 157: temporal.server.api.historyservice.v1.ActivitySyncInfo.retry_maximum_interval:type_name -> google.protobuf.Duration
-	186, // 158: temporal.server.api.historyservice.v1.DescribeMutableStateRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	228, // 159: temporal.server.api.historyservice.v1.DescribeMutableStateResponse.cache_mutable_state:type_name -> temporal.server.api.persistence.v1.WorkflowMutableState
-	228, // 160: temporal.server.api.historyservice.v1.DescribeMutableStateResponse.database_mutable_state:type_name -> temporal.server.api.persistence.v1.WorkflowMutableState
-	186, // 161: temporal.server.api.historyservice.v1.DescribeHistoryHostRequest.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	230, // 162: temporal.server.api.historyservice.v1.DescribeHistoryHostResponse.namespace_cache:type_name -> temporal.server.api.namespace.v1.NamespaceCacheInfo
-	231, // 163: temporal.server.api.historyservice.v1.GetShardResponse.shard_info:type_name -> temporal.server.api.persistence.v1.ShardInfo
-	171, // 164: temporal.server.api.historyservice.v1.RemoveTaskRequest.visibility_time:type_name -> google.protobuf.Timestamp
-	232, // 165: temporal.server.api.historyservice.v1.GetReplicationMessagesRequest.tokens:type_name -> temporal.server.api.replication.v1.ReplicationToken
-	164, // 166: temporal.server.api.historyservice.v1.GetReplicationMessagesResponse.shard_messages:type_name -> temporal.server.api.historyservice.v1.GetReplicationMessagesResponse.ShardMessagesEntry
-	233, // 167: temporal.server.api.historyservice.v1.GetDLQReplicationMessagesRequest.task_infos:type_name -> temporal.server.api.replication.v1.ReplicationTaskInfo
-	234, // 168: temporal.server.api.historyservice.v1.GetDLQReplicationMessagesResponse.replication_tasks:type_name -> temporal.server.api.replication.v1.ReplicationTask
-	235, // 169: temporal.server.api.historyservice.v1.QueryWorkflowRequest.request:type_name -> temporal.api.workflowservice.v1.QueryWorkflowRequest
-	236, // 170: temporal.server.api.historyservice.v1.QueryWorkflowResponse.response:type_name -> temporal.api.workflowservice.v1.QueryWorkflowResponse
-	237, // 171: temporal.server.api.historyservice.v1.ReapplyEventsRequest.request:type_name -> temporal.server.api.adminservice.v1.ReapplyEventsRequest
-	238, // 172: temporal.server.api.historyservice.v1.GetDLQMessagesRequest.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
-	238, // 173: temporal.server.api.historyservice.v1.GetDLQMessagesResponse.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
-	234, // 174: temporal.server.api.historyservice.v1.GetDLQMessagesResponse.replication_tasks:type_name -> temporal.server.api.replication.v1.ReplicationTask
-	233, // 175: temporal.server.api.historyservice.v1.GetDLQMessagesResponse.replication_tasks_info:type_name -> temporal.server.api.replication.v1.ReplicationTaskInfo
-	238, // 176: temporal.server.api.historyservice.v1.PurgeDLQMessagesRequest.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
-	238, // 177: temporal.server.api.historyservice.v1.MergeDLQMessagesRequest.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
-	239, // 178: temporal.server.api.historyservice.v1.RefreshWorkflowTasksRequest.request:type_name -> temporal.server.api.adminservice.v1.RefreshWorkflowTasksRequest
-	186, // 179: temporal.server.api.historyservice.v1.GenerateLastHistoryReplicationTasksRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	96,  // 180: temporal.server.api.historyservice.v1.GetReplicationStatusResponse.shards:type_name -> temporal.server.api.historyservice.v1.ShardReplicationStatus
-	171, // 181: temporal.server.api.historyservice.v1.ShardReplicationStatus.shard_local_time:type_name -> google.protobuf.Timestamp
-	165, // 182: temporal.server.api.historyservice.v1.ShardReplicationStatus.remote_clusters:type_name -> temporal.server.api.historyservice.v1.ShardReplicationStatus.RemoteClustersEntry
-	166, // 183: temporal.server.api.historyservice.v1.ShardReplicationStatus.handover_namespaces:type_name -> temporal.server.api.historyservice.v1.ShardReplicationStatus.HandoverNamespacesEntry
-	171, // 184: temporal.server.api.historyservice.v1.ShardReplicationStatus.max_replication_task_visibility_time:type_name -> google.protobuf.Timestamp
-	171, // 185: temporal.server.api.historyservice.v1.ShardReplicationStatusPerCluster.acked_task_visibility_time:type_name -> google.protobuf.Timestamp
-	186, // 186: temporal.server.api.historyservice.v1.RebuildMutableStateRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	186, // 187: temporal.server.api.historyservice.v1.ImportWorkflowExecutionRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	226, // 188: temporal.server.api.historyservice.v1.ImportWorkflowExecutionRequest.history_batches:type_name -> temporal.api.common.v1.DataBlob
-	229, // 189: temporal.server.api.historyservice.v1.ImportWorkflowExecutionRequest.version_history:type_name -> temporal.server.api.history.v1.VersionHistory
-	186, // 190: temporal.server.api.historyservice.v1.DeleteWorkflowVisibilityRecordRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	171, // 191: temporal.server.api.historyservice.v1.DeleteWorkflowVisibilityRecordRequest.workflow_start_time:type_name -> google.protobuf.Timestamp
-	171, // 192: temporal.server.api.historyservice.v1.DeleteWorkflowVisibilityRecordRequest.workflow_close_time:type_name -> google.protobuf.Timestamp
-	240, // 193: temporal.server.api.historyservice.v1.UpdateWorkflowExecutionRequest.request:type_name -> temporal.api.workflowservice.v1.UpdateWorkflowExecutionRequest
-	241, // 194: temporal.server.api.historyservice.v1.UpdateWorkflowExecutionResponse.response:type_name -> temporal.api.workflowservice.v1.UpdateWorkflowExecutionResponse
-	242, // 195: temporal.server.api.historyservice.v1.StreamWorkflowReplicationMessagesRequest.sync_replication_state:type_name -> temporal.server.api.replication.v1.SyncReplicationState
-	243, // 196: temporal.server.api.historyservice.v1.StreamWorkflowReplicationMessagesResponse.messages:type_name -> temporal.server.api.replication.v1.WorkflowReplicationMessages
-	244, // 197: temporal.server.api.historyservice.v1.PollWorkflowExecutionUpdateRequest.request:type_name -> temporal.api.workflowservice.v1.PollWorkflowExecutionUpdateRequest
-	245, // 198: temporal.server.api.historyservice.v1.PollWorkflowExecutionUpdateResponse.response:type_name -> temporal.api.workflowservice.v1.PollWorkflowExecutionUpdateResponse
-	246, // 199: temporal.server.api.historyservice.v1.GetWorkflowExecutionHistoryRequest.request:type_name -> temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryRequest
-	247, // 200: temporal.server.api.historyservice.v1.GetWorkflowExecutionHistoryResponse.response:type_name -> temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse
-	200, // 201: temporal.server.api.historyservice.v1.GetWorkflowExecutionHistoryResponse.history:type_name -> temporal.api.history.v1.History
-	247, // 202: temporal.server.api.historyservice.v1.GetWorkflowExecutionHistoryResponseWithRaw.response:type_name -> temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse
-	248, // 203: temporal.server.api.historyservice.v1.GetWorkflowExecutionHistoryReverseRequest.request:type_name -> temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryReverseRequest
-	249, // 204: temporal.server.api.historyservice.v1.GetWorkflowExecutionHistoryReverseResponse.response:type_name -> temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryReverseResponse
-	250, // 205: temporal.server.api.historyservice.v1.GetWorkflowExecutionRawHistoryV2Request.request:type_name -> temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryV2Request
-	251, // 206: temporal.server.api.historyservice.v1.GetWorkflowExecutionRawHistoryV2Response.response:type_name -> temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryV2Response
-	252, // 207: temporal.server.api.historyservice.v1.GetWorkflowExecutionRawHistoryRequest.request:type_name -> temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryRequest
-	253, // 208: temporal.server.api.historyservice.v1.GetWorkflowExecutionRawHistoryResponse.response:type_name -> temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryResponse
-	254, // 209: temporal.server.api.historyservice.v1.ForceDeleteWorkflowExecutionRequest.request:type_name -> temporal.server.api.adminservice.v1.DeleteWorkflowExecutionRequest
-	255, // 210: temporal.server.api.historyservice.v1.ForceDeleteWorkflowExecutionResponse.response:type_name -> temporal.server.api.adminservice.v1.DeleteWorkflowExecutionResponse
-	256, // 211: temporal.server.api.historyservice.v1.GetDLQTasksRequest.dlq_key:type_name -> temporal.server.api.common.v1.HistoryDLQKey
-	257, // 212: temporal.server.api.historyservice.v1.GetDLQTasksResponse.dlq_tasks:type_name -> temporal.server.api.common.v1.HistoryDLQTask
-	256, // 213: temporal.server.api.historyservice.v1.DeleteDLQTasksRequest.dlq_key:type_name -> temporal.server.api.common.v1.HistoryDLQKey
-	258, // 214: temporal.server.api.historyservice.v1.DeleteDLQTasksRequest.inclusive_max_task_metadata:type_name -> temporal.server.api.common.v1.HistoryDLQTaskMetadata
-	167, // 215: temporal.server.api.historyservice.v1.ListQueuesResponse.queues:type_name -> temporal.server.api.historyservice.v1.ListQueuesResponse.QueueInfo
-	168, // 216: temporal.server.api.historyservice.v1.AddTasksRequest.tasks:type_name -> temporal.server.api.historyservice.v1.AddTasksRequest.Task
-	259, // 217: temporal.server.api.historyservice.v1.ListTasksRequest.request:type_name -> temporal.server.api.adminservice.v1.ListHistoryTasksRequest
-	260, // 218: temporal.server.api.historyservice.v1.ListTasksResponse.response:type_name -> temporal.server.api.adminservice.v1.ListHistoryTasksResponse
-	261, // 219: temporal.server.api.historyservice.v1.CompleteNexusOperationChasmRequest.completion:type_name -> temporal.server.api.token.v1.NexusOperationCompletion
-	262, // 220: temporal.server.api.historyservice.v1.CompleteNexusOperationChasmRequest.success:type_name -> temporal.api.common.v1.Payload
-	173, // 221: temporal.server.api.historyservice.v1.CompleteNexusOperationChasmRequest.failure:type_name -> temporal.api.failure.v1.Failure
-	171, // 222: temporal.server.api.historyservice.v1.CompleteNexusOperationChasmRequest.close_time:type_name -> google.protobuf.Timestamp
-	185, // 223: temporal.server.api.historyservice.v1.CompleteNexusOperationChasmRequest.links:type_name -> temporal.api.common.v1.Link
-	171, // 224: temporal.server.api.historyservice.v1.CompleteNexusOperationChasmRequest.start_time:type_name -> google.protobuf.Timestamp
-	261, // 225: temporal.server.api.historyservice.v1.CompleteNexusOperationRequest.completion:type_name -> temporal.server.api.token.v1.NexusOperationCompletion
-	262, // 226: temporal.server.api.historyservice.v1.CompleteNexusOperationRequest.success:type_name -> temporal.api.common.v1.Payload
-	263, // 227: temporal.server.api.historyservice.v1.CompleteNexusOperationRequest.failure:type_name -> temporal.api.nexus.v1.Failure
-	171, // 228: temporal.server.api.historyservice.v1.CompleteNexusOperationRequest.start_time:type_name -> google.protobuf.Timestamp
-	185, // 229: temporal.server.api.historyservice.v1.CompleteNexusOperationRequest.links:type_name -> temporal.api.common.v1.Link
-	264, // 230: temporal.server.api.historyservice.v1.InvokeStateMachineMethodRequest.ref:type_name -> temporal.server.api.persistence.v1.StateMachineRef
-	265, // 231: temporal.server.api.historyservice.v1.DeepHealthCheckResponse.state:type_name -> temporal.server.api.enums.v1.HealthState
-	266, // 232: temporal.server.api.historyservice.v1.DeepHealthCheckResponse.checks:type_name -> temporal.server.api.health.v1.HealthCheck
-	186, // 233: temporal.server.api.historyservice.v1.SyncWorkflowStateRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	188, // 234: temporal.server.api.historyservice.v1.SyncWorkflowStateRequest.versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	192, // 235: temporal.server.api.historyservice.v1.SyncWorkflowStateRequest.version_histories:type_name -> temporal.server.api.history.v1.VersionHistories
-	267, // 236: temporal.server.api.historyservice.v1.SyncWorkflowStateResponse.versioned_transition_artifact:type_name -> temporal.server.api.replication.v1.VersionedTransitionArtifact
-	268, // 237: temporal.server.api.historyservice.v1.UpdateActivityOptionsRequest.update_request:type_name -> temporal.api.workflowservice.v1.UpdateActivityOptionsRequest
-	269, // 238: temporal.server.api.historyservice.v1.UpdateActivityOptionsResponse.activity_options:type_name -> temporal.api.activity.v1.ActivityOptions
-	270, // 239: temporal.server.api.historyservice.v1.PauseActivityRequest.frontend_request:type_name -> temporal.api.workflowservice.v1.PauseActivityRequest
-	271, // 240: temporal.server.api.historyservice.v1.UnpauseActivityRequest.frontend_request:type_name -> temporal.api.workflowservice.v1.UnpauseActivityRequest
-	272, // 241: temporal.server.api.historyservice.v1.ResetActivityRequest.frontend_request:type_name -> temporal.api.workflowservice.v1.ResetActivityRequest
-	273, // 242: temporal.server.api.historyservice.v1.UpdateWorkflowExecutionOptionsRequest.update_request:type_name -> temporal.api.workflowservice.v1.UpdateWorkflowExecutionOptionsRequest
-	274, // 243: temporal.server.api.historyservice.v1.UpdateWorkflowExecutionOptionsResponse.workflow_execution_options:type_name -> temporal.api.workflow.v1.WorkflowExecutionOptions
-	275, // 244: temporal.server.api.historyservice.v1.PauseWorkflowExecutionRequest.pause_request:type_name -> temporal.api.workflowservice.v1.PauseWorkflowExecutionRequest
-	276, // 245: temporal.server.api.historyservice.v1.UnpauseWorkflowExecutionRequest.unpause_request:type_name -> temporal.api.workflowservice.v1.UnpauseWorkflowExecutionRequest
-	277, // 246: temporal.server.api.historyservice.v1.StartNexusOperationRequest.request:type_name -> temporal.api.nexus.v1.StartOperationRequest
-	278, // 247: temporal.server.api.historyservice.v1.StartNexusOperationResponse.response:type_name -> temporal.api.nexus.v1.StartOperationResponse
-	279, // 248: temporal.server.api.historyservice.v1.CancelNexusOperationRequest.request:type_name -> temporal.api.nexus.v1.CancelOperationRequest
-	280, // 249: temporal.server.api.historyservice.v1.CancelNexusOperationResponse.response:type_name -> temporal.api.nexus.v1.CancelOperationResponse
-	1,   // 250: temporal.server.api.historyservice.v1.ExecuteMultiOperationRequest.Operation.start_workflow:type_name -> temporal.server.api.historyservice.v1.StartWorkflowExecutionRequest
-	105, // 251: temporal.server.api.historyservice.v1.ExecuteMultiOperationRequest.Operation.update_workflow:type_name -> temporal.server.api.historyservice.v1.UpdateWorkflowExecutionRequest
-	2,   // 252: temporal.server.api.historyservice.v1.ExecuteMultiOperationResponse.Response.start_workflow:type_name -> temporal.server.api.historyservice.v1.StartWorkflowExecutionResponse
-	106, // 253: temporal.server.api.historyservice.v1.ExecuteMultiOperationResponse.Response.update_workflow:type_name -> temporal.server.api.historyservice.v1.UpdateWorkflowExecutionResponse
-	281, // 254: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.QueriesEntry.value:type_name -> temporal.api.query.v1.WorkflowQuery
-	281, // 255: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponseWithRawHistory.QueriesEntry.value:type_name -> temporal.api.query.v1.WorkflowQuery
-	282, // 256: temporal.server.api.historyservice.v1.GetReplicationMessagesResponse.ShardMessagesEntry.value:type_name -> temporal.server.api.replication.v1.ReplicationMessages
-	98,  // 257: temporal.server.api.historyservice.v1.ShardReplicationStatus.RemoteClustersEntry.value:type_name -> temporal.server.api.historyservice.v1.ShardReplicationStatusPerCluster
-	97,  // 258: temporal.server.api.historyservice.v1.ShardReplicationStatus.HandoverNamespacesEntry.value:type_name -> temporal.server.api.historyservice.v1.HandoverNamespaceInfo
-	226, // 259: temporal.server.api.historyservice.v1.AddTasksRequest.Task.blob:type_name -> temporal.api.common.v1.DataBlob
-	283, // 260: temporal.server.api.historyservice.v1.routing:extendee -> google.protobuf.MessageOptions
-	0,   // 261: temporal.server.api.historyservice.v1.routing:type_name -> temporal.server.api.historyservice.v1.RoutingOptions
-	262, // [262:262] is the sub-list for method output_type
-	262, // [262:262] is the sub-list for method input_type
-	261, // [261:262] is the sub-list for extension type_name
-	260, // [260:261] is the sub-list for extension extendee
-	0,   // [0:260] is the sub-list for field type_name
+	175, // 13: temporal.server.api.historyservice.v1.StartWorkflowExecutionRequest.initial_skipped_duration:type_name -> google.protobuf.Duration
+	182, // 14: temporal.server.api.historyservice.v1.StartWorkflowExecutionResponse.clock:type_name -> temporal.server.api.clock.v1.VectorClock
+	183, // 15: temporal.server.api.historyservice.v1.StartWorkflowExecutionResponse.eager_workflow_task:type_name -> temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse
+	184, // 16: temporal.server.api.historyservice.v1.StartWorkflowExecutionResponse.status:type_name -> temporal.api.enums.v1.WorkflowExecutionStatus
+	185, // 17: temporal.server.api.historyservice.v1.StartWorkflowExecutionResponse.link:type_name -> temporal.api.common.v1.Link
+	186, // 18: temporal.server.api.historyservice.v1.GetMutableStateRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	187, // 19: temporal.server.api.historyservice.v1.GetMutableStateRequest.version_history_item:type_name -> temporal.server.api.history.v1.VersionHistoryItem
+	188, // 20: temporal.server.api.historyservice.v1.GetMutableStateRequest.versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	186, // 21: temporal.server.api.historyservice.v1.GetMutableStateResponse.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	189, // 22: temporal.server.api.historyservice.v1.GetMutableStateResponse.workflow_type:type_name -> temporal.api.common.v1.WorkflowType
+	190, // 23: temporal.server.api.historyservice.v1.GetMutableStateResponse.task_queue:type_name -> temporal.api.taskqueue.v1.TaskQueue
+	190, // 24: temporal.server.api.historyservice.v1.GetMutableStateResponse.sticky_task_queue:type_name -> temporal.api.taskqueue.v1.TaskQueue
+	175, // 25: temporal.server.api.historyservice.v1.GetMutableStateResponse.sticky_task_queue_schedule_to_start_timeout:type_name -> google.protobuf.Duration
+	191, // 26: temporal.server.api.historyservice.v1.GetMutableStateResponse.workflow_state:type_name -> temporal.server.api.enums.v1.WorkflowExecutionState
+	184, // 27: temporal.server.api.historyservice.v1.GetMutableStateResponse.workflow_status:type_name -> temporal.api.enums.v1.WorkflowExecutionStatus
+	192, // 28: temporal.server.api.historyservice.v1.GetMutableStateResponse.version_histories:type_name -> temporal.server.api.history.v1.VersionHistories
+	176, // 29: temporal.server.api.historyservice.v1.GetMutableStateResponse.most_recent_worker_version_stamp:type_name -> temporal.api.common.v1.WorkerVersionStamp
+	188, // 30: temporal.server.api.historyservice.v1.GetMutableStateResponse.transition_history:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	193, // 31: temporal.server.api.historyservice.v1.GetMutableStateResponse.versioning_info:type_name -> temporal.api.workflow.v1.WorkflowExecutionVersioningInfo
+	194, // 32: temporal.server.api.historyservice.v1.GetMutableStateResponse.transient_or_speculative_tasks:type_name -> temporal.server.api.history.v1.TransientWorkflowTaskInfo
+	186, // 33: temporal.server.api.historyservice.v1.PollMutableStateRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	187, // 34: temporal.server.api.historyservice.v1.PollMutableStateRequest.version_history_item:type_name -> temporal.server.api.history.v1.VersionHistoryItem
+	186, // 35: temporal.server.api.historyservice.v1.PollMutableStateResponse.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	189, // 36: temporal.server.api.historyservice.v1.PollMutableStateResponse.workflow_type:type_name -> temporal.api.common.v1.WorkflowType
+	190, // 37: temporal.server.api.historyservice.v1.PollMutableStateResponse.task_queue:type_name -> temporal.api.taskqueue.v1.TaskQueue
+	190, // 38: temporal.server.api.historyservice.v1.PollMutableStateResponse.sticky_task_queue:type_name -> temporal.api.taskqueue.v1.TaskQueue
+	175, // 39: temporal.server.api.historyservice.v1.PollMutableStateResponse.sticky_task_queue_schedule_to_start_timeout:type_name -> google.protobuf.Duration
+	192, // 40: temporal.server.api.historyservice.v1.PollMutableStateResponse.version_histories:type_name -> temporal.server.api.history.v1.VersionHistories
+	191, // 41: temporal.server.api.historyservice.v1.PollMutableStateResponse.workflow_state:type_name -> temporal.server.api.enums.v1.WorkflowExecutionState
+	184, // 42: temporal.server.api.historyservice.v1.PollMutableStateResponse.workflow_status:type_name -> temporal.api.enums.v1.WorkflowExecutionStatus
+	186, // 43: temporal.server.api.historyservice.v1.ResetStickyTaskQueueRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	160, // 44: temporal.server.api.historyservice.v1.ExecuteMultiOperationRequest.operations:type_name -> temporal.server.api.historyservice.v1.ExecuteMultiOperationRequest.Operation
+	161, // 45: temporal.server.api.historyservice.v1.ExecuteMultiOperationResponse.responses:type_name -> temporal.server.api.historyservice.v1.ExecuteMultiOperationResponse.Response
+	186, // 46: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedRequest.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	195, // 47: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedRequest.poll_request:type_name -> temporal.api.workflowservice.v1.PollWorkflowTaskQueueRequest
+	182, // 48: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedRequest.clock:type_name -> temporal.server.api.clock.v1.VectorClock
+	196, // 49: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedRequest.build_id_redirect_info:type_name -> temporal.server.api.taskqueue.v1.BuildIdRedirectInfo
+	197, // 50: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedRequest.scheduled_deployment:type_name -> temporal.api.deployment.v1.Deployment
+	198, // 51: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedRequest.version_directive:type_name -> temporal.server.api.taskqueue.v1.TaskVersionDirective
+	179, // 52: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedRequest.target_deployment_version:type_name -> temporal.api.deployment.v1.WorkerDeploymentVersion
+	189, // 53: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.workflow_type:type_name -> temporal.api.common.v1.WorkflowType
+	194, // 54: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.transient_workflow_task:type_name -> temporal.server.api.history.v1.TransientWorkflowTaskInfo
+	190, // 55: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.workflow_execution_task_queue:type_name -> temporal.api.taskqueue.v1.TaskQueue
+	171, // 56: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.scheduled_time:type_name -> google.protobuf.Timestamp
+	171, // 57: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.started_time:type_name -> google.protobuf.Timestamp
+	162, // 58: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.queries:type_name -> temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.QueriesEntry
+	182, // 59: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.clock:type_name -> temporal.server.api.clock.v1.VectorClock
+	199, // 60: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.messages:type_name -> temporal.api.protocol.v1.Message
+	200, // 61: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.history:type_name -> temporal.api.history.v1.History
+	200, // 62: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.raw_history:type_name -> temporal.api.history.v1.History
+	189, // 63: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponseWithRawHistory.workflow_type:type_name -> temporal.api.common.v1.WorkflowType
+	194, // 64: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponseWithRawHistory.transient_workflow_task:type_name -> temporal.server.api.history.v1.TransientWorkflowTaskInfo
+	190, // 65: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponseWithRawHistory.workflow_execution_task_queue:type_name -> temporal.api.taskqueue.v1.TaskQueue
+	171, // 66: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponseWithRawHistory.scheduled_time:type_name -> google.protobuf.Timestamp
+	171, // 67: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponseWithRawHistory.started_time:type_name -> google.protobuf.Timestamp
+	163, // 68: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponseWithRawHistory.queries:type_name -> temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponseWithRawHistory.QueriesEntry
+	182, // 69: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponseWithRawHistory.clock:type_name -> temporal.server.api.clock.v1.VectorClock
+	199, // 70: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponseWithRawHistory.messages:type_name -> temporal.api.protocol.v1.Message
+	200, // 71: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponseWithRawHistory.history:type_name -> temporal.api.history.v1.History
+	186, // 72: temporal.server.api.historyservice.v1.RecordActivityTaskStartedRequest.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	201, // 73: temporal.server.api.historyservice.v1.RecordActivityTaskStartedRequest.poll_request:type_name -> temporal.api.workflowservice.v1.PollActivityTaskQueueRequest
+	182, // 74: temporal.server.api.historyservice.v1.RecordActivityTaskStartedRequest.clock:type_name -> temporal.server.api.clock.v1.VectorClock
+	196, // 75: temporal.server.api.historyservice.v1.RecordActivityTaskStartedRequest.build_id_redirect_info:type_name -> temporal.server.api.taskqueue.v1.BuildIdRedirectInfo
+	197, // 76: temporal.server.api.historyservice.v1.RecordActivityTaskStartedRequest.scheduled_deployment:type_name -> temporal.api.deployment.v1.Deployment
+	198, // 77: temporal.server.api.historyservice.v1.RecordActivityTaskStartedRequest.version_directive:type_name -> temporal.server.api.taskqueue.v1.TaskVersionDirective
+	202, // 78: temporal.server.api.historyservice.v1.RecordActivityTaskStartedResponse.scheduled_event:type_name -> temporal.api.history.v1.HistoryEvent
+	171, // 79: temporal.server.api.historyservice.v1.RecordActivityTaskStartedResponse.started_time:type_name -> google.protobuf.Timestamp
+	171, // 80: temporal.server.api.historyservice.v1.RecordActivityTaskStartedResponse.current_attempt_scheduled_time:type_name -> google.protobuf.Timestamp
+	174, // 81: temporal.server.api.historyservice.v1.RecordActivityTaskStartedResponse.heartbeat_details:type_name -> temporal.api.common.v1.Payloads
+	189, // 82: temporal.server.api.historyservice.v1.RecordActivityTaskStartedResponse.workflow_type:type_name -> temporal.api.common.v1.WorkflowType
+	182, // 83: temporal.server.api.historyservice.v1.RecordActivityTaskStartedResponse.clock:type_name -> temporal.server.api.clock.v1.VectorClock
+	203, // 84: temporal.server.api.historyservice.v1.RecordActivityTaskStartedResponse.priority:type_name -> temporal.api.common.v1.Priority
+	204, // 85: temporal.server.api.historyservice.v1.RecordActivityTaskStartedResponse.retry_policy:type_name -> temporal.api.common.v1.RetryPolicy
+	205, // 86: temporal.server.api.historyservice.v1.RespondWorkflowTaskCompletedRequest.complete_request:type_name -> temporal.api.workflowservice.v1.RespondWorkflowTaskCompletedRequest
+	12,  // 87: temporal.server.api.historyservice.v1.RespondWorkflowTaskCompletedResponse.started_response:type_name -> temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse
+	206, // 88: temporal.server.api.historyservice.v1.RespondWorkflowTaskCompletedResponse.activity_tasks:type_name -> temporal.api.workflowservice.v1.PollActivityTaskQueueResponse
+	183, // 89: temporal.server.api.historyservice.v1.RespondWorkflowTaskCompletedResponse.new_workflow_task:type_name -> temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse
+	207, // 90: temporal.server.api.historyservice.v1.RespondWorkflowTaskFailedRequest.failed_request:type_name -> temporal.api.workflowservice.v1.RespondWorkflowTaskFailedRequest
+	186, // 91: temporal.server.api.historyservice.v1.IsWorkflowTaskValidRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	182, // 92: temporal.server.api.historyservice.v1.IsWorkflowTaskValidRequest.clock:type_name -> temporal.server.api.clock.v1.VectorClock
+	208, // 93: temporal.server.api.historyservice.v1.RecordActivityTaskHeartbeatRequest.heartbeat_request:type_name -> temporal.api.workflowservice.v1.RecordActivityTaskHeartbeatRequest
+	209, // 94: temporal.server.api.historyservice.v1.RespondActivityTaskCompletedRequest.complete_request:type_name -> temporal.api.workflowservice.v1.RespondActivityTaskCompletedRequest
+	210, // 95: temporal.server.api.historyservice.v1.RespondActivityTaskFailedRequest.failed_request:type_name -> temporal.api.workflowservice.v1.RespondActivityTaskFailedRequest
+	211, // 96: temporal.server.api.historyservice.v1.RespondActivityTaskCanceledRequest.cancel_request:type_name -> temporal.api.workflowservice.v1.RespondActivityTaskCanceledRequest
+	186, // 97: temporal.server.api.historyservice.v1.IsActivityTaskValidRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	182, // 98: temporal.server.api.historyservice.v1.IsActivityTaskValidRequest.clock:type_name -> temporal.server.api.clock.v1.VectorClock
+	212, // 99: temporal.server.api.historyservice.v1.SignalWorkflowExecutionRequest.signal_request:type_name -> temporal.api.workflowservice.v1.SignalWorkflowExecutionRequest
+	186, // 100: temporal.server.api.historyservice.v1.SignalWorkflowExecutionRequest.external_workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	213, // 101: temporal.server.api.historyservice.v1.SignalWithStartWorkflowExecutionRequest.signal_with_start_request:type_name -> temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest
+	186, // 102: temporal.server.api.historyservice.v1.RemoveSignalMutableStateRequest.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	214, // 103: temporal.server.api.historyservice.v1.TerminateWorkflowExecutionRequest.terminate_request:type_name -> temporal.api.workflowservice.v1.TerminateWorkflowExecutionRequest
+	186, // 104: temporal.server.api.historyservice.v1.TerminateWorkflowExecutionRequest.external_workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	186, // 105: temporal.server.api.historyservice.v1.DeleteWorkflowExecutionRequest.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	215, // 106: temporal.server.api.historyservice.v1.ResetWorkflowExecutionRequest.reset_request:type_name -> temporal.api.workflowservice.v1.ResetWorkflowExecutionRequest
+	216, // 107: temporal.server.api.historyservice.v1.RequestCancelWorkflowExecutionRequest.cancel_request:type_name -> temporal.api.workflowservice.v1.RequestCancelWorkflowExecutionRequest
+	186, // 108: temporal.server.api.historyservice.v1.RequestCancelWorkflowExecutionRequest.external_workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	186, // 109: temporal.server.api.historyservice.v1.ScheduleWorkflowTaskRequest.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	182, // 110: temporal.server.api.historyservice.v1.ScheduleWorkflowTaskRequest.child_clock:type_name -> temporal.server.api.clock.v1.VectorClock
+	182, // 111: temporal.server.api.historyservice.v1.ScheduleWorkflowTaskRequest.parent_clock:type_name -> temporal.server.api.clock.v1.VectorClock
+	186, // 112: temporal.server.api.historyservice.v1.VerifyFirstWorkflowTaskScheduledRequest.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	182, // 113: temporal.server.api.historyservice.v1.VerifyFirstWorkflowTaskScheduledRequest.clock:type_name -> temporal.server.api.clock.v1.VectorClock
+	186, // 114: temporal.server.api.historyservice.v1.RecordChildExecutionCompletedRequest.parent_execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	186, // 115: temporal.server.api.historyservice.v1.RecordChildExecutionCompletedRequest.child_execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	202, // 116: temporal.server.api.historyservice.v1.RecordChildExecutionCompletedRequest.completion_event:type_name -> temporal.api.history.v1.HistoryEvent
+	182, // 117: temporal.server.api.historyservice.v1.RecordChildExecutionCompletedRequest.clock:type_name -> temporal.server.api.clock.v1.VectorClock
+	186, // 118: temporal.server.api.historyservice.v1.VerifyChildExecutionCompletionRecordedRequest.parent_execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	186, // 119: temporal.server.api.historyservice.v1.VerifyChildExecutionCompletionRecordedRequest.child_execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	182, // 120: temporal.server.api.historyservice.v1.VerifyChildExecutionCompletionRecordedRequest.clock:type_name -> temporal.server.api.clock.v1.VectorClock
+	217, // 121: temporal.server.api.historyservice.v1.DescribeWorkflowExecutionRequest.request:type_name -> temporal.api.workflowservice.v1.DescribeWorkflowExecutionRequest
+	218, // 122: temporal.server.api.historyservice.v1.DescribeWorkflowExecutionResponse.execution_config:type_name -> temporal.api.workflow.v1.WorkflowExecutionConfig
+	219, // 123: temporal.server.api.historyservice.v1.DescribeWorkflowExecutionResponse.workflow_execution_info:type_name -> temporal.api.workflow.v1.WorkflowExecutionInfo
+	220, // 124: temporal.server.api.historyservice.v1.DescribeWorkflowExecutionResponse.pending_activities:type_name -> temporal.api.workflow.v1.PendingActivityInfo
+	221, // 125: temporal.server.api.historyservice.v1.DescribeWorkflowExecutionResponse.pending_children:type_name -> temporal.api.workflow.v1.PendingChildExecutionInfo
+	222, // 126: temporal.server.api.historyservice.v1.DescribeWorkflowExecutionResponse.pending_workflow_task:type_name -> temporal.api.workflow.v1.PendingWorkflowTaskInfo
+	223, // 127: temporal.server.api.historyservice.v1.DescribeWorkflowExecutionResponse.callbacks:type_name -> temporal.api.workflow.v1.CallbackInfo
+	224, // 128: temporal.server.api.historyservice.v1.DescribeWorkflowExecutionResponse.pending_nexus_operations:type_name -> temporal.api.workflow.v1.PendingNexusOperationInfo
+	225, // 129: temporal.server.api.historyservice.v1.DescribeWorkflowExecutionResponse.workflow_extended_info:type_name -> temporal.api.workflow.v1.WorkflowExecutionExtendedInfo
+	186, // 130: temporal.server.api.historyservice.v1.ReplicateEventsV2Request.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	187, // 131: temporal.server.api.historyservice.v1.ReplicateEventsV2Request.version_history_items:type_name -> temporal.server.api.history.v1.VersionHistoryItem
+	226, // 132: temporal.server.api.historyservice.v1.ReplicateEventsV2Request.events:type_name -> temporal.api.common.v1.DataBlob
+	226, // 133: temporal.server.api.historyservice.v1.ReplicateEventsV2Request.new_run_events:type_name -> temporal.api.common.v1.DataBlob
+	227, // 134: temporal.server.api.historyservice.v1.ReplicateEventsV2Request.base_execution_info:type_name -> temporal.server.api.workflow.v1.BaseExecutionInfo
+	228, // 135: temporal.server.api.historyservice.v1.ReplicateWorkflowStateRequest.workflow_state:type_name -> temporal.server.api.persistence.v1.WorkflowMutableState
+	171, // 136: temporal.server.api.historyservice.v1.SyncShardStatusRequest.status_time:type_name -> google.protobuf.Timestamp
+	171, // 137: temporal.server.api.historyservice.v1.SyncActivityRequest.scheduled_time:type_name -> google.protobuf.Timestamp
+	171, // 138: temporal.server.api.historyservice.v1.SyncActivityRequest.started_time:type_name -> google.protobuf.Timestamp
+	171, // 139: temporal.server.api.historyservice.v1.SyncActivityRequest.last_heartbeat_time:type_name -> google.protobuf.Timestamp
+	174, // 140: temporal.server.api.historyservice.v1.SyncActivityRequest.details:type_name -> temporal.api.common.v1.Payloads
+	173, // 141: temporal.server.api.historyservice.v1.SyncActivityRequest.last_failure:type_name -> temporal.api.failure.v1.Failure
+	229, // 142: temporal.server.api.historyservice.v1.SyncActivityRequest.version_history:type_name -> temporal.server.api.history.v1.VersionHistory
+	227, // 143: temporal.server.api.historyservice.v1.SyncActivityRequest.base_execution_info:type_name -> temporal.server.api.workflow.v1.BaseExecutionInfo
+	171, // 144: temporal.server.api.historyservice.v1.SyncActivityRequest.first_scheduled_time:type_name -> google.protobuf.Timestamp
+	171, // 145: temporal.server.api.historyservice.v1.SyncActivityRequest.last_attempt_complete_time:type_name -> google.protobuf.Timestamp
+	175, // 146: temporal.server.api.historyservice.v1.SyncActivityRequest.retry_initial_interval:type_name -> google.protobuf.Duration
+	175, // 147: temporal.server.api.historyservice.v1.SyncActivityRequest.retry_maximum_interval:type_name -> google.protobuf.Duration
+	64,  // 148: temporal.server.api.historyservice.v1.SyncActivitiesRequest.activities_info:type_name -> temporal.server.api.historyservice.v1.ActivitySyncInfo
+	171, // 149: temporal.server.api.historyservice.v1.ActivitySyncInfo.scheduled_time:type_name -> google.protobuf.Timestamp
+	171, // 150: temporal.server.api.historyservice.v1.ActivitySyncInfo.started_time:type_name -> google.protobuf.Timestamp
+	171, // 151: temporal.server.api.historyservice.v1.ActivitySyncInfo.last_heartbeat_time:type_name -> google.protobuf.Timestamp
+	174, // 152: temporal.server.api.historyservice.v1.ActivitySyncInfo.details:type_name -> temporal.api.common.v1.Payloads
+	173, // 153: temporal.server.api.historyservice.v1.ActivitySyncInfo.last_failure:type_name -> temporal.api.failure.v1.Failure
+	229, // 154: temporal.server.api.historyservice.v1.ActivitySyncInfo.version_history:type_name -> temporal.server.api.history.v1.VersionHistory
+	171, // 155: temporal.server.api.historyservice.v1.ActivitySyncInfo.first_scheduled_time:type_name -> google.protobuf.Timestamp
+	171, // 156: temporal.server.api.historyservice.v1.ActivitySyncInfo.last_attempt_complete_time:type_name -> google.protobuf.Timestamp
+	175, // 157: temporal.server.api.historyservice.v1.ActivitySyncInfo.retry_initial_interval:type_name -> google.protobuf.Duration
+	175, // 158: temporal.server.api.historyservice.v1.ActivitySyncInfo.retry_maximum_interval:type_name -> google.protobuf.Duration
+	186, // 159: temporal.server.api.historyservice.v1.DescribeMutableStateRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	228, // 160: temporal.server.api.historyservice.v1.DescribeMutableStateResponse.cache_mutable_state:type_name -> temporal.server.api.persistence.v1.WorkflowMutableState
+	228, // 161: temporal.server.api.historyservice.v1.DescribeMutableStateResponse.database_mutable_state:type_name -> temporal.server.api.persistence.v1.WorkflowMutableState
+	186, // 162: temporal.server.api.historyservice.v1.DescribeHistoryHostRequest.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	230, // 163: temporal.server.api.historyservice.v1.DescribeHistoryHostResponse.namespace_cache:type_name -> temporal.server.api.namespace.v1.NamespaceCacheInfo
+	231, // 164: temporal.server.api.historyservice.v1.GetShardResponse.shard_info:type_name -> temporal.server.api.persistence.v1.ShardInfo
+	171, // 165: temporal.server.api.historyservice.v1.RemoveTaskRequest.visibility_time:type_name -> google.protobuf.Timestamp
+	232, // 166: temporal.server.api.historyservice.v1.GetReplicationMessagesRequest.tokens:type_name -> temporal.server.api.replication.v1.ReplicationToken
+	164, // 167: temporal.server.api.historyservice.v1.GetReplicationMessagesResponse.shard_messages:type_name -> temporal.server.api.historyservice.v1.GetReplicationMessagesResponse.ShardMessagesEntry
+	233, // 168: temporal.server.api.historyservice.v1.GetDLQReplicationMessagesRequest.task_infos:type_name -> temporal.server.api.replication.v1.ReplicationTaskInfo
+	234, // 169: temporal.server.api.historyservice.v1.GetDLQReplicationMessagesResponse.replication_tasks:type_name -> temporal.server.api.replication.v1.ReplicationTask
+	235, // 170: temporal.server.api.historyservice.v1.QueryWorkflowRequest.request:type_name -> temporal.api.workflowservice.v1.QueryWorkflowRequest
+	236, // 171: temporal.server.api.historyservice.v1.QueryWorkflowResponse.response:type_name -> temporal.api.workflowservice.v1.QueryWorkflowResponse
+	237, // 172: temporal.server.api.historyservice.v1.ReapplyEventsRequest.request:type_name -> temporal.server.api.adminservice.v1.ReapplyEventsRequest
+	238, // 173: temporal.server.api.historyservice.v1.GetDLQMessagesRequest.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
+	238, // 174: temporal.server.api.historyservice.v1.GetDLQMessagesResponse.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
+	234, // 175: temporal.server.api.historyservice.v1.GetDLQMessagesResponse.replication_tasks:type_name -> temporal.server.api.replication.v1.ReplicationTask
+	233, // 176: temporal.server.api.historyservice.v1.GetDLQMessagesResponse.replication_tasks_info:type_name -> temporal.server.api.replication.v1.ReplicationTaskInfo
+	238, // 177: temporal.server.api.historyservice.v1.PurgeDLQMessagesRequest.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
+	238, // 178: temporal.server.api.historyservice.v1.MergeDLQMessagesRequest.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
+	239, // 179: temporal.server.api.historyservice.v1.RefreshWorkflowTasksRequest.request:type_name -> temporal.server.api.adminservice.v1.RefreshWorkflowTasksRequest
+	186, // 180: temporal.server.api.historyservice.v1.GenerateLastHistoryReplicationTasksRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	96,  // 181: temporal.server.api.historyservice.v1.GetReplicationStatusResponse.shards:type_name -> temporal.server.api.historyservice.v1.ShardReplicationStatus
+	171, // 182: temporal.server.api.historyservice.v1.ShardReplicationStatus.shard_local_time:type_name -> google.protobuf.Timestamp
+	165, // 183: temporal.server.api.historyservice.v1.ShardReplicationStatus.remote_clusters:type_name -> temporal.server.api.historyservice.v1.ShardReplicationStatus.RemoteClustersEntry
+	166, // 184: temporal.server.api.historyservice.v1.ShardReplicationStatus.handover_namespaces:type_name -> temporal.server.api.historyservice.v1.ShardReplicationStatus.HandoverNamespacesEntry
+	171, // 185: temporal.server.api.historyservice.v1.ShardReplicationStatus.max_replication_task_visibility_time:type_name -> google.protobuf.Timestamp
+	171, // 186: temporal.server.api.historyservice.v1.ShardReplicationStatusPerCluster.acked_task_visibility_time:type_name -> google.protobuf.Timestamp
+	186, // 187: temporal.server.api.historyservice.v1.RebuildMutableStateRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	186, // 188: temporal.server.api.historyservice.v1.ImportWorkflowExecutionRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	226, // 189: temporal.server.api.historyservice.v1.ImportWorkflowExecutionRequest.history_batches:type_name -> temporal.api.common.v1.DataBlob
+	229, // 190: temporal.server.api.historyservice.v1.ImportWorkflowExecutionRequest.version_history:type_name -> temporal.server.api.history.v1.VersionHistory
+	186, // 191: temporal.server.api.historyservice.v1.DeleteWorkflowVisibilityRecordRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	171, // 192: temporal.server.api.historyservice.v1.DeleteWorkflowVisibilityRecordRequest.workflow_start_time:type_name -> google.protobuf.Timestamp
+	171, // 193: temporal.server.api.historyservice.v1.DeleteWorkflowVisibilityRecordRequest.workflow_close_time:type_name -> google.protobuf.Timestamp
+	240, // 194: temporal.server.api.historyservice.v1.UpdateWorkflowExecutionRequest.request:type_name -> temporal.api.workflowservice.v1.UpdateWorkflowExecutionRequest
+	241, // 195: temporal.server.api.historyservice.v1.UpdateWorkflowExecutionResponse.response:type_name -> temporal.api.workflowservice.v1.UpdateWorkflowExecutionResponse
+	242, // 196: temporal.server.api.historyservice.v1.StreamWorkflowReplicationMessagesRequest.sync_replication_state:type_name -> temporal.server.api.replication.v1.SyncReplicationState
+	243, // 197: temporal.server.api.historyservice.v1.StreamWorkflowReplicationMessagesResponse.messages:type_name -> temporal.server.api.replication.v1.WorkflowReplicationMessages
+	244, // 198: temporal.server.api.historyservice.v1.PollWorkflowExecutionUpdateRequest.request:type_name -> temporal.api.workflowservice.v1.PollWorkflowExecutionUpdateRequest
+	245, // 199: temporal.server.api.historyservice.v1.PollWorkflowExecutionUpdateResponse.response:type_name -> temporal.api.workflowservice.v1.PollWorkflowExecutionUpdateResponse
+	246, // 200: temporal.server.api.historyservice.v1.GetWorkflowExecutionHistoryRequest.request:type_name -> temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryRequest
+	247, // 201: temporal.server.api.historyservice.v1.GetWorkflowExecutionHistoryResponse.response:type_name -> temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse
+	200, // 202: temporal.server.api.historyservice.v1.GetWorkflowExecutionHistoryResponse.history:type_name -> temporal.api.history.v1.History
+	247, // 203: temporal.server.api.historyservice.v1.GetWorkflowExecutionHistoryResponseWithRaw.response:type_name -> temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse
+	248, // 204: temporal.server.api.historyservice.v1.GetWorkflowExecutionHistoryReverseRequest.request:type_name -> temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryReverseRequest
+	249, // 205: temporal.server.api.historyservice.v1.GetWorkflowExecutionHistoryReverseResponse.response:type_name -> temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryReverseResponse
+	250, // 206: temporal.server.api.historyservice.v1.GetWorkflowExecutionRawHistoryV2Request.request:type_name -> temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryV2Request
+	251, // 207: temporal.server.api.historyservice.v1.GetWorkflowExecutionRawHistoryV2Response.response:type_name -> temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryV2Response
+	252, // 208: temporal.server.api.historyservice.v1.GetWorkflowExecutionRawHistoryRequest.request:type_name -> temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryRequest
+	253, // 209: temporal.server.api.historyservice.v1.GetWorkflowExecutionRawHistoryResponse.response:type_name -> temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryResponse
+	254, // 210: temporal.server.api.historyservice.v1.ForceDeleteWorkflowExecutionRequest.request:type_name -> temporal.server.api.adminservice.v1.DeleteWorkflowExecutionRequest
+	255, // 211: temporal.server.api.historyservice.v1.ForceDeleteWorkflowExecutionResponse.response:type_name -> temporal.server.api.adminservice.v1.DeleteWorkflowExecutionResponse
+	256, // 212: temporal.server.api.historyservice.v1.GetDLQTasksRequest.dlq_key:type_name -> temporal.server.api.common.v1.HistoryDLQKey
+	257, // 213: temporal.server.api.historyservice.v1.GetDLQTasksResponse.dlq_tasks:type_name -> temporal.server.api.common.v1.HistoryDLQTask
+	256, // 214: temporal.server.api.historyservice.v1.DeleteDLQTasksRequest.dlq_key:type_name -> temporal.server.api.common.v1.HistoryDLQKey
+	258, // 215: temporal.server.api.historyservice.v1.DeleteDLQTasksRequest.inclusive_max_task_metadata:type_name -> temporal.server.api.common.v1.HistoryDLQTaskMetadata
+	167, // 216: temporal.server.api.historyservice.v1.ListQueuesResponse.queues:type_name -> temporal.server.api.historyservice.v1.ListQueuesResponse.QueueInfo
+	168, // 217: temporal.server.api.historyservice.v1.AddTasksRequest.tasks:type_name -> temporal.server.api.historyservice.v1.AddTasksRequest.Task
+	259, // 218: temporal.server.api.historyservice.v1.ListTasksRequest.request:type_name -> temporal.server.api.adminservice.v1.ListHistoryTasksRequest
+	260, // 219: temporal.server.api.historyservice.v1.ListTasksResponse.response:type_name -> temporal.server.api.adminservice.v1.ListHistoryTasksResponse
+	261, // 220: temporal.server.api.historyservice.v1.CompleteNexusOperationChasmRequest.completion:type_name -> temporal.server.api.token.v1.NexusOperationCompletion
+	262, // 221: temporal.server.api.historyservice.v1.CompleteNexusOperationChasmRequest.success:type_name -> temporal.api.common.v1.Payload
+	173, // 222: temporal.server.api.historyservice.v1.CompleteNexusOperationChasmRequest.failure:type_name -> temporal.api.failure.v1.Failure
+	171, // 223: temporal.server.api.historyservice.v1.CompleteNexusOperationChasmRequest.close_time:type_name -> google.protobuf.Timestamp
+	185, // 224: temporal.server.api.historyservice.v1.CompleteNexusOperationChasmRequest.links:type_name -> temporal.api.common.v1.Link
+	171, // 225: temporal.server.api.historyservice.v1.CompleteNexusOperationChasmRequest.start_time:type_name -> google.protobuf.Timestamp
+	261, // 226: temporal.server.api.historyservice.v1.CompleteNexusOperationRequest.completion:type_name -> temporal.server.api.token.v1.NexusOperationCompletion
+	262, // 227: temporal.server.api.historyservice.v1.CompleteNexusOperationRequest.success:type_name -> temporal.api.common.v1.Payload
+	263, // 228: temporal.server.api.historyservice.v1.CompleteNexusOperationRequest.failure:type_name -> temporal.api.nexus.v1.Failure
+	171, // 229: temporal.server.api.historyservice.v1.CompleteNexusOperationRequest.start_time:type_name -> google.protobuf.Timestamp
+	185, // 230: temporal.server.api.historyservice.v1.CompleteNexusOperationRequest.links:type_name -> temporal.api.common.v1.Link
+	264, // 231: temporal.server.api.historyservice.v1.InvokeStateMachineMethodRequest.ref:type_name -> temporal.server.api.persistence.v1.StateMachineRef
+	265, // 232: temporal.server.api.historyservice.v1.DeepHealthCheckResponse.state:type_name -> temporal.server.api.enums.v1.HealthState
+	266, // 233: temporal.server.api.historyservice.v1.DeepHealthCheckResponse.checks:type_name -> temporal.server.api.health.v1.HealthCheck
+	186, // 234: temporal.server.api.historyservice.v1.SyncWorkflowStateRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	188, // 235: temporal.server.api.historyservice.v1.SyncWorkflowStateRequest.versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	192, // 236: temporal.server.api.historyservice.v1.SyncWorkflowStateRequest.version_histories:type_name -> temporal.server.api.history.v1.VersionHistories
+	267, // 237: temporal.server.api.historyservice.v1.SyncWorkflowStateResponse.versioned_transition_artifact:type_name -> temporal.server.api.replication.v1.VersionedTransitionArtifact
+	268, // 238: temporal.server.api.historyservice.v1.UpdateActivityOptionsRequest.update_request:type_name -> temporal.api.workflowservice.v1.UpdateActivityOptionsRequest
+	269, // 239: temporal.server.api.historyservice.v1.UpdateActivityOptionsResponse.activity_options:type_name -> temporal.api.activity.v1.ActivityOptions
+	270, // 240: temporal.server.api.historyservice.v1.PauseActivityRequest.frontend_request:type_name -> temporal.api.workflowservice.v1.PauseActivityRequest
+	271, // 241: temporal.server.api.historyservice.v1.UnpauseActivityRequest.frontend_request:type_name -> temporal.api.workflowservice.v1.UnpauseActivityRequest
+	272, // 242: temporal.server.api.historyservice.v1.ResetActivityRequest.frontend_request:type_name -> temporal.api.workflowservice.v1.ResetActivityRequest
+	273, // 243: temporal.server.api.historyservice.v1.UpdateWorkflowExecutionOptionsRequest.update_request:type_name -> temporal.api.workflowservice.v1.UpdateWorkflowExecutionOptionsRequest
+	274, // 244: temporal.server.api.historyservice.v1.UpdateWorkflowExecutionOptionsResponse.workflow_execution_options:type_name -> temporal.api.workflow.v1.WorkflowExecutionOptions
+	275, // 245: temporal.server.api.historyservice.v1.PauseWorkflowExecutionRequest.pause_request:type_name -> temporal.api.workflowservice.v1.PauseWorkflowExecutionRequest
+	276, // 246: temporal.server.api.historyservice.v1.UnpauseWorkflowExecutionRequest.unpause_request:type_name -> temporal.api.workflowservice.v1.UnpauseWorkflowExecutionRequest
+	277, // 247: temporal.server.api.historyservice.v1.StartNexusOperationRequest.request:type_name -> temporal.api.nexus.v1.StartOperationRequest
+	278, // 248: temporal.server.api.historyservice.v1.StartNexusOperationResponse.response:type_name -> temporal.api.nexus.v1.StartOperationResponse
+	279, // 249: temporal.server.api.historyservice.v1.CancelNexusOperationRequest.request:type_name -> temporal.api.nexus.v1.CancelOperationRequest
+	280, // 250: temporal.server.api.historyservice.v1.CancelNexusOperationResponse.response:type_name -> temporal.api.nexus.v1.CancelOperationResponse
+	1,   // 251: temporal.server.api.historyservice.v1.ExecuteMultiOperationRequest.Operation.start_workflow:type_name -> temporal.server.api.historyservice.v1.StartWorkflowExecutionRequest
+	105, // 252: temporal.server.api.historyservice.v1.ExecuteMultiOperationRequest.Operation.update_workflow:type_name -> temporal.server.api.historyservice.v1.UpdateWorkflowExecutionRequest
+	2,   // 253: temporal.server.api.historyservice.v1.ExecuteMultiOperationResponse.Response.start_workflow:type_name -> temporal.server.api.historyservice.v1.StartWorkflowExecutionResponse
+	106, // 254: temporal.server.api.historyservice.v1.ExecuteMultiOperationResponse.Response.update_workflow:type_name -> temporal.server.api.historyservice.v1.UpdateWorkflowExecutionResponse
+	281, // 255: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponse.QueriesEntry.value:type_name -> temporal.api.query.v1.WorkflowQuery
+	281, // 256: temporal.server.api.historyservice.v1.RecordWorkflowTaskStartedResponseWithRawHistory.QueriesEntry.value:type_name -> temporal.api.query.v1.WorkflowQuery
+	282, // 257: temporal.server.api.historyservice.v1.GetReplicationMessagesResponse.ShardMessagesEntry.value:type_name -> temporal.server.api.replication.v1.ReplicationMessages
+	98,  // 258: temporal.server.api.historyservice.v1.ShardReplicationStatus.RemoteClustersEntry.value:type_name -> temporal.server.api.historyservice.v1.ShardReplicationStatusPerCluster
+	97,  // 259: temporal.server.api.historyservice.v1.ShardReplicationStatus.HandoverNamespacesEntry.value:type_name -> temporal.server.api.historyservice.v1.HandoverNamespaceInfo
+	226, // 260: temporal.server.api.historyservice.v1.AddTasksRequest.Task.blob:type_name -> temporal.api.common.v1.DataBlob
+	283, // 261: temporal.server.api.historyservice.v1.routing:extendee -> google.protobuf.MessageOptions
+	0,   // 262: temporal.server.api.historyservice.v1.routing:type_name -> temporal.server.api.historyservice.v1.RoutingOptions
+	263, // [263:263] is the sub-list for method output_type
+	263, // [263:263] is the sub-list for method input_type
+	262, // [262:263] is the sub-list for extension type_name
+	261, // [261:262] is the sub-list for extension extendee
+	0,   // [0:261] is the sub-list for field type_name
 }
 
 func init() { file_temporal_server_api_historyservice_v1_request_response_proto_init() }

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
-	go.temporal.io/api v1.62.11-0.20260424170946-a466cbfca93f
+	go.temporal.io/api v1.62.12-0.20260424184119-9015efabce8d
 	go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2
 	go.temporal.io/sdk v1.41.1
 	go.uber.org/fx v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -469,8 +469,8 @@ go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0 h1:R
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0/go.mod h1:I89cynRj8y+383o7tEQVg2SVA6SRgDVIouWPUVXjx0U=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0 h1:CQvJSldHRUN6Z8jsUeYv8J0lXRvygALXIzsmAeCcZE0=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0/go.mod h1:xSQ+mEfJe/GjK1LXEyVOoSI1N9JV9ZI923X5kup43W4=
-go.temporal.io/api v1.62.11-0.20260424170946-a466cbfca93f h1:/x+K4EoJ6GI9NUsTrvU0OPzF4OeVyKIB84z9ZeA247I=
-go.temporal.io/api v1.62.11-0.20260424170946-a466cbfca93f/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
+go.temporal.io/api v1.62.12-0.20260424184119-9015efabce8d h1:On7TmNeQ/mm1fxkXCn2Aqqf9Sy8GgcKPJUZunqA7Wpo=
+go.temporal.io/api v1.62.12-0.20260424184119-9015efabce8d/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2 h1:1hKeH3GyR6YD6LKMHGCZ76t6h1Sgha0hXVQBxWi3dlQ=
 go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2/go.mod h1:T8dnzVPeO+gaUTj9eDgm/lT2lZH4+JXNvrGaQGyVi50=
 go.temporal.io/sdk v1.41.1 h1:yOpvsHyDD1lNuwlGBv/SUodCPhjv9nDeC9lLHW/fJUA=

--- a/proto/internal/temporal/server/api/historyservice/v1/request_response.proto
+++ b/proto/internal/temporal/server/api/historyservice/v1/request_response.proto
@@ -104,6 +104,11 @@ message StartWorkflowExecutionRequest {
   // directly from the started event. Written onto the new run's
   // WorkflowExecutionStartedEvent.
   temporal.api.history.v1.DeclinedTargetVersionUpgrade declined_target_version_upgrade = 17;
+
+  // If a workflow execution is started by a previous execution (parent-child workflow or continue-as-new)
+  // that has already skipped some time, the accumulated skipped duration from that execution
+  // can be passed to the new workflow execution through this field.
+  google.protobuf.Duration initial_skipped_duration = 18;
 }
 
 message StartWorkflowExecutionResponse {

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -734,14 +734,6 @@ func (wh *WorkflowHandler) validateTimeSkippingConfig(
 					namespace.MinTimeSkippingDuration,
 				)
 			}
-		// todo: need to adapt the timeSource after time-skipping timeSource is implemented
-		case *workflowpb.TimeSkippingConfig_MaxTargetTime:
-			if bound.MaxTargetTime.AsTime().Before(wh.namespaceHandler.timeSource.Now().Add(namespace.MinTimeSkippingDuration)) {
-				return serviceerror.NewInvalidArgumentf(
-					"Max target time must be at least %s from current time of the workflow",
-					namespace.MinTimeSkippingDuration,
-				)
-			}
 		default:
 			return serviceerror.NewInvalidArgumentf("unsupported time skipping bound type: %T", bound)
 		}

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -3296,17 +3296,6 @@ func (s *WorkflowHandlerSuite) TestValidateTimeSkippingConfig() {
 		Bound:   &workflowpb.TimeSkippingConfig_MaxElapsedDuration{MaxElapsedDuration: durationpb.New(namespace.MinTimeSkippingDuration)},
 	}, s.testNamespace))
 
-	// MaxTargetTime less than 1 minute from now is rejected
-	s.Require().ErrorAs(wh.validateTimeSkippingConfig(&workflowpb.TimeSkippingConfig{
-		Enabled: true,
-		Bound:   &workflowpb.TimeSkippingConfig_MaxTargetTime{MaxTargetTime: timestamppb.New(time.Now().Add(halfMinDuration))},
-	}, s.testNamespace), &invalidArgumentErr)
-
-	// MaxTargetTime well beyond 1 minute from now is valid
-	s.Require().NoError(wh.validateTimeSkippingConfig(&workflowpb.TimeSkippingConfig{
-		Enabled: true,
-		Bound:   &workflowpb.TimeSkippingConfig_MaxTargetTime{MaxTargetTime: timestamppb.New(time.Now().Add(2 * namespace.MinTimeSkippingDuration))},
-	}, s.testNamespace))
 }
 
 // TestExecuteMultiOperation_TimeSkipping_DCDisabled verifies that when the DC gate is off,

--- a/service/history/api/updateworkflowoptions/api.go
+++ b/service/history/api/updateworkflowoptions/api.go
@@ -251,13 +251,6 @@ func mergeWorkflowExecutionOptions(
 		mergeInto.TimeSkippingConfig.Enabled = mergeFrom.GetTimeSkippingConfig().GetEnabled()
 	}
 
-	if _, ok := updateFields["timeSkippingConfig.disablePropagation"]; ok {
-		if mergeInto.TimeSkippingConfig == nil {
-			mergeInto.TimeSkippingConfig = &workflowpb.TimeSkippingConfig{}
-		}
-		mergeInto.TimeSkippingConfig.DisablePropagation = mergeFrom.GetTimeSkippingConfig().GetDisablePropagation()
-	}
-
 	if _, ok := updateFields["timeSkippingConfig.maxSkippedDuration"]; ok {
 		if mergeInto.TimeSkippingConfig == nil {
 			mergeInto.TimeSkippingConfig = &workflowpb.TimeSkippingConfig{}

--- a/service/history/api/updateworkflowoptions/api.go
+++ b/service/history/api/updateworkflowoptions/api.go
@@ -269,14 +269,5 @@ func mergeWorkflowExecutionOptions(
 		}
 	}
 
-	if _, ok := updateFields["timeSkippingConfig.maxTargetTime"]; ok {
-		if mergeInto.TimeSkippingConfig == nil {
-			mergeInto.TimeSkippingConfig = &workflowpb.TimeSkippingConfig{}
-		}
-		mergeInto.TimeSkippingConfig.Bound = &workflowpb.TimeSkippingConfig_MaxTargetTime{
-			MaxTargetTime: mergeFrom.GetTimeSkippingConfig().GetMaxTargetTime(),
-		}
-	}
-
 	return mergeInto, nil
 }

--- a/service/history/api/updateworkflowoptions/api_test.go
+++ b/service/history/api/updateworkflowoptions/api_test.go
@@ -348,10 +348,9 @@ func TestMergeAndApply_TimeSkippingConfig(t *testing.T) {
 		expectedConfig *workflowpb.TimeSkippingConfig
 	}{
 		{
-			name: "update max_skipped_duration preserves enabled and disable_propagation",
+			name: "update max_skipped_duration preserves enabled",
 			initialConfig: &workflowpb.TimeSkippingConfig{
-				Enabled:            true,
-				DisablePropagation: true,
+				Enabled: true,
 				Bound: &workflowpb.TimeSkippingConfig_MaxSkippedDuration{
 					MaxSkippedDuration: oneHour,
 				},
@@ -365,8 +364,7 @@ func TestMergeAndApply_TimeSkippingConfig(t *testing.T) {
 			},
 			updateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.max_skipped_duration"}},
 			expectedConfig: &workflowpb.TimeSkippingConfig{
-				Enabled:            true,
-				DisablePropagation: true,
+				Enabled: true,
 				Bound: &workflowpb.TimeSkippingConfig_MaxSkippedDuration{
 					MaxSkippedDuration: twoHours,
 				},

--- a/service/history/api/updateworkflowoptions/api_test.go
+++ b/service/history/api/updateworkflowoptions/api_test.go
@@ -30,7 +30,6 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type noopVersionCache struct{}
@@ -338,7 +337,6 @@ func TestMergeAndApply_TimeSkippingConfig(t *testing.T) {
 	oneHour := durationpb.New(time.Hour)
 	twoHours := durationpb.New(2 * time.Hour)
 	thirtyMin := durationpb.New(30 * time.Minute)
-	targetTime := timestamppb.New(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 
 	testCases := []struct {
 		name           string
@@ -410,29 +408,6 @@ func TestMergeAndApply_TimeSkippingConfig(t *testing.T) {
 			},
 			updateMask:     &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.enabled"}},
 			expectedConfig: &workflowpb.TimeSkippingConfig{Enabled: false},
-		},
-		{
-			name: "change bound type to max_target_time preserves enabled",
-			initialConfig: &workflowpb.TimeSkippingConfig{
-				Enabled: true,
-				Bound: &workflowpb.TimeSkippingConfig_MaxSkippedDuration{
-					MaxSkippedDuration: oneHour,
-				},
-			},
-			updateOptions: &workflowpb.WorkflowExecutionOptions{
-				TimeSkippingConfig: &workflowpb.TimeSkippingConfig{
-					Bound: &workflowpb.TimeSkippingConfig_MaxTargetTime{
-						MaxTargetTime: targetTime,
-					},
-				},
-			},
-			updateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.max_target_time"}},
-			expectedConfig: &workflowpb.TimeSkippingConfig{
-				Enabled: true,
-				Bound: &workflowpb.TimeSkippingConfig_MaxTargetTime{
-					MaxTargetTime: targetTime,
-				},
-			},
 		},
 	}
 

--- a/service/history/historybuilder/event_factory.go
+++ b/service/history/historybuilder/event_factory.go
@@ -88,6 +88,9 @@ func (b *EventFactory) CreateWorkflowExecutionStartedEvent(
 	if req.TimeSkippingConfig != nil {
 		attributes.TimeSkippingConfig = req.TimeSkippingConfig
 	}
+	if request.GetInitialSkippedDuration() != nil {
+		attributes.InitialSkippedDuration = request.GetInitialSkippedDuration()
+	}
 
 	parentInfo := request.ParentExecutionInfo
 	if parentInfo != nil {
@@ -841,6 +844,7 @@ func (b *EventFactory) CreateStartChildWorkflowExecutionInitiatedEvent(
 	command *commandpb.StartChildWorkflowExecutionCommandAttributes,
 	targetNamespaceID namespace.ID,
 	timeSkippingConfig *workflowpb.TimeSkippingConfig,
+	initialSkippedDuration *durationpb.Duration,
 ) *historypb.HistoryEvent {
 	event := b.createHistoryEvent(enumspb.EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED, b.timeSource.Now())
 	event.Attributes = &historypb.HistoryEvent_StartChildWorkflowExecutionInitiatedEventAttributes{
@@ -863,12 +867,13 @@ func (b *EventFactory) CreateStartChildWorkflowExecutionInitiatedEvent(
 			// Filter nil values here rather than in the API layer because not all
 			// creation paths go through the frontend (continue-as-new, child workflows, replication).
 			// This CaN event is created on the parent workflow, so we need to filter nil values here.
-			Memo:               payload.FilterNilMemo(command.Memo),
-			SearchAttributes:   payload.FilterNilSearchAttributes(command.SearchAttributes),
-			ParentClosePolicy:  command.GetParentClosePolicy(),
-			InheritBuildId:     command.InheritBuildId, //nolint:staticcheck // SA1019: worker versioning v0.2
-			Priority:           command.Priority,
-			TimeSkippingConfig: timeSkippingConfig,
+			Memo:                   payload.FilterNilMemo(command.Memo),
+			SearchAttributes:       payload.FilterNilSearchAttributes(command.SearchAttributes),
+			ParentClosePolicy:      command.GetParentClosePolicy(),
+			InheritBuildId:         command.InheritBuildId, //nolint:staticcheck // SA1019: worker versioning v0.2
+			Priority:               command.Priority,
+			TimeSkippingConfig:     timeSkippingConfig,
+			InitialSkippedDuration: initialSkippedDuration,
 		},
 	}
 	return event

--- a/service/history/historybuilder/event_factory.go
+++ b/service/history/historybuilder/event_factory.go
@@ -840,6 +840,7 @@ func (b *EventFactory) CreateStartChildWorkflowExecutionInitiatedEvent(
 	workflowTaskCompletedEventID int64,
 	command *commandpb.StartChildWorkflowExecutionCommandAttributes,
 	targetNamespaceID namespace.ID,
+	timeSkippingConfig *workflowpb.TimeSkippingConfig,
 ) *historypb.HistoryEvent {
 	event := b.createHistoryEvent(enumspb.EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED, b.timeSource.Now())
 	event.Attributes = &historypb.HistoryEvent_StartChildWorkflowExecutionInitiatedEventAttributes{
@@ -862,11 +863,12 @@ func (b *EventFactory) CreateStartChildWorkflowExecutionInitiatedEvent(
 			// Filter nil values here rather than in the API layer because not all
 			// creation paths go through the frontend (continue-as-new, child workflows, replication).
 			// This CaN event is created on the parent workflow, so we need to filter nil values here.
-			Memo:              payload.FilterNilMemo(command.Memo),
-			SearchAttributes:  payload.FilterNilSearchAttributes(command.SearchAttributes),
-			ParentClosePolicy: command.GetParentClosePolicy(),
-			InheritBuildId:    command.InheritBuildId, //nolint:staticcheck // SA1019: worker versioning v0.2
-			Priority:          command.Priority,
+			Memo:               payload.FilterNilMemo(command.Memo),
+			SearchAttributes:   payload.FilterNilSearchAttributes(command.SearchAttributes),
+			ParentClosePolicy:  command.GetParentClosePolicy(),
+			InheritBuildId:     command.InheritBuildId, //nolint:staticcheck // SA1019: worker versioning v0.2
+			Priority:           command.Priority,
+			TimeSkippingConfig: timeSkippingConfig,
 		},
 	}
 	return event

--- a/service/history/historybuilder/history_builder.go
+++ b/service/history/historybuilder/history_builder.go
@@ -770,11 +770,13 @@ func (b *HistoryBuilder) AddStartChildWorkflowExecutionInitiatedEvent(
 	workflowTaskCompletedEventID int64,
 	command *commandpb.StartChildWorkflowExecutionCommandAttributes,
 	targetNamespaceID namespace.ID,
+	timeSkippingConfig *workflowpb.TimeSkippingConfig,
 ) *historypb.HistoryEvent {
 	event := b.EventFactory.CreateStartChildWorkflowExecutionInitiatedEvent(
 		workflowTaskCompletedEventID,
 		command,
 		targetNamespaceID,
+		timeSkippingConfig,
 	)
 	event, _ = b.EventStore.add(event)
 	return event

--- a/service/history/historybuilder/history_builder.go
+++ b/service/history/historybuilder/history_builder.go
@@ -771,12 +771,14 @@ func (b *HistoryBuilder) AddStartChildWorkflowExecutionInitiatedEvent(
 	command *commandpb.StartChildWorkflowExecutionCommandAttributes,
 	targetNamespaceID namespace.ID,
 	timeSkippingConfig *workflowpb.TimeSkippingConfig,
+	initialSkippedDuration *durationpb.Duration,
 ) *historypb.HistoryEvent {
 	event := b.EventFactory.CreateStartChildWorkflowExecutionInitiatedEvent(
 		workflowTaskCompletedEventID,
 		command,
 		targetNamespaceID,
 		timeSkippingConfig,
+		initialSkippedDuration,
 	)
 	event, _ = b.EventStore.add(event)
 	return event

--- a/service/history/historybuilder/history_builder_categorization_test.go
+++ b/service/history/historybuilder/history_builder_categorization_test.go
@@ -1479,7 +1479,7 @@ func (s *sutTestingAdapter) AddWorkflowExecutionSignaledEvent(_ ...eventConfig) 
 
 func (s *sutTestingAdapter) AddStartChildWorkflowExecutionInitiatedEvent(_ ...eventConfig) *historypb.HistoryEvent {
 	attrs := &commandpb.StartChildWorkflowExecutionCommandAttributes{}
-	return s.HistoryBuilder.AddStartChildWorkflowExecutionInitiatedEvent(64, attrs, namespace.ID("ns-target"), nil)
+	return s.HistoryBuilder.AddStartChildWorkflowExecutionInitiatedEvent(64, attrs, namespace.ID("ns-target"), nil, nil)
 }
 
 func (s *sutTestingAdapter) AddChildWorkflowExecutionStartedEvent(optionalConfig ...eventConfig) *historypb.HistoryEvent {

--- a/service/history/historybuilder/history_builder_categorization_test.go
+++ b/service/history/historybuilder/history_builder_categorization_test.go
@@ -1479,7 +1479,7 @@ func (s *sutTestingAdapter) AddWorkflowExecutionSignaledEvent(_ ...eventConfig) 
 
 func (s *sutTestingAdapter) AddStartChildWorkflowExecutionInitiatedEvent(_ ...eventConfig) *historypb.HistoryEvent {
 	attrs := &commandpb.StartChildWorkflowExecutionCommandAttributes{}
-	return s.HistoryBuilder.AddStartChildWorkflowExecutionInitiatedEvent(64, attrs, namespace.ID("ns-target"))
+	return s.HistoryBuilder.AddStartChildWorkflowExecutionInitiatedEvent(64, attrs, namespace.ID("ns-target"), nil)
 }
 
 func (s *sutTestingAdapter) AddChildWorkflowExecutionStartedEvent(optionalConfig ...eventConfig) *historypb.HistoryEvent {

--- a/service/history/historybuilder/history_builder_test.go
+++ b/service/history/historybuilder/history_builder_test.go
@@ -1363,6 +1363,7 @@ func (s *historyBuilderSuite) TestStartChildWorkflowExecutionInitiated() {
 		workflowTaskCompletionEventID,
 		attributes,
 		testNamespaceID,
+		nil,
 	)
 	s.Equal(event, s.flush())
 	s.Equal(&historypb.HistoryEvent{
@@ -2566,6 +2567,7 @@ func (s *historyBuilderSuite) TestStartChildWorkflowExecutionInitiated_NilSearch
 		rand.Int63(),
 		command,
 		testNamespaceID,
+		nil,
 	)
 
 	// Verify that nil search attributes are filtered out

--- a/service/history/historybuilder/history_builder_test.go
+++ b/service/history/historybuilder/history_builder_test.go
@@ -1364,6 +1364,7 @@ func (s *historyBuilderSuite) TestStartChildWorkflowExecutionInitiated() {
 		attributes,
 		testNamespaceID,
 		nil,
+		nil,
 	)
 	s.Equal(event, s.flush())
 	s.Equal(&historypb.HistoryEvent{
@@ -2567,6 +2568,7 @@ func (s *historyBuilderSuite) TestStartChildWorkflowExecutionInitiated_NilSearch
 		rand.Int63(),
 		command,
 		testNamespaceID,
+		nil,
 		nil,
 	)
 

--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -1667,6 +1667,7 @@ func (t *transferQueueActiveTaskExecutor) startWorkflow(
 	request.SourceVersionStamp = sourceVersionStamp
 	request.InheritedBuildId = inheritedBuildId
 	request.InheritedPinnedVersion = inheritedPinnedVersion
+	request.InitialSkippedDuration = attributes.GetInitialSkippedDuration()
 
 	// Only set the AutoUpgrade info if the Pinned version is not set.
 	if request.InheritedPinnedVersion == nil {

--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -1643,6 +1643,7 @@ func (t *transferQueueActiveTaskExecutor) startWorkflow(
 		UserMetadata:             userMetadata,
 		VersioningOverride:       inheritedPinnedOverride,
 		Priority:                 priority,
+		TimeSkippingConfig:       attributes.GetTimeSkippingConfig(),
 	}
 
 	request := common.CreateHistoryStartWorkflowRequest(

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -2589,7 +2589,34 @@ func (ms *MutableStateImpl) addWorkflowExecutionStartedEventForContinueAsNew(
 		}
 	}
 
-	// TODO: add TimeSkippingConfig to StartWorkflowExecutionRequest
+	// Continue-as-new is a continuation of the same logical workflow, so the previous
+	// run's accumulated skipped duration flows directly into the new run's
+	// AccumulatedSkippedDuration — the virtual clock continues seamlessly across the
+	// boundary. This is seeded here, before AddWorkflowExecutionStartedEventWithOptions
+	// builds the new run's first event, so the event's timestamp already sits in the
+	// virtual frame.
+	var newRunTSConfig *workflowpb.TimeSkippingConfig
+	var inheritedAccumulated *durationpb.Duration
+	if prevTSInfo := previousExecutionInfo.GetTimeSkippingInfo(); prevTSInfo != nil {
+		if prevTSC := prevTSInfo.GetConfig(); prevTSC != nil {
+			newRunTSConfig = proto.Clone(prevTSC).(*workflowpb.TimeSkippingConfig)
+			// Across CaN the inherited skip is carried in AccumulatedSkippedDuration,
+			// not as Config.PropagatedSkippedDuration metadata.
+			newRunTSConfig.PropagatedSkippedDuration = nil
+		}
+		if skipped := prevTSInfo.GetAccumulatedSkippedDuration(); skipped != nil && skipped.AsDuration() > 0 {
+			inheritedAccumulated = durationpb.New(skipped.AsDuration())
+		}
+	}
+	if newRunTSConfig != nil || inheritedAccumulated != nil {
+		ms.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
+			Config:                     newRunTSConfig,
+			AccumulatedSkippedDuration: inheritedAccumulated,
+		}
+		ms.wrapTimeSourceWithTimeSkipping()
+		ms.timeSkippingInfoUpdated = true
+	}
+
 	createRequest := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:                uuid.NewString(),
 		Namespace:                ms.namespaceEntry.Name().String(),
@@ -2610,6 +2637,7 @@ func (ms *MutableStateImpl) addWorkflowExecutionStartedEventForContinueAsNew(
 		CompletionCallbacks:   completionCallbacks,
 		Links:                 links,
 		Priority:              previousExecutionInfo.Priority,
+		TimeSkippingConfig:    newRunTSConfig,
 	}
 
 	enums.SetDefaultContinueAsNewInitiator(&command.Initiator)

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -2589,32 +2589,21 @@ func (ms *MutableStateImpl) addWorkflowExecutionStartedEventForContinueAsNew(
 		}
 	}
 
-	// Continue-as-new is a continuation of the same logical workflow, so the previous
-	// run's accumulated skipped duration flows directly into the new run's
-	// AccumulatedSkippedDuration — the virtual clock continues seamlessly across the
-	// boundary. This is seeded here, before AddWorkflowExecutionStartedEventWithOptions
-	// builds the new run's first event, so the event's timestamp already sits in the
-	// virtual frame.
+	// Snapshot previous run's time-skipping config and accumulated skipped duration
+	// so the new run inherits skipping behavior across the continue-as-new boundary.
+	// PropagatedSkippedDuration carries the old run's accumulated skip; applyTimeSkippingConfig
+	// converts it into the new MS's AccumulatedSkippedDuration on first TSI init.
 	var newRunTSConfig *workflowpb.TimeSkippingConfig
-	var inheritedAccumulated *durationpb.Duration
 	if prevTSInfo := previousExecutionInfo.GetTimeSkippingInfo(); prevTSInfo != nil {
 		if prevTSC := prevTSInfo.GetConfig(); prevTSC != nil {
 			newRunTSConfig = proto.Clone(prevTSC).(*workflowpb.TimeSkippingConfig)
-			// Across CaN the inherited skip is carried in AccumulatedSkippedDuration,
-			// not as Config.PropagatedSkippedDuration metadata.
-			newRunTSConfig.PropagatedSkippedDuration = nil
 		}
-		if skipped := prevTSInfo.GetAccumulatedSkippedDuration(); skipped != nil && skipped.AsDuration() > 0 {
-			inheritedAccumulated = durationpb.New(skipped.AsDuration())
+		if skipped := prevTSInfo.GetAccumulatedSkippedDuration(); skipped != nil {
+			if newRunTSConfig == nil {
+				newRunTSConfig = &workflowpb.TimeSkippingConfig{}
+			}
+			newRunTSConfig.PropagatedSkippedDuration = durationpb.New(skipped.AsDuration())
 		}
-	}
-	if newRunTSConfig != nil || inheritedAccumulated != nil {
-		ms.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
-			Config:                     newRunTSConfig,
-			AccumulatedSkippedDuration: inheritedAccumulated,
-		}
-		ms.wrapTimeSourceWithTimeSkipping()
-		ms.timeSkippingInfoUpdated = true
 	}
 
 	createRequest := &workflowservice.StartWorkflowExecutionRequest{
@@ -9641,12 +9630,34 @@ func (ms *MutableStateImpl) wrapTimeSourceWithTimeSkipping() {
 }
 
 // applyTimeSkippingConfig applies the time skipping config from the request or event to the mutable state.
+// If the incoming config carries a PropagatedSkippedDuration (from a parent workflow on child start,
+// or the previous run on continue-as-new), seed the new MS's AccumulatedSkippedDuration with it so
+// the virtual clock continues from where the originator left off. The stored Config has PSD stripped
+// because the inherited skip is represented by AccumulatedSkippedDuration, not metadata — the
+// incoming event/request still retains the PSD snapshot for history observability.
+//
+// Stripping happens on both the first-init and the re-init branch so the function is idempotent:
+// during workflow start, applyTimeSkippingConfig is called twice (once via event replay in
+// ApplyWorkflowExecutionStartedEvent, once directly from the request), and the second call must
+// not re-poison the stored Config with PSD.
 func (ms *MutableStateImpl) applyTimeSkippingConfig(config *workflowpb.TimeSkippingConfig) {
+	var inheritedAccum *durationpb.Duration
+	if psd := config.GetPropagatedSkippedDuration(); psd != nil && psd.AsDuration() > 0 {
+		inheritedAccum = durationpb.New(psd.AsDuration())
+		config = proto.Clone(config).(*workflowpb.TimeSkippingConfig)
+		config.PropagatedSkippedDuration = nil
+	}
 	if ms.executionInfo.GetTimeSkippingInfo() == nil {
-		ms.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{Config: config}
+		ms.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
+			Config:                     config,
+			AccumulatedSkippedDuration: inheritedAccum,
+		}
 		ms.wrapTimeSourceWithTimeSkipping() // time source should be wrapped when time skipping info is initialized
 	} else {
 		ms.executionInfo.TimeSkippingInfo.Config = config
+		// AccumulatedSkippedDuration is not overwritten here — PSD propagation only
+		// applies on first TSI init; subsequent applies (e.g., UpdateWorkflowExecutionOptions)
+		// carry a user-provided Config without PSD.
 	}
 	ms.timeSkippingInfoUpdated = true
 }

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -2589,24 +2589,7 @@ func (ms *MutableStateImpl) addWorkflowExecutionStartedEventForContinueAsNew(
 		}
 	}
 
-	// Snapshot previous run's time-skipping config and accumulated skipped duration
-	// so the new run inherits skipping behavior across the continue-as-new boundary.
-	// PropagatedSkippedDuration carries the old run's accumulated skip; applyTimeSkippingConfig
-	// converts it into the new MS's AccumulatedSkippedDuration on first TSI init.
-	var newRunTSConfig *workflowpb.TimeSkippingConfig
-	if prevTSInfo := previousExecutionInfo.GetTimeSkippingInfo(); prevTSInfo != nil {
-		if prevTSC := prevTSInfo.GetConfig(); prevTSC != nil {
-			if cloned, ok := proto.Clone(prevTSC).(*workflowpb.TimeSkippingConfig); ok {
-				newRunTSConfig = cloned
-			}
-		}
-		if skipped := prevTSInfo.GetAccumulatedSkippedDuration(); skipped != nil {
-			if newRunTSConfig == nil {
-				newRunTSConfig = &workflowpb.TimeSkippingConfig{}
-			}
-			newRunTSConfig.PropagatedSkippedDuration = durationpb.New(skipped.AsDuration())
-		}
-	}
+	newRunTSConfig, newRunInitialSkipped := snapshotTimeSkippingInfo(previousExecutionInfo)
 
 	createRequest := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:                uuid.NewString(),
@@ -2663,6 +2646,7 @@ func (ms *MutableStateImpl) addWorkflowExecutionStartedEventForContinueAsNew(
 		InheritedPinnedVersion:       inheritedPinnedVersion,
 		VersioningOverride:           pinnedOverride,
 		DeclinedTargetVersionUpgrade: computeDeclinedTargetVersionUpgrade(previousExecutionInfo),
+		InitialSkippedDuration:       newRunInitialSkipped,
 	}
 	if command.GetInitiator() == enumspb.CONTINUE_AS_NEW_INITIATOR_RETRY {
 		req.Attempt = previousExecutionState.GetExecutionInfo().Attempt + 1
@@ -2833,7 +2817,7 @@ func (ms *MutableStateImpl) AddWorkflowExecutionStartedEventWithOptions(
 	}
 
 	if tsc := startRequest.GetStartRequest().GetTimeSkippingConfig(); tsc != nil {
-		ms.applyTimeSkippingConfig(tsc)
+		ms.applyTimeSkippingConfig(tsc, startRequest.GetInitialSkippedDuration())
 	}
 	return event, nil
 }
@@ -3067,7 +3051,7 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionStartedEvent(
 	ms.executionInfo.Priority = event.Priority
 
 	if tsc := event.GetTimeSkippingConfig(); tsc != nil {
-		ms.applyTimeSkippingConfig(tsc)
+		ms.applyTimeSkippingConfig(tsc, event.GetInitialSkippedDuration())
 	}
 
 	ms.approximateSize += ms.executionInfo.Size()
@@ -5687,7 +5671,9 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionOptionsUpdatedEvent(event *his
 
 	// Update time skipping config.
 	if tsc := attributes.GetTimeSkippingConfig(); tsc != nil {
-		ms.applyTimeSkippingConfig(tsc)
+		// WorkflowExecutionOptionsUpdated does not carry an initial skipped duration;
+		// inherited seeding only applies on first TSI init at workflow start.
+		ms.applyTimeSkippingConfig(tsc, nil)
 	}
 
 	// Finally, reschedule the pending workflow task if so requested.
@@ -6053,29 +6039,13 @@ func (ms *MutableStateImpl) AddStartChildWorkflowExecutionInitiatedEvent(
 		return nil, nil, err
 	}
 
-	// Snapshot parent's current time-skipping config and accumulated skipped duration
-	// into the initiated event so that the transfer task can use them to start the child wf.
-	var childTSConfig *workflowpb.TimeSkippingConfig
-	if ms.executionInfo != nil && ms.executionInfo.TimeSkippingInfo != nil {
-		parentTSInfo := ms.executionInfo.TimeSkippingInfo
-		if parentTSC := parentTSInfo.GetConfig(); parentTSC != nil {
-			if cloned, ok := proto.Clone(parentTSC).(*workflowpb.TimeSkippingConfig); ok {
-				childTSConfig = cloned
-			}
-		}
-		if skipped := parentTSInfo.GetAccumulatedSkippedDuration(); skipped != nil {
-			if childTSConfig == nil {
-				childTSConfig = &workflowpb.TimeSkippingConfig{}
-			}
-			childTSConfig.PropagatedSkippedDuration = durationpb.New(skipped.AsDuration())
-		}
-	}
-
+	childTSConfig, childInitialSkipped := snapshotTimeSkippingInfo(ms.executionInfo)
 	event := ms.hBuilder.AddStartChildWorkflowExecutionInitiatedEvent(
 		workflowTaskCompletedEventID,
 		command,
 		targetNamespaceID,
 		childTSConfig,
+		childInitialSkipped,
 	)
 	ci, err := ms.ApplyStartChildWorkflowExecutionInitiatedEvent(workflowTaskCompletedEventID, event)
 	if err != nil {
@@ -9634,24 +9604,17 @@ func (ms *MutableStateImpl) wrapTimeSourceWithTimeSkipping() {
 }
 
 // applyTimeSkippingConfig applies the time skipping config from the request or event to the mutable state.
-// If the incoming config carries a PropagatedSkippedDuration (from a parent workflow on child start,
-// or the previous run on continue-as-new), seed the new MS's AccumulatedSkippedDuration with it so
-// the virtual clock continues from where the originator left off. The stored Config has PSD stripped
-// because the inherited skip is represented by AccumulatedSkippedDuration, not metadata — the
-// incoming event/request still retains the PSD snapshot for history observability.
-//
-// Stripping happens on both the first-init and the re-init branch so the function is idempotent:
-// during workflow start, applyTimeSkippingConfig is called twice (once via event replay in
-// ApplyWorkflowExecutionStartedEvent, once directly from the request), and the second call must
-// not re-poison the stored Config with PSD.
-func (ms *MutableStateImpl) applyTimeSkippingConfig(config *workflowpb.TimeSkippingConfig) {
+// initialSkippedDuration (from a parent workflow on child start, or the previous run on
+// continue-as-new) seeds the new MS's AccumulatedSkippedDuration so the virtual clock continues
+// from where the originator left off. It is only used on first TSI init; subsequent applies
+// (e.g., UpdateWorkflowExecutionOptions) pass nil.
+func (ms *MutableStateImpl) applyTimeSkippingConfig(
+	config *workflowpb.TimeSkippingConfig,
+	initialSkippedDuration *durationpb.Duration,
+) {
 	var inheritedAccum *durationpb.Duration
-	if psd := config.GetPropagatedSkippedDuration(); psd != nil && psd.AsDuration() > 0 {
-		inheritedAccum = durationpb.New(psd.AsDuration())
-		if cloned, ok := proto.Clone(config).(*workflowpb.TimeSkippingConfig); ok {
-			cloned.PropagatedSkippedDuration = nil
-			config = cloned
-		}
+	if initialSkippedDuration != nil && initialSkippedDuration.AsDuration() > 0 {
+		inheritedAccum = durationpb.New(initialSkippedDuration.AsDuration())
 	}
 	if ms.executionInfo.GetTimeSkippingInfo() == nil {
 		ms.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
@@ -9661,9 +9624,32 @@ func (ms *MutableStateImpl) applyTimeSkippingConfig(config *workflowpb.TimeSkipp
 		ms.wrapTimeSourceWithTimeSkipping() // time source should be wrapped when time skipping info is initialized
 	} else {
 		ms.executionInfo.TimeSkippingInfo.Config = config
-		// AccumulatedSkippedDuration is not overwritten here — PSD propagation only
+		// AccumulatedSkippedDuration is not overwritten here — inherited seeding only
 		// applies on first TSI init; subsequent applies (e.g., UpdateWorkflowExecutionOptions)
-		// carry a user-provided Config without PSD.
+		// carry only a user-provided Config.
 	}
 	ms.timeSkippingInfoUpdated = true
+}
+
+// snapshotTimeSkippingInfo returns a clone of the source execution's TimeSkippingConfig
+// and a copy of its AccumulatedSkippedDuration, for propagation to a new run (child workflow
+// or continue-as-new). The source is passed explicitly so callers can snapshot from the
+// originating run's executionInfo — on CaN, the new MS is empty at snapshot time, so we
+// must read from the previous run.
+func snapshotTimeSkippingInfo(source *persistencespb.WorkflowExecutionInfo) (*workflowpb.TimeSkippingConfig, *durationpb.Duration) {
+	tsInfo := source.GetTimeSkippingInfo()
+	if tsInfo == nil {
+		return nil, nil
+	}
+	var tsc *workflowpb.TimeSkippingConfig
+	var initialSkipped *durationpb.Duration
+	if srcTSC := tsInfo.GetConfig(); srcTSC != nil {
+		if cloned, ok := proto.Clone(srcTSC).(*workflowpb.TimeSkippingConfig); ok {
+			tsc = cloned
+		}
+	}
+	if skipped := tsInfo.GetAccumulatedSkippedDuration(); skipped != nil {
+		initialSkipped = durationpb.New(skipped.AsDuration())
+	}
+	return tsc, initialSkipped
 }

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -6034,10 +6034,27 @@ func (ms *MutableStateImpl) AddStartChildWorkflowExecutionInitiatedEvent(
 		return nil, nil, err
 	}
 
+	// Snapshot parent's current time-skipping config and accumulated skipped duration
+	// into the initiated event so that the transfer task can use them to start the child wf.
+	var childTSConfig *workflowpb.TimeSkippingConfig
+	if ms.executionInfo != nil && ms.executionInfo.TimeSkippingInfo != nil {
+		parentTSInfo := ms.executionInfo.TimeSkippingInfo
+		if parentTSC := parentTSInfo.GetConfig(); parentTSC != nil {
+			childTSConfig = proto.Clone(parentTSC).(*workflowpb.TimeSkippingConfig)
+		}
+		if skipped := parentTSInfo.GetAccumulatedSkippedDuration(); skipped != nil {
+			if childTSConfig == nil {
+				childTSConfig = &workflowpb.TimeSkippingConfig{}
+			}
+			childTSConfig.PropagatedSkippedDuration = durationpb.New(skipped.AsDuration())
+		}
+	}
+
 	event := ms.hBuilder.AddStartChildWorkflowExecutionInitiatedEvent(
 		workflowTaskCompletedEventID,
 		command,
 		targetNamespaceID,
+		childTSConfig,
 	)
 	ci, err := ms.ApplyStartChildWorkflowExecutionInitiatedEvent(workflowTaskCompletedEventID, event)
 	if err != nil {

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -2596,7 +2596,9 @@ func (ms *MutableStateImpl) addWorkflowExecutionStartedEventForContinueAsNew(
 	var newRunTSConfig *workflowpb.TimeSkippingConfig
 	if prevTSInfo := previousExecutionInfo.GetTimeSkippingInfo(); prevTSInfo != nil {
 		if prevTSC := prevTSInfo.GetConfig(); prevTSC != nil {
-			newRunTSConfig = proto.Clone(prevTSC).(*workflowpb.TimeSkippingConfig)
+			if cloned, ok := proto.Clone(prevTSC).(*workflowpb.TimeSkippingConfig); ok {
+				newRunTSConfig = cloned
+			}
 		}
 		if skipped := prevTSInfo.GetAccumulatedSkippedDuration(); skipped != nil {
 			if newRunTSConfig == nil {
@@ -6057,7 +6059,9 @@ func (ms *MutableStateImpl) AddStartChildWorkflowExecutionInitiatedEvent(
 	if ms.executionInfo != nil && ms.executionInfo.TimeSkippingInfo != nil {
 		parentTSInfo := ms.executionInfo.TimeSkippingInfo
 		if parentTSC := parentTSInfo.GetConfig(); parentTSC != nil {
-			childTSConfig = proto.Clone(parentTSC).(*workflowpb.TimeSkippingConfig)
+			if cloned, ok := proto.Clone(parentTSC).(*workflowpb.TimeSkippingConfig); ok {
+				childTSConfig = cloned
+			}
 		}
 		if skipped := parentTSInfo.GetAccumulatedSkippedDuration(); skipped != nil {
 			if childTSConfig == nil {
@@ -9644,8 +9648,10 @@ func (ms *MutableStateImpl) applyTimeSkippingConfig(config *workflowpb.TimeSkipp
 	var inheritedAccum *durationpb.Duration
 	if psd := config.GetPropagatedSkippedDuration(); psd != nil && psd.AsDuration() > 0 {
 		inheritedAccum = durationpb.New(psd.AsDuration())
-		config = proto.Clone(config).(*workflowpb.TimeSkippingConfig)
-		config.PropagatedSkippedDuration = nil
+		if cloned, ok := proto.Clone(config).(*workflowpb.TimeSkippingConfig); ok {
+			cloned.PropagatedSkippedDuration = nil
+			config = cloned
+		}
 	}
 	if ms.executionInfo.GetTimeSkippingInfo() == nil {
 		ms.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -4131,6 +4131,7 @@ func (s *mutableStateSuite) TestStartChildWorkflowRequestID() {
 		workflowTaskCompletionEventID,
 		attributes,
 		tests.NamespaceID,
+		nil,
 	)
 	createRequestID := fmt.Sprintf("%s:%d:%d", s.mutableState.executionState.RunId, event.GetEventId(), event.GetVersion())
 	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
@@ -4141,6 +4142,100 @@ func (s *mutableStateSuite) TestStartChildWorkflowRequestID() {
 	)
 	s.NoError(err)
 	s.Equal(createRequestID, ci.CreateRequestId)
+}
+
+// TestAddStartChildWorkflowExecutionInitiatedEvent_TimeSkippingSnapshot verifies that
+// AddStartChildWorkflowExecutionInitiatedEvent snapshots the parent's TimeSkippingInfo
+// into the event attributes at command time. The transfer task that later starts the
+// child reads this snapshot off the event (see transfer_queue_active_task_executor.go),
+// so the snapshot must faithfully represent what the parent workflow observed.
+func (s *mutableStateSuite) TestAddStartChildWorkflowExecutionInitiatedEvent_TimeSkippingSnapshot() {
+	cases := []struct {
+		name      string
+		parentTSI *persistencespb.TimeSkippingInfo
+		expectNil bool
+		expectCfg *workflowpb.TimeSkippingConfig
+	}{
+		{
+			name:      "no TimeSkippingInfo on parent → no snapshot on event",
+			parentTSI: nil,
+			expectNil: true,
+		},
+		{
+			name: "config only, no accumulated skip → config cloned verbatim",
+			parentTSI: &persistencespb.TimeSkippingInfo{
+				Config: &workflowpb.TimeSkippingConfig{Enabled: true},
+			},
+			expectCfg: &workflowpb.TimeSkippingConfig{Enabled: true},
+		},
+		{
+			name: "config + accumulated skip → PSD overwritten from parent's accumulated",
+			parentTSI: &persistencespb.TimeSkippingInfo{
+				Config:                     &workflowpb.TimeSkippingConfig{Enabled: true},
+				AccumulatedSkippedDuration: durationpb.New(time.Hour),
+			},
+			expectCfg: &workflowpb.TimeSkippingConfig{
+				Enabled:                   true,
+				PropagatedSkippedDuration: durationpb.New(time.Hour),
+			},
+		},
+		{
+			name: "multi-generation: parent's own config carries inherited PSD from grandparent, parent's accumulated overrides it so grandparent contribution is NOT re-added",
+			parentTSI: &persistencespb.TimeSkippingInfo{
+				Config: &workflowpb.TimeSkippingConfig{
+					Enabled:                   true,
+					PropagatedSkippedDuration: durationpb.New(30 * time.Minute), // from grandparent
+				},
+				AccumulatedSkippedDuration: durationpb.New(2 * time.Hour),
+			},
+			expectCfg: &workflowpb.TimeSkippingConfig{
+				Enabled:                   true,
+				PropagatedSkippedDuration: durationpb.New(2 * time.Hour),
+			},
+		},
+		{
+			name: "accumulated skip only, no config (corrupt-ish but handled) → bare TSC with PSD",
+			parentTSI: &persistencespb.TimeSkippingInfo{
+				AccumulatedSkippedDuration: durationpb.New(15 * time.Minute),
+			},
+			expectCfg: &workflowpb.TimeSkippingConfig{
+				PropagatedSkippedDuration: durationpb.New(15 * time.Minute),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
+			s.mutableState.executionInfo.TimeSkippingInfo = tc.parentTSI
+
+			event, _, err := s.mutableState.AddStartChildWorkflowExecutionInitiatedEvent(
+				rand.Int63(),
+				&commandpb.StartChildWorkflowExecutionCommandAttributes{
+					WorkflowId:   "child-wf",
+					WorkflowType: &commonpb.WorkflowType{Name: "ChildWF"},
+				},
+				tests.NamespaceID,
+			)
+			s.NoError(err)
+
+			gotTSC := event.GetStartChildWorkflowExecutionInitiatedEventAttributes().GetTimeSkippingConfig()
+			if tc.expectNil {
+				s.Nil(gotTSC)
+				return
+			}
+			s.NotNil(gotTSC)
+			s.True(proto.Equal(tc.expectCfg, gotTSC),
+				"expected %v, got %v", tc.expectCfg, gotTSC)
+
+			// The snapshot must be a clone — mutating it must not leak back into parent state.
+			if tc.parentTSI.GetConfig() != nil {
+				gotTSC.Enabled = !gotTSC.GetEnabled()
+				s.True(tc.parentTSI.GetConfig().GetEnabled(),
+					"mutation of snapshot leaked into parent's Config")
+			}
+		})
+	}
 }
 
 func (s *mutableStateSuite) TestGetCloseVersion() {
@@ -7380,9 +7475,8 @@ func (s *mutableStateSuite) TestCloseTransactionPrepareTasks() {
 // rebuild flows.
 func (s *mutableStateSuite) TestApplyWorkflowExecutionStartedEvent_TimeSkippingConfig() {
 	inputConfig := &workflowpb.TimeSkippingConfig{
-		Enabled:            true,
-		DisablePropagation: true,
-		Bound:              &workflowpb.TimeSkippingConfig_MaxSkippedDuration{MaxSkippedDuration: durationpb.New(time.Hour)},
+		Enabled: true,
+		Bound:   &workflowpb.TimeSkippingConfig_MaxSkippedDuration{MaxSkippedDuration: durationpb.New(time.Hour)},
 	}
 
 	testCases := []struct {
@@ -7453,9 +7547,8 @@ func (s *mutableStateSuite) TestApplyWorkflowExecutionOptionsUpdatedEvent_TimeSk
 		Bound:   &workflowpb.TimeSkippingConfig_MaxSkippedDuration{MaxSkippedDuration: durationpb.New(time.Hour)},
 	}
 	updatedConfig := &workflowpb.TimeSkippingConfig{
-		Enabled:            true,
-		DisablePropagation: true,
-		Bound:              &workflowpb.TimeSkippingConfig_MaxElapsedDuration{MaxElapsedDuration: durationpb.New(2 * time.Hour)},
+		Enabled: true,
+		Bound:   &workflowpb.TimeSkippingConfig_MaxElapsedDuration{MaxElapsedDuration: durationpb.New(2 * time.Hour)},
 	}
 
 	testCases := []struct {

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -4132,6 +4132,7 @@ func (s *mutableStateSuite) TestStartChildWorkflowRequestID() {
 		attributes,
 		tests.NamespaceID,
 		nil,
+		nil,
 	)
 	createRequestID := fmt.Sprintf("%s:%d:%d", s.mutableState.executionState.RunId, event.GetEventId(), event.GetVersion())
 	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
@@ -4151,56 +4152,49 @@ func (s *mutableStateSuite) TestStartChildWorkflowRequestID() {
 // so the snapshot must faithfully represent what the parent workflow observed.
 func (s *mutableStateSuite) TestAddStartChildWorkflowExecutionInitiatedEvent_TimeSkippingSnapshot() {
 	cases := []struct {
-		name      string
-		parentTSI *persistencespb.TimeSkippingInfo
-		expectNil bool
-		expectCfg *workflowpb.TimeSkippingConfig
+		name              string
+		parentTSI         *persistencespb.TimeSkippingInfo
+		expectNilCfg      bool
+		expectCfg         *workflowpb.TimeSkippingConfig
+		expectInitialSkip *durationpb.Duration
 	}{
 		{
-			name:      "no TimeSkippingInfo on parent → no snapshot on event",
-			parentTSI: nil,
-			expectNil: true,
+			name:         "no TimeSkippingInfo on parent → no snapshot on event",
+			parentTSI:    nil,
+			expectNilCfg: true,
 		},
 		{
-			name: "config only, no accumulated skip → config cloned verbatim",
+			name: "config only, no accumulated skip → config cloned verbatim, no initial skip",
 			parentTSI: &persistencespb.TimeSkippingInfo{
 				Config: &workflowpb.TimeSkippingConfig{Enabled: true},
 			},
 			expectCfg: &workflowpb.TimeSkippingConfig{Enabled: true},
 		},
 		{
-			name: "config + accumulated skip → PSD overwritten from parent's accumulated",
+			name: "config + accumulated skip → config cloned, InitialSkippedDuration = parent's accumulated",
 			parentTSI: &persistencespb.TimeSkippingInfo{
 				Config:                     &workflowpb.TimeSkippingConfig{Enabled: true},
 				AccumulatedSkippedDuration: durationpb.New(time.Hour),
 			},
-			expectCfg: &workflowpb.TimeSkippingConfig{
-				Enabled:                   true,
-				PropagatedSkippedDuration: durationpb.New(time.Hour),
-			},
+			expectCfg:         &workflowpb.TimeSkippingConfig{Enabled: true},
+			expectInitialSkip: durationpb.New(time.Hour),
 		},
 		{
-			name: "multi-generation: parent's own config carries inherited PSD from grandparent, parent's accumulated overrides it so grandparent contribution is NOT re-added",
+			name: "multi-generation: parent's accumulated (which already includes grandparent's contribution) becomes InitialSkippedDuration",
 			parentTSI: &persistencespb.TimeSkippingInfo{
-				Config: &workflowpb.TimeSkippingConfig{
-					Enabled:                   true,
-					PropagatedSkippedDuration: durationpb.New(30 * time.Minute), // from grandparent
-				},
+				Config:                     &workflowpb.TimeSkippingConfig{Enabled: true},
 				AccumulatedSkippedDuration: durationpb.New(2 * time.Hour),
 			},
-			expectCfg: &workflowpb.TimeSkippingConfig{
-				Enabled:                   true,
-				PropagatedSkippedDuration: durationpb.New(2 * time.Hour),
-			},
+			expectCfg:         &workflowpb.TimeSkippingConfig{Enabled: true},
+			expectInitialSkip: durationpb.New(2 * time.Hour),
 		},
 		{
-			name: "accumulated skip only, no config (corrupt-ish but handled) → bare TSC with PSD",
+			name: "accumulated skip only, no config (corrupt-ish but handled) → no config snapshot, just InitialSkippedDuration",
 			parentTSI: &persistencespb.TimeSkippingInfo{
 				AccumulatedSkippedDuration: durationpb.New(15 * time.Minute),
 			},
-			expectCfg: &workflowpb.TimeSkippingConfig{
-				PropagatedSkippedDuration: durationpb.New(15 * time.Minute),
-			},
+			expectNilCfg:      true,
+			expectInitialSkip: durationpb.New(15 * time.Minute),
 		},
 	}
 
@@ -4219,8 +4213,18 @@ func (s *mutableStateSuite) TestAddStartChildWorkflowExecutionInitiatedEvent_Tim
 			)
 			s.NoError(err)
 
-			gotTSC := event.GetStartChildWorkflowExecutionInitiatedEventAttributes().GetTimeSkippingConfig()
-			if tc.expectNil {
+			gotAttrs := event.GetStartChildWorkflowExecutionInitiatedEventAttributes()
+			gotTSC := gotAttrs.GetTimeSkippingConfig()
+			gotInitialSkip := gotAttrs.GetInitialSkippedDuration()
+
+			if tc.expectInitialSkip == nil {
+				s.Nil(gotInitialSkip)
+			} else {
+				s.NotNil(gotInitialSkip)
+				s.Equal(tc.expectInitialSkip.AsDuration(), gotInitialSkip.AsDuration())
+			}
+
+			if tc.expectNilCfg {
 				s.Nil(gotTSC)
 				return
 			}

--- a/service/history/workflow/retry.go
+++ b/service/history/workflow/retry.go
@@ -303,6 +303,13 @@ func SetupNewWorkflowForRetryOrCron(
 		VersioningOverride:       pinnedOverride,
 	}
 
+	// Retry inherits the TimeSkippingConfig snapshot from the previous run's
+	// WorkflowExecutionStarted event verbatim. Cron does not inherit TSC — new
+	// cron runs start fresh, consistent with the cron-never-inherits convention.
+	if initiator == enumspb.CONTINUE_AS_NEW_INITIATOR_RETRY {
+		createRequest.TimeSkippingConfig = startAttr.GetTimeSkippingConfig()
+	}
+
 	attempt := int32(1)
 	if initiator == enumspb.CONTINUE_AS_NEW_INITIATOR_RETRY {
 		attempt = previousExecutionInfo.Attempt + 1

--- a/service/history/workflow/retry.go
+++ b/service/history/workflow/retry.go
@@ -340,6 +340,9 @@ func SetupNewWorkflowForRetryOrCron(
 		InheritedAutoUpgradeInfo: inheritedAutoUpgradeInfo,
 		// For retries, pass through the declined value from the started event directly.
 		DeclinedTargetVersionUpgrade: startAttr.GetDeclinedTargetVersionUpgrade(),
+		// Retry and Cron inherit InitialSkippedDuration from the previous run's
+		// WorkflowExecutionStarted event verbatim — same semantics as TimeSkippingConfig above.
+		InitialSkippedDuration: startAttr.GetInitialSkippedDuration(),
 	}
 	workflowTimeoutTime := timestamp.TimeValue(previousExecutionInfo.WorkflowExecutionExpirationTime)
 	if !workflowTimeoutTime.IsZero() {

--- a/service/history/workflow/retry.go
+++ b/service/history/workflow/retry.go
@@ -303,12 +303,9 @@ func SetupNewWorkflowForRetryOrCron(
 		VersioningOverride:       pinnedOverride,
 	}
 
-	// Retry inherits the TimeSkippingConfig snapshot from the previous run's
-	// WorkflowExecutionStarted event verbatim. Cron does not inherit TSC — new
-	// cron runs start fresh, consistent with the cron-never-inherits convention.
-	if initiator == enumspb.CONTINUE_AS_NEW_INITIATOR_RETRY {
-		createRequest.TimeSkippingConfig = startAttr.GetTimeSkippingConfig()
-	}
+	// Retry and Cron inherit the TimeSkippingConfig snapshot from the previous
+	// run's WorkflowExecutionStarted event verbatim.
+	createRequest.TimeSkippingConfig = startAttr.GetTimeSkippingConfig()
 
 	attempt := int32(1)
 	if initiator == enumspb.CONTINUE_AS_NEW_INITIATOR_RETRY {

--- a/tests/timeskipping_propagation_test.go
+++ b/tests/timeskipping_propagation_test.go
@@ -41,8 +41,9 @@
 //	then reapplies any WorkflowExecutionOptionsUpdated events that occurred between
 //	the reset point and the original run's terminal state. Reapply is unconditional
 //	— there is no ResetReapplyExcludeType value that can suppress OPTIONS_UPDATED.
-//	AccumulatedSkippedDuration on the reset run starts from the event #1 PSD (same
-//	as Group 2); original-run in-flight skip is not carried forward.
+//	AccumulatedSkippedDuration on the reset run starts from the event #1
+//	InitialSkippedDuration (same as Group 2); original-run in-flight skip is not
+//	carried forward.
 //
 //	Covered by:
 //	  - TestTSPInReset
@@ -88,11 +89,11 @@ func TestTimeSkippingPropagationTestSuite(t *testing.T) {
 // propagation of TimeSkippingConfig + AccumulatedSkippedDuration from parent to child,
 // together with the idle-only skipping invariant on the parent.
 //
-// The parent's StartChildWorkflowExecutionInitiated event carries a PSD snapshot of
-// the parent's accumulated skip at child-start time. applyTimeSkippingConfig on the
-// child's MS converts that PSD into AccumulatedSkippedDuration and strips PSD from
-// the stored Config, so the child's virtual clock continues from where the parent
-// left off.
+// The parent's StartChildWorkflowExecutionInitiated event carries an InitialSkippedDuration
+// snapshot of the parent's accumulated skip at child-start time (separate from the
+// TimeSkippingConfig Config snapshot). applyTimeSkippingConfig on the child's MS uses the
+// initial skip to seed AccumulatedSkippedDuration, so the child's virtual clock continues
+// from where the parent left off.
 //
 // Scenario:
 //   - Parent starts with TimeSkippingConfig{Enabled: true}.
@@ -101,8 +102,8 @@ func TestTimeSkippingPropagationTestSuite(t *testing.T) {
 //   - t1 fires. Parent issues StartChildWorkflow(child) and StartTimer(t2, 1h).
 //     Parent now has a pending child → NOT idle → parent does NOT skip.
 //   - Child is started. Its MS is seeded with AccumulatedSkippedDuration = 1h
-//     (converted from the PSD=1h on the initiated event) and Config.Enabled = true
-//     (Config.PSD stripped by applyTimeSkippingConfig).
+//     (from the InitialSkippedDuration=1h on the initiated event) and Config.Enabled
+//     = true (cloned verbatim from parent's Config).
 //   - Child issues StartTimer(tc, 3h). Child is idle → server skips 3h.
 //     After skip: child.AccumulatedSkippedDuration = 1h + 3h = 4h.
 //   - tc fires. Child completes.
@@ -114,11 +115,10 @@ func TestTimeSkippingPropagationTestSuite(t *testing.T) {
 // End-state assertions:
 //   - parent.AccumulatedSkippedDuration == 2h.
 //   - child.TimeSkippingInfo.Config.Enabled == true (propagated).
-//   - child.TimeSkippingInfo.Config.PropagatedSkippedDuration is unset on the MS —
-//     applyTimeSkippingConfig stripped it after converting to AccumulatedSkippedDuration.
 //   - child.AccumulatedSkippedDuration == 4h (1h inherited + 3h own from tc).
-//   - The parent's StartChildWorkflowExecutionInitiated event retains PSD=1h (the
-//     pre-apply snapshot; it is the wire form the transfer task consumes).
+//   - The parent's StartChildWorkflowExecutionInitiated event carries
+//     TimeSkippingConfig{Enabled=true} and InitialSkippedDuration=1h (the pre-apply
+//     snapshots; the wire form the transfer task consumes).
 //   - Wall-clock elapsed is nowhere near 5h of virtual time.
 func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_Basic() {
 	env := testcore.NewEnv(s.T())
@@ -210,27 +210,27 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_Basic() {
 	childCfg := childTSI.GetConfig()
 	s.NotNil(childCfg)
 	s.True(childCfg.GetEnabled(), "child TSC.Enabled propagated from parent")
-	s.Zero(childCfg.GetPropagatedSkippedDuration().AsDuration(),
-		"child Config.PSD is stripped on apply; the inherited skip lives in AccumulatedSkippedDuration")
 	s.approxDuration(4*time.Hour, childTSI.GetAccumulatedSkippedDuration().AsDuration(),
 		"child AccumulatedSkippedDuration == parent's accumulated at child-start (1h) + child's own skip for tc (3h) = 4h")
 
 	// The parent's StartChildWorkflowExecutionInitiated event must carry the propagated
-	// TimeSkippingConfig — this is what the transfer task consumes when it starts the child.
+	// TimeSkippingConfig and InitialSkippedDuration — these are what the transfer task
+	// consumes when it starts the child.
 	initEvents := s.initiatedChildEvents(ctx, env, parentWFID, parentRunID)
 	s.Len(initEvents, 1)
-	initTSC := initEvents[0].GetStartChildWorkflowExecutionInitiatedEventAttributes().GetTimeSkippingConfig()
+	initAttrs := initEvents[0].GetStartChildWorkflowExecutionInitiatedEventAttributes()
+	initTSC := initAttrs.GetTimeSkippingConfig()
 	s.NotNil(initTSC, "initiated event should carry TimeSkippingConfig snapshot")
 	s.True(initTSC.GetEnabled(), "snapshot mirrors parent's Enabled flag")
-	s.approxDuration(time.Hour, initTSC.GetPropagatedSkippedDuration().AsDuration(),
-		"snapshot PSD == parent's AccumulatedSkippedDuration at command time (1h)")
+	s.approxDuration(time.Hour, initAttrs.GetInitialSkippedDuration().AsDuration(),
+		"initiated event InitialSkippedDuration == parent's AccumulatedSkippedDuration at command time (1h)")
 }
 
 // TestTSPInChildWf_TwoChildren verifies that:
 //   - All children started in the same WFT inherit the parent's TimeSkippingConfig
 //     and have their AccumulatedSkippedDuration seeded to the parent's accumulated
-//     skip at child-start time (via the PSD snapshot on the initiated event, which
-//     applyTimeSkippingConfig converts into AccumulatedSkippedDuration).
+//     skip at child-start time (via InitialSkippedDuration on the initiated event,
+//     which applyTimeSkippingConfig converts into AccumulatedSkippedDuration).
 //   - The parent is blocked from skipping while ANY child is pending, and resumes
 //     skipping only after all children complete (idle-only invariant).
 //
@@ -335,22 +335,21 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_TwoChildren() {
 		childTSI := childMS.State.ExecutionInfo.GetTimeSkippingInfo()
 		s.NotNil(childTSI, "%s TSI", id)
 		s.True(childTSI.GetConfig().GetEnabled(), "%s inherited Enabled", id)
-		s.Zero(childTSI.GetConfig().GetPropagatedSkippedDuration().AsDuration(),
-			"%s Config.PSD is stripped on apply; the inherited skip lives in AccumulatedSkippedDuration", id)
 		s.approxDuration(3*time.Hour, childTSI.GetAccumulatedSkippedDuration().AsDuration(),
 			"%s AccumulatedSkippedDuration == parent's accumulated at child-start (1h) + own skip for tc (2h) = 3h", id)
 	}
 
 	// Both children are initiated in the same WFT — the parent's history must carry two
-	// StartChildWorkflowExecutionInitiated events, each with the snapshot (Enabled=true,
-	// PSD=1h) computed from parent state at command time.
+	// StartChildWorkflowExecutionInitiated events, each with the snapshot (Config{Enabled=true},
+	// InitialSkippedDuration=1h) computed from parent state at command time.
 	initEvents := s.initiatedChildEvents(ctx, env, parentWFID, parentRunID)
 	s.Len(initEvents, 2)
 	for _, e := range initEvents {
-		tsc := e.GetStartChildWorkflowExecutionInitiatedEventAttributes().GetTimeSkippingConfig()
+		attrs := e.GetStartChildWorkflowExecutionInitiatedEventAttributes()
+		tsc := attrs.GetTimeSkippingConfig()
 		s.NotNil(tsc)
 		s.True(tsc.GetEnabled())
-		s.approxDuration(time.Hour, tsc.GetPropagatedSkippedDuration().AsDuration())
+		s.approxDuration(time.Hour, attrs.GetInitialSkippedDuration().AsDuration())
 	}
 }
 
@@ -359,18 +358,18 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_TwoChildren() {
 // parent's accumulated skip (which already includes all ancestors' contributions) seeded
 // into AccumulatedSkippedDuration, then adds its own skipping on top.
 //
-// The initiated-event PSD snapshot on any parent reflects that parent's full accumulated
-// skip at command time — which includes the parent's own inherited portion. There is no
-// "direct-parent-only" carve-out; the ancestry's virtual clock is continuous.
+// The initiated-event InitialSkippedDuration snapshot on any parent reflects that parent's
+// full accumulated skip at command time — which includes the parent's own inherited portion.
+// There is no "direct-parent-only" carve-out; the ancestry's virtual clock is continuous.
 //
 // Scenario:
 //   - Grandparent (G) TSC enabled. G: StartTimer(gt1, 1h) → skips 1h → G.accum = 1h.
-//   - G: StartChild(P) + StartTimer(gt2, 1h). P's initiated event snapshots PSD=1h.
-//     P's MS: AccumulatedSkippedDuration seeded to 1h, Config.PSD stripped.
+//   - G: StartChild(P) + StartTimer(gt2, 1h). P's initiated event snapshots
+//     InitialSkippedDuration=1h. P's MS: AccumulatedSkippedDuration seeded to 1h.
 //   - P: StartTimer(pt1, 2h) → skips 2h → P.accum = 1h + 2h = 3h.
-//   - P: StartChild(C) + StartTimer(pt2, 1h). C's initiated event snapshots PSD=3h
-//     (P's full accumulated at command time, which already includes G's 1h).
-//     C's MS: AccumulatedSkippedDuration seeded to 3h, Config.PSD stripped.
+//   - P: StartChild(C) + StartTimer(pt2, 1h). C's initiated event snapshots
+//     InitialSkippedDuration=3h (P's full accumulated at command time, which already
+//     includes G's 1h). C's MS: AccumulatedSkippedDuration seeded to 3h.
 //   - C: StartTimer(ct, 1h) → skips 1h → C.accum = 3h + 1h = 4h → completes.
 //   - P: idle on pt2 → skips 1h → P.accum = 3h + 1h = 4h. pt2 fires. P completes.
 //   - G: idle on gt2 → skips 1h → G.accum = 1h + 1h = 2h. gt2 fires. G completes.
@@ -488,8 +487,6 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_ThreeGenerations() {
 	pTSI := pMS.State.ExecutionInfo.GetTimeSkippingInfo()
 	s.NotNil(pTSI)
 	s.True(pTSI.GetConfig().GetEnabled())
-	s.Zero(pTSI.GetConfig().GetPropagatedSkippedDuration().AsDuration(),
-		"P.Config.PSD is stripped on apply; the inherited skip lives in AccumulatedSkippedDuration")
 	s.approxDuration(4*time.Hour, pTSI.GetAccumulatedSkippedDuration().AsDuration(),
 		"P.accum == G's accumulated at P-start (1h) + P's own pt1 (2h) + P's own pt2 (1h) = 4h")
 
@@ -499,26 +496,25 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_ThreeGenerations() {
 	cTSI := cMS.State.ExecutionInfo.GetTimeSkippingInfo()
 	s.NotNil(cTSI)
 	s.True(cTSI.GetConfig().GetEnabled())
-	s.Zero(cTSI.GetConfig().GetPropagatedSkippedDuration().AsDuration(),
-		"C.Config.PSD is stripped on apply")
 	s.approxDuration(4*time.Hour, cTSI.GetAccumulatedSkippedDuration().AsDuration(),
 		"C.accum == P's accumulated at C-start (3h, which already includes G's 1h) + C's own ct (1h) = 4h")
 
-	// History-side check: G's initiated event for P snapshots PSD=1h (G's accumulated
-	// at command time); P's initiated event for C snapshots PSD=3h (P's full accumulated
-	// at command time — includes G's 1h contribution, which propagates transitively).
+	// History-side check: G's initiated event for P snapshots InitialSkippedDuration=1h
+	// (G's accumulated at command time); P's initiated event for C snapshots
+	// InitialSkippedDuration=3h (P's full accumulated at command time — includes G's 1h
+	// contribution, which propagates transitively).
 	gInit := s.initiatedChildEvents(ctx, env, gWFID, gRunID)
 	s.Len(gInit, 1)
-	gInitTSC := gInit[0].GetStartChildWorkflowExecutionInitiatedEventAttributes().GetTimeSkippingConfig()
-	s.NotNil(gInitTSC)
-	s.approxDuration(time.Hour, gInitTSC.GetPropagatedSkippedDuration().AsDuration())
+	gInitAttrs := gInit[0].GetStartChildWorkflowExecutionInitiatedEventAttributes()
+	s.NotNil(gInitAttrs.GetTimeSkippingConfig())
+	s.approxDuration(time.Hour, gInitAttrs.GetInitialSkippedDuration().AsDuration())
 
 	pRunID := pMS.State.ExecutionState.RunId
 	pInit := s.initiatedChildEvents(ctx, env, pWFID, pRunID)
 	s.Len(pInit, 1)
-	pInitTSC := pInit[0].GetStartChildWorkflowExecutionInitiatedEventAttributes().GetTimeSkippingConfig()
-	s.NotNil(pInitTSC)
-	s.approxDuration(3*time.Hour, pInitTSC.GetPropagatedSkippedDuration().AsDuration(),
+	pInitAttrs := pInit[0].GetStartChildWorkflowExecutionInitiatedEventAttributes()
+	s.NotNil(pInitAttrs.GetTimeSkippingConfig())
+	s.approxDuration(3*time.Hour, pInitAttrs.GetInitialSkippedDuration().AsDuration(),
 		"P's initiated event for C carries P's full accumulated at command time (3h = G's 1h + P's pt1 2h)")
 }
 
@@ -902,19 +898,19 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInReset() {
 // AccumulatedSkippedDuration are propagated to the new run on continue-as-new.
 //
 // CaN uses the same propagation mechanism as child workflows: the previous run's
-// AccumulatedSkippedDuration is snapshotted as PropagatedSkippedDuration on the new
-// run's WorkflowExecutionStarted event. applyTimeSkippingConfig then converts that
-// PSD into AccumulatedSkippedDuration on the new MS (stripping PSD from the stored
-// Config) so the virtual clock continues seamlessly.
+// AccumulatedSkippedDuration is snapshotted as InitialSkippedDuration on the new
+// run's WorkflowExecutionStarted event (separate from the TimeSkippingConfig snapshot).
+// applyTimeSkippingConfig uses InitialSkippedDuration to seed AccumulatedSkippedDuration
+// on the new MS, so the virtual clock continues seamlessly.
 //
 // Scenario:
 //   - Run 1 starts with TimeSkippingConfig{Enabled: true}.
 //   - Run 1 issues StartTimer(t1, 1h). Idle → server skips 1h.
 //     After skip: run1.AccumulatedSkippedDuration = 1h.
 //   - t1 fires. Run 1 issues ContinueAsNew (same type, same task queue).
-//   - Run 2 starts. Its WorkflowExecutionStarted event carries TSC with Enabled=true
-//     and PropagatedSkippedDuration=1h. The applied MS has Config.Enabled=true,
-//     Config.PSD unset, AccumulatedSkippedDuration=1h.
+//   - Run 2 starts. Its WorkflowExecutionStarted event carries
+//     TimeSkippingConfig{Enabled=true} and InitialSkippedDuration=1h. The applied MS
+//     has Config.Enabled=true and AccumulatedSkippedDuration=1h.
 //   - Run 2 issues StartTimer(t2, 2h). Idle → skips 2h.
 //     After skip: run2.AccumulatedSkippedDuration = 1h + 2h = 3h.
 //   - t2 fires. Run 2 completes.
@@ -923,11 +919,9 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInReset() {
 //   - run1.status == CONTINUED_AS_NEW, run1.AccumulatedSkippedDuration == 1h.
 //   - run2.status == COMPLETED.
 //   - run2.TimeSkippingInfo.Config.Enabled == true (propagated).
-//   - run2.TimeSkippingInfo.Config.PropagatedSkippedDuration is unset on the MS —
-//     applyTimeSkippingConfig stripped it after converting to AccumulatedSkippedDuration.
 //   - run2.AccumulatedSkippedDuration == 3h.
-//   - run2 WorkflowExecutionStarted event retains the PSD=1h snapshot (history
-//     observability — the event is created before applyTimeSkippingConfig runs).
+//   - run2 WorkflowExecutionStarted event retains the InitialSkippedDuration=1h snapshot
+//     (history observability — the event is created before applyTimeSkippingConfig runs).
 //   - Wall-clock elapsed is nowhere near 3h of virtual time.
 func (s *TimeSkippingPropagationTestSuite) TestTSPInCaN() {
 	env := testcore.NewEnv(s.T())
@@ -998,8 +992,6 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInCaN() {
 	run2Cfg := run2TSI.GetConfig()
 	s.NotNil(run2Cfg)
 	s.True(run2Cfg.GetEnabled(), "run 2 TSC.Enabled propagated from run 1")
-	s.Zero(run2Cfg.GetPropagatedSkippedDuration().AsDuration(),
-		"CaN must not leave PropagatedSkippedDuration set on the Config; the inherited skip goes into AccumulatedSkippedDuration")
 	s.approxDuration(3*time.Hour, run2TSI.GetAccumulatedSkippedDuration().AsDuration(),
 		"run 2 AccumulatedSkippedDuration == run 1's accumulated (1h) + run 2's own skip for t2 (2h) = 3h")
 
@@ -1017,19 +1009,20 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInCaN() {
 	startedTSC := startedAttr.GetTimeSkippingConfig()
 	s.NotNil(startedTSC, "run 2's WorkflowExecutionStarted must carry the TSC snapshot")
 	s.True(startedTSC.GetEnabled(), "started event TSC.Enabled mirrors run 1's config")
-	s.approxDuration(time.Hour, startedTSC.GetPropagatedSkippedDuration().AsDuration(),
-		"started event retains PSD=1h (run 1's accumulated at CaN time); applyTimeSkippingConfig converts it to AccumulatedSkippedDuration on the MS but the event snapshot is unchanged")
+	s.approxDuration(time.Hour, startedAttr.GetInitialSkippedDuration().AsDuration(),
+		"started event retains InitialSkippedDuration=1h (run 1's accumulated at CaN time); applyTimeSkippingConfig uses it to seed AccumulatedSkippedDuration on the MS but the event snapshot is unchanged")
 }
 
 // TestTSPInRetry verifies that TimeSkippingConfig is propagated from the
 // original run's WorkflowExecutionStarted event to a retried workflow run.
 //
 // Retry's createRequest.TimeSkippingConfig is a verbatim copy of startAttr.TimeSkippingConfig
-// (event #1 of the previous run). applyTimeSkippingConfig then produces the same MS state
+// (event #1 of the previous run), and req.InitialSkippedDuration is a verbatim copy of
+// startAttr.InitialSkippedDuration. applyTimeSkippingConfig then produces the same MS state
 // the original run was booted with: Config.Enabled preserved; if the original event #1 had
-// a non-zero PSD snapshot (e.g., the original run was itself started as a child or via CaN),
-// that PSD is converted to AccumulatedSkippedDuration on the retry — otherwise the retry
-// starts with Accum=0.
+// a non-zero InitialSkippedDuration snapshot (e.g., the original run was itself started as
+// a child or via CaN), that value seeds AccumulatedSkippedDuration on the retry — otherwise
+// the retry starts with Accum=0.
 //
 // Key semantic: unlike continue-as-new, the previous attempt's *in-flight* accumulated
 // skip (skip that happened during the attempt) is NOT carried forward to the retry.
@@ -1038,21 +1031,23 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInCaN() {
 //
 // Scenario:
 //   - Start a top-level workflow with TimeSkippingConfig{Enabled: true} and
-//     RetryPolicy{MaximumAttempts: 2}. Event #1's TSC has PSD=0 (no parent, no prior CaN).
+//     RetryPolicy{MaximumAttempts: 2}. Event #1's InitialSkippedDuration is unset
+//     (no parent, no prior CaN).
 //   - Attempt 1 issues StartTimer(t1, 1h). Idle → server skips 1h → attempt1.Accum = 1h.
 //   - Attempt 1 issues FailWorkflowExecution with a bare (retryable) Failure.
 //   - Server schedules retry. Attempt 2 (retry run) starts.
-//     Its MS applies startAttr.TimeSkippingConfig: Config.Enabled=true, PSD=0 → Accum=0.
-//     Attempt 1's 1h in-flight skip is NOT carried forward.
+//     Its MS applies startAttr.TimeSkippingConfig: Config.Enabled=true, no initial skip
+//     → Accum=0. Attempt 1's 1h in-flight skip is NOT carried forward.
 //   - Attempt 2 issues StartTimer(t2, 2h). Idle → server skips 2h → attempt2.Accum = 2h.
 //   - Attempt 2 completes.
 //
 // End-state assertions:
 //   - Attempt 1: status=FAILED, Config.Enabled=true, Accum=1h.
-//   - Attempt 2: status=COMPLETED, Config.Enabled=true, Config.PSD unset on the MS,
-//     Accum=2h (own skip only; 1h from attempt 1 is NOT inherited).
+//   - Attempt 2: status=COMPLETED, Config.Enabled=true, Accum=2h (own skip only;
+//     1h from attempt 1 is NOT inherited).
 //   - Attempt 2's WorkflowExecutionStarted carries the same TSC snapshot as attempt 1's
-//     event #1 (Enabled=true, PSD=0) and references attempt 1 as ContinuedExecutionRunId.
+//     event #1 (Enabled=true, no InitialSkippedDuration) and references attempt 1 as
+//     ContinuedExecutionRunId.
 func (s *TimeSkippingPropagationTestSuite) TestTSPInRetry() {
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
@@ -1128,8 +1123,6 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInRetry() {
 	attempt2Cfg := attempt2TSI.GetConfig()
 	s.NotNil(attempt2Cfg)
 	s.True(attempt2Cfg.GetEnabled(), "attempt 2 TSC.Enabled propagated from attempt 1's event #1")
-	s.Zero(attempt2Cfg.GetPropagatedSkippedDuration().AsDuration(),
-		"attempt 2 Config.PSD unset — original event #1 had PSD=0 and applyTimeSkippingConfig strips PSD regardless")
 	s.approxDuration(2*time.Hour, attempt2TSI.GetAccumulatedSkippedDuration().AsDuration(),
 		"attempt 2 accumulated only its own 2h from t2; attempt 1's 1h in-flight skip is NOT carried forward on retry")
 
@@ -1149,34 +1142,36 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInRetry() {
 	startedTSC := startedAttr.GetTimeSkippingConfig()
 	s.NotNil(startedTSC, "attempt 2's WorkflowExecutionStarted must carry the TSC snapshot")
 	s.True(startedTSC.GetEnabled(), "started event TSC.Enabled mirrors attempt 1's event #1")
-	s.Zero(startedTSC.GetPropagatedSkippedDuration().AsDuration(),
-		"started event PSD matches attempt 1's event #1 (PSD=0 for a top-level workflow)")
+	s.Zero(startedAttr.GetInitialSkippedDuration().AsDuration(),
+		"started event InitialSkippedDuration matches attempt 1's event #1 (unset for a top-level workflow)")
 }
 
 // TestTSPInCron verifies that TimeSkippingConfig (Enabled + Bound) is
 // propagated from the previous run's WorkflowExecutionStarted event to a cron-scheduled
 // next run verbatim, while AccumulatedSkippedDuration is NOT inherited.
 //
-// Cron and retry share SetupNewWorkflowForRetryOrCron, which unconditionally copies
-// createRequest.TimeSkippingConfig = startAttr.GetTimeSkippingConfig() (event #1 of
-// the previous run) onto the new run. applyTimeSkippingConfig then strips PSD and
-// seeds AccumulatedSkippedDuration from it. For a top-level cron workflow, event #1
-// has PSD=0, so each cron run starts with Accum=0 — the previous run's in-flight
-// skip is NOT carried forward.
+// Cron and retry share SetupNewWorkflowForRetryOrCron, which copies
+// createRequest.TimeSkippingConfig = startAttr.GetTimeSkippingConfig() and
+// req.InitialSkippedDuration = startAttr.GetInitialSkippedDuration() from event #1 of
+// the previous run onto the new run. applyTimeSkippingConfig then seeds
+// AccumulatedSkippedDuration from InitialSkippedDuration. For a top-level cron workflow,
+// event #1 has no InitialSkippedDuration, so each cron run starts with Accum=0 — the
+// previous run's in-flight skip is NOT carried forward.
 //
 // Scenario:
 //   - Start a cron workflow (`* * * * *`) with TimeSkippingConfig{Enabled: true,
-//     Bound: MaxSkippedDuration(1h)}. Event #1's TSC has PSD=0 (no parent, no prior CaN).
+//     Bound: MaxSkippedDuration(1h)}. Event #1's InitialSkippedDuration is unset
+//     (no parent, no prior CaN).
 //   - Run 1 issues StartTimer(t1, 50min). Idle → server skips 50min → run1.Accum ≈ 50min.
 //   - Run 1 completes. Cron rolls forward; server creates run 2 with
 //     createRequest.TimeSkippingConfig = run 1's event #1 TSC (Enabled=true,
-//     Bound=MaxSkippedDuration(1h), PSD=0). applyTimeSkippingConfig strips PSD →
-//     run 2 MS has Config{Enabled: true, Bound: MaxSkippedDuration(1h)}, Accum=0.
+//     Bound=MaxSkippedDuration(1h)) and no InitialSkippedDuration → run 2 MS has
+//     Config{Enabled: true, Bound: MaxSkippedDuration(1h)}, Accum=0.
 //   - Run 2 completes immediately (no own skipping). Run 1's 50min accum is NOT inherited.
 //
 // End-state assertions:
 //   - Run 1: Config{Enabled, Bound=1h}, Accum ≈ 50min.
-//   - Run 2: Config{Enabled, Bound=1h} (inherited verbatim, PSD unset),
+//   - Run 2: Config{Enabled, Bound=1h} (inherited verbatim),
 //     Accum ≪ 50min (the previous run's in-flight skip is not carried forward).
 //   - Run 2's WorkflowExecutionStarted event carries the verbatim TSC snapshot from
 //     run 1's event #1, with initiator=CRON_SCHEDULE.
@@ -1221,22 +1216,16 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInCron() {
 		case state == 1 && fired["t1"]:
 			state = 2
 			return cmdsResponse(completeCmd()), nil
-		case state == 2:
-			// Run 2's first WFT: complete immediately. We only need run 2 to start
-			// so we can read its propagated Config; its own skipping behavior is
-			// not the subject of this test.
-			state = 3
-			return cmdsResponse(completeCmd()), nil
 		}
 		return &workflowservice.RespondWorkflowTaskCompletedRequest{}, nil
 	}
 
-	// Phase 1: drive run 1 to non-RUNNING (CONTINUED_AS_NEW once cron rolls forward).
+	// Drive run 1 to non-RUNNING (CONTINUED_AS_NEW once cron rolls forward). Run 2's
+	// assertions below only read state that's populated at run 2 creation (mutable state
+	// + event #1), so we don't need to drive run 2 through its cron backoff.
 	s.drivePollsUntilRunNotRunning(ctx, env, tv, handler, wfID, run1ID, 30)
 
 	// After run 1 closes, describe (no runID) gives the current chain run — that's run 2.
-	// Run 2 hasn't started executing yet (our state machine only fires on poll), so cron
-	// hasn't rolled past run 2.
 	desc, err := env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
 		Namespace: env.Namespace().String(),
 		Execution: &commonpb.WorkflowExecution{WorkflowId: wfID},
@@ -1245,13 +1234,10 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInCron() {
 	run2ID := desc.WorkflowExecutionInfo.Execution.RunId
 	s.NotEqual(run1ID, run2ID, "cron should have rolled forward to a new run")
 
-	// Phase 2: drive run 2 to non-RUNNING.
-	s.drivePollsUntilRunNotRunning(ctx, env, tv, handler, wfID, run2ID, 30)
-
 	elapsed := time.Since(startWall)
 	s.Less(elapsed, 3*time.Minute, "wall-clock elapsed (%s) should be far less than virtual time", elapsed)
 
-	// Stop the cron chain so run 3 (or later) doesn't keep firing.
+	// Stop the cron chain so run 2 (still in cron backoff) and any subsequent runs don't fire.
 	_, _ = env.FrontendClient().TerminateWorkflowExecution(ctx, &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace:         env.Namespace().String(),
 		WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: wfID},
@@ -1263,7 +1249,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInCron() {
 	run1TSI := run1MS.State.ExecutionInfo.GetTimeSkippingInfo()
 	s.NotNil(run1TSI)
 	s.True(proto.Equal(inputCfg, run1TSI.GetConfig()),
-		"run 1 Config mirrors the start request: Enabled=true, Bound=MaxSkippedDuration(1h), PSD unset")
+		"run 1 Config mirrors the start request: Enabled=true, Bound=MaxSkippedDuration(1h)")
 	// Tolerance absorbs per-skip clock drift plus up to ~60s of cron backoff that may
 	// be skipped while waiting for the first WFT.
 	s.InDelta(float64(50*time.Minute), float64(run1TSI.GetAccumulatedSkippedDuration().AsDuration()), float64(90*time.Second),
@@ -1274,7 +1260,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInCron() {
 	run2TSI := run2MS.State.ExecutionInfo.GetTimeSkippingInfo()
 	s.NotNil(run2TSI, "run 2 should have TimeSkippingInfo propagated from run 1's event #1")
 	s.True(proto.Equal(inputCfg, run2TSI.GetConfig()),
-		"run 2 Config matches run 1's event #1 verbatim: Enabled=true and Bound=MaxSkippedDuration(1h) are inherited; Config.PSD is stripped by applyTimeSkippingConfig")
+		"run 2 Config matches run 1's event #1 verbatim: Enabled=true and Bound=MaxSkippedDuration(1h) are inherited")
 	s.Less(run2TSI.GetAccumulatedSkippedDuration().AsDuration(), 10*time.Minute,
 		"run 2 Accum is fresh — nowhere near run 1's 50min; the previous run's in-flight skip is NOT carried forward on cron")
 
@@ -1292,5 +1278,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInCron() {
 	s.Equal(enumspb.CONTINUE_AS_NEW_INITIATOR_CRON_SCHEDULE, startedAttr.GetInitiator(),
 		"run 2 is initiated by cron schedule")
 	s.True(proto.Equal(inputCfg, startedAttr.GetTimeSkippingConfig()),
-		"started event carries Enabled=true, Bound=MaxSkippedDuration(1h), PSD=0 — the verbatim snapshot from run 1's event #1")
+		"started event carries Enabled=true, Bound=MaxSkippedDuration(1h) — the verbatim snapshot from run 1's event #1")
+	s.Zero(startedAttr.GetInitialSkippedDuration().AsDuration(),
+		"started event InitialSkippedDuration is unset for a top-level cron workflow")
 }

--- a/tests/timeskipping_propagation_test.go
+++ b/tests/timeskipping_propagation_test.go
@@ -620,6 +620,22 @@ func completeCmd() *commandpb.Command {
 	}
 }
 
+// continueAsNewCmd builds a ContinueAsNewWorkflowExecution command with the given workflow
+// type and task queue, using the same virtual-time timeouts as the other command helpers.
+func continueAsNewCmd(wfType *commonpb.WorkflowType, tq *taskqueuepb.TaskQueue) *commandpb.Command {
+	return &commandpb.Command{
+		CommandType: enumspb.COMMAND_TYPE_CONTINUE_AS_NEW_WORKFLOW_EXECUTION,
+		Attributes: &commandpb.Command_ContinueAsNewWorkflowExecutionCommandAttributes{
+			ContinueAsNewWorkflowExecutionCommandAttributes: &commandpb.ContinueAsNewWorkflowExecutionCommandAttributes{
+				WorkflowType:        wfType,
+				TaskQueue:           tq,
+				WorkflowRunTimeout:  durationpb.New(24 * time.Hour),
+				WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+			},
+		},
+	}
+}
+
 // cmdsResponse wraps a list of commands in a RespondWorkflowTaskCompletedRequest.
 func cmdsResponse(cmds ...*commandpb.Command) *workflowservice.RespondWorkflowTaskCompletedRequest {
 	return &workflowservice.RespondWorkflowTaskCompletedRequest{Commands: cmds}
@@ -774,4 +790,124 @@ func (s *TimeSkippingPropagationTestSuite) TestPropagationInReset() {
 	s.NotNil(startedTSC, "WorkflowExecutionStarted should carry the original TimeSkippingConfig")
 	s.False(startedTSC.GetEnabled(),
 		"WorkflowExecutionStarted on reset run should carry the original disabled config; the later enable comes from reapply, not replay")
+}
+
+// TestPropagationInCaN verifies that TimeSkippingConfig and the previous run's
+// AccumulatedSkippedDuration are propagated to the new run on continue-as-new.
+//
+// Continue-as-new is a continuation of the same logical workflow, so the previous
+// run's accumulated skip flows directly into the new run's AccumulatedSkippedDuration
+// (not stored as Config.PropagatedSkippedDuration metadata like the child-workflow case).
+//
+// Scenario:
+//   - Run 1 starts with TimeSkippingConfig{Enabled: true}.
+//   - Run 1 issues StartTimer(t1, 1h). Idle → server skips 1h.
+//     After skip: run1.AccumulatedSkippedDuration = 1h.
+//   - t1 fires. Run 1 issues ContinueAsNew (same type, same task queue).
+//   - Run 2 starts with its AccumulatedSkippedDuration seeded to 1h (inherited
+//     from run 1) and Config.Enabled = true.
+//   - Run 2 issues StartTimer(t2, 2h). Idle → skips 2h.
+//     After skip: run2.AccumulatedSkippedDuration = 1h + 2h = 3h.
+//   - t2 fires. Run 2 completes.
+//
+// End-state assertions:
+//   - run1.status == CONTINUED_AS_NEW, run1.AccumulatedSkippedDuration == 1h.
+//   - run2.status == COMPLETED.
+//   - run2.TimeSkippingInfo.Config.Enabled == true (propagated).
+//   - run2.TimeSkippingInfo.Config.PropagatedSkippedDuration is unset — CaN carries
+//     the inherited skip in AccumulatedSkippedDuration, not as PSD metadata.
+//   - run2.AccumulatedSkippedDuration == 3h.
+//   - run2 WorkflowExecutionStarted event carries a TSC snapshot with Enabled=true
+//     and no PSD.
+//   - Wall-clock elapsed is nowhere near 3h of virtual time.
+func (s *TimeSkippingPropagationTestSuite) TestPropagationInCaN() {
+	env := testcore.NewEnv(s.T())
+	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	tv := testvars.New(s.T())
+	ctx := testcore.NewContext()
+
+	wfType := tv.WorkflowType()
+	wfID := tv.WorkflowID()
+	tq := tv.TaskQueue()
+
+	startWall := time.Now()
+
+	start1, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           uuid.NewString(),
+		Namespace:           env.Namespace().String(),
+		WorkflowId:          wfID,
+		WorkflowType:        wfType,
+		TaskQueue:           tq,
+		WorkflowRunTimeout:  durationpb.New(24 * time.Hour),
+		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+		TimeSkippingConfig:  &workflowpb.TimeSkippingConfig{Enabled: true},
+	})
+	s.NoError(err)
+	run1ID := start1.RunId
+
+	state := 0
+	handler := func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		fired := firedTimers(task)
+		switch {
+		case state == 0:
+			state = 1
+			return cmdsResponse(timerCmd("t1", time.Hour)), nil
+		case state == 1 && fired["t1"]:
+			state = 2
+			return cmdsResponse(continueAsNewCmd(wfType, tq)), nil
+		case state == 2:
+			state = 3
+			return cmdsResponse(timerCmd("t2", 2*time.Hour)), nil
+		case state == 3 && fired["t2"]:
+			state = 4
+			return cmdsResponse(completeCmd()), nil
+		}
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{}, nil
+	}
+
+	// Empty runID so describe follows the chain to the current run (run 2 after CaN).
+	s.drivePollsUntilClosed(env, ctx, tv, handler, wfID, "", 20)
+
+	elapsed := time.Since(startWall)
+	s.Less(elapsed, 2*time.Minute, "wall-clock elapsed (%s) should be far less than 3h of virtual time", elapsed)
+
+	// ---- Run 1: closed with CONTINUED_AS_NEW ----
+	run1MS := s.getMutableState(env, wfID, run1ID)
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW, run1MS.State.ExecutionState.Status)
+	run1TSI := run1MS.State.ExecutionInfo.GetTimeSkippingInfo()
+	s.NotNil(run1TSI)
+	s.approxDuration(time.Hour, run1TSI.GetAccumulatedSkippedDuration().AsDuration(),
+		"run 1 should have skipped 1h for t1 before continue-as-new")
+
+	// ---- Run 2: the CaN'd-into run, completed ----
+	run2MS := s.getMutableStateByID(env, ctx, wfID)
+	run2ID := run2MS.State.ExecutionState.RunId
+	s.NotEqual(run1ID, run2ID, "run 2 should have a new run ID")
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, run2MS.State.ExecutionState.Status)
+	run2TSI := run2MS.State.ExecutionInfo.GetTimeSkippingInfo()
+	s.NotNil(run2TSI, "run 2 should have TimeSkippingInfo propagated from run 1")
+	run2Cfg := run2TSI.GetConfig()
+	s.NotNil(run2Cfg)
+	s.True(run2Cfg.GetEnabled(), "run 2 TSC.Enabled propagated from run 1")
+	s.Zero(run2Cfg.GetPropagatedSkippedDuration().AsDuration(),
+		"CaN must not leave PropagatedSkippedDuration set on the Config; the inherited skip goes into AccumulatedSkippedDuration")
+	s.approxDuration(3*time.Hour, run2TSI.GetAccumulatedSkippedDuration().AsDuration(),
+		"run 2 AccumulatedSkippedDuration == run 1's accumulated (1h) + run 2's own skip for t2 (2h) = 3h")
+
+	// Run 2's WorkflowExecutionStarted event must carry the propagated TSC snapshot.
+	hist2, err := env.FrontendClient().GetWorkflowExecutionHistory(ctx, &workflowservice.GetWorkflowExecutionHistoryRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: wfID, RunId: run2ID},
+	})
+	s.NoError(err)
+	s.NotEmpty(hist2.History.Events)
+	startedAttr := hist2.History.Events[0].GetWorkflowExecutionStartedEventAttributes()
+	s.NotNil(startedAttr)
+	s.Equal(run1ID, startedAttr.GetContinuedExecutionRunId(),
+		"run 2 should reference run 1 as its predecessor")
+	startedTSC := startedAttr.GetTimeSkippingConfig()
+	s.NotNil(startedTSC, "run 2's WorkflowExecutionStarted must carry the TSC snapshot")
+	s.True(startedTSC.GetEnabled(), "started event TSC.Enabled mirrors run 1's config")
+	s.Zero(startedTSC.GetPropagatedSkippedDuration().AsDuration(),
+		"started event must not carry PropagatedSkippedDuration; the inherited skip is on run 2's AccumulatedSkippedDuration")
 }

--- a/tests/timeskipping_propagation_test.go
+++ b/tests/timeskipping_propagation_test.go
@@ -1,3 +1,51 @@
+// Tests in this file exercise how TimeSkippingConfig and AccumulatedSkippedDuration
+// cross workflow boundaries. Each test pins one of three inheritance semantics.
+//
+// Group 1 — Inherit both from the current execution.
+//
+//	Continue-as-new: a new run is a technical continuation of the same logical run,
+//	so the current config AND accumulated skipped duration are both inherited. The
+//	configured bound is shared: it caps the sum of inherited skip + new-run skip,
+//	not each separately.
+//
+//	Child workflows: same as continue-as-new. A child can be viewed as either an
+//	extension of the parent or a separate workflow; either way, virtual time must
+//	not rewind, so the child inherits the parent's accumulated skip. The default
+//	behavior treats the child as an extension and shares the config; a child-level
+//	override is only added when explicitly needed.
+//
+//	Covered by:
+//	  - TestTSPInChildWf_Basic
+//	  - TestTSPInChildWf_TwoChildren
+//	  - TestTSPInChildWf_ThreeGenerations
+//	  - TestTSPInCaN
+//
+// Group 2 — Inherit from a specific point in history.
+//
+//	Retry: a retried run is defined as restarting execution from the previous run's
+//	WorkflowExecutionStarted event. The new run inherits the config and PSD recorded
+//	on that event verbatim; in-flight skip accumulated during the failed attempt is
+//	NOT carried forward.
+//
+//	Cron: same as retry. Each cron run restarts from the previous run's event #1
+//	snapshot; the previous run's in-flight skip is not carried forward.
+//
+//	Covered by:
+//	  - TestTSPInRetry
+//	  - TestTSPInCron
+//
+// Group 3 — Inherit from a specific point, then catch up on config changes.
+//
+//	Reset: retains the current TimeSkippingConfig at reset time. Reset replays all
+//	events up to the reset point (giving the new run the config as-of that point),
+//	then reapplies any WorkflowExecutionOptionsUpdated events that occurred between
+//	the reset point and the original run's terminal state. Reapply is unconditional
+//	— there is no ResetReapplyExcludeType value that can suppress OPTIONS_UPDATED.
+//	AccumulatedSkippedDuration on the reset run starts from the event #1 PSD (same
+//	as Group 2); original-run in-flight skip is not carried forward.
+//
+//	Covered by:
+//	  - TestTSPInReset
 package tests
 
 import (
@@ -23,6 +71,7 @@ import (
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/common/testing/testvars"
 	"go.temporal.io/server/tests/testcore"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
@@ -35,7 +84,7 @@ func TestTimeSkippingPropagationTestSuite(t *testing.T) {
 	parallelsuite.Run(t, &TimeSkippingPropagationTestSuite{})
 }
 
-// TestTimeSkippingPropagation_ParentTimerChildTimerParentTimer exercises end-to-end
+// TestTSPInChildWf_Basic exercises end-to-end
 // propagation of TimeSkippingConfig + AccumulatedSkippedDuration from parent to child,
 // together with the idle-only skipping invariant on the parent.
 //
@@ -71,7 +120,7 @@ func TestTimeSkippingPropagationTestSuite(t *testing.T) {
 //   - The parent's StartChildWorkflowExecutionInitiated event retains PSD=1h (the
 //     pre-apply snapshot; it is the wire form the transfer task consumes).
 //   - Wall-clock elapsed is nowhere near 5h of virtual time.
-func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ParentTimerChildTimerParentTimer() {
+func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_Basic() {
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
@@ -177,7 +226,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ParentTim
 		"snapshot PSD == parent's AccumulatedSkippedDuration at command time (1h)")
 }
 
-// TestTimeSkippingPropagation_ParentWithTwoChildren verifies that:
+// TestTSPInChildWf_TwoChildren verifies that:
 //   - All children started in the same WFT inherit the parent's TimeSkippingConfig
 //     and have their AccumulatedSkippedDuration seeded to the parent's accumulated
 //     skip at child-start time (via the PSD snapshot on the initiated event, which
@@ -194,7 +243,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ParentTim
 //   - c2 issues StartTimer(tc2, 2h) → idle → skips 2h → completes.
 //   - Only after BOTH c1 and c2 complete does parent become idle on t2 → skips 1h → t2 fires.
 //   - Parent completes.
-func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ParentWithTwoChildren() {
+func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_TwoChildren() {
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
@@ -305,7 +354,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ParentWit
 	}
 }
 
-// TestTimeSkippingPropagation_ThreeGenerations verifies that AccumulatedSkippedDuration
+// TestTSPInChildWf_ThreeGenerations verifies that AccumulatedSkippedDuration
 // flows transitively through the ancestry: each generation's MS starts with its direct
 // parent's accumulated skip (which already includes all ancestors' contributions) seeded
 // into AccumulatedSkippedDuration, then adds its own skipping on top.
@@ -327,7 +376,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ParentWit
 //   - G: idle on gt2 → skips 1h → G.accum = 1h + 1h = 2h. gt2 fires. G completes.
 //
 // Final state: C.accum == 4h (3h inherited + 1h own); P.accum == 4h; G.accum == 2h.
-func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ThreeGenerations() {
+func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_ThreeGenerations() {
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
@@ -531,6 +580,33 @@ func (s *TimeSkippingPropagationTestSuite) drivePollsUntilClosed(
 	}
 }
 
+// drivePollsUntilRunNotRunning is like drivePollsUntilClosed but exits on any non-RUNNING
+// status. Used for cron, where a run rolls to CONTINUED_AS_NEW rather than COMPLETED and
+// the chain's "current run" keeps advancing indefinitely.
+func (s *TimeSkippingPropagationTestSuite) drivePollsUntilRunNotRunning(
+	ctx context.Context,
+	env *testcore.TestEnv,
+	tv *testvars.TestVars,
+	handler func(*workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error),
+	workflowID, runID string,
+	maxIterations int,
+) {
+	for i := range maxIterations {
+		_, pollErr := env.TaskPoller().PollAndHandleWorkflowTask(tv, handler)
+		if pollErr != nil {
+			s.T().Logf("iter %d: poll error (likely timeout): %v", i, pollErr)
+		}
+		desc, err := env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
+			Execution: &commonpb.WorkflowExecution{WorkflowId: workflowID, RunId: runID},
+		})
+		s.NoError(err)
+		if desc.WorkflowExecutionInfo.Status != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING {
+			return
+		}
+	}
+}
+
 // getMutableState loads the persistence-layer mutable state for a workflow run.
 // Mirrors the helper in timeskipping_test.go to keep this file self-contained.
 func (s *TimeSkippingPropagationTestSuite) getMutableState(env *testcore.TestEnv, workflowID, runID string) *persistence.GetWorkflowExecutionResponse {
@@ -710,7 +786,7 @@ func (s *TimeSkippingPropagationTestSuite) firstWorkflowTaskCompletedEventID(
 // is reapplied unconditionally at workflow_resetter.go — there is no
 // ResetReapplyExcludeType value that can suppress it. The test pins this
 // behavior so a future change would surface it.
-func (s *TimeSkippingPropagationTestSuite) TestPropagationInReset() {
+func (s *TimeSkippingPropagationTestSuite) TestTSPInReset() {
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
@@ -822,7 +898,7 @@ func (s *TimeSkippingPropagationTestSuite) TestPropagationInReset() {
 		"WorkflowExecutionStarted on reset run should carry the original disabled config; the later enable comes from reapply, not replay")
 }
 
-// TestPropagationInCaN verifies that TimeSkippingConfig and the previous run's
+// TestTSPInCaN verifies that TimeSkippingConfig and the previous run's
 // AccumulatedSkippedDuration are propagated to the new run on continue-as-new.
 //
 // CaN uses the same propagation mechanism as child workflows: the previous run's
@@ -853,7 +929,7 @@ func (s *TimeSkippingPropagationTestSuite) TestPropagationInReset() {
 //   - run2 WorkflowExecutionStarted event retains the PSD=1h snapshot (history
 //     observability — the event is created before applyTimeSkippingConfig runs).
 //   - Wall-clock elapsed is nowhere near 3h of virtual time.
-func (s *TimeSkippingPropagationTestSuite) TestPropagationInCaN() {
+func (s *TimeSkippingPropagationTestSuite) TestTSPInCaN() {
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
@@ -945,7 +1021,7 @@ func (s *TimeSkippingPropagationTestSuite) TestPropagationInCaN() {
 		"started event retains PSD=1h (run 1's accumulated at CaN time); applyTimeSkippingConfig converts it to AccumulatedSkippedDuration on the MS but the event snapshot is unchanged")
 }
 
-// TestPropagationInRetry verifies that TimeSkippingConfig is propagated from the
+// TestTSPInRetry verifies that TimeSkippingConfig is propagated from the
 // original run's WorkflowExecutionStarted event to a retried workflow run.
 //
 // Retry's createRequest.TimeSkippingConfig is a verbatim copy of startAttr.TimeSkippingConfig
@@ -977,7 +1053,7 @@ func (s *TimeSkippingPropagationTestSuite) TestPropagationInCaN() {
 //     Accum=2h (own skip only; 1h from attempt 1 is NOT inherited).
 //   - Attempt 2's WorkflowExecutionStarted carries the same TSC snapshot as attempt 1's
 //     event #1 (Enabled=true, PSD=0) and references attempt 1 as ContinuedExecutionRunId.
-func (s *TimeSkippingPropagationTestSuite) TestPropagationInRetry() {
+func (s *TimeSkippingPropagationTestSuite) TestTSPInRetry() {
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
@@ -1075,4 +1151,146 @@ func (s *TimeSkippingPropagationTestSuite) TestPropagationInRetry() {
 	s.True(startedTSC.GetEnabled(), "started event TSC.Enabled mirrors attempt 1's event #1")
 	s.Zero(startedTSC.GetPropagatedSkippedDuration().AsDuration(),
 		"started event PSD matches attempt 1's event #1 (PSD=0 for a top-level workflow)")
+}
+
+// TestTSPInCron verifies that TimeSkippingConfig (Enabled + Bound) is
+// propagated from the previous run's WorkflowExecutionStarted event to a cron-scheduled
+// next run verbatim, while AccumulatedSkippedDuration is NOT inherited.
+//
+// Cron and retry share SetupNewWorkflowForRetryOrCron, which unconditionally copies
+// createRequest.TimeSkippingConfig = startAttr.GetTimeSkippingConfig() (event #1 of
+// the previous run) onto the new run. applyTimeSkippingConfig then strips PSD and
+// seeds AccumulatedSkippedDuration from it. For a top-level cron workflow, event #1
+// has PSD=0, so each cron run starts with Accum=0 — the previous run's in-flight
+// skip is NOT carried forward.
+//
+// Scenario:
+//   - Start a cron workflow (`* * * * *`) with TimeSkippingConfig{Enabled: true,
+//     Bound: MaxSkippedDuration(1h)}. Event #1's TSC has PSD=0 (no parent, no prior CaN).
+//   - Run 1 issues StartTimer(t1, 50min). Idle → server skips 50min → run1.Accum ≈ 50min.
+//   - Run 1 completes. Cron rolls forward; server creates run 2 with
+//     createRequest.TimeSkippingConfig = run 1's event #1 TSC (Enabled=true,
+//     Bound=MaxSkippedDuration(1h), PSD=0). applyTimeSkippingConfig strips PSD →
+//     run 2 MS has Config{Enabled: true, Bound: MaxSkippedDuration(1h)}, Accum=0.
+//   - Run 2 completes immediately (no own skipping). Run 1's 50min accum is NOT inherited.
+//
+// End-state assertions:
+//   - Run 1: Config{Enabled, Bound=1h}, Accum ≈ 50min.
+//   - Run 2: Config{Enabled, Bound=1h} (inherited verbatim, PSD unset),
+//     Accum ≪ 50min (the previous run's in-flight skip is not carried forward).
+//   - Run 2's WorkflowExecutionStarted event carries the verbatim TSC snapshot from
+//     run 1's event #1, with initiator=CRON_SCHEDULE.
+func (s *TimeSkippingPropagationTestSuite) TestTSPInCron() {
+	env := testcore.NewEnv(s.T())
+	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	tv := testvars.New(s.T())
+	ctx := testcore.NewContext()
+
+	wfType := tv.WorkflowType()
+	wfID := tv.WorkflowID()
+	tq := tv.TaskQueue()
+
+	bound := &workflowpb.TimeSkippingConfig_MaxSkippedDuration{
+		MaxSkippedDuration: durationpb.New(time.Hour),
+	}
+	inputCfg := &workflowpb.TimeSkippingConfig{Enabled: true, Bound: bound}
+
+	startWall := time.Now()
+
+	start1, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           uuid.NewString(),
+		Namespace:           env.Namespace().String(),
+		WorkflowId:          wfID,
+		WorkflowType:        wfType,
+		TaskQueue:           tq,
+		WorkflowRunTimeout:  durationpb.New(24 * time.Hour),
+		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+		TimeSkippingConfig:  inputCfg,
+		CronSchedule:        "* * * * *",
+	})
+	s.NoError(err)
+	run1ID := start1.RunId
+
+	state := 0
+	handler := func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		fired := firedTimers(task)
+		switch {
+		case state == 0:
+			state = 1
+			return cmdsResponse(timerCmd("t1", 50*time.Minute)), nil
+		case state == 1 && fired["t1"]:
+			state = 2
+			return cmdsResponse(completeCmd()), nil
+		case state == 2:
+			// Run 2's first WFT: complete immediately. We only need run 2 to start
+			// so we can read its propagated Config; its own skipping behavior is
+			// not the subject of this test.
+			state = 3
+			return cmdsResponse(completeCmd()), nil
+		}
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{}, nil
+	}
+
+	// Phase 1: drive run 1 to non-RUNNING (CONTINUED_AS_NEW once cron rolls forward).
+	s.drivePollsUntilRunNotRunning(ctx, env, tv, handler, wfID, run1ID, 30)
+
+	// After run 1 closes, describe (no runID) gives the current chain run — that's run 2.
+	// Run 2 hasn't started executing yet (our state machine only fires on poll), so cron
+	// hasn't rolled past run 2.
+	desc, err := env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: wfID},
+	})
+	s.NoError(err)
+	run2ID := desc.WorkflowExecutionInfo.Execution.RunId
+	s.NotEqual(run1ID, run2ID, "cron should have rolled forward to a new run")
+
+	// Phase 2: drive run 2 to non-RUNNING.
+	s.drivePollsUntilRunNotRunning(ctx, env, tv, handler, wfID, run2ID, 30)
+
+	elapsed := time.Since(startWall)
+	s.Less(elapsed, 3*time.Minute, "wall-clock elapsed (%s) should be far less than virtual time", elapsed)
+
+	// Stop the cron chain so run 3 (or later) doesn't keep firing.
+	_, _ = env.FrontendClient().TerminateWorkflowExecution(ctx, &workflowservice.TerminateWorkflowExecutionRequest{
+		Namespace:         env.Namespace().String(),
+		WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: wfID},
+		Reason:            "test cleanup: stop cron chain",
+	})
+
+	// ---- Run 1: Config{Enabled, Bound=1h}, Accum ≈ 50min ----
+	run1MS := s.getMutableState(env, wfID, run1ID)
+	run1TSI := run1MS.State.ExecutionInfo.GetTimeSkippingInfo()
+	s.NotNil(run1TSI)
+	s.True(proto.Equal(inputCfg, run1TSI.GetConfig()),
+		"run 1 Config mirrors the start request: Enabled=true, Bound=MaxSkippedDuration(1h), PSD unset")
+	// Tolerance absorbs per-skip clock drift plus up to ~60s of cron backoff that may
+	// be skipped while waiting for the first WFT.
+	s.InDelta(float64(50*time.Minute), float64(run1TSI.GetAccumulatedSkippedDuration().AsDuration()), float64(90*time.Second),
+		"run 1 skipped ~50min for t1 before cron rolled it forward")
+
+	// ---- Run 2: Config inherited (Enabled + Bound); Accum NOT inherited ----
+	run2MS := s.getMutableState(env, wfID, run2ID)
+	run2TSI := run2MS.State.ExecutionInfo.GetTimeSkippingInfo()
+	s.NotNil(run2TSI, "run 2 should have TimeSkippingInfo propagated from run 1's event #1")
+	s.True(proto.Equal(inputCfg, run2TSI.GetConfig()),
+		"run 2 Config matches run 1's event #1 verbatim: Enabled=true and Bound=MaxSkippedDuration(1h) are inherited; Config.PSD is stripped by applyTimeSkippingConfig")
+	s.Less(run2TSI.GetAccumulatedSkippedDuration().AsDuration(), 10*time.Minute,
+		"run 2 Accum is fresh — nowhere near run 1's 50min; the previous run's in-flight skip is NOT carried forward on cron")
+
+	// Run 2's WorkflowExecutionStarted carries the verbatim TSC snapshot from run 1's event #1.
+	hist2, err := env.FrontendClient().GetWorkflowExecutionHistory(ctx, &workflowservice.GetWorkflowExecutionHistoryRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: wfID, RunId: run2ID},
+	})
+	s.NoError(err)
+	s.NotEmpty(hist2.History.Events)
+	startedAttr := hist2.History.Events[0].GetWorkflowExecutionStartedEventAttributes()
+	s.NotNil(startedAttr)
+	s.Equal(run1ID, startedAttr.GetContinuedExecutionRunId(),
+		"run 2 references run 1 as its predecessor via ContinuedExecutionRunId")
+	s.Equal(enumspb.CONTINUE_AS_NEW_INITIATOR_CRON_SCHEDULE, startedAttr.GetInitiator(),
+		"run 2 is initiated by cron schedule")
+	s.True(proto.Equal(inputCfg, startedAttr.GetTimeSkippingConfig()),
+		"started event carries Enabled=true, Bound=MaxSkippedDuration(1h), PSD=0 — the verbatim snapshot from run 1's event #1")
 }

--- a/tests/timeskipping_propagation_test.go
+++ b/tests/timeskipping_propagation_test.go
@@ -1,0 +1,625 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	commandpb "go.temporal.io/api/command/v1"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	workflowpb "go.temporal.io/api/workflow/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/testing/parallelsuite"
+	"go.temporal.io/server/common/testing/testvars"
+	"go.temporal.io/server/tests/testcore"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+type TimeSkippingPropagationTestSuite struct {
+	parallelsuite.Suite[*TimeSkippingPropagationTestSuite]
+}
+
+func TestTimeSkippingPropagationTestSuite(t *testing.T) {
+	parallelsuite.Run(t, &TimeSkippingPropagationTestSuite{})
+}
+
+// TestTimeSkippingPropagation_ParentTimerChildTimerParentTimer exercises end-to-end
+// propagation of TimeSkippingConfig + PropagatedSkippedDuration from parent to child,
+// together with the idle-only skipping invariant on the parent.
+//
+// Scenario:
+//   - Parent starts with TimeSkippingConfig{Enabled: true}.
+//   - Parent issues StartTimer(t1, 1h). Parent is idle on t1 → server skips 1h.
+//     After skip: parent.AccumulatedSkippedDuration = 1h.
+//   - t1 fires. Parent issues StartChildWorkflow(child) and StartTimer(t2, 1h).
+//     Parent now has a pending child → NOT idle → parent does NOT skip.
+//   - Child is started. Its mutable state receives TimeSkippingConfig propagated
+//     from the parent, plus PropagatedSkippedDuration = 1h (parent's accumulated
+//     skip at the moment the child started).
+//   - Child issues StartTimer(tc, 3h). Child is idle → server skips 3h.
+//     After skip: child.AccumulatedSkippedDuration = 3h.
+//   - tc fires. Child completes.
+//   - Parent receives ChildWorkflowExecutionCompleted. Parent is now only waiting
+//     on t2 → idle → server skips 1h to fire t2.
+//     After skip: parent.AccumulatedSkippedDuration = 2h.
+//   - t2 fires. Parent completes.
+//
+// End-state assertions:
+//   - parent.AccumulatedSkippedDuration == 2h.
+//   - child.TimeSkippingInfo.Config.Enabled == true (propagated).
+//   - child.TimeSkippingInfo.Config.PropagatedSkippedDuration == 1h.
+//   - child.AccumulatedSkippedDuration == 3h.
+//   - child's total virtual advance (propagated + accumulated) == 4h.
+//   - Wall-clock elapsed is nowhere near 5h of virtual time.
+func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ParentTimerChildTimerParentTimer() {
+	env := testcore.NewEnv(s.T())
+	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	tv := testvars.New(s.T())
+	ctx := testcore.NewContext()
+
+	parentWFType := tv.WorkflowType()
+	childWFType := &commonpb.WorkflowType{Name: parentWFType.Name + "-child"}
+	parentWFID := tv.WorkflowID()
+	childWFID := parentWFID + "-child"
+
+	startWall := time.Now()
+
+	parentStart, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           uuid.NewString(),
+		Namespace:           env.Namespace().String(),
+		WorkflowId:          parentWFID,
+		WorkflowType:        parentWFType,
+		TaskQueue:           tv.TaskQueue(),
+		WorkflowRunTimeout:  durationpb.New(24 * time.Hour),
+		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+		TimeSkippingConfig:  &workflowpb.TimeSkippingConfig{Enabled: true},
+	})
+	s.NoError(err)
+	parentRunID := parentStart.RunId
+
+	ns := env.Namespace().String()
+	tq := tv.TaskQueue()
+
+	parentStarted, parentKickedOff, parentDone := false, false, false
+	parentHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		fired := firedTimers(task)
+		if !parentStarted {
+			parentStarted = true
+			return cmdsResponse(timerCmd("t1", time.Hour)), nil
+		}
+		if fired["t1"] && !parentKickedOff {
+			parentKickedOff = true
+			return cmdsResponse(
+				childCmd(ns, childWFID, childWFType, tq),
+				timerCmd("t2", time.Hour),
+			), nil
+		}
+		if fired["t2"] && !parentDone {
+			parentDone = true
+			return cmdsResponse(completeCmd()), nil
+		}
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{}, nil
+	}
+
+	childStarted, childDone := false, false
+	childHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		fired := firedTimers(task)
+		if !childStarted {
+			childStarted = true
+			return cmdsResponse(timerCmd("tc", 3*time.Hour)), nil
+		}
+		if fired["tc"] && !childDone {
+			childDone = true
+			return cmdsResponse(completeCmd()), nil
+		}
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{}, nil
+	}
+
+	dispatch := typeDispatch(map[string]wftHandler{
+		parentWFType.Name: parentHandler,
+		childWFType.Name:  childHandler,
+	})
+
+	s.drivePollsUntilClosed(env, ctx, tv, dispatch, parentWFID, parentRunID, 20)
+
+	elapsed := time.Since(startWall)
+	s.Less(elapsed, 2*time.Minute, "wall-clock elapsed (%s) should be far less than 5h of virtual time", elapsed)
+
+	// ---- Parent ----
+	parentMS := s.getMutableState(env, parentWFID, parentRunID)
+	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED, parentMS.State.ExecutionState.State)
+	parentTSI := parentMS.State.ExecutionInfo.GetTimeSkippingInfo()
+	s.NotNil(parentTSI)
+	s.approxDuration(2*time.Hour, parentTSI.GetAccumulatedSkippedDuration().AsDuration(),
+		"parent should accumulate 1h (t1) + 1h (t2 after child) = 2h")
+
+	// ---- Child ----
+	childMS := s.getMutableStateByID(env, ctx, childWFID)
+	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED, childMS.State.ExecutionState.State)
+	childTSI := childMS.State.ExecutionInfo.GetTimeSkippingInfo()
+	s.NotNil(childTSI)
+	childCfg := childTSI.GetConfig()
+	s.NotNil(childCfg)
+	s.True(childCfg.GetEnabled(), "child TSC.Enabled propagated from parent")
+	s.approxDuration(time.Hour, childCfg.GetPropagatedSkippedDuration().AsDuration(),
+		"child PropagatedSkippedDuration == parent's AccumulatedSkippedDuration at child-start (1h)")
+	s.approxDuration(3*time.Hour, childTSI.GetAccumulatedSkippedDuration().AsDuration(),
+		"child accumulated 3h from tc")
+	s.approxDuration(4*time.Hour,
+		childCfg.GetPropagatedSkippedDuration().AsDuration()+childTSI.GetAccumulatedSkippedDuration().AsDuration(),
+		"child virtual ends 4h ahead (1h propagated + 3h accumulated)")
+
+	// The parent's StartChildWorkflowExecutionInitiated event must carry the propagated
+	// TimeSkippingConfig — this is what the transfer task consumes when it starts the child.
+	initEvents := s.initiatedChildEvents(ctx, env, parentWFID, parentRunID)
+	s.Len(initEvents, 1)
+	initTSC := initEvents[0].GetStartChildWorkflowExecutionInitiatedEventAttributes().GetTimeSkippingConfig()
+	s.NotNil(initTSC, "initiated event should carry TimeSkippingConfig snapshot")
+	s.True(initTSC.GetEnabled(), "snapshot mirrors parent's Enabled flag")
+	s.approxDuration(time.Hour, initTSC.GetPropagatedSkippedDuration().AsDuration(),
+		"snapshot PSD == parent's AccumulatedSkippedDuration at command time (1h)")
+}
+
+// TestTimeSkippingPropagation_ParentWithTwoChildren verifies that:
+//   - All children started in the same WFT inherit the parent's TimeSkippingConfig and
+//     the parent's AccumulatedSkippedDuration at the moment they start.
+//   - The parent is blocked from skipping while ANY child is pending, and resumes
+//     skipping only after all children complete (idle-only invariant).
+//
+// Scenario:
+//   - Parent TSC enabled. Parent issues StartTimer(t1, 1h) → skips 1h.
+//   - Parent issues [StartChild(c1), StartChild(c2), StartTimer(t2, 1h)].
+//     Each child inherits TSC and receives PropagatedSkippedDuration = 1h.
+//   - c1 issues StartTimer(tc1, 2h) → idle → skips 2h → completes.
+//   - c2 issues StartTimer(tc2, 2h) → idle → skips 2h → completes.
+//   - Only after BOTH c1 and c2 complete does parent become idle on t2 → skips 1h → t2 fires.
+//   - Parent completes.
+func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ParentWithTwoChildren() {
+	env := testcore.NewEnv(s.T())
+	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	tv := testvars.New(s.T())
+	ctx := testcore.NewContext()
+
+	parentWFType := tv.WorkflowType()
+	childWFType := &commonpb.WorkflowType{Name: parentWFType.Name + "-child"}
+	parentWFID := tv.WorkflowID()
+	child1WFID := parentWFID + "-child-1"
+	child2WFID := parentWFID + "-child-2"
+
+	startWall := time.Now()
+
+	parentStart, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           uuid.NewString(),
+		Namespace:           env.Namespace().String(),
+		WorkflowId:          parentWFID,
+		WorkflowType:        parentWFType,
+		TaskQueue:           tv.TaskQueue(),
+		WorkflowRunTimeout:  durationpb.New(24 * time.Hour),
+		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+		TimeSkippingConfig:  &workflowpb.TimeSkippingConfig{Enabled: true},
+	})
+	s.NoError(err)
+	parentRunID := parentStart.RunId
+
+	ns := env.Namespace().String()
+	tq := tv.TaskQueue()
+
+	parentStarted, parentKickedOff, parentDone := false, false, false
+	parentHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		fired := firedTimers(task)
+		if !parentStarted {
+			parentStarted = true
+			return cmdsResponse(timerCmd("t1", time.Hour)), nil
+		}
+		if fired["t1"] && !parentKickedOff {
+			parentKickedOff = true
+			return cmdsResponse(
+				childCmd(ns, child1WFID, childWFType, tq),
+				childCmd(ns, child2WFID, childWFType, tq),
+				timerCmd("t2", time.Hour),
+			), nil
+		}
+		if fired["t2"] && !parentDone {
+			parentDone = true
+			return cmdsResponse(completeCmd()), nil
+		}
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{}, nil
+	}
+
+	// Child handler keyed by WorkflowID so the two children track state independently.
+	childStarted := map[string]bool{}
+	childDone := map[string]bool{}
+	childHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		id := task.WorkflowExecution.WorkflowId
+		fired := firedTimers(task)
+		if !childStarted[id] {
+			childStarted[id] = true
+			return cmdsResponse(timerCmd("tc", 2*time.Hour)), nil
+		}
+		if fired["tc"] && !childDone[id] {
+			childDone[id] = true
+			return cmdsResponse(completeCmd()), nil
+		}
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{}, nil
+	}
+
+	dispatch := typeDispatch(map[string]wftHandler{
+		parentWFType.Name: parentHandler,
+		childWFType.Name:  childHandler,
+	})
+
+	s.drivePollsUntilClosed(env, ctx, tv, dispatch, parentWFID, parentRunID, 30)
+
+	elapsed := time.Since(startWall)
+	s.Less(elapsed, 2*time.Minute, "wall-clock elapsed (%s) should be far less than virtual time", elapsed)
+
+	// ---- Parent ----
+	parentMS := s.getMutableState(env, parentWFID, parentRunID)
+	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED, parentMS.State.ExecutionState.State)
+	s.approxDuration(2*time.Hour, parentMS.State.ExecutionInfo.GetTimeSkippingInfo().GetAccumulatedSkippedDuration().AsDuration(),
+		"parent skip: 1h (t1) + 1h (t2 after BOTH children complete) = 2h")
+
+	// ---- Each child inherits identically ----
+	for _, id := range []string{child1WFID, child2WFID} {
+		childMS := s.getMutableStateByID(env, ctx, id)
+		s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED, childMS.State.ExecutionState.State, "%s", id)
+		childTSI := childMS.State.ExecutionInfo.GetTimeSkippingInfo()
+		s.NotNil(childTSI, "%s TSI", id)
+		s.True(childTSI.GetConfig().GetEnabled(), "%s inherited Enabled", id)
+		s.approxDuration(time.Hour, childTSI.GetConfig().GetPropagatedSkippedDuration().AsDuration(),
+			"%s PropagatedSkippedDuration == parent's accumulated at child-start (1h)", id)
+		s.approxDuration(2*time.Hour, childTSI.GetAccumulatedSkippedDuration().AsDuration(),
+			"%s accumulated 2h from its own timer", id)
+	}
+
+	// Both children are initiated in the same WFT — the parent's history must carry two
+	// StartChildWorkflowExecutionInitiated events, each with the snapshot (Enabled=true,
+	// PSD=1h) computed from parent state at command time.
+	initEvents := s.initiatedChildEvents(ctx, env, parentWFID, parentRunID)
+	s.Len(initEvents, 2)
+	for _, e := range initEvents {
+		tsc := e.GetStartChildWorkflowExecutionInitiatedEventAttributes().GetTimeSkippingConfig()
+		s.NotNil(tsc)
+		s.True(tsc.GetEnabled())
+		s.approxDuration(time.Hour, tsc.GetPropagatedSkippedDuration().AsDuration())
+	}
+}
+
+// TestTimeSkippingPropagation_ThreeGenerations verifies that propagation only carries
+// the *direct* parent's accumulated skip — grandparent contributions are NOT re-added
+// transitively (they are already folded into the direct parent's accumulated skip before
+// the direct parent started its own child).
+//
+// Scenario:
+//   - Grandparent (G) TSC enabled. G: StartTimer(gt1, 1h) → skips 1h → G.accum = 1h.
+//   - G: StartChild(P) + StartTimer(gt2, 1h). P inherits PropagatedSkippedDuration = 1h.
+//   - P: StartTimer(pt1, 2h) → skips 2h → P.accum = 2h.
+//   - P: StartChild(C) + StartTimer(pt2, 1h). C inherits PropagatedSkippedDuration = 2h
+//     (= P's accumulated at time of C start, NOT 1h + 2h = 3h).
+//   - C: StartTimer(ct, 1h) → skips 1h → C.accum = 1h → completes.
+//   - P: idle on pt2 → skips 1h → P.accum = 3h. pt2 fires. P completes.
+//   - G: idle on gt2 → skips 1h → G.accum = 2h. gt2 fires. G completes.
+//
+// Final state: C.config.Propagated == 2h (direct parent only); C.accum == 1h.
+func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ThreeGenerations() {
+	env := testcore.NewEnv(s.T())
+	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	tv := testvars.New(s.T())
+	ctx := testcore.NewContext()
+
+	gWFType := &commonpb.WorkflowType{Name: tv.WorkflowType().Name + "-g"}
+	pWFType := &commonpb.WorkflowType{Name: tv.WorkflowType().Name + "-p"}
+	cWFType := &commonpb.WorkflowType{Name: tv.WorkflowType().Name + "-c"}
+	gWFID := tv.WorkflowID() + "-g"
+	pWFID := tv.WorkflowID() + "-p"
+	cWFID := tv.WorkflowID() + "-c"
+
+	startWall := time.Now()
+
+	// Start grandparent with TSC enabled. We start with gWFType (not tv's default) so
+	// dispatch can route G's tasks distinctly.
+	gStart, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           uuid.NewString(),
+		Namespace:           env.Namespace().String(),
+		WorkflowId:          gWFID,
+		WorkflowType:        gWFType,
+		TaskQueue:           tv.TaskQueue(),
+		WorkflowRunTimeout:  durationpb.New(24 * time.Hour),
+		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+		TimeSkippingConfig:  &workflowpb.TimeSkippingConfig{Enabled: true},
+	})
+	s.NoError(err)
+	gRunID := gStart.RunId
+
+	ns := env.Namespace().String()
+	tq := tv.TaskQueue()
+
+	gStarted, gKickedOff, gDone := false, false, false
+	gHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		fired := firedTimers(task)
+		if !gStarted {
+			gStarted = true
+			return cmdsResponse(timerCmd("gt1", time.Hour)), nil
+		}
+		if fired["gt1"] && !gKickedOff {
+			gKickedOff = true
+			return cmdsResponse(
+				childCmd(ns, pWFID, pWFType, tq),
+				timerCmd("gt2", time.Hour),
+			), nil
+		}
+		if fired["gt2"] && !gDone {
+			gDone = true
+			return cmdsResponse(completeCmd()), nil
+		}
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{}, nil
+	}
+
+	pStarted, pKickedOff, pDone := false, false, false
+	pHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		fired := firedTimers(task)
+		if !pStarted {
+			pStarted = true
+			return cmdsResponse(timerCmd("pt1", 2*time.Hour)), nil
+		}
+		if fired["pt1"] && !pKickedOff {
+			pKickedOff = true
+			return cmdsResponse(
+				childCmd(ns, cWFID, cWFType, tq),
+				timerCmd("pt2", time.Hour),
+			), nil
+		}
+		if fired["pt2"] && !pDone {
+			pDone = true
+			return cmdsResponse(completeCmd()), nil
+		}
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{}, nil
+	}
+
+	cStarted, cDone := false, false
+	cHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		fired := firedTimers(task)
+		if !cStarted {
+			cStarted = true
+			return cmdsResponse(timerCmd("ct", time.Hour)), nil
+		}
+		if fired["ct"] && !cDone {
+			cDone = true
+			return cmdsResponse(completeCmd()), nil
+		}
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{}, nil
+	}
+
+	dispatch := typeDispatch(map[string]wftHandler{
+		gWFType.Name: gHandler,
+		pWFType.Name: pHandler,
+		cWFType.Name: cHandler,
+	})
+
+	s.drivePollsUntilClosed(env, ctx, tv, dispatch, gWFID, gRunID, 40)
+
+	elapsed := time.Since(startWall)
+	s.Less(elapsed, 3*time.Minute, "wall-clock elapsed (%s) should be far less than virtual time", elapsed)
+
+	// ---- Grandparent ----
+	gMS := s.getMutableState(env, gWFID, gRunID)
+	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED, gMS.State.ExecutionState.State)
+	s.approxDuration(2*time.Hour, gMS.State.ExecutionInfo.GetTimeSkippingInfo().GetAccumulatedSkippedDuration().AsDuration(),
+		"G: 1h (gt1) + 1h (gt2 after P completes) = 2h")
+
+	// ---- Parent ----
+	pMS := s.getMutableStateByID(env, ctx, pWFID)
+	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED, pMS.State.ExecutionState.State)
+	pTSI := pMS.State.ExecutionInfo.GetTimeSkippingInfo()
+	s.NotNil(pTSI)
+	s.True(pTSI.GetConfig().GetEnabled())
+	s.approxDuration(time.Hour, pTSI.GetConfig().GetPropagatedSkippedDuration().AsDuration(),
+		"P.PropagatedSkippedDuration == G's accumulated at P-start (1h)")
+	s.approxDuration(3*time.Hour, pTSI.GetAccumulatedSkippedDuration().AsDuration(),
+		"P: 2h (pt1) + 1h (pt2 after C completes) = 3h")
+
+	// ---- Child (direct-parent-only propagation) ----
+	cMS := s.getMutableStateByID(env, ctx, cWFID)
+	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED, cMS.State.ExecutionState.State)
+	cTSI := cMS.State.ExecutionInfo.GetTimeSkippingInfo()
+	s.NotNil(cTSI)
+	s.True(cTSI.GetConfig().GetEnabled())
+	s.approxDuration(2*time.Hour, cTSI.GetConfig().GetPropagatedSkippedDuration().AsDuration(),
+		"C.PropagatedSkippedDuration == P's accumulated at C-start (2h); grandparent skip is NOT re-added")
+	s.approxDuration(time.Hour, cTSI.GetAccumulatedSkippedDuration().AsDuration(),
+		"C accumulated 1h from ct")
+
+	// History-side check: G's initiated event for P snapshots PSD=1h (G's accumulated at
+	// command time); P's initiated event for C snapshots PSD=2h (P's accumulated at its
+	// own command time — grandparent contribution is NOT carried transitively).
+	gInit := s.initiatedChildEvents(ctx, env, gWFID, gRunID)
+	s.Len(gInit, 1)
+	gInitTSC := gInit[0].GetStartChildWorkflowExecutionInitiatedEventAttributes().GetTimeSkippingConfig()
+	s.NotNil(gInitTSC)
+	s.approxDuration(time.Hour, gInitTSC.GetPropagatedSkippedDuration().AsDuration())
+
+	pRunID := pMS.State.ExecutionState.RunId
+	pInit := s.initiatedChildEvents(ctx, env, pWFID, pRunID)
+	s.Len(pInit, 1)
+	pInitTSC := pInit[0].GetStartChildWorkflowExecutionInitiatedEventAttributes().GetTimeSkippingConfig()
+	s.NotNil(pInitTSC)
+	s.approxDuration(2*time.Hour, pInitTSC.GetPropagatedSkippedDuration().AsDuration())
+}
+
+// approxDuration asserts actual is within 5s of expected. Each skip loses
+// (event_time - command_apply_time) of wall clock because
+// AccumulatedSkippedDuration is computed as TargetTime - event.EventTime in
+// ApplyWorkflowExecutionTimeSkippingTransitionedEvent; that drift accrues per
+// skip and across nested workflows.
+func (s *TimeSkippingPropagationTestSuite) approxDuration(expected, actual time.Duration, msgAndArgs ...any) {
+	s.InDelta(float64(expected), float64(actual), float64(5*time.Second), msgAndArgs...)
+}
+
+// initiatedChildEvents returns every StartChildWorkflowExecutionInitiated event in the
+// given parent's history in order. Used to assert the TimeSkippingConfig snapshot that
+// the transfer task will consume when the child is actually started.
+func (s *TimeSkippingPropagationTestSuite) initiatedChildEvents(
+	ctx context.Context,
+	env *testcore.TestEnv,
+	workflowID, runID string,
+) []*historypb.HistoryEvent {
+	histResp, err := env.FrontendClient().GetWorkflowExecutionHistory(ctx, &workflowservice.GetWorkflowExecutionHistoryRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: workflowID, RunId: runID},
+	})
+	s.NoError(err)
+	var out []*historypb.HistoryEvent
+	for _, e := range histResp.History.Events {
+		if e.GetEventType() == enumspb.EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// drivePollsUntilClosed runs the task poller up to maxIterations times or until the
+// named workflow reaches COMPLETED. Poll errors (typically long-poll timeouts) are
+// logged and ignored so transient emptiness doesn't fail the test.
+func (s *TimeSkippingPropagationTestSuite) drivePollsUntilClosed(
+	env *testcore.TestEnv,
+	ctx context.Context,
+	tv *testvars.TestVars,
+	handler func(*workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error),
+	workflowID, runID string,
+	maxIterations int,
+) {
+	for i := range maxIterations {
+		_, pollErr := env.TaskPoller().PollAndHandleWorkflowTask(tv, handler)
+		if pollErr != nil {
+			s.T().Logf("iter %d: poll error (likely timeout): %v", i, pollErr)
+		}
+		desc, err := env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
+			Execution: &commonpb.WorkflowExecution{WorkflowId: workflowID, RunId: runID},
+		})
+		s.NoError(err)
+		if desc.WorkflowExecutionInfo.Status == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED {
+			return
+		}
+	}
+}
+
+// getMutableState loads the persistence-layer mutable state for a workflow run.
+// Mirrors the helper in timeskipping_test.go to keep this file self-contained.
+func (s *TimeSkippingPropagationTestSuite) getMutableState(env *testcore.TestEnv, workflowID, runID string) *persistence.GetWorkflowExecutionResponse {
+	shardID := common.WorkflowIDToHistoryShard(
+		env.NamespaceID().String(),
+		workflowID,
+		env.GetTestClusterConfig().HistoryConfig.NumHistoryShards,
+	)
+	ms, err := env.GetTestCluster().ExecutionManager().GetWorkflowExecution(testcore.NewContext(), &persistence.GetWorkflowExecutionRequest{
+		ShardID:     shardID,
+		NamespaceID: env.NamespaceID().String(),
+		WorkflowID:  workflowID,
+		RunID:       runID,
+		ArchetypeID: chasm.WorkflowArchetypeID,
+	})
+	s.NoError(err)
+	return ms
+}
+
+// getMutableStateByID resolves the current run ID of a workflow via DescribeWorkflowExecution
+// and returns its persistence-layer mutable state.
+func (s *TimeSkippingPropagationTestSuite) getMutableStateByID(env *testcore.TestEnv, ctx context.Context, workflowID string) *persistence.GetWorkflowExecutionResponse {
+	desc, err := env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: workflowID},
+	})
+	s.NoError(err)
+	return s.getMutableState(env, workflowID, desc.WorkflowExecutionInfo.Execution.RunId)
+}
+
+// wftHandler is the signature of a per-workflow-type handler used by typeDispatch.
+type wftHandler = func(*workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error)
+
+// typeDispatch routes a polled workflow task to a handler keyed by the workflow type name.
+// Returns an error for unexpected types so a test failure pinpoints a mis-routed task.
+func typeDispatch(handlers map[string]wftHandler) wftHandler {
+	return func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		name := task.WorkflowType.GetName()
+		h, ok := handlers[name]
+		if !ok {
+			return nil, fmt.Errorf("unexpected workflow type: %q", name)
+		}
+		return h(task)
+	}
+}
+
+// firedTimers returns the set of TimerFired event timer IDs delivered in the WFT batch
+// (events newer than task.PreviousStartedEventId).
+func firedTimers(task *workflowservice.PollWorkflowTaskQueueResponse) map[string]bool {
+	out := map[string]bool{}
+	events := task.History.Events
+	from := int(task.PreviousStartedEventId)
+	if from < 0 || from > len(events) {
+		from = 0
+	}
+	for _, e := range events[from:] {
+		if e.GetEventType() == enumspb.EVENT_TYPE_TIMER_FIRED {
+			out[e.GetTimerFiredEventAttributes().GetTimerId()] = true
+		}
+	}
+	return out
+}
+
+// timerCmd builds a StartTimerCommand with the given id and StartToFireTimeout.
+func timerCmd(id string, d time.Duration) *commandpb.Command {
+	return &commandpb.Command{
+		CommandType: enumspb.COMMAND_TYPE_START_TIMER,
+		Attributes: &commandpb.Command_StartTimerCommandAttributes{
+			StartTimerCommandAttributes: &commandpb.StartTimerCommandAttributes{
+				TimerId:            id,
+				StartToFireTimeout: durationpb.New(d),
+			},
+		},
+	}
+}
+
+// childCmd builds a StartChildWorkflowExecutionCommand with ABANDON parent-close policy
+// and generous (virtual-time) run/task timeouts appropriate for time-skipping tests.
+func childCmd(ns, wfID string, wfType *commonpb.WorkflowType, tq *taskqueuepb.TaskQueue) *commandpb.Command {
+	return &commandpb.Command{
+		CommandType: enumspb.COMMAND_TYPE_START_CHILD_WORKFLOW_EXECUTION,
+		Attributes: &commandpb.Command_StartChildWorkflowExecutionCommandAttributes{
+			StartChildWorkflowExecutionCommandAttributes: &commandpb.StartChildWorkflowExecutionCommandAttributes{
+				Namespace:           ns,
+				WorkflowId:          wfID,
+				WorkflowType:        wfType,
+				TaskQueue:           tq,
+				WorkflowRunTimeout:  durationpb.New(24 * time.Hour),
+				WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+				ParentClosePolicy:   enumspb.PARENT_CLOSE_POLICY_ABANDON,
+			},
+		},
+	}
+}
+
+// completeCmd builds a CompleteWorkflowExecution command with an empty payload.
+func completeCmd() *commandpb.Command {
+	return &commandpb.Command{
+		CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
+		Attributes: &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{
+			CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{},
+		},
+	}
+}
+
+// cmdsResponse wraps a list of commands in a RespondWorkflowTaskCompletedRequest.
+func cmdsResponse(cmds ...*commandpb.Command) *workflowservice.RespondWorkflowTaskCompletedRequest {
+	return &workflowservice.RespondWorkflowTaskCompletedRequest{Commands: cmds}
+}

--- a/tests/timeskipping_propagation_test.go
+++ b/tests/timeskipping_propagation_test.go
@@ -10,6 +10,7 @@ import (
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
 	historypb "go.temporal.io/api/history/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
@@ -139,7 +140,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ParentTim
 		childWFType.Name:  childHandler,
 	})
 
-	s.drivePollsUntilClosed(env, ctx, tv, dispatch, parentWFID, parentRunID, 20)
+	s.drivePollsUntilClosed(ctx, env, tv, dispatch, parentWFID, parentRunID, 20)
 
 	elapsed := time.Since(startWall)
 	s.Less(elapsed, 2*time.Minute, "wall-clock elapsed (%s) should be far less than 5h of virtual time", elapsed)
@@ -153,7 +154,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ParentTim
 		"parent should accumulate 1h (t1) + 1h (t2 after child) = 2h")
 
 	// ---- Child ----
-	childMS := s.getMutableStateByID(env, ctx, childWFID)
+	childMS := s.getMutableStateByID(ctx, env, childWFID)
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED, childMS.State.ExecutionState.State)
 	childTSI := childMS.State.ExecutionInfo.GetTimeSkippingInfo()
 	s.NotNil(childTSI)
@@ -267,7 +268,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ParentWit
 		childWFType.Name:  childHandler,
 	})
 
-	s.drivePollsUntilClosed(env, ctx, tv, dispatch, parentWFID, parentRunID, 30)
+	s.drivePollsUntilClosed(ctx, env, tv, dispatch, parentWFID, parentRunID, 30)
 
 	elapsed := time.Since(startWall)
 	s.Less(elapsed, 2*time.Minute, "wall-clock elapsed (%s) should be far less than virtual time", elapsed)
@@ -280,7 +281,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ParentWit
 
 	// ---- Each child inherits identically ----
 	for _, id := range []string{child1WFID, child2WFID} {
-		childMS := s.getMutableStateByID(env, ctx, id)
+		childMS := s.getMutableStateByID(ctx, env, id)
 		s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED, childMS.State.ExecutionState.State, "%s", id)
 		childTSI := childMS.State.ExecutionInfo.GetTimeSkippingInfo()
 		s.NotNil(childTSI, "%s TSI", id)
@@ -421,7 +422,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ThreeGene
 		cWFType.Name: cHandler,
 	})
 
-	s.drivePollsUntilClosed(env, ctx, tv, dispatch, gWFID, gRunID, 40)
+	s.drivePollsUntilClosed(ctx, env, tv, dispatch, gWFID, gRunID, 40)
 
 	elapsed := time.Since(startWall)
 	s.Less(elapsed, 3*time.Minute, "wall-clock elapsed (%s) should be far less than virtual time", elapsed)
@@ -433,7 +434,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ThreeGene
 		"G: 1h (gt1) + 1h (gt2 after P completes) = 2h")
 
 	// ---- Parent ----
-	pMS := s.getMutableStateByID(env, ctx, pWFID)
+	pMS := s.getMutableStateByID(ctx, env, pWFID)
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED, pMS.State.ExecutionState.State)
 	pTSI := pMS.State.ExecutionInfo.GetTimeSkippingInfo()
 	s.NotNil(pTSI)
@@ -444,7 +445,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ThreeGene
 		"P.accum == G's accumulated at P-start (1h) + P's own pt1 (2h) + P's own pt2 (1h) = 4h")
 
 	// ---- Child (accum inherited transitively through the ancestry) ----
-	cMS := s.getMutableStateByID(env, ctx, cWFID)
+	cMS := s.getMutableStateByID(ctx, env, cWFID)
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED, cMS.State.ExecutionState.State)
 	cTSI := cMS.State.ExecutionInfo.GetTimeSkippingInfo()
 	s.NotNil(cTSI)
@@ -507,8 +508,8 @@ func (s *TimeSkippingPropagationTestSuite) initiatedChildEvents(
 // named workflow reaches COMPLETED. Poll errors (typically long-poll timeouts) are
 // logged and ignored so transient emptiness doesn't fail the test.
 func (s *TimeSkippingPropagationTestSuite) drivePollsUntilClosed(
-	env *testcore.TestEnv,
 	ctx context.Context,
+	env *testcore.TestEnv,
 	tv *testvars.TestVars,
 	handler func(*workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error),
 	workflowID, runID string,
@@ -551,7 +552,7 @@ func (s *TimeSkippingPropagationTestSuite) getMutableState(env *testcore.TestEnv
 
 // getMutableStateByID resolves the current run ID of a workflow via DescribeWorkflowExecution
 // and returns its persistence-layer mutable state.
-func (s *TimeSkippingPropagationTestSuite) getMutableStateByID(env *testcore.TestEnv, ctx context.Context, workflowID string) *persistence.GetWorkflowExecutionResponse {
+func (s *TimeSkippingPropagationTestSuite) getMutableStateByID(ctx context.Context, env *testcore.TestEnv, workflowID string) *persistence.GetWorkflowExecutionResponse {
 	desc, err := env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
 		Namespace: env.Namespace().String(),
 		Execution: &commonpb.WorkflowExecution{WorkflowId: workflowID},
@@ -631,6 +632,20 @@ func completeCmd() *commandpb.Command {
 		CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
 		Attributes: &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{
 			CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{},
+		},
+	}
+}
+
+// failCmd builds a FailWorkflowExecution command with a bare Failure{Message: msg}.
+// Such a failure carries no specific FailureInfo, so retry.isRetryable treats it as
+// retryable — the server schedules a new run under RETRY initiator when RetryPolicy allows.
+func failCmd(msg string) *commandpb.Command {
+	return &commandpb.Command{
+		CommandType: enumspb.COMMAND_TYPE_FAIL_WORKFLOW_EXECUTION,
+		Attributes: &commandpb.Command_FailWorkflowExecutionCommandAttributes{
+			FailWorkflowExecutionCommandAttributes: &commandpb.FailWorkflowExecutionCommandAttributes{
+				Failure: &failurepb.Failure{Message: msg},
+			},
 		},
 	}
 }
@@ -769,7 +784,7 @@ func (s *TimeSkippingPropagationTestSuite) TestPropagationInReset() {
 	s.NotEqual(originalRunID, resetRunID, "reset must produce a fresh run")
 
 	// Drive the reset run's fresh WFT to completion.
-	s.drivePollsUntilClosed(env, ctx, tv, func(_ *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+	s.drivePollsUntilClosed(ctx, env, tv, func(_ *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
 		return cmdsResponse(completeCmd()), nil
 	}, wfID, resetRunID, 10)
 
@@ -884,7 +899,7 @@ func (s *TimeSkippingPropagationTestSuite) TestPropagationInCaN() {
 	}
 
 	// Empty runID so describe follows the chain to the current run (run 2 after CaN).
-	s.drivePollsUntilClosed(env, ctx, tv, handler, wfID, "", 20)
+	s.drivePollsUntilClosed(ctx, env, tv, handler, wfID, "", 20)
 
 	elapsed := time.Since(startWall)
 	s.Less(elapsed, 2*time.Minute, "wall-clock elapsed (%s) should be far less than 3h of virtual time", elapsed)
@@ -898,7 +913,7 @@ func (s *TimeSkippingPropagationTestSuite) TestPropagationInCaN() {
 		"run 1 should have skipped 1h for t1 before continue-as-new")
 
 	// ---- Run 2: the CaN'd-into run, completed ----
-	run2MS := s.getMutableStateByID(env, ctx, wfID)
+	run2MS := s.getMutableStateByID(ctx, env, wfID)
 	run2ID := run2MS.State.ExecutionState.RunId
 	s.NotEqual(run1ID, run2ID, "run 2 should have a new run ID")
 	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, run2MS.State.ExecutionState.Status)
@@ -928,4 +943,136 @@ func (s *TimeSkippingPropagationTestSuite) TestPropagationInCaN() {
 	s.True(startedTSC.GetEnabled(), "started event TSC.Enabled mirrors run 1's config")
 	s.approxDuration(time.Hour, startedTSC.GetPropagatedSkippedDuration().AsDuration(),
 		"started event retains PSD=1h (run 1's accumulated at CaN time); applyTimeSkippingConfig converts it to AccumulatedSkippedDuration on the MS but the event snapshot is unchanged")
+}
+
+// TestPropagationInRetry verifies that TimeSkippingConfig is propagated from the
+// original run's WorkflowExecutionStarted event to a retried workflow run.
+//
+// Retry's createRequest.TimeSkippingConfig is a verbatim copy of startAttr.TimeSkippingConfig
+// (event #1 of the previous run). applyTimeSkippingConfig then produces the same MS state
+// the original run was booted with: Config.Enabled preserved; if the original event #1 had
+// a non-zero PSD snapshot (e.g., the original run was itself started as a child or via CaN),
+// that PSD is converted to AccumulatedSkippedDuration on the retry — otherwise the retry
+// starts with Accum=0.
+//
+// Key semantic: unlike continue-as-new, the previous attempt's *in-flight* accumulated
+// skip (skip that happened during the attempt) is NOT carried forward to the retry.
+// Each attempt gets a fresh virtual-time clock at whatever offset the original run was
+// booted with — the retry is semantically a re-attempt, not a continuation.
+//
+// Scenario:
+//   - Start a top-level workflow with TimeSkippingConfig{Enabled: true} and
+//     RetryPolicy{MaximumAttempts: 2}. Event #1's TSC has PSD=0 (no parent, no prior CaN).
+//   - Attempt 1 issues StartTimer(t1, 1h). Idle → server skips 1h → attempt1.Accum = 1h.
+//   - Attempt 1 issues FailWorkflowExecution with a bare (retryable) Failure.
+//   - Server schedules retry. Attempt 2 (retry run) starts.
+//     Its MS applies startAttr.TimeSkippingConfig: Config.Enabled=true, PSD=0 → Accum=0.
+//     Attempt 1's 1h in-flight skip is NOT carried forward.
+//   - Attempt 2 issues StartTimer(t2, 2h). Idle → server skips 2h → attempt2.Accum = 2h.
+//   - Attempt 2 completes.
+//
+// End-state assertions:
+//   - Attempt 1: status=FAILED, Config.Enabled=true, Accum=1h.
+//   - Attempt 2: status=COMPLETED, Config.Enabled=true, Config.PSD unset on the MS,
+//     Accum=2h (own skip only; 1h from attempt 1 is NOT inherited).
+//   - Attempt 2's WorkflowExecutionStarted carries the same TSC snapshot as attempt 1's
+//     event #1 (Enabled=true, PSD=0) and references attempt 1 as ContinuedExecutionRunId.
+func (s *TimeSkippingPropagationTestSuite) TestPropagationInRetry() {
+	env := testcore.NewEnv(s.T())
+	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	tv := testvars.New(s.T())
+	ctx := testcore.NewContext()
+
+	wfType := tv.WorkflowType()
+	wfID := tv.WorkflowID()
+	tq := tv.TaskQueue()
+
+	startWall := time.Now()
+
+	start1, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           uuid.NewString(),
+		Namespace:           env.Namespace().String(),
+		WorkflowId:          wfID,
+		WorkflowType:        wfType,
+		TaskQueue:           tq,
+		WorkflowRunTimeout:  durationpb.New(24 * time.Hour),
+		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+		TimeSkippingConfig:  &workflowpb.TimeSkippingConfig{Enabled: true},
+		RetryPolicy: &commonpb.RetryPolicy{
+			InitialInterval:    durationpb.New(time.Second),
+			BackoffCoefficient: 1.0,
+			MaximumAttempts:    2,
+		},
+	})
+	s.NoError(err)
+	attempt1ID := start1.RunId
+
+	state := 0
+	handler := func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		fired := firedTimers(task)
+		switch {
+		case state == 0:
+			state = 1
+			return cmdsResponse(timerCmd("t1", time.Hour)), nil
+		case state == 1 && fired["t1"]:
+			state = 2
+			return cmdsResponse(failCmd("retry me")), nil
+		case state == 2:
+			state = 3
+			return cmdsResponse(timerCmd("t2", 2*time.Hour)), nil
+		case state == 3 && fired["t2"]:
+			state = 4
+			return cmdsResponse(completeCmd()), nil
+		}
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{}, nil
+	}
+
+	// Empty runID so describe follows the chain to the current run (attempt 2 after retry).
+	s.drivePollsUntilClosed(ctx, env, tv, handler, wfID, "", 20)
+
+	elapsed := time.Since(startWall)
+	s.Less(elapsed, 2*time.Minute, "wall-clock elapsed (%s) should be far less than 3h of virtual time", elapsed)
+
+	// ---- Attempt 1: failed, retried ----
+	attempt1MS := s.getMutableState(env, wfID, attempt1ID)
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_FAILED, attempt1MS.State.ExecutionState.Status)
+	attempt1TSI := attempt1MS.State.ExecutionInfo.GetTimeSkippingInfo()
+	s.NotNil(attempt1TSI)
+	s.True(attempt1TSI.GetConfig().GetEnabled(), "attempt 1 has TSC enabled from the initial start request")
+	s.approxDuration(time.Hour, attempt1TSI.GetAccumulatedSkippedDuration().AsDuration(),
+		"attempt 1 skipped 1h for t1 before failing")
+
+	// ---- Attempt 2: retry run, completed ----
+	attempt2MS := s.getMutableStateByID(ctx, env, wfID)
+	attempt2ID := attempt2MS.State.ExecutionState.RunId
+	s.NotEqual(attempt1ID, attempt2ID, "attempt 2 has a new run ID")
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, attempt2MS.State.ExecutionState.Status)
+	attempt2TSI := attempt2MS.State.ExecutionInfo.GetTimeSkippingInfo()
+	s.NotNil(attempt2TSI, "attempt 2 should have TimeSkippingInfo from the propagated event #1 snapshot")
+	attempt2Cfg := attempt2TSI.GetConfig()
+	s.NotNil(attempt2Cfg)
+	s.True(attempt2Cfg.GetEnabled(), "attempt 2 TSC.Enabled propagated from attempt 1's event #1")
+	s.Zero(attempt2Cfg.GetPropagatedSkippedDuration().AsDuration(),
+		"attempt 2 Config.PSD unset — original event #1 had PSD=0 and applyTimeSkippingConfig strips PSD regardless")
+	s.approxDuration(2*time.Hour, attempt2TSI.GetAccumulatedSkippedDuration().AsDuration(),
+		"attempt 2 accumulated only its own 2h from t2; attempt 1's 1h in-flight skip is NOT carried forward on retry")
+
+	// Attempt 2's WorkflowExecutionStarted must carry the same TSC snapshot as attempt 1's event #1.
+	hist2, err := env.FrontendClient().GetWorkflowExecutionHistory(ctx, &workflowservice.GetWorkflowExecutionHistoryRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: wfID, RunId: attempt2ID},
+	})
+	s.NoError(err)
+	s.NotEmpty(hist2.History.Events)
+	startedAttr := hist2.History.Events[0].GetWorkflowExecutionStartedEventAttributes()
+	s.NotNil(startedAttr)
+	s.Equal(attempt1ID, startedAttr.GetContinuedExecutionRunId(),
+		"attempt 2 references attempt 1 as its predecessor via ContinuedExecutionRunId")
+	s.Equal(enumspb.CONTINUE_AS_NEW_INITIATOR_RETRY, startedAttr.GetInitiator(),
+		"attempt 2 is initiated by retry")
+	startedTSC := startedAttr.GetTimeSkippingConfig()
+	s.NotNil(startedTSC, "attempt 2's WorkflowExecutionStarted must carry the TSC snapshot")
+	s.True(startedTSC.GetEnabled(), "started event TSC.Enabled mirrors attempt 1's event #1")
+	s.Zero(startedTSC.GetPropagatedSkippedDuration().AsDuration(),
+		"started event PSD matches attempt 1's event #1 (PSD=0 for a top-level workflow)")
 }

--- a/tests/timeskipping_propagation_test.go
+++ b/tests/timeskipping_propagation_test.go
@@ -23,6 +23,7 @@ import (
 	"go.temporal.io/server/common/testing/testvars"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 type TimeSkippingPropagationTestSuite struct {
@@ -622,4 +623,155 @@ func completeCmd() *commandpb.Command {
 // cmdsResponse wraps a list of commands in a RespondWorkflowTaskCompletedRequest.
 func cmdsResponse(cmds ...*commandpb.Command) *workflowservice.RespondWorkflowTaskCompletedRequest {
 	return &workflowservice.RespondWorkflowTaskCompletedRequest{Commands: cmds}
+}
+
+// firstWorkflowTaskCompletedEventID returns the event ID of the first
+// WorkflowTaskCompleted event in the given run's history. Used as the reset
+// point for tests that need to rewind to just past the first WFT.
+func (s *TimeSkippingPropagationTestSuite) firstWorkflowTaskCompletedEventID(
+	ctx context.Context,
+	env *testcore.TestEnv,
+	workflowID, runID string,
+) int64 {
+	hist, err := env.FrontendClient().GetWorkflowExecutionHistory(ctx, &workflowservice.GetWorkflowExecutionHistoryRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: workflowID, RunId: runID},
+	})
+	s.NoError(err)
+	for _, e := range hist.History.Events {
+		if e.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED {
+			return e.GetEventId()
+		}
+	}
+	s.FailNow("no WorkflowTaskCompleted event found in history")
+	return 0
+}
+
+// TestReset_OptionsUpdateIsReapplied_TimeSkippingEnabled documents the
+// interaction between reset and WorkflowExecutionOptionsUpdated events.
+//
+// Scenario:
+//   - Start W with TimeSkippingConfig{Enabled: false}.
+//   - Drive WFT 1 with no commands → workflow idles after first WFTCompleted.
+//   - Call UpdateWorkflowExecutionOptions setting Enabled: true → emits
+//     OPTIONS_UPDATED event (does not schedule a WFT).
+//   - Terminate W so it closes cleanly before reset.
+//   - Reset to the first WFTCompleted event, with default reapply (no excludes).
+//   - Drive the reset run's fresh WFT to completion.
+//
+// Expected: the reset run has TimeSkippingConfig.Enabled == true even though
+// the reset point precedes the options update. This is because OPTIONS_UPDATED
+// is reapplied unconditionally at workflow_resetter.go — there is no
+// ResetReapplyExcludeType value that can suppress it. The test pins this
+// behavior so a future change would surface it.
+func (s *TimeSkippingPropagationTestSuite) TestPropagationInReset() {
+	env := testcore.NewEnv(s.T())
+	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	tv := testvars.New(s.T())
+	ctx := testcore.NewContext()
+
+	wfID := tv.WorkflowID()
+
+	startResp, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           uuid.NewString(),
+		Namespace:           env.Namespace().String(),
+		WorkflowId:          wfID,
+		WorkflowType:        tv.WorkflowType(),
+		TaskQueue:           tv.TaskQueue(),
+		WorkflowRunTimeout:  durationpb.New(24 * time.Hour),
+		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+		TimeSkippingConfig:  &workflowpb.TimeSkippingConfig{Enabled: false},
+	})
+	s.NoError(err)
+	originalRunID := startResp.RunId
+
+	// Drive WFT 1 with an empty command response so the workflow completes its
+	// first task and idles. This gives us a stable reset point before the
+	// options update.
+	_, err = env.TaskPoller().PollAndHandleWorkflowTask(tv, func(_ *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{}, nil
+	})
+	s.NoError(err)
+
+	resetEventID := s.firstWorkflowTaskCompletedEventID(ctx, env, wfID, originalRunID)
+
+	// UpdateWorkflowExecutionOptions to enable time-skipping. This emits a
+	// WorkflowExecutionOptionsUpdated event. It does NOT schedule a new WFT,
+	// so we terminate the workflow below to close it before resetting.
+	_, err = env.FrontendClient().UpdateWorkflowExecutionOptions(ctx, &workflowservice.UpdateWorkflowExecutionOptionsRequest{
+		Namespace:         env.Namespace().String(),
+		WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: wfID, RunId: originalRunID},
+		WorkflowExecutionOptions: &workflowpb.WorkflowExecutionOptions{
+			TimeSkippingConfig: &workflowpb.TimeSkippingConfig{Enabled: true},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config"}},
+	})
+	s.NoError(err)
+
+	// Terminate the original workflow so it's closed; the terminate event
+	// lands in history after the OPTIONS_UPDATED event. Terminate events are
+	// always excluded from reapply, so the reset scan will see OPTIONS_UPDATED
+	// as the only reapplyable post-reset event.
+	_, err = env.FrontendClient().TerminateWorkflowExecution(ctx, &workflowservice.TerminateWorkflowExecutionRequest{
+		Namespace:         env.Namespace().String(),
+		WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: wfID, RunId: originalRunID},
+		Reason:            "test: close original before reset",
+	})
+	s.NoError(err)
+
+	// Sanity: original run ended with TSC enabled.
+	origMS := s.getMutableState(env, wfID, originalRunID)
+	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED, origMS.State.ExecutionState.State)
+	s.True(origMS.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig().GetEnabled(),
+		"original run should have TSC enabled after UpdateWorkflowExecutionOptions")
+
+	// Reset to the first WFTCompleted event with default reapply.
+	resetResp, err := env.FrontendClient().ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
+		Namespace:                 env.Namespace().String(),
+		WorkflowExecution:         &commonpb.WorkflowExecution{WorkflowId: wfID, RunId: originalRunID},
+		Reason:                    "test: verify OPTIONS_UPDATED reapply preserves TimeSkippingConfig",
+		WorkflowTaskFinishEventId: resetEventID,
+		RequestId:                 uuid.NewString(),
+	})
+	s.NoError(err)
+	resetRunID := resetResp.RunId
+	s.NotEqual(originalRunID, resetRunID, "reset must produce a fresh run")
+
+	// Drive the reset run's fresh WFT to completion.
+	s.drivePollsUntilClosed(env, ctx, tv, func(_ *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		return cmdsResponse(completeCmd()), nil
+	}, wfID, resetRunID, 10)
+
+	// Key assertion: the reset run has TSC enabled because the post-reset
+	// OPTIONS_UPDATED event was reapplied onto the new run.
+	resetMS := s.getMutableState(env, wfID, resetRunID)
+	s.True(resetMS.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig().GetEnabled(),
+		"reset run should have TSC enabled; OPTIONS_UPDATED event is reapplied from original run")
+
+	// Confirm the mechanism: the reset run's history contains exactly one
+	// reapplied OPTIONS_UPDATED event, and the WorkflowExecutionStarted event
+	// still reflects the original disabled config (i.e. replay restored the
+	// start-point state before reapply enabled it).
+	resetHist, err := env.FrontendClient().GetWorkflowExecutionHistory(ctx, &workflowservice.GetWorkflowExecutionHistoryRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: wfID, RunId: resetRunID},
+	})
+	s.NoError(err)
+	var optionsUpdatedCount int
+	var startedEvent *historypb.HistoryEvent
+	for _, e := range resetHist.History.Events {
+		if e.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED {
+			optionsUpdatedCount++
+		}
+		if e.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED {
+			startedEvent = e
+		}
+	}
+	s.Equal(1, optionsUpdatedCount,
+		"reset run should contain exactly one reapplied OPTIONS_UPDATED event")
+	s.NotNil(startedEvent)
+	startedTSC := startedEvent.GetWorkflowExecutionStartedEventAttributes().GetTimeSkippingConfig()
+	s.NotNil(startedTSC, "WorkflowExecutionStarted should carry the original TimeSkippingConfig")
+	s.False(startedTSC.GetEnabled(),
+		"WorkflowExecutionStarted on reset run should carry the original disabled config; the later enable comes from reapply, not replay")
 }

--- a/tests/timeskipping_propagation_test.go
+++ b/tests/timeskipping_propagation_test.go
@@ -35,8 +35,14 @@ func TestTimeSkippingPropagationTestSuite(t *testing.T) {
 }
 
 // TestTimeSkippingPropagation_ParentTimerChildTimerParentTimer exercises end-to-end
-// propagation of TimeSkippingConfig + PropagatedSkippedDuration from parent to child,
+// propagation of TimeSkippingConfig + AccumulatedSkippedDuration from parent to child,
 // together with the idle-only skipping invariant on the parent.
+//
+// The parent's StartChildWorkflowExecutionInitiated event carries a PSD snapshot of
+// the parent's accumulated skip at child-start time. applyTimeSkippingConfig on the
+// child's MS converts that PSD into AccumulatedSkippedDuration and strips PSD from
+// the stored Config, so the child's virtual clock continues from where the parent
+// left off.
 //
 // Scenario:
 //   - Parent starts with TimeSkippingConfig{Enabled: true}.
@@ -44,11 +50,11 @@ func TestTimeSkippingPropagationTestSuite(t *testing.T) {
 //     After skip: parent.AccumulatedSkippedDuration = 1h.
 //   - t1 fires. Parent issues StartChildWorkflow(child) and StartTimer(t2, 1h).
 //     Parent now has a pending child → NOT idle → parent does NOT skip.
-//   - Child is started. Its mutable state receives TimeSkippingConfig propagated
-//     from the parent, plus PropagatedSkippedDuration = 1h (parent's accumulated
-//     skip at the moment the child started).
+//   - Child is started. Its MS is seeded with AccumulatedSkippedDuration = 1h
+//     (converted from the PSD=1h on the initiated event) and Config.Enabled = true
+//     (Config.PSD stripped by applyTimeSkippingConfig).
 //   - Child issues StartTimer(tc, 3h). Child is idle → server skips 3h.
-//     After skip: child.AccumulatedSkippedDuration = 3h.
+//     After skip: child.AccumulatedSkippedDuration = 1h + 3h = 4h.
 //   - tc fires. Child completes.
 //   - Parent receives ChildWorkflowExecutionCompleted. Parent is now only waiting
 //     on t2 → idle → server skips 1h to fire t2.
@@ -58,9 +64,11 @@ func TestTimeSkippingPropagationTestSuite(t *testing.T) {
 // End-state assertions:
 //   - parent.AccumulatedSkippedDuration == 2h.
 //   - child.TimeSkippingInfo.Config.Enabled == true (propagated).
-//   - child.TimeSkippingInfo.Config.PropagatedSkippedDuration == 1h.
-//   - child.AccumulatedSkippedDuration == 3h.
-//   - child's total virtual advance (propagated + accumulated) == 4h.
+//   - child.TimeSkippingInfo.Config.PropagatedSkippedDuration is unset on the MS —
+//     applyTimeSkippingConfig stripped it after converting to AccumulatedSkippedDuration.
+//   - child.AccumulatedSkippedDuration == 4h (1h inherited + 3h own from tc).
+//   - The parent's StartChildWorkflowExecutionInitiated event retains PSD=1h (the
+//     pre-apply snapshot; it is the wire form the transfer task consumes).
 //   - Wall-clock elapsed is nowhere near 5h of virtual time.
 func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ParentTimerChildTimerParentTimer() {
 	env := testcore.NewEnv(s.T())
@@ -152,13 +160,10 @@ func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ParentTim
 	childCfg := childTSI.GetConfig()
 	s.NotNil(childCfg)
 	s.True(childCfg.GetEnabled(), "child TSC.Enabled propagated from parent")
-	s.approxDuration(time.Hour, childCfg.GetPropagatedSkippedDuration().AsDuration(),
-		"child PropagatedSkippedDuration == parent's AccumulatedSkippedDuration at child-start (1h)")
-	s.approxDuration(3*time.Hour, childTSI.GetAccumulatedSkippedDuration().AsDuration(),
-		"child accumulated 3h from tc")
-	s.approxDuration(4*time.Hour,
-		childCfg.GetPropagatedSkippedDuration().AsDuration()+childTSI.GetAccumulatedSkippedDuration().AsDuration(),
-		"child virtual ends 4h ahead (1h propagated + 3h accumulated)")
+	s.Zero(childCfg.GetPropagatedSkippedDuration().AsDuration(),
+		"child Config.PSD is stripped on apply; the inherited skip lives in AccumulatedSkippedDuration")
+	s.approxDuration(4*time.Hour, childTSI.GetAccumulatedSkippedDuration().AsDuration(),
+		"child AccumulatedSkippedDuration == parent's accumulated at child-start (1h) + child's own skip for tc (3h) = 4h")
 
 	// The parent's StartChildWorkflowExecutionInitiated event must carry the propagated
 	// TimeSkippingConfig — this is what the transfer task consumes when it starts the child.
@@ -172,15 +177,18 @@ func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ParentTim
 }
 
 // TestTimeSkippingPropagation_ParentWithTwoChildren verifies that:
-//   - All children started in the same WFT inherit the parent's TimeSkippingConfig and
-//     the parent's AccumulatedSkippedDuration at the moment they start.
+//   - All children started in the same WFT inherit the parent's TimeSkippingConfig
+//     and have their AccumulatedSkippedDuration seeded to the parent's accumulated
+//     skip at child-start time (via the PSD snapshot on the initiated event, which
+//     applyTimeSkippingConfig converts into AccumulatedSkippedDuration).
 //   - The parent is blocked from skipping while ANY child is pending, and resumes
 //     skipping only after all children complete (idle-only invariant).
 //
 // Scenario:
 //   - Parent TSC enabled. Parent issues StartTimer(t1, 1h) → skips 1h.
 //   - Parent issues [StartChild(c1), StartChild(c2), StartTimer(t2, 1h)].
-//     Each child inherits TSC and receives PropagatedSkippedDuration = 1h.
+//     Each child's MS is seeded with AccumulatedSkippedDuration = 1h
+//     (inherited from the parent's accumulated at command time).
 //   - c1 issues StartTimer(tc1, 2h) → idle → skips 2h → completes.
 //   - c2 issues StartTimer(tc2, 2h) → idle → skips 2h → completes.
 //   - Only after BOTH c1 and c2 complete does parent become idle on t2 → skips 1h → t2 fires.
@@ -277,10 +285,10 @@ func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ParentWit
 		childTSI := childMS.State.ExecutionInfo.GetTimeSkippingInfo()
 		s.NotNil(childTSI, "%s TSI", id)
 		s.True(childTSI.GetConfig().GetEnabled(), "%s inherited Enabled", id)
-		s.approxDuration(time.Hour, childTSI.GetConfig().GetPropagatedSkippedDuration().AsDuration(),
-			"%s PropagatedSkippedDuration == parent's accumulated at child-start (1h)", id)
-		s.approxDuration(2*time.Hour, childTSI.GetAccumulatedSkippedDuration().AsDuration(),
-			"%s accumulated 2h from its own timer", id)
+		s.Zero(childTSI.GetConfig().GetPropagatedSkippedDuration().AsDuration(),
+			"%s Config.PSD is stripped on apply; the inherited skip lives in AccumulatedSkippedDuration", id)
+		s.approxDuration(3*time.Hour, childTSI.GetAccumulatedSkippedDuration().AsDuration(),
+			"%s AccumulatedSkippedDuration == parent's accumulated at child-start (1h) + own skip for tc (2h) = 3h", id)
 	}
 
 	// Both children are initiated in the same WFT — the parent's history must carry two
@@ -296,22 +304,28 @@ func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ParentWit
 	}
 }
 
-// TestTimeSkippingPropagation_ThreeGenerations verifies that propagation only carries
-// the *direct* parent's accumulated skip — grandparent contributions are NOT re-added
-// transitively (they are already folded into the direct parent's accumulated skip before
-// the direct parent started its own child).
+// TestTimeSkippingPropagation_ThreeGenerations verifies that AccumulatedSkippedDuration
+// flows transitively through the ancestry: each generation's MS starts with its direct
+// parent's accumulated skip (which already includes all ancestors' contributions) seeded
+// into AccumulatedSkippedDuration, then adds its own skipping on top.
+//
+// The initiated-event PSD snapshot on any parent reflects that parent's full accumulated
+// skip at command time — which includes the parent's own inherited portion. There is no
+// "direct-parent-only" carve-out; the ancestry's virtual clock is continuous.
 //
 // Scenario:
 //   - Grandparent (G) TSC enabled. G: StartTimer(gt1, 1h) → skips 1h → G.accum = 1h.
-//   - G: StartChild(P) + StartTimer(gt2, 1h). P inherits PropagatedSkippedDuration = 1h.
-//   - P: StartTimer(pt1, 2h) → skips 2h → P.accum = 2h.
-//   - P: StartChild(C) + StartTimer(pt2, 1h). C inherits PropagatedSkippedDuration = 2h
-//     (= P's accumulated at time of C start, NOT 1h + 2h = 3h).
-//   - C: StartTimer(ct, 1h) → skips 1h → C.accum = 1h → completes.
-//   - P: idle on pt2 → skips 1h → P.accum = 3h. pt2 fires. P completes.
-//   - G: idle on gt2 → skips 1h → G.accum = 2h. gt2 fires. G completes.
+//   - G: StartChild(P) + StartTimer(gt2, 1h). P's initiated event snapshots PSD=1h.
+//     P's MS: AccumulatedSkippedDuration seeded to 1h, Config.PSD stripped.
+//   - P: StartTimer(pt1, 2h) → skips 2h → P.accum = 1h + 2h = 3h.
+//   - P: StartChild(C) + StartTimer(pt2, 1h). C's initiated event snapshots PSD=3h
+//     (P's full accumulated at command time, which already includes G's 1h).
+//     C's MS: AccumulatedSkippedDuration seeded to 3h, Config.PSD stripped.
+//   - C: StartTimer(ct, 1h) → skips 1h → C.accum = 3h + 1h = 4h → completes.
+//   - P: idle on pt2 → skips 1h → P.accum = 3h + 1h = 4h. pt2 fires. P completes.
+//   - G: idle on gt2 → skips 1h → G.accum = 1h + 1h = 2h. gt2 fires. G completes.
 //
-// Final state: C.config.Propagated == 2h (direct parent only); C.accum == 1h.
+// Final state: C.accum == 4h (3h inherited + 1h own); P.accum == 4h; G.accum == 2h.
 func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ThreeGenerations() {
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
@@ -424,25 +438,25 @@ func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ThreeGene
 	pTSI := pMS.State.ExecutionInfo.GetTimeSkippingInfo()
 	s.NotNil(pTSI)
 	s.True(pTSI.GetConfig().GetEnabled())
-	s.approxDuration(time.Hour, pTSI.GetConfig().GetPropagatedSkippedDuration().AsDuration(),
-		"P.PropagatedSkippedDuration == G's accumulated at P-start (1h)")
-	s.approxDuration(3*time.Hour, pTSI.GetAccumulatedSkippedDuration().AsDuration(),
-		"P: 2h (pt1) + 1h (pt2 after C completes) = 3h")
+	s.Zero(pTSI.GetConfig().GetPropagatedSkippedDuration().AsDuration(),
+		"P.Config.PSD is stripped on apply; the inherited skip lives in AccumulatedSkippedDuration")
+	s.approxDuration(4*time.Hour, pTSI.GetAccumulatedSkippedDuration().AsDuration(),
+		"P.accum == G's accumulated at P-start (1h) + P's own pt1 (2h) + P's own pt2 (1h) = 4h")
 
-	// ---- Child (direct-parent-only propagation) ----
+	// ---- Child (accum inherited transitively through the ancestry) ----
 	cMS := s.getMutableStateByID(env, ctx, cWFID)
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED, cMS.State.ExecutionState.State)
 	cTSI := cMS.State.ExecutionInfo.GetTimeSkippingInfo()
 	s.NotNil(cTSI)
 	s.True(cTSI.GetConfig().GetEnabled())
-	s.approxDuration(2*time.Hour, cTSI.GetConfig().GetPropagatedSkippedDuration().AsDuration(),
-		"C.PropagatedSkippedDuration == P's accumulated at C-start (2h); grandparent skip is NOT re-added")
-	s.approxDuration(time.Hour, cTSI.GetAccumulatedSkippedDuration().AsDuration(),
-		"C accumulated 1h from ct")
+	s.Zero(cTSI.GetConfig().GetPropagatedSkippedDuration().AsDuration(),
+		"C.Config.PSD is stripped on apply")
+	s.approxDuration(4*time.Hour, cTSI.GetAccumulatedSkippedDuration().AsDuration(),
+		"C.accum == P's accumulated at C-start (3h, which already includes G's 1h) + C's own ct (1h) = 4h")
 
-	// History-side check: G's initiated event for P snapshots PSD=1h (G's accumulated at
-	// command time); P's initiated event for C snapshots PSD=2h (P's accumulated at its
-	// own command time — grandparent contribution is NOT carried transitively).
+	// History-side check: G's initiated event for P snapshots PSD=1h (G's accumulated
+	// at command time); P's initiated event for C snapshots PSD=3h (P's full accumulated
+	// at command time — includes G's 1h contribution, which propagates transitively).
 	gInit := s.initiatedChildEvents(ctx, env, gWFID, gRunID)
 	s.Len(gInit, 1)
 	gInitTSC := gInit[0].GetStartChildWorkflowExecutionInitiatedEventAttributes().GetTimeSkippingConfig()
@@ -454,7 +468,8 @@ func (s *TimeSkippingPropagationTestSuite) TestTimeSkippingPropagation_ThreeGene
 	s.Len(pInit, 1)
 	pInitTSC := pInit[0].GetStartChildWorkflowExecutionInitiatedEventAttributes().GetTimeSkippingConfig()
 	s.NotNil(pInitTSC)
-	s.approxDuration(2*time.Hour, pInitTSC.GetPropagatedSkippedDuration().AsDuration())
+	s.approxDuration(3*time.Hour, pInitTSC.GetPropagatedSkippedDuration().AsDuration(),
+		"P's initiated event for C carries P's full accumulated at command time (3h = G's 1h + P's pt1 2h)")
 }
 
 // approxDuration asserts actual is within 5s of expected. Each skip loses
@@ -795,17 +810,20 @@ func (s *TimeSkippingPropagationTestSuite) TestPropagationInReset() {
 // TestPropagationInCaN verifies that TimeSkippingConfig and the previous run's
 // AccumulatedSkippedDuration are propagated to the new run on continue-as-new.
 //
-// Continue-as-new is a continuation of the same logical workflow, so the previous
-// run's accumulated skip flows directly into the new run's AccumulatedSkippedDuration
-// (not stored as Config.PropagatedSkippedDuration metadata like the child-workflow case).
+// CaN uses the same propagation mechanism as child workflows: the previous run's
+// AccumulatedSkippedDuration is snapshotted as PropagatedSkippedDuration on the new
+// run's WorkflowExecutionStarted event. applyTimeSkippingConfig then converts that
+// PSD into AccumulatedSkippedDuration on the new MS (stripping PSD from the stored
+// Config) so the virtual clock continues seamlessly.
 //
 // Scenario:
 //   - Run 1 starts with TimeSkippingConfig{Enabled: true}.
 //   - Run 1 issues StartTimer(t1, 1h). Idle → server skips 1h.
 //     After skip: run1.AccumulatedSkippedDuration = 1h.
 //   - t1 fires. Run 1 issues ContinueAsNew (same type, same task queue).
-//   - Run 2 starts with its AccumulatedSkippedDuration seeded to 1h (inherited
-//     from run 1) and Config.Enabled = true.
+//   - Run 2 starts. Its WorkflowExecutionStarted event carries TSC with Enabled=true
+//     and PropagatedSkippedDuration=1h. The applied MS has Config.Enabled=true,
+//     Config.PSD unset, AccumulatedSkippedDuration=1h.
 //   - Run 2 issues StartTimer(t2, 2h). Idle → skips 2h.
 //     After skip: run2.AccumulatedSkippedDuration = 1h + 2h = 3h.
 //   - t2 fires. Run 2 completes.
@@ -814,11 +832,11 @@ func (s *TimeSkippingPropagationTestSuite) TestPropagationInReset() {
 //   - run1.status == CONTINUED_AS_NEW, run1.AccumulatedSkippedDuration == 1h.
 //   - run2.status == COMPLETED.
 //   - run2.TimeSkippingInfo.Config.Enabled == true (propagated).
-//   - run2.TimeSkippingInfo.Config.PropagatedSkippedDuration is unset — CaN carries
-//     the inherited skip in AccumulatedSkippedDuration, not as PSD metadata.
+//   - run2.TimeSkippingInfo.Config.PropagatedSkippedDuration is unset on the MS —
+//     applyTimeSkippingConfig stripped it after converting to AccumulatedSkippedDuration.
 //   - run2.AccumulatedSkippedDuration == 3h.
-//   - run2 WorkflowExecutionStarted event carries a TSC snapshot with Enabled=true
-//     and no PSD.
+//   - run2 WorkflowExecutionStarted event retains the PSD=1h snapshot (history
+//     observability — the event is created before applyTimeSkippingConfig runs).
 //   - Wall-clock elapsed is nowhere near 3h of virtual time.
 func (s *TimeSkippingPropagationTestSuite) TestPropagationInCaN() {
 	env := testcore.NewEnv(s.T())
@@ -908,6 +926,6 @@ func (s *TimeSkippingPropagationTestSuite) TestPropagationInCaN() {
 	startedTSC := startedAttr.GetTimeSkippingConfig()
 	s.NotNil(startedTSC, "run 2's WorkflowExecutionStarted must carry the TSC snapshot")
 	s.True(startedTSC.GetEnabled(), "started event TSC.Enabled mirrors run 1's config")
-	s.Zero(startedTSC.GetPropagatedSkippedDuration().AsDuration(),
-		"started event must not carry PropagatedSkippedDuration; the inherited skip is on run 2's AccumulatedSkippedDuration")
+	s.approxDuration(time.Hour, startedTSC.GetPropagatedSkippedDuration().AsDuration(),
+		"started event retains PSD=1h (run 1's accumulated at CaN time); applyTimeSkippingConfig converts it to AccumulatedSkippedDuration on the MS but the event snapshot is unchanged")
 }

--- a/tests/timeskipping_test.go
+++ b/tests/timeskipping_test.go
@@ -75,16 +75,15 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_StartWorkflow_DCEnabled() {
 		TaskQueue:           tv.TaskQueue(),
 		WorkflowRunTimeout:  durationpb.New(100 * time.Second),
 		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
-		TimeSkippingConfig:  &workflowpb.TimeSkippingConfig{Enabled: true, DisablePropagation: false, Bound: inputBound},
+		TimeSkippingConfig:  &workflowpb.TimeSkippingConfig{Enabled: true, Bound: inputBound},
 	})
 	s.NoError(err)
 
 	ms := s.getMutableState(env, tv.WorkflowID(), resp.RunId)
 	s.True(ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig().GetEnabled())
 	s.True(proto.Equal(&workflowpb.TimeSkippingConfig{
-		Enabled:            true,
-		DisablePropagation: false,
-		Bound:              inputBound,
+		Enabled: true,
+		Bound:   inputBound,
 	}, ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig()))
 }
 
@@ -109,18 +108,16 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_SignalWithStart_DCEnabled() {
 		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
 		SignalName:          tv.SignalName(),
 		TimeSkippingConfig: &workflowpb.TimeSkippingConfig{
-			Enabled:            true,
-			DisablePropagation: true,
-			Bound:              inputBound,
+			Enabled: true,
+			Bound:   inputBound,
 		},
 	})
 	s.NoError(err)
 
 	ms := s.getMutableState(env, tv.WorkflowID(), resp.RunId)
 	s.True(proto.Equal(&workflowpb.TimeSkippingConfig{
-		Enabled:            true,
-		DisablePropagation: true,
-		Bound:              inputBound,
+		Enabled: true,
+		Bound:   inputBound,
 	}, ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig()))
 }
 
@@ -134,8 +131,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_ExecuteMultiOperation_DCEnabled
 	maxSkippedDuration := time.Hour
 
 	inputConfig := &workflowpb.TimeSkippingConfig{
-		Enabled:            true,
-		DisablePropagation: true,
+		Enabled: true,
 		Bound: &workflowpb.TimeSkippingConfig_MaxSkippedDuration{
 			MaxSkippedDuration: durationpb.New(maxSkippedDuration),
 		},
@@ -248,9 +244,8 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_UpdateWorkflowOptions_DCEnabled
 
 	// Second update: change bound type, add DisablePropagation.
 	config2 := &workflowpb.TimeSkippingConfig{
-		Enabled:            true,
-		DisablePropagation: true,
-		Bound:              &workflowpb.TimeSkippingConfig_MaxElapsedDuration{MaxElapsedDuration: durationpb.New(2 * time.Hour)},
+		Enabled: true,
+		Bound:   &workflowpb.TimeSkippingConfig_MaxElapsedDuration{MaxElapsedDuration: durationpb.New(2 * time.Hour)},
 	}
 	updateOptions(config2)
 
@@ -314,9 +309,8 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_ResetWithUpdateOptions() {
 
 	// Reset with PostResetOperations that sets TimeSkippingConfig.
 	inputConfig := &workflowpb.TimeSkippingConfig{
-		Enabled:            true,
-		DisablePropagation: true,
-		Bound:              &workflowpb.TimeSkippingConfig_MaxSkippedDuration{MaxSkippedDuration: durationpb.New(time.Hour)},
+		Enabled: true,
+		Bound:   &workflowpb.TimeSkippingConfig_MaxSkippedDuration{MaxSkippedDuration: durationpb.New(time.Hour)},
 	}
 	resetResp, err := env.FrontendClient().ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
 		Namespace:                 env.Namespace().String(),


### PR DESCRIPTION
## What changed and Why?

Paired with [api change](https://github.com/temporalio/api/pull/770/changes) 

Define the default time-skipping propagation behavior for current features: continue-as-new (CAN), child workflows, retry, and reset.

**Group 1 — Inherit both from the current execution:**

- Continue-as-new (CAN): inherits the current config and accumulated skipped duration; the configured bound is shared across both the inherited skipped duration and any duration skipped by the new run. 
- Child workflows: same behavior as CAN

This design is because CAN is a technical reason to start a new run of current run, so logically they can be viewed as a same "run". For Child WFs they can be viewed as an extension of previous workflows or separate workflows, and in either case, they shall inherit the skipped duration so that the virtual time doesn't rewind back, and the default behavior is designed to treat them as an extension of the parent and share the config. We only consider adding new config to provide flexibility on demand.

**Group 2 — Inherit from a specific point in history:**

- Retry: inherits the config and skipped duration recorded in the StartWorkflowExecutionEvent of the current workflow, since retry is defined as restarting execution from that event
- Cron: same with Retry

**Group3 -- Both inherit from a specific point and catch up of config change to current**
- Reset: retains the current time-skipping config, since reset is designed to replay all events up to the reset point and apply any UpdateWorkflowExecutionOptions changes made after that point — with no option to exclude them (covered by tests only)


## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

