### PR TITLE
`testing/testcontext` package

### DIFF
--- a/common/testing/testcontext/context.go
+++ b/common/testing/testcontext/context.go
@@ -1,0 +1,179 @@
+package testcontext
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"go.temporal.io/server/common/debug"
+)
+
+const defaultTimeout = 90 * time.Second
+
+type contextStore struct {
+	sync.Mutex
+	byTest map[*testing.T]*contextState
+}
+
+// testContexts is process-global so repeated helpers in the same test share
+// one context and one cleanup.
+var testContexts = contextStore{
+	byTest: make(map[*testing.T]*contextState),
+}
+
+type config struct {
+	timeout    time.Duration
+	timeoutSet bool
+	decorators []contextDecorator
+}
+
+type contextDecorator struct {
+	key      any
+	decorate func(context.Context) context.Context
+}
+
+// New returns the test-scoped context for t. The context is canceled when the
+// test ends or when the configured test timeout expires.
+//
+// The first call creates the per-test context and fixes its timeout. Later calls
+// may add decorators, but an explicit different timeout fails instead of being
+// silently ignored.
+func New(t *testing.T, opts ...Option) context.Context {
+	t.Helper()
+
+	cfg := config{timeout: effectiveTimeout(0)}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	st := getContextState(t, cfg.timeout)
+	st.configure(t, cfg)
+	return st.context()
+}
+
+// Option configures the test-scoped context returned by [New].
+type Option func(*config)
+
+// WithTimeout sets a custom timeout for the test-scoped context.
+func WithTimeout(timeout time.Duration) Option {
+	return func(cfg *config) {
+		if timeout <= 0 {
+			return
+		}
+		cfg.timeout = effectiveTimeout(timeout)
+		cfg.timeoutSet = true
+	}
+}
+
+// WithContextDecorator applies decorator to the test-scoped context once for key.
+// Reusing the same key is a no-op.
+func WithContextDecorator[K comparable](key K, decorator func(context.Context) context.Context) Option {
+	return func(cfg *config) {
+		cfg.decorators = append(cfg.decorators, contextDecorator{
+			key:      key,
+			decorate: decorator,
+		})
+	}
+}
+
+type contextState struct {
+	mu         sync.Mutex
+	ctx        context.Context
+	cancel     context.CancelFunc
+	timeout    time.Duration
+	decorators map[any]struct{}
+}
+
+func getContextState(t *testing.T, timeout time.Duration) *contextState {
+	t.Helper()
+
+	testContexts.Lock()
+	defer testContexts.Unlock()
+
+	if st, ok := testContexts.byTest[t]; ok {
+		return st
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), timeout)
+	st := &contextState{
+		ctx:        ctx,
+		cancel:     cancel,
+		timeout:    timeout,
+		decorators: make(map[any]struct{}),
+	}
+	testContexts.byTest[t] = st
+
+	t.Cleanup(func() {
+		st.cancel()
+		testContexts.Lock()
+		delete(testContexts.byTest, t)
+		testContexts.Unlock()
+		if st.err() == context.DeadlineExceeded {
+			t.Errorf("Test exceeded timeout of %v", st.timeout)
+		}
+	})
+	return st
+}
+
+func (s *contextState) configure(t *testing.T, cfg config) {
+	t.Helper()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if cfg.timeoutSet && cfg.timeout != s.timeout {
+		t.Fatalf("testcontext: test context already exists with timeout %v; cannot change it to %v", s.timeout, cfg.timeout)
+	}
+
+	// Decorators may be registered by independent helpers, so apply each keyed
+	// decorator at most once while preserving call order.
+	for _, decorator := range cfg.decorators {
+		if decorator.key == nil {
+			t.Fatal("testcontext: context decorator key must not be nil")
+		}
+		if decorator.decorate == nil {
+			t.Fatal("testcontext: context decorator must not be nil")
+		}
+		if _, ok := s.decorators[decorator.key]; ok {
+			continue
+		}
+		s.ctx = decorator.decorate(s.ctx)
+		s.decorators[decorator.key] = struct{}{}
+	}
+}
+
+func (s *contextState) context() context.Context {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ctx
+}
+
+func (s *contextState) err() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ctx.Err()
+}
+
+func effectiveTimeout(customTimeout time.Duration) (timeout time.Duration) {
+	defer func() {
+		// Build flag TEMPORAL_DEBUG applies a timeout multiplier to all test timeouts.
+		timeout *= debug.TimeoutMultiplier
+	}()
+
+	// 1. Custom timeout (via WithTimeout option).
+	if customTimeout > 0 {
+		return customTimeout
+	}
+
+	// 2. TEMPORAL_TEST_TIMEOUT environment variable.
+	if envTimeout := os.Getenv("TEMPORAL_TEST_TIMEOUT"); envTimeout != "" {
+		if dur, err := time.ParseDuration(envTimeout); err == nil && dur > 0 {
+			return dur
+		}
+	}
+
+	// 3. Default 90 seconds.
+	return defaultTimeout
+}

