### PR TITLE
Add --password-file flag to temporal-sql-tool (#10028)

### DIFF
--- a/tools/common/schema/types.go
+++ b/tools/common/schema/types.go
@@ -61,6 +61,11 @@ const (
 	CLIOptUser = "user"
 	// CLIOptPassword is the cli option for password
 	CLIOptPassword = "password"
+	// CLIOptPasswordFile is the cli option for reading the password from a
+	// file path. Useful for defense-in-depth: a value passed via --password
+	// or $SQL_PASSWORD is visible in the host's process table; a file path
+	// is not. See #10028.
+	CLIOptPasswordFile = "password-file"
 	// CLIOptAuthenticator is the cli option for allowed authenticator settings
 	CLIOptAllowedAuthenticators = "allowed-authenticators"
 	// CLIOptTimeout is the cli option for timeout
@@ -112,6 +117,8 @@ const (
 	CLIFlagUser = CLIOptUser + ", u"
 	// CLIFlagPassword is the cli flag for password
 	CLIFlagPassword = CLIOptPassword + ", pw"
+	// CLIFlagPasswordFile is the cli flag for password-file (alias: pwf)
+	CLIFlagPasswordFile = CLIOptPasswordFile + ", pwf"
 	// CLIFlagAllowedAuthenticators is the cli flag for allowed authenticators
 	CLIFlagAllowedAuthenticators = CLIOptAllowedAuthenticators + ", aa"
 	// CLIFlagTimeout is the cli flag for timeout

--- a/tools/sql/handler.go
+++ b/tools/sql/handler.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
+	"strings"
 
 	"github.com/urfave/cli"
 	"go.temporal.io/server/common/auth"
@@ -114,6 +116,30 @@ func DoDropDatabase(cfg *config.SQL, defaultDb string, logger log.Logger) error 
 	return nil
 }
 
+// resolvePassword returns the SQL password to use given the literal --password
+// value and the --password-file path. Exactly one of the two should be
+// supplied: passing both is rejected so an operator gets a clear error rather
+// than silently picking one. The file's contents are returned with a single
+// trailing newline trimmed (the convention POSIX `echo` and most editors
+// produce). See #10028.
+func resolvePassword(password, passwordFile string, readFile func(string) ([]byte, error)) (string, error) {
+	if password != "" && passwordFile != "" {
+		return "", fmt.Errorf("both --%s and --%s were provided; choose one",
+			schema.CLIOptPassword, schema.CLIOptPasswordFile)
+	}
+	if passwordFile == "" {
+		return password, nil
+	}
+	b, err := readFile(passwordFile)
+	if err != nil {
+		return "", fmt.Errorf("reading --%s %q: %w", schema.CLIOptPasswordFile, passwordFile, err)
+	}
+	// Trim a single trailing newline so files written by `echo "..." > pw` work
+	// out of the box; keep any other whitespace intact in case the password
+	// genuinely contains it.
+	return strings.TrimSuffix(string(b), "\n"), nil
+}
+
 func parseConnectConfig(cli *cli.Context) (*config.SQL, error) {
 	cfg := new(config.SQL)
 
@@ -121,7 +147,15 @@ func parseConnectConfig(cli *cli.Context) (*config.SQL, error) {
 	port := cli.GlobalInt(schema.CLIOptPort)
 	cfg.ConnectAddr = fmt.Sprintf("%s:%v", host, port)
 	cfg.User = cli.GlobalString(schema.CLIOptUser)
-	cfg.Password = cli.GlobalString(schema.CLIOptPassword)
+	password, err := resolvePassword(
+		cli.GlobalString(schema.CLIOptPassword),
+		cli.GlobalString(schema.CLIOptPasswordFile),
+		os.ReadFile,
+	)
+	if err != nil {
+		return nil, err
+	}
+	cfg.Password = password
 	cfg.DatabaseName = cli.GlobalString(schema.CLIOptDatabase)
 	cfg.PluginName = cli.GlobalString(schema.CLIOptPluginName)
 

--- a/tools/sql/handler_test.go
+++ b/tools/sql/handler_test.go
@@ -1,0 +1,97 @@
+package sql
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolvePassword exercises the small helper introduced for #10028 that
+// chooses between a literal --password and the contents of --password-file.
+// readFile is injected so the test does not touch the real filesystem.
+func TestResolvePassword(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		password   string
+		file       string
+		fileBytes  []byte
+		fileErr    error
+		want       string
+		wantErrSub string // substring expected in error, "" if no error
+	}{
+		{
+			name:     "neither flag set yields empty password",
+			password: "",
+			file:     "",
+			want:     "",
+		},
+		{
+			name:     "literal password passes through unchanged",
+			password: "s3cret",
+			file:     "",
+			want:     "s3cret",
+		},
+		{
+			name:      "file password trims one trailing newline",
+			password:  "",
+			file:      "/etc/secrets/sqlpw",
+			fileBytes: []byte("s3cret\n"),
+			want:      "s3cret",
+		},
+		{
+			name:      "file password without trailing newline is unchanged",
+			password:  "",
+			file:      "/etc/secrets/sqlpw",
+			fileBytes: []byte("s3cret"),
+			want:      "s3cret",
+		},
+		{
+			name:      "internal whitespace and other newlines are preserved (only one trailing \\n is trimmed)",
+			password:  "",
+			file:      "/etc/secrets/sqlpw",
+			fileBytes: []byte("line1\nline2\n"),
+			want:      "line1\nline2",
+		},
+		{
+			name:       "both flags set is rejected to avoid silent precedence",
+			password:   "literal",
+			file:       "/etc/secrets/sqlpw",
+			fileBytes:  []byte("ignored"),
+			wantErrSub: "both --password and --password-file were provided",
+		},
+		{
+			name:       "file read error is surfaced with path context",
+			password:   "",
+			file:       "/etc/secrets/missing",
+			fileErr:    errors.New("open: no such file"),
+			wantErrSub: "reading --password-file",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			read := func(path string) ([]byte, error) {
+				assert.Equal(t, tc.file, path,
+					"readFile should be called with the path passed to resolvePassword")
+				if tc.fileErr != nil {
+					return nil, tc.fileErr
+				}
+				return tc.fileBytes, nil
+			}
+			got, err := resolvePassword(tc.password, tc.file, read)
+			if tc.wantErrSub != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErrSub)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/tools/sql/main.go
+++ b/tools/sql/main.go
@@ -64,6 +64,15 @@ func BuildCLIOptions() *cli.App {
 			EnvVar: "SQL_PASSWORD",
 		},
 		cli.StringFlag{
+			Name: schema.CLIFlagPasswordFile,
+			// Path to a file whose contents are read as the SQL password.
+			// Mutually exclusive with --password / $SQL_PASSWORD. Avoids
+			// exposing the password in /proc, shell history, and `ps` output
+			// (see #10028).
+			Usage:  "path to a file containing the password used for authentication when connecting to sql host (mutually exclusive with --password)",
+			EnvVar: "SQL_PASSWORD_FILE",
+		},
+		cli.StringFlag{
 			Name:   schema.CLIFlagDatabase,
 			Value:  "temporal",
 			Usage:  "name of the sql database",


### PR DESCRIPTION
## What changed?

Adds a new `--password-file` flag (alias `--pwf`, env `SQL_PASSWORD_FILE`) to
`temporal-sql-tool`. The flag reads the SQL password from a file path
instead of from `--password` / `$SQL_PASSWORD`. The two flags are mutually
exclusive — passing both is rejected with a clear error so an operator
isn't surprised by silent precedence.

A single trailing newline is trimmed from the file's contents so that files
written via the conventional `echo "secret" > /run/secrets/sqlpw` work
without surprises; other whitespace is preserved in case the password
genuinely contains it.

The flag is added in three places:

- `tools/common/schema/types.go` — declares `CLIOptPasswordFile` /
  `CLIFlagPasswordFile` (alias `pwf`).
- `tools/sql/main.go` — wires the flag into the CLI alongside `--password`.
- `tools/sql/handler.go` — `parseConnectConfig` now resolves the password via
  a new `resolvePassword(literal, filePath, readFile)` helper.

## Why?

`temporal-sql-tool` today supports `--password` and `$SQL_PASSWORD`. Both
expose the password in `/proc/<pid>/cmdline` and in `ps` output, which is
visible to other processes on the same host. Operators in shared-host or
container environments want a defense-in-depth path that keeps the
password out of the process table. The reporter on #10028 explicitly asked
for this; the comment thread also notes that `.pgpass` is a Postgres-only
workaround and a Temporal-native flag is preferable for portability across
the SQL plugins (mysql, postgres, sqlite).

The pattern matches what other tools in the ecosystem already ship —
`mysqldump --defaults-extra-file=…`, `psql --pgpass`, `kubectl
--token-file=…`, `docker login --password-stdin`, and so on.

## How did you test it?

- [x] built (`go build ./...`)
- [x] run locally and tested manually (verified `--password-file` shows up
  in `temporal-sql-tool --help` and is absent on `origin/main`)
- [ ] covered by existing tests
- [x] added new unit test(s) (`TestResolvePassword`, 7 sub-cases)
- [ ] added new functional test(s)

Concrete results on this branch:

```
$ go test ./tools/sql/...
ok      go.temporal.io/server/tools/sql        0.030s
?       go.temporal.io/server/tools/sql/clitest [no test files]

$ go vet ./tools/sql/... ./tools/common/schema/...   # clean
$ go build ./...                                      # whole tree builds
$ go test -run TestResolvePassword ./tools/sql/ -v    # 7/7 sub-cases pass
```

## Potential risks

- The CLI flag namespace is global to `temporal-sql-tool`. The new alias
  `pwf` does not collide with any existing alias (`pw` is `--password`,
  `pl` is `--plugin`, `p` is `--port`).
- `resolvePassword` is private to the `sql` package and is invoked exactly
  once in `parseConnectConfig`. No other call sites need to change.
- Reading `~/.pgpass` (the existing Postgres-side workaround mentioned by
  `@scjody` in #10028) keeps working unchanged because the new flag is opt-in.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/temporalio/temporal.git /tmp/repro-10028 && cd /tmp/repro-10028
git fetch https://github.com/jbbqqf/temporal.git feat/10028-sql-tool-password-file

# --- BEFORE (origin/main) ---
git checkout origin/main
go build -o /tmp/sql-tool-before ./cmd/tools/sql/
/tmp/sql-tool-before --help 2>&1 | grep -E '\-\-password' || true
# Expected: only "--password value, --pw value ..." is listed; no --password-file

# --- AFTER (this PR) ---
git checkout FETCH_HEAD
go build -o /tmp/sql-tool-after ./cmd/tools/sql/
/tmp/sql-tool-after --help 2>&1 | grep -E '\-\-password' || true
# Expected: BOTH "--password value, --pw value ..." AND
#                "--password-file value, --pwf value ... [$SQL_PASSWORD_FILE]"

# --- functional check: file is read and trimmed ---
printf 's3cret\n' > /tmp/pw && chmod 600 /tmp/pw
go test -run TestResolvePassword ./tools/sql/ -v
# Expected: PASS (7/7 subtests). On origin/main this test does not exist.
```

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | Neither flag set | empty/empty | password = "" | `TestResolvePassword/neither_flag_set...` |
| 2 | Only `--password` | "s3cret"/empty | password = "s3cret" | `TestResolvePassword/literal_password...` |
| 3 | Only `--password-file`, file ends in `\n` | empty/path, contents=`s3cret\n` | password = "s3cret" | `TestResolvePassword/file_password_trims...` |
| 4 | Only `--password-file`, file ends without `\n` | empty/path, contents=`s3cret` | password = "s3cret" | `TestResolvePassword/file_password_without_trailing_newline...` |
| 5 | File contains embedded newlines | empty/path, contents=`line1\nline2\n` | password = "line1\nline2" (only one trailing trimmed) | `TestResolvePassword/internal_whitespace...` |
| 6 | Both flags set | "literal"/path | error: "both --password and --password-file were provided" | `TestResolvePassword/both_flags_set...` |
| 7 | `--password-file` path is unreadable | empty/path, ReadFile errors | error wraps the read error and includes the path | `TestResolvePassword/file_read_error...` |

## Risk / blast radius

The change is confined to `temporal-sql-tool` and one new CLI flag string in
`tools/common/schema/types.go`. The cassandra and elasticsearch tools
(`tools/cassandra/main.go`, `tools/elasticsearch/main.go`) reuse the same
`schema.CLIFlagPassword` constant but do not opt into the new
`--password-file` flag in this PR — happy to extend them in a follow-up if
maintainers prefer; keeping scope tight to what the issue actually asked
for here.

## Release note

```release-note
feat(temporal-sql-tool): support reading the SQL password from a file via
--password-file / SQL_PASSWORD_FILE so it stays out of /proc and ps output.
```

---

*PR drafted with assistance from Claude Code. The flag wiring and helper
function were reviewed manually against the existing `--password` /
`$SQL_PASSWORD` pattern (`tools/sql/main.go:60`, `tools/sql/handler.go:124`).
The reproducer block above was used during development.*
