### PR TITLE
Patch/idle task on single action schedule

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,20 @@
 ## What changed?
-_Describe what has changed in this PR._
 
-## Why?
-_Tell your future self why have you made these changes._
+<!-- Give a brief description of what the commit or commits included in this
+patch do. -->
 
-## How did you test it?
-- [ ] built
-- [ ] run locally and tested manually
-- [ ] covered by existing tests
-- [ ] added new unit test(s)
-- [ ] added new functional test(s)
+### Original PRs
 
-## Potential risks
-_Any change is risky. Identify all risks you are aware of. If none, remove this section._
+<!-- Link the original PR(s) here. -->
+
+## Why is this necessary as a patch?
+
+<!-- Why can't we wait until the next release? -->
+
+## What testing or retesting is appropriate for this patch after merge?
+
+<!-- E.g., do we need to rerun VCR? OSS Longhaul? Some subset of those? Manual
+validation? Etc. -->
+
+<!-- As part of answering this, it is usually helpful to describe what testing
+has already been done. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,15 @@
 ## What changed?
+_Describe what has changed in this PR._
 
-<!-- Give a brief description of what the commit or commits included in this
-patch do. -->
+## Why?
+_Tell your future self why have you made these changes._
 
-### Original PRs
+## How did you test it?
+- [ ] built
+- [ ] run locally and tested manually
+- [ ] covered by existing tests
+- [ ] added new unit test(s)
+- [ ] added new functional test(s)
 
-<!-- Link the original PR(s) here. -->
-
-## Why is this necessary as a patch?
-
-<!-- Why can't we wait until the next release? -->
-
-## What testing or retesting is appropriate for this patch after merge?
-
-<!-- E.g., do we need to rerun VCR? OSS Longhaul? Some subset of those? Manual
-validation? Etc. -->
-
-<!-- As part of answering this, it is usually helpful to describe what testing
-has already been done. -->
+## Potential risks
+_Any change is risky. Identify all risks you are aware of. If none, remove this section._

