### PR TITLE
Fix history host reader limiter when persistence max QPS is zero

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1552,7 +1552,8 @@ execution is deleted. When enabled, workflow deletions on the active cluster wil
 	HistoryPersistenceMaxQPS = NewGlobalIntSetting(
 		"history.persistenceMaxQPS",
 		9000,
-		`HistoryPersistenceMaxQPS is the max qps history host can query DB`,
+		`HistoryPersistenceMaxQPS is the max qps history host can query DB
+If value is less or equal to 0, persistence host rate limiting is disabled`,
 	)
 	HistoryPersistenceGlobalMaxQPS = NewGlobalIntSetting(
 		"history.persistenceGlobalMaxQPS",
@@ -1927,7 +1928,8 @@ Higher values allow limited parallelism per workflow. Values <= 0 are capped to 
 	TimerProcessorMaxPollHostRPS = NewGlobalIntSetting(
 		"history.timerProcessorMaxPollHostRPS",
 		0,
-		`TimerProcessorMaxPollHostRPS is max poll rate per second for all timer processor on a host`,
+		`TimerProcessorMaxPollHostRPS is max poll rate per second for all timer processor on a host
+If value is less or equal to 0, it falls back to a HistoryPersistenceMaxQPS-derived host poll rate when HistoryPersistenceMaxQPS is positive; otherwise no host poll rate limiter is applied`,
 	)
 	TimerProcessorMaxPollInterval = NewGlobalDurationSetting(
 		"history.timerProcessorMaxPollInterval",
@@ -1979,7 +1981,8 @@ Higher values allow limited parallelism per workflow. Values <= 0 are capped to 
 	TransferProcessorMaxPollHostRPS = NewGlobalIntSetting(
 		"history.transferProcessorMaxPollHostRPS",
 		0,
-		`TransferProcessorMaxPollHostRPS is max poll rate per second for all transferQueueProcessor on a host`,
+		`TransferProcessorMaxPollHostRPS is max poll rate per second for all transferQueueProcessor on a host
+If value is less or equal to 0, it falls back to a HistoryPersistenceMaxQPS-derived host poll rate when HistoryPersistenceMaxQPS is positive; otherwise no host poll rate limiter is applied`,
 	)
 	TransferProcessorSchedulerWorkerCount = NewGlobalIntSetting(
 		"history.transferProcessorSchedulerWorkerCount",
@@ -2069,7 +2072,8 @@ filtering logic.
 	OutboundProcessorMaxPollHostRPS = NewGlobalIntSetting(
 		"history.outboundProcessorMaxPollHostRPS",
 		0,
-		`OutboundProcessorMaxPollHostRPS is max poll rate per second for all outboundQueueFactory on a host`,
+		`OutboundProcessorMaxPollHostRPS is max poll rate per second for all outboundQueueFactory on a host
+If value is less or equal to 0, it falls back to a HistoryPersistenceMaxQPS-derived host poll rate when HistoryPersistenceMaxQPS is positive; otherwise no host poll rate limiter is applied`,
 	)
 	OutboundProcessorMaxPollInterval = NewGlobalDurationSetting(
 		"history.outboundProcessorMaxPollInterval",
@@ -2153,7 +2157,8 @@ the outbound standby task failed to be processed due to missing events.`,
 	VisibilityProcessorMaxPollHostRPS = NewGlobalIntSetting(
 		"history.visibilityProcessorMaxPollHostRPS",
 		0,
-		`VisibilityProcessorMaxPollHostRPS is max poll rate per second for all visibilityQueueProcessor on a host`,
+		`VisibilityProcessorMaxPollHostRPS is max poll rate per second for all visibilityQueueProcessor on a host
+If value is less or equal to 0, it falls back to a HistoryPersistenceMaxQPS-derived host poll rate when HistoryPersistenceMaxQPS is positive; otherwise no host poll rate limiter is applied`,
 	)
 	VisibilityProcessorSchedulerWorkerCount = NewGlobalIntSetting(
 		"history.visibilityProcessorSchedulerWorkerCount",
@@ -2239,7 +2244,8 @@ visibility if they were removed from the mutable state`,
 	ArchivalProcessorMaxPollHostRPS = NewGlobalIntSetting(
 		"history.archivalProcessorMaxPollHostRPS",
 		0,
-		`ArchivalProcessorMaxPollHostRPS is max poll rate per second for all archivalQueueProcessor on a host`,
+		`ArchivalProcessorMaxPollHostRPS is max poll rate per second for all archivalQueueProcessor on a host
+If value is less or equal to 0, it falls back to a HistoryPersistenceMaxQPS-derived host poll rate when HistoryPersistenceMaxQPS is positive; otherwise no host poll rate limiter is applied`,
 	)
 	ArchivalProcessorSchedulerWorkerCount = NewGlobalIntSetting(
 		"history.archivalProcessorSchedulerWorkerCount",

--- a/service/history/archival_queue_factory.go
+++ b/service/history/archival_queue_factory.go
@@ -96,12 +96,10 @@ func newQueueFactoryBase(params ArchivalQueueFactoryParams) QueueFactoryBase {
 			params.NamespaceRegistry,
 			params.ClusterMetadata.GetCurrentClusterName(),
 		),
-		HostReaderRateLimiter: queues.NewReaderPriorityRateLimiter(
-			NewHostRateLimiterRateFn(
-				params.Config.ArchivalProcessorMaxPollHostRPS,
-				params.Config.PersistenceMaxQPS,
-				archivalQueuePersistenceMaxRPSRatio,
-			),
+		HostReaderRateLimiter: newHostReaderRateLimiter(
+			params.Config.ArchivalProcessorMaxPollHostRPS,
+			params.Config.PersistenceMaxQPS,
+			archivalQueuePersistenceMaxRPSRatio,
 			int64(params.Config.ArchivalQueueMaxReaderCount()),
 		),
 		Tracer: params.TracerProvider.Tracer(telemetry.ComponentQueueArchival),

--- a/service/history/outbound_queue_factory.go
+++ b/service/history/outbound_queue_factory.go
@@ -108,12 +108,10 @@ func NewOutboundQueueFactory(params outboundQueueFactoryParams) QueueFactory {
 	grouper := queues.GrouperStateMachineNamespaceIDAndDestination{}
 	f := &outboundQueueFactory{
 		outboundQueueFactoryParams: params,
-		hostReaderRateLimiter: queues.NewReaderPriorityRateLimiter(
-			NewHostRateLimiterRateFn(
-				params.Config.OutboundProcessorMaxPollHostRPS,
-				params.Config.PersistenceMaxQPS,
-				outboundQueuePersistenceMaxRPSRatio,
-			),
+		hostReaderRateLimiter: newHostReaderRateLimiter(
+			params.Config.OutboundProcessorMaxPollHostRPS,
+			params.Config.PersistenceMaxQPS,
+			outboundQueuePersistenceMaxRPSRatio,
 			int64(params.Config.OutboundQueueMaxReaderCount()),
 		),
 		hostScheduler: &queues.CommonSchedulerWrapper{

--- a/service/history/queue_factory_base.go
+++ b/service/history/queue_factory_base.go
@@ -2,6 +2,8 @@ package history
 
 import (
 	"context"
+	"sync"
+	"time"
 
 	"go.opentelemetry.io/otel/trace"
 	"go.temporal.io/server/chasm"
@@ -71,6 +73,15 @@ type (
 
 		Lifecycle fx.Lifecycle
 		Factories []QueueFactory `group:"queueFactory"`
+	}
+
+	optionalRequestRateLimiter struct {
+		rateFn quotas.RateFn
+
+		newDelegate func() quotas.RequestRateLimiter
+
+		mu       sync.Mutex
+		delegate quotas.RequestRateLimiter
 	}
 )
 
@@ -214,6 +225,68 @@ func (f *QueueFactoryBase) Stop() {
 	}
 }
 
+func newOptionalRequestRateLimiter(
+	rateFn quotas.RateFn,
+	newDelegate func() quotas.RequestRateLimiter,
+) quotas.RequestRateLimiter {
+	return &optionalRequestRateLimiter{
+		rateFn:      rateFn,
+		newDelegate: newDelegate,
+	}
+}
+
+func (r *optionalRequestRateLimiter) Allow(
+	now time.Time,
+	request quotas.Request,
+) bool {
+	if r.rateFn() <= 0 {
+		return true
+	}
+	return r.getDelegate().Allow(now, request)
+}
+
+func (r *optionalRequestRateLimiter) Reserve(
+	now time.Time,
+	request quotas.Request,
+) quotas.Reservation {
+	if r.rateFn() <= 0 {
+		return quotas.NoopReservation
+	}
+	return r.getDelegate().Reserve(now, request)
+}
+
+func (r *optionalRequestRateLimiter) Wait(
+	ctx context.Context,
+	request quotas.Request,
+) error {
+	if r.rateFn() <= 0 {
+		return nil
+	}
+	return r.getDelegate().Wait(ctx, request)
+}
+
+func (r *optionalRequestRateLimiter) getDelegate() quotas.RequestRateLimiter {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.delegate == nil {
+		r.delegate = r.newDelegate()
+	}
+	return r.delegate
+}
+
+func newHostReaderRateLimiter(
+	hostRPS dynamicconfig.IntPropertyFn,
+	persistenceMaxRPS dynamicconfig.IntPropertyFn,
+	persistenceMaxRPSRatio float64,
+	maxReaders int64,
+) quotas.RequestRateLimiter {
+	rateFn := NewHostRateLimiterRateFn(hostRPS, persistenceMaxRPS, persistenceMaxRPSRatio)
+	return newOptionalRequestRateLimiter(rateFn, func() quotas.RequestRateLimiter {
+		return queues.NewReaderPriorityRateLimiter(rateFn, maxReaders)
+	})
+}
+
 func NewHostRateLimiterRateFn(
 	hostRPS dynamicconfig.IntPropertyFn,
 	persistenceMaxRPS dynamicconfig.IntPropertyFn,
@@ -229,6 +302,7 @@ func NewHostRateLimiterRateFn(
 		// ensure queue loading won't consume all persistence tokens
 		// especially upon host restart when we need to perform a load
 		// for all shards
+		// A non-positive result means there is no host-level fallback cap.
 		return float64(persistenceMaxRPS()) * persistenceMaxRPSRatio
 	}
 }

--- a/service/history/queue_factory_base_test.go
+++ b/service/history/queue_factory_base_test.go
@@ -1,13 +1,17 @@
 package history
 
 import (
+	"context"
+	"strconv"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/client"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -18,6 +22,7 @@ import (
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/persistence/visibility/manager"
+	"go.temporal.io/server/common/quotas"
 	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/telemetry"
@@ -160,4 +165,112 @@ type unusedDependencies struct {
 	chasm.Engine
 	ChasmRegistry *chasm.Registry
 	worker_versioning.VersionMembershipCache
+}
+
+func TestNewHostRateLimiterRateFn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		hostRPS        int
+		persistenceRPS int
+		ratio          float64
+		expected       float64
+	}{
+		{
+			name:           "explicit host cap wins",
+			hostRPS:        50,
+			persistenceRPS: 9000,
+			ratio:          0.3,
+			expected:       50,
+		},
+		{
+			name:           "falls back to persistence-derived rate",
+			hostRPS:        0,
+			persistenceRPS: 9000,
+			ratio:          0.3,
+			expected:       2700,
+		},
+		{
+			name:           "non positive persistence leaves no fallback cap",
+			hostRPS:        0,
+			persistenceRPS: 0,
+			ratio:          0.3,
+			expected:       0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			hostRPS := tc.hostRPS
+			persistenceRPS := tc.persistenceRPS
+			rateFn := NewHostRateLimiterRateFn(
+				func() int { return hostRPS },
+				func() int { return persistenceRPS },
+				tc.ratio,
+			)
+
+			require.InDelta(t, tc.expected, rateFn(), 0.001)
+		})
+	}
+}
+
+func TestNewHostReaderRateLimiter_NoopsWhenNoHostFallbackCapExists(t *testing.T) {
+	t.Parallel()
+
+	limiter := newHostReaderRateLimiter(
+		func() int { return 0 },
+		func() int { return 0 },
+		0.3,
+		1,
+	)
+
+	request := quotas.NewRequest(
+		"",
+		1,
+		strconv.FormatInt(common.DefaultQueueReaderID, 10),
+		"",
+		0,
+		"",
+	)
+
+	require.True(t, limiter.Allow(time.Now(), request))
+	require.Equal(t, quotas.NoopReservation, limiter.Reserve(time.Now(), request))
+	require.NoError(t, limiter.Wait(context.Background(), request))
+}
+
+func TestNewHostReaderRateLimiter_TracksRuntimeTransitions(t *testing.T) {
+	t.Parallel()
+
+	persistenceRPS := 0
+	limiter := newHostReaderRateLimiter(
+		func() int { return 0 },
+		func() int { return persistenceRPS },
+		0.3,
+		1,
+	)
+
+	request := quotas.NewRequest(
+		"",
+		1,
+		strconv.FormatInt(common.DefaultQueueReaderID, 10),
+		"",
+		0,
+		"",
+	)
+
+	require.Equal(t, quotas.NoopReservation, limiter.Reserve(time.Now(), request))
+	require.NoError(t, limiter.Wait(context.Background(), request))
+
+	persistenceRPS = 10
+	reservation := limiter.Reserve(time.Now(), request)
+	require.NotEqual(t, quotas.NoopReservation, reservation)
+	require.True(t, reservation.OK())
+	require.NoError(t, limiter.Wait(context.Background(), request))
+
+	persistenceRPS = 0
+	require.Equal(t, quotas.NoopReservation, limiter.Reserve(time.Now(), request))
+	require.NoError(t, limiter.Wait(context.Background(), request))
 }

--- a/service/history/queues/reader.go
+++ b/service/history/queues/reader.go
@@ -430,7 +430,12 @@ func (r *ReaderImpl) loadAndSubmitTasks() {
 		}
 
 		// this should never happen
-		r.logger.Error("Queue reader rate limiter burst size is smaller than required token count")
+		r.logger.Error(
+			"Queue reader rate limiter burst size is smaller than required token count",
+			tag.Error(err),
+			tag.NewInt("rate_limiter_request_token", r.rateLimiterRequest.Token),
+			tag.Value(r.rateLimiterRequest),
+		)
 	}
 
 	r.Lock()

--- a/service/history/timer_queue_factory.go
+++ b/service/history/timer_queue_factory.go
@@ -65,12 +65,10 @@ func NewTimerQueueFactory(
 				params.NamespaceRegistry,
 				params.ClusterMetadata.GetCurrentClusterName(),
 			),
-			HostReaderRateLimiter: queues.NewReaderPriorityRateLimiter(
-				NewHostRateLimiterRateFn(
-					params.Config.TimerProcessorMaxPollHostRPS,
-					params.Config.PersistenceMaxQPS,
-					timerQueuePersistenceMaxRPSRatio,
-				),
+			HostReaderRateLimiter: newHostReaderRateLimiter(
+				params.Config.TimerProcessorMaxPollHostRPS,
+				params.Config.PersistenceMaxQPS,
+				timerQueuePersistenceMaxRPSRatio,
 				int64(params.Config.TimerQueueMaxReaderCount()),
 			),
 			Tracer: params.TracerProvider.Tracer(telemetry.ComponentQueueTimer),

--- a/service/history/transfer_queue_factory.go
+++ b/service/history/transfer_queue_factory.go
@@ -70,12 +70,10 @@ func NewTransferQueueFactory(
 				params.NamespaceRegistry,
 				params.ClusterMetadata.GetCurrentClusterName(),
 			),
-			HostReaderRateLimiter: queues.NewReaderPriorityRateLimiter(
-				NewHostRateLimiterRateFn(
-					params.Config.TransferProcessorMaxPollHostRPS,
-					params.Config.PersistenceMaxQPS,
-					transferQueuePersistenceMaxRPSRatio,
-				),
+			HostReaderRateLimiter: newHostReaderRateLimiter(
+				params.Config.TransferProcessorMaxPollHostRPS,
+				params.Config.PersistenceMaxQPS,
+				transferQueuePersistenceMaxRPSRatio,
 				int64(params.Config.TransferQueueMaxReaderCount()),
 			),
 			Tracer: params.TracerProvider.Tracer(telemetry.ComponentQueueTransfer),

--- a/service/history/visibility_queue_factory.go
+++ b/service/history/visibility_queue_factory.go
@@ -61,12 +61,10 @@ func NewVisibilityQueueFactory(
 				params.NamespaceRegistry,
 				params.ClusterMetadata.GetCurrentClusterName(),
 			),
-			HostReaderRateLimiter: queues.NewReaderPriorityRateLimiter(
-				NewHostRateLimiterRateFn(
-					params.Config.VisibilityProcessorMaxPollHostRPS,
-					params.Config.PersistenceMaxQPS,
-					visibilityQueuePersistenceMaxRPSRatio,
-				),
+			HostReaderRateLimiter: newHostReaderRateLimiter(
+				params.Config.VisibilityProcessorMaxPollHostRPS,
+				params.Config.PersistenceMaxQPS,
+				visibilityQueuePersistenceMaxRPSRatio,
 				int64(params.Config.VisibilityQueueMaxReaderCount()),
 			),
 			Tracer: params.TracerProvider.Tracer(telemetry.ComponentQueueVisibility),


### PR DESCRIPTION
## What changed?
This change updates history queue host reader limiting so that non-positive `history.persistenceMaxQPS` no longer produces an effective zero-rate host poll limiter.

If a queue-specific host poll cap is positive, that explicit value is used. Otherwise, the host reader limiter falls back to a `HistoryPersistenceMaxQPS`-derived rate only when `HistoryPersistenceMaxQPS` is positive. When both are non-positive, no host-level reader limiter is applied.

This also adds targeted tests for rate selection and runtime `0 -> positive -> 0` transitions, and enriches the queue reader error log with the limiter request details.

## Why?
`common/persistence/client/fx.go` already treats `PersistenceMaxQPS <= 0` as disabling persistence host rate limiting.

Before this change, the history queue host poll path could still build a zero-rate limiter when `history.persistenceMaxQPS=0`, which could drive the reader into the error path instead of behaving like an effectively unlimited/no-op host limiter.

This keeps the history queue host reader behavior aligned with existing persistence limiter semantics, while still leaving shard-level queue poll limiting intact.

Related to #9599

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

- Ran `go test -tags test_dep ./service/history/...`
- Ran `go test -tags test_dep ./common/persistence/client -count=1`
- Ran `go build ./service/history/... ./common/persistence/client ./common/dynamicconfig`
- Ran `go vet -tags test_dep ./service/history/... ./common/persistence/client ./common/dynamicconfig/...`
- Ran full lint with `make lint-code GOLANGCI_LINT_FIX=false`
- Built the server locally with `make temporal-server`
- Started `./temporal-server --config-file /tmp/temporal-9599-development-sqlite.yaml --allow-no-auth start` against a temporary SQLite config wired to a temporary dynamic config file with `history.persistenceMaxQPS=0` and all relevant history queue host poll caps set to `0`
- Verified listeners came up on `127.0.0.1:7233`, `:7234`, `:7235`, and `:7239`
- Verified startup logs reflected `history.persistenceMaxQPS=0` and did not emit `Queue reader rate limiter burst size is smaller than required token count`

## Potential risks
- Low risk behavior change in history queue polling when operators relied on the previous implicit zero-rate behavior from non-positive `history.persistenceMaxQPS`
- Dynamic-config transitions between disabled and enabled host limiting continue to rely on runtime rate function evaluation, so the main regression surface is host-level throttling expectations rather than correctness of task execution