### PR TITLE
Strongly consistent Nexus endpoints lookup via dynamic config

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -959,10 +959,10 @@ and deployment interaction in matching and history.`,
 		1*time.Second,
 		`RefreshNexusEndpointsMinWait is the minimum wait time between background long poll requests to update Nexus endpoints.`,
 	)
-	RefreshNexusEndpointsOnRead = NewGlobalBoolSetting(
-		"system.refreshNexusEndpointsOnRead",
+	ForceNexusEndpointRefreshOnRead = NewGlobalBoolSetting(
+		"system.forceNexusEndpointRefreshOnRead",
 		false,
-		`RefreshNexusEndpointsOnRead forces the Nexus endpoint registry to refresh from matching service on read.
+		`ForceNexusEndpointRefreshOnRead forces the Nexus endpoint registry to refresh from matching service on read.
 This effectively bypasses the cache so that endpoint writes are visible to readers immediately, instead of after the
 next background long-poll refresh. This should not be turned on in production, as it would introduce scalability
 and reliability problems.`,

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -964,7 +964,8 @@ and deployment interaction in matching and history.`,
 		false,
 		`RefreshNexusEndpointsOnRead forces the Nexus endpoint registry to refresh from matching service on read.
 This effectively bypasses the cache so that endpoint writes are visible to readers immediately, instead of after the
