### PR TITLE
Add workflow-age priority boost to matching (RFC / draft)

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1445,6 +1445,22 @@ second per poller by one physical queue manager`,
 		5,
 		`Number of simple priority levels (requires new matcher)`,
 	)
+	MatchingWorkflowAgingEnabled = NewTaskQueueBoolSetting(
+		"matching.workflowAgingEnabled",
+		false,
+		`If true, boost effectivePriority for tasks whose workflow has been observed longer.
+The boost is bounded below effectivePriorityFactor so it cannot cross a configured priority level.`,
+	)
+	MatchingWorkflowAgingFullBoostAfter = NewTaskQueueDurationSetting(
+		"matching.workflowAgingFullBoostAfter",
+		30*time.Minute,
+		`Workflow age at which the workflow-age boost saturates. The boost grows linearly with age up to this value.`,
+	)
+	MatchingWorkflowAgingTrackerSize = NewTaskQueueIntSetting(
+		"matching.workflowAgingTrackerSize",
+		10000,
+		`Maximum number of RunIds tracked per backlog manager for workflow-age aging. LRU-evicted when full.`,
+	)
 	MatchingBacklogTaskForwardTimeout = NewTaskQueueDurationSetting(
 		"matching.backlogTaskForwardTimeout",
 		60*time.Second,

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -91,6 +91,9 @@ type (
 		MembershipUnloadDelay                    dynamicconfig.DurationPropertyFn
 		TaskQueueInfoByBuildIdTTL                dynamicconfig.DurationPropertyFnWithTaskQueueFilter
 		PriorityLevels                           dynamicconfig.IntPropertyFnWithTaskQueueFilter
+		WorkflowAgingEnabled                     dynamicconfig.BoolPropertyFnWithTaskQueueFilter
+		WorkflowAgingFullBoostAfter              dynamicconfig.DurationPropertyFnWithTaskQueueFilter
+		WorkflowAgingTrackerSize                 dynamicconfig.IntPropertyFnWithTaskQueueFilter
 
 		RateLimiterRefreshInterval    time.Duration
 		FairnessKeyRateLimitCacheSize dynamicconfig.IntPropertyFnWithTaskQueueFilter
@@ -176,6 +179,9 @@ type (
 		TaskDeleteInterval             func() time.Duration
 		PriorityLevels                 priorityKey
 		DefaultPriorityKey             priorityKey
+		WorkflowAgingEnabled           func() bool
+		WorkflowAgingFullBoostAfter    func() time.Duration
+		WorkflowAgingTrackerSize       func() int
 
 		GetUserDataLongPollTimeout dynamicconfig.DurationPropertyFn
 		GetUserDataMinWaitTime     time.Duration
@@ -338,6 +344,9 @@ func NewConfig(
 		MembershipUnloadDelay:                    dynamicconfig.MatchingMembershipUnloadDelay.Get(dc),
 		TaskQueueInfoByBuildIdTTL:                dynamicconfig.TaskQueueInfoByBuildIdTTL.Get(dc),
 		PriorityLevels:                           dynamicconfig.MatchingPriorityLevels.Get(dc),
+		WorkflowAgingEnabled:                     dynamicconfig.MatchingWorkflowAgingEnabled.Get(dc),
+		WorkflowAgingFullBoostAfter:              dynamicconfig.MatchingWorkflowAgingFullBoostAfter.Get(dc),
+		WorkflowAgingTrackerSize:                 dynamicconfig.MatchingWorkflowAgingTrackerSize.Get(dc),
 		RateLimiterRefreshInterval:               time.Minute,
 		FairnessKeyRateLimitCacheSize:            dynamicconfig.MatchingFairnessKeyRateLimitCacheSize.Get(dc),
 		MaxFairnessKeyWeightOverrides:            dynamicconfig.MatchingMaxFairnessKeyWeightOverrides.Get(dc),
@@ -451,8 +460,17 @@ func newTaskQueueConfig(tq *tqid.TaskQueue, config *Config, ns namespace.Name) *
 		TaskDeleteInterval: func() time.Duration {
 			return config.TaskDeleteInterval(ns.String(), taskQueueName, taskType)
 		},
-		PriorityLevels:             priorityLevels,
-		DefaultPriorityKey:         defaultPriorityKey,
+		PriorityLevels:     priorityLevels,
+		DefaultPriorityKey: defaultPriorityKey,
+		WorkflowAgingEnabled: func() bool {
+			return config.WorkflowAgingEnabled(ns.String(), taskQueueName, taskType)
+		},
+		WorkflowAgingFullBoostAfter: func() time.Duration {
+			return config.WorkflowAgingFullBoostAfter(ns.String(), taskQueueName, taskType)
+		},
+		WorkflowAgingTrackerSize: func() int {
+			return config.WorkflowAgingTrackerSize(ns.String(), taskQueueName, taskType)
+		},
 		GetUserDataLongPollTimeout: config.GetUserDataLongPollTimeout,
 		GetUserDataMinWaitTime:     1 * time.Second,
 		GetUserDataReturnBudget:    returnEmptyTaskTimeBudget,

--- a/service/matching/fair_backlog_manager.go
+++ b/service/matching/fair_backlog_manager.go
@@ -38,6 +38,8 @@ type (
 		subqueuesByPriority map[priorityKey]subqueueIndex
 		priorityBySubqueue  map[subqueueIndex]priorityKey
 
+		ageTracker *workflowAgeTracker
+
 		logger          log.Logger
 		throttledLogger log.ThrottledLogger
 		matchingClient  matchingservice.MatchingServiceClient
@@ -83,6 +85,7 @@ func newFairBacklogManager(
 		logger:              logger,
 		throttledLogger:     throttledLogger,
 		initializedError:    future.NewFuture[struct{}](),
+		ageTracker:          newWorkflowAgeTracker(config.WorkflowAgingTrackerSize),
 	}
 	bmg.taskWriter = newFairTaskWriter(bmg, bmg.newCounterForSubqueue)
 	return bmg
@@ -443,4 +446,5 @@ func (c *fairBacklogManagerImpl) setPriority(task *internalTask) {
 		// draining goes before active backlog so we're guaranteed to finish migration
 		task.effectivePriority -= effectivePriorityFactor * maxPriorityLevels
 	}
+	applyWorkflowAgeBoost(c.config, c.ageTracker, task)
 }

--- a/service/matching/pri_backlog_manager.go
+++ b/service/matching/pri_backlog_manager.go
@@ -57,6 +57,8 @@ type (
 		subqueuesByPriority map[priorityKey]subqueueIndex
 		priorityBySubqueue  map[subqueueIndex]priorityKey
 
+		ageTracker *workflowAgeTracker
+
 		logger           log.Logger
 		throttledLogger  log.ThrottledLogger
 		matchingClient   matchingservice.MatchingServiceClient
@@ -96,6 +98,7 @@ func newPriBacklogManager(
 		logger:              logger,
 		throttledLogger:     throttledLogger,
 		initializedError:    future.NewFuture[struct{}](),
+		ageTracker:          newWorkflowAgeTracker(config.WorkflowAgingTrackerSize),
 	}
 	bmg.taskWriter = newPriTaskWriter(bmg)
 	return bmg
@@ -436,4 +439,5 @@ func (c *priBacklogManagerImpl) setPriority(task *internalTask) {
 		// draining goes before active backlog so we're guaranteed to finish migration
 		task.effectivePriority -= effectivePriorityFactor * maxPriorityLevels
 	}
+	applyWorkflowAgeBoost(c.config, c.ageTracker, task)
 }

--- a/service/matching/workflow_age_tracker.go
+++ b/service/matching/workflow_age_tracker.go
@@ -1,0 +1,119 @@
+package matching
+
+import (
+	"container/list"
+	"sync"
+	"time"
+)
+
+// workflowAgeTracker records the first time a given RunId was observed enqueueing
+// a task in this backlog manager. It is used to compute a workflow-age priority
+// boost so that long-running workflows are dispatched ahead of fresh ones.
+//
+// The tracker is bounded: when more than sizeFn() distinct RunIds are present the
+// oldest (least recently observed) entries are evicted. Eviction is acceptable —
+// a workflow that returns after eviction simply starts fresh from age 0.
+type workflowAgeTracker struct {
+	sizeFn func() int
+
+	mu      sync.Mutex
+	byKey   map[string]*list.Element
+	byOrder *list.List // front = most recently observed
+}
+
+type workflowAgeEntry struct {
+	runID     string
+	firstSeen time.Time
+}
+
+func newWorkflowAgeTracker(sizeFn func() int) *workflowAgeTracker {
+	return &workflowAgeTracker{
+		sizeFn:  sizeFn,
+		byKey:   make(map[string]*list.Element),
+		byOrder: list.New(),
+	}
+}
+
+// observe records (or refreshes the recency of) a RunId and returns now-firstSeen.
+// If the RunId has not been seen before, firstSeen is set to now and 0 is returned.
+func (t *workflowAgeTracker) observe(runID string, now time.Time) time.Duration {
+	if runID == "" {
+		return 0
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if elt, ok := t.byKey[runID]; ok {
+		entry := elt.Value.(*workflowAgeEntry)
+		t.byOrder.MoveToFront(elt)
+		age := now.Sub(entry.firstSeen)
+		if age < 0 {
+			return 0
+		}
+		return age
+	}
+
+	entry := &workflowAgeEntry{runID: runID, firstSeen: now}
+	elt := t.byOrder.PushFront(entry)
+	t.byKey[runID] = elt
+
+	maxSize := t.sizeFn()
+	if maxSize <= 0 {
+		maxSize = 1
+	}
+	for t.byOrder.Len() > maxSize {
+		oldest := t.byOrder.Back()
+		if oldest == nil {
+			break
+		}
+		t.byOrder.Remove(oldest)
+		delete(t.byKey, oldest.Value.(*workflowAgeEntry).runID)
+	}
+	return 0
+}
+
+// size returns the current number of tracked RunIds. For tests/metrics.
+func (t *workflowAgeTracker) size() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.byOrder.Len()
+}
+
+// applyWorkflowAgeBoost subtracts a sub-level workflow-age boost from
+// task.effectivePriority when enabled. The boost is bounded so it cannot
+// promote a task across a configured priority level.
+func applyWorkflowAgeBoost(cfg *taskQueueConfig, tracker *workflowAgeTracker, task *internalTask) {
+	if cfg.WorkflowAgingEnabled == nil || !cfg.WorkflowAgingEnabled() {
+		return
+	}
+	if tracker == nil || task.event == nil || task.event.Data == nil {
+		return
+	}
+	runID := task.event.Data.GetRunId()
+	if runID == "" {
+		return
+	}
+	age := tracker.observe(runID, time.Now())
+	task.effectivePriority -= workflowAgeBoost(age, cfg.WorkflowAgingFullBoostAfter())
+}
+
+// workflowAgeBoost translates a workflow age into a sub-level priority boost.
+// The return value is in [0, effectivePriorityFactor-1] so that subtracting it
+// from effectivePriority can never cross a configured priority level.
+func workflowAgeBoost(age time.Duration, fullBoostAfter time.Duration) priorityKey {
+	if age <= 0 || fullBoostAfter <= 0 {
+		return 0
+	}
+	const maxBoost = effectivePriorityFactor - 1
+	if age >= fullBoostAfter {
+		return maxBoost
+	}
+	boost := int64(age) * maxBoost / int64(fullBoostAfter)
+	if boost < 0 {
+		return 0
+	}
+	if boost > maxBoost {
+		return maxBoost
+	}
+	return priorityKey(boost)
+}

--- a/service/matching/workflow_age_tracker_test.go
+++ b/service/matching/workflow_age_tracker_test.go
@@ -1,0 +1,179 @@
+package matching
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+)
+
+func TestWorkflowAgeTracker_FirstObserveReturnsZero(t *testing.T) {
+	tr := newWorkflowAgeTracker(func() int { return 10 })
+	now := time.Now()
+	require.Equal(t, time.Duration(0), tr.observe("run-1", now))
+}
+
+func TestWorkflowAgeTracker_RepeatObserveReturnsAge(t *testing.T) {
+	tr := newWorkflowAgeTracker(func() int { return 10 })
+	t0 := time.Now()
+	tr.observe("run-1", t0)
+	got := tr.observe("run-1", t0.Add(5*time.Minute))
+	require.Equal(t, 5*time.Minute, got)
+}
+
+func TestWorkflowAgeTracker_EmptyRunIDIsNoop(t *testing.T) {
+	tr := newWorkflowAgeTracker(func() int { return 10 })
+	require.Equal(t, time.Duration(0), tr.observe("", time.Now()))
+	require.Equal(t, 0, tr.size())
+}
+
+func TestWorkflowAgeTracker_NegativeClockSkewClampsToZero(t *testing.T) {
+	tr := newWorkflowAgeTracker(func() int { return 10 })
+	t0 := time.Now()
+	tr.observe("run-1", t0)
+	require.Equal(t, time.Duration(0), tr.observe("run-1", t0.Add(-time.Second)))
+}
+
+func TestWorkflowAgeTracker_EvictsOldestWhenFull(t *testing.T) {
+	tr := newWorkflowAgeTracker(func() int { return 3 })
+	t0 := time.Now()
+	tr.observe("run-1", t0)
+	tr.observe("run-2", t0.Add(time.Second))
+	tr.observe("run-3", t0.Add(2*time.Second))
+	tr.observe("run-4", t0.Add(3*time.Second))
+
+	require.Equal(t, 3, tr.size())
+	// run-2 should still be present and report its real age.
+	require.Equal(t, 3*time.Second, tr.observe("run-2", t0.Add(4*time.Second)))
+	// run-1 should have been evicted; re-observe returns 0 (treated as new).
+	require.Equal(t, time.Duration(0), tr.observe("run-1", t0.Add(5*time.Second)))
+}
+
+func TestWorkflowAgeTracker_ReObservingRefreshesRecency(t *testing.T) {
+	tr := newWorkflowAgeTracker(func() int { return 3 })
+	t0 := time.Now()
+	tr.observe("run-1", t0)
+	tr.observe("run-2", t0.Add(time.Second))
+	tr.observe("run-3", t0.Add(2*time.Second))
+	// touching run-1 should move it to front; next insert should evict run-2 instead.
+	tr.observe("run-1", t0.Add(3*time.Second))
+	tr.observe("run-4", t0.Add(4*time.Second))
+
+	require.Equal(t, 3, tr.size())
+	// run-1 still tracked (and still reports original firstSeen)
+	require.Equal(t, 5*time.Second, tr.observe("run-1", t0.Add(5*time.Second)))
+	// run-2 evicted
+	require.Equal(t, time.Duration(0), tr.observe("run-2", t0.Add(6*time.Second)))
+}
+
+func TestWorkflowAgeTracker_ZeroSizeFallsBackToOne(t *testing.T) {
+	tr := newWorkflowAgeTracker(func() int { return 0 })
+	t0 := time.Now()
+	tr.observe("run-1", t0)
+	tr.observe("run-2", t0.Add(time.Second))
+	require.Equal(t, 1, tr.size())
+}
+
+func TestWorkflowAgeTracker_ShrinkingMaxSizeEvictsOnNextInsert(t *testing.T) {
+	maxSize := 5
+	tr := newWorkflowAgeTracker(func() int { return maxSize })
+	t0 := time.Now()
+	for i := 0; i < 5; i++ {
+		tr.observe("run-"+strconv.Itoa(i), t0.Add(time.Duration(i)*time.Second))
+	}
+	require.Equal(t, 5, tr.size())
+
+	maxSize = 2
+	tr.observe("run-new", t0.Add(10*time.Second))
+	require.Equal(t, 2, tr.size())
+}
+
+func TestWorkflowAgeBoost_ZeroForZeroAge(t *testing.T) {
+	require.Equal(t, priorityKey(0), workflowAgeBoost(0, time.Minute))
+}
+
+func TestWorkflowAgeBoost_ZeroForZeroFullBoost(t *testing.T) {
+	require.Equal(t, priorityKey(0), workflowAgeBoost(time.Hour, 0))
+}
+
+func TestWorkflowAgeBoost_SaturatesAtFullBoost(t *testing.T) {
+	want := priorityKey(effectivePriorityFactor - 1)
+	require.Equal(t, want, workflowAgeBoost(time.Hour, time.Minute))
+	require.Equal(t, want, workflowAgeBoost(time.Minute, time.Minute))
+}
+
+func TestWorkflowAgeBoost_MonotonicallyIncreases(t *testing.T) {
+	full := 10 * time.Minute
+	var prev priorityKey
+	for i := 1; i <= 10; i++ {
+		got := workflowAgeBoost(time.Duration(i)*time.Minute, full)
+		require.GreaterOrEqual(t, got, prev, "boost should be monotonic")
+		prev = got
+	}
+}
+
+func TestApplyWorkflowAgeBoost_DisabledIsNoop(t *testing.T) {
+	cfg := &taskQueueConfig{
+		WorkflowAgingEnabled:        func() bool { return false },
+		WorkflowAgingFullBoostAfter: func() time.Duration { return 10 * time.Minute },
+	}
+	tr := newWorkflowAgeTracker(func() int { return 10 })
+	task := newInternalTaskFromBacklog(&persistencespb.AllocatedTaskInfo{
+		Data: &persistencespb.TaskInfo{RunId: "run-1"},
+	}, nil)
+	task.effectivePriority = effectivePriorityFactor * 1
+	before := task.effectivePriority
+	applyWorkflowAgeBoost(cfg, tr, task)
+	require.Equal(t, before, task.effectivePriority)
+	require.Equal(t, 0, tr.size(), "tracker should not record observations when disabled")
+}
+
+func TestApplyWorkflowAgeBoost_StaysWithinLevel(t *testing.T) {
+	// A level-1 task (effectivePriority = 10) must never end up at <= 0 after boost,
+	// or it would leapfrog level 0 / unbounded space reserved for draining tasks.
+	cfg := &taskQueueConfig{
+		WorkflowAgingEnabled:        func() bool { return true },
+		WorkflowAgingFullBoostAfter: func() time.Duration { return time.Millisecond },
+	}
+	tr := newWorkflowAgeTracker(func() int { return 10 })
+	task := newInternalTaskFromBacklog(&persistencespb.AllocatedTaskInfo{
+		Data: &persistencespb.TaskInfo{RunId: "run-1"},
+	}, nil)
+	task.effectivePriority = effectivePriorityFactor * 1
+
+	// First observation: age=0, no boost.
+	applyWorkflowAgeBoost(cfg, tr, task)
+	require.Equal(t, priorityKey(effectivePriorityFactor*1), task.effectivePriority)
+
+	// Second observation: age is well past fullBoostAfter, max boost applied.
+	time.Sleep(5 * time.Millisecond)
+	applyWorkflowAgeBoost(cfg, tr, task)
+	require.Equal(t, priorityKey(effectivePriorityFactor*1-(effectivePriorityFactor-1)), task.effectivePriority)
+	require.Greater(t, task.effectivePriority, priorityKey(0),
+		"boost must not let a level-1 task cross into level 0")
+}
+
+func TestApplyWorkflowAgeBoost_NoEventIsNoop(t *testing.T) {
+	cfg := &taskQueueConfig{
+		WorkflowAgingEnabled:        func() bool { return true },
+		WorkflowAgingFullBoostAfter: func() time.Duration { return time.Minute },
+	}
+	tr := newWorkflowAgeTracker(func() int { return 10 })
+	task := &internalTask{effectivePriority: effectivePriorityFactor * 2}
+	applyWorkflowAgeBoost(cfg, tr, task)
+	require.Equal(t, priorityKey(effectivePriorityFactor*2), task.effectivePriority)
+}
+
+func TestWorkflowAgeBoost_NeverCrossesPriorityLevel(t *testing.T) {
+	// effectivePriority for priority level 1 = 10. Subtracting any boost from
+	// a level-1 task must stay strictly above 0 (i.e. >= 1), guaranteeing it
+	// never reaches the effective priority of level 0 (which doesn't exist)
+	// or lands in negative territory that would let it leapfrog a draining task.
+	for age := time.Duration(0); age <= 2*time.Hour; age += time.Minute {
+		boost := workflowAgeBoost(age, time.Hour)
+		require.Less(t, boost, priorityKey(effectivePriorityFactor),
+			"boost %d at age %s must be < effectivePriorityFactor", boost, age)
+	}
+}


### PR DESCRIPTION
> Draft / RFC for discussion.

## Summary

Optional, sub-level `effectivePriority` boost based on how long the matcher has observed a workflow. Off by default. When enabled, newly enqueued tasks from longer-running workflows sort ahead of those from fresh workflows, bounded so the boost can never cross a configured priority level.

## Why

Long-running workflows that emit bursts of activities each turn — most acutely, agent workflows doing 20–50 LLM turns over tens of minutes — currently get FIFO-interleaved with brand-new workflows under load. Worst-slot-per-turn dominates wall clock and tail latency grows with turn count: a steady arrival rate of fresh workflows effectively starves older ones.

This is the same neighborhood as #2517, which closed with the observation that single-partition queues are FIFO and balanced partitions are FIFO-ish. That holds when producers are independent, but a single workflow turn produces a same-partition burst — the variance source is the workflow, not the producer mix. Aging by workflow identity addresses that.

## Design

Builds on existing matcher scaffolding rather than introducing new mechanisms:

- **Post-hoc `effectivePriority` adjustment** — exactly the idiom already used for draining tasks (`fair_backlog_manager.go:440`, `pri_backlog_manager.go:437`). Subtract a small amount from `effectivePriority` to gain priority.
- **Bounded by `effectivePriorityFactor`** — boost ∈ `[0, effectivePriorityFactor-1]`. By construction a level-N task can never cross into level N-1 territory. This fills the intermediate slots that `effectivePriorityFactor = 10` already reserves at `matcher_data.go:20`.
- **Enqueue-time only.** `taskPQ.Less` (`matcher_data.go:139`) must be stable across heap swaps, so reading `time.Now()` from `Less` is unsafe — this is what the existing TODO at `matcher_data.go:149-157` was wrestling with. Setting the boost once at enqueue side-steps the heap-invariant trap. Each new turn re-stamps with the workflow's current age, so per-turn wait *does* drop as the workflow ages.

Workflow age is tracked per backlog manager by a bounded LRU keyed on `RunId`. On eviction a workflow simply starts fresh from age 0 — acceptable degradation.

### Trade-offs / limits

- **Enqueue-time only** means an individual turn's already-queued tasks don't continue aging while waiting; only the *next* turn's tasks pick up the larger boost. For 20–50-turn agents this is a small fraction of total wall clock. Periodic coarse re-heapify is the escape hatch if needed.
- **In-matcher tracker** loses workflow age across matcher reload / partition reassignment. A more authoritative alternative would be plumbing `workflow_start_time` through `persistencespb.TaskInfo` — happy to do that if preferred, kept the surface area small for the draft.
- **Per-partition** — a workflow's tasks generally route to one partition consistently, but worth confirming for the case where versioning redirection moves tasks across backlog managers.

## What's not in scope

- Lifting the `priorityLevels` cap — already configurable up to `maxPriorityLevels = 60` via `matching.priorityLevels`.
- Dispatch-time re-evaluation of fairness weights / stride-scheduler changes.
- Dynamic submission-time priority assignment — global rank isn't knowable when workflows arrive continuously.
- Task-create-time aging — strictly weaker signal; a 30-min-old workflow on turn 15 emits a *fresh* task and would get zero boost.

## Configuration

| Setting | Default | Purpose |
| --- | --- | --- |
| `matching.workflowAgingEnabled` | `false` | Master toggle |
| `matching.workflowAgingFullBoostAfter` | `30m` | Age at which boost saturates at `effectivePriorityFactor-1` |
| `matching.workflowAgingTrackerSize` | `10000` | Max RunIds per backlog manager (LRU) |

## Test plan

- [x] `go build ./...`
- [x] `go test -tags test_dep ./service/matching/` — full package, 36s
- [x] `go test -tags test_dep ./common/dynamicconfig/...`
- [x] Unit tests cover: LRU eviction & recency refresh, zero-size fallback, negative-clock-skew clamp, boost monotonicity & saturation, boost-never-crosses-level, disabled-is-noop, no-event-is-noop
- [ ] Functional / load tests — not yet run

## Open questions for maintainers

1. **In-matcher tracking vs. plumbed `workflow_start_time`** — preference?
2. **Linear ramp** to saturation — fine, or should boost follow a different curve?
3. **Opt-in granularity** — task-queue level (current) feels right for the agent-tool-queue use case, but happy to make it namespace-scoped instead.
4. **Periodic re-heapify** — worth adding behind another flag, or wait until there's evidence the enqueue-time-only version isn't enough?

## Context

Originated from observed behavior running [pydantic-ai](https://github.com/pydantic/pydantic-ai) agent workflows on Temporal with rate-limited tool activities on a dedicated task queue (`MaxTaskQueueActivitiesPerSecond` set, the documented pattern). Happy to share traces / repro setup if helpful.