### PR TITLE
Worker-Versioning: Bug fix (and flaky test fix) for fetching the right current/ramping version

### DIFF
--- a/common/worker_versioning/worker_versioning.go
+++ b/common/worker_versioning/worker_versioning.go
@@ -928,42 +928,55 @@ func CalculateTaskQueueVersioningInfo(deployments *persistencespb.DeploymentData
 	var routingConfigLatestCurrentVersion *deploymentpb.RoutingConfig
 	var routingConfigLatestRampingVersion *deploymentpb.RoutingConfig
 
-	isPartOfSomeCurrentVersion := false
-	isPartOfSomeRampingVersion := false
+	// Track the latest "versioned and TQ is a member" and "unversioned" routing configs
+	// separately so a versioned current/ramping always wins over an unversioned-but-newer
+	// entry in another deployment bucket, independent of map iteration order.
+	//
+	// Only chose those RoutingConfigs which pass the HasDeploymentVersion check due to the following example case:
+	// t0: TQ "foo" is in current version A with other TQ's
+	// t1: All other TQ's are moved to new version B except for "foo".
+	// t2: New version B is set as the current version.
+	//
+	// When this happens, we sync to "foo" that A is no longer the current version by passing in the new routing config. However,
+	// version B should not be considered as the current version for "foo" because the task-queue is not part of version B.
+	var latestVersionedCurrent, latestUnversionedCurrent *deploymentpb.RoutingConfig
+	var latestVersionedRamping, latestUnversionedRamping *deploymentpb.RoutingConfig
 
-	if deployments.GetDeploymentsData() != nil {
+	for _, deploymentInfo := range deployments.GetDeploymentsData() {
+		rc := deploymentInfo.GetRoutingConfig()
 
-		for _, deploymentInfo := range deployments.GetDeploymentsData() {
-			routingConfig := deploymentInfo.GetRoutingConfig()
-			if routingConfig == nil {
-				continue
+		tCurrent := rc.GetCurrentVersionChangedTime().AsTime()
+		if HasDeploymentVersion(deployments, DeploymentVersionFromDeployment(DeploymentFromExternalDeploymentVersion(rc.GetCurrentDeploymentVersion()))) {
+			if tCurrent.After(latestVersionedCurrent.GetCurrentVersionChangedTime().AsTime()) {
+				latestVersionedCurrent = rc
 			}
-
-			// Only chose those RoutingConfigs which pass the HasDeploymentVersion check due to the following example case:
-			// t0: TQ "foo" is in current version A with other TQ's
-			// t1: All other TQ's are moved to new version B except for "foo".
-			// t2: New version B is set as the current version.
-			//
-			// When this happens, we sync to "foo" that A is no longer the current version by passing in the new routing config. However,
-			// version B should not be considered as the current version for "foo" because the task-queue is not part of version B.
-			if t := routingConfig.GetCurrentVersionChangedTime().AsTime(); t.After(routingConfigLatestCurrentVersion.GetCurrentVersionChangedTime().AsTime()) {
-				if HasDeploymentVersion(deployments, DeploymentVersionFromDeployment(DeploymentFromExternalDeploymentVersion(routingConfig.GetCurrentDeploymentVersion()))) {
-					routingConfigLatestCurrentVersion = routingConfig
-					isPartOfSomeCurrentVersion = true
-				} else if !isPartOfSomeCurrentVersion && routingConfig.GetCurrentDeploymentVersion() == nil {
-					routingConfigLatestCurrentVersion = routingConfig
-				}
-			}
-
-			if t := routingConfig.GetRampingVersionPercentageChangedTime().AsTime(); t.After(routingConfigLatestRampingVersion.GetRampingVersionPercentageChangedTime().AsTime()) {
-				if HasDeploymentVersion(deployments, DeploymentVersionFromDeployment(DeploymentFromExternalDeploymentVersion(routingConfig.GetRampingDeploymentVersion()))) {
-					routingConfigLatestRampingVersion = routingConfig
-					isPartOfSomeRampingVersion = true
-				} else if !isPartOfSomeRampingVersion && routingConfig.GetRampingDeploymentVersion() == nil {
-					routingConfigLatestRampingVersion = routingConfig
-				}
+		} else if rc.GetCurrentDeploymentVersion() == nil {
+			if tCurrent.After(latestUnversionedCurrent.GetCurrentVersionChangedTime().AsTime()) {
+				latestUnversionedCurrent = rc
 			}
 		}
+
+		tRamping := rc.GetRampingVersionPercentageChangedTime().AsTime()
+		if HasDeploymentVersion(deployments, DeploymentVersionFromDeployment(DeploymentFromExternalDeploymentVersion(rc.GetRampingDeploymentVersion()))) {
+			if tRamping.After(latestVersionedRamping.GetRampingVersionPercentageChangedTime().AsTime()) {
+				latestVersionedRamping = rc
+			}
+		} else if rc.GetRampingDeploymentVersion() == nil {
+			if tRamping.After(latestUnversionedRamping.GetRampingVersionPercentageChangedTime().AsTime()) {
+				latestUnversionedRamping = rc
+			}
+		}
+	}
+
+	if latestVersionedCurrent != nil {
+		routingConfigLatestCurrentVersion = latestVersionedCurrent
+	} else {
+		routingConfigLatestCurrentVersion = latestUnversionedCurrent
+	}
+	if latestVersionedRamping != nil {
+		routingConfigLatestRampingVersion = latestVersionedRamping
+	} else {
+		routingConfigLatestRampingVersion = latestUnversionedRamping
 	}
 
 	if routingConfigLatestCurrentVersion.GetCurrentDeploymentVersion() == nil && current.GetVersion() != nil {

--- a/common/worker_versioning/worker_versioning_test.go
+++ b/common/worker_versioning/worker_versioning_test.go
@@ -762,18 +762,18 @@ func TestCalculateTaskQueueVersioningInfo(t *testing.T) {
 // per range, so calling the function many times on the same input makes a
 // ~50%-per-call probabilistic bug practically deterministic.
 func TestCalculateTaskQueueVersioningInfo_MapIterationOrderRegression(t *testing.T) {
-	t2 := timestamp.TimePtr(time.Now().Add(-time.Hour))
-	t3 := timestamp.TimePtr(time.Now())
+	t1 := timestamp.TimePtr(time.Now().Add(-time.Hour))
+	t2 := timestamp.TimePtr(time.Now())
 
 	data := &persistencespb.DeploymentData{
 		DeploymentsData: map[string]*persistencespb.WorkerDeploymentData{
 			"foo": {
 				RoutingConfig: &deploymentpb.RoutingConfig{
 					CurrentDeploymentVersion:            &deploymentpb.WorkerDeploymentVersion{DeploymentName: "foo", BuildId: v1.GetBuildId()},
-					CurrentVersionChangedTime:           t2,
+					CurrentVersionChangedTime:           t1,
 					RampingDeploymentVersion:            &deploymentpb.WorkerDeploymentVersion{DeploymentName: "foo", BuildId: v1.GetBuildId()},
 					RampingVersionPercentage:            30,
-					RampingVersionPercentageChangedTime: t2,
+					RampingVersionPercentageChangedTime: t1,
 				},
 				Versions: map[string]*deploymentspb.WorkerDeploymentVersionData{
 					v1.GetBuildId(): {},
@@ -782,10 +782,10 @@ func TestCalculateTaskQueueVersioningInfo_MapIterationOrderRegression(t *testing
 			"bar": {
 				RoutingConfig: &deploymentpb.RoutingConfig{
 					CurrentDeploymentVersion:            nil,
-					CurrentVersionChangedTime:           t3,
+					CurrentVersionChangedTime:           t2,
 					RampingDeploymentVersion:            nil,
 					RampingVersionPercentage:            20,
-					RampingVersionPercentageChangedTime: t3,
+					RampingVersionPercentageChangedTime: t2,
 				},
 				Versions: map[string]*deploymentspb.WorkerDeploymentVersionData{},
 			},

--- a/common/worker_versioning/worker_versioning_test.go
+++ b/common/worker_versioning/worker_versioning_test.go
@@ -755,6 +755,55 @@ func TestCalculateTaskQueueVersioningInfo(t *testing.T) {
 	}
 }
 
+// TestCalculateTaskQueueVersioningInfo_MapIterationOrderRegression guards against
+// reintroducing a bug where the per-deployment loop in CalculateTaskQueueVersioningInfo
+// would pick an unversioned-but-newer RoutingConfig over a versioned-and-member
+// RoutingConfig depending on Go map iteration order. Go re-randomizes map iteration
+// per range, so calling the function many times on the same input makes a
+// ~50%-per-call probabilistic bug practically deterministic.
+func TestCalculateTaskQueueVersioningInfo_MapIterationOrderRegression(t *testing.T) {
+	t2 := timestamp.TimePtr(time.Now().Add(-time.Hour))
+	t3 := timestamp.TimePtr(time.Now())
+
+	data := &persistencespb.DeploymentData{
+		DeploymentsData: map[string]*persistencespb.WorkerDeploymentData{
+			"foo": {
+				RoutingConfig: &deploymentpb.RoutingConfig{
+					CurrentDeploymentVersion:            &deploymentpb.WorkerDeploymentVersion{DeploymentName: "foo", BuildId: v1.GetBuildId()},
+					CurrentVersionChangedTime:           t2,
+					RampingDeploymentVersion:            &deploymentpb.WorkerDeploymentVersion{DeploymentName: "foo", BuildId: v1.GetBuildId()},
+					RampingVersionPercentage:            30,
+					RampingVersionPercentageChangedTime: t2,
+				},
+				Versions: map[string]*deploymentspb.WorkerDeploymentVersionData{
+					v1.GetBuildId(): {},
+				},
+			},
+			"bar": {
+				RoutingConfig: &deploymentpb.RoutingConfig{
+					CurrentDeploymentVersion:            nil,
+					CurrentVersionChangedTime:           t3,
+					RampingDeploymentVersion:            nil,
+					RampingVersionPercentage:            20,
+					RampingVersionPercentageChangedTime: t3,
+				},
+				Versions: map[string]*deploymentspb.WorkerDeploymentVersionData{},
+			},
+		},
+	}
+
+	const N = 100
+	for i := 0; i < N; i++ {
+		current, _, _, ramping, _, _, _, _ := CalculateTaskQueueVersioningInfo(data)
+		if !current.Equal(v1) {
+			t.Fatalf("iteration %d: got current = %v, want %v (map iteration order regression)", i, current, v1)
+		}
+		if !ramping.Equal(v1) {
+			t.Fatalf("iteration %d: got ramping = %v, want %v (map iteration order regression)", i, ramping, v1)
+		}
+	}
+}
+
 func TestFindDeploymentVersionForWorkflowID(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/common/worker_versioning/worker_versioning_test.go
+++ b/common/worker_versioning/worker_versioning_test.go
@@ -793,7 +793,7 @@ func TestCalculateTaskQueueVersioningInfo_MapIterationOrderRegression(t *testing
 	}
 
 	const N = 100
-	for i := 0; i < N; i++ {
+	for i := range N {
 		current, _, _, ramping, _, _, _, _ := CalculateTaskQueueVersioningInfo(data)
 		if !current.Equal(v1) {
 			t.Fatalf("iteration %d: got current = %v, want %v (map iteration order regression)", i, current, v1)


### PR DESCRIPTION
## What changed?
- This is a continuation from one of my earlier efforts: https://github.com/temporalio/temporal/pull/8643
- Solves a real legitimate bug in the code.
- Also added a regression styled unit test which iterates the map 100 times to spot the bug. The total test time of this new test, in the worst case, is 3 seconds so not a lot of overhead imo.

## Why?
- because i recently learned that go uses non-deterministic routing when traversing maps and we can't rely on timestamps for the right order of iteration
- the property of versioning we preserve with this change:
"if you place a task queue in a new worker deployment which does not have a current version, and the task queue was present in a different worker deployment with a current version, the current version of the task queue is the previously set current version"

## **Why this isn't a hotfix candidate**

The bug only surfaces under a specific combination of conditions:
1. A task queue is migrated from one worker deployment to another, **and**
2. No `setXXX` operation is called on the new deployment

Looking at current usage patterns, nearly all users in this flow are doing one of the following instead:
- Bumping to a new **version** (not a raw deployment swap)
- Pairing the deployment move with a `setXXX` call
- Explicitly unsetting the current version on the new deployment before making a switch

Because none of those paths hit the problematic code, the blast radius is small enough that this doesn't warrant an expedited release imo

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- I would love a thorough review on this one, since it does tackle the core of routing for worker-versioning

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches task-queue routing selection logic for worker versioning; incorrect ordering or nil handling could misroute traffic, though the change is localized and covered by a regression test.
> 
> **Overview**
> Fixes a bug in `CalculateTaskQueueVersioningInfo` where iterating `DeploymentsData` could non-deterministically pick an *unversioned-but-newer* `RoutingConfig` over a *versioned-and-member* one due to Go map iteration order.
> 
> The selection now tracks **versioned-member** and **unversioned** candidates separately for both *current* and *ramping*, and only falls back to unversioned when no valid versioned candidate exists. Adds `TestCalculateTaskQueueVersioningInfo_MapIterationOrderRegression` to repeatedly exercise the prior probabilistic failure and prevent regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20fea44c430c028fc1592aeb85d8d53438607408. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->