### PR TITLE
Nexus Operations handler side metrics

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -734,7 +734,7 @@ var (
 		WithDescription("The number of Nexus requests for which pre-processing failed."),
 	)
 	NexusRequestErrors = NewCounterDef(
-		"nexus_request_error",
+		"nexus_request_errors",
 		WithDescription("The number of Nexus requests that resulted in errors."),
 	)
 	NexusLatency = NewTimerDef(

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -21,8 +21,6 @@ const (
 	nexusEndpointTagName           = "nexus_endpoint"
 	nexusServiceTagName            = "nexus_service"
 	nexusOperationTagName          = "nexus_operation"
-	nexusCallerTagName             = "nexus_caller"
-	nexusCallerTypeTagName         = "nexus_caller_type"
 	outcomeTagName                 = "outcome"
 	versionedTagName               = "versioned"
 	resourceExhaustedTag           = "resource_exhausted_cause"

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -736,7 +736,7 @@ var (
 		WithDescription("The number of Nexus requests for which pre-processing failed."),
 	)
 	NexusRequestErrors = NewCounterDef(
-		"nexus_request_error_count",
+		"nexus_request_error",
 		WithDescription("The number of Nexus requests that resulted in errors."),
 	)
 	NexusLatency = NewTimerDef(

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -21,6 +21,8 @@ const (
 	nexusEndpointTagName           = "nexus_endpoint"
 	nexusServiceTagName            = "nexus_service"
 	nexusOperationTagName          = "nexus_operation"
+	nexusCallerTagName             = "nexus_caller"
+	nexusCallerTypeTagName         = "nexus_caller_type"
 	outcomeTagName                 = "outcome"
 	versionedTagName               = "versioned"
 	resourceExhaustedTag           = "resource_exhausted_cause"
@@ -732,6 +734,10 @@ var (
 	NexusRequestPreProcessErrors = NewCounterDef(
 		"nexus_request_preprocess_errors",
 		WithDescription("The number of Nexus requests for which pre-processing failed."),
+	)
+	NexusRequestErrors = NewCounterDef(
+		"nexus_request_error_count",
+		WithDescription("The number of Nexus requests that resulted in errors."),
 	)
 	NexusLatency = NewTimerDef(
 		"nexus_latency",

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -395,20 +395,6 @@ func NexusOperationTag(value string) Tag {
 	return Tag{Key: nexusOperationTagName, Value: value}
 }
 
-func NexusCallerTag(value string) Tag {
-	if len(value) == 0 {
-		value = unknownValue
-	}
-	return Tag{Key: nexusCallerTagName, Value: value}
-}
-
-func NexusCallerTypeTag(value string) Tag {
-	if len(value) == 0 {
-		value = unknownValue
-	}
-	return Tag{Key: nexusCallerTypeTagName, Value: value}
-}
-
 // HttpStatusTag returns a new httpStatusTag.
 func HttpStatusTag(value int) Tag {
 	return Tag{Key: httpStatusTagName, Value: strconv.Itoa(value)}

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -395,6 +395,20 @@ func NexusOperationTag(value string) Tag {
 	return Tag{Key: nexusOperationTagName, Value: value}
 }
 
+func NexusCallerTag(value string) Tag {
+	if len(value) == 0 {
+		value = unknownValue
+	}
+	return Tag{Key: nexusCallerTagName, Value: value}
+}
+
+func NexusCallerTypeTag(value string) Tag {
+	if len(value) == 0 {
+		value = unknownValue
+	}
+	return Tag{Key: nexusCallerTypeTagName, Value: value}
+}
+
 // HttpStatusTag returns a new httpStatusTag.
 func HttpStatusTag(value int) Tag {
 	return Tag{Key: httpStatusTagName, Value: strconv.Itoa(value)}

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -302,12 +302,6 @@ func (c *operationContext) enrichNexusOperationMetrics(ctx context.Context, serv
 		tags = append(tags, metrics.StringTag(mapping.TargetTag, requestHeader.Get(mapping.SourceHeader)))
 	}
 
-	// Add caller tags from the context.
-	callerInfo := headers.GetCallerInfo(ctx)
-	tags = append(tags, metrics.NexusCallerTag(callerInfo.CallerName))
-	// Namespace is the only valid caller_type. To be updated when there are more kinds
-	tags = append(tags, metrics.NexusCallerTypeTag("namespace"))
-
 	if len(tags) > 0 {
 		c.metricsHandler = c.metricsHandler.WithTags(tags...)
 	}

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -285,7 +285,7 @@ func (c *operationContext) shouldForwardRequest(ctx context.Context, header nexu
 }
 
 // enrichNexusOperationMetrics enhances metrics with additional Nexus operation context based on configuration.
-func (c *operationContext) enrichNexusOperationMetrics(ctx context.Context, service, operation string, requestHeader nexus.Header) {
+func (c *operationContext) enrichNexusOperationMetrics(service, operation string, requestHeader nexus.Header) {
 	conf := c.metricTagConfig()
 
 	var tags []metrics.Tag
@@ -395,7 +395,7 @@ func (h *nexusHandler) StartOperation(
 		return nil, err
 	}
 	ctx = oc.augmentContext(ctx, options.Header)
-	oc.enrichNexusOperationMetrics(ctx, service, operation, options.Header)
+	oc.enrichNexusOperationMetrics(service, operation, options.Header)
 	defer oc.capturePanicAndRecordMetrics(&ctx, &retErr)
 
 	var links []*nexuspb.Link
@@ -633,7 +633,7 @@ func (h *nexusHandler) CancelOperation(ctx context.Context, service, operation, 
 		return err
 	}
 	ctx = oc.augmentContext(ctx, options.Header)
-	oc.enrichNexusOperationMetrics(ctx, service, operation, options.Header)
+	oc.enrichNexusOperationMetrics(service, operation, options.Header)
 	defer oc.capturePanicAndRecordMetrics(&ctx, &retErr)
 
 	request := oc.matchingRequest(&nexuspb.Request{

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -106,6 +106,9 @@ func (c *operationContext) capturePanicAndRecordMetrics(ctxPtr *context.Context,
 	// Record Nexus-specific metrics
 	metrics.NexusRequests.With(c.metricsHandler).Record(1)
 	metrics.NexusLatency.With(c.metricsHandler).Record(time.Since(c.requestStartTime))
+	if *errPtr != nil {
+		metrics.NexusRequestErrors.With(c.metricsHandler).Record(1)
+	}
 
 	// Record general telemetry metrics
 	metrics.ServiceRequests.With(c.metricsHandlerForInterceptors).Record(1)
@@ -282,7 +285,7 @@ func (c *operationContext) shouldForwardRequest(ctx context.Context, header nexu
 }
 
 // enrichNexusOperationMetrics enhances metrics with additional Nexus operation context based on configuration.
-func (c *operationContext) enrichNexusOperationMetrics(service, operation string, requestHeader nexus.Header) {
+func (c *operationContext) enrichNexusOperationMetrics(ctx context.Context, service, operation string, requestHeader nexus.Header) {
 	conf := c.metricTagConfig()
 
 	var tags []metrics.Tag
@@ -298,6 +301,12 @@ func (c *operationContext) enrichNexusOperationMetrics(service, operation string
 	for _, mapping := range conf.HeaderTagMappings {
 		tags = append(tags, metrics.StringTag(mapping.TargetTag, requestHeader.Get(mapping.SourceHeader)))
 	}
+
+	// Add caller tags from the context.
+	callerInfo := headers.GetCallerInfo(ctx)
+	tags = append(tags, metrics.NexusCallerTag(callerInfo.CallerName))
+	// Namespace is the only valid caller_type. To be updated when there are more kinds
+	tags = append(tags, metrics.NexusCallerTypeTag("namespace"))
 
 	if len(tags) > 0 {
 		c.metricsHandler = c.metricsHandler.WithTags(tags...)
@@ -392,7 +401,7 @@ func (h *nexusHandler) StartOperation(
 		return nil, err
 	}
 	ctx = oc.augmentContext(ctx, options.Header)
-	oc.enrichNexusOperationMetrics(service, operation, options.Header)
+	oc.enrichNexusOperationMetrics(ctx, service, operation, options.Header)
 	defer oc.capturePanicAndRecordMetrics(&ctx, &retErr)
 
 	var links []*nexuspb.Link
@@ -630,7 +639,7 @@ func (h *nexusHandler) CancelOperation(ctx context.Context, service, operation, 
 		return err
 	}
 	ctx = oc.augmentContext(ctx, options.Header)
-	oc.enrichNexusOperationMetrics(service, operation, options.Header)
+	oc.enrichNexusOperationMetrics(ctx, service, operation, options.Header)
 	defer oc.capturePanicAndRecordMetrics(&ctx, &retErr)
 
 	request := oc.matchingRequest(&nexuspb.Request{

--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -326,7 +326,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes(useTemporalFailures
 		s.Contains(latency[0].Tags, "nexus_endpoint")
 
 		// Verify error counter is emitted for error outcomes and absent for success.
-		errorRequests := capture.Metric("nexus_request_error")
+		errorRequests := capture.Metric("nexus_request_errors")
 		if tc.outcome == "sync_success" || tc.outcome == "async_success" {
 			s.Empty(errorRequests)
 		} else {
@@ -594,7 +594,7 @@ func (s *NexusApiTestSuite) TestNexusCancelOperation_Outcomes(useTemporalFailure
 		s.Contains(latency[0].Tags, "nexus_endpoint")
 
 		// Verify error counter is emitted for error outcomes and absent for success.
-		errorRequests := capture.Metric("nexus_request_error")
+		errorRequests := capture.Metric("nexus_request_errors")
 		if tc.outcome == "success" {
 			s.Empty(errorRequests)
 		} else {

--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -316,11 +316,9 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes(useTemporalFailures
 		requests := capture.Metric("nexus_requests")
 		s.Len(requests, 1)
 		s.Subset(requests[0].Tags, map[string]string{
-			"namespace":         env.Namespace().String(),
-			"method":            "StartNexusOperation",
-			"outcome":           tc.outcome,
-			"nexus_caller":      env.Namespace().String(),
-			"nexus_caller_type": "namespace",
+			"namespace": env.Namespace().String(),
+			"method":    "StartNexusOperation",
+			"outcome":   tc.outcome,
 		})
 		s.Contains(requests[0].Tags, "nexus_endpoint")
 		s.Equal(int64(1), requests[0].Value)
@@ -329,16 +327,14 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes(useTemporalFailures
 		latency := capture.Metric("nexus_latency")
 		s.Len(latency, 1)
 		s.Subset(latency[0].Tags, map[string]string{
-			"namespace":         env.Namespace().String(),
-			"method":            "StartNexusOperation",
-			"outcome":           tc.outcome,
-			"nexus_caller":      env.Namespace().String(),
-			"nexus_caller_type": "namespace",
+			"namespace": env.Namespace().String(),
+			"method":    "StartNexusOperation",
+			"outcome":   tc.outcome,
 		})
 		s.Contains(latency[0].Tags, "nexus_endpoint")
 
 		// Verify error counter is emitted for error outcomes and absent for success.
-		errorRequests := capture.Metric("nexus_request_error_count")
+		errorRequests := capture.Metric("nexus_request_error")
 		if tc.outcome == "sync_success" || tc.outcome == "async_success" {
 			s.Empty(errorRequests)
 		} else {
@@ -596,11 +592,9 @@ func (s *NexusApiTestSuite) TestNexusCancelOperation_Outcomes(useTemporalFailure
 		requests := capture.Metric("nexus_requests")
 		s.Len(requests, 1)
 		s.Subset(requests[0].Tags, map[string]string{
-			"namespace":         env.Namespace().String(),
-			"method":            "CancelNexusOperation",
-			"outcome":           tc.outcome,
-			"nexus_caller":      env.Namespace().String(),
-			"nexus_caller_type": "namespace",
+			"namespace": env.Namespace().String(),
+			"method":    "CancelNexusOperation",
+			"outcome":   tc.outcome,
 		})
 		s.Contains(requests[0].Tags, "nexus_endpoint")
 		s.Equal(int64(1), requests[0].Value)
@@ -609,16 +603,14 @@ func (s *NexusApiTestSuite) TestNexusCancelOperation_Outcomes(useTemporalFailure
 		latency := capture.Metric("nexus_latency")
 		s.Len(latency, 1)
 		s.Subset(latency[0].Tags, map[string]string{
-			"namespace":         env.Namespace().String(),
-			"method":            "CancelNexusOperation",
-			"outcome":           tc.outcome,
-			"nexus_caller":      env.Namespace().String(),
-			"nexus_caller_type": "namespace",
+			"namespace": env.Namespace().String(),
+			"method":    "CancelNexusOperation",
+			"outcome":   tc.outcome,
 		})
 		s.Contains(latency[0].Tags, "nexus_endpoint")
 
 		// Verify error counter is emitted for error outcomes and absent for success.
-		errorRequests := capture.Metric("nexus_request_error_count")
+		errorRequests := capture.Metric("nexus_request_error")
 		if tc.outcome == "success" {
 			s.Empty(errorRequests)
 		} else {

--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -315,15 +315,41 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes(useTemporalFailures
 
 		requests := capture.Metric("nexus_requests")
 		s.Len(requests, 1)
-		s.Subset(requests[0].Tags, map[string]string{"namespace": env.Namespace().String(), "method": "StartNexusOperation", "outcome": tc.outcome})
+		s.Subset(requests[0].Tags, map[string]string{
+			"namespace":         env.Namespace().String(),
+			"method":            "StartNexusOperation",
+			"outcome":           tc.outcome,
+			"nexus_caller":      env.Namespace().String(),
+			"nexus_caller_type": "namespace",
+		})
 		s.Contains(requests[0].Tags, "nexus_endpoint")
 		s.Equal(int64(1), requests[0].Value)
 		s.Equal(metrics.MetricUnit(""), requests[0].Unit)
 
 		latency := capture.Metric("nexus_latency")
 		s.Len(latency, 1)
-		s.Subset(latency[0].Tags, map[string]string{"namespace": env.Namespace().String(), "method": "StartNexusOperation", "outcome": tc.outcome})
+		s.Subset(latency[0].Tags, map[string]string{
+			"namespace":         env.Namespace().String(),
+			"method":            "StartNexusOperation",
+			"outcome":           tc.outcome,
+			"nexus_caller":      env.Namespace().String(),
+			"nexus_caller_type": "namespace",
+		})
 		s.Contains(latency[0].Tags, "nexus_endpoint")
+
+		// Verify error counter is emitted for error outcomes and absent for success.
+		errorRequests := capture.Metric("nexus_request_error_count")
+		if tc.outcome == "sync_success" || tc.outcome == "async_success" {
+			s.Empty(errorRequests)
+		} else {
+			s.Len(errorRequests, 1)
+			s.Subset(errorRequests[0].Tags, map[string]string{
+				"namespace": env.Namespace().String(),
+				"method":    "StartNexusOperation",
+				"outcome":   tc.outcome,
+			})
+			s.Equal(int64(1), errorRequests[0].Value)
+		}
 
 		// Ensure that StartOperation request is tracked as part of normal service telemetry metrics
 		s.Condition(func() bool {
@@ -569,15 +595,41 @@ func (s *NexusApiTestSuite) TestNexusCancelOperation_Outcomes(useTemporalFailure
 
 		requests := capture.Metric("nexus_requests")
 		s.Len(requests, 1)
-		s.Subset(requests[0].Tags, map[string]string{"namespace": env.Namespace().String(), "method": "CancelNexusOperation", "outcome": tc.outcome})
+		s.Subset(requests[0].Tags, map[string]string{
+			"namespace":         env.Namespace().String(),
+			"method":            "CancelNexusOperation",
+			"outcome":           tc.outcome,
+			"nexus_caller":      env.Namespace().String(),
+			"nexus_caller_type": "namespace",
+		})
 		s.Contains(requests[0].Tags, "nexus_endpoint")
 		s.Equal(int64(1), requests[0].Value)
 		s.Equal(metrics.MetricUnit(""), requests[0].Unit)
 
 		latency := capture.Metric("nexus_latency")
 		s.Len(latency, 1)
-		s.Subset(latency[0].Tags, map[string]string{"namespace": env.Namespace().String(), "method": "CancelNexusOperation", "outcome": tc.outcome})
+		s.Subset(latency[0].Tags, map[string]string{
+			"namespace":         env.Namespace().String(),
+			"method":            "CancelNexusOperation",
+			"outcome":           tc.outcome,
+			"nexus_caller":      env.Namespace().String(),
+			"nexus_caller_type": "namespace",
+		})
 		s.Contains(latency[0].Tags, "nexus_endpoint")
+
+		// Verify error counter is emitted for error outcomes and absent for success.
+		errorRequests := capture.Metric("nexus_request_error_count")
+		if tc.outcome == "success" {
+			s.Empty(errorRequests)
+		} else {
+			s.Len(errorRequests, 1)
+			s.Subset(errorRequests[0].Tags, map[string]string{
+				"namespace": env.Namespace().String(),
+				"method":    "CancelNexusOperation",
+				"outcome":   tc.outcome,
+			})
+			s.Equal(int64(1), errorRequests[0].Value)
+		}
 
 		// Ensure that CancelOperation request is tracked as part of normal service telemetry metrics
 		s.Condition(func() bool {

--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -315,22 +315,14 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes(useTemporalFailures
 
 		requests := capture.Metric("nexus_requests")
 		s.Len(requests, 1)
-		s.Subset(requests[0].Tags, map[string]string{
-			"namespace": env.Namespace().String(),
-			"method":    "StartNexusOperation",
-			"outcome":   tc.outcome,
-		})
+		s.Subset(requests[0].Tags, map[string]string{"namespace": env.Namespace().String(), "method": "StartNexusOperation", "outcome": tc.outcome})
 		s.Contains(requests[0].Tags, "nexus_endpoint")
 		s.Equal(int64(1), requests[0].Value)
 		s.Equal(metrics.MetricUnit(""), requests[0].Unit)
 
 		latency := capture.Metric("nexus_latency")
 		s.Len(latency, 1)
-		s.Subset(latency[0].Tags, map[string]string{
-			"namespace": env.Namespace().String(),
-			"method":    "StartNexusOperation",
-			"outcome":   tc.outcome,
-		})
+		s.Subset(latency[0].Tags, map[string]string{"namespace": env.Namespace().String(), "method": "StartNexusOperation", "outcome": tc.outcome})
 		s.Contains(latency[0].Tags, "nexus_endpoint")
 
 		// Verify error counter is emitted for error outcomes and absent for success.
@@ -591,22 +583,14 @@ func (s *NexusApiTestSuite) TestNexusCancelOperation_Outcomes(useTemporalFailure
 
 		requests := capture.Metric("nexus_requests")
 		s.Len(requests, 1)
-		s.Subset(requests[0].Tags, map[string]string{
-			"namespace": env.Namespace().String(),
-			"method":    "CancelNexusOperation",
-			"outcome":   tc.outcome,
-		})
+		s.Subset(requests[0].Tags, map[string]string{"namespace": env.Namespace().String(), "method": "CancelNexusOperation", "outcome": tc.outcome})
 		s.Contains(requests[0].Tags, "nexus_endpoint")
 		s.Equal(int64(1), requests[0].Value)
 		s.Equal(metrics.MetricUnit(""), requests[0].Unit)
 
 		latency := capture.Metric("nexus_latency")
 		s.Len(latency, 1)
-		s.Subset(latency[0].Tags, map[string]string{
-			"namespace": env.Namespace().String(),
-			"method":    "CancelNexusOperation",
-			"outcome":   tc.outcome,
-		})
+		s.Subset(latency[0].Tags, map[string]string{"namespace": env.Namespace().String(), "method": "CancelNexusOperation", "outcome": tc.outcome})
 		s.Contains(latency[0].Tags, "nexus_endpoint")
 
 		// Verify error counter is emitted for error outcomes and absent for success.


### PR DESCRIPTION
## What changed?
New Metrics:
### Counters

| Metric | Description |
|--------|-------------|
| `nexus_request_error` | Nexus requests that result in an error |

New Labels:

All of these labels already exist:

| Label | Notes |
|-------|-------|
| `namespace` | |
| `nexus_endpoint` | |
| `nexus_service` | Controlled by Dynamic config |
| `nexus_operation` | Controlled by Dynamic config |
| `nexus_caller` | Controlled by Dynamic Config |
| `nexus_caller_type` | Controlled by DynamicConfig |

An earlier version of this PR included adding `nexus_caller` and `nexus_caller_type`, but they are already available by dynamic config.


## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
