### PR TITLE
Reduce test runner resources

### DIFF
--- a/.github/workflows/optimize-test-sharding.yml
+++ b/.github/workflows/optimize-test-sharding.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           # NOTE: shard count must match shards in run-tests.yml
           go run ./cmd/tools/optimize-test-sharding \
-            -shards 4 \
+            -shards 5 \
             -workflow run-tests.yml \
             -artifact-pattern 'junit-xml--*shard*--functional-test' \
             -file "${{ env.SALT_FILE }}" \

--- a/.github/workflows/optimize-test-sharding.yml
+++ b/.github/workflows/optimize-test-sharding.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           # NOTE: shard count must match shards in run-tests.yml
           go run ./cmd/tools/optimize-test-sharding \
-            -shards 3 \
+            -shards 4 \
             -workflow run-tests.yml \
             -artifact-pattern 'junit-xml--*shard*--functional-test' \
             -file "${{ env.SALT_FILE }}" \

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,7 +25,8 @@ env:
   TEMPORAL_VERSION_CHECK_DISABLED: 1
   TEMPORAL_AWAIT_ATTEMPT_TIMEOUT: 15s
   MAX_TEST_ATTEMPTS: 3
-  SHARD_COUNT: 3 # NOTE: must match shard count in optimize-test-sharding.yml
+  SHARD_COUNT: 4 # NOTE: must match shard count in optimize-test-sharding.yml
+  RUNNER_ARM: ubuntu-24.04-arm
 
 jobs:
   test-setup:
@@ -100,14 +101,7 @@ jobs:
 
       - name: Configure runners
         id: configure_runners
-        run: |
-          # Use 8-core runners for temporalio org, standard runners for forks
-          if [[ "${{ github.repository_owner }}" == "temporalio" ]]; then
-            runner_arm="ubuntu-24.04-arm64-8-cores"
-          else
-            runner_arm="ubuntu-24.04-arm"
-          fi
-          echo "runner_arm=$runner_arm" >> "$GITHUB_OUTPUT"
+        run: echo "runner_arm=$RUNNER_ARM" >> "$GITHUB_OUTPUT"
 
       # Primary DBs always get full tests, extended DBs get smoke tests (1 job) in abridged PRs.
       - name: Build job matrix

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,7 +25,7 @@ env:
   TEMPORAL_VERSION_CHECK_DISABLED: 1
   TEMPORAL_AWAIT_ATTEMPT_TIMEOUT: 15s
   MAX_TEST_ATTEMPTS: 3
-  SHARD_COUNT: 4 # NOTE: must match shard count in optimize-test-sharding.yml
+  SHARD_COUNT: 5 # NOTE: must match shard count in optimize-test-sharding.yml
   RUNNER_ARM: ubuntu-24.04-arm
 
 jobs:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -434,6 +434,7 @@ jobs:
           TEMPORAL_TEST_LOG_FILE: ${{ github.workspace }}/.testoutput/debug.log
           TEMPORAL_TEST_LOG_LEVEL: info
           TEMPORAL_TEST_CLUSTER_EVENTS_FILE: ${{ github.workspace }}/.testoutput/test-cluster-events.jsonl
+          GOMEMLIMIT: 5GiB
 
       - name: Dump container logs
         if: ${{ failure() && toJson(matrix.containers) != '[]' }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -149,6 +149,7 @@ jobs:
               test_timeout: 35m
               github_timeout: 40
               sharded: true
+              reuse_schema: true
             smoke:
               cmd: make functional-test-coverage
               test_timeout: 5m
@@ -422,6 +423,15 @@ jobs:
           compose_file: ${{ env.DOCKER_COMPOSE_FILE }}
           services: ${{ env.CONTAINERS }}
 
+      - name: Install schema
+        if: ${{ matrix.reuse_schema }}
+        run: |
+          case "${{ matrix.persistence_driver }}" in
+            cassandra)    make install-schema-functional-cassandra ;;
+            mysql8)       make install-schema-functional-mysql8 ;;
+            postgres12*)  make install-schema-functional-postgresql12 ;;
+          esac
+
       - name: Run functional test
         timeout-minutes: ${{ fromJSON(env.GITHUB_TIMEOUT) }}
         run: |
@@ -435,6 +445,7 @@ jobs:
           TEMPORAL_TEST_LOG_LEVEL: info
           TEMPORAL_TEST_CLUSTER_EVENTS_FILE: ${{ github.workspace }}/.testoutput/test-cluster-events.jsonl
           GOMEMLIMIT: 5GiB
+          TEMPORAL_REUSE_SCHEMA: ${{ matrix.reuse_schema && 'true' || '' }}
 
       - name: Dump container logs
         if: ${{ failure() && toJson(matrix.containers) != '[]' }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -149,6 +149,7 @@ jobs:
               test_timeout: 35m
               github_timeout: 40
               sharded: true
+              reuse_schema: true
             smoke:
               cmd: make functional-test-coverage
               test_timeout: 5m
@@ -422,6 +423,15 @@ jobs:
           compose_file: ${{ env.DOCKER_COMPOSE_FILE }}
           services: ${{ env.CONTAINERS }}
 
+      - name: Install schema
+        if: ${{ matrix.reuse_schema }}
+        run: |
+          case "${{ matrix.persistence_driver }}" in
+            cassandra)    make install-schema-functional-cassandra ;;
+            mysql8)       make install-schema-functional-mysql8 ;;
+            postgres12*)  make install-schema-functional-postgresql12 ;;
+          esac
+
       - name: Run functional test
         timeout-minutes: ${{ fromJSON(env.GITHUB_TIMEOUT) }}
         run: |
