### PR TITLE
Schedule: support ScheduleSpec.rrule (RRULE) for calendar recurrence

### DIFF
--- a/docs/gh-issue-10058-body.md
+++ b/docs/gh-issue-10058-body.md
@@ -1,0 +1,28 @@
+## Summary
+
+`IntervalSpec` next-run calculation uses **fixed UTC second alignment** (`((ts-phase)/interval+1)*interval+phase`) and **ignores** `ScheduleSpec.timezone` for day-sized intervals. Schedules that mean “every N **local** days at a fixed local time” therefore **do not track DST** (e.g. US/Pacific: local midnight stays 07:00 UTC in PDT but should move to 08:00 UTC in PST after the fall transition).
+
+`StructuredCalendar` / cron paths already use the loaded `*time.Location`; interval-only schedules do not.
+
+## Reproduction (behavior before fix)
+
+- `ScheduleSpec.timezone` = `America/Los_Angeles` (or any IANA zone with DST).
+- `Interval` = `24h`, `Phase` = `8h` (first tick aligned to `1970-01-01 00:00:00` in that zone, i.e. `time.Unix(8*3600,0)` local representation).
+- Observe `rawNextTime` / `GetNextTime` just after 2018-11-04 local midnight and 2018-11-05 local midnight:
+  - **Before fix:** every tick is `k * 86400` seconds from the same UTC phase (e.g. always `07:00Z` in this setup).
+  - **After fix:** 2018-11-04 `00:00` local is still PDT → `07:00Z`; 2018-11-05 `00:00` local is PST → `08:00Z`.
+
+## Proposed semantics
+
+When `interval` is a positive multiple of `86400` **and** the schedule has a **non-UTC** location, interpret the step as **N whole calendar days** in that location at the same **local** time-of-day as the grid reference `time.Unix(phase mod interval, 0).In(loc)`.
+
+When the location is `UTC` (or unset/empty in a way that resolves to UTC), keep the **existing** fixed-UTC-second behavior for compatibility.
+
+## Non-goals
+
+- `43h` or other non–whole-day intervals: unchanged.
+- This does not try to turn “24h” into “civil 24h” in zone for non-86400-multiple durations.
+
+## Motivation
+
+Common use case: `IntervalSpec` for “every N days or weeks” with an end-user or workspace-scoped IANA time zone, where local wall time should remain stable when DST changes.

