### PR TITLE
Allow Configuring CassandraReconnectionPolicy

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -376,6 +376,13 @@ type (
 		DisableInitialHostLookup bool `yaml:"disableInitialHostLookup"`
 		// AddressTranslator translates Cassandra IP addresses, used for cases when IP addresses gocql driver returns are not accessible from the server
 		AddressTranslator *CassandraAddressTranslator `yaml:"addressTranslator"`
+		// ReconnectionPolicy configures gocql's exponential reconnection policy for downed connections.
+		// If not set, gocql is configured with MaxRetries=30, InitialInterval=1s, MaxInterval=10s.
+		// Lowering MaxRetries is recommended on large clusters: gocql calls pool.connect()
+		// synchronously during NewSession (one goroutine per discovered host) and waits for all
+		// per-host pools to finish initial fill before returning, so a single host that is down can
+		// hold session creation for the full retry budget (~275s with the defaults).
+		ReconnectionPolicy *CassandraReconnectionPolicy `yaml:"reconnectionPolicy"`
 	}
 
 	// CassandraStoreConsistency enables you to set the consistency settings for each Cassandra Persistence Store for Temporal
@@ -398,6 +405,21 @@ type (
 		Consistency string `yaml:"consistency"`
 		// SerialConsistency sets the consistency for the serial prtion of queries. Values identical to gocql SerialConsistency values. (defaults to LOCAL_SERIAL if not set)
 		SerialConsistency string `yaml:"serialConsistency"`
+	}
+
+	// CassandraReconnectionPolicy configures the parameters of gocql's ExponentialReconnectionPolicy.
+	// Any zero-valued field falls back to the gocql wrapper default (MaxRetries=30, InitialInterval=1s, MaxInterval=10s).
+	CassandraReconnectionPolicy struct {
+		// MaxRetries caps the number of reconnection attempts gocql makes when filling a host's pool.
+		// Note: pool.connect() is invoked synchronously during NewSession, so the worst-case wait
+		// for a single down host is roughly InitialInterval + 2*InitialInterval + ... capped at
+		// MaxInterval, summed over MaxRetries. (defaults to 30 if not set)
+		MaxRetries int `yaml:"maxRetries"`
+		// InitialInterval is the wait before the first reconnection attempt; subsequent attempts
+		// double until MaxInterval. (defaults to 1 second if not set)
+		InitialInterval time.Duration `yaml:"initialInterval"`
+		// MaxInterval caps the exponential backoff between reconnection attempts. (defaults to 10 seconds if not set)
+		MaxInterval time.Duration `yaml:"maxInterval"`
 	}
 
 	// PasswordCommandConfig configures an external command to fetch the datastore password.

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -403,15 +403,18 @@ type (
 	}
 
 	// CassandraReconnectionPolicy configures the parameters of gocql's ExponentialReconnectionPolicy.
-	// Any zero-valued field falls back to the gocql wrapper default (MaxRetries=3, InitialInterval=1s, MaxInterval=10s).
+	// Unset fields fall back to the gocql wrapper default (MaxRetries=3, InitialInterval=1s, MaxInterval=10s).
 	CassandraReconnectionPolicy struct {
 		// MaxRetries caps the number of reconnection attempts gocql makes when filling a host's pool.
+		// Pointer so an explicit 0 (give up after the first failure) is distinguishable from unset.
 		// Defaults to 3.
-		MaxRetries int `yaml:"maxRetries"`
+		MaxRetries *int `yaml:"maxRetries"`
 		// InitialInterval is the wait before the first reconnection attempt; subsequent attempts
-		// double until MaxInterval. (defaults to 1 second if not set)
+		// double until MaxInterval. Zero is treated as unset to avoid tight reconnect loops.
+		// (defaults to 1 second if not set)
 		InitialInterval time.Duration `yaml:"initialInterval"`
-		// MaxInterval caps the exponential backoff between reconnection attempts. (defaults to 10 seconds if not set)
+		// MaxInterval caps the exponential backoff between reconnection attempts. Zero is treated
+		// as unset to avoid tight reconnect loops. (defaults to 10 seconds if not set)
 		MaxInterval time.Duration `yaml:"maxInterval"`
 	}
 

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -376,12 +376,7 @@ type (
 		DisableInitialHostLookup bool `yaml:"disableInitialHostLookup"`
 		// AddressTranslator translates Cassandra IP addresses, used for cases when IP addresses gocql driver returns are not accessible from the server
 		AddressTranslator *CassandraAddressTranslator `yaml:"addressTranslator"`
-		// ReconnectionPolicy configures gocql's exponential reconnection policy for downed connections.
-		// If not set, gocql is configured with MaxRetries=30, InitialInterval=1s, MaxInterval=10s.
-		// Lowering MaxRetries is recommended on large clusters: gocql calls pool.connect()
-		// synchronously during NewSession (one goroutine per discovered host) and waits for all
-		// per-host pools to finish initial fill before returning, so a single host that is down can
-		// hold session creation for the full retry budget (~275s with the defaults).
+		// ReconnectionPolicy configures gocql's exponential reconnection policy.
 		ReconnectionPolicy *CassandraReconnectionPolicy `yaml:"reconnectionPolicy"`
 	}
 
