### PR TITLE
Fix cache_pinned_usage going negative when pinned entries grow (#9954)

### DIFF
--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -58,6 +58,14 @@ type (
 		value      any
 		refCount   int
 		size       int
+		// pinnedSize records the entry's size at the moment its ref count
+		// transitioned from 0→1 in pin-mode. Release uses this snapshot when
+		// refCount hits 0 again so that the exact same number of bytes added
+		// to the cache's pinnedSize counter is removed. Without this snapshot
+		// the metric could go negative or stale because entry.size is mutated
+		// in place by Release/putInternal as the underlying value's reported
+		// CacheSize() changes (#9954).
+		pinnedSize int
 	}
 )
 
@@ -267,7 +275,12 @@ func (c *lru) Release(key any) {
 	entry := elt.Value.(*entryImpl)
 	entry.refCount--
 	if entry.refCount == 0 {
-		c.pinnedSize -= entry.Size()
+		// Subtract the size that was added when pin happened (the 0→1
+		// transition), not entry.Size(): the latter may have been mutated by
+		// earlier Release calls or external value mutations and would leave
+		// pinnedSize negative or stale (#9954).
+		c.pinnedSize -= entry.pinnedSize
+		entry.pinnedSize = 0
 		metrics.CachePinnedUsage.With(c.metricsHandler).Record(float64(c.pinnedSize))
 	}
 	// Entry size might have changed. Recalculate size and evict entries if necessary.
@@ -439,7 +452,12 @@ func (c *lru) updateEntryRefCount(entry *entryImpl) {
 	if c.pin {
 		entry.refCount++
 		if entry.refCount == 1 {
-			c.pinnedSize += entry.Size()
+			// Snapshot the size that we add to pinnedSize so Release subtracts
+			// exactly the same amount when refCount returns to 0. entry.size
+			// may be mutated later (Release recomputes currSize, putInternal
+			// may update value/size) but pinnedSize must be balanced (#9954).
+			entry.pinnedSize = entry.Size()
+			c.pinnedSize += entry.pinnedSize
 			metrics.CachePinnedUsage.With(c.metricsHandler).Record(float64(c.pinnedSize))
 		}
 	}

--- a/common/cache/lru_test.go
+++ b/common/cache/lru_test.go
@@ -698,6 +698,64 @@ func TestCache_ItemSizeChangeBeforeRelease(t *testing.T) {
 	assert.Equal(t, 2, cache.Size())
 }
 
+// Regression test for #9954: pinnedSize (and the cache_pinned_usage metric)
+// could go negative when a pinned entry's underlying CacheSize() grew while
+// the entry was held. The increment happens at the 0→1 ref-count transition
+// using entry.Size() at that moment, but the matching decrement at the 1→0
+// transition used entry.Size() at release time. Release also recomputes
+// entry.size from getSize(entry.value) on every call (regardless of refCount),
+// so a non-zero-going-down release earlier in the sequence is enough to
+// poison the value subtracted by the final release.
+func TestCache_PinnedSizeNotNegativeWhenPinnedEntryGrows(t *testing.T) {
+	t.Parallel()
+
+	metricsHandler := metricstest.NewCaptureHandler()
+	cache := NewWithMetrics(100,
+		&Options{
+			Pin: true,
+		},
+		metricsHandler,
+	)
+
+	key := "k"
+	entry := &testEntryWithCacheSize{cacheSize: 3}
+
+	capture := metricsHandler.StartCapture()
+
+	// First insert: refCount 0→1, pinnedSize += 3.
+	_, err := cache.PutIfNotExist(key, entry)
+	require.NoError(t, err)
+
+	// Acquire a second reference: refCount 1→2 (pinnedSize untouched).
+	cache.Get(key)
+
+	// The held value is mutated externally so its reported CacheSize grows.
+	// Several callers in temporal store pointer-typed values whose contents
+	// (and therefore CacheSize) grow while held — this is the scenario that
+	// motivated #9954.
+	entry.cacheSize = 10
+
+	// First release: refCount 2→1. The if-block at refCount==0 does NOT fire,
+	// but Release still recomputes entry.size from the new CacheSize.
+	cache.Release(key)
+	// Second release: refCount 1→0. The if-block fires; before the fix it
+	// subtracted the (now-larger) entry.Size(), driving pinnedSize negative.
+	cache.Release(key)
+
+	snapshot := capture.Snapshot()
+	pinnedRecords := snapshot[metrics.CachePinnedUsage.Name()]
+	require.NotEmpty(t, pinnedRecords, "expected at least one cache_pinned_usage record")
+	for _, r := range pinnedRecords {
+		assert.GreaterOrEqual(t, r.Value, float64(0),
+			"cache_pinned_usage must never be negative; got %v in series %v", r.Value, pinnedRecords)
+	}
+	// After all references are released, pinnedSize must be exactly 0 — every
+	// pinned byte that was added has been removed.
+	final := pinnedRecords[len(pinnedRecords)-1].Value
+	assert.Equal(t, float64(0), final,
+		"after releasing all refs pinnedSize must return to 0; got %v", final)
+}
+
 func TestCache_InvokeLifecycleCallbacks(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed?

Fixes a balancing bug in `common/cache/lru.go` that caused the
`cache_pinned_usage` Prometheus gauge to go negative when a pinned entry's
underlying `CacheSize()` grew while the entry was held.

`pinnedSize` is incremented on the `0 -> 1` ref-count transition (taking
`entry.Size()` as the snapshot) and decremented on the `1 -> 0` transition.
`Release` also recomputes `entry.size = getSize(entry.value)` on every call
(regardless of ref-count), so an earlier non-zero-going-down `Release` could
mutate `entry.size` between the increment and the matching decrement. When
the underlying value's `CacheSize()` grew while held, the final `Release`
subtracted more than was originally added and `pinnedSize` went negative
(reported in production at `-4.7e7` with `history.cacheSizeBasedLimit=true`,
v1.29.1).

The fix snapshots the pinned size on the entry at the `0 -> 1` transition and
uses that exact value at the `1 -> 0` transition so the increment and
decrement are always balanced.

## Why?

A monotonically counting gauge that ratchets negative is misleading for
operators who alert on cache pressure or use the metric to size pinned
caches. The bug was reported with concrete `pkg:line` citations
(`common/cache/lru.go:441-444` and `269-272`) by a user running v1.29.1 on
RKE2/Linux/amd64 in #9954.

## How did you test it?

- [x] built (`go build ./...`)
- [x] run locally and tested manually (regression test demonstrates BEFORE
  fail / AFTER pass)
- [ ] covered by existing tests
- [x] added new unit test(s) (`TestCache_PinnedSizeNotNegativeWhenPinnedEntryGrows`)
- [ ] added new functional test(s)

Concrete results on this branch:

```
$ go test ./common/cache/...
ok      go.temporal.io/server/common/cache      2.265s
$ go test -race ./common/cache/...
ok      go.temporal.io/server/common/cache      3.500s
$ go vet ./common/cache/...      # clean
$ go build ./...                 # whole tree builds
```

## Potential risks

- The fix adds one `int` field (`pinnedSize`) to `entryImpl`. Memory delta is
  `8 bytes * #entries`; for a million pinned mutable-state entries this is
  `8 MB`, well under typical history-cache budgets.
- Behavior change is bounded to the pin-mode path (`opts.Pin == true`).
  Non-pin caches go through the same code but `updateEntryRefCount` and the
  refCount-zero branch in `Release` only run when `c.pin == true`.
- The snapshot is reset to `0` when refCount returns to `0`, so re-pinning
  the same key (e.g. via `PutIfNotExist` re-acquiring) starts a fresh cycle.

## Reproduce BEFORE/AFTER yourself (copy-paste)

A reviewer can verify this fix end-to-end by pasting the block below. The
only thing that changes between BEFORE and AFTER is the checked-out git
ref. The regression test is on this branch — we use `git checkout
FETCH_HEAD -- ...` to import only the test file when we want to run it
against `origin/main` for the BEFORE step.

```bash
# --- one-time setup ---
git clone https://github.com/temporalio/temporal.git /tmp/repro-9954 && cd /tmp/repro-9954
git fetch https://github.com/jbbqqf/temporal.git feat/9954-fix-cache-pinned-usage-negative

# --- BEFORE (origin/main, with the regression test imported from this PR) ---
git checkout origin/main
git checkout FETCH_HEAD -- common/cache/lru_test.go
go test -run TestCache_PinnedSizeNotNegativeWhenPinnedEntryGrows ./common/cache/ -v
# Expected: FAIL with "cache_pinned_usage must never be negative; got -7"
git checkout -- common/cache/lru_test.go

# --- AFTER (this PR) ---
git checkout FETCH_HEAD
go test -run TestCache_PinnedSizeNotNegativeWhenPinnedEntryGrows ./common/cache/ -v
# Expected: PASS — pinnedSize stays >= 0 throughout and returns to 0
```

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | Pinned entry grows while held, two refs | put(size=3) → get → grow value to size=10 → release → release | pinnedSize stays >= 0; returns to 0 after final release | `TestCache_PinnedSizeNotNegativeWhenPinnedEntryGrows` |
| 2 | Pinned entry held without growth | put(size=3) → get → release → release | unchanged: pinnedSize 3 → 0 (no regression) | existing `TestTTLWithPin`, `TestMaxSizeWithPin_*` |
| 3 | Non-pin cache (`Pin: false`) | any put/get/release sequence | `pinnedSize` field never written; metric never recorded | existing `TestLRU`, `TestCache_*` (non-pin variants) |
| 4 | Re-pin after release | put → release (refCount=0, pinnedSize cleared) → get → release | new cycle starts cleanly; entry.pinnedSize re-snapshotted on 0→1 | manual review of `Release` + `updateEntryRefCount` paths |

## Risk / blast radius

The change is confined to `common/cache/lru.go` and one new test in
`common/cache/lru_test.go`. The history mutable-state cache is the primary
in-tree user of pin-mode (`history.cacheSizeBasedLimit`); other callers of
`cache.NewWithMetrics` not using `Pin: true` are unaffected.

## Release note

```release-note
fix: cache_pinned_usage Prometheus gauge no longer reports negative values
when a pinned entry's underlying CacheSize() grows while held.
```

---

*PR drafted with assistance from Claude Code. The fix and regression test were
reviewed manually against the source paths cited in #9954
(`common/cache/lru.go:441-444`, `:269-272`). The reproducer block above was
used during development; it is the same one a reviewer can paste verbatim.*
