### PR TITLE
Verify child workflow exists in start child standby task

### DIFF
--- a/service/history/ndc_standby_task_util.go
+++ b/service/history/ndc_standby_task_util.go
@@ -157,6 +157,10 @@ type (
 		parentWorkflowKey *definition.WorkflowKey
 	}
 
+	startChildExecutionPostActionInfo struct {
+		childWorkflowKey *definition.WorkflowKey
+	}
+
 	workflowTaskPostActionInfo struct {
 		workflowTaskScheduleToStartTimeout time.Duration
 		taskqueue                          *taskqueuepb.TaskQueue

--- a/service/history/transfer_queue_standby_task_executor.go
+++ b/service/history/transfer_queue_standby_task_executor.go
@@ -495,7 +495,7 @@ func (t *transferQueueStandbyTaskExecutor) processStartChildExecution(
 		}
 
 		if !childStarted {
-			return &struct{}{}, nil
+			return &startChildExecutionPostActionInfo{}, nil
 		}
 
 		if childTargetNamespaceID == "" {
@@ -508,6 +508,11 @@ func (t *transferQueueStandbyTaskExecutor) processStartChildExecution(
 			}
 			childTargetNamespaceID = targetNamespaceEntry.ID().String()
 		}
+		childWorkflowKey := definition.NewWorkflowKey(
+			childTargetNamespaceID,
+			childStartedWorkflowID,
+			childStartedRunID,
+		)
 
 		_, err = t.historyRawClient.VerifyFirstWorkflowTaskScheduled(ctx, &historyservice.VerifyFirstWorkflowTaskScheduledRequest{
 			NamespaceId: childTargetNamespaceID,
@@ -524,7 +529,9 @@ func (t *transferQueueStandbyTaskExecutor) processStartChildExecution(
 		case *serviceerror.NotFound, *serviceerror.WorkflowNotReady:
 			// Case 2: Target workflow is not in the desired state.
 			// Return a non-nil pointer as postActionInfo here to indicate that verification is not done yet.
-			return &struct{}{}, nil
+			return &startChildExecutionPostActionInfo{
+				childWorkflowKey: &childWorkflowKey,
+			}, nil
 		default:
 			// Case 3: Verification itself failed.
 			// NOTE: Wrapping the error as a verification error to prevent mutable state from being cleared and reloaded upon retry,
@@ -545,7 +552,7 @@ func (t *transferQueueStandbyTaskExecutor) processStartChildExecution(
 			transferTask,
 			t.getCurrentTime,
 			t.config.StandbyTaskMissingEventsDiscardDelay(transferTask.GetType()),
-			t.checkExecutionStillExistsOnSourceBeforeDiscard,
+			t.checkStartChildExecutionStillExistsOnSourceBeforeDiscard,
 		),
 	)
 }
@@ -681,6 +688,35 @@ func (t *transferQueueStandbyTaskExecutor) checkExecutionStillExistsOnSourceBefo
 		ctx,
 		taskWorkflowKey(taskInfo),
 		getTaskArchetypeID(taskInfo),
+		logger,
+		t.clusterName,
+		t.clientBean,
+		t.shardContext.GetNamespaceRegistry(),
+		t.shardContext.ChasmRegistry(),
+	) {
+		return standbyTransferTaskPostActionTaskDiscarded(ctx, taskInfo, nil, logger)
+	}
+	return standbyTransferTaskPostActionTaskDiscarded(ctx, taskInfo, postActionInfo, logger)
+}
+
+func (t *transferQueueStandbyTaskExecutor) checkStartChildExecutionStillExistsOnSourceBeforeDiscard(
+	ctx context.Context,
+	taskInfo tasks.Task,
+	postActionInfo any,
+	logger log.Logger,
+) error {
+	if postActionInfo == nil {
+		return nil
+	}
+	startChildInfo, ok := postActionInfo.(*startChildExecutionPostActionInfo)
+	if !ok || startChildInfo.childWorkflowKey == nil {
+		return t.checkExecutionStillExistsOnSourceBeforeDiscard(ctx, taskInfo, postActionInfo, logger)
+	}
+
+	if !executionExistsOnSource(
+		ctx,
+		*startChildInfo.childWorkflowKey,
+		chasm.WorkflowArchetypeID,
 		logger,
 		t.clusterName,
 		t.clientBean,

--- a/service/history/transfer_queue_standby_task_executor_test.go
+++ b/service/history/transfer_queue_standby_task_executor_test.go
@@ -24,6 +24,7 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	workflowspb "go.temporal.io/server/api/workflow/v1"
 	"go.temporal.io/server/chasm"
+	chasmworkflow "go.temporal.io/server/chasm/lib/workflow"
 	"go.temporal.io/server/client"
 	"go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/archiver/provider"
@@ -136,6 +137,8 @@ func (s *transferQueueStandbyTaskExecutorSuite) SetupTest() {
 	err := workflow.RegisterStateMachine(reg)
 	s.NoError(err)
 	s.mockShard.SetStateMachineRegistry(reg)
+	err = s.mockShard.ChasmRegistry().Register(chasmworkflow.NewLibrary(chasmworkflow.NewRegistry()))
+	s.NoError(err)
 
 	s.mockShard.SetEventsCacheForTesting(events.NewHostLevelEventsCache(
 		s.mockShard.GetExecutionManager(),
@@ -1177,7 +1180,8 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessStartChildExecution_P
 	resp = s.transferQueueStandbyTaskExecutor.Execute(context.Background(), s.newTaskExecutable(transferTask))
 	s.Equal(consts.ErrTaskRetry, resp.ExecutionErr)
 
-	event = addChildWorkflowExecutionStartedEvent(mutableState, event.GetEventId(), childWorkflowID, uuid.NewString(), childWorkflowType, nil)
+	childRunID := uuid.NewString()
+	event = addChildWorkflowExecutionStartedEvent(mutableState, event.GetEventId(), childWorkflowID, childRunID, childWorkflowType, nil)
 	mutableState.FlushBufferedEvents()
 
 	// clear the cache
@@ -1208,10 +1212,30 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessStartChildExecution_P
 	var resourceExhaustedErr *serviceerror.ResourceExhausted
 	s.True(errors.As(resp.ExecutionErr, &resourceExhaustedErr))
 
+	childExecution := &commonpb.WorkflowExecution{
+		WorkflowId: childWorkflowID,
+		RunId:      childRunID,
+	}
+	expectedDescribeChildMutableStateRequest := protomock.Eq(&adminservice.DescribeMutableStateRequest{
+		Namespace:       tests.ChildNamespace.String(),
+		Execution:       childExecution,
+		Archetype:       chasm.WorkflowArchetype,
+		SkipForceReload: true,
+	})
+	s.clientBean.EXPECT().GetRemoteAdminClient(
+		tests.GlobalChildNamespaceEntry.ActiveClusterName(namespace.RoutingKey{ID: childWorkflowID}),
+	).Return(s.mockRemoteAdminClient, nil).AnyTimes()
+
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.discardDuration))
 	s.mockHistoryClient.EXPECT().VerifyFirstWorkflowTaskScheduled(gomock.Any(), gomock.Any()).Return(nil, &serviceerror.WorkflowNotReady{})
+	s.mockRemoteAdminClient.EXPECT().DescribeMutableState(gomock.Any(), expectedDescribeChildMutableStateRequest).Return(nil, nil)
 	resp = s.transferQueueStandbyTaskExecutor.Execute(context.Background(), s.newTaskExecutable(transferTask))
 	s.Equal(consts.ErrTaskDiscarded, resp.ExecutionErr)
+
+	s.mockHistoryClient.EXPECT().VerifyFirstWorkflowTaskScheduled(gomock.Any(), gomock.Any()).Return(nil, &serviceerror.WorkflowNotReady{})
+	s.mockRemoteAdminClient.EXPECT().DescribeMutableState(gomock.Any(), expectedDescribeChildMutableStateRequest).Return(nil, &serviceerror.NotFound{})
+	resp = s.transferQueueStandbyTaskExecutor.Execute(context.Background(), s.newTaskExecutable(transferTask))
+	s.NoError(resp.ExecutionErr)
 
 	randomErr := errors.New("some random error")
 	s.mockHistoryClient.EXPECT().VerifyFirstWorkflowTaskScheduled(gomock.Any(), gomock.Any()).Return(nil, randomErr)


### PR DESCRIPTION
## What changed?
Verify child workflow exists in start child standby task.

## Why?
The start child task should verify the exist of child in source cluster.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)