### PR TITLE
Port channel send/wait helpers to TestEnv 

### DIFF
--- a/tests/activity_api_pause_test.go
+++ b/tests/activity_api_pause_test.go
@@ -62,7 +62,7 @@ func (s *ActivityAPIPauseClientTestSuite) TestActivityPauseApi_WhileRunning() {
 	activityFunction := func() (string, error) {
 		startedActivityCount.Add(1)
 		if startedActivityCount.Load() == 1 {
-			env.WaitForChannel(ctx, activityPausedCn)
+			env.WaitForChannel(activityPausedCn)
 			return "", activityErr
 		}
 		return "done!", nil
@@ -115,7 +115,7 @@ func (s *ActivityAPIPauseClientTestSuite) TestActivityPauseApi_WhileRunning() {
 	}, 5*time.Second, 500*time.Millisecond)
 
 	// unblock the activity
-	env.SendToChannel(ctx, activityPausedCn)
+	env.SendToChannel(activityPausedCn)
 	// make sure activity is paused on server and completed on the worker
 	s.EventuallyWithT(func(t *assert.CollectT) {
 		description, err := env.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
@@ -208,7 +208,7 @@ func (s *ActivityAPIPauseClientTestSuite) TestActivityPauseApi_IncreaseAttemptsO
 	activityFunction := func() (string, error) {
 		startedActivityCount.Add(1)
 		if startedActivityCount.Load() == 1 {
-			env.WaitForChannel(ctx, activityPausedCn)
+			env.WaitForChannel(activityPausedCn)
 			return "", activityErr
 		}
 		if shouldSucceed.Load() {
@@ -264,7 +264,7 @@ func (s *ActivityAPIPauseClientTestSuite) TestActivityPauseApi_IncreaseAttemptsO
 	}, 5*time.Second, 500*time.Millisecond)
 
 	// End the activity
-	env.SendToChannel(ctx, activityPausedCn)
+	env.SendToChannel(activityPausedCn)
 
 	s.EventuallyWithT(func(t *assert.CollectT) {
 		description, err := env.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
@@ -559,7 +559,7 @@ func (s *ActivityAPIPauseClientTestSuite) TestActivityPauseApi_WithReset() {
 			activityErr := errors.New("bad-luck-please-retry")
 			return "", activityErr
 		}
-		env.WaitForChannel(ctx, activityCompleteCn)
+		env.WaitForChannel(activityCompleteCn)
 		return "done!", nil
 	}
 
@@ -632,7 +632,7 @@ func (s *ActivityAPIPauseClientTestSuite) TestActivityPauseApi_WithReset() {
 	}, 5*time.Second, 100*time.Millisecond)
 
 	// let activity finish
-	env.SendToChannel(ctx, activityCompleteCn)
+	env.SendToChannel(activityCompleteCn)
 
 	// wait for workflow to finish
 	var out string

--- a/tests/activity_api_reset_test.go
+++ b/tests/activity_api_reset_test.go
@@ -87,7 +87,7 @@ func (s *ActivityApiResetClientTestSuite) TestActivityResetApi_AfterRetry() {
 			return "", activityErr
 		}
 
-		env.WaitForChannel(ctx, activityCompleteCh)
+		env.WaitForChannel(activityCompleteCh)
 		return "done!", nil
 	}
 
@@ -160,7 +160,7 @@ func (s *ActivityApiResetClientTestSuite) TestActivityResetApi_WhileRunning() {
 	var startedActivityCount atomic.Int32
 	activityFunction := func() (string, error) {
 		startedActivityCount.Add(1)
-		env.WaitForChannel(ctx, activityCompleteCh)
+		env.WaitForChannel(activityCompleteCh)
 		return "done!", nil
 	}
 
@@ -242,7 +242,7 @@ func (s *ActivityApiResetClientTestSuite) TestActivityResetApi_InRetry() {
 			return "", activityErr
 		}
 
-		env.WaitForChannel(ctx, activityCompleteCh)
+		env.WaitForChannel(activityCompleteCh)
 		return "done!", nil
 	}
 
@@ -322,7 +322,7 @@ func (s *ActivityApiResetClientTestSuite) TestActivityResetApi_KeepPaused() {
 			return "", activityErr
 		}
 
-		env.WaitForChannel(ctx, activityCompleteCh)
+		env.WaitForChannel(activityCompleteCh)
 		return "done!", nil
 	}
 
@@ -462,7 +462,7 @@ func (s *ActivityApiResetClientTestSuite) TestActivityReset_HeartbeatDetails() {
 			return "", errors.New("bad-luck-please-retry")
 		}
 		// not the first iteration
-		env.WaitForChannel(ctx, activityCompleteCh)
+		env.WaitForChannel(activityCompleteCh)
 		for activityShouldFinish.Load() == false {
 			activity.RecordHeartbeat(ctx, "second")
 			time.Sleep(time.Second) //nolint:forbidigo

--- a/tests/activity_api_update_test.go
+++ b/tests/activity_api_update_test.go
@@ -82,7 +82,7 @@ func (s *ActivityAPIUpdateClientTestSuite) TestActivityUpdateApi_ChangeRetryInte
 			return "", activityErr
 		}
 
-		env.WaitForChannel(ctx, activityUpdated)
+		env.WaitForChannel(activityUpdated)
 		return "done!", nil
 	}
 
