### PR TITLE
Check only principal type for system worker classification

### DIFF
--- a/service/matching/workers/registry_impl.go
+++ b/service/matching/workers/registry_impl.go
@@ -482,11 +482,11 @@ func (m *registryImpl) DescribeWorker(nsID namespace.ID, workerInstanceKey strin
 
 // isSystemWorker determines if a worker is a system worker.
 // If a principal is available, it checks whether the principal identifies
-// the Temporal server itself (type="temporal", name="internal"). Otherwise,
-// it falls back to checking the task queue name prefix.
+// the Temporal server itself (type="temporal"). Otherwise, it falls back to
+// checking the task queue name prefix.
 func isSystemWorker(principal *commonpb.Principal, taskQueue string) bool {
 	if principal != nil {
-		return principal.GetType() == authorization.InternalPrincipalType && principal.GetName() == authorization.InternalPrincipalName
+		return principal.GetType() == authorization.InternalPrincipalType
 	}
 	return primitives.IsInternalTaskQueue(taskQueue)
 }

--- a/service/matching/workers/registry_impl_test.go
+++ b/service/matching/workers/registry_impl_test.go
@@ -230,7 +230,7 @@ func TestIsSystemWorker(t *testing.T) {
 		require.Len(t, list, 1)
 	})
 
-	t.Run("principal with type temporal but non-internal name is not system worker", func(t *testing.T) {
+	t.Run("principal with type temporal but non-internal name is still system worker", func(t *testing.T) {
 		m := newRegistryImpl(testDefaultRegistryParams(metrics.NoopMetricsHandler))
 		defer m.Stop()
 
@@ -240,7 +240,7 @@ func TestIsSystemWorker(t *testing.T) {
 		})
 
 		list := m.filterWorkers("ns", false /* includeSystemWorkers */, alwaysTrue)
-		require.Len(t, list, 1, "worker with non-internal name should not be excluded")
+		require.Empty(t, list, "worker with temporal principal type should be excluded regardless of name")
 	})
 
 	t.Run("principal with non-temporal type is not system worker", func(t *testing.T) {


### PR DESCRIPTION
## What
Simplify system worker detection to only check the principal type (`temporal`), without requiring a specific name.

## Why
All workers with the `temporal` principal type are internal system workers regardless of their name.

## How did you test it?
- Unit tests updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)