### PR TITLE
fix: deduplicate schedule StructuredCalendar entries on create/update

### DIFF
--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -636,7 +636,6 @@ func (s *Scheduler) Describe(
 	}, nil
 }
 
-
 // ListMatchingTimes returns the upcoming times that the schedule will trigger
 // within the given time range.
 func (s *Scheduler) ListMatchingTimes(

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -22,7 +22,7 @@ import (
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/util"
-	"go.temporal.io/server/service/worker/scheduler"
+	legacyscheduler "go.temporal.io/server/service/worker/scheduler"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -52,7 +52,7 @@ type Scheduler struct {
 
 	// Locally-cached state, invalidated whenever cacheConflictToken != ConflictToken.
 	cacheConflictToken int64
-	compiledSpec       *scheduler.CompiledSpec // compiledSpec is only ever replaced whole, not mutated.
+	compiledSpec       *legacyscheduler.CompiledSpec // compiledSpec is only ever replaced whole, not mutated.
 }
 
 var (
@@ -66,7 +66,7 @@ var (
 )
 
 var executionStatusSearchAttribute = chasm.NewSearchAttributeKeyword("ExecutionStatus", chasm.SearchAttributeFieldLowCardinalityKeyword01)
-var initialSerializedConflictToken = serializeConflictToken(scheduler.InitialConflictToken)
+var initialSerializedConflictToken = serializeConflictToken(legacyscheduler.InitialConflictToken)
 
 const (
 	// How many recent actions to keep on the Info.RecentActions list.
@@ -113,9 +113,9 @@ func NewScheduler(
 			Namespace:     namespace,
 			NamespaceId:   namespaceID,
 			ScheduleId:    scheduleID,
-			ConflictToken: scheduler.InitialConflictToken,
+			ConflictToken: legacyscheduler.InitialConflictToken,
 		},
-		cacheConflictToken:   scheduler.InitialConflictToken,
+		cacheConflictToken:   legacyscheduler.InitialConflictToken,
 		Backfillers:          make(chasm.Map[string, *Backfiller]),
 		LastCompletionResult: chasm.NewDataField(ctx, &schedulerpb.LastCompletionResult{}),
 	}
@@ -152,10 +152,10 @@ func NewSentinel(
 			NamespaceId:   namespaceID,
 			ScheduleId:    scheduleID,
 			Sentinel:      true,
-			ConflictToken: scheduler.InitialConflictToken,
+			ConflictToken: legacyscheduler.InitialConflictToken,
 			Info:          &schedulepb.ScheduleInfo{},
 		},
-		cacheConflictToken: scheduler.InitialConflictToken,
+		cacheConflictToken: legacyscheduler.InitialConflictToken,
 	}
 	now := ctx.Now(s)
 	s.Info.CreateTime = timestamppb.New(now)
@@ -375,7 +375,7 @@ func (s *Scheduler) useScheduledAction(decrement bool) bool {
 	return false
 }
 
-func (s *Scheduler) getCompiledSpec(specBuilder *scheduler.SpecBuilder) (*scheduler.CompiledSpec, error) {
+func (s *Scheduler) getCompiledSpec(specBuilder *legacyscheduler.SpecBuilder) (*legacyscheduler.CompiledSpec, error) {
 	s.validateCachedState()
 
 	// Cache compiled spec.
@@ -586,7 +586,7 @@ func (s *Scheduler) HandleNexusCompletion(
 func (s *Scheduler) Describe(
 	ctx chasm.Context,
 	req *schedulerpb.DescribeScheduleRequest,
-	specBuilder *scheduler.SpecBuilder,
+	specBuilder *legacyscheduler.SpecBuilder,
 ) (*schedulerpb.DescribeScheduleResponse, error) {
 	if s.Sentinel {
 		return nil, ErrSentinel
@@ -608,7 +608,7 @@ func (s *Scheduler) Describe(
 	}
 
 	schedule := common.CloneProto(s.Schedule)
-	cleanSpec(schedule.Spec)
+	legacyscheduler.CleanSpec(schedule.Spec)
 
 	generator := s.Generator.Get(ctx)
 	if generator.GetFutureActionTimes() == nil {
@@ -636,41 +636,13 @@ func (s *Scheduler) Describe(
 	}, nil
 }
 
-// cleanSpec sets default values in ranges for the DescribeSchedule response.
-func cleanSpec(spec *schedulepb.ScheduleSpec) {
-	cleanRanges := func(ranges []*schedulepb.Range) {
-		for _, r := range ranges {
-			if r.End < r.Start {
-				r.End = r.Start
-			}
-			if r.Step == 0 {
-				r.Step = 1
-			}
-		}
-	}
-	cleanCal := func(structured *schedulepb.StructuredCalendarSpec) {
-		cleanRanges(structured.Second)
-		cleanRanges(structured.Minute)
-		cleanRanges(structured.Hour)
-		cleanRanges(structured.DayOfMonth)
-		cleanRanges(structured.Month)
-		cleanRanges(structured.Year)
-		cleanRanges(structured.DayOfWeek)
-	}
-	for _, structured := range spec.StructuredCalendar {
-		cleanCal(structured)
-	}
-	for _, structured := range spec.ExcludeStructuredCalendar {
-		cleanCal(structured)
-	}
-}
 
 // ListMatchingTimes returns the upcoming times that the schedule will trigger
 // within the given time range.
 func (s *Scheduler) ListMatchingTimes(
 	ctx chasm.Context,
 	req *schedulerpb.ListScheduleMatchingTimesRequest,
-	specBuilder *scheduler.SpecBuilder,
+	specBuilder *legacyscheduler.SpecBuilder,
 ) (*schedulerpb.ListScheduleMatchingTimesResponse, error) {
 	if s.Sentinel {
 		return nil, ErrSentinel

--- a/service/worker/scheduler/spec.go
+++ b/service/worker/scheduler/spec.go
@@ -13,6 +13,7 @@ import (
 	"go.temporal.io/server/common/cache"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/util"
+	"google.golang.org/protobuf/proto"
 )
 
 type (
@@ -89,6 +90,17 @@ func (b *SpecBuilder) NewCompiledSpec(spec *schedulepb.ScheduleSpec) (*CompiledS
 
 // CleanSpec sets default values in ranges.
 func CleanSpec(spec *schedulepb.ScheduleSpec) {
+	for _, structured := range spec.StructuredCalendar {
+		cleanCalendar(structured)
+	}
+	for _, structured := range spec.ExcludeStructuredCalendar {
+		cleanCalendar(structured)
+	}
+}
+
+// cleanCalendar normalizes range defaults on a single StructuredCalendarSpec
+// in place: End defaults to Start when less than Start, Step defaults to 1.
+func cleanCalendar(structured *schedulepb.StructuredCalendarSpec) {
 	cleanRanges := func(ranges []*schedulepb.Range) {
 		for _, r := range ranges {
 			if r.End < r.Start {
@@ -99,21 +111,41 @@ func CleanSpec(spec *schedulepb.ScheduleSpec) {
 			}
 		}
 	}
-	cleanCal := func(structured *schedulepb.StructuredCalendarSpec) {
-		cleanRanges(structured.Second)
-		cleanRanges(structured.Minute)
-		cleanRanges(structured.Hour)
-		cleanRanges(structured.DayOfMonth)
-		cleanRanges(structured.Month)
-		cleanRanges(structured.Year)
-		cleanRanges(structured.DayOfWeek)
+	cleanRanges(structured.Second)
+	cleanRanges(structured.Minute)
+	cleanRanges(structured.Hour)
+	cleanRanges(structured.DayOfMonth)
+	cleanRanges(structured.Month)
+	cleanRanges(structured.Year)
+	cleanRanges(structured.DayOfWeek)
+}
+
+// deduplicateStructuredCalendars removes duplicate StructuredCalendarSpec
+// entries by normalizing range defaults before comparing with proto.Equal.
+// Entries that differ only in proto default representation (e.g. Step 0 vs
+// 1, End unset vs End==Start) are treated as equal.
+func deduplicateStructuredCalendars(entries []*schedulepb.StructuredCalendarSpec) []*schedulepb.StructuredCalendarSpec {
+	if len(entries) <= 1 {
+		return entries
 	}
-	for _, structured := range spec.StructuredCalendar {
-		cleanCal(structured)
+	out := make([]*schedulepb.StructuredCalendarSpec, 0, len(entries))
+	seen := make([]*schedulepb.StructuredCalendarSpec, 0, len(entries))
+	for _, e := range entries {
+		normalized := common.CloneProto(e)
+		cleanCalendar(normalized)
+		duplicate := false
+		for _, s := range seen {
+			if proto.Equal(normalized, s) {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			out = append(out, e)
+			seen = append(seen, normalized)
+		}
 	}
-	for _, structured := range spec.ExcludeStructuredCalendar {
-		cleanCal(structured)
-	}
+	return out
 }
 
 //revive:disable-next-line:cognitive-complexity
@@ -186,6 +218,12 @@ func canonicalizeSpec(spec *schedulepb.ScheduleSpec) (*schedulepb.ScheduleSpec, 
 			return nil, err
 		}
 	}
+
+	// deduplicate structured calendars after validation, so that entries
+	// differing only in proto default representation (e.g. Step 0 vs 1,
+	// End unset vs End==Start) are collapsed.
+	spec.StructuredCalendar = deduplicateStructuredCalendars(spec.StructuredCalendar)
+	spec.ExcludeStructuredCalendar = deduplicateStructuredCalendars(spec.ExcludeStructuredCalendar)
 
 	return spec, nil
 }

--- a/service/worker/scheduler/spec_test.go
+++ b/service/worker/scheduler/spec_test.go
@@ -544,11 +544,11 @@ func (s *specSuite) TestCanonicalizeDeduplicates() {
 	spec, err := canonicalizeSpec(&schedulepb.ScheduleSpec{
 		StructuredCalendar: []*schedulepb.StructuredCalendarSpec{
 			{Hour: []*schedulepb.Range{{Start: 9, End: 9, Step: 1}}},
-			{Hour: []*schedulepb.Range{{Start: 9}}}, // same after normalization
+			{Hour: []*schedulepb.Range{{Start: 9}}},  // same after normalization
 			{Hour: []*schedulepb.Range{{Start: 17}}}, // different
 		},
 	})
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(spec.StructuredCalendar, 2)
 
 	// also deduplicates ExcludeStructuredCalendar
@@ -558,6 +558,6 @@ func (s *specSuite) TestCanonicalizeDeduplicates() {
 			{Hour: []*schedulepb.Range{{Start: 12}}},
 		},
 	})
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(spec.ExcludeStructuredCalendar, 1)
 }

--- a/service/worker/scheduler/spec_test.go
+++ b/service/worker/scheduler/spec_test.go
@@ -494,3 +494,70 @@ func (s *specSuite) TestSpecJitterSeed() {
 		time.Date(2022, 3, 24, 0, 39, 16, 922000000, time.UTC),
 	)
 }
+
+func (s *specSuite) TestDeduplicateStructuredCalendars() {
+	cal1 := &schedulepb.StructuredCalendarSpec{
+		Hour:   []*schedulepb.Range{{Start: 9, End: 9, Step: 1}},
+		Minute: []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+	}
+	// Same as cal1 but with proto defaults (Step=0, End=0 which defaults to Start)
+	cal1Defaults := &schedulepb.StructuredCalendarSpec{
+		Hour:   []*schedulepb.Range{{Start: 9}},
+		Minute: []*schedulepb.Range{{Start: 0}},
+	}
+	cal2 := &schedulepb.StructuredCalendarSpec{
+		Hour:   []*schedulepb.Range{{Start: 17, End: 17, Step: 1}},
+		Minute: []*schedulepb.Range{{Start: 30, End: 30, Step: 1}},
+	}
+
+	// exact duplicates removed
+	result := deduplicateStructuredCalendars([]*schedulepb.StructuredCalendarSpec{cal1, cal1})
+	s.Len(result, 1)
+
+	// proto-default-equivalent duplicates removed
+	result = deduplicateStructuredCalendars([]*schedulepb.StructuredCalendarSpec{cal1, cal1Defaults})
+	s.Len(result, 1)
+
+	// distinct entries preserved
+	result = deduplicateStructuredCalendars([]*schedulepb.StructuredCalendarSpec{cal1, cal2})
+	s.Len(result, 2)
+
+	// nil/empty input
+	result = deduplicateStructuredCalendars(nil)
+	s.Nil(result)
+	result = deduplicateStructuredCalendars([]*schedulepb.StructuredCalendarSpec{})
+	s.Empty(result)
+
+	// single entry returned as-is
+	result = deduplicateStructuredCalendars([]*schedulepb.StructuredCalendarSpec{cal1})
+	s.Len(result, 1)
+
+	// multiple duplicates with different default representations
+	result = deduplicateStructuredCalendars([]*schedulepb.StructuredCalendarSpec{
+		cal1, cal1Defaults, cal2, cal1, cal2,
+	})
+	s.Len(result, 2)
+}
+
+func (s *specSuite) TestCanonicalizeDeduplicates() {
+	// canonicalizeSpec should deduplicate StructuredCalendar entries
+	spec, err := canonicalizeSpec(&schedulepb.ScheduleSpec{
+		StructuredCalendar: []*schedulepb.StructuredCalendarSpec{
+			{Hour: []*schedulepb.Range{{Start: 9, End: 9, Step: 1}}},
+			{Hour: []*schedulepb.Range{{Start: 9}}}, // same after normalization
+			{Hour: []*schedulepb.Range{{Start: 17}}}, // different
+		},
+	})
+	s.NoError(err)
+	s.Len(spec.StructuredCalendar, 2)
+
+	// also deduplicates ExcludeStructuredCalendar
+	spec, err = canonicalizeSpec(&schedulepb.ScheduleSpec{
+		ExcludeStructuredCalendar: []*schedulepb.StructuredCalendarSpec{
+			{Hour: []*schedulepb.Range{{Start: 12, End: 12, Step: 1}}},
+			{Hour: []*schedulepb.Range{{Start: 12}}},
+		},
+	})
+	s.NoError(err)
+	s.Len(spec.ExcludeStructuredCalendar, 1)
+}

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -115,6 +115,8 @@ func runSharedScheduleTests(t *testing.T, newContext contextFactory) {
 	t.Run("TestUpdateScheduleBlobSizeLimit", func(t *testing.T) { testUpdateScheduleBlobSizeLimit(t, newContext) })
 	t.Run("TestListSchedulesPagination", func(t *testing.T) { testListSchedulesPagination(t, newContext) })
 	t.Run("TestListSchedulesFilterAndEntryFields", func(t *testing.T) { testListSchedulesFilterAndEntryFields(t, newContext) })
+	t.Run("TestUpdateDeduplicatesCalendars", func(t *testing.T) { testUpdateDeduplicatesCalendars(t, newContext) })
+	t.Run("TestCreateDeduplicatesCalendars", func(t *testing.T) { testCreateDeduplicatesCalendars(t, newContext) })
 }
 
 func testDeletedScheduleOperations(t *testing.T, newContext contextFactory) {
@@ -3015,4 +3017,119 @@ func testUpdateScheduleBlobSizeLimit(t *testing.T, newContext contextFactory) {
 	})
 	var invalidArgBlob *serviceerror.InvalidArgument
 	require.ErrorAs(t, err, &invalidArgBlob)
+}
+
+// testUpdateDeduplicatesCalendars reproduces the describe-then-update
+// accumulation pattern where repeated SDK updates with the same cron expression
+// would previously cause StructuredCalendar entries to accumulate. With
+// server-side dedup in canonicalizeSpec, the count should stay at 1.
+func testUpdateDeduplicatesCalendars(t *testing.T, newContext contextFactory) {
+	s := testcore.NewEnv(t, scheduleCommonOpts()...)
+
+	sid := testcore.RandomizeStr("sched-test-update-dedup")
+
+	schedule := &schedulepb.Schedule{
+		Spec: &schedulepb.ScheduleSpec{
+			CronString: []string{"0 * * * *"},
+		},
+		Action: &schedulepb.ScheduleAction{
+			Action: &schedulepb.ScheduleAction_StartWorkflow{
+				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+					WorkflowId:   "wf-" + sid,
+					WorkflowType: &commonpb.WorkflowType{Name: "myworkflow"},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				},
+			},
+		},
+	}
+
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Schedule:   schedule,
+		Identity:   testcore.RandomizeStr("identity"),
+		RequestId:  testcore.RandomizeStr("request-id"),
+	})
+	require.NoError(t, err)
+
+	// Simulate the SDK describe-then-update pattern: read the current schedule
+	// (which has StructuredCalendar entries from the original cron), then send
+	// an update that includes both the existing StructuredCalendar entries and
+	// the same cron string again. Without server-side dedup this would
+	// accumulate one extra entry per round.
+	const rounds = 5
+	for i := range rounds {
+		desc, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+		})
+		require.NoError(t, err, "describe round %d", i+1)
+
+		// Re-add the same cron on top of existing StructuredCalendar entries,
+		// mimicking what the SDK does when the user sets CronExpressions.
+		desc.Schedule.Spec.CronString = []string{"0 * * * *"}
+
+		_, err = s.FrontendClient().UpdateSchedule(ctx, &workflowservice.UpdateScheduleRequest{
+			Namespace:     s.Namespace().String(),
+			ScheduleId:    sid,
+			Schedule:      desc.Schedule,
+			ConflictToken: desc.ConflictToken,
+			Identity:      testcore.RandomizeStr("identity"),
+			RequestId:     testcore.RandomizeStr("request-id"),
+		})
+		require.NoError(t, err, "update round %d", i+1)
+	}
+
+	after, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+	})
+	require.NoError(t, err)
+	require.Len(t, after.Schedule.Spec.StructuredCalendar, 1,
+		"server-side dedup should prevent calendar accumulation across %d update rounds", rounds)
+}
+
+// testCreateDeduplicatesCalendars verifies that CreateSchedule deduplicates
+// StructuredCalendar entries when the same calendar is specified multiple times
+// in the initial request (e.g. via both CronString and StructuredCalendar).
+func testCreateDeduplicatesCalendars(t *testing.T, newContext contextFactory) {
+	s := testcore.NewEnv(t, scheduleCommonOpts()...)
+
+	sid := testcore.RandomizeStr("sched-test-create-dedup")
+
+	// Send the same cron string twice to verify dedup on create. Both get
+	// parsed into identical StructuredCalendarSpec entries.
+	schedule := &schedulepb.Schedule{
+		Spec: &schedulepb.ScheduleSpec{
+			CronString: []string{"0 * * * *", "0 * * * *"},
+		},
+		Action: &schedulepb.ScheduleAction{
+			Action: &schedulepb.ScheduleAction_StartWorkflow{
+				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+					WorkflowId:   "wf-" + sid,
+					WorkflowType: &commonpb.WorkflowType{Name: "myworkflow"},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				},
+			},
+		},
+	}
+
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Schedule:   schedule,
+		Identity:   testcore.RandomizeStr("identity"),
+		RequestId:  testcore.RandomizeStr("request-id"),
+	})
+	require.NoError(t, err)
+
+	desc, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+	})
+	require.NoError(t, err)
+	require.Len(t, desc.Schedule.Spec.StructuredCalendar, 1,
+		"create should deduplicate identical cron-derived structured calendar entries")
 }


