### PR TITLE
Add `NamespaceReplicationAdmitter` extension point for custom cluster replication admission logic

### DIFF
--- a/common/namespace/nsreplication/replication_admitter.go
+++ b/common/namespace/nsreplication/replication_admitter.go
@@ -1,0 +1,42 @@
+package nsreplication
+
+import (
+	"context"
+
+	replicationpb "go.temporal.io/api/replication/v1"
+	replicationspb "go.temporal.io/server/api/replication/v1"
+)
+
+// NamespaceReplicationAdmitter decides whether to process a namespace
+// replication task when the namespace does not yet exist locally.
+type NamespaceReplicationAdmitter interface {
+	Admit(ctx context.Context, currentCluster string, task *replicationspb.NamespaceTaskAttributes) bool
+}
+
+// DefaultAdmitter is the default implementation: admit the task iff the
+// current cluster is listed in task.ReplicationConfig.Clusters.
+type DefaultAdmitter struct{}
+
+// NewDefaultAdmitter creates the default NamespaceReplicationAdmitter.
+func NewDefaultAdmitter() NamespaceReplicationAdmitter {
+	return &DefaultAdmitter{}
+}
+
+// Admit returns true iff currentCluster appears in the task's replication
+// config cluster list.
+func (*DefaultAdmitter) Admit(
+	_ context.Context,
+	currentCluster string,
+	task *replicationspb.NamespaceTaskAttributes,
+) bool {
+	return checkClusterIncludedInReplicationConfig(currentCluster, task.GetReplicationConfig().GetClusters())
+}
+
+func checkClusterIncludedInReplicationConfig(clusterName string, repCfg []*replicationpb.ClusterReplicationConfig) bool {
+	for _, cluster := range repCfg {
+		if clusterName == cluster.GetClusterName() {
+			return true
+		}
+	}
+	return false
+}

