### PR TITLE
Guard against overlapping dynamic config overrides

### DIFF
--- a/common/testing/parallelsuite/suite.go
+++ b/common/testing/parallelsuite/suite.go
@@ -59,6 +59,19 @@ func (s *Suite[T]) T() *testing.T {
 	return s.guardT.T
 }
 
+// Name returns the name of the underlying *testing.T. Provided so that *Suite
+// can be passed directly where a `Name() string` interface is expected (e.g.
+// testcore.DynamicConfigT) without forcing the caller to dereference via T().
+func (s *Suite[T]) Name() string {
+	return s.T().Name()
+}
+
+// Fatalf forwards to the underlying *testing.T.Fatalf. Like Name, this lets
+// *Suite satisfy small testing.T-shaped interfaces directly.
+func (s *Suite[T]) Fatalf(format string, args ...any) {
+	s.T().Fatalf(format, args...)
+}
+
 // Run creates a parallel subtest. The callback receives a fresh copy of the
 // concrete suite type, initialized for the subtest's *testing.T.
 func (s *Suite[T]) Run(name string, fn func(T)) bool {

--- a/common/testing/parallelsuite/suite.go
+++ b/common/testing/parallelsuite/suite.go
@@ -62,14 +62,20 @@ func (s *Suite[T]) T() *testing.T {
 // Name returns the name of the underlying *testing.T. Provided so that *Suite
 // can be passed directly where a `Name() string` interface is expected (e.g.
 // testcore.DynamicConfigT) without forcing the caller to dereference via T().
+//
+// Unlike T(), this is safe to call after Run() has sealed the suite: it reads
+// the stored name and does not assert. The seal protects assertion misuse;
+// diagnostic reads should always succeed.
 func (s *Suite[T]) Name() string {
-	return s.T().Name()
+	return s.guardT.name
 }
 
 // Fatalf forwards to the underlying *testing.T.Fatalf. Like Name, this lets
-// *Suite satisfy small testing.T-shaped interfaces directly.
+// *Suite satisfy small testing.T-shaped interfaces directly. It bypasses the
+// post-Run() seal so that callers reporting an unrelated error (e.g.
+// testcore's env-misuse diagnostic) get their message through.
 func (s *Suite[T]) Fatalf(format string, args ...any) {
-	s.T().Fatalf(format, args...)
+	s.guardT.T.Fatalf(format, args...)
 }
 
 // Run creates a parallel subtest. The callback receives a fresh copy of the

--- a/tests/nexus_matching_test.go
+++ b/tests/nexus_matching_test.go
@@ -39,10 +39,10 @@ func (s *NexusMatchingTestSuite) TestDispatchNexusTaskOnNonRootPartitionNoForwar
 	// non-root partitions work correctly even when no forwarding is involved.
 	env := testcore.NewEnv(s.T())
 
-	env.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueReadPartitions, 4)
-	env.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueWritePartitions, 4)
-	env.OverrideDynamicConfig(dynamicconfig.MatchingForwarderMaxOutstandingTasks, 0) // disable forwarding
-	env.OverrideDynamicConfig(dynamicconfig.MatchingForwarderMaxOutstandingPolls, 0) // disable forwarding
+	env.OverrideDynamicConfig(s, dynamicconfig.MatchingNumTaskqueueReadPartitions, 4)
+	env.OverrideDynamicConfig(s, dynamicconfig.MatchingNumTaskqueueWritePartitions, 4)
+	env.OverrideDynamicConfig(s, dynamicconfig.MatchingForwarderMaxOutstandingTasks, 0) // disable forwarding
+	env.OverrideDynamicConfig(s, dynamicconfig.MatchingForwarderMaxOutstandingPolls, 0) // disable forwarding
 	env.InjectHook(testhooks.NewHook(testhooks.MatchingLBForceWritePartition, 1))
 	env.InjectHook(testhooks.NewHook(testhooks.MatchingLBForceReadPartition, 1))
 	env.InjectHook(testhooks.NewHook(testhooks.MatchingDisableSyncMatch, false))

