### PR TITLE
Add flag to skip setting up ES cluster settings

### DIFF
--- a/tools/elasticsearch/handler.go
+++ b/tools/elasticsearch/handler.go
@@ -48,10 +48,13 @@ func setupSchema(cli *cli.Context, logger log.Logger) error {
 		return err
 	}
 
-	settingsContent, err := schema.ElasticsearchClusterSettings()
-	if err != nil {
-		logger.Error("Unable to load embedded cluster settings.", tag.Error(err))
-		return err
+	settingsContent := ""
+	if !cli.Bool(CLIOptSkipClusterSettings) {
+		settingsContent, err = schema.ElasticsearchClusterSettings()
+		if err != nil {
+			logger.Error("Unable to load embedded cluster settings.", tag.Error(err))
+			return err
+		}
 	}
 
 	templateContent, err := schema.ElasticsearchIndexTemplate()

--- a/tools/elasticsearch/main.go
+++ b/tools/elasticsearch/main.go
@@ -9,15 +9,17 @@ import (
 )
 
 const (
-	CLIOptVisibilityIndex = "index"
-	CLIOptAWSCredentials  = "aws-credentials"
-	CLIOptAWSToken        = "aws-session-token"
-	CLIOptFailSilently    = "fail"
+	CLIOptVisibilityIndex     = "index"
+	CLIOptAWSCredentials      = "aws-credentials"
+	CLIOptAWSToken            = "aws-session-token"
+	CLIOptFailSilently        = "fail"
+	CLIOptSkipClusterSettings = "skip-cluster-settings"
 
-	CLIFlagVisibilityIndex = CLIOptVisibilityIndex + ", i"
-	CLIFlagAWSToken        = CLIOptAWSToken
-	CLIFlagAWSCredentials  = CLIOptAWSCredentials + ", aws"
-	CLIFlagFailSilently    = CLIOptFailSilently
+	CLIFlagVisibilityIndex     = CLIOptVisibilityIndex + ", i"
+	CLIFlagAWSToken            = CLIOptAWSToken
+	CLIFlagAWSCredentials      = CLIOptAWSCredentials + ", aws"
+	CLIFlagFailSilently        = CLIOptFailSilently
+	CLIFlagSkipClusterSettings = CLIOptSkipClusterSettings
 )
 
 // RunTool runs the temporal-elasticsearch-tool command line tool
@@ -126,6 +128,10 @@ func BuildCLIOptions() *cli.App {
 				cli.BoolFlag{
 					Name:  CLIFlagFailSilently,
 					Usage: "fail silently on HTTP errors",
+				},
+				cli.BoolFlag{
+					Name:  CLIFlagSkipClusterSettings,
+					Usage: "skip setting up cluster settings",
 				},
 			},
 			Action: func(c *cli.Context) error {

--- a/tools/elasticsearch/tasks.go
+++ b/tools/elasticsearch/tasks.go
@@ -31,7 +31,7 @@ type SetupTask struct {
 func (task *SetupTask) setupClusterSettings() error {
 	config := task.config
 	if len(config.SettingsContent) == 0 {
-		task.logger.Info("Skipping cluster settings update, no embedded settings content")
+		task.logger.Info("Skipping cluster settings update")
 		return nil
 	}
 


### PR DESCRIPTION
## What changed?
Add flag to skip setting up ES cluster settings. Eg: `temporal-elasticsearch-tool setup-schema --skip-cluster-settings`

## Why?
Allow users to not use our provided cluster settings (eg: avoid overwriting their cluster settings).
https://github.com/temporalio/temporal/issues/9857

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

