### PR TITLE
Bump defaultCliVersion to 1.7.0

### DIFF
--- a/.github/actions/build-docker-images/scripts/main.go
+++ b/.github/actions/build-docker-images/scripts/main.go
@@ -14,7 +14,7 @@ import (
 var validArchs = []string{"amd64", "arm64"}
 
 // defaultCliVersion should be updated to the latest cli version
-const defaultCliVersion = "1.6.1"
+const defaultCliVersion = "1.7.0"
 
 func main() {
 	if len(os.Args) < 2 {


### PR DESCRIPTION
## What changed?
Bump `defaultCliVersion` in `.github/actions/build-docker-images/scripts/main.go` from `1.6.1` → `1.7.0`. 

## Why?
CLI v1.7.0 was released today (https://github.com/temporalio/cli/releases/tag/v1.7.0) alongside the v1.31.0 server release. 

## How did you test it?
- [x] built (`go build` on the helper script)
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)