### PR TITLE
Reapply "Ensure Handover state is removed during replication (#10207)…

### DIFF
--- a/common/namespace/nsreplication/replication_task_executor.go
+++ b/common/namespace/nsreplication/replication_task_executor.go
@@ -322,6 +322,7 @@ func (h *taskExecutorImpl) handleNamespaceUpdateReplicationTask(
 	if resp.Namespace.FailoverVersion < task.GetFailoverVersion() {
 		recordUpdated = true
 		request.Namespace.ReplicationConfig.ActiveClusterName = task.ReplicationConfig.GetActiveClusterName()
+		request.Namespace.ReplicationConfig.State = task.ReplicationConfig.GetState()
 		request.Namespace.FailoverVersion = task.GetFailoverVersion()
 		request.Namespace.FailoverNotificationVersion = notificationVersion
 		request.Namespace.ReplicationConfig.FailoverHistory = ConvertFailoverHistoryToPersistenceProto(task.GetFailoverHistory())

--- a/common/namespace/nsreplication/replication_task_executor_test.go
+++ b/common/namespace/nsreplication/replication_task_executor_test.go
@@ -735,3 +735,69 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_
 	err := s.namespaceReplicator.Execute(context.Background(), updateTask)
 	s.Nil(err)
 }
+
+// TestExecute_UpdateNamespaceTask_FailoverPropagatesNormalState verifies the
+// self-heal path: a standby stuck at UNSPECIFIED gets State=NORMAL written from
+// the next failover task.
+func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_FailoverPropagatesNormalState() {
+	id := uuid.NewString()
+	name := "some random namespace test name"
+	updateOperation := enumsspb.NAMESPACE_OPERATION_UPDATE
+	updateState := enumspb.NAMESPACE_STATE_REGISTERED
+	updateClusterActive := "other random active cluster name"
+	updateClusterStandby := "other random standby cluster name"
+	existingConfigVersion := int64(1)
+	existingFailoverVersion := int64(10)
+	updateFailoverVersion := int64(59)
+	updateClusters := []*replicationpb.ClusterReplicationConfig{
+		{ClusterName: updateClusterActive},
+		{ClusterName: updateClusterStandby},
+	}
+	updateTask := &replicationspb.NamespaceTaskAttributes{
+		NamespaceOperation: updateOperation,
+		Id:                 id,
+		Info: &namespacepb.NamespaceInfo{
+			Name:  name,
+			State: updateState,
+		},
+		Config: &namespacepb.NamespaceConfig{},
+		ReplicationConfig: &replicationpb.NamespaceReplicationConfig{
+			ActiveClusterName: updateClusterActive,
+			Clusters:          updateClusters,
+			State:             enumspb.REPLICATION_STATE_NORMAL,
+		},
+		ConfigVersion:   existingConfigVersion, // no config bump
+		FailoverVersion: updateFailoverVersion, // failover bump
+	}
+
+	s.namespaceReplicator.currentCluster = updateClusterStandby
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), &persistence.GetNamespaceRequest{
+		Name: name,
+	}).Return(&persistence.GetNamespaceResponse{Namespace: &persistencespb.NamespaceDetail{
+		Info: &persistencespb.NamespaceInfo{Id: id},
+		ReplicationConfig: &persistencespb.NamespaceReplicationConfig{
+			State: enumspb.REPLICATION_STATE_UNSPECIFIED, // pre-fix stuck state
+		},
+		ConfigVersion:   existingConfigVersion,
+		FailoverVersion: existingFailoverVersion,
+	}}, nil).Times(2)
+	s.mockMetadataMgr.EXPECT().GetMetadata(gomock.Any()).Return(&persistence.GetMetadataResponse{
+		NotificationVersion: updateFailoverVersion,
+	}, nil).Times(1)
+	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any(), &persistence.UpdateNamespaceRequest{
+		Namespace: &persistencespb.NamespaceDetail{
+			Info: &persistencespb.NamespaceInfo{Id: id},
+			ReplicationConfig: &persistencespb.NamespaceReplicationConfig{
+				ActiveClusterName: updateClusterActive,
+				State:             enumspb.REPLICATION_STATE_NORMAL,
+			},
+			ConfigVersion:               existingConfigVersion,
+			FailoverNotificationVersion: updateFailoverVersion,
+			FailoverVersion:             updateFailoverVersion,
+		},
+		IsGlobalNamespace:   false,
+		NotificationVersion: updateFailoverVersion,
+	})
+	err := s.namespaceReplicator.Execute(context.Background(), updateTask)
+	s.NoError(err)
+}

