### PR TITLE
Fix schedule interval offsets with microsecond precision

### DIFF
--- a/service/worker/scheduler/spec.go
+++ b/service/worker/scheduler/spec.go
@@ -300,42 +300,48 @@ func (cs *CompiledSpec) GetNextTime(jitterSeed string, after time.Time) GetNextT
 
 // Returns the next matching time (without jitter), or the zero value if no time matches.
 func (cs *CompiledSpec) rawNextTime(after time.Time) (nominal time.Time) {
-	var minTimestamp int64 = math.MaxInt64 // unix seconds-since-epoch as int64
+	minTimestamp := time.Time{}
 
 	for _, cal := range cs.calendar {
 		if next := cal.next(after); !next.IsZero() {
-			nextTs := next.Unix()
-			if nextTs < minTimestamp {
-				minTimestamp = nextTs
+			if minTimestamp.IsZero() || next.Before(minTimestamp) {
+				minTimestamp = next
 			}
 		}
 	}
 
-	ts := after.Unix()
 	for _, iv := range cs.spec.Interval {
-		next := cs.nextIntervalTime(iv, ts)
-		if next < minTimestamp {
+		next := cs.nextIntervalTime(iv, after)
+		if minTimestamp.IsZero() || next.Before(minTimestamp) {
 			minTimestamp = next
 		}
 	}
 
-	if minTimestamp == math.MaxInt64 {
+	if minTimestamp.IsZero() {
 		return time.Time{}
 	}
-	return time.Unix(minTimestamp, 0).UTC()
+	return minTimestamp.UTC()
 }
 
 // Returns the next matching time for a single interval spec.
-func (cs *CompiledSpec) nextIntervalTime(iv *schedulepb.IntervalSpec, ts int64) int64 {
-	interval := int64(timestamp.DurationValue(iv.Interval) / time.Second)
-	if interval < 1 {
-		interval = 1
+func (cs *CompiledSpec) nextIntervalTime(iv *schedulepb.IntervalSpec, after time.Time) time.Time {
+	interval := timestamp.DurationValue(iv.Interval)
+	if interval < time.Second {
+		interval = time.Second
 	}
-	phase := int64(timestamp.DurationValue(iv.Phase) / time.Second)
+	phase := timestamp.DurationValue(iv.Phase)
 	if phase < 0 {
 		phase = 0
 	}
-	return (((ts-phase)/interval)+1)*interval + phase
+
+	base := time.Unix(0, 0).UTC().Add(phase)
+	elapsed := after.Sub(base)
+	steps := elapsed / interval
+	next := base.Add((steps + 1) * interval)
+	if !next.After(after) {
+		next = next.Add(interval)
+	}
+	return next
 }
 
 // Returns true if any exclude spec matches the time.

--- a/service/worker/scheduler/spec_test.go
+++ b/service/worker/scheduler/spec_test.go
@@ -237,6 +237,24 @@ func (s *specSuite) TestSpecIntervalPhase() {
 	)
 }
 
+func (s *specSuite) TestSpecIntervalPhaseWithMicroseconds() {
+	s.checkSequenceRaw(
+		&schedulepb.ScheduleSpec{
+			Interval: []*schedulepb.IntervalSpec{
+				{
+					Interval: durationpb.New(120 * time.Second),
+					Phase:    durationpb.New(63*time.Second + 123*time.Microsecond),
+				},
+			},
+		},
+		time.Date(2022, 3, 23, 12, 53, 2, 9, time.UTC),
+		time.Date(2022, 3, 23, 12, 53, 3, 123000, time.UTC),
+		time.Date(2022, 3, 23, 12, 55, 3, 123000, time.UTC),
+		time.Date(2022, 3, 23, 12, 57, 3, 123000, time.UTC),
+		time.Date(2022, 3, 23, 12, 59, 3, 123000, time.UTC),
+	)
+}
+
 func (s *specSuite) TestSpecIntervalMultiple() {
 	s.checkSequenceRaw(
 		&schedulepb.ScheduleSpec{


### PR DESCRIPTION
## What changed
- preserve sub-second precision when computing the next fire time for interval schedules
- add regression coverage for interval phases that include microseconds

## Why
Issue #10312 reports that schedules with microseconds in the interval offset only launch once.

The root cause is in `service/worker/scheduler/spec.go`:
- `rawNextTime()` compared interval candidates after converting times through `after.Unix()` / `time.Unix(..., 0)`
- `nextIntervalTime()` reduced both `Interval` and `Phase` to integer seconds

That truncates offsets such as `63s + 123us`, so subsequent interval matches lose the original phase precision.

This patch keeps the calculation in `time.Time` / `time.Duration`, preserving the original phase precision.

## How I tested it
- `go test -tags test_dep ./service/worker/scheduler -run TestSpec -count=1`
- `go test -tags test_dep ./service/worker/scheduler -run TestSpec -testify.m TestSpecIntervalPhaseWithMicroseconds -count=1 -v`