### PR TITLE
Test version reactivation cache for all versioning tests

### DIFF
--- a/tests/worker_deployment_version_test.go
+++ b/tests/worker_deployment_version_test.go
@@ -87,6 +87,9 @@ func (s *DeploymentVersionSuite) SetupSuite() {
 		dynamicconfig.VersionDrainageStatusRefreshInterval.Key():       testVersionDrainageRefreshInterval,
 		dynamicconfig.VersionDrainageStatusVisibilityGracePeriod.Key(): testVersionDrainageVisibilityGracePeriod,
 		dynamicconfig.VersionMembershipCacheTTL.Key():                  testVersionMembershipCacheTTL,
+
+		// Test reactivation cache for all versioning tests.
+		dynamicconfig.EnableVersionReactivationSignals.Key(): true,
 	}))
 }
 
@@ -2212,8 +2215,6 @@ func (s *DeploymentVersionSuite) TestUpdateWorkflowExecutionOptions_ReactivateVe
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	s.OverrideDynamicConfig(dynamicconfig.EnableVersionReactivationSignals, true)
-
 	// Use shorter, explicit deployment series names to avoid truncation issues
 	// Include workflow version in deployment name to avoid conflicts in parallel tests
 	deploymentName := fmt.Sprintf("test-reactivate-wfv%d", s.workflowVersion)
@@ -2336,8 +2337,6 @@ func (s *DeploymentVersionSuite) TestStartWorkflowExecution_ReactivateVersionOnP
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	s.OverrideDynamicConfig(dynamicconfig.EnableVersionReactivationSignals, true)
-
 	deploymentName := fmt.Sprintf("test-start-reactivate-wfv%d", s.workflowVersion)
 	tv1 := testvars.New(s).WithDeploymentSeries(deploymentName).WithBuildID(deploymentName + "-v1").WithTaskQueue("test-start-task-queue")
 
@@ -2421,8 +2420,6 @@ func (s *DeploymentVersionSuite) TestStartWorkflowExecution_ReactivateVersionOnP
 func (s *DeploymentVersionSuite) TestStartWorkflowExecution_ReactivateVersionOnPinned_WithConflictPolicy() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
-
-	s.OverrideDynamicConfig(dynamicconfig.EnableVersionReactivationSignals, true)
 
 	deploymentName := fmt.Sprintf("test-start-conflict-reactivate-wfv%d", s.workflowVersion)
 	tv1 := testvars.New(s).WithDeploymentSeries(deploymentName).WithBuildID(deploymentName + "-v1").WithTaskQueue("test-conflict-task-queue")
@@ -2538,8 +2535,6 @@ func (s *DeploymentVersionSuite) TestSignalWithStartWorkflowExecution_Reactivate
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	s.OverrideDynamicConfig(dynamicconfig.EnableVersionReactivationSignals, true)
-
 	deploymentName := fmt.Sprintf("test-sws-reactivate-wfv%d", s.workflowVersion)
 	tv1 := testvars.New(s).WithDeploymentSeries(deploymentName).WithBuildID(deploymentName + "-v1").WithTaskQueue("test-sws-task-queue")
 
@@ -2629,8 +2624,6 @@ func (s *DeploymentVersionSuite) TestSignalWithStartWorkflowExecution_Reactivate
 func (s *DeploymentVersionSuite) TestResetWorkflowExecution_ReactivateVersionOnPinned() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
-
-	s.OverrideDynamicConfig(dynamicconfig.EnableVersionReactivationSignals, true)
 
 	// Use shorter, explicit deployment series names to avoid truncation issues
 	// Include workflow version in deployment name to avoid conflicts in parallel tests


### PR DESCRIPTION
## What changed?
Test version reactivation cache for all versioning tests

## Why?
This is simpler and will lead to less flaky tests than just enabling it for some tests, which could lead to forgetting some.
This is a minor thing which will not negatively affect coverage.
Soon we will re-enable this by default anyways, so there is no point in rewriting the tests to expect it to be disabled.

In real life, the versioning override is not relevant very often, but we use it a lot in tests, so it is highly possible that random tests we didn't think of could be affected by this flag. It is not a good use of our time to sort through that.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Removes potential coverage for "what if the flag is disabled, like it is by default in v1.31.0 and Cloud"
That is ok though, because we will re-enable it by default shortly, and WAS enabled for the last ~3 months.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that flips a dynamic config default for the suite; risk is limited to altered test behavior/coverage around the flag being disabled.
> 
> **Overview**
> Enables `dynamicconfig.EnableVersionReactivationSignals` at the `DeploymentVersionSuite` level so **all** worker deployment versioning tests run with version reactivation signals/caching enabled.
> 
> Removes per-test overrides that enabled this flag in the reactivation-related tests, reducing configuration churn and potential flakiness from inconsistent flag state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2ac117ae5711308b8115184737fdb2cdb5dba04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->