### PR TITLE
[Nexus/CHASM] Use token instead of storing batch ID for event load

### DIFF
--- a/chasm/lib/buf.yaml
+++ b/chasm/lib/buf.yaml
@@ -6,13 +6,8 @@ breaking:
   use:
     - WIRE
   ignore:
-    # TODO lina: remove after frontend handler PRs merge
-    - chasm/lib/scheduler/proto/v1/message.proto
-    # TODO seankane: remove after merging #8499
-    - chasm/lib/callback/proto/v1/tasks.proto
-    # TODO bergundy: remove after nexus-chasm-cleanup merges
-    - chasm/lib/nexusoperation/proto/v1/operation.proto
-    - chasm/lib/nexusoperation/proto/v1/tasks.proto
+    # TODO(bergundy): remove after 10154 is merged
+    - chasm/lib/workflow/proto/v1/state.proto
 lint:
   use:
     - DEFAULT

--- a/chasm/lib/workflow/gen/workflowpb/v1/state.pb.go
+++ b/chasm/lib/workflow/gen/workflowpb/v1/state.pb.go
@@ -28,10 +28,10 @@ type NexusOperationParentData struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Event ID of the NEXUS_OPERATION_SCHEDULED event.
 	ScheduledEventId int64 `protobuf:"varint,1,opt,name=scheduled_event_id,json=scheduledEventId,proto3" json:"scheduled_event_id,omitempty"`
-	// Batch ID of the NEXUS_OPERATION_SCHEDULED event.
-	ScheduledEventBatchId int64 `protobuf:"varint,2,opt,name=scheduled_event_batch_id,json=scheduledEventBatchId,proto3" json:"scheduled_event_batch_id,omitempty"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	// Token for loading the NEXUS_OPERATION_SCHEDULED event.
+	ScheduledEventToken []byte `protobuf:"bytes,2,opt,name=scheduled_event_token,json=scheduledEventToken,proto3" json:"scheduled_event_token,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *NexusOperationParentData) Reset() {
@@ -71,11 +71,11 @@ func (x *NexusOperationParentData) GetScheduledEventId() int64 {
 	return 0
 }
 
-func (x *NexusOperationParentData) GetScheduledEventBatchId() int64 {
+func (x *NexusOperationParentData) GetScheduledEventToken() []byte {
 	if x != nil {
-		return x.ScheduledEventBatchId
+		return x.ScheduledEventToken
 	}
-	return 0
+	return nil
 }
 
 // NexusCancellationParentData contains workflow-specific data stored in a nexus cancellation's
@@ -129,10 +129,10 @@ var File_temporal_server_chasm_lib_workflow_proto_v1_state_proto protoreflect.Fi
 
 const file_temporal_server_chasm_lib_workflow_proto_v1_state_proto_rawDesc = "" +
 	"\n" +
-	"7temporal/server/chasm/lib/workflow/proto/v1/state.proto\x12+temporal.server.chasm.lib.workflow.proto.v1\"\x81\x01\n" +
+	"7temporal/server/chasm/lib/workflow/proto/v1/state.proto\x12+temporal.server.chasm.lib.workflow.proto.v1\"|\n" +
 	"\x18NexusOperationParentData\x12,\n" +
-	"\x12scheduled_event_id\x18\x01 \x01(\x03R\x10scheduledEventId\x127\n" +
-	"\x18scheduled_event_batch_id\x18\x02 \x01(\x03R\x15scheduledEventBatchId\"K\n" +
+	"\x12scheduled_event_id\x18\x01 \x01(\x03R\x10scheduledEventId\x122\n" +
+	"\x15scheduled_event_token\x18\x02 \x01(\fR\x13scheduledEventToken\"K\n" +
 	"\x1bNexusCancellationParentData\x12,\n" +
 	"\x12requested_event_id\x18\x01 \x01(\x03R\x10requestedEventIdBDZBgo.temporal.io/server/chasm/lib/workflow/gen/workflowpb;workflowpbb\x06proto3"
 

--- a/chasm/lib/workflow/nexus_commands_test.go
+++ b/chasm/lib/workflow/nexus_commands_test.go
@@ -593,8 +593,8 @@ func TestHandleScheduleCommand(t *testing.T) {
 		opParentData := &workflowpb.NexusOperationParentData{}
 		require.NoError(t, op.ParentData.UnmarshalTo(opParentData))
 		require.EqualExportedValues(t, &workflowpb.NexusOperationParentData{
-			ScheduledEventId:      event.EventId,
-			ScheduledEventBatchId: 1, // WorkflowTaskCompletedEventID
+			ScheduledEventId:    event.EventId,
+			ScheduledEventToken: []byte("test token"),
 		}, opParentData)
 		require.EqualExportedValues(t, userMetadata, event.UserMetadata)
 	})

