### PR TITLE
Drop retry for Nexus endpoint not found

### DIFF
--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -289,26 +289,17 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes(useTemporalFailures
 
 		pollerErrCh := env.nexusTaskPoller(env.Context(), s.T(), endpoint.Spec.Target.GetWorker().TaskQueue, tc.handler)
 
-		eventuallyTick := 500 * time.Millisecond
 		header := nexus.Header{"key": "value", "temporal-nexus-failure-support": "true"}
 		if tc.timeout > 0 {
-			eventuallyTick = tc.timeout + (100 * time.Millisecond)
 			header[nexus.HeaderRequestTimeout] = tc.timeout.String()
 		}
 
-		var result *nexusrpc.ClientStartOperationResponse[string]
-
-		// Wait until the endpoint is loaded into the registry.
-		s.Eventually(func() bool {
-			result, err = nexusrpc.StartOperation(env.Context(), client, op, "input", nexus.StartOperationOptions{
-				CallbackURL: "http://localhost/callback",
-				RequestID:   "request-id",
-				Header:      header,
-				Links:       []nexus.Link{callerNexusLink},
-			})
-			var handlerErr *nexus.HandlerError
-			return err == nil || !(errors.As(err, &handlerErr) && handlerErr.Type == nexus.HandlerErrorTypeNotFound)
-		}, 10*time.Second, eventuallyTick)
+		result, err := nexusrpc.StartOperation(env.Context(), client, op, "input", nexus.StartOperationOptions{
+			CallbackURL: "http://localhost/callback",
+			RequestID:   "request-id",
+			Header:      header,
+			Links:       []nexus.Link{callerNexusLink},
+		})
 
 		tc.assertion(s, result, err, headerCapture.lastHeaders)
 		s.NoError(<-pollerErrCh)
@@ -562,19 +553,12 @@ func (s *NexusApiTestSuite) TestNexusCancelOperation_Outcomes(useTemporalFailure
 		handle, err := client.NewOperationHandle("operation", "token")
 		s.NoError(err)
 
-		eventuallyTick := 500 * time.Millisecond
 		header := nexus.Header{"key": "value"}
 		if tc.timeout > 0 {
-			eventuallyTick = tc.timeout + (100 * time.Millisecond)
 			header[nexus.HeaderRequestTimeout] = tc.timeout.String()
 		}
 
-		// Wait until the endpoint is loaded into the registry.
-		s.Eventually(func() bool {
-			err = handle.Cancel(env.Context(), nexus.CancelOperationOptions{Header: header})
-			var handlerErr *nexus.HandlerError
-			return err == nil || !(errors.As(err, &handlerErr) && handlerErr.Type == nexus.HandlerErrorTypeNotFound)
-		}, 10*time.Second, eventuallyTick)
+		err = handle.Cancel(env.Context(), nexus.CancelOperationOptions{Header: header})
 
 		tc.assertion(s, err, headerCapture.lastHeaders)
 		s.NoError(<-pollerErrCh)
@@ -708,11 +692,7 @@ func (s *NexusApiTestSuite) TestNexusClientNameMetricPropagation(useTemporalFail
 	})
 	s.NoError(err)
 
-	s.Eventually(func() bool {
-		_, err = nexusrpc.StartOperation(env.Context(), client, op, "input", nexus.StartOperationOptions{})
-		var handlerErr *nexus.HandlerError
-		return err == nil || (!errors.As(err, &handlerErr) || handlerErr.Type != nexus.HandlerErrorTypeNotFound)
-	}, 10*time.Second, 500*time.Millisecond)
+	_, err = nexusrpc.StartOperation(env.Context(), client, op, "input", nexus.StartOperationOptions{})
 	s.NoError(err)
 	s.NoError(<-pollerErrCh)
 

--- a/tests/nexus_api_validation_test.go
+++ b/tests/nexus_api_validation_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/nexus-rpc/sdk-go/nexus"
@@ -198,12 +197,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_Forbidden() {
 
 		capture := env.StartNamespaceMetricCapture()
 
-		// Wait until the endpoint is loaded into the registry.
-		s.Eventually(func() bool {
-			_, err = nexusrpc.StartOperation(env.Context(), client, op, "input", nexus.StartOperationOptions{})
-			var handlerErr *nexus.HandlerError
-			return err == nil || (!errors.As(err, &handlerErr) || handlerErr.Type != nexus.HandlerErrorTypeNotFound)
-		}, 10*time.Second, 1*time.Second)
+		_, err = nexusrpc.StartOperation(env.Context(), client, op, "input", nexus.StartOperationOptions{})
 
 		var handlerErr *nexus.HandlerError
 		s.ErrorAs(err, &handlerErr)
@@ -242,17 +236,10 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_PayloadSizeLimit()
 
 		client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: dispatchURL, Service: "test-service"})
 		s.NoError(err)
-		var result *nexusrpc.ClientStartOperationResponse[string]
-
-		// Wait until the endpoint is loaded into the registry.
-		s.Eventually(func() bool {
-			result, err = nexusrpc.StartOperation(env.Context(), client, op, input, nexus.StartOperationOptions{
-				CallbackURL: "http://localhost/callback",
-				RequestID:   "request-id",
-			})
-			var handlerErr *nexus.HandlerError
-			return err == nil || (!errors.As(err, &handlerErr) || handlerErr.Type != nexus.HandlerErrorTypeNotFound)
-		}, 10*time.Second, 500*time.Millisecond)
+		result, err := nexusrpc.StartOperation(env.Context(), client, op, input, nexus.StartOperationOptions{
+			CallbackURL: "http://localhost/callback",
+			RequestID:   "request-id",
+		})
 
 		s.Nil(result)
 		var handlerErr *nexus.HandlerError


### PR DESCRIPTION
## What changed?

Removed retries in test when Nexus endpoint wasn't found.

Follow-up to https://github.com/temporalio/temporal/pull/10208

## Why?

Nexus lookups are now strongly consistent.