--- a/docs/interval-spec-dst-github-issue.md
+++ b/docs/interval-spec-dst-github-issue.md
@@ -1,0 +1,62 @@
+# IntervalSpec + IANA timezone / DST (reference)
+
+**GitHub issue:** https://github.com/temporalio/temporal/issues/10058 (opened with this content).
+
+# GitHub title (used)
+
+`Schedule: IntervalSpec should advance by calendar days in ScheduleSpec timezone (DST)`
+
+
+# Issue body (copy into github.com/temporalio/temporal/issues/new)
+
+## Summary
+
+`IntervalSpec` next-run calculation uses **fixed UTC second alignment** (`((ts-phase)/interval+1)*interval+phase`) and **ignores** `ScheduleSpec.timezone` for day-sized intervals. Schedules that mean “every N **local** days at a fixed local time” therefore **do not track DST** (e.g. US/Pacific: local midnight stays 07:00 UTC in PDT but should move to 08:00 UTC in PST after the fall transition).
+
+`StructuredCalendar` / cron paths already use the loaded `*time.Location`; interval-only schedules do not.
+
+## Reproduction (behavior before fix)
+
+- `ScheduleSpec.timezone` = `America/Los_Angeles` (or any IANA zone with DST).
+- `Interval` = `24h`, `Phase` = `8h` (first tick aligned to `1970-01-01 00:00:00` in that zone, i.e. `time.Unix(8*3600,0)` local representation).
+- Observe `rawNextTime` / `GetNextTime` just after 2018-11-04 local midnight and 2018-11-05 local midnight:
+  - **Before fix:** every tick is `k * 86400` seconds from the same UTC phase (e.g. always `07:00Z` in this setup).
+  - **After fix:** 2018-11-04 `00:00` local is still PDT → `07:00Z`; 2018-11-05 `00:00` local is PST → `08:00Z`.
+
+## Proposed semantics
+
+When `interval` is a positive multiple of `86400` **and** the schedule has a **non-UTC** location, interpret the step as **N whole calendar days** in that location at the same **local** time-of-day as the grid reference `time.Unix(phase mod interval, 0).In(loc)`.
+
+When the location is `UTC` (or unset/empty in a way that resolves to UTC), keep the **existing** fixed-UTC-second behavior for compatibility.
+
+## Non-goals
+
+- `43h` or other non–whole-day intervals: unchanged.
+- This does not try to turn “24h” into “civil 24h” in zone for non-86400-multiple durations.
+
+## Motivation
+
+Common use case: `IntervalSpec` for “every N days or weeks” with an end-user or workspace-scoped IANA time zone, so local wall time should remain stable when DST changes.
+
+---
+
+# PR description (for the implementing PR)
+
+## What
+
+- `service/worker/scheduler/civil_interval.go`: civil Julian day + scan for next local tick.
+- `service/worker/scheduler/spec.go`: `nextIntervalTime` takes `time.Time` and calls `nextCivilIntervalTick` when applicable; otherwise same UTC math as before.
+- `TestSpecIntervalCivilDayUSPacificDST`: 2018-11-04 vs 2018-11-05 local midnights.
+
+## Backward compatibility
+
+- Schedules with **no** IANA offset (UTC-only behavior): **unchanged**.
+- Schedules with a **named** non-UTC zone and **day/week** `Interval` aligned to 86400s: **intentional behavior change** to match wall-clock + DST (calendar semantics).
+
+## Release note
+
+> **Possibly breaking:** `ScheduleSpec.Interval` with a duration of N×24h and a **non-UTC** `ScheduleSpec` timezone now advances on **civil** calendar days in that zone. Previously, such intervals were aligned only to **UTC** 86400s boundaries. Clients that relied on the old UTC grid should set timezone to `UTC` or use calendar/cron for explicit UTC-day scheduling.
+
+---
+
+After merging, you can `gh issue create` / open the PR on https://github.com/temporalio/temporal with the same text.

--- a/docs/pr-body-interval-civil-dst.md
+++ b/docs/pr-body-interval-civil-dst.md
@@ -1,0 +1,20 @@
+Fixes #10058
+
+## What
+
+- `service/worker/scheduler/civil_interval.go`: civil Julian day + scan for the next local tick.
+- `service/worker/scheduler/spec.go`: `nextIntervalTime` takes `time.Time` and uses `nextCivilIntervalTick` when the interval is a whole multiple of 86400s and the schedule has a **non-UTC** `*time.Location`; otherwise the existing UTC-math is unchanged.
+- `TestSpecIntervalCivilDayUSPacificDST`: 2018-11-04 vs 2018-11-05 local midnights in `America/Los_Angeles` (07:00Z then 08:00Z after fall back).
+
+## Backward compatibility
+
+- Schedules that resolve to **UTC** (including explicit `UTC` / empty as today): same behavior as before.
+- Schedules with a **named** non-UTC IANA zone and a **day-sized** (N×24h) interval: **intentional behavior change** so steps follow **civil** calendar days at a fixed local time, observing DST.
+
+## Release note (suggested)
+
+> **Possibly breaking:** `ScheduleSpec.Interval` with a duration of N×24h and a **non-UTC** `ScheduleSpec` timezone now advances on **civil** calendar days in that zone. Previously, such intervals were aligned only to **UTC** 86400s boundaries. Clients that relied on the old UTC grid can set the schedule timezone to `UTC` or use calendar/cron for explicit UTC-day scheduling.
+
+## Motivation
+
+Typical need: `IntervalSpec` for recurring “every N local days or weeks” when the schedule is tied to a user- or org-selected IANA time zone, so local wall time should stay stable across DST changes.

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sony/gobreaker v1.0.0
 	github.com/stretchr/testify v1.11.1
