### PR TITLE
migrate standalone activities tests to parallel suite

### DIFF
--- a/tests/standalone_activity_test.go
+++ b/tests/standalone_activity_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 	activitypb "go.temporal.io/api/activity/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -31,8 +30,8 @@ import (
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/tasktoken"
+	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/common/testing/protorequire"
-	"go.temporal.io/server/common/testing/testvars"
 	"go.temporal.io/server/components/callbacks"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/grpc/codes"
@@ -86,37 +85,42 @@ var (
 )
 
 type standaloneActivityTestSuite struct {
-	testcore.FunctionalTestBase
-	tv *testvars.TestVars
+	parallelsuite.Suite[*standaloneActivityTestSuite]
 }
 
 func TestStandaloneActivityTestSuite(t *testing.T) {
-	t.Parallel()
-	suite.Run(t, new(standaloneActivityTestSuite))
+	parallelsuite.Run(t, &standaloneActivityTestSuite{})
 }
 
-func (s *standaloneActivityTestSuite) SetupSuite() {
-	s.FunctionalTestBase.SetupSuite()
-	s.OverrideDynamicConfig(
-		dynamicconfig.EnableChasm,
-		true,
-	)
-	s.OverrideDynamicConfig(
-		activity.Enabled,
-		true,
-	)
-	s.OverrideDynamicConfig(
-		activity.StartDelayEnabled,
-		true,
-	)
+// standaloneActivityEnv wraps testcore.TestEnv to host the helper methods used
+// across the tests in this file. parallelsuite forbids fields and exported
+// non-Test methods on the suite itself, so per-test state and helpers live here.
+type standaloneActivityEnv struct {
+	*testcore.TestEnv
 }
 
-func (s *standaloneActivityTestSuite) SetupTest() {
-	s.FunctionalTestBase.SetupTest()
-	s.tv = testvars.New(s.T())
+func (s *standaloneActivityTestSuite) newTestEnv(opts ...testcore.TestOption) *standaloneActivityEnv {
+	env := &standaloneActivityEnv{
+		TestEnv: testcore.NewEnv(s.T(), opts...),
+	}
+	// The CHASM/activity dynamic configs are namespace-scoped. Apply them to both
+	// the test's primary namespace and the shared external namespace so cross-namespace
+	// cases (e.g. mismatched-token tests) can start activities in either namespace.
+	nsValues := func(value any) []dynamicconfig.ConstrainedValue {
+		return []dynamicconfig.ConstrainedValue{
+			{Constraints: dynamicconfig.Constraints{Namespace: env.Namespace().String()}, Value: value},
+			{Constraints: dynamicconfig.Constraints{Namespace: env.ExternalNamespace().String()}, Value: value},
+		}
+	}
+	cluster := env.GetTestCluster()
+	cluster.OverrideDynamicConfig(s.T(), dynamicconfig.EnableChasm, nsValues(true))
+	cluster.OverrideDynamicConfig(s.T(), activity.Enabled, nsValues(true))
+	cluster.OverrideDynamicConfig(s.T(), activity.StartDelayEnabled, nsValues(true))
+	return env
 }
 
 func (s *standaloneActivityTestSuite) TestIDReusePolicy() {
+	env := s.newTestEnv()
 	t := s.T()
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -125,25 +129,25 @@ func (s *standaloneActivityTestSuite) TestIDReusePolicy() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
-		pollTaskResp := s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+		pollTaskResp := env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
 
-		_, err := s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-			Namespace: s.Namespace().String(),
+		_, err := env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollTaskResp.TaskToken,
 			Result:    defaultResult,
 			Identity:  "new-worker",
 		})
 		require.NoError(t, err)
 
-		s.validateCompletion(ctx, t, activityID, runID, "new-worker")
+		env.validateCompletion(ctx, t, activityID, runID, "new-worker")
 
-		_, err = s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:    s.Namespace().String(),
+		_, err = env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:    env.Namespace().String(),
 			ActivityId:   activityID,
-			ActivityType: s.tv.ActivityType(),
-			Identity:     s.tv.WorkerIdentity(),
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
@@ -158,26 +162,26 @@ func (s *standaloneActivityTestSuite) TestIDReusePolicy() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		pollTaskResp := s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+		pollTaskResp := env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
 
-		_, err := s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace: s.Namespace().String(),
+		_, err := env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollTaskResp.TaskToken,
 			Failure:   defaultFailure,
 			Identity:  "new-worker",
 		})
 		require.NoError(t, err)
 
-		s.validateFailure(ctx, t, activityID, runID, nil, "new-worker")
+		env.validateFailure(ctx, t, activityID, runID, nil, "new-worker")
 
-		_, err = s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:    s.Namespace().String(),
+		_, err = env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:    env.Namespace().String(),
 			ActivityId:   activityID,
-			ActivityType: s.tv.ActivityType(),
-			Identity:     s.tv.WorkerIdentity(),
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
@@ -190,6 +194,7 @@ func (s *standaloneActivityTestSuite) TestIDReusePolicy() {
 }
 
 func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
+	env := s.newTestEnv()
 	t := s.T()
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -197,14 +202,14 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 	t.Run("Fail", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
-		firstStartResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		firstStartResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 
 		startWithFail := func(requestID string) (*workflowservice.StartActivityExecutionResponse, error) {
-			return s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-				Namespace:    s.Namespace().String(),
+			return env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+				Namespace:    env.Namespace().String(),
 				ActivityId:   activityID,
-				ActivityType: s.tv.ActivityType(),
-				Identity:     s.tv.WorkerIdentity(),
+				ActivityType: env.Tv().ActivityType(),
+				Identity:     env.Tv().WorkerIdentity(),
 				Input:        defaultInput,
 				TaskQueue: &taskqueuepb.TaskQueue{
 					Name: taskQueue,
@@ -218,12 +223,12 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 			_, err := startWithFail("different-request-id")
 			var alreadyStartedErr *serviceerror.ActivityExecutionAlreadyStarted
 			require.ErrorAs(t, err, &alreadyStartedErr)
-			require.Equal(t, s.tv.RequestID(), alreadyStartedErr.StartRequestId)
+			require.Equal(t, env.Tv().RequestID(), alreadyStartedErr.StartRequestId)
 			require.Equal(t, firstStartResp.GetRunId(), alreadyStartedErr.RunId)
 		})
 
 		t.Run("SecondStartWithSameRequestIdReturnsExistingRun", func(t *testing.T) {
-			resp, err := startWithFail(s.tv.RequestID())
+			resp, err := startWithFail(env.Tv().RequestID())
 			require.NoError(t, err)
 			require.Equal(t, firstStartResp.RunId, resp.RunId)
 			require.False(t, resp.GetStarted())
@@ -233,14 +238,14 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 	t.Run("UseExisting", func(t *testing.T) {
 		originalActivityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
-		firstStartResp := s.startAndValidateActivity(ctx, t, originalActivityID, taskQueue)
+		firstStartResp := env.startAndValidateActivity(ctx, t, originalActivityID, taskQueue)
 
 		startWithUseExisting := func(requestID string) (*workflowservice.StartActivityExecutionResponse, error) {
-			return s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-				Namespace:    s.Namespace().String(),
+			return env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+				Namespace:    env.Namespace().String(),
 				ActivityId:   originalActivityID,
-				ActivityType: s.tv.ActivityType(),
-				Identity:     s.tv.WorkerIdentity(),
+				ActivityType: env.Tv().ActivityType(),
+				Identity:     env.Tv().WorkerIdentity(),
 				Input:        defaultInput,
 				TaskQueue: &taskqueuepb.TaskQueue{
 					Name: taskQueue,
@@ -260,19 +265,19 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 			// Link should point to the existing activity run.
 			link := resp.GetLink().GetActivity()
 			require.NotNil(t, link)
-			require.Equal(t, s.Namespace().String(), link.Namespace)
+			require.Equal(t, env.Namespace().String(), link.Namespace)
 			require.Equal(t, originalActivityID, link.ActivityId)
 			require.Equal(t, firstStartResp.RunId, link.RunId)
 		})
 		t.Run("SecondStartWithSameRequestIdReturnsExistingRun", func(t *testing.T) {
-			resp, err := startWithUseExisting(s.tv.RequestID())
+			resp, err := startWithUseExisting(env.Tv().RequestID())
 			require.NoError(t, err)
 			require.Equal(t, firstStartResp.RunId, resp.RunId)
 			require.False(t, resp.GetStarted())
 		})
 
 		t.Run("OnConflictOptions", func(t *testing.T) {
-			s.OverrideDynamicConfig(
+			env.OverrideDynamicConfig(
 				callbacks.AllowedAddresses,
 				[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}},
 			)
@@ -287,18 +292,18 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 				newActivityID := testcore.RandomizeStr(t.Name())
 				newTaskQueue := testcore.RandomizeStr(t.Name())
 
-				resp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-					Namespace:    s.Namespace().String(),
+				resp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+					Namespace:    env.Namespace().String(),
 					ActivityId:   newActivityID,
-					ActivityType: s.tv.ActivityType(),
-					Identity:     s.tv.WorkerIdentity(),
+					ActivityType: env.Tv().ActivityType(),
+					Identity:     env.Tv().WorkerIdentity(),
 					Input:        defaultInput,
 					TaskQueue: &taskqueuepb.TaskQueue{
 						Name: newTaskQueue,
 					},
 					StartToCloseTimeout: durationpb.New(1 * time.Minute),
 					IdConflictPolicy:    enumspb.ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING,
-					RequestId:           s.tv.Any().String(),
+					RequestId:           env.Tv().Any().String(),
 					CompletionCallbacks: []*commonpb.Callback{
 						{Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: "http://localhost/new-activity-cb"}}},
 					},
@@ -307,8 +312,8 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 				require.NoError(t, err)
 				require.True(t, resp.GetStarted())
 
-				descResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-					Namespace:  s.Namespace().String(),
+				descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+					Namespace:  env.Namespace().String(),
 					ActivityId: newActivityID,
 					RunId:      resp.RunId,
 				})
@@ -318,18 +323,18 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 			})
 
 			t.Run("AttachesToExistingActivity", func(t *testing.T) {
-				resp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-					Namespace:    s.Namespace().String(),
+				resp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+					Namespace:    env.Namespace().String(),
 					ActivityId:   originalActivityID,
-					ActivityType: s.tv.ActivityType(),
-					Identity:     s.tv.WorkerIdentity(),
+					ActivityType: env.Tv().ActivityType(),
+					Identity:     env.Tv().WorkerIdentity(),
 					Input:        defaultInput,
 					TaskQueue: &taskqueuepb.TaskQueue{
 						Name: taskQueue,
 					},
 					StartToCloseTimeout: durationpb.New(1 * time.Minute),
 					IdConflictPolicy:    enumspb.ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING,
-					RequestId:           s.tv.Any().String(),
+					RequestId:           env.Tv().Any().String(),
 					CompletionCallbacks: []*commonpb.Callback{
 						{Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: "http://localhost/existing-activity-cb"}}},
 					},
@@ -339,8 +344,8 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 				require.False(t, resp.GetStarted())
 				require.Equal(t, firstStartResp.RunId, resp.RunId)
 
-				descResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-					Namespace:  s.Namespace().String(),
+				descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+					Namespace:  env.Namespace().String(),
 					ActivityId: originalActivityID,
 					RunId:      firstStartResp.RunId,
 				})
@@ -352,14 +357,14 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 			t.Run("IdempotentWithSameRequestId", func(t *testing.T) {
 				idempotentActivityID := testcore.RandomizeStr(t.Name())
 				idempotentTaskQueue := testcore.RandomizeStr(t.Name())
-				idempotentStartResp := s.startAndValidateActivity(ctx, t, idempotentActivityID, idempotentTaskQueue)
+				idempotentStartResp := env.startAndValidateActivity(ctx, t, idempotentActivityID, idempotentTaskQueue)
 
-				requestID := s.tv.Any().String()
+				requestID := env.Tv().Any().String()
 				startReq := &workflowservice.StartActivityExecutionRequest{
-					Namespace:    s.Namespace().String(),
+					Namespace:    env.Namespace().String(),
 					ActivityId:   idempotentActivityID,
-					ActivityType: s.tv.ActivityType(),
-					Identity:     s.tv.WorkerIdentity(),
+					ActivityType: env.Tv().ActivityType(),
+					Identity:     env.Tv().WorkerIdentity(),
 					Input:        defaultInput,
 					TaskQueue: &taskqueuepb.TaskQueue{
 						Name: idempotentTaskQueue,
@@ -374,17 +379,17 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 				}
 
 				// First call attaches the callback.
-				resp1, err := s.FrontendClient().StartActivityExecution(ctx, startReq)
+				resp1, err := env.FrontendClient().StartActivityExecution(ctx, startReq)
 				require.NoError(t, err)
 				require.False(t, resp1.GetStarted())
 
 				// Second call with the same request ID should not duplicate the callback.
-				resp2, err := s.FrontendClient().StartActivityExecution(ctx, startReq)
+				resp2, err := env.FrontendClient().StartActivityExecution(ctx, startReq)
 				require.NoError(t, err)
 				require.False(t, resp2.GetStarted())
 
-				descResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-					Namespace:  s.Namespace().String(),
+				descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+					Namespace:  env.Namespace().String(),
 					ActivityId: idempotentActivityID,
 					RunId:      idempotentStartResp.RunId,
 				})
@@ -396,9 +401,9 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 		})
 
 		t.Run("DoesNotApplyToCompletedActivity", func(t *testing.T) {
-			pollTaskResp := s.pollActivityTaskAndValidate(ctx, t, originalActivityID, taskQueue, firstStartResp.RunId)
-			_, err := s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-				Namespace: s.Namespace().String(),
+			pollTaskResp := env.pollActivityTaskAndValidate(ctx, t, originalActivityID, taskQueue, firstStartResp.RunId)
+			_, err := env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+				Namespace: env.Namespace().String(),
 				TaskToken: pollTaskResp.TaskToken,
 				Result:    defaultResult,
 				Identity:  defaultIdentity,
@@ -416,6 +421,7 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 }
 
 func (s *standaloneActivityTestSuite) TestPollActivityTaskQueue() {
+	env := s.newTestEnv()
 	t := s.T()
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -423,7 +429,7 @@ func (s *standaloneActivityTestSuite) TestPollActivityTaskQueue() {
 	t.Run("FirstAttempt", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
-		namespace := s.Namespace().String()
+		namespace := env.Namespace().String()
 
 		startToCloseTimeout := durationpb.New(1 * time.Minute)
 		scheduleToCloseTimeout := durationpb.New(2 * time.Minute)
@@ -432,11 +438,11 @@ func (s *standaloneActivityTestSuite) TestPollActivityTaskQueue() {
 			FairnessKey: "test-key",
 		}
 
-		startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
 			Namespace:    namespace,
 			ActivityId:   activityID,
-			ActivityType: s.tv.ActivityType(),
-			Identity:     s.tv.WorkerIdentity(),
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
@@ -444,24 +450,24 @@ func (s *standaloneActivityTestSuite) TestPollActivityTaskQueue() {
 			StartToCloseTimeout:    startToCloseTimeout,
 			ScheduleToCloseTimeout: scheduleToCloseTimeout,
 			HeartbeatTimeout:       heartbeatTimeout,
-			RequestId:              s.tv.RequestID(),
+			RequestId:              env.Tv().RequestID(),
 			Priority:               priority,
 			Header:                 defaultHeader,
 		})
 		require.NoError(t, err)
 
-		pollTaskResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+		pollTaskResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
 			Namespace: namespace,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 				Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 			},
-			Identity: s.tv.WorkerIdentity(),
+			Identity: env.Tv().WorkerIdentity(),
 		})
 		require.NoError(t, err)
 		require.Equal(t, activityID, pollTaskResp.GetActivityId())
 		require.Equal(t, namespace, pollTaskResp.GetWorkflowNamespace())
-		protorequire.ProtoEqual(t, s.tv.ActivityType(), pollTaskResp.GetActivityType())
+		protorequire.ProtoEqual(t, env.Tv().ActivityType(), pollTaskResp.GetActivityType())
 		require.Equal(t, startResp.GetRunId(), pollTaskResp.GetActivityRunId())
 		protorequire.ProtoEqual(t, defaultInput, pollTaskResp.GetInput())
 		require.False(t, pollTaskResp.GetStartedTime().AsTime().IsZero())
@@ -479,7 +485,7 @@ func (s *standaloneActivityTestSuite) TestPollActivityTaskQueue() {
 	t.Run("RetriedAttempt", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
-		namespace := s.Namespace().String()
+		namespace := env.Namespace().String()
 
 		startToCloseTimeout := durationpb.New(1 * time.Minute)
 		scheduleToCloseTimeout := durationpb.New(2 * time.Minute)
@@ -488,11 +494,11 @@ func (s *standaloneActivityTestSuite) TestPollActivityTaskQueue() {
 			FairnessKey: "test-key",
 		}
 
-		startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
 			Namespace:    namespace,
 			ActivityId:   activityID,
-			ActivityType: s.tv.ActivityType(),
-			Identity:     s.tv.WorkerIdentity(),
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
@@ -500,25 +506,25 @@ func (s *standaloneActivityTestSuite) TestPollActivityTaskQueue() {
 			StartToCloseTimeout:    startToCloseTimeout,
 			ScheduleToCloseTimeout: scheduleToCloseTimeout,
 			HeartbeatTimeout:       heartbeatTimeout,
-			RequestId:              s.tv.RequestID(),
+			RequestId:              env.Tv().RequestID(),
 			Priority:               priority,
 			Header:                 defaultHeader,
 		})
 		require.NoError(t, err)
 
-		pollTaskResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+		pollTaskResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
 			Namespace: namespace,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 				Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 			},
-			Identity: s.tv.WorkerIdentity(),
+			Identity: env.Tv().WorkerIdentity(),
 		})
 		require.NoError(t, err)
 
 		nextRetryDelay := durationpb.New(1 * time.Second)
-		_, err = s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollTaskResp.TaskToken,
 			Failure: &failurepb.Failure{
 				Message: "retryable failure",
@@ -530,25 +536,25 @@ func (s *standaloneActivityTestSuite) TestPollActivityTaskQueue() {
 		})
 		require.NoError(t, err)
 
-		describeResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		describeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      startResp.GetRunId(),
 		})
 		require.NoError(t, err)
 
-		pollTaskResp, err = s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+		pollTaskResp, err = env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
 			Namespace: namespace,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 				Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 			},
-			Identity: s.tv.WorkerIdentity(),
+			Identity: env.Tv().WorkerIdentity(),
 		})
 		require.NoError(t, err)
 		require.Equal(t, activityID, pollTaskResp.GetActivityId())
 		require.Equal(t, namespace, pollTaskResp.GetWorkflowNamespace())
-		protorequire.ProtoEqual(t, s.tv.ActivityType(), pollTaskResp.GetActivityType())
+		protorequire.ProtoEqual(t, env.Tv().ActivityType(), pollTaskResp.GetActivityType())
 		require.Equal(t, startResp.GetRunId(), pollTaskResp.GetActivityRunId())
 		protorequire.ProtoEqual(t, defaultInput, pollTaskResp.GetInput())
 		require.False(t, pollTaskResp.GetStartedTime().AsTime().IsZero())
@@ -568,20 +574,21 @@ func (s *standaloneActivityTestSuite) TestPollActivityTaskQueue() {
 }
 
 func (s *standaloneActivityTestSuite) TestStart() {
+	env := s.newTestEnv()
 	t := s.T()
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	t.Run("RequestValidations", func(t *testing.T) {
 		t.Run("RequestIDTooLong", func(t *testing.T) {
-			_, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-				Namespace:    s.Namespace().String(),
-				ActivityId:   s.tv.ActivityID(),
-				ActivityType: s.tv.ActivityType(),
-				Identity:     s.tv.WorkerIdentity(),
+			_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+				Namespace:    env.Namespace().String(),
+				ActivityId:   env.Tv().ActivityID(),
+				ActivityType: env.Tv().ActivityType(),
+				Identity:     env.Tv().WorkerIdentity(),
 				Input:        defaultInput,
 				TaskQueue: &taskqueuepb.TaskQueue{
-					Name: s.tv.TaskQueue().GetName(),
+					Name: env.Tv().TaskQueue().GetName(),
 				},
 				StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
 				RequestId:           string(make([]byte, defaultMaxIDLengthLimit+1)),
@@ -594,17 +601,17 @@ func (s *standaloneActivityTestSuite) TestStart() {
 		})
 
 		t.Run("IdentityTooLong", func(t *testing.T) {
-			_, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-				Namespace:    s.Namespace().String(),
-				ActivityId:   s.tv.ActivityID(),
-				ActivityType: s.tv.ActivityType(),
+			_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+				Namespace:    env.Namespace().String(),
+				ActivityId:   env.Tv().ActivityID(),
+				ActivityType: env.Tv().ActivityType(),
 				Identity:     string(make([]byte, defaultMaxIDLengthLimit+1)),
 				Input:        defaultInput,
 				TaskQueue: &taskqueuepb.TaskQueue{
-					Name: s.tv.TaskQueue().GetName(),
+					Name: env.Tv().TaskQueue().GetName(),
 				},
 				StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-				RequestId:           s.tv.RequestID(),
+				RequestId:           env.Tv().RequestID(),
 			})
 
 			var invalidArgErr *serviceerror.InvalidArgument
@@ -615,7 +622,7 @@ func (s *standaloneActivityTestSuite) TestStart() {
 
 		t.Run("InputTooLarge", func(t *testing.T) {
 			blobSizeLimitError := 1000
-			cleanup := s.OverrideDynamicConfig(
+			cleanup := env.OverrideDynamicConfig(
 				dynamicconfig.BlobSizeLimitError,
 				blobSizeLimitError,
 			)
@@ -623,17 +630,17 @@ func (s *standaloneActivityTestSuite) TestStart() {
 
 			input := payloads.EncodeString(string(make([]byte, blobSizeLimitError+1)))
 
-			_, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-				Namespace:    s.Namespace().String(),
-				ActivityId:   s.tv.ActivityID(),
-				ActivityType: s.tv.ActivityType(),
-				Identity:     s.tv.WorkerIdentity(),
+			_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+				Namespace:    env.Namespace().String(),
+				ActivityId:   env.Tv().ActivityID(),
+				ActivityType: env.Tv().ActivityType(),
+				Identity:     env.Tv().WorkerIdentity(),
 				Input:        input,
 				TaskQueue: &taskqueuepb.TaskQueue{
-					Name: s.tv.TaskQueue().GetName(),
+					Name: env.Tv().TaskQueue().GetName(),
 				},
 				StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-				RequestId:           s.tv.RequestID(),
+				RequestId:           env.Tv().RequestID(),
 			})
 
 			var invalidArgErr *serviceerror.InvalidArgument
@@ -648,17 +655,17 @@ func (s *standaloneActivityTestSuite) TestStart() {
 				},
 			}
 
-			_, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-				Namespace:    s.Namespace().String(),
-				ActivityId:   s.tv.ActivityID(),
-				ActivityType: s.tv.ActivityType(),
-				Identity:     s.tv.WorkerIdentity(),
+			_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+				Namespace:    env.Namespace().String(),
+				ActivityId:   env.Tv().ActivityID(),
+				ActivityType: env.Tv().ActivityType(),
+				Identity:     env.Tv().WorkerIdentity(),
 				Input:        defaultInput,
 				TaskQueue: &taskqueuepb.TaskQueue{
-					Name: s.tv.TaskQueue().GetName(),
+					Name: env.Tv().TaskQueue().GetName(),
 				},
 				StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-				RequestId:           s.tv.RequestID(),
+				RequestId:           env.Tv().RequestID(),
 				SearchAttributes:    invalidSearchAttributes,
 			})
 
@@ -671,17 +678,17 @@ func (s *standaloneActivityTestSuite) TestStart() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		resp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:    s.Namespace().String(),
+		resp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:    env.Namespace().String(),
 			ActivityId:   activityID,
-			ActivityType: s.tv.ActivityType(),
-			Identity:     s.tv.WorkerIdentity(),
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 			},
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-			RequestId:           s.tv.Any().String(),
+			RequestId:           env.Tv().Any().String(),
 		})
 		require.NoError(t, err)
 
@@ -691,13 +698,14 @@ func (s *standaloneActivityTestSuite) TestStart() {
 		// Verify link points to the started activity.
 		link := resp.GetLink().GetActivity()
 		require.NotNil(t, link)
-		require.Equal(t, s.Namespace().String(), link.Namespace)
+		require.Equal(t, env.Namespace().String(), link.Namespace)
 		require.Equal(t, activityID, link.ActivityId)
 		require.Equal(t, resp.RunId, link.RunId)
 	})
 }
 
 func (s *standaloneActivityTestSuite) TestComplete() {
+	env := s.newTestEnv()
 	t := s.T()
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -706,86 +714,86 @@ func (s *standaloneActivityTestSuite) TestComplete() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		pollTaskResp := s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+		pollTaskResp := env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
 
-		_, err := s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-			Namespace: s.Namespace().String(),
+		_, err := env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollTaskResp.TaskToken,
 			Result:    defaultResult,
 			Identity:  "new-worker",
 		})
 		require.NoError(t, err)
 
