### PR TITLE
Fix logging for tasks that don't have RawTaskInfo set.

### DIFF
--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -336,6 +336,8 @@ func (e *ExecutableTaskImpl) workflowKeyFromTask() (namespaceID, workflowID, run
 	case *replicationspb.ReplicationTask_SyncVersionedTransitionTaskAttributes:
 		a := attrs.SyncVersionedTransitionTaskAttributes
 		namespaceID, workflowID, runID = a.NamespaceId, a.WorkflowId, a.RunId
+	default:
+		return
 	}
 	return
 }

--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -302,15 +302,52 @@ func (e *ExecutableTaskImpl) NamespaceName() string {
 	return ""
 }
 
+// workflowKeyFromTask extracts namespace ID, workflow ID, and run ID from the
+// replication task. It first tries RawTaskInfo, then falls back to task-type-specific
+// attributes. Returns empty strings when workflow identity cannot be determined.
+func (e *ExecutableTaskImpl) workflowKeyFromTask() (namespaceID, workflowID, runID string) {
+	if e.replicationTask == nil {
+		return
+	}
+	if info := e.replicationTask.RawTaskInfo; info != nil {
+		return info.NamespaceId, info.WorkflowId, info.RunId
+	}
+	switch attrs := e.replicationTask.Attributes.(type) {
+	case *replicationspb.ReplicationTask_SyncWorkflowStateTaskAttributes:
+		ws := attrs.SyncWorkflowStateTaskAttributes.GetWorkflowState()
+		namespaceID = ws.GetExecutionInfo().GetNamespaceId()
+		workflowID = ws.GetExecutionInfo().GetWorkflowId()
+		runID = ws.GetExecutionState().GetRunId()
+	case *replicationspb.ReplicationTask_SyncActivityTaskAttributes:
+		a := attrs.SyncActivityTaskAttributes
+		namespaceID, workflowID, runID = a.NamespaceId, a.WorkflowId, a.RunId
+	case *replicationspb.ReplicationTask_HistoryTaskAttributes:
+		a := attrs.HistoryTaskAttributes
+		namespaceID, workflowID, runID = a.NamespaceId, a.WorkflowId, a.RunId
+	case *replicationspb.ReplicationTask_SyncHsmAttributes:
+		a := attrs.SyncHsmAttributes
+		namespaceID, workflowID, runID = a.NamespaceId, a.WorkflowId, a.RunId
+	case *replicationspb.ReplicationTask_BackfillHistoryTaskAttributes:
+		a := attrs.BackfillHistoryTaskAttributes
+		namespaceID, workflowID, runID = a.NamespaceId, a.WorkflowId, a.RunId
+	case *replicationspb.ReplicationTask_VerifyVersionedTransitionTaskAttributes:
+		a := attrs.VerifyVersionedTransitionTaskAttributes
+		namespaceID, workflowID, runID = a.NamespaceId, a.WorkflowId, a.RunId
+	case *replicationspb.ReplicationTask_SyncVersionedTransitionTaskAttributes:
+		a := attrs.SyncVersionedTransitionTaskAttributes
+		namespaceID, workflowID, runID = a.NamespaceId, a.WorkflowId, a.RunId
+	}
+	return
+}
+
 func (e *ExecutableTaskImpl) emitFinishMetrics(
 	now time.Time,
 ) {
 	if e.isDuplicated {
-		if e.replicationTask.RawTaskInfo != nil {
-			metrics.ReplicationDuplicatedTaskCount.With(e.MetricsHandler).Record(1,
-				metrics.OperationTag(e.metricsTag),
-				metrics.NamespaceTag(e.replicationTask.RawTaskInfo.NamespaceId))
-		}
+		namespaceID, _, _ := e.workflowKeyFromTask()
+		metrics.ReplicationDuplicatedTaskCount.With(e.MetricsHandler).Record(1,
+			metrics.OperationTag(e.metricsTag),
+			metrics.NamespaceTag(namespaceID))
 		return
 	}
 	nsTag := metrics.NamespaceUnknownTag()
@@ -337,19 +374,22 @@ func (e *ExecutableTaskImpl) emitFinishMetrics(
 			metrics.OperationTag(e.metricsTag),
 			nsTag,
 		)
-		if processingLatency > 10*time.Second && e.replicationTask != nil && e.replicationTask.RawTaskInfo != nil {
-			e.ThrottledLogger.Warn(fmt.Sprintf(
-				"replication task latency is too long: queue=%.2fs processing=%.2fs",
-				queueLatency.Seconds(),
-				processingLatency.Seconds(),
-			),
-				tag.WorkflowNamespace(e.NamespaceName()),
-				tag.WorkflowID(e.replicationTask.RawTaskInfo.WorkflowId),
-				tag.WorkflowRunID(e.replicationTask.RawTaskInfo.RunId),
-				tag.ReplicationTask(e.replicationTask.GetRawTaskInfo()),
-				tag.ShardID(e.Config.GetShardID(namespace.ID(e.replicationTask.RawTaskInfo.NamespaceId), e.replicationTask.RawTaskInfo.WorkflowId)),
-				tag.AttemptCount(int64(e.Attempt())),
-			)
+		if processingLatency > 10*time.Second && e.replicationTask != nil {
+			namespaceID, workflowID, runID := e.workflowKeyFromTask()
+			if workflowID != "" {
+				e.ThrottledLogger.Warn(fmt.Sprintf(
+					"replication task latency is too long: queue=%.2fs processing=%.2fs",
+					queueLatency.Seconds(),
+					processingLatency.Seconds(),
+				),
+					tag.WorkflowNamespace(e.NamespaceName()),
+					tag.WorkflowID(workflowID),
+					tag.WorkflowRunID(runID),
+					tag.ReplicationTask(e.replicationTask.GetRawTaskInfo()),
+					tag.ShardID(e.Config.GetShardID(namespace.ID(namespaceID), workflowID)),
+					tag.AttemptCount(int64(e.Attempt())),
+				)
+			}
 		}
 	}
 


### PR DESCRIPTION
## What changed?
Removed the dependency on `RawTaskInfo` in order to log slow task processing and emit duplicate task metric.

## Why?
A lot of task types don't set `RawTaskInfo`, of particular note is `SyncWorkflowStateTask` which is used for backfilling.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk observability-only change, but it alters how namespace/workflow identifiers are derived for metrics/logging and could affect tag values for some replication task types.
> 
> **Overview**
> Improves replication task observability when `RawTaskInfo` is missing by deriving `(namespaceID, workflowID, runID)` from task-type-specific attributes via new helper `workflowKeyFromTask()`.
> 
> `emitFinishMetrics` now uses this helper to always emit the duplicated-task metric with a namespace tag and to log slow-processing warnings (including shard ID) for additional replication task types, instead of skipping when `RawTaskInfo` is nil.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15390be2f85f69fa9bc3e87e237670bef6cb12c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->