### PR TITLE
Add GH WF to check cloud release patch PRs

### DIFF
--- a/.github/workflows/check-patch-pr.yml
+++ b/.github/workflows/check-patch-pr.yml
@@ -1,0 +1,56 @@
+name: Check Patch PR
+on:
+  pull_request_target:
+    branches:
+      - 'cloud/*'
+
+permissions:
+  contents: read
+
+jobs:
+  check-patch-pr:
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate GitHub token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
+          private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
+          owner: temporalio
+          permission-contents: read
+
+      - name: Fetch latest launchpad release
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          gh release download \
+            --repo temporalio/launchpad \
+            --pattern "launchpad_Linux_x86_64.tar.gz" \
+            --output - \
+          | tar -xz launchpad
+
+      - name: Run patch PR checks
+        env:
+          ORG: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          TEMPORAL_API_KEY: "${{ secrets.TEMPORAL_LAUNCHPAD_API_KEY }}"
+        run: |
+          output=$(./launchpad patch check-pr \
+            --org "$ORG" \
+            --repo "$REPO" \
+            --number "$NUMBER" \
+            --json)
+
+          if jq -e '.success' <<< "$output" > /dev/null; then
+            exit 0
+          fi
+
+          echo "Patch PR checks failed:"
+          jq -r '.messages[]' <<< "$output" | while IFS= read -r msg; do
+            echo "  - $msg"
+          done
+          exit 1


### PR DESCRIPTION
## What changed?

Adds a workflow to check self-service cloud release patch PRs.

## Why?

Enable self-service cloud release patching.

## How did you test it?

Cannot be tested until merged, because the job has to use `pull_request_target` in order to get access to secrets.

## Potential risks

Makes the fact of our cloud release process more obvious; details are already being leaked via this repo, so no new disclosures, just easier to find.