### PR TITLE
add RESET_REQUESTED state to standalone activity

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -979,9 +979,6 @@ func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetAc
 	case activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED:
 		return nil, serviceerror.NewFailedPrecondition("cannot reset an activity with a pending cancellation")
 	case activitypb.ACTIVITY_EXECUTION_STATUS_STARTED, activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED:
-		if frontendReq.GetResetHeartbeat() {
-			a.ResetHeartbeats = true
-		}
 		if a.Status == activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED && !keepPaused {
 			// Unpause; the deferred reset will apply on the next retry via STARTED->SCHEDULED.
 			if err := TransitionUnpausedWhilePauseRequested.Apply(a, ctx, unpauseEvent{
@@ -1069,14 +1066,6 @@ func (a *Activity) recordScheduleToStartOrCloseTimeoutFailure(ctx chasm.MutableC
 // applyFailedAttempt mutates activity state when a worker yields with retries remaining.
 func (a *Activity) applyFailedAttempt(ctx chasm.MutableContext, event rescheduleEvent) error {
 	attempt := a.LastAttempt.Get(ctx)
-	if a.ActivityReset {
-		attempt.Count = 0
-		a.ActivityReset = false
-		if a.ResetHeartbeats {
-			a.ResetHeartbeats = false
-			a.clearHeartbeat(ctx)
-		}
-	}
 	attempt.Count++
 	attempt.Stamp++
 	return a.recordFailedAttempt(ctx, event.retryInterval, event.failure, ctx.Now(a), false)
@@ -1128,13 +1117,21 @@ func (a *Activity) tryReschedule(
 		return true, TransitionAttemptFailedWhilePauseRequested.Apply(a, ctx, event)
 	}
 	if a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED {
+		// keepPaused=true on a paused activity preserves PauseState across the reset; yield must
+		// land in PAUSED rather than SCHEDULED so the activity stays paused until unpaused.
+		if a.PauseState != nil {
+			return true, TransitionResetAttemptFailedToPaused.Apply(a, ctx, event)
+		}
 		return true, TransitionResetAttemptFailedToScheduled.Apply(a, ctx, event)
 	}
 	return true, TransitionRescheduled.Apply(a, ctx, event)
 }
 
 func (a *Activity) shouldRetry(ctx chasm.Context, overridingRetryInterval time.Duration) (bool, time.Duration) {
-	if !TransitionRescheduled.Possible(a) && !TransitionAttemptFailedWhilePauseRequested.Possible(a) && !TransitionResetAttemptFailedToScheduled.Possible(a) {
+	if !TransitionRescheduled.Possible(a) &&
+		!TransitionAttemptFailedWhilePauseRequested.Possible(a) &&
+		!TransitionResetAttemptFailedToScheduled.Possible(a) &&
+		!TransitionResetAttemptFailedToPaused.Possible(a) {
 		return false, 0
 	}
 	attempt := a.LastAttempt.Get(ctx)
@@ -1229,7 +1226,7 @@ func (a *Activity) RecordHeartbeat(
 	}
 	return &historyservice.RecordActivityTaskHeartbeatResponse{
 		CancelRequested: a.Status == activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
-		ActivityPaused:  a.Status == activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED1,
+		ActivityPaused:  (a.PauseState != nil || a.Status == activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED) && a.Status != activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
 		ActivityReset:   a.Status == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
 	}, nil
 }

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -995,8 +995,7 @@ func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetAc
 			a.ResetHeartbeats = true
 		}
 		// keepPaused on a paused (PAUSE_REQUESTED) activity preserves the pause: when the worker
-		// yields the activity lands back in PAUSED rather than SCHEDULED. Recorded as an explicit
-		// flag so no logic has to gate on the descriptive LastPauseState field.
+		// yields the activity lands back in PAUSED rather than SCHEDULED.
 		a.ResetKeepPaused = keepPaused && a.Status == activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED
 		if err := TransitionResetRequested.Apply(a, ctx, resetEvent{
 			req:          frontendReq,

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -601,7 +601,8 @@ func (a *Activity) UpdateActivityExecutionOptions(
 
 	if a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_STARTED ||
 		a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED ||
-		a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED {
+		a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED ||
+		a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED {
 		// Re-create the start-to-close timeout task with the new stamp and (possibly updated) timeout.
 		// The old task was invalidated by the stamp increment above.
 		if timeout := a.GetStartToCloseTimeout().AsDuration(); timeout > 0 {
@@ -943,7 +944,11 @@ func (a *Activity) reset(ctx chasm.MutableContext, event resetEvent) {
 
 // handleReset handles the activity execution reset.
 // For SCHEDULED/PAUSED activities: immediately re-dispatches at attempt 1.
-// For STARTED/CANCEL_REQUESTED activities: defers the reset to the next retry via the ActivityReset flag.
+// For STARTED activities: transitions to RESET_REQUESTED. The worker is notified via
+// ActivityReset=true on its next heartbeat response and continues to use its existing task token.
+// When the worker yields (failure or timeout with retries remaining), the activity transitions
+// back to SCHEDULED at attempt 1 via TransitionResetAttemptFailedToScheduled.
+// For CANCEL_REQUESTED activities: rejected with FailedPrecondition; cancel takes precedence.
 func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetActivityExecutionRequest) (*activitypb.ResetActivityExecutionResponse, error) {
 	frontendReq := req.GetFrontendRequest()
 	keepPaused := frontendReq.GetKeepPaused()
@@ -970,12 +975,10 @@ func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetAc
 	}
 
 	switch a.Status {
-	case activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
-		activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
-		activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED:
-		// Activity is running. Defer reset to the next retry so we don't break
-		// the running worker's task token (which encodes the current attempt count).
-		a.ActivityReset = true
+
+	case activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED:
+		return nil, serviceerror.NewFailedPrecondition("cannot reset an activity with a pending cancellation")
+	case activitypb.ACTIVITY_EXECUTION_STATUS_STARTED, activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED:
 		if frontendReq.GetResetHeartbeat() {
 			a.ResetHeartbeats = true
 		}
@@ -987,6 +990,24 @@ func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetAc
 			}); err != nil {
 				return nil, err
 			}
+		}
+		// Worker is still executing under its existing task token. Transition to RESET_REQUESTED
+		// so heartbeat/completion calls continue to authenticate; when the worker yields the
+		// activity will land back in SCHEDULED at attempt 1.
+		if frontendReq.GetResetHeartbeat() {
+			a.ResetHeartbeats = true
+		}
+		if !keepPaused {
+			// Clear PauseState now so the deferred reset can dispatch on retry without being
+			// blocked by the validator (which drops dispatch tasks when PauseState != nil).
+			a.PauseState = nil
+		}
+		if err := TransitionResetRequested.Apply(a, ctx, resetEvent{
+			req:          frontendReq,
+			scheduleTime: scheduleTime,
+			handler:      metricsHandler,
+		}); err != nil {
+			return nil, err
 		}
 		a.emitOnResetMetrics(metricsHandler)
 		return &activitypb.ResetActivityExecutionResponse{}, nil
@@ -1088,8 +1109,11 @@ func (a *Activity) recordFailedAttempt(
 }
 
 // tryReschedule attempts to reschedule the activity for retry. Returns true if rescheduled, false
-// if retry is not possible. If a pause request has been received then we transition to Paused;
-// otherwise to Scheduled.
+// if retry is not possible. When the activity has PauseState set (flag-based pause from STARTED),
+// the retry transitions to SCHEDULED normally but the dispatch task is blocked by the pause flag
+// until the activity is unpaused. If a reset request has been received then the retry transitions
+// through TransitionResetAttemptFailedToScheduled which applies the deferred reset (attempt count
+// goes back to 1).
 func (a *Activity) tryReschedule(
 	ctx chasm.MutableContext,
 	overridingRetryInterval time.Duration,
@@ -1103,11 +1127,14 @@ func (a *Activity) tryReschedule(
 	if a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED {
 		return true, TransitionAttemptFailedWhilePauseRequested.Apply(a, ctx, event)
 	}
+	if a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED {
+		return true, TransitionResetAttemptFailedToScheduled.Apply(a, ctx, event)
+	}
 	return true, TransitionRescheduled.Apply(a, ctx, event)
 }
 
 func (a *Activity) shouldRetry(ctx chasm.Context, overridingRetryInterval time.Duration) (bool, time.Duration) {
-	if !TransitionRescheduled.Possible(a) && !TransitionAttemptFailedWhilePauseRequested.Possible(a) {
+	if !TransitionRescheduled.Possible(a) && !TransitionAttemptFailedWhilePauseRequested.Possible(a) && !TransitionResetAttemptFailedToScheduled.Possible(a) {
 		return false, 0
 	}
 	attempt := a.LastAttempt.Get(ctx)
@@ -1202,8 +1229,8 @@ func (a *Activity) RecordHeartbeat(
 	}
 	return &historyservice.RecordActivityTaskHeartbeatResponse{
 		CancelRequested: a.Status == activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
-		ActivityPaused:  a.Status == activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED,
-		ActivityReset:   a.ActivityReset,
+		ActivityPaused:  a.Status == activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED1,
+		ActivityReset:   a.Status == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
 	}, nil
 }
 
@@ -1214,7 +1241,8 @@ func InternalStatusToAPIStatus(status activitypb.ActivityExecutionStatus) enumsp
 		activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
 		activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
 		activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED,
-		activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED:
+		activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED,
+		activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED:
 		return enumspb.ACTIVITY_EXECUTION_STATUS_RUNNING
 	case activitypb.ACTIVITY_EXECUTION_STATUS_COMPLETED:
 		return enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED
@@ -1237,7 +1265,12 @@ func internalStatusToRunState(status activitypb.ActivityExecutionStatus) enumspb
 	switch status {
 	case activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED:
 		return enumspb.PENDING_ACTIVITY_STATE_SCHEDULED
-	case activitypb.ACTIVITY_EXECUTION_STATUS_STARTED:
+	case activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
+		activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED:
+		// RESET_REQUESTED surfaces as STARTED externally — the worker is still executing
+		// under its existing task token; the public PendingActivityState enum does not have
+		// a RESET_REQUESTED variant. The reset is surfaced to the worker via
+		// ActivityReset=true on its next heartbeat response.
 		return enumspb.PENDING_ACTIVITY_STATE_STARTED
 	case activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED:
 		return enumspb.PENDING_ACTIVITY_STATE_CANCEL_REQUESTED
@@ -1473,7 +1506,8 @@ func (a *Activity) validateActivityTaskToken(
 ) error {
 	if a.Status != activitypb.ACTIVITY_EXECUTION_STATUS_STARTED &&
 		a.Status != activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED &&
-		a.Status != activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED {
+		a.Status != activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED &&
+		a.Status != activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED {
 		return serviceerror.NewNotFound("activity task not found")
 	}
 	if token.Attempt != ByIDTokenAttempt && token.Attempt != a.LastAttempt.Get(ctx).GetCount() {

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -798,7 +798,7 @@ func (a *Activity) handlePauseRequested(ctx chasm.MutableContext, req *activityp
 	}
 	if a.isPaused() {
 		newReqID := req.GetFrontendRequest().GetRequestId()
-		existingReqID := a.PauseState.GetRequestId()
+		existingReqID := a.LastPauseState.GetRequestId()
 		if newReqID != "" && existingReqID == newReqID {
 			return &activitypb.PauseActivityExecutionResponse{}, nil
 		}
@@ -903,7 +903,7 @@ func (a *Activity) recordPauseState(
 	ctx chasm.MutableContext,
 	event pauseEvent,
 ) {
-	a.PauseState = &activitypb.ActivityPauseState{
+	a.LastPauseState = &activitypb.ActivityPauseState{
 		PauseTime: timestamppb.New(ctx.Now(a)),
 		Identity:  event.req.GetIdentity(),
 		Reason:    event.req.GetReason(),
@@ -994,11 +994,10 @@ func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetAc
 		if frontendReq.GetResetHeartbeat() {
 			a.ResetHeartbeats = true
 		}
-		if !keepPaused {
-			// Clear PauseState now so the deferred reset can dispatch on retry without being
-			// blocked by the validator (which drops dispatch tasks when PauseState != nil).
-			a.PauseState = nil
-		}
+		// keepPaused on a paused (PAUSE_REQUESTED) activity preserves the pause: when the worker
+		// yields the activity lands back in PAUSED rather than SCHEDULED. Recorded as an explicit
+		// flag so no logic has to gate on the descriptive LastPauseState field.
+		a.ResetKeepPaused = keepPaused && a.Status == activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED
 		if err := TransitionResetRequested.Apply(a, ctx, resetEvent{
 			req:          frontendReq,
 			scheduleTime: scheduleTime,
@@ -1098,11 +1097,10 @@ func (a *Activity) recordFailedAttempt(
 }
 
 // tryReschedule attempts to reschedule the activity for retry. Returns true if rescheduled, false
-// if retry is not possible. When the activity has PauseState set (flag-based pause from STARTED),
-// the retry transitions to SCHEDULED normally but the dispatch task is blocked by the pause flag
-// until the activity is unpaused. If a reset request has been received then the retry transitions
+// if retry is not possible. If a reset request has been received then the retry transitions
 // through TransitionResetAttemptFailedToScheduled which applies the deferred reset (attempt count
-// goes back to 1).
+// goes back to 1), unless the reset was issued with keepPaused (ResetKeepPaused), in which case it
+// transitions through TransitionResetAttemptFailedToPaused and the activity stays paused.
 func (a *Activity) tryReschedule(
 	ctx chasm.MutableContext,
 	overridingRetryInterval time.Duration,
@@ -1117,9 +1115,9 @@ func (a *Activity) tryReschedule(
 		return true, TransitionAttemptFailedWhilePauseRequested.Apply(a, ctx, event)
 	}
 	if a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED {
-		// keepPaused=true on a paused activity preserves PauseState across the reset; yield must
-		// land in PAUSED rather than SCHEDULED so the activity stays paused until unpaused.
-		if a.PauseState != nil {
+		// keepPaused=true on a paused activity (ResetKeepPaused) requires the yield to land in
+		// PAUSED rather than SCHEDULED so the activity stays paused until unpaused.
+		if a.ResetKeepPaused {
 			return true, TransitionResetAttemptFailedToPaused.Apply(a, ctx, event)
 		}
 		return true, TransitionResetAttemptFailedToScheduled.Apply(a, ctx, event)
@@ -1226,7 +1224,7 @@ func (a *Activity) RecordHeartbeat(
 	}
 	return &historyservice.RecordActivityTaskHeartbeatResponse{
 		CancelRequested: a.Status == activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
-		ActivityPaused:  (a.PauseState != nil || a.Status == activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED) && a.Status != activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
+		ActivityPaused:  a.Status == activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED || (a.Status == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED && a.ResetKeepPaused),
 		ActivityReset:   a.Status == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
 	}, nil
 }

--- a/chasm/lib/activity/activity_tasks.go
+++ b/chasm/lib/activity/activity_tasks.go
@@ -177,7 +177,8 @@ func (h *startToCloseTimeoutTaskHandler) Validate(
 ) (bool, error) {
 	valid := ((activity.Status == activitypb.ACTIVITY_EXECUTION_STATUS_STARTED ||
 		activity.Status == activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED ||
-		activity.Status == activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED) &&
+		activity.Status == activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED ||
+		activity.Status == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED) &&
 		task.Stamp == activity.LastAttempt.Get(ctx).GetStamp())
 	return valid, nil
 }
@@ -239,7 +240,8 @@ func (h *heartbeatTimeoutTaskHandler) Validate(
 	// Execute function runs and we fail the attempt.
 	if activity.Status != activitypb.ACTIVITY_EXECUTION_STATUS_STARTED &&
 		activity.Status != activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED &&
-		activity.Status != activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED {
+		activity.Status != activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED &&
+		activity.Status != activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED {
 		return false, nil
 	}
 	// Task attempt must still match current attempt.

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -270,12 +270,12 @@ func TestRecordHeartbeatPauseResetCancelFlags(t *testing.T) {
 	require.NoError(t, err)
 
 	testCases := []struct {
-		name          string
-		status        activitypb.ActivityExecutionStatus
-		activityReset bool
-		wantPaused    bool
-		wantReset     bool
-		wantCancel    bool
+		name       string
+		status     activitypb.ActivityExecutionStatus
+		pauseState *activitypb.ActivityPauseState
+		wantPaused bool
+		wantReset  bool
+		wantCancel bool
 	}{
 		{
 			name:   "no pause or reset returns zero flags",
@@ -285,10 +285,9 @@ func TestRecordHeartbeatPauseResetCancelFlags(t *testing.T) {
 			// Regression guard: reset must propagate to the next heartbeat response
 			// immediately so the worker can abort the in-flight attempt; previously
 			// reset was withheld until the next retry.
-			name:          "reset set propagates ActivityReset on next heartbeat",
-			status:        activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
-			activityReset: true,
-			wantReset:     true,
+			name:      "RESET_REQUESTED status propagates ActivityReset on next heartbeat",
+			status:    activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
+			wantReset: true,
 		},
 		{
 			name:       "PAUSE_REQUESTED status propagates ActivityPaused",
@@ -296,18 +295,16 @@ func TestRecordHeartbeatPauseResetCancelFlags(t *testing.T) {
 			wantPaused: true,
 		},
 		{
-			name:          "pause and reset both propagate",
-			status:        activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED,
-			activityReset: true,
-			wantPaused:    true,
-			wantReset:     true,
+			name:       "pause and reset both propagate",
+			status:     activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
+			pauseState: &activitypb.ActivityPauseState{PauseTime: timestamppb.New(testTime)},
+			wantPaused: true,
+			wantReset:  true,
 		},
 		{
-			name:          "cancel requested coexists with reset",
-			status:        activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
-			activityReset: true,
-			wantCancel:    true,
-			wantReset:     true,
+			name:       "cancel requested status propagates CancelRequested",
+			status:     activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
+			wantCancel: true,
 		},
 	}
 
@@ -330,7 +327,7 @@ func TestRecordHeartbeatPauseResetCancelFlags(t *testing.T) {
 				ActivityState: &activitypb.ActivityState{
 					Status:           tc.status,
 					HeartbeatTimeout: durationpb.New(0),
-					ActivityReset:    tc.activityReset,
+					PauseState:       tc.pauseState,
 				},
 				LastAttempt: chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{Count: attempt}),
 			}

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -270,12 +270,12 @@ func TestRecordHeartbeatPauseResetCancelFlags(t *testing.T) {
 	require.NoError(t, err)
 
 	testCases := []struct {
-		name       string
-		status     activitypb.ActivityExecutionStatus
-		pauseState *activitypb.ActivityPauseState
-		wantPaused bool
-		wantReset  bool
-		wantCancel bool
+		name            string
+		status          activitypb.ActivityExecutionStatus
+		resetKeepPaused bool
+		wantPaused      bool
+		wantReset       bool
+		wantCancel      bool
 	}{
 		{
 			name:   "no pause or reset returns zero flags",
@@ -295,11 +295,13 @@ func TestRecordHeartbeatPauseResetCancelFlags(t *testing.T) {
 			wantPaused: true,
 		},
 		{
-			name:       "pause and reset both propagate",
-			status:     activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
-			pauseState: &activitypb.ActivityPauseState{PauseTime: timestamppb.New(testTime)},
-			wantPaused: true,
-			wantReset:  true,
+			// A reset issued with keepPaused on a paused activity sets ResetKeepPaused; the worker
+			// must be told it is both paused and being reset.
+			name:            "reset with keep-paused propagates both paused and reset",
+			status:          activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
+			resetKeepPaused: true,
+			wantPaused:      true,
+			wantReset:       true,
 		},
 		{
 			name:       "cancel requested status propagates CancelRequested",
@@ -327,7 +329,7 @@ func TestRecordHeartbeatPauseResetCancelFlags(t *testing.T) {
 				ActivityState: &activitypb.ActivityState{
 					Status:           tc.status,
 					HeartbeatTimeout: durationpb.New(0),
-					PauseState:       tc.pauseState,
+					ResetKeepPaused:  tc.resetKeepPaused,
 				},
 				LastAttempt: chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{Count: attempt}),
 			}

--- a/chasm/lib/activity/gen/activitypb/v1/activity_state.go-helpers.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/activity_state.go-helpers.pb.go
@@ -316,6 +316,7 @@ var (
 		"TimedOut":        8,
 		"Paused":          9,
 		"PauseRequested":  10,
+		"ResetRequested":  11,
 	}
 )
 

--- a/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
@@ -71,6 +71,12 @@ const (
 	// heartbeat response. When the worker yields due to failure with retries remaining, or due to
 	// timeout with retries remaining, the activity will transition to PAUSED.
 	ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED ActivityExecutionStatus = 10
+	// An operator reset was issued while the activity was STARTED. The worker is still executing
+	// under its existing task token; status remains in the worker-token-valid set so heartbeat and
+	// completion calls continue to authenticate. The worker is notified via ActivityReset=true on
+	// its next heartbeat response. When the worker yields (failure or timeout with retries
+	// remaining), the activity transitions back to SCHEDULED at attempt 1.
+	ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED ActivityExecutionStatus = 11
 )
 
 // Enum value maps for ActivityExecutionStatus.
@@ -87,6 +93,7 @@ var (
 		8:  "ACTIVITY_EXECUTION_STATUS_TIMED_OUT",
 		9:  "ACTIVITY_EXECUTION_STATUS_PAUSED",
 		10: "ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED",
+		11: "ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED",
 	}
 	ActivityExecutionStatus_value = map[string]int32{
 		"ACTIVITY_EXECUTION_STATUS_UNSPECIFIED":      0,
@@ -100,6 +107,7 @@ var (
 		"ACTIVITY_EXECUTION_STATUS_TIMED_OUT":        8,
 		"ACTIVITY_EXECUTION_STATUS_PAUSED":           9,
 		"ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED":  10,
+		"ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED":  11,
 	}
 )
 
@@ -135,6 +143,8 @@ func (x ActivityExecutionStatus) String() string {
 		return "Paused"
 	case ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED:
 		return "PauseRequested"
+	case ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED:
+		return "ResetRequested"
 	default:
 		return strconv.Itoa(int(x))
 	}
@@ -214,11 +224,10 @@ type ActivityState struct {
 	ScheduleToCloseStamp int32 `protobuf:"varint,15,opt,name=schedule_to_close_stamp,json=scheduleToCloseStamp,proto3" json:"schedule_to_close_stamp,omitempty"`
 	// Set if the activity was paused.
 	PauseState *ActivityPauseState `protobuf:"bytes,16,opt,name=pause_state,json=pauseState,proto3" json:"pause_state,omitempty"`
-	// Set when reset was requested while the activity was running.
-	// On the next retry, TransitionRescheduled will reset the attempt count to 1 before incrementing.
-	ActivityReset bool `protobuf:"varint,17,opt,name=activity_reset,json=activityReset,proto3" json:"activity_reset,omitempty"`
-	// Set alongside activity_reset when heartbeat details should be cleared on the next retry.
-	ResetHeartbeats bool `protobuf:"varint,18,opt,name=reset_heartbeats,json=resetHeartbeats,proto3" json:"reset_heartbeats,omitempty"`
+	// Set when reset was requested while the activity was STARTED and the operator asked for
+	// heartbeat details to be cleared on the next retry. Consumed when the worker yields and the
+	// activity transitions out of RESET_REQUESTED.
+	ResetHeartbeats bool `protobuf:"varint,17,opt,name=reset_heartbeats,json=resetHeartbeats,proto3" json:"reset_heartbeats,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -363,13 +372,6 @@ func (x *ActivityState) GetPauseState() *ActivityPauseState {
 		return x.PauseState
 	}
 	return nil
-}
-
-func (x *ActivityState) GetActivityReset() bool {
-	if x != nil {
-		return x.ActivityReset
-	}
-	return false
 }
 
 func (x *ActivityState) GetResetHeartbeats() bool {
@@ -1046,7 +1048,7 @@ var File_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto protor
 
 const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawDesc = "" +
 	"\n" +
-	"@temporal/server/chasm/lib/activity/proto/v1/activity_state.proto\x12+temporal.server.chasm.lib.activity.proto.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&temporal/api/activity/v1/message.proto\x1a$temporal/api/common/v1/message.proto\x1a(temporal/api/deployment/v1/message.proto\x1a%temporal/api/failure/v1/message.proto\x1a'temporal/api/sdk/v1/user_metadata.proto\x1a'temporal/api/taskqueue/v1/message.proto\"\xd8\n" +
+	"@temporal/server/chasm/lib/activity/proto/v1/activity_state.proto\x12+temporal.server.chasm.lib.activity.proto.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&temporal/api/activity/v1/message.proto\x1a$temporal/api/common/v1/message.proto\x1a(temporal/api/deployment/v1/message.proto\x1a%temporal/api/failure/v1/message.proto\x1a'temporal/api/sdk/v1/user_metadata.proto\x1a'temporal/api/taskqueue/v1/message.proto\"\xb1\n" +
 	"\n" +
 	"\rActivityState\x12I\n" +
 	"\ractivity_type\x18\x01 \x01(\v2$.temporal.api.common.v1.ActivityTypeR\factivityType\x12C\n" +
@@ -1068,9 +1070,8 @@ const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawD
 	"\x10original_options\x18\x0e \x01(\v2).temporal.api.activity.v1.ActivityOptionsR\x0foriginalOptions\x125\n" +
 	"\x17schedule_to_close_stamp\x18\x0f \x01(\x05R\x14scheduleToCloseStamp\x12`\n" +
 	"\vpause_state\x18\x10 \x01(\v2?.temporal.server.chasm.lib.activity.proto.v1.ActivityPauseStateR\n" +
-	"pauseState\x12%\n" +
-	"\x0eactivity_reset\x18\x11 \x01(\bR\ractivityReset\x12)\n" +
-	"\x10reset_heartbeats\x18\x12 \x01(\bR\x0fresetHeartbeats\"\xa7\x01\n" +
+	"pauseState\x12)\n" +
+	"\x10reset_heartbeats\x18\x11 \x01(\bR\x0fresetHeartbeats\"\xa7\x01\n" +
 	"\x13ActivityCancelState\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x01 \x01(\tR\trequestId\x12=\n" +
@@ -1118,7 +1119,7 @@ const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawD
 	"\x06output\x18\x01 \x01(\v2 .temporal.api.common.v1.PayloadsR\x06output\x1aD\n" +
 	"\x06Failed\x12:\n" +
 	"\afailure\x18\x01 \x01(\v2 .temporal.api.failure.v1.FailureR\afailureB\t\n" +
-	"\avariant*\xe3\x03\n" +
+	"\avariant*\x92\x04\n" +
 	"\x17ActivityExecutionStatus\x12)\n" +
 	"%ACTIVITY_EXECUTION_STATUS_UNSPECIFIED\x10\x00\x12'\n" +
 	"#ACTIVITY_EXECUTION_STATUS_SCHEDULED\x10\x01\x12%\n" +
@@ -1131,7 +1132,8 @@ const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawD
 	"#ACTIVITY_EXECUTION_STATUS_TIMED_OUT\x10\b\x12$\n" +
 	" ACTIVITY_EXECUTION_STATUS_PAUSED\x10\t\x12-\n" +
 	")ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED\x10\n" +
-	"BDZBgo.temporal.io/server/chasm/lib/activity/gen/activitypb;activitypbb\x06proto3"
+	"\x12-\n" +
+	")ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED\x10\vBDZBgo.temporal.io/server/chasm/lib/activity/gen/activitypb;activitypbb\x06proto3"
 
 var (
 	file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawDescOnce sync.Once

--- a/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
@@ -222,12 +222,19 @@ type ActivityState struct {
 	// and on each options update that re-schedules the task). Unlike attempt.stamp, this counter
 	// is NOT incremented on retries, because schedule-to-close spans the full activity lifetime.
 	ScheduleToCloseStamp int32 `protobuf:"varint,15,opt,name=schedule_to_close_stamp,json=scheduleToCloseStamp,proto3" json:"schedule_to_close_stamp,omitempty"`
-	// Set if the activity was paused.
-	PauseState *ActivityPauseState `protobuf:"bytes,16,opt,name=pause_state,json=pauseState,proto3" json:"pause_state,omitempty"`
+	// The most recent pause request, if the activity has ever been paused. Like cancel_state and
+	// terminate_state this is never cleared; unlike them it may be non-current (the activity may have
+	// since been unpaused), hence the "last" prefix. No logic gates on this field — it is descriptive
+	// metadata only.
+	LastPauseState *ActivityPauseState `protobuf:"bytes,16,opt,name=last_pause_state,json=lastPauseState,proto3" json:"last_pause_state,omitempty"`
 	// Set when reset was requested while the activity was STARTED and the operator asked for
 	// heartbeat details to be cleared on the next retry. Consumed when the worker yields and the
 	// activity transitions out of RESET_REQUESTED.
 	ResetHeartbeats bool `protobuf:"varint,17,opt,name=reset_heartbeats,json=resetHeartbeats,proto3" json:"reset_heartbeats,omitempty"`
+	// Set when a reset is requested with keep_paused=true on a paused (PAUSE_REQUESTED) activity, so
+	// that when the worker yields the activity lands back in PAUSED rather than SCHEDULED. Consumed
+	// when the activity transitions out of RESET_REQUESTED.
+	ResetKeepPaused bool `protobuf:"varint,18,opt,name=reset_keep_paused,json=resetKeepPaused,proto3" json:"reset_keep_paused,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -367,9 +374,9 @@ func (x *ActivityState) GetScheduleToCloseStamp() int32 {
 	return 0
 }
 
-func (x *ActivityState) GetPauseState() *ActivityPauseState {
+func (x *ActivityState) GetLastPauseState() *ActivityPauseState {
 	if x != nil {
-		return x.PauseState
+		return x.LastPauseState
 	}
 	return nil
 }
@@ -377,6 +384,13 @@ func (x *ActivityState) GetPauseState() *ActivityPauseState {
 func (x *ActivityState) GetResetHeartbeats() bool {
 	if x != nil {
 		return x.ResetHeartbeats
+	}
+	return false
+}
+
+func (x *ActivityState) GetResetKeepPaused() bool {
+	if x != nil {
+		return x.ResetKeepPaused
 	}
 	return false
 }
@@ -1048,7 +1062,7 @@ var File_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto protor
 
 const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawDesc = "" +
 	"\n" +
-	"@temporal/server/chasm/lib/activity/proto/v1/activity_state.proto\x12+temporal.server.chasm.lib.activity.proto.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&temporal/api/activity/v1/message.proto\x1a$temporal/api/common/v1/message.proto\x1a(temporal/api/deployment/v1/message.proto\x1a%temporal/api/failure/v1/message.proto\x1a'temporal/api/sdk/v1/user_metadata.proto\x1a'temporal/api/taskqueue/v1/message.proto\"\xb1\n" +
+	"@temporal/server/chasm/lib/activity/proto/v1/activity_state.proto\x12+temporal.server.chasm.lib.activity.proto.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&temporal/api/activity/v1/message.proto\x1a$temporal/api/common/v1/message.proto\x1a(temporal/api/deployment/v1/message.proto\x1a%temporal/api/failure/v1/message.proto\x1a'temporal/api/sdk/v1/user_metadata.proto\x1a'temporal/api/taskqueue/v1/message.proto\"\xe6\n" +
 	"\n" +
 	"\rActivityState\x12I\n" +
 	"\ractivity_type\x18\x01 \x01(\v2$.temporal.api.common.v1.ActivityTypeR\factivityType\x12C\n" +
@@ -1068,10 +1082,10 @@ const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawD
 	"\vstart_delay\x18\r \x01(\v2\x19.google.protobuf.DurationR\n" +
 	"startDelay\x12T\n" +
 	"\x10original_options\x18\x0e \x01(\v2).temporal.api.activity.v1.ActivityOptionsR\x0foriginalOptions\x125\n" +
-	"\x17schedule_to_close_stamp\x18\x0f \x01(\x05R\x14scheduleToCloseStamp\x12`\n" +
-	"\vpause_state\x18\x10 \x01(\v2?.temporal.server.chasm.lib.activity.proto.v1.ActivityPauseStateR\n" +
-	"pauseState\x12)\n" +
-	"\x10reset_heartbeats\x18\x11 \x01(\bR\x0fresetHeartbeats\"\xa7\x01\n" +
+	"\x17schedule_to_close_stamp\x18\x0f \x01(\x05R\x14scheduleToCloseStamp\x12i\n" +
+	"\x10last_pause_state\x18\x10 \x01(\v2?.temporal.server.chasm.lib.activity.proto.v1.ActivityPauseStateR\x0elastPauseState\x12)\n" +
+	"\x10reset_heartbeats\x18\x11 \x01(\bR\x0fresetHeartbeats\x12*\n" +
+	"\x11reset_keep_paused\x18\x12 \x01(\bR\x0fresetKeepPaused\"\xa7\x01\n" +
 	"\x13ActivityCancelState\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x01 \x01(\tR\trequestId\x12=\n" +
@@ -1190,7 +1204,7 @@ var file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_depIdx
 	3,  // 11: temporal.server.chasm.lib.activity.proto.v1.ActivityState.terminate_state:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityTerminateState
 	14, // 12: temporal.server.chasm.lib.activity.proto.v1.ActivityState.start_delay:type_name -> google.protobuf.Duration
 	18, // 13: temporal.server.chasm.lib.activity.proto.v1.ActivityState.original_options:type_name -> temporal.api.activity.v1.ActivityOptions
-	4,  // 14: temporal.server.chasm.lib.activity.proto.v1.ActivityState.pause_state:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityPauseState
+	4,  // 14: temporal.server.chasm.lib.activity.proto.v1.ActivityState.last_pause_state:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityPauseState
 	16, // 15: temporal.server.chasm.lib.activity.proto.v1.ActivityCancelState.request_time:type_name -> google.protobuf.Timestamp
 	16, // 16: temporal.server.chasm.lib.activity.proto.v1.ActivityPauseState.pause_time:type_name -> google.protobuf.Timestamp
 	14, // 17: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.current_retry_interval:type_name -> google.protobuf.Duration

--- a/chasm/lib/activity/proto/v1/activity_state.proto
+++ b/chasm/lib/activity/proto/v1/activity_state.proto
@@ -122,13 +122,21 @@ message ActivityState {
   // is NOT incremented on retries, because schedule-to-close spans the full activity lifetime.
   int32 schedule_to_close_stamp = 15;
 
-  // Set if the activity was paused.
-  ActivityPauseState pause_state = 16;
+  // The most recent pause request, if the activity has ever been paused. Like cancel_state and
+  // terminate_state this is never cleared; unlike them it may be non-current (the activity may have
+  // since been unpaused), hence the "last" prefix. No logic gates on this field — it is descriptive
+  // metadata only.
+  ActivityPauseState last_pause_state = 16;
 
   // Set when reset was requested while the activity was STARTED and the operator asked for
   // heartbeat details to be cleared on the next retry. Consumed when the worker yields and the
   // activity transitions out of RESET_REQUESTED.
   bool reset_heartbeats = 17;
+
+  // Set when a reset is requested with keep_paused=true on a paused (PAUSE_REQUESTED) activity, so
+  // that when the worker yields the activity lands back in PAUSED rather than SCHEDULED. Consumed
+  // when the activity transitions out of RESET_REQUESTED.
+  bool reset_keep_paused = 18;
 }
 
 message ActivityCancelState {

--- a/chasm/lib/activity/proto/v1/activity_state.proto
+++ b/chasm/lib/activity/proto/v1/activity_state.proto
@@ -52,6 +52,12 @@ enum ActivityExecutionStatus {
   // heartbeat response. When the worker yields due to failure with retries remaining, or due to
   // timeout with retries remaining, the activity will transition to PAUSED.
   ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED = 10;
+  // An operator reset was issued while the activity was STARTED. The worker is still executing
+  // under its existing task token; status remains in the worker-token-valid set so heartbeat and
+  // completion calls continue to authenticate. The worker is notified via ActivityReset=true on
+  // its next heartbeat response. When the worker yields (failure or timeout with retries
+  // remaining), the activity transitions back to SCHEDULED at attempt 1.
+  ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED = 11;
 }
 
 message ActivityState {
@@ -119,12 +125,10 @@ message ActivityState {
   // Set if the activity was paused.
   ActivityPauseState pause_state = 16;
 
-  // Set when reset was requested while the activity was running.
-  // On the next retry, TransitionRescheduled will reset the attempt count to 1 before incrementing.
-  bool activity_reset = 17;
-
-  // Set alongside activity_reset when heartbeat details should be cleared on the next retry.
-  bool reset_heartbeats = 18;
+  // Set when reset was requested while the activity was STARTED and the operator asked for
+  // heartbeat details to be cleared on the next retry. Consumed when the worker yields and the
+  // activity transitions out of RESET_REQUESTED.
+  bool reset_heartbeats = 17;
 }
 
 message ActivityCancelState {

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -189,7 +189,6 @@ var TransitionCompleted = chasm.NewTransition(
 	activitypb.ACTIVITY_EXECUTION_STATUS_COMPLETED,
 	func(a *Activity, ctx chasm.MutableContext, event completeEvent) error {
 		return a.StoreOrSelf(ctx).RecordCompleted(ctx, func(ctx chasm.MutableContext) error {
-			a.ActivityReset = false
 			a.PauseState = nil
 			a.ResetHeartbeats = false
 
@@ -229,7 +228,6 @@ var TransitionFailed = chasm.NewTransition(
 	func(a *Activity, ctx chasm.MutableContext, event failedEvent) error {
 		return a.StoreOrSelf(ctx).RecordCompleted(ctx, func(ctx chasm.MutableContext) error {
 			req := event.req.GetFailedRequest()
-			a.ActivityReset = false
 			a.PauseState = nil
 			a.ResetHeartbeats = false
 
@@ -274,7 +272,6 @@ var TransitionTerminated = chasm.NewTransition(
 			a.TerminateState = &activitypb.ActivityTerminateState{
 				RequestId: event.request.RequestID,
 			}
-			a.ActivityReset = false
 			a.PauseState = nil
 			a.ResetHeartbeats = false
 			outcome := a.Outcome.Get(ctx)
@@ -351,7 +348,6 @@ var TransitionCanceled = chasm.NewTransition(
 					Failure: failure,
 				},
 			}
-			a.ActivityReset = false
 			a.PauseState = nil
 			a.ResetHeartbeats = false
 
@@ -401,7 +397,6 @@ var TransitionTimedOut = chasm.NewTransition(
 				return err
 			}
 
-			a.ActivityReset = false
 			a.PauseState = nil
 			a.ResetHeartbeats = false
 
@@ -514,17 +509,43 @@ var TransitionReset = chasm.NewTransition(
 	},
 )
 
-// TransitionResetRequested transitions a STARTED activity to RESET_REQUESTED. The worker is still
-// in charge of the activity. It will be notified via ActivityReset=true on its next heartbeat
-// response, its task token is not invalidated by this transition, and there is no stamp bump since
-// StartToCloseTimeoutTask and HeartbeatTimeoutTask must stay valid.
+// TransitionResetRequested transitions a STARTED or PAUSE_REQUESTED activity to RESET_REQUESTED.
+// PAUSE_REQUESTED is allowed when the operator issues reset with keepPaused=true: PauseState is
+// preserved across the transition so the activity lands back in PAUSED (not SCHEDULED) when the
+// worker yields. The worker is still in charge of the activity; it will be notified via
+// ActivityReset=true on its next heartbeat response, its task token is not invalidated by this
+// transition, and there is no stamp bump since StartToCloseTimeoutTask and HeartbeatTimeoutTask
+// must stay valid.
 var TransitionResetRequested = chasm.NewTransition(
 	[]activitypb.ActivityExecutionStatus{
 		activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
+		activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED,
 	},
 	activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
 	func(a *Activity, ctx chasm.MutableContext, _ resetEvent) error {
 		return nil
+	},
+)
+
+// TransitionResetAttemptFailedToPaused transitions RESET_REQUESTED → PAUSED. It is performed
+// when the worker yields in RESET_REQUESTED with PauseState still set (i.e. reset was issued with
+// keepPaused=true while the activity was in PAUSE_REQUESTED). The failed attempt is recorded, the
+// attempt count is reset to 1, and no dispatch task is emitted — the activity stays paused until
+// an explicit unpause.
+var TransitionResetAttemptFailedToPaused = chasm.NewTransition(
+	[]activitypb.ActivityExecutionStatus{
+		activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
+	},
+	activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED,
+	func(a *Activity, ctx chasm.MutableContext, event rescheduleEvent) error {
+		attempt := a.LastAttempt.Get(ctx)
+		if a.ResetHeartbeats {
+			a.ResetHeartbeats = false
+			a.clearHeartbeat(ctx)
+		}
+		attempt.Count = 1
+		attempt.Stamp++
+		return a.recordFailedAttempt(ctx, event.retryInterval, event.failure, ctx.Now(a), false)
 	},
 )
 

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -184,11 +184,13 @@ var TransitionCompleted = chasm.NewTransition(
 		activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
 		activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
 		activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED,
+		activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
 	},
 	activitypb.ACTIVITY_EXECUTION_STATUS_COMPLETED,
 	func(a *Activity, ctx chasm.MutableContext, event completeEvent) error {
 		return a.StoreOrSelf(ctx).RecordCompleted(ctx, func(ctx chasm.MutableContext) error {
 			a.ActivityReset = false
+			a.PauseState = nil
 			a.ResetHeartbeats = false
 
 			req := event.req.GetCompleteRequest()
@@ -221,12 +223,14 @@ var TransitionFailed = chasm.NewTransition(
 		activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
 		activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
 		activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED,
+		activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
 	},
 	activitypb.ACTIVITY_EXECUTION_STATUS_FAILED,
 	func(a *Activity, ctx chasm.MutableContext, event failedEvent) error {
 		return a.StoreOrSelf(ctx).RecordCompleted(ctx, func(ctx chasm.MutableContext) error {
 			req := event.req.GetFailedRequest()
 			a.ActivityReset = false
+			a.PauseState = nil
 			a.ResetHeartbeats = false
 
 			if details := req.GetLastHeartbeatDetails(); details != nil {
@@ -262,6 +266,7 @@ var TransitionTerminated = chasm.NewTransition(
 		activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
 		activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED,
 		activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED,
+		activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
 	},
 	activitypb.ACTIVITY_EXECUTION_STATUS_TERMINATED,
 	func(a *Activity, ctx chasm.MutableContext, event terminateEvent) error {
@@ -270,6 +275,7 @@ var TransitionTerminated = chasm.NewTransition(
 				RequestId: event.request.RequestID,
 			}
 			a.ActivityReset = false
+			a.PauseState = nil
 			a.ResetHeartbeats = false
 			outcome := a.Outcome.Get(ctx)
 			failure := &failurepb.Failure{
@@ -301,6 +307,7 @@ var TransitionCancelRequested = chasm.NewTransition(
 		activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
 		activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED,
 		activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED,
+		activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
 	},
 	activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
 	func(a *Activity, ctx chasm.MutableContext, req *workflowservice.RequestCancelActivityExecutionRequest) error {
@@ -345,6 +352,7 @@ var TransitionCanceled = chasm.NewTransition(
 				},
 			}
 			a.ActivityReset = false
+			a.PauseState = nil
 			a.ResetHeartbeats = false
 
 			a.emitOnCanceledMetrics(ctx, event.handler, event.fromStatus)
@@ -368,6 +376,7 @@ var TransitionTimedOut = chasm.NewTransition(
 		activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
 		activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED,
 		activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED,
+		activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
 	},
 	activitypb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT,
 	func(a *Activity, ctx chasm.MutableContext, event timeoutEvent) error {
@@ -393,6 +402,7 @@ var TransitionTimedOut = chasm.NewTransition(
 			}
 
 			a.ActivityReset = false
+			a.PauseState = nil
 			a.ResetHeartbeats = false
 
 			a.emitOnTimedOutMetrics(ctx, event.metricsHandler, timeoutType, event.fromStatus)
@@ -489,7 +499,9 @@ type resetEvent struct {
 
 // TransitionReset resets a SCHEDULED or PAUSED activity back to attempt 1. The stamp is bumped to
 // invalidate any pending dispatch task, then a new dispatch task is added at the given schedule time.
-// For STARTED/CANCEL_REQUESTED activities the reset is deferred — see Activity.ActivityReset flag.
+// For STARTED activities the reset is deferred — the activity transitions to RESET_REQUESTED via
+// TransitionResetRequested and lands back in SCHEDULED via TransitionResetAttemptFailedToScheduled
+// when the worker yields.
 var TransitionReset = chasm.NewTransition(
 	[]activitypb.ActivityExecutionStatus{
 		activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
@@ -498,6 +510,70 @@ var TransitionReset = chasm.NewTransition(
 	activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
 	func(a *Activity, ctx chasm.MutableContext, event resetEvent) error {
 		a.reset(ctx, event)
+		return nil
+	},
+)
+
+// TransitionResetRequested transitions a STARTED activity to RESET_REQUESTED. The worker is still
+// in charge of the activity. It will be notified via ActivityReset=true on its next heartbeat
+// response, its task token is not invalidated by this transition, and there is no stamp bump since
+// StartToCloseTimeoutTask and HeartbeatTimeoutTask must stay valid.
+var TransitionResetRequested = chasm.NewTransition(
+	[]activitypb.ActivityExecutionStatus{
+		activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
+	},
+	activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
+	func(a *Activity, ctx chasm.MutableContext, _ resetEvent) error {
+		return nil
+	},
+)
+
+// TransitionResetAttemptFailedToScheduled transitions RESET_REQUESTED → SCHEDULED. It is performed
+// instead of TransitionRescheduled when the activity is in RESET_REQUESTED and the worker yields
+// (failure or timeout) with retries remaining. The failed attempt is recorded, the count is reset
+// to 0 and then incremented to 1 (so the next attempt is "attempt 1"), and a fresh dispatch task
+// is emitted at the next retry time.
+var TransitionResetAttemptFailedToScheduled = chasm.NewTransition(
+	[]activitypb.ActivityExecutionStatus{
+		activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
+	},
+	activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+	func(a *Activity, ctx chasm.MutableContext, event rescheduleEvent) error {
+		attempt := a.LastAttempt.Get(ctx)
+		currentTime := ctx.Now(a)
+
+		if a.ResetHeartbeats {
+			a.ResetHeartbeats = false
+			a.clearHeartbeat(ctx)
+		}
+
+		attempt.Count = 1
+		attempt.Stamp++
+
+		if err := a.recordFailedAttempt(ctx, event.retryInterval, event.failure, currentTime, false); err != nil {
+			return err
+		}
+
+		retryScheduledTime := attemptScheduleTimeForRetry(attempt).AsTime()
+		if timeout := a.GetScheduleToStartTimeout().AsDuration(); timeout > 0 {
+			ctx.AddTask(
+				a,
+				chasm.TaskAttributes{
+					ScheduledTime: retryScheduledTime.Add(timeout),
+				},
+				&activitypb.ScheduleToStartTimeoutTask{
+					Stamp: attempt.GetStamp(),
+				})
+		}
+		ctx.AddTask(
+			a,
+			chasm.TaskAttributes{
+				ScheduledTime: retryScheduledTime,
+			},
+			&activitypb.ActivityDispatchTask{
+				Stamp: attempt.GetStamp(),
+			})
+
 		return nil
 	},
 )

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -189,7 +189,6 @@ var TransitionCompleted = chasm.NewTransition(
 	activitypb.ACTIVITY_EXECUTION_STATUS_COMPLETED,
 	func(a *Activity, ctx chasm.MutableContext, event completeEvent) error {
 		return a.StoreOrSelf(ctx).RecordCompleted(ctx, func(ctx chasm.MutableContext) error {
-			a.PauseState = nil
 			a.ResetHeartbeats = false
 
 			req := event.req.GetCompleteRequest()
@@ -228,7 +227,6 @@ var TransitionFailed = chasm.NewTransition(
 	func(a *Activity, ctx chasm.MutableContext, event failedEvent) error {
 		return a.StoreOrSelf(ctx).RecordCompleted(ctx, func(ctx chasm.MutableContext) error {
 			req := event.req.GetFailedRequest()
-			a.PauseState = nil
 			a.ResetHeartbeats = false
 
 			if details := req.GetLastHeartbeatDetails(); details != nil {
@@ -272,7 +270,6 @@ var TransitionTerminated = chasm.NewTransition(
 			a.TerminateState = &activitypb.ActivityTerminateState{
 				RequestId: event.request.RequestID,
 			}
-			a.PauseState = nil
 			a.ResetHeartbeats = false
 			outcome := a.Outcome.Get(ctx)
 			failure := &failurepb.Failure{
@@ -348,7 +345,6 @@ var TransitionCanceled = chasm.NewTransition(
 					Failure: failure,
 				},
 			}
-			a.PauseState = nil
 			a.ResetHeartbeats = false
 
 			a.emitOnCanceledMetrics(ctx, event.handler, event.fromStatus)
@@ -397,7 +393,6 @@ var TransitionTimedOut = chasm.NewTransition(
 				return err
 			}
 
-			a.PauseState = nil
 			a.ResetHeartbeats = false
 
 			a.emitOnTimedOutMetrics(ctx, event.metricsHandler, timeoutType, event.fromStatus)
@@ -510,9 +505,9 @@ var TransitionReset = chasm.NewTransition(
 )
 
 // TransitionResetRequested transitions a STARTED or PAUSE_REQUESTED activity to RESET_REQUESTED.
-// PAUSE_REQUESTED is allowed when the operator issues reset with keepPaused=true: PauseState is
-// preserved across the transition so the activity lands back in PAUSED (not SCHEDULED) when the
-// worker yields. The worker is still in charge of the activity; it will be notified via
+// PAUSE_REQUESTED is allowed when the operator issues reset with keepPaused=true: ResetKeepPaused is
+// set so the activity lands back in PAUSED (not SCHEDULED) when the worker yields. The worker is
+// still in charge of the activity; it will be notified via
 // ActivityReset=true on its next heartbeat response, its task token is not invalidated by this
 // transition, and there is no stamp bump since StartToCloseTimeoutTask and HeartbeatTimeoutTask
 // must stay valid.
@@ -528,7 +523,7 @@ var TransitionResetRequested = chasm.NewTransition(
 )
 
 // TransitionResetAttemptFailedToPaused transitions RESET_REQUESTED → PAUSED. It is performed
-// when the worker yields in RESET_REQUESTED with PauseState still set (i.e. reset was issued with
+// when the worker yields in RESET_REQUESTED with ResetKeepPaused set (i.e. reset was issued with
 // keepPaused=true while the activity was in PAUSE_REQUESTED). The failed attempt is recorded, the
 // attempt count is reset to 1, and no dispatch task is emitted — the activity stays paused until
 // an explicit unpause.
@@ -539,6 +534,7 @@ var TransitionResetAttemptFailedToPaused = chasm.NewTransition(
 	activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED,
 	func(a *Activity, ctx chasm.MutableContext, event rescheduleEvent) error {
 		attempt := a.LastAttempt.Get(ctx)
+		a.ResetKeepPaused = false
 		if a.ResetHeartbeats {
 			a.ResetHeartbeats = false
 			a.clearHeartbeat(ctx)
@@ -563,6 +559,7 @@ var TransitionResetAttemptFailedToScheduled = chasm.NewTransition(
 		attempt := a.LastAttempt.Get(ctx)
 		currentTime := ctx.Now(a)
 
+		a.ResetKeepPaused = false
 		if a.ResetHeartbeats {
 			a.ResetHeartbeats = false
 			a.clearHeartbeat(ctx)

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -917,7 +917,7 @@ func TestTransitionResetFromPaused(t *testing.T) {
 					StartToCloseTimeout:    durationpb.New(defaultStartToCloseTimeout),
 					Status:                 activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED,
 					TaskQueue:              &taskqueuepb.TaskQueue{Name: "test-task-queue"},
-					PauseState: &activitypb.ActivityPauseState{
+					LastPauseState: &activitypb.ActivityPauseState{
 						Identity: "test-identity",
 						Reason:   "test reason",
 					},

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -716,8 +716,9 @@ func TestTransitionCanceled(t *testing.T) {
 	protorequire.ProtoEqual(t, expectedFailure, outcome.GetFailed().GetFailure())
 }
 
-// TestTerminalTransitionsClearResetFlags verifies that ActivityReset and ResetHeartbeats are
-// cleared by every terminal transition so deferred-reset state does not linger on a terminal activity.
+// TestTerminalTransitionsClearResetFlags verifies that ResetHeartbeats is cleared by every
+// terminal transition and that terminals are reachable from RESET_REQUESTED so a reset-in-flight
+// activity does not get stuck.
 func TestTerminalTransitionsClearResetFlags(t *testing.T) {
 	makeActivity := func(ctx *chasm.MockMutableContext, status activitypb.ActivityExecutionStatus) *Activity {
 		return &Activity{
@@ -729,7 +730,6 @@ func TestTerminalTransitionsClearResetFlags(t *testing.T) {
 				StartToCloseTimeout:    durationpb.New(defaultStartToCloseTimeout),
 				Status:                 status,
 				TaskQueue:              &taskqueuepb.TaskQueue{Name: "test-task-queue"},
-				ActivityReset:          true,
 				ResetHeartbeats:        true,
 			},
 			LastAttempt:   chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{Count: 2}),
@@ -767,7 +767,6 @@ func TestTerminalTransitionsClearResetFlags(t *testing.T) {
 			metricsHandler: mh,
 		})
 		require.NoError(t, err)
-		require.False(t, act.ActivityReset, "ActivityReset should be cleared by TransitionCompleted")
 		require.False(t, act.ResetHeartbeats, "ResetHeartbeats should be cleared by TransitionCompleted")
 	})
 
@@ -804,7 +803,6 @@ func TestTerminalTransitionsClearResetFlags(t *testing.T) {
 			metricsHandler: mh,
 		})
 		require.NoError(t, err)
-		require.False(t, act.ActivityReset, "ActivityReset should be cleared by TransitionFailed")
 		require.False(t, act.ResetHeartbeats, "ResetHeartbeats should be cleared by TransitionFailed")
 	})
 
@@ -824,7 +822,6 @@ func TestTerminalTransitionsClearResetFlags(t *testing.T) {
 			fromStatus:     activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
 		})
 		require.NoError(t, err)
-		require.False(t, act.ActivityReset, "ActivityReset should be cleared by TransitionTerminated")
 		require.False(t, act.ResetHeartbeats, "ResetHeartbeats should be cleared by TransitionTerminated")
 	})
 
@@ -849,7 +846,6 @@ func TestTerminalTransitionsClearResetFlags(t *testing.T) {
 			fromStatus: activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
 		})
 		require.NoError(t, err)
-		require.False(t, act.ActivityReset, "ActivityReset should be cleared by TransitionCanceled")
 		require.False(t, act.ResetHeartbeats, "ResetHeartbeats should be cleared by TransitionCanceled")
 	})
 
@@ -879,7 +875,6 @@ func TestTerminalTransitionsClearResetFlags(t *testing.T) {
 			fromStatus:     activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
 		})
 		require.NoError(t, err)
-		require.False(t, act.ActivityReset, "ActivityReset should be cleared by TransitionTimedOut")
 		require.False(t, act.ResetHeartbeats, "ResetHeartbeats should be cleared by TransitionTimedOut")
 	})
 }

--- a/chasm/lib/buf.yaml
+++ b/chasm/lib/buf.yaml
@@ -5,6 +5,11 @@ deps:
 breaking:
   use:
     - WIRE
+  # Uncomment this to temporarily ignore specific files or directories:
+  ignore:
+    # example: - temporal/server/api/.../message.proto
+    # TODO (seankane): Remove after merging PR #10364
+    - chasm/lib/activity/proto/v1/activity_state.proto
 lint:
   use:
     - DEFAULT

--- a/proto/internal/buf.yaml
+++ b/proto/internal/buf.yaml
@@ -17,6 +17,8 @@ breaking:
     # TODO: Remove once this is stable. business_id was intentionally changed from
     # optional to repeated to support multiple fallback routing fields.
     - temporal/server/api/routing/v1/extension.proto
+    # TODO (seankane): Remove after merging PR #10364
+    - chasm/lib/activity/proto/v1/activity_state.proto
 lint:
   use:
     - DEFAULT

--- a/proto/internal/buf.yaml
+++ b/proto/internal/buf.yaml
@@ -17,8 +17,6 @@ breaking:
     # TODO: Remove once this is stable. business_id was intentionally changed from
     # optional to repeated to support multiple fallback routing fields.
     - temporal/server/api/routing/v1/extension.proto
-    # TODO (seankane): Remove after merging PR #10364
-    - chasm/lib/activity/proto/v1/activity_state.proto
 lint:
   use:
     - DEFAULT

--- a/tests/standalone_activity_test.go
+++ b/tests/standalone_activity_test.go
@@ -7218,7 +7218,7 @@ func (s *standaloneActivityTestSuite) TestPauseActivityExecution() {
 		require.NoError(t, err)
 		require.True(t, heartbeatResp.GetActivityPaused())
 
-		// Describe should show PAUSE_REQUESTED: status is STARTED with PauseState set.
+		// Describe should show PAUSE_REQUESTED: a pause was requested while the worker was running.
 		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
 			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
@@ -7313,7 +7313,7 @@ func (s *standaloneActivityTestSuite) TestPauseActivityExecution() {
 		})
 		require.NoError(t, err)
 
-		// Describe should show PAUSE_REQUESTED: status is STARTED with PauseState set.
+		// Describe should show PAUSE_REQUESTED: a pause was requested while the worker was running.
 		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
 			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
@@ -8376,7 +8376,7 @@ func (s *standaloneActivityTestSuite) TestUnpauseActivityExecution() {
 		})
 		require.NoError(t, err)
 
-		// After unpause of a STARTED+PauseState activity, the status stays STARTED (the worker's
+		// After unpause of a PAUSE_REQUESTED activity, the status goes back to STARTED (the worker's
 		// token is still valid — no stamp bump). Verify via describe that the activity is no longer paused.
 		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
 			Namespace:  env.Namespace().String(),
@@ -9498,8 +9498,8 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 	})
 
 	t.Run("ScheduledWithPauseStateKeepPausedFalse", func(t *testing.T) {
-		// SCHEDULED status with non-nil PauseState (RunState=PAUSED), reset with keepPaused=false.
-		// Verify: PauseState is cleared, attempt count reset to 1, activity dispatches.
+		// PAUSED activity (SCHEDULED status), reset with keepPaused=false.
+		// Verify: attempt count reset to 1 and the activity dispatches (does not stay paused).
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
@@ -9513,11 +9513,11 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		failRetryable(ctx, t, pollResp1.TaskToken, 0)
 		waitForState(ctx, t, activityID, startResp.GetRunId(), enumspb.PENDING_ACTIVITY_STATE_SCHEDULED)
 
-		// Pause → PAUSED (SCHEDULED status + non-nil PauseState).
+		// Pause → PAUSED.
 		pauseActivity(ctx, t, activityID, startResp.GetRunId())
 		waitForState(ctx, t, activityID, startResp.GetRunId(), enumspb.PENDING_ACTIVITY_STATE_PAUSED)
 
-		// Reset with keepPaused=false — should clear PauseState and dispatch at attempt 1.
+		// Reset with keepPaused=false — should dispatch at attempt 1 (not stay paused).
 		_, err := env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
 			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
@@ -9544,8 +9544,8 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 	})
 
 	t.Run("StartedWithPauseStateKeepPausedFalse", func(t *testing.T) {
-		// STARTED status with non-nil PauseState (RunState=PAUSE_REQUESTED), reset with keepPaused=false.
-		// Reset is deferred; PauseState must be cleared eagerly so the next retry dispatches.
+		// PAUSE_REQUESTED activity (STARTED status), reset with keepPaused=false.
+		// Reset is deferred; without ResetKeepPaused the next retry dispatches instead of pausing.
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
@@ -9556,11 +9556,11 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		})
 		require.EqualValues(t, 1, pollResp1.Attempt)
 
-		// Pause while STARTED → PauseState set, status remains STARTED (PAUSE_REQUESTED).
+		// Pause while STARTED → status becomes PAUSE_REQUESTED (worker still running).
 		pauseActivity(ctx, t, activityID, startResp.GetRunId())
 		waitForState(ctx, t, activityID, startResp.GetRunId(), enumspb.PENDING_ACTIVITY_STATE_PAUSE_REQUESTED)
 
-		// Reset with keepPaused=false — deferred; must also clear PauseState so dispatch isn't blocked.
+		// Reset with keepPaused=false — deferred; ResetKeepPaused stays false so dispatch isn't blocked.
 		_, err := env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
 			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
@@ -9591,8 +9591,8 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 	})
 
 	t.Run("StartedWithPauseStateKeepPausedTrue", func(t *testing.T) {
-		// STARTED status with non-nil PauseState (RunState=PAUSE_REQUESTED), reset with keepPaused=true.
-		// Reset is deferred; PauseState is preserved so after the retry the activity stays paused.
+		// PAUSE_REQUESTED activity (STARTED status), reset with keepPaused=true.
+		// Reset is deferred; ResetKeepPaused is set so after the retry the activity stays paused.
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
@@ -9607,7 +9607,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		pauseActivity(ctx, t, activityID, startResp.GetRunId())
 		waitForState(ctx, t, activityID, startResp.GetRunId(), enumspb.PENDING_ACTIVITY_STATE_PAUSE_REQUESTED)
 
-		// Reset with keepPaused=true — deferred; PauseState should be preserved.
+		// Reset with keepPaused=true — deferred; ResetKeepPaused should be set.
 		_, err := env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
 			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,

--- a/tests/standalone_activity_test.go
+++ b/tests/standalone_activity_test.go
@@ -9019,16 +9019,9 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.NoError(t, err)
 	})
 
-	t.Run("WhileCancelRequestedDoesNotFail", func(t *testing.T) {
-		// Reset while the activity is in CANCEL_REQUESTED state.
-		// handleReset sets the ActivityReset flag (same deferred path as STARTED).
-		// NOTE: TransitionRescheduled currently only allows STARTED as a source state, so a
-		// CANCEL_REQUESTED activity that fails retryably goes to FAILED (terminal) rather
-		// than retrying — the ActivityReset flag would have no effect in that case. This test
-		// verifies: (1) the reset API succeeds, (2) the activity remains in CANCEL_REQUESTED
-		// with its state intact, and (3) the activity can still complete normally. Full
-		// deferred-reset verification (attempt count reset to 1) requires extending
-		// TransitionRescheduled to accept CANCEL_REQUESTED as a source state.
+	t.Run("WhileCancelRequestedReturnsFailedPrecondition", func(t *testing.T) {
+		// Reset on a CANCEL_REQUESTED activity is rejected: cancel takes precedence and the
+		// state machine has no meaningful transition for "reset while cancel is pending".
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
@@ -9039,7 +9032,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		})
 		require.EqualValues(t, 1, pollResp1.Attempt)
 
-		// Request cancellation — moves to CANCEL_REQUESTED
+		// Request cancellation — moves to CANCEL_REQUESTED.
 		_, err := env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
 			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
@@ -9049,7 +9042,6 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		})
 		require.NoError(t, err)
 
-		// Verify CANCEL_REQUESTED state
 		desc, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
 			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
@@ -9058,19 +9050,18 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.NoError(t, err)
 		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_CANCEL_REQUESTED, desc.GetInfo().GetRunState())
 
-		// Reset while CANCEL_REQUESTED — must succeed without error
-		resetActivity(ctx, t, activityID, startResp.GetRunId(), false)
-
-		// Activity must still be in CANCEL_REQUESTED (reset is deferred, no immediate side effect)
-		desc, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+		// Reset while CANCEL_REQUESTED — must be rejected.
+		_, err = env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
 			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      startResp.GetRunId(),
 		})
-		require.NoError(t, err)
-		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_CANCEL_REQUESTED, desc.GetInfo().GetRunState())
+		require.Error(t, err)
+		var failedPrecondition *serviceerror.FailedPrecondition
+		require.ErrorAs(t, err, &failedPrecondition,
+			"reset on CANCEL_REQUESTED activity must return FailedPrecondition")
 
-		// Worker ignores the cancel and completes — activity should complete cleanly
+		// Activity is still CANCEL_REQUESTED and can still complete via the existing token.
 		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
 			Namespace: env.Namespace().String(),
 			TaskToken: pollResp1.TaskToken,
@@ -9658,6 +9649,184 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 			Identity:  defaultIdentity,
 		})
 		require.NoError(t, err)
+	})
+
+	// StartToCloseTimeoutWhileResetRequested: a STARTED activity with a pending reset must still
+	// observe its StartToClose timeout. The worker stops responding, the timer fires, the retry
+	// path consumes the reset-request and lands the activity in SCHEDULED with the attempt count
+	// reset to 1.
+	t.Run("StartToCloseTimeoutWhileResetRequested", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(testcore.NewContext(), 30*time.Second)
+		defer cancel()
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			ActivityType:           env.Tv().ActivityType(),
+			Identity:               env.Tv().WorkerIdentity(),
+			Input:                  defaultInput,
+			TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout:    durationpb.New(1 * time.Second),
+			ScheduleToCloseTimeout: durationpb.New(5 * time.Minute),
+			RequestId:              env.Tv().RequestID(),
+			RetryPolicy: &commonpb.RetryPolicy{
+				MaximumAttempts:    10,
+				InitialInterval:    durationpb.New(1 * time.Millisecond),
+				BackoffCoefficient: 1.0,
+			},
+		})
+		require.NoError(t, err)
+
+		// Worker polls → activity is STARTED.
+		_, err = env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
+			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			Identity:  env.Tv().WorkerIdentity(),
+		})
+		require.NoError(t, err)
+
+		// Reset while STARTED → RESET_REQUESTED.
+		_, err = env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+		})
+		require.NoError(t, err)
+
+		// Worker stops responding. StartToCloseTimeout must fire and the reset-request must be
+		// consumed by a retry, landing the activity in SCHEDULED at attempt 1 (reset applied).
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			dr, dErr := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
+				ActivityId: activityID,
+			})
+			require.NoError(c, dErr)
+			require.Equal(c, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, dr.GetInfo().GetRunState())
+			require.EqualValues(c, 1, dr.GetInfo().GetAttempt())
+		}, 10*time.Second, 200*time.Millisecond)
+	})
+
+	// HeartbeatTimeoutWhileResetRequested: as above but for the heartbeat timer. Without the
+	// validator accepting RESET_REQUESTED, the HeartbeatTimeoutTask is silently dropped and the
+	// activity never times out (only the longer ScheduleToCloseTimeout would catch it).
+	t.Run("HeartbeatTimeoutWhileResetRequested", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(testcore.NewContext(), 30*time.Second)
+		defer cancel()
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			ActivityType:           env.Tv().ActivityType(),
+			Identity:               env.Tv().WorkerIdentity(),
+			Input:                  defaultInput,
+			TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout:    durationpb.New(1 * time.Minute),
+			HeartbeatTimeout:       durationpb.New(1 * time.Second),
+			ScheduleToCloseTimeout: durationpb.New(5 * time.Minute),
+			RequestId:              env.Tv().RequestID(),
+			RetryPolicy: &commonpb.RetryPolicy{
+				MaximumAttempts:    10,
+				InitialInterval:    durationpb.New(1 * time.Millisecond),
+				BackoffCoefficient: 1.0,
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
+			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			Identity:  env.Tv().WorkerIdentity(),
+		})
+		require.NoError(t, err)
+
+		_, err = env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+		})
+		require.NoError(t, err)
+
+		// No heartbeat → HeartbeatTimeoutTask fires → retry consumes reset-request → SCHEDULED at attempt 1.
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			dr, dErr := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
+				ActivityId: activityID,
+			})
+			require.NoError(c, dErr)
+			require.Equal(c, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, dr.GetInfo().GetRunState())
+			require.EqualValues(c, 1, dr.GetInfo().GetAttempt())
+		}, 10*time.Second, 200*time.Millisecond)
+	})
+
+	// UpdateOptionsPreservesTimeoutsWhileResetRequested: UpdateActivityExecutionOptions bumps the
+	// attempt stamp, which invalidates all attempt-scoped timeout tasks. The handler must re-emit
+	// fresh StartToClose and Heartbeat timeout tasks for RESET_REQUESTED activities, otherwise the
+	// running worker is left with no server-side timeout enforcement (only the long
+	// ScheduleToCloseTimeout would eventually catch a hung worker).
+	t.Run("UpdateOptionsPreservesTimeoutsWhileResetRequested", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(testcore.NewContext(), 30*time.Second)
+		defer cancel()
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			ActivityType:           env.Tv().ActivityType(),
+			Identity:               env.Tv().WorkerIdentity(),
+			Input:                  defaultInput,
+			TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout:    durationpb.New(1 * time.Minute),
+			ScheduleToCloseTimeout: durationpb.New(5 * time.Minute),
+			RequestId:              env.Tv().RequestID(),
+			RetryPolicy: &commonpb.RetryPolicy{
+				MaximumAttempts:    10,
+				InitialInterval:    durationpb.New(1 * time.Millisecond),
+				BackoffCoefficient: 1.0,
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
+			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			Identity:  env.Tv().WorkerIdentity(),
+		})
+		require.NoError(t, err)
+
+		// Reset while STARTED → RESET_REQUESTED.
+		_, err = env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+		})
+		require.NoError(t, err)
+
+		// Update StartToCloseTimeout to 1s. The handler bumps the attempt stamp (invalidating the
+		// old 1-minute timeout task) and must re-emit a fresh 1-second timeout task that fires
+		// while the activity is RESET_REQUESTED.
+		_, err = env.FrontendClient().UpdateActivityExecutionOptions(ctx, &workflowservice.UpdateActivityExecutionOptionsRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+			ActivityOptions: &activitypb.ActivityOptions{
+				StartToCloseTimeout: durationpb.New(1 * time.Second),
+			},
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"start_to_close_timeout"}},
+		})
+		require.NoError(t, err)
+
+		// New StartToCloseTimeout fires → retry consumes reset-request → SCHEDULED at attempt 1.
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			dr, dErr := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
+				ActivityId: activityID,
+			})
+			require.NoError(c, dErr)
+			require.Equal(c, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, dr.GetInfo().GetRunState())
+			require.EqualValues(c, 1, dr.GetInfo().GetAttempt())
+		}, 10*time.Second, 200*time.Millisecond)
 	})
 
 	t.Run("Jitter", func(t *testing.T) {


### PR DESCRIPTION
## What changed?
Replace the flagged base `RESET` state with a `RESET_REQUESTED` state. This takes fuller advantage of the CHASM state transition functionality.

## Why?
Reduces the amount of special casing code and replaces this with an additional state (`RESET_REQUESTED`) and state transitions to handle the case where a `STARTED` activity is reset and has to be delivered on the next heartbeat or when an activity completes the attempt.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [X] added new functional test(s)

## Potential risks
NA, unreleased code. 