### PR DESCRIPTION
## Why

When an SDK client uses the describe-then-update pattern to modify a schedule originally created with a cron expression, the accumulation bug triggers:

1. User creates a schedule with `CronString: ["0 * * * *"]`.
2. `CreateSchedule` canonicalizes the cron into a `StructuredCalendarSpec` entry and stores it.
3. User calls `DescribeSchedule`, which returns the spec with the `StructuredCalendar` entry.
4. User's update callback sets `CronExpressions` from their config (e.g. `["0 * * * *"]`) on the described spec, which already has the equivalent `StructuredCalendar` entry from step 3.
5. `UpdateSchedule` canonicalizes the cron into another `StructuredCalendarSpec` and appends it -- now there are two identical entries.
6. Each describe-then-update cycle adds another duplicate. Over time the spec grows unboundedly.

This pattern is reproduced in the functional tests (`TestUpdateDeduplicatesCalendars`).

See chaptersix/temporal#18 for an isolated reproducer and chaptersix/temporal#19 for operational tooling to remediate existing schedules.

## What changed

Added `deduplicateStructuredCalendars` to `canonicalizeSpec` (`spec.go:225-226`). After validation, each entry is normalized (range defaults filled in) and compared via `proto.Equal`. Entries differing only in proto default representation (e.g. `Step=0` vs `Step=1`, `End` unset vs `End==Start`) are treated as duplicates and collapsed.

