### PR TITLE
time skipping patch: compatible with other features

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -8912,7 +8912,6 @@ func (ms *MutableStateImpl) closeTransactionRegenerateTimerTasksForTimeSkipping(
 ) error {
 	switch transactionPolicy {
 	case historyi.TransactionPolicyActive:
-		// todo@time-skipping: impacts of paused workflow to be considered
 		if !ms.IsWorkflowExecutionRunning() {
 			return nil
 		}
@@ -10073,6 +10072,7 @@ func snapshotTimeSkippingInfo(source *persistencespb.WorkflowExecutionInfo) (*wo
 }
 
 func (ms *MutableStateImpl) hasInflightWorkToPreventTimeSkipping() (bool, string) {
+	// HasPendingWorkflowTask covers both normal and speculative workflow tasks
 	if ms.HasPendingWorkflowTask() {
 		return true, "has pending workflow task"
 	}
@@ -10121,6 +10121,10 @@ func (ms *MutableStateImpl) shouldExecuteTimeSkipping() (bool, *timeSkippingTran
 		noSkippingReason = "workflow is not running"
 		return false, nil
 	}
+	if ms.IsWorkflowExecutionStatusPaused() {
+		noSkippingReason = "workflow is paused"
+		return false, nil
+	}
 	if hasPendingWork, detailedReason := ms.hasInflightWorkToPreventTimeSkipping(); hasPendingWork {
 		noSkippingReason = fmt.Sprintf("pending work: %s", detailedReason)
 		return false, nil
@@ -10154,6 +10158,14 @@ func (d timeSkippingTransition) isValid() bool {
 	return !d.targetTime.IsZero() || d.disabledAfterBound
 }
 
+// calculateTimeSkippingTransition calculates the transition state which includes two fields:
+// 1. targetTime: the time to skip to
+// 2. disabledAfterBound: a flag indicating whether the time skipping should be flipped off
+// right now the time points considered for target time are:
+// 1. the first expiry time of the pending user timers
+// 2. the start delay of the workflow execution
+// 3. the current elapsed duration bound of the time skipping config
+// 4. the remaining time to skip to the max skipped duration bound
 func (ms *MutableStateImpl) calculateTimeSkippingTransition() (timeSkippingTransition, error) {
 	var transition timeSkippingTransition
 	advance := func(candidate time.Time, dueToBound bool) {

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -6631,6 +6631,7 @@ func (s *mutableStateSuite) TestHasInflightWorkToPreventTimeSkipping() {
 		s.True(hasPendingWork)
 		s.Equal("has pending request cancel external", reason)
 	})
+
 }
 
 func (s *mutableStateSuite) TestShouldExecuteTimeSkipping() {
@@ -6748,6 +6749,15 @@ func (s *mutableStateSuite) TestShouldExecuteTimeSkipping() {
 		}
 		s.mutableState.pendingTimerInfoIDs["t1"] = &persistencespb.TimerInfo{TimerId: "t1"}
 		s.True(s.mutableState.shouldExecuteTimeSkipping())
+	})
+
+	s.Run("FalseWhenPaused", func() {
+		s.mutableState.executionState.Status = enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED
+		s.mutableState.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
+			Config: &workflowpb.TimeSkippingConfig{Enabled: true},
+		}
+		s.mutableState.pendingTimerInfoIDs["t1"] = &persistencespb.TimerInfo{TimerId: "t1"}
+		s.False(s.mutableState.shouldExecuteTimeSkipping())
 	})
 }
 

--- a/tests/timeskipping_bound_test.go
+++ b/tests/timeskipping_bound_test.go
@@ -581,6 +581,169 @@ func (s *TimeSkippingBoundFunctionalSuite) TestBound_MaxElapsed_WithActivity() {
 	s.True(bi.GetHasReached())
 }
 
+// TestBound_MaxElapsed_PauseLifecycle exercises the full paused-workflow
+// time-skipping lifecycle and verifies three invariants together:
+//
+//	(1) Pause blocks close-transaction skipping. While paused, no new
+//	    TimeSkippingTransitioned event is added on close-tx — both
+//	    closeTransactionHandleTimeSkipping and shouldExecuteTimeSkipping
+//	    short-circuit on IsWorkflowExecutionStatusPaused.
+//	(2) The MaxElapsed bound's TimeSkippingTimerTask still fires while paused.
+//	    executeTimeSkippingTimerTask only checks IsWorkflowExecutionRunning
+//	    (paused workflows are State=RUNNING), so the disable transition is
+//	    written through pause — analogous to user-timer-fired events firing
+//	    through pause.
+//	(3) The unpause transaction does not trigger an extra skip. Unpause sets
+//	    CreateWorkflowTask=true; the new WFT is scheduled in the same
+//	    transaction, and hasInflightWorkToPreventTimeSkipping returns true
+//	    on the pending WFT, blocking shouldExecuteTimeSkipping.
+//
+// Sequence:
+//
+//	WT1 → start timer1 (29:50). Close-tx fires transition 1 (skip-to-timer1)
+//	      and timer1 fires. Bound wake-up timer task is wall-anchored at
+//	      ~10s real-time from now.
+//	WT2 → schedule activity1. Close-tx: pending activity → no skip.
+//	Pause → activity1 stamp bumped (dispatched task now invalid). Pause
+//	        close-tx is blocked by IsWorkflowExecutionStatusPaused.
+//	(wait) Bound timer task fires while paused → transition 2
+//	       (DisabledAfterBound=true); Config.Enabled becomes false.
+//	Unpause → activity1 re-dispatched, WT3 scheduled in the same tx;
+//	          close-tx pending WFT → no extra transition.
+//	Poll & complete activity1.
+//	WT3 → completeWorkflowCmd.
+//
+// Final history must contain exactly two transitions, in order:
+// (a) skip-to-timer1 (DisabledAfterBound=false), (b) bound-disable.
+func (s *TimeSkippingBoundFunctionalSuite) TestBound_MaxElapsed_PauseLifecycle() {
+	env := testcore.NewEnv(s.T())
+	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	env.OverrideDynamicConfig(dynamicconfig.WorkflowPauseEnabled, true)
+	tv := testvars.New(s.T())
+	ctx := testcore.NewContext()
+
+	const (
+		bound       = 30 * time.Minute
+		timer1Dur   = 29*time.Minute + 50*time.Second
+		minuteToler = time.Minute
+	)
+
+	cfg := &workflowpb.TimeSkippingConfig{
+		Enabled: true,
+		Bound:   &workflowpb.TimeSkippingConfig_MaxElapsedDuration{MaxElapsedDuration: durationpb.New(bound)},
+	}
+	startResp, err := env.FrontendClient().StartWorkflowExecution(ctx, boundStartReq(env, tv, 24*time.Hour, cfg))
+	s.NoError(err)
+	runID := startResp.RunId
+
+	// WT1: start timer1. Close-tx skips to timer1 and timer1 fires.
+	_, err = env.TaskPoller().PollAndHandleWorkflowTask(tv, func(_ *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{
+			Commands: []*commandpb.Command{startTimerCmd("t1", timer1Dur)},
+		}, nil
+	})
+	s.NoError(err)
+
+	// WT2: timer1 fired → schedule activity1. The bound wake-up timer is wall-anchored
+	// at start+bound (~10s real time from this point).
+	_, err = env.TaskPoller().PollAndHandleWorkflowTask(tv, func(_ *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{
+			Commands: []*commandpb.Command{scheduleActivityCmd(tv)},
+		}, nil
+	})
+	s.NoError(err)
+
+	// Pause. Activity1's stamp is bumped: the dispatched matching task becomes
+	// undeliverable until unpause re-generates it. The pause close-tx is blocked
+	// by IsWorkflowExecutionStatusPaused.
+	_, err = env.FrontendClient().PauseWorkflowExecution(ctx, &workflowservice.PauseWorkflowExecutionRequest{
+		Namespace:  env.Namespace().String(),
+		WorkflowId: tv.WorkflowID(),
+		RunId:      runID,
+		Identity:   "test",
+		Reason:     "pause lifecycle test",
+		RequestId:  uuid.NewString(),
+	})
+	s.NoError(err)
+
+	// Wait for the bound TimeSkippingTimerTask to fire while paused. The executor
+	// writes the disable event regardless of pause status: HasReached becomes true
+	// and Config.Enabled becomes false.
+	s.AwaitTruef(func() bool {
+		ms := s.getMutableState(env, tv.WorkflowID(), runID)
+		tsi := ms.State.ExecutionInfo.GetTimeSkippingInfo()
+		bi := tsi.GetCurrentElapsedDurationBound()
+		return bi != nil && bi.GetHasReached()
+	}, 30*time.Second, 200*time.Millisecond, "expected bound timer task to fire while paused")
+
+	// Snapshot history while still paused: exactly two transitions — skip-to-timer1
+	// (from WT1 close-tx) and bound-disable (from the timer task that just fired).
+	// No spurious third transition from any close-tx evaluated under pause.
+	histDuringPause := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{
+		WorkflowId: tv.WorkflowID(), RunId: runID,
+	})
+	s.Len(s.findTransitionedEvents(histDuringPause), 2,
+		"pause must not produce a spurious close-tx transition")
+
+	// Unpause. ApplyUnpaused re-dispatches activity1 (new stamp), the unpause
+	// action sets CreateWorkflowTask=true so a new WFT is scheduled in the same
+	// transaction. The pending WFT keeps hasInflightWorkToPreventTimeSkipping
+	// true through close-tx, so no extra transition fires here either.
+	_, err = env.FrontendClient().UnpauseWorkflowExecution(ctx, &workflowservice.UnpauseWorkflowExecutionRequest{
+		Namespace:  env.Namespace().String(),
+		WorkflowId: tv.WorkflowID(),
+		RunId:      runID,
+		Identity:   "test",
+		Reason:     "unpause lifecycle test",
+		RequestId:  uuid.NewString(),
+	})
+	s.NoError(err)
+
+	// Activity1 is dispatchable again after unpause: poll and complete it.
+	_, err = env.TaskPoller().PollAndHandleActivityTask(tv, taskpoller.CompleteActivityTask(tv))
+	s.NoError(err)
+
+	// WT3: complete the workflow.
+	_, err = env.TaskPoller().PollAndHandleWorkflowTask(tv, func(_ *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{
+			Commands: []*commandpb.Command{completeWorkflowCmd()},
+		}, nil
+	})
+	s.NoError(err)
+
+	hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: tv.WorkflowID(), RunId: runID})
+	transitions := s.findTransitionedEvents(hist)
+	s.Len(transitions, 2, "expected exactly two transitions across the entire lifecycle")
+
+	first := transitions[0].GetWorkflowExecutionTimeSkippingTransitionedEventAttributes()
+	s.False(first.GetDisabledAfterBound())
+	s.NotNil(first.GetTargetTime())
+
+	second := transitions[1].GetWorkflowExecutionTimeSkippingTransitionedEventAttributes()
+	s.True(second.GetDisabledAfterBound(), "second transition must be the bound-disable event")
+
+	s.True(hasEventType(hist, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_PAUSED), "pause event must be in history")
+	s.True(hasEventType(hist, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UNPAUSED), "unpause event must be in history")
+	s.True(hasEventType(hist, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED), "workflow must complete")
+
+	desc, err := env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: tv.WorkflowID(), RunId: runID},
+	})
+	s.NoError(err)
+	startTime := desc.WorkflowExecutionInfo.GetStartTime().AsTime()
+	secondVirtual := transitions[1].GetEventTime().AsTime().Sub(startTime)
+	s.InDelta(float64(bound), float64(secondVirtual), float64(minuteToler))
+
+	ms := s.getMutableState(env, tv.WorkflowID(), runID)
+	tsi := ms.State.ExecutionInfo.GetTimeSkippingInfo()
+	s.NotNil(tsi)
+	s.False(tsi.GetConfig().GetEnabled(), "Config.Enabled must be false after bound reached")
+	bi := tsi.GetCurrentElapsedDurationBound()
+	s.NotNil(bi)
+	s.True(bi.GetHasReached(), "HasReached must be true after bound timer fired")
+}
+
 func (s *TimeSkippingBoundFunctionalSuite) TestBound_MaxElapsed_NoUserTimer() {
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)

