### PR TITLE
When skipping task queue metadata write, check rangeid instead

### DIFF
--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -453,7 +453,7 @@ func (s *BacklogManagerTestSuite) TestSyncState_UnloadsOnOwnershipLoss() {
 
 	s.blm.Start()
 	defer s.blm.Stop()
-	s.NoError(s.blm.WaitUntilInitialized(context.Background()))
+	s.Require().NoError(s.blm.WaitUntilInitialized(context.Background()))
 
 	// physical queue should unload soon
 	var unloadCalled atomic.Bool

--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -444,6 +444,33 @@ func (s *BacklogManagerTestSuite) TestApproximateBacklogCount_ResetOnDrained() {
 	s.Zero(totalApproximateBacklogCount(s.blm))
 }
 
+func (s *BacklogManagerTestSuite) TestSyncState_UnloadsOnOwnershipLoss() {
+	if !s.newMatcher {
+		s.T().Skip("SyncState is only used by the new backlog manager")
+	}
+
+	s.cfgcli.OverrideValue(dynamicconfig.MatchingUpdateAckInterval.Key(), 100*time.Millisecond)
+
+	s.blm.Start()
+	defer s.blm.Stop()
+	s.NoError(s.blm.WaitUntilInitialized(context.Background()))
+
+	// physical queue should unload soon
+	var unloadCalled atomic.Bool
+	s.ptqMgr.EXPECT().UnloadFromPartitionManager(unloadCauseConflict).Do(func(unloadCause) {
+		unloadCalled.Store(true)
+	}).AnyTimes()
+
+	// simulate another partition stealing and releasing ownership
+	db := s.blm.getDB()
+	tqd := s.taskMgr.getQueueDataByKey(db.queue)
+	tqd.Lock()
+	tqd.rangeID++
+	tqd.Unlock()
+
+	s.Eventually(unloadCalled.Load, time.Second, 100*time.Millisecond)
+}
+
 type taskBlock struct {
 	count   int
 	expired bool

--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -3,6 +3,7 @@ package matching
 import (
 	"cmp"
 	"context"
+	"fmt"
 	"math"
 	"slices"
 	"sync"
@@ -289,10 +290,31 @@ func (db *taskQueueDB) SyncState(ctx context.Context) error {
 	ttl := min(24*time.Hour, cmp.Or(db.queue.Partition().PersistenceTTL(), 24*time.Hour))
 	needWrite := db.lastChange.After(db.lastWrite) || time.Since(db.lastWrite) > ttl/2
 	if !needWrite {
-		return nil
+		// If we don't write, though, we wouldn't know if someone else has stolen ownership
+		// momentarily (this could happen due to eventual consistency of membership updates).
+		// So instead, do a (cheaper) read to just check the range id.
+		return db.verifyOwnershipLocked(ctx)
 	}
 
 	return db.updateTaskQueueLocked(ctx, false)
+}
+
+func (db *taskQueueDB) verifyOwnershipLocked(ctx context.Context) error {
+	response, err := db.store.GetTaskQueue(ctx, &persistence.GetTaskQueueRequest{
+		NamespaceID: db.queue.NamespaceId(),
+		TaskQueue:   db.queue.PersistenceName(),
+		TaskType:    db.queue.TaskType(),
+	})
+	if err != nil {
+		return err
+	}
+	if response.RangeID != db.rangeID {
+		return &persistence.ConditionFailedError{
+			Msg: fmt.Sprintf("task queue ownership lost: stored rangeID %d, in-memory rangeID %d",
+				response.RangeID, db.rangeID),
+		}
+	}
+	return nil
 }
 
 func (db *taskQueueDB) updateAckLevelAndBacklogStats(subqueue subqueueIndex, newAckLevel int64, countDelta int64, oldestTime time.Time) {


### PR DESCRIPTION
## What changed?
There was a recent optimization to skip the periodic task queue metadata write when there are no changes in metadata. This missed that a secondary purpose of the metadata write was to detect ownership being lost temporarily, i.e. the real owning instance still has the partition loaded correctly, but another one had taken it over and then unloaded.

This adds a read of metadata in that case, to detect if that happened and unload.

## Why?
If ownership changed right as a bunch of tasks was written, and then no tasks were written for a long time, and membership changes happened in a particular order so that the real owner took over the partition, then another one took it back and wrote a task and then unload, then the real owner wouldn't see that task until another one was written.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
