### PR TITLE
chore: typo sweep (publically, enviroment, occured)

### DIFF
--- a/docs/architecture/nexus.md
+++ b/docs/architecture/nexus.md
@@ -325,7 +325,7 @@ workflow and operation state machine. The
 [component.nexusoperations.callback.endpoint.template](https://github.com/temporalio/temporal/blob/7c8025aff96af7d72a91af615f1d625817842894/components/nexusoperations/config.go#L69)
 global dynamic config must be set to construct callback URLs or the executor will fail to process invocation tasks. When
 routing callbacks to external clusters and non-Temporal destinations, the URL is used and should be a value that is
-publically accessible to those external destinations. Callbacks that are routed internally within the cluster resolve
+publicly accessible to those external destinations. Callbacks that are routed internally within the cluster resolve
 the frontend URL via membership or, as a last resort, via static configuration overrides.
 
 The timeout for making a single Nexus HTTP call is configurable via: `component.nexusoperations.request.timeout`

--- a/service/matching/matcher_test.go
+++ b/service/matching/matcher_test.go
@@ -300,7 +300,7 @@ func (t *MatcherTestSuite) TestForwardingWhenBacklogIsYoung() {
 	wg.Add(1)
 	t.client.EXPECT().AddWorkflowTask(gomock.Any(), gomock.Any(), gomock.Any()).Do(
 		func(arg0 context.Context, arg1 *matchingservice.AddWorkflowTaskRequest, arg2 ...any) {
-			// Offer forwarding has occured
+			// Offer forwarding has occurred
 			wg.Done()
 		},
 	).Return(&matchingservice.AddWorkflowTaskResponse{}, errMatchingHostThrottleTest)

--- a/tools/tdbg/app.go
+++ b/tools/tdbg/app.go
@@ -115,7 +115,7 @@ func NewCliApp(opts ...Option) *cli.App {
 		case "never":
 			color.NoColor = true
 		default:
-			// fatih/color will inspect the enviroment and terminal and set a reasonable default.
+			// fatih/color will inspect the environment and terminal and set a reasonable default.
 		}
 		return nil
 	}


### PR DESCRIPTION
Three single-character typo fixes, all in prose/comments, no functional change:

- `docs/architecture/nexus.md:328`, `publically accessible` -> `publicly accessible`
- `tools/tdbg/app.go:118`, comment `fatih/color will inspect the enviroment` -> `environment`
- `service/matching/matcher_test.go:303`, comment `Offer forwarding has occured` -> `occurred`