### PR TITLE
Improve chasm Map deserialization/serialization logic

### DIFF
--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -893,8 +893,17 @@ func (n *Node) syncSubComponents() error {
 				internalField.Set(reflect.ValueOf(internal))
 			}
 		case fieldKindSubMap:
-			if field.val.IsNil() {
-				// If Map field is nil then delete all collection items nodes and collection node itself.
+			// Validate map type before doing anything with it.
+			if !field.val.IsNil() && field.val.Kind() != reflect.Map {
+				return softassert.UnexpectedInternalErr(
+					n.logger,
+					"CHASM map must be of map type",
+					fmt.Errorf("node %s", n.nodeName))
+			}
+
+			if field.val.IsNil() || len(field.val.MapKeys()) == 0 {
+				// nil or empty map: skip without creating a collection node.
+				// Any existing collection node will be removed by deleteChildren below.
 				continue
 			}
 
@@ -904,19 +913,6 @@ func (n *Node) syncSubComponents() error {
 				collectionNode.initSerializedCollectionNode()
 				collectionNode.setValueState(valueStateNeedSyncStructure)
 				n.children[field.name] = collectionNode
-			}
-
-			// Validate map type.
-			if field.val.Kind() != reflect.Map {
-				return softassert.UnexpectedInternalErr(
-					n.logger,
-					"CHASM map must be of map type",
-					fmt.Errorf("node %s", n.nodeName))
-			}
-
-			if len(field.val.MapKeys()) == 0 {
-				// If Map field is empty then delete all collection items nodes and collection node itself.
-				continue
 			}
 
 			mapValT := field.typ.Elem()
@@ -1291,6 +1287,8 @@ func (n *Node) deserializeComponentNode(
 					}
 					mapFieldV.SetMapIndex(mapKeyV, chasmFieldV)
 				}
+			} else if field.val.IsNil() {
+				field.val.Set(reflect.MakeMap(field.typ))
 			}
 		case fieldKindMutableState:
 			field.val.Set(reflect.ValueOf(NewMSPointer(n.backend)))

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -439,6 +439,37 @@ func (s *nodeSuite) TestCollectionAttributes() {
 	}
 }
 
+func (s *nodeSuite) TestMapDeserializeNilToEmpty() {
+	// Verify that a Map field that was never set deserializes to an empty (non-nil)
+	// map so callers can range over it without nil checks.
+	var nilSerializedNodes map[string]*persistencespb.ChasmNode
+	rootNode, err := s.newTestTree(nilSerializedNodes)
+	s.NoError(err)
+
+	rootNode.value = &TestComponent{}
+	rootNode.valueState = valueStateNeedSyncStructure
+
+	mutations, err := rootNode.CloseTransaction()
+	s.NoError(err)
+	// Only root is updated; no collection nodes because maps were nil/empty.
+	s.Len(mutations.UpdatedNodes, 1)
+	s.Empty(mutations.DeletedNodes)
+
+	persistedNodes := common.CloneProtoMap(mutations.UpdatedNodes)
+
+	rootNode2, err := s.newTestTree(persistedNodes)
+	s.NoError(err)
+
+	err = rootNode2.deserialize(reflect.TypeFor[*TestComponent]())
+	s.NoError(err)
+
+	rootComponent := rootNode2.value.(*TestComponent)
+	s.NotNil(rootComponent.SubComponents, "SubComponents must be non-nil after deserialization")
+	s.Empty(rootComponent.SubComponents)
+	s.NotNil(rootComponent.PendingActivities, "PendingActivities must be non-nil after deserialization")
+	s.Empty(rootComponent.PendingActivities)
+}
+
 func (s *nodeSuite) TestPointerAttributes() {
 	var persistedNodes map[string]*persistencespb.ChasmNode
 

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -436,6 +436,47 @@ func (s *nodeSuite) TestCollectionAttributes() {
 			s.Len(mutation.UpdatedNodes, 1, "although root component is not updated, collection is tracked as part of component, therefore root must be updated")
 			s.Len(mutation.DeletedNodes, 3, "collection and 2 items must be deleted")
 		})
+
+		s.Run("Nil map "+tc.name+" on first transaction produces no deletions", func() {
+			// A map field that was never set (nil) should not produce any DeletedNodes
+			// entries when the first transaction is closed — there is nothing in persistence
+			// to delete.
+			var nilSerializedNodes map[string]*persistencespb.ChasmNode
+			rootNode, err := s.newTestTree(nilSerializedNodes)
+			s.NoError(err)
+
+			rootNode.value = &TestComponent{} // all map fields are nil
+			rootNode.valueState = valueStateNeedSyncStructure
+
+			mutation, err := rootNode.CloseTransaction()
+			s.NoError(err)
+			s.Empty(mutation.DeletedNodes, "no nodes should be deleted for a map that never existed")
+		})
+
+		s.Run("Empty (non-nil) map "+tc.name+" on first transaction produces no deletions", func() {
+			// A map field initialized to an empty (non-nil) map should also not produce
+			// any DeletedNodes entries — an empty map is equivalent to nil at the
+			// persistence layer and there is nothing to delete.
+			var nilSerializedNodes map[string]*persistencespb.ChasmNode
+			rootNode, err := s.newTestTree(nilSerializedNodes)
+			s.NoError(err)
+
+			var rootComponent TestComponent
+			switch tc.mapField {
+			case "SubComponents":
+				rootComponent.SubComponents = Map[string, *TestSubComponent1]{}
+			case "PendingActivities":
+				rootComponent.PendingActivities = Map[int, *TestSubComponent1]{}
+			default:
+				s.Failf("unexpected mapField", "unknown mapField %q in test case", tc.mapField)
+			}
+			rootNode.value = &rootComponent
+			rootNode.valueState = valueStateNeedSyncStructure
+
+			mutation, err := rootNode.CloseTransaction()
+			s.NoError(err)
+			s.Empty(mutation.DeletedNodes, "no nodes should be deleted for a newly-created empty map")
+		})
 	}
 }
 


### PR DESCRIPTION
## What changed?
Improve chasm Map deserialization/serialization logic

## Why?
chasm.Map should not be added to DeletedNodes if never persisted. When deserializing, it should always be initialized to avoid excessive nil checks.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)
