### PR TITLE
Include in-memory (sync match) backlog in ApproximateBacklogCount

### DIFF
--- a/service/matching/matcher_data.go
+++ b/service/matching/matcher_data.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/log"
@@ -122,6 +123,8 @@ type taskPQ struct {
 	// note that matcherData may get tasks from multiple versioned backlogs due to
 	// versioning redirection.
 	ages backlogAgeTracker
+
+	syncBacklog *syncMatchBacklogTracker
 }
 
 func (t *taskPQ) Add(task *internalTask) {
@@ -193,6 +196,7 @@ func (t *taskPQ) Push(x any) {
 	if task.source == enumsspb.TASK_SOURCE_DB_BACKLOG && task.forwardInfo == nil {
 		t.ages.record(task.event.Data.CreateTime, 1)
 	}
+	t.syncBacklog.record(task, 1)
 }
 
 // implements heap.Interface, do not call directly
@@ -205,6 +209,7 @@ func (t *taskPQ) Pop() any {
 	if task.source == enumsspb.TASK_SOURCE_DB_BACKLOG && task.forwardInfo == nil {
 		t.ages.record(task.event.Data.CreateTime, -1)
 	}
+	t.syncBacklog.record(task, -1)
 
 	return task
 }
@@ -221,6 +226,7 @@ func (t *taskPQ) ForEachTask(pred func(*internalTask) bool, post func(*internalT
 		if task.source == enumsspb.TASK_SOURCE_DB_BACKLOG && task.forwardInfo == nil {
 			t.ages.record(task.event.Data.CreateTime, -1)
 		}
+		t.syncBacklog.record(task, -1)
 		post(task)
 		return true
 	})
@@ -254,6 +260,7 @@ type matcherData struct {
 }
 
 func newMatcherData(config *taskQueueConfig, logger log.Logger, timeSource clock.TimeSource, canForward bool, rateLimitManager *rateLimitManager) matcherData {
+	syncBacklog := &syncMatchBacklogTracker{}
 	return matcherData{
 		config:           config,
 		logger:           logger,
@@ -261,7 +268,8 @@ func newMatcherData(config *taskQueueConfig, logger log.Logger, timeSource clock
 		canForward:       canForward,
 		rateLimitManager: rateLimitManager,
 		tasks: taskPQ{
-			ages: newBacklogAgeTracker(),
+			ages:        newBacklogAgeTracker(),
+			syncBacklog: syncBacklog,
 		},
 	}
 }
@@ -589,6 +597,10 @@ func (d *matcherData) TimeSinceLastPoll() time.Duration {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 	return time.Since(d.lastPoller)
+}
+
+func (d *matcherData) SyncMatchStatsByPriority() map[int32]*taskqueuepb.TaskQueueStats {
+	return d.tasks.syncBacklog.statsByPriority()
 }
 
 // HasWaitingPoller returns if there's a normal (non forwarder)

--- a/service/matching/matcher_data_test.go
+++ b/service/matching/matcher_data_test.go
@@ -23,6 +23,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/softassert"
+	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/common/tqid"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -239,9 +240,15 @@ func (s *MatcherDataSuite) TestQuery() {
 	respC := make(chan taskResponse)
 	go s.queryFakeTime(time.Second, respC)
 
+	await.RequireTrue(s.T(), func() bool {
+		return s.md.SyncMatchStatsByPriority()[0].GetApproximateBacklogCount() == 1
+	}, time.Second, 10*time.Millisecond)
+
 	pres := s.pollFakeTime(time.Second)
 	s.NotNil(pres.task)
 	s.True(pres.task.isQuery())
+	s.Empty(s.md.SyncMatchStatsByPriority())
+
 	// wake up getResponse. use some error just to check it's passed through.
 	someError := errors.New("some error")
 	pres.task.finish(someError, true)
@@ -249,6 +256,53 @@ func (s *MatcherDataSuite) TestQuery() {
 	resp := <-respC
 	s.False(resp.forwarded)
 	s.ErrorIs(resp.startErr, someError)
+}
+
+func (s *MatcherDataSuite) TestQuerySyncMatchStatsRemovedOnReprocess() {
+	ctx, cancel := clock.ContextWithTimeout(context.Background(), time.Second, s.ts)
+	defer cancel()
+
+	done := make(chan *matchResult, 1)
+	task := s.newQueryTask("1")
+	go func() {
+		done <- s.md.EnqueueTaskAndWait([]context.Context{ctx}, task)
+	}()
+
+	await.RequireTrue(s.T(), func() bool {
+		return s.md.SyncMatchStatsByPriority()[0].GetApproximateBacklogCount() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	reprocessed := s.md.ReprocessTasks(func(task *internalTask) bool {
+		return task.isQuery()
+	})
+	s.Len(reprocessed, 1)
+	s.Empty(s.md.SyncMatchStatsByPriority())
+	result := <-done
+	s.ErrorIs(result.ctxErr, errReprocessTask)
+}
+
+func (s *MatcherDataSuite) TestNexusSyncMatchStats() {
+	ctx, cancel := clock.ContextWithTimeout(context.Background(), time.Second, s.ts)
+	defer cancel()
+
+	task := newInternalNexusTask("1", s.now().Add(time.Minute), s.now().Add(time.Minute), &matchingservice.DispatchNexusTaskRequest{})
+	done := make(chan *matchResult, 1)
+	go func() {
+		done <- s.md.EnqueueTaskAndWait([]context.Context{ctx}, task)
+	}()
+
+	await.RequireTrue(s.T(), func() bool {
+		return s.md.SyncMatchStatsByPriority()[0].GetApproximateBacklogCount() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	pres := s.pollFakeTime(time.Second)
+	s.NotNil(pres.task)
+	s.True(pres.task.isNexus())
+	s.Empty(s.md.SyncMatchStatsByPriority())
+
+	pres.task.finish(nil, true)
+	result := <-done
+	s.NoError(result.ctxErr)
 }
 
 func (s *MatcherDataSuite) TestQueryForwardNil() {

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -679,6 +679,12 @@ func (c *physicalTaskQueueManagerImpl) GetStatsByPriority(includeRates bool) map
 		}
 	}
 
+	if c.priMatcher != nil {
+		for pri, tqs := range c.priMatcher.SyncMatchStatsByPriority() {
+			taskqueue.MergeStats(util.GetOrSetNew(stats, pri), tqs)
+		}
+	}
+
 	if includeRates {
 		c.taskTrackerLock.RLock()
 		for pri, tt := range c.tasksAdded {

--- a/service/matching/physical_task_queue_manager_test.go
+++ b/service/matching/physical_task_queue_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math"
 	"math/rand"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/api/matchingservicemock/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
@@ -25,6 +27,7 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/quotas"
+	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/common/tqid"
 	"go.uber.org/mock/gomock"
@@ -181,6 +184,51 @@ func (s *PhysicalTaskQueueManagerTestSuite) getTaskManager() *testTaskManager {
 		return s.tqMgr.partitionMgr.engine.fairTaskManager.(*testTaskManager)
 	}
 	return s.tqMgr.partitionMgr.engine.taskManager.(*testTaskManager)
+}
+
+// Query and Nexus tasks wait only in memory while looking for a sync match. Verify they
+// are included in physical backlog stats while waiting and removed after cancellation.
+func (s *PhysicalTaskQueueManagerTestSuite) TestGetStatsByPriorityIncludesSyncMatchBacklog() {
+	if s.tqMgr.priMatcher == nil {
+		s.T().Skip("sync-match backlog accounting is only covered for the new matcher")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	queryTask := newInternalQueryTask(uuid.NewString(), &matchingservice.QueryWorkflowRequest{})
+	nexusTask := newInternalNexusTask(uuid.NewString(), time.Now().Add(time.Second), time.Now().Add(time.Second), &matchingservice.DispatchNexusTaskRequest{})
+	s.tqMgr.config.setDefaultPriority(queryTask)
+	s.tqMgr.config.setDefaultPriority(nexusTask)
+	defaultPriority := int32(s.tqMgr.config.DefaultPriorityKey)
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 2)
+	wg.Go(func() {
+		_, err := s.tqMgr.DispatchQueryTask(ctx, queryTask)
+		errCh <- err
+	})
+	wg.Go(func() {
+		_, err := s.tqMgr.DispatchNexusTask(ctx, nexusTask)
+		errCh <- err
+	})
+
+	await.RequireTrue(s.T(), func() bool {
+		stats := s.tqMgr.GetStatsByPriority(false)
+		return stats[defaultPriority].GetApproximateBacklogCount() == 2 &&
+			stats[defaultPriority].GetApproximateBacklogAge().AsDuration() >= 0
+	}, time.Second, 10*time.Millisecond)
+
+	// Both dispatch calls should return errors after the shared context is canceled.
+	cancel()
+	s.True(common.AwaitWaitGroup(&wg, time.Second))
+	close(errCh)
+	for err := range errCh {
+		s.Require().Error(err)
+	}
+	await.RequireTrue(s.T(), func() bool {
+		return s.tqMgr.GetStatsByPriority(false)[defaultPriority].GetApproximateBacklogCount() == 0
+	}, time.Second, 10*time.Millisecond)
 }
 
 // TODO(pri): old matcher cleanup

--- a/service/matching/pri_matcher.go
+++ b/service/matching/pri_matcher.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"go.temporal.io/api/serviceerror"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/common"
@@ -159,6 +160,10 @@ func (tm *priTaskMatcher) Stop() {
 	// backlog tasks that were redirected from another versioned queue (or the default). To
 	// handle those, the caller of Stop should also call ReprocessRedirectedTasksAfterStop
 	// when applicable.
+}
+
+func (tm *priTaskMatcher) SyncMatchStatsByPriority() map[int32]*taskqueuepb.TaskQueueStats {
+	return tm.data.SyncMatchStatsByPriority()
 }
 
 // TODO(pri): access to retrier is not synchronized

--- a/service/matching/sync_match_backlog_tracker.go
+++ b/service/matching/sync_match_backlog_tracker.go
@@ -1,0 +1,83 @@
+package matching
+
+import (
+	"sync"
+	"time"
+
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+type syncMatchBacklogTracker struct {
+	lock     sync.Mutex
+	byPri    map[int32]int64
+	ageByPri map[int32]backlogAgeTracker
+}
+
+func syncMatchBacklogPriority(task *internalTask) int32 {
+	// Tasks entering taskPQ have effectivePriority initialized from the caller-provided priority
+	// or the task queue default. Nexus tasks do not have a caller-provided priority on this path,
+	// so they use the task queue default. effectivePriority uses a scaled internal representation
+	// to leave room for intermediate matcher priorities; convert it back to the public priority key.
+	return int32(task.effectivePriority / effectivePriorityFactor)
+}
+
+func isSyncMatchBacklogTask(task *internalTask) bool {
+	// DB backlog tasks are already counted by the backlog manager. This tracker only accounts for
+	// real in-memory sync-match tasks that would otherwise be invisible while waiting in taskPQ.
+	// Excludes synthetic poll-forwarder marker tasks. Those are not real user tasks,
+	// so they should never affect backlog counts.
+	return !task.isPollForwarder() && task.source != enumsspb.TASK_SOURCE_DB_BACKLOG
+}
+
+func (t *syncMatchBacklogTracker) record(task *internalTask, delta int) {
+	if !isSyncMatchBacklogTask(task) {
+		return
+	}
+
+	pri := syncMatchBacklogPriority(task)
+
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	if t.byPri == nil {
+		t.byPri = make(map[int32]int64)
+	}
+	if t.ageByPri == nil {
+		t.ageByPri = make(map[int32]backlogAgeTracker)
+	}
+
+	count := max(0, t.byPri[pri]+int64(delta))
+	if count == 0 {
+		delete(t.byPri, pri)
+		delete(t.ageByPri, pri)
+		return
+	}
+	t.byPri[pri] = count
+
+	ageTracker, ok := t.ageByPri[pri]
+	if !ok {
+		ageTracker = newBacklogAgeTracker()
+	}
+	ageTracker.record(task.getCreateTime(), delta)
+	t.ageByPri[pri] = ageTracker
+}
+
+func (t *syncMatchBacklogTracker) statsByPriority() map[int32]*taskqueuepb.TaskQueueStats {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	result := make(map[int32]*taskqueuepb.TaskQueueStats, len(t.byPri))
+	for pri, count := range t.byPri {
+		age := time.Duration(0)
+		if oldest := t.ageByPri[pri].oldestTime(); !oldest.IsZero() {
+			age = time.Since(oldest)
+		}
+		result[pri] = &taskqueuepb.TaskQueueStats{
+			ApproximateBacklogCount: count,
+			ApproximateBacklogAge:   durationpb.New(age),
+		}
+	}
+	return result
+}

--- a/service/matching/task_queue_partition_manager_test.go
+++ b/service/matching/task_queue_partition_manager_test.go
@@ -12,8 +12,11 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	deploymentpb "go.temporal.io/api/deployment/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
+	querypb "go.temporal.io/api/query/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	"go.temporal.io/api/workflowservice/v1"
 	deploymentspb "go.temporal.io/server/api/deployment/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
@@ -240,10 +243,114 @@ func (s *PartitionManagerTestSuite) TestDescribeTaskQueuePartition_UnloadedVersi
 	// unload sourceQ
 	s.partitionMgr.unloadPhysicalQueue(sourceQ, unloadCauseUnspecified)
 
-	s.describeStatsEventually(buildIds, false, false, false, func(resp *matchingservice.DescribeTaskQueuePartitionResponse) bool {
+	s.describeStatsEventually(s.partitionMgr, buildIds, false, false, false, func(resp *matchingservice.DescribeTaskQueuePartitionResponse) bool {
 		// 1 task in the backlog
 		stats := resp.VersionsInfoInternal[bld].GetPhysicalTaskQueueInfo().GetTaskQueueStats()
 		return stats != nil && stats.GetApproximateBacklogCount() == 1
+	})
+}
+
+func (s *PartitionManagerTestSuite) TestDescribeTaskQueuePartition_IncludesQuerySyncMatchBacklog() {
+	if !s.newMatcher {
+		s.T().Skip("sync-match backlog accounting is only covered for the new matcher")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	queryReq := &matchingservice.QueryWorkflowRequest{
+		NamespaceId: namespaceID,
+		QueryRequest: &workflowservice.QueryWorkflowRequest{
+			Execution: &commonpb.WorkflowExecution{
+				WorkflowId: "workflow-id",
+				RunId:      "run-id",
+			},
+			Query: &querypb.WorkflowQuery{QueryType: "query-type"},
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := s.partitionMgr.DispatchQueryTask(ctx, "query-task-id", queryReq)
+		done <- err
+	}()
+
+	s.describeStatsEventually(s.partitionMgr, map[string]bool{"": true}, false, false, false, func(resp *matchingservice.DescribeTaskQueuePartitionResponse) bool {
+		stats := resp.GetVersionsInfoInternal()[""].GetPhysicalTaskQueueInfo().GetTaskQueueStats()
+		return stats.GetApproximateBacklogCount() == 1 &&
+			stats.GetApproximateBacklogAge().AsDuration() >= 0
+	})
+
+	cancel()
+	s.Require().Error(<-done)
+
+	s.describeStatsEventually(s.partitionMgr, map[string]bool{"": true}, false, false, false, func(resp *matchingservice.DescribeTaskQueuePartitionResponse) bool {
+		stats := resp.GetVersionsInfoInternal()[""].GetPhysicalTaskQueueInfo().GetTaskQueueStats()
+		return stats.GetApproximateBacklogCount() == 0
+	})
+}
+
+func (s *PartitionManagerTestSuite) TestDescribeTaskQueuePartition_IncludesNexusSyncMatchBacklog() {
+	if !s.newMatcher {
+		s.T().Skip("sync-match backlog accounting is only covered for the new matcher")
+	}
+
+	engine := s.partitionMgr.engine
+	f, err := tqid.NewTaskQueueFamily(namespaceID, taskQueueName)
+	s.Require().NoError(err)
+	// SetupTest creates a workflow partition manager; Nexus tasks need a Nexus partition manager.
+	partition := f.TaskQueue(enumspb.TASK_QUEUE_TYPE_NEXUS).RootPartition()
+	tqConfig := newTaskQueueConfig(partition.TaskQueue(), engine.config, s.ns.Name())
+
+	pm, err := newTaskQueuePartitionManager(
+		engine,
+		s.ns,
+		partition,
+		tqConfig,
+		s.partitionMgr.logger,
+		s.partitionMgr.throttledLogger,
+		metrics.NoopMetricsHandler,
+		&mockUserDataManager{},
+	)
+	s.Require().NoError(err)
+	engine.partitions[partition.Key()] = pm
+	pm.Start()
+	defer pm.Stop(unloadCauseUnspecified)
+
+	initCtx, initCancel := context.WithTimeout(context.Background(), time.Second)
+	defer initCancel()
+	s.Require().NoError(pm.WaitUntilInitialized(initCtx))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	nexusReq := &matchingservice.DispatchNexusTaskRequest{
+		NamespaceId: namespaceID,
+		TaskQueue: &taskqueuepb.TaskQueue{
+			Name: taskQueueName,
+			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
+		},
+		Request: &nexuspb.Request{},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := pm.DispatchNexusTask(ctx, "nexus-task-id", nexusReq)
+		done <- err
+	}()
+
+	s.describeStatsEventually(pm, map[string]bool{"": true}, false, false, false, func(resp *matchingservice.DescribeTaskQueuePartitionResponse) bool {
+		stats := resp.GetVersionsInfoInternal()[""].GetPhysicalTaskQueueInfo().GetTaskQueueStats()
+		return stats.GetApproximateBacklogCount() == 1 &&
+			stats.GetApproximateBacklogAge().AsDuration() >= 0
+	})
+
+	cancel()
+	s.Require().Error(<-done)
+
+	s.describeStatsEventually(pm, map[string]bool{"": true}, false, false, false, func(resp *matchingservice.DescribeTaskQueuePartitionResponse) bool {
+		stats := resp.GetVersionsInfoInternal()[""].GetPhysicalTaskQueueInfo().GetTaskQueueStats()
+		return stats.GetApproximateBacklogCount() == 0
 	})
 }
 
@@ -340,7 +447,7 @@ func (s *PartitionManagerTestSuite) TestDescribeTaskQueuePartition_CurrentAndRam
 		&deploymentpb.WorkerDeploymentVersion{DeploymentName: deploymentName, BuildId: rampingBuildID},
 	)
 
-	s.describeStatsEventually(buildIds, false, false, false, func(resp *matchingservice.DescribeTaskQueuePartitionResponse) bool {
+	s.describeStatsEventually(s.partitionMgr, buildIds, false, false, false, func(resp *matchingservice.DescribeTaskQueuePartitionResponse) bool {
 		currentStats := resp.VersionsInfoInternal[currentKey].GetPhysicalTaskQueueInfo().GetTaskQueueStats()
 		rampingStats := resp.VersionsInfoInternal[rampingKey].GetPhysicalTaskQueueInfo().GetTaskQueueStats()
 		unversionedStats := resp.VersionsInfoInternal[""].GetPhysicalTaskQueueInfo().GetTaskQueueStats()
@@ -425,7 +532,7 @@ func (s *PartitionManagerTestSuite) TestDescribeTaskQueuePartition_OneUnversione
 		&deploymentpb.WorkerDeploymentVersion{DeploymentName: deploymentName, BuildId: rampingBuildID},
 	)
 
-	s.describeStatsEventually(buildIds, false, false, false, func(resp *matchingservice.DescribeTaskQueuePartitionResponse) bool {
+	s.describeStatsEventually(s.partitionMgr, buildIds, false, false, false, func(resp *matchingservice.DescribeTaskQueuePartitionResponse) bool {
 		currentStats := resp.VersionsInfoInternal[currentKey].GetPhysicalTaskQueueInfo().GetTaskQueueStats()
 		rampingStats := resp.VersionsInfoInternal[rampingKey].GetPhysicalTaskQueueInfo().GetTaskQueueStats()
 		unversionedStats := resp.VersionsInfoInternal[""].GetPhysicalTaskQueueInfo().GetTaskQueueStats()
@@ -495,7 +602,7 @@ func (s *PartitionManagerTestSuite) TestDescribeTaskQueuePartition_OnlyCurrentNo
 		&deploymentpb.WorkerDeploymentVersion{DeploymentName: deploymentName, BuildId: currentBuildID},
 	)
 
-	s.describeStatsEventually(buildIds, false, false, false, func(resp *matchingservice.DescribeTaskQueuePartitionResponse) bool {
+	s.describeStatsEventually(s.partitionMgr, buildIds, false, false, false, func(resp *matchingservice.DescribeTaskQueuePartitionResponse) bool {
 		currentStats := resp.VersionsInfoInternal[currentKey].GetPhysicalTaskQueueInfo().GetTaskQueueStats()
 		unversionedStats := resp.VersionsInfoInternal[""].GetPhysicalTaskQueueInfo().GetTaskQueueStats()
 		if currentStats == nil || unversionedStats == nil {
@@ -567,7 +674,7 @@ func (s *PartitionManagerTestSuite) TestDescribeTaskQueuePartition_OnlyRampingNo
 		&deploymentpb.WorkerDeploymentVersion{DeploymentName: deploymentName, BuildId: rampingBuildID},
 	)
 
-	s.describeStatsEventually(buildIds, false, false, false, func(resp *matchingservice.DescribeTaskQueuePartitionResponse) bool {
+	s.describeStatsEventually(s.partitionMgr, buildIds, false, false, false, func(resp *matchingservice.DescribeTaskQueuePartitionResponse) bool {
 		rampingStats := resp.VersionsInfoInternal[rampingKey].GetPhysicalTaskQueueInfo().GetTaskQueueStats()
 		unversionedStats := resp.VersionsInfoInternal[""].GetPhysicalTaskQueueInfo().GetTaskQueueStats()
 		return rampingStats.GetApproximateBacklogCount() == 3 && unversionedStats.GetApproximateBacklogCount() == 7
@@ -611,7 +718,7 @@ func (s *PartitionManagerTestSuite) TestDescribeTaskQueuePartition_UnversionedDo
 		s.Require().NoError(err)
 	}
 
-	s.describeStatsEventually(map[string]bool{"": true}, false, false, false, func(resp *matchingservice.DescribeTaskQueuePartitionResponse) bool {
+	s.describeStatsEventually(s.partitionMgr, map[string]bool{"": true}, false, false, false, func(resp *matchingservice.DescribeTaskQueuePartitionResponse) bool {
 		uvStats := resp.VersionsInfoInternal[""].GetPhysicalTaskQueueInfo().GetTaskQueueStats()
 		return uvStats != nil && uvStats.GetApproximateBacklogCount() == 5
 	})
@@ -706,25 +813,83 @@ func (s *PartitionManagerTestSuite) TestLogicalBacklogMetrics_NoVersioning() {
 	}, 2*time.Second, 50*time.Millisecond)
 }
 
-func (s *PartitionManagerTestSuite) TestLogicalBacklogMetrics_CurrentOnly() {
-	const (
-		deploymentName = "foo"
-		currentBuildID = "A"
-	)
-
-	s.addRoutingConfigUserData(deploymentName, currentBuildID, "", 0)
+func (s *PartitionManagerTestSuite) TestLogicalBacklogMetrics_IncludesSyncMatchBacklog() {
+	if !s.newMatcher {
+		s.T().Skip("sync-match backlog accounting is only covered for the new matcher")
+	}
 
 	pm, capture, cleanup := s.setupPartitionManagerWithCapture(testPartitionManagerConfig{
 		loadTime: 1 * time.Minute,
 	})
 	defer cleanup()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	s.spoolDefaultTasks(pm, 2)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+	queryReq := &matchingservice.QueryWorkflowRequest{
+		NamespaceId: namespaceID,
+		Priority: &commonpb.Priority{
+			PriorityKey: int32(pm.config.DefaultPriorityKey),
+		},
+		QueryRequest: &workflowservice.QueryWorkflowRequest{
+			Execution: &commonpb.WorkflowExecution{
+				WorkflowId: "workflow-id",
+				RunId:      "run-id",
+			},
+			Query: &querypb.WorkflowQuery{QueryType: "query-type"},
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := pm.DispatchQueryTask(ctx, "query-task-id", queryReq)
+		done <- err
+	}()
+
+	await.RequireTrue(s.T(), func() bool {
+		emitCtx, emitCancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer emitCancel()
+		pm.fetchAndEmitLogicalBacklogMetrics(emitCtx)
+
+		count, ok := latestLogicalBacklogCount(
+			capture.Snapshot(),
+			"__unversioned__",
+			defaultPriorityTag,
+		)
+		return ok && count == float64(3)
+	}, 2*time.Second, 50*time.Millisecond)
+
+	cancel()
+	s.Require().Error(<-done)
+
+	await.RequireTrue(s.T(), func() bool {
+		emitCtx, emitCancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer emitCancel()
+		pm.fetchAndEmitLogicalBacklogMetrics(emitCtx)
+
+		count, ok := latestLogicalBacklogCount(
+			capture.Snapshot(),
+			"__unversioned__",
+			defaultPriorityTag,
+		)
+		return ok && count == float64(2)
+	}, 2*time.Second, 50*time.Millisecond)
+}
+
+func (s *PartitionManagerTestSuite) setupCurrentVersionLogicalBacklog(
+	ctx context.Context,
+	deploymentName string,
+	currentBuildID string,
+) (*taskQueuePartitionManagerImpl, *metricstest.Capture, func(), string) {
+	s.addRoutingConfigUserData(deploymentName, currentBuildID, "", 0)
+
+	pm, capture, cleanup := s.setupPartitionManagerWithCapture(testPartitionManagerConfig{
+		loadTime: 1 * time.Minute,
+	})
 
 	s.spoolDefaultTasks(pm, 10)
 
-	// Create versioned queue and spool 2 pinned tasks.
 	currentQ, err := pm.getVersionedQueue(ctx, "", "", &deploymentpb.Deployment{
 		SeriesName: deploymentName,
 		BuildId:    currentBuildID,
@@ -750,10 +915,98 @@ func (s *PartitionManagerTestSuite) TestLogicalBacklogMetrics_CurrentOnly() {
 	currentVersionTag := worker_versioning.ExternalWorkerDeploymentVersionToString(
 		&deploymentpb.WorkerDeploymentVersion{DeploymentName: deploymentName, BuildId: currentBuildID},
 	)
+	return pm, capture, cleanup, currentVersionTag
+}
+
+func (s *PartitionManagerTestSuite) TestLogicalBacklogMetrics_CurrentOnly() {
+	const (
+		deploymentName = "foo"
+		currentBuildID = "A"
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	pm, capture, cleanup, currentVersionTag := s.setupCurrentVersionLogicalBacklog(
+		ctx,
+		deploymentName,
+		currentBuildID,
+	)
+	defer cleanup()
 
 	// Wait for backlog stats to stabilize, then emit logical metrics.
 	s.Require().Eventually(func() bool {
 		pm.fetchAndEmitLogicalBacklogMetrics(ctx)
+		snap := capture.Snapshot()
+
+		unvCount, unvOk := latestLogicalBacklogCount(snap, "__unversioned__", defaultPriorityTag)
+		curCount, curOk := latestLogicalBacklogCount(snap, currentVersionTag, defaultPriorityTag)
+		return unvOk && unvCount == float64(0) &&
+			curOk && curCount == float64(12)
+	}, 2*time.Second, 50*time.Millisecond)
+}
+
+func (s *PartitionManagerTestSuite) TestLogicalBacklogMetrics_VersionedIncludesSyncMatchBacklog() {
+	if !s.newMatcher {
+		s.T().Skip("sync-match backlog accounting is only covered for the new matcher")
+	}
+
+	const (
+		deploymentName = "foo"
+		currentBuildID = "A"
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pm, capture, cleanup, currentVersionTag := s.setupCurrentVersionLogicalBacklog(
+		ctx,
+		deploymentName,
+		currentBuildID,
+	)
+	defer cleanup()
+
+	queryCtx, queryCancel := context.WithCancel(ctx)
+	queryReq := &matchingservice.QueryWorkflowRequest{
+		NamespaceId:      namespaceID,
+		VersionDirective: worker_versioning.MakeUseAssignmentRulesDirective(),
+		Priority: &commonpb.Priority{
+			PriorityKey: int32(pm.config.DefaultPriorityKey),
+		},
+		QueryRequest: &workflowservice.QueryWorkflowRequest{
+			Execution: &commonpb.WorkflowExecution{
+				WorkflowId: "workflow-id",
+				RunId:      "run-id",
+			},
+			Query: &querypb.WorkflowQuery{QueryType: "query-type"},
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := pm.DispatchQueryTask(queryCtx, "query-task-id", queryReq)
+		done <- err
+	}()
+
+	await.RequireTrue(s.T(), func() bool {
+		emitCtx, emitCancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer emitCancel()
+		pm.fetchAndEmitLogicalBacklogMetrics(emitCtx)
+		snap := capture.Snapshot()
+
+		unvCount, unvOk := latestLogicalBacklogCount(snap, "__unversioned__", defaultPriorityTag)
+		curCount, curOk := latestLogicalBacklogCount(snap, currentVersionTag, defaultPriorityTag)
+		return unvOk && unvCount == float64(0) &&
+			curOk && curCount == float64(13)
+	}, 2*time.Second, 50*time.Millisecond)
+
+	queryCancel()
+	s.Require().Error(<-done)
+
+	await.RequireTrue(s.T(), func() bool {
+		emitCtx, emitCancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer emitCancel()
+		pm.fetchAndEmitLogicalBacklogMetrics(emitCtx)
 		snap := capture.Snapshot()
 
 		unvCount, unvOk := latestLogicalBacklogCount(snap, "__unversioned__", defaultPriorityTag)
@@ -1321,7 +1574,10 @@ func createVersionSet(buildId string) *persistencespb.CompatibleVersionSet {
 	}
 }
 
+// Polls Describe until the expected stats are available. The partition manager is explicit because
+// tests may describe Workflow, Activity, or Nexus task queues.
 func (s *PartitionManagerTestSuite) describeStatsEventually(
+	pm *taskQueuePartitionManagerImpl,
 	buildIds map[string]bool,
 	includeAllActive, reportPollers, internalTaskQueueStatus bool,
 	check func(resp *matchingservice.DescribeTaskQueuePartitionResponse) bool,
@@ -1330,7 +1586,7 @@ func (s *PartitionManagerTestSuite) describeStatsEventually(
 	s.Require().Eventually(func() bool {
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
-		resp, err := s.partitionMgr.Describe(ctx, buildIds, includeAllActive, true /* reportStats */, reportPollers, internalTaskQueueStatus)
+		resp, err := pm.Describe(ctx, buildIds, includeAllActive, true /* reportStats */, reportPollers, internalTaskQueueStatus)
 		if err != nil {
 			return false
 		}


### PR DESCRIPTION
## What changed?
Added in-memory sync-match backlog accounting for the new matcher so query and Nexus tasks waiting in taskPQ are included in task queue stats. Classic matcher is intentionally left unchanged.

Closes : https://github.com/temporalio/temporal/issues/6760

## Why?
Query and Nexus tasks can wait in memory while looking for a sync match and are not represented in DB backlog stats, so Describe could underreport backlog.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

## Potential risks
The change is scoped to the new matcher and only counts non-DB-backlog in-memory tasks to avoid double counting.
