### PR TITLE
Generate JSON test summary

### DIFF
--- a/.github/actions/post-test-reporting/action.yml
+++ b/.github/actions/post-test-reporting/action.yml
@@ -1,0 +1,106 @@
+name: Post Test Reporting
+description: Generate test reports and upload post-test artifacts
+inputs:
+  artifact-name-suffix:
+    description: Suffix to use for uploaded artifact names
+    required: true
+  codecov-flag:
+    description: Codecov flag for coverage and test result uploads
+    required: false
+    default: ""
+  debug-log-path:
+    description: Optional debug log path to upload
+    required: false
+    default: ""
+  job-name:
+    description: Exact job name to resolve for artifact names
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Print memory snapshot
+      if: always()
+      shell: bash
+      run: cat /tmp/memory_snapshot.txt || true
+
+    - name: Generate crash report
+      if: failure()
+      shell: bash
+      run: |
+        [ "$(find .testoutput -maxdepth 1 -name 'junit.*.xml' | wc -l)" -lt "$MAX_TEST_ATTEMPTS" ] &&
+          CRASH_REPORT_NAME="$GITHUB_JOB" make report-test-crash
+
+    - name: Generate test summary
+      if: ${{ !cancelled() }}
+      shell: bash
+      run: |
+        make -s generate-test-summary
+        if [ -s .testoutput/test-summary.md ]; then
+          cat .testoutput/test-summary.md > "$GITHUB_STEP_SUMMARY"
+        fi
+
+    - name: Resolve Codecov flag
+      id: codecov
+      if: ${{ !cancelled() }}
+      shell: bash
+      env:
+        CODECOV_FLAG: ${{ inputs.codecov-flag }}
+        ARTIFACT_NAME_SUFFIX: ${{ inputs.artifact-name-suffix }}
+      run: |
+        flag="$CODECOV_FLAG"
+        if [ -z "$flag" ]; then
+          flag="$ARTIFACT_NAME_SUFFIX"
+        fi
+        echo "flag=$flag" >> "$GITHUB_OUTPUT"
+
+    - name: Upload code coverage to Codecov
+      if: ${{ !failure() && !cancelled() }}
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ env.CODECOV_TOKEN }}
+        directory: ./.testoutput
+        flags: ${{ steps.codecov.outputs.flag }}
+
+    - name: Upload test results to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ env.CODECOV_TOKEN }}
+        directory: ./.testoutput
+        flags: ${{ steps.codecov.outputs.flag }}
+        report_type: test_results
+
+    - name: Get job ID
+      id: get_job_id
+      uses: ./.github/actions/get-job-id
+      with:
+        job_name: ${{ inputs.job-name }}
+        run_id: ${{ github.run_id }}
+
+    - name: Upload test results to GitHub
+      # Can't pin to major because the action linter doesn't recognize the include-hidden-files flag.
+      uses: actions/upload-artifact@v6
+      if: ${{ !cancelled() }}
+      with:
+        name: junit-xml--${{ github.run_id }}--${{ steps.get_job_id.outputs.job_id }}--${{ github.run_attempt }}--${{ inputs.artifact-name-suffix }}
+        path: ./.testoutput/junit.*.xml
+        include-hidden-files: true
+        retention-days: 28
+
+    - name: Upload test summary JSON to GitHub
+      uses: actions/upload-artifact@v6
+      if: ${{ !cancelled() }}
+      with:
+        name: test-summary-json--${{ github.run_id }}--${{ steps.get_job_id.outputs.job_id }}--${{ github.run_attempt }}--${{ inputs.artifact-name-suffix }}
+        path: ./.testoutput/test-summary.json
+        if-no-files-found: ignore
+        retention-days: 28
+
+    - name: Upload debug logs
+      uses: actions/upload-artifact@v6
+      if: ${{ !cancelled() && inputs.debug-log-path != '' }}
+      with:
+        name: debug-logs--${{ github.run_id }}--${{ steps.get_job_id.outputs.job_id }}--${{ github.run_attempt }}--${{ inputs.artifact-name-suffix }}
+        path: ${{ inputs.debug-log-path }}
+        if-no-files-found: ignore
+        retention-days: 14

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -318,65 +318,14 @@ jobs:
         timeout-minutes: 20
         run: TEST_TIMEOUT=15m ./develop/github/monitor_test.sh make unit-test-coverage
 
-      - name: Print memory snapshot
+      - name: Post-test reporting
         if: always()
-        run: cat /tmp/memory_snapshot.txt || true
-
-      - name: Generate crash report
-        if: failure() # if the tests failed, we would expect one JUnit XML report per attempt; otherwise it must have crashed
-        run: |
-          [ "$(find .testoutput -maxdepth 1 -name 'junit.*.xml' | wc -l)" -lt "$MAX_TEST_ATTEMPTS" ] &&
-            CRASH_REPORT_NAME="$GITHUB_JOB" make report-test-crash
-
-      - name: Generate test summary
-        if: ${{ !cancelled() }}
-        run: |
-          make -s generate-test-summary
-          if [ -s .testoutput/test-summary.md ]; then
-            cat .testoutput/test-summary.md > "$GITHUB_STEP_SUMMARY"
-          fi
-
-      - name: Upload code coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: ./.github/actions/post-test-reporting
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ./.testoutput
-          flags: unit-test
-
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ./.testoutput
-          flags: unit-test
-          report_type: test_results
-
-      - name: Get job ID
-        id: get_job_id
-        uses: ./.github/actions/get-job-id
-        with:
-          job_name: Unit test
-          run_id: ${{ github.run_id }}
-
-      - name: Upload test results to GitHub
-        # Can't pin to major because the action linter doesn't recognize the include-hidden-files flag.
-        uses: actions/upload-artifact@v6
-        if: ${{ !cancelled() }}
-        with:
-          name: junit-xml--${{ github.run_id }}--${{ steps.get_job_id.outputs.job_id }}--${{ github.run_attempt }}--unit-test
-          path: ./.testoutput/junit.*.xml
-          include-hidden-files: true
-          retention-days: 28
-
-      - name: Upload test summary JSON to GitHub
-        uses: actions/upload-artifact@v6
-        if: ${{ !cancelled() }}
-        with:
-          name: test-summary-json--${{ github.run_id }}--${{ steps.get_job_id.outputs.job_id }}--${{ github.run_attempt }}--unit-test
-          path: ./.testoutput/test-summary.json
-          if-no-files-found: ignore
-          retention-days: 28
+          job-name: Unit test
+          artifact-name-suffix: unit-test
 
   integration-test:
     name: Integration test
@@ -425,65 +374,14 @@ jobs:
         timeout-minutes: 15
         run: ./develop/github/monitor_test.sh make integration-test-coverage
 
-      - name: Print memory snapshot
+      - name: Post-test reporting
         if: always()