-		s.validateCompletion(ctx, t, activityID, runID, "new-worker")
+		env.validateCompletion(ctx, t, activityID, runID, "new-worker")
 	})
 
 	t.Run("ByIDWithRunID", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+		env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
 
-		_, err := s.FrontendClient().RespondActivityTaskCompletedById(ctx, &workflowservice.RespondActivityTaskCompletedByIdRequest{
-			Namespace:  s.Namespace().String(),
+		_, err := env.FrontendClient().RespondActivityTaskCompletedById(ctx, &workflowservice.RespondActivityTaskCompletedByIdRequest{
+			Namespace:  env.Namespace().String(),
 			RunId:      runID,
 			ActivityId: activityID,
 			Result:     defaultResult,
-			Identity:   s.tv.WorkerIdentity(),
+			Identity:   env.Tv().WorkerIdentity(),
 		})
 		require.NoError(t, err)
 
-		s.validateCompletion(ctx, t, activityID, runID, s.tv.WorkerIdentity())
+		env.validateCompletion(ctx, t, activityID, runID, env.Tv().WorkerIdentity())
 	})
 
 	t.Run("ByIDWithoutRunID", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+		env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
 
-		_, err := s.FrontendClient().RespondActivityTaskCompletedById(ctx, &workflowservice.RespondActivityTaskCompletedByIdRequest{
-			Namespace:  s.Namespace().String(),
+		_, err := env.FrontendClient().RespondActivityTaskCompletedById(ctx, &workflowservice.RespondActivityTaskCompletedByIdRequest{
+			Namespace:  env.Namespace().String(),
 			RunId:      runID,
 			ActivityId: activityID,
 			Result:     defaultResult,
-			Identity:   s.tv.WorkerIdentity(),
+			Identity:   env.Tv().WorkerIdentity(),
 		})
 		require.NoError(t, err)
 
-		s.validateCompletion(ctx, t, activityID, runID, s.tv.WorkerIdentity())
+		env.validateCompletion(ctx, t, activityID, runID, env.Tv().WorkerIdentity())
 	})
 
 	t.Run("StaleToken", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
-		_, err := s.startActivity(ctx, activityID, taskQueue)
+		_, err := env.startActivity(ctx, activityID, taskQueue)
 		require.NoError(t, err)
 
-		pollResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		pollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollResp.TaskToken,
 			Result:    defaultResult,
 		})
 		require.NoError(t, err)
 
 		// Complete with stale token (activity already completed)
-		_, err = s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollResp.TaskToken,
 			Result:    defaultResult,
 		})
@@ -801,10 +809,10 @@ func (s *standaloneActivityTestSuite) TestComplete() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		_, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:              s.Namespace().String(),
+		_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
 			ActivityId:             activityID,
-			ActivityType:           s.tv.ActivityType(),
+			ActivityType:           env.Tv().ActivityType(),
 			TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
 			ScheduleToCloseTimeout: durationpb.New(1 * time.Minute),
 			RetryPolicy: &commonpb.RetryPolicy{
@@ -814,16 +822,16 @@ func (s *standaloneActivityTestSuite) TestComplete() {
 		require.NoError(t, err)
 
 		// Poll and get task token for attempt 1
-		attempt1Resp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		attempt1Resp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 		require.EqualValues(t, 1, attempt1Resp.Attempt)
 
 		// Fail the task with NextRetryDelay to control retry timing
-		_, err = s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: attempt1Resp.TaskToken,
 			Failure: &failurepb.Failure{
 				Message: "retryable failure",
@@ -836,16 +844,16 @@ func (s *standaloneActivityTestSuite) TestComplete() {
 		require.NoError(t, err)
 
 		// Poll to get attempt 2 (ensures retry has happened)
-		attempt2Resp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		attempt2Resp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 		require.EqualValues(t, 2, attempt2Resp.Attempt)
 
 		// Try to complete with the old attempt 1 token - should fail with NotFound
-		_, err = s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: attempt1Resp.TaskToken,
 			Result:    defaultResult,
 		})
@@ -855,8 +863,8 @@ func (s *standaloneActivityTestSuite) TestComplete() {
 		require.Contains(t, statusErr.Message(), fmt.Sprintf("activity not found for ID: %s", activityID))
 
 		// Complete with the attempt 2 token and should succeed
-		_, err = s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: attempt2Resp.TaskToken,
 			Result:    defaultResult,
 		})
@@ -870,10 +878,10 @@ func (s *standaloneActivityTestSuite) TestComplete() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		_, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:              s.Namespace().String(),
+		_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
 			ActivityId:             activityID,
-			ActivityType:           s.tv.ActivityType(),
+			ActivityType:           env.Tv().ActivityType(),
 			TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
 			Input:                  defaultInput,
 			ScheduleToCloseTimeout: durationpb.New(1 * time.Minute),
@@ -884,15 +892,15 @@ func (s *standaloneActivityTestSuite) TestComplete() {
 		require.NoError(t, err)
 
 		// Poll and fail attempt 1 retryably.
-		attempt1Resp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		attempt1Resp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 		require.EqualValues(t, 1, attempt1Resp.Attempt)
 
-		_, err = s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: attempt1Resp.TaskToken,
 			Failure: &failurepb.Failure{
 				Message: "retryable failure",
@@ -905,20 +913,20 @@ func (s *standaloneActivityTestSuite) TestComplete() {
 		require.NoError(t, err)
 
 		// Poll to start attempt 2.
-		attempt2Resp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		attempt2Resp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 		require.EqualValues(t, 2, attempt2Resp.Attempt)
 
 		// Complete by ID — this must succeed on attempt 2.
-		_, err = s.FrontendClient().RespondActivityTaskCompletedById(ctx, &workflowservice.RespondActivityTaskCompletedByIdRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskCompletedById(ctx, &workflowservice.RespondActivityTaskCompletedByIdRequest{
+			Namespace:  env.Namespace().String(),
 			RunId:      attempt2Resp.ActivityRunId,
 			ActivityId: activityID,
 			Result:     defaultResult,
-			Identity:   s.tv.WorkerIdentity(),
+			Identity:   env.Tv().WorkerIdentity(),
 		})
 		require.NoError(t, err)
 	})
@@ -926,33 +934,33 @@ func (s *standaloneActivityTestSuite) TestComplete() {
 	t.Run("MismatchedTokenNamespace", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
-		existingNamespace := s.Namespace().String()
-		_, err := s.startActivity(ctx, activityID, taskQueue)
+		existingNamespace := env.Namespace().String()
+		_, err := env.startActivity(ctx, activityID, taskQueue)
 		require.NoError(t, err)
 
-		pollResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+		pollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
 			Namespace: existingNamespace,
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 
 		// Start an activity in a different namespace and try to complete with existing token
-		externalNamespace := s.ExternalNamespace().String()
-		_, err = s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+		externalNamespace := env.ExternalNamespace().String()
+		_, err = env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
 			Namespace:    externalNamespace,
 			ActivityId:   activityID,
-			ActivityType: s.tv.ActivityType(),
-			Identity:     s.tv.WorkerIdentity(),
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 			},
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-			RequestId:           s.tv.Any().String(),
+			RequestId:           env.Tv().Any().String(),
 		})
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
 			Namespace: externalNamespace,
 			TaskToken: pollResp.TaskToken,
 			Result:    defaultResult,
@@ -968,13 +976,13 @@ func (s *standaloneActivityTestSuite) TestComplete() {
 	t.Run("MismatchedTokenComponentRef", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
-		existingNamespace := s.Namespace().String()
+		existingNamespace := env.Namespace().String()
 
 		// Start activity in namespace A and get its task token
-		_, err := s.startActivity(ctx, activityID, taskQueue)
+		_, err := env.startActivity(ctx, activityID, taskQueue)
 		require.NoError(t, err)
 
-		pollResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+		pollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
 			Namespace: existingNamespace,
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
@@ -982,23 +990,23 @@ func (s *standaloneActivityTestSuite) TestComplete() {
 
 		// Start another activity in namespace B with the same activity ID
 		// (different namespaces allow same activity IDs)
-		externalNamespace := s.ExternalNamespace().String()
-		_, err = s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+		externalNamespace := env.ExternalNamespace().String()
+		_, err = env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
 			Namespace:    externalNamespace,
 			ActivityId:   activityID,
-			ActivityType: s.tv.ActivityType(),
-			Identity:     s.tv.WorkerIdentity(),
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 			},
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-			RequestId:           s.tv.Any().String(),
+			RequestId:           env.Tv().Any().String(),
 		})
 		require.NoError(t, err)
 
 		// Poll for the task from namespace B
-		externalPollResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+		externalPollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
 			Namespace: externalNamespace,
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
@@ -1016,7 +1024,7 @@ func (s *standaloneActivityTestSuite) TestComplete() {
 		existingTaskToken, err := tasktoken.NewSerializer().Serialize(existingTask)
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
 			Namespace: existingNamespace,
 			TaskToken: existingTaskToken,
 			Result:    defaultResult,
@@ -1030,6 +1038,7 @@ func (s *standaloneActivityTestSuite) TestComplete() {
 }
 
 func (s *standaloneActivityTestSuite) TestFail() {
+	env := s.newTestEnv()
 	t := s.T()
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -1038,106 +1047,106 @@ func (s *standaloneActivityTestSuite) TestFail() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		pollTaskResp := s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+		pollTaskResp := env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
 
-		_, err := s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace: s.Namespace().String(),
+		_, err := env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollTaskResp.TaskToken,
 			Failure:   defaultFailure,
 			Identity:  "new-worker",
 		})
 		require.NoError(t, err)
 
-		s.validateFailure(ctx, t, activityID, runID, nil, "new-worker")
+		env.validateFailure(ctx, t, activityID, runID, nil, "new-worker")
 	})
 
 	t.Run("WithHeartbeatDetails", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		pollTaskResp := s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+		pollTaskResp := env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
 
-		_, err := s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace:            s.Namespace().String(),
+		_, err := env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace:            env.Namespace().String(),
 			TaskToken:            pollTaskResp.TaskToken,
 			Failure:              defaultFailure,
 			LastHeartbeatDetails: defaultHeartbeatDetails,
-			Identity:             s.tv.WorkerIdentity(),
+			Identity:             env.Tv().WorkerIdentity(),
 		})
 		require.NoError(t, err)
 
-		s.validateFailure(ctx, t, activityID, runID, defaultHeartbeatDetails, s.tv.WorkerIdentity())
+		env.validateFailure(ctx, t, activityID, runID, defaultHeartbeatDetails, env.Tv().WorkerIdentity())
 	})
 
 	t.Run("ByIDWithRunID", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+		env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
 
-		_, err := s.FrontendClient().RespondActivityTaskFailedById(ctx, &workflowservice.RespondActivityTaskFailedByIdRequest{
-			Namespace:  s.Namespace().String(),
+		_, err := env.FrontendClient().RespondActivityTaskFailedById(ctx, &workflowservice.RespondActivityTaskFailedByIdRequest{
+			Namespace:  env.Namespace().String(),
 			RunId:      runID,
 			ActivityId: activityID,
 			Failure:    defaultFailure,
-			Identity:   s.tv.WorkerIdentity(),
+			Identity:   env.Tv().WorkerIdentity(),
 		})
 		require.NoError(t, err)
 
-		s.validateFailure(ctx, t, activityID, runID, nil, s.tv.WorkerIdentity())
+		env.validateFailure(ctx, t, activityID, runID, nil, env.Tv().WorkerIdentity())
 	})
 
 	t.Run("ByIDWithoutRunID", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+		env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
 
-		_, err := s.FrontendClient().RespondActivityTaskFailedById(ctx, &workflowservice.RespondActivityTaskFailedByIdRequest{
-			Namespace:  s.Namespace().String(),
+		_, err := env.FrontendClient().RespondActivityTaskFailedById(ctx, &workflowservice.RespondActivityTaskFailedByIdRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			Failure:    defaultFailure,
-			Identity:   s.tv.WorkerIdentity(),
+			Identity:   env.Tv().WorkerIdentity(),
 		})
 		require.NoError(t, err)
 
-		s.validateFailure(ctx, t, activityID, runID, nil, s.tv.WorkerIdentity())
+		env.validateFailure(ctx, t, activityID, runID, nil, env.Tv().WorkerIdentity())
 	})
 
 	t.Run("StaleToken", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
-		_, err := s.startActivity(ctx, activityID, taskQueue)
+		_, err := env.startActivity(ctx, activityID, taskQueue)
 		require.NoError(t, err)
 
-		pollResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		pollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollResp.TaskToken,
 			Result:    defaultResult,
 		})
 		require.NoError(t, err)
 
 		// Fail with stale token (activity already completed)
-		_, err = s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollResp.TaskToken,
 			Failure:   defaultFailure,
 		})
@@ -1153,10 +1162,10 @@ func (s *standaloneActivityTestSuite) TestFail() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		_, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:              s.Namespace().String(),
+		_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
 			ActivityId:             activityID,
-			ActivityType:           s.tv.ActivityType(),
+			ActivityType:           env.Tv().ActivityType(),
 			TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
 			ScheduleToCloseTimeout: durationpb.New(1 * time.Minute),
 			RetryPolicy: &commonpb.RetryPolicy{
@@ -1166,16 +1175,16 @@ func (s *standaloneActivityTestSuite) TestFail() {
 		require.NoError(t, err)
 
 		// Poll and get task token for attempt 1
-		attempt1Resp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		attempt1Resp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 		require.EqualValues(t, 1, attempt1Resp.Attempt)
 
 		// Fail the task with NextRetryDelay to control retry timing
-		_, err = s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: attempt1Resp.TaskToken,
 			Failure: &failurepb.Failure{
 				Message: "retryable failure",
@@ -1188,16 +1197,16 @@ func (s *standaloneActivityTestSuite) TestFail() {
 		require.NoError(t, err)
 
 		// Poll to get attempt 2 (ensures retry has happened)
-		attempt2Resp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		attempt2Resp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 		require.EqualValues(t, 2, attempt2Resp.Attempt)
 
 		// Try to fail with the old attempt 1 token - should fail with NotFound
-		_, err = s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: attempt1Resp.TaskToken,
 			Failure:   defaultFailure,
 		})
@@ -1207,8 +1216,8 @@ func (s *standaloneActivityTestSuite) TestFail() {
 		require.Contains(t, statusErr.Message(), fmt.Sprintf("activity not found for ID: %s", activityID))
 
 		// Fail with the attempt 2 token and should be no error
-		_, err = s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: attempt2Resp.TaskToken,
 			Failure:   defaultFailure,
 		})
@@ -1220,10 +1229,10 @@ func (s *standaloneActivityTestSuite) TestFail() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		_, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:              s.Namespace().String(),
+		_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
 			ActivityId:             activityID,
-			ActivityType:           s.tv.ActivityType(),
+			ActivityType:           env.Tv().ActivityType(),
 			TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
 			Input:                  defaultInput,
 			ScheduleToCloseTimeout: durationpb.New(1 * time.Minute),
@@ -1234,15 +1243,15 @@ func (s *standaloneActivityTestSuite) TestFail() {
 		require.NoError(t, err)
 
 		// Poll and fail attempt 1 retryably.
-		attempt1Resp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		attempt1Resp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 		require.EqualValues(t, 1, attempt1Resp.Attempt)
 
-		_, err = s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: attempt1Resp.TaskToken,
 			Failure: &failurepb.Failure{
 				Message: "retryable failure",
@@ -1255,16 +1264,16 @@ func (s *standaloneActivityTestSuite) TestFail() {
 		require.NoError(t, err)
 
 		// Poll to start attempt 2.
-		attempt2Resp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		attempt2Resp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 		require.EqualValues(t, 2, attempt2Resp.Attempt)
 
 		// Fail by ID with a non-retryable failure — must succeed on attempt 2.
-		_, err = s.FrontendClient().RespondActivityTaskFailedById(ctx, &workflowservice.RespondActivityTaskFailedByIdRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskFailedById(ctx, &workflowservice.RespondActivityTaskFailedByIdRequest{
+			Namespace:  env.Namespace().String(),
 			RunId:      attempt2Resp.ActivityRunId,
 			ActivityId: activityID,
 			Failure: &failurepb.Failure{
@@ -1273,7 +1282,7 @@ func (s *standaloneActivityTestSuite) TestFail() {
 					NonRetryable: true,
 				}},
 			},
-			Identity: s.tv.WorkerIdentity(),
+			Identity: env.Tv().WorkerIdentity(),
 		})
 		require.NoError(t, err)
 	})
@@ -1281,33 +1290,33 @@ func (s *standaloneActivityTestSuite) TestFail() {
 	t.Run("MismatchedTokenNamespace", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
-		existingNamespace := s.Namespace().String()
-		_, err := s.startActivity(ctx, activityID, taskQueue)
+		existingNamespace := env.Namespace().String()
+		_, err := env.startActivity(ctx, activityID, taskQueue)
 		require.NoError(t, err)
 
-		pollResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+		pollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
 			Namespace: existingNamespace,
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 
 		// Start an activity in a different namespace and try to fail with existing token
-		externalNamespace := s.ExternalNamespace().String()
-		_, err = s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+		externalNamespace := env.ExternalNamespace().String()
+		_, err = env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
 			Namespace:    externalNamespace,
 			ActivityId:   activityID,
-			ActivityType: s.tv.ActivityType(),
-			Identity:     s.tv.WorkerIdentity(),
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 			},
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-			RequestId:           s.tv.Any().String(),
+			RequestId:           env.Tv().Any().String(),
 		})
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+		_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
 			Namespace: externalNamespace,
 			TaskToken: pollResp.TaskToken,
 			Failure: &failurepb.Failure{
@@ -1329,13 +1338,13 @@ func (s *standaloneActivityTestSuite) TestFail() {
 	t.Run("MismatchedTokenComponentRef", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
-		existingNamespace := s.Namespace().String()
+		existingNamespace := env.Namespace().String()
 
 		// Start activity in namespace A and get its task token
-		_, err := s.startActivity(ctx, activityID, taskQueue)
+		_, err := env.startActivity(ctx, activityID, taskQueue)
 		require.NoError(t, err)
 
-		pollResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+		pollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
 			Namespace: existingNamespace,
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
@@ -1343,23 +1352,23 @@ func (s *standaloneActivityTestSuite) TestFail() {
 
 		// Start another activity in namespace B with the same activity ID
 		// (different namespaces allow same activity IDs)
-		externalNamespace := s.ExternalNamespace().String()
-		_, err = s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+		externalNamespace := env.ExternalNamespace().String()
+		_, err = env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
 			Namespace:    externalNamespace,
 			ActivityId:   activityID,
-			ActivityType: s.tv.ActivityType(),
-			Identity:     s.tv.WorkerIdentity(),
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 			},
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-			RequestId:           s.tv.Any().String(),
+			RequestId:           env.Tv().Any().String(),
 		})
 		require.NoError(t, err)
 
 		// Poll for the task from namespace B
-		externalPollResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+		externalPollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
 			Namespace: externalNamespace,
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
@@ -1377,7 +1386,7 @@ func (s *standaloneActivityTestSuite) TestFail() {
 		existingTaskToken, err := tasktoken.NewSerializer().Serialize(existingTask)
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+		_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
 			Namespace: existingNamespace,
 			TaskToken: existingTaskToken,
 			Failure:   defaultFailure,
@@ -1391,6 +1400,7 @@ func (s *standaloneActivityTestSuite) TestFail() {
 }
 
 func (s *standaloneActivityTestSuite) TestRequestCancel() {
+	env := s.newTestEnv()
 	t := s.T()
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -1400,23 +1410,23 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		taskQueue := testcore.RandomizeStr(t.Name())
 		identity := "client-that-requested-cancellation"
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		pollTaskResp := s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+		pollTaskResp := env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
 
-		_, err := s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err := env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      runID,
 			Identity:   identity,
-			RequestId:  s.tv.RequestID(),
+			RequestId:  env.Tv().RequestID(),
 			Reason:     "Test Cancellation",
 		})
 		require.NoError(t, err)
 
-		heartbeatResp, err := s.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
-			Namespace: s.Namespace().String(),
+		heartbeatResp, err := env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollTaskResp.TaskToken,
 		})
 		require.NoError(t, err)
@@ -1428,16 +1438,16 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 			},
 		}
 
-		_, err = s.FrontendClient().RespondActivityTaskCanceled(ctx, &workflowservice.RespondActivityTaskCanceledRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskCanceled(ctx, &workflowservice.RespondActivityTaskCanceledRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollTaskResp.TaskToken,
 			Details:   details,
 			Identity:  "new-worker",
 		})
 		require.NoError(t, err)
 
-		activityResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:      s.Namespace().String(),
+		activityResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:      env.Namespace().String(),
 			ActivityId:     activityID,
 			RunId:          runID,
 			IncludeInput:   true,