@@ -435,6 +445,7 @@ jobs:
           TEMPORAL_TEST_LOG_LEVEL: warn
           TEMPORAL_TEST_CLUSTER_EVENTS_FILE: ${{ github.workspace }}/.testoutput/test-cluster-events.jsonl
           GOMEMLIMIT: 5GiB
+          TEMPORAL_REUSE_SCHEMA: ${{ matrix.reuse_schema && 'true' || '' }}
 
       - name: Dump container logs
         if: ${{ failure() && toJson(matrix.containers) != '[]' }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -434,6 +434,7 @@ jobs:
           TEMPORAL_TEST_LOG_FILE: ${{ github.workspace }}/.testoutput/debug.log
           TEMPORAL_TEST_LOG_LEVEL: warn
           TEMPORAL_TEST_CLUSTER_EVENTS_FILE: ${{ github.workspace }}/.testoutput/test-cluster-events.jsonl
+          GOMEMLIMIT: 5GiB
 
       - name: Dump container logs
         if: ${{ failure() && toJson(matrix.containers) != '[]' }}

--- a/Makefile
+++ b/Makefile
@@ -619,6 +619,29 @@ install-schema-postgresql12: temporal-sql-tool
 	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres12 --db $(VISIBILITY_DB) setup-schema -v 0.0
 	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres12 --db $(VISIBILITY_DB) update-schema -d ./schema/postgresql/v12/visibility/versioned
 
+install-schema-functional-cassandra: temporal-cassandra-tool
+	@printf $(COLOR) "Install Cassandra functional test schema..."
+	./temporal-cassandra-tool drop -k $(TEMPORAL_DB) -f
+	./temporal-cassandra-tool create -k $(TEMPORAL_DB) --rf 1
+	./temporal-cassandra-tool -k $(TEMPORAL_DB) setup-schema -v 0.0
+	./temporal-cassandra-tool -k $(TEMPORAL_DB) update-schema -d ./schema/cassandra/temporal/versioned
+
+install-schema-functional-mysql8: temporal-sql-tool
+	@printf $(COLOR) "Install MySQL functional test schema (temporal + visibility into one DB)..."
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) --pl mysql8 --db $(TEMPORAL_DB) drop -f
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) --pl mysql8 --db $(TEMPORAL_DB) create
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) --pl mysql8 --db $(TEMPORAL_DB) setup-schema -v 0.0
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) --pl mysql8 --db $(TEMPORAL_DB) update-schema -d ./schema/mysql/v8/temporal/versioned
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) --pl mysql8 --db $(TEMPORAL_DB) update-schema -d ./schema/mysql/v8/visibility/versioned
+
+install-schema-functional-postgresql12: temporal-sql-tool
+	@printf $(COLOR) "Install Postgres functional test schema (temporal + visibility into one DB)..."
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres12 --db $(TEMPORAL_DB) drop -f
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres12 --db $(TEMPORAL_DB) create
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres12 --db $(TEMPORAL_DB) setup-schema -v 0.0
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres12 --db $(TEMPORAL_DB) update-schema -d ./schema/postgresql/v12/temporal/versioned
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres12 --db $(TEMPORAL_DB) update-schema -d ./schema/postgresql/v12/visibility/versioned
+
 install-schema-es: temporal-elasticsearch-tool
 	@printf $(COLOR) "Install Elasticsearch schema..."
 	./temporal-elasticsearch-tool -ep http://127.0.0.1:9200 setup-schema

--- a/Makefile
+++ b/Makefile
@@ -640,6 +640,29 @@ install-schema-postgresql12: temporal-sql-tool
 	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres12 --db $(VISIBILITY_DB) setup-schema -v 0.0
 	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres12 --db $(VISIBILITY_DB) update-schema -d ./schema/postgresql/v12/visibility/versioned
 
+install-schema-functional-cassandra: temporal-cassandra-tool
+	@printf $(COLOR) "Install Cassandra functional test schema..."
+	./temporal-cassandra-tool drop -k $(TEMPORAL_DB) -f
+	./temporal-cassandra-tool create -k $(TEMPORAL_DB) --rf 1
+	./temporal-cassandra-tool -k $(TEMPORAL_DB) setup-schema -v 0.0
+	./temporal-cassandra-tool -k $(TEMPORAL_DB) update-schema -d ./schema/cassandra/temporal/versioned
+
+install-schema-functional-mysql8: temporal-sql-tool
+	@printf $(COLOR) "Install MySQL functional test schema (temporal + visibility into one DB)..."
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) --pl mysql8 --db $(TEMPORAL_DB) drop -f
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) --pl mysql8 --db $(TEMPORAL_DB) create
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) --pl mysql8 --db $(TEMPORAL_DB) setup-schema -v 0.0
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) --pl mysql8 --db $(TEMPORAL_DB) update-schema -d ./schema/mysql/v8/temporal/versioned
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) --pl mysql8 --db $(TEMPORAL_DB) update-schema -d ./schema/mysql/v8/visibility/versioned
+
+install-schema-functional-postgresql12: temporal-sql-tool
+	@printf $(COLOR) "Install Postgres functional test schema (temporal + visibility into one DB)..."
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres12 --db $(TEMPORAL_DB) drop -f
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres12 --db $(TEMPORAL_DB) create
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres12 --db $(TEMPORAL_DB) setup-schema -v 0.0
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres12 --db $(TEMPORAL_DB) update-schema -d ./schema/postgresql/v12/temporal/versioned
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres12 --db $(TEMPORAL_DB) update-schema -d ./schema/postgresql/v12/visibility/versioned
+
 install-schema-es: temporal-elasticsearch-tool
 	@printf $(COLOR) "Install Elasticsearch schema..."
 	./temporal-elasticsearch-tool -ep http://127.0.0.1:9200 setup-schema

