### PR TITLE
Mention go-generate when building local changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,16 +235,12 @@ If you need to make changes to the gRPC / protobuf definitions while also workin
           go.temporal.io/sdk => ../sdk-go
       )
       ```
-   2. Build & fix errors: `make proto && make bins`
-
-## License headers
-
-This project is Open Source Software, and requires a header at the beginning of
-all source files. To verify that all files contain the header execute:
-
-```bash
-make copyright
-```
+   2. Build & fix errors:
+      ```
+      make proto
+      make go-generate
+      make bins
+      ```
 
 ## Commit Messages And Titles of Pull Requests
 


### PR DESCRIPTION
## What changed?

A couple of trivial changes to `CONTRIBUTING.md`.

## Why?

- Mention `make go-generate` in the instructions for building with API changes from other repos. This step is required if adding new endpoints, such as extending `workflowservice.WorkflowServiceClient`.
- Removes reference to the `make copyright` target. The copyright headers were removed in https://github.com/temporalio/temporal/pull/7689, which was merged last year.


## How did you test it?

NA

## Potential risks

None