### PR TITLE
Cherry-pick: also check for initialization errors of the dbq for ephemeralDataChanged (#9765)

### DIFF
--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -1394,7 +1394,9 @@ func (pm *taskQueuePartitionManagerImpl) ephemeralDataChanged(data *taskqueuespb
 	// for now, only sticky partitions act on ephemeral data, normal partitions ignore it.
 	if pm.partition.Kind() != enumspb.TASK_QUEUE_KIND_STICKY {
 		return
-	} else if !pm.defaultQueueFuture.Ready() {
+	}
+	dbq, err := pm.defaultQueueFuture.GetIfReady()
+	if err != nil {
 		return // not initialized yet
 	}
 
@@ -1424,7 +1426,6 @@ func (pm *taskQueuePartitionManagerImpl) ephemeralDataChanged(data *taskqueuespb
 		pqm.UpdateRemotePriorityBacklogs(updates[key])
 	}
 
-	dbq := pm.defaultQueue()
 	if dbq != nil {
 		update(PhysicalTaskQueueVersion{}, dbq)
 	}


### PR DESCRIPTION
Cherry-pick of #9765 into `release/v1.31.x` for the v1.31.0 minor release.

Original PR: https://github.com/temporalio/temporal/pull/9765

Clean cherry-pick (single file, no conflicts). Verified with `go build ./service/matching/...`.