Also replaced the duplicated `cleanSpec` in the CHASM scheduler with a call to the now-exported `legacyscheduler.CleanSpec`.

## How it flows

All `NewCompiledSpec` call sites are pre-existing and unchanged by this PR. `canonicalizeSpec` is called by `NewCompiledSpec` (`spec.go:57`), which is invoked in three places:

1. **Frontend** (`workflow_handler.go:6757` via `canonicalizeScheduleSpec`) -- called on both `CreateSchedule` and `UpdateSchedule` before CHASM/workflow routing. The canonical (now deduped) form is written back to the request via `compiledSpec.CanonicalForm()`, so both backends receive a clean spec. This is what breaks the accumulation cycle: the signal payload sent to the workflow-based scheduler is already deduped.

2. **Workflow-based scheduler** (`workflow.go:418` via `compileSpec`) -- recompiles on start and after updates.

3. **CHASM scheduler** (`scheduler.go:383` via `getCompiledSpec`) -- called by the generator after updates and by `Describe`/`ListMatchingTimes`.

## Replay safety

`canonicalizeSpec` returns a new spec into a local variable -- it does not mutate the persisted `s.Schedule.Spec` or write to workflow history. Duplicate calendar entries produce the same set of candidate times as a single entry (it's a union), so removing them does not change which next action time is selected. The dedup cannot be added to `processUpdate` (`workflow.go:958`) because that would mutate persisted workflow state and break replay of existing histories.

## Test plan
- [x] Unit tests for `deduplicateStructuredCalendars` (exact dupes, proto-default-equivalent, distinct, nil/empty)
- [x] Unit test for `canonicalizeSpec` dedup integration (both `StructuredCalendar` and `ExcludeStructuredCalendar`)
- [x] Functional test `TestUpdateDeduplicatesCalendars` -- reproduces SDK describe-then-update accumulation across 5 rounds (V1 + CHASM)
- [x] Functional test `TestCreateDeduplicatesCalendars` -- duplicate cron strings on create (V1 + CHASM)
