### PR TITLE
fix: re-kick generator on unpause to resume CHASM schedule processing (#9889) [3.154 backport]

### DIFF
--- a/chasm/lib/scheduler/generator_tasks_test.go
+++ b/chasm/lib/scheduler/generator_tasks_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	schedulepb "go.temporal.io/api/schedule/v1"
+	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/scheduler"
 	"go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
@@ -152,4 +154,32 @@ func TestGeneratorTask_UpdateFutureActionTimes_SkipsBeforeUpdateTime(t *testing.
 	for _, futureTime := range generator.FutureActionTimes {
 		require.True(t, futureTime.AsTime().After(updateTime))
 	}
+}
+
+func TestUnpause_ResumesProcessing(t *testing.T) {
+	env := newTestEnv(t)
+
+	// Pause the schedule.
+	env.Scheduler.Schedule.State.Paused = true
+	require.NoError(t, env.CloseTransaction())
+
+	// Clear tasks from setup, then unpause. UpdateTime is captured at T0.
+	env.NodeBackend.TasksByCategory = nil
+	ctx := env.MutableContext()
+	_, err := env.Scheduler.Patch(ctx, &schedulerpb.PatchScheduleRequest{
+		FrontendRequest: &workflowservice.PatchScheduleRequest{
+			Patch: &schedulepb.SchedulePatch{Unpause: "resuming"},
+		},
+	})
+	require.NoError(t, err)
+
+	// Advance time before closing so the generator has actions to process.
+	env.TimeSource.Update(env.TimeSource.Now().Add(defaultInterval * 3))
+	require.NoError(t, env.CloseTransaction())
+
+	// With the fix, Patch kicks an immediate generator task. During CloseTransaction
+	// it processes the elapsed interval, buffers starts, and the invoker schedules
+	// side-effect tasks to start workflows. Without the fix, nothing runs.
+	require.True(t, env.HasTask(&tasks.ChasmTask{}, chasm.TaskScheduledTimeImmediate),
+		"schedule should resume processing after unpause")
 }

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -836,6 +836,7 @@ func (s *Scheduler) Patch(
 		}
 		s.Schedule.State.Paused = false
 		s.Schedule.State.Notes = req.FrontendRequest.Patch.Unpause
+		s.Generator.Get(ctx).Generate(ctx)
 	}
 
 	if err := s.handlePatch(ctx, req.FrontendRequest.Patch); err != nil {

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -110,6 +110,7 @@ func runSharedScheduleTests(t *testing.T, newContext contextFactory) {
 	t.Run("TestCountSchedules", func(t *testing.T) { testCountSchedules(t, newContext) })
 	t.Run("TestSchedule_InternalTaskQueue", func(t *testing.T) { testScheduleInternalTaskQueue(t, newContext) })
 	t.Run("TestDeletedScheduleOperations", func(t *testing.T) { testDeletedScheduleOperations(t, newContext) })
+	t.Run("TestUnpauseResumesProcessing", func(t *testing.T) { testCHASMUnpauseResumesProcessing(t, newContext) })
 }
 
 func testDeletedScheduleOperations(t *testing.T, newContext contextFactory) {
@@ -2642,4 +2643,94 @@ func testUpdateScheduleMemoOnly(t *testing.T, newContext contextFactory) {
 	require.NotNil(t, describeResp.Schedule.Spec, "schedule spec should not be nil")
 	require.NotEmpty(t, describeResp.Schedule.Spec.Interval, "schedule spec intervals should be preserved")
 	require.NotNil(t, describeResp.Schedule.Action, "schedule action should be preserved")
+}
+
+func testCHASMUnpauseResumesProcessing(t *testing.T, newContext contextFactory) {
+	s := testcore.NewEnv(t, scheduleCommonOpts()...)
+
+	sid := "sched-test-unpause-resumes"
+	wid := "sched-test-unpause-resumes-wf"
+	wt := "sched-test-unpause-resumes-wt"
+
+	var runs int32
+	s.SdkWorker().RegisterWorkflowWithOptions(
+		func(ctx workflow.Context) error {
+			workflow.SideEffect(ctx, func(ctx workflow.Context) any {
+				atomic.AddInt32(&runs, 1)
+				return 0
+			})
+			return nil
+		},
+		workflow.RegisterOptions{Name: wt},
+	)
+
+	_, err := s.FrontendClient().CreateSchedule(newContext(s.Context()), &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Schedule: &schedulepb.Schedule{
+			Spec: &schedulepb.ScheduleSpec{
+				Interval: []*schedulepb.IntervalSpec{{Interval: durationpb.New(1 * time.Second)}},
+			},
+			Action: &schedulepb.ScheduleAction{
+				Action: &schedulepb.ScheduleAction_StartWorkflow{
+					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+						WorkflowId:   wid,
+						WorkflowType: &commonpb.WorkflowType{Name: wt},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					},
+				},
+			},
+		},
+		Identity:  "test",
+		RequestId: uuid.NewString(),
+	})
+	s.NoError(err)
+
+	// Wait for the schedule to fire at least once, confirming it's running.
+	s.Eventually(func() bool { return atomic.LoadInt32(&runs) >= 1 }, 15*time.Second, 500*time.Millisecond)
+
+	// Pause.
+	_, err = s.FrontendClient().PatchSchedule(newContext(s.Context()), &workflowservice.PatchScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Patch:      &schedulepb.SchedulePatch{Pause: "pausing for test"},
+		Identity:   "test",
+		RequestId:  uuid.NewString(),
+	})
+	s.NoError(err)
+
+	// Wait for the already-queued generator task to run after pause. That task
+	// observes paused state, performs no-op scheduling, and then the schedule
+	// becomes quiescent (no new runs over a stability window).
+	stableSamples := 0
+	lastRuns := atomic.LoadInt32(&runs)
+	s.Eventually(func() bool {
+		currentRuns := atomic.LoadInt32(&runs)
+		if currentRuns == lastRuns {
+			stableSamples++
+		} else {
+			lastRuns = currentRuns
+			stableSamples = 0
+		}
+		return stableSamples >= 6
+	}, 15*time.Second, 500*time.Millisecond)
+	runsBeforeUnpause := atomic.LoadInt32(&runs)
+
+	// Unpause.
+	_, err = s.FrontendClient().PatchSchedule(newContext(s.Context()), &workflowservice.PatchScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Patch:      &schedulepb.SchedulePatch{Unpause: "resuming"},
+		Identity:   "test",
+		RequestId:  uuid.NewString(),
+	})
+	s.NoError(err)
+
+	// The generator should be kicked immediately on unpause and new runs should follow.
+	s.Eventually(
+		func() bool { return atomic.LoadInt32(&runs) > runsBeforeUnpause },
+		15*time.Second,
+		500*time.Millisecond,
+		"schedule should resume processing after unpause",
+	)
 }


### PR DESCRIPTION
## Summary

Backport of #9889 to `cloud/v1.31.0-154` so the scheduler-advance fix is available on a 3.154.x patch as a safety net if 3.155 needs to be rolled back.

## Cherry-pick details
- Source commit: 6cbb490c3 (on `origin/cloud/v1.32.0-155`)
- Original PR: https://github.com/temporalio/temporal/pull/9889
- Clean cherry-pick, no conflicts
- Files: `chasm/lib/scheduler/scheduler.go` (1 line fix), `chasm/lib/scheduler/generator_tasks_test.go`, `tests/schedule_test.go`

## Original PR description (excerpt)

When a CHASM schedule is paused, the generator task exits without scheduling its next task. If the schedule is unpaused before that last pending task has fired, the schedule resumes naturally when the task eventually fires. However, if the unpause happens after that last task has already fired (and gone dormant), there is nothing left to restart the generator — the schedule stays stuck indefinitely.

Fix: call `generator.Generate()` in `Patch` when unpausing.

## Test plan
- [x] Cherry-pick clean
- [ ] CI passes on this PR
- [ ] After merge, cut 3.154.7 patch via `ct launchpad patch release --version 3.154 --accept-existing-commits`