### PR TITLE
perf: cache WithTags handlers in tallyMetricsHandler to reduce allocations (replaced with https://github.com/temporalio/temporal/pull/9620 )

### DIFF
--- a/common/metrics/tally_metrics_handler.go
+++ b/common/metrics/tally_metrics_handler.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"sync"
 	"time"
 
 	"github.com/uber-go/tally/v4"
@@ -21,6 +22,7 @@ type (
 		scope          tally.Scope
 		perUnitBuckets map[MetricUnit]tally.Buckets
 		excludeTags    excludeTags
+		childCache     sync.Map // tagsCacheKey(tags) -> *tallyMetricsHandler
 	}
 )
 
@@ -40,14 +42,75 @@ func NewTallyMetricsHandler(cfg ClientConfig, scope tally.Scope) *tallyMetricsHa
 	}
 }
 
-// WithTags creates a new MetricProvder with provided []Tag
-// Tags are merged with registered Tags from the source MetricsHandler
+// tagsCacheKey builds a compact string key from a tag slice for use as a
+// sync.Map lookup key.
+func tagsCacheKey(tags []Tag) string {
+	if len(tags) == 1 {
+		return tags[0].Key + "\x00" + tags[0].Value
+	}
+	size := len(tags) - 1 // separators between pairs
+	for i := range tags {
+		size += len(tags[i].Key) + 1 + len(tags[i].Value)
+	}
+	b := make([]byte, 0, size)
+	for i, t := range tags {
+		if i > 0 {
+			b = append(b, 0)
+		}
+		b = append(b, t.Key...)
+		b = append(b, 0)
+		b = append(b, t.Value...)
+	}
+	return string(b)
+}
+
+// WithTags creates a new MetricProvider with provided []Tag
+// Tags are merged with registered Tags from the source MetricsHandler.
+// Handlers are cached by tag combination so repeated calls avoid allocations.
 func (tmh *tallyMetricsHandler) WithTags(tags ...Tag) Handler {
-	return &tallyMetricsHandler{
+	if len(tags) == 0 {
+		return tmh
+	}
+	key := tagsCacheKey(normalizeTagsForCaching(tags, tmh.excludeTags))
+	if v, ok := tmh.childCache.Load(key); ok {
+		return v.(*tallyMetricsHandler)
+	}
+	child := &tallyMetricsHandler{
 		scope:          tmh.scope.Tagged(tagsToMap(tags, tmh.excludeTags)),
 		perUnitBuckets: tmh.perUnitBuckets,
 		excludeTags:    tmh.excludeTags,
 	}
+	actual, _ := tmh.childCache.LoadOrStore(key, child)
+	return actual.(*tallyMetricsHandler)
+}
+
+// normalizeTagsForCaching applies excludeTags substitution to produce
+// canonical tag values for cache key computation. Returns the original slice
+// unchanged if no tags need normalization (zero-alloc fast path).
+func normalizeTagsForCaching(tags []Tag, excl excludeTags) []Tag {
+	if len(excl) == 0 {
+		return tags
+	}
+	var normalized []Tag
+	for i, t := range tags {
+		if vals, ok := excl[t.Key]; ok {
+			if _, ok := vals[t.Value]; !ok {
+				if normalized == nil {
+					normalized = make([]Tag, len(tags))
+					copy(normalized, tags[:i])
+				}
+				normalized[i] = Tag{Key: t.Key, Value: tagExcludedValue}
+				continue
+			}
+		}
+		if normalized != nil {
+			normalized[i] = t
+		}
+	}
+	if normalized != nil {
+		return normalized
+	}
+	return tags
 }
 
 // Counter obtains a counter for the given name.

--- a/common/metrics/tally_metrics_handler_test.go
+++ b/common/metrics/tally_metrics_handler_test.go
@@ -2,11 +2,13 @@ package metrics
 
 import (
 	"math"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally/v4"
 )
 
@@ -86,4 +88,285 @@ func recordTallyMetrics(h Handler) {
 	histogram.Record(1234567)
 	hitsTaggedCounter.Record(11, UnsafeTaskQueueTag("__sticky__"))
 	hitsTaggedExcludedCounter.Record(14, UnsafeTaskQueueTag("filtered"))
+}
+
+func TestWithTags_EmptyTagsReturnsSelf(t *testing.T) {
+	scope := tally.NewTestScope("test", map[string]string{})
+	h := NewTallyMetricsHandler(defaultConfig, scope)
+
+	got := h.WithTags()
+	require.Same(t, h, got, "WithTags() with no args should return the same handler")
+}
+
+func TestWithTags_CacheHitReturnsSamePointer(t *testing.T) {
+	scope := tally.NewTestScope("test", map[string]string{})
+	h := NewTallyMetricsHandler(defaultConfig, scope)
+
+	h1 := h.WithTags(OperationTag("op1"))
+	h2 := h.WithTags(OperationTag("op1"))
+	require.Same(t, h1, h2, "repeated WithTags with identical args should return the same handler")
+}
+
+func TestWithTags_DifferentTagsReturnDifferentHandlers(t *testing.T) {
+	scope := tally.NewTestScope("test", map[string]string{})
+	h := NewTallyMetricsHandler(defaultConfig, scope)
+
+	h1 := h.WithTags(OperationTag("op1"))
+	h2 := h.WithTags(OperationTag("op2"))
+	require.NotSame(t, h1, h2, "WithTags with different values must produce different handlers")
+
+	// Different keys with same value.
+	h3 := h.WithTags(StringTag("key_a", "val"))
+	h4 := h.WithTags(StringTag("key_b", "val"))
+	require.NotSame(t, h3, h4, "WithTags with different keys must produce different handlers")
+}
+
+func TestWithTags_CachedHandlerRecordsMetricsCorrectly(t *testing.T) {
+	scope := tally.NewTestScope("test", map[string]string{})
+	h := NewTallyMetricsHandler(defaultConfig, scope)
+
+	tagged := h.WithTags(StringTag("env", "prod"))
+
+	// Record via first call.
+	tagged.Counter("requests").Record(5)
+
+	// Record via second (cached) call.
+	cached := h.WithTags(StringTag("env", "prod"))
+	cached.Counter("requests").Record(3)
+
+	snap := scope.Snapshot()
+	c := snap.Counters()["test.requests+env=prod"]
+	require.NotNil(t, c)
+	assert.EqualValues(t, 8, c.Value())
+	assert.EqualValues(t, map[string]string{"env": "prod"}, c.Tags())
+}
+
+func TestWithTags_MultipleTagsCacheCorrectly(t *testing.T) {
+	scope := tally.NewTestScope("test", map[string]string{})
+	h := NewTallyMetricsHandler(defaultConfig, scope)
+
+	tags := []Tag{OperationTag("op1"), StringTag("env", "staging")}
+	h1 := h.WithTags(tags...)
+	h2 := h.WithTags(tags...)
+	require.Same(t, h1, h2, "multi-tag WithTags should be cached")
+
+	h1.Counter("hits").Record(1)
+	h2.Counter("hits").Record(2)
+	snap := scope.Snapshot()
+	c := snap.Counters()["test.hits+env=staging,operation=op1"]
+	require.NotNil(t, c)
+	assert.EqualValues(t, 3, c.Value())
+}
+
+func TestWithTags_TagOrderMatters(t *testing.T) {
+	scope := tally.NewTestScope("test", map[string]string{})
+	h := NewTallyMetricsHandler(defaultConfig, scope)
+
+	// Different ordering of the same two tags should be separate cache
+	// entries (the tally scope will merge them, but the cache keys differ).
+	h1 := h.WithTags(StringTag("a", "1"), StringTag("b", "2"))
+	h2 := h.WithTags(StringTag("b", "2"), StringTag("a", "1"))
+
+	// They must both work — record via each.
+	h1.Counter("c").Record(1)
+	h2.Counter("c").Record(1)
+
+	snap := scope.Snapshot()
+	c := snap.Counters()["test.c+a=1,b=2"]
+	require.NotNil(t, c)
+	assert.EqualValues(t, 2, c.Value())
+}
+
+func TestWithTags_ChildCachesAreIndependent(t *testing.T) {
+	scope := tally.NewTestScope("test", map[string]string{})
+	h := NewTallyMetricsHandler(defaultConfig, scope)
+
+	child := h.WithTags(OperationTag("parent_op"))
+	grandchild := child.WithTags(StringTag("env", "dev"))
+
+	// Grandchild should be cached on child, not on root.
+	grandchild2 := child.WithTags(StringTag("env", "dev"))
+	require.Same(t, grandchild, grandchild2)
+
+	// Root should not have the grandchild cached.
+	fromRoot := h.WithTags(StringTag("env", "dev"))
+	require.NotSame(t, grandchild, fromRoot, "child and root caches should be independent")
+}
+
+func TestWithTags_ExcludeTagsStillApply(t *testing.T) {
+	scope := tally.NewTestScope("test", map[string]string{})
+	h := NewTallyMetricsHandler(defaultConfig, scope)
+
+	// "activityType" is in excludeTags with empty allow-list, so any value
+	// should be replaced with tagExcludedValue.
+	tagged := h.WithTags(ActivityTypeTag("MyActivity"))
+	tagged.Counter("hits").Record(1)
+
+	snap := scope.Snapshot()
+	c := snap.Counters()["test.hits+activityType="+tagExcludedValue]
+	require.NotNil(t, c, "excluded tag value should be sanitized")
+	assert.EqualValues(t, 1, c.Value())
+}
+
+func TestWithTags_ConcurrentAccess(t *testing.T) {
+	scope := tally.NewTestScope("test", map[string]string{})
+	h := NewTallyMetricsHandler(defaultConfig, scope)
+
+	const goroutines = 32
+	const iterations = 100
+	var wg sync.WaitGroup
+	handlers := make([]Handler, goroutines)
+
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			var last Handler
+			for j := 0; j < iterations; j++ {
+				last = h.WithTags(OperationTag("concurrent_op"))
+				last.Counter("concurrent_count").Record(1)
+			}
+			handlers[idx] = last
+		}(i)
+	}
+	wg.Wait()
+
+	// All goroutines should have received the same cached handler.
+	for i := 1; i < goroutines; i++ {
+		require.Same(t, handlers[0], handlers[i],
+			"all goroutines should get the same cached handler")
+	}
+
+	snap := scope.Snapshot()
+	c := snap.Counters()["test.concurrent_count+operation=concurrent_op"]
+	require.NotNil(t, c)
+	assert.EqualValues(t, int64(goroutines*iterations), c.Value())
+}
+
+func TestTagsCacheKey(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b []Tag
+		same bool
+	}{
+		{
+			name: "identical single tags",
+			a:    []Tag{{Key: "op", Value: "foo"}},
+			b:    []Tag{{Key: "op", Value: "foo"}},
+			same: true,
+		},
+		{
+			name: "different values",
+			a:    []Tag{{Key: "op", Value: "foo"}},
+			b:    []Tag{{Key: "op", Value: "bar"}},
+			same: false,
+		},
+		{
+			name: "different keys",
+			a:    []Tag{{Key: "op", Value: "x"}},
+			b:    []Tag{{Key: "ns", Value: "x"}},
+			same: false,
+		},
+		{
+			name: "identical multi tags",
+			a:    []Tag{{Key: "a", Value: "1"}, {Key: "b", Value: "2"}},
+			b:    []Tag{{Key: "a", Value: "1"}, {Key: "b", Value: "2"}},
+			same: true,
+		},
+		{
+			name: "different ordering",
+			a:    []Tag{{Key: "a", Value: "1"}, {Key: "b", Value: "2"}},
+			b:    []Tag{{Key: "b", Value: "2"}, {Key: "a", Value: "1"}},
+			same: false,
+		},
+		{
+			name: "single vs multi",
+			a:    []Tag{{Key: "a", Value: "1"}},
+			b:    []Tag{{Key: "a", Value: "1"}, {Key: "b", Value: "2"}},
+			same: false,
+		},
+		{
+			name: "key boundary ambiguity",
+			a:    []Tag{{Key: "ab", Value: "c"}},
+			b:    []Tag{{Key: "a", Value: "bc"}},
+			same: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ka := tagsCacheKey(tt.a)
+			kb := tagsCacheKey(tt.b)
+			if tt.same {
+				require.Equal(t, ka, kb)
+			} else {
+				require.NotEqual(t, ka, kb)
+			}
+		})
+	}
+}
+
+func TestWithTags_ExcludedTagsShareChildHandler(t *testing.T) {
+	scope := tally.NewTestScope("test", map[string]string{})
+	h := NewTallyMetricsHandler(defaultConfig, scope)
+
+	// Different excluded-tag values should produce the same cached child handler,
+	// preventing unbounded childCache growth from high-cardinality excluded tags.
+	h1 := h.WithTags(ActivityTypeTag("TypeA"))
+	h2 := h.WithTags(ActivityTypeTag("TypeB"))
+	h3 := h.WithTags(ActivityTypeTag("TypeC"))
+	require.Same(t, h1, h2, "excluded tag variants should share the same child handler")
+	require.Same(t, h2, h3, "excluded tag variants should share the same child handler")
+
+	// Verify the child handler still records metrics correctly.
+	h1.Counter("hits").Record(1)
+	h2.Counter("hits").Record(2)
+	h3.Counter("hits").Record(4)
+
+	snap := scope.Snapshot()
+	c := snap.Counters()["test.hits+activityType="+tagExcludedValue]
+	require.NotNil(t, c)
+	assert.EqualValues(t, 7, c.Value())
+}
+
+func TestNormalizeTagsForCaching(t *testing.T) {
+	excl := excludeTags{
+		"activityType": {},                        // empty allow-list: exclude all
+		"taskqueue":    {"__sticky__": struct{}{}}, // allow only __sticky__
+	}
+
+	t.Run("no excluded tags returns original slice", func(t *testing.T) {
+		tags := []Tag{{Key: "env", Value: "prod"}}
+		result := normalizeTagsForCaching(tags, excl)
+		require.Same(t, &tags[0], &result[0], "should return the same slice when no normalization needed")
+	})
+
+	t.Run("excluded tag gets normalized", func(t *testing.T) {
+		tags := []Tag{{Key: "activityType", Value: "MyActivity"}}
+		result := normalizeTagsForCaching(tags, excl)
+		require.Equal(t, tagExcludedValue, result[0].Value)
+	})
+
+	t.Run("allowed tag value is not normalized", func(t *testing.T) {
+		tags := []Tag{{Key: "taskqueue", Value: "__sticky__"}}
+		result := normalizeTagsForCaching(tags, excl)
+		require.Same(t, &tags[0], &result[0], "allowed value should not trigger normalization")
+	})
+
+	t.Run("mixed tags normalize only excluded ones", func(t *testing.T) {
+		tags := []Tag{
+			{Key: "env", Value: "prod"},
+			{Key: "activityType", Value: "DoSomething"},
+			{Key: "taskqueue", Value: "non-sticky"},
+		}
+		result := normalizeTagsForCaching(tags, excl)
+		require.Equal(t, "prod", result[0].Value)
+		require.Equal(t, tagExcludedValue, result[1].Value)
+		require.Equal(t, tagExcludedValue, result[2].Value)
+	})
+
+	t.Run("empty excludeTags returns original", func(t *testing.T) {
+		tags := []Tag{{Key: "anything", Value: "val"}}
+		result := normalizeTagsForCaching(tags, nil)
+		require.Same(t, &tags[0], &result[0])
+	})
 }