--- a/chasm/lib/scheduler/invoker.go
+++ b/chasm/lib/scheduler/invoker.go
@@ -180,6 +180,7 @@ func (i *Invoker) recordExecuteResult(ctx chasm.MutableContext, result *executeR
 		if completedStart, ok := completed[start.RequestId]; ok {
 			start.RunId = completedStart.GetRunId()
 			start.StartTime = completedStart.GetStartTime()
+			start.HasCallback = true
 		}
 		if retry, ok := retryable[start.RequestId]; ok {
 			start.Attempt++

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -448,15 +448,17 @@ func (s *Scheduler) updateConflictToken() {
 // value is used for calculating the retention time (how long an idle schedule
 // lives after becoming idle).
 func (s *Scheduler) getLastEventTime(ctx chasm.Context) time.Time {
-	var lastEvent time.Time
 	invoker := s.Invoker.Get(ctx)
 	recentActions := invoker.recentActions()
+
+	latest := util.MaxTime(
+		s.Info.GetCreateTime().AsTime(),
+		s.Info.GetUpdateTime().AsTime(),
+	)
 	if len(recentActions) > 0 {
-		lastEvent = recentActions[len(recentActions)-1].GetActualTime().AsTime()
+		latest = util.MaxTime(latest, recentActions[len(recentActions)-1].GetActualTime().AsTime())
 	}
-	lastEvent = util.MaxTime(lastEvent, s.Info.GetCreateTime().AsTime())
-	lastEvent = util.MaxTime(lastEvent, s.Info.GetUpdateTime().AsTime())
-	return lastEvent
+	return latest
 }
 
 // getIdleExpiration returns an idle close time and the boolean value of 'true'
@@ -582,6 +584,11 @@ func (s *Scheduler) HandleNexusCompletion(
 		CloseTime: info.CloseTime,
 	}
 	invoker.recordCompletedAction(ctx, completed, info.RequestId)
+
+	// Generate immediately after recording completions, so that an idle task
+	// can be scheduled if no more actions are remaining. Necessary as
+	// additional events invalidate in-flight idle tasks.
+	s.Generator.Get(ctx).Generate(ctx)
 
 	return nil
 }

--- a/chasm/lib/scheduler/scheduler_tasks.go
+++ b/chasm/lib/scheduler/scheduler_tasks.go
@@ -48,6 +48,14 @@ func (r *SchedulerIdleTaskHandler) Execute(
 	return nil
 }
 
+// Validate returns true when all three conditions hold:
+//  1. The schedule is still idle — no new actions have been queued since this
+//     task was created (getIdleExpiration returns isIdle=true).
+//  2. The idle expiration has not shifted — getIdleExpiration recomputes
+//     getLastEventTime()+idleTimeTotal and it must equal the task's scheduled
+//     time. If a workflow start has advanced getLastEventTime() since the task
+//     was written, the expiration no longer matches and the task is dropped.
+//  3. The scheduler is not already closed (idempotency guard).
 func (r *SchedulerIdleTaskHandler) Validate(
 	ctx chasm.Context,
 	scheduler *Scheduler,

--- a/common/util/util.go
+++ b/common/util/util.go
@@ -19,12 +19,15 @@ func MinTime(a, b time.Time) time.Time {
 	return b
 }
 
-// MaxTime returns the later of two given time.Time
-func MaxTime(a, b time.Time) time.Time {
-	if a.After(b) {
-		return a
+// MaxTime returns the latest of the given time.Time values.
+func MaxTime(first time.Time, rest ...time.Time) time.Time {
+	latest := first
+	for _, t := range rest {
+		if t.After(latest) {
+			latest = t
+		}
 	}
-	return b
+	return latest
 }
 
 // NextAlignedTime returns the earliest time after `t` that is aligned to an integer multiple

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -25,6 +25,7 @@ import (
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 	schedulespb "go.temporal.io/server/api/schedule/v1"
+	chasmscheduler "go.temporal.io/server/chasm/lib/scheduler"
 	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
@@ -84,6 +85,8 @@ func TestScheduleCHASM(t *testing.T) {
 	t.Run("TestSkipsWorkflowSentinelWhenDisabled", func(t *testing.T) { testSkipsWorkflowSentinelWhenDisabled(t, newContext) })
 	t.Run("TestUpdateScheduleMemo", func(t *testing.T) { testUpdateScheduleMemo(t, newContext) })
 	t.Run("TestUpdateScheduleMemoOnly", func(t *testing.T) { testUpdateScheduleMemoOnly(t, newContext) })
+	t.Run("TestSingleDateScheduleCloses", func(t *testing.T) { testSingleDateScheduleCloses(t, newContext) })
+	t.Run("TestMultiDateScheduleCloses", func(t *testing.T) { testMultiDateScheduleCloses(t, newContext) })
 }
 
 func TestScheduleV1(t *testing.T) {
@@ -3322,4 +3325,177 @@ func testUpdateScheduleBlobSizeLimit(t *testing.T, newContext contextFactory) {
 	})
 	var invalidArgBlob *serviceerror.InvalidArgument
 	require.ErrorAs(t, err, &invalidArgBlob)
+}
+
+// testSingleDateScheduleCloses verifies that a CHASM schedule configured with
+// a single calendar date closes after its one workflow completes.
+func testSingleDateScheduleCloses(t *testing.T, newContext contextFactory) {
+	shortIdleTime := 3 * time.Second
+	tweakables := chasmscheduler.DefaultTweakables
+	tweakables.IdleTime = shortIdleTime
+	s := testcore.NewEnv(t, append(scheduleCommonOpts(),
+		testcore.WithDynamicConfig(chasmscheduler.CurrentTweakables, tweakables),
+	)...)
+
+	fireAt := time.Now().Add(2 * time.Second).UTC()
+	sid := "sched-single-date-closes-" + uuid.NewString()
+	wid := "sched-single-date-wf-" + uuid.NewString()
+
+	const wfType = "testSingleDateScheduleClosesWf"
+	var ran atomic.Bool
+	s.SdkWorker().RegisterWorkflowWithOptions(func(ctx workflow.Context) error {
+		ran.Store(true)
+		return nil
+	}, workflow.RegisterOptions{Name: wfType})
+
+	ctx := newContext(testcore.NewContext())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		RequestId:  uuid.NewString(),
+		Schedule: &schedulepb.Schedule{
+			Spec: &schedulepb.ScheduleSpec{
+				Calendar: []*schedulepb.CalendarSpec{{
+					Year:       fmt.Sprintf("%d", fireAt.Year()),
+					Month:      fireAt.Month().String(),
+					DayOfMonth: fmt.Sprintf("%d", fireAt.Day()),
+					Hour:       fmt.Sprintf("%d", fireAt.Hour()),
+					Minute:     fmt.Sprintf("%d", fireAt.Minute()),
+					Second:     fmt.Sprintf("%d", fireAt.Second()),
+				}},
+			},
+			Action: &schedulepb.ScheduleAction{
+				Action: &schedulepb.ScheduleAction_StartWorkflow{
+					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+						WorkflowId:   wid,
+						WorkflowType: &commonpb.WorkflowType{Name: wfType},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Wait for the workflow to fire and complete.
+	require.Eventually(t, func() bool { return ran.Load() },
+		10*time.Second, 200*time.Millisecond, "workflow should have fired")
+
+	// Poll until DescribeSchedule reflects the completed action and no future times.
+	var preCloseDesc *workflowservice.DescribeScheduleResponse
+	require.Eventually(t, func() bool {
+		resp, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+		})
+		if err != nil || len(resp.Info.RecentActions) == 0 {
+			return false
+		}
+		preCloseDesc = resp
+		return len(resp.Info.FutureActionTimes) == 0
+	}, 10*time.Second, 200*time.Millisecond, "schedule should have one completed action and no future times")
+
+	require.Len(t, preCloseDesc.Info.RecentActions, 1)
+	require.NotNil(t, preCloseDesc.Info.RecentActions[0].StartWorkflowResult)
+	require.Empty(t, preCloseDesc.Info.FutureActionTimes)
+
+	// Schedule goes idle and closes after IdleTime (3s).
+	require.Eventually(t, func() bool {
+		_, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+		})
+		return err != nil
+	}, 15*time.Second, 200*time.Millisecond, "schedule should have closed")
+}
+
+// testMultiDateScheduleCloses verifies that a CHASM schedule configured with
+// two calendar dates closes after both workflows complete.
+func testMultiDateScheduleCloses(t *testing.T, newContext contextFactory) {
+	shortIdleTime := 3 * time.Second
+	tweakables := chasmscheduler.DefaultTweakables
+	tweakables.IdleTime = shortIdleTime
+	s := testcore.NewEnv(t, append(scheduleCommonOpts(),
+		testcore.WithDynamicConfig(chasmscheduler.CurrentTweakables, tweakables),
+	)...)
+
+	now := time.Now().UTC()
+	fire1 := now.Add(2 * time.Second)
+	fire2 := now.Add(5 * time.Second)
+	sid := "sched-multi-date-closes-" + uuid.NewString()
+	wid := "sched-multi-date-wf-" + uuid.NewString()
+
+	const wfType2 = "testMultiDateScheduleClosesWf"
+	var runs atomic.Int32
+	s.SdkWorker().RegisterWorkflowWithOptions(func(ctx workflow.Context) error {
+		runs.Add(1)
+		return nil
+	}, workflow.RegisterOptions{Name: wfType2})
+
+	calSpec := func(t time.Time) *schedulepb.CalendarSpec {
+		return &schedulepb.CalendarSpec{
+			Year:       fmt.Sprintf("%d", t.Year()),
+			Month:      t.Month().String(),
+			DayOfMonth: fmt.Sprintf("%d", t.Day()),
+			Hour:       fmt.Sprintf("%d", t.Hour()),
+			Minute:     fmt.Sprintf("%d", t.Minute()),
+			Second:     fmt.Sprintf("%d", t.Second()),
+		}
+	}
+
+	ctx := newContext(testcore.NewContext())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		RequestId:  uuid.NewString(),
+		Schedule: &schedulepb.Schedule{
+			Spec: &schedulepb.ScheduleSpec{
+				Calendar: []*schedulepb.CalendarSpec{calSpec(fire1), calSpec(fire2)},
+			},
+			Action: &schedulepb.ScheduleAction{
+				Action: &schedulepb.ScheduleAction_StartWorkflow{
+					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+						WorkflowId:            wid,
+						WorkflowType:          &commonpb.WorkflowType{Name: wfType2},
+						TaskQueue:             &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+						WorkflowIdReusePolicy: enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Wait for both workflows to fire and complete.
+	require.Eventually(t, func() bool { return runs.Load() >= 2 },
+		15*time.Second, 200*time.Millisecond, "both workflows should have fired")
+
+	// Poll until DescribeSchedule reflects both completed actions and no future times.
+	var preCloseDesc *workflowservice.DescribeScheduleResponse
+	require.Eventually(t, func() bool {
+		resp, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+		})
+		if err != nil || len(resp.Info.RecentActions) < 2 {
+			return false
+		}
+		preCloseDesc = resp
+		return len(resp.Info.FutureActionTimes) == 0
+	}, 15*time.Second, 200*time.Millisecond, "schedule should have two completed actions and no future times")
+
+	require.Len(t, preCloseDesc.Info.RecentActions, 2)
+	for _, action := range preCloseDesc.Info.RecentActions {
+		require.NotNil(t, action.StartWorkflowResult)
+	}
+	require.Empty(t, preCloseDesc.Info.FutureActionTimes)
+
+	// Schedule goes idle and closes after IdleTime (3s).
+	require.Eventually(t, func() bool {
+		_, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+		})
+		return err != nil
+	}, 15*time.Second, 200*time.Millisecond, "schedule should have closed")
 }


### PR DESCRIPTION
## What changed?

Fixes a bug where SchedulerIdleTask is silently dropped when InvokerExecuteTask commits, leaving a single-action schedule stuck open forever.

### Original PRs

https://github.com/temporalio/temporal/pull/10313

## Why is this necessary as a patch?

Leaks very slowly for a single customer NS on one cell and we'd like to avoid it leaking further.

## What testing or retesting is appropriate for this patch after merge?

We don't need longhaul or VCR for this