### PR TITLE
[Issue-10224] Fix replication ack propagation across mismatched shard count

### DIFF
--- a/service/history/api/replication/get_tasks.go
+++ b/service/history/api/replication/get_tasks.go
@@ -10,6 +10,7 @@ import (
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/persistence"
 	historyi "go.temporal.io/server/service/history/interfaces"
@@ -34,32 +35,39 @@ func GetTasks(
 			fmt.Sprintf("missing cluster info for cluster: %v", pollingCluster),
 		)
 	}
-	readerID := shard.ReplicationReaderIDFromClusterShardID(
-		clusterInfo.InitialFailoverVersion,
-		shardContext.GetShardID(),
-	)
-
 	if ackMessageID != persistence.EmptyQueueMessageID {
-		if err := shardContext.UpdateReplicationQueueReaderState(
-			readerID,
-			&persistencespb.QueueReaderState{
-				Scopes: []*persistencespb.QueueSliceScope{{
-					Range: &persistencespb.QueueSliceRange{
-						InclusiveMin: shard.ConvertToPersistenceTaskKey(
-							tasks.NewImmediateKey(ackMessageID + 1),
-						),
-						ExclusiveMax: shard.ConvertToPersistenceTaskKey(
-							tasks.NewImmediateKey(math.MaxInt64),
-						),
-					},
-					Predicate: &persistencespb.Predicate{
-						PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
-						Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
-					},
-				}},
-			},
-		); err != nil {
-			shardContext.GetLogger().Error("error updating replication level for shard", tag.Error(err), tag.OperationFailed)
+		currentClusterName := shardContext.GetClusterMetadata().GetCurrentClusterName()
+		currentClusterInfo := allClusterInfo[currentClusterName]
+
+		readerState := &persistencespb.QueueReaderState{
+			Scopes: []*persistencespb.QueueSliceScope{{
+				Range: &persistencespb.QueueSliceRange{
+					InclusiveMin: shard.ConvertToPersistenceTaskKey(
+						tasks.NewImmediateKey(ackMessageID + 1),
+					),
+					ExclusiveMax: shard.ConvertToPersistenceTaskKey(
+						tasks.NewImmediateKey(math.MaxInt64),
+					),
+				},
+				Predicate: &persistencespb.Predicate{
+					PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
+					Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
+				},
+			}},
+		}
+
+		for _, targetShardID := range common.MapShardID(
+			currentClusterInfo.ShardCount,
+			clusterInfo.ShardCount,
+			shardContext.GetShardID(),
+		) {
+			readerID := shard.ReplicationReaderIDFromClusterShardID(
+				clusterInfo.InitialFailoverVersion,
+				targetShardID,
+			)
+			if err := shardContext.UpdateReplicationQueueReaderState(readerID, readerState); err != nil {
+				shardContext.GetLogger().Error("error updating replication level for shard", tag.Error(err), tag.OperationFailed)
+			}
 		}
 		shardContext.UpdateRemoteClusterInfo(pollingCluster, ackMessageID, ackTimestamp)
 	}

--- a/service/history/api/replication/get_tasks_test.go
+++ b/service/history/api/replication/get_tasks_test.go
@@ -30,16 +30,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence"
+	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/replication"
 	"go.temporal.io/server/service/history/shard"
+	"go.uber.org/mock/gomock"
 )
 
 type (
@@ -48,7 +48,7 @@ type (
 		*require.Assertions
 
 		controller          *gomock.Controller
-		mockShard           *shard.MockContext
+		mockShard           *historyi.MockShardContext
 		mockClusterMetadata *cluster.MockMetadata
 		mockAckManager      *replication.MockAckManager
 	}
@@ -62,7 +62,7 @@ func (s *getTasksSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 	s.controller = gomock.NewController(s.T())
 
-	s.mockShard = shard.NewMockContext(s.controller)
+	s.mockShard = historyi.NewMockShardContext(s.controller)
 	s.mockClusterMetadata = cluster.NewMockMetadata(s.controller)
 	s.mockAckManager = replication.NewMockAckManager(s.controller)
 

--- a/service/history/api/replication/get_tasks_test.go
+++ b/service/history/api/replication/get_tasks_test.go
@@ -1,0 +1,301 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package replication
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	replicationspb "go.temporal.io/server/api/replication/v1"
+	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/service/history/replication"
+	"go.temporal.io/server/service/history/shard"
+)
+
+type (
+	getTasksSuite struct {
+		suite.Suite
+		*require.Assertions
+
+		controller          *gomock.Controller
+		mockShard           *shard.MockContext
+		mockClusterMetadata *cluster.MockMetadata
+		mockAckManager      *replication.MockAckManager
+	}
+)
+
+func TestGetTasksSuite(t *testing.T) {
+	suite.Run(t, new(getTasksSuite))
+}
+
+func (s *getTasksSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+	s.controller = gomock.NewController(s.T())
+
+	s.mockShard = shard.NewMockContext(s.controller)
+	s.mockClusterMetadata = cluster.NewMockMetadata(s.controller)
+	s.mockAckManager = replication.NewMockAckManager(s.controller)
+
+	s.mockShard.EXPECT().GetClusterMetadata().Return(s.mockClusterMetadata).AnyTimes()
+	s.mockShard.EXPECT().GetLogger().Return(log.NewNoopLogger()).AnyTimes()
+}
+
+// TestUnknownPollingCluster verifies that an error is returned immediately when
+// the polling cluster is not present in the cluster info map.
+func (s *getTasksSuite) TestUnknownPollingCluster() {
+	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(map[string]cluster.ClusterInformation{
+		cluster.TestCurrentClusterName: {
+			Enabled:                true,
+			InitialFailoverVersion: cluster.TestCurrentClusterInitialFailoverVersion,
+			ShardCount:             4,
+		},
+	})
+
+	_, err := GetTasks(
+		context.Background(),
+		s.mockShard,
+		s.mockAckManager,
+		"unknown-cluster",
+		persistence.EmptyQueueMessageID+1,
+		time.Now(),
+		0,
+	)
+
+	s.Error(err)
+}
+
+// TestAckMessageIDEmpty_SkipsReaderStateUpdate verifies that when ackMessageID is
+// EmptyQueueMessageID the reader-state update block is skipped entirely.
+func (s *getTasksSuite) TestAckMessageIDEmpty_SkipsReaderStateUpdate() {
+	clusterInfo := map[string]cluster.ClusterInformation{
+		cluster.TestCurrentClusterName: {
+			Enabled:                true,
+			InitialFailoverVersion: cluster.TestCurrentClusterInitialFailoverVersion,
+			ShardCount:             4,
+		},
+		cluster.TestAlternativeClusterName: {
+			Enabled:                true,
+			InitialFailoverVersion: cluster.TestAlternativeClusterInitialFailoverVersion,
+			ShardCount:             4,
+		},
+	}
+	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(clusterInfo)
+
+	expectedMessages := &replicationspb.ReplicationMessages{LastRetrievedMessageId: 42}
+	s.mockAckManager.EXPECT().
+		GetTasks(gomock.Any(), cluster.TestAlternativeClusterName, int64(0)).
+		Return(expectedMessages, nil)
+
+	msgs, err := GetTasks(
+		context.Background(),
+		s.mockShard,
+		s.mockAckManager,
+		cluster.TestAlternativeClusterName,
+		persistence.EmptyQueueMessageID,
+		time.Now(),
+		0,
+	)
+
+	s.NoError(err)
+	s.Equal(expectedMessages, msgs)
+	// UpdateReplicationQueueReaderState and UpdateRemoteClusterInfo must NOT be called —
+	// verified implicitly by gomock (no EXPECT set for them).
+}
+
+// TestEqualShardCounts_SingleReaderStateUpdate verifies that when source and target
+// shard counts are equal, MapShardID returns a single shard ID, resulting in exactly
+// one UpdateReplicationQueueReaderState call.
+func (s *getTasksSuite) TestEqualShardCounts_SingleReaderStateUpdate() {
+	const (
+		sourceShardID   = int32(3)
+		shardCount      = int32(4)
+		ackMsgID        = int64(100)
+		pollingFailover = cluster.TestAlternativeClusterInitialFailoverVersion
+	)
+
+	clusterInfo := map[string]cluster.ClusterInformation{
+		cluster.TestCurrentClusterName: {
+			Enabled:                true,
+			InitialFailoverVersion: cluster.TestCurrentClusterInitialFailoverVersion,
+			ShardCount:             shardCount,
+		},
+		cluster.TestAlternativeClusterName: {
+			Enabled:                true,
+			InitialFailoverVersion: pollingFailover,
+			ShardCount:             shardCount,
+		},
+	}
+
+	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(clusterInfo)
+	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName)
+	s.mockShard.EXPECT().GetShardID().Return(sourceShardID)
+
+	// MapShardID(4, 4, 3) → [3]; readerID computed for shard 3.
+	expectedReaderID := shard.ReplicationReaderIDFromClusterShardID(pollingFailover, sourceShardID)
+	s.mockShard.EXPECT().
+		UpdateReplicationQueueReaderState(expectedReaderID, gomock.Any()).
+		Return(nil).
+		Times(1)
+	s.mockShard.EXPECT().
+		UpdateRemoteClusterInfo(cluster.TestAlternativeClusterName, ackMsgID, gomock.Any()).
+		Times(1)
+
+	expectedMessages := &replicationspb.ReplicationMessages{}
+	s.mockAckManager.EXPECT().
+		GetTasks(gomock.Any(), cluster.TestAlternativeClusterName, int64(0)).
+		Return(expectedMessages, nil)
+
+	msgs, err := GetTasks(
+		context.Background(),
+		s.mockShard,
+		s.mockAckManager,
+		cluster.TestAlternativeClusterName,
+		ackMsgID,
+		time.Now(),
+		0,
+	)
+
+	s.NoError(err)
+	s.Equal(expectedMessages, msgs)
+}
+
+// TestScaleOut_DoubleShardCount_TwoReaderStateUpdates verifies the new behaviour:
+// when the polling cluster has 2× the shard count of the current cluster,
+// MapShardID returns two target shard IDs and UpdateReplicationQueueReaderState
+// is called once per target shard.
+func (s *getTasksSuite) TestScaleOut_DoubleShardCount_TwoReaderStateUpdates() {
+	const (
+		sourceShardID   = int32(3)
+		currentShards   = int32(4)
+		pollingShards   = int32(8) // 2× current → scale-out
+		ackMsgID        = int64(200)
+		pollingFailover = cluster.TestAlternativeClusterInitialFailoverVersion
+	)
+
+	clusterInfo := map[string]cluster.ClusterInformation{
+		cluster.TestCurrentClusterName: {
+			Enabled:                true,
+			InitialFailoverVersion: cluster.TestCurrentClusterInitialFailoverVersion,
+			ShardCount:             currentShards,
+		},
+		cluster.TestAlternativeClusterName: {
+			Enabled:                true,
+			InitialFailoverVersion: pollingFailover,
+			ShardCount:             pollingShards,
+		},
+	}
+
+	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(clusterInfo)
+	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName)
+	s.mockShard.EXPECT().GetShardID().Return(sourceShardID)
+
+	// MapShardID(4, 8, 3):
+	//   sourceShardID - 1 = 2
+	//   ratio = 8 / 4 = 2
+	//   targetIDs = [2 + 0*4 + 1, 2 + 1*4 + 1] = [3, 7]
+	readerID3 := shard.ReplicationReaderIDFromClusterShardID(pollingFailover, 3)
+	readerID7 := shard.ReplicationReaderIDFromClusterShardID(pollingFailover, 7)
+
+	s.mockShard.EXPECT().
+		UpdateReplicationQueueReaderState(readerID3, gomock.Any()).
+		Return(nil).
+		Times(1)
+	s.mockShard.EXPECT().
+		UpdateReplicationQueueReaderState(readerID7, gomock.Any()).
+		Return(nil).
+		Times(1)
+	s.mockShard.EXPECT().
+		UpdateRemoteClusterInfo(cluster.TestAlternativeClusterName, ackMsgID, gomock.Any()).
+		Times(1)
+
+	expectedMessages := &replicationspb.ReplicationMessages{}
+	s.mockAckManager.EXPECT().
+		GetTasks(gomock.Any(), cluster.TestAlternativeClusterName, int64(0)).
+		Return(expectedMessages, nil)
+
+	msgs, err := GetTasks(
+		context.Background(),
+		s.mockShard,
+		s.mockAckManager,
+		cluster.TestAlternativeClusterName,
+		ackMsgID,
+		time.Now(),
+		0,
+	)
+
+	s.NoError(err)
+	s.Equal(expectedMessages, msgs)
+}
+
+// TestAckManagerError_PropagatesError verifies that an error from
+// replicationAckMgr.GetTasks is surfaced to the caller unchanged.
+func (s *getTasksSuite) TestAckManagerError_PropagatesError() {
+	clusterInfo := map[string]cluster.ClusterInformation{
+		cluster.TestCurrentClusterName: {
+			Enabled:                true,
+			InitialFailoverVersion: cluster.TestCurrentClusterInitialFailoverVersion,
+			ShardCount:             4,
+		},
+		cluster.TestAlternativeClusterName: {
+			Enabled:                true,
+			InitialFailoverVersion: cluster.TestAlternativeClusterInitialFailoverVersion,
+			ShardCount:             4,
+		},
+	}
+
+	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(clusterInfo)
+	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName)
+	s.mockShard.EXPECT().GetShardID().Return(int32(1))
+	s.mockShard.EXPECT().
+		UpdateReplicationQueueReaderState(gomock.Any(), gomock.Any()).
+		Return(nil)
+	s.mockShard.EXPECT().
+		UpdateRemoteClusterInfo(gomock.Any(), gomock.Any(), gomock.Any())
+
+	ackMgrErr := errors.New("ack manager failure")
+	s.mockAckManager.EXPECT().
+		GetTasks(gomock.Any(), cluster.TestAlternativeClusterName, int64(0)).
+		Return(nil, ackMgrErr)
+
+	_, err := GetTasks(
+		context.Background(),
+		s.mockShard,
+		s.mockAckManager,
+		cluster.TestAlternativeClusterName,
+		int64(50),
+		time.Now(),
+		0,
+	)
+
+	s.ErrorIs(err, ackMgrErr)
+}

