### PR TITLE
Remove buf breaking ignore directive for chasm workflow

### DIFF
--- a/chasm/lib/buf.yaml
+++ b/chasm/lib/buf.yaml
@@ -5,9 +5,6 @@ deps:
 breaking:
   use:
     - WIRE
-  ignore:
-    # TODO(bergundy): remove after 10154 is merged
-    - chasm/lib/workflow/proto/v1/state.proto
 lint:
   use:
     - DEFAULT


### PR DESCRIPTION
## What changed?

WYSIOTT

## Why?

Safety.