### PR TITLE
Wrap archival URI validation errors with context

### DIFF
--- a/service/frontend/namespace_handler.go
+++ b/service/frontend/namespace_handler.go
@@ -1044,29 +1044,35 @@ func (d *namespaceHandler) toArchivalUpdateEvent(
 func (d *namespaceHandler) validateHistoryArchivalURI(URIString string) error {
 	URI, err := archiver.NewURI(URIString)
 	if err != nil {
-		return err
+		return fmt.Errorf("invalid history archival URI %q: %w", URIString, err)
 	}
 
 	a, err := d.archiverProvider.GetHistoryArchiver(URI.Scheme())
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get history archiver for scheme %q: %w", URI.Scheme(), err)
 	}
 
-	return a.ValidateURI(URI)
+	if err := a.ValidateURI(URI); err != nil {
+		return fmt.Errorf("failed to validate history archival URI %q: %w", URIString, err)
+	}
+	return nil
 }
 
 func (d *namespaceHandler) validateVisibilityArchivalURI(URIString string) error {
 	URI, err := archiver.NewURI(URIString)
 	if err != nil {
-		return err
+		return fmt.Errorf("invalid visibility archival URI %q: %w", URIString, err)
 	}
 
 	a, err := d.archiverProvider.GetVisibilityArchiver(URI.Scheme())
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get visibility archiver for scheme %q: %w", URI.Scheme(), err)
 	}
 
-	return a.ValidateURI(URI)
+	if err := a.ValidateURI(URI); err != nil {
+		return fmt.Errorf("failed to validate visibility archival URI %q: %w", URIString, err)
+	}
+	return nil
 }
 
 // maybeUpdateFailoverHistory adds an entry if the Namespace is becoming active in a new cluster.


### PR DESCRIPTION
When registering a namespace with archival enabled, if the archival storage (like S3) returns an error, the message can be cryptic. For example, an S3 403 shows up as just 'Forbidden: Forbidden' without any hint that the error came from archival configuration.

This change wraps the errors from 'validateHistoryArchivalURI' and 'validateVisibilityArchivalURI' with context so users can identify where the error originated. A 403 from S3 now surfaces as 'failed to validate history archival URI: Forbidden' which makes it clear that the problem is with archival storage access, not some other part of the system.

I ran into this myself when setting up S3 archival with incorrect credentials -- spent a while chasing the 403 before realizing it was the archival bucket validation failing.

Closes #983