-next background long-poll refresh. This should not be turned on in production.`,
+next background long-poll refresh. This should not be turned on in production, as it would introduce scalability
+and reliability problems.`,
 	)
 	NexusReadThroughCacheSize = NewGlobalIntSetting(
 		"system.nexusReadThroughCacheSize",

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -959,6 +959,13 @@ and deployment interaction in matching and history.`,
 		1*time.Second,
 		`RefreshNexusEndpointsMinWait is the minimum wait time between background long poll requests to update Nexus endpoints.`,
 	)
+	RefreshNexusEndpointsOnRead = NewGlobalBoolSetting(
+		"system.refreshNexusEndpointsOnRead",
+		false,
+		`RefreshNexusEndpointsOnRead forces the Nexus endpoint registry to refresh from matching service on read.
+This effectively bypasses the cache so that endpoint writes are visible to readers immediately, instead of after the
+next background long-poll refresh. This should not be turned on in production.`,
+	)
 	NexusReadThroughCacheSize = NewGlobalIntSetting(
 		"system.nexusReadThroughCacheSize",
 		100,

--- a/common/nexus/endpoint_registry.go
+++ b/common/nexus/endpoint_registry.go
@@ -3,6 +3,7 @@ package nexus
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -155,7 +156,7 @@ func (r *EndpointRegistryImpl) GetByName(ctx context.Context, _ namespace.ID, en
 		// This is useful for test and single-node deployments that need endpoint writes
 		// to be visible to GetByName immediately, without waiting for background long poll.
 		if err := r.loadEndpoints(ctx); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("refreshing endpoints: %w", err)
 		}
 	}
 
@@ -178,7 +179,7 @@ func (r *EndpointRegistryImpl) GetByID(ctx context.Context, id string) (*persist
 		// This is useful for test and single-node deployments that need endpoint writes
 		// to be visible to GetByID immediately, without waiting for background long poll.
 		if err := r.loadEndpoints(ctx); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("refreshing endpoints: %w", err)
 		}
 	}
 

--- a/common/nexus/endpoint_registry.go
+++ b/common/nexus/endpoint_registry.go
@@ -80,7 +80,7 @@ func NewEndpointRegistryConfig(dc *dynamicconfig.Collection) *EndpointRegistryCo
 		refreshMinWait:         dynamicconfig.RefreshNexusEndpointsMinWait.Get(dc),
 		readThroughCacheSize:   dynamicconfig.NexusReadThroughCacheSize.Get(dc),
 		readThroughCacheTTL:    dynamicconfig.NexusReadThroughCacheTTL.Get(dc),
-		refreshOnRead:          dynamicconfig.RefreshNexusEndpointsOnRead.Get(dc),
+		refreshOnRead:          dynamicconfig.ForceNexusEndpointRefreshOnRead.Get(dc),
 	}
 	config.refreshRetryPolicy = backoff.NewExponentialRetryPolicy(config.refreshMinWait()).WithMaximumInterval(config.refreshLongPollTimeout())
 	return config

--- a/common/nexus/endpoint_registry.go
+++ b/common/nexus/endpoint_registry.go
@@ -30,6 +30,7 @@ type (
 		refreshPageSize        dynamicconfig.IntPropertyFn
 		refreshMinWait         dynamicconfig.DurationPropertyFn
 		refreshRetryPolicy     backoff.RetryPolicy
+		refreshOnRead          dynamicconfig.BoolPropertyFn
 		readThroughCacheSize   dynamicconfig.IntPropertyFn
 		readThroughCacheTTL    dynamicconfig.DurationPropertyFn
 	}
@@ -78,6 +79,7 @@ func NewEndpointRegistryConfig(dc *dynamicconfig.Collection) *EndpointRegistryCo
 		refreshMinWait:         dynamicconfig.RefreshNexusEndpointsMinWait.Get(dc),
 		readThroughCacheSize:   dynamicconfig.NexusReadThroughCacheSize.Get(dc),
 		readThroughCacheTTL:    dynamicconfig.NexusReadThroughCacheTTL.Get(dc),
+		refreshOnRead:          dynamicconfig.RefreshNexusEndpointsOnRead.Get(dc),
 	}
 	config.refreshRetryPolicy = backoff.NewExponentialRetryPolicy(config.refreshMinWait()).WithMaximumInterval(config.refreshLongPollTimeout())
 	return config
@@ -148,6 +150,15 @@ func (r *EndpointRegistryImpl) GetByName(ctx context.Context, _ namespace.ID, en
 	if err := r.waitUntilInitialized(ctx); err != nil {
 		return nil, err
 	}
+
+	if r.config.refreshOnRead() {
+		// This is useful for test and single-node deployments that need endpoint writes
+		// to be visible to GetByName immediately, without waiting for background long poll.
+		if err := r.loadEndpoints(ctx); err != nil {
+			return nil, err
+		}
+	}
+
 	r.dataLock.RLock()
 	endpoint, ok := r.endpointsByName[endpointName]
 	r.dataLock.RUnlock()
@@ -161,6 +172,14 @@ func (r *EndpointRegistryImpl) GetByName(ctx context.Context, _ namespace.ID, en
 func (r *EndpointRegistryImpl) GetByID(ctx context.Context, id string) (*persistencespb.NexusEndpointEntry, error) {
 	if err := r.waitUntilInitialized(ctx); err != nil {
 		return nil, err
+	}
+
+	if r.config.refreshOnRead() {
+		// This is useful for test and single-node deployments that need endpoint writes
+		// to be visible to GetByID immediately, without waiting for background long poll.
+		if err := r.loadEndpoints(ctx); err != nil {
+			return nil, err
+		}
 	}
 
 	r.dataLock.RLock()

--- a/common/nexus/endpoint_registry_test.go
+++ b/common/nexus/endpoint_registry_test.go
@@ -21,6 +21,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/testing/protoassert"
+	"go.temporal.io/server/common/testing/protorequire"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -127,6 +128,52 @@ func TestGetNotFound(t *testing.T) {
 	reg.dataLock.RLock()
 	defer reg.dataLock.RUnlock()
 	assert.Equal(t, int64(1), reg.tableVersion)
+}
+
+func TestRefreshOnRead(t *testing.T) {
+	t.Parallel()
+
+	for name, read := range map[string]func(*EndpointRegistryImpl, *persistencespb.NexusEndpointEntry) (*persistencespb.NexusEndpointEntry, error){
+		"GetByName": func(reg *EndpointRegistryImpl, entry *persistencespb.NexusEndpointEntry) (*persistencespb.NexusEndpointEntry, error) {
+			return reg.GetByName(context.Background(), "ignored", entry.Endpoint.Spec.Name)
+		},
+		"GetByID": func(reg *EndpointRegistryImpl, entry *persistencespb.NexusEndpointEntry) (*persistencespb.NexusEndpointEntry, error) {
+			return reg.GetByID(context.Background(), entry.Id)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			testEntry := newEndpointEntry(t.Name())
+			mocks := newTestMocks(t)
+			mocks.config.refreshOnRead = dynamicconfig.GetBoolPropertyFn(true)
+
+			mocks.matchingClient.EXPECT().ListNexusEndpoints(gomock.Any(), &matchingservice.ListNexusEndpointsRequest{
+				PageSize:              int32(100),
+				LastKnownTableVersion: int64(0),
+				Wait:                  false,
+			}).Return(&matchingservice.ListNexusEndpointsResponse{
+				Entries:      []*persistencespb.NexusEndpointEntry{testEntry},
+				TableVersion: int64(2),
+			}, nil)
+
+			reg := NewEndpointRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
+
+			// Skip StartLifecycle so the background loop does not race with the single mock
+			// expectation above. Pre-closing ready lets waitUntilInitialized fall through.
+			ready := make(chan struct{})
+			close(ready)
+			reg.dataReady.Store(&dataReady{ready: ready})
+
+			endpoint, err := read(reg, testEntry)
+			require.NoError(t, err)
+			protorequire.ProtoEqual(t, testEntry, endpoint)
+
+			reg.dataLock.RLock()
+			defer reg.dataLock.RUnlock()
+			require.Equal(t, int64(2), reg.tableVersion)
+		})
+	}
 }
 
 func TestInitializationFallback(t *testing.T) {

--- a/tests/nexus_test_base.go
+++ b/tests/nexus_test_base.go
@@ -3,9 +3,7 @@ package tests
 import (
 	"context"
 	"errors"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/nexus-rpc/sdk-go/nexus"
@@ -59,7 +57,6 @@ func (env *NexusTestEnv) createNexusEndpoint(ctx context.Context, t *testing.T, 
 		})
 	})
 
-	env.ensureNexusEndpoint(ctx, t, name)
 	return resp.Endpoint
 }
 
@@ -94,27 +91,7 @@ func (env *NexusTestEnv) createRandomExternalNexusServer(ctx context.Context, t 
 		})
 	})
 
-	env.ensureNexusEndpoint(ctx, t, endpointName)
 	return endpointName
-}
-
-// ensureNexusEndpoint probes the specified endpoint until it's visible to StartNexusOperationExecution to ensure tests
-// can use it.
-func (env *NexusTestEnv) ensureNexusEndpoint(ctx context.Context, t *testing.T, endpointName string) {
-	require.Eventually(t, func() bool {
-		_, err := env.FrontendClient().StartNexusOperationExecution(ctx, &workflowservice.StartNexusOperationExecutionRequest{
-			Namespace: env.Namespace().String(),
-			Endpoint:  endpointName,
-			Service:   "probe",
-			Operation: "probe",
-			RequestId: "probe",
-		})
-		if notFound, ok := errors.AsType[*serviceerror.NotFound](err); ok {
-			msg := notFound.Error()
-			return msg != "endpoint not registered" && !strings.HasPrefix(msg, "could not find Nexus endpoint by name:")
-		}
-		return true
-	}, 10*time.Second, 100*time.Millisecond, "endpoint should become visible")
 }
 
 // nexusTaskResponse represents a successful response from a nexus task handler.

--- a/tests/testcore/dynamic_config_overrides.go
+++ b/tests/testcore/dynamic_config_overrides.go
@@ -62,6 +62,7 @@ var (
 		dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace.Key(): ClientSuiteLimit,
 		dynamicconfig.FrontendEnableWorkerVersioningDataAPIs.Key():          true,
 		dynamicconfig.FrontendEnableWorkerVersioningWorkflowAPIs.Key():      true,
+		dynamicconfig.RefreshNexusEndpointsOnRead.Key():                     true,
 		dynamicconfig.RefreshNexusEndpointsMinWait.Key():                    1 * time.Millisecond,
 		nexusoperations.RecordCancelRequestCompletionEvents.Key():           true,
 		nexusoperations.UseSystemCallbackURL.Key():                          true,

--- a/tests/testcore/dynamic_config_overrides.go
+++ b/tests/testcore/dynamic_config_overrides.go
@@ -62,7 +62,7 @@ var (
 		dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace.Key(): ClientSuiteLimit,
 		dynamicconfig.FrontendEnableWorkerVersioningDataAPIs.Key():          true,
 		dynamicconfig.FrontendEnableWorkerVersioningWorkflowAPIs.Key():      true,
-		dynamicconfig.RefreshNexusEndpointsOnRead.Key():                     true,
+		dynamicconfig.ForceNexusEndpointRefreshOnRead.Key():                 true,
 		dynamicconfig.RefreshNexusEndpointsMinWait.Key():                    1 * time.Millisecond,
 		nexusoperations.RecordCancelRequestCompletionEvents.Key():           true,
 		nexusoperations.UseSystemCallbackURL.Key():                          true,


### PR DESCRIPTION
## What changed?

Instead of using the cache for Nexus endpoint name lookups, always look it up via RPC when `RefreshNexusEndpointsOnRead` is set.

See https://github.com/temporalio/temporal/pull/10204 for an alternative approach.

## Why?

During testing - such as functional server tests or SDK tests against the CLI - the Nexus endpoint is not always immediately available after creation. This creates friction as it requires extra retries and causes flakiness if not guarded against. This change eliminates that need.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
