### PR TITLE
fix: add missing metrics and normalize logs for schedule migration

### DIFF
--- a/chasm/lib/scheduler/scheduler_migrate_task.go
+++ b/chasm/lib/scheduler/scheduler_migrate_task.go
@@ -19,6 +19,7 @@ import (
 	"go.temporal.io/server/chasm/lib/scheduler/migration"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/primitives"
@@ -82,11 +83,20 @@ func (h *SchedulerMigrateToWorkflowTaskHandler) Execute(
 		metrics.StringTag(metrics.ScheduleMigrationDirectionTag, metrics.ScheduleMigrationDirectionToWorkflow),
 	)
 	metricsHandler.Counter(metrics.ScheduleMigrationStarted.Name()).Record(1)
+
+	// logger is initialized after ReadComponent, once namespace/scheduleID are known.
+	var logger log.Logger
 	defer func() {
 		if retErr != nil {
 			metricsHandler.Counter(metrics.ScheduleMigrationFailed.Name()).Record(1)
+			if logger != nil {
+				logger.Error("schedule migration to workflow failed", tag.Error(retErr))
+			}
 		} else {
 			metricsHandler.Counter(metrics.ScheduleMigrationCompleted.Name()).Record(1)
+			if logger != nil {
+				logger.Info("schedule migration to workflow succeeded")
+			}
 		}
 	}()
 
@@ -155,6 +165,13 @@ func (h *SchedulerMigrateToWorkflowTaskHandler) Execute(
 	if err != nil {
 		return fmt.Errorf("failed to read scheduler state: %w", err)
 	}
+
+	logger = log.With(
+		h.baseLogger,
+		tag.WorkflowNamespace(result.namespace),
+		tag.ScheduleID(result.scheduleID),
+	)
+	logger.Info("schedule migration to workflow started")
 
 	// Serialize the V1 workflow input.
 	inputPayloads, err := sdk.PreferProtoDataConverter.ToPayloads(result.args)

--- a/chasm/lib/scheduler/scheduler_migrate_task.go
+++ b/chasm/lib/scheduler/scheduler_migrate_task.go
@@ -77,7 +77,19 @@ func (h *SchedulerMigrateToWorkflowTaskHandler) Execute(
 	schedulerRef chasm.ComponentRef,
 	_ chasm.TaskAttributes,
 	_ *schedulerpb.SchedulerMigrateToWorkflowTask,
-) error {
+) (retErr error) {
+	metricsHandler := h.metricsHandler.WithTags(
+		metrics.StringTag(metrics.ScheduleMigrationDirectionTag, metrics.ScheduleMigrationDirectionToWorkflow),
+	)
+	metricsHandler.Counter(metrics.ScheduleMigrationStarted.Name()).Record(1)
+	defer func() {
+		if retErr != nil {
+			metricsHandler.Counter(metrics.ScheduleMigrationFailed.Name()).Record(1)
+		} else {
+			metricsHandler.Counter(metrics.ScheduleMigrationCompleted.Name()).Record(1)
+		}
+	}()
+
 	// Read state and convert to V1 args inside the ReadComponent callback,
 	// where we have access to the CHASM context for consistent time.
 	type readResult struct {

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -328,7 +328,7 @@ func (s *scheduler) run() error {
 		if s.State.PendingMigration {
 			err := s.executeMigration()
 			if err == nil {
-				s.logger.Info("Migration to CHASM succeeded, closing V1 workflow",
+				s.logger.Info("schedule migration to CHASM succeeded",
 					"namespace", s.State.Namespace,
 					"schedule-id", s.State.ScheduleId,
 				)
@@ -337,7 +337,7 @@ func (s *scheduler) run() error {
 				}).Counter(metrics.ScheduleMigrationCompleted.Name()).Inc(1)
 				return nil
 			}
-			s.logger.Error("Migration to CHASM failed, continuing V1 workflow",
+			s.logger.Error("schedule migration to CHASM failed",
 				"namespace", s.State.Namespace,
 				"schedule-id", s.State.ScheduleId,
 				"error", err,
@@ -1007,7 +1007,7 @@ func (s *scheduler) handleMigrateSignal(ch workflow.ReceiveChannel, _ bool) {
 }
 
 func (s *scheduler) executeMigration() error {
-	s.logger.Info("Starting migration to CHASM",
+	s.logger.Info("schedule migration to CHASM started",
 		"namespace", s.State.Namespace,
 		"schedule-id", s.State.ScheduleId,
 	)


### PR DESCRIPTION
## Summary
- Add missing `schedule_migration_started`, `schedule_migration_completed`, and `schedule_migration_failed` counter metrics tagged with `to_workflow` direction to `SchedulerMigrateToWorkflowTaskHandler` -- the constant was defined but never used
- Normalize all migration log messages to `"schedule migration to {workflow,CHASM} {started,succeeded,failed}"` across both directions for easier Loki filtering

## Test plan
- [x] `TestScheduleMigrationV2ToV1` passes
- [x] `TestScheduleMigrationV2ToV1Idempotent` passes
- [x] `TestScheduleMigrationV2ToV1RoutingFallback` passes