--- a/common/namespace/nsreplication/replication_admitter_test.go
+++ b/common/namespace/nsreplication/replication_admitter_test.go
@@ -1,0 +1,157 @@
+package nsreplication
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	namespacepb "go.temporal.io/api/namespace/v1"
+	replicationpb "go.temporal.io/api/replication/v1"
+	"go.temporal.io/api/serviceerror"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	replicationspb "go.temporal.io/server/api/replication/v1"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/persistence"
+	"go.uber.org/mock/gomock"
+)
+
+func TestDefaultAdmitter_Admit(t *testing.T) {
+	admitter := NewDefaultAdmitter()
+	ctx := context.Background()
+
+	build := func(clusters ...string) *replicationspb.NamespaceTaskAttributes {
+		repCfg := make([]*replicationpb.ClusterReplicationConfig, 0, len(clusters))
+		for _, c := range clusters {
+			repCfg = append(repCfg, &replicationpb.ClusterReplicationConfig{ClusterName: c})
+		}
+		return &replicationspb.NamespaceTaskAttributes{
+			ReplicationConfig: &replicationpb.NamespaceReplicationConfig{Clusters: repCfg},
+		}
+	}
+
+	t.Run("cluster in list is admitted", func(t *testing.T) {
+		require.True(t, admitter.Admit(ctx, "cluster-a", build("cluster-a", "cluster-b")))
+	})
+
+	t.Run("cluster not in list is rejected", func(t *testing.T) {
+		require.False(t, admitter.Admit(ctx, "cluster-c", build("cluster-a", "cluster-b")))
+	})
+
+	t.Run("empty cluster list is rejected", func(t *testing.T) {
+		require.False(t, admitter.Admit(ctx, "cluster-a", build()))
+	})
+
+	t.Run("nil replication config is rejected", func(t *testing.T) {
+		// GetReplicationConfig is nil-safe via proto getters; admitter must not panic.
+		require.False(t, admitter.Admit(ctx, "cluster-a", &replicationspb.NamespaceTaskAttributes{}))
+	})
+
+	t.Run("empty current-cluster name never matches", func(t *testing.T) {
+		// Defensive: a caller passing "" should never be admitted even if "" somehow slipped into the list.
+		require.False(t, admitter.Admit(ctx, "", build("cluster-a", "cluster-b")))
+	})
+}
+
+// stubAdmitter is a deterministic admitter used by shouldProcessTask tests.
+type stubAdmitter struct {
+	admit  bool
+	called int
+}
+
+func (s *stubAdmitter) Admit(
+	context.Context,
+	string,
+	*replicationspb.NamespaceTaskAttributes,
+) bool {
+	s.called++
+	return s.admit
+}
+
+func newExecutorForAdmitterTest(t *testing.T, admitter NamespaceReplicationAdmitter) (*taskExecutorImpl, *persistence.MockMetadataManager) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	mockMgr := persistence.NewMockMetadataManager(ctrl)
+	exec := NewTaskExecutor(
+		"cluster-local",
+		mockMgr,
+		NewNoopDataMerger(),
+		admitter,
+		log.NewTestLogger(),
+	).(*taskExecutorImpl)
+	return exec, mockMgr
+}
+
+func newTaskForAdmitterTest() *replicationspb.NamespaceTaskAttributes {
+	return &replicationspb.NamespaceTaskAttributes{
+		Id: "ns-id",
+		Info: &namespacepb.NamespaceInfo{
+			Name: "test-ns",
+			Data: map[string]string{},
+		},
+		ReplicationConfig: &replicationpb.NamespaceReplicationConfig{},
+	}
+}
+
+func expectNotFound(mockMgr *persistence.MockMetadataManager) {
+	mockMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(
+		nil, &serviceerror.NamespaceNotFound{},
+	).Times(1)
+}
+
+func TestShouldProcessTask_ConsultsAdmitterOnNamespaceNotFound(t *testing.T) {
+	cases := []struct {
+		name         string
+		admitterSays bool
+		wantProcess  bool
+	}{
+		{"admitter accepts", true, true},
+		{"admitter rejects", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			admitter := &stubAdmitter{admit: tc.admitterSays}
+			exec, mockMgr := newExecutorForAdmitterTest(t, admitter)
+			expectNotFound(mockMgr)
+
+			shouldProcess, err := exec.shouldProcessTask(context.Background(), newTaskForAdmitterTest())
+
+			require.NoError(t, err)
+			require.Equal(t, tc.wantProcess, shouldProcess)
+			require.Equal(t, 1, admitter.called)
+		})
+	}
+}
+
+func TestShouldProcessTask_SkipsAdmitterWhenNamespaceExists(t *testing.T) {
+	admitter := &stubAdmitter{admit: false}
+	exec, mockMgr := newExecutorForAdmitterTest(t, admitter)
+
+	// GetNamespace returns a matching local record, so shouldProcessTask takes the
+	// nil-error branch and must NOT consult the admitter.
+	mockMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(
+		&persistence.GetNamespaceResponse{Namespace: &persistencespb.NamespaceDetail{
+			Info: &persistencespb.NamespaceInfo{Id: "ns-id"},
+		}}, nil,
+	).Times(1)
+
+	shouldProcess, err := exec.shouldProcessTask(context.Background(), newTaskForAdmitterTest())
+
+	require.NoError(t, err)
+	require.True(t, shouldProcess)
+	require.Equal(t, 0, admitter.called, "admitter must not be called when local namespace record exists")
+}
+
+func TestShouldProcessTask_PropagatesUnknownGetNamespaceError(t *testing.T) {
+	admitter := &stubAdmitter{admit: true}
+	exec, mockMgr := newExecutorForAdmitterTest(t, admitter)
+
+	// Non-NamespaceNotFound error must short-circuit without consulting the admitter.
+	boom := serviceerror.NewUnavailable("boom")
+	mockMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, boom).Times(1)
+
+	shouldProcess, err := exec.shouldProcessTask(context.Background(), newTaskForAdmitterTest())
+
+	require.ErrorIs(t, err, boom)
+	require.False(t, shouldProcess)
+	require.Equal(t, 0, admitter.called, "admitter must not be called when GetNamespace fails unexpectedly")
+}

