### PR TITLE
added docs on protorequire.ProtoEqual in testing.md

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -163,6 +163,7 @@ will ultimately fail the test.
 ### protorequire package
 
 Use `protorequire.ProtoEqual` to compare proto messages with proto semantics.
+Prefer a single `ProtoEqual` call over asserting fields one-by-one, since it catches unexpected field changes and keeps the expected value next to the assertion.
 
 To ignore specific fields on the top-level message (e.g. non-deterministic timestamps), pass `protorequire.IgnoreFields`:
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -160,6 +160,21 @@ It is *not* a substitute for regular error handling, validation, or control flow
 In functional tests, a failed soft assertion will not stop the test execution immediately, but it
 will ultimately fail the test.
 
+### protorequire package
+
+Use `protorequire.ProtoEqual` to compare proto messages with proto semantics.
+
+To ignore specific fields on the top-level message (e.g. non-deterministic timestamps), pass `protorequire.IgnoreFields`:
+
+```go
+protorequire.ProtoEqual(t, expected, actual,
+    protorequire.IgnoreFields(
+        "execution_duration",
+        "schedule_time",
+    ),
+)
+```
+
 ### Test Cluster
 
 Use `testcore.NewEnv(t)` to create a test environment with access to a Temporal cluster for end-to-end testing.


### PR DESCRIPTION
## What changed?
 Added a short protorequire package subsection to docs/development/testing.md documenting protorequire.ProtoEqual and the new protorequire.IgnoreFields option, with a minimal usage example.    

## Why?
Follow-up to PR #9937. Without a doc entry, the new IgnoreFields helper is undiscoverable and contributors will keep reaching for the verbose cmp.Diff pattern.


## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