--- a/common/persistence/cassandra/test.go
+++ b/common/persistence/cassandra/test.go
@@ -47,16 +47,17 @@ const (
 
 // TestCluster allows executing cassandra operations in testing.
 type TestCluster struct {
-	keyspace       string
-	schemaDir      string
-	session        commongocql.Session
-	cfg            config.Cassandra
-	faultInjection *config.FaultInjection
-	logger         log.Logger
+	keyspace        string
+	schemaDir       string
+	session         commongocql.Session
+	cfg             config.Cassandra
+	faultInjection  *config.FaultInjection
+	skipSchemaSetup bool
+	logger          log.Logger
 }
 
 // NewTestCluster returns a new cassandra test cluster
-func NewTestCluster(keyspace, username, password, host string, port int, schemaDir string, faultInjection *config.FaultInjection, logger log.Logger) *TestCluster {
+func NewTestCluster(keyspace, username, password, host string, port int, schemaDir string, faultInjection *config.FaultInjection, skipSchemaSetup bool, logger log.Logger) *TestCluster {
 	var result TestCluster
 	result.logger = logger
 	result.keyspace = keyspace
@@ -80,6 +81,7 @@ func NewTestCluster(keyspace, username, password, host string, port int, schemaD
 		Keyspace:       keyspace,
 	}
 	result.faultInjection = faultInjection
+	result.skipSchemaSetup = skipSchemaSetup
 	return &result
 }
 
@@ -102,6 +104,10 @@ func (s *TestCluster) DatabaseName() string {
 
 // SetupTestDatabase from PersistenceTestCluster interface
 func (s *TestCluster) SetupTestDatabase() {
+	if s.skipSchemaSetup {
+		s.CreateSession(s.DatabaseName())
+		return
+	}
 	s.CreateSession("system")
 	s.CreateDatabase()
 	s.CreateSession(s.DatabaseName())
@@ -118,7 +124,9 @@ func (s *TestCluster) SetupTestDatabase() {
 
 // TearDownTestDatabase from PersistenceTestCluster interface
 func (s *TestCluster) TearDownTestDatabase() {
-	s.DropDatabase()
+	if !s.skipSchemaSetup {
+		s.DropDatabase()
+	}
 	s.session.Close()
 }
 

--- a/common/persistence/persistence-tests/persistence_test_base.go
+++ b/common/persistence/persistence-tests/persistence_test_base.go
@@ -61,6 +61,9 @@ type (
 		SchemaDir         string `yaml:"-"`
 		FaultInjection    *config.FaultInjection
 		Logger            log.Logger `yaml:"-"`
+		// SkipSchemaSetup skips database creation, schema loading, and teardown.
+		// Use when the database and schema are pre-created externally (e.g. in CI).
+		SkipSchemaSetup bool `yaml:"-"`
 	}
 )
 
@@ -131,7 +134,7 @@ func NewTestClusterForCassandra(options *TestBaseOptions, logger log.Logger) *ca
 	if options.DBName == "" {
 		options.DBName = GenerateRandomDBName()
 	}
-	testCluster := cassandra.NewTestCluster(options.DBName, options.DBUsername, options.DBPassword, options.DBHost, options.DBPort, options.SchemaDir, options.FaultInjection, logger)
+	testCluster := cassandra.NewTestCluster(options.DBName, options.DBUsername, options.DBPassword, options.DBHost, options.DBPort, options.SchemaDir, options.FaultInjection, options.SkipSchemaSetup, logger)
 	return testCluster
 }
 
@@ -166,7 +169,7 @@ func NewTestBaseWithSQL(options *TestBaseOptions) *TestBase {
 			panic(fmt.Sprintf("unknown sql store driver: %v", options.SQLDBPluginName))
 		}
 	}
-	testCluster := sql.NewTestCluster(options.SQLDBPluginName, options.DBName, options.DBUsername, options.DBPassword, options.DBHost, options.DBPort, options.ConnectAttributes, options.SchemaDir, options.FaultInjection, logger)
+	testCluster := sql.NewTestCluster(options.SQLDBPluginName, options.DBName, options.DBUsername, options.DBPassword, options.DBHost, options.DBPort, options.ConnectAttributes, options.SchemaDir, options.FaultInjection, options.SkipSchemaSetup, logger)
 	return NewTestBaseForCluster(testCluster, logger)
 }
 

--- a/common/persistence/sql/test_sql_persistence.go
+++ b/common/persistence/sql/test_sql_persistence.go
@@ -20,13 +20,14 @@ import (
 	"go.temporal.io/server/tests/testutils"
 )
 
-// TestCluster allows executing cassandra operations in testing.
+// TestCluster allows executing SQL operations in testing.
 type TestCluster struct {
-	dbName         string
-	schemaDir      string
-	cfg            config.SQL
-	faultInjection *config.FaultInjection
-	logger         log.Logger
+	dbName          string
+	schemaDir       string
+	cfg             config.SQL
+	faultInjection  *config.FaultInjection
+	skipSchemaSetup bool
+	logger          log.Logger
 }
 
 // NewTestCluster returns a new SQL test cluster
@@ -40,12 +41,12 @@ func NewTestCluster(
 	connectAttributes map[string]string,
 	schemaDir string,
 	faultInjection *config.FaultInjection,
+	skipSchemaSetup bool,
 	logger log.Logger,
 ) *TestCluster {
 	var result TestCluster
 	result.logger = logger
 	result.dbName = dbName
-
 	result.schemaDir = schemaDir
 	result.cfg = config.SQL{
 		User:               username,
@@ -57,8 +58,8 @@ func NewTestCluster(
 		TaskScanPartitions: 4,
 		ConnectAttributes:  connectAttributes,
 	}
-
 	result.faultInjection = faultInjection
+	result.skipSchemaSetup = skipSchemaSetup
 	return &result
 }
 
@@ -69,20 +70,17 @@ func (s *TestCluster) DatabaseName() string {
 
 // SetupTestDatabase from PersistenceTestCluster interface
 func (s *TestCluster) SetupTestDatabase() {
-	s.CreateDatabase()
-
-	if s.schemaDir == "" {
-		s.logger.Info("No schema directory provided, skipping schema setup")
+	if s.skipSchemaSetup {
 		return
 	}
+	s.createDatabase(s.dbName)
 
-	schemaDir := s.schemaDir + "/"
-	if !strings.HasPrefix(schemaDir, "/") && !strings.HasPrefix(schemaDir, "../") {
-		temporalPackageDir := testutils.GetRepoRootDirectory()
-		schemaDir = path.Join(temporalPackageDir, schemaDir)
+	schemaDir := s.resolveSchemaDir()
+	if schemaDir == "" {
+		return
 	}
-	s.LoadSchema(path.Join(schemaDir, "temporal", "schema.sql"))
-	s.LoadSchema(path.Join(schemaDir, "visibility", "schema.sql"))
+	s.loadSchema(s.dbName, path.Join(schemaDir, "temporal", "schema.sql"))
+	s.loadSchema(s.dbName, path.Join(schemaDir, "visibility", "schema.sql"))
 	s.loadSchemaVersion()
 }
 
@@ -90,64 +88,55 @@ func (s *TestCluster) SetupTestDatabase() {
 func (s *TestCluster) Config() config.Persistence {
 	cfg := s.cfg
 	return config.Persistence{
-		DefaultStore:    "test",
-		VisibilityStore: "test",
-		DataStores: map[string]config.DataStore{
-			"test": {SQL: &cfg, FaultInjection: s.faultInjection},
-		},
+		DefaultStore:         "test",
+		VisibilityStore:      "test",
+		DataStores:           map[string]config.DataStore{"test": {SQL: &cfg, FaultInjection: s.faultInjection}},
 		TransactionSizeLimit: dynamicconfig.GetIntPropertyFn(primitives.DefaultTransactionSizeLimit),
 	}
 }
 
 // TearDownTestDatabase from PersistenceTestCluster interface
 func (s *TestCluster) TearDownTestDatabase() {
-	s.DropDatabase()
+	if !s.skipSchemaSetup {
+		s.dropDatabase(s.dbName)
+	}
 }
 
-// CreateDatabase from PersistenceTestCluster interface
-func (s *TestCluster) CreateDatabase() {
+func (s *TestCluster) createDatabase(dbName string) {
 	cfg2 := s.cfg
 	// NOTE need to connect with empty name to create new database
 	if cfg2.PluginName != "sqlite" {
 		cfg2.DatabaseName = ""
 	}
-
 	db := s.newAdminDB(sqlplugin.DbKindUnknown, &cfg2)
 	defer s.closeAdminDB(db)
-	err := db.CreateDatabase(s.cfg.DatabaseName)
-	if err != nil {
+	if err := db.CreateDatabase(dbName); err != nil {
 		panic(err)
 	}
-	s.logger.Info("created database", tag.String("database", s.cfg.DatabaseName))
+	s.logger.Info("created database", tag.String("database", dbName))
 }
 
-// DropDatabase from PersistenceTestCluster interface
-func (s *TestCluster) DropDatabase() {
+func (s *TestCluster) dropDatabase(dbName string) {
 	cfg2 := s.cfg
-
-	if cfg2.PluginName == "sqlite" && cfg2.DatabaseName != ":memory:" && cfg2.ConnectAttributes["mode"] != "memory" {
-		if len(cfg2.DatabaseName) > 3 { // 3 should mean not ., .., empty, or /
-			// Remove main database file
-			_ = os.Remove(cfg2.DatabaseName)
-			// Remove WAL mode files (may not exist if WAL wasn't used)
-			_ = os.Remove(cfg2.DatabaseName + "-wal")
-			_ = os.Remove(cfg2.DatabaseName + "-shm")
+	if cfg2.PluginName == "sqlite" && dbName != ":memory:" && cfg2.ConnectAttributes["mode"] != "memory" {
+		if len(dbName) > 3 { // 3 should mean not ., .., empty, or /
+			_ = os.Remove(dbName)
+			_ = os.Remove(dbName + "-wal")
+			_ = os.Remove(dbName + "-shm")
 		}
 		return
 	}
-
 	// NOTE need to connect with empty name to drop the database
 	cfg2.DatabaseName = ""
 	db := s.newAdminDB(sqlplugin.DbKindUnknown, &cfg2)
 	defer s.closeAdminDB(db)
-	if err := db.DropDatabase(s.cfg.DatabaseName); err != nil {
+	if err := db.DropDatabase(dbName); err != nil {
 		panic(err)
 	}
-	s.logger.Info("dropped database", tag.String("database", s.cfg.DatabaseName))
+	s.logger.Info("dropped database", tag.String("database", dbName))
 }
 
-// LoadSchema from PersistenceTestCluster interface
-func (s *TestCluster) LoadSchema(schemaFile string) {
+func (s *TestCluster) loadSchema(dbName, schemaFile string) {
 	statements, err := p.LoadAndSplitQuery([]string{schemaFile})
 	if err != nil {
 		s.logger.Fatal(
@@ -157,8 +146,9 @@ func (s *TestCluster) LoadSchema(schemaFile string) {
 			tag.String("schema-file", schemaFile),
 		)
 	}
-
-	db := s.newAdminDB(sqlplugin.DbKindUnknown, &s.cfg)
+	cfg2 := s.cfg
+	cfg2.DatabaseName = dbName
+	db := s.newAdminDB(sqlplugin.DbKindUnknown, &cfg2)
 	defer s.closeAdminDB(db)
 
 	if rewriter, ok := db.(sqlplugin.SchemaStatementRewriter); ok {
@@ -168,16 +158,16 @@ func (s *TestCluster) LoadSchema(schemaFile string) {
 	for i, stmt := range statements {
 		if err = db.Exec(stmt); err != nil {
 			s.logger.Fatal(
-				fmt.Sprintf("LoadSchema statement %d for database %s: %v", i, s.cfg.DatabaseName, err),
+				fmt.Sprintf("LoadSchema statement %d for database %s: %v", i, dbName, err),
 				tag.Error(err),
-				tag.String("database", s.cfg.DatabaseName),
+				tag.String("database", dbName),
 				tag.String("schema-file", schemaFile),
 				tag.Int("statement-index", i),
 				tag.String("statement", stmt),
 			)
 		}
 	}
-	s.logger.Info("loaded schema")
+	s.logger.Info("loaded schema", tag.String("database", dbName))
 }
 
 func (s *TestCluster) loadSchemaVersion() {
@@ -218,4 +208,17 @@ func (s *TestCluster) closeAdminDB(db sqlplugin.AdminDB) {
 	if err := db.Close(); err != nil {
 		s.logger.Fatal("Close schema DB", tag.Error(err))
 	}
+}
+
+func (s *TestCluster) resolveSchemaDir() string {
+	if s.schemaDir == "" {
+		s.logger.Info("No schema directory provided, skipping schema setup")
+		return ""
+	}
+	schemaDir := s.schemaDir + "/"
+	if !strings.HasPrefix(schemaDir, "/") && !strings.HasPrefix(schemaDir, "../") {
+		temporalPackageDir := testutils.GetRepoRootDirectory()
+		schemaDir = path.Join(temporalPackageDir, schemaDir)
+	}
+	return schemaDir
 }

--- a/common/persistence/sql/test_sql_persistence.go
+++ b/common/persistence/sql/test_sql_persistence.go
@@ -20,13 +20,14 @@ import (
 	"go.temporal.io/server/tests/testutils"
 )
 
-// TestCluster allows executing cassandra operations in testing.
+// TestCluster allows executing SQL operations in testing.
 type TestCluster struct {
-	dbName         string
-	schemaDir      string
-	cfg            config.SQL
-	faultInjection *config.FaultInjection
-	logger         log.Logger
+	dbName          string
+	schemaDir       string
+	cfg             config.SQL
+	faultInjection  *config.FaultInjection
+	skipSchemaSetup bool
+	logger          log.Logger
 }
 
 type forceDatabaseDropper interface {
@@ -44,12 +45,12 @@ func NewTestCluster(
 	connectAttributes map[string]string,
 	schemaDir string,
 	faultInjection *config.FaultInjection,
+	skipSchemaSetup bool,
 	logger log.Logger,
 ) *TestCluster {
 	var result TestCluster
 	result.logger = logger
 	result.dbName = dbName
-
 	result.schemaDir = schemaDir
 	result.cfg = config.SQL{
 		User:               username,
@@ -61,8 +62,8 @@ func NewTestCluster(
 		TaskScanPartitions: 4,
 		ConnectAttributes:  connectAttributes,
 	}
-
 	result.faultInjection = faultInjection
+	result.skipSchemaSetup = skipSchemaSetup
 	return &result
 }
 
@@ -73,20 +74,17 @@ func (s *TestCluster) DatabaseName() string {
 
 // SetupTestDatabase from PersistenceTestCluster interface
 func (s *TestCluster) SetupTestDatabase() {
-	s.CreateDatabase()
-
-	if s.schemaDir == "" {
-		s.logger.Info("No schema directory provided, skipping schema setup")
+	if s.skipSchemaSetup {
 		return
 	}
+	s.createDatabase(s.dbName)
 
-	schemaDir := s.schemaDir + "/"
-	if !strings.HasPrefix(schemaDir, "/") && !strings.HasPrefix(schemaDir, "../") {
-		temporalPackageDir := testutils.GetRepoRootDirectory()
-		schemaDir = path.Join(temporalPackageDir, schemaDir)
+	schemaDir := s.resolveSchemaDir()
+	if schemaDir == "" {
+		return
 	}
-	s.LoadSchema(path.Join(schemaDir, "temporal", "schema.sql"))
-	s.LoadSchema(path.Join(schemaDir, "visibility", "schema.sql"))
+	s.loadSchema(s.dbName, path.Join(schemaDir, "temporal", "schema.sql"))
+	s.loadSchema(s.dbName, path.Join(schemaDir, "visibility", "schema.sql"))
 	s.loadSchemaVersion()
 }
 
@@ -94,70 +92,61 @@ func (s *TestCluster) SetupTestDatabase() {
 func (s *TestCluster) Config() config.Persistence {
 	cfg := s.cfg
 	return config.Persistence{
-		DefaultStore:    "test",
-		VisibilityStore: "test",
-		DataStores: map[string]config.DataStore{
-			"test": {SQL: &cfg, FaultInjection: s.faultInjection},
-		},
+		DefaultStore:         "test",
+		VisibilityStore:      "test",
+		DataStores:           map[string]config.DataStore{"test": {SQL: &cfg, FaultInjection: s.faultInjection}},
 		TransactionSizeLimit: dynamicconfig.GetIntPropertyFn(primitives.DefaultTransactionSizeLimit),
 	}
 }
 
 // TearDownTestDatabase from PersistenceTestCluster interface
 func (s *TestCluster) TearDownTestDatabase() {
-	s.DropDatabase()
+	if !s.skipSchemaSetup {
+		s.dropDatabase(s.dbName)
+	}
 }
 
-// CreateDatabase from PersistenceTestCluster interface
-func (s *TestCluster) CreateDatabase() {
+func (s *TestCluster) createDatabase(dbName string) {
 	cfg2 := s.cfg
 	// NOTE need to connect with empty name to create new database
 	if cfg2.PluginName != "sqlite" {
 		cfg2.DatabaseName = ""
 	}
-
 	db := s.newAdminDB(sqlplugin.DbKindUnknown, &cfg2)
 	defer s.closeAdminDB(db)
-	err := db.CreateDatabase(s.cfg.DatabaseName)
-	if err != nil {
+	if err := db.CreateDatabase(dbName); err != nil {
 		panic(err)
 	}
-	s.logger.Info("created database", tag.String("database", s.cfg.DatabaseName))
+	s.logger.Info("created database", tag.String("database", dbName))
 }
 
-// DropDatabase from PersistenceTestCluster interface
-func (s *TestCluster) DropDatabase() {
+func (s *TestCluster) dropDatabase(dbName string) {
 	cfg2 := s.cfg
-
-	if cfg2.PluginName == "sqlite" && cfg2.DatabaseName != ":memory:" && cfg2.ConnectAttributes["mode"] != "memory" {
-		if len(cfg2.DatabaseName) > 3 { // 3 should mean not ., .., empty, or /
-			// Remove main database file
-			_ = os.Remove(cfg2.DatabaseName)
-			// Remove WAL mode files (may not exist if WAL wasn't used)
-			_ = os.Remove(cfg2.DatabaseName + "-wal")
-			_ = os.Remove(cfg2.DatabaseName + "-shm")
+	if cfg2.PluginName == "sqlite" && dbName != ":memory:" && cfg2.ConnectAttributes["mode"] != "memory" {
+		if len(dbName) > 3 { // 3 should mean not ., .., empty, or /
+			_ = os.Remove(dbName)
+			_ = os.Remove(dbName + "-wal")
+			_ = os.Remove(dbName + "-shm")
 		}
 		return
 	}
-
 	// NOTE need to connect with empty name to drop the database
 	cfg2.DatabaseName = ""
 	db := s.newAdminDB(sqlplugin.DbKindUnknown, &cfg2)
 	defer s.closeAdminDB(db)
 	var err error
 	if dropper, ok := db.(forceDatabaseDropper); ok {
-		err = dropper.ForceDropDatabase(s.cfg.DatabaseName)
+		err = dropper.ForceDropDatabase(dbName)
 	} else {
-		err = db.DropDatabase(s.cfg.DatabaseName)
+		err = db.DropDatabase(dbName)
 	}
 	if err != nil {
 		panic(err)
 	}
-	s.logger.Info("dropped database", tag.String("database", s.cfg.DatabaseName))
+	s.logger.Info("dropped database", tag.String("database", dbName))
 }
 
-// LoadSchema from PersistenceTestCluster interface
-func (s *TestCluster) LoadSchema(schemaFile string) {
+func (s *TestCluster) loadSchema(dbName, schemaFile string) {
 	statements, err := p.LoadAndSplitQuery([]string{schemaFile})
 	if err != nil {
 		s.logger.Fatal(
@@ -167,8 +156,9 @@ func (s *TestCluster) LoadSchema(schemaFile string) {
 			tag.String("schema-file", schemaFile),
 		)
 	}
-
-	db := s.newAdminDB(sqlplugin.DbKindUnknown, &s.cfg)
+	cfg2 := s.cfg
+	cfg2.DatabaseName = dbName
+	db := s.newAdminDB(sqlplugin.DbKindUnknown, &cfg2)
 	defer s.closeAdminDB(db)
 
 	if rewriter, ok := db.(sqlplugin.SchemaStatementRewriter); ok {
@@ -178,16 +168,16 @@ func (s *TestCluster) LoadSchema(schemaFile string) {
 	for i, stmt := range statements {
 		if err = db.Exec(stmt); err != nil {
 			s.logger.Fatal(
-				fmt.Sprintf("LoadSchema statement %d for database %s: %v", i, s.cfg.DatabaseName, err),
+				fmt.Sprintf("LoadSchema statement %d for database %s: %v", i, dbName, err),
 				tag.Error(err),
-				tag.String("database", s.cfg.DatabaseName),
+				tag.String("database", dbName),
 				tag.String("schema-file", schemaFile),
 				tag.Int("statement-index", i),
 				tag.String("statement", stmt),
 			)
 		}
 	}
-	s.logger.Info("loaded schema")
+	s.logger.Info("loaded schema", tag.String("database", dbName))
 }
 
 func (s *TestCluster) loadSchemaVersion() {
@@ -228,4 +218,17 @@ func (s *TestCluster) closeAdminDB(db sqlplugin.AdminDB) {
 	if err := db.Close(); err != nil {
 		s.logger.Fatal("Close schema DB", tag.Error(err))
 	}
+}
+
+func (s *TestCluster) resolveSchemaDir() string {
+	if s.schemaDir == "" {
+		s.logger.Info("No schema directory provided, skipping schema setup")
+		return ""
+	}
+	schemaDir := s.schemaDir + "/"
+	if !strings.HasPrefix(schemaDir, "/") && !strings.HasPrefix(schemaDir, "../") {
+		temporalPackageDir := testutils.GetRepoRootDirectory()
+		schemaDir = path.Join(temporalPackageDir, schemaDir)
+	}
+	return schemaDir
 }

--- a/develop/github/docker-compose.yml
+++ b/develop/github/docker-compose.yml
@@ -10,8 +10,8 @@ services:
       - "9042:9042"
     environment:
       CASSANDRA_LISTEN_ADDRESS: 127.0.0.1
-      MAX_HEAP_SIZE: "2G"
-      HEAP_NEWSIZE: "200M"
+      MAX_HEAP_SIZE: "1G"
+      HEAP_NEWSIZE: "100M"
       # Increase native transport threads for handling more concurrent connections
       JVM_EXTRA_OPTS: "-Dcassandra.native_transport_max_threads=512"
     healthcheck:
@@ -55,7 +55,7 @@ services:
       - cluster.routing.allocation.disk.watermark.high=256mb
       - cluster.routing.allocation.disk.watermark.flood_stage=128mb
       - discovery.type=single-node
-      - ES_JAVA_OPTS=-Xms1g -Xmx1g
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
     healthcheck:
       !!merge <<: *healthcheck-defaults
       test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
@@ -71,7 +71,7 @@ services:
       - cluster.routing.allocation.disk.watermark.flood_stage=128mb
       - discovery.type=single-node
       - xpack.security.enabled=false
-      - ES_JAVA_OPTS=-Xms1g -Xmx1g
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
     healthcheck:
       !!merge <<: *healthcheck-defaults
       test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
@@ -87,7 +87,7 @@ services:
       - cluster.routing.allocation.disk.watermark.flood_stage=128mb
       - discovery.type=single-node
       - DISABLE_SECURITY_PLUGIN=true
-      - OPENSEARCH_JAVA_OPTS=-Xms1g -Xmx1g
+      - OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m
     healthcheck:
       !!merge <<: *healthcheck-defaults
       test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
@@ -103,7 +103,7 @@ services:
       - cluster.routing.allocation.disk.watermark.flood_stage=128mb
       - discovery.type=single-node
       - DISABLE_SECURITY_PLUGIN=true
-      - OPENSEARCH_JAVA_OPTS=-Xms1g -Xmx1g
+      - OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m
     healthcheck:
       !!merge <<: *healthcheck-defaults
       test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1"]

--- a/develop/github/docker-compose.yml
+++ b/develop/github/docker-compose.yml
@@ -10,8 +10,8 @@ services:
       - "9042:9042"
     environment:
       CASSANDRA_LISTEN_ADDRESS: 127.0.0.1
-      MAX_HEAP_SIZE: "1G"
-      HEAP_NEWSIZE: "100M"
+      MAX_HEAP_SIZE: "2G"
+      HEAP_NEWSIZE: "200M"
       # Increase native transport threads for handling more concurrent connections
       JVM_EXTRA_OPTS: "-Dcassandra.native_transport_max_threads=512"
     healthcheck:

--- a/develop/github/memory_monitor.sh
+++ b/develop/github/memory_monitor.sh
@@ -30,9 +30,9 @@ fi
 
 # Snapshot config.
 readonly SNAPSHOT_DIR="${SNAPSHOT_DIR:-.testoutput/memory}"
-# Sample every second so short OOM ramps still leave history, but print less
+# Sample every five seconds so short OOM ramps still leave history, but print less
 # often to keep CI logs readable.
-readonly SNAPSHOT_INTERVAL_SECONDS="${SNAPSHOT_INTERVAL_SECONDS:-1}"
+readonly SNAPSHOT_INTERVAL_SECONDS="${SNAPSHOT_INTERVAL_SECONDS:-5}"
 readonly SNAPSHOT_PRINT_INTERVAL_SECONDS="${SNAPSHOT_PRINT_INTERVAL_SECONDS:-30}"
 readonly SNAPSHOT_FILE="${SNAPSHOT_FILE:-$SNAPSHOT_DIR/memory-snapshot.txt}"
 readonly SNAPSHOT_HISTORY_FILE="${SNAPSHOT_HISTORY_FILE:-$SNAPSHOT_DIR/memory-history.txt}"

--- a/tests/testcore/dynamic_config_overrides.go
+++ b/tests/testcore/dynamic_config_overrides.go
@@ -26,6 +26,22 @@ var (
 	//        doesn't allow parallel execution of tests in the same suite anyway. If one day, it is allowed,
 	//        unique namespaces with overrides per namespace should be used for tests that require overrides.
 	defaultDynamicConfigOverrides = map[dynamicconfig.Key]any{
+		// Reduce history processor worker pools: default is 512/shard which creates thousands of
+		// goroutines across shards. Tests don't need production throughput.
+		dynamicconfig.TimerProcessorSchedulerWorkerCount.Key():                  8,
+		dynamicconfig.MemoryTimerProcessorSchedulerWorkerCount.Key():            4,
+		dynamicconfig.TransferProcessorSchedulerWorkerCount.Key():               8,
+		dynamicconfig.VisibilityProcessorSchedulerWorkerCount.Key():             8,
+		dynamicconfig.ArchivalProcessorSchedulerWorkerCount.Key():               4,
+		dynamicconfig.ReplicationProcessorSchedulerWorkerCount.Key():            4,
+		dynamicconfig.ReplicationLowPriorityProcessorSchedulerWorkerCount.Key(): 4,
+
+		// Reduce matching task queue partitions and fanout: default is 4 partitions each with
+		// their own goroutine tree. Tests create many task queues, so this compounds quickly.
+		dynamicconfig.MatchingNumTaskqueueWritePartitions.Key(): 1,
+		dynamicconfig.MatchingNumTaskqueueReadPartitions.Key():  1,
+		dynamicconfig.MatchingForwarderMaxChildrenPerNode.Key(): 3,
+
 		dynamicconfig.FrontendRPS.Key(): 3000,
 		// Make sure we don't hit the rate limiter in tests.
 		dynamicconfig.FrontendNamespaceReplicationInducingAPIsRPS.Key(): 1000,

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -303,7 +303,7 @@ func (s *FunctionalTestBase) setupCluster(options ...TestClusterOption) {
 	s.testClusterConfig = &TestClusterConfig{
 		FaultInjection: params.FaultInjectionConfig,
 		HistoryConfig: HistoryConfig{
-			NumHistoryShards: cmp.Or(params.NumHistoryShards, 4),
+			NumHistoryShards: cmp.Or(params.NumHistoryShards, 2),
 		},
 		DCRedirectionPolicy:             params.DCRedirectionPolicy,
 		DynamicConfigOverrides:          params.DynamicConfigOverrides,

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -297,7 +297,7 @@ func (s *FunctionalTestBase) setupCluster(options ...TestClusterOption) {
 	s.testClusterConfig = &TestClusterConfig{
 		FaultInjection: params.FaultInjectionConfig,
 		HistoryConfig: HistoryConfig{
-			NumHistoryShards: cmp.Or(params.NumHistoryShards, 4),
+			NumHistoryShards: cmp.Or(params.NumHistoryShards, 2),
 		},
 		DCRedirectionPolicy:       params.DCRedirectionPolicy,
 		DynamicConfigOverrides:    params.DynamicConfigOverrides,

--- a/tests/testcore/test_cluster.go
+++ b/tests/testcore/test_cluster.go
@@ -127,12 +127,24 @@ type defaultPersistenceTestBaseFactory struct{}
 // GetPersistenceTestDefaults returns the default persistence options based on CLI flags.
 // Use this when creating TestClusterConfig to ensure proper database configuration.
 func GetPersistenceTestDefaults() persistencetests.TestBaseOptions {
-	return *persistencetests.GetTestClusterOption(cliFlags.persistenceType, cliFlags.persistenceDriver)
+	opts := *persistencetests.GetTestClusterOption(cliFlags.persistenceType, cliFlags.persistenceDriver)
+	if os.Getenv("TEMPORAL_REUSE_SCHEMA") == "true" && cliFlags.persistenceDriver != "sqlite" {
+		opts.DBName = "temporal"
+		opts.SkipSchemaSetup = true
+	}
+	return opts
 }
 
 func (f *defaultPersistenceTestBaseFactory) NewTestBase(options *persistencetests.TestBaseOptions) *persistencetests.TestBase {
 	defaults := GetPersistenceTestDefaults()
+	// Schema-specific flags are only inherited by blank options (dedicated clusters).
+	// Explicitly-constructed options, like the shared SQLite cluster, must not inherit
+	// these flags even when the store type happens to match.
+	isBlank := options.DBName == "" && options.StoreType == ""
 	options.ApplyDefaults(&defaults)
+	if isBlank {
+		options.SkipSchemaSetup = defaults.SkipSchemaSetup
+	}
 
 	if cliFlags.enableFaultInjection != "" && options.FaultInjection == nil {
 		// If -enableFaultInjection is passed to the test runner, then default fault injection config is added to the persistence options.

--- a/tests/testcore/test_cluster.go
+++ b/tests/testcore/test_cluster.go
@@ -121,12 +121,24 @@ type defaultPersistenceTestBaseFactory struct{}
 // GetPersistenceTestDefaults returns the default persistence options based on CLI flags.
 // Use this when creating TestClusterConfig to ensure proper database configuration.
 func GetPersistenceTestDefaults() persistencetests.TestBaseOptions {
-	return *persistencetests.GetTestClusterOption(cliFlags.persistenceType, cliFlags.persistenceDriver)
+	opts := *persistencetests.GetTestClusterOption(cliFlags.persistenceType, cliFlags.persistenceDriver)
+	if os.Getenv("TEMPORAL_REUSE_SCHEMA") == "true" && cliFlags.persistenceDriver != "sqlite" {
+		opts.DBName = "temporal"
+		opts.SkipSchemaSetup = true
+	}
+	return opts
 }
 
 func (f *defaultPersistenceTestBaseFactory) NewTestBase(options *persistencetests.TestBaseOptions) *persistencetests.TestBase {
 	defaults := GetPersistenceTestDefaults()
+	// Schema-specific flags are only inherited by blank options (dedicated clusters).
+	// Explicitly-constructed options, like the shared SQLite cluster, must not inherit
+	// these flags even when the store type happens to match.
+	isBlank := options.DBName == "" && options.StoreType == ""
 	options.ApplyDefaults(&defaults)
+	if isBlank {
+		options.SkipSchemaSetup = defaults.SkipSchemaSetup
+	}
 
 	if cliFlags.enableFaultInjection != "" && options.FaultInjection == nil {
 		// If -enableFaultInjection is passed to the test runner, then default fault injection config is added to the persistence options.


### PR DESCRIPTION
## What changed?

Only use 4-core ARM runners instead of 8-core; and increase shard size for test sharding.

## Why?

8-core runners have - at least during peak hours - very long provisioning time (several minutes). By using 4-core we reduce that time, but risk OOM kills as they have less memory. To counter that, we increase the number of test shards so that fewer tests are run per shard.

## How did you test it?

TBD