### PR TITLE
Refactor Nexus endpoint creation for functional tests

### DIFF
--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -270,15 +270,15 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes(useTemporalFailures
 
 	testFn := func(s *NexusApiTestSuite, tc testcase, dispatchOnlyByEndpoint bool) {
 		env := newNexusTestEnv(s.T(), useTemporalFailures)
-		endpoint := env.createNexusEndpoint(s.T(), tc.endpointName, testcore.RandomizeStr("task-queue"))
+		ctx, cancel := context.WithCancel(env.Context())
+		defer cancel()
+		endpoint := env.createNexusEndpoint(ctx, s.T(), tc.endpointName, testcore.RandomizeStr("task-queue"))
 		var dispatchURL string
 		if dispatchOnlyByEndpoint {
 			dispatchURL = getDispatchByEndpointURL(env.HttpAPIAddress(), endpoint.Id)
 		} else {
 			dispatchURL = getDispatchByNsAndTqURL(env.HttpAPIAddress(), env.Namespace().String(), endpoint.Spec.Target.GetWorker().TaskQueue)
 		}
-		ctx, cancel := context.WithCancel(testcore.NewContext())
-		defer cancel()
 
 		httpCaller, headerCapture := newHeaderCaptureCaller()
 		client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{
@@ -416,16 +416,15 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Claims(useTemporalFailures b
 		})
 		defer env.GetTestCluster().Host().SetOnGetClaims(nil)
 
-		testEndpoint := env.createNexusEndpoint(s.T(), testcore.RandomizeStr("test-endpoint"), taskQueue)
+		ctx, cancel := context.WithCancel(env.Context())
+		defer cancel()
+		testEndpoint := env.createNexusEndpoint(ctx, s.T(), testcore.RandomizeStr("test-endpoint"), taskQueue)
 		var dispatchURL string
 		if dispatchOnlyByEndpoint {
 			dispatchURL = getDispatchByEndpointURL(env.HttpAPIAddress(), testEndpoint.Id)
 		} else {
 			dispatchURL = getDispatchByNsAndTqURL(env.HttpAPIAddress(), env.Namespace().String(), taskQueue)
 		}
-
-		ctx, cancel := context.WithCancel(testcore.NewContext())
-		defer cancel()
 
 		client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: dispatchURL, Service: "test-service"})
 		s.NoError(err)