--- a/common/testing/testcontext/context_test.go
+++ b/common/testing/testcontext/context_test.go
@@ -1,0 +1,126 @@
+package testcontext
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithTimeout(t *testing.T) {
+	t.Parallel()
+
+	ctx := New(t, WithTimeout(time.Second))
+	deadline, ok := ctx.Deadline()
+	require.True(t, ok)
+	require.WithinDuration(t, time.Now().Add(time.Second), deadline, 50*time.Millisecond)
+}
+
+func TestContextDecorators(t *testing.T) {
+	t.Parallel()
+
+	t.Run("applied once across calls", func(t *testing.T) {
+		t.Parallel()
+
+		type key struct{}
+
+		var calls atomic.Int32
+		decorator := func(ctx context.Context) context.Context {
+			calls.Add(1)
+			return context.WithValue(ctx, key{}, "decorated")
+		}
+
+		ctx := New(t, WithContextDecorator(key{}, decorator))
+		require.Equal(t, "decorated", ctx.Value(key{}))
+
+		ctx = New(t, WithContextDecorator(key{}, decorator))
+		require.Equal(t, "decorated", ctx.Value(key{}))
+		require.Equal(t, int32(1), calls.Load(), "decorator should only be applied once")
+	})
+
+	t.Run("applied once in single call", func(t *testing.T) {
+		t.Parallel()
+
+		type key struct{}
+
+		var calls atomic.Int32
+		decorator := func(ctx context.Context) context.Context {
+			calls.Add(1)
+			return context.WithValue(ctx, key{}, "decorated")
+		}
+
+		ctx := New(t,
+			WithContextDecorator(key{}, decorator),
+			WithContextDecorator(key{}, decorator),
+		)
+
+		require.Equal(t, "decorated", ctx.Value(key{}))
+		require.Equal(t, int32(1), calls.Load(), "decorator should only be applied once")
+	})
+
+	t.Run("multiple decorators", func(t *testing.T) {
+		t.Parallel()
+
+		type key1 struct{}
+		type key2 struct{}
+
+		ctx := New(t,
+			WithContextDecorator(key1{}, func(ctx context.Context) context.Context {
+				return context.WithValue(ctx, key1{}, "one")
+			}),
+			WithContextDecorator(key2{}, func(ctx context.Context) context.Context {
+				return context.WithValue(ctx, key2{}, "two")
+			}),
+		)
+
+		require.Equal(t, "one", ctx.Value(key1{}))
+		require.Equal(t, "two", ctx.Value(key2{}))
+	})
+
+	t.Run("later call decorates cached context", func(t *testing.T) {
+		t.Parallel()
+
+		type key struct{}
+
+		ctx := New(t)
+		require.Nil(t, ctx.Value(key{}))
+
+		ctx = New(t, WithContextDecorator(key{}, func(ctx context.Context) context.Context {
+			return context.WithValue(ctx, key{}, "decorated")
+		}))
+		require.Equal(t, "decorated", ctx.Value(key{}))
+	})
+}
+
+func TestCleanupCancelsContext(t *testing.T) {
+	t.Parallel()
+
+	var ctx context.Context
+	t.Run("subtest", func(t *testing.T) {
+		ctx = New(t)
+		require.NoError(t, ctx.Err())
+	})
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
+}
+
+func TestEnvTimeout(t *testing.T) {
+	t.Run("from env", func(t *testing.T) {
+		t.Setenv("TEMPORAL_TEST_TIMEOUT", "10s")
+
+		ctx := New(t)
+		deadline, ok := ctx.Deadline()
+		require.True(t, ok)
+		require.WithinDuration(t, time.Now().Add(10*time.Second), deadline, 50*time.Millisecond)
+	})
+
+	t.Run("custom overrides env", func(t *testing.T) {
+		t.Setenv("TEMPORAL_TEST_TIMEOUT", "10s")
+
+		ctx := New(t, WithTimeout(time.Second))
+		deadline, ok := ctx.Deadline()
+		require.True(t, ok)
+		require.WithinDuration(t, time.Now().Add(time.Second), deadline, 50*time.Millisecond)
+	})
+}

