### PR TITLE
Shared Nexus endpoint lookup cache

### DIFF
--- a/chasm/lib/nexusoperation/fx.go
+++ b/chasm/lib/nexusoperation/fx.go
@@ -68,6 +68,7 @@ func register(
 func endpointRegistryProvider(
 	matchingClient resource.MatchingClient,
 	endpointManager persistence.NexusEndpointManager,
+	lookupCache *commonnexus.EndpointLookupCache,
 	dc *dynamicconfig.Collection,
 	logger log.Logger,
 	metricsHandler metrics.Handler,
@@ -75,6 +76,7 @@ func endpointRegistryProvider(
 	registryConfig := commonnexus.NewEndpointRegistryConfig(dc)
 	return commonnexus.NewEndpointRegistry(
 		registryConfig,
+		lookupCache,
 		matchingClient,
 		endpointManager,
 		logger,

--- a/common/nexus/endpoint_lookup_cache.go
+++ b/common/nexus/endpoint_lookup_cache.go
@@ -1,0 +1,139 @@
+package nexus
+
+import (
+	"sync"
+
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+)
+
+// EndpointLookupCache is a concurrent-safe in-memory view of Nexus endpoints keyed by ID and name.
+//
+// Writers fall into two roles:
+//   - Owner: the sole authority on the endpoint set. It mints new versions and writes them
+//     via ApplyChange (incremental update) or ReplaceAll (full snapshot).
+//   - Follower: a passive replica. It does not mint versions; it only writes snapshots it has
+//     previously fetched from the owner, via ReplaceAll.
+//
+// Production mode (one cache instance per process): the owner and any followers run in separate
+// processes, each with their own cache. Every cache has exactly one writer: its local owner or
+// follower.
+//
+// Development mode (one cache instance shared by owner and follower in the same process): both
+// write to the same instance. Correctness relies on the monotonic version: only the owner
+// mints new versions, so a follower's snapshot is always at or behind the owner's current
+// version. The version check on every write drops a follower's stale snapshot and accepts a
+// same-version snapshot as idempotent.
+type EndpointLookupCache struct {
+	lock                 sync.RWMutex
+	version              int64
+	versionChanged       chan struct{} // closed and replaced whenever version advances or Notify is called
+	nexusEndpointsByID   map[string]*persistencespb.NexusEndpointEntry
+	nexusEndpointsByName map[string]*persistencespb.NexusEndpointEntry
+}
+
+// NewEndpointLookupCache returns an empty cache at version 0.
+func NewEndpointLookupCache() *EndpointLookupCache {
+	return &EndpointLookupCache{
+		nexusEndpointsByID:   make(map[string]*persistencespb.NexusEndpointEntry),
+		nexusEndpointsByName: make(map[string]*persistencespb.NexusEndpointEntry),
+		versionChanged:       make(chan struct{}),
+	}
+}
+
+// GetByID looks up an endpoint by ID at the cache's current version.
+func (c *EndpointLookupCache) GetByID(id string) (entry *persistencespb.NexusEndpointEntry, version int64, found bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	entry, found = c.nexusEndpointsByID[id]
+	return entry, c.version, found
+}
+
+// GetByName looks up an endpoint by name at the cache's current version.
+func (c *EndpointLookupCache) GetByName(name string) (entry *persistencespb.NexusEndpointEntry, version int64, found bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	entry, found = c.nexusEndpointsByName[name]
+	return entry, c.version, found
+}
+
+// Version returns the cache's current version.
+func (c *EndpointLookupCache) Version() int64 {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.version
+}
+
+// ApplyChange applies a single endpoint change, bumps the version by 1, and notifies subscribers.
+// Pass previous=nil for a create, current=nil for a delete, or both non-nil for an update.
+// Must only be invoked by the owner.
+func (c *EndpointLookupCache) ApplyChange(
+	previous *persistencespb.NexusEndpointEntry,
+	current *persistencespb.NexusEndpointEntry,
+) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.version++
+	if previous != nil {
+		delete(c.nexusEndpointsByID, previous.Id)
+		delete(c.nexusEndpointsByName, previous.Endpoint.Spec.Name)
+	}
+	if current != nil {
+		c.nexusEndpointsByID[current.Id] = current
+		c.nexusEndpointsByName[current.Endpoint.Spec.Name] = current
+	}
+	c.notifyLocked()
+}
+
+// ReplaceAll replaces the entire cache contents with the given entries at the given version.
+// The write is dropped if the given version is older than the cache's current version. Notifies
+// subscribers only when the version actually advances.
+func (c *EndpointLookupCache) ReplaceAll(
+	version int64,
+	entries []*persistencespb.NexusEndpointEntry,
+) {
+	nexusEndpointsByID := make(map[string]*persistencespb.NexusEndpointEntry, len(entries))
+	nexusEndpointsByName := make(map[string]*persistencespb.NexusEndpointEntry, len(entries))
+	for _, entry := range entries {
+		nexusEndpointsByID[entry.Id] = entry
+		nexusEndpointsByName[entry.Endpoint.Spec.Name] = entry
+	}
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// When the cache is shared, this drops stale observer writes so they cannot overwrite a newer
+	// state already written by the owner.
+	if version < c.version {
+		return
+	}
+	advanced := version > c.version
+	c.version = version
+	c.nexusEndpointsByID = nexusEndpointsByID
+	c.nexusEndpointsByName = nexusEndpointsByName
+	if advanced {
+		c.notifyLocked()
+	}
+}
+
+// Subscribe returns the current version and a one-shot channel that closes when the version
+// next changes.
+func (c *EndpointLookupCache) Subscribe() (int64, <-chan struct{}) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.version, c.versionChanged
+}
+
+// Notify wakes any subscribers without changing data. Use this when external state has drifted
+// and subscribers should re-check, even though the cache itself hasn't been updated yet.
+func (c *EndpointLookupCache) Notify() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.notifyLocked()
+}
+
+func (c *EndpointLookupCache) notifyLocked() {
+	ch := c.versionChanged
+	c.versionChanged = make(chan struct{})
+	close(ch)
+}

--- a/common/nexus/endpoint_registry.go
+++ b/common/nexus/endpoint_registry.go
@@ -3,7 +3,6 @@ package nexus
 import (
 	"context"
 	"errors"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -51,11 +50,7 @@ type (
 
 		dataReady atomic.Pointer[dataReady]
 
-		dataLock        sync.RWMutex // Protects tableVersion and endpoints.
-		tableVersion    int64
-		endpointsByID   map[string]*persistencespb.NexusEndpointEntry // Mapping of endpoint ID -> endpoint.
-		endpointsByName map[string]*persistencespb.NexusEndpointEntry // Mapping of endpoint name -> endpoint.
-
+		lookupCache    *EndpointLookupCache
 		matchingClient matchingservice.MatchingServiceClient
 		persistence    p.NexusEndpointManager
 		logger         log.Logger
@@ -85,18 +80,18 @@ func NewEndpointRegistryConfig(dc *dynamicconfig.Collection) *EndpointRegistryCo
 
 func NewEndpointRegistry(
 	config *EndpointRegistryConfig,
+	lookupCache *EndpointLookupCache,
 	matchingClient matchingservice.MatchingServiceClient,
 	persistence p.NexusEndpointManager,
 	logger log.Logger,
 	metricsHandler metrics.Handler,
 ) *EndpointRegistryImpl {
 	return &EndpointRegistryImpl{
-		config:          config,
-		endpointsByID:   make(map[string]*persistencespb.NexusEndpointEntry),
-		endpointsByName: make(map[string]*persistencespb.NexusEndpointEntry),
-		matchingClient:  matchingClient,
-		persistence:     persistence,
-		logger:          logger,
+		config:         config,
+		lookupCache:    lookupCache,
+		matchingClient: matchingClient,
+		persistence:    persistence,
+		logger:         logger,
 		readThroughCacheByID: cache.NewWithMetrics(config.readThroughCacheSize(), &cache.Options{
 			TTL: config.readThroughCacheTTL(),
 		}, metricsHandler.WithTags(metrics.CacheTypeTag(metrics.NexusEndpointRegistryReadThroughCacheTypeTagValue))),
@@ -148,14 +143,11 @@ func (r *EndpointRegistryImpl) GetByName(ctx context.Context, _ namespace.ID, en
 	if err := r.waitUntilInitialized(ctx); err != nil {
 		return nil, err
 	}
-	r.dataLock.RLock()
-	endpoint, ok := r.endpointsByName[endpointName]
-	r.dataLock.RUnlock()
 
-	if !ok {
-		return nil, serviceerror.NewNotFoundf("could not find Nexus endpoint by name: %v", endpointName)
+	if endpoint, _, ok := r.lookupCache.GetByName(endpointName); ok {
+		return endpoint, nil
 	}
-	return endpoint, nil
+	return nil, serviceerror.NewNotFoundf("could not find Nexus endpoint by name: %v", endpointName)
 }
 
 func (r *EndpointRegistryImpl) GetByID(ctx context.Context, id string) (*persistencespb.NexusEndpointEntry, error) {
@@ -163,9 +155,7 @@ func (r *EndpointRegistryImpl) GetByID(ctx context.Context, id string) (*persist
 		return nil, err
 	}
 
-	r.dataLock.RLock()
-	endpoint, ok := r.endpointsByID[id]
-	r.dataLock.RUnlock()
+	endpoint, _, ok := r.lookupCache.GetByID(id)
 
 	if !ok {
 		// Entry not found, attempt read-through to persistence.
@@ -219,18 +209,14 @@ func (r *EndpointRegistryImpl) refreshEndpointsLoop(ctx context.Context, dataRea
 				close(dataReady.ready)
 			}
 		} else {
-			r.dataLock.Lock()
-			prevTableVersion := r.tableVersion
-			r.dataLock.Unlock()
+			prevTableVersion := r.lookupCache.Version()
 
 			// Endpoints have previously been loaded, so just keep them up to date with long poll requests to
 			// matching, without fallback to persistence. Ignoring long poll errors since we will just retry
 			// on next loop iteration.
 			_ = backoff.ThrottleRetryContext(ctx, r.refreshEndpoints, r.config.refreshRetryPolicy, nil)
 
-			r.dataLock.Lock()
-			enforceMinWait = prevTableVersion == r.tableVersion
-			r.dataLock.Unlock()
+			enforceMinWait = prevTableVersion == r.lookupCache.Version()
 		}
 		elapsed := time.Since(start)
 
@@ -254,27 +240,14 @@ func (r *EndpointRegistryImpl) loadEndpoints(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	endpointsByID := make(map[string]*persistencespb.NexusEndpointEntry, len(endpoints))
-	endpointsByName := make(map[string]*persistencespb.NexusEndpointEntry, len(endpoints))
-	for _, endpoint := range endpoints {
-		endpointsByID[endpoint.Id] = endpoint
-		endpointsByName[endpoint.Endpoint.Spec.Name] = endpoint
-	}
 
-	r.dataLock.Lock()
-	defer r.dataLock.Unlock()
-
-	r.tableVersion = tableVersion
-	r.endpointsByID = endpointsByID
-	r.endpointsByName = endpointsByName
+	r.lookupCache.ReplaceAll(tableVersion, endpoints)
 	return nil
 }
 
 // refreshEndpoints sends long-poll requests to matching to check for any updates to endpoint data.
 func (r *EndpointRegistryImpl) refreshEndpoints(ctx context.Context) error {
-	r.dataLock.RLock()
-	currentTableVersion := r.tableVersion
-	r.dataLock.RUnlock()
+	currentTableVersion := r.lookupCache.Version()
 
 	resp, err := r.matchingClient.ListNexusEndpoints(ctx, &matchingservice.ListNexusEndpointsRequest{
 		NextPageToken:         nil,
@@ -328,19 +301,7 @@ func (r *EndpointRegistryImpl) refreshEndpoints(ctx context.Context) error {
 		entries = append(entries, resp.Entries...)
 	}
 
-	endpointsByID := make(map[string]*persistencespb.NexusEndpointEntry, len(entries))
-	endpointsByName := make(map[string]*persistencespb.NexusEndpointEntry, len(entries))
-	for _, entry := range entries {
-		endpointsByID[entry.Id] = entry
-		endpointsByName[entry.Endpoint.Spec.Name] = entry
-	}
-
-	r.dataLock.Lock()
-	defer r.dataLock.Unlock()
-
-	r.tableVersion = currentTableVersion
-	r.endpointsByID = endpointsByID
-	r.endpointsByName = endpointsByName
+	r.lookupCache.ReplaceAll(currentTableVersion, entries)
 
 	return nil
 }

--- a/common/nexus/endpoint_registry_test.go
+++ b/common/nexus/endpoint_registry_test.go
@@ -27,6 +27,7 @@ import (
 
 type testMocks struct {
 	config         *EndpointRegistryConfig
+	lookupCache    *EndpointLookupCache
 	matchingClient *matchingservicemock.MockMatchingServiceClient
 	persistence    *persistence.MockNexusEndpointManager
 }
@@ -54,7 +55,7 @@ func TestGet(t *testing.T) {
 		return &matchingservice.ListNexusEndpointsResponse{TableVersion: int64(1)}, nil
 	}).AnyTimes()
 
-	reg := NewEndpointRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
+	reg := NewEndpointRegistry(mocks.config, mocks.lookupCache, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
 	reg.StartLifecycle()
 	defer reg.StopLifecycle()
 
@@ -65,10 +66,7 @@ func TestGet(t *testing.T) {
 	endpoint, err = reg.GetByName(context.Background(), "ignored", testEntry.Endpoint.Spec.Name)
 	require.NoError(t, err)
 	protoassert.ProtoEqual(t, testEntry, endpoint)
-
-	reg.dataLock.RLock()
-	defer reg.dataLock.RUnlock()
-	assert.Equal(t, int64(1), reg.tableVersion)
+	require.Equal(t, int64(1), mocks.lookupCache.Version())
 }
 
 func TestGetNotFound(t *testing.T) {
@@ -99,7 +97,7 @@ func TestGetNotFound(t *testing.T) {
 	sentinelErr := errors.New("sentinel")
 	mocks.persistence.EXPECT().GetNexusEndpoint(gomock.Any(), gomock.Any()).Return(nil, sentinelErr)
 
-	reg := NewEndpointRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
+	reg := NewEndpointRegistry(mocks.config, mocks.lookupCache, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
 	reg.StartLifecycle()
 	defer reg.StopLifecycle()
 
@@ -123,10 +121,7 @@ func TestGetNotFound(t *testing.T) {
 	endpoint, err = reg.GetByName(context.Background(), "ignored", uuid.NewString())
 	assert.ErrorAs(t, err, &notFound)
 	assert.Nil(t, endpoint)
-
-	reg.dataLock.RLock()
-	defer reg.dataLock.RUnlock()
-	assert.Equal(t, int64(1), reg.tableVersion)
+	require.Equal(t, int64(1), mocks.lookupCache.Version())
 }
 
 func TestInitializationFallback(t *testing.T) {
@@ -142,17 +137,14 @@ func TestInitializationFallback(t *testing.T) {
 		Entries:       []*persistencespb.NexusEndpointEntry{testEndpoint},
 	}, nil)
 
-	reg := NewEndpointRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
+	reg := NewEndpointRegistry(mocks.config, mocks.lookupCache, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
 	reg.StartLifecycle()
 	defer reg.StopLifecycle()
 
 	endpoint, err := reg.GetByID(context.Background(), testEndpoint.Id)
 	require.NoError(t, err)
 	protoassert.ProtoEqual(t, testEndpoint, endpoint)
-
-	reg.dataLock.RLock()
-	defer reg.dataLock.RUnlock()
-	assert.Equal(t, int64(1), reg.tableVersion)
+	require.Equal(t, int64(1), mocks.lookupCache.Version())
 }
 
 func TestTableVersionErrorResetsMatchingPagination(t *testing.T) {
@@ -216,7 +208,7 @@ func TestTableVersionErrorResetsMatchingPagination(t *testing.T) {
 		return &matchingservice.ListNexusEndpointsResponse{TableVersion: int64(1)}, nil
 	}).MaxTimes(1)
 
-	reg := NewEndpointRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
+	reg := NewEndpointRegistry(mocks.config, mocks.lookupCache, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
 	reg.StartLifecycle()
 	defer reg.StopLifecycle()
 
@@ -227,10 +219,7 @@ func TestTableVersionErrorResetsMatchingPagination(t *testing.T) {
 	entry, err = reg.GetByID(context.Background(), testEntry1.Id)
 	require.NoError(t, err)
 	protoassert.ProtoEqual(t, testEntry1, entry)
-
-	reg.dataLock.RLock()
-	defer reg.dataLock.RUnlock()
-	assert.Equal(t, int64(3), reg.tableVersion)
+	require.Equal(t, int64(3), mocks.lookupCache.Version())
 }
 
 func TestTableVersionErrorResetsPersistencePagination(t *testing.T) {
@@ -283,7 +272,7 @@ func TestTableVersionErrorResetsPersistencePagination(t *testing.T) {
 		NextPageToken: nil,
 	}, nil)
 
-	reg := NewEndpointRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
+	reg := NewEndpointRegistry(mocks.config, mocks.lookupCache, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
 	reg.StartLifecycle()
 	defer reg.StopLifecycle()
 
@@ -294,10 +283,7 @@ func TestTableVersionErrorResetsPersistencePagination(t *testing.T) {
 	entry, err = reg.GetByID(context.Background(), testEntry1.Id)
 	require.NoError(t, err)
 	protoassert.ProtoEqual(t, testEntry1, entry)
-
-	reg.dataLock.RLock()
-	defer reg.dataLock.RUnlock()
-	assert.Equal(t, int64(3), reg.tableVersion)
+	require.Equal(t, int64(3), mocks.lookupCache.Version())
 }
 
 func newTestMocks(t *testing.T) *testMocks {
@@ -305,6 +291,7 @@ func newTestMocks(t *testing.T) *testMocks {
 	testConfig := NewEndpointRegistryConfig(dynamicconfig.NewNoopCollection())
 	return &testMocks{
 		config:         testConfig,
+		lookupCache:    NewEndpointLookupCache(),
 		matchingClient: matchingservicemock.NewMockMatchingServiceClient(ctrl),
 		persistence:    persistence.NewMockNexusEndpointManager(ctrl),
 	}

--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -17,6 +17,7 @@ import (
 	"go.temporal.io/server/common/membership"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
+	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/persistence/visibility/manager"
@@ -67,6 +68,7 @@ type (
 		NamespaceReplicationQueue     persistence.NamespaceReplicationQueue
 		VisibilityManager             manager.VisibilityManager
 		NexusEndpointManager          persistence.NexusEndpointManager
+		EndpointLookupCache           *commonnexus.EndpointLookupCache
 		TestHooks                     testhooks.TestHooks
 		SearchAttributeProvider       searchattribute.Provider
 		SearchAttributeMapperProvider searchattribute.MapperProvider
@@ -111,6 +113,7 @@ func NewHandler(
 			params.NamespaceReplicationQueue,
 			params.VisibilityManager,
 			params.NexusEndpointManager,
+			params.EndpointLookupCache,
 			params.TestHooks,
 			params.SearchAttributeProvider,
 			params.SearchAttributeMapperProvider,

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -267,6 +267,7 @@ func NewEngine(
 	namespaceReplicationQueue persistence.NamespaceReplicationQueue,
 	visibilityManager manager.VisibilityManager,
 	nexusEndpointManager persistence.NexusEndpointManager,
+	endpointLookupCache *commonnexus.EndpointLookupCache,
 	testHooks testhooks.TestHooks,
 	saProvider searchattribute.Provider,
 	saMapperProvider searchattribute.MapperProvider,
@@ -293,7 +294,7 @@ func NewEngine(
 		clusterMeta:            clusterMeta,
 		timeSource:             clock.NewRealTimeSource(), // No need to mock this at the moment
 		visibilityManager:      visibilityManager,
-		nexusEndpointClient:    newEndpointClient(config.NexusEndpointsRefreshInterval, nexusEndpointManager),
+		nexusEndpointClient:    newEndpointClient(config.NexusEndpointsRefreshInterval, nexusEndpointManager, endpointLookupCache),
 		// nexusEndpointsOwnershipLostCh initialized below
 		saProvider:       saProvider,
 		saMapperProvider: saMapperProvider,

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -54,6 +54,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/namespace"
+	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/persistence"
@@ -264,7 +265,7 @@ func newMatchingEngine(
 		clusterMeta:         clustertest.NewMetadataForTest(cluster.NewTestClusterMetadataConfig(false, true)),
 		timeSource:          clock.NewRealTimeSource(),
 		visibilityManager:   mockVisibilityManager,
-		nexusEndpointClient: newEndpointClient(config.NexusEndpointsRefreshInterval, nexusEndpointManager),
+		nexusEndpointClient: newEndpointClient(config.NexusEndpointsRefreshInterval, nexusEndpointManager, commonnexus.NewEndpointLookupCache()),
 	}
 	e.nexusEndpointsOwnershipLostCh.Store(make(chan struct{}))
 	return e

--- a/service/matching/nexus_endpoint_client.go
+++ b/service/matching/nexus_endpoint_client.go
@@ -19,6 +19,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/goro"
 	"go.temporal.io/server/common/headers"
+	commonnexus "go.temporal.io/server/common/nexus"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/util"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -55,29 +56,27 @@ type (
 	nexusEndpointClient struct {
 		hasLoadedEndpoints atomic.Bool
 
-		sync.RWMutex        // protects tableVersion, endpoints, endpointsByID, endpointsByName, and tableVersionChanged
-		tableVersion        int64
-		endpointEntries     []*persistencespb.NexusEndpointEntry // sorted by ID to support pagination during ListNexusEndpoints
-		endpointsByID       map[string]*persistencespb.NexusEndpointEntry
-		endpointsByName     map[string]*persistencespb.NexusEndpointEntry
-		tableVersionChanged chan struct{}
+		sync.RWMutex                                         // protects endpointEntries
+		endpointEntries []*persistencespb.NexusEndpointEntry // sorted by ID to support pagination during ListNexusEndpoints
 
 		refreshLock              sync.Mutex // protects refreshHandle which is updated whenever node gains/loses ownership
 		refreshHandle            *goro.Handle
 		endpointsRefreshInterval dynamicconfig.DurationPropertyFn
 
 		persistence p.NexusEndpointManager
+		lookupCache *commonnexus.EndpointLookupCache
 	}
 )
 
 func newEndpointClient(
 	endpointsRefreshInterval dynamicconfig.DurationPropertyFn,
 	persistence p.NexusEndpointManager,
+	lookupCache *commonnexus.EndpointLookupCache,
 ) *nexusEndpointClient {
 	return &nexusEndpointClient{
 		endpointsRefreshInterval: endpointsRefreshInterval,
 		persistence:              persistence,
-		tableVersionChanged:      make(chan struct{}),
+		lookupCache:              lookupCache,
 	}
 }
 
@@ -96,7 +95,7 @@ func (m *nexusEndpointClient) CreateNexusEndpoint(
 	m.Lock()
 	defer m.Unlock()
 
-	if _, exists := m.endpointsByName[request.spec.GetName()]; exists {
+	if _, _, exists := m.lookupCache.GetByName(request.spec.GetName()); exists {
 		return nil, serviceerror.NewAlreadyExistsf("error creating Nexus endpoint. Endpoint with name %v already registered", request.spec.GetName())
 	}
 
@@ -111,7 +110,7 @@ func (m *nexusEndpointClient) CreateNexusEndpoint(
 	}
 
 	resp, err := m.persistence.CreateOrUpdateNexusEndpoint(ctx, &p.CreateOrUpdateNexusEndpointRequest{
-		LastKnownTableVersion: m.tableVersion,
+		LastKnownTableVersion: m.lookupCache.Version(),
 		Entry:                 entry,
 	})
 	if err != nil {
@@ -119,13 +118,8 @@ func (m *nexusEndpointClient) CreateNexusEndpoint(
 	}
 
 	entry.Version = resp.Version
-	m.tableVersion++
-	m.endpointsByID[entry.Id] = entry
-	m.endpointsByName[entry.Endpoint.Spec.Name] = entry
+	m.lookupCache.ApplyChange(nil, entry)
 	m.insertEndpointLocked(entry)
-	ch := m.tableVersionChanged
-	m.tableVersionChanged = make(chan struct{})
-	close(ch)
 
 	return &matchingservice.CreateNexusEndpointResponse{
 		Entry: entry,
@@ -147,7 +141,7 @@ func (m *nexusEndpointClient) UpdateNexusEndpoint(
 	m.Lock()
 	defer m.Unlock()
 
-	previous, exists := m.endpointsByID[request.endpointID]
+	previous, _, exists := m.lookupCache.GetByID(request.endpointID)
 	if !exists {
 		return nil, serviceerror.NewNotFoundf("error updating Nexus endpoint. endpoint ID %v not found", request.endpointID)
 	}
@@ -166,7 +160,7 @@ func (m *nexusEndpointClient) UpdateNexusEndpoint(
 	}
 
 	resp, err := m.persistence.CreateOrUpdateNexusEndpoint(ctx, &p.CreateOrUpdateNexusEndpointRequest{
-		LastKnownTableVersion: m.tableVersion,
+		LastKnownTableVersion: m.lookupCache.Version(),
 		Entry:                 entry,
 	})
 	if err != nil {
@@ -174,13 +168,8 @@ func (m *nexusEndpointClient) UpdateNexusEndpoint(
 	}
 
 	entry.Version = resp.Version
-	m.tableVersion++
-	m.endpointsByID[entry.Id] = entry
-	m.endpointsByName[entry.Endpoint.Spec.Name] = entry
+	m.lookupCache.ApplyChange(previous, entry)
 	m.insertEndpointLocked(entry)
-	ch := m.tableVersionChanged
-	m.tableVersionChanged = make(chan struct{})
-	close(ch)
 
 	return &matchingservice.UpdateNexusEndpointResponse{
 		Entry: entry,
@@ -213,28 +202,23 @@ func (m *nexusEndpointClient) DeleteNexusEndpoint(
 	m.Lock()
 	defer m.Unlock()
 
-	entry, ok := m.endpointsByID[request.Id]
+	entry, _, ok := m.lookupCache.GetByID(request.Id)
 	if !ok {
 		return nil, serviceerror.NewNotFoundf("error deleting nexus endpoint with ID: %v", request.Id)
 	}
 
 	err := m.persistence.DeleteNexusEndpoint(ctx, &p.DeleteNexusEndpointRequest{
-		LastKnownTableVersion: m.tableVersion,
+		LastKnownTableVersion: m.lookupCache.Version(),
 		ID:                    entry.Id,
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	m.tableVersion++
-	delete(m.endpointsByID, request.Id)
-	delete(m.endpointsByName, entry.Endpoint.Spec.Name)
+	m.lookupCache.ApplyChange(entry, nil)
 	m.endpointEntries = slices.DeleteFunc(m.endpointEntries, func(entry *persistencespb.NexusEndpointEntry) bool {
 		return entry.Id == request.Id
 	})
-	ch := m.tableVersionChanged
-	m.tableVersionChanged = make(chan struct{})
-	close(ch)
 
 	return &matchingservice.DeleteNexusEndpointResponse{}, nil
 }
@@ -242,13 +226,11 @@ func (m *nexusEndpointClient) DeleteNexusEndpoint(
 func (m *nexusEndpointClient) ListNexusEndpoints(
 	ctx context.Context,
 	request *matchingservice.ListNexusEndpointsRequest,
-) (*matchingservice.ListNexusEndpointsResponse, chan struct{}, error) {
-	m.RLock()
-	if request.LastKnownTableVersion > m.tableVersion {
+) (*matchingservice.ListNexusEndpointsResponse, <-chan struct{}, error) {
+	if request.LastKnownTableVersion > m.lookupCache.Version() {
 		// indicates we may have lost table ownership, so need to reload from persistence
 		m.hasLoadedEndpoints.Store(false)
 	}
-	m.RUnlock()
 
 	if !m.hasLoadedEndpoints.Load() {
 		if err := m.loadEndpoints(ctx); err != nil {
@@ -259,8 +241,9 @@ func (m *nexusEndpointClient) ListNexusEndpoints(
 	m.RLock()
 	defer m.RUnlock()
 
-	if request.LastKnownTableVersion != 0 && request.LastKnownTableVersion != m.tableVersion {
-		return nil, nil, serviceerror.NewFailedPreconditionf("nexus endpoints table version mismatch. received: %v expected %v", request.LastKnownTableVersion, m.tableVersion)
+	tableVersion, changedCh := m.lookupCache.Subscribe()
+	if request.LastKnownTableVersion != 0 && request.LastKnownTableVersion != tableVersion {
+		return nil, nil, serviceerror.NewFailedPreconditionf("nexus endpoints table version mismatch. received: %v expected %v", request.LastKnownTableVersion, tableVersion)
 	}
 
 	startIdx := 0
@@ -288,12 +271,12 @@ func (m *nexusEndpointClient) ListNexusEndpoints(
 	}
 
 	resp := &matchingservice.ListNexusEndpointsResponse{
-		TableVersion:  m.tableVersion,
+		TableVersion:  tableVersion,
 		NextPageToken: nextPageToken,
 		Entries:       slices.Clone(m.endpointEntries[startIdx:endIdx]),
 	}
 
-	return resp, m.tableVersionChanged, nil
+	return resp, changedCh, nil
 }
 
 func (m *nexusEndpointClient) loadEndpoints(ctx context.Context) error {
@@ -305,49 +288,41 @@ func (m *nexusEndpointClient) loadEndpoints(ctx context.Context) error {
 		return nil
 	}
 
-	// reset cached view since we will be paging from the start
-	m.resetCacheStateLocked()
-
 	var pageToken []byte
+	var tableVersion int64
+	var entries []*persistencespb.NexusEndpointEntry
 
 	for ctx.Err() == nil {
 		resp, err := m.persistence.ListNexusEndpoints(ctx, &p.ListNexusEndpointsRequest{
-			LastKnownTableVersion: m.tableVersion,
+			LastKnownTableVersion: tableVersion,
 			NextPageToken:         pageToken,
 			PageSize:              loadEndpointsPageSize,
 		})
 		if err != nil {
 			if errors.Is(err, p.ErrNexusTableVersionConflict) {
 				// indicates table was updated during paging, so reset and start from the beginning
-				m.resetCacheStateLocked()
-				pageToken = nil
+				pageToken, tableVersion, entries = nil, 0, nil
 				continue
 			}
 			return err
 		}
 
 		pageToken = resp.NextPageToken
-		m.tableVersion = resp.TableVersion
-		for _, entry := range resp.Entries {
-			m.endpointEntries = append(m.endpointEntries, entry)
-			m.endpointsByID[entry.Id] = entry
-			m.endpointsByName[entry.Endpoint.Spec.Name] = entry
-		}
+		tableVersion = resp.TableVersion
+		entries = append(entries, resp.Entries...)
 
 		if len(pageToken) == 0 {
 			break
 		}
 	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
 
-	m.hasLoadedEndpoints.Store(ctx.Err() == nil)
-	return ctx.Err()
-}
-
-func (m *nexusEndpointClient) resetCacheStateLocked() {
-	m.tableVersion = 0
-	m.endpointEntries = []*persistencespb.NexusEndpointEntry{}
-	m.endpointsByID = make(map[string]*persistencespb.NexusEndpointEntry)
-	m.endpointsByName = make(map[string]*persistencespb.NexusEndpointEntry)
+	m.endpointEntries = entries
+	m.lookupCache.ReplaceAll(tableVersion, entries)
+	m.hasLoadedEndpoints.Store(true)
+	return nil
 }
 
 // notifyOwnershipChanged starts or stops a background routine which watches the Nexus endpoints table version for
@@ -394,10 +369,8 @@ func (m *nexusEndpointClient) checkTableVersion(ctx context.Context) {
 		LastKnownTableVersion: 0,
 		PageSize:              0,
 	})
-	if err != nil || resp.TableVersion != m.tableVersion {
+	if err != nil || resp.TableVersion != m.lookupCache.Version() {
 		m.hasLoadedEndpoints.Store(false)
-		ch := m.tableVersionChanged
-		m.tableVersionChanged = make(chan struct{})
-		close(ch)
+		m.lookupCache.Notify()
 	}
 }

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -36,6 +36,7 @@ import (
 	"go.temporal.io/server/common/membership/ringpop"
 	"go.temporal.io/server/common/membership/static"
 	"go.temporal.io/server/common/metrics"
+	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/cassandra"
 	persistenceClient "go.temporal.io/server/common/persistence/client"
@@ -135,6 +136,7 @@ var (
 			ServerOptionsProvider,
 			resource.ArchivalMetadataProvider,
 			TaskCategoryRegistryProvider,
+			commonnexus.NewEndpointLookupCache,
 			PersistenceFactoryProvider,
 			HistoryServiceProvider,
 			MatchingServiceProvider,
@@ -373,6 +375,7 @@ type (
 		InstanceID                      resource.InstanceID                     `optional:"true"`
 		StaticServiceHosts              map[primitives.ServiceName]static.Hosts `optional:"true"`
 		TaskCategoryRegistry            tasks.TaskCategoryRegistry
+		NexusEndpointLookupCache        *commonnexus.EndpointLookupCache
 	}
 )
 
@@ -396,6 +399,8 @@ func (params ServiceProviderParamsCommon) GetCommonServiceOptions(serviceName pr
 			params.ClusterMetadata,
 			params.Cfg,
 			params.SpanExporters,
+			// Share the Nexus endpoint lookup cache between history and matching for consistent lookups when run in-process.
+			params.NexusEndpointLookupCache,
 		),
 		fx.Provide(
 			resource.DefaultSnTaggedLoggerProvider,

--- a/tests/nexus_test_base.go
+++ b/tests/nexus_test_base.go
@@ -3,9 +3,7 @@ package tests
 import (
 	"context"
 	"errors"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/nexus-rpc/sdk-go/nexus"
@@ -59,7 +57,6 @@ func (env *NexusTestEnv) createNexusEndpoint(ctx context.Context, t *testing.T, 
 		})
 	})
 
-	env.ensureNexusEndpoint(ctx, t, name)
 	return resp.Endpoint
 }
 
@@ -94,27 +91,7 @@ func (env *NexusTestEnv) createRandomExternalNexusServer(ctx context.Context, t 
 		})
 	})
 
-	env.ensureNexusEndpoint(ctx, t, endpointName)
 	return endpointName
-}
-
-// ensureNexusEndpoint probes the specified endpoint until it's visible to StartNexusOperationExecution to ensure tests
-// can use it.
-func (env *NexusTestEnv) ensureNexusEndpoint(ctx context.Context, t *testing.T, endpointName string) {
-	require.Eventually(t, func() bool {
-		_, err := env.FrontendClient().StartNexusOperationExecution(ctx, &workflowservice.StartNexusOperationExecutionRequest{
-			Namespace: env.Namespace().String(),
-			Endpoint:  endpointName,
-			Service:   "probe",
-			Operation: "probe",
-			RequestId: "probe",
-		})
-		if notFound, ok := errors.AsType[*serviceerror.NotFound](err); ok {
-			msg := notFound.Error()
-			return msg != "endpoint not registered" && !strings.HasPrefix(msg, "could not find Nexus endpoint by name:")
-		}
-		return true
-	}, 10*time.Second, 100*time.Millisecond, "endpoint should become visible")
 }
 
 // nexusTaskResponse represents a successful response from a nexus task handler.

--- a/tests/testcore/onebox.go
+++ b/tests/testcore/onebox.go
@@ -40,6 +40,7 @@ import (
 	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/namespace/nsreplication"
+	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/persistence"
 	persistenceClient "go.temporal.io/server/common/persistence/client"
 	"go.temporal.io/server/common/persistence/visibility"
@@ -77,6 +78,7 @@ type (
 		frontendMembershipAddress string
 		chasmEngine               chasm.Engine
 		chasmVisibilityMgr        chasm.VisibilityManager
+		nexusEndpointLookupCache  *commonnexus.EndpointLookupCache
 
 		// These are routing/load balancing clients but do not do retries:
 		adminClient     adminservice.AdminServiceClient
@@ -222,6 +224,7 @@ func newTemporal(t *testing.T, params *TemporalParams) *TemporalImpl {
 		testHooks:                        testhooks.NewTestHooks(),
 		serviceFxOptions:                 params.ServiceFxOptions,
 		taskCategoryRegistry:             params.TaskCategoryRegistry,
+		nexusEndpointLookupCache:         commonnexus.NewEndpointLookupCache(),
 		hostsByProtocolByService:         params.HostsByProtocolByService,
 		grpcClientInterceptor:            grpcinject.NewInterceptor(),
 		replicationStreamRecorder:        NewReplicationStreamRecorder(),
@@ -670,7 +673,12 @@ func (c *TemporalImpl) startWorker() {
 }
 
 func (c *TemporalImpl) getFxOptionsForService(serviceName primitives.ServiceName) fx.Option {
-	return fx.Options(c.serviceFxOptions[serviceName]...)
+	options := []fx.Option{
+		// Share the Nexus endpoint lookup cache between history and matching for consistent lookups.
+		fx.Supply(c.nexusEndpointLookupCache),
+		fx.Options(c.serviceFxOptions[serviceName]...),
+	}
+	return fx.Options(options...)
 }
 
 func (c *TemporalImpl) createSystemNamespace() error {


### PR DESCRIPTION
## What changed?

Shared cache for Nexus endpoint name lookups when history/matching run in same process.

## Why?

During testing - such as functional server tests or SDK tests against the CLI - the Nexus endpoint is not always immediately available after creation. This creates friction as it requires extra retries and causes flakiness if not guarded against. This change eliminates that need.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Risk

Significantly more complex change than https://github.com/temporalio/temporal/pull/10208