### PR TITLE
CHASM Visibility support for Text type search attribute

### DIFF
--- a/chasm/search_attribute.go
+++ b/chasm/search_attribute.go
@@ -57,6 +57,11 @@ var (
 	SearchAttributeFieldKeywordList01 = newSearchAttributeFieldKeywordList(1)
 	SearchAttributeFieldKeywordList02 = newSearchAttributeFieldKeywordList(2)
 
+	// CHASM search attribute of type Text is not supported at this moment.
+	// SearchAttributeFieldText01 = newSearchAttributeFieldText(1)
+
+	// Predefined search attributes don't have alias.
+	// TaskQueue is a system search attribute outside CHASM, but treated as predefined inside CHASM.
 	SearchAttributeTaskQueue                            = newSearchAttributeKeywordByField(sadefs.TaskQueue)
 	SearchAttributeTemporalChangeVersion                = newSearchAttributeKeywordListByField(sadefs.TemporalChangeVersion)
 	SearchAttributeBinaryChecksums                      = newSearchAttributeKeywordListByField(sadefs.BinaryChecksums)
@@ -76,14 +81,13 @@ var (
 )
 
 var (
-	// CHASM search attribute of type Text is not supported at this moment.
-	// Note that it's currently assumed that string type values are Keyword search attributes.
 	_ SearchAttribute = (*SearchAttributeBool)(nil)
 	_ SearchAttribute = (*SearchAttributeDateTime)(nil)
 	_ SearchAttribute = (*SearchAttributeInt)(nil)
 	_ SearchAttribute = (*SearchAttributeDouble)(nil)
 	_ SearchAttribute = (*SearchAttributeKeyword)(nil)
 	_ SearchAttribute = (*SearchAttributeKeywordList)(nil)
+	_ SearchAttribute = (*SearchAttributeText)(nil)
 
 	_ typedSearchAttribute[bool]      = (*SearchAttributeBool)(nil)
 	_ typedSearchAttribute[time.Time] = (*SearchAttributeDateTime)(nil)
@@ -91,6 +95,7 @@ var (
 	_ typedSearchAttribute[float64]   = (*SearchAttributeDouble)(nil)
 	_ typedSearchAttribute[string]    = (*SearchAttributeKeyword)(nil)
 	_ typedSearchAttribute[[]string]  = (*SearchAttributeKeywordList)(nil)
+	_ typedSearchAttribute[string]    = (*SearchAttributeText)(nil)
 )
 
 type (
@@ -191,6 +196,17 @@ type SearchAttributeFieldKeywordList struct {
 func newSearchAttributeFieldKeywordList(index int) SearchAttributeFieldKeywordList {
 	return SearchAttributeFieldKeywordList{
 		field: resolveFieldName(enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, index),
+	}
+}
+
+// SearchAttributeFieldText is a search attribute field for a text value.
+type SearchAttributeFieldText struct {
+	field string
+}
+
+func newSearchAttributeFieldText(index int) SearchAttributeFieldText {
+	return SearchAttributeFieldText{
+		field: resolveFieldName(enumspb.INDEXED_VALUE_TYPE_TEXT, index),
 	}
 }
 
@@ -415,6 +431,43 @@ func (s SearchAttributeKeywordList) Value(value []string) SearchAttributeKeyValu
 
 func (s SearchAttributeKeywordList) typeMarker(_ []string) {}
 
+// SearchAttributeText is a search attribute for a text value.
+type SearchAttributeText struct {
+	searchAttributeDefinition
+}
+
+// NewSearchAttributeText creates a new text search attribute given a predefined chasm field
+func NewSearchAttributeText(alias string, textField SearchAttributeFieldText) SearchAttributeText {
+	return SearchAttributeText{
+		searchAttributeDefinition: searchAttributeDefinition{
+			alias:     alias,
+			field:     textField.field,
+			valueType: enumspb.INDEXED_VALUE_TYPE_TEXT,
+		},
+	}
+}
+
+func newSearchAttributeTextByField(field string) SearchAttributeText {
+	return SearchAttributeText{
+		searchAttributeDefinition: searchAttributeDefinition{
+			alias:     field,
+			field:     field,
+			valueType: enumspb.INDEXED_VALUE_TYPE_TEXT,
+		},
+	}
+}
+
+// Value sets the string value of the search attribute.
+func (s SearchAttributeText) Value(value string) SearchAttributeKeyValue {
+	return SearchAttributeKeyValue{
+		Alias: s.alias,
+		Field: s.field,
+		Value: VisibilityValueText(value),
+	}
+}
+
+func (s SearchAttributeText) typeMarker(_ string) {}
+
 // SearchAttributesMap wraps search attribute values with type-safe access.
 type SearchAttributesMap struct {
 	values map[string]VisibilityValue
@@ -438,7 +491,7 @@ func newSearchAttributesMapFromProto(
 	for saName, saPayload := range searchAttributes.IndexedFields {
 		value, err := visibilityValueFromPayload(saPayload)
 		if err != nil {
-			return SearchAttributesMap{}, nil
+			return SearchAttributesMap{}, err
 		}
 		result.values[saName] = value
 	}

--- a/chasm/search_attribute_test.go
+++ b/chasm/search_attribute_test.go
@@ -10,6 +10,8 @@ import (
 	"go.temporal.io/server/common/searchattribute/sadefs"
 )
 
+var textField01 = newSearchAttributeFieldText(1)
+
 func TestSearchAttributesMap_Get(t *testing.T) {
 	// Define test search attributes
 	boolAttr := NewSearchAttributeBool("completed", SearchAttributeFieldBool01)
@@ -18,6 +20,7 @@ func TestSearchAttributesMap_Get(t *testing.T) {
 	keywordAttr := NewSearchAttributeKeyword("status", SearchAttributeFieldKeyword01)
 	datetimeAttr := NewSearchAttributeDateTime("timestamp", SearchAttributeFieldDateTime01)
 	keywordListAttr := NewSearchAttributeKeywordList("tags", SearchAttributeFieldKeywordList01)
+	textAttr := NewSearchAttributeText("summary", textField01)
 
 	now := time.Now()
 
@@ -29,6 +32,7 @@ func TestSearchAttributesMap_Get(t *testing.T) {
 		"status":    VisibilityValueKeyword("active"),
 		"timestamp": VisibilityValueTime(now),
 		"tags":      VisibilityValueStringSlice([]string{"tag1", "tag2"}),
+		"summary":   VisibilityValueText("foo bar"),
 	}
 	m := NewSearchAttributesMap(values)
 
@@ -66,6 +70,12 @@ func TestSearchAttributesMap_Get(t *testing.T) {
 		val, ok := SearchAttributeValue(m, keywordListAttr)
 		require.True(t, ok)
 		require.Equal(t, []string{"tag1", "tag2"}, val)
+	})
+
+	t.Run("GetText", func(t *testing.T) {
+		val, ok := SearchAttributeValue(m, textAttr)
+		require.True(t, ok)
+		require.Equal(t, "foo bar", val)
 	})
 
 	t.Run("NotFound", func(t *testing.T) {
@@ -123,6 +133,7 @@ func TestNewSearchAttributesMapFromProto(t *testing.T) {
 				"status":    sadefs.MustEncodeValue("active", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 				"timestamp": sadefs.MustEncodeValue(now, enumspb.INDEXED_VALUE_TYPE_DATETIME),
 				"tags":      sadefs.MustEncodeValue([]string{"tag1", "tag2"}, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST),
+				"summary":   sadefs.MustEncodeValue("foo bar", enumspb.INDEXED_VALUE_TYPE_TEXT),
 			},
 		}
 		m, err := newSearchAttributesMapFromProto(sa)
@@ -157,6 +168,12 @@ func TestNewSearchAttributesMapFromProto(t *testing.T) {
 		listVal, ok := SearchAttributeValue(m, keywordListAttr)
 		require.True(t, ok)
 		require.Equal(t, []string{"tag1", "tag2"}, listVal)
+
+		textAttr := NewSearchAttributeText("summary", textField01)
+		textVal, ok := SearchAttributeValue(m, textAttr)
+		require.True(t, ok)
+		require.Equal(t, "foo bar", textVal)
+
 	})
 
 	t.Run("InvalidPayload", func(t *testing.T) {
@@ -165,9 +182,7 @@ func TestNewSearchAttributesMapFromProto(t *testing.T) {
 				"bad": {Data: []byte("not valid")},
 			},
 		}
-		m, err := newSearchAttributesMapFromProto(sa)
-		// Current implementation returns nil error on decode failure
-		require.NoError(t, err)
-		require.Empty(t, m.values)
+		_, err := newSearchAttributesMapFromProto(sa)
+		require.Error(t, err)
 	})
 }

--- a/chasm/visibility.go
+++ b/chasm/visibility.go
@@ -61,7 +61,10 @@ func (v *VisibilitySearchAttributesMapper) Alias(field string) (string, error) {
 	}
 	alias, ok := v.fieldToAlias[field]
 	if !ok {
-		return "", serviceerror.NewInvalidArgument(fmt.Sprintf("visibility search attributes mapper has no registered field %q", field))
+		return "", serviceerror.NewInvalidArgumentf(
+			"visibility search attributes mapper has no registered field %q",
+			field,
+		)
 	}
 	return alias, nil
 }

--- a/chasm/visibility_value.go
+++ b/chasm/visibility_value.go
@@ -134,6 +134,24 @@ func isVisibilityValueEqual(v1, v2 VisibilityValue) bool {
 	return v1.Equal(v2)
 }
 
+type VisibilityValueText string
+
+func (v VisibilityValueText) MustEncode() *commonpb.Payload {
+	return sadefs.MustEncodeValue(string(v), enumspb.INDEXED_VALUE_TYPE_TEXT)
+}
+
+func (v VisibilityValueText) Equal(other VisibilityValue) bool {
+	ov, ok := other.(VisibilityValueText)
+	if !ok {
+		return false
+	}
+	return v == ov
+}
+
+func (v VisibilityValueText) Value() any {
+	return string(v)
+}
+
 // visibilityValueFromPayload decoded payload based on type set in its metadata.
 func visibilityValueFromPayload(payload *commonpb.Payload) (VisibilityValue, error) {
 	value, err := sadefs.DecodeValue(payload, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, false)
@@ -141,25 +159,23 @@ func visibilityValueFromPayload(payload *commonpb.Payload) (VisibilityValue, err
 		return nil, err
 	}
 
-	switch val := value.(type) {
-	case int64:
-		return VisibilityValueInt64(val), nil
-	case float64:
-		return VisibilityValueFloat64(val), nil
-	case bool:
-		return VisibilityValueBool(val), nil
-	case time.Time:
-		return VisibilityValueTime(val), nil
-	case string:
-		// Try to parse as datetime first
-		if parsedTime, err := time.Parse(time.RFC3339, val); err == nil {
-			return VisibilityValueTime(parsedTime), nil
-		}
-		return VisibilityValueKeyword(val), nil
-	case []string:
-		return VisibilityValueStringSlice(val), nil
+	switch t := sadefs.GetMetadataType(payload); t {
+	case enumspb.INDEXED_VALUE_TYPE_BOOL:
+		return VisibilityValueBool(value.(bool)), nil
+	case enumspb.INDEXED_VALUE_TYPE_DATETIME:
+		return VisibilityValueTime(value.(time.Time)), nil
+	case enumspb.INDEXED_VALUE_TYPE_DOUBLE:
+		return VisibilityValueFloat64(value.(float64)), nil
+	case enumspb.INDEXED_VALUE_TYPE_INT:
+		return VisibilityValueInt64(value.(int64)), nil
+	case enumspb.INDEXED_VALUE_TYPE_KEYWORD:
+		return VisibilityValueKeyword(value.(string)), nil
+	case enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST:
+		return VisibilityValueStringSlice(value.([]string)), nil
+	case enumspb.INDEXED_VALUE_TYPE_TEXT:
+		return VisibilityValueText(value.(string)), nil
 	default:
 		// this should never happen given that DecodeValue did not return an error
-		return nil, fmt.Errorf("unexpected search attribute value type %T", value)
+		return nil, fmt.Errorf("unexpected metadata type %s", t)
 	}
 }

--- a/chasm/visibility_value_test.go
+++ b/chasm/visibility_value_test.go
@@ -100,6 +100,21 @@ func TestVisibilityValue(t *testing.T) {
 		require.False(t, v.Equal(VisibilityValueTime(base.Add(time.Second))))
 		require.False(t, v.Equal(VisibilityValueKeyword(base.String())))
 	})
+
+	t.Run("Text", func(t *testing.T) {
+		v := VisibilityValueText("foo bar")
+		p := v.MustEncode()
+		require.NotNil(t, p)
+
+		var out string
+		err := payload.Decode(p, &out)
+		require.NoError(t, err)
+		require.Equal(t, "foo bar", out)
+
+		require.True(t, v.Equal(VisibilityValueText("foo bar")))
+		require.False(t, v.Equal(VisibilityValueText("foo")))
+		require.False(t, v.Equal(VisibilityValueBool(true)))
+	})
 }
 
 func TestIsVisibilityValueEqual(t *testing.T) {


### PR DESCRIPTION
## What changed?
CHASM Visibility support for Text type search attribute

## Why?
Full support for all search attributes types.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