--- a/tests/testcore/context.go
+++ b/tests/testcore/context.go
@@ -2,14 +2,14 @@ package testcore
 
 import (
 	"context"
-	"os"
 	"testing"
-	"time"
 
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/rpc"
+	"go.temporal.io/server/common/testing/testcontext"
 )
+
+type versionHeadersContextKey struct{}
 
 // NewContext creates a context with default 90-second timeout and RPC headers.
 //
@@ -34,45 +34,13 @@ func NewContext(parent ...context.Context) context.Context {
 	return ctx
 }
 
-// calculateTimeout determines the appropriate timeout duration based on custom timeout,
-// environment variable, and default values.
-//
-// Priority order:
-//  1. Custom timeout (via WithTimeout option)
-//  2. TEMPORAL_TEST_TIMEOUT environment variable (in seconds)
-//  3. Default 90 seconds
-func calculateTimeout(customTimeout time.Duration) time.Duration {
-	if customTimeout > 0 {
-		return customTimeout * debug.TimeoutMultiplier
-	}
-
-	if envTimeout := os.Getenv("TEMPORAL_TEST_TIMEOUT"); envTimeout != "" {
-		if dur, err := time.ParseDuration(envTimeout); err == nil && dur > 0 {
-			return dur * debug.TimeoutMultiplier
-		}
-	}
-
-	return defaultTestTimeout
-}
-
 // setupTestTimeoutWithContext creates a context that will be canceled on timeout,
 // and reports the timeout error during cleanup. Returns a context that tests can
 // use to be interrupted when timeout occurs. The context includes RPC version headers.
-func setupTestTimeoutWithContext(t *testing.T, customTimeout time.Duration) context.Context {
+func setupTestTimeoutWithContext(t *testing.T) context.Context {
 	t.Helper()
-
-	timeout := calculateTimeout(customTimeout)
-	ctx, cancel := context.WithTimeout(t.Context(), timeout)
-	ctx = headers.SetVersions(ctx)
-
-	// Register cleanup to cancel context and check timeout.
-	// t.Cleanup() functions run in LIFO order, so this runs after test code.
-	t.Cleanup(func() {
-		cancel()
-		if ctx.Err() == context.DeadlineExceeded {
-			t.Errorf("Test exceeded timeout of %v", timeout)
-		}
-	})
-
-	return ctx
+	return testcontext.New(
+		t,
+		testcontext.WithContextDecorator(versionHeadersContextKey{}, headers.SetVersions),
+	)
 }

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -88,7 +88,6 @@ type TestOption func(*testOptions)
 type testOptions struct {
 	dedicatedCluster      bool
 	dynamicConfigSettings []dynamicConfigOverride
-	timeout               time.Duration
 }
 
 type dynamicConfigOverride struct {
@@ -122,15 +121,6 @@ func WithDynamicConfig(setting dynamicconfig.GenericSetting, value any) TestOpti
 			o.dedicatedCluster = true
 		}
 		o.dynamicConfigSettings = append(o.dynamicConfigSettings, dynamicConfigOverride{setting: setting, value: value})
-	}
-}
-
-// WithTimeout sets a custom timeout for the test. The test will fail if it runs longer
-// than this duration. The timeout is multiplied by debug.TimeoutMultiplier when debugging.
-// The TEMPORAL_TEST_TIMEOUT environment variable can also set the default timeout in seconds.
-func WithTimeout(duration time.Duration) TestOption {
-	return func(o *testOptions) {
-		o.timeout = duration
 	}
 }
 
@@ -187,7 +177,7 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 		taskPoller:         taskpoller.New(t, cluster.FrontendClient(), ns.String()),
 		t:                  t,
 		tv:                 testvars.New(t),
-		ctx:                setupTestTimeoutWithContext(t, options.timeout),
+		ctx:                setupTestTimeoutWithContext(t),
 		sdkWorkerTQ:        RandomizeStr("tq-" + t.Name()),
 		dedicatedGuard:     dedicatedGuard,
 	}


### PR DESCRIPTION
## What changed?

Adds a new package `testing/testcontext` for creating and managing test `context.Context`s.

No behavior change expected/intended.

## Why?

tl;dr encapsulating the test context behavior and decouple from TestEnv

Bigger picture: Right now the test context behavior is coupled to TestEnv; and legacy suites use `testcore.NewContext()`. That served us well so far, but it's suboptimal. A test context should be available outside of TestEnv and `tests/` package; ie unit and integration tests can also benefit it. 

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