--- a/service/history/replication/task_processor_manager_test.go
+++ b/service/history/replication/task_processor_manager_test.go
@@ -1,6 +1,7 @@
 package replication
 
 import (
+	"errors"
 	"math"
 	"math/rand"
 	"testing"
@@ -184,5 +185,195 @@ func (s *taskProcessorManagerSuite) TestCleanupReplicationTask_Cleanup() {
 		},
 	).Return(nil).Times(1)
 	err := s.taskProcessorManager.cleanupReplicationTasks()
+	s.NoError(err)
+}
+
+// TestCleanupReplicationTask_NoQueueState verifies that when GetQueueState returns !ok,
+// minAckedTaskID is clamped to 0 for every reader and cleanup still proceeds up to that
+// conservative bound (ExclusiveMaxTaskKey = 1), updating minTxAckedTaskID to 0.
+func (s *taskProcessorManagerSuite) TestCleanupReplicationTask_NoQueueState() {
+	s.mockShard.EXPECT().GetQueueExclusiveHighReadWatermark(tasks.CategoryReplication).
+		Return(tasks.NewImmediateKey(100)).AnyTimes()
+	s.mockShard.EXPECT().GetQueueState(tasks.CategoryReplication).
+		Return(nil, false)
+
+	s.mockExecutionManager.EXPECT().RangeCompleteHistoryTasks(
+		gomock.Any(),
+		&persistence.RangeCompleteHistoryTasksRequest{
+			ShardID:             s.shardID,
+			TaskCategory:        tasks.CategoryReplication,
+			ExclusiveMaxTaskKey: tasks.NewImmediateKey(1),
+		},
+	).Return(nil)
+
+	err := s.taskProcessorManager.cleanupReplicationTasks()
+	s.NoError(err)
+	s.Equal(int64(0), s.taskProcessorManager.minTxAckedTaskID)
+}
+
+// TestCleanupReplicationTask_MissingReaderState verifies the !ok branch inside the
+// targetReaderIDs loop: when the queue state exists but contains no entry for a reader,
+// minAckedTaskID clamps to 0 and cleanup runs up to ExclusiveMaxTaskKey = 1.
+func (s *taskProcessorManagerSuite) TestCleanupReplicationTask_MissingReaderState() {
+	s.mockShard.EXPECT().GetQueueExclusiveHighReadWatermark(tasks.CategoryReplication).
+		Return(tasks.NewImmediateKey(100)).AnyTimes()
+	s.mockShard.EXPECT().GetQueueState(tasks.CategoryReplication).Return(
+		&persistencespb.QueueState{
+			ExclusiveReaderHighWatermark: nil,
+			ReaderStates:                 map[int64]*persistencespb.QueueReaderState{},
+		}, true,
+	)
+
+	s.mockExecutionManager.EXPECT().RangeCompleteHistoryTasks(
+		gomock.Any(),
+		&persistence.RangeCompleteHistoryTasksRequest{
+			ShardID:             s.shardID,
+			TaskCategory:        tasks.CategoryReplication,
+			ExclusiveMaxTaskKey: tasks.NewImmediateKey(1),
+		},
+	).Return(nil)
+
+	err := s.taskProcessorManager.cleanupReplicationTasks()
+	s.NoError(err)
+	s.Equal(int64(0), s.taskProcessorManager.minTxAckedTaskID)
+}
+
+// TestCleanupReplicationTask_PersistenceError verifies that an error from
+// RangeCompleteHistoryTasks is surfaced to the caller and that minTxAckedTaskID
+// is NOT updated when the persistence call fails.
+func (s *taskProcessorManagerSuite) TestCleanupReplicationTask_PersistenceError() {
+	const ackedTaskID = int64(12345)
+	s.mockShard.EXPECT().GetQueueExclusiveHighReadWatermark(tasks.CategoryReplication).
+		Return(tasks.NewImmediateKey(ackedTaskID + 2)).AnyTimes()
+	s.mockShard.EXPECT().GetQueueState(tasks.CategoryReplication).Return(&persistencespb.QueueState{
+		ExclusiveReaderHighWatermark: nil,
+		ReaderStates: map[int64]*persistencespb.QueueReaderState{
+			shard.ReplicationReaderIDFromClusterShardID(cluster.TestAlternativeClusterInitialFailoverVersion, common.MapShardID(
+				cluster.TestAllClusterInfo[cluster.TestCurrentClusterName].ShardCount,
+				cluster.TestAllClusterInfo[cluster.TestAlternativeClusterName].ShardCount,
+				s.shardID,
+			)[0]): {
+				Scopes: []*persistencespb.QueueSliceScope{{
+					Range: &persistencespb.QueueSliceRange{
+						InclusiveMin: shard.ConvertToPersistenceTaskKey(
+							tasks.NewImmediateKey(ackedTaskID + 1),
+						),
+						ExclusiveMax: shard.ConvertToPersistenceTaskKey(
+							tasks.NewImmediateKey(math.MaxInt64),
+						),
+					},
+					Predicate: &persistencespb.Predicate{
+						PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
+						Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
+					},
+				}},
+			},
+		},
+	}, true)
+
+	s.taskProcessorManager.minTxAckedTaskID = ackedTaskID - 1
+	persistenceErr := errors.New("persistence failure")
+	s.mockExecutionManager.EXPECT().RangeCompleteHistoryTasks(
+		gomock.Any(),
+		&persistence.RangeCompleteHistoryTasksRequest{
+			ShardID:             s.shardID,
+			TaskCategory:        tasks.CategoryReplication,
+			ExclusiveMaxTaskKey: tasks.NewImmediateKey(ackedTaskID + 1),
+		},
+	).Return(persistenceErr)
+
+	err := s.taskProcessorManager.cleanupReplicationTasks()
+	s.ErrorIs(err, persistenceErr)
+	s.Equal(ackedTaskID-1, s.taskProcessorManager.minTxAckedTaskID)
+}
+
+// TestCleanupReplicationTask_ScaleOut_TwoReaders verifies that when the alternative cluster
+// has 2× the shard count of the current cluster, targetReaderIDs produces two reader IDs
+// and both are consulted when computing the minimum acked task ID.
+func (s *taskProcessorManagerSuite) TestCleanupReplicationTask_ScaleOut_TwoReaders() {
+	const (
+		specificShardID = int32(3) // fixed so MapShardID output is deterministic
+		currentShards   = int32(4)
+		pollingShards   = int32(8) // 2× current → MapShardID(4, 8, 3) = [3, 7]
+		ackedTaskID     = int64(200)
+		pollingFailover = cluster.TestAlternativeClusterInitialFailoverVersion
+	)
+
+	customClusterInfo := map[string]cluster.ClusterInformation{
+		cluster.TestCurrentClusterName: {
+			Enabled:                true,
+			InitialFailoverVersion: cluster.TestCurrentClusterInitialFailoverVersion,
+			ShardCount:             currentShards,
+		},
+		cluster.TestAlternativeClusterName: {
+			Enabled:                true,
+			InitialFailoverVersion: pollingFailover,
+			ShardCount:             pollingShards,
+		},
+	}
+
+	// Use fresh mocks to avoid the AnyTimes() expectation from SetupTest shadowing
+	// the custom cluster info required for this test.
+	ctrl := gomock.NewController(s.T())
+	mockClusterMetadata := cluster.NewMockMetadata(ctrl)
+	mockShard := historyi.NewMockShardContext(ctrl)
+	mockExecutionManager := persistence.NewMockExecutionManager(ctrl)
+
+	mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
+	mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(customClusterInfo).AnyTimes()
+	mockShard.EXPECT().GetClusterMetadata().Return(mockClusterMetadata).AnyTimes()
+	mockShard.EXPECT().GetShardID().Return(specificShardID).AnyTimes()
+	mockShard.EXPECT().GetLogger().Return(log.NewNoopLogger()).AnyTimes()
+	mockShard.EXPECT().GetMetricsHandler().Return(metrics.NoopMetricsHandler).AnyTimes()
+	mockShard.EXPECT().GetExecutionManager().Return(mockExecutionManager).AnyTimes()
+
+	// MapShardID(4, 8, 3): (3-1) + i*4 + 1 → [3, 7]
+	readerID1 := shard.ReplicationReaderIDFromClusterShardID(pollingFailover, 3)
+	readerID2 := shard.ReplicationReaderIDFromClusterShardID(pollingFailover, 7)
+
+	readerState := &persistencespb.QueueReaderState{
+		Scopes: []*persistencespb.QueueSliceScope{{
+			Range: &persistencespb.QueueSliceRange{
+				InclusiveMin: shard.ConvertToPersistenceTaskKey(
+					tasks.NewImmediateKey(ackedTaskID + 1),
+				),
+				ExclusiveMax: shard.ConvertToPersistenceTaskKey(
+					tasks.NewImmediateKey(math.MaxInt64),
+				),
+			},
+			Predicate: &persistencespb.Predicate{
+				PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
+				Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
+			},
+		}},
+	}
+
+	mockShard.EXPECT().GetQueueExclusiveHighReadWatermark(tasks.CategoryReplication).
+		Return(tasks.NewImmediateKey(ackedTaskID + 2)).AnyTimes()
+	mockShard.EXPECT().GetQueueState(tasks.CategoryReplication).Return(&persistencespb.QueueState{
+		ExclusiveReaderHighWatermark: nil,
+		ReaderStates: map[int64]*persistencespb.QueueReaderState{
+			readerID1: readerState,
+			readerID2: readerState,
+		},
+	}, true)
+
+	mockExecutionManager.EXPECT().RangeCompleteHistoryTasks(
+		gomock.Any(),
+		&persistence.RangeCompleteHistoryTasksRequest{
+			ShardID:             specificShardID,
+			TaskCategory:        tasks.CategoryReplication,
+			ExclusiveMaxTaskKey: tasks.NewImmediateKey(ackedTaskID + 1),
+		},
+	).Return(nil).Times(1)
+
+	manager := &taskProcessorManagerImpl{
+		shard:            mockShard,
+		logger:           log.NewNoopLogger(),
+		metricsHandler:   metrics.NoopMetricsHandler,
+		minTxAckedTaskID: ackedTaskID - 1,
+	}
+
+	err := manager.cleanupReplicationTasks()
 	s.NoError(err)
 }


