### PR TITLE
Bump defaultCliVersion to 1.7.0 for v1.30.4.1

### DIFF
--- a/.github/actions/build-docker-images/scripts/main.go
+++ b/.github/actions/build-docker-images/scripts/main.go
@@ -14,7 +14,7 @@ import (
 var validArchs = []string{"amd64", "arm64"}
 
 // defaultCliVersion should be updated to the latest cli version
-const defaultCliVersion = "1.6.1"
+const defaultCliVersion = "1.7.0"
 
 func main() {
 	if len(os.Args) < 2 {


### PR DESCRIPTION
Bumps the default CLI version downloaded by Docker image builds from v1.6.1 to v1.7.0.

## Why
CLI v1.6.1 transitively pulls in vulnerable Go module versions through its embedded `temporal server start-dev`:
- `github.com/jackc/pgx/v5@v5.7.4` (CRITICAL — GHSA-9jj7-4m8r-rfcm)
- `google.golang.org/grpc@v1.72.2` (CRITICAL — GHSA-p77j-4mvh-x3m3)
- Go 1.26.0 stdlib (multiple CRITICAL/HIGH stdlib CVEs)
- `github.com/go-jose/go-jose/v4@v4.0.5`, `go.opentelemetry.io/otel/sdk@v1.35.0`, etc.

CLI v1.7.0 pins `go.temporal.io/server v1.31.0` and ships built with Go 1.26.2; `govulncheck` reports clean against v1.7.0.

## Effect
After merge, `build-and-publish.yml` will rebuild `temporaliotest/admin-tools:sha-{commit}` with the v1.7.0 CLI bundled. That image is then promoted as part of the v1.30.4.1 security release.