### PR TITLE
[tests] Tie nexus callback URL default to cluster lifetime

### DIFF
--- a/tests/testcore/onebox.go
+++ b/tests/testcore/onebox.go
@@ -21,6 +21,7 @@ import (
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/chasm"
+	chasmnexus "go.temporal.io/server/chasm/lib/nexusoperation"
 	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	chasmtests "go.temporal.io/server/chasm/lib/tests"
 	"go.temporal.io/server/client"
@@ -53,6 +54,7 @@ import (
 	"go.temporal.io/server/common/telemetry"
 	"go.temporal.io/server/common/testing/grpcinject"
 	"go.temporal.io/server/common/testing/testhooks"
+	"go.temporal.io/server/components/nexusoperations"
 	"go.temporal.io/server/service/frontend"
 	"go.temporal.io/server/service/history"
 	"go.temporal.io/server/service/history/replication"
@@ -233,13 +235,15 @@ func newTemporal(t *testing.T, params *TemporalParams) *TemporalImpl {
 
 	// Global defaults: applied without cleanup so they persist across cluster reuse.
 	for k, v := range defaultDynamicConfigOverrides {
-		impl.dcClient.PartialOverrideValue(k, v)
+		impl.overrideDynamicConfigForClusterLifetime(k, v)
 	}
+	// Override Nexus callback URL. This is parameterized on the frontend's HTTP address,
+	// so it can't be overriden in the loop above.
+	impl.setNexusCallbackURL()
 	// Per-test overrides: cleaned up when the creating test finishes.
 	for k, v := range params.DynamicConfigOverrides {
 		impl.overrideDynamicConfigForTest(t, k, v)
 	}
-
 	return impl
 }
 
@@ -966,6 +970,22 @@ func sdkClientFactoryProvider(
 		logger,
 		dynamicconfig.WorkerStickyCacheSize.Get(dc),
 	)
+}
+
+func (c *TemporalImpl) setNexusCallbackURL() {
+	// Set Nexus callback URL with the cluster's HTTP address. This is a sensible default to avoid
+	// users to need to manually set this.
+	//nolint:revive // test callback endpoints are served by the local HTTP API in functional tests
+	nexusCallbackTemplate := fmt.Sprintf(
+		"http://%s/namespaces/{{.NamespaceName}}/nexus/callback",
+		c.FrontendHTTPAddress(),
+	)
+	c.overrideDynamicConfigForClusterLifetime(nexusoperations.CallbackURLTemplate.Key(), nexusCallbackTemplate)
+	c.overrideDynamicConfigForClusterLifetime(chasmnexus.CallbackURLTemplate.Key(), nexusCallbackTemplate)
+}
+
+func (c *TemporalImpl) overrideDynamicConfigForClusterLifetime(name dynamicconfig.Key, value any) {
+	c.dcClient.PartialOverrideValue(name, value)
 }
 
 // overrideDynamicConfigForTest overrides a dynamic config value for the duration of the test.

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -18,7 +18,6 @@ import (
 	sdkclient "go.temporal.io/sdk/client"
 	sdkworker "go.temporal.io/sdk/worker"
 	"go.temporal.io/server/api/adminservice/v1"
-	chasmnexus "go.temporal.io/server/chasm/lib/nexusoperation"
 	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
@@ -26,7 +25,6 @@ import (
 	"go.temporal.io/server/common/testing/taskpoller"
 	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/common/testing/testvars"
-	"go.temporal.io/server/components/nexusoperations"
 	"google.golang.org/grpc"
 )
 
@@ -184,13 +182,6 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 		ctx:                setupTestTimeoutWithContext(t, options.timeout),
 		sdkWorkerTQ:        RandomizeStr("tq-" + t.Name()),
 	}
-
-	// Set Nexus callback URL now that we have the cluster's HTTP address. Note that we set
-	// a default for the global config here so callers that rely on this can still use a shared cluster.
-	//nolint:revive // test callback endpoints are served by the local HTTP API in functional tests
-	nexusCallbackTemplate := fmt.Sprintf("http://%s/namespaces/{{.NamespaceName}}/nexus/callback", env.HttpAPIAddress())
-	env.FunctionalTestBase.OverrideDynamicConfig(nexusoperations.CallbackURLTemplate, nexusCallbackTemplate)
-	env.FunctionalTestBase.OverrideDynamicConfig(chasmnexus.CallbackURLTemplate, nexusCallbackTemplate)
 
 	// For shared clusters, apply all dynamic config settings as overrides.
 	if !options.dedicatedCluster && len(options.dynamicConfigSettings) > 0 {


### PR DESCRIPTION
## What changed?

When we set Nexus callback URL in test_env.go, the dynamic config override is still tied to the test's lifetime, not the cluster's lifetime, so a subsequent test that reuse this cluster will not have that override. Moving the override to onebox.go (similar pattern to https://github.com/temporalio/temporal/pull/9918) so this default lives for the lifetime of the cluster.

## Why?

Ran into issue with task token not set in https://github.com/temporalio/temporal/pull/9614/, this solves it. Breaking the fix in a separate PR for ease of review + checking this in first.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
