### PR TITLE
Stop passing `nil` registry to ArchetypeID in delete replication task

### DIFF
--- a/service/history/replication/executable_delete_execution_task.go
+++ b/service/history/replication/executable_delete_execution_task.go
@@ -107,7 +107,10 @@ func (e *ExecutableDeleteExecutionTask) Execute() error {
 	ctx, cancel := newTaskContext(namespaceName, e.Config.ReplicationTaskApplyTimeout(), callerInfo)
 	defer cancel()
 
-	archetypeID, _ := e.ArchetypeID(nil)
+	archetypeID, err := e.ArchetypeID(e.ChasmRegistry)
+	if err != nil {
+		return err
+	}
 	switch archetypeID {
 	case chasm.WorkflowArchetypeID:
 		return e.deleteWorkflowExecution(ctx)

--- a/service/history/replication/executable_task_tool_box.go
+++ b/service/history/replication/executable_task_tool_box.go
@@ -25,6 +25,7 @@ type (
 		ClientBean                client.Bean
 		ShardController           shard.Controller
 		ChasmEngine               chasm.Engine
+		ChasmRegistry             *chasm.Registry
 		NamespaceCache            namespace.Registry
 		EagerNamespaceRefresher   EagerNamespaceRefresher
 		ResendHandler             eventhandler.ResendHandler


### PR DESCRIPTION
## What changed?

Wire in archetype registry and used for resolving ArchetypeID.

## Why?
Stop passing nil registry to ArchetypeID in delete replication task, as this is fragile when relying on early return to avoid nil reference. 

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

