### PR TITLE
Detect dedicated cluster misuse

### DIFF
--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -410,7 +410,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Claims(useTemporalFailures b
 	testFn := func(s *NexusApiTestSuite, tc testcase, dispatchOnlyByEndpoint bool) {
 		// This still needs a dedicated cluster because of SetOnAuthorize/SetOnGetClaims.
 		env := newNexusTestEnv(s.T(), useTemporalFailures, testcore.WithDedicatedCluster())
-		env.GetTestCluster().Host().SetOnAuthorize(func(ctx context.Context, c *authorization.Claims, ct *authorization.CallTarget) (authorization.Result, error) {
+		env.SetOnAuthorize(func(ctx context.Context, c *authorization.Claims, ct *authorization.CallTarget) (authorization.Result, error) {
 			if ct.APIName == configs.DispatchNexusTaskByNamespaceAndTaskQueueAPIName && (c == nil || c.Subject != "test") {
 				return authorization.Result{Decision: authorization.DecisionDeny}, nil
 			}
@@ -419,14 +419,12 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Claims(useTemporalFailures b
 			}
 			return authorization.Result{Decision: authorization.DecisionAllow}, nil
 		})
-		defer env.GetTestCluster().Host().SetOnAuthorize(nil)
-		env.GetTestCluster().Host().SetOnGetClaims(func(ai *authorization.AuthInfo) (*authorization.Claims, error) {
+		env.SetOnGetClaims(func(ai *authorization.AuthInfo) (*authorization.Claims, error) {
 			if ai.AuthToken != "Bearer test" {
 				return nil, errors.New("invalid auth token")
 			}
 			return &authorization.Claims{Subject: "test"}, nil
 		})
-		defer env.GetTestCluster().Host().SetOnGetClaims(nil)
 
 		testEndpoint := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizeStr("test-endpoint"), taskQueue)
 		var dispatchURL string
@@ -630,7 +628,6 @@ func (s *NexusApiTestSuite) TestNexusCancelOperation_Outcomes(useTemporalFailure
 
 func (s *NexusApiTestSuite) TestNexusStartOperation_WithNamespaceAndTaskQueue_SupportsVersioning(useTemporalFailures bool) {
 	env := newNexusTestEnv(s.T(), useTemporalFailures,
-		testcore.WithDedicatedCluster(),
 		testcore.WithDynamicConfig(dynamicconfig.FrontendEnableWorkerVersioningRuleAPIs, true),
 		// UpdateWorkerBuildIdCompatibility is the v0.1 (Version Set-based) API gated by DataAPIs.
 		testcore.WithDynamicConfig(dynamicconfig.FrontendEnableWorkerVersioningDataAPIs, true),

--- a/tests/nexus_api_validation_test.go
+++ b/tests/nexus_api_validation_test.go
@@ -178,14 +178,13 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_Forbidden() {
 	}
 
 	testFn := func(s *NexusAPIValidationTestSuite, tc testcase, dispatchOnlyByEndpoint bool) {
-		env := newNexusTestEnv(s.T(), false, testcore.WithDedicatedCluster())
+		env := newNexusTestEnv(s.T(), false,
+			testcore.WithDynamicConfig(dynamicconfig.ExposeAuthorizerErrors, tc.exposeAuthorizerErrors),
+		)
 		taskQueue := testcore.RandomizeStr("task-queue")
 		testEndpoint := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizeStr("test-endpoint"), taskQueue)
 
-		env.GetTestCluster().Host().SetOnAuthorize(tc.onAuthorize(testEndpoint.Spec.Name))
-		s.T().Cleanup(func() { env.GetTestCluster().Host().SetOnAuthorize(nil) })
-
-		env.OverrideDynamicConfig(dynamicconfig.ExposeAuthorizerErrors, tc.exposeAuthorizerErrors)
+		env.SetOnAuthorize(tc.onAuthorize(testEndpoint.Spec.Name))
 
 		var dispatchURL string
 		if dispatchOnlyByEndpoint {

--- a/tests/nexus_matching_test.go
+++ b/tests/nexus_matching_test.go
@@ -15,31 +15,39 @@ import (
 	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/metrics/metricstest"
+	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/tests/testcore"
 )
 
-func TestDispatchNexusTaskWithMatchingBehaviors(t *testing.T) {
-	t.Parallel()
-	runWithMatchingBehaviors(t, nil, func(s *testcore.TestEnv, b testcore.MatchingBehavior) {
-		dispatchAndCompleteNexusTask(t, s, b.ForceTaskForward, b.ForcePollForward)
+type NexusMatchingTestSuite struct {
+	parallelsuite.Suite[*NexusMatchingTestSuite]
+}
+
+func TestNexusMatchingTestSuite(t *testing.T) {
+	parallelsuite.Run(t, &NexusMatchingTestSuite{})
+}
+
+func (s *NexusMatchingTestSuite) TestDispatchNexusTaskWithMatchingBehaviors() {
+	runWithMatchingBehaviors(s.T(), nil, func(env *testcore.TestEnv, b testcore.MatchingBehavior) {
+		dispatchAndCompleteNexusTask(s.T(), env, b.ForceTaskForward, b.ForcePollForward)
 	})
 }
 
-func TestDispatchNexusTaskOnNonRootPartitionNoForwarding(t *testing.T) {
+func (s *NexusMatchingTestSuite) TestDispatchNexusTaskOnNonRootPartitionNoForwarding() {
 	// Both poll and task go to partition 1 with no forwarding. This verifies that
 	// non-root partitions work correctly even when no forwarding is involved.
-	s := testcore.NewEnv(t)
+	env := testcore.NewEnv(s.T())
 
-	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueReadPartitions, 4)
-	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueWritePartitions, 4)
-	s.OverrideDynamicConfig(dynamicconfig.MatchingForwarderMaxOutstandingTasks, 0) // disable forwarding
-	s.OverrideDynamicConfig(dynamicconfig.MatchingForwarderMaxOutstandingPolls, 0) // disable forwarding
-	s.InjectHook(testhooks.NewHook(testhooks.MatchingLBForceWritePartition, 1))
-	s.InjectHook(testhooks.NewHook(testhooks.MatchingLBForceReadPartition, 1))
-	s.InjectHook(testhooks.NewHook(testhooks.MatchingDisableSyncMatch, false))
+	env.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueReadPartitions, 4)
+	env.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueWritePartitions, 4)
+	env.OverrideDynamicConfig(dynamicconfig.MatchingForwarderMaxOutstandingTasks, 0) // disable forwarding
+	env.OverrideDynamicConfig(dynamicconfig.MatchingForwarderMaxOutstandingPolls, 0) // disable forwarding
+	env.InjectHook(testhooks.NewHook(testhooks.MatchingLBForceWritePartition, 1))
+	env.InjectHook(testhooks.NewHook(testhooks.MatchingLBForceReadPartition, 1))
+	env.InjectHook(testhooks.NewHook(testhooks.MatchingDisableSyncMatch, false))
 
-	dispatchAndCompleteNexusTask(t, s, false, false)
+	dispatchAndCompleteNexusTask(s.T(), env, false, false)
 }
 
 func dispatchAndCompleteNexusTask(t *testing.T, s *testcore.TestEnv, expectTaskForwarded, expectPollForwarded bool) {

--- a/tests/nexus_matching_test.go
+++ b/tests/nexus_matching_test.go
@@ -29,7 +29,7 @@ func TestDispatchNexusTaskWithMatchingBehaviors(t *testing.T) {
 func TestDispatchNexusTaskOnNonRootPartitionNoForwarding(t *testing.T) {
 	// Both poll and task go to partition 1 with no forwarding. This verifies that
 	// non-root partitions work correctly even when no forwarding is involved.
-	s := testcore.NewEnv(t, testcore.WithDedicatedCluster())
+	s := testcore.NewEnv(t)
 
 	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueReadPartitions, 4)
 	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueWritePartitions, 4)

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -1377,14 +1377,13 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 
 	s.Run("InvalidCallbackToken", func(s *NexusWorkflowTestSuite) {
 		env := s.newTestEnv(chasmEnabled)
-		ctx := env.Context()
 		completion := nexusrpc.CompleteOperationOptions{
 			Result: testcore.MustToPayload(s.T(), "result"),
 		}
 		publicCallbackURL := "http://" + env.HttpAPIAddress() + "/" + commonnexus.RouteCompletionCallback.Path(env.Namespace().String())
 		// metrics collection is not initialized before callback validation
 		// Send request without callback token, helper does not add token if blank
-		err := s.sendNexusCompletionRequest(ctx, publicCallbackURL, completion)
+		err := s.sendNexusCompletionRequest(env.Context(), publicCallbackURL, completion)
 		// Verify we get the correct error response
 		var handlerErr *nexus.HandlerError
 		s.ErrorAs(err, &handlerErr)
@@ -1394,14 +1393,13 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 
 	s.Run("InvalidCallbackTokenNoIdentifier", func(s *NexusWorkflowTestSuite) {
 		env := s.newTestEnv(chasmEnabled)
-		ctx := env.Context()
 		completion := nexusrpc.CompleteOperationOptions{
 			Result: testcore.MustToPayload(s.T(), "result"),
 		}
 		publicCallbackURL := "http://" + env.HttpAPIAddress() + commonnexus.PathCompletionCallbackNoIdentifier
 		// metrics collection is not initialized before callback validation
 		// Send request without callback token, helper does not add token if blank
-		err := s.sendNexusCompletionRequest(ctx, publicCallbackURL, completion)
+		err := s.sendNexusCompletionRequest(env.Context(), publicCallbackURL, completion)
 		// Verify we get the correct error response
 		var handlerErr *nexus.HandlerError
 		s.ErrorAs(err, &handlerErr)
@@ -1411,7 +1409,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 
 	s.Run("InvalidClientVersion", func(s *NexusWorkflowTestSuite) {
 		env := s.newTestEnv(chasmEnabled)
-		ctx := env.Context()
 		publicCallbackURL := "http://" + env.HttpAPIAddress() + "/" + commonnexus.RouteCompletionCallback.Path(env.Namespace().String())
 		capture := env.StartNamespaceMetricCapture()
 
@@ -1430,7 +1427,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 		client := nexusrpc.NewCompletionHTTPClient(nexusrpc.CompletionHTTPClientOptions{
 			Serializer: commonnexus.PayloadSerializer,
 		})
-		err = client.CompleteOperation(ctx, publicCallbackURL, completion)
+		err = client.CompleteOperation(env.Context(), publicCallbackURL, completion)
 		completionRequests := capture.Metric("nexus_completion_requests")
 		var handlerErr *nexus.HandlerError
 		s.ErrorAs(err, &handlerErr)
@@ -1441,7 +1438,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 
 	s.Run("InvalidClientVersionNoIdentifier", func(s *NexusWorkflowTestSuite) {
 		env := s.newTestEnv(chasmEnabled)
-		ctx := env.Context()
 		publicCallbackURL := "http://" + env.HttpAPIAddress() + commonnexus.PathCompletionCallbackNoIdentifier
 		capture := env.StartNamespaceMetricCapture()
 
@@ -1461,7 +1457,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 		client := nexusrpc.NewCompletionHTTPClient(nexusrpc.CompletionHTTPClientOptions{
 			Serializer: commonnexus.PayloadSerializer,
 		})
-		err = client.CompleteOperation(ctx, publicCallbackURL, completion)
+		err = client.CompleteOperation(env.Context(), publicCallbackURL, completion)
 		completionRequests := capture.Metric("nexus_completion_requests")
 		var handlerErr *nexus.HandlerError
 		s.ErrorAs(err, &handlerErr)
@@ -1479,7 +1475,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAuthErrors(cha
 		return authorization.Result{Decision: authorization.DecisionAllow}, nil
 	}
 	env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
-	ctx := env.Context()
 	env.SetOnAuthorize(onAuthorize)
 
 	// Generate a valid callback token for testing
@@ -1494,7 +1489,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAuthErrors(cha
 
 	publicCallbackURL := "http://" + env.HttpAPIAddress() + "/" + commonnexus.RouteCompletionCallback.Path(env.Namespace().String())
 	capture := env.StartNamespaceMetricCapture()
-	err = s.sendNexusCompletionRequest(ctx, publicCallbackURL, completion)
+	err = s.sendNexusCompletionRequest(env.Context(), publicCallbackURL, completion)
 	completionRequests := capture.Metric("nexus_completion_requests")
 	var handlerErr *nexus.HandlerError
 	s.ErrorAs(err, &handlerErr)
@@ -1511,7 +1506,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAuthErrorsNoId
 		return authorization.Result{Decision: authorization.DecisionAllow}, nil
 	}
 	env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
-	ctx := env.Context()
 	env.SetOnAuthorize(onAuthorize)
 
 	// Generate a valid callback token for testing
@@ -1525,7 +1519,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAuthErrorsNoId
 	}
 	publicCallbackURL := "http://" + env.HttpAPIAddress() + commonnexus.PathCompletionCallbackNoIdentifier
 	capture := env.StartNamespaceMetricCapture()
-	err = s.sendNexusCompletionRequest(ctx, publicCallbackURL, completion)
+	err = s.sendNexusCompletionRequest(env.Context(), publicCallbackURL, completion)
 	completionRequests := capture.Metric("nexus_completion_requests")
 	var handlerErr *nexus.HandlerError
 	s.ErrorAs(err, &handlerErr)
@@ -1728,7 +1722,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelBeforeStarted_Cancelati
 		s.T().Skip("Blocked on CHASM Nexus cancellation before start support")
 	}
 	env := s.newTestEnv(chasmEnabled)
-	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 
 	canStartCh := make(chan struct{})
@@ -1748,14 +1741,14 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelBeforeStarted_Cancelati
 			return nil
 		},
 	}
-	endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
+	endpointName := env.createRandomExternalNexusServer(env.Context(), s.T(), h)
 
-	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+	run, err := env.SdkClient().ExecuteWorkflow(env.Context(), client.StartWorkflowOptions{
 		TaskQueue: taskQueue,
 	}, "workflow")
 	s.NoError(err)
 
-	pollResp, err := env.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+	pollResp, err := env.FrontendClient().PollWorkflowTaskQueue(env.Context(), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: env.Namespace().String(),
 		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: taskQueue,
@@ -1764,7 +1757,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelBeforeStarted_Cancelati
 		Identity: "test",
 	})
 	s.NoError(err)
-	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(env.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Identity:  "test",
 		TaskToken: pollResp.TaskToken,
 		Commands: []*commandpb.Command{
@@ -1794,7 +1787,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelBeforeStarted_Cancelati
 	s.NoError(err)
 
 	// Poll and cancel the operation.
-	pollResp, err = env.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+	pollResp, err = env.FrontendClient().PollWorkflowTaskQueue(env.Context(), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: env.Namespace().String(),
 		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: taskQueue,
@@ -1811,7 +1804,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelBeforeStarted_Cancelati
 	s.Positive(scheduledEventIdx)
 	scheduledEventID := pollResp.History.Events[scheduledEventIdx].EventId
 
-	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(env.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Identity:  "test",
 		TaskToken: pollResp.TaskToken,
 		Commands: []*commandpb.Command{
@@ -1827,11 +1820,11 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelBeforeStarted_Cancelati
 	})
 	s.NoError(err)
 
-	env.SendToChannel(ctx, canStartCh)
-	env.WaitForChannel(ctx, cancelSentCh)
+	env.SendToChannel(env.Context(), canStartCh)
+	env.WaitForChannel(env.Context(), cancelSentCh)
 
 	// Terminate the workflow for good measure.
-	err = env.SdkClient().TerminateWorkflow(ctx, run.GetID(), run.GetRunID(), "test")
+	err = env.SdkClient().TerminateWorkflow(env.Context(), run.GetID(), run.GetRunID(), "test")
 	s.NoError(err)
 
 	// Assert that we did not send a cancel request until after the operation was started.
@@ -2522,7 +2515,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncNexusFailure(chasmEnabled
 		s.T().Skip("Blocked on CHASM Nexus sync failure conversion support")
 	}
 	env := s.newTestEnv(chasmEnabled)
-	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 
 	h := nexustest.Handler{
@@ -2539,7 +2531,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncNexusFailure(chasmEnabled
 			}
 		},
 	}
-	endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
+	endpointName := env.createRandomExternalNexusServer(env.Context(), s.T(), h)
 
 	w := worker.New(
 		env.SdkClient(),
@@ -2558,11 +2550,11 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncNexusFailure(chasmEnabled
 	s.T().Cleanup(w.Stop)
 
 	capture := env.StartNamespaceMetricCapture()
-	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+	run, err := env.SdkClient().ExecuteWorkflow(env.Context(), client.StartWorkflowOptions{
 		TaskQueue: taskQueue,
 	}, callerWF)
 	s.NoError(err)
-	wfErr := run.Get(ctx, nil)
+	wfErr := run.Get(env.Context(), nil)
 
 	var handlerErr *nexus.HandlerError
 	s.ErrorAs(wfErr, &handlerErr)

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -1376,7 +1376,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 	})
 
 	s.Run("InvalidCallbackToken", func(s *NexusWorkflowTestSuite) {
-		env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
+		env := s.newTestEnv(chasmEnabled)
 		ctx := env.Context()
 		completion := nexusrpc.CompleteOperationOptions{
 			Result: testcore.MustToPayload(s.T(), "result"),
@@ -1393,7 +1393,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 	})
 
 	s.Run("InvalidCallbackTokenNoIdentifier", func(s *NexusWorkflowTestSuite) {
-		env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
+		env := s.newTestEnv(chasmEnabled)
 		ctx := env.Context()
 		completion := nexusrpc.CompleteOperationOptions{
 			Result: testcore.MustToPayload(s.T(), "result"),
@@ -1410,7 +1410,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 	})
 
 	s.Run("InvalidClientVersion", func(s *NexusWorkflowTestSuite) {
-		env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
+		env := s.newTestEnv(chasmEnabled)
 		ctx := env.Context()
 		publicCallbackURL := "http://" + env.HttpAPIAddress() + "/" + commonnexus.RouteCompletionCallback.Path(env.Namespace().String())
 		capture := env.StartNamespaceMetricCapture()
@@ -1440,7 +1440,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 	})
 
 	s.Run("InvalidClientVersionNoIdentifier", func(s *NexusWorkflowTestSuite) {
-		env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
+		env := s.newTestEnv(chasmEnabled)
 		ctx := env.Context()
 		publicCallbackURL := "http://" + env.HttpAPIAddress() + commonnexus.PathCompletionCallbackNoIdentifier
 		capture := env.StartNamespaceMetricCapture()
@@ -1472,17 +1472,15 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 }
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAuthErrors(chasmEnabled bool) {
-	env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
-	ctx := env.Context()
-
 	onAuthorize := func(ctx context.Context, c *authorization.Claims, ct *authorization.CallTarget) (authorization.Result, error) {
 		if ct.APIName == configs.CompleteNexusOperation {
 			return authorization.Result{Decision: authorization.DecisionDeny, Reason: "unauthorized in test"}, nil
 		}
 		return authorization.Result{Decision: authorization.DecisionAllow}, nil
 	}
-	env.GetTestCluster().Host().SetOnAuthorize(onAuthorize)
-	defer env.GetTestCluster().Host().SetOnAuthorize(nil)
+	env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
+	ctx := env.Context()
+	env.SetOnAuthorize(onAuthorize)
 
 	// Generate a valid callback token for testing
 	namespaceID := env.NamespaceID().String()
@@ -1506,17 +1504,15 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAuthErrors(cha
 }
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAuthErrorsNoIdentifier(chasmEnabled bool) {
-	env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
-	ctx := env.Context()
-
 	onAuthorize := func(ctx context.Context, c *authorization.Claims, ct *authorization.CallTarget) (authorization.Result, error) {
 		if ct.APIName == configs.CompleteNexusOperation {
 			return authorization.Result{Decision: authorization.DecisionDeny, Reason: "unauthorized in test"}, nil
 		}
 		return authorization.Result{Decision: authorization.DecisionAllow}, nil
 	}
-	env.GetTestCluster().Host().SetOnAuthorize(onAuthorize)
-	defer env.GetTestCluster().Host().SetOnAuthorize(nil)
+	env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
+	ctx := env.Context()
+	env.SetOnAuthorize(onAuthorize)
 
 	// Generate a valid callback token for testing
 	namespaceID := env.NamespaceID().String()
@@ -1731,7 +1727,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelBeforeStarted_Cancelati
 	if chasmEnabled {
 		s.T().Skip("Blocked on CHASM Nexus cancellation before start support")
 	}
-	env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
+	env := s.newTestEnv(chasmEnabled)
 	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 
@@ -2172,7 +2168,7 @@ func (s *NexusWorkflowTestSuite) TestNexusSyncOperationErrorRehydration(chasmEna
 	}
 
 	testFn := func(s *NexusWorkflowTestSuite, tc testcase) {
-		env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
+		env := s.newTestEnv(chasmEnabled)
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
 		defer cancel()
 		taskQueue := testcore.RandomizeStr("caller_" + s.T().Name())
@@ -2327,7 +2323,7 @@ func (s *NexusWorkflowTestSuite) TestNexusAsyncOperationErrorRehydration(chasmEn
 	}
 
 	testFn := func(s *NexusWorkflowTestSuite, tc testcase) {
-		env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
+		env := s.newTestEnv(chasmEnabled)
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
 		defer cancel()
 		testCtx := ctx
@@ -2525,7 +2521,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncNexusFailure(chasmEnabled
 	if chasmEnabled {
 		s.T().Skip("Blocked on CHASM Nexus sync failure conversion support")
 	}
-	env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
+	env := s.newTestEnv(chasmEnabled)
 	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 

--- a/tests/premature_eos_test.go
+++ b/tests/premature_eos_test.go
@@ -52,7 +52,7 @@ func (s *PrematureEosTestSuite) Test_SpeculativeWFTEventsLostAfterSignalMidHisto
 	// leaving batches [6] and [7] for the second page.
 	const maxBatchesPerPage = 3
 
-	env := testcore.NewEnv(s.T(), testcore.WithDedicatedCluster())
+	env := testcore.NewEnv(s.T())
 	tv := env.Tv()
 	runID := mustStartWorkflow(env, tv)
 	wfExecution := &commonpb.WorkflowExecution{WorkflowId: tv.WorkflowID(), RunId: runID}

--- a/tests/query_workflow_test.go
+++ b/tests/query_workflow_test.go
@@ -346,14 +346,13 @@ func (s *QueryWorkflowSuite) TestQueryWorkflow_ClosedWithoutWorkflowTaskStarted(
 // non-sticky query task poll is a valid HistoryContinuation token usable with
 // GetWorkflowExecutionHistory. Fails with "Invalid NextPageToken" if matching service
 // returns a RawHistoryContinuation token instead.
-// Uses a dedicated cluster with MatchingHistoryMaxPageSize=14 (for query tasks) and
-// HistoryMaxPageSize=14 (for regular workflow tasks via RecordWorkflowTaskStarted).
+// Uses MatchingHistoryMaxPageSize=14 (for query tasks) and HistoryMaxPageSize=14
+// (for regular workflow tasks via RecordWorkflowTaskStarted).
 // With 5 activities generating ~16 history blobs, page size 14 ensures any task type
 // produces a multi-page history response with a non-empty NextPageToken. 14 is large
 // enough that activity-phase WFTs (≤14 blobs) don't need extra pagination roundtrips.
 func (s *QueryWorkflowSuite) TestQueryWorkflow_NonStickyMultiPageHistory() {
 	env := testcore.NewEnv(s.T(),
-		testcore.WithDedicatedCluster(),
 		testcore.WithDynamicConfig(dynamicconfig.MatchingHistoryMaxPageSize, 14),
 		testcore.WithDynamicConfig(dynamicconfig.HistoryMaxPageSize, 14),
 	)

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -20,6 +20,7 @@ import (
 	sdkworker "go.temporal.io/sdk/worker"
 	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/authorization"
 	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
@@ -235,6 +236,32 @@ func (e *TestEnv) InjectHook(hook testhooks.Hook) (cleanup func()) {
 		e.t.Fatalf("InjectHook: unknown scope %v", hook.Scope())
 	}
 	return e.cluster.host.injectHook(e.t, hook, scope)
+}
+
+func (e *TestEnv) SetOnAuthorize(
+	fn func(context.Context, *authorization.Claims, *authorization.CallTarget) (authorization.Result, error),
+) {
+	e.t.Helper()
+	if e.isShared {
+		e.t.Fatal("SetOnAuthorize cannot be called on a shared cluster; use testcore.WithDedicatedCluster()")
+	}
+	e.dedicatedGuard.record("authorization callback")
+	e.cluster.host.SetOnAuthorize(fn)
+	e.t.Cleanup(func() {
+		e.cluster.host.SetOnAuthorize(nil)
+	})
+}
+
+func (e *TestEnv) SetOnGetClaims(fn func(*authorization.AuthInfo) (*authorization.Claims, error)) {
+	e.t.Helper()
+	if e.isShared {
+		e.t.Fatal("SetOnGetClaims cannot be called on a shared cluster; use testcore.WithDedicatedCluster()")
+	}
+	e.dedicatedGuard.record("authorization callback")
+	e.cluster.host.SetOnGetClaims(fn)
+	e.t.Cleanup(func() {
+		e.cluster.host.SetOnGetClaims(nil)
+	})
 }
 
 func (e *TestEnv) TaskPoller() *taskpoller.TaskPoller {

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -3,6 +3,7 @@ package testcore
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -18,6 +19,7 @@ import (
 	sdkclient "go.temporal.io/sdk/client"
 	sdkworker "go.temporal.io/sdk/worker"
 	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
@@ -64,13 +66,14 @@ type TestEnv struct {
 
 	Logger log.Logger
 
-	cluster    *TestCluster
-	nsName     namespace.Name
-	nsID       namespace.ID
-	taskPoller *taskpoller.TaskPoller
-	t          *testing.T
-	tv         *testvars.TestVars
-	ctx        context.Context
+	cluster        *TestCluster
+	nsName         namespace.Name
+	nsID           namespace.ID
+	taskPoller     *taskpoller.TaskPoller
+	t              *testing.T
+	tv             *testvars.TestVars
+	ctx            context.Context
+	dedicatedGuard *dedicatedClusterGuard
 
 	sdkClientOnce sync.Once
 	sdkClient     sdkclient.Client
@@ -141,12 +144,16 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 	for _, opt := range opts {
 		opt(&options)
 	}
+	dedicatedGuard := newDedicatedClusterGuard(options.dedicatedCluster)
 
 	// For dedicated clusters, pass all dynamic config settings at cluster creation.
 	var startupConfig map[dynamicconfig.Key]any
 	if options.dedicatedCluster && len(options.dynamicConfigSettings) > 0 {
 		startupConfig = make(map[dynamicconfig.Key]any, len(options.dynamicConfigSettings))
 		for _, override := range options.dynamicConfigSettings {
+			if !canBeNamespaceScoped(override.setting.Precedence()) {
+				dedicatedGuard.record("global dynamic config used")
+			}
 			startupConfig[override.setting.Key()] = override.value
 		}
 	}
@@ -181,7 +188,13 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 		tv:                 testvars.New(t),
 		ctx:                setupTestTimeoutWithContext(t, options.timeout),
 		sdkWorkerTQ:        RandomizeStr("tq-" + t.Name()),
+		dedicatedGuard:     dedicatedGuard,
 	}
+	t.Cleanup(func() {
+		if err := env.dedicatedGuard.validate(); err != nil && !t.Failed() {
+			t.Fatal(err)
+		}
+	})
 
 	// For shared clusters, apply all dynamic config settings as overrides.
 	if !options.dedicatedCluster && len(options.dynamicConfigSettings) > 0 {
@@ -216,6 +229,7 @@ func (e *TestEnv) InjectHook(hook testhooks.Hook) (cleanup func()) {
 		if e.isShared {
 			e.t.Fatal("InjectHook: global hooks require a dedicated cluster; use testcore.WithDedicatedCluster()")
 		}
+		e.dedicatedGuard.record("global hook injected")
 		scope = testhooks.GlobalScope
 	default:
 		e.t.Fatalf("InjectHook: unknown scope %v", hook.Scope())
@@ -341,6 +355,8 @@ func (e *TestEnv) OverrideDynamicConfig(setting dynamicconfig.GenericSetting, va
 				Value:       value,
 			}}
 		}
+	} else if !canBeNamespaceScoped(setting.Precedence()) {
+		e.dedicatedGuard.record("global dynamic config used")
 	}
 	return e.cluster.host.overrideDynamicConfigForTest(e.t, setting.Key(), value)
 }
@@ -352,6 +368,7 @@ func (e *TestEnv) StartGlobalMetricCapture() *GlobalMetricCapture {
 	if e.isShared {
 		e.t.Fatal("StartGlobalMetricCapture cannot be called on a shared cluster; use testcore.WithDedicatedCluster()")
 	}
+	e.dedicatedGuard.record("global metric capture") // note that globalCapture has its own misuse detection
 
 	handler := e.cluster.host.CaptureMetricsHandler()
 	if handler == nil {
@@ -388,6 +405,20 @@ func (e *TestEnv) StartNamespaceMetricCaptureFor(namespaceName string) *Namespac
 	return newNamespaceMetricCapture(capture, namespaceName)
 }
 
+// CloseShard closes the shard that contains the given workflow.
+// This is a cluster-global operation and cannot be called on shared clusters.
+func (e *TestEnv) CloseShard(namespaceID string, workflowID string) {
+	if e.isShared {
+		e.t.Fatalf("CloseShard cannot be called on a shared cluster; use testcore.WithDedicatedCluster()")
+	}
+	e.dedicatedGuard.record("shard closed")
+	shardID := common.WorkflowIDToHistoryShard(namespaceID, workflowID, e.testClusterConfig.HistoryConfig.NumHistoryShards)
+	_, err := e.AdminClient().CloseShard(NewContext(), &adminservice.CloseShardRequest{
+		ShardId: shardID,
+	})
+	e.NoError(err)
+}
+
 func canBeNamespaceScoped(p dynamicconfig.Precedence) bool {
 	switch p {
 	case dynamicconfig.PrecedenceNamespace,
@@ -422,4 +453,40 @@ func checkTestShard(t *testing.T) {
 		t.Skipf("Skipping %s in test shard %d/%d (it runs in %d)", t.Name(), index+1, total, testIndex+1)
 	}
 	t.Logf("Running %s in test shard %d/%d", t.Name(), index+1, total)
+}
+
+type dedicatedClusterGuard struct {
+	required    bool
+	mu          sync.Mutex
+	usageReason string
+}
+
+func newDedicatedClusterGuard(required bool) *dedicatedClusterGuard {
+	return &dedicatedClusterGuard{required: required}
+}
+
+// record marks that a dedicated-cluster-only feature was used, satisfying the guard.
+func (u *dedicatedClusterGuard) record(reason string) {
+	if !u.required {
+		return
+	}
+	u.mu.Lock()
+	if u.usageReason == "" {
+		u.usageReason = reason
+	}
+	u.mu.Unlock()
+}
+
+// validate checks that the guard was satisfied i.e. a dedicated-cluster-only feature was used.
+func (u *dedicatedClusterGuard) validate() error {
+	if !u.required {
+		return nil
+	}
+	u.mu.Lock()
+	usageReason := u.usageReason
+	u.mu.Unlock()
+	if usageReason == "" {
+		return errors.New("testcore.WithDedicatedCluster() was requested but no dedicated-cluster-only feature was used")
+	}
+	return nil
 }

--- a/tests/testcore/test_env_test.go
+++ b/tests/testcore/test_env_test.go
@@ -1,0 +1,48 @@
+package testcore
+
+import (
+	"sync"
+	"testing"
+
+	"go.temporal.io/server/common/testing/parallelsuite"
+)
+
+type TestEnvSuite struct {
+	parallelsuite.Suite[*TestEnvSuite]
+}
+
+func TestTestEnvSuite(t *testing.T) {
+	parallelsuite.Run(t, &TestEnvSuite{})
+}
+
+func (s *TestEnvSuite) TestDedicatedClusterGuard_NoErrorWithoutExplicitRequest() {
+	guard := newDedicatedClusterGuard(false)
+
+	s.NoError(guard.validate())
+}
+
+func (s *TestEnvSuite) TestDedicatedClusterGuard_FailsWhenUnused() {
+	guard := newDedicatedClusterGuard(true)
+
+	s.EqualError(guard.validate(),
+		`testcore.WithDedicatedCluster() was requested but no dedicated-cluster-only feature was used`)
+}
+
+func (s *TestEnvSuite) TestDedicatedClusterGuard_NoErrorAfterUse() {
+	guard := newDedicatedClusterGuard(true)
+	guard.record("global hook")
+
+	s.NoError(guard.validate())
+}
+
+func (s *TestEnvSuite) TestDedicatedClusterGuard_ConcurrentRecord() {
+	guard := newDedicatedClusterGuard(true)
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Go(func() {
+			guard.record("reason")
+		})
+	}
+	wg.Wait()
+	s.NoError(guard.validate())
+}

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -44,17 +44,17 @@ func speculativeWorkflowTaskOutcomes(
 	return
 }
 
-func clearUpdateRegistryAndAbortPendingUpdates(s testcore.Env, tv *testvars.TestVars) {
+func clearUpdateRegistryAndAbortPendingUpdates(s *testcore.TestEnv, tv *testvars.TestVars) {
 	closeShard(s, tv.WorkflowID())
 }
 
-func loseUpdateRegistryAndAbandonPendingUpdates(s testcore.Env, tv *testvars.TestVars) {
+func loseUpdateRegistryAndAbandonPendingUpdates(s *testcore.TestEnv, tv *testvars.TestVars) {
 	cleanup := s.OverrideDynamicConfig(dynamicconfig.ShardFinalizerTimeout, 0)
 	defer cleanup()
 	closeShard(s, tv.WorkflowID())
 }
 
-func closeShard(s testcore.Env, wid string) {
+func closeShard(s *testcore.TestEnv, wid string) {
 	s.T().Helper()
 
 	resp, err := s.FrontendClient().DescribeNamespace(testcore.NewContext(s.Context()), &workflowservice.DescribeNamespaceRequest{


### PR DESCRIPTION
## What changed?

Added a guard for detecting if `WithDedicatedCluster` option for `TestEnv` was unnecessary. 

## Why?

Using a dedicated cluster when not needed is wasteful. 

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
