### PR TITLE
Add context.Context to callback.Validator interface

### DIFF
--- a/chasm/lib/activity/frontend.go
+++ b/chasm/lib/activity/frontend.go
@@ -95,7 +95,7 @@ func (h *frontendHandler) StartActivityExecution(ctx context.Context, req *workf
 		return nil, err
 	}
 
-	modifiedReq, err := h.validateAndPopulateStartRequest(req, namespaceID)
+	modifiedReq, err := h.validateAndPopulateStartRequest(ctx, req, namespaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -351,6 +351,7 @@ func (h *frontendHandler) RequestCancelActivityExecution(
 }
 
 func (h *frontendHandler) validateAndPopulateStartRequest(
+	ctx context.Context,
 	req *workflowservice.StartActivityExecutionRequest,
 	namespaceID namespace.ID,
 ) (*workflowservice.StartActivityExecutionRequest, error) {
@@ -405,7 +406,7 @@ func (h *frontendHandler) validateAndPopulateStartRequest(
 	}
 
 	if cbs := req.GetCompletionCallbacks(); len(cbs) > 0 {
-		if err := h.callbackValidator.Validate(req.GetNamespace(), cbs); err != nil {
+		if err := h.callbackValidator.Validate(ctx, req.GetNamespace(), cbs); err != nil {
 			return nil, err
 		}
 	}

--- a/chasm/lib/activity/frontend_test.go
+++ b/chasm/lib/activity/frontend_test.go
@@ -1,6 +1,7 @@
 package activity
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -50,11 +51,11 @@ func TestRequestIdStableAcrossRetries(t *testing.T) {
 	// validateAndPopulateStartRequest with the same request pointer.
 	validateTwoAttempts := func(t *testing.T, req *workflowservice.StartActivityExecutionRequest) {
 		t.Helper()
-		clone1, err := h.validateAndPopulateStartRequest(req, nsID)
+		clone1, err := h.validateAndPopulateStartRequest(context.Background(), req, nsID)
 		require.NoError(t, err)
 		require.NotEmpty(t, clone1.RequestId)
 
-		clone2, err := h.validateAndPopulateStartRequest(req, nsID)
+		clone2, err := h.validateAndPopulateStartRequest(context.Background(), req, nsID)
 		require.NoError(t, err)
 		require.Equal(t, clone1.RequestId, clone2.RequestId)
 	}

--- a/chasm/lib/callback/validator.go
+++ b/chasm/lib/callback/validator.go
@@ -1,6 +1,7 @@
 package callback
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -12,7 +13,7 @@ import (
 
 // Validator validates completion callbacks attached to executions (workflows and standalone activities).
 type Validator interface {
-	Validate(namespaceName string, cbs []*commonpb.Callback) error
+	Validate(ctx context.Context, namespaceName string, cbs []*commonpb.Callback) error
 }
 
 type validator struct {
@@ -38,7 +39,7 @@ func NewValidator(
 
 // Validate validates completion callbacks: count, URL length, endpoint allowlist, header size, and normalizes header
 // keys to lowercase.
-func (v *validator) Validate(namespaceName string, cbs []*commonpb.Callback) error {
+func (v *validator) Validate(_ context.Context, namespaceName string, cbs []*commonpb.Callback) error {
 	if len(cbs) > v.maxCallbacksPerExecution(namespaceName) {
 		return serviceerror.NewInvalidArgumentf(
 			"cannot attach more than %d callbacks to an execution", v.maxCallbacksPerExecution(namespaceName),

--- a/chasm/lib/callback/validator_test.go
+++ b/chasm/lib/callback/validator_test.go
@@ -1,6 +1,7 @@
 package callback
 
 import (
+	"context"
 	"regexp"
 	"testing"
 
@@ -31,7 +32,7 @@ func TestValidateCallbacks(t *testing.T) {
 				},
 			}},
 		}
-		err := v.Validate("ns", cbs)
+		err := v.Validate(context.Background(), "ns", cbs)
 		require.NoError(t, err)
 	})
 
@@ -46,7 +47,7 @@ func TestValidateCallbacks(t *testing.T) {
 			{Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: "http://localhost/cb1"}}},
 			{Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: "http://localhost/cb2"}}},
 		}
-		err := v.Validate("ns", cbs)
+		err := v.Validate(context.Background(), "ns", cbs)
 		var invalidArgErr *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgErr)
 		require.Contains(t, err.Error(), "cannot attach more than 1 callbacks")
@@ -66,7 +67,7 @@ func TestValidateCallbacks(t *testing.T) {
 				},
 			}},
 		}
-		err := v.Validate("ns", cbs)
+		err := v.Validate(context.Background(), "ns", cbs)
 		var invalidArgErr *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgErr)
 		require.Contains(t, err.Error(), "url length longer than max length allowed")
@@ -81,7 +82,7 @@ func TestValidateCallbacks(t *testing.T) {
 				},
 			}},
 		}
-		err := v.Validate("ns", cbs)
+		err := v.Validate(context.Background(), "ns", cbs)
 		var invalidArgErr *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgErr)
 		require.Contains(t, err.Error(), "header size longer than max allowed size")
@@ -96,7 +97,7 @@ func TestValidateCallbacks(t *testing.T) {
 				},
 			}},
 		}
-		err := v.Validate("ns", cbs)
+		err := v.Validate(context.Background(), "ns", cbs)
 		require.NoError(t, err)
 		nexus := cbs[0].GetNexus()
 		require.Equal(t, "application/json", nexus.Header["content-type"])
