### PR TITLE
Check elasticsearch store name as prefix

### DIFF
--- a/service/frontend/operator_handler.go
+++ b/service/frontend/operator_handler.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"slices"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -185,7 +187,7 @@ func (h *OperatorHandlerImpl) addSearchAttributesInternal(
 	visManager manager.VisibilityManager,
 ) error {
 	storeName := visManager.GetStoreNames()[0]
-	if storeName == elasticsearch.PersistenceName {
+	if strings.HasPrefix(storeName, elasticsearch.PersistenceName) {
 		return h.addSearchAttributesElasticsearch(ctx, request, visManager)
 	}
 	return h.addSearchAttributesSQL(ctx, request, visManager)
@@ -367,7 +369,7 @@ func (h *OperatorHandlerImpl) removeSearchAttributesInternal(
 	visManager manager.VisibilityManager,
 ) error {
 	storeName := visManager.GetStoreNames()[0]
-	if storeName == elasticsearch.PersistenceName {
+	if strings.HasPrefix(storeName, elasticsearch.PersistenceName) {
 		return h.removeSearchAttributesElasticsearch(ctx, request, visManager)
 	}
 	return h.removeSearchAttributesSQL(ctx, request, visManager)
@@ -485,7 +487,12 @@ func (h *OperatorHandlerImpl) ListSearchAttributes(
 		)
 	}
 
-	if h.visibilityMgr.HasStoreName(elasticsearch.PersistenceName) {
+	if slices.ContainsFunc(
+		h.visibilityMgr.GetStoreNames(),
+		func(storeName string) bool {
+			return strings.HasPrefix(storeName, elasticsearch.PersistenceName)
+		},
+	) {
 		return h.listSearchAttributesElasticsearch(ctx, indexName, searchAttributes)
 	}
 	return h.listSearchAttributesSQL(ctx, request, searchAttributes)

--- a/service/frontend/operator_handler_test.go
+++ b/service/frontend/operator_handler_test.go
@@ -817,7 +817,7 @@ func (s *operatorHandlerSuite) Test_ListSearchAttributes_Elasticsearch() {
 	ctx := context.Background()
 
 	// Configure Elasticsearch: add advanced visibility store config with index name.
-	s.mockResource.VisibilityManager.EXPECT().HasStoreName(elasticsearch.PersistenceName).Return(true)
+	s.mockResource.VisibilityManager.EXPECT().GetStoreNames().Return([]string{elasticsearch.PersistenceName})
 	s.mockResource.VisibilityManager.EXPECT().GetIndexName().Return(testIndexName).AnyTimes()
 	s.mockResource.SearchAttributesManager.EXPECT().GetSearchAttributes(testIndexName, true).Return(searchattribute.TestEsNameTypeMap(), nil)
 	resp, err := handler.ListSearchAttributes(ctx, &operatorservice.ListSearchAttributesRequest{})
@@ -834,7 +834,7 @@ func (s *operatorHandlerSuite) Test_ListSearchAttributes_SQL() {
 	handler := s.handler
 	ctx := context.Background()
 
-	s.mockResource.VisibilityManager.EXPECT().HasStoreName(elasticsearch.PersistenceName).Return(false)
+	s.mockResource.VisibilityManager.EXPECT().GetStoreNames().Return([]string{mysql.PluginName})
 	s.mockResource.VisibilityManager.EXPECT().GetIndexName().Return(testIndexName).AnyTimes()
 	s.mockResource.ClientFactory.EXPECT().
 		NewLocalFrontendClientWithTimeout(gomock.Any(), gomock.Any()).


### PR DESCRIPTION
## What changed?
Check elasticsearch store name as prefix instead of exact match.

## Why?
Makes possible for Elasticsearch based Visibility store named with "elasticsearch" as prefix to behave as Elasticsearch.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

