### PR TITLE
Removes eager creation of Outcome from SANO

### DIFF
--- a/chasm/lib/nexusoperation/operation.go
+++ b/chasm/lib/nexusoperation/operation.go
@@ -117,7 +117,6 @@ func newStandaloneOperation(
 		UserMetadata: frontendReq.GetUserMetadata(),
 		Identity:     frontendReq.GetIdentity(),
 	})
-	op.Outcome = chasm.NewDataField(ctx, &nexusoperationpb.OperationOutcome{})
 	op.Visibility = chasm.NewComponentField(ctx, chasm.NewVisibilityWithData(
 		ctx,
 		frontendReq.GetSearchAttributes().GetIndexedFields(),

--- a/tests/nexus_standalone_test.go
+++ b/tests/nexus_standalone_test.go
@@ -485,7 +485,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 		// can be completed through the public Nexus task APIs.
 
 		s.Run("ScheduleToStartTimeout", func(s *NexusStandaloneTestSuite) {
-			env := s.newTestEnv(testcore.WithDedicatedCluster())
+			env := s.newTestEnv()
 			taskQueue := testcore.RandomizedNexusEndpoint(s.T().Name())
 			endpointName := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
 

--- a/tests/nexus_standalone_test.go
+++ b/tests/nexus_standalone_test.go
@@ -28,7 +28,6 @@ import (
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/common/testing/protorequire"
-	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
@@ -487,16 +486,6 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 
 		s.Run("ScheduleToStartTimeout", func(s *NexusStandaloneTestSuite) {
 			env := s.newTestEnv(testcore.WithDedicatedCluster())
-
-			// When a standalone operation fails from scheduled, we'll never
-			// set the Outcome variant. Add a testlogger fail here to make sure we don't
-			// trip the softassert when building our outcome response. This will fail if
-			// Outcome is created eagerly.
-			tl, ok := env.Logger.(*testlogger.TestLogger)
-			s.True(ok)
-			prev := tl.FailOnError(true)
-			defer tl.FailOnError(prev)
-
 			taskQueue := testcore.RandomizedNexusEndpoint(s.T().Name())
 			endpointName := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
 

--- a/tests/nexus_standalone_test.go
+++ b/tests/nexus_standalone_test.go
@@ -28,6 +28,7 @@ import (
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/common/testing/protorequire"
+	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
@@ -485,7 +486,17 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 		// can be completed through the public Nexus task APIs.
 
 		s.Run("ScheduleToStartTimeout", func(s *NexusStandaloneTestSuite) {
-			env := s.newTestEnv()
+			env := s.newTestEnv(testcore.WithDedicatedCluster())
+
+			// When a standalone operation fails from scheduled, we'll never
+			// set the Outcome variant. Add a testlogger fail here to make sure we don't
+			// trip the softassert when building our outcome response. This will fail if
+			// Outcome is created eagerly.
+			tl, ok := env.Logger.(*testlogger.TestLogger)
+			s.True(ok)
+			prev := tl.FailOnError(true)
+			defer tl.FailOnError(prev)
+
 			taskQueue := testcore.RandomizedNexusEndpoint(s.T().Name())
 			endpointName := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
 


### PR DESCRIPTION
## What changed?
Removes eager creation of the outcome for standalone nexus operations.

## Why?
The eager creation leaves an Outcome around without a variant. This means if the SANO fails, in some circumstances, we'll look up the empty outcome for our result. This does correctly return LastAttemptFailure, but it also trips a softassert. 

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