@@ -533,15 +532,15 @@ func (s *NexusApiTestSuite) TestNexusCancelOperation_Outcomes(useTemporalFailure
 
 	testFn := func(s *NexusApiTestSuite, tc testcase, dispatchOnlyByEndpoint bool) {
 		env := newNexusTestEnv(s.T(), useTemporalFailures)
-		endpoint := env.createNexusEndpoint(s.T(), tc.endpointName, testcore.RandomizeStr("task-queue"))
+		ctx, cancel := context.WithCancel(env.Context())
+		defer cancel()
+		endpoint := env.createNexusEndpoint(ctx, s.T(), tc.endpointName, testcore.RandomizeStr("task-queue"))
 		var dispatchURL string
 		if dispatchOnlyByEndpoint {
 			dispatchURL = getDispatchByEndpointURL(env.HttpAPIAddress(), endpoint.Id)
 		} else {
 			dispatchURL = getDispatchByNsAndTqURL(env.HttpAPIAddress(), env.Namespace().String(), endpoint.Spec.Target.GetWorker().TaskQueue)
 		}
-		ctx, cancel := context.WithCancel(testcore.NewContext())
-		defer cancel()
 
 		httpCaller, headerCapture := newHeaderCaptureCaller()
 		client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{
@@ -615,7 +614,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_WithNamespaceAndTaskQueue_Su
 		testcore.WithDynamicConfig(dynamicconfig.FrontendEnableWorkerVersioningDataAPIs, true),
 	)
 
-	ctx, cancel := context.WithCancel(testcore.NewContext())
+	ctx, cancel := context.WithCancel(env.Context())
 	defer cancel()
 	taskQueue := testcore.RandomizeStr("task-queue")
 	err := env.SdkClient().UpdateWorkerBuildIdCompatibility(ctx, &sdkclient.UpdateWorkerBuildIdCompatibilityOptions{ //nolint:staticcheck // SA1019 deprecated
@@ -667,12 +666,11 @@ func (s *NexusApiTestSuite) TestNexusClientNameMetricPropagation(useTemporalFail
 	env := newNexusTestEnv(s.T(), useTemporalFailures)
 	const expectedClientName = "temporal-go"
 	taskQueue := testcore.RandomizeStr("tq")
-	endpoint := env.createNexusEndpoint(s.T(), testcore.RandomizeStr("endpoint"), taskQueue)
+	ctx, cancel := context.WithCancel(env.Context())
+	defer cancel()
+	endpoint := env.createNexusEndpoint(ctx, s.T(), testcore.RandomizeStr("endpoint"), taskQueue)
 
 	capture := env.StartNamespaceMetricCapture()
-
-	ctx, cancel := context.WithCancel(testcore.NewContext())
-	defer cancel()
 
 	// Start a poller that simulates an SDK worker with a specific client-name.
 	// We build the outgoing metadata from scratch (instead of using NewContext which

--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -270,9 +270,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes(useTemporalFailures
 
 	testFn := func(s *NexusApiTestSuite, tc testcase, dispatchOnlyByEndpoint bool) {
 		env := newNexusTestEnv(s.T(), useTemporalFailures)
-		ctx, cancel := context.WithCancel(env.Context())
-		defer cancel()
-		endpoint := env.createNexusEndpoint(ctx, s.T(), tc.endpointName, testcore.RandomizeStr("task-queue"))
+		endpoint := env.createNexusEndpoint(env.Context(), s.T(), tc.endpointName, testcore.RandomizeStr("task-queue"))
 		var dispatchURL string
 		if dispatchOnlyByEndpoint {
 			dispatchURL = getDispatchByEndpointURL(env.HttpAPIAddress(), endpoint.Id)
@@ -289,7 +287,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes(useTemporalFailures
 		s.NoError(err)
 		capture := env.StartNamespaceMetricCapture()
 
-		pollerErrCh := env.nexusTaskPoller(ctx, s.T(), endpoint.Spec.Target.GetWorker().TaskQueue, tc.handler)
+		pollerErrCh := env.nexusTaskPoller(env.Context(), s.T(), endpoint.Spec.Target.GetWorker().TaskQueue, tc.handler)
 
 		eventuallyTick := 500 * time.Millisecond
 		header := nexus.Header{"key": "value", "temporal-nexus-failure-support": "true"}
@@ -302,7 +300,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes(useTemporalFailures
 
 		// Wait until the endpoint is loaded into the registry.
 		s.Eventually(func() bool {
-			result, err = nexusrpc.StartOperation(ctx, client, op, "input", nexus.StartOperationOptions{
+			result, err = nexusrpc.StartOperation(env.Context(), client, op, "input", nexus.StartOperationOptions{
 				CallbackURL: "http://localhost/callback",
 				RequestID:   "request-id",
 				Header:      header,
@@ -416,9 +414,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Claims(useTemporalFailures b
 		})
 		defer env.GetTestCluster().Host().SetOnGetClaims(nil)
 
-		ctx, cancel := context.WithCancel(env.Context())
-		defer cancel()
-		testEndpoint := env.createNexusEndpoint(ctx, s.T(), testcore.RandomizeStr("test-endpoint"), taskQueue)
+		testEndpoint := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizeStr("test-endpoint"), taskQueue)
 		var dispatchURL string
 		if dispatchOnlyByEndpoint {
 			dispatchURL = getDispatchByEndpointURL(env.HttpAPIAddress(), testEndpoint.Id)
@@ -432,11 +428,11 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Claims(useTemporalFailures b
 		var pollerErrCh <-chan error
 		if tc.handler != nil {
 			// only set on valid request
-			pollerErrCh = env.nexusTaskPoller(ctx, s.T(), taskQueue, tc.handler)
+			pollerErrCh = env.nexusTaskPoller(env.Context(), s.T(), taskQueue, tc.handler)
 		}
 
 		capture := env.StartGlobalMetricCapture()
-		result, err := nexusrpc.StartOperation(ctx, client, op, "input", nexus.StartOperationOptions{
+		result, err := nexusrpc.StartOperation(env.Context(), client, op, "input", nexus.StartOperationOptions{
 			Header: tc.header,
 		})
 		preprocessErrors := capture.Metric("nexus_request_preprocess_errors")
@@ -532,9 +528,7 @@ func (s *NexusApiTestSuite) TestNexusCancelOperation_Outcomes(useTemporalFailure
 
 	testFn := func(s *NexusApiTestSuite, tc testcase, dispatchOnlyByEndpoint bool) {
 		env := newNexusTestEnv(s.T(), useTemporalFailures)
-		ctx, cancel := context.WithCancel(env.Context())
-		defer cancel()
-		endpoint := env.createNexusEndpoint(ctx, s.T(), tc.endpointName, testcore.RandomizeStr("task-queue"))
+		endpoint := env.createNexusEndpoint(env.Context(), s.T(), tc.endpointName, testcore.RandomizeStr("task-queue"))
 		var dispatchURL string
 		if dispatchOnlyByEndpoint {
 			dispatchURL = getDispatchByEndpointURL(env.HttpAPIAddress(), endpoint.Id)
@@ -551,7 +545,7 @@ func (s *NexusApiTestSuite) TestNexusCancelOperation_Outcomes(useTemporalFailure
 		s.NoError(err)
 		capture := env.StartNamespaceMetricCapture()
 
-		pollerErrCh := env.nexusTaskPoller(ctx, s.T(), endpoint.Spec.Target.GetWorker().TaskQueue, tc.handler)
+		pollerErrCh := env.nexusTaskPoller(env.Context(), s.T(), endpoint.Spec.Target.GetWorker().TaskQueue, tc.handler)
 
 		handle, err := client.NewOperationHandle("operation", "token")
 		s.NoError(err)
@@ -565,7 +559,7 @@ func (s *NexusApiTestSuite) TestNexusCancelOperation_Outcomes(useTemporalFailure
 
 		// Wait until the endpoint is loaded into the registry.
 		s.Eventually(func() bool {
-			err = handle.Cancel(ctx, nexus.CancelOperationOptions{Header: header})
+			err = handle.Cancel(env.Context(), nexus.CancelOperationOptions{Header: header})
 			var handlerErr *nexus.HandlerError
 			return err == nil || !(errors.As(err, &handlerErr) && handlerErr.Type == nexus.HandlerErrorTypeNotFound)
 		}, 10*time.Second, eventuallyTick)
@@ -614,15 +608,13 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_WithNamespaceAndTaskQueue_Su
 		testcore.WithDynamicConfig(dynamicconfig.FrontendEnableWorkerVersioningDataAPIs, true),
 	)
 
-	ctx, cancel := context.WithCancel(env.Context())
-	defer cancel()
 	taskQueue := testcore.RandomizeStr("task-queue")
-	err := env.SdkClient().UpdateWorkerBuildIdCompatibility(ctx, &sdkclient.UpdateWorkerBuildIdCompatibilityOptions{ //nolint:staticcheck // SA1019 deprecated
+	err := env.SdkClient().UpdateWorkerBuildIdCompatibility(env.Context(), &sdkclient.UpdateWorkerBuildIdCompatibilityOptions{ //nolint:staticcheck // SA1019 deprecated
 		TaskQueue: taskQueue,
 		Operation: &sdkclient.BuildIDOpAddNewIDInNewDefaultSet{BuildID: "old-build-id"},
 	})
 	s.NoError(err)
-	err = env.SdkClient().UpdateWorkerBuildIdCompatibility(ctx, &sdkclient.UpdateWorkerBuildIdCompatibilityOptions{ //nolint:staticcheck // SA1019 deprecated
+	err = env.SdkClient().UpdateWorkerBuildIdCompatibility(env.Context(), &sdkclient.UpdateWorkerBuildIdCompatibilityOptions{ //nolint:staticcheck // SA1019 deprecated
 		TaskQueue: taskQueue,
 		Operation: &sdkclient.BuildIDOpAddNewIDInNewDefaultSet{BuildID: "new-build-id"},
 	})
@@ -632,19 +624,19 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_WithNamespaceAndTaskQueue_Su
 	client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: u, Service: "test-service"})
 	s.NoError(err)
 	// Versioned poller gets task
-	pollerErrCh1 := env.versionedNexusTaskPoller(ctx, s.T(), taskQueue, "new-build-id", nexusEchoHandler)
+	pollerErrCh1 := env.versionedNexusTaskPoller(env.Context(), s.T(), taskQueue, "new-build-id", nexusEchoHandler)
 
-	result, err := nexusrpc.StartOperation(ctx, client, op, "input", nexus.StartOperationOptions{})
+	result, err := nexusrpc.StartOperation(env.Context(), client, op, "input", nexus.StartOperationOptions{})
 	s.NoError(err)
 	s.Equal("input", result.Successful)
 	s.NoError(<-pollerErrCh1)
 
 	// Unversioned poller doesn't get a task
-	pollerErrCh2 := env.nexusTaskPoller(ctx, s.T(), taskQueue, nexusEchoHandler)
+	pollerErrCh2 := env.nexusTaskPoller(env.Context(), s.T(), taskQueue, nexusEchoHandler)
 	// Versioned poller gets task with wrong build ID
-	pollerErrCh3 := env.versionedNexusTaskPoller(ctx, s.T(), taskQueue, "old-build-id", nexusEchoHandler)
+	pollerErrCh3 := env.versionedNexusTaskPoller(env.Context(), s.T(), taskQueue, "old-build-id", nexusEchoHandler)
 
-	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, time.Second*2)
+	timeoutCtx, timeoutCancel := context.WithTimeout(env.Context(), time.Second*2)
 	defer timeoutCancel()
 	_, err = nexusrpc.StartOperation(timeoutCtx, client, op, "input", nexus.StartOperationOptions{})
 	if !errors.Is(err, context.DeadlineExceeded) {
@@ -654,6 +646,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_WithNamespaceAndTaskQueue_Su
 		}
 	}
 	// Cancel the parent context to unblock the pollers that didn't receive a task.
+	_, cancel := context.WithCancel(env.Context())
 	cancel()
 	s.NoError(<-pollerErrCh2)
 	s.NoError(<-pollerErrCh3)
@@ -666,16 +659,15 @@ func (s *NexusApiTestSuite) TestNexusClientNameMetricPropagation(useTemporalFail
 	env := newNexusTestEnv(s.T(), useTemporalFailures)
 	const expectedClientName = "temporal-go"
 	taskQueue := testcore.RandomizeStr("tq")
-	ctx, cancel := context.WithCancel(env.Context())
-	defer cancel()
-	endpoint := env.createNexusEndpoint(ctx, s.T(), testcore.RandomizeStr("endpoint"), taskQueue)
+
+	endpoint := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizeStr("endpoint"), taskQueue)
 
 	capture := env.StartNamespaceMetricCapture()
 
 	// Start a poller that simulates an SDK worker with a specific client-name.
 	// We build the outgoing metadata from scratch (instead of using NewContext which
 	// sets client-name=temporal-server) so the SDK name is the only value.
-	pollerCtx := metadata.NewOutgoingContext(ctx, metadata.Pairs(
+	pollerCtx := metadata.NewOutgoingContext(env.Context(), metadata.Pairs(
 		"client-name", expectedClientName,
 		"client-version", "1.0.0",
 		"supported-server-versions", headers.SupportedServerVersions,
@@ -691,7 +683,7 @@ func (s *NexusApiTestSuite) TestNexusClientNameMetricPropagation(useTemporalFail
 	s.NoError(err)
 
 	s.Eventually(func() bool {
-		_, err = nexusrpc.StartOperation(ctx, client, op, "input", nexus.StartOperationOptions{})
+		_, err = nexusrpc.StartOperation(env.Context(), client, op, "input", nexus.StartOperationOptions{})
 		var handlerErr *nexus.HandlerError
 		return err == nil || (!errors.As(err, &handlerErr) || handlerErr.Type != nexus.HandlerErrorTypeNotFound)
 	}, 10*time.Second, 500*time.Millisecond)

--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -607,14 +607,16 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_WithNamespaceAndTaskQueue_Su
 		// UpdateWorkerBuildIdCompatibility is the v0.1 (Version Set-based) API gated by DataAPIs.
 		testcore.WithDynamicConfig(dynamicconfig.FrontendEnableWorkerVersioningDataAPIs, true),
 	)
+	ctx, cancel := context.WithCancel(env.Context())
+	defer cancel()
 
 	taskQueue := testcore.RandomizeStr("task-queue")
-	err := env.SdkClient().UpdateWorkerBuildIdCompatibility(env.Context(), &sdkclient.UpdateWorkerBuildIdCompatibilityOptions{ //nolint:staticcheck // SA1019 deprecated
+	err := env.SdkClient().UpdateWorkerBuildIdCompatibility(ctx, &sdkclient.UpdateWorkerBuildIdCompatibilityOptions{ //nolint:staticcheck // SA1019 deprecated
 		TaskQueue: taskQueue,
 		Operation: &sdkclient.BuildIDOpAddNewIDInNewDefaultSet{BuildID: "old-build-id"},
 	})
 	s.NoError(err)
-	err = env.SdkClient().UpdateWorkerBuildIdCompatibility(env.Context(), &sdkclient.UpdateWorkerBuildIdCompatibilityOptions{ //nolint:staticcheck // SA1019 deprecated
+	err = env.SdkClient().UpdateWorkerBuildIdCompatibility(ctx, &sdkclient.UpdateWorkerBuildIdCompatibilityOptions{ //nolint:staticcheck // SA1019 deprecated
 		TaskQueue: taskQueue,
 		Operation: &sdkclient.BuildIDOpAddNewIDInNewDefaultSet{BuildID: "new-build-id"},
 	})
@@ -624,19 +626,19 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_WithNamespaceAndTaskQueue_Su
 	client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: u, Service: "test-service"})
 	s.NoError(err)
 	// Versioned poller gets task
-	pollerErrCh1 := env.versionedNexusTaskPoller(env.Context(), s.T(), taskQueue, "new-build-id", nexusEchoHandler)
+	pollerErrCh1 := env.versionedNexusTaskPoller(ctx, s.T(), taskQueue, "new-build-id", nexusEchoHandler)
 
-	result, err := nexusrpc.StartOperation(env.Context(), client, op, "input", nexus.StartOperationOptions{})
+	result, err := nexusrpc.StartOperation(ctx, client, op, "input", nexus.StartOperationOptions{})
 	s.NoError(err)
 	s.Equal("input", result.Successful)
 	s.NoError(<-pollerErrCh1)
 
 	// Unversioned poller doesn't get a task
-	pollerErrCh2 := env.nexusTaskPoller(env.Context(), s.T(), taskQueue, nexusEchoHandler)
+	pollerErrCh2 := env.nexusTaskPoller(ctx, s.T(), taskQueue, nexusEchoHandler)
 	// Versioned poller gets task with wrong build ID
-	pollerErrCh3 := env.versionedNexusTaskPoller(env.Context(), s.T(), taskQueue, "old-build-id", nexusEchoHandler)
+	pollerErrCh3 := env.versionedNexusTaskPoller(ctx, s.T(), taskQueue, "old-build-id", nexusEchoHandler)
 
-	timeoutCtx, timeoutCancel := context.WithTimeout(env.Context(), time.Second*2)
+	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, time.Second*2)
 	defer timeoutCancel()
 	_, err = nexusrpc.StartOperation(timeoutCtx, client, op, "input", nexus.StartOperationOptions{})
 	if !errors.Is(err, context.DeadlineExceeded) {
@@ -646,7 +648,6 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_WithNamespaceAndTaskQueue_Su
 		}
 	}
 	// Cancel the parent context to unblock the pollers that didn't receive a task.
-	_, cancel := context.WithCancel(env.Context())
 	cancel()
 	s.NoError(<-pollerErrCh2)
 	s.NoError(<-pollerErrCh3)

--- a/tests/nexus_api_validation_test.go
+++ b/tests/nexus_api_validation_test.go
@@ -38,9 +38,8 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_WithNamespaceAndTa
 	u := getDispatchByNsAndTqURL(env.HttpAPIAddress(), namespace, taskQueue)
 	client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: u, Service: "test-service"})
 	s.NoError(err)
-	ctx := env.Context()
 	capture := env.StartNamespaceMetricCaptureFor(namespace)
-	_, err = nexusrpc.StartOperation(ctx, client, op, "input", nexus.StartOperationOptions{})
+	_, err = nexusrpc.StartOperation(env.Context(), client, op, "input", nexus.StartOperationOptions{})
 	var handlerError *nexus.HandlerError
 	s.ErrorAs(err, &handlerError)
 	s.Equal(nexus.HandlerErrorTypeNotFound, handlerError.Type)
@@ -64,9 +63,8 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_WithNamespaceAndTa
 	u := getDispatchByNsAndTqURL(env.HttpAPIAddress(), namespace, taskQueue)
 	client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: u, Service: "test-service"})
 	s.NoError(err)
-	ctx := env.Context()
 	capture := env.StartGlobalMetricCapture()
-	_, err = nexusrpc.StartOperation(ctx, client, op, "input", nexus.StartOperationOptions{})
+	_, err = nexusrpc.StartOperation(env.Context(), client, op, "input", nexus.StartOperationOptions{})
 	var handlerErr *nexus.HandlerError
 	s.ErrorAs(err, &handlerErr)
 	s.Equal(nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
@@ -182,8 +180,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_Forbidden() {
 	testFn := func(s *NexusAPIValidationTestSuite, tc testcase, dispatchOnlyByEndpoint bool) {
 		env := newNexusTestEnv(s.T(), false, testcore.WithDedicatedCluster())
 		taskQueue := testcore.RandomizeStr("task-queue")
-		ctx := env.Context()
-		testEndpoint := env.createNexusEndpoint(ctx, s.T(), testcore.RandomizeStr("test-endpoint"), taskQueue)
+		testEndpoint := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizeStr("test-endpoint"), taskQueue)
 
 		env.GetTestCluster().Host().SetOnAuthorize(tc.onAuthorize(testEndpoint.Spec.Name))
 		s.T().Cleanup(func() { env.GetTestCluster().Host().SetOnAuthorize(nil) })
@@ -204,7 +201,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_Forbidden() {
 
 		// Wait until the endpoint is loaded into the registry.
 		s.Eventually(func() bool {
-			_, err = nexusrpc.StartOperation(ctx, client, op, "input", nexus.StartOperationOptions{})
+			_, err = nexusrpc.StartOperation(env.Context(), client, op, "input", nexus.StartOperationOptions{})
 			var handlerErr *nexus.HandlerError
 			return err == nil || (!errors.As(err, &handlerErr) || handlerErr.Type != nexus.HandlerErrorTypeNotFound)
 		}, 10*time.Second, 1*time.Second)
@@ -235,9 +232,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_PayloadSizeLimit()
 	testFn := func(s *NexusAPIValidationTestSuite, dispatchOnlyByEndpoint bool) {
 		env := newNexusTestEnv(s.T(), false)
 		taskQueue := testcore.RandomizeStr("task-queue")
-		ctx, cancel := context.WithCancel(env.Context())
-		defer cancel()
-		testEndpoint := env.createNexusEndpoint(ctx, s.T(), testcore.RandomizeStr("test-endpoint"), taskQueue)
+		testEndpoint := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizeStr("test-endpoint"), taskQueue)
 
 		var dispatchURL string
 		if dispatchOnlyByEndpoint {
@@ -252,7 +247,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_PayloadSizeLimit()
 
 		// Wait until the endpoint is loaded into the registry.
 		s.Eventually(func() bool {
-			result, err = nexusrpc.StartOperation(ctx, client, op, input, nexus.StartOperationOptions{
+			result, err = nexusrpc.StartOperation(env.Context(), client, op, input, nexus.StartOperationOptions{
 				CallbackURL: "http://localhost/callback",
 				RequestID:   "request-id",
 			})
@@ -273,7 +268,6 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_PayloadSizeLimit()
 
 func (s *NexusAPIValidationTestSuite) TestNexus_RespondNexusTaskMethods_VerifiesTaskTokenMatchesRequestNamespace() {
 	env := newNexusTestEnv(s.T(), false)
-	ctx := env.Context()
 
 	tt := tokenspb.NexusTask{
 		NamespaceId: env.NamespaceID().String(),
@@ -283,7 +277,7 @@ func (s *NexusAPIValidationTestSuite) TestNexus_RespondNexusTaskMethods_Verifies
 	ttBytes, err := tt.Marshal()
 	s.NoError(err)
 
-	_, err = env.FrontendClient().RespondNexusTaskCompleted(ctx, &workflowservice.RespondNexusTaskCompletedRequest{
+	_, err = env.FrontendClient().RespondNexusTaskCompleted(env.Context(), &workflowservice.RespondNexusTaskCompletedRequest{
 		Namespace: env.ExternalNamespace().String(),
 		Identity:  uuid.NewString(),
 		TaskToken: ttBytes,
@@ -291,7 +285,7 @@ func (s *NexusAPIValidationTestSuite) TestNexus_RespondNexusTaskMethods_Verifies
 	})
 	s.ErrorContains(err, "Operation requested with a token from a different namespace.")
 
-	_, err = env.FrontendClient().RespondNexusTaskFailed(ctx, &workflowservice.RespondNexusTaskFailedRequest{
+	_, err = env.FrontendClient().RespondNexusTaskFailed(env.Context(), &workflowservice.RespondNexusTaskFailedRequest{
 		Namespace: env.ExternalNamespace().String(),
 		Identity:  uuid.NewString(),
 		TaskToken: ttBytes,
@@ -302,7 +296,6 @@ func (s *NexusAPIValidationTestSuite) TestNexus_RespondNexusTaskMethods_Verifies
 
 func (s *NexusAPIValidationTestSuite) TestNexus_RespondNexusTaskCompleted_ValidateOperationTokenLength() {
 	env := newNexusTestEnv(s.T(), false)
-	ctx := env.Context()
 
 	tt := tokenspb.NexusTask{
 		NamespaceId: env.NamespaceID().String(),
@@ -312,7 +305,7 @@ func (s *NexusAPIValidationTestSuite) TestNexus_RespondNexusTaskCompleted_Valida
 	ttBytes, err := tt.Marshal()
 	s.NoError(err)
 
-	_, err = env.FrontendClient().RespondNexusTaskCompleted(ctx, &workflowservice.RespondNexusTaskCompletedRequest{
+	_, err = env.FrontendClient().RespondNexusTaskCompleted(env.Context(), &workflowservice.RespondNexusTaskCompletedRequest{
 		Namespace: env.Namespace().String(),
 		Identity:  uuid.NewString(),
 		TaskToken: ttBytes,
@@ -335,7 +328,6 @@ func (s *NexusAPIValidationTestSuite) TestNexus_RespondNexusTaskCompleted_Valida
 
 func (s *NexusAPIValidationTestSuite) TestNexus_RespondNexusTaskMethods_ValidateFailureDetailsJSON() {
 	env := newNexusTestEnv(s.T(), false)
-	ctx := env.Context()
 
 	tt := tokenspb.NexusTask{
 		NamespaceId: env.NamespaceID().String(),
@@ -345,7 +337,7 @@ func (s *NexusAPIValidationTestSuite) TestNexus_RespondNexusTaskMethods_Validate
 	ttBytes, err := tt.Marshal()
 	s.NoError(err)
 
-	_, err = env.FrontendClient().RespondNexusTaskCompleted(ctx, &workflowservice.RespondNexusTaskCompletedRequest{
+	_, err = env.FrontendClient().RespondNexusTaskCompleted(env.Context(), &workflowservice.RespondNexusTaskCompletedRequest{
 		Namespace: env.Namespace().String(),
 		Identity:  uuid.NewString(),
 		TaskToken: ttBytes,
@@ -368,7 +360,7 @@ func (s *NexusAPIValidationTestSuite) TestNexus_RespondNexusTaskMethods_Validate
 	s.ErrorAs(err, &invalidArgumentErr)
 	s.Equal("failure details must be JSON serializable", invalidArgumentErr.Message)
 
-	_, err = env.FrontendClient().RespondNexusTaskFailed(ctx, &workflowservice.RespondNexusTaskFailedRequest{
+	_, err = env.FrontendClient().RespondNexusTaskFailed(env.Context(), &workflowservice.RespondNexusTaskFailedRequest{
 		Namespace: env.Namespace().String(),
 		Identity:  uuid.NewString(),
 		TaskToken: ttBytes,
@@ -387,9 +379,8 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_ByEndpoint_Endpoin
 	u := getDispatchByEndpointURL(env.HttpAPIAddress(), uuid.NewString())
 	client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: u, Service: "test-service"})
 	s.NoError(err)
-	ctx := env.Context()
 	capture := env.StartGlobalMetricCapture()
-	_, err = nexusrpc.StartOperation(ctx, client, op, "input", nexus.StartOperationOptions{})
+	_, err = nexusrpc.StartOperation(env.Context(), client, op, "input", nexus.StartOperationOptions{})
 	var handlerErr *nexus.HandlerError
 	s.ErrorAs(err, &handlerErr)
 	s.Equal(nexus.HandlerErrorTypeNotFound, handlerErr.Type)

--- a/tests/nexus_api_validation_test.go
+++ b/tests/nexus_api_validation_test.go
@@ -38,7 +38,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_WithNamespaceAndTa
 	u := getDispatchByNsAndTqURL(env.HttpAPIAddress(), namespace, taskQueue)
 	client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: u, Service: "test-service"})
 	s.NoError(err)
-	ctx := testcore.NewContext()
+	ctx := env.Context()
 	capture := env.StartNamespaceMetricCaptureFor(namespace)
 	_, err = nexusrpc.StartOperation(ctx, client, op, "input", nexus.StartOperationOptions{})
 	var handlerError *nexus.HandlerError
@@ -64,7 +64,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_WithNamespaceAndTa
 	u := getDispatchByNsAndTqURL(env.HttpAPIAddress(), namespace, taskQueue)
 	client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: u, Service: "test-service"})
 	s.NoError(err)
-	ctx := testcore.NewContext()
+	ctx := env.Context()
 	capture := env.StartGlobalMetricCapture()
 	_, err = nexusrpc.StartOperation(ctx, client, op, "input", nexus.StartOperationOptions{})
 	var handlerErr *nexus.HandlerError
@@ -182,7 +182,8 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_Forbidden() {
 	testFn := func(s *NexusAPIValidationTestSuite, tc testcase, dispatchOnlyByEndpoint bool) {
 		env := newNexusTestEnv(s.T(), false, testcore.WithDedicatedCluster())
 		taskQueue := testcore.RandomizeStr("task-queue")
-		testEndpoint := env.createNexusEndpoint(s.T(), testcore.RandomizeStr("test-endpoint"), taskQueue)
+		ctx := env.Context()
+		testEndpoint := env.createNexusEndpoint(ctx, s.T(), testcore.RandomizeStr("test-endpoint"), taskQueue)
 
 		env.GetTestCluster().Host().SetOnAuthorize(tc.onAuthorize(testEndpoint.Spec.Name))
 		s.T().Cleanup(func() { env.GetTestCluster().Host().SetOnAuthorize(nil) })
@@ -198,7 +199,6 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_Forbidden() {
 
 		client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: dispatchURL, Service: "test-service"})
 		s.NoError(err)
-		ctx := testcore.NewContext()
 
 		capture := env.StartNamespaceMetricCapture()
 
@@ -235,7 +235,9 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_PayloadSizeLimit()
 	testFn := func(s *NexusAPIValidationTestSuite, dispatchOnlyByEndpoint bool) {
 		env := newNexusTestEnv(s.T(), false)
 		taskQueue := testcore.RandomizeStr("task-queue")
-		testEndpoint := env.createNexusEndpoint(s.T(), testcore.RandomizeStr("test-endpoint"), taskQueue)
+		ctx, cancel := context.WithCancel(env.Context())
+		defer cancel()
+		testEndpoint := env.createNexusEndpoint(ctx, s.T(), testcore.RandomizeStr("test-endpoint"), taskQueue)
 
 		var dispatchURL string
 		if dispatchOnlyByEndpoint {
@@ -243,9 +245,6 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_PayloadSizeLimit()
 		} else {
 			dispatchURL = getDispatchByNsAndTqURL(env.HttpAPIAddress(), env.Namespace().String(), taskQueue)
 		}
-
-		ctx, cancel := context.WithCancel(testcore.NewContext())
-		defer cancel()
 
 		client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: dispatchURL, Service: "test-service"})
 		s.NoError(err)
@@ -274,7 +273,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_PayloadSizeLimit()
 
 func (s *NexusAPIValidationTestSuite) TestNexus_RespondNexusTaskMethods_VerifiesTaskTokenMatchesRequestNamespace() {
 	env := newNexusTestEnv(s.T(), false)
-	ctx := testcore.NewContext()
+	ctx := env.Context()
 
 	tt := tokenspb.NexusTask{
 		NamespaceId: env.NamespaceID().String(),
@@ -303,7 +302,7 @@ func (s *NexusAPIValidationTestSuite) TestNexus_RespondNexusTaskMethods_Verifies
 
 func (s *NexusAPIValidationTestSuite) TestNexus_RespondNexusTaskCompleted_ValidateOperationTokenLength() {
 	env := newNexusTestEnv(s.T(), false)
-	ctx := testcore.NewContext()
+	ctx := env.Context()
 
 	tt := tokenspb.NexusTask{
 		NamespaceId: env.NamespaceID().String(),
@@ -336,7 +335,7 @@ func (s *NexusAPIValidationTestSuite) TestNexus_RespondNexusTaskCompleted_Valida
 
 func (s *NexusAPIValidationTestSuite) TestNexus_RespondNexusTaskMethods_ValidateFailureDetailsJSON() {
 	env := newNexusTestEnv(s.T(), false)
-	ctx := testcore.NewContext()
+	ctx := env.Context()
 
 	tt := tokenspb.NexusTask{
 		NamespaceId: env.NamespaceID().String(),
@@ -388,7 +387,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_ByEndpoint_Endpoin
 	u := getDispatchByEndpointURL(env.HttpAPIAddress(), uuid.NewString())
 	client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: u, Service: "test-service"})
 	s.NoError(err)
-	ctx := testcore.NewContext()
+	ctx := env.Context()
 	capture := env.StartGlobalMetricCapture()
 	_, err = nexusrpc.StartOperation(ctx, client, op, "input", nexus.StartOperationOptions{})
 	var handlerErr *nexus.HandlerError

--- a/tests/nexus_standalone_test.go
+++ b/tests/nexus_standalone_test.go
@@ -52,7 +52,7 @@ func (s *NexusStandaloneTestSuite) newTestEnv(opts ...testcore.TestOption) *Nexu
 func (s *NexusStandaloneTestSuite) TestStartStandaloneNexusOperation() {
 	s.Run("StartAndDescribe", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		testInput := payload.EncodeString("test-input")
 		testHeader := map[string]string{"test-key": "test-value"}
@@ -153,7 +153,7 @@ func (s *NexusStandaloneTestSuite) TestStartStandaloneNexusOperation() {
 
 	s.Run("IDConflictPolicyFail", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		resp1, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -188,7 +188,7 @@ func (s *NexusStandaloneTestSuite) TestStartStandaloneNexusOperation() {
 
 	s.Run("IDConflictPolicyUseExisting", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		resp1, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -223,7 +223,9 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 
 	s.Run("LongPollStateChange", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		ctx, cancel := context.WithTimeout(env.Context(), 10*time.Second)
+		defer cancel()
+		endpointName := env.createRandomNexusEndpoint(ctx, s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -240,9 +242,6 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 		s.NoError(err)
 		s.NotEmpty(firstResp.GetLongPollToken())
 		s.Equal(enumspb.NEXUS_OPERATION_EXECUTION_STATUS_RUNNING, firstResp.GetInfo().GetStatus())
-
-		ctx, cancel := context.WithTimeout(env.Context(), 10*time.Second)
-		defer cancel()
 
 		// Start polling.
 		type describeResult struct {
@@ -306,7 +305,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 
 	s.Run("LongPollTimeoutReturnsEmptyResponse", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -357,8 +356,10 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 
 	s.Run("IncludeOutcome_Success", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
+		ctx, cancel := context.WithTimeout(env.Context(), 10*time.Second)
+		defer cancel()
 		taskQueue := testcore.RandomizedNexusEndpoint(s.T().Name())
-		endpointName := env.createNexusEndpoint(s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
+		endpointName := env.createNexusEndpoint(ctx, s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
 		expectedResult := payload.EncodeString("successful result")
 		handlerLink := &commonpb.Link_WorkflowEvent{
 			Namespace:  env.Namespace().String(),
@@ -377,9 +378,6 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 			Endpoint:    endpointName,
 		})
 		s.NoError(err)
-
-		ctx, cancel := context.WithTimeout(env.Context(), 10*time.Second)
-		defer cancel()
 
 		pollerErrCh := make(chan error, 1)
 		go func() {
@@ -474,7 +472,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 		s.Run("ScheduleToStartTimeout", func(s *NexusStandaloneTestSuite) {
 			env := s.newTestEnv()
 			taskQueue := testcore.RandomizedNexusEndpoint(s.T().Name())
-			endpointName := env.createNexusEndpoint(s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
+			endpointName := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
 
 			startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 				OperationId:            "test-op",
@@ -522,7 +520,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 		s.Run("ScheduleToCloseTimeout_BeforeStart", func(s *NexusStandaloneTestSuite) {
 			env := s.newTestEnv()
 			taskQueue := testcore.RandomizedNexusEndpoint(s.T().Name())
-			endpointName := env.createNexusEndpoint(s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
+			endpointName := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
 
 			startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 				OperationId:            "test-op",
@@ -731,8 +729,10 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 		for _, tc := range testCases {
 			s.Run(tc.name, func(s *NexusStandaloneTestSuite) {
 				env := s.newTestEnv()
+				ctx, cancel := context.WithTimeout(env.Context(), 10*time.Second)
+				defer cancel()
 				taskQueue := testcore.RandomizedNexusEndpoint(s.T().Name())
-				endpointName := env.createNexusEndpoint(s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
+				endpointName := env.createNexusEndpoint(ctx, s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
 				startReq := &workflowservice.StartNexusOperationExecutionRequest{
 					OperationId: "test-op",
 					Endpoint:    endpointName,
@@ -743,9 +743,6 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 
 				startResp, err := s.startNexusOperation(env, startReq)
 				s.NoError(err)
-
-				ctx, cancel := context.WithTimeout(env.Context(), 10*time.Second)
-				defer cancel()
 
 				pollerErrCh := make(chan error, 1)
 				go func() {
@@ -804,7 +801,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 	s.Run("RequestCancel", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -851,7 +848,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 
 	s.Run("AlreadyCanceled", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -956,7 +953,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 
 	s.Run("AlreadyTerminated", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -1013,7 +1010,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 func (s *NexusStandaloneTestSuite) TestTerminateStandaloneNexusOperation() {
 	s.Run("Terminate", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -1050,7 +1047,7 @@ func (s *NexusStandaloneTestSuite) TestTerminateStandaloneNexusOperation() {
 
 	s.Run("AlreadyTerminated", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -1092,7 +1089,7 @@ func (s *NexusStandaloneTestSuite) TestTerminateStandaloneNexusOperation() {
 
 	s.Run("AlreadyCanceled", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -1157,7 +1154,7 @@ func (s *NexusStandaloneTestSuite) TestTerminateStandaloneNexusOperation() {
 func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 	s.Run("ListAndVerifyFields", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "list-test-op",
@@ -1193,7 +1190,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 
 	s.Run("ListWithCustomSearchAttributes", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		testSA := &commonpb.SearchAttributes{
 			IndexedFields: map[string]*commonpb.Payload{
@@ -1227,7 +1224,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 
 	s.Run("QueryByMultipleFields", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "multi-op",
@@ -1251,7 +1248,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 
 	s.Run("QueryBySupportedSearchAttributes", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 		testStartTime := time.Now().UTC().Format(time.RFC3339Nano)
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
@@ -1392,7 +1389,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 
 	s.Run("PageSizeCapping", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		for i := range 2 {
 			_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
@@ -1492,7 +1489,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 func (s *NexusStandaloneTestSuite) TestCountStandaloneNexusOperation() {
 	s.Run("CountByOperationID", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "count-op",
@@ -1512,7 +1509,7 @@ func (s *NexusStandaloneTestSuite) TestCountStandaloneNexusOperation() {
 
 	s.Run("CountByEndpoint", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		for i := range 3 {
 			_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
@@ -1534,7 +1531,7 @@ func (s *NexusStandaloneTestSuite) TestCountStandaloneNexusOperation() {
 
 	s.Run("CountByExecutionStatus", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "count-status-op",
@@ -1554,7 +1551,7 @@ func (s *NexusStandaloneTestSuite) TestCountStandaloneNexusOperation() {
 
 	s.Run("GroupByExecutionStatus", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		for i := range 3 {
 			_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
@@ -1583,7 +1580,7 @@ func (s *NexusStandaloneTestSuite) TestCountStandaloneNexusOperation() {
 
 	s.Run("CountByCustomSearchAttribute", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		for i := range 2 {
 			_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
@@ -1655,7 +1652,7 @@ func (s *NexusStandaloneTestSuite) TestCountStandaloneNexusOperation() {
 func (s *NexusStandaloneTestSuite) TestDeleteStandaloneNexusOperation() {
 	s.Run("Scheduled", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -1675,7 +1672,7 @@ func (s *NexusStandaloneTestSuite) TestDeleteStandaloneNexusOperation() {
 
 	s.Run("NoRunID", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -1705,7 +1702,7 @@ func (s *NexusStandaloneTestSuite) TestDeleteStandaloneNexusOperation() {
 
 	s.Run("AlreadyDeleted", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -1746,8 +1743,10 @@ func (s *NexusStandaloneTestSuite) TestDeleteStandaloneNexusOperation() {
 func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 	s.Run("WaitStageStarted", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
+		ctx, cancel := context.WithTimeout(env.Context(), 10*time.Second)
+		defer cancel()
 		taskQueue := testcore.RandomizedNexusEndpoint(s.T().Name())
-		endpointName := env.createNexusEndpoint(s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
+		endpointName := env.createNexusEndpoint(ctx, s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
 		handlerLink := &commonpb.Link_WorkflowEvent{
 			Namespace:  env.Namespace().String(),
 			WorkflowId: "handler-workflow",
@@ -1765,9 +1764,6 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 			Endpoint:    endpointName,
 		})
 		s.NoError(err)
-
-		ctx, cancel := context.WithTimeout(env.Context(), 10*time.Second)
-		defer cancel()
 
 		type pollResult struct {
 			resp *workflowservice.PollNexusOperationExecutionResponse
@@ -1880,7 +1876,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 		} {
 			s.Run(tc.name, func(s *NexusStandaloneTestSuite) {
 				env := s.newTestEnv()
-				endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+				endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 				startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 					OperationId: "test-op",
@@ -1973,7 +1969,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 
 	s.Run("UnspecifiedWaitStageDefaultsToClosed", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -2011,8 +2007,10 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 
 	s.Run("ReturnsLastAttemptFailure", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
+		ctx, cancel := context.WithTimeout(env.Context(), 10*time.Second)
+		defer cancel()
 		taskQueue := testcore.RandomizedNexusEndpoint(s.T().Name())
-		endpointName := env.createNexusEndpoint(s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
+		endpointName := env.createNexusEndpoint(ctx, s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId:            "test-op",
@@ -2020,9 +2018,6 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 			ScheduleToCloseTimeout: durationpb.New(4 * time.Second),
 		})
 		s.NoError(err)
-
-		ctx, cancel := context.WithTimeout(env.Context(), 10*time.Second)
-		defer cancel()
 
 		pollerErrCh := make(chan error, 1)
 		go func() {
@@ -2076,7 +2071,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 
 	s.Run("NamespaceNotFound", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -2097,7 +2092,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 
 	s.Run("NotFound", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",

--- a/tests/nexus_standalone_test.go
+++ b/tests/nexus_standalone_test.go
@@ -877,7 +877,6 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 
 	s.Run("RequestCancel_ForwardsOriginalNexusHeaders", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 		taskHeaderCh := make(chan string, 1)
 		handler := nexustest.Handler{
 			OnStartOperation: func(
@@ -894,7 +893,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 				return nil
 			},
 		}
-		env.createExternalNexusServer(env.Context(), s.T(), endpointName, handler)
+		endpointName := env.createRandomExternalNexusServer(env.Context(), s.T(), handler)
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -2096,7 +2095,6 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 
 func (s *NexusStandaloneTestSuite) TestAsyncCompletionIgnoresTransitionFieldsInCallbackToken() {
 	env := s.newTestEnv()
-	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 	handlerLink := &commonpb.Link_WorkflowEvent{
 		Namespace:  env.Namespace().String(),
 		WorkflowId: "handler-workflow",
@@ -2131,7 +2129,7 @@ func (s *NexusStandaloneTestSuite) TestAsyncCompletionIgnoresTransitionFieldsInC
 			return &nexus.HandlerStartOperationResultAsync{OperationToken: "test-operation-token"}, nil
 		},
 	}
-	env.createExternalNexusServer(env.Context(), s.T(), endpointName, handler)
+	endpointName := env.createRandomExternalNexusServer(env.Context(), s.T(), handler)
 
 	startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 		OperationId: "test-op",

--- a/tests/nexus_standalone_test.go
+++ b/tests/nexus_standalone_test.go
@@ -15,7 +15,6 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
 	nexuspb "go.temporal.io/api/nexus/v1"
-	"go.temporal.io/api/operatorservice/v1"
 	sdkpb "go.temporal.io/api/sdk/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
@@ -223,9 +222,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 
 	s.Run("LongPollStateChange", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		ctx, cancel := context.WithTimeout(env.Context(), 10*time.Second)
-		defer cancel()
-		endpointName := env.createRandomNexusEndpoint(ctx, s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -251,7 +248,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 		describeResultCh := make(chan describeResult, 1)
 
 		go func() {
-			resp, err := env.FrontendClient().DescribeNexusOperationExecution(ctx, &workflowservice.DescribeNexusOperationExecutionRequest{
+			resp, err := env.FrontendClient().DescribeNexusOperationExecution(env.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
 				Namespace:      env.Namespace().String(),
 				OperationId:    "test-op",
 				RunId:          startResp.RunId,
@@ -272,7 +269,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 		// Terminate the operation.
 		terminateErrCh := make(chan error, 1)
 		go func() {
-			_, err := env.FrontendClient().TerminateNexusOperationExecution(ctx, &workflowservice.TerminateNexusOperationExecutionRequest{
+			_, err := env.FrontendClient().TerminateNexusOperationExecution(env.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
 				Namespace:   env.Namespace().String(),
 				OperationId: "test-op",
 				RunId:       startResp.RunId,
@@ -284,7 +281,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 		select {
 		case err := <-terminateErrCh:
 			s.NoError(err)
-		case <-ctx.Done():
+		case <-env.Context().Done():
 			s.T().Fatal("TerminateNexusOperationExecution timed out")
 		}
 
@@ -294,7 +291,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 		case result := <-describeResultCh:
 			s.NoError(result.err)
 			longPollResp = result.resp
-		case <-ctx.Done():
+		case <-env.Context().Done():
 			s.T().Fatal("DescribeNexusOperationExecution timed out")
 		}
 
@@ -325,10 +322,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 			env.OverrideDynamicConfig(nexusoperation.LongPollBuffer, time.Second)
 			env.OverrideDynamicConfig(nexusoperation.LongPollTimeout, 10*time.Millisecond)
 
-			ctx, cancel := context.WithTimeout(env.Context(), 5*time.Second)
-			defer cancel()
-
-			longPollResp, err := env.FrontendClient().DescribeNexusOperationExecution(ctx, &workflowservice.DescribeNexusOperationExecutionRequest{
+			longPollResp, err := env.FrontendClient().DescribeNexusOperationExecution(env.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
 				Namespace:     env.Namespace().String(),
 				OperationId:   "test-op",
 				RunId:         startResp.RunId,
@@ -356,10 +350,8 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 
 	s.Run("IncludeOutcome_Success", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		ctx, cancel := context.WithTimeout(env.Context(), 10*time.Second)
-		defer cancel()
 		taskQueue := testcore.RandomizedNexusEndpoint(s.T().Name())
-		endpointName := env.createNexusEndpoint(ctx, s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
+		endpointName := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
 		expectedResult := payload.EncodeString("successful result")
 		handlerLink := &commonpb.Link_WorkflowEvent{
 			Namespace:  env.Namespace().String(),
@@ -381,7 +373,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 
 		pollerErrCh := make(chan error, 1)
 		go func() {
-			task, err := env.FrontendClient().PollNexusTaskQueue(ctx, &workflowservice.PollNexusTaskQueueRequest{
+			task, err := env.FrontendClient().PollNexusTaskQueue(env.Context(), &workflowservice.PollNexusTaskQueueRequest{
 				Namespace: env.Namespace().String(),
 				Identity:  "test-worker",
 				TaskQueue: &taskqueuepb.TaskQueue{
@@ -412,7 +404,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 				return
 			}
 
-			_, err = env.FrontendClient().RespondNexusTaskCompleted(ctx, &workflowservice.RespondNexusTaskCompletedRequest{
+			_, err = env.FrontendClient().RespondNexusTaskCompleted(env.Context(), &workflowservice.RespondNexusTaskCompletedRequest{
 				Namespace: env.Namespace().String(),
 				Identity:  "test-worker",
 				TaskToken: task.GetTaskToken(),
@@ -729,10 +721,8 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 		for _, tc := range testCases {
 			s.Run(tc.name, func(s *NexusStandaloneTestSuite) {
 				env := s.newTestEnv()
-				ctx, cancel := context.WithTimeout(env.Context(), 10*time.Second)
-				defer cancel()
 				taskQueue := testcore.RandomizedNexusEndpoint(s.T().Name())
-				endpointName := env.createNexusEndpoint(ctx, s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
+				endpointName := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
 				startReq := &workflowservice.StartNexusOperationExecutionRequest{
 					OperationId: "test-op",
 					Endpoint:    endpointName,
@@ -746,7 +736,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 
 				pollerErrCh := make(chan error, 1)
 				go func() {
-					task, err := env.FrontendClient().PollNexusTaskQueue(ctx, &workflowservice.PollNexusTaskQueueRequest{
+					task, err := env.FrontendClient().PollNexusTaskQueue(env.Context(), &workflowservice.PollNexusTaskQueueRequest{
 						Namespace: env.Namespace().String(),
 						Identity:  "test-worker",
 						TaskQueue: &taskqueuepb.TaskQueue{
@@ -758,7 +748,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 						pollerErrCh <- err
 						return
 					}
-					pollerErrCh <- tc.respond(ctx, env, task)
+					pollerErrCh <- tc.respond(env.Context(), env, task)
 				}()
 
 				s.EventuallyWithT(func(t *assert.CollectT) {
@@ -889,9 +879,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 		env := s.newTestEnv()
 		endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 		taskHeaderCh := make(chan string, 1)
-
-		listenAddr := nexustest.AllocListenAddress()
-		nexustest.NewNexusServer(s.T(), listenAddr, nexustest.Handler{
+		handler := nexustest.Handler{
 			OnStartOperation: func(
 				ctx context.Context,
 				service string,
@@ -905,21 +893,8 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 				taskHeaderCh <- options.Header.Get("x-test-header")
 				return nil
 			},
-		})
-
-		_, err := env.OperatorClient().CreateNexusEndpoint(env.Context(), &operatorservice.CreateNexusEndpointRequest{
-			Spec: &nexuspb.EndpointSpec{
-				Name: endpointName,
-				Target: &nexuspb.EndpointTarget{
-					Variant: &nexuspb.EndpointTarget_External_{
-						External: &nexuspb.EndpointTarget_External{
-							Url: "http://" + listenAddr,
-						},
-					},
-				},
-			},
-		})
-		s.NoError(err)
+		}
+		env.createExternalNexusServer(env.Context(), s.T(), endpointName, handler)
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -1743,10 +1718,8 @@ func (s *NexusStandaloneTestSuite) TestDeleteStandaloneNexusOperation() {
 func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 	s.Run("WaitStageStarted", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		ctx, cancel := context.WithTimeout(env.Context(), 10*time.Second)
-		defer cancel()
 		taskQueue := testcore.RandomizedNexusEndpoint(s.T().Name())
-		endpointName := env.createNexusEndpoint(ctx, s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
+		endpointName := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
 		handlerLink := &commonpb.Link_WorkflowEvent{
 			Namespace:  env.Namespace().String(),
 			WorkflowId: "handler-workflow",
@@ -1774,7 +1747,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 
 		go func() {
 			pollStartedCh <- struct{}{}
-			resp, err := env.FrontendClient().PollNexusOperationExecution(ctx, &workflowservice.PollNexusOperationExecutionRequest{
+			resp, err := env.FrontendClient().PollNexusOperationExecution(env.Context(), &workflowservice.PollNexusOperationExecutionRequest{
 				Namespace:   env.Namespace().String(),
 				OperationId: "test-op",
 				RunId:       startResp.RunId,
@@ -1785,7 +1758,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 
 		select {
 		case <-pollStartedCh:
-		case <-ctx.Done():
+		case <-env.Context().Done():
 			s.T().Fatal("PollNexusOperationExecution did not start before timeout")
 		}
 
@@ -1797,7 +1770,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 		default:
 		}
 
-		task, err := env.FrontendClient().PollNexusTaskQueue(ctx, &workflowservice.PollNexusTaskQueueRequest{
+		task, err := env.FrontendClient().PollNexusTaskQueue(env.Context(), &workflowservice.PollNexusTaskQueueRequest{
 			Namespace: env.Namespace().String(),
 			Identity:  "test-worker",
 			TaskQueue: &taskqueuepb.TaskQueue{
@@ -1817,7 +1790,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 		s.Equal(expectedLink.URL.String(), startRequest.GetLinks()[0].GetUrl())
 		s.Equal(expectedLink.Type, startRequest.GetLinks()[0].GetType())
 
-		_, err = env.FrontendClient().RespondNexusTaskCompleted(ctx, &workflowservice.RespondNexusTaskCompletedRequest{
+		_, err = env.FrontendClient().RespondNexusTaskCompleted(env.Context(), &workflowservice.RespondNexusTaskCompletedRequest{
 			Namespace: env.Namespace().String(),
 			Identity:  "test-worker",
 			TaskToken: task.GetTaskToken(),
@@ -1847,7 +1820,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 				WaitStage:      enumspb.NEXUS_OPERATION_WAIT_STAGE_STARTED,
 				OperationToken: "test-operation-token",
 			}, result.resp)
-		case <-ctx.Done():
+		case <-env.Context().Done():
 			s.T().Fatal("PollNexusOperationExecution did not resolve before timeout")
 		}
 
@@ -1884,9 +1857,6 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 				})
 				s.NoError(err)
 
-				ctx, cancel := context.WithTimeout(env.Context(), 10*time.Second)
-				defer cancel()
-
 				// Start pollling.
 				type pollResult struct {
 					resp *workflowservice.PollNexusOperationExecutionResponse
@@ -1902,7 +1872,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 					}
 
 					pollStartedCh <- struct{}{}
-					resp, err := env.FrontendClient().PollNexusOperationExecution(ctx, &workflowservice.PollNexusOperationExecutionRequest{
+					resp, err := env.FrontendClient().PollNexusOperationExecution(env.Context(), &workflowservice.PollNexusOperationExecutionRequest{
 						Namespace:   env.Namespace().String(),
 						OperationId: "test-op",
 						RunId:       runID,
@@ -1913,7 +1883,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 
 				select {
 				case <-pollStartedCh:
-				case <-ctx.Done():
+				case <-env.Context().Done():
 					s.T().Fatal("PollNexusOperationExecution did not start before timeout")
 				}
 
@@ -1928,7 +1898,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 				// Terminate the operation.
 				terminateErrCh := make(chan error, 1)
 				go func() {
-					_, err := env.FrontendClient().TerminateNexusOperationExecution(ctx, &workflowservice.TerminateNexusOperationExecutionRequest{
+					_, err := env.FrontendClient().TerminateNexusOperationExecution(env.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
 						Namespace:   env.Namespace().String(),
 						OperationId: "test-op",
 						RunId:       startResp.RunId,
@@ -1940,7 +1910,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 				select {
 				case err := <-terminateErrCh:
 					s.NoError(err)
-				case <-ctx.Done():
+				case <-env.Context().Done():
 					s.T().Fatal("TerminateNexusOperationExecution timed out")
 				}
 
@@ -1948,7 +1918,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 				var result pollResult
 				select {
 				case result = <-pollResultCh:
-				case <-ctx.Done():
+				case <-env.Context().Done():
 					s.T().Fatal("PollNexusOperationExecution did not resolve before timeout")
 				}
 				s.NoError(result.err)
@@ -2007,10 +1977,8 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 
 	s.Run("ReturnsLastAttemptFailure", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		ctx, cancel := context.WithTimeout(env.Context(), 10*time.Second)
-		defer cancel()
 		taskQueue := testcore.RandomizedNexusEndpoint(s.T().Name())
-		endpointName := env.createNexusEndpoint(ctx, s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
+		endpointName := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId:            "test-op",
@@ -2021,7 +1989,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 
 		pollerErrCh := make(chan error, 1)
 		go func() {
-			task, err := env.FrontendClient().PollNexusTaskQueue(ctx, &workflowservice.PollNexusTaskQueueRequest{
+			task, err := env.FrontendClient().PollNexusTaskQueue(env.Context(), &workflowservice.PollNexusTaskQueueRequest{
 				Namespace: env.Namespace().String(),
 				Identity:  "test-worker",
 				TaskQueue: &taskqueuepb.TaskQueue{
@@ -2033,7 +2001,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 				pollerErrCh <- err
 				return
 			}
-			_, err = env.FrontendClient().RespondNexusTaskFailed(ctx, &workflowservice.RespondNexusTaskFailedRequest{
+			_, err = env.FrontendClient().RespondNexusTaskFailed(env.Context(), &workflowservice.RespondNexusTaskFailedRequest{
 				Namespace: env.Namespace().String(),
 				Identity:  "test-worker",
 				TaskToken: task.GetTaskToken(),
@@ -2147,8 +2115,7 @@ func (s *NexusStandaloneTestSuite) TestAsyncCompletionIgnoresTransitionFieldsInC
 		url   string
 	}
 	callbackCh := make(chan callbackInfo, 1)
-	listenAddr := nexustest.AllocListenAddress()
-	nexustest.NewNexusServer(s.T(), listenAddr, nexustest.Handler{
+	handler := nexustest.Handler{
 		OnStartOperation: func(
 			ctx context.Context,
 			service string,
@@ -2163,38 +2130,22 @@ func (s *NexusStandaloneTestSuite) TestAsyncCompletionIgnoresTransitionFieldsInC
 			nexus.AddHandlerLinks(ctx, handlerNexusLink)
 			return &nexus.HandlerStartOperationResultAsync{OperationToken: "test-operation-token"}, nil
 		},
-	})
-
-	_, err := env.OperatorClient().CreateNexusEndpoint(env.Context(), &operatorservice.CreateNexusEndpointRequest{
-		Spec: &nexuspb.EndpointSpec{
-			Name: endpointName,
-			Target: &nexuspb.EndpointTarget{
-				Variant: &nexuspb.EndpointTarget_External_{
-					External: &nexuspb.EndpointTarget_External{
-						Url: "http://" + listenAddr,
-					},
-				},
-			},
-		},
-	})
-	s.NoError(err)
+	}
+	env.createExternalNexusServer(env.Context(), s.T(), endpointName, handler)
 
 	startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 		OperationId: "test-op",
 		Endpoint:    endpointName,
 	})
 	s.NoError(err)
-
-	ctx, cancel := context.WithTimeout(env.Context(), 10*time.Second)
-	defer cancel()
 	var callbackToken string
 	var callbackURL string
 	select {
 	case callback := <-callbackCh:
 		callbackToken = callback.token
 		callbackURL = callback.url
-	case <-ctx.Done():
-		s.FailNow("timed out waiting for Nexus callback details", ctx.Err().Error())
+	case <-env.Context().Done():
+		s.FailNow("timed out waiting for Nexus callback details", env.Context().Err().Error())
 	}
 
 	gen := &commonnexus.CallbackTokenGenerator{}
@@ -2226,7 +2177,7 @@ func (s *NexusStandaloneTestSuite) TestAsyncCompletionIgnoresTransitionFieldsInC
 	c := nexusrpc.NewCompletionHTTPClient(nexusrpc.CompletionHTTPClientOptions{
 		Serializer: commonnexus.PayloadSerializer,
 	})
-	err = c.CompleteOperation(ctx, callbackURL, nexusrpc.CompleteOperationOptions{
+	err = c.CompleteOperation(env.Context(), callbackURL, nexusrpc.CompleteOperationOptions{
 		Result: payload.EncodeString("result"),
 		Header: nexus.Header{commonnexus.CallbackTokenHeader: callbackToken},
 	})

--- a/tests/nexus_test_base.go
+++ b/tests/nexus_test_base.go
@@ -36,7 +36,7 @@ func newNexusTestEnv(t *testing.T, useTemporalFailures bool, opts ...testcore.Te
 }
 
 func (env *NexusTestEnv) createNexusEndpoint(ctx context.Context, t *testing.T, name string, taskQueue string) *nexuspb.Endpoint {
-	resp, err := env.OperatorClient().CreateNexusEndpoint(testcore.NewContext(), &operatorservice.CreateNexusEndpointRequest{
+	resp, err := env.OperatorClient().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
 		Spec: &nexuspb.EndpointSpec{
 			Name: name,
 			Target: &nexuspb.EndpointTarget{
@@ -50,8 +50,14 @@ func (env *NexusTestEnv) createNexusEndpoint(ctx context.Context, t *testing.T, 
 		},
 	})
 	require.NoError(t, err)
-	env.setNexusEndpointCleanupFn(t, resp.Endpoint.Id, resp.Endpoint.Version)
-	env.probeEndpoint(ctx, t, name)
+	t.Cleanup(func() {
+		_, _ = env.OperatorClient().DeleteNexusEndpoint(ctx, &operatorservice.DeleteNexusEndpointRequest{
+			Id:      resp.Endpoint.Id,
+			Version: resp.Endpoint.Version,
+		})
+	})
+
+	env.ensureNexusEndpoint(ctx, t, name)
 	return resp.Endpoint
 }
 
@@ -76,23 +82,19 @@ func (env *NexusTestEnv) createExternalNexusServer(ctx context.Context, t *testi
 		},
 	})
 	require.NoError(t, err)
-	env.setNexusEndpointCleanupFn(t, resp.Endpoint.Id, resp.Endpoint.Version)
-	env.probeEndpoint(ctx, t, endpointName)
-}
-
-// setNexusEndpointCleanupFn sets the cleanup fn that deletes the Nexus endpoint after the current test,
-// so the cluster can be safely reused by subsequent tests.
-func (env *NexusTestEnv) setNexusEndpointCleanupFn(t *testing.T, id string, version int64) {
 	t.Cleanup(func() {
-		_, _ = env.OperatorClient().DeleteNexusEndpoint(testcore.NewContext(), &operatorservice.DeleteNexusEndpointRequest{
-			Id:      id,
-			Version: version,
+		_, _ = env.OperatorClient().DeleteNexusEndpoint(ctx, &operatorservice.DeleteNexusEndpointRequest{
+			Id:      resp.Endpoint.Id,
+			Version: resp.Endpoint.Version,
 		})
 	})
+
+	env.ensureNexusEndpoint(ctx, t, endpointName)
 }
 
-// probeEndpoint probes the specified endpoint until it's visible to StartNexusOperationExecution.
-func (env *NexusTestEnv) probeEndpoint(ctx context.Context, t *testing.T, endpointName string) {
+// ensureNexusEndpoint probes the specified endpoint until it's visible to StartNexusOperationExecution to ensure tests
+// can use it.
+func (env *NexusTestEnv) ensureNexusEndpoint(ctx context.Context, t *testing.T, endpointName string) {
 	require.Eventually(t, func() bool {
 		_, err := env.FrontendClient().StartNexusOperationExecution(ctx, &workflowservice.StartNexusOperationExecutionRequest{
 			Namespace: env.Namespace().String(),

--- a/tests/nexus_test_base.go
+++ b/tests/nexus_test_base.go
@@ -19,6 +19,7 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	cnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexusrpc"
+	"go.temporal.io/server/common/nexus/nexustest"
 	"go.temporal.io/server/tests/testcore"
 )
 
@@ -34,7 +35,7 @@ func newNexusTestEnv(t *testing.T, useTemporalFailures bool, opts ...testcore.Te
 	}
 }
 
-func (env *NexusTestEnv) createNexusEndpoint(t *testing.T, name string, taskQueue string) *nexuspb.Endpoint {
+func (env *NexusTestEnv) createNexusEndpoint(ctx context.Context, t *testing.T, name string, taskQueue string) *nexuspb.Endpoint {
 	resp, err := env.OperatorClient().CreateNexusEndpoint(testcore.NewContext(), &operatorservice.CreateNexusEndpointRequest{
 		Spec: &nexuspb.EndpointSpec{
 			Name: name,
@@ -49,20 +50,53 @@ func (env *NexusTestEnv) createNexusEndpoint(t *testing.T, name string, taskQueu
 		},
 	})
 	require.NoError(t, err)
+	env.setNexusEndpointCleanupFn(t, resp.Endpoint.Id, resp.Endpoint.Version)
+	env.probeEndpoint(ctx, t, name)
+	return resp.Endpoint
+}
 
+func (env *NexusTestEnv) createRandomNexusEndpoint(ctx context.Context, t *testing.T) *nexuspb.Endpoint {
+	return env.createNexusEndpoint(ctx, t, testcore.RandomizedNexusEndpoint(t.Name()), "unused")
+}
+
+// createExternalNexusServer creates a mock nexus server that listens via a provided endpoint address.
+func (env *NexusTestEnv) createExternalNexusServer(ctx context.Context, t *testing.T, endpointName string, handler nexustest.Handler) {
+	listenAddr := nexustest.AllocListenAddress()
+	nexustest.NewNexusServer(t, listenAddr, handler)
+	resp, err := env.OperatorClient().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
+		Spec: &nexuspb.EndpointSpec{
+			Name: endpointName,
+			Target: &nexuspb.EndpointTarget{
+				Variant: &nexuspb.EndpointTarget_External_{
+					External: &nexuspb.EndpointTarget_External{
+						Url: "http://" + listenAddr,
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	env.setNexusEndpointCleanupFn(t, resp.Endpoint.Id, resp.Endpoint.Version)
+	env.probeEndpoint(ctx, t, endpointName)
+}
+
+// setNexusEndpointCleanupFn sets the cleanup fn that deletes the Nexus endpoint after the current test,
+// so the cluster can be safely reused by subsequent tests.
+func (env *NexusTestEnv) setNexusEndpointCleanupFn(t *testing.T, id string, version int64) {
 	t.Cleanup(func() {
-		// Delete the endpoint so the cluster can be safely reused by subsequent tests.
 		_, _ = env.OperatorClient().DeleteNexusEndpoint(testcore.NewContext(), &operatorservice.DeleteNexusEndpointRequest{
-			Id:      resp.Endpoint.Id,
-			Version: resp.Endpoint.Version,
+			Id:      id,
+			Version: version,
 		})
 	})
+}
 
-	// Wait for the endpoint to be visible to StartNexusOperationExecution.
+// probeEndpoint probes the specified endpoint until it's visible to StartNexusOperationExecution.
+func (env *NexusTestEnv) probeEndpoint(ctx context.Context, t *testing.T, endpointName string) {
 	require.Eventually(t, func() bool {
-		_, err := env.FrontendClient().StartNexusOperationExecution(testcore.NewContext(), &workflowservice.StartNexusOperationExecutionRequest{
+		_, err := env.FrontendClient().StartNexusOperationExecution(ctx, &workflowservice.StartNexusOperationExecutionRequest{
 			Namespace: env.Namespace().String(),
-			Endpoint:  name,
+			Endpoint:  endpointName,
 			Service:   "probe",
 			Operation: "probe",
 			RequestId: "probe",
@@ -73,11 +107,6 @@ func (env *NexusTestEnv) createNexusEndpoint(t *testing.T, name string, taskQueu
 		}
 		return true
 	}, 10*time.Second, 100*time.Millisecond, "endpoint should become visible")
-	return resp.Endpoint
-}
-
-func (env *NexusTestEnv) createRandomNexusEndpoint(t *testing.T) *nexuspb.Endpoint {
-	return env.createNexusEndpoint(t, testcore.RandomizedNexusEndpoint(t.Name()), "unused")
 }
 
 // nexusTaskResponse represents a successful response from a nexus task handler.

--- a/tests/nexus_test_base.go
+++ b/tests/nexus_test_base.go
@@ -50,8 +50,10 @@ func (env *NexusTestEnv) createNexusEndpoint(ctx context.Context, t *testing.T, 
 		},
 	})
 	require.NoError(t, err)
+
+	// Using a fresh context here in case 'ctx' is tied to a test's lifetime which could cancel this deletion request.
 	t.Cleanup(func() {
-		_, _ = env.OperatorClient().DeleteNexusEndpoint(ctx, &operatorservice.DeleteNexusEndpointRequest{
+		_, _ = env.OperatorClient().DeleteNexusEndpoint(testcore.NewContext(), &operatorservice.DeleteNexusEndpointRequest{
 			Id:      resp.Endpoint.Id,
 			Version: resp.Endpoint.Version,
 		})
@@ -65,8 +67,9 @@ func (env *NexusTestEnv) createRandomNexusEndpoint(ctx context.Context, t *testi
 	return env.createNexusEndpoint(ctx, t, testcore.RandomizedNexusEndpoint(t.Name()), "unused")
 }
 
-// createExternalNexusServer creates a mock nexus server that listens via a provided endpoint address.
-func (env *NexusTestEnv) createExternalNexusServer(ctx context.Context, t *testing.T, endpointName string, handler nexustest.Handler) {
+// createRandomExternalNexusServer creates a mock nexus server that listens via a randomized endpointName and return this name to the caller.
+func (env *NexusTestEnv) createRandomExternalNexusServer(ctx context.Context, t *testing.T, handler nexustest.Handler) string {
+	endpointName := testcore.RandomizedNexusEndpoint(t.Name())
 	listenAddr := nexustest.AllocListenAddress()
 	nexustest.NewNexusServer(t, listenAddr, handler)
 	resp, err := env.OperatorClient().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
@@ -82,14 +85,16 @@ func (env *NexusTestEnv) createExternalNexusServer(ctx context.Context, t *testi
 		},
 	})
 	require.NoError(t, err)
+	// Using a fresh context here in case 'ctx' is tied to a test's lifetime which could cancel this deletion request.
 	t.Cleanup(func() {
-		_, _ = env.OperatorClient().DeleteNexusEndpoint(ctx, &operatorservice.DeleteNexusEndpointRequest{
+		_, _ = env.OperatorClient().DeleteNexusEndpoint(testcore.NewContext(), &operatorservice.DeleteNexusEndpointRequest{
 			Id:      resp.Endpoint.Id,
 			Version: resp.Endpoint.Version,
 		})
 	})
 
 	env.ensureNexusEndpoint(ctx, t, endpointName)
+	return endpointName
 }
 
 // ensureNexusEndpoint probes the specified endpoint until it's visible to StartNexusOperationExecution to ensure tests

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -76,7 +76,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelation(chasmEnabled bool
 	}
 
 	env := s.newTestEnv(chasmEnabled)
-	ctx := testcore.NewContext()
+	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
@@ -97,22 +97,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelation(chasmEnabled bool
 			return nil
 		},
 	}
-	listenAddr := nexustest.AllocListenAddress()
-	nexustest.NewNexusServer(s.T(), listenAddr, h)
-
-	_, err := env.OperatorClient().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
-		Spec: &nexuspb.EndpointSpec{
-			Name: endpointName,
-			Target: &nexuspb.EndpointTarget{
-				Variant: &nexuspb.EndpointTarget_External_{
-					External: &nexuspb.EndpointTarget_External{
-						Url: "http://" + listenAddr,
-					},
-				},
-			},
-		},
-	})
-	s.NoError(err)
+	env.createExternalNexusServer(ctx, s.T(), endpointName, h)
 
 	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 		TaskQueue:           taskQueue,
@@ -292,7 +277,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelation(chasmEnabled bool
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion(chasmEnabled bool) {
 	env := s.newTestEnv(chasmEnabled)
-	ctx := testcore.NewContext()
+	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
@@ -314,22 +299,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion(chasmEnabled b
 			return &nexus.HandlerStartOperationResultSync[any]{Value: "result"}, nil
 		},
 	}
-	listenAddr := nexustest.AllocListenAddress()
-	nexustest.NewNexusServer(s.T(), listenAddr, h)
-
-	_, err := env.OperatorClient().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
-		Spec: &nexuspb.EndpointSpec{
-			Name: endpointName,
-			Target: &nexuspb.EndpointTarget{
-				Variant: &nexuspb.EndpointTarget_External_{
-					External: &nexuspb.EndpointTarget_External{
-						Url: "http://" + listenAddr,
-					},
-				},
-			},
-		},
-	})
-	s.NoError(err)
+	env.createExternalNexusServer(ctx, s.T(), endpointName, h)
 
 	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 		TaskQueue: taskQueue,
@@ -421,7 +391,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion(chasmEnabled b
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion_LargePayload(chasmEnabled bool) {
 	env := s.newTestEnv(chasmEnabled)
-	ctx := testcore.NewContext()
+	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
@@ -432,22 +402,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion_LargePayload(c
 			return &nexus.HandlerStartOperationResultSync[any]{Value: strings.Repeat("a", (2*1024*1024)-10)}, nil
 		},
 	}
-	listenAddr := nexustest.AllocListenAddress()
-	nexustest.NewNexusServer(s.T(), listenAddr, h)
-
-	_, err := env.OperatorClient().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
-		Spec: &nexuspb.EndpointSpec{
-			Name: endpointName,
-			Target: &nexuspb.EndpointTarget{
-				Variant: &nexuspb.EndpointTarget_External_{
-					External: &nexuspb.EndpointTarget_External{
-						Url: "http://" + listenAddr,
-					},
-				},
-			},
-		},
-	})
-	s.NoError(err)
+	env.createExternalNexusServer(ctx, s.T(), endpointName, h)
 
 	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 		TaskQueue: taskQueue,
@@ -525,7 +480,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion_LargePayload(c
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletion(chasmEnabled bool) {
 	env := s.newTestEnv(chasmEnabled)
-	ctx := testcore.NewContext()
+	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
@@ -616,22 +571,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletion(chasmEnabled 
 			}, nil
 		},
 	}
-	listenAddr := nexustest.AllocListenAddress()
-	nexustest.NewNexusServer(s.T(), listenAddr, h)
-
-	_, err = env.OperatorClient().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
-		Spec: &nexuspb.EndpointSpec{
-			Name: endpointName,
-			Target: &nexuspb.EndpointTarget{
-				Variant: &nexuspb.EndpointTarget_External_{
-					External: &nexuspb.EndpointTarget_External{
-						Url: "http://" + listenAddr,
-					},
-				},
-			},
-		},
-	})
-	s.NoError(err)
+	env.createExternalNexusServer(ctx, s.T(), endpointName, h)
 
 	pollResp, err := env.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: env.Namespace().String(),
@@ -954,7 +894,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletion(chasmEnabled 
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionBeforeStart(chasmEnabled bool) {
 	env := s.newTestEnv(chasmEnabled)
-	ctx := testcore.NewContext()
+	ctx := env.Context()
 	taskQueues := []string{testcore.RandomizeStr(s.T().Name()), testcore.RandomizeStr(s.T().Name())}
 	wfRuns := []client.WorkflowRun{}
 	nexusTasks := []*workflowservice.PollNexusTaskQueueResponse{}
@@ -1222,7 +1162,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionBeforeStart(ch
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncFailure(chasmEnabled bool) {
 	env := s.newTestEnv(chasmEnabled)
-	ctx := testcore.NewContext()
+	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
@@ -1235,22 +1175,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncFailure(chasmEnabled boo
 			return &nexus.HandlerStartOperationResultAsync{OperationToken: "test"}, nil
 		},
 	}
-	listenAddr := nexustest.AllocListenAddress()
-	nexustest.NewNexusServer(s.T(), listenAddr, h)
-
-	_, err := env.OperatorClient().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
-		Spec: &nexuspb.EndpointSpec{
-			Name: endpointName,
-			Target: &nexuspb.EndpointTarget{
-				Variant: &nexuspb.EndpointTarget_External_{
-					External: &nexuspb.EndpointTarget_External{
-						Url: "http://" + listenAddr,
-					},
-				},
-			},
-		},
-	})
-	s.NoError(err)
+	env.createExternalNexusServer(ctx, s.T(), endpointName, h)
 
 	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 		TaskQueue: taskQueue,
@@ -1361,10 +1286,9 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncFailure(chasmEnabled boo
 }
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEnabled bool) {
-	ctx := testcore.NewContext()
-
 	s.Run("NamespaceNotFound", func(s *NexusWorkflowTestSuite) {
 		env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
+		ctx := env.Context()
 		// Generate a token with a non-existent namespace ID
 		tokenWithBadNamespace, err := s.generateValidCallbackToken("namespace-doesnt-exist-id", testcore.RandomizeStr("workflow"), uuid.NewString())
 		s.NoError(err)
@@ -1384,6 +1308,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 
 	s.Run("NamespaceNotFoundNoIdentifier", func(s *NexusWorkflowTestSuite) {
 		env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
+		ctx := env.Context()
 		// Generate a token with a non-existent namespace ID
 		tokenWithBadNamespace, err := s.generateValidCallbackToken("namespace-doesnt-exist-id", testcore.RandomizeStr("workflow"), uuid.NewString())
 		s.NoError(err)
@@ -1403,6 +1328,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 
 	s.Run("OperationTokenTooLong", func(s *NexusWorkflowTestSuite) {
 		env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
+		ctx := env.Context()
 		publicCallbackURL := "http://" + env.HttpAPIAddress() + "/" + commonnexus.RouteCompletionCallback.Path(env.Namespace().String())
 
 		// Generate a valid callback token to get past initial validation
@@ -1429,6 +1355,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 
 	s.Run("OperationTokenTooLongNoIdentifier", func(s *NexusWorkflowTestSuite) {
 		env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
+		ctx := env.Context()
 		publicCallbackURL := "http://" + env.HttpAPIAddress() + commonnexus.PathCompletionCallbackNoIdentifier
 		// Generate a valid callback token to get past initial validation
 		namespaceID := env.NamespaceID().String()
@@ -1455,6 +1382,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 
 	s.Run("InvalidCallbackToken", func(s *NexusWorkflowTestSuite) {
 		env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
+		ctx := env.Context()
 		completion := nexusrpc.CompleteOperationOptions{
 			Result: testcore.MustToPayload(s.T(), "result"),
 		}
@@ -1471,6 +1399,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 
 	s.Run("InvalidCallbackTokenNoIdentifier", func(s *NexusWorkflowTestSuite) {
 		env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
+		ctx := env.Context()
 		completion := nexusrpc.CompleteOperationOptions{
 			Result: testcore.MustToPayload(s.T(), "result"),
 		}
@@ -1487,6 +1416,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 
 	s.Run("InvalidClientVersion", func(s *NexusWorkflowTestSuite) {
 		env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
+		ctx := env.Context()
 		publicCallbackURL := "http://" + env.HttpAPIAddress() + "/" + commonnexus.RouteCompletionCallback.Path(env.Namespace().String())
 		capture := env.StartNamespaceMetricCapture()
 
@@ -1516,6 +1446,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 
 	s.Run("InvalidClientVersionNoIdentifier", func(s *NexusWorkflowTestSuite) {
 		env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
+		ctx := env.Context()
 		publicCallbackURL := "http://" + env.HttpAPIAddress() + commonnexus.PathCompletionCallbackNoIdentifier
 		capture := env.StartNamespaceMetricCapture()
 
@@ -1547,7 +1478,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAuthErrors(chasmEnabled bool) {
 	env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
-	ctx := testcore.NewContext()
+	ctx := env.Context()
 
 	onAuthorize := func(ctx context.Context, c *authorization.Claims, ct *authorization.CallTarget) (authorization.Result, error) {
 		if ct.APIName == configs.CompleteNexusOperation {
@@ -1581,7 +1512,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAuthErrors(cha
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAuthErrorsNoIdentifier(chasmEnabled bool) {
 	env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
-	ctx := testcore.NewContext()
+	ctx := env.Context()
 
 	onAuthorize := func(ctx context.Context, c *authorization.Claims, ct *authorization.CallTarget) (authorization.Result, error) {
 		if ct.APIName == configs.CompleteNexusOperation {
@@ -1622,7 +1553,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionInternalAuth(c
 		nexusoperations.CallbackURLTemplate,
 		"http://INTERNAL/namespaces/{{.NamespaceName}}/nexus/callback")
 
-	ctx := testcore.NewContext()
+	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
@@ -1806,7 +1737,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelBeforeStarted_Cancelati
 		s.T().Skip("Blocked on CHASM Nexus cancellation before start support")
 	}
 	env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
-	ctx := testcore.NewContext()
+	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
@@ -1827,22 +1758,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelBeforeStarted_Cancelati
 			return nil
 		},
 	}
-	listenAddr := nexustest.AllocListenAddress()
-	nexustest.NewNexusServer(s.T(), listenAddr, h)
-
-	_, err := env.OperatorClient().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
-		Spec: &nexuspb.EndpointSpec{
-			Name: endpointName,
-			Target: &nexuspb.EndpointTarget{
-				Variant: &nexuspb.EndpointTarget_External_{
-					External: &nexuspb.EndpointTarget_External{
-						Url: "http://" + listenAddr,
-					},
-				},
-			},
-		},
-	})
-	s.NoError(err)
+	env.createExternalNexusServer(ctx, s.T(), endpointName, h)
 
 	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 		TaskQueue: taskQueue,
@@ -1943,7 +1859,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAfterReset(cha
 		s.T().Skip("Blocked on CHASM Nexus async completion after reset support")
 	}
 	env := s.newTestEnv(chasmEnabled)
-	ctx := testcore.NewContext()
+	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
@@ -1956,22 +1872,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAfterReset(cha
 			return &nexus.HandlerStartOperationResultAsync{OperationToken: "test"}, nil
 		},
 	}
-	listenAddr := nexustest.AllocListenAddress()
-	nexustest.NewNexusServer(s.T(), listenAddr, h)
-
-	_, err := env.OperatorClient().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
-		Spec: &nexuspb.EndpointSpec{
-			Name: endpointName,
-			Target: &nexuspb.EndpointTarget{
-				Variant: &nexuspb.EndpointTarget_External_{
-					External: &nexuspb.EndpointTarget_External{
-						Url: "http://" + listenAddr,
-					},
-				},
-			},
-		},
-	})
-	s.NoError(err)
+	env.createExternalNexusServer(ctx, s.T(), endpointName, h)
 
 	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 		TaskQueue: taskQueue,
@@ -2632,7 +2533,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncNexusFailure(chasmEnabled
 		s.T().Skip("Blocked on CHASM Nexus sync failure conversion support")
 	}
 	env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
-	ctx := testcore.NewContext()
+	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
@@ -2650,22 +2551,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncNexusFailure(chasmEnabled
 			}
 		},
 	}
-	listenAddr := nexustest.AllocListenAddress()
-	nexustest.NewNexusServer(s.T(), listenAddr, h)
-
-	_, err := env.OperatorClient().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
-		Spec: &nexuspb.EndpointSpec{
-			Name: endpointName,
-			Target: &nexuspb.EndpointTarget{
-				Variant: &nexuspb.EndpointTarget_External_{
-					External: &nexuspb.EndpointTarget_External{
-						Url: "http://" + listenAddr,
-					},
-				},
-			},
-		},
-	})
-	s.NoError(err)
+	env.createExternalNexusServer(ctx, s.T(), endpointName, h)
 
 	w := worker.New(
 		env.SdkClient(),
@@ -2905,7 +2791,7 @@ func (s *NexusWorkflowTestSuite) TestNexusAsyncOperationWithMultipleCallers(chas
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationScheduleToCloseTimeout(chasmEnabled bool) {
 	env := s.newTestEnv(chasmEnabled)
-	ctx := testcore.NewContext()
+	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
@@ -3003,7 +2889,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationScheduleToCloseTimeout(chasmE
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationScheduleToStartTimeout(chasmEnabled bool) {
 	env := s.newTestEnv(chasmEnabled)
-	ctx := testcore.NewContext()
+	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
@@ -3101,7 +2987,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationScheduleToStartTimeout(chasmE
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationStartToCloseTimeout(chasmEnabled bool) {
 	env := s.newTestEnv(chasmEnabled)
-	ctx := testcore.NewContext()
+	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
@@ -3112,22 +2998,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationStartToCloseTimeout(chasmEnab
 			return &nexus.HandlerStartOperationResultAsync{OperationToken: "test-op-token"}, nil
 		},
 	}
-	listenAddr := nexustest.AllocListenAddress()
-	nexustest.NewNexusServer(s.T(), listenAddr, h)
-
-	_, err := env.OperatorClient().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
-		Spec: &nexuspb.EndpointSpec{
-			Name: endpointName,
-			Target: &nexuspb.EndpointTarget{
-				Variant: &nexuspb.EndpointTarget_External_{
-					External: &nexuspb.EndpointTarget_External{
-						Url: "http://" + listenAddr,
-					},
-				},
-			},
-		},
-	})
-	s.NoError(err)
+	env.createExternalNexusServer(ctx, s.T(), endpointName, h)
 
 	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 		TaskQueue: taskQueue,
@@ -3273,7 +3144,7 @@ func (s *NexusWorkflowTestSuite) sendNexusCompletionRequest(
 // __temporal_system endpoint.
 func (s *NexusWorkflowTestSuite) TestNexusOperationSystemEndpoint(chasmEnabled bool) {
 	env := s.newTestEnv(chasmEnabled)
-	ctx := testcore.NewContext()
+	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 
 	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -78,7 +78,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelation(chasmEnabled bool
 	env := s.newTestEnv(chasmEnabled)
 	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
-	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
 	firstCancelSeen := false
 	h := nexustest.Handler{
@@ -97,7 +96,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelation(chasmEnabled bool
 			return nil
 		},
 	}
-	env.createExternalNexusServer(ctx, s.T(), endpointName, h)
+	endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
 
 	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 		TaskQueue:           taskQueue,
@@ -279,7 +278,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion(chasmEnabled b
 	env := s.newTestEnv(chasmEnabled)
 	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
-	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
 	handlerLink := &commonpb.Link_WorkflowEvent{
 		Namespace:  "handler-ns",
@@ -299,7 +297,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion(chasmEnabled b
 			return &nexus.HandlerStartOperationResultSync[any]{Value: "result"}, nil
 		},
 	}
-	env.createExternalNexusServer(ctx, s.T(), endpointName, h)
+	endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
 
 	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 		TaskQueue: taskQueue,
@@ -393,7 +391,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion_LargePayload(c
 	env := s.newTestEnv(chasmEnabled)
 	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
-	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
 	h := nexustest.Handler{
 		OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
@@ -402,7 +399,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion_LargePayload(c
 			return &nexus.HandlerStartOperationResultSync[any]{Value: strings.Repeat("a", (2*1024*1024)-10)}, nil
 		},
 	}
-	env.createExternalNexusServer(ctx, s.T(), endpointName, h)
+	endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
 
 	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 		TaskQueue: taskQueue,
@@ -482,7 +479,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletion(chasmEnabled 
 	env := s.newTestEnv(chasmEnabled)
 	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
-	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
 	testClusterInfo, err := env.FrontendClient().GetClusterInfo(ctx, &workflowservice.GetClusterInfoRequest{})
 	s.NoError(err)
@@ -571,7 +567,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletion(chasmEnabled 
 			}, nil
 		},
 	}
-	env.createExternalNexusServer(ctx, s.T(), endpointName, h)
+	endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
 
 	pollResp, err := env.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: env.Namespace().String(),
@@ -1164,7 +1160,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncFailure(chasmEnabled boo
 	env := s.newTestEnv(chasmEnabled)
 	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
-	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
 	var callbackToken, publicCallbackURL string
 
@@ -1175,7 +1170,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncFailure(chasmEnabled boo
 			return &nexus.HandlerStartOperationResultAsync{OperationToken: "test"}, nil
 		},
 	}
-	env.createExternalNexusServer(ctx, s.T(), endpointName, h)
+	endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
 
 	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 		TaskQueue: taskQueue,
@@ -1739,7 +1734,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelBeforeStarted_Cancelati
 	env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
 	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
-	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
 	canStartCh := make(chan struct{})
 	cancelSentCh := make(chan struct{})
@@ -1758,7 +1752,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelBeforeStarted_Cancelati
 			return nil
 		},
 	}
-	env.createExternalNexusServer(ctx, s.T(), endpointName, h)
+	endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
 
 	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 		TaskQueue: taskQueue,
@@ -1861,7 +1855,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAfterReset(cha
 	env := s.newTestEnv(chasmEnabled)
 	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
-	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
 	var callbackToken, publicCallbackUrl string
 
@@ -1872,7 +1865,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAfterReset(cha
 			return &nexus.HandlerStartOperationResultAsync{OperationToken: "test"}, nil
 		},
 	}
-	env.createExternalNexusServer(ctx, s.T(), endpointName, h)
+	endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
 
 	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 		TaskQueue: taskQueue,
@@ -2535,7 +2528,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncNexusFailure(chasmEnabled
 	env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
 	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
-	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
 	h := nexustest.Handler{
 		OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
@@ -2551,7 +2543,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncNexusFailure(chasmEnabled
 			}
 		},
 	}
-	env.createExternalNexusServer(ctx, s.T(), endpointName, h)
+	endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
 
 	w := worker.New(
 		env.SdkClient(),
@@ -2989,7 +2981,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationStartToCloseTimeout(chasmEnab
 	env := s.newTestEnv(chasmEnabled)
 	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
-	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
 	// Handler that starts quickly (returns async) but never completes
 	h := nexustest.Handler{
@@ -2998,7 +2989,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationStartToCloseTimeout(chasmEnab
 			return &nexus.HandlerStartOperationResultAsync{OperationToken: "test-op-token"}, nil
 		},
 	}
-	env.createExternalNexusServer(ctx, s.T(), endpointName, h)
+	endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
 
 	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 		TaskQueue: taskQueue,


### PR DESCRIPTION
## What changed?

Added a `createExternalNexusServer(...)` which sets up an external Nexus endpoint with user-provided handler and listens on a provided address. This is used in nexus_workflow_test.go and will be used more in https://github.com/temporalio/temporal/pull/9614/

Opportunistically did a couple more drive-by refactors/consistency fixes, specifically:
* Force user to provide `ctx` into the endpoint creation functions instead of making a new `ctx`
* Use `env.Context()` instead of `testcore.NewContext()` in all suites that I touched here

## Why?

Pulling changes out of https://github.com/temporalio/temporal/pull/9614/ into targeted PRs to reduce load on reviewers.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)