### PR TITLE
Wire up activity links

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -32,6 +32,7 @@ import (
 	"go.temporal.io/server/common/payload"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/tqid"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -165,6 +166,7 @@ func NewStandaloneActivity(
 			Input:        request.Input,
 			Header:       request.Header,
 			UserMetadata: request.UserMetadata,
+			Links:        request.Links,
 		}),
 		Outcome:    chasm.NewDataField(ctx, &activitypb.ActivityOutcome{}),
 		Visibility: chasm.NewComponentField(ctx, visibility),
@@ -257,6 +259,7 @@ func (a *Activity) GenerateRecordActivityTaskStartedResponse(
 					HeartbeatTimeout:       a.GetHeartbeatTimeout(),
 				},
 			},
+			Links: requestData.GetLinks(),
 		},
 	}, nil
 }
@@ -341,6 +344,48 @@ func (a *Activity) addCompletionCallbacks(
 		a.Callbacks[id] = chasm.NewComponentField(ctx, callbackObj)
 	}
 	return nil
+}
+
+// attachLinks appends the given links to the activity's request data, skipping any that are
+// proto-equal to a link already attached or to an earlier entry in the same batch. Returns an
+// error if the activity is closed or if attaching the deduplicated set would exceed maxLinks.
+func (a *Activity) attachLinks(ctx chasm.MutableContext, links []*commonpb.Link, maxLinks int) error {
+	if len(links) == 0 {
+		return nil
+	}
+	if a.LifecycleState(ctx).IsClosed() {
+		return serviceerror.NewFailedPrecondition("cannot attach links to a closed activity")
+	}
+	requestData := a.RequestData.Get(ctx)
+	existing := requestData.GetLinks()
+	toAdd := make([]*commonpb.Link, 0, len(links))
+	for _, l := range links {
+		if containsLink(existing, l) || containsLink(toAdd, l) {
+			continue
+		}
+		toAdd = append(toAdd, l)
+	}
+	if len(toAdd) == 0 {
+		return nil
+	}
+	if len(existing)+len(toAdd) > maxLinks {
+		return serviceerror.NewFailedPreconditionf(
+			"cannot attach more than %d links to an activity (%d links already attached)",
+			maxLinks,
+			len(existing),
+		)
+	}
+	requestData.Links = append(existing, toAdd...)
+	return nil
+}
+
+func containsLink(haystack []*commonpb.Link, needle *commonpb.Link) bool {
+	for _, l := range haystack {
+		if proto.Equal(l, needle) {
+			return true
+		}
+	}
+	return false
 }
 
 // GetNexusCompletion returns the activity's completion data in the format required by the Nexus callback invocation.
@@ -824,6 +869,7 @@ func (a *Activity) buildActivityExecutionInfo(ctx chasm.Context) *apiactivitypb.
 		Header:                  requestData.GetHeader(),
 		HeartbeatDetails:        heartbeat.GetDetails(),
 		HeartbeatTimeout:        a.GetHeartbeatTimeout(),
