### PR TITLE
Add binary-safe gRPC trailer encoding for context metadata

### DIFF
--- a/common/contextutil/metadata.go
+++ b/common/contextutil/metadata.go
@@ -21,6 +21,11 @@ type (
 var metadataCtxKey = metadataContextKey{}
 
 const (
+	// Metadata keys must NOT end in "-bin". The gRPC trailer interceptor uses a "-bin" suffix
+	// to create binary-safe trailer keys, and a metadata key ending in "-bin" would be
+	// ambiguous on the wire (e.g., "contextmetadata-foo-bin" could be a plain-text key for
+	// metadata key "foo-bin" or a binary key for metadata key "foo").
+
 	// MetadataKeyWorkflowType is the context metadata key for workflow type
 	MetadataKeyWorkflowType = "workflow-type"
 	// MetadataKeyWorkflowTaskQueue is the context metadata key for workflow task queue

--- a/common/rpc/interceptor/context_metadata_interceptor.go
+++ b/common/rpc/interceptor/context_metadata_interceptor.go
@@ -15,6 +15,20 @@ import (
 // interceptor can distinguish them from gRPC-internal and other interceptor trailer keys.
 const trailerKeyPrefix = "contextmetadata-"
 
+// trailerBinSuffix is appended to trailer keys so that gRPC automatically base64-encodes
+// values on the wire per the gRPC over HTTP/2 spec (PROTOCOL-HTTP2.md §Requests, "Binary-Header"):
+//
+//	https://github.com/grpc/grpc/blob/cf61c7d62a1a7f43b9d2ea6488186bc14fc41a8c/doc/PROTOCOL-HTTP2.md
+//
+// Binary headers use Base64 encoding (RFC 4648 §4) because the gRPC HTTP/2 framer rejects
+// header values containing certain control bytes. Without this, values containing C0 control bytes
+// (0x00–0x1F except HTAB) or DEL (0x7F) cause the HTTP/2 framer to reject the response.
+//
+// Constraint: context metadata keys (in contextutil) must NOT end in "-bin", or the reader
+// cannot distinguish "contextmetadata-<key>-bin" (binary) from "contextmetadata-<key>" (plain)
+// when <key> itself ends in "-bin".
+const trailerBinSuffix = "-bin"
+
 type ContextMetadataInterceptor struct {
 	setTrailer      bool
 	logger          log.Logger
@@ -54,6 +68,51 @@ func (c *ContextMetadataInterceptor) Intercept(
 	return resp, err
 }
 
+// isHTTP2HeaderSafe reports whether s can be sent through Go's gRPC HTTP/2 framer
+// without rejection. The framer forbids C0 control bytes 0x00–0x1F (except HTAB 0x09)
+// and DEL 0x7F. Bytes >= 0x80 (UTF-8, emoji, accented chars) are allowed by Go's
+// framer but are technically outside strict RFC 9113 visible-ASCII range — if a non-Go
+// proxy or gRPC implementation sits between endpoints, the -bin path handles those.
+// Iterates bytes, not runes — this is intentional because HTTP/2 validation is octet-based.
+func isHTTP2HeaderSafe(s string) bool {
+	for i := range len(s) {
+		b := s[i]
+		if b == 0x7f || (b < 0x20 && b != 0x09) {
+			return false
+		}
+	}
+	return true
+}
+
+// buildTrailerPairs constructs gRPC trailer key-value pairs for all context metadata.
+// Each key is emitted in up to three formats for backward compatibility:
+// (1) binary-safe with "-bin" suffix (always), (2) plain-text with prefix (when value
+// is HTTP/2-safe), (3) unprefixed well-known keys (when value is HTTP/2-safe).
+func (c *ContextMetadataInterceptor) buildTrailerPairs(ctx context.Context, info *grpc.UnaryServerInfo) []string {
+	var trailerPairs []string
+	for key, value := range contextutil.ContextMetadataGetAll(ctx) {
+		valStr := fmt.Sprint(value)
+		trailerPairs = append(trailerPairs, trailerKeyPrefix+key+trailerBinSuffix, valStr)
+		if isHTTP2HeaderSafe(valStr) {
+			trailerPairs = append(trailerPairs, trailerKeyPrefix+key, valStr)
+			if key == contextutil.MetadataKeyWorkflowType || key == contextutil.MetadataKeyWorkflowTaskQueue {
+				trailerPairs = append(trailerPairs, key, valStr)
+			}
+		} else {
+			valueSample := valStr
+			if len(valueSample) > 128 {
+				valueSample = valueSample[:128]
+			}
+			c.throttledLogger.Warn("ContextMetadataInterceptor: Skipping plain-text trailer key for HTTP/2-unsafe value (only -bin key emitted)",
+				tag.NewStringTag("key", key),
+				tag.NewStringTag("fullMethod", info.FullMethod),
+				tag.NewStringTag("valueSample", fmt.Sprintf("%q", valueSample)),
+			)
+		}
+	}
+	return trailerPairs
+}
+
 func (c *ContextMetadataInterceptor) appendContextMetadataToTrailer(ctx context.Context, info *grpc.UnaryServerInfo) {
 	// If the context is done, the gRPC stream may already be in streamDone state,
 	// and SetTrailer would return ErrIllegalHeaderWrite ("SendHeader called multiple times").
@@ -63,16 +122,7 @@ func (c *ContextMetadataInterceptor) appendContextMetadataToTrailer(ctx context.
 	default:
 	}
 
-	var trailerPairs []string
-
-	for key, value := range contextutil.ContextMetadataGetAll(ctx) {
-		valStr := fmt.Sprint(value)
-		trailerPairs = append(trailerPairs, trailerKeyPrefix+key, valStr)
-		// Backward compatibility: also emit unprefixed keys for older readers.
-		if key == contextutil.MetadataKeyWorkflowType || key == contextutil.MetadataKeyWorkflowTaskQueue {
-			trailerPairs = append(trailerPairs, key, valStr)
-		}
-	}
+	trailerPairs := c.buildTrailerPairs(ctx, info)
 
 	if len(trailerPairs) == 0 {
 		c.throttledLogger.Info("ContextMetadataInterceptor: No metadata in context, not setting trailer",

--- a/common/rpc/interceptor/context_metadata_interceptor_test.go
+++ b/common/rpc/interceptor/context_metadata_interceptor_test.go
@@ -2,7 +2,6 @@ package interceptor
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -134,6 +133,7 @@ func TestContextMetadataInterceptor_appendContextMetadataToTrailer(t *testing.T)
 		name             string
 		setupContext     func() context.Context
 		expectTrailerErr bool
+		expectUnsafeWarn bool
 	}{
 		{
 			name: "AllPropagatedKeys",
@@ -181,6 +181,16 @@ func TestContextMetadataInterceptor_appendContextMetadataToTrailer(t *testing.T)
 			},
 			expectTrailerErr: true,
 		},
+		{
+			name:             "UnsafeValueEmitsBinKeyOnly",
+			expectUnsafeWarn: true,
+			setupContext: func() context.Context {
+				ctx := contextutil.WithMetadataContext(t.Context())
+				contextutil.ContextMetadataSet(ctx, contextutil.MetadataKeyWorkflowType, "Foo\nBar")
+				return metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{}))
+			},
+			expectTrailerErr: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -188,6 +198,9 @@ func TestContextMetadataInterceptor_appendContextMetadataToTrailer(t *testing.T)
 			tl := testlogger.NewTestLogger(t, testlogger.FailOnAnyUnexpectedError)
 			if tc.expectTrailerErr {
 				tl.Expect(testlogger.Error, "ContextMetadataInterceptor: Failed to set trailer")
+			}
+			if tc.expectUnsafeWarn {
+				tl.Expect(testlogger.Warn, "ContextMetadataInterceptor: Skipping plain-text trailer key for HTTP/2-unsafe value (only -bin key emitted)")
 			}
 			interceptor := NewContextMetadataInterceptor(true, tl)
 
@@ -201,32 +214,112 @@ func TestContextMetadataInterceptor_appendContextMetadataToTrailer(t *testing.T)
 }
 
 func TestContextMetadataInterceptor_backwardCompatTrailerKeys(t *testing.T) {
+	tl := testlogger.NewTestLogger(t, testlogger.FailOnAnyUnexpectedError)
+	interceptor := NewContextMetadataInterceptor(true, tl)
+
 	ctx := contextutil.WithMetadataContext(t.Context())
 	contextutil.ContextMetadataSet(ctx, contextutil.MetadataKeyWorkflowType, "test-workflow")
 	contextutil.ContextMetadataSet(ctx, contextutil.MetadataKeyWorkflowTaskQueue, "test-queue")
 	contextutil.ContextMetadataSet(ctx, "other-key", "other-value")
 
-	allMetadata := contextutil.ContextMetadataGetAll(ctx)
-	var trailerPairs []string
-	for key, value := range allMetadata {
-		valStr := fmt.Sprint(value)
-		trailerPairs = append(trailerPairs, trailerKeyPrefix+key, valStr)
-		if key == contextutil.MetadataKeyWorkflowType || key == contextutil.MetadataKeyWorkflowTaskQueue {
-			trailerPairs = append(trailerPairs, key, valStr)
-		}
-	}
-
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/TestMethod"}
+	trailerPairs := interceptor.buildTrailerPairs(ctx, info)
 	trailer := metadata.Pairs(trailerPairs...)
 
-	// Well-known keys appear both with and without prefix
+	// Level 1 (newest): all keys get -bin suffixed entries
+	require.Contains(t, trailer, trailerKeyPrefix+contextutil.MetadataKeyWorkflowType+trailerBinSuffix)
+	require.Contains(t, trailer, trailerKeyPrefix+contextutil.MetadataKeyWorkflowTaskQueue+trailerBinSuffix)
+	require.Contains(t, trailer, trailerKeyPrefix+"other-key"+trailerBinSuffix)
+
+	// Level 2: all keys get plain prefixed entries (for safe values)
 	require.Contains(t, trailer, trailerKeyPrefix+contextutil.MetadataKeyWorkflowType)
+	require.Contains(t, trailer, trailerKeyPrefix+contextutil.MetadataKeyWorkflowTaskQueue)
+	require.Contains(t, trailer, trailerKeyPrefix+"other-key")
+
+	// Level 3 (oldest): well-known keys also get unprefixed entries
 	require.Contains(t, trailer, contextutil.MetadataKeyWorkflowType)
+	require.Contains(t, trailer, contextutil.MetadataKeyWorkflowTaskQueue)
+	require.NotContains(t, trailer, "other-key")
+}
+
+func TestContextMetadataInterceptor_binTrailerKeys_SafeValues(t *testing.T) {
+	tl := testlogger.NewTestLogger(t, testlogger.FailOnAnyUnexpectedError)
+	interceptor := NewContextMetadataInterceptor(true, tl)
+
+	ctx := contextutil.WithMetadataContext(t.Context())
+	contextutil.ContextMetadataSet(ctx, contextutil.MetadataKeyWorkflowType, "test-workflow")
+	contextutil.ContextMetadataSet(ctx, contextutil.MetadataKeyWorkflowTaskQueue, "test-queue")
+	contextutil.ContextMetadataSet(ctx, "other-key", "other-value")
+
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/TestMethod"}
+	trailerPairs := interceptor.buildTrailerPairs(ctx, info)
+	trailer := metadata.Pairs(trailerPairs...)
+
+	// Binary-safe keys always present
+	require.Contains(t, trailer, trailerKeyPrefix+contextutil.MetadataKeyWorkflowType+trailerBinSuffix)
+	require.Contains(t, trailer, trailerKeyPrefix+contextutil.MetadataKeyWorkflowTaskQueue+trailerBinSuffix)
+	require.Contains(t, trailer, trailerKeyPrefix+"other-key"+trailerBinSuffix)
+
+	// Plain-text keys also present for safe values (backward compat during rolling deploy)
+	require.Contains(t, trailer, trailerKeyPrefix+contextutil.MetadataKeyWorkflowType)
+	require.Contains(t, trailer, trailerKeyPrefix+contextutil.MetadataKeyWorkflowTaskQueue)
+	require.Contains(t, trailer, trailerKeyPrefix+"other-key")
+}
+
+func TestContextMetadataInterceptor_binTrailerKeys_UnsafeValues(t *testing.T) {
+	tl := testlogger.NewTestLogger(t, testlogger.FailOnAnyUnexpectedError)
+	tl.Expect(testlogger.Warn, "ContextMetadataInterceptor: Skipping plain-text trailer key for HTTP/2-unsafe value (only -bin key emitted)")
+	interceptor := NewContextMetadataInterceptor(true, tl)
+
+	ctx := contextutil.WithMetadataContext(t.Context())
+	contextutil.ContextMetadataSet(ctx, contextutil.MetadataKeyWorkflowType, "Foo\nBar")
+	contextutil.ContextMetadataSet(ctx, contextutil.MetadataKeyWorkflowTaskQueue, "safe-queue")
+
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/TestMethod"}
+	trailerPairs := interceptor.buildTrailerPairs(ctx, info)
+	trailer := metadata.Pairs(trailerPairs...)
+
+	// Binary-safe keys present for all values
+	require.Contains(t, trailer, trailerKeyPrefix+contextutil.MetadataKeyWorkflowType+trailerBinSuffix)
+	require.Contains(t, trailer, trailerKeyPrefix+contextutil.MetadataKeyWorkflowTaskQueue+trailerBinSuffix)
+
+	// Plain-text key suppressed for the unsafe value (newline)
+	require.NotContains(t, trailer, trailerKeyPrefix+contextutil.MetadataKeyWorkflowType)
+	require.NotContains(t, trailer, contextutil.MetadataKeyWorkflowType)
+
+	// Safe value still gets plain-text keys
 	require.Contains(t, trailer, trailerKeyPrefix+contextutil.MetadataKeyWorkflowTaskQueue)
 	require.Contains(t, trailer, contextutil.MetadataKeyWorkflowTaskQueue)
+}
 
-	// Other keys only appear with prefix
-	require.Contains(t, trailer, trailerKeyPrefix+"other-key")
-	require.NotContains(t, trailer, "other-key")
+func TestIsHTTP2HeaderSafe(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		want bool
+	}{
+		{"empty", "", true},
+		{"plain ASCII", "hello-world", true},
+		{"with HTAB", "hello\tworld", true},
+		{"with space", "hello world", true},
+		{"UTF-8 CJK", "Workflow-日本語", true},
+		{"emoji", "🚀-workflow", true},
+		{"accented chars", "café-résumé", true},
+		{"mixed Unicode", "workflow-über-naïve-🎉", true},
+		{"newline", "Foo\nBar", false},
+		{"carriage return", "Foo\rBar", false},
+		{"NUL byte", "Foo\x00Bar", false},
+		{"DEL", "Foo\x7fBar", false},
+		{"bell", "Foo\x07Bar", false},
+		{"escape", "Foo\x1bBar", false},
+		{"unit separator 0x1F boundary", "\x1f", false},
+		{"space 0x20 boundary", "\x20", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isHTTP2HeaderSafe(tt.s))
+		})
+	}
 }
 
 func TestNewContextMetadataInterceptor(t *testing.T) {

--- a/common/rpc/interceptor/trailer_to_context_metadata_interceptor.go
+++ b/common/rpc/interceptor/trailer_to_context_metadata_interceptor.go
@@ -36,29 +36,75 @@ func TrailerToContextMetadataInterceptor(logger log.Logger) grpc.UnaryClientInte
 		trailerMetadata := make(map[string]string)
 		propagatedMetadata := make(map[string]string)
 
-		for prefixedKey, values := range trailer {
-			key, ok := strings.CutPrefix(prefixedKey, trailerKeyPrefix)
-			if !ok {
-				// Backward compatibility: accept unprefixed keys from older writers.
-				if prefixedKey != contextutil.MetadataKeyWorkflowType && prefixedKey != contextutil.MetadataKeyWorkflowTaskQueue {
-					continue
-				}
-				key = prefixedKey
+		setMetadata := func(key, value string) {
+			trailerMetadata[key] = value
+			if contextutil.ContextMetadataSet(ctx, key, value) {
+				propagatedMetadata[key] = value
 			}
-			if len(values) == 0 {
+		}
+
+		// Pass 1: -bin keys from new writers (highest priority).
+		// These are authoritative and take precedence over plain-text keys.
+		binKeys := make(map[string]struct{})
+		for trailerKey, values := range trailer {
+			if !strings.HasPrefix(trailerKey, trailerKeyPrefix) || !strings.HasSuffix(trailerKey, trailerBinSuffix) {
 				continue
 			}
-
-			trailerMetadata[key] = values[0]
-			if contextutil.ContextMetadataSet(ctx, key, values[0]) {
-				propagatedMetadata[key] = values[0]
+			key := trailerKey[len(trailerKeyPrefix) : len(trailerKey)-len(trailerBinSuffix)]
+			if key == "" {
+				continue
 			}
+			if len(values) == 0 {
+				throttledLogger.Warn("TrailerToContextMetadataInterceptor: -bin trailer key has empty values",
+					tag.NewStringTag("trailerKey", trailerKey),
+					tag.NewStringTag("method", method),
+				)
+				continue
+			}
+			binKeys[key] = struct{}{}
+			setMetadata(key, values[0])
+		}
+
+		// Pass 2: plain prefixed and unprefixed keys from old writers.
+		// Skip keys already set by a -bin entry.
+		for trailerKey, values := range trailer {
+			if strings.HasPrefix(trailerKey, trailerKeyPrefix) && strings.HasSuffix(trailerKey, trailerBinSuffix) {
+				continue
+			}
+			key, ok := extractContextMetadataKey(trailerKey)
+			if !ok || key == "" || len(values) == 0 {
+				continue
+			}
+			if _, hasBin := binKeys[key]; hasBin {
+				continue
+			}
+			setMetadata(key, values[0])
 		}
 
 		logMetadataPropagationStatus(ctx, method, trailerMetadata, propagatedMetadata, throttledLogger)
 
 		return err
 	}
+}
+
+// extractContextMetadataKey extracts the context metadata key from a plain-text
+// gRPC trailer key (formats 2 and 3 only — binary "-bin" keys are handled
+// separately by the caller's first pass).
+//
+// Recognized formats (format 1, binary "-bin" keys, is handled by the caller's first pass):
+//  2. Plain-text prefixed: "contextmetadata-<key>" (old writers)
+//  3. Unprefixed well-known: "workflow-type" / "workflow-task-queue" (very old writers)
+func extractContextMetadataKey(trailerKey string) (string, bool) {
+	if after, ok := strings.CutPrefix(trailerKey, trailerKeyPrefix); ok {
+		if after == "" {
+			return "", false
+		}
+		return after, true
+	}
+	if trailerKey == contextutil.MetadataKeyWorkflowType || trailerKey == contextutil.MetadataKeyWorkflowTaskQueue {
+		return trailerKey, true
+	}
+	return "", false
 }
 
 func logMetadataPropagationStatus(

--- a/common/rpc/interceptor/trailer_to_context_metadata_interceptor_test.go
+++ b/common/rpc/interceptor/trailer_to_context_metadata_interceptor_test.go
@@ -316,6 +316,277 @@ func TestTrailerToContextMetadataInterceptor(t *testing.T) {
 	}
 }
 
+func TestTrailerToContextMetadataInterceptor_BinSuffixedKeys(t *testing.T) {
+	testCases := []struct {
+		name             string
+		setupInvoker     func() grpc.UnaryInvoker
+		validateMetadata func(*testing.T, context.Context)
+	}{
+		{
+			name: "BinSuffixedWorkflowType",
+			setupInvoker: func() grpc.UnaryInvoker {
+				return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+					for _, opt := range opts {
+						if trailer, ok := opt.(grpc.TrailerCallOption); ok {
+							md := trailer.TrailerAddr
+							*md = metadata.Pairs(trailerKeyPrefix+contextutil.MetadataKeyWorkflowType+trailerBinSuffix, "test-workflow-type")
+						}
+					}
+					return nil
+				}
+			},
+			validateMetadata: func(t *testing.T, ctx context.Context) {
+				value, ok := contextutil.ContextMetadataGet(ctx, contextutil.MetadataKeyWorkflowType)
+				require.True(t, ok)
+				require.Equal(t, "test-workflow-type", value)
+			},
+		},
+		{
+			name: "BinSuffixedAllMetadata",
+			setupInvoker: func() grpc.UnaryInvoker {
+				return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+					for _, opt := range opts {
+						if trailer, ok := opt.(grpc.TrailerCallOption); ok {
+							md := trailer.TrailerAddr
+							*md = metadata.Pairs(
+								trailerKeyPrefix+contextutil.MetadataKeyWorkflowType+trailerBinSuffix, "test-workflow-type",
+								trailerKeyPrefix+contextutil.MetadataKeyWorkflowTaskQueue+trailerBinSuffix, "test-task-queue",
+							)
+						}
+					}
+					return nil
+				}
+			},
+			validateMetadata: func(t *testing.T, ctx context.Context) {
+				workflowType, ok := contextutil.ContextMetadataGet(ctx, contextutil.MetadataKeyWorkflowType)
+				require.True(t, ok)
+				require.Equal(t, "test-workflow-type", workflowType)
+
+				taskQueue, ok := contextutil.ContextMetadataGet(ctx, contextutil.MetadataKeyWorkflowTaskQueue)
+				require.True(t, ok)
+				require.Equal(t, "test-task-queue", taskQueue)
+			},
+		},
+		{
+			name: "EmojiValue",
+			setupInvoker: func() grpc.UnaryInvoker {
+				return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+					for _, opt := range opts {
+						if trailer, ok := opt.(grpc.TrailerCallOption); ok {
+							md := trailer.TrailerAddr
+							*md = metadata.Pairs(trailerKeyPrefix+contextutil.MetadataKeyWorkflowType+trailerBinSuffix, "🚀-workflow")
+						}
+					}
+					return nil
+				}
+			},
+			validateMetadata: func(t *testing.T, ctx context.Context) {
+				value, ok := contextutil.ContextMetadataGet(ctx, contextutil.MetadataKeyWorkflowType)
+				require.True(t, ok)
+				require.Equal(t, "🚀-workflow", value)
+			},
+		},
+		{
+			name: "AccentedCharsValue",
+			setupInvoker: func() grpc.UnaryInvoker {
+				return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+					for _, opt := range opts {
+						if trailer, ok := opt.(grpc.TrailerCallOption); ok {
+							md := trailer.TrailerAddr
+							*md = metadata.Pairs(trailerKeyPrefix+contextutil.MetadataKeyWorkflowType+trailerBinSuffix, "café-résumé")
+						}
+					}
+					return nil
+				}
+			},
+			validateMetadata: func(t *testing.T, ctx context.Context) {
+				value, ok := contextutil.ContextMetadataGet(ctx, contextutil.MetadataKeyWorkflowType)
+				require.True(t, ok)
+				require.Equal(t, "café-résumé", value)
+			},
+		},
+		{
+			name: "BinSuffixedMultipleValues",
+			setupInvoker: func() grpc.UnaryInvoker {
+				return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+					for _, opt := range opts {
+						if trailer, ok := opt.(grpc.TrailerCallOption); ok {
+							md := trailer.TrailerAddr
+							*md = metadata.MD{
+								trailerKeyPrefix + contextutil.MetadataKeyWorkflowType + trailerBinSuffix: []string{"first-value", "second-value", "third-value"},
+							}
+						}
+					}
+					return nil
+				}
+			},
+			validateMetadata: func(t *testing.T, ctx context.Context) {
+				value, ok := contextutil.ContextMetadataGet(ctx, contextutil.MetadataKeyWorkflowType)
+				require.True(t, ok)
+				require.Equal(t, "first-value", value)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tl := testlogger.NewTestLogger(t, testlogger.FailOnAnyUnexpectedError)
+			interceptor := TrailerToContextMetadataInterceptor(tl)
+
+			invoker := tc.setupInvoker()
+			ctx := contextutil.WithMetadataContext(t.Context())
+
+			err := interceptor(ctx, "/test.Service/Method", "request", "reply", nil, invoker)
+
+			require.NoError(t, err)
+			if tc.validateMetadata != nil {
+				tc.validateMetadata(t, ctx)
+			}
+		})
+	}
+}
+
+func TestExtractContextMetadataKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantKey   string
+		wantFound bool
+	}{
+		{"plain prefixed workflow type", trailerKeyPrefix + "workflow-type", "workflow-type", true},
+		{"plain prefixed task queue", trailerKeyPrefix + "workflow-task-queue", "workflow-task-queue", true},
+		{"plain prefixed key ending in -bin", trailerKeyPrefix + "foo-bin", "foo-bin", true},
+		{"unprefixed workflow type", contextutil.MetadataKeyWorkflowType, contextutil.MetadataKeyWorkflowType, true},
+		{"unprefixed task queue", contextutil.MetadataKeyWorkflowTaskQueue, contextutil.MetadataKeyWorkflowTaskQueue, true},
+		{"unknown key", "some-random-key", "", false},
+		{"empty string", "", "", false},
+		{"prefix only", trailerKeyPrefix, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, found := extractContextMetadataKey(tt.input)
+			require.Equal(t, tt.wantFound, found)
+			if found {
+				require.Equal(t, tt.wantKey, key)
+			}
+		})
+	}
+}
+
+func TestTrailerToContextMetadataInterceptor_AllThreeKeyFormats(t *testing.T) {
+	tl := testlogger.NewTestLogger(t, testlogger.FailOnAnyUnexpectedError)
+	interceptor := TrailerToContextMetadataInterceptor(tl)
+
+	invoker := func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+		for _, opt := range opts {
+			if trailer, ok := opt.(grpc.TrailerCallOption); ok {
+				md := trailer.TrailerAddr
+				// All three formats in one trailer, each carrying a different key:
+				//   Level 1 (newest, -bin):  workflow-type via contextmetadata-workflow-type-bin
+				//   Level 2 (prefixed):      workflow-task-queue via contextmetadata-workflow-task-queue
+				//   Level 3 (oldest, bare):  workflow-type via bare workflow-type
+				*md = metadata.Pairs(
+					trailerKeyPrefix+contextutil.MetadataKeyWorkflowType+trailerBinSuffix, "bin-wf-type",
+					trailerKeyPrefix+contextutil.MetadataKeyWorkflowTaskQueue, "prefixed-tq",
+					contextutil.MetadataKeyWorkflowType, "unprefixed-wf-type",
+				)
+			}
+		}
+		return nil
+	}
+
+	ctx := contextutil.WithMetadataContext(t.Context())
+	err := interceptor(ctx, "/test.Service/Method", "request", "reply", nil, invoker)
+	require.NoError(t, err)
+
+	// -bin key takes priority over unprefixed key (both map to workflow-type)
+	wfType, ok := contextutil.ContextMetadataGet(ctx, contextutil.MetadataKeyWorkflowType)
+	require.True(t, ok)
+	require.Equal(t, "bin-wf-type", wfType,
+		"-bin key should take priority over unprefixed key")
+
+	// Prefixed key recognized
+	tq, ok := contextutil.ContextMetadataGet(ctx, contextutil.MetadataKeyWorkflowTaskQueue)
+	require.True(t, ok)
+	require.Equal(t, "prefixed-tq", tq)
+}
+
+func TestTrailerToContextMetadataInterceptor_BinKeyPriorityOverPrefixedKey(t *testing.T) {
+	tl := testlogger.NewTestLogger(t, testlogger.FailOnAnyUnexpectedError)
+	interceptor := TrailerToContextMetadataInterceptor(tl)
+
+	invoker := func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+		for _, opt := range opts {
+			if trailer, ok := opt.(grpc.TrailerCallOption); ok {
+				md := trailer.TrailerAddr
+				*md = metadata.Pairs(
+					trailerKeyPrefix+contextutil.MetadataKeyWorkflowType+trailerBinSuffix, "bin-value",
+					trailerKeyPrefix+contextutil.MetadataKeyWorkflowType, "plain-prefixed-value",
+				)
+			}
+		}
+		return nil
+	}
+
+	ctx := contextutil.WithMetadataContext(t.Context())
+	err := interceptor(ctx, "/test.Service/Method", "request", "reply", nil, invoker)
+	require.NoError(t, err)
+
+	wfType, ok := contextutil.ContextMetadataGet(ctx, contextutil.MetadataKeyWorkflowType)
+	require.True(t, ok)
+	require.Equal(t, "bin-value", wfType,
+		"-bin key should take priority over plain prefixed key")
+}
+
+func TestTrailerToContextMetadataInterceptor_EmptyBinKey(t *testing.T) {
+	tl := testlogger.NewTestLogger(t, testlogger.FailOnAnyUnexpectedError)
+	interceptor := TrailerToContextMetadataInterceptor(tl)
+
+	invoker := func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+		for _, opt := range opts {
+			if trailer, ok := opt.(grpc.TrailerCallOption); ok {
+				md := trailer.TrailerAddr
+				*md = metadata.MD{
+					trailerKeyPrefix + trailerBinSuffix: []string{"some-value"},
+				}
+			}
+		}
+		return nil
+	}
+
+	ctx := contextutil.WithMetadataContext(t.Context())
+	err := interceptor(ctx, "/test.Service/Method", "request", "reply", nil, invoker)
+	require.NoError(t, err)
+
+	allMetadata := contextutil.ContextMetadataGetAll(ctx)
+	require.Empty(t, allMetadata)
+}
+
+func TestTrailerToContextMetadataInterceptor_BinKeyEmptyValues(t *testing.T) {
+	tl := testlogger.NewTestLogger(t, testlogger.FailOnAnyUnexpectedError)
+	tl.Expect(testlogger.Warn, "TrailerToContextMetadataInterceptor: -bin trailer key has empty values")
+	interceptor := TrailerToContextMetadataInterceptor(tl)
+
+	invoker := func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+		for _, opt := range opts {
+			if trailer, ok := opt.(grpc.TrailerCallOption); ok {
+				md := trailer.TrailerAddr
+				*md = metadata.MD{
+					trailerKeyPrefix + contextutil.MetadataKeyWorkflowType + trailerBinSuffix: []string{},
+				}
+			}
+		}
+		return nil
+	}
+
+	ctx := contextutil.WithMetadataContext(t.Context())
+	err := interceptor(ctx, "/test.Service/Method", "request", "reply", nil, invoker)
+	require.NoError(t, err)
+
+	allMetadata := contextutil.ContextMetadataGetAll(ctx)
+	require.Empty(t, allMetadata)
+}
+
 func TestTrailerToContextMetadataInterceptor_PassesThroughCallOptions(t *testing.T) {
 	tl := testlogger.NewTestLogger(t, testlogger.FailOnAnyUnexpectedError)
 	interceptor := TrailerToContextMetadataInterceptor(tl)

--- a/tests/testcore/onebox.go
+++ b/tests/testcore/onebox.go
@@ -49,6 +49,7 @@ import (
 	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/common/rpc"
 	"go.temporal.io/server/common/rpc/encryption"
+	"go.temporal.io/server/common/rpc/interceptor"
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/telemetry"
@@ -829,7 +830,10 @@ func (c *TemporalImpl) newRPCFactory(
 		int(httpPort),
 		frontendTLSConfig,
 		options,
-		map[primitives.ServiceName][]grpc.DialOption{},
+		map[primitives.ServiceName][]grpc.DialOption{
+			primitives.HistoryService:  {grpc.WithChainUnaryInterceptor(interceptor.TrailerToContextMetadataInterceptor(logger))},
+			primitives.MatchingService: {grpc.WithChainUnaryInterceptor(interceptor.TrailerToContextMetadataInterceptor(logger))},
+		},
 		monitor,
 	), nil
 }

--- a/tests/workflow_type_encoding_test.go
+++ b/tests/workflow_type_encoding_test.go
@@ -1,0 +1,122 @@
+package tests
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	sdkclient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/common/testing/parallelsuite"
+	"go.temporal.io/server/tests/testcore"
+)
+
+// WorkflowTypeEncodingSuite verifies that workflow type names containing
+// arbitrary bytes — including HTTP/2-unsafe control characters and multi-byte
+// UTF-8 — can be used end-to-end without breaking gRPC transport.
+//
+// Workflow type names flow through several layers (mutable state, context
+// metadata, gRPC response trailers via ContextMetadataInterceptor) and any
+// layer that places raw strings into HTTP/2 headers will reject C0 control
+// bytes (0x00–0x1F except HTAB 0x09) and DEL (0x7F). If these tests had
+// existed when the interceptor was first introduced, they would have caught
+// the deficiency immediately.
+//
+// The server-side fix uses gRPC's "-bin" trailer key convention
+// (PROTOCOL-HTTP2.md, RFC 4648 §4) to base64-encode values on the wire.
+type WorkflowTypeEncodingSuite struct {
+	parallelsuite.Suite[*WorkflowTypeEncodingSuite]
+}
+
+func TestWorkflowTypeEncodingSuite(t *testing.T) {
+	parallelsuite.Run(t, &WorkflowTypeEncodingSuite{})
+}
+
+func (s *WorkflowTypeEncodingSuite) runWithWorkflowType(env *testcore.TestEnv, workflowType string) error {
+	env.SdkWorker().RegisterWorkflowWithOptions(
+		func(ctx workflow.Context) error { return nil },
+		workflow.RegisterOptions{Name: workflowType},
+	)
+
+	run, err := env.SdkClient().ExecuteWorkflow(
+		env.Context(),
+		sdkclient.StartWorkflowOptions{
+			ID:        testcore.RandomizeStr("wf-trailer"),
+			TaskQueue: env.WorkerTaskQueue(),
+		},
+		workflowType,
+	)
+	if err != nil {
+		return err
+	}
+	return run.Get(env.Context(), nil)
+}
+
+func (s *WorkflowTypeEncodingSuite) TestPlainASCII() {
+	s.Run("Succeeds", func(s *WorkflowTypeEncodingSuite) {
+		env := testcore.NewEnv(s.T())
+		s.NoError(s.runWithWorkflowType(env, "PlainAsciiWorkflowType"))
+	})
+}
+
+func (s *WorkflowTypeEncodingSuite) TestControlCharsInWorkflowType() {
+	cases := []struct {
+		label string
+		char  string
+	}{
+		{"HTAB (safe control char)", "\t"},
+		{"newline", "\n"},
+		{"carriage return", "\r"},
+		{"CRLF", "\r\n"},
+		{"NUL", "\x00"},
+		{"bell", "\x07"},
+		{"escape", "\x1b"},
+		{"DEL", "\x7f"},
+	}
+	for _, tc := range cases {
+		s.Run(fmt.Sprintf("control char %s succeeds", tc.label), func(s *WorkflowTypeEncodingSuite) {
+			env := testcore.NewEnv(s.T())
+			s.NoError(s.runWithWorkflowType(env, "Foo"+tc.char+"Bar"))
+		})
+	}
+}
+
+func (s *WorkflowTypeEncodingSuite) TestAllControlCharsWorkflowType() {
+	s.Run("only control chars succeeds", func(s *WorkflowTypeEncodingSuite) {
+		env := testcore.NewEnv(s.T())
+		s.NoError(s.runWithWorkflowType(env, "\n\x00\r"))
+	})
+}
+
+func (s *WorkflowTypeEncodingSuite) TestLongWorkflowType() {
+	s.Run("succeeds", func(s *WorkflowTypeEncodingSuite) {
+		env := testcore.NewEnv(s.T())
+		longName := strings.Repeat("a", 999)
+		s.NoError(s.runWithWorkflowType(env, longName))
+	})
+}
+
+func (s *WorkflowTypeEncodingSuite) TestWorkflowTypeEndingInBin() {
+	s.Run("succeeds", func(s *WorkflowTypeEncodingSuite) {
+		env := testcore.NewEnv(s.T())
+		s.NoError(s.runWithWorkflowType(env, "my-workflow-bin"))
+	})
+}
+
+func (s *WorkflowTypeEncodingSuite) TestUTF8WorkflowType() {
+	cases := []struct {
+		label        string
+		workflowType string
+	}{
+		{"CJK", "Workflow-日本語"},
+		{"emoji", "🚀-workflow"},
+		{"accented", "café-résumé"},
+		{"mixed", "über-naïve-🎉-工作流"},
+	}
+	for _, tc := range cases {
+		s.Run(fmt.Sprintf("UTF-8 %s succeeds", tc.label), func(s *WorkflowTypeEncodingSuite) {
+			env := testcore.NewEnv(s.T())
+			s.NoError(s.runWithWorkflowType(env, tc.workflowType))
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- Added `-bin` suffix to gRPC trailer keys so values are automatically base64-encoded on the wire, preventing HTTP/2 framer rejections for workflow type names containing control characters (newlines, NUL, etc.)
- Writer emits keys in three backward-compatible formats: (1) binary `-bin` suffixed (always), (2) plain-text prefixed (when safe), (3) unprefixed well-known keys (when safe)
- Reader uses a two-pass approach: `-bin` keys take priority over plain-text keys from old writers
- Added `isHTTP2HeaderSafe` to detect values needing binary encoding
- Reader now warns when a `-bin` trailer key has empty values instead of silently skipping

## Why

Workflow type names containing C0 control bytes (0x00–0x1F except HTAB) or DEL (0x7F) cause Go's gRPC HTTP/2 framer to reject the response trailer. By appending `-bin` to trailer keys, gRPC automatically base64-encodes values per the gRPC over HTTP/2 spec, making arbitrary byte sequences transport-safe.

The three-level key format ensures safe rolling deploys: old readers ignore `-bin` keys and continue reading plain-text keys; new readers prefer `-bin` keys but fall back to plain-text keys from old writers.

## How tested

- Unit tests for `isHTTP2HeaderSafe` (16 cases covering boundary values, UTF-8, control chars)
- Unit tests for `buildTrailerPairs` (safe values, unsafe values, backward compat levels)
- Unit tests for `extractContextMetadataKey` (all key formats, edge cases)
- Unit tests for two-pass reader priority (`-bin` over prefixed, `-bin` over unprefixed)
- Unit tests for edge cases (empty keys, empty values with warning, multiple values)
- Integration test suite (`TestWorkflowTypeEncodingSuite`) exercising full gRPC transport with control chars, UTF-8, long names, and `-bin` suffix workflow types

## Risks

- During rolling deploy, old writers emit only plain-text keys. New readers handle this via pass-2 fallback. No data loss.
- Metadata keys must not end in `-bin` (documented constraint in `contextutil/metadata.go`). All current keys use hard-coded prefixes that structurally cannot end in `-bin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gRPC trailer encoding/decoding for context metadata used across services; while backward-compatible, mistakes could break metadata propagation or cause subtle interoperability issues during rolling deploys.
> 
> **Overview**
> **Makes context-metadata gRPC trailers binary-safe.** Server-side `ContextMetadataInterceptor` now always emits `contextmetadata-<key>-bin` trailer entries (letting gRPC base64-encode values), and only emits the legacy plain-text trailer keys when the value is HTTP/2 header-safe (logging a throttled warning otherwise).
> 
> **Updates the client-side reader for compatibility and precedence.** `TrailerToContextMetadataInterceptor` now prefers `-bin` keys in a first pass, then falls back to legacy prefixed/unprefixed keys, adds parsing helpers, and warns on empty `-bin` values. Tests are expanded plus a new end-to-end suite ensures workflow type names with control chars/UTF-8/long names survive transport, and onebox wiring adds the trailer reader interceptor for history/matching clients in tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 228947a86f23cc3712f03cbda8f51a056ba4f9ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->