### PR TITLE
Migrate tests/purge_dlq_tasks_api_test.go

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -301,6 +301,16 @@ type (
 		// This will cause the UpdateShard method of the ShardStore to always return ShardOwnershipLostError.
 		// See config/development-cass-es-fi.yaml for a more detailed example.
 		Targets FaultInjectionTargets `yaml:"targets"`
+
+		// Injector optionally injects faults using runtime code instead of static YAML config.
+		Injector FaultInjector `yaml:"-" json:"-"`
+	}
+
+	FaultInjector func(FaultInjectionTarget) error
+
+	FaultInjectionTarget struct {
+		Store  DataStoreName
+		Method string
 	}
 
 	// FaultInjectionTargets is the set of targets for fault injection. A target is a method of a data store.

--- a/common/persistence/faultinjection/data_store_factory.go
+++ b/common/persistence/faultinjection/data_store_factory.go
@@ -42,10 +42,10 @@ func (d *FaultInjectionDataStoreFactory) NewTaskStore() (persistence.TaskStore, 
 		if err != nil {
 			return nil, err
 		}
-		if storeConfig, ok := d.fiConfig.Targets.DataStores[config.TaskStoreName]; ok && len(storeConfig.Methods) > 0 {
+		if generator, ok := d.storeFaultInjector(config.TaskStoreName); ok {
 			d.taskStore = newFaultInjectionTaskStore(
 				baseStore,
-				newStoreFaultGenerator(&storeConfig),
+				generator,
 			)
 		} else {
 			d.taskStore = baseStore
@@ -60,10 +60,10 @@ func (d *FaultInjectionDataStoreFactory) NewFairTaskStore() (persistence.TaskSto
 		if err != nil {
 			return nil, err
 		}
-		if storeConfig, ok := d.fiConfig.Targets.DataStores[config.TaskStoreName]; ok && len(storeConfig.Methods) > 0 {
+		if generator, ok := d.storeFaultInjector(config.TaskStoreName); ok {
 			d.fairTaskStore = newFaultInjectionTaskStore(
 				baseStore,
-				newStoreFaultGenerator(&storeConfig),
+				generator,
 			)
 		} else {
 			d.fairTaskStore = baseStore
@@ -78,10 +78,10 @@ func (d *FaultInjectionDataStoreFactory) NewShardStore() (persistence.ShardStore
 		if err != nil {
 			return nil, err
 		}
-		if storeConfig, ok := d.fiConfig.Targets.DataStores[config.ShardStoreName]; ok && len(storeConfig.Methods) > 0 {
+		if generator, ok := d.storeFaultInjector(config.ShardStoreName); ok {
 			d.shardStore = newFaultInjectionShardStore(
 				baseStore,
-				newStoreFaultGenerator(&storeConfig),
+				generator,
 			)
 		} else {
 			d.shardStore = baseStore
@@ -95,10 +95,10 @@ func (d *FaultInjectionDataStoreFactory) NewMetadataStore() (persistence.Metadat
 		if err != nil {
 			return nil, err
 		}
-		if storeConfig, ok := d.fiConfig.Targets.DataStores[config.MetadataStoreName]; ok && len(storeConfig.Methods) > 0 {
+		if generator, ok := d.storeFaultInjector(config.MetadataStoreName); ok {
 			d.metadataStore = newFaultInjectionMetadataStore(
 				baseStore,
-				newStoreFaultGenerator(&storeConfig),
+				generator,
 			)
 		} else {
 			d.metadataStore = baseStore
@@ -113,10 +113,10 @@ func (d *FaultInjectionDataStoreFactory) NewExecutionStore() (persistence.Execut
 		if err != nil {
 			return nil, err
 		}
-		if storeConfig, ok := d.fiConfig.Targets.DataStores[config.ExecutionStoreName]; ok && len(storeConfig.Methods) > 0 {
+		if generator, ok := d.storeFaultInjector(config.ExecutionStoreName); ok {
 			d.executionStore = newFaultInjectionExecutionStore(
 				baseStore,
-				newStoreFaultGenerator(&storeConfig),
+				generator,
 			)
 		} else {
 			d.executionStore = baseStore
@@ -131,10 +131,10 @@ func (d *FaultInjectionDataStoreFactory) NewQueue(queueType persistence.QueueTyp
 		if err != nil {
 			return baseQueue, err
 		}
-		if storeConfig, ok := d.fiConfig.Targets.DataStores[config.QueueName]; ok && len(storeConfig.Methods) > 0 {
+		if generator, ok := d.storeFaultInjector(config.QueueName); ok {
 			d.queue = newFaultInjectionQueue(
 				baseQueue,
-				newStoreFaultGenerator(&storeConfig),
+				generator,
 			)
 		} else {
 			d.queue = baseQueue
@@ -149,10 +149,10 @@ func (d *FaultInjectionDataStoreFactory) NewQueueV2() (persistence.QueueV2, erro
 		if err != nil {
 			return baseQueue, err
 		}
-		if storeConfig, ok := d.fiConfig.Targets.DataStores[config.QueueV2Name]; ok && len(storeConfig.Methods) > 0 {
+		if generator, ok := d.storeFaultInjector(config.QueueV2Name); ok {
 			d.queueV2 = newFaultInjectionQueueV2(
 				baseQueue,
-				newStoreFaultGenerator(&storeConfig),
+				generator,
 			)
 		} else {
 			d.queueV2 = baseQueue
@@ -167,10 +167,10 @@ func (d *FaultInjectionDataStoreFactory) NewClusterMetadataStore() (persistence.
 		if err != nil {
 			return nil, err
 		}
-		if storeConfig, ok := d.fiConfig.Targets.DataStores[config.ClusterMDStoreName]; ok && len(storeConfig.Methods) > 0 {
+		if generator, ok := d.storeFaultInjector(config.ClusterMDStoreName); ok {
 			d.clusterMDStore = newFaultInjectionClusterMetadataStore(
 				baseStore,
-				newStoreFaultGenerator(&storeConfig),
+				generator,
 			)
 		} else {
 			d.clusterMDStore = baseStore
@@ -185,14 +185,22 @@ func (d *FaultInjectionDataStoreFactory) NewNexusEndpointStore() (persistence.Ne
 		if err != nil {
 			return nil, err
 		}
-		if storeConfig, ok := d.fiConfig.Targets.DataStores[config.NexusEndpointStoreName]; ok && len(storeConfig.Methods) > 0 {
+		if generator, ok := d.storeFaultInjector(config.NexusEndpointStoreName); ok {
 			d.nexusEndpointStore = newFaultInjectionNexusEndpointStore(
 				baseStore,
-				newStoreFaultGenerator(&storeConfig),
+				generator,
 			)
 		} else {
 			d.nexusEndpointStore = baseStore
 		}
 	}
 	return d.nexusEndpointStore, nil
+}
+
+func (d *FaultInjectionDataStoreFactory) storeFaultInjector(storeName config.DataStoreName) (faultGenerator, bool) {
+	storeConfig, ok := d.fiConfig.Targets.DataStores[storeName]
+	if !ok {
+		storeConfig = config.FaultInjectionDataStoreConfig{}
+	}
+	return newStoreFaultInjector(storeName, &storeConfig, d.fiConfig.Injector)
 }

--- a/common/persistence/faultinjection/store_fault_generator.go
+++ b/common/persistence/faultinjection/store_fault_generator.go
@@ -5,16 +5,51 @@ import (
 )
 
 type (
-	// storeFaultGenerator is an implementation of faultGenerator that will inject errors into the persistence layer
-	// using a per-method configuration.
-	storeFaultGenerator struct {
-		methodFaultGenerators map[string]faultGenerator
+	// storeFaultInjector is an implementation of faultGenerator that will inject errors into the persistence layer
+	// using runtime injectors or per-method configuration.
+	storeFaultInjector struct {
+		storeName config.DataStoreName
+		injectors []faultInjector
 	}
+
+	faultInjector func(config.FaultInjectionTarget) *fault
 )
 
-// newStoreFaultGenerator returns a new instance of a data store error generator that will inject errors
+// newStoreFaultInjector returns a new instance of a data store fault injector that will inject errors
 // into the persistence layer based on the provided configuration.
-func newStoreFaultGenerator(cfg *config.FaultInjectionDataStoreConfig) *storeFaultGenerator {
+func newStoreFaultInjector(
+	storeName config.DataStoreName,
+	cfg *config.FaultInjectionDataStoreConfig,
+	injector config.FaultInjector,
+) (*storeFaultInjector, bool) {
+	var injectors []faultInjector
+	if injector != nil {
+		injectors = append(injectors, runtimeFaultInjector(injector))
+	}
+	if len(cfg.Methods) > 0 {
+		injectors = append(injectors, configuredFaultInjector(cfg))
+	}
+	if len(injectors) == 0 {
+		return nil, false
+	}
+	return &storeFaultInjector{
+		storeName: storeName,
+		injectors: injectors,
+	}, true
+}
+
+func runtimeFaultInjector(injector config.FaultInjector) faultInjector {
+	return func(target config.FaultInjectionTarget) *fault {
+		err := injector(target)
+		if err == nil {
+			return nil
+		}
+		f := newFaultFromError(err, 1.0)
+		return &f
+	}
+}
+
+func configuredFaultInjector(cfg *config.FaultInjectionDataStoreConfig) faultInjector {
 	methodFaultGenerators := make(map[string]faultGenerator, len(cfg.Methods))
 	for methodName, methodConfig := range cfg.Methods {
 		var faults []fault
@@ -23,19 +58,26 @@ func newStoreFaultGenerator(cfg *config.FaultInjectionDataStoreConfig) *storeFau
 		}
 		methodFaultGenerators[methodName] = newMethodFaultGenerator(faults, methodConfig.Seed)
 	}
-	return &storeFaultGenerator{
-		methodFaultGenerators: methodFaultGenerators,
+	return func(target config.FaultInjectionTarget) *fault {
+		methodGenerator, ok := methodFaultGenerators[target.Method]
+		if !ok {
+			return nil
+		}
+		return methodGenerator.generate(target.Method)
 	}
 }
 
-// Generate returns an error from the configured error types and rates for this method.
-// If no errors are configured for the method, or if there are some errors configured for this method,
-// but no error is sampled, then this method returns nil.
-// When this method returns nil, this causes the persistence layer to use the real implementation.
-func (d *storeFaultGenerator) generate(methodName string) *fault {
-	methodGenerator, ok := d.methodFaultGenerators[methodName]
-	if !ok {
-		return nil
+// generate returns a fault from the first injector that chooses to inject one.
+// When this method returns nil, the persistence layer uses the real implementation.
+func (d *storeFaultInjector) generate(methodName string) *fault {
+	target := config.FaultInjectionTarget{
+		Store:  d.storeName,
+		Method: methodName,
 	}
-	return methodGenerator.generate(methodName)
+	for _, injector := range d.injectors {
+		if f := injector(target); f != nil {
+			return f
+		}
+	}
+	return nil
 }

--- a/tests/purge_dlq_tasks_api_test.go
+++ b/tests/purge_dlq_tasks_api_test.go
@@ -1,180 +1,145 @@
 package tests
 
 import (
-	"context"
+	"sync/atomic"
 	"testing"
-	"time"
 
-	"github.com/stretchr/testify/suite"
 	"go.temporal.io/api/serviceerror"
+	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/server/api/adminservice/v1"
 	commonspb "go.temporal.io/server/api/common/v1"
+	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/persistencetest"
 	"go.temporal.io/server/common/primitives"
-	"go.temporal.io/server/common/sdk"
+	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/tests/testcore"
-	"go.uber.org/fx"
 	"google.golang.org/grpc/codes"
 )
 
 type (
 	PurgeDLQTasksSuite struct {
-		testcore.FunctionalTestBase
-
-		dlq              *faultyDLQ
-		sdkClientFactory sdk.ClientFactory
-	}
-	purgeDLQTasksTestCase struct {
-		name      string
-		configure func(p *purgeDLQTasksTestParams)
-	}
-	purgeDLQTasksTestParams struct {
-		category                 tasks.Category
-		sourceCluster            string
-		targetCluster            string
-		maxMessageID             int64
-		apiCallErrorExpectation  func(err error)
-		workflowErrorExpectation func(err error)
-		deleteTasksErr           error
-	}
-	faultyDLQ struct {
-		persistence.HistoryTaskQueueManager
-		err error
+		parallelsuite.Suite[*PurgeDLQTasksSuite]
 	}
 )
 
 func TestPurgeDLQTasksSuite(t *testing.T) {
-	t.Parallel()
-	suite.Run(t, new(PurgeDLQTasksSuite))
-}
-
-func (q *faultyDLQ) DeleteTasks(
-	ctx context.Context,
-	request *persistence.DeleteTasksRequest,
-) (*persistence.DeleteTasksResponse, error) {
-	if q.err != nil {
-		return nil, q.err
-	}
-
-	return q.HistoryTaskQueueManager.DeleteTasks(ctx, request)
-}
-
-func (s *PurgeDLQTasksSuite) SetupSuite() {
-	s.FunctionalTestBase.SetupSuiteWithCluster(
-		testcore.WithFxOptionsForService(primitives.HistoryService,
-			fx.Decorate(func(manager persistence.HistoryTaskQueueManager) persistence.HistoryTaskQueueManager {
-				s.dlq = &faultyDLQ{HistoryTaskQueueManager: manager}
-				return s.dlq
-			}),
-		),
-		testcore.WithFxOptionsForService(primitives.FrontendService,
-			fx.Populate(&s.sdkClientFactory),
-		),
-	)
+	parallelsuite.Run(t, &PurgeDLQTasksSuite{})
 }
 
 func (s *PurgeDLQTasksSuite) TestPurgeDLQTasks() {
-	for _, tc := range []purgeDLQTasksTestCase{
+	var deleteTasksFaultCount atomic.Int32
+	for _, tc := range []struct {
+		name          string
+		envOptions    []testcore.TestOption
+		mutateRequest func(*adminservice.PurgeDLQTasksRequest)
+		apiErr        string
+		workflowErr   string
+		faultCount    *atomic.Int32
+	}{
 		{
-			name: "HappyPath",
+			name:       "HappyPath",
+			envOptions: []testcore.TestOption{testcore.WithWorkerService("purge DLQ workflow")},
 		},
 		{
 			name: "MissingSourceCluster",
-			configure: func(p *purgeDLQTasksTestParams) {
-				p.sourceCluster = ""
-				p.apiCallErrorExpectation = func(err error) {
-					s.Error(err)
-					s.ErrorContains(err, "SourceCluster")
-					s.Equal(codes.InvalidArgument, serviceerror.ToStatus(err).Code())
-				}
+			mutateRequest: func(request *adminservice.PurgeDLQTasksRequest) {
+				request.DlqKey.SourceCluster = ""
 			},
+			apiErr: "SourceCluster",
 		},
 		{
 			name: "MissingTargetCluster",
-			configure: func(p *purgeDLQTasksTestParams) {
-				p.targetCluster = ""
-				p.apiCallErrorExpectation = func(err error) {
-					s.Error(err)
-					s.ErrorContains(err, "TargetCluster")
-					s.Equal(codes.InvalidArgument, serviceerror.ToStatus(err).Code())
-				}
+			mutateRequest: func(request *adminservice.PurgeDLQTasksRequest) {
+				request.DlqKey.TargetCluster = ""
 			},
+			apiErr: "TargetCluster",
 		},
 		{
-			name: "QueueDoesNotExist",
-			configure: func(p *purgeDLQTasksTestParams) {
-				p.targetCluster = "does-not-exist"
-				p.workflowErrorExpectation = func(err error) {
-					s.Error(err)
-					s.ErrorContains(err, "queue not found")
-				}
+			name:       "QueueDoesNotExist",
+			envOptions: []testcore.TestOption{testcore.WithWorkerService("purge DLQ workflow")},
+			mutateRequest: func(request *adminservice.PurgeDLQTasksRequest) {
+				request.DlqKey.TargetCluster = "does-not-exist"
 			},
+			workflowErr: "queue not found",
 		},
 		{
 			name: "DeleteTasksUnavailableError",
-			configure: func(p *purgeDLQTasksTestParams) {
-				p.deleteTasksErr = serviceerror.NewUnavailable("DLQ unavailable")
-				p.workflowErrorExpectation = func(err error) {
-					s.NoError(err)
-				}
+			envOptions: []testcore.TestOption{
+				testcore.WithWorkerService("purge DLQ workflow"),
+				testcore.WithPersistenceFaultInjection(&config.FaultInjection{
+					Injector: func(target config.FaultInjectionTarget) error {
+						if target.Store == config.QueueV2Name &&
+							target.Method == "RangeDeleteMessages" &&
+							deleteTasksFaultCount.CompareAndSwap(0, 1) {
+							return serviceerror.NewUnavailable("DLQ unavailable")
+						}
+						return nil
+					},
+				}),
 			},
+			faultCount: &deleteTasksFaultCount,
 		},
 	} {
-		s.Run(tc.name, func() {
-			defaultParams := s.defaultDlqTestParams()
-
-			params := defaultParams
-			if tc.configure != nil {
-				tc.configure(&params)
-			}
-
-			ctx := context.Background()
-
-			ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-			defer cancel()
+		s.Run(tc.name, func(s *PurgeDLQTasksSuite) {
+			env := testcore.NewEnv(s.T(), tc.envOptions...)
+			defaultQueueKey := persistencetest.GetQueueKey(s.T())
 
 			queueKey := persistence.QueueKey{
 				QueueType:     persistence.QueueTypeHistoryDLQ,
-				Category:      defaultParams.category,
-				SourceCluster: defaultParams.sourceCluster,
-				TargetCluster: defaultParams.targetCluster,
+				Category:      tasks.CategoryTransfer,
+				SourceCluster: defaultQueueKey.SourceCluster,
+				TargetCluster: defaultQueueKey.TargetCluster,
 			}
-			s.enqueueTasks(ctx, queueKey, &tasks.WorkflowTask{})
+			dlq := s.enqueueTasks(env, queueKey, &tasks.WorkflowTask{})
 
-			purgeDLQTasksResponse, err := s.AdminClient().PurgeDLQTasks(ctx, &adminservice.PurgeDLQTasksRequest{
+			request := &adminservice.PurgeDLQTasksRequest{
 				DlqKey: &commonspb.HistoryDLQKey{
-					TaskCategory:  int32(params.category.ID()),
-					SourceCluster: params.sourceCluster,
-					TargetCluster: params.targetCluster,
+					TaskCategory:  int32(tasks.CategoryTransfer.ID()),
+					SourceCluster: defaultQueueKey.SourceCluster,
+					TargetCluster: defaultQueueKey.TargetCluster,
 				},
 				InclusiveMaxTaskMetadata: &commonspb.HistoryDLQTaskMetadata{
 					MessageId: persistence.FirstQueueMessageID + 1,
 				},
-			})
-			if params.apiCallErrorExpectation != nil {
-				params.apiCallErrorExpectation(err)
-				return
+			}
+			if tc.mutateRequest != nil {
+				tc.mutateRequest(request)
 			}
 
+			purgeDLQTasksResponse, err := env.AdminClient().PurgeDLQTasks(s.Context(), request)
+			if tc.apiErr != "" {
+				s.Error(err)
+				s.ErrorContains(err, tc.apiErr)
+				s.Equal(codes.InvalidArgument, serviceerror.ToStatus(err).Code())
+				return
+			}
 			s.NoError(err)
-			client := s.sdkClientFactory.GetSystemClient()
+
+			client, err := sdkclient.NewClientFromExisting(env.SdkClient(), sdkclient.Options{
+				Namespace: primitives.SystemLocalNamespace,
+			})
+			s.NoError(err)
 
 			var jobToken adminservice.DLQJobToken
 			err = jobToken.Unmarshal(purgeDLQTasksResponse.JobToken)
 			s.NoError(err)
 
-			workflow := client.GetWorkflow(ctx, jobToken.WorkflowId, jobToken.RunId)
-
-			err = workflow.Get(ctx, nil)
-			if params.workflowErrorExpectation != nil {
-				params.workflowErrorExpectation(err)
+			workflow := client.GetWorkflow(s.Context(), jobToken.WorkflowId, jobToken.RunId)
+			err = workflow.Get(s.Context(), nil)
+			if tc.workflowErr != "" {
+				s.Error(err)
+				s.ErrorContains(err, tc.workflowErr)
 				return
 			}
-
 			s.NoError(err)
-			readRawTasksResponse, err := s.dlq.ReadRawTasks(ctx, &persistence.ReadRawTasksRequest{
+
+			if tc.faultCount != nil {
+				s.Equal(int32(1), tc.faultCount.Load())
+			}
+
+			readRawTasksResponse, err := dlq.ReadRawTasks(s.Context(), &persistence.ReadRawTasksRequest{
 				QueueKey: queueKey,
 				PageSize: 10,
 			})
@@ -185,30 +150,29 @@ func (s *PurgeDLQTasksSuite) TestPurgeDLQTasks() {
 	}
 }
 
-func (s *PurgeDLQTasksSuite) defaultDlqTestParams() purgeDLQTasksTestParams {
-	queueKey := persistencetest.GetQueueKey(s.T())
+func (s *PurgeDLQTasksSuite) enqueueTasks(
+	env *testcore.TestEnv,
+	queueKey persistence.QueueKey,
+	task *tasks.WorkflowTask,
+) persistence.HistoryTaskQueueManager {
+	dlq, err := env.GetTestCluster().TestBase().Factory.NewHistoryTaskQueueManager()
+	s.NoError(err)
 
-	return purgeDLQTasksTestParams{
-		category:      tasks.CategoryTransfer,
-		sourceCluster: queueKey.SourceCluster,
-		targetCluster: queueKey.TargetCluster,
-	}
-}
-
-func (s *PurgeDLQTasksSuite) enqueueTasks(ctx context.Context, queueKey persistence.QueueKey, task *tasks.WorkflowTask) {
-	_, err := s.dlq.CreateQueue(ctx, &persistence.CreateQueueRequest{
+	_, err = dlq.CreateQueue(s.Context(), &persistence.CreateQueueRequest{
 		QueueKey: queueKey,
 	})
 	s.NoError(err)
 
 	for range 3 {
-		_, err := s.dlq.EnqueueTask(ctx, &persistence.EnqueueTaskRequest{
+		_, err = dlq.EnqueueTask(s.Context(), &persistence.EnqueueTaskRequest{
 			QueueType:     queueKey.QueueType,
 			SourceCluster: queueKey.SourceCluster,
 			TargetCluster: queueKey.TargetCluster,
 			Task:          task,
-			SourceShardID: tasks.GetShardIDForTask(task, int(s.GetTestClusterConfig().HistoryConfig.NumHistoryShards)),
+			SourceShardID: tasks.GetShardIDForTask(task, int(env.GetTestClusterConfig().HistoryConfig.NumHistoryShards)),
 		})
 		s.NoError(err)
 	}
+
+	return dlq
 }

--- a/tests/testcore/onebox.go
+++ b/tests/testcore/onebox.go
@@ -807,7 +807,7 @@ func (c *TemporalImpl) newRPCFactory(
 			grpc.WithChainStreamInterceptor(grpcClientInterceptor.Stream()),
 		)
 	}
-	// Add replication stream recorder interceptor
+	// Add replication stream recorder injector
 	if c.replicationStreamRecorder != nil {
 		options = append(options,
 			grpc.WithChainUnaryInterceptor(c.replicationStreamRecorder.UnaryInterceptor(c.clusterMetadataConfig.CurrentClusterName)),
@@ -950,6 +950,20 @@ func copyPersistenceConfig(cfg config.Persistence) config.Persistence {
 	} else if err = json.Unmarshal(b, &newCfg); err != nil {
 		panic("copy persistence config: " + err.Error())
 	}
+
+	// Preserve fault injection injectors after the JSON copy.
+	for name, dataStore := range cfg.DataStores {
+		if dataStore.FaultInjection == nil {
+			continue
+		}
+		newDataStore := newCfg.DataStores[name]
+		if newDataStore.FaultInjection == nil {
+			newDataStore.FaultInjection = &config.FaultInjection{}
+		}
+		newDataStore.FaultInjection.Injector = dataStore.FaultInjection.Injector
+		newCfg.DataStores[name] = newDataStore
+	}
+
 	return newCfg
 }
 

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -21,6 +21,7 @@ import (
 	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/authorization"
+	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
@@ -131,6 +132,15 @@ func WithWorkerService(reason string) TestOption {
 		o.dedicatedCluster = true
 		o.clusterOptions = append(o.clusterOptions, withWorkerService(true))
 		o.dedicatedReason = "worker service required: " + reason
+	}
+}
+
+// WithPersistenceFaultInjection requests a dedicated cluster with the given persistence fault injection config.
+func WithPersistenceFaultInjection(cfg *config.FaultInjection) TestOption {
+	return func(o *testOptions) {
+		o.dedicatedCluster = true
+		o.clusterOptions = append(o.clusterOptions, WithFaultInjectionConfig(cfg))
+		o.dedicatedReason = "fault injection config used"
 	}
 }
 


### PR DESCRIPTION
## What changed

Migrate `tests/purge_dlq_tasks_api_test.go` to parallelsuite/testEnv; also also remove its use of `WithFxOptionsForService` by allowing to inject custom errors into persistence calls.

## Why

We want to eliminate `WithFxOptionsForService` as it is blocking us from migrating away from the `onebox.go` approach (which duplicates the fx setup) since we don't want to expose an equivalent method in `temporal/fx.go`.