### PR TITLE
Cherry-pick: CHASM: Fix apply empty snapshot (#10109)

### DIFF
--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -2308,6 +2308,28 @@ func (n *Node) applyDeletions(
 			continue
 		}
 
+		if node == n.root() {
+			// Root node can never be deleted
+			// This can happen when:
+			// 1. CHASM framework is disabled in source cluster and sends an
+			// empty snapshot to the standby cluster. If the standby cluster
+			// has a non-empty chasm tree, the root node will be marked for
+			// deletion and we will lose archetype information for the execution,
+			// and hit other undefined issues when root is deleted.
+			// Disabled CHASM framework itself is already an undefined situation
+			// for non-workflow chasm executions, and we are ok with not deleting
+			// the root node.
+			//
+			// 2. CHASM is enabled but the execution is a workflow which doesn't
+			// have any chasm nodes. In this case, again an empty snapshot will be sent to
+			// standby cluster.
+			// In this case, we can actually choose to delete the root itself because empty
+			// chasm tree is assume to be a Workflow. However, given chasm workflow component's
+			// state is an empty proto, skipping deletion is fine as well. All other child nodes
+			// will still be deleted.
+			continue
+		}
+
 		if err := node.delete(isSystemUpdates); err != nil {
 			return err
 		}

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -1169,6 +1169,45 @@ func (s *nodeSuite) TestApplySnapshot() {
 	s.True(root.currentSA["TemporalDatetime01"].(VisibilityValueTime).Equal(VisibilityValueTime(now.AsTime())))
 }
 
+func (s *nodeSuite) TestApplySnapshot_EmptySnapshot() {
+	persistenceNodes := map[string]*persistencespb.ChasmNode{
+		"": {
+			Metadata: &persistencespb.ChasmNodeMetadata{
+				InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+				LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+				Attributes: &persistencespb.ChasmNodeMetadata_ComponentAttributes{
+					ComponentAttributes: &persistencespb.ChasmComponentAttributes{
+						TypeId: testComponentTypeID,
+					},
+				},
+			},
+		},
+		"SubComponent1": {
+			Metadata: &persistencespb.ChasmNodeMetadata{
+				InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 2},
+				LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 2},
+			},
+		},
+	}
+	root, err := s.newTestTree(persistenceNodes)
+	s.NoError(err)
+
+	// Apply an empty snapshot to simulate the case where
+	// chasm is disabled in source cluster or chasm tree is empty in
+	// source cluster.
+	err = root.ApplySnapshot(NodesSnapshot{})
+	s.NoError(err)
+
+	// Validate that nodeBase.mutation reflects the applied snapshot.
+	expectedMutation := NodesMutation{
+		UpdatedNodes: map[string]*persistencespb.ChasmNode{},
+		DeletedNodes: map[string]struct{}{
+			"SubComponent1": {}, // NOTE: root component can't be deleted.
+		},
+	}
+	s.Equal(expectedMutation, root.mutation)
+}
+
 func (s *nodeSuite) TestApplyMutation_OutOfOrder() {
 	persistenceNodes := map[string]*persistencespb.ChasmNode{
 		"": {


### PR DESCRIPTION
Cherry-pick of #10109 into `release/v1.31.x` for the v1.31.0 minor release.

Original PR: https://github.com/temporalio/temporal/pull/10109

Auto-merged in `chasm/tree.go` and `chasm/tree_test.go`; no manual conflict resolution. Verified with `go build` and `go vet` on `./chasm/...`.