### PR TITLE
Add signal_external_workflow_execution_failed metric

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1397,7 +1397,11 @@ var (
 	NamespaceReplicationEnqueueDLQCount               = NewCounterDef("namespace_replication_dlq_enqueue_requests")
 	ParentClosePolicyProcessorSuccess                 = NewCounterDef("parent_close_policy_processor_requests")
 	ParentClosePolicyProcessorFailures                = NewCounterDef("parent_close_policy_processor_errors")
-	ScheduleMissedCatchupWindow                       = NewCounterDef(
+	SignalExternalWorkflowExecutionFailed             = NewCounterDef(
+		"signal_external_workflow_execution_failed",
+		WithDescription("The number of signal external workflow execution failures by cause."),
+	)
+	ScheduleMissedCatchupWindow = NewCounterDef(
 		"schedule_missed_catchup_window",
 		WithDescription("The number of times a schedule missed an action due to the configured catchup window"),
 	)

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1397,8 +1397,8 @@ var (
 	NamespaceReplicationEnqueueDLQCount               = NewCounterDef("namespace_replication_dlq_enqueue_requests")
 	ParentClosePolicyProcessorSuccess                 = NewCounterDef("parent_close_policy_processor_requests")
 	ParentClosePolicyProcessorFailures                = NewCounterDef("parent_close_policy_processor_errors")
-	SignalExternalWorkflowExecutionFailed             = NewCounterDef(
-		"signal_external_workflow_execution_failed",
+	SignalExternalWorkflowExecutionFailures           = NewCounterDef(
+		"signal_external_workflow_execution_failures",
 		WithDescription("The number of signal external workflow execution failures by cause."),
 	)
 	ScheduleMissedCatchupWindow = NewCounterDef(

--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -663,6 +663,11 @@ func (t *transferQueueActiveTaskExecutor) processSignalExecution(
 	}
 
 	if targetNamespaceEntry == nil {
+		metrics.SignalExternalWorkflowExecutionFailed.With(t.metricHandler).Record(
+			1,
+			metrics.StringTag("failed_cause", enumspb.SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_NAMESPACE_NOT_FOUND.String()),
+			metrics.StringTag("source", "local_check"),
+		)
 		return t.signalExternalExecutionFailed(
 			ctx,
 			task,
@@ -682,6 +687,11 @@ func (t *transferQueueActiveTaskExecutor) processSignalExecution(
 	// handle workflow signal itself
 	if task.NamespaceID == targetNamespaceID.String() && task.WorkflowID == attributes.GetWorkflowExecution().GetWorkflowId() {
 		// it does not matter if the run ID is a mismatch
+		metrics.SignalExternalWorkflowExecutionFailed.With(t.metricHandler).Record(
+			1,
+			metrics.StringTag("failed_cause", enumspb.SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_EXTERNAL_WORKFLOW_EXECUTION_NOT_FOUND.String()),
+			metrics.StringTag("source", "local_check"),
+		)
 		return t.signalExternalExecutionFailed(
 			ctx,
 			task,
@@ -708,7 +718,7 @@ func (t *transferQueueActiveTaskExecutor) processSignalExecution(
 		// Check to see if the error is non-transient, in which case add SignalFailed
 		// event and complete transfer task by returning nil error.
 		if common.IsServiceTransientError(err) || common.IsContextDeadlineExceededErr(err) {
-			// for retryable error just return
+			// Transient errors are retried by the task framework; don't emit the failure metric here.
 			return err
 		}
 		var failedCause enumspb.SignalExternalWorkflowExecutionFailedCause
@@ -721,8 +731,21 @@ func (t *transferQueueActiveTaskExecutor) processSignalExecution(
 			failedCause = enumspb.SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_SIGNAL_COUNT_LIMIT_EXCEEDED
 		default:
 			t.logger.Error("Unexpected error type returned from SignalWorkflowExecution API call.", tag.ServiceErrorType(err), tag.Error(err))
+			metrics.SignalExternalWorkflowExecutionFailed.With(t.metricHandler).Record(
+				1,
+				metrics.StringTag("failed_cause", enumspb.SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_UNSPECIFIED.String()),
+				metrics.StringTag("source", "remote_call"),
+			)
 			return err
 		}
+		// Metric is emitted when the failure cause is detected, before recording the
+		// SignalExternalWorkflowExecutionFailed history event. If the event fails to
+		// commit, the task will be retried and the metric emitted again.
+		metrics.SignalExternalWorkflowExecutionFailed.With(t.metricHandler).Record(
+			1,
+			metrics.StringTag("failed_cause", failedCause.String()),
+			metrics.StringTag("source", "remote_call"),
+		)
 		return t.signalExternalExecutionFailed(
 			ctx,
 			task,

--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -663,9 +663,9 @@ func (t *transferQueueActiveTaskExecutor) processSignalExecution(
 	}
 
 	if targetNamespaceEntry == nil {
-		metrics.SignalExternalWorkflowExecutionFailed.With(t.metricHandler).Record(
+		metrics.SignalExternalWorkflowExecutionFailures.With(t.metricHandler).Record(
 			1,
-			metrics.StringTag("failed_cause", enumspb.SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_NAMESPACE_NOT_FOUND.String()),
+			metrics.FailureTag(enumspb.SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_NAMESPACE_NOT_FOUND.String()),
 			metrics.StringTag("source", "local_check"),
 		)
 		return t.signalExternalExecutionFailed(
@@ -687,9 +687,9 @@ func (t *transferQueueActiveTaskExecutor) processSignalExecution(
 	// handle workflow signal itself
 	if task.NamespaceID == targetNamespaceID.String() && task.WorkflowID == attributes.GetWorkflowExecution().GetWorkflowId() {
 		// it does not matter if the run ID is a mismatch
-		metrics.SignalExternalWorkflowExecutionFailed.With(t.metricHandler).Record(
+		metrics.SignalExternalWorkflowExecutionFailures.With(t.metricHandler).Record(
 			1,
-			metrics.StringTag("failed_cause", enumspb.SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_EXTERNAL_WORKFLOW_EXECUTION_NOT_FOUND.String()),
+			metrics.FailureTag(enumspb.SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_EXTERNAL_WORKFLOW_EXECUTION_NOT_FOUND.String()),
 			metrics.StringTag("source", "local_check"),
 		)
 		return t.signalExternalExecutionFailed(
@@ -731,9 +731,9 @@ func (t *transferQueueActiveTaskExecutor) processSignalExecution(
 			failedCause = enumspb.SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_SIGNAL_COUNT_LIMIT_EXCEEDED
 		default:
 			t.logger.Error("Unexpected error type returned from SignalWorkflowExecution API call.", tag.ServiceErrorType(err), tag.Error(err))
-			metrics.SignalExternalWorkflowExecutionFailed.With(t.metricHandler).Record(
+			metrics.SignalExternalWorkflowExecutionFailures.With(t.metricHandler).Record(
 				1,
-				metrics.StringTag("failed_cause", enumspb.SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_UNSPECIFIED.String()),
+				metrics.FailureTag(enumspb.SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_UNSPECIFIED.String()),
 				metrics.StringTag("source", "remote_call"),
 			)
 			return err
@@ -741,9 +741,9 @@ func (t *transferQueueActiveTaskExecutor) processSignalExecution(
 		// Metric is emitted when the failure cause is detected, before recording the
 		// SignalExternalWorkflowExecutionFailed history event. If the event fails to
 		// commit, the task will be retried and the metric emitted again.
-		metrics.SignalExternalWorkflowExecutionFailed.With(t.metricHandler).Record(
+		metrics.SignalExternalWorkflowExecutionFailures.With(t.metricHandler).Record(
 			1,
-			metrics.StringTag("failed_cause", failedCause.String()),
+			metrics.FailureTag(failedCause.String()),
 			metrics.StringTag("source", "remote_call"),
 		)
 		return t.signalExternalExecutionFailed(


### PR DESCRIPTION
## What changed
Add a new `signal_external_workflow_execution_failed` counter metric to the transfer queue active task executor. The metric is emitted at all four failure paths in `processSignalExecution`, tagged with:
- `failed_cause`: proto enum string value (`NAMESPACE_NOT_FOUND`, `EXTERNAL_WORKFLOW_EXECUTION_NOT_FOUND`, `SIGNAL_COUNT_LIMIT_EXCEEDED`, `UNSPECIFIED`)
- `source`: `local_check` (pre-delivery validation) or `remote_call` (gRPC call to target history shard)

## Why
Signal external workflow execution failures were previously invisible in metrics — expected errors (`NotFound`, `InvalidArgument`, `NamespaceNotFound`) from the gRPC call were silently converted into `SignalExternalWorkflowExecutionFailed` history events with no metric or log emitted at default levels. This made it difficult to:
- Diagnose elevated signal failure rates
- Distinguish backend-originated failures from frontend-originated ones in `service_error_with_type{operation="SignalWorkflowExecution"}`
- Understand the breakdown of failure causes

## How tested
- Existing unit tests pass: `TestProcessSignalExecution_Success`, `TestProcessSignalExecution_Failure_TargetWorkflowNotFound`, `TestProcessSignalExecution_Failure_TargetNamespaceNotFound`, `TestProcessSignalExecution_Failure_SignalCountLimitExceeded`, `TestProcessSignalExecution_Duplication`
- `go build ./service/history/...` compiles clean

## Risks
- Low risk: metric emissions are fire-and-forget (`Record` returns nothing), cannot panic, and do not alter control flow
- New metric tags (`failed_cause`, `source`) have bounded cardinality (4 cause values × 2 source values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metrics-only instrumentation on existing failure paths with bounded tag cardinality; no change to retry or history semantics beyond possible duplicate counts on task retry.
> 
> **Overview**
> Adds observability for **signal external workflow** failures in the active transfer queue’s `processSignalExecution` path.
> 
> A new counter, `signal_external_workflow_execution_failures`, is defined in metrics and incremented when the executor turns a failure into a `SignalExternalWorkflowExecutionFailed` outcome (or the equivalent local checks). Each increment is tagged with **`failure`** (proto failed-cause string) and **`source`**: `local_check` for pre-RPC validation (missing target namespace, signaling the same workflow) or `remote_call` after a non-retryable `SignalWorkflowExecution` error (`NotFound`, `NamespaceNotFound`, `InvalidArgument`, or `UNSPECIFIED` for unexpected errors). **Transient** RPC/deadline errors are still retried and **do not** emit this counter.
> 
> Control flow and history-event behavior are unchanged aside from metrics; retries after a failed history commit may double-count, as noted in code comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e55fb85da67fd070b7553faed8c472d2ada21c85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->