### PR TITLE
Use typed DC redirection policy option in xdc tests

### DIFF
--- a/tests/xdc/delete_execution_replication_test.go
+++ b/tests/xdc/delete_execution_replication_test.go
@@ -21,9 +21,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/payloads"
-	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/tests/testcore"
-	"go.uber.org/fx"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
@@ -65,13 +63,7 @@ func (s *deleteExecutionReplicationTestSuite) SetupSuite() {
 	s.logger = log.NewTestLogger()
 
 	s.setupSuite(
-		testcore.WithFxOptionsForService(primitives.AllServices,
-			fx.Decorate(
-				func(_ config.DCRedirectionPolicy) config.DCRedirectionPolicy {
-					return config.DCRedirectionPolicy{Policy: "noop"}
-				},
-			),
-		),
+		testcore.WithDCRedirectionPolicy(config.DCRedirectionPolicy{Policy: "noop"}),
 	)
 }
 

--- a/tests/xdc/stream_based_replication_test.go
+++ b/tests/xdc/stream_based_replication_test.go
@@ -39,12 +39,10 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/persistence/serialization"
-	"go.temporal.io/server/common/primitives"
 	test "go.temporal.io/server/common/testing"
 	"go.temporal.io/server/service/history/replication/eventhandler"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/tests/testcore"
-	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
@@ -98,13 +96,7 @@ func (s *streamBasedReplicationTestSuite) SetupSuite() {
 	s.serializer = serialization.NewSerializer()
 
 	s.setupSuite(
-		testcore.WithFxOptionsForService(primitives.AllServices,
-			fx.Decorate(
-				func(_ config.DCRedirectionPolicy) config.DCRedirectionPolicy {
-					return config.DCRedirectionPolicy{Policy: "noop"}
-				},
-			),
-		),
+		testcore.WithDCRedirectionPolicy(config.DCRedirectionPolicy{Policy: "noop"}),
 	)
 }
 


### PR DESCRIPTION
## What changed?

Replaced the remaining xdc `DCRedirectionPolicy` `WithFxOptionsForService` call sites with `testcore.WithDCRedirectionPolicy`.

## Why?

We want to eliminate `WithFxOptionsForService` as it is blocking us from migrating away from the `onebox.go` approach (which duplicates the fx setup) since we don't want to expose an equivalent method in `temporal/fx.go`.