-        run: cat /tmp/memory_snapshot.txt || true
-
-      - name: Generate crash report
-        if: failure() # if the tests failed, we would expect one JUnit XML report per attempt; otherwise it must have crashed
-        run: |
-          [ "$(find .testoutput -maxdepth 1 -name 'junit.*.xml' | wc -l)" -lt "$MAX_TEST_ATTEMPTS" ] &&
-            CRASH_REPORT_NAME="$GITHUB_JOB" make report-test-crash
-
-      - name: Generate test summary
-        if: ${{ !cancelled() }}
-        run: |
-          make -s generate-test-summary
-          if [ -s .testoutput/test-summary.md ]; then
-            cat .testoutput/test-summary.md > "$GITHUB_STEP_SUMMARY"
-          fi
-
-      - name: Upload code coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: ./.github/actions/post-test-reporting
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ./.testoutput
-          flags: integration-test
-
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ./.testoutput
-          flags: integration-test
-          report_type: test_results
-
-      - name: Get job ID
-        id: get_job_id
-        uses: ./.github/actions/get-job-id
-        with:
-          job_name: Integration test
-          run_id: ${{ github.run_id }}
-
-      - name: Upload test results to GitHub
-        # Can't pin to major because the action linter doesn't recognize the include-hidden-files flag.
-        uses: actions/upload-artifact@v6
-        if: ${{ !cancelled() }}
-        with:
-          name: junit-xml--${{ github.run_id }}--${{ steps.get_job_id.outputs.job_id }}--${{ github.run_attempt }}--integration-test
-          path: ./.testoutput/junit.*.xml
-          include-hidden-files: true
-          retention-days: 28
-
-      - name: Upload test summary JSON to GitHub
-        uses: actions/upload-artifact@v6
-        if: ${{ !cancelled() }}
-        with:
-          name: test-summary-json--${{ github.run_id }}--${{ steps.get_job_id.outputs.job_id }}--${{ github.run_attempt }}--integration-test
-          path: ./.testoutput/test-summary.json
-          if-no-files-found: ignore
-          retention-days: 28
+          job-name: Integration test
+          artifact-name-suffix: integration-test
 
       - name: Tear down docker compose
         if: ${{ always() }}
@@ -540,13 +438,6 @@ jobs:
           path: ~/.cache/go-build
           key: go-${{ runner.os }}${{ runner.arch }}-build-${{ env.COMMIT }}
 
-      - name: Get job ID
-        id: get_job_id
-        uses: ./.github/actions/get-job-id
-        with:
-          job_name: Functional test (${{ matrix.name }}, ${{ matrix.display_name }})
-          run_id: ${{ github.run_id }}
-
       - name: ${{ matrix.display_name == 'smoke' && 'ℹ️ Smoke test' || 'ℹ️ Full test' }}
         run: echo "::notice::${{ matrix.display_name == 'smoke' && 'This is a smoke test. Add the test-all-dbs label to run all tests on all DBs.' || needs.test-setup.outputs.full_test_reason }}"
 
@@ -571,67 +462,16 @@ jobs:
         if: ${{ failure() && toJson(matrix.containers) != '[]' }}
         run: docker compose -f ${{ env.DOCKER_COMPOSE_FILE }} logs --no-color
 
-      - name: Print memory snapshot
+      - name: Post-test reporting
         if: always()
-        run: cat /tmp/memory_snapshot.txt || true
-
-      - name: Generate crash report
-        if: failure() # if the tests failed, we would expect one JUnit XML report per attempt; otherwise it must have crashed
-        run: |
-          [ "$(find .testoutput -maxdepth 1 -name 'junit.*.xml' | wc -l)" -lt "$MAX_TEST_ATTEMPTS" ] &&
-            CRASH_REPORT_NAME="$GITHUB_JOB" make report-test-crash
-
-      - name: Generate test summary
-        if: ${{ !cancelled() }}
-        run: |
-          make -s generate-test-summary
-          if [ -s .testoutput/test-summary.md ]; then
-            cat .testoutput/test-summary.md > "$GITHUB_STEP_SUMMARY"
-          fi
-
-      - name: Upload code coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: ./.github/actions/post-test-reporting
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ./.testoutput
-          flags: functional-test
-
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ./.testoutput
-          flags: functional-test
-          report_type: test_results
-
-      - name: Upload test results to GitHub
-        # Can't pin to major because the action linter doesn't recognize the include-hidden-files flag.
-        uses: actions/upload-artifact@v6
-        if: ${{ !cancelled() }}
-        with:
-          name: junit-xml--${{ github.run_id }}--${{ steps.get_job_id.outputs.job_id }}--${{ github.run_attempt }}--${{ matrix.name }}--${{ matrix.display_name }}--functional-test
-          path: ./.testoutput/junit.*.xml
-          include-hidden-files: true
-          retention-days: 28
-
-      - name: Upload test summary JSON to GitHub
-        uses: actions/upload-artifact@v6
-        if: ${{ !cancelled() }}
-        with:
-          name: test-summary-json--${{ github.run_id }}--${{ steps.get_job_id.outputs.job_id }}--${{ github.run_attempt }}--${{ matrix.name }}--${{ matrix.display_name }}--functional-test
-          path: ./.testoutput/test-summary.json
-          if-no-files-found: ignore
-          retention-days: 28
-
-      - name: Upload debug logs
-        uses: actions/upload-artifact@v6
-        if: ${{ !cancelled() }}
-        with:
-          name: debug-logs--${{ github.run_id }}--${{ steps.get_job_id.outputs.job_id }}--${{ github.run_attempt }}--${{ matrix.name }}--${{ matrix.display_name }}--functional-test
-          path: ${{ github.workspace }}/.testoutput/debug.log
-          if-no-files-found: ignore
-          retention-days: 14
+          job-name: Functional test (${{ matrix.name }}, ${{ matrix.display_name }})
+          artifact-name-suffix: ${{ matrix.name }}--${{ matrix.display_name }}--functional-test
+          codecov-flag: functional-test
+          debug-log-path: ${{ github.workspace }}/.testoutput/debug.log
 
   mixed-brain-test:
     name: Mixed brain test

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -328,12 +328,12 @@ jobs:
           [ "$(find .testoutput -maxdepth 1 -name 'junit.*.xml' | wc -l)" -lt "$MAX_TEST_ATTEMPTS" ] &&
             CRASH_REPORT_NAME="$GITHUB_JOB" make report-test-crash
 
-      - name: Write test summary
+      - name: Generate test summary
         if: ${{ !cancelled() }}
         run: |
-          summary="$(make -s print-test-summary)"
-          if [ -n "$summary" ]; then
-            printf '%s\n' "$summary" > "$GITHUB_STEP_SUMMARY"
+          make -s generate-test-summary
+          if [ -s .testoutput/test-summary.md ]; then
+            cat .testoutput/test-summary.md > "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Upload code coverage to Codecov
@@ -367,6 +367,15 @@ jobs:
           name: junit-xml--${{ github.run_id }}--${{ steps.get_job_id.outputs.job_id }}--${{ github.run_attempt }}--unit-test
           path: ./.testoutput/junit.*.xml
           include-hidden-files: true
+          retention-days: 28
+
+      - name: Upload test summary JSON to GitHub
+        uses: actions/upload-artifact@v6
+        if: ${{ !cancelled() }}
+        with:
+          name: test-summary-json--${{ github.run_id }}--${{ steps.get_job_id.outputs.job_id }}--${{ github.run_attempt }}--unit-test
+          path: ./.testoutput/test-summary.json
+          if-no-files-found: ignore
           retention-days: 28
 
   integration-test:
@@ -426,12 +435,12 @@ jobs:
           [ "$(find .testoutput -maxdepth 1 -name 'junit.*.xml' | wc -l)" -lt "$MAX_TEST_ATTEMPTS" ] &&
             CRASH_REPORT_NAME="$GITHUB_JOB" make report-test-crash
 
