### PR TITLE
Remove one more WithFxOptionsForService from tests/dlq_test.go

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -311,6 +311,8 @@ type (
 	FaultInjectionTarget struct {
 		Store  DataStoreName
 		Method string
+		// Request is optionally populated by fault injection wrappers for request-aware faults.
+		Request any
 	}
 
 	// FaultInjectionTargets is the set of targets for fault injection. A target is a method of a data store.

--- a/common/persistence/faultinjection/cluster_metadata_store_gen.go
+++ b/common/persistence/faultinjection/cluster_metadata_store_gen.go
@@ -33,7 +33,7 @@ func newFaultInjectionClusterMetadataStore(
 
 // DeleteClusterMetadata wraps ClusterMetadataStore.DeleteClusterMetadata.
 func (d faultInjectionClusterMetadataStore) DeleteClusterMetadata(ctx context.Context, request *_sourcePersistence.InternalDeleteClusterMetadataRequest) (err error) {
-	err = d.generator.generate("DeleteClusterMetadata").inject(func() error {
+	err = d.generator.generate("DeleteClusterMetadata", request).inject(func() error {
 		err = d.ClusterMetadataStore.DeleteClusterMetadata(ctx, request)
 		return err
 	})
@@ -42,7 +42,7 @@ func (d faultInjectionClusterMetadataStore) DeleteClusterMetadata(ctx context.Co
 
 // GetClusterMembers wraps ClusterMetadataStore.GetClusterMembers.
 func (d faultInjectionClusterMetadataStore) GetClusterMembers(ctx context.Context, request *_sourcePersistence.GetClusterMembersRequest) (gp1 *_sourcePersistence.GetClusterMembersResponse, err error) {
-	err = d.generator.generate("GetClusterMembers").inject(func() error {
+	err = d.generator.generate("GetClusterMembers", request).inject(func() error {
 		gp1, err = d.ClusterMetadataStore.GetClusterMembers(ctx, request)
 		return err
 	})
@@ -51,7 +51,7 @@ func (d faultInjectionClusterMetadataStore) GetClusterMembers(ctx context.Contex
 
 // GetClusterMetadata wraps ClusterMetadataStore.GetClusterMetadata.
 func (d faultInjectionClusterMetadataStore) GetClusterMetadata(ctx context.Context, request *_sourcePersistence.InternalGetClusterMetadataRequest) (ip1 *_sourcePersistence.InternalGetClusterMetadataResponse, err error) {
-	err = d.generator.generate("GetClusterMetadata").inject(func() error {
+	err = d.generator.generate("GetClusterMetadata", request).inject(func() error {
 		ip1, err = d.ClusterMetadataStore.GetClusterMetadata(ctx, request)
 		return err
 	})
@@ -60,7 +60,7 @@ func (d faultInjectionClusterMetadataStore) GetClusterMetadata(ctx context.Conte
 
 // ListClusterMetadata wraps ClusterMetadataStore.ListClusterMetadata.
 func (d faultInjectionClusterMetadataStore) ListClusterMetadata(ctx context.Context, request *_sourcePersistence.InternalListClusterMetadataRequest) (ip1 *_sourcePersistence.InternalListClusterMetadataResponse, err error) {
-	err = d.generator.generate("ListClusterMetadata").inject(func() error {
+	err = d.generator.generate("ListClusterMetadata", request).inject(func() error {
 		ip1, err = d.ClusterMetadataStore.ListClusterMetadata(ctx, request)
 		return err
 	})
@@ -69,7 +69,7 @@ func (d faultInjectionClusterMetadataStore) ListClusterMetadata(ctx context.Cont
 
 // PruneClusterMembership wraps ClusterMetadataStore.PruneClusterMembership.
 func (d faultInjectionClusterMetadataStore) PruneClusterMembership(ctx context.Context, request *_sourcePersistence.PruneClusterMembershipRequest) (err error) {
-	err = d.generator.generate("PruneClusterMembership").inject(func() error {
+	err = d.generator.generate("PruneClusterMembership", request).inject(func() error {
 		err = d.ClusterMetadataStore.PruneClusterMembership(ctx, request)
 		return err
 	})
@@ -78,7 +78,7 @@ func (d faultInjectionClusterMetadataStore) PruneClusterMembership(ctx context.C
 
 // SaveClusterMetadata wraps ClusterMetadataStore.SaveClusterMetadata.
 func (d faultInjectionClusterMetadataStore) SaveClusterMetadata(ctx context.Context, request *_sourcePersistence.InternalSaveClusterMetadataRequest) (b1 bool, err error) {
-	err = d.generator.generate("SaveClusterMetadata").inject(func() error {
+	err = d.generator.generate("SaveClusterMetadata", request).inject(func() error {
 		b1, err = d.ClusterMetadataStore.SaveClusterMetadata(ctx, request)
 		return err
 	})
@@ -87,7 +87,7 @@ func (d faultInjectionClusterMetadataStore) SaveClusterMetadata(ctx context.Cont
 
 // UpsertClusterMembership wraps ClusterMetadataStore.UpsertClusterMembership.
 func (d faultInjectionClusterMetadataStore) UpsertClusterMembership(ctx context.Context, request *_sourcePersistence.UpsertClusterMembershipRequest) (err error) {
-	err = d.generator.generate("UpsertClusterMembership").inject(func() error {
+	err = d.generator.generate("UpsertClusterMembership", request).inject(func() error {
 		err = d.ClusterMetadataStore.UpsertClusterMembership(ctx, request)
 		return err
 	})

--- a/common/persistence/faultinjection/execution_store_gen.go
+++ b/common/persistence/faultinjection/execution_store_gen.go
@@ -33,7 +33,7 @@ func newFaultInjectionExecutionStore(
 
 // AddHistoryTasks wraps ExecutionStore.AddHistoryTasks.
 func (d faultInjectionExecutionStore) AddHistoryTasks(ctx context.Context, request *_sourcePersistence.InternalAddHistoryTasksRequest) (err error) {
-	err = d.generator.generate("AddHistoryTasks").inject(func() error {
+	err = d.generator.generate("AddHistoryTasks", request).inject(func() error {
 		err = d.ExecutionStore.AddHistoryTasks(ctx, request)
 		return err
 	})
@@ -42,7 +42,7 @@ func (d faultInjectionExecutionStore) AddHistoryTasks(ctx context.Context, reque
 
 // AppendHistoryNodes wraps ExecutionStore.AppendHistoryNodes.
 func (d faultInjectionExecutionStore) AppendHistoryNodes(ctx context.Context, request *_sourcePersistence.InternalAppendHistoryNodesRequest) (err error) {
-	err = d.generator.generate("AppendHistoryNodes").inject(func() error {
+	err = d.generator.generate("AppendHistoryNodes", request).inject(func() error {
 		err = d.ExecutionStore.AppendHistoryNodes(ctx, request)
 		return err
 	})
@@ -51,7 +51,7 @@ func (d faultInjectionExecutionStore) AppendHistoryNodes(ctx context.Context, re
 
 // CompleteHistoryTask wraps ExecutionStore.CompleteHistoryTask.
 func (d faultInjectionExecutionStore) CompleteHistoryTask(ctx context.Context, request *_sourcePersistence.CompleteHistoryTaskRequest) (err error) {
-	err = d.generator.generate("CompleteHistoryTask").inject(func() error {
+	err = d.generator.generate("CompleteHistoryTask", request).inject(func() error {
 		err = d.ExecutionStore.CompleteHistoryTask(ctx, request)
 		return err
 	})
@@ -60,7 +60,7 @@ func (d faultInjectionExecutionStore) CompleteHistoryTask(ctx context.Context, r
 
 // ConflictResolveWorkflowExecution wraps ExecutionStore.ConflictResolveWorkflowExecution.
 func (d faultInjectionExecutionStore) ConflictResolveWorkflowExecution(ctx context.Context, request *_sourcePersistence.InternalConflictResolveWorkflowExecutionRequest) (err error) {
-	err = d.generator.generate("ConflictResolveWorkflowExecution").inject(func() error {
+	err = d.generator.generate("ConflictResolveWorkflowExecution", request).inject(func() error {
 		err = d.ExecutionStore.ConflictResolveWorkflowExecution(ctx, request)
 		return err
 	})
@@ -69,7 +69,7 @@ func (d faultInjectionExecutionStore) ConflictResolveWorkflowExecution(ctx conte
 
 // CreateWorkflowExecution wraps ExecutionStore.CreateWorkflowExecution.
 func (d faultInjectionExecutionStore) CreateWorkflowExecution(ctx context.Context, request *_sourcePersistence.InternalCreateWorkflowExecutionRequest) (ip1 *_sourcePersistence.InternalCreateWorkflowExecutionResponse, err error) {
-	err = d.generator.generate("CreateWorkflowExecution").inject(func() error {
+	err = d.generator.generate("CreateWorkflowExecution", request).inject(func() error {
 		ip1, err = d.ExecutionStore.CreateWorkflowExecution(ctx, request)
 		return err
 	})
@@ -78,7 +78,7 @@ func (d faultInjectionExecutionStore) CreateWorkflowExecution(ctx context.Contex
 
 // DeleteCurrentWorkflowExecution wraps ExecutionStore.DeleteCurrentWorkflowExecution.
 func (d faultInjectionExecutionStore) DeleteCurrentWorkflowExecution(ctx context.Context, request *_sourcePersistence.DeleteCurrentWorkflowExecutionRequest) (err error) {
-	err = d.generator.generate("DeleteCurrentWorkflowExecution").inject(func() error {
+	err = d.generator.generate("DeleteCurrentWorkflowExecution", request).inject(func() error {
 		err = d.ExecutionStore.DeleteCurrentWorkflowExecution(ctx, request)
 		return err
 	})
@@ -87,7 +87,7 @@ func (d faultInjectionExecutionStore) DeleteCurrentWorkflowExecution(ctx context
 
 // DeleteHistoryBranch wraps ExecutionStore.DeleteHistoryBranch.
 func (d faultInjectionExecutionStore) DeleteHistoryBranch(ctx context.Context, request *_sourcePersistence.InternalDeleteHistoryBranchRequest) (err error) {
-	err = d.generator.generate("DeleteHistoryBranch").inject(func() error {
+	err = d.generator.generate("DeleteHistoryBranch", request).inject(func() error {
 		err = d.ExecutionStore.DeleteHistoryBranch(ctx, request)
 		return err
 	})
@@ -96,7 +96,7 @@ func (d faultInjectionExecutionStore) DeleteHistoryBranch(ctx context.Context, r
 
 // DeleteHistoryNodes wraps ExecutionStore.DeleteHistoryNodes.
 func (d faultInjectionExecutionStore) DeleteHistoryNodes(ctx context.Context, request *_sourcePersistence.InternalDeleteHistoryNodesRequest) (err error) {
-	err = d.generator.generate("DeleteHistoryNodes").inject(func() error {
+	err = d.generator.generate("DeleteHistoryNodes", request).inject(func() error {
 		err = d.ExecutionStore.DeleteHistoryNodes(ctx, request)
 		return err
 	})
@@ -105,7 +105,7 @@ func (d faultInjectionExecutionStore) DeleteHistoryNodes(ctx context.Context, re
 
 // DeleteReplicationTaskFromDLQ wraps ExecutionStore.DeleteReplicationTaskFromDLQ.
 func (d faultInjectionExecutionStore) DeleteReplicationTaskFromDLQ(ctx context.Context, request *_sourcePersistence.DeleteReplicationTaskFromDLQRequest) (err error) {
-	err = d.generator.generate("DeleteReplicationTaskFromDLQ").inject(func() error {
+	err = d.generator.generate("DeleteReplicationTaskFromDLQ", request).inject(func() error {
 		err = d.ExecutionStore.DeleteReplicationTaskFromDLQ(ctx, request)
 		return err
 	})
@@ -114,7 +114,7 @@ func (d faultInjectionExecutionStore) DeleteReplicationTaskFromDLQ(ctx context.C
 
 // DeleteWorkflowExecution wraps ExecutionStore.DeleteWorkflowExecution.
 func (d faultInjectionExecutionStore) DeleteWorkflowExecution(ctx context.Context, request *_sourcePersistence.DeleteWorkflowExecutionRequest) (err error) {
-	err = d.generator.generate("DeleteWorkflowExecution").inject(func() error {
+	err = d.generator.generate("DeleteWorkflowExecution", request).inject(func() error {
 		err = d.ExecutionStore.DeleteWorkflowExecution(ctx, request)
 		return err
 	})
@@ -123,7 +123,7 @@ func (d faultInjectionExecutionStore) DeleteWorkflowExecution(ctx context.Contex
 
 // ForkHistoryBranch wraps ExecutionStore.ForkHistoryBranch.
 func (d faultInjectionExecutionStore) ForkHistoryBranch(ctx context.Context, request *_sourcePersistence.InternalForkHistoryBranchRequest) (err error) {
-	err = d.generator.generate("ForkHistoryBranch").inject(func() error {
+	err = d.generator.generate("ForkHistoryBranch", request).inject(func() error {
 		err = d.ExecutionStore.ForkHistoryBranch(ctx, request)
 		return err
 	})
@@ -132,7 +132,7 @@ func (d faultInjectionExecutionStore) ForkHistoryBranch(ctx context.Context, req
 
 // GetAllHistoryTreeBranches wraps ExecutionStore.GetAllHistoryTreeBranches.
 func (d faultInjectionExecutionStore) GetAllHistoryTreeBranches(ctx context.Context, request *_sourcePersistence.GetAllHistoryTreeBranchesRequest) (ip1 *_sourcePersistence.InternalGetAllHistoryTreeBranchesResponse, err error) {
-	err = d.generator.generate("GetAllHistoryTreeBranches").inject(func() error {
+	err = d.generator.generate("GetAllHistoryTreeBranches", request).inject(func() error {
 		ip1, err = d.ExecutionStore.GetAllHistoryTreeBranches(ctx, request)
 		return err
 	})
@@ -141,7 +141,7 @@ func (d faultInjectionExecutionStore) GetAllHistoryTreeBranches(ctx context.Cont
 
 // GetCurrentExecution wraps ExecutionStore.GetCurrentExecution.
 func (d faultInjectionExecutionStore) GetCurrentExecution(ctx context.Context, request *_sourcePersistence.GetCurrentExecutionRequest) (ip1 *_sourcePersistence.InternalGetCurrentExecutionResponse, err error) {
-	err = d.generator.generate("GetCurrentExecution").inject(func() error {
+	err = d.generator.generate("GetCurrentExecution", request).inject(func() error {
 		ip1, err = d.ExecutionStore.GetCurrentExecution(ctx, request)
 		return err
 	})
@@ -150,7 +150,7 @@ func (d faultInjectionExecutionStore) GetCurrentExecution(ctx context.Context, r
 
 // GetHistoryTasks wraps ExecutionStore.GetHistoryTasks.
 func (d faultInjectionExecutionStore) GetHistoryTasks(ctx context.Context, request *_sourcePersistence.GetHistoryTasksRequest) (ip1 *_sourcePersistence.InternalGetHistoryTasksResponse, err error) {
-	err = d.generator.generate("GetHistoryTasks").inject(func() error {
+	err = d.generator.generate("GetHistoryTasks", request).inject(func() error {
 		ip1, err = d.ExecutionStore.GetHistoryTasks(ctx, request)
 		return err
 	})
@@ -159,7 +159,7 @@ func (d faultInjectionExecutionStore) GetHistoryTasks(ctx context.Context, reque
 
 // GetHistoryTreeContainingBranch wraps ExecutionStore.GetHistoryTreeContainingBranch.
 func (d faultInjectionExecutionStore) GetHistoryTreeContainingBranch(ctx context.Context, request *_sourcePersistence.InternalGetHistoryTreeContainingBranchRequest) (ip1 *_sourcePersistence.InternalGetHistoryTreeContainingBranchResponse, err error) {
-	err = d.generator.generate("GetHistoryTreeContainingBranch").inject(func() error {
+	err = d.generator.generate("GetHistoryTreeContainingBranch", request).inject(func() error {
 		ip1, err = d.ExecutionStore.GetHistoryTreeContainingBranch(ctx, request)
 		return err
 	})
@@ -168,7 +168,7 @@ func (d faultInjectionExecutionStore) GetHistoryTreeContainingBranch(ctx context
 
 // GetReplicationTasksFromDLQ wraps ExecutionStore.GetReplicationTasksFromDLQ.
 func (d faultInjectionExecutionStore) GetReplicationTasksFromDLQ(ctx context.Context, request *_sourcePersistence.GetReplicationTasksFromDLQRequest) (ip1 *_sourcePersistence.InternalGetReplicationTasksFromDLQResponse, err error) {
-	err = d.generator.generate("GetReplicationTasksFromDLQ").inject(func() error {
+	err = d.generator.generate("GetReplicationTasksFromDLQ", request).inject(func() error {
 		ip1, err = d.ExecutionStore.GetReplicationTasksFromDLQ(ctx, request)
 		return err
 	})
@@ -177,7 +177,7 @@ func (d faultInjectionExecutionStore) GetReplicationTasksFromDLQ(ctx context.Con
 
 // GetWorkflowExecution wraps ExecutionStore.GetWorkflowExecution.
 func (d faultInjectionExecutionStore) GetWorkflowExecution(ctx context.Context, request *_sourcePersistence.GetWorkflowExecutionRequest) (ip1 *_sourcePersistence.InternalGetWorkflowExecutionResponse, err error) {
-	err = d.generator.generate("GetWorkflowExecution").inject(func() error {
+	err = d.generator.generate("GetWorkflowExecution", request).inject(func() error {
 		ip1, err = d.ExecutionStore.GetWorkflowExecution(ctx, request)
 		return err
 	})
@@ -186,7 +186,7 @@ func (d faultInjectionExecutionStore) GetWorkflowExecution(ctx context.Context, 
 
 // IsReplicationDLQEmpty wraps ExecutionStore.IsReplicationDLQEmpty.
 func (d faultInjectionExecutionStore) IsReplicationDLQEmpty(ctx context.Context, request *_sourcePersistence.GetReplicationTasksFromDLQRequest) (b1 bool, err error) {
-	err = d.generator.generate("IsReplicationDLQEmpty").inject(func() error {
+	err = d.generator.generate("IsReplicationDLQEmpty", request).inject(func() error {
 		b1, err = d.ExecutionStore.IsReplicationDLQEmpty(ctx, request)
 		return err
 	})
@@ -195,7 +195,7 @@ func (d faultInjectionExecutionStore) IsReplicationDLQEmpty(ctx context.Context,
 
 // ListConcreteExecutions wraps ExecutionStore.ListConcreteExecutions.
 func (d faultInjectionExecutionStore) ListConcreteExecutions(ctx context.Context, request *_sourcePersistence.ListConcreteExecutionsRequest) (ip1 *_sourcePersistence.InternalListConcreteExecutionsResponse, err error) {
-	err = d.generator.generate("ListConcreteExecutions").inject(func() error {
+	err = d.generator.generate("ListConcreteExecutions", request).inject(func() error {
 		ip1, err = d.ExecutionStore.ListConcreteExecutions(ctx, request)
 		return err
 	})
@@ -204,7 +204,7 @@ func (d faultInjectionExecutionStore) ListConcreteExecutions(ctx context.Context
 
 // PutReplicationTaskToDLQ wraps ExecutionStore.PutReplicationTaskToDLQ.
 func (d faultInjectionExecutionStore) PutReplicationTaskToDLQ(ctx context.Context, request *_sourcePersistence.PutReplicationTaskToDLQRequest) (err error) {
-	err = d.generator.generate("PutReplicationTaskToDLQ").inject(func() error {
+	err = d.generator.generate("PutReplicationTaskToDLQ", request).inject(func() error {
 		err = d.ExecutionStore.PutReplicationTaskToDLQ(ctx, request)
 		return err
 	})
@@ -213,7 +213,7 @@ func (d faultInjectionExecutionStore) PutReplicationTaskToDLQ(ctx context.Contex
 
 // RangeCompleteHistoryTasks wraps ExecutionStore.RangeCompleteHistoryTasks.
 func (d faultInjectionExecutionStore) RangeCompleteHistoryTasks(ctx context.Context, request *_sourcePersistence.RangeCompleteHistoryTasksRequest) (err error) {
-	err = d.generator.generate("RangeCompleteHistoryTasks").inject(func() error {
+	err = d.generator.generate("RangeCompleteHistoryTasks", request).inject(func() error {
 		err = d.ExecutionStore.RangeCompleteHistoryTasks(ctx, request)
 		return err
 	})
@@ -222,7 +222,7 @@ func (d faultInjectionExecutionStore) RangeCompleteHistoryTasks(ctx context.Cont
 
 // RangeDeleteReplicationTaskFromDLQ wraps ExecutionStore.RangeDeleteReplicationTaskFromDLQ.
 func (d faultInjectionExecutionStore) RangeDeleteReplicationTaskFromDLQ(ctx context.Context, request *_sourcePersistence.RangeDeleteReplicationTaskFromDLQRequest) (err error) {
-	err = d.generator.generate("RangeDeleteReplicationTaskFromDLQ").inject(func() error {
+	err = d.generator.generate("RangeDeleteReplicationTaskFromDLQ", request).inject(func() error {
 		err = d.ExecutionStore.RangeDeleteReplicationTaskFromDLQ(ctx, request)
 		return err
 	})
@@ -231,7 +231,7 @@ func (d faultInjectionExecutionStore) RangeDeleteReplicationTaskFromDLQ(ctx cont
 
 // ReadHistoryBranch wraps ExecutionStore.ReadHistoryBranch.
 func (d faultInjectionExecutionStore) ReadHistoryBranch(ctx context.Context, request *_sourcePersistence.InternalReadHistoryBranchRequest) (ip1 *_sourcePersistence.InternalReadHistoryBranchResponse, err error) {
-	err = d.generator.generate("ReadHistoryBranch").inject(func() error {
+	err = d.generator.generate("ReadHistoryBranch", request).inject(func() error {
 		ip1, err = d.ExecutionStore.ReadHistoryBranch(ctx, request)
 		return err
 	})
@@ -240,7 +240,7 @@ func (d faultInjectionExecutionStore) ReadHistoryBranch(ctx context.Context, req
 
 // SetWorkflowExecution wraps ExecutionStore.SetWorkflowExecution.
 func (d faultInjectionExecutionStore) SetWorkflowExecution(ctx context.Context, request *_sourcePersistence.InternalSetWorkflowExecutionRequest) (err error) {
-	err = d.generator.generate("SetWorkflowExecution").inject(func() error {
+	err = d.generator.generate("SetWorkflowExecution", request).inject(func() error {
 		err = d.ExecutionStore.SetWorkflowExecution(ctx, request)
 		return err
 	})
@@ -249,7 +249,7 @@ func (d faultInjectionExecutionStore) SetWorkflowExecution(ctx context.Context, 
 
 // UpdateWorkflowExecution wraps ExecutionStore.UpdateWorkflowExecution.
 func (d faultInjectionExecutionStore) UpdateWorkflowExecution(ctx context.Context, request *_sourcePersistence.InternalUpdateWorkflowExecutionRequest) (err error) {
-	err = d.generator.generate("UpdateWorkflowExecution").inject(func() error {
+	err = d.generator.generate("UpdateWorkflowExecution", request).inject(func() error {
 		err = d.ExecutionStore.UpdateWorkflowExecution(ctx, request)
 		return err
 	})

--- a/common/persistence/faultinjection/fault_generator.go
+++ b/common/persistence/faultinjection/fault_generator.go
@@ -2,6 +2,6 @@ package faultinjection
 
 type (
 	faultGenerator interface {
-		generate(methodName string) *fault
+		generate(methodName string, request ...any) *fault
 	}
 )

--- a/common/persistence/faultinjection/gowrap_template
+++ b/common/persistence/faultinjection/gowrap_template
@@ -24,7 +24,8 @@ func new{{upFirst $decorator}} (
         {{ $methodIdent := (printf "%s.%s" $.Interface.Name $method.Name) }}
         // {{$method.Name}} wraps {{ (printf "%s.%s" $.Interface.Name $method.Name) }}.
         func (d {{$decorator}}) {{$method.Declaration}} {
-            err = d.generator.generate("{{ $method.Name }}").inject(func() error {
+            {{- $request := (index $method.Params 1) }}
+            err = d.generator.generate("{{ $method.Name }}", {{ $request.Name }}).inject(func() error {
                 {{$method.ResultsNames}} = d.{{$.Interface.Name}}.{{$method.Call}}
                 return err
             })

--- a/common/persistence/faultinjection/metadata_store_gen.go
+++ b/common/persistence/faultinjection/metadata_store_gen.go
@@ -33,7 +33,7 @@ func newFaultInjectionMetadataStore(
 
 // CreateNamespace wraps MetadataStore.CreateNamespace.
 func (d faultInjectionMetadataStore) CreateNamespace(ctx context.Context, request *_sourcePersistence.InternalCreateNamespaceRequest) (cp1 *_sourcePersistence.CreateNamespaceResponse, err error) {
-	err = d.generator.generate("CreateNamespace").inject(func() error {
+	err = d.generator.generate("CreateNamespace", request).inject(func() error {
 		cp1, err = d.MetadataStore.CreateNamespace(ctx, request)
 		return err
 	})
@@ -42,7 +42,7 @@ func (d faultInjectionMetadataStore) CreateNamespace(ctx context.Context, reques
 
 // DeleteNamespace wraps MetadataStore.DeleteNamespace.
 func (d faultInjectionMetadataStore) DeleteNamespace(ctx context.Context, request *_sourcePersistence.DeleteNamespaceRequest) (err error) {
-	err = d.generator.generate("DeleteNamespace").inject(func() error {
+	err = d.generator.generate("DeleteNamespace", request).inject(func() error {
 		err = d.MetadataStore.DeleteNamespace(ctx, request)
 		return err
 	})
@@ -51,7 +51,7 @@ func (d faultInjectionMetadataStore) DeleteNamespace(ctx context.Context, reques
 
 // DeleteNamespaceByName wraps MetadataStore.DeleteNamespaceByName.
 func (d faultInjectionMetadataStore) DeleteNamespaceByName(ctx context.Context, request *_sourcePersistence.DeleteNamespaceByNameRequest) (err error) {
-	err = d.generator.generate("DeleteNamespaceByName").inject(func() error {
+	err = d.generator.generate("DeleteNamespaceByName", request).inject(func() error {
 		err = d.MetadataStore.DeleteNamespaceByName(ctx, request)
 		return err
 	})
@@ -60,7 +60,7 @@ func (d faultInjectionMetadataStore) DeleteNamespaceByName(ctx context.Context, 
 
 // GetNamespace wraps MetadataStore.GetNamespace.
 func (d faultInjectionMetadataStore) GetNamespace(ctx context.Context, request *_sourcePersistence.GetNamespaceRequest) (ip1 *_sourcePersistence.InternalGetNamespaceResponse, err error) {
-	err = d.generator.generate("GetNamespace").inject(func() error {
+	err = d.generator.generate("GetNamespace", request).inject(func() error {
 		ip1, err = d.MetadataStore.GetNamespace(ctx, request)
 		return err
 	})
@@ -69,7 +69,7 @@ func (d faultInjectionMetadataStore) GetNamespace(ctx context.Context, request *
 
 // ListNamespaces wraps MetadataStore.ListNamespaces.
 func (d faultInjectionMetadataStore) ListNamespaces(ctx context.Context, request *_sourcePersistence.InternalListNamespacesRequest) (ip1 *_sourcePersistence.InternalListNamespacesResponse, err error) {
-	err = d.generator.generate("ListNamespaces").inject(func() error {
+	err = d.generator.generate("ListNamespaces", request).inject(func() error {
 		ip1, err = d.MetadataStore.ListNamespaces(ctx, request)
 		return err
 	})
@@ -78,7 +78,7 @@ func (d faultInjectionMetadataStore) ListNamespaces(ctx context.Context, request
 
 // RenameNamespace wraps MetadataStore.RenameNamespace.
 func (d faultInjectionMetadataStore) RenameNamespace(ctx context.Context, request *_sourcePersistence.InternalRenameNamespaceRequest) (err error) {
-	err = d.generator.generate("RenameNamespace").inject(func() error {
+	err = d.generator.generate("RenameNamespace", request).inject(func() error {
 		err = d.MetadataStore.RenameNamespace(ctx, request)
 		return err
 	})
@@ -87,7 +87,7 @@ func (d faultInjectionMetadataStore) RenameNamespace(ctx context.Context, reques
 
 // UpdateNamespace wraps MetadataStore.UpdateNamespace.
 func (d faultInjectionMetadataStore) UpdateNamespace(ctx context.Context, request *_sourcePersistence.InternalUpdateNamespaceRequest) (err error) {
-	err = d.generator.generate("UpdateNamespace").inject(func() error {
+	err = d.generator.generate("UpdateNamespace", request).inject(func() error {
 		err = d.MetadataStore.UpdateNamespace(ctx, request)
 		return err
 	})

--- a/common/persistence/faultinjection/method_fault_generator.go
+++ b/common/persistence/faultinjection/method_fault_generator.go
@@ -43,7 +43,7 @@ func newMethodFaultGenerator(faults []fault, seed int64) *methodFaultGenerator {
 	}
 }
 
-func (p *methodFaultGenerator) generate(_ string) *fault {
+func (p *methodFaultGenerator) generate(_ string, _ ...any) *fault {
 	if p.rate <= 0 {
 		return nil
 	}

--- a/common/persistence/faultinjection/nexus_endpoint_store_gen.go
+++ b/common/persistence/faultinjection/nexus_endpoint_store_gen.go
@@ -33,7 +33,7 @@ func newFaultInjectionNexusEndpointStore(
 
 // CreateOrUpdateNexusEndpoint wraps NexusEndpointStore.CreateOrUpdateNexusEndpoint.
 func (d faultInjectionNexusEndpointStore) CreateOrUpdateNexusEndpoint(ctx context.Context, request *_sourcePersistence.InternalCreateOrUpdateNexusEndpointRequest) (err error) {
-	err = d.generator.generate("CreateOrUpdateNexusEndpoint").inject(func() error {
+	err = d.generator.generate("CreateOrUpdateNexusEndpoint", request).inject(func() error {
 		err = d.NexusEndpointStore.CreateOrUpdateNexusEndpoint(ctx, request)
 		return err
 	})
@@ -42,7 +42,7 @@ func (d faultInjectionNexusEndpointStore) CreateOrUpdateNexusEndpoint(ctx contex
 
 // DeleteNexusEndpoint wraps NexusEndpointStore.DeleteNexusEndpoint.
 func (d faultInjectionNexusEndpointStore) DeleteNexusEndpoint(ctx context.Context, request *_sourcePersistence.DeleteNexusEndpointRequest) (err error) {
-	err = d.generator.generate("DeleteNexusEndpoint").inject(func() error {
+	err = d.generator.generate("DeleteNexusEndpoint", request).inject(func() error {
 		err = d.NexusEndpointStore.DeleteNexusEndpoint(ctx, request)
 		return err
 	})
@@ -51,7 +51,7 @@ func (d faultInjectionNexusEndpointStore) DeleteNexusEndpoint(ctx context.Contex
 
 // GetNexusEndpoint wraps NexusEndpointStore.GetNexusEndpoint.
 func (d faultInjectionNexusEndpointStore) GetNexusEndpoint(ctx context.Context, request *_sourcePersistence.GetNexusEndpointRequest) (ip1 *_sourcePersistence.InternalNexusEndpoint, err error) {
-	err = d.generator.generate("GetNexusEndpoint").inject(func() error {
+	err = d.generator.generate("GetNexusEndpoint", request).inject(func() error {
 		ip1, err = d.NexusEndpointStore.GetNexusEndpoint(ctx, request)
 		return err
 	})
@@ -60,7 +60,7 @@ func (d faultInjectionNexusEndpointStore) GetNexusEndpoint(ctx context.Context, 
 
 // ListNexusEndpoints wraps NexusEndpointStore.ListNexusEndpoints.
 func (d faultInjectionNexusEndpointStore) ListNexusEndpoints(ctx context.Context, request *_sourcePersistence.ListNexusEndpointsRequest) (ip1 *_sourcePersistence.InternalListNexusEndpointsResponse, err error) {
-	err = d.generator.generate("ListNexusEndpoints").inject(func() error {
+	err = d.generator.generate("ListNexusEndpoints", request).inject(func() error {
 		ip1, err = d.NexusEndpointStore.ListNexusEndpoints(ctx, request)
 		return err
 	})

--- a/common/persistence/faultinjection/queue_gen.go
+++ b/common/persistence/faultinjection/queue_gen.go
@@ -34,7 +34,7 @@ func newFaultInjectionQueue(
 
 // DeleteMessageFromDLQ wraps Queue.DeleteMessageFromDLQ.
 func (d faultInjectionQueue) DeleteMessageFromDLQ(ctx context.Context, messageID int64) (err error) {
-	err = d.generator.generate("DeleteMessageFromDLQ").inject(func() error {
+	err = d.generator.generate("DeleteMessageFromDLQ", messageID).inject(func() error {
 		err = d.Queue.DeleteMessageFromDLQ(ctx, messageID)
 		return err
 	})
@@ -43,7 +43,7 @@ func (d faultInjectionQueue) DeleteMessageFromDLQ(ctx context.Context, messageID
 
 // DeleteMessagesBefore wraps Queue.DeleteMessagesBefore.
 func (d faultInjectionQueue) DeleteMessagesBefore(ctx context.Context, messageID int64) (err error) {
-	err = d.generator.generate("DeleteMessagesBefore").inject(func() error {
+	err = d.generator.generate("DeleteMessagesBefore", messageID).inject(func() error {
 		err = d.Queue.DeleteMessagesBefore(ctx, messageID)
 		return err
 	})
@@ -52,7 +52,7 @@ func (d faultInjectionQueue) DeleteMessagesBefore(ctx context.Context, messageID
 
 // EnqueueMessage wraps Queue.EnqueueMessage.
 func (d faultInjectionQueue) EnqueueMessage(ctx context.Context, blob *commonpb.DataBlob) (err error) {
-	err = d.generator.generate("EnqueueMessage").inject(func() error {
+	err = d.generator.generate("EnqueueMessage", blob).inject(func() error {
 		err = d.Queue.EnqueueMessage(ctx, blob)
 		return err
 	})
@@ -61,7 +61,7 @@ func (d faultInjectionQueue) EnqueueMessage(ctx context.Context, blob *commonpb.
 
 // EnqueueMessageToDLQ wraps Queue.EnqueueMessageToDLQ.
 func (d faultInjectionQueue) EnqueueMessageToDLQ(ctx context.Context, blob *commonpb.DataBlob) (i1 int64, err error) {
-	err = d.generator.generate("EnqueueMessageToDLQ").inject(func() error {
+	err = d.generator.generate("EnqueueMessageToDLQ", blob).inject(func() error {
 		i1, err = d.Queue.EnqueueMessageToDLQ(ctx, blob)
 		return err
 	})
@@ -70,7 +70,7 @@ func (d faultInjectionQueue) EnqueueMessageToDLQ(ctx context.Context, blob *comm
 
 // Init wraps Queue.Init.
 func (d faultInjectionQueue) Init(ctx context.Context, blob *commonpb.DataBlob) (err error) {
-	err = d.generator.generate("Init").inject(func() error {
+	err = d.generator.generate("Init", blob).inject(func() error {
 		err = d.Queue.Init(ctx, blob)
 		return err
 	})
@@ -79,7 +79,7 @@ func (d faultInjectionQueue) Init(ctx context.Context, blob *commonpb.DataBlob) 
 
 // RangeDeleteMessagesFromDLQ wraps Queue.RangeDeleteMessagesFromDLQ.
 func (d faultInjectionQueue) RangeDeleteMessagesFromDLQ(ctx context.Context, firstMessageID int64, lastMessageID int64) (err error) {
-	err = d.generator.generate("RangeDeleteMessagesFromDLQ").inject(func() error {
+	err = d.generator.generate("RangeDeleteMessagesFromDLQ", firstMessageID).inject(func() error {
 		err = d.Queue.RangeDeleteMessagesFromDLQ(ctx, firstMessageID, lastMessageID)
 		return err
 	})
@@ -88,7 +88,7 @@ func (d faultInjectionQueue) RangeDeleteMessagesFromDLQ(ctx context.Context, fir
 
 // ReadMessages wraps Queue.ReadMessages.
 func (d faultInjectionQueue) ReadMessages(ctx context.Context, lastMessageID int64, maxCount int) (qpa1 []*_sourcePersistence.QueueMessage, err error) {
-	err = d.generator.generate("ReadMessages").inject(func() error {
+	err = d.generator.generate("ReadMessages", lastMessageID).inject(func() error {
 		qpa1, err = d.Queue.ReadMessages(ctx, lastMessageID, maxCount)
 		return err
 	})
@@ -97,7 +97,7 @@ func (d faultInjectionQueue) ReadMessages(ctx context.Context, lastMessageID int
 
 // ReadMessagesFromDLQ wraps Queue.ReadMessagesFromDLQ.
 func (d faultInjectionQueue) ReadMessagesFromDLQ(ctx context.Context, firstMessageID int64, lastMessageID int64, pageSize int, pageToken []byte) (qpa1 []*_sourcePersistence.QueueMessage, ba1 []byte, err error) {
-	err = d.generator.generate("ReadMessagesFromDLQ").inject(func() error {
+	err = d.generator.generate("ReadMessagesFromDLQ", firstMessageID).inject(func() error {
 		qpa1, ba1, err = d.Queue.ReadMessagesFromDLQ(ctx, firstMessageID, lastMessageID, pageSize, pageToken)
 		return err
 	})
@@ -106,7 +106,7 @@ func (d faultInjectionQueue) ReadMessagesFromDLQ(ctx context.Context, firstMessa
 
 // UpdateAckLevel wraps Queue.UpdateAckLevel.
 func (d faultInjectionQueue) UpdateAckLevel(ctx context.Context, metadata *_sourcePersistence.InternalQueueMetadata) (err error) {
-	err = d.generator.generate("UpdateAckLevel").inject(func() error {
+	err = d.generator.generate("UpdateAckLevel", metadata).inject(func() error {
 		err = d.Queue.UpdateAckLevel(ctx, metadata)
 		return err
 	})
@@ -115,7 +115,7 @@ func (d faultInjectionQueue) UpdateAckLevel(ctx context.Context, metadata *_sour
 
 // UpdateDLQAckLevel wraps Queue.UpdateDLQAckLevel.
 func (d faultInjectionQueue) UpdateDLQAckLevel(ctx context.Context, metadata *_sourcePersistence.InternalQueueMetadata) (err error) {
-	err = d.generator.generate("UpdateDLQAckLevel").inject(func() error {
+	err = d.generator.generate("UpdateDLQAckLevel", metadata).inject(func() error {
 		err = d.Queue.UpdateDLQAckLevel(ctx, metadata)
 		return err
 	})

--- a/common/persistence/faultinjection/queue_v2_gen.go
+++ b/common/persistence/faultinjection/queue_v2_gen.go
@@ -33,7 +33,7 @@ func newFaultInjectionQueueV2(
 
 // CreateQueue wraps QueueV2.CreateQueue.
 func (d faultInjectionQueueV2) CreateQueue(ctx context.Context, request *_sourcePersistence.InternalCreateQueueRequest) (ip1 *_sourcePersistence.InternalCreateQueueResponse, err error) {
-	err = d.generator.generate("CreateQueue").inject(func() error {
+	err = d.generator.generate("CreateQueue", request).inject(func() error {
 		ip1, err = d.QueueV2.CreateQueue(ctx, request)
 		return err
 	})
@@ -42,7 +42,7 @@ func (d faultInjectionQueueV2) CreateQueue(ctx context.Context, request *_source
 
 // EnqueueMessage wraps QueueV2.EnqueueMessage.
 func (d faultInjectionQueueV2) EnqueueMessage(ctx context.Context, request *_sourcePersistence.InternalEnqueueMessageRequest) (ip1 *_sourcePersistence.InternalEnqueueMessageResponse, err error) {
-	err = d.generator.generate("EnqueueMessage").inject(func() error {
+	err = d.generator.generate("EnqueueMessage", request).inject(func() error {
 		ip1, err = d.QueueV2.EnqueueMessage(ctx, request)
 		return err
 	})
@@ -51,7 +51,7 @@ func (d faultInjectionQueueV2) EnqueueMessage(ctx context.Context, request *_sou
 
 // ListQueues wraps QueueV2.ListQueues.
 func (d faultInjectionQueueV2) ListQueues(ctx context.Context, request *_sourcePersistence.InternalListQueuesRequest) (ip1 *_sourcePersistence.InternalListQueuesResponse, err error) {
-	err = d.generator.generate("ListQueues").inject(func() error {
+	err = d.generator.generate("ListQueues", request).inject(func() error {
 		ip1, err = d.QueueV2.ListQueues(ctx, request)
 		return err
 	})
@@ -60,7 +60,7 @@ func (d faultInjectionQueueV2) ListQueues(ctx context.Context, request *_sourceP
 
 // RangeDeleteMessages wraps QueueV2.RangeDeleteMessages.
 func (d faultInjectionQueueV2) RangeDeleteMessages(ctx context.Context, request *_sourcePersistence.InternalRangeDeleteMessagesRequest) (ip1 *_sourcePersistence.InternalRangeDeleteMessagesResponse, err error) {
-	err = d.generator.generate("RangeDeleteMessages").inject(func() error {
+	err = d.generator.generate("RangeDeleteMessages", request).inject(func() error {
 		ip1, err = d.QueueV2.RangeDeleteMessages(ctx, request)
 		return err
 	})
@@ -69,7 +69,7 @@ func (d faultInjectionQueueV2) RangeDeleteMessages(ctx context.Context, request 
 
 // ReadMessages wraps QueueV2.ReadMessages.
 func (d faultInjectionQueueV2) ReadMessages(ctx context.Context, request *_sourcePersistence.InternalReadMessagesRequest) (ip1 *_sourcePersistence.InternalReadMessagesResponse, err error) {
-	err = d.generator.generate("ReadMessages").inject(func() error {
+	err = d.generator.generate("ReadMessages", request).inject(func() error {
 		ip1, err = d.QueueV2.ReadMessages(ctx, request)
 		return err
 	})

--- a/common/persistence/faultinjection/shard_store_gen.go
+++ b/common/persistence/faultinjection/shard_store_gen.go
@@ -33,7 +33,7 @@ func newFaultInjectionShardStore(
 
 // AssertShardOwnership wraps ShardStore.AssertShardOwnership.
 func (d faultInjectionShardStore) AssertShardOwnership(ctx context.Context, request *_sourcePersistence.AssertShardOwnershipRequest) (err error) {
-	err = d.generator.generate("AssertShardOwnership").inject(func() error {
+	err = d.generator.generate("AssertShardOwnership", request).inject(func() error {
 		err = d.ShardStore.AssertShardOwnership(ctx, request)
 		return err
 	})
@@ -42,7 +42,7 @@ func (d faultInjectionShardStore) AssertShardOwnership(ctx context.Context, requ
 
 // GetOrCreateShard wraps ShardStore.GetOrCreateShard.
 func (d faultInjectionShardStore) GetOrCreateShard(ctx context.Context, request *_sourcePersistence.InternalGetOrCreateShardRequest) (ip1 *_sourcePersistence.InternalGetOrCreateShardResponse, err error) {
-	err = d.generator.generate("GetOrCreateShard").inject(func() error {
+	err = d.generator.generate("GetOrCreateShard", request).inject(func() error {
 		ip1, err = d.ShardStore.GetOrCreateShard(ctx, request)
 		return err
 	})
@@ -51,7 +51,7 @@ func (d faultInjectionShardStore) GetOrCreateShard(ctx context.Context, request 
 
 // UpdateShard wraps ShardStore.UpdateShard.
 func (d faultInjectionShardStore) UpdateShard(ctx context.Context, request *_sourcePersistence.InternalUpdateShardRequest) (err error) {
-	err = d.generator.generate("UpdateShard").inject(func() error {
+	err = d.generator.generate("UpdateShard", request).inject(func() error {
 		err = d.ShardStore.UpdateShard(ctx, request)
 		return err
 	})

--- a/common/persistence/faultinjection/store_fault_generator.go
+++ b/common/persistence/faultinjection/store_fault_generator.go
@@ -69,10 +69,13 @@ func configuredFaultInjector(cfg *config.FaultInjectionDataStoreConfig) faultInj
 
 // generate returns a fault from the first injector that chooses to inject one.
 // When this method returns nil, the persistence layer uses the real implementation.
-func (d *storeFaultInjector) generate(methodName string) *fault {
+func (d *storeFaultInjector) generate(methodName string, requests ...any) *fault {
 	target := config.FaultInjectionTarget{
 		Store:  d.storeName,
 		Method: methodName,
+	}
+	if len(requests) > 0 {
+		target.Request = requests[0]
 	}
 	for _, injector := range d.injectors {
 		if f := injector(target); f != nil {

--- a/common/persistence/faultinjection/task_store_gen.go
+++ b/common/persistence/faultinjection/task_store_gen.go
@@ -33,7 +33,7 @@ func newFaultInjectionTaskStore(
 
 // CompleteTasksLessThan wraps TaskStore.CompleteTasksLessThan.
 func (d faultInjectionTaskStore) CompleteTasksLessThan(ctx context.Context, request *_sourcePersistence.CompleteTasksLessThanRequest) (i1 int, err error) {
-	err = d.generator.generate("CompleteTasksLessThan").inject(func() error {
+	err = d.generator.generate("CompleteTasksLessThan", request).inject(func() error {
 		i1, err = d.TaskStore.CompleteTasksLessThan(ctx, request)
 		return err
 	})
@@ -42,7 +42,7 @@ func (d faultInjectionTaskStore) CompleteTasksLessThan(ctx context.Context, requ
 
 // CountTaskQueuesByBuildId wraps TaskStore.CountTaskQueuesByBuildId.
 func (d faultInjectionTaskStore) CountTaskQueuesByBuildId(ctx context.Context, request *_sourcePersistence.CountTaskQueuesByBuildIdRequest) (i1 int, err error) {
-	err = d.generator.generate("CountTaskQueuesByBuildId").inject(func() error {
+	err = d.generator.generate("CountTaskQueuesByBuildId", request).inject(func() error {
 		i1, err = d.TaskStore.CountTaskQueuesByBuildId(ctx, request)
 		return err
 	})
@@ -51,7 +51,7 @@ func (d faultInjectionTaskStore) CountTaskQueuesByBuildId(ctx context.Context, r
 
 // CreateTaskQueue wraps TaskStore.CreateTaskQueue.
 func (d faultInjectionTaskStore) CreateTaskQueue(ctx context.Context, request *_sourcePersistence.InternalCreateTaskQueueRequest) (err error) {
-	err = d.generator.generate("CreateTaskQueue").inject(func() error {
+	err = d.generator.generate("CreateTaskQueue", request).inject(func() error {
 		err = d.TaskStore.CreateTaskQueue(ctx, request)
 		return err
 	})
@@ -60,7 +60,7 @@ func (d faultInjectionTaskStore) CreateTaskQueue(ctx context.Context, request *_
 
 // CreateTasks wraps TaskStore.CreateTasks.
 func (d faultInjectionTaskStore) CreateTasks(ctx context.Context, request *_sourcePersistence.InternalCreateTasksRequest) (cp1 *_sourcePersistence.CreateTasksResponse, err error) {
-	err = d.generator.generate("CreateTasks").inject(func() error {
+	err = d.generator.generate("CreateTasks", request).inject(func() error {
 		cp1, err = d.TaskStore.CreateTasks(ctx, request)
 		return err
 	})
@@ -69,7 +69,7 @@ func (d faultInjectionTaskStore) CreateTasks(ctx context.Context, request *_sour
 
 // DeleteTaskQueue wraps TaskStore.DeleteTaskQueue.
 func (d faultInjectionTaskStore) DeleteTaskQueue(ctx context.Context, request *_sourcePersistence.DeleteTaskQueueRequest) (err error) {
-	err = d.generator.generate("DeleteTaskQueue").inject(func() error {
+	err = d.generator.generate("DeleteTaskQueue", request).inject(func() error {
 		err = d.TaskStore.DeleteTaskQueue(ctx, request)
 		return err
 	})
@@ -78,7 +78,7 @@ func (d faultInjectionTaskStore) DeleteTaskQueue(ctx context.Context, request *_
 
 // GetTaskQueue wraps TaskStore.GetTaskQueue.
 func (d faultInjectionTaskStore) GetTaskQueue(ctx context.Context, request *_sourcePersistence.InternalGetTaskQueueRequest) (ip1 *_sourcePersistence.InternalGetTaskQueueResponse, err error) {
-	err = d.generator.generate("GetTaskQueue").inject(func() error {
+	err = d.generator.generate("GetTaskQueue", request).inject(func() error {
 		ip1, err = d.TaskStore.GetTaskQueue(ctx, request)
 		return err
 	})
@@ -87,7 +87,7 @@ func (d faultInjectionTaskStore) GetTaskQueue(ctx context.Context, request *_sou
 
 // GetTaskQueueUserData wraps TaskStore.GetTaskQueueUserData.
 func (d faultInjectionTaskStore) GetTaskQueueUserData(ctx context.Context, request *_sourcePersistence.GetTaskQueueUserDataRequest) (ip1 *_sourcePersistence.InternalGetTaskQueueUserDataResponse, err error) {
-	err = d.generator.generate("GetTaskQueueUserData").inject(func() error {
+	err = d.generator.generate("GetTaskQueueUserData", request).inject(func() error {
 		ip1, err = d.TaskStore.GetTaskQueueUserData(ctx, request)
 		return err
 	})
@@ -96,7 +96,7 @@ func (d faultInjectionTaskStore) GetTaskQueueUserData(ctx context.Context, reque
 
 // GetTaskQueuesByBuildId wraps TaskStore.GetTaskQueuesByBuildId.
 func (d faultInjectionTaskStore) GetTaskQueuesByBuildId(ctx context.Context, request *_sourcePersistence.GetTaskQueuesByBuildIdRequest) (sa1 []string, err error) {
-	err = d.generator.generate("GetTaskQueuesByBuildId").inject(func() error {
+	err = d.generator.generate("GetTaskQueuesByBuildId", request).inject(func() error {
 		sa1, err = d.TaskStore.GetTaskQueuesByBuildId(ctx, request)
 		return err
 	})
@@ -105,7 +105,7 @@ func (d faultInjectionTaskStore) GetTaskQueuesByBuildId(ctx context.Context, req
 
 // GetTasks wraps TaskStore.GetTasks.
 func (d faultInjectionTaskStore) GetTasks(ctx context.Context, request *_sourcePersistence.GetTasksRequest) (ip1 *_sourcePersistence.InternalGetTasksResponse, err error) {
-	err = d.generator.generate("GetTasks").inject(func() error {
+	err = d.generator.generate("GetTasks", request).inject(func() error {
 		ip1, err = d.TaskStore.GetTasks(ctx, request)
 		return err
 	})
@@ -114,7 +114,7 @@ func (d faultInjectionTaskStore) GetTasks(ctx context.Context, request *_sourceP
 
 // ListTaskQueue wraps TaskStore.ListTaskQueue.
 func (d faultInjectionTaskStore) ListTaskQueue(ctx context.Context, request *_sourcePersistence.ListTaskQueueRequest) (ip1 *_sourcePersistence.InternalListTaskQueueResponse, err error) {
-	err = d.generator.generate("ListTaskQueue").inject(func() error {
+	err = d.generator.generate("ListTaskQueue", request).inject(func() error {
 		ip1, err = d.TaskStore.ListTaskQueue(ctx, request)
 		return err
 	})
@@ -123,7 +123,7 @@ func (d faultInjectionTaskStore) ListTaskQueue(ctx context.Context, request *_so
 
 // ListTaskQueueUserDataEntries wraps TaskStore.ListTaskQueueUserDataEntries.
 func (d faultInjectionTaskStore) ListTaskQueueUserDataEntries(ctx context.Context, request *_sourcePersistence.ListTaskQueueUserDataEntriesRequest) (ip1 *_sourcePersistence.InternalListTaskQueueUserDataEntriesResponse, err error) {
-	err = d.generator.generate("ListTaskQueueUserDataEntries").inject(func() error {
+	err = d.generator.generate("ListTaskQueueUserDataEntries", request).inject(func() error {
 		ip1, err = d.TaskStore.ListTaskQueueUserDataEntries(ctx, request)
 		return err
 	})
@@ -132,7 +132,7 @@ func (d faultInjectionTaskStore) ListTaskQueueUserDataEntries(ctx context.Contex
 
 // UpdateTaskQueue wraps TaskStore.UpdateTaskQueue.
 func (d faultInjectionTaskStore) UpdateTaskQueue(ctx context.Context, request *_sourcePersistence.InternalUpdateTaskQueueRequest) (up1 *_sourcePersistence.UpdateTaskQueueResponse, err error) {
-	err = d.generator.generate("UpdateTaskQueue").inject(func() error {
+	err = d.generator.generate("UpdateTaskQueue", request).inject(func() error {
 		up1, err = d.TaskStore.UpdateTaskQueue(ctx, request)
 		return err
 	})
@@ -141,7 +141,7 @@ func (d faultInjectionTaskStore) UpdateTaskQueue(ctx context.Context, request *_
 
 // UpdateTaskQueueUserData wraps TaskStore.UpdateTaskQueueUserData.
 func (d faultInjectionTaskStore) UpdateTaskQueueUserData(ctx context.Context, request *_sourcePersistence.InternalUpdateTaskQueueUserDataRequest) (err error) {
-	err = d.generator.generate("UpdateTaskQueueUserData").inject(func() error {
+	err = d.generator.generate("UpdateTaskQueueUserData", request).inject(func() error {
 		err = d.TaskStore.UpdateTaskQueueUserData(ctx, request)
 		return err
 	})

--- a/tests/dlq_test.go
+++ b/tests/dlq_test.go
@@ -25,6 +25,7 @@ import (
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/codec"
+	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/persistence"
@@ -32,7 +33,6 @@ import (
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/testing/await"
-	"go.temporal.io/server/service/history/queues"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/tests/testcore"
 	"go.temporal.io/server/tests/testutils"
@@ -66,13 +66,6 @@ type (
 		targetCluster       string
 		expectedNumMessages int
 	}
-	testExecutorWrapper struct {
-		suite *DLQSuite
-	}
-	testExecutor struct {
-		base  queues.Executor
-		suite *DLQSuite
-	}
 	testTaskQueueManager struct {
 		suite *DLQSuite
 		persistence.HistoryTaskQueueManager
@@ -92,15 +85,21 @@ func (s *DLQSuite) SetupSuite() {
 	testPrefix := "dlq-test-terminal-wfts-"
 	s.failingWorkflowIDPrefix.Store(&testPrefix)
 	s.FunctionalTestBase.SetupSuiteWithCluster(
+		// Return a terminal error that will cause workflow task to be added to the DLQ.
+		testcore.WithFaultInjectionConfig(&config.FaultInjection{
+			Injector: func(target config.FaultInjectionTarget) error {
+				if target.Store != config.ExecutionStoreName || target.Method != "GetWorkflowExecution" {
+					return nil
+				}
+				request, ok := target.Request.(*persistence.GetWorkflowExecutionRequest)
+				if !ok || !strings.HasPrefix(request.WorkflowID, *s.failingWorkflowIDPrefix.Load()) {
+					return nil
+				}
+				return serialization.NewDeserializationError(enumspb.ENCODING_TYPE_PROTO3, errors.New("test error"))
+			},
+		}),
 		testcore.WithFxOptionsForService(primitives.HistoryService,
 			fx.Populate(&s.dlq),
-			fx.Provide(
-				func() queues.ExecutorWrapper {
-					return &testExecutorWrapper{
-						suite: s,
-					}
-				},
-			),
 			fx.Decorate(
 				func(m persistence.HistoryTaskQueueManager) persistence.HistoryTaskQueueManager {
 					return &testTaskQueueManager{
@@ -617,28 +616,6 @@ func (s *DLQSuite) readTransferTasks(file *os.File) []tdbgtest.DLQMessage[*persi
 	})
 	s.NoError(err)
 	return dlqTasks
-}
-
-// Wrap is used to wrap the executor with our own faulty one.
-func (t testExecutorWrapper) Wrap(delegate queues.Executor) queues.Executor {
-	return &testExecutor{
-		base:  delegate,
-		suite: t.suite,
-	}
-}
-
-// Execute is used to wrap the executor so that we can intercept the workflow task and ensure it fails with a terminal
-// error.
-//
-//nolint:err113
-func (t testExecutor) Execute(ctx context.Context, e queues.Executable) queues.ExecuteResponse {
-	if strings.HasPrefix(e.GetWorkflowID(), *t.suite.failingWorkflowIDPrefix.Load()) && e.GetCategory() == tasks.CategoryTransfer {
-		// Return a terminal error that will cause this task to be added to the DLQ.
-		return queues.ExecuteResponse{
-			ExecutionErr: serialization.NewDeserializationError(enumspb.ENCODING_TYPE_PROTO3, errors.New("test error")),
-		}
-	}
-	return t.base.Execute(ctx, e)
 }
 
 // ReadTasks is used to block the dlq job workflow until one of them is cancelled in TestCancelRunningMerge.


### PR DESCRIPTION
## What changed

Replaced one `WithFxOptionsForService` with fault injection.

## Why

We want to eliminate `WithFxOptionsForService` as it is blocking us from migrating away from the `onebox.go` approach (which duplicates the fx setup) since we don't want to expose an equivalent method in `temporal/fx.go`.