### PR TITLE
Ts/patch 2 - time precision

### DIFF
--- a/common/namespace/const.go
+++ b/common/namespace/const.go
@@ -12,6 +12,6 @@ const (
 	// interpreting zero as infinite.
 	MinRetentionLocal = 1 * time.Hour
 
-	MinTimeSkippingBound  = 1 * time.Second
-	TimeSkippingPrecision = 100 * time.Millisecond
+	MinTimeSkippingBound  = 1 * time.Minute
+	TimeSkippingPrecision = 1 * time.Second
 )

--- a/common/namespace/const.go
+++ b/common/namespace/const.go
@@ -12,6 +12,7 @@ const (
 	// interpreting zero as infinite.
 	MinRetentionLocal = 1 * time.Hour
 
-	// MinTimeSkippingDuration is the minimum duration for time skipping.
-	MinTimeSkippingDuration = 1 * time.Minute
+	// MinTimeSkippingBound is the minimum duration for time skipping bound.
+	MinTimeSkippingBound  = 1 * time.Minute
+	TimeSkippingPrecision = 1 * time.Second
 )

--- a/common/namespace/const.go
+++ b/common/namespace/const.go
@@ -12,6 +12,6 @@ const (
 	// interpreting zero as infinite.
 	MinRetentionLocal = 1 * time.Hour
 
-	MinTimeSkippingBound  = 1 * time.Minute
-	TimeSkippingPrecision = 1 * time.Second
+	MinTimeSkippingBound  = 1 * time.Second
+	TimeSkippingPrecision = 100 * time.Millisecond
 )

--- a/common/namespace/const.go
+++ b/common/namespace/const.go
@@ -12,7 +12,6 @@ const (
 	// interpreting zero as infinite.
 	MinRetentionLocal = 1 * time.Hour
 
-	// MinTimeSkippingBound is the minimum duration for time skipping bound.
 	MinTimeSkippingBound  = 1 * time.Minute
 	TimeSkippingPrecision = 1 * time.Second
 )

