### PR TITLE
Emit metric to track nil value in a KeywordList value

### DIFF
--- a/chasm/lib/nexusoperation/validator_test.go
+++ b/chasm/lib/nexusoperation/validator_test.go
@@ -14,6 +14,7 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
@@ -36,6 +37,8 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 		mockVisibilityManager,
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+		metrics.NoopMetricsHandler,
+		log.NewNoopLogger(),
 	)
 
 	config := &Config{

--- a/chasm/lib/workflow/validator_test.go
+++ b/chasm/lib/workflow/validator_test.go
@@ -11,6 +11,8 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/retrypolicy"
 	"go.temporal.io/server/common/searchattribute"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -28,6 +30,8 @@ func newTestValidator() *RequestValidator {
 		nil, // visibility manager not needed when SA is nil
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+		metrics.NoopMetricsHandler,
+		log.NewNoopLogger(),
 	)
 	return NewValidator(
 		Config{

--- a/common/resource/fx.go
+++ b/common/resource/fx.go
@@ -202,6 +202,8 @@ func SearchAttributeValidatorProvider(
 	saMapperProvider searchattribute.MapperProvider,
 	visibilityMgr manager.VisibilityManager,
 	dynamicCollection *dynamicconfig.Collection,
+	metricsHandler metrics.Handler,
+	logger log.Logger,
 ) *searchattribute.Validator {
 	return searchattribute.NewValidator(
 		saProvider,
@@ -215,6 +217,8 @@ func SearchAttributeValidatorProvider(
 			dynamicconfig.VisibilityAllowList.Get(dynamicCollection),
 		),
 		dynamicconfig.SuppressErrorSetSystemSearchAttribute.Get(dynamicCollection),
+		metricsHandler,
+		logger,
 	)
 }
 

--- a/common/searchattribute/name_type_map.go
+++ b/common/searchattribute/name_type_map.go
@@ -16,8 +16,9 @@ const (
 )
 
 var (
-	system     = sadefs.System()
-	predefined = sadefs.Predefined()
+	system              = sadefs.System()
+	predefined          = sadefs.Predefined()
+	predefinedWhiteList = sadefs.PredefinedWhiteList()
 )
 
 type (

--- a/common/searchattribute/sadefs/encode_value.go
+++ b/common/searchattribute/sadefs/encode_value.go
@@ -7,6 +7,7 @@ import (
 
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/converter"
 	"go.temporal.io/server/common/payload"
 )
 
@@ -107,24 +108,61 @@ func decodeValueTyped[T any](value *commonpb.Payload, allowList bool) (any, erro
 	// only one element, then return it. Otherwise, return an error.
 	// If search attribute value is `nil`, it means that search attribute needs to be removed from the document.
 	var val *T
-	if err := payload.Decode(value, &val); err != nil {
-		var listVal []T
-		if err := payload.Decode(value, &listVal); err != nil {
-			return nil, err
-		}
-		if len(listVal) == 0 {
+	if err := payload.Decode(value, &val); err == nil {
+		if val == nil {
 			return nil, nil
 		}
-		if allowList {
-			return listVal, nil
-		}
-		if len(listVal) == 1 {
-			return listVal[0], nil
-		}
-		return nil, fmt.Errorf("list of values not allowed for type %T", listVal[0])
+		return *val, nil
 	}
-	if val == nil {
+	var listVal []T
+	if err := payload.Decode(value, &listVal); err != nil {
+		return nil, err
+	}
+	if len(listVal) == 0 {
 		return nil, nil
 	}
-	return *val, nil
+	if allowList {
+		return listVal, nil
+	}
+	if len(listVal) == 1 {
+		return listVal[0], nil
+	}
+	return nil, fmt.Errorf(
+		"%w: list of values not allowed for type %T",
+		converter.ErrUnableToDecode,
+		listVal[0],
+	)
+}
+
+func DecodeKeywordList(value *commonpb.Payload) ([]string, error) {
+	// Decode to []any because json.Unmarshal decodes null values to zero value,
+	// i.e., if we decoded to []string, null values would become empty string,
+	// which is invalid.
+	dv, err := decodeValueTyped[[]any](value, false)
+	if err != nil {
+		return nil, err
+	}
+	if dv == nil {
+		return nil, nil
+	}
+	// Validate that every value is a string.
+	tdv, ok := dv.([]any)
+	if !ok {
+		//nolint:forbidigo // this should never happen
+		panic(fmt.Sprintf("unexpected return type of decodeValueTyped (got: %T, expected: []any)", dv))
+	}
+	res := make([]string, len(tdv))
+	for i, v := range tdv {
+		switch vt := v.(type) {
+		case string:
+			res[i] = vt
+		default:
+			return nil, fmt.Errorf(
+				"%w: invalid item value type in KeywordList value (got: %T, expected: string)",
+				converter.ErrUnableToDecode,
+				dv,
+			)
+		}
+	}
+	return res, nil
 }

--- a/common/searchattribute/sadefs/encode_value_test.go
+++ b/common/searchattribute/sadefs/encode_value_test.go
@@ -2,351 +2,394 @@ package sadefs
 
 import (
 	"errors"
+	"fmt"
+	"math"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/server/common/payload"
 )
 
-func Test_DecodeValue_AllowList_FromMetadata_Success(t *testing.T) {
-	s := assert.New(t)
-	allowList := true
+func Test_DecodeValue_Success(t *testing.T) {
+	testCases := []struct {
+		name      string
+		value     any
+		valueType enumspb.IndexedValueType
+	}{
+		{
+			name:      "nil",
+			value:     nil,
+			valueType: enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		},
+		{
+			name:      "bool",
+			value:     true,
+			valueType: enumspb.INDEXED_VALUE_TYPE_BOOL,
+		},
+		{
+			name:      "datetime",
+			value:     time.Date(2026, 1, 2, 3, 4, 5, 6, time.UTC),
+			valueType: enumspb.INDEXED_VALUE_TYPE_DATETIME,
+		},
+		{
+			name:      "double",
+			value:     1.23,
+			valueType: enumspb.INDEXED_VALUE_TYPE_DOUBLE,
+		},
+		{
+			name:      "int",
+			value:     int64(123),
+			valueType: enumspb.INDEXED_VALUE_TYPE_INT,
+		},
+		{
+			name:      "keyword",
+			value:     "foo",
+			valueType: enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		},
+		{
+			name:      "keyword list",
+			value:     []string{"foo", "bar"},
+			valueType: enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
+		},
+		{
+			name:      "text",
+			value:     "foo bar",
+			valueType: enumspb.INDEXED_VALUE_TYPE_TEXT,
+		},
+	}
 
-	payloadStr := payload.EncodeString("qwe")
-	payloadStr.Metadata["type"] = []byte("Text")
-	decodedStr, err := DecodeValue(payloadStr, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, allowList) // MetadataType is used.
-	s.NoError(err)
-	s.Equal("qwe", decodedStr)
+	for _, tc := range testCases {
+		for _, setMetadata := range []bool{false, true} {
+			for _, allowList := range []bool{false, true} {
+				tcName := fmt.Sprintf("%s/setMetadata=%v/allowList=%v", tc.name, setMetadata, allowList)
+				t.Run(tcName, func(t *testing.T) {
+					encodedValue, err := payload.Encode(tc.value)
+					require.NoError(t, err)
+					valueType := tc.valueType
+					if setMetadata {
+						encodedValue.Metadata[MetadataType] = []byte(tc.valueType.String())
+						valueType = enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED
+					}
+					decodedValue, err := DecodeValue(encodedValue, valueType, allowList)
+					require.NoError(t, err)
+					require.Equal(t, tc.value, decodedValue)
+				})
+			}
+		}
+	}
 
-	payloadBool, err := payload.Encode(true)
-	s.NoError(err)
-	payloadBool.Metadata["type"] = []byte("Bool")
-	decodedBool, err := DecodeValue(payloadBool, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, allowList) // MetadataType is used.
-	s.NoError(err)
-	s.Equal(true, decodedBool)
-
-	payloadNil, err := payload.Encode(nil)
-	s.NoError(err)
-	payloadNil.Metadata["type"] = []byte("Double")
-	decodedNil, err := DecodeValue(payloadNil, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, allowList)
-	s.NoError(err)
-	s.Nil(decodedNil)
-
-	payloadSlice, err := payload.Encode([]string{"val1", "val2"})
-	s.NoError(err)
-	payloadSlice.Metadata["type"] = []byte("Keyword")
-	decodedSlice, err := DecodeValue(payloadSlice, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, allowList)
-	s.NoError(err)
-	s.Equal([]string{"val1", "val2"}, decodedSlice)
-
-	payloadEmptySlice, err := payload.Encode([]string{})
-	s.NoError(err)
-	payloadEmptySlice.Metadata["type"] = []byte("Keyword")
-	decodedNil, err = DecodeValue(payloadEmptySlice, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, allowList)
-	s.NoError(err)
-	s.Nil(decodedNil)
-
-	var expectedEncodedRepresentation = "2022-03-07T21:27:35.986848-05:00"
-	timeValue, err := time.Parse(time.RFC3339, expectedEncodedRepresentation)
-	s.NoError(err)
-	payloadDatetime, err := payload.Encode(timeValue)
-	s.NoError(err)
-	payloadDatetime.Metadata["type"] = []byte("Datetime")
-	decodedDatetime, err := DecodeValue(payloadDatetime, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, allowList)
-	s.NoError(err)
-	s.Equal(timeValue, decodedDatetime)
+	t.Run("from parameter ignore metadata", func(t *testing.T) {
+		value := int64(123)
+		encodedValue, err := payload.Encode(value)
+		require.NoError(t, err)
+		encodedValue.Metadata[MetadataType] = []byte("UnknownType") // MetadataType is not used.
+		decodedValue, err := DecodeValue(encodedValue, enumspb.INDEXED_VALUE_TYPE_INT, false)
+		require.NoError(t, err)
+		require.Equal(t, value, decodedValue)
+	})
 }
 
-func Test_DecodeValue_AllowList_FromParameter_Success(t *testing.T) {
-	s := assert.New(t)
-	allowList := true
+func Test_DecodeValue_AllowList_BackwardsCompatibility(t *testing.T) {
+	t.Run("list of int", func(t *testing.T) {
+		value := []int64{123, 456}
+		encodedValue, err := payload.Encode(value)
+		require.NoError(t, err)
+		decodedValue, err := DecodeValue(encodedValue, enumspb.INDEXED_VALUE_TYPE_INT, true)
+		require.NoError(t, err)
+		require.Equal(t, value, decodedValue)
+	})
 
-	payloadStr := payload.EncodeString("qwe")
-	decodedStr, err := DecodeValue(payloadStr, enumspb.INDEXED_VALUE_TYPE_TEXT, allowList)
-	s.NoError(err)
-	s.Equal("qwe", decodedStr)
+	t.Run("list of keyword", func(t *testing.T) {
+		value := []string{"foo", "bar"}
+		encodedValue, err := payload.Encode(value)
+		require.NoError(t, err)
+		decodedValue, err := DecodeValue(encodedValue, enumspb.INDEXED_VALUE_TYPE_KEYWORD, true)
+		require.NoError(t, err)
+		require.Equal(t, value, decodedValue)
+	})
 
-	payloadInt, err := payload.Encode(123)
-	s.NoError(err)
-	decodedInt, err := DecodeValue(payloadInt, enumspb.INDEXED_VALUE_TYPE_INT, allowList)
-	s.NoError(err)
-	s.Equal(int64(123), decodedInt)
+	t.Run("empty list", func(t *testing.T) {
+		value := []string{}
+		encodedValue, err := payload.Encode(value)
+		require.NoError(t, err)
+		decodedValue, err := DecodeValue(encodedValue, enumspb.INDEXED_VALUE_TYPE_KEYWORD, true)
+		require.NoError(t, err)
+		require.Nil(t, decodedValue)
+	})
 
-	payloadNil, err := payload.Encode(nil)
-	s.NoError(err)
-	decodedNil, err := DecodeValue(payloadNil, enumspb.INDEXED_VALUE_TYPE_DOUBLE, allowList)
-	s.NoError(err)
-	s.Nil(decodedNil)
+	t.Run("list with single value allowing list", func(t *testing.T) {
+		value := []string{"foo"}
+		encodedValue, err := payload.Encode(value)
+		require.NoError(t, err)
+		decodedValue, err := DecodeValue(encodedValue, enumspb.INDEXED_VALUE_TYPE_KEYWORD, true)
+		require.NoError(t, err)
+		require.Equal(t, value, decodedValue)
+	})
 
-	payloadSlice, err := payload.Encode([]string{"val1", "val2"})
-	s.NoError(err)
-	decodedSlice, err := DecodeValue(payloadSlice, enumspb.INDEXED_VALUE_TYPE_KEYWORD, allowList)
-	s.NoError(err)
-	s.Equal([]string{"val1", "val2"}, decodedSlice)
-
-	payloadEmptySlice, err := payload.Encode([]string{})
-	s.NoError(err)
-	decodedNil, err = DecodeValue(payloadEmptySlice, enumspb.INDEXED_VALUE_TYPE_KEYWORD, allowList)
-	s.NoError(err)
-	s.Nil(decodedNil)
-
-	var expectedEncodedRepresentation = "2022-03-07T21:27:35.986848-05:00"
-	timeValue, err := time.Parse(time.RFC3339, expectedEncodedRepresentation)
-	s.NoError(err)
-	payloadDatetime, err := payload.Encode(timeValue)
-	s.NoError(err)
-	decodedDatetime, err := DecodeValue(payloadDatetime, enumspb.INDEXED_VALUE_TYPE_DATETIME, allowList)
-	s.NoError(err)
-	s.Equal(timeValue, decodedDatetime)
-
-	payloadInt, err = payload.Encode(123)
-	s.NoError(err)
-	payloadInt.Metadata["type"] = []byte("String") // MetadataType is not used.
-	decodedInt, err = DecodeValue(payloadInt, enumspb.INDEXED_VALUE_TYPE_INT, allowList)
-	s.NoError(err)
-	s.Equal(int64(123), decodedInt)
-
-	payloadInt, err = payload.Encode(123)
-	s.NoError(err)
-	payloadInt.Metadata["type"] = []byte("UnknownType") // MetadataType is not used.
-	decodedInt, err = DecodeValue(payloadInt, enumspb.INDEXED_VALUE_TYPE_INT, allowList)
-	s.NoError(err)
-	s.Equal(int64(123), decodedInt)
-
-	payloadBool, err := payload.Encode(true)
-	s.NoError(err)
-	decodedBool, err := DecodeValue(payloadBool, enumspb.INDEXED_VALUE_TYPE_BOOL, allowList)
-	s.NoError(err)
-	s.Equal(true, decodedBool)
+	t.Run("list with single value not allowing list", func(t *testing.T) {
+		value := []string{"foo"}
+		encodedValue, err := payload.Encode(value)
+		require.NoError(t, err)
+		decodedValue, err := DecodeValue(encodedValue, enumspb.INDEXED_VALUE_TYPE_KEYWORD, false)
+		require.NoError(t, err)
+		require.Equal(t, "foo", decodedValue)
+	})
 }
 
-func Test_DecodeValue_AllowList_Error(t *testing.T) {
-	s := assert.New(t)
-	allowList := true
+func Test_DecodeValue_Error(t *testing.T) {
+	t.Run("no value type set", func(t *testing.T) {
+		value := int64(123)
+		encodedValue, err := payload.Encode(value)
+		require.NoError(t, err)
+		_, err = DecodeValue(encodedValue, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, false)
+		require.ErrorIs(t, err, ErrInvalidType)
+	})
 
-	payloadStr := payload.EncodeString("qwe")
-	decodedStr, err := DecodeValue(payloadStr, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, allowList)
-	s.Error(err)
-	s.ErrorIs(err, ErrInvalidType)
-	s.Nil(decodedStr)
+	t.Run("invalid metadata type", func(t *testing.T) {
+		value := int64(123)
+		encodedValue, err := payload.Encode(value)
+		encodedValue.Metadata[MetadataType] = []byte("UnknownType")
+		require.NoError(t, err)
+		_, err = DecodeValue(encodedValue, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, false)
+		require.ErrorIs(t, err, ErrInvalidType)
+	})
 
-	payloadInt, err := payload.Encode(123)
-	s.NoError(err)
-	payloadInt.Metadata["type"] = []byte("UnknownType")
-	decodedInt, err := DecodeValue(payloadInt, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, allowList)
-	s.Error(err)
-	s.ErrorIs(err, ErrInvalidType)
-	s.Nil(decodedInt)
+	t.Run("unknown value type", func(t *testing.T) {
+		value := int64(123)
+		encodedValue, err := payload.Encode(value)
+		require.NoError(t, err)
+		_, err = DecodeValue(encodedValue, enumspb.IndexedValueType(999), false)
+		require.ErrorIs(t, err, ErrInvalidType)
+	})
 
-	payloadInt, err = payload.Encode(123)
-	s.NoError(err)
-	payloadInt.Metadata["type"] = []byte("Text")
-	decodedInt, err = DecodeValue(payloadInt, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, allowList)
-	s.Error(err)
-	s.ErrorIs(err, converter.ErrUnableToDecode, err.Error())
-	s.Nil(decodedInt)
+	t.Run("incorrect metadata type", func(t *testing.T) {
+		value := int64(123)
+		encodedValue, err := payload.Encode(value)
+		encodedValue.Metadata[MetadataType] = []byte("Keyword")
+		require.NoError(t, err)
+		_, err = DecodeValue(encodedValue, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, false)
+		require.ErrorIs(t, err, converter.ErrUnableToDecode)
+	})
+
+	t.Run("incorrect input type", func(t *testing.T) {
+		value := int64(123)
+		encodedValue, err := payload.Encode(value)
+		require.NoError(t, err)
+		_, err = DecodeValue(encodedValue, enumspb.INDEXED_VALUE_TYPE_KEYWORD, false)
+		require.ErrorIs(t, err, converter.ErrUnableToDecode)
+	})
+
+	t.Run("incorrect input type with correct metadata type", func(t *testing.T) {
+		value := int64(123)
+		encodedValue, err := payload.Encode(value)
+		encodedValue.Metadata[MetadataType] = []byte("Int")
+		require.NoError(t, err)
+		_, err = DecodeValue(encodedValue, enumspb.INDEXED_VALUE_TYPE_KEYWORD, false)
+		require.ErrorIs(t, err, converter.ErrUnableToDecode)
+	})
+
+	t.Run("list not allowed", func(t *testing.T) {
+		value := []int64{123, 456}
+		encodedValue, err := payload.Encode(value)
+		require.NoError(t, err)
+		_, err = DecodeValue(encodedValue, enumspb.INDEXED_VALUE_TYPE_INT, false)
+		require.ErrorIs(t, err, converter.ErrUnableToDecode)
+	})
+
+	t.Run("single value invalid for KeywordList", func(t *testing.T) {
+		value := "foo"
+		encodedValue, err := payload.Encode(value)
+		require.NoError(t, err)
+		_, err = DecodeValue(encodedValue, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, true)
+		require.ErrorIs(t, err, converter.ErrUnableToDecode)
+	})
+
+	t.Run("list of KeywordList never allowed", func(t *testing.T) {
+		value := [][]string{{"foo", "bar"}, {"asdf", "qwer"}}
+		encodedValue, err := payload.Encode(value)
+		require.NoError(t, err)
+		_, err = DecodeValue(encodedValue, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, true)
+		require.ErrorIs(t, err, converter.ErrUnableToDecode)
+	})
+
+	// TODO(rodrigozhou): test disabled as it an existing bug
+	// t.Run("nil value not allowed in KeywordList", func(t *testing.T) {
+	// 	value := []any{nil}
+	// 	encodedValue, err := payload.Encode(value)
+	// 	require.NoError(t, err)
+	// 	_, err = DecodeValue(encodedValue, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, true)
+	// 	require.ErrorIs(t, err, converter.ErrUnableToDecode)
+	// })
 }
 
-func Test_DecodeValue_NotAllowList_FromMetadata_Success(t *testing.T) {
-	s := assert.New(t)
-	allowList := false
+func Test_DecodeKeywordList(t *testing.T) {
+	t.Run("nil payload", func(t *testing.T) {
+		encodedValue, err := payload.Encode(nil)
+		require.NoError(t, err)
+		decodedValue, err := DecodeKeywordList(encodedValue)
+		require.NoError(t, err)
+		require.Nil(t, decodedValue)
+	})
 
-	payloadStr := payload.EncodeString("qwe")
-	payloadStr.Metadata["type"] = []byte("Text")
-	decodedStr, err := DecodeValue(payloadStr, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, allowList)
-	s.NoError(err)
-	s.Equal("qwe", decodedStr)
+	t.Run("list of strings", func(t *testing.T) {
+		value := []string{"foo", "bar"}
+		encodedValue, err := payload.Encode(value)
+		require.NoError(t, err)
+		decodedValue, err := DecodeKeywordList(encodedValue)
+		require.NoError(t, err)
+		require.Equal(t, value, decodedValue)
+	})
 
-	payloadBool, err := payload.Encode(true)
-	s.NoError(err)
-	payloadBool.Metadata["type"] = []byte("Bool")
-	decodedBool, err := DecodeValue(payloadBool, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, allowList)
-	s.NoError(err)
-	s.Equal(true, decodedBool)
+	t.Run("list with single value", func(t *testing.T) {
+		value := []string{"foo"}
+		encodedValue, err := payload.Encode(value)
+		require.NoError(t, err)
+		decodedValue, err := DecodeKeywordList(encodedValue)
+		require.NoError(t, err)
+		require.Equal(t, value, decodedValue)
+	})
 
-	payloadNil, err := payload.Encode(nil)
-	s.NoError(err)
-	payloadNil.Metadata["type"] = []byte("Double")
-	decodedNil, err := DecodeValue(payloadNil, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, allowList)
-	s.NoError(err)
-	s.Nil(decodedNil)
+	t.Run("empty list", func(t *testing.T) {
+		value := []string{}
+		encodedValue, err := payload.Encode(value)
+		require.NoError(t, err)
+		decodedValue, err := DecodeKeywordList(encodedValue)
+		require.NoError(t, err)
+		require.Equal(t, value, decodedValue)
+	})
 
-	payloadKeyword, err := payload.Encode([]string{"Keyword"})
-	s.NoError(err)
-	payloadKeyword.Metadata["type"] = []byte("Keyword")
-	decodedKeyword, err := DecodeValue(payloadKeyword, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, allowList)
-	s.NoError(err)
-	s.Equal("Keyword", decodedKeyword)
+	t.Run("error: nil value in list", func(t *testing.T) {
+		value := []any{"foo", nil}
+		encodedValue, err := payload.Encode(value)
+		require.NoError(t, err)
+		_, err = DecodeKeywordList(encodedValue)
+		require.ErrorIs(t, err, converter.ErrUnableToDecode)
+	})
 
-	payloadSlice, err := payload.Encode([]string{"val1", "val2"})
-	s.NoError(err)
-	payloadSlice.Metadata["type"] = []byte("KeywordList")
-	decodedSlice, err := DecodeValue(payloadSlice, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, allowList)
-	s.NoError(err)
-	s.Equal([]string{"val1", "val2"}, decodedSlice)
+	t.Run("error: non-string value in list", func(t *testing.T) {
+		value := []any{"foo", 123}
+		encodedValue, err := payload.Encode(value)
+		require.NoError(t, err)
+		_, err = DecodeKeywordList(encodedValue)
+		require.ErrorIs(t, err, converter.ErrUnableToDecode)
+	})
 
-	payloadEmptySlice, err := payload.Encode([]string{})
-	s.NoError(err)
-	payloadEmptySlice.Metadata["type"] = []byte("Keyword")
-	decodedNil, err = DecodeValue(payloadEmptySlice, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, allowList)
-	s.NoError(err)
-	s.Nil(decodedNil)
+	t.Run("error: not a list", func(t *testing.T) {
+		value := "foo"
+		encodedValue, err := payload.Encode(value)
+		require.NoError(t, err)
+		_, err = DecodeKeywordList(encodedValue)
+		require.ErrorIs(t, err, converter.ErrUnableToDecode)
+	})
 
-	var expectedEncodedRepresentation = "2022-03-07T21:27:35.986848-05:00"
-	timeValue, err := time.Parse(time.RFC3339, expectedEncodedRepresentation)
-	s.NoError(err)
-	payloadDatetime, err := payload.Encode(timeValue)
-	s.NoError(err)
-	payloadDatetime.Metadata["type"] = []byte("Datetime")
-	decodedDatetime, err := DecodeValue(payloadDatetime, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, allowList)
-	s.NoError(err)
-	s.Equal(timeValue, decodedDatetime)
-}
-
-func Test_DecodeValue_NotAllowList_FromParameter_Success(t *testing.T) {
-	s := assert.New(t)
-	allowList := false
-
-	payloadStr := payload.EncodeString("qwe")
-	decodedStr, err := DecodeValue(payloadStr, enumspb.INDEXED_VALUE_TYPE_TEXT, allowList)
-	s.NoError(err)
-	s.Equal("qwe", decodedStr)
-
-	payloadInt, err := payload.Encode(123)
-	s.NoError(err)
-	decodedInt, err := DecodeValue(payloadInt, enumspb.INDEXED_VALUE_TYPE_INT, allowList)
-	s.NoError(err)
-	s.Equal(int64(123), decodedInt)
-
-	payloadNil, err := payload.Encode(nil)
-	s.NoError(err)
-	decodedNil, err := DecodeValue(payloadNil, enumspb.INDEXED_VALUE_TYPE_DOUBLE, allowList)
-	s.NoError(err)
-	s.Nil(decodedNil)
-
-	payloadKeyword, err := payload.Encode([]string{"Keyword"})
-	s.NoError(err)
-	decodedKeyword, err := DecodeValue(payloadKeyword, enumspb.INDEXED_VALUE_TYPE_KEYWORD, allowList)
-	s.NoError(err)
-	s.Equal("Keyword", decodedKeyword)
-
-	payloadSlice, err := payload.Encode([]string{"val1", "val2"})
-	s.NoError(err)
-	decodedSlice, err := DecodeValue(payloadSlice, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, allowList)
-	s.NoError(err)
-	s.Equal([]string{"val1", "val2"}, decodedSlice)
-
-	payloadEmptySlice, err := payload.Encode([]string{})
-	s.NoError(err)
-	decodedNil, err = DecodeValue(payloadEmptySlice, enumspb.INDEXED_VALUE_TYPE_KEYWORD, allowList)
-	s.NoError(err)
-	s.Nil(decodedNil)
-
-	var expectedEncodedRepresentation = "2022-03-07T21:27:35.986848-05:00"
-	timeValue, err := time.Parse(time.RFC3339, expectedEncodedRepresentation)
-	s.NoError(err)
-	payloadDatetime, err := payload.Encode(timeValue)
-	s.NoError(err)
-	decodedDatetime, err := DecodeValue(payloadDatetime, enumspb.INDEXED_VALUE_TYPE_DATETIME, allowList)
-	s.NoError(err)
-	s.Equal(timeValue, decodedDatetime)
-
-	payloadInt, err = payload.Encode(123)
-	s.NoError(err)
-	payloadInt.Metadata["type"] = []byte("String") // MetadataType is not used.
-	decodedInt, err = DecodeValue(payloadInt, enumspb.INDEXED_VALUE_TYPE_INT, allowList)
-	s.NoError(err)
-	s.Equal(int64(123), decodedInt)
-
-	payloadInt, err = payload.Encode(123)
-	s.NoError(err)
-	payloadInt.Metadata["type"] = []byte("UnknownType") // MetadataType is not used.
-	decodedInt, err = DecodeValue(payloadInt, enumspb.INDEXED_VALUE_TYPE_INT, allowList)
-	s.NoError(err)
-	s.Equal(int64(123), decodedInt)
-
-	payloadBool, err := payload.Encode(true)
-	s.NoError(err)
-	decodedBool, err := DecodeValue(payloadBool, enumspb.INDEXED_VALUE_TYPE_BOOL, allowList)
-	s.NoError(err)
-	s.Equal(true, decodedBool)
-}
-
-func Test_DecodeValue_NotAllowList_Error(t *testing.T) {
-	s := assert.New(t)
-	allowList := false
-
-	payloadStr := payload.EncodeString("qwe")
-	decodedStr, err := DecodeValue(payloadStr, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, allowList)
-	s.Error(err)
-	s.ErrorIs(err, ErrInvalidType)
-	s.Nil(decodedStr)
-
-	payloadInt, err := payload.Encode(123)
-	s.NoError(err)
-	payloadInt.Metadata["type"] = []byte("UnknownType")
-	decodedInt, err := DecodeValue(payloadInt, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, allowList)
-	s.Error(err)
-	s.ErrorIs(err, ErrInvalidType)
-	s.Nil(decodedInt)
-
-	payloadInt, err = payload.Encode(123)
-	s.NoError(err)
-	payloadInt.Metadata["type"] = []byte("Text")
-	decodedInt, err = DecodeValue(payloadInt, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, allowList)
-	s.Error(err)
-	s.ErrorIs(err, converter.ErrUnableToDecode, err.Error())
-	s.Nil(decodedInt)
-
-	payloadSlice, err := payload.Encode([]string{"val1", "val2"})
-	s.NoError(err)
-	decodedSlice, err := DecodeValue(payloadSlice, enumspb.INDEXED_VALUE_TYPE_KEYWORD, allowList)
-	s.Error(err)
-	s.Nil(decodedSlice)
+	t.Run("error: list of lists", func(t *testing.T) {
+		value := [][]string{{"foo", "bar"}, {"asdf", "qwer"}}
+		encodedValue, err := payload.Encode(value)
+		require.NoError(t, err)
+		_, err = DecodeKeywordList(encodedValue)
+		require.ErrorIs(t, err, converter.ErrUnableToDecode)
+	})
 }
 
 func Test_EncodeValue(t *testing.T) {
-	s := assert.New(t)
+	testCases := []struct {
+		name             string
+		value            any
+		valueType        enumspb.IndexedValueType
+		expectedData     []byte
+		expectedEncoding string
+	}{
+		{
+			name:             "nil",
+			value:            nil,
+			valueType:        enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			expectedData:     nil,
+			expectedEncoding: "binary/null",
+		},
+		{
+			name:             "bool",
+			value:            true,
+			valueType:        enumspb.INDEXED_VALUE_TYPE_BOOL,
+			expectedData:     []byte("true"),
+			expectedEncoding: "json/plain",
+		},
+		{
+			name:             "datetime",
+			value:            time.Date(2026, 1, 2, 3, 4, 5, 6, time.UTC),
+			valueType:        enumspb.INDEXED_VALUE_TYPE_DATETIME,
+			expectedData:     []byte(`"2026-01-02T03:04:05.000000006Z"`),
+			expectedEncoding: "json/plain",
+		},
+		{
+			name:             "double",
+			value:            1.23,
+			valueType:        enumspb.INDEXED_VALUE_TYPE_DOUBLE,
+			expectedData:     []byte("1.23"),
+			expectedEncoding: "json/plain",
+		},
+		{
+			name:             "int",
+			value:            int64(123),
+			valueType:        enumspb.INDEXED_VALUE_TYPE_INT,
+			expectedData:     []byte("123"),
+			expectedEncoding: "json/plain",
+		},
+		{
+			name:             "keyword",
+			value:            "foo",
+			valueType:        enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			expectedData:     []byte(`"foo"`),
+			expectedEncoding: "json/plain",
+		},
+		{
+			name:             "keyword list",
+			value:            []string{"foo", "bar"},
+			valueType:        enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
+			expectedData:     []byte(`["foo","bar"]`),
+			expectedEncoding: "json/plain",
+		},
+		{
+			name:             "text",
+			value:            "foo bar",
+			valueType:        enumspb.INDEXED_VALUE_TYPE_TEXT,
+			expectedData:     []byte(`"foo bar"`),
+			expectedEncoding: "json/plain",
+		},
+	}
 
-	encodedPayload, err := EncodeValue(123, enumspb.INDEXED_VALUE_TYPE_INT)
-	s.NoError(err)
-	s.Equal("123", string(encodedPayload.GetData()))
-	s.Equal("Int", string(encodedPayload.Metadata["type"]))
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			encodedValue, err := EncodeValue(tc.value, tc.valueType)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedData, encodedValue.Data)
+			require.Equal(t, tc.expectedEncoding, string(encodedValue.Metadata[converter.MetadataEncoding]))
+			require.Equal(t, tc.valueType.String(), string(encodedValue.Metadata[MetadataType]))
+		})
+	}
 
-	encodedPayload, err = EncodeValue("qwe", enumspb.INDEXED_VALUE_TYPE_TEXT)
-	s.NoError(err)
-	s.Equal(`"qwe"`, string(encodedPayload.GetData()))
-	s.Equal("Text", string(encodedPayload.Metadata["type"]))
+	t.Run("error", func(t *testing.T) {
+		_, err := EncodeValue(math.Inf(1), enumspb.INDEXED_VALUE_TYPE_DOUBLE)
+		require.Error(t, err)
+	})
+}
 
-	encodedPayload, err = EncodeValue(nil, enumspb.INDEXED_VALUE_TYPE_DOUBLE)
-	s.NoError(err)
-	s.Equal("", string(encodedPayload.GetData()))
-	s.Equal("Double", string(encodedPayload.Metadata["type"]))
-	s.Equal("binary/null", string(encodedPayload.Metadata["encoding"]))
+func Test_MustEncodeValue(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		_ = MustEncodeValue("foo", enumspb.INDEXED_VALUE_TYPE_KEYWORD)
+	})
 
-	encodedPayload, err = EncodeValue([]string{"val1", "val2"}, enumspb.INDEXED_VALUE_TYPE_KEYWORD)
-	s.NoError(err)
-	s.Equal(`["val1","val2"]`, string(encodedPayload.GetData()))
-	s.Equal("Keyword", string(encodedPayload.Metadata["type"]))
-	s.Equal("json/plain", string(encodedPayload.Metadata["encoding"]))
-
-	encodedPayload, err = EncodeValue([]string{}, enumspb.INDEXED_VALUE_TYPE_KEYWORD)
-	s.NoError(err)
-	s.Equal("[]", string(encodedPayload.GetData()))
-	s.Equal("Keyword", string(encodedPayload.Metadata["type"]))
-	s.Equal("json/plain", string(encodedPayload.Metadata["encoding"]))
-
-	var expectedEncodedRepresentation = "2022-03-07T21:27:35.986848-05:00"
-	timeValue, err := time.Parse(time.RFC3339, expectedEncodedRepresentation)
-	s.NoError(err)
-	encodedPayload, err = EncodeValue(timeValue, enumspb.INDEXED_VALUE_TYPE_DATETIME)
-	s.NoError(err)
-	s.Equal(`"`+expectedEncodedRepresentation+`"`, string(encodedPayload.GetData()),
-		"Datetime Search Attribute is expected to be encoded in RFC 3339 format")
-	s.Equal("Datetime", string(encodedPayload.Metadata["type"]))
+	t.Run("panic", func(t *testing.T) {
+		defer func() {
+			err := recover()
+			require.NotNil(t, err)
+		}()
+		_ = MustEncodeValue(math.Inf(1), enumspb.INDEXED_VALUE_TYPE_DOUBLE)
+		require.Fail(t, "MustEncodeValue did not panic with invalid value")
+	})
 }
 
 func Test_ValidateStrings(t *testing.T) {

--- a/common/searchattribute/validator.go
+++ b/common/searchattribute/validator.go
@@ -5,12 +5,20 @@ import (
 	"fmt"
 
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/searchattribute/sadefs"
+)
+
+var acceptedInvalidValueKeywordList = metrics.NewCounterDef(
+	"visibility_accepted_invalid_value_keywordlist",
 )
 
 type (
@@ -29,6 +37,9 @@ type (
 		// suppressErrorSetSystemSearchAttribute suppresses errors when the user
 		// attempts to set values in system search attributes.
 		suppressErrorSetSystemSearchAttribute dynamicconfig.BoolPropertyFnWithNamespaceFilter
+
+		metricsHandler metrics.Handler
+		logger         log.Logger
 	}
 )
 
@@ -42,6 +53,8 @@ func NewValidator(
 	visibilityManager manager.VisibilityManager,
 	allowList dynamicconfig.BoolPropertyFnWithNamespaceFilter,
 	suppressErrorSetSystemSearchAttribute dynamicconfig.BoolPropertyFnWithNamespaceFilter,
+	metricsHandler metrics.Handler,
+	logger log.Logger,
 ) *Validator {
 	return &Validator{
 		searchAttributesProvider:              searchAttributesProvider,
@@ -52,6 +65,9 @@ func NewValidator(
 		visibilityManager:                     visibilityManager,
 		allowList:                             allowList,
 		suppressErrorSetSystemSearchAttribute: suppressErrorSetSystemSearchAttribute,
+
+		metricsHandler: metricsHandler,
+		logger:         logger,
 	}
 }
 
@@ -104,22 +120,21 @@ func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namesp
 				)
 			}
 			return v.validationError(
-				fmt.Sprintf("unable to get %s search attribute type: %v", "%s", err),
+				fmt.Sprintf("unable to get %%s search attribute type: %v", err),
 				saFieldName,
 				namespace,
 			)
 		}
 
 		// Don't allow those SA's that are in predefined but not in predefinedWhiteList to be set by a user
-		predefined := sadefs.Predefined()
 		if _, ok := predefined[saFieldName]; ok {
-			predefinedWhiteList := sadefs.PredefinedWhiteList()
 			if _, ok = predefinedWhiteList[saFieldName]; !ok {
 				return serviceerror.NewInvalidArgumentf(
 					"%s attribute can't be set in SearchAttributes", saFieldName,
 				)
 			}
 		}
+
 		saValue, err := sadefs.DecodeValue(saPayload, saType, v.allowList(namespace))
 		if err != nil {
 			var invalidValue any
@@ -128,8 +143,7 @@ func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namesp
 			}
 			return v.validationError(
 				fmt.Sprintf(
-					"invalid value for search attribute %s of type %s: %v",
-					"%s",
+					"invalid value for search attribute %%s of type %s: %v",
 					saType,
 					invalidValue,
 				),
@@ -137,6 +151,30 @@ func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namesp
 				namespace,
 			)
 		}
+
+		// Log occurrences of invalid values for KeywordList search attribute being accepted.
+		// Eg: [nil] is decoded successfully in sadefs.DecodeValue.
+		if saType == enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST {
+			_, err := sadefs.DecodeKeywordList(saPayload)
+			if err != nil {
+				var invalidValue any
+				if err = payload.Decode(saPayload, &invalidValue); err != nil {
+					invalidValue = fmt.Sprintf("value from <%s>", saPayload.String())
+				}
+				err = v.validationError(
+					fmt.Sprintf(
+						"invalid value for search attribute %%s of type %s: %v",
+						saType,
+						invalidValue,
+					),
+					saFieldName,
+					namespace,
+				)
+				acceptedInvalidValueKeywordList.With(v.metricsHandler).Record(1, metrics.NamespaceTag(namespace))
+				v.logger.Warn("invalid KeywordList value decoded successfully", tag.Error(err))
+			}
+		}
+
 		saMap[saFieldName] = saValue
 	}
 	_, err = v.visibilityManager.ValidateCustomSearchAttributes(saMap)

--- a/common/searchattribute/validator_test.go
+++ b/common/searchattribute/validator_test.go
@@ -6,7 +6,10 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/searchattribute/sadefs"
@@ -16,13 +19,19 @@ import (
 type searchAttributesValidatorSuite struct {
 	suite.Suite
 
+	ctrl *gomock.Controller
+
 	mockVisibilityManager *manager.MockVisibilityManager
+	mockMetricsHandler    *metrics.MockHandler
 }
 
 func TestSearchAttributesValidatorSuite(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := &searchAttributesValidatorSuite{
+		ctrl: ctrl,
+
 		mockVisibilityManager: manager.NewMockVisibilityManager(ctrl),
+		mockMetricsHandler:    metrics.NewMockHandler(ctrl),
 	}
 	s.mockVisibilityManager.EXPECT().GetIndexName().Return("").AnyTimes()
 	s.mockVisibilityManager.EXPECT().
@@ -36,20 +45,36 @@ func TestSearchAttributesValidatorSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
-func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate() {
+func (s *searchAttributesValidatorSuite) newValidator(
+	searchAttributesProvider Provider,
+	searchAttributesMapperProvider MapperProvider,
+	allowList bool,
+	suppressErrorSetSystemSearchAttribute bool,
+) *Validator {
 	numOfKeysLimit := 2
 	sizeOfValueLimit := 5
 	sizeOfTotalLimit := 20
 
-	saValidator := NewValidator(
-		NewTestProvider(),
-		NewTestMapperProvider(nil),
+	return NewValidator(
+		searchAttributesProvider,
+		searchAttributesMapperProvider,
 		dynamicconfig.GetIntPropertyFnFilteredByNamespace(numOfKeysLimit),
 		dynamicconfig.GetIntPropertyFnFilteredByNamespace(sizeOfValueLimit),
 		dynamicconfig.GetIntPropertyFnFilteredByNamespace(sizeOfTotalLimit),
 		s.mockVisibilityManager,
-		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
-		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(allowList),
+		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(suppressErrorSetSystemSearchAttribute),
+		s.mockMetricsHandler,
+		log.NewNoopLogger(),
+	)
+}
+
+func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate() {
+	saValidator := s.newValidator(
+		NewTestProvider(),
+		NewTestMapperProvider(nil),
+		true,
+		false,
 	)
 
 	namespace := "namespace"
@@ -131,20 +156,35 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate() {
 	}
 }
 
-func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_SuppressError() {
-	numOfKeysLimit := 2
-	sizeOfValueLimit := 5
-	sizeOfTotalLimit := 20
-
-	saValidator := NewValidator(
+func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_EmitAcceptedInvalidValueKeywordList() {
+	saValidator := s.newValidator(
 		NewTestProvider(),
 		NewTestMapperProvider(nil),
-		dynamicconfig.GetIntPropertyFnFilteredByNamespace(numOfKeysLimit),
-		dynamicconfig.GetIntPropertyFnFilteredByNamespace(sizeOfValueLimit),
-		dynamicconfig.GetIntPropertyFnFilteredByNamespace(sizeOfTotalLimit),
-		s.mockVisibilityManager,
-		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
-		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
+		false,
+		false,
+	)
+
+	namespace := "namespace"
+	attr := &commonpb.SearchAttributes{
+		IndexedFields: map[string]*commonpb.Payload{
+			"KeywordList01": sadefs.MustEncodeValue([]any{nil}, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST),
+		},
+	}
+
+	mockCounter := metrics.NewMockCounterIface(s.ctrl)
+	mockCounter.EXPECT().Record(int64(1), metrics.NamespaceTag(namespace))
+	s.mockMetricsHandler.EXPECT().Counter(acceptedInvalidValueKeywordList.Name()).Return(mockCounter)
+
+	err := saValidator.Validate(attr, namespace)
+	s.NoError(err)
+}
+
+func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_SuppressError() {
+	saValidator := s.newValidator(
+		NewTestProvider(),
+		NewTestMapperProvider(nil),
+		false,
+		true,
 	)
 
 	namespace := "namespace"
@@ -159,19 +199,11 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_SuppressEr
 }
 
 func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_Mapper() {
-	numOfKeysLimit := 2
-	sizeOfValueLimit := 5
-	sizeOfTotalLimit := 20
-
-	saValidator := NewValidator(
+	saValidator := s.newValidator(
 		NewTestProvider(),
 		NewTestMapperProvider(&TestMapper{}),
-		dynamicconfig.GetIntPropertyFnFilteredByNamespace(numOfKeysLimit),
-		dynamicconfig.GetIntPropertyFnFilteredByNamespace(sizeOfValueLimit),
-		dynamicconfig.GetIntPropertyFnFilteredByNamespace(sizeOfTotalLimit),
-		s.mockVisibilityManager,
-		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
-		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+		false,
+		false,
 	)
 
 	namespace := "test-namespace"
@@ -223,19 +255,11 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_Mapper() {
 }
 
 func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize() {
-	numOfKeysLimit := 2
-	sizeOfValueLimit := 5
-	sizeOfTotalLimit := 20
-
-	saValidator := NewValidator(
+	saValidator := s.newValidator(
 		NewTestProvider(),
 		NewTestMapperProvider(nil),
-		dynamicconfig.GetIntPropertyFnFilteredByNamespace(numOfKeysLimit),
-		dynamicconfig.GetIntPropertyFnFilteredByNamespace(sizeOfValueLimit),
-		dynamicconfig.GetIntPropertyFnFilteredByNamespace(sizeOfTotalLimit),
-		s.mockVisibilityManager,
-		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
-		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+		false,
+		false,
 	)
 
 	namespace := "namespace"
@@ -263,19 +287,11 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize() {
 }
 
 func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize_Mapper() {
-	numOfKeysLimit := 2
-	sizeOfValueLimit := 5
-	sizeOfTotalLimit := 20
-
-	saValidator := NewValidator(
+	saValidator := s.newValidator(
 		NewTestProvider(),
 		NewTestMapperProvider(&TestMapper{}),
-		dynamicconfig.GetIntPropertyFnFilteredByNamespace(numOfKeysLimit),
-		dynamicconfig.GetIntPropertyFnFilteredByNamespace(sizeOfValueLimit),
-		dynamicconfig.GetIntPropertyFnFilteredByNamespace(sizeOfTotalLimit),
-		s.mockVisibilityManager,
-		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
-		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+		false,
+		false,
 	)
 
 	namespace := "test-namespace"

--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -220,6 +220,8 @@ func NewAdminHandler(
 				args.Config.VisibilityAllowList,
 			),
 			args.Config.SuppressErrorSetSystemSearchAttribute,
+			args.MetricsHandler,
+			args.Logger,
 		),
 		clusterMetadata:      args.ClusterMetadata,
 		healthServer:         args.HealthServer,

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -48,6 +48,7 @@ import (
 	dc "go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
@@ -195,6 +196,8 @@ func (s *WorkflowHandlerSuite) getWorkflowHandler(config *Config) *WorkflowHandl
 			config.VisibilityAllowList,
 		),
 		config.SuppressErrorSetSystemSearchAttribute,
+		metrics.NoopMetricsHandler,
+		log.NewNoopLogger(),
 	)
 	return NewWorkflowHandler(
 		cbValidator,

--- a/service/history/api/command_attr_validator_test.go
+++ b/service/history/api/command_attr_validator_test.go
@@ -17,6 +17,8 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/persistence/visibility/manager"
@@ -120,6 +122,8 @@ func (s *commandAttrValidatorSuite) SetupTest() {
 			s.mockVisibilityManager,
 			dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
 			dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+			metrics.NoopMetricsHandler,
+			log.NewNoopLogger(),
 		))
 }
 

--- a/service/history/history_engine.go
+++ b/service/history/history_engine.go
@@ -310,6 +310,8 @@ func NewEngineWithShardContext(
 			config.VisibilityAllowList,
 		),
 		config.SuppressErrorSetSystemSearchAttribute,
+		shard.GetMetricsHandler(),
+		logger,
 	)
 
 	historyEngImpl.replicationDLQHandler = replication.NewLazyDLQHandler(

--- a/service/history/history_engine2_test.go
+++ b/service/history/history_engine2_test.go
@@ -219,6 +219,8 @@ func (s *engine2Suite) SetupTest() {
 			s.mockVisibilityManager,
 			dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
 			dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+			metrics.NoopMetricsHandler,
+			log.NewNoopLogger(),
 		),
 		workflowConsistencyChecker: api.NewWorkflowConsistencyChecker(mockShard, s.workflowCache),
 		persistenceVisibilityMgr:   s.mockVisibilityManager,


### PR DESCRIPTION
## What changed?
Add metric to track invalid usage of `KeywordList` value.

## Why?
The payload decoder uses `json.Unmarshal` to decode `KeywordList` value to `[]string`, and it decodes without error values such as `[]any{nil}` to `[]string{""}`. This leads to unexpected behavior (eg: Temporal SDK's might not expect this).

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

