### PR TITLE
Tune postgres database for tests

### DIFF
--- a/develop/github/docker-compose.yml
+++ b/develop/github/docker-compose.yml
@@ -1,7 +1,9 @@
 x-healthcheck-defaults: &healthcheck-defaults
-  interval: 3s
+  interval: 5s # steady-state polling once healthy; avoids ongoing probe overhead
   timeout: 3s
-  retries: 60
+  retries: 3 # ~90s of failures at steady-state before marking unhealthy (startup is covered by start_period)
+  start_period: 60s # probe failures within this window don't count against retries
+  start_interval: 1s # probe every 1s during start_period; trims startup wait
 
 services:
   cassandra:
@@ -38,7 +40,16 @@ services:
     environment:
       POSTGRES_USER: temporal
       POSTGRES_PASSWORD: temporal
-    command: postgres -c max_connections=500
+    command:
+      - postgres
+      - -c
+      - max_connections=500
+      - -c
+      - fsync=off # test DB is ephemeral; skip per-commit fsync
+      - -c
+      - synchronous_commit=off # don't block on WAL flush
+      - -c
+      - full_page_writes=off # torn-page protection irrelevant for tests
     volumes:
       - ./postgresql-init:/docker-entrypoint-initdb.d
     healthcheck:


### PR DESCRIPTION
## What changed?

This PR updates CI docker-compose behavior in two places:

- Healthchecks probe quickly during startup with `start_interval: 1s`, then use slower steady-state polling with `interval: 5s`, `retries: 3`, and `start_period: 60s`.
- The PostgreSQL test DB keeps `max_connections=500` and disables durability work with `fsync=off`, `synchronous_commit=off`, and `full_page_writes=off`.

## Why

| Shard | main | this branch | delta |
| --- | ---: | ---: | ---: |
| postgres12 shard0 | 1047s | 1043s | -4s |
| postgres12 shard1 | 767s | 750s | -17s |
| postgres12 shard2 | 1272s | 876s | -396s |
| postgres12 xdc | 547s | 563s | +16s |
| postgres12 ndc | 187s | 184s | -3s |
| postgres12_pgx shard0 | 1033s | 904s | -129s |
| postgres12_pgx shard1 | 738s | 749s | +11s |
| postgres12_pgx shard2 | 813s | 865s | +52s |
| postgres12_pgx xdc | 546s | 541s | -5s |
| postgres12_pgx ndc | 186s | 187s | +1s |
| Total | 7136s | 6662s | -474s (-6.6%) |
