### PR TITLE
Retry CI docker compose pull

### DIFF
--- a/.github/actions/docker-compose-pull/action.yml
+++ b/.github/actions/docker-compose-pull/action.yml
@@ -1,0 +1,45 @@
+name: Docker Compose Start
+description: Pull Docker Compose services with retries, then start them.
+
+inputs:
+  compose-file:
+    description: Docker Compose file to use.
+    required: true
+  services:
+    description: Whitespace-delimited list of services to pull.
+    required: true
+  attempts:
+    description: Number of pull attempts.
+    default: "3"
+  delay-seconds:
+    description: Delay between failed attempts.
+    default: "15"
+  down-flags:
+    description: Additional options to pass to docker compose down.
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Pull services
+      uses: nick-fields/retry@v3
+      env:
+        COMPOSE_FILE: ${{ inputs['compose-file'] }}
+        SERVICES: ${{ inputs.services }}
+      with:
+        max_attempts: ${{ inputs.attempts }}
+        retry_wait_seconds: ${{ inputs['delay-seconds'] }}
+        shell: bash
+        command: |
+          if [[ -z "${SERVICES//[[:space:]]/}" ]]; then
+            echo "No services configured for docker compose pull."
+            exit 0
+          fi
+          docker compose -f "$COMPOSE_FILE" pull $SERVICES
+
+    - name: Start services
+      uses: hoverkraft-tech/compose-action@v2.0.1
+      with:
+        compose-file: ${{ inputs['compose-file'] }}
+        services: ${{ inputs.services }}
+        down-flags: ${{ inputs['down-flags'] }}

--- a/.github/actions/docker-compose-pull/action.yml
+++ b/.github/actions/docker-compose-pull/action.yml
@@ -14,6 +14,9 @@ inputs:
   delay-seconds:
     description: Delay between failed attempts.
     default: "15"
+  timeout-minutes:
+    description: Timeout for each pull attempt.
+    default: "1"
   down-flags:
     description: Additional options to pass to docker compose down.
     default: ""
@@ -29,6 +32,7 @@ runs:
       with:
         max_attempts: ${{ inputs.attempts }}
         retry_wait_seconds: ${{ inputs['delay-seconds'] }}
+        timeout_minutes: ${{ inputs['timeout-minutes'] }}
         shell: bash
         command: |
           if [[ -z "${SERVICES//[[:space:]]/}" ]]; then

--- a/.github/actions/docker-compose-pull/action.yml
+++ b/.github/actions/docker-compose-pull/action.yml
@@ -13,7 +13,7 @@ inputs:
     default: "3"
   delay-seconds:
     description: Delay between failed attempts.
-    default: "15"
+    default: "5"
   timeout-minutes:
     description: Timeout for each pull attempt.
     default: "1"

--- a/.github/actions/docker-compose-pull/action.yml
+++ b/.github/actions/docker-compose-pull/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: true
   attempts:
     description: Number of pull attempts.
-    default: "3"
+    default: "5"
   delay-seconds:
     description: Delay between failed attempts.
     default: "5"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -380,7 +380,7 @@ jobs:
           ref: ${{ env.COMMIT }}
 
       - name: Start containerized dependencies
-        uses: hoverkraft-tech/compose-action@v2.0.1
+        uses: ./.github/actions/docker-compose-pull
         with:
           compose-file: ${{ env.DOCKER_COMPOSE_FILE }}
           services: |
@@ -499,7 +499,7 @@ jobs:
 
       - name: Start containerized dependencies
         if: ${{ toJson(matrix.containers) != '[]' }}
-        uses: hoverkraft-tech/compose-action@v2.0.1
+        uses: ./.github/actions/docker-compose-pull
         with:
           compose-file: ${{ env.DOCKER_COMPOSE_FILE }}
           services: "${{ join(matrix.containers, '\n') }}"
@@ -617,7 +617,7 @@ jobs:
           ref: ${{ env.COMMIT }}
 
       - name: Start PostgreSQL
-        uses: hoverkraft-tech/compose-action@v2.0.1
+        uses: ./.github/actions/docker-compose-pull
         with:
           compose-file: ${{ env.DOCKER_COMPOSE_FILE }}
           services: postgresql


### PR DESCRIPTION
## What changed?

Added retries for docker compose pull.

## Why?

They occasionally fail which fails the CI check immediately. Annoying.

Example: https://github.com/temporalio/temporal/actions/runs/24159347422/job/70506923692