### PR TITLE
Range-complete acked tasks on queue Stop

### DIFF
--- a/service/history/outbound_queue_factory_test.go
+++ b/service/history/outbound_queue_factory_test.go
@@ -62,6 +62,7 @@ func TestOutboundQueueFactory_ChasmTaskGroupWiring(t *testing.T) {
 	mockShard.Resource.ClusterMetadata.EXPECT().GetClusterID().Return(int64(1)).AnyTimes()
 	mockShard.Resource.NamespaceCache.EXPECT().GetNamespaceByID(gomock.Any()).Return(tests.GlobalNamespaceEntry, nil).AnyTimes()
 	mockShard.Resource.NamespaceCache.EXPECT().GetNamespaceName(gomock.Any()).Return(tests.Namespace, nil).AnyTimes()
+	mockShard.Resource.ExecutionMgr.EXPECT().RangeCompleteHistoryTasks(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	taskTypeID := chasm.GenerateTypeID("TestLib.MyTask")
 	chasmTask := &tasks.ChasmTask{

--- a/service/history/queues/queue_base.go
+++ b/service/history/queues/queue_base.go
@@ -246,6 +246,11 @@ func (p *queueBase) Stop() {
 	p.readerGroup.Stop()
 	p.rescheduler.Stop()
 	p.checkpointTimer.Stop()
+
+	// Final flush so acked tasks aren't re-dispatched on restart.
+	if err := p.doCheckpoint(true); err != nil {
+		p.logger.Warn("Final checkpoint on Stop failed", tag.Error(err))
+	}
 }
 
 func (p *queueBase) Category() tasks.Category {
@@ -290,6 +295,13 @@ func (p *queueBase) processNewRange() {
 }
 
 func (p *queueBase) checkpoint() {
+	err := p.doCheckpoint(false)
+	p.resetCheckpointTimer(err)
+}
+
+// doCheckpoint runs a checkpoint pass without resetting the timer. When
+// onShutdown is true, skips the UpdateShard call (rejected once Stopped).
+func (p *queueBase) doCheckpoint(onShutdown bool) error {
 	var tasksCompleted int
 	p.readerGroup.ForEach(func(_ int64, r Reader) {
 		tasksCompleted += r.ShrinkSlices()
@@ -340,17 +352,18 @@ func (p *queueBase) checkpoint() {
 		(p.updateShardRangeID() && newExclusiveDeletionHighWatermark.CompareTo(tasks.MinimumKey) > 0) {
 		// When shard rangeID is updated, perform range completion again in case the underlying persistence implementation
 		// serves traffic based on the persisted shardInfo.
-		err := p.rangeCompleteTasks(p.exclusiveDeletionHighWatermark, newExclusiveDeletionHighWatermark)
-		if err != nil {
-			p.resetCheckpointTimer(err)
-			return
+		if err := p.rangeCompleteTasks(p.exclusiveDeletionHighWatermark, newExclusiveDeletionHighWatermark); err != nil {
+			return err
 		}
 
 		p.exclusiveDeletionHighWatermark = newExclusiveDeletionHighWatermark
 	}
 
-	err := p.updateQueueState(tasksCompleted, readerScopes)
-	p.resetCheckpointTimer(err)
+	if onShutdown {
+		// Skip UpdateShard.
+		return nil
+	}
+	return p.updateQueueState(tasksCompleted, readerScopes)
 }
 
 func (p *queueBase) updateShardRangeID() bool {

--- a/service/history/queues/queue_base_test.go
+++ b/service/history/queues/queue_base_test.go
@@ -229,6 +229,8 @@ func (s *queueBaseSuite) TestStartStop() {
 	<-doneCh
 	<-base.checkpointTimer.C
 
+	mockShard.Resource.ExecutionMgr.EXPECT().RangeCompleteHistoryTasks(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
 	s.mockRescheduler.EXPECT().Stop().Times(1)
 	base.Stop()
 	s.False(base.checkpointTimer.Stop())


### PR DESCRIPTION
## What changed?
`queueBase.Stop` now runs a best-effort `doCheckpoint(true)` that range-deletes already-acked task rows via `RangeCompleteHistoryTasks`. The shard-state write (`UpdateShard`) is intentionally skipped — by the time `engine.Stop` runs from `FinishStop`, the shard is already Stopped and `updateShardInfo` would reject it anyway.

## Why?
Without this, the next shard owner reloads the task rows acked between the last periodic checkpoint and shutdown, and re-dispatches them. Most visible on the transfer queue (high throughput, exact-key deletion). Deleting the rows is enough — the next owner's pagination returns empty for the stale reader-scope range, the slice compacts on the first post-startup checkpoint, and no tasks are reprocessed.

## How did you test it?
- [x] built
- [x] covered by existing tests