-      - name: Write test summary
+      - name: Generate test summary
         if: ${{ !cancelled() }}
         run: |
-          summary="$(make -s print-test-summary)"
-          if [ -n "$summary" ]; then
-            printf '%s\n' "$summary" > "$GITHUB_STEP_SUMMARY"
+          make -s generate-test-summary
+          if [ -s .testoutput/test-summary.md ]; then
+            cat .testoutput/test-summary.md > "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Upload code coverage to Codecov
@@ -465,6 +474,15 @@ jobs:
           name: junit-xml--${{ github.run_id }}--${{ steps.get_job_id.outputs.job_id }}--${{ github.run_attempt }}--integration-test
           path: ./.testoutput/junit.*.xml
           include-hidden-files: true
+          retention-days: 28
+
+      - name: Upload test summary JSON to GitHub
+        uses: actions/upload-artifact@v6
+        if: ${{ !cancelled() }}
+        with:
+          name: test-summary-json--${{ github.run_id }}--${{ steps.get_job_id.outputs.job_id }}--${{ github.run_attempt }}--integration-test
+          path: ./.testoutput/test-summary.json
+          if-no-files-found: ignore
           retention-days: 28
 
       - name: Tear down docker compose
@@ -563,12 +581,12 @@ jobs:
           [ "$(find .testoutput -maxdepth 1 -name 'junit.*.xml' | wc -l)" -lt "$MAX_TEST_ATTEMPTS" ] &&
             CRASH_REPORT_NAME="$GITHUB_JOB" make report-test-crash
 
-      - name: Write test summary
+      - name: Generate test summary
         if: ${{ !cancelled() }}
         run: |
-          summary="$(make -s print-test-summary)"
-          if [ -n "$summary" ]; then
-            printf '%s\n' "$summary" > "$GITHUB_STEP_SUMMARY"
+          make -s generate-test-summary
+          if [ -s .testoutput/test-summary.md ]; then
+            cat .testoutput/test-summary.md > "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Upload code coverage to Codecov
@@ -595,6 +613,15 @@ jobs:
           name: junit-xml--${{ github.run_id }}--${{ steps.get_job_id.outputs.job_id }}--${{ github.run_attempt }}--${{ matrix.name }}--${{ matrix.display_name }}--functional-test
           path: ./.testoutput/junit.*.xml
           include-hidden-files: true
+          retention-days: 28
+
+      - name: Upload test summary JSON to GitHub
+        uses: actions/upload-artifact@v6
+        if: ${{ !cancelled() }}
+        with:
+          name: test-summary-json--${{ github.run_id }}--${{ steps.get_job_id.outputs.job_id }}--${{ github.run_attempt }}--${{ matrix.name }}--${{ matrix.display_name }}--functional-test
+          path: ./.testoutput/test-summary.json
+          if-no-files-found: ignore
           retention-days: 28
 
       - name: Upload debug logs

--- a/Makefile
+++ b/Makefile
@@ -559,9 +559,10 @@ report-test-crash: $(TEST_OUTPUT_ROOT)
 		--junitfile=$(TEST_OUTPUT_ROOT)/junit.crash.xml \
 		--crashreportname=$(CRASH_REPORT_NAME)
 
-print-test-summary: $(TEST_OUTPUT_ROOT)
-	@go run ./cmd/tools/test-runner print-summary \
-		--junit-glob=$(TEST_OUTPUT_ROOT)/junit.*.xml
+generate-test-summary: $(TEST_OUTPUT_ROOT)
+	@go run ./cmd/tools/test-runner generate-summary \
+		--junit-glob=$(TEST_OUTPUT_ROOT)/junit.*.xml \
+		--summary-output-dir=$(TEST_OUTPUT_ROOT)
 
 ##### Schema #####
 install-schema-cass-es: temporal-cassandra-tool install-schema-es

--- a/common/testing/await/report.go
+++ b/common/testing/await/report.go
@@ -55,7 +55,11 @@ func reportAttemptErrors(tb testing.TB, failures []attemptFailure) {
 }
 
 func writeAttemptFailure(b *strings.Builder, f attemptFailure) {
-	fmt.Fprintf(b, "\n  attempt %d:", f.attempt)
+	fmt.Fprintf(b, "\n\n  --- attempt %d ---", f.attempt)
+	if len(f.errors) == 0 {
+		b.WriteString("\n    (attempt failed without recorded assertion output)")
+		return
+	}
 	for _, e := range f.errors {
 		for line := range strings.SplitSeq(e, "\n") {
 			b.WriteString("\n    ")

--- a/common/testing/await/require_ctx_test.go
+++ b/common/testing/await/require_ctx_test.go
@@ -268,7 +268,7 @@ func TestRequire_FailureScenarios(t *testing.T) {
 		})
 		require.True(t, tb.Failed())
 		require.Contains(t, tb.fatals(), "not satisfied after")
-		require.Equal(t, "attempt errors:\n  attempt 1:\n    first attempt error\n  attempt 2:\n    last attempt error", tb.errors())
+		require.Equal(t, "attempt errors:\n\n  --- attempt 1 ---\n    first attempt error\n\n  --- attempt 2 ---\n    last attempt error", tb.errors())
 		require.Equal(t, int32(2), attempts.Load())
 	})
 
@@ -291,11 +291,11 @@ func TestRequire_FailureScenarios(t *testing.T) {
 		require.Greater(t, n, int32(4), "need >4 attempts to exercise truncation")
 
 		errs := tb.errors()
-		require.Contains(t, errs, "attempt errors:\n  attempt 1:\n    attempt 1 failed\n")
+		require.Contains(t, errs, "attempt errors:\n\n  --- attempt 1 ---\n    attempt 1 failed\n")
 		require.Contains(t, errs, fmt.Sprintf("... %d attempts omitted ...", n-4))
 		// Last three attempts present in order.
 		for i := n - 2; i <= n; i++ {
-			require.Contains(t, errs, fmt.Sprintf("attempt %d:\n    attempt %d failed", i, i))
+			require.Contains(t, errs, fmt.Sprintf("--- attempt %d ---\n    attempt %d failed", i, i))
 		}
 	})
 

