### PR TITLE
matching: dispatch highest-priority backlog tasks first on cold start

### DIFF
--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -444,6 +444,106 @@ func (s *BacklogManagerTestSuite) TestApproximateBacklogCount_ResetOnDrained() {
 	s.Zero(totalApproximateBacklogCount(s.blm))
 }
 
+// TestPriorityOrdering_ColdStartLoadsHighPriorityFirst verifies that when a
+// partition cold-starts against an existing on-disk backlog containing both
+// low- and high-priority tasks, the very first task handed to the matcher is
+// the highest-priority one.
+//
+// Scenario: low-priority (P5) tasks were spooled before high-priority (P1)
+// tasks, so persistence ends up with subqueues in order [default(P3), P5, P1].
+// On cold start, each subqueue reader currently primes its own pump on
+// Start(), so the lowest-priority subqueue's reader (started first because of
+// persistence order) ends up populating the matcher before higher-priority
+// readers — and the first dispatch is P5 instead of P1.
+func (s *BacklogManagerTestSuite) TestPriorityOrdering_ColdStartLoadsHighPriorityFirst() {
+	if !s.newMatcher || s.fairness {
+		s.T().Skip("only for priority backlog manager")
+	}
+
+	// Single AddSpooledTask interceptor; only capture during phase 2 so that
+	// phase-1 bypass-path deliveries don't pollute the captured order.
+	var captureEnabled atomic.Bool
+	s.ptqMgr.EXPECT().AddSpooledTask(gomock.Any()).DoAndReturn(func(t *internalTask) error {
+		if captureEnabled.Load() {
+			s.capturedTasksLock.Lock()
+			defer s.capturedTasksLock.Unlock()
+			s.capturedTasksSlice = append(s.capturedTasksSlice, t)
+		}
+		return nil
+	}).AnyTimes()
+
+	// Phase 1: populate persistence by spooling P5 tasks first, then P1 tasks.
+	// SpoolTask -> AllocateSubqueue is FCFS, so subqueues land in persistence
+	// in the order [default(P3), P5, P1].
+	s.blm.Start()
+	s.Require().NoError(s.blm.WaitUntilInitialized(context.Background()))
+
+	const numEach = 3
+	for range numEach {
+		s.Require().NoError(s.blm.SpoolTask(&persistencespb.TaskInfo{
+			ExpiryTime: timestamp.TimeNowPtrUtcAddSeconds(3000),
+			CreateTime: timestamp.TimeNowPtrUtc(),
+			Priority:   &commonpb.Priority{PriorityKey: 5},
+		}))
+	}
+	for range numEach {
+		s.Require().NoError(s.blm.SpoolTask(&persistencespb.TaskInfo{
+			ExpiryTime: timestamp.TimeNowPtrUtcAddSeconds(3000),
+			CreateTime: timestamp.TimeNowPtrUtc(),
+			Priority:   &commonpb.Priority{PriorityKey: 1},
+		}))
+	}
+
+	// Tear down phase 1 fully so its goroutines don't interfere with phase 2.
+	s.blm.Stop()
+	s.cancelCtx()
+
+	// Phase 2: cold-start a fresh backlog manager against the persisted state.
+	// This is the path exercised when a partition is reloaded onto a host —
+	// the readers must load the backlog from persistence, which is exactly
+	// where the priority-ordering bug lives.
+	tlCfg := newTaskQueueConfig(
+		s.ptqMgr.QueueKey().Partition().TaskQueue(),
+		NewConfig(s.cfgcol),
+		"test-namespace",
+	)
+	freshCtx, cancelFresh := context.WithCancel(context.Background())
+	defer cancelFresh()
+
+	freshBlm := newPriBacklogManager(
+		freshCtx,
+		s.ptqMgr,
+		tlCfg,
+		s.taskMgr,
+		s.logger,
+		s.logger,
+		nil,
+		metrics.NoopMetricsHandler,
+		false,
+	)
+
+	captureEnabled.Store(true)
+	freshBlm.Start()
+	defer freshBlm.Stop()
+	s.Require().NoError(freshBlm.WaitUntilInitialized(context.Background()))
+
+	s.Require().Eventually(func() bool {
+		return s.capturedTasksLen() >= 2*numEach
+	}, 5*time.Second, 10*time.Millisecond,
+		"timed out waiting for backlog to be re-loaded after cold start")
+
+	captured := s.capturedTasks()
+	priorities := make([]int32, len(captured))
+	for i, t := range captured {
+		priorities[i] = t.getPriority().GetPriorityKey()
+	}
+	s.T().Logf("cold-start delivery order: %v", priorities)
+
+	s.Equal(int32(1), priorities[0],
+		"first task delivered to the matcher should be P1 (highest priority); "+
+			"got P%d. Full delivery order: %v", priorities[0], priorities)
+}
+
 type taskBlock struct {
 	count   int
 	expired bool

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -4820,6 +4820,10 @@ type testQueueData struct {
 	info     *persistencespb.TaskQueueInfo
 	tasks    treemap.Map
 	userData *persistencespb.VersionedTaskQueueUserData
+	// taskSubqueue maps TaskId to subqueue index. Tasks without an entry are treated
+	// as subqueue 0 so single-subqueue tests that don't set CreateTasksRequest.Subqueues
+	// keep working.
+	taskSubqueue map[int64]int
 
 	testQueuePersistenceStats
 }
@@ -4834,7 +4838,10 @@ type testQueuePersistenceStats struct {
 }
 
 func newTestQueueData() *testQueueData {
-	return &testQueueData{tasks: *newFairLevelTreeMap()}
+	return &testQueueData{
+		tasks:        *newFairLevelTreeMap(),
+		taskSubqueue: make(map[int64]int),
+	}
 }
 
 func (q *testQueueData) String() string {
@@ -5066,8 +5073,11 @@ func (m *testTaskManager) CreateTasks(
 	}
 
 	// Then insert all tasks if no errors
-	for _, task := range request.Tasks {
+	for i, task := range request.Tasks {
 		tlm.tasks.Put(fairLevelFromAllocatedTask(task), common.CloneProto(task))
+		if i < len(request.Subqueues) {
+			tlm.taskSubqueue[task.TaskId] = request.Subqueues[i]
+		}
 		tlm.createTaskCount++
 	}
 	tlm.createTaskBatchCount++
@@ -5118,6 +5128,9 @@ func (m *testTaskManager) GetTasks(
 			if level.id >= request.ExclusiveMaxTaskID {
 				break
 			}
+		}
+		if tlm.taskSubqueue[level.id] != request.Subqueue {
+			continue
 		}
 		tasks = append(tasks, it.Value().(*persistencespb.AllocatedTaskInfo))
 	}

--- a/service/matching/pri_backlog_manager.go
+++ b/service/matching/pri_backlog_manager.go
@@ -161,10 +161,34 @@ func (c *priBacklogManagerImpl) initState(state taskQueueState, err error) {
 	}
 
 	c.subqueueLock.Lock()
-	defer c.subqueueLock.Unlock()
+	fresh := c.loadSubqueuesLocked(state.subqueues)
+	c.subqueueLock.Unlock()
 
-	c.loadSubqueuesLocked(state.subqueues)
+	// Drain each new reader's initial backlog in priority order, then start the
+	// pump goroutines. This runs in a background goroutine — not in the writer
+	// init path — for two reasons:
+	//   1. processTaskBatch ultimately calls partitionMgr.AddSpooledTask, which
+	//      can load other queues and would deadlock or stall if it ran while
+	//      callers were blocked on WaitUntilInitialized.
+	//   2. WaitUntilInitialized has tight timeouts at some call sites (e.g.
+	//      getVersionedQueue uses 100ms in tests), and we should not block them
+	//      on the synchronous backlog read.
+	// The matcher only dispatches tasks that have been loaded, so even though
+	// initialization is signaled before loadInitial finishes, no out-of-order
+	// dispatch is possible: high-priority tasks always reach the matcher first
+	// because loadInitial calls are sequenced highest-priority-first here.
+	go c.coldStartLoad(fresh)
+
 	go c.periodicSync()
+}
+
+func (c *priBacklogManagerImpl) coldStartLoad(fresh []*priTaskReader) {
+	for _, r := range fresh {
+		r.loadInitial(c.tqCtx)
+	}
+	for _, r := range fresh {
+		r.Start()
+	}
 }
 
 func (c *priBacklogManagerImpl) WaitUntilInitialized(ctx context.Context) error {
@@ -172,18 +196,36 @@ func (c *priBacklogManagerImpl) WaitUntilInitialized(ctx context.Context) error 
 	return err
 }
 
-func (c *priBacklogManagerImpl) loadSubqueuesLocked(subqueues []persistencespb.SubqueueInfo) {
-	// TODO(pri): This assumes that subqueues never shrinks, and priority/fairness index of
-	// existing subqueues never changes. If we change that, this logic will need to change.
+// loadSubqueuesLocked creates readers for any new subqueues and updates the priority
+// maps. It returns the newly-created readers sorted highest-priority first, so the
+// caller can drive their initial load + Start in priority order outside this lock.
+//
+// TODO(pri): This assumes that subqueues never shrinks, and priority/fairness index
+// of existing subqueues never changes. If we change that, this logic will need to
+// change. Each reader's subqueueIndex must match its persistence position (it's used
+// to filter GetTasks calls), so c.subqueues stays indexed in persistence
+// (FCFS-allocation) order regardless of priority.
+func (c *priBacklogManagerImpl) loadSubqueuesLocked(subqueues []persistencespb.SubqueueInfo) []*priTaskReader {
+	type newReader struct {
+		r   *priTaskReader
+		pri priorityKey
+	}
+	var added []newReader
 	for i := range subqueues {
 		if i >= len(c.subqueues) {
 			r := newPriTaskReader(c, subqueueIndex(i), subqueues[i].AckLevel)
-			r.Start()
 			c.subqueues = append(c.subqueues, r)
+			added = append(added, newReader{r: r, pri: priorityKey(subqueues[i].Key.Priority)})
 		}
 		c.subqueuesByPriority[priorityKey(subqueues[i].Key.Priority)] = subqueueIndex(i)
 		c.priorityBySubqueue[subqueueIndex(i)] = priorityKey(subqueues[i].Key.Priority)
 	}
+	slices.SortFunc(added, func(a, b newReader) int { return int(a.pri) - int(b.pri) })
+	fresh := make([]*priTaskReader, len(added))
+	for i, nr := range added {
+		fresh[i] = nr.r
+	}
+	return fresh
 }
 
 func (c *priBacklogManagerImpl) getSubqueueForPriority(priority priorityKey) subqueueIndex {
@@ -209,7 +251,12 @@ func (c *priBacklogManagerImpl) getSubqueueForPriority(priority priorityKey) sub
 		return subqueueZero
 	}
 
-	c.loadSubqueuesLocked(subqueues)
+	fresh := c.loadSubqueuesLocked(subqueues)
+	// A newly-allocated subqueue has no backlog, so we skip loadInitial here and just
+	// start the pump. Tasks spooled to this priority will arrive via signalNewTasks.
+	for _, r := range fresh {
+		r.Start()
+	}
 
 	// After AllocateSubqueue added a subqueue for this priority, and we merged the result into
 	// our state with loadSubqueuesLocked, this lookup should now find a subqueue.

--- a/service/matching/pri_task_reader.go
+++ b/service/matching/pri_task_reader.go
@@ -152,11 +152,44 @@ func (tr *priTaskReader) completeTask(task *internalTask, res taskResponse) {
 	tr.backlogMgr.db.updateAckLevelAndBacklogStats(tr.subqueue, tr.ackLevel, -numAcked, tr.backlogAge.oldestTime())
 }
 
+// loadInitial synchronously drains the subqueue's backlog up to the reload
+// threshold (mirroring what getTasksPump would do, but in the caller's
+// goroutine). The backlog manager calls this on each new reader in priority
+// order on cold start so the matcher sees high-priority tasks before
+// low-priority ones — relying on Start() / goroutine scheduling order is not
+// enough, since the runtime can run spawned getTasksPump goroutines in any
+// order. Draining fully (including through expired-only gaps) also matches
+// the pre-fix invariant that by the time WaitUntilInitialized returns, readers
+// have advanced their readLevel as far as the loaded threshold allows; tests
+// and callers that rely on isDrainedLocked depend on this.
+func (tr *priTaskReader) loadInitial(ctx context.Context) {
+	for {
+		if tr.getLoadedTasks() > tr.backlogMgr.config.GetTasksReloadAt() {
+			return
+		}
+		batch, err := tr.getTaskBatch(ctx)
+		if err != nil {
+			return // pump will retry once started
+		}
+		if len(batch.tasks) == 0 {
+			tr.setReadLevelAfterGap(batch.readLevel)
+			if batch.isReadBatchDone {
+				return
+			}
+			continue
+		}
+		tr.processTaskBatch(batch.tasks)
+	}
+}
+
 // nolint:revive // can simplify later
 func (tr *priTaskReader) getTasksPump() {
 	ctx := tr.backlogMgr.tqCtx
 
-	tr.SignalTaskLoading() // prime pump
+	// Cold-start priming is done synchronously by loadInitial in priority order.
+	// The pump only handles ongoing notifications (new task signals, reload-threshold
+	// signals). Self-priming here would race with concurrent SpoolTask deliveries
+	// arriving via signalNewTasks just after init.
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
## Summary
- Fix a cold-start priority inversion in `priBacklogManager`: when a partition is reloaded against an existing on-disk backlog, the very first dispatched task was always the lowest-priority one, regardless of what higher-priority tasks were waiting. Subsequent dispatches were correct.
- Subqueue indices follow FCFS-allocation order (the order distinct priorities first appeared in `SpoolTask`), so the lowest-priority subqueue's pump goroutine was started first and consistently won the read race against higher-priority subqueues.
- The fix sorts newly-created readers highest-priority-first and synchronously drains each one's first batch in a background goroutine before starting the pumps. Goroutine scheduling no longer determines which priority lands in the matcher first.

## Changes

**`service/matching/pri_task_reader.go`**
- Add `priTaskReader.loadInitial`, which synchronously drains a subqueue up to the reload threshold (mirrors `getTasksPump`'s loop, but in the caller's goroutine).
- Remove the pump's self-prime — cold-start priming now happens in `loadInitial`, and self-priming would race with `signalNewTasks` deliveries arriving just after init.

**`service/matching/pri_backlog_manager.go`**
- `loadSubqueuesLocked` now returns the newly-created readers sorted highest-priority-first.
- `initState` runs `loadInitial` then `Start` on each new reader in priority order from a background `coldStartLoad` goroutine. The goroutine keeps `WaitUntilInitialized` fast (callers like `getVersionedQueue` use tight 100ms timeouts) and avoids holding `subqueueLock` while `partitionMgr.AddSpooledTask` runs (which can deadlock by loading sibling queues).
- `getSubqueueForPriority` (dynamic-add path) just calls `Start` on its fresh reader since a newly-allocated subqueue has no backlog to load.

**`service/matching/matching_engine_test.go`**
- `testTaskManager` now tracks per-task subqueue and filters `GetTasks` by `request.Subqueue`, so multi-subqueue cold-start tests work against the in-memory mock. Existing single-subqueue tests are unaffected (untracked tasks default to subqueue 0).

**`service/matching/backlog_manager_test.go`**
- New `TestPriorityOrdering_ColdStartLoadsHighPriorityFirst`: spools P5 tasks then P1 tasks (so persistence ends up with subqueues `[default(P3), P5, P1]`), tears down the backlog manager, cold-starts a fresh one against the same persistence, and asserts the first task delivered to the matcher is P1. Fails on `main`, passes 20/20 with this fix.

## Test plan
- [ ] `TestBacklogManager_Pri_Suite` (including the new test) — passes 20/20
- [ ] `TestBacklogManager_Classic_Suite`, `TestBacklogManager_Fair_Suite` — no regressions
- [ ] `TestTaskQueuePartitionManager_Pri_Suite/TestRedirectRuleLoadUpstream` — passes (was at risk because of the 100ms `getVersionedQueue` timeout)
- [ ] `TestBacklogManager_Pri_Suite/TestSkipExpiredTasks_*`, `TestBypassReader`, `TestApproximateBacklogCount_ResetOnDrained` — pass
- [ ] Spot-checked the rest of the matching package; remaining flakes (e.g. `TestMultipleWorkersLesserNumberOfPollersThanTasksNoDBErrors`) reproduce on `main` and are unrelated.

## Notes
- For 1–N priorities, cold-start drain is now serialized rather than parallel (one persistence round-trip per priority instead of one round-trip total). Time-to-first-dispatch is unchanged: the highest-existing-priority reader loads first, and any waiting poller dispatches as soon as that batch lands. Only the trailing low-priority drain takes slightly longer — which is the desired ordering anyway.
- Hot-path behavior (sync match, `signalNewTasks` direct-add, ongoing pump reads) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)