### PR TITLE
Migrate TestAddTasks_GetEngineErr to unit test

### DIFF
--- a/service/history/handler_test.go
+++ b/service/history/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.temporal.io/server/api/historyservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/log"
@@ -14,6 +15,7 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/service/history/configs"
+	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tests"
 	"go.uber.org/mock/gomock"
@@ -69,4 +71,24 @@ func TestDescribeHistoryHost(t *testing.T) {
 		ShardId: 2,
 	})
 	assert.NoError(t, err)
+}
+
+func TestAddTasks_GetEngineErr(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	controller := shard.NewMockController(ctrl)
+	shardContext := historyi.NewMockShardContext(ctrl)
+	h := Handler{
+		controller: controller,
+	}
+
+	expectedErr := errors.New("example shard engine error")
+	controller.EXPECT().GetShardByID(int32(1)).Return(shardContext, nil)
+	shardContext.EXPECT().GetEngine(gomock.Any()).Return(nil, expectedErr)
+
+	_, err := h.AddTasks(context.Background(), &historyservice.AddTasksRequest{
+		ShardId: 1,
+	})
+	require.ErrorContains(t, err, expectedErr.Error())
 }

--- a/service/history/handler_test.go
+++ b/service/history/handler_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.temporal.io/server/api/historyservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/log"
@@ -15,7 +14,6 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/service/history/configs"
-	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tests"
 	"go.uber.org/mock/gomock"
@@ -71,24 +69,4 @@ func TestDescribeHistoryHost(t *testing.T) {
 		ShardId: 2,
 	})
 	assert.NoError(t, err)
-}
-
-func TestAddTasks_GetEngineErr(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	controller := shard.NewMockController(ctrl)
-	shardContext := historyi.NewMockShardContext(ctrl)
-	h := Handler{
-		controller: controller,
-	}
-
-	expectedErr := errors.New("example shard engine error")
-	controller.EXPECT().GetShardByID(int32(1)).Return(shardContext, nil)
-	shardContext.EXPECT().GetEngine(gomock.Any()).Return(nil, expectedErr)
-
-	_, err := h.AddTasks(context.Background(), &historyservice.AddTasksRequest{
-		ShardId: 1,
-	})
-	require.ErrorContains(t, err, expectedErr.Error())
 }

--- a/tests/add_tasks_test.go
+++ b/tests/add_tasks_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -19,9 +18,7 @@ import (
 	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/primitives"
-	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/queues"
-	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/tests/testcore"
 	"go.uber.org/fx"
@@ -36,21 +33,11 @@ type (
 	AddTasksSuite struct {
 		testcore.FunctionalTestBase
 
-		shardController *faultyShardController
-		worker          worker.Worker
-		skippedTasks    chan tasks.Task
+		worker       worker.Worker
+		skippedTasks chan tasks.Task
 
-		shouldSkip   atomic.Bool
-		getEngineErr atomic.Pointer[error]
-		workflowID   atomic.Pointer[string]
-	}
-	faultyShardController struct {
-		shard.Controller
-		s *AddTasksSuite
-	}
-	faultyShardContext struct {
-		historyi.ShardContext
-		suite *AddTasksSuite
+		shouldSkip atomic.Bool
+		workflowID atomic.Pointer[string]
 	}
 	// executorWrapper is used to wrap any [queues.Executable] that the history service makes so that we can intercept
 	// workflow tasks.
@@ -68,22 +55,6 @@ type (
 func TestAddTasksSuite(t *testing.T) {
 	t.Parallel()
 	suite.Run(t, new(AddTasksSuite))
-}
-
-func (c *faultyShardController) GetShardByID(shardID int32) (historyi.ShardContext, error) {
-	ctx, err := c.Controller.GetShardByID(shardID)
-	if err != nil {
-		return nil, err
-	}
-	return &faultyShardContext{ShardContext: ctx, suite: c.s}, nil
-}
-
-func (c *faultyShardContext) GetEngine(ctx context.Context) (historyi.Engine, error) {
-	err := c.suite.getEngineErr.Load()
-	if err != nil && *err != nil {
-		return nil, *err
-	}
-	return c.ShardContext.GetEngine(ctx)
 }
 
 // Wrap a [queues.Executable] with the noopExecutor.
@@ -123,12 +94,6 @@ func (s *AddTasksSuite) SetupSuite() {
 		fx.Provide(
 			func() queues.ExecutorWrapper {
 				return &executorWrapper{s: s}
-			},
-		),
-		fx.Decorate(
-			func(c shard.Controller) shard.Controller {
-				s.shardController = &faultyShardController{Controller: c, s: s}
-				return s.shardController
 			},
 		),
 	),
@@ -214,24 +179,10 @@ func (s *AddTasksSuite) TestAddTasks_Ok() {
 	}
 }
 
-var ExampleShardEngineErr = errors.New("example shard engine error")
-
 func (s *AddTasksSuite) TestAddTasks_ErrGetShardByID() {
 	_, err := s.GetTestCluster().HistoryClient().AddTasks(context.Background(), &historyservice.AddTasksRequest{
 		ShardId: 0,
 	})
 	s.Error(err)
 	s.Contains(strings.ToLower(err.Error()), "invalid shardid")
-}
-
-func (s *AddTasksSuite) TestAddTasks_GetEngineErr() {
-	defer func() {
-		s.getEngineErr.Store(nil)
-	}()
-	s.getEngineErr.Store(&ExampleShardEngineErr)
-	_, err := s.GetTestCluster().HistoryClient().AddTasks(context.Background(), &historyservice.AddTasksRequest{
-		ShardId: 1,
-	})
-	s.Error(err)
-	s.ErrorContains(err, (*s.getEngineErr.Load()).Error())
 }


### PR DESCRIPTION
## What changed

Migrated the existing `TestAddTasks_GetEngineErr` functional test to a unit test.

## Why

We want to eliminate `WithFxOptionsForService` as it is blocking us from migrating away from the `onebox.go` approach (which duplicates the fx setup) since we don't want to expose an equivalent method in `temporal/fx.go`.