### PR TITLE
Refactor the taskAdd enums in favor of the existing outcome enums

### DIFF
--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -316,14 +316,6 @@ func ForwardedTag(forwarded bool) Tag {
 	return Tag{Key: forwardedTag, Value: strconv.FormatBool(forwarded)}
 }
 
-const (
-	TaskAddResultSyncMatch        = "sync_match"
-	TaskAddResultSyncMatchUnavail = "sync_match_unavailable"
-	TaskAddResultBacklog          = "backlog"
-	TaskAddResultThrottled        = "throttled"
-	TaskAddResultFailure          = "failure"
-)
-
 func TaskAddResultTag(result string) Tag {
 	return Tag{Key: taskAddResult, Value: result}
 }

--- a/service/matching/matcher_data.go
+++ b/service/matching/matcher_data.go
@@ -3,10 +3,12 @@ package matching
 import (
 	"container/heap"
 	"context"
+	"errors"
 	"slices"
 	"sync"
 	"time"
 
+	"go.temporal.io/api/serviceerror"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/log"
@@ -29,7 +31,8 @@ const (
 	priorityBacklogPollForwarder
 )
 
-// syncMatchOutcome describes the outcome of a sync match attempt.
+// syncMatchOutcome describes the outcome of a task-add operation, covering both sync match
+// attempts and the final disposition (backlog, throttled, failure).
 type syncMatchOutcome int
 
 const (
@@ -43,7 +46,37 @@ const (
 	syncMatchNoPoller
 	// A poller was available but rate limiting blocked the match.
 	syncMatchRateLimited
+	// The task was spooled to the backlog.
+	syncMatchBacklog
+	// The task-add was throttled (ResourceExhausted error).
+	syncMatchThrottled
+	// The task-add failed with an unexpected error.
+	syncMatchFailure
 )
+
+var syncMatchOutcomeTagMap = map[syncMatchOutcome]string{
+	syncMatchUnspecified:    "backlog",
+	syncMatchSuccess:        "sync_match",
+	syncMatchBacklogPresent: "backlog",
+	syncMatchNoPoller:       "backlog",
+	syncMatchRateLimited:    "throttled",
+	syncMatchBacklog:        "backlog",
+	syncMatchThrottled:      "throttled",
+	syncMatchFailure:        "failure",
+}
+
+func syncMatchOutcomeToTag(outcome syncMatchOutcome) string {
+	return syncMatchOutcomeTagMap[outcome]
+}
+
+// syncMatchOutcomeFromErr derives an outcome from a non-nil error.
+func syncMatchOutcomeFromErr(err error) syncMatchOutcome {
+	var resourceExhausted *serviceerror.ResourceExhausted
+	if errors.As(err, &resourceExhausted) {
+		return syncMatchThrottled
+	}
+	return syncMatchFailure
+}
 
 type taskForwarderType int32
 

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -451,10 +451,10 @@ func (c *physicalTaskQueueManagerImpl) SpoolTask(taskInfo *persistencespb.TaskIn
 	return c.backlogMgr.SpoolTask(taskInfo)
 }
 
-func (c *physicalTaskQueueManagerImpl) RecordTaskAdd(result string, forwarded bool, behavior enumspb.VersioningBehavior) {
+func (c *physicalTaskQueueManagerImpl) RecordTaskAdd(outcome syncMatchOutcome, forwarded bool, behavior enumspb.VersioningBehavior) {
 	c.metricsHandler.Counter(metrics.TasksAddedCounter.Name()).Record(
 		1,
-		metrics.TaskAddResultTag(result),
+		metrics.TaskAddResultTag(syncMatchOutcomeToTag(outcome)),
 		metrics.ForwardedTag(forwarded),
 		metrics.VersioningBehaviorTag(behavior),
 	)

--- a/service/matching/physical_task_queue_manager_interface.go
+++ b/service/matching/physical_task_queue_manager_interface.go
@@ -66,8 +66,10 @@ type (
 		// GetFairnessWeightOverrides returns current fairness weight overrides for this queue.
 		GetFairnessWeightOverrides() fairnessWeightOverrides
 		UpdateRemotePriorityBacklogs(remotePriorityBacklogSet)
-		// RecordTaskAdd records the outcome of a task add to this physical queue using
-		// the queue's tagged metrics handler, so all per-physical-queue labels are included.
-		RecordTaskAdd(result string, forwarded bool, behavior enumspb.VersioningBehavior)
+		// RecordTaskAdd records the outcome of a task add to this physical queue using the
+		// queue's tagged metrics handler. When a task is backlogged the child partition records
+		// (spoolQueue is always set on the child). When a forwarded task is sync-matched on the
+		// parent, the parent records with forwarded=true; the child also records with forwarded=false.
+		RecordTaskAdd(outcome syncMatchOutcome, forwarded bool, behavior enumspb.VersioningBehavior)
 	}
 )

--- a/service/matching/physical_task_queue_manager_mock.go
+++ b/service/matching/physical_task_queue_manager_mock.go
@@ -284,15 +284,15 @@ func (mr *MockphysicalTaskQueueManagerMockRecorder) QueueKey() *gomock.Call {
 }
 
 // RecordTaskAdd mocks base method.
-func (m *MockphysicalTaskQueueManager) RecordTaskAdd(result string, forwarded bool, behavior enums.VersioningBehavior) {
+func (m *MockphysicalTaskQueueManager) RecordTaskAdd(outcome syncMatchOutcome, forwarded bool, behavior enums.VersioningBehavior) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RecordTaskAdd", result, forwarded, behavior)
+	m.ctrl.Call(m, "RecordTaskAdd", outcome, forwarded, behavior)
 }
 
 // RecordTaskAdd indicates an expected call of RecordTaskAdd.
-func (mr *MockphysicalTaskQueueManagerMockRecorder) RecordTaskAdd(result, forwarded, behavior any) *gomock.Call {
+func (mr *MockphysicalTaskQueueManagerMockRecorder) RecordTaskAdd(outcome, forwarded, behavior any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordTaskAdd", reflect.TypeOf((*MockphysicalTaskQueueManager)(nil).RecordTaskAdd), result, forwarded, behavior)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordTaskAdd", reflect.TypeOf((*MockphysicalTaskQueueManager)(nil).RecordTaskAdd), outcome, forwarded, behavior)
 }
 
 // RemovePoller mocks base method.

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -453,11 +453,10 @@ reredirectTask:
 				pm.processTaskAddHooks(ctx, targetVersion, outcome)
 			}
 
-			syncMatchResult := metrics.TaskAddResultSyncMatch
 			if err != nil {
-				syncMatchResult = taskAddErrResult(err)
+				outcome = syncMatchOutcomeFromErr(err)
 			}
-			syncMatchQueue.RecordTaskAdd(syncMatchResult, forwarded, behavior)
+			syncMatchQueue.RecordTaskAdd(outcome, forwarded, behavior)
 
 			// Build ID is not returned for sync match. The returned build ID is used by History to update
 			// mutable state (and visibility) when the first workflow task is spooled.
@@ -474,7 +473,6 @@ reredirectTask:
 
 	if spoolQueue == nil {
 		// This means the task is being forwarded. Child partition will persist the task when sync match fails.
-		syncMatchQueue.RecordTaskAdd(metrics.TaskAddResultSyncMatchUnavail, forwarded, behavior)
 		return "", false, errRemoteSyncMatchFailed
 	}
 
@@ -485,11 +483,13 @@ reredirectTask:
 	}
 
 	err = spoolQueue.SpoolTask(params.taskInfo)
+	spoolOutcome := syncMatchBacklog
+	if err != nil {
+		spoolOutcome = syncMatchOutcomeFromErr(err)
+	}
+	spoolQueue.RecordTaskAdd(spoolOutcome, forwarded, behavior)
 	if err == nil {
-		spoolQueue.RecordTaskAdd(metrics.TaskAddResultBacklog, forwarded, behavior)
 		pm.processTaskAddHooks(ctx, targetVersion, outcome)
-	} else {
-		spoolQueue.RecordTaskAdd(taskAddErrResult(err), forwarded, behavior)
 	}
 
 	return assignedBuildId, false, err
@@ -517,14 +517,6 @@ func (pm *taskQueuePartitionManagerImpl) processTaskAddHooks(ctx context.Context
 			SyncMatchOutcome:  hookOutcome,
 		})
 	}
-}
-
-func taskAddErrResult(err error) string {
-	var resourceExhausted *serviceerror.ResourceExhausted
-	if errors.As(err, &resourceExhausted) {
-		return metrics.TaskAddResultThrottled
-	}
-	return metrics.TaskAddResultFailure
 }
 
 func (pm *taskQueuePartitionManagerImpl) shouldBacklogSyncMatchTaskOnError(err error) bool {


### PR DESCRIPTION
## What changed?
This addresses some follow on comments that @dnr had in the initial pr for this new matric (#10180).
Outside of some specific fixes the larger set of this change is to consolidate this work with work that
was recently merged just before the #10180 from @rkannan82 to add this syncMatchOutcome. We
can probably share the enum here (as dnr pointed out) and this is an attempt at that.

## Why?
Fixes a couple of logic bugs in #10180 and does some mild cleanup to consolidate on a single set of enums.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