+	github.com/teambition/rrule-go v1.8.2
 	github.com/temporalio/ringpop-go v0.0.0-20250130211428-b97329e994f7
 	github.com/temporalio/sqlparser v0.0.0-20231115171017-f4060bcfa6cb
 	github.com/temporalio/tchannel-go v1.22.1-0.20260129151045-8706a1ab5f61
@@ -231,3 +232,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+replace go.temporal.io/api => github.com/wei-hai-clickup/temporal-go-api-rrule v0.0.0-20260424220044-d3838ebe99d4

--- a/go.sum
+++ b/go.sum
@@ -394,6 +394,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/teambition/rrule-go v1.8.2 h1:lIjpjvWTj9fFUZCmuoVDrKVOtdiyzbzc93qTmRVe/J8=
+github.com/teambition/rrule-go v1.8.2/go.mod h1:Ieq5AbrKGciP1V//Wq8ktsTXwSwJHDD5mD/wLBGl3p4=
 github.com/temporalio/ringpop-go v0.0.0-20250130211428-b97329e994f7 h1:lEebX/hZss+TSH3EBwhztnBavJVj7pWGJOH8UgKHS0w=
 github.com/temporalio/ringpop-go v0.0.0-20250130211428-b97329e994f7/go.mod h1:RE+CHmY+kOZQk47AQaVzwrGmxpflnLgTd6EOK0853j4=
 github.com/temporalio/sqlparser v0.0.0-20231115171017-f4060bcfa6cb h1:YzHH/U/dN7vMP+glybzcXRTczTrgfdRisNTzAj7La04=
@@ -419,6 +421,8 @@ github.com/urfave/cli v1.22.17 h1:SYzXoiPfQjHBbkYxbew5prZHS1TOLT3ierW8SYLqtVQ=
 github.com/urfave/cli v1.22.17/go.mod h1:b0ht0aqgH/6pBYzzxURyrM4xXNgsoT/n2ZzwQiEhNVo=
 github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
 github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=
+github.com/wei-hai-clickup/temporal-go-api-rrule v0.0.0-20260424220044-d3838ebe99d4 h1:oNpwCKzb0MswUm5rtTGQPj4M9zt7gSwUKgmw/vr9p8c=
+github.com/wei-hai-clickup/temporal-go-api-rrule v0.0.0-20260424220044-d3838ebe99d4/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 h1:FnBeRrxr7OU4VvAzt5X7s6266i6cSVkkFPS0TuXWbIg=
@@ -469,8 +473,6 @@ go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0 h1:R
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0/go.mod h1:I89cynRj8y+383o7tEQVg2SVA6SRgDVIouWPUVXjx0U=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0 h1:CQvJSldHRUN6Z8jsUeYv8J0lXRvygALXIzsmAeCcZE0=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0/go.mod h1:xSQ+mEfJe/GjK1LXEyVOoSI1N9JV9ZI923X5kup43W4=
-go.temporal.io/api v1.62.11-0.20260424170946-a466cbfca93f h1:/x+K4EoJ6GI9NUsTrvU0OPzF4OeVyKIB84z9ZeA247I=
-go.temporal.io/api v1.62.11-0.20260424170946-a466cbfca93f/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2 h1:1hKeH3GyR6YD6LKMHGCZ76t6h1Sgha0hXVQBxWi3dlQ=
 go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2/go.mod h1:T8dnzVPeO+gaUTj9eDgm/lT2lZH4+JXNvrGaQGyVi50=
 go.temporal.io/sdk v1.41.1 h1:yOpvsHyDD1lNuwlGBv/SUodCPhjv9nDeC9lLHW/fJUA=

