### PR TITLE
Add OR statement to match V1 and V2 Scheduler BusinessIds (#10248)

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/query_interceptors.go
+++ b/common/persistence/visibility/store/elasticsearch/query_interceptors.go
@@ -13,7 +13,6 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/visibility/store"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
-	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 )
@@ -129,10 +128,6 @@ func (vi *valuesInterceptor) Values(name string, fieldName string, values ...any
 		value, err = parseSystemSearchAttributeValues(name, value)
 		if err != nil {
 			return nil, err
-		}
-
-		if name == sadefs.ScheduleID && fieldName == sadefs.WorkflowID {
-			value = primitives.ScheduleWorkflowIDPrefix + fmt.Sprintf("%v", value)
 		}
 
 		value, err = vi.validateValueType(name, value, fieldType)

--- a/common/persistence/visibility/store/elasticsearch/query_interceptors_test.go
+++ b/common/persistence/visibility/store/elasticsearch/query_interceptors_test.go
@@ -9,7 +9,6 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
-	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.uber.org/mock/gomock"
@@ -177,32 +176,6 @@ func (s *QueryInterceptorSuite) TestNameInterceptor_ScheduleIDToWorkflowID() {
 	fieldName, err := ni.Name(sadefs.ScheduleID, query.FieldNameFilter)
 	s.NoError(err)
 	s.Equal(sadefs.WorkflowID, fieldName)
-}
-
-// Ensures the valuesInterceptor applies the ScheduleID to WorkflowID transformation,
-// including prepending the WorkflowIDPrefix.
-func (s *QueryInterceptorSuite) TestValuesInterceptor_ScheduleIDToWorkflowID() {
-	vi := NewValuesInterceptor(
-		"test-namespace",
-		searchattribute.TestEsNameTypeMap(),
-		nil,
-		metrics.NoopMetricsHandler,
-		log.NewNoopLogger(),
-	)
-
-	values, err := vi.Values(sadefs.ScheduleID, sadefs.WorkflowID, "test-schedule-id")
-	s.NoError(err)
-	s.Len(values, 1)
-	s.Equal(primitives.ScheduleWorkflowIDPrefix+"test-schedule-id", values[0])
-
-	values, err = vi.Values(sadefs.ScheduleID,
-		sadefs.WorkflowID,
-		"test-schedule-id-1",
-		"test-schedule-id-2")
-	s.NoError(err)
-	s.Len(values, 2)
-	s.Equal(primitives.ScheduleWorkflowIDPrefix+"test-schedule-id-1", values[0])
-	s.Equal(primitives.ScheduleWorkflowIDPrefix+"test-schedule-id-2", values[1])
 }
 
 // Ensures the valuesInterceptor doesn't modify values when no transformation is needed.

--- a/common/persistence/visibility/store/query/converter.go
+++ b/common/persistence/visibility/store/query/converter.go
@@ -14,7 +14,6 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/namespace"
-	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/sqlquery"
@@ -577,9 +576,6 @@ func (c *QueryConverter[ExprT]) parseValueExpr(
 		value, err := c.parseSQLVal(e, saName, saFieldName, saType)
 		if err != nil {
 			return nil, err
-		}
-		if saName == sadefs.ScheduleID && saFieldName == sadefs.WorkflowID {
-			value = primitives.ScheduleWorkflowIDPrefix + fmt.Sprintf("%v", value)
 		}
 		return value, nil
 	case sqlparser.BoolVal:

--- a/common/persistence/visibility/store/query/converter_test.go
+++ b/common/persistence/visibility/store/query/converter_test.go
@@ -12,7 +12,6 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/namespace"
-	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.uber.org/mock/gomock"
@@ -1708,18 +1707,6 @@ func TestQueryConverter_ConvertColName(t *testing.T) {
 		},
 
 		{
-			name: "success special ScheduleID",
-			in: &sqlparser.ColName{
-				Name: sqlparser.NewColIdent(sadefs.ScheduleID),
-			},
-			out: NewSAColumn(
-				sadefs.ScheduleID,
-				sadefs.WorkflowID,
-				enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-			),
-		},
-
-		{
 			name: "success backticks",
 			in: &sqlparser.ColName{
 				Name: sqlparser.NewColIdent("`AliasForKeyword01`"),
@@ -1964,15 +1951,6 @@ func TestQueryConverter_ParseValueExpr(t *testing.T) {
 			field:  sadefs.WorkflowType,
 			saType: enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 			out:    "foo",
-		},
-
-		{
-			name:   "success special ScheduleID",
-			expr:   sqlparser.NewStrVal([]byte("foo")),
-			alias:  sadefs.ScheduleID,
-			field:  sadefs.WorkflowID,
-			saType: enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-			out:    primitives.ScheduleWorkflowIDPrefix + "foo",
 		},
 
 		{

--- a/common/persistence/visibility/store/sql/query_converter_legacy.go
+++ b/common/persistence/visibility/store/sql/query_converter_legacy.go
@@ -13,7 +13,6 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
-	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/sqlquery"
@@ -487,10 +486,6 @@ func (c *QueryConverterLegacy) convertValueExpr(
 		value, err := c.parseSQLVal(e, name, saFieldName, saType)
 		if err != nil {
 			return err
-		}
-
-		if name == sadefs.ScheduleID && saFieldName == sadefs.WorkflowID {
-			value = primitives.ScheduleWorkflowIDPrefix + fmt.Sprintf("%v", value)
 		}
 
 		switch v := value.(type) {

--- a/common/persistence/visibility/store/sql/query_converter_legacy_test.go
+++ b/common/persistence/visibility/store/sql/query_converter_legacy_test.go
@@ -14,7 +14,6 @@ import (
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
-	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 )
@@ -771,17 +770,6 @@ func (s *queryConverterSuite) TestConvertValueExpr() {
 				"saType":      enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
 			},
 			output: "('foo', 'bar')",
-			err:    nil,
-		},
-		{
-			name:  "ScheduleId transformation",
-			input: "'test-schedule'",
-			args: map[string]any{
-				"saName":      sadefs.ScheduleID,
-				"saFieldName": sadefs.WorkflowID,
-				"saType":      enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-			},
-			output: fmt.Sprintf("'%stest-schedule'", primitives.ScheduleWorkflowIDPrefix),
 			err:    nil,
 		},
 	}

--- a/common/searchattribute/mapper.go
+++ b/common/searchattribute/mapper.go
@@ -209,3 +209,23 @@ func UnaliasFields(
 
 	return &commonpb.SearchAttributes{IndexedFields: newIndexedFields}, nil
 }
+
+// IsUserDefinedSearchAttribute returns true if alias refers to a user-defined custom search
+// attribute rather than a synthetic one (e.g. the synthetic ScheduleId that maps to WorkflowId).
+//
+// Two independent checks are required because custom SAs can be registered in two ways:
+//  1. Via UpdateNamespace with an explicit alias: stored in the Mapper as alias → field-name.
+//     GetFieldName returns the underlying field name (different from the alias), so the SA is
+//     identifiable even when it is absent from the NameTypeMap under the alias.
+//  2. Via AddSearchAttributes without an alias: stored directly in NameTypeMap's custom map
+//     under the alias itself. GetFieldName returns an error (no mapping exists), so the type
+//     map is the only way to detect these.
+func IsUserDefinedSearchAttribute(alias string, saMapper Mapper, saNameType NameTypeMap, ns string) bool {
+	// Check 1: explicit alias mapping resolves to a different underlying field name.
+	if mapped, err := saMapper.GetFieldName(alias, ns); err == nil && mapped != alias {
+		return true
+	}
+	// Check 2: alias is registered as a custom SA in the type map (no alias mapping).
+	_, ok := saNameType.Custom()[alias]
+	return ok
+}

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -5002,6 +5002,15 @@ func (wh *WorkflowHandler) prepareSchedulerQuery(
 			return "", err
 		}
 
+		saMapper, err := wh.saMapperProvider.GetMapper(namespaceName)
+		if err != nil {
+			return "", serviceerror.NewUnavailablef(errUnableToGetSearchAttributesMessage, err)
+		}
+		query, err = scheduler.RewriteScheduleIDQuery(query, chasmEnabled, saMapper, saNameType, namespaceName)
+		if err != nil {
+			return "", err
+		}
+
 		result = fmt.Sprintf("%s AND (%s)", baseQuery, query)
 	}
 

--- a/service/worker/scheduler/schedule_id_query_rewriter.go
+++ b/service/worker/scheduler/schedule_id_query_rewriter.go
@@ -1,0 +1,181 @@
+package scheduler
+
+import (
+	"strings"
+
+	"github.com/temporalio/sqlparser"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/common/searchattribute/sadefs"
+)
+
+var workflowIDCol = &sqlparser.ColName{Name: sqlparser.NewColIdent(sadefs.WorkflowID)}
+
+// RewriteScheduleIDQuery rewrites ScheduleId comparisons in the query string to WorkflowId
+// comparisons before the query reaches the visibility store converters.
+//
+// V1 schedules store WorkflowId with a "temporal-sys-scheduler:" prefix; V2/CHASM schedules
+// store it without any prefix. When chasmEnabled (migration period), each ScheduleId comparison
+// becomes an OR of the prefixed (V1) and unprefixed (V2) WorkflowId conditions for positive
+// operators, and AND for negative operators (!=, NOT IN, NOT STARTS_WITH), so both stores are
+// correctly included or excluded.
+//
+// If the user has defined a custom search attribute named ScheduleId, this function leaves the
+// expression unchanged; the converter handles it as a regular keyword SA.
+//
+// TODO: once V1 schedules are fully migrated to CHASM, drop the OR/AND and emit only the
+// unprefixed V2 WorkflowId condition.
+func RewriteScheduleIDQuery(
+	queryStr string,
+	chasmEnabled bool,
+	saMapper searchattribute.Mapper,
+	saNameType searchattribute.NameTypeMap,
+	ns namespace.Name,
+) (string, error) {
+	if strings.TrimSpace(queryStr) == "" {
+		return queryStr, nil
+	}
+
+	stmt, err := sqlparser.Parse("select * from table1 where " + queryStr)
+	if err != nil {
+		// Malformed SQL is passed through; the normal validation path will return a proper error.
+		return queryStr, nil
+	}
+	sel, ok := stmt.(*sqlparser.Select)
+	if !ok {
+		return queryStr, nil
+	}
+	if sel.Where == nil {
+		return queryStr, nil
+	}
+
+	changed := rewriteExpr(&sel.Where.Expr, chasmEnabled, saMapper, saNameType, ns.String())
+	if !changed {
+		return queryStr, nil
+	}
+
+	// Reconstruct the query from the rewritten WHERE expression.
+	// If the original query also had a GROUP BY clause, append it so it is preserved for
+	// when GROUP BY support is added to prepareSchedulerQuery — omitting it would silently
+	// drop the clause and cause the ScheduleId issue to resurface once GROUP BY is supported.
+	result := sqlparser.String(sel.Where.Expr)
+	if len(sel.GroupBy) > 0 {
+		groupByCols := make([]string, len(sel.GroupBy))
+		for i, expr := range sel.GroupBy {
+			groupByCols[i] = sqlparser.String(expr)
+		}
+		result += " group by " + strings.Join(groupByCols, ", ")
+	}
+	return result, nil
+}
+
+// rewriteExpr recursively walks expr and rewrites ScheduleId comparison nodes in-place.
+// Returns true if any rewriting occurred.
+func rewriteExpr(exprRef *sqlparser.Expr, chasmEnabled bool, saMapper searchattribute.Mapper, saNameType searchattribute.NameTypeMap, ns string) bool {
+	switch e := (*exprRef).(type) {
+	case *sqlparser.AndExpr:
+		l := rewriteExpr(&e.Left, chasmEnabled, saMapper, saNameType, ns)
+		r := rewriteExpr(&e.Right, chasmEnabled, saMapper, saNameType, ns)
+		return l || r
+	case *sqlparser.OrExpr:
+		l := rewriteExpr(&e.Left, chasmEnabled, saMapper, saNameType, ns)
+		r := rewriteExpr(&e.Right, chasmEnabled, saMapper, saNameType, ns)
+		return l || r
+	case *sqlparser.ParenExpr:
+		return rewriteExpr(&e.Expr, chasmEnabled, saMapper, saNameType, ns)
+	case *sqlparser.NotExpr:
+		return rewriteExpr(&e.Expr, chasmEnabled, saMapper, saNameType, ns)
+	case *sqlparser.ComparisonExpr:
+		return rewriteComparison(exprRef, e, chasmEnabled, saMapper, saNameType, ns)
+	case *sqlparser.IsExpr:
+		return rewriteIsExpr(e, saMapper, saNameType, ns)
+	}
+	return false
+}
+
+// rewriteComparison rewrites a single ComparisonExpr if its LHS is the synthetic ScheduleId SA.
+func rewriteComparison(exprRef *sqlparser.Expr, expr *sqlparser.ComparisonExpr, chasmEnabled bool, saMapper searchattribute.Mapper, saNameType searchattribute.NameTypeMap, ns string) bool {
+	col, ok := expr.Left.(*sqlparser.ColName)
+	if !ok || !isScheduleIDToWorkflowIDColumn(col, saMapper, saNameType, ns) {
+		return false
+	}
+
+	if !chasmEnabled {
+		// V1-only: prefix the value and use WorkflowId as column.
+		expr.Left = workflowIDCol
+		expr.Right = prefixScheduleIDSQLValues(expr.Right)
+		return true
+	}
+
+	// CHASM migration path: OR of prefixed (V1) and unprefixed (V2) for positive operators;
+	// AND for negative operators so both forms are excluded.
+	v1Expr := &sqlparser.ComparisonExpr{
+		Operator: expr.Operator,
+		Left:     workflowIDCol,
+		Right:    prefixScheduleIDSQLValues(expr.Right),
+	}
+	v2Expr := &sqlparser.ComparisonExpr{
+		Operator: expr.Operator,
+		Left:     workflowIDCol,
+		Right:    expr.Right,
+	}
+
+	if IsNegativeScheduleIDOperator(expr.Operator) {
+		*exprRef = &sqlparser.ParenExpr{Expr: &sqlparser.AndExpr{Left: v1Expr, Right: v2Expr}}
+	} else {
+		*exprRef = &sqlparser.ParenExpr{Expr: &sqlparser.OrExpr{Left: v1Expr, Right: v2Expr}}
+	}
+	return true
+}
+
+// rewriteIsExpr rewrites a ScheduleId IS [NOT] NULL expression to use WorkflowId.
+// No prefix rewriting is needed for IS NULL / IS NOT NULL.
+func rewriteIsExpr(expr *sqlparser.IsExpr, saMapper searchattribute.Mapper, saNameType searchattribute.NameTypeMap, ns string) bool {
+	col, ok := expr.Expr.(*sqlparser.ColName)
+	if !ok || !isScheduleIDToWorkflowIDColumn(col, saMapper, saNameType, ns) {
+		return false
+	}
+	expr.Expr = &sqlparser.ColName{Name: sqlparser.NewColIdent(sadefs.WorkflowID)}
+	return true
+}
+
+// IsNegativeScheduleIDOperator returns true for operators that express exclusion.
+// Negative operators require AND when combining V1 and V2 WorkflowId conditions so that
+// both prefixed and unprefixed forms are excluded; positive operators use OR.
+func IsNegativeScheduleIDOperator(operator string) bool {
+	return operator == sqlparser.NotEqualStr ||
+		operator == sqlparser.NotInStr ||
+		operator == sqlparser.NotStartsWithStr
+}
+
+// isScheduleIDToWorkflowIDColumn returns true if col refers to the ScheduleId search attribute
+// that maps to WorkflowId (the built-in virtual SA), as opposed to a user-defined custom SA
+// named ScheduleId which should be queried as-is.
+func isScheduleIDToWorkflowIDColumn(col *sqlparser.ColName, saMapper searchattribute.Mapper, saNameType searchattribute.NameTypeMap, ns string) bool {
+	alias := col.Name.String()
+	if searchattribute.IsUserDefinedSearchAttribute(alias, saMapper, saNameType, ns) {
+		return false
+	}
+	return strings.TrimPrefix(alias, sadefs.ReservedPrefix) == sadefs.ScheduleID
+}
+
+// prefixScheduleIDSQLValues returns a copy of the SQL value expression with the V1 schedule
+// WorkflowId prefix prepended to each string literal. Handles single SQLVal and ValTuple (IN).
+func prefixScheduleIDSQLValues(expr sqlparser.Expr) sqlparser.Expr {
+	switch e := expr.(type) {
+	case *sqlparser.SQLVal:
+		if e.Type == sqlparser.StrVal {
+			return sqlparser.NewStrVal([]byte(primitives.ScheduleWorkflowIDPrefix + string(e.Val)))
+		}
+		return e
+	case sqlparser.ValTuple:
+		result := make(sqlparser.ValTuple, len(e))
+		for i, item := range e {
+			result[i] = prefixScheduleIDSQLValues(item)
+		}
+		return result
+	default:
+		return expr
+	}
+}

--- a/service/worker/scheduler/schedule_id_query_rewriter_test.go
+++ b/service/worker/scheduler/schedule_id_query_rewriter_test.go
@@ -1,0 +1,214 @@
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/searchattribute"
+)
+
+// TestMapper only processes "test-namespace"; use it so custom SA lookups resolve correctly.
+var testNS = namespace.Name("test-namespace")
+
+// emptyNameTypeMap has no custom SAs — ScheduleId is synthetic.
+var emptyNameTypeMap = searchattribute.NewNameTypeMap(nil)
+
+// customScheduleIDNameTypeMap simulates a namespace that registered ScheduleId as a custom SA.
+var customScheduleIDNameTypeMap = searchattribute.NewNameTypeMap(map[string]enumspb.IndexedValueType{
+	"ScheduleId": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+})
+
+func TestRewriteScheduleIDQuery(t *testing.T) {
+	t.Parallel()
+
+	prefix := primitives.ScheduleWorkflowIDPrefix
+
+	tests := []struct {
+		name         string
+		query        string
+		chasmEnabled bool
+		mapper       searchattribute.Mapper
+		saNameType   *searchattribute.NameTypeMap // nil means emptyNameTypeMap
+		want         string
+	}{
+		// Empty / no-op cases.
+		{
+			name:  "empty query",
+			query: "",
+			want:  "",
+		},
+		{
+			// ScheduleId is rewritten and GROUP BY is preserved so that when GROUP BY support
+			// is added to prepareSchedulerQuery the rewrite is already in place.
+			name:         "CHASM ScheduleId with GROUP BY rewrites WHERE preserves GROUP BY",
+			query:        "ScheduleId = 'my-sched' Group By TemporalSchedulePaused",
+			chasmEnabled: true,
+			want:         "(WorkflowId = '" + prefix + "my-sched' or WorkflowId = 'my-sched') group by TemporalSchedulePaused",
+		},
+		{
+			name:  "whitespace query",
+			query: "   ",
+			want:  "   ",
+		},
+		{
+			name:  "no ScheduleId no rewrite",
+			query: "ExecutionStatus = 'Running'",
+			want:  "ExecutionStatus = 'Running'",
+		},
+
+		// V1 (chasmEnabled=false) — single-value operators.
+		{
+			name:         "V1 equal",
+			query:        "ScheduleId = 'my-sched'",
+			chasmEnabled: false,
+			want:         "WorkflowId = '" + prefix + "my-sched'",
+		},
+		{
+			name:         "V1 not equal",
+			query:        "ScheduleId != 'my-sched'",
+			chasmEnabled: false,
+			want:         "WorkflowId != '" + prefix + "my-sched'",
+		},
+		{
+			name:         "V1 starts with",
+			query:        "ScheduleId STARTS_WITH 'my-'",
+			chasmEnabled: false,
+			want:         "WorkflowId starts_with '" + prefix + "my-'",
+		},
+		{
+			name:         "V1 not starts with",
+			query:        "ScheduleId NOT STARTS_WITH 'my-'",
+			chasmEnabled: false,
+			want:         "WorkflowId not starts_with '" + prefix + "my-'",
+		},
+		{
+			name:         "V1 IN",
+			query:        "ScheduleId IN ('foo', 'bar')",
+			chasmEnabled: false,
+			want:         "WorkflowId in ('" + prefix + "foo', '" + prefix + "bar')",
+		},
+		{
+			name:         "V1 NOT IN",
+			query:        "ScheduleId NOT IN ('foo', 'bar')",
+			chasmEnabled: false,
+			want:         "WorkflowId not in ('" + prefix + "foo', '" + prefix + "bar')",
+		},
+
+		// V1 — reserved TemporalScheduleId alias.
+		{
+			name:         "V1 TemporalScheduleId alias",
+			query:        "TemporalScheduleId = 'my-sched'",
+			chasmEnabled: false,
+			want:         "WorkflowId = '" + prefix + "my-sched'",
+		},
+
+		// V1 — IS NOT NULL (no prefix, just column rename).
+		{
+			name:         "V1 IS NOT NULL",
+			query:        "ScheduleId IS NOT NULL",
+			chasmEnabled: false,
+			want:         "WorkflowId is not null",
+		},
+
+		// CHASM (chasmEnabled=true) — positive operators produce OR.
+		{
+			name:         "CHASM equal OR",
+			query:        "ScheduleId = 'my-sched'",
+			chasmEnabled: true,
+			want:         "(WorkflowId = '" + prefix + "my-sched' or WorkflowId = 'my-sched')",
+		},
+		{
+			name:         "CHASM TemporalScheduleId alias OR",
+			query:        "TemporalScheduleId = 'my-sched'",
+			chasmEnabled: true,
+			want:         "(WorkflowId = '" + prefix + "my-sched' or WorkflowId = 'my-sched')",
+		},
+		{
+			name:         "CHASM starts with OR",
+			query:        "ScheduleId STARTS_WITH 'my-'",
+			chasmEnabled: true,
+			want:         "(WorkflowId starts_with '" + prefix + "my-' or WorkflowId starts_with 'my-')",
+		},
+		{
+			name:         "CHASM IN OR",
+			query:        "ScheduleId IN ('foo', 'bar')",
+			chasmEnabled: true,
+			want:         "(WorkflowId in ('" + prefix + "foo', '" + prefix + "bar') or WorkflowId in ('foo', 'bar'))",
+		},
+
+		// CHASM — negative operators produce AND.
+		{
+			name:         "CHASM not equal AND",
+			query:        "ScheduleId != 'my-sched'",
+			chasmEnabled: true,
+			want:         "(WorkflowId != '" + prefix + "my-sched' and WorkflowId != 'my-sched')",
+		},
+		{
+			name:         "CHASM not starts with AND",
+			query:        "ScheduleId NOT STARTS_WITH 'my-'",
+			chasmEnabled: true,
+			want:         "(WorkflowId not starts_with '" + prefix + "my-' and WorkflowId not starts_with 'my-')",
+		},
+		{
+			name:         "CHASM NOT IN AND",
+			query:        "ScheduleId NOT IN ('foo', 'bar')",
+			chasmEnabled: true,
+			want:         "(WorkflowId not in ('" + prefix + "foo', '" + prefix + "bar') and WorkflowId not in ('foo', 'bar'))",
+		},
+
+		// CHASM — IS NOT NULL (just column rename, no OR/AND needed).
+		{
+			name:         "CHASM IS NOT NULL",
+			query:        "ScheduleId IS NOT NULL",
+			chasmEnabled: true,
+			want:         "WorkflowId is not null",
+		},
+
+		// ScheduleId combined with another filter.
+		{
+			name:         "CHASM combined AND with other filter",
+			query:        "ScheduleId = 'my-sched' AND TemporalSchedulePaused = true",
+			chasmEnabled: true,
+			want:         "(WorkflowId = '" + prefix + "my-sched' or WorkflowId = 'my-sched') and TemporalSchedulePaused = true",
+		},
+
+		// Custom SA named ScheduleId with explicit alias mapping (check 1: mapper).
+		{
+			name:         "custom SA with alias mapping not rewritten",
+			query:        "ScheduleId = 'my-sched'",
+			chasmEnabled: true,
+			mapper:       &searchattribute.TestMapper{WithCustomScheduleID: true},
+			want:         "ScheduleId = 'my-sched'",
+		},
+
+		// Custom SA named ScheduleId registered in the type map without alias (check 2: type map).
+		// This is the common case when a user adds ScheduleId via AddSearchAttributes.
+		{
+			name:         "custom SA in type map not rewritten",
+			query:        "ScheduleId = 'my-sched'",
+			chasmEnabled: true,
+			saNameType:   &customScheduleIDNameTypeMap,
+			want:         "ScheduleId = 'my-sched'",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mapper := tc.mapper
+			if mapper == nil {
+				mapper = &searchattribute.NoopMapper{}
+			}
+			saNameType := emptyNameTypeMap
+			if tc.saNameType != nil {
+				saNameType = *tc.saNameType
+			}
+			got, err := RewriteScheduleIDQuery(tc.query, tc.chasmEnabled, mapper, saNameType, testNS)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -110,6 +110,76 @@ func runSharedScheduleTests(t *testing.T, newContext contextFactory) {
 	t.Run("TestCountSchedules", func(t *testing.T) { testCountSchedules(t, newContext) })
 	t.Run("TestSchedule_InternalTaskQueue", func(t *testing.T) { testScheduleInternalTaskQueue(t, newContext) })
 	t.Run("TestDeletedScheduleOperations", func(t *testing.T) { testDeletedScheduleOperations(t, newContext) })
+	t.Run("TestListSchedulesPagination", func(t *testing.T) { testListSchedulesPagination(t, newContext) })
+	t.Run("TestListSchedulesFilterAndEntryFields", func(t *testing.T) { testListSchedulesFilterAndEntryFields(t, newContext) })
+	t.Run("TestListSchedulesFilterByScheduleId", func(t *testing.T) { testListSchedulesFilterByScheduleID(t, newContext) })
+	t.Run("TestBufferSizeReportedWhenBuffered", func(t *testing.T) { testBufferSizeReportedWhenBuffered(t, newContext) })
+}
+
+// testBufferSizeReportedWhenBuffered verifies that ScheduleInfo.BufferSize is
+// populated by both the V1 and V2 (CHASM) schedulers when at least one fire is
+// queued behind a still-running workflow. A schedule with a 1s interval and
+// BUFFER_ONE keeps exactly one start in the buffer while the first workflow
+// is still running.
+func testBufferSizeReportedWhenBuffered(t *testing.T, newContext contextFactory) {
+	s := testcore.NewEnv(t, scheduleCommonOpts()...)
+
+	sid := testcore.RandomizeStr("sched-buffer-size")
+	wid := testcore.RandomizeStr("sched-buffer-size-wf")
+	wt := testcore.RandomizeStr("sched-buffer-size-wt")
+
+	s.SdkWorker().RegisterWorkflowWithOptions(
+		func(ctx workflow.Context) error {
+			return workflow.Sleep(ctx, time.Hour)
+		},
+		workflow.RegisterOptions{Name: wt},
+	)
+
+	schedule := &schedulepb.Schedule{
+		Spec: &schedulepb.ScheduleSpec{
+			Interval: []*schedulepb.IntervalSpec{
+				{Interval: durationpb.New(1 * time.Second)},
+			},
+		},
+		Action: &schedulepb.ScheduleAction{
+			Action: &schedulepb.ScheduleAction_StartWorkflow{
+				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+					WorkflowId:   wid,
+					WorkflowType: &commonpb.WorkflowType{Name: wt},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				},
+			},
+		},
+		Policies: &schedulepb.SchedulePolicies{
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
+		},
+	}
+
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Schedule:   schedule,
+		Identity:   "test",
+		RequestId:  uuid.NewString(),
+	})
+	s.NoError(err)
+
+	var lastDescribe *workflowservice.DescribeScheduleResponse
+	s.Eventually(func() bool {
+		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+		})
+		if descErr != nil {
+			return false
+		}
+		lastDescribe = desc
+		return desc.GetInfo().GetBufferSize() >= 1 && len(desc.GetInfo().GetRunningWorkflows()) >= 1
+	}, 30*time.Second, 500*time.Millisecond, "DescribeSchedule should report BufferSize >= 1 with a running workflow blocking the buffer")
+
+	s.GreaterOrEqual(lastDescribe.GetInfo().GetBufferSize(), int64(1), "BufferSize must reflect at least one buffered start")
+	s.GreaterOrEqual(len(lastDescribe.GetInfo().GetRunningWorkflows()), 1, "expected the buffered fire to be queued behind a running workflow")
 }
 
 func testDeletedScheduleOperations(t *testing.T, newContext contextFactory) {
@@ -1085,6 +1155,301 @@ func testCountSchedules(t *testing.T, newContext contextFactory) {
 		})
 		return err == nil && countResp.Count >= 2
 	}, 15*time.Second, 1*time.Second, "Expected at least 2 non-paused schedules")