--- a/chasm/lib/workflow/nexus_events.go
+++ b/chasm/lib/workflow/nexus_events.go
@@ -25,9 +25,14 @@ func (d ScheduledEventDefinition) Type() enumspb.EventType {
 func (d ScheduledEventDefinition) Apply(ctx chasm.MutableContext, wf *Workflow, event *historypb.HistoryEvent) error {
 	attrs := event.GetNexusOperationScheduledEventAttributes()
 
+	token, err := wf.GenerateEventLoadToken(event)
+	if err != nil {
+		return serviceerror.NewInternalf("failed to generate event load token: %v", err)
+	}
+
 	parentData, err := anypb.New(&workflowpb.NexusOperationParentData{
-		ScheduledEventId:      event.GetEventId(),
-		ScheduledEventBatchId: attrs.GetWorkflowTaskCompletedEventId(),
+		ScheduledEventId:    event.GetEventId(),
+		ScheduledEventToken: token,
 	})
 	if err != nil {
 		return serviceerror.NewInternalf("failed to marshal parent data: %v", err)

--- a/chasm/lib/workflow/nexus_methods.go
+++ b/chasm/lib/workflow/nexus_methods.go
@@ -10,14 +10,12 @@ import (
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
 	workflowpb "go.temporal.io/api/workflow/v1"
-	tokenspb "go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/nexusoperation"
 	nexusoperationpb "go.temporal.io/server/chasm/lib/nexusoperation/gen/nexusoperationpb/v1"
 	chasmworkflowpb "go.temporal.io/server/chasm/lib/workflow/gen/workflowpb/v1"
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexusrpc"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -239,17 +237,7 @@ func (w *Workflow) NexusOperationInvocationData(
 		)
 	}
 
-	token, err := proto.Marshal(&tokenspb.HistoryEventRef{
-		EventId:      parentData.GetScheduledEventId(),
-		EventBatchId: parentData.GetScheduledEventBatchId(),
-	})
-	if err != nil {
-		return nexusoperation.InvocationData{}, serviceerror.NewInternalf(
-			"failed to marshal history event ref: %v", err,
-		)
-	}
-
-	event, err := w.LoadHistoryEvent(ctx, token)
+	event, err := w.LoadHistoryEvent(ctx, parentData.GetScheduledEventToken())
 	if err != nil {
 		return nexusoperation.InvocationData{}, err
 	}

--- a/chasm/lib/workflow/proto/v1/state.proto
+++ b/chasm/lib/workflow/proto/v1/state.proto
@@ -9,8 +9,8 @@ option go_package = "go.temporal.io/server/chasm/lib/workflow/gen/workflowpb;wor
 message NexusOperationParentData {
   // Event ID of the NEXUS_OPERATION_SCHEDULED event.
   int64 scheduled_event_id = 1;
-  // Batch ID of the NEXUS_OPERATION_SCHEDULED event.
-  int64 scheduled_event_batch_id = 2;
+  // Token for loading the NEXUS_OPERATION_SCHEDULED event.
+  bytes scheduled_event_token = 2;
 }
 
 // NexusCancellationParentData contains workflow-specific data stored in a nexus cancellation's

--- a/chasm/ms_pointer.go
+++ b/chasm/ms_pointer.go
@@ -38,6 +38,10 @@ func (m MSPointer) HasAnyBufferedEvent(filter func(*historypb.HistoryEvent) bool
 	return m.backend.HasAnyBufferedEvent(filter)
 }
 
+func (m MSPointer) GenerateEventLoadToken(event *historypb.HistoryEvent) ([]byte, error) {
+	return m.backend.GenerateEventLoadToken(event)
+}
+
 // LoadHistoryEvent loads a history event from the underlying mutable state using the given token.
 func (m MSPointer) LoadHistoryEvent(ctx Context, token []byte) (*historypb.HistoryEvent, error) {
 	return m.backend.LoadHistoryEvent(ctx.goContext(), token)

--- a/chasm/node_backend_mock.go
+++ b/chasm/node_backend_mock.go
@@ -15,6 +15,8 @@ import (
 	"go.temporal.io/server/service/history/tasks"
 )
 
+var _ NodeBackend = (*MockNodeBackend)(nil)
+
 // MockNodeBackend is a lightweight manual mock for the NodeBackend interface.
 // Methods may be stubbed by assigning the corresponding Handle fields. Update call history is recorded in the struct
 // fields (thread-safe).
@@ -32,6 +34,7 @@ type MockNodeBackend struct {
 	HandleGetNexusCompletion          func(ctx context.Context, requestID string) (nexusrpc.CompleteOperationOptions, error)
 	HandleAddHistoryEvent             func(t enumspb.EventType, setAttributes func(*historypb.HistoryEvent)) *historypb.HistoryEvent
 	HandleLoadHistoryEvent            func(ctx context.Context, token []byte) (*historypb.HistoryEvent, error)
+	HandleGenerateEventLoadToken      func(event *historypb.HistoryEvent) ([]byte, error)
 	HandleHasAnyBufferedEvent         func(filter func(*historypb.HistoryEvent) bool) bool
 	HandleGetNamespaceEntry           func() *namespace.Namespace
 	HandleEndpointRegistry            func() EndpointRegistry
@@ -191,6 +194,13 @@ func (m *MockNodeBackend) AddHistoryEvent(t enumspb.EventType, setAttributes fun
 		return m.HandleAddHistoryEvent(t, setAttributes)
 	}
 	return nil
+}
+
+func (m *MockNodeBackend) GenerateEventLoadToken(event *historypb.HistoryEvent) ([]byte, error) {
+	if m.HandleGenerateEventLoadToken != nil {
+		return m.HandleGenerateEventLoadToken(event)
+	}
+	return []byte("test token"), nil
 }
 
 func (m *MockNodeBackend) LoadHistoryEvent(ctx context.Context, token []byte) (*historypb.HistoryEvent, error) {

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -207,6 +207,7 @@ type (
 		GetWorkflowKey() definition.WorkflowKey
 		AddTasks(...tasks.Task)
 		AddHistoryEvent(t enumspb.EventType, setAttributes func(*historypb.HistoryEvent)) *historypb.HistoryEvent
+		GenerateEventLoadToken(event *historypb.HistoryEvent) ([]byte, error)
 		LoadHistoryEvent(ctx context.Context, token []byte) (*historypb.HistoryEvent, error)
 		HasAnyBufferedEvent(filter func(*historypb.HistoryEvent) bool) bool
 		DeleteCHASMPureTasks(maxScheduledTime time.Time)

--- a/service/history/interfaces/mutable_state.go
+++ b/service/history/interfaces/mutable_state.go
@@ -43,6 +43,7 @@ type (
 
 	MutableState interface {
 		AddHistoryEvent(t enumspb.EventType, setAttributes func(*historypb.HistoryEvent)) *historypb.HistoryEvent
+		GenerateEventLoadToken(event *historypb.HistoryEvent) ([]byte, error)
 		LoadHistoryEvent(ctx context.Context, token []byte) (*historypb.HistoryEvent, error)
 
 		AddActivityTaskCancelRequestedEvent(int64, int64, string) (*historypb.HistoryEvent, *persistencespb.ActivityInfo, error)

--- a/service/history/interfaces/mutable_state_mock.go
+++ b/service/history/interfaces/mutable_state_mock.go
@@ -1972,6 +1972,21 @@ func (mr *MockMutableStateMockRecorder) FlushBufferedEvents() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlushBufferedEvents", reflect.TypeOf((*MockMutableState)(nil).FlushBufferedEvents))
 }
 
+// GenerateEventLoadToken mocks base method.
+func (m *MockMutableState) GenerateEventLoadToken(event *history.HistoryEvent) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GenerateEventLoadToken", event)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GenerateEventLoadToken indicates an expected call of GenerateEventLoadToken.
+func (mr *MockMutableStateMockRecorder) GenerateEventLoadToken(event any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateEventLoadToken", reflect.TypeOf((*MockMutableState)(nil).GenerateEventLoadToken), event)
+}
+
 // GenerateMigrationTasks mocks base method.
 func (m *MockMutableState) GenerateMigrationTasks(targetClusters []string) ([]tasks.Task, int64, error) {
 	m.ctrl.T.Helper()

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -1307,6 +1307,37 @@ func (ms *MutableStateImpl) AddHistoryEvent(t enumspb.EventType, setAttributes f
 	return event
 }
 
+// GenerateEventLoadToken generates a token for loading a history event at a later time. The token encodes the event ID
+// and the batch ID (if applicable) which can be used to load the event from the events cache.
+func (ms *MutableStateImpl) GenerateEventLoadToken(event *historypb.HistoryEvent) ([]byte, error) {
+	attrs := reflect.ValueOf(event.Attributes).Elem()
+
+	// Attributes is always a struct with a single field (e.g: HistoryEvent_NexusOperationScheduledEventAttributes)
+	if attrs.Kind() != reflect.Struct || attrs.NumField() != 1 {
+		return nil, serviceerror.NewInternalf("got an invalid event structure: %v", event.EventType)
+	}
+
+	f := attrs.Field(0).Interface()
+
+	var eventBatchID int64
+	if getter, ok := f.(interface{ GetWorkflowTaskCompletedEventId() int64 }); ok {
+		// Command-Events always have a WorkflowTaskCompletedEventId field that is equal to the batch ID.
+		eventBatchID = getter.GetWorkflowTaskCompletedEventId()
+	} else if attrs := event.GetWorkflowExecutionStartedEventAttributes(); attrs != nil {
+		// WFEStarted is always stored in the first batch of events.
+		eventBatchID = 1
+	} else {
+		// By default, events aren't referenceable as they may end up buffered.
+		// This limitation may be relaxed later and the platform would need a way to fix references to buffered events.
+		return nil, serviceerror.NewInternalf("cannot reference event: %v", event.EventType)
+	}
+	ref := &tokenspb.HistoryEventRef{
+		EventId:      event.EventId,
+		EventBatchId: eventBatchID,
+	}
+	return proto.Marshal(ref)
+}
+
 func (ms *MutableStateImpl) LoadHistoryEvent(ctx context.Context, token []byte) (*historypb.HistoryEvent, error) {
 	ref := &tokenspb.HistoryEventRef{}
 	err := proto.Unmarshal(token, ref)


### PR DESCRIPTION
## What changed?

Added a method to generate an event load token in:
- `MutableState`
- `MutableStateImpl`
- `chasm.NodeBackend`
- `chasm.MSPointer`
- `workflow.Workflow`

## Why?

This was pointed out during the initial implementation but was not addressed. The point of having a token is to avoid exposing the persistence concept of event batches to the application.
