### PR TITLE
Fix sync match outcome when RecordTaskStarted fails

### DIFF
--- a/service/matching/hooks/task_lifecycle_hooks.go
+++ b/service/matching/hooks/task_lifecycle_hooks.go
@@ -24,6 +24,11 @@ const (
 	SyncMatchOutcomeSuccess
 	// A poller was available but rate limiting blocked the match.
 	SyncMatchOutcomeRateLimited
+	// A poller was available and the task was matched, but the dispatch failed internally
+	// (e.g. RecordTaskStarted rejected by history due to busy workflow). This is not a poller
+	// shortage — worker capacity was sufficient, but the task could not be started for reasons
+	// unrelated to scaling.
+	SyncMatchOutcomeStartFailed
 )
 
 type (

--- a/service/matching/matcher_data.go
+++ b/service/matching/matcher_data.go
@@ -43,7 +43,7 @@ const (
 	syncMatchNoPoller
 	// A poller was available but rate limiting blocked the match.
 	syncMatchRateLimited
-	// The task was matched to a poller but RecordTaskStarted failed (e.g. busy workflow).
+	// A poller was available but RecordTaskStarted failed (e.g. busy workflow), so the task was not dispatched.
 	syncMatchStartFailed
 )
 

--- a/service/matching/matcher_data.go
+++ b/service/matching/matcher_data.go
@@ -43,6 +43,8 @@ const (
 	syncMatchNoPoller
 	// A poller was available but rate limiting blocked the match.
 	syncMatchRateLimited
+	// The task was matched to a poller but RecordTaskStarted failed (e.g. busy workflow).
+	syncMatchStartFailed
 )
 
 type taskForwarderType int32

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -699,7 +699,10 @@ func (c *physicalTaskQueueManagerImpl) TrySyncMatch(ctx context.Context, task *i
 
 	matched, err := c.oldMatcher.Offer(childCtx, task)
 	if matched {
-		return syncMatchSuccess, err
+		if err != nil {
+			return syncMatchStartFailed, err
+		}
+		return syncMatchSuccess, nil
 	}
 	return syncMatchNoPoller, err
 }

--- a/service/matching/pri_matcher.go
+++ b/service/matching/pri_matcher.go
@@ -410,9 +410,10 @@ func (tm *priTaskMatcher) Offer(ctx context.Context, task *internalTask) (syncMa
 		if res.startErr == nil && !task.isForwarded() {
 			tm.emitDispatchLatency(task, false)
 		}
-		// TODO: when startErr is non-nil (e.g. busy workflow), the task was not actually
-		// dispatched. This should return a failure outcome instead of syncMatchSuccess.
-		return syncMatchSuccess, res.startErr
+		if res.startErr != nil {
+			return syncMatchStartFailed, res.startErr
+		}
+		return syncMatchSuccess, nil
 	}
 
 	// Fast path if we have a waiting poller (or forwarder).

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -443,7 +443,7 @@ reredirectTask:
 	if isActive {
 		outcome, err = syncMatchQueue.TrySyncMatch(ctx, syncMatchTask)
 		syncMatched = outcome == syncMatchSuccess
-		if syncMatched && !pm.shouldBacklogSyncMatchTaskOnError(err) {
+		if syncMatched {
 			// Only fire hooks for non-forwarded tasks. Forwarded tasks already had hooks fired
 			// on the child partition that originally received the task.
 			if params.forwardInfo == nil {
@@ -494,6 +494,8 @@ func syncMatchOutcomeToHook(outcome syncMatchOutcome) hooks.SyncMatchOutcome {
 		return hooks.SyncMatchOutcomeNoPoller
 	case syncMatchRateLimited:
 		return hooks.SyncMatchOutcomeRateLimited
+	case syncMatchStartFailed:
+		return hooks.SyncMatchOutcomeStartFailed
 	}
 	return hooks.SyncMatchOutcomeUnspecified
 }
@@ -507,16 +509,6 @@ func (pm *taskQueuePartitionManagerImpl) processTaskAddHooks(ctx context.Context
 			SyncMatchOutcome:  hookOutcome,
 		})
 	}
-}
-
-func (pm *taskQueuePartitionManagerImpl) shouldBacklogSyncMatchTaskOnError(err error) bool {
-	var resourceExhaustedErr *serviceerror.ResourceExhausted
-	if err != nil && errors.As(err, &resourceExhaustedErr) {
-		if resourceExhaustedErr.Cause == enumspb.RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW {
-			return true
-		}
-	}
-	return false
 }
 
 func (pm *taskQueuePartitionManagerImpl) isActiveInCluster() (bool, error) {


### PR DESCRIPTION
## What

Return `syncMatchStartFailed` instead of `syncMatchSuccess` when a task is matched to a poller but `RecordTaskStarted` is rejected by history (e.g. `BUSY_WORKFLOW`). Expose this as `SyncMatchOutcomeStartFailed` in the hooks API.

## Why

When `RecordTaskStarted` fails (e.g. busy workflow), the system misreports the outcome.

**Before:**
- `Offer()` returns `(syncMatchSuccess, startErr)`
- `shouldBacklogSyncMatchTaskOnError` catches `BUSY_WORKFLOW` and falls through to spool
- Hooks fire with `syncMatchSuccess` — operator thinks the task was dispatched
- `SyncMatchLatencyPerTaskQueue` is recorded — incorrect, task wasn't dispatched

**After:**
- `Offer()` returns `(syncMatchStartFailed, startErr)`
- Task naturally falls through to spool — `shouldBacklogSyncMatchTaskOnError` removed
- Hooks fire with `SyncMatchOutcomeStartFailed` — operator knows dispatch failed internally, not a poller shortage
- `SyncMatchLatencyPerTaskQueue` is not recorded — correct

**Why this is safe:** The only consumer of `syncMatched` upstream is the matching handler, which uses it solely for the `SyncMatchLatencyPerTaskQueue` metric. History ignores the field.

## How did you test it?

Existing unit tests (MatcherDataSuite, PartitionManagerTestSuite, PhysicalTaskQueueManagerSuite) all pass. The `BUSY_WORKFLOW` path is rare in practice (workflow-level task concurrency race) and the behavioral change is conservative: we go from "report as success + separately guard against it" to "report as start-failed and let it spool naturally."

🤖 Generated with [Claude Code](https://claude.com/claude-code)