### PR TITLE
Adds Link_NexusOperation to link validation

### DIFF
--- a/chasm/lib/workflow/validator.go
+++ b/chasm/lib/workflow/validator.go
@@ -154,6 +154,16 @@ func (v *RequestValidator) ValidateLinks(
 			if t.BatchJob.GetJobId() == "" {
 				return serviceerror.NewInvalidArgument("batch job link must not have an empty job ID")
 			}
+		case *commonpb.Link_NexusOperation_:
+			if t.NexusOperation.GetNamespace() == "" {
+				return serviceerror.NewInvalidArgument("nexus operation link must not have an empty namespace field")
+			}
+			if t.NexusOperation.GetOperationId() == "" {
+				return serviceerror.NewInvalidArgument("nexus operation link must not have an empty operation ID field")
+			}
+			if t.NexusOperation.GetRunId() == "" {
+				return serviceerror.NewInvalidArgument("nexus operation link must not have an empty run ID field")
+			}
 		default:
 			return serviceerror.NewInvalidArgument("unsupported link variant")
 		}

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -6335,6 +6335,16 @@ func (wh *WorkflowHandler) validateLinks(
 			if t.BatchJob.GetJobId() == "" {
 				return serviceerror.NewInvalidArgument("batch job link must not have an empty job ID")
 			}
+		case *commonpb.Link_NexusOperation_:
+			if t.NexusOperation.GetNamespace() == "" {
+				return serviceerror.NewInvalidArgument("nexus operation link must not have an empty namespace field")
+			}
+			if t.NexusOperation.GetOperationId() == "" {
+				return serviceerror.NewInvalidArgument("nexus operation link must not have an empty operation ID field")
+			}
+			if t.NexusOperation.GetRunId() == "" {
+				return serviceerror.NewInvalidArgument("nexus operation link must not have an empty run ID field")
+			}
 		default:
 			return serviceerror.NewInvalidArgument("unsupported link variant")
 		}

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -853,6 +853,47 @@ func (s *WorkflowHandlerSuite) TestStartWorkflowExecution_Failed_InvalidLinks() 
 	_, err = wh.StartWorkflowExecution(context.Background(), req)
 	s.ErrorAs(err, &invalidArgument)
 	s.ErrorContains(err, "batch job link must not have an empty job ID")
+
+	req.Links = []*commonpb.Link{
+		{
+			Variant: &commonpb.Link_NexusOperation_{
+				NexusOperation: &commonpb.Link_NexusOperation{},
+			},
+		},
+	}
+
+	_, err = wh.StartWorkflowExecution(context.Background(), req)
+	s.ErrorAs(err, &invalidArgument)
+	s.ErrorContains(err, "nexus operation link must not have an empty namespace field")
+
+	req.Links = []*commonpb.Link{
+		{
+			Variant: &commonpb.Link_NexusOperation_{
+				NexusOperation: &commonpb.Link_NexusOperation{
+					Namespace: "present",
+				},
+			},
+		},
+	}
+
+	_, err = wh.StartWorkflowExecution(context.Background(), req)
+	s.ErrorAs(err, &invalidArgument)
+	s.ErrorContains(err, "nexus operation link must not have an empty operation ID field")
+
+	req.Links = []*commonpb.Link{
+		{
+			Variant: &commonpb.Link_NexusOperation_{
+				NexusOperation: &commonpb.Link_NexusOperation{
+					Namespace:   "present",
+					OperationId: "present",
+				},
+			},
+		},
+	}
+
+	_, err = wh.StartWorkflowExecution(context.Background(), req)
+	s.ErrorAs(err, &invalidArgument)
+	s.ErrorContains(err, "nexus operation link must not have an empty run ID field")
 }
 
 func (s *WorkflowHandlerSuite) TestStartWorkflowExecution_Failed_InvalidCallbackLinks() {


### PR DESCRIPTION
## What changed?
Adds validation in workflow validator for NexusOperation links

## Why?
Covers workflow flows started by standalone operations.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

Closes [#10345](https://github.com/temporalio/temporal/issues/10345)