@@ -1470,7 +1480,7 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		},
 	}
 	for _, tc := range testByIDCases {
-		s.Run(tc.name, func() {
+		s.Run(tc.name, func(s *standaloneActivityTestSuite) {
 			t := s.T()
 			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			t.Cleanup(cancel)
@@ -1479,23 +1489,23 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 			taskQueue := testcore.RandomizeStr(tc.name)
 			identity := "client-that-requested-cancellation"
 
-			startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+			startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 			runID := startResp.RunId
 
-			s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+			env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
 
-			_, err := s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
-				Namespace:  s.Namespace().String(),
+			_, err := env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
 				ActivityId: activityID,
 				RunId:      runID,
 				Identity:   identity,
-				RequestId:  s.tv.RequestID(),
+				RequestId:  env.Tv().RequestID(),
 				Reason:     "Test Cancellation",
 			})
 			require.NoError(t, err)
 
-			heartbeatResp, err := s.FrontendClient().RecordActivityTaskHeartbeatById(ctx, &workflowservice.RecordActivityTaskHeartbeatByIdRequest{
-				Namespace:  s.Namespace().String(),
+			heartbeatResp, err := env.FrontendClient().RecordActivityTaskHeartbeatById(ctx, &workflowservice.RecordActivityTaskHeartbeatByIdRequest{
+				Namespace:  env.Namespace().String(),
 				ActivityId: activityID,
 				RunId:      startResp.RunId,
 			})
@@ -1509,7 +1519,7 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 			}
 
 			cancelReq := &workflowservice.RespondActivityTaskCanceledByIdRequest{
-				Namespace:  s.Namespace().String(),
+				Namespace:  env.Namespace().String(),
 				ActivityId: activityID,
 				Details:    details,
 				Identity:   "new-worker",
@@ -1519,11 +1529,11 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 				cancelReq.RunId = runID
 			}
 
-			_, err = s.FrontendClient().RespondActivityTaskCanceledById(ctx, cancelReq)
+			_, err = env.FrontendClient().RespondActivityTaskCanceledById(ctx, cancelReq)
 			require.NoError(t, err)
 
-			activityResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:      s.Namespace().String(),
+			activityResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:      env.Namespace().String(),
 				ActivityId:     activityID,
 				RunId:          runID,
 				IncludeInput:   true,
@@ -1546,10 +1556,10 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		_, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:              s.Namespace().String(),
+		_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
 			ActivityId:             activityID,
-			ActivityType:           s.tv.ActivityType(),
+			ActivityType:           env.Tv().ActivityType(),
 			TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
 			Input:                  defaultInput,
 			ScheduleToCloseTimeout: durationpb.New(1 * time.Minute),
@@ -1560,15 +1570,15 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		require.NoError(t, err)
 
 		// Poll and fail attempt 1 retryably.
-		attempt1Resp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		attempt1Resp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 		require.EqualValues(t, 1, attempt1Resp.Attempt)
 
-		_, err = s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: attempt1Resp.TaskToken,
 			Failure: &failurepb.Failure{
 				Message: "retryable failure",
@@ -1581,27 +1591,27 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		require.NoError(t, err)
 
 		// Poll to start attempt 2.
-		attempt2Resp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		attempt2Resp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 		require.EqualValues(t, 2, attempt2Resp.Attempt)
 
 		// Request cancellation first.
-		_, err = s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      attempt2Resp.ActivityRunId,
-			Identity:   s.tv.WorkerIdentity(),
-			RequestId:  s.tv.Any().String(),
+			Identity:   env.Tv().WorkerIdentity(),
+			RequestId:  env.Tv().Any().String(),
 			Reason:     "Test Cancellation",
 		})
 		require.NoError(t, err)
 
 		// Cancel by ID — must succeed on attempt 2.
-		_, err = s.FrontendClient().RespondActivityTaskCanceledById(ctx, &workflowservice.RespondActivityTaskCanceledByIdRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskCanceledById(ctx, &workflowservice.RespondActivityTaskCanceledByIdRequest{
+			Namespace:  env.Namespace().String(),
 			RunId:      attempt2Resp.ActivityRunId,
 			ActivityId: activityID,
 			Details: &commonpb.Payloads{
@@ -1609,7 +1619,7 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 					payload.EncodeString("Canceled Details"),
 				},
 			},
-			Identity: s.tv.WorkerIdentity(),
+			Identity: env.Tv().WorkerIdentity(),
 		})
 		require.NoError(t, err)
 	})
@@ -1618,10 +1628,10 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		pollTaskResp := s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+		pollTaskResp := env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
 
 		details := &commonpb.Payloads{
 			Payloads: []*commonpb.Payload{
@@ -1629,8 +1639,8 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 			},
 		}
 
-		_, err := s.FrontendClient().RespondActivityTaskCanceled(ctx, &workflowservice.RespondActivityTaskCanceledRequest{
-			Namespace: s.Namespace().String(),
+		_, err := env.FrontendClient().RespondActivityTaskCanceled(ctx, &workflowservice.RespondActivityTaskCanceledRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollTaskResp.TaskToken,
 			Details:   details,
 			Identity:  "new-worker",
@@ -1643,14 +1653,14 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+		env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
 
 		for range 2 {
-			_, err := s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
-				Namespace:  s.Namespace().String(),
+			_, err := env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
 				ActivityId: activityID,
 				RunId:      runID,
 				Identity:   "client-that-requested-cancellation",
@@ -1660,16 +1670,16 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 			require.NoError(t, err)
 		}
 
-		heartbeatResp, err := s.FrontendClient().RecordActivityTaskHeartbeatById(ctx, &workflowservice.RecordActivityTaskHeartbeatByIdRequest{
-			Namespace:  s.Namespace().String(),
+		heartbeatResp, err := env.FrontendClient().RecordActivityTaskHeartbeatById(ctx, &workflowservice.RecordActivityTaskHeartbeatByIdRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      startResp.RunId,
 		})
 		require.NoError(t, err)
 		require.True(t, heartbeatResp.GetCancelRequested(), "expected CancelRequested to be true but was false")
 
-		activityResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:      s.Namespace().String(),
+		activityResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:      env.Namespace().String(),
 			ActivityId:     activityID,
 			RunId:          runID,
 			IncludeInput:   true,
@@ -1691,13 +1701,13 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		taskQueue := testcore.RandomizeStr(t.Name())
 		identity := "client-that-requested-cancellation"
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+		env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
 
-		_, err := s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err := env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      runID,
 			Identity:   identity,
@@ -1706,8 +1716,8 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		})
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      runID,
 			Identity:   identity,
@@ -1726,8 +1736,8 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		{
 			name: "finish with completion",
 			taskCompletionFn: func(ctx context.Context, t *testing.T, taskToken []byte, activityID string, runID string) error {
-				_, err := s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-					Namespace: s.Namespace().String(),
+				_, err := env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+					Namespace: env.Namespace().String(),
 					TaskToken: taskToken,
 					Result:    defaultResult,
 				})
@@ -1739,8 +1749,8 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		{
 			name: "finish with failure",
 			taskCompletionFn: func(ctx context.Context, t *testing.T, taskToken []byte, activityID string, runID string) error {
-				_, err := s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-					Namespace: s.Namespace().String(),
+				_, err := env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+					Namespace: env.Namespace().String(),
 					TaskToken: taskToken,
 					Failure:   defaultFailure,
 				})
@@ -1752,8 +1762,8 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		{
 			name: "finish with termination",
 			taskCompletionFn: func(ctx context.Context, t *testing.T, taskToken []byte, activityID string, runID string) error {
-				_, err := s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
-					Namespace:  s.Namespace().String(),
+				_, err := env.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+					Namespace:  env.Namespace().String(),
 					ActivityId: activityID,
 					RunId:      runID,
 					Reason:     "Test Termination",
@@ -1765,7 +1775,7 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		},
 	}
 	for _, tc := range testAfterFinishedCases {
-		s.Run(tc.name, func() {
+		s.Run(tc.name, func(s *standaloneActivityTestSuite) {
 			t := s.T()
 
 			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
@@ -1774,17 +1784,17 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 			activityID := testcore.RandomizeStr(t.Name())
 			taskQueue := testcore.RandomizeStr(t.Name())
 
-			startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+			startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 			runID := startResp.RunId
 
-			pollTaskResp := s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+			pollTaskResp := env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
 
-			_, err := s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
-				Namespace:  s.Namespace().String(),
+			_, err := env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
 				ActivityId: activityID,
 				RunId:      runID,
 				Identity:   "client-that-requested-cancellation",
-				RequestId:  s.tv.RequestID(),
+				RequestId:  env.Tv().RequestID(),
 				Reason:     "Test Cancellation",
 			})
 			require.NoError(t, err)
@@ -1792,8 +1802,8 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 			err = tc.taskCompletionFn(ctx, t, pollTaskResp.GetTaskToken(), activityID, runID)
 			require.NoError(t, err)
 
-			activityResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:  s.Namespace().String(),
+			activityResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
 				ActivityId: activityID,
 				RunId:      runID,
 			})
@@ -1812,10 +1822,10 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 			activityID := testcore.RandomizeStr(t.Name())
 			taskQueue := testcore.RandomizeStr(t.Name())
 
-			startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-				Namespace:              s.Namespace().String(),
+			startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+				Namespace:              env.Namespace().String(),
 				ActivityId:             activityID,
-				ActivityType:           s.tv.ActivityType(),
+				ActivityType:           env.Tv().ActivityType(),
 				TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
 				ScheduleToCloseTimeout: durationpb.New(1 * time.Minute),
 				RetryPolicy: &commonpb.RetryPolicy{
@@ -1826,20 +1836,20 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 			require.NoError(t, err)
 			runID := startResp.RunId
 
-			pollResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-				Namespace: s.Namespace().String(),
+			pollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+				Namespace: env.Namespace().String(),
 				TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 			})
 			require.NoError(t, err)
 			require.EqualValues(t, 1, pollResp.Attempt)
 
 			if requestCancellation {
-				_, err = s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
-					Namespace:  s.Namespace().String(),
+				_, err = env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+					Namespace:  env.Namespace().String(),
 					ActivityId: activityID,
 					RunId:      runID,
 					Identity:   "test",
-					RequestId:  s.tv.RequestID(),
+					RequestId:  env.Tv().RequestID(),
 				})
 				require.NoError(t, err)
 			}
@@ -1850,15 +1860,15 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 					ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{NonRetryable: false},
 				},
 			}
-			_, err = s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-				Namespace: s.Namespace().String(),
+			_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+				Namespace: env.Namespace().String(),
 				TaskToken: pollResp.TaskToken,
 				Failure:   retryableFailure,
 			})
 			require.NoError(t, err)
 
-			activityResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:  s.Namespace().String(),
+			activityResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
 				ActivityId: activityID,
 				RunId:      runID,
 			})
@@ -1881,8 +1891,8 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 
 	t.Run("RequestValidations", func(t *testing.T) {
 		t.Run("EmptyActivityID", func(t *testing.T) {
-			_, err := s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
-				Namespace: s.Namespace().String(),
+			_, err := env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+				Namespace: env.Namespace().String(),
 				Reason:    "Test Cancellation",
 				Identity:  "client-that-requested-cancellation",
 			})
@@ -1893,9 +1903,9 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		})
 
 		t.Run("ActivityIDTooLong", func(t *testing.T) {
-			_, err := s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+			_, err := env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
 				ActivityId: string(make([]byte, defaultMaxIDLengthLimit+1)), // dynamic config default is 1000
-				Namespace:  s.Namespace().String(),
+				Namespace:  env.Namespace().String(),
 				Reason:     "Test Cancellation",
 				Identity:   "client-that-requested-cancellation",
 			})
@@ -1907,10 +1917,10 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		})
 
 		t.Run("RequestIDTooLong", func(t *testing.T) {
-			_, err := s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+			_, err := env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
 				ActivityId: testcore.RandomizeStr(t.Name()),
 				RequestId:  string(make([]byte, defaultMaxIDLengthLimit+1)), // dynamic config default is 1000
-				Namespace:  s.Namespace().String(),
+				Namespace:  env.Namespace().String(),
 				Reason:     "Test Cancellation",
 				Identity:   "client-that-requested-cancellation",
 			})
@@ -1922,9 +1932,9 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		})
 
 		t.Run("IdentityTooLong", func(t *testing.T) {
-			_, err := s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+			_, err := env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
 				ActivityId: testcore.RandomizeStr(t.Name()),
-				Namespace:  s.Namespace().String(),
+				Namespace:  env.Namespace().String(),
 				Reason:     "Test Cancellation",
 				Identity:   string(make([]byte, defaultMaxIDLengthLimit+1)), // dynamic config default is 1000
 			})
@@ -1936,10 +1946,10 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		})
 
 		t.Run("InvalidRunID", func(t *testing.T) {
-			_, err := s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+			_, err := env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
 				ActivityId: testcore.RandomizeStr(t.Name()),
 				RunId:      "invalid-run-id",
-				Namespace:  s.Namespace().String(),
+				Namespace:  env.Namespace().String(),
 				Reason:     "Test Cancellation",
 				Identity:   "client-that-requested-cancellation",
 			})
@@ -1951,15 +1961,15 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 
 		t.Run("ReasonTooLong", func(t *testing.T) {
 			blobSizeLimitError := 1000
-			cleanup := s.OverrideDynamicConfig(
+			cleanup := env.OverrideDynamicConfig(
 				dynamicconfig.BlobSizeLimitError,
 				blobSizeLimitError,
 			)
 			defer cleanup()
 
-			_, err := s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+			_, err := env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
 				ActivityId: testcore.RandomizeStr(t.Name()),
-				Namespace:  s.Namespace().String(),
+				Namespace:  env.Namespace().String(),
 				Reason:     string(make([]byte, blobSizeLimitError+1)),
 				Identity:   "client-that-requested-cancellation",
 			})
@@ -1974,21 +1984,21 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		_, err := s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err := env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      runID,
 			Identity:   "client-that-requested-cancellation",
-			RequestId:  s.tv.RequestID(),
+			RequestId:  env.Tv().RequestID(),
 			Reason:     "Test Cancellation",
 		})
 		require.NoError(t, err)
 
-		activityResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:      s.Namespace().String(),
+		activityResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:      env.Namespace().String(),
 			ActivityId:     activityID,
 			RunId:          runID,
 			IncludeInput:   true,
@@ -2005,25 +2015,25 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		t.Cleanup(cancel)
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
-		_, err := s.startActivity(ctx, activityID, taskQueue)
+		_, err := env.startActivity(ctx, activityID, taskQueue)
 		require.NoError(t, err)
 
-		pollResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		pollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollResp.TaskToken,
 			Result:    defaultResult,
 		})
 		require.NoError(t, err)
 
 		// Fail with stale token (activity already completed)
-		_, err = s.FrontendClient().RespondActivityTaskCanceled(ctx, &workflowservice.RespondActivityTaskCanceledRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskCanceled(ctx, &workflowservice.RespondActivityTaskCanceledRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollResp.TaskToken,
 		})
 		require.Error(t, err)
@@ -2040,10 +2050,10 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:              s.Namespace().String(),
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
 			ActivityId:             activityID,
-			ActivityType:           s.tv.ActivityType(),
+			ActivityType:           env.Tv().ActivityType(),
 			TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
 			ScheduleToCloseTimeout: durationpb.New(1 * time.Minute),
 			RetryPolicy: &commonpb.RetryPolicy{
@@ -2053,16 +2063,16 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		require.NoError(t, err)
 
 		// Poll and get task token for attempt 1
-		attempt1Resp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		attempt1Resp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 		require.EqualValues(t, 1, attempt1Resp.Attempt)
 
 		// Fail the task with NextRetryDelay to control retry timing
-		_, err = s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: attempt1Resp.TaskToken,
 			Failure: &failurepb.Failure{
 				Message: "retryable failure",
@@ -2075,25 +2085,25 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		require.NoError(t, err)
 
 		// Poll to get attempt 2 (ensures retry has happened)
-		attempt2Resp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		attempt2Resp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 		require.EqualValues(t, 2, attempt2Resp.Attempt)
 
-		_, err = s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      startResp.GetRunId(),
-			RequestId:  s.tv.RequestID(),
+			RequestId:  env.Tv().RequestID(),
 			Reason:     "Test Cancellation",
 		})
 		require.NoError(t, err)
 
 		// Try to cancel with the old attempt 1 token - should fail with NotFound
-		_, err = s.FrontendClient().RespondActivityTaskCanceled(ctx, &workflowservice.RespondActivityTaskCanceledRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskCanceled(ctx, &workflowservice.RespondActivityTaskCanceledRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: attempt1Resp.TaskToken,
 		})
 		require.Error(t, err)
@@ -2102,15 +2112,15 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		require.Contains(t, statusErr.Message(), fmt.Sprintf("activity not found for ID: %s", activityID))
 
 		// Heartbeat then cancel with the attempt 2 token and should be no error
-		heartbeatResp, err := s.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
-			Namespace: s.Namespace().String(),
+		heartbeatResp, err := env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: attempt2Resp.TaskToken,
 		})
 		require.NoError(t, err)
 		require.True(t, heartbeatResp.GetCancelRequested(), "expected CancelRequested to be true but was false")
 
-		_, err = s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: attempt2Resp.TaskToken,
 			Failure:   defaultFailure,
 		})
@@ -2122,33 +2132,33 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		t.Cleanup(cancel)
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
-		existingNamespace := s.Namespace().String()
-		_, err := s.startActivity(ctx, activityID, taskQueue)
+		existingNamespace := env.Namespace().String()
+		_, err := env.startActivity(ctx, activityID, taskQueue)
 		require.NoError(t, err)
 
-		pollResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+		pollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
 			Namespace: existingNamespace,
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 
 		// Start an activity in a different namespace and try to cancel with existing token
-		externalNamespace := s.ExternalNamespace().String()
-		_, err = s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+		externalNamespace := env.ExternalNamespace().String()
+		_, err = env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
 			Namespace:    externalNamespace,
 			ActivityId:   activityID,
-			ActivityType: s.tv.ActivityType(),
-			Identity:     s.tv.WorkerIdentity(),
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 			},
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-			RequestId:           s.tv.Any().String(),
+			RequestId:           env.Tv().Any().String(),
 		})
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().RespondActivityTaskCanceled(ctx, &workflowservice.RespondActivityTaskCanceledRequest{
+		_, err = env.FrontendClient().RespondActivityTaskCanceled(ctx, &workflowservice.RespondActivityTaskCanceledRequest{
 			Namespace: externalNamespace,
 			TaskToken: pollResp.TaskToken,
 		})
@@ -2165,13 +2175,13 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		t.Cleanup(cancel)
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
-		existingNamespace := s.Namespace().String()
+		existingNamespace := env.Namespace().String()
 
 		// Start activity in namespace A and get its task token
-		_, err := s.startActivity(ctx, activityID, taskQueue)
+		_, err := env.startActivity(ctx, activityID, taskQueue)
 		require.NoError(t, err)
 
-		pollResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+		pollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
 			Namespace: existingNamespace,
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
@@ -2179,23 +2189,23 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 
 		// Start another activity in namespace B with the same activity ID
 		// (different namespaces allow same activity IDs)
-		externalNamespace := s.ExternalNamespace().String()
-		_, err = s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+		externalNamespace := env.ExternalNamespace().String()
+		_, err = env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
 			Namespace:    externalNamespace,
 			ActivityId:   activityID,
-			ActivityType: s.tv.ActivityType(),
-			Identity:     s.tv.WorkerIdentity(),
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 			},
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-			RequestId:           s.tv.Any().String(),
+			RequestId:           env.Tv().Any().String(),
 		})
 		require.NoError(t, err)
 
 		// Poll for the task from namespace B
-		externalPollResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+		externalPollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
 			Namespace: externalNamespace,
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
@@ -2213,7 +2223,7 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 		existingTaskToken, err := tasktoken.NewSerializer().Serialize(existingTask)
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().RespondActivityTaskCanceled(ctx, &workflowservice.RespondActivityTaskCanceledRequest{
+		_, err = env.FrontendClient().RespondActivityTaskCanceled(ctx, &workflowservice.RespondActivityTaskCanceledRequest{
 			Namespace: existingNamespace,
 			TaskToken: existingTaskToken,
 		})
@@ -2227,8 +2237,8 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 	t.Run("NonExistent", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 
-		_, err := s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err := env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			Reason:     "Test Cancellation",
 			Identity:   "canceller",
@@ -2241,6 +2251,7 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 }
 
 func (s *standaloneActivityTestSuite) TestTerminate() {
+	env := s.newTestEnv()
 	t := s.T()
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -2249,14 +2260,14 @@ func (s *standaloneActivityTestSuite) TestTerminate() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+		env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
 
 		identity := "terminator"
-		_, err := s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err := env.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      runID,
 			Reason:     "Test Termination",
@@ -2264,8 +2275,8 @@ func (s *standaloneActivityTestSuite) TestTerminate() {
 		})
 		require.NoError(t, err)
 
-		activityResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:      s.Namespace().String(),
+		activityResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:      env.Namespace().String(),
 			ActivityId:     activityID,
 			RunId:          runID,
 			IncludeInput:   true,
@@ -2275,7 +2286,7 @@ func (s *standaloneActivityTestSuite) TestTerminate() {
 		info := activityResp.GetInfo()
 
 		require.NoError(t, err)
-		s.validateBaseActivityResponse(t, activityID, runID, activityResp)
+		env.validateBaseActivityResponse(t, activityID, runID, activityResp)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_TERMINATED, info.GetStatus(),
 			"expected Terminated but is %s", info.GetStatus())
 		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_UNSPECIFIED, info.GetRunState(),
@@ -2283,7 +2294,7 @@ func (s *standaloneActivityTestSuite) TestTerminate() {
 		require.EqualValues(t, 1, info.GetAttempt())
 		require.Greater(t, info.GetExecutionDuration().AsDuration(), time.Duration(0)) // Terminated doesn't set attempt completion, thus expect 0 here
 		require.NotNil(t, info.GetCloseTime())
-		require.Equal(t, s.tv.WorkerIdentity(), info.GetLastWorkerIdentity())
+		require.Equal(t, env.Tv().WorkerIdentity(), info.GetLastWorkerIdentity())
 		require.NotNil(t, info.GetLastStartedTime())
 		require.Nil(t, info.GetLastFailure())
 
@@ -2302,21 +2313,21 @@ func (s *standaloneActivityTestSuite) TestTerminate() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		pollTaskResp := s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+		pollTaskResp := env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
 
-		_, err := s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-			Namespace: s.Namespace().String(),
+		_, err := env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollTaskResp.TaskToken,
 			Result:    defaultResult,
 			Identity:  "new-worker",
 		})
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      runID,
 			Reason:     "Test Termination",
@@ -2330,13 +2341,13 @@ func (s *standaloneActivityTestSuite) TestTerminate() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+		env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
 
-		_, err := s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err := env.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RequestId:  "test-request-id",
 			RunId:      runID,
@@ -2345,8 +2356,8 @@ func (s *standaloneActivityTestSuite) TestTerminate() {
 		})
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RequestId:  "test-request-id",
 			RunId:      runID,
@@ -2360,13 +2371,13 @@ func (s *standaloneActivityTestSuite) TestTerminate() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+		env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
 
-		_, err := s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err := env.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RequestId:  "test-request-id",
 			RunId:      runID,
@@ -2375,8 +2386,8 @@ func (s *standaloneActivityTestSuite) TestTerminate() {
 		})
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RequestId:  "test-request-id-2",
 			RunId:      runID,
