### PR TITLE
DescribeNamespace with weak consistency

### DIFF
--- a/common/namespace/namespace.go
+++ b/common/namespace/namespace.go
@@ -231,6 +231,24 @@ func (ns *Namespace) FailoverNotificationVersion() int64 {
 	return ns.replicationResolver.FailoverNotificationVersion()
 }
 
+// Info returns the underlying NamespaceInfo proto. The returned value is the registry's own
+// copy and must not be mutated.
+func (ns *Namespace) Info() *persistencespb.NamespaceInfo {
+	return ns.info
+}
+
+// Config returns the underlying NamespaceConfig proto. The returned value is the registry's own
+// copy and must not be mutated.
+func (ns *Namespace) Config() *persistencespb.NamespaceConfig {
+	return ns.config
+}
+
+// ReplicationConfig returns the underlying NamespaceReplicationConfig proto. The returned value
+// is the registry's own copy and must not be mutated.
+func (ns *Namespace) ReplicationConfig() *persistencespb.NamespaceReplicationConfig {
+	return ns.replicationResolver.ReplicationConfig()
+}
+
 // NotificationVersion return the global notification version of when namespace changed
 func (ns *Namespace) NotificationVersion() int64 {
 	return ns.notificationVersion

--- a/common/namespace/replication_resolver.go
+++ b/common/namespace/replication_resolver.go
@@ -29,6 +29,7 @@ type ReplicationResolver interface {
 	IsGlobalNamespace() bool
 	FailoverVersion(businessID string) int64
 	FailoverNotificationVersion() int64
+	ReplicationConfig() *persistencespb.NamespaceReplicationConfig
 
 	// Mutation methods for modifying resolver state
 	SetGlobalFlag(isGlobal bool)
@@ -104,6 +105,10 @@ func (r *defaultReplicationResolver) FailoverVersion(businessID string) int64 {
 
 func (r *defaultReplicationResolver) FailoverNotificationVersion() int64 {
 	return r.failoverNotificationVersion
+}
+
+func (r *defaultReplicationResolver) ReplicationConfig() *persistencespb.NamespaceReplicationConfig {
+	return r.replicationConfig
 }
 
 func (r *defaultReplicationResolver) SetGlobalFlag(isGlobal bool) {

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
-	go.temporal.io/api v1.62.12-0.20260427172148-34044e215df3
+	go.temporal.io/api v1.62.12-0.20260428190948-a7b1d495e2e4
 	go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2
 	go.temporal.io/sdk v1.41.1
 	go.uber.org/fx v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -469,8 +469,8 @@ go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0 h1:R
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0/go.mod h1:I89cynRj8y+383o7tEQVg2SVA6SRgDVIouWPUVXjx0U=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0 h1:CQvJSldHRUN6Z8jsUeYv8J0lXRvygALXIzsmAeCcZE0=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0/go.mod h1:xSQ+mEfJe/GjK1LXEyVOoSI1N9JV9ZI923X5kup43W4=
-go.temporal.io/api v1.62.12-0.20260427172148-34044e215df3 h1:6MMqFF1Gj9wMPOY3VM1EIEA/y29Y92CZKj4IjGy5UNA=
-go.temporal.io/api v1.62.12-0.20260427172148-34044e215df3/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
+go.temporal.io/api v1.62.12-0.20260428190948-a7b1d495e2e4 h1:AwdQ+0+voxlyZZ54q88ezX0Zzxz2s9H+oSmCf4byy5k=
+go.temporal.io/api v1.62.12-0.20260428190948-a7b1d495e2e4/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2 h1:1hKeH3GyR6YD6LKMHGCZ76t6h1Sgha0hXVQBxWi3dlQ=
 go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2/go.mod h1:T8dnzVPeO+gaUTj9eDgm/lT2lZH4+JXNvrGaQGyVi50=
 go.temporal.io/sdk v1.41.1 h1:yOpvsHyDD1lNuwlGBv/SUodCPhjv9nDeC9lLHW/fJUA=

--- a/service/frontend/namespace_handler.go
+++ b/service/frontend/namespace_handler.go
@@ -38,6 +38,7 @@ type (
 	namespaceHandler struct {
 		logger                 log.Logger
 		metadataMgr            persistence.MetadataManager
+		namespaceRegistry      namespace.Registry
 		clusterMetadata        cluster.Metadata
 		namespaceReplicator    nsreplication.Replicator
 		namespaceAttrValidator *nsmanager.Validator
@@ -66,6 +67,7 @@ var (
 func newNamespaceHandler(
 	logger log.Logger,
 	metadataMgr persistence.MetadataManager,
+	namespaceRegistry namespace.Registry,
 	clusterMetadata cluster.Metadata,
 	namespaceReplicator nsreplication.Replicator,
 	archivalMetadata archiver.ArchivalMetadata,
@@ -76,6 +78,7 @@ func newNamespaceHandler(
 	return &namespaceHandler{
 		logger:                 logger,
 		metadataMgr:            metadataMgr,
+		namespaceRegistry:      namespaceRegistry,
 		clusterMetadata:        clusterMetadata,
 		namespaceReplicator:    namespaceReplicator,
 		namespaceAttrValidator: nsmanager.NewValidator(clusterMetadata),
@@ -317,6 +320,10 @@ func (d *namespaceHandler) DescribeNamespace(
 	describeRequest *workflowservice.DescribeNamespaceRequest,
 ) (*workflowservice.DescribeNamespaceResponse, error) {
 
+	if describeRequest.GetWeakConsistency() {
+		return d.describeNamespaceFromRegistry(describeRequest)
+	}
+
 	// TODO, we should migrate the non global namespace to new table, see #773
 	req := &persistence.GetNamespaceRequest{
 		Name: describeRequest.GetNamespace(),
@@ -333,6 +340,35 @@ func (d *namespaceHandler) DescribeNamespace(
 	}
 	response.NamespaceInfo, response.Config, response.ReplicationConfig, response.FailoverHistory =
 		d.createResponse(resp.Namespace.Info, resp.Namespace.Config, resp.Namespace.ReplicationConfig)
+	return response, nil
+}
+
+// describeNamespaceFromRegistry serves DescribeNamespace from the in-memory namespace registry. The response may be stale,
+// and may return NamespaceNotFound for namespaces created within the registry's refresh window.
+func (d *namespaceHandler) describeNamespaceFromRegistry(request *workflowservice.DescribeNamespaceRequest) (*workflowservice.DescribeNamespaceResponse, error) {
+	opts := namespace.GetNamespaceOptions{DisableReadthrough: true}
+	var ns *namespace.Namespace
+	var err error
+	switch {
+	case request.GetId() != "" && request.GetNamespace() != "":
+		return nil, serviceerror.NewInvalidArgument("GetNamespace operation failed. Both ID and Name specified in request.")
+	case request.GetId() != "":
+		ns, err = d.namespaceRegistry.GetNamespaceByIDWithOptions(namespace.ID(request.GetId()), opts)
+	case request.GetNamespace() != "":
+		ns, err = d.namespaceRegistry.GetNamespaceWithOptions(namespace.Name(request.GetNamespace()), opts)
+	default:
+		return nil, errNamespaceNotSet
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	response := &workflowservice.DescribeNamespaceResponse{
+		IsGlobalNamespace: ns.IsGlobalNamespace(),
+		FailoverVersion:   ns.FailoverVersion(namespace.EmptyBusinessID),
+	}
+	response.NamespaceInfo, response.Config, response.ReplicationConfig, response.FailoverHistory =
+		d.createResponse(ns.Info(), ns.Config(), ns.ReplicationConfig())
 	return response, nil
 }
 

--- a/service/frontend/namespace_handler_test.go
+++ b/service/frontend/namespace_handler_test.go
@@ -23,6 +23,7 @@ import (
 	"go.temporal.io/server/common/config"
 	dc "go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/namespace/nsreplication"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/testing/protoassert"
@@ -87,6 +88,7 @@ func (s *namespaceHandlerCommonSuite) SetupTest() {
 	s.handler = newNamespaceHandler(
 		logger,
 		s.mockMetadataMgr,
+		namespace.NewMockRegistry(s.controller),
 		s.mockClusterMetadata,
 		s.mockNamespaceReplicator,
 		s.archivalMetadata,

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -344,6 +344,7 @@ func NewWorkflowHandler(
 		namespaceHandler: newNamespaceHandler(
 			logger,
 			persistenceMetadataManager,
+			namespaceRegistry,
 			clusterMetadata,
 			nsreplication.NewReplicator(namespaceReplicationQueue, logger),
 			archivalMetadata,

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -1606,6 +1606,91 @@ func (s *WorkflowHandlerSuite) TestDescribeNamespace_Success_ArchivalEnabled() {
 	s.Equal(testVisibilityArchivalURI, result.Config.GetVisibilityArchivalUri())
 }
 
+func (s *WorkflowHandlerSuite) TestDescribeNamespace_WeakConsistency_ByName() {
+	ns := namespace.NewLocalNamespaceForTest(
+		&persistencespb.NamespaceInfo{Id: testNamespaceID, Name: "test-namespace"},
+		&persistencespb.NamespaceConfig{Retention: timestamp.DurationFromDays(1)},
+		cluster.TestCurrentClusterName,
+	)
+	s.mockNamespaceCache.EXPECT().
+		GetNamespaceWithOptions(namespace.Name("test-namespace"), namespace.GetNamespaceOptions{DisableReadthrough: true}).
+		Return(ns, nil)
+
+	wh := s.getWorkflowHandler(s.newConfig())
+	result, err := wh.DescribeNamespace(context.Background(), &workflowservice.DescribeNamespaceRequest{
+		Namespace:       "test-namespace",
+		WeakConsistency: true,
+	})
+
+	s.NoError(err)
+	s.NotNil(result)
+	s.Equal("test-namespace", result.NamespaceInfo.Name)
+	s.Equal(testNamespaceID, result.NamespaceInfo.Id)
+}
+
+func (s *WorkflowHandlerSuite) TestDescribeNamespace_WeakConsistency_ByID() {
+	ns := namespace.NewLocalNamespaceForTest(
+		&persistencespb.NamespaceInfo{Id: testNamespaceID, Name: "test-namespace"},
+		&persistencespb.NamespaceConfig{Retention: timestamp.DurationFromDays(1)},
+		cluster.TestCurrentClusterName,
+	)
+	s.mockNamespaceCache.EXPECT().
+		GetNamespaceByIDWithOptions(namespace.ID(testNamespaceID), namespace.GetNamespaceOptions{DisableReadthrough: true}).
+		Return(ns, nil)
+
+	wh := s.getWorkflowHandler(s.newConfig())
+	result, err := wh.DescribeNamespace(context.Background(), &workflowservice.DescribeNamespaceRequest{
+		Id:              testNamespaceID,
+		WeakConsistency: true,
+	})
+
+	s.NoError(err)
+	s.NotNil(result)
+	s.Equal(testNamespaceID, result.NamespaceInfo.Id)
+}
+
+func (s *WorkflowHandlerSuite) TestDescribeNamespace_WeakConsistency_CacheMiss() {
+	notFound := serviceerror.NewNamespaceNotFound("missing")
+	s.mockNamespaceCache.EXPECT().
+		GetNamespaceWithOptions(namespace.Name("missing"), namespace.GetNamespaceOptions{DisableReadthrough: true}).
+		Return(nil, notFound)
+
+	wh := s.getWorkflowHandler(s.newConfig())
+	result, err := wh.DescribeNamespace(context.Background(), &workflowservice.DescribeNamespaceRequest{
+		Namespace:       "missing",
+		WeakConsistency: true,
+	})
+
+	s.Error(err)
+	s.Nil(result)
+	var nsNotFound *serviceerror.NamespaceNotFound
+	s.ErrorAs(err, &nsNotFound)
+}
+
+func (s *WorkflowHandlerSuite) TestDescribeNamespace_WeakConsistency_NameAndIDNotSet() {
+	wh := s.getWorkflowHandler(s.newConfig())
+	result, err := wh.DescribeNamespace(context.Background(), &workflowservice.DescribeNamespaceRequest{
+		WeakConsistency: true,
+	})
+
+	s.Equal(errNamespaceNotSet, err)
+	s.Nil(result)
+}
+
+func (s *WorkflowHandlerSuite) TestDescribeNamespace_WeakConsistency_BothNameAndIDSet() {
+	wh := s.getWorkflowHandler(s.newConfig())
+	result, err := wh.DescribeNamespace(context.Background(), &workflowservice.DescribeNamespaceRequest{
+		Namespace:       "test-namespace",
+		Id:              testNamespaceID,
+		WeakConsistency: true,
+	})
+
+	s.Error(err)
+	s.Nil(result)
+	var invalidArg *serviceerror.InvalidArgument
+	s.ErrorAs(err, &invalidArg)
+}
+
 func (s *WorkflowHandlerSuite) TestUpdateNamespace_Failure_UpdateExistingArchivalURI() {
 	s.mockMetadataMgr.EXPECT().GetMetadata(gomock.Any()).Return(&persistence.GetMetadataResponse{
 		NotificationVersion: int64(0),

--- a/tests/namespace_test.go
+++ b/tests/namespace_test.go
@@ -418,3 +418,58 @@ func (s *namespaceTestSuite) Test_NamespaceDelete_Protected() {
 	s.ErrorAs(err, &failedPreconditionErr)
 	s.Equal(fmt.Sprintf("namespace %s is protected from deletion", tv.NamespaceName().String()), failedPreconditionErr.Message)
 }
+
+func (s *namespaceTestSuite) Test_DescribeNamespace_WeakConsistency() {
+	ctx, cancel := rpc.NewContextWithTimeoutAndVersionHeaders(60 * time.Second)
+	defer cancel()
+
+	nsName := "ns_weak_" + uuid.NewString()
+	_, err := s.FrontendClient().RegisterNamespace(ctx, &workflowservice.RegisterNamespaceRequest{
+		Namespace:                        nsName,
+		Description:                      "weak consistency test",
+		WorkflowExecutionRetentionPeriod: durationpb.New(24 * time.Hour),
+		HistoryArchivalState:             enumspb.ARCHIVAL_STATE_DISABLED,
+		VisibilityArchivalState:          enumspb.ARCHIVAL_STATE_DISABLED,
+	})
+	s.NoError(err)
+
+	var nsNotFound *serviceerror.NamespaceNotFound
+
+	// Cache is populated by the periodic refresh, so the weak path should eventually succeed.
+	var weakResp *workflowservice.DescribeNamespaceResponse
+	s.Eventually(func() bool {
+		weakResp, err = s.FrontendClient().DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{
+			Namespace:       nsName,
+			WeakConsistency: true,
+		})
+		// fail the test if error is not nil or NamespaceNotFound
+		if err != nil && !errors.As(err, &nsNotFound) {
+			s.Failf("unexpected error", "Expected NamespaceNotFound error, got: %v", err)
+		}
+		return err == nil
+	}, 5*testcore.NamespaceCacheRefreshInterval, 100*time.Millisecond) //nolint:forbidigo
+
+	strongResp, err := s.FrontendClient().DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{
+		Namespace: nsName,
+	})
+	s.NoError(err)
+	s.Equal(strongResp.GetNamespaceInfo().GetId(), weakResp.GetNamespaceInfo().GetId())
+	s.Equal(strongResp.GetNamespaceInfo().GetName(), weakResp.GetNamespaceInfo().GetName())
+	s.Equal(strongResp.GetIsGlobalNamespace(), weakResp.GetIsGlobalNamespace())
+
+	// Lookup by ID should also work via the weak path.
+	nsID := strongResp.GetNamespaceInfo().GetId()
+	weakByIDResp, err := s.FrontendClient().DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{
+		Id:              nsID,
+		WeakConsistency: true,
+	})
+	s.NoError(err)
+	s.Equal(nsName, weakByIDResp.GetNamespaceInfo().GetName())
+
+	// Non-existent namespace should return NamespaceNotFound.
+	_, err = s.FrontendClient().DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{
+		Namespace:       "ns_does_not_exist_" + uuid.NewString(),
+		WeakConsistency: true,
+	})
+	s.ErrorAs(err, &nsNotFound)
+}


### PR DESCRIPTION
## What changed?
Added server-side handling for the new `weak_consistency` flag on `DescribeNamespaceRequest` (proto change in https://github.com/temporalio/api/pull/775). When the flag is set, `DescribeNamespace` is served from the in-memory namespace registry, bypassing the metadata store. When unset, behavior is unchanged.

## Why?
`DescribeNamespace` currently always reads through to the persistence store. The new field lets clients opt into eventually-consistent reads where read-after-write semantics aren't required, while preserving the existing strong-consistency contract for operator/admin callers (default behavior unchanged).

## How did you test it?
- [X] built
- [X] added new unit test(s)
- [X] added new functional test(s)

## Potential risks
- Eventual consistency on when weak_consistency is set. A namespace created within the registry's refresh interval may return `NamespaceNotFound` even though it exists in persistence. 