### PR TITLE
feat(matching): opt-in age-based priority boost for queued tasks

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1445,6 +1445,21 @@ second per poller by one physical queue manager`,
 		5,
 		`Number of simple priority levels (requires new matcher)`,
 	)
+	MatchingPriorityAgingTickInterval = NewTaskQueueDurationSetting(
+		"matching.priorityAgingTickInterval",
+		0,
+		`Interval at which the matcher walks queued tasks and re-applies age-based priority boosts. Set to 0 to disable aging entirely. (requires new matcher)`,
+	)
+	MatchingPriorityAgingThreshold = NewTaskQueueDurationSetting(
+		"matching.priorityAgingThreshold",
+		30*time.Second,
+		`Wait time at which a queued task earns one unit of effective-priority boost (lower effectivePriority = preferred for dispatch). Each additional threshold-wait grants one more unit, capped by priorityAgingMaxBoost.`,
+	)
+	MatchingPriorityAgingMaxBoost = NewTaskQueueIntSetting(
+		"matching.priorityAgingMaxBoost",
+		9,
+		`Maximum age-based priority boost a single task may accumulate, in units of effective priority. Hard-capped at effectivePriorityFactor-1 (=9) inside the matcher so an aged task at priority N+1 never leap-frogs a fresh task at priority N.`,
+	)
 	MatchingBacklogTaskForwardTimeout = NewTaskQueueDurationSetting(
 		"matching.backlogTaskForwardTimeout",
 		60*time.Second,

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -91,6 +91,9 @@ type (
 		MembershipUnloadDelay                    dynamicconfig.DurationPropertyFn
 		TaskQueueInfoByBuildIdTTL                dynamicconfig.DurationPropertyFnWithTaskQueueFilter
 		PriorityLevels                           dynamicconfig.IntPropertyFnWithTaskQueueFilter
+		PriorityAgingTickInterval                dynamicconfig.DurationPropertyFnWithTaskQueueFilter
+		PriorityAgingThreshold                   dynamicconfig.DurationPropertyFnWithTaskQueueFilter
+		PriorityAgingMaxBoost                    dynamicconfig.IntPropertyFnWithTaskQueueFilter
 
 		RateLimiterRefreshInterval    time.Duration
 		FairnessKeyRateLimitCacheSize dynamicconfig.IntPropertyFnWithTaskQueueFilter
@@ -176,6 +179,9 @@ type (
 		TaskDeleteInterval             func() time.Duration
 		PriorityLevels                 priorityKey
 		DefaultPriorityKey             priorityKey
+		PriorityAgingTickInterval      func() time.Duration
+		PriorityAgingThreshold         func() time.Duration
+		PriorityAgingMaxBoost          func() int
 
 		GetUserDataLongPollTimeout dynamicconfig.DurationPropertyFn
 		GetUserDataMinWaitTime     time.Duration
@@ -338,6 +344,9 @@ func NewConfig(
 		MembershipUnloadDelay:                    dynamicconfig.MatchingMembershipUnloadDelay.Get(dc),
 		TaskQueueInfoByBuildIdTTL:                dynamicconfig.TaskQueueInfoByBuildIdTTL.Get(dc),
 		PriorityLevels:                           dynamicconfig.MatchingPriorityLevels.Get(dc),
+		PriorityAgingTickInterval:                dynamicconfig.MatchingPriorityAgingTickInterval.Get(dc),
+		PriorityAgingThreshold:                   dynamicconfig.MatchingPriorityAgingThreshold.Get(dc),
+		PriorityAgingMaxBoost:                    dynamicconfig.MatchingPriorityAgingMaxBoost.Get(dc),
 		RateLimiterRefreshInterval:               time.Minute,
 		FairnessKeyRateLimitCacheSize:            dynamicconfig.MatchingFairnessKeyRateLimitCacheSize.Get(dc),
 		MaxFairnessKeyWeightOverrides:            dynamicconfig.MatchingMaxFairnessKeyWeightOverrides.Get(dc),
@@ -453,6 +462,15 @@ func newTaskQueueConfig(tq *tqid.TaskQueue, config *Config, ns namespace.Name) *
 		},
 		PriorityLevels:             priorityLevels,
 		DefaultPriorityKey:         defaultPriorityKey,
+		PriorityAgingTickInterval: func() time.Duration {
+			return config.PriorityAgingTickInterval(ns.String(), taskQueueName, taskType)
+		},
+		PriorityAgingThreshold: func() time.Duration {
+			return config.PriorityAgingThreshold(ns.String(), taskQueueName, taskType)
+		},
+		PriorityAgingMaxBoost: func() int {
+			return config.PriorityAgingMaxBoost(ns.String(), taskQueueName, taskType)
+		},
 		GetUserDataLongPollTimeout: config.GetUserDataLongPollTimeout,
 		GetUserDataMinWaitTime:     1 * time.Second,
 		GetUserDataReturnBudget:    returnEmptyTaskTimeBudget,

--- a/service/matching/matcher_data.go
+++ b/service/matching/matcher_data.go
@@ -229,6 +229,72 @@ func (t *taskPQ) ForEachTask(pred func(*internalTask) bool, post func(*internalT
 	heap.Init(t)
 }
 
+// applyAging walks tasks in the heap and lowers their effectivePriority
+// (= raises dispatch priority) as a function of how long each task has been
+// waiting. Older tasks within the same operator-set priority level dispatch
+// ahead of newer tasks at that level, without ever crossing into a higher
+// operator-set level.
+//
+// Aging is bounded to (effectivePriorityFactor - 1) units of boost so an
+// aged task at priority N+1 can never leap-frog a fresh task at priority N.
+//
+// Idempotent under stable `now`: the boost is recomputed from a per-task
+// `basePriority` snapshot rather than accumulated, so calling applyAging
+// repeatedly with the same `now` produces the same heap state. This also
+// means lowering the threshold at runtime correctly de-boosts tasks that
+// were previously boosted past their new target.
+//
+// Returns true if any task's effectivePriority changed (caller may want to
+// emit a metric).
+func (t *taskPQ) applyAging(
+	now time.Time,
+	threshold time.Duration,
+	maxBoost priorityKey,
+) (changed bool) {
+	if threshold <= 0 || maxBoost <= 0 || len(t.heap) == 0 {
+		return false
+	}
+	// Cap so aging stays strictly within a single operator-set priority level.
+	if maxBoost >= effectivePriorityFactor {
+		maxBoost = effectivePriorityFactor - 1
+	}
+	for _, task := range t.heap {
+		if task.isPollForwarder() {
+			continue
+		}
+		// Snapshot the pre-aging priority on first encounter.
+		if task.basePriority == 0 {
+			task.basePriority = task.effectivePriority
+		}
+		ct := task.getCreateTime()
+		if ct == nil {
+			continue
+		}
+		createdAt := ct.AsTime()
+		if createdAt.IsZero() {
+			continue
+		}
+		age := now.Sub(createdAt)
+		var boost priorityKey
+		if age >= threshold {
+			units := priorityKey(age / threshold)
+			if units > maxBoost {
+				units = maxBoost
+			}
+			boost = units
+		}
+		want := task.basePriority - boost
+		if want != task.effectivePriority {
+			task.effectivePriority = want
+			changed = true
+		}
+	}
+	if changed {
+		heap.Init(t)
+	}
+	return changed
+}
+
 type matcherData struct {
 	config           *taskQueueConfig
 	logger           log.Logger
@@ -502,6 +568,24 @@ func (d *matcherData) allowForwarding() (allowForwarding bool) {
 	delayToForwardingAllowed := d.config.MaxWaitForPollerBeforeFwd() - time.Since(d.lastPoller)
 	d.reconsiderForwardTimer.set(d.timeSource, d.rematchAfterTimer, delayToForwardingAllowed)
 	return delayToForwardingAllowed <= 0
+}
+
+// ApplyAging acquires the matcher lock, re-applies age-based priority boosts
+// to queued tasks, and wakes any newly-eligible matches if priorities changed.
+//
+// Safe to call at any cadence; returns true if any task's effectivePriority
+// was modified. Caller is responsible for the tick rhythm.
+func (d *matcherData) ApplyAging(threshold time.Duration, maxBoost int) bool {
+	if threshold <= 0 || maxBoost <= 0 {
+		return false
+	}
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	changed := d.tasks.applyAging(d.timeSource.Now(), threshold, priorityKey(maxBoost))
+	if changed {
+		d.findAndWakeMatches()
+	}
+	return changed
 }
 
 // call with lock held

--- a/service/matching/matcher_data_test.go
+++ b/service/matching/matcher_data_test.go
@@ -1119,3 +1119,83 @@ func gosched(n int) {
 		runtime.Gosched()
 	}
 }
+
+// TestPriorityAging_OlderTaskDispatchedFirst exercises the new aging hook:
+// two tasks at the same operator-set priority, but one has been queued
+// longer. Without aging, they tie on effectivePriority and the older one
+// only wins by fair-level tiebreak (taskId order). After aging, the older
+// one's effectivePriority is boosted down so it wins decisively.
+func (s *MatcherDataSuite) TestPriorityAging_OlderTaskDispatchedFirst() {
+	pri := &commonpb.Priority{PriorityKey: 3}
+
+	// Both tasks at priority 3 → effectivePriority = effectivePriorityFactor * 3 = 30.
+	// Older task: createTime = now - 5min.
+	// Newer task: createTime = now (just enqueued).
+	older := s.newBacklogTaskWithPriority(1, 5*time.Minute, nil, pri)
+	newer := s.newBacklogTaskWithPriority(2, 0, nil, pri)
+
+	s.md.EnqueueTaskNoWait(older)
+	s.md.EnqueueTaskNoWait(newer)
+
+	// Sanity: both have the same effectivePriority before aging.
+	s.md.lock.Lock()
+	s.Require().Equal(priorityKey(30), older.effectivePriority)
+	s.Require().Equal(priorityKey(30), newer.effectivePriority)
+	s.md.lock.Unlock()
+
+	// Apply aging with threshold=1min, maxBoost=5. Older task has been
+	// waiting 5min so it earns the full 5-unit boost; newer task has been
+	// waiting 0s so no boost.
+	changed := s.md.ApplyAging(time.Minute, 5)
+	s.True(changed, "aging should have lowered the older task's effectivePriority")
+
+	s.md.lock.Lock()
+	s.Equal(priorityKey(25), older.effectivePriority, "older task should be boosted by 5 units")
+	s.Equal(priorityKey(30), newer.effectivePriority, "newer task should be untouched")
+	s.Equal(priorityKey(30), older.basePriority, "basePriority preserves the pre-aging value")
+	s.Equal(priorityKey(30), newer.basePriority)
+	s.md.lock.Unlock()
+
+	// Idempotency: a second call with the same `now` shouldn't change anything.
+	changed = s.md.ApplyAging(time.Minute, 5)
+	s.False(changed, "applying aging again with the same time should be a no-op")
+
+	// Lowering maxBoost should de-boost: applyAging recomputes from basePriority.
+	changed = s.md.ApplyAging(time.Minute, 2)
+	s.True(changed)
+	s.md.lock.Lock()
+	s.Equal(priorityKey(28), older.effectivePriority, "older task should be re-derived as base(30) - cap(2)")
+	s.md.lock.Unlock()
+}
+
+// TestPriorityAging_NeverCrossesLevels verifies the per-priority-level
+// guard: even with a configured maxBoost larger than effectivePriorityFactor,
+// an aged task at priority N+1 can never leap-frog a fresh task at priority N.
+func (s *MatcherDataSuite) TestPriorityAging_NeverCrossesLevels() {
+	lowPriTask := s.newBacklogTaskWithPriority(
+		1, 24*time.Hour, nil, &commonpb.Priority{PriorityKey: 4})
+	s.md.EnqueueTaskNoWait(lowPriTask)
+
+	// 24h waiting + threshold=1s + maxBoost=1000 would naively let aging
+	// blow through the 10-unit gap between priority levels. Verify it
+	// gets clamped to effectivePriorityFactor-1 = 9.
+	s.md.ApplyAging(time.Second, 1000)
+	s.md.lock.Lock()
+	s.GreaterOrEqual(int(lowPriTask.effectivePriority), 31,
+		"aged priority-4 task should not enter priority-3's range")
+	s.md.lock.Unlock()
+}
+
+// TestPriorityAging_Disabled_NoOp confirms that aging with threshold=0 or
+// maxBoost=0 does nothing, matching the dynamic-config "disabled" path.
+func (s *MatcherDataSuite) TestPriorityAging_Disabled_NoOp() {
+	pri := &commonpb.Priority{PriorityKey: 3}
+	old := s.newBacklogTaskWithPriority(1, time.Hour, nil, pri)
+	s.md.EnqueueTaskNoWait(old)
+
+	s.False(s.md.ApplyAging(0, 5), "threshold=0 must be a no-op")
+	s.False(s.md.ApplyAging(time.Minute, 0), "maxBoost=0 must be a no-op")
+	s.md.lock.Lock()
+	s.Equal(priorityKey(30), old.effectivePriority, "task untouched when aging is disabled")
+	s.md.lock.Unlock()
+}

--- a/service/matching/pri_matcher.go
+++ b/service/matching/pri_matcher.go
@@ -125,6 +125,10 @@ func (tm *priTaskMatcher) Start() {
 	retrier := backoff.NewRetrier(policy, clock.NewRealTimeSource())
 	lim := quotas.NewDefaultOutgoingRateLimiter(tm.config.ForwarderMaxRatePerSecond)
 
+	// Priority aging runs on every priTaskMatcher instance that has a local
+	// backlog — root, sticky, or non-root. Cheap no-op when tick interval is 0.
+	go tm.priorityAgingLoop()
+
 	if tm.fwdr == nil {
 		// Root/sticky doesn't forward. But it does need something to validate tasks.
 		go tm.validateTasksOnRoot(retrier)
@@ -160,6 +164,37 @@ func (tm *priTaskMatcher) Stop() {
 	// backlog tasks that were redirected from another versioned queue (or the default). To
 	// handle those, the caller of Stop should also call ReprocessRedirectedTasksAfterStop
 	// when applicable.
+}
+
+// priorityAgingLoop periodically re-applies age-based priority boosts to
+// queued tasks so a task that has been waiting longer gets dispatched
+// ahead of newer tasks at the same operator-set priority level.
+//
+// Polls the dynamic config on each tick so an operator can change the
+// cadence / threshold / max boost (or disable entirely by setting
+// PriorityAgingTickInterval to 0) without bouncing the matcher.
+func (tm *priTaskMatcher) priorityAgingLoop() {
+	// Initial interval check; treat 0 as "disabled" but keep polling at a
+	// long cadence so a later config flip can turn aging on.
+	const disabledPollInterval = time.Minute
+	for {
+		interval := tm.config.PriorityAgingTickInterval()
+		if interval <= 0 {
+			interval = disabledPollInterval
+		}
+		select {
+		case <-tm.tqCtx.Done():
+			return
+		case <-time.After(interval):
+		}
+		if tm.config.PriorityAgingTickInterval() <= 0 {
+			continue
+		}
+		tm.data.ApplyAging(
+			tm.config.PriorityAgingThreshold(),
+			tm.config.PriorityAgingMaxBoost(),
+		)
+	}
 }
 
 // TODO(pri): access to retrier is not synchronized

--- a/service/matching/task.go
+++ b/service/matching/task.go
@@ -83,10 +83,15 @@ type (
 		// effectivePriority is initialized from an explicit task priority if present, or the
 		// default for the task queue. It can also be the special pollForwarderPriority (higher
 		// than normal priorities) to indicate the poll forwarder. In some other cases (e.g.
-		// migration) it may be adjusted from the explicit task priority.
+		// migration, priority aging) it may be adjusted from the explicit task priority.
 		// The scale of effectivePriority is 10× the normal scale to allow inserting forwards
 		// in between priority levels.
 		effectivePriority priorityKey
+		// basePriority is the effectivePriority at heap-insert time, before any aging
+		// adjustments. Aging recomputes effectivePriority = basePriority - boost(age)
+		// idempotently each tick. Zero means "not yet snapshotted" — applyAging will
+		// snapshot the current effectivePriority on first encounter.
+		basePriority      priorityKey
 		pollForwarderType pollForwarderType
 	}
 


### PR DESCRIPTION
## Motivation

When many workflows submit activities to the same rate-limited task queue in close succession (the typical agentic-AI pattern: each workflow does an LLM call, then dispatches several tool activities in parallel), Temporal's task queue is FIFO at the **activity** level — not at the workflow level. A workflow whose tool activities happen to land in dispatch slots 2 and 6 of a 6-slot window finishes ~3–4× later than a workflow whose tools landed in slots 1 and 3, purely by scheduling luck. The variance across concurrent workflows is high.

Static `priority_key` doesn't solve this: it's set once at submission and immutable, and the global rank of an in-flight workflow isn't known up-front because new workflows enter the system continuously. What's needed is **aging** — older queued tasks progressively earn higher dispatch priority while they wait.

Issue #2517 covered task-level FIFO and was resolved via single-partition queues. This PR addresses the orthogonal problem of *workflow-age bias* on the dispatch side.

## What this does

Opt-in (default-off) aging hook in the priority matcher. When `matching.priorityAgingTickInterval` > 0, a background goroutine on each `priTaskMatcher` periodically walks the local backlog and re-applies an age-derived boost to `effectivePriority`:

```
boost(age) = min(age / threshold, maxBoost, effectivePriorityFactor - 1)
effectivePriority = basePriority - boost
```

Three properties worth calling out:

- **Bounded within an operator priority level.** Boost is hard-capped at `effectivePriorityFactor - 1` (= 9), so an aged task at priority N+1 can never leap-frog a fresh task at priority N. Aging is a tiebreaker within a level, not a level-crosser.
- **Idempotent.** Each tick recomputes from a per-task `basePriority` snapshot rather than mutating cumulatively. Calling `applyAging` repeatedly with the same `now` produces the same heap state. Lowering `maxBoost` or `threshold` mid-run correctly de-boosts tasks that were boosted past the new target.
- **Heap-safe.** Comparisons in `taskPQ.Less` remain stable between dispatches because `effectivePriority` only changes inside `applyAging` under the matcher lock, which then calls `heap.Init` once before releasing. Time doesn't leak into `Less`.

## Files touched

| File | Change |
|---|---|
| `common/dynamicconfig/constants.go` | 3 new task-queue-level dynamic config keys |
| `service/matching/config.go` | Plumb through `taskQueueConfig` |
| `service/matching/task.go` | Add `basePriority` field to `internalTask` |
| `service/matching/matcher_data.go` | `taskPQ.applyAging` + `matcherData.ApplyAging` wrapper |
| `service/matching/pri_matcher.go` | `priorityAgingLoop` goroutine started in `Start()` |
| `service/matching/matcher_data_test.go` | 3 unit tests |

## Open questions for review (the reason this is a draft)

1. **Is the per-task-queue cadence right?** I started the aging loop on every `priTaskMatcher` instance. Alternatives: per-namespace, per-partition-set. Latter would amortize work across partitions for a queue but loses local-state knowledge.

2. **Should aging be activity-create-time-based (what's here) or workflow-start-time-based?** The latter is the more correct model for "older workflow's activities win" but would require propagating `WorkflowStartTime` into `AllocatedTaskInfo`. Happy to do that as a follow-up; wanted to land the matcher mechanics first.

3. **Should aging apply to forwarded tasks?** Currently it does — the boost is computed from `task.getCreateTime()`, which falls back to `forwardInfo.GetCreateTime()` for forwarded tasks. That preserves origin-time across hops. Worth confirming this is the desired semantics.

4. **Interaction with fairness.** Aging changes `effectivePriority` (the first ordering key in `taskPQ.Less`); fairness's `fairLevel` is the secondary key. So aging will move tasks within a fairness key's pass ordering. Confirming this composition is what you want for "old + fair-share" use cases — happy to adjust if you want aging to live below fairness in the ordering.

5. **TODO(pri) at `taskPQ.Less:135-143`.** I noticed the existing time-dependent-ordering placeholder. Should aging eventually subsume that, or stay separate?

## Tests

- `TestPriorityAging_OlderTaskDispatchedFirst` — two tasks at same priority, different ages; verify boost applied, idempotency, de-boost.
- `TestPriorityAging_NeverCrossesLevels` — naive `maxBoost=1000` config still can't leap-frog a higher priority level.
- `TestPriorityAging_Disabled_NoOp` — `threshold=0` or `maxBoost=0` is a no-op.

`go build ./...` and `go vet ./service/matching/...` clean.

Full `service/matching/` test suite passes my new tests in isolation; the pre-existing flake on `TestMatchingEngine_*_Suite` reproduces on main without my changes, so I believe it's unrelated.

## Default behavior

`matching.priorityAgingTickInterval = 0` → fully disabled. No behavior change for any existing deployment until an operator opts in.

---

Marking as **draft** so the team can weigh in on the open questions above before I expand testing / wire up the workflow-start-time variant. Happy to iterate.