@@ -2390,8 +2401,8 @@ func (s *standaloneActivityTestSuite) TestTerminate() {
 	t.Run("NonExistent", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 
-		_, err := s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err := env.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			Reason:     "Test Termination",
 			Identity:   "terminator",
@@ -2404,8 +2415,8 @@ func (s *standaloneActivityTestSuite) TestTerminate() {
 
 	t.Run("RequestValidations", func(t *testing.T) {
 		t.Run("EmptyActivityID", func(t *testing.T) {
-			_, err := s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
-				Namespace: s.Namespace().String(),
+			_, err := env.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+				Namespace: env.Namespace().String(),
 				Reason:    "Test Termination",
 				Identity:  "terminator",
 			})
@@ -2416,9 +2427,9 @@ func (s *standaloneActivityTestSuite) TestTerminate() {
 		})
 
 		t.Run("ActivityIDTooLong", func(t *testing.T) {
-			_, err := s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+			_, err := env.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
 				ActivityId: string(make([]byte, defaultMaxIDLengthLimit+1)), // dynamic config default is 1000
-				Namespace:  s.Namespace().String(),
+				Namespace:  env.Namespace().String(),
 				Reason:     "Test Termination",
 				Identity:   "terminator",
 			})
@@ -2430,10 +2441,10 @@ func (s *standaloneActivityTestSuite) TestTerminate() {
 		})
 
 		t.Run("RequestIDTooLong", func(t *testing.T) {
-			_, err := s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+			_, err := env.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
 				ActivityId: testcore.RandomizeStr(t.Name()),
 				RequestId:  string(make([]byte, defaultMaxIDLengthLimit+1)), // dynamic config default is 1000
-				Namespace:  s.Namespace().String(),
+				Namespace:  env.Namespace().String(),
 				Reason:     "Test Termination",
 				Identity:   "terminator",
 			})
@@ -2445,9 +2456,9 @@ func (s *standaloneActivityTestSuite) TestTerminate() {
 		})
 
 		t.Run("IdentityTooLong", func(t *testing.T) {
-			_, err := s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+			_, err := env.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
 				ActivityId: testcore.RandomizeStr(t.Name()),
-				Namespace:  s.Namespace().String(),
+				Namespace:  env.Namespace().String(),
 				Reason:     "Test Termination",
 				Identity:   string(make([]byte, defaultMaxIDLengthLimit+1)), // dynamic config default is 1000
 			})
@@ -2459,10 +2470,10 @@ func (s *standaloneActivityTestSuite) TestTerminate() {
 		})
 
 		t.Run("InvalidRunID", func(t *testing.T) {
-			_, err := s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+			_, err := env.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
 				ActivityId: testcore.RandomizeStr(t.Name()),
 				RunId:      "invalid-run-id",
-				Namespace:  s.Namespace().String(),
+				Namespace:  env.Namespace().String(),
 				Reason:     "Test Termination",
 				Identity:   "terminator",
 			})
@@ -2474,15 +2485,15 @@ func (s *standaloneActivityTestSuite) TestTerminate() {
 
 		t.Run("ReasonTooLong", func(t *testing.T) {
 			blobSizeLimitError := 1000
-			cleanup := s.OverrideDynamicConfig(
+			cleanup := env.OverrideDynamicConfig(
 				dynamicconfig.BlobSizeLimitError,
 				blobSizeLimitError,
 			)
 			defer cleanup()
 
-			_, err := s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+			_, err := env.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
 				ActivityId: testcore.RandomizeStr(t.Name()),
-				Namespace:  s.Namespace().String(),
+				Namespace:  env.Namespace().String(),
 				Reason:     string(make([]byte, blobSizeLimitError+1)),
 				Identity:   "terminator",
 			})
@@ -2494,11 +2505,11 @@ func (s *standaloneActivityTestSuite) TestTerminate() {
 	})
 }
 
-func (s *standaloneActivityTestSuite) eventuallyTerminated(ctx context.Context, t *testing.T, activityID, runID string) {
+func (env *standaloneActivityEnv) eventuallyTerminated(ctx context.Context, t *testing.T, activityID, runID string) {
 	t.Helper()
 	require.Eventually(t, func() bool {
-		resp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		resp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      runID,
 		})
@@ -2506,11 +2517,11 @@ func (s *standaloneActivityTestSuite) eventuallyTerminated(ctx context.Context, 
 	}, 5*time.Second, 100*time.Millisecond)
 }
 
-func (s *standaloneActivityTestSuite) eventuallyTimedOut(ctx context.Context, t *testing.T, activityID, runID string) {
+func (env *standaloneActivityEnv) eventuallyTimedOut(ctx context.Context, t *testing.T, activityID, runID string) {
 	t.Helper()
 	require.Eventually(t, func() bool {
-		resp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		resp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      runID,
 		})
@@ -2518,11 +2529,11 @@ func (s *standaloneActivityTestSuite) eventuallyTimedOut(ctx context.Context, t 
 	}, 10*time.Second, 100*time.Millisecond)
 }
 
-func (s *standaloneActivityTestSuite) eventuallyDeleted(ctx context.Context, t *testing.T, activityID, runID string) {
+func (env *standaloneActivityEnv) eventuallyDeleted(ctx context.Context, t *testing.T, activityID, runID string) {
 	t.Helper()
 	require.Eventually(t, func() bool {
-		_, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      runID,
 		})
@@ -2532,6 +2543,7 @@ func (s *standaloneActivityTestSuite) eventuallyDeleted(ctx context.Context, t *
 }
 
 func (s *standaloneActivityTestSuite) TestDelete() {
+	env := s.newTestEnv()
 	t := s.T()
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -2540,143 +2552,143 @@ func (s *standaloneActivityTestSuite) TestDelete() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		_, err := s.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err := env.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      runID,
 		})
 		require.NoError(t, err)
 
-		s.eventuallyDeleted(ctx, t, activityID, runID)
+		env.eventuallyDeleted(ctx, t, activityID, runID)
 	})
 
 	t.Run("DeleteRunningActivity", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+		env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
 
-		_, err := s.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err := env.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      runID,
 		})
 		require.NoError(t, err)
 
-		s.eventuallyDeleted(ctx, t, activityID, runID)
+		env.eventuallyDeleted(ctx, t, activityID, runID)
 	})
 
 	t.Run("DeleteCompletedActivity", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		pollTaskResp := s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
-		_, err := s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-			Namespace: s.Namespace().String(),
+		pollTaskResp := env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+		_, err := env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollTaskResp.TaskToken,
 			Result:    defaultResult,
 			Identity:  defaultIdentity,
 		})
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      runID,
 		})
 		require.NoError(t, err)
 
-		s.eventuallyDeleted(ctx, t, activityID, runID)
+		env.eventuallyDeleted(ctx, t, activityID, runID)
 	})
 
 	t.Run("DeleteTerminatedActivity", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		_ = s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
-		_, err := s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_ = env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+		_, err := env.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			Identity:   defaultIdentity,
 			ActivityId: activityID,
 			RunId:      runID,
 		})
 		require.NoError(t, err)
-		s.eventuallyTerminated(ctx, t, activityID, runID)
+		env.eventuallyTerminated(ctx, t, activityID, runID)
 
-		_, err = s.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      runID,
 		})
 		require.NoError(t, err)
 
-		s.eventuallyDeleted(ctx, t, activityID, runID)
+		env.eventuallyDeleted(ctx, t, activityID, runID)
 	})
 
 	t.Run("DeleteCancelRequestedActivity", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		_ = s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+		_ = env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
 
-		_, err := s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err := env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      runID,
 			Identity:   defaultIdentity,
-			RequestId:  s.tv.RequestID(),
+			RequestId:  env.Tv().RequestID(),
 		})
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      runID,
 		})
 		require.NoError(t, err)
 
-		s.eventuallyDeleted(ctx, t, activityID, runID)
+		env.eventuallyDeleted(ctx, t, activityID, runID)
 	})
 
 	t.Run("DeleteFailedActivity", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		pollTaskResp := s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
-		_, err := s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace: s.Namespace().String(),
+		pollTaskResp := env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+		_, err := env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollTaskResp.TaskToken,
 			Failure:   defaultFailure,
 			Identity:  defaultIdentity,
 		})
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      runID,
 		})
 		require.NoError(t, err)
 
-		s.eventuallyDeleted(ctx, t, activityID, runID)
+		env.eventuallyDeleted(ctx, t, activityID, runID)
 	})
 
 	t.Run("DeleteTimedOutActivity", func(t *testing.T) {
@@ -2686,10 +2698,10 @@ func (s *standaloneActivityTestSuite) TestDelete() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp, err := s.FrontendClient().StartActivityExecution(timedOutCtx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:    s.Namespace().String(),
+		startResp, err := env.FrontendClient().StartActivityExecution(timedOutCtx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:    env.Namespace().String(),
 			ActivityId:   activityID,
-			ActivityType: s.tv.ActivityType(),
+			ActivityType: env.Tv().ActivityType(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
@@ -2698,51 +2710,51 @@ func (s *standaloneActivityTestSuite) TestDelete() {
 			RetryPolicy: &commonpb.RetryPolicy{
 				MaximumAttempts: 1,
 			},
-			RequestId: s.tv.RequestID(),
+			RequestId: env.Tv().RequestID(),
 		})
 		require.NoError(t, err)
 		runID := startResp.RunId
 
-		_, err = s.FrontendClient().PollActivityTaskQueue(timedOutCtx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().PollActivityTaskQueue(timedOutCtx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 				Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 			},
-			Identity: s.tv.WorkerIdentity(),
+			Identity: env.Tv().WorkerIdentity(),
 		})
 		require.NoError(t, err)
 
-		s.eventuallyTimedOut(timedOutCtx, t, activityID, runID)
+		env.eventuallyTimedOut(timedOutCtx, t, activityID, runID)
 
-		_, err = s.FrontendClient().DeleteActivityExecution(timedOutCtx, &workflowservice.DeleteActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().DeleteActivityExecution(timedOutCtx, &workflowservice.DeleteActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      runID,
 		})
 		require.NoError(t, err)
 
-		s.eventuallyDeleted(timedOutCtx, t, activityID, runID)
+		env.eventuallyDeleted(timedOutCtx, t, activityID, runID)
 	})
 
 	t.Run("DeleteDeletedActivity", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		_, err := s.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err := env.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      runID,
 		})
 		require.NoError(t, err)
 
-		s.eventuallyDeleted(ctx, t, activityID, runID)
+		env.eventuallyDeleted(ctx, t, activityID, runID)
 
-		_, err = s.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      runID,
 		})
@@ -2755,32 +2767,32 @@ func (s *standaloneActivityTestSuite) TestDelete() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 		runID := startResp.RunId
 
-		pollTaskResp := s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
-		_, err := s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-			Namespace: s.Namespace().String(),
+		pollTaskResp := env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+		_, err := env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollTaskResp.TaskToken,
 			Result:    defaultResult,
 			Identity:  defaultIdentity,
 		})
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 		})
 		require.NoError(t, err)
 
-		s.eventuallyDeleted(ctx, t, activityID, runID)
+		env.eventuallyDeleted(ctx, t, activityID, runID)
 	})
 
 	t.Run("DeleteNonExistent", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 
-		_, err := s.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err := env.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 		})
 
