### PR TITLE
Sets identity on Operation Cancellation CanceledFailureInfo

### DIFF
--- a/chasm/lib/nexusoperation/operation_statemachine.go
+++ b/chasm/lib/nexusoperation/operation_statemachine.go
@@ -7,6 +7,7 @@ import (
 	failurepb "go.temporal.io/api/failure/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/nexusoperation/gen/nexusoperationpb/v1"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -242,10 +243,17 @@ var TransitionCanceled = chasm.NewTransition(
 		if event.CompleteTime != nil {
 			closeTime = *event.CompleteTime
 		}
+		failure := event.Failure
+		if cancellation, ok := o.Cancellation.TryGet(ctx); ok {
+			if canceledInfo := failure.GetCanceledFailureInfo(); canceledInfo != nil && canceledInfo.Identity == "" {
+				failure = common.CloneProto(event.Failure)
+				failure.GetCanceledFailureInfo().Identity = cancellation.GetIdentity()
+			}
+		}
 		o.emitOnCanceledMetrics(ctx, closeTime)
 		// Attempts only execute in SCHEDULED, so that status identifies attempt-originated cancels.
 		fromAttempt := o.GetStatus() == nexusoperationpb.OPERATION_STATUS_SCHEDULED
-		return o.resolveUnsuccessfully(ctx, event.Failure, closeTime, fromAttempt)
+		return o.resolveUnsuccessfully(ctx, failure, closeTime, fromAttempt)
 	},
 )
 