--- a/tests/nexus_standalone_test.go
+++ b/tests/nexus_standalone_test.go
@@ -342,8 +342,8 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 		s.NotEmpty(firstResp.GetLongPollToken())
 
 		s.Run("CallerDeadlineNotExceeded", func(s *NexusStandaloneTestSuite) {
-			env.OverrideDynamicConfig(nexusoperation.LongPollBuffer, time.Second)
-			env.OverrideDynamicConfig(nexusoperation.LongPollTimeout, 10*time.Millisecond)
+			env.OverrideDynamicConfig(s, nexusoperation.LongPollBuffer, time.Second)
+			env.OverrideDynamicConfig(s, nexusoperation.LongPollTimeout, 10*time.Millisecond)
 
 			longPollResp, err := env.FrontendClient().DescribeNexusOperationExecution(env.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
 				Namespace:     env.Namespace().String(),
@@ -357,8 +357,8 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 
 		s.Run("NoCallerDeadline", func(s *NexusStandaloneTestSuite) {
 			// Frontend still imposes its own deadline upstream, so the buffer must fit within that.
-			env.OverrideDynamicConfig(nexusoperation.LongPollBuffer, 29*time.Second)
-			env.OverrideDynamicConfig(nexusoperation.LongPollTimeout, 10*time.Millisecond)
+			env.OverrideDynamicConfig(s, nexusoperation.LongPollBuffer, 29*time.Second)
+			env.OverrideDynamicConfig(s, nexusoperation.LongPollTimeout, 10*time.Millisecond)
 
 			longPollResp, err := env.FrontendClient().DescribeNexusOperationExecution(context.Background(), &workflowservice.DescribeNexusOperationExecutionRequest{
 				Namespace:     env.Namespace().String(),
@@ -1415,7 +1415,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 		}, testcore.WaitForESToSettle, 100*time.Millisecond)
 
 		// Override max page size to 1.
-		env.OverrideDynamicConfig(dynamicconfig.FrontendVisibilityMaxPageSize, 1)
+		env.OverrideDynamicConfig(s, dynamicconfig.FrontendVisibilityMaxPageSize, 1)
 
 		// PageSize 0 should default to max (1), returning only 1 result.
 		resp, err := env.FrontendClient().ListNexusOperationExecutions(env.Context(), &workflowservice.ListNexusOperationExecutionsRequest{

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -1281,7 +1281,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionInternalAuth(c
 	}
 	env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
 	// Set URL template with invalid host
-	env.OverrideDynamicConfig(
+	env.OverrideDynamicConfig(s, 
 		nexusoperations.CallbackURLTemplate,
 		"http://INTERNAL/namespaces/{{.NamespaceName}}/nexus/callback")
 

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -1281,7 +1281,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionInternalAuth(c
 	}
 	env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
 	// Set URL template with invalid host
-	env.OverrideDynamicConfig(s, 
+	env.OverrideDynamicConfig(s,
 		nexusoperations.CallbackURLTemplate,
 		"http://INTERNAL/namespaces/{{.NamespaceName}}/nexus/callback")
 

--- a/tests/schedule_migration_test.go
+++ b/tests/schedule_migration_test.go
@@ -740,8 +740,8 @@ func (s *ScheduleMigrationTestSuite) TestCHASMScheduleDescribeAfterDisablingCrea
 	)
 	s.NoError(err)
 
-	env.OverrideDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, false)
-	env.OverrideDynamicConfig(dynamicconfig.EnableCHASMSchedulerMigration, false)
+	env.OverrideDynamicConfig(s, dynamicconfig.EnableCHASMSchedulerCreation, false)
+	env.OverrideDynamicConfig(s, dynamicconfig.EnableCHASMSchedulerMigration, false)
 
 	s.Eventually(func() bool {
 		describeResp, describeErr := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
@@ -1194,7 +1194,7 @@ func TestScheduleMigrationV1ToV2NoDuplicateRecentActions(t *testing.T) {
 	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 
 	// Disable CHASM to create V1 schedule.
-	env.OverrideDynamicConfig(dynamicconfig.EnableChasm, false)
+	env.OverrideDynamicConfig(t, dynamicconfig.EnableChasm, false)
 
 	// Create a V1 schedule with an immediate trigger.
 	sched := &schedulepb.Schedule{
@@ -1245,7 +1245,7 @@ func TestScheduleMigrationV1ToV2NoDuplicateRecentActions(t *testing.T) {
 	}, 15*time.Second, 500*time.Millisecond)
 
 	// Enable CHASM now so the migration activity can create the V2 schedule.
-	env.OverrideDynamicConfig(dynamicconfig.EnableChasm, true)
+	env.OverrideDynamicConfig(t, dynamicconfig.EnableChasm, true)
 
 	// Migrate from V1 to V2 while the workflow is still running.
 	_, err = env.AdminClient().MigrateSchedule(ctx, &adminservice.MigrateScheduleRequest{

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -1420,7 +1420,7 @@ func testScheduleInternalTaskQueue(t *testing.T, newContext contextFactory) {
 
 func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, enableCHASMCallbacks bool) {
 	s := testcore.NewEnv(t, scheduleCommonOpts()...)
-	s.OverrideDynamicConfig(dynamicconfig.EnableCHASMCallbacks, enableCHASMCallbacks)
+	s.OverrideDynamicConfig(t, dynamicconfig.EnableCHASMCallbacks, enableCHASMCallbacks)
 
 	sid := "sched-test-double-reset"
 	wid := "sched-test-double-reset-wf"
@@ -1577,8 +1577,8 @@ func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, e
 
 func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, enableCHASMCallbacks bool) {
 	s := testcore.NewEnv(t, scheduleCommonOpts()...)
-	s.OverrideDynamicConfig(dynamicconfig.EnableCHASMCallbacks, enableCHASMCallbacks)
-	s.OverrideDynamicConfig(
+	s.OverrideDynamicConfig(t, dynamicconfig.EnableCHASMCallbacks, enableCHASMCallbacks)
+	s.OverrideDynamicConfig(t,
 		callbacks.AllowedAddresses,
 		[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}},
 	)

--- a/tests/signal_workflow_test.go
+++ b/tests/signal_workflow_test.go
@@ -374,7 +374,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWorkflow_DuplicateRequest() {
 
 func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand() {
 	env := testcore.NewEnv(s.T(), testcore.WithDedicatedCluster())
-	env.OverrideDynamicConfig(dynamicconfig.EnableCrossNamespaceCommands, true) // explicitly enable cross namespace commands for this test
+	env.OverrideDynamicConfig(s, dynamicconfig.EnableCrossNamespaceCommands, true) // explicitly enable cross namespace commands for this test
 	id := "functional-signal-external-workflow-test"
 	wt := "functional-signal-external-workflow-test-type"
 	tl := "functional-signal-external-workflow-test-taskqueue"
@@ -753,7 +753,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWorkflow_WorkflowCloseAttempted() {
 
 func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand_WithoutRunID() {
 	env := testcore.NewEnv(s.T(), testcore.WithDedicatedCluster())
-	env.OverrideDynamicConfig(dynamicconfig.EnableCrossNamespaceCommands, true) // explicitly enable cross namespace commands for this test
+	env.OverrideDynamicConfig(s, dynamicconfig.EnableCrossNamespaceCommands, true) // explicitly enable cross namespace commands for this test
 	id := "functional-signal-external-workflow-test-without-run-id"
 	wt := "functional-signal-external-workflow-test-without-run-id-type"
 	tl := "functional-signal-external-workflow-test-without-run-id-taskqueue"
@@ -967,7 +967,7 @@ CheckHistoryLoopForSignalSent:
 
 func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand_UnKnownTarget() {
 	env := testcore.NewEnv(s.T(), testcore.WithDedicatedCluster())
-	env.OverrideDynamicConfig(dynamicconfig.EnableCrossNamespaceCommands, true) // explicitly enable cross namespace commands for this test
+	env.OverrideDynamicConfig(s, dynamicconfig.EnableCrossNamespaceCommands, true) // explicitly enable cross namespace commands for this test
 	id := "functional-signal-unknown-workflow-command-test"
 	wt := "functional-signal-unknown-workflow-command-test-type"
 	tl := "functional-signal-unknown-workflow-command-test-taskqueue"
@@ -1492,7 +1492,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWithStartWorkflow_ResolveIDDeduplica
 	env := testcore.NewEnv(s.T())
 
 	// setting this to 0 to be sure we are terminating the current workflow
-	env.OverrideDynamicConfig(dynamicconfig.WorkflowIdReuseMinimalInterval, 0)
+	env.OverrideDynamicConfig(s, dynamicconfig.WorkflowIdReuseMinimalInterval, 0)
 
 	id := "functional-signal-with-start-workflow-id-reuse-test"
 	wt := "functional-signal-with-start-workflow-id-reuse-test-type"

--- a/tests/standalone_activity_test.go
+++ b/tests/standalone_activity_test.go
@@ -271,7 +271,7 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 		})
 
 		t.Run("OnConflictOptions", func(t *testing.T) {
-			env.OverrideDynamicConfig(
+			env.OverrideDynamicConfig(s, 
 				callbacks.AllowedAddresses,
 				[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}},
 			)
@@ -616,7 +616,7 @@ func (s *standaloneActivityTestSuite) TestStart() {
 
 		t.Run("InputTooLarge", func(t *testing.T) {
 			blobSizeLimitError := 1000
-			cleanup := env.OverrideDynamicConfig(
+			cleanup := env.OverrideDynamicConfig(s, 
 				dynamicconfig.BlobSizeLimitError,
 				blobSizeLimitError,
 			)
@@ -1955,7 +1955,7 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 
 		t.Run("ReasonTooLong", func(t *testing.T) {
 			blobSizeLimitError := 1000
-			cleanup := env.OverrideDynamicConfig(
+			cleanup := env.OverrideDynamicConfig(s, 
 				dynamicconfig.BlobSizeLimitError,
 				blobSizeLimitError,
 			)
@@ -2479,7 +2479,7 @@ func (s *standaloneActivityTestSuite) TestTerminate() {
 
 		t.Run("ReasonTooLong", func(t *testing.T) {
 			blobSizeLimitError := 1000
-			cleanup := env.OverrideDynamicConfig(
+			cleanup := env.OverrideDynamicConfig(s, 
 				dynamicconfig.BlobSizeLimitError,
 				blobSizeLimitError,
 			)
@@ -3938,7 +3938,7 @@ func (s *standaloneActivityTestSuite) TestListActivityExecutions() {
 
 	t.Run("ExceededPageSizeIsCapped", func(t *testing.T) {
 		maxPageSize := int32(1)
-		cleanup := env.OverrideDynamicConfig(
+		cleanup := env.OverrideDynamicConfig(s, 
 			dynamicconfig.FrontendVisibilityMaxPageSize,
 			maxPageSize,
 		)
@@ -4199,13 +4199,13 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_DeadlineExce
 	// result with at least buffer remaining before the caller deadline.
 	t.Run("CallerDeadlineNotExceeded", func(t *testing.T) {
 		// CallerTimeout - LongPollBuffer is far in the future
-		cleanup1 := env.OverrideDynamicConfig(activity.LongPollBuffer, 1*time.Second)
+		cleanup1 := env.OverrideDynamicConfig(s, activity.LongPollBuffer, 1*time.Second)
 		defer cleanup1()
 		ctx, cancel := context.WithTimeout(ctx, 9999*time.Millisecond)
 		defer cancel()
 
 		// DescribeActivityExecution will return when this long poll timeout expires.
-		cleanup2 := env.OverrideDynamicConfig(activity.LongPollTimeout, 10*time.Millisecond)
+		cleanup2 := env.OverrideDynamicConfig(s, activity.LongPollTimeout, 10*time.Millisecond)
 		defer cleanup2()
 
 		describeResp, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
@@ -4228,10 +4228,10 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_DeadlineExce
 		// will have a 30s deadline that was applied by one of the upstream server layers, so we
 		// still must use a buffer < 30s.
 		ctx := context.Background()
-		cleanup1 := env.OverrideDynamicConfig(activity.LongPollBuffer, 29*time.Second)
+		cleanup1 := env.OverrideDynamicConfig(s, activity.LongPollBuffer, 29*time.Second)
 		defer cleanup1()
 		// DescribeActivityExecution will return when this long poll timeout expires.
-		cleanup2 := env.OverrideDynamicConfig(activity.LongPollTimeout, 10*time.Millisecond)
+		cleanup2 := env.OverrideDynamicConfig(s, activity.LongPollTimeout, 10*time.Millisecond)
 		defer cleanup2()
 
 		_, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
@@ -5839,7 +5839,7 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
 	defer cancel()
 
-	env.OverrideDynamicConfig(
+	env.OverrideDynamicConfig(s, 
 		callbacks.AllowedAddresses,
 		[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}},
 	)
@@ -5936,7 +5936,7 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 
 	t.Run("ExceedsMaxCallbacksLimit", func(t *testing.T) {
 		maxCallbacks := 1
-		env.OverrideDynamicConfig(
+		env.OverrideDynamicConfig(s, 
 			callback.MaxPerExecution,
 			maxCallbacks,
 		)

--- a/tests/standalone_activity_test.go
+++ b/tests/standalone_activity_test.go
@@ -271,7 +271,7 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 		})
 
 		t.Run("OnConflictOptions", func(t *testing.T) {
-			env.OverrideDynamicConfig(s, 
+			env.OverrideDynamicConfig(s,
 				callbacks.AllowedAddresses,
 				[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}},
 			)
@@ -616,7 +616,7 @@ func (s *standaloneActivityTestSuite) TestStart() {
 
 		t.Run("InputTooLarge", func(t *testing.T) {
 			blobSizeLimitError := 1000
-			cleanup := env.OverrideDynamicConfig(s, 
+			cleanup := env.OverrideDynamicConfig(s,
 				dynamicconfig.BlobSizeLimitError,
 				blobSizeLimitError,
 			)
@@ -1955,7 +1955,7 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 
 		t.Run("ReasonTooLong", func(t *testing.T) {
 			blobSizeLimitError := 1000
-			cleanup := env.OverrideDynamicConfig(s, 
+			cleanup := env.OverrideDynamicConfig(s,
 				dynamicconfig.BlobSizeLimitError,
 				blobSizeLimitError,
 			)
@@ -2479,7 +2479,7 @@ func (s *standaloneActivityTestSuite) TestTerminate() {
 
 		t.Run("ReasonTooLong", func(t *testing.T) {
 			blobSizeLimitError := 1000
-			cleanup := env.OverrideDynamicConfig(s, 
+			cleanup := env.OverrideDynamicConfig(s,
 				dynamicconfig.BlobSizeLimitError,
 				blobSizeLimitError,
 			)
@@ -3938,7 +3938,7 @@ func (s *standaloneActivityTestSuite) TestListActivityExecutions() {
 
 	t.Run("ExceededPageSizeIsCapped", func(t *testing.T) {
 		maxPageSize := int32(1)
-		cleanup := env.OverrideDynamicConfig(s, 
+		cleanup := env.OverrideDynamicConfig(s,
 			dynamicconfig.FrontendVisibilityMaxPageSize,
 			maxPageSize,
 		)
@@ -5839,7 +5839,7 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
 	defer cancel()
 
-	env.OverrideDynamicConfig(s, 
+	env.OverrideDynamicConfig(s,
 		callbacks.AllowedAddresses,
 		[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}},
 	)
@@ -5936,7 +5936,7 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 
 	t.Run("ExceedsMaxCallbacksLimit", func(t *testing.T) {
 		maxCallbacks := 1
-		env.OverrideDynamicConfig(s, 
+		env.OverrideDynamicConfig(s,
 			callback.MaxPerExecution,
 			maxCallbacks,
 		)

--- a/tests/task_queue_stats_test.go
+++ b/tests/task_queue_stats_test.go
@@ -151,15 +151,15 @@ type TaskQueueStatsVersionSuite struct {
 
 func (s *TaskQueueStatsVersionSuite) TestMultipleTasks_ValidateStats(usePriMatcher bool, behavior testcore.MatchingBehavior) {
 	env := newTaskQueueStatsContext(s.T(), usePriMatcher, behavior)
-	env.OverrideDynamicConfig(dynamicconfig.MatchingLongPollExpirationInterval, 10*time.Second)
-	env.OverrideDynamicConfig(dynamicconfig.TaskQueueInfoByBuildIdTTL, 1*time.Millisecond)
+	env.OverrideDynamicConfig(s, dynamicconfig.MatchingLongPollExpirationInterval, 10*time.Second)
+	env.OverrideDynamicConfig(s, dynamicconfig.TaskQueueInfoByBuildIdTTL, 1*time.Millisecond)
 	env.publishConsumeWorkflowTasksValidateStats(4, false)
 }
 
 func (s *TaskQueueStatsVersionSuite) TestCurrentVersionAbsorbsUnversionedBacklog_NoRamping(usePriMatcher bool, behavior testcore.MatchingBehavior) {
 	env := newTaskQueueStatsContext(s.T(), usePriMatcher, behavior)
-	env.OverrideDynamicConfig(dynamicconfig.MatchingLongPollExpirationInterval, 10*time.Second)
-	env.OverrideDynamicConfig(dynamicconfig.TaskQueueInfoByBuildIdTTL, 1*time.Millisecond) // zero means no TTL
+	env.OverrideDynamicConfig(s, dynamicconfig.MatchingLongPollExpirationInterval, 10*time.Second)
+	env.OverrideDynamicConfig(s, dynamicconfig.TaskQueueInfoByBuildIdTTL, 1*time.Millisecond) // zero means no TTL
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
@@ -257,8 +257,8 @@ func (s *TaskQueueStatsVersionSuite) TestCurrentVersionAbsorbsUnversionedBacklog
 
 func (s *TaskQueueStatsVersionSuite) TestRampingAndCurrentAbsorbUnversionedBacklog(usePriMatcher bool, behavior testcore.MatchingBehavior) {
 	env := newTaskQueueStatsContext(s.T(), usePriMatcher, behavior)
-	env.OverrideDynamicConfig(dynamicconfig.MatchingLongPollExpirationInterval, 10*time.Second)
-	env.OverrideDynamicConfig(dynamicconfig.TaskQueueInfoByBuildIdTTL, 1*time.Millisecond) // zero means no TTL
+	env.OverrideDynamicConfig(s, dynamicconfig.MatchingLongPollExpirationInterval, 10*time.Second)
+	env.OverrideDynamicConfig(s, dynamicconfig.TaskQueueInfoByBuildIdTTL, 1*time.Millisecond) // zero means no TTL
 
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
@@ -417,8 +417,8 @@ func (s *TaskQueueStatsVersionSuite) TestRampingAndCurrentAbsorbUnversionedBackl
 
 func (s *TaskQueueStatsVersionSuite) TestCurrentAbsorbsUnversionedBacklog_WhenRampingToUnversioned(usePriMatcher bool, behavior testcore.MatchingBehavior) {
 	env := newTaskQueueStatsContext(s.T(), usePriMatcher, behavior)
-	env.OverrideDynamicConfig(dynamicconfig.MatchingLongPollExpirationInterval, 10*time.Second)
-	env.OverrideDynamicConfig(dynamicconfig.TaskQueueInfoByBuildIdTTL, 1*time.Millisecond) // zero means no TTL
+	env.OverrideDynamicConfig(s, dynamicconfig.MatchingLongPollExpirationInterval, 10*time.Second)
+	env.OverrideDynamicConfig(s, dynamicconfig.TaskQueueInfoByBuildIdTTL, 1*time.Millisecond) // zero means no TTL
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
@@ -483,8 +483,8 @@ func (s *TaskQueueStatsVersionSuite) TestCurrentAbsorbsUnversionedBacklog_WhenRa
 
 func (s *TaskQueueStatsVersionSuite) TestRampingAbsorbsUnversionedBacklog_WhenCurrentIsUnversioned(usePriMatcher bool, behavior testcore.MatchingBehavior) {
 	env := newTaskQueueStatsContext(s.T(), usePriMatcher, behavior)
-	env.OverrideDynamicConfig(dynamicconfig.MatchingLongPollExpirationInterval, 10*time.Second)
-	env.OverrideDynamicConfig(dynamicconfig.TaskQueueInfoByBuildIdTTL, 1*time.Millisecond) // zero means no TTL
+	env.OverrideDynamicConfig(s, dynamicconfig.MatchingLongPollExpirationInterval, 10*time.Second)
+	env.OverrideDynamicConfig(s, dynamicconfig.TaskQueueInfoByBuildIdTTL, 1*time.Millisecond) // zero means no TTL
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
@@ -553,8 +553,8 @@ func (s *TaskQueueStatsVersionSuite) TestInactiveVersionDoesNotAbsorbUnversioned
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	env.OverrideDynamicConfig(dynamicconfig.MatchingLongPollExpirationInterval, 10*time.Second)
-	env.OverrideDynamicConfig(dynamicconfig.TaskQueueInfoByBuildIdTTL, 1*time.Millisecond) // zero means no TTL
+	env.OverrideDynamicConfig(s, dynamicconfig.MatchingLongPollExpirationInterval, 10*time.Second)
+	env.OverrideDynamicConfig(s, dynamicconfig.TaskQueueInfoByBuildIdTTL, 1*time.Millisecond) // zero means no TTL
 
 	tqName := "tq-" + common.GenerateRandomString(5)
 	deploymentName := testcore.RandomizeStr("deployment")
@@ -722,7 +722,7 @@ func (s *TaskQueueStatsVersionSuite) TestInactiveVersionDoesNotAbsorbUnversioned
 
 // taskQueueStatsContext holds the per-test environment and configuration for task queue stats tests.
 type taskQueueStatsContext struct {
-	testcore.Env
+	*testcore.TestEnv
 	usePriMatcher   bool
 	minPriority     int
 	maxPriority     int
@@ -747,7 +747,7 @@ func newTaskQueueStatsContext(
 	env := testcore.NewEnv(t, opts...)
 	behavior.InjectHooks(env)
 	return &taskQueueStatsContext{
-		Env:             env,
+		TestEnv:         env,
 		usePriMatcher:   usePriMatcher,
 		minPriority:     1,
 		maxPriority:     5,

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -51,9 +51,22 @@ type Env interface {
 	AdminClient() adminservice.AdminServiceClient
 	GetTestCluster() *TestCluster
 	CloseShard(namespaceID string, workflowID string)
-	OverrideDynamicConfig(setting dynamicconfig.GenericSetting, value any) (cleanup func())
 	Context() context.Context
 	InjectHook(hook testhooks.Hook) (cleanup func())
+}
+
+// (OverrideDynamicConfig is intentionally not on Env: its new t-arg signature
+// would force every Env-implementing helper type — like resetTest, which
+// embeds a suite that embeds FunctionalTestBase with the old signature — to
+// adapt. Concrete *TestEnv exposes the new signature directly.)
+
+// DynamicConfigT is the narrow *testing.T interface required by
+// OverrideDynamicConfig. It is satisfied by *testing.T directly and by
+// parallelsuite/testify suites (which expose delegating Name/Fatalf methods on
+// top of their *testing.T), so callers may pass either `s` or `s.T()`.
+type DynamicConfigT interface {
+	Name() string
+	Fatalf(format string, args ...any)
 }
 
 type TestEnv struct {
@@ -81,6 +94,8 @@ type TestEnv struct {
 	sdkWorkerOnce sync.Once
 	sdkWorker     sdkworker.Worker
 	sdkWorkerTQ   string
+
+	dcGuard *dynamicConfigGuard
 }
 
 type TestOption func(*testOptions)
@@ -180,6 +195,7 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 		ctx:                setupTestTimeoutWithContext(t),
 		sdkWorkerTQ:        RandomizeStr("tq-" + t.Name()),
 		dedicatedGuard:     dedicatedGuard,
+		dcGuard:            newDynamicConfigGuard(),
 	}
 	t.Cleanup(func() {
 		if err := env.dedicatedGuard.validate(); err != nil && !t.Failed() {
@@ -188,9 +204,11 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 	})
 
 	// For shared clusters, apply all dynamic config settings as overrides.
+	// Baseline overrides applied at NewEnv time are intentionally not tracked
+	// by dcGuard — they form the test's baseline; subtests may further override.
 	if !options.dedicatedCluster && len(options.dynamicConfigSettings) > 0 {
 		for _, override := range options.dynamicConfigSettings {
-			env.OverrideDynamicConfig(override.setting, override.value)
+			env.applyDynamicConfigOverride(override.setting, override.value)
 		}
 	}
 
@@ -368,10 +386,44 @@ func (e *TestEnv) WorkerTaskQueue() string {
 	return e.sdkWorkerTQ
 }
 
-// OverrideDynamicConfig overrides a dynamic config setting for the duration of this test.
-// For settings that can be namespace-scoped, a namespace constraint is applied.
-// All others cannot be applied to a shared cluster and require `WithDedicatedCluster`.
-func (e *TestEnv) OverrideDynamicConfig(setting dynamicconfig.GenericSetting, value any) (cleanup func()) {
+// OverrideDynamicConfig overrides a dynamic config setting for the duration of
+// this test. For settings that can be namespace-scoped, a namespace constraint
+// is applied. All others cannot be applied to a shared cluster and require
+// `WithDedicatedCluster`.
+//
+// The caller must pass the current (sub)test's *testing.T (or a suite that
+// satisfies DynamicConfigT). Overlapping overrides of the same setting on the
+// same TestEnv are rejected: if two subtests share an env and both override
+// the same key, the second call Fatals. To re-override, invoke the cleanup
+// returned by the first call before calling again.
+func (e *TestEnv) OverrideDynamicConfig(t DynamicConfigT, setting dynamicconfig.GenericSetting, value any) (cleanup func()) {
+	key := setting.Key()
+
+	if prev, ok := e.dcGuard.acquire(key, t.Name()); !ok {
+		t.Fatalf("OverrideDynamicConfig for setting %s already active on this TestEnv (previously overridden by %s); call the returned cleanup before overriding again. Most often this means two subtests sharing an env both override the same setting.", key, prev)
+		return func() {}
+	}
+
+	innerCleanup := e.applyDynamicConfigOverride(setting, value)
+
+	var once sync.Once
+	cleanup = func() {
+		once.Do(func() {
+			e.dcGuard.release(key)
+			innerCleanup()
+		})
+	}
+	// Cleanup is registered on the env's t (not the passed-in t) so that an
+	// override from one subtest is still considered active in a sibling subtest
+	// — that's the very overlap we want to detect.
+	e.t.Cleanup(cleanup)
+	return cleanup
+}
+
+// applyDynamicConfigOverride applies an override without registering it in the
+// dcGuard tracker. Used by NewEnv for baseline WithDynamicConfig settings and
+// by OverrideDynamicConfig itself after the tracker has accepted the override.
+func (e *TestEnv) applyDynamicConfigOverride(setting dynamicconfig.GenericSetting, value any) (cleanup func()) {
 	if e.isShared {
 		if !canBeNamespaceScoped(setting.Precedence()) {
 			e.t.Fatalf("OverrideDynamicConfig for setting %s (precedence %v) cannot be called on a shared cluster; use testcore.WithDedicatedCluster()", setting.Key(), setting.Precedence())
@@ -490,6 +542,38 @@ func checkTestShard(t *testing.T) {
 		t.Skipf("Skipping %s in test shard %d/%d (it runs in %d)", t.Name(), index+1, total, testIndex+1)
 	}
 	t.Logf("Running %s in test shard %d/%d", t.Name(), index+1, total)
+}
+
+// dynamicConfigGuard tracks active per-TestEnv dynamic config overrides keyed
+// by setting, so that overlapping overrides of the same key (typically two
+// subtests sharing an env) can be detected and rejected.
+type dynamicConfigGuard struct {
+	mu     sync.Mutex
+	active map[dynamicconfig.Key]string // setting key -> caller (sub)test name
+}
+
+func newDynamicConfigGuard() *dynamicConfigGuard {
+	return &dynamicConfigGuard{active: make(map[dynamicconfig.Key]string)}
+}
+
+// acquire records that key is being overridden by caller. Returns ("", true)
+// on success, or (prevCaller, false) if key is already overridden.
+func (g *dynamicConfigGuard) acquire(key dynamicconfig.Key, caller string) (prev string, ok bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if existing, exists := g.active[key]; exists {
+		return existing, false
+	}
+	g.active[key] = caller
+	return "", true
+}
+
+// release clears the active override for key. Safe to call when key is not
+// currently held.
+func (g *dynamicConfigGuard) release(key dynamicconfig.Key) {
+	g.mu.Lock()
+	delete(g.active, key)
+	g.mu.Unlock()
 }
 
 type dedicatedClusterGuard struct {

--- a/tests/timeskipping_bound_test.go
+++ b/tests/timeskipping_bound_test.go
@@ -91,7 +91,7 @@ func boundStartReq(env *testcore.TestEnv, tv *testvars.TestVars, runTimeout time
 
 func (s *TimeSkippingBoundFunctionalSuite) TestBound_MaxSkip_LongUserTimer() {
 	env := testcore.NewEnv(s.T())
-	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(s, dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 	ctx := testcore.NewContext()
 
@@ -179,7 +179,7 @@ func (s *TimeSkippingBoundFunctionalSuite) TestBound_MaxSkip_LongUserTimer() {
 
 func (s *TimeSkippingBoundFunctionalSuite) TestBound_MaxSkip_TwoShortUserTimers() {
 	env := testcore.NewEnv(s.T())
-	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(s, dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 	ctx := testcore.NewContext()
 
@@ -279,7 +279,7 @@ func (s *TimeSkippingBoundFunctionalSuite) TestBound_MaxSkip_TwoShortUserTimers(
 
 func (s *TimeSkippingBoundFunctionalSuite) TestBound_MaxSkip_NoUserTimer() {
 	env := testcore.NewEnv(s.T())
-	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(s, dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 	ctx := testcore.NewContext()
 
@@ -331,7 +331,7 @@ func (s *TimeSkippingBoundFunctionalSuite) TestBound_MaxSkip_NoUserTimer() {
 
 func (s *TimeSkippingBoundFunctionalSuite) TestBound_MaxSkip_StartBackoffCron() {
 	env := testcore.NewEnv(s.T())
-	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(s, dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 	ctx := testcore.NewContext()
 
@@ -409,7 +409,7 @@ func (s *TimeSkippingBoundFunctionalSuite) TestBound_MaxSkip_StartBackoffCron() 
 
 func (s *TimeSkippingBoundFunctionalSuite) TestBound_MaxSkip_StartWithDelay() {
 	env := testcore.NewEnv(s.T())
-	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(s, dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 	ctx := testcore.NewContext()
 
@@ -482,7 +482,7 @@ func (s *TimeSkippingBoundFunctionalSuite) TestBound_MaxElapsed_WithActivity() {
 	// B3 not fixed: bound disable fires regardless of in-flight activity. Update this
 	// test when B3 lands so it asserts the disable is deferred to the next idle moment.
 	env := testcore.NewEnv(s.T())
-	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(s, dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 	ctx := testcore.NewContext()
 
@@ -583,7 +583,7 @@ func (s *TimeSkippingBoundFunctionalSuite) TestBound_MaxElapsed_WithActivity() {
 
 func (s *TimeSkippingBoundFunctionalSuite) TestBound_MaxElapsed_NoUserTimer() {
 	env := testcore.NewEnv(s.T())
-	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(s, dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 	ctx := testcore.NewContext()
 

--- a/tests/timeskipping_propagation_test.go
+++ b/tests/timeskipping_propagation_test.go
@@ -123,7 +123,7 @@ func TestTimeSkippingPropagationTestSuite(t *testing.T) {
 //   - Wall-clock elapsed is nowhere near 5h of virtual time.
 func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_Basic() {
 	env := testcore.NewEnv(s.T())
-	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(s, dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 	ctx := testcore.NewContext()
 
@@ -246,7 +246,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_Basic() {
 //   - Parent completes.
 func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_TwoChildren() {
 	env := testcore.NewEnv(s.T())
-	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(s, dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 	ctx := testcore.NewContext()
 
@@ -378,7 +378,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_TwoChildren() {
 // Final state: C.accum == 4h (3h inherited + 1h own); P.accum == 4h; G.accum == 2h.
 func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_ThreeGenerations() {
 	env := testcore.NewEnv(s.T())
-	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(s, dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 	ctx := testcore.NewContext()
 
@@ -547,7 +547,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_ThreeGenerations() {
 // wall time, not less.
 func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_AdmissionTimestampsShifted() {
 	env := testcore.NewEnv(s.T())
-	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(s, dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 	ctx := testcore.NewContext()
 
@@ -972,7 +972,7 @@ func (s *TimeSkippingPropagationTestSuite) firstWorkflowTaskCompletedEventID(
 // behavior so a future change would surface it.
 func (s *TimeSkippingPropagationTestSuite) TestTSPInReset() {
 	env := testcore.NewEnv(s.T())
-	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(s, dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 	ctx := testcore.NewContext()
 
@@ -1113,7 +1113,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInReset() {
 //   - Wall-clock elapsed is nowhere near 3h of virtual time.
 func (s *TimeSkippingPropagationTestSuite) TestTSPInCaN() {
 	env := testcore.NewEnv(s.T())
-	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(s, dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 	ctx := testcore.NewContext()
 
@@ -1238,7 +1238,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInCaN() {
 //     ContinuedExecutionRunId.
 func (s *TimeSkippingPropagationTestSuite) TestTSPInRetry() {
 	env := testcore.NewEnv(s.T())
-	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(s, dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 	ctx := testcore.NewContext()
 
@@ -1365,7 +1365,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInRetry() {
 //     run 1's event #1, with initiator=CRON_SCHEDULE.
 func (s *TimeSkippingPropagationTestSuite) TestTSPInCron() {
 	env := testcore.NewEnv(s.T())
-	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(s, dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 	ctx := testcore.NewContext()
 

--- a/tests/timeskipping_test.go
+++ b/tests/timeskipping_test.go
@@ -61,7 +61,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_FeatureDisabled() {
 // TimeSkippingConfig persists the config in mutable state when the feature flag is on.
 func (s *TimeSkippingTestSuite) TestTimeSkipping_StartWorkflow_DCEnabled() {
 	env := testcore.NewEnv(s.T())
-	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(s, dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 
 	inputBound := &workflowpb.TimeSkippingConfig_MaxSkippedDuration{
@@ -92,7 +92,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_StartWorkflow_DCEnabled() {
 // with TimeSkippingConfig persists the config in mutable state when the feature flag is on.
 func (s *TimeSkippingTestSuite) TestTimeSkipping_SignalWithStart_DCEnabled() {
 	env := testcore.NewEnv(s.T())
-	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(s, dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 
 	inputBound := &workflowpb.TimeSkippingConfig_MaxElapsedDuration{
@@ -127,7 +127,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_SignalWithStart_DCEnabled() {
 // when the feature flag is on.
 func (s *TimeSkippingTestSuite) TestTimeSkipping_ExecuteMultiOperation_DCEnabled() {
 	env := testcore.NewEnv(s.T())
-	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(s, dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 	maxSkippedDuration := time.Hour
 
@@ -185,7 +185,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_ExecuteMultiOperation_DCEnabled
 //  5. Assert exactly 3 WorkflowExecutionOptionsUpdated events appear in history.
 func (s *TimeSkippingTestSuite) TestTimeSkipping_UpdateWorkflowOptions_DCEnabled() {
 	env := testcore.NewEnv(s.T())
-	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(s, dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 
 	// Start a workflow without any time-skipping config.
@@ -273,7 +273,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_UpdateWorkflowOptions_DCEnabled
 // attributes carry the full config.
 func (s *TimeSkippingTestSuite) TestTimeSkipping_ResetWithUpdateOptions() {
 	env := testcore.NewEnv(s.T())
-	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(s, dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 	ctx := testcore.NewContext()
 
@@ -451,7 +451,7 @@ func hasEventType(events []*historypb.HistoryEvent, t enumspb.EventType) bool {
 //	WT3 → complete workflow (timer has fired)
 func (s *TimeSkippingTestSuite) TestTimeSkipping_TimerAndActivity() {
 	env := testcore.NewEnv(s.T())
-	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(s, dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 
 	// Run timeout must exceed the 1h timer; otherwise skip shifts the run-timeout
@@ -520,7 +520,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_TimerAndActivity() {
 //  4. The latest task's VisibilityTimestamp is ≈ wallStart, not wallStart + 1h.
 func (s *TimeSkippingTestSuite) TestTimeSkipping_StartWithDelay() {
 	env := testcore.NewEnv(s.T())
-	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(s, dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 
 	const (
@@ -632,7 +632,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_StartWithDelay() {
 // fail.
 func (s *TimeSkippingTestSuite) TestWorkflowLifecycle_VirtualTimeContract() {
 	env := testcore.NewEnv(s.T())
-	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(s, dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 
 	const (

--- a/tests/transient_task_test.go
+++ b/tests/transient_task_test.go
@@ -152,7 +152,7 @@ func (s *TransientTaskSuite) TestTransientWorkflowTaskHistorySize() {
 	}
 
 	// start with 20kb limit
-	env.OverrideDynamicConfig(dynamicconfig.HistorySizeSuggestContinueAsNew, 20*1024)
+	env.OverrideDynamicConfig(s, dynamicconfig.HistorySizeSuggestContinueAsNew, 20*1024)
 
 	// workflow logic
 	stage := 0
@@ -270,7 +270,7 @@ func (s *TransientTaskSuite) TestTransientWorkflowTaskHistorySize() {
 
 	// change the dynamic config so that SuggestContinueAsNew should now be false. the current
 	// workflow task should still see true, but the next one will see false.
-	env.OverrideDynamicConfig(dynamicconfig.HistorySizeSuggestContinueAsNew, 8*1024*1024)
+	env.OverrideDynamicConfig(s, dynamicconfig.HistorySizeSuggestContinueAsNew, 8*1024*1024)
 
 	// stage 4: transient task may not be immediately available after stage 3 failure
 	// Increase retries to handle asynchronous task creation timing

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -49,7 +49,7 @@ func clearUpdateRegistryAndAbortPendingUpdates(s *testcore.TestEnv, tv *testvars
 }
 
 func loseUpdateRegistryAndAbandonPendingUpdates(s *testcore.TestEnv, tv *testvars.TestVars) {
-	cleanup := s.OverrideDynamicConfig(dynamicconfig.ShardFinalizerTimeout, 0)
+	cleanup := s.OverrideDynamicConfig(s.T(), dynamicconfig.ShardFinalizerTimeout, 0)
 	defer cleanup()
 	closeShard(s, tv.WorkflowID())
 }


### PR DESCRIPTION
OverrideDynamicConfig now takes a (sub)test's *testing.T (or a parallelsuite Suite that satisfies the narrow DynamicConfigT interface) and tracks active overrides per-key via a dynamicConfigGuard. If two subtests share a TestEnv and both override the same setting, the second call Fatals on the offending subtest's t with a diagnostic identifying the prior caller — instead of silently stomping and producing flaky behavior.

Cleanup is registered on env.t (not the passed-in t), so the override stays live across subtest boundaries; this is what lets the guard detect overlap between sibling subtests of the env. Baseline WithDynamicConfig overrides applied at NewEnv time are intentionally untracked.

## What changed?
_Describe what has changed in this PR._

## Why?
_Tell your future self why have you made these changes._

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
_Any change is risky. Identify all risks you are aware of. If none, remove this section._