--- a/common/namespace/nsreplication/replication_task_executor.go
+++ b/common/namespace/nsreplication/replication_task_executor.go
@@ -51,6 +51,7 @@ type (
 		currentCluster  string
 		metadataManager persistence.MetadataManager
 		dataMerger      NamespaceDataMerger
+		admitter        NamespaceReplicationAdmitter
 		logger          log.Logger
 	}
 )
@@ -60,6 +61,7 @@ func NewTaskExecutor(
 	currentCluster string,
 	metadataManagerV2 persistence.MetadataManager,
 	dataMerger NamespaceDataMerger,
+	admitter NamespaceReplicationAdmitter,
 	logger log.Logger,
 ) TaskExecutor {
 
@@ -67,6 +69,7 @@ func NewTaskExecutor(
 		currentCluster:  currentCluster,
 		metadataManager: metadataManagerV2,
 		dataMerger:      dataMerger,
+		admitter:        admitter,
 		logger:          logger,
 	}
 }
@@ -93,15 +96,6 @@ func (h *taskExecutorImpl) Execute(
 	}
 }
 
-func checkClusterIncludedInReplicationConfig(clusterName string, repCfg []*replicationpb.ClusterReplicationConfig) bool {
-	for _, cluster := range repCfg {
-		if clusterName == cluster.ClusterName {
-			return true
-		}
-	}
-	return false
-}
-
 func (h *taskExecutorImpl) shouldProcessTask(ctx context.Context, task *replicationspb.NamespaceTaskAttributes) (bool, error) {
 	resp, err := h.metadataManager.GetNamespace(ctx, &persistence.GetNamespaceRequest{
 		Name: task.Info.GetName(),
@@ -119,7 +113,7 @@ func (h *taskExecutorImpl) shouldProcessTask(ctx context.Context, task *replicat
 
 		return true, nil
 	case *serviceerror.NamespaceNotFound:
-		return checkClusterIncludedInReplicationConfig(h.currentCluster, task.ReplicationConfig.Clusters), nil
+		return h.admitter.Admit(ctx, h.currentCluster, task), nil
 	default:
 		// return the original err
 		return false, err

--- a/common/namespace/nsreplication/replication_task_executor_test.go
+++ b/common/namespace/nsreplication/replication_task_executor_test.go
@@ -52,6 +52,7 @@ func (s *namespaceReplicationTaskExecutorSuite) SetupTest() {
 		"some random standby cluster name",
 		s.mockMetadataMgr,
 		NewNoopDataMerger(),
+		NewDefaultAdmitter(),
 		logger,
 	).(*taskExecutorImpl)
 }

--- a/service/frontend/admin_handler_test.go
+++ b/service/frontend/admin_handler_test.go
@@ -195,6 +195,7 @@ func (s *adminHandlerSuite) SetupTest() {
 		s.mockMetadata,
 		s.mockResource.GetMetadataManager(),
 		nsreplication.NewNoopDataMerger(),
+		nsreplication.NewDefaultAdmitter(),
 		s.mockResource.GetNamespaceReplicationQueue(),
 		s.mockResource.GetLogger(),
 	)

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -100,6 +100,7 @@ var Module = fx.Options(
 	service.PersistenceLazyLoadedServiceResolverModule,
 	fx.Provide(FEReplicatorNamespaceReplicationQueueProvider),
 	fx.Provide(nsreplication.NewNoopDataMerger),
+	fx.Provide(nsreplication.NewDefaultAdmitter),
 	fx.Provide(AuthorizationInterceptorProvider),
 	fx.Provide(NamespaceCheckerProvider),
 	fx.Provide(func(so GrpcServerOptions) *grpc.Server { return grpc.NewServer(so.Options...) }),
@@ -749,6 +750,7 @@ func NamespaceDLQHandlerProvider(
 	clusterMetadata cluster.Metadata,
 	persistenceMetadataManager persistence.MetadataManager,
 	namespaceDataMerger nsreplication.NamespaceDataMerger,
+	namespaceAdmitter nsreplication.NamespaceReplicationAdmitter,
 	namespaceReplicationQueue persistence.NamespaceReplicationQueue,
 	logger log.SnTaggedLogger,
 ) nsreplication.DLQMessageHandler {
@@ -756,6 +758,7 @@ func NamespaceDLQHandlerProvider(
 		clusterMetadata.GetCurrentClusterName(),
 		persistenceMetadataManager,
 		namespaceDataMerger,
+		namespaceAdmitter,
 		logger,
 	)
 	return nsreplication.NewDLQMessageHandler(

--- a/service/history/replication/fx.go
+++ b/service/history/replication/fx.go
@@ -45,6 +45,7 @@ var Module = fx.Provide(
 		return m
 	},
 	nsreplication.NewNoopDataMerger,
+	nsreplication.NewDefaultAdmitter,
 	NewExecutionManagerDLQWriter,
 	ClientSchedulerRateLimiterProvider,
 	ServerSchedulerRateLimiterProvider,
@@ -81,6 +82,7 @@ func eagerNamespaceRefresherProvider(
 	clientBean client.Bean,
 	clusterMetadata cluster.Metadata,
 	dataMerger nsreplication.NamespaceDataMerger,
+	admitter nsreplication.NamespaceReplicationAdmitter,
 	metricsHandler metrics.Handler,
 ) EagerNamespaceRefresher {
 	return NewEagerNamespaceRefresher(
@@ -92,6 +94,7 @@ func eagerNamespaceRefresherProvider(
 			clusterMetadata.GetCurrentClusterName(),
 			metadataManager,
 			dataMerger,
+			admitter,
 			logger,
 		),
 		clusterMetadata.GetCurrentClusterName(),

--- a/service/worker/fx.go
+++ b/service/worker/fx.go
@@ -85,16 +85,19 @@ var Module = fx.Options(
 		clusterMetadata cluster.Metadata,
 		metadataManager persistence.MetadataManager,
 		dataMerger nsreplication.NamespaceDataMerger,
+		admitter nsreplication.NamespaceReplicationAdmitter,
 		logger log.Logger,
 	) nsreplication.TaskExecutor {
 		return nsreplication.NewTaskExecutor(
 			clusterMetadata.GetCurrentClusterName(),
 			metadataManager,
 			dataMerger,
+			admitter,
 			logger,
 		)
 	}),
 	fx.Provide(nsreplication.NewNoopDataMerger),
+	fx.Provide(nsreplication.NewDefaultAdmitter),
 	fx.Provide(ServerProvider),
 	fx.Provide(NewService),
 	fx.Provide(fx.Annotate(NewWorkerManager, fx.ParamTags(workercommon.WorkerComponentTag))),

--- a/tests/testcore/test_cluster.go
+++ b/tests/testcore/test_cluster.go
@@ -339,7 +339,7 @@ func newClusterWithPersistenceTestBaseFactory(
 		MatchingConfig:                   clusterConfig.MatchingConfig,
 		WorkerConfig:                     clusterConfig.WorkerConfig,
 		MockAdminClient:                  clusterConfig.MockAdminClient,
-		NamespaceReplicationTaskExecutor: nsreplication.NewTaskExecutor(clusterConfig.ClusterMetadata.CurrentClusterName, testBase.MetadataManager, nsreplication.NewNoopDataMerger(), logger),
+		NamespaceReplicationTaskExecutor: nsreplication.NewTaskExecutor(clusterConfig.ClusterMetadata.CurrentClusterName, testBase.MetadataManager, nsreplication.NewNoopDataMerger(), nsreplication.NewDefaultAdmitter(), logger),
 		DynamicConfigOverrides:           clusterConfig.DynamicConfigOverrides,
 		TLSConfigProvider:                tlsConfigProvider,
 		ServiceFxOptions:                 clusterConfig.ServiceFxOptions,


### PR DESCRIPTION
## What changed?

This PR extracts the “should this cluster process an incoming namespace replication task?” decision into a new `NamespaceReplicationAdmitter` interface.

Allows custom override that decides whether the current cluster should admit an incoming namespace replication task for a namespace that does not yet exist locally.

> Note: The default behavior is unchanged.

## Why?
Allow integrate with custom `admitter` to override the replication logic.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
