### PR TITLE
Use EventuallyWithT in versioning tests

### DIFF
--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -862,7 +862,7 @@ func (s *Versioning3Suite) TestUnpinnedWorkflow_SuccessfulUpdate_TransitionsToNe
 4 WorkflowTaskCompleted
 5 WorkflowTaskScheduled // Was speculative WT...
 6 WorkflowTaskStarted
-7 WorkflowTaskCompleted // ...and events were written to the history when WT completes.  
+7 WorkflowTaskCompleted // ...and events were written to the history when WT completes.
 8 WorkflowExecutionUpdateAccepted {"AcceptedRequestSequencingEventId": 5} // WTScheduled event which delivered update to the worker.
 9 WorkflowExecutionUpdateCompleted {"AcceptedEventId": 8}
 `, events)
@@ -3507,19 +3507,14 @@ func (s *Versioning3Suite) TestSyncDeploymentUserDataWithRoutingConfig_Update() 
 func (s *Versioning3Suite) setCurrentDeployment(tv *testvars.TestVars) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		req := &workflowservice.SetWorkerDeploymentCurrentVersionRequest{
 			Namespace:      s.Namespace().String(),
 			DeploymentName: tv.DeploymentSeries(),
 		}
 		req.BuildId = tv.BuildID()
 		_, err := s.FrontendClient().SetWorkerDeploymentCurrentVersion(ctx, req)
-		var notFound *serviceerror.NotFound
-		if errors.As(err, &notFound) || (err != nil && strings.Contains(err.Error(), serviceerror.NewFailedPreconditionf(workerdeployment.ErrCurrentVersionDoesNotHaveAllTaskQueues, tv.DeploymentVersionStringV32()).Error())) {
-			return false
-		}
-		s.NoError(err)
-		return err == nil
+		require.NoError(t, err)
 	}, 60*time.Second, 500*time.Millisecond)
 
 	// Wait for propagation to complete since we have tests using async entity workflows to set the current version
@@ -3552,16 +3547,12 @@ func (s *Versioning3Suite) pollUntilRegistered(ctx context.Context, tv *testvars
 		}()
 	}
 	// Wait until the version is visible and all requested task queue types are registered.
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		resp, err := s.FrontendClient().DescribeWorkerDeploymentVersion(ctx, &workflowservice.DescribeWorkerDeploymentVersionRequest{
 			Namespace: s.Namespace().String(),
 			Version:   tv.DeploymentVersionString(),
 		})
-		var notFound *serviceerror.NotFound
-		if errors.As(err, &notFound) {
-			return false
-		}
-		s.NoError(err)
+		require.NoError(t, err)
 		tqName := tv.TaskQueue().GetName()
 		for _, tqType := range tqTypes {
 			found := false
@@ -3572,10 +3563,10 @@ func (s *Versioning3Suite) pollUntilRegistered(ctx context.Context, tv *testvars
 				}
 			}
 			if !found {
-				return false
+				require.True(t, found)
+				return
 			}
 		}
-		return true
 	}, 30*time.Second, 100*time.Millisecond)
 	cancel()
 }
@@ -3583,18 +3574,13 @@ func (s *Versioning3Suite) pollUntilRegistered(ctx context.Context, tv *testvars
 func (s *Versioning3Suite) unsetCurrentDeployment(tv *testvars.TestVars) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		req := &workflowservice.SetWorkerDeploymentCurrentVersionRequest{
 			Namespace:      s.Namespace().String(),
 			DeploymentName: tv.DeploymentSeries(),
 		}
 		_, err := s.FrontendClient().SetWorkerDeploymentCurrentVersion(ctx, req)
-		var notFound *serviceerror.NotFound
-		if errors.As(err, &notFound) {
-			return false
-		}
-		s.NoError(err)
-		return err == nil
+		require.NoError(t, err)
 	}, 60*time.Second, 500*time.Millisecond)
 
 	// Wait for propagation to complete since we have tests using async entity workflows to set the current version
@@ -3613,7 +3599,7 @@ func (s *Versioning3Suite) setRampingDeployment(
 		bid = ""
 	}
 
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		req := &workflowservice.SetWorkerDeploymentRampingVersionRequest{
 			Namespace:      s.Namespace().String(),
 			DeploymentName: tv.DeploymentSeries(),
@@ -3621,12 +3607,7 @@ func (s *Versioning3Suite) setRampingDeployment(
 		}
 		req.BuildId = bid
 		_, err := s.FrontendClient().SetWorkerDeploymentRampingVersion(ctx, req)
-		var notFound *serviceerror.NotFound
-		if errors.As(err, &notFound) || (err != nil && strings.Contains(err.Error(), serviceerror.NewFailedPreconditionf(workerdeployment.ErrRampingVersionDoesNotHaveAllTaskQueues, tv.DeploymentVersionStringV32()).Error())) {
-			return false
-		}
-		s.NoError(err)
-		return err == nil
+		require.NoError(t, err)
 	}, 60*time.Second, 500*time.Millisecond)
 
 	// Wait for propagation to complete since we have tests using async entity workflows to set the current version
@@ -3635,13 +3616,13 @@ func (s *Versioning3Suite) setRampingDeployment(
 
 func (s *Versioning3Suite) waitForDeploymentDataPropagationQueryWorkerDeployment(tv *testvars.TestVars) {
 	if s.deploymentWorkflowVersion == workerdeployment.AsyncSetCurrentAndRamping {
-		s.Eventually(func() bool {
+		s.EventuallyWithT(func(t *assert.CollectT) {
 			resp, err := s.FrontendClient().DescribeWorkerDeployment(context.Background(), &workflowservice.DescribeWorkerDeploymentRequest{
 				Namespace:      s.Namespace().String(),
 				DeploymentName: tv.DeploymentSeries(),
 			})
-			s.NoError(err)
-			return resp.GetWorkerDeploymentInfo().GetRoutingConfigUpdateState() == enumspb.ROUTING_CONFIG_UPDATE_STATE_COMPLETED
+			require.NoError(t, err)
+			require.Equal(t, enumspb.ROUTING_CONFIG_UPDATE_STATE_COMPLETED, resp.GetWorkerDeploymentInfo().GetRoutingConfigUpdateState())
 		}, 10*time.Second, 100*time.Millisecond)
 	}
 }
@@ -3764,15 +3745,16 @@ func (s *Versioning3Suite) rollbackTaskQueueToVersion(
 	}}, nil, tqTypeWf)
 
 	// Verify that the rollback propagated to all partitions
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		ms, err := s.GetTestCluster().MatchingClient().GetTaskQueueUserData(context.Background(), &matchingservice.GetTaskQueueUserDataRequest{
 			NamespaceId:   s.NamespaceID().String(),
 			TaskQueue:     tv.TaskQueue().GetName(),
 			TaskQueueType: tqTypeWf,
 		})
-		s.NoError(err)
+		require.NoError(t, err)
 		current, currentRevisionNumber, _, _, _, _, _, _ := worker_versioning.CalculateTaskQueueVersioningInfo(ms.GetUserData().GetData().GetPerType()[int32(tqTypeWf)].GetDeploymentData())
-		return current.GetBuildId() == tv.DeploymentVersion().GetBuildId() && currentRevisionNumber == 0
+		require.Equal(t, tv.DeploymentVersion().GetBuildId(), current.GetBuildId())
+		require.Equal(t, int64(0), currentRevisionNumber)
 	}, 10*time.Second, 100*time.Millisecond)
 }
 
@@ -4868,21 +4850,14 @@ func (s *Versioning3Suite) TestChildStartsWithParentRevision_SameTQ_TQAhead() {
 	s.NoError(s.SdkClient().SignalWorkflow(ctx, run.GetID(), run.GetRunID(), "startChild", nil))
 
 	// Verify that the child started and completed on the v2 worker.
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		desc, err := s.SdkClient().DescribeWorkflowExecution(ctx, tvChild.WorkflowID(), "")
-		if err != nil {
-			return false
-		}
+		require.NoError(t, err)
 		execInfo := desc.GetWorkflowExecutionInfo()
 
 		// Verify that the child workflow started and completed on the v1 worker
-		if execInfo.GetVersioningInfo().GetDeploymentVersion().GetBuildId() != tv2.BuildID() {
-			return false
-		}
-		if execInfo.GetStatus() != enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED {
-			return false
-		}
-		return true
+		require.Equal(t, tv2.BuildID(), execInfo.GetVersioningInfo().GetDeploymentVersion().GetBuildId())
+		require.Equal(t, enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, execInfo.GetStatus())
 	}, 10*time.Second, 100*time.Millisecond)
 
 	// Verify that the parent workflow completed successfully. This shall only be possible if the child workflow
@@ -4980,12 +4955,10 @@ func (s *Versioning3Suite) TestChildStartsWithParentRevision_SameTQ_TQLags() {
 	s.NoError(err)
 
 	// Verify that the parent workflow has started on the v1 worker
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		desc, err := s.SdkClient().DescribeWorkflowExecution(ctx, tvParent.WorkflowID(), "")
-		if err != nil {
-			return false
-		}
-		return desc.GetWorkflowExecutionInfo().GetVersioningInfo().GetDeploymentVersion().GetBuildId() == tvParent.BuildID()
+		require.NoError(t, err)
+		require.Equal(t, tvParent.BuildID(), desc.GetWorkflowExecutionInfo().GetVersioningInfo().GetDeploymentVersion().GetBuildId())
 	}, 10*time.Second, 100*time.Millisecond)
 
 	// Roll back the child TQ routing-config revision to simulate Routing Config lag in matching partitions (set v0 as current with older revision)
@@ -5001,21 +4974,14 @@ func (s *Versioning3Suite) TestChildStartsWithParentRevision_SameTQ_TQLags() {
 	s.NoError(s.SdkClient().SignalWorkflow(ctx, run.GetID(), run.GetRunID(), "startChild", nil))
 
 	// Verify that the child started and completed on the v1 worker.
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		desc, err := s.SdkClient().DescribeWorkflowExecution(ctx, tvChild.WorkflowID(), "")
-		if err != nil {
-			return false
-		}
+		require.NoError(t, err)
 		execInfo := desc.GetWorkflowExecutionInfo()
 
 		// Verify that the child workflow started and completed on the v1 worker
-		if execInfo.GetVersioningInfo().GetDeploymentVersion().GetBuildId() != tvChild.BuildID() {
-			return false
-		}
-		if execInfo.GetStatus() != enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED {
-			return false
-		}
-		return true
+		require.Equal(t, tvChild.BuildID(), execInfo.GetVersioningInfo().GetDeploymentVersion().GetBuildId())
+		require.Equal(t, enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, execInfo.GetStatus())
 	}, 10*time.Second, 100*time.Millisecond)
 
 	// Verify that the parent workflow completed successfully. This shall only be possible if the child workflow
@@ -5088,21 +5054,13 @@ func (s *Versioning3Suite) TestChildStartsWithNoInheritedAutoUpgradeInfo_CrossTQ
 	s.NoError(s.SdkClient().SignalWorkflow(ctx, run.GetID(), run.GetRunID(), "startChild", nil))
 
 	// Verify that the child workflow started and completed on it's worker, which shall verify that no AutoUpgradeInheritedInfo was inherited.
-	s.Eventually(func() bool {
-		s.Eventually(func() bool {
-			desc, err := s.SdkClient().DescribeWorkflowExecution(ctx, tvChild.WorkflowID(), "")
-			if err != nil {
-				return false
-			}
-			execInfo := desc.GetWorkflowExecutionInfo()
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		desc, err := s.SdkClient().DescribeWorkflowExecution(ctx, tvChild.WorkflowID(), "")
+		require.NoError(t, err)
+		execInfo := desc.GetWorkflowExecutionInfo()
 
-			// Verify that the new run starts on the v1 worker
-			if execInfo.GetVersioningInfo().GetDeploymentVersion().GetBuildId() != tvChild.BuildID() {
-				return false
-			}
-			return true
-		}, 10*time.Second, 100*time.Millisecond)
-		return true
+		// Verify that the new run starts on the v1 worker
+		require.Equal(t, tvChild.BuildID(), execInfo.GetVersioningInfo().GetDeploymentVersion().GetBuildId())
 	}, 10*time.Second, 100*time.Millisecond)
 
 	// Verify that the parent workflow completed successfully.
@@ -5149,12 +5107,10 @@ func (s *Versioning3Suite) TestContinueAsNewOfAutoUpgradeWorkflow_RevisionNumber
 	s.NoError(err)
 
 	// Ensure the workflow has started on the v1 worker
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		desc, err := s.SdkClient().DescribeWorkflowExecution(ctx, tv1.WorkflowID(), "")
-		if err != nil {
-			return false
-		}
-		return desc.GetWorkflowExecutionInfo().GetVersioningInfo().GetDeploymentVersion().GetBuildId() == tv1.BuildID()
+		require.NoError(t, err)
+		require.Equal(t, tv1.BuildID(), desc.GetWorkflowExecutionInfo().GetVersioningInfo().GetDeploymentVersion().GetBuildId())
 	}, 10*time.Second, 100*time.Millisecond)
 
 	// Rollback the TaskQueueUserData to simulate task queue partition lag
@@ -5170,27 +5126,18 @@ func (s *Versioning3Suite) TestContinueAsNewOfAutoUpgradeWorkflow_RevisionNumber
 
 	// Wait for the new run to start
 	var newRunID string
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		desc, err := s.SdkClient().DescribeWorkflowExecution(ctx, tv1.WorkflowID(), "")
-		if err != nil {
-			return false
-		}
+		require.NoError(t, err)
 		execInfo := desc.GetWorkflowExecutionInfo()
 
 		// Verify that the workflow truly CAN'ed and started a new run
-		if execInfo.GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED {
-			newRunID = execInfo.GetExecution().GetRunId()
-			if newRunID == run.GetRunID() {
-				return false
-			}
-		}
+		require.Equal(t, enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, execInfo.GetStatus())
+		newRunID = execInfo.GetExecution().GetRunId()
+		require.NotEqual(t, run.GetRunID(), newRunID)
 
 		// Verify that the new run starts on the v1 worker
-		if execInfo.GetVersioningInfo().GetDeploymentVersion().GetBuildId() != tv1.BuildID() {
-			return false
-		}
-
-		return true
+		require.Equal(t, tv1.BuildID(), execInfo.GetVersioningInfo().GetDeploymentVersion().GetBuildId())
 	}, 10*time.Second, 100*time.Millisecond)
 
 	// Verify that the workflow completed successfully on v1
@@ -5331,13 +5278,11 @@ func (s *Versioning3Suite) testRetryNoBounceBack(testContinueAsNew bool, testChi
 		s.NoError(err)
 
 		// Wait for child workflow to be created and executing on v1
-		s.Eventually(func() bool {
+		s.EventuallyWithT(func(t *assert.CollectT) {
 			desc, err := s.SdkClient().DescribeWorkflowExecution(ctx, childWorkflowID, "")
-			if err != nil {
-				return false
-			}
+			require.NoError(t, err)
 			runIDBeforeRetry = desc.GetWorkflowExecutionInfo().GetExecution().GetRunId()
-			return desc.GetWorkflowExecutionInfo().GetVersioningInfo().GetDeploymentVersion().GetBuildId() == tv1.BuildID()
+			require.Equal(t, tv1.BuildID(), desc.GetWorkflowExecutionInfo().GetVersioningInfo().GetDeploymentVersion().GetBuildId())
 		}, 10*time.Second, 100*time.Millisecond)
 
 		wfID = childWorkflowID
@@ -5360,29 +5305,21 @@ func (s *Versioning3Suite) testRetryNoBounceBack(testContinueAsNew bool, testChi
 
 		if testContinueAsNew {
 			// Wait for ContinueAsNew to happen
-			s.Eventually(func() bool {
+			s.EventuallyWithT(func(t *assert.CollectT) {
 				desc, err := s.SdkClient().DescribeWorkflowExecution(ctx, wfID, "")
-				s.NoError(err)
-				if err != nil {
-					return false
-				}
+				require.NoError(t, err)
 				// After CAN, the run ID changes and we should see execution on v1
-				if desc.GetWorkflowExecutionInfo().GetExecution().GetRunId() != run0.GetRunID() {
-					runIDBeforeRetry = desc.GetWorkflowExecutionInfo().GetExecution().GetRunId()
-					return desc.GetWorkflowExecutionInfo().GetVersioningInfo().GetDeploymentVersion().GetBuildId() == tv1.BuildID()
-				}
-				return false
+				runIDBeforeRetry = desc.GetWorkflowExecutionInfo().GetExecution().GetRunId()
+				require.NotEqual(t, run0.GetRunID(), runIDBeforeRetry)
+				require.Equal(t, tv1.BuildID(), desc.GetWorkflowExecutionInfo().GetVersioningInfo().GetDeploymentVersion().GetBuildId())
 			}, 10*time.Second, 100*time.Millisecond)
 		} else {
 			runIDBeforeRetry = run0.GetRunID()
 			// Ensure initial run is executing on v1.
-			s.Eventually(func() bool {
+			s.EventuallyWithT(func(t *assert.CollectT) {
 				desc, err := s.SdkClient().DescribeWorkflowExecution(ctx, wfID, runIDBeforeRetry)
-				s.NoError(err)
-				if err != nil {
-					return false
-				}
-				return desc.GetWorkflowExecutionInfo().GetVersioningInfo().GetDeploymentVersion().GetBuildId() == tv1.BuildID()
+				require.NoError(t, err)
+				require.Equal(t, tv1.BuildID(), desc.GetWorkflowExecutionInfo().GetVersioningInfo().GetDeploymentVersion().GetBuildId())
 			}, 10*time.Second, 100*time.Millisecond)
 		}
 	}
@@ -5396,44 +5333,37 @@ func (s *Versioning3Suite) testRetryNoBounceBack(testContinueAsNew bool, testChi
 	go s.idlePollWorkflow(idlePollerCtx, tv0, true, 10*time.Second, "v0 poller should not receive a task")
 
 	// Verify that the rollback propagated to all partitions
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		ms, err := s.GetTestCluster().MatchingClient().GetTaskQueueUserData(context.Background(), &matchingservice.GetTaskQueueUserDataRequest{
 			NamespaceId:   s.NamespaceID().String(),
 			TaskQueue:     tv0.TaskQueue().GetName(),
 			TaskQueueType: tqTypeWf,
 		})
-		s.NoError(err)
+		require.NoError(t, err)
 
 		current, currentRevisionNumber, _, _, _, _, _, _ := worker_versioning.CalculateTaskQueueVersioningInfo(ms.GetUserData().GetData().GetPerType()[int32(tqTypeWf)].GetDeploymentData())
-		return current.GetBuildId() == tv0.DeploymentVersion().GetBuildId() && currentRevisionNumber == 0
+		require.Equal(t, tv0.DeploymentVersion().GetBuildId(), current.GetBuildId())
+		require.Equal(t, int64(0), currentRevisionNumber)
 	}, 10*time.Second, 100*time.Millisecond)
 
 	// Trigger failure of the run to cause retry.
 	s.NoError(s.SdkClient().SignalWorkflow(ctx, wfID, runIDBeforeRetry, "proceed", nil))
 
 	// Wait for run to fail.
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		desc, err := s.SdkClient().DescribeWorkflow(ctx, wfID, runIDBeforeRetry)
-		s.NoError(err)
-		if err != nil {
-			return false
-		}
-		return desc.Status == enumspb.WORKFLOW_EXECUTION_STATUS_FAILED
+		require.NoError(t, err)
+		require.Equal(t, enumspb.WORKFLOW_EXECUTION_STATUS_FAILED, desc.Status)
 	}, 10*time.Second, 100*time.Millisecond)
 
 	// Verify that retry run is still on v1 (didn't bounce back to v0)
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		desc, err := s.SdkClient().DescribeWorkflowExecution(ctx, wfID, "")
-		s.NoError(err)
-		if err != nil {
-			return false
-		}
+		require.NoError(t, err)
 		// After retry, there should be a new run
-		if desc.GetWorkflowExecutionInfo().GetExecution().GetRunId() != runIDBeforeRetry {
-			// Verify workflow (parent or child) is still on v1
-			return desc.GetWorkflowExecutionInfo().GetVersioningInfo().GetDeploymentVersion().GetBuildId() == tv1.BuildID()
-		}
-		return false
+		require.NotEqual(t, runIDBeforeRetry, desc.GetWorkflowExecutionInfo().GetExecution().GetRunId())
+		// Verify workflow (parent or child) is still on v1
+		require.Equal(t, tv1.BuildID(), desc.GetWorkflowExecutionInfo().GetVersioningInfo().GetDeploymentVersion().GetBuildId())
 	}, 10*time.Second, 100*time.Millisecond)
 
 }
@@ -5455,15 +5385,15 @@ func (s *Versioning3Suite) TestCheckTaskQueueVersionMembership() {
 	tv1 := testvars.New(s).WithBuildIDNumber(1)
 
 	// No version exists in the task queue's userData as of now
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		resp, err := s.GetTestCluster().MatchingClient().CheckTaskQueueVersionMembership(context.Background(), &matchingservice.CheckTaskQueueVersionMembershipRequest{
 			NamespaceId:   s.NamespaceID().String(),
 			TaskQueue:     tv1.TaskQueue().GetName(),
 			TaskQueueType: tqTypeWf,
 			Version:       worker_versioning.DeploymentVersionFromDeployment(tv1.Deployment()),
 		})
-		s.NoError(err)
-		return !resp.GetIsMember() // the check should pass if no version is present
+		require.NoError(t, err)
+		require.False(t, resp.GetIsMember()) // the check should pass if no version is present
 	}, 10*time.Second, 100*time.Millisecond)
 
 	// Start v1 worker which shall register the version in the task queue
@@ -5477,15 +5407,15 @@ func (s *Versioning3Suite) TestCheckTaskQueueVersionMembership() {
 	defer w1.Stop()
 
 	// The version should eventually show up in the task queue's user data
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		resp, err := s.GetTestCluster().MatchingClient().CheckTaskQueueVersionMembership(context.Background(), &matchingservice.CheckTaskQueueVersionMembershipRequest{
 			NamespaceId:   s.NamespaceID().String(),
 			TaskQueue:     tv1.TaskQueue().GetName(),
 			TaskQueueType: tqTypeWf,
 			Version:       worker_versioning.DeploymentVersionFromDeployment(tv1.Deployment()),
 		})
-		s.NoError(err)
-		return resp.GetIsMember()
+		require.NoError(t, err)
+		require.True(t, resp.GetIsMember())
 	}, 10*time.Second, 100*time.Millisecond)
 }
 
@@ -5667,12 +5597,10 @@ func (s *Versioning3Suite) TestActivityRetryAutoUpgradeDuringBackoff() {
 	s.NoError(err)
 
 	// Wait for the workflow to start on v1
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		desc, err := s.SdkClient().DescribeWorkflowExecution(ctx, run.GetID(), "")
-		if err != nil {
-			return false
-		}
-		return desc.GetWorkflowExecutionInfo().GetVersioningInfo().GetDeploymentVersion().GetBuildId() == tv1.BuildID()
+		require.NoError(t, err)
+		require.Equal(t, tv1.BuildID(), desc.GetWorkflowExecutionInfo().GetVersioningInfo().GetDeploymentVersion().GetBuildId())
 	}, 10*time.Second, 100*time.Millisecond)
 
 	// Wait for first activity attempt to fail (should be on v1)
@@ -6586,12 +6514,10 @@ func (s *Versioning3Suite) TestRetryOfDeclinedCaN_SignalsOnNewTarget() {
 	wfID := run0.GetID()
 
 	// Wait for workflow to be running on v1.
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		desc, err := s.SdkClient().DescribeWorkflowExecution(ctx, wfID, run0.GetRunID())
-		if err != nil {
-			return false
-		}
-		return desc.GetWorkflowExecutionInfo().GetVersioningInfo().GetDeploymentVersion().GetBuildId() == tv1.BuildID()
+		require.NoError(t, err)
+		require.Equal(t, tv1.BuildID(), desc.GetWorkflowExecutionInfo().GetVersioningInfo().GetDeploymentVersion().GetBuildId())
 	}, 10*time.Second, 100*time.Millisecond)
 
 	// Set v2 as current, signal workflow to CaN without AU (decline upgrade).
@@ -6602,38 +6528,32 @@ func (s *Versioning3Suite) TestRetryOfDeclinedCaN_SignalsOnNewTarget() {
 
 	// Wait for CaN to happen — new run on v1.
 	var canRunID string
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		desc, err := s.SdkClient().DescribeWorkflowExecution(ctx, wfID, "")
-		if err != nil {
-			return false
-		}
+		require.NoError(t, err)
 		canRunID = desc.GetWorkflowExecutionInfo().GetExecution().GetRunId()
-		return canRunID != run0.GetRunID() &&
-			desc.GetWorkflowExecutionInfo().GetVersioningInfo().GetDeploymentVersion().GetBuildId() == tv1.BuildID()
+		require.NotEqual(t, run0.GetRunID(), canRunID)
+		require.Equal(t, tv1.BuildID(), desc.GetWorkflowExecutionInfo().GetVersioningInfo().GetDeploymentVersion().GetBuildId())
 	}, 10*time.Second, 100*time.Millisecond)
 
 	// Signal CaN run to fail (triggers server retry). Target remains v2.
 	s.NoError(s.SdkClient().SignalWorkflow(ctx, wfID, canRunID, "proceed", nil))
 
 	// Wait for CaN run to fail.
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		desc, err := s.SdkClient().DescribeWorkflow(ctx, wfID, canRunID)
-		if err != nil {
-			return false
-		}
-		return desc.Status == enumspb.WORKFLOW_EXECUTION_STATUS_FAILED
+		require.NoError(t, err)
+		require.Equal(t, enumspb.WORKFLOW_EXECUTION_STATUS_FAILED, desc.Status)
 	}, 10*time.Second, 100*time.Millisecond)
 
 	// Wait for retry run to complete.
 	var retryRunID string
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		desc, err := s.SdkClient().DescribeWorkflowExecution(ctx, wfID, "")
-		if err != nil {
-			return false
-		}
+		require.NoError(t, err)
 		retryRunID = desc.GetWorkflowExecutionInfo().GetExecution().GetRunId()
-		return retryRunID != canRunID &&
-			desc.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
+		require.NotEqual(t, canRunID, retryRunID)
+		require.Equal(t, enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, desc.GetWorkflowExecutionInfo().GetStatus())
 	}, 10*time.Second, 100*time.Millisecond)
 
 	// Verify: retry run's WFT started should have targetDeploymentVersionChanged=false

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -254,7 +254,7 @@ func (s *Versioning3Suite) TestSessionActivityResourceSpecificTaskQueueNotRegist
 		Namespace: s.Namespace().String(),
 		Version:   tv.DeploymentVersionString(),
 	})
-	s.Require().NoError(err)
+	s.NoError(err)
 
 	totalActTQ := 0
 	for _, tq := range resp.GetVersionTaskQueues() {
@@ -2378,13 +2378,13 @@ func (s *Versioning3Suite) testPinnedCaNUpgradeOnCaN(normalTask, speculativeTask
 						if i < eventsBeforeDeploymentChange {
 							// Events before deployment change should NOT have the flag
 							s.False(attr.GetSuggestContinueAsNew())
-							s.Require().Empty(attr.GetSuggestContinueAsNewReasons())
+							s.Empty(attr.GetSuggestContinueAsNewReasons())
 							s.False(attr.GetTargetWorkerDeploymentVersionChanged(),
 								"Event %d should not have flag (before deployment change)", event.GetEventId())
 						} else {
 							// Events after deployment change SHOULD have the flag (including failed attempts and transient retries)
 							s.False(attr.GetSuggestContinueAsNew())
-							s.Require().Empty(attr.GetSuggestContinueAsNewReasons())
+							s.Empty(attr.GetSuggestContinueAsNewReasons())
 							s.True(attr.GetTargetWorkerDeploymentVersionChanged(),
 								"Event %d should have flag (after deployment change)", event.GetEventId())
 						}
@@ -2393,7 +2393,7 @@ func (s *Versioning3Suite) testPinnedCaNUpgradeOnCaN(normalTask, speculativeTask
 					for _, event := range wfTaskStartedEvents {
 						attr := event.GetWorkflowTaskStartedEventAttributes()
 						s.False(attr.GetSuggestContinueAsNew())
-						s.Require().Empty(attr.GetSuggestContinueAsNewReasons())
+						s.Empty(attr.GetSuggestContinueAsNewReasons())
 						s.False(attr.GetTargetWorkerDeploymentVersionChanged())
 					}
 				}
@@ -2540,7 +2540,7 @@ func (s *Versioning3Suite) testPinnedCaNUseRampingVersionOnCaN(pinnedOverride, n
 					if event.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED {
 						attr := event.GetWorkflowTaskStartedEventAttributes()
 						s.False(attr.GetSuggestContinueAsNew())
-						s.Require().Empty(attr.GetSuggestContinueAsNewReasons())
+						s.Empty(attr.GetSuggestContinueAsNewReasons())
 						// Setting a ramping version does not change the target for a Pinned workflow:
 						// the target is the pinned version, not current or ramping.
 						s.False(attr.GetTargetWorkerDeploymentVersionChanged(),
@@ -2949,7 +2949,7 @@ func (s *Versioning3Suite) verifyTransientTask(task *workflowservice.PollWorkflo
 			lastScheduledEvent = event
 		}
 	}
-	s.Require().NotNil(lastScheduledEvent)
+	s.NotNil(lastScheduledEvent)
 	s.Equal(int32(2), lastScheduledEvent.GetWorkflowTaskScheduledEventAttributes().GetAttempt())
 }
 
@@ -3001,12 +3001,12 @@ func (s *Versioning3Suite) TestAutoUpgradeCaN_UpgradeOnCaN() {
 						wfTaskStartedEvents = append(wfTaskStartedEvents, event)
 					}
 				}
-				s.Require().Len(wfTaskStartedEvents, 2) // make sure we are actually verifying non-zero # of events
+				s.Len(wfTaskStartedEvents, 2) // make sure we are actually verifying non-zero # of events
 
 				for _, event := range wfTaskStartedEvents {
 					attr := event.GetWorkflowTaskStartedEventAttributes()
 					s.False(attr.GetSuggestContinueAsNew())
-					s.Require().Empty(attr.GetSuggestContinueAsNewReasons())
+					s.Empty(attr.GetSuggestContinueAsNewReasons())
 				}
 
 				// For AutoUpgrade, I want to test that once the workflow has transitioned to v2, it doesn't get the CaN suggestion anymore.
@@ -3037,7 +3037,7 @@ func (s *Versioning3Suite) TestAutoUpgradeCaN_UpgradeOnCaN() {
 				for _, event := range wfTaskStartedEvents {
 					attr := event.GetWorkflowTaskStartedEventAttributes()
 					s.False(attr.GetSuggestContinueAsNew())
-					s.Require().Empty(attr.GetSuggestContinueAsNewReasons())
+					s.Empty(attr.GetSuggestContinueAsNewReasons())
 				}
 
 				return &workflowservice.RespondWorkflowTaskCompletedRequest{

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -3507,6 +3507,8 @@ func (s *Versioning3Suite) TestSyncDeploymentUserDataWithRoutingConfig_Update() 
 func (s *Versioning3Suite) setCurrentDeployment(tv *testvars.TestVars) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
+
+	var unexpectedErr error
 	s.EventuallyWithT(func(t *assert.CollectT) {
 		req := &workflowservice.SetWorkerDeploymentCurrentVersionRequest{
 			Namespace:      s.Namespace().String(),
@@ -3514,8 +3516,14 @@ func (s *Versioning3Suite) setCurrentDeployment(tv *testvars.TestVars) {
 		}
 		req.BuildId = tv.BuildID()
 		_, err := s.FrontendClient().SetWorkerDeploymentCurrentVersion(ctx, req)
-		require.NoError(t, err)
+		if _, ok := errors.AsType[*serviceerror.NotFound](err); ok || (err != nil && strings.Contains(err.Error(), serviceerror.NewFailedPreconditionf(workerdeployment.ErrCurrentVersionDoesNotHaveAllTaskQueues, tv.DeploymentVersionStringV32()).Error())) {
+			require.NoError(t, err)
+		}
+		if err != nil {
+			unexpectedErr = err
+		}
 	}, 60*time.Second, 500*time.Millisecond)
+	s.NoError(unexpectedErr)
 
 	// Wait for propagation to complete since we have tests using async entity workflows to set the current version
 	s.waitForDeploymentDataPropagationQueryWorkerDeployment(tv)
@@ -3546,42 +3554,59 @@ func (s *Versioning3Suite) pollUntilRegistered(ctx context.Context, tv *testvars
 			}
 		}()
 	}
+
 	// Wait until the version is visible and all requested task queue types are registered.
+	var unexpectedErr error
 	s.EventuallyWithT(func(t *assert.CollectT) {
 		resp, err := s.FrontendClient().DescribeWorkerDeploymentVersion(ctx, &workflowservice.DescribeWorkerDeploymentVersionRequest{
 			Namespace: s.Namespace().String(),
 			Version:   tv.DeploymentVersionString(),
 		})
-		require.NoError(t, err)
-		tqName := tv.TaskQueue().GetName()
-		for _, tqType := range tqTypes {
-			found := false
-			for _, tq := range resp.GetVersionTaskQueues() {
-				if tq.GetName() == tqName && tq.GetType() == tqType {
-					found = true
-					break
+		if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
+			require.NoError(t, err)
+		}
+		if err != nil {
+			unexpectedErr = err
+		} else {
+			tqName := tv.TaskQueue().GetName()
+			for _, tqType := range tqTypes {
+				found := false
+				for _, tq := range resp.GetVersionTaskQueues() {
+					if tq.GetName() == tqName && tq.GetType() == tqType {
+						found = true
+						break
+					}
 				}
-			}
-			if !found {
-				require.True(t, found)
-				return
+				if !found {
+					require.True(t, found)
+					return
+				}
 			}
 		}
 	}, 30*time.Second, 100*time.Millisecond)
+	s.NoError(unexpectedErr)
 	cancel()
 }
 
 func (s *Versioning3Suite) unsetCurrentDeployment(tv *testvars.TestVars) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
+
+	var unexpectedErr error
 	s.EventuallyWithT(func(t *assert.CollectT) {
 		req := &workflowservice.SetWorkerDeploymentCurrentVersionRequest{
 			Namespace:      s.Namespace().String(),
 			DeploymentName: tv.DeploymentSeries(),
 		}
 		_, err := s.FrontendClient().SetWorkerDeploymentCurrentVersion(ctx, req)
-		require.NoError(t, err)
+		if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
+			require.NoError(t, err)
+		}
+		if err != nil {
+			unexpectedErr = err
+		}
 	}, 60*time.Second, 500*time.Millisecond)
+	s.NoError(unexpectedErr)
 
 	// Wait for propagation to complete since we have tests using async entity workflows to set the current version
 	s.waitForDeploymentDataPropagationQueryWorkerDeployment(tv)
@@ -3599,6 +3624,7 @@ func (s *Versioning3Suite) setRampingDeployment(
 		bid = ""
 	}
 
+	var unexpectedErr error
 	s.EventuallyWithT(func(t *assert.CollectT) {
 		req := &workflowservice.SetWorkerDeploymentRampingVersionRequest{
 			Namespace:      s.Namespace().String(),
@@ -3607,8 +3633,14 @@ func (s *Versioning3Suite) setRampingDeployment(
 		}
 		req.BuildId = bid
 		_, err := s.FrontendClient().SetWorkerDeploymentRampingVersion(ctx, req)
-		require.NoError(t, err)
+		if _, ok := errors.AsType[*serviceerror.NotFound](err); ok || (err != nil && strings.Contains(err.Error(), serviceerror.NewFailedPreconditionf(workerdeployment.ErrRampingVersionDoesNotHaveAllTaskQueues, tv.DeploymentVersionStringV32()).Error())) {
+			require.NoError(t, err)
+		}
+		if err != nil {
+			unexpectedErr = err
+		}
 	}, 60*time.Second, 500*time.Millisecond)
+	s.NoError(unexpectedErr)
 
 	// Wait for propagation to complete since we have tests using async entity workflows to set the current version
 	s.waitForDeploymentDataPropagationQueryWorkerDeployment(tv)

--- a/tests/versioning_test.go
+++ b/tests/versioning_test.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/dgryski/go-farm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
@@ -3953,14 +3955,14 @@ func (s *VersioningIntegSuite) TestDescribeTaskQueueEnhanced_Versioned_Reachabil
 	s.WaitForChannel(ctx, started)
 
 	// 2. Wait for visibility to show A as running with BuildId SearchAttribute 'assigned:A'
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		queryARunning := fmt.Sprintf("TaskQueue = '%s' AND BuildIds IN ('assigned:A') AND ExecutionStatus = \"Running\"", tq)
 		resp, err := s.FrontendClient().CountWorkflowExecutions(ctx, &workflowservice.CountWorkflowExecutionsRequest{
 			Namespace: s.Namespace().String(),
 			Query:     queryARunning,
 		})
-		s.NoError(err)
-		return resp.GetCount() > 0
+		require.NoError(t, err)
+		require.Positive(t, resp.GetCount())
 	}, 5*time.Second, 50*time.Millisecond)
 
 	// 3. Commit a different build id --> A should now only be reachable via visibility query
@@ -4021,14 +4023,14 @@ func (s *VersioningIntegSuite) TestDescribeTaskQueueEnhanced_Versioned_BasicReac
 	s.WaitForChannel(ctx, started)
 
 	// wait for visibility to show A as running with BuildId SearchAttribute 'assigned:A'
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		queryARunning := fmt.Sprintf("TaskQueue = '%s' AND BuildIds IN ('assigned:A') AND ExecutionStatus = \"Running\"", tq)
 		resp, err := s.FrontendClient().CountWorkflowExecutions(ctx, &workflowservice.CountWorkflowExecutionsRequest{
 			Namespace: s.Namespace().String(),
 			Query:     queryARunning,
 		})
-		s.NoError(err)
-		return resp.GetCount() > 0
+		require.NoError(t, err)
+		require.Positive(t, resp.GetCount())
 	}, 3*time.Second, 50*time.Millisecond)
 
 	// commit a different build ID --> A should now only be reachable via visibility query, B reachable as default
@@ -4045,11 +4047,11 @@ func (s *VersioningIntegSuite) TestDescribeTaskQueueEnhanced_Versioned_BasicReac
 	s.NoError(s.SdkClient().SignalWorkflow(ctx, run.GetID(), "", "wait", nil))
 
 	// Query reachability(A) --> eventually shows closed_only by visibility db (after TTL passes and A is closed in visibility)
-	s.Eventually(func() bool {
-		return s.checkBuildIdReachability(ctx, tq, &taskqueuepb.TaskQueueVersionSelection{BuildIds: []string{"A"}}, map[string]enumspb.BuildIdTaskReachability{
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		require.True(t, s.checkBuildIdReachability(ctx, tq, &taskqueuepb.TaskQueueVersionSelection{BuildIds: []string{"A"}}, map[string]enumspb.BuildIdTaskReachability{
 			"A": enumspb.BUILD_ID_TASK_REACHABILITY_CLOSED_WORKFLOWS_ONLY, // closed_only by visibility db (after TTL)
 			"B": enumspb.BUILD_ID_TASK_REACHABILITY_REACHABLE,             // reachable by default assignment rule
-		})
+		}))
 	}, 5*time.Second, 50*time.Millisecond)
 }
 
@@ -4073,7 +4075,7 @@ func (s *VersioningIntegSuite) TestDescribeTaskQueueEnhanced_Unversioned() {
 		workerMap[wId] = w
 	}
 
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		resp, err := s.FrontendClient().DescribeTaskQueue(ctx, &workflowservice.DescribeTaskQueueRequest{
 			Namespace:              s.Namespace().String(),
 			TaskQueue:              &taskqueuepb.TaskQueue{Name: tq, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
@@ -4084,11 +4086,11 @@ func (s *VersioningIntegSuite) TestDescribeTaskQueueEnhanced_Unversioned() {
 			ReportTaskReachability: true,
 			ReportStats:            false,
 		})
-		s.NoError(err)
-		s.NotNil(resp)
-		s.Len(resp.GetVersionsInfo(), 1, "should be 1 because only default/unversioned queue") //nolint:staticcheck
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Len(t, resp.GetVersionsInfo(), 1, "should be 1 because only default/unversioned queue") //nolint:staticcheck
 		versionInfo := resp.GetVersionsInfo()[""]
-		s.Equal(enumspb.BUILD_ID_TASK_REACHABILITY_REACHABLE, versionInfo.GetTaskReachability())
+		require.Equal(t, enumspb.BUILD_ID_TASK_REACHABILITY_REACHABLE, versionInfo.GetTaskReachability())
 		var pollersInfo []*taskqueuepb.PollerInfo
 		for _, t := range versionInfo.GetTypesInfo() {
 			pollersInfo = append(pollersInfo, t.GetPollers()...)
@@ -4096,7 +4098,8 @@ func (s *VersioningIntegSuite) TestDescribeTaskQueueEnhanced_Unversioned() {
 		foundN := 0
 		for wId := range workerMap {
 			for _, pi := range pollersInfo {
-				s.False(pi.GetWorkerVersionCapabilities().GetUseVersioning())
+				//nolint:staticcheck // SA1019: this test covers legacy build-ID versioning.
+				require.False(t, pi.GetWorkerVersionCapabilities().GetUseVersioning())
 				if pi.GetIdentity() == wId {
 					foundN++
 					break
@@ -4104,7 +4107,7 @@ func (s *VersioningIntegSuite) TestDescribeTaskQueueEnhanced_Unversioned() {
 			}
 		}
 
-		return foundN == workerN
+		require.Equal(t, workerN, foundN)
 	}, 3*time.Second, 50*time.Millisecond)
 }
 
@@ -4124,7 +4127,7 @@ func (s *VersioningIntegSuite) TestDescribeTaskQueueEnhanced_ReportFlags() {
 	defer w.Stop()
 
 	// wait for pollers to show up, verify both ReportPollers and ReportTaskReachability
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		resp, err := s.FrontendClient().DescribeTaskQueue(ctx, &workflowservice.DescribeTaskQueueRequest{
 			Namespace:              s.Namespace().String(),
 			TaskQueue:              &taskqueuepb.TaskQueue{Name: tq, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
@@ -4134,23 +4137,25 @@ func (s *VersioningIntegSuite) TestDescribeTaskQueueEnhanced_ReportFlags() {
 			ReportPollers:          true,
 			ReportTaskReachability: true,
 		})
-		s.NoError(err)
-		s.NotNil(resp)
-		s.Len(resp.GetVersionsInfo(), 1, "should be 1 because only default/unversioned queue") //nolint:staticcheck
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Len(t, resp.GetVersionsInfo(), 1, "should be 1 because only default/unversioned queue") //nolint:staticcheck
 		versionInfo := resp.GetVersionsInfo()[""]
-		s.Equal(enumspb.BUILD_ID_TASK_REACHABILITY_REACHABLE, versionInfo.GetTaskReachability())
+		require.Equal(t, enumspb.BUILD_ID_TASK_REACHABILITY_REACHABLE, versionInfo.GetTaskReachability())
 		var pollersInfo []*taskqueuepb.PollerInfo
 		for _, t := range versionInfo.GetTypesInfo() {
 			pollersInfo = append(pollersInfo, t.GetPollers()...)
 		}
+		foundPoller := false
 		for _, pi := range pollersInfo {
-			s.False(pi.GetWorkerVersionCapabilities().GetUseVersioning())
+			//nolint:staticcheck // SA1019: this test covers legacy build-ID versioning.
+			require.False(t, pi.GetWorkerVersionCapabilities().GetUseVersioning())
 			if pi.GetIdentity() == wId {
-				return true
+				foundPoller = true
+				break
 			}
 		}
-
-		return false
+		require.True(t, foundPoller)
 	}, 3*time.Second, 50*time.Millisecond)
 
 	// ask for reachability only
@@ -4269,13 +4274,13 @@ func (s *VersioningIntegSuite) TestDescribeTaskQueueLegacy_VersionSets() {
 	s.NoError(w2.Start())
 	defer w2.Stop()
 
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		resp, err := s.FrontendClient().DescribeTaskQueue(ctx, &workflowservice.DescribeTaskQueueRequest{
 			Namespace:     s.Namespace().String(),
 			TaskQueue:     &taskqueuepb.TaskQueue{Name: tq, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 			TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW,
 		})
-		s.NoError(err)
+		require.NoError(t, err)
 		havePoller := func(v string) bool {
 			for _, p := range resp.Pollers {
 				if p.WorkerVersionCapabilities.UseVersioning && v == p.WorkerVersionCapabilities.BuildId {
@@ -4285,7 +4290,9 @@ func (s *VersioningIntegSuite) TestDescribeTaskQueueLegacy_VersionSets() {
 			return false
 		}
 		// v1 polls get rejected because v11 is newer
-		return !havePoller(v1) && havePoller(v11) && havePoller(v2)
+		require.False(t, havePoller(v1))
+		require.True(t, havePoller(v11))
+		require.True(t, havePoller(v2))
 	}, 3*time.Second, 50*time.Millisecond)
 }
 
@@ -4328,10 +4335,11 @@ func (s *VersioningIntegSuite) TestDescribeWorkflowExecution() {
 	s.WaitForChannel(ctx, started1)
 
 	// describe and check build ID
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		resp, err := s.SdkClient().DescribeWorkflowExecution(ctx, run.GetID(), "")
-		s.NoError(err)
-		return v1 == resp.GetWorkflowExecutionInfo().GetMostRecentWorkerVersionStamp().GetBuildId()
+		require.NoError(t, err)
+		//nolint:staticcheck // SA1019: this test covers legacy build-ID versioning.
+		require.Equal(t, v1, resp.GetWorkflowExecutionInfo().GetMostRecentWorkerVersionStamp().GetBuildId())
 	}, 5*time.Second, 100*time.Millisecond)
 
 	// now register v11 as newer compatible with v1
@@ -4356,10 +4364,11 @@ func (s *VersioningIntegSuite) TestDescribeWorkflowExecution() {
 	s.NoError(s.SdkClient().SignalWorkflow(ctx, run.GetID(), "", "wait", nil))
 	s.WaitForChannel(ctx, started11)
 
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		resp, err := s.SdkClient().DescribeWorkflowExecution(ctx, run.GetID(), "")
-		s.NoError(err)
-		return v11 == resp.GetWorkflowExecutionInfo().GetMostRecentWorkerVersionStamp().GetBuildId()
+		require.NoError(t, err)
+		//nolint:staticcheck // SA1019: this test covers legacy build-ID versioning.
+		require.Equal(t, v11, resp.GetWorkflowExecutionInfo().GetMostRecentWorkerVersionStamp().GetBuildId())
 	}, 5*time.Second, 100*time.Millisecond)
 
 	// unblock. it should complete
@@ -4901,10 +4910,10 @@ func (s *VersioningIntegSuite) waitForPropagation(
 		remaining[partAndType{i, enumspb.TASK_QUEUE_TYPE_ACTIVITY}] = struct{}{}
 		remaining[partAndType{i, enumspb.TASK_QUEUE_TYPE_WORKFLOW}] = struct{}{}
 	}
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		for pt := range remaining {
 			f, err := tqid.NewTaskQueueFamily(s.NamespaceID().String(), taskQueue)
-			s.NoError(err)
+			require.NoError(t, err)
 			partition := f.TaskQueue(pt.tp).NormalPartition(pt.part)
 			// Use lower-level GetTaskQueueUserData instead of GetWorkerBuildIdCompatibility
 			// here so that we can target activity queues.
@@ -4915,12 +4924,12 @@ func (s *VersioningIntegSuite) waitForPropagation(
 					TaskQueue:     partition.RpcName(),
 					TaskQueueType: partition.TaskType(),
 				})
-			s.NoError(err)
+			require.NoError(t, err)
 			if condition(res.GetUserData().GetData().GetVersioningData()) {
 				delete(remaining, pt)
 			}
 		}
-		return len(remaining) == 0
+		require.Empty(t, remaining)
 	}, 10*time.Second, 100*time.Millisecond)
 }
 

--- a/tests/versioning_test.go
+++ b/tests/versioning_test.go
@@ -2385,7 +2385,7 @@ func (s *VersioningIntegSuite) TestDispatchActivityEager() {
 	defer cancel()
 
 	_, err := s.SdkClient().ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{TaskQueue: tq}, "wf")
-	s.Require().NoError(err)
+	s.NoError(err)
 
 	pollResponse, err := s.SdkClient().WorkflowService().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.Namespace().String(),
@@ -2395,7 +2395,7 @@ func (s *VersioningIntegSuite) TestDispatchActivityEager() {
 			BuildId: v1,
 		},
 	})
-	s.Require().NoError(err)
+	s.NoError(err)
 	startToCloseTimeout := time.Minute
 
 	completionResponse, err := s.SdkClient().WorkflowService().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
@@ -2442,9 +2442,9 @@ func (s *VersioningIntegSuite) TestDispatchActivityEager() {
 			},
 		},
 	})
-	s.Require().NoError(err)
-	s.Require().Len(completionResponse.ActivityTasks, 1)
-	s.Require().Equal("compatible", completionResponse.ActivityTasks[0].ActivityId)
+	s.NoError(err)
+	s.Len(completionResponse.ActivityTasks, 1)
+	s.Equal("compatible", completionResponse.ActivityTasks[0].ActivityId)
 }
 
 func (s *VersioningIntegSuite) TestDispatchActivityCrossTQFails() {
@@ -4941,7 +4941,7 @@ func (s *VersioningIntegSuite) unloadTaskQueue(ctx context.Context, tq string) {
 			TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW,
 		},
 	})
-	s.Require().NoError(err)
+	s.NoError(err)
 }
 
 func (s *VersioningIntegSuite) getStickyQueueName(ctx context.Context, id string) string {


### PR DESCRIPTION
## What changed?

Replaces (almost) all use of `s.Eventually` with `s.EventuallyWithT`.

## Why?

Assertions are often used inside `s.Eventually` here and that's not safe as it aborts the test immediately.
