### PR TITLE
Bump defaultCliVersion to 1.7.0

### DIFF
--- a/.github/actions/build-docker-images/scripts/main.go
+++ b/.github/actions/build-docker-images/scripts/main.go
@@ -14,7 +14,7 @@ import (
 var validArchs = []string{"amd64", "arm64"}
 
 // defaultCliVersion should be updated to the latest cli version
-const defaultCliVersion = "1.6.1"
+const defaultCliVersion = "1.7.0"
 
 func main() {
 	if len(os.Args) < 2 {


### PR DESCRIPTION
## What changed?

Bump `defaultCliVersion` in `.github/actions/build-docker-images/scripts/main.go` from `1.6.1` to `1.7.0`. This is the CLI version baked into admin-tools images by the automatic `build-and-publish.yml` workflow when no explicit `cli-version` is provided.

### Original PRs

N/A — this is a release-branch-only sync change for the v1.31.0 release. CLI v1.7.0 is the new latest CLI: https://github.com/temporalio/cli/releases/tag/v1.7.0
