### PR TITLE
Bump go.temporal.io/api to v1.62.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
-	go.temporal.io/api v1.62.12-0.20260511225354-0a978d4fd72c
+	go.temporal.io/api v1.62.12
 	go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2
 	go.temporal.io/sdk v1.41.1
 	go.uber.org/fx v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -469,8 +469,8 @@ go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0 h1:R
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0/go.mod h1:I89cynRj8y+383o7tEQVg2SVA6SRgDVIouWPUVXjx0U=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0 h1:CQvJSldHRUN6Z8jsUeYv8J0lXRvygALXIzsmAeCcZE0=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0/go.mod h1:xSQ+mEfJe/GjK1LXEyVOoSI1N9JV9ZI923X5kup43W4=
-go.temporal.io/api v1.62.12-0.20260511225354-0a978d4fd72c h1:ADDxNS26VTfDWmW55zYgAFkG6WEU83RHv0HwrarHXtk=
-go.temporal.io/api v1.62.12-0.20260511225354-0a978d4fd72c/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
+go.temporal.io/api v1.62.12 h1:627rVnItegQmrszg1bH4vfyc/1uNo5qCereCNkvZefw=
+go.temporal.io/api v1.62.12/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2 h1:1hKeH3GyR6YD6LKMHGCZ76t6h1Sgha0hXVQBxWi3dlQ=
 go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2/go.mod h1:T8dnzVPeO+gaUTj9eDgm/lT2lZH4+JXNvrGaQGyVi50=
 go.temporal.io/sdk v1.41.1 h1:yOpvsHyDD1lNuwlGBv/SUodCPhjv9nDeC9lLHW/fJUA=


### PR DESCRIPTION
## Summary

Replace the pseudo-version pin of `go.temporal.io/api` with the freshly-tagged `v1.62.12`. This is a prerequisite for cutting cloud release 3.156, which requires all OSS dependencies to be on tagged versions (runbook step 2).

## Details
- `v1.62.12` tags api-go commit `0a978d4fd72ccadc7666d7f19aa6df9b335b3133` — the same commit the previous pseudo-version pinned (`v1.62.12-0.20260511225354-0a978d4fd72c`).
- No source code changes — the module content is identical (the `/go.mod` h1 hash didn't change in go.sum, only the version-identifier hash).
- Tag created via `temporalio/api`'s `create-release.yml` workflow.

## Test plan
- [x] `go mod tidy` clean
- [ ] CI passes