### PR DESCRIPTION
## Summary

Cache `WithTags()` child handlers in `tallyMetricsHandler` via `sync.Map` to eliminate repeated `tagsToMap()`, `scope.Tagged()`, and handler struct allocations on the hot path. On cache hit: zero allocations.

## Design

- **`childCache`** (`sync.Map`): maps normalized tag cache keys to `*tallyMetricsHandler` children. Uses `LoadOrStore` for safe concurrent access.
- **`normalizeTagsForCaching`**: normalizes excluded tags before cache key computation so high-cardinality excluded values (e.g. `activityType` with thousands of distinct activity names) collapse to a single cache entry, preventing unbounded cache growth. Zero-alloc fast path when no tags need substitution.
- **`tagsCacheKey`**: builds compact `\x00`-separated string keys from tag slices, with a single-tag fast path that avoids byte buffer allocation.
- Empty `WithTags()` calls short-circuit and return `self`.

## Allocation Reduction (pprof alloc_space, 5min ScyllaDB workload)

| Metric | Before | After | Reduction |
|--------|--------|-------|-----------|
| WithTags cumulative | 1,930 MB | 316 MB | -83.6% |
| Total server allocs | 18,030 MB | 16,481 MB | -8.6% |

## Benchmark (omes throughput_stress, mc150, 5 min)

Host networking, i7-1270P 4 cores/component, inter-run data resets:

| Database | Baseline | After | Change |
|----------|----------|-------|--------|
| Cassandra | 280 | 294 | +5.0% |
| ScyllaDB | 290 | 296 | +2.1% |

Note: Throughput variance at mc150 is ~5-10%. The allocation reduction is confirmed by pprof but throughput gains are within noise at this concurrency level.

## Testing

- Cache hit returns same pointer (`require.Same`)
- Different tags return different handlers
- Cached handler records metrics correctly
- Multi-tag caching
- Tag order sensitivity (documented, not normalized)
- Child caches are independent per handler level
- Excluded tags share a single child handler (prevents unbounded growth)
- Concurrent access (32 goroutines × 100 iterations, `-race`)
- `tagsCacheKey` boundary ambiguity prevention
- `normalizeTagsForCaching` unit tests (zero-alloc fast path, excluded, allowed, mixed, empty)
- All existing tests continue to pass