### PR TITLE
fix COVERPKG_FLAG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ PINNED_DEPENDENCIES := \
 TEST_OUTPUT_ROOT        := ./.testoutput
 NEW_COVER_PROFILE       = $(TEST_OUTPUT_ROOT)/coverage.$(shell xxd -p -l 16 /dev/urandom).out   # generates a new filename each time it's substituted
 NEW_REPORT              = $(TEST_OUTPUT_ROOT)/junit.$(shell xxd -p -l 16 /dev/urandom).xml   # generates a new filename each time it's substituted
-COVERPKG_FLAG 		    = -coverpkg=$(shell go list ./... | paste -sd "," -)
+COVERPKG_FLAG 		    = -coverpkg=./...
 
 # DB
 SQL_USER ?= temporal


### PR DESCRIPTION
## What changed?

Changed `-coverpkg` to list all packages with wildcard expression instead of listing them individually.

## Why?

Previously a lot of [warnings were printed](https://github.com/temporalio/temporal/actions/runs/25144303588/job/73700946660?pr=10130#step:11:28).

<img width="1010" height="955" alt="Screenshot 2026-04-29 at 7 37 41 PM" src="https://github.com/user-attachments/assets/c6e88362-745e-4d7c-a9ed-50f740108129" />

## How did you test it?

Code coverage is still about the same (not sure where the minor diff comes from tbh but I see it for individual files, too, not just packages):

<img width="3284" height="333" alt="Screenshot 2026-04-29 at 7 57 11 PM" src="https://github.com/user-attachments/assets/c5f59090-e439-4d6b-9b46-994972e43379" />
