### PR TITLE
rename nexusoperation.enableChasm dc

### DIFF
--- a/chasm/lib/nexusoperation/config.go
+++ b/chasm/lib/nexusoperation/config.go
@@ -34,8 +34,8 @@ var Enabled = dynamicconfig.NewNamespaceBoolSetting(
 	`Toggles standalone Nexus operation functionality on the server.`,
 )
 
-var EnableChasmNexus = dynamicconfig.NewNamespaceBoolSetting(
-	"nexusoperation.enableChasm",
+var EnableChasmWorkflowOperations = dynamicconfig.NewNamespaceBoolSetting(
+	"nexusoperation.enableChasmWorkflowOperations",
 	false,
 	`Feature flag that controls whether the legacy HSM-based implementation (when flag is false; default) or the newer
 CHASM-based implementation of Nexus will be used when scheduling new Nexus Operations.`,
@@ -218,7 +218,7 @@ Added for safety. Defaults to true. Likely to be removed in future server versio
 type Config struct {
 	Enabled                             dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	EnableChasm                         dynamicconfig.BoolPropertyFnWithNamespaceFilter
-	EnableChasmNexus                    dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	EnableChasmNexusWorkflowOperations  dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	NumHistoryShards                    int32
 	LongPollBuffer                      dynamicconfig.DurationPropertyFnWithNamespaceFilter
 	LongPollTimeout                     dynamicconfig.DurationPropertyFnWithNamespaceFilter
@@ -247,7 +247,7 @@ func configProvider(dc *dynamicconfig.Collection, cfg *config.Persistence) *Conf
 	return &Config{
 		Enabled:                            Enabled.Get(dc),
 		EnableChasm:                        dynamicconfig.EnableChasm.Get(dc),
-		EnableChasmNexus:                   EnableChasmNexus.Get(dc),
+		EnableChasmNexusWorkflowOperations: EnableChasmWorkflowOperations.Get(dc),
 		NumHistoryShards:                   cfg.NumHistoryShards,
 		LongPollBuffer:                     LongPollBuffer.Get(dc),
 		LongPollTimeout:                    LongPollTimeout.Get(dc),

--- a/chasm/lib/workflow/nexus_commands.go
+++ b/chasm/lib/workflow/nexus_commands.go
@@ -35,7 +35,7 @@ func (ch *nexusCommandHandler) handleScheduleCommand(
 	ns := ctx.NamespaceEntry()
 	nsName := ns.Name().String()
 
-	if !ch.config.EnableChasmNexus(nsName) {
+	if !ch.config.EnableChasmNexusWorkflowOperations(nsName) {
 		return ErrCommandNotSupported
 	}
 
@@ -234,7 +234,7 @@ func (ch *nexusCommandHandler) handleCancelCommand(
 	opts CommandHandlerOptions,
 ) error {
 	nsName := ctx.NamespaceEntry().Name().String()
-	if !ch.config.EnableChasmNexus(nsName) {
+	if !ch.config.EnableChasmNexusWorkflowOperations(nsName) {
 		return ErrCommandNotSupported
 	}
 

--- a/chasm/lib/workflow/nexus_commands_test.go
+++ b/chasm/lib/workflow/nexus_commands_test.go
@@ -54,7 +54,7 @@ func (tcx *testContext) setHasAnyBufferedEvent(value bool) {
 }
 
 var defaultConfig = &nexusoperation.Config{
-	EnableChasmNexus:                   dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
+	EnableChasmNexusWorkflowOperations: dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
 	MaxServiceNameLength:               dynamicconfig.GetIntPropertyFnFilteredByNamespace(len("service")),
 	MaxOperationNameLength:             dynamicconfig.GetIntPropertyFnFilteredByNamespace(len("op")),
 	MaxConcurrentOperationsPerWorkflow: dynamicconfig.GetIntPropertyFnFilteredByNamespace(2),
@@ -143,7 +143,7 @@ func newTestContext(t *testing.T, cfg *nexusoperation.Config) testContext {
 func TestHandleScheduleCommand(t *testing.T) {
 	t.Run("chasm nexus not enabled", func(t *testing.T) {
 		tcx := newTestContext(t, &nexusoperation.Config{
-			EnableChasmNexus: dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+			EnableChasmNexusWorkflowOperations: dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
 		})
 		err := tcx.scheduleHandler(tcx.chasmCtx, tcx.wf, commandValidator{maxPayloadSize: 1}, &commandpb.Command{}, CommandHandlerOptions{WorkflowTaskCompletedEventID: 1})
 		require.ErrorIs(t, err, ErrCommandNotSupported)
@@ -641,7 +641,7 @@ func TestHandleScheduleCommand(t *testing.T) {
 func TestHandleCancelCommand(t *testing.T) {
 	t.Run("chasm nexus not enabled", func(t *testing.T) {
 		tcx := newTestContext(t, &nexusoperation.Config{
-			EnableChasmNexus: dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+			EnableChasmNexusWorkflowOperations: dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
 		})
 		err := tcx.cancelHandler(tcx.chasmCtx, tcx.wf, commandValidator{maxPayloadSize: 1}, &commandpb.Command{}, CommandHandlerOptions{WorkflowTaskCompletedEventID: 1})
 		require.ErrorIs(t, err, ErrCommandNotSupported)

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -67,7 +67,7 @@ func (s *NexusWorkflowTestSuite) newTestEnv(chasmEnabled bool, opts ...testcore.
 		opts,
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, chasmEnabled),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMCallbacks, chasmEnabled),
-		testcore.WithDynamicConfig(chasmnexus.EnableChasmNexus, chasmEnabled),
+		testcore.WithDynamicConfig(chasmnexus.EnableChasmWorkflowOperations, chasmEnabled),
 	)...)
 }
 


### PR DESCRIPTION
## What changed?

Rename nexusoperation.enableChasm dc.

## Why?

Clearer.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
