### PR TITLE
fix(scheduler): civil day intervals in IANA timezones (DST)

### DIFF
--- a/docs/gh-issue-10058-body.md
+++ b/docs/gh-issue-10058-body.md
@@ -1,0 +1,28 @@
+## Summary
+
+`IntervalSpec` next-run calculation uses **fixed UTC second alignment** (`((ts-phase)/interval+1)*interval+phase`) and **ignores** `ScheduleSpec.timezone` for day-sized intervals. Schedules that mean “every N **local** days at a fixed local time” therefore **do not track DST** (e.g. US/Pacific: local midnight stays 07:00 UTC in PDT but should move to 08:00 UTC in PST after the fall transition).
+
+`StructuredCalendar` / cron paths already use the loaded `*time.Location`; interval-only schedules do not.
+
+## Reproduction (behavior before fix)
+
+- `ScheduleSpec.timezone` = `America/Los_Angeles` (or any IANA zone with DST).
+- `Interval` = `24h`, `Phase` = `8h` (first tick aligned to `1970-01-01 00:00:00` in that zone, i.e. `time.Unix(8*3600,0)` local representation).
+- Observe `rawNextTime` / `GetNextTime` just after 2018-11-04 local midnight and 2018-11-05 local midnight:
+  - **Before fix:** every tick is `k * 86400` seconds from the same UTC phase (e.g. always `07:00Z` in this setup).
+  - **After fix:** 2018-11-04 `00:00` local is still PDT → `07:00Z`; 2018-11-05 `00:00` local is PST → `08:00Z`.
+
+## Proposed semantics
+
+When `interval` is a positive multiple of `86400` **and** the schedule has a **non-UTC** location, interpret the step as **N whole calendar days** in that location at the same **local** time-of-day as the grid reference `time.Unix(phase mod interval, 0).In(loc)`.
+
+When the location is `UTC` (or unset/empty in a way that resolves to UTC), keep the **existing** fixed-UTC-second behavior for compatibility.
+
+## Non-goals
+
+- `43h` or other non–whole-day intervals: unchanged.
+- This does not try to turn “24h” into “civil 24h” in zone for non-86400-multiple durations.
+
+## Motivation
+
+Common use case: `IntervalSpec` for “every N days or weeks” with an end-user or workspace-scoped IANA time zone, where local wall time should remain stable when DST changes.

