### PR TITLE
Cherry-pick: When skipping task queue metadata write, check rangeid instead (#10018)

### DIFF
--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -443,6 +443,33 @@ func (s *BacklogManagerTestSuite) TestApproximateBacklogCount_ResetOnDrained() {
 	s.Zero(totalApproximateBacklogCount(s.blm))
 }
 
+func (s *BacklogManagerTestSuite) TestSyncState_UnloadsOnOwnershipLoss() {
+	if !s.newMatcher {
+		s.T().Skip("SyncState is only used by the new backlog manager")
+	}
+
+	s.cfgcli.OverrideValue(dynamicconfig.MatchingUpdateAckInterval.Key(), 100*time.Millisecond)
+
+	s.blm.Start()
+	defer s.blm.Stop()
+	s.Require().NoError(s.blm.WaitUntilInitialized(context.Background()))
+
+	// physical queue should unload soon
+	var unloadCalled atomic.Bool
+	s.ptqMgr.EXPECT().UnloadFromPartitionManager(unloadCauseConflict).Do(func(unloadCause) {
+		unloadCalled.Store(true)
+	}).AnyTimes()
+
+	// simulate another partition stealing and releasing ownership
+	db := s.blm.getDB()
+	tqd := s.taskMgr.getQueueDataByKey(db.queue)
+	tqd.Lock()
+	tqd.rangeID++
+	tqd.Unlock()
+
+	s.Eventually(unloadCalled.Load, time.Second, 100*time.Millisecond)
+}
+
 func (s *BacklogManagerTestSuite) TestSkipExpiredTasks_AllExpiredThenValid() {
 	s.testSkipExpiredTasks(10, 0, 33, 3)
 }

--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -290,10 +290,31 @@ func (db *taskQueueDB) SyncState(ctx context.Context) error {
 	// persistence TTL, since the scavenger looks for metadata that hasn't been updated in 48 hours.
 	needWrite := db.lastChange.After(db.lastWrite) || time.Since(db.lastWrite) > stickyTaskQueueTTL/2
 	if !needWrite {
-		return nil
+		// If we don't write, though, we wouldn't know if someone else has stolen ownership
+		// momentarily (this could happen due to eventual consistency of membership updates).
+		// So instead, do a (cheaper) read to just check the range id.
+		return db.verifyOwnershipLocked(ctx)
 	}
 
 	return db.updateTaskQueueLocked(ctx, false)
+}
+
+func (db *taskQueueDB) verifyOwnershipLocked(ctx context.Context) error {
+	response, err := db.store.GetTaskQueue(ctx, &persistence.GetTaskQueueRequest{
+		NamespaceID: db.queue.NamespaceId(),
+		TaskQueue:   db.queue.PersistenceName(),
+		TaskType:    db.queue.TaskType(),
+	})
+	if err != nil {
+		return err
+	}
+	if response.RangeID != db.rangeID {
+		return &persistence.ConditionFailedError{
+			Msg: fmt.Sprintf("task queue ownership lost: stored rangeID %d, in-memory rangeID %d",
+				response.RangeID, db.rangeID),
+		}
+	}
+	return nil
 }
 
 func (db *taskQueueDB) updateAckLevelAndBacklogStats(subqueue subqueueIndex, newAckLevel int64, countDelta int64, oldestTime time.Time) {


### PR DESCRIPTION
Cherry-pick of #10018 into `release/v1.31.x` for the v1.31.0 minor release.

Original PR: https://github.com/temporalio/temporal/pull/10018

## Conflicts resolved

`service/matching/backlog_manager_test.go` conflicted — main has an unrelated `TestSkipExpiredTasks` refactor (introducing `taskBlock`/`expiredBlock`/`validBlock` helpers) that this branch lacks.

Resolution: added only the new `TestSyncState_UnloadsOnOwnershipLoss` test (the regression test for this fix) and kept HEAD's existing `TestSkipExpiredTasks_AllExpiredThenValid` signature. The unrelated test refactor was **not** brought across.

Verified: `go vet ./service/matching/...` and `go test -c -o /dev/null ./service/matching/` both pass.