### PR TITLE
cli: explain when a global flag is passed after the subcommand

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -79,9 +79,10 @@ func buildCLI() *cli.App {
 
 	app.Commands = []*cli.Command{
 		{
-			Name:      "validate-dynamic-config",
-			Usage:     "Validate a dynamic config file[s] with known keys and types",
-			ArgsUsage: "<file> ...",
+			Name:         "validate-dynamic-config",
+			Usage:        "Validate a dynamic config file[s] with known keys and types",
+			ArgsUsage:    "<file> ...",
+			OnUsageError: helpfulSubcommandFlagError,
 			Action: func(c *cli.Context) error {
 				total := 0
 				for _, fileName := range c.Args().Slice() {
@@ -106,9 +107,10 @@ func buildCLI() *cli.App {
 			},
 		},
 		{
-			Name:      "render-config",
-			Usage:     "Render server config template",
-			ArgsUsage: " ",
+			Name:         "render-config",
+			Usage:        "Render server config template",
+			ArgsUsage:    " ",
+			OnUsageError: helpfulSubcommandFlagError,
 			Action: func(c *cli.Context) error {
 				cfg, err := config.Load(
 					config.WithEnv(c.String("env")),
@@ -123,9 +125,10 @@ func buildCLI() *cli.App {
 			},
 		},
 		{
-			Name:      "start",
-			Usage:     "Start Temporal server",
-			ArgsUsage: " ",
+			Name:         "start",
+			Usage:        "Start Temporal server",
+			ArgsUsage:    " ",
+			OnUsageError: helpfulSubcommandFlagError,
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:    "services",
@@ -245,4 +248,74 @@ func buildCLI() *cli.App {
 		},
 	}
 	return app
+}
+
+// helpfulSubcommandFlagError rewrites the urfave/cli "flag provided but not
+// defined" error to a more actionable message when the unknown flag turns out
+// to be a known global flag passed in the wrong position (after a subcommand
+// instead of before it).
+//
+// The global flags `--root`, `--config`, `--env`, `--zone` and `--config-file`
+// must be passed before the subcommand (for example, `temporal-server --env
+// docker start`, not `temporal-server start --env docker`). Without this
+// rewrite the bare "flag provided but not defined: -e" message is hard to
+// debug — see https://github.com/temporalio/temporal/issues/6226.
+func helpfulSubcommandFlagError(cCtx *cli.Context, err error, isSubcommand bool) error {
+	if err == nil {
+		return nil
+	}
+	out := err
+	if rewritten, ok := rewriteAsGlobalFlagPlacementError(cCtx, err); ok {
+		out = rewritten
+	}
+	// Mirror urfave/cli's default "Incorrect Usage: ..." behavior, which is
+	// otherwise suppressed when OnUsageError is set. The production `main`
+	// discards the returned error, so without this print the user would see
+	// nothing.
+	if cCtx != nil && cCtx.App != nil && cCtx.App.Writer != nil {
+		_, _ = fmt.Fprintf(cCtx.App.Writer, "Incorrect Usage: %s\n", out.Error())
+	}
+	return out
+}
+
+// rewriteAsGlobalFlagPlacementError returns a friendlier error and true when
+// the urfave/cli "flag provided but not defined: -X" error refers to a flag
+// that is actually defined at the global (app) level. Returns the input error
+// and false in all other cases.
+func rewriteAsGlobalFlagPlacementError(cCtx *cli.Context, err error) (error, bool) {
+	const prefix = "flag provided but not defined: -"
+	msg := err.Error()
+	if !strings.HasPrefix(msg, prefix) {
+		return err, false
+	}
+	name := strings.TrimLeft(strings.TrimPrefix(msg, prefix), "-")
+	if cCtx == nil || cCtx.App == nil {
+		return err, false
+	}
+	var canonical string
+	for _, fl := range cCtx.App.Flags {
+		for _, n := range fl.Names() {
+			if n == name {
+				canonical = fl.Names()[0]
+				break
+			}
+		}
+		if canonical != "" {
+			break
+		}
+	}
+	if canonical == "" {
+		return err, false
+	}
+	subcommand := "the subcommand"
+	example := "<subcommand>"
+	if cCtx.Command != nil && cCtx.Command.Name != "" {
+		subcommand = "`" + cCtx.Command.Name + "`"
+		example = cCtx.Command.Name
+	}
+	return fmt.Errorf(
+		"--%s is a global flag and must be passed before %s "+
+			"(for example, `%s --%s <value> %s ...`)",
+		canonical, subcommand, cCtx.App.Name, canonical, example,
+	), true
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+// TestStart_GlobalFlagAfterSubcommand_Helpful asserts that when a user passes
+// a global flag (such as `-c`, `--config`, `-e`, `--env`, `-r`, `--root`,
+// `--zone`, `--config-file`) AFTER the `start` subcommand, the resulting
+// error message points them at the correct placement instead of the bare
+// "flag provided but not defined" string from urfave/cli.
+//
+// See https://github.com/temporalio/temporal/issues/6226.
+func TestStart_GlobalFlagAfterSubcommand_Helpful(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{name: "short config", args: []string{"temporal", "start", "-c", "/etc/temporal"}},
+		{name: "long config", args: []string{"temporal", "start", "--config", "/etc/temporal"}},
+		{name: "short env", args: []string{"temporal", "start", "-e", "docker"}},
+		{name: "long env", args: []string{"temporal", "start", "--env", "docker"}},
+		{name: "short root", args: []string{"temporal", "start", "-r", "/etc"}},
+		{name: "long root", args: []string{"temporal", "start", "--root", "/etc"}},
+		{name: "zone alias", args: []string{"temporal", "start", "--az", "us-east-1a"}},
+		{name: "long zone", args: []string{"temporal", "start", "--zone", "us-east-1a"}},
+		{name: "config-file", args: []string{"temporal", "start", "--config-file", "/etc/temporal/cfg.yaml"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := buildCLI()
+			app.Writer = &bytes.Buffer{}
+			app.ErrWriter = &bytes.Buffer{}
+
+			err := app.Run(tc.args)
+
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "is a global flag",
+				"expected a helpful message naming the global flag, got %q", err.Error())
+			require.Contains(t, err.Error(), "before `start`",
+				"expected guidance about placement before the start subcommand, got %q", err.Error())
+		})
+	}
+}
+
+// TestStart_UnknownFlag_PreservesOriginalError asserts that unrelated unknown
+// flags still return the original urfave/cli error (we only rewrite when the
+// flag actually maps to a known global flag).
+func TestStart_UnknownFlag_PreservesOriginalError(t *testing.T) {
+	app := buildCLI()
+	app.Writer = &bytes.Buffer{}
+	app.ErrWriter = &bytes.Buffer{}
+
+	err := app.Run([]string{"temporal", "start", "--not-a-real-flag", "x"})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "flag provided but not defined")
+	require.NotContains(t, err.Error(), "is a global flag")
+}
+
+// TestRewriteAsGlobalFlagPlacementError exercises the unit-level helper for
+// the cases we care about: non-matching errors pass through, and an error
+// that names a flag not defined globally also passes through.
+func TestRewriteAsGlobalFlagPlacementError(t *testing.T) {
+	app := cli.NewApp()
+	app.Name = "temporal"
+	app.Flags = []cli.Flag{
+		&cli.StringFlag{Name: "config", Aliases: []string{"c"}},
+	}
+	cCtx := cli.NewContext(app, nil, nil)
+
+	t.Run("non-usage error passes through", func(t *testing.T) {
+		orig := errors.New("some other error")
+		got, rewritten := rewriteAsGlobalFlagPlacementError(cCtx, orig)
+		require.False(t, rewritten)
+		require.Same(t, orig, got)
+	})
+
+	t.Run("usage error for unknown flag passes through", func(t *testing.T) {
+		orig := errors.New("flag provided but not defined: -bogus")
+		got, rewritten := rewriteAsGlobalFlagPlacementError(cCtx, orig)
+		require.False(t, rewritten)
+		require.Same(t, orig, got)
+	})
+
+	t.Run("usage error for known global flag is rewritten", func(t *testing.T) {
+		orig := errors.New("flag provided but not defined: -c")
+		got, rewritten := rewriteAsGlobalFlagPlacementError(cCtx, orig)
+		require.True(t, rewritten)
+		require.NotSame(t, orig, got)
+		require.Contains(t, got.Error(), "--config is a global flag")
+	})
+}
+
+// TestHelpfulSubcommandFlagError_NilInputs exercises the nil-safety of the
+// top-level OnUsageError callback.
+func TestHelpfulSubcommandFlagError_NilInputs(t *testing.T) {
+	app := cli.NewApp()
+	cCtx := cli.NewContext(app, nil, nil)
+	require.NoError(t, helpfulSubcommandFlagError(cCtx, nil, true))
+}


### PR DESCRIPTION
Fixes #6226.

## What

`temporal-server start -c /etc/temporal` fails with:

```
Incorrect Usage: flag provided but not defined: -c
```

`-c` is a global flag. It has to come before the subcommand (`temporal-server -c /etc/temporal start`). The bare urfave/cli error gives the user no hint about that.

This PR adds an `OnUsageError` callback on each subcommand (`start`, `validate-dynamic-config`, `render-config`) that rewrites the "flag provided but not defined" message when the unknown flag matches one of the program's global flags. Output for the original repro becomes:

```
--config is a global flag and must be passed before `start` (for example,
`temporal --config <value> start ...`).
```

Unrelated unknown-flag typos still surface the original urfave/cli error untouched.

## Why

Discussion in #6226 already converged on "the help text should make this clearer." This is the smallest mechanical fix on that path. No semantic change to flag behavior.

## Test

`cmd/server/main_test.go` adds sub-tests under `-race` for the rewrite for every global flag's short and long form (`-c`/`--config`, `-e`/`--env`, `-r`/`--root`, `--az`/`--zone`, `--config-file`), pass-through for unknown flags, and nil-safety of the helpers.

The tests fail without the change and pass with it.