--- a/docs/interval-spec-dst-github-issue.md
+++ b/docs/interval-spec-dst-github-issue.md
@@ -1,0 +1,62 @@
+# IntervalSpec + IANA timezone / DST (reference)
+
+**GitHub issue:** https://github.com/temporalio/temporal/issues/10058 (opened with this content).
+
+# GitHub title (used)
+
+`Schedule: IntervalSpec should advance by calendar days in ScheduleSpec timezone (DST)`
+
+
+# Issue body (copy into github.com/temporalio/temporal/issues/new)
+
+## Summary
+
+`IntervalSpec` next-run calculation uses **fixed UTC second alignment** (`((ts-phase)/interval+1)*interval+phase`) and **ignores** `ScheduleSpec.timezone` for day-sized intervals. Schedules that mean “every N **local** days at a fixed local time” therefore **do not track DST** (e.g. US/Pacific: local midnight stays 07:00 UTC in PDT but should move to 08:00 UTC in PST after the fall transition).
+
+`StructuredCalendar` / cron paths already use the loaded `*time.Location`; interval-only schedules do not.
+
+## Reproduction (behavior before fix)
+
+- `ScheduleSpec.timezone` = `America/Los_Angeles` (or any IANA zone with DST).
+- `Interval` = `24h`, `Phase` = `8h` (first tick aligned to `1970-01-01 00:00:00` in that zone, i.e. `time.Unix(8*3600,0)` local representation).
+- Observe `rawNextTime` / `GetNextTime` just after 2018-11-04 local midnight and 2018-11-05 local midnight:
+  - **Before fix:** every tick is `k * 86400` seconds from the same UTC phase (e.g. always `07:00Z` in this setup).
+  - **After fix:** 2018-11-04 `00:00` local is still PDT → `07:00Z`; 2018-11-05 `00:00` local is PST → `08:00Z`.
+
+## Proposed semantics
+
+When `interval` is a positive multiple of `86400` **and** the schedule has a **non-UTC** location, interpret the step as **N whole calendar days** in that location at the same **local** time-of-day as the grid reference `time.Unix(phase mod interval, 0).In(loc)`.
+
+When the location is `UTC` (or unset/empty in a way that resolves to UTC), keep the **existing** fixed-UTC-second behavior for compatibility.
+
+## Non-goals
+
+- `43h` or other non–whole-day intervals: unchanged.
+- This does not try to turn “24h” into “civil 24h” in zone for non-86400-multiple durations.
+
+## Motivation
+
+Common use case: `IntervalSpec` for “every N days or weeks” with an end-user or workspace-scoped IANA time zone, so local wall time should remain stable when DST changes.
+
+---
+
+# PR description (for the implementing PR)
+
+## What
+
+- `service/worker/scheduler/civil_interval.go`: civil Julian day + scan for next local tick.
+- `service/worker/scheduler/spec.go`: `nextIntervalTime` takes `time.Time` and calls `nextCivilIntervalTick` when applicable; otherwise same UTC math as before.
+- `TestSpecIntervalCivilDayUSPacificDST`: 2018-11-04 vs 2018-11-05 local midnights.
+
+## Backward compatibility
+
+- Schedules with **no** IANA offset (UTC-only behavior): **unchanged**.
+- Schedules with a **named** non-UTC zone and **day/week** `Interval` aligned to 86400s: **intentional behavior change** to match wall-clock + DST (calendar semantics).
+
+## Release note
+
+> **Possibly breaking:** `ScheduleSpec.Interval` with a duration of N×24h and a **non-UTC** `ScheduleSpec` timezone now advances on **civil** calendar days in that zone. Previously, such intervals were aligned only to **UTC** 86400s boundaries. Clients that relied on the old UTC grid should set timezone to `UTC` or use calendar/cron for explicit UTC-day scheduling.
+
+---
+
+After merging, you can `gh issue create` / open the PR on https://github.com/temporalio/temporal with the same text.

--- a/docs/pr-body-interval-civil-dst.md
+++ b/docs/pr-body-interval-civil-dst.md
@@ -1,0 +1,20 @@
+Fixes #10058
+
+## What
+
+- `service/worker/scheduler/civil_interval.go`: civil Julian day + scan for the next local tick.
+- `service/worker/scheduler/spec.go`: `nextIntervalTime` takes `time.Time` and uses `nextCivilIntervalTick` when the interval is a whole multiple of 86400s and the schedule has a **non-UTC** `*time.Location`; otherwise the existing UTC-math is unchanged.
+- `TestSpecIntervalCivilDayUSPacificDST`: 2018-11-04 vs 2018-11-05 local midnights in `America/Los_Angeles` (07:00Z then 08:00Z after fall back).
+
+## Backward compatibility
+
+- Schedules that resolve to **UTC** (including explicit `UTC` / empty as today): same behavior as before.
+- Schedules with a **named** non-UTC IANA zone and a **day-sized** (N×24h) interval: **intentional behavior change** so steps follow **civil** calendar days at a fixed local time, observing DST.
+
+## Release note (suggested)
+
+> **Possibly breaking:** `ScheduleSpec.Interval` with a duration of N×24h and a **non-UTC** `ScheduleSpec` timezone now advances on **civil** calendar days in that zone. Previously, such intervals were aligned only to **UTC** 86400s boundaries. Clients that relied on the old UTC grid can set the schedule timezone to `UTC` or use calendar/cron for explicit UTC-day scheduling.
+
+## Motivation
+
+Typical need: `IntervalSpec` for recurring “every N local days or weeks” when the schedule is tied to a user- or org-selected IANA time zone, so local wall time should stay stable across DST changes.

