### PR TITLE
Cherry-pick: Bump defaultCliVersion to 1.7.0 (#10126) for v1.30.4.1

### DIFF
--- a/.github/actions/build-docker-images/scripts/main.go
+++ b/.github/actions/build-docker-images/scripts/main.go
@@ -14,7 +14,7 @@ import (
 var validArchs = []string{"amd64", "arm64"}
 
 // defaultCliVersion should be updated to the latest cli version
-const defaultCliVersion = "1.6.1"
+const defaultCliVersion = "1.7.0"
 
 func main() {
 	if len(os.Args) < 2 {


### PR DESCRIPTION
## What
Cherry-picks #10126 from main onto `release/v1.30.x` as part of the v1.30.4.1 security image release.

## Why
CLI v1.6.1 transitively pulls in CRITICAL/HIGH CVEs (pgx v5.7.4, grpc v1.72.2, Go 1.26.0 stdlib, go-jose, otel/sdk, etc.). CLI v1.7.0 pins `go.temporal.io/server v1.31.0`, ships built with Go 1.26.2, and reports clean from `govulncheck`.

Original PR: #10126