### PR TITLE
Use softassert for "dirty mutable state" log

### DIFF
--- a/service/history/workflow/cache/cache.go
+++ b/service/history/workflow/cache/cache.go
@@ -377,8 +377,8 @@ func (c *cacheImpl) makeReleaseFunc(
 					isDirty := wfContext.IsDirty()
 					if isDirty {
 						wfContext.Clear()
-						logger := log.With(shardContext.GetLogger(), tag.ComponentHistoryCache)
-						logger.Error("Cache encountered dirty mutable state transaction",
+						softassert.Fail(shardContext.GetLogger(), "Cache encountered dirty mutable state transaction",
+							tag.ComponentHistoryCache,
 							tag.WorkflowNamespaceID(wfContext.GetWorkflowKey().NamespaceID),
 							tag.WorkflowID(wfContext.GetWorkflowKey().WorkflowID),
 							tag.WorkflowRunID(wfContext.GetWorkflowKey().RunID),


### PR DESCRIPTION
## What changed?

Make "dirty mutable state" an invariant.

## Why?

The situation describes a bug that needs to be flagged; not just a transient error.

NOTE: the `softassert.Fail` still emits the same error log, but with a `failed assertion: ` prefix.