--- a/service/worker/scheduler/civil_interval.go
+++ b/service/worker/scheduler/civil_interval.go
@@ -1,0 +1,78 @@
+package scheduler
+
+import "time"
+
+// gregorianJDN returns the Julian day number for a proleptic Gregorian civil date
+// (year, month=1-12, day) using a standard Hatcher/Fliegel form.
+func gregorianJDN(year, month, day int) int64 {
+	a := (14 - month) / 12
+	y := int64(year) + 4800 - int64(a)
+	m := int64(month) + 12*int64(a) - 3
+	return int64(day) + (153*m+2)/5 + 365*y + y/4 - y/100 + y/400 - 32045
+}
+
+// normalizePhaseInInterval returns phase reduced into [0, interval), matching
+// the math used in nextIntervalTime.
+func normalizePhaseInInterval(phase, interval int64) int64 {
+	if interval < 1 {
+		interval = 1
+	}
+	if phase < 0 {
+		phase = 0
+	}
+	p := phase % interval
+	if p < 0 {
+		p += interval
+	}
+	return p
+}
+
+// nextCivilIntervalTick returns the next Unix time (second resolution) strictly
+// after "after" for an interval that is a multiple of 86400 seconds, interpreted
+// as steps of n whole calendar days in the schedule's timezone, each at the
+// same local time of day as time.Unix(p,0) in that location, where p is
+// phase mod interval (the first tick in [0,interval) aligned to 1970-01-01 UTC+offset).
+// When the location is UTC (or nil), (0, false) is returned so the caller
+// continues to use fixed-UTC-second interval math for backward compatibility.
+func nextCivilIntervalTick(phase, interval int64, after time.Time, loc *time.Location) (int64, bool) {
+	if interval%86400 != 0 || interval < 86400 {
+		return 0, false
+	}
+	if loc == nil || loc == time.UTC {
+		return 0, false
+	}
+	p := normalizePhaseInInterval(phase, interval)
+	nDayStep := interval / 86400
+	if nDayStep < 1 {
+		return 0, false
+	}
+
+	// One tick in the current UTC-math grid is t ≡ p (mod interval). Use
+	// 1970-01-01 00:00:00Z + p as a representative; local time-of-day for all
+	// "same wall clock in zone" series is taken from that instant in loc.
+	ref := time.Unix(p, 0).In(loc)
+	h, m, s := ref.Clock()
+	nsec := ref.Nanosecond()
+	j0 := gregorianJDN(ref.Year(), int(ref.Month()), ref.Day())
+
+	probe := after.Add(1 * time.Nanosecond)
+	if !probe.After(after) {
+		return 0, false
+	}
+	probeLoc := probe.In(loc)
+	day0 := time.Date(probeLoc.Year(), probeLoc.Month(), probeLoc.Day(), 0, 0, 0, 0, loc)
+
+	const maxDayScan = 20000
+	for d := 0; d < maxDayScan; d++ {
+		day := day0.AddDate(0, 0, d)
+		cand := time.Date(day.Year(), day.Month(), day.Day(), h, m, s, nsec, loc)
+		if !cand.After(after) {
+			continue
+		}
+		jc := gregorianJDN(cand.Year(), int(cand.Month()), cand.Day())
+		if (jc-j0)%nDayStep == 0 {
+			return cand.Unix(), true
+		}
+	}
+	return 0, false
+}

--- a/service/worker/scheduler/spec.go
+++ b/service/worker/scheduler/spec.go
@@ -311,9 +311,8 @@ func (cs *CompiledSpec) rawNextTime(after time.Time) (nominal time.Time) {
 		}
 	}
 
