### PR TITLE
Isolate V1 cleanup context in DeleteSchedule

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -48,6 +48,7 @@ import (
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/collection"
+	"go.temporal.io/server/common/contextutil"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/enums"
 	"go.temporal.io/server/common/failure"
@@ -4960,7 +4961,11 @@ func (wh *WorkflowHandler) DeleteSchedule(ctx context.Context, request *workflow
 	if chasmEnabled {
 		_, chasmErr = wh.deleteScheduleCHASM(ctx, request)
 	}
-	_, v1Err := wh.deleteScheduleWorkflow(ctx, request)
+	// Isolate V1's terminate call in a fresh metadata context so its trailers
+	// (from the sentinel/dummy workflow it terminates) don't overwrite the
+	// schedule's metadata set by the CHASM path.
+	v1Ctx := contextutil.WithMetadataContext(ctx)
+	_, v1Err := wh.deleteScheduleWorkflow(v1Ctx, request)
 
 	// At least one side actually deleted → success.
 	if (chasmEnabled && chasmErr == nil) || v1Err == nil {


### PR DESCRIPTION
## What changed?
In `WorkflowHandler.DeleteSchedule`, wrap the V1 `deleteScheduleWorkflow` call in a fresh metadata context via `contextutil.WithMetadataContext`.   

## Why?
PR #10197 made V1's `TerminateWorkflowExecution` always run alongside the CHASM delete where both a workflow backed and CHASM backed schedule exists. Both calls share the same request ctx, so V1's response trailers, populated from the sentinel workflow (`temporal-sys-dummy-workflow` / `temporal-sys-per-ns-tq`), were overwriting the schedule's metadata (`ScheduleTargetWF`) set by the CHASM call. Downstream metering then saw the per-namespace worker task queue and dropped the tags, emitting `delete_schedule` with `_unknown_` workflow type/task queue.

Basically the timeline is:                                                                                                               
1. CHASM call returns → trailer interceptor: holder["workflow-type"] = "ScheduleTargetWF" (Correct)
2. V1 call returns → trailer interceptor: holder["workflow-type"] = "temporal-sys-dummy-workflow" (Broke)   

Wrapping V1 in a fresh metadata holder lets V1's trailer interceptor write into a disposable holder, leaving the schedule's metadata on the outer ctx intact for metering to read.                                                           
                                            

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