--- a/common/util.go
+++ b/common/util.go
@@ -541,6 +541,13 @@ func CreateHistoryStartWorkflowRequest(
 	if startRequest.ContinuedFailure != nil || startRequest.LastCompletionResult != nil {
 		startRequest = CloneProto(startRequest)
 	}
+	// InitialSkippedDuration is intentionally not set here. It is an
+	// internal-only field set by CaN/retry/child-wf/reset paths in the
+	// history service; the public workflowservice proto has no equivalent,
+	// so frontend-originated starts always carry InitialSkippedDuration=0.
+	// This is the precondition that lets the MS chokepoint check at
+	// AddWorkflowExecutionStartedEventWithOptions reduce to the frontend
+	// min-floor for external Start callers.
 	histRequest := &historyservice.StartWorkflowExecutionRequest{
 		NamespaceId:              namespaceID,
 		StartRequest:             startRequest,

--- a/common/util.go
+++ b/common/util.go
@@ -541,13 +541,6 @@ func CreateHistoryStartWorkflowRequest(
 	if startRequest.ContinuedFailure != nil || startRequest.LastCompletionResult != nil {
 		startRequest = CloneProto(startRequest)
 	}
-	// InitialSkippedDuration is intentionally not set here. It is an
-	// internal-only field set by CaN/retry/child-wf/reset paths in the
-	// history service; the public workflowservice proto has no equivalent,
-	// so frontend-originated starts always carry InitialSkippedDuration=0.
-	// This is the precondition that lets the MS chokepoint check at
-	// AddWorkflowExecutionStartedEventWithOptions reduce to the frontend
-	// min-floor for external Start callers.
 	histRequest := &historyservice.StartWorkflowExecutionRequest{
 		NamespaceId:              namespaceID,
 		StartRequest:             startRequest,

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -724,17 +724,17 @@ func (wh *WorkflowHandler) validateTimeSkippingConfig(
 	if timeSkippingConfig.GetBound() != nil {
 		switch bound := timeSkippingConfig.GetBound().(type) {
 		case *workflowpb.TimeSkippingConfig_MaxSkippedDuration:
-			if bound.MaxSkippedDuration.AsDuration() < namespace.MinTimeSkippingDuration {
+			if bound.MaxSkippedDuration.AsDuration() < namespace.MinTimeSkippingBound {
 				return serviceerror.NewInvalidArgumentf(
 					"Max skipped duration must be at least %s",
-					namespace.MinTimeSkippingDuration,
+					namespace.MinTimeSkippingBound,
 				)
 			}
 		case *workflowpb.TimeSkippingConfig_MaxElapsedDuration:
-			if bound.MaxElapsedDuration.AsDuration() < namespace.MinTimeSkippingDuration {
+			if bound.MaxElapsedDuration.AsDuration() < namespace.MinTimeSkippingBound {
 				return serviceerror.NewInvalidArgumentf(
 					"Max elapsed duration must be at least %s",
-					namespace.MinTimeSkippingDuration,
+					namespace.MinTimeSkippingBound,
 				)
 			}
 		default:

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -3358,7 +3358,7 @@ func (s *WorkflowHandlerSuite) TestValidateTimeSkippingConfig() {
 
 	// MaxSkippedDuration below 1 minute is rejected
 	// error type is InvalidArgument
-	halfMinDuration := time.Duration(0.5 * float64(namespace.MinTimeSkippingDuration))
+	halfMinDuration := time.Duration(0.5 * float64(namespace.MinTimeSkippingBound))
 	s.Require().ErrorAs(wh.validateTimeSkippingConfig(&workflowpb.TimeSkippingConfig{
 		Enabled: true,
 		Bound:   &workflowpb.TimeSkippingConfig_MaxSkippedDuration{MaxSkippedDuration: durationpb.New(halfMinDuration)},
@@ -3367,7 +3367,7 @@ func (s *WorkflowHandlerSuite) TestValidateTimeSkippingConfig() {
 	// MaxSkippedDuration exactly 1 minute is valid
 	s.Require().NoError(wh.validateTimeSkippingConfig(&workflowpb.TimeSkippingConfig{
 		Enabled: true,
-		Bound:   &workflowpb.TimeSkippingConfig_MaxSkippedDuration{MaxSkippedDuration: durationpb.New(namespace.MinTimeSkippingDuration)},
+		Bound:   &workflowpb.TimeSkippingConfig_MaxSkippedDuration{MaxSkippedDuration: durationpb.New(namespace.MinTimeSkippingBound)},
 	}, s.testNamespace))
 
 	// MaxElapsedDuration below 1 minute is rejected
@@ -3379,7 +3379,7 @@ func (s *WorkflowHandlerSuite) TestValidateTimeSkippingConfig() {
 	// MaxElapsedDuration exactly 1 minute is valid
 	s.Require().NoError(wh.validateTimeSkippingConfig(&workflowpb.TimeSkippingConfig{
 		Enabled: true,
-		Bound:   &workflowpb.TimeSkippingConfig_MaxElapsedDuration{MaxElapsedDuration: durationpb.New(namespace.MinTimeSkippingDuration)},
+		Bound:   &workflowpb.TimeSkippingConfig_MaxElapsedDuration{MaxElapsedDuration: durationpb.New(namespace.MinTimeSkippingBound)},
 	}, s.testNamespace))
 
 }

--- a/service/history/api/updateworkflowoptions/api.go
+++ b/service/history/api/updateworkflowoptions/api.go
@@ -154,8 +154,8 @@ func MergeAndApply(
 	// would put the workflow over-budget the moment it lands. MaxElapsedDuration
 	// has no equivalent constraint because it resets each enable window.
 	if mergedBound, ok := mergedOpts.GetTimeSkippingConfig().GetBound().(*workflowpb.TimeSkippingConfig_MaxSkippedDuration); ok {
-		currentBound, _ := getOptionsFromMutableState(ms).GetTimeSkippingConfig().GetBound().(*workflowpb.TimeSkippingConfig_MaxSkippedDuration)
-		changingMaxSkipped := currentBound == nil ||
+		currentBound, ok := getOptionsFromMutableState(ms).GetTimeSkippingConfig().GetBound().(*workflowpb.TimeSkippingConfig_MaxSkippedDuration)
+		changingMaxSkipped := !ok ||
 			currentBound.MaxSkippedDuration.AsDuration() != mergedBound.MaxSkippedDuration.AsDuration()
 		if changingMaxSkipped {
 			accumulated := ms.GetExecutionInfo().GetTimeSkippingInfo().GetAccumulatedSkippedDuration().AsDuration()

--- a/service/history/api/updateworkflowoptions/api.go
+++ b/service/history/api/updateworkflowoptions/api.go
@@ -148,11 +148,7 @@ func MergeAndApply(
 		return mergedOpts, false, nil
 	}
 
-	// A new MaxSkippedDuration bound must leave at least MinTimeSkippingDuration of
-	// remaining budget above what the workflow has already accumulated. Skipped
-	// duration grows monotonically, so a bound below the current accumulated value
-	// would put the workflow over-budget the moment it lands. MaxElapsedDuration
-	// has no equivalent constraint because it resets each enable window.
+	// the new max skipped duration must be larger than the current accumulated skipped duration
 	if mergedBound, ok := mergedOpts.GetTimeSkippingConfig().GetBound().(*workflowpb.TimeSkippingConfig_MaxSkippedDuration); ok {
 		currentBound, ok := getOptionsFromMutableState(ms).GetTimeSkippingConfig().GetBound().(*workflowpb.TimeSkippingConfig_MaxSkippedDuration)
 		changingMaxSkipped := !ok ||

--- a/service/history/api/updateworkflowoptions/api.go
+++ b/service/history/api/updateworkflowoptions/api.go
@@ -148,6 +148,25 @@ func MergeAndApply(
 		return mergedOpts, false, nil
 	}
 
+	// A new MaxSkippedDuration bound must leave at least MinTimeSkippingDuration of
+	// remaining budget above what the workflow has already accumulated. Skipped
+	// duration grows monotonically, so a bound below the current accumulated value
+	// would put the workflow over-budget the moment it lands. MaxElapsedDuration
+	// has no equivalent constraint because it resets each enable window.
+	if mergedBound, ok := mergedOpts.GetTimeSkippingConfig().GetBound().(*workflowpb.TimeSkippingConfig_MaxSkippedDuration); ok {
+		currentBound, _ := getOptionsFromMutableState(ms).GetTimeSkippingConfig().GetBound().(*workflowpb.TimeSkippingConfig_MaxSkippedDuration)
+		changingMaxSkipped := currentBound == nil ||
+			currentBound.MaxSkippedDuration.AsDuration() != mergedBound.MaxSkippedDuration.AsDuration()
+		if changingMaxSkipped {
+			accumulated := ms.GetExecutionInfo().GetTimeSkippingInfo().GetAccumulatedSkippedDuration().AsDuration()
+			minDuration := namespace.TimeSkippingPrecision + accumulated
+			if mergedBound.MaxSkippedDuration.AsDuration() < minDuration {
+				return nil, false, serviceerror.NewInvalidArgumentf(
+					"max skipped duration shall be larger than current accumulated skipped duration")
+			}
+		}
+	}
+
 	unsetOverride := false
 	if mergedOpts.GetVersioningOverride() == nil {
 		unsetOverride = true

--- a/service/history/api/updateworkflowoptions/api_test.go
+++ b/service/history/api/updateworkflowoptions/api_test.go
@@ -11,6 +11,7 @@ import (
 	deploymentpb "go.temporal.io/api/deployment/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
+	"go.temporal.io/api/serviceerror"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/historyservice/v1"
@@ -426,6 +427,153 @@ func TestMergeAndApply_TimeSkippingConfig(t *testing.T) {
 			require.NoError(t, err)
 			require.True(t, hasChanges)
 			require.True(t, proto.Equal(tc.expectedConfig, result.GetTimeSkippingConfig()))
+		})
+	}
+}
+
+// TestMergeAndApply_MaxSkippedFloor covers the validation introduced for
+// MaxSkippedDuration updates: the new bound must leave at least
+// TimeSkippingPrecision of remaining budget above the workflow's already-
+// accumulated skipped duration. The check fires only when MaxSkippedDuration
+// is changing; MaxElapsedDuration is exempt (it resets each enable window),
+// and an update that leaves the bound unchanged (but flips e.g. Enabled) also
+// bypasses the floor check.
+func TestMergeAndApply_MaxSkippedFloor(t *testing.T) {
+	maxSkippedCfg := func(d time.Duration) *workflowpb.TimeSkippingConfig {
+		return &workflowpb.TimeSkippingConfig{
+			Enabled: true,
+			Bound:   &workflowpb.TimeSkippingConfig_MaxSkippedDuration{MaxSkippedDuration: durationpb.New(d)},
+		}
+	}
+	maxElapsedCfg := func(d time.Duration) *workflowpb.TimeSkippingConfig {
+		return &workflowpb.TimeSkippingConfig{
+			Enabled: true,
+			Bound:   &workflowpb.TimeSkippingConfig_MaxElapsedDuration{MaxElapsedDuration: durationpb.New(d)},
+		}
+	}
+
+	testCases := []struct {
+		name              string
+		initialConfig     *workflowpb.TimeSkippingConfig
+		initialAccumulate time.Duration
+		updateOptions     *workflowpb.WorkflowExecutionOptions
+		updateMask        *fieldmaskpb.FieldMask
+		wantErr           bool
+	}{
+		{
+			name:              "first-time MaxSkipped at exactly precision succeeds (accumulated=0, strict <)",
+			initialConfig:     nil,
+			initialAccumulate: 0,
+			updateOptions: &workflowpb.WorkflowExecutionOptions{
+				TimeSkippingConfig: maxSkippedCfg(namespace.TimeSkippingPrecision),
+			},
+			updateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.max_skipped_duration"}},
+			wantErr:    false,
+		},
+		{
+			name:              "first-time MaxSkipped below precision rejected (accumulated=0)",
+			initialConfig:     nil,
+			initialAccumulate: 0,
+			updateOptions: &workflowpb.WorkflowExecutionOptions{
+				TimeSkippingConfig: maxSkippedCfg(namespace.TimeSkippingPrecision - 1),
+			},
+			updateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.max_skipped_duration"}},
+			wantErr:    true,
+		},
+		{
+			name:              "updating MaxSkipped above accumulated+precision succeeds",
+			initialConfig:     maxSkippedCfg(time.Hour),
+			initialAccumulate: 30 * time.Minute,
+			updateOptions: &workflowpb.WorkflowExecutionOptions{
+				TimeSkippingConfig: maxSkippedCfg(2 * time.Hour),
+			},
+			updateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.max_skipped_duration"}},
+			wantErr:    false,
+		},
+		{
+			name:              "updating MaxSkipped to value at exactly accumulated+precision succeeds (boundary)",
+			initialConfig:     maxSkippedCfg(time.Hour),
+			initialAccumulate: 30 * time.Minute,
+			updateOptions: &workflowpb.WorkflowExecutionOptions{
+				TimeSkippingConfig: maxSkippedCfg(30*time.Minute + namespace.TimeSkippingPrecision),
+			},
+			updateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.max_skipped_duration"}},
+			wantErr:    false,
+		},
+		{
+			name:              "updating MaxSkipped below accumulated+precision rejected",
+			initialConfig:     maxSkippedCfg(time.Hour),
+			initialAccumulate: 30 * time.Minute,
+			updateOptions: &workflowpb.WorkflowExecutionOptions{
+				TimeSkippingConfig: maxSkippedCfg(20 * time.Minute),
+			},
+			updateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.max_skipped_duration"}},
+			wantErr:    true,
+		},
+		{
+			name:              "updating MaxSkipped below accumulated (over-budget on landing) rejected",
+			initialConfig:     maxSkippedCfg(time.Hour),
+			initialAccumulate: 30 * time.Minute,
+			updateOptions: &workflowpb.WorkflowExecutionOptions{
+				TimeSkippingConfig: maxSkippedCfg(10 * time.Minute),
+			},
+			updateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.max_skipped_duration"}},
+			wantErr:    true,
+		},
+		{
+			name:              "toggling enabled while MaxSkipped is unchanged bypasses the floor check",
+			initialConfig:     maxSkippedCfg(time.Hour),
+			initialAccumulate: 2 * time.Hour, // bound already exceeded
+			updateOptions: &workflowpb.WorkflowExecutionOptions{
+				TimeSkippingConfig: &workflowpb.TimeSkippingConfig{Enabled: false},
+			},
+			updateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.enabled"}},
+			wantErr:    false,
+		},
+		{
+			name:              "MaxElapsed bound is exempt from the floor check",
+			initialConfig:     nil,
+			initialAccumulate: 10 * time.Hour,
+			updateOptions: &workflowpb.WorkflowExecutionOptions{
+				TimeSkippingConfig: maxElapsedCfg(time.Minute),
+			},
+			updateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.max_elapsed_duration"}},
+			wantErr:    false,
+		},
+		{
+			name:              "switching from MaxElapsed to MaxSkipped triggers the floor check",
+			initialConfig:     maxElapsedCfg(time.Hour),
+			initialAccumulate: 30 * time.Minute,
+			updateOptions: &workflowpb.WorkflowExecutionOptions{
+				TimeSkippingConfig: maxSkippedCfg(10 * time.Minute),
+			},
+			updateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.max_skipped_duration"}},
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			ms := historyi.NewMockMutableState(ctrl)
+			ms.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
+				TimeSkippingInfo: &persistencespb.TimeSkippingInfo{
+					Config:                     tc.initialConfig,
+					AccumulatedSkippedDuration: durationpb.New(tc.initialAccumulate),
+				},
+			}).AnyTimes()
+			if !tc.wantErr {
+				ms.EXPECT().AddWorkflowExecutionOptionsUpdatedEvent(nil, true, "", nil, nil, "", nil, gomock.Any()).Return(&historypb.HistoryEvent{}, nil)
+			}
+
+			_, _, err := MergeAndApply(ms, tc.updateOptions, tc.updateMask, "")
+			if tc.wantErr {
+				require.Error(t, err)
+				var invalidArg *serviceerror.InvalidArgument
+				require.ErrorAs(t, err, &invalidArg)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/service/history/api/updateworkflowoptions/api_test.go
+++ b/service/history/api/updateworkflowoptions/api_test.go
@@ -432,12 +432,7 @@ func TestMergeAndApply_TimeSkippingConfig(t *testing.T) {
 }
 
 // TestMergeAndApply_MaxSkippedFloor covers the validation introduced for
-// MaxSkippedDuration updates: the new bound must leave at least
-// TimeSkippingPrecision of remaining budget above the workflow's already-
-// accumulated skipped duration. The check fires only when MaxSkippedDuration
-// is changing; MaxElapsedDuration is exempt (it resets each enable window),
-// and an update that leaves the bound unchanged (but flips e.g. Enabled) also
-// bypasses the floor check.
+// MaxSkippedDuration updates
 func TestMergeAndApply_MaxSkippedFloor(t *testing.T) {
 	maxSkippedCfg := func(d time.Duration) *workflowpb.TimeSkippingConfig {
 		return &workflowpb.TimeSkippingConfig{
@@ -461,91 +456,41 @@ func TestMergeAndApply_MaxSkippedFloor(t *testing.T) {
 		wantErr           bool
 	}{
 		{
-			name:              "first-time MaxSkipped at exactly precision succeeds (accumulated=0, strict <)",
+			name:              "new MaxSkippedDuration is larger than the current accumulated skipped duration",
 			initialConfig:     nil,
-			initialAccumulate: 0,
+			initialAccumulate: 30 * time.Minute,
 			updateOptions: &workflowpb.WorkflowExecutionOptions{
-				TimeSkippingConfig: maxSkippedCfg(namespace.TimeSkippingPrecision),
+				TimeSkippingConfig: maxSkippedCfg(30*time.Minute + 2*namespace.TimeSkippingPrecision),
 			},
 			updateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.max_skipped_duration"}},
 			wantErr:    false,
 		},
 		{
-			name:              "first-time MaxSkipped below precision rejected (accumulated=0)",
-			initialConfig:     nil,
-			initialAccumulate: 0,
+			name:              "new MaxSkippedDuration is less than the current accumulated skipped duration",
+			initialConfig:     maxSkippedCfg(60 * time.Minute),
+			initialAccumulate: 30 * time.Minute,
 			updateOptions: &workflowpb.WorkflowExecutionOptions{
-				TimeSkippingConfig: maxSkippedCfg(namespace.TimeSkippingPrecision - 1),
+				TimeSkippingConfig: maxSkippedCfg(30*time.Minute - namespace.TimeSkippingPrecision),
 			},
 			updateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.max_skipped_duration"}},
 			wantErr:    true,
 		},
 		{
-			name:              "updating MaxSkipped above accumulated+precision succeeds",
-			initialConfig:     maxSkippedCfg(time.Hour),
-			initialAccumulate: 30 * time.Minute,
-			updateOptions: &workflowpb.WorkflowExecutionOptions{
-				TimeSkippingConfig: maxSkippedCfg(2 * time.Hour),
-			},
-			updateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.max_skipped_duration"}},
-			wantErr:    false,
-		},
-		{
-			name:              "updating MaxSkipped to value at exactly accumulated+precision succeeds (boundary)",
-			initialConfig:     maxSkippedCfg(time.Hour),
-			initialAccumulate: 30 * time.Minute,
-			updateOptions: &workflowpb.WorkflowExecutionOptions{
-				TimeSkippingConfig: maxSkippedCfg(30*time.Minute + namespace.TimeSkippingPrecision),
-			},
-			updateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.max_skipped_duration"}},
-			wantErr:    false,
-		},
-		{
-			name:              "updating MaxSkipped below accumulated+precision rejected",
-			initialConfig:     maxSkippedCfg(time.Hour),
-			initialAccumulate: 30 * time.Minute,
-			updateOptions: &workflowpb.WorkflowExecutionOptions{
-				TimeSkippingConfig: maxSkippedCfg(20 * time.Minute),
-			},
-			updateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.max_skipped_duration"}},
-			wantErr:    true,
-		},
-		{
-			name:              "updating MaxSkipped below accumulated (over-budget on landing) rejected",
-			initialConfig:     maxSkippedCfg(time.Hour),
-			initialAccumulate: 30 * time.Minute,
-			updateOptions: &workflowpb.WorkflowExecutionOptions{
-				TimeSkippingConfig: maxSkippedCfg(10 * time.Minute),
-			},
-			updateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.max_skipped_duration"}},
-			wantErr:    true,
-		},
-		{
-			name:              "toggling enabled while MaxSkipped is unchanged bypasses the floor check",
-			initialConfig:     maxSkippedCfg(time.Hour),
-			initialAccumulate: 2 * time.Hour, // bound already exceeded
-			updateOptions: &workflowpb.WorkflowExecutionOptions{
-				TimeSkippingConfig: &workflowpb.TimeSkippingConfig{Enabled: false},
-			},
-			updateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.enabled"}},
-			wantErr:    false,
-		},
-		{
-			name:              "MaxElapsed bound is exempt from the floor check",
+			name:              "the MaxElapsed bound is not impacted by the check",
 			initialConfig:     nil,
 			initialAccumulate: 10 * time.Hour,
 			updateOptions: &workflowpb.WorkflowExecutionOptions{
-				TimeSkippingConfig: maxElapsedCfg(time.Minute),
+				TimeSkippingConfig: maxElapsedCfg(time.Hour),
 			},
 			updateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.max_elapsed_duration"}},
 			wantErr:    false,
 		},
 		{
-			name:              "switching from MaxElapsed to MaxSkipped triggers the floor check",
+			name:              "switching from MaxElapsed to MaxSkipped also triggers the check",
 			initialConfig:     maxElapsedCfg(time.Hour),
 			initialAccumulate: 30 * time.Minute,
 			updateOptions: &workflowpb.WorkflowExecutionOptions{
-				TimeSkippingConfig: maxSkippedCfg(10 * time.Minute),
+				TimeSkippingConfig: maxSkippedCfg(30*time.Minute - namespace.TimeSkippingPrecision),
 			},
 			updateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.max_skipped_duration"}},
 			wantErr:    true,

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -2620,7 +2620,7 @@ func (ms *MutableStateImpl) addWorkflowExecutionStartedEventForContinueAsNew(
 		}
 	}
 
-	newRunTSConfig, newRunInitialSkipped := snapshotTimeSkippingInfo(previousExecutionInfo)
+	newRunTSConfig, newRunInitialSkipped := snapshotTimeSkippingInfoForPropagation(previousExecutionInfo)
 
 	createRequest := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:                uuid.NewString(),
@@ -5983,7 +5983,7 @@ func (ms *MutableStateImpl) AddStartChildWorkflowExecutionInitiatedEvent(
 		return nil, nil, err
 	}
 
-	childTSConfig, childInitialSkipped := snapshotTimeSkippingInfo(ms.executionInfo)
+	childTSConfig, childInitialSkipped := snapshotTimeSkippingInfoForPropagation(ms.executionInfo)
 	event := ms.hBuilder.AddStartChildWorkflowExecutionInitiatedEvent(
 		workflowTaskCompletedEventID,
 		command,
@@ -9647,19 +9647,12 @@ func (ms *MutableStateImpl) wrapTimeSourceWithTimeSkipping() {
 	ms.hBuilder.SetTimeSource(ms.timeSource)
 }
 
-// snapshotTimeSkippingInfo returns a clone of the source execution's TimeSkippingConfig
+// snapshotTimeSkippingInfoForPropagation returns a clone of the source execution's TimeSkippingConfig
 // and a copy of its AccumulatedSkippedDuration, for propagation to a new run (child workflow
 // or continue-as-new). The source is passed explicitly so callers can snapshot from the
 // originating run's executionInfo — on CaN, the new MS is empty at snapshot time, so we
 // must read from the previous run.
-//
-// When the source's MaxSkippedDuration bound has less than
-// MinRemainingTimeSkippingBoundForPropagation of remaining budget, the config is
-// dropped from the snapshot — propagating it would land the new run with a near-zero
-// or already-exceeded MaxSkipped budget, which would just disable on first skip.
-// InitialSkippedDuration still propagates so the new run's virtual time stays
-// consistent with the parent across the run boundary.
-func snapshotTimeSkippingInfo(source *persistencespb.WorkflowExecutionInfo) (*workflowpb.TimeSkippingConfig, *durationpb.Duration) {
+func snapshotTimeSkippingInfoForPropagation(source *persistencespb.WorkflowExecutionInfo) (*workflowpb.TimeSkippingConfig, *durationpb.Duration) {
 	tsInfo := source.GetTimeSkippingInfo()
 	if tsInfo == nil {
 		return nil, nil
@@ -9672,12 +9665,15 @@ func snapshotTimeSkippingInfo(source *persistencespb.WorkflowExecutionInfo) (*wo
 	if srcTSC == nil {
 		return nil, initialSkipped
 	}
+	// This case should be rare—typically, time skipping is disabled before the remaining budget falls below the precision threshold.
+	// This additional check provides a final safeguard.
 	if bound, ok := srcTSC.GetBound().(*workflowpb.TimeSkippingConfig_MaxSkippedDuration); ok {
 		remaining := bound.MaxSkippedDuration.AsDuration() - tsInfo.GetAccumulatedSkippedDuration().AsDuration()
 		if remaining <= namespace.TimeSkippingPrecision {
 			return nil, initialSkipped
 		}
 	}
+
 	var tsc *workflowpb.TimeSkippingConfig
 	if cloned, ok := proto.Clone(srcTSC).(*workflowpb.TimeSkippingConfig); ok {
 		tsc = cloned

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -9674,7 +9674,7 @@ func snapshotTimeSkippingInfo(source *persistencespb.WorkflowExecutionInfo) (*wo
 	}
 	if bound, ok := srcTSC.GetBound().(*workflowpb.TimeSkippingConfig_MaxSkippedDuration); ok {
 		remaining := bound.MaxSkippedDuration.AsDuration() - tsInfo.GetAccumulatedSkippedDuration().AsDuration()
-		if remaining < namespace.TimeSkippingPrecision {
+		if remaining <= namespace.TimeSkippingPrecision {
 			return nil, initialSkipped
 		}
 	}
@@ -9772,15 +9772,16 @@ func (d timeSkippingTransition) isValid() bool {
 
 func (ms *MutableStateImpl) calculateTimeSkippingTransition() (timeSkippingTransition, error) {
 	var transition timeSkippingTransition
-	advance := func(candidate time.Time, dueToBound bool) {
+	updateTransition := func(candidate time.Time) (bool, time.Duration) {
 		if transition.targetTime.IsZero() || candidate.Before(transition.targetTime) {
 			transition.targetTime = candidate
-			transition.disabledAfterBound = dueToBound
+			return true, 0
 		}
+		return false, candidate.Sub(transition.targetTime)
 	}
 
 	for _, timerInfo := range ms.GetPendingTimerInfos() {
-		advance(timerInfo.ExpiryTime.AsTime(), false)
+		updateTransition(timerInfo.ExpiryTime.AsTime())
 	}
 
 	if !ms.HadOrHasWorkflowTask() {
@@ -9795,7 +9796,7 @@ func (ms *MutableStateImpl) calculateTimeSkippingTransition() (timeSkippingTrans
 		executionTime := ms.executionInfo.GetExecutionTime().AsTime()
 		startTime := ms.executionInfo.GetStartTime().AsTime()
 		if executionTime.After(startTime) && executionTime.After(ms.Now()) {
-			advance(executionTime, false)
+			updateTransition(executionTime)
 		}
 	}
 
@@ -9805,12 +9806,16 @@ func (ms *MutableStateImpl) calculateTimeSkippingTransition() (timeSkippingTrans
 		return transition, nil
 	}
 
+	// bound impacts should come at last so that we can be sure if bound is reached
 	switch b := bound.(type) {
 	case *workflowpb.TimeSkippingConfig_MaxElapsedDuration:
 		if info.GetCurrentElapsedDurationBound() == nil {
-			return timeSkippingTransition{}, serviceerror.NewInternal("time skipping bound target time is not set for elapsed-duration bound")
+			return timeSkippingTransition{}, serviceerror.NewInternal("time-skipping data corruption: bound target time is not set for elapsed-duration bound")
 		}
-		advance(info.GetCurrentElapsedDurationBound().GetTargetTime().AsTime(), true)
+		updated, gap := updateTransition(info.GetCurrentElapsedDurationBound().GetTargetTime().AsTime())
+		if updated || gap <= namespace.TimeSkippingPrecision {
+			transition.disabledAfterBound = true
+		}
 	case *workflowpb.TimeSkippingConfig_MaxSkippedDuration:
 		// MaxSkippedDuration enforces its cap lazily: no wake-up task is emitted, and the
 		// remaining-skip candidate is consulted on every MS mutation. The cap can therefore
@@ -9818,18 +9823,15 @@ func (ms *MutableStateImpl) calculateTimeSkippingTransition() (timeSkippingTrans
 		// maxSkipped never persists past a single transaction.
 		accumulated := info.GetAccumulatedSkippedDuration().AsDuration()
 		maxSkipped := b.MaxSkippedDuration.AsDuration()
-		if accumulated > maxSkipped {
-			return timeSkippingTransition{}, serviceerror.NewInternal("accumulated skipped duration exceeds the configured max skipped duration")
+		if accumulated >= maxSkipped {
+			return timeSkippingTransition{}, serviceerror.NewInternal("time-skipping data corruption: accumulated skipped duration exceeds the configured max skipped duration")
 		}
-		if accumulated == maxSkipped {
-			// Cap exactly hit — emit a "disable, no skip" transition. Going through
-			// advance(ms.Now(), true) would set targetTime to now and trigger a no-op
-			// regen pass downstream.
-			return timeSkippingTransition{disabledAfterBound: true}, nil
+		updated, gap := updateTransition(ms.Now().Add(maxSkipped - accumulated))
+		if updated || gap <= namespace.TimeSkippingPrecision {
+			transition.disabledAfterBound = true
 		}
-		advance(ms.Now().Add(maxSkipped-accumulated), true)
 	default:
-		return timeSkippingTransition{}, serviceerror.NewInternal("unknown time skipping bound type")
+		return timeSkippingTransition{}, serviceerror.NewInternal("time-skipping data corruption: unknown time skipping bound type")
 	}
 	return transition, nil
 }

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -9652,20 +9652,35 @@ func (ms *MutableStateImpl) wrapTimeSourceWithTimeSkipping() {
 // or continue-as-new). The source is passed explicitly so callers can snapshot from the
 // originating run's executionInfo — on CaN, the new MS is empty at snapshot time, so we
 // must read from the previous run.
+//
+// When the source's MaxSkippedDuration bound has less than
+// MinRemainingTimeSkippingBoundForPropagation of remaining budget, the config is
+// dropped from the snapshot — propagating it would land the new run with a near-zero
+// or already-exceeded MaxSkipped budget, which would just disable on first skip.
+// InitialSkippedDuration still propagates so the new run's virtual time stays
+// consistent with the parent across the run boundary.
 func snapshotTimeSkippingInfo(source *persistencespb.WorkflowExecutionInfo) (*workflowpb.TimeSkippingConfig, *durationpb.Duration) {
 	tsInfo := source.GetTimeSkippingInfo()
 	if tsInfo == nil {
 		return nil, nil
 	}
-	var tsc *workflowpb.TimeSkippingConfig
 	var initialSkipped *durationpb.Duration
-	if srcTSC := tsInfo.GetConfig(); srcTSC != nil {
-		if cloned, ok := proto.Clone(srcTSC).(*workflowpb.TimeSkippingConfig); ok {
-			tsc = cloned
-		}
-	}
 	if skipped := tsInfo.GetAccumulatedSkippedDuration(); skipped != nil {
 		initialSkipped = durationpb.New(skipped.AsDuration())
+	}
+	srcTSC := tsInfo.GetConfig()
+	if srcTSC == nil {
+		return nil, initialSkipped
+	}
+	if bound, ok := srcTSC.GetBound().(*workflowpb.TimeSkippingConfig_MaxSkippedDuration); ok {
+		remaining := bound.MaxSkippedDuration.AsDuration() - tsInfo.GetAccumulatedSkippedDuration().AsDuration()
+		if remaining < namespace.TimeSkippingPrecision {
+			return nil, initialSkipped
+		}
+	}
+	var tsc *workflowpb.TimeSkippingConfig
+	if cloned, ok := proto.Clone(srcTSC).(*workflowpb.TimeSkippingConfig); ok {
+		tsc = cloned
 	}
 	return tsc, initialSkipped
 }

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -4173,28 +4173,23 @@ func (s *mutableStateSuite) TestAddStartChildWorkflowExecutionInitiatedEvent_Tim
 		{
 			name: "config + accumulated skip → config cloned, InitialSkippedDuration = parent's accumulated",
 			parentTSI: &persistencespb.TimeSkippingInfo{
-				Config:                     &workflowpb.TimeSkippingConfig{Enabled: true},
+				Config: &workflowpb.TimeSkippingConfig{Enabled: true,
+					Bound: &workflowpb.TimeSkippingConfig_MaxSkippedDuration{MaxSkippedDuration: durationpb.New(2 * time.Hour)}},
 				AccumulatedSkippedDuration: durationpb.New(time.Hour),
 			},
-			expectCfg:         &workflowpb.TimeSkippingConfig{Enabled: true},
+			expectCfg: &workflowpb.TimeSkippingConfig{Enabled: true,
+				Bound: &workflowpb.TimeSkippingConfig_MaxSkippedDuration{MaxSkippedDuration: durationpb.New(2 * time.Hour)}},
 			expectInitialSkip: durationpb.New(time.Hour),
 		},
 		{
-			name: "multi-generation: parent's accumulated (which already includes grandparent's contribution) becomes InitialSkippedDuration",
+			name: "accumulated skip only, no config (safe gate) → no config snapshot, just InitialSkippedDuration",
 			parentTSI: &persistencespb.TimeSkippingInfo{
-				Config:                     &workflowpb.TimeSkippingConfig{Enabled: true},
-				AccumulatedSkippedDuration: durationpb.New(2 * time.Hour),
-			},
-			expectCfg:         &workflowpb.TimeSkippingConfig{Enabled: true},
-			expectInitialSkip: durationpb.New(2 * time.Hour),
-		},
-		{
-			name: "accumulated skip only, no config (corrupt-ish but handled) → no config snapshot, just InitialSkippedDuration",
-			parentTSI: &persistencespb.TimeSkippingInfo{
-				AccumulatedSkippedDuration: durationpb.New(15 * time.Minute),
+				AccumulatedSkippedDuration: durationpb.New(time.Hour - namespace.TimeSkippingPrecision),
+				Config: &workflowpb.TimeSkippingConfig{Enabled: true,
+					Bound: &workflowpb.TimeSkippingConfig_MaxSkippedDuration{MaxSkippedDuration: durationpb.New(time.Hour)}},
 			},
 			expectNilCfg:      true,
-			expectInitialSkip: durationpb.New(15 * time.Minute),
+			expectInitialSkip: durationpb.New(time.Hour - namespace.TimeSkippingPrecision),
 		},
 	}
 
@@ -4340,7 +4335,7 @@ func TestSnapshotTimeSkippingInfo(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotCfg, gotInitial := snapshotTimeSkippingInfo(tc.source)
+			gotCfg, gotInitial := snapshotTimeSkippingInfoForPropagation(tc.source)
 
 			if tc.expectCfg == nil {
 				require.Nil(t, gotCfg)
@@ -8064,31 +8059,37 @@ func (s *mutableStateSuite) TestCalculateTimeSkippingTransition() {
 		s.True(tr.disabledAfterBound)
 	})
 
-	s.Run("MaxSkipped_AccumEqualMax_DisableNoSkip", func() {
-		resetMS()
+	// Invariant: calculateTimeSkippingTransition is never called with
+	// accumulated >= maxSkipped, because:
+	//   (a) ApplyWorkflowExecutionTimeSkippingTransitionedEvent
+	//       updates accumulated and Config.Enabled atomically — when accumulated
+	//       hits maxSkipped, Enabled is set to false in the same apply.
+	//   (b) shouldExecuteTimeSkipping short-circuits when
+	//       !Config.Enabled, so the next close-tx never re-enters this function.
+	//   (c) The updateworkflowoptions validator rejects any
+	//       external update that would leave accumulated >= maxSkipped.
+	// Reaching this branch is therefore data corruption, and the function must
+	// return serviceerror.NewInternal so the caller can log and stop.
+	s.Run("MaxSkipped_AccumAtOrAboveMax_Unreachable", func() {
 		maxBound := time.Hour
-		s.mutableState.executionInfo.TimeSkippingInfo.Config.Bound =
-			&workflowpb.TimeSkippingConfig_MaxSkippedDuration{MaxSkippedDuration: durationpb.New(maxBound)}
-		s.mutableState.executionInfo.TimeSkippingInfo.AccumulatedSkippedDuration = durationpb.New(maxBound)
+		for _, tc := range []struct {
+			name  string
+			accum time.Duration
+		}{
+			{"equal_to_max", maxBound},
+			{"above_max", 2 * maxBound},
+		} {
+			s.Run(tc.name, func() {
+				resetMS()
+				s.mutableState.executionInfo.TimeSkippingInfo.Config.Bound =
+					&workflowpb.TimeSkippingConfig_MaxSkippedDuration{MaxSkippedDuration: durationpb.New(maxBound)}
+				s.mutableState.executionInfo.TimeSkippingInfo.AccumulatedSkippedDuration = durationpb.New(tc.accum)
 
-		tr, err := s.mutableState.calculateTimeSkippingTransition()
-		s.Require().NoError(err)
-		s.True(tr.targetTime.IsZero(), "cap exactly hit must produce zero target time")
-		s.True(tr.disabledAfterBound)
-		s.True(tr.isValid())
-	})
-
-	s.Run("MaxSkipped_AccumGreaterThanMax_InternalError", func() {
-		resetMS()
-		maxBound := time.Hour
-		s.mutableState.executionInfo.TimeSkippingInfo.Config.Bound =
-			&workflowpb.TimeSkippingConfig_MaxSkippedDuration{MaxSkippedDuration: durationpb.New(maxBound)}
-		s.mutableState.executionInfo.TimeSkippingInfo.AccumulatedSkippedDuration = durationpb.New(2 * maxBound)
-
-		_, err := s.mutableState.calculateTimeSkippingTransition()
-		s.Require().Error(err)
-		var internalErr *serviceerror.Internal
-		s.Require().ErrorAs(err, &internalErr)
+				_, err := s.mutableState.calculateTimeSkippingTransition()
+				var internalErr *serviceerror.Internal
+				s.Require().ErrorAs(err, &internalErr)
+			})
+		}
 	})
 
 	s.Run("MaxElapsed_NilCurrentBound_InternalError", func() {
@@ -8155,6 +8156,8 @@ func (s *mutableStateSuite) TestCalculateTimeSkippingTransition() {
 
 // TestCloseTransactionTimeSkipping_Bound exercises the bound-fired path inside
 // closeTransactionHandleTimeSkipping.
+// invariant: every transition that consumes bound must carry disabled_after_bound=true,
+// and atomically flip Config.Enabled to false.
 func (s *mutableStateSuite) TestCloseTransactionTimeSkipping_Bound() {
 	failoverVersion := s.namespaceEntry.FailoverVersion(tests.WorkflowID)
 
@@ -8191,50 +8194,7 @@ func (s *mutableStateSuite) TestCloseTransactionTimeSkipping_Bound() {
 		return dbState
 	}
 
-	s.Run("MaxSkippedCapHit_DisableNoSkip_NoRegen", func() {
-		// With accumulated == max, calculateTimeSkippingTransition returns
-		// (zero, true). closeTransactionHandleTimeSkipping must:
-		//   - emit a transitioned event with target_time unset and disabled_after_bound=true.
-		//   - return regenTimerTasksForTimeSkipping=false (zero target time).
-		dbState := buildState(func(s *persistencespb.WorkflowMutableState) {
-			s.ExecutionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
-				Config: &workflowpb.TimeSkippingConfig{
-					Enabled: true,
-					Bound:   &workflowpb.TimeSkippingConfig_MaxSkippedDuration{MaxSkippedDuration: durationpb.New(time.Hour)},
-				},
-				AccumulatedSkippedDuration: durationpb.New(time.Hour),
-			}
-		})
-
-		ms, err := NewMutableStateFromDB(s.mockShard, s.mockEventsCache, s.logger, s.namespaceEntry, dbState, 1)
-		s.Require().NoError(err)
-		_, err = ms.StartTransaction(s.namespaceEntry)
-		s.Require().NoError(err)
-
-		_, workflowEventsSeq, err := ms.CloseTransactionAsMutation(context.Background(), historyi.TransactionPolicyActive)
-		s.Require().NoError(err)
-
-		var tsEvent *historypb.HistoryEvent
-		for _, we := range workflowEventsSeq {
-			for _, ev := range we.Events {
-				if ev.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TIME_SKIPPING_TRANSITIONED {
-					tsEvent = ev
-				}
-			}
-		}
-		s.Require().NotNil(tsEvent)
-		attr := tsEvent.GetWorkflowExecutionTimeSkippingTransitionedEventAttributes()
-		s.Nil(attr.GetTargetTime(), "cap-hit transition must have unset target_time")
-		s.True(attr.GetDisabledAfterBound())
-		s.False(ms.GetExecutionInfo().TimeSkippingInfo.Config.Enabled,
-			"applying disable_after_bound must flip Enabled to false")
-	})
-
-	s.Run("MaxSkippedAccumBelowMax_SkipsToCap_RegensTasks", func() {
-		// Accumulated < max, no other candidates → bound becomes the only candidate;
-		// transition has both target_time set AND disabled_after_bound=true. The
-		// resulting regen pass produces both an updated user-timer task and the
-		// regenerated bound timer (none here since it's a Skipped bound).
+	s.Run("CloseTransaction_MaxSkippedReached", func() {
 		dbState := buildState(func(s *persistencespb.WorkflowMutableState) {
 			s.ExecutionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
 				Config: &workflowpb.TimeSkippingConfig{
@@ -8273,5 +8233,44 @@ func (s *mutableStateSuite) TestCloseTransactionTimeSkipping_Bound() {
 		// 40 min off, not <1 ms).
 		got := ms.GetExecutionInfo().TimeSkippingInfo.AccumulatedSkippedDuration.AsDuration()
 		s.InDelta(float64(time.Hour), float64(got), float64(time.Millisecond))
+	})
+
+	s.Run("CloseTransaction_MaxElapsedReached", func() {
+		boundTarget := time.Now().UTC().Add(40 * time.Minute)
+		dbState := buildState(func(s *persistencespb.WorkflowMutableState) {
+			s.ExecutionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
+				Config: &workflowpb.TimeSkippingConfig{
+					Enabled: true,
+					Bound:   &workflowpb.TimeSkippingConfig_MaxElapsedDuration{MaxElapsedDuration: durationpb.New(time.Hour)},
+				},
+				CurrentElapsedDurationBound: &persistencespb.TimeSkippingBoundInfo{
+					TargetTime: timestamppb.New(boundTarget),
+				},
+			}
+		})
+
+		ms, err := NewMutableStateFromDB(s.mockShard, s.mockEventsCache, s.logger, s.namespaceEntry, dbState, 1)
+		s.Require().NoError(err)
+		_, err = ms.StartTransaction(s.namespaceEntry)
+		s.Require().NoError(err)
+
+		_, workflowEventsSeq, err := ms.CloseTransactionAsMutation(context.Background(), historyi.TransactionPolicyActive)
+		s.Require().NoError(err)
+
+		var tsEvent *historypb.HistoryEvent
+		for _, we := range workflowEventsSeq {
+			for _, ev := range we.Events {
+				if ev.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TIME_SKIPPING_TRANSITIONED {
+					tsEvent = ev
+				}
+			}
+		}
+		s.Require().NotNil(tsEvent)
+		attr := tsEvent.GetWorkflowExecutionTimeSkippingTransitionedEventAttributes()
+		s.NotNil(attr.GetTargetTime())
+		s.True(attr.GetDisabledAfterBound())
+		s.False(ms.GetExecutionInfo().TimeSkippingInfo.Config.Enabled)
+		s.True(ms.GetExecutionInfo().TimeSkippingInfo.CurrentElapsedDurationBound.HasReached,
+			"applying disable_after_bound for an elapsed bound must mark HasReached")
 	})
 }

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -4242,6 +4242,136 @@ func (s *mutableStateSuite) TestAddStartChildWorkflowExecutionInitiatedEvent_Tim
 	}
 }
 
+// TestSnapshotTimeSkippingInfo unit-tests the pure helper that builds the
+// (config, initialSkippedDuration) tuple propagated to child workflows / CaN.
+// The notable branch is the MaxSkippedDuration remaining-budget gate: when the
+// source has consumed all but < TimeSkippingPrecision of its MaxSkipped bound,
+// the config is dropped from the snapshot so the child/new run does not boot
+// with a near-zero or already-exceeded budget. InitialSkippedDuration still
+// propagates so virtual time stays consistent.
+func TestSnapshotTimeSkippingInfo(t *testing.T) {
+	maxSkippedCfg := func(d time.Duration) *workflowpb.TimeSkippingConfig {
+		return &workflowpb.TimeSkippingConfig{
+			Enabled: true,
+			Bound:   &workflowpb.TimeSkippingConfig_MaxSkippedDuration{MaxSkippedDuration: durationpb.New(d)},
+		}
+	}
+	maxElapsedCfg := func(d time.Duration) *workflowpb.TimeSkippingConfig {
+		return &workflowpb.TimeSkippingConfig{
+			Enabled: true,
+			Bound:   &workflowpb.TimeSkippingConfig_MaxElapsedDuration{MaxElapsedDuration: durationpb.New(d)},
+		}
+	}
+
+	cases := []struct {
+		name              string
+		source            *persistencespb.WorkflowExecutionInfo
+		expectCfg         *workflowpb.TimeSkippingConfig
+		expectInitialSkip *durationpb.Duration
+	}{
+		{
+			name:   "nil TimeSkippingInfo → (nil, nil)",
+			source: &persistencespb.WorkflowExecutionInfo{},
+		},
+		{
+			name: "config nil, accumulated set → (nil, initialSkipped) — accumulated still propagates",
+			source: &persistencespb.WorkflowExecutionInfo{
+				TimeSkippingInfo: &persistencespb.TimeSkippingInfo{
+					AccumulatedSkippedDuration: durationpb.New(15 * time.Minute),
+				},
+			},
+			expectInitialSkip: durationpb.New(15 * time.Minute),
+		},
+		{
+			name: "config set, accumulated nil → cloned config, no initial skip",
+			source: &persistencespb.WorkflowExecutionInfo{
+				TimeSkippingInfo: &persistencespb.TimeSkippingInfo{
+					Config: &workflowpb.TimeSkippingConfig{Enabled: true},
+				},
+			},
+			expectCfg: &workflowpb.TimeSkippingConfig{Enabled: true},
+		},
+		{
+			name: "MaxSkipped with ample remaining budget → cloned config, initial skip propagates",
+			source: &persistencespb.WorkflowExecutionInfo{
+				TimeSkippingInfo: &persistencespb.TimeSkippingInfo{
+					Config:                     maxSkippedCfg(time.Hour),
+					AccumulatedSkippedDuration: durationpb.New(10 * time.Minute),
+				},
+			},
+			expectCfg:         maxSkippedCfg(time.Hour),
+			expectInitialSkip: durationpb.New(10 * time.Minute),
+		},
+		{
+			name: "MaxSkipped with exactly TimeSkippingPrecision remaining → cloned (boundary is strict <)",
+			source: &persistencespb.WorkflowExecutionInfo{
+				TimeSkippingInfo: &persistencespb.TimeSkippingInfo{
+					Config:                     maxSkippedCfg(time.Hour),
+					AccumulatedSkippedDuration: durationpb.New(time.Hour - namespace.TimeSkippingPrecision),
+				},
+			},
+			expectCfg:         maxSkippedCfg(time.Hour),
+			expectInitialSkip: durationpb.New(time.Hour - namespace.TimeSkippingPrecision),
+		},
+		{
+			name: "MaxSkipped with remaining < TimeSkippingPrecision → config dropped, initial skip kept",
+			source: &persistencespb.WorkflowExecutionInfo{
+				TimeSkippingInfo: &persistencespb.TimeSkippingInfo{
+					Config:                     maxSkippedCfg(time.Hour),
+					AccumulatedSkippedDuration: durationpb.New(time.Hour - 500*time.Millisecond),
+				},
+			},
+			expectInitialSkip: durationpb.New(time.Hour - 500*time.Millisecond),
+		},
+		{
+			name: "MaxSkipped already exceeded → config dropped, initial skip kept",
+			source: &persistencespb.WorkflowExecutionInfo{
+				TimeSkippingInfo: &persistencespb.TimeSkippingInfo{
+					Config:                     maxSkippedCfg(time.Hour),
+					AccumulatedSkippedDuration: durationpb.New(2 * time.Hour),
+				},
+			},
+			expectInitialSkip: durationpb.New(2 * time.Hour),
+		},
+		{
+			name: "MaxElapsed bound is NOT subject to the remaining-budget gate — config always clones through",
+			source: &persistencespb.WorkflowExecutionInfo{
+				TimeSkippingInfo: &persistencespb.TimeSkippingInfo{
+					Config:                     maxElapsedCfg(time.Minute),
+					AccumulatedSkippedDuration: durationpb.New(10 * time.Hour),
+				},
+			},
+			expectCfg:         maxElapsedCfg(time.Minute),
+			expectInitialSkip: durationpb.New(10 * time.Hour),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotCfg, gotInitial := snapshotTimeSkippingInfo(tc.source)
+
+			if tc.expectCfg == nil {
+				require.Nil(t, gotCfg)
+			} else {
+				require.NotNil(t, gotCfg)
+				require.True(t, proto.Equal(tc.expectCfg, gotCfg),
+					"expected config %v, got %v", tc.expectCfg, gotCfg)
+				// Must be a clone — mutating must not leak into source.
+				gotCfg.Enabled = !gotCfg.Enabled
+				require.True(t, tc.source.GetTimeSkippingInfo().GetConfig().GetEnabled(),
+					"mutation of snapshot leaked into source's Config")
+			}
+
+			if tc.expectInitialSkip == nil {
+				require.Nil(t, gotInitial)
+			} else {
+				require.NotNil(t, gotInitial)
+				require.Equal(t, tc.expectInitialSkip.AsDuration(), gotInitial.AsDuration())
+			}
+		})
+	}
+}
+
 func (s *mutableStateSuite) TestGetCloseVersion() {
 	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
 

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -4242,13 +4242,6 @@ func (s *mutableStateSuite) TestAddStartChildWorkflowExecutionInitiatedEvent_Tim
 	}
 }
 
-// TestSnapshotTimeSkippingInfo unit-tests the pure helper that builds the
-// (config, initialSkippedDuration) tuple propagated to child workflows / CaN.
-// The notable branch is the MaxSkippedDuration remaining-budget gate: when the
-// source has consumed all but < TimeSkippingPrecision of its MaxSkipped bound,
-// the config is dropped from the snapshot so the child/new run does not boot
-// with a near-zero or already-exceeded budget. InitialSkippedDuration still
-// propagates so virtual time stays consistent.
 func TestSnapshotTimeSkippingInfo(t *testing.T) {
 	maxSkippedCfg := func(d time.Duration) *workflowpb.TimeSkippingConfig {
 		return &workflowpb.TimeSkippingConfig{
@@ -4310,7 +4303,6 @@ func TestSnapshotTimeSkippingInfo(t *testing.T) {
 					AccumulatedSkippedDuration: durationpb.New(time.Hour - namespace.TimeSkippingPrecision),
 				},
 			},
-			expectCfg:         maxSkippedCfg(time.Hour),
 			expectInitialSkip: durationpb.New(time.Hour - namespace.TimeSkippingPrecision),
 		},
 		{


### PR DESCRIPTION
## What changed?
1. When updating the timer config, `MaxSkippedDuration` must not be less than the current accumulated skipped duration.
2. Added a minimum precision unit **X** to time skipping (primarily affecting the bound):
   - If the remaining budget on the bound is less than **X**, the bound is considered reached.
   - For point 1, the comparison is evaluated with an **X** tolerance.

## Why

**1. Why disallow setting `MaxSkippedDuration` below the current accumulated skipped duration?**

If we allowed this, there would be no way to distinguish whether the current accumulated skipped duration is a bug or a legitimate value carried over from a previously larger limit.

**2. Why do we need a minimum unit for the bound?**

Without one, the effective minimum would be 1ns, which causes problems:

- **2a. Elapse-based bound:** if a user starts or updates a workflow with a bound as small as 10ns, we may need to disable time skipping during the configuration request itself, since the operation takes longer than 10ns.
- **2b. Skip-based bound:** while technically feasible, nanosecond precision seems excessive for this feature at least for now — it is assumed to let users skip real timers in a testing environment, without requiring them to set artificially small timer values and skip the small values

**3. Why do we need a minimum precision for time skipping?**

Without it, precision defaults to 1ns. When a parent workflow propagates time skipping, the remaining budget passed to a child workflow can be extremely small, reintroducing the problems described in point 2.

**4. What are the right values?**

The constraints are:
- Minimum bound > precision
- Precision > the duration of a single transaction

Current values: **precision = 1s**, **minimum bound = 1 min** — open to revision.
## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)