### PR TITLE
Don't consider busy workflow as an error during replication validation.

### DIFF
--- a/service/worker/migration/activities.go
+++ b/service/worker/migration/activities.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	replicationpb "go.temporal.io/api/replication/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
@@ -873,7 +874,7 @@ func (a *activities) verifySingleReplicationTask(
 	})
 	a.forceReplicationMetricsHandler.Timer(metrics.VerifyDescribeMutableStateLatency.Name()).Record(time.Since(s))
 
-	switch err.(type) {
+	switch e := err.(type) {
 	case nil:
 		result, err := a.workflowVerifier(ctx, request, remotAdminClient, a.adminClient, ns, execution, mu)
 		if err == nil && result.status == verified {
@@ -891,6 +892,18 @@ func (a *activities) verifySingleReplicationTask(
 		return verifyResult{
 			status: notVerified,
 		}, temporal.NewNonRetryableApplicationError("failed to describe workflow from the remote cluster", "NamespaceNotFound", err)
+
+	case *serviceerror.ResourceExhausted:
+		if e.Cause == enumspb.RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW {
+			// The passive cluster holds the workflow cache lock while applying history
+			// during SyncWorkflowStateTask. This is actually a small sign of progress.
+			return verifyResult{status: notVerified}, nil
+		}
+		a.forceReplicationMetricsHandler.WithTags(metrics.NamespaceTag(request.Namespace), metrics.ServiceErrorTypeTag(err)).
+			Counter(metrics.VerifyReplicationTaskFailed.Name()).Record(1)
+		return verifyResult{
+			status: notVerified,
+		}, fmt.Errorf("failed to describe workflow from the remote cluster: %w", err)
 
 	default:
 		a.forceReplicationMetricsHandler.WithTags(metrics.NamespaceTag(request.Namespace), metrics.ServiceErrorTypeTag(err)).

--- a/service/worker/migration/activities_test.go
+++ b/service/worker/migration/activities_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	replicationpb "go.temporal.io/api/replication/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
@@ -418,6 +419,23 @@ func (s *activitiesSuite) Test_verifySingleReplicationTask() {
 	})).Return(completeState, nil).AnyTimes()
 
 	result, err = s.a.verifySingleReplicationTask(ctx, &request, s.mockRemoteAdminClient, &testNamespace, request.Executions[1])
+	s.NoError(err)
+	s.False(result.isVerified())
+
+	// Test busy workflow — treated as not-yet-replicated, not an error
+	s.mockRemoteAdminClient.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&adminservice.DescribeMutableStateRequest{
+		Namespace: mockedNamespace,
+		Execution: &commonpb.WorkflowExecution{
+			WorkflowId: execution1.BusinessID,
+			RunId:      execution1.RunID,
+		},
+		Archetype:       chasm.WorkflowArchetype,
+		ArchetypeId:     execution1.ArchetypeID,
+		SkipForceReload: true,
+	})).Return(nil, &serviceerror.ResourceExhausted{
+		Cause: enumspb.RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW,
+	}).Times(1)
+	result, err = s.a.verifySingleReplicationTask(ctx, &request, s.mockRemoteAdminClient, &testNamespace, request.Executions[0])
 	s.NoError(err)
 	s.False(result.isVerified())
 }


### PR DESCRIPTION
## What changed?
Stop considering `RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW` as an error during validation.

## Why?
It will happen often as the workflow lock is taken while applying history. Just allow the loop to continue rather than failing the activity.

## How did you test it?
- [x] added new unit test(s)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, scoped change to migration verification error handling; main risk is masking unexpected `ResourceExhausted` variants, but the special-case is limited to the explicit `BUSY_WORKFLOW` cause and is covered by a unit test.
> 
> **Overview**
> Updates replication validation to treat `serviceerror.ResourceExhausted` with cause `RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW` as a transient *not-yet-replicated* state (returning `notVerified` without failing), instead of counting it as a validation error.
> 
> Adds a unit test in `activities_test.go` covering the busy-workflow path to ensure validation continues looping rather than erroring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a6efe5c902bc8669a3e6d69bdbe7a378ca42f5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->