### PR TITLE
Standalone Nexus: completion ignores version transition

### DIFF
--- a/chasm/lib/nexusoperation/task_handler_helpers.go
+++ b/chasm/lib/nexusoperation/task_handler_helpers.go
@@ -391,21 +391,13 @@ func lookupEndpoint(ctx context.Context, registry commonnexus.EndpointRegistry, 
 	return entry, nil
 }
 
-func (h *operationInvocationTaskHandler) generateCallbackToken(serializedRef []byte, requestID string) (string, error) {
-	ref := &persistencespb.ChasmComponentRef{}
-	if err := ref.Unmarshal(serializedRef); err != nil {
-		return "", fmt.Errorf("%w: %w", queueserrors.NewUnprocessableTaskError("failed to decode component ref for callback token"), err)
-	}
-	// Both VTs become stale after workflow mutations between token minting and completion arrival.
-	ref.ExecutionVersionedTransition = nil
-	ref.ComponentInitialVersionedTransition = nil
-	stableRef, err := ref.Marshal()
-	if err != nil {
-		return "", fmt.Errorf("%w: %w", queueserrors.NewUnprocessableTaskError("failed to encode component ref for callback token"), err)
-	}
-
+// generateCallbackToken creates a callback token for the given operation reference.
+func (h *operationInvocationTaskHandler) generateCallbackToken(
+	serializedRef []byte,
+	requestID string,
+) (string, error) {
 	token, err := h.callbackTokenGenerator.Tokenize(&tokenspb.NexusOperationCompletion{
-		ComponentRef: stableRef,
+		ComponentRef: serializedRef,
 		RequestId:    requestID,
 	})
 	if err != nil {

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -2249,22 +2249,24 @@ func (h *Handler) CompleteNexusOperationChasm(
 	ctx context.Context,
 	request *historyservice.CompleteNexusOperationChasmRequest,
 ) (*historyservice.CompleteNexusOperationChasmResponse, error) {
-	// TODO(stephan): This should be a CHASM transition option.
 	componentRef := request.GetCompletion().GetComponentRef()
-	if len(componentRef) > 0 {
-		// Ignore transition-history fields when applying completion,
-		// use Request ID to accept or reject the completion instead.
-		ref := &persistencespb.ChasmComponentRef{}
-		if err := ref.Unmarshal(componentRef); err != nil {
-			return nil, serviceerror.NewInvalidArgument("invalid component ref")
-		}
-		ref.ExecutionVersionedTransition = nil
-		ref.ComponentInitialVersionedTransition = nil
-		var err error
-		componentRef, err = ref.Marshal()
-		if err != nil {
-			return nil, serviceerror.NewInvalidArgument("invalid component ref")
-		}
+	if len(componentRef) == 0 {
+		return nil, serviceerror.NewInvalidArgument("invalid component ref")
+	}
+
+	// Ignore transition-history fields when applying completion,
+	// use Request ID to accept or reject the completion instead.
+	// TODO(stephan): This should be a CHASM transition option.
+	ref := &persistencespb.ChasmComponentRef{}
+	if err := ref.Unmarshal(componentRef); err != nil {
+		return nil, serviceerror.NewInvalidArgument("invalid component ref")
+	}
+	ref.ExecutionVersionedTransition = nil
+	ref.ComponentInitialVersionedTransition = nil
+	var err error
+	componentRef, err = ref.Marshal()
+	if err != nil {
+		return nil, serviceerror.NewInvalidArgument("invalid component ref")
 	}
 
 	completion := &persistencespb.ChasmNexusCompletion{
@@ -2289,7 +2291,7 @@ func (h *Handler) CompleteNexusOperationChasm(
 	// this similarly as we would a pure task (holding an exclusive lock), as the
 	// assumption is that the accessed component will be recording (or generating a
 	// task) based on this result.
-	_, _, err := chasm.UpdateComponent(
+	_, _, err = chasm.UpdateComponent(
 		ctx,
 		componentRef,
 		func(c chasm.NexusCompletionHandler, ctx chasm.MutableContext, completion *persistencespb.ChasmNexusCompletion) (chasm.NoValue, error) {

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -2249,6 +2249,7 @@ func (h *Handler) CompleteNexusOperationChasm(
 	ctx context.Context,
 	request *historyservice.CompleteNexusOperationChasmRequest,
 ) (*historyservice.CompleteNexusOperationChasmResponse, error) {
+	// TODO(stephan): This should be a CHASM transition option.
 	componentRef := request.GetCompletion().GetComponentRef()
 	if len(componentRef) > 0 {
 		// Ignore transition-history fields when applying completion,

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -2249,6 +2249,23 @@ func (h *Handler) CompleteNexusOperationChasm(
 	ctx context.Context,
 	request *historyservice.CompleteNexusOperationChasmRequest,
 ) (*historyservice.CompleteNexusOperationChasmResponse, error) {
+	componentRef := request.GetCompletion().GetComponentRef()
+	if len(componentRef) > 0 {
+		// Ignore transition-history fields when applying completion,
+		// use Request ID to accept or reject the completion instead.
+		ref := &persistencespb.ChasmComponentRef{}
+		if err := ref.Unmarshal(componentRef); err != nil {
+			return nil, serviceerror.NewInvalidArgument("invalid component ref")
+		}
+		ref.ExecutionVersionedTransition = nil
+		ref.ComponentInitialVersionedTransition = nil
+		var err error
+		componentRef, err = ref.Marshal()
+		if err != nil {
+			return nil, serviceerror.NewInvalidArgument("invalid component ref")
+		}
+	}
+
 	completion := &persistencespb.ChasmNexusCompletion{
 		CloseTime: request.CloseTime,
 		RequestId: request.Completion.RequestId,
@@ -2273,7 +2290,7 @@ func (h *Handler) CompleteNexusOperationChasm(
 	// task) based on this result.
 	_, _, err := chasm.UpdateComponent(
 		ctx,
-		request.GetCompletion().GetComponentRef(),
+		componentRef,
 		func(c chasm.NexusCompletionHandler, ctx chasm.MutableContext, completion *persistencespb.ChasmNexusCompletion) (chasm.NoValue, error) {
 			return nil, c.HandleNexusCompletion(ctx, completion)
 		},

--- a/tests/nexus_standalone_test.go
+++ b/tests/nexus_standalone_test.go
@@ -20,9 +20,12 @@ import (
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm/lib/nexusoperation"
 	"go.temporal.io/server/common/dynamicconfig"
 	commonnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/nexus/nexusrpc"
+	"go.temporal.io/server/common/nexus/nexustest"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/tests/testcore"
@@ -1767,6 +1770,103 @@ func TestStandaloneNexusOperationPoll(t *testing.T) {
 		s.Error(err)
 		s.Contains(err.Error(), "operation_id is required")
 	})
+}
+
+func TestAsyncCompletionIgnoresTransitionFieldsInCallbackToken(t *testing.T) {
+	t.Parallel()
+
+	s := testcore.NewEnv(t, nexusStandaloneOpts...)
+	endpointName := testcore.RandomizedNexusEndpoint(t.Name())
+
+	var callbackToken string
+	var callbackURL string
+	listenAddr := nexustest.AllocListenAddress()
+	nexustest.NewNexusServer(t, listenAddr, nexustest.Handler{
+		OnStartOperation: func(
+			ctx context.Context,
+			service string,
+			operation string,
+			input *nexus.LazyValue,
+			options nexus.StartOperationOptions,
+		) (nexus.HandlerStartOperationResult[any], error) {
+			callbackToken = options.CallbackHeader.Get(commonnexus.CallbackTokenHeader)
+			callbackURL = options.CallbackURL
+			return &nexus.HandlerStartOperationResultAsync{OperationToken: "test-operation-token"}, nil
+		},
+	})
+
+	_, err := s.OperatorClient().CreateNexusEndpoint(s.Context(), &operatorservice.CreateNexusEndpointRequest{
+		Spec: &nexuspb.EndpointSpec{
+			Name: endpointName,
+			Target: &nexuspb.EndpointTarget{
+				Variant: &nexuspb.EndpointTarget_External_{
+					External: &nexuspb.EndpointTarget_External{
+						Url: "http://" + listenAddr,
+					},
+				},
+			},
+		},
+	})
+	s.NoError(err)
+
+	startResp, err := startNexusOperation(s, &workflowservice.StartNexusOperationExecutionRequest{
+		OperationId: "test-op",
+		Endpoint:    endpointName,
+	})
+	s.NoError(err)
+
+	ctx, cancel := context.WithTimeout(s.Context(), 10*time.Second)
+	defer cancel()
+	require.Eventually(t, func() bool {
+		return callbackToken != "" && callbackURL != ""
+	}, 10*time.Second, 100*time.Millisecond)
+
+	gen := &commonnexus.CallbackTokenGenerator{}
+	decodedToken, err := commonnexus.DecodeCallbackToken(callbackToken)
+	s.NoError(err)
+	completionToken, err := gen.DecodeCompletion(decodedToken)
+	s.NoError(err)
+
+	// Deliberately corrupt transition fields in the callback token. Completion should
+	// still succeed because the handler strips these fields before validation.
+	ref := &persistencespb.ChasmComponentRef{}
+	s.NoError(ref.Unmarshal(completionToken.GetComponentRef()))
+	s.NotNil(ref.ExecutionVersionedTransition)
+	s.NotNil(ref.ComponentInitialVersionedTransition)
+	ref.ExecutionVersionedTransition = &persistencespb.VersionedTransition{
+		NamespaceFailoverVersion: ref.ExecutionVersionedTransition.NamespaceFailoverVersion + 1000,
+		TransitionCount:          ref.ExecutionVersionedTransition.TransitionCount + 1000,
+	}
+	ref.ComponentInitialVersionedTransition = &persistencespb.VersionedTransition{
+		NamespaceFailoverVersion: ref.ComponentInitialVersionedTransition.NamespaceFailoverVersion + 1000,
+		TransitionCount:          ref.ComponentInitialVersionedTransition.TransitionCount + 1000,
+	}
+	completionToken.ComponentRef, err = ref.Marshal()
+	s.NoError(err)
+
+	callbackToken, err = gen.Tokenize(completionToken)
+	s.NoError(err)
+
+	c := nexusrpc.NewCompletionHTTPClient(nexusrpc.CompletionHTTPClientOptions{
+		Serializer: commonnexus.PayloadSerializer,
+	})
+	err = c.CompleteOperation(ctx, callbackURL, nexusrpc.CompleteOperationOptions{
+		Result: payload.EncodeString("result"),
+		Header: nexus.Header{commonnexus.CallbackTokenHeader: callbackToken},
+	})
+	s.NoError(err)
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		descResp, err := s.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+			Namespace:      s.Namespace().String(),
+			OperationId:    "test-op",
+			RunId:          startResp.RunId,
+			IncludeOutcome: true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, enumspb.NEXUS_OPERATION_EXECUTION_STATUS_COMPLETED, descResp.GetInfo().GetStatus())
+		protorequire.ProtoEqual(t, payload.EncodeString("result"), descResp.GetResult())
+	}, 10*time.Second, 100*time.Millisecond)
 }
 
 func startNexusOperation(


### PR DESCRIPTION
## What changed?

Instead of removing version transition info from token on caller-side, instead ignore it on handler side.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)
