### PR TITLE
expose SDK name and version on DescribeActivityExecution

### DIFF
--- a/chasm/context.go
+++ b/chasm/context.go
@@ -41,6 +41,10 @@ type Context interface {
 	Value(key any) any
 	// RequestHeader returns the first value of the named gRPC metadata header from the inbound request context, or ""
 	// if absent.
+	//
+	// Only available when this Context was constructed from an inbound gRPC request, i.e. inside the start/update/read
+	// callbacks invoked by the chasm engine. In other contexts, such as pure tasks executed at the end of a transaction
+	// or background task handlers, the underlying ctx has no gRPC metadata and this method always returns "".
 	RequestHeader(key string) string
 
 	// Intent() OperationIntent

--- a/chasm/context.go
+++ b/chasm/context.go
@@ -9,6 +9,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
+	"google.golang.org/grpc/metadata"
 )
 
 type Context interface {
@@ -38,6 +39,9 @@ type Context interface {
 	// Registered key-value pairs will automatically be added to the Context whenever framework accesses the component.
 	// Alternatively, use ContextWithValue() to manually set values on Context which will take precedence over registered ones.
 	Value(key any) any
+	// RequestHeader returns the first value of the named gRPC metadata header from the inbound request context, or ""
+	// if absent.
+	RequestHeader(key string) string
 
 	// Intent() OperationIntent
 	// ComponentOptions(Component) []ComponentOption
@@ -190,6 +194,13 @@ func (c *immutableCtx) NamespaceEntry() *namespace.Namespace {
 
 func (c *immutableCtx) goContext() context.Context {
 	return c.ctx
+}
+
+func (c *immutableCtx) RequestHeader(key string) string {
+	if values := metadata.ValueFromIncomingContext(c.ctx, key); len(values) > 0 {
+		return values[0]
+	}
+	return ""
 }
 
 func (c *immutableCtx) EndpointByName(name string) (*persistencespb.NexusEndpointEntry, error) {

--- a/chasm/context_mock.go
+++ b/chasm/context_mock.go
@@ -13,6 +13,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
+	"google.golang.org/grpc/metadata"
 )
 
 var _ Context = (*MockContext)(nil)
@@ -60,6 +61,13 @@ func (c *MockContext) goContext() context.Context {
 		c.GoCtx = context.Background()
 	}
 	return c.GoCtx
+}
+
+func (c *MockContext) RequestHeader(key string) string {
+	if values := metadata.ValueFromIncomingContext(c.goContext(), key); len(values) > 0 {
+		return values[0]
+	}
+	return ""
 }
 
 func (c *MockContext) EndpointByName(name string) (*persistencespb.NexusEndpointEntry, error) {

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -830,6 +830,8 @@ func (a *Activity) buildActivityExecutionInfo(ctx chasm.Context) *apiactivitypb.
 		LastHeartbeatTime:       heartbeat.GetRecordedTime(),
 		LastStartedTime:         attempt.GetStartedTime(),
 		LastWorkerIdentity:      attempt.GetLastWorkerIdentity(),
+		SdkName:                 attempt.GetSdkName(),
+		SdkVersion:              attempt.GetSdkVersion(),
 		NextAttemptScheduleTime: attemptScheduleTimeForRetry(attempt),
 		Priority:                a.GetPriority(),
 		RetryPolicy:             a.GetRetryPolicy(),

--- a/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
@@ -456,8 +456,17 @@ type ActivityAttemptState struct {
 	// The request ID that came from matching's RecordActivityTaskStarted API call. Used to make this API idempotent in
 	// case of implicit retries.
 	StartRequestId string `protobuf:"bytes,9,opt,name=start_request_id,json=startRequestId,proto3" json:"start_request_id,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// The name of the SDK of the worker that most recently picked up an attempt of this activity
+	// (from the gRPC `client-name` header on PollActivityTaskQueue). Overwritten on each new attempt.
+	// Empty if no worker has ever picked up this activity, or if the most recent worker did not send
+	// a client-name header.
+	SdkName string `protobuf:"bytes,10,opt,name=sdk_name,json=sdkName,proto3" json:"sdk_name,omitempty"`
+	// The version of the SDK of the worker that most recently picked up an attempt of this activity
+	// (from the gRPC `client-version` header on PollActivityTaskQueue). Same overwrite semantics as
+	// sdk_name.
+	SdkVersion    string `protobuf:"bytes,11,opt,name=sdk_version,json=sdkVersion,proto3" json:"sdk_version,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ActivityAttemptState) Reset() {
@@ -549,6 +558,20 @@ func (x *ActivityAttemptState) GetLastDeploymentVersion() *v12.WorkerDeploymentV
 func (x *ActivityAttemptState) GetStartRequestId() string {
 	if x != nil {
 		return x.StartRequestId
+	}
+	return ""
+}
+
+func (x *ActivityAttemptState) GetSdkName() string {
+	if x != nil {
+		return x.SdkName
+	}
+	return ""
+}
+
+func (x *ActivityAttemptState) GetSdkVersion() string {
+	if x != nil {
+		return x.SdkVersion
 	}
 	return ""
 }
@@ -934,7 +957,7 @@ const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawD
 	"\x06reason\x18\x04 \x01(\tR\x06reason\"7\n" +
 	"\x16ActivityTerminateState\x12\x1d\n" +
 	"\n" +
-	"request_id\x18\x01 \x01(\tR\trequestId\"\xe8\x05\n" +
+	"request_id\x18\x01 \x01(\tR\trequestId\"\xa4\x06\n" +
 	"\x14ActivityAttemptState\x12\x14\n" +
 	"\x05count\x18\x01 \x01(\x05R\x05count\x12O\n" +
 	"\x16current_retry_interval\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\x14currentRetryInterval\x12=\n" +
@@ -944,7 +967,11 @@ const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawD
 	"\x05stamp\x18\x06 \x01(\x05R\x05stamp\x120\n" +
 	"\x14last_worker_identity\x18\a \x01(\tR\x12lastWorkerIdentity\x12k\n" +
 	"\x17last_deployment_version\x18\b \x01(\v23.temporal.api.deployment.v1.WorkerDeploymentVersionR\x15lastDeploymentVersion\x12(\n" +
-	"\x10start_request_id\x18\t \x01(\tR\x0estartRequestId\x1a\x80\x01\n" +
+	"\x10start_request_id\x18\t \x01(\tR\x0estartRequestId\x12\x19\n" +
+	"\bsdk_name\x18\n" +
+	" \x01(\tR\asdkName\x12\x1f\n" +
+	"\vsdk_version\x18\v \x01(\tR\n" +
+	"sdkVersion\x1a\x80\x01\n" +
 	"\x12LastFailureDetails\x12.\n" +
 	"\x04time\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x04time\x12:\n" +
 	"\afailure\x18\x02 \x01(\v2 .temporal.api.failure.v1.FailureR\afailure\"\xc9\x01\n" +

--- a/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
@@ -456,14 +456,12 @@ type ActivityAttemptState struct {
 	// The request ID that came from matching's RecordActivityTaskStarted API call. Used to make this API idempotent in
 	// case of implicit retries.
 	StartRequestId string `protobuf:"bytes,9,opt,name=start_request_id,json=startRequestId,proto3" json:"start_request_id,omitempty"`
-	// The name of the SDK of the worker that most recently picked up an attempt of this activity
-	// (from the gRPC `client-name` header on PollActivityTaskQueue). Overwritten on each new attempt.
-	// Empty if no worker has ever picked up this activity, or if the most recent worker did not send
-	// a client-name header.
+	// The name of the SDK of the worker that most recently picked up an attempt of this activity (from the gRPC
+	// `client-name` header on PollActivityTaskQueue). Overwritten on each new attempt. Empty if no worker has ever
+	// picked up this activity, or if the most recent worker did not send a client-name header.
 	SdkName string `protobuf:"bytes,10,opt,name=sdk_name,json=sdkName,proto3" json:"sdk_name,omitempty"`
-	// The version of the SDK of the worker that most recently picked up an attempt of this activity
-	// (from the gRPC `client-version` header on PollActivityTaskQueue). Same overwrite semantics as
-	// sdk_name.
+	// The version of the SDK of the worker that most recently picked up an attempt of this activity (from the gRPC
+	// `client-version` header on PollActivityTaskQueue). Same overwrite semantics as sdk_name.
 	SdkVersion    string `protobuf:"bytes,11,opt,name=sdk_version,json=sdkVersion,proto3" json:"sdk_version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/chasm/lib/activity/proto/v1/activity_state.proto
+++ b/chasm/lib/activity/proto/v1/activity_state.proto
@@ -155,6 +155,15 @@ message ActivityAttemptState {
   // The request ID that came from matching's RecordActivityTaskStarted API call. Used to make this API idempotent in
   // case of implicit retries.
   string start_request_id = 9;
+
+  // The name of the SDK of the worker that most recently picked up an attempt of this activity (from the gRPC
+  // `client-name` header on PollActivityTaskQueue). Overwritten on each new attempt. Empty if no worker has ever
+  // picked up this activity, or if the most recent worker did not send a client-name header.
+  string sdk_name = 10;
+
+  // The version of the SDK of the worker that most recently picked up an attempt of this activity (from the gRPC
+  // `client-version` header on PollActivityTaskQueue). Same overwrite semantics as sdk_name.
+  string sdk_version = 11;
 }
 
 message ActivityHeartbeatState {

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -12,6 +12,7 @@ import (
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/activity/gen/activitypb/v1"
+	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/metrics"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -146,6 +147,8 @@ var TransitionStarted = chasm.NewTransition(
 		attempt.StartedTime = timestamppb.New(ctx.Now(a))
 		attempt.StartRequestId = request.GetRequestId()
 		attempt.LastWorkerIdentity = request.GetPollRequest().GetIdentity()
+		attempt.SdkName = ctx.RequestHeader(headers.ClientNameHeaderName)
+		attempt.SdkVersion = ctx.RequestHeader(headers.ClientVersionHeaderName)
 		if versionDirective := request.GetVersionDirective().GetDeploymentVersion(); versionDirective != nil {
 			attempt.LastDeploymentVersion = &deploymentpb.WorkerDeploymentVersion{
 				BuildId:        versionDirective.GetBuildId(),

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -1,6 +1,7 @@
 package activity
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -10,9 +11,11 @@ import (
 	failurepb "go.temporal.io/api/failure/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/activity/gen/activitypb/v1"
+	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/testing/protorequire"
@@ -281,6 +284,7 @@ func TestTransitionRescheduled(t *testing.T) {
 func TestTransitionStarted(t *testing.T) {
 	ctx := &chasm.MockMutableContext{}
 	ctx.HandleNow = func(chasm.Component) time.Time { return defaultTime }
+	ctx.MockContext.GoCtx = headers.SetVersionsForTests(context.Background(), temporal.SDKVersion, headers.ClientNameGoSDK, "", "")
 	attemptState := &activitypb.ActivityAttemptState{
 		Count:       1,
 		StartedTime: timestamppb.New(defaultTime),
@@ -309,6 +313,8 @@ func TestTransitionStarted(t *testing.T) {
 	require.EqualValues(t, 1, attemptState.Count)
 	require.Equal(t, defaultTime, attemptState.StartedTime.AsTime())
 	require.Equal(t, "test-worker", attemptState.LastWorkerIdentity)
+	require.Equal(t, headers.ClientNameGoSDK, attemptState.SdkName)
+	require.Equal(t, temporal.SDKVersion, attemptState.SdkVersion)
 
 	// Verify added tasks
 	require.Len(t, ctx.Tasks, 1)

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -284,7 +284,7 @@ func TestTransitionRescheduled(t *testing.T) {
 func TestTransitionStarted(t *testing.T) {
 	ctx := &chasm.MockMutableContext{}
 	ctx.HandleNow = func(chasm.Component) time.Time { return defaultTime }
-	ctx.MockContext.GoCtx = headers.SetVersionsForTests(context.Background(), temporal.SDKVersion, headers.ClientNameGoSDK, "", "")
+	ctx.GoCtx = headers.SetVersionsForTests(context.Background(), temporal.SDKVersion, headers.ClientNameGoSDK, "", "")
 	attemptState := &activitypb.ActivityAttemptState{
 		Count:       1,
 		StartedTime: timestamppb.New(defaultTime),

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
-	go.temporal.io/api v1.62.13-0.20260519214255-11907b499103
+	go.temporal.io/api v1.62.13-0.20260522153111-260c04482807
 	go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2
 	go.temporal.io/sdk v1.41.1
 	go.uber.org/fx v1.24.0
@@ -100,7 +100,6 @@ require (
 	github.com/go-openapi/swag/typeutils v0.26.0 // indirect
 	github.com/go-openapi/swag/yamlutils v0.26.0 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
-	github.com/nexus-rpc/nexus-proto-annotations v0.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.56.0 // indirect
 )
 
@@ -233,7 +232,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
-
-// TODO(saa-expose-sdk-meta): remove once go.temporal.io/api adds sdk_name/sdk_version to
-// ActivityExecutionInfo. Local checkout has the field added.
-replace go.temporal.io/api => /Users/fredtzeng/GolandProjects/api-go

--- a/go.mod
+++ b/go.mod
@@ -100,6 +100,7 @@ require (
 	github.com/go-openapi/swag/typeutils v0.26.0 // indirect
 	github.com/go-openapi/swag/yamlutils v0.26.0 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
+	github.com/nexus-rpc/nexus-proto-annotations v0.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.56.0 // indirect
 )
 
@@ -232,3 +233,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+// TODO(saa-expose-sdk-meta): remove once go.temporal.io/api adds sdk_name/sdk_version to
+// ActivityExecutionInfo. Local checkout has the field added.
+replace go.temporal.io/api => /Users/fredtzeng/GolandProjects/api-go

--- a/go.sum
+++ b/go.sum
@@ -471,8 +471,8 @@ go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0 h1:R
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0/go.mod h1:I89cynRj8y+383o7tEQVg2SVA6SRgDVIouWPUVXjx0U=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0 h1:CQvJSldHRUN6Z8jsUeYv8J0lXRvygALXIzsmAeCcZE0=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0/go.mod h1:xSQ+mEfJe/GjK1LXEyVOoSI1N9JV9ZI923X5kup43W4=
-go.temporal.io/api v1.62.13-0.20260519214255-11907b499103 h1:mPaS2+VdLF+TEcQ7nbAqjFIJPPmLzS+Tr0qDmrzvlG0=
-go.temporal.io/api v1.62.13-0.20260519214255-11907b499103/go.mod h1:0k75tRljEuELWGeXjEZZO7zYqBln4+1FrG6+IMOMy7Q=
+go.temporal.io/api v1.62.13-0.20260522153111-260c04482807 h1:/w/PvtpSFE7WcBOxHgC1MpZ8SC8GVMjsGK+pstKnYFA=
+go.temporal.io/api v1.62.13-0.20260522153111-260c04482807/go.mod h1:0k75tRljEuELWGeXjEZZO7zYqBln4+1FrG6+IMOMy7Q=
 go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2 h1:1hKeH3GyR6YD6LKMHGCZ76t6h1Sgha0hXVQBxWi3dlQ=
 go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2/go.mod h1:T8dnzVPeO+gaUTj9eDgm/lT2lZH4+JXNvrGaQGyVi50=
 go.temporal.io/sdk v1.41.1 h1:yOpvsHyDD1lNuwlGBv/SUodCPhjv9nDeC9lLHW/fJUA=

--- a/tests/standalone_activity_test.go
+++ b/tests/standalone_activity_test.go
@@ -3501,6 +3501,15 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution() {
 			require.NoError(t, err)
 			require.EqualValues(t, 1, pollResp1.Attempt)
 
+			// Sanity-check that attempt 1's Go SDK identity is set before the retry overwrites it.
+			describeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
+				ActivityId: activityID,
+			})
+			require.NoError(t, err)
+			require.Equal(t, headers.ClientNameGoSDK, describeResp.GetInfo().GetSdkName())
+			require.Equal(t, temporal.SDKVersion, describeResp.GetInfo().GetSdkVersion())
+
 			_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
 				Namespace: env.Namespace().String(),
 				TaskToken: pollResp1.TaskToken,
@@ -3529,7 +3538,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution() {
 			require.NoError(t, err)
 			require.EqualValues(t, 2, pollResp2.Attempt)
 
-			describeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			describeResp, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
 				Namespace:  env.Namespace().String(),
 				ActivityId: activityID,
 			})

--- a/tests/standalone_activity_test.go
+++ b/tests/standalone_activity_test.go
@@ -24,6 +24,7 @@ import (
 	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexusrpc"
@@ -34,6 +35,7 @@ import (
 	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -3160,335 +3162,63 @@ func (s *standaloneActivityTestSuite) TestScheduleToStartTimeout() {
 		"expected ScheduleToStartTimeout but is %s", describeResp.GetOutcome().GetFailure().GetTimeoutFailureInfo().GetTimeoutType())
 }
 
-func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_NoWait() {
-	env := s.newTestEnv()
-	t := s.T()
-	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
-	defer cancel()
-	activityID := env.Tv().ActivityID()
-	taskQueue := env.Tv().TaskQueue()
+func (s *standaloneActivityTestSuite) TestDescribeActivityExecution() {
+	s.Run("NoWait", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		env := s.newTestEnv()
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		defer cancel()
+		activityID := env.Tv().ActivityID()
+		taskQueue := env.Tv().TaskQueue()
 
-	startReq := &workflowservice.StartActivityExecutionRequest{
-		Namespace:              env.Namespace().String(),
-		ActivityId:             activityID,
-		ActivityType:           env.Tv().ActivityType(),
-		Header:                 defaultHeader,
-		HeartbeatTimeout:       durationpb.New(45 * time.Second),
-		Identity:               env.Tv().WorkerIdentity(),
-		Input:                  defaultInput,
-		ScheduleToStartTimeout: durationpb.New(30 * time.Second),
-		ScheduleToCloseTimeout: durationpb.New(3 * time.Minute),
-		StartToCloseTimeout:    durationpb.New(1 * time.Minute),
-		RequestId:              env.Tv().RequestID(),
-		RetryPolicy: &commonpb.RetryPolicy{
-			InitialInterval:    durationpb.New(2 * time.Second),
-			BackoffCoefficient: 1.5,
-			MaximumAttempts:    3,
-			MaximumInterval:    durationpb.New(111 * time.Second),
-		},
-		Priority: &commonpb.Priority{
-			FairnessKey: "test-key",
-		},
-		SearchAttributes: defaultSearchAttributes,
-		TaskQueue: &taskqueuepb.TaskQueue{
-			Name: taskQueue.GetName(),
-		},
-		UserMetadata: defaultUserMetadata,
-	}
-
-	startResp, err := env.FrontendClient().StartActivityExecution(ctx, startReq)
-	require.NoError(t, err)
-
-	t.Run("MinimalResponse", func(t *testing.T) {
-		describeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  env.Namespace().String(),
-			ActivityId: activityID,
-			// Omit RunID to verify that latest run will be used
-			IncludeInput:   false,
-			IncludeOutcome: false,
-		})
-		require.NoError(t, err)
-		require.NotNil(t, describeResp.LongPollToken)
-		require.Equal(t, startResp.RunId, describeResp.RunId)
-		require.Nil(t, describeResp.Input)
-		require.Nil(t, describeResp.GetOutcome().GetResult())
-		require.Nil(t, describeResp.GetOutcome().GetFailure())
-	})
-
-	t.Run("FullResponse", func(t *testing.T) {
-		describeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:      env.Namespace().String(),
-			ActivityId:     activityID,
-			RunId:          startResp.RunId,
-			IncludeInput:   true,
-			IncludeOutcome: true,
-		})
-		require.NoError(t, err)
-
-		respInfo := describeResp.GetInfo()
-		require.NotNil(t, describeResp.LongPollToken)
-		require.NotNil(t, respInfo)
-
-		expectedExpirationTime := timestamppb.New(respInfo.GetScheduleTime().AsTime().Add(
-			startReq.GetScheduleToCloseTimeout().AsDuration()))
-
-		expected := &activitypb.ActivityExecutionInfo{
+		startReq := &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
 			ActivityId:             activityID,
 			ActivityType:           env.Tv().ActivityType(),
-			Attempt:                1,
-			ExpirationTime:         expectedExpirationTime,
 			Header:                 defaultHeader,
-			HeartbeatTimeout:       startReq.GetHeartbeatTimeout(),
-			RetryPolicy:            startReq.GetRetryPolicy(),
-			RunId:                  startResp.RunId,
-			RunState:               enumspb.PENDING_ACTIVITY_STATE_SCHEDULED,
-			Priority:               startReq.GetPriority(),
-			ScheduleToCloseTimeout: startReq.GetScheduleToCloseTimeout(),
-			ScheduleToStartTimeout: startReq.GetScheduleToStartTimeout(),
-			StartToCloseTimeout:    startReq.GetStartToCloseTimeout(),
-			Status:                 enumspb.ACTIVITY_EXECUTION_STATUS_RUNNING,
-			SearchAttributes:       defaultSearchAttributes,
-			TaskQueue:              taskQueue.Name,
-			UserMetadata:           defaultUserMetadata,
+			HeartbeatTimeout:       durationpb.New(45 * time.Second),
+			Identity:               env.Tv().WorkerIdentity(),
+			Input:                  defaultInput,
+			ScheduleToStartTimeout: durationpb.New(30 * time.Second),
+			ScheduleToCloseTimeout: durationpb.New(3 * time.Minute),
+			StartToCloseTimeout:    durationpb.New(1 * time.Minute),
+			RequestId:              env.Tv().RequestID(),
+			RetryPolicy: &commonpb.RetryPolicy{
+				InitialInterval:    durationpb.New(2 * time.Second),
+				BackoffCoefficient: 1.5,
+				MaximumAttempts:    3,
+				MaximumInterval:    durationpb.New(111 * time.Second),
+			},
+			Priority: &commonpb.Priority{
+				FairnessKey: "test-key",
+			},
+			SearchAttributes: defaultSearchAttributes,
+			TaskQueue: &taskqueuepb.TaskQueue{
+				Name: taskQueue.GetName(),
+			},
+			UserMetadata: defaultUserMetadata,
 		}
 
-		// Ignore non-deterministic fields. Validated separately.
-		protorequire.ProtoEqual(t, expected, respInfo,
-			protorequire.IgnoreFields(
-				"execution_duration",
-				"schedule_time",
-				"state_size_bytes",
-				"state_transition_count",
-			),
-		)
-		require.Equal(t, respInfo.GetExecutionDuration().AsDuration(), time.Duration(0)) // Never completed, so expect 0
-		require.Nil(t, describeResp.GetInfo().GetCloseTime())
-		require.Positive(t, respInfo.GetScheduleTime().AsTime().Unix())
-		require.Positive(t, respInfo.GetStateSizeBytes())
-		require.Positive(t, respInfo.GetStateTransitionCount())
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, startReq)
+		require.NoError(t, err)
 
-		protorequire.ProtoEqual(t, defaultInput, describeResp.Input)
-
-		// Activity is scheduled but not completed, so no outcome yet
-		require.Nil(t, describeResp.GetOutcome().GetResult())
-		require.Nil(t, describeResp.GetOutcome().GetFailure())
-	})
-}
-
-func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_WaitAnyStateChange() {
-	// Long poll for any state change. PollActivityTaskQueue is used to cause a state change.
-	env := s.newTestEnv()
-	t := s.T()
-	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
-	defer cancel()
-	activityID := env.Tv().ActivityID()
-	taskQueue := env.Tv().TaskQueue()
-
-	startResp, err := env.startActivity(ctx, activityID, taskQueue.Name)
-	require.NoError(t, err)
-
-	// First poll lacks token and therefore responds immediately, returning a token
-	firstDescribeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-		Namespace:  env.Namespace().String(),
-		ActivityId: activityID,
-		// RunId:        startResp.RunId, // RunID is now required by validation [?]
-		IncludeInput: true,
-	})
-	require.NoError(t, err)
-	require.NotNil(t, firstDescribeResp.LongPollToken)
-	require.NotNil(t, firstDescribeResp.Info)
-	require.Equal(t, firstDescribeResp.RunId, startResp.RunId)
-
-	expected := &activitypb.ActivityExecutionInfo{
-		ActivityId:             activityID,
-		ActivityType:           env.Tv().ActivityType(),
-		Attempt:                1,
-		HeartbeatTimeout:       durationpb.New(0),
-		RetryPolicy:            defaultRetryPolicy,
-		RunId:                  startResp.RunId,
-		RunState:               enumspb.PENDING_ACTIVITY_STATE_SCHEDULED,
-		SearchAttributes:       &commonpb.SearchAttributes{},
-		ScheduleToCloseTimeout: durationpb.New(0),
-		ScheduleToStartTimeout: durationpb.New(0),
-		StartToCloseTimeout:    durationpb.New(defaultStartToCloseTimeout),
-		Status:                 enumspb.ACTIVITY_EXECUTION_STATUS_RUNNING,
-		TaskQueue:              taskQueue.Name,
-	}
-
-	// Ignore non-deterministic fields. Validated separately.
-	protorequire.ProtoEqual(t, expected, firstDescribeResp.GetInfo(),
-		protorequire.IgnoreFields(
-			"execution_duration",
-			"schedule_time",
-			"state_size_bytes",
-			"state_transition_count",
-		),
-	)
-	require.Positive(t, firstDescribeResp.GetInfo().GetStateSizeBytes())
-
-	taskQueuePollErr := make(chan error, 1)
-	activityPollDone := make(chan struct{})
-	var describeResp *workflowservice.DescribeActivityExecutionResponse
-	var describeErr error
-
-	go func() {
-		defer close(activityPollDone)
-		// Second poll uses token and therefore waits for a state transition
-		describeResp, describeErr = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:     env.Namespace().String(),
-			ActivityId:    activityID,
-			RunId:         startResp.RunId,
-			IncludeInput:  true,
-			LongPollToken: firstDescribeResp.LongPollToken,
-		})
-	}()
-
-	// TODO(dan): race here: subscription might not be established yet
-
-	// Worker picks up activity task, triggering transition (via RecordActivityTaskStarted)
-	go func() {
-		_, err := env.pollActivityTaskQueue(ctx, taskQueue.Name)
-		taskQueuePollErr <- err
-	}()
-
-	select {
-	case <-activityPollDone:
-		require.NoError(t, describeErr)
-		require.NotNil(t, describeResp)
-		require.NotNil(t, describeResp.Info)
-
-		expected := &activitypb.ActivityExecutionInfo{
-			ActivityId:             activityID,
-			ActivityType:           env.Tv().ActivityType(),
-			Attempt:                1,
-			HeartbeatTimeout:       durationpb.New(0),
-			LastWorkerIdentity:     defaultIdentity,
-			RetryPolicy:            defaultRetryPolicy,
-			RunId:                  startResp.RunId,
-			RunState:               enumspb.PENDING_ACTIVITY_STATE_STARTED,
-			ScheduleToCloseTimeout: durationpb.New(0),
-			ScheduleToStartTimeout: durationpb.New(0),
-			SearchAttributes:       &commonpb.SearchAttributes{},
-			StartToCloseTimeout:    durationpb.New(defaultStartToCloseTimeout),
-			Status:                 enumspb.ACTIVITY_EXECUTION_STATUS_RUNNING,
-			TaskQueue:              taskQueue.Name,
-		}
-
-		// Ignore non-deterministic fields. Validated separately.
-		protorequire.ProtoEqual(t, expected, describeResp.GetInfo(),
-			protorequire.IgnoreFields(
-				"execution_duration",
-				"last_started_time",
-				"schedule_time",
-				"state_size_bytes",
-				"state_transition_count",
-			),
-		)
-		require.Positive(t, describeResp.GetInfo().GetStateSizeBytes())
-
-		protorequire.ProtoEqual(t, defaultInput, describeResp.Input)
-
-	case <-ctx.Done():
-		t.Fatal("DescribeActivityExecution timed out")
-	}
-
-	err = <-taskQueuePollErr
-	require.NoError(t, err)
-}
-
-func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_Completed() {
-	env := s.newTestEnv()
-	testCases := []struct {
-		name             string
-		expectedStatus   enumspb.ActivityExecutionStatus
-		taskCompletionFn func(ctx context.Context, taskToken []byte, activityID, runID string) error
-		outcomeValidator func(*testing.T, *workflowservice.DescribeActivityExecutionResponse)
-	}{
-		{
-			name:           "successful completion",
-			expectedStatus: enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED,
-			taskCompletionFn: func(ctx context.Context, taskToken []byte, _, _ string) error {
-				_, err := env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-					Namespace: env.Namespace().String(),
-					TaskToken: taskToken,
-					Result:    defaultResult,
-					Identity:  defaultIdentity,
-				})
-				return err
-			},
-			outcomeValidator: func(t *testing.T, response *workflowservice.DescribeActivityExecutionResponse) {
-				protorequire.ProtoEqual(t, defaultResult, response.GetOutcome().GetResult())
-				require.Nil(t, response.GetOutcome().GetFailure())
-			},
-		},
-		{
-			name:           "failure completion",
-			expectedStatus: enumspb.ACTIVITY_EXECUTION_STATUS_FAILED,
-			taskCompletionFn: func(ctx context.Context, taskToken []byte, _, _ string) error {
-				_, err := env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
-					Namespace: env.Namespace().String(),
-					TaskToken: taskToken,
-					Failure:   defaultFailure,
-					Identity:  defaultIdentity,
-				})
-				return err
-			},
-			outcomeValidator: func(t *testing.T, response *workflowservice.DescribeActivityExecutionResponse) {
-				protorequire.ProtoEqual(t, defaultFailure, response.GetOutcome().GetFailure())
-				require.Nil(t, response.GetOutcome().GetResult())
-			},
-		},
-		{
-			name:           "termination",
-			expectedStatus: enumspb.ACTIVITY_EXECUTION_STATUS_TERMINATED,
-			taskCompletionFn: func(ctx context.Context, _ []byte, activityID, runID string) error {
-				_, err := env.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
-					Namespace:  env.Namespace().String(),
-					ActivityId: activityID,
-					RunId:      runID,
-					Reason:     "test termination",
-				})
-				return err
-			},
-			outcomeValidator: func(t *testing.T, response *workflowservice.DescribeActivityExecutionResponse) {
-				require.NotNil(t, response.GetOutcome().GetFailure())
-				require.NotNil(t, response.GetOutcome().GetFailure().GetTerminatedFailureInfo())
-				require.Nil(t, response.GetOutcome().GetResult())
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		s.Run(tc.name, func(s *standaloneActivityTestSuite) {
-			t := s.T()
-			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
-			t.Cleanup(cancel)
-			activityID := env.Tv().Any().String()
-			taskQueue := &taskqueuepb.TaskQueue{Name: testcore.RandomizeStr(t.Name())}
-
-			startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-				Namespace:           env.Namespace().String(),
-				ActivityId:          activityID,
-				ActivityType:        env.Tv().ActivityType(),
-				Header:              defaultHeader,
-				HeartbeatTimeout:    durationpb.New(45 * time.Second),
-				Identity:            env.Tv().WorkerIdentity(),
-				Input:               defaultInput,
-				StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-				RequestId:           env.Tv().RequestID(),
-				RetryPolicy:         defaultRetryPolicy,
-				Priority:            &commonpb.Priority{FairnessKey: "test-key"},
-				SearchAttributes:    defaultSearchAttributes,
-				TaskQueue:           taskQueue,
-				UserMetadata:        defaultUserMetadata,
+		t.Run("MinimalResponse", func(t *testing.T) {
+			describeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
+				ActivityId: activityID,
+				// Omit RunID to verify that latest run will be used
+				IncludeInput:   false,
+				IncludeOutcome: false,
 			})
 			require.NoError(t, err)
+			require.NotNil(t, describeResp.LongPollToken)
+			require.Equal(t, startResp.RunId, describeResp.RunId)
+			require.Nil(t, describeResp.Input)
+			require.Nil(t, describeResp.GetOutcome().GetResult())
+			require.Nil(t, describeResp.GetOutcome().GetFailure())
+		})
 
-			pollTaskResp, err := env.pollActivityTaskQueue(ctx, taskQueue.Name)
-			require.NoError(t, err)
-			err = tc.taskCompletionFn(ctx, pollTaskResp.TaskToken, activityID, startResp.RunId)
-			require.NoError(t, err)
-
+		t.Run("FullResponse", func(t *testing.T) {
 			describeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
 				Namespace:      env.Namespace().String(),
 				ActivityId:     activityID,
@@ -3497,40 +3227,792 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_Completed() 
 				IncludeOutcome: true,
 			})
 			require.NoError(t, err)
-			require.NotNil(t, describeResp)
-			require.Equal(t, startResp.RunId, describeResp.GetRunId())
-			protorequire.ProtoEqual(t, defaultInput, describeResp.GetInput())
-			// info fields
-			info := describeResp.GetInfo()
-			require.NotNil(t, info)
-			require.Equal(t, activityID, info.GetActivityId())
-			require.Equal(t, startResp.RunId, info.GetRunId())
-			protorequire.ProtoEqual(t, env.Tv().ActivityType(), info.GetActivityType())
-			require.Equal(t, tc.expectedStatus, info.GetStatus())
-			require.Equal(t, taskQueue.Name, info.GetTaskQueue())
-			require.Equal(t, int32(1), info.GetAttempt())
-			protorequire.ProtoEqual(t, defaultRetryPolicy, info.GetRetryPolicy())
-			protorequire.ProtoEqual(t, defaultHeader, info.GetHeader())
-			protorequire.ProtoEqual(t, &commonpb.Priority{FairnessKey: "test-key"}, info.GetPriority())
-			protorequire.ProtoEqual(t, defaultSearchAttributes, info.GetSearchAttributes())
-			protorequire.ProtoEqual(t, defaultUserMetadata, info.GetUserMetadata())
-			require.Equal(t, 45*time.Second, info.GetHeartbeatTimeout().AsDuration())
-			require.Equal(t, defaultStartToCloseTimeout, info.GetStartToCloseTimeout().AsDuration())
-			require.Equal(t, defaultIdentity, info.GetLastWorkerIdentity())
-			// time fields
-			require.NotNil(t, info.GetScheduleTime())
-			require.Positive(t, info.GetScheduleTime().AsTime().Unix())
-			require.NotNil(t, info.GetLastStartedTime())
-			require.Positive(t, info.GetLastStartedTime().AsTime().Unix())
-			require.NotNil(t, info.GetCloseTime())
-			require.Positive(t, info.GetCloseTime().AsTime().Unix())
-			require.GreaterOrEqual(t, info.GetCloseTime().AsTime().UnixNano(), info.GetLastStartedTime().AsTime().UnixNano())
-			require.Positive(t, info.GetStateSizeBytes())
-			require.Positive(t, info.GetStateTransitionCount())
 
-			tc.outcomeValidator(t, describeResp)
+			respInfo := describeResp.GetInfo()
+			require.NotNil(t, describeResp.LongPollToken)
+			require.NotNil(t, respInfo)
+
+			expectedExpirationTime := timestamppb.New(respInfo.GetScheduleTime().AsTime().Add(
+				startReq.GetScheduleToCloseTimeout().AsDuration()))
+
+			expected := &activitypb.ActivityExecutionInfo{
+				ActivityId:             activityID,
+				ActivityType:           env.Tv().ActivityType(),
+				Attempt:                1,
+				ExpirationTime:         expectedExpirationTime,
+				Header:                 defaultHeader,
+				HeartbeatTimeout:       startReq.GetHeartbeatTimeout(),
+				RetryPolicy:            startReq.GetRetryPolicy(),
+				RunId:                  startResp.RunId,
+				RunState:               enumspb.PENDING_ACTIVITY_STATE_SCHEDULED,
+				Priority:               startReq.GetPriority(),
+				ScheduleToCloseTimeout: startReq.GetScheduleToCloseTimeout(),
+				ScheduleToStartTimeout: startReq.GetScheduleToStartTimeout(),
+				StartToCloseTimeout:    startReq.GetStartToCloseTimeout(),
+				Status:                 enumspb.ACTIVITY_EXECUTION_STATUS_RUNNING,
+				SearchAttributes:       defaultSearchAttributes,
+				TaskQueue:              taskQueue.Name,
+				UserMetadata:           defaultUserMetadata,
+			}
+
+			// Ignore non-deterministic fields. Validated separately.
+			protorequire.ProtoEqual(t, expected, respInfo,
+				protorequire.IgnoreFields(
+					"execution_duration",
+					"schedule_time",
+					"state_size_bytes",
+					"state_transition_count",
+				),
+			)
+			require.Equal(t, respInfo.GetExecutionDuration().AsDuration(), time.Duration(0)) // Never completed, so expect 0
+			require.Nil(t, describeResp.GetInfo().GetCloseTime())
+			require.Positive(t, respInfo.GetScheduleTime().AsTime().Unix())
+			require.Positive(t, respInfo.GetStateSizeBytes())
+			require.Positive(t, respInfo.GetStateTransitionCount())
+
+			protorequire.ProtoEqual(t, defaultInput, describeResp.Input)
+
+			// Activity is scheduled but not completed, so no outcome yet
+			require.Nil(t, describeResp.GetOutcome().GetResult())
+			require.Nil(t, describeResp.GetOutcome().GetFailure())
 		})
-	}
+	})
+
+	s.Run("WaitAnyStateChange", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		// Long poll for any state change. PollActivityTaskQueue is used to cause a state change.
+		env := s.newTestEnv()
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		defer cancel()
+		activityID := env.Tv().ActivityID()
+		taskQueue := env.Tv().TaskQueue()
+
+		startResp, err := env.startActivity(ctx, activityID, taskQueue.Name)
+		require.NoError(t, err)
+
+		// First poll lacks token and therefore responds immediately, returning a token
+		firstDescribeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			// RunId:        startResp.RunId, // RunID is now required by validation [?]
+			IncludeInput: true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, firstDescribeResp.LongPollToken)
+		require.NotNil(t, firstDescribeResp.Info)
+		require.Equal(t, firstDescribeResp.RunId, startResp.RunId)
+
+		expected := &activitypb.ActivityExecutionInfo{
+			ActivityId:             activityID,
+			ActivityType:           env.Tv().ActivityType(),
+			Attempt:                1,
+			HeartbeatTimeout:       durationpb.New(0),
+			RetryPolicy:            defaultRetryPolicy,
+			RunId:                  startResp.RunId,
+			RunState:               enumspb.PENDING_ACTIVITY_STATE_SCHEDULED,
+			SearchAttributes:       &commonpb.SearchAttributes{},
+			ScheduleToCloseTimeout: durationpb.New(0),
+			ScheduleToStartTimeout: durationpb.New(0),
+			StartToCloseTimeout:    durationpb.New(defaultStartToCloseTimeout),
+			Status:                 enumspb.ACTIVITY_EXECUTION_STATUS_RUNNING,
+			TaskQueue:              taskQueue.Name,
+		}
+
+		// Ignore non-deterministic fields. Validated separately.
+		protorequire.ProtoEqual(t, expected, firstDescribeResp.GetInfo(),
+			protorequire.IgnoreFields(
+				"execution_duration",
+				"schedule_time",
+				"state_size_bytes",
+				"state_transition_count",
+			),
+		)
+		require.Positive(t, firstDescribeResp.GetInfo().GetStateSizeBytes())
+
+		taskQueuePollErr := make(chan error, 1)
+		activityPollDone := make(chan struct{})
+		var describeResp *workflowservice.DescribeActivityExecutionResponse
+		var describeErr error
+
+		go func() {
+			defer close(activityPollDone)
+			// Second poll uses token and therefore waits for a state transition
+			describeResp, describeErr = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:     env.Namespace().String(),
+				ActivityId:    activityID,
+				RunId:         startResp.RunId,
+				IncludeInput:  true,
+				LongPollToken: firstDescribeResp.LongPollToken,
+			})
+		}()
+
+		// TODO(dan): race here: subscription might not be established yet
+
+		// Worker picks up activity task, triggering transition (via RecordActivityTaskStarted)
+		go func() {
+			_, err := env.pollActivityTaskQueue(ctx, taskQueue.Name)
+			taskQueuePollErr <- err
+		}()
+
+		select {
+		case <-activityPollDone:
+			require.NoError(t, describeErr)
+			require.NotNil(t, describeResp)
+			require.NotNil(t, describeResp.Info)
+
+			expected := &activitypb.ActivityExecutionInfo{
+				ActivityId:             activityID,
+				ActivityType:           env.Tv().ActivityType(),
+				Attempt:                1,
+				HeartbeatTimeout:       durationpb.New(0),
+				LastWorkerIdentity:     defaultIdentity,
+				RetryPolicy:            defaultRetryPolicy,
+				RunId:                  startResp.RunId,
+				RunState:               enumspb.PENDING_ACTIVITY_STATE_STARTED,
+				ScheduleToCloseTimeout: durationpb.New(0),
+				ScheduleToStartTimeout: durationpb.New(0),
+				SearchAttributes:       &commonpb.SearchAttributes{},
+				StartToCloseTimeout:    durationpb.New(defaultStartToCloseTimeout),
+				Status:                 enumspb.ACTIVITY_EXECUTION_STATUS_RUNNING,
+				TaskQueue:              taskQueue.Name,
+			}
+
+			// Ignore non-deterministic fields. Validated separately.
+			protorequire.ProtoEqual(t, expected, describeResp.GetInfo(),
+				protorequire.IgnoreFields(
+					"execution_duration",
+					"last_started_time",
+					"schedule_time",
+					"state_size_bytes",
+					"state_transition_count",
+				),
+			)
+			require.Positive(t, describeResp.GetInfo().GetStateSizeBytes())
+
+			protorequire.ProtoEqual(t, defaultInput, describeResp.Input)
+
+		case <-ctx.Done():
+			t.Fatal("DescribeActivityExecution timed out")
+		}
+
+		err = <-taskQueuePollErr
+		require.NoError(t, err)
+	})
+
+	s.Run("ExposesSDKMetadata", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		env := s.newTestEnv()
+
+		t.Run("Populated", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+			activityID := testcore.RandomizeStr(t.Name())
+			taskQueue := testcore.RandomizeStr(t.Name())
+
+			startResp, err := env.startActivity(ctx, activityID, taskQueue)
+			require.NoError(t, err)
+
+			pollCtx := metadata.AppendToOutgoingContext(ctx,
+				headers.ClientNameHeaderName, headers.ClientNameGoSDK,
+				headers.ClientVersionHeaderName, temporal.SDKVersion,
+			)
+			_, err = env.FrontendClient().PollActivityTaskQueue(pollCtx, &workflowservice.PollActivityTaskQueueRequest{
+				Namespace: env.Namespace().String(),
+				TaskQueue: &taskqueuepb.TaskQueue{
+					Name: taskQueue,
+					Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
+				},
+				Identity: defaultIdentity,
+			})
+			require.NoError(t, err)
+
+			describeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
+				ActivityId: activityID,
+				RunId:      startResp.RunId,
+			})
+			require.NoError(t, err)
+			require.Equal(t, headers.ClientNameGoSDK, describeResp.GetInfo().GetSdkName())
+			require.Equal(t, temporal.SDKVersion, describeResp.GetInfo().GetSdkVersion())
+		})
+
+		t.Run("EmptyWhenAbsent", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+			activityID := testcore.RandomizeStr(t.Name())
+			taskQueue := testcore.RandomizeStr(t.Name())
+
+			startResp, err := env.startActivity(ctx, activityID, taskQueue)
+			require.NoError(t, err)
+
+			pollCtx := metadata.NewOutgoingContext(ctx, metadata.MD{})
+			_, err = env.FrontendClient().PollActivityTaskQueue(pollCtx, &workflowservice.PollActivityTaskQueueRequest{
+				Namespace: env.Namespace().String(),
+				TaskQueue: &taskqueuepb.TaskQueue{
+					Name: taskQueue,
+					Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
+				},
+				Identity: defaultIdentity,
+			})
+			require.NoError(t, err)
+
+			describeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
+				ActivityId: activityID,
+				RunId:      startResp.RunId,
+			})
+			require.NoError(t, err)
+			require.Empty(t, describeResp.GetInfo().GetSdkName())
+			require.Empty(t, describeResp.GetInfo().GetSdkVersion())
+		})
+
+		// When an attempt fails and a new attempt is scheduled, the next poller's SDK identity must overwrite the
+		// previous attempt's values.
+		t.Run("OverwrittenOnRetry", func(t *testing.T) {
+
+			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+			defer cancel()
+			activityID := testcore.RandomizeStr(t.Name())
+			taskQueue := testcore.RandomizeStr(t.Name())
+
+			_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+				Namespace:           env.Namespace().String(),
+				ActivityId:          activityID,
+				ActivityType:        &commonpb.ActivityType{Name: "test-activity-type"},
+				TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+				StartToCloseTimeout: durationpb.New(1 * time.Minute),
+				RetryPolicy: &commonpb.RetryPolicy{
+					InitialInterval: durationpb.New(1 * time.Millisecond),
+					MaximumAttempts: 2,
+				},
+			})
+			require.NoError(t, err)
+
+			// Attempt 1: poll as the Go SDK, then fail retryably.
+			pollCtx1 := metadata.AppendToOutgoingContext(ctx,
+				headers.ClientNameHeaderName, headers.ClientNameGoSDK,
+				headers.ClientVersionHeaderName, temporal.SDKVersion,
+			)
+			pollResp1, err := env.FrontendClient().PollActivityTaskQueue(pollCtx1, &workflowservice.PollActivityTaskQueueRequest{
+				Namespace: env.Namespace().String(),
+				TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				Identity:  defaultIdentity,
+			})
+			require.NoError(t, err)
+			require.EqualValues(t, 1, pollResp1.Attempt)
+
+			_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+				Namespace: env.Namespace().String(),
+				TaskToken: pollResp1.TaskToken,
+				Failure: &failurepb.Failure{
+					Message: "retryable failure",
+					FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+						ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{NonRetryable: false},
+					},
+				},
+				Identity: defaultIdentity,
+			})
+			require.NoError(t, err)
+
+			// Attempt 2: poll as a different SDK to prove the value is overwritten, not appended.
+			// Java version is hardcoded since we don't have the Java SDK imported.
+			javaSdkVersion := "1.35.0"
+			pollCtx2 := metadata.AppendToOutgoingContext(ctx,
+				headers.ClientNameHeaderName, headers.ClientNameJavaSDK,
+				headers.ClientVersionHeaderName, javaSdkVersion,
+			)
+			pollResp2, err := env.FrontendClient().PollActivityTaskQueue(pollCtx2, &workflowservice.PollActivityTaskQueueRequest{
+				Namespace: env.Namespace().String(),
+				TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				Identity:  defaultIdentity,
+			})
+			require.NoError(t, err)
+			require.EqualValues(t, 2, pollResp2.Attempt)
+
+			describeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
+				ActivityId: activityID,
+			})
+			require.NoError(t, err)
+			require.Equal(t, headers.ClientNameJavaSDK, describeResp.GetInfo().GetSdkName())
+			require.Equal(t, javaSdkVersion, describeResp.GetInfo().GetSdkVersion())
+			require.EqualValues(t, 2, describeResp.GetInfo().GetAttempt())
+		})
+	})
+
+	s.Run("Completed", func(s *standaloneActivityTestSuite) {
+		env := s.newTestEnv()
+		testCases := []struct {
+			name             string
+			expectedStatus   enumspb.ActivityExecutionStatus
+			taskCompletionFn func(ctx context.Context, taskToken []byte, activityID, runID string) error
+			outcomeValidator func(*testing.T, *workflowservice.DescribeActivityExecutionResponse)
+		}{
+			{
+				name:           "successful completion",
+				expectedStatus: enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED,
+				taskCompletionFn: func(ctx context.Context, taskToken []byte, _, _ string) error {
+					_, err := env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+						Namespace: env.Namespace().String(),
+						TaskToken: taskToken,
+						Result:    defaultResult,
+						Identity:  defaultIdentity,
+					})
+					return err
+				},
+				outcomeValidator: func(t *testing.T, response *workflowservice.DescribeActivityExecutionResponse) {
+					protorequire.ProtoEqual(t, defaultResult, response.GetOutcome().GetResult())
+					require.Nil(t, response.GetOutcome().GetFailure())
+				},
+			},
+			{
+				name:           "failure completion",
+				expectedStatus: enumspb.ACTIVITY_EXECUTION_STATUS_FAILED,
+				taskCompletionFn: func(ctx context.Context, taskToken []byte, _, _ string) error {
+					_, err := env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+						Namespace: env.Namespace().String(),
+						TaskToken: taskToken,
+						Failure:   defaultFailure,
+						Identity:  defaultIdentity,
+					})
+					return err
+				},
+				outcomeValidator: func(t *testing.T, response *workflowservice.DescribeActivityExecutionResponse) {
+					protorequire.ProtoEqual(t, defaultFailure, response.GetOutcome().GetFailure())
+					require.Nil(t, response.GetOutcome().GetResult())
+				},
+			},
+			{
+				name:           "termination",
+				expectedStatus: enumspb.ACTIVITY_EXECUTION_STATUS_TERMINATED,
+				taskCompletionFn: func(ctx context.Context, _ []byte, activityID, runID string) error {
+					_, err := env.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+						Namespace:  env.Namespace().String(),
+						ActivityId: activityID,
+						RunId:      runID,
+						Reason:     "test termination",
+					})
+					return err
+				},
+				outcomeValidator: func(t *testing.T, response *workflowservice.DescribeActivityExecutionResponse) {
+					require.NotNil(t, response.GetOutcome().GetFailure())
+					require.NotNil(t, response.GetOutcome().GetFailure().GetTerminatedFailureInfo())
+					require.Nil(t, response.GetOutcome().GetResult())
+				},
+			},
+		}
+
+		for _, tc := range testCases {
+			s.Run(tc.name, func(s *standaloneActivityTestSuite) {
+				t := s.T()
+				ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+				t.Cleanup(cancel)
+				activityID := env.Tv().Any().String()
+				taskQueue := &taskqueuepb.TaskQueue{Name: testcore.RandomizeStr(t.Name())}
+
+				startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+					Namespace:           env.Namespace().String(),
+					ActivityId:          activityID,
+					ActivityType:        env.Tv().ActivityType(),
+					Header:              defaultHeader,
+					HeartbeatTimeout:    durationpb.New(45 * time.Second),
+					Identity:            env.Tv().WorkerIdentity(),
+					Input:               defaultInput,
+					StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+					RequestId:           env.Tv().RequestID(),
+					RetryPolicy:         defaultRetryPolicy,
+					Priority:            &commonpb.Priority{FairnessKey: "test-key"},
+					SearchAttributes:    defaultSearchAttributes,
+					TaskQueue:           taskQueue,
+					UserMetadata:        defaultUserMetadata,
+				})
+				require.NoError(t, err)
+
+				pollTaskResp, err := env.pollActivityTaskQueue(ctx, taskQueue.Name)
+				require.NoError(t, err)
+				err = tc.taskCompletionFn(ctx, pollTaskResp.TaskToken, activityID, startResp.RunId)
+				require.NoError(t, err)
+
+				describeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+					Namespace:      env.Namespace().String(),
+					ActivityId:     activityID,
+					RunId:          startResp.RunId,
+					IncludeInput:   true,
+					IncludeOutcome: true,
+				})
+				require.NoError(t, err)
+				require.NotNil(t, describeResp)
+				require.Equal(t, startResp.RunId, describeResp.GetRunId())
+				protorequire.ProtoEqual(t, defaultInput, describeResp.GetInput())
+				// info fields
+				info := describeResp.GetInfo()
+				require.NotNil(t, info)
+				require.Equal(t, activityID, info.GetActivityId())
+				require.Equal(t, startResp.RunId, info.GetRunId())
+				protorequire.ProtoEqual(t, env.Tv().ActivityType(), info.GetActivityType())
+				require.Equal(t, tc.expectedStatus, info.GetStatus())
+				require.Equal(t, taskQueue.Name, info.GetTaskQueue())
+				require.Equal(t, int32(1), info.GetAttempt())
+				protorequire.ProtoEqual(t, defaultRetryPolicy, info.GetRetryPolicy())
+				protorequire.ProtoEqual(t, defaultHeader, info.GetHeader())
+				protorequire.ProtoEqual(t, &commonpb.Priority{FairnessKey: "test-key"}, info.GetPriority())
+				protorequire.ProtoEqual(t, defaultSearchAttributes, info.GetSearchAttributes())
+				protorequire.ProtoEqual(t, defaultUserMetadata, info.GetUserMetadata())
+				require.Equal(t, 45*time.Second, info.GetHeartbeatTimeout().AsDuration())
+				require.Equal(t, defaultStartToCloseTimeout, info.GetStartToCloseTimeout().AsDuration())
+				require.Equal(t, defaultIdentity, info.GetLastWorkerIdentity())
+				// time fields
+				require.NotNil(t, info.GetScheduleTime())
+				require.Positive(t, info.GetScheduleTime().AsTime().Unix())
+				require.NotNil(t, info.GetLastStartedTime())
+				require.Positive(t, info.GetLastStartedTime().AsTime().Unix())
+				require.NotNil(t, info.GetCloseTime())
+				require.Positive(t, info.GetCloseTime().AsTime().Unix())
+				require.GreaterOrEqual(t, info.GetCloseTime().AsTime().UnixNano(), info.GetLastStartedTime().AsTime().UnixNano())
+				require.Positive(t, info.GetStateSizeBytes())
+				require.Positive(t, info.GetStateTransitionCount())
+
+				tc.outcomeValidator(t, describeResp)
+			})
+		}
+	})
+
+	s.Run("DeadlineExceeded", func(s *standaloneActivityTestSuite) {
+		env := s.newTestEnv()
+		t := s.T()
+		ctx := testcore.NewContext()
+
+		// Start an activity and get initial long-poll state token
+		activityID := env.Tv().ActivityID()
+		taskQueue := env.Tv().TaskQueue()
+		startResp, err := env.startActivity(ctx, activityID, taskQueue.Name)
+		require.NoError(t, err)
+		describeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+
+		// The DescribeActivityExecution calls below use a long-poll token and will necessarily time out,
+		// because the activity undergoes no further state transitions.
+
+		// The timeout imposed by the server is essentially
+		// Min(CallerTimeout - LongPollBuffer, LongPollTimeout)
+
+		// Case 1: Caller sets a deadline which has room for the buffer. History returns empty success
+		// result with at least buffer remaining before the caller deadline.
+		t.Run("CallerDeadlineNotExceeded", func(t *testing.T) {
+			// CallerTimeout - LongPollBuffer is far in the future
+			cleanup1 := env.OverrideDynamicConfig(activity.LongPollBuffer, 1*time.Second)
+			defer cleanup1()
+			ctx, cancel := context.WithTimeout(ctx, 9999*time.Millisecond)
+			defer cancel()
+
+			// DescribeActivityExecution will return when this long poll timeout expires.
+			cleanup2 := env.OverrideDynamicConfig(activity.LongPollTimeout, 10*time.Millisecond)
+			defer cleanup2()
+
+			describeResp, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:     env.Namespace().String(),
+				ActivityId:    activityID,
+				RunId:         startResp.RunId,
+				LongPollToken: describeResp.LongPollToken,
+			})
+			// The server uses an empty non-error response to indicate to the caller that it should resubmit
+			// its long-poll.
+			require.NoError(t, err)
+			require.Empty(t, describeResp.GetInfo())
+		})
+
+		// Case 2: caller does not set a deadline. In practice this is equivalent to them setting a 30s
+		// deadline since that is what Histry receives. In this case History times out the wait at
+		// LongPollTimeout and the caller gets an empty response.
+		t.Run("NoCallerDeadline", func(t *testing.T) {
+			// The caller sets no deadline. However, the ctx received by the history service handler
+			// will have a 30s deadline that was applied by one of the upstream server layers, so we
+			// still must use a buffer < 30s.
+			ctx := context.Background()
+			cleanup1 := env.OverrideDynamicConfig(activity.LongPollBuffer, 29*time.Second)
+			defer cleanup1()
+			// DescribeActivityExecution will return when this long poll timeout expires.
+			cleanup2 := env.OverrideDynamicConfig(activity.LongPollTimeout, 10*time.Millisecond)
+			defer cleanup2()
+
+			_, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:     env.Namespace().String(),
+				ActivityId:    activityID,
+				RunId:         startResp.RunId,
+				LongPollToken: describeResp.LongPollToken,
+			})
+			require.NoError(t, err)
+			require.Empty(t, describeResp.GetInfo())
+		})
+
+		// Case 3: caller sets a deadline that is < the buffer. In this case DescribeActivityExecution
+		// will return an empty result immediately, and there is a race between caller receiving that
+		// and caller's client timing out the request. Therefore we do not test this.
+	})
+
+	s.Run("NotFound", func(s *standaloneActivityTestSuite) {
+		env := s.newTestEnv()
+		t := s.T()
+		ctx := testcore.NewContext()
+
+		existingActivityID := env.Tv().ActivityID()
+		tq := env.Tv().TaskQueue()
+		startResp, err := env.startActivity(ctx, existingActivityID, tq.Name)
+		require.NoError(t, err)
+		existingRunID := startResp.RunId
+		require.NotEmpty(t, existingRunID)
+		existingNamespace := env.Namespace().String()
+
+		var notFoundErr *serviceerror.NotFound
+		var namespaceNotFoundErr *serviceerror.NamespaceNotFound
+
+		testCases := []struct {
+			name           string
+			request        *workflowservice.DescribeActivityExecutionRequest
+			expectedErr    error
+			expectedErrMsg string
+		}{
+			{
+				name: "NonExistentNamespace",
+				request: &workflowservice.DescribeActivityExecutionRequest{
+					Namespace:  "non-existent-namespace",
+					ActivityId: existingActivityID,
+					RunId:      existingRunID,
+				},
+				expectedErr:    namespaceNotFoundErr,
+				expectedErrMsg: "Namespace non-existent-namespace is not found.",
+			},
+			{
+				name: "NonExistentActivityID",
+				request: &workflowservice.DescribeActivityExecutionRequest{
+					Namespace:  existingNamespace,
+					ActivityId: "non-existent-activity",
+					RunId:      existingRunID,
+				},
+				expectedErr:    notFoundErr,
+				expectedErrMsg: "activity not found for ID: non-existent-activity",
+			},
+			{
+				name: "NonExistentRunID",
+				request: &workflowservice.DescribeActivityExecutionRequest{
+					Namespace:  existingNamespace,
+					ActivityId: existingActivityID,
+					RunId:      "11111111-2222-3333-4444-555555555555",
+				},
+				expectedErr:    notFoundErr,
+				expectedErrMsg: fmt.Sprintf("activity not found for ID: %s", existingActivityID),
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := env.FrontendClient().DescribeActivityExecution(ctx, tc.request)
+				require.ErrorAs(t, err, &tc.expectedErr) //nolint:testifylint
+				require.Equal(t, tc.expectedErrMsg, tc.expectedErr.Error())
+			})
+		}
+
+		t.Run("LongPollNonExistentActivity", func(t *testing.T) {
+			// Poll to get a token
+			validPollResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  existingNamespace,
+				ActivityId: existingActivityID,
+				RunId:      existingRunID,
+			})
+			require.NoError(t, err)
+
+			// Use the token with a non-existent activity
+			_, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:     existingNamespace,
+				ActivityId:    "non-existent-activity",
+				RunId:         existingRunID,
+				LongPollToken: validPollResp.LongPollToken,
+			})
+			var notFoundErr *serviceerror.NotFound
+			require.ErrorAs(t, err, &notFoundErr)
+			require.Equal(t, "activity not found for ID: non-existent-activity", notFoundErr.Message)
+		})
+	})
+
+	s.Run("InvalidArgument", func(s *standaloneActivityTestSuite) {
+		env := s.newTestEnv()
+		t := s.T()
+		ctx := testcore.NewContext()
+
+		existingActivityID := env.Tv().ActivityID()
+		tq := env.Tv().TaskQueue()
+		startResp, err := env.startActivity(ctx, existingActivityID, tq.Name)
+		require.NoError(t, err)
+		existingRunID := startResp.RunId
+		require.NotEmpty(t, existingRunID)
+		existingNamespace := env.Namespace().String()
+
+		validActivityID := "activity-id"
+		validRunID := "11111111-2222-3333-4444-555555555555"
+
+		testCases := []struct {
+			name        string
+			request     *workflowservice.DescribeActivityExecutionRequest
+			expectedErr string
+		}{
+			{
+				name: "EmptyNamespace",
+				request: &workflowservice.DescribeActivityExecutionRequest{
+					Namespace:  "",
+					ActivityId: validActivityID,
+					RunId:      validRunID,
+				},
+				expectedErr: "Namespace is empty",
+			},
+			{
+				name: "EmptyActivityID",
+				request: &workflowservice.DescribeActivityExecutionRequest{
+					Namespace:  existingNamespace,
+					ActivityId: "",
+					RunId:      validRunID,
+				},
+				expectedErr: "activity ID is required",
+			},
+			{
+				name: "ActivityIDTooLong",
+				request: &workflowservice.DescribeActivityExecutionRequest{
+					Namespace:  existingNamespace,
+					ActivityId: string(make([]byte, 2000)),
+					RunId:      validRunID,
+				},
+				expectedErr: "activity ID exceeds length limit",
+			},
+			{
+				name: "InvalidRunID",
+				request: &workflowservice.DescribeActivityExecutionRequest{
+					Namespace:  existingNamespace,
+					ActivityId: validActivityID,
+					RunId:      "invalid-uuid",
+				},
+				expectedErr: "invalid run id",
+			},
+			{
+				name: "RunIdNotRequiredWhenWaitPolicyAbsent",
+				request: &workflowservice.DescribeActivityExecutionRequest{
+					Namespace:  existingNamespace,
+					ActivityId: existingActivityID,
+					RunId:      "",
+				},
+				expectedErr: "",
+			},
+			{
+				name: "RunIdNotRequiredWhenLongPollTokenAbsent",
+				request: &workflowservice.DescribeActivityExecutionRequest{
+					Namespace:  existingNamespace,
+					ActivityId: existingActivityID,
+					RunId:      "",
+				},
+				expectedErr: "",
+			},
+			{
+				name: "RunIdRequiredWhenLongPollTokenPresent",
+				request: &workflowservice.DescribeActivityExecutionRequest{
+					Namespace:     existingNamespace,
+					ActivityId:    validActivityID,
+					RunId:         "",
+					LongPollToken: []byte("doesn't-matter"),
+				},
+				expectedErr: "run id is required",
+			},
+			{
+				name: "MalformedLongPollToken",
+				request: &workflowservice.DescribeActivityExecutionRequest{
+					Namespace:     existingNamespace,
+					ActivityId:    existingActivityID,
+					RunId:         existingRunID,
+					LongPollToken: []byte("invalid-token"),
+				},
+				expectedErr: "invalid long poll token",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := env.FrontendClient().DescribeActivityExecution(ctx, tc.request)
+				if tc.expectedErr == "" {
+					require.NoError(t, err)
+					return
+				}
+				var invalidArgErr *serviceerror.InvalidArgument
+				require.ErrorAs(t, err, &invalidArgErr)
+				require.Contains(t, invalidArgErr.Message, tc.expectedErr)
+			})
+		}
+
+		t.Run("LongPollTokenFromWrongExecution", func(t *testing.T) {
+			validPollResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  existingNamespace,
+				ActivityId: existingActivityID,
+				RunId:      existingRunID,
+			})
+			require.NoError(t, err)
+			require.NotEmpty(t, validPollResp.LongPollToken)
+
+			activityID2 := env.Tv().Any().String()
+			startResp2, err := env.startActivity(ctx, activityID2, tq.Name)
+			require.NoError(t, err)
+			require.NotEmpty(t, startResp2.GetRunId())
+
+			_, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:     existingNamespace,
+				ActivityId:    activityID2,
+				RunId:         startResp2.GetRunId(),
+				LongPollToken: validPollResp.LongPollToken,
+			})
+			var invalidArgErr *serviceerror.InvalidArgument
+			require.ErrorAs(t, err, &invalidArgErr)
+			require.Equal(t, "long poll token does not match execution", invalidArgErr.Message)
+		})
+
+		t.Run("LongPollTokenFromDifferentNamespace", func(t *testing.T) {
+			// Get a valid poll token from activity in main namespace
+			validPollResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  existingNamespace,
+				ActivityId: existingActivityID,
+				RunId:      existingRunID,
+			})
+			require.NoError(t, err)
+			require.NotEmpty(t, validPollResp.LongPollToken)
+
+			// Start an activity in a different namespace
+			externalNamespace := env.ExternalNamespace().String()
+			externalActivityID := env.Tv().Any().String()
+			externalStartResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+				Namespace:    externalNamespace,
+				ActivityId:   externalActivityID,
+				ActivityType: env.Tv().ActivityType(),
+				Identity:     env.Tv().WorkerIdentity(),
+				Input:        defaultInput,
+				TaskQueue: &taskqueuepb.TaskQueue{
+					Name: tq.Name,
+				},
+				StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+				RequestId:           env.Tv().Any().String(),
+			})
+			require.NoError(t, err)
+			require.NotEmpty(t, externalStartResp.GetRunId())
+
+			// Try to use main namespace's poll token with external namespace's activity
+			_, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:     externalNamespace,
+				ActivityId:    externalActivityID,
+				RunId:         externalStartResp.GetRunId(),
+				LongPollToken: validPollResp.LongPollToken,
+			})
+			var invalidArgErr *serviceerror.InvalidArgument
+			require.ErrorAs(t, err, &invalidArgErr)
+			require.Equal(t, "long poll token does not match execution", invalidArgErr.Message)
+		})
+	})
 }
 
 func (s *standaloneActivityTestSuite) TestPollActivityExecution() {
@@ -4168,343 +4650,6 @@ func (s *standaloneActivityTestSuite) TestCountActivityExecutions() {
 			Query:     "",
 		})
 		s.ErrorAs(err, new(*serviceerror.NamespaceNotFound))
-	})
-}
-
-func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_DeadlineExceeded() {
-	env := s.newTestEnv()
-	t := s.T()
-	ctx := testcore.NewContext()
-
-	// Start an activity and get initial long-poll state token
-	activityID := env.Tv().ActivityID()
-	taskQueue := env.Tv().TaskQueue()
-	startResp, err := env.startActivity(ctx, activityID, taskQueue.Name)
-	require.NoError(t, err)
-	describeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-		Namespace:  env.Namespace().String(),
-		ActivityId: activityID,
-		RunId:      startResp.RunId,
-	})
-	require.NoError(t, err)
-
-	// The DescribeActivityExecution calls below use a long-poll token and will necessarily time out,
-	// because the activity undergoes no further state transitions.
-
-	// The timeout imposed by the server is essentially
-	// Min(CallerTimeout - LongPollBuffer, LongPollTimeout)
-
-	// Case 1: Caller sets a deadline which has room for the buffer. History returns empty success
-	// result with at least buffer remaining before the caller deadline.
-	t.Run("CallerDeadlineNotExceeded", func(t *testing.T) {
-		// CallerTimeout - LongPollBuffer is far in the future
-		cleanup1 := env.OverrideDynamicConfig(activity.LongPollBuffer, 1*time.Second)
-		defer cleanup1()
-		ctx, cancel := context.WithTimeout(ctx, 9999*time.Millisecond)
-		defer cancel()
-
-		// DescribeActivityExecution will return when this long poll timeout expires.
-		cleanup2 := env.OverrideDynamicConfig(activity.LongPollTimeout, 10*time.Millisecond)
-		defer cleanup2()
-
-		describeResp, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:     env.Namespace().String(),
-			ActivityId:    activityID,
-			RunId:         startResp.RunId,
-			LongPollToken: describeResp.LongPollToken,
-		})
-		// The server uses an empty non-error response to indicate to the caller that it should resubmit
-		// its long-poll.
-		require.NoError(t, err)
-		require.Empty(t, describeResp.GetInfo())
-	})
-
-	// Case 2: caller does not set a deadline. In practice this is equivalent to them setting a 30s
-	// deadline since that is what Histry receives. In this case History times out the wait at
-	// LongPollTimeout and the caller gets an empty response.
-	t.Run("NoCallerDeadline", func(t *testing.T) {
-		// The caller sets no deadline. However, the ctx received by the history service handler
-		// will have a 30s deadline that was applied by one of the upstream server layers, so we
-		// still must use a buffer < 30s.
-		ctx := context.Background()
-		cleanup1 := env.OverrideDynamicConfig(activity.LongPollBuffer, 29*time.Second)
-		defer cleanup1()
-		// DescribeActivityExecution will return when this long poll timeout expires.
-		cleanup2 := env.OverrideDynamicConfig(activity.LongPollTimeout, 10*time.Millisecond)
-		defer cleanup2()
-
-		_, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:     env.Namespace().String(),
-			ActivityId:    activityID,
-			RunId:         startResp.RunId,
-			LongPollToken: describeResp.LongPollToken,
-		})
-		require.NoError(t, err)
-		require.Empty(t, describeResp.GetInfo())
-	})
-
-	// Case 3: caller sets a deadline that is < the buffer. In this case DescribeActivityExecution
-	// will return an empty result immediately, and there is a race between caller receiving that
-	// and caller's client timing out the request. Therefore we do not test this.
-}
-
-func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_NotFound() {
-	env := s.newTestEnv()
-	t := s.T()
-	ctx := testcore.NewContext()
-
-	existingActivityID := env.Tv().ActivityID()
-	tq := env.Tv().TaskQueue()
-	startResp, err := env.startActivity(ctx, existingActivityID, tq.Name)
-	require.NoError(t, err)
-	existingRunID := startResp.RunId
-	require.NotEmpty(t, existingRunID)
-	existingNamespace := env.Namespace().String()
-
-	var notFoundErr *serviceerror.NotFound
-	var namespaceNotFoundErr *serviceerror.NamespaceNotFound
-
-	testCases := []struct {
-		name           string
-		request        *workflowservice.DescribeActivityExecutionRequest
-		expectedErr    error
-		expectedErrMsg string
-	}{
-		{
-			name: "NonExistentNamespace",
-			request: &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:  "non-existent-namespace",
-				ActivityId: existingActivityID,
-				RunId:      existingRunID,
-			},
-			expectedErr:    namespaceNotFoundErr,
-			expectedErrMsg: "Namespace non-existent-namespace is not found.",
-		},
-		{
-			name: "NonExistentActivityID",
-			request: &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:  existingNamespace,
-				ActivityId: "non-existent-activity",
-				RunId:      existingRunID,
-			},
-			expectedErr:    notFoundErr,
-			expectedErrMsg: "activity not found for ID: non-existent-activity",
-		},
-		{
-			name: "NonExistentRunID",
-			request: &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:  existingNamespace,
-				ActivityId: existingActivityID,
-				RunId:      "11111111-2222-3333-4444-555555555555",
-			},
-			expectedErr:    notFoundErr,
-			expectedErrMsg: fmt.Sprintf("activity not found for ID: %s", existingActivityID),
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			_, err := env.FrontendClient().DescribeActivityExecution(ctx, tc.request)
-			require.ErrorAs(t, err, &tc.expectedErr) //nolint:testifylint
-			require.Equal(t, tc.expectedErrMsg, tc.expectedErr.Error())
-		})
-	}
-
-	t.Run("LongPollNonExistentActivity", func(t *testing.T) {
-		// Poll to get a token
-		validPollResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  existingNamespace,
-			ActivityId: existingActivityID,
-			RunId:      existingRunID,
-		})
-		require.NoError(t, err)
-
-		// Use the token with a non-existent activity
-		_, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:     existingNamespace,
-			ActivityId:    "non-existent-activity",
-			RunId:         existingRunID,
-			LongPollToken: validPollResp.LongPollToken,
-		})
-		var notFoundErr *serviceerror.NotFound
-		require.ErrorAs(t, err, &notFoundErr)
-		require.Equal(t, "activity not found for ID: non-existent-activity", notFoundErr.Message)
-	})
-}
-
-func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_InvalidArgument() {
-	env := s.newTestEnv()
-	t := s.T()
-	ctx := testcore.NewContext()
-
-	existingActivityID := env.Tv().ActivityID()
-	tq := env.Tv().TaskQueue()
-	startResp, err := env.startActivity(ctx, existingActivityID, tq.Name)
-	require.NoError(t, err)
-	existingRunID := startResp.RunId
-	require.NotEmpty(t, existingRunID)
-	existingNamespace := env.Namespace().String()
-
-	validActivityID := "activity-id"
-	validRunID := "11111111-2222-3333-4444-555555555555"
-
-	testCases := []struct {
-		name        string
-		request     *workflowservice.DescribeActivityExecutionRequest
-		expectedErr string
-	}{
-		{
-			name: "EmptyNamespace",
-			request: &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:  "",
-				ActivityId: validActivityID,
-				RunId:      validRunID,
-			},
-			expectedErr: "Namespace is empty",
-		},
-		{
-			name: "EmptyActivityID",
-			request: &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:  existingNamespace,
-				ActivityId: "",
-				RunId:      validRunID,
-			},
-			expectedErr: "activity ID is required",
-		},
-		{
-			name: "ActivityIDTooLong",
-			request: &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:  existingNamespace,
-				ActivityId: string(make([]byte, 2000)),
-				RunId:      validRunID,
-			},
-			expectedErr: "activity ID exceeds length limit",
-		},
-		{
-			name: "InvalidRunID",
-			request: &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:  existingNamespace,
-				ActivityId: validActivityID,
-				RunId:      "invalid-uuid",
-			},
-			expectedErr: "invalid run id",
-		},
-		{
-			name: "RunIdNotRequiredWhenWaitPolicyAbsent",
-			request: &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:  existingNamespace,
-				ActivityId: existingActivityID,
-				RunId:      "",
-			},
-			expectedErr: "",
-		},
-		{
-			name: "RunIdNotRequiredWhenLongPollTokenAbsent",
-			request: &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:  existingNamespace,
-				ActivityId: existingActivityID,
-				RunId:      "",
-			},
-			expectedErr: "",
-		},
-		{
-			name: "RunIdRequiredWhenLongPollTokenPresent",
-			request: &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:     existingNamespace,
-				ActivityId:    validActivityID,
-				RunId:         "",
-				LongPollToken: []byte("doesn't-matter"),
-			},
-			expectedErr: "run id is required",
-		},
-		{
-			name: "MalformedLongPollToken",
-			request: &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:     existingNamespace,
-				ActivityId:    existingActivityID,
-				RunId:         existingRunID,
-				LongPollToken: []byte("invalid-token"),
-			},
-			expectedErr: "invalid long poll token",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			_, err := env.FrontendClient().DescribeActivityExecution(ctx, tc.request)
-			if tc.expectedErr == "" {
-				require.NoError(t, err)
-				return
-			}
-			var invalidArgErr *serviceerror.InvalidArgument
-			require.ErrorAs(t, err, &invalidArgErr)
-			require.Contains(t, invalidArgErr.Message, tc.expectedErr)
-		})
-	}
-
-	t.Run("LongPollTokenFromWrongExecution", func(t *testing.T) {
-		validPollResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  existingNamespace,
-			ActivityId: existingActivityID,
-			RunId:      existingRunID,
-		})
-		require.NoError(t, err)
-		require.NotEmpty(t, validPollResp.LongPollToken)
-
-		activityID2 := env.Tv().Any().String()
-		startResp2, err := env.startActivity(ctx, activityID2, tq.Name)
-		require.NoError(t, err)
-		require.NotEmpty(t, startResp2.GetRunId())
-
-		_, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:     existingNamespace,
-			ActivityId:    activityID2,
-			RunId:         startResp2.GetRunId(),
-			LongPollToken: validPollResp.LongPollToken,
-		})
-		var invalidArgErr *serviceerror.InvalidArgument
-		require.ErrorAs(t, err, &invalidArgErr)
-		require.Equal(t, "long poll token does not match execution", invalidArgErr.Message)
-	})
-
-	t.Run("LongPollTokenFromDifferentNamespace", func(t *testing.T) {
-		// Get a valid poll token from activity in main namespace
-		validPollResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  existingNamespace,
-			ActivityId: existingActivityID,
-			RunId:      existingRunID,
-		})
-		require.NoError(t, err)
-		require.NotEmpty(t, validPollResp.LongPollToken)
-
-		// Start an activity in a different namespace
-		externalNamespace := env.ExternalNamespace().String()
-		externalActivityID := env.Tv().Any().String()
-		externalStartResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:    externalNamespace,
-			ActivityId:   externalActivityID,
-			ActivityType: env.Tv().ActivityType(),
-			Identity:     env.Tv().WorkerIdentity(),
-			Input:        defaultInput,
-			TaskQueue: &taskqueuepb.TaskQueue{
-				Name: tq.Name,
-			},
-			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-			RequestId:           env.Tv().Any().String(),
-		})
-		require.NoError(t, err)
-		require.NotEmpty(t, externalStartResp.GetRunId())
-
-		// Try to use main namespace's poll token with external namespace's activity
-		_, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:     externalNamespace,
-			ActivityId:    externalActivityID,
-			RunId:         externalStartResp.GetRunId(),
-			LongPollToken: validPollResp.LongPollToken,
-		})
-		var invalidArgErr *serviceerror.InvalidArgument
-		require.ErrorAs(t, err, &invalidArgErr)
-		require.Equal(t, "long poll token does not match execution", invalidArgErr.Message)
 	})
 }
 


### PR DESCRIPTION
## What changed?
- Added `sdk_name`/`sdk_version` to `ActivityAttemptState and `ActivityExecutionInfo` (via the companion api PR).
- Added `chasm.Context.RequestHeader(key) string` so transitions can read inbound gRPC metadata directly.
- `TransitionStarted` stamps `client-name`/`client-version` onto the attempt; `buildActivityExecutionInfo` expose them through `DescribeActivityExecution`. Overwritten per attempt.
- Consolidated the scattered `TestDescribeActivityExecution_*` methods into one parent with parallel subtests.

## Why?
Standalone Activities had no way to convey which SDK ran a given activity. The SDK already sends `client-name`/`client-version` on every poll and `headers.Propagate` carries them to history, so the only missing piece was a way for the CHASM transition to read them.

`RequestHeader(key)` is intentionally narrow: gRPC metadata lives in the Go context under an unexported key that `chasm.Context.Value()` can't reach. A single-purpose accessor for inbound transport metadata captures what we need without opening that door.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [X] added new functional test(s)