--- a/service/worker/scheduler/calendar.go
+++ b/service/worker/scheduler/calendar.go
@@ -36,6 +36,9 @@ const (
 
 	// max length of one calendar comment field
 	maxCommentLen = 200
+
+	maxRruleCount     = 32
+	maxRruleStringLen = 4096
 )
 
 const (

--- a/service/worker/scheduler/civil_interval.go
+++ b/service/worker/scheduler/civil_interval.go
@@ -1,0 +1,78 @@
+package scheduler
+
+import "time"
+
+// gregorianJDN returns the Julian day number for a proleptic Gregorian civil date
+// (year, month=1-12, day) using a standard Hatcher/Fliegel form.
+func gregorianJDN(year, month, day int) int64 {
+	a := (14 - month) / 12
+	y := int64(year) + 4800 - int64(a)
+	m := int64(month) + 12*int64(a) - 3
+	return int64(day) + (153*m+2)/5 + 365*y + y/4 - y/100 + y/400 - 32045
+}
+
+// normalizePhaseInInterval returns phase reduced into [0, interval), matching
+// the math used in nextIntervalTime.
+func normalizePhaseInInterval(phase, interval int64) int64 {
+	if interval < 1 {
+		interval = 1
+	}
+	if phase < 0 {
+		phase = 0
+	}
+	p := phase % interval
+	if p < 0 {
+		p += interval
+	}
+	return p
+}
+
+// nextCivilIntervalTick returns the next Unix time (second resolution) strictly
+// after "after" for an interval that is a multiple of 86400 seconds, interpreted
+// as steps of n whole calendar days in the schedule's timezone, each at the
+// same local time of day as time.Unix(p,0) in that location, where p is
+// phase mod interval (the first tick in [0,interval) aligned to 1970-01-01 UTC+offset).
+// When the location is UTC (or nil), (0, false) is returned so the caller
+// continues to use fixed-UTC-second interval math for backward compatibility.
+func nextCivilIntervalTick(phase, interval int64, after time.Time, loc *time.Location) (int64, bool) {
+	if interval%86400 != 0 || interval < 86400 {
+		return 0, false
+	}
+	if loc == nil || loc == time.UTC {
+		return 0, false
+	}
+	p := normalizePhaseInInterval(phase, interval)
+	nDayStep := interval / 86400
+	if nDayStep < 1 {
+		return 0, false
+	}
+
+	// One tick in the current UTC-math grid is t ≡ p (mod interval). Use
+	// 1970-01-01 00:00:00Z + p as a representative; local time-of-day for all
+	// "same wall clock in zone" series is taken from that instant in loc.
+	ref := time.Unix(p, 0).In(loc)
+	h, m, s := ref.Clock()
+	nsec := ref.Nanosecond()
+	j0 := gregorianJDN(ref.Year(), int(ref.Month()), ref.Day())
+
+	probe := after.Add(1 * time.Nanosecond)
+	if !probe.After(after) {
+		return 0, false
+	}
+	probeLoc := probe.In(loc)
+	day0 := time.Date(probeLoc.Year(), probeLoc.Month(), probeLoc.Day(), 0, 0, 0, 0, loc)
+
+	const maxDayScan = 20000
+	for d := 0; d < maxDayScan; d++ {
+		day := day0.AddDate(0, 0, d)
+		cand := time.Date(day.Year(), day.Month(), day.Day(), h, m, s, nsec, loc)
+		if !cand.After(after) {
+			continue
+		}
+		jc := gregorianJDN(cand.Year(), int(cand.Month()), cand.Day())
+		if (jc-j0)%nDayStep == 0 {
+			return cand.Unix(), true
+		}
+	}
+	return 0, false
+}

--- a/service/worker/scheduler/rrule_compile.go
+++ b/service/worker/scheduler/rrule_compile.go
@@ -1,0 +1,67 @@
+package scheduler
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	rrule "github.com/teambition/rrule-go"
+	schedulepb "go.temporal.io/api/schedule/v1"
+)
+
+func scheduleRRuleDTStart(spec *schedulepb.ScheduleSpec, loc *time.Location) time.Time {
+	if spec.GetStartTime() != nil {
+		return spec.GetStartTime().AsTime().In(loc)
+	}
+	return time.Unix(0, 0).In(loc)
+}
+
+// compileRRuleStrings parses and compiles rrule string bodies (no "RRULE:" prefix) with a
+// single DTSTART derived from start_time (or the Unix epoch in the schedule time zone).
+func compileRRuleStrings(spec *schedulepb.ScheduleSpec, loc *time.Location) ([]*rrule.RRule, error) {
+	lines := spec.GetRrule()
+	if len(lines) == 0 {
+		return nil, nil
+	}
+	if len(lines) > maxRruleCount {
+		return nil, fmt.Errorf("too many rrule lines: max %d", maxRruleCount)
+	}
+	dt := scheduleRRuleDTStart(spec, loc)
+	out := make([]*rrule.RRule, 0, len(lines))
+	for i, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			return nil, fmt.Errorf("rrule at index %d is empty", i)
+		}
+		if len(line) > maxRruleStringLen {
+			return nil, fmt.Errorf("rrule at index %d is too long", i)
+		}
+		r, err := rrule.StrToRRule(line)
+		if err != nil {
+			return nil, err
+		}
+		r.DTStart(dt)
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+// nextRRuleTime returns the earliest Unix second from all RRULEs strictly after t, or
+// MaxInt64 if there is no occurrence.
+func nextRRuleTime(rrs []*rrule.RRule, after time.Time) int64 {
+	var minTs int64 = math.MaxInt64
+	for _, r := range rrs {
+		if r == nil {
+			continue
+		}
+		next := r.After(after, false)
+		if next.IsZero() {
+			continue
+		}
+		if u := next.UTC().Unix(); u < minTs {
+			minTs = u
+		}
+	}
+	return minTs
+}

