### PR TITLE
Set EnableCHASMCallbacks to true by default

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2910,7 +2910,7 @@ to the CHASM (V2) implementation on active scheduler workflows.`,
 
 	EnableCHASMCallbacks = NewNamespaceBoolSetting(
 		"history.enableCHASMCallbacks",
-		false,
+		true,
 		`Controls whether new callbacks are created using the CHASM implementation
 instead of the previous HSM backed implementation.`,
 	)


### PR DESCRIPTION
## What changed?
Change default setting for CHASM callbacks to true.

## Why?
CHASM is enabled by default so we can enable chasm backed callbacks too.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Minimal, this has been running in production for a few months now without issues.