--- a/chasm/lib/nexusoperation/operation_statemachine_test.go
+++ b/chasm/lib/nexusoperation/operation_statemachine_test.go
@@ -546,6 +546,12 @@ func TestTransitionFailed(t *testing.T) {
 func TestTransitionCanceled(t *testing.T) {
 	customCompleteTime := defaultTime.Add(time.Minute)
 	failure := &failurepb.Failure{Message: "canceled"}
+	failureWithInfo := &failurepb.Failure{
+		Message: "canceled",
+		FailureInfo: &failurepb.Failure_CanceledFailureInfo{
+			CanceledFailureInfo: &failurepb.CanceledFailureInfo{},
+		},
+	}
 
 	for _, tc := range []struct {
 		name       string
@@ -586,6 +592,94 @@ func TestTransitionCanceled(t *testing.T) {
 			event:      EventCanceled{Failure: failure, CompleteTime: &customCompleteTime},
 			assert: func(t *testing.T, ctx *chasm.MockMutableContext, operation *Operation) {
 				require.Equal(t, customCompleteTime, operation.ClosedTime.AsTime())
+			},
+		},
+		{
+			name:       "adds cancellation identity",
+			fromStatus: nexusoperationpb.OPERATION_STATUS_STARTED,
+			event:      EventCanceled{Failure: failureWithInfo},
+			prepare: func(operation *Operation) {
+				cancellation := newCancellation(&nexusoperationpb.CancellationState{
+					Status:    nexusoperationpb.CANCELLATION_STATUS_SCHEDULED,
+					RequestId: "cancel-request-id",
+					Identity:  "test-identity",
+				})
+				cancellation.Operation = chasm.NewMockParentPtr[*Operation](operation)
+				operation.Cancellation = chasm.NewComponentField[*Cancellation](nil, cancellation)
+			},
+			assert: func(t *testing.T, ctx *chasm.MockMutableContext, operation *Operation) {
+				stored := operation.Outcome.Get(ctx).GetFailed().GetFailure()
+				require.Equal(t, "test-identity", stored.GetCanceledFailureInfo().GetIdentity())
+				require.Empty(t, failureWithInfo.GetCanceledFailureInfo().GetIdentity())
+				require.NotSame(t, failureWithInfo, stored)
+			},
+		},
+		{
+			name:       "stamps cancellation identity onto LastAttemptFailure",
+			fromStatus: nexusoperationpb.OPERATION_STATUS_SCHEDULED,
+			event: EventCanceled{
+				Failure: &failurepb.Failure{
+					Message: "canceled",
+					FailureInfo: &failurepb.Failure_CanceledFailureInfo{
+						CanceledFailureInfo: &failurepb.CanceledFailureInfo{},
+					},
+				},
+			},
+			prepare: func(operation *Operation) {
+				cancellation := newCancellation(&nexusoperationpb.CancellationState{
+					Status:    nexusoperationpb.CANCELLATION_STATUS_SCHEDULED,
+					RequestId: "cancel-request-id",
+					Identity:  "test-identity",
+				})
+				cancellation.Operation = chasm.NewMockParentPtr[*Operation](operation)
+				operation.Cancellation = chasm.NewComponentField[*Cancellation](nil, cancellation)
+			},
+			assert: func(t *testing.T, ctx *chasm.MockMutableContext, operation *Operation) {
+				require.Equal(t, "test-identity", operation.LastAttemptFailure.GetCanceledFailureInfo().GetIdentity())
+				require.Nil(t, operation.Outcome.Get(ctx).GetVariant())
+			},
+		},
+		{
+			name:       "no CanceledFailureInfo leaves cancellation identity unset",
+			fromStatus: nexusoperationpb.OPERATION_STATUS_STARTED,
+			event:      EventCanceled{Failure: failure},
+			prepare: func(operation *Operation) {
+				cancellation := newCancellation(&nexusoperationpb.CancellationState{
+					Status:    nexusoperationpb.CANCELLATION_STATUS_SCHEDULED,
+					RequestId: "cancel-request-id",
+					Identity:  "test-identity",
+				})
+				cancellation.Operation = chasm.NewMockParentPtr[*Operation](operation)
+				operation.Cancellation = chasm.NewComponentField[*Cancellation](nil, cancellation)
+			},
+			assert: func(t *testing.T, ctx *chasm.MockMutableContext, operation *Operation) {
+				stored := operation.Outcome.Get(ctx).GetFailed().GetFailure()
+				require.Nil(t, stored.GetCanceledFailureInfo())
+			},
+		},
+		{
+			name:       "preserves caller-provided identity on CanceledFailureInfo",
+			fromStatus: nexusoperationpb.OPERATION_STATUS_STARTED,
+			event: EventCanceled{
+				Failure: &failurepb.Failure{
+					Message: "canceled",
+					FailureInfo: &failurepb.Failure_CanceledFailureInfo{
+						CanceledFailureInfo: &failurepb.CanceledFailureInfo{Identity: "upstream-identity"},
+					},
+				},
+			},
+			prepare: func(operation *Operation) {
+				cancellation := newCancellation(&nexusoperationpb.CancellationState{
+					Status:    nexusoperationpb.CANCELLATION_STATUS_SCHEDULED,
+					RequestId: "cancel-request-id",
+					Identity:  "test-identity",
+				})
+				cancellation.Operation = chasm.NewMockParentPtr[*Operation](operation)
+				operation.Cancellation = chasm.NewComponentField[*Cancellation](nil, cancellation)
+			},
+			assert: func(t *testing.T, ctx *chasm.MockMutableContext, operation *Operation) {
+				stored := operation.Outcome.Get(ctx).GetFailed().GetFailure()
+				require.Equal(t, "upstream-identity", stored.GetCanceledFailureInfo().GetIdentity())
 			},
 		},
 	} {

--- a/chasm/lib/nexusoperation/operation_test.go
+++ b/chasm/lib/nexusoperation/operation_test.go
@@ -236,6 +236,30 @@ func TestHandleNexusCompletion(t *testing.T) {
 			require.Equal(t, nexusoperationpb.OPERATION_STATUS_CANCELED, op.GetStatus())
 		})
 
+		t.Run("AfterRequestCancel", func(t *testing.T) {
+			ctx := newCtx()
+			op := newStartedOp(t, ctx)
+			require.NoError(t, op.RequestCancel(ctx, &nexusoperationpb.CancellationState{
+				RequestId: "cancel-request-id",
+				Identity:  "test-identity",
+			}))
+			err := op.HandleNexusCompletion(ctx, &persistencespb.ChasmNexusCompletion{
+				RequestId: op.GetRequestId(),
+				Outcome: &persistencespb.ChasmNexusCompletion_Failure{
+					Failure: &failurepb.Failure{
+						Message: "canceled",
+						FailureInfo: &failurepb.Failure_CanceledFailureInfo{
+							CanceledFailureInfo: &failurepb.CanceledFailureInfo{},
+						},
+					},
+				},
+			})
+			require.NoError(t, err)
+			require.Equal(t, nexusoperationpb.OPERATION_STATUS_CANCELED, op.GetStatus())
+			stored := op.Outcome.Get(ctx).GetFailed().GetFailure()
+			require.Equal(t, "test-identity", stored.GetCanceledFailureInfo().GetIdentity())
+		})
+
 		t.Run("CompletionBeforeStart", func(t *testing.T) {
 			ctx := newCtx()
 			op := newScheduledTestOperation(t, ctx)


### PR DESCRIPTION
## What changed?
Attaches the identity on the cancellation to the canceled failure info.

## Why?
Useful information to have / parity with termination failures. 

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

