### PR TITLE
Clamp ClockedRateLimiter burst to a minimum of 1

### DIFF
--- a/common/quotas/clocked_rate_limiter.go
+++ b/common/quotas/clocked_rate_limiter.go
@@ -146,6 +146,9 @@ func (l ClockedRateLimiter) SetLimitAt(t time.Time, newLimit rate.Limit) {
 }
 
 func (l ClockedRateLimiter) SetBurstAt(t time.Time, newBurst int) {
+	if newBurst < 1 {
+		newBurst = 1
+	}
 	l.rateLimiter.SetBurstAt(t, newBurst)
 }
 

--- a/common/quotas/clocked_rate_limiter.go
+++ b/common/quotas/clocked_rate_limiter.go
@@ -146,10 +146,7 @@ func (l ClockedRateLimiter) SetLimitAt(t time.Time, newLimit rate.Limit) {
 }
 
 func (l ClockedRateLimiter) SetBurstAt(t time.Time, newBurst int) {
-	// Clamp burst to at least 1 whenever the limiter has a positive rate.
-	// A zero burst with a positive rate would permanently stall the limiter.
-	// A zero burst with a zero rate is preserved to keep the "fully paused"
-	// semantic used by callers that disable rate limiting via rate=0,burst=0.
+	// Clamp burst to >=1 when rate is positive; burst=0 with rate=0 is allowed for pause.
 	if newBurst < 1 && l.rateLimiter.Limit() > 0 {
 		newBurst = 1
 	}

--- a/common/quotas/clocked_rate_limiter.go
+++ b/common/quotas/clocked_rate_limiter.go
@@ -146,7 +146,11 @@ func (l ClockedRateLimiter) SetLimitAt(t time.Time, newLimit rate.Limit) {
 }
 
 func (l ClockedRateLimiter) SetBurstAt(t time.Time, newBurst int) {
-	if newBurst < 1 {
+	// Clamp burst to at least 1 whenever the limiter has a positive rate.
+	// A zero burst with a positive rate would permanently stall the limiter.
+	// A zero burst with a zero rate is preserved to keep the "fully paused"
+	// semantic used by callers that disable rate limiting via rate=0,burst=0.
+	if newBurst < 1 && l.rateLimiter.Limit() > 0 {
 		newBurst = 1
 	}
 	l.rateLimiter.SetBurstAt(t, newBurst)


### PR DESCRIPTION
## What changed?
`ClockedRateLimiter.SetBurstAt` now clamps `newBurst` to a minimum of 1 when the limiter's rate is positive. `rate=0, burst=0` is still accepted so callers can fully pause the limiter.

## Why?
A zero or negative burst on an actively rate-limiting limiter stalls it — `Allow`/`Wait` can never succeed and waiters block indefinitely. The conditional clamp prevents that while preserving the existing pause semantic (rate=0, burst=0) used by the matching task queue rate limiter.

## How did you test it?
- [x] built
- [x] covered by existing tests