@@ -2791,8 +2803,8 @@ func (s *standaloneActivityTestSuite) TestDelete() {
 
 	t.Run("RequestValidations", func(t *testing.T) {
 		t.Run("EmptyActivityID", func(t *testing.T) {
-			_, err := s.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
-				Namespace: s.Namespace().String(),
+			_, err := env.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
+				Namespace: env.Namespace().String(),
 			})
 
 			var invalidArgErr *serviceerror.InvalidArgument
@@ -2801,8 +2813,8 @@ func (s *standaloneActivityTestSuite) TestDelete() {
 		})
 
 		t.Run("ActivityIDTooLong", func(t *testing.T) {
-			_, err := s.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
-				Namespace:  s.Namespace().String(),
+			_, err := env.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
 				ActivityId: string(make([]byte, defaultMaxIDLengthLimit+1)),
 			})
 
@@ -2813,8 +2825,8 @@ func (s *standaloneActivityTestSuite) TestDelete() {
 		})
 
 		t.Run("InvalidRunID", func(t *testing.T) {
-			_, err := s.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
-				Namespace:  s.Namespace().String(),
+			_, err := env.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
 				ActivityId: testcore.RandomizeStr(t.Name()),
 				RunId:      "invalid-run-id",
 			})
@@ -2827,6 +2839,7 @@ func (s *standaloneActivityTestSuite) TestDelete() {
 }
 
 func (s *standaloneActivityTestSuite) TestRetryWithoutScheduleToCloseTimeout() {
+	env := s.newTestEnv()
 	t := s.T()
 	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
@@ -2835,8 +2848,8 @@ func (s *standaloneActivityTestSuite) TestRetryWithoutScheduleToCloseTimeout() {
 	taskQueue := testcore.RandomizeStr(t.Name())
 
 	// Start activity without ScheduleToCloseTimeout
-	_, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-		Namespace:           s.Namespace().String(),
+	_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+		Namespace:           env.Namespace().String(),
 		ActivityId:          activityID,
 		ActivityType:        &commonpb.ActivityType{Name: "test-activity-type"},
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
@@ -2849,14 +2862,14 @@ func (s *standaloneActivityTestSuite) TestRetryWithoutScheduleToCloseTimeout() {
 	require.NoError(t, err)
 
 	// Attempt 1: fail retryably
-	pollResp1, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-		Namespace: s.Namespace().String(),
+	pollResp1, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+		Namespace: env.Namespace().String(),
 		TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 	})
 	require.NoError(t, err)
 	require.EqualValues(t, 1, pollResp1.Attempt)
-	_, err = s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-		Namespace: s.Namespace().String(),
+	_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+		Namespace: env.Namespace().String(),
 		TaskToken: pollResp1.TaskToken,
 		Failure: &failurepb.Failure{
 			Message: "retryable failure",
@@ -2868,8 +2881,8 @@ func (s *standaloneActivityTestSuite) TestRetryWithoutScheduleToCloseTimeout() {
 	require.NoError(t, err)
 
 	// Attempt 2 should be scheduled
-	pollResp2, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-		Namespace: s.Namespace().String(),
+	pollResp2, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+		Namespace: env.Namespace().String(),
 		TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 	})
 	require.NoError(t, err)
@@ -2877,6 +2890,7 @@ func (s *standaloneActivityTestSuite) TestRetryWithoutScheduleToCloseTimeout() {
 }
 
 func (s *standaloneActivityTestSuite) Test_ScheduleToCloseTimeout_WithRetry() {
+	env := s.newTestEnv()
 	t := s.T()
 	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
@@ -2884,8 +2898,8 @@ func (s *standaloneActivityTestSuite) Test_ScheduleToCloseTimeout_WithRetry() {
 	taskQueue := testcore.RandomizeStr(t.Name())
 
 	// Start an activity
-	startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-		Namespace:  s.Namespace().String(),
+	startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+		Namespace:  env.Namespace().String(),
 		ActivityId: activityID,
 		ActivityType: &commonpb.ActivityType{
 			Name: "test-activity-type",
@@ -2902,10 +2916,10 @@ func (s *standaloneActivityTestSuite) Test_ScheduleToCloseTimeout_WithRetry() {
 	require.NoError(t, err)
 
 	// Fail attempt 1, causing the attempt counter to increment.
-	pollTaskResp, err := s.pollActivityTaskQueue(ctx, taskQueue)
+	pollTaskResp, err := env.pollActivityTaskQueue(ctx, taskQueue)
 	require.NoError(t, err)
-	_, err = s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-		Namespace: s.Namespace().String(),
+	_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+		Namespace: env.Namespace().String(),
 		TaskToken: pollTaskResp.TaskToken,
 		Failure: &failurepb.Failure{
 			Message: "Retryable failure",
@@ -2916,12 +2930,12 @@ func (s *standaloneActivityTestSuite) Test_ScheduleToCloseTimeout_WithRetry() {
 		},
 	})
 	require.NoError(t, err)
-	_, err = s.pollActivityTaskQueue(ctx, taskQueue)
+	_, err = env.pollActivityTaskQueue(ctx, taskQueue)
 	require.NoError(t, err)
 
 	// Wait for schedule-to-close timeout.
-	pollActivityResp, err := s.FrontendClient().PollActivityExecution(ctx, &workflowservice.PollActivityExecutionRequest{
-		Namespace:  s.Namespace().String(),
+	pollActivityResp, err := env.FrontendClient().PollActivityExecution(ctx, &workflowservice.PollActivityExecutionRequest{
+		Namespace:  env.Namespace().String(),
 		ActivityId: activityID,
 		RunId:      startResp.RunId,
 	})
@@ -2929,8 +2943,8 @@ func (s *standaloneActivityTestSuite) Test_ScheduleToCloseTimeout_WithRetry() {
 	require.Equal(t, enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, pollActivityResp.GetOutcome().GetFailure().GetTimeoutFailureInfo().GetTimeoutType(),
 		"expected ScheduleToCloseTimeout but is %s", pollActivityResp.GetOutcome().GetFailure().GetTimeoutFailureInfo().GetTimeoutType())
 
-	describeResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-		Namespace:  s.Namespace().String(),
+	describeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+		Namespace:  env.Namespace().String(),
 		ActivityId: activityID,
 		RunId:      startResp.RunId,
 	})
@@ -2943,16 +2957,17 @@ func (s *standaloneActivityTestSuite) Test_ScheduleToCloseTimeout_WithRetry() {
 // started. It also verifies that DescribeActivityExecution can be used to long-poll for a TimedOut
 // state change caused by execution of a timer task.
 func (s *standaloneActivityTestSuite) TestStartToCloseTimeout() {
+	env := s.newTestEnv()
 	t := s.T()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
-	activityID := s.tv.ActivityID()
-	taskQueue := s.tv.TaskQueue()
+	activityID := env.Tv().ActivityID()
+	taskQueue := env.Tv().TaskQueue()
 
-	startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-		Namespace:  s.Namespace().String(),
+	startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+		Namespace:  env.Namespace().String(),
 		ActivityId: activityID,
 		ActivityType: &commonpb.ActivityType{
 			Name: "test-activity-type",
@@ -2971,8 +2986,8 @@ func (s *standaloneActivityTestSuite) TestStartToCloseTimeout() {
 	require.NoError(t, err)
 
 	// First poll: activity has not started yet
-	describeResp1, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-		Namespace:  s.Namespace().String(),
+	describeResp1, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+		Namespace:  env.Namespace().String(),
 		ActivityId: activityID,
 		RunId:      startResp.RunId,
 	})
@@ -2985,20 +3000,20 @@ func (s *standaloneActivityTestSuite) TestStartToCloseTimeout() {
 		"expected Scheduled but is %s", describeResp1.GetInfo().GetRunState())
 
 	// Worker poll to start the activity
-	pollTaskResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-		Namespace: s.Namespace().String(),
+	pollTaskResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+		Namespace: env.Namespace().String(),
 		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: taskQueue.Name,
 		},
-		Identity: s.tv.WorkerIdentity(),
+		Identity: env.Tv().WorkerIdentity(),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, pollTaskResp)
 	require.NotEmpty(t, pollTaskResp.TaskToken)
 
 	// Second poll: activity has started
-	describeResp2, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-		Namespace:     s.Namespace().String(),
+	describeResp2, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+		Namespace:     env.Namespace().String(),
 		ActivityId:    activityID,
 		RunId:         startResp.RunId,
 		LongPollToken: describeResp1.LongPollToken,
@@ -3014,8 +3029,8 @@ func (s *standaloneActivityTestSuite) TestStartToCloseTimeout() {
 		"expected Started but is %s", describeResp2.GetInfo().GetRunState())
 
 	// Third poll: activity has timed out
-	describeResp3, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-		Namespace:      s.Namespace().String(),
+	describeResp3, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+		Namespace:      env.Namespace().String(),
 		ActivityId:     activityID,
 		RunId:          startResp.RunId,
 		IncludeOutcome: true,
@@ -3050,6 +3065,7 @@ func (s *standaloneActivityTestSuite) TestStartToCloseTimeout() {
 // TestStartToCloseTimeout_WhileCancelRequested verifies that an activity
 // times out due to start-to-close timeout, after a cancellation request has been accepted.
 func (s *standaloneActivityTestSuite) TestStartToCloseTimeout_WhileCancelRequested() {
+	env := s.newTestEnv()
 	t := s.T()
 	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
@@ -3057,8 +3073,8 @@ func (s *standaloneActivityTestSuite) TestStartToCloseTimeout_WhileCancelRequest
 	activityID := testcore.RandomizeStr(t.Name())
 	taskQueue := testcore.RandomizeStr(t.Name())
 
-	startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-		Namespace:           s.Namespace().String(),
+	startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+		Namespace:           env.Namespace().String(),
 		ActivityId:          activityID,
 		ActivityType:        &commonpb.ActivityType{Name: "test-activity"},
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
@@ -3068,15 +3084,15 @@ func (s *standaloneActivityTestSuite) TestStartToCloseTimeout_WhileCancelRequest
 	require.NoError(t, err)
 
 	// Worker accepts the task — activity is STARTED.
-	_, err = s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-		Namespace: s.Namespace().String(),
+	_, err = env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+		Namespace: env.Namespace().String(),
 		TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 	})
 	require.NoError(t, err)
 
 	// Request cancellation — activity moves to CANCEL_REQUESTED.
-	_, err = s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
-		Namespace:  s.Namespace().String(),
+	_, err = env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+		Namespace:  env.Namespace().String(),
 		ActivityId: activityID,
 		RunId:      startResp.RunId,
 		Identity:   "canceller",
@@ -3086,8 +3102,8 @@ func (s *standaloneActivityTestSuite) TestStartToCloseTimeout_WhileCancelRequest
 
 	// Worker ignores cancellation and doesn't respond.
 	// The start-to-close timeout (2s) should still fire.
-	pollOutcome, err := s.FrontendClient().PollActivityExecution(ctx, &workflowservice.PollActivityExecutionRequest{
-		Namespace:  s.Namespace().String(),
+	pollOutcome, err := env.FrontendClient().PollActivityExecution(ctx, &workflowservice.PollActivityExecutionRequest{
+		Namespace:  env.Namespace().String(),
 		ActivityId: activityID,
 		RunId:      startResp.RunId,
 	})
@@ -3101,16 +3117,17 @@ func (s *standaloneActivityTestSuite) TestStartToCloseTimeout_WhileCancelRequest
 // created but never started. It also verifies that DescribeActivityExecution can be used to long-poll for a TimedOut
 // state change caused by execution of a timer task.
 func (s *standaloneActivityTestSuite) TestScheduleToStartTimeout() {
+	env := s.newTestEnv()
 	t := s.T()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
-	activityID := s.tv.ActivityID()
-	taskQueue := s.tv.TaskQueue()
+	activityID := env.Tv().ActivityID()
+	taskQueue := env.Tv().TaskQueue()
 
-	startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-		Namespace:  s.Namespace().String(),
+	startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+		Namespace:  env.Namespace().String(),
 		ActivityId: activityID,
 		ActivityType: &commonpb.ActivityType{
 			Name: "test-activity-type",
@@ -3125,16 +3142,16 @@ func (s *standaloneActivityTestSuite) TestScheduleToStartTimeout() {
 	})
 	require.NoError(t, err)
 
-	describeResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-		Namespace:  s.Namespace().String(),
+	describeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+		Namespace:  env.Namespace().String(),
 		ActivityId: activityID,
 		RunId:      startResp.RunId,
 	})
 	require.NoError(t, err)
 
 	// Long poll to await activity timeout
-	describeResp, err = s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-		Namespace:      s.Namespace().String(),
+	describeResp, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+		Namespace:      env.Namespace().String(),
 		ActivityId:     activityID,
 		RunId:          startResp.RunId,
 		IncludeOutcome: true,
@@ -3151,24 +3168,25 @@ func (s *standaloneActivityTestSuite) TestScheduleToStartTimeout() {
 }
 
 func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_NoWait() {
+	env := s.newTestEnv()
 	t := s.T()
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
-	activityID := s.tv.ActivityID()
-	taskQueue := s.tv.TaskQueue()
+	activityID := env.Tv().ActivityID()
+	taskQueue := env.Tv().TaskQueue()
 
 	startReq := &workflowservice.StartActivityExecutionRequest{
-		Namespace:              s.Namespace().String(),
+		Namespace:              env.Namespace().String(),
 		ActivityId:             activityID,
-		ActivityType:           s.tv.ActivityType(),
+		ActivityType:           env.Tv().ActivityType(),
 		Header:                 defaultHeader,
 		HeartbeatTimeout:       durationpb.New(45 * time.Second),
-		Identity:               s.tv.WorkerIdentity(),
+		Identity:               env.Tv().WorkerIdentity(),
 		Input:                  defaultInput,
 		ScheduleToStartTimeout: durationpb.New(30 * time.Second),
 		ScheduleToCloseTimeout: durationpb.New(3 * time.Minute),
 		StartToCloseTimeout:    durationpb.New(1 * time.Minute),
-		RequestId:              s.tv.RequestID(),
+		RequestId:              env.Tv().RequestID(),
 		RetryPolicy: &commonpb.RetryPolicy{
 			InitialInterval:    durationpb.New(2 * time.Second),
 			BackoffCoefficient: 1.5,
@@ -3185,12 +3203,12 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_NoWait() {
 		UserMetadata: defaultUserMetadata,
 	}
 
-	startResp, err := s.FrontendClient().StartActivityExecution(ctx, startReq)
+	startResp, err := env.FrontendClient().StartActivityExecution(ctx, startReq)
 	require.NoError(t, err)
 
 	t.Run("MinimalResponse", func(t *testing.T) {
-		describeResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		describeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			// Omit RunID to verify that latest run will be used
 			IncludeInput:   false,
@@ -3205,8 +3223,8 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_NoWait() {
 	})
 
 	t.Run("FullResponse", func(t *testing.T) {
-		describeResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:      s.Namespace().String(),
+		describeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:      env.Namespace().String(),
 			ActivityId:     activityID,
 			RunId:          startResp.RunId,
 			IncludeInput:   true,
@@ -3223,7 +3241,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_NoWait() {
 
 		expected := &activitypb.ActivityExecutionInfo{
 			ActivityId:             activityID,
-			ActivityType:           s.tv.ActivityType(),
+			ActivityType:           env.Tv().ActivityType(),
 			Attempt:                1,
 			ExpirationTime:         expectedExpirationTime,
 			Header:                 defaultHeader,
@@ -3266,18 +3284,19 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_NoWait() {
 
 func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_WaitAnyStateChange() {
 	// Long poll for any state change. PollActivityTaskQueue is used to cause a state change.
+	env := s.newTestEnv()
 	t := s.T()
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
-	activityID := s.tv.ActivityID()
-	taskQueue := s.tv.TaskQueue()
+	activityID := env.Tv().ActivityID()
+	taskQueue := env.Tv().TaskQueue()
 
-	startResp, err := s.startActivity(ctx, activityID, taskQueue.Name)
+	startResp, err := env.startActivity(ctx, activityID, taskQueue.Name)
 	require.NoError(t, err)
 
 	// First poll lacks token and therefore responds immediately, returning a token
-	firstDescribeResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-		Namespace:  s.Namespace().String(),
+	firstDescribeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+		Namespace:  env.Namespace().String(),
 		ActivityId: activityID,
 		// RunId:        startResp.RunId, // RunID is now required by validation [?]
 		IncludeInput: true,
@@ -3289,7 +3308,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_WaitAnyState
 
 	expected := &activitypb.ActivityExecutionInfo{
 		ActivityId:             activityID,
-		ActivityType:           s.tv.ActivityType(),
+		ActivityType:           env.Tv().ActivityType(),
 		Attempt:                1,
 		HeartbeatTimeout:       durationpb.New(0),
 		RetryPolicy:            defaultRetryPolicy,
@@ -3322,8 +3341,8 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_WaitAnyState
 	go func() {
 		defer close(activityPollDone)
 		// Second poll uses token and therefore waits for a state transition
-		describeResp, describeErr = s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:     s.Namespace().String(),
+		describeResp, describeErr = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:     env.Namespace().String(),
 			ActivityId:    activityID,
 			RunId:         startResp.RunId,
 			IncludeInput:  true,
@@ -3335,7 +3354,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_WaitAnyState
 
 	// Worker picks up activity task, triggering transition (via RecordActivityTaskStarted)
 	go func() {
-		_, err := s.pollActivityTaskQueue(ctx, taskQueue.Name)
+		_, err := env.pollActivityTaskQueue(ctx, taskQueue.Name)
 		taskQueuePollErr <- err
 	}()
 
@@ -3347,7 +3366,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_WaitAnyState
 
 		expected := &activitypb.ActivityExecutionInfo{
 			ActivityId:             activityID,
-			ActivityType:           s.tv.ActivityType(),
+			ActivityType:           env.Tv().ActivityType(),
 			Attempt:                1,
 			HeartbeatTimeout:       durationpb.New(0),
 			LastWorkerIdentity:     defaultIdentity,
@@ -3385,6 +3404,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_WaitAnyState
 }
 
 func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_Completed() {
+	env := s.newTestEnv()
 	testCases := []struct {
 		name             string
 		expectedStatus   enumspb.ActivityExecutionStatus
@@ -3395,8 +3415,8 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_Completed() 
 			name:           "successful completion",
 			expectedStatus: enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED,
 			taskCompletionFn: func(ctx context.Context, taskToken []byte, _, _ string) error {
-				_, err := s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-					Namespace: s.Namespace().String(),
+				_, err := env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+					Namespace: env.Namespace().String(),
 					TaskToken: taskToken,
 					Result:    defaultResult,
 					Identity:  defaultIdentity,
@@ -3412,8 +3432,8 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_Completed() 
 			name:           "failure completion",
 			expectedStatus: enumspb.ACTIVITY_EXECUTION_STATUS_FAILED,
 			taskCompletionFn: func(ctx context.Context, taskToken []byte, _, _ string) error {
-				_, err := s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-					Namespace: s.Namespace().String(),
+				_, err := env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+					Namespace: env.Namespace().String(),
 					TaskToken: taskToken,
 					Failure:   defaultFailure,
 					Identity:  defaultIdentity,
@@ -3429,8 +3449,8 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_Completed() 
 			name:           "termination",
 			expectedStatus: enumspb.ACTIVITY_EXECUTION_STATUS_TERMINATED,
 			taskCompletionFn: func(ctx context.Context, _ []byte, activityID, runID string) error {
-				_, err := s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
-					Namespace:  s.Namespace().String(),
+				_, err := env.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+					Namespace:  env.Namespace().String(),
 					ActivityId: activityID,
 					RunId:      runID,
 					Reason:     "test termination",
@@ -3446,23 +3466,23 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_Completed() 
 	}
 
 	for _, tc := range testCases {
-		s.Run(tc.name, func() {
+		s.Run(tc.name, func(s *standaloneActivityTestSuite) {
 			t := s.T()
 			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			t.Cleanup(cancel)
-			activityID := s.tv.Any().String()
-			taskQueue := s.tv.TaskQueue()
+			activityID := env.Tv().Any().String()
+			taskQueue := env.Tv().TaskQueue()
 
-			startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-				Namespace:           s.Namespace().String(),
+			startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+				Namespace:           env.Namespace().String(),
 				ActivityId:          activityID,
-				ActivityType:        s.tv.ActivityType(),
+				ActivityType:        env.Tv().ActivityType(),
 				Header:              defaultHeader,
 				HeartbeatTimeout:    durationpb.New(45 * time.Second),
-				Identity:            s.tv.WorkerIdentity(),
+				Identity:            env.Tv().WorkerIdentity(),
 				Input:               defaultInput,
 				StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-				RequestId:           s.tv.RequestID(),
+				RequestId:           env.Tv().RequestID(),
 				RetryPolicy:         defaultRetryPolicy,
 				Priority:            &commonpb.Priority{FairnessKey: "test-key"},
 				SearchAttributes:    defaultSearchAttributes,
@@ -3471,13 +3491,13 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_Completed() 
 			})
 			require.NoError(t, err)
 
-			pollTaskResp, err := s.pollActivityTaskQueue(ctx, taskQueue.Name)
+			pollTaskResp, err := env.pollActivityTaskQueue(ctx, taskQueue.Name)
 			require.NoError(t, err)
 			err = tc.taskCompletionFn(ctx, pollTaskResp.TaskToken, activityID, startResp.RunId)
 			require.NoError(t, err)
 
-			describeResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:      s.Namespace().String(),
+			describeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:      env.Namespace().String(),
 				ActivityId:     activityID,
 				RunId:          startResp.RunId,
 				IncludeInput:   true,
@@ -3492,7 +3512,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_Completed() 
 			require.NotNil(t, info)
 			require.Equal(t, activityID, info.GetActivityId())
 			require.Equal(t, startResp.RunId, info.GetRunId())
-			protorequire.ProtoEqual(t, s.tv.ActivityType(), info.GetActivityType())
+			protorequire.ProtoEqual(t, env.Tv().ActivityType(), info.GetActivityType())
 			require.Equal(t, tc.expectedStatus, info.GetStatus())
 			require.Equal(t, taskQueue.Name, info.GetTaskQueue())
 			require.Equal(t, int32(1), info.GetAttempt())
@@ -3521,6 +3541,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_Completed() 
 }
 
 func (s *standaloneActivityTestSuite) TestPollActivityExecution() {
+	env := s.newTestEnv()
 	testCases := []struct {
 		name                   string
 		taskCompletionFn       func(ctx context.Context, taskToken []byte, activityID, runID string) error
@@ -3529,8 +3550,8 @@ func (s *standaloneActivityTestSuite) TestPollActivityExecution() {
 		{
 			name: "successful completion",
 			taskCompletionFn: func(ctx context.Context, taskToken []byte, _, _ string) error {
-				_, err := s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-					Namespace: s.Namespace().String(),
+				_, err := env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+					Namespace: env.Namespace().String(),
 					TaskToken: taskToken,
 					Result:    defaultResult,
 				})
@@ -3543,8 +3564,8 @@ func (s *standaloneActivityTestSuite) TestPollActivityExecution() {
 		{
 			name: "failure completion",
 			taskCompletionFn: func(ctx context.Context, taskToken []byte, _, _ string) error {
-				_, err := s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-					Namespace: s.Namespace().String(),
+				_, err := env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+					Namespace: env.Namespace().String(),
 					TaskToken: taskToken,
 					Failure:   defaultFailure,
 				})
@@ -3557,16 +3578,16 @@ func (s *standaloneActivityTestSuite) TestPollActivityExecution() {
 		{
 			name: "cancellation",
 			taskCompletionFn: func(ctx context.Context, taskToken []byte, activityID, runID string) error {
-				_, err := s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
-					Namespace:  s.Namespace().String(),
+				_, err := env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+					Namespace:  env.Namespace().String(),
 					ActivityId: activityID,
 					RunId:      runID,
 				})
 				if err != nil {
 					return err
 				}
-				_, err = s.FrontendClient().RespondActivityTaskCanceled(ctx, &workflowservice.RespondActivityTaskCanceledRequest{
-					Namespace: s.Namespace().String(),
+				_, err = env.FrontendClient().RespondActivityTaskCanceled(ctx, &workflowservice.RespondActivityTaskCanceledRequest{
+					Namespace: env.Namespace().String(),
 					TaskToken: taskToken,
 				})
 				return err
@@ -3579,8 +3600,8 @@ func (s *standaloneActivityTestSuite) TestPollActivityExecution() {
 		{
 			name: "termination",
 			taskCompletionFn: func(ctx context.Context, _ []byte, activityID, runID string) error {
-				_, err := s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
-					Namespace:  s.Namespace().String(),
+				_, err := env.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+					Namespace:  env.Namespace().String(),
 					ActivityId: activityID,
 					RunId:      runID,
 					Reason:     "test termination",
@@ -3595,21 +3616,21 @@ func (s *standaloneActivityTestSuite) TestPollActivityExecution() {
 	}
 
 	for _, tc := range testCases {
-		s.Run(tc.name, func() {
+		s.Run(tc.name, func(s *standaloneActivityTestSuite) {
 			t := s.T()
 			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			t.Cleanup(cancel)
-			activityID := s.tv.Any().String()
-			taskQueue := s.tv.TaskQueue().String()
+			activityID := env.Tv().Any().String()
+			taskQueue := env.Tv().TaskQueue().String()
 
-			startResp, err := s.startActivity(ctx, activityID, taskQueue)
+			startResp, err := env.startActivity(ctx, activityID, taskQueue)
 			require.NoError(t, err)
-			pollTaskResp, err := s.pollActivityTaskQueue(ctx, taskQueue)
+			pollTaskResp, err := env.pollActivityTaskQueue(ctx, taskQueue)
 			require.NoError(t, err)
 			err = tc.taskCompletionFn(ctx, pollTaskResp.TaskToken, activityID, startResp.RunId)
 			require.NoError(t, err)
-			pollActivityResp, err := s.FrontendClient().PollActivityExecution(ctx, &workflowservice.PollActivityExecutionRequest{
-				Namespace:  s.Namespace().String(),
+			pollActivityResp, err := env.FrontendClient().PollActivityExecution(ctx, &workflowservice.PollActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
 				ActivityId: activityID,
 				RunId:      startResp.RunId,
 			})
@@ -3622,28 +3643,29 @@ func (s *standaloneActivityTestSuite) TestPollActivityExecution() {
 }
 
 func (s *standaloneActivityTestSuite) TestPollActivityExecution_EmptyRunID() {
+	env := s.newTestEnv()
 	t := s.T()
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	t.Cleanup(cancel)
 
-	activityID := s.tv.Any().String()
-	taskQueue := s.tv.TaskQueue().String()
+	activityID := env.Tv().Any().String()
+	taskQueue := env.Tv().TaskQueue().String()
 
-	startResp, err := s.startActivity(ctx, activityID, taskQueue)
+	startResp, err := env.startActivity(ctx, activityID, taskQueue)
 	require.NoError(t, err)
 
-	pollTaskResp, err := s.pollActivityTaskQueue(ctx, taskQueue)
+	pollTaskResp, err := env.pollActivityTaskQueue(ctx, taskQueue)
 	require.NoError(t, err)
 
-	_, err = s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-		Namespace: s.Namespace().String(),
+	_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+		Namespace: env.Namespace().String(),
 		TaskToken: pollTaskResp.TaskToken,
 		Result:    defaultResult,
 	})
 	require.NoError(t, err)
 
-	pollActivityResp, err := s.FrontendClient().PollActivityExecution(ctx, &workflowservice.PollActivityExecutionRequest{
-		Namespace:  s.Namespace().String(),
+	pollActivityResp, err := env.FrontendClient().PollActivityExecution(ctx, &workflowservice.PollActivityExecutionRequest{
+		Namespace:  env.Namespace().String(),
 		ActivityId: activityID,
 		RunId:      "", // resolves to current run ID
 	})
@@ -3654,16 +3676,17 @@ func (s *standaloneActivityTestSuite) TestPollActivityExecution_EmptyRunID() {
 }
 
 func (s *standaloneActivityTestSuite) TestPollActivityExecution_NotFound() {
+	env := s.newTestEnv()
 	t := s.T()
 	ctx := testcore.NewContext()
 
-	existingActivityID := s.tv.ActivityID()
-	tq := s.tv.TaskQueue()
-	startResp, err := s.startActivity(ctx, existingActivityID, tq.Name)
+	existingActivityID := env.Tv().ActivityID()
+	tq := env.Tv().TaskQueue()
+	startResp, err := env.startActivity(ctx, existingActivityID, tq.Name)
 	require.NoError(t, err)
 	existingRunID := startResp.RunId
 	require.NotEmpty(t, existingRunID)
-	existingNamespace := s.Namespace().String()
+	existingNamespace := env.Namespace().String()
 
 	var notFoundErr *serviceerror.NotFound
 	var namespaceNotFoundErr *serviceerror.NamespaceNotFound
@@ -3708,7 +3731,7 @@ func (s *standaloneActivityTestSuite) TestPollActivityExecution_NotFound() {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := s.FrontendClient().PollActivityExecution(ctx, tc.request)
+			_, err := env.FrontendClient().PollActivityExecution(ctx, tc.request)
 			require.ErrorAs(t, err, &tc.expectedErr) //nolint:testifylint
 			require.Equal(t, tc.expectedErrMsg, tc.expectedErr.Error())
 		})
@@ -3716,10 +3739,11 @@ func (s *standaloneActivityTestSuite) TestPollActivityExecution_NotFound() {
 }
 
 func (s *standaloneActivityTestSuite) TestPollActivityExecution_InvalidArgument() {
+	env := s.newTestEnv()
 	t := s.T()
 	ctx := testcore.NewContext()
 
-	existingNamespace := s.Namespace().String()
+	existingNamespace := env.Namespace().String()
 	validRunID := "11111111-2222-3333-4444-555555555555"
 
 	testCases := []struct {
@@ -3767,7 +3791,7 @@ func (s *standaloneActivityTestSuite) TestPollActivityExecution_InvalidArgument(
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := s.FrontendClient().PollActivityExecution(ctx, tc.request)
+			_, err := env.FrontendClient().PollActivityExecution(ctx, tc.request)
 			var invalidArgErr *serviceerror.InvalidArgument
 			require.ErrorAs(t, err, &invalidArgErr)
 			require.Contains(t, invalidArgErr.Message, tc.expectedErr)
@@ -3778,14 +3802,15 @@ func (s *standaloneActivityTestSuite) TestPollActivityExecution_InvalidArgument(
 // TODO(dan): add tests that DescribeActivityExecution can wait for deletion, termination, cancellation etc
 
 func (s *standaloneActivityTestSuite) TestListActivityExecutions() {
+	env := s.newTestEnv()
 	t := s.T()
 	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
-	activityID := s.tv.ActivityID()
-	activityType := s.tv.ActivityType().GetName()
-	taskQueue := s.tv.TaskQueue().GetName()
-	startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+	activityID := env.Tv().ActivityID()
+	activityType := env.Tv().ActivityType().GetName()
+	taskQueue := env.Tv().TaskQueue().GetName()
+	startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
 	runID := startResp.RunId
 
 	verifyListQuery := func(t *testing.T, query string, pageSize int32) {
@@ -3794,8 +3819,8 @@ func (s *standaloneActivityTestSuite) TestListActivityExecutions() {
 		s.Eventually(
 			func() bool {
 				var err error
-				resp, err = s.FrontendClient().ListActivityExecutions(ctx, &workflowservice.ListActivityExecutionsRequest{
-					Namespace: s.Namespace().String(),
+				resp, err = env.FrontendClient().ListActivityExecutions(ctx, &workflowservice.ListActivityExecutionsRequest{
+					Namespace: env.Namespace().String(),
 					PageSize:  pageSize,
 					Query:     query,
 				})
@@ -3844,15 +3869,15 @@ func (s *standaloneActivityTestSuite) TestListActivityExecutions() {
 		customSAValue := "custom-sa-test-value"
 		customSAActivityID := "custom-sa-activity-id"
 
-		_, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:           s.Namespace().String(),
+		_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
 			ActivityId:          customSAActivityID,
 			ActivityType:        &commonpb.ActivityType{Name: "custom-sa-activity-type"},
-			Identity:            s.tv.WorkerIdentity(),
+			Identity:            env.Tv().WorkerIdentity(),
 			Input:               defaultInput,
-			TaskQueue:           &taskqueuepb.TaskQueue{Name: s.tv.TaskQueue().GetName()},
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: env.Tv().TaskQueue().GetName()},
 			StartToCloseTimeout: durationpb.New(1 * time.Minute),
-			RequestId:           s.tv.RequestID(),
+			RequestId:           env.Tv().RequestID(),
 			SearchAttributes: &commonpb.SearchAttributes{
 				IndexedFields: map[string]*commonpb.Payload{
 					customSAName: payload.EncodeString(customSAValue),
@@ -3865,8 +3890,8 @@ func (s *standaloneActivityTestSuite) TestListActivityExecutions() {
 		s.Eventually(
 			func() bool {
 				var err error
-				resp, err = s.FrontendClient().ListActivityExecutions(ctx, &workflowservice.ListActivityExecutionsRequest{
-					Namespace: s.Namespace().String(),
+				resp, err = env.FrontendClient().ListActivityExecutions(ctx, &workflowservice.ListActivityExecutionsRequest{
+					Namespace: env.Namespace().String(),
 					PageSize:  10,
 					Query:     fmt.Sprintf("%s = '%s'", customSAName, customSAValue),
 				})
@@ -3887,8 +3912,8 @@ func (s *standaloneActivityTestSuite) TestListActivityExecutions() {
 	})
 
 	t.Run("InvalidQuery", func(t *testing.T) {
-		_, err := s.FrontendClient().ListActivityExecutions(ctx, &workflowservice.ListActivityExecutionsRequest{
-			Namespace: s.Namespace().String(),
+		_, err := env.FrontendClient().ListActivityExecutions(ctx, &workflowservice.ListActivityExecutionsRequest{
+			Namespace: env.Namespace().String(),
 			PageSize:  10,
 			Query:     "invalid query syntax !!!",
 		})
@@ -3896,8 +3921,8 @@ func (s *standaloneActivityTestSuite) TestListActivityExecutions() {
 	})
 
 	t.Run("InvalidSearchAttribute", func(t *testing.T) {
-		_, err := s.FrontendClient().ListActivityExecutions(ctx, &workflowservice.ListActivityExecutionsRequest{
-			Namespace: s.Namespace().String(),
+		_, err := env.FrontendClient().ListActivityExecutions(ctx, &workflowservice.ListActivityExecutionsRequest{
+			Namespace: env.Namespace().String(),
 			PageSize:  10,
 			Query:     "NonExistentField = 'value'",
 		})
@@ -3905,7 +3930,7 @@ func (s *standaloneActivityTestSuite) TestListActivityExecutions() {
 	})
 
 	t.Run("NamespaceNotFound", func(t *testing.T) {
-		_, err := s.FrontendClient().ListActivityExecutions(ctx, &workflowservice.ListActivityExecutionsRequest{
+		_, err := env.FrontendClient().ListActivityExecutions(ctx, &workflowservice.ListActivityExecutionsRequest{
 			Namespace: "non-existent-namespace",
 			PageSize:  10,
 			Query:     "",
@@ -3919,7 +3944,7 @@ func (s *standaloneActivityTestSuite) TestListActivityExecutions() {
 
 	t.Run("ExceededPageSizeIsCapped", func(t *testing.T) {
 		maxPageSize := int32(1)
-		cleanup := s.OverrideDynamicConfig(
+		cleanup := env.OverrideDynamicConfig(
 			dynamicconfig.FrontendVisibilityMaxPageSize,
 			maxPageSize,
 		)
@@ -3929,16 +3954,16 @@ func (s *standaloneActivityTestSuite) TestListActivityExecutions() {
 
 		// Start multiple activities of the same type
 		for range 2 {
-			_, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-				Namespace:           s.Namespace().String(),
+			_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+				Namespace:           env.Namespace().String(),
 				ActivityId:          testcore.RandomizeStr(t.Name()),
 				ActivityType:        &commonpb.ActivityType{Name: testActivityType},
-				Identity:            s.tv.WorkerIdentity(),
+				Identity:            env.Tv().WorkerIdentity(),
 				StartToCloseTimeout: durationpb.New(10 * time.Second),
 				TaskQueue: &taskqueuepb.TaskQueue{
 					Name: taskQueue,
 				},
-				RequestId: s.tv.RequestID(),
+				RequestId: env.Tv().RequestID(),
 			})
 			require.NoError(t, err)
 		}
@@ -3946,8 +3971,8 @@ func (s *standaloneActivityTestSuite) TestListActivityExecutions() {
 		// Wait for both activities to be indexed in Elasticsearch before testing pagination
 		s.Eventually(
 			func() bool {
-				countResp, err := s.FrontendClient().CountActivityExecutions(ctx, &workflowservice.CountActivityExecutionsRequest{
-					Namespace: s.Namespace().String(),
+				countResp, err := env.FrontendClient().CountActivityExecutions(ctx, &workflowservice.CountActivityExecutionsRequest{
+					Namespace: env.Namespace().String(),
 					Query:     fmt.Sprintf("ActivityType = '%s'", testActivityType),
 				})
 				return err == nil && countResp.GetCount() == 2
@@ -3959,8 +3984,8 @@ func (s *standaloneActivityTestSuite) TestListActivityExecutions() {
 		// Get first page. Use pageSize > FrontendVisibilityMaxPageSize to test it is capped by the server
 		var resp *workflowservice.ListActivityExecutionsResponse
 		var err error
-		resp, err = s.FrontendClient().ListActivityExecutions(ctx, &workflowservice.ListActivityExecutionsRequest{
-			Namespace: s.Namespace().String(),
+		resp, err = env.FrontendClient().ListActivityExecutions(ctx, &workflowservice.ListActivityExecutionsRequest{
+			Namespace: env.Namespace().String(),
 			PageSize:  maxPageSize + 1,
 			Query:     fmt.Sprintf("ActivityType = '%s'", testActivityType),
 		})
@@ -3968,8 +3993,8 @@ func (s *standaloneActivityTestSuite) TestListActivityExecutions() {
 		require.Len(t, resp.GetExecutions(), 1)
 
 		// Get next page. Use pageSize > FrontendVisibilityMaxPageSize to test it is capped by the server
-		resp, err = s.FrontendClient().ListActivityExecutions(ctx, &workflowservice.ListActivityExecutionsRequest{
-			Namespace:     s.Namespace().String(),
+		resp, err = env.FrontendClient().ListActivityExecutions(ctx, &workflowservice.ListActivityExecutionsRequest{
+			Namespace:     env.Namespace().String(),
 			PageSize:      maxPageSize + 1,
 			Query:         fmt.Sprintf("ActivityType = '%s'", testActivityType),
 			NextPageToken: resp.GetNextPageToken(),
@@ -3978,8 +4003,8 @@ func (s *standaloneActivityTestSuite) TestListActivityExecutions() {
 		require.Len(t, resp.GetExecutions(), 1)
 
 		// Ensure no more results
-		resp, err = s.FrontendClient().ListActivityExecutions(ctx, &workflowservice.ListActivityExecutionsRequest{
-			Namespace:     s.Namespace().String(),
+		resp, err = env.FrontendClient().ListActivityExecutions(ctx, &workflowservice.ListActivityExecutionsRequest{
+			Namespace:     env.Namespace().String(),
 			PageSize:      maxPageSize + 1,
 			Query:         fmt.Sprintf("ActivityType = '%s'", testActivityType),
 			NextPageToken: resp.GetNextPageToken(),
@@ -3991,20 +4016,21 @@ func (s *standaloneActivityTestSuite) TestListActivityExecutions() {
 }
 
 func (s *standaloneActivityTestSuite) TestCountActivityExecutions() {
+	env := s.newTestEnv()
 	t := s.T()
 	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
-	activityID := s.tv.ActivityID()
-	activityType := s.tv.ActivityType().GetName()
-	s.startAndValidateActivity(ctx, t, activityID, s.tv.TaskQueue().GetName())
+	activityID := env.Tv().ActivityID()
+	activityType := env.Tv().ActivityType().GetName()
+	env.startAndValidateActivity(ctx, t, activityID, env.Tv().TaskQueue().GetName())
 
 	verifyCountQuery := func(t *testing.T, query string, expectedCount int) {
 		t.Helper()
 		s.Eventually(
 			func() bool {
-				resp, err := s.FrontendClient().CountActivityExecutions(ctx, &workflowservice.CountActivityExecutionsRequest{
-					Namespace: s.Namespace().String(),
+				resp, err := env.FrontendClient().CountActivityExecutions(ctx, &workflowservice.CountActivityExecutionsRequest{
+					Namespace: env.Namespace().String(),
 					Query:     query,
 				})
 				return err == nil && resp.GetCount() == int64(expectedCount)
@@ -4027,16 +4053,16 @@ func (s *standaloneActivityTestSuite) TestCountActivityExecutions() {
 	})
 
 	t.Run("CountByTaskQueue", func(t *testing.T) {
-		verifyCountQuery(t, fmt.Sprintf("TaskQueue = '%s' AND ActivityType = '%s'", s.tv.TaskQueue().GetName(), activityType), 1)
+		verifyCountQuery(t, fmt.Sprintf("TaskQueue = '%s' AND ActivityType = '%s'", env.Tv().TaskQueue().GetName(), activityType), 1)
 	})
 
 	t.Run("GroupByExecutionStatus", func(t *testing.T) {
 		groupByType := &commonpb.ActivityType{Name: "count-groupby-test-type"}
-		taskQueue := s.tv.TaskQueue().GetName()
+		taskQueue := env.Tv().TaskQueue().GetName()
 
 		for i := range 3 {
 			id := fmt.Sprintf("%s-%d", groupByType.Name, i)
-			resp, err := s.startActivityWithType(ctx, id, taskQueue, groupByType)
+			resp, err := env.startActivityWithType(ctx, id, taskQueue, groupByType)
 			require.NoError(t, err)
 			require.NotEmpty(t, resp.GetRunId())
 		}
@@ -4046,8 +4072,8 @@ func (s *standaloneActivityTestSuite) TestCountActivityExecutions() {
 		s.Eventually(
 			func() bool {
 				var err error
-				resp, err = s.FrontendClient().CountActivityExecutions(ctx, &workflowservice.CountActivityExecutionsRequest{
-					Namespace: s.Namespace().String(),
+				resp, err = env.FrontendClient().CountActivityExecutions(ctx, &workflowservice.CountActivityExecutionsRequest{
+					Namespace: env.Namespace().String(),
 					Query:     query,
 				})
 				return err == nil && resp.GetCount() == 3
@@ -4067,8 +4093,8 @@ func (s *standaloneActivityTestSuite) TestCountActivityExecutions() {
 		customSAName := "ActivityCountCustomKeyword"
 		customSAValue := "count-custom-sa-value"
 
-		_, err := s.OperatorClient().AddSearchAttributes(ctx, &operatorservice.AddSearchAttributesRequest{
-			Namespace: s.Namespace().String(),
+		_, err := env.OperatorClient().AddSearchAttributes(ctx, &operatorservice.AddSearchAttributesRequest{
+			Namespace: env.Namespace().String(),
 			SearchAttributes: map[string]enumspb.IndexedValueType{
 				customSAName: enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 			},
@@ -4076,8 +4102,8 @@ func (s *standaloneActivityTestSuite) TestCountActivityExecutions() {
 		require.NoError(t, err)
 
 		s.Eventually(func() bool {
-			descResp, err := s.OperatorClient().ListSearchAttributes(ctx, &operatorservice.ListSearchAttributesRequest{
-				Namespace: s.Namespace().String(),
+			descResp, err := env.OperatorClient().ListSearchAttributes(ctx, &operatorservice.ListSearchAttributesRequest{
+				Namespace: env.Namespace().String(),
 			})
 			if err != nil {
 				return false
@@ -4087,15 +4113,15 @@ func (s *standaloneActivityTestSuite) TestCountActivityExecutions() {
 		}, 10*time.Second, 100*time.Millisecond)
 
 		for i := range 2 {
-			_, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-				Namespace:           s.Namespace().String(),
+			_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+				Namespace:           env.Namespace().String(),
 				ActivityId:          fmt.Sprintf("count-custom-sa-%d", i),
 				ActivityType:        &commonpb.ActivityType{Name: "count-custom-sa-type"},
-				Identity:            s.tv.WorkerIdentity(),
+				Identity:            env.Tv().WorkerIdentity(),
 				Input:               defaultInput,
-				TaskQueue:           &taskqueuepb.TaskQueue{Name: s.tv.TaskQueue().GetName()},
+				TaskQueue:           &taskqueuepb.TaskQueue{Name: env.Tv().TaskQueue().GetName()},
 				StartToCloseTimeout: durationpb.New(1 * time.Minute),
-				RequestId:           s.tv.RequestID(),
+				RequestId:           env.Tv().RequestID(),
 				SearchAttributes: &commonpb.SearchAttributes{
 					IndexedFields: map[string]*commonpb.Payload{
 						customSAName: payload.EncodeString(customSAValue),
@@ -4107,8 +4133,8 @@ func (s *standaloneActivityTestSuite) TestCountActivityExecutions() {
 
 		s.Eventually(
 			func() bool {
-				resp, err := s.FrontendClient().CountActivityExecutions(ctx, &workflowservice.CountActivityExecutionsRequest{
-					Namespace: s.Namespace().String(),
+				resp, err := env.FrontendClient().CountActivityExecutions(ctx, &workflowservice.CountActivityExecutionsRequest{
+					Namespace: env.Namespace().String(),
 					Query:     fmt.Sprintf("%s = '%s'", customSAName, customSAValue),
 				})
 				return err == nil && resp.GetCount() == 2
@@ -4119,8 +4145,8 @@ func (s *standaloneActivityTestSuite) TestCountActivityExecutions() {
 	})
 
 	t.Run("GroupByUnsupportedField", func(t *testing.T) {
-		_, err := s.FrontendClient().CountActivityExecutions(ctx, &workflowservice.CountActivityExecutionsRequest{
-			Namespace: s.Namespace().String(),
+		_, err := env.FrontendClient().CountActivityExecutions(ctx, &workflowservice.CountActivityExecutionsRequest{
+			Namespace: env.Namespace().String(),
 			Query:     "GROUP BY ActivityType",
 		})
 		s.ErrorAs(err, new(*serviceerror.InvalidArgument))
@@ -4128,23 +4154,23 @@ func (s *standaloneActivityTestSuite) TestCountActivityExecutions() {
 	})
 
 	t.Run("InvalidQuery", func(t *testing.T) {
-		_, err := s.FrontendClient().CountActivityExecutions(ctx, &workflowservice.CountActivityExecutionsRequest{
-			Namespace: s.Namespace().String(),
+		_, err := env.FrontendClient().CountActivityExecutions(ctx, &workflowservice.CountActivityExecutionsRequest{
+			Namespace: env.Namespace().String(),
 			Query:     "invalid query syntax !!!",
 		})
 		s.ErrorAs(err, new(*serviceerror.InvalidArgument))
 	})
 
 	t.Run("InvalidSearchAttribute", func(t *testing.T) {
-		_, err := s.FrontendClient().CountActivityExecutions(ctx, &workflowservice.CountActivityExecutionsRequest{
-			Namespace: s.Namespace().String(),
+		_, err := env.FrontendClient().CountActivityExecutions(ctx, &workflowservice.CountActivityExecutionsRequest{
+			Namespace: env.Namespace().String(),
 			Query:     "NonExistentField = 'value'",
 		})
 		s.ErrorAs(err, new(*serviceerror.InvalidArgument))
 	})
 
 	t.Run("NamespaceNotFound", func(t *testing.T) {
-		_, err := s.FrontendClient().CountActivityExecutions(ctx, &workflowservice.CountActivityExecutionsRequest{
+		_, err := env.FrontendClient().CountActivityExecutions(ctx, &workflowservice.CountActivityExecutionsRequest{
 			Namespace: "non-existent-namespace",
 			Query:     "",
 		})
@@ -4153,16 +4179,17 @@ func (s *standaloneActivityTestSuite) TestCountActivityExecutions() {
 }
 
 func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_DeadlineExceeded() {
+	env := s.newTestEnv()
 	t := s.T()
 	ctx := testcore.NewContext()
 
 	// Start an activity and get initial long-poll state token
-	activityID := s.tv.ActivityID()
-	taskQueue := s.tv.TaskQueue()
-	startResp, err := s.startActivity(ctx, activityID, taskQueue.Name)
+	activityID := env.Tv().ActivityID()
+	taskQueue := env.Tv().TaskQueue()
+	startResp, err := env.startActivity(ctx, activityID, taskQueue.Name)
 	require.NoError(t, err)
-	describeResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-		Namespace:  s.Namespace().String(),
+	describeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+		Namespace:  env.Namespace().String(),
 		ActivityId: activityID,
 		RunId:      startResp.RunId,
 	})
@@ -4178,17 +4205,17 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_DeadlineExce
 	// result with at least buffer remaining before the caller deadline.
 	t.Run("CallerDeadlineNotExceeded", func(t *testing.T) {
 		// CallerTimeout - LongPollBuffer is far in the future
-		cleanup1 := s.OverrideDynamicConfig(activity.LongPollBuffer, 1*time.Second)
+		cleanup1 := env.OverrideDynamicConfig(activity.LongPollBuffer, 1*time.Second)
 		defer cleanup1()
 		ctx, cancel := context.WithTimeout(ctx, 9999*time.Millisecond)
 		defer cancel()
 
 		// DescribeActivityExecution will return when this long poll timeout expires.
-		cleanup2 := s.OverrideDynamicConfig(activity.LongPollTimeout, 10*time.Millisecond)
+		cleanup2 := env.OverrideDynamicConfig(activity.LongPollTimeout, 10*time.Millisecond)
 		defer cleanup2()
 
-		describeResp, err = s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:     s.Namespace().String(),
+		describeResp, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:     env.Namespace().String(),
 			ActivityId:    activityID,
 			RunId:         startResp.RunId,
 			LongPollToken: describeResp.LongPollToken,
@@ -4207,14 +4234,14 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_DeadlineExce
 		// will have a 30s deadline that was applied by one of the upstream server layers, so we
 		// still must use a buffer < 30s.
 		ctx := context.Background()
-		cleanup1 := s.OverrideDynamicConfig(activity.LongPollBuffer, 29*time.Second)
+		cleanup1 := env.OverrideDynamicConfig(activity.LongPollBuffer, 29*time.Second)
 		defer cleanup1()
 		// DescribeActivityExecution will return when this long poll timeout expires.
-		cleanup2 := s.OverrideDynamicConfig(activity.LongPollTimeout, 10*time.Millisecond)
+		cleanup2 := env.OverrideDynamicConfig(activity.LongPollTimeout, 10*time.Millisecond)
 		defer cleanup2()
 
-		_, err = s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:     s.Namespace().String(),
+		_, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:     env.Namespace().String(),
 			ActivityId:    activityID,
 			RunId:         startResp.RunId,
 			LongPollToken: describeResp.LongPollToken,
@@ -4229,16 +4256,17 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_DeadlineExce
 }
 
 func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_NotFound() {
+	env := s.newTestEnv()
 	t := s.T()
 	ctx := testcore.NewContext()
 
-	existingActivityID := s.tv.ActivityID()
-	tq := s.tv.TaskQueue()
-	startResp, err := s.startActivity(ctx, existingActivityID, tq.Name)
+	existingActivityID := env.Tv().ActivityID()
+	tq := env.Tv().TaskQueue()
+	startResp, err := env.startActivity(ctx, existingActivityID, tq.Name)
 	require.NoError(t, err)
 	existingRunID := startResp.RunId
 	require.NotEmpty(t, existingRunID)
-	existingNamespace := s.Namespace().String()
+	existingNamespace := env.Namespace().String()
 
 	var notFoundErr *serviceerror.NotFound
 	var namespaceNotFoundErr *serviceerror.NamespaceNotFound
@@ -4283,7 +4311,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_NotFound() {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := s.FrontendClient().DescribeActivityExecution(ctx, tc.request)
+			_, err := env.FrontendClient().DescribeActivityExecution(ctx, tc.request)
 			require.ErrorAs(t, err, &tc.expectedErr) //nolint:testifylint
 			require.Equal(t, tc.expectedErrMsg, tc.expectedErr.Error())
 		})
@@ -4291,7 +4319,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_NotFound() {
 
 	t.Run("LongPollNonExistentActivity", func(t *testing.T) {
 		// Poll to get a token
-		validPollResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+		validPollResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
 			Namespace:  existingNamespace,
 			ActivityId: existingActivityID,
 			RunId:      existingRunID,
@@ -4299,7 +4327,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_NotFound() {
 		require.NoError(t, err)
 
 		// Use the token with a non-existent activity
-		_, err = s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+		_, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
 			Namespace:     existingNamespace,
 			ActivityId:    "non-existent-activity",
 			RunId:         existingRunID,
@@ -4312,17 +4340,17 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_NotFound() {
 }
 
 func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_InvalidArgument() {
-
+	env := s.newTestEnv()
 	t := s.T()
 	ctx := testcore.NewContext()
 
-	existingActivityID := s.tv.ActivityID()
-	tq := s.tv.TaskQueue()
-	startResp, err := s.startActivity(ctx, existingActivityID, tq.Name)
+	existingActivityID := env.Tv().ActivityID()
+	tq := env.Tv().TaskQueue()
+	startResp, err := env.startActivity(ctx, existingActivityID, tq.Name)
 	require.NoError(t, err)
 	existingRunID := startResp.RunId
 	require.NotEmpty(t, existingRunID)
-	existingNamespace := s.Namespace().String()
+	existingNamespace := env.Namespace().String()
 
 	validActivityID := "activity-id"
 	validRunID := "11111111-2222-3333-4444-555555555555"
@@ -4410,7 +4438,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_InvalidArgum
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := s.FrontendClient().DescribeActivityExecution(ctx, tc.request)
+			_, err := env.FrontendClient().DescribeActivityExecution(ctx, tc.request)
 			if tc.expectedErr == "" {
 				require.NoError(t, err)
 				return
@@ -4422,7 +4450,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_InvalidArgum
 	}
 
 	t.Run("LongPollTokenFromWrongExecution", func(t *testing.T) {
-		validPollResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+		validPollResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
 			Namespace:  existingNamespace,
 			ActivityId: existingActivityID,
 			RunId:      existingRunID,
@@ -4430,12 +4458,12 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_InvalidArgum
 		require.NoError(t, err)
 		require.NotEmpty(t, validPollResp.LongPollToken)
 
-		activityID2 := s.tv.Any().String()
-		startResp2, err := s.startActivity(ctx, activityID2, tq.Name)
+		activityID2 := env.Tv().Any().String()
+		startResp2, err := env.startActivity(ctx, activityID2, tq.Name)
 		require.NoError(t, err)
 		require.NotEmpty(t, startResp2.GetRunId())
 
-		_, err = s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+		_, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
 			Namespace:     existingNamespace,
 			ActivityId:    activityID2,
 			RunId:         startResp2.GetRunId(),
@@ -4448,7 +4476,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_InvalidArgum
 
 	t.Run("LongPollTokenFromDifferentNamespace", func(t *testing.T) {
 		// Get a valid poll token from activity in main namespace
-		validPollResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+		validPollResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
 			Namespace:  existingNamespace,
 			ActivityId: existingActivityID,
 			RunId:      existingRunID,
@@ -4457,25 +4485,25 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_InvalidArgum
 		require.NotEmpty(t, validPollResp.LongPollToken)
 
 		// Start an activity in a different namespace
-		externalNamespace := s.ExternalNamespace().String()
-		externalActivityID := s.tv.Any().String()
-		externalStartResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+		externalNamespace := env.ExternalNamespace().String()
+		externalActivityID := env.Tv().Any().String()
+		externalStartResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
 			Namespace:    externalNamespace,
 			ActivityId:   externalActivityID,
-			ActivityType: s.tv.ActivityType(),
-			Identity:     s.tv.WorkerIdentity(),
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: tq.Name,
 			},
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-			RequestId:           s.tv.Any().String(),
+			RequestId:           env.Tv().Any().String(),
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, externalStartResp.GetRunId())
 
 		// Try to use main namespace's poll token with external namespace's activity
-		_, err = s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+		_, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
 			Namespace:     externalNamespace,
 			ActivityId:    externalActivityID,
 			RunId:         externalStartResp.GetRunId(),
@@ -4488,6 +4516,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_InvalidArgum
 }
 
 func (s *standaloneActivityTestSuite) TestHeartbeat() {
+	env := s.newTestEnv()
 	t := s.T()
 	ctx := testcore.NewContext()
 	heartbeatDetails := payloads.EncodeString("Heartbeat Details")
@@ -4512,8 +4541,8 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				_, err := s.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
-					Namespace: s.Namespace().String(),
+				_, err := env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
+					Namespace: env.Namespace().String(),
 					TaskToken: tc.taskToken,
 					Details:   heartbeatDetails,
 				})
@@ -4530,25 +4559,25 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		// Start an activity and get a valid task token, then complete it
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
-		_, err := s.startActivity(ctx, activityID, taskQueue)
+		_, err := env.startActivity(ctx, activityID, taskQueue)
 		require.NoError(t, err)
 
-		pollResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		pollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollResp.TaskToken,
 			Result:    defaultResult,
 		})
 		require.NoError(t, err)
 
 		// Heartbeat with stale token (activity already completed)
-		_, err = s.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollResp.TaskToken,
 			Details:   heartbeatDetails,
 		})
@@ -4564,10 +4593,10 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		_, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:              s.Namespace().String(),
+		_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
 			ActivityId:             activityID,
-			ActivityType:           s.tv.ActivityType(),
+			ActivityType:           env.Tv().ActivityType(),
 			TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
 			ScheduleToCloseTimeout: durationpb.New(1 * time.Minute),
 			RetryPolicy: &commonpb.RetryPolicy{
@@ -4577,16 +4606,16 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		require.NoError(t, err)
 
 		// Poll and get task token for attempt 1
-		attempt1Resp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		attempt1Resp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 		require.EqualValues(t, 1, attempt1Resp.Attempt)
 
 		// Fail the task with NextRetryDelay to control retry timing
-		_, err = s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: attempt1Resp.TaskToken,
 			Failure: &failurepb.Failure{
 				Message: "retryable failure",
@@ -4599,24 +4628,24 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		require.NoError(t, err)
 
 		// Poll to get attempt 2 (ensures retry has happened)
-		attempt2Resp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		attempt2Resp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 		require.EqualValues(t, 2, attempt2Resp.Attempt)
 
 		// Heartbeat with the attempt 2 token
-		_, err = s.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: attempt2Resp.TaskToken,
 			Details:   heartbeatDetails,
 		})
 		require.NoError(t, err)
 
 		// Try to heartbeat with the old attempt 1 token - should fail with NotFound
-		_, err = s.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: attempt1Resp.TaskToken,
 			Details:   heartbeatDetails,
 		})
@@ -4631,10 +4660,10 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		_, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:              s.Namespace().String(),
+		_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
 			ActivityId:             activityID,
-			ActivityType:           s.tv.ActivityType(),
+			ActivityType:           env.Tv().ActivityType(),
 			TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
 			Input:                  defaultInput,
 			ScheduleToCloseTimeout: durationpb.New(1 * time.Minute),
@@ -4645,15 +4674,15 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		require.NoError(t, err)
 
 		// Poll and fail attempt 1 retryably.
-		attempt1Resp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		attempt1Resp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 		require.EqualValues(t, 1, attempt1Resp.Attempt)
 
-		_, err = s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: attempt1Resp.TaskToken,
 			Failure: &failurepb.Failure{
 				Message: "retryable failure",
@@ -4666,16 +4695,16 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		require.NoError(t, err)
 
 		// Poll to start attempt 2.
-		attempt2Resp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		attempt2Resp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 		require.EqualValues(t, 2, attempt2Resp.Attempt)
 
 		// Heartbeat by ID — must succeed on attempt 2.
-		_, err = s.FrontendClient().RecordActivityTaskHeartbeatById(ctx, &workflowservice.RecordActivityTaskHeartbeatByIdRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().RecordActivityTaskHeartbeatById(ctx, &workflowservice.RecordActivityTaskHeartbeatByIdRequest{
+			Namespace:  env.Namespace().String(),
 			RunId:      attempt2Resp.ActivityRunId,
 			ActivityId: activityID,
 			Details:    heartbeatDetails,
@@ -4687,33 +4716,33 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		// Start an activity and get a valid task token, then complete it
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
-		existingNamespace := s.Namespace().String()
-		_, err := s.startActivity(ctx, activityID, taskQueue)
+		existingNamespace := env.Namespace().String()
+		_, err := env.startActivity(ctx, activityID, taskQueue)
 		require.NoError(t, err)
 
-		pollResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+		pollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
 			Namespace: existingNamespace,
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 
 		// Start an activity in a different namespace and try to heartbeat with existing token
-		externalNamespace := s.ExternalNamespace().String()
-		_, err = s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+		externalNamespace := env.ExternalNamespace().String()
+		_, err = env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
 			Namespace:    externalNamespace,
 			ActivityId:   activityID,
-			ActivityType: s.tv.ActivityType(),
-			Identity:     s.tv.WorkerIdentity(),
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 			},
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-			RequestId:           s.tv.Any().String(),
+			RequestId:           env.Tv().Any().String(),
 		})
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
+		_, err = env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
 			Namespace: externalNamespace,
 			TaskToken: pollResp.TaskToken,
 			Details:   heartbeatDetails,
@@ -4729,13 +4758,13 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 	t.Run("MismatchedTokenComponentRef", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
-		existingNamespace := s.Namespace().String()
+		existingNamespace := env.Namespace().String()
 
 		// Start activity in namespace A and get its task token
-		_, err := s.startActivity(ctx, activityID, taskQueue)
+		_, err := env.startActivity(ctx, activityID, taskQueue)
 		require.NoError(t, err)
 
-		pollResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+		pollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
 			Namespace: existingNamespace,
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
@@ -4743,23 +4772,23 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 
 		// Start another activity in namespace B with the same activity ID
 		// (different namespaces allow same activity IDs)
-		externalNamespace := s.ExternalNamespace().String()
-		_, err = s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+		externalNamespace := env.ExternalNamespace().String()
+		_, err = env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
 			Namespace:    externalNamespace,
 			ActivityId:   activityID,
-			ActivityType: s.tv.ActivityType(),
-			Identity:     s.tv.WorkerIdentity(),
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 			},
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-			RequestId:           s.tv.Any().String(),
+			RequestId:           env.Tv().Any().String(),
 		})
 		require.NoError(t, err)
 
 		// Poll for the task from namespace B
-		externalPollResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+		externalPollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
 			Namespace: externalNamespace,
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
@@ -4777,7 +4806,7 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		existingTaskToken, err := tasktoken.NewSerializer().Serialize(existingTask)
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
+		_, err = env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
 			Namespace: existingNamespace,
 			TaskToken: existingTaskToken,
 			Details:   heartbeatDetails,
@@ -4795,10 +4824,10 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:           s.Namespace().String(),
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
 			ActivityId:          activityID,
-			ActivityType:        s.tv.ActivityType(),
+			ActivityType:        env.Tv().ActivityType(),
 			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
 			StartToCloseTimeout: durationpb.New(1 * time.Minute),
 		})
@@ -4806,15 +4835,15 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		runID := startResp.RunId
 
 		// Worker accepts task
-		pollResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		pollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 
 		// Heartbeat before cancellation - cancel_requested should be false
-		hbResp, err := s.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
-			Namespace: s.Namespace().String(),
+		hbResp, err := env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollResp.TaskToken,
 			Details:   heartbeatDetails,
 		})
@@ -4822,18 +4851,18 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		require.False(t, hbResp.CancelRequested)
 
 		// Request cancellation
-		_, err = s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      runID,
-			RequestId:  s.tv.RequestID(),
+			RequestId:  env.Tv().RequestID(),
 			Reason:     "test cancellation",
 		})
 		require.NoError(t, err)
 
 		// Heartbeat after cancellation - cancel_requested should be true
-		hbResp, err = s.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
-			Namespace: s.Namespace().String(),
+		hbResp, err = env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollResp.TaskToken,
 			Details:   heartbeatDetails,
 		})
@@ -4848,10 +4877,10 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		_, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:              s.Namespace().String(),
+		_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
 			ActivityId:             activityID,
-			ActivityType:           s.tv.ActivityType(),
+			ActivityType:           env.Tv().ActivityType(),
 			TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
 			StartToCloseTimeout:    durationpb.New(1 * time.Minute),
 			ScheduleToCloseTimeout: durationpb.New(5 * time.Minute),
@@ -4863,8 +4892,8 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		require.NoError(t, err)
 
 		// First attempt: worker accepts task
-		pollResp1, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		pollResp1, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
@@ -4872,16 +4901,16 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		require.Nil(t, pollResp1.HeartbeatDetails) // No heartbeat details on first attempt
 
 		// Worker heartbeats with details
-		_, err = s.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollResp1.TaskToken,
 			Details:   heartbeatDetails,
 		})
 		require.NoError(t, err)
 
 		// Worker fails with retryable error
-		_, err = s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollResp1.TaskToken,
 			Failure: &failurepb.Failure{
 				Message: "retryable failure",
@@ -4895,8 +4924,8 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		require.NoError(t, err)
 
 		// Second attempt: worker accepts retry task
-		pollResp2, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		pollResp2, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
@@ -4905,15 +4934,15 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		// Verify: heartbeat details from first attempt are available
 		protorequire.ProtoEqual(t, heartbeatDetails, pollResp2.HeartbeatDetails)
 
-		_, err = s.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollResp2.TaskToken,
 			Details:   heartbeatDetails,
 		})
 		require.NoError(t, err)
 
-		desc, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		desc, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 		})
 		require.NoError(t, err)
@@ -4928,10 +4957,10 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:           s.Namespace().String(),
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
 			ActivityId:          activityID,
-			ActivityType:        s.tv.ActivityType(),
+			ActivityType:        env.Tv().ActivityType(),
 			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
 			StartToCloseTimeout: durationpb.New(1 * time.Minute),
 			HeartbeatTimeout:    durationpb.New(1 * time.Second),
@@ -4942,16 +4971,16 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		require.NoError(t, err)
 
 		// Worker accepts task (starts the activity)
-		pollTaskResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		pollTaskResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, pollTaskResp.TaskToken)
 
 		// Long poll for completion (heartbeat timeout will fire)
-		pollResp, err := s.FrontendClient().PollActivityExecution(ctx, &workflowservice.PollActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		pollResp, err := env.FrontendClient().PollActivityExecution(ctx, &workflowservice.PollActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      startResp.RunId,
 		})
@@ -4967,10 +4996,10 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		_, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:              s.Namespace().String(),
+		_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
 			ActivityId:             activityID,
-			ActivityType:           s.tv.ActivityType(),
+			ActivityType:           env.Tv().ActivityType(),
 			TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
 			StartToCloseTimeout:    durationpb.New(1 * time.Minute),
 			ScheduleToCloseTimeout: durationpb.New(5 * time.Minute),
@@ -4983,8 +5012,8 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		require.NoError(t, err)
 
 		// Attempt 1: worker accepts task
-		pollTaskResp1, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		pollTaskResp1, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
@@ -4992,8 +5021,8 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 
 		// Don't heartbeat - let it timeout and retry
 		// Second attempt: worker accepts retry task
-		pollTaskResp2, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		pollTaskResp2, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
@@ -5007,10 +5036,10 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:           s.Namespace().String(),
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
 			ActivityId:          activityID,
-			ActivityType:        s.tv.ActivityType(),
+			ActivityType:        env.Tv().ActivityType(),
 			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
 			StartToCloseTimeout: durationpb.New(1 * time.Minute),
 			HeartbeatTimeout:    durationpb.New(1 * time.Second),
@@ -5021,8 +5050,8 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		require.NoError(t, err)
 
 		// Worker accepts task
-		pollTaskResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		pollTaskResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
@@ -5030,8 +5059,8 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 
 		// Heartbeat before timeout
 		time.Sleep(600 * time.Millisecond) //nolint:forbidigo
-		_, err = s.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollTaskResp.TaskToken,
 			Details:   heartbeatDetails,
 		})
@@ -5039,24 +5068,24 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 
 		// Wait again, then heartbeat again
 		time.Sleep(600 * time.Millisecond) //nolint:forbidigo
-		_, err = s.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollTaskResp.TaskToken,
 			Details:   heartbeatDetails,
 		})
 		require.NoError(t, err)
 
 		// Complete the activity
-		_, err = s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollTaskResp.TaskToken,
 			Result:    defaultResult,
 		})
 		require.NoError(t, err)
 
 		// Verify activity completed successfully (didn't timeout)
-		pollResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:      s.Namespace().String(),
+		pollResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:      env.Namespace().String(),
 			ActivityId:     activityID,
 			RunId:          startResp.RunId,
 			IncludeOutcome: true,
@@ -5075,10 +5104,10 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:           s.Namespace().String(),
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
 			ActivityId:          activityID,
-			ActivityType:        s.tv.ActivityType(),
+			ActivityType:        env.Tv().ActivityType(),
 			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
 			StartToCloseTimeout: durationpb.New(1 * time.Minute),
 			// No HeartbeatTimeout set.
@@ -5088,15 +5117,15 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		})
 		require.NoError(t, err)
 
-		pollTaskResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		pollTaskResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, pollTaskResp.TaskToken)
 
-		_, err = s.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollTaskResp.TaskToken,
 			Details:   heartbeatDetails,
 		})
@@ -5106,8 +5135,8 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		time.Sleep(2 * time.Second) //nolint:forbidigo
 
 		// Activity should still be running.
-		descResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      startResp.RunId,
 		})
@@ -5117,15 +5146,15 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		require.Equal(t, int64(1), descResp.GetInfo().GetTotalHeartbeatCount(), "total heartbeat count")
 
 		// Complete the activity to confirm it's still operable.
-		_, err = s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollTaskResp.TaskToken,
 			Result:    defaultResult,
 		})
 		require.NoError(t, err)
 
-		descResp, err = s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:      s.Namespace().String(),
+		descResp, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:      env.Namespace().String(),
 			ActivityId:     activityID,
 			RunId:          startResp.RunId,
 			IncludeOutcome: true,
@@ -5144,10 +5173,10 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:           s.Namespace().String(),
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
 			ActivityId:          activityID,
-			ActivityType:        s.tv.ActivityType(),
+			ActivityType:        env.Tv().ActivityType(),
 			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
 			StartToCloseTimeout: durationpb.New(1 * time.Minute),
 			HeartbeatTimeout:    durationpb.New(1 * time.Second),
@@ -5158,16 +5187,16 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		require.NoError(t, err)
 
 		// Worker accepts task
-		pollTaskResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		pollTaskResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, pollTaskResp.TaskToken)
 
 		// Heartbeat before timeout
-		_, err = s.FrontendClient().RecordActivityTaskHeartbeatById(ctx, &workflowservice.RecordActivityTaskHeartbeatByIdRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().RecordActivityTaskHeartbeatById(ctx, &workflowservice.RecordActivityTaskHeartbeatByIdRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      startResp.RunId,
 			Details:    heartbeatDetails,
@@ -5175,16 +5204,16 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		require.NoError(t, err)
 
 		// Complete the activity
-		_, err = s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollTaskResp.TaskToken,
 			Result:    defaultResult,
 		})
 		require.NoError(t, err)
 
 		// Verify activity completed successfully (didn't timeout)
-		pollResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:      s.Namespace().String(),
+		pollResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:      env.Namespace().String(),
 			ActivityId:     activityID,
 			RunId:          startResp.RunId,
 			IncludeOutcome: true,
@@ -5200,32 +5229,32 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:           s.Namespace().String(),
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
 			ActivityId:          activityID,
-			ActivityType:        s.tv.ActivityType(),
+			ActivityType:        env.Tv().ActivityType(),
 			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
 			StartToCloseTimeout: durationpb.New(1 * time.Minute),
 		})
 		require.NoError(t, err)
 
-		pollTaskResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		pollTaskResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		})
 		require.NoError(t, err)
 
 		const numHeartbeats = 5
 		for i := range numHeartbeats {
-			_, err = s.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
-				Namespace: s.Namespace().String(),
+			_, err = env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
+				Namespace: env.Namespace().String(),
 				TaskToken: pollTaskResp.TaskToken,
 				Details:   heartbeatDetails,
 			})
 			require.NoError(t, err)
 
-			descResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:  s.Namespace().String(),
+			descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
 				ActivityId: activityID,
 				RunId:      startResp.RunId,
 			})
@@ -5236,6 +5265,7 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 }
 
 func (s *standaloneActivityTestSuite) TestStartDelay() {
+	env := s.newTestEnv()
 	t := s.T()
 
 	t.Run("Dispatch", func(t *testing.T) {
@@ -5247,11 +5277,11 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		requestID := testcore.RandomizeStr("request-id")
 		startDelay := 3 * time.Second
 
-		startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:           s.Namespace().String(),
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
 			ActivityId:          activityID,
-			ActivityType:        s.tv.ActivityType(),
-			Identity:            s.tv.WorkerIdentity(),
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
 			Input:               defaultInput,
 			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
@@ -5264,8 +5294,8 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 
 		// Verify activity stays in SCHEDULED state throughout the delay (not dispatched early).
 		require.Never(t, func() bool {
-			describeResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:  s.Namespace().String(),
+			describeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
 				ActivityId: activityID,
 				RunId:      startResp.GetRunId(),
 			})
@@ -5274,7 +5304,7 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 			"expected activity to remain in SCHEDULED state during start delay")
 
 		// Poll blocks until the task is dispatched after the delay elapses.
-		pollResp, err := s.pollActivityTaskQueue(ctx, taskQueue)
+		pollResp, err := env.pollActivityTaskQueue(ctx, taskQueue)
 		require.NoError(t, err)
 		require.NotEmpty(t, pollResp.GetTaskToken(), "expected task after start delay")
 
@@ -5293,11 +5323,11 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		requestID := testcore.RandomizeStr("request-id")
 		startDelay := 1 * time.Second
 
-		startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:           s.Namespace().String(),
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
 			ActivityId:          activityID,
-			ActivityType:        s.tv.ActivityType(),
-			Identity:            s.tv.WorkerIdentity(),
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
 			Input:               defaultInput,
 			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
@@ -5307,20 +5337,20 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		require.NoError(t, err)
 
 		// Poll blocks until the task is dispatched after the delay elapses.
-		pollResp, err := s.pollActivityTaskQueue(ctx, taskQueue)
+		pollResp, err := env.pollActivityTaskQueue(ctx, taskQueue)
 		require.NoError(t, err)
 		require.NotEmpty(t, pollResp.GetTaskToken())
 
-		_, err = s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollResp.TaskToken,
 			Result:    defaultResult,
 			Identity:  defaultIdentity,
 		})
 		require.NoError(t, err)
 
-		descResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:      s.Namespace().String(),
+		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:      env.Namespace().String(),
 			ActivityId:     activityID,
 			RunId:          startResp.RunId,
 			IncludeOutcome: true,
@@ -5340,11 +5370,11 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		startDelay := 3 * time.Second
 		scheduleToStartTimeout := 1 * time.Second
 
-		startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:              s.Namespace().String(),
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
 			ActivityId:             activityID,
-			ActivityType:           s.tv.ActivityType(),
-			Identity:               s.tv.WorkerIdentity(),
+			ActivityType:           env.Tv().ActivityType(),
+			Identity:               env.Tv().WorkerIdentity(),
 			Input:                  defaultInput,
 			TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
 			StartToCloseTimeout:    durationpb.New(30 * time.Second),
@@ -5357,8 +5387,8 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		// Activity should stay running (not timed out) throughout startDelay + most of scheduleToStartTimeout.
 		// The timeout should only fire after startDelay + scheduleToStartTimeout.
 		require.Never(t, func() bool {
-			descResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:  s.Namespace().String(),
+			descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
 				ActivityId: activityID,
 				RunId:      startResp.RunId,
 			})
@@ -5368,8 +5398,8 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 
 		// Now wait for the ScheduleToStart timeout to actually fire (measured from after delay).
 		require.Eventually(t, func() bool {
-			resp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:  s.Namespace().String(),
+			resp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
 				ActivityId: activityID,
 				RunId:      startResp.RunId,
 			})
@@ -5387,11 +5417,11 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		startDelay := 3 * time.Second
 		scheduleToCloseTimeout := 1 * time.Second
 
-		startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:              s.Namespace().String(),
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
 			ActivityId:             activityID,
-			ActivityType:           s.tv.ActivityType(),
-			Identity:               s.tv.WorkerIdentity(),
+			ActivityType:           env.Tv().ActivityType(),
+			Identity:               env.Tv().WorkerIdentity(),
 			Input:                  defaultInput,
 			TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
 			ScheduleToCloseTimeout: durationpb.New(scheduleToCloseTimeout),
@@ -5401,8 +5431,8 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		require.NoError(t, err)
 
 		// ExpirationTime should account for start delay: ScheduleTime + StartDelay + ScheduleToCloseTimeout.
-		descResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      startResp.RunId,
 		})
@@ -5413,8 +5443,8 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		// Activity should stay running (not timed out) throughout startDelay + most of scheduleToCloseTimeout.
 		// The timeout should only fire after startDelay + scheduleToCloseTimeout.
 		require.Never(t, func() bool {
-			descResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:  s.Namespace().String(),
+			descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
 				ActivityId: activityID,
 				RunId:      startResp.RunId,
 			})
@@ -5424,8 +5454,8 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 
 		// Now wait for the ScheduleToClose timeout to actually fire (measured from after delay).
 		require.Eventually(t, func() bool {
-			resp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:  s.Namespace().String(),
+			resp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
 				ActivityId: activityID,
 				RunId:      startResp.RunId,
 			})
@@ -5442,11 +5472,11 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		requestID := testcore.RandomizeStr("request-id")
 		startDelay := 10 * time.Second // Long delay so the activity stays in SCHEDULED state.
 
-		startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:           s.Namespace().String(),
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
 			ActivityId:          activityID,
-			ActivityType:        s.tv.ActivityType(),
-			Identity:            s.tv.WorkerIdentity(),
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
 			Input:               defaultInput,
 			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
@@ -5456,8 +5486,8 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		require.NoError(t, err)
 
 		// Cancel while still in the delay period (SCHEDULED state). Should immediately cancel.
-		_, err = s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      startResp.RunId,
 			Identity:   defaultIdentity,
@@ -5467,8 +5497,8 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		require.NoError(t, err)
 
 		// Activity should be CANCELED immediately, not waiting for the delay to elapse.
-		descResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:      s.Namespace().String(),
+		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:      env.Namespace().String(),
 			ActivityId:     activityID,
 			RunId:          startResp.RunId,
 			IncludeOutcome: true,
@@ -5486,11 +5516,11 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		requestID := testcore.RandomizeStr("request-id")
 		startDelay := 10 * time.Second // Long delay so the activity stays in SCHEDULED state.
 
-		startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:           s.Namespace().String(),
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
 			ActivityId:          activityID,
-			ActivityType:        s.tv.ActivityType(),
-			Identity:            s.tv.WorkerIdentity(),
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
 			Input:               defaultInput,
 			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
@@ -5500,8 +5530,8 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		require.NoError(t, err)
 
 		// Terminate while still in the delay period (SCHEDULED state).
-		_, err = s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      startResp.RunId,
 			Identity:   defaultIdentity,
@@ -5509,8 +5539,8 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		})
 		require.NoError(t, err)
 
-		descResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:      s.Namespace().String(),
+		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:      env.Namespace().String(),
 			ActivityId:     activityID,
 			RunId:          startResp.RunId,
 			IncludeOutcome: true,
@@ -5534,11 +5564,11 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		startDelay := 2 * time.Second
 		scheduleToCloseTimeout := 3 * time.Second
 
-		startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:              s.Namespace().String(),
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
 			ActivityId:             activityID,
-			ActivityType:           s.tv.ActivityType(),
-			Identity:               s.tv.WorkerIdentity(),
+			ActivityType:           env.Tv().ActivityType(),
+			Identity:               env.Tv().WorkerIdentity(),
 			Input:                  defaultInput,
 			TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
 			ScheduleToCloseTimeout: durationpb.New(scheduleToCloseTimeout),
@@ -5549,14 +5579,14 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		require.NotEmpty(t, startResp.GetRunId())
 
 		// Poll blocks until the task is dispatched after the delay elapses.
-		pollResp1, err := s.pollActivityTaskQueue(ctx, taskQueue)
+		pollResp1, err := env.pollActivityTaskQueue(ctx, taskQueue)
 		require.NoError(t, err)
 		require.NotEmpty(t, pollResp1.GetTaskToken())
 		require.EqualValues(t, 1, pollResp1.GetAttempt())
 
 		// Fail attempt 1 with a retryable error and short retry delay.
-		_, err = s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollResp1.TaskToken,
 			Failure: &failurepb.Failure{
 				Message: "retryable failure",
@@ -5572,7 +5602,7 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 
 		// Attempt 2 should be scheduled (start delay extended the ScheduleToClose deadline).
 		// It should arrive within the retry backoff interval, NOT re-applying the start delay.
-		pollResp2, err := s.pollActivityTaskQueue(ctx, taskQueue)
+		pollResp2, err := env.pollActivityTaskQueue(ctx, taskQueue)
 		require.NoError(t, err)
 		require.NotEmpty(t, pollResp2.GetTaskToken(), "expected retry attempt 2 to be dispatched")
 		require.EqualValues(t, 2, pollResp2.GetAttempt())
@@ -5580,16 +5610,16 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 			"retry was dispatched after startDelay, suggesting start delay was re-applied")
 
 		// Complete attempt 2.
-		_, err = s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollResp2.TaskToken,
 			Result:    defaultResult,
 			Identity:  defaultIdentity,
 		})
 		require.NoError(t, err)
 
-		descResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:      s.Namespace().String(),
+		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:      env.Namespace().String(),
 			ActivityId:     activityID,
 			RunId:          startResp.RunId,
 			IncludeOutcome: true,
@@ -5601,9 +5631,9 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 	})
 }
 
-func (s *standaloneActivityTestSuite) pollActivityTaskQueue(ctx context.Context, taskQueue string) (*workflowservice.PollActivityTaskQueueResponse, error) {
-	return s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-		Namespace: s.Namespace().String(),
+func (env *standaloneActivityEnv) pollActivityTaskQueue(ctx context.Context, taskQueue string) (*workflowservice.PollActivityTaskQueueResponse, error) {
+	return env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+		Namespace: env.Namespace().String(),
 		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: taskQueue,
 			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
@@ -5612,20 +5642,20 @@ func (s *standaloneActivityTestSuite) pollActivityTaskQueue(ctx context.Context,
 	})
 }
 
-func (s *standaloneActivityTestSuite) startAndValidateActivity(
+func (env *standaloneActivityEnv) startAndValidateActivity(
 	ctx context.Context,
 	t *testing.T,
 	activityID string,
 	taskQueue string,
 ) *workflowservice.StartActivityExecutionResponse {
-	startResponse, err := s.startActivity(ctx, activityID, taskQueue)
+	startResponse, err := env.startActivity(ctx, activityID, taskQueue)
 
 	require.NoError(t, err)
 	require.NotNil(t, startResponse.GetRunId())
 	require.True(t, startResponse.Started)
 
-	activityResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-		Namespace:      s.Namespace().String(),
+	activityResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+		Namespace:      env.Namespace().String(),
 		ActivityId:     activityID,
 		RunId:          startResponse.RunId,
 		IncludeInput:   true,
@@ -5635,7 +5665,7 @@ func (s *standaloneActivityTestSuite) startAndValidateActivity(
 	info := activityResp.GetInfo()
 
 	require.NoError(t, err)
-	s.validateBaseActivityResponse(t, activityID, startResponse.RunId, activityResp)
+	env.validateBaseActivityResponse(t, activityID, startResponse.RunId, activityResp)
 	require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_RUNNING, info.GetStatus(),
 		"expected Running but is %s", info.GetStatus())
 	require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, info.GetRunState(),
@@ -5649,28 +5679,28 @@ func (s *standaloneActivityTestSuite) startAndValidateActivity(
 	return startResponse
 }
 
-func (s *standaloneActivityTestSuite) pollActivityTaskAndValidate(
+func (env *standaloneActivityEnv) pollActivityTaskAndValidate(
 	ctx context.Context,
 	t *testing.T,
 	activityID string,
 	taskQueue string,
 	runID string,
 ) *workflowservice.PollActivityTaskQueueResponse {
-	pollTaskResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-		Namespace: s.Namespace().String(),
+	pollTaskResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+		Namespace: env.Namespace().String(),
 		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: taskQueue,
 			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		},
-		Identity: s.tv.WorkerIdentity(),
+		Identity: env.Tv().WorkerIdentity(),
 	})
 	require.NoError(t, err)
 	require.Equal(t, activityID, pollTaskResp.GetActivityId())
-	protorequire.ProtoEqual(t, s.tv.ActivityType(), pollTaskResp.GetActivityType())
+	protorequire.ProtoEqual(t, env.Tv().ActivityType(), pollTaskResp.GetActivityType())
 	require.EqualValues(t, 1, pollTaskResp.Attempt)
 
-	activityResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-		Namespace:      s.Namespace().String(),
+	activityResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+		Namespace:      env.Namespace().String(),
 		ActivityId:     activityID,
 		RunId:          runID,
 		IncludeInput:   true,
@@ -5680,13 +5710,13 @@ func (s *standaloneActivityTestSuite) pollActivityTaskAndValidate(
 	info := activityResp.GetInfo()
 
 	require.NoError(t, err)
-	s.validateBaseActivityResponse(t, activityID, runID, activityResp)
+	env.validateBaseActivityResponse(t, activityID, runID, activityResp)
 	require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_RUNNING, info.GetStatus(),
 		"expected Running but is %s", info.GetStatus())
 	require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, info.GetRunState(),
 		"expected Started but is %s", info.GetRunState())
 	require.EqualValues(t, 1, info.GetAttempt())
-	require.Equal(t, s.tv.WorkerIdentity(), info.GetLastWorkerIdentity())
+	require.Equal(t, env.Tv().WorkerIdentity(), info.GetLastWorkerIdentity())
 	require.NotNil(t, info.GetLastStartedTime())
 	require.Nil(t, activityResp.Outcome)
 	require.Nil(t, info.GetLastFailure())
@@ -5696,15 +5726,15 @@ func (s *standaloneActivityTestSuite) pollActivityTaskAndValidate(
 	return pollTaskResp
 }
 
-func (s *standaloneActivityTestSuite) validateCompletion(
+func (env *standaloneActivityEnv) validateCompletion(
 	ctx context.Context,
 	t *testing.T,
 	activityID string,
 	runID string,
 	workerIdentity string,
 ) {
-	activityResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-		Namespace:      s.Namespace().String(),
+	activityResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+		Namespace:      env.Namespace().String(),
 		ActivityId:     activityID,
 		RunId:          runID,
 		IncludeInput:   true,
@@ -5714,7 +5744,7 @@ func (s *standaloneActivityTestSuite) validateCompletion(
 	info := activityResp.GetInfo()
 
 	require.NoError(t, err)
-	s.validateBaseActivityResponse(t, activityID, runID, activityResp)
+	env.validateBaseActivityResponse(t, activityID, runID, activityResp)
 	require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, info.GetStatus(),
 		"expected Completed but is %s", info.GetStatus())
 	require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_UNSPECIFIED, info.GetRunState(),
@@ -5730,7 +5760,7 @@ func (s *standaloneActivityTestSuite) validateCompletion(
 	protorequire.ProtoEqual(t, defaultResult, activityResp.GetOutcome().GetResult())
 }
 
-func (s *standaloneActivityTestSuite) validateFailure(
+func (env *standaloneActivityEnv) validateFailure(
 	ctx context.Context,
 	t *testing.T,
 	activityID string,
@@ -5738,8 +5768,8 @@ func (s *standaloneActivityTestSuite) validateFailure(
 	expectedHeartbeatDetails *commonpb.Payloads,
 	workerIdentity string,
 ) {
-	activityResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-		Namespace:      s.Namespace().String(),
+	activityResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+		Namespace:      env.Namespace().String(),
 		ActivityId:     activityID,
 		RunId:          runID,
 		IncludeInput:   true,
@@ -5749,7 +5779,7 @@ func (s *standaloneActivityTestSuite) validateFailure(
 	info := activityResp.GetInfo()
 
 	require.NoError(t, err)
-	s.validateBaseActivityResponse(t, activityID, runID, activityResp)
+	env.validateBaseActivityResponse(t, activityID, runID, activityResp)
 	require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_FAILED, info.GetStatus(),
 		"expected Failed but is %s", info.GetStatus())
 	require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_UNSPECIFIED, info.GetRunState(),
@@ -5767,7 +5797,7 @@ func (s *standaloneActivityTestSuite) validateFailure(
 	}
 }
 
-func (s *standaloneActivityTestSuite) validateBaseActivityResponse(
+func (env *standaloneActivityEnv) validateBaseActivityResponse(
 	t *testing.T,
 	activityID string,
 	expectedRunID string,
@@ -5775,32 +5805,32 @@ func (s *standaloneActivityTestSuite) validateBaseActivityResponse(
 ) {
 	require.NotNil(t, response.LongPollToken)
 	require.Equal(t, activityID, response.GetInfo().GetActivityId())
-	require.Equal(t, s.tv.ActivityType(), response.GetInfo().GetActivityType())
+	require.Equal(t, env.Tv().ActivityType(), response.GetInfo().GetActivityType())
 	require.Equal(t, expectedRunID, response.RunId)
 	require.NotNil(t, response.GetInfo().GetScheduleTime())
 	protorequire.ProtoEqual(t, defaultInput, response.GetInput())
 }
 
-func (s *standaloneActivityTestSuite) startActivity(ctx context.Context, activityID string, taskQueue string) (*workflowservice.StartActivityExecutionResponse, error) {
-	return s.startActivityWithType(ctx, activityID, taskQueue, s.tv.ActivityType())
+func (env *standaloneActivityEnv) startActivity(ctx context.Context, activityID string, taskQueue string) (*workflowservice.StartActivityExecutionResponse, error) {
+	return env.startActivityWithType(ctx, activityID, taskQueue, env.Tv().ActivityType())
 }
 
-func (s *standaloneActivityTestSuite) startActivityWithType(ctx context.Context, activityID string, taskQueue string, activityType *commonpb.ActivityType) (*workflowservice.StartActivityExecutionResponse, error) {
-	return s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-		Namespace:    s.Namespace().String(),
+func (env *standaloneActivityEnv) startActivityWithType(ctx context.Context, activityID string, taskQueue string, activityType *commonpb.ActivityType) (*workflowservice.StartActivityExecutionResponse, error) {
+	return env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+		Namespace:    env.Namespace().String(),
 		ActivityId:   activityID,
 		ActivityType: activityType,
-		Identity:     s.tv.WorkerIdentity(),
+		Identity:     env.Tv().WorkerIdentity(),
 		Input:        defaultInput,
 		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: taskQueue,
 		},
 		StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-		RequestId:           s.tv.RequestID(),
+		RequestId:           env.Tv().RequestID(),
 	})
 }
 
-func (s *standaloneActivityTestSuite) runNexusCompletionHTTPServer(t *testing.T, h *completionHandler) string {
+func (env *standaloneActivityEnv) runNexusCompletionHTTPServer(t *testing.T, h *completionHandler) string {
 	hh := nexusrpc.NewCompletionHTTPHandler(nexusrpc.CompletionHandlerOptions{Handler: h})
 	srv := httptest.NewServer(hh)
 	t.Cleanup(func() {
@@ -5810,11 +5840,12 @@ func (s *standaloneActivityTestSuite) runNexusCompletionHTTPServer(t *testing.T,
 }
 
 func (s *standaloneActivityTestSuite) TestCallbacks() {
+	env := s.newTestEnv()
 	t := s.T()
 	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
 	defer cancel()
 
-	s.OverrideDynamicConfig(
+	env.OverrideDynamicConfig(
 		callbacks.AllowedAddresses,
 		[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}},
 	)
@@ -5823,17 +5854,17 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		resp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:    s.Namespace().String(),
+		resp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:    env.Namespace().String(),
 			ActivityId:   activityID,
-			ActivityType: s.tv.ActivityType(),
-			Identity:     s.tv.WorkerIdentity(),
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 			},
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-			RequestId:           s.tv.Any().String(),
+			RequestId:           env.Tv().Any().String(),
 			CompletionCallbacks: []*commonpb.Callback{{
 				Variant: &commonpb.Callback_Nexus_{
 					Nexus: &commonpb.Callback_Nexus{
@@ -5851,17 +5882,17 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		resp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:    s.Namespace().String(),
+		resp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:    env.Namespace().String(),
 			ActivityId:   activityID,
-			ActivityType: s.tv.ActivityType(),
-			Identity:     s.tv.WorkerIdentity(),
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 			},
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-			RequestId:           s.tv.Any().String(),
+			RequestId:           env.Tv().Any().String(),
 			CompletionCallbacks: []*commonpb.Callback{
 				{Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: "http://localhost/callback1"}}},
 				{Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: "http://localhost/callback2"}}},
@@ -5877,25 +5908,25 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		taskQueue := testcore.RandomizeStr(t.Name())
 
 		callbackURL := "http://localhost/describe-callback"
-		startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:    s.Namespace().String(),
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:    env.Namespace().String(),
 			ActivityId:   activityID,
-			ActivityType: s.tv.ActivityType(),
-			Identity:     s.tv.WorkerIdentity(),
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 			},
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-			RequestId:           s.tv.Any().String(),
+			RequestId:           env.Tv().Any().String(),
 			CompletionCallbacks: []*commonpb.Callback{
 				{Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: callbackURL}}},
 			},
 		})
 		require.NoError(t, err)
 
-		describeResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		describeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      startResp.RunId,
 		})
@@ -5911,7 +5942,7 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 
 	t.Run("ExceedsMaxCallbacksLimit", func(t *testing.T) {
 		maxCallbacks := 1
-		s.OverrideDynamicConfig(
+		env.OverrideDynamicConfig(
 			callback.MaxPerExecution,
 			maxCallbacks,
 		)
@@ -5919,17 +5950,17 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		_, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:    s.Namespace().String(),
+		_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:    env.Namespace().String(),
 			ActivityId:   activityID,
-			ActivityType: s.tv.ActivityType(),
-			Identity:     s.tv.WorkerIdentity(),
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 			},
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-			RequestId:           s.tv.Any().String(),
+			RequestId:           env.Tv().Any().String(),
 			// Two callbacks when overridden max dynamic config is 1, so should error.
 			CompletionCallbacks: []*commonpb.Callback{
 				{Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: "http://localhost/callback1"}}},
@@ -5952,34 +5983,34 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 			close(ch.requestCh)
 			close(ch.requestCompleteCh)
 		}()
-		callbackAddress := s.runNexusCompletionHTTPServer(t, ch)
+		callbackAddress := env.runNexusCompletionHTTPServer(t, ch)
 
-		_, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:    s.Namespace().String(),
+		_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:    env.Namespace().String(),
 			ActivityId:   activityID,
-			ActivityType: s.tv.ActivityType(),
-			Identity:     s.tv.WorkerIdentity(),
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 			},
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-			RequestId:           s.tv.Any().String(),
+			RequestId:           env.Tv().Any().String(),
 			CompletionCallbacks: []*commonpb.Callback{{
 				Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: callbackAddress}},
 			}},
 		})
 		require.NoError(t, err)
 
-		pollResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		pollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-			Identity:  s.tv.WorkerIdentity(),
+			Identity:  env.Tv().WorkerIdentity(),
 		})
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollResp.TaskToken,
 			Result:    defaultResult,
 			Identity:  defaultIdentity,
@@ -6003,8 +6034,8 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		}
 
 		// Verify the activity is in completed state.
-		descResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 		})
 		require.NoError(t, err)
@@ -6023,34 +6054,34 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 			close(ch.requestCh)
 			close(ch.requestCompleteCh)
 		}()
-		callbackAddress := s.runNexusCompletionHTTPServer(t, ch)
+		callbackAddress := env.runNexusCompletionHTTPServer(t, ch)
 
-		_, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:    s.Namespace().String(),
+		_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:    env.Namespace().String(),
 			ActivityId:   activityID,
-			ActivityType: s.tv.ActivityType(),
-			Identity:     s.tv.WorkerIdentity(),
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 			},
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-			RequestId:           s.tv.Any().String(),
+			RequestId:           env.Tv().Any().String(),
 			CompletionCallbacks: []*commonpb.Callback{{
 				Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: callbackAddress}},
 			}},
 		})
 		require.NoError(t, err)
 
-		pollResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		pollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-			Identity:  s.tv.WorkerIdentity(),
+			Identity:  env.Tv().WorkerIdentity(),
 		})
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollResp.TaskToken,
 			Failure:   defaultFailure,
 			Identity:  defaultIdentity,
@@ -6077,8 +6108,8 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		}
 
 		// Verify the activity is in failed state.
-		descResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 		})
 		require.NoError(t, err)
@@ -6097,19 +6128,19 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 			close(ch.requestCh)
 			close(ch.requestCompleteCh)
 		}()
-		callbackAddress := s.runNexusCompletionHTTPServer(t, ch)
+		callbackAddress := env.runNexusCompletionHTTPServer(t, ch)
 
-		startResp, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:    s.Namespace().String(),
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:    env.Namespace().String(),
 			ActivityId:   activityID,
-			ActivityType: s.tv.ActivityType(),
-			Identity:     s.tv.WorkerIdentity(),
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 			},
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-			RequestId:           s.tv.Any().String(),
+			RequestId:           env.Tv().Any().String(),
 			CompletionCallbacks: []*commonpb.Callback{{
 				Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: callbackAddress}},
 			}},
@@ -6117,16 +6148,16 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		require.NoError(t, err)
 		runID := startResp.RunId
 
-		_, err = s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-			Identity:  s.tv.WorkerIdentity(),
+			Identity:  env.Tv().WorkerIdentity(),
 		})
 		require.NoError(t, err)
 
 		reason := "Test Termination"
-		_, err = s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      runID,
 			Reason:     reason,
@@ -6152,8 +6183,8 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 			require.Fail(t, "timed out waiting for completion callback")
 		}
 
-		descResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 		})
 		require.NoError(t, err)
@@ -6172,43 +6203,43 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 			close(ch.requestCh)
 			close(ch.requestCompleteCh)
 		}()
-		callbackAddress := s.runNexusCompletionHTTPServer(t, ch)
+		callbackAddress := env.runNexusCompletionHTTPServer(t, ch)
 
-		_, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:    s.Namespace().String(),
+		_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:    env.Namespace().String(),
 			ActivityId:   activityID,
-			ActivityType: s.tv.ActivityType(),
-			Identity:     s.tv.WorkerIdentity(),
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 			},
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-			RequestId:           s.tv.Any().String(),
+			RequestId:           env.Tv().Any().String(),
 			CompletionCallbacks: []*commonpb.Callback{{
 				Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: callbackAddress}},
 			}},
 		})
 		require.NoError(t, err)
 
-		pollResp, err := s.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: s.Namespace().String(),
+		pollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-			Identity:  s.tv.WorkerIdentity(),
+			Identity:  env.Tv().WorkerIdentity(),
 		})
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			Identity:   "cancelling-worker",
-			RequestId:  s.tv.Any().String(),
+			RequestId:  env.Tv().Any().String(),
 			Reason:     "Test Cancellation",
 		})
 		require.NoError(t, err)
 
-		_, err = s.FrontendClient().RespondActivityTaskCanceled(ctx, &workflowservice.RespondActivityTaskCanceledRequest{
-			Namespace: s.Namespace().String(),
+		_, err = env.FrontendClient().RespondActivityTaskCanceled(ctx, &workflowservice.RespondActivityTaskCanceledRequest{
+			Namespace: env.Namespace().String(),
 			TaskToken: pollResp.TaskToken,
 			Identity:  defaultIdentity,
 		})
@@ -6232,8 +6263,8 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 			require.Fail(t, "timed out waiting for completion callback")
 		}
 
-		descResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 		})
 		require.NoError(t, err)
@@ -6254,20 +6285,20 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 			close(ch.requestCh)
 			close(ch.requestCompleteCh)
 		}()
-		callbackAddress := s.runNexusCompletionHTTPServer(t, ch)
+		callbackAddress := env.runNexusCompletionHTTPServer(t, ch)
 
-		_, err := s.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:    s.Namespace().String(),
+		_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:    env.Namespace().String(),
 			ActivityId:   activityID,
-			ActivityType: s.tv.ActivityType(),
-			Identity:     s.tv.WorkerIdentity(),
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
 			Input:        defaultInput,
 			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 			},
 			StartToCloseTimeout:    durationpb.New(1 * time.Minute),
 			ScheduleToStartTimeout: durationpb.New(1 * time.Second),
-			RequestId:              s.tv.Any().String(),
+			RequestId:              env.Tv().Any().String(),
 			CompletionCallbacks: []*commonpb.Callback{{
 				Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: callbackAddress}},
 			}},
@@ -6295,8 +6326,8 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		}
 
 		// Verify the activity is in timed-out state.
-		descResp, err := s.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
+		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 		})
 		require.NoError(t, err)

--- a/tests/standalone_activity_test.go
+++ b/tests/standalone_activity_test.go
@@ -92,9 +92,6 @@ func TestStandaloneActivityTestSuite(t *testing.T) {
 	parallelsuite.Run(t, &standaloneActivityTestSuite{})
 }
 
-// standaloneActivityEnv wraps testcore.TestEnv to host the helper methods used
-// across the tests in this file. parallelsuite forbids fields and exported
-// non-Test methods on the suite itself, so per-test state and helpers live here.
 type standaloneActivityEnv struct {
 	*testcore.TestEnv
 }
@@ -103,9 +100,6 @@ func (s *standaloneActivityTestSuite) newTestEnv(opts ...testcore.TestOption) *s
 	env := &standaloneActivityEnv{
 		TestEnv: testcore.NewEnv(s.T(), opts...),
 	}
-	// The CHASM/activity dynamic configs are namespace-scoped. Apply them to both
-	// the test's primary namespace and the shared external namespace so cross-namespace
-	// cases (e.g. mismatched-token tests) can start activities in either namespace.
 	nsValues := func(value any) []dynamicconfig.ConstrainedValue {
 		return []dynamicconfig.ConstrainedValue{
 			{Constraints: dynamicconfig.Constraints{Namespace: env.Namespace().String()}, Value: value},

--- a/tests/standalone_activity_test.go
+++ b/tests/standalone_activity_test.go
@@ -3465,7 +3465,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_Completed() 
 			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			t.Cleanup(cancel)
 			activityID := env.Tv().Any().String()
-			taskQueue := env.Tv().TaskQueue()
+			taskQueue := &taskqueuepb.TaskQueue{Name: testcore.RandomizeStr(t.Name())}
 
 			startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
 				Namespace:           env.Namespace().String(),
@@ -3615,7 +3615,7 @@ func (s *standaloneActivityTestSuite) TestPollActivityExecution() {
 			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			t.Cleanup(cancel)
 			activityID := env.Tv().Any().String()
-			taskQueue := env.Tv().TaskQueue().String()
+			taskQueue := testcore.RandomizeStr(t.Name())
 
 			startResp, err := env.startActivity(ctx, activityID, taskQueue)
 			require.NoError(t, err)


### PR DESCRIPTION
## What changed?
 Migrated tests/standalone_activity_test.go from testify suite to parallelsuite


## Why?
parallelsuite is the project's standard for new functional tests — it gives each test its own pooled cluster + isolated namespace and runs the suite's Test* methods  in parallel. Test reduced from ~48s -> 17s

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

