### PR TITLE
Remove WithFxOptionsForService from xdc/history_replication_signals_and_updates_test.go

### DIFF
--- a/common/namespace/nsreplication/replication_admitter_test.go
+++ b/common/namespace/nsreplication/replication_admitter_test.go
@@ -12,6 +12,7 @@ import (
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/testing/testhooks"
 	"go.uber.org/mock/gomock"
 )
 
@@ -77,6 +78,7 @@ func newExecutorForAdmitterTest(t *testing.T, admitter NamespaceReplicationAdmit
 		NewNoopDataMerger(),
 		admitter,
 		log.NewTestLogger(),
+		testhooks.TestHooks{},
 	).(*taskExecutorImpl)
 	return exec, mockMgr
 }

--- a/common/namespace/nsreplication/replication_task_executor.go
+++ b/common/namespace/nsreplication/replication_task_executor.go
@@ -13,7 +13,9 @@ import (
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/testing/testhooks"
 )
 
 var (
@@ -53,6 +55,7 @@ type (
 		dataMerger      NamespaceDataMerger
 		admitter        NamespaceReplicationAdmitter
 		logger          log.Logger
+		testHooks       testhooks.TestHooks
 	}
 )
 
@@ -63,14 +66,15 @@ func NewTaskExecutor(
 	dataMerger NamespaceDataMerger,
 	admitter NamespaceReplicationAdmitter,
 	logger log.Logger,
+	testHooks testhooks.TestHooks,
 ) TaskExecutor {
-
 	return &taskExecutorImpl{
 		currentCluster:  currentCluster,
 		metadataManager: metadataManagerV2,
 		dataMerger:      dataMerger,
 		admitter:        admitter,
 		logger:          logger,
+		testHooks:       testHooks,
 	}
 }
 
@@ -82,6 +86,22 @@ func (h *taskExecutorImpl) Execute(
 	if err := h.validateNamespaceReplicationTask(task); err != nil {
 		return err
 	}
+	if hook, ok := testhooks.Get(
+		h.testHooks,
+		testhooks.NamespaceReplicationTaskInterceptor,
+		namespace.Name(task.GetInfo().GetName()),
+	); ok {
+		return hook(ctx, task, func() error {
+			return h.executeValidatedTask(ctx, task)
+		})
+	}
+	return h.executeValidatedTask(ctx, task)
+}
+
+func (h *taskExecutorImpl) executeValidatedTask(
+	ctx context.Context,
+	task *replicationspb.NamespaceTaskAttributes,
+) error {
 	if shouldProcess, err := h.shouldProcessTask(ctx, task); !shouldProcess || err != nil {
 		return err
 	}

--- a/common/namespace/nsreplication/replication_task_executor_test.go
+++ b/common/namespace/nsreplication/replication_task_executor_test.go
@@ -17,6 +17,7 @@ import (
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/testing/testhooks"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -54,6 +55,7 @@ func (s *namespaceReplicationTaskExecutorSuite) SetupTest() {
 		NewNoopDataMerger(),
 		NewDefaultAdmitter(),
 		logger,
+		testhooks.TestHooks{},
 	).(*taskExecutorImpl)
 }
 

--- a/common/testing/testhooks/hooks.go
+++ b/common/testing/testhooks/hooks.go
@@ -1,8 +1,10 @@
 package testhooks
 
 import (
+	"context"
 	"time"
 
+	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common/namespace"
 )
 
@@ -18,6 +20,8 @@ var (
 	MatchingIgnoreRoutingConfigRevisionCheck = newKey[bool, namespace.ID]()
 	MatchingDeploymentRegisterErrorBackoff   = newKey[time.Duration, namespace.ID]()
 	MatchingForwardTaskDelay                 = newKey[time.Duration, namespace.ID]()
+	HistoryReplicationTaskInterceptor        = newKey[func(*replicationspb.ReplicationTask, func() error) error, global]()
+	NamespaceReplicationTaskInterceptor      = newKey[func(context.Context, *replicationspb.NamespaceTaskAttributes, func() error) error, namespace.Name]()
 )
 
 // keyID is a unique identifier for a key, used as a map key.

