### PR TITLE
Revert "Only consider a history host unhealthy in the health check if it has been gone more than 10 seconds (#9986)"

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -807,12 +807,7 @@ This config is EXPERIMENTAL and may be changed or removed in a later release.`,
 	HistoryHostSelfErrorProportion = NewGlobalFloatSetting(
 		"frontend.historyHostSelfErrorProportion",
 		0.05,
-		`HistoryHostSelfErrorProportion is the proportion of hosts that have marked themselves as not ready -- this could be due to waiting to acquire all shards on startup, or an internal health check failure`,
-	)
-	HistoryHostFailureTimeThreshold = NewGlobalDurationSetting(
-		"frontend.historyHostFailureTimeThreshold",
-		10*time.Second,
-		`HistoryHostFailureTimeThreshold is the length of time a host must have failed before it is considered unhealthy`,
+		`HistoryHostStartingProportion is the proportion of hosts that have marked themselves as not ready -- this could due to waiting to acquire all shards on startup, or an internal health check failure`,
 	)
 	SendRawWorkflowHistory = NewNamespaceBoolSetting(
 		"frontend.sendRawWorkflowHistory",

--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -176,7 +176,6 @@ func NewAdminHandler(
 		args.MembershipMonitor,
 		args.Config.HistoryHostErrorPercentage,
 		args.Config.HistoryHostSelfErrorProportion,
-		args.Config.HistoryHostFailureTimeThreshold,
 		func(ctx context.Context, hostAddress string) (*historyservice.DeepHealthCheckResponse, error) {
 			return args.HistoryClient.DeepHealthCheck(ctx, &historyservice.DeepHealthCheckRequest{HostAddress: hostAddress})
 		},
@@ -259,7 +258,7 @@ func (adh *AdminHandler) DeepHealthCheck(
 ) (_ *adminservice.DeepHealthCheckResponse, retError error) {
 	defer log.CapturePanic(adh.logger, &retError)
 
-	result, err := adh.historyHealthChecker.Check(ctx, time.Now())
+	result, err := adh.historyHealthChecker.Check(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/service/frontend/health_check.go
+++ b/service/frontend/health_check.go
@@ -3,9 +3,7 @@ package frontend
 import (
 	"context"
 	"fmt"
-	"slices"
-	"sync"
-	"time"
+	"math"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	healthspb "go.temporal.io/server/api/health/v1"
@@ -25,7 +23,7 @@ type (
 	}
 
 	HealthChecker interface {
-		Check(ctx context.Context, now time.Time) (HealthCheckResult, error)
+		Check(ctx context.Context) (HealthCheckResult, error)
 	}
 
 	healthCheckerImpl struct {
@@ -33,9 +31,7 @@ type (
 		membershipMonitor             membership.Monitor
 		hostFailurePercentage         dynamicconfig.FloatPropertyFn
 		hostDeclinedServingProportion dynamicconfig.FloatPropertyFn
-		hostFailureTimeThreshold      dynamicconfig.DurationPropertyFn
 		healthCheckFn                 func(ctx context.Context, hostAddress string) (*historyservice.DeepHealthCheckResponse, error)
-		recentUnhealthyHosts          *unhealthyHostTracker
 		logger                        log.Logger
 	}
 
@@ -43,93 +39,13 @@ type (
 		address  string
 		response *historyservice.DeepHealthCheckResponse
 	}
-	unhealthyHostTracker struct {
-		mu    sync.Mutex
-		hosts map[string]unhealthyHostRecord
-	}
-	unhealthyHostRecord struct {
-		address        string
-		lastSeenHealth enumsspb.HealthState
-		failedAt       time.Time
-	}
 )
-
-// Compile-time assert: healthCheckerImpl implements HealthChecker
-var _ HealthChecker = (*healthCheckerImpl)(nil)
-
-// trackUnhealthyHost tracks the last time a host failed health check.
-// Must be called with mu held.
-func (u *unhealthyHostTracker) trackUnhealthyHost(address string, now time.Time, state enumsspb.HealthState) {
-	if existing, present := u.hosts[address]; !present || existing.lastSeenHealth != state {
-		// Preserve the earliest time that the host failed, even if it changes states
-		var failedAt time.Time
-		if present {
-			failedAt = slices.MinFunc([]time.Time{now, existing.failedAt}, time.Time.Compare)
-		} else {
-			failedAt = now
-		}
-		u.hosts[address] = unhealthyHostRecord{
-			address:        address,
-			lastSeenHealth: state,
-			failedAt:       failedAt,
-		}
-	}
-}
-
-// clearStaleEntries removes any entries from the tracker that are no longer in the list of hosts.
-// Must be called with mu held.
-func (u *unhealthyHostTracker) clearStaleEntries(hosts []*healthspb.HostHealthDetail) {
-	validAddresses := make(map[string]struct{})
-	for _, host := range hosts {
-		// Keep any addresses that are failing or declined serving.
-		if host.GetState() == enumsspb.HEALTH_STATE_SERVING {
-			continue
-		}
-		validAddresses[host.GetAddress()] = struct{}{}
-	}
-	for address := range u.hosts {
-		if _, present := validAddresses[address]; !present {
-			delete(u.hosts, address)
-		}
-	}
-}
-
-// unhealthyHosts returns a list of hosts that have failed health check recently.
-// Must be called with mu held.
-func (u *unhealthyHostTracker) unhealthyHosts(now time.Time, duration time.Duration) (declinedServing []unhealthyHostRecord, otherUnhealthy []unhealthyHostRecord) {
-	for _, record := range u.hosts {
-		if now.Sub(record.failedAt) >= duration {
-			if record.lastSeenHealth == enumsspb.HEALTH_STATE_DECLINED_SERVING {
-				declinedServing = append(declinedServing, record)
-			} else {
-				otherUnhealthy = append(otherUnhealthy, record)
-			}
-		}
-	}
-	return
-}
-
-// updateUnhealthyHosts updates the local host health entries while holding mu, then returns the unhealthy hosts.
-func (u *unhealthyHostTracker) updateUnhealthyHosts(hostHealths []*healthspb.HostHealthDetail, now time.Time,
-	threshold time.Duration) (declinedServing []unhealthyHostRecord, otherUnhealthy []unhealthyHostRecord) {
-	u.mu.Lock()
-	defer u.mu.Unlock()
-	for _, result := range hostHealths {
-		// Only track unhealthy hosts, healthy hosts will be cleaned up in clearStaleEntries
-		if result.GetState() != enumsspb.HEALTH_STATE_SERVING {
-			u.trackUnhealthyHost(result.Address, now, result.State)
-		}
-	}
-	u.clearStaleEntries(hostHealths)
-	return u.unhealthyHosts(now, threshold)
-}
 
 func NewHealthChecker(
 	serviceName primitives.ServiceName,
 	membershipMonitor membership.Monitor,
 	hostFailurePercentage dynamicconfig.FloatPropertyFn,
 	hostDeclinedServingProportion dynamicconfig.FloatPropertyFn,
-	hostFailureTimeThreshold dynamicconfig.DurationPropertyFn,
 	healthCheckFn func(ctx context.Context, hostAddress string) (*historyservice.DeepHealthCheckResponse, error),
 	logger log.Logger,
 ) HealthChecker {
@@ -138,14 +54,12 @@ func NewHealthChecker(
 		membershipMonitor:             membershipMonitor,
 		hostFailurePercentage:         hostFailurePercentage,
 		hostDeclinedServingProportion: hostDeclinedServingProportion,
-		hostFailureTimeThreshold:      hostFailureTimeThreshold,
 		healthCheckFn:                 healthCheckFn,
-		recentUnhealthyHosts:          &unhealthyHostTracker{hosts: make(map[string]unhealthyHostRecord)},
 		logger:                        logger,
 	}
 }
 
-func (h *healthCheckerImpl) Check(ctx context.Context, now time.Time) (HealthCheckResult, error) {
+func (h *healthCheckerImpl) Check(ctx context.Context) (HealthCheckResult, error) {
 	resolver, err := h.membershipMonitor.GetResolver(h.serviceName)
 	if err != nil {
 		return HealthCheckResult{
@@ -170,52 +84,7 @@ func (h *healthCheckerImpl) Check(ctx context.Context, now time.Time) (HealthChe
 		}, nil
 	}
 
-	hostDetails := h.collectHostHealth(ctx, hosts)
-	declinedServing, otherUnhealthy := h.recentUnhealthyHosts.updateUnhealthyHosts(hostDetails, now, h.hostFailureTimeThreshold())
-
-	overallState := enumsspb.HEALTH_STATE_SERVING
-	hostDeclinedServingProportion := float64(len(declinedServing)) / float64(len(hosts))
-	failedHostCountProportion := float64(len(otherUnhealthy)) / float64(len(hosts))
-
-	if failedHostCountProportion+hostDeclinedServingProportion > h.hostFailurePercentage() {
-		overallState = enumsspb.HEALTH_STATE_NOT_SERVING
-	}
-	if len(declinedServing) > 2 && hostDeclinedServingProportion > h.hostDeclinedServingProportion() {
-		overallState = enumsspb.HEALTH_STATE_DECLINED_SERVING
-	}
-	if overallState != enumsspb.HEALTH_STATE_SERVING {
-		var exampleFailedHost *healthspb.HostHealthDetail
-		for _, host := range hostDetails {
-			if host.State != enumsspb.HEALTH_STATE_SERVING {
-				exampleFailedHost = host
-				break
-			}
-		}
-		h.logger.Warn("Health check determined the service is unhealthy!",
-			tag.Int("host failure count", len(otherUnhealthy)),
-			tag.Float64("host failure percentage threshold", h.hostFailurePercentage()),
-			tag.Float64("host failure percentage", failedHostCountProportion),
-			tag.Int("host declined serving count", len(declinedServing)),
-			tag.Float64("host declined serving percentage", hostDeclinedServingProportion),
-			tag.Float64("host declined serving percentage threshold", h.hostDeclinedServingProportion()),
-			tag.NewStringTag("example_failed_host", failedHostSummary(exampleFailedHost)),
-		)
-	}
-
-	return HealthCheckResult{
-		State: overallState,
-		ServiceDetail: &healthspb.ServiceHealthDetail{
-			Service: string(h.serviceName),
-			State:   overallState,
-			Hosts:   hostDetails,
-		},
-	}, nil
-}
-
-func (h *healthCheckerImpl) collectHostHealth(ctx context.Context, hosts []membership.HostInfo) []*healthspb.HostHealthDetail {
-	hostDetails := make([]*healthspb.HostHealthDetail, 0, len(hosts))
 	receiveCh := make(chan hostResult, len(hosts))
-	defer close(receiveCh)
 	for _, host := range hosts {
 		go func(hostAddress string) {
 			resp, err := h.checkHost(ctx, hostAddress)
@@ -235,6 +104,10 @@ func (h *healthCheckerImpl) collectHostHealth(ctx context.Context, hosts []membe
 		}(host.GetAddress())
 	}
 
+	var failedHostCount float64
+	var hostDeclinedServingCount float64
+	var hostDetails []*healthspb.HostHealthDetail
+	var exampleFailedHost *healthspb.HostHealthDetail
 	for range hosts {
 		result := <-receiveCh
 		state := result.response.GetState()
@@ -245,8 +118,53 @@ func (h *healthCheckerImpl) collectHostHealth(ctx context.Context, hosts []membe
 			Checks:  result.response.GetChecks(),
 		}
 		hostDetails = append(hostDetails, detail)
+
+		switch state {
+		case enumsspb.HEALTH_STATE_SERVING:
+			// Do nothing.
+		case enumsspb.HEALTH_STATE_DECLINED_SERVING:
+			hostDeclinedServingCount++
+		default:
+			// NOT_SERVING, UNSPECIFIED, INTERNAL_ERROR, or any unknown state.
+			failedHostCount++
+			if exampleFailedHost == nil {
+				exampleFailedHost = detail
+			}
+		}
 	}
-	return hostDetails
+	close(receiveCh)
+
+	// Make sure that at lease 2 hosts must be not ready to trigger this check.
+	proportionOfDeclinedServiceHosts := ensureMinimumProportionOfHosts(h.hostDeclinedServingProportion(), len(hosts))
+
+	var overallState enumsspb.HealthState
+	hostDeclinedServingProportion := hostDeclinedServingCount / float64(len(hosts))
+	if hostDeclinedServingProportion > proportionOfDeclinedServiceHosts {
+		h.logger.Warn("health check exceeded host declined serving proportion threshold", tag.Float64("host declined serving proportion threshold", proportionOfDeclinedServiceHosts))
+		overallState = enumsspb.HEALTH_STATE_DECLINED_SERVING
+	} else {
+		failedHostCountProportion := failedHostCount / float64(len(hosts))
+		if failedHostCountProportion+hostDeclinedServingProportion > h.hostFailurePercentage() {
+			h.logger.Warn("health check exceeded host failure percentage threshold",
+				tag.Float64("host failure percentage threshold", h.hostFailurePercentage()),
+				tag.Float64("host failure percentage", failedHostCountProportion),
+				tag.Float64("host declined serving percentage", hostDeclinedServingProportion),
+				tag.NewStringTag("example_failed_host", failedHostSummary(exampleFailedHost)),
+			)
+			overallState = enumsspb.HEALTH_STATE_NOT_SERVING
+		} else {
+			overallState = enumsspb.HEALTH_STATE_SERVING
+		}
+	}
+
+	return HealthCheckResult{
+		State: overallState,
+		ServiceDetail: &healthspb.ServiceHealthDetail{
+			Service: string(h.serviceName),
+			State:   overallState,
+			Hosts:   hostDetails,
+		},
+	}, nil
 }
 
 func (h *healthCheckerImpl) checkHost(ctx context.Context, hostAddress string) (resp *historyservice.DeepHealthCheckResponse, retErr error) {
@@ -282,4 +200,10 @@ func failedHostSummary(host *healthspb.HostHealthDetail) string {
 		}
 	}
 	return fmt.Sprintf("%s: %s", host.GetAddress(), host.GetState().String())
+}
+
+func ensureMinimumProportionOfHosts(proportionOfDeclinedServingHosts float64, totalHosts int) float64 {
+	const minimumHostsFailed = 2.0 // We want to ensure that at least 2 fail before we notify the upstream.
+	minimumProportion := minimumHostsFailed / float64(totalHosts)
+	return math.Max(proportionOfDeclinedServingHosts, minimumProportion)
 }

--- a/service/frontend/health_check_test.go
+++ b/service/frontend/health_check_test.go
@@ -82,7 +82,7 @@ func (s *healthCheckerSuite) Test_Check_Serving() {
 	})
 
 	result, err := s.checker.Check(context.Background())
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(enumsspb.HEALTH_STATE_SERVING, result.State)
 }
 
@@ -96,7 +96,7 @@ func (s *healthCheckerSuite) Test_Check_Not_Serving() {
 	})
 
 	result, err := s.checker.Check(context.Background())
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(enumsspb.HEALTH_STATE_NOT_SERVING, result.State)
 }
 
@@ -112,7 +112,7 @@ func (s *healthCheckerSuite) Test_Check_Declined_Serving() {
 	})
 
 	result, err := s.checker.Check(context.Background())
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(enumsspb.HEALTH_STATE_DECLINED_SERVING, result.State)
 }
 
@@ -120,7 +120,7 @@ func (s *healthCheckerSuite) Test_Check_No_Available_Hosts() {
 	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{})
 
 	result, err := s.checker.Check(context.Background())
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(enumsspb.HEALTH_STATE_NOT_SERVING, result.State)
 	s.NotNil(result.ServiceDetail)
 	s.Equal("no available hosts in membership", result.ServiceDetail.Message)
@@ -162,7 +162,7 @@ func (s *healthCheckerSuite) Test_Check_Boundary_Failure_Percentage_Equals_Thres
 	})
 
 	result, err := s.checker.Check(context.Background())
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(enumsspb.HEALTH_STATE_SERVING, result.State)
 }
 
@@ -201,7 +201,7 @@ func (s *healthCheckerSuite) Test_Check_Single_Host_Scenarios() {
 			})
 
 			result, err := s.checker.Check(context.Background())
-			s.NoError(err)
+			s.Require().NoError(err)
 			s.Equal(tc.expectedState, result.State)
 		})
 	}
@@ -287,7 +287,7 @@ func (s *healthCheckerSuite) Test_Check_Mixed_Host_States_Edge_Cases() {
 			s.resolver.EXPECT().AvailableMembers().Return(hostInfos)
 
 			result, err := s.checker.Check(context.Background())
-			s.NoError(err, tc.description)
+			s.Require().NoError(err, tc.description)
 			s.Equal(tc.expectedState, result.State, tc.description)
 		})
 	}

--- a/service/frontend/health_check_test.go
+++ b/service/frontend/health_check_test.go
@@ -3,9 +3,7 @@ package frontend
 import (
 	"context"
 	"errors"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/suite"
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -50,155 +48,70 @@ func (s *healthCheckerSuite) SetupTest() {
 		func() float64 {
 			return 0.15
 		},
-		func() time.Duration {
-			return 0 * time.Second
-		},
 		func(ctx context.Context, hostAddress string) (*historyservice.DeepHealthCheckResponse, error) {
-			if strings.HasPrefix(hostAddress, "serving") {
+			switch hostAddress {
+			case "1", "3":
 				return &historyservice.DeepHealthCheckResponse{State: enumsspb.HEALTH_STATE_SERVING}, nil
-			} else if strings.HasPrefix(hostAddress, "error") {
+			case "2":
 				return nil, errors.New("test")
-			} else if strings.HasPrefix(hostAddress, "declined") {
+			case "4":
 				return &historyservice.DeepHealthCheckResponse{State: enumsspb.HEALTH_STATE_DECLINED_SERVING}, nil
+			default:
+				return &historyservice.DeepHealthCheckResponse{State: enumsspb.HEALTH_STATE_NOT_SERVING}, nil
 			}
-			return &historyservice.DeepHealthCheckResponse{State: enumsspb.HEALTH_STATE_NOT_SERVING}, nil
 		},
 		log.NewNoopLogger(),
 	)
-	s.checker = checker.(*healthCheckerImpl)
+	healthChecker, ok := checker.(*healthCheckerImpl)
+	if !ok {
+		s.Fail("The constructor did not return correct type")
+	}
+	s.checker = healthChecker
 }
 
 func (s *healthCheckerSuite) TearDownTest() {
 	s.controller.Finish()
 }
 
-func (s *healthCheckerSuite) Test_Unique_Host_Health() {
-	s.checker.hostFailureTimeThreshold = func() time.Duration {
-		return 1 * time.Second
-	}
-	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
-		membership.NewHostInfoFromAddress("servingA"),
-		membership.NewHostInfoFromAddress("errorB"),
-	}).Times(4)
-	result, err := s.checker.Check(context.Background(), time.Unix(1, 0))
-	s.Require().NoError(err)
-	s.Equal(enumsspb.HEALTH_STATE_SERVING, result.State)
-	// Make sure a consistent unhealthy host keeps the state in NOT_SERVING
-	for i := range 3 {
-		result, err = s.checker.Check(context.Background(), time.Unix(int64(i)+2, 0))
-		s.Require().NoError(err)
-		s.Equal(enumsspb.HEALTH_STATE_NOT_SERVING, result.State)
-	}
-	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
-		membership.NewHostInfoFromAddress("servingA"),
-		membership.NewHostInfoFromAddress("errorC"),
-	})
-	result, err = s.checker.Check(context.Background(), time.Unix(3, 0))
-	s.Require().NoError(err)
-	s.Equal(enumsspb.HEALTH_STATE_SERVING, result.State)
-	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
-		membership.NewHostInfoFromAddress("servingA"),
-		membership.NewHostInfoFromAddress("errorD"),
-	})
-	result, err = s.checker.Check(context.Background(), time.Unix(4, 0))
-	s.Require().NoError(err)
-	s.Equal(enumsspb.HEALTH_STATE_SERVING, result.State)
-}
-
-func (s *healthCheckerSuite) Test_Unhealthy_Host_Tracker() {
-	tracker := &unhealthyHostTracker{hosts: make(map[string]unhealthyHostRecord)}
-	tracker.trackUnhealthyHost("A", time.Unix(1, 0), enumsspb.HEALTH_STATE_NOT_SERVING)
-	tracker.trackUnhealthyHost("B", time.Unix(1, 0), enumsspb.HEALTH_STATE_DECLINED_SERVING)
-	tracker.trackUnhealthyHost("C", time.Unix(1, 0), enumsspb.HEALTH_STATE_INTERNAL_ERROR)
-	declinedServing, otherUnhealthy := tracker.unhealthyHosts(time.Unix(2, 0), 1*time.Second)
-	s.Require().Len(declinedServing, 1, "Should be one declined host. Instead found: %+v", declinedServing)
-	s.Require().Len(otherUnhealthy, 2, "Should be two other unhealthy hosts. Instead found: %+v", otherUnhealthy)
-	declinedServing, otherUnhealthy = tracker.unhealthyHosts(time.Unix(1, 0), 1*time.Second)
-	s.Require().Empty(declinedServing, "Should be no declined hosts. Instead found: %+v", declinedServing)
-	s.Require().Empty(otherUnhealthy, "Should be no other unhealthy hosts. Instead found: %+v", otherUnhealthy)
-
-	// Demonstrate status updates to existing host
-	tracker.trackUnhealthyHost("A", time.Unix(2, 0), enumsspb.HEALTH_STATE_NOT_SERVING)
-	s.Require().Equal(tracker.hosts["A"].failedAt, time.Unix(1, 0), "Host A should keep original time, but was %v", tracker.hosts["A"].failedAt.Unix())
-	tracker.trackUnhealthyHost("A", time.Unix(3, 0), enumsspb.HEALTH_STATE_DECLINED_SERVING)
-	s.Require().Equal(enumsspb.HEALTH_STATE_DECLINED_SERVING, tracker.hosts["A"].lastSeenHealth, "Host A should now be DECLINED_SERVING, but was %s", tracker.hosts["A"].lastSeenHealth.String())
-	s.Require().Equal(tracker.hosts["A"].failedAt, time.Unix(1, 0), "Host A should keep original time, but was %v", tracker.hosts["A"].failedAt.Unix())
-
-	// Test stale entries
-	tracker.clearStaleEntries([]*healthspb.HostHealthDetail{
-		{Address: "A", State: enumsspb.HEALTH_STATE_DECLINED_SERVING},
-		{Address: "B", State: enumsspb.HEALTH_STATE_DECLINED_SERVING},
-		{Address: "C", State: enumsspb.HEALTH_STATE_INTERNAL_ERROR},
-	})
-	declinedServing, otherUnhealthy = tracker.unhealthyHosts(time.Unix(2, 0), 1*time.Second)
-	// No change
-	s.Require().Len(declinedServing, 2, "Should be two declined hosts. Instead found: %+v", declinedServing)
-	s.Require().Len(otherUnhealthy, 1, "Should be one other unhealthy host. Instead found: %+v", otherUnhealthy)
-	tracker.clearStaleEntries([]*healthspb.HostHealthDetail{
-		{Address: "A", State: enumsspb.HEALTH_STATE_DECLINED_SERVING},
-		{Address: "B", State: enumsspb.HEALTH_STATE_SERVING},
-		{Address: "C", State: enumsspb.HEALTH_STATE_INTERNAL_ERROR},
-	})
-	declinedServing, otherUnhealthy = tracker.unhealthyHosts(time.Unix(2, 0), 1*time.Second)
-	// Declined host is healthy now!
-	s.Require().Len(declinedServing, 1, "Should be one declined host. Instead found: %+v", declinedServing)
-	s.Require().Len(otherUnhealthy, 1, "Should be one other unhealthy host. Instead found: %+v", otherUnhealthy)
-
-	tracker.clearStaleEntries([]*healthspb.HostHealthDetail{})
-	// Host list empty -> No more unhealthy hosts
-	declinedServing, otherUnhealthy = tracker.unhealthyHosts(time.Unix(2, 0), 1*time.Second)
-	s.Require().Empty(declinedServing, "Should be no declined hosts. Instead found: %+v", declinedServing)
-	s.Require().Empty(otherUnhealthy, "Should be no other unhealthy hosts. Instead found: %+v", otherUnhealthy)
-}
-
-func (s *healthCheckerSuite) Test_Unhealthy_Host_Tracker_Ignore_Healthy() {
-	tracker := &unhealthyHostTracker{hosts: make(map[string]unhealthyHostRecord)}
-	tracker.updateUnhealthyHosts([]*healthspb.HostHealthDetail{
-		{Address: "A", State: enumsspb.HEALTH_STATE_SERVING},
-		{Address: "B", State: enumsspb.HEALTH_STATE_SERVING},
-	}, time.Unix(2, 0), 1*time.Second)
-	s.Require().Empty(tracker.hosts)
-}
-
 func (s *healthCheckerSuite) Test_Check_Serving() {
 	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
-		membership.NewHostInfoFromAddress("servingA"),
-		membership.NewHostInfoFromAddress("errorB"),
-		membership.NewHostInfoFromAddress("servingC"),
-		membership.NewHostInfoFromAddress("servingD"),
+		membership.NewHostInfoFromAddress("1"),
+		membership.NewHostInfoFromAddress("2"),
+		membership.NewHostInfoFromAddress("3"),
+		membership.NewHostInfoFromAddress("1"),
 	})
 
-	result, err := s.checker.Check(context.Background(), time.Now())
+	result, err := s.checker.Check(context.Background())
 	s.NoError(err)
 	s.Equal(enumsspb.HEALTH_STATE_SERVING, result.State)
 }
 
 func (s *healthCheckerSuite) Test_Check_Not_Serving() {
 	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
-		membership.NewHostInfoFromAddress("servingA"),
-		membership.NewHostInfoFromAddress("errorB"),
-		membership.NewHostInfoFromAddress("servingC"),
-		membership.NewHostInfoFromAddress("declinedD"),
-		membership.NewHostInfoFromAddress("E"), // not-serving
+		membership.NewHostInfoFromAddress("1"),
+		membership.NewHostInfoFromAddress("2"),
+		membership.NewHostInfoFromAddress("3"),
+		membership.NewHostInfoFromAddress("4"),
+		membership.NewHostInfoFromAddress("5"),
 	})
 
-	result, err := s.checker.Check(context.Background(), time.Now())
+	result, err := s.checker.Check(context.Background())
 	s.NoError(err)
 	s.Equal(enumsspb.HEALTH_STATE_NOT_SERVING, result.State)
 }
 
 func (s *healthCheckerSuite) Test_Check_Declined_Serving() {
 	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
-		membership.NewHostInfoFromAddress("servingA"),
-		membership.NewHostInfoFromAddress("errorB"),
-		membership.NewHostInfoFromAddress("declinedC"),
-		membership.NewHostInfoFromAddress("declinedD"),
-		membership.NewHostInfoFromAddress("declinedE"),
-		membership.NewHostInfoFromAddress("declinedF"),
-		membership.NewHostInfoFromAddress("G"),
+		membership.NewHostInfoFromAddress("1"),
+		membership.NewHostInfoFromAddress("2"),
+		membership.NewHostInfoFromAddress("4"),
+		membership.NewHostInfoFromAddress("4"),
+		membership.NewHostInfoFromAddress("4"),
+		membership.NewHostInfoFromAddress("4"),
+		membership.NewHostInfoFromAddress("7"),
 	})
 
-	result, err := s.checker.Check(context.Background(), time.Now())
+	result, err := s.checker.Check(context.Background())
 	s.NoError(err)
 	s.Equal(enumsspb.HEALTH_STATE_DECLINED_SERVING, result.State)
 }
@@ -206,7 +119,7 @@ func (s *healthCheckerSuite) Test_Check_Declined_Serving() {
 func (s *healthCheckerSuite) Test_Check_No_Available_Hosts() {
 	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{})
 
-	result, err := s.checker.Check(context.Background(), time.Now())
+	result, err := s.checker.Check(context.Background())
 	s.NoError(err)
 	s.Equal(enumsspb.HEALTH_STATE_NOT_SERVING, result.State)
 	s.NotNil(result.ServiceDetail)
@@ -223,22 +136,34 @@ func (s *healthCheckerSuite) Test_Check_GetResolver_Error() {
 		membershipMonitor,
 		func() float64 { return 0.25 },
 		func() float64 { return 0.15 },
-		func() time.Duration {
-			return 0 * time.Second
-		},
 		func(ctx context.Context, hostAddress string) (*historyservice.DeepHealthCheckResponse, error) {
 			return &historyservice.DeepHealthCheckResponse{State: enumsspb.HEALTH_STATE_SERVING}, nil
 		},
 		log.NewNoopLogger(),
 	)
 
-	result, err := checker.Check(context.Background(), time.Now())
+	result, err := checker.Check(context.Background())
 	s.Error(err)
 	s.Equal(enumsspb.HEALTH_STATE_INTERNAL_ERROR, result.State)
 	s.Contains(err.Error(), "resolver error")
 	s.NotNil(result.ServiceDetail)
 	s.Equal(enumsspb.HEALTH_STATE_INTERNAL_ERROR, result.ServiceDetail.State)
 	s.Contains(result.ServiceDetail.Message, "failed to get membership resolver")
+}
+
+func (s *healthCheckerSuite) Test_Check_Boundary_Failure_Percentage_Equals_Threshold() {
+	// Test when failure percentage exactly equals the threshold (0.25)
+	// With 4 hosts, 1 failed = 0.25 (25%), should return SERVING since it's not > threshold
+	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
+		membership.NewHostInfoFromAddress("1"), // SERVING
+		membership.NewHostInfoFromAddress("2"), // NOT_SERVING (failed)
+		membership.NewHostInfoFromAddress("3"), // SERVING
+		membership.NewHostInfoFromAddress("1"), // SERVING
+	})
+
+	result, err := s.checker.Check(context.Background())
+	s.NoError(err)
+	s.Equal(enumsspb.HEALTH_STATE_SERVING, result.State)
 }
 
 func (s *healthCheckerSuite) Test_Check_Single_Host_Scenarios() {
@@ -249,22 +174,22 @@ func (s *healthCheckerSuite) Test_Check_Single_Host_Scenarios() {
 	}{
 		{
 			name:          "single host serving",
-			hostAddress:   "servingA", // SERVING
+			hostAddress:   "1", // SERVING
 			expectedState: enumsspb.HEALTH_STATE_SERVING,
 		},
 		{
 			name:          "single host failed",
-			hostAddress:   "errorA", // NOT_SERVING (failed)
+			hostAddress:   "2", // NOT_SERVING (failed)
 			expectedState: enumsspb.HEALTH_STATE_NOT_SERVING,
 		},
 		{
 			name:          "single host declined serving",
-			hostAddress:   "declinedA",                       // DECLINED_SERVING
+			hostAddress:   "4",                               // DECLINED_SERVING
 			expectedState: enumsspb.HEALTH_STATE_NOT_SERVING, // Combined logic: 0% failed + 100% declined = 100% > 25% threshold
 		},
 		{
 			name:          "single host not serving",
-			hostAddress:   "A", // NOT_SERVING
+			hostAddress:   "5", // NOT_SERVING
 			expectedState: enumsspb.HEALTH_STATE_NOT_SERVING,
 		},
 	}
@@ -275,7 +200,7 @@ func (s *healthCheckerSuite) Test_Check_Single_Host_Scenarios() {
 				membership.NewHostInfoFromAddress(tc.hostAddress),
 			})
 
-			result, err := s.checker.Check(context.Background(), time.Now())
+			result, err := s.checker.Check(context.Background())
 			s.NoError(err)
 			s.Equal(tc.expectedState, result.State)
 		})
@@ -284,8 +209,8 @@ func (s *healthCheckerSuite) Test_Check_Single_Host_Scenarios() {
 
 func (s *healthCheckerSuite) Test_Check_Context_Cancellation() {
 	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
-		membership.NewHostInfoFromAddress("servingA"),
-		membership.NewHostInfoFromAddress("errorB"),
+		membership.NewHostInfoFromAddress("1"),
+		membership.NewHostInfoFromAddress("2"),
 	})
 
 	// Create a cancelled context
@@ -298,9 +223,6 @@ func (s *healthCheckerSuite) Test_Check_Context_Cancellation() {
 		s.membershipMonitor,
 		func() float64 { return 0.25 },
 		func() float64 { return 0.15 },
-		func() time.Duration {
-			return 0 * time.Second
-		},
 		func(ctx context.Context, hostAddress string) (*historyservice.DeepHealthCheckResponse, error) {
 			select {
 			case <-ctx.Done():
@@ -312,7 +234,7 @@ func (s *healthCheckerSuite) Test_Check_Context_Cancellation() {
 		log.NewNoopLogger(),
 	)
 
-	result, err := checker.Check(ctx, time.Now())
+	result, err := checker.Check(ctx)
 	s.Require().NoError(err)                                 // Context cancellation in individual health checks should not fail the overall check
 	s.Equal(enumsspb.HEALTH_STATE_NOT_SERVING, result.State) // All hosts will return NOT_SERVING due to cancellation
 }
@@ -326,31 +248,31 @@ func (s *healthCheckerSuite) Test_Check_Mixed_Host_States_Edge_Cases() {
 	}{
 		{
 			name:          "edge case: 50% declined serving equals minimum threshold",
-			hosts:         []string{"declinedA", "declinedB", "servingC", "servingD"}, // 2 declined, 2 serving out of 4
-			expectedState: enumsspb.HEALTH_STATE_NOT_SERVING,                          // Combined: 0% failed + 50% declined = 50% > 25% threshold
+			hosts:         []string{"4", "4", "1", "1"},      // 2 declined, 2 serving out of 4
+			expectedState: enumsspb.HEALTH_STATE_NOT_SERVING, // Combined: 0% failed + 50% declined = 50% > 25% threshold
 			description:   "50% declined serving triggers combined failure threshold, returns NOT_SERVING",
 		},
 		{
 			name:          "edge case: 60% declined serving exceeds minimum threshold",
-			hosts:         []string{"declinedA", "declinedB", "declinedC", "servingD", "servingE"}, // 3 declined, 2 serving out of 5
-			expectedState: enumsspb.HEALTH_STATE_DECLINED_SERVING,                                  // 60% > 40% minimum threshold
+			hosts:         []string{"4", "4", "4", "1", "1"},      // 3 declined, 2 serving out of 5
+			expectedState: enumsspb.HEALTH_STATE_DECLINED_SERVING, // 60% > 40% minimum threshold
 			description:   "60% declined serving should trigger DECLINED_SERVING response",
 		},
 		{
 			name:          "edge case: mixed failures just under threshold",
-			hosts:         []string{"errorA", "servingB", "servingC", "servingD", "servingE"}, // 1 failed (20%), 4 serving (80%) out of 5
-			expectedState: enumsspb.HEALTH_STATE_SERVING,                                      // 20% < 25% threshold
+			hosts:         []string{"2", "1", "1", "1", "1"}, // 1 failed (20%), 4 serving (80%) out of 5
+			expectedState: enumsspb.HEALTH_STATE_SERVING,     // 20% < 25% threshold
 			description:   "20% failures should still return SERVING",
 		},
 		{
 			name:          "edge case: combined failures and declined just over threshold",
-			hosts:         []string{"errorA", "declinedB", "servingC", "servingD"}, // 1 failed (25%) + 1 declined (25%) = 50% > 25% threshold
+			hosts:         []string{"2", "4", "1", "1"}, // 1 failed (25%) + 1 declined (25%) = 50% > 25% threshold
 			expectedState: enumsspb.HEALTH_STATE_NOT_SERVING,
 			description:   "Combined 50% failures and declined serving should trigger NOT_SERVING",
 		},
 		{
 			name:          "edge case: all declined serving with many hosts",
-			hosts:         []string{"declinedA", "declinedB", "declinedC", "declinedD", "declinedE"}, // All declined serving
+			hosts:         []string{"4", "4", "4", "4", "4"}, // All declined serving
 			expectedState: enumsspb.HEALTH_STATE_DECLINED_SERVING,
 			description:   "100% declined serving should return DECLINED_SERVING",
 		},
@@ -364,7 +286,7 @@ func (s *healthCheckerSuite) Test_Check_Mixed_Host_States_Edge_Cases() {
 			}
 			s.resolver.EXPECT().AvailableMembers().Return(hostInfos)
 
-			result, err := s.checker.Check(context.Background(), time.Now())
+			result, err := s.checker.Check(context.Background())
 			s.NoError(err, tc.description)
 			s.Equal(tc.expectedState, result.State, tc.description)
 		})
@@ -373,11 +295,11 @@ func (s *healthCheckerSuite) Test_Check_Mixed_Host_States_Edge_Cases() {
 
 func (s *healthCheckerSuite) Test_Check_ServiceDetail_Populated() {
 	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
-		membership.NewHostInfoFromAddress("servingA"),
-		membership.NewHostInfoFromAddress("errorB"),
+		membership.NewHostInfoFromAddress("1"),
+		membership.NewHostInfoFromAddress("2"),
 	})
 
-	result, err := s.checker.Check(context.Background(), time.Now())
+	result, err := s.checker.Check(context.Background())
 	s.Require().NoError(err)
 	s.NotNil(result.ServiceDetail)
 	s.Equal("history", result.ServiceDetail.Service)
@@ -408,9 +330,6 @@ func (s *healthCheckerSuite) Test_Check_HostChecks_Propagated() {
 		membershipMonitor,
 		func() float64 { return 0.25 },
 		func() float64 { return 0.15 },
-		func() time.Duration {
-			return 0 * time.Second
-		},
 		func(ctx context.Context, hostAddress string) (*historyservice.DeepHealthCheckResponse, error) {
 			return &historyservice.DeepHealthCheckResponse{
 				State:  enumsspb.HEALTH_STATE_NOT_SERVING,
@@ -420,7 +339,7 @@ func (s *healthCheckerSuite) Test_Check_HostChecks_Propagated() {
 		log.NewNoopLogger(),
 	)
 
-	result, err := checker.Check(context.Background(), time.Now())
+	result, err := checker.Check(context.Background())
 	s.Require().NoError(err)
 	s.NotNil(result.ServiceDetail)
 	s.Require().Len(result.ServiceDetail.Hosts, 1)
@@ -431,4 +350,45 @@ func (s *healthCheckerSuite) Test_Check_HostChecks_Propagated() {
 	s.Equal(health.CheckTypeRPCLatency, host.Checks[0].CheckType)
 	s.InDelta(850.0, host.Checks[0].Value, 0.01)
 	s.InDelta(500.0, host.Checks[0].Threshold, 0.01)
+}
+
+func (s *healthCheckerSuite) Test_GetProportionOfNotReadyHosts() {
+	testCases := []struct {
+		name                             string
+		proportionOfDeclinedServingHosts float64
+		totalHosts                       int
+		expectedProportion               float64
+	}{
+		{
+			name:                             "zero proportion",
+			proportionOfDeclinedServingHosts: 0.0,
+			totalHosts:                       10,
+			expectedProportion:               0.2,
+		},
+		{
+			name:                             "small proportion with few hosts",
+			proportionOfDeclinedServingHosts: 0.1,
+			totalHosts:                       10,
+			expectedProportion:               0.2, // 2/10 = 0.2 since numHostsToFail < 2
+		},
+		{
+			name:                             "small proportion with many hosts",
+			proportionOfDeclinedServingHosts: 0.1,
+			totalHosts:                       100,
+			expectedProportion:               0.1, // 10 hosts > 2, so use original proportion
+		},
+		{
+			name:                             "large proportion",
+			proportionOfDeclinedServingHosts: 0.8,
+			totalHosts:                       10,
+			expectedProportion:               0.8, // 8 hosts > 2, so use original proportion
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			proportion := ensureMinimumProportionOfHosts(tc.proportionOfDeclinedServingHosts, tc.totalHosts)
+			s.Equal(tc.expectedProportion, proportion)
+		})
+	}
 }

--- a/service/frontend/health_check_test.go
+++ b/service/frontend/health_check_test.go
@@ -388,7 +388,7 @@ func (s *healthCheckerSuite) Test_GetProportionOfNotReadyHosts() {
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
 			proportion := ensureMinimumProportionOfHosts(tc.proportionOfDeclinedServingHosts, tc.totalHosts)
-			s.Equal(tc.expectedProportion, proportion)
+			s.InDelta(tc.expectedProportion, proportion, 0.01)
 		})
 	}
 }

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -212,9 +212,8 @@ type Config struct {
 	MaskInternalErrorDetails dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
 	// Health check
-	HistoryHostErrorPercentage      dynamicconfig.FloatPropertyFn
-	HistoryHostSelfErrorProportion  dynamicconfig.FloatPropertyFn
-	HistoryHostFailureTimeThreshold dynamicconfig.DurationPropertyFn
+	HistoryHostErrorPercentage     dynamicconfig.FloatPropertyFn
+	HistoryHostSelfErrorProportion dynamicconfig.FloatPropertyFn
 
 	LogAllReqErrors dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
@@ -387,7 +386,6 @@ func NewConfig(
 
 		HistoryHostErrorPercentage:        dynamicconfig.HistoryHostErrorPercentage.Get(dc),
 		HistoryHostSelfErrorProportion:    dynamicconfig.HistoryHostSelfErrorProportion.Get(dc),
-		HistoryHostFailureTimeThreshold:   dynamicconfig.HistoryHostFailureTimeThreshold.Get(dc),
 		LogAllReqErrors:                   dynamicconfig.LogAllReqErrors.Get(dc),
 		EnableEagerWorkflowStart:          dynamicconfig.EnableEagerWorkflowStart.Get(dc),
 		WorkflowRulesAPIsEnabled:          dynamicconfig.WorkflowRulesAPIsEnabled.Get(dc),


### PR DESCRIPTION
## What changed?
This reverts commit a7cc3d7a0ac2c369c2bceb5dbf2fe50638fd0f7b.

## Why?
For clusters with large frontend service sizes, this change was too likely to suppress real problems, because each frontend pod would need to be called twice in the worst case.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Low/no risk, this change was never released.