@@ -119,7 +120,7 @@ func TestValidateCallbacks(t *testing.T) {
 				},
 			}},
 		}
-		err := v.Validate("ns", cbs)
+		err := v.Validate(context.Background(), "ns", cbs)
 		var invalidArgErr *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgErr)
 		require.Contains(t, err.Error(), "does not match any configured callback address")
@@ -129,14 +130,14 @@ func TestValidateCallbacks(t *testing.T) {
 		cbs := []*commonpb.Callback{
 			{Variant: nil},
 		}
-		err := v.Validate("ns", cbs)
+		err := v.Validate(context.Background(), "ns", cbs)
 		var unimplementedErr *serviceerror.Unimplemented
 		require.ErrorAs(t, err, &unimplementedErr)
 		require.Contains(t, err.Error(), "unknown callback variant")
 	})
 
 	t.Run("EmptyCallbacksNoError", func(t *testing.T) {
-		err := v.Validate("ns", nil)
+		err := v.Validate(context.Background(), "ns", nil)
 		require.NoError(t, err)
 	})
 
@@ -146,7 +147,7 @@ func TestValidateCallbacks(t *testing.T) {
 				Internal: &commonpb.Callback_Internal{},
 			}},
 		}
-		err := v.Validate("ns", cbs)
+		err := v.Validate(context.Background(), "ns", cbs)
 		require.NoError(t, err)
 	})
 }

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -546,7 +546,7 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 	defer log.CapturePanic(wh.logger, &retError)
 
 	var err error
-	if request, err = wh.prepareStartWorkflowRequest(request); err != nil {
+	if request, err = wh.prepareStartWorkflowRequest(ctx, request); err != nil {
 		return nil, err
 	}
 
@@ -604,6 +604,7 @@ func (wh *WorkflowHandler) convertToStartWorkflowExecutionResponse(
 
 // Validates the request and sets default values where they are missing.
 func (wh *WorkflowHandler) prepareStartWorkflowRequest(
+	ctx context.Context,
 	request *workflowservice.StartWorkflowExecutionRequest,
 ) (*workflowservice.StartWorkflowExecutionRequest, error) {
 	if request == nil {
@@ -681,7 +682,7 @@ func (wh *WorkflowHandler) prepareStartWorkflowRequest(
 	}
 
 	if cbs := request.GetCompletionCallbacks(); len(cbs) > 0 {
-		if err := wh.callbackValidator.Validate(namespaceName.String(), cbs); err != nil {
+		if err := wh.callbackValidator.Validate(ctx, namespaceName.String(), cbs); err != nil {
 			return nil, err
 		}
 	}
@@ -784,7 +785,7 @@ func (wh *WorkflowHandler) ExecuteMultiOperation(
 		return nil, errMultiOpNotStartAndUpdate
 	}
 
-	historyReq, err := wh.convertToHistoryMultiOperationRequest(namespaceID, request)
+	historyReq, err := wh.convertToHistoryMultiOperationRequest(ctx, namespaceID, request)
 	if err != nil {
 		return nil, err
 	}
@@ -808,6 +809,7 @@ func (wh *WorkflowHandler) ExecuteMultiOperation(
 }
 
 func (wh *WorkflowHandler) convertToHistoryMultiOperationRequest(
+	ctx context.Context,
 	namespaceID namespace.ID,
 	request *workflowservice.ExecuteMultiOperationRequest,
 ) (*historyservice.ExecuteMultiOperationRequest, error) {
@@ -818,7 +820,7 @@ func (wh *WorkflowHandler) convertToHistoryMultiOperationRequest(
 	errs := make([]error, len(request.Operations))
 
 	for i, op := range request.Operations {
-		convertedOp, opWorkflowID, err := wh.convertToHistoryMultiOperationItem(namespaceID, namespace.Name(request.Namespace), op)
+		convertedOp, opWorkflowID, err := wh.convertToHistoryMultiOperationItem(ctx, namespaceID, namespace.Name(request.Namespace), op)
 		if err != nil {
 			hasError = true
 		} else {
@@ -849,6 +851,7 @@ func (wh *WorkflowHandler) convertToHistoryMultiOperationRequest(
 }
 
 func (wh *WorkflowHandler) convertToHistoryMultiOperationItem(
+	ctx context.Context,
 	namespaceID namespace.ID,
 	namespaceName namespace.Name,
 	op *workflowservice.ExecuteMultiOperationRequest_Operation,
@@ -861,7 +864,7 @@ func (wh *WorkflowHandler) convertToHistoryMultiOperationItem(
 			return nil, "", errMultiOpNamespaceMismatch
 		}
 		var err error
-		if startReq, err = wh.prepareStartWorkflowRequest(startReq); err != nil {
+		if startReq, err = wh.prepareStartWorkflowRequest(ctx, startReq); err != nil {
 			return nil, "", err
 		}
 		if len(startReq.CronSchedule) > 0 {


### PR DESCRIPTION
## What changed?
 Added `context.Context` as the first parameter to the `callback.Validator` interface and threaded it through all call                                                                          
  sites (`WorkflowHandler`, `activity.FrontendHandler`, and their internal validation/preparation methods). The base validator ignores the context. No behavioral change. 

## Why?
 Deployments that decorate the validator (via `fx.Decorate`) need  access to the gRPC context to check caller identity — e.g. to allow internal callers (scheduler) to attach `temporal://internal` callbacks while rejecting them from external users.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