@@ -327,7 +327,7 @@ func (s *ActivityAPIUpdateClientTestSuite) TestActivityUpdateApi_ResetDefaultOpt
 			return "", activityErr
 		}
 
-		env.WaitForChannel(ctx, activityUpdated)
+		env.WaitForChannel(activityUpdated)
 		return "done!", nil
 	}
 

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -1408,8 +1408,8 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelBeforeStarted_Cancelati
 		require.NotNil(t, desc.PendingNexusOperations[0].CancellationInfo)
 	}, time.Second*10, time.Millisecond*100)
 
-	env.SendToChannel(ctx, canStartCh)
-	env.WaitForChannel(ctx, cancelSentCh)
+	env.SendToChannel(canStartCh)
+	env.WaitForChannel(cancelSentCh)
 
 	// Terminate the workflow for good measure.
 	err = env.SdkClient().TerminateWorkflow(ctx, run.GetID(), run.GetRunID(), "test")

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -693,6 +693,7 @@ func (s *FunctionalTestBase) RunTestWithMatchingBehavior(subtest func()) {
 	}
 }
 
+// Deprecated: use (*TestEnv).WaitForChannel instead.
 func (s *FunctionalTestBase) WaitForChannel(ctx context.Context, ch chan struct{}) {
 	s.T().Helper()
 	select {
@@ -702,6 +703,7 @@ func (s *FunctionalTestBase) WaitForChannel(ctx context.Context, ch chan struct{
 	}
 }
 
+// Deprecated: use (*TestEnv).SendToChannel instead.
 func (s *FunctionalTestBase) SendToChannel(ctx context.Context, ch chan struct{}) {
 	s.T().Helper()
 	select {

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -310,6 +310,26 @@ func (e *TestEnv) Context() context.Context {
 	return e.ctx
 }
 
+// WaitForChannel waits for ch to receive using the TestEnv context.
+func (e *TestEnv) WaitForChannel(ch <-chan struct{}) {
+	e.t.Helper()
+	select {
+	case <-ch:
+	case <-e.ctx.Done():
+		e.FailNow("context timeout while waiting for channel")
+	}
+}
+
+// SendToChannel sends to ch using the TestEnv context.
+func (e *TestEnv) SendToChannel(ch chan<- struct{}) {
+	e.t.Helper()
+	select {
+	case ch <- struct{}{}:
+	case <-e.ctx.Done():
+		e.FailNow("context timeout while sending to channel")
+	}
+}
+
 // SdkClient returns the SDK client. It is lazily initialized on the first call.
 func (e *TestEnv) SdkClient() sdkclient.Client {
 	e.sdkClientOnce.Do(func() {


### PR DESCRIPTION
## What changed?

Port `WaitForChannel` and `SendToChannel` to TestEnv.

## Why?

Safer / simpler.

