### PR TITLE
Add RateLimited to TaskAddHookDetails

### DIFF
--- a/service/matching/hooks/task_lifecycle_hooks.go
+++ b/service/matching/hooks/task_lifecycle_hooks.go
@@ -26,7 +26,7 @@ type (
 	TaskAddHookDetails struct {
 		DeploymentVersion *deploymentpb.WorkerDeploymentVersion
 		IsSyncMatch       bool
-		RateLimited       bool
+		IsRateLimited     bool
 	}
 
 	TaskHookFactory interface {

--- a/service/matching/hooks/task_lifecycle_hooks.go
+++ b/service/matching/hooks/task_lifecycle_hooks.go
@@ -26,6 +26,7 @@ type (
 	TaskAddHookDetails struct {
 		DeploymentVersion *deploymentpb.WorkerDeploymentVersion
 		IsSyncMatch       bool
+		RateLimited       bool
 	}
 
 	TaskHookFactory interface {

--- a/service/matching/matcher_data.go
+++ b/service/matching/matcher_data.go
@@ -359,7 +359,13 @@ func (d *matcherData) EnqueuePollerAndWait(ctxs []context.Context, poller *waiti
 	return poller.waitForMatch()
 }
 
-func (d *matcherData) MatchTaskImmediately(task *internalTask) (canSyncMatch, gotSyncMatch bool) {
+type immediateMatchResult struct {
+	canSyncMatch bool
+	gotSyncMatch bool
+	rateLimited  bool
+}
+
+func (d *matcherData) MatchTaskImmediately(task *internalTask) immediateMatchResult {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 
@@ -369,18 +375,18 @@ func (d *matcherData) MatchTaskImmediately(task *internalTask) (canSyncMatch, go
 		// poller to become available. In presence of a backlog the chance of a poller being available when sync match
 		// request comes is almost zero.
 		// This check is mostly effective for the sync match requests that come from child partitions for spooled tasks.
-		return false, false
+		return immediateMatchResult{}
 	}
 
 	task.initMatch(d)
 	d.tasks.Add(task)
-	d.findAndWakeMatches()
+	rateLimited := d.findAndWakeMatches()
 	// don't wait, check if match() picked this one already
 	if task.matchResult != nil {
-		return true, true
+		return immediateMatchResult{canSyncMatch: true, gotSyncMatch: true}
 	}
 	d.tasks.Remove(task)
-	return true, false
+	return immediateMatchResult{canSyncMatch: true, rateLimited: rateLimited}
 }
 
 func (d *matcherData) MatchPollerImmediately(poller *waitingPoller) *matchResult {
@@ -489,8 +495,8 @@ func (d *matcherData) allowForwarding() (allowForwarding bool) {
 	return delayToForwardingAllowed <= 0
 }
 
-// call with lock held
-func (d *matcherData) findAndWakeMatches() {
+// call with lock held. Returns true if a match was found but blocked by rate limiting.
+func (d *matcherData) findAndWakeMatches() (rateLimited bool) {
 	allowForwarding := d.canForward && d.allowForwarding()
 
 	now := d.timeSource.Now().UnixNano()
@@ -502,14 +508,14 @@ func (d *matcherData) findAndWakeMatches() {
 		if task == nil || poller == nil {
 			// no more current matches, stop rate limit timer if was running
 			d.rateLimitTimer.unset()
-			return
+			return false
 		}
 
 		// check ready time
 		delay := d.rateLimitManager.readyTimeForTask(task).delay(now)
 		d.rateLimitTimer.set(d.timeSource, d.rematchAfterTimer, delay)
 		if delay > 0 {
-			return // not ready yet, timer will call match later
+			return true // not ready yet, timer will call match later
 		}
 
 		// ready to signal match

--- a/service/matching/matcher_data_test.go
+++ b/service/matching/matcher_data_test.go
@@ -214,6 +214,26 @@ func (s *MatcherDataSuite) TestMatchTaskImmediately() {
 	s.Equal(t, pres.task)
 }
 
+func (s *MatcherDataSuite) TestMatchTaskImmediatelyRateLimited() {
+	// Set rate limit to zero — blocks all matches.
+	s.md.rateLimitManager.SetEffectiveRPSAndSourceForTesting(0, enumspb.RATE_LIMIT_SOURCE_API)
+	s.md.rateLimitManager.UpdateSimpleRateLimitWithBurstForTesting(0)
+
+	// Add a waiting poller.
+	go func() {
+		poller := &waitingPoller{startTime: s.now()}
+		s.md.EnqueuePollerAndWait(nil, poller)
+	}()
+	s.waitForPollers(1)
+
+	// Sync match should fail due to rate limiting, not lack of poller.
+	t := s.newSyncTask(nil)
+	imr := s.md.MatchTaskImmediately(t)
+	s.True(imr.canSyncMatch)
+	s.False(imr.gotSyncMatch)
+	s.True(imr.rateLimited)
+}
+
 func (s *MatcherDataSuite) TestMatchTaskImmediatelyDisabledBacklog() {
 	// register some backlog with old tasks
 	s.md.EnqueueTaskNoWait(s.newBacklogTask(123, 10*time.Minute, nil))

--- a/service/matching/matcher_data_test.go
+++ b/service/matching/matcher_data_test.go
@@ -189,9 +189,9 @@ func (s *MatcherDataSuite) TestMatchTaskImmediately() {
 	t := s.newSyncTask(nil)
 
 	// no match yet
-	canSyncMatch, gotSyncMatch := s.md.MatchTaskImmediately(t)
-	s.True(canSyncMatch)
-	s.False(gotSyncMatch)
+	imr := s.md.MatchTaskImmediately(t)
+	s.True(imr.canSyncMatch)
+	s.False(imr.gotSyncMatch)
 
 	// poll in a goroutine
 	ch := make(chan *matchResult, 1)
@@ -204,9 +204,9 @@ func (s *MatcherDataSuite) TestMatchTaskImmediately() {
 	s.waitForPollers(1)
 
 	// should match this time
-	canSyncMatch, gotSyncMatch = s.md.MatchTaskImmediately(t)
-	s.True(canSyncMatch)
-	s.True(gotSyncMatch)
+	imr = s.md.MatchTaskImmediately(t)
+	s.True(imr.canSyncMatch)
+	s.True(imr.gotSyncMatch)
 
 	// check match
 	pres := <-ch
@@ -219,9 +219,9 @@ func (s *MatcherDataSuite) TestMatchTaskImmediatelyDisabledBacklog() {
 	s.md.EnqueueTaskNoWait(s.newBacklogTask(123, 10*time.Minute, nil))
 
 	t := s.newSyncTask(nil)
-	canSyncMatch, gotSyncMatch := s.md.MatchTaskImmediately(t)
-	s.False(canSyncMatch)
-	s.False(gotSyncMatch)
+	imr := s.md.MatchTaskImmediately(t)
+	s.False(imr.canSyncMatch)
+	s.False(imr.gotSyncMatch)
 }
 
 func (s *MatcherDataSuite) TestQuery() {

--- a/service/matching/matcher_data_test.go
+++ b/service/matching/matcher_data_test.go
@@ -189,9 +189,9 @@ func (s *MatcherDataSuite) TestMatchTaskImmediately() {
 	t := s.newSyncTask(nil)
 
 	// no match yet
-	imr := s.md.MatchTaskImmediately(t)
-	s.True(imr.canSyncMatch)
-	s.False(imr.gotSyncMatch)
+	immediateResult := s.md.MatchTaskImmediately(t)
+	s.True(immediateResult.canSyncMatch)
+	s.False(immediateResult.gotSyncMatch)
 
 	// poll in a goroutine
 	ch := make(chan *matchResult, 1)
@@ -204,9 +204,9 @@ func (s *MatcherDataSuite) TestMatchTaskImmediately() {
 	s.waitForPollers(1)
 
 	// should match this time
-	imr = s.md.MatchTaskImmediately(t)
-	s.True(imr.canSyncMatch)
-	s.True(imr.gotSyncMatch)
+	immediateResult = s.md.MatchTaskImmediately(t)
+	s.True(immediateResult.canSyncMatch)
+	s.True(immediateResult.gotSyncMatch)
 
 	// check match
 	pres := <-ch
@@ -228,10 +228,10 @@ func (s *MatcherDataSuite) TestMatchTaskImmediatelyRateLimited() {
 
 	// Sync match should fail due to rate limiting, not lack of poller.
 	t := s.newSyncTask(nil)
-	imr := s.md.MatchTaskImmediately(t)
-	s.True(imr.canSyncMatch)
-	s.False(imr.gotSyncMatch)
-	s.True(imr.rateLimited)
+	immediateResult := s.md.MatchTaskImmediately(t)
+	s.True(immediateResult.canSyncMatch)
+	s.False(immediateResult.gotSyncMatch)
+	s.True(immediateResult.rateLimited)
 }
 
 func (s *MatcherDataSuite) TestMatchTaskImmediatelyDisabledBacklog() {
@@ -239,9 +239,9 @@ func (s *MatcherDataSuite) TestMatchTaskImmediatelyDisabledBacklog() {
 	s.md.EnqueueTaskNoWait(s.newBacklogTask(123, 10*time.Minute, nil))
 
 	t := s.newSyncTask(nil)
-	imr := s.md.MatchTaskImmediately(t)
-	s.False(imr.canSyncMatch)
-	s.False(imr.gotSyncMatch)
+	immediateResult := s.md.MatchTaskImmediately(t)
+	s.False(immediateResult.canSyncMatch)
+	s.False(immediateResult.gotSyncMatch)
 }
 
 func (s *MatcherDataSuite) TestQuery() {

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -680,24 +680,33 @@ func (c *physicalTaskQueueManagerImpl) GetInternalTaskQueueStatus() []*taskqueue
 	return status
 }
 
-func (c *physicalTaskQueueManagerImpl) TrySyncMatch(ctx context.Context, task *internalTask) (bool, error) {
+// syncMatchResult contains the outcome of a TrySyncMatch attempt.
+type syncMatchResult struct {
+	matched     bool
+	rateLimited bool
+	err         error
+}
+
+func (c *physicalTaskQueueManagerImpl) TrySyncMatch(ctx context.Context, task *internalTask) syncMatchResult {
 	if !task.isForwarded() {
 		// request sent by history service
 		c.liveness.markAlive()
 		c.getOrCreateTaskTracker(c.tasksAdded, priorityKey(task.getPriority().GetPriorityKey())).inc(1)
 		if disable, _ := testhooks.Get(c.partitionMgr.engine.testHooks, testhooks.MatchingDisableSyncMatch, c.partitionMgr.ns.ID()); disable {
-			return false, nil
+			return syncMatchResult{}
 		}
 	}
 
 	if c.priMatcher != nil {
-		return c.priMatcher.Offer(ctx, task)
+		matched, rateLimited, err := c.priMatcher.Offer(ctx, task)
+		return syncMatchResult{matched: matched, rateLimited: rateLimited, err: err}
 	}
 
 	childCtx, cancel := contextutil.WithDeadlineBuffer(ctx, c.config.SyncMatchWaitDuration(), time.Second)
 	defer cancel()
 
-	return c.oldMatcher.Offer(childCtx, task)
+	matched, err := c.oldMatcher.Offer(childCtx, task)
+	return syncMatchResult{matched: matched, err: err}
 }
 
 func (c *physicalTaskQueueManagerImpl) ensureRegisteredInDeploymentVersion(

--- a/service/matching/physical_task_queue_manager_interface.go
+++ b/service/matching/physical_task_queue_manager_interface.go
@@ -29,7 +29,8 @@ type (
 		PollTask(ctx context.Context, pollMetadata *pollMetadata) (*internalTask, error)
 		// MarkAlive updates the liveness timer to keep this physicalTaskQueueManager alive.
 		MarkAlive()
-		// TrySyncMatch tries to match task to a local or remote poller. If not possible, returns false.
+		// TrySyncMatch tries to match task to a local or remote poller. Returns a syncMatchResult
+		// indicating whether the match succeeded, and if not, whether it was blocked by rate limiting.
 		TrySyncMatch(ctx context.Context, task *internalTask) syncMatchResult
 		// SpoolTask spools a task to persistence to be matched asynchronously when a poller is available.
 		SpoolTask(taskInfo *persistencespb.TaskInfo) error

--- a/service/matching/physical_task_queue_manager_interface.go
+++ b/service/matching/physical_task_queue_manager_interface.go
@@ -30,7 +30,7 @@ type (
 		// MarkAlive updates the liveness timer to keep this physicalTaskQueueManager alive.
 		MarkAlive()
 		// TrySyncMatch tries to match task to a local or remote poller. If not possible, returns false.
-		TrySyncMatch(ctx context.Context, task *internalTask) (bool, error)
+		TrySyncMatch(ctx context.Context, task *internalTask) syncMatchResult
 		// SpoolTask spools a task to persistence to be matched asynchronously when a poller is available.
 		SpoolTask(taskInfo *persistencespb.TaskInfo) error
 		// TODO(pri): old matcher cleanup

--- a/service/matching/physical_task_queue_manager_mock.go
+++ b/service/matching/physical_task_queue_manager_mock.go
@@ -357,12 +357,11 @@ func (mr *MockphysicalTaskQueueManagerMockRecorder) Stop(arg0 any) *gomock.Call 
 }
 
 // TrySyncMatch mocks base method.
-func (m *MockphysicalTaskQueueManager) TrySyncMatch(ctx context.Context, task *internalTask) (bool, error) {
+func (m *MockphysicalTaskQueueManager) TrySyncMatch(ctx context.Context, task *internalTask) syncMatchResult {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TrySyncMatch", ctx, task)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(syncMatchResult)
+	return ret0
 }
 
 // TrySyncMatch indicates an expected call of TrySyncMatch.

--- a/service/matching/pri_matcher.go
+++ b/service/matching/pri_matcher.go
@@ -406,14 +406,14 @@ func (tm *priTaskMatcher) Offer(ctx context.Context, task *internalTask) (matche
 	// Fast path if we have a waiting poller (or forwarder).
 	// Forwarding happens here if we match with the task forwarding poller.
 	task.forwardCtx = ctx
-	imr := tm.data.MatchTaskImmediately(task)
-	if imr.gotSyncMatch {
+	immediateResult := tm.data.MatchTaskImmediately(task)
+	if immediateResult.gotSyncMatch {
 		return finish()
-	} else if !imr.canSyncMatch {
+	} else if !immediateResult.canSyncMatch {
 		return false, false, nil
 	}
 
-	if imr.rateLimited {
+	if immediateResult.rateLimited {
 		return false, true, nil
 	}
 

--- a/service/matching/pri_matcher.go
+++ b/service/matching/pri_matcher.go
@@ -380,19 +380,19 @@ func (tm *priTaskMatcher) forwardPolls(
 //   - ratelimit is exceeded (does not apply to query task)
 //   - context deadline is exceeded
 //   - task is matched and consumer returns error in response channel
-func (tm *priTaskMatcher) Offer(ctx context.Context, task *internalTask) (bool, error) {
-	finish := func() (bool, error) {
+func (tm *priTaskMatcher) Offer(ctx context.Context, task *internalTask) (matched bool, rateLimited bool, err error) {
+	finish := func() (bool, bool, error) {
 		res, ok := task.getResponse()
 		if !softassert.That(tm.logger, ok, "expected a sync match task") {
-			return false, nil
+			return false, false, nil
 		}
 		if res.forwarded {
 			if res.forwardErr == nil {
 				// task was remotely sync matched on the parent partition
 				tm.emitDispatchLatency(task, true)
-				return true, nil
+				return true, false, nil
 			}
-			return false, nil // forward error, give up here
+			return false, false, nil // forward error, give up here
 		}
 		// TODO(pri): can we just always do this on the parent and simplify this to:
 		// if res.startErr == nil { tm.emitDispatchLatency(task, task.isForwarded) }
@@ -400,16 +400,21 @@ func (tm *priTaskMatcher) Offer(ctx context.Context, task *internalTask) (bool, 
 		if res.startErr == nil && !task.isForwarded() {
 			tm.emitDispatchLatency(task, false)
 		}
-		return true, res.startErr
+		return true, false, res.startErr
 	}
 
 	// Fast path if we have a waiting poller (or forwarder).
 	// Forwarding happens here if we match with the task forwarding poller.
 	task.forwardCtx = ctx
-	if canMatch, gotMatch := tm.data.MatchTaskImmediately(task); gotMatch {
+	imr := tm.data.MatchTaskImmediately(task)
+	if imr.gotSyncMatch {
 		return finish()
-	} else if !canMatch {
-		return false, nil
+	} else if !imr.canSyncMatch {
+		return false, false, nil
+	}
+
+	if imr.rateLimited {
+		return false, true, nil
 	}
 
 	// We only block if we are the root and the task is forwarded from a backlog.
@@ -417,15 +422,15 @@ func (tm *priTaskMatcher) Offer(ctx context.Context, task *internalTask) (bool, 
 	if tm.isForwardingAllowed() ||
 		task.source != enumsspb.TASK_SOURCE_DB_BACKLOG ||
 		!task.isForwarded() {
-		return false, nil
+		return false, false, nil
 	}
 
 	res := tm.data.EnqueueTaskAndWait([]context.Context{ctx, tm.tqCtx}, task)
 	if res.ctxErr != nil {
-		return false, res.ctxErr
+		return false, false, res.ctxErr
 	}
 	if !softassert.That(tm.logger, res.poller != nil, "expeced poller from match") {
-		return false, nil
+		return false, false, nil
 	}
 
 	return finish()

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -441,8 +441,8 @@ reredirectTask:
 
 	var rateLimited bool
 	if isActive {
-		smr := syncMatchQueue.TrySyncMatch(ctx, syncMatchTask)
-		syncMatched, rateLimited, err = smr.matched, smr.rateLimited, smr.err
+		syncResult := syncMatchQueue.TrySyncMatch(ctx, syncMatchTask)
+		syncMatched, rateLimited, err = syncResult.matched, syncResult.rateLimited, syncResult.err
 		if syncMatched && !pm.shouldBacklogSyncMatchTaskOnError(err) {
 			// Only fire hooks for non-forwarded tasks. Forwarded tasks already had hooks fired
 			// on the child partition that originally received the task.

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -487,7 +487,7 @@ func (pm *taskQueuePartitionManagerImpl) processTaskAddHooks(ctx context.Context
 		l.ProcessTaskAdd(ctx, &hooks.TaskAddHookDetails{
 			DeploymentVersion: worker_versioning.ExternalWorkerDeploymentVersionFromVersion(targetVersion),
 			IsSyncMatch:       syncMatched,
-			RateLimited:       rateLimited,
+			IsRateLimited:     rateLimited,
 		})
 	}
 }

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -439,13 +439,15 @@ reredirectTask:
 		return "", false, err
 	}
 
+	var rateLimited bool
 	if isActive {
-		syncMatched, err = syncMatchQueue.TrySyncMatch(ctx, syncMatchTask)
+		smr := syncMatchQueue.TrySyncMatch(ctx, syncMatchTask)
+		syncMatched, rateLimited, err = smr.matched, smr.rateLimited, smr.err
 		if syncMatched && !pm.shouldBacklogSyncMatchTaskOnError(err) {
 			// Only fire hooks for non-forwarded tasks. Forwarded tasks already had hooks fired
 			// on the child partition that originally received the task.
 			if params.forwardInfo == nil {
-				pm.processTaskAddHooks(ctx, targetVersion, syncMatched)
+				pm.processTaskAddHooks(ctx, targetVersion, syncMatched, false)
 			}
 
 			// Build ID is not returned for sync match. The returned build ID is used by History to update
@@ -474,17 +476,18 @@ reredirectTask:
 
 	err = spoolQueue.SpoolTask(params.taskInfo)
 	if err == nil {
-		pm.processTaskAddHooks(ctx, targetVersion, false)
+		pm.processTaskAddHooks(ctx, targetVersion, false, rateLimited)
 	}
 
 	return assignedBuildId, false, err
 }
 
-func (pm *taskQueuePartitionManagerImpl) processTaskAddHooks(ctx context.Context, targetVersion *deploymentspb.WorkerDeploymentVersion, syncMatched bool) {
+func (pm *taskQueuePartitionManagerImpl) processTaskAddHooks(ctx context.Context, targetVersion *deploymentspb.WorkerDeploymentVersion, syncMatched bool, rateLimited bool) {
 	for _, l := range pm.taskHooks {
 		l.ProcessTaskAdd(ctx, &hooks.TaskAddHookDetails{
 			DeploymentVersion: worker_versioning.ExternalWorkerDeploymentVersionFromVersion(targetVersion),
 			IsSyncMatch:       syncMatched,
+			RateLimited:       rateLimited,
 		})
 	}
 }

--- a/service/matching/task_queue_partition_manager_test.go
+++ b/service/matching/task_queue_partition_manager_test.go
@@ -1351,7 +1351,7 @@ type capturedTaskMatchDetails struct {
 	TaskQueueName     string
 	TaskQueueType     enumspb.TaskQueueType
 	IsSyncMatch       bool
-	RateLimited       bool
+	IsRateLimited     bool
 	DeploymentVersion *deploymentpb.WorkerDeploymentVersion
 }
 
@@ -1374,7 +1374,7 @@ func (h *capturingTaskMatchHook) ProcessTaskAdd(ctx context.Context, event *hook
 		TaskQueueName: h.taskQueueName,
 		TaskQueueType: h.taskQueueType,
 		IsSyncMatch:   event.IsSyncMatch,
-		RateLimited:   event.RateLimited,
+		IsRateLimited: event.IsRateLimited,
 	}
 	if event.DeploymentVersion != nil {
 		details.DeploymentVersion = &deploymentpb.WorkerDeploymentVersion{
@@ -1772,7 +1772,7 @@ func (s *PartitionManagerTestSuite) TestTaskAddHooks_RateLimited() {
 	calls := hook.getCalls()
 	s.Require().Len(calls, 1)
 	s.False(calls[0].IsSyncMatch)
-	s.True(calls[0].RateLimited)
+	s.True(calls[0].IsRateLimited)
 }
 
 func (s *PartitionManagerTestSuite) TestTaskAddHooks_NotRateLimited() {
@@ -1795,7 +1795,7 @@ func (s *PartitionManagerTestSuite) TestTaskAddHooks_NotRateLimited() {
 	calls := hook.getCalls()
 	s.Require().Len(calls, 1)
 	s.False(calls[0].IsSyncMatch)
-	s.False(calls[0].RateLimited)
+	s.False(calls[0].IsRateLimited)
 }
 
 func (s *PartitionManagerTestSuite) TestTaskAddHooks_MultipleHooksInvoked() {

--- a/service/matching/task_queue_partition_manager_test.go
+++ b/service/matching/task_queue_partition_manager_test.go
@@ -1351,6 +1351,7 @@ type capturedTaskMatchDetails struct {
 	TaskQueueName     string
 	TaskQueueType     enumspb.TaskQueueType
 	IsSyncMatch       bool
+	RateLimited       bool
 	DeploymentVersion *deploymentpb.WorkerDeploymentVersion
 }
 
@@ -1373,6 +1374,7 @@ func (h *capturingTaskMatchHook) ProcessTaskAdd(ctx context.Context, event *hook
 		TaskQueueName: h.taskQueueName,
 		TaskQueueType: h.taskQueueType,
 		IsSyncMatch:   event.IsSyncMatch,
+		RateLimited:   event.RateLimited,
 	}
 	if event.DeploymentVersion != nil {
 		details.DeploymentVersion = &deploymentpb.WorkerDeploymentVersion{
@@ -1712,6 +1714,75 @@ func (s *PartitionManagerTestSuite) TestTaskAddHooks_ForwardedNoSyncMatch_HooksN
 
 	// Hooks should NOT have been called on the parent partition.
 	s.Require().Empty(hook.getCalls())
+}
+
+func (s *PartitionManagerTestSuite) TestTaskAddHooks_RateLimited() {
+	if !s.newMatcher {
+		s.T().Skip("rate limiting signal from matcher is only available in new matcher")
+	}
+	hook := &capturingTaskMatchHook{}
+	pm, cleanup := s.setupPartitionManagerWithTaskHookFactories([]hooks.TaskHookFactory{hook})
+	defer cleanup()
+
+	// Set rate limit to zero RPS — this blocks all sync matches due to rate limiting.
+	pm.rateLimitManager.SetEffectiveRPSAndSourceForTesting(0, enumspb.RATE_LIMIT_SOURCE_API)
+	pm.rateLimitManager.UpdateSimpleRateLimitWithBurstForTesting(0)
+
+	// Set up a waiting poller so sync match would succeed if not rate-limited.
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		task, _, _ := pm.PollTask(ctx, &pollMetadata{
+			workerVersionCapabilities: &commonpb.WorkerVersionCapabilities{
+				BuildId:       "",
+				UseVersioning: false,
+			},
+		})
+		if task != nil && task.responseC != nil {
+			close(task.responseC)
+		}
+	}()
+	pq := pm.defaultQueue().(*physicalTaskQueueManagerImpl)
+	s.Require().Eventually(pq.matcher.HasWaitingPoller, 2*time.Second, time.Millisecond)
+
+	// AddTask should fall through to spool because rate limiting blocked sync match.
+	_, syncMatched, err := pm.AddTask(context.Background(), addTaskParams{
+		taskInfo: &persistencespb.TaskInfo{
+			NamespaceId: namespaceID,
+			RunId:       "run",
+			WorkflowId:  "wf",
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().False(syncMatched)
+
+	calls := hook.getCalls()
+	s.Require().Len(calls, 1)
+	s.False(calls[0].IsSyncMatch)
+	s.True(calls[0].RateLimited)
+}
+
+func (s *PartitionManagerTestSuite) TestTaskAddHooks_NotRateLimited() {
+	hook := &capturingTaskMatchHook{}
+	pm, cleanup := s.setupPartitionManagerWithTaskHookFactories([]hooks.TaskHookFactory{hook})
+	defer cleanup()
+
+	// No rate limiting configured — task should spool normally without rate limit flag.
+	_, syncMatched, err := pm.AddTask(context.Background(), addTaskParams{
+		taskInfo: &persistencespb.TaskInfo{
+			NamespaceId:      namespaceID,
+			RunId:            "run",
+			WorkflowId:       "wf",
+			VersionDirective: worker_versioning.MakeBuildIdDirective("buildXYZ"),
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().False(syncMatched)
+
+	calls := hook.getCalls()
+	s.Require().Len(calls, 1)
+	s.False(calls[0].IsSyncMatch)
+	s.False(calls[0].RateLimited)
 }
 
 func (s *PartitionManagerTestSuite) TestTaskAddHooks_MultipleHooksInvoked() {

--- a/service/matching/task_queue_partition_manager_test.go
+++ b/service/matching/task_queue_partition_manager_test.go
@@ -1646,6 +1646,7 @@ func (s *PartitionManagerTestSuite) TestTaskAddHooks_ForwardedSyncMatch_HooksNot
 	pm, cleanup := s.setupPartitionManagerWithTaskHookFactories([]hooks.TaskHookFactory{hook})
 	defer cleanup()
 
+	// Start a poller in a background goroutine so there's someone to sync-match with.
 	type pollResult struct {
 		task *internalTask
 		err  error
@@ -1665,9 +1666,15 @@ func (s *PartitionManagerTestSuite) TestTaskAddHooks_ForwardedSyncMatch_HooksNot
 			close(task.responseC)
 		}
 	}()
+
+	// Wait until the poller is actually blocked in the matcher, ready to receive a task.
+	// This guarantees the subsequent AddTask will sync-match rather than spool.
 	pq := pm.defaultQueue().(*physicalTaskQueueManagerImpl)
 	s.Require().Eventually(pq.matcher.HasWaitingPoller, 2*time.Second, time.Millisecond)
 
+	// Add a forwarded task (simulating a child partition forwarding to this parent).
+	// With a poller waiting, this should sync-match successfully.
+	// forwardInfo being set is what marks this task as forwarded from another partition.
 	_, syncMatched, err := pm.AddTask(context.Background(), addTaskParams{
 		taskInfo: &persistencespb.TaskInfo{
 			NamespaceId: namespaceID,
@@ -1679,6 +1686,7 @@ func (s *PartitionManagerTestSuite) TestTaskAddHooks_ForwardedSyncMatch_HooksNot
 	s.Require().NoError(err)
 	s.Require().True(syncMatched)
 
+	// Drain the poller goroutine and verify it received the task.
 	var pr pollResult
 	s.Require().Eventually(func() bool {
 		select {
@@ -1691,16 +1699,21 @@ func (s *PartitionManagerTestSuite) TestTaskAddHooks_ForwardedSyncMatch_HooksNot
 	s.Require().NoError(pr.err)
 	s.Require().NotNil(pr.task)
 
-	// Hooks should NOT have been called — the child partition is responsible for firing hooks.
+	// Hooks should NOT have been called on the parent — the child partition that
+	// originated the forwarded task is responsible for firing hooks.
 	s.Require().Empty(hook.getCalls())
 }
 
 func (s *PartitionManagerTestSuite) TestTaskAddHooks_ForwardedNoSyncMatch_HooksNotInvoked() {
-	// When a forwarded task fails to sync-match, hooks should not fire on the parent.
+	// When a forwarded task fails to sync-match (no poller available), hooks should
+	// not fire on the parent. This documents existing behavior — the errRemoteSyncMatchFailed
+	// return path already skips hooks since it exits before reaching processTaskAddHooks.
 	hook := &capturingTaskMatchHook{}
 	pm, cleanup := s.setupPartitionManagerWithTaskHookFactories([]hooks.TaskHookFactory{hook})
 	defer cleanup()
 
+	// Add a forwarded task with no poller — sync match fails and the parent returns
+	// errRemoteSyncMatchFailed so the child can spool the task instead.
 	_, syncMatched, err := pm.AddTask(context.Background(), addTaskParams{
 		taskInfo: &persistencespb.TaskInfo{
 			NamespaceId: namespaceID,

--- a/service/matching/task_queue_partition_manager_test.go
+++ b/service/matching/task_queue_partition_manager_test.go
@@ -1706,8 +1706,8 @@ func (s *PartitionManagerTestSuite) TestTaskAddHooks_ForwardedSyncMatch_HooksNot
 
 func (s *PartitionManagerTestSuite) TestTaskAddHooks_ForwardedNoSyncMatch_HooksNotInvoked() {
 	// When a forwarded task fails to sync-match (no poller available), hooks should
-	// not fire on the parent. This documents existing behavior — the errRemoteSyncMatchFailed
-	// return path already skips hooks since it exits before reaching processTaskAddHooks.
+	// not fire on the parent. The errRemoteSyncMatchFailed return path already skips
+	// hooks since it exits AddTask before reaching processTaskAddHooks.
 	hook := &capturingTaskMatchHook{}
 	pm, cleanup := s.setupPartitionManagerWithTaskHookFactories([]hooks.TaskHookFactory{hook})
 	defer cleanup()


### PR DESCRIPTION
## What
Surface the rate-limiting signal from the matcher through `TrySyncMatch` to task hooks. `TaskAddHookDetails` now includes `RateLimited bool`.

## Why
Hook consumers need to distinguish "sync match failed because no poller was available" from "sync match failed because rate limiting blocked the match despite a poller being available."

## How did you test it?
Unit tests across all three partition manager suites (Classic, Pri, Fair):
- Task rate-limited during sync match with a waiting poller → hook receives `RateLimited=true` (new matcher only, skipped on Classic)
- Task not rate-limited → hook receives `RateLimited=false`
- Existing `MatchTaskImmediately` tests updated for new return type