### PR TITLE
docs: fix duplicated words in architecture/matching docs

### DIFF
--- a/client/matching/README.md
+++ b/client/matching/README.md
@@ -74,7 +74,7 @@ and then the extra partitions have to be empty before reducing read partitions.
 Changing batch size will cause most partitions to move between nodes.
 To avoid moving lots of partitions simultaneously on a live cluster,
 spread routing can be rolled out gradually (partition by partition)
-using wall-clock-synchronized changes. See the the `GradualChange` mechanism.
+using wall-clock-synchronized changes. See the `GradualChange` mechanism.
 
 ## Interface
 

--- a/docs/architecture/nexus.md
+++ b/docs/architecture/nexus.md
@@ -126,7 +126,7 @@ polling.
 
 ## Outbound Task Queue
 
-The outbound task queue is a task queue that is internal to the history service. Similarly to the the [transfer task
+The outbound task queue is a task queue that is internal to the history service. Similarly to the [transfer task
 queue](./history-service.md#transfer-task-queue), the outbound queue is a sharded "immediate" queue. The difference
 between the transfer queue and the outbound queue is that outbound tasks target external destinations, meaning that
 tasks are allowed to make long running (typically up to 10 seconds) external requests. The outbound queue groups tasks

--- a/docs/architecture/speculative-workflow-task.md
+++ b/docs/architecture/speculative-workflow-task.md
@@ -82,7 +82,7 @@ can't be properly handled outside of the Workflow lock, or returned to the user.
 the speculative Workflow Task is converted to a normal one and creates a transfer task which will
 eventually reach matching and the worker.
 
-The timeout timer task is is created for a `SCHEDULE_TO_START` timeout for every speculative
+The timeout timer task is created for a `SCHEDULE_TO_START` timeout for every speculative
 Workflow Task - even if it is on a *normal* task queue. In comparision, for a normal Workflow Task, the
 `SCHEDULE_TO_START` timeout timer is only created for *sticky* task queues.
 


### PR DESCRIPTION
Three one-line typo fixes for duplicated words in docs:
- `docs/architecture/nexus.md` — "Similarly to the the [transfer task" → "Similarly to the [transfer task"
- `docs/architecture/speculative-workflow-task.md` — "The timeout timer task is is created" → "The timeout timer task is created"
- `client/matching/README.md` — "See the the `GradualChange` mechanism." → "See the `GradualChange` mechanism."

No code/behavior change.