--- a/tests/timeskipping_test.go
+++ b/tests/timeskipping_test.go
@@ -674,6 +674,93 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_StartWithDelay() {
 	}
 }
 
+// TestTimeSkipping_CanceledTimerNotUsedAsSkipTarget confirms that a timer
+// canceled via command is excluded from the skip-target calculation.
+// ApplyTimerCanceledEvent deletes the timer from pendingTimerInfoIDs, so it is
+// invisible to calculateTimeSkippingTransition.
+//
+// If a canceled timer were mistakenly used, the accumulated skip would equal
+// the sum of all timers' durations rather than just the surviving timers'.
+//
+// Sequence:
+//
+//	WT1 → start timer-A (1h) + timer-B (5h)
+//	Skip to timer-A (nearest), accumulated = 1h, timer-A fires → WT2
+//	WT2 → cancel timer-B + start timer-C (2h)
+//	Skip to timer-C (2h), accumulated = 1h + 2h = 3h, timer-C fires → WT3
+//	WT3 → complete workflow
+//	Verify: AccumulatedSkippedDuration ≈ 3h (NOT 1h+4h=5h from canceled timer-B)
+func (s *TimeSkippingTestSuite) TestTimeSkipping_CanceledTimerNotUsedAsSkipTarget() {
+	env := testcore.NewEnv(s.T())
+	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	tv := testvars.New(s.T())
+
+	const (
+		timerADuration = time.Hour
+		timerBDuration = 5 * time.Hour
+		timerCDuration = 2 * time.Hour
+		runTimeout     = 10 * time.Hour
+	)
+
+	runID := s.startWorkflowWithTimeSkipping(env, tv, runTimeout)
+	poller := taskpoller.New(s.T(), env.FrontendClient(), env.Namespace().String())
+
+	// WT1: start timer-A (1h) + timer-B (5h). No activity → time skipping fires
+	// on close-tx and targets timer-A (nearest candidate).
+	_, err := poller.PollAndHandleWorkflowTask(tv, func(_ *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{
+			Commands: []*commandpb.Command{
+				startTimerCmd("timer-A", timerADuration),
+				startTimerCmd("timer-B", timerBDuration),
+			},
+		}, nil
+	})
+	s.NoError(err)
+
+	// WT2: timer-A has fired. Cancel timer-B and start timer-C (2h). After this
+	// WFT, only timer-C is a candidate — timer-B is gone from pendingTimerInfoIDs.
+	_, err = poller.PollAndHandleWorkflowTask(tv, func(_ *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{
+			Commands: []*commandpb.Command{
+				{
+					CommandType: enumspb.COMMAND_TYPE_CANCEL_TIMER,
+					Attributes: &commandpb.Command_CancelTimerCommandAttributes{
+						CancelTimerCommandAttributes: &commandpb.CancelTimerCommandAttributes{
+							TimerId: "timer-B",
+						},
+					},
+				},
+				startTimerCmd("timer-C", timerCDuration),
+			},
+		}, nil
+	})
+	s.NoError(err)
+
+	// WT3: timer-C fired (skip targeted it at 2h, not the 4h remaining on
+	// canceled timer-B). Complete workflow.
+	_, err = poller.PollAndHandleWorkflowTask(tv, func(_ *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{
+			Commands: []*commandpb.Command{completeWorkflowCmd()},
+		}, nil
+	})
+	s.NoError(err)
+
+	// Accumulated skip ≈ 1h + 2h = 3h. 1s tolerance covers real-time slack
+	// between skip transition and timer-fired and is far below the 2h margin
+	// between the right answer (3h) and the wrong answer (5h with canceled
+	// timer-B included).
+	ms := s.getMutableState(env, tv.WorkflowID(), runID)
+	accumulated := ms.State.ExecutionInfo.GetTimeSkippingInfo().GetAccumulatedSkippedDuration().AsDuration()
+	s.InDelta(float64(timerADuration+timerCDuration), float64(accumulated), float64(time.Second),
+		"AccumulatedSkippedDuration must equal sum of non-canceled timer durations (1h+2h=3h), not include the canceled timer-B")
+
+	history := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{
+		WorkflowId: tv.WorkflowID(), RunId: runID,
+	})
+	s.True(hasEventType(history, enumspb.EVENT_TYPE_TIMER_CANCELED), "timer-B must be canceled")
+	s.True(hasEventType(history, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED))
+}
+
 // TestWorkflowLifecycle_VirtualTimeContract is an end-to-end regression test
 // that exercises the virtual-time contract across a full workflow lifecycle:
 // activity execution before and after skip, skip transition, workflow close,


### PR DESCRIPTION
## What changed?

1. (pause) define a reasonable behavior of time skipping in a paused workflow: 
(1) when workflow paused, time shall not be skipped
(2) when workflow paused, max elapsed time bound (implemented by a timer task) can still fire to disable the time skipping and add a time skipping transitioned event (consistent with the logic of user timer)
(3) when workflow resumes, time skipping shouldn't be triggered in the same transaction as there should be a new pending workflow task scheduled in the same trx

2. (cancel timer) nit, added a functional test to show canceled user timers won't impact time skipping
2. (update) nit, only add comments for speculative workflow task


## Why?
make sure TS is compatible with all other features which is not directly related

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

