### PR TITLE
Cherry-pick: CHASM: Enable by default (#10083)

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2830,7 +2830,7 @@ that task will be sent to DLQ.`,
 
 	EnableChasm = NewNamespaceBoolSetting(
 		"history.enableChasm",
-		false,
+		true,
 		"Use real chasm tree implementation instead of the noop one",
 	)
 

--- a/tests/schedule_migration_test.go
+++ b/tests/schedule_migration_test.go
@@ -1193,6 +1193,9 @@ func TestScheduleMigrationV1ToV2NoDuplicateRecentActions(t *testing.T) {
 	}
 	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 
+	// Disable CHASM to create V1 schedule.
+	env.OverrideDynamicConfig(dynamicconfig.EnableChasm, false)
+
 	// Create a V1 schedule with an immediate trigger.
 	sched := &schedulepb.Schedule{
 		Spec: &schedulepb.ScheduleSpec{


### PR DESCRIPTION
Cherry-pick of #10083 into `release/v1.31.x` for the v1.31.0 minor release.

Original PR: https://github.com/temporalio/temporal/pull/10083

Auto-merged in `common/dynamicconfig/constants.go`; no manual conflict resolution needed. Verified with `go build ./...`.