### PR TITLE
Extract callback.Validator interface for extensibility

### DIFF
--- a/chasm/lib/activity/frontend.go
+++ b/chasm/lib/activity/frontend.go
@@ -38,7 +38,7 @@ var ErrStandaloneActivityDisabled = serviceerror.NewUnimplemented("Standalone ac
 
 type frontendHandler struct {
 	FrontendHandler
-	callbackValidator *callback.Validator
+	callbackValidator callback.Validator
 	client            activitypb.ActivityServiceClient
 	config            *Config
 	logger            log.Logger
@@ -50,7 +50,7 @@ type frontendHandler struct {
 
 // NewFrontendHandler creates a new FrontendHandler instance for processing activity frontend requests.
 func NewFrontendHandler(
-	callbackValidator *callback.Validator,
+	callbackValidator callback.Validator,
 	client activitypb.ActivityServiceClient,
 	config *Config,
 	logger log.Logger,

--- a/chasm/lib/callback/validator.go
+++ b/chasm/lib/callback/validator.go
@@ -11,7 +11,11 @@ import (
 )
 
 // Validator validates completion callbacks attached to executions (workflows and standalone activities).
-type Validator struct {
+type Validator interface {
+	Validate(namespaceName string, cbs []*commonpb.Callback) error
+}
+
+type validator struct {
 	maxCallbacksPerExecution dynamicconfig.IntPropertyFnWithNamespaceFilter
 	urlMaxLength             dynamicconfig.IntPropertyFnWithNamespaceFilter
 	headerMaxSize            dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -23,8 +27,8 @@ func NewValidator(
 	urlMaxLength dynamicconfig.IntPropertyFnWithNamespaceFilter,
 	headerMaxSize dynamicconfig.IntPropertyFnWithNamespaceFilter,
 	endpointRules dynamicconfig.TypedPropertyFnWithNamespaceFilter[AddressMatchRules],
-) *Validator {
-	return &Validator{
+) Validator {
+	return &validator{
 		maxCallbacksPerExecution: maxCallbacksPerExecution,
 		urlMaxLength:             urlMaxLength,
 		headerMaxSize:            headerMaxSize,
@@ -34,7 +38,7 @@ func NewValidator(
 
 // Validate validates completion callbacks: count, URL length, endpoint allowlist, header size, and normalizes header
 // keys to lowercase.
-func (v *Validator) Validate(namespaceName string, cbs []*commonpb.Callback) error {
+func (v *validator) Validate(namespaceName string, cbs []*commonpb.Callback) error {
 	if len(cbs) > v.maxCallbacksPerExecution(namespaceName) {
 		return serviceerror.NewInvalidArgumentf(
 			"cannot attach more than %d callbacks to an execution", v.maxCallbacksPerExecution(namespaceName),

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -827,7 +827,7 @@ func OperatorHandlerProvider(
 // so that existing operator configurations (component.callbacks.allowedAddresses) are honored.
 // TODO: Once HSM callbacks (components/callbacks) are removed, move this provider into
 // chasm/lib/callback/fx.go and read directly from callback.AllowedAddresses.
-func callbackValidatorProvider(dc *dynamicconfig.Collection) *callback.Validator {
+func callbackValidatorProvider(dc *dynamicconfig.Collection) callback.Validator {
 	return callback.NewValidator(
 		callback.MaxPerExecution.Get(dc),
 		dynamicconfig.FrontendCallbackURLMaxLength.Get(dc),
@@ -876,7 +876,7 @@ func HandlerProvider(
 	healthInterceptor *interceptor.HealthInterceptor,
 	scheduleSpecBuilder *scheduler.SpecBuilder,
 	activityHandler activity.FrontendHandler,
-	callbackValidator *callback.Validator,
+	callbackValidator callback.Validator,
 	nexusOperationHandler chasmnexus.FrontendHandler,
 	registry *chasm.Registry,
 	frontendServiceResolver membership.ServiceResolver,

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -123,7 +123,7 @@ type (
 
 		status int32
 
-		callbackValidator               *callback.Validator
+		callbackValidator               callback.Validator
 		tokenSerializer                 *tasktoken.Serializer
 		config                          *Config
 		versionChecker                  headers.VersionChecker
@@ -302,7 +302,7 @@ func (wh *WorkflowHandler) ValidateWorkerDeploymentVersionComputeConfig(
 
 // NewWorkflowHandler creates a gRPC handler for workflowservice
 func NewWorkflowHandler(
-	callbackValidator *callback.Validator,
+	callbackValidator callback.Validator,
 	config *Config,
 	namespaceReplicationQueue persistence.NamespaceReplicationQueue,
 	visibilityMgr manager.VisibilityManager,


### PR DESCRIPTION
## What changed?
Extracted a `callback.Validator` interface from the concrete struct in `chasm/lib/callback`. The struct is now unexported, and all consumers accept the interface instead of the concrete type.

## Why?
The concrete struct couldn't be decorated or wrapped. By exposing an interface, deployments can use `fx.Decorate` to layer additional callback validation rules on top of the default implementation without modifying server code.  

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

