### PR TITLE
fix: schedule_action_delay metric and add schedule_generate_latency

### DIFF
--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -602,9 +603,10 @@ func (h *InvokerExecuteTaskHandler) startWorkflow(
 
 	// Record time taken from action eligible to workflow started.
 	if !start.Manual {
+		desiredTime := cmp.Or(start.DesiredTime, start.ActualTime)
 		metricsHandler.
 			Timer(metrics.ScheduleActionDelay.Name()).
-			Record(actualStartTime.Sub(start.DesiredTime.AsTime()))
+			Record(actualStartTime.Sub(desiredTime.AsTime()))
 	}
 
 	return &schedulepb.ScheduleActionResult{

--- a/chasm/lib/scheduler/spec_processor.go
+++ b/chasm/lib/scheduler/spec_processor.go
@@ -152,6 +152,10 @@ func (s *SpecProcessorImpl) ProcessTimeRange(
 			droppedCount++
 			continue
 		}
+		if !manual {
+			metricsHandler.Timer(metrics.ScheduleGenerateLatency.Name()).
+				Record(end.Sub(next.Next))
+		}
 		bufferedStarts = append(bufferedStarts, &schedulespb.BufferedStart{
 			NominalTime:   timestamppb.New(next.Nominal),
 			ActualTime:    timestamppb.New(next.Next),

--- a/chasm/lib/scheduler/spec_processor.go
+++ b/chasm/lib/scheduler/spec_processor.go
@@ -148,13 +148,14 @@ func (s *SpecProcessorImpl) ProcessTimeRange(
 			continue
 		}
 
-		if limitReached {
-			droppedCount++
-			continue
-		}
 		if !manual {
 			metricsHandler.Timer(metrics.ScheduleGenerateLatency.Name()).
 				Record(end.Sub(next.Next))
+		}
+
+		if limitReached {
+			droppedCount++
+			continue
 		}
 		bufferedStarts = append(bufferedStarts, &schedulespb.BufferedStart{
 			NominalTime:   timestamppb.New(next.Nominal),

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1413,6 +1413,10 @@ var (
 		"schedule_action_delay",
 		WithDescription("Delay between when scheduled actions should/actually happen"),
 	)
+	ScheduleGenerateLatency = NewTimerDef(
+		"schedule_generate_latency",
+		WithDescription("Delay between when a scheduled action was due and when the generator buffered it"),
+	)
 	SchedulePayloadSize = NewCounterDef(
 		"schedule_payload_size",
 		WithDescription("The size in bytes of a customer payload (including action results and update signals)"),


### PR DESCRIPTION
## Summary
- Fix `schedule_action_delay` for CHASM schedules: `DesiredTime` is nil for most starts (only set when blocked behind overlap), causing the metric to record ~56 years (now minus epoch). Use `cmp.Or(start.DesiredTime, start.ActualTime)` to fall back to `ActualTime`, matching V1 behavior.
- Add `schedule_generate_latency` timer metric to measure the delay between when a scheduled action was due and when the generator buffered it. Only recorded for non-manual (non-backfill) actions.

