### PR TITLE
[CHASM Visibility] Filter nil values from memo

### DIFF
--- a/chasm/visibility.go
+++ b/chasm/visibility.go
@@ -169,10 +169,13 @@ func NewVisibilityWithData(
 			&commonpb.SearchAttributes{IndexedFields: filteredSA},
 		)
 	}
-	if len(customMemo) != 0 {
+
+	// Filter out nil/empty payload values for memo.
+	filteredMemo := payload.MergeMapOfPayload(nil, customMemo)
+	if len(filteredMemo) != 0 {
 		visibility.Memo = NewDataField(
 			mutableContext,
-			&commonpb.Memo{Fields: customMemo},
+			&commonpb.Memo{Fields: filteredMemo},
 		)
 	}
 
@@ -307,7 +310,10 @@ func (v *Visibility) ReplaceCustomMemo(
 	mutableContext MutableContext,
 	customMemo map[string]*commonpb.Payload,
 ) {
-	if len(customMemo) == 0 {
+	// Filter out nil/empty payload values for memo.
+	filteredMemo := payload.MergeMapOfPayload(nil, customMemo)
+
+	if len(filteredMemo) == 0 {
 		_, ok := v.Memo.TryGet(mutableContext)
 		if !ok {
 			// Already empty, no-op
@@ -318,7 +324,7 @@ func (v *Visibility) ReplaceCustomMemo(
 	} else {
 		v.Memo = NewDataField(
 			mutableContext,
-			&commonpb.Memo{Fields: customMemo},
+			&commonpb.Memo{Fields: filteredMemo},
 		)
 	}
 

--- a/chasm/visibility_test.go
+++ b/chasm/visibility_test.go
@@ -139,7 +139,7 @@ func (s *visibilitySuite) TestNewVisibilityWithData_FilterNilSearchAttributes() 
 		"nilKey1": nil,
 		"nilKey2": nil,
 	}
-	// Memo with 1 valid and 2 nil values - nil values should NOT be filtered out
+	// Memo with 1 valid and 2 nil values - nil values should be filtered out
 	customMemo := map[string]*commonpb.Payload{
 		stringKey: s.mustEncode(stringVal),
 		"nilKey1": nil,
@@ -149,8 +149,8 @@ func (s *visibilitySuite) TestNewVisibilityWithData_FilterNilSearchAttributes() 
 	// SA should have only 1 field (nil values filtered out)
 	s.Len(visibility.SA.Get(s.mockContext).IndexedFields, 1)
 	s.NotNil(visibility.SA.Get(s.mockContext).IndexedFields[stringKey])
-	// Memo should have all 3 fields (nil values NOT filtered)
-	s.Len(visibility.Memo.Get(s.mockContext).Fields, 3)
+	// Memo should have only 1 field (nil values filtered out)
+	s.Len(visibility.Memo.Get(s.mockContext).Fields, 1)
 	s.NotNil(visibility.Memo.Get(s.mockContext).Fields[stringKey])
 }
 
@@ -314,8 +314,9 @@ func (s *visibilitySuite) TestReplaceCustomMemo() {
 	s.visibility.ReplaceCustomMemo(
 		s.mockMutableContext,
 		map[string]*commonpb.Payload{
-			floatKey: s.mustEncode(floatVal),
-			byteKey:  s.mustEncode(byteVal),
+			floatKey:  s.mustEncode(floatVal),
+			byteKey:   s.mustEncode(byteVal),
+			stringKey: nil, // nil value must be filtered out
 		},
 	)
 	s.Len(s.mockMutableContext.Tasks, 2)


### PR DESCRIPTION
## What changed?
Remove keys with `nil` value from the memo when instantiating CHASM Visibility.

## Why?
`nil` value is used to remove keys from the memo, and it needs to match the behavior in workflows.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