--- a/common/namespace/nsreplication/transmission_task_handler.go
+++ b/common/namespace/nsreplication/transmission_task_handler.go
@@ -109,9 +109,7 @@ func (r *replicator) HandleTransmissionTask(
 		},
 	}
 
-	// Only replicate on Create operation, and only if state is Normal
-	if namespaceOperation == enumsspb.NAMESPACE_OPERATION_CREATE &&
-		replicationConfig.State == enumspb.REPLICATION_STATE_NORMAL {
+	if replicationConfig.State == enumspb.REPLICATION_STATE_NORMAL {
 		task.NamespaceTaskAttributes.ReplicationConfig.State = replicationConfig.State
 	}
 

--- a/common/namespace/nsreplication/transmission_task_handler_test.go
+++ b/common/namespace/nsreplication/transmission_task_handler_test.go
@@ -292,7 +292,7 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_I
 	s.Require().NoError(err)
 }
 
-func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_StateNotReplicated() {
+func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_NormalStateReplicated() {
 	taskType := enumsspb.REPLICATION_TASK_TYPE_NAMESPACE_TASK
 	id := primitives.NewUUID().String()
 	name := "some random namespace test name"
@@ -359,7 +359,98 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_S
 				ReplicationConfig: &replicationpb.NamespaceReplicationConfig{
 					ActiveClusterName: clusterActive,
 					Clusters:          convertClusterReplicationConfigToProto(clusters),
-					// State must not be set on UPDATE even when source state is NORMAL
+					State:             enumspb.REPLICATION_STATE_NORMAL,
+				},
+				ConfigVersion:   configVersion,
+				FailoverVersion: failoverVersion,
+			},
+		},
+	}).Return(nil)
+
+	err := s.namespaceReplicator.HandleTransmissionTask(
+		context.Background(),
+		namespaceOperation,
+		info,
+		config,
+		replicationConfig,
+		true,
+		configVersion,
+		failoverVersion,
+		isGlobalNamespace,
+		nil,
+		false, // forceReplicate
+	)
+	s.Require().NoError(err)
+}
+
+func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_HandoverStateNotReplicated() {
+	taskType := enumsspb.REPLICATION_TASK_TYPE_NAMESPACE_TASK
+	id := primitives.NewUUID().String()
+	name := "some random namespace test name"
+	state := enumspb.NAMESPACE_STATE_REGISTERED
+	description := "some random test description"
+	ownerEmail := "some random test owner"
+	data := map[string]string{"k": "v"}
+	retention := 10 * time.Hour * 24
+	historyArchivalState := enumspb.ARCHIVAL_STATE_ENABLED
+	historyArchivalURI := "some random history archival uri"
+	visibilityArchivalState := enumspb.ARCHIVAL_STATE_ENABLED
+	visibilityArchivalURI := "some random visibility archival uri"
+	clusterActive := "some random active cluster name"
+	clusterStandby := "some random standby cluster name"
+	configVersion := int64(0)
+	failoverVersion := int64(59)
+	clusters := []string{clusterActive, clusterStandby}
+
+	namespaceOperation := enumsspb.NAMESPACE_OPERATION_UPDATE
+	info := &persistencespb.NamespaceInfo{
+		Id:          id,
+		Name:        name,
+		State:       state,
+		Description: description,
+		Owner:       ownerEmail,
+		Data:        data,
+	}
+	config := &persistencespb.NamespaceConfig{
+		Retention:               durationpb.New(retention),
+		HistoryArchivalState:    historyArchivalState,
+		HistoryArchivalUri:      historyArchivalURI,
+		VisibilityArchivalState: visibilityArchivalState,
+		VisibilityArchivalUri:   visibilityArchivalURI,
+		BadBinaries:             &namespacepb.BadBinaries{Binaries: map[string]*namespacepb.BadBinaryInfo{}},
+	}
+	replicationConfig := &persistencespb.NamespaceReplicationConfig{
+		ActiveClusterName: clusterActive,
+		Clusters:          clusters,
+		State:             enumspb.REPLICATION_STATE_HANDOVER,
+	}
+	isGlobalNamespace := true
+
+	s.namespaceReplicationQueue.EXPECT().Publish(gomock.Any(), &replicationspb.ReplicationTask{
+		TaskType: taskType,
+		Attributes: &replicationspb.ReplicationTask_NamespaceTaskAttributes{
+			NamespaceTaskAttributes: &replicationspb.NamespaceTaskAttributes{
+				NamespaceOperation: namespaceOperation,
+				Id:                 id,
+				Info: &namespacepb.NamespaceInfo{
+					Name:        name,
+					State:       state,
+					Description: description,
+					OwnerEmail:  ownerEmail,
+					Data:        data,
+				},
+				Config: &namespacepb.NamespaceConfig{
+					WorkflowExecutionRetentionTtl: durationpb.New(retention),
+					HistoryArchivalState:          historyArchivalState,
+					HistoryArchivalUri:            historyArchivalURI,
+					VisibilityArchivalState:       visibilityArchivalState,
+					VisibilityArchivalUri:         visibilityArchivalURI,
+					BadBinaries:                   &namespacepb.BadBinaries{Binaries: map[string]*namespacepb.BadBinaryInfo{}},
+				},
+				ReplicationConfig: &replicationpb.NamespaceReplicationConfig{
+					ActiveClusterName: clusterActive,
+					Clusters:          convertClusterReplicationConfigToProto(clusters),
+					// HANDOVER is local-only and must not be propagated
 				},
 				ConfigVersion:   configVersion,
 				FailoverVersion: failoverVersion,

--- a/service/worker/migration/handover_workflow.go
+++ b/service/worker/migration/handover_workflow.go
@@ -110,20 +110,10 @@ func NamespaceHandoverWorkflow(ctx workflow.Context, params NamespaceHandoverPar
 		return err
 	}
 
-	// ** Step 4: RecoverOrInitialize Handover (WARNING: Namespace cannot serve traffic while in this state)
-	handoverRequest := updateStateRequest{
-		Namespace: params.Namespace,
-		NewState:  enumspb.REPLICATION_STATE_HANDOVER,
-	}
-	err = workflow.ExecuteActivity(ctx, a.UpdateNamespaceState, handoverRequest).Get(ctx, nil)
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		// ** Final Step: Reset namespace state from Handover -> Registered. This helps ensure that whether
-		//                handover failed or succeeded, the namespace (for whichever cluster it is Active on)
-		//                is able to process traffic again.
+	// ** Final Step: Reset namespace state from Handover -> Registered. This helps ensure that whether
+	//                handover failed or succeeded, the namespace (for whichever cluster it is Active on)
+	//                is able to process traffic again.
+	resetState := func() {
 		resetStateRequest := updateStateRequest{
 			Namespace: params.Namespace,
 			NewState:  enumspb.REPLICATION_STATE_NORMAL,
@@ -138,11 +128,30 @@ func NamespaceHandoverWorkflow(ctx workflow.Context, params NamespaceHandoverPar
 		} else {
 			err = workflow.ExecuteActivity(ctx, a.UpdateNamespaceState, resetStateRequest).Get(ctx, nil)
 		}
-		if err != nil {
+		if err != nil && retErr == nil {
 			retErr = err
-			return
 		}
-	}()
+	}
+
+	// Register before Step 4 so a cancel during the HANDOVER write still triggers the reset.
+	// The reset activity is idempotent so a no-op pre-Step-4 is fine.
+	deferBeforeHandover := workflow.GetVersion(ctx, "defer-before-handover-write-20260510", workflow.DefaultVersion, 1) > workflow.DefaultVersion
+	if deferBeforeHandover {
+		defer resetState()
+	}
+
+	// ** Step 4: RecoverOrInitialize Handover (WARNING: Namespace cannot serve traffic while in this state)
+	handoverRequest := updateStateRequest{
+		Namespace: params.Namespace,
+		NewState:  enumspb.REPLICATION_STATE_HANDOVER,
+	}
+	err = workflow.ExecuteActivity(ctx, a.UpdateNamespaceState, handoverRequest).Get(ctx, nil)
+	if err != nil {
+		return err
+	}
+	if !deferBeforeHandover {
+		defer resetState()
+	}
 
 	// ** Step 5: Wait for Remote Cluster to completely drain its Replication Tasks
 	ao3 := workflow.ActivityOptions{

--- a/service/worker/migration/handover_workflow_test.go
+++ b/service/worker/migration/handover_workflow_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
 )
@@ -48,6 +49,54 @@ func TestHandoverWorkflow(t *testing.T) {
 	require.True(t, env.IsWorkflowCompleted())
 	require.NoError(t, env.GetWorkflowError())
 	env.AssertExpectations(t)
+}
+
+// TestHandoverWorkflow_CancelAfterHandoverState_ResetsToNormal guards against the
+// regression where a cancel after the HANDOVER write skipped the deferred reset.
+func TestHandoverWorkflow_CancelAfterHandoverState_ResetsToNormal(t *testing.T) {
+	testSuite := &testsuite.WorkflowTestSuite{}
+	env := testSuite.NewTestWorkflowEnvironment()
+	var a *activities
+
+	namespaceID := uuid.NewString()
+
+	env.OnActivity(a.GetMetadata, mock.Anything, MetadataRequest{Namespace: "test-ns"}).
+		Return(&MetadataResponse{ShardCount: 4, NamespaceID: namespaceID}, nil)
+	env.OnActivity(a.GetMaxReplicationTaskIDs, mock.Anything).
+		Return(&ReplicationStatus{MaxReplicationTaskIds: map[int32]int64{1: 100}}, nil)
+	env.OnActivity(a.WaitReplication, mock.Anything, mock.Anything).Return(nil)
+
+	var stateUpdates []enumspb.ReplicationState
+	env.OnActivity(a.UpdateNamespaceState, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			req := args.Get(1).(updateStateRequest)
+			stateUpdates = append(stateUpdates, req.NewState)
+			// Simulate a cancel arriving once HANDOVER has been written.
+			if req.NewState == enumspb.REPLICATION_STATE_HANDOVER {
+				env.CancelWorkflow()
+			}
+		}).
+		Return(nil)
+	// WaitHandover should observe the cancel and return an error; the defer must still run.
+	env.OnActivity(a.WaitHandover, mock.Anything, mock.Anything).Return(temporal.NewCanceledError())
+
+	env.ExecuteWorkflow(NamespaceHandoverWorkflow, NamespaceHandoverParams{
+		Namespace:              "test-ns",
+		RemoteCluster:          "test-remote",
+		AllowedLaggingSeconds:  10,
+		HandoverTimeoutSeconds: 10,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.Equal(
+		t,
+		[]enumspb.ReplicationState{
+			enumspb.REPLICATION_STATE_HANDOVER,
+			enumspb.REPLICATION_STATE_NORMAL,
+		},
+		stateUpdates,
+		"defer must reset state to NORMAL after cancel",
+	)
 }
 
 func TestHandoverWorkflow_SetTimeout(t *testing.T) {

--- a/tests/xdc/failover_test.go
+++ b/tests/xdc/failover_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
@@ -33,6 +34,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/service/worker/migration"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -113,6 +115,32 @@ func (s *FunctionalClustersTestSuite) TestNamespaceFailover() {
 	we, err := s.clusters[1].FrontendClient().StartWorkflowExecution(testcore.NewContext(), startReq)
 	s.NoError(err)
 	s.NotNil(we.GetRunId())
+}
+
+// TestNamespaceFailover_ReplicationStateIsNormalOnBothClusters guards against
+// State being dropped on the wire for UPDATE replication tasks, which left the
+// non-receiving cluster stuck at UNSPECIFIED after a force-failover.
+func (s *FunctionalClustersTestSuite) TestNamespaceFailover_ReplicationStateIsNormalOnBothClusters() {
+	namespace := s.createGlobalNamespace()
+
+	s.failover(namespace, 0, s.clusters[1].ClusterName(), 2)
+
+	await.Require(testcore.NewContext(), s.T(), func(t *await.T) {
+		for _, c := range s.clusters {
+			resp, err := c.FrontendClient().DescribeNamespace(t.Context(), &workflowservice.DescribeNamespaceRequest{
+				Namespace: namespace,
+			})
+			require.NoError(t, err)
+			require.Equal(
+				t,
+				enumspb.REPLICATION_STATE_NORMAL,
+				resp.ReplicationConfig.State,
+				"cluster %s left ReplicationConfig.State = %s after failover",
+				c.ClusterName(),
+				resp.ReplicationConfig.State,
+			)
+		}
+	}, replicationWaitTime, replicationCheckInterval)
 }
 
 func (s *FunctionalClustersTestSuite) TestSimpleWorkflowFailover() {


### PR DESCRIPTION
…" (#10363)

This reverts commit 000a5ade5d1effa07b02486548728bde82c9dc1e.

## What changed?
Appears that the CI/CD issues that led to the initial revert were unrelated

## Why?
Putting back Handover changes

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