--- a/common/testing/testhooks/test_impl.go
+++ b/common/testing/testhooks/test_impl.go
@@ -92,7 +92,7 @@ func newKey[T any, S any]() Key[T, S] {
 	var zero S
 	var s ScopeType
 	switch any(zero).(type) {
-	case namespace.ID:
+	case namespace.ID, namespace.Name:
 		s = ScopeNamespace
 	case global:
 		s = ScopeGlobal

--- a/service/frontend/admin_handler_test.go
+++ b/service/frontend/admin_handler_test.go
@@ -56,6 +56,7 @@ import (
 	"go.temporal.io/server/common/testing/historyrequire"
 	"go.temporal.io/server/common/testing/mocksdk"
 	"go.temporal.io/server/common/testing/protorequire"
+	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/common/testing/testvars"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/service/worker/dlq"
@@ -198,6 +199,7 @@ func (s *adminHandlerSuite) SetupTest() {
 		nsreplication.NewDefaultAdmitter(),
 		s.mockResource.GetNamespaceReplicationQueue(),
 		s.mockResource.GetLogger(),
+		testhooks.TestHooks{},
 	)
 	s.handler = NewAdminHandler(args, namespaceDLQHandler)
 	s.handler.Start()

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -44,6 +44,7 @@ import (
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/telemetry"
+	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/service"
 	"go.temporal.io/server/service/frontend/configs"
 	"go.temporal.io/server/service/history/tasks"
@@ -796,6 +797,7 @@ func NamespaceDLQHandlerProvider(
 	namespaceAdmitter nsreplication.NamespaceReplicationAdmitter,
 	namespaceReplicationQueue persistence.NamespaceReplicationQueue,
 	logger log.SnTaggedLogger,
+	testHooks testhooks.TestHooks,
 ) nsreplication.DLQMessageHandler {
 	taskExecutor := nsreplication.NewTaskExecutor(
 		clusterMetadata.GetCurrentClusterName(),
@@ -803,6 +805,7 @@ func NamespaceDLQHandlerProvider(
 		namespaceDataMerger,
 		namespaceAdmitter,
 		logger,
+		testHooks,
 	)
 	return nsreplication.NewDLQMessageHandler(
 		taskExecutor,

--- a/service/history/history_engine.go
+++ b/service/history/history_engine.go
@@ -329,6 +329,7 @@ func NewEngineWithShardContext(
 		serializer,
 		replicationTaskFetcherFactory,
 		replicationTaskExecutorProvider,
+		testHooks,
 		dlqWriter,
 	)
 

--- a/service/history/replication/executable_task_tool_box.go
+++ b/service/history/replication/executable_task_tool_box.go
@@ -9,6 +9,7 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/serialization"
 	ctasks "go.temporal.io/server/common/tasks"
+	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/replication/eventhandler"
 	"go.temporal.io/server/service/history/shard"
@@ -36,6 +37,7 @@ type (
 		Logger                   log.Logger
 		ThrottledLogger          log.ThrottledLogger
 		Serializer               serialization.Serializer
+		TestHooks                testhooks.TestHooks
 		DLQWriter                DLQWriter
 		HistoryEventsHandler     eventhandler.HistoryEventsHandler
 		WorkflowCache            wcache.Cache

--- a/service/history/replication/fx.go
+++ b/service/history/replication/fx.go
@@ -19,6 +19,7 @@ import (
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/quotas"
 	ctasks "go.temporal.io/server/common/tasks"
+	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/service/history/configs"
 	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/queues"
@@ -83,6 +84,7 @@ func eagerNamespaceRefresherProvider(
 	dataMerger nsreplication.NamespaceDataMerger,
 	admitter nsreplication.NamespaceReplicationAdmitter,
 	metricsHandler metrics.Handler,
+	testHooks testhooks.TestHooks,
 ) EagerNamespaceRefresher {
 	return NewEagerNamespaceRefresher(
 		metadataManager,
@@ -95,6 +97,7 @@ func eagerNamespaceRefresherProvider(
 			dataMerger,
 			admitter,
 			logger,
+			testHooks,
 		),
 		clusterMetadata.GetCurrentClusterName(),
 		metricsHandler,

--- a/service/history/replication/stream_receiver.go
+++ b/service/history/replication/stream_receiver.go
@@ -20,6 +20,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/primitives/timestamp"
 	ctasks "go.temporal.io/server/common/tasks"
+	"go.temporal.io/server/common/testing/testhooks"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -55,7 +56,16 @@ type (
 		slowSubmissionMu         sync.RWMutex
 		slowSubmissionTimestamps map[enumsspb.TaskPriority]time.Time
 	}
+
+	executeInterceptedTask struct {
+		TrackableExecutableTask
+		execute func() error
+	}
 )
+
+func (t executeInterceptedTask) Execute() error {
+	return t.execute()
+}
 
 func NewClusterShardKey(
 	ClusterID int32,
@@ -373,6 +383,18 @@ func (r *StreamReceiverImpl) processMessages(
 			if err != nil {
 				return err
 			}
+
+			// Tests use this hook to pause replication tasks before they are applied.
+			if hook, ok := testhooks.Get(r.TestHooks, testhooks.HistoryReplicationTaskInterceptor, testhooks.GlobalScope); ok {
+				originalTask := task
+				task = executeInterceptedTask{
+					TrackableExecutableTask: originalTask,
+					execute: func() error {
+						return hook(originalTask.ReplicationTask(), originalTask.Execute)
+					},
+				}
+			}
+
 			start := time.Now()
 			scheduler.Submit(task)
 			end := time.Now()

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -28,6 +28,7 @@ import (
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/quotas"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
+	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/service/history/configs"
 	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/shard"
@@ -64,6 +65,7 @@ type (
 		config                  *configs.Config
 		metricsHandler          metrics.Handler
 		logger                  log.Logger
+		testHooks               testhooks.TestHooks
 		replicationTaskExecutor TaskExecutor
 		dlqWriter               DLQWriter
 
@@ -99,6 +101,7 @@ func NewTaskProcessor(
 	replicationTaskFetcher taskFetcher,
 	replicationTaskExecutor TaskExecutor,
 	eventSerializer serialization.Serializer,
+	testHooks testhooks.TestHooks,
 	dlqWriter DLQWriter,
 ) TaskProcessor {
 	shardID := shardContext.GetShardID()
@@ -125,6 +128,7 @@ func NewTaskProcessor(
 		config:                  config,
 		metricsHandler:          metricsHandler,
 		logger:                  shardContext.GetLogger(),
+		testHooks:               testHooks,
 		replicationTaskExecutor: replicationTaskExecutor,
 		dlqWriter:               dlqWriter,
 		rateLimiter: quotas.NewMultiRateLimiter([]quotas.RateLimiter{
@@ -313,7 +317,15 @@ func (p *taskProcessorImpl) handleReplicationTask(
 	operationTagValue := p.getOperationTagValue(replicationTask)
 
 	operation := func() error {
-		err := p.replicationTaskExecutor.Execute(ctx, replicationTask, false)
+		var err error
+		// Tests use this hook to pause replication tasks before they are applied.
+		if hook, ok := testhooks.Get(p.testHooks, testhooks.HistoryReplicationTaskInterceptor, testhooks.GlobalScope); ok {
+			err = hook(replicationTask, func() error {
+				return p.replicationTaskExecutor.Execute(ctx, replicationTask, false)
+			})
+		} else {
+			err = p.replicationTaskExecutor.Execute(ctx, replicationTask, false)
+		}
 		p.emitTaskMetrics(operationTagValue, err)
 		return err
 	}

--- a/service/history/replication/task_processor_manager.go
+++ b/service/history/replication/task_processor_manager.go
@@ -17,6 +17,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/deletemanager"
 	historyi "go.temporal.io/server/service/history/interfaces"
@@ -46,6 +47,7 @@ type (
 		taskPollerManager             pollerManager
 		metricsHandler                metrics.Handler
 		logger                        log.Logger
+		testHooks                     testhooks.TestHooks
 		dlqWriter                     DLQWriter
 
 		enableFetcher     bool
@@ -66,6 +68,7 @@ func NewTaskProcessorManager(
 	eventSerializer serialization.Serializer,
 	replicationTaskFetcherFactory TaskFetcherFactory,
 	taskExecutorProvider TaskExecutorProvider,
+	testHooks testhooks.TestHooks,
 	dlqWriter DLQWriter,
 ) *taskProcessorManagerImpl {
 	historyFetcher := eventhandler.NewHistoryPaginatedFetcher(shardContext.GetNamespaceRegistry(), clientBean, eventSerializer, shardContext.GetLogger())
@@ -81,6 +84,7 @@ func NewTaskProcessorManager(
 		removeHistoryFetcher:          historyFetcher,
 		logger:                        shardContext.GetLogger(),
 		metricsHandler:                shardContext.GetMetricsHandler(),
+		testHooks:                     testHooks,
 		dlqWriter:                     dlqWriter,
 
 		enableFetcher:        !config.EnableReplicationStream(),
@@ -193,6 +197,7 @@ func (r *taskProcessorManagerImpl) handleClusterMetadataUpdate(
 					WorkflowCache:        r.workflowCache,
 				}),
 				r.eventSerializer,
+				r.testHooks,
 				r.dlqWriter,
 			)
 			replicationTaskProcessor.Start()

--- a/service/history/replication/task_processor_manager_test.go
+++ b/service/history/replication/task_processor_manager_test.go
@@ -18,6 +18,7 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/service/history/configs"
 	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/shard"
@@ -106,6 +107,7 @@ func (s *taskProcessorManagerSuite) SetupTest() {
 		func(params TaskExecutorParams) TaskExecutor {
 			return s.mockReplicationTaskExecutor
 		},
+		testhooks.TestHooks{},
 		NewExecutionManagerDLQWriter(s.mockExecutionManager),
 	)
 }

--- a/service/history/replication/task_processor_test.go
+++ b/service/history/replication/task_processor_test.go
@@ -30,6 +30,7 @@ import (
 	"go.temporal.io/server/common/quotas"
 	"go.temporal.io/server/common/resourcetest"
 	"go.temporal.io/server/common/testing/protorequire"
+	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/service/history/configs"
 	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/shard"
@@ -124,6 +125,7 @@ func (s *taskProcessorSuite) SetupTest() {
 		s.mockReplicationTaskFetcher,
 		s.mockReplicationTaskExecutor,
 		serialization.NewSerializer(),
+		testhooks.TestHooks{},
 		NewExecutionManagerDLQWriter(s.mockExecutionManager),
 	).(*taskProcessorImpl)
 }

--- a/service/worker/fx.go
+++ b/service/worker/fx.go
@@ -30,6 +30,7 @@ import (
 	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/service"
 	"go.temporal.io/server/service/worker/batcher"
 	workercommon "go.temporal.io/server/service/worker/common"
@@ -91,6 +92,7 @@ var Module = fx.Options(
 		dataMerger nsreplication.NamespaceDataMerger,
 		admitter nsreplication.NamespaceReplicationAdmitter,
 		logger log.Logger,
+		testHooks testhooks.TestHooks,
 	) nsreplication.TaskExecutor {
 		return nsreplication.NewTaskExecutor(
 			clusterMetadata.GetCurrentClusterName(),
@@ -98,6 +100,7 @@ var Module = fx.Options(
 			dataMerger,
 			admitter,
 			logger,
+			testHooks,
 		)
 	}),
 	fx.Provide(nsreplication.NewNoopDataMerger),

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -127,6 +127,8 @@ func init() {
 // This is similar to the pattern of plumbing dependencies through the TestClusterConfig, but it's much more convenient,
 // scalable and flexible. The reason we need to do this on a per-service basis is that there are separate fx apps for
 // each one.
+//
+// Deprecated: prefer dedicated TestClusterOption helpers or testhooks over injecting arbitrary Fx options.
 func WithFxOptionsForService(serviceName primitives.ServiceName, options ...fx.Option) TestClusterOption {
 	return func(params *TestClusterParams) {
 		params.ServiceOptions[serviceName] = append(params.ServiceOptions[serviceName], options...)

--- a/tests/testcore/test_cluster.go
+++ b/tests/testcore/test_cluster.go
@@ -45,6 +45,7 @@ import (
 	"go.temporal.io/server/common/rpc/encryption"
 	"go.temporal.io/server/common/telemetry"
 	"go.temporal.io/server/common/testing/freeport"
+	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/temporal"
 	"go.temporal.io/server/temporal/environment"
 	"go.temporal.io/server/tests/testutils"
@@ -340,7 +341,7 @@ func newClusterWithPersistenceTestBaseFactory(
 		MatchingConfig:                   clusterConfig.MatchingConfig,
 		WorkerConfig:                     clusterConfig.WorkerConfig,
 		MockAdminClient:                  clusterConfig.MockAdminClient,
-		NamespaceReplicationTaskExecutor: nsreplication.NewTaskExecutor(clusterConfig.ClusterMetadata.CurrentClusterName, testBase.MetadataManager, nsreplication.NewNoopDataMerger(), nsreplication.NewDefaultAdmitter(), logger),
+		NamespaceReplicationTaskExecutor: nsreplication.NewTaskExecutor(clusterConfig.ClusterMetadata.CurrentClusterName, testBase.MetadataManager, nsreplication.NewNoopDataMerger(), nsreplication.NewDefaultAdmitter(), logger, testhooks.TestHooks{}),
 		DCRedirectionPolicy:              clusterConfig.DCRedirectionPolicy,
 		DynamicConfigOverrides:           clusterConfig.DynamicConfigOverrides,
 		TLSConfigProvider:                tlsConfigProvider,
@@ -600,6 +601,10 @@ func (tc *TestCluster) ExecutionManager() persistence.ExecutionManager {
 // TODO (alex): expose only needed objects from TemporalImpl.
 func (tc *TestCluster) Host() *TemporalImpl {
 	return tc.host
+}
+
+func (tc *TestCluster) InjectHook(t *testing.T, hook testhooks.Hook, scope any) func() {
+	return tc.host.injectHook(t, hook, scope)
 }
 
 func (tc *TestCluster) WorkerGRPCAddress() string {

--- a/tests/xdc/history_replication_signals_and_updates_test.go
+++ b/tests/xdc/history_replication_signals_and_updates_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -25,15 +24,13 @@ import (
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
-	"go.temporal.io/server/common/namespace/nsreplication"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/persistence/serialization"
-	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/testing/protoutils"
+	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/common/testing/testvars"
-	"go.temporal.io/server/service/history/replication"
 	"go.temporal.io/server/tests/testcore"
-	"go.uber.org/fx"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
@@ -47,50 +44,31 @@ type (
 	// that push their tasks into test-specific (i.e. workflow-specific) buffers.
 	hrsuTestSuite struct {
 		xdcBaseSuite
-		namespaceTaskExecutor nsreplication.TaskExecutor
-		// The injection is performed once, at the level of the test suite, but we need the modified executors to be
-		// able to route tasks to test-specific (i.e. workflow-specific) buffers. The following two maps serve that
-		// purpose (each test registers itself in these maps as it starts). Workflow ID and namespace name are both
-		// unique per test (due to the use of TestVars).
-		testMapLock          sync.Mutex
-		testsByWorkflowId    map[string]*hrsuTest
-		testsByNamespaceName map[string]*hrsuTest
 	}
 	// Each test starts its own workflow, in its own namespace.
 	hrsuTest struct {
-		tv *testvars.TestVars
-		// Per-test buffer of namespace replication tasks.
-		// TODO (dan): buffer namespace replication tasks from each cluster separately, as we do for history replication
-		// tasks.
-		namespaceReplicationTasks chan *replicationspb.NamespaceTaskAttributes
-		cluster1                  hrsuTestCluster
-		cluster2                  hrsuTestCluster
-		s                         *hrsuTestSuite
+		tv       *testvars.TestVars
+		cluster1 hrsuTestCluster
+		cluster2 hrsuTestCluster
+		s        *hrsuTestSuite
 	}
 	hrsuTestCluster struct {
 		testCluster *testcore.TestCluster
 		client      sdkclient.Client
-		// Per-test, per-cluster buffer of history event replication tasks
+		// Per-test, per-cluster buffers of replication tasks.
+		namespaceReplicationTasks      chan *hrsuNamespaceReplicationTask
 		inboundHistoryReplicationTasks chan *hrsuTestExecutableTask
 		t                              *hrsuTest
 	}
-	// Used to inject a modified namespace replication task executor.
-	hrsuTestNamespaceReplicationTaskExecutor struct {
-		replicationTaskExecutor nsreplication.TaskExecutor
-		s                       *hrsuTestSuite
-	}
-	// Used to inject a modified history event replication task executor.
-	hrsuTestExecutableTaskConverter struct {
-		converter replication.ExecutableTaskConverter
-		s         *hrsuTestSuite
+	hrsuNamespaceReplicationTask struct {
+		task    *replicationspb.NamespaceTaskAttributes
+		execute func() error
 	}
 	// Used to inject a modified history event replication task executor.
 	hrsuTestExecutableTask struct {
-		replication.TrackableExecutableTask
 		replicationTask *replicationspb.ReplicationTask
-		sourceCluster   string
+		execute         func() error
 		result          chan error
-		s               *hrsuTestSuite
 	}
 )
 
@@ -110,31 +88,7 @@ func (s *hrsuTestSuite) SetupSuite() {
 		dynamicconfig.HistoryLongPollExpirationInterval.Key(): 100 * time.Millisecond,
 	}
 	s.logger = log.NewTestLogger()
-	s.setupSuite(
-		testcore.WithFxOptionsForService(primitives.WorkerService,
-			fx.Decorate(
-				func(executor nsreplication.TaskExecutor) nsreplication.TaskExecutor {
-					s.namespaceTaskExecutor = executor
-					return &hrsuTestNamespaceReplicationTaskExecutor{
-						replicationTaskExecutor: executor,
-						s:                       s,
-					}
-				},
-			),
-		),
-		testcore.WithFxOptionsForService(primitives.HistoryService,
-			fx.Decorate(
-				func(converter replication.ExecutableTaskConverter) replication.ExecutableTaskConverter {
-					return &hrsuTestExecutableTaskConverter{
-						converter: converter,
-						s:         s,
-					}
-				},
-			),
-		),
-	)
-	s.testsByWorkflowId = make(map[string]*hrsuTest)
-	s.testsByNamespaceName = make(map[string]*hrsuTest)
+	s.setupSuite()
 }
 
 func (s *hrsuTestSuite) SetupTest() {
@@ -149,17 +103,7 @@ func (s *hrsuTestSuite) startHrsuTest() (*hrsuTest, context.Context, context.Can
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	tv := testvars.New(s.T())
 	ns := tv.NamespaceName().String()
-	t := hrsuTest{
-		tv:                        tv,
-		namespaceReplicationTasks: make(chan *replicationspb.NamespaceTaskAttributes, taskBufferCapacity),
-		s:                         s,
-	}
-	// Register test with the suite, so that globally modified task executors can push tasks to test-specific buffers.
-	s.testMapLock.Lock()
-	s.testsByWorkflowId[tv.WorkflowID()] = &t
-	s.testsByNamespaceName[ns] = &t
-	s.testMapLock.Unlock()
-
+	t := hrsuTest{tv: tv, s: s}
 	t.cluster1 = t.newHrsuTestCluster(ns, s.clusters[0])
 	t.cluster2 = t.newHrsuTestCluster(ns, s.clusters[1])
 	t.registerMultiRegionNamespace(ctx)
@@ -173,12 +117,47 @@ func (t *hrsuTest) newHrsuTestCluster(ns string, cluster *testcore.TestCluster) 
 		Logger:    log.NewSdkLogger(t.s.logger),
 	})
 	t.s.NoError(err)
-	return hrsuTestCluster{
+
+	c := hrsuTestCluster{
 		testCluster:                    cluster,
 		client:                         sdkClient,
+		namespaceReplicationTasks:      make(chan *hrsuNamespaceReplicationTask, taskBufferCapacity),
 		inboundHistoryReplicationTasks: make(chan *hrsuTestExecutableTask, taskBufferCapacity),
 		t:                              t,
 	}
+
+	// Buffer namespace replication tasks so tests can inspect and release them in a controlled order.
+	cluster.InjectHook(
+		t.s.T(),
+		testhooks.NewHook(testhooks.NamespaceReplicationTaskInterceptor, func(
+			_ context.Context,
+			task *replicationspb.NamespaceTaskAttributes,
+			execute func() error,
+		) error {
+			c.namespaceReplicationTasks <- &hrsuNamespaceReplicationTask{
+				task:    task,
+				execute: execute,
+			}
+			return nil
+		}),
+		namespace.Name(ns),
+	)
+
+	// Buffer history replication tasks so tests can inspect and release them in a controlled order.
+	cluster.InjectHook(
+		t.s.T(),
+		testhooks.NewHook(testhooks.HistoryReplicationTaskInterceptor, func(task *replicationspb.ReplicationTask, execute func() error) error {
+			historyTask := &hrsuTestExecutableTask{
+				replicationTask: task,
+				execute:         execute,
+				result:          make(chan error),
+			}
+			c.inboundHistoryReplicationTasks <- historyTask
+			return <-historyTask.result
+		}),
+		testhooks.GlobalScope,
+	)
+	return c
 }
 
 // TestAcceptedUpdateCanBeCompletedAfterFailoverAndFailback tests that an update can be accepted in one cluster, and completed in a
@@ -617,7 +596,7 @@ func (t *hrsuTest) failover1To2(ctx context.Context) {
 
 	time.Sleep(testcore.NamespaceCacheRefreshInterval) //nolint:forbidigo
 
-	t.executeNamespaceReplicationTasksUntil(ctx, enumsspb.NAMESPACE_OPERATION_UPDATE)
+	t.cluster2.executeNamespaceReplicationTasksUntil(enumsspb.NAMESPACE_OPERATION_UPDATE)
 	// Wait for active cluster to be changed in namespace registry entry.
 	// TODO (dan) It would be nice to find a better approach.
 	time.Sleep(testcore.NamespaceCacheRefreshInterval) //nolint:forbidigo
@@ -631,7 +610,7 @@ func (t *hrsuTest) failover2To1(ctx context.Context) {
 
 	time.Sleep(testcore.NamespaceCacheRefreshInterval) //nolint:forbidigo
 
-	t.executeNamespaceReplicationTasksUntil(ctx, enumsspb.NAMESPACE_OPERATION_UPDATE)
+	t.cluster2.executeNamespaceReplicationTasksUntil(enumsspb.NAMESPACE_OPERATION_UPDATE)
 	// Wait for active cluster to be changed in namespace registry entry.
 	// TODO (dan) It would be nice to find a better approach.
 	time.Sleep(testcore.NamespaceCacheRefreshInterval) //nolint:forbidigo
@@ -646,7 +625,7 @@ func (t *hrsuTest) enterSplitBrainState(ctx context.Context) {
 	t.s.Equal([]string{t.s.clusters[0].ClusterName(), t.s.clusters[1].ClusterName()}, t.getActiveClusters(ctx))
 
 	// TODO (dan) Why do the tests still pass with this? Does this not remove the split-brain?
-	// s.executeNamespaceReplicationTasksUntil(ctx, enumsspb.NAMESPACE_OPERATION_UPDATE, 2)
+	// t.cluster1.executeNamespaceReplicationTasksUntil(enumsspb.NAMESPACE_OPERATION_UPDATE)
 
 	// Wait for active cluster to be changed in namespace registry entry.
 	// TODO (dan) It would be nice to find a better approach.
@@ -655,12 +634,12 @@ func (t *hrsuTest) enterSplitBrainState(ctx context.Context) {
 
 // executeNamespaceReplicationTasksUntil executes buffered namespace event replication tasks until the specified event
 // type is encountered with the specified failover version.
-func (t *hrsuTest) executeNamespaceReplicationTasksUntil(ctx context.Context, operation enumsspb.NamespaceOperation) {
+func (c *hrsuTestCluster) executeNamespaceReplicationTasksUntil(operation enumsspb.NamespaceOperation) {
 	for {
-		task := <-t.namespaceReplicationTasks
-		err := t.s.namespaceTaskExecutor.Execute(ctx, task)
-		t.s.NoError(err)
-		if task.NamespaceOperation == operation {
+		bufferedTask := <-c.namespaceReplicationTasks
+		err := bufferedTask.execute()
+		c.t.s.NoError(err)
+		if bufferedTask.task.NamespaceOperation == operation {
 			return
 		}
 	}
@@ -683,77 +662,14 @@ func (c *hrsuTestCluster) executeHistoryReplicationTasksUntil(
 }
 
 func (s *hrsuTestSuite) executeHistoryReplicationTask(task *hrsuTestExecutableTask) []*historypb.HistoryEvent {
-	trackableTask := (*task).TrackableExecutableTask
-	err := trackableTask.Execute()
+	err := task.execute()
 	s.NoError(err)
 	task.result <- err
-	attrs := (*task).replicationTask.GetHistoryTaskAttributes()
+	attrs := task.replicationTask.GetHistoryTaskAttributes()
 	s.NotNil(attrs)
 	events, err := serialization.DefaultDecoder.DeserializeEvents(attrs.Events)
 	s.NoError(err)
 	return events
-}
-
-func (e *hrsuTestNamespaceReplicationTaskExecutor) Execute(_ context.Context, task *replicationspb.NamespaceTaskAttributes) error {
-	// TODO (dan) Use one channel per cluster, as we do for history replication tasks in this test suite. This is
-	// currently blocked by the fact that namespace tasks don't expose the current cluster name.
-	ns := task.Info.Name
-	e.s.testMapLock.Lock()
-	test := e.s.testsByNamespaceName[ns]
-	e.s.testMapLock.Unlock()
-	if test == nil {
-		// This can happen after a test has completed
-		return fmt.Errorf("failed to retrieve test for namespace %s", ns)
-	}
-	test.namespaceReplicationTasks <- task
-	// Report success, although we have merely buffered the task and will execute it later.
-	return nil
-}
-
-// Convert the replication tasks using the testcore converter, and wrap them in our own executable tasks.
-func (t *hrsuTestExecutableTaskConverter) Convert(
-	taskClusterName string,
-	clientShardKey replication.ClusterShardKey,
-	serverShardKey replication.ClusterShardKey,
-	replicationTasks ...*replicationspb.ReplicationTask,
-) []replication.TrackableExecutableTask {
-	convertedTasks := t.converter.Convert(taskClusterName, clientShardKey, serverShardKey, replicationTasks...)
-	testExecutableTasks := make([]replication.TrackableExecutableTask, len(convertedTasks))
-	for i, task := range convertedTasks {
-		testExecutableTasks[i] = &hrsuTestExecutableTask{
-			sourceCluster:           taskClusterName,
-			s:                       t.s,
-			TrackableExecutableTask: task,
-			replicationTask:         replicationTasks[i],
-			result:                  make(chan error),
-		}
-	}
-	return testExecutableTasks
-}
-
-// Execute pushes the task to a buffer and waits for it to be executed.
-func (task *hrsuTestExecutableTask) Execute() error {
-	task.s.testMapLock.Lock()
-	test := task.s.testsByWorkflowId[task.workflowId()]
-	task.s.testMapLock.Unlock()
-	if test == nil {
-		return fmt.Errorf("failed to retrieve test for workflow %s", task.workflowId())
-	}
-	switch task.sourceCluster {
-	case task.s.clusters[0].ClusterName():
-		test.cluster2.inboundHistoryReplicationTasks <- task
-	case task.s.clusters[1].ClusterName():
-		test.cluster1.inboundHistoryReplicationTasks <- task
-	default:
-		task.s.FailNow(fmt.Sprintf("invalid cluster name: %s", task.sourceCluster))
-	}
-	return <-task.result
-}
-
-func (task *hrsuTestExecutableTask) workflowId() string {
-	attrs := (*task).replicationTask.GetHistoryTaskAttributes()
-	task.s.NotNil(attrs)
-	return attrs.WorkflowId
 }
 
 // Update test utilities
@@ -978,9 +894,9 @@ func (t *hrsuTest) registerMultiRegionNamespace(ctx context.Context) {
 		WorkflowExecutionRetentionPeriod: durationpb.New(time.Hour * 24), // Required parameter
 	})
 	t.s.NoError(err)
-	// Namespace event replication tasks are being captured; we need to execute the pending ones now to propagate the
-	// new namespace to cluster1.
-	t.executeNamespaceReplicationTasksUntil(ctx, enumsspb.NAMESPACE_OPERATION_CREATE)
+
+	// Namespace event replication tasks are being captured; execute the pending ones to propagate the new namespace to cluster2.
+	t.cluster2.executeNamespaceReplicationTasksUntil(enumsspb.NAMESPACE_OPERATION_CREATE)
 	t.s.Equal([]string{t.s.clusters[0].ClusterName(), t.s.clusters[0].ClusterName()}, t.getActiveClusters(ctx))
 }
 


### PR DESCRIPTION
## What changed

Migrated `tests/xdc/history_replication_signals_and_updates_test.go` to stop relying on `WithFxOptionsForService` to replace fx modules and instead use test hooks.

## Why

We want to eliminate `WithFxOptionsForService` as it is blocking us from migrating away from the `onebox.go` approach (which duplicates the fx setup) since we don't want to expose an equivalent method in `temporal/fx.go`.