### PR TITLE
Validate user metadata of StartNexusOperationExecutionRequest

### DIFF
--- a/chasm/lib/nexusoperation/config.go
+++ b/chasm/lib/nexusoperation/config.go
@@ -235,6 +235,8 @@ type Config struct {
 	CallbackURLTemplate                 dynamicconfig.TypedPropertyFn[*template.Template]
 	UseSystemCallbackURL                dynamicconfig.BoolPropertyFn
 	PayloadSizeLimitWarn                dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxUserMetadataSummarySize          dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxUserMetadataDetailsSize          dynamicconfig.IntPropertyFnWithNamespaceFilter
 	UseNewFailureWireFormat             dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	RecordCancelRequestCompletionEvents dynamicconfig.BoolPropertyFn
 	VisibilityMaxPageSize               dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -262,6 +264,8 @@ func configProvider(dc *dynamicconfig.Collection, cfg *config.Persistence) *Conf
 		MaxOperationScheduleToCloseTimeout: MaxOperationScheduleToCloseTimeout.Get(dc),
 		PayloadSizeLimit:                   dynamicconfig.BlobSizeLimitError.Get(dc),
 		PayloadSizeLimitWarn:               dynamicconfig.BlobSizeLimitWarn.Get(dc),
+		MaxUserMetadataSummarySize:         dynamicconfig.MaxUserMetadataSummarySize.Get(dc),
+		MaxUserMetadataDetailsSize:         dynamicconfig.MaxUserMetadataDetailsSize.Get(dc),
 		CallbackURLTemplate:                CallbackURLTemplate.Get(dc),
 		UseSystemCallbackURL:               UseSystemCallbackURL.Get(dc),
 		UseNewFailureWireFormat:            UseNewFailureWireFormat.Get(dc),

--- a/chasm/lib/nexusoperation/validator.go
+++ b/chasm/lib/nexusoperation/validator.go
@@ -145,6 +145,21 @@ func validateAndNormalizeStartRequest(
 			inputSize, config.PayloadSizeLimit(ns))
 	}
 
+	if summary := req.GetUserMetadata().GetSummary(); summary != nil && summary.Size() > config.MaxUserMetadataSummarySize(ns) {
+		return serviceerror.NewInvalidArgumentf(
+			"user_metadata.summary exceeds size limit. Length=%d Limit=%d",
+			summary.Size(),
+			config.MaxUserMetadataSummarySize(ns),
+		)
+	}
+	if details := req.GetUserMetadata().GetDetails(); details != nil && details.Size() > config.MaxUserMetadataDetailsSize(ns) {
+		return serviceerror.NewInvalidArgumentf(
+			"user_metadata.details exceeds size limit. Length=%d Limit=%d",
+			details.Size(),
+			config.MaxUserMetadataDetailsSize(ns),
+		)
+	}
+
 	loweredHeaders, err := ValidateAndLowercaseNexusHeaders(req.GetNexusHeader(), config.DisallowedOperationHeaders(), config.MaxOperationHeaderSize(ns))
 	if err != nil {
 		return serviceerror.NewInvalidArgument(err.Error())

--- a/chasm/lib/nexusoperation/validator_test.go
+++ b/chasm/lib/nexusoperation/validator_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	sdkpb "go.temporal.io/api/sdk/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
@@ -43,6 +44,8 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 		MaxOperationNameLength:             func(string) int { return 10 },
 		PayloadSizeLimit:                   func(string) int { return 20 },
 		PayloadSizeLimitWarn:               func(string) int { return 10 },
+		MaxUserMetadataSummarySize:         func(string) int { return 10 },
+		MaxUserMetadataDetailsSize:         func(string) int { return 20 },
 		MaxOperationHeaderSize:             func(string) int { return 10 },
 		DisallowedOperationHeaders:         func() []string { return []string{"disallowed-header"} },
 		MaxOperationScheduleToCloseTimeout: func(string) time.Duration { return time.Hour },
@@ -240,6 +243,24 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 				r.Input = &commonpb.Payload{Data: []byte("this-input-is-longer-than-twenty-characters")}
 			},
 			errMsg: "input exceeds size limit",
+		},
+		{
+			name: "user_metadata.summary - exceeds size limit",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.UserMetadata = &sdkpb.UserMetadata{
+					Summary: &commonpb.Payload{Data: []byte("too-long-summary")},
+				}
+			},
+			errMsg: "user_metadata.summary exceeds size limit",
+		},
+		{
+			name: "user_metadata.details - exceeds size limit",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.UserMetadata = &sdkpb.UserMetadata{
+					Details: &commonpb.Payload{Data: []byte("this-details-payload-is-too-long")},
+				}
+			},
+			errMsg: "user_metadata.details exceeds size limit",
 		},
 		{
 			name: "nexus_header - disallowed key",


### PR DESCRIPTION
## What changed?

Added validation of the user metadata in the `StartNexusOperationExecutionRequest`.

## Why?

All other fields are validated.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