+}
+
+func testListSchedulesPagination(t *testing.T, newContext contextFactory) {
+	s := testcore.NewEnv(t, scheduleCommonOpts()...)
+
+	const numSchedules = 4
+	sidPrefix := "sched-test-pagination-"
+
+	for i := range numSchedules {
+		sid := fmt.Sprintf("%s%d", sidPrefix, i)
+		schedule := &schedulepb.Schedule{
+			Spec: &schedulepb.ScheduleSpec{
+				Interval: []*schedulepb.IntervalSpec{
+					{Interval: durationpb.New(1 * time.Hour)},
+				},
+			},
+			Action: &schedulepb.ScheduleAction{
+				Action: &schedulepb.ScheduleAction_StartWorkflow{
+					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+						WorkflowId:   fmt.Sprintf("wf-pagination-%d", i),
+						WorkflowType: &commonpb.WorkflowType{Name: "action"},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					},
+				},
+			},
+		}
+		_, err := s.FrontendClient().CreateSchedule(newContext(s.Context()), &workflowservice.CreateScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+			Schedule:   schedule,
+			Identity:   "test",
+			RequestId:  uuid.NewString(),
+		})
+		s.NoError(err)
+	}
+
+	// Wait for all schedules to be visible.
+	s.Eventually(func() bool {
+		countResp, err := s.FrontendClient().CountSchedules(newContext(s.Context()), &workflowservice.CountSchedulesRequest{
+			Namespace: s.Namespace().String(),
+		})
+		return err == nil && countResp.Count >= numSchedules
+	}, 15*time.Second, 1*time.Second, "Expected all schedules to be visible")
+
+	// Paginate with page size 2 and collect all schedule IDs.
+	ctx := newContext(s.Context())
+	var allIDs []string
+	var nextPageToken []byte
+	for {
+		resp, err := s.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
+			Namespace:       s.Namespace().String(),
+			MaximumPageSize: 2,
+			NextPageToken:   nextPageToken,
+		})
+		s.NoError(err)
+		for _, entry := range resp.Schedules {
+			allIDs = append(allIDs, entry.ScheduleId)
+		}
+		nextPageToken = resp.NextPageToken
+		if len(nextPageToken) == 0 {
+			break
+		}
+		// Each page except possibly the last should have entries.
+		s.NotEmpty(resp.Schedules)
+	}
+
+	// Verify we found all created schedules.
+	for i := range numSchedules {
+		sid := fmt.Sprintf("%s%d", sidPrefix, i)
+		s.Contains(allIDs, sid, "Expected schedule %s in paginated results", sid)
+	}
+}
+
+func testListSchedulesFilterAndEntryFields(t *testing.T, newContext contextFactory) {
+	s := testcore.NewEnv(t, scheduleCommonOpts()...)
+
+	sid := "sched-test-list-fields"
+	wt := "sched-test-list-fields-wt"
+
+	schMemo, _ := payload.Encode("memo value")
+	csaKeyword := "CustomKeywordField"
+	schSAValue, _ := payload.Encode("sa-val")
+
+	// Create a paused schedule with memo and custom search attributes.
+	schedule := &schedulepb.Schedule{
+		Spec: &schedulepb.ScheduleSpec{
+			Interval: []*schedulepb.IntervalSpec{
+				{Interval: durationpb.New(1 * time.Hour)},
+			},
+		},
+		Action: &schedulepb.ScheduleAction{
+			Action: &schedulepb.ScheduleAction_StartWorkflow{
+				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+					WorkflowId:   "wf-" + sid,
+					WorkflowType: &commonpb.WorkflowType{Name: wt},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				},
+			},
+		},
+		State: &schedulepb.ScheduleState{
+			Paused: true,
+			Notes:  "paused for test",
+		},
+	}
+
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Schedule:   schedule,
+		Identity:   "test",
+		RequestId:  uuid.NewString(),
+		Memo: &commonpb.Memo{
+			Fields: map[string]*commonpb.Payload{
+				"schedmemo1": schMemo,
+			},
+		},
+		SearchAttributes: &commonpb.SearchAttributes{
+			IndexedFields: map[string]*commonpb.Payload{
+				csaKeyword: schSAValue,
+			},
+		},
+	})
+	s.NoError(err)
+
+	// Wait for the schedule to appear with correct paused state.
+	entry := getScheduleEntryFromVisibility(s, sid, newContext, func(e *schedulepb.ScheduleListEntry) bool {
+		return e.Info.Paused
+	})
+
+	// Verify entry-level fields.
+	s.Equal(schMemo.Data, entry.Memo.Fields["schedmemo1"].Data)
+	s.Equal(schSAValue.Data, entry.SearchAttributes.IndexedFields[csaKeyword].Data)
+	s.Equal(wt, entry.Info.WorkflowType.Name)
+	s.True(entry.Info.Paused)
+	s.Equal("paused for test", entry.Info.Notes)
+
+	// Filter by TemporalSchedulePaused should find this schedule.
+	s.EventuallyWithT(func(c *assert.CollectT) {
+		listResp, err := s.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
+			Namespace:       s.Namespace().String(),
+			MaximumPageSize: 10,
+			Query:           fmt.Sprintf("%s = true", sadefs.TemporalSchedulePaused),
+		})
+		require.NoError(c, err)
+		var ids []string
+		for _, e := range listResp.Schedules {
+			ids = append(ids, e.ScheduleId)
+		}
+		require.Contains(c, ids, sid)
+	}, 15*time.Second, 1*time.Second)
+
+	// Filter for paused=false should not include this schedule.
+	s.EventuallyWithT(func(c *assert.CollectT) {
+		listResp, err := s.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
+			Namespace:       s.Namespace().String(),
+			MaximumPageSize: 10,
+			Query:           fmt.Sprintf("%s = false", sadefs.TemporalSchedulePaused),
+		})
+		require.NoError(c, err)
+		for _, e := range listResp.Schedules {
+			require.NotEqual(c, sid, e.ScheduleId)
+		}
+	}, 15*time.Second, 1*time.Second)
+}
+
+func testListSchedulesFilterByScheduleID(t *testing.T, newContext contextFactory) {
+	s := testcore.NewEnv(t, scheduleCommonOpts()...)
+
+	sid1 := "sched-filter-by-id-alpha"
+	sid2 := "sched-filter-by-id-beta"
+
+	schedule := func(sid string) *schedulepb.Schedule {
+		return &schedulepb.Schedule{
+			Spec: &schedulepb.ScheduleSpec{
+				Interval: []*schedulepb.IntervalSpec{
+					{Interval: durationpb.New(1 * time.Hour)},
+				},
+			},
+			Action: &schedulepb.ScheduleAction{
+				Action: &schedulepb.ScheduleAction_StartWorkflow{
+					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+						WorkflowId:   "wf-" + sid,
+						WorkflowType: &commonpb.WorkflowType{Name: "action"},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					},
+				},
+			},
+			State: &schedulepb.ScheduleState{Paused: true},
+		}
+	}
+
+	ctx := newContext(s.Context())
+
+	// Create two schedules.
+	for _, sid := range []string{sid1, sid2} {
+		_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+			Schedule:   schedule(sid),
+			Identity:   "test",
+			RequestId:  uuid.NewString(),
+		})
+		s.NoError(err)
+	}
+
+	// Wait for both schedules to appear in visibility.
+	getScheduleEntryFromVisibility(s, sid1, newContext, nil)
+	getScheduleEntryFromVisibility(s, sid2, newContext, nil)
+
+	listScheduleIDs := func(query string) []string {
+		t.Helper()
+		listResp, err := s.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
+			Namespace:       s.Namespace().String(),
+			MaximumPageSize: 10,
+			Query:           query,
+		})
+		require.NoError(t, err)
+		var ids []string
+		for _, e := range listResp.Schedules {
+			ids = append(ids, e.ScheduleId)
+		}
+		return ids
+	}
+
+	// wantIDs is the exact set of schedule IDs expected in the result.
+	// IsNegativeScheduleIDOperator drives whether an operator excludes or includes:
+	// negative operators (!=, NOT IN, NOT STARTS_WITH) produce AND in the rewriter so both
+	// V1 and V2 forms are excluded; positive operators produce OR so both forms are included.
+	tests := []struct {
+		name    string
+		query   string
+		wantIDs []string
+	}{
+		{
+			name:    "Equal",
+			query:   fmt.Sprintf("ScheduleId = '%s'", sid1),
+			wantIDs: []string{sid1},
+		},
+		{
+			// scheduler.IsNegativeScheduleIDOperator("!=") == true
+			name:    "NotEqual",
+			query:   fmt.Sprintf("ScheduleId != '%s'", sid1),
+			wantIDs: []string{sid2},
+		},
+		{
+			name:    "StartsWith",
+			query:   "ScheduleId STARTS_WITH 'sched-filter-by-id-'",
+			wantIDs: []string{sid1, sid2},
+		},
+		{
+			name:    "StartsWithSpecific",
+			query:   "ScheduleId STARTS_WITH 'sched-filter-by-id-a'",
+			wantIDs: []string{sid1},
+		},
+		{
+			// scheduler.IsNegativeScheduleIDOperator("not starts_with") == true
+			name:    "NotStartsWith",
+			query:   "ScheduleId NOT STARTS_WITH 'sched-filter-by-id-a'",
+			wantIDs: []string{sid2},
+		},
+		{
+			name:    "In",
+			query:   fmt.Sprintf("ScheduleId IN ('%s', '%s')", sid1, sid2),
+			wantIDs: []string{sid1, sid2},
+		},
+		{
+			name:    "InSingle",
+			query:   fmt.Sprintf("ScheduleId IN ('%s')", sid2),
+			wantIDs: []string{sid2},
+		},
+		{
+			// scheduler.IsNegativeScheduleIDOperator("not in") == true
+			name:    "NotIn",
+			query:   fmt.Sprintf("ScheduleId NOT IN ('%s')", sid1),
+			wantIDs: []string{sid2},
+		},
+		{
+			name:    "IsNotNull",
+			query:   "ScheduleId IS NOT NULL",
+			wantIDs: []string{sid1, sid2},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s.EventuallyWithT(func(c *assert.CollectT) {
+				ids := listScheduleIDs(tc.query)
+				require.Len(c, ids, len(tc.wantIDs))
+				for _, want := range tc.wantIDs {
+					require.Contains(c, ids, want)
+				}
+			}, 15*time.Second, 1*time.Second)
+		})
+	}
 }
 
 func testScheduleInternalTaskQueue(t *testing.T, newContext contextFactory) {


### PR DESCRIPTION
## What changed?
Add a Scheduler specific query converter to handle `ScheduleId` search attribute alias to underlying `WorkflowId` system search attribute field. If chasm is enabled, the query converter will match against both V1 and V2 Scheduler workflowId formats. V1 prefixes the workflowId with `temporal-sys-scheduler`, while V2 doesn't, so to handle either case, we need to add a OR/AND statement to match both V1 and V2 Scheduler BusinessId. OR will be used if the operator's boolean is positive, AND if the operator's boolean is negative.

## Why?
Unable to retrieve V2 Schedules that query using `ScheduleId` as a search attribute.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [X] added new functional test(s)
