### PR TITLE
switch the history.enableVersionReactivationSignals to false

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2937,7 +2937,7 @@ instead of the previous HSM backed implementation.`,
 
 	EnableVersionReactivationSignals = NewGlobalBoolSetting(
 		"history.enableVersionReactivationSignals",
-		true,
+		false,
 		`EnableVersionReactivationSignals controls whether reactivation signals are sent to version workflows
 		when workflows are pinned to a potentially DRAINED/INACTIVE version. Set to false to disable signals
 		globally if load becomes problematic.`,

--- a/tests/worker_deployment_version_test.go
+++ b/tests/worker_deployment_version_test.go
@@ -2212,6 +2212,8 @@ func (s *DeploymentVersionSuite) TestUpdateWorkflowExecutionOptions_ReactivateVe
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
+	s.OverrideDynamicConfig(dynamicconfig.EnableVersionReactivationSignals, true)
+
 	// Use shorter, explicit deployment series names to avoid truncation issues
 	// Include workflow version in deployment name to avoid conflicts in parallel tests
 	deploymentName := fmt.Sprintf("test-reactivate-wfv%d", s.workflowVersion)
@@ -2334,6 +2336,8 @@ func (s *DeploymentVersionSuite) TestStartWorkflowExecution_ReactivateVersionOnP
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
+	s.OverrideDynamicConfig(dynamicconfig.EnableVersionReactivationSignals, true)
+
 	deploymentName := fmt.Sprintf("test-start-reactivate-wfv%d", s.workflowVersion)
 	tv1 := testvars.New(s).WithDeploymentSeries(deploymentName).WithBuildID(deploymentName + "-v1").WithTaskQueue("test-start-task-queue")
 
@@ -2417,6 +2421,8 @@ func (s *DeploymentVersionSuite) TestStartWorkflowExecution_ReactivateVersionOnP
 func (s *DeploymentVersionSuite) TestStartWorkflowExecution_ReactivateVersionOnPinned_WithConflictPolicy() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
+
+	s.OverrideDynamicConfig(dynamicconfig.EnableVersionReactivationSignals, true)
 
 	deploymentName := fmt.Sprintf("test-start-conflict-reactivate-wfv%d", s.workflowVersion)
 	tv1 := testvars.New(s).WithDeploymentSeries(deploymentName).WithBuildID(deploymentName + "-v1").WithTaskQueue("test-conflict-task-queue")
@@ -2532,6 +2538,8 @@ func (s *DeploymentVersionSuite) TestSignalWithStartWorkflowExecution_Reactivate
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
+	s.OverrideDynamicConfig(dynamicconfig.EnableVersionReactivationSignals, true)
+
 	deploymentName := fmt.Sprintf("test-sws-reactivate-wfv%d", s.workflowVersion)
 	tv1 := testvars.New(s).WithDeploymentSeries(deploymentName).WithBuildID(deploymentName + "-v1").WithTaskQueue("test-sws-task-queue")
 
@@ -2621,6 +2629,8 @@ func (s *DeploymentVersionSuite) TestSignalWithStartWorkflowExecution_Reactivate
 func (s *DeploymentVersionSuite) TestResetWorkflowExecution_ReactivateVersionOnPinned() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
+
+	s.OverrideDynamicConfig(dynamicconfig.EnableVersionReactivationSignals, true)
 
 	// Use shorter, explicit deployment series names to avoid truncation issues
 	// Include workflow version in deployment name to avoid conflicts in parallel tests


### PR DESCRIPTION
## What changed?
- WISOTT

## Why?
- Making this change since we want to disable this feature for all users. We experienced an issue where if a user has a lot of workflows, and were to have an override on them, we would wrongly send a lot of these signals to the corresponding version workflow which could cause the workflow to be stuck

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a history feature flag default that affects whether reactivation signals are emitted, which can alter behavior for pinned workflows and version drainage state transitions if operators relied on the previous default.
> 
> **Overview**
> **Default behavior change:** flips `dynamicconfig.EnableVersionReactivationSignals` (`history.enableVersionReactivationSignals`) from `true` to `false`, disabling reactivation signals cluster-wide unless explicitly enabled.
> 
> **Test updates:** deployment version reactivation tests now call `OverrideDynamicConfig(dynamicconfig.EnableVersionReactivationSignals, true)` to keep validating reactivation behavior under the new default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8408704f7bf5ddb7eae8275ae375e41e648bc93a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->