### PR TITLE
WCP 1/X: Split history event batches by MaximumEventBatchSizeInBytes

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2418,6 +2418,15 @@ archivalQueueProcessor`,
 		`MaximumBufferedEventsSizeInBytes is the maximum permissible size of all buffered events for any given mutable
 state. The total size is determined by the sum of the size, in bytes, of each HistoryEvent proto.`,
 	)
+	MaximumEventBatchSizeInBytes = NewGlobalIntSetting(
+		"history.maximumEventBatchSizeInBytes",
+		0,
+		`This is EXPERIMENTAL feature that is under development. Things can break if you use it.
+MaximumEventBatchSizeInBytes is the size threshold (in bytes) at which the EventStore rolls the
+current in-memory batch and starts a new one. A single oversized event may cause a batch to
+exceed this size. A value of 0 disables the check. This value should stay below
+system.transactionSizeLimit, since each batch is persisted within a single transaction.`,
+	)
 	MaximumSignalsPerExecution = NewNamespaceIntSetting(
 		"history.maximumSignalsPerExecution",
 		10000,

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -196,6 +196,7 @@ type Config struct {
 	MaximumBufferedEventsBatch       dynamicconfig.IntPropertyFn
 	MaximumBufferedEventsSizeInBytes dynamicconfig.IntPropertyFn
 	MaximumSignalsPerExecution       dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaximumEventBatchSizeInBytes     dynamicconfig.IntPropertyFn
 
 	// ShardUpdateMinInterval is the minimum time interval within which the shard info can be updated.
 	ShardUpdateMinInterval dynamicconfig.DurationPropertyFn
@@ -637,6 +638,7 @@ func NewConfig(
 		MaximumBufferedEventsBatch:       dynamicconfig.MaximumBufferedEventsBatch.Get(dc),
 		MaximumBufferedEventsSizeInBytes: dynamicconfig.MaximumBufferedEventsSizeInBytes.Get(dc),
 		MaximumSignalsPerExecution:       dynamicconfig.MaximumSignalsPerExecution.Get(dc),
+		MaximumEventBatchSizeInBytes:     dynamicconfig.MaximumEventBatchSizeInBytes.Get(dc),
 		ShardUpdateMinInterval:           dynamicconfig.ShardUpdateMinInterval.Get(dc),
 		ShardFirstUpdateInterval:         dynamicconfig.ShardFirstUpdateInterval.Get(dc),
 		ShardUpdateMinTasksCompleted:     dynamicconfig.ShardUpdateMinTasksCompleted.Get(dc),

--- a/service/history/historybuilder/event_store.go
+++ b/service/history/historybuilder/event_store.go
@@ -34,7 +34,6 @@ type EventStore struct {
 	// When appending the next event would push this above
 	// maxEventBatchSizeInBytes, the batch is rolled into
 	// memEventsBatches and a fresh memLatestBatch is started.
-	// Only used if maxEventBatchSizeInBytes returns a positive value.
 	memLatestBatchSize int
 
 	maxEventBatchSizeInBytes dynamicconfig.IntPropertyFn
@@ -108,13 +107,16 @@ func (b *EventStore) add(
 // first if the additional event would push the current batch over
 // maxEventBatchSizeInBytes. A value of <= 0 disables the check.
 func (b *EventStore) appendToLatestBatch(event *historypb.HistoryEvent) {
+	eventSize := proto.Size(event)
 	if limit := b.maxEventBatchSizeInBytes(); limit > 0 {
-		eventSize := proto.Size(event)
 		if len(b.memLatestBatch) > 0 && b.memLatestBatchSize+eventSize > limit {
 			b.FlushAndCreateNewBatch()
 		}
-		b.memLatestBatchSize += eventSize
 	}
+	// Always accumulate so the size reflects the full batch even when the
+	// limit is disabled. Otherwise, enabling maxEventBatchSizeInBytes mid-flight
+	// would start counting from that point and undercount the current batch.
+	b.memLatestBatchSize += eventSize
 	b.memLatestBatch = append(b.memLatestBatch, event)
 }
 

--- a/service/history/historybuilder/event_store.go
+++ b/service/history/historybuilder/event_store.go
@@ -5,6 +5,7 @@ import (
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/metrics"
 	"google.golang.org/protobuf/proto"
 )
@@ -28,6 +29,15 @@ type EventStore struct {
 	memEventsBatches [][]*historypb.HistoryEvent
 	memLatestBatch   []*historypb.HistoryEvent
 	memBufferBatch   []*historypb.HistoryEvent
+
+	// Cumulative serialized size in bytes of events currently in memLatestBatch.
+	// When appending the next event would push this above
+	// maxEventBatchSizeInBytes, the batch is rolled into
+	// memEventsBatches and a fresh memLatestBatch is started.
+	// Only used if maxEventBatchSizeInBytes returns a positive value.
+	memLatestBatchSize int
+
+	maxEventBatchSizeInBytes dynamicconfig.IntPropertyFn
 
 	// scheduled to started event ID mapping
 	scheduledIDToStartedID map[int64]int64
@@ -88,10 +98,24 @@ func (b *EventStore) add(
 		b.memBufferBatch = append(b.memBufferBatch, event)
 	} else {
 		event.EventId = b.AllocateEventID()
-		b.memLatestBatch = append(b.memLatestBatch, event)
+		b.appendToLatestBatch(event)
 		batchID = b.memLatestBatch[0].EventId
 	}
 	return event, batchID
+}
+
+// appendToLatestBatch appends event to memLatestBatch, rolling into a new batch
+// first if the additional event would push the current batch over
+// maxEventBatchSizeInBytes. A value of <= 0 disables the check.
+func (b *EventStore) appendToLatestBatch(event *historypb.HistoryEvent) {
+	if limit := b.maxEventBatchSizeInBytes(); limit > 0 {
+		eventSize := proto.Size(event)
+		if len(b.memLatestBatch) > 0 && b.memLatestBatchSize+eventSize > limit {
+			b.FlushAndCreateNewBatch()
+		}
+		b.memLatestBatchSize += eventSize
+	}
+	b.memLatestBatch = append(b.memLatestBatch, event)
 }
 
 func (b *EventStore) HasBufferEvents() bool {
@@ -162,7 +186,9 @@ func (b *EventStore) FlushBufferToCurrentBatch() (map[int64]int64, map[string]in
 	// 2nd wire event ID, e.g. activity, child workflow
 	b.wireEventIDs(bufferBatch)
 
-	b.memLatestBatch = append(b.memLatestBatch, bufferBatch...)
+	for _, event := range bufferBatch {
+		b.appendToLatestBatch(event)
+	}
 
 	return b.scheduledIDToStartedID, b.requestIDToEventID
 }
@@ -175,6 +201,7 @@ func (b *EventStore) FlushAndCreateNewBatch() {
 
 	b.memEventsBatches = append(b.memEventsBatches, b.memLatestBatch)
 	b.memLatestBatch = nil
+	b.memLatestBatchSize = 0
 }
 
 func (b *EventStore) Finish(
@@ -200,6 +227,7 @@ func (b *EventStore) Finish(
 	b.memEventsBatches = nil
 	b.memBufferBatch = nil
 	b.memLatestBatch = nil
+	b.memLatestBatchSize = 0
 	b.dbClearBuffer = false
 	b.dbBufferBatch = nil
 	b.scheduledIDToStartedID = nil

--- a/service/history/historybuilder/history_builder.go
+++ b/service/history/historybuilder/history_builder.go
@@ -16,6 +16,7 @@ import (
 	historyspb "go.temporal.io/server/api/history/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/worker_versioning"
@@ -63,6 +64,7 @@ func New(
 	nextEventID int64,
 	dbBufferBatch []*historypb.HistoryEvent,
 	metricsHandler metrics.Handler,
+	maxEventBatchSizeInBytes dynamicconfig.IntPropertyFn,
 ) *HistoryBuilder {
 	return &HistoryBuilder{
 		EventStore: EventStore{
@@ -82,6 +84,8 @@ func New(
 			memBufferBatch:         nil,
 			scheduledIDToStartedID: make(map[int64]int64),
 			requestIDToEventID:     make(map[string]int64),
+
+			maxEventBatchSizeInBytes: maxEventBatchSizeInBytes,
 
 			metricsHandler: metricsHandler,
 		},

--- a/service/history/historybuilder/history_builder_categorization_test.go
+++ b/service/history/historybuilder/history_builder_categorization_test.go
@@ -16,6 +16,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/service/history/tests"
 )
 
 type StubHandler struct{}
@@ -51,7 +52,7 @@ func (h StubHandler) StartBatch(_ string) metrics.BatchHandler {
 }
 
 func TestHistoryBuilder_IsDirty(t *testing.T) {
-	hb := HistoryBuilder{EventStore: EventStore{}}
+	hb := HistoryBuilder{EventStore: EventStore{maxEventBatchSizeInBytes: tests.NewDynamicConfig().MaximumEventBatchSizeInBytes}}
 	if hb.IsDirty() {
 		t.Fatal("newly created history is dirty")
 	}
@@ -60,7 +61,7 @@ func TestHistoryBuilder_IsDirty(t *testing.T) {
 func TestHistoryBuilder_AddWorkflowExecutionStartedEvent(t *testing.T) {
 	ns := "some-namespace"
 	t.Run("When ParentExecutionInfo is nil should not include in attributes", func(t *testing.T) {
-		hb := HistoryBuilder{}
+		hb := HistoryBuilder{EventStore: EventStore{maxEventBatchSizeInBytes: tests.NewDynamicConfig().MaximumEventBatchSizeInBytes}}
 		startReq := &workflowservice.StartWorkflowExecutionRequest{}
 		req := &historyservice.StartWorkflowExecutionRequest{StartRequest: startReq}
 		startTime := time.Date(2023, 12, 27, 1, 11, 00, 00, time.UTC)
@@ -88,7 +89,7 @@ func TestHistoryBuilder_AddWorkflowExecutionStartedEvent(t *testing.T) {
 	})
 
 	t.Run("When ParentExecutionInfo is not nil should copy values to attributes", func(t *testing.T) {
-		hb := HistoryBuilder{}
+		hb := HistoryBuilder{EventStore: EventStore{maxEventBatchSizeInBytes: tests.NewDynamicConfig().MaximumEventBatchSizeInBytes}}
 		parentInfo := &workflowspb.ParentExecutionInfo{Namespace: ns}
 		startReq := &workflowservice.StartWorkflowExecutionRequest{}
 		req := &historyservice.StartWorkflowExecutionRequest{StartRequest: startReq, ParentExecutionInfo: parentInfo}
@@ -125,7 +126,7 @@ func TestHistoryBuilder_AddWorkflowExecutionStartedEvent(t *testing.T) {
 func TestHistoryBuilder_FlushBufferToCurrentBatch(t *testing.T) {
 	t.Run("when no events in dbBufferBatch or meBufferBatch will return scheduledIDToStartedID", func(t *testing.T) {
 		hb := HistoryBuilder{
-			EventStore{scheduledIDToStartedID: make(map[int64]int64), requestIDToEventID: make(map[string]int64)},
+			EventStore{scheduledIDToStartedID: make(map[int64]int64), requestIDToEventID: make(map[string]int64), maxEventBatchSizeInBytes: tests.NewDynamicConfig().MaximumEventBatchSizeInBytes},
 			EventFactory{},
 		}
 		hb.scheduledIDToStartedID[71] = 42
@@ -1212,7 +1213,7 @@ type builderConfig struct {
 func newHistoryBuilderFromConfig(config builderConfig) *HistoryBuilder {
 	ts := clock.NewRealTimeSource()
 	tig := func(n int) ([]int64, error) { return []int64{1, 2, 3, 4, 5}, nil }
-	return New(ts, tig, int64(101), config.nextEventId, config.dbBufferBatch, StubHandler{})
+	return New(ts, tig, int64(101), config.nextEventId, config.dbBufferBatch, StubHandler{}, tests.NewDynamicConfig().MaximumEventBatchSizeInBytes)
 }
 
 func newHistoryBuilder() *HistoryBuilder {

--- a/service/history/historybuilder/history_builder_test.go
+++ b/service/history/historybuilder/history_builder_test.go
@@ -2,6 +2,7 @@ package historybuilder
 
 import (
 	"math/rand"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,10 +23,12 @@ import (
 	workflowspb "go.temporal.io/server/api/workflow/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/service/history/tests"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -152,6 +155,7 @@ func (s *historyBuilderSuite) SetupTest() {
 		s.nextEventID,
 		nil,
 		metrics.NoopMetricsHandler,
+		tests.NewDynamicConfig().MaximumEventBatchSizeInBytes,
 	)
 }
 
@@ -2139,6 +2143,7 @@ func (s *historyBuilderSuite) testWireEventIDs(
 		s.nextEventID,
 		nil,
 		metrics.NoopMetricsHandler,
+		tests.NewDynamicConfig().MaximumEventBatchSizeInBytes,
 	)
 	s.historyBuilder.dbBufferBatch = []*historypb.HistoryEvent{startEvent}
 	s.historyBuilder.memEventsBatches = nil
@@ -2186,6 +2191,7 @@ func (s *historyBuilderSuite) TestHasBufferEvent() {
 		s.nextEventID,
 		nil,
 		metrics.NoopMetricsHandler,
+		tests.NewDynamicConfig().MaximumEventBatchSizeInBytes,
 	)
 	historyBuilder.dbBufferBatch = nil
 	historyBuilder.memEventsBatches = nil
@@ -2676,4 +2682,121 @@ func (s *historyBuilderSuite) taskIDGenerator(number int) ([]int64, error) {
 		nextTaskID++
 	}
 	return result, nil
+}
+
+// newBuilderWithMaxBatchBytes constructs a fresh HistoryBuilder using the
+// suite's task/time fixtures with MaximumEventBatchSizeInBytes overridden.
+func (s *historyBuilderSuite) newBuilderWithMaxBatchBytes(limit int) *HistoryBuilder {
+	return New(
+		s.mockTimeSource,
+		s.taskIDGenerator,
+		s.version,
+		s.nextEventID,
+		nil,
+		metrics.NoopMetricsHandler,
+		dynamicconfig.GetIntPropertyFn(limit),
+	)
+}
+
+func makeMarkerEvent(markerNameSize int) *historypb.HistoryEvent {
+	return &historypb.HistoryEvent{
+		EventType: enumspb.EVENT_TYPE_MARKER_RECORDED,
+		Attributes: &historypb.HistoryEvent_MarkerRecordedEventAttributes{
+			MarkerRecordedEventAttributes: &historypb.MarkerRecordedEventAttributes{
+				MarkerName: strings.Repeat("x", markerNameSize),
+			},
+		},
+	}
+}
+
+func makeBufferedEvent(signalNameSize int) *historypb.HistoryEvent {
+	return &historypb.HistoryEvent{
+		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED,
+		Attributes: &historypb.HistoryEvent_WorkflowExecutionSignaledEventAttributes{
+			WorkflowExecutionSignaledEventAttributes: &historypb.WorkflowExecutionSignaledEventAttributes{
+				SignalName: strings.Repeat("s", signalNameSize),
+			},
+		},
+	}
+}
+
+func (s *historyBuilderSuite) TestEventStore_NoRolloverWhenDisabled() {
+	b := s.newBuilderWithMaxBatchBytes(0)
+
+	for range 5 {
+		_, _ = b.add(makeMarkerEvent(1024))
+	}
+
+	s.Empty(b.memEventsBatches, "no batch should be sealed while feature disabled")
+	s.Len(b.memLatestBatch, 5)
+	s.Equal(0, b.memLatestBatchSize, "size accounting should be skipped when disabled")
+}
+
+func (s *historyBuilderSuite) TestEventStore_RolloverOnSizeThreshold() {
+	eventSize := proto.Size(makeMarkerEvent(500))
+	// Sized such that two events fit and the third forces a rollover.
+	limit := 2*eventSize + eventSize/2
+	b := s.newBuilderWithMaxBatchBytes(limit)
+
+	var batchIDs []int64
+	for range 5 {
+		_, batchID := b.add(makeMarkerEvent(500))
+		batchIDs = append(batchIDs, batchID)
+	}
+
+	s.Len(b.memEventsBatches, 2)
+	s.Len(b.memEventsBatches[0], 2)
+	s.Len(b.memEventsBatches[1], 2)
+	s.Len(b.memLatestBatch, 1)
+
+	s.Equal(batchIDs[0], batchIDs[1])
+	s.Equal(batchIDs[2], batchIDs[3])
+	s.NotEqual(batchIDs[1], batchIDs[2])
+	s.Equal(b.memEventsBatches[0][0].EventId, batchIDs[0])
+	s.Equal(b.memEventsBatches[1][0].EventId, batchIDs[2])
+	s.Equal(b.memLatestBatch[0].EventId, batchIDs[4])
+}
+
+// A single event larger than the configured threshold must still be appended
+func (s *historyBuilderSuite) TestEventStore_SingleOversizedEventAppended() {
+	b := s.newBuilderWithMaxBatchBytes(10)
+
+	_, batchID := b.add(makeMarkerEvent(1024))
+	s.Empty(b.memEventsBatches)
+	s.Len(b.memLatestBatch, 1)
+	s.Equal(b.memLatestBatch[0].EventId, batchID)
+
+	// Adding a second oversized event triggers a rollover so each lives alone.
+	_, batchID2 := b.add(makeMarkerEvent(1024))
+	s.Len(b.memEventsBatches, 1)
+	s.Len(b.memEventsBatches[0], 1)
+	s.Len(b.memLatestBatch, 1)
+	s.NotEqual(batchID, batchID2)
+}
+
+func (s *historyBuilderSuite) TestEventStore_FlushBufferRolloverProducesMultipleBatches() {
+	eventSize := proto.Size(makeBufferedEvent(500))
+	limit := 2*eventSize + eventSize/2
+	b := s.newBuilderWithMaxBatchBytes(limit)
+
+	// Buffered event type: WorkflowExecutionSignaled lands in memBufferBatch.
+	for range 5 {
+		b.memBufferBatch = append(b.memBufferBatch, makeBufferedEvent(500))
+	}
+
+	_, _ = b.FlushBufferToCurrentBatch()
+
+	s.Len(b.memEventsBatches, 2)
+	s.Len(b.memEventsBatches[0], 2)
+	s.Len(b.memEventsBatches[1], 2)
+	s.Len(b.memLatestBatch, 1)
+	s.Empty(b.memBufferBatch)
+
+	all := append([]*historypb.HistoryEvent{}, b.memEventsBatches[0]...)
+	all = append(all, b.memEventsBatches[1]...)
+	all = append(all, b.memLatestBatch...)
+	for i, ev := range all {
+		s.Equal(s.nextEventID+int64(i), ev.EventId)
+		s.NotEqual(common.BufferedEventID, ev.EventId)
+	}
 }

--- a/service/history/historybuilder/history_builder_test.go
+++ b/service/history/historybuilder/history_builder_test.go
@@ -313,7 +313,7 @@ func (s *historyBuilderSuite) TestWorkflowExecutionCancelRequested() {
 		request,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   common.BufferedEventID,
 		TaskId:    common.EmptyEventTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -339,7 +339,7 @@ func (s *historyBuilderSuite) TestWorkflowExecutionSignaled() {
 		signalName, testPayloads, testIdentity, testHeader, nil, "", nil,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   common.BufferedEventID,
 		TaskId:    common.EmptyEventTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -371,7 +371,7 @@ func (s *historyBuilderSuite) TestWorkflowExecutionMarkerRecord() {
 		attributes,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   s.nextEventID,
 		TaskId:    s.nextTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -399,7 +399,7 @@ func (s *historyBuilderSuite) TestWorkflowExecutionSearchAttribute() {
 		attributes,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   s.nextEventID,
 		TaskId:    s.nextTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -424,7 +424,7 @@ func (s *historyBuilderSuite) TestWorkflowExecutionMemo() {
 		attributes,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   s.nextEventID,
 		TaskId:    s.nextTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -450,7 +450,7 @@ func (s *historyBuilderSuite) TestWorkflowExecutionCompleted() {
 		"",
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   s.nextEventID,
 		TaskId:    s.nextTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -479,7 +479,7 @@ func (s *historyBuilderSuite) TestWorkflowExecutionFailed() {
 	)
 	s.Equal(event, s.flush())
 	s.Equal(batchID, event.EventId)
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   s.nextEventID,
 		TaskId:    s.nextTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -502,7 +502,7 @@ func (s *historyBuilderSuite) TestWorkflowExecutionTimeout() {
 		"",
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   s.nextEventID,
 		TaskId:    s.nextTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -526,7 +526,7 @@ func (s *historyBuilderSuite) TestWorkflowExecutionCancelled() {
 		attributes,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   s.nextEventID,
 		TaskId:    s.nextTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -550,7 +550,7 @@ func (s *historyBuilderSuite) TestWorkflowExecutionTerminated() {
 		nil,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   s.nextEventID,
 		TaskId:    s.nextTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -595,7 +595,7 @@ func (s *historyBuilderSuite) TestWorkflowExecutionContinueAsNew() {
 		attributes,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   s.nextEventID,
 		TaskId:    s.nextTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -635,7 +635,7 @@ func (s *historyBuilderSuite) TestWorkflowTaskScheduled() {
 		s.now,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   s.nextEventID,
 		TaskId:    s.nextTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -666,7 +666,7 @@ func (s *historyBuilderSuite) TestWorkflowTaskStarted() {
 		true,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   s.nextEventID,
 		TaskId:    s.nextTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -706,7 +706,7 @@ func (s *historyBuilderSuite) TestWorkflowTaskCompleted() {
 		enumspb.VERSIONING_BEHAVIOR_UNSPECIFIED,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   s.nextEventID,
 		TaskId:    s.nextTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -746,7 +746,7 @@ func (s *historyBuilderSuite) TestWorkflowTaskFailed() {
 		checksum,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   s.nextEventID,
 		TaskId:    s.nextTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -778,7 +778,7 @@ func (s *historyBuilderSuite) TestWorkflowTaskTimeout() {
 		timeoutType,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   s.nextEventID,
 		TaskId:    s.nextTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -822,7 +822,7 @@ func (s *historyBuilderSuite) TestActivityTaskScheduled() {
 		defaultNamespace,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   s.nextEventID,
 		TaskId:    s.nextTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -860,7 +860,7 @@ func (s *historyBuilderSuite) TestActivityTaskStarted() {
 		int64(0),
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   common.BufferedEventID,
 		TaskId:    common.EmptyEventTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -887,7 +887,7 @@ func (s *historyBuilderSuite) TestActivityTaskCancelRequested() {
 		scheduledEventID,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   s.nextEventID,
 		TaskId:    s.nextTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -913,7 +913,7 @@ func (s *historyBuilderSuite) TestActivityTaskCompleted() {
 		defaultNamespace,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   common.BufferedEventID,
 		TaskId:    common.EmptyEventTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -943,7 +943,7 @@ func (s *historyBuilderSuite) TestActivityTaskFailed() {
 		defaultNamespace,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   common.BufferedEventID,
 		TaskId:    common.EmptyEventTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -972,7 +972,7 @@ func (s *historyBuilderSuite) TestActivityTaskTimeout() {
 		retryState,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   common.BufferedEventID,
 		TaskId:    common.EmptyEventTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -1001,7 +1001,7 @@ func (s *historyBuilderSuite) TestActivityTaskCancelled() {
 		testIdentity,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   common.BufferedEventID,
 		TaskId:    common.EmptyEventTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -1035,7 +1035,7 @@ func (s *historyBuilderSuite) TestTimerStarted() {
 		attributes,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   s.nextEventID,
 		TaskId:    s.nextTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -1059,7 +1059,7 @@ func (s *historyBuilderSuite) TestTimerFired() {
 		timerID,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   common.BufferedEventID,
 		TaskId:    common.EmptyEventTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -1085,7 +1085,7 @@ func (s *historyBuilderSuite) TestTimerCancelled() {
 		testIdentity,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   s.nextEventID,
 		TaskId:    s.nextTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -1122,7 +1122,7 @@ func (s *historyBuilderSuite) TestRequestCancelExternalWorkflowExecutionInitiate
 		testNamespaceID,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   s.nextEventID,
 		TaskId:    s.nextTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -1154,7 +1154,7 @@ func (s *historyBuilderSuite) TestRequestCancelExternalWorkflowExecutionSuccess(
 		testRunID,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   common.BufferedEventID,
 		TaskId:    common.EmptyEventTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -1188,7 +1188,7 @@ func (s *historyBuilderSuite) TestRequestCancelExternalWorkflowExecutionFailed()
 		cause,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   common.BufferedEventID,
 		TaskId:    common.EmptyEventTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -1236,7 +1236,7 @@ func (s *historyBuilderSuite) TestSignalExternalWorkflowExecutionInitiated() {
 		testNamespaceID,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   s.nextEventID,
 		TaskId:    s.nextTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -1273,7 +1273,7 @@ func (s *historyBuilderSuite) TestSignalExternalWorkflowExecutionSuccess() {
 		control,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   common.BufferedEventID,
 		TaskId:    common.EmptyEventTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -1310,7 +1310,7 @@ func (s *historyBuilderSuite) TestSignalExternalWorkflowExecutionFailed() {
 		cause,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   common.BufferedEventID,
 		TaskId:    common.EmptyEventTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -1371,7 +1371,7 @@ func (s *historyBuilderSuite) TestStartChildWorkflowExecutionInitiated() {
 		nil,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   s.nextEventID,
 		TaskId:    s.nextTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -1416,7 +1416,7 @@ func (s *historyBuilderSuite) TestStartChildWorkflowExecutionSuccess() {
 		testHeader,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   common.BufferedEventID,
 		TaskId:    common.EmptyEventTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -1454,7 +1454,7 @@ func (s *historyBuilderSuite) TestStartChildWorkflowExecutionFailed() {
 		control,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   common.BufferedEventID,
 		TaskId:    common.EmptyEventTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -1492,7 +1492,7 @@ func (s *historyBuilderSuite) TestChildWorkflowExecutionCompleted() {
 		testPayloads,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   common.BufferedEventID,
 		TaskId:    common.EmptyEventTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -1533,7 +1533,7 @@ func (s *historyBuilderSuite) TestChildWorkflowExecutionFailed() {
 		retryState,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   common.BufferedEventID,
 		TaskId:    common.EmptyEventTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -1574,7 +1574,7 @@ func (s *historyBuilderSuite) TestChildWorkflowExecutionTimeout() {
 		retryState,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   common.BufferedEventID,
 		TaskId:    common.EmptyEventTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -1613,7 +1613,7 @@ func (s *historyBuilderSuite) TestChildWorkflowExecutionCancelled() {
 		testPayloads,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   common.BufferedEventID,
 		TaskId:    common.EmptyEventTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -1651,7 +1651,7 @@ func (s *historyBuilderSuite) TestChildWorkflowExecutionTerminated() {
 		testWorkflowType,
 	)
 	s.Equal(event, s.flush())
-	s.Equal(&historypb.HistoryEvent{
+	protorequire.ProtoEqual(s.T(), &historypb.HistoryEvent{
 		EventId:   common.BufferedEventID,
 		TaskId:    common.EmptyEventTaskID,
 		EventTime: timestamppb.New(s.now),
@@ -2729,7 +2729,8 @@ func (s *historyBuilderSuite) TestEventStore_NoRolloverWhenDisabled() {
 
 	s.Empty(b.memEventsBatches, "no batch should be sealed while feature disabled")
 	s.Len(b.memLatestBatch, 5)
-	s.Equal(0, b.memLatestBatchSize, "size accounting should be skipped when disabled")
+	// Size is still accumulated while the limit is disabled.
+	s.Positive(b.memLatestBatchSize)
 }
 
 func (s *historyBuilderSuite) TestEventStore_RolloverOnSizeThreshold() {

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -408,6 +408,7 @@ func NewMutableState(
 		common.FirstEventID,
 		s.bufferEventsInDB,
 		s.metricsHandler,
+		s.config.MaximumEventBatchSizeInBytes,
 	)
 	s.taskGenerator = GetTaskGeneratorProvider().NewTaskGenerator(shard, s)
 	s.workflowTaskManager = newWorkflowTaskStateMachine(s, s.metricsHandler)
@@ -526,6 +527,7 @@ func NewMutableStateFromDB(
 		dbRecord.NextEventId,
 		dbRecord.BufferedEvents,
 		mutableState.metricsHandler,
+		mutableState.config.MaximumEventBatchSizeInBytes,
 	)
 	mutableState.currentVersion = common.EmptyVersion
 	mutableState.bufferEventsInDB = dbRecord.BufferedEvents
@@ -1155,6 +1157,7 @@ func (ms *MutableStateImpl) UpdateCurrentVersion(
 		ms.nextEventIDInDB,
 		ms.bufferEventsInDB,
 		ms.metricsHandler,
+		ms.config.MaximumEventBatchSizeInBytes,
 	)
 
 	return nil
@@ -8350,6 +8353,7 @@ func (ms *MutableStateImpl) cleanupTransaction() error {
 		ms.nextEventIDInDB,
 		ms.bufferEventsInDB,
 		ms.metricsHandler,
+		ms.config.MaximumEventBatchSizeInBytes,
 	)
 
 	ms.InsertTasks = make(map[tasks.Category][]tasks.Task)

--- a/service/history/workflow/workflow_test/mutable_state_impl_test.go
+++ b/service/history/workflow/workflow_test/mutable_state_impl_test.go
@@ -30,6 +30,7 @@ import (
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/persistence/versionhistory"
+	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/events"
 	"go.temporal.io/server/service/history/hsm"
@@ -382,10 +383,12 @@ func TestGetNexusCompletion(t *testing.T) {
 			},
 			verifyCompletion: func(t *testing.T, event *historypb.HistoryEvent, completion nexusrpc.CompleteOperationOptions) {
 				require.Nil(t, completion.Error)
-				require.Equal(t, &commonpb.Payload{
+				result, ok := completion.Result.(*commonpb.Payload)
+				require.True(t, ok)
+				protorequire.ProtoEqual(t, &commonpb.Payload{
 					Metadata: map[string][]byte{"encoding": []byte("json/plain")},
 					Data:     []byte("3"),
-				}, completion.Result)
+				}, result)
 				require.Equal(t, event.GetEventTime().AsTime(), completion.CloseTime)
 			},
 		},


### PR DESCRIPTION
## What changed?
New `MaximumEventBatchSizeInBytes` dynamic config, disabled by default. When set, EventStore rolls the current in-memory batch and starts a new one before appending an event that would push the cumulative serialized size over the threshold. A single oversized event still gets its own batch. If enabled things will break because of the incorrect event batch id references, so there is a big warning. 

## Why?
This is an initial step for support of workflow tasks completion requests larger than gRPC limit. Today, for such large requests the size of the batch could easily exceed the configured tx limit system.transactionSizeLimit. Because of that, we have to generate smaller batches, which this PR enables to do. 

There are many places in the code, where we assume that the event lands in the same batch as the corresponding WorkflowTaskCompleted event. So currently, if MaximumEventBatchSizeInBytes is set to >0, things will break. But adding this early on allows to find the issues in the code faster, by setting MaximumEventBatchSizeInBytes to a small value.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
This change doesn't have any effect unless MaximumEventBatchSizeInBytes is tuned from the default value of 0. The config comment explicitly says that this is experimental and things will break if it is enabled.
