### PR TITLE
Add tdbg schedule audit command

### DIFF
--- a/tools/tdbg/flags.go
+++ b/tools/tdbg/flags.go
@@ -80,4 +80,13 @@ var (
 	FlagScheduleID                 = "schedule-id"
 	FlagScheduleIDAlias            = []string{"sid"}
 	FlagTarget                     = "target"
+	FlagNamespaceFile              = "namespace-file"
+	FlagAuditStart                 = "start"
+	FlagAuditEnd                   = "end"
+	FlagOutputDir                  = "output-dir"
+	FlagNamespaceConcurrency       = "namespace-concurrency"
+)
+
+var (
+	FlagOutputDirAlias = []string{"o"}
 )

--- a/tools/tdbg/flags.go
+++ b/tools/tdbg/flags.go
@@ -85,6 +85,7 @@ var (
 	FlagEnd                        = "end"
 	FlagOutputDir                  = "output-dir"
 	FlagNamespaceConcurrency       = "namespace-concurrency"
+	FlagFormat                     = "format"
 )
 
 var (

--- a/tools/tdbg/flags.go
+++ b/tools/tdbg/flags.go
@@ -80,13 +80,15 @@ var (
 	FlagScheduleID                 = "schedule-id"
 	FlagScheduleIDAlias            = []string{"sid"}
 	FlagTarget                     = "target"
-	FlagNamespaceFile              = "namespace-file"
-	FlagAuditStart                 = "start"
-	FlagAuditEnd                   = "end"
+	FlagFile                       = "file"
+	FlagStart                      = "start"
+	FlagEnd                        = "end"
+	FlagMaxWindow                  = "max-window"
 	FlagOutputDir                  = "output-dir"
 	FlagNamespaceConcurrency       = "namespace-concurrency"
 )
 
 var (
 	FlagOutputDirAlias = []string{"o"}
+	FlagFileAlias      = []string{"f"}
 )

--- a/tools/tdbg/flags.go
+++ b/tools/tdbg/flags.go
@@ -83,7 +83,6 @@ var (
 	FlagFile                       = "file"
 	FlagStart                      = "start"
 	FlagEnd                        = "end"
-	FlagMaxWindow                  = "max-window"
 	FlagOutputDir                  = "output-dir"
 	FlagNamespaceConcurrency       = "namespace-concurrency"
 )

--- a/tools/tdbg/schedule_audit.go
+++ b/tools/tdbg/schedule_audit.go
@@ -125,7 +125,6 @@ type auditInputs struct {
 	Targets              []auditTarget
 	WindowStart          time.Time
 	WindowEnd            time.Time
-	MaxWindow            time.Duration
 	OutputDir            string
 	NamespaceConcurrency int
 }
@@ -134,13 +133,9 @@ func parseAuditInputs(c *cli.Context) (*auditInputs, error) {
 	in := &auditInputs{
 		OutputDir:            c.String(FlagOutputDir),
 		NamespaceConcurrency: c.Int(FlagNamespaceConcurrency),
-		MaxWindow:            c.Duration(FlagMaxWindow),
 	}
 	if in.NamespaceConcurrency <= 0 {
 		in.NamespaceConcurrency = 1
-	}
-	if in.MaxWindow <= 0 {
-		in.MaxWindow = defaultMaxAuditWindow
 	}
 
 	targets, err := resolveTargetsFromFlags(c.String(FlagNamespace), c.String(FlagScheduleID), c.String(FlagFile), os.Stdin)
@@ -159,19 +154,8 @@ func parseAuditInputs(c *cli.Context) (*auditInputs, error) {
 	if err := in.validate(); err != nil {
 		return nil, err
 	}
-
-	if d := in.WindowEnd.Sub(in.WindowStart); d > defaultMaxAuditWindow {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: window is %s (longer than default cap %s); proportionally slower and more memory-intensive\n",
-			d.Round(time.Hour), defaultMaxAuditWindow)
-	}
-
 	return in, nil
 }
-
-// defaultMaxAuditWindow caps how wide a single audit window can be by default. Catches typos (e.g. wrong month in
-// --end) and discourages expensive multi-day runs that should be chunked into separate invocations. Operators can
-// raise the cap via --max-window for schedules that fire less frequently (quarterly, yearly).
-const defaultMaxAuditWindow = 7 * 24 * time.Hour
 
 func (in *auditInputs) validate() error {
 	if len(in.Targets) == 0 {
@@ -181,14 +165,6 @@ func (in *auditInputs) validate() error {
 		return fmt.Errorf("--end (%s) must be after --start (%s)",
 			in.WindowEnd.UTC().Format(time.RFC3339),
 			in.WindowStart.UTC().Format(time.RFC3339))
-	}
-	if d := in.WindowEnd.Sub(in.WindowStart); d > in.MaxWindow {
-		return fmt.Errorf("window is %s (--start %s to --end %s); max is %s. Pass --max-window=%s if intentional",
-			d.Round(time.Hour),
-			in.WindowStart.UTC().Format(time.RFC3339),
-			in.WindowEnd.UTC().Format(time.RFC3339),
-			in.MaxWindow,
-			d.Round(time.Hour))
 	}
 	return nil
 }
@@ -381,28 +357,43 @@ func (t *timeline) matchNominal(expected time.Time) *workflowChain {
 }
 
 // classifyFirings diffs expected fire times against the timeline and populates the classification fields on r.
-// Classification at this stage is binary: "skip_overlap" when some chain was active at the expected fire moment,
-// "real_miss" otherwise. (Other buckets like inconclusive_schedule_changed and unsupported_policy are not assigned
-// here as they're populated later by postProcess based on DescribeSchedule output.)
-func classifyFirings(r *scheduleResult, expected []time.Time, tl *timeline) {
+// For "never-skip-by-design" overlap policies (ALLOW_ALL, CANCEL_OTHER, TERMINATE_OTHER), the skip_overlap heuristic
+// is bypassed because the policy never policy-skips a fire; any unmatched nominal time must be a true real_miss.
+// For all other policies (SKIP, BUFFER_ONE, BUFFER_ALL, UNSPECIFIED), the heuristic applies: skip_overlap when some
+// chain was active at the expected fire moment, real_miss otherwise.
+func classifyFirings(r *scheduleResult, expected []time.Time, tl *timeline, policies *schedulepb.SchedulePolicies) {
 	r.Categories = map[time.Time]string{}
 	r.Counts = map[string]int{}
 	r.Expected = len(expected)
 	r.Actual = len(tl.byWorkflowID)
 
+	neverSkips := neverSkipsByPolicy(policies)
 	for _, et := range expected {
 		if tl.matchNominal(et) != nil {
 			r.Matched++
 			continue
 		}
 		r.Missed = append(r.Missed, et)
-		if len(tl.activeAt(et)) > 0 {
+		if !neverSkips && len(tl.activeAt(et)) > 0 {
 			r.Categories[et] = categorySkipOverlap
 			r.Counts[categorySkipOverlap]++
 			continue
 		}
 		r.Categories[et] = categoryRealMiss
 		r.Counts[categoryRealMiss]++
+	}
+}
+
+// neverSkipsByPolicy reports whether the overlap policy always dispatches per nominal fire. For these policies,
+// any unmatched nominal is a real_miss.
+func neverSkipsByPolicy(policies *schedulepb.SchedulePolicies) bool {
+	switch policies.GetOverlapPolicy() {
+	case enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+		enumspb.SCHEDULE_OVERLAP_POLICY_CANCEL_OTHER,
+		enumspb.SCHEDULE_OVERLAP_POLICY_TERMINATE_OTHER:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -420,43 +411,28 @@ const retentionSafetyBuffer = 24 * time.Hour
 
 // scheduleLoader fetches schedule specs from the cluster.
 type scheduleLoader interface {
-	// ListSchedules pages through every schedule in the namespace and projects each ScheduleListEntry into a
-	// scheduleEntry (ID, spec, workflow type, jitter, paused). Paginated under the hood; one logical call may issue
-	// many RPCs.
+	// ListSchedules pages through every schedule in the namespace, calls DescribeSchedule per schedule, and projects
+	// the combined data into a scheduleEntry.
 	ListSchedules(ctx context.Context, namespace string) ([]scheduleEntry, error)
-	// LookupSchedule fetches a single schedule entry via DescribeSchedule
+	// LookupSchedule fetches a single schedule's full data via DescribeSchedule.
 	LookupSchedule(ctx context.Context, namespace, scheduleID string) (scheduleEntry, error)
-	// DescribeSchedule fetches a schedule's full metadata (create/update times, exhausted state, policies, catchup
-	// window) via a single DescribeSchedule RPC, projected into scheduleDescription.
-	DescribeSchedule(ctx context.Context, namespace, scheduleID string) (scheduleDescription, error)
 	// NamespaceRetention returns the workflow execution retention TTL for the namespace.
 	NamespaceRetention(ctx context.Context, namespace string) (time.Duration, error)
 }
 
-type scheduleDescription struct {
+// scheduleEntry carries everything the audit needs to classify a schedule
+type scheduleEntry struct {
+	ID           string
+	Spec         *schedulepb.ScheduleSpec
+	WorkflowType string
+	// Paused: skip analysis to avoid flagging never-fired runs as real_miss.
+	Paused     bool
+	Policies   *schedulepb.SchedulePolicies
 	CreateTime time.Time
 	UpdateTime time.Time
-	// Exhausted is true when the schedule has limited_actions enabled and remaining_actions == 0. It won't fire anymore
-	// even though its spec still evaluates to fire times.
-	Exhausted bool
-	// UnsupportedReason is non-empty when the schedule uses a policy our algorithm doesn't currently handle correctly.
-	// Multiple reasons are joined with ";". When set, real_miss entries are reclassified into the unsupported_policy
-	// bucket so operators can see which schedules need manual review.
-	UnsupportedReason string
-	// CatchupWindow is the schedule's configured catchup window. Recorded to troubleshoot dropped firings if the
-	// catchup window is shorter than the observed gap between the expected fire time and the actual workflow start time.
+	// Exhausted: limited_actions schedule with remaining_actions == 0; dropped at load time.
+	Exhausted     bool
 	CatchupWindow time.Duration
-}
-
-// scheduleEntry is a minimal projection of ScheduleListEntry - exactly what the audit needs.
-type scheduleEntry struct {
-	ID            string
-	Spec          *schedulepb.ScheduleSpec
-	WorkflowType  string
-	JitterSeconds int64
-	// Paused schedules never fire even though their spec evaluates to fire times. Analysis skips them entirely to avoid
-	// flagging expected-but-never-fired runs as real_miss.
-	Paused bool
 }
 
 // executionLoader fetches every scheduled workflow that was alive at some moment in [windowStart, queryEnd] -- where
@@ -467,8 +443,6 @@ type scheduleEntry struct {
 type executionLoader interface {
 	ListExecutions(ctx context.Context, namespace, scheduleIDFilter string, windowStart, queryEnd time.Time) (map[string][]timelineEntry, error)
 }
-
-// --- auditor ---
 
 // scheduleAuditor performs the audit for one namespace and time window.
 type scheduleAuditor struct {
@@ -492,15 +466,13 @@ const (
 	categoryRealMiss            = "real_miss"
 	categorySkipOverlap         = "skip_overlap"
 	categoryInconclusiveChanged = "inconclusive_schedule_changed"
-	categoryUnsupportedPolicy   = "unsupported_policy"
 )
 
 // scheduleResult is the per-schedule output for downstream writers.
 type scheduleResult struct {
-	Namespace     string
-	ScheduleID    string
-	WorkflowType  string
-	JitterSeconds int64
+	Namespace    string
+	ScheduleID   string
+	WorkflowType string
 
 	Expected   int
 	Actual     int
@@ -508,12 +480,8 @@ type scheduleResult struct {
 	Missed     []time.Time
 	Categories map[time.Time]string
 	Counts     map[string]int
-	// UnsupportedReason, when non-empty, names the policy/state config that caused this row's real_miss entries to be
-	// reclassified into the unsupported_policy bucket. Mirrored from scheduleDescription.
-	UnsupportedReason string
-	// CatchupWindowSeconds is the schedule's configured catchup window in seconds. Populated only when DescribeSchedule
-	// was called (i.e. real_miss > 0); zero/unset otherwise. Lets operators correlate a real_miss with a known scheduler
-	// outage duration: if catchup_window < outage gap, fires are dropped permanently.
+	// CatchupWindowSeconds is the schedule's configured catchup window in seconds. Lets operators correlate a
+	// real_miss with a known scheduler outage duration: if catchup_window < outage gap, fires are dropped permanently.
 	CatchupWindowSeconds int64
 }
 
@@ -542,11 +510,6 @@ func (a *scheduleAuditor) run(ctx context.Context) ([]scheduleResult, error) {
 	}
 
 	results, err := a.analyzeAll(scheds, executions)
-	if err != nil {
-		return nil, err
-	}
-
-	results, err = a.postProcess(ctx, scheds, executions, results)
 	if err != nil {
 		return nil, err
 	}
@@ -583,9 +546,15 @@ func (a *scheduleAuditor) checkRetention(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-// loadSchedules returns the schedules to analyze: either the single --schedule-id target (one DescribeSchedule RPC) or
-// every active schedule in the namespace (paginated ListSchedules). Paused schedules are dropped in both modes -- their
-// specs still produce expected fire times but nothing fires, which would otherwise show up as false-positive real_miss.
+// loadSchedules returns the schedules to analyze. Each entry carries everything needed for classification (Spec,
+// Policies, CreateTime, UpdateTime, Exhausted, CatchupWindow, etc.), fetched via DescribeSchedule per schedule
+// either as part of ListSchedules pagination or as a one-shot LookupSchedule when --schedule-id is set. Schedules
+// that cannot possibly produce a useful audit row are dropped here:
+//   - Paused: spec evaluates to fire times but the scheduler won't fire them.
+//   - Exhausted: limited_actions with remaining_actions == 0; same outcome as paused.
+//   - CreateTime >= WindowEnd: schedule didn't exist for any part of the audit window.
+//
+// Schedules deleted between list and describe (NotFound race) are also skipped inside the loader.
 func (a *scheduleAuditor) loadSchedules(ctx context.Context) ([]scheduleEntry, error) {
 	var scheds []scheduleEntry
 	if a.ScheduleID != "" {
@@ -607,9 +576,13 @@ func (a *scheduleAuditor) loadSchedules(ctx context.Context) ([]scheduleEntry, e
 
 	active := scheds[:0]
 	for _, s := range scheds {
-		if !s.Paused {
-			active = append(active, s)
+		if s.Paused || s.Exhausted {
+			continue
 		}
+		if !s.CreateTime.IsZero() && !s.CreateTime.Before(a.WindowEnd) {
+			continue
+		}
+		active = append(active, s)
 	}
 	return active, nil
 }
@@ -642,7 +615,7 @@ func (a *scheduleAuditor) analyzeAll(scheds []scheduleEntry, executions map[stri
 		sem <- struct{}{}
 		wg.Go(func() {
 			defer func() { <-sem }()
-			res, err := a.analyzeSchedule(s, entries, a.WindowStart)
+			res, err := a.analyzeSchedule(s, entries)
 			mu.Lock()
 			defer mu.Unlock()
 			if err != nil {
@@ -663,121 +636,19 @@ func (a *scheduleAuditor) analyzeAll(scheds []scheduleEntry, executions map[stri
 	return results, nil
 }
 
-// postProcess re-examines schedules flagged with real_miss > 0 by calling DescribeSchedule and applying the following
-// reclassification rules (checked in order; first match wins):
-//
-//   - NotFound (deleted between list and describe)  -> drop the row.
-//   - UpdateTime > windowStart (spec changed mid-window) -> reclassify real_miss to inconclusive_schedule_changed.
-//   - Exhausted (limited_actions, remaining_actions == 0) -> drop the row.
-//   - UnsupportedReason != "" -> reclassify real_miss to unsupported_policy and stamp the reason. These are
-//     corner-case policy/state configs the algorithm does not model correctly today, so we move the count out of
-//     the trusted real_miss bucket and surface the row for manual review. Reasons currently detected:
-//   - keep_original_workflow_id  -- defined in the API but not server-supported today (and not on the near-term roadmap).
-//   - overlap_buffer_all         -- fires can be queued for arbitrary durations, beyond our 24h query buffer.
-//   - overlap_allow_all          -- scheduler never skips on overlap, so skip_overlap labels may be wrong.
-//   - overlap_cancel_other       -- new fire cancels prior; chain lifecycle differs (likely works, unverified).
-//   - overlap_terminate_other    -- same as cancel_other; likely works, unverified.
-//   - CreateTime >= windowEnd -> drop the row. The schedule was created after the audit window ended, so it could
-//     not have fired during the window. The expected fires we computed are phantom -- the spec compiler is
-//     stateless and doesn't know when the schedule was created, so it generates fires the schedule never had a
-//     chance to run. Dropping the row removes the false-positive real_miss count entirely.
-//   - CreateTime > windowStart (created mid-window) -> re-analyze with expectedStart = CreateTime. The schedule
-//     existed for part of the window but not all of it. Fires before CreateTime are phantom (same reason as
-//     above) but fires at-or-after CreateTime are real. Re-running classifyFirings with the lower bound advanced
-//     to CreateTime drops the phantom expected fires while preserving any genuine misses that occurred after the
-//     schedule came online.
-//   - Otherwise: row stands as real_miss.
-//
-// Done sequentially to keep describe RPCs gentle on the frontend.
-func (a *scheduleAuditor) postProcess(ctx context.Context, scheds []scheduleEntry, executions map[string][]timelineEntry, results []scheduleResult) ([]scheduleResult, error) {
-	schedByID := make(map[string]scheduleEntry, len(scheds))
-	for _, s := range scheds {
-		schedByID[s.ID] = s
+// analyzeSchedule runs the audit for a single schedule against the pre-fetched timeline entries.
+func (a *scheduleAuditor) analyzeSchedule(s scheduleEntry, entries []timelineEntry) (*scheduleResult, error) {
+	// If the spec was modified after the audit window began, the current spec doesn't describe what was firing
+	// earlier in the window. Short-circuit: mark all fires as inconclusive_schedule_changed; don't attempt to match.
+	if !s.UpdateTime.IsZero() && s.UpdateTime.After(a.WindowStart) {
+		return a.inconclusiveResult(s)
 	}
-	revised := results[:0]
-	for _, r := range results {
-		if r.Counts[categoryRealMiss] == 0 {
-			revised = append(revised, r)
-			continue
-		}
-		newR, err := a.reclassifyOne(ctx, r, schedByID, executions)
-		if err != nil {
-			return nil, err
-		}
-		if newR != nil {
-			revised = append(revised, *newR)
-		}
+	// Truncate expectedStart to CreateTime when the schedule was created mid-window. Drops phantom expected fires
+	// from before the schedule existed.
+	expectedStart := a.WindowStart
+	if !s.CreateTime.IsZero() && s.CreateTime.After(expectedStart) {
+		expectedStart = s.CreateTime
 	}
-	return revised, nil
-}
-
-// reclassifyOne applies the post-process rules to a single result with real_miss > 0. Returns (nil, nil) when the row
-// should be dropped (NotFound race, exhausted, or created after windowEnd) and (newRow, nil) when it should be kept
-// (possibly reclassified or re-analyzed against a truncated window).
-func (a *scheduleAuditor) reclassifyOne(ctx context.Context, r scheduleResult, schedByID map[string]scheduleEntry, executions map[string][]timelineEntry) (*scheduleResult, error) {
-	desc, err := a.Schedules.DescribeSchedule(ctx, a.Namespace, r.ScheduleID)
-	if err != nil {
-		// Race: ListSchedules saw this schedule but it was deleted before our post-process call. Drop the row -- we
-		// can't classify real_miss for a schedule that no longer exists.
-		if status.Code(err) == codes.NotFound {
-			_, _ = fmt.Fprintf(a.Progress, "    %s: %s: deleted between list and describe, dropping row\n",
-				a.Namespace, r.ScheduleID)
-			return nil, nil
-		}
-		return nil, fmt.Errorf("describe %s: %w", r.ScheduleID, err)
-	}
-	// Record to help correlate real_miss, especially for short catch-ups
-	r.CatchupWindowSeconds = int64(desc.CatchupWindow.Seconds())
-
-	switch {
-	// Spec modified during window: current spec doesn't describe what was firing pre-modification.
-	case !desc.UpdateTime.IsZero() && desc.UpdateTime.After(a.WindowStart):
-		recategorize(&r, categoryRealMiss, categoryInconclusiveChanged)
-		return &r, nil
-	// Exhausted (limited_actions with remaining_actions==0): won't fire anymore even though spec still produces fire
-	// times. Drop.
-	case desc.Exhausted:
-		return nil, nil
-	// Unsupported policy/state: algorithm doesn't fully model these (keepOriginalWorkflowId, BUFFER_ALL, etc). Surface
-	// for manual review but don't claim the misses are real.
-	case desc.UnsupportedReason != "":
-		recategorize(&r, categoryRealMiss, categoryUnsupportedPolicy)
-		r.UnsupportedReason = desc.UnsupportedReason
-		return &r, nil
-	// Created after windowEnd: couldn't have fired during the window.
-	case !desc.CreateTime.IsZero() && !desc.CreateTime.Before(a.WindowEnd):
-		return nil, nil
-	// Created mid-window: re-analyze with truncated expected.
-	case !desc.CreateTime.IsZero() && desc.CreateTime.After(a.WindowStart):
-		return a.reanalyzeFromCreate(r, desc.CreateTime, schedByID, executions)
-	}
-	// Schedule unchanged and pre-existing: result stands.
-	return &r, nil
-}
-
-// reanalyzeFromCreate handles the "created mid-window" branch: re-runs the per-schedule analysis with expectedStart
-// advanced to the schedule's CreateTime, so phantom expected fires from before the schedule existed are dropped.
-func (a *scheduleAuditor) reanalyzeFromCreate(r scheduleResult, createTime time.Time, schedByID map[string]scheduleEntry, executions map[string][]timelineEntry) (*scheduleResult, error) {
-	s, ok := schedByID[r.ScheduleID]
-	if !ok {
-		return &r, nil
-	}
-	newR, err := a.analyzeSchedule(s, executions[r.ScheduleID], createTime)
-	if err != nil {
-		return nil, fmt.Errorf("re-analyze %s: %w", r.ScheduleID, err)
-	}
-	if newR == nil {
-		return nil, nil
-	}
-	newR.CatchupWindowSeconds = r.CatchupWindowSeconds
-	return newR, nil
-}
-
-// analyzeSchedule runs the audit for a single schedule entry against the pre-fetched timeline entries. expectedStart
-// bounds the lower edge of expected fires; pass a.WindowStart for the normal case, or a schedule's createTime (when
-// later than WindowStart) to suppress false-positive real_miss for schedules that didn't yet exist at the start of the
-// audit window.
-func (a *scheduleAuditor) analyzeSchedule(s scheduleEntry, entries []timelineEntry, expectedStart time.Time) (*scheduleResult, error) {
 	expected, err := expectedFireTimes(s.Spec, expectedStart, a.WindowEnd)
 	if err != nil {
 		return nil, fmt.Errorf("expected fires for %s: %w", s.ID, err)
@@ -790,29 +661,40 @@ func (a *scheduleAuditor) analyzeSchedule(s scheduleEntry, entries []timelineEnt
 		tl.addExecution(e)
 	}
 	r := &scheduleResult{
-		Namespace:     a.Namespace,
-		ScheduleID:    s.ID,
-		WorkflowType:  s.WorkflowType,
-		JitterSeconds: s.JitterSeconds,
+		Namespace:            a.Namespace,
+		ScheduleID:           s.ID,
+		WorkflowType:         s.WorkflowType,
+		CatchupWindowSeconds: int64(s.CatchupWindow.Seconds()),
 	}
-	classifyFirings(r, expected, tl)
+	classifyFirings(r, expected, tl, s.Policies)
 	return r, nil
 }
 
-// recategorize moves all entries currently classified as `from` into `to`, updating both the per-fire Categories map
-// and the aggregate Counts. Used by the post-process to reclassify real_miss entries when we can't trust the spec (e.g.
-// the schedule was modified during the audit window).
-func recategorize(r *scheduleResult, from, to string) {
-	if r.Counts[from] == 0 {
-		return
+// inconclusiveResult constructs a result for a schedule whose spec was modified mid-window. All expected fires are
+// labeled inconclusive_schedule_changed because the current spec can't be trusted to describe what was firing
+// earlier in the window.
+func (a *scheduleAuditor) inconclusiveResult(s scheduleEntry) (*scheduleResult, error) {
+	expected, err := expectedFireTimes(s.Spec, a.WindowStart, a.WindowEnd)
+	if err != nil {
+		return nil, fmt.Errorf("expected fires for %s: %w", s.ID, err)
 	}
-	for t, cat := range r.Categories {
-		if cat == from {
-			r.Categories[t] = to
-		}
+	if len(expected) == 0 {
+		return nil, nil
 	}
-	r.Counts[to] += r.Counts[from]
-	delete(r.Counts, from)
+	r := &scheduleResult{
+		Namespace:            a.Namespace,
+		ScheduleID:           s.ID,
+		WorkflowType:         s.WorkflowType,
+		CatchupWindowSeconds: int64(s.CatchupWindow.Seconds()),
+		Expected:             len(expected),
+		Missed:               append([]time.Time(nil), expected...),
+		Categories:           make(map[time.Time]string, len(expected)),
+		Counts:               map[string]int{categoryInconclusiveChanged: len(expected)},
+	}
+	for _, et := range expected {
+		r.Categories[et] = categoryInconclusiveChanged
+	}
+	return r, nil
 }
 
 // grpcRetrier wraps RPCs with retry-on-ResourceExhausted
@@ -871,8 +753,10 @@ type grpcScheduleLoader struct {
 	retrier *grpcRetrier
 }
 
+// ListSchedules pages through ListSchedules, then calls DescribeSchedule sequentially per schedule to populate the
+// full scheduleEntry (Policies, CreateTime, UpdateTime, Exhausted, CatchupWindow).
 func (l *grpcScheduleLoader) ListSchedules(ctx context.Context, namespace string) ([]scheduleEntry, error) {
-	var out []scheduleEntry
+	var ids []string
 	var pageToken []byte
 	for {
 		var resp *workflowservice.ListSchedulesResponse
@@ -880,7 +764,7 @@ func (l *grpcScheduleLoader) ListSchedules(ctx context.Context, namespace string
 			var rpcErr error
 			resp, rpcErr = l.client.ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
 				Namespace:       namespace,
-				MaximumPageSize: 1000,
+				MaximumPageSize: visibilityPageSize,
 				NextPageToken:   pageToken,
 			})
 			return rpcErr
@@ -889,31 +773,34 @@ func (l *grpcScheduleLoader) ListSchedules(ctx context.Context, namespace string
 			return nil, err
 		}
 		for _, s := range resp.GetSchedules() {
-			info := s.GetInfo()
-			if info == nil {
+			if s.GetInfo() == nil {
 				continue
 			}
-			var jitterSecs int64
-			if j := info.GetSpec().GetJitter(); j != nil {
-				jitterSecs = int64(j.AsDuration().Seconds())
-			}
-			out = append(out, scheduleEntry{
-				ID:            s.GetScheduleId(),
-				Spec:          info.GetSpec(),
-				WorkflowType:  info.GetWorkflowType().GetName(),
-				JitterSeconds: jitterSecs,
-				Paused:        info.GetPaused(),
-			})
+			ids = append(ids, s.GetScheduleId())
 		}
 		if len(resp.GetNextPageToken()) == 0 {
 			break
 		}
 		pageToken = resp.GetNextPageToken()
 	}
+
+	out := make([]scheduleEntry, 0, len(ids))
+	for _, id := range ids {
+		entry, err := l.LookupSchedule(ctx, namespace, id)
+		if err != nil {
+			if status.Code(err) == codes.NotFound {
+				// Deleted between list and describe, so skip.
+				continue
+			}
+			return nil, fmt.Errorf("describe %s/%s: %w", namespace, id, err)
+		}
+		out = append(out, entry)
+	}
 	return out, nil
 }
 
-// LookupSchedule fetches a single schedule via DescribeSchedule and projects the response into a scheduleEntry
+// LookupSchedule fetches a single schedule via DescribeSchedule and projects the response into a scheduleEntry,
+// including the policies, create/update times, exhausted/paused state, and catchup window needed for classification.
 func (l *grpcScheduleLoader) LookupSchedule(ctx context.Context, namespace, scheduleID string) (scheduleEntry, error) {
 	var resp *workflowservice.DescribeScheduleResponse
 	err := l.retrier.do(ctx, fmt.Sprintf("DescribeSchedule(%s/%s)", namespace, scheduleID), func() error {
@@ -927,19 +814,29 @@ func (l *grpcScheduleLoader) LookupSchedule(ctx context.Context, namespace, sche
 	if err != nil {
 		return scheduleEntry{}, err
 	}
+	info := resp.GetInfo()
 	sched := resp.GetSchedule()
 	spec := sched.GetSpec()
-	var jitterSecs int64
-	if j := spec.GetJitter(); j != nil {
-		jitterSecs = int64(j.AsDuration().Seconds())
+	state := sched.GetState()
+	policies := sched.GetPolicies()
+	entry := scheduleEntry{
+		ID:           scheduleID,
+		Spec:         spec,
+		WorkflowType: sched.GetAction().GetStartWorkflow().GetWorkflowType().GetName(),
+		Paused:       state.GetPaused(),
+		Policies:     policies,
+		Exhausted:    state.GetLimitedActions() && state.GetRemainingActions() == 0,
 	}
-	return scheduleEntry{
-		ID:            scheduleID,
-		Spec:          spec,
-		WorkflowType:  sched.GetAction().GetStartWorkflow().GetWorkflowType().GetName(),
-		JitterSeconds: jitterSecs,
-		Paused:        sched.GetState().GetPaused(),
-	}, nil
+	if ct := info.GetCreateTime(); ct != nil {
+		entry.CreateTime = ct.AsTime()
+	}
+	if ut := info.GetUpdateTime(); ut != nil {
+		entry.UpdateTime = ut.AsTime()
+	}
+	if cw := policies.GetCatchupWindow(); cw != nil {
+		entry.CatchupWindow = cw.AsDuration()
+	}
+	return entry, nil
 }
 
 // NamespaceRetention returns the workflow execution retention TTL via DescribeNamespace. One RPC per namespace.
@@ -961,75 +858,6 @@ func (l *grpcScheduleLoader) NamespaceRetention(ctx context.Context, namespace s
 	return 0, nil
 }
 
-// DescribeSchedule fetches a schedule's metadata via one DescribeSchedule RPC, projected into scheduleDescription
-func (l *grpcScheduleLoader) DescribeSchedule(ctx context.Context, namespace, scheduleID string) (scheduleDescription, error) {
-	var resp *workflowservice.DescribeScheduleResponse
-	err := l.retrier.do(ctx, fmt.Sprintf("DescribeSchedule(%s/%s)", namespace, scheduleID), func() error {
-		var rpcErr error
-		resp, rpcErr = l.client.DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  namespace,
-			ScheduleId: scheduleID,
-		})
-		return rpcErr
-	})
-	if err != nil {
-		return scheduleDescription{}, err
-	}
-	info := resp.GetInfo()
-	sched := resp.GetSchedule()
-	state := sched.GetState()
-	policies := sched.GetPolicies()
-	var desc scheduleDescription
-	if ct := info.GetCreateTime(); ct != nil {
-		desc.CreateTime = ct.AsTime()
-	}
-	if ut := info.GetUpdateTime(); ut != nil {
-		desc.UpdateTime = ut.AsTime()
-	}
-	desc.Exhausted = state.GetLimitedActions() && state.GetRemainingActions() == 0
-	desc.UnsupportedReason = unsupportedPolicyReason(policies)
-	if cw := policies.GetCatchupWindow(); cw != nil {
-		desc.CatchupWindow = cw.AsDuration()
-	}
-	return desc, nil
-}
-
-// unsupportedPolicyReason returns a non-empty string when a schedule's policies/state use a configuration our audit
-// doesn't fully handle. Multiple reasons are joined with ";". Operators see this in the report and know those rows need
-// manual review rather than being trusted as real_miss.
-func unsupportedPolicyReason(policies *schedulepb.SchedulePolicies) string {
-	if policies == nil {
-		return ""
-	}
-	var reasons []string
-	if policies.GetKeepOriginalWorkflowId() {
-		// All fires share one WorkflowID, breaking our chain-by-WorkflowID model.
-		reasons = append(reasons, "keep_original_workflow_id")
-	}
-	switch policies.GetOverlapPolicy() {
-	case enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL:
-		// Fires can be buffered for arbitrary durations; our delayedFireBuffer of 24h may miss the workflow.
-		reasons = append(reasons, "overlap_buffer_all")
-	case enumspb.SCHEDULE_OVERLAP_POLICY_CANCEL_OTHER:
-		// Each new fire cancels the running one; chain lifecycle differs from the standard model. Likely works but
-		// unverified.
-		reasons = append(reasons, "overlap_cancel_other")
-	case enumspb.SCHEDULE_OVERLAP_POLICY_TERMINATE_OTHER:
-		// Similar to CANCEL_OTHER. Likely works but unverified.
-		reasons = append(reasons, "overlap_terminate_other")
-	case enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL:
-		// ALLOW_ALL never skips on overlap, so classifyFirings can mis-label
-		// real_miss as skip_overlap when a long-running prior fire is active
-		// at the expected time. Surface for inspection; we don't reclassify
-		// here because the skip_overlap labels were already computed before
-		// post-process and DescribeSchedule isn't called for skip-only rows.
-		reasons = append(reasons, "overlap_allow_all")
-	default:
-		// SKIP, BUFFER_ONE, and UNSPECIFIED are fully modeled; nothing to flag.
-	}
-	return strings.Join(reasons, ";")
-}
-
 // grpcExecutionLoader pages through ListWorkflowExecutions for an entire namespace in a single visibility query,
 // returning entries grouped by schedule ID. The query uses `TemporalScheduledById IS NOT NULL` so the server can
 // satisfy it with an index scan, and pagination is shared across all schedules.
@@ -1039,11 +867,10 @@ type grpcExecutionLoader struct {
 	log     io.Writer
 }
 
-// visibilityPageSize is the per-call ListWorkflowExecutions page size. 1000 is a safe default; the server may
-// silently clamp to a lower max. Larger values reduce RPC count but each call returns more bytes (4MB gRPC limit
-// caps practical sizes around ~5000).
+// visibilityPageSize is the per-call page size for visibility queries (ListWorkflowExecutions, ListSchedules).
+// 1000 is a safe default; the server may silently clamp to a lower max. Larger values reduce RPC count but each
+// call returns more bytes (4MB gRPC limit caps practical sizes around ~5000).
 const visibilityPageSize = 1000
-
 const pageProgressEvery = 5
 
 // ListExecutions issues one paginated visibility query that returns every scheduled workflow alive at some moment in
@@ -1205,7 +1032,6 @@ var flatCSVBaseHeader = []string{
 	"namespace",
 	"schedule_id",
 	"workflow_type",
-	"jitter_s",
 	"expected",
 	"actual",
 	"matched",
@@ -1213,8 +1039,6 @@ var flatCSVBaseHeader = []string{
 	categoryRealMiss,
 	categorySkipOverlap,
 	categoryInconclusiveChanged,
-	categoryUnsupportedPolicy,
-	"unsupported_reason",
 	"catchup_window_s",
 	"real_miss_times",
 }
@@ -1237,9 +1061,8 @@ func writeFlatCSV(w io.Writer, results []scheduleResult) error {
 }
 
 func flatRow(r scheduleResult) []string {
-	// Only emit the real_miss times -- the other buckets (skip_overlap, inconclusive_schedule_changed, unsupported_policy)
-	// all have valid reasons, so their timestamps add noise to the output column. Categories may have been mutated by
-	// recategorize during post-process, so filter on the final classification.
+	// Only emit the real_miss times -- the other buckets (skip_overlap, inconclusive_schedule_changed) all have
+	// valid reasons, so their timestamps add noise to the output column.
 	var realMissTimes []time.Time
 	for _, t := range r.Missed {
 		if r.Categories[t] == categoryRealMiss {
@@ -1250,7 +1073,6 @@ func flatRow(r scheduleResult) []string {
 		r.Namespace,
 		r.ScheduleID,
 		strings.ReplaceAll(r.WorkflowType, ",", ";"),
-		fmt.Sprintf("%d", r.JitterSeconds),
 		fmt.Sprintf("%d", r.Expected),
 		fmt.Sprintf("%d", r.Actual),
 		fmt.Sprintf("%d", r.Matched),
@@ -1258,8 +1080,6 @@ func flatRow(r scheduleResult) []string {
 		fmt.Sprintf("%d", r.Counts[categoryRealMiss]),
 		fmt.Sprintf("%d", r.Counts[categorySkipOverlap]),
 		fmt.Sprintf("%d", r.Counts[categoryInconclusiveChanged]),
-		fmt.Sprintf("%d", r.Counts[categoryUnsupportedPolicy]),
-		strings.ReplaceAll(r.UnsupportedReason, ",", ";"),
 		fmt.Sprintf("%d", r.CatchupWindowSeconds),
 		joinTimes(realMissTimes, 20),
 	}
@@ -1303,8 +1123,9 @@ func writeOutput(dir string, results []scheduleResult) error {
 	}
 
 	for ns, rs := range byNS {
-		// Sanitize "/" -> "_"
-		safeName := strings.NewReplacer("/", "_", string(filepath.Separator), "_").Replace(ns)
+		// Sanitize path separators and dots so namespaces with literal dots (e.g. "foo.bar") or pathological values
+		// like ".." cannot escape perNSDir or produce hidden files.
+		safeName := strings.NewReplacer("/", "_", string(filepath.Separator), "_", ".", "_").Replace(ns)
 		path := filepath.Join(perNSDir, safeName+".csv")
 		f, err := os.Create(path)
 		if err != nil {
@@ -1338,7 +1159,6 @@ func writeSummaryCSV(path string, byNS map[string][]scheduleResult) (retErr erro
 	if err := cw.Write([]string{
 		"namespace", "schedules_flagged",
 		categoryRealMiss, categorySkipOverlap, categoryInconclusiveChanged,
-		categoryUnsupportedPolicy,
 	}); err != nil {
 		return err
 	}
@@ -1349,12 +1169,11 @@ func writeSummaryCSV(path string, byNS map[string][]scheduleResult) (retErr erro
 	sort.Strings(nss)
 	for _, ns := range nss {
 		rs := byNS[ns]
-		var realMisses, skips, specChanged, unsupported int
+		var realMisses, skips, specChanged int
 		for _, r := range rs {
 			realMisses += r.Counts[categoryRealMiss]
 			skips += r.Counts[categorySkipOverlap]
 			specChanged += r.Counts[categoryInconclusiveChanged]
-			unsupported += r.Counts[categoryUnsupportedPolicy]
 		}
 		if err := cw.Write([]string{
 			ns,
@@ -1362,7 +1181,6 @@ func writeSummaryCSV(path string, byNS map[string][]scheduleResult) (retErr erro
 			fmt.Sprintf("%d", realMisses),
 			fmt.Sprintf("%d", skips),
 			fmt.Sprintf("%d", specChanged),
-			fmt.Sprintf("%d", unsupported),
 		}); err != nil {
 			return err
 		}

--- a/tools/tdbg/schedule_audit.go
+++ b/tools/tdbg/schedule_audit.go
@@ -1,0 +1,1272 @@
+package tdbg
+
+import (
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/urfave/cli/v2"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	schedulepb "go.temporal.io/api/schedule/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/service/worker/scheduler"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// AdminAuditSchedules is the entry point for `tdbg schedule audit`. It parses CLI inputs once, then runs the audit per
+// namespace and writes the combined output bundle.
+func AdminAuditSchedules(c *cli.Context, factory ClientFactory) error {
+	in, err := parseAuditInputs(c)
+	if err != nil {
+		return err
+	}
+
+	wfClient := factory.WorkflowClient(c)
+	retrier := &grpcRetrier{log: os.Stderr}
+
+	// Cross-namespace parallelism is bounded by --namespace-concurrency (default 8); RPCs within a single namespace are
+	// sequential to keep concurrent frontend pressure low. Per-schedule CPU work (classification) fans out to NumCPU
+	// goroutines within a namespace. If any namespace fails, queued (not-yet-started) namespaces bail; in-flight
+	// namespaces continue until finish.
+	auditStart := time.Now()
+	total := len(in.Namespaces)
+	sem := make(chan struct{}, in.NamespaceConcurrency)
+	var (
+		mu         sync.Mutex
+		allResults []scheduleResult
+		firstErr   error
+		done       int
+	)
+	var wg sync.WaitGroup
+	for _, ns := range in.Namespaces {
+		ns := ns
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			// Bail early if a sibling already failed.
+			mu.Lock()
+			if firstErr != nil {
+				mu.Unlock()
+				return
+			}
+			mu.Unlock()
+
+			nsStart := time.Now()
+			fmt.Fprintf(os.Stderr, "auditing %s...\n", ns)
+			auditor := &scheduleAuditor{
+				Namespace:   ns,
+				ScheduleID:  in.ScheduleID,
+				WindowStart: in.WindowStart,
+				WindowEnd:   in.WindowEnd,
+				Schedules:   &grpcScheduleLoader{client: wfClient, retrier: retrier},
+				Executions:  &grpcExecutionLoader{client: wfClient, retrier: retrier, log: os.Stderr},
+				Progress:    os.Stderr,
+			}
+			results, err := auditor.run(c.Context)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				if firstErr == nil {
+					firstErr = fmt.Errorf("audit %s: %w", ns, err)
+				}
+				return
+			}
+			done++
+			fmt.Fprintf(os.Stderr, "[%d/%d] %s: %d schedule(s) flagged in %s\n",
+				done, total, ns, len(results), time.Since(nsStart).Round(time.Second))
+			allResults = append(allResults, results...)
+		}()
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return firstErr
+	}
+	fmt.Fprintf(os.Stderr, "audit complete: %d total flagged across %d namespaces in %s\n",
+		len(allResults), total, time.Since(auditStart).Round(time.Second))
+	if in.OutputDir == "" {
+		// Stdout mode: one CSV stream, all rows, single header, no summary file.
+		// Sort across namespaces (per-namespace.run() only sorts within its own batch).
+		sort.Slice(allResults, func(i, j int) bool {
+			if allResults[i].Namespace != allResults[j].Namespace {
+				return allResults[i].Namespace < allResults[j].Namespace
+			}
+			return allResults[i].ScheduleID < allResults[j].ScheduleID
+		})
+		return writeFlatCSV(os.Stdout, allResults)
+	}
+	return writeOutput(in.OutputDir, allResults)
+}
+
+type auditInputs struct {
+	Namespaces           []string
+	ScheduleID           string // optional; if set, len(Namespaces) == 1
+	WindowStart          time.Time
+	WindowEnd            time.Time
+	OutputDir            string
+	NamespaceConcurrency int
+}
+
+func parseAuditInputs(c *cli.Context) (*auditInputs, error) {
+	in := &auditInputs{
+		ScheduleID:           c.String(FlagScheduleID),
+		OutputDir:            c.String(FlagOutputDir),
+		NamespaceConcurrency: c.Int(FlagNamespaceConcurrency),
+	}
+	if in.NamespaceConcurrency <= 0 {
+		in.NamespaceConcurrency = 1
+	}
+
+	ns, err := resolveNamespaces(c)
+	if err != nil {
+		return nil, err
+	}
+	in.Namespaces = ns
+
+	if in.WindowStart, err = time.Parse(time.RFC3339, c.String(FlagAuditStart)); err != nil {
+		return nil, fmt.Errorf("--start: %w", err)
+	}
+	if in.WindowEnd, err = time.Parse(time.RFC3339, c.String(FlagAuditEnd)); err != nil {
+		return nil, fmt.Errorf("--end: %w", err)
+	}
+
+	if err := in.validate(); err != nil {
+		return nil, err
+	}
+	return in, nil
+}
+
+// maxAuditWindow caps how wide a single audit window can be. Catches typos (e.g. wrong month in --end) and discourages
+// expensive multi-day runs that should be chunked into separate invocations.
+const maxAuditWindow = 7 * 24 * time.Hour
+
+func (in *auditInputs) validate() error {
+	if in.ScheduleID != "" && len(in.Namespaces) != 1 {
+		return errors.New("--schedule-id requires exactly one namespace (use --namespace, not --namespace-file)")
+	}
+	if !in.WindowEnd.After(in.WindowStart) {
+		return fmt.Errorf("--end (%s) must be after --start (%s)",
+			in.WindowEnd.UTC().Format(time.RFC3339),
+			in.WindowStart.UTC().Format(time.RFC3339))
+	}
+	if d := in.WindowEnd.Sub(in.WindowStart); d > maxAuditWindow {
+		return fmt.Errorf("window is %s (--start %s to --end %s); max is %s -- run multiple shorter audits for longer spans",
+			d.Round(time.Hour),
+			in.WindowStart.UTC().Format(time.RFC3339),
+			in.WindowEnd.UTC().Format(time.RFC3339),
+			maxAuditWindow)
+	}
+	return nil
+}
+
+func resolveNamespaces(c *cli.Context) ([]string, error) {
+	ns := c.String(FlagNamespace)
+	file := c.String(FlagNamespaceFile)
+	switch {
+	case ns != "" && file != "":
+		return nil, errors.New("--namespace and --namespace-file are mutually exclusive")
+	case ns != "":
+		return []string{ns}, nil
+	case file != "":
+		data, err := os.ReadFile(file)
+		if err != nil {
+			return nil, fmt.Errorf("--namespace-file: %w", err)
+		}
+		var out []string
+		for _, line := range strings.Split(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			out = append(out, line)
+		}
+		if len(out) == 0 {
+			return nil, fmt.Errorf("--namespace-file %q has no namespace entries", file)
+		}
+		return out, nil
+	default:
+		return nil, errors.New("one of --namespace or --namespace-file is required")
+	}
+}
+
+// expectedFireTimes returns the nominal (pre-jitter) fire times the spec would produce in (start, end]. Uses the
+// server's own spec compiler so the semantics exactly match the live scheduler.
+//
+// jitterSeed is required by the underlying compiler but does not affect the returned nominal times. Pass the schedule
+// ID so the seed is stable per schedule.
+func expectedFireTimes(spec *schedulepb.ScheduleSpec, jitterSeed string, start, end time.Time) ([]time.Time, error) {
+	if spec == nil {
+		return nil, nil
+	}
+	builder := scheduler.NewSpecBuilder()
+	compiled, err := builder.NewCompiledSpec(spec)
+	if err != nil {
+		return nil, fmt.Errorf("compile spec: %w", err)
+	}
+	var out []time.Time
+	cursor := start
+	for {
+		res := compiled.GetNextTime(jitterSeed, cursor)
+		if res.Nominal.IsZero() || res.Nominal.After(end) {
+			return out, nil
+		}
+		out = append(out, res.Nominal)
+		cursor = res.Nominal
+		if len(out) > 100_000 {
+			// Defensive cap -- sub-minute schedules over very large windows could otherwise OOM. Caller should chunk windows.
+			return nil, fmt.Errorf("expected fire times exceeded cap (100k)")
+		}
+	}
+}
+
+// timelineEntry is a single workflow execution row observed in visibility.
+type timelineEntry struct {
+	WorkflowID  string
+	RunID       string
+	StartTime   time.Time
+	CloseTime   *time.Time // nil if still running
+	Status      enumspb.WorkflowExecutionStatus
+	NominalTime time.Time // from TemporalScheduledStartTime search attribute
+}
+
+// workflowChain is one logical scheduled fire, possibly spanning many ContinueAsNew links that share the same
+// WorkflowID. The chain's lifetime is the union of its links' lifetimes, used to answer "was this fire still active at
+// time T?".
+type workflowChain struct {
+	WorkflowID  string
+	NominalTime time.Time
+	// Earliest start across the chain.
+	ChainStart time.Time
+	// Latest close across the chain. Only meaningful when StillRunning is false; activeAt ignores this field when any
+	// link is RUNNING.
+	ChainEnd time.Time
+	// StillRunning is true if any link in the chain is currently running.
+	StillRunning bool
+}
+
+func (c *workflowChain) activeAt(at time.Time) bool {
+	if c.StillRunning {
+		return !at.Before(c.ChainStart)
+	}
+	// Fully closed: active in [ChainStart, ChainEnd).
+	return !at.Before(c.ChainStart) && at.Before(c.ChainEnd)
+}
+
+// timeline holds all observed executions for a single schedule, grouped into ContinueAsNew chains keyed by WorkflowID.
+type timeline struct {
+	byWorkflowID map[string]*workflowChain
+}
+
+// addExecution incorporates one visibility row into the timeline, building or updating the chain for its WorkflowID.
+func (t *timeline) addExecution(e timelineEntry) {
+	chain, ok := t.byWorkflowID[e.WorkflowID]
+	if !ok {
+		chain = &workflowChain{
+			WorkflowID:  e.WorkflowID,
+			NominalTime: e.NominalTime,
+			ChainStart:  e.StartTime,
+		}
+		t.byWorkflowID[e.WorkflowID] = chain
+	}
+	if e.StartTime.Before(chain.ChainStart) {
+		chain.ChainStart = e.StartTime
+	}
+	if e.Status == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING {
+		chain.StillRunning = true
+	}
+	if e.CloseTime != nil && !chain.StillRunning {
+		if chain.ChainEnd.Before(*e.CloseTime) {
+			chain.ChainEnd = *e.CloseTime
+		}
+	}
+}
+
+func (t *timeline) activeAt(at time.Time) []*workflowChain {
+	var out []*workflowChain
+	for _, c := range t.byWorkflowID {
+		if c.activeAt(at) {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// matchNominal finds a chain whose NominalTime equals the given expected time, or nil if none match. Match is strict
+// equality because the server's spec compiler produces whole-second UTC nominal times and our local expectedFireTimes
+// uses the same compiler; both sides are byte-identical when the spec hasn't changed.
+func (t *timeline) matchNominal(expected time.Time) *workflowChain {
+	for _, c := range t.byWorkflowID {
+		if c.NominalTime.Equal(expected) {
+			return c
+		}
+	}
+	return nil
+}
+
+// classifyFirings diffs expected fire times against the timeline and populates the classification fields on r.
+// Classification at this stage is binary: "skip_overlap" when some chain was active at the expected fire moment,
+// "real_miss" otherwise. (Other buckets like inconclusive_schedule_changed and unsupported_policy are not assigned
+// here as they're populated later by postProcess based on DescribeSchedule output.)
+func classifyFirings(r *scheduleResult, expected []time.Time, tl *timeline) {
+	r.Categories = map[time.Time]string{}
+	r.Counts = map[string]int{}
+	r.Expected = len(expected)
+	r.Actual = len(tl.byWorkflowID)
+
+	for _, et := range expected {
+		if tl.matchNominal(et) != nil {
+			r.Matched++
+			continue
+		}
+		r.Missed = append(r.Missed, et)
+		if len(tl.activeAt(et)) > 0 {
+			r.Categories[et] = categorySkipOverlap
+			r.Counts[categorySkipOverlap]++
+			continue
+		}
+		r.Categories[et] = categoryRealMiss
+		r.Counts[categoryRealMiss]++
+	}
+}
+
+// delayedFireBuffer is how far past the audit's windowEnd the visibility query keeps looking for workflows. A
+// BUFFER-policy schedule whose nominal fire time falls inside the audit window can have its workflow start much
+// later than windowEnd (because the scheduler queued it behind a still-running prior fire). Without this buffer,
+// we'd miss those workflows and falsely flag them as real_miss. 24h is generous for the patterns we've observed
+// in practice; may need to raise if we encounter BUFFER chains that routinely run longer than a day.
+const delayedFireBuffer = 24 * time.Hour
+
+// retentionSafetyBuffer is how far inside the retention boundary windowStart must sit to be considered "safe to audit".
+// Visibility purges workflows retention-from-CloseTime ago, so a windowStart that's exactly at the boundary risks
+// missing workflows that closed near windowStart. One day of slack absorbs clock skew and retention-job lag.
+const retentionSafetyBuffer = 24 * time.Hour
+
+// scheduleLoader fetches schedule specs from the cluster.
+type scheduleLoader interface {
+	// ListSchedules pages through every schedule in the namespace and projects each ScheduleListEntry into a
+	// scheduleEntry (ID, spec, workflow type, jitter, paused). Paginated under the hood; one logical call may issue
+	// many RPCs.
+	ListSchedules(ctx context.Context, namespace string) ([]scheduleEntry, error)
+	// LookupSchedule fetches a single schedule entry via DescribeSchedule
+	LookupSchedule(ctx context.Context, namespace, scheduleID string) (scheduleEntry, error)
+	// DescribeSchedule fetches a schedule's full metadata (create/update times, exhausted state, policies, catchup
+	// window) via a single DescribeSchedule RPC, projected into scheduleDescription.
+	DescribeSchedule(ctx context.Context, namespace, scheduleID string) (scheduleDescription, error)
+	// NamespaceRetention returns the workflow execution retention TTL for the namespace.
+	NamespaceRetention(ctx context.Context, namespace string) (time.Duration, error)
+}
+
+type scheduleDescription struct {
+	CreateTime time.Time
+	UpdateTime time.Time
+	// Exhausted is true when the schedule has limited_actions enabled and remaining_actions == 0. It won't fire anymore
+	// even though its spec still evaluates to fire times.
+	Exhausted bool
+	// UnsupportedReason is non-empty when the schedule uses a policy our algorithm doesn't currently handle correctly.
+	// Multiple reasons are joined with ";". When set, real_miss entries are reclassified into the unsupported_policy
+	// bucket so operators can see which schedules need manual review.
+	UnsupportedReason string
+	// CatchupWindow is the schedule's configured catchup window. Recorded to troubleshoot dropped firings if the
+	// catchup window is shorter than the observed gap between the expected fire time and the actual workflow start time.
+	CatchupWindow time.Duration
+}
+
+// scheduleEntry is a minimal projection of ScheduleListEntry - exactly what the audit needs.
+type scheduleEntry struct {
+	ID            string
+	Spec          *schedulepb.ScheduleSpec
+	WorkflowType  string
+	JitterSeconds int64
+	// Paused schedules never fire even though their spec evaluates to fire times. Analysis skips them entirely to avoid
+	// flagging expected-but-never-fired runs as real_miss.
+	Paused bool
+}
+
+// executionLoader fetches every scheduled workflow that was alive at some moment in [windowStart, queryEnd] -- where
+// "alive" is the natural interval predicate StartTime <= queryEnd AND (CloseTime >= windowStart OR CloseTime IS NULL).
+// One paginated query covers everything our analysis needs: in-window starts, still-running long-runners, closed
+// long-runners, and heavily-delayed BUFFER fires. When scheduleIDFilter is set, the query restricts to that one
+// schedule.
+type executionLoader interface {
+	ListExecutions(ctx context.Context, namespace, scheduleIDFilter string, windowStart, queryEnd time.Time) (map[string][]timelineEntry, error)
+}
+
+// --- auditor ---
+
+// scheduleAuditor performs the audit for one namespace and time window.
+type scheduleAuditor struct {
+	Namespace string
+	// ScheduleID is optional; if non-empty, only this schedule is audited.
+	ScheduleID  string
+	WindowStart time.Time
+	WindowEnd   time.Time
+
+	// Progress receives one-line progress updates (start/end of the namespace, rare events like retention skip or
+	// list/describe race). Required -- callers that don't want logs should pass io.Discard.
+	Progress io.Writer
+
+	Schedules  scheduleLoader
+	Executions executionLoader
+}
+
+// Classification bucket names. Used both as keys in scheduleResult.Categories/Counts and as CSV column headers.
+// The duplication is intentional -- one source of truth keeps map keys and column names in lockstep.
+const (
+	categoryRealMiss            = "real_miss"
+	categorySkipOverlap         = "skip_overlap"
+	categoryInconclusiveChanged = "inconclusive_schedule_changed"
+	categoryUnsupportedPolicy   = "unsupported_policy"
+)
+
+// scheduleResult is the per-schedule output for downstream writers.
+type scheduleResult struct {
+	Namespace     string
+	ScheduleID    string
+	WorkflowType  string
+	JitterSeconds int64
+
+	Expected   int
+	Actual     int
+	Matched    int
+	Missed     []time.Time
+	Categories map[time.Time]string
+	Counts     map[string]int
+	// UnsupportedReason, when non-empty, names the policy/state config that caused this row's real_miss entries to be
+	// reclassified into the unsupported_policy bucket. Mirrored from scheduleDescription.
+	UnsupportedReason string
+	// CatchupWindowSeconds is the schedule's configured catchup window in seconds. Populated only when DescribeSchedule
+	// was called (i.e. real_miss > 0); zero/unset otherwise. Lets operators correlate a real_miss with a known scheduler
+	// outage duration: if catchup_window < outage gap, fires are dropped permanently.
+	CatchupWindowSeconds int64
+}
+
+// run executes the audit and returns one result per analyzed schedule. Schedules with no expected fire times in the
+// window are omitted.
+//
+// One visibility query per namespace (not per schedule) keeps the RPC count down to O(namespaces) instead of
+// O(schedules); critical for namespaces with thousands of schedules and a per-namespace visibility rate limit.
+func (a *scheduleAuditor) run(ctx context.Context) ([]scheduleResult, error) {
+	skip, err := a.checkRetention(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if skip {
+		return nil, nil
+	}
+
+	scheds, err := a.loadSchedules(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	executions, err := a.fetchExecutions(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	results, err := a.analyzeAll(scheds, executions)
+	if err != nil {
+		return nil, err
+	}
+
+	results, err = a.postProcess(ctx, scheds, executions, results)
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].Namespace != results[j].Namespace {
+			return results[i].Namespace < results[j].Namespace
+		}
+		return results[i].ScheduleID < results[j].ScheduleID
+	})
+	return results, nil
+}
+
+// checkRetention refuses to audit a window that crosses the retention boundary -- purged workflows would silently turn
+// into false-positive real_miss. Returns (skip=true, nil) when the caller should treat the namespace as a no-op.
+func (a *scheduleAuditor) checkRetention(ctx context.Context) (bool, error) {
+	retention, err := a.Schedules.NamespaceRetention(ctx, a.Namespace)
+	if err != nil {
+		return false, fmt.Errorf("namespace retention %s: %w", a.Namespace, err)
+	}
+	if retention == 0 {
+		return false, nil
+	}
+	safeStart := time.Now().Add(-retention + retentionSafetyBuffer)
+	if !a.WindowStart.Before(safeStart) {
+		return false, nil
+	}
+	fmt.Fprintf(a.Progress,
+		"    %s: SKIPPING - windowStart %s is past retention boundary (retention=%s, safe-start=%s)\n",
+		a.Namespace,
+		a.WindowStart.UTC().Format(time.RFC3339),
+		retention,
+		safeStart.UTC().Format(time.RFC3339))
+	return true, nil
+}
+
+// loadSchedules returns the schedules to analyze: either the single --schedule-id target (one DescribeSchedule RPC) or
+// every active schedule in the namespace (paginated ListSchedules). Paused schedules are dropped in both modes -- their
+// specs still produce expected fire times but nothing fires, which would otherwise show up as false-positive real_miss.
+func (a *scheduleAuditor) loadSchedules(ctx context.Context) ([]scheduleEntry, error) {
+	var scheds []scheduleEntry
+	if a.ScheduleID != "" {
+		entry, err := a.Schedules.LookupSchedule(ctx, a.Namespace, a.ScheduleID)
+		if err != nil {
+			if status.Code(err) == codes.NotFound {
+				return nil, fmt.Errorf("schedule %q not found in namespace %q", a.ScheduleID, a.Namespace)
+			}
+			return nil, fmt.Errorf("lookup schedule %s: %w", a.ScheduleID, err)
+		}
+		scheds = []scheduleEntry{entry}
+	} else {
+		var err error
+		scheds, err = a.Schedules.ListSchedules(ctx, a.Namespace)
+		if err != nil {
+			return nil, fmt.Errorf("list schedules: %w", err)
+		}
+	}
+
+	active := scheds[:0]
+	for _, s := range scheds {
+		if !s.Paused {
+			active = append(active, s)
+		}
+	}
+	return active, nil
+}
+
+// fetchExecutions runs the single alive-during-window visibility query and returns workflow timelines grouped by
+// schedule ID. queryEnd extends past windowEnd by delayedFireBuffer to catch heavily-delayed BUFFER fires whose nominal
+// time falls in the window but whose actual StartTime lands well after windowEnd (e.g. 5-min schedules whose workflows
+// take 24h to run). When --schedule-id is set, the filter is pushed down to the server.
+func (a *scheduleAuditor) fetchExecutions(ctx context.Context) (map[string][]timelineEntry, error) {
+	queryEnd := a.WindowEnd.Add(delayedFireBuffer)
+	executions, err := a.Executions.ListExecutions(ctx, a.Namespace, a.ScheduleID, a.WindowStart, queryEnd)
+	if err != nil {
+		return nil, fmt.Errorf("list executions: %w", err)
+	}
+	return executions, nil
+}
+
+// analyzeAll fans out analyzeSchedule across worker goroutines and gathers the per-schedule results. Concurrency is
+// sized to NumCPU since the work is pure CPU (spec compile + classification), with no RPCs.
+func (a *scheduleAuditor) analyzeAll(scheds []scheduleEntry, executions map[string][]timelineEntry) ([]scheduleResult, error) {
+	sem := make(chan struct{}, runtime.NumCPU())
+	var (
+		mu       sync.Mutex
+		results  []scheduleResult
+		firstErr error
+	)
+	var wg sync.WaitGroup
+	for _, s := range scheds {
+		s := s
+		entries := executions[s.ID]
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			res, err := a.analyzeSchedule(s, entries, a.WindowStart)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+				return
+			}
+			if res != nil {
+				results = append(results, *res)
+			}
+		}()
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return nil, firstErr
+	}
+	return results, nil
+}
+
+// postProcess re-examines schedules flagged with real_miss > 0 by calling DescribeSchedule and applying the following
+// reclassification rules (checked in order; first match wins):
+//
+//   - NotFound (deleted between list and describe)  -> drop the row.
+//   - UpdateTime > windowStart (spec changed mid-window) -> reclassify real_miss to inconclusive_schedule_changed.
+//   - Exhausted (limited_actions, remaining_actions == 0) -> drop the row.
+//   - UnsupportedReason != "" -> reclassify real_miss to unsupported_policy and stamp the reason. These are
+//     corner-case policy/state configs the algorithm does not model correctly today, so we move the count out of
+//     the trusted real_miss bucket and surface the row for manual review. Reasons currently detected:
+//   - keep_original_workflow_id  -- all fires share one WorkflowID, collapsing the chain-by-WorkflowID model.
+//   - overlap_buffer_all         -- fires can be queued for arbitrary durations, beyond our 24h query buffer.
+//   - overlap_allow_all          -- scheduler never skips on overlap, so skip_overlap labels may be wrong.
+//   - overlap_cancel_other       -- new fire cancels prior; chain lifecycle differs (likely works, unverified).
+//   - overlap_terminate_other    -- same as cancel_other; likely works, unverified.
+//   - CreateTime >= windowEnd -> drop the row. The schedule was created after the audit window ended, so it could
+//     not have fired during the window. The expected fires we computed are phantom -- the spec compiler is
+//     stateless and doesn't know when the schedule was created, so it generates fires the schedule never had a
+//     chance to run. Dropping the row removes the false-positive real_miss count entirely.
+//   - CreateTime > windowStart (created mid-window) -> re-analyze with expectedStart = CreateTime. The schedule
+//     existed for part of the window but not all of it. Fires before CreateTime are phantom (same reason as
+//     above) but fires at-or-after CreateTime are real. Re-running classifyFirings with the lower bound advanced
+//     to CreateTime drops the phantom expected fires while preserving any genuine misses that occurred after the
+//     schedule came online.
+//   - Otherwise: row stands as real_miss.
+//
+// Done sequentially to keep describe RPCs gentle on the frontend.
+func (a *scheduleAuditor) postProcess(ctx context.Context, scheds []scheduleEntry, executions map[string][]timelineEntry, results []scheduleResult) ([]scheduleResult, error) {
+	schedByID := make(map[string]scheduleEntry, len(scheds))
+	for _, s := range scheds {
+		schedByID[s.ID] = s
+	}
+	revised := results[:0]
+	for _, r := range results {
+		if r.Counts[categoryRealMiss] == 0 {
+			revised = append(revised, r)
+			continue
+		}
+		desc, err := a.Schedules.DescribeSchedule(ctx, a.Namespace, r.ScheduleID)
+		if err != nil {
+			// Race: ListSchedules saw this schedule but it was deleted before our post-process call. Drop the row -- we can't
+			// classify real_miss for a schedule that no longer exists.
+			if status.Code(err) == codes.NotFound {
+				fmt.Fprintf(a.Progress, "    %s: %s: deleted between list and describe, dropping row\n",
+					a.Namespace, r.ScheduleID)
+				continue
+			}
+			return nil, fmt.Errorf("describe %s: %w", r.ScheduleID, err)
+		}
+		// Record to help correlate real_miss, especially for short catch-ups
+		r.CatchupWindowSeconds = int64(desc.CatchupWindow.Seconds())
+		// Spec modified during window: current spec doesn't describe what was firing pre-modification, so unmatched fires
+		// can't be trusted as real_miss.
+		if !desc.UpdateTime.IsZero() && desc.UpdateTime.After(a.WindowStart) {
+			recategorize(&r, categoryRealMiss, categoryInconclusiveChanged)
+			revised = append(revised, r)
+			continue
+		}
+		// Exhausted (limited_actions with remaining_actions==0): won't fire anymore even though spec still produces fire
+		// times. Drop.
+		if desc.Exhausted {
+			continue
+		}
+		// Unsupported policy/state: algorithm doesn't fully model these (keepOriginalWorkflowId, BUFFER_ALL, etc). Surface
+		// for manual review but don't claim the misses are real.
+		if desc.UnsupportedReason != "" {
+			recategorize(&r, categoryRealMiss, categoryUnsupportedPolicy)
+			r.UnsupportedReason = desc.UnsupportedReason
+			revised = append(revised, r)
+			continue
+		}
+		// Created after windowEnd: couldn't have fired during the window.
+		if !desc.CreateTime.IsZero() && !desc.CreateTime.Before(a.WindowEnd) {
+			continue
+		}
+		// Created mid-window: re-analyze with truncated expected.
+		if !desc.CreateTime.IsZero() && desc.CreateTime.After(a.WindowStart) {
+			s, ok := schedByID[r.ScheduleID]
+			if !ok {
+				revised = append(revised, r)
+				continue
+			}
+			entries := executions[r.ScheduleID]
+			newR, err := a.analyzeSchedule(s, entries, desc.CreateTime)
+			if err != nil {
+				return nil, fmt.Errorf("re-analyze %s: %w", r.ScheduleID, err)
+			}
+			if newR != nil {
+				newR.CatchupWindowSeconds = r.CatchupWindowSeconds
+				revised = append(revised, *newR)
+			}
+			continue
+		}
+		// Schedule unchanged and pre-existing: result stands.
+		revised = append(revised, r)
+	}
+	return revised, nil
+}
+
+// analyzeSchedule runs the audit for a single schedule entry against the pre-fetched timeline entries. expectedStart
+// bounds the lower edge of expected fires; pass a.WindowStart for the normal case, or a schedule's createTime (when
+// later than WindowStart) to suppress false-positive real_miss for schedules that didn't yet exist at the start of the
+// audit window.
+func (a *scheduleAuditor) analyzeSchedule(s scheduleEntry, entries []timelineEntry, expectedStart time.Time) (*scheduleResult, error) {
+	expected, err := expectedFireTimes(s.Spec, s.ID, expectedStart, a.WindowEnd)
+	if err != nil {
+		return nil, fmt.Errorf("expected fires for %s: %w", s.ID, err)
+	}
+	if len(expected) == 0 {
+		return nil, nil
+	}
+	tl := &timeline{byWorkflowID: map[string]*workflowChain{}}
+	for _, e := range entries {
+		tl.addExecution(e)
+	}
+	r := &scheduleResult{
+		Namespace:     a.Namespace,
+		ScheduleID:    s.ID,
+		WorkflowType:  s.WorkflowType,
+		JitterSeconds: s.JitterSeconds,
+	}
+	classifyFirings(r, expected, tl)
+	return r, nil
+}
+
+// recategorize moves all entries currently classified as `from` into `to`, updating both the per-fire Categories map
+// and the aggregate Counts. Used by the post-process to reclassify real_miss entries when we can't trust the spec (e.g.
+// the schedule was modified during the audit window).
+func recategorize(r *scheduleResult, from, to string) {
+	if r.Counts[from] == 0 {
+		return
+	}
+	for t, cat := range r.Categories {
+		if cat == from {
+			r.Categories[t] = to
+		}
+	}
+	r.Counts[to] += r.Counts[from]
+	delete(r.Counts, from)
+}
+
+// grpcRetrier wraps RPCs with retry-on-ResourceExhausted
+type grpcRetrier struct {
+	log io.Writer
+}
+
+// retrier parameters
+const (
+	retryMaxAttempts     = 10
+	retryInitialBackoff  = time.Second
+	retryMaxBackoff      = 10 * time.Second
+	retryBackoffJitter   = 0.2
+	retryLogAfterAttempt = 3
+)
+
+// do executes f with retry-on-ResourceExhausted. Backoff is exponential with jitter.
+func (t *grpcRetrier) do(ctx context.Context, opName string, f func() error) error {
+	var err error
+	for attempt := 0; attempt < retryMaxAttempts; attempt++ {
+		err = f()
+		if err == nil {
+			return nil
+		}
+		if status.Code(err) != codes.ResourceExhausted {
+			return err
+		}
+		if attempt == retryMaxAttempts-1 {
+			return err
+		}
+		wait := backoffForAttempt(attempt)
+		// attempt is 0-indexed; this is the (attempt+1)-th retry about to start.
+		nextAttempt := attempt + 2
+		if t.log != nil && nextAttempt > retryLogAfterAttempt {
+			fmt.Fprintf(t.log, "    rate limited on %s; sleeping %s before retry %d/%d\n",
+				opName, wait, nextAttempt, retryMaxAttempts)
+		}
+		select {
+		case <-time.After(wait):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return err
+}
+
+func backoffForAttempt(attempt int) time.Duration {
+	wait := time.Duration(float64(retryInitialBackoff) * math.Pow(2, float64(attempt)))
+	if wait > retryMaxBackoff {
+		wait = retryMaxBackoff
+	}
+	jitter := (rand.Float64()*2 - 1) * retryBackoffJitter
+	return time.Duration(float64(wait) * (1 + jitter))
+}
+
+// grpcScheduleLoader is the production implementation of scheduleLoader, backed by the workflow-service frontend.
+type grpcScheduleLoader struct {
+	client  workflowservice.WorkflowServiceClient
+	retrier *grpcRetrier
+}
+
+func (l *grpcScheduleLoader) ListSchedules(ctx context.Context, namespace string) ([]scheduleEntry, error) {
+	var out []scheduleEntry
+	var pageToken []byte
+	for {
+		var resp *workflowservice.ListSchedulesResponse
+		err := l.retrier.do(ctx, fmt.Sprintf("ListSchedules(%s)", namespace), func() error {
+			var rpcErr error
+			resp, rpcErr = l.client.ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
+				Namespace:       namespace,
+				MaximumPageSize: 1000,
+				NextPageToken:   pageToken,
+			})
+			return rpcErr
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, s := range resp.GetSchedules() {
+			info := s.GetInfo()
+			if info == nil {
+				continue
+			}
+			var jitterSecs int64
+			if j := info.GetSpec().GetJitter(); j != nil {
+				jitterSecs = int64(j.AsDuration().Seconds())
+			}
+			out = append(out, scheduleEntry{
+				ID:            s.GetScheduleId(),
+				Spec:          info.GetSpec(),
+				WorkflowType:  info.GetWorkflowType().GetName(),
+				JitterSeconds: jitterSecs,
+				Paused:        info.GetPaused(),
+			})
+		}
+		if len(resp.GetNextPageToken()) == 0 {
+			break
+		}
+		pageToken = resp.GetNextPageToken()
+	}
+	return out, nil
+}
+
+// LookupSchedule fetches a single schedule via DescribeSchedule and projects the response into a scheduleEntry
+func (l *grpcScheduleLoader) LookupSchedule(ctx context.Context, namespace, scheduleID string) (scheduleEntry, error) {
+	var resp *workflowservice.DescribeScheduleResponse
+	err := l.retrier.do(ctx, fmt.Sprintf("DescribeSchedule(%s/%s)", namespace, scheduleID), func() error {
+		var rpcErr error
+		resp, rpcErr = l.client.DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  namespace,
+			ScheduleId: scheduleID,
+		})
+		return rpcErr
+	})
+	if err != nil {
+		return scheduleEntry{}, err
+	}
+	sched := resp.GetSchedule()
+	spec := sched.GetSpec()
+	var jitterSecs int64
+	if j := spec.GetJitter(); j != nil {
+		jitterSecs = int64(j.AsDuration().Seconds())
+	}
+	return scheduleEntry{
+		ID:            scheduleID,
+		Spec:          spec,
+		WorkflowType:  sched.GetAction().GetStartWorkflow().GetWorkflowType().GetName(),
+		JitterSeconds: jitterSecs,
+		Paused:        sched.GetState().GetPaused(),
+	}, nil
+}
+
+// NamespaceRetention returns the workflow execution retention TTL via DescribeNamespace. One RPC per namespace.
+func (l *grpcScheduleLoader) NamespaceRetention(ctx context.Context, namespace string) (time.Duration, error) {
+	var resp *workflowservice.DescribeNamespaceResponse
+	err := l.retrier.do(ctx, fmt.Sprintf("DescribeNamespace(%s)", namespace), func() error {
+		var rpcErr error
+		resp, rpcErr = l.client.DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{
+			Namespace: namespace,
+		})
+		return rpcErr
+	})
+	if err != nil {
+		return 0, err
+	}
+	if d := resp.GetConfig().GetWorkflowExecutionRetentionTtl(); d != nil {
+		return d.AsDuration(), nil
+	}
+	return 0, nil
+}
+
+// DescribeSchedule fetches a schedule's metadata via one DescribeSchedule RPC, projected into scheduleDescription
+func (l *grpcScheduleLoader) DescribeSchedule(ctx context.Context, namespace, scheduleID string) (scheduleDescription, error) {
+	var resp *workflowservice.DescribeScheduleResponse
+	err := l.retrier.do(ctx, fmt.Sprintf("DescribeSchedule(%s/%s)", namespace, scheduleID), func() error {
+		var rpcErr error
+		resp, rpcErr = l.client.DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  namespace,
+			ScheduleId: scheduleID,
+		})
+		return rpcErr
+	})
+	if err != nil {
+		return scheduleDescription{}, err
+	}
+	info := resp.GetInfo()
+	sched := resp.GetSchedule()
+	state := sched.GetState()
+	policies := sched.GetPolicies()
+	var desc scheduleDescription
+	if ct := info.GetCreateTime(); ct != nil {
+		desc.CreateTime = ct.AsTime()
+	}
+	if ut := info.GetUpdateTime(); ut != nil {
+		desc.UpdateTime = ut.AsTime()
+	}
+	desc.Exhausted = state.GetLimitedActions() && state.GetRemainingActions() == 0
+	desc.UnsupportedReason = unsupportedPolicyReason(policies)
+	if cw := policies.GetCatchupWindow(); cw != nil {
+		desc.CatchupWindow = cw.AsDuration()
+	}
+	return desc, nil
+}
+
+// unsupportedPolicyReason returns a non-empty string when a schedule's policies/state use a configuration our audit
+// doesn't fully handle. Multiple reasons are joined with ";". Operators see this in the report and know those rows need
+// manual review rather than being trusted as real_miss.
+func unsupportedPolicyReason(policies *schedulepb.SchedulePolicies) string {
+	if policies == nil {
+		return ""
+	}
+	var reasons []string
+	if policies.GetKeepOriginalWorkflowId() {
+		// All fires share one WorkflowID, breaking our chain-by-WorkflowID model.
+		reasons = append(reasons, "keep_original_workflow_id")
+	}
+	switch policies.GetOverlapPolicy() {
+	case enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL:
+		// Fires can be buffered for arbitrary durations; our delayedFireBuffer of 24h may miss the workflow.
+		reasons = append(reasons, "overlap_buffer_all")
+	case enumspb.SCHEDULE_OVERLAP_POLICY_CANCEL_OTHER:
+		// Each new fire cancels the running one; chain lifecycle differs from the standard model. Likely works but
+		// unverified.
+		reasons = append(reasons, "overlap_cancel_other")
+	case enumspb.SCHEDULE_OVERLAP_POLICY_TERMINATE_OTHER:
+		// Similar to CANCEL_OTHER. Likely works but unverified.
+		reasons = append(reasons, "overlap_terminate_other")
+	case enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL:
+		// ALLOW_ALL never skips on overlap, so classifyFirings can mis-label
+		// real_miss as skip_overlap when a long-running prior fire is active
+		// at the expected time. Surface for inspection; we don't reclassify
+		// here because the skip_overlap labels were already computed before
+		// post-process and DescribeSchedule isn't called for skip-only rows.
+		reasons = append(reasons, "overlap_allow_all")
+	}
+	return strings.Join(reasons, ";")
+}
+
+// grpcExecutionLoader pages through ListWorkflowExecutions for an entire namespace in a single visibility query,
+// returning entries grouped by schedule ID. The query uses `TemporalScheduledById IS NOT NULL` so the server can
+// satisfy it with an index scan, and pagination is shared across all schedules.
+type grpcExecutionLoader struct {
+	client  workflowservice.WorkflowServiceClient
+	retrier *grpcRetrier
+	log     io.Writer
+}
+
+// visibilityPageSize is the per-call ListWorkflowExecutions page size. 1000 is a safe default; the server may
+// silently clamp to a lower max. Larger values reduce RPC count but each call returns more bytes (4MB gRPC limit
+// caps practical sizes around ~5000).
+const visibilityPageSize = 1000
+
+const pageProgressEvery = 5
+
+// ListExecutions issues one paginated visibility query that returns every scheduled workflow alive at some moment in
+// [windowStart, queryEnd]. The predicate `StartTime <= queryEnd AND (CloseTime >= windowStart OR CloseTime IS NULL)`
+// captures in-window starts, still-running long-runners, closed long-runners that crossed windowStart, and
+// heavily-delayed BUFFER fires in one shot -- replacing what used to be three separate queries.
+func (l *grpcExecutionLoader) ListExecutions(ctx context.Context, namespace, scheduleIDFilter string, windowStart, queryEnd time.Time) (map[string][]timelineEntry, error) {
+	scheduleClause := buildScheduleClause(scheduleIDFilter)
+	query := fmt.Sprintf(
+		`%s AND StartTime <= %q AND (CloseTime >= %q OR CloseTime IS NULL)`,
+		scheduleClause,
+		queryEnd.UTC().Format(time.RFC3339),
+		windowStart.UTC().Format(time.RFC3339),
+	)
+	return l.paginate(ctx, namespace, scheduleIDFilter, query, "alive-during-window")
+}
+
+func buildScheduleClause(scheduleIDFilter string) string {
+	if scheduleIDFilter != "" {
+		return fmt.Sprintf(`TemporalScheduledById = %q`, scheduleIDFilter)
+	}
+	return `TemporalScheduledById IS NOT NULL`
+}
+
+// paginate runs a visibility query to completion, demuxing results by TemporalScheduledById. opTag is a short label
+// included in retry/progress log lines so operators can identify the query when scanning stderr.
+func (l *grpcExecutionLoader) paginate(ctx context.Context, namespace, scheduleIDFilter, query, opTag string) (map[string][]timelineEntry, error) {
+	opLabel := fmt.Sprintf("ListWorkflowExecutions(%s,%s)", namespace, opTag)
+	if scheduleIDFilter != "" {
+		opLabel = fmt.Sprintf("ListWorkflowExecutions(%s/%s,%s)", namespace, scheduleIDFilter, opTag)
+	}
+	out := map[string][]timelineEntry{}
+	var pageToken []byte
+	var page, total, skipped int
+	for {
+		var resp *workflowservice.ListWorkflowExecutionsResponse
+		err := l.retrier.do(ctx, opLabel, func() error {
+			var rpcErr error
+			resp, rpcErr = l.client.ListWorkflowExecutions(ctx, &workflowservice.ListWorkflowExecutionsRequest{
+				Namespace:     namespace,
+				Query:         query,
+				PageSize:      visibilityPageSize,
+				NextPageToken: pageToken,
+			})
+			return rpcErr
+		})
+		if err != nil {
+			return nil, err
+		}
+		page++
+		for _, exec := range resp.GetExecutions() {
+			sa := exec.GetSearchAttributes().GetIndexedFields()
+			scheduleID, ok := decodeScheduledById(sa["TemporalScheduledById"])
+			if !ok || scheduleID == "" {
+				skipped++
+				continue
+			}
+			entry := timelineEntry{
+				WorkflowID: exec.GetExecution().GetWorkflowId(),
+				RunID:      exec.GetExecution().GetRunId(),
+				Status:     exec.GetStatus(),
+			}
+			if st := exec.GetStartTime(); st != nil {
+				entry.StartTime = st.AsTime()
+			}
+			if ct := exec.GetCloseTime(); ct != nil {
+				t := ct.AsTime()
+				entry.CloseTime = &t
+			}
+			if nominal, ok := decodeNominalStartTime(sa["TemporalScheduledStartTime"]); ok {
+				entry.NominalTime = nominal
+			}
+			// Skip rows with neither nominal nor start time - nothing to match.
+			if entry.NominalTime.IsZero() && entry.StartTime.IsZero() {
+				skipped++
+				continue
+			}
+			if entry.NominalTime.IsZero() {
+				entry.NominalTime = entry.StartTime
+			}
+			out[scheduleID] = append(out[scheduleID], entry)
+			total++
+		}
+		if l.log != nil && page%pageProgressEvery == 0 {
+			fmt.Fprintf(l.log, "      %s (%s): page %d, %d entries (%d skipped) across %d schedules\n",
+				namespace, opTag, page, total, skipped, len(out))
+		}
+		if len(resp.GetNextPageToken()) == 0 {
+			return out, nil
+		}
+		pageToken = resp.GetNextPageToken()
+	}
+}
+
+// decodeScheduledById extracts the schedule ID from a TemporalScheduledById search-attribute payload. Returns false if
+// the payload is missing or in an unexpected encoding so the caller can skip the row instead of grouping it under an
+// empty key.
+func decodeScheduledById(payload *commonpb.Payload) (string, bool) {
+	if payload == nil {
+		return "", false
+	}
+	encoding := string(payload.GetMetadata()["encoding"])
+	if !strings.HasPrefix(encoding, "json/plain") {
+		return "", false
+	}
+	var raw string
+	if err := json.Unmarshal(payload.GetData(), &raw); err != nil {
+		return "", false
+	}
+	return raw, true
+}
+
+// decodeNominalStartTime extracts the nominal scheduled start time from a TemporalScheduledStartTime search-attribute
+// payload. Returns zero time if the payload is missing or in an unexpected encoding.
+func decodeNominalStartTime(payload *commonpb.Payload) (time.Time, bool) {
+	if payload == nil {
+		return time.Time{}, false
+	}
+	encoding := string(payload.GetMetadata()["encoding"])
+	if !strings.HasPrefix(encoding, "json/plain") {
+		return time.Time{}, false
+	}
+	// Visibility payloads carry a JSON-encoded scalar (string like "2026-05-19T18:00:00Z").
+	var raw string
+	if err := json.Unmarshal(payload.GetData(), &raw); err != nil {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+var flatCSVBaseHeader = []string{
+	"namespace",
+	"schedule_id",
+	"workflow_type",
+	"jitter_s",
+	"expected",
+	"actual",
+	"matched",
+	"missed",
+	categoryRealMiss,
+	categorySkipOverlap,
+	categoryInconclusiveChanged,
+	categoryUnsupportedPolicy,
+	"unsupported_reason",
+	"catchup_window_s",
+	"real_miss_times",
+}
+
+func writeFlatCSV(w io.Writer, results []scheduleResult) error {
+	cw := csv.NewWriter(w)
+	defer cw.Flush()
+	if err := cw.Write(flatCSVBaseHeader); err != nil {
+		return err
+	}
+	for _, r := range results {
+		if len(r.Missed) == 0 {
+			continue
+		}
+		if err := cw.Write(flatRow(r)); err != nil {
+			return err
+		}
+	}
+	return cw.Error()
+}
+
+func flatRow(r scheduleResult) []string {
+	// Only emit the real_miss times -- the other buckets (skip_overlap, inconclusive_schedule_changed, unsupported_policy)
+	// all have valid reasons, so their timestamps add noise to the output column. Categories may have been mutated by
+	// recategorize during post-process, so filter on the final classification.
+	var realMissTimes []time.Time
+	for _, t := range r.Missed {
+		if r.Categories[t] == categoryRealMiss {
+			realMissTimes = append(realMissTimes, t)
+		}
+	}
+	return []string{
+		r.Namespace,
+		r.ScheduleID,
+		strings.ReplaceAll(r.WorkflowType, ",", ";"),
+		fmt.Sprintf("%d", r.JitterSeconds),
+		fmt.Sprintf("%d", r.Expected),
+		fmt.Sprintf("%d", r.Actual),
+		fmt.Sprintf("%d", r.Matched),
+		fmt.Sprintf("%d", len(r.Missed)),
+		fmt.Sprintf("%d", r.Counts[categoryRealMiss]),
+		fmt.Sprintf("%d", r.Counts[categorySkipOverlap]),
+		fmt.Sprintf("%d", r.Counts[categoryInconclusiveChanged]),
+		fmt.Sprintf("%d", r.Counts[categoryUnsupportedPolicy]),
+		strings.ReplaceAll(r.UnsupportedReason, ",", ";"),
+		fmt.Sprintf("%d", r.CatchupWindowSeconds),
+		joinTimes(realMissTimes, 20),
+	}
+}
+
+// joinTimes joins up to maxItems timestamps with `;` separators, truncating with a `...+N more` suffix if there are
+// more.
+func joinTimes(times []time.Time, maxItems int) string {
+	sort.Slice(times, func(i, j int) bool { return times[i].Before(times[j]) })
+	if len(times) > maxItems {
+		s := make([]string, 0, maxItems+1)
+		for _, t := range times[:maxItems] {
+			s = append(s, t.UTC().Format(time.RFC3339))
+		}
+		s = append(s, fmt.Sprintf("...+%d more", len(times)-maxItems))
+		return strings.Join(s, ";")
+	}
+	s := make([]string, 0, len(times))
+	for _, t := range times {
+		s = append(s, t.UTC().Format(time.RFC3339))
+	}
+	return strings.Join(s, ";")
+}
+
+// writeOutput writes a per-namespace bundle directory:
+//
+//	<dir>/summary.csv
+//	<dir>/per-namespace/<ns>.csv
+func writeOutput(dir string, results []scheduleResult) error {
+	perNSDir := filepath.Join(dir, "per-namespace")
+	if err := os.MkdirAll(perNSDir, 0o755); err != nil {
+		return err
+	}
+
+	byNS := map[string][]scheduleResult{}
+	for _, r := range results {
+		if len(r.Missed) == 0 {
+			continue
+		}
+		byNS[r.Namespace] = append(byNS[r.Namespace], r)
+	}
+
+	for ns, rs := range byNS {
+		// Sanitize "/" -> "_"
+		safeName := strings.NewReplacer("/", "_", string(filepath.Separator), "_").Replace(ns)
+		path := filepath.Join(perNSDir, safeName+".csv")
+		f, err := os.Create(path)
+		if err != nil {
+			return err
+		}
+		if err := writeFlatCSV(f, rs); err != nil {
+			f.Close()
+			return err
+		}
+		f.Close()
+	}
+
+	return writeSummaryCSV(filepath.Join(dir, "summary.csv"), byNS)
+}
+
+// writeSummaryCSV emits one row per namespace with aggregated counts across the namespace's flagged schedules.
+func writeSummaryCSV(path string, byNS map[string][]scheduleResult) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	cw := csv.NewWriter(f)
+	defer cw.Flush()
+	if err := cw.Write([]string{
+		"namespace", "schedules_flagged",
+		categoryRealMiss, categorySkipOverlap, categoryInconclusiveChanged,
+		categoryUnsupportedPolicy,
+	}); err != nil {
+		return err
+	}
+	nss := make([]string, 0, len(byNS))
+	for ns := range byNS {
+		nss = append(nss, ns)
+	}
+	sort.Strings(nss)
+	for _, ns := range nss {
+		rs := byNS[ns]
+		var realMisses, skips, specChanged, unsupported int
+		for _, r := range rs {
+			realMisses += r.Counts[categoryRealMiss]
+			skips += r.Counts[categorySkipOverlap]
+			specChanged += r.Counts[categoryInconclusiveChanged]
+			unsupported += r.Counts[categoryUnsupportedPolicy]
+		}
+		if err := cw.Write([]string{
+			ns,
+			fmt.Sprintf("%d", len(rs)),
+			fmt.Sprintf("%d", realMisses),
+			fmt.Sprintf("%d", skips),
+			fmt.Sprintf("%d", specChanged),
+			fmt.Sprintf("%d", unsupported),
+		}); err != nil {
+			return err
+		}
+	}
+	return cw.Error()
+}

--- a/tools/tdbg/schedule_audit.go
+++ b/tools/tdbg/schedule_audit.go
@@ -103,7 +103,7 @@ func AdminAuditSchedules(c *cli.Context, factory ClientFactory) error {
 	_, _ = fmt.Fprintf(os.Stderr, "audit complete: %d total flagged across %d target(s) in %s\n",
 		len(allResults), total, time.Since(auditStart).Round(time.Second))
 	if in.OutputDir == "" {
-		// Stdout mode: one CSV stream, all rows, single header, no summary file.
+		// Stdout mode: stream all rows, no summary file.
 		// Sort across namespaces (per-namespace.run() only sorts within its own batch).
 		sort.Slice(allResults, func(i, j int) bool {
 			if allResults[i].Namespace != allResults[j].Namespace {
@@ -111,9 +111,9 @@ func AdminAuditSchedules(c *cli.Context, factory ClientFactory) error {
 			}
 			return allResults[i].ScheduleID < allResults[j].ScheduleID
 		})
-		return writeFlatCSV(os.Stdout, allResults)
+		return writeFlat(os.Stdout, allResults, in.Format)
 	}
-	return writeOutput(in.OutputDir, allResults)
+	return writeOutput(in.OutputDir, allResults, in.Format)
 }
 
 type auditTarget struct {
@@ -127,15 +127,20 @@ type auditInputs struct {
 	WindowEnd            time.Time
 	OutputDir            string
 	NamespaceConcurrency int
+	Format               string
 }
 
 func parseAuditInputs(c *cli.Context) (*auditInputs, error) {
 	in := &auditInputs{
 		OutputDir:            c.String(FlagOutputDir),
 		NamespaceConcurrency: c.Int(FlagNamespaceConcurrency),
+		Format:               strings.ToLower(strings.TrimSpace(c.String(FlagFormat))),
 	}
 	if in.NamespaceConcurrency <= 0 {
 		in.NamespaceConcurrency = 1
+	}
+	if in.Format == "" {
+		in.Format = formatJSONL
 	}
 
 	targets, err := resolveTargetsFromFlags(c.String(FlagNamespace), c.String(FlagScheduleID), c.String(FlagFile), os.Stdin)
@@ -165,6 +170,11 @@ func (in *auditInputs) validate() error {
 		return fmt.Errorf("--end (%s) must be after --start (%s)",
 			in.WindowEnd.UTC().Format(time.RFC3339),
 			in.WindowStart.UTC().Format(time.RFC3339))
+	}
+	switch in.Format {
+	case formatJSONL, formatCSV:
+	default:
+		return fmt.Errorf("--format %q: must be %q or %q", in.Format, formatJSONL, formatCSV)
 	}
 	return nil
 }
@@ -1028,6 +1038,96 @@ func decodeNominalStartTime(payload *commonpb.Payload) (time.Time, bool) {
 	return t, true
 }
 
+const (
+	formatJSONL = "jsonl"
+	formatCSV   = "csv"
+)
+
+// writeFlat dispatches to the format-specific row writer for stdout / per-namespace files.
+func writeFlat(w io.Writer, results []scheduleResult, format string) error {
+	if format == formatCSV {
+		return writeFlatCSV(w, results)
+	}
+	return writeFlatJSONL(w, results)
+}
+
+func formatExt(format string) string {
+	if format == formatCSV {
+		return "csv"
+	}
+	return "jsonl"
+}
+
+// flatJSONLRow is the per-schedule JSONL output shape.
+type flatJSONLRow struct {
+	Namespace                   string   `json:"namespace"`
+	ScheduleID                  string   `json:"schedule_id"`
+	WorkflowType                string   `json:"workflow_type"`
+	Expected                    int      `json:"expected"`
+	Actual                      int      `json:"actual"`
+	Matched                     int      `json:"matched"`
+	Missed                      int      `json:"missed"`
+	RealMiss                    int      `json:"real_miss"`
+	SkipOverlap                 int      `json:"skip_overlap"`
+	InconclusiveScheduleChanged int      `json:"inconclusive_schedule_changed"`
+	CatchupWindowSeconds        int64    `json:"catchup_window_s"`
+	RealMissTimes               []string `json:"real_miss_times"`
+}
+
+// summaryJSONLRow is the per-namespace JSONL summary shape.
+type summaryJSONLRow struct {
+	Namespace                   string `json:"namespace"`
+	SchedulesFlagged            int    `json:"schedules_flagged"`
+	RealMiss                    int    `json:"real_miss"`
+	SkipOverlap                 int    `json:"skip_overlap"`
+	InconclusiveScheduleChanged int    `json:"inconclusive_schedule_changed"`
+}
+
+func writeFlatJSONL(w io.Writer, results []scheduleResult) error {
+	enc := json.NewEncoder(w)
+	for _, r := range results {
+		if len(r.Missed) == 0 {
+			continue
+		}
+		if err := enc.Encode(jsonlRow(r)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func jsonlRow(r scheduleResult) flatJSONLRow {
+	var realMissTimes []time.Time
+	for _, t := range r.Missed {
+		if r.Categories[t] == categoryRealMiss {
+			realMissTimes = append(realMissTimes, t)
+		}
+	}
+	sort.Slice(realMissTimes, func(i, j int) bool { return realMissTimes[i].Before(realMissTimes[j]) })
+	const maxTimes = 20
+	if len(realMissTimes) > maxTimes {
+		realMissTimes = realMissTimes[:maxTimes]
+	}
+	rmt := make([]string, 0, len(realMissTimes))
+	for _, t := range realMissTimes {
+		rmt = append(rmt, t.UTC().Format(time.RFC3339))
+	}
+	return flatJSONLRow{
+		Namespace:                   r.Namespace,
+		ScheduleID:                  r.ScheduleID,
+		WorkflowType:                r.WorkflowType,
+		Expected:                    r.Expected,
+		Actual:                      r.Actual,
+		Matched:                     r.Matched,
+		Missed:                      len(r.Missed),
+		RealMiss:                    r.Counts[categoryRealMiss],
+		SkipOverlap:                 r.Counts[categorySkipOverlap],
+		InconclusiveScheduleChanged: r.Counts[categoryInconclusiveChanged],
+		CatchupWindowSeconds:        r.CatchupWindowSeconds,
+		RealMissTimes:               rmt,
+	}
+}
+
 var flatCSVBaseHeader = []string{
 	"namespace",
 	"schedule_id",
@@ -1106,9 +1206,11 @@ func joinTimes(times []time.Time, maxItems int) string {
 
 // writeOutput writes a per-namespace bundle directory:
 //
-//	<dir>/summary.csv
-//	<dir>/per-namespace/<ns>.csv
-func writeOutput(dir string, results []scheduleResult) error {
+//	<dir>/summary.<ext>
+//	<dir>/per-namespace/<ns>.<ext>
+//
+// where <ext> is jsonl (default) or csv based on the format argument.
+func writeOutput(dir string, results []scheduleResult, format string) error {
 	perNSDir := filepath.Join(dir, "per-namespace")
 	if err := os.MkdirAll(perNSDir, 0o755); err != nil {
 		return err
@@ -1122,16 +1224,17 @@ func writeOutput(dir string, results []scheduleResult) error {
 		byNS[r.Namespace] = append(byNS[r.Namespace], r)
 	}
 
+	ext := formatExt(format)
 	for ns, rs := range byNS {
 		// Sanitize path separators and dots so namespaces with literal dots (e.g. "foo.bar") or pathological values
 		// like ".." cannot escape perNSDir or produce hidden files.
 		safeName := strings.NewReplacer("/", "_", string(filepath.Separator), "_", ".", "_").Replace(ns)
-		path := filepath.Join(perNSDir, safeName+".csv")
+		path := filepath.Join(perNSDir, safeName+"."+ext)
 		f, err := os.Create(path)
 		if err != nil {
 			return err
 		}
-		if err := writeFlatCSV(f, rs); err != nil {
+		if err := writeFlat(f, rs, format); err != nil {
 			_ = f.Close()
 			return err
 		}
@@ -1140,7 +1243,53 @@ func writeOutput(dir string, results []scheduleResult) error {
 		}
 	}
 
-	return writeSummaryCSV(filepath.Join(dir, "summary.csv"), byNS)
+	return writeSummary(filepath.Join(dir, "summary."+ext), byNS, format)
+}
+
+// writeSummary dispatches to the format-specific summary writer.
+func writeSummary(path string, byNS map[string][]scheduleResult, format string) error {
+	if format == formatCSV {
+		return writeSummaryCSV(path, byNS)
+	}
+	return writeSummaryJSONL(path, byNS)
+}
+
+// writeSummaryJSONL emits one JSON object per line (one per namespace) with aggregated counts.
+func writeSummaryJSONL(path string, byNS map[string][]scheduleResult) (retErr error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := f.Close(); cerr != nil && retErr == nil {
+			retErr = cerr
+		}
+	}()
+	enc := json.NewEncoder(f)
+	nss := make([]string, 0, len(byNS))
+	for ns := range byNS {
+		nss = append(nss, ns)
+	}
+	sort.Strings(nss)
+	for _, ns := range nss {
+		rs := byNS[ns]
+		var realMisses, skips, specChanged int
+		for _, r := range rs {
+			realMisses += r.Counts[categoryRealMiss]
+			skips += r.Counts[categorySkipOverlap]
+			specChanged += r.Counts[categoryInconclusiveChanged]
+		}
+		if err := enc.Encode(summaryJSONLRow{
+			Namespace:                   ns,
+			SchedulesFlagged:            len(rs),
+			RealMiss:                    realMisses,
+			SkipOverlap:                 skips,
+			InconclusiveScheduleChanged: specChanged,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // writeSummaryCSV emits one row per namespace with aggregated counts across the namespace's flagged schedules.

--- a/tools/tdbg/schedule_audit.go
+++ b/tools/tdbg/schedule_audit.go
@@ -1,6 +1,7 @@
 package tdbg
 
 import (
+	"bufio"
 	"context"
 	"encoding/csv"
 	"encoding/json"
@@ -44,7 +45,7 @@ func AdminAuditSchedules(c *cli.Context, factory ClientFactory) error {
 	// goroutines within a namespace. If any namespace fails, queued (not-yet-started) namespaces bail; in-flight
 	// namespaces continue until finish.
 	auditStart := time.Now()
-	total := len(in.Namespaces)
+	total := len(in.Targets)
 	sem := make(chan struct{}, in.NamespaceConcurrency)
 	var (
 		mu         sync.Mutex
@@ -53,7 +54,7 @@ func AdminAuditSchedules(c *cli.Context, factory ClientFactory) error {
 		done       int
 	)
 	var wg sync.WaitGroup
-	for _, ns := range in.Namespaces {
+	for _, t := range in.Targets {
 		sem <- struct{}{}
 		wg.Go(func() {
 			defer func() { <-sem }()
@@ -65,11 +66,15 @@ func AdminAuditSchedules(c *cli.Context, factory ClientFactory) error {
 			}
 			mu.Unlock()
 
+			label := t.Namespace
+			if t.ScheduleID != "" {
+				label = fmt.Sprintf("%s/%s", t.Namespace, t.ScheduleID)
+			}
 			nsStart := time.Now()
-			_, _ = fmt.Fprintf(os.Stderr, "auditing %s...\n", ns)
+			_, _ = fmt.Fprintf(os.Stderr, "auditing %s...\n", label)
 			auditor := &scheduleAuditor{
-				Namespace:   ns,
-				ScheduleID:  in.ScheduleID,
+				Namespace:   t.Namespace,
+				ScheduleID:  t.ScheduleID,
 				WindowStart: in.WindowStart,
 				WindowEnd:   in.WindowEnd,
 				Schedules:   &grpcScheduleLoader{client: wfClient, retrier: retrier},
@@ -81,13 +86,13 @@ func AdminAuditSchedules(c *cli.Context, factory ClientFactory) error {
 			defer mu.Unlock()
 			if err != nil {
 				if firstErr == nil {
-					firstErr = fmt.Errorf("audit %s: %w", ns, err)
+					firstErr = fmt.Errorf("audit %s: %w", label, err)
 				}
 				return
 			}
 			done++
 			_, _ = fmt.Fprintf(os.Stderr, "[%d/%d] %s: %d schedule(s) flagged in %s\n",
-				done, total, ns, len(results), time.Since(nsStart).Round(time.Second))
+				done, total, label, len(results), time.Since(nsStart).Round(time.Second))
 			allResults = append(allResults, results...)
 		})
 	}
@@ -95,7 +100,7 @@ func AdminAuditSchedules(c *cli.Context, factory ClientFactory) error {
 	if firstErr != nil {
 		return firstErr
 	}
-	_, _ = fmt.Fprintf(os.Stderr, "audit complete: %d total flagged across %d namespaces in %s\n",
+	_, _ = fmt.Fprintf(os.Stderr, "audit complete: %d total flagged across %d target(s) in %s\n",
 		len(allResults), total, time.Since(auditStart).Round(time.Second))
 	if in.OutputDir == "" {
 		// Stdout mode: one CSV stream, all rows, single header, no summary file.
@@ -111,103 +116,160 @@ func AdminAuditSchedules(c *cli.Context, factory ClientFactory) error {
 	return writeOutput(in.OutputDir, allResults)
 }
 
+type auditTarget struct {
+	Namespace  string
+	ScheduleID string
+}
+
 type auditInputs struct {
-	Namespaces           []string
-	ScheduleID           string // optional; if set, len(Namespaces) == 1
+	Targets              []auditTarget
 	WindowStart          time.Time
 	WindowEnd            time.Time
+	MaxWindow            time.Duration
 	OutputDir            string
 	NamespaceConcurrency int
 }
 
 func parseAuditInputs(c *cli.Context) (*auditInputs, error) {
 	in := &auditInputs{
-		ScheduleID:           c.String(FlagScheduleID),
 		OutputDir:            c.String(FlagOutputDir),
 		NamespaceConcurrency: c.Int(FlagNamespaceConcurrency),
+		MaxWindow:            c.Duration(FlagMaxWindow),
 	}
 	if in.NamespaceConcurrency <= 0 {
 		in.NamespaceConcurrency = 1
 	}
+	if in.MaxWindow <= 0 {
+		in.MaxWindow = defaultMaxAuditWindow
+	}
 
-	ns, err := resolveNamespaces(c)
+	targets, err := resolveTargetsFromFlags(c.String(FlagNamespace), c.String(FlagScheduleID), c.String(FlagFile), os.Stdin)
 	if err != nil {
 		return nil, err
 	}
-	in.Namespaces = ns
+	in.Targets = targets
 
-	if in.WindowStart, err = time.Parse(time.RFC3339, c.String(FlagAuditStart)); err != nil {
+	if in.WindowStart, err = time.Parse(time.RFC3339, c.String(FlagStart)); err != nil {
 		return nil, fmt.Errorf("--start: %w", err)
 	}
-	if in.WindowEnd, err = time.Parse(time.RFC3339, c.String(FlagAuditEnd)); err != nil {
+	if in.WindowEnd, err = time.Parse(time.RFC3339, c.String(FlagEnd)); err != nil {
 		return nil, fmt.Errorf("--end: %w", err)
 	}
 
 	if err := in.validate(); err != nil {
 		return nil, err
 	}
+
+	if d := in.WindowEnd.Sub(in.WindowStart); d > defaultMaxAuditWindow {
+		_, _ = fmt.Fprintf(os.Stderr, "warning: window is %s (longer than default cap %s); proportionally slower and more memory-intensive\n",
+			d.Round(time.Hour), defaultMaxAuditWindow)
+	}
+
 	return in, nil
 }
 
-// maxAuditWindow caps how wide a single audit window can be. Catches typos (e.g. wrong month in --end) and discourages
-// expensive multi-day runs that should be chunked into separate invocations.
-const maxAuditWindow = 7 * 24 * time.Hour
+// defaultMaxAuditWindow caps how wide a single audit window can be by default. Catches typos (e.g. wrong month in
+// --end) and discourages expensive multi-day runs that should be chunked into separate invocations. Operators can
+// raise the cap via --max-window for schedules that fire less frequently (quarterly, yearly).
+const defaultMaxAuditWindow = 7 * 24 * time.Hour
 
 func (in *auditInputs) validate() error {
-	if in.ScheduleID != "" && len(in.Namespaces) != 1 {
-		return errors.New("--schedule-id requires exactly one namespace (use --namespace, not --namespace-file)")
+	if len(in.Targets) == 0 {
+		return errors.New("no audit targets resolved")
 	}
 	if !in.WindowEnd.After(in.WindowStart) {
 		return fmt.Errorf("--end (%s) must be after --start (%s)",
 			in.WindowEnd.UTC().Format(time.RFC3339),
 			in.WindowStart.UTC().Format(time.RFC3339))
 	}
-	if d := in.WindowEnd.Sub(in.WindowStart); d > maxAuditWindow {
-		return fmt.Errorf("window is %s (--start %s to --end %s); max is %s -- run multiple shorter audits for longer spans",
+	if d := in.WindowEnd.Sub(in.WindowStart); d > in.MaxWindow {
+		return fmt.Errorf("window is %s (--start %s to --end %s); max is %s. Pass --max-window=%s if intentional",
 			d.Round(time.Hour),
 			in.WindowStart.UTC().Format(time.RFC3339),
 			in.WindowEnd.UTC().Format(time.RFC3339),
-			maxAuditWindow)
+			in.MaxWindow,
+			d.Round(time.Hour))
 	}
 	return nil
 }
 
-func resolveNamespaces(c *cli.Context) ([]string, error) {
-	ns := c.String(FlagNamespace)
-	file := c.String(FlagNamespaceFile)
+// resolveTargetsFromFlags returns the list of audit targets, sourced from one of (in priority order):
+//   - namespace (+ optional scheduleID) for a single target
+//   - file path (or "-" for stdin via the provided Reader) for many targets
+//
+// Takes flag values directly (not cli.Context) so tests don't need to fake a context.
+func resolveTargetsFromFlags(namespace, scheduleID, file string, stdin io.Reader) ([]auditTarget, error) {
 	switch {
-	case ns != "" && file != "":
-		return nil, errors.New("--namespace and --namespace-file are mutually exclusive")
-	case ns != "":
-		return []string{ns}, nil
+	case namespace != "" && file != "":
+		return nil, errors.New("--namespace and --file are mutually exclusive")
+	case file != "" && scheduleID != "":
+		return nil, errors.New("--schedule-id is only valid with --namespace; for multiple targets put schedule IDs inline in --file as 'namespace,schedule_id'")
+	case namespace != "":
+		return []auditTarget{{Namespace: namespace, ScheduleID: scheduleID}}, nil
 	case file != "":
-		data, err := os.ReadFile(file)
-		if err != nil {
-			return nil, fmt.Errorf("--namespace-file: %w", err)
-		}
-		var out []string
-		for line := range strings.SplitSeq(string(data), "\n") {
-			line = strings.TrimSpace(line)
-			if line == "" || strings.HasPrefix(line, "#") {
-				continue
-			}
-			out = append(out, line)
-		}
-		if len(out) == 0 {
-			return nil, fmt.Errorf("--namespace-file %q has no namespace entries", file)
-		}
-		return out, nil
+		return loadTargets(file, stdin)
 	default:
-		return nil, errors.New("one of --namespace or --namespace-file is required")
+		return nil, errors.New("one of --namespace or --file is required")
 	}
 }
 
-// expectedFireTimes returns the nominal (pre-jitter) fire times the spec would produce in (start, end]. Uses the
-// server's own spec compiler so the semantics exactly match the live scheduler.
-//
-// jitterSeed is required by the underlying compiler but does not affect the returned nominal times. Pass the schedule
-// ID so the seed is stable per schedule.
-func expectedFireTimes(spec *schedulepb.ScheduleSpec, jitterSeed string, start, end time.Time) ([]time.Time, error) {
+// loadTargets reads audit targets from a file path (or the provided stdin Reader when path is "-") and parses them.
+func loadTargets(path string, stdin io.Reader) ([]auditTarget, error) {
+	r := stdin
+	if path != "-" {
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = f.Close() }()
+		r = f
+	}
+	targets, err := parseTargetLines(r)
+	if err != nil {
+		return nil, fmt.Errorf("--file: %w", err)
+	}
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("--file %q has no target entries", path)
+	}
+	return targets, nil
+}
+
+// parseTargetLines parses an io.Reader of audit-target lines. Each non-blank, non-comment line is 'namespace' or
+// 'namespace,schedule_id'. Whitespace around fields is trimmed. Returns an error if any line has more than one comma.
+func parseTargetLines(r io.Reader) ([]auditTarget, error) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var out []auditTarget
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.Split(line, ",")
+		if len(parts) > 2 {
+			return nil, fmt.Errorf("malformed line %q: expected 'namespace' or 'namespace,schedule_id'", line)
+		}
+		t := auditTarget{Namespace: strings.TrimSpace(parts[0])}
+		if t.Namespace == "" {
+			return nil, fmt.Errorf("malformed line %q: namespace is empty", line)
+		}
+		if len(parts) == 2 {
+			t.ScheduleID = strings.TrimSpace(parts[1])
+			if t.ScheduleID == "" {
+				return nil, fmt.Errorf("malformed line %q: schedule_id is empty after comma", line)
+			}
+		}
+		out = append(out, t)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// expectedFireTimes returns the nominal fire times the spec would produce in (start, end]. Uses the server's own spec
+// compiler so the semantics exactly match the live scheduler.
+func expectedFireTimes(spec *schedulepb.ScheduleSpec, start, end time.Time) ([]time.Time, error) {
 	if spec == nil {
 		return nil, nil
 	}
@@ -219,7 +281,9 @@ func expectedFireTimes(spec *schedulepb.ScheduleSpec, jitterSeed string, start, 
 	var out []time.Time
 	cursor := start
 	for {
-		res := compiled.GetNextTime(jitterSeed, cursor)
+		// Pass empty jitter seed: only GetNextTimeResult.Nominal is consumed, which is computed without the seed
+		// (the seed only feeds GetNextTimeResult.Next, which we discard).
+		res := compiled.GetNextTime("", cursor)
 		if res.Nominal.IsZero() || res.Nominal.After(end) {
 			return out, nil
 		}
@@ -608,7 +672,7 @@ func (a *scheduleAuditor) analyzeAll(scheds []scheduleEntry, executions map[stri
 //   - UnsupportedReason != "" -> reclassify real_miss to unsupported_policy and stamp the reason. These are
 //     corner-case policy/state configs the algorithm does not model correctly today, so we move the count out of
 //     the trusted real_miss bucket and surface the row for manual review. Reasons currently detected:
-//   - keep_original_workflow_id  -- all fires share one WorkflowID, collapsing the chain-by-WorkflowID model.
+//   - keep_original_workflow_id  -- defined in the API but not server-supported today (and not on the near-term roadmap).
 //   - overlap_buffer_all         -- fires can be queued for arbitrary durations, beyond our 24h query buffer.
 //   - overlap_allow_all          -- scheduler never skips on overlap, so skip_overlap labels may be wrong.
 //   - overlap_cancel_other       -- new fire cancels prior; chain lifecycle differs (likely works, unverified).
@@ -714,7 +778,7 @@ func (a *scheduleAuditor) reanalyzeFromCreate(r scheduleResult, createTime time.
 // later than WindowStart) to suppress false-positive real_miss for schedules that didn't yet exist at the start of the
 // audit window.
 func (a *scheduleAuditor) analyzeSchedule(s scheduleEntry, entries []timelineEntry, expectedStart time.Time) (*scheduleResult, error) {
-	expected, err := expectedFireTimes(s.Spec, s.ID, expectedStart, a.WindowEnd)
+	expected, err := expectedFireTimes(s.Spec, expectedStart, a.WindowEnd)
 	if err != nil {
 		return nil, fmt.Errorf("expected fires for %s: %w", s.ID, err)
 	}

--- a/tools/tdbg/schedule_audit.go
+++ b/tools/tdbg/schedule_audit.go
@@ -21,6 +21,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	schedulepb "go.temporal.io/api/schedule/v1"
+	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/service/worker/scheduler"
 	"google.golang.org/grpc/codes"
@@ -53,11 +54,8 @@ func AdminAuditSchedules(c *cli.Context, factory ClientFactory) error {
 	)
 	var wg sync.WaitGroup
 	for _, ns := range in.Namespaces {
-		ns := ns
-		wg.Add(1)
 		sem <- struct{}{}
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			defer func() { <-sem }()
 			// Bail early if a sibling already failed.
 			mu.Lock()
@@ -68,7 +66,7 @@ func AdminAuditSchedules(c *cli.Context, factory ClientFactory) error {
 			mu.Unlock()
 
 			nsStart := time.Now()
-			fmt.Fprintf(os.Stderr, "auditing %s...\n", ns)
+			_, _ = fmt.Fprintf(os.Stderr, "auditing %s...\n", ns)
 			auditor := &scheduleAuditor{
 				Namespace:   ns,
 				ScheduleID:  in.ScheduleID,
@@ -88,16 +86,16 @@ func AdminAuditSchedules(c *cli.Context, factory ClientFactory) error {
 				return
 			}
 			done++
-			fmt.Fprintf(os.Stderr, "[%d/%d] %s: %d schedule(s) flagged in %s\n",
+			_, _ = fmt.Fprintf(os.Stderr, "[%d/%d] %s: %d schedule(s) flagged in %s\n",
 				done, total, ns, len(results), time.Since(nsStart).Round(time.Second))
 			allResults = append(allResults, results...)
-		}()
+		})
 	}
 	wg.Wait()
 	if firstErr != nil {
 		return firstErr
 	}
-	fmt.Fprintf(os.Stderr, "audit complete: %d total flagged across %d namespaces in %s\n",
+	_, _ = fmt.Fprintf(os.Stderr, "audit complete: %d total flagged across %d namespaces in %s\n",
 		len(allResults), total, time.Since(auditStart).Round(time.Second))
 	if in.OutputDir == "" {
 		// Stdout mode: one CSV stream, all rows, single header, no summary file.
@@ -188,7 +186,7 @@ func resolveNamespaces(c *cli.Context) ([]string, error) {
 			return nil, fmt.Errorf("--namespace-file: %w", err)
 		}
 		var out []string
-		for _, line := range strings.Split(string(data), "\n") {
+		for line := range strings.SplitSeq(string(data), "\n") {
 			line = strings.TrimSpace(line)
 			if line == "" || strings.HasPrefix(line, "#") {
 				continue
@@ -229,7 +227,7 @@ func expectedFireTimes(spec *schedulepb.ScheduleSpec, jitterSeed string, start, 
 		cursor = res.Nominal
 		if len(out) > 100_000 {
 			// Defensive cap -- sub-minute schedules over very large windows could otherwise OOM. Caller should chunk windows.
-			return nil, fmt.Errorf("expected fire times exceeded cap (100k)")
+			return nil, errors.New("expected fire times exceeded cap (100k)")
 		}
 	}
 }
@@ -512,7 +510,7 @@ func (a *scheduleAuditor) checkRetention(ctx context.Context) (bool, error) {
 	if !a.WindowStart.Before(safeStart) {
 		return false, nil
 	}
-	fmt.Fprintf(a.Progress,
+	_, _ = fmt.Fprintf(a.Progress,
 		"    %s: SKIPPING - windowStart %s is past retention boundary (retention=%s, safe-start=%s)\n",
 		a.Namespace,
 		a.WindowStart.UTC().Format(time.RFC3339),
@@ -576,12 +574,9 @@ func (a *scheduleAuditor) analyzeAll(scheds []scheduleEntry, executions map[stri
 	)
 	var wg sync.WaitGroup
 	for _, s := range scheds {
-		s := s
 		entries := executions[s.ID]
-		wg.Add(1)
 		sem <- struct{}{}
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			defer func() { <-sem }()
 			res, err := a.analyzeSchedule(s, entries, a.WindowStart)
 			mu.Lock()
@@ -595,7 +590,7 @@ func (a *scheduleAuditor) analyzeAll(scheds []scheduleEntry, executions map[stri
 			if res != nil {
 				results = append(results, *res)
 			}
-		}()
+		})
 	}
 	wg.Wait()
 	if firstErr != nil {
@@ -641,65 +636,77 @@ func (a *scheduleAuditor) postProcess(ctx context.Context, scheds []scheduleEntr
 			revised = append(revised, r)
 			continue
 		}
-		desc, err := a.Schedules.DescribeSchedule(ctx, a.Namespace, r.ScheduleID)
+		newR, err := a.reclassifyOne(ctx, r, schedByID, executions)
 		if err != nil {
-			// Race: ListSchedules saw this schedule but it was deleted before our post-process call. Drop the row -- we can't
-			// classify real_miss for a schedule that no longer exists.
-			if status.Code(err) == codes.NotFound {
-				fmt.Fprintf(a.Progress, "    %s: %s: deleted between list and describe, dropping row\n",
-					a.Namespace, r.ScheduleID)
-				continue
-			}
-			return nil, fmt.Errorf("describe %s: %w", r.ScheduleID, err)
+			return nil, err
 		}
-		// Record to help correlate real_miss, especially for short catch-ups
-		r.CatchupWindowSeconds = int64(desc.CatchupWindow.Seconds())
-		// Spec modified during window: current spec doesn't describe what was firing pre-modification, so unmatched fires
-		// can't be trusted as real_miss.
-		if !desc.UpdateTime.IsZero() && desc.UpdateTime.After(a.WindowStart) {
-			recategorize(&r, categoryRealMiss, categoryInconclusiveChanged)
-			revised = append(revised, r)
-			continue
+		if newR != nil {
+			revised = append(revised, *newR)
 		}
-		// Exhausted (limited_actions with remaining_actions==0): won't fire anymore even though spec still produces fire
-		// times. Drop.
-		if desc.Exhausted {
-			continue
-		}
-		// Unsupported policy/state: algorithm doesn't fully model these (keepOriginalWorkflowId, BUFFER_ALL, etc). Surface
-		// for manual review but don't claim the misses are real.
-		if desc.UnsupportedReason != "" {
-			recategorize(&r, categoryRealMiss, categoryUnsupportedPolicy)
-			r.UnsupportedReason = desc.UnsupportedReason
-			revised = append(revised, r)
-			continue
-		}
-		// Created after windowEnd: couldn't have fired during the window.
-		if !desc.CreateTime.IsZero() && !desc.CreateTime.Before(a.WindowEnd) {
-			continue
-		}
-		// Created mid-window: re-analyze with truncated expected.
-		if !desc.CreateTime.IsZero() && desc.CreateTime.After(a.WindowStart) {
-			s, ok := schedByID[r.ScheduleID]
-			if !ok {
-				revised = append(revised, r)
-				continue
-			}
-			entries := executions[r.ScheduleID]
-			newR, err := a.analyzeSchedule(s, entries, desc.CreateTime)
-			if err != nil {
-				return nil, fmt.Errorf("re-analyze %s: %w", r.ScheduleID, err)
-			}
-			if newR != nil {
-				newR.CatchupWindowSeconds = r.CatchupWindowSeconds
-				revised = append(revised, *newR)
-			}
-			continue
-		}
-		// Schedule unchanged and pre-existing: result stands.
-		revised = append(revised, r)
 	}
 	return revised, nil
+}
+
+// reclassifyOne applies the post-process rules to a single result with real_miss > 0. Returns (nil, nil) when the row
+// should be dropped (NotFound race, exhausted, or created after windowEnd) and (newRow, nil) when it should be kept
+// (possibly reclassified or re-analyzed against a truncated window).
+func (a *scheduleAuditor) reclassifyOne(ctx context.Context, r scheduleResult, schedByID map[string]scheduleEntry, executions map[string][]timelineEntry) (*scheduleResult, error) {
+	desc, err := a.Schedules.DescribeSchedule(ctx, a.Namespace, r.ScheduleID)
+	if err != nil {
+		// Race: ListSchedules saw this schedule but it was deleted before our post-process call. Drop the row -- we
+		// can't classify real_miss for a schedule that no longer exists.
+		if status.Code(err) == codes.NotFound {
+			_, _ = fmt.Fprintf(a.Progress, "    %s: %s: deleted between list and describe, dropping row\n",
+				a.Namespace, r.ScheduleID)
+			return nil, nil
+		}
+		return nil, fmt.Errorf("describe %s: %w", r.ScheduleID, err)
+	}
+	// Record to help correlate real_miss, especially for short catch-ups
+	r.CatchupWindowSeconds = int64(desc.CatchupWindow.Seconds())
+
+	switch {
+	// Spec modified during window: current spec doesn't describe what was firing pre-modification.
+	case !desc.UpdateTime.IsZero() && desc.UpdateTime.After(a.WindowStart):
+		recategorize(&r, categoryRealMiss, categoryInconclusiveChanged)
+		return &r, nil
+	// Exhausted (limited_actions with remaining_actions==0): won't fire anymore even though spec still produces fire
+	// times. Drop.
+	case desc.Exhausted:
+		return nil, nil
+	// Unsupported policy/state: algorithm doesn't fully model these (keepOriginalWorkflowId, BUFFER_ALL, etc). Surface
+	// for manual review but don't claim the misses are real.
+	case desc.UnsupportedReason != "":
+		recategorize(&r, categoryRealMiss, categoryUnsupportedPolicy)
+		r.UnsupportedReason = desc.UnsupportedReason
+		return &r, nil
+	// Created after windowEnd: couldn't have fired during the window.
+	case !desc.CreateTime.IsZero() && !desc.CreateTime.Before(a.WindowEnd):
+		return nil, nil
+	// Created mid-window: re-analyze with truncated expected.
+	case !desc.CreateTime.IsZero() && desc.CreateTime.After(a.WindowStart):
+		return a.reanalyzeFromCreate(r, desc.CreateTime, schedByID, executions)
+	}
+	// Schedule unchanged and pre-existing: result stands.
+	return &r, nil
+}
+
+// reanalyzeFromCreate handles the "created mid-window" branch: re-runs the per-schedule analysis with expectedStart
+// advanced to the schedule's CreateTime, so phantom expected fires from before the schedule existed are dropped.
+func (a *scheduleAuditor) reanalyzeFromCreate(r scheduleResult, createTime time.Time, schedByID map[string]scheduleEntry, executions map[string][]timelineEntry) (*scheduleResult, error) {
+	s, ok := schedByID[r.ScheduleID]
+	if !ok {
+		return &r, nil
+	}
+	newR, err := a.analyzeSchedule(s, executions[r.ScheduleID], createTime)
+	if err != nil {
+		return nil, fmt.Errorf("re-analyze %s: %w", r.ScheduleID, err)
+	}
+	if newR == nil {
+		return nil, nil
+	}
+	newR.CatchupWindowSeconds = r.CatchupWindowSeconds
+	return newR, nil
 }
 
 // analyzeSchedule runs the audit for a single schedule entry against the pre-fetched timeline entries. expectedStart
@@ -761,7 +768,7 @@ const (
 // do executes f with retry-on-ResourceExhausted. Backoff is exponential with jitter.
 func (t *grpcRetrier) do(ctx context.Context, opName string, f func() error) error {
 	var err error
-	for attempt := 0; attempt < retryMaxAttempts; attempt++ {
+	for attempt := range retryMaxAttempts {
 		err = f()
 		if err == nil {
 			return nil
@@ -776,7 +783,7 @@ func (t *grpcRetrier) do(ctx context.Context, opName string, f func() error) err
 		// attempt is 0-indexed; this is the (attempt+1)-th retry about to start.
 		nextAttempt := attempt + 2
 		if t.log != nil && nextAttempt > retryLogAfterAttempt {
-			fmt.Fprintf(t.log, "    rate limited on %s; sleeping %s before retry %d/%d\n",
+			_, _ = fmt.Fprintf(t.log, "    rate limited on %s; sleeping %s before retry %d/%d\n",
 				opName, wait, nextAttempt, retryMaxAttempts)
 		}
 		select {
@@ -789,10 +796,7 @@ func (t *grpcRetrier) do(ctx context.Context, opName string, f func() error) err
 }
 
 func backoffForAttempt(attempt int) time.Duration {
-	wait := time.Duration(float64(retryInitialBackoff) * math.Pow(2, float64(attempt)))
-	if wait > retryMaxBackoff {
-		wait = retryMaxBackoff
-	}
+	wait := min(time.Duration(float64(retryInitialBackoff)*math.Pow(2, float64(attempt))), retryMaxBackoff)
 	jitter := (rand.Float64()*2 - 1) * retryBackoffJitter
 	return time.Duration(float64(wait) * (1 + jitter))
 }
@@ -956,6 +960,8 @@ func unsupportedPolicyReason(policies *schedulepb.SchedulePolicies) string {
 		// here because the skip_overlap labels were already computed before
 		// post-process and DescribeSchedule isn't called for skip-only rows.
 		reasons = append(reasons, "overlap_allow_all")
+	default:
+		// SKIP, BUFFER_ONE, and UNSPECIFIED are fully modeled; nothing to flag.
 	}
 	return strings.Join(reasons, ";")
 }
@@ -1009,56 +1015,16 @@ func (l *grpcExecutionLoader) paginate(ctx context.Context, namespace, scheduleI
 	var pageToken []byte
 	var page, total, skipped int
 	for {
-		var resp *workflowservice.ListWorkflowExecutionsResponse
-		err := l.retrier.do(ctx, opLabel, func() error {
-			var rpcErr error
-			resp, rpcErr = l.client.ListWorkflowExecutions(ctx, &workflowservice.ListWorkflowExecutionsRequest{
-				Namespace:     namespace,
-				Query:         query,
-				PageSize:      visibilityPageSize,
-				NextPageToken: pageToken,
-			})
-			return rpcErr
-		})
+		resp, err := l.fetchPage(ctx, namespace, query, pageToken, opLabel)
 		if err != nil {
 			return nil, err
 		}
 		page++
-		for _, exec := range resp.GetExecutions() {
-			sa := exec.GetSearchAttributes().GetIndexedFields()
-			scheduleID, ok := decodeScheduledById(sa["TemporalScheduledById"])
-			if !ok || scheduleID == "" {
-				skipped++
-				continue
-			}
-			entry := timelineEntry{
-				WorkflowID: exec.GetExecution().GetWorkflowId(),
-				RunID:      exec.GetExecution().GetRunId(),
-				Status:     exec.GetStatus(),
-			}
-			if st := exec.GetStartTime(); st != nil {
-				entry.StartTime = st.AsTime()
-			}
-			if ct := exec.GetCloseTime(); ct != nil {
-				t := ct.AsTime()
-				entry.CloseTime = &t
-			}
-			if nominal, ok := decodeNominalStartTime(sa["TemporalScheduledStartTime"]); ok {
-				entry.NominalTime = nominal
-			}
-			// Skip rows with neither nominal nor start time - nothing to match.
-			if entry.NominalTime.IsZero() && entry.StartTime.IsZero() {
-				skipped++
-				continue
-			}
-			if entry.NominalTime.IsZero() {
-				entry.NominalTime = entry.StartTime
-			}
-			out[scheduleID] = append(out[scheduleID], entry)
-			total++
-		}
+		added, skip := appendPageEntries(resp, out)
+		total += added
+		skipped += skip
 		if l.log != nil && page%pageProgressEvery == 0 {
-			fmt.Fprintf(l.log, "      %s (%s): page %d, %d entries (%d skipped) across %d schedules\n",
+			_, _ = fmt.Fprintf(l.log, "      %s (%s): page %d, %d entries (%d skipped) across %d schedules\n",
 				namespace, opTag, page, total, skipped, len(out))
 		}
 		if len(resp.GetNextPageToken()) == 0 {
@@ -1068,10 +1034,73 @@ func (l *grpcExecutionLoader) paginate(ctx context.Context, namespace, scheduleI
 	}
 }
 
-// decodeScheduledById extracts the schedule ID from a TemporalScheduledById search-attribute payload. Returns false if
+func (l *grpcExecutionLoader) fetchPage(ctx context.Context, namespace, query string, pageToken []byte, opLabel string) (*workflowservice.ListWorkflowExecutionsResponse, error) {
+	var resp *workflowservice.ListWorkflowExecutionsResponse
+	err := l.retrier.do(ctx, opLabel, func() error {
+		var rpcErr error
+		resp, rpcErr = l.client.ListWorkflowExecutions(ctx, &workflowservice.ListWorkflowExecutionsRequest{
+			Namespace:     namespace,
+			Query:         query,
+			PageSize:      visibilityPageSize,
+			NextPageToken: pageToken,
+		})
+		return rpcErr
+	})
+	return resp, err
+}
+
+// appendPageEntries parses each execution in resp into a timelineEntry and appends it under its TemporalScheduledById bucket
+// in out. Returns (added, skipped) counts for the page.
+func appendPageEntries(resp *workflowservice.ListWorkflowExecutionsResponse, out map[string][]timelineEntry) (added, skipped int) {
+	for _, exec := range resp.GetExecutions() {
+		sa := exec.GetSearchAttributes().GetIndexedFields()
+		scheduleID, ok := decodeScheduledByID(sa["TemporalScheduledById"])
+		if !ok || scheduleID == "" {
+			skipped++
+			continue
+		}
+		entry, ok := buildTimelineEntry(exec, sa)
+		if !ok {
+			skipped++
+			continue
+		}
+		out[scheduleID] = append(out[scheduleID], entry)
+		added++
+	}
+	return added, skipped
+}
+
+// buildTimelineEntry constructs a timelineEntry from one visibility execution. Returns ok=false if the row has neither
+// nominal nor start time, since there's nothing to match against.
+func buildTimelineEntry(exec *workflowpb.WorkflowExecutionInfo, sa map[string]*commonpb.Payload) (timelineEntry, bool) {
+	entry := timelineEntry{
+		WorkflowID: exec.GetExecution().GetWorkflowId(),
+		RunID:      exec.GetExecution().GetRunId(),
+		Status:     exec.GetStatus(),
+	}
+	if st := exec.GetStartTime(); st != nil {
+		entry.StartTime = st.AsTime()
+	}
+	if ct := exec.GetCloseTime(); ct != nil {
+		t := ct.AsTime()
+		entry.CloseTime = &t
+	}
+	if nominal, ok := decodeNominalStartTime(sa["TemporalScheduledStartTime"]); ok {
+		entry.NominalTime = nominal
+	}
+	if entry.NominalTime.IsZero() && entry.StartTime.IsZero() {
+		return timelineEntry{}, false
+	}
+	if entry.NominalTime.IsZero() {
+		entry.NominalTime = entry.StartTime
+	}
+	return entry, true
+}
+
+// decodeScheduledByID extracts the schedule ID from a TemporalScheduledById search-attribute payload. Returns false if
 // the payload is missing or in an unexpected encoding so the caller can skip the row instead of grouping it under an
 // empty key.
-func decodeScheduledById(payload *commonpb.Payload) (string, bool) {
+func decodeScheduledByID(payload *commonpb.Payload) (string, bool) {
 	if payload == nil {
 		return "", false
 	}
@@ -1218,22 +1247,28 @@ func writeOutput(dir string, results []scheduleResult) error {
 			return err
 		}
 		if err := writeFlatCSV(f, rs); err != nil {
-			f.Close()
+			_ = f.Close()
 			return err
 		}
-		f.Close()
+		if err := f.Close(); err != nil {
+			return err
+		}
 	}
 
 	return writeSummaryCSV(filepath.Join(dir, "summary.csv"), byNS)
 }
 
 // writeSummaryCSV emits one row per namespace with aggregated counts across the namespace's flagged schedules.
-func writeSummaryCSV(path string, byNS map[string][]scheduleResult) error {
+func writeSummaryCSV(path string, byNS map[string][]scheduleResult) (retErr error) {
 	f, err := os.Create(path)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); cerr != nil && retErr == nil {
+			retErr = cerr
+		}
+	}()
 	cw := csv.NewWriter(f)
 	defer cw.Flush()
 	if err := cw.Write([]string{

--- a/tools/tdbg/schedule_audit_test.go
+++ b/tools/tdbg/schedule_audit_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -29,6 +30,7 @@ func TestAuditInputs_Validate(t *testing.T) {
 			WindowStart: mustParseTime("2026-05-19T18:00:00Z"),
 			WindowEnd:   mustParseTime("2026-05-19T20:00:00Z"),
 			OutputDir:   "/tmp/out",
+			Format:      formatJSONL,
 		}
 	}
 
@@ -1142,6 +1144,99 @@ func TestWriter_Stdout_FlatCSV(t *testing.T) {
 		require.Contains(t, realMissTimes, "2026-05-19T00:19:00Z", "20th time present")
 		require.NotContains(t, realMissTimes, "2026-05-19T00:20:00Z", "21st time elided")
 		require.Contains(t, realMissTimes, "...+5 more")
+	})
+}
+
+func TestWriter_Stdout_FlatJSONL(t *testing.T) {
+	t.Run("emits one JSON object per line, no header, with structured real_miss_times", func(t *testing.T) {
+		missTime := mustParseTime("2026-05-19T19:00:00Z")
+		skipTime := mustParseTime("2026-05-19T20:00:00Z")
+		results := []scheduleResult{{
+			Namespace: "ns1", ScheduleID: "s1", WorkflowType: "Foo,Bar",
+			CatchupWindowSeconds: 600,
+			Expected:             5, Actual: 4, Matched: 3,
+			Missed: []time.Time{missTime, skipTime},
+			Categories: map[time.Time]string{
+				missTime: categoryRealMiss,
+				skipTime: categorySkipOverlap,
+			},
+			Counts: map[string]int{
+				categoryRealMiss:    1,
+				categorySkipOverlap: 1,
+			},
+		}}
+		var buf bytes.Buffer
+		require.NoError(t, writeFlatJSONL(&buf, results))
+		lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+		require.Len(t, lines, 1)
+		var row flatJSONLRow
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &row))
+		require.Equal(t, flatJSONLRow{
+			Namespace: "ns1", ScheduleID: "s1", WorkflowType: "Foo,Bar", // comma preserved (no CSV escaping needed)
+			Expected: 5, Actual: 4, Matched: 3, Missed: 2,
+			RealMiss: 1, SkipOverlap: 1, InconclusiveScheduleChanged: 0,
+			CatchupWindowSeconds: 600,
+			RealMissTimes:        []string{"2026-05-19T19:00:00Z"},
+		}, row)
+	})
+
+	t.Run("skips results with no missed fires", func(t *testing.T) {
+		results := []scheduleResult{{
+			Namespace: "ns1", ScheduleID: "perfect", WorkflowType: "W",
+			Expected: 5, Actual: 5, Matched: 5, Missed: nil,
+		}}
+		var buf bytes.Buffer
+		require.NoError(t, writeFlatJSONL(&buf, results))
+		require.Empty(t, buf.String(), "no output for results with no misses (no header in JSONL)")
+	})
+
+	t.Run("truncates real_miss_times beyond 20 (no '...+N more' suffix in array form)", func(t *testing.T) {
+		base := mustParseTime("2026-05-19T00:00:00Z")
+		var missed []time.Time
+		categories := map[time.Time]string{}
+		for i := range 25 {
+			tm := base.Add(time.Duration(i) * time.Minute)
+			missed = append(missed, tm)
+			categories[tm] = categoryRealMiss
+		}
+		results := []scheduleResult{{
+			Namespace: "ns1", ScheduleID: "s1", WorkflowType: "W",
+			Expected: 25, Missed: missed, Categories: categories,
+			Counts: map[string]int{categoryRealMiss: 25},
+		}}
+		var buf bytes.Buffer
+		require.NoError(t, writeFlatJSONL(&buf, results))
+		var row flatJSONLRow
+		require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &row))
+		require.Len(t, row.RealMissTimes, 20, "truncated to 20")
+		require.Equal(t, "2026-05-19T00:00:00Z", row.RealMissTimes[0])
+		require.Equal(t, "2026-05-19T00:19:00Z", row.RealMissTimes[19])
+	})
+}
+
+func TestAuditInputs_Validate_Format(t *testing.T) {
+	base := func() *auditInputs {
+		return &auditInputs{
+			Targets:     []auditTarget{{Namespace: "ns"}},
+			WindowStart: mustParseTime("2026-05-19T18:00:00Z"),
+			WindowEnd:   mustParseTime("2026-05-19T20:00:00Z"),
+			Format:      formatJSONL,
+		}
+	}
+	t.Run("jsonl accepted", func(t *testing.T) {
+		in := base()
+		in.Format = formatJSONL
+		require.NoError(t, in.validate())
+	})
+	t.Run("csv accepted", func(t *testing.T) {
+		in := base()
+		in.Format = formatCSV
+		require.NoError(t, in.validate())
+	})
+	t.Run("unknown format rejected", func(t *testing.T) {
+		in := base()
+		in.Format = "yaml"
+		require.ErrorContains(t, in.validate(), `--format "yaml"`)
 	})
 }
 

--- a/tools/tdbg/schedule_audit_test.go
+++ b/tools/tdbg/schedule_audit_test.go
@@ -28,7 +28,6 @@ func TestAuditInputs_Validate(t *testing.T) {
 			Targets:     []auditTarget{{Namespace: "ns"}},
 			WindowStart: mustParseTime("2026-05-19T18:00:00Z"),
 			WindowEnd:   mustParseTime("2026-05-19T20:00:00Z"),
-			MaxWindow:   defaultMaxAuditWindow,
 			OutputDir:   "/tmp/out",
 		}
 	}
@@ -70,36 +69,6 @@ func TestAuditInputs_Validate(t *testing.T) {
 		in := base()
 		in.WindowEnd = in.WindowStart
 		require.ErrorContains(t, in.validate(), "must be after")
-	})
-
-	t.Run("window at default cap accepted", func(t *testing.T) {
-		in := base()
-		in.WindowEnd = in.WindowStart.Add(defaultMaxAuditWindow)
-		require.NoError(t, in.validate())
-	})
-
-	t.Run("window over default cap rejected with override hint", func(t *testing.T) {
-		in := base()
-		in.WindowEnd = in.WindowStart.Add(defaultMaxAuditWindow + time.Second)
-		err := in.validate()
-		require.ErrorContains(t, err, "max is 168h")
-		require.ErrorContains(t, err, "Pass --max-window=")
-	})
-
-	t.Run("raised --max-window accepts wider window", func(t *testing.T) {
-		in := base()
-		in.MaxWindow = 400 * 24 * time.Hour
-		in.WindowEnd = in.WindowStart.Add(365 * 24 * time.Hour)
-		require.NoError(t, in.validate())
-	})
-
-	t.Run("--max-window still bounds the window", func(t *testing.T) {
-		in := base()
-		in.MaxWindow = 30 * 24 * time.Hour
-		in.WindowEnd = in.WindowStart.Add(31 * 24 * time.Hour)
-		err := in.validate()
-		require.ErrorContains(t, err, "max is 720h")
-		require.ErrorContains(t, err, "Pass --max-window=")
 	})
 }
 
@@ -552,7 +521,7 @@ func TestClassifyFirings(t *testing.T) {
 			NominalTime: mustParseTime("2026-05-19T19:00:00Z"),
 		})
 		res := &scheduleResult{}
-		classifyFirings(res, expectedFires, tl)
+		classifyFirings(res, expectedFires, tl, nil)
 		require.Equal(t, 2, res.Matched)
 		require.Empty(t, res.Missed)
 	})
@@ -573,7 +542,7 @@ func TestClassifyFirings(t *testing.T) {
 			NominalTime: mustParseTime("2026-05-19T18:00:00Z"),
 		})
 		res := &scheduleResult{}
-		classifyFirings(res, expectedFires, tl)
+		classifyFirings(res, expectedFires, tl, nil)
 		require.Equal(t, 1, res.Matched)
 		require.Len(t, res.Missed, 1)
 		require.Equal(t, "real_miss", res.Categories[res.Missed[0]])
@@ -593,21 +562,18 @@ func TestClassifyFirings(t *testing.T) {
 			NominalTime: mustParseTime("2026-05-19T18:00:00Z"),
 		})
 		res := &scheduleResult{}
-		classifyFirings(res, expectedFires, tl)
+		classifyFirings(res, expectedFires, tl, nil)
 		require.Equal(t, "skip_overlap", res.Categories[mustParseTime("2026-05-19T19:00:00Z")])
 	})
 }
 
 type fakeScheduleLoader struct {
+	// entries is the set of schedules the loader returns. Tests populate every field they care about
+	// (Spec, Policies, CreateTime, UpdateTime, Exhausted, Paused, CatchupWindow) directly on each entry, since
+	// the audit consumes a single source of describe-derived data per schedule.
 	entries []scheduleEntry
-	// describes, if set, returns these from DescribeSchedule. Lets tests model schedules created or modified after the
-	// audit window starts.
-	describes map[string]scheduleDescription
-	// describeErrors, if set for a given scheduleID, makes DescribeSchedule return that error instead of looking up
-	// a normal description. Used to model the "deleted between list and describe" race.
-	describeErrors map[string]error
-	// retention, if non-zero, is returned by NamespaceRetention. Defaults to 0, which the auditor treats as "no retention
-	// guard" -- fine for most tests that use synthetic times.
+	// retention, if non-zero, is returned by NamespaceRetention. Defaults to 0, which the auditor treats as
+	// "no retention guard" -- fine for most tests that use synthetic times.
 	retention time.Duration
 }
 
@@ -622,16 +588,6 @@ func (f *fakeScheduleLoader) LookupSchedule(_ context.Context, _, scheduleID str
 		}
 	}
 	return scheduleEntry{}, status.Error(codes.NotFound, "schedule not found")
-}
-
-func (f *fakeScheduleLoader) DescribeSchedule(_ context.Context, _, scheduleID string) (scheduleDescription, error) {
-	if err, ok := f.describeErrors[scheduleID]; ok {
-		return scheduleDescription{}, err
-	}
-	if f.describes == nil {
-		return scheduleDescription{}, nil
-	}
-	return f.describes[scheduleID], nil
 }
 
 func (f *fakeScheduleLoader) NamespaceRetention(_ context.Context, _ string) (time.Duration, error) {
@@ -932,25 +888,16 @@ func TestScheduleAuditor(t *testing.T) {
 		require.Equal(t, 3, r.Counts["skip_overlap"], "every fire should be skip_overlap")
 	})
 
-	t.Run("postProcess: created after windowEnd excluded from results", func(t *testing.T) {
-		spec := &schedulepb.ScheduleSpec{
-			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{
-				{
-					Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
-					Minute:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
-					Hour:       []*schedulepb.Range{{Start: 0, End: 23, Step: 1}},
-					DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
-					Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
-					DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
-				},
-			},
-		}
+	t.Run("created after windowEnd excluded from results", func(t *testing.T) {
+		spec := hourlyAllHoursSpec()
 		loader := &fakeScheduleLoader{
-			entries: []scheduleEntry{{ID: "s1", Spec: spec, WorkflowType: "W"}},
-			describes: map[string]scheduleDescription{
+			entries: []scheduleEntry{{
+				ID:           "s1",
+				Spec:         spec,
+				WorkflowType: "W",
 				// Created one day after the window ends.
-				"s1": {CreateTime: mustParseTime("2026-05-21T00:00:00Z")},
-			},
+				CreateTime: mustParseTime("2026-05-21T00:00:00Z"),
+			}},
 		}
 		exec := &fakeExecutionLoader{byScheduleID: map[string][]timelineEntry{}}
 		a := &scheduleAuditor{
@@ -966,25 +913,16 @@ func TestScheduleAuditor(t *testing.T) {
 		require.Empty(t, results, "schedule was created after windowEnd, should produce no result")
 	})
 
-	t.Run("postProcess: created mid-window truncates expected", func(t *testing.T) {
-		spec := &schedulepb.ScheduleSpec{
-			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{
-				{
-					Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
-					Minute:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
-					Hour:       []*schedulepb.Range{{Start: 0, End: 23, Step: 1}},
-					DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
-					Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
-					DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
-				},
-			},
-		}
+	t.Run("created mid-window truncates expected", func(t *testing.T) {
+		spec := hourlyAllHoursSpec()
 		loader := &fakeScheduleLoader{
-			entries: []scheduleEntry{{ID: "s1", Spec: spec, WorkflowType: "W"}},
-			// Created in the middle of a 4-hour window (18:00 - 22:00).
-			describes: map[string]scheduleDescription{
-				"s1": {CreateTime: mustParseTime("2026-05-19T20:30:00Z")},
-			},
+			entries: []scheduleEntry{{
+				ID:           "s1",
+				Spec:         spec,
+				WorkflowType: "W",
+				// Created in the middle of a 4-hour window (18:00 - 22:00).
+				CreateTime: mustParseTime("2026-05-19T20:30:00Z"),
+			}},
 		}
 		exec := &fakeExecutionLoader{byScheduleID: map[string][]timelineEntry{}}
 		a := &scheduleAuditor{
@@ -999,34 +937,23 @@ func TestScheduleAuditor(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, results, 1)
 		r := results[0]
-		// First-pass would have flagged 4 expected (19:00, 20:00, 21:00, 22:00) all real_miss. Re-analysis with
-		// createTime=20:30 truncates to fires at 21:00 and 22:00 only -> 2 real_miss.
+		// expectedStart is advanced to CreateTime=20:30, dropping the 19:00 and 20:00 phantom fires. Only 21:00
+		// and 22:00 remain expected; with no observed workflows both are real_miss.
 		require.Equal(t, 2, r.Counts["real_miss"],
 			"expected 2 real_miss (21:00, 22:00); 19:00 and 20:00 were pre-creation and shouldn't count")
 	})
 
-	t.Run("postProcess: modified during window -> inconclusive", func(t *testing.T) {
-		spec := &schedulepb.ScheduleSpec{
-			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{
-				{
-					Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
-					Minute:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
-					Hour:       []*schedulepb.Range{{Start: 0, End: 23, Step: 1}},
-					DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
-					Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
-					DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
-				},
-			},
-		}
+	t.Run("modified during window -> inconclusive", func(t *testing.T) {
+		spec := hourlyAllHoursSpec()
 		loader := &fakeScheduleLoader{
-			entries: []scheduleEntry{{ID: "s1", Spec: spec, WorkflowType: "W"}},
-			describes: map[string]scheduleDescription{
+			entries: []scheduleEntry{{
+				ID:           "s1",
+				Spec:         spec,
+				WorkflowType: "W",
 				// Created well before window, but spec updated mid-window.
-				"s1": {
-					CreateTime: mustParseTime("2026-01-01T00:00:00Z"),
-					UpdateTime: mustParseTime("2026-05-19T19:30:00Z"),
-				},
-			},
+				CreateTime: mustParseTime("2026-01-01T00:00:00Z"),
+				UpdateTime: mustParseTime("2026-05-19T19:30:00Z"),
+			}},
 		}
 		exec := &fakeExecutionLoader{byScheduleID: map[string][]timelineEntry{}}
 		a := &scheduleAuditor{
@@ -1037,38 +964,27 @@ func TestScheduleAuditor(t *testing.T) {
 			Executions:  exec,
 			Progress:    io.Discard,
 		}
-		// With no executions and 4 expected hourly fires (19:00, 20:00, 21:00, 22:00), the initial analysis would produce 4
-		// real_miss. Because the spec was updated mid-window, all 4 should be moved to inconclusive_schedule_changed.
+		// With no executions and 4 expected hourly fires (19:00, 20:00, 21:00, 22:00), because the spec was updated
+		// mid-window, all 4 should be marked inconclusive_schedule_changed (the current spec can't be trusted to
+		// describe what was firing earlier).
 		results, err := a.run(context.Background())
 		require.NoError(t, err)
 		require.Len(t, results, 1)
 		r := results[0]
-		require.Zero(t, r.Counts["real_miss"], "expected real_miss reclassified")
+		require.Zero(t, r.Counts["real_miss"], "expected no real_miss (spec changed in window)")
 		require.Equal(t, 4, r.Counts["inconclusive_schedule_changed"])
 	})
 
-	t.Run("postProcess: exhausted excluded from results", func(t *testing.T) {
-		spec := &schedulepb.ScheduleSpec{
-			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{
-				{
-					Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
-					Minute:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
-					Hour:       []*schedulepb.Range{{Start: 0, End: 23, Step: 1}},
-					DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
-					Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
-					DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
-				},
-			},
-		}
+	t.Run("exhausted excluded from results", func(t *testing.T) {
+		spec := hourlyAllHoursSpec()
 		loader := &fakeScheduleLoader{
-			entries: []scheduleEntry{{ID: "s1", Spec: spec, WorkflowType: "W"}},
-			describes: map[string]scheduleDescription{
-				// Pre-existing schedule, never modified, but exhausted.
-				"s1": {
-					CreateTime: mustParseTime("2026-01-01T00:00:00Z"),
-					Exhausted:  true,
-				},
-			},
+			entries: []scheduleEntry{{
+				ID:           "s1",
+				Spec:         spec,
+				WorkflowType: "W",
+				CreateTime:   mustParseTime("2026-01-01T00:00:00Z"),
+				Exhausted:    true,
+			}},
 		}
 		exec := &fakeExecutionLoader{byScheduleID: map[string][]timelineEntry{}}
 		a := &scheduleAuditor{
@@ -1084,29 +1000,41 @@ func TestScheduleAuditor(t *testing.T) {
 		require.Empty(t, results, "exhausted schedule should be dropped")
 	})
 
-	t.Run("postProcess: unsupported policy -> unsupported bucket", func(t *testing.T) {
-		spec := &schedulepb.ScheduleSpec{
-			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{
+	t.Run("ALLOW_ALL: unmatched fires labeled real_miss (skip_overlap heuristic bypassed)", func(t *testing.T) {
+		spec := hourlyAllHoursSpec()
+		// Two concurrent workflows are active across the audit window -- under the old heuristic these would have
+		// caused unmatched fires to be mis-labeled as skip_overlap. With policy-aware classification, ALLOW_ALL
+		// schedules bypass the heuristic and label unmatched fires as real_miss directly.
+		closeTime := mustParseTime("2026-05-19T23:30:00Z")
+		exec := &fakeExecutionLoader{byScheduleID: map[string][]timelineEntry{
+			"s1": {
 				{
-					Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
-					Minute:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
-					Hour:       []*schedulepb.Range{{Start: 0, End: 23, Step: 1}},
-					DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
-					Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
-					DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
+					WorkflowID:  "concurrent-A",
+					StartTime:   mustParseTime("2026-05-19T17:00:00Z"),
+					CloseTime:   &closeTime,
+					Status:      enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+					NominalTime: mustParseTime("2026-05-19T17:00:00Z"),
+				},
+				{
+					WorkflowID:  "concurrent-B",
+					StartTime:   mustParseTime("2026-05-19T17:30:00Z"),
+					CloseTime:   &closeTime,
+					Status:      enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+					NominalTime: mustParseTime("2026-05-19T17:30:00Z"),
 				},
 			},
-		}
+		}}
 		loader := &fakeScheduleLoader{
-			entries: []scheduleEntry{{ID: "s1", Spec: spec, WorkflowType: "W"}},
-			describes: map[string]scheduleDescription{
-				"s1": {
-					CreateTime:        mustParseTime("2026-01-01T00:00:00Z"),
-					UnsupportedReason: "overlap_buffer_all",
+			entries: []scheduleEntry{{
+				ID:           "s1",
+				Spec:         spec,
+				WorkflowType: "W",
+				CreateTime:   mustParseTime("2026-01-01T00:00:00Z"),
+				Policies: &schedulepb.SchedulePolicies{
+					OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
 				},
-			},
+			}},
 		}
-		exec := &fakeExecutionLoader{byScheduleID: map[string][]timelineEntry{}}
 		a := &scheduleAuditor{
 			Namespace:   "ns",
 			WindowStart: mustParseTime("2026-05-19T18:00:00Z"),
@@ -1119,49 +1047,27 @@ func TestScheduleAuditor(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, results, 1)
 		r := results[0]
-		require.Zero(t, r.Counts["real_miss"], "real_miss reclassified")
-		require.Equal(t, 4, r.Counts["unsupported_policy"])
-		require.Equal(t, "overlap_buffer_all", r.UnsupportedReason)
+		require.Equal(t, 4, r.Counts["real_miss"], "all 4 unmatched fires should be real_miss under ALLOW_ALL")
+		require.Zero(t, r.Counts["skip_overlap"], "no skip_overlap labels for ALLOW_ALL")
 	})
 
-	t.Run("postProcess: NotFound race (deleted between list and describe)", func(t *testing.T) {
-		// Hourly spec; window contains 19:00 and 20:00. With no executions, both are real_miss -> postProcess runs.
-		spec := &schedulepb.ScheduleSpec{
-			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{
-				{
-					Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
-					Minute:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
-					Hour:       []*schedulepb.Range{{Start: 0, End: 23, Step: 1}},
-					DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
-					Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
-					DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
-				},
+}
+
+// hourlyAllHoursSpec returns a ScheduleSpec that fires at the top of every hour, every day, every month -- used
+// by integration tests as a simple deterministic generator of expected fire times.
+func hourlyAllHoursSpec() *schedulepb.ScheduleSpec {
+	return &schedulepb.ScheduleSpec{
+		StructuredCalendar: []*schedulepb.StructuredCalendarSpec{
+			{
+				Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+				Minute:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+				Hour:       []*schedulepb.Range{{Start: 0, End: 23, Step: 1}},
+				DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
+				Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
+				DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
 			},
-		}
-		loader := &fakeScheduleLoader{
-			entries: []scheduleEntry{
-				{ID: "deleted", Spec: spec, WorkflowType: "W"},
-				{ID: "alive", Spec: spec, WorkflowType: "W"},
-			},
-			describeErrors: map[string]error{
-				// "deleted" returns NotFound when postProcess calls DescribeSchedule.
-				"deleted": status.Error(codes.NotFound, "schedule not found"),
-			},
-		}
-		a := &scheduleAuditor{
-			Namespace:   "ns",
-			WindowStart: mustParseTime("2026-05-19T18:30:00Z"),
-			WindowEnd:   mustParseTime("2026-05-19T20:30:00Z"),
-			Schedules:   loader,
-			Executions:  &fakeExecutionLoader{},
-			Progress:    io.Discard,
-		}
-		results, err := a.run(context.Background())
-		require.NoError(t, err, "NotFound during postProcess must not propagate as an error")
-		// "deleted" gets dropped silently; "alive" gets describe -> no UpdateTime/Exhausted/etc. -> row stands.
-		require.Len(t, results, 1)
-		require.Equal(t, "alive", results[0].ScheduleID)
-	})
+		},
+	}
 }
 
 func TestWriter_Stdout_FlatCSV(t *testing.T) {
@@ -1170,8 +1076,8 @@ func TestWriter_Stdout_FlatCSV(t *testing.T) {
 		skipTime := mustParseTime("2026-05-19T20:00:00Z")
 		results := []scheduleResult{{
 			Namespace: "ns1", ScheduleID: "s1", WorkflowType: "Foo,Bar",
-			JitterSeconds: 30, CatchupWindowSeconds: 600,
-			Expected: 5, Actual: 4, Matched: 3,
+			CatchupWindowSeconds: 600,
+			Expected:             5, Actual: 4, Matched: 3,
 			Missed: []time.Time{missTime, skipTime},
 			Categories: map[time.Time]string{
 				missTime: categoryRealMiss,
@@ -1181,7 +1087,6 @@ func TestWriter_Stdout_FlatCSV(t *testing.T) {
 				categoryRealMiss:    1,
 				categorySkipOverlap: 1,
 			},
-			UnsupportedReason: "",
 		}}
 		var buf bytes.Buffer
 		require.NoError(t, writeFlatCSV(&buf, results))
@@ -1191,11 +1096,9 @@ func TestWriter_Stdout_FlatCSV(t *testing.T) {
 		require.Equal(t, flatCSVBaseHeader, rows[0])
 		require.Equal(t, []string{
 			"ns1", "s1", "Foo;Bar", // comma in workflow type sanitized to semicolon
-			"30",          // jitter_s
 			"5", "4", "3", // expected, actual, matched
-			"2",                // missed
-			"1", "1", "0", "0", // real_miss, skip_overlap, inconclusive, unsupported
-			"",                     // unsupported_reason
+			"2",           // missed
+			"1", "1", "0", // real_miss, skip_overlap, inconclusive
 			"600",                  // catchup_window_s
 			"2026-05-19T19:00:00Z", // real_miss_times: only the real_miss, not the skip
 		}, rows[1])
@@ -1242,69 +1145,30 @@ func TestWriter_Stdout_FlatCSV(t *testing.T) {
 	})
 }
 
-// TestUnsupportedPolicyReason exercises every policy/state combination unsupportedPolicyReason recognizes, plus the
-// nil-policies and supported-policies cases that must return empty.
-func TestUnsupportedPolicyReason(t *testing.T) {
+// TestNeverSkipsByPolicy verifies the helper that decides whether classifyFirings should bypass its skip_overlap
+// heuristic. ALLOW_ALL / CANCEL_OTHER / TERMINATE_OTHER never policy-skip; everything else does (or might).
+func TestNeverSkipsByPolicy(t *testing.T) {
 	cases := []struct {
 		name     string
 		policies *schedulepb.SchedulePolicies
-		expected string
+		want     bool
 	}{
-		{"nil policies", nil, ""},
-		{"default SKIP (unspecified)", &schedulepb.SchedulePolicies{}, ""},
-		{
-			"explicit SKIP",
-			&schedulepb.SchedulePolicies{OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP},
-			"",
-		},
-		{
-			"BUFFER_ONE is supported",
-			&schedulepb.SchedulePolicies{OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE},
-			"",
-		},
-		{
-			"BUFFER_ALL flagged",
-			&schedulepb.SchedulePolicies{OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL},
-			"overlap_buffer_all",
-		},
-		{
-			"ALLOW_ALL flagged",
-			&schedulepb.SchedulePolicies{OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL},
-			"overlap_allow_all",
-		},
-		{
-			"CANCEL_OTHER flagged",
-			&schedulepb.SchedulePolicies{OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_CANCEL_OTHER},
-			"overlap_cancel_other",
-		},
-		{
-			"TERMINATE_OTHER flagged",
-			&schedulepb.SchedulePolicies{OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_TERMINATE_OTHER},
-			"overlap_terminate_other",
-		},
-		{
-			"KeepOriginalWorkflowId only",
-			&schedulepb.SchedulePolicies{KeepOriginalWorkflowId: true},
-			"keep_original_workflow_id",
-		},
-		{
-			"KeepOriginalWorkflowId + BUFFER_ALL joined with semicolon",
-			&schedulepb.SchedulePolicies{
-				KeepOriginalWorkflowId: true,
-				OverlapPolicy:          enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL,
-			},
-			"keep_original_workflow_id;overlap_buffer_all",
-		},
+		{"nil policies (default SKIP)", nil, false},
+		{"unspecified", &schedulepb.SchedulePolicies{}, false},
+		{"SKIP", &schedulepb.SchedulePolicies{OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP}, false},
+		{"BUFFER_ONE", &schedulepb.SchedulePolicies{OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE}, false},
+		{"BUFFER_ALL", &schedulepb.SchedulePolicies{OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL}, false},
+		{"ALLOW_ALL", &schedulepb.SchedulePolicies{OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL}, true},
+		{"CANCEL_OTHER", &schedulepb.SchedulePolicies{OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_CANCEL_OTHER}, true},
+		{"TERMINATE_OTHER", &schedulepb.SchedulePolicies{OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_TERMINATE_OTHER}, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expected, unsupportedPolicyReason(tc.policies))
+			require.Equal(t, tc.want, neverSkipsByPolicy(tc.policies))
 		})
 	}
 }
 
-// TestPostProcess_NotFoundRace exercises the race-handling branch where DescribeSchedule returns NotFound for a
-// schedule that ListSchedules saw moments earlier. The row should be silently dropped (no error returned).
 // TestDecodePayloads covers the skip-on-failure contract of decodeScheduledByID and decodeNominalStartTime so the
 // caller can drop visibility rows with malformed search-attribute payloads instead of grouping them under empty keys.
 func TestDecodePayloads(t *testing.T) {

--- a/tools/tdbg/schedule_audit_test.go
+++ b/tools/tdbg/schedule_audit_test.go
@@ -1,0 +1,1187 @@
+package tdbg
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	schedulepb "go.temporal.io/api/schedule/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestAuditInputs_Validate(t *testing.T) {
+	base := func() *auditInputs {
+		return &auditInputs{
+			Namespaces:  []string{"ns"},
+			WindowStart: mustParseTime("2026-05-19T18:00:00Z"),
+			WindowEnd:   mustParseTime("2026-05-19T20:00:00Z"),
+			OutputDir:   "/tmp/out",
+		}
+	}
+
+	t.Run("valid passes", func(t *testing.T) {
+		require.NoError(t, base().validate())
+	})
+
+	t.Run("missing output-dir accepted (stdout mode)", func(t *testing.T) {
+		in := base()
+		in.OutputDir = ""
+		require.NoError(t, in.validate())
+	})
+
+	t.Run("schedule-id requires single namespace", func(t *testing.T) {
+		in := base()
+		in.ScheduleID = "sched1"
+		in.Namespaces = []string{"ns1", "ns2"}
+		require.ErrorContains(t, in.validate(), "--schedule-id requires exactly one namespace")
+	})
+
+	t.Run("schedule-id with one namespace OK", func(t *testing.T) {
+		in := base()
+		in.ScheduleID = "sched1"
+		require.NoError(t, in.validate())
+	})
+
+	t.Run("end must be after start", func(t *testing.T) {
+		in := base()
+		in.WindowStart = mustParseTime("2026-05-19T20:00:00Z")
+		in.WindowEnd = mustParseTime("2026-05-19T18:00:00Z")
+		require.ErrorContains(t, in.validate(), "must be after")
+	})
+
+	t.Run("end == start rejected", func(t *testing.T) {
+		in := base()
+		in.WindowEnd = in.WindowStart
+		require.ErrorContains(t, in.validate(), "must be after")
+	})
+
+	t.Run("window at 7d cap accepted", func(t *testing.T) {
+		in := base()
+		in.WindowEnd = in.WindowStart.Add(7 * 24 * time.Hour)
+		require.NoError(t, in.validate())
+	})
+
+	t.Run("window over 7d cap rejected", func(t *testing.T) {
+		in := base()
+		in.WindowEnd = in.WindowStart.Add(7*24*time.Hour + time.Second)
+		require.ErrorContains(t, in.validate(), "max is 168h")
+	})
+
+}
+
+func TestAuditCommandIsRegistered(t *testing.T) {
+	app := NewCliApp()
+	var found bool
+	for _, top := range app.Commands {
+		if top.Name != "schedule" {
+			continue
+		}
+		for _, ss := range top.Subcommands {
+			if ss.Name == "audit" {
+				found = true
+				break
+			}
+		}
+	}
+	require.True(t, found, "audit subcommand not registered under schedule")
+}
+
+func TestExpectedFireTimes(t *testing.T) {
+	hourlyStructured := func() *schedulepb.StructuredCalendarSpec {
+		return &schedulepb.StructuredCalendarSpec{
+			Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+			Minute:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+			Hour:       []*schedulepb.Range{{Start: 0, End: 23, Step: 1}},
+			DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
+			Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
+			DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
+		}
+	}
+
+	t.Run("hourly", func(t *testing.T) {
+		spec := &schedulepb.ScheduleSpec{
+			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{hourlyStructured()},
+		}
+		start := time.Date(2026, 5, 19, 18, 0, 0, 0, time.UTC)
+		end := time.Date(2026, 5, 19, 23, 0, 0, 0, time.UTC)
+
+		actual, err := expectedFireTimes(spec, "schedid", start, end)
+		require.NoError(t, err)
+
+		expected := []time.Time{
+			time.Date(2026, 5, 19, 19, 0, 0, 0, time.UTC),
+			time.Date(2026, 5, 19, 20, 0, 0, 0, time.UTC),
+			time.Date(2026, 5, 19, 21, 0, 0, 0, time.UTC),
+			time.Date(2026, 5, 19, 22, 0, 0, 0, time.UTC),
+			time.Date(2026, 5, 19, 23, 0, 0, 0, time.UTC),
+		}
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("every 15 min", func(t *testing.T) {
+		spec := &schedulepb.ScheduleSpec{
+			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{
+				{
+					Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Minute:     []*schedulepb.Range{{Start: 0, End: 59, Step: 15}},
+					Hour:       []*schedulepb.Range{{Start: 0, End: 23, Step: 1}},
+					DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
+					Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
+					DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
+				},
+			},
+		}
+		start := time.Date(2026, 5, 19, 18, 0, 0, 0, time.UTC)
+		end := time.Date(2026, 5, 19, 19, 0, 0, 0, time.UTC)
+		actual, err := expectedFireTimes(spec, "x", start, end)
+		require.NoError(t, err)
+
+		expected := []time.Time{
+			time.Date(2026, 5, 19, 18, 15, 0, 0, time.UTC),
+			time.Date(2026, 5, 19, 18, 30, 0, 0, time.UTC),
+			time.Date(2026, 5, 19, 18, 45, 0, 0, time.UTC),
+			time.Date(2026, 5, 19, 19, 0, 0, 0, time.UTC),
+		}
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("cron_string hourly", func(t *testing.T) {
+		spec := &schedulepb.ScheduleSpec{
+			CronString: []string{"0 * * * *"},
+		}
+		actual, err := expectedFireTimes(spec, "sid",
+			mustParseTime("2026-05-19T18:00:00Z"),
+			mustParseTime("2026-05-19T21:00:00Z"))
+		require.NoError(t, err)
+		require.Equal(t, []time.Time{
+			mustParseTime("2026-05-19T19:00:00Z"),
+			mustParseTime("2026-05-19T20:00:00Z"),
+			mustParseTime("2026-05-19T21:00:00Z"),
+		}, actual)
+	})
+
+	t.Run("legacy calendar daily at 09:00", func(t *testing.T) {
+		spec := &schedulepb.ScheduleSpec{
+			Calendar: []*schedulepb.CalendarSpec{{
+				Hour:   "9",
+				Minute: "0",
+				Second: "0",
+			}},
+		}
+		actual, err := expectedFireTimes(spec, "sid",
+			mustParseTime("2026-05-19T00:00:00Z"),
+			mustParseTime("2026-05-21T12:00:00Z"))
+		require.NoError(t, err)
+		require.Equal(t, []time.Time{
+			mustParseTime("2026-05-19T09:00:00Z"),
+			mustParseTime("2026-05-20T09:00:00Z"),
+			mustParseTime("2026-05-21T09:00:00Z"),
+		}, actual)
+	})
+
+	t.Run("exclude_structured_calendar drops hour 2", func(t *testing.T) {
+		spec := &schedulepb.ScheduleSpec{
+			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{hourlyStructured()},
+			ExcludeStructuredCalendar: []*schedulepb.StructuredCalendarSpec{{
+				Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+				Minute:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+				Hour:       []*schedulepb.Range{{Start: 2, End: 2, Step: 1}},
+				DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
+				Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
+				DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
+			}},
+		}
+		actual, err := expectedFireTimes(spec, "sid",
+			mustParseTime("2026-05-19T00:30:00Z"),
+			mustParseTime("2026-05-19T04:00:00Z"))
+		require.NoError(t, err)
+		// 02:00 is excluded; 01:00, 03:00, 04:00 fire.
+		require.Equal(t, []time.Time{
+			mustParseTime("2026-05-19T01:00:00Z"),
+			mustParseTime("2026-05-19T03:00:00Z"),
+			mustParseTime("2026-05-19T04:00:00Z"),
+		}, actual)
+	})
+
+	t.Run("timezone_name shifts daily fire to UTC offset", func(t *testing.T) {
+		// Daily at 9 AM Pacific. May is DST (UTC-7) so 9 AM PT = 16:00 UTC.
+		spec := &schedulepb.ScheduleSpec{
+			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{{
+				Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+				Minute:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+				Hour:       []*schedulepb.Range{{Start: 9, End: 9, Step: 1}},
+				DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
+				Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
+				DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
+			}},
+			TimezoneName: "America/Los_Angeles",
+		}
+		actual, err := expectedFireTimes(spec, "sid",
+			mustParseTime("2026-05-19T00:00:00Z"),
+			mustParseTime("2026-05-20T00:00:00Z"))
+		require.NoError(t, err)
+		require.Equal(t, []time.Time{mustParseTime("2026-05-19T16:00:00Z")}, actual)
+	})
+
+	t.Run("DST spring-forward records compiler behavior", func(t *testing.T) {
+		// US spring-forward 2026: March 8 at 02:00 AM ET -> 03:00 AM ET. Hour 2:30 doesn't exist locally on March 8. We don't
+		// assert a specific outcome -- the compiler may skip, advance, or duplicate. What we want is for the result to be
+		// stable across runs.
+		spec := &schedulepb.ScheduleSpec{
+			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{{
+				Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+				Minute:     []*schedulepb.Range{{Start: 30, End: 30, Step: 1}},
+				Hour:       []*schedulepb.Range{{Start: 2, End: 2, Step: 1}},
+				DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
+				Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
+				DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
+			}},
+			TimezoneName: "America/New_York",
+		}
+		actual, err := expectedFireTimes(spec, "sid",
+			mustParseTime("2026-03-07T00:00:00Z"),
+			mustParseTime("2026-03-11T00:00:00Z"))
+		require.NoError(t, err)
+		// March 7 and March 9-10 produce normal fires (one each). March 8's 02:30 ET fire is in the DST gap; the compiler
+		// should not produce a fire for that day. So we expect 3 fires across 4 calendar days.
+		require.Len(t, actual, 3, "DST gap day should not produce a fire")
+	})
+
+	t.Run("end_time in past returns no fires", func(t *testing.T) {
+		spec := &schedulepb.ScheduleSpec{
+			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{hourlyStructured()},
+			EndTime:            timestamppb.New(mustParseTime("2026-01-01T00:00:00Z")),
+		}
+		actual, err := expectedFireTimes(spec, "sid",
+			mustParseTime("2026-05-19T18:00:00Z"),
+			mustParseTime("2026-05-19T22:00:00Z"))
+		require.NoError(t, err)
+		require.Empty(t, actual)
+	})
+
+	t.Run("start_time in future returns no fires", func(t *testing.T) {
+		spec := &schedulepb.ScheduleSpec{
+			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{hourlyStructured()},
+			StartTime:          timestamppb.New(mustParseTime("2027-01-01T00:00:00Z")),
+		}
+		actual, err := expectedFireTimes(spec, "sid",
+			mustParseTime("2026-05-19T18:00:00Z"),
+			mustParseTime("2026-05-19T22:00:00Z"))
+		require.NoError(t, err)
+		require.Empty(t, actual)
+	})
+
+	t.Run("interval with phase produces 15-min cadence offset by phase", func(t *testing.T) {
+		spec := &schedulepb.ScheduleSpec{
+			Interval: []*schedulepb.IntervalSpec{{
+				Interval: durationpb.New(15 * time.Minute),
+				Phase:    durationpb.New(6*time.Minute + 7*time.Second),
+			}},
+		}
+		actual, err := expectedFireTimes(spec, "sid",
+			mustParseTime("2026-05-19T18:00:00Z"),
+			mustParseTime("2026-05-19T19:00:00Z"))
+		require.NoError(t, err)
+		require.NotEmpty(t, actual)
+		for i := 1; i < len(actual); i++ {
+			require.Equal(t, 15*time.Minute, actual[i].Sub(actual[i-1]),
+				"consecutive fires must be exactly 15min apart")
+		}
+		// Phase = 6m7s means every fire's (unix_seconds - 367) is a multiple of 900. Spot-check the first one.
+		first := actual[0]
+		require.Equal(t, int64(0), (first.Unix()-367)%900,
+			"fire %s does not align with phase=6m7s", first.Format(time.RFC3339))
+	})
+}
+
+func TestTimeline(t *testing.T) {
+	t.Run("ActiveAt: still running", func(t *testing.T) {
+		tl := &timeline{byWorkflowID: map[string]*workflowChain{}}
+		tl.addExecution(timelineEntry{
+			WorkflowID:  "wf1",
+			StartTime:   mustParseTime("2026-05-19T18:00:00Z"),
+			Status:      enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			NominalTime: mustParseTime("2026-05-19T18:00:00Z"),
+		})
+		require.Len(t, tl.activeAt(mustParseTime("2026-05-19T19:00:00Z")), 1)
+	})
+
+	t.Run("ActiveAt: closed before query time", func(t *testing.T) {
+		tl := &timeline{byWorkflowID: map[string]*workflowChain{}}
+		closeTime := mustParseTime("2026-05-19T18:30:00Z")
+		tl.addExecution(timelineEntry{
+			WorkflowID:  "wf1",
+			StartTime:   mustParseTime("2026-05-19T18:00:00Z"),
+			CloseTime:   &closeTime,
+			Status:      enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			NominalTime: mustParseTime("2026-05-19T18:00:00Z"),
+		})
+		require.Empty(t, tl.activeAt(mustParseTime("2026-05-19T19:00:00Z")))
+	})
+
+	t.Run("ContinueAsNew chain treated as one active execution", func(t *testing.T) {
+		tl := &timeline{byWorkflowID: map[string]*workflowChain{}}
+		canTime := mustParseTime("2026-05-19T18:30:00Z")
+		// First link: closed via CONTINUED_AS_NEW at 18:30
+		tl.addExecution(timelineEntry{
+			WorkflowID:  "wfChain",
+			RunID:       "run1",
+			StartTime:   mustParseTime("2026-05-19T18:00:00Z"),
+			CloseTime:   &canTime,
+			Status:      enumspb.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW,
+			NominalTime: mustParseTime("2026-05-19T18:00:00Z"),
+		})
+		// Second link: still running, started at 18:30 (sharing workflowId)
+		tl.addExecution(timelineEntry{
+			WorkflowID:  "wfChain",
+			RunID:       "run2",
+			StartTime:   mustParseTime("2026-05-19T18:30:00Z"),
+			Status:      enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			NominalTime: mustParseTime("2026-05-19T18:00:00Z"), // inherited
+		})
+		// At 19:00, chain is still active.
+		require.Len(t, tl.activeAt(mustParseTime("2026-05-19T19:00:00Z")), 1)
+	})
+}
+
+func TestClassifyFirings(t *testing.T) {
+	t.Run("all matched", func(t *testing.T) {
+		expectedFires := []time.Time{
+			mustParseTime("2026-05-19T18:00:00Z"),
+			mustParseTime("2026-05-19T19:00:00Z"),
+		}
+		tl := &timeline{byWorkflowID: map[string]*workflowChain{}}
+		closed := mustParseTime("2026-05-19T18:05:00Z")
+		tl.addExecution(timelineEntry{
+			WorkflowID:  "w1",
+			StartTime:   mustParseTime("2026-05-19T18:00:00Z"),
+			CloseTime:   &closed,
+			Status:      enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			NominalTime: mustParseTime("2026-05-19T18:00:00Z"),
+		})
+		closed2 := mustParseTime("2026-05-19T19:05:00Z")
+		tl.addExecution(timelineEntry{
+			WorkflowID:  "w2",
+			StartTime:   mustParseTime("2026-05-19T19:00:00Z"),
+			CloseTime:   &closed2,
+			Status:      enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			NominalTime: mustParseTime("2026-05-19T19:00:00Z"),
+		})
+		res := &scheduleResult{}
+		classifyFirings(res, expectedFires, tl)
+		require.Equal(t, 2, res.Matched)
+		require.Empty(t, res.Missed)
+	})
+
+	t.Run("real_miss", func(t *testing.T) {
+		// Two expected fires; the second has no execution and nothing else was active at that time -> real_miss.
+		expectedFires := []time.Time{
+			mustParseTime("2026-05-19T18:00:00Z"),
+			mustParseTime("2026-05-19T19:00:00Z"),
+		}
+		tl := &timeline{byWorkflowID: map[string]*workflowChain{}}
+		closed := mustParseTime("2026-05-19T18:05:00Z")
+		tl.addExecution(timelineEntry{
+			WorkflowID:  "w1",
+			StartTime:   mustParseTime("2026-05-19T18:00:00Z"),
+			CloseTime:   &closed,
+			Status:      enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			NominalTime: mustParseTime("2026-05-19T18:00:00Z"),
+		})
+		res := &scheduleResult{}
+		classifyFirings(res, expectedFires, tl)
+		require.Equal(t, 1, res.Matched)
+		require.Len(t, res.Missed, 1)
+		require.Equal(t, "real_miss", res.Categories[res.Missed[0]])
+	})
+
+	t.Run("skip_overlap", func(t *testing.T) {
+		// First workflow still running at 19:00 -> missed 19:00 is skip_overlap.
+		expectedFires := []time.Time{
+			mustParseTime("2026-05-19T18:00:00Z"),
+			mustParseTime("2026-05-19T19:00:00Z"),
+		}
+		tl := &timeline{byWorkflowID: map[string]*workflowChain{}}
+		tl.addExecution(timelineEntry{
+			WorkflowID:  "w1",
+			StartTime:   mustParseTime("2026-05-19T18:00:00Z"),
+			Status:      enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			NominalTime: mustParseTime("2026-05-19T18:00:00Z"),
+		})
+		res := &scheduleResult{}
+		classifyFirings(res, expectedFires, tl)
+		require.Equal(t, "skip_overlap", res.Categories[mustParseTime("2026-05-19T19:00:00Z")])
+	})
+}
+
+type fakeScheduleLoader struct {
+	entries []scheduleEntry
+	// describes, if set, returns these from DescribeSchedule. Lets tests model schedules created or modified after the
+	// audit window starts.
+	describes map[string]scheduleDescription
+	// describeErrors, if set for a given scheduleID, makes DescribeSchedule return that error instead of looking up
+	// a normal description. Used to model the "deleted between list and describe" race.
+	describeErrors map[string]error
+	// retention, if non-zero, is returned by NamespaceRetention. Defaults to 0, which the auditor treats as "no retention
+	// guard" -- fine for most tests that use synthetic times.
+	retention time.Duration
+}
+
+func (f *fakeScheduleLoader) ListSchedules(_ context.Context, _ string) ([]scheduleEntry, error) {
+	return f.entries, nil
+}
+
+func (f *fakeScheduleLoader) LookupSchedule(_ context.Context, _, scheduleID string) (scheduleEntry, error) {
+	for _, e := range f.entries {
+		if e.ID == scheduleID {
+			return e, nil
+		}
+	}
+	return scheduleEntry{}, status.Error(codes.NotFound, "schedule not found")
+}
+
+func (f *fakeScheduleLoader) DescribeSchedule(_ context.Context, _, scheduleID string) (scheduleDescription, error) {
+	if err, ok := f.describeErrors[scheduleID]; ok {
+		return scheduleDescription{}, err
+	}
+	if f.describes == nil {
+		return scheduleDescription{}, nil
+	}
+	return f.describes[scheduleID], nil
+}
+
+func (f *fakeScheduleLoader) NamespaceRetention(_ context.Context, _ string) (time.Duration, error) {
+	return f.retention, nil
+}
+
+type fakeExecutionLoader struct {
+	byScheduleID map[string][]timelineEntry
+}
+
+func (f *fakeExecutionLoader) ListExecutions(_ context.Context, _, scheduleIDFilter string, _, _ time.Time) (map[string][]timelineEntry, error) {
+	if f.byScheduleID == nil {
+		return map[string][]timelineEntry{}, nil
+	}
+	if scheduleIDFilter != "" {
+		if entries, ok := f.byScheduleID[scheduleIDFilter]; ok {
+			return map[string][]timelineEntry{scheduleIDFilter: entries}, nil
+		}
+		return map[string][]timelineEntry{}, nil
+	}
+	return f.byScheduleID, nil
+}
+
+func TestScheduleAuditor(t *testing.T) {
+	t.Run("real_miss", func(t *testing.T) {
+		spec := &schedulepb.ScheduleSpec{
+			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{
+				{
+					Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Minute:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Hour:       []*schedulepb.Range{{Start: 0, End: 23, Step: 1}},
+					DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
+					Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
+					DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
+				},
+			},
+		}
+		loader := &fakeScheduleLoader{entries: []scheduleEntry{{ID: "s1", Spec: spec, WorkflowType: "W"}}}
+		closed := mustParseTime("2026-05-19T18:05:00Z")
+		exec := &fakeExecutionLoader{byScheduleID: map[string][]timelineEntry{
+			"s1": {
+				{
+					WorkflowID:  "w1",
+					StartTime:   mustParseTime("2026-05-19T18:00:00Z"),
+					CloseTime:   &closed,
+					Status:      enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+					NominalTime: mustParseTime("2026-05-19T18:00:00Z"),
+				},
+			},
+		}}
+		a := &scheduleAuditor{
+			Namespace:   "ns",
+			WindowStart: mustParseTime("2026-05-19T18:00:00Z"),
+			WindowEnd:   mustParseTime("2026-05-19T20:00:00Z"),
+			Schedules:   loader,
+			Executions:  exec,
+			Progress:    io.Discard,
+		}
+		results, err := a.run(context.Background())
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		// 18:00 matched; 19:00 and 20:00 missed with no prior fire that's still running -> real_miss.
+		require.Equal(t, 2, results[0].Counts["real_miss"])
+	})
+
+	t.Run("concurrency", func(t *testing.T) {
+		spec := &schedulepb.ScheduleSpec{
+			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{
+				{
+					Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Minute:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Hour:       []*schedulepb.Range{{Start: 0, End: 23, Step: 1}},
+					DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
+					Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
+					DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
+				},
+			},
+		}
+		var schedules []scheduleEntry
+		exec := &fakeExecutionLoader{byScheduleID: map[string][]timelineEntry{}}
+		for i := 0; i < 100; i++ {
+			id := fmt.Sprintf("s%d", i)
+			schedules = append(schedules, scheduleEntry{ID: id, Spec: spec, WorkflowType: "W"})
+			exec.byScheduleID[id] = nil // no executions -> all missed
+		}
+		a := &scheduleAuditor{
+			Namespace:   "ns",
+			WindowStart: mustParseTime("2026-05-19T18:00:00Z"),
+			WindowEnd:   mustParseTime("2026-05-19T20:00:00Z"),
+			Schedules:   &fakeScheduleLoader{entries: schedules},
+			Executions:  exec,
+			Progress:    io.Discard,
+		}
+		results, err := a.run(context.Background())
+		require.NoError(t, err)
+		require.Len(t, results, 100)
+	})
+
+	t.Run("schedule-id filter: only analyzes selected", func(t *testing.T) {
+		spec := &schedulepb.ScheduleSpec{
+			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{
+				{
+					Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Minute:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Hour:       []*schedulepb.Range{{Start: 0, End: 23, Step: 1}},
+					DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
+					Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
+					DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
+				},
+			},
+		}
+		loader := &fakeScheduleLoader{entries: []scheduleEntry{
+			{ID: "s1", Spec: spec, WorkflowType: "W"},
+			{ID: "s2", Spec: spec, WorkflowType: "W"},
+			{ID: "s3", Spec: spec, WorkflowType: "W"},
+		}}
+		exec := &fakeExecutionLoader{byScheduleID: map[string][]timelineEntry{}}
+		a := &scheduleAuditor{
+			Namespace:   "ns",
+			ScheduleID:  "s2",
+			WindowStart: mustParseTime("2026-05-19T18:00:00Z"),
+			WindowEnd:   mustParseTime("2026-05-19T20:00:00Z"),
+			Schedules:   loader,
+			Executions:  exec,
+			Progress:    io.Discard,
+		}
+		results, err := a.run(context.Background())
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		require.Equal(t, "s2", results[0].ScheduleID)
+	})
+
+	t.Run("schedule-id filter: unknown returns error", func(t *testing.T) {
+		loader := &fakeScheduleLoader{entries: []scheduleEntry{{ID: "s1"}}}
+		a := &scheduleAuditor{
+			Namespace:   "ns",
+			ScheduleID:  "missing",
+			WindowStart: mustParseTime("2026-05-19T18:00:00Z"),
+			WindowEnd:   mustParseTime("2026-05-19T20:00:00Z"),
+			Schedules:   loader,
+			Executions:  &fakeExecutionLoader{},
+			Progress:    io.Discard,
+		}
+		_, err := a.run(context.Background())
+		require.ErrorContains(t, err, `schedule "missing" not found in namespace "ns"`)
+	})
+
+	t.Run("paused schedule is skipped", func(t *testing.T) {
+		spec := &schedulepb.ScheduleSpec{
+			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{
+				{
+					Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Minute:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Hour:       []*schedulepb.Range{{Start: 0, End: 23, Step: 1}},
+					DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
+					Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
+					DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
+				},
+			},
+		}
+		loader := &fakeScheduleLoader{entries: []scheduleEntry{
+			{ID: "active", Spec: spec, WorkflowType: "W"},
+			{ID: "paused", Spec: spec, WorkflowType: "W", Paused: true},
+		}}
+		exec := &fakeExecutionLoader{byScheduleID: map[string][]timelineEntry{}}
+		a := &scheduleAuditor{
+			Namespace:   "ns",
+			WindowStart: mustParseTime("2026-05-19T18:00:00Z"),
+			WindowEnd:   mustParseTime("2026-05-19T20:00:00Z"),
+			Schedules:   loader,
+			Executions:  exec,
+			Progress:    io.Discard,
+		}
+		results, err := a.run(context.Background())
+		require.NoError(t, err)
+		// Only the active schedule should produce a result.
+		require.Len(t, results, 1)
+		require.Equal(t, "active", results[0].ScheduleID)
+	})
+
+	t.Run("window past retention is skipped", func(t *testing.T) {
+		spec := &schedulepb.ScheduleSpec{
+			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{
+				{
+					Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Minute:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Hour:       []*schedulepb.Range{{Start: 0, End: 23, Step: 1}},
+					DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
+					Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
+					DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
+				},
+			},
+		}
+		// Retention 30d, window 40d ago -- well past safe boundary.
+		a := &scheduleAuditor{
+			Namespace:   "ns",
+			WindowStart: time.Now().Add(-40 * 24 * time.Hour),
+			WindowEnd:   time.Now().Add(-39 * 24 * time.Hour),
+			Schedules: &fakeScheduleLoader{
+				entries:   []scheduleEntry{{ID: "s1", Spec: spec, WorkflowType: "W"}},
+				retention: 30 * 24 * time.Hour,
+			},
+			Executions: &fakeExecutionLoader{},
+			Progress:   io.Discard,
+		}
+		results, err := a.run(context.Background())
+		require.NoError(t, err)
+		require.Nil(t, results, "expected nil results when window is past retention")
+	})
+
+	t.Run("long runner closed during window -> skip_overlap", func(t *testing.T) {
+		spec := &schedulepb.ScheduleSpec{
+			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{
+				{
+					Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Minute:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Hour:       []*schedulepb.Range{{Start: 0, End: 23, Step: 1}},
+					DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
+					Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
+					DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
+				},
+			},
+		}
+		// Workflow started 7 days before the window and closed mid-window.
+		closeTime := mustParseTime("2026-05-19T19:30:00Z")
+		exec := &fakeExecutionLoader{
+			byScheduleID: map[string][]timelineEntry{
+				"s1": {
+					{
+						WorkflowID:  "wLongRunner",
+						StartTime:   mustParseTime("2026-05-12T17:09:00Z"),
+						CloseTime:   &closeTime,
+						Status:      enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+						NominalTime: mustParseTime("2026-05-12T17:09:00Z"),
+					},
+				},
+			},
+		}
+		a := &scheduleAuditor{
+			Namespace:   "ns",
+			WindowStart: mustParseTime("2026-05-19T18:00:00Z"),
+			WindowEnd:   mustParseTime("2026-05-19T21:00:00Z"),
+			Schedules:   &fakeScheduleLoader{entries: []scheduleEntry{{ID: "s1", Spec: spec, WorkflowType: "W"}}},
+			Executions:  exec,
+			Progress:    io.Discard,
+		}
+		results, err := a.run(context.Background())
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		r := results[0]
+		// All three expected fires (19:00, 20:00, 21:00) fall inside the closed chain's [start, close) interval up to 19:30,
+		// so at least the 19:00 fire must be skip_overlap; 20:00 and 21:00 land after close and are legitimately real_miss in
+		// this synthetic test (no other blocker), but the key assertion is that we *did* see the chain.
+		require.GreaterOrEqual(t, r.Counts["skip_overlap"], 1, "expected the closed long-runner to block at least one fire")
+	})
+
+	t.Run("still-running workflow started long before window -> skip_overlap", func(t *testing.T) {
+		spec := &schedulepb.ScheduleSpec{
+			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{
+				{
+					Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Minute:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Hour:       []*schedulepb.Range{{Start: 0, End: 23, Step: 1}},
+					DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
+					Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
+					DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
+				},
+			},
+		}
+		// Window 18:00-21:00. Workflow started 7 days earlier and still running. The alive-during-window query returns this
+		// via the CloseTime IS NULL branch, regardless of how far back StartTime is.
+		exec := &fakeExecutionLoader{
+			byScheduleID: map[string][]timelineEntry{
+				"s1": {
+					{
+						WorkflowID:  "wLongRunner",
+						StartTime:   mustParseTime("2026-05-12T17:09:00Z"),
+						Status:      enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+						NominalTime: mustParseTime("2026-05-12T17:09:00Z"),
+					},
+				},
+			},
+		}
+		a := &scheduleAuditor{
+			Namespace:   "ns",
+			WindowStart: mustParseTime("2026-05-19T18:00:00Z"),
+			WindowEnd:   mustParseTime("2026-05-19T21:00:00Z"),
+			Schedules:   &fakeScheduleLoader{entries: []scheduleEntry{{ID: "s1", Spec: spec, WorkflowType: "W"}}},
+			Executions:  exec,
+			Progress:    io.Discard,
+		}
+		results, err := a.run(context.Background())
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		r := results[0]
+		require.Equal(t, 3, r.Expected, "three hourly fires expected (19:00, 20:00, 21:00)")
+		require.Zero(t, r.Counts["real_miss"], "the long-running workflow blocks every fire -> no real_miss")
+		require.Equal(t, 3, r.Counts["skip_overlap"], "every fire should be skip_overlap")
+	})
+
+	t.Run("postProcess: created after windowEnd excluded from results", func(t *testing.T) {
+		spec := &schedulepb.ScheduleSpec{
+			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{
+				{
+					Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Minute:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Hour:       []*schedulepb.Range{{Start: 0, End: 23, Step: 1}},
+					DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
+					Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
+					DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
+				},
+			},
+		}
+		loader := &fakeScheduleLoader{
+			entries: []scheduleEntry{{ID: "s1", Spec: spec, WorkflowType: "W"}},
+			describes: map[string]scheduleDescription{
+				// Created one day after the window ends.
+				"s1": {CreateTime: mustParseTime("2026-05-21T00:00:00Z")},
+			},
+		}
+		exec := &fakeExecutionLoader{byScheduleID: map[string][]timelineEntry{}}
+		a := &scheduleAuditor{
+			Namespace:   "ns",
+			WindowStart: mustParseTime("2026-05-19T18:00:00Z"),
+			WindowEnd:   mustParseTime("2026-05-19T20:00:00Z"),
+			Schedules:   loader,
+			Executions:  exec,
+			Progress:    io.Discard,
+		}
+		results, err := a.run(context.Background())
+		require.NoError(t, err)
+		require.Empty(t, results, "schedule was created after windowEnd, should produce no result")
+	})
+
+	t.Run("postProcess: created mid-window truncates expected", func(t *testing.T) {
+		spec := &schedulepb.ScheduleSpec{
+			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{
+				{
+					Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Minute:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Hour:       []*schedulepb.Range{{Start: 0, End: 23, Step: 1}},
+					DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
+					Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
+					DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
+				},
+			},
+		}
+		loader := &fakeScheduleLoader{
+			entries: []scheduleEntry{{ID: "s1", Spec: spec, WorkflowType: "W"}},
+			// Created in the middle of a 4-hour window (18:00 - 22:00).
+			describes: map[string]scheduleDescription{
+				"s1": {CreateTime: mustParseTime("2026-05-19T20:30:00Z")},
+			},
+		}
+		exec := &fakeExecutionLoader{byScheduleID: map[string][]timelineEntry{}}
+		a := &scheduleAuditor{
+			Namespace:   "ns",
+			WindowStart: mustParseTime("2026-05-19T18:00:00Z"),
+			WindowEnd:   mustParseTime("2026-05-19T22:00:00Z"),
+			Schedules:   loader,
+			Executions:  exec,
+			Progress:    io.Discard,
+		}
+		results, err := a.run(context.Background())
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		r := results[0]
+		// First-pass would have flagged 4 expected (19:00, 20:00, 21:00, 22:00) all real_miss. Re-analysis with
+		// createTime=20:30 truncates to fires at 21:00 and 22:00 only -> 2 real_miss.
+		require.Equal(t, 2, r.Counts["real_miss"],
+			"expected 2 real_miss (21:00, 22:00); 19:00 and 20:00 were pre-creation and shouldn't count")
+	})
+
+	t.Run("postProcess: modified during window -> inconclusive", func(t *testing.T) {
+		spec := &schedulepb.ScheduleSpec{
+			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{
+				{
+					Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Minute:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Hour:       []*schedulepb.Range{{Start: 0, End: 23, Step: 1}},
+					DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
+					Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
+					DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
+				},
+			},
+		}
+		loader := &fakeScheduleLoader{
+			entries: []scheduleEntry{{ID: "s1", Spec: spec, WorkflowType: "W"}},
+			describes: map[string]scheduleDescription{
+				// Created well before window, but spec updated mid-window.
+				"s1": {
+					CreateTime: mustParseTime("2026-01-01T00:00:00Z"),
+					UpdateTime: mustParseTime("2026-05-19T19:30:00Z"),
+				},
+			},
+		}
+		exec := &fakeExecutionLoader{byScheduleID: map[string][]timelineEntry{}}
+		a := &scheduleAuditor{
+			Namespace:   "ns",
+			WindowStart: mustParseTime("2026-05-19T18:00:00Z"),
+			WindowEnd:   mustParseTime("2026-05-19T22:00:00Z"),
+			Schedules:   loader,
+			Executions:  exec,
+			Progress:    io.Discard,
+		}
+		// With no executions and 4 expected hourly fires (19:00, 20:00, 21:00, 22:00), the initial analysis would produce 4
+		// real_miss. Because the spec was updated mid-window, all 4 should be moved to inconclusive_schedule_changed.
+		results, err := a.run(context.Background())
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		r := results[0]
+		require.Zero(t, r.Counts["real_miss"], "expected real_miss reclassified")
+		require.Equal(t, 4, r.Counts["inconclusive_schedule_changed"])
+	})
+
+	t.Run("postProcess: exhausted excluded from results", func(t *testing.T) {
+		spec := &schedulepb.ScheduleSpec{
+			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{
+				{
+					Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Minute:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Hour:       []*schedulepb.Range{{Start: 0, End: 23, Step: 1}},
+					DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
+					Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
+					DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
+				},
+			},
+		}
+		loader := &fakeScheduleLoader{
+			entries: []scheduleEntry{{ID: "s1", Spec: spec, WorkflowType: "W"}},
+			describes: map[string]scheduleDescription{
+				// Pre-existing schedule, never modified, but exhausted.
+				"s1": {
+					CreateTime: mustParseTime("2026-01-01T00:00:00Z"),
+					Exhausted:  true,
+				},
+			},
+		}
+		exec := &fakeExecutionLoader{byScheduleID: map[string][]timelineEntry{}}
+		a := &scheduleAuditor{
+			Namespace:   "ns",
+			WindowStart: mustParseTime("2026-05-19T18:00:00Z"),
+			WindowEnd:   mustParseTime("2026-05-19T22:00:00Z"),
+			Schedules:   loader,
+			Executions:  exec,
+			Progress:    io.Discard,
+		}
+		results, err := a.run(context.Background())
+		require.NoError(t, err)
+		require.Empty(t, results, "exhausted schedule should be dropped")
+	})
+
+	t.Run("postProcess: unsupported policy -> unsupported bucket", func(t *testing.T) {
+		spec := &schedulepb.ScheduleSpec{
+			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{
+				{
+					Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Minute:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Hour:       []*schedulepb.Range{{Start: 0, End: 23, Step: 1}},
+					DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
+					Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
+					DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
+				},
+			},
+		}
+		loader := &fakeScheduleLoader{
+			entries: []scheduleEntry{{ID: "s1", Spec: spec, WorkflowType: "W"}},
+			describes: map[string]scheduleDescription{
+				"s1": {
+					CreateTime:        mustParseTime("2026-01-01T00:00:00Z"),
+					UnsupportedReason: "overlap_buffer_all",
+				},
+			},
+		}
+		exec := &fakeExecutionLoader{byScheduleID: map[string][]timelineEntry{}}
+		a := &scheduleAuditor{
+			Namespace:   "ns",
+			WindowStart: mustParseTime("2026-05-19T18:00:00Z"),
+			WindowEnd:   mustParseTime("2026-05-19T22:00:00Z"),
+			Schedules:   loader,
+			Executions:  exec,
+			Progress:    io.Discard,
+		}
+		results, err := a.run(context.Background())
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		r := results[0]
+		require.Zero(t, r.Counts["real_miss"], "real_miss reclassified")
+		require.Equal(t, 4, r.Counts["unsupported_policy"])
+		require.Equal(t, "overlap_buffer_all", r.UnsupportedReason)
+	})
+
+	t.Run("postProcess: NotFound race (deleted between list and describe)", func(t *testing.T) {
+		// Hourly spec; window contains 19:00 and 20:00. With no executions, both are real_miss -> postProcess runs.
+		spec := &schedulepb.ScheduleSpec{
+			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{
+				{
+					Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Minute:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
+					Hour:       []*schedulepb.Range{{Start: 0, End: 23, Step: 1}},
+					DayOfMonth: []*schedulepb.Range{{Start: 1, End: 31, Step: 1}},
+					Month:      []*schedulepb.Range{{Start: 1, End: 12, Step: 1}},
+					DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
+				},
+			},
+		}
+		loader := &fakeScheduleLoader{
+			entries: []scheduleEntry{
+				{ID: "deleted", Spec: spec, WorkflowType: "W"},
+				{ID: "alive", Spec: spec, WorkflowType: "W"},
+			},
+			describeErrors: map[string]error{
+				// "deleted" returns NotFound when postProcess calls DescribeSchedule.
+				"deleted": status.Error(codes.NotFound, "schedule not found"),
+			},
+		}
+		a := &scheduleAuditor{
+			Namespace:   "ns",
+			WindowStart: mustParseTime("2026-05-19T18:30:00Z"),
+			WindowEnd:   mustParseTime("2026-05-19T20:30:00Z"),
+			Schedules:   loader,
+			Executions:  &fakeExecutionLoader{},
+			Progress:    io.Discard,
+		}
+		results, err := a.run(context.Background())
+		require.NoError(t, err, "NotFound during postProcess must not propagate as an error")
+		// "deleted" gets dropped silently; "alive" gets describe -> no UpdateTime/Exhausted/etc. -> row stands.
+		require.Len(t, results, 1)
+		require.Equal(t, "alive", results[0].ScheduleID)
+	})
+}
+
+func TestWriter_Stdout_FlatCSV(t *testing.T) {
+	t.Run("emits header + row with exact column order and values", func(t *testing.T) {
+		missTime := mustParseTime("2026-05-19T19:00:00Z")
+		skipTime := mustParseTime("2026-05-19T20:00:00Z")
+		results := []scheduleResult{{
+			Namespace: "ns1", ScheduleID: "s1", WorkflowType: "Foo,Bar",
+			JitterSeconds: 30, CatchupWindowSeconds: 600,
+			Expected: 5, Actual: 4, Matched: 3,
+			Missed: []time.Time{missTime, skipTime},
+			Categories: map[time.Time]string{
+				missTime: categoryRealMiss,
+				skipTime: categorySkipOverlap,
+			},
+			Counts: map[string]int{
+				categoryRealMiss:    1,
+				categorySkipOverlap: 1,
+			},
+			UnsupportedReason: "",
+		}}
+		var buf bytes.Buffer
+		require.NoError(t, writeFlatCSV(&buf, results))
+		rows, err := csv.NewReader(&buf).ReadAll()
+		require.NoError(t, err)
+		require.Len(t, rows, 2, "expected header + 1 data row")
+		require.Equal(t, flatCSVBaseHeader, rows[0])
+		require.Equal(t, []string{
+			"ns1", "s1", "Foo;Bar", // comma in workflow type sanitized to semicolon
+			"30",          // jitter_s
+			"5", "4", "3", // expected, actual, matched
+			"2",                // missed
+			"1", "1", "0", "0", // real_miss, skip_overlap, inconclusive, unsupported
+			"",                     // unsupported_reason
+			"600",                  // catchup_window_s
+			"2026-05-19T19:00:00Z", // real_miss_times: only the real_miss, not the skip
+		}, rows[1])
+	})
+
+	t.Run("skips results with no missed fires", func(t *testing.T) {
+		results := []scheduleResult{{
+			Namespace: "ns1", ScheduleID: "perfect", WorkflowType: "W",
+			Expected: 5, Actual: 5, Matched: 5,
+			Missed: nil,
+		}}
+		var buf bytes.Buffer
+		require.NoError(t, writeFlatCSV(&buf, results))
+		rows, err := csv.NewReader(&buf).ReadAll()
+		require.NoError(t, err)
+		require.Len(t, rows, 1, "header only, no data row for results with no misses")
+		require.Equal(t, flatCSVBaseHeader, rows[0])
+	})
+
+	t.Run("truncates real_miss_times beyond 20 with ...+N more suffix", func(t *testing.T) {
+		base := mustParseTime("2026-05-19T00:00:00Z")
+		var missed []time.Time
+		categories := map[time.Time]string{}
+		for i := range 25 {
+			tm := base.Add(time.Duration(i) * time.Minute)
+			missed = append(missed, tm)
+			categories[tm] = categoryRealMiss
+		}
+		results := []scheduleResult{{
+			Namespace: "ns1", ScheduleID: "s1", WorkflowType: "W",
+			Expected: 25, Missed: missed, Categories: categories,
+			Counts: map[string]int{categoryRealMiss: 25},
+		}}
+		var buf bytes.Buffer
+		require.NoError(t, writeFlatCSV(&buf, results))
+		rows, err := csv.NewReader(&buf).ReadAll()
+		require.NoError(t, err)
+		require.Len(t, rows, 2)
+		realMissTimes := rows[1][len(flatCSVBaseHeader)-1]
+		require.Contains(t, realMissTimes, "2026-05-19T00:00:00Z", "earliest time present")
+		require.Contains(t, realMissTimes, "2026-05-19T00:19:00Z", "20th time present")
+		require.NotContains(t, realMissTimes, "2026-05-19T00:20:00Z", "21st time elided")
+		require.Contains(t, realMissTimes, "...+5 more")
+	})
+}
+
+// TestUnsupportedPolicyReason exercises every policy/state combination unsupportedPolicyReason recognizes, plus the
+// nil-policies and supported-policies cases that must return empty.
+func TestUnsupportedPolicyReason(t *testing.T) {
+	cases := []struct {
+		name     string
+		policies *schedulepb.SchedulePolicies
+		expected string
+	}{
+		{"nil policies", nil, ""},
+		{"default SKIP (unspecified)", &schedulepb.SchedulePolicies{}, ""},
+		{
+			"explicit SKIP",
+			&schedulepb.SchedulePolicies{OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP},
+			"",
+		},
+		{
+			"BUFFER_ONE is supported",
+			&schedulepb.SchedulePolicies{OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE},
+			"",
+		},
+		{
+			"BUFFER_ALL flagged",
+			&schedulepb.SchedulePolicies{OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL},
+			"overlap_buffer_all",
+		},
+		{
+			"ALLOW_ALL flagged",
+			&schedulepb.SchedulePolicies{OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL},
+			"overlap_allow_all",
+		},
+		{
+			"CANCEL_OTHER flagged",
+			&schedulepb.SchedulePolicies{OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_CANCEL_OTHER},
+			"overlap_cancel_other",
+		},
+		{
+			"TERMINATE_OTHER flagged",
+			&schedulepb.SchedulePolicies{OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_TERMINATE_OTHER},
+			"overlap_terminate_other",
+		},
+		{
+			"KeepOriginalWorkflowId only",
+			&schedulepb.SchedulePolicies{KeepOriginalWorkflowId: true},
+			"keep_original_workflow_id",
+		},
+		{
+			"KeepOriginalWorkflowId + BUFFER_ALL joined with semicolon",
+			&schedulepb.SchedulePolicies{
+				KeepOriginalWorkflowId: true,
+				OverlapPolicy:          enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL,
+			},
+			"keep_original_workflow_id;overlap_buffer_all",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, unsupportedPolicyReason(tc.policies))
+		})
+	}
+}
+
+// TestPostProcess_NotFoundRace exercises the race-handling branch where DescribeSchedule returns NotFound for a
+// schedule that ListSchedules saw moments earlier. The row should be silently dropped (no error returned).
+// TestDecodePayloads covers the skip-on-failure contract of decodeScheduledById and decodeNominalStartTime so the
+// caller can drop visibility rows with malformed search-attribute payloads instead of grouping them under empty keys.
+func TestDecodePayloads(t *testing.T) {
+	makePayload := func(encoding string, data []byte) *commonpb.Payload {
+		return &commonpb.Payload{
+			Metadata: map[string][]byte{"encoding": []byte(encoding)},
+			Data:     data,
+		}
+	}
+
+	t.Run("decodeScheduledById nil payload returns false", func(t *testing.T) {
+		_, ok := decodeScheduledById(nil)
+		require.False(t, ok)
+	})
+	t.Run("decodeScheduledById wrong encoding returns false", func(t *testing.T) {
+		_, ok := decodeScheduledById(makePayload("proto/binary", []byte("anything")))
+		require.False(t, ok)
+	})
+	t.Run("decodeScheduledById malformed json returns false", func(t *testing.T) {
+		_, ok := decodeScheduledById(makePayload("json/plain", []byte("not-json-quoted")))
+		require.False(t, ok)
+	})
+	t.Run("decodeScheduledById valid json returns the string", func(t *testing.T) {
+		actual, ok := decodeScheduledById(makePayload("json/plain", []byte(`"my-schedule-id"`)))
+		require.True(t, ok)
+		require.Equal(t, "my-schedule-id", actual)
+	})
+
+	t.Run("decodeNominalStartTime nil payload returns zero", func(t *testing.T) {
+		_, ok := decodeNominalStartTime(nil)
+		require.False(t, ok)
+	})
+	t.Run("decodeNominalStartTime wrong encoding returns zero", func(t *testing.T) {
+		_, ok := decodeNominalStartTime(makePayload("proto/binary", []byte("anything")))
+		require.False(t, ok)
+	})
+	t.Run("decodeNominalStartTime non-RFC3339 returns zero", func(t *testing.T) {
+		_, ok := decodeNominalStartTime(makePayload("json/plain", []byte(`"not-a-timestamp"`)))
+		require.False(t, ok)
+	})
+	t.Run("decodeNominalStartTime valid RFC3339 parses", func(t *testing.T) {
+		actual, ok := decodeNominalStartTime(makePayload("json/plain", []byte(`"2026-05-19T18:00:00Z"`)))
+		require.True(t, ok)
+		require.Equal(t, mustParseTime("2026-05-19T18:00:00Z"), actual)
+	})
+}
+
+func mustParseTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}

--- a/tools/tdbg/schedule_audit_test.go
+++ b/tools/tdbg/schedule_audit_test.go
@@ -538,7 +538,7 @@ func TestScheduleAuditor(t *testing.T) {
 		}
 		var schedules []scheduleEntry
 		exec := &fakeExecutionLoader{byScheduleID: map[string][]timelineEntry{}}
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			id := fmt.Sprintf("s%d", i)
 			schedules = append(schedules, scheduleEntry{ID: id, Spec: spec, WorkflowType: "W"})
 			exec.byScheduleID[id] = nil // no executions -> all missed
@@ -1131,7 +1131,7 @@ func TestUnsupportedPolicyReason(t *testing.T) {
 
 // TestPostProcess_NotFoundRace exercises the race-handling branch where DescribeSchedule returns NotFound for a
 // schedule that ListSchedules saw moments earlier. The row should be silently dropped (no error returned).
-// TestDecodePayloads covers the skip-on-failure contract of decodeScheduledById and decodeNominalStartTime so the
+// TestDecodePayloads covers the skip-on-failure contract of decodeScheduledByID and decodeNominalStartTime so the
 // caller can drop visibility rows with malformed search-attribute payloads instead of grouping them under empty keys.
 func TestDecodePayloads(t *testing.T) {
 	makePayload := func(encoding string, data []byte) *commonpb.Payload {
@@ -1141,20 +1141,20 @@ func TestDecodePayloads(t *testing.T) {
 		}
 	}
 
-	t.Run("decodeScheduledById nil payload returns false", func(t *testing.T) {
-		_, ok := decodeScheduledById(nil)
+	t.Run("decodeScheduledByID nil payload returns false", func(t *testing.T) {
+		_, ok := decodeScheduledByID(nil)
 		require.False(t, ok)
 	})
-	t.Run("decodeScheduledById wrong encoding returns false", func(t *testing.T) {
-		_, ok := decodeScheduledById(makePayload("proto/binary", []byte("anything")))
+	t.Run("decodeScheduledByID wrong encoding returns false", func(t *testing.T) {
+		_, ok := decodeScheduledByID(makePayload("proto/binary", []byte("anything")))
 		require.False(t, ok)
 	})
-	t.Run("decodeScheduledById malformed json returns false", func(t *testing.T) {
-		_, ok := decodeScheduledById(makePayload("json/plain", []byte("not-json-quoted")))
+	t.Run("decodeScheduledByID malformed json returns false", func(t *testing.T) {
+		_, ok := decodeScheduledByID(makePayload("json/plain", []byte("not-json-quoted")))
 		require.False(t, ok)
 	})
-	t.Run("decodeScheduledById valid json returns the string", func(t *testing.T) {
-		actual, ok := decodeScheduledById(makePayload("json/plain", []byte(`"my-schedule-id"`)))
+	t.Run("decodeScheduledByID valid json returns the string", func(t *testing.T) {
+		actual, ok := decodeScheduledByID(makePayload("json/plain", []byte(`"my-schedule-id"`)))
 		require.True(t, ok)
 		require.Equal(t, "my-schedule-id", actual)
 	})

--- a/tools/tdbg/schedule_audit_test.go
+++ b/tools/tdbg/schedule_audit_test.go
@@ -6,6 +6,9 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,9 +25,10 @@ import (
 func TestAuditInputs_Validate(t *testing.T) {
 	base := func() *auditInputs {
 		return &auditInputs{
-			Namespaces:  []string{"ns"},
+			Targets:     []auditTarget{{Namespace: "ns"}},
 			WindowStart: mustParseTime("2026-05-19T18:00:00Z"),
 			WindowEnd:   mustParseTime("2026-05-19T20:00:00Z"),
+			MaxWindow:   defaultMaxAuditWindow,
 			OutputDir:   "/tmp/out",
 		}
 	}
@@ -39,16 +43,19 @@ func TestAuditInputs_Validate(t *testing.T) {
 		require.NoError(t, in.validate())
 	})
 
-	t.Run("schedule-id requires single namespace", func(t *testing.T) {
+	t.Run("no targets resolved is rejected", func(t *testing.T) {
 		in := base()
-		in.ScheduleID = "sched1"
-		in.Namespaces = []string{"ns1", "ns2"}
-		require.ErrorContains(t, in.validate(), "--schedule-id requires exactly one namespace")
+		in.Targets = nil
+		require.ErrorContains(t, in.validate(), "no audit targets resolved")
 	})
 
-	t.Run("schedule-id with one namespace OK", func(t *testing.T) {
+	t.Run("multiple targets with per-line schedule IDs accepted", func(t *testing.T) {
 		in := base()
-		in.ScheduleID = "sched1"
+		in.Targets = []auditTarget{
+			{Namespace: "ns1", ScheduleID: "sched1"},
+			{Namespace: "ns2"},
+			{Namespace: "ns3", ScheduleID: "sched3"},
+		}
 		require.NoError(t, in.validate())
 	})
 
@@ -65,18 +72,35 @@ func TestAuditInputs_Validate(t *testing.T) {
 		require.ErrorContains(t, in.validate(), "must be after")
 	})
 
-	t.Run("window at 7d cap accepted", func(t *testing.T) {
+	t.Run("window at default cap accepted", func(t *testing.T) {
 		in := base()
-		in.WindowEnd = in.WindowStart.Add(7 * 24 * time.Hour)
+		in.WindowEnd = in.WindowStart.Add(defaultMaxAuditWindow)
 		require.NoError(t, in.validate())
 	})
 
-	t.Run("window over 7d cap rejected", func(t *testing.T) {
+	t.Run("window over default cap rejected with override hint", func(t *testing.T) {
 		in := base()
-		in.WindowEnd = in.WindowStart.Add(7*24*time.Hour + time.Second)
-		require.ErrorContains(t, in.validate(), "max is 168h")
+		in.WindowEnd = in.WindowStart.Add(defaultMaxAuditWindow + time.Second)
+		err := in.validate()
+		require.ErrorContains(t, err, "max is 168h")
+		require.ErrorContains(t, err, "Pass --max-window=")
 	})
 
+	t.Run("raised --max-window accepts wider window", func(t *testing.T) {
+		in := base()
+		in.MaxWindow = 400 * 24 * time.Hour
+		in.WindowEnd = in.WindowStart.Add(365 * 24 * time.Hour)
+		require.NoError(t, in.validate())
+	})
+
+	t.Run("--max-window still bounds the window", func(t *testing.T) {
+		in := base()
+		in.MaxWindow = 30 * 24 * time.Hour
+		in.WindowEnd = in.WindowStart.Add(31 * 24 * time.Hour)
+		err := in.validate()
+		require.ErrorContains(t, err, "max is 720h")
+		require.ErrorContains(t, err, "Pass --max-window=")
+	})
 }
 
 func TestAuditCommandIsRegistered(t *testing.T) {
@@ -94,6 +118,156 @@ func TestAuditCommandIsRegistered(t *testing.T) {
 		}
 	}
 	require.True(t, found, "audit subcommand not registered under schedule")
+}
+
+func TestParseTargetLines(t *testing.T) {
+	t.Run("just namespaces, one per line", func(t *testing.T) {
+		got, err := parseTargetLines(strings.NewReader("ns1\nns2\nns3\n"))
+		require.NoError(t, err)
+		require.Equal(t, []auditTarget{{Namespace: "ns1"}, {Namespace: "ns2"}, {Namespace: "ns3"}}, got)
+	})
+
+	t.Run("namespace + schedule_id pairs", func(t *testing.T) {
+		input := "ns1,sched1\nns2,sched2\n"
+		got, err := parseTargetLines(strings.NewReader(input))
+		require.NoError(t, err)
+		require.Equal(t, []auditTarget{
+			{Namespace: "ns1", ScheduleID: "sched1"},
+			{Namespace: "ns2", ScheduleID: "sched2"},
+		}, got)
+	})
+
+	t.Run("mixed: some namespaces only, some with schedule_id", func(t *testing.T) {
+		input := "ns1\nns2,sched2\nns3\n"
+		got, err := parseTargetLines(strings.NewReader(input))
+		require.NoError(t, err)
+		require.Equal(t, []auditTarget{
+			{Namespace: "ns1"},
+			{Namespace: "ns2", ScheduleID: "sched2"},
+			{Namespace: "ns3"},
+		}, got)
+	})
+
+	t.Run("blank lines and # comments are ignored", func(t *testing.T) {
+		input := "# top comment\n\nns1\n\n# inline comment\nns2,sched2\n   \n"
+		got, err := parseTargetLines(strings.NewReader(input))
+		require.NoError(t, err)
+		require.Equal(t, []auditTarget{
+			{Namespace: "ns1"},
+			{Namespace: "ns2", ScheduleID: "sched2"},
+		}, got)
+	})
+
+	t.Run("whitespace around fields is trimmed", func(t *testing.T) {
+		input := "  ns1  ,  sched1  \n  ns2  \n"
+		got, err := parseTargetLines(strings.NewReader(input))
+		require.NoError(t, err)
+		require.Equal(t, []auditTarget{
+			{Namespace: "ns1", ScheduleID: "sched1"},
+			{Namespace: "ns2"},
+		}, got)
+	})
+
+	t.Run("trailing newline missing is fine", func(t *testing.T) {
+		got, err := parseTargetLines(strings.NewReader("ns1,sched1"))
+		require.NoError(t, err)
+		require.Equal(t, []auditTarget{{Namespace: "ns1", ScheduleID: "sched1"}}, got)
+	})
+
+	t.Run("CRLF line endings handled", func(t *testing.T) {
+		got, err := parseTargetLines(strings.NewReader("ns1\r\nns2,sched2\r\n"))
+		require.NoError(t, err)
+		require.Equal(t, []auditTarget{{Namespace: "ns1"}, {Namespace: "ns2", ScheduleID: "sched2"}}, got)
+	})
+
+	t.Run("empty input returns no targets without error", func(t *testing.T) {
+		got, err := parseTargetLines(strings.NewReader(""))
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+
+	t.Run("line with more than one comma is rejected", func(t *testing.T) {
+		_, err := parseTargetLines(strings.NewReader("ns1,sched1,extra\n"))
+		require.ErrorContains(t, err, `malformed line "ns1,sched1,extra"`)
+	})
+
+	t.Run("empty namespace is rejected", func(t *testing.T) {
+		_, err := parseTargetLines(strings.NewReader(",sched1\n"))
+		require.ErrorContains(t, err, "namespace is empty")
+	})
+
+	t.Run("trailing comma with empty schedule_id is rejected", func(t *testing.T) {
+		_, err := parseTargetLines(strings.NewReader("ns1,\n"))
+		require.ErrorContains(t, err, "schedule_id is empty after comma")
+	})
+}
+
+func TestResolveTargetsFromFlags(t *testing.T) {
+	t.Run("single --namespace, no schedule-id", func(t *testing.T) {
+		got, err := resolveTargetsFromFlags("ns1", "", "", nil)
+		require.NoError(t, err)
+		require.Equal(t, []auditTarget{{Namespace: "ns1"}}, got)
+	})
+
+	t.Run("single --namespace with --schedule-id", func(t *testing.T) {
+		got, err := resolveTargetsFromFlags("ns1", "sched1", "", nil)
+		require.NoError(t, err)
+		require.Equal(t, []auditTarget{{Namespace: "ns1", ScheduleID: "sched1"}}, got)
+	})
+
+	t.Run("--namespace and --file are mutually exclusive", func(t *testing.T) {
+		_, err := resolveTargetsFromFlags("ns1", "", "some-path", nil)
+		require.ErrorContains(t, err, "--namespace and --file are mutually exclusive")
+	})
+
+	t.Run("--schedule-id with --file is rejected", func(t *testing.T) {
+		_, err := resolveTargetsFromFlags("", "sched1", "some-path", nil)
+		require.ErrorContains(t, err, "--schedule-id is only valid with --namespace")
+	})
+
+	t.Run("neither --namespace nor --file is an error", func(t *testing.T) {
+		_, err := resolveTargetsFromFlags("", "", "", nil)
+		require.ErrorContains(t, err, "one of --namespace or --file is required")
+	})
+
+	t.Run("--file - reads from stdin", func(t *testing.T) {
+		stdin := strings.NewReader("ns1\nns2,sched2\n")
+		got, err := resolveTargetsFromFlags("", "", "-", stdin)
+		require.NoError(t, err)
+		require.Equal(t, []auditTarget{{Namespace: "ns1"}, {Namespace: "ns2", ScheduleID: "sched2"}}, got)
+	})
+
+	t.Run("--file - with empty stdin is rejected", func(t *testing.T) {
+		_, err := resolveTargetsFromFlags("", "", "-", strings.NewReader(""))
+		require.ErrorContains(t, err, `--file "-" has no target entries`)
+	})
+
+	t.Run("--file path reads from disk", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "targets.tsv")
+		require.NoError(t, os.WriteFile(path, []byte("ns1\nns2,sched2\n"), 0o600))
+		got, err := resolveTargetsFromFlags("", "", path, nil)
+		require.NoError(t, err)
+		require.Equal(t, []auditTarget{{Namespace: "ns1"}, {Namespace: "ns2", ScheduleID: "sched2"}}, got)
+	})
+
+	t.Run("--file path that doesn't exist returns an error", func(t *testing.T) {
+		_, err := resolveTargetsFromFlags("", "", filepath.Join(t.TempDir(), "missing.tsv"), nil)
+		require.ErrorContains(t, err, "no such file or directory")
+	})
+
+	t.Run("--file with only comments is rejected", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "comments.tsv")
+		require.NoError(t, os.WriteFile(path, []byte("# only comments\n\n# nothing else\n"), 0o600))
+		_, err := resolveTargetsFromFlags("", "", path, nil)
+		require.ErrorContains(t, err, "has no target entries")
+	})
+
+	t.Run("--file with malformed line surfaces parser error", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "bad.tsv")
+		require.NoError(t, os.WriteFile(path, []byte("ns1,sched1,extra\n"), 0o600))
+		_, err := resolveTargetsFromFlags("", "", path, nil)
+		require.ErrorContains(t, err, "malformed line")
+	})
 }
 
 func TestExpectedFireTimes(t *testing.T) {
@@ -115,7 +289,7 @@ func TestExpectedFireTimes(t *testing.T) {
 		start := time.Date(2026, 5, 19, 18, 0, 0, 0, time.UTC)
 		end := time.Date(2026, 5, 19, 23, 0, 0, 0, time.UTC)
 
-		actual, err := expectedFireTimes(spec, "schedid", start, end)
+		actual, err := expectedFireTimes(spec, start, end)
 		require.NoError(t, err)
 
 		expected := []time.Time{
@@ -143,7 +317,7 @@ func TestExpectedFireTimes(t *testing.T) {
 		}
 		start := time.Date(2026, 5, 19, 18, 0, 0, 0, time.UTC)
 		end := time.Date(2026, 5, 19, 19, 0, 0, 0, time.UTC)
-		actual, err := expectedFireTimes(spec, "x", start, end)
+		actual, err := expectedFireTimes(spec, start, end)
 		require.NoError(t, err)
 
 		expected := []time.Time{
@@ -159,7 +333,7 @@ func TestExpectedFireTimes(t *testing.T) {
 		spec := &schedulepb.ScheduleSpec{
 			CronString: []string{"0 * * * *"},
 		}
-		actual, err := expectedFireTimes(spec, "sid",
+		actual, err := expectedFireTimes(spec,
 			mustParseTime("2026-05-19T18:00:00Z"),
 			mustParseTime("2026-05-19T21:00:00Z"))
 		require.NoError(t, err)
@@ -178,7 +352,7 @@ func TestExpectedFireTimes(t *testing.T) {
 				Second: "0",
 			}},
 		}
-		actual, err := expectedFireTimes(spec, "sid",
+		actual, err := expectedFireTimes(spec,
 			mustParseTime("2026-05-19T00:00:00Z"),
 			mustParseTime("2026-05-21T12:00:00Z"))
 		require.NoError(t, err)
@@ -201,7 +375,7 @@ func TestExpectedFireTimes(t *testing.T) {
 				DayOfWeek:  []*schedulepb.Range{{Start: 0, End: 6, Step: 1}},
 			}},
 		}
-		actual, err := expectedFireTimes(spec, "sid",
+		actual, err := expectedFireTimes(spec,
 			mustParseTime("2026-05-19T00:30:00Z"),
 			mustParseTime("2026-05-19T04:00:00Z"))
 		require.NoError(t, err)
@@ -226,7 +400,7 @@ func TestExpectedFireTimes(t *testing.T) {
 			}},
 			TimezoneName: "America/Los_Angeles",
 		}
-		actual, err := expectedFireTimes(spec, "sid",
+		actual, err := expectedFireTimes(spec,
 			mustParseTime("2026-05-19T00:00:00Z"),
 			mustParseTime("2026-05-20T00:00:00Z"))
 		require.NoError(t, err)
@@ -248,7 +422,7 @@ func TestExpectedFireTimes(t *testing.T) {
 			}},
 			TimezoneName: "America/New_York",
 		}
-		actual, err := expectedFireTimes(spec, "sid",
+		actual, err := expectedFireTimes(spec,
 			mustParseTime("2026-03-07T00:00:00Z"),
 			mustParseTime("2026-03-11T00:00:00Z"))
 		require.NoError(t, err)
@@ -262,7 +436,7 @@ func TestExpectedFireTimes(t *testing.T) {
 			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{hourlyStructured()},
 			EndTime:            timestamppb.New(mustParseTime("2026-01-01T00:00:00Z")),
 		}
-		actual, err := expectedFireTimes(spec, "sid",
+		actual, err := expectedFireTimes(spec,
 			mustParseTime("2026-05-19T18:00:00Z"),
 			mustParseTime("2026-05-19T22:00:00Z"))
 		require.NoError(t, err)
@@ -274,7 +448,7 @@ func TestExpectedFireTimes(t *testing.T) {
 			StructuredCalendar: []*schedulepb.StructuredCalendarSpec{hourlyStructured()},
 			StartTime:          timestamppb.New(mustParseTime("2027-01-01T00:00:00Z")),
 		}
-		actual, err := expectedFireTimes(spec, "sid",
+		actual, err := expectedFireTimes(spec,
 			mustParseTime("2026-05-19T18:00:00Z"),
 			mustParseTime("2026-05-19T22:00:00Z"))
 		require.NoError(t, err)
@@ -288,7 +462,7 @@ func TestExpectedFireTimes(t *testing.T) {
 				Phase:    durationpb.New(6*time.Minute + 7*time.Second),
 			}},
 		}
-		actual, err := expectedFireTimes(spec, "sid",
+		actual, err := expectedFireTimes(spec,
 			mustParseTime("2026-05-19T18:00:00Z"),
 			mustParseTime("2026-05-19T19:00:00Z"))
 		require.NoError(t, err)

--- a/tools/tdbg/tdbg_commands.go
+++ b/tools/tdbg/tdbg_commands.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/urfave/cli/v2"
 	commonpb "go.temporal.io/api/common/v1"
@@ -338,36 +337,23 @@ OUTPUT FORMAT
   Per-schedule columns (identical in both modes, in order):
     namespace                      namespace the schedule lives in
     schedule_id                    schedule's ID
-    workflow_type                  workflow type the schedule's action starts 
-    jitter_s                       schedule's configured jitter in seconds
+    workflow_type                  workflow type the schedule's action starts
     expected                       how many fires the spec should have produced
     actual                         unique workflows observed in visibility (multiple ContinueAsNew links of one
                                    fire are counted once)
     matched                        fires whose nominal time aligns with a workflow
-    missed                         total unmatched expected fires (real_miss + skip_overlap + inconclusive + unsupported)
+    missed                         total unmatched expected fires (real_miss + skip_overlap + inconclusive)
     real_miss                      expected fires with no matching workflow and nothing else from this schedule
-                                   running to justify a skip; counts here warrant investigation (see CAVEATS for
-                                   known by-design patterns)
+                                   running to justify a skip. Covers all overlap policies. Counts here warrant
+                                   investigation (see CAVEATS for known by-design patterns).
     skip_overlap                   fires the scheduler correctly skipped because a prior workflow from this schedule
-                                   was still running
+                                   was still running (SKIP / BUFFER_ONE / BUFFER_ALL policies)
     inconclusive_schedule_changed  schedule's spec was modified DURING the audit window; current spec doesn't describe
-                                   what was firing earlier, so unmatched fires can't be classified as real_miss
+                                   what was firing earlier, so all fires for this schedule are marked inconclusive
                                    (the row stays for inspection)
-    unsupported_policy             fires belonging to a schedule using a policy this audit does not fully model;
-                                   exposed rather than counted as real_miss (see unsupported_reason for which one)
-    unsupported_reason             which policy was detected; semicolon-separated if multiple. Possible values:
-                                     keep_original_workflow_id  -- all fires share one WorkflowID, so the audit can't
-                                                                   distinguish individual fires from each other
-                                     overlap_buffer_all         -- fires can be queued for arbitrary durations, beyond
-                                                                   our 24h query buffer; we may miss the workflow
-                                     overlap_allow_all          -- scheduler never skips on overlap, so skip_overlap
-                                                                   labels for this schedule may actually be real misses
-                                     overlap_cancel_other       -- new fire cancels prior; workflow lifecycle differs
-                                                                   from the standard model 
-                                     overlap_terminate_other    -- same as cancel_other
     catchup_window_s               the schedule's configured catchupWindow in seconds
-    real_miss_times                up to 20 nominal times classified as real_miss after post-process reclassification
-                                   (excludes skip_overlap, inconclusive_schedule_changed, unsupported_policy times)
+    real_miss_times                up to 20 nominal times classified as real_miss
+                                   (excludes skip_overlap, inconclusive_schedule_changed times)
 
 CAVEATS AND LIMITATIONS
   Retention: the audit will not process a namespace whose windowStart is past (retention - 24h). Visibility purges
@@ -375,11 +361,7 @@ CAVEATS AND LIMITATIONS
     namespaces are logged to stderr.
 
   Schedule modified during window: see inconclusive_schedule_changed. The audit can't compute the historical spec,
-    so any unmatched fires for these schedules are reclassified rather than counted.
-
-  Unsupported policies: the audit's algorithm doesn't fully model a few overlap policies and keep_original_workflow_id.
-    Real_miss entries on schedules using those are moved to unsupported_policy with the specific reason in
-    unsupported_reason.
+    so the schedule's row is marked inconclusive rather than producing untrustworthy classifications.
 
   Paused / exhausted schedules: dropped from analysis (their spec evaluates to fire times but the scheduler won't fire).
 
@@ -396,10 +378,6 @@ CAVEATS AND LIMITATIONS
     numbers, followed by a multi-minute gap, then a single WORKFLOW_TASK_COMPLETED that resumes normal cadence;
     (3) compare the identity field on WORKFLOW_TASK_STARTED across affected schedules. A shared worker identity points
     to a single sick worker pod; distinct identities point to a broader frontend/matching/persistence issue.
-
-  Window size cap: --start and --end must span no more than the value of --max-window (default 168h = 7 days).
-    Raise --max-window to audit lower-frequency schedules (e.g. quarterly, yearly); see the --max-window flag help
-    for details and unit caveats. Wider windows are proportionally slower and use more memory.
 
 FILE FORMAT (for --file / stdin)
   One audit target per line as 'namespace[,schedule_id]'. Examples:
@@ -454,14 +432,6 @@ EXAMPLES
 					Name:     FlagEnd,
 					Usage:    "Window end (RFC3339)",
 					Required: true,
-				},
-				&cli.DurationFlag{
-					Name: FlagMaxWindow,
-					Usage: "Maximum allowed window between --start and --end. Default 168h (7d). Raise this " +
-						"to audit schedules that fire less frequently (e.g. quarterly, yearly); larger windows " +
-						"are proportionally slower and use more memory. Use hour units (e.g. 9600h for 400 days); " +
-						"day suffixes are not supported by Go's duration parser.",
-					Value: 7 * 24 * time.Hour,
 				},
 				&cli.StringFlag{
 					Name:    FlagOutputDir,

--- a/tools/tdbg/tdbg_commands.go
+++ b/tools/tdbg/tdbg_commands.go
@@ -319,6 +319,143 @@ func newAdminScheduleCommands(clientFactory ClientFactory) []*cli.Command {
 				return AdminMigrateSchedule(c, clientFactory)
 			},
 		},
+		{
+			Name:  "audit",
+			Usage: "Audit a namespace's schedules for missed runs in a time window",
+			Description: `Lists every schedule in the target namespace(s), computes the nominal fire times each spec should have
+produced in the audit window, and classifies each fire against actual workflow executions found in visibility.
+Designed to answer: did the scheduler fire when it should have, during a specific time range?
+
+OUTPUT FORMAT
+  With --output-dir set, two file types are written:
+    summary.csv                  one row per flagged namespace (aggregated counts)
+    per-namespace/<ns>.csv       one row per flagged schedule
+
+  Without --output-dir, a single CSV stream of every flagged row across all namespaces is written to stdout, with one
+  header and no summary file. The same per-schedule columns are used.
+
+  Per-schedule columns (identical in both modes, in order):
+    namespace                      namespace the schedule lives in
+    schedule_id                    schedule's ID
+    workflow_type                  workflow type the schedule's action starts 
+    jitter_s                       schedule's configured jitter in seconds
+    expected                       how many fires the spec should have produced
+    actual                         unique workflows observed in visibility (multiple ContinueAsNew links of one
+                                   fire are counted once)
+    matched                        fires whose nominal time aligns with a workflow
+    missed                         total unmatched expected fires (real_miss + skip_overlap + inconclusive + unsupported)
+    real_miss                      expected fires with no matching workflow and nothing else from this schedule
+                                   running to justify a skip; counts here warrant investigation (see CAVEATS for
+                                   known by-design patterns)
+    skip_overlap                   fires the scheduler correctly skipped because a prior workflow from this schedule
+                                   was still running
+    inconclusive_schedule_changed  schedule's spec was modified DURING the audit window; current spec doesn't describe
+                                   what was firing earlier, so unmatched fires can't be classified as real_miss
+                                   (the row stays for inspection)
+    unsupported_policy             fires belonging to a schedule using a policy this audit does not fully model;
+                                   exposed rather than counted as real_miss (see unsupported_reason for which one)
+    unsupported_reason             which policy was detected; semicolon-separated if multiple. Possible values:
+                                     keep_original_workflow_id  -- all fires share one WorkflowID, so the audit can't
+                                                                   distinguish individual fires from each other
+                                     overlap_buffer_all         -- fires can be queued for arbitrary durations, beyond
+                                                                   our 24h query buffer; we may miss the workflow
+                                     overlap_allow_all          -- scheduler never skips on overlap, so skip_overlap
+                                                                   labels for this schedule may actually be real misses
+                                     overlap_cancel_other       -- new fire cancels prior; workflow lifecycle differs
+                                                                   from the standard model 
+                                     overlap_terminate_other    -- same as cancel_other
+    catchup_window_s               the schedule's configured catchupWindow in seconds
+    real_miss_times                up to 20 nominal times classified as real_miss after post-process reclassification
+                                   (excludes skip_overlap, inconclusive_schedule_changed, unsupported_policy times)
+
+CAVEATS AND LIMITATIONS
+  Retention: the audit will not process a namespace whose windowStart is past (retention - 24h). Visibility purges
+    closed workflows after retention; the guard prevents silent false-positive real_miss against purged data. Skipped
+    namespaces are logged to stderr.
+
+  Schedule modified during window: see inconclusive_schedule_changed. The audit can't compute the historical spec,
+    so any unmatched fires for these schedules are reclassified rather than counted.
+
+  Unsupported policies: the audit's algorithm doesn't fully model a few overlap policies and keep_original_workflow_id.
+    Real_miss entries on schedules using those are moved to unsupported_policy with the specific reason in
+    unsupported_reason.
+
+  Paused / exhausted schedules: dropped from analysis (their spec evaluates to fire times but the scheduler won't fire).
+
+  Catchup window: a schedule with a tight catchupWindow (e.g. 10s) will lose fires if the scheduler is briefly
+    unavailable. The audit reports such losses as real_miss; the catchup_window_s column lets users distinguish
+    "true sustained outage" from "brief blip + tight catchup".
+
+  Catchup under overlap=SKIP after a brief outage: when the V1 scheduler resumes with multiple queued fires, it
+    dispatches only the oldest and discards the rest. The audit reports the discarded fires as real_miss. A burst of
+    real_miss across many schedules within minutes typically indicates this behavior. To confirm, the user must:
+    (1) ListWorkflowExecutions with WorkflowId='temporal-sys-scheduler:<schedule_id>' and
+    TemporalNamespaceDivision='TemporalScheduler' to find the scheduler workflow run active during the window;
+    (2) GetWorkflowExecutionHistory on that run and look for WORKFLOW_TASK_TIMED_OUT events with escalating attempt
+    numbers, followed by a multi-minute gap, then a single WORKFLOW_TASK_COMPLETED that resumes normal cadence;
+    (3) compare the identity field on WORKFLOW_TASK_STARTED across affected schedules. A shared worker identity points
+    to a single sick worker pod; distinct identities point to a broader frontend/matching/persistence issue.
+
+  Window size cap: --start and --end must span no more than 7 days. Wider windows are rejected; chunk into multiple
+    shorter audits instead.
+
+EXAMPLES
+  Single namespace, 1-day window, write CSV bundle:
+    tdbg schedule audit --namespace my-ns --start 2026-05-19T00:00:00Z --end 2026-05-20T00:00:00Z --output-dir ./audit-out
+
+  Many namespaces from a file:
+    tdbg schedule audit --namespace-file ./ns-list.txt --start 2026-05-01T19:30:00Z --end 2026-05-02T10:00:00Z \
+      --output-dir ./audit-out
+
+  Single schedule deep-dive (omit --output-dir to print one CSV row to stdout):
+    tdbg schedule audit --namespace my-ns --schedule-id my-schedule \
+      --start 2026-05-19T18:00:00Z --end 2026-05-19T22:00:00Z
+
+  Pipe stdout output to your favorite filter (e.g. only show rows with real_miss > 0):
+    tdbg schedule audit --namespace-file ./ns-list.txt \
+      --start 2026-05-01T19:30:00Z --end 2026-05-02T10:00:00Z \
+      | awk -F, 'NR==1 || $9 > 0'`,
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:    FlagNamespace,
+					Aliases: FlagNamespaceAlias,
+					Usage:   "Single namespace to audit (mutually exclusive with --namespace-file)",
+				},
+				&cli.StringFlag{
+					Name:  FlagNamespaceFile,
+					Usage: "Path to file with one namespace per line (mutually exclusive with --namespace)",
+				},
+				&cli.StringFlag{
+					Name:    FlagScheduleID,
+					Aliases: FlagScheduleIDAlias,
+					Usage:   "Optional: audit only this schedule within --namespace",
+				},
+				&cli.StringFlag{
+					Name:     FlagAuditStart,
+					Usage:    "Window start (RFC3339)",
+					Required: true,
+				},
+				&cli.StringFlag{
+					Name:     FlagAuditEnd,
+					Usage:    "Window end (RFC3339)",
+					Required: true,
+				},
+				&cli.StringFlag{
+					Name:    FlagOutputDir,
+					Aliases: FlagOutputDirAlias,
+					Usage: "Directory to write summary.csv + per-namespace/<ns>.csv (will be created if missing). " +
+						"If unset, writes one CSV stream (all rows from all namespaces, single header) to stdout instead.",
+				},
+				&cli.IntFlag{
+					Name:  FlagNamespaceConcurrency,
+					Usage: "How many namespaces to audit in parallel.",
+					Value: 8,
+				},
+			},
+			Action: func(c *cli.Context) error {
+				return AdminAuditSchedules(c, clientFactory)
+			},
+		},
 	}
 }
 

--- a/tools/tdbg/tdbg_commands.go
+++ b/tools/tdbg/tdbg_commands.go
@@ -327,14 +327,15 @@ produced in the audit window, and classifies each fire against actual workflow e
 Designed to answer: did the scheduler fire when it should have, during a specific time range?
 
 OUTPUT FORMAT
-  With --output-dir set, two file types are written:
-    summary.csv                  one row per flagged namespace (aggregated counts)
-    per-namespace/<ns>.csv       one row per flagged schedule
+  --format jsonl (default) emits one JSON object per line; --format csv emits CSV.
 
-  Without --output-dir, a single CSV stream of every flagged row across all namespaces is written to stdout, with one
-  header and no summary file. The same per-schedule columns are used.
+  With --output-dir set, two file types are written (extension follows --format):
+    summary.<ext>                  one row per flagged namespace (aggregated counts)
+    per-namespace/<ns>.<ext>       one row per flagged schedule
 
-  Per-schedule columns (identical in both modes, in order):
+  Without --output-dir, every flagged row across all namespaces is streamed to stdout (no summary).
+
+  Per-schedule fields (identical across both formats; CSV uses these as column headers, JSONL as object keys):
     namespace                      namespace the schedule lives in
     schedule_id                    schedule's ID
     workflow_type                  workflow type the schedule's action starts
@@ -436,13 +437,18 @@ EXAMPLES
 				&cli.StringFlag{
 					Name:    FlagOutputDir,
 					Aliases: FlagOutputDirAlias,
-					Usage: "Directory to write summary.csv + per-namespace/<ns>.csv (will be created if missing). " +
-						"If unset, writes one CSV stream (all rows from all namespaces, single header) to stdout instead.",
+					Usage: "Directory to write summary + per-namespace/<ns> files (will be created if missing). " +
+						"File extension follows --format. If unset, streams all rows to stdout instead.",
 				},
 				&cli.IntFlag{
 					Name:  FlagNamespaceConcurrency,
 					Usage: "How many namespaces to audit in parallel.",
 					Value: 8,
+				},
+				&cli.StringFlag{
+					Name:  FlagFormat,
+					Usage: "Output format: jsonl (one object per line, jq-friendly) or csv.",
+					Value: "jsonl",
 				},
 			},
 			Action: func(c *cli.Context) error {

--- a/tools/tdbg/tdbg_commands.go
+++ b/tools/tdbg/tdbg_commands.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/urfave/cli/v2"
 	commonpb "go.temporal.io/api/common/v1"
@@ -396,49 +397,71 @@ CAVEATS AND LIMITATIONS
     (3) compare the identity field on WORKFLOW_TASK_STARTED across affected schedules. A shared worker identity points
     to a single sick worker pod; distinct identities point to a broader frontend/matching/persistence issue.
 
-  Window size cap: --start and --end must span no more than 7 days. Wider windows are rejected; chunk into multiple
-    shorter audits instead.
+  Window size cap: --start and --end must span no more than the value of --max-window (default 168h = 7 days).
+    Raise --max-window to audit lower-frequency schedules (e.g. quarterly, yearly); see the --max-window flag help
+    for details and unit caveats. Wider windows are proportionally slower and use more memory.
+
+FILE FORMAT (for --file / stdin)
+  One audit target per line as 'namespace[,schedule_id]'. Examples:
+    checker-ses-northwest-prod.90d0d
+    datastore-northwest-prod.90d0d,DeleteExpiredSecretsScheduledWorkflow--one
+    synthetics-northwest-prod.90d0d,my-schedule
+  Lines starting with '#' and blank lines are ignored. Schedule IDs must not contain commas.
 
 EXAMPLES
   Single namespace, 1-day window, write CSV bundle:
     tdbg schedule audit --namespace my-ns --start 2026-05-19T00:00:00Z --end 2026-05-20T00:00:00Z --output-dir ./audit-out
 
-  Many namespaces from a file:
-    tdbg schedule audit --namespace-file ./ns-list.txt --start 2026-05-01T19:30:00Z --end 2026-05-02T10:00:00Z \
+  Many targets from a file:
+    tdbg schedule audit -f ./targets.csv --start 2026-05-01T19:30:00Z --end 2026-05-02T10:00:00Z \
       --output-dir ./audit-out
+
+  Pipe targets from stdin (cat, psql, awk, etc.):
+    cat ./targets.csv | tdbg schedule audit -f - --start 2026-05-01T00:00:00Z --end 2026-05-02T00:00:00Z
 
   Single schedule deep-dive (omit --output-dir to print one CSV row to stdout):
     tdbg schedule audit --namespace my-ns --schedule-id my-schedule \
       --start 2026-05-19T18:00:00Z --end 2026-05-19T22:00:00Z
 
   Pipe stdout output to your favorite filter (e.g. only show rows with real_miss > 0):
-    tdbg schedule audit --namespace-file ./ns-list.txt \
+    tdbg schedule audit -f ./targets.csv \
       --start 2026-05-01T19:30:00Z --end 2026-05-02T10:00:00Z \
       | awk -F, 'NR==1 || $9 > 0'`,
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:    FlagNamespace,
 					Aliases: FlagNamespaceAlias,
-					Usage:   "Single namespace to audit (mutually exclusive with --namespace-file)",
+					Usage:   "Single namespace to audit (mutually exclusive with --file)",
 				},
 				&cli.StringFlag{
-					Name:  FlagNamespaceFile,
-					Usage: "Path to file with one namespace per line (mutually exclusive with --namespace)",
+					Name:    FlagFile,
+					Aliases: FlagFileAlias,
+					Usage: "Path to file with one audit target per line as 'namespace[,schedule_id]'. " +
+						"Use '-' to read from stdin. Mutually exclusive with --namespace. " +
+						"Schedule IDs must not contain commas. Lines starting with '#' and blank lines are ignored.",
 				},
 				&cli.StringFlag{
 					Name:    FlagScheduleID,
 					Aliases: FlagScheduleIDAlias,
-					Usage:   "Optional: audit only this schedule within --namespace",
+					Usage:   "Optional: audit only this schedule within --namespace (use the per-line form in --file for multiple targets)",
 				},
 				&cli.StringFlag{
-					Name:     FlagAuditStart,
+					Name:     FlagStart,
 					Usage:    "Window start (RFC3339)",
 					Required: true,
 				},
 				&cli.StringFlag{
-					Name:     FlagAuditEnd,
+					Name:     FlagEnd,
 					Usage:    "Window end (RFC3339)",
 					Required: true,
+				},
+				&cli.DurationFlag{
+					Name: FlagMaxWindow,
+					Usage: "Maximum allowed window between --start and --end. Default 168h (7d). Raise this " +
+						"to audit schedules that fire less frequently (e.g. quarterly, yearly); larger windows " +
+						"are proportionally slower and use more memory. Use hour units (e.g. 9600h for 400 days); " +
+						"day suffixes are not supported by Go's duration parser.",
+					Value: 7 * 24 * time.Hour,
 				},
 				&cli.StringFlag{
 					Name:    FlagOutputDir,


### PR DESCRIPTION
## What changed?
Adds a new tdbg schedule audit subcommand under tdbg schedule. The command lists every schedule in the target namespace(s), computes the nominal fire times each spec should have produced inside a user-specified window, queries visibility for the workflows that actually ran, and emits a per-schedule classification of each expected fire:
  - real_miss — expected fire with no matching workflow and nothing else from the schedule running to justify a skip
  - skip_overlap — fire correctly skipped because a prior workflow was still running
  - inconclusive_schedule_changed — schedule spec was modified during the audit window; historical spec can't be recovered
  - unsupported_policy — schedule uses a policy this audit doesn't fully model (BUFFER_ALL, ALLOW_ALL, CANCEL_OTHER, TERMINATE_OTHER, KeepOriginalWorkflowId); surfaced rather than miscounted

Output is either a CSV bundle (summary.csv + per-namespace files) when --output-dir is set, or a single flat CSV stream to stdout when it isn't.

## Why?
We've had several incidents where schedules silently missed fires, and answering "did the scheduler fire when it should have, during this window?" required ad-hoc visibility queries per schedule. This tool makes that question answerable in a single command across all schedules in many namespaces in parallel, and produces a machine-readable artifact that can be diffed across days to spot regressions. 

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [ ] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)
