### PR TITLE
Tweaks cancellation error log

### DIFF
--- a/chasm/lib/nexusoperation/cancellation_tasks.go
+++ b/chasm/lib/nexusoperation/cancellation_tasks.go
@@ -114,7 +114,7 @@ func (h *cancellationInvocationTaskHandler) Execute(
 	endpoint, err := h.lookupEndpoint(ctx, ns.ID(), args.endpointID, args.endpointName)
 	if err != nil {
 		if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
-			h.logger.Error("endpoint not found while processing invocation task", tag.Error(err))
+			h.logger.Error("endpoint not found while processing cancellation invocation", tag.Error(err))
 			handlerErr := nexus.NewHandlerErrorf(nexus.HandlerErrorTypeNotFound, "endpoint not registered")
 			return h.saveCancellationResult(ctx, cancelRef, handlerErr)
 		}


### PR DESCRIPTION
## What changed?
Log message for nexus operation cancellation invocation

## Why?
Makes the log distinct from errors during operation invocation. 

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

