### PR TITLE
Block usage of internal worker controller per-namespace task queue

### DIFF
--- a/chasm/lib/activity/validator_test.go
+++ b/chasm/lib/activity/validator_test.go
@@ -313,7 +313,7 @@ func TestStandaloneActivityTaskQueueValidations(t *testing.T) {
 }
 
 func TestEmbeddedActivityTaskQueueValidations(t *testing.T) {
-	t.Run("Allow PerNSWorkerTaskQueue TaskQueue", func(t *testing.T) {
+	t.Run("Allow PerNSWorkerTaskQueue TaskQueue on the same TaskQueue", func(t *testing.T) {
 		options := &activitypb.ActivityOptions{
 			TaskQueue:              &taskqueuepb.TaskQueue{Name: primitives.PerNSWorkerTaskQueue},
 			ScheduleToCloseTimeout: durationpb.New(10 * time.Second),
@@ -332,7 +332,7 @@ func TestEmbeddedActivityTaskQueueValidations(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("Disallow PerNSWorkerTaskQueue TaskQueue", func(t *testing.T) {
+	t.Run("Disallow PerNSWorkerTaskQueue TaskQueue from non-internal TaskQueue", func(t *testing.T) {
 		options := &activitypb.ActivityOptions{
 			TaskQueue:              &taskqueuepb.TaskQueue{Name: primitives.PerNSWorkerTaskQueue},
 			ScheduleToCloseTimeout: durationpb.New(10 * time.Second),

--- a/common/primitives/task_queues.go
+++ b/common/primitives/task_queues.go
@@ -10,8 +10,11 @@ import (
 
 // all internal task queues shall be defined here such that we enhance security on top of them
 const (
-	DefaultWorkerTaskQueue = "default-worker-tq"
-	PerNSWorkerTaskQueue   = "temporal-sys-per-ns-tq"
+	DefaultWorkerTaskQueue               = "default-worker-tq"
+	PerNSWorkerTaskQueue                 = "temporal-sys-per-ns-tq"
+	WorkerControllerPerNSWorkerTaskQueue = "temporal-sys-worker-controller-per-ns-tq"
+	internalTaskQueuePrefix              = "temporal-sys-"
+	internalTaskQueuePerNSPrefix         = "temporal-sys-per-ns-"
 
 	MigrationActivityTQ           = "temporal-sys-migration-activity-tq"
 	AddSearchAttributesActivityTQ = "temporal-sys-add-search-attributes-activity-tq"
@@ -34,15 +37,15 @@ func IsInternalTaskQueueKind(kind enumspb.TaskQueueKind) bool {
 	return false
 }
 
-const internalTaskQueuePrefix = "temporal-sys-"
-
 // IsInternalTaskQueue returns true if the task queue name belongs to an internal system task queue.
 func IsInternalTaskQueue(taskQueue string) bool {
 	return strings.HasPrefix(taskQueue, internalTaskQueuePrefix)
 }
 
+// IsInternalPerNsTaskQueue returns true if the task queue name belongs to a per-namespace internal system worker
 func IsInternalPerNsTaskQueue(taskQueue string) bool {
-	return taskQueue == PerNSWorkerTaskQueue
+	// TODO: remove WorkerControllerPerNSWorkerTaskQueue once it has been updated to match the prefix
+	return strings.HasPrefix(taskQueue, internalTaskQueuePerNSPrefix) || taskQueue == WorkerControllerPerNSWorkerTaskQueue
 }
 
 // CheckInternalPerNsTaskQueueAllowed tries to block the usage of internal per-namespace task queue for illegal cases.


### PR DESCRIPTION
## What changed?
Add `WorkerControllerPerNSWorkerTaskQueue` ("temporal-sys-worker-controller-per-ns-tq") to the set of internal per-namespace task queues and treat it the same as `PerNSWorkerTaskQueue` in `IsInternalPerNsTaskQueue`, so user workflows cannot start workflows, schedule activities, start child workflows, continue-as-new, or update activity options targeting it.

## Why?
The Worker Controller internal task queue has the same security concerns as the shared one, so treating it the same seems appropriate.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [X] added new functional test(s)
