### PR TITLE
Preserve metadata for json/plain payloads in nexus serializer

### DIFF
--- a/common/nexus/payload_serializer.go
+++ b/common/nexus/payload_serializer.go
@@ -139,6 +139,9 @@ func (payloadSerializer) Serialize(v any) (*nexus.Content, error) {
 		}
 		content.Header["type"] = fmt.Sprintf("application/x-protobuf; message-type=%q", messageType)
 	case "json/plain":
+		if len(payload.Metadata) != 1 {
+			return xTemporalPayload(payload)
+		}
 		content.Header["type"] = "application/json"
 	case "binary/null":
 		if len(payload.Metadata) != 1 {

--- a/common/nexus/payload_serializer_test.go
+++ b/common/nexus/payload_serializer_test.go
@@ -124,6 +124,17 @@ func TestNexusPayloadSerializer(t *testing.T) {
 			header: nexus.Header{"type": "application/x-temporal-payload"},
 		},
 		{
+			name: "json/plain with non-standard metadata field",
+			inputPayload: &commonpb.Payload{
+				Data: []byte(`"data"`),
+				Metadata: map[string][]byte{
+					"encoding":     []byte("json/plain"),
+					"non-standard": []byte("value"),
+				},
+			},
+			header: nexus.Header{"type": "application/x-temporal-payload"},
+		},
+		{
 			name: "nexus content with non-standard header",
 			inputPayload: &commonpb.Payload{
 				Metadata: map[string][]byte{


### PR DESCRIPTION
When a payload with json/plain encoding had additional metadata fields, those fields were silently dropped during nexus serialization. Fall back to x-temporal-payload to preserve the full payload, matching the behavior already in place for other encodings.