### PR TITLE
config: sqlite + cluster address env overrides for embedded template

### DIFF
--- a/common/config/config_template_embedded.yaml
+++ b/common/config/config_template_embedded.yaml
@@ -147,8 +147,8 @@ persistence:
         {{- else if eq $db "sqlite" }}
         default:
             sql:
-                pluginName: "sqlite"
-                databaseName: "{{ default "temporal.db" (env "DBNAME") }}"
+                pluginName: "{{ $db }}"
+                databaseName: "{{ default "temporal" (env "DBNAME") }}"
                 connectAddr: "localhost"
                 connectProtocol: "tcp"
                 connectAttributes:
@@ -161,8 +161,8 @@ persistence:
                 maxIdleConns: {{ default "1" (env "SQL_MAX_IDLE_CONNS") }}
         visibility:
             sql:
-                pluginName: "sqlite"
-                databaseName: "{{ default "temporal_visibility.db" (env "VISIBILITY_DBNAME") }}"
+                pluginName: "{{ $db }}"
+                databaseName: "{{ default "temporal_visibility" (env "VISIBILITY_DBNAME") }}"
                 connectAddr: "localhost"
                 connectProtocol: "tcp"
                 connectAttributes:

--- a/common/config/config_template_embedded.yaml
+++ b/common/config/config_template_embedded.yaml
@@ -144,6 +144,35 @@ persistence:
                     keyFile: {{ default "" (env "SQL_CERT_KEY") }}
                     enableHostVerification: {{ default "false" (env "SQL_HOST_VERIFICATION") }}
                     serverName: {{ default "" (env "SQL_HOST_NAME") }}
+        {{- else if eq $db "sqlite" }}
+        default:
+            sql:
+                pluginName: "sqlite"
+                databaseName: "{{ default "temporal.db" (env "DBNAME") }}"
+                connectAddr: "localhost"
+                connectProtocol: "tcp"
+                connectAttributes:
+                    cache: "{{ default "private" (env "SQLITE_CACHE") }}"
+                    setup: "{{ default "true" (env "SQLITE_SETUP") }}"
+                    journal_mode: "{{ default "wal" (env "SQLITE_JOURNAL_MODE") }}"
+                    synchronous: "{{ default "2" (env "SQLITE_SYNCHRONOUS") }}"
+                    busy_timeout: "{{ default "10000" (env "SQLITE_BUSY_TIMEOUT") }}"
+                maxConns: {{ default "1" (env "SQL_MAX_CONNS") }}
+                maxIdleConns: {{ default "1" (env "SQL_MAX_IDLE_CONNS") }}
+        visibility:
+            sql:
+                pluginName: "sqlite"
+                databaseName: "{{ default "temporal_visibility.db" (env "VISIBILITY_DBNAME") }}"
+                connectAddr: "localhost"
+                connectProtocol: "tcp"
+                connectAttributes:
+                    cache: "{{ default "private" (env "SQLITE_CACHE") }}"
+                    setup: "{{ default "true" (env "SQLITE_SETUP") }}"
+                    journal_mode: "{{ default "wal" (env "SQLITE_JOURNAL_MODE") }}"
+                    synchronous: "{{ default "2" (env "SQLITE_SYNCHRONOUS") }}"
+                    busy_timeout: "{{ default "10000" (env "SQLITE_BUSY_TIMEOUT") }}"
+                maxConns: {{ default "1" (env "SQL_VIS_MAX_CONNS") }}
+                maxIdleConns: {{ default "1" (env "SQL_VIS_MAX_IDLE_CONNS") }}
         {{- end }}
         {{- if eq $es "true" }}
         es-visibility:
@@ -317,8 +346,8 @@ clusterMetadata:
             enabled: true
             initialFailoverVersion: 1
             rpcName: "frontend"
-            rpcAddress: {{ (print "127.0.0.1:" $temporalGrpcPort) }}
-            httpAddress: {{ (print "127.0.0.1:" $temporalHTTPPort) }}
+            rpcAddress: {{ default (print "127.0.0.1:" $temporalGrpcPort) (env "CLUSTER_RPC_ADDRESS") }}
+            httpAddress: {{ default (print "127.0.0.1:" $temporalHTTPPort) (env "CLUSTER_HTTP_ADDRESS") }}
 
 dcRedirectionPolicy:
     policy: "noop"

--- a/common/config/config_template_embedded.yaml
+++ b/common/config/config_template_embedded.yaml
@@ -152,6 +152,7 @@ persistence:
                 connectAddr: "localhost"
                 connectProtocol: "tcp"
                 connectAttributes:
+                    mode: "{{ default "rwc" (env "SQLITE_MODE") }}"
                     cache: "{{ default "private" (env "SQLITE_CACHE") }}"
                     setup: "{{ default "true" (env "SQLITE_SETUP") }}"
                     journal_mode: "{{ default "wal" (env "SQLITE_JOURNAL_MODE") }}"
@@ -166,6 +167,7 @@ persistence:
                 connectAddr: "localhost"
                 connectProtocol: "tcp"
                 connectAttributes:
+                    mode: "{{ default "rwc" (env "SQLITE_MODE") }}"
                     cache: "{{ default "private" (env "SQLITE_CACHE") }}"
                     setup: "{{ default "true" (env "SQLITE_SETUP") }}"
                     journal_mode: "{{ default "wal" (env "SQLITE_JOURNAL_MODE") }}"

--- a/common/config/config_template_embedded.yaml
+++ b/common/config/config_template_embedded.yaml
@@ -303,6 +303,7 @@ global:
 {{- $temporalGrpcPort := default "7233" (env "FRONTEND_GRPC_PORT") }}
 {{- $temporalHTTPPort := default "7243" (env "FRONTEND_HTTP_PORT") }}
 {{- $temporalInternalHTTPPort := default "7246" (env "INTERNAL_FRONTEND_HTTP_PORT") }}
+{{- $temporalClusterAddress := default (default "127.0.0.1" (env "BIND_ON_IP")) (env "TEMPORAL_BROADCAST_ADDRESS") }}
 services:
     frontend:
         rpc:
@@ -348,8 +349,8 @@ clusterMetadata:
             enabled: true
             initialFailoverVersion: 1
             rpcName: "frontend"
-            rpcAddress: {{ default (print "127.0.0.1:" $temporalGrpcPort) (env "CLUSTER_RPC_ADDRESS") }}
-            httpAddress: {{ default (print "127.0.0.1:" $temporalHTTPPort) (env "CLUSTER_HTTP_ADDRESS") }}
+            rpcAddress: {{ default (print $temporalClusterAddress ":" $temporalGrpcPort) (env "CLUSTER_RPC_ADDRESS") }}
+            httpAddress: {{ default (print $temporalClusterAddress ":" $temporalHTTPPort) (env "CLUSTER_HTTP_ADDRESS") }}
 
 dcRedirectionPolicy:
     policy: "noop"


### PR DESCRIPTION
## What

Extend `common/config/config_template_embedded.yaml` with

(1) SQLite option
(2) option to override `rpcAddress` and/or `httpAddress`

## Why

https://github.com/temporalio/omes needs to be able to start a Temporal server with sqlite and custom addresses.

See https://github.com/temporalio/omes/pull/348