### PR DESCRIPTION
Open issue: https://github.com/temporalio/temporal/issues/10224

## What changed?
In pull-based replication mode, `GetTasks` now writes one `QueueReaderState` entry per mapped target shard ID instead of a single entry keyed by the source shard ID. When source shard count < target shard count (e.g. 8192 → 16384), `common.MapShardID` returns multiple target shard IDs per source shard, and `UpdateReplicationQueueReaderState` is now called once for each. The `common` package import is added to support this.

## Why?
The cleanup loop in `cleanupReplicationTasks` calls `targetReaderIDs`, which enumerates reader keys via `MapShardID(sourceCount, targetCount, sourceShardID)`. With a 1:2 shard ratio this produces two expected keys per source shard (e.g. `[19, 8211]` for shard 19). The old code wrote only one key (keyed by the source shard ID), so cleanup always found the second key missing, collapsed `minAckedTaskID` to 0, and issued a no-op range delete (`task_id < 1`). Replication rows (type=4) in the `executions` table accumulated indefinitely without any error being logged. Handover was unaffected because it reads a separate map (`remoteClusterInfos`) that `UpdateRemoteClusterInfo` already bulk-fills across all mapped target shards. This fix makes the writer structurally consistent with what the cleanup loop expects for any shard ratio.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

## Potential risks
- Shard count mismatch only: when source and target shard counts are equal, `MapShardID` returns a single-element slice (the source shard ID), so this is a no-op change for that case and there is no regression risk.
- Multiple persistence writes per poll: with a 1:2 ratio, each standby poll now issues 2 `UpdateReplicationQueueReaderState` calls instead of 1. These are in-memory shard state updates (flushed on the next shard persistence write), not synchronous DB round-trips per call, so the overhead is negligible.
- Pull mode is deprecated in favor of streaming (`history.enableReplicationStream=true`, default since v1.24.0). This fix only matters for clusters still on pull mode. No risk to the streaming path.