+		Links:                   requestData.GetLinks(),
 		TotalHeartbeatCount:     heartbeat.GetTotalHeartbeatCount(),
 		LastAttemptCompleteTime: attempt.GetCompleteTime(),
 		LastFailure:             attempt.GetLastFailureDetails().GetFailure(),

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -348,8 +348,9 @@ func (a *Activity) addCompletionCallbacks(
 
 // attachLinks appends the given links to the activity's request data, skipping any that are
 // proto-equal to a link already attached or to an earlier entry in the same batch. Returns an
-// error if the activity is closed or if attaching the deduplicated set would exceed maxLinks.
-func (a *Activity) attachLinks(ctx chasm.MutableContext, links []*commonpb.Link, maxLinks int) error {
+// error if the activity is closed or if attaching the deduplicated set would exceed the
+// per-execution cap enforced by linkValidator.
+func (a *Activity) attachLinks(ctx chasm.MutableContext, links []*commonpb.Link, validator *linkValidator, namespaceName string) error {
 	if len(links) == 0 {
 		return nil
 	}
@@ -368,12 +369,8 @@ func (a *Activity) attachLinks(ctx chasm.MutableContext, links []*commonpb.Link,
 	if len(toAdd) == 0 {
 		return nil
 	}
-	if len(existing)+len(toAdd) > maxLinks {
-		return serviceerror.NewFailedPreconditionf(
-			"cannot attach more than %d links to an activity (%d links already attached)",
-			maxLinks,
-			len(existing),
-		)
+	if err := validator.ValidateExecutionTotal(namespaceName, len(existing), len(toAdd)); err != nil {
+		return err
 	}
 	requestData.Links = append(existing, toAdd...)
 	return nil

--- a/chasm/lib/activity/config.go
+++ b/chasm/lib/activity/config.go
@@ -46,13 +46,10 @@ type Config struct {
 	BlobSizeLimitWarn           dynamicconfig.IntPropertyFnWithNamespaceFilter
 	BreakdownMetricsByTaskQueue dynamicconfig.TypedPropertyFnWithTaskQueueFilter[bool]
 	Enabled                     dynamicconfig.BoolPropertyFnWithNamespaceFilter
-	LinkMaxSize                 dynamicconfig.IntPropertyFnWithNamespaceFilter
 	LongPollBuffer              dynamicconfig.DurationPropertyFnWithNamespaceFilter
 	LongPollTimeout             dynamicconfig.DurationPropertyFnWithNamespaceFilter
 	MaxIDLengthLimit            dynamicconfig.IntPropertyFn
 	MaxCallbacksPerExecution    dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxLinksPerExecution        dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxLinksPerRequest          dynamicconfig.IntPropertyFnWithNamespaceFilter
 	DefaultActivityRetryPolicy  dynamicconfig.TypedPropertyFnWithNamespaceFilter[retrypolicy.DefaultRetrySettings]
 	StartDelayEnabled           dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	VisibilityMaxPageSize       dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -65,14 +62,20 @@ func ConfigProvider(dc *dynamicconfig.Collection) *Config {
 		BreakdownMetricsByTaskQueue: dynamicconfig.MetricsBreakdownByTaskQueue.Get(dc),
 		DefaultActivityRetryPolicy:  dynamicconfig.DefaultActivityRetryPolicy.Get(dc),
 		Enabled:                     Enabled.Get(dc),
-		LinkMaxSize:                 dynamicconfig.FrontendLinkMaxSize.Get(dc),
 		LongPollBuffer:              LongPollBuffer.Get(dc),
 		LongPollTimeout:             LongPollTimeout.Get(dc),
 		MaxIDLengthLimit:            dynamicconfig.MaxIDLengthLimit.Get(dc),
-		MaxLinksPerExecution:        MaxLinksPerExecution.Get(dc),
-		MaxLinksPerRequest:          dynamicconfig.FrontendMaxLinksPerRequest.Get(dc),
 		StartDelayEnabled:           StartDelayEnabled.Get(dc),
 		MaxCallbacksPerExecution:    callback.MaxPerExecution.Get(dc),
 		VisibilityMaxPageSize:       dynamicconfig.FrontendVisibilityMaxPageSize.Get(dc),
 	}
+}
+
+// linkValidatorProvider builds the linkValidator from dynamic config.
+func linkValidatorProvider(dc *dynamicconfig.Collection) *linkValidator {
+	return newLinkValidator(
+		dynamicconfig.FrontendMaxLinksPerRequest.Get(dc),
+		MaxLinksPerExecution.Get(dc),
+		dynamicconfig.FrontendLinkMaxSize.Get(dc),
+	)
 }

--- a/chasm/lib/activity/config.go
+++ b/chasm/lib/activity/config.go
@@ -33,6 +33,12 @@ var (
 		false,
 		`Allows non-zero start_delay on StartActivityExecution requests.`,
 	)
+
+	MaxLinksPerExecution = dynamicconfig.NewNamespaceIntSetting(
+		"activity.maxLinksPerExecution",
+		2000,
+		`MaxLinksPerExecution is the maximum number of links that can be attached to a standalone activity execution across all start/attach calls.`,
+	)
 )
 
 type Config struct {
@@ -40,10 +46,13 @@ type Config struct {
 	BlobSizeLimitWarn           dynamicconfig.IntPropertyFnWithNamespaceFilter
 	BreakdownMetricsByTaskQueue dynamicconfig.TypedPropertyFnWithTaskQueueFilter[bool]
 	Enabled                     dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	LinkMaxSize                 dynamicconfig.IntPropertyFnWithNamespaceFilter
 	LongPollBuffer              dynamicconfig.DurationPropertyFnWithNamespaceFilter
 	LongPollTimeout             dynamicconfig.DurationPropertyFnWithNamespaceFilter
 	MaxIDLengthLimit            dynamicconfig.IntPropertyFn
 	MaxCallbacksPerExecution    dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxLinksPerExecution        dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxLinksPerRequest          dynamicconfig.IntPropertyFnWithNamespaceFilter
 	DefaultActivityRetryPolicy  dynamicconfig.TypedPropertyFnWithNamespaceFilter[retrypolicy.DefaultRetrySettings]
 	StartDelayEnabled           dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	VisibilityMaxPageSize       dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -56,9 +65,12 @@ func ConfigProvider(dc *dynamicconfig.Collection) *Config {
 		BreakdownMetricsByTaskQueue: dynamicconfig.MetricsBreakdownByTaskQueue.Get(dc),
 		DefaultActivityRetryPolicy:  dynamicconfig.DefaultActivityRetryPolicy.Get(dc),
 		Enabled:                     Enabled.Get(dc),
+		LinkMaxSize:                 dynamicconfig.FrontendLinkMaxSize.Get(dc),
 		LongPollBuffer:              LongPollBuffer.Get(dc),
 		LongPollTimeout:             LongPollTimeout.Get(dc),
 		MaxIDLengthLimit:            dynamicconfig.MaxIDLengthLimit.Get(dc),
+		MaxLinksPerExecution:        MaxLinksPerExecution.Get(dc),
+		MaxLinksPerRequest:          dynamicconfig.FrontendMaxLinksPerRequest.Get(dc),
 		StartDelayEnabled:           StartDelayEnabled.Get(dc),
 		MaxCallbacksPerExecution:    callback.MaxPerExecution.Get(dc),
 		VisibilityMaxPageSize:       dynamicconfig.FrontendVisibilityMaxPageSize.Get(dc),

--- a/chasm/lib/activity/frontend.go
+++ b/chasm/lib/activity/frontend.go
@@ -13,6 +13,7 @@ import (
 	"go.temporal.io/server/chasm/lib/activity/gen/activitypb/v1"
 	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common"
+	commonlinks "go.temporal.io/server/common/links"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
@@ -409,6 +410,14 @@ func (h *frontendHandler) validateAndPopulateStartRequest(
 		if err := h.callbackValidator.Validate(ctx, req.GetNamespace(), cbs); err != nil {
 			return nil, err
 		}
+	}
+
+	if err := commonlinks.Validate(
+		req.GetLinks(),
+		h.config.MaxLinksPerRequest(req.GetNamespace()),
+		h.config.LinkMaxSize(req.GetNamespace()),
+	); err != nil {
+		return nil, err
 	}
 
 	return req, nil

--- a/chasm/lib/activity/frontend.go
+++ b/chasm/lib/activity/frontend.go
@@ -13,7 +13,6 @@ import (
 	"go.temporal.io/server/chasm/lib/activity/gen/activitypb/v1"
 	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common"
-	commonlinks "go.temporal.io/server/common/links"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
@@ -40,6 +39,7 @@ var ErrStandaloneActivityDisabled = serviceerror.NewUnimplemented("Standalone ac
 type frontendHandler struct {
 	FrontendHandler
 	callbackValidator callback.Validator
+	linkValidator     *linkValidator
 	client            activitypb.ActivityServiceClient
 	config            *Config
 	logger            log.Logger
@@ -52,6 +52,7 @@ type frontendHandler struct {
 // NewFrontendHandler creates a new FrontendHandler instance for processing activity frontend requests.
 func NewFrontendHandler(
 	callbackValidator callback.Validator,
+	linkValidator *linkValidator,
 	client activitypb.ActivityServiceClient,
 	config *Config,
 	logger log.Logger,
@@ -62,6 +63,7 @@ func NewFrontendHandler(
 ) FrontendHandler {
 	return &frontendHandler{
 		callbackValidator: callbackValidator,
+		linkValidator:     linkValidator,
 		client:            client,
 		config:            config,
 		logger:            logger,
@@ -412,11 +414,7 @@ func (h *frontendHandler) validateAndPopulateStartRequest(
 		}
 	}
 
-	if err := commonlinks.Validate(
-		req.GetLinks(),
-		h.config.MaxLinksPerRequest(req.GetNamespace()),
-		h.config.LinkMaxSize(req.GetNamespace()),
-	); err != nil {
+	if err := h.linkValidator.ValidateRequest(ctx, req.GetNamespace(), req.GetLinks()); err != nil {
 		return nil, err
 	}
 

--- a/chasm/lib/activity/frontend_test.go
+++ b/chasm/lib/activity/frontend_test.go
@@ -25,11 +25,14 @@ func TestRequestIdStableAcrossRetries(t *testing.T) {
 		config: &Config{
 			BlobSizeLimitError:         defaultBlobSizeLimitError,
 			BlobSizeLimitWarn:          defaultBlobSizeLimitWarn,
-			LinkMaxSize:                defaultLinkMaxSize,
 			MaxIDLengthLimit:           func() int { return defaultMaxIDLengthLimit },
-			MaxLinksPerRequest:         defaultMaxLinksPerRequest,
 			DefaultActivityRetryPolicy: getDefaultRetrySettings,
 		},
+		linkValidator: newLinkValidator(
+			defaultMaxLinksPerRequest,
+			func(string) int { return 2000 },
+			defaultLinkMaxSize,
+		),
 		logger: log.NewNoopLogger(),
 	}
 	nsID := namespace.ID("test-namespace-id")

--- a/chasm/lib/activity/frontend_test.go
+++ b/chasm/lib/activity/frontend_test.go
@@ -25,7 +25,9 @@ func TestRequestIdStableAcrossRetries(t *testing.T) {
 		config: &Config{
 			BlobSizeLimitError:         defaultBlobSizeLimitError,
 			BlobSizeLimitWarn:          defaultBlobSizeLimitWarn,
+			LinkMaxSize:                defaultLinkMaxSize,
 			MaxIDLengthLimit:           func() int { return defaultMaxIDLengthLimit },
+			MaxLinksPerRequest:         defaultMaxLinksPerRequest,
 			DefaultActivityRetryPolicy: getDefaultRetrySettings,
 		},
 		logger: log.NewNoopLogger(),

--- a/chasm/lib/activity/fx.go
+++ b/chasm/lib/activity/fx.go
@@ -11,6 +11,7 @@ var HistoryModule = fx.Module(
 	"activity-history",
 	fx.Provide(
 		ConfigProvider,
+		linkValidatorProvider,
 		newActivityDispatchTaskHandler,
 		newScheduleToStartTimeoutTaskHandler,
 		newScheduleToCloseTimeoutTaskHandler,
@@ -27,6 +28,7 @@ var HistoryModule = fx.Module(
 var FrontendModule = fx.Module(
 	"activity-frontend",
 	fx.Provide(ConfigProvider),
+	fx.Provide(linkValidatorProvider),
 	fx.Provide(activitypb.NewActivityServiceLayeredClient),
 	fx.Provide(NewFrontendHandler),
 	fx.Provide(resource.SearchAttributeValidatorProvider),

--- a/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
@@ -643,7 +643,9 @@ type ActivityRequestData struct {
 	Input  *v1.Payloads `protobuf:"bytes,1,opt,name=input,proto3" json:"input,omitempty"`
 	Header *v1.Header   `protobuf:"bytes,2,opt,name=header,proto3" json:"header,omitempty"`
 	// Metadata for use by user interfaces to display the fixed as-of-start summary and details of the activity.
-	UserMetadata  *v13.UserMetadata `protobuf:"bytes,3,opt,name=user_metadata,json=userMetadata,proto3" json:"user_metadata,omitempty"`
+	UserMetadata *v13.UserMetadata `protobuf:"bytes,3,opt,name=user_metadata,json=userMetadata,proto3" json:"user_metadata,omitempty"`
+	// Links associated with the activity at start time.
+	Links         []*v1.Link `protobuf:"bytes,4,rep,name=links,proto3" json:"links,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -695,6 +697,13 @@ func (x *ActivityRequestData) GetHeader() *v1.Header {
 func (x *ActivityRequestData) GetUserMetadata() *v13.UserMetadata {
 	if x != nil {
 		return x.UserMetadata
+	}
+	return nil
+}
+
+func (x *ActivityRequestData) GetLinks() []*v1.Link {
+	if x != nil {
+		return x.Links
 	}
 	return nil
 }
@@ -976,11 +985,12 @@ const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawD
 	"\x16ActivityHeartbeatState\x12:\n" +
 	"\adetails\x18\x01 \x01(\v2 .temporal.api.common.v1.PayloadsR\adetails\x12?\n" +
 	"\rrecorded_time\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\frecordedTime\x122\n" +
-	"\x15total_heartbeat_count\x18\x03 \x01(\x03R\x13totalHeartbeatCount\"\xcd\x01\n" +
+	"\x15total_heartbeat_count\x18\x03 \x01(\x03R\x13totalHeartbeatCount\"\x81\x02\n" +
 	"\x13ActivityRequestData\x126\n" +
 	"\x05input\x18\x01 \x01(\v2 .temporal.api.common.v1.PayloadsR\x05input\x126\n" +
 	"\x06header\x18\x02 \x01(\v2\x1e.temporal.api.common.v1.HeaderR\x06header\x12F\n" +
-	"\ruser_metadata\x18\x03 \x01(\v2!.temporal.api.sdk.v1.UserMetadataR\fuserMetadata\"\xf4\x02\n" +
+	"\ruser_metadata\x18\x03 \x01(\v2!.temporal.api.sdk.v1.UserMetadataR\fuserMetadata\x122\n" +
+	"\x05links\x18\x04 \x03(\v2\x1c.temporal.api.common.v1.LinkR\x05links\"\xf4\x02\n" +
 	"\x0fActivityOutcome\x12i\n" +
 	"\n" +
 	"successful\x18\x01 \x01(\v2G.temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.SuccessfulH\x00R\n" +
@@ -1039,7 +1049,8 @@ var file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_goType
 	(*v1.Payloads)(nil),                             // 18: temporal.api.common.v1.Payloads
 	(*v1.Header)(nil),                               // 19: temporal.api.common.v1.Header
 	(*v13.UserMetadata)(nil),                        // 20: temporal.api.sdk.v1.UserMetadata
-	(*v14.Failure)(nil),                             // 21: temporal.api.failure.v1.Failure
+	(*v1.Link)(nil),                                 // 21: temporal.api.common.v1.Link
+	(*v14.Failure)(nil),                             // 22: temporal.api.failure.v1.Failure
 }
 var file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_depIdxs = []int32{
 	11, // 0: temporal.server.chasm.lib.activity.proto.v1.ActivityState.activity_type:type_name -> temporal.api.common.v1.ActivityType
@@ -1066,17 +1077,18 @@ var file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_depIdx
 	18, // 21: temporal.server.chasm.lib.activity.proto.v1.ActivityRequestData.input:type_name -> temporal.api.common.v1.Payloads
 	19, // 22: temporal.server.chasm.lib.activity.proto.v1.ActivityRequestData.header:type_name -> temporal.api.common.v1.Header
 	20, // 23: temporal.server.chasm.lib.activity.proto.v1.ActivityRequestData.user_metadata:type_name -> temporal.api.sdk.v1.UserMetadata
-	9,  // 24: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.successful:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Successful
-	10, // 25: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.failed:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Failed
-	15, // 26: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.LastFailureDetails.time:type_name -> google.protobuf.Timestamp
-	21, // 27: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.LastFailureDetails.failure:type_name -> temporal.api.failure.v1.Failure
-	18, // 28: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Successful.output:type_name -> temporal.api.common.v1.Payloads
-	21, // 29: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Failed.failure:type_name -> temporal.api.failure.v1.Failure
-	30, // [30:30] is the sub-list for method output_type
-	30, // [30:30] is the sub-list for method input_type
-	30, // [30:30] is the sub-list for extension type_name
-	30, // [30:30] is the sub-list for extension extendee
-	0,  // [0:30] is the sub-list for field type_name
+	21, // 24: temporal.server.chasm.lib.activity.proto.v1.ActivityRequestData.links:type_name -> temporal.api.common.v1.Link
+	9,  // 25: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.successful:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Successful
+	10, // 26: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.failed:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Failed
+	15, // 27: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.LastFailureDetails.time:type_name -> google.protobuf.Timestamp
+	22, // 28: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.LastFailureDetails.failure:type_name -> temporal.api.failure.v1.Failure
+	18, // 29: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Successful.output:type_name -> temporal.api.common.v1.Payloads
+	22, // 30: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Failed.failure:type_name -> temporal.api.failure.v1.Failure
+	31, // [31:31] is the sub-list for method output_type
+	31, // [31:31] is the sub-list for method input_type
+	31, // [31:31] is the sub-list for extension type_name
+	31, // [31:31] is the sub-list for extension extendee
+	0,  // [0:31] is the sub-list for field type_name
 }
 
 func init() { file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_init() }

--- a/chasm/lib/activity/handler.go
+++ b/chasm/lib/activity/handler.go
@@ -32,14 +32,22 @@ var (
 type handler struct {
 	activitypb.UnimplementedActivityServiceServer
 	config            *Config
+	linkValidator     *linkValidator
 	logger            log.Logger
 	metricsHandler    metrics.Handler
 	namespaceRegistry namespace.Registry
 }
 
-func newHandler(config *Config, metricsHandler metrics.Handler, logger log.Logger, namespaceRegistry namespace.Registry) *handler {
+func newHandler(
+	config *Config,
+	linkValidator *linkValidator,
+	metricsHandler metrics.Handler,
+	logger log.Logger,
+	namespaceRegistry namespace.Registry,
+) *handler {
 	return &handler{
 		config:            config,
+		linkValidator:     linkValidator,
 		logger:            logger,
 		metricsHandler:    metricsHandler,
 		namespaceRegistry: namespaceRegistry,
@@ -63,14 +71,9 @@ func (h *handler) StartActivityExecution(ctx context.Context, req *activitypb.St
 	}
 
 	maxCallbacks := h.config.MaxCallbacksPerExecution(frontendReq.GetNamespace())
-	maxLinks := h.config.MaxLinksPerExecution(frontendReq.GetNamespace())
 
-	if len(frontendReq.GetLinks()) > maxLinks {
-		return nil, serviceerror.NewFailedPreconditionf(
-			"cannot attach more than %d links to an activity (%d links already attached)",
-			maxLinks,
-			0,
-		)
+	if err := h.linkValidator.ValidateExecutionTotal(frontendReq.GetNamespace(), 0, len(frontendReq.GetLinks())); err != nil {
+		return nil, err
 	}
 
 	result, err := chasm.StartExecution(
@@ -132,7 +135,7 @@ func (h *handler) StartActivityExecution(ctx context.Context, req *activitypb.St
 					}
 				}
 				if attachLinks {
-					if err := a.attachLinks(ctx, links, maxLinks); err != nil {
+					if err := a.attachLinks(ctx, links, h.linkValidator, frontendReq.GetNamespace()); err != nil {
 						return nil, err
 					}
 				}

--- a/chasm/lib/activity/handler.go
+++ b/chasm/lib/activity/handler.go
@@ -63,6 +63,7 @@ func (h *handler) StartActivityExecution(ctx context.Context, req *activitypb.St
 	}
 
 	maxCallbacks := h.config.MaxCallbacksPerExecution(frontendReq.GetNamespace())
+	maxLinks := h.config.MaxLinksPerExecution(frontendReq.GetNamespace())
 
 	result, err := chasm.StartExecution(
 		ctx,
@@ -103,17 +104,31 @@ func (h *handler) StartActivityExecution(ctx context.Context, req *activitypb.St
 		return nil, err
 	}
 
-	// Attach callbacks to an existing activity when on_conflict_options.attach_completion_callbacks is set.
+	// Apply on_conflict_options to an existing activity.
 	// TODO: Use chasm.UpdateWithStartExecution to avoid a second transaction once the engine supports BusinessIDConflictPolicyFail in the updateFn path.
 	cbs := frontendReq.GetCompletionCallbacks()
-	if !result.Created && frontendReq.GetOnConflictOptions().GetAttachCompletionCallbacks() && len(cbs) > 0 {
+	links := frontendReq.GetLinks()
+	onConflict := frontendReq.GetOnConflictOptions()
+	attachCallbacks := onConflict.GetAttachCompletionCallbacks() && len(cbs) > 0
+	attachLinks := onConflict.GetAttachLinks() && len(links) > 0
+	if !result.Created && (attachCallbacks || attachLinks) {
 		requestID := frontendReq.GetRequestId()
 		ref := chasm.NewComponentRef[*Activity](result.ExecutionKey)
 		_, _, err := chasm.UpdateComponent(
 			ctx,
 			ref,
 			func(a *Activity, ctx chasm.MutableContext, _ any) (any, error) {
-				return nil, a.addCompletionCallbacks(ctx, requestID, cbs, maxCallbacks)
+				if attachCallbacks {
+					if err := a.addCompletionCallbacks(ctx, requestID, cbs, maxCallbacks); err != nil {
+						return nil, err
+					}
+				}
+				if attachLinks {
+					if err := a.attachLinks(ctx, links, maxLinks); err != nil {
+						return nil, err
+					}
+				}
+				return nil, nil
 			},
 			nil,
 		)

--- a/chasm/lib/activity/handler.go
+++ b/chasm/lib/activity/handler.go
@@ -65,6 +65,14 @@ func (h *handler) StartActivityExecution(ctx context.Context, req *activitypb.St
 	maxCallbacks := h.config.MaxCallbacksPerExecution(frontendReq.GetNamespace())
 	maxLinks := h.config.MaxLinksPerExecution(frontendReq.GetNamespace())
 
+	if len(frontendReq.GetLinks()) > maxLinks {
+		return nil, serviceerror.NewFailedPreconditionf(
+			"cannot attach more than %d links to an activity (%d links already attached)",
+			maxLinks,
+			0,
+		)
+	}
+
 	result, err := chasm.StartExecution(
 		ctx,
 		chasm.ExecutionKey{

--- a/chasm/lib/activity/handler_test.go
+++ b/chasm/lib/activity/handler_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // TestStartActivityExecution_RejectsLinksOverExecutionLimit verifies that the
-// initial-create path enforces MaxLinksPerExecution before persisting the
+// initial-create path enforces the per-execution link cap before persisting the
 // activity, preventing inconsistent state where later attachLinks calls would
 // fail because the activity was seeded with more links than the cap.
 func TestStartActivityExecution_RejectsLinksOverExecutionLimit(t *testing.T) {
@@ -22,8 +22,12 @@ func TestStartActivityExecution_RejectsLinksOverExecutionLimit(t *testing.T) {
 	h := &handler{
 		config: &Config{
 			MaxCallbacksPerExecution: func(string) int { return 10 },
-			MaxLinksPerExecution:     func(string) int { return maxLinks },
 		},
+		linkValidator: newLinkValidator(
+			func(string) int { return 100 },
+			func(string) int { return maxLinks },
+			func(string) int { return 4000 },
+		),
 	}
 
 	links := make([]*commonpb.Link, maxLinks+1)

--- a/chasm/lib/activity/handler_test.go
+++ b/chasm/lib/activity/handler_test.go
@@ -1,0 +1,58 @@
+package activity
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/chasm/lib/activity/gen/activitypb/v1"
+)
+
+// TestStartActivityExecution_RejectsLinksOverExecutionLimit verifies that the
+// initial-create path enforces MaxLinksPerExecution before persisting the
+// activity, preventing inconsistent state where later attachLinks calls would
+// fail because the activity was seeded with more links than the cap.
+func TestStartActivityExecution_RejectsLinksOverExecutionLimit(t *testing.T) {
+	const maxLinks = 3
+	h := &handler{
+		config: &Config{
+			MaxCallbacksPerExecution: func(string) int { return 10 },
+			MaxLinksPerExecution:     func(string) int { return maxLinks },
+		},
+	}
+
+	links := make([]*commonpb.Link, maxLinks+1)
+	for i := range links {
+		links[i] = &commonpb.Link{
+			Variant: &commonpb.Link_WorkflowEvent_{
+				WorkflowEvent: &commonpb.Link_WorkflowEvent{
+					Namespace:  "test-namespace",
+					WorkflowId: fmt.Sprintf("wf-%d", i),
+				},
+			},
+		}
+	}
+
+	_, err := h.StartActivityExecution(context.Background(), &activitypb.StartActivityExecutionRequest{
+		NamespaceId: "test-namespace-id",
+		FrontendRequest: &workflowservice.StartActivityExecutionRequest{
+			Namespace:          "test-namespace",
+			ActivityId:         "test-activity-id",
+			IdReusePolicy:      enumspb.ACTIVITY_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+			IdConflictPolicy:   enumspb.ACTIVITY_ID_CONFLICT_POLICY_FAIL,
+			Links:              links,
+		},
+	})
+
+	require.Error(t, err)
+	require.ErrorAs(t, err, new(*serviceerror.FailedPrecondition))
+	require.EqualError(t, err, fmt.Sprintf(
+		"cannot attach more than %d links to an activity (%d links already attached)",
+		maxLinks, 0,
+	))
+}

--- a/chasm/lib/activity/handler_test.go
+++ b/chasm/lib/activity/handler_test.go
@@ -41,11 +41,11 @@ func TestStartActivityExecution_RejectsLinksOverExecutionLimit(t *testing.T) {
 	_, err := h.StartActivityExecution(context.Background(), &activitypb.StartActivityExecutionRequest{
 		NamespaceId: "test-namespace-id",
 		FrontendRequest: &workflowservice.StartActivityExecutionRequest{
-			Namespace:          "test-namespace",
-			ActivityId:         "test-activity-id",
-			IdReusePolicy:      enumspb.ACTIVITY_ID_REUSE_POLICY_ALLOW_DUPLICATE,
-			IdConflictPolicy:   enumspb.ACTIVITY_ID_CONFLICT_POLICY_FAIL,
-			Links:              links,
+			Namespace:        "test-namespace",
+			ActivityId:       "test-activity-id",
+			IdReusePolicy:    enumspb.ACTIVITY_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+			IdConflictPolicy: enumspb.ACTIVITY_ID_CONFLICT_POLICY_FAIL,
+			Links:            links,
 		},
 	})
 

--- a/chasm/lib/activity/link_validator.go
+++ b/chasm/lib/activity/link_validator.go
@@ -1,0 +1,51 @@
+package activity
+
+import (
+	"context"
+
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common/dynamicconfig"
+	commonlinks "go.temporal.io/server/common/links"
+)
+
+// linkValidator validates links attached to standalone activity executions.
+// It enforces both per-request limits (count + size + variant shape) and a
+// per-execution cumulative cap across start/attach calls.
+type linkValidator struct {
+	maxLinksPerRequest   dynamicconfig.IntPropertyFnWithNamespaceFilter
+	maxLinksPerExecution dynamicconfig.IntPropertyFnWithNamespaceFilter
+	linkMaxSize          dynamicconfig.IntPropertyFnWithNamespaceFilter
+}
+
+func newLinkValidator(
+	maxLinksPerRequest dynamicconfig.IntPropertyFnWithNamespaceFilter,
+	maxLinksPerExecution dynamicconfig.IntPropertyFnWithNamespaceFilter,
+	linkMaxSize dynamicconfig.IntPropertyFnWithNamespaceFilter,
+) *linkValidator {
+	return &linkValidator{
+		maxLinksPerRequest:   maxLinksPerRequest,
+		maxLinksPerExecution: maxLinksPerExecution,
+		linkMaxSize:          linkMaxSize,
+	}
+}
+
+// ValidateRequest checks count, per-link size, and variant shape for the links
+// on a single incoming request.
+func (v *linkValidator) ValidateRequest(_ context.Context, namespaceName string, links []*commonpb.Link) error {
+	return commonlinks.Validate(links, v.maxLinksPerRequest(namespaceName), v.linkMaxSize(namespaceName))
+}
+
+// ValidateExecutionTotal checks that adding addingCount links to an execution
+// already holding existingCount links would not exceed the per-execution cap.
+func (v *linkValidator) ValidateExecutionTotal(namespaceName string, existingCount, addingCount int) error {
+	maxLinks := v.maxLinksPerExecution(namespaceName)
+	if existingCount+addingCount > maxLinks {
+		return serviceerror.NewFailedPreconditionf(
+			"cannot attach more than %d links to an activity (%d links already attached)",
+			maxLinks,
+			existingCount,
+		)
+	}
+	return nil
+}

--- a/chasm/lib/activity/proto/v1/activity_state.proto
+++ b/chasm/lib/activity/proto/v1/activity_state.proto
@@ -182,6 +182,9 @@ message ActivityRequestData {
 
   // Metadata for use by user interfaces to display the fixed as-of-start summary and details of the activity.
   temporal.api.sdk.v1.UserMetadata user_metadata = 3;
+
+  // Links associated with the activity at start time.
+  repeated temporal.api.common.v1.Link links = 4;
 }
 
 message ActivityOutcome {

--- a/chasm/lib/activity/validator_test.go
+++ b/chasm/lib/activity/validator_test.go
@@ -46,6 +46,12 @@ var (
 	defaultBlobSizeLimitWarn = func(ns string) int {
 		return 32
 	}
+	defaultMaxLinksPerRequest = func(ns string) int {
+		return 10
+	}
+	defaultLinkMaxSize = func(ns string) int {
+		return 4000
+	}
 )
 
 func TestValidateSuccess(t *testing.T) {

--- a/chasm/lib/nexusoperation/operation.go
+++ b/chasm/lib/nexusoperation/operation.go
@@ -345,7 +345,7 @@ func (o *Operation) saveInvocationResult(
 ) (chasm.NoValue, error) {
 	switch r := input.result.(type) {
 	case invocationResultOK:
-		links := convertResponseLinks(r.response.Links, ctx.Logger())
+		links := commonnexus.ConvertNexusLinksToProtoLinks(r.response.Links, ctx.Logger())
 		if r.response.Pending != nil {
 			// An async operation transitions to STARTED here;
 			// HandleNexusCompletion will apply its outcome from the completion callback.

--- a/chasm/lib/nexusoperation/task_handler_helpers.go
+++ b/chasm/lib/nexusoperation/task_handler_helpers.go
@@ -18,7 +18,6 @@ import (
 	tokenspb "go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
-	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/namespace"
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexusrpc"
@@ -43,28 +42,7 @@ func (o *operationTimeoutBelowMinError) Error() string {
 }
 
 func convertResponseLinks(links []nexus.Link, logger log.Logger) []*commonpb.Link {
-	var result []*commonpb.Link
-	for _, nexusLink := range links {
-		switch nexusLink.Type {
-		case string((&commonpb.Link_WorkflowEvent{}).ProtoReflect().Descriptor().FullName()):
-			link, err := commonnexus.ConvertNexusLinkToLinkWorkflowEvent(nexusLink)
-			if err != nil {
-				logger.Error(
-					fmt.Sprintf("failed to parse link to %q: %s", nexusLink.Type, nexusLink.URL),
-					tag.Error(err),
-				)
-				continue
-			}
-			result = append(result, &commonpb.Link{
-				Variant: &commonpb.Link_WorkflowEvent_{
-					WorkflowEvent: link,
-				},
-			})
-		default:
-			logger.Error(fmt.Sprintf("invalid link data type: %q", nexusLink.Type))
-		}
-	}
-	return result
+	return commonnexus.ConvertNexusLinksToProtoLinks(links, logger)
 }
 
 func isDestinationDown(err error) bool {

--- a/chasm/lib/nexusoperation/task_handler_helpers.go
+++ b/chasm/lib/nexusoperation/task_handler_helpers.go
@@ -17,7 +17,6 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/common"
-	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexusrpc"
@@ -39,10 +38,6 @@ type operationTimeoutBelowMinError struct {
 
 func (o *operationTimeoutBelowMinError) Error() string {
 	return fmt.Sprintf("not enough time to execute another request before %s timeout", o.timeoutType.String())
-}
-
-func convertResponseLinks(links []nexus.Link, logger log.Logger) []*commonpb.Link {
-	return commonnexus.ConvertNexusLinksToProtoLinks(links, logger)
 }
 
 func isDestinationDown(err error) bool {

--- a/chasm/lib/nexusoperation/task_handler_helpers_test.go
+++ b/chasm/lib/nexusoperation/task_handler_helpers_test.go
@@ -9,10 +9,11 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/common/log"
+	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/testing/protorequire"
 )
 
-func TestConvertResponseLinks(t *testing.T) {
+func TestConvertNexusLinksToProtoLinks(t *testing.T) {
 	logger := log.NewTestLogger()
 
 	workflowEvent := nexus.Link{
@@ -26,7 +27,7 @@ func TestConvertResponseLinks(t *testing.T) {
 	activity := nexus.Link{
 		URL: &url.URL{
 			Scheme: "temporal",
-			Path:   "/namespaces/ns/activities/act-id/run-id",
+			Path:   "/namespaces/ns/activities/act-id/run-id/details",
 		},
 		Type: "temporal.api.common.v1.Link.Activity",
 	}
@@ -39,7 +40,7 @@ func TestConvertResponseLinks(t *testing.T) {
 		Type: "temporal.api.common.v1.Link.Activity",
 	}
 
-	out := convertResponseLinks([]nexus.Link{workflowEvent, activity, unsupported, malformedActivity}, logger)
+	out := commonnexus.ConvertNexusLinksToProtoLinks([]nexus.Link{workflowEvent, activity, unsupported, malformedActivity}, logger)
 	require.Len(t, out, 2)
 
 	expected := []*commonpb.Link{

--- a/chasm/lib/nexusoperation/task_handler_helpers_test.go
+++ b/chasm/lib/nexusoperation/task_handler_helpers_test.go
@@ -1,0 +1,72 @@
+package nexusoperation
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/testing/protorequire"
+)
+
+func TestConvertResponseLinks(t *testing.T) {
+	logger := log.NewTestLogger()
+
+	workflowEvent := nexus.Link{
+		URL: &url.URL{
+			Scheme:   "temporal",
+			Path:     "/namespaces/ns/workflows/wf-id/run-id/history",
+			RawQuery: "eventID=1&eventType=WorkflowExecutionStarted&referenceType=EventReference",
+		},
+		Type: "temporal.api.common.v1.Link.WorkflowEvent",
+	}
+	activity := nexus.Link{
+		URL: &url.URL{
+			Scheme: "temporal",
+			Path:   "/namespaces/ns/activities/act-id/run-id",
+		},
+		Type: "temporal.api.common.v1.Link.Activity",
+	}
+	unsupported := nexus.Link{
+		URL:  &url.URL{Scheme: "temporal", Path: "/foo"},
+		Type: "unknown.Type",
+	}
+	malformedActivity := nexus.Link{
+		URL:  &url.URL{Scheme: "temporal", Path: "/namespaces/ns/foo/act-id"},
+		Type: "temporal.api.common.v1.Link.Activity",
+	}
+
+	out := convertResponseLinks([]nexus.Link{workflowEvent, activity, unsupported, malformedActivity}, logger)
+	require.Len(t, out, 2)
+
+	expected := []*commonpb.Link{
+		{
+			Variant: &commonpb.Link_WorkflowEvent_{
+				WorkflowEvent: &commonpb.Link_WorkflowEvent{
+					Namespace:  "ns",
+					WorkflowId: "wf-id",
+					RunId:      "run-id",
+					Reference: &commonpb.Link_WorkflowEvent_EventRef{
+						EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+							EventId:   1,
+							EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+						},
+					},
+				},
+			},
+		},
+		{
+			Variant: &commonpb.Link_Activity_{
+				Activity: &commonpb.Link_Activity{
+					Namespace:  "ns",
+					ActivityId: "act-id",
+					RunId:      "run-id",
+				},
+			},
+		},
+	}
+	protorequire.ProtoSliceEqual(t, expected, out)
+}

--- a/chasm/lib/workflow/validator.go
+++ b/chasm/lib/workflow/validator.go
@@ -9,6 +9,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/common/enums"
+	commonlinks "go.temporal.io/server/common/links"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/priorities"
 	"go.temporal.io/server/common/retrypolicy"
@@ -126,49 +127,7 @@ func (v *RequestValidator) ValidateLinks(
 	ns string,
 	links []*commonpb.Link,
 ) error {
-	maxAllowedLinks := v.config.maxLinksPerRequest(ns)
-	if len(links) > maxAllowedLinks {
-		return serviceerror.NewInvalidArgumentf("cannot attach more than %d links per request, got %d", maxAllowedLinks, len(links))
-	}
-
-	maxSize := v.config.linkMaxSize(ns)
-	for _, l := range links {
-		if l.Size() > maxSize {
-			return serviceerror.NewInvalidArgumentf("link exceeds allowed size of %d, got %d", maxSize, l.Size())
-		}
-		switch t := l.Variant.(type) {
-		case *commonpb.Link_WorkflowEvent_:
-			if t.WorkflowEvent.GetNamespace() == "" {
-				return serviceerror.NewInvalidArgument("workflow event link must not have an empty namespace field")
-			}
-			if t.WorkflowEvent.GetWorkflowId() == "" {
-				return serviceerror.NewInvalidArgument("workflow event link must not have an empty workflow ID field")
-			}
-			if t.WorkflowEvent.GetRunId() == "" {
-				return serviceerror.NewInvalidArgument("workflow event link must not have an empty run ID field")
-			}
-			if t.WorkflowEvent.GetEventRef().GetEventType() == enumspb.EVENT_TYPE_UNSPECIFIED && t.WorkflowEvent.GetEventRef().GetEventId() != 0 {
-				return serviceerror.NewInvalidArgument("workflow event link ref cannot have an unspecified event type and a non-zero event ID")
-			}
-		case *commonpb.Link_BatchJob_:
-			if t.BatchJob.GetJobId() == "" {
-				return serviceerror.NewInvalidArgument("batch job link must not have an empty job ID")
-			}
-		case *commonpb.Link_NexusOperation_:
-			if t.NexusOperation.GetNamespace() == "" {
-				return serviceerror.NewInvalidArgument("nexus operation link must not have an empty namespace field")
-			}
-			if t.NexusOperation.GetOperationId() == "" {
-				return serviceerror.NewInvalidArgument("nexus operation link must not have an empty operation ID field")
-			}
-			if t.NexusOperation.GetRunId() == "" {
-				return serviceerror.NewInvalidArgument("nexus operation link must not have an empty run ID field")
-			}
-		default:
-			return serviceerror.NewInvalidArgument("unsupported link variant")
-		}
-	}
-	return nil
+	return commonlinks.Validate(links, v.config.maxLinksPerRequest(ns), v.config.linkMaxSize(ns))
 }
 
 func (v *RequestValidator) UnaliasedSearchAttributesFrom(

--- a/chasm/lib/workflow/validator.go
+++ b/chasm/lib/workflow/validator.go
@@ -123,13 +123,6 @@ func (v *RequestValidator) ValidateWorkflowIDReusePolicy(
 	return nil
 }
 
-func (v *RequestValidator) ValidateLinks(
-	ns string,
-	links []*commonpb.Link,
-) error {
-	return commonlinks.Validate(links, v.config.maxLinksPerRequest(ns), v.config.linkMaxSize(ns))
-}
-
 func (v *RequestValidator) UnaliasedSearchAttributesFrom(
 	attributes *commonpb.SearchAttributes,
 	namespaceName string,
@@ -224,5 +217,5 @@ func (v *RequestValidator) ValidateSignalWithStartRequest(request *workflowservi
 		return err
 	}
 
-	return v.ValidateLinks(request.GetNamespace(), request.GetLinks())
+	return commonlinks.Validate(request.GetLinks(), v.config.maxLinksPerRequest(request.GetNamespace()), v.config.linkMaxSize(request.GetNamespace()))
 }

--- a/common/links/validator.go
+++ b/common/links/validator.go
@@ -1,0 +1,65 @@
+// Package links provides validation helpers for temporal.api.common.v1.Link values.
+package links
+
+import (
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+)
+
+// Validate checks that the given links do not exceed the configured count and
+// per-link size limits, and that each link's variant has its required fields
+// populated.
+// nolint:revive // cognitive-complexity is high but justified to keep each case together for readability.
+func Validate(links []*commonpb.Link, maxAllowedLinks, maxSize int) error {
+	if len(links) > maxAllowedLinks {
+		return serviceerror.NewInvalidArgumentf("cannot attach more than %d links per request, got %d", maxAllowedLinks, len(links))
+	}
+	for _, l := range links {
+		if l.Size() > maxSize {
+			return serviceerror.NewInvalidArgumentf("link exceeds allowed size of %d, got %d", maxSize, l.Size())
+		}
+		switch t := l.Variant.(type) {
+		case *commonpb.Link_WorkflowEvent_:
+			if t.WorkflowEvent.GetNamespace() == "" {
+				return serviceerror.NewInvalidArgument("workflow event link must not have an empty namespace field")
+			}
+			if t.WorkflowEvent.GetWorkflowId() == "" {
+				return serviceerror.NewInvalidArgument("workflow event link must not have an empty workflow ID field")
+			}
+			if t.WorkflowEvent.GetRunId() == "" {
+				return serviceerror.NewInvalidArgument("workflow event link must not have an empty run ID field")
+			}
+			if t.WorkflowEvent.GetEventRef().GetEventType() == enumspb.EVENT_TYPE_UNSPECIFIED && t.WorkflowEvent.GetEventRef().GetEventId() != 0 {
+				return serviceerror.NewInvalidArgument("workflow event link ref cannot have an unspecified event type and a non-zero event ID")
+			}
+		case *commonpb.Link_BatchJob_:
+			if t.BatchJob.GetJobId() == "" {
+				return serviceerror.NewInvalidArgument("batch job link must not have an empty job ID")
+			}
+		case *commonpb.Link_NexusOperation_:
+			if t.NexusOperation.GetNamespace() == "" {
+				return serviceerror.NewInvalidArgument("nexus operation link must not have an empty namespace field")
+			}
+			if t.NexusOperation.GetOperationId() == "" {
+				return serviceerror.NewInvalidArgument("nexus operation link must not have an empty operation ID field")
+			}
+			if t.NexusOperation.GetRunId() == "" {
+				return serviceerror.NewInvalidArgument("nexus operation link must not have an empty run ID field")
+			}
+		case *commonpb.Link_Activity_:
+			if t.Activity.GetNamespace() == "" {
+				return serviceerror.NewInvalidArgument("activity link must not have an empty namespace field")
+			}
+			if t.Activity.GetActivityId() == "" {
+				return serviceerror.NewInvalidArgument("activity link must not have an empty activity ID field")
+			}
+			if t.Activity.GetRunId() == "" {
+				return serviceerror.NewInvalidArgument("activity link must not have an empty run ID field")
+			}
+		default:
+			return serviceerror.NewInvalidArgument("unsupported link variant")
+		}
+	}
+	return nil
+}

--- a/common/links/validator_test.go
+++ b/common/links/validator_test.go
@@ -1,0 +1,158 @@
+package links_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/common/links"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestValidate(t *testing.T) {
+	const maxLinks = 3
+	const maxSize = 1024
+
+	validWorkflowEvent := &commonpb.Link{
+		Variant: &commonpb.Link_WorkflowEvent_{
+			WorkflowEvent: &commonpb.Link_WorkflowEvent{
+				Namespace:  "ns",
+				WorkflowId: "wf",
+				RunId:      "run",
+				Reference: &commonpb.Link_WorkflowEvent_EventRef{
+					EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+						EventId:   1,
+						EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+					},
+				},
+			},
+		},
+	}
+	validBatchJob := &commonpb.Link{
+		Variant: &commonpb.Link_BatchJob_{
+			BatchJob: &commonpb.Link_BatchJob{JobId: "job"},
+		},
+	}
+	validNexusOperation := &commonpb.Link{
+		Variant: &commonpb.Link_NexusOperation_{
+			NexusOperation: &commonpb.Link_NexusOperation{
+				Namespace:   "ns",
+				OperationId: "op",
+				RunId:       "run",
+			},
+		},
+	}
+	validActivity := &commonpb.Link{
+		Variant: &commonpb.Link_Activity_{
+			Activity: &commonpb.Link_Activity{
+				Namespace:  "ns",
+				ActivityId: "act",
+				RunId:      "run",
+			},
+		},
+	}
+
+	t.Run("HappyPath", func(t *testing.T) {
+		err := links.Validate([]*commonpb.Link{
+			validWorkflowEvent,
+			validBatchJob,
+			validNexusOperation,
+			validActivity,
+		}, maxLinks+1, maxSize)
+		require.NoError(t, err)
+	})
+
+	t.Run("ExceedsCountLimit", func(t *testing.T) {
+		err := links.Validate([]*commonpb.Link{validWorkflowEvent, validBatchJob, validNexusOperation, validActivity}, maxLinks, maxSize)
+		require.ErrorContains(t, err, "cannot attach more than 3 links per request")
+	})
+
+	t.Run("ExceedsSizeLimit", func(t *testing.T) {
+		err := links.Validate([]*commonpb.Link{validWorkflowEvent}, maxLinks, 1)
+		require.ErrorContains(t, err, "link exceeds allowed size")
+	})
+
+	t.Run("WorkflowEvent/EmptyNamespace", func(t *testing.T) {
+		l := proto.Clone(validWorkflowEvent).(*commonpb.Link)
+		l.GetWorkflowEvent().Namespace = ""
+		err := links.Validate([]*commonpb.Link{l}, maxLinks, maxSize)
+		require.ErrorContains(t, err, "workflow event link must not have an empty namespace field")
+	})
+
+	t.Run("WorkflowEvent/EmptyWorkflowID", func(t *testing.T) {
+		l := proto.Clone(validWorkflowEvent).(*commonpb.Link)
+		l.GetWorkflowEvent().WorkflowId = ""
+		err := links.Validate([]*commonpb.Link{l}, maxLinks, maxSize)
+		require.ErrorContains(t, err, "workflow event link must not have an empty workflow ID field")
+	})
+
+	t.Run("WorkflowEvent/EmptyRunID", func(t *testing.T) {
+		l := proto.Clone(validWorkflowEvent).(*commonpb.Link)
+		l.GetWorkflowEvent().RunId = ""
+		err := links.Validate([]*commonpb.Link{l}, maxLinks, maxSize)
+		require.ErrorContains(t, err, "workflow event link must not have an empty run ID field")
+	})
+
+	t.Run("WorkflowEvent/UnspecifiedTypeWithNonZeroEventID", func(t *testing.T) {
+		l := proto.Clone(validWorkflowEvent).(*commonpb.Link)
+		l.GetWorkflowEvent().GetEventRef().EventType = enumspb.EVENT_TYPE_UNSPECIFIED
+		l.GetWorkflowEvent().GetEventRef().EventId = 42
+		err := links.Validate([]*commonpb.Link{l}, maxLinks, maxSize)
+		require.ErrorContains(t, err, "workflow event link ref cannot have an unspecified event type and a non-zero event ID")
+	})
+
+	t.Run("BatchJob/EmptyJobID", func(t *testing.T) {
+		l := proto.Clone(validBatchJob).(*commonpb.Link)
+		l.GetBatchJob().JobId = ""
+		err := links.Validate([]*commonpb.Link{l}, maxLinks, maxSize)
+		require.ErrorContains(t, err, "batch job link must not have an empty job ID")
+	})
+
+	t.Run("NexusOperation/EmptyNamespace", func(t *testing.T) {
+		l := proto.Clone(validNexusOperation).(*commonpb.Link)
+		l.GetNexusOperation().Namespace = ""
+		err := links.Validate([]*commonpb.Link{l}, maxLinks, maxSize)
+		require.ErrorContains(t, err, "nexus operation link must not have an empty namespace field")
+	})
+
+	t.Run("NexusOperation/EmptyOperationID", func(t *testing.T) {
+		l := proto.Clone(validNexusOperation).(*commonpb.Link)
+		l.GetNexusOperation().OperationId = ""
+		err := links.Validate([]*commonpb.Link{l}, maxLinks, maxSize)
+		require.ErrorContains(t, err, "nexus operation link must not have an empty operation ID field")
+	})
+
+	t.Run("NexusOperation/EmptyRunID", func(t *testing.T) {
+		l := proto.Clone(validNexusOperation).(*commonpb.Link)
+		l.GetNexusOperation().RunId = ""
+		err := links.Validate([]*commonpb.Link{l}, maxLinks, maxSize)
+		require.ErrorContains(t, err, "nexus operation link must not have an empty run ID field")
+	})
+
+	t.Run("Activity/EmptyNamespace", func(t *testing.T) {
+		l := proto.Clone(validActivity).(*commonpb.Link)
+		l.GetActivity().Namespace = ""
+		err := links.Validate([]*commonpb.Link{l}, maxLinks, maxSize)
+		require.ErrorContains(t, err, "activity link must not have an empty namespace field")
+	})
+
+	t.Run("Activity/EmptyActivityID", func(t *testing.T) {
+		l := proto.Clone(validActivity).(*commonpb.Link)
+		l.GetActivity().ActivityId = ""
+		err := links.Validate([]*commonpb.Link{l}, maxLinks, maxSize)
+		require.ErrorContains(t, err, "activity link must not have an empty activity ID field")
+	})
+
+	t.Run("Activity/EmptyRunID", func(t *testing.T) {
+		l := proto.Clone(validActivity).(*commonpb.Link)
+		l.GetActivity().RunId = ""
+		err := links.Validate([]*commonpb.Link{l}, maxLinks, maxSize)
+		require.ErrorContains(t, err, "activity link must not have an empty run ID field")
+	})
+
+	t.Run("UnsupportedVariant", func(t *testing.T) {
+		err := links.Validate([]*commonpb.Link{{}}, maxLinks, maxSize)
+		require.ErrorContains(t, err, "unsupported link variant")
+	})
+}

--- a/common/nexus/link_converter.go
+++ b/common/nexus/link_converter.go
@@ -42,9 +42,11 @@ const (
 	urlSchemeTemporalKey          = "temporal"
 	urlPathNamespaceKey           = "namespace"
 	urlPathWorkflowIDKey          = "workflowID"
+	urlPathActivityIDKey          = "activityID"
 	urlPathRunIDKey               = "runID"
 	urlPathWorkflowEventTemplate  = "/namespaces/%s/workflows/%s/%s/history"
 	urlPathNexusOperationTemplate = "/namespaces/%s/nexus-operations/%s"
+	urlPathActivityTemplate       = "/namespaces/%s/activities/%s/%s"
 
 	linkWorkflowEventReferenceTypeKey = "referenceType"
 	linkEventIDKey                    = "eventID"
@@ -55,11 +57,18 @@ const (
 var (
 	rePatternNamespace  = fmt.Sprintf(`(?P<%s>[^/]+)`, urlPathNamespaceKey)
 	rePatternWorkflowID = fmt.Sprintf(`(?P<%s>[^/]+)`, urlPathWorkflowIDKey)
+	rePatternActivityID = fmt.Sprintf(`(?P<%s>[^/]+)`, urlPathActivityIDKey)
 	rePatternRunID      = fmt.Sprintf(`(?P<%s>[^/]+)`, urlPathRunIDKey)
 	urlPathRE           = regexp.MustCompile(fmt.Sprintf(
 		`^/namespaces/%s/workflows/%s/%s/history$`,
 		rePatternNamespace,
 		rePatternWorkflowID,
+		rePatternRunID,
+	))
+	urlPathActivityRE = regexp.MustCompile(fmt.Sprintf(
+		`^/namespaces/%s/activities/%s/%s$`,
+		rePatternNamespace,
+		rePatternActivityID,
 		rePatternRunID,
 	))
 	eventReferenceType     = string((&commonpb.Link_WorkflowEvent_EventReference{}).ProtoReflect().Descriptor().Name())
@@ -86,6 +95,70 @@ func ConvertLinkNexusOperationToNexusLink(no *commonpb.Link_NexusOperation) nexu
 		URL:  u,
 		Type: string(no.ProtoReflect().Descriptor().FullName()),
 	}
+}
+
+// ConvertLinkActivityToNexusLink converts a Link_Activity type to Nexus Link.
+//
+// NOTE: Experimental
+func ConvertLinkActivityToNexusLink(a *commonpb.Link_Activity) nexus.Link {
+	u := &url.URL{
+		Scheme: urlSchemeTemporalKey,
+		Path:   fmt.Sprintf(urlPathActivityTemplate, a.GetNamespace(), a.GetActivityId(), a.GetRunId()),
+		RawPath: fmt.Sprintf(
+			urlPathActivityTemplate,
+			url.PathEscape(a.GetNamespace()),
+			url.PathEscape(a.GetActivityId()),
+			url.PathEscape(a.GetRunId()),
+		),
+	}
+
+	return nexus.Link{
+		URL:  u,
+		Type: string(a.ProtoReflect().Descriptor().FullName()),
+	}
+}
+
+// ConvertNexusLinkToLinkActivity converts a Nexus Link to Link_Activity.
+//
+// NOTE: Experimental
+func ConvertNexusLinkToLinkActivity(link nexus.Link) (*commonpb.Link_Activity, error) {
+	a := &commonpb.Link_Activity{}
+	if link.Type != string(a.ProtoReflect().Descriptor().FullName()) {
+		return nil, fmt.Errorf(
+			"cannot parse link type %q to %q",
+			link.Type,
+			a.ProtoReflect().Descriptor().FullName(),
+		)
+	}
+
+	if link.URL.Scheme != urlSchemeTemporalKey {
+		return nil, fmt.Errorf(
+			"failed to parse link to Link_Activity: invalid scheme: %s",
+			link.URL.Scheme,
+		)
+	}
+
+	matches := urlPathActivityRE.FindStringSubmatch(link.URL.EscapedPath())
+	if len(matches) != 4 {
+		return nil, errors.New("failed to parse link to Link_Activity: malformed URL path")
+	}
+
+	var err error
+	a.Namespace, err = url.PathUnescape(matches[urlPathActivityRE.SubexpIndex(urlPathNamespaceKey)])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse link to Link_Activity: %w", err)
+	}
+
+	a.ActivityId, err = url.PathUnescape(matches[urlPathActivityRE.SubexpIndex(urlPathActivityIDKey)])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse link to Link_Activity: %w", err)
+	}
+
+	a.RunId, err = url.PathUnescape(matches[urlPathActivityRE.SubexpIndex(urlPathRunIDKey)])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse link to Link_Activity: %w", err)
+	}
+	return a, nil
 }
 
 // ConvertLinkWorkflowEventToNexusLink converts a Link_WorkflowEvent type to Nexus Link.

--- a/common/nexus/link_converter.go
+++ b/common/nexus/link_converter.go
@@ -46,7 +46,7 @@ const (
 	urlPathRunIDKey               = "runID"
 	urlPathWorkflowEventTemplate  = "/namespaces/%s/workflows/%s/%s/history"
 	urlPathNexusOperationTemplate = "/namespaces/%s/nexus-operations/%s"
-	urlPathActivityTemplate       = "/namespaces/%s/activities/%s/%s"
+	urlPathActivityTemplate       = "/namespaces/%s/activities/%s/%s/details"
 
 	linkWorkflowEventReferenceTypeKey = "referenceType"
 	linkEventIDKey                    = "eventID"
@@ -66,7 +66,7 @@ var (
 		rePatternRunID,
 	))
 	urlPathActivityRE = regexp.MustCompile(fmt.Sprintf(
-		`^/namespaces/%s/activities/%s/%s$`,
+		`^/namespaces/%s/activities/%s/%s/details$`,
 		rePatternNamespace,
 		rePatternActivityID,
 		rePatternRunID,

--- a/common/nexus/link_converter_test.go
+++ b/common/nexus/link_converter_test.go
@@ -33,6 +33,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	commonnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/testing/protorequire"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
@@ -54,6 +55,101 @@ func TestConvertLinkNexusOperationToNexusLink(t *testing.T) {
 		Type: "temporal.api.common.v1.Link.NexusOperation",
 	}, output)
 	require.Equal(t, "temporal:///namespaces/ns/nexus-operations/op-id?runID=run-id", output.URL.String())
+}
+
+func TestConvertLinkActivityToNexusLink(t *testing.T) {
+	input := &commonpb.Link_Activity{
+		Namespace:  "ns",
+		ActivityId: "act-id",
+		RunId:      "run-id",
+	}
+
+	output := commonnexus.ConvertLinkActivityToNexusLink(input)
+	require.Equal(t, nexus.Link{
+		URL: &url.URL{
+			Scheme:  "temporal",
+			Path:    "/namespaces/ns/activities/act-id/run-id",
+			RawPath: "/namespaces/ns/activities/act-id/run-id",
+		},
+		Type: "temporal.api.common.v1.Link.Activity",
+	}, output)
+	require.Equal(t, "temporal:///namespaces/ns/activities/act-id/run-id", output.URL.String())
+}
+
+func TestConvertNexusLinkToLinkActivity(t *testing.T) {
+	type testcase struct {
+		name     string
+		input    nexus.Link
+		expected *commonpb.Link_Activity
+		errMsg   string
+	}
+
+	cases := []testcase{
+		{
+			name: "valid",
+			input: nexus.Link{
+				URL: &url.URL{
+					Scheme: "temporal",
+					Path:   "/namespaces/ns/activities/act-id/run-id",
+				},
+				Type: "temporal.api.common.v1.Link.Activity",
+			},
+			expected: &commonpb.Link_Activity{
+				Namespace:  "ns",
+				ActivityId: "act-id",
+				RunId:      "run-id",
+			},
+		},
+		{
+			name: "round-trip with escaped path",
+			input: commonnexus.ConvertLinkActivityToNexusLink(&commonpb.Link_Activity{
+				Namespace:  "ns/with/slash",
+				ActivityId: "act id with space",
+				RunId:      "run-id",
+			}),
+			expected: &commonpb.Link_Activity{
+				Namespace:  "ns/with/slash",
+				ActivityId: "act id with space",
+				RunId:      "run-id",
+			},
+		},
+		{
+			name: "wrong type",
+			input: nexus.Link{
+				URL:  &url.URL{Scheme: "temporal", Path: "/namespaces/ns/activities/act-id"},
+				Type: "temporal.api.common.v1.Link.WorkflowEvent",
+			},
+			errMsg: "cannot parse link type",
+		},
+		{
+			name: "invalid scheme",
+			input: nexus.Link{
+				URL:  &url.URL{Scheme: "http", Path: "/namespaces/ns/activities/act-id"},
+				Type: "temporal.api.common.v1.Link.Activity",
+			},
+			errMsg: "invalid scheme",
+		},
+		{
+			name: "malformed path",
+			input: nexus.Link{
+				URL:  &url.URL{Scheme: "temporal", Path: "/namespaces/ns/foo/act-id"},
+				Type: "temporal.api.common.v1.Link.Activity",
+			},
+			errMsg: "malformed URL path",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := commonnexus.ConvertNexusLinkToLinkActivity(tc.input)
+			if tc.errMsg != "" {
+				require.ErrorContains(t, err, tc.errMsg)
+				return
+			}
+			require.NoError(t, err)
+			protorequire.ProtoEqual(t, tc.expected, out)
+		})
+	}
 }
 
 func TestConvertLinkWorkflowEventToNexusLink(t *testing.T) {

--- a/common/nexus/link_converter_test.go
+++ b/common/nexus/link_converter_test.go
@@ -68,12 +68,12 @@ func TestConvertLinkActivityToNexusLink(t *testing.T) {
 	require.Equal(t, nexus.Link{
 		URL: &url.URL{
 			Scheme:  "temporal",
-			Path:    "/namespaces/ns/activities/act-id/run-id",
-			RawPath: "/namespaces/ns/activities/act-id/run-id",
+			Path:    "/namespaces/ns/activities/act-id/run-id/details",
+			RawPath: "/namespaces/ns/activities/act-id/run-id/details",
 		},
 		Type: "temporal.api.common.v1.Link.Activity",
 	}, output)
-	require.Equal(t, "temporal:///namespaces/ns/activities/act-id/run-id", output.URL.String())
+	require.Equal(t, "temporal:///namespaces/ns/activities/act-id/run-id/details", output.URL.String())
 }
 
 func TestConvertNexusLinkToLinkActivity(t *testing.T) {
@@ -90,7 +90,7 @@ func TestConvertNexusLinkToLinkActivity(t *testing.T) {
 			input: nexus.Link{
 				URL: &url.URL{
 					Scheme: "temporal",
-					Path:   "/namespaces/ns/activities/act-id/run-id",
+					Path:   "/namespaces/ns/activities/act-id/run-id/details",
 				},
 				Type: "temporal.api.common.v1.Link.Activity",
 			},

--- a/common/nexus/links.go
+++ b/common/nexus/links.go
@@ -1,0 +1,48 @@
+package nexus
+
+import (
+	"fmt"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+)
+
+// ConvertNexusLinksToProtoLinks converts a slice of Nexus SDK links into Temporal proto links,
+// supporting Link_WorkflowEvent and Link_Activity variants. Unsupported or malformed entries
+// are skipped with a warning since links are non-essential to execution.
+func ConvertNexusLinksToProtoLinks(nexusLinks []nexus.Link, logger log.Logger) []*commonpb.Link {
+	var out []*commonpb.Link
+	for _, nexusLink := range nexusLinks {
+		switch nexusLink.Type {
+		case string((&commonpb.Link_WorkflowEvent{}).ProtoReflect().Descriptor().FullName()):
+			link, err := ConvertNexusLinkToLinkWorkflowEvent(nexusLink)
+			if err != nil {
+				logger.Warn(
+					fmt.Sprintf("failed to parse link to %q: %s", nexusLink.Type, nexusLink.URL),
+					tag.Error(err),
+				)
+				continue
+			}
+			out = append(out, &commonpb.Link{
+				Variant: &commonpb.Link_WorkflowEvent_{WorkflowEvent: link},
+			})
+		case string((&commonpb.Link_Activity{}).ProtoReflect().Descriptor().FullName()):
+			link, err := ConvertNexusLinkToLinkActivity(nexusLink)
+			if err != nil {
+				logger.Warn(
+					fmt.Sprintf("failed to parse link to %q: %s", nexusLink.Type, nexusLink.URL),
+					tag.Error(err),
+				)
+				continue
+			}
+			out = append(out, &commonpb.Link{
+				Variant: &commonpb.Link_Activity_{Activity: link},
+			})
+		default:
+			logger.Warn(fmt.Sprintf("invalid link data type: %q", nexusLink.Type))
+		}
+	}
+	return out
+}

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -425,32 +425,7 @@ func (e taskExecutor) saveResult(ctx context.Context, env hsm.Environment, ref h
 			return err
 		}
 
-		var links []*commonpb.Link
-		if result.Links != nil {
-			for _, nexusLink := range result.Links {
-				switch nexusLink.Type {
-				case string((&commonpb.Link_WorkflowEvent{}).ProtoReflect().Descriptor().FullName()):
-					link, err := commonnexus.ConvertNexusLinkToLinkWorkflowEvent(nexusLink)
-					if err != nil {
-						// TODO(rodrigozhou): links are non-essential for the execution of the workflow,
-						// so ignoring the error for now; we will revisit how to handle these errors later.
-						e.Logger.Error(
-							fmt.Sprintf("failed to parse link to %q: %s", nexusLink.Type, nexusLink.URL),
-							tag.Error(err),
-						)
-						continue
-					}
-					links = append(links, &commonpb.Link{
-						Variant: &commonpb.Link_WorkflowEvent_{
-							WorkflowEvent: link,
-						},
-					})
-				default:
-					// If the link data type is unsupported, just ignore it for now.
-					e.Logger.Error(fmt.Sprintf("invalid link data type: %q", nexusLink.Type))
-				}
-			}
-		}
+		links := commonnexus.ConvertNexusLinksToProtoLinks(result.Links, e.Logger)
 
 		if result.Pending != nil {
 			// Handler has indicated that the operation will complete asynchronously. Mark the operation as started

--- a/service/frontend/nexus_completion_http_handler.go
+++ b/service/frontend/nexus_completion_http_handler.go
@@ -216,30 +216,7 @@ func (h *nexusCompletionHandler) CompleteOperation(ctx context.Context, r *nexus
 		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "operation token length exceeds allowed limit (%d/%d)", len(r.OperationToken), tokenLimit)
 	}
 
-	var links []*commonpb.Link
-	for _, nexusLink := range r.Links {
-		switch nexusLink.Type {
-		case string((&commonpb.Link_WorkflowEvent{}).ProtoReflect().Descriptor().FullName()):
-			link, err := commonnexus.ConvertNexusLinkToLinkWorkflowEvent(nexusLink)
-			if err != nil {
-				// TODO(rodrigozhou): links are non-essential for the execution of the workflow,
-				// so ignoring the error for now; we will revisit how to handle these errors later.
-				h.Logger.Warn(
-					fmt.Sprintf("failed to parse link to %q: %s", nexusLink.Type, nexusLink.URL),
-					tag.Error(err),
-				)
-				continue
-			}
-			links = append(links, &commonpb.Link{
-				Variant: &commonpb.Link_WorkflowEvent_{
-					WorkflowEvent: link,
-				},
-			})
-		default:
-			// If the link data type is unsupported, just ignore it for now.
-			h.Logger.Warn(fmt.Sprintf("invalid link data type: %q", nexusLink.Type))
-		}
-	}
+	links := commonnexus.ConvertNexusLinksToProtoLinks(r.Links, h.Logger)
 
 	var successPayload *commonpb.Payload
 	switch r.State { // nolint:exhaustive

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -55,6 +55,7 @@ import (
 	"go.temporal.io/server/common/enums"
 	"go.temporal.io/server/common/failure"
 	"go.temporal.io/server/common/headers"
+	commonlinks "go.temporal.io/server/common/links"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/membership"
@@ -687,7 +688,7 @@ func (wh *WorkflowHandler) prepareStartWorkflowRequest(
 	for _, cb := range request.GetCompletionCallbacks() {
 		allLinks = append(allLinks, cb.GetLinks()...)
 	}
-	if err := wh.validator.ValidateLinks(namespaceName.String(), allLinks); err != nil {
+	if err := commonlinks.Validate(allLinks, wh.config.MaxLinksPerRequest(namespaceName.String()), wh.config.LinkMaxSize(namespaceName.String())); err != nil {
 		return nil, err
 	}
 
@@ -2222,7 +2223,7 @@ func (wh *WorkflowHandler) RequestCancelWorkflowExecution(ctx context.Context, r
 		return nil, err
 	}
 
-	if err := wh.validator.ValidateLinks(request.GetNamespace(), request.GetLinks()); err != nil {
+	if err := commonlinks.Validate(request.GetLinks(), wh.config.MaxLinksPerRequest(request.GetNamespace()), wh.config.LinkMaxSize(request.GetNamespace())); err != nil {
 		return nil, err
 	}
 
@@ -2267,7 +2268,7 @@ func (wh *WorkflowHandler) SignalWorkflowExecution(ctx context.Context, request 
 		return nil, errRequestIDTooLong
 	}
 
-	if err := wh.validator.ValidateLinks(request.GetNamespace(), request.GetLinks()); err != nil {
+	if err := commonlinks.Validate(request.GetLinks(), wh.config.MaxLinksPerRequest(request.GetNamespace()), wh.config.LinkMaxSize(request.GetNamespace())); err != nil {
 		return nil, err
 	}
 
@@ -2331,7 +2332,7 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 		return nil, err
 	}
 
-	if err := wh.validator.ValidateLinks(request.GetNamespace(), request.GetLinks()); err != nil {
+	if err := commonlinks.Validate(request.GetLinks(), wh.config.MaxLinksPerRequest(request.GetNamespace()), wh.config.LinkMaxSize(request.GetNamespace())); err != nil {
 		return nil, err
 	}
 
@@ -2425,7 +2426,7 @@ func (wh *WorkflowHandler) TerminateWorkflowExecution(ctx context.Context, reque
 		return nil, err
 	}
 
-	if err := wh.validator.ValidateLinks(request.GetNamespace(), request.GetLinks()); err != nil {
+	if err := commonlinks.Validate(request.GetLinks(), wh.config.MaxLinksPerRequest(request.GetNamespace()), wh.config.LinkMaxSize(request.GetNamespace())); err != nil {
 		return nil, err
 	}
 
@@ -6301,55 +6302,6 @@ func dedupLinksFromCallbacks(
 		}
 	}
 	return res
-}
-
-func (wh *WorkflowHandler) validateLinks(
-	ns namespace.Name,
-	links []*commonpb.Link,
-) error {
-	maxAllowedLinks := wh.config.MaxLinksPerRequest(ns.String())
-	if len(links) > maxAllowedLinks {
-		return serviceerror.NewInvalidArgumentf("cannot attach more than %d links per request, got %d", maxAllowedLinks, len(links))
-	}
-
-	maxSize := wh.config.LinkMaxSize(ns.String())
-	for _, l := range links {
-		if l.Size() > maxSize {
-			return serviceerror.NewInvalidArgumentf("link exceeds allowed size of %d, got %d", maxSize, l.Size())
-		}
-		switch t := l.Variant.(type) {
-		case *commonpb.Link_WorkflowEvent_:
-			if t.WorkflowEvent.GetNamespace() == "" {
-				return serviceerror.NewInvalidArgument("workflow event link must not have an empty namespace field")
-			}
-			if t.WorkflowEvent.GetWorkflowId() == "" {
-				return serviceerror.NewInvalidArgument("workflow event link must not have an empty workflow ID field")
-			}
-			if t.WorkflowEvent.GetRunId() == "" {
-				return serviceerror.NewInvalidArgument("workflow event link must not have an empty run ID field")
-			}
-			if t.WorkflowEvent.GetEventRef().GetEventType() == enumspb.EVENT_TYPE_UNSPECIFIED && t.WorkflowEvent.GetEventRef().GetEventId() != 0 {
-				return serviceerror.NewInvalidArgument("workflow event link ref cannot have an unspecified event type and a non-zero event ID")
-			}
-		case *commonpb.Link_BatchJob_:
-			if t.BatchJob.GetJobId() == "" {
-				return serviceerror.NewInvalidArgument("batch job link must not have an empty job ID")
-			}
-		case *commonpb.Link_NexusOperation_:
-			if t.NexusOperation.GetNamespace() == "" {
-				return serviceerror.NewInvalidArgument("nexus operation link must not have an empty namespace field")
-			}
-			if t.NexusOperation.GetOperationId() == "" {
-				return serviceerror.NewInvalidArgument("nexus operation link must not have an empty operation ID field")
-			}
-			if t.NexusOperation.GetRunId() == "" {
-				return serviceerror.NewInvalidArgument("nexus operation link must not have an empty run ID field")
-			}
-		default:
-			return serviceerror.NewInvalidArgument("unsupported link variant")
-		}
-	}
-	return nil
 }
 
 type buildIdAndFlag interface {

--- a/tests/standalone_activity_test.go
+++ b/tests/standalone_activity_test.go
@@ -349,6 +349,62 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 				require.Equal(t, "http://localhost/existing-activity-cb", descResp.Callbacks[0].GetInfo().GetCallback().GetNexus().GetUrl())
 			})
 
+			t.Run("AttachesCallbacksAndLinksTogether", func(t *testing.T) {
+				bothActivityID := testcore.RandomizeStr(t.Name())
+				bothTaskQueue := testcore.RandomizeStr(t.Name())
+				bothStartResp := env.startAndValidateActivity(ctx, t, bothActivityID, bothTaskQueue)
+
+				attachedLinks := []*commonpb.Link{
+					{
+						Variant: &commonpb.Link_WorkflowEvent_{
+							WorkflowEvent: &commonpb.Link_WorkflowEvent{
+								Namespace:  env.Namespace().String(),
+								WorkflowId: "both-wf",
+								RunId:      "both-run",
+								Reference: &commonpb.Link_WorkflowEvent_EventRef{
+									EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+										EventId:   1,
+										EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+									},
+								},
+							},
+						},
+					},
+				}
+
+				resp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+					Namespace:    env.Namespace().String(),
+					ActivityId:   bothActivityID,
+					ActivityType: env.Tv().ActivityType(),
+					Identity:     env.Tv().WorkerIdentity(),
+					Input:        defaultInput,
+					TaskQueue: &taskqueuepb.TaskQueue{
+						Name: bothTaskQueue,
+					},
+					StartToCloseTimeout: durationpb.New(1 * time.Minute),
+					IdConflictPolicy:    enumspb.ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING,
+					RequestId:           env.Tv().Any().String(),
+					CompletionCallbacks: []*commonpb.Callback{
+						{Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: "http://localhost/both-cb"}}},
+					},
+					Links:             attachedLinks,
+					OnConflictOptions: onConflictOpts,
+				})
+				require.NoError(t, err)
+				require.False(t, resp.GetStarted())
+				require.Equal(t, bothStartResp.RunId, resp.RunId)
+
+				descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+					Namespace:  env.Namespace().String(),
+					ActivityId: bothActivityID,
+					RunId:      bothStartResp.RunId,
+				})
+				require.NoError(t, err)
+				require.Len(t, descResp.Callbacks, 1)
+				require.Equal(t, "http://localhost/both-cb", descResp.Callbacks[0].GetInfo().GetCallback().GetNexus().GetUrl())
+				protorequire.ProtoSliceEqual(t, attachedLinks, descResp.GetInfo().GetLinks())
+			})
+
 			t.Run("IdempotentWithSameRequestId", func(t *testing.T) {
 				idempotentActivityID := testcore.RandomizeStr(t.Name())
 				idempotentTaskQueue := testcore.RandomizeStr(t.Name())
@@ -696,6 +752,212 @@ func (s *standaloneActivityTestSuite) TestStart() {
 		require.Equal(t, env.Namespace().String(), link.Namespace)
 		require.Equal(t, activityID, link.ActivityId)
 		require.Equal(t, resp.RunId, link.RunId)
+	})
+
+	t.Run("RequestLinksSurfacedOnDescribe", func(t *testing.T) {
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		requestLinks := []*commonpb.Link{
+			{
+				Variant: &commonpb.Link_WorkflowEvent_{
+					WorkflowEvent: &commonpb.Link_WorkflowEvent{
+						Namespace:  env.Namespace().String(),
+						WorkflowId: "linked-workflow-id",
+						RunId:      "linked-run-id",
+						Reference: &commonpb.Link_WorkflowEvent_EventRef{
+							EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+								EventId:   1,
+								EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+							},
+						},
+					},
+				},
+			},
+			{
+				Variant: &commonpb.Link_Activity_{
+					Activity: &commonpb.Link_Activity{
+						Namespace:  env.Namespace().String(),
+						ActivityId: "linked-activity-id",
+						RunId:      "linked-activity-run-id",
+					},
+				},
+			},
+		}
+
+		resp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:    env.Namespace().String(),
+			ActivityId:   activityID,
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
+			Input:        defaultInput,
+			TaskQueue: &taskqueuepb.TaskQueue{
+				Name: taskQueue,
+			},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			RequestId:           env.Tv().Any().String(),
+			Links:               requestLinks,
+		})
+		require.NoError(t, err)
+		require.True(t, resp.Started)
+
+		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      resp.RunId,
+		})
+		require.NoError(t, err)
+		protorequire.ProtoSliceEqual(t, requestLinks, descResp.GetInfo().GetLinks())
+	})
+
+	t.Run("AttachLinksOnConflictUnionsLinks", func(t *testing.T) {
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		firstLinks := []*commonpb.Link{
+			{
+				Variant: &commonpb.Link_WorkflowEvent_{
+					WorkflowEvent: &commonpb.Link_WorkflowEvent{
+						Namespace:  env.Namespace().String(),
+						WorkflowId: "first-wf",
+						RunId:      "first-run",
+						Reference: &commonpb.Link_WorkflowEvent_EventRef{
+							EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+								EventId:   1,
+								EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+							},
+						},
+					},
+				},
+			},
+		}
+		secondLinks := []*commonpb.Link{
+			{
+				Variant: &commonpb.Link_Activity_{
+					Activity: &commonpb.Link_Activity{
+						Namespace:  env.Namespace().String(),
+						ActivityId: "second-act",
+						RunId:      "second-run",
+					},
+				},
+			},
+		}
+
+		firstResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:    env.Namespace().String(),
+			ActivityId:   activityID,
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
+			Input:        defaultInput,
+			TaskQueue: &taskqueuepb.TaskQueue{
+				Name: taskQueue,
+			},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			RequestId:           env.Tv().Any().String(),
+			IdConflictPolicy:    enumspb.ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING,
+			Links:               firstLinks,
+		})
+		require.NoError(t, err)
+		require.True(t, firstResp.Started)
+
+		secondResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:    env.Namespace().String(),
+			ActivityId:   activityID,
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
+			Input:        defaultInput,
+			TaskQueue: &taskqueuepb.TaskQueue{
+				Name: taskQueue,
+			},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			RequestId:           env.Tv().Any().String(),
+			IdConflictPolicy:    enumspb.ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING,
+			Links:               secondLinks,
+			OnConflictOptions: &commonpb.OnConflictOptions{
+				AttachLinks: true,
+			},
+		})
+		require.NoError(t, err)
+		require.False(t, secondResp.Started)
+		require.Equal(t, firstResp.RunId, secondResp.RunId)
+
+		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      firstResp.RunId,
+		})
+		require.NoError(t, err)
+		expected := append([]*commonpb.Link{}, firstLinks...)
+		expected = append(expected, secondLinks...)
+		protorequire.ProtoSliceEqual(t, expected, descResp.GetInfo().GetLinks())
+	})
+
+	t.Run("AttachLinksOnConflictDeduplicates", func(t *testing.T) {
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		startLinks := []*commonpb.Link{
+			{
+				Variant: &commonpb.Link_WorkflowEvent_{
+					WorkflowEvent: &commonpb.Link_WorkflowEvent{
+						Namespace:  env.Namespace().String(),
+						WorkflowId: "dedup-wf",
+						RunId:      "dedup-run",
+						Reference: &commonpb.Link_WorkflowEvent_EventRef{
+							EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+								EventId:   1,
+								EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		firstResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:    env.Namespace().String(),
+			ActivityId:   activityID,
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
+			Input:        defaultInput,
+			TaskQueue: &taskqueuepb.TaskQueue{
+				Name: taskQueue,
+			},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			RequestId:           env.Tv().Any().String(),
+			IdConflictPolicy:    enumspb.ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING,
+			Links:               startLinks,
+		})
+		require.NoError(t, err)
+		require.True(t, firstResp.Started)
+
+		// Second start re-sends the same link plus an extra duplicate within the same batch.
+		_, err = env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:    env.Namespace().String(),
+			ActivityId:   activityID,
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
+			Input:        defaultInput,
+			TaskQueue: &taskqueuepb.TaskQueue{
+				Name: taskQueue,
+			},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			RequestId:           env.Tv().Any().String(),
+			IdConflictPolicy:    enumspb.ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING,
+			Links:               append(startLinks, startLinks...),
+			OnConflictOptions: &commonpb.OnConflictOptions{
+				AttachLinks: true,
+			},
+		})
+		require.NoError(t, err)
+
+		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      firstResp.RunId,
+		})
+		require.NoError(t, err)
+		protorequire.ProtoSliceEqual(t, startLinks, descResp.GetInfo().GetLinks())
 	})
 }
 


### PR DESCRIPTION

## What changed?
Wire up stand alone activity links. Allowing links to be recorded on the activity execution and links to the execution.

## Why?

Properly support bi-directional linking to/from the activity execution. Critical for bi-directional linking we use with Nexus Operations.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple request paths (activity start, workflow APIs, Nexus completions) and persisted activity state; behavior is bounded by caps and tests but scope is broad across frontend/history.
> 
> **Overview**
> Adds **end-to-end link support for standalone activities**: links on `StartActivityExecution` are stored on `ActivityRequestData`, returned on describe/poll/history-shaped responses, and can be **merged on conflict** when `OnConflictOptions.attach_links` is set (with proto dedup and a per-execution cap via `activity.maxLinksPerExecution`).
> 
> Introduces **`common/links.Validate`** (including **`Link_Activity`**) and an activity **`linkValidator`**, wired through frontend/history FX. **Nexus** gains activity URL conversion and **`ConvertNexusLinksToProtoLinks`**, replacing duplicated link-parsing in Nexus operation paths, frontend completion, and legacy executors.
> 
> Workflow/frontend link checks now call the shared validator instead of local duplicates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9483491d8ebb7f06d728f3239ba429f80f562563. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->