### PR TITLE
Replace calls to payload.Encode with sadefs.EncodeValue

### DIFF
--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -20,7 +20,6 @@ import (
 	"go.temporal.io/server/common/contextutil"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/primitives/timestamp"
-	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/service/worker/scheduler"
 	"google.golang.org/protobuf/proto"
@@ -938,15 +937,15 @@ func (s *Scheduler) ListInfo(
 func (s *Scheduler) startWorkflowSearchAttributes(
 	nominal time.Time,
 ) *commonpb.SearchAttributes {
-	attributes := s.Schedule.GetAction().GetStartWorkflow().GetSearchAttributes()
-
-	fields := util.CloneMapNonNil(attributes.GetIndexedFields())
-	if p, err := payload.Encode(nominal); err == nil {
-		fields[sadefs.TemporalScheduledStartTime] = p
-	}
-	if p, err := payload.Encode(s.ScheduleId); err == nil {
-		fields[sadefs.TemporalScheduledById] = p
-	}
+	scheduledStartTime := chasm.SearchAttributeTemporalScheduledStartTime.Value(nominal)
+	scheduledByID := chasm.SearchAttributeTemporalScheduledByID.Value(s.ScheduleId)
+	fields := payload.MergeMapOfPayload(
+		s.Schedule.GetAction().GetStartWorkflow().GetSearchAttributes().GetIndexedFields(),
+		map[string]*commonpb.Payload{
+			scheduledStartTime.Field: scheduledStartTime.Value.MustEncode(),
+			scheduledByID.Field:      scheduledByID.Value.MustEncode(),
+		},
+	)
 	return &commonpb.SearchAttributes{
 		IndexedFields: fields,
 	}

--- a/common/searchattribute/stringify.go
+++ b/common/searchattribute/stringify.go
@@ -10,7 +10,6 @@ import (
 
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
-	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 )
 
@@ -121,13 +120,7 @@ func parseValueOrArray(valStr string, t enumspb.IndexedValueType) (*commonpb.Pay
 		}
 	}
 
-	valPayload, err := payload.Encode(val)
-	if err != nil {
-		return nil, err
-	}
-
-	sadefs.SetMetadataType(valPayload, t)
-	return valPayload, nil
+	return sadefs.EncodeValue(val, t)
 }
 
 func parseValueTyped(valStr string, t enumspb.IndexedValueType) (any, error) {

--- a/service/history/visibility_queue_task_executor.go
+++ b/service/history/visibility_queue_task_executor.go
@@ -576,8 +576,8 @@ func (t *visibilityQueueTaskExecutor) getClosedVisibilityRequest(
 		externalPayloadCount := executionInfo.GetExecutionStats().GetExternalPayloadCount()
 		externalPayloadSizeBytes := executionInfo.GetExecutionStats().GetExternalPayloadSize()
 		if externalPayloadCount > 0 {
-			externalPayloadCountPayload, _ := payload.Encode(externalPayloadCount)
-			externalPayloadSizeBytesPayload, _ := payload.Encode(externalPayloadSizeBytes)
+			externalPayloadCountPayload := sadefs.MustEncodeValue(externalPayloadCount, enumspb.INDEXED_VALUE_TYPE_INT)
+			externalPayloadSizeBytesPayload := sadefs.MustEncodeValue(externalPayloadSizeBytes, enumspb.INDEXED_VALUE_TYPE_INT)
 			base.SearchAttributes.IndexedFields[sadefs.TemporalExternalPayloadCount] = externalPayloadCountPayload
 			base.SearchAttributes.IndexedFields[sadefs.TemporalExternalPayloadSizeBytes] = externalPayloadSizeBytesPayload
 		}


### PR DESCRIPTION
## What changed?
Replace calls to `payload.Encode` with `sadefs.EncodeValue`/`sadefs.MustEncodeValue`.

## Why?
`payload.Encode` doesn't set the metadata type, which might be useful when decoding. Besides, encoding search attributes value should've used `sadefs.EncodeValue` anyway.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

