### PR TITLE
Verify replication timing

### DIFF
--- a/service/worker/migration/activities.go
+++ b/service/worker/migration/activities.go
@@ -915,45 +915,37 @@ func (a *activities) verifySingleReplicationTask(
 	}
 }
 
-func (a *activities) verifyReplicationTasks(
+// verifyBatch scans executions starting at startIndex, verifying each on the remote cluster.
+// onProgress is called after each successful verification with the next index to scan from.
+// Returns the next index to scan from, whether all executions were verified, and the first
+// unverified execution if any.
+func (a *activities) verifyBatch(
 	ctx context.Context,
 	request *verifyReplicationTasksRequest,
-	details *replicationTasksHeartbeatDetails,
-	remotAdminClient adminservice.AdminServiceClient,
+	startIndex int,
+	remoteAdminClient adminservice.AdminServiceClient,
 	ns *namespace.Namespace,
-	heartbeat func(details replicationTasksHeartbeatDetails),
-) (bool, error) {
+	onProgress func(nextIndex int),
+) (nextIndex int, done bool, lastUnverified *ExecutionInfo, err error) {
 	start := time.Now()
-	progress := false
 	defer func() {
-		if progress {
-			// Update CheckPoint when there is a progress
-			details.CheckPoint = time.Now()
-		}
-
-		heartbeat(*details)
 		a.forceReplicationMetricsHandler.Timer(metrics.VerifyReplicationTasksLatency.Name()).Record(time.Since(start))
 	}()
 
 	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(interceptor.DCRedirectionContextHeaderName, "false"))
 
-	for ; details.NextIndex < len(request.Executions); details.NextIndex++ {
-		we := request.Executions[details.NextIndex]
-		r, err := a.verifySingleReplicationTask(ctx, request, remotAdminClient, ns, we)
+	for i := startIndex; i < len(request.Executions); i++ {
+		we := request.Executions[i]
+		r, err := a.verifySingleReplicationTask(ctx, request, remoteAdminClient, ns, we)
 		if err != nil {
-			return false, err
+			return i, false, nil, err
 		}
-
 		if !r.isVerified() {
-			details.LastNotVerifiedWorkflowExecution = we
-			return false, nil
+			return i, false, we, nil
 		}
-
-		heartbeat(*details)
-		progress = true
+		onProgress(i + 1)
 	}
-
-	return true, nil
+	return len(request.Executions), true, nil, nil
 }
 
 const (
@@ -968,12 +960,11 @@ func (a *activities) VerifyReplicationTasks(ctx context.Context, request *verify
 			return response, err
 		}
 	} else {
-		details.NextIndex = 0
 		details.CheckPoint = time.Now()
 		activity.RecordHeartbeat(ctx, details)
 	}
 
-	remotAdminClient, err := a.clientBean.GetRemoteAdminClient(request.TargetClusterName)
+	remoteAdminClient, err := a.clientBean.GetRemoteAdminClient(request.TargetClusterName)
 	if err != nil {
 		return response, err
 	}
@@ -983,41 +974,53 @@ func (a *activities) VerifyReplicationTasks(ctx context.Context, request *verify
 		return response, err
 	}
 
-	// Verify if replication tasks exist on target cluster. There are several cases where execution was not found on target cluster.
+	// Verify if replication tasks exist on target cluster. There are several cases where an
+	// execution is not found on the target cluster:
 	//  1. replication lag
 	//  2. Zombie workflow execution
 	//  3. workflow execution was deleted (due to retention) after replication task was created
 	//  4. workflow execution was not applied successfully on target cluster (i.e, bug)
 	//
-	// The verification step is retried for every VerifyInterval to handle #1. Verification progress
-	// is recorded in activity heartbeat. The verification is considered of making progress if there was at least one new execution
-	// being verified. If no progress is made for long enough, then
-	//  - more than checkSkipThreshold, it checks if outstanding workflow execution can be skipped locally (#2 and #3)
-	//  - more than NonRetryableTimeout, it means potentially #4. The activity returns
-	//    non-retryable error and force-replication will fail.
+	// The verification step is retried every VerifyInterval to handle #1. Progress is recorded
+	// in the activity heartbeat: checkpoint is updated whenever an execution is successfully
+	// verified. If no progress is made for defaultNoProgressNotRetryableTimeout, the activity
+	// returns a non-retryable error indicating a likely bug (#4).
 	for {
-		// Since replication has a lag, sleep first.
-		time.Sleep(request.VerifyInterval)
+		// Since replication has a lag, wait before each scan.
+		select {
+		case <-time.After(request.VerifyInterval):
+		case <-ctx.Done():
+			return response, ctx.Err()
+		}
 
-		verified, err := a.verifyReplicationTasks(ctx, request, &details, remotAdminClient, nsEntry,
-			func(d replicationTasksHeartbeatDetails) {
-				activity.RecordHeartbeat(ctx, d)
-			})
+		nextIndex, done, lastUnverified, err := a.verifyBatch(
+			ctx, request, details.NextIndex, remoteAdminClient, nsEntry,
+			func(nextIdx int) {
+				details.NextIndex = nextIdx
+				details.CheckPoint = time.Now()
+				activity.RecordHeartbeat(ctx, details)
+			},
+		)
 		if err != nil {
 			return response, err
 		}
 
-		if verified {
+		details.NextIndex = nextIndex
+		if lastUnverified != nil {
+			details.LastNotVerifiedWorkflowExecution = lastUnverified
+		}
+		activity.RecordHeartbeat(ctx, details)
+
+		if done {
 			response.VerifiedWorkflowCount = int64(len(request.Executions))
 			return response, nil
 		}
 
-		diff := time.Since(details.CheckPoint)
-		if diff > defaultNoProgressNotRetryableTimeout {
-			// Potentially encountered a missing execution, return non-retryable error
+		staleDuration := time.Since(details.CheckPoint)
+		if staleDuration > defaultNoProgressNotRetryableTimeout {
 			return response, temporal.NewNonRetryableApplicationError(
 				fmt.Sprintf("verifyReplicationTasks was not able to make progress for more than %v minutes (not retryable): could not find WorkflowExecution: '%v' in TargetCluster: '%s': Checkpoint: '%v', ",
-					diff.Minutes(),
+					staleDuration.Minutes(),
 					details.LastNotVerifiedWorkflowExecution, request.TargetClusterName, details.CheckPoint),
 				"",
 				nil)

--- a/service/worker/migration/activities.go
+++ b/service/worker/migration/activities.go
@@ -38,6 +38,7 @@ import (
 type (
 	replicationTasksHeartbeatDetails struct {
 		NextIndex                        int
+		DeferredIndices                  []int // indices skipped over due to shard contention; retried each pass
 		CheckPoint                       time.Time
 		LastNotVerifiedWorkflowExecution *ExecutionInfo
 	}
@@ -915,18 +916,31 @@ func (a *activities) verifySingleReplicationTask(
 	}
 }
 
-// verifyBatch scans executions starting at startIndex, verifying each on the remote cluster.
-// onProgress is called after each successful verification with the next index to scan from.
-// Returns the next index to scan from, whether all executions were verified, and the first
-// unverified execution if any.
+// verifyBatch scans executions in two phases:
+//  1. Retry items from deferredIndices that were skipped in previous passes.
+//  2. Sequential scan starting at startIndex, with skip-ahead once checkpoint age exceeds skipAheadAfter.
+//
+// When skip-ahead is active and an item fails, the item and all consecutive items on the same
+// source shard are added to the deferred set without further RPC calls, on the premise that the
+// whole shard is contended. The scan then continues from the first item on a different shard.
+//
+// onProgress is called after each successful verification (deferred or sequential) with the
+// updated sequential frontier and remaining deferred set; callers should update their checkpoint
+// and heartbeat inside this callback.
+//
+// Returns: next sequential index, remaining deferred indices, done (all verified), last unverified
+// execution (nil if scan completed or all remaining items were deferred).
 func (a *activities) verifyBatch(
 	ctx context.Context,
 	request *verifyReplicationTasksRequest,
 	startIndex int,
+	deferredIndices []int,
+	checkpoint time.Time,
+	skipAheadAfter time.Duration,
 	remoteAdminClient adminservice.AdminServiceClient,
 	ns *namespace.Namespace,
-	onProgress func(nextIndex int),
-) (nextIndex int, done bool, lastUnverified *ExecutionInfo, err error) {
+	onProgress func(nextIndex int, remainingDeferred []int),
+) (nextIndex int, remainingDeferred []int, done bool, lastUnverified *ExecutionInfo, err error) {
 	start := time.Now()
 	defer func() {
 		a.forceReplicationMetricsHandler.Timer(metrics.VerifyReplicationTasksLatency.Name()).Record(time.Since(start))
@@ -934,22 +948,69 @@ func (a *activities) verifyBatch(
 
 	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(interceptor.DCRedirectionContextHeaderName, "false"))
 
+	// Phase 1: retry deferred items from previous passes.
+	remaining := make([]int, 0, len(deferredIndices))
+	for retryIdx, idx := range deferredIndices {
+		we := request.Executions[idx]
+		r, verifyErr := a.verifySingleReplicationTask(ctx, request, remoteAdminClient, ns, we)
+		if verifyErr != nil {
+			// Preserve all not-yet-processed deferred indices so they survive the retry.
+			remaining = append(remaining, deferredIndices[retryIdx:]...)
+			return startIndex, remaining, false, nil, verifyErr
+		}
+		if r.isVerified() {
+			onProgress(startIndex, remaining)
+		} else {
+			remaining = append(remaining, idx)
+		}
+	}
+
+	// Phase 2: sequential scan, deferring stuck items once past the skip-ahead threshold.
+	pastThreshold := time.Since(checkpoint) >= skipAheadAfter
 	for i := startIndex; i < len(request.Executions); i++ {
 		we := request.Executions[i]
-		r, err := a.verifySingleReplicationTask(ctx, request, remoteAdminClient, ns, we)
-		if err != nil {
-			return i, false, nil, err
+		r, verifyErr := a.verifySingleReplicationTask(ctx, request, remoteAdminClient, ns, we)
+		if verifyErr != nil {
+			return i, remaining, false, nil, verifyErr
 		}
-		if !r.isVerified() {
-			return i, false, we, nil
+		if r.isVerified() {
+			onProgress(i+1, remaining)
+		} else if pastThreshold {
+			// Defer this item and any consecutive items on the same source shard without
+			// further RPC calls: if one item on a shard is stuck, its siblings likely are too.
+			hotShard := common.WorkflowIDToHistoryShard(request.NamespaceID, we.BusinessID, a.HistoryShardCount)
+			deferStart := i
+			remaining = append(remaining, i)
+			for i+1 < len(request.Executions) {
+				next := request.Executions[i+1]
+				if common.WorkflowIDToHistoryShard(request.NamespaceID, next.BusinessID, a.HistoryShardCount) == hotShard {
+					i++
+					remaining = append(remaining, i)
+				} else {
+					break
+				}
+			}
+			a.Logger.Info("verifyBatch deferring stuck executions",
+				tag.WorkflowNamespace(request.Namespace),
+				tag.Int32("ShardID", hotShard),
+				tag.Int("DeferredCount", i-deferStart+1),
+				tag.Int("TotalDeferred", len(remaining)),
+			)
+			// Continue the outer loop from the next different-shard item.
+		} else {
+			return i, remaining, false, we, nil
 		}
-		onProgress(i + 1)
 	}
-	return len(request.Executions), true, nil, nil
+
+	return len(request.Executions), remaining, len(remaining) == 0, nil, nil
 }
 
 const (
 	defaultNoProgressNotRetryableTimeout = 30 * time.Minute
+	// defaultSkipAheadAfter is the duration after the last verified item at which verifyBatch
+	// starts deferring stuck items instead of blocking. Chosen as half the non-retryable timeout
+	// so there is still time to detect genuine failures after skip-ahead begins.
+	defaultSkipAheadAfter = defaultNoProgressNotRetryableTimeout / 2
 )
 
 func (a *activities) VerifyReplicationTasks(ctx context.Context, request *verifyReplicationTasksRequest) (verifyReplicationTasksResponse, error) {
@@ -993,23 +1054,34 @@ func (a *activities) VerifyReplicationTasks(ctx context.Context, request *verify
 			return response, ctx.Err()
 		}
 
-		nextIndex, done, lastUnverified, err := a.verifyBatch(
-			ctx, request, details.NextIndex, remoteAdminClient, nsEntry,
-			func(nextIdx int) {
+		nextIndex, remainingDeferred, done, lastUnverified, err := a.verifyBatch(
+			ctx, request,
+			details.NextIndex, details.DeferredIndices,
+			details.CheckPoint, defaultSkipAheadAfter,
+			remoteAdminClient, nsEntry,
+			func(nextIdx int, remaining []int) {
 				details.NextIndex = nextIdx
+				details.DeferredIndices = remaining
 				details.CheckPoint = time.Now()
 				activity.RecordHeartbeat(ctx, details)
 			},
 		)
+
+		details.NextIndex = nextIndex
+		details.DeferredIndices = remainingDeferred
+		switch {
+		case lastUnverified != nil:
+			// Sequential scan stopped at this unverified item.
+			details.LastNotVerifiedWorkflowExecution = lastUnverified
+		case len(remainingDeferred) > 0:
+			// All sequential items were processed but some are deferred; record one for diagnostics.
+			details.LastNotVerifiedWorkflowExecution = request.Executions[remainingDeferred[0]]
+		}
+		activity.RecordHeartbeat(ctx, details)
+
 		if err != nil {
 			return response, err
 		}
-
-		details.NextIndex = nextIndex
-		if lastUnverified != nil {
-			details.LastNotVerifiedWorkflowExecution = lastUnverified
-		}
-		activity.RecordHeartbeat(ctx, details)
 
 		if done {
 			response.VerifiedWorkflowCount = int64(len(request.Executions))

--- a/service/worker/migration/activities.go
+++ b/service/worker/migration/activities.go
@@ -959,7 +959,9 @@ func (a *activities) verifyBatch(
 			return startIndex, remaining, false, nil, verifyErr
 		}
 		if r.isVerified() {
-			onProgress(startIndex, remaining)
+			// Include not-yet-tried deferred items so the heartbeat is complete if the
+			// activity crashes between iterations.
+			onProgress(startIndex, append(remaining, deferredIndices[retryIdx+1:]...))
 		} else {
 			remaining = append(remaining, idx)
 		}

--- a/service/worker/migration/activities.go
+++ b/service/worker/migration/activities.go
@@ -985,12 +985,11 @@ func (a *activities) verifyBatch(
 			remaining = append(remaining, i)
 			for i+1 < len(request.Executions) {
 				next := request.Executions[i+1]
-				if common.WorkflowIDToHistoryShard(request.NamespaceID, next.BusinessID, a.HistoryShardCount) == hotShard {
-					i++
-					remaining = append(remaining, i)
-				} else {
+				if common.WorkflowIDToHistoryShard(request.NamespaceID, next.BusinessID, a.HistoryShardCount) != hotShard {
 					break
 				}
+				i++
+				remaining = append(remaining, i)
 			}
 			a.Logger.Info("verifyBatch deferring stuck executions",
 				tag.WorkflowNamespace(request.Namespace),
@@ -1071,12 +1070,9 @@ func (a *activities) VerifyReplicationTasks(ctx context.Context, request *verify
 
 		details.NextIndex = nextIndex
 		details.DeferredIndices = remainingDeferred
-		switch {
-		case lastUnverified != nil:
-			// Sequential scan stopped at this unverified item.
+		if lastUnverified != nil {
 			details.LastNotVerifiedWorkflowExecution = lastUnverified
-		case len(remainingDeferred) > 0:
-			// All sequential items were processed but some are deferred; record one for diagnostics.
+		} else if len(remainingDeferred) > 0 {
 			details.LastNotVerifiedWorkflowExecution = request.Executions[remainingDeferred[0]]
 		}
 		activity.RecordHeartbeat(ctx, details)

--- a/service/worker/migration/activities_test.go
+++ b/service/worker/migration/activities_test.go
@@ -506,7 +506,7 @@ Loop:
 	return executions
 }
 
-func (s *activitiesSuite) Test_verifyBatch() {
+func (s *activitiesSuite) TestVerifyBatch() {
 	s.a.HistoryShardCount = 1 // deterministic shard mapping for all test executions
 	request := verifyReplicationTasksRequest{
 		Namespace:         mockedNamespace,
@@ -602,13 +602,13 @@ func (s *activitiesSuite) Test_verifyBatch() {
 // are deferred and the scan continues past them. With HistoryShardCount=1 all executions share a
 // single shard, so the first failure causes all remaining items to be bulk-deferred without
 // further RPC calls — exercising the shard-aware consecutive-defer optimisation.
-func (s *activitiesSuite) Test_verifyBatchSkipAhead() {
+func (s *activitiesSuite) TestVerifyBatchSkipAhead() {
 	s.a.HistoryShardCount = 1
 	ctx := context.TODO()
 	pastThreshold := time.Time{} // zero time is always past any positive threshold
 
-	// Mocks: only items 0 (found) and 2 (not-found) are tried; items 3-4 share the same
-	// shard as 2 and are bulk-deferred without RPC calls.
+	// Mocks: only items 0 (found) and 1 (not-found) are tried; items 2-4 share the same
+	// shard as 1 and are bulk-deferred without RPC calls.
 	s.mockRemoteAdminClient.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&adminservice.DescribeMutableStateRequest{
 		Namespace: mockedNamespace,
 		Execution: &commonpb.WorkflowExecution{WorkflowId: execution1.BusinessID, RunId: execution1.RunID},
@@ -652,7 +652,7 @@ func (s *activitiesSuite) Test_verifyBatchSkipAhead() {
 
 // Test_verifyBatchDeferredRetry verifies that items in deferredIndices are retried at the start
 // of each call and removed from the deferred set when they succeed.
-func (s *activitiesSuite) Test_verifyBatchDeferredRetry() {
+func (s *activitiesSuite) TestVerifyBatchDeferredRetry() {
 	s.a.HistoryShardCount = 1
 	ctx := context.TODO()
 
@@ -685,7 +685,7 @@ func (s *activitiesSuite) Test_verifyBatchDeferredRetry() {
 	s.Equal(2, progressCallCount)
 }
 
-func (s *activitiesSuite) Test_verifyBatchNoProgress() {
+func (s *activitiesSuite) TestVerifyBatchNoProgress() {
 	s.a.HistoryShardCount = 1
 	request := verifyReplicationTasksRequest{
 		Namespace:         mockedNamespace,
@@ -744,7 +744,7 @@ func (s *activitiesSuite) Test_verifyBatchNoProgress() {
 	s.Equal(0, secondProgressCount)
 }
 
-func (s *activitiesSuite) Test_verifyBatchSkipRetention() {
+func (s *activitiesSuite) TestVerifyBatchSkipRetention() {
 	s.a.HistoryShardCount = 1
 	request := verifyReplicationTasksRequest{
 		Namespace:         mockedNamespace,

--- a/service/worker/migration/activities_test.go
+++ b/service/worker/migration/activities_test.go
@@ -502,15 +502,7 @@ Loop:
 	return executions
 }
 
-type mockHeartBeatRecorder struct {
-	lastHeartBeat replicationTasksHeartbeatDetails
-}
-
-func (m *mockHeartBeatRecorder) hearbeat(details replicationTasksHeartbeatDetails) {
-	m.lastHeartBeat = details
-}
-
-func (s *activitiesSuite) Test_verifyReplicationTasks() {
+func (s *activitiesSuite) Test_verifyBatch() {
 	request := verifyReplicationTasksRequest{
 		Namespace:         mockedNamespace,
 		NamespaceID:       mockedNamespaceID,
@@ -521,41 +513,36 @@ func (s *activitiesSuite) Test_verifyReplicationTasks() {
 
 	var tests = []struct {
 		remoteExecutionStates []executionState
-		nextIndex             int
-		expectedVerified      bool
+		startIndex            int
+		expectedDone          bool
 		expectedErr           error
 		expectedNextIndex     int
 	}{
 		{
-			expectedVerified: true,
-			expectedErr:      nil,
+			expectedDone: true,
 		},
 		{
 			remoteExecutionStates: []executionState{executionFound, executionFound, executionFound, executionFound},
-			nextIndex:             0,
-			expectedVerified:      true,
-			expectedErr:           nil,
+			startIndex:            0,
+			expectedDone:          true,
 			expectedNextIndex:     4,
 		},
 		{
 			remoteExecutionStates: []executionState{executionFound, executionFound, executionFound, executionFound},
-			nextIndex:             2,
-			expectedVerified:      true,
-			expectedErr:           nil,
+			startIndex:            2,
+			expectedDone:          true,
 			expectedNextIndex:     4,
 		},
 		{
 			remoteExecutionStates: []executionState{executionFound, executionFound, executionNotfound},
-			nextIndex:             0,
-			expectedVerified:      false,
-			expectedErr:           nil,
+			startIndex:            0,
+			expectedDone:          false,
 			expectedNextIndex:     2,
 		},
 		{
 			remoteExecutionStates: []executionState{executionFound, executionFound, executionNotfound, executionFound, executionNotfound},
-			nextIndex:             0,
-			expectedVerified:      false,
-			expectedErr:           nil,
+			startIndex:            0,
+			expectedDone:          false,
 			expectedNextIndex:     2,
 		},
 	}
@@ -570,38 +557,39 @@ func (s *activitiesSuite) Test_verifyReplicationTasks() {
 		SkipForceReload: true,
 	})).Return(completeState, nil).AnyTimes()
 
-	checkPointTime := time.Now()
 	for _, tc := range tests {
-		var recorder mockHeartBeatRecorder
-		// mockRemoteClient := workflowservicemock.NewMockWorkflowServiceClient(s.controller)
-		request.Executions = createExecutions(s.mockRemoteAdminClient, tc.remoteExecutionStates, tc.nextIndex)
-		details := replicationTasksHeartbeatDetails{
-			NextIndex:  tc.nextIndex,
-			CheckPoint: checkPointTime,
-		}
+		request.Executions = createExecutions(s.mockRemoteAdminClient, tc.remoteExecutionStates, tc.startIndex)
 
-		verified, err := s.a.verifyReplicationTasks(ctx, &request, &details, s.mockRemoteAdminClient, &testNamespace, recorder.hearbeat)
+		var progressCallCount int
+		var lastProgressIndex int
+		nextIndex, done, lastUnverified, err := s.a.verifyBatch(
+			ctx, &request, tc.startIndex, s.mockRemoteAdminClient, &testNamespace,
+			func(ni int) {
+				lastProgressIndex = ni
+				progressCallCount++
+			},
+		)
+
 		if tc.expectedErr == nil {
 			s.NoError(err)
 		}
-		s.Equal(tc.expectedVerified, verified)
-		s.Equal(tc.expectedNextIndex, details.NextIndex)
-		s.GreaterOrEqual(len(tc.remoteExecutionStates), details.NextIndex)
-		s.Equal(recorder.lastHeartBeat, details)
-		if details.NextIndex < len(tc.remoteExecutionStates) && tc.remoteExecutionStates[details.NextIndex] == executionNotfound {
-			s.Equal(execution1, details.LastNotVerifiedWorkflowExecution)
+		s.Equal(tc.expectedDone, done)
+		s.Equal(tc.expectedNextIndex, nextIndex)
+		s.GreaterOrEqual(len(tc.remoteExecutionStates), nextIndex)
+
+		if nextIndex < len(tc.remoteExecutionStates) && tc.remoteExecutionStates[nextIndex] == executionNotfound {
+			s.Equal(execution1, lastUnverified)
 		}
 
 		if len(request.Executions) > 0 {
-			// Except for empty Executions, all should set new CheckPoint to indicate making progress.
-			s.True(checkPointTime.Before(details.CheckPoint))
+			// Except for empty Executions, onProgress should have been called to signal progress.
+			s.Greater(progressCallCount, 0)
+			s.Equal(nextIndex, lastProgressIndex)
 		}
 	}
 }
 
-func (s *activitiesSuite) Test_verifyReplicationTasksNoProgress() {
-	var recorder mockHeartBeatRecorder
-
+func (s *activitiesSuite) Test_verifyBatchNoProgress() {
 	request := verifyReplicationTasksRequest{
 		Namespace:         mockedNamespace,
 		NamespaceID:       mockedNamespaceID,
@@ -619,23 +607,19 @@ func (s *activitiesSuite) Test_verifyReplicationTasksNoProgress() {
 		SkipForceReload: true,
 	})).Return(completeState, nil).AnyTimes()
 
-	checkPointTime := time.Now()
-	details := replicationTasksHeartbeatDetails{
-		NextIndex:  0,
-		CheckPoint: checkPointTime,
-	}
-
 	ctx := context.TODO()
-	verified, err := s.a.verifyReplicationTasks(ctx, &request, &details, s.mockRemoteAdminClient, &testNamespace, recorder.hearbeat)
+
+	var firstProgressCount int
+	nextIndex, done, _, err := s.a.verifyBatch(
+		ctx, &request, 0, s.mockRemoteAdminClient, &testNamespace,
+		func(ni int) { firstProgressCount++ },
+	)
 	s.NoError(err)
-	s.False(verified)
-	// Verify has made progress.
-	s.True(checkPointTime.Before(details.CheckPoint))
-	s.Equal(2, details.NextIndex)
+	s.False(done)
+	s.Equal(2, nextIndex)
+	s.Equal(2, firstProgressCount) // items 0 and 1 verified
 
-	prevDetails := details
-
-	// Mock for one more NotFound call
+	// Mock for one more NotFound call when retrying from nextIndex.
 	s.mockRemoteAdminClient.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&adminservice.DescribeMutableStateRequest{
 		Namespace: mockedNamespace,
 		Execution: &commonpb.WorkflowExecution{
@@ -647,14 +631,19 @@ func (s *activitiesSuite) Test_verifyReplicationTasksNoProgress() {
 		SkipForceReload: true,
 	})).Return(nil, serviceerror.NewNotFound("")).Times(1)
 
-	// All results should be either NotFound or cached and no progress should be made.
-	verified, err = s.a.verifyReplicationTasks(ctx, &request, &details, s.mockRemoteAdminClient, &testNamespace, recorder.hearbeat)
+	// Retrying from the same index makes no progress.
+	var secondProgressCount int
+	nextIndex2, done2, _, err := s.a.verifyBatch(
+		ctx, &request, nextIndex, s.mockRemoteAdminClient, &testNamespace,
+		func(ni int) { secondProgressCount++ },
+	)
 	s.NoError(err)
-	s.False(verified)
-	s.Equal(prevDetails, details)
+	s.False(done2)
+	s.Equal(nextIndex, nextIndex2)
+	s.Equal(0, secondProgressCount)
 }
 
-func (s *activitiesSuite) Test_verifyReplicationTasksSkipRetention() {
+func (s *activitiesSuite) Test_verifyBatchSkipRetention() {
 	request := verifyReplicationTasksRequest{
 		Namespace:         mockedNamespace,
 		NamespaceID:       mockedNamespaceID,
@@ -663,21 +652,20 @@ func (s *activitiesSuite) Test_verifyReplicationTasksSkipRetention() {
 	}
 
 	var tests = []struct {
-		deleteDiff time.Duration // diff between deleteTime and now
-		verified   bool
+		deleteDiff  time.Duration // diff between deleteTime and now
+		expectedDone bool
 	}{
 		{
-			-30 * time.Second,
-			true,
+			deleteDiff:   -30 * time.Second,
+			expectedDone: true,
 		},
 		{
-			30 * time.Second,
-			false,
+			deleteDiff:   30 * time.Second,
+			expectedDone: false,
 		},
 	}
 
 	for _, tc := range tests {
-		var recorder mockHeartBeatRecorder
 		deleteTime := time.Now().Add(tc.deleteDiff)
 		retention := time.Hour
 		closeTime := deleteTime.Add(-retention)
@@ -723,12 +711,13 @@ func (s *activitiesSuite) Test_verifyReplicationTasksSkipRetention() {
 		ns, nsErr := namespace.FromPersistentState(detail, factory(detail))
 		s.Require().NoError(nsErr)
 
-		details := replicationTasksHeartbeatDetails{}
 		ctx := context.TODO()
-		verified, err := s.a.verifyReplicationTasks(ctx, &request, &details, s.mockRemoteAdminClient, ns, recorder.hearbeat)
+		_, done, lastUnverified, err := s.a.verifyBatch(ctx, &request, 0, s.mockRemoteAdminClient, ns, func(int) {})
 		s.NoError(err)
-		s.Equal(tc.verified, verified)
-		s.Equal(recorder.lastHeartBeat, details)
+		s.Equal(tc.expectedDone, done)
+		if !done {
+			s.Equal(execution1, lastUnverified)
+		}
 	}
 }
 

--- a/service/worker/migration/activities_test.go
+++ b/service/worker/migration/activities_test.go
@@ -592,7 +592,7 @@ func (s *activitiesSuite) TestVerifyBatch() {
 
 		if len(request.Executions) > 0 {
 			// Except for empty Executions, onProgress should have been called for progress.
-			s.Greater(progressCallCount, 0)
+			s.Positive(progressCallCount)
 			s.Equal(nextIndex, lastProgressIndex)
 		}
 	}

--- a/service/worker/migration/activities_test.go
+++ b/service/worker/migration/activities_test.go
@@ -133,6 +133,7 @@ func (s *activitiesSuite) SetupTest() {
 	s.NoError(err)
 
 	s.a = &activities{
+		HistoryShardCount:                1,
 		NamespaceRegistry:                s.mockNamespaceRegistry,
 		namespaceReplicationQueue:        s.mockNamespaceReplicationQueue,
 		clientFactory:                    s.mockClientFactory,
@@ -348,7 +349,10 @@ func (s *activitiesSuite) TestVerifyReplicationTasks_FailedNotFound() {
 
 	s.Greater(len(iceptor.replicationRecordedHeartbeats), 0)
 	lastHeartBeat := iceptor.replicationRecordedHeartbeats[len(iceptor.replicationRecordedHeartbeats)-1]
-	s.Equal(0, lastHeartBeat.NextIndex)
+	// With skip-ahead active (checkpoint is past the threshold), the item is deferred rather than
+	// stopping the sequential frontier; NextIndex advances to 1 (past the only item).
+	s.Equal(1, lastHeartBeat.NextIndex)
+	s.Equal([]int{0}, lastHeartBeat.DeferredIndices)
 	s.Equal(execution1, lastHeartBeat.LastNotVerifiedWorkflowExecution)
 }
 
@@ -503,6 +507,7 @@ Loop:
 }
 
 func (s *activitiesSuite) Test_verifyBatch() {
+	s.a.HistoryShardCount = 1 // deterministic shard mapping for all test executions
 	request := verifyReplicationTasksRequest{
 		Namespace:         mockedNamespace,
 		NamespaceID:       mockedNamespaceID,
@@ -510,6 +515,7 @@ func (s *activitiesSuite) Test_verifyBatch() {
 	}
 
 	ctx := context.TODO()
+	notPastThreshold := time.Now()
 
 	var tests = []struct {
 		remoteExecutionStates []executionState
@@ -562,9 +568,11 @@ func (s *activitiesSuite) Test_verifyBatch() {
 
 		var progressCallCount int
 		var lastProgressIndex int
-		nextIndex, done, lastUnverified, err := s.a.verifyBatch(
-			ctx, &request, tc.startIndex, s.mockRemoteAdminClient, &testNamespace,
-			func(ni int) {
+		nextIndex, remainingDeferred, done, lastUnverified, err := s.a.verifyBatch(
+			ctx, &request,
+			tc.startIndex, nil, notPastThreshold, defaultSkipAheadAfter,
+			s.mockRemoteAdminClient, &testNamespace,
+			func(ni int, rem []int) {
 				lastProgressIndex = ni
 				progressCallCount++
 			},
@@ -575,6 +583,7 @@ func (s *activitiesSuite) Test_verifyBatch() {
 		}
 		s.Equal(tc.expectedDone, done)
 		s.Equal(tc.expectedNextIndex, nextIndex)
+		s.Empty(remainingDeferred)
 		s.GreaterOrEqual(len(tc.remoteExecutionStates), nextIndex)
 
 		if nextIndex < len(tc.remoteExecutionStates) && tc.remoteExecutionStates[nextIndex] == executionNotfound {
@@ -582,14 +591,102 @@ func (s *activitiesSuite) Test_verifyBatch() {
 		}
 
 		if len(request.Executions) > 0 {
-			// Except for empty Executions, onProgress should have been called to signal progress.
+			// Except for empty Executions, onProgress should have been called for progress.
 			s.Greater(progressCallCount, 0)
 			s.Equal(nextIndex, lastProgressIndex)
 		}
 	}
 }
 
+// Test_verifyBatchSkipAhead verifies that once the skip-ahead threshold is exceeded, stuck items
+// are deferred and the scan continues past them. With HistoryShardCount=1 all executions share a
+// single shard, so the first failure causes all remaining items to be bulk-deferred without
+// further RPC calls — exercising the shard-aware consecutive-defer optimisation.
+func (s *activitiesSuite) Test_verifyBatchSkipAhead() {
+	s.a.HistoryShardCount = 1
+	ctx := context.TODO()
+	pastThreshold := time.Time{} // zero time is always past any positive threshold
+
+	// Mocks: only items 0 (found) and 2 (not-found) are tried; items 3-4 share the same
+	// shard as 2 and are bulk-deferred without RPC calls.
+	s.mockRemoteAdminClient.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&adminservice.DescribeMutableStateRequest{
+		Namespace: mockedNamespace,
+		Execution: &commonpb.WorkflowExecution{WorkflowId: execution1.BusinessID, RunId: execution1.RunID},
+		Archetype:       chasm.WorkflowArchetype,
+		ArchetypeId:     execution1.ArchetypeID,
+		SkipForceReload: true,
+	})).Return(&adminservice.DescribeMutableStateResponse{}, nil).Times(1) // item 0 found
+
+	s.mockRemoteAdminClient.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&adminservice.DescribeMutableStateRequest{
+		Namespace: mockedNamespace,
+		Execution: &commonpb.WorkflowExecution{WorkflowId: execution1.BusinessID, RunId: execution1.RunID},
+		Archetype:       chasm.WorkflowArchetype,
+		ArchetypeId:     execution1.ArchetypeID,
+		SkipForceReload: true,
+	})).Return(nil, serviceerror.NewNotFound("")).Times(1) // item 1 not found (triggers skip-ahead)
+
+	request := verifyReplicationTasksRequest{
+		Namespace:         mockedNamespace,
+		NamespaceID:       mockedNamespaceID,
+		TargetClusterName: remoteCluster,
+		Executions:        []*ExecutionInfo{execution1, execution1, execution1, execution1, execution1}, // 5 items, all shard 1
+	}
+
+	s.mockHistoryClient.EXPECT().DescribeMutableState(gomock.Any(), gomock.Any()).Return(completeState, nil).AnyTimes()
+
+	var progressCallCount int
+	nextIndex, remainingDeferred, done, lastUnverified, err := s.a.verifyBatch(
+		ctx, &request,
+		0, nil, pastThreshold, defaultSkipAheadAfter,
+		s.mockRemoteAdminClient, &testNamespace,
+		func(ni int, rem []int) { progressCallCount++ },
+	)
+
+	s.NoError(err)
+	s.False(done)
+	s.Equal(5, nextIndex)                        // scan reached the end
+	s.Equal([]int{1, 2, 3, 4}, remainingDeferred) // item 1 and all same-shard items deferred
+	s.Nil(lastUnverified)                         // no sequential stop point; items were deferred
+	s.Equal(1, progressCallCount)                 // only item 0 was verified
+}
+
+// Test_verifyBatchDeferredRetry verifies that items in deferredIndices are retried at the start
+// of each call and removed from the deferred set when they succeed.
+func (s *activitiesSuite) Test_verifyBatchDeferredRetry() {
+	s.a.HistoryShardCount = 1
+	ctx := context.TODO()
+
+	// Three executions; items 0 and 2 were previously deferred. The sequential frontier is at 3
+	// (past the end), so only the deferred retry phase runs.
+	executions := []*ExecutionInfo{execution1, execution1, execution1}
+	request := verifyReplicationTasksRequest{
+		Namespace:         mockedNamespace,
+		NamespaceID:       mockedNamespaceID,
+		TargetClusterName: remoteCluster,
+		Executions:        executions,
+	}
+
+	// Deferred items 0 and 2 are now found on the remote cluster.
+	s.mockRemoteAdminClient.EXPECT().DescribeMutableState(gomock.Any(), gomock.Any()).
+		Return(&adminservice.DescribeMutableStateResponse{}, nil).Times(2)
+
+	var progressCallCount int
+	nextIndex, remainingDeferred, done, _, err := s.a.verifyBatch(
+		ctx, &request,
+		3, []int{0, 2}, time.Now(), defaultSkipAheadAfter,
+		s.mockRemoteAdminClient, &testNamespace,
+		func(ni int, rem []int) { progressCallCount++ },
+	)
+
+	s.NoError(err)
+	s.True(done)
+	s.Equal(3, nextIndex)        // sequential frontier unchanged
+	s.Empty(remainingDeferred)   // both deferred items verified
+	s.Equal(2, progressCallCount)
+}
+
 func (s *activitiesSuite) Test_verifyBatchNoProgress() {
+	s.a.HistoryShardCount = 1
 	request := verifyReplicationTasksRequest{
 		Namespace:         mockedNamespace,
 		NamespaceID:       mockedNamespaceID,
@@ -610,9 +707,11 @@ func (s *activitiesSuite) Test_verifyBatchNoProgress() {
 	ctx := context.TODO()
 
 	var firstProgressCount int
-	nextIndex, done, _, err := s.a.verifyBatch(
-		ctx, &request, 0, s.mockRemoteAdminClient, &testNamespace,
-		func(ni int) { firstProgressCount++ },
+	nextIndex, _, done, _, err := s.a.verifyBatch(
+		ctx, &request,
+		0, nil, time.Now(), defaultSkipAheadAfter,
+		s.mockRemoteAdminClient, &testNamespace,
+		func(ni int, rem []int) { firstProgressCount++ },
 	)
 	s.NoError(err)
 	s.False(done)
@@ -633,9 +732,11 @@ func (s *activitiesSuite) Test_verifyBatchNoProgress() {
 
 	// Retrying from the same index makes no progress.
 	var secondProgressCount int
-	nextIndex2, done2, _, err := s.a.verifyBatch(
-		ctx, &request, nextIndex, s.mockRemoteAdminClient, &testNamespace,
-		func(ni int) { secondProgressCount++ },
+	nextIndex2, _, done2, _, err := s.a.verifyBatch(
+		ctx, &request,
+		nextIndex, nil, time.Now(), defaultSkipAheadAfter,
+		s.mockRemoteAdminClient, &testNamespace,
+		func(ni int, rem []int) { secondProgressCount++ },
 	)
 	s.NoError(err)
 	s.False(done2)
@@ -644,6 +745,7 @@ func (s *activitiesSuite) Test_verifyBatchNoProgress() {
 }
 
 func (s *activitiesSuite) Test_verifyBatchSkipRetention() {
+	s.a.HistoryShardCount = 1
 	request := verifyReplicationTasksRequest{
 		Namespace:         mockedNamespace,
 		NamespaceID:       mockedNamespaceID,
@@ -652,7 +754,7 @@ func (s *activitiesSuite) Test_verifyBatchSkipRetention() {
 	}
 
 	var tests = []struct {
-		deleteDiff  time.Duration // diff between deleteTime and now
+		deleteDiff   time.Duration // diff between deleteTime and now
 		expectedDone bool
 	}{
 		{
@@ -712,7 +814,12 @@ func (s *activitiesSuite) Test_verifyBatchSkipRetention() {
 		s.Require().NoError(nsErr)
 
 		ctx := context.TODO()
-		_, done, lastUnverified, err := s.a.verifyBatch(ctx, &request, 0, s.mockRemoteAdminClient, ns, func(int) {})
+		_, _, done, lastUnverified, err := s.a.verifyBatch(
+			ctx, &request,
+			0, nil, time.Now(), defaultSkipAheadAfter,
+			s.mockRemoteAdminClient, ns,
+			func(int, []int) {},
+		)
 		s.NoError(err)
 		s.Equal(tc.expectedDone, done)
 		if !done {

--- a/service/worker/migration/activities_test.go
+++ b/service/worker/migration/activities_test.go
@@ -610,16 +610,16 @@ func (s *activitiesSuite) TestVerifyBatchSkipAhead() {
 	// Mocks: only items 0 (found) and 1 (not-found) are tried; items 2-4 share the same
 	// shard as 1 and are bulk-deferred without RPC calls.
 	s.mockRemoteAdminClient.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&adminservice.DescribeMutableStateRequest{
-		Namespace: mockedNamespace,
-		Execution: &commonpb.WorkflowExecution{WorkflowId: execution1.BusinessID, RunId: execution1.RunID},
+		Namespace:       mockedNamespace,
+		Execution:       &commonpb.WorkflowExecution{WorkflowId: execution1.BusinessID, RunId: execution1.RunID},
 		Archetype:       chasm.WorkflowArchetype,
 		ArchetypeId:     execution1.ArchetypeID,
 		SkipForceReload: true,
 	})).Return(&adminservice.DescribeMutableStateResponse{}, nil).Times(1) // item 0 found
 
 	s.mockRemoteAdminClient.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&adminservice.DescribeMutableStateRequest{
-		Namespace: mockedNamespace,
-		Execution: &commonpb.WorkflowExecution{WorkflowId: execution1.BusinessID, RunId: execution1.RunID},
+		Namespace:       mockedNamespace,
+		Execution:       &commonpb.WorkflowExecution{WorkflowId: execution1.BusinessID, RunId: execution1.RunID},
 		Archetype:       chasm.WorkflowArchetype,
 		ArchetypeId:     execution1.ArchetypeID,
 		SkipForceReload: true,
@@ -644,7 +644,7 @@ func (s *activitiesSuite) TestVerifyBatchSkipAhead() {
 
 	s.NoError(err)
 	s.False(done)
-	s.Equal(5, nextIndex)                        // scan reached the end
+	s.Equal(5, nextIndex)                         // scan reached the end
 	s.Equal([]int{1, 2, 3, 4}, remainingDeferred) // item 1 and all same-shard items deferred
 	s.Nil(lastUnverified)                         // no sequential stop point; items were deferred
 	s.Equal(1, progressCallCount)                 // only item 0 was verified
@@ -680,8 +680,8 @@ func (s *activitiesSuite) TestVerifyBatchDeferredRetry() {
 
 	s.NoError(err)
 	s.True(done)
-	s.Equal(3, nextIndex)        // sequential frontier unchanged
-	s.Empty(remainingDeferred)   // both deferred items verified
+	s.Equal(3, nextIndex)      // sequential frontier unchanged
+	s.Empty(remainingDeferred) // both deferred items verified
 	s.Equal(2, progressCallCount)
 }
 


### PR DESCRIPTION
## What changed?
Allow VerifyReplicationTasks to skip ahead and try other tasks once we're half way through our progress deadline window. Refactored the heartbeating code.

## Why?
If there is shard contention some tasks may take a while to replicate causing us to hit our progress deadline and report failure. Give ourselves a better chance of eventually reaching completion by checking if progress has been made on any  other tasks in the batch that are on a different shard, giving the slow shard more time to work through a backlog. This will also help us identify if a slow shard was the cause of failure due to the added logging.

The heartbeating code was refactored to avoid mutating the heartbeat details in multiple places, which was hard to follow.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the control flow for replication verification/heartbeating, which could affect migration completion or timeout behavior under replication lag or shard contention. Logic is unit-tested but touches a core migration activity loop and retry semantics.
> 
> **Overview**
> `VerifyReplicationTasks` now supports *skip-ahead* verification when progress stalls: after `defaultSkipAheadAfter` it defers stuck executions (tracked via new heartbeat field `DeferredIndices`) and continues verifying other executions, bulk-deferring consecutive items on the same source shard and logging shard deferrals.
> 
> The old in-loop verification/heartbeating is refactored into `verifyBatch`, which (1) retries deferred items first and (2) advances the sequential frontier while emitting progress callbacks that update heartbeat/checkpoint; tests are updated and expanded to cover skip-ahead, deferred retry, and updated heartbeat expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a31fd7f7aa42191bc95c1786f552c0cba1d15888. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->