### PR TITLE
fix: report uncompressed size in AppendHistoryNodesResponse

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -268,6 +268,8 @@ type (
 		DataStores map[string]DataStore `yaml:"datastores"`
 		// TransactionSizeLimit is the largest allowed transaction size
 		TransactionSizeLimit dynamicconfig.IntPropertyFn `yaml:"-" json:"-"`
+		// HistoryNodeBlobCompressionThreshold is the minimum blob size to compress (0 = disabled)
+		HistoryNodeBlobCompressionThreshold dynamicconfig.IntPropertyFn `yaml:"-" json:"-"`
 	}
 
 	// DataStore is the configuration for a single datastore

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -140,6 +140,11 @@ for signal / start / signal with start API if namespace is not active`,
 		primitives.DefaultTransactionSizeLimit,
 		`TransactionSizeLimit is the largest allowed transaction size to persistence`,
 	)
+	HistoryNodeBlobCompressionThreshold = NewGlobalIntSetting(
+		"system.historyNodeBlobCompressionThreshold",
+		0,
+		`HistoryNodeBlobCompressionThreshold is the minimum blob size in bytes to trigger zstd compression for history_node data. 0 disables compression (default). Enable only after all nodes are upgraded.`,
+	)
 	DisallowQuery = NewNamespaceBoolSetting(
 		"system.disallowQuery",
 		false,

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -143,7 +143,7 @@ for signal / start / signal with start API if namespace is not active`,
 	HistoryNodeBlobCompressionThreshold = NewGlobalIntSetting(
 		"system.historyNodeBlobCompressionThreshold",
 		0,
-		`HistoryNodeBlobCompressionThreshold is the minimum blob size in bytes to trigger zstd compression for history_node data. 0 disables compression (default). Enable only after all nodes are upgraded.`,
+		`HistoryNodeBlobCompressionThreshold is the minimum blob size in bytes to trigger compression for history_node data. 0 disables compression (default). Enable only after all nodes are upgraded.`,
 	)
 	DisallowQuery = NewNamespaceBoolSetting(
 		"system.disallowQuery",

--- a/common/persistence/cassandra/history_store.go
+++ b/common/persistence/cassandra/history_store.go
@@ -76,7 +76,7 @@ func (h *HistoryStore) AppendHistoryNodes(
 			node.PrevTransactionID,
 			node.TransactionID,
 			node.Events.Data,
-			node.Events.EncodingType.String(),
+			p.HistoryNodeEncodingString(node),
 		).WithContext(ctx)
 		if err := query.Exec(); err != nil {
 			return convertTimeoutError(gocql.ConvertError("AppendHistoryNodes", err))
@@ -99,7 +99,7 @@ func (h *HistoryStore) AppendHistoryNodes(
 		node.PrevTransactionID,
 		node.TransactionID,
 		node.Events.Data,
-		node.Events.EncodingType.String(),
+		p.HistoryNodeEncodingString(node),
 	)
 	if err := h.Session.ExecuteBatch(batch); err != nil {
 		return convertTimeoutError(gocql.ConvertError("AppendHistoryNodes", err))

--- a/common/persistence/client/factory.go
+++ b/common/persistence/client/factory.go
@@ -206,6 +206,7 @@ func (f *factoryImpl) NewExecutionManager() (persistence.ExecutionManager, error
 		f.eventBlobCache,
 		f.logger,
 		f.config.TransactionSizeLimit,
+		f.config.HistoryNodeBlobCompressionThreshold,
 		f.enableBestEffortDeleteTasksOnWorkflowUpdate,
 	)
 	if f.systemRateLimiter != nil && f.namespaceRateLimiter != nil {

--- a/common/persistence/data_blob.go
+++ b/common/persistence/data_blob.go
@@ -3,11 +3,27 @@ package persistence
 import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/common/persistence/serialization"
 )
 
-// NewDataBlob returns a new DataBlob.
+// NewDataBlob returns a new DataBlob. If the encoding indicates zstd compression,
+// the data is transparently decompressed.
 // TODO: return an UnknowEncodingType error with the actual type string when encodingTypeStr is invalid
 func NewDataBlob(data []byte, encodingTypeStr string) *commonpb.DataBlob {
+	if serialization.IsCompressedEncoding(encodingTypeStr) {
+		blob, err := serialization.DecompressHistoryEventBlob(data, encodingTypeStr)
+		if err != nil {
+			// Decompression failed — return raw data with UNSPECIFIED encoding.
+			// The downstream deserializer will produce an actionable error including
+			// the context from DecompressHistoryEventBlob (encoding type, blob size).
+			return &commonpb.DataBlob{
+				Data:         data,
+				EncodingType: enumspb.ENCODING_TYPE_UNSPECIFIED,
+			}
+		}
+		return blob
+	}
+
 	encodingType, err := enumspb.EncodingTypeFromString(encodingTypeStr)
 	if err != nil {
 		// encodingTypeStr not valid, an error will be returned on deserialization

--- a/common/persistence/data_blob_test.go
+++ b/common/persistence/data_blob_test.go
@@ -1,0 +1,38 @@
+package persistence
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/common/persistence/serialization"
+)
+
+func TestNewDataBlob_DecompressesZstd(t *testing.T) {
+	original := bytes.Repeat([]byte("test data "), 500)
+	blob := &commonpb.DataBlob{
+		Data:         original,
+		EncodingType: enumspb.ENCODING_TYPE_PROTO3,
+	}
+
+	compressed, encodingStr, err := serialization.CompressHistoryEventBlob(blob)
+	require.NoError(t, err)
+
+	result := NewDataBlob(compressed.Data, encodingStr)
+	require.Equal(t, enumspb.ENCODING_TYPE_PROTO3, result.EncodingType)
+	require.Equal(t, original, result.Data)
+}
+
+func TestNewDataBlob_PlainProto3Unchanged(t *testing.T) {
+	data := []byte("plain proto3 data")
+	result := NewDataBlob(data, enumspb.ENCODING_TYPE_PROTO3.String())
+	require.Equal(t, enumspb.ENCODING_TYPE_PROTO3, result.EncodingType)
+	require.Equal(t, data, result.Data)
+}
+
+func TestNewDataBlob_CorruptedZstdFallsBack(t *testing.T) {
+	result := NewDataBlob([]byte("not zstd"), serialization.EncodingTypeProto3Zstd)
+	require.Equal(t, enumspb.ENCODING_TYPE_UNSPECIFIED, result.EncodingType)
+}

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -33,6 +33,7 @@ type (
 		logger                                      log.Logger
 		pagingTokenSerializer                       *jsonHistoryTokenSerializer
 		transactionSizeLimit                        dynamicconfig.IntPropertyFn
+		historyNodeBlobCompressionThreshold         dynamicconfig.IntPropertyFn
 		enableBestEffortDeleteTasksOnWorkflowUpdate dynamicconfig.BoolPropertyFn
 	}
 )
@@ -46,15 +47,17 @@ func NewExecutionManager(
 	eventBlobCache XDCCache,
 	logger log.Logger,
 	transactionSizeLimit dynamicconfig.IntPropertyFn,
+	historyNodeBlobCompressionThreshold dynamicconfig.IntPropertyFn,
 	enableBestEffortDeleteTasksOnWorkflowUpdate dynamicconfig.BoolPropertyFn,
 ) ExecutionManager {
 	return &executionManagerImpl{
-		serializer:            serializer,
-		eventBlobCache:        eventBlobCache,
-		persistence:           persistence,
-		logger:                logger,
-		pagingTokenSerializer: newJSONHistoryTokenSerializer(),
-		transactionSizeLimit:  transactionSizeLimit,
+		serializer:                          serializer,
+		eventBlobCache:                      eventBlobCache,
+		persistence:                         persistence,
+		logger:                              logger,
+		pagingTokenSerializer:               newJSONHistoryTokenSerializer(),
+		transactionSizeLimit:                transactionSizeLimit,
+		historyNodeBlobCompressionThreshold: historyNodeBlobCompressionThreshold,
 		enableBestEffortDeleteTasksOnWorkflowUpdate: enableBestEffortDeleteTasksOnWorkflowUpdate,
 	}
 }

--- a/common/persistence/execution_manager_test.go
+++ b/common/persistence/execution_manager_test.go
@@ -72,6 +72,7 @@ func TestExecutionManager_DeletesTasksWhenEnabled(t *testing.T) {
 		nil,
 		log.NewNoopLogger(),
 		dynamicconfig.GetIntPropertyFn(1024*1024),
+		dynamicconfig.GetIntPropertyFn(0),
 		dynamicconfig.GetBoolPropertyFn(true),
 	)
 
@@ -97,6 +98,7 @@ func TestExecutionManager_DoesNotDeleteTasksWhenDisabled(t *testing.T) {
 		nil,
 		log.NewNoopLogger(),
 		dynamicconfig.GetIntPropertyFn(1024*1024),
+		dynamicconfig.GetIntPropertyFn(0),
 		dynamicconfig.GetBoolPropertyFn(false),
 	)
 
@@ -133,6 +135,7 @@ func TestExecutionManager_DeleteTasksError_DoesNotFailUpdate(t *testing.T) {
 		nil,
 		log.NewNoopLogger(),
 		dynamicconfig.GetIntPropertyFn(1024*1024),
+		dynamicconfig.GetIntPropertyFn(0),
 		dynamicconfig.GetBoolPropertyFn(true),
 	)
 
@@ -162,6 +165,7 @@ func TestExecutionManager_TrimHistoryBranchSkipped_NonWorkflow(t *testing.T) {
 		// Capture error logs to verify no unexpected errors.
 		testlogger.NewTestLogger(t, testlogger.FailOnAnyUnexpectedError),
 		dynamicconfig.GetIntPropertyFn(1024*1024),
+		dynamicconfig.GetIntPropertyFn(0),
 		dynamicconfig.GetBoolPropertyFn(false),
 	)
 
@@ -225,6 +229,7 @@ func TestExecutionManager_TrimHistoryBranchSkipped_EmptyBranchToken(t *testing.T
 		// Capture error logs to verify no unexpected errors.
 		testlogger.NewTestLogger(t, testlogger.FailOnAnyUnexpectedError),
 		dynamicconfig.GetIntPropertyFn(1024*1024),
+		dynamicconfig.GetIntPropertyFn(0),
 		dynamicconfig.GetBoolPropertyFn(false),
 	)
 

--- a/common/persistence/history_manager.go
+++ b/common/persistence/history_manager.go
@@ -364,6 +364,13 @@ func (m *executionManagerImpl) serializeAppendHistoryNodesRequest(
 	if err != nil {
 		return nil, err
 	}
+
+	var encodingOverride string
+	blob, encodingOverride, err = m.maybeCompressHistoryBlob(blob)
+	if err != nil {
+		return nil, err
+	}
+
 	size := len(blob.Data)
 	sizeLimit := m.transactionSizeLimit()
 	if size > sizeLimit {
@@ -380,6 +387,7 @@ func (m *executionManagerImpl) serializeAppendHistoryNodesRequest(
 		Node: InternalHistoryNode{
 			NodeID:            nodeID,
 			Events:            blob,
+			EncodingOverride:  encodingOverride,
 			PrevTransactionID: request.PrevTransactionID,
 			TransactionID:     request.TransactionID,
 		},
@@ -418,7 +426,7 @@ func (m *executionManagerImpl) serializeAppendRawHistoryNodesRequest(
 		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("unable to parse branch token: %v", err))
 	}
 
-	if len(request.History.Data) == 0 {
+	if request.History == nil || len(request.History.Data) == 0 {
 		return nil, &InvalidPersistenceRequestError{
 			Msg: "events to be appended cannot be empty",
 		}
@@ -431,8 +439,16 @@ func (m *executionManagerImpl) serializeAppendRawHistoryNodesRequest(
 			Msg: "eventID cannot be less than 1",
 		}
 	}
+
+	blob := request.History
+	var encodingOverride string
+	blob, encodingOverride, err = m.maybeCompressHistoryBlob(blob)
+	if err != nil {
+		return nil, err
+	}
+
 	// nodeID will be the first eventID
-	size := len(request.History.Data)
+	size := len(blob.Data)
 	sizeLimit := m.transactionSizeLimit()
 	if size > sizeLimit {
 		return nil, &TransactionSizeLimitError{
@@ -447,7 +463,8 @@ func (m *executionManagerImpl) serializeAppendRawHistoryNodesRequest(
 		BranchInfo:  branch,
 		Node: InternalHistoryNode{
 			NodeID:            nodeID,
-			Events:            request.History,
+			Events:            blob,
+			EncodingOverride:  encodingOverride,
 			PrevTransactionID: request.PrevTransactionID,
 			TransactionID:     request.TransactionID,
 		},

--- a/common/persistence/history_manager.go
+++ b/common/persistence/history_manager.go
@@ -365,6 +365,8 @@ func (m *executionManagerImpl) serializeAppendHistoryNodesRequest(
 		return nil, err
 	}
 
+	dataSize := len(blob.Data)
+
 	var encodingOverride string
 	blob, encodingOverride, err = m.maybeCompressHistoryBlob(blob)
 	if err != nil {
@@ -390,6 +392,7 @@ func (m *executionManagerImpl) serializeAppendHistoryNodesRequest(
 			EncodingOverride:  encodingOverride,
 			PrevTransactionID: request.PrevTransactionID,
 			TransactionID:     request.TransactionID,
+			DataSize:          dataSize,
 		},
 		ShardID: request.ShardID,
 	}
@@ -441,6 +444,8 @@ func (m *executionManagerImpl) serializeAppendRawHistoryNodesRequest(
 	}
 
 	blob := request.History
+	dataSize := len(blob.Data)
+
 	var encodingOverride string
 	blob, encodingOverride, err = m.maybeCompressHistoryBlob(blob)
 	if err != nil {
@@ -467,6 +472,7 @@ func (m *executionManagerImpl) serializeAppendRawHistoryNodesRequest(
 			EncodingOverride:  encodingOverride,
 			PrevTransactionID: request.PrevTransactionID,
 			TransactionID:     request.TransactionID,
+			DataSize:          dataSize,
 		},
 		ShardID: request.ShardID,
 	}
@@ -509,7 +515,7 @@ func (m *executionManagerImpl) AppendHistoryNodes(
 	err = m.persistence.AppendHistoryNodes(ctx, req)
 
 	return &AppendHistoryNodesResponse{
-		Size: len(req.Node.Events.Data),
+		Size: req.Node.DataSize,
 	}, err
 }
 
@@ -526,7 +532,7 @@ func (m *executionManagerImpl) AppendRawHistoryNodes(
 
 	err = m.persistence.AppendHistoryNodes(ctx, req)
 	return &AppendHistoryNodesResponse{
-		Size: len(request.History.Data),
+		Size: req.Node.DataSize,
 	}, err
 }
 

--- a/common/persistence/history_manager_test.go
+++ b/common/persistence/history_manager_test.go
@@ -114,6 +114,7 @@ func TestHistoryManager_InvalidBranchToken_ReturnsInvalidArgument(t *testing.T) 
 				nil,
 				log.NewNoopLogger(),
 				dynamicconfig.GetIntPropertyFn(1024*1024),
+				dynamicconfig.GetIntPropertyFn(0),
 				dynamicconfig.GetBoolPropertyFn(false),
 			)
 

--- a/common/persistence/history_node_compression.go
+++ b/common/persistence/history_node_compression.go
@@ -1,0 +1,35 @@
+package persistence
+
+import (
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/server/common/persistence/serialization"
+)
+
+const (
+	// minCompressionSize is the absolute minimum blob size in bytes worth compressing.
+	// Below this, zstd framing overhead negates any savings.
+	minCompressionSize = 1024
+)
+
+// HistoryNodeEncodingString returns the encoding string to persist for a history node.
+// It uses EncodingOverride if set, otherwise falls back to the DataBlob's EncodingType.
+func HistoryNodeEncodingString(node InternalHistoryNode) string {
+	if node.EncodingOverride != "" {
+		return node.EncodingOverride
+	}
+	return node.Events.EncodingType.String()
+}
+
+// maybeCompressHistoryBlob compresses the blob if it exceeds the configured threshold.
+func (m *executionManagerImpl) maybeCompressHistoryBlob(blob *commonpb.DataBlob) (*commonpb.DataBlob, string, error) {
+	threshold := m.historyNodeBlobCompressionThreshold()
+	if threshold <= 0 || len(blob.Data) < max(threshold, minCompressionSize) {
+		return blob, "", nil
+	}
+
+	compressed, encodingStr, err := serialization.CompressHistoryEventBlob(blob)
+	if err != nil {
+		return nil, "", err
+	}
+	return compressed, encodingStr, nil
+}

--- a/common/persistence/persistence_interface.go
+++ b/common/persistence/persistence_interface.go
@@ -533,6 +533,9 @@ type (
 		// EncodingOverride, if non-empty, overrides Events.EncodingType for the data_encoding column.
 		// Used when the blob is compressed (e.g. "proto3+zstd").
 		EncodingOverride string
+		// DataSize is the uncompressed logical payload size in bytes.
+		// Used to report consistent Size in AppendHistoryNodesResponse regardless of compression.
+		DataSize int
 	}
 
 	// InternalAppendHistoryNodesRequest is used to append a batch of history nodes

--- a/common/persistence/persistence_interface.go
+++ b/common/persistence/persistence_interface.go
@@ -530,6 +530,9 @@ type (
 		PrevTransactionID int64
 		// The events to be appended
 		Events *commonpb.DataBlob
+		// EncodingOverride, if non-empty, overrides Events.EncodingType for the data_encoding column.
+		// Used when the blob is compressed (e.g. "proto3+zstd").
+		EncodingOverride string
 	}
 
 	// InternalAppendHistoryNodesRequest is used to append a batch of history nodes

--- a/common/persistence/serialization/blob_compression.go
+++ b/common/persistence/serialization/blob_compression.go
@@ -1,0 +1,108 @@
+package serialization
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/klauspost/compress/zstd"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+)
+
+const (
+	// zstdSuffix is appended to the base encoding type to indicate zstd compression.
+	// Example: "Proto3" -> "Proto3+zstd", "Json" -> "Json+zstd".
+	zstdSuffix = "+zstd"
+
+	// EncodingTypeProto3Zstd is the canonical encoding string for compressed proto3 blobs.
+	// Kept as a constant for backward compatibility and common-case optimization.
+	EncodingTypeProto3Zstd = "Proto3+zstd"
+
+	// MaxDecompressedSize is the safety limit in bytes for decompressed output.
+	// Blobs larger than this are not eligible for compression, and the decoder
+	// will refuse to produce output exceeding this size.
+	MaxDecompressedSize = 16 * 1024 * 1024
+)
+
+var (
+	zstdEncoder *zstd.Encoder
+	zstdDecoder *zstd.Decoder
+)
+
+func init() {
+	var err error
+	zstdEncoder, err = zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault))
+	if err != nil {
+		panic("failed to initialize zstd encoder: " + err.Error()) //nolint:forbidigo // must fail fast on broken build
+	}
+	zstdDecoder, err = zstd.NewReader(nil, zstd.WithDecoderMaxMemory(MaxDecompressedSize))
+	if err != nil {
+		panic("failed to initialize zstd decoder: " + err.Error()) //nolint:forbidigo // must fail fast on broken build
+	}
+}
+
+// IsCompressedEncoding returns true if the encoding string indicates zstd compression
+// (e.g. "Proto3+zstd", "Json+zstd").
+func IsCompressedEncoding(encoding string) bool {
+	return len(encoding) > len(zstdSuffix) && strings.HasSuffix(strings.ToLower(encoding), zstdSuffix)
+}
+
+// CompressHistoryEventBlob compresses the data in a DataBlob using zstd.
+// Returns the original blob unchanged if compression doesn't reduce size or if
+// the blob exceeds MaxDecompressedSize (would fail to decompress later).
+func CompressHistoryEventBlob(blob *commonpb.DataBlob) (*commonpb.DataBlob, string, error) {
+	if blob == nil {
+		return nil, "", nil
+	}
+
+	// Blobs at or above the decoder limit cannot be decompressed later.
+	if len(blob.Data) >= MaxDecompressedSize {
+		return blob, "", nil
+	}
+
+	compressed := zstdEncoder.EncodeAll(blob.Data, make([]byte, 0, len(blob.Data)/2))
+	// If compression didn't reduce size, store uncompressed to avoid overhead on read.
+	if len(compressed) >= len(blob.Data) {
+		return blob, "", nil
+	}
+
+	encodingStr := blob.EncodingType.String() + zstdSuffix
+	return &commonpb.DataBlob{
+		Data:         compressed,
+		EncodingType: blob.EncodingType,
+	}, encodingStr, nil
+}
+
+// DecompressHistoryEventBlob decompresses a zstd-compressed DataBlob back to its
+// original encoding. The base encoding type is parsed from the encoding string
+// (e.g. "Proto3+zstd" -> ENCODING_TYPE_PROTO3). If the encoding is not compressed,
+// it returns the blob unchanged.
+func DecompressHistoryEventBlob(data []byte, encodingStr string) (*commonpb.DataBlob, error) {
+	if !IsCompressedEncoding(encodingStr) {
+		encodingType, err := enumspb.EncodingTypeFromString(encodingStr)
+		if err != nil {
+			encodingType = enumspb.ENCODING_TYPE_UNSPECIFIED
+		}
+		return &commonpb.DataBlob{
+			Data:         data,
+			EncodingType: encodingType,
+		}, nil
+	}
+
+	decompressed, err := zstdDecoder.DecodeAll(data, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decompress history node blob (encoding=%q, size=%d): %w", encodingStr, len(data), err)
+	}
+
+	// Parse base encoding from the marker (strip "+zstd" suffix).
+	baseEncodingStr := encodingStr[:len(encodingStr)-len(zstdSuffix)]
+	baseEncoding, err := enumspb.EncodingTypeFromString(baseEncodingStr)
+	if err != nil {
+		baseEncoding = enumspb.ENCODING_TYPE_PROTO3
+	}
+
+	return &commonpb.DataBlob{
+		Data:         decompressed,
+		EncodingType: baseEncoding,
+	}, nil
+}

--- a/common/persistence/serialization/blob_compression_test.go
+++ b/common/persistence/serialization/blob_compression_test.go
@@ -1,0 +1,121 @@
+package serialization
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+)
+
+func TestCompressDecompressRoundTrip(t *testing.T) {
+	original := bytes.Repeat([]byte("hello world "), 200)
+	blob := &commonpb.DataBlob{
+		Data:         original,
+		EncodingType: enumspb.ENCODING_TYPE_PROTO3,
+	}
+
+	compressed, encodingStr, err := CompressHistoryEventBlob(blob)
+	require.NoError(t, err)
+	require.Equal(t, EncodingTypeProto3Zstd, encodingStr)
+	require.Less(t, len(compressed.Data), len(original))
+
+	decompressed, err := DecompressHistoryEventBlob(compressed.Data, encodingStr)
+	require.NoError(t, err)
+	require.Equal(t, enumspb.ENCODING_TYPE_PROTO3, decompressed.EncodingType)
+	require.Equal(t, original, decompressed.Data)
+}
+
+func TestCompressHistoryEventBlob_NilBlob(t *testing.T) {
+	result, encodingStr, err := CompressHistoryEventBlob(nil)
+	require.NoError(t, err)
+	require.Nil(t, result)
+	require.Empty(t, encodingStr)
+}
+
+func TestCompressHistoryEventBlob_EmptyData(t *testing.T) {
+	blob := &commonpb.DataBlob{
+		Data:         []byte{},
+		EncodingType: enumspb.ENCODING_TYPE_PROTO3,
+	}
+	result, encodingStr, err := CompressHistoryEventBlob(blob)
+	require.NoError(t, err)
+	// Empty data: compressed will be larger due to zstd framing, so original returned.
+	require.Same(t, blob, result)
+	require.Empty(t, encodingStr)
+}
+
+func TestDecompressHistoryEventBlob_CorruptedData(t *testing.T) {
+	_, err := DecompressHistoryEventBlob([]byte("not zstd data"), EncodingTypeProto3Zstd)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to decompress")
+}
+
+func TestCompressHistoryEventBlob_IncompressibleData(t *testing.T) {
+	// Use already-compressed data to guarantee incompressibility:
+	// zstd output has maximum entropy and cannot be compressed further.
+	randomSource := bytes.Repeat([]byte("ab"), 1024)
+	preCompressed := zstdEncoder.EncodeAll(randomSource, nil)
+
+	blob := &commonpb.DataBlob{
+		Data:         preCompressed,
+		EncodingType: enumspb.ENCODING_TYPE_PROTO3,
+	}
+
+	result, encodingStr, err := CompressHistoryEventBlob(blob)
+	require.NoError(t, err)
+	// Should return original blob unchanged since compression doesn't help.
+	require.Same(t, blob, result)
+	require.Empty(t, encodingStr)
+}
+
+func TestDecompressHistoryEventBlob_PlainEncoding(t *testing.T) {
+	data := []byte("plain proto3 data")
+	blob, err := DecompressHistoryEventBlob(data, enumspb.ENCODING_TYPE_PROTO3.String())
+	require.NoError(t, err)
+	require.Equal(t, enumspb.ENCODING_TYPE_PROTO3, blob.EncodingType)
+	require.Equal(t, data, blob.Data)
+}
+
+func TestIsCompressedEncoding(t *testing.T) {
+	require.True(t, IsCompressedEncoding(EncodingTypeProto3Zstd))
+	require.True(t, IsCompressedEncoding("PROTO3+ZSTD"))
+	require.True(t, IsCompressedEncoding("proto3+zstd"))
+	require.True(t, IsCompressedEncoding("Json+zstd"))
+	require.False(t, IsCompressedEncoding("proto3"))
+	require.False(t, IsCompressedEncoding("json"))
+	require.False(t, IsCompressedEncoding(""))
+	require.False(t, IsCompressedEncoding("+zstd"))
+}
+
+func TestCompressDecompressRoundTrip_JSON(t *testing.T) {
+	original := bytes.Repeat([]byte(`{"event":"data"}`), 200)
+	blob := &commonpb.DataBlob{
+		Data:         original,
+		EncodingType: enumspb.ENCODING_TYPE_JSON,
+	}
+
+	compressed, encodingStr, err := CompressHistoryEventBlob(blob)
+	require.NoError(t, err)
+	require.Equal(t, "Json+zstd", encodingStr)
+	require.Less(t, len(compressed.Data), len(original))
+
+	decompressed, err := DecompressHistoryEventBlob(compressed.Data, encodingStr)
+	require.NoError(t, err)
+	require.Equal(t, enumspb.ENCODING_TYPE_JSON, decompressed.EncodingType)
+	require.Equal(t, original, decompressed.Data)
+}
+
+func TestCompressHistoryEventBlob_ExceedsMaxDecompressedSize(t *testing.T) {
+	// Blob at the limit should be returned unchanged (not compressed).
+	blob := &commonpb.DataBlob{
+		Data:         make([]byte, MaxDecompressedSize),
+		EncodingType: enumspb.ENCODING_TYPE_PROTO3,
+	}
+
+	result, encodingStr, err := CompressHistoryEventBlob(blob)
+	require.NoError(t, err)
+	require.Same(t, blob, result)
+	require.Empty(t, encodingStr)
+}

--- a/common/persistence/sql/history_store.go
+++ b/common/persistence/sql/history_store.go
@@ -44,7 +44,7 @@ func (m *sqlExecutionStore) AppendHistoryNodes(
 		PrevTxnID:    node.PrevTransactionID,
 		TxnID:        node.TransactionID,
 		Data:         node.Events.Data,
-		DataEncoding: node.Events.EncodingType.String(),
+		DataEncoding: p.HistoryNodeEncodingString(node),
 		ShardID:      request.ShardID,
 	}
 

--- a/common/persistence/tests/execution_mutable_state.go
+++ b/common/persistence/tests/execution_mutable_state.go
@@ -73,6 +73,7 @@ func NewExecutionMutableStateSuite(
 			nil,
 			logger,
 			dynamicconfig.GetIntPropertyFn(4*1024*1024),
+			dynamicconfig.GetIntPropertyFn(0),
 			dynamicconfig.GetBoolPropertyFn(false),
 		),
 		HistoryBranchUtil: p.NewHistoryBranchUtil(serializer),

--- a/common/persistence/tests/execution_mutable_state_task.go
+++ b/common/persistence/tests/execution_mutable_state_task.go
@@ -75,6 +75,7 @@ func NewExecutionMutableStateTaskSuite(
 			nil,
 			logger,
 			dynamicconfig.GetIntPropertyFn(4*1024*1024),
+			dynamicconfig.GetIntPropertyFn(0),
 			dynamicconfig.GetBoolPropertyFn(false),
 		),
 		Logger: logger,

--- a/common/persistence/tests/history_store.go
+++ b/common/persistence/tests/history_store.go
@@ -65,6 +65,7 @@ func NewHistoryEventsSuite(
 			nil,
 			logger,
 			dynamicconfig.GetIntPropertyFn(4*1024*1024),
+			dynamicconfig.GetIntPropertyFn(0),
 			dynamicconfig.GetBoolPropertyFn(false),
 		),
 		serializer: serializer,

--- a/common/resource/fx.go
+++ b/common/resource/fx.go
@@ -338,6 +338,7 @@ func MatchingClientProvider(matchingRawClient MatchingRawClient) MatchingClient 
 
 func PersistenceConfigProvider(persistenceConfig config.Persistence, dc *dynamicconfig.Collection) *config.Persistence {
 	persistenceConfig.TransactionSizeLimit = dynamicconfig.TransactionSizeLimit.Get(dc)
+	persistenceConfig.HistoryNodeBlobCompressionThreshold = dynamicconfig.HistoryNodeBlobCompressionThreshold.Get(dc)
 	return &persistenceConfig
 }
 


### PR DESCRIPTION
AppendHistoryNodesResponse.Size now reports the logical (uncompressed) payload size rather than the compressed on-disk size. This preserves the pre-compression semantics for callers that accumulate Size for pagination decisions.

The DataSize field on InternalHistoryNode captures len(blob.Data) before compression and is used for the response. The compressed size is still used for TransactionSizeLimit enforcement.

Fixes: https://github.com/temporalio/temporal/issues/10307