### PR TITLE
Cherry-pick: Update alpine to v3.23.4 (#10068)

### DIFF
--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -38,7 +38,7 @@ variable "TAG_LATEST" {
 # NOTE: We use just the tag without a digest pin because digest-pinned manifest lists
 # cause platform resolution issues in multi-arch buildx builds (InvalidBaseImagePlatform warnings).
 variable "ALPINE_TAG" {
-  default = "3.23.3"
+  default = "3.23.4"
 }
 
 target "admin-tools" {


### PR DESCRIPTION
Cherry-pick of #10068 (originally targeting `release/v1.30.x`) into `release/v1.31.x` for the v1.31.0 minor release.

Original PR: https://github.com/temporalio/temporal/pull/10068

## Conflicts resolved

On 1.31.x the Alpine tag is centralized in `docker/docker-bake.hcl` (single source of truth via the `ALPINE_TAG` variable); the Dockerfiles and workflow/action files consume it rather than hard-coding a default. The 1.30.x PR also updated local defaults in those 4 files, but those structural changes don't apply here.

- `docker/docker-bake.hcl` — auto-merged cleanly (3.23.3 → 3.23.4). ✅
- `docker/targets/server.Dockerfile` — kept HEAD (consumes ARG from bake var; no local default needed).
- `docker/targets/admin-tools.Dockerfile` — kept HEAD (same reason).
- `.github/actions/build-docker-images/action.yml` — kept HEAD (input default is empty string; resolves from bake var).
- `.github/workflows/docker-build-manual.yml` — kept HEAD (optional override; empty means use bake default).

Net change: one-line bump in `docker/docker-bake.hcl`.