@@ -408,12 +403,10 @@ type (
 	}
 
 	// CassandraReconnectionPolicy configures the parameters of gocql's ExponentialReconnectionPolicy.
-	// Any zero-valued field falls back to the gocql wrapper default (MaxRetries=30, InitialInterval=1s, MaxInterval=10s).
+	// Any zero-valued field falls back to the gocql wrapper default (MaxRetries=3, InitialInterval=1s, MaxInterval=10s).
 	CassandraReconnectionPolicy struct {
 		// MaxRetries caps the number of reconnection attempts gocql makes when filling a host's pool.
-		// Note: pool.connect() is invoked synchronously during NewSession, so the worst-case wait
-		// for a single down host is roughly InitialInterval + 2*InitialInterval + ... capped at
-		// MaxInterval, summed over MaxRetries. (defaults to 30 if not set)
+		// Defaults to 3.
 		MaxRetries int `yaml:"maxRetries"`
 		// InitialInterval is the wait before the first reconnection attempt; subsequent attempts
 		// double until MaxInterval. (defaults to 1 second if not set)

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
@@ -154,8 +154,8 @@ func ConfigureCassandraCluster(cfg config.Cassandra, cluster *gocql.ClusterConfi
 		MaxInterval:     10 * time.Second,
 	}
 	if rp := cfg.ReconnectionPolicy; rp != nil {
-		if rp.MaxRetries > 0 {
-			reconnectionPolicy.MaxRetries = rp.MaxRetries
+		if rp.MaxRetries != nil {
+			reconnectionPolicy.MaxRetries = *rp.MaxRetries
 		}
 		if rp.InitialInterval > 0 {
 			reconnectionPolicy.InitialInterval = rp.InitialInterval

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
@@ -149,7 +149,7 @@ func ConfigureCassandraCluster(cfg config.Cassandra, cluster *gocql.ClusterConfi
 	cluster.DisableInitialHostLookup = cfg.DisableInitialHostLookup
 
 	reconnectionPolicy := &gocql.ExponentialReconnectionPolicy{
-		MaxRetries:      30,
+		MaxRetries:      3,
 		InitialInterval: time.Second,
 		MaxInterval:     10 * time.Second,
 	}

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
@@ -148,11 +148,23 @@ func ConfigureCassandraCluster(cfg config.Cassandra, cluster *gocql.ClusterConfi
 	cluster.SerialConsistency = cfg.Consistency.GetSerialConsistency()
 	cluster.DisableInitialHostLookup = cfg.DisableInitialHostLookup
 
-	cluster.ReconnectionPolicy = &gocql.ExponentialReconnectionPolicy{
+	reconnectionPolicy := &gocql.ExponentialReconnectionPolicy{
 		MaxRetries:      30,
 		InitialInterval: time.Second,
 		MaxInterval:     10 * time.Second,
 	}
+	if rp := cfg.ReconnectionPolicy; rp != nil {
+		if rp.MaxRetries > 0 {
+			reconnectionPolicy.MaxRetries = rp.MaxRetries
+		}
+		if rp.InitialInterval > 0 {
+			reconnectionPolicy.InitialInterval = rp.InitialInterval
+		}
+		if rp.MaxInterval > 0 {
+			reconnectionPolicy.MaxInterval = rp.MaxInterval
+		}
+	}
+	cluster.ReconnectionPolicy = reconnectionPolicy
 
 	cluster.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(gocql.RoundRobinHostPolicy())
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/client_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/client_test.go
@@ -15,6 +15,8 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func ptr[T any](v T) *T { return &v }
+
 func TestNewCassandraCluster(t *testing.T) {
 	tests := map[string]struct {
 		cfg    config.Cassandra
@@ -163,7 +165,7 @@ func TestNewCassandraCluster(t *testing.T) {
 		"reconnection_policy_max_retries": {
 			cfg: config.Cassandra{
 				ReconnectionPolicy: &config.CassandraReconnectionPolicy{
-					MaxRetries: 3,
+					MaxRetries: ptr(3),
 				},
 			},
 			verify: func(t *testing.T, cluster *gocql.ClusterConfig) {
@@ -173,10 +175,21 @@ func TestNewCassandraCluster(t *testing.T) {
 				assert.Equal(t, 10*time.Second, rp.MaxInterval)
 			},
 		},
+		"reconnection_policy_max_retries_explicit_zero": {
+			cfg: config.Cassandra{
+				ReconnectionPolicy: &config.CassandraReconnectionPolicy{
+					MaxRetries: ptr(0),
+				},
+			},
+			verify: func(t *testing.T, cluster *gocql.ClusterConfig) {
+				rp := cluster.ReconnectionPolicy.(*gocql.ExponentialReconnectionPolicy)
+				assert.Equal(t, 0, rp.MaxRetries)
+			},
+		},
 		"reconnection_policy_all_fields": {
 			cfg: config.Cassandra{
 				ReconnectionPolicy: &config.CassandraReconnectionPolicy{
-					MaxRetries:      5,
+					MaxRetries:      ptr(5),
 					InitialInterval: 250 * time.Millisecond,
 					MaxInterval:     2 * time.Second,
 				},

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/client_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/client_test.go
@@ -157,7 +157,7 @@ func TestNewCassandraCluster(t *testing.T) {
 			verify: func(t *testing.T, cluster *gocql.ClusterConfig) {
 				rp, ok := cluster.ReconnectionPolicy.(*gocql.ExponentialReconnectionPolicy)
 				assert.True(t, ok, "reconnection policy must be ExponentialReconnectionPolicy")
-				assert.Equal(t, 30, rp.MaxRetries)
+				assert.Equal(t, 3, rp.MaxRetries)
 				assert.Equal(t, time.Second, rp.InitialInterval)
 				assert.Equal(t, 10*time.Second, rp.MaxInterval)
 			},

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/client_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/client_test.go
@@ -150,6 +150,44 @@ func TestNewCassandraCluster(t *testing.T) {
 				assert.Equal(t, time.Duration(789), cluster.WriteTimeout)
 			},
 		},
+		"reconnection_policy_default": {
+			cfg: config.Cassandra{},
+			verify: func(t *testing.T, cluster *gocql.ClusterConfig) {
+				rp, ok := cluster.ReconnectionPolicy.(*gocql.ExponentialReconnectionPolicy)
+				assert.True(t, ok, "reconnection policy must be ExponentialReconnectionPolicy")
+				assert.Equal(t, 30, rp.MaxRetries)
+				assert.Equal(t, time.Second, rp.InitialInterval)
+				assert.Equal(t, 10*time.Second, rp.MaxInterval)
+			},
+		},
+		"reconnection_policy_max_retries": {
+			cfg: config.Cassandra{
+				ReconnectionPolicy: &config.CassandraReconnectionPolicy{
+					MaxRetries: 3,
+				},
+			},
+			verify: func(t *testing.T, cluster *gocql.ClusterConfig) {
+				rp := cluster.ReconnectionPolicy.(*gocql.ExponentialReconnectionPolicy)
+				assert.Equal(t, 3, rp.MaxRetries)
+				assert.Equal(t, time.Second, rp.InitialInterval)
+				assert.Equal(t, 10*time.Second, rp.MaxInterval)
+			},
+		},
+		"reconnection_policy_all_fields": {
+			cfg: config.Cassandra{
+				ReconnectionPolicy: &config.CassandraReconnectionPolicy{
+					MaxRetries:      5,
+					InitialInterval: 250 * time.Millisecond,
+					MaxInterval:     2 * time.Second,
+				},
+			},
+			verify: func(t *testing.T, cluster *gocql.ClusterConfig) {
+				rp := cluster.ReconnectionPolicy.(*gocql.ExponentialReconnectionPolicy)
+				assert.Equal(t, 5, rp.MaxRetries)
+				assert.Equal(t, 250*time.Millisecond, rp.InitialInterval)
+				assert.Equal(t, 2*time.Second, rp.MaxInterval)
+			},
+		},
 		"set_allowed_authenticators": {
 			cfg: config.Cassandra{
 				User:                  "TestUser",


### PR DESCRIPTION
TL;DR - `gocql` session creation can take up to 10m with the present hardcoded defaults in Temporal and this PR lowers those defaults and allows custom configuration via yaml.

## What changed?
1. Adjust default value of `MaxRetries` on `CassandraReconnectionPolicy` to 3  
2. Allow configuring `CassandraReconnectionPolicy` similarly to other Cassandra configs

We are also happy to either contribute one of the two changes or close the PR if there is a different resolution or if this is solved in the most recent server version.

## Why?
For some context - we have experienced a single Cassandra node outage in one of our production clusters. The node shut down abruptly due to AWS EC2 issues. An important note is that upon trying to connect to that node - client gets a black hole (rather than any sort of "connection reset" or similar immediate response) and so - typically waits for full timeout window (default 10s on connection)

The cluster itself remained fully operational and able to serve all traffic at QUORUM.

Temporal, however, experienced an outsized impact with many tasks (like transfer tasks) being almost completely stuck. Some logs point to dead lock detector showing that shard rw lock could not be acquired.

We believe that [this PR](https://github.com/temporalio/temporal/pull/6207) can possibly address the "node dies at runtime" issue though we haven't tried that yet. We presently run 1.22 and that PR looks to be available in 1.23 only.

We did, however, discovered another issue that is likely related to [this one](https://github.com/temporalio/temporal/issues/2729)

The problem is that by default - `gocql` driver will try to connect to _every_ host that it discovers in the cluster's topology from the control connection (those are shuffled from seeds so in a practical prod setup at least some containers will hit a living host and discover the rest of the cluster). Only upon _failing_ to connect is the host convicted and marked with `IsDown`.

With the present configuration of 30 retries (31 total attempts), 10s timeout and 10s maximum backoff - the upper bound for creating a gocql session with a black hole host is 30 * 20 (~10min). That value also roughly matches the impact window we experienced (so presumably the session was finally recreated and the shard locks could be acquired again)

Also note that even though the Cassandra ring considers the host dead - this information is not provided with the control connection's topology info and the driver _must_ declare the host dead on its own by first exhausting all connection attempts.

We have confirmed that upon redeploying our test cluster's history service with existing setup _and_ with or without cherry-picking the PR I mentioned (6207) - the cluster remains completely inoperable because the pods start and mark themselves as healthy (which might be another issue we'd want to look at) but then the hosts cannot join the ring because they cannot create a Cassandra session (this did not seem to resolve itself within 10m)

So the symptom is that Temporal pods\containers cannot be replaced during the outage nor redeployed even with no config or code changes and it _looks_ to remain an issue on `main`.

Note: that's a lot of text already but happy to add any specific details you require, help with reproducing\confirming the issue and so on. Also happy to be wrong if this is a non-issue in latest Temporal

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

~*NOTE*: We will cherry-pick this into our setup and test it before undrafting this PR.~ Done

UPD: I did not use this exact commit but we did test changing the max attempt and connection timeout parameters and with them - the cluster was able to start successfully while without - they were stuck trying to create a gocql session.

UPD2: Tested basically cherry-picking this commit onto our version and with its default values cold start was around 1-1.5m (4 tries, 10s each plus up to 10s backoff (~70s))

Also tested cherry-picking the #6207 PR onto our version. Cold start still fails but the cluster was not nearly as disrupted at a runtime node failure. (gocql session was likely not being recreated like it was before)

## Potential risks
This _technically_ changes the effective Cassandra config for almost all clients who will upgrade without adjusting their config.

But unless the present default of '30' was selected intentionally (we found no such reasons) - I believe it's for the best given the described symptoms.
