### PR TITLE
Bump ServerVersion to 1.31.0

### DIFF
--- a/common/headers/version_checker.go
+++ b/common/headers/version_checker.go
@@ -23,7 +23,7 @@ const (
 
 	// ServerVersion value can be changed by the create-tag Github workflow.
 	// If you change the var name or move it, be sure to update the workflow.
-	ServerVersion = "1.31.0-154.3"
+	ServerVersion = "1.31.0"
 
 	// SupportedServerVersions is used by CLI and inter role communication.
 	SupportedServerVersions = ">=1.0.0 <2.0.0"


### PR DESCRIPTION
A-3 of the v1.31.0 minor release: bump `ServerVersion` from cloud-style `"1.31.0-154.3"` to the public release version `"1.31.0"`.

Single-line change in `common/headers/version_checker.go`. Verified with `go build ./...`.