### PR TITLE
handle chasm not found cleanup

### DIFF
--- a/service/history/replication/executable_sync_versioned_transition_task.go
+++ b/service/history/replication/executable_sync_versioned_transition_task.go
@@ -228,17 +228,10 @@ func (e *ExecutableSyncVersionedTransitionTask) HandleErr(err error) error {
 			tag.WorkflowID(e.WorkflowID),
 			tag.WorkflowRunID(e.RunID),
 		)
-		// workflow is not found in source cluster, cleanup workflow in target cluster
-		ctx, cancel := newTaskContext(e.NamespaceName(), e.Config.ReplicationTaskApplyTimeout(), callerInfo)
-		defer cancel()
-		return e.DeleteWorkflow(
-			ctx,
-			definition.NewWorkflowKey(
-				e.NamespaceID,
-				e.WorkflowID,
-				e.RunID,
-			),
-		)
+		// Workflow is not found in source cluster, cleanup workflow in target cluster.
+		// This handles workflow deletion from source cluster and this is optional as deletion operation will replicate to target clusters.
+		deletionTask := NewExecutableDeleteExecutionTask(e.ProcessToolBox, e.TaskID(), e.TaskCreationTime(), e.SourceClusterName(), e.SourceShardKey(), e.ReplicationTask())
+		return deletionTask.Execute()
 	default:
 		return err
 	}

--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -56,6 +56,7 @@ type (
 		TaskID() int64
 		TaskCreationTime() time.Time
 		SourceClusterName() string
+		SourceShardKey() ClusterShardKey
 		Ack()
 		Nack(err error)
 		Abort()
@@ -162,6 +163,10 @@ func (e *ExecutableTaskImpl) TaskCreationTime() time.Time {
 
 func (e *ExecutableTaskImpl) SourceClusterName() string {
 	return e.sourceClusterName
+}
+
+func (e *ExecutableTaskImpl) SourceShardKey() ClusterShardKey {
+	return e.sourceShardKey
 }
 
 func (e *ExecutableTaskImpl) ReplicationTask() *replicationspb.ReplicationTask {

--- a/service/history/replication/executable_task_mock.go
+++ b/service/history/replication/executable_task_mock.go
@@ -302,6 +302,20 @@ func (mr *MockExecutableTaskMockRecorder) SourceClusterName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SourceClusterName", reflect.TypeOf((*MockExecutableTask)(nil).SourceClusterName))
 }
 
+// SourceShardKey mocks base method.
+func (m *MockExecutableTask) SourceShardKey() ClusterShardKey {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SourceShardKey")
+	ret0, _ := ret[0].(ClusterShardKey)
+	return ret0
+}
+
+// SourceShardKey indicates an expected call of SourceShardKey.
+func (mr *MockExecutableTaskMockRecorder) SourceShardKey() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SourceShardKey", reflect.TypeOf((*MockExecutableTask)(nil).SourceShardKey))
+}
+
 // State mocks base method.
 func (m *MockExecutableTask) State() tasks.State {
 	m.ctrl.T.Helper()

--- a/service/history/replication/executable_verify_versioned_transition_task.go
+++ b/service/history/replication/executable_verify_versioned_transition_task.go
@@ -307,18 +307,10 @@ func (e *ExecutableVerifyVersionedTransitionTask) HandleErr(err error) error {
 			tag.WorkflowID(e.WorkflowID),
 			tag.WorkflowRunID(e.RunID),
 		)
-		callerInfo := getReplicaitonCallerInfo(e.GetPriority())
-		// workflow is not found in source cluster, cleanup workflow in target cluster
-		ctx, cancel := newTaskContext(e.NamespaceName(), e.Config.ReplicationTaskApplyTimeout(), callerInfo)
-		defer cancel()
-		return e.DeleteWorkflow(
-			ctx,
-			definition.NewWorkflowKey(
-				e.NamespaceID,
-				e.WorkflowID,
-				e.RunID,
-			),
-		)
+		// workflow is not found in source cluster, cleanup workflow in target cluster.
+		// This handles workflow deletion from source cluster and this is optional as deletion operation will replicate to target clusters.
+		deletionTask := NewExecutableDeleteExecutionTask(e.ProcessToolBox, e.TaskID(), e.TaskCreationTime(), e.SourceClusterName(), e.SourceShardKey(), e.ReplicationTask())
+		return deletionTask.Execute()
 	default:
 		return err
 	}

--- a/service/history/replication/executable_verify_versioned_transition_task_test.go
+++ b/service/history/replication/executable_verify_versioned_transition_task_test.go
@@ -13,6 +13,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	historyspb "go.temporal.io/server/api/history/v1"
+	"go.temporal.io/server/api/historyservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/chasm"

--- a/service/history/replication/executable_verify_versioned_transition_task_test.go
+++ b/service/history/replication/executable_verify_versioned_transition_task_test.go
@@ -13,7 +13,6 @@ import (
 	"go.temporal.io/api/serviceerror"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	historyspb "go.temporal.io/server/api/history/v1"
-	"go.temporal.io/server/api/historyservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/chasm"


### PR DESCRIPTION
## What changed?
Handle non workflow chasm clean up logic in replication

## Why?
Support clean up logic for both workflow and chasm

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
