### PR TITLE
[Scheduler] Fix the race between SchedulerCallbacksTask and InvokerProcessBufferTask that lead to dropped actions

### DIFF
--- a/chasm/lib/scheduler/generator.go
+++ b/chasm/lib/scheduler/generator.go
@@ -23,17 +23,18 @@ type Generator struct {
 // NewGenerator returns an initialized Generator component, which should
 // be parented under a Scheduler root node.
 func NewGenerator(ctx chasm.MutableContext) *Generator {
-	return newGeneratorWithState(ctx, &schedulerpb.GeneratorState{
+	generator := newGeneratorWithState(ctx, &schedulerpb.GeneratorState{
 		LastProcessedTime: nil,
 	})
+	// Kick off initial generator run as an immediate task.
+	generator.Generate(ctx)
+	return generator
 }
 
 func newGeneratorWithState(ctx chasm.MutableContext, state *schedulerpb.GeneratorState) *Generator {
 	generator := &Generator{
 		GeneratorState: state,
 	}
-	// Kick off initial generator run as an immediate task.
-	generator.Generate(ctx)
 	return generator
 }
 

--- a/chasm/lib/scheduler/invoker.go
+++ b/chasm/lib/scheduler/invoker.go
@@ -39,7 +39,6 @@ func newInvokerWithState(ctx chasm.MutableContext, state *schedulerpb.InvokerSta
 	i := &Invoker{
 		InvokerState: state,
 	}
-	i.addTasks(ctx)
 	return i
 }
 

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -262,6 +262,10 @@ func CreateSchedulerFromMigration(
 	}
 	sched.setNullableFields()
 
+	// These components won't start with any tasks, as stale running workflow entries
+	// can cause immediate computation after migration to drop actions due to overlap
+	// policy. Instead, SchedulerCallbacksTask fires both tasks after ensuring cached
+	// running workflow state is up-to-date.
 	sched.Invoker = chasm.NewComponentField(ctx, newInvokerWithState(ctx, state.GetInvokerState()))
 	sched.Generator = chasm.NewComponentField(ctx, newGeneratorWithState(ctx, state.GetGeneratorState()))
 

--- a/chasm/lib/scheduler/scheduler_tasks.go
+++ b/chasm/lib/scheduler/scheduler_tasks.go
@@ -146,12 +146,14 @@ func (r *SchedulerCallbacksTaskHandler) Execute(
 		results[start.RequestId] = result
 	}
 
-	// Apply results to the invoker's BufferedStarts.
+	// Apply results to the invoker's BufferedStarts and fire tasks.
 	_, _, err = chasm.UpdateComponent(
 		ctx,
 		schedulerRef,
 		func(s *Scheduler, ctx chasm.MutableContext, _ any) (chasm.NoValue, error) {
+			generator := s.Generator.Get(ctx)
 			invoker := s.Invoker.Get(ctx)
+
 			for _, start := range invoker.BufferedStarts {
 				if result, ok := results[start.RequestId]; ok {
 					start.HasCallback = true
@@ -160,6 +162,12 @@ func (r *SchedulerCallbacksTaskHandler) Execute(
 					}
 				}
 			}
+
+			// Now that running workflow state has been refreshed, scheduler tasks can be
+			// fired.
+			invoker.addTasks(ctx)
+			generator.Generate(ctx)
+
 			return nil, nil
 		},
 		nil,

--- a/tests/schedule_migration_test.go
+++ b/tests/schedule_migration_test.go
@@ -1306,3 +1306,160 @@ func TestScheduleMigrationV1ToV2NoDuplicateRecentActions(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
+
+// TestScheduleMigration_StaleRunningDoesNotSkipPending guards the race fix in
+// CreateSchedulerFromMigration. Without the fix, a "running" BufferedStart
+// migrated from V1 (RunId set, Completed=nil, HasCallback=false) is treated as
+// live by InvokerProcessBufferTask if it fires before SchedulerCallbacksTask
+// has a chance to refresh it. With SCHEDULE_OVERLAP_POLICY_SKIP that causes a
+// concurrently-pending start to be silently dropped (Info.OverlapSkipped++).
+//
+// The test sends a tailored CreateFromMigrationStateRequest directly to the
+// CHASM scheduler API, bypassing V1 and the migration activity:
+//   - One pending BufferedStart for a recent nominal time.
+//   - One stale "running" BufferedStart whose underlying workflow has already
+//     completed by the time the request is sent.
+//
+// SchedulerCallbacksTask must run first, observe the workflow as completed,
+// stamp Completed, and only then fire ProcessBuffer (which then sees
+// isRunning=false and does not apply SKIP).
+func TestScheduleMigration_StaleRunningDoesNotSkipPending(t *testing.T) {
+	env := testcore.NewEnv(
+		t,
+		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
+	)
+
+	ctx := testcore.NewContext()
+	sid := testcore.RandomizeStr("sched-stale-running")
+	pendingWid := testcore.RandomizeStr("sched-stale-running-pending-wf")
+	runningWid := testcore.RandomizeStr("sched-stale-running-running-wf")
+	wt := testcore.RandomizeStr("sched-stale-running-wt")
+
+	nsName := env.Namespace().String()
+	nsID := env.NamespaceID().String()
+
+	workflowFn := func(workflow.Context) error { return nil }
+	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+
+	// Start the workflow that will appear as a stale "running" entry in the
+	// migration state, and wait for it to complete.
+	startResp, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+		Namespace:    nsName,
+		WorkflowId:   runningWid,
+		WorkflowType: &commonpb.WorkflowType{Name: wt},
+		TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		Identity:     "test",
+		RequestId:    uuid.NewString(),
+	})
+	require.NoError(t, err)
+	runningRunID := startResp.GetRunId()
+	require.Eventually(t, func() bool {
+		desc, err := env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: nsName,
+			Execution: &commonpb.WorkflowExecution{WorkflowId: runningWid, RunId: runningRunID},
+		})
+		return err == nil && desc.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
+	}, 10*time.Second, 200*time.Millisecond)
+
+	sched := &schedulepb.Schedule{
+		Spec: &schedulepb.ScheduleSpec{
+			Interval: []*schedulepb.IntervalSpec{
+				{Interval: durationpb.New(1 * time.Hour)},
+			},
+		},
+		Action: &schedulepb.ScheduleAction{
+			Action: &schedulepb.ScheduleAction_StartWorkflow{
+				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+					WorkflowId:   pendingWid,
+					WorkflowType: &commonpb.WorkflowType{Name: wt},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				},
+			},
+		},
+		Policies: &schedulepb.SchedulePolicies{
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP,
+			CatchupWindow: durationpb.New(time.Hour),
+		},
+	}
+
+	// Two BufferedStarts:
+	//   - Pending (Attempt=0, no RunId): SKIP-eligible if isRunning=true.
+	//   - Running (Attempt=1, RunId set, Completed=nil, HasCallback=false):
+	//     mirrors convertRunningWorkflowsToBufferedStarts, but the underlying
+	//     workflow has already finished -- the stale state SchedulerCallbacksTask
+	//     must refresh before ProcessBuffer runs.
+	now := time.Now().UTC()
+	pendingNominal := now.Add(-30 * time.Second)
+	state := &schedulerpb.SchedulerMigrationState{
+		SchedulerState: &schedulerpb.SchedulerState{
+			Namespace:     nsName,
+			NamespaceId:   nsID,
+			ScheduleId:    sid,
+			Schedule:      sched,
+			Info:          &schedulepb.ScheduleInfo{},
+			ConflictToken: scheduler.InitialConflictToken,
+		},
+		GeneratorState: &schedulerpb.GeneratorState{
+			LastProcessedTime: timestamppb.New(now),
+		},
+		InvokerState: &schedulerpb.InvokerState{
+			LastProcessedTime: timestamppb.New(now),
+			BufferedStarts: []*schedulespb.BufferedStart{
+				{
+					NominalTime:   timestamppb.New(pendingNominal),
+					ActualTime:    timestamppb.New(pendingNominal),
+					RequestId:     "sched-migrated-pending-" + uuid.NewString(),
+					OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP,
+					WorkflowId:    pendingWid + "-" + pendingNominal.Format(time.RFC3339Nano),
+					Attempt:       0,
+				},
+				{
+					NominalTime:   timestamppb.New(now),
+					ActualTime:    timestamppb.New(now),
+					StartTime:     timestamppb.New(now),
+					RequestId:     "sched-migrated-running-" + runningRunID,
+					OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP,
+					WorkflowId:    runningWid,
+					RunId:         runningRunID,
+					Attempt:       1,
+					HasCallback:   false,
+				},
+			},
+		},
+	}
+
+	_, err = env.GetTestCluster().SchedulerClient().CreateFromMigrationState(
+		ctx,
+		&schedulerpb.CreateFromMigrationStateRequest{
+			NamespaceId: nsID,
+			State:       state,
+		},
+	)
+	require.NoError(t, err)
+
+	// Wait for both actions to surface in RecentActions:
+	//   - The original running workflow, refreshed to Completed by
+	//     SchedulerCallbacksTask.
+	//   - The pending start, kicked off by ProcessBuffer once isRunning
+	//     resolves to false, then run to completion by the SDK worker.
+	var lastDesc *schedulerpb.DescribeScheduleResponse
+	require.Eventually(t, func() bool {
+		desc, err := env.GetTestCluster().SchedulerClient().DescribeSchedule(
+			ctx,
+			&schedulerpb.DescribeScheduleRequest{
+				NamespaceId:     nsID,
+				FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: nsName, ScheduleId: sid},
+			},
+		)
+		if err != nil {
+			return false
+		}
+		lastDesc = desc
+		return len(desc.GetFrontendResponse().GetInfo().GetRecentActions()) >= 2
+	}, 30*time.Second, 500*time.Millisecond, "expected both running and pending starts to surface in RecentActions")
+
+	// Load-bearing assertion: the pending start must NOT have been dropped
+	// under SKIP overlap policy.
+	require.Equal(t, int64(0), lastDesc.GetFrontendResponse().GetInfo().GetOverlapSkipped(),
+		"stale running entry must not cause the pending start to be dropped under SKIP overlap policy")
+}


### PR DESCRIPTION
## What changed?
- SchedulerCallbacksTask must now complete for migrated schedules before GeneratorTask/InvokerProcessBufferTask are fired.

## Why?
- If InvokerProcessBufferTask runs before CallbacksTask, it may operate on stale `RunningStarts`. Worse, InvokerProcessBufferTask will always win that race as it is an immediate pure task (runs with end of TX) vs a side effect task (async).
  - V1 scheduler migration is triggered *before* a V1 workflow refreshes its own running state, so it is prudent for V2 to do the refresh up-front after migration.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)

## Potential risks
- If CallbacksTask is stuck, no other tasks will fire for migrated workflows. Seems no worse a fate than dropping actions on the floor.
