### PR TITLE
Implement namespace soft deletion

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1110,6 +1110,15 @@ Default is 4. Read once before delete of specified namespace is started.`,
 after all namespace resources (i.e. workflow executions) are deleted.
 Default is 0, means, namespace will be deleted immediately.`,
 	)
+	DeleteNamespaceSoftDeleteWindow = NewGlobalDurationSetting(
+		"frontend.deleteNamespaceSoftDeleteWindow",
+		0*time.Duration(0),
+		`DeleteNamespaceSoftDeleteWindow is the duration for which a deleted namespace can be restored
+before workflow executions are deleted. During this window, the namespace state is DELETED and
+new workflow executions cannot be started, but existing executions are preserved. A restore call
+cancels the deletion and returns the namespace to REGISTERED state.
+Default is 0, meaning no soft delete window: execution deletion begins immediately.`,
+	)
 	ProtectedNamespaces = NewGlobalTypedSetting(
 		"worker.protectedNamespaces",
 		([]string)(nil),

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1305,6 +1305,10 @@ var (
 		"reclaim_resources_namespace_delete_failure",
 		WithDescription("Incremented every time when ReclaimResources workflow completes without deleting a namespace"),
 	)
+	ReclaimResourcesNamespaceRestoreSuccessCount = NewCounterDef(
+		"reclaim_resources_namespace_restore_success",
+		WithDescription("Incremented every time when ReclaimResources workflow restores a namespace to REGISTERED during the soft-delete window"),
+	)
 	ReclaimResourcesDeleteExecutionsSuccessCount = NewCounterDef(
 		"reclaim_resources_delete_executions_success",
 		WithDescription("The number of workflow executions that was successfully deleted when ReclaimResources workflow completes"),

--- a/config/dynamicconfig/development-sql.yaml
+++ b/config/dynamicconfig/development-sql.yaml
@@ -73,3 +73,7 @@ history.enableChasm:
   - value: true
 activity.enableStandalone:
   - value: true
+
+frontend.deleteNamespaceSoftDeleteWindow:
+- value: "120s"
+  constraints: {}

--- a/go.mod
+++ b/go.mod
@@ -215,3 +215,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+replace go.temporal.io/api => /tmp/temporal-api-local

--- a/go.sum
+++ b/go.sum
@@ -442,8 +442,6 @@ go.opentelemetry.io/otel/trace v1.40.0 h1:WA4etStDttCSYuhwvEa8OP8I5EWu24lkOzp+ZY
 go.opentelemetry.io/otel/trace v1.40.0/go.mod h1:zeAhriXecNGP/s2SEG3+Y8X9ujcJOTqQ5RgdEJcawiA=
 go.opentelemetry.io/proto/otlp v1.7.1 h1:gTOMpGDb0WTBOP8JaO72iL3auEZhVmAQg4ipjOVAtj4=
 go.opentelemetry.io/proto/otlp v1.7.1/go.mod h1:b2rVh6rfI/s2pHWNlB7ILJcRALpcNDzKhACevjI+ZnE=
-go.temporal.io/api v1.62.8 h1:g8RAZmdebYODoNa2GLA4M4TsXNe1096WV3n26C4+fdw=
-go.temporal.io/api v1.62.8/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2 h1:1hKeH3GyR6YD6LKMHGCZ76t6h1Sgha0hXVQBxWi3dlQ=
 go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2/go.mod h1:T8dnzVPeO+gaUTj9eDgm/lT2lZH4+JXNvrGaQGyVi50=
 go.temporal.io/sdk v1.41.1 h1:yOpvsHyDD1lNuwlGBv/SUodCPhjv9nDeC9lLHW/fJUA=

--- a/proto/internal/temporal/server/api/adminservice/v1/service.proto
+++ b/proto/internal/temporal/server/api/adminservice/v1/service.proto
@@ -227,4 +227,5 @@ service AdminService {
   rpc MigrateSchedule(MigrateScheduleRequest) returns (MigrateScheduleResponse) {
     option (temporal.server.api.common.v1.api_category).category = API_CATEGORY_SYSTEM;
   }
+
 }

--- a/service/frontend/errors.go
+++ b/service/frontend/errors.go
@@ -58,6 +58,7 @@ var (
 	errIdentityNotSet                                     = serviceerror.NewInvalidArgument("Identity is not set on request.")
 	errMigrationTargetNotSet                              = serviceerror.NewInvalidArgument("Target is not set on request.")
 	errNamespaceNotSet                                    = serviceerror.NewInvalidArgument("Namespace is not set on request.")
+	errNamespaceIDNotSet                                  = serviceerror.NewInvalidArgument("NamespaceId is not set on request.")
 	errReasonNotSet                                       = serviceerror.NewInvalidArgument("Reason is not set on request.")
 	errBatchOperationNotSet                               = serviceerror.NewInvalidArgument("Batch operation is not set on request.")
 	errCronAndStartDelaySet                               = serviceerror.NewInvalidArgument("CronSchedule and WorkflowStartDelay may not be used together.")

--- a/service/frontend/namespace_handler.go
+++ b/service/frontend/namespace_handler.go
@@ -1147,7 +1147,12 @@ func validateStateUpdate(existingNamespace *persistence.GetNamespaceResponse, ns
 		}
 
 	case enumspb.NAMESPACE_STATE_DELETED:
-		return errInvalidNamespaceStateUpdate
+		switch newState {
+		case enumspb.NAMESPACE_STATE_REGISTERED:
+			return nil
+		default:
+			return errInvalidNamespaceStateUpdate
+		}
 	default:
 		return errInvalidNamespaceStateUpdate
 	}

--- a/service/frontend/operator_handler.go
+++ b/service/frontend/operator_handler.go
@@ -37,6 +37,7 @@ import (
 	"go.temporal.io/server/service/worker/deletenamespace"
 	"go.temporal.io/server/service/worker/deletenamespace/deleteexecutions"
 	delnserrors "go.temporal.io/server/service/worker/deletenamespace/errors"
+	"go.temporal.io/server/service/worker/deletenamespace/reclaimresources"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
@@ -561,6 +562,14 @@ func (h *OperatorHandlerImpl) DeleteNamespace(
 		namespaceDeleteDelay = request.NamespaceDeleteDelay.AsDuration()
 	}
 
+	// If SoftDeleteWindow is not provided, the default window configured in the cluster should be used.
+	var softDeleteWindow time.Duration
+	if request.SoftDeleteWindow == nil {
+		softDeleteWindow = h.config.DeleteNamespaceSoftDeleteWindow()
+	} else {
+		softDeleteWindow = request.SoftDeleteWindow.AsDuration()
+	}
+
 	// Execute workflow.
 	wfParams := deletenamespace.DeleteNamespaceWorkflowParams{
 		Namespace:   namespace.Name(request.GetNamespace()),
@@ -572,6 +581,7 @@ func (h *OperatorHandlerImpl) DeleteNamespace(
 			ConcurrentDeleteExecutionsActivities: h.config.DeleteNamespaceConcurrentDeleteExecutionsActivities(),
 		},
 		NamespaceDeleteDelay: namespaceDeleteDelay,
+		SoftDeleteWindow:     softDeleteWindow,
 	}
 
 	sdkClient := h.sdkClientFactory.GetSystemClient()
@@ -806,4 +816,44 @@ func (h *OperatorHandlerImpl) ListNexusEndpoints(
 ) (_ *operatorservice.ListNexusEndpointsResponse, retErr error) {
 	defer log.CapturePanic(h.logger, &retErr)
 	return h.nexusEndpointClient.List(ctx, request)
+}
+
+func (h *OperatorHandlerImpl) RestoreSoftDeletedNamespace(
+	ctx context.Context,
+	request *operatorservice.RestoreSoftDeletedNamespaceRequest,
+) (_ *operatorservice.RestoreSoftDeletedNamespaceResponse, retErr error) {
+	defer log.CapturePanic(h.logger, &retErr)
+
+	if request == nil {
+		return nil, errRequestNotSet
+	}
+	if request.GetNamespaceId() == "" {
+		return nil, errNamespaceIDNotSet
+	}
+
+	// Look up the current (deleted) namespace name by ID via the registry.
+	ns, err := h.namespaceRegistry.GetNamespaceByID(namespace.ID(request.GetNamespaceId()))
+	if err != nil {
+		return nil, err
+	}
+	deletedName := ns.Name()
+
+	// The ReclaimResourcesWorkflow ID is deterministic: WorkflowName/deletedName.
+	workflowID := fmt.Sprintf("%s/%s", reclaimresources.WorkflowName, deletedName)
+
+	sdkClient := h.sdkClientFactory.GetSystemClient()
+	handle, err := sdkClient.UpdateWorkflow(ctx, sdkclient.UpdateWorkflowOptions{
+		WorkflowID:   workflowID,
+		UpdateName:   reclaimresources.RestoreNamespaceUpdateName,
+		Args:         []interface{}{struct{}{}},
+		WaitForStage: sdkclient.WorkflowUpdateStageCompleted,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var updateResult struct{}
+	if err = handle.Get(ctx, &updateResult); err != nil {
+		return nil, err
+	}
+	return &operatorservice.RestoreSoftDeletedNamespaceResponse{}, nil
 }

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -161,6 +161,10 @@ type Config struct {
 	// after all namespace resources (i.e. workflow executions) are deleted.
 	// Default is 0, means, namespace will be deleted immediately.
 	DeleteNamespaceNamespaceDeleteDelay dynamicconfig.DurationPropertyFn
+	// Duration of the soft delete window before execution deletion begins,
+	// during which a restore call can revert the deletion.
+	// Default is 0, meaning no soft delete window.
+	DeleteNamespaceSoftDeleteWindow dynamicconfig.DurationPropertyFn
 
 	// Enable schedule-related RPCs
 	EnableSchedules dynamicconfig.BoolPropertyFnWithNamespaceFilter
@@ -343,6 +347,7 @@ func NewConfig(
 		DeleteNamespacePagesPerExecution:                    dynamicconfig.DeleteNamespacePagesPerExecution.Get(dc),
 		DeleteNamespaceConcurrentDeleteExecutionsActivities: dynamicconfig.DeleteNamespaceConcurrentDeleteExecutionsActivities.Get(dc),
 		DeleteNamespaceNamespaceDeleteDelay:                 dynamicconfig.DeleteNamespaceNamespaceDeleteDelay.Get(dc),
+		DeleteNamespaceSoftDeleteWindow:                     dynamicconfig.DeleteNamespaceSoftDeleteWindow.Get(dc),
 
 		MaxFairnessWeightOverrideConfigLimit: dynamicconfig.MatchingMaxFairnessKeyWeightOverrides.Get(dc),
 

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -344,6 +344,12 @@ func (e *executableImpl) Execute() (retErr error) {
 		e.terminalFailureCause = nil
 	}
 
+	// The namespace may have been deleted after this task was admitted to the
+	// scheduler. Close that race before invoking the task executor.
+	if isNamespaceDeleted(e.namespaceRegistry, e.GetNamespaceID()) {
+		return consts.ErrTaskDiscarded
+	}
+
 	resp := e.executor.Execute(ctx, e)
 	e.refreshMetricsHandlers(resp.ExecutionMetricTags)
 

--- a/service/history/queues/executable_test.go
+++ b/service/history/queues/executable_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
@@ -47,6 +48,7 @@ type (
 		mockClusterMetadata   *cluster.MockMetadata
 		chasmRegistry         *chasm.Registry
 		metricsHandler        *metricstest.CaptureHandler
+		namespaceEntry        *namespace.Namespace
 
 		timeSource *clock.EventTimeSource
 	}
@@ -78,7 +80,12 @@ func (s *executableSuite) SetupTest() {
 	s.metricsHandler = metricstest.NewCaptureHandler()
 
 	s.mockNamespaceRegistry.EXPECT().GetNamespaceName(gomock.Any()).Return(tests.Namespace, nil).AnyTimes()
-	s.mockNamespaceRegistry.EXPECT().GetNamespaceByID(gomock.Any()).Return(tests.GlobalNamespaceEntry, nil).AnyTimes()
+	s.namespaceEntry = tests.GlobalNamespaceEntry
+	s.mockNamespaceRegistry.EXPECT().GetNamespaceByID(gomock.Any()).DoAndReturn(
+		func(namespace.ID) (*namespace.Namespace, error) {
+			return s.namespaceEntry, nil
+		},
+	).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(map[string]cluster.ClusterInformation{
 		cluster.TestCurrentClusterName: {
@@ -110,6 +117,19 @@ func (s *executableSuite) TestExecute_TaskExecuted() {
 		ExecutionErr:        nil,
 	})
 	s.NoError(executable.Execute())
+}
+
+func (s *executableSuite) TestExecute_DeletedNamespaceTaskDiscarded() {
+	executable := s.newTestExecutable()
+	s.namespaceEntry = namespace.NewLocalNamespaceForTest(
+		&persistencespb.NamespaceInfo{State: enumspb.NAMESPACE_STATE_DELETED},
+		nil,
+		cluster.TestCurrentClusterName,
+	)
+
+	err := executable.Execute()
+	s.ErrorIs(err, consts.ErrTaskDiscarded)
+	s.NoError(executable.HandleErr(err))
 }
 
 func (s *executableSuite) TestExecute_InMemoryNoUserLatency_SingleAttempt() {

--- a/service/history/queues/scheduler.go
+++ b/service/history/queues/scheduler.go
@@ -3,6 +3,7 @@
 package queues
 
 import (
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/definition"
@@ -89,6 +90,14 @@ type (
 		tasks.Scheduler[Executable]
 
 		baseScheduler Scheduler
+	}
+
+	namespaceStateFilterScheduler struct {
+		Scheduler
+
+		namespaceRegistry namespace.Registry
+		metricsHandler    metrics.Handler
+		metricTagsFn      func(Executable) []metrics.Tag
 	}
 )
 
@@ -285,10 +294,55 @@ func NewRateLimitedScheduler(
 		metricsHandler,
 	)
 
-	return &rateLimitedSchedulerImpl{
+	wrappedRateLimitedScheduler := &rateLimitedSchedulerImpl{
 		Scheduler:     rateLimitedScheduler,
 		baseScheduler: baseScheduler,
 	}
+
+	return &namespaceStateFilterScheduler{
+		Scheduler:         wrappedRateLimitedScheduler,
+		namespaceRegistry: namespaceRegistry,
+		metricsHandler:    metricsHandler,
+		metricTagsFn:      taskMetricsTagsFn,
+	}
+}
+
+func (s *namespaceStateFilterScheduler) Submit(executable Executable) {
+	if s.discardTask(executable) {
+		return
+	}
+	s.Scheduler.Submit(executable)
+}
+
+func (s *namespaceStateFilterScheduler) TrySubmit(executable Executable) bool {
+	if s.discardTask(executable) {
+		return true
+	}
+	return s.Scheduler.TrySubmit(executable)
+}
+
+func (s *namespaceStateFilterScheduler) discardTask(executable Executable) bool {
+	if !isNamespaceDeleted(s.namespaceRegistry, executable.GetNamespaceID()) {
+		return false
+	}
+
+	metrics.TaskDiscarded.With(s.metricsHandler).Record(1, s.metricTagsFn(executable)...)
+	executable.Ack()
+	return true
+}
+
+func isNamespaceDeleted(namespaceRegistry namespace.Registry, namespaceID string) bool {
+	ns, err := namespaceRegistry.GetNamespaceByID(namespace.ID(namespaceID))
+	return err == nil && ns.State() == enumspb.NAMESPACE_STATE_DELETED
+}
+
+// HandleBusyWorkflow implements BusyWorkflowHandler by delegating to the
+// wrapped scheduler.
+func (s *namespaceStateFilterScheduler) HandleBusyWorkflow(executable Executable) bool {
+	if handler, ok := s.Scheduler.(BusyWorkflowHandler); ok {
+		return handler.HandleBusyWorkflow(executable)
+	}
+	return false
 }
 
 func (s *rateLimitedSchedulerImpl) Start() {

--- a/service/history/queues/scheduler_test.go
+++ b/service/history/queues/scheduler_test.go
@@ -1,0 +1,94 @@
+package queues
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	"go.uber.org/mock/gomock"
+)
+
+func TestNamespaceStateFilterScheduler_Submit(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		namespace     *namespace.Namespace
+		namespaceErr  error
+		expectDiscard bool
+	}{
+		{
+			name: "deleted namespace",
+			namespace: namespace.NewLocalNamespaceForTest(
+				&persistencespb.NamespaceInfo{State: enumspb.NAMESPACE_STATE_DELETED},
+				nil,
+				"",
+			),
+			expectDiscard: true,
+		},
+		{
+			name: "registered namespace",
+			namespace: namespace.NewLocalNamespaceForTest(
+				&persistencespb.NamespaceInfo{State: enumspb.NAMESPACE_STATE_REGISTERED},
+				nil,
+				"",
+			),
+		},
+		{
+			name:         "namespace lookup error",
+			namespaceErr: serviceerror.NewNamespaceNotFound("namespace"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			baseScheduler := NewMockScheduler(controller)
+			namespaceRegistry := namespace.NewMockRegistry(controller)
+			executable := NewMockExecutable(controller)
+
+			executable.EXPECT().GetNamespaceID().Return("namespace-id")
+			namespaceRegistry.EXPECT().GetNamespaceByID(namespace.ID("namespace-id")).
+				Return(tc.namespace, tc.namespaceErr)
+			if tc.expectDiscard {
+				executable.EXPECT().Ack()
+			} else {
+				baseScheduler.EXPECT().Submit(executable)
+			}
+
+			scheduler := &namespaceStateFilterScheduler{
+				Scheduler:         baseScheduler,
+				namespaceRegistry: namespaceRegistry,
+				metricsHandler:    metrics.NoopMetricsHandler,
+				metricTagsFn:      func(Executable) []metrics.Tag { return nil },
+			}
+			scheduler.Submit(executable)
+		})
+	}
+}
+
+func TestNamespaceStateFilterScheduler_TrySubmitDeletedNamespace(t *testing.T) {
+	controller := gomock.NewController(t)
+	baseScheduler := NewMockScheduler(controller)
+	namespaceRegistry := namespace.NewMockRegistry(controller)
+	executable := NewMockExecutable(controller)
+
+	executable.EXPECT().GetNamespaceID().Return("namespace-id")
+	namespaceRegistry.EXPECT().GetNamespaceByID(namespace.ID("namespace-id")).Return(
+		namespace.NewLocalNamespaceForTest(
+			&persistencespb.NamespaceInfo{State: enumspb.NAMESPACE_STATE_DELETED},
+			nil,
+			"",
+		),
+		nil,
+	)
+	executable.EXPECT().Ack()
+
+	scheduler := &namespaceStateFilterScheduler{
+		Scheduler:         baseScheduler,
+		namespaceRegistry: namespaceRegistry,
+		metricsHandler:    metrics.NoopMetricsHandler,
+		metricTagsFn:      func(Executable) []metrics.Tag { return nil },
+	}
+	require.True(t, scheduler.TrySubmit(executable))
+}

--- a/service/worker/deletenamespace/reclaimresources/activities.go
+++ b/service/worker/deletenamespace/reclaimresources/activities.go
@@ -2,8 +2,11 @@ package reclaimresources
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"time"
 
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
@@ -55,6 +58,19 @@ func NewLocalActivities(
 
 		namespaceCacheRefreshInterval: namespaceCacheRefreshInterval,
 	}
+}
+
+// OriginalNameFromDeletedName derives the original namespace name from the deleted form
+// produced by GenerateDeletedNamespaceNameActivity (e.g. "myns-deleted-ABCDE" to "myns").
+// Returns the input unchanged if it does not match the deleted name pattern.
+func OriginalNameFromDeletedName(deletedName namespace.Name, nsID namespace.ID) namespace.Name {
+	for suffixLength := 5; suffixLength <= len(nsID.String()); suffixLength++ {
+		suffix := fmt.Sprintf("-deleted-%s", nsID.String()[:suffixLength])
+		if strings.HasSuffix(deletedName.String(), suffix) {
+			return namespace.Name(strings.TrimSuffix(deletedName.String(), suffix))
+		}
+	}
+	return deletedName
 }
 
 func (a *LocalActivities) IsAdvancedVisibilityActivity(_ context.Context, _ namespace.Name) (bool, error) {
@@ -160,4 +176,79 @@ func (a *LocalActivities) DeleteNamespaceActivity(ctx context.Context, nsID name
 
 func (a *LocalActivities) GetNamespaceCacheRefreshInterval(_ context.Context) (time.Duration, error) {
 	return a.namespaceCacheRefreshInterval(), nil
+}
+
+// RenameNamespaceBackActivity renames the namespace from its deleted form back to originalName
+// while the namespace is still in DELETED state, preserving the state gate against new traffic.
+// Idempotent: does nothing if the namespace is already named originalName or if deletedName == originalName.
+func (a *LocalActivities) RenameNamespaceBackActivity(ctx context.Context, nsID namespace.ID, deletedName namespace.Name, originalName namespace.Name) error {
+	if deletedName == originalName {
+		return nil
+	}
+	ctx = headers.SetCallerName(ctx, deletedName.String())
+
+	logger := log.With(a.logger,
+		tag.WorkflowNamespace(deletedName.String()),
+		tag.WorkflowNamespaceID(nsID.String()))
+
+	ns, err := a.metadataManager.GetNamespace(ctx, &persistence.GetNamespaceRequest{ID: nsID.String()})
+	if err != nil {
+		logger.Error("Unable to get namespace details.", tag.Error(err))
+		return err
+	}
+	if namespace.Name(ns.Namespace.Info.Name) == originalName {
+		logger.Info("Namespace already renamed back to original, skipping.")
+		return nil
+	}
+
+	if err = a.metadataManager.RenameNamespace(ctx, &persistence.RenameNamespaceRequest{
+		PreviousName: deletedName.String(),
+		NewName:      originalName.String(),
+	}); err != nil {
+		logger.Error("Unable to rename namespace back to original.", tag.Error(err))
+		return err
+	}
+	logger.Info("Namespace renamed back to original.", tag.WorkflowNamespace(originalName.String()))
+	return nil
+}
+
+// RestoreNamespaceStateActivity sets the namespace state from DELETED back to REGISTERED.
+// It must be called only after RenameNamespaceBackActivity succeeds so that the original
+// name is already in place when traffic is readmitted.
+// Idempotent: does nothing if the namespace is already REGISTERED.
+func (a *LocalActivities) RestoreNamespaceStateActivity(ctx context.Context, nsID namespace.ID, nsName namespace.Name) error {
+	ctx = headers.SetCallerName(ctx, nsName.String())
+
+	logger := log.With(a.logger,
+		tag.WorkflowNamespace(nsName.String()),
+		tag.WorkflowNamespaceID(nsID.String()))
+
+	metadata, err := a.metadataManager.GetMetadata(ctx)
+	if err != nil {
+		logger.Error("Unable to get cluster metadata.", tag.Error(err))
+		return err
+	}
+
+	ns, err := a.metadataManager.GetNamespace(ctx, &persistence.GetNamespaceRequest{ID: nsID.String()})
+	if err != nil {
+		logger.Error("Unable to get namespace details.", tag.Error(err))
+		return err
+	}
+	if ns.Namespace.Info.State != enumspb.NAMESPACE_STATE_DELETED {
+		logger.Info("Namespace is not in deleted state, skipping restore.",
+			tag.NewStringTag("state", ns.Namespace.Info.State.String()))
+		return nil
+	}
+
+	ns.Namespace.Info.State = enumspb.NAMESPACE_STATE_REGISTERED
+	if err = a.metadataManager.UpdateNamespace(ctx, &persistence.UpdateNamespaceRequest{
+		Namespace:           ns.Namespace,
+		IsGlobalNamespace:   ns.IsGlobalNamespace,
+		NotificationVersion: metadata.NotificationVersion,
+	}); err != nil {
+		logger.Error("Unable to update namespace state to Registered.", tag.Error(err))
+		return err
+	}
+	logger.Info("Namespace state restored to Registered.")
+	return nil
 }

--- a/service/worker/deletenamespace/reclaimresources/workflow.go
+++ b/service/worker/deletenamespace/reclaimresources/workflow.go
@@ -16,7 +16,8 @@ import (
 )
 
 const (
-	WorkflowName = "temporal-sys-reclaim-namespace-resources-workflow"
+	WorkflowName               = "temporal-sys-reclaim-namespace-resources-workflow"
+	RestoreNamespaceUpdateName = "restore_namespace"
 )
 
 type (
@@ -27,12 +28,19 @@ type (
 		// will sleep between workflow execution and namespace deletion.
 		// Default is 0, means, workflow won't sleep.
 		NamespaceDeleteDelay time.Duration
+
+		// SoftDeleteWindow is how long to wait before beginning execution deletion,
+		// during which a restore Update can cancel the deletion.
+		// Default is 0, meaning execution deletion starts immediately after cache refresh.
+		SoftDeleteWindow time.Duration
 	}
 
 	ReclaimResourcesResult struct {
 		DeleteSuccessCount int
 		DeleteErrorCount   int
 		NamespaceDeleted   bool
+		// NamespaceRestored is true when the namespace was restored during the soft delete window.
+		NamespaceRestored bool
 	}
 )
 
@@ -93,6 +101,8 @@ func ReclaimResourcesWorkflow(ctx workflow.Context, params ReclaimResourcesParam
 	defer func() {
 		if result.NamespaceDeleted {
 			mh.Counter(metrics.ReclaimResourcesNamespaceDeleteSuccessCount.Name()).Inc(1)
+		} else if result.NamespaceRestored {
+			mh.Counter(metrics.ReclaimResourcesNamespaceRestoreSuccessCount.Name()).Inc(1)
 		} else {
 			mh.Counter(metrics.ReclaimResourcesNamespaceDeleteFailureCount.Name()).Inc(1)
 		}
@@ -107,9 +117,13 @@ func ReclaimResourcesWorkflow(ctx workflow.Context, params ReclaimResourcesParam
 	ctx = workflow.WithTaskQueue(ctx, primitives.DeleteNamespaceActivityTQ)
 
 	var (
-		namespaceDeleteDelay = params.NamespaceDeleteDelay
-		cancelDeleteDelay    workflow.CancelFunc
+		namespaceDeleteDelay   = params.NamespaceDeleteDelay
+		cancelDeleteDelay      workflow.CancelFunc
+		restoreRequested       bool
+		cancelSoftDeleteWindow workflow.CancelFunc
 	)
+
+	// update_namespace_delete_delay: adjust or clear the post-deletion grace period.
 	err := workflow.SetUpdateHandlerWithOptions(ctx, "update_namespace_delete_delay", func(ctx workflow.Context, newNamespaceDeleteDelayStr string) (string, error) {
 		// This must succeed because Update validator already validated the input.
 		namespaceDeleteDelay, _ = time.ParseDuration(newNamespaceDeleteDelayStr)
@@ -151,6 +165,32 @@ func ReclaimResourcesWorkflow(ctx workflow.Context, params ReclaimResourcesParam
 		return result, err
 	}
 
+	// restore_namespace: cancel the soft delete window and restore the namespace to REGISTERED.
+	// The validator rejects calls that arrive after the window has closed.
+	err = workflow.SetUpdateHandlerWithOptions(ctx, RestoreNamespaceUpdateName,
+		func(_ workflow.Context, _ struct{}) (struct{}, error) {
+			restoreRequested = true
+			if cancelSoftDeleteWindow != nil {
+				cancelSoftDeleteWindow()
+			}
+			return struct{}{}, nil
+		},
+		workflow.UpdateHandlerOptions{
+			Validator: func(_ workflow.Context, _ struct{}) error {
+				// cancelSoftDeleteWindow is set only during the soft delete window sleep.
+				// After the window closes (or if there is no window) it is nil.
+				if cancelSoftDeleteWindow == nil {
+					return errors.NewFailedPrecondition(
+						"namespace soft delete window has passed; namespace cannot be restored", nil)
+				}
+				return nil
+			},
+		},
+	)
+	if err != nil {
+		return result, err
+	}
+
 	var la *LocalActivities
 
 	// TODO: remove version check and 9s const after v1.27 release.
@@ -171,13 +211,48 @@ func ReclaimResourcesWorkflow(ctx workflow.Context, params ReclaimResourcesParam
 		return result, err
 	}
 
-	// Step 1. Delete workflow executions.
+	// Step 1 (optional). Soft delete window: sleep before starting execution deletion.
+	// During this window a restore_namespace Update can cancel the deletion.
+	if params.SoftDeleteWindow > 0 {
+		var softDeleteWindowCtx workflow.Context
+		softDeleteWindowCtx, cancelSoftDeleteWindow = workflow.WithCancel(ctx)
+		logger.Info("Entering soft delete window. Send 'restore_namespace' update to cancel deletion.",
+			"duration", params.SoftDeleteWindow.String())
+		_ = workflow.Sleep(softDeleteWindowCtx, params.SoftDeleteWindow)
+		cancelSoftDeleteWindow = nil // window is now closed; future restore attempts will be rejected
+
+		if restoreRequested {
+			logger.Info("Restore requested during soft delete window. Restoring namespace.")
+			originalName := OriginalNameFromDeletedName(params.Namespace, params.NamespaceID)
+			ctx1r := workflow.WithLocalActivityOptions(ctx, localActivityOptions)
+
+			// Step 1: rename back while still DELETED. The state gate is preserved until rename succeeds.
+			err = workflow.ExecuteLocalActivity(ctx1r, la.RenameNamespaceBackActivity,
+				params.NamespaceID, params.Namespace, originalName).Get(ctx, nil)
+			if err != nil {
+				return result, err
+			}
+
+			// Step 2: open traffic. Only reached if rename succeeded.
+			err = workflow.ExecuteLocalActivity(ctx1r, la.RestoreNamespaceStateActivity,
+				params.NamespaceID, originalName).Get(ctx, nil)
+			if err != nil {
+				return result, err
+			}
+
+			result.NamespaceRestored = true
+			logger.Info("Namespace restored successfully.", tag.WorkflowNamespace(originalName.String()))
+			return result, nil
+		}
+	}
+
+	// Step 2. Delete workflow executions.
 	result, err = deleteWorkflowExecutions(ctx, logger, params)
 	if err != nil {
 		return result, err
 	}
 
-	// Step 2. Sleep before deleting namespace from a database.
+	// Step 3. Sleep before deleting namespace from a database.
 	for namespaceDeleteDelay > 0 {
 		var cancelableCtx workflow.Context
 		cancelableCtx, cancelDeleteDelay = workflow.WithCancel(ctx)
@@ -189,7 +264,7 @@ func ReclaimResourcesWorkflow(ctx workflow.Context, params ReclaimResourcesParam
 		_ = workflow.Sleep(cancelableCtx, ndd)
 	}
 
-	// Step 3. Delete namespace from database.
+	// Step 4. Delete namespace from database.
 	ctx5 := workflow.WithLocalActivityOptions(ctx, localActivityOptions)
 	err = workflow.ExecuteLocalActivity(ctx5, la.DeleteNamespaceActivity, params.NamespaceID, params.Namespace).Get(ctx, nil)
 	if err != nil {

--- a/service/worker/deletenamespace/reclaimresources/workflow_test.go
+++ b/service/worker/deletenamespace/reclaimresources/workflow_test.go
@@ -21,6 +21,101 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func Test_ReclaimResourcesWorkflow_SoftDelete_Restore(t *testing.T) {
+	testSuite := &testsuite.WorkflowTestSuite{}
+	testSuite.SetLogger(log.NewSdkLogger(log.NewTestLogger()))
+	env := testSuite.NewTestWorkflowEnvironment()
+
+	var la *LocalActivities
+
+	env.OnActivity(la.GetNamespaceCacheRefreshInterval, mock.Anything).Return(10*time.Second, nil).Once()
+
+	// The restore_namespace Update fires during the soft delete window timer.
+	timerFired := false
+	env.SetOnTimerScheduledListener(func(_ string, _ time.Duration) {
+		if !timerFired {
+			timerFired = true
+			return // let the cache refresh timer expire normally
+		}
+		// Second timer is the soft delete window. Send restore Update.
+		uc := &testsuite.TestUpdateCallback{
+			OnReject: func(err error) {
+				require.Failf(t, "restore update should not be rejected", "%v", err)
+			},
+			OnAccept:   func() {},
+			OnComplete: func(_ any, err error) { require.NoError(t, err) },
+		}
+		env.UpdateWorkflow(RestoreNamespaceUpdateName, "", uc, struct{}{})
+	})
+
+	// nsID[:5] = "names", so deleted name = "ns-deleted-names", original = "ns"
+	// Restore runs as two sequential activities: rename first, then state update.
+	env.OnActivity(la.RenameNamespaceBackActivity,
+		mock.Anything,
+		namespace.ID("namespace-id"),
+		namespace.Name("ns-deleted-names"),
+		namespace.Name("ns"),
+	).Return(nil).Once()
+	env.OnActivity(la.RestoreNamespaceStateActivity,
+		mock.Anything,
+		namespace.ID("namespace-id"),
+		namespace.Name("ns"),
+	).Return(nil).Once()
+
+	env.ExecuteWorkflow(ReclaimResourcesWorkflow, ReclaimResourcesParams{
+		DeleteExecutionsParams: deleteexecutions.DeleteExecutionsParams{
+			Namespace:   "ns-deleted-names",
+			NamespaceID: "namespace-id",
+			Config:      deleteexecutions.DeleteExecutionsConfig{},
+		},
+		SoftDeleteWindow: 5 * time.Minute,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	var result ReclaimResourcesResult
+	require.NoError(t, env.GetWorkflowResult(&result))
+	require.True(t, result.NamespaceRestored)
+	require.False(t, result.NamespaceDeleted)
+}
+
+func Test_ReclaimResourcesWorkflow_SoftDelete_WindowExpires(t *testing.T) {
+	testSuite := &testsuite.WorkflowTestSuite{}
+	testSuite.SetLogger(log.NewSdkLogger(log.NewTestLogger()))
+	env := testSuite.NewTestWorkflowEnvironment()
+
+	var a *Activities
+	var la *LocalActivities
+
+	env.RegisterWorkflow(deleteexecutions.DeleteExecutionsWorkflow)
+	env.OnWorkflow(deleteexecutions.DeleteExecutionsWorkflow, mock.Anything, mock.Anything).Return(deleteexecutions.DeleteExecutionsResult{
+		SuccessCount: 0, ErrorCount: 0,
+	}, nil).Once()
+
+	env.OnActivity(la.GetNamespaceCacheRefreshInterval, mock.Anything).Return(10*time.Second, nil).Once()
+	env.OnActivity(la.CountExecutionsAdvVisibilityActivity, mock.Anything, namespace.ID("namespace-id"), namespace.Name("ns-deleted-names")).Return(int64(0), nil).Once()
+	env.OnActivity(la.DeleteNamespaceActivity, mock.Anything, namespace.ID("namespace-id"), namespace.Name("ns-deleted-names")).Return(nil).Once()
+
+	// No restore Update sent. Window should expire and deletion should proceed.
+	_ = a
+
+	env.ExecuteWorkflow(ReclaimResourcesWorkflow, ReclaimResourcesParams{
+		DeleteExecutionsParams: deleteexecutions.DeleteExecutionsParams{
+			Namespace:   "ns-deleted-names",
+			NamespaceID: "namespace-id",
+			Config:      deleteexecutions.DeleteExecutionsConfig{},
+		},
+		SoftDeleteWindow: 5 * time.Minute,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	var result ReclaimResourcesResult
+	require.NoError(t, env.GetWorkflowResult(&result))
+	require.False(t, result.NamespaceRestored)
+	require.True(t, result.NamespaceDeleted)
+}
+
 func Test_ReclaimResourcesWorkflow_Success(t *testing.T) {
 	testSuite := &testsuite.WorkflowTestSuite{}
 	testSuite.SetLogger(log.NewSdkLogger(log.NewTestLogger()))

--- a/service/worker/deletenamespace/workflow.go
+++ b/service/worker/deletenamespace/workflow.go
@@ -32,6 +32,11 @@ type (
 		// Default is 0, means, namespace will be deleted immediately.
 		NamespaceDeleteDelay time.Duration
 
+		// SoftDeleteWindow is how long to wait before beginning execution deletion,
+		// during which the namespace can be restored via RestoreSoftDeletedNamespace.
+		// Default is 0, meaning execution deletion starts immediately after cache refresh.
+		SoftDeleteWindow time.Duration
+
 		DeleteExecutionsConfig deleteexecutions.DeleteExecutionsConfig
 	}
 
@@ -181,6 +186,7 @@ func DeleteNamespaceWorkflow(ctx workflow.Context, params DeleteNamespaceWorkflo
 			Config:      params.DeleteExecutionsConfig,
 		},
 		NamespaceDeleteDelay: params.NamespaceDeleteDelay,
+		SoftDeleteWindow:     params.SoftDeleteWindow,
 	})
 	var reclaimResourcesExecution workflow.Execution
 	if err = reclaimResourcesFuture.GetChildWorkflowExecution().Get(ctx, &reclaimResourcesExecution); err != nil {

--- a/tests/namespace_delete_test.go
+++ b/tests/namespace_delete_test.go
@@ -418,3 +418,92 @@ func (s *namespaceTestSuite) Test_NamespaceDelete_Protected() {
 	s.ErrorAs(err, &failedPreconditionErr)
 	s.Equal(fmt.Sprintf("namespace %s is protected from deletion", tv.NamespaceName().String()), failedPreconditionErr.Message)
 }
+
+// Test_NamespaceSoftDelete_RestoreWithinWindow verifies that RestoreSoftDeletedNamespace
+// cancels the deletion and returns the namespace to REGISTERED with its original name.
+func (s *namespaceTestSuite) Test_NamespaceSoftDelete_RestoreWithinWindow() {
+	ctx, cancel := rpc.NewContextWithTimeoutAndVersionHeaders(60 * time.Second)
+	defer cancel()
+
+	nsName := "ns_softdelete_restore_" + uuid.NewString()[:8]
+	_, err := s.FrontendClient().RegisterNamespace(ctx, &workflowservice.RegisterNamespaceRequest{
+		Namespace:                        nsName,
+		WorkflowExecutionRetentionPeriod: durationpb.New(24 * time.Hour),
+		HistoryArchivalState:             enumspb.ARCHIVAL_STATE_DISABLED,
+		VisibilityArchivalState:          enumspb.ARCHIVAL_STATE_DISABLED,
+	})
+	s.NoError(err)
+
+	descResp, err := s.FrontendClient().DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{
+		Namespace: nsName,
+	})
+	s.NoError(err)
+	nsID := descResp.GetNamespaceInfo().GetId()
+
+	// Kick off deletion with a long soft delete window so the restore call arrives before it expires.
+	delResp, err := s.OperatorClient().DeleteNamespace(ctx, &operatorservice.DeleteNamespaceRequest{
+		Namespace:            nsName,
+		NamespaceDeleteDelay: durationpb.New(0),
+		SoftDeleteWindow:     durationpb.New(30 * time.Second),
+	})
+	s.NoError(err)
+	s.Contains(delResp.GetDeletedNamespace(), "-deleted-")
+
+	// Namespace should be DELETED now.
+	descResp2, err := s.FrontendClient().DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{Id: nsID})
+	s.NoError(err)
+	s.Equal(enumspb.NAMESPACE_STATE_DELETED, descResp2.GetNamespaceInfo().GetState())
+
+	// Restore within the window.
+	_, err = s.OperatorClient().RestoreSoftDeletedNamespace(ctx, &operatorservice.RestoreSoftDeletedNamespaceRequest{
+		NamespaceId: nsID,
+	})
+	s.NoError(err)
+
+	// After restore the namespace should be REGISTERED with its original name.
+	s.Eventually(func() bool {
+		d, e := s.FrontendClient().DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{Namespace: nsName})
+		if e != nil {
+			return false
+		}
+		return d.GetNamespaceInfo().GetState() == enumspb.NAMESPACE_STATE_REGISTERED
+	}, 20*time.Second, time.Second, "namespace should be REGISTERED after restore")
+}
+
+// Test_NamespaceSoftDelete_RestoreAfterWindowFails verifies that a restore attempt
+// after the soft delete window has closed returns a FailedPrecondition error.
+func (s *namespaceTestSuite) Test_NamespaceSoftDelete_RestoreAfterWindowFails() {
+	ctx, cancel := rpc.NewContextWithTimeoutAndVersionHeaders(60 * time.Second)
+	defer cancel()
+
+	nsName := "ns_softdelete_expired_" + uuid.NewString()[:8]
+	_, err := s.FrontendClient().RegisterNamespace(ctx, &workflowservice.RegisterNamespaceRequest{
+		Namespace:                        nsName,
+		WorkflowExecutionRetentionPeriod: durationpb.New(24 * time.Hour),
+		HistoryArchivalState:             enumspb.ARCHIVAL_STATE_DISABLED,
+		VisibilityArchivalState:          enumspb.ARCHIVAL_STATE_DISABLED,
+	})
+	s.NoError(err)
+
+	descResp, err := s.FrontendClient().DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{
+		Namespace: nsName,
+	})
+	s.NoError(err)
+	nsID := descResp.GetNamespaceInfo().GetId()
+
+	// Use a very short window so it expires before we call restore.
+	_, err = s.OperatorClient().DeleteNamespace(ctx, &operatorservice.DeleteNamespaceRequest{
+		Namespace:            nsName,
+		NamespaceDeleteDelay: durationpb.New(0),
+		SoftDeleteWindow:     durationpb.New(1 * time.Second),
+	})
+	s.NoError(err)
+
+	// Poll until the soft delete window has expired and the workflow has closed it.
+	s.Require().Eventually(func() bool {
+		_, restoreErr := s.OperatorClient().RestoreSoftDeletedNamespace(ctx, &operatorservice.RestoreSoftDeletedNamespaceRequest{
+			NamespaceId: nsID,
+		})
+		return restoreErr != nil
+	}, 30*time.Second, 500*time.Millisecond, "restore should fail once soft delete window expires")
+}


### PR DESCRIPTION
## What changed?
Implement namespace soft deletion. During system workflow to delete namespace, add a workflow sleep and Update handler to accept restoration of the namespace. If restore signal received, rename namespace back to original namespace if possible, and if successful, change namespace state to REGISTERED.

## Why?
Support namespace soft deletion operation.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [X] added new functional test(s)
