### PR TITLE
chore: enable scheduler sentinel creation and chasm scheduler routing

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2905,7 +2905,7 @@ instead of the existing (V1) implementation.`,
 
 	EnableCHASMSchedulerRouting = NewNamespaceBoolSetting(
 		"history.enableCHASMSchedulerRouting",
-		false,
+		true,
 		`EnableCHASMSchedulerRouting controls whether schedule RPCs are routed to the CHASM (V2) implementation
 first (with fallback to V1), excluding CreateSchedule.`,
 	)
@@ -2919,7 +2919,7 @@ to the CHASM (V2) implementation on active scheduler workflows.`,
 
 	EnableCHASMSchedulerSentinels = NewNamespaceBoolSetting(
 		"history.enableCHASMSchedulerSentinels",
-		false,
+		true,
 		`EnableCHASMSchedulerSentinels enables ID-space collision sentinels, and must be enabled and propagated in advance of EnableCHASMSchedulerCreation.`,
 	)
 

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -4429,6 +4429,7 @@ func (s *WorkflowHandlerSuite) TestShutdownWorkerWithPartialCancellationFailure(
 func (s *WorkflowHandlerSuite) TestPatchSchedule_TriggerImmediatelyScheduledTime() {
 	config := s.newConfig()
 	config.EnableSchedules = dc.GetBoolPropertyFnFilteredByNamespace(true)
+	config.EnableCHASMSchedulerRouting = dc.GetBoolPropertyFnFilteredByNamespace(false)
 	wh := s.getWorkflowHandler(config)
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary
- Sets `EnableCHASMSchedulerRouting` default to `true` — schedule RPCs are now routed to the CHASM (V2) implementation first (with fallback to V1), excluding CreateSchedule.
- Sets `EnableCHASMSchedulerSentinels` default to `true` — enables ID-space collision sentinels ahead of enabling CHASM scheduler creation.

## Why
Both of these flags need to be enabled if there are any chasm schedules on the cluster. 