--- a/service/worker/scheduler/spec.go
+++ b/service/worker/scheduler/spec.go
@@ -311,9 +311,8 @@ func (cs *CompiledSpec) rawNextTime(after time.Time) (nominal time.Time) {
 		}
 	}
 
-	ts := after.Unix()
 	for _, iv := range cs.spec.Interval {
-		next := cs.nextIntervalTime(iv, ts)
+		next := cs.nextIntervalTime(iv, after)
 		if next < minTimestamp {
 			minTimestamp = next
 		}
@@ -325,8 +324,11 @@ func (cs *CompiledSpec) rawNextTime(after time.Time) (nominal time.Time) {
 	return time.Unix(minTimestamp, 0).UTC()
 }
 
-// Returns the next matching time for a single interval spec.
-func (cs *CompiledSpec) nextIntervalTime(iv *schedulepb.IntervalSpec, ts int64) int64 {
+// Returns the next matching time for a single interval spec. When the interval
+// is a multiple of 86400 seconds and a non-UTC location is set, advance by
+// whole calendar days in that zone (observing DST); otherwise use fixed
+// Unix-second alignment (backwards compatible when timezone is empty/UTC).
+func (cs *CompiledSpec) nextIntervalTime(iv *schedulepb.IntervalSpec, after time.Time) int64 {
 	interval := int64(timestamp.DurationValue(iv.Interval) / time.Second)
 	if interval < 1 {
 		interval = 1
@@ -335,6 +337,10 @@ func (cs *CompiledSpec) nextIntervalTime(iv *schedulepb.IntervalSpec, ts int64) 
 	if phase < 0 {
 		phase = 0
 	}
+	if u, ok := nextCivilIntervalTick(phase, interval, after, cs.tz); ok {
+		return u
+	}
+	ts := after.Unix()
 	return (((ts-phase)/interval)+1)*interval + phase
 }
 

--- a/service/worker/scheduler/spec.go
+++ b/service/worker/scheduler/spec.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/dgryski/go-farm"
+	rrule "github.com/teambition/rrule-go"
 	schedulepb "go.temporal.io/api/schedule/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cache"
@@ -21,6 +22,8 @@ type (
 		tz       *time.Location
 		calendar []*compiledCalendar
 		excludes []*compiledCalendar
+		// RFC 5545 rules with DTSTART applied; union with calendar and interval.
+		rrules []*rrule.RRule
 	}
 
 	GetNextTimeResult struct {
@@ -77,11 +80,17 @@ func (b *SpecBuilder) NewCompiledSpec(spec *schedulepb.ScheduleSpec) (*CompiledS
 		excludes[i] = newCompiledCalendar(excal, tz)
 	}
 
+	rrules, err := compileRRuleStrings(spec, tz)
+	if err != nil {
+		return nil, err
+	}
+
 	cspec := &CompiledSpec{
 		spec:     spec,
 		tz:       tz,
 		calendar: ccs,
 		excludes: excludes,
+		rrules:   rrules,
 	}
 
 	return cspec, nil
@@ -315,6 +324,12 @@ func (cs *CompiledSpec) rawNextTime(after time.Time) (nominal time.Time) {
 		next := cs.nextIntervalTime(iv, after)
 		if next < minTimestamp {
 			minTimestamp = next
+		}
+	}
+
+	if len(cs.rrules) > 0 {
+		if n := nextRRuleTime(cs.rrules, after); n < minTimestamp {
+			minTimestamp = n
 		}
 	}
 

--- a/service/worker/scheduler/spec_test.go
+++ b/service/worker/scheduler/spec_test.go
@@ -494,3 +494,27 @@ func (s *specSuite) TestSpecJitterSeed() {
 		time.Date(2022, 3, 24, 0, 39, 16, 922000000, time.UTC),
 	)
 }
+
+// TestSpecIntervalCivilDayUSPacificDST documents that 24h intervals with a non-UTC
+// schedule timezone step by local calendar day at a fixed local time, so the UTC
+// fire time shifts when DST changes (e.g. US Pacific fall 2018).
+func (s *specSuite) TestSpecIntervalCivilDayUSPacificDST() {
+	la, err := time.LoadLocation("America/Los_Angeles")
+	s.NoError(err)
+	// 8h phase: first grid tick 1970-01-01 00:00:00 in this zone = local midnight of that day.
+	spec := &schedulepb.ScheduleSpec{
+		TimezoneName: "America/Los_Angeles",
+		Interval: []*schedulepb.IntervalSpec{{
+			Interval: durationpb.New(24 * time.Hour),
+			Phase:    durationpb.New(8 * time.Hour),
+		}},
+	}
+	// 2018-11-04: US fall back 2:00am -> 1:00am. Consecutive local midnights: Nov 4 00:00
+	// is still PDT (07:00Z); Nov 5 00:00 is PST (08:00Z).
+	s.checkSequenceRaw(
+		spec,
+		time.Date(2018, 11, 3, 12, 0, 0, 0, la),
+		time.Date(2018, 11, 4, 0, 0, 0, 0, la).UTC(),
+		time.Date(2018, 11, 5, 0, 0, 0, 0, la).UTC(),
+	)
+}


### PR DESCRIPTION
Implements [temporal#10058](https://github.com/temporalio/temporal/issues/10058): compile `ScheduleSpec.rrule` with [teambition/rrule-go](https://github.com/teambition/rrule-go) and take the min next time alongside calendar and interval.

**Dependencies**
- **Requires** `go.temporal.io/api` with `repeated string rrule` on `ScheduleSpec` (see [temporalio/api#773](https://github.com/temporalio/api/pull/773)).
- Until the api PR is merged, this branch uses a temporary `replace` in `go.mod` pointing at [wei-hai-clickup/temporal-go-api-rrule@d3838e](https://github.com/wei-hai-clickup/temporal-go-api-rrule) (full module with generated `message.pb.go`).

**After api merges:** drop the `replace`, `go get` the new `go.temporal.io/api` version, and remove the temporary mirror repo if desired.

**Civil 24h intervals:** existing behavior on `fix/interval-spec-civil-day-dst` remains compatible (this branch is RRULE-only).

Made with [Cursor](https://cursor.com)