-	ts := after.Unix()
 	for _, iv := range cs.spec.Interval {
-		next := cs.nextIntervalTime(iv, ts)
+		next := cs.nextIntervalTime(iv, after)
 		if next < minTimestamp {
 			minTimestamp = next
 		}
@@ -325,8 +324,11 @@ func (cs *CompiledSpec) rawNextTime(after time.Time) (nominal time.Time) {
 	return time.Unix(minTimestamp, 0).UTC()
 }
 
-// Returns the next matching time for a single interval spec.
-func (cs *CompiledSpec) nextIntervalTime(iv *schedulepb.IntervalSpec, ts int64) int64 {
+// Returns the next matching time for a single interval spec. When the interval
+// is a multiple of 86400 seconds and a non-UTC location is set, advance by
+// whole calendar days in that zone (observing DST); otherwise use fixed
+// Unix-second alignment (backwards compatible when timezone is empty/UTC).
+func (cs *CompiledSpec) nextIntervalTime(iv *schedulepb.IntervalSpec, after time.Time) int64 {
 	interval := int64(timestamp.DurationValue(iv.Interval) / time.Second)
 	if interval < 1 {
 		interval = 1
@@ -335,6 +337,10 @@ func (cs *CompiledSpec) nextIntervalTime(iv *schedulepb.IntervalSpec, ts int64) 
 	if phase < 0 {
 		phase = 0
 	}
+	if u, ok := nextCivilIntervalTick(phase, interval, after, cs.tz); ok {
+		return u
+	}
+	ts := after.Unix()
 	return (((ts-phase)/interval)+1)*interval + phase
 }
 

--- a/service/worker/scheduler/spec_test.go
+++ b/service/worker/scheduler/spec_test.go
@@ -494,3 +494,27 @@ func (s *specSuite) TestSpecJitterSeed() {
 		time.Date(2022, 3, 24, 0, 39, 16, 922000000, time.UTC),
 	)
 }
+
+// TestSpecIntervalCivilDayUSPacificDST documents that 24h intervals with a non-UTC
+// schedule timezone step by local calendar day at a fixed local time, so the UTC
+// fire time shifts when DST changes (e.g. US Pacific fall 2018).
+func (s *specSuite) TestSpecIntervalCivilDayUSPacificDST() {
+	la, err := time.LoadLocation("America/Los_Angeles")
+	s.NoError(err)
+	// 8h phase: first grid tick 1970-01-01 00:00:00 in this zone = local midnight of that day.
+	spec := &schedulepb.ScheduleSpec{
+		TimezoneName: "America/Los_Angeles",
+		Interval: []*schedulepb.IntervalSpec{{
+			Interval: durationpb.New(24 * time.Hour),
+			Phase:    durationpb.New(8 * time.Hour),
+		}},
+	}
+	// 2018-11-04: US fall back 2:00am -> 1:00am. Consecutive local midnights: Nov 4 00:00
+	// is still PDT (07:00Z); Nov 5 00:00 is PST (08:00Z).
+	s.checkSequenceRaw(
+		spec,
+		time.Date(2018, 11, 3, 12, 0, 0, 0, la),
+		time.Date(2018, 11, 4, 0, 0, 0, 0, la).UTC(),
+		time.Date(2018, 11, 5, 0, 0, 0, 0, la).UTC(),
+	)
+}


### PR DESCRIPTION
Fixes #10058

## What

- `service/worker/scheduler/civil_interval.go`: civil Julian day + scan for the next local tick.
- `service/worker/scheduler/spec.go`: `nextIntervalTime` takes `time.Time` and uses `nextCivilIntervalTick` when the interval is a whole multiple of 86400s and the schedule has a **non-UTC** `*time.Location`; otherwise the existing UTC-math is unchanged.
- `TestSpecIntervalCivilDayUSPacificDST`: 2018-11-04 vs 2018-11-05 local midnights in `America/Los_Angeles` (07:00Z then 08:00Z after fall back).

## Backward compatibility

- Schedules that resolve to **UTC** (including explicit `UTC` / empty as today): same behavior as before.
- Schedules with a **named** non-UTC IANA zone and a **day-sized** (N×24h) interval: **intentional behavior change** so steps follow **civil** calendar days at a fixed local time, observing DST.

## Release note (suggested)

> **Possibly breaking:** `ScheduleSpec.Interval` with a duration of N×24h and a **non-UTC** `ScheduleSpec` timezone now advances on **civil** calendar days in that zone. Previously, such intervals were aligned only to **UTC** 86400s boundaries. Clients that relied on the old UTC grid can set the schedule timezone to `UTC` or use calendar/cron for explicit UTC-day scheduling.

## Motivation

Typical need: `IntervalSpec` for recurring “every N local days or weeks” when the schedule is tied to a user- or org-selected IANA time zone, so local wall time should stay stable across DST changes.
