### PR TITLE
long poll timeout constants

### DIFF
--- a/chasm/lib/activity/config.go
+++ b/chasm/lib/activity/config.go
@@ -1,9 +1,8 @@
 package activity
 
 import (
-	"time"
-
 	"go.temporal.io/server/chasm/lib/callback"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/retrypolicy"
 )
@@ -17,13 +16,13 @@ var (
 
 	LongPollTimeout = dynamicconfig.NewNamespaceDurationSetting(
 		"activity.longPollTimeout",
-		20*time.Second,
+		common.DefaultLongPollTimeout,
 		`Timeout for activity long-poll requests.`,
 	)
 
 	LongPollBuffer = dynamicconfig.NewNamespaceDurationSetting(
 		"activity.longPollBuffer",
-		time.Second,
+		common.DefaultLongPollBuffer,
 		`A buffer used to adjust the activity long-poll timeouts.
  Specifically, activity long-poll requests are timed out at a time which leaves at least the buffer's duration
  remaining before the caller's deadline, if permitted by the caller's deadline.`,

--- a/chasm/lib/nexusoperation/config.go
+++ b/chasm/lib/nexusoperation/config.go
@@ -6,6 +6,7 @@ import (
 	"text/template"
 	"time"
 
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -15,14 +16,14 @@ import (
 
 var LongPollTimeout = dynamicconfig.NewNamespaceDurationSetting(
 	"nexusoperation.longPollTimeout",
-	20*time.Second,
+	common.DefaultLongPollTimeout,
 	`Maximum timeout for nexus operation long-poll requests. Actual wait may be shorter to leave
 longPollBuffer before the caller deadline.`,
 )
 
 var LongPollBuffer = dynamicconfig.NewNamespaceDurationSetting(
 	"nexusoperation.longPollBuffer",
-	time.Second,
+	common.DefaultLongPollBuffer,
 	`A buffer used to adjust the nexus operation long-poll timeouts.
  Specifically, nexus operation long-poll requests are timed out at a time which leaves at least the buffer's duration
  remaining before the caller's deadline, if permitted by the caller's deadline.`,

--- a/common/constants.go
+++ b/common/constants.go
@@ -31,10 +31,16 @@ const (
 )
 
 const (
-	// MinLongPollTimeout is the minimum context timeout for long poll API, below which
-	// the request won't be processed
+	// DefaultLongPollTimeout is the default context timeout for a long poll request.
+	DefaultLongPollTimeout = time.Second * 60
+	// DefaultLongPollBuffer is the buffer used to adjust a long poll request timeout.
+	// Specifically, long poll requests are timed out at a time which leaves at least the buffer's duration
+	// remaining before the caller's deadline, if permitted by the caller's deadline.
+	DefaultLongPollBuffer = time.Second
+	// MinLongPollTimeout is the minimum context timeout for a long poll request, below which
+	// the request won't be processed.
 	MinLongPollTimeout = time.Second * 2
-	// CriticalLongPollTimeout is a threshold for the context timeout passed into long poll API,
+	// CriticalLongPollTimeout is a threshold for the context timeout passed into a long poll request,
 	// below which a warning will be logged
 	CriticalLongPollTimeout = time.Second * 10
 )

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	sdkworker "go.temporal.io/sdk/worker"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/retrypolicy"
@@ -1628,7 +1629,7 @@ See DynamicRateLimitingParams comments for more details.`,
 	)
 	HistoryLongPollExpirationInterval = NewNamespaceDurationSetting(
 		"history.longPollExpirationInterval",
-		time.Second*20,
+		common.DefaultLongPollTimeout,
 		`HistoryLongPollExpirationInterval is the long poll expiration interval in the history service`,
 	)
 	HistoryCacheSizeBasedLimit = NewGlobalBoolSetting(

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	sdkworker "go.temporal.io/sdk/worker"
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/retrypolicy"
@@ -1629,7 +1628,7 @@ See DynamicRateLimitingParams comments for more details.`,
 	)
 	HistoryLongPollExpirationInterval = NewNamespaceDurationSetting(
 		"history.longPollExpirationInterval",
-		common.DefaultLongPollTimeout,
+		time.Second*20,
 		`HistoryLongPollExpirationInterval is the long poll expiration interval in the history service`,
 	)
 	HistoryCacheSizeBasedLimit = NewGlobalBoolSetting(

--- a/service/history/api/get_workflow_util.go
+++ b/service/history/api/get_workflow_util.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"fmt"
-	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -24,8 +23,6 @@ import (
 	"go.temporal.io/server/service/history/events"
 	historyi "go.temporal.io/server/service/history/interfaces"
 )
-
-const longPollSoftTimeout = time.Second
 
 //nolint:revive // cognitive complexity 39 (> max enabled 25)
 func GetOrPollWorkflowMutableState(
@@ -191,7 +188,7 @@ func GetOrPollWorkflowMutableState(
 
 		// Send back response just before caller context would time out.
 		longPollInterval := shardContext.GetConfig().LongPollExpirationInterval(namespaceRegistry.Name().String())
-		longPollCtx, cancel := contextutil.WithDeadlineBuffer(ctx, longPollInterval, longPollSoftTimeout)
+		longPollCtx, cancel := contextutil.WithDeadlineBuffer(ctx, longPollInterval, common.DefaultLongPollBuffer)
 		defer cancel()
 
 		for {


### PR DESCRIPTION
## What changed?

Introduces shared constants for default long poll timeout/buffer and applies them to SAA and SANO.

## Why?

After a long internal technical discussion, 60s was determined as the default for the timeout.