--- a/tools/testrunner/junit_test.go
+++ b/tools/testrunner/junit_test.go
@@ -125,7 +125,7 @@ func TestMergeReports_SingleReport(t *testing.T) {
 	require.Contains(t, failureData, "Error Trace:")
 	require.Contains(t, failureData, "expected: 1")
 	require.NotContains(t, failureData, "=== RUN")
-	require.NotContains(t, failureData, "--- FAIL:")
+	require.Contains(t, failureData, "--- FAIL: TestCallbacksSuite/TestWorkflowCallbacks_InvalidArgument")
 	for _, tc := range suites[0].Testcases {
 		if tc.Failure != nil {
 			require.Equal(t, string(failureTypeFailed), tc.Failure.Type)

--- a/tools/testrunner/log.go
+++ b/tools/testrunner/log.go
@@ -9,9 +9,12 @@ import (
 	"github.com/maruel/panicparse/v2/stack"
 )
 
-// noFailureDetails is returned by parseFailureDetails when no recognisable
-// failure block is found.
-const noFailureDetails = "(error details not found)"
+const (
+	// noFailureDetails is returned by parseFailureDetails when no recognisable
+	// failure block is found.
+	noFailureDetails     = "(error details not found)"
+	goTestFailLinePrefix = "--- FAIL:"
+)
 
 // parseTestTimeouts parses the stdout of a test run and returns the stacktrace and names of tests that timed out.
 func parseTestTimeouts(stdout string) (stacktrace string, timedoutTests []string) {
@@ -144,11 +147,11 @@ func parseAlerts(stdout string) []alert {
 }
 
 // extractTestNames tries to identify Go test function names from a log block.
-// It looks for fully-qualified names like pkg.TestXxx(...) and '--- FAIL: TestXxx' lines.
+// It looks for fully-qualified names like pkg.TestXxx(...) and Go test failure lines.
 func extractTestNames(block string) []string {
 	var tests []string
 	seen := make(map[string]struct{})
-	for _, line := range strings.Split(block, "\n") {
+	for line := range strings.SplitSeq(block, "\n") {
 		l := strings.TrimSpace(line)
 		if l == "" {
 			continue
@@ -177,18 +180,13 @@ func addUniqueTest(tests *[]string, seen map[string]struct{}, name string) {
 	*tests = append(*tests, name)
 }
 
-// parseTripleDashTestName parses lines like:
-// "--- FAIL: TestName (0.00s)" and returns the test name if present.
+// parseTripleDashTestName parses Go test failure lines and returns the test name if present.
 func parseTripleDashTestName(line string) (string, bool) {
-	if !strings.HasPrefix(line, "--- ") {
+	if !strings.HasPrefix(line, goTestFailLinePrefix) {
 		return "", false
 	}
-	parts := strings.Split(line, ":")
-	if len(parts) < 2 {
-		return "", false
-	}
-	name := strings.TrimSpace(parts[1])
-	name = strings.Split(name, " ")[0]
+	name := strings.TrimSpace(strings.TrimPrefix(line, goTestFailLinePrefix))
+	name, _, _ = strings.Cut(name, " ")
 	if !strings.HasPrefix(name, "Test") {
 		return "", false
 	}
@@ -304,17 +302,14 @@ func findRaceBlockStart(lines []string, i int) int {
 // collectBlock builds a block from start until the stop condition is met.
 func collectBlock(lines []string, start int, stop func(line string, idx, start int) bool) (string, int) {
 	var b strings.Builder
-	end := len(lines) - 1
 	for j := start; j < len(lines); j++ {
 		b.WriteString(lines[j])
 		b.WriteByte('\n')
 		if stop(lines[j], j, start) {
-			end = j
-			break
+			return b.String(), j
 		}
-		end = j
 	}
-	return b.String(), end
+	return b.String(), len(lines) - 1
 }
 
 func isRaceBoundary(line string) bool {
@@ -330,14 +325,14 @@ func shouldStopOnTestBoundary(line string, _ int, _ int) bool {
 }
 
 // parseFailedTestsFromOutput extracts failing test names from gotestsum stdout.
-// It looks for "--- FAIL: TestName" lines produced as tests complete, and is
+// It looks for Go test failure lines produced as tests complete, and is
 // used when the test binary was killed externally before producing a JUnit XML.
 func parseFailedTestsFromOutput(stdout string) []string {
 	var failed []string
 	seen := make(map[string]struct{})
-	for _, line := range strings.Split(strings.ReplaceAll(stdout, "\r\n", "\n"), "\n") {
+	for line := range strings.SplitSeq(strings.ReplaceAll(stdout, "\r\n", "\n"), "\n") {
 		line = strings.TrimSpace(line)
-		if !strings.HasPrefix(line, "--- FAIL: ") {
+		if !strings.HasPrefix(line, goTestFailLinePrefix) {
 			continue
 		}
 		if name, ok := parseTripleDashTestName(line); ok {
@@ -351,10 +346,14 @@ func parseFailedTestsFromOutput(stdout string) []string {
 func parseFailureDetails(data string) string {
 	lines := normalizedFailureLines(data)
 
-	if start, end, ok := findTestifyFailureBlock(lines); ok {
-		return strings.Join(lines[start:end], "\n")
+	// Prefer assertion blocks because they contain the useful testify failure
+	// detail and can be selected from the end while ignoring trailing logs.
+	if block, ok := findLastAssertionFailureBlock(lines); ok {
+		return block
 	}
-	if start, end, ok := findLastFailureBlock(lines); ok {
+	// Some failures, such as gomock errors, do not include an Error Trace.
+	// Fall back to the last Go test output block in those cases.
+	if start, end, ok := findLastTestOutputFailureBlock(lines); ok {
 		return strings.Join(lines[start:end], "\n")
 	}
 	return noFailureDetails
@@ -372,39 +371,68 @@ func normalizedFailureLines(data string) []string {
 	return lines
 }
 
-func findTestifyFailureBlock(lines []string) (start, end int, ok bool) {
-	for i, line := range lines {
-		if !strings.Contains(line, "Error Trace:") {
+func findLastAssertionFailureBlock(lines []string) (string, bool) {
+	var failLine string
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if failLine == "" && strings.HasPrefix(line, goTestFailLinePrefix) {
+			// Keep the final Go test failure line because it carries the test duration.
+			failLine = line
 			continue
 		}
-		start = i
-		if i > 0 {
-			start = i - 1
+		if !strings.Contains(lines[i], "Error Trace:") {
+			continue
 		}
-		return start, endOfFailureBlock(lines, start+1), true
+
+		// Include the nearest preceding line when present. For testify this is
+		// the file header; for await failures this is the attempt marker.
+		start := i
+		for prev := i - 1; prev >= 0; prev-- {
+			if strings.TrimSpace(lines[prev]) != "" {
+				start = prev
+				break
+			}
+		}
+		out := append([]string{}, lines[start:endOfAssertionBlock(lines, i+1)]...)
+		if failLine != "" {
+			out = append(out, "", failLine)
+		}
+		return strings.Join(out, "\n"), true
+	}
+	return "", false
+}
+
+func endOfAssertionBlock(lines []string, start int) int {
+	sawTestLine := false
+	for i := start; i < len(lines); i++ {
+		line := strings.TrimSpace(lines[i])
+		if line == "" || strings.HasPrefix(line, goTestFailLinePrefix) {
+			return i
+		}
+		if strings.HasPrefix(line, "Test:") {
+			sawTestLine = true
+			continue
+		}
+		// Logs written after the Test line are not part of the assertion block.
+		if sawTestLine && isTestOutputLine(lines[i]) {
+			return i
+		}
+	}
+	return len(lines)
+}
+
+func findLastTestOutputFailureBlock(lines []string) (start, end int, ok bool) {
+	for start := len(lines) - 1; start >= 0; start-- {
+		if !isTestOutputLine(lines[start]) {
+			continue
+		}
+		end := start + 1
+		for end < len(lines) && !isTestOutputLine(lines[end]) && lines[end] != "" {
+			end++
+		}
+		return start, end, true
 	}
 	return 0, 0, false
-}
-
-func findLastFailureBlock(lines []string) (start, end int, ok bool) {
-	lastStart := -1
-	for i, line := range lines {
-		if isTestOutputLine(line) {
-			lastStart = i
-		}
-	}
-	if lastStart < 0 {
-		return 0, 0, false
-	}
-	return lastStart, endOfFailureBlock(lines, lastStart+1), true
-}
-
-func endOfFailureBlock(lines []string, start int) int {
-	end := start
-	for end < len(lines) && !isTestOutputLine(lines[end]) && lines[end] != "" {
-		end++
-	}
-	return end
 }
 
 // isTestOutputLine reports whether line is a Go test-framework output line,

--- a/tools/testrunner/log_test.go
+++ b/tools/testrunner/log_test.go
@@ -170,6 +170,34 @@ FAIL`,
 			contains:    []string{"Error Trace:"},
 			notContains: []string{"FAIL"},
 		},
+		{
+			name: "keeps last await attempt without trailing logs",
+			data: `    report.go:54: attempt errors:
+  --- attempt 1 ---
+    
+    Error Trace:	suite_test.go:10
+    Error:      	first failure
+
+  --- attempt 2 ---
+    
+    Error Trace:	suite_test.go:10
+    Error:      	penultimate failure
+
+  --- attempt 3 ---
+    
+    Error Trace:	suite_test.go:10
+    Error:      	last failure
+
+logger.go:146: network dial error connection refused
+--- FAIL: TestSuite/TestCase (92.93s)
+FAIL`,
+			contains: []string{
+				"--- attempt 3 ---",
+				"Error:      \tlast failure",
+				"--- FAIL: TestSuite/TestCase (92.93s)",
+			},
+			notContains: []string{"attempts omitted", "--- attempt 1 ---", "first failure", "--- attempt 2 ---", "penultimate failure", "logger.go", "connection refused"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/tools/testrunner/summary.go
+++ b/tools/testrunner/summary.go
@@ -1,64 +1,31 @@
 package testrunner
 
 import (
+	"encoding/json"
 	"fmt"
 	"html"
 	"slices"
 	"strings"
 )
 
-const summaryMaxBytes = 1000 * 1024
-const summaryMaxDetailBytes = 1024
+const summaryMaxDetailBytes = 4 * 1024
+const summaryMarkdownMaxBytes = 1000 * 1024
+const summaryTruncatedMarker = "\n… (truncated - see full output in job logs)\n"
 
 type summary struct {
-	rows []summaryRow
-}
-
-// summaryRow is a single entry in the summary table.
-type summaryRow struct {
-	kind    failureType
-	name    string // test or alert name
-	details string // failure body
+	Rows []summaryRow `json:"rows"`
 }
 
 func newSummaryFromReports(reports []*junitReport) summary {
 	return summary{
-		rows: newSummaryRowsFromReports(reports),
+		Rows: newSummaryRowsFromReports(reports),
 	}
 }
 
-func newSummaryRowsFromReports(reports []*junitReport) []summaryRow {
-	var rows []summaryRow
-	for _, report := range reports {
-		for _, suite := range report.Suites {
-			for _, tc := range suite.Testcases {
-				if tc.Failure == nil {
-					continue
-				}
-				rows = append(rows, summaryRow{
-					kind:    failureType(tc.Failure.Type),
-					name:    tc.Name,
-					details: tc.Failure.Data,
-				})
-			}
-		}
-	}
-	slices.SortFunc(rows, func(a, b summaryRow) int {
-		if byName := strings.Compare(a.name, b.name); byName != 0 {
-			return byName
-		}
-		if byKind := strings.Compare(string(a.kind), string(b.kind)); byKind != 0 {
-			return byKind
-		}
-		return strings.Compare(a.details, b.details)
-	})
-	return rows
-}
-
-// String renders the GitHub step summary HTML and enforces both the total
+// Markdown renders the GitHub step summary HTML and enforces both the total
 // summary budget and per-row detail truncation.
-func (s summary) String() string {
-	if len(s.rows) == 0 {
+func (s summary) Markdown() string {
+	if len(s.Rows) == 0 {
 		return ""
 	}
 
@@ -67,13 +34,13 @@ func (s summary) String() string {
 
 	// Reserve bytes for the closing tag so we can always finish the table.
 	const tableClose = "</table>\n"
-	budget := summaryMaxBytes - sb.Len() - len(tableClose)
+	budget := summaryMarkdownMaxBytes - sb.Len() - len(tableClose)
 
 	written := 0
-	for _, row := range s.rows {
-		rendered := row.String()
+	for _, row := range s.Rows {
+		rendered := row.Markdown()
 		if len(rendered) > budget {
-			omitted := len(s.rows) - written
+			omitted := len(s.Rows) - written
 			fmt.Fprintf(&sb, "<tr><td colspan=\"2\">… %d failure(s) not shown — see full output in job logs</td></tr>\n", omitted)
 			break
 		}
@@ -86,31 +53,74 @@ func (s summary) String() string {
 	return sb.String()
 }
 
-// String renders one summary table row.
-func (row summaryRow) String() string {
-	details := row.details
-	truncated := false
-	if len(details) > summaryMaxDetailBytes {
-		details = details[:summaryMaxDetailBytes]
-		truncated = true
-	}
+func (s summary) JSON() ([]byte, error) {
+	return json.MarshalIndent(s, "", "  ")
+}
 
-	kind := string(row.kind)
-	if strings.Contains(row.name, "(final)") {
+// summaryRow is a single failure entry rendered in both Markdown and JSON summaries.
+type summaryRow struct {
+	Kind    failureType `json:"kind"`
+	Name    string      `json:"name"`              // test or alert name
+	Details string      `json:"details,omitempty"` // failure body
+	Final   bool        `json:"final,omitempty"`
+}
+
+func newSummaryRowsFromReports(reports []*junitReport) []summaryRow {
+	var rows []summaryRow
+	for _, report := range reports {
+		for _, suite := range report.Suites {
+			for _, tc := range suite.Testcases {
+				if tc.Failure == nil {
+					continue
+				}
+				rows = append(rows, newSummaryRow(failureType(tc.Failure.Type), tc.Name, tc.Failure.Data))
+			}
+		}
+	}
+	slices.SortFunc(rows, func(a, b summaryRow) int {
+		if byName := strings.Compare(a.Name, b.Name); byName != 0 {
+			return byName
+		}
+		if byKind := strings.Compare(string(a.Kind), string(b.Kind)); byKind != 0 {
+			return byKind
+		}
+		return strings.Compare(a.Details, b.Details)
+	})
+	return rows
+}
+
+func newSummaryRow(kind failureType, name string, details string) summaryRow {
+	if len(details) > summaryMaxDetailBytes {
+		headBytes := (summaryMaxDetailBytes - len(summaryTruncatedMarker)) / 2
+		tailBytes := summaryMaxDetailBytes - len(summaryTruncatedMarker) - headBytes
+		details = details[:headBytes] + summaryTruncatedMarker + details[len(details)-tailBytes:]
+	}
+	return summaryRow{
+		Kind:    kind,
+		Name:    name,
+		Details: details,
+		Final:   strings.Contains(name, "(final)"),
+	}
+}
+
+// Markdown renders one summary table row.
+func (row summaryRow) Markdown() string {
+	kind := string(row.Kind)
+	if row.Final {
 		kind = "❌ " + kind
 	}
 
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "<tr><td>%s</td><td>", html.EscapeString(kind))
-	if details != "" {
-		escaped := html.EscapeString(details)
-		if truncated {
+	if row.Details != "" {
+		escaped := html.EscapeString(row.Details)
+		if strings.Contains(row.Details, summaryTruncatedMarker) {
 			escaped += "\n… (truncated — see full output in job logs)"
 		}
 		fmt.Fprintf(&sb, "<details><summary>%s</summary><pre>%s</pre></details>",
-			html.EscapeString(row.name), escaped)
+			html.EscapeString(row.Name), escaped)
 	} else {
-		sb.WriteString(html.EscapeString(row.name))
+		sb.WriteString(html.EscapeString(row.Name))
 	}
 	sb.WriteString("</td></tr>\n")
 	return sb.String()

--- a/tools/testrunner/summary_test.go
+++ b/tools/testrunner/summary_test.go
@@ -8,30 +8,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRenderSummaryFromReports_RendersAssertionFailure(t *testing.T) {
+func TestNewSummaryFromReports_RendersAssertionFailureRow(t *testing.T) {
 	report := mustReadReportFixture(t, "testdata/junit-assertion-failure.xml")
 
 	summary := mustNewMergedSummary(t, report)
 	require.Equal(t, []summaryRow{{
-		kind:    failureTypeFailed,
-		name:    "TestBar",
-		details: "    bar_test.go:9:\n        Error Trace:\t__SOURCE__:2\n        Error:      \tNot equal:\n                    \texpected: 1\n                    \tactual  : 2",
-	}}, summary.rows)
-
-	rendered := summary.String()
-	require.Contains(t, rendered, "<table>")
-	require.Contains(t, rendered, "<details><summary>TestBar</summary>")
-	require.NotContains(t, rendered, "<th>Details</th>")
-	require.Contains(t, rendered, "expected: 1")
+		Kind:    failureTypeFailed,
+		Name:    "TestBar",
+		Details: "    bar_test.go:9:\n        Error Trace:\t__SOURCE__:2\n        Error:      \tNot equal:\n                    \texpected: 1\n                    \tactual  : 2",
+	}}, summary.Rows)
 }
 
-func TestRenderSummaryFromReports_EmptyWhenNoFailures(t *testing.T) {
+func TestNewSummaryFromReports_EmptyWhenNoFailures(t *testing.T) {
 	s := newSummaryFromReports([]*junitReport{mustReadReportFixture(t, "testdata/junit-empty.xml")})
-	require.Empty(t, s.rows)
-	require.Empty(t, s.String())
+	require.Empty(t, s.Rows)
 }
 
-func TestRenderSummaryFromReports_KeepsFailureAndAlertRows(t *testing.T) {
+func TestNewSummaryFromReports_KeepsFailureAndAlertRows(t *testing.T) {
 	failureReport := mustReadReportFixture(t, "testdata/junit-single-failure.xml")
 	failureReport.Suites[0].Testcases[0].Name = "TestFoo"
 	failureReport.Suites[0].Testcases[0].Failure.Data = "FAIL\n"
@@ -40,84 +33,34 @@ func TestRenderSummaryFromReports_KeepsFailureAndAlertRows(t *testing.T) {
 
 	summary := mustNewMergedSummary(t, failureReport, alertReport)
 	require.Equal(t, []summaryRow{
-		{kind: failureTypeFailed, name: "TestFoo", details: "FAIL\n"},
-		{kind: failureTypePanic, name: "panic test (retry 1) (final)", details: "panic: boom"},
-	}, summary.rows)
-
-	s := summary.String()
-	require.Contains(t, s, "panic: boom")
-	require.Contains(t, s, "❌ PANIC")
-	require.Contains(t, s, "<pre>FAIL\n</pre>")
-	require.Contains(t, s, "<details><summary>TestFoo</summary>")
-	require.Contains(t, s, "<details><summary>panic test (retry 1) (final)</summary>")
-	require.Equal(t, 2, strings.Count(s, "<tr><td>"))
+		{Kind: failureTypeFailed, Name: "TestFoo", Details: "FAIL\n"},
+		{Kind: failureTypePanic, Name: "panic test (retry 1) (final)", Details: "panic: boom", Final: true},
+	}, summary.Rows)
 }
 
-func TestRenderSummaryFromReports_RendersTrimmedFailureBody(t *testing.T) {
+func TestNewSummaryFromReports_RendersTrimmedFailureBodyRow(t *testing.T) {
 	report := mustReadReportFixture(t, "testdata/junit-unexpected-call-failure.xml")
 
 	summary := mustNewMergedSummary(t, report)
 	require.Equal(t, []summaryRow{{
-		kind:    failureTypeFailed,
-		name:    "TestBaz",
-		details: "    mock_file.go:42: Unexpected call to SomeMethod(...)\n        expected call at foo_test.go:10 doesn't match argument at index 0.\n        Got:  \"actual\"\n        Want: is equal to \"expected\"",
-	}}, summary.rows)
-
-	s := summary.String()
-	require.Contains(t, s, "<details><summary>TestBaz</summary>")
-	require.Contains(t, s, "Unexpected call to SomeMethod")
-	require.NotContains(t, s, "some setup log")
+		Kind:    failureTypeFailed,
+		Name:    "TestBaz",
+		Details: "    mock_file.go:42: Unexpected call to SomeMethod(...)\n        expected call at foo_test.go:10 doesn't match argument at index 0.\n        Got:  \"actual\"\n        Want: is equal to \"expected\"",
+	}}, summary.Rows)
 }
 
-func TestRenderSummaryFromReports_RendersAlertRow(t *testing.T) {
+func TestNewSummaryFromReports_RendersAlertRow(t *testing.T) {
 	report := mustReadReportFixture(t, "testdata/junit-alert-data-race.xml")
 
 	s := newSummaryFromReports([]*junitReport{report})
 	require.Equal(t, []summaryRow{{
-		kind:    failureTypeDataRace,
-		name:    "DATA RACE: Data race detected in TestFoo",
-		details: "WARNING: DATA RACE\nWrite at 0x00c000123456 by goroutine 7:\n  main.TestFoo()\n      /path/to/foo_test.go:42 +0x123\n\nPrevious read at 0x00c000123456 by goroutine 8:\n  main.TestFoo()\n      /path/to/foo_test.go:43 +0x456",
-	}}, s.rows)
-	rendered := s.String()
-	require.Contains(t, rendered, failureTypeDataRace)
-	require.Contains(t, rendered, "Write at 0x00c000123456 by goroutine 7")
+		Kind:    failureTypeDataRace,
+		Name:    "DATA RACE: Data race detected in TestFoo",
+		Details: "WARNING: DATA RACE\nWrite at 0x00c000123456 by goroutine 7:\n  main.TestFoo()\n      /path/to/foo_test.go:42 +0x123\n\nPrevious read at 0x00c000123456 by goroutine 8:\n  main.TestFoo()\n      /path/to/foo_test.go:43 +0x456",
+	}}, s.Rows)
 }
 
-func TestRenderSummaryFromReports_TruncatesOversizedDetail(t *testing.T) {
-	report := mustReadReportFixture(t, "testdata/junit-single-failure.xml")
-	report.Suites[0].Testcases[0].Failure.Data = strings.Repeat("x", summaryMaxDetailBytes+1)
-
-	summary := mustNewMergedSummary(t, report)
-	require.Equal(t, []summaryRow{{
-		kind:    failureTypeFailed,
-		name:    "TestStandalone",
-		details: strings.Repeat("x", summaryMaxDetailBytes+1),
-	}}, summary.rows)
-
-	s := summary.String()
-	require.Contains(t, s, "truncated")
-	require.Less(t, len(s), summaryMaxBytes)
-}
-
-func TestRenderSummaryFromReports_OmitsRowsWhenBudgetExceeded(t *testing.T) {
-	n := summaryMaxBytes/summaryMaxDetailBytes + 1
-	reports := make([]*junitReport, n)
-	for i := range n {
-		report := mustReadReportFixture(t, "testdata/junit-single-failure.xml")
-		report.Suites[0].Testcases[0].Name = "Test" + strconv.Itoa(i)
-		report.Suites[0].Testcases[0].Failure.Data = strings.Repeat("x", summaryMaxDetailBytes)
-		reports[i] = report
-	}
-	summary := newSummaryFromReports(reports)
-	require.Len(t, summary.rows, n)
-
-	s := summary.String()
-	require.Less(t, len(s), summaryMaxBytes+len("</table>\n")+200)
-	require.Contains(t, s, "not shown")
-	require.Contains(t, s, "</table>")
-}
-
-func TestRenderSummaryFromReports_MergesMultipleReportsIntoSingleTable(t *testing.T) {
+func TestNewSummaryFromReports_MergesMultipleReports(t *testing.T) {
 	reportOld := mustReadReportFixture(t, "testdata/junit-single-failure.xml")
 	reportOld.Suites[0].Name = "SuiteA"
 	reportOld.Suites[0].Testcases[0].Name = "TestOld"
@@ -130,14 +73,118 @@ func TestRenderSummaryFromReports_MergesMultipleReportsIntoSingleTable(t *testin
 
 	summary := newSummaryFromReports([]*junitReport{reportOld, reportNew})
 	require.Equal(t, []summaryRow{
-		{kind: failureTypeFailed, name: "TestNew", details: "new failure"},
-		{kind: failureTypeFailed, name: "TestOld", details: "old failure"},
-	}, summary.rows)
+		{Kind: failureTypeFailed, Name: "TestNew", Details: "new failure"},
+		{Kind: failureTypeFailed, Name: "TestOld", Details: "old failure"},
+	}, summary.Rows)
+}
 
-	s := summary.String()
-	require.Equal(t, 1, strings.Count(s, "<table>"))
-	require.Contains(t, s, "TestNew")
-	require.Contains(t, s, "TestOld")
+func TestNewSummaryRow_TruncatesOversizedDetail(t *testing.T) {
+	detail := "head" + strings.Repeat("x", summaryMaxDetailBytes) + "tail"
+
+	row := newSummaryRow(failureTypeFailed, "TestStandalone", detail)
+	require.Equal(t, failureTypeFailed, row.Kind)
+	require.Equal(t, "TestStandalone", row.Name)
+	require.LessOrEqual(t, len(row.Details), summaryMaxDetailBytes)
+	require.Contains(t, row.Details, "head")
+	require.Contains(t, row.Details, "tail")
+	require.Contains(t, row.Details, summaryTruncatedMarker)
+}
+
+func TestRenderSummaryFromReports_Markdown_RendersFailureRows(t *testing.T) {
+	failureReport := mustReadReportFixture(t, "testdata/junit-single-failure.xml")
+	failureReport.Suites[0].Testcases[0].Name = "TestFoo"
+	failureReport.Suites[0].Testcases[0].Failure.Data = "FAIL\n"
+
+	alertReport := mustReadReportFixture(t, "testdata/junit-alert-panic.xml")
+
+	s := mustNewMergedSummary(t, failureReport, alertReport).Markdown()
+	require.Contains(t, s, "<table>")
+	require.NotContains(t, s, "<th>Details</th>")
+	require.Contains(t, s, "<details><summary>TestFoo</summary>")
+	require.Contains(t, s, "<pre>FAIL\n</pre>")
+	require.Contains(t, s, "<details><summary>panic test (retry 1) (final)</summary>")
+	require.Contains(t, s, "❌ PANIC")
+	require.Equal(t, 2, strings.Count(s, "<tr><td>"))
+}
+
+func TestRenderSummaryFromReports_Markdown_RendersTrimmedFailureBody(t *testing.T) {
+	report := mustReadReportFixture(t, "testdata/junit-unexpected-call-failure.xml")
+
+	s := mustNewMergedSummary(t, report).Markdown()
+	require.Contains(t, s, "<details><summary>TestBaz</summary>")
+	require.Contains(t, s, "Unexpected call to SomeMethod")
+	require.NotContains(t, s, "some setup log")
+}
+
+func TestRenderSummaryFromReports_Markdown_RendersAlertRow(t *testing.T) {
+	report := mustReadReportFixture(t, "testdata/junit-alert-data-race.xml")
+
+	rendered := newSummaryFromReports([]*junitReport{report}).Markdown()
+	require.Contains(t, rendered, failureTypeDataRace)
+	require.Contains(t, rendered, "Write at 0x00c000123456 by goroutine 7")
+}
+
+func TestRenderSummaryFromReports_Markdown_EmptyWhenNoFailures(t *testing.T) {
+	s := newSummaryFromReports([]*junitReport{mustReadReportFixture(t, "testdata/junit-empty.xml")})
+	require.Empty(t, s.Markdown())
+}
+
+func TestRenderSummaryFromReports_Markdown_ShowsTruncatedDetail(t *testing.T) {
+	detail := "head" + strings.Repeat("x", summaryMaxDetailBytes) + "tail"
+	summary := summary{
+		Rows: []summaryRow{newSummaryRow(failureTypeFailed, "TestStandalone", detail)},
+	}
+
+	s := summary.Markdown()
+	require.Contains(t, s, "truncated")
+	require.Contains(t, s, "head")
+	require.Contains(t, s, "tail")
+	require.Less(t, len(s), summaryMarkdownMaxBytes)
+}
+
+func TestRenderSummaryFromReports_Markdown_OmitsRowsWhenBudgetExceeded(t *testing.T) {
+	n := summaryMarkdownMaxBytes/summaryMaxDetailBytes + 1
+	rows := make([]summaryRow, n)
+	for i := range n {
+		rows[i] = summaryRow{
+			Kind:    failureTypeFailed,
+			Name:    "Test" + strconv.Itoa(i),
+			Details: strings.Repeat("x", summaryMaxDetailBytes),
+		}
+	}
+
+	s := (summary{Rows: rows}).Markdown()
+	require.Less(t, len(s), summaryMarkdownMaxBytes+len("</table>\n")+200)
+	require.Contains(t, s, "not shown")
+	require.Contains(t, s, "</table>")
+}
+
+func TestRenderSummaryFromReports_JSON(t *testing.T) {
+	failureReport := mustReadReportFixture(t, "testdata/junit-single-failure.xml")
+	failureReport.Suites[0].Testcases[0].Name = "TestFoo"
+	failureReport.Suites[0].Testcases[0].Failure.Data = "FAIL\n"
+
+	alertReport := mustReadReportFixture(t, "testdata/junit-alert-panic.xml")
+
+	summary := mustNewMergedSummary(t, failureReport, alertReport)
+	content, err := summary.JSON()
+	require.NoError(t, err)
+
+	require.JSONEq(t, `{
+		"rows": [
+			{
+				"kind": "Failed",
+				"name": "TestFoo",
+				"details": "FAIL\n"
+			},
+			{
+				"kind": "PANIC",
+				"name": "panic test (retry 1) (final)",
+				"details": "panic: boom",
+				"final": true
+			}
+		]
+	}`, string(content))
 }
 
 func mustNewMergedSummary(t *testing.T, reports ...*junitReport) summary {

--- a/tools/testrunner/testrunner.go
+++ b/tools/testrunner/testrunner.go
@@ -24,6 +24,7 @@ const (
 	coverProfileFlag      = "-coverprofile="
 	junitReportFlag       = "--junitfile="
 	junitGlobFlag         = "--junit-glob="
+	summaryOutputDirFlag  = "--summary-output-dir="
 	crashReportNameFlag   = "--crashreportname="
 	gotestsumPathFlag     = "--gotestsum-path="
 
@@ -40,7 +41,7 @@ const (
 const (
 	testCommand        = "test"
 	crashReportCommand = "report-crash"
-	summaryCommand     = "print-summary"
+	summaryCommand     = "generate-summary"
 )
 
 type attempt struct {
@@ -78,6 +79,7 @@ type runner struct {
 	maxAttempts      int
 	crashName        string
 	junitGlob        string
+	summaryOutputDir string
 	alerts           []alert
 	totalTimeout     time.Duration // derived from the -timeout go test flag
 }
@@ -136,6 +138,13 @@ func (r *runner) sanitizeAndParseArgs(command string, args []string) ([]string, 
 			r.junitGlob = strings.Split(arg, "=")[1]
 			continue
 		}
+		if strings.HasPrefix(arg, summaryOutputDirFlag) {
+			r.summaryOutputDir = strings.Split(arg, "=")[1]
+			if command != summaryCommand {
+				return nil, fmt.Errorf("argument %q is only valid for command %q", summaryOutputDirFlag, summaryCommand)
+			}
+			continue
+		}
 		if strings.HasPrefix(arg, coverProfileFlag) {
 			r.coverProfilePath = strings.Split(arg, "=")[1]
 		} else if strings.HasPrefix(arg, junitReportFlag) {
@@ -167,6 +176,9 @@ func (r *runner) sanitizeAndParseArgs(command string, args []string) ([]string, 
 	case summaryCommand:
 		if r.junitGlob == "" {
 			return nil, fmt.Errorf("missing required argument %q", junitGlobFlag)
+		}
+		if r.summaryOutputDir == "" {
+			return nil, fmt.Errorf("missing required argument %q", summaryOutputDirFlag)
 		}
 	default:
 		return nil, fmt.Errorf("unknown command %q", command)
@@ -229,7 +241,7 @@ func Main() {
 	case crashReportCommand:
 		r.reportCrash()
 	case summaryCommand:
-		if err := r.printSummary(); err != nil {
+		if err := r.generateSummary(); err != nil {
 			log.Fatal(err)
 		}
 	default:
@@ -246,13 +258,10 @@ func (r *runner) reportCrash() {
 	}
 }
 
-func (r *runner) printSummary() error {
+func (r *runner) generateSummary() error {
 	paths, err := filepath.Glob(r.junitGlob)
 	if err != nil {
 		return fmt.Errorf("failed to expand junit glob %q: %w", r.junitGlob, err)
-	}
-	if len(paths) == 0 {
-		return nil
 	}
 	slices.Sort(paths)
 
@@ -265,12 +274,26 @@ func (r *runner) printSummary() error {
 		reports = append(reports, report)
 	}
 
-	content := newSummaryFromReports(reports).String()
-	if content == "" {
+	summary := newSummaryFromReports(reports)
+	if len(summary.Rows) == 0 {
+		fmt.Println("no failed tests found in junit reports; skipping test summary")
 		return nil
 	}
-	if _, err := os.Stdout.WriteString(content); err != nil {
-		return fmt.Errorf("failed to write summary to stdout: %w", err)
+
+	markdown := summary.Markdown()
+	if err := os.MkdirAll(r.summaryOutputDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create summary output directory: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(r.summaryOutputDir, "test-summary.md"), []byte(markdown), 0o644); err != nil {
+		return fmt.Errorf("failed to write summary markdown: %w", err)
+	}
+
+	content, err := summary.JSON()
+	if err != nil {
+		return fmt.Errorf("failed to render summary json: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(r.summaryOutputDir, "test-summary.json"), append(content, '\n'), 0o644); err != nil {
+		return fmt.Errorf("failed to write summary json: %w", err)
 	}
 	return nil
 }

--- a/tools/testrunner/testrunner_test.go
+++ b/tools/testrunner/testrunner_test.go
@@ -1,7 +1,6 @@
 package testrunner
 
 import (
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -239,26 +238,41 @@ func TestRunnerPrintSummary(t *testing.T) {
 	require.NoError(t, report2.write())
 
 	r := newRunner()
+	summaryMarkdownPath := filepath.Join(dir, "test-summary.md")
+	summaryJSONPath := filepath.Join(dir, "test-summary.json")
 	_, err := r.sanitizeAndParseArgs(summaryCommand, []string{
 		"--junit-glob=" + filepath.Join(dir, "junit.*.xml"),
+		"--summary-output-dir=" + dir,
 	})
 	require.NoError(t, err)
 
-	stdout := os.Stdout
-	rpipe, wpipe, err := os.Pipe()
-	require.NoError(t, err)
-	defer func() {
-		os.Stdout = stdout
-		require.NoError(t, rpipe.Close())
-	}()
-
-	os.Stdout = wpipe
-	require.NoError(t, r.printSummary())
-	require.NoError(t, wpipe.Close())
-
-	body, err := io.ReadAll(rpipe)
+	require.NoError(t, r.generateSummary())
+	body, err := os.ReadFile(summaryMarkdownPath)
 	require.NoError(t, err)
 	require.Equal(t, 1, strings.Count(string(body), "<table>"))
 	require.Contains(t, string(body), "TestAlpha")
 	require.Contains(t, string(body), "TestBeta")
+
+	jsonBody, err := os.ReadFile(summaryJSONPath)
+	require.NoError(t, err)
+	require.Contains(t, string(jsonBody), `"name": "TestAlpha"`)
+	require.Contains(t, string(jsonBody), `"name": "TestBeta"`)
+}
+
+func TestRunnerPrintSummarySkipsEmptySummary(t *testing.T) {
+	dir := t.TempDir()
+	report := mustReadReportFixture(t, "testdata/junit-empty.xml")
+	report.path = filepath.Join(dir, "junit.empty.xml")
+	require.NoError(t, report.write())
+
+	r := newRunner()
+	_, err := r.sanitizeAndParseArgs(summaryCommand, []string{
+		"--junit-glob=" + filepath.Join(dir, "junit.*.xml"),
+		"--summary-output-dir=" + dir,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, r.generateSummary())
+	require.NoFileExists(t, filepath.Join(dir, "test-summary.md"))
+	require.NoFileExists(t, filepath.Join(dir, "test-summary.json"))
 }


### PR DESCRIPTION
## What changed?

(1) Generate JSON test summary, too
(2) Tweak summary detail capture esp for `Await`

## Why?

Allow AI agents to easily/quickly/cheaply inspect CI results.

<img width="1582" height="707" alt="Screenshot 2026-05-25 at 6 46 13 PM" src="https://github.com/user-attachments/assets/ca232f52-4f6f-45cb-9b52-450d32999d0c" />

<img width="2158" height="254" alt="Screenshot 2026-05-25 at 6 47 03 PM" src="https://github.com/user-attachments/assets/447ccf28-bec7-424b-a961-630c44a02cb0" />

