### PR TITLE
[Standalone Activity] Emit ContextMetadata keys from CHASM handlers

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -24,6 +24,7 @@ import (
 	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/common/contextutil"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	commonnexus "go.temporal.io/server/common/nexus"
@@ -118,8 +119,17 @@ func (a *Activity) LifecycleState(_ chasm.Context) chasm.LifecycleState {
 }
 
 func (a *Activity) ContextMetadata(_ chasm.Context) map[string]string {
-	// TODO: Export standalone activity context metadata.
-	return nil
+	md := make(map[string]string, 2)
+	if actType := a.GetActivityType().GetName(); actType != "" {
+		md[contextutil.MetadataKeyStandaloneActivityType] = actType
+	}
+	if tq := a.GetTaskQueue().GetName(); tq != "" {
+		md[contextutil.MetadataKeyStandaloneActivityTaskQueue] = tq
+	}
+	if len(md) == 0 {
+		return nil
+	}
+	return md
 }
 
 // NewStandaloneActivity creates a new activity component and adds associated tasks to start execution.

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -249,3 +249,59 @@ func TestActivityTerminate(t *testing.T) {
 		})
 	}
 }
+
+func TestContextMetadata(t *testing.T) {
+	t.Run("returns activity type and task queue", func(t *testing.T) {
+		ctx := &chasm.MockMutableContext{}
+		activity := &Activity{
+			ActivityState: &activitypb.ActivityState{
+				ActivityType: &commonpb.ActivityType{Name: "my-activity"},
+				TaskQueue:    &taskqueuepb.TaskQueue{Name: "my-task-queue"},
+			},
+		}
+
+		md := activity.ContextMetadata(ctx)
+		require.Equal(t, map[string]string{
+			"standalone-activity-type":       "my-activity",
+			"standalone-activity-task-queue": "my-task-queue",
+		}, md)
+	})
+
+	t.Run("returns only activity type when task queue is empty", func(t *testing.T) {
+		ctx := &chasm.MockMutableContext{}
+		activity := &Activity{
+			ActivityState: &activitypb.ActivityState{
+				ActivityType: &commonpb.ActivityType{Name: "my-activity"},
+			},
+		}
+
+		md := activity.ContextMetadata(ctx)
+		require.Equal(t, map[string]string{
+			"standalone-activity-type": "my-activity",
+		}, md)
+	})
+
+	t.Run("returns only task queue when activity type is empty", func(t *testing.T) {
+		ctx := &chasm.MockMutableContext{}
+		activity := &Activity{
+			ActivityState: &activitypb.ActivityState{
+				TaskQueue: &taskqueuepb.TaskQueue{Name: "my-task-queue"},
+			},
+		}
+
+		md := activity.ContextMetadata(ctx)
+		require.Equal(t, map[string]string{
+			"standalone-activity-task-queue": "my-task-queue",
+		}, md)
+	})
+
+	t.Run("returns nil when both are empty", func(t *testing.T) {
+		ctx := &chasm.MockMutableContext{}
+		activity := &Activity{
+			ActivityState: &activitypb.ActivityState{},
+		}
+
+		md := activity.ContextMetadata(ctx)
+		require.Nil(t, md)
+	})
+}


### PR DESCRIPTION
## What changed?
- CHASM standalone activity now emits ContextMetadata for metering purposes (on activity type and task queue keys).
- CHASM framework automatically calls this method internally for engine/handler methods.

## Why?
- Metering exposes these tags for customer usage, matching the pattern already established by the Scheduler component in #9877.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Risks
- Low risk. Follows the same pattern as the Scheduler `ContextMetadata` implementation. No behavioral changes to existing code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds context metadata tags (activity type/task queue) for standalone activities plus unit coverage; no state transitions or request handling logic changes.
> 
> **Overview**
> CHASM standalone activities now emit `ContextMetadata` for metering by tagging requests with `standalone-activity-type` and `standalone-activity-task-queue` when available (returning `nil` when both are empty).
> 
> Adds unit tests covering the new metadata behavior across combinations of populated/empty activity type and task queue fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92c406512b2a200fb75a777b32965713cfbeda86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->