### PR TITLE
Trampolining fix: Suppress targetWorkerDeploymentVersionChanged on inline WFT path

### DIFF
--- a/service/history/api/create_workflow_util.go
+++ b/service/history/api/create_workflow_util.go
@@ -113,7 +113,7 @@ func NewWorkflowWithSignal(
 			nil,
 			false,
 			nil,
-			0,
+			-1, // sentinel: eager-exec path didn't consult matching, has no routing revision
 		)
 		if err != nil {
 			// Unable to add WorkflowTaskStarted event to history

--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -603,7 +603,7 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 				workflowLease.GetContext().UpdateRegistry(ctx),
 				false,
 				nil,
-				0,
+				-1, // sentinel: inline path didn't consult matching, has no routing revision
 			)
 			if err != nil {
 				return nil, err
@@ -729,7 +729,7 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 			workflowLease.GetContext().UpdateRegistry(ctx),
 			false,
 			nil,
-			0,
+			-1, // sentinel: inline path didn't consult matching, has no routing revision
 		)
 		if err != nil {
 			return nil, err

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -541,7 +541,7 @@ func (r *workflowResetterImpl) failWorkflowTask(
 			// skipping versioning checks because this task is not actually dispatched but will fail immediately.
 			true,
 			nil,
-			0,
+			-1, // sentinel: synthetic event, no routing info
 		)
 		if err != nil {
 			return err

--- a/service/history/workflow/workflow_task_state_machine.go
+++ b/service/history/workflow/workflow_task_state_machine.go
@@ -532,10 +532,8 @@ func (m *workflowTaskStateMachine) AddWorkflowTaskStartedEvent(
 		case m.ms.executionInfo.GetDeclinedTargetVersionUpgrade() != nil &&
 			targetRevisionNumber <= m.ms.executionInfo.GetDeclinedTargetVersionUpgrade().GetRevisionNumber():
 		default:
-			// Stale matching reports (revision <= highestSeenRevNumber) are suppressed to avoid
-			// corrupting state with outdated data. This also handles the inline WFT
-			// path in RespondWorkflowTaskCompleted, which passes revision 0.
-			if targetRevisionNumber <= highestSeenRevNumber {
+			// Strict `<` (not `<=`) so legitimate same-revision re-firings (e.g., transient retries, repeated updates) still fire; inline path uses revision=-1 sentinel to be caught here.
+			if targetRevisionNumber < highestSeenRevNumber {
 				break
 			}
 			// Otherwise — target changed + did not decline to upgrade on CaN/retry. Signal the SDK.

--- a/service/history/workflow/workflow_task_state_machine.go
+++ b/service/history/workflow/workflow_task_state_machine.go
@@ -500,6 +500,16 @@ func (m *workflowTaskStateMachine) AddWorkflowTaskStartedEvent(
 		// in that case proto getters return zero values and we correctly fall through to signal.
 		effectiveDeploymentVersion := worker_versioning.ExternalWorkerDeploymentVersionFromDeployment(m.ms.GetEffectiveDeployment())
 
+		// Highest revision the workflow knows about from matching, whether from a
+		// notification on this run (LastNotifiedTargetVersion) or carried via CaN
+		// (DeclinedTargetVersionUpgrade). Used to suppress stale matching reports,
+		// including inline WFTs in RespondWorkflowTaskCompleted which don't consult
+		// matching and pass revision 0.
+		highestSeenRevNumber := max(
+			m.ms.executionInfo.GetLastNotifiedTargetVersion().GetRevisionNumber(),
+			m.ms.executionInfo.GetDeclinedTargetVersionUpgrade().GetRevisionNumber(),
+		)
+
 		switch {
 		// 1. Override active — operator controls version, don't signal. Clear any stale declined/notified state so that
 		// when/if the operator removes the override, we re-calculate the declined/notified state and appropriately fire the
@@ -510,16 +520,24 @@ func (m *workflowTaskStateMachine) AddWorkflowTaskStartedEvent(
 		// 2. AutoUpgrade — will transition naturally, no CaN needed.
 		case m.ms.GetEffectiveVersioningBehavior() == enumspb.VERSIONING_BEHAVIOR_AUTO_UPGRADE:
 		// Rest of the checks are guaranteed to have the Workflow's Effective Versioning Behavior to be Pinned in nature.
-		// 3. Already on target — nothing changed. Clear any stale declined/notified state.
+		// 3. Already on target AND partition's view is at least as fresh as what we last knew.
+		// The revision check prevents a stale partition (coincidentally matching by buildId)
+		// from wiping legitimate declined/notified state.
 		case effectiveDeploymentVersion.GetBuildId() == targetDeploymentVersion.GetBuildId() &&
-			effectiveDeploymentVersion.GetDeploymentName() == targetDeploymentVersion.GetDeploymentName():
-			// TODO (Shivam): Revision number mechanics to strengthen this check
+			effectiveDeploymentVersion.GetDeploymentName() == targetDeploymentVersion.GetDeploymentName() &&
+			targetRevisionNumber >= highestSeenRevNumber:
 			m.ms.executionInfo.DeclinedTargetVersionUpgrade = nil
 			m.ms.executionInfo.LastNotifiedTargetVersion = nil
 		// 4. Previously declined upgrade — target revision is not newer than what was declined.
 		case m.ms.executionInfo.GetDeclinedTargetVersionUpgrade() != nil &&
 			targetRevisionNumber <= m.ms.executionInfo.GetDeclinedTargetVersionUpgrade().GetRevisionNumber():
 		default:
+			// Stale matching reports (revision <= highestSeenRevNumber) are suppressed to avoid
+			// corrupting state with outdated data. This also handles the inline WFT
+			// path in RespondWorkflowTaskCompleted, which passes revision 0.
+			if targetRevisionNumber <= highestSeenRevNumber {
+				break
+			}
 			// Otherwise — target changed + did not decline to upgrade on CaN/retry. Signal the SDK.
 			targetDeploymentVersionChanged = true
 			m.ms.executionInfo.LastNotifiedTargetVersion = &persistencespb.LastNotifiedTargetVersion{

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -6511,6 +6511,106 @@ func (s *Versioning3Suite) TestStalePartition_RevisionSuppressesTrampolining() {
 		})
 }
 
+// TestInlinePath_StableRouting_NoSpuriousFlag verifies that a PINNED workflow
+// on stable routing does NOT receive targetWorkerDeploymentVersionChanged=true
+// on WFTs created via the inline path in RespondWorkflowTaskCompleted (e.g.,
+// when a buffered signal arrives during WFT processing).
+//
+// Flow:
+// 1. Start pinned workflow on v1; set v1 as current (stable routing).
+// 2. Trigger a regular WFT via a first signal.
+// 3. During that WFT's processing, send a second signal → gets buffered →
+//    server creates an inline WFT to deliver it.
+// 4. Poll the inline WFT and assert:
+//      - requestId == "request-from-RespondWorkflowTaskCompleted" (self-check
+//        that we actually exercised the inline path)
+//      - targetWorkerDeploymentVersionChanged == false (the bug being fixed)
+func (s *Versioning3Suite) TestInlinePath_StableRouting_NoSpuriousFlag() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	tv1 := testvars.New(s).WithBuildIDNumber(1)
+
+	// Async poller for first WFT, declares pinned behavior
+	wftCompleted := make(chan struct{})
+	s.pollWftAndHandle(tv1, false, wftCompleted,
+		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+			s.NotNil(task)
+			return respondEmptyWft(tv1, false, vbPinned), nil
+		})
+
+	s.waitForDeploymentDataPropagation(tv1, versionStatusInactive, false, tqTypeWf)
+	s.setCurrentDeployment(tv1)
+
+	runID := s.startWorkflow(tv1, nil)
+	execution := tv1.WithRunID(runID).WorkflowExecution()
+	s.WaitForChannel(ctx, wftCompleted)
+	s.verifyWorkflowVersioning(s.Assertions, tv1, vbPinned, tv1.Deployment(), nil, nil)
+
+	// Trigger a regular WFT via a first signal.
+	_, err := s.FrontendClient().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
+		Namespace:         s.Namespace().String(),
+		WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: tv1.WorkflowID()},
+		SignalName:        "first-signal",
+		Identity:          tv1.WorkerIdentity(),
+	})
+	s.NoError(err)
+
+	// Process the WFT for the first signal; during processing send a second signal
+	// that will be buffered. Set ReturnNewWorkflowTask=true so the server takes the
+	// bypassTaskGeneration path and embeds the inline follow-up WFT in the response.
+	poller, resp := s.pollWftAndHandle(tv1, false, nil,
+		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+			s.NotNil(task)
+			_, err := s.FrontendClient().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
+				Namespace:         s.Namespace().String(),
+				WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: tv1.WorkflowID()},
+				SignalName:        "buffered-signal",
+				Identity:          tv1.WorkerIdentity(),
+			})
+			s.NoError(err)
+			reply := respondEmptyWft(tv1, false, vbPinned)
+			reply.ReturnNewWorkflowTask = true
+			return reply, nil
+		})
+
+	// The inline follow-up WFT should be embedded in the response.
+	s.NotNil(resp)
+	inlineTask := resp.GetWorkflowTask()
+	s.NotNil(inlineTask, "expected inline follow-up WFT in RespondWorkflowTaskCompletedResponse")
+
+	// Self-verification: WFT-Started event from the inline path carries the marker requestId.
+	var lastStarted *historypb.HistoryEvent
+	for _, e := range inlineTask.GetHistory().GetEvents() {
+		if e.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED {
+			lastStarted = e
+		}
+	}
+	s.NotNil(lastStarted)
+	s.Equal("request-from-RespondWorkflowTaskCompleted",
+		lastStarted.GetWorkflowTaskStartedEventAttributes().GetRequestId(),
+		"inline WFT-Started event should carry the marker requestId (test exercises inline path)")
+	// Core assertion.
+	s.False(lastStarted.GetWorkflowTaskStartedEventAttributes().GetTargetWorkerDeploymentVersionChanged(),
+		"inline WFT on stable routing must NOT fire targetWorkerDeploymentVersionChanged=true")
+
+	// Complete the inline WFT to finish the workflow.
+	_, err = poller.HandleWorkflowTask(tv1, inlineTask,
+		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+			return respondCompleteWorkflow(tv1, vbPinned), nil
+		})
+	s.NoError(err)
+
+	// Sanity: full history should have no WFT-Started event with the flag.
+	events := s.GetHistory(s.Namespace().String(), execution)
+	for _, e := range events {
+		if e.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED {
+			s.False(e.GetWorkflowTaskStartedEventAttributes().GetTargetWorkerDeploymentVersionChanged(),
+				"no WFT-Started event should have flag=true on stable routing (event %d)", e.GetEventId())
+		}
+	}
+}
+
 // TestRetryOfDeclinedCaN_SignalsOnNewTarget verifies that when a CaN'd run
 // ,which declined to upgrade, fails and is retried by the server, the retry
 // run inherits NotificationSuppressedTargetVersion from the original CaN

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -6544,7 +6544,7 @@ func (s *Versioning3Suite) TestInlinePath_StableRouting_NoSpuriousFlag() {
 
 	runID := s.startWorkflow(tv1, nil)
 	execution := tv1.WithRunID(runID).WorkflowExecution()
-	s.WaitForChannel(ctx, wftCompleted)
+	s.WaitForChannel(ctx, wftCompleted) //nolint:staticcheck // SA1019: matches pattern used throughout versioning_3_test.go
 	s.verifyWorkflowVersioning(s.Assertions, tv1, vbPinned, tv1.Deployment(), nil, nil)
 
 	// Trigger a regular WFT via a first signal.

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -6517,14 +6517,14 @@ func (s *Versioning3Suite) TestStalePartition_RevisionSuppressesTrampolining() {
 // when a buffered signal arrives during WFT processing).
 //
 // Flow:
-// 1. Start pinned workflow on v1; set v1 as current (stable routing).
-// 2. Trigger a regular WFT via a first signal.
-// 3. During that WFT's processing, send a second signal → gets buffered →
-//    server creates an inline WFT to deliver it.
-// 4. Poll the inline WFT and assert:
-//      - requestId == "request-from-RespondWorkflowTaskCompleted" (self-check
-//        that we actually exercised the inline path)
-//      - targetWorkerDeploymentVersionChanged == false (the bug being fixed)
+//  1. Start pinned workflow on v1; set v1 as current (stable routing).
+//  2. Trigger a regular WFT via a first signal.
+//  3. During that WFT's processing, send a second signal → gets buffered →
+//     server creates an inline WFT to deliver it.
+//  4. Poll the inline WFT and assert:
+//     - requestId == "request-from-RespondWorkflowTaskCompleted" (self-check
+//     that we actually exercised the inline path)
+//     - targetWorkerDeploymentVersionChanged == false (the bug being fixed)
 func (s *Versioning3Suite) TestInlinePath_StableRouting_NoSpuriousFlag() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()


### PR DESCRIPTION
## Summary
- Added revision number mechanics to strengthen checks while deciding between clearing/setting the LastNotifiedTargetVersion!

## Problem
- The inline WFT path in `RespondWorkflowTaskCompleted` (both `bypassTaskGeneration` at line 596 and speculative at line 722) calls `AddWorkflowTaskStartedEvent` with `targetDeploymentVersion=nil` and `targetRevisionNumber=0` because matching is never consulted on this path.
- In AddWorkflowTaskStartedEvent, case 3 compared only `buildId + deploymentName`, so a `nil` target fails that case and the default fires — also corrupting `LastNotifiedTargetVersion` with `{nil, 0}`. For update- or signal-driven PINNED workflows (where the updates and the signals were buffered on workflow task completion) this manifested as a continuous CaN loop on a stable deployment.
- A separate but related hazard: even on the normal poll path, a stale matching partition that happens to report `target == effective` by buildId would spuriously hit case 3 and clear legitimate notifications, silently defeating the trampolining-suppression mechanism from #9895.

## Test plan
- [x] `TestInlinePath_StableRouting_NoSpuriousFlag` — new integration test that exercises the user-reported scenario:
  - Sends a buffered signal during a regular WFT, completes with `ReturnNewWorkflowTask=true`.
  - Asserts the inline follow-up WFT's WFT-Started event has `requestId == "request-from-RespondWorkflowTaskCompleted"` (self-verification that the test actually exercises the inline code path).
  - Asserts `TargetWorkerDeploymentVersionChanged == false` on the inline WFT-Started event.
  - Confirmed to **fail** before the state machine change (test commit is on top of the fix commit) and **pass** after.
- [x] All 8 related existing tests still pass:
  - `TestStalePartition_RevisionSuppressesTrampolining` (from #9895)
  - `TestPinnedCaN_NoAUOnCaN_NoInfiniteLoop`
  - `TestOverride_SuppressesTargetVersionChangedSignal`
  - `TestAutoUpgrade_SuppressesTargetVersionChangedSignal`
  - `TestPinnedCaN_TargetChangesAgain_SignalsTrue`
  - `TestRemoveOverride_ClearsDeclinedState`
  - `TestRetryOfDeclinedCaN_SignalsOnNewTarget`
  - `TestPinnedCaN_RollbackResetsDeclined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workflow-task start/versioning decision logic in history service; mistakes could suppress legitimate upgrade notifications or alter trampolining behavior, but changes are localized and covered by a new integration test.
> 
> **Overview**
> Fixes a trampolining loop where inline workflow tasks created in `RespondWorkflowTaskCompleted` could incorrectly set `targetWorkerDeploymentVersionChanged` and corrupt `LastNotifiedTargetVersion` despite not consulting matching.
> 
> Inline/eager/synthetic `AddWorkflowTaskStartedEvent` call sites now pass `targetRevisionNumber=-1` as a sentinel, and the workflow-task state machine strengthens its decision logic by tracking the *highest seen* matching revision and refusing to clear/set notification state based on stale (older-revision) reports.
> 
> Adds `TestInlinePath_StableRouting_NoSpuriousFlag` to reproduce the buffered-signal inline-WFT scenario and assert the flag remains false on stable routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baf0f63467506f83a4673d89a813055b3c2b1f3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->