### PR TITLE
Define constants for internal principal identity

### DIFF
--- a/common/authorization/claim_mapper.go
+++ b/common/authorization/claim_mapper.go
@@ -70,7 +70,7 @@ func NewInternalClaimMapper() ClaimMapper {
 }
 
 func (*internalClaimMapper) GetClaims(_ *AuthInfo) (*Claims, error) {
-	return &Claims{System: RoleAdmin, AuthType: "temporal", Subject: "internal"}, nil
+	return &Claims{System: RoleAdmin, AuthType: InternalPrincipalType, Subject: InternalPrincipalName}, nil
 }
 
 func (*internalClaimMapper) AuthInfoRequired() bool {

--- a/common/authorization/principal.go
+++ b/common/authorization/principal.go
@@ -1,0 +1,9 @@
+package authorization
+
+// Defines principal types and names supported in Temporal.
+const (
+	// Identifies internal Temporal-managed services such as history,
+	// matching, per-namespace worker, etc.
+	InternalPrincipalType = "temporal"
+	InternalPrincipalName = "internal"
+)


### PR DESCRIPTION
## What
Extract `"temporal"` and `"internal"` string literals into `InternalPrincipalType` and `InternalPrincipalName` constants in `common/authorization/principal.go`.

## Why
Reuse across the codebase.

## How did you test it?
Existing unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)