### PR TITLE
CHASM: Enable by default

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2877,7 +2877,7 @@ Requires service restart to take effect.`,
 
 	EnableChasm = NewNamespaceBoolSetting(
 		"history.enableChasm",
-		false,
+		true,
 		"Use real chasm tree implementation instead of the noop one",
 	)
 

--- a/tests/schedule_migration_test.go
+++ b/tests/schedule_migration_test.go
@@ -1193,6 +1193,9 @@ func TestScheduleMigrationV1ToV2NoDuplicateRecentActions(t *testing.T) {
 	}
 	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 
+	// Disable CHASM to create V1 schedule.
+	env.OverrideDynamicConfig(dynamicconfig.EnableChasm, false)
+
 	// Create a V1 schedule with an immediate trigger.
 	sched := &schedulepb.Schedule{
 		Spec: &schedulepb.ScheduleSpec{


### PR DESCRIPTION
## What changed?
- Enable chasm framework by default

## Why?
- Avoid potential downgrade issues in future releases which have application on top of CHASM enabled by default

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- Only chasm framework is enabled, but not any application on top of it so the change should be a noop.
