### PR TITLE
Use suite context in Nexus standalone tests

### DIFF
--- a/tests/nexus_standalone_test.go
+++ b/tests/nexus_standalone_test.go
@@ -54,7 +54,7 @@ func (s *NexusStandaloneTestSuite) TestStartStandaloneNexusOperation() {
 	s.Run("StartAndDescribe", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
 		// Ensure operation reaches STARTED on the first dispatch attempt.
-		endpointName := env.createRandomExternalNexusServer(env.Context(), s.T(), nexustest.Handler{
+		endpointName := env.createRandomExternalNexusServer(s.Context(), s.T(), nexustest.Handler{
 			OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
 				return &nexus.HandlerStartOperationResultAsync{OperationToken: "test-operation-token"}, nil
 			},
@@ -87,7 +87,7 @@ func (s *NexusStandaloneTestSuite) TestStartStandaloneNexusOperation() {
 		s.True(startResp.GetStarted())
 
 		// Ensure the operation is in a stable STARTED state.
-		_, err = env.FrontendClient().PollNexusOperationExecution(env.Context(), &workflowservice.PollNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().PollNexusOperationExecution(s.Context(), &workflowservice.PollNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -103,7 +103,7 @@ func (s *NexusStandaloneTestSuite) TestStartStandaloneNexusOperation() {
 			{name: "WithEmptyRunID", runID: ""},
 		} {
 			s.Run(tc.name, func(s *NexusStandaloneTestSuite) {
-				descResp, err := env.FrontendClient().DescribeNexusOperationExecution(env.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+				descResp, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
 					Namespace:   env.Namespace().String(),
 					OperationId: "test-op",
 					RunId:       tc.runID,
@@ -139,7 +139,7 @@ func (s *NexusStandaloneTestSuite) TestStartStandaloneNexusOperation() {
 		}
 
 		s.Run("IncludeInput", func(s *NexusStandaloneTestSuite) {
-			descResp, err := env.FrontendClient().DescribeNexusOperationExecution(env.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+			descResp, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
 				Namespace:    env.Namespace().String(),
 				OperationId:  "test-op",
 				RunId:        startResp.RunId,
@@ -164,7 +164,7 @@ func (s *NexusStandaloneTestSuite) TestStartStandaloneNexusOperation() {
 
 	s.Run("IDConflictPolicyFail", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 		resp1, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -199,7 +199,7 @@ func (s *NexusStandaloneTestSuite) TestStartStandaloneNexusOperation() {
 
 	s.Run("IDConflictPolicyUseExisting", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 		resp1, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -223,7 +223,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 	s.Run("NotFound", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
 
-		_, err := env.FrontendClient().DescribeNexusOperationExecution(env.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+		_, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "does-not-exist",
 		})
@@ -234,7 +234,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 
 	s.Run("LongPollStateChange", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -243,7 +243,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 		s.NoError(err)
 
 		// Obtain longpoll token.
-		firstResp, err := env.FrontendClient().DescribeNexusOperationExecution(env.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+		firstResp, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -260,7 +260,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 		describeResultCh := make(chan describeResult, 1)
 
 		go func() {
-			resp, err := env.FrontendClient().DescribeNexusOperationExecution(env.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+			resp, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
 				Namespace:      env.Namespace().String(),
 				OperationId:    "test-op",
 				RunId:          startResp.RunId,
@@ -281,7 +281,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 		// Terminate the operation.
 		terminateErrCh := make(chan error, 1)
 		go func() {
-			_, err := env.FrontendClient().TerminateNexusOperationExecution(env.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
+			_, err := env.FrontendClient().TerminateNexusOperationExecution(s.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
 				Namespace:   env.Namespace().String(),
 				OperationId: "test-op",
 				RunId:       startResp.RunId,
@@ -293,7 +293,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 		select {
 		case err := <-terminateErrCh:
 			s.NoError(err)
-		case <-env.Context().Done():
+		case <-s.Context().Done():
 			s.T().Fatal("TerminateNexusOperationExecution timed out")
 		}
 
@@ -303,7 +303,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 		case result := <-describeResultCh:
 			s.NoError(result.err)
 			longPollResp = result.resp
-		case <-env.Context().Done():
+		case <-s.Context().Done():
 			s.T().Fatal("DescribeNexusOperationExecution timed out")
 		}
 
@@ -326,7 +326,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 					env.OverrideDynamicConfig(nexusoperation.LongPollTimeout, 10*time.Millisecond)
 				},
 				callerCtx: func(env *NexusTestEnv) (context.Context, context.CancelFunc) {
-					return context.WithTimeout(env.Context(), 9999*time.Millisecond)
+					return context.WithTimeout(s.Context(), 9999*time.Millisecond)
 				},
 			},
 			{
@@ -335,7 +335,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 					env.OverrideDynamicConfig(nexusoperation.LongPollTimeout, 10*time.Millisecond)
 				},
 				callerCtx: func(env *NexusTestEnv) (context.Context, context.CancelFunc) {
-					return env.Context(), func() {}
+					return s.Context(), func() {}
 				},
 			},
 			{
@@ -344,12 +344,12 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 					env.OverrideDynamicConfig(nexusoperation.LongPollBuffer, common.DefaultLongPollTimeout-time.Second)
 				},
 				callerCtx: func(env *NexusTestEnv) (context.Context, context.CancelFunc) {
-					return env.Context(), func() {}
+					return s.Context(), func() {}
 				},
 			},
 		} {
 			env := s.newTestEnv()
-			endpointName := env.createRandomExternalNexusServer(env.Context(), s.T(), nexustest.Handler{
+			endpointName := env.createRandomExternalNexusServer(s.Context(), s.T(), nexustest.Handler{
 				OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
 					return &nexus.HandlerStartOperationResultAsync{OperationToken: "test-operation-token"}, nil
 				},
@@ -362,7 +362,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 			s.NoError(err)
 
 			// Ensure the operation is in a stable STARTED state.
-			_, err = env.FrontendClient().PollNexusOperationExecution(env.Context(), &workflowservice.PollNexusOperationExecutionRequest{
+			_, err = env.FrontendClient().PollNexusOperationExecution(s.Context(), &workflowservice.PollNexusOperationExecutionRequest{
 				Namespace:   env.Namespace().String(),
 				OperationId: "test-op",
 				RunId:       startResp.RunId,
@@ -370,7 +370,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 			})
 			s.NoError(err)
 
-			firstResp, err := env.FrontendClient().DescribeNexusOperationExecution(env.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+			firstResp, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
 				Namespace:   env.Namespace().String(),
 				OperationId: "test-op",
 				RunId:       startResp.RunId,
@@ -398,7 +398,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 	s.Run("IncludeOutcome_Success", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
 		taskQueue := testcore.RandomizedNexusEndpoint(s.T().Name())
-		endpointName := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
+		endpointName := env.createNexusEndpoint(s.Context(), s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
 		expectedResult := payload.EncodeString("successful result")
 		handlerLink := &commonpb.Link_WorkflowEvent{
 			Namespace:  env.Namespace().String(),
@@ -420,7 +420,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 
 		pollerErrCh := make(chan error, 1)
 		go func() {
-			task, err := env.FrontendClient().PollNexusTaskQueue(env.Context(), &workflowservice.PollNexusTaskQueueRequest{
+			task, err := env.FrontendClient().PollNexusTaskQueue(s.Context(), &workflowservice.PollNexusTaskQueueRequest{
 				Namespace: env.Namespace().String(),
 				Identity:  "test-worker",
 				TaskQueue: &taskqueuepb.TaskQueue{
@@ -451,7 +451,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 				return
 			}
 
-			_, err = env.FrontendClient().RespondNexusTaskCompleted(env.Context(), &workflowservice.RespondNexusTaskCompletedRequest{
+			_, err = env.FrontendClient().RespondNexusTaskCompleted(s.Context(), &workflowservice.RespondNexusTaskCompletedRequest{
 				Namespace: env.Namespace().String(),
 				Identity:  "test-worker",
 				TaskToken: task.GetTaskToken(),
@@ -474,7 +474,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 		}()
 
 		s.EventuallyWithT(func(t *assert.CollectT) {
-			descResp, err := env.FrontendClient().DescribeNexusOperationExecution(env.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+			descResp, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
 				Namespace:      env.Namespace().String(),
 				OperationId:    "test-op",
 				RunId:          startResp.RunId,
@@ -491,7 +491,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 				},
 			}, descResp.GetInfo().GetLinks())
 
-			pollResp, err := env.FrontendClient().PollNexusOperationExecution(env.Context(), &workflowservice.PollNexusOperationExecutionRequest{
+			pollResp, err := env.FrontendClient().PollNexusOperationExecution(s.Context(), &workflowservice.PollNexusOperationExecutionRequest{
 				Namespace:   env.Namespace().String(),
 				OperationId: "test-op",
 				RunId:       startResp.RunId,
@@ -511,7 +511,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 		s.Run("ScheduleToStartTimeout", func(s *NexusStandaloneTestSuite) {
 			env := s.newTestEnv()
 			taskQueue := testcore.RandomizedNexusEndpoint(s.T().Name())
-			endpointName := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
+			endpointName := env.createNexusEndpoint(s.Context(), s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
 
 			startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 				OperationId:            "test-op",
@@ -521,7 +521,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 			s.NoError(err)
 
 			s.EventuallyWithT(func(t *assert.CollectT) {
-				descResp, err := env.FrontendClient().DescribeNexusOperationExecution(env.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+				descResp, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
 					Namespace:      env.Namespace().String(),
 					OperationId:    "test-op",
 					RunId:          startResp.RunId,
@@ -538,7 +538,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 					},
 				}, descResp.GetFailure())
 
-				pollResp, err := env.FrontendClient().PollNexusOperationExecution(env.Context(), &workflowservice.PollNexusOperationExecutionRequest{
+				pollResp, err := env.FrontendClient().PollNexusOperationExecution(s.Context(), &workflowservice.PollNexusOperationExecutionRequest{
 					Namespace:   env.Namespace().String(),
 					OperationId: "test-op",
 					RunId:       startResp.RunId,
@@ -559,7 +559,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 		s.Run("ScheduleToCloseTimeout_BeforeStart", func(s *NexusStandaloneTestSuite) {
 			env := s.newTestEnv()
 			taskQueue := testcore.RandomizedNexusEndpoint(s.T().Name())
-			endpointName := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
+			endpointName := env.createNexusEndpoint(s.Context(), s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
 
 			startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 				OperationId:            "test-op",
@@ -569,7 +569,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 			s.NoError(err)
 
 			s.EventuallyWithT(func(t *assert.CollectT) {
-				descResp, err := env.FrontendClient().DescribeNexusOperationExecution(env.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+				descResp, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
 					Namespace:      env.Namespace().String(),
 					OperationId:    "test-op",
 					RunId:          startResp.RunId,
@@ -586,7 +586,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 					},
 				}, descResp.GetFailure())
 
-				pollResp, err := env.FrontendClient().PollNexusOperationExecution(env.Context(), &workflowservice.PollNexusOperationExecutionRequest{
+				pollResp, err := env.FrontendClient().PollNexusOperationExecution(s.Context(), &workflowservice.PollNexusOperationExecutionRequest{
 					Namespace:   env.Namespace().String(),
 					OperationId: "test-op",
 					RunId:       startResp.RunId,
@@ -769,7 +769,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 			s.Run(tc.name, func(s *NexusStandaloneTestSuite) {
 				env := s.newTestEnv()
 				taskQueue := testcore.RandomizedNexusEndpoint(s.T().Name())
-				endpointName := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
+				endpointName := env.createNexusEndpoint(s.Context(), s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
 				startReq := &workflowservice.StartNexusOperationExecutionRequest{
 					OperationId: "test-op",
 					Endpoint:    endpointName,
@@ -783,7 +783,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 
 				pollerErrCh := make(chan error, 1)
 				go func() {
-					task, err := env.FrontendClient().PollNexusTaskQueue(env.Context(), &workflowservice.PollNexusTaskQueueRequest{
+					task, err := env.FrontendClient().PollNexusTaskQueue(s.Context(), &workflowservice.PollNexusTaskQueueRequest{
 						Namespace: env.Namespace().String(),
 						Identity:  "test-worker",
 						TaskQueue: &taskqueuepb.TaskQueue{
@@ -795,11 +795,11 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 						pollerErrCh <- err
 						return
 					}
-					pollerErrCh <- tc.respond(env.Context(), env, task)
+					pollerErrCh <- tc.respond(s.Context(), env, task)
 				}()
 
 				s.EventuallyWithT(func(t *assert.CollectT) {
-					descResp, err := env.FrontendClient().DescribeNexusOperationExecution(env.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+					descResp, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
 						Namespace:      env.Namespace().String(),
 						OperationId:    "test-op",
 						RunId:          startResp.RunId,
@@ -807,7 +807,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 					})
 					require.NoError(t, err)
 
-					pollResp, err := env.FrontendClient().PollNexusOperationExecution(env.Context(), &workflowservice.PollNexusOperationExecutionRequest{
+					pollResp, err := env.FrontendClient().PollNexusOperationExecution(s.Context(), &workflowservice.PollNexusOperationExecutionRequest{
 						Namespace:   env.Namespace().String(),
 						OperationId: "test-op",
 						RunId:       startResp.RunId,
@@ -827,7 +827,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 	s.Run("Validation", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
 
-		_, err := env.FrontendClient().DescribeNexusOperationExecution(env.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+		_, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
 			Namespace: env.Namespace().String(),
 		})
 		s.Error(err)
@@ -838,7 +838,7 @@ func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {
 func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 	s.Run("RequestCancel", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomExternalNexusServer(env.Context(), s.T(), nexustest.Handler{
+		endpointName := env.createRandomExternalNexusServer(s.Context(), s.T(), nexustest.Handler{
 			OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
 				return &nexus.HandlerStartOperationResultAsync{OperationToken: "test-operation-token"}, nil
 			},
@@ -855,7 +855,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 		s.True(startResp.GetStarted())
 
 		// Ensure the operation is in a stable STARTED state.
-		_, err = env.FrontendClient().PollNexusOperationExecution(env.Context(), &workflowservice.PollNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().PollNexusOperationExecution(s.Context(), &workflowservice.PollNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -863,7 +863,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 		})
 		s.NoError(err)
 
-		_, err = env.FrontendClient().RequestCancelNexusOperationExecution(env.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().RequestCancelNexusOperationExecution(s.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -871,7 +871,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 		s.NoError(err)
 
 		// Verify state after cancel — operation is still running
-		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(env.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -896,7 +896,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 
 	s.Run("AlreadyCanceled", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -905,7 +905,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 		s.NoError(err)
 
 		// Cancel the operation.
-		_, err = env.FrontendClient().RequestCancelNexusOperationExecution(env.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().RequestCancelNexusOperationExecution(s.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -914,7 +914,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 		s.NoError(err)
 
 		// Cancel again with same request ID — should be idempotent.
-		_, err = env.FrontendClient().RequestCancelNexusOperationExecution(env.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().RequestCancelNexusOperationExecution(s.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -923,7 +923,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 		s.NoError(err)
 
 		// Cancel with a different request ID — should error.
-		_, err = env.FrontendClient().RequestCancelNexusOperationExecution(env.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().RequestCancelNexusOperationExecution(s.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -951,7 +951,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 				return nil
 			},
 		}
-		endpointName := env.createRandomExternalNexusServer(env.Context(), s.T(), handler)
+		endpointName := env.createRandomExternalNexusServer(s.Context(), s.T(), handler)
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -960,7 +960,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 		})
 		s.NoError(err)
 
-		_, err = env.FrontendClient().PollNexusOperationExecution(env.Context(), &workflowservice.PollNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().PollNexusOperationExecution(s.Context(), &workflowservice.PollNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -968,7 +968,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 		})
 		s.NoError(err)
 
-		_, err = env.FrontendClient().RequestCancelNexusOperationExecution(env.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().RequestCancelNexusOperationExecution(s.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -985,7 +985,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 
 	s.Run("AlreadyTerminated", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -994,7 +994,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 		s.NoError(err)
 
 		// Terminate the operation first.
-		_, err = env.FrontendClient().TerminateNexusOperationExecution(env.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().TerminateNexusOperationExecution(s.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -1005,7 +1005,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 		s.NoError(err)
 
 		// Cancel a terminated operation — should error.
-		_, err = env.FrontendClient().RequestCancelNexusOperationExecution(env.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().RequestCancelNexusOperationExecution(s.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -1017,7 +1017,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 	s.Run("NotFound", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
 
-		_, err := env.FrontendClient().RequestCancelNexusOperationExecution(env.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
+		_, err := env.FrontendClient().RequestCancelNexusOperationExecution(s.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "does-not-exist",
 		})
@@ -1030,7 +1030,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 	s.Run("Validation", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
 
-		_, err := env.FrontendClient().RequestCancelNexusOperationExecution(env.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
+		_, err := env.FrontendClient().RequestCancelNexusOperationExecution(s.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "", // required field
 		})
@@ -1042,7 +1042,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 func (s *NexusStandaloneTestSuite) TestTerminateStandaloneNexusOperation() {
 	s.Run("Terminate", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -1051,7 +1051,7 @@ func (s *NexusStandaloneTestSuite) TestTerminateStandaloneNexusOperation() {
 		s.NoError(err)
 		s.True(startResp.GetStarted())
 
-		_, err = env.FrontendClient().TerminateNexusOperationExecution(env.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().TerminateNexusOperationExecution(s.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -1062,7 +1062,7 @@ func (s *NexusStandaloneTestSuite) TestTerminateStandaloneNexusOperation() {
 		s.NoError(err)
 
 		// Verify outcome after terminate.
-		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(env.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
 			Namespace:      env.Namespace().String(),
 			OperationId:    "test-op",
 			RunId:          startResp.RunId,
@@ -1079,7 +1079,7 @@ func (s *NexusStandaloneTestSuite) TestTerminateStandaloneNexusOperation() {
 
 	s.Run("AlreadyTerminated", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -1088,7 +1088,7 @@ func (s *NexusStandaloneTestSuite) TestTerminateStandaloneNexusOperation() {
 		s.NoError(err)
 
 		// Terminate the operation.
-		_, err = env.FrontendClient().TerminateNexusOperationExecution(env.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().TerminateNexusOperationExecution(s.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -1098,7 +1098,7 @@ func (s *NexusStandaloneTestSuite) TestTerminateStandaloneNexusOperation() {
 		s.NoError(err)
 
 		// Terminate again with same request ID — should be idempotent.
-		_, err = env.FrontendClient().TerminateNexusOperationExecution(env.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().TerminateNexusOperationExecution(s.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -1108,7 +1108,7 @@ func (s *NexusStandaloneTestSuite) TestTerminateStandaloneNexusOperation() {
 		s.NoError(err)
 
 		// Terminate with a different request ID — should error.
-		_, err = env.FrontendClient().TerminateNexusOperationExecution(env.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().TerminateNexusOperationExecution(s.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -1121,7 +1121,7 @@ func (s *NexusStandaloneTestSuite) TestTerminateStandaloneNexusOperation() {
 
 	s.Run("AlreadyCanceled", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -1130,7 +1130,7 @@ func (s *NexusStandaloneTestSuite) TestTerminateStandaloneNexusOperation() {
 		s.NoError(err)
 
 		// Cancel the operation first.
-		_, err = env.FrontendClient().RequestCancelNexusOperationExecution(env.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().RequestCancelNexusOperationExecution(s.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -1138,7 +1138,7 @@ func (s *NexusStandaloneTestSuite) TestTerminateStandaloneNexusOperation() {
 		s.NoError(err)
 
 		// Terminate a canceled operation — should succeed.
-		_, err = env.FrontendClient().TerminateNexusOperationExecution(env.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().TerminateNexusOperationExecution(s.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -1148,7 +1148,7 @@ func (s *NexusStandaloneTestSuite) TestTerminateStandaloneNexusOperation() {
 		s.NoError(err)
 
 		// Verify state changed to terminated (terminate overrides cancel request).
-		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(env.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -1160,7 +1160,7 @@ func (s *NexusStandaloneTestSuite) TestTerminateStandaloneNexusOperation() {
 	s.Run("NotFound", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
 
-		_, err := env.FrontendClient().TerminateNexusOperationExecution(env.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
+		_, err := env.FrontendClient().TerminateNexusOperationExecution(s.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "does-not-exist",
 			Reason:      "test termination",
@@ -1174,7 +1174,7 @@ func (s *NexusStandaloneTestSuite) TestTerminateStandaloneNexusOperation() {
 	s.Run("Validation", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
 
-		_, err := env.FrontendClient().TerminateNexusOperationExecution(env.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
+		_, err := env.FrontendClient().TerminateNexusOperationExecution(s.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "", // required field
 		})
@@ -1186,7 +1186,7 @@ func (s *NexusStandaloneTestSuite) TestTerminateStandaloneNexusOperation() {
 func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 	s.Run("ListAndVerifyFields", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "list-test-op",
@@ -1197,7 +1197,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 		var listResp *workflowservice.ListNexusOperationExecutionsResponse
 		s.EventuallyWithT(func(t *assert.CollectT) {
 			var err error
-			listResp, err = env.FrontendClient().ListNexusOperationExecutions(env.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
+			listResp, err = env.FrontendClient().ListNexusOperationExecutions(s.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
 				Namespace: env.Namespace().String(),
 				Query:     "OperationId = 'list-test-op'",
 			})
@@ -1220,7 +1220,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 
 	s.Run("ListWithCustomSearchAttributes", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 		testSA := &commonpb.SearchAttributes{
 			IndexedFields: map[string]*commonpb.Payload{
@@ -1237,7 +1237,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 		var listResp *workflowservice.ListNexusOperationExecutionsResponse
 		s.EventuallyWithT(func(t *assert.CollectT) {
 			var err error
-			listResp, err = env.FrontendClient().ListNexusOperationExecutions(env.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
+			listResp, err = env.FrontendClient().ListNexusOperationExecutions(s.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
 				Namespace: env.Namespace().String(),
 				Query:     "CustomKeywordField = 'list-sa-value'",
 			})
@@ -1254,7 +1254,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 
 	s.Run("QueryByMultipleFields", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 		_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "multi-op",
@@ -1266,7 +1266,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 		var listResp *workflowservice.ListNexusOperationExecutionsResponse
 		s.EventuallyWithT(func(t *assert.CollectT) {
 			var err error
-			listResp, err = env.FrontendClient().ListNexusOperationExecutions(env.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
+			listResp, err = env.FrontendClient().ListNexusOperationExecutions(s.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
 				Namespace: env.Namespace().String(),
 				Query:     fmt.Sprintf("Endpoint = '%s' AND Service = 'multi-service'", endpointName),
 			})
@@ -1278,7 +1278,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 
 	s.Run("QueryBySupportedSearchAttributes", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 		testStartTime := time.Now().UTC().Format(time.RFC3339Nano)
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
@@ -1289,7 +1289,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 		})
 		s.NoError(err)
 
-		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(env.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "supported-closed-op",
 			RunId:       startResp.RunId,
@@ -1298,7 +1298,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 		requestID := descResp.GetInfo().GetRequestId()
 		s.NotEmpty(requestID)
 
-		_, err = env.FrontendClient().TerminateNexusOperationExecution(env.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().TerminateNexusOperationExecution(s.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "supported-closed-op",
 			RunId:       startResp.RunId,
@@ -1403,7 +1403,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 			var resp *workflowservice.ListNexusOperationExecutionsResponse
 			s.EventuallyWithT(func(t *assert.CollectT) {
 				var err error
-				resp, err = env.FrontendClient().ListNexusOperationExecutions(env.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
+				resp, err = env.FrontendClient().ListNexusOperationExecutions(s.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
 					Namespace: env.Namespace().String(),
 					PageSize:  10,
 					Query:     tc.query,
@@ -1417,7 +1417,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 
 	s.Run("PageSizeCapping", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 		for i := range 2 {
 			_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
@@ -1430,7 +1430,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 		// Wait for both to be indexed.
 		query := fmt.Sprintf("Endpoint = '%s'", endpointName)
 		s.EventuallyWithT(func(t *assert.CollectT) {
-			resp, err := env.FrontendClient().ListNexusOperationExecutions(env.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
+			resp, err := env.FrontendClient().ListNexusOperationExecutions(s.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
 				Namespace: env.Namespace().String(),
 				Query:     query,
 			})
@@ -1442,7 +1442,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 		env.OverrideDynamicConfig(dynamicconfig.FrontendVisibilityMaxPageSize, 1)
 
 		// PageSize 0 should default to max (1), returning only 1 result.
-		resp, err := env.FrontendClient().ListNexusOperationExecutions(env.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
+		resp, err := env.FrontendClient().ListNexusOperationExecutions(s.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
 			Namespace: env.Namespace().String(),
 			PageSize:  0,
 			Query:     query,
@@ -1451,7 +1451,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 		s.Len(resp.GetOperations(), 1)
 
 		// PageSize > max should also be capped. First page.
-		resp, err = env.FrontendClient().ListNexusOperationExecutions(env.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
+		resp, err = env.FrontendClient().ListNexusOperationExecutions(s.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
 			Namespace: env.Namespace().String(),
 			PageSize:  2,
 			Query:     query,
@@ -1460,7 +1460,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 		s.Len(resp.GetOperations(), 1)
 
 		// Second page.
-		resp, err = env.FrontendClient().ListNexusOperationExecutions(env.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
+		resp, err = env.FrontendClient().ListNexusOperationExecutions(s.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
 			Namespace:     env.Namespace().String(),
 			PageSize:      2,
 			Query:         query,
@@ -1470,7 +1470,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 		s.Len(resp.GetOperations(), 1)
 
 		// No more results.
-		resp, err = env.FrontendClient().ListNexusOperationExecutions(env.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
+		resp, err = env.FrontendClient().ListNexusOperationExecutions(s.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
 			Namespace:     env.Namespace().String(),
 			PageSize:      2,
 			Query:         query,
@@ -1484,7 +1484,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 	s.Run("InvalidQuery", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
 
-		_, err := env.FrontendClient().ListNexusOperationExecutions(env.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
+		_, err := env.FrontendClient().ListNexusOperationExecutions(s.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
 			Namespace: env.Namespace().String(),
 			Query:     "invalid query syntax !!!",
 		})
@@ -1495,7 +1495,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 	s.Run("InvalidSearchAttribute", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
 
-		_, err := env.FrontendClient().ListNexusOperationExecutions(env.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
+		_, err := env.FrontendClient().ListNexusOperationExecutions(s.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
 			Namespace: env.Namespace().String(),
 			Query:     "NonExistentField = 'value'",
 		})
@@ -1506,7 +1506,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 	s.Run("NamespaceNotFound", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
 
-		_, err := env.FrontendClient().ListNexusOperationExecutions(env.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
+		_, err := env.FrontendClient().ListNexusOperationExecutions(s.Context(), &workflowservice.ListNexusOperationExecutionsRequest{
 			Namespace: "non-existent-namespace",
 		})
 		s.ErrorAs(err, new(*serviceerror.NamespaceNotFound))
@@ -1517,7 +1517,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 func (s *NexusStandaloneTestSuite) TestCountStandaloneNexusOperation() {
 	s.Run("CountByOperationID", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 		_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "count-op",
@@ -1526,7 +1526,7 @@ func (s *NexusStandaloneTestSuite) TestCountStandaloneNexusOperation() {
 		s.NoError(err)
 
 		s.EventuallyWithT(func(t *assert.CollectT) {
-			resp, err := env.FrontendClient().CountNexusOperationExecutions(env.Context(), &workflowservice.CountNexusOperationExecutionsRequest{
+			resp, err := env.FrontendClient().CountNexusOperationExecutions(s.Context(), &workflowservice.CountNexusOperationExecutionsRequest{
 				Namespace: env.Namespace().String(),
 				Query:     "OperationId = 'count-op'",
 			})
@@ -1537,7 +1537,7 @@ func (s *NexusStandaloneTestSuite) TestCountStandaloneNexusOperation() {
 
 	s.Run("CountByEndpoint", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 		for i := range 3 {
 			_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
@@ -1548,7 +1548,7 @@ func (s *NexusStandaloneTestSuite) TestCountStandaloneNexusOperation() {
 		}
 
 		s.EventuallyWithT(func(t *assert.CollectT) {
-			resp, err := env.FrontendClient().CountNexusOperationExecutions(env.Context(), &workflowservice.CountNexusOperationExecutionsRequest{
+			resp, err := env.FrontendClient().CountNexusOperationExecutions(s.Context(), &workflowservice.CountNexusOperationExecutionsRequest{
 				Namespace: env.Namespace().String(),
 				Query:     fmt.Sprintf("Endpoint = '%s'", endpointName),
 			})
@@ -1559,7 +1559,7 @@ func (s *NexusStandaloneTestSuite) TestCountStandaloneNexusOperation() {
 
 	s.Run("CountByExecutionStatus", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 		_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "count-status-op",
@@ -1568,7 +1568,7 @@ func (s *NexusStandaloneTestSuite) TestCountStandaloneNexusOperation() {
 		s.NoError(err)
 
 		s.EventuallyWithT(func(t *assert.CollectT) {
-			resp, err := env.FrontendClient().CountNexusOperationExecutions(env.Context(), &workflowservice.CountNexusOperationExecutionsRequest{
+			resp, err := env.FrontendClient().CountNexusOperationExecutions(s.Context(), &workflowservice.CountNexusOperationExecutionsRequest{
 				Namespace: env.Namespace().String(),
 				Query:     fmt.Sprintf("ExecutionStatus = 'Running' AND Endpoint = '%s'", endpointName),
 			})
@@ -1579,7 +1579,7 @@ func (s *NexusStandaloneTestSuite) TestCountStandaloneNexusOperation() {
 
 	s.Run("GroupByExecutionStatus", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 		for i := range 3 {
 			_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
@@ -1592,7 +1592,7 @@ func (s *NexusStandaloneTestSuite) TestCountStandaloneNexusOperation() {
 		var countResp *workflowservice.CountNexusOperationExecutionsResponse
 		s.EventuallyWithT(func(t *assert.CollectT) {
 			var err error
-			countResp, err = env.FrontendClient().CountNexusOperationExecutions(env.Context(), &workflowservice.CountNexusOperationExecutionsRequest{
+			countResp, err = env.FrontendClient().CountNexusOperationExecutions(s.Context(), &workflowservice.CountNexusOperationExecutionsRequest{
 				Namespace: env.Namespace().String(),
 				Query:     fmt.Sprintf("Endpoint = '%s' GROUP BY ExecutionStatus", endpointName),
 			})
@@ -1608,7 +1608,7 @@ func (s *NexusStandaloneTestSuite) TestCountStandaloneNexusOperation() {
 
 	s.Run("CountByCustomSearchAttribute", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 		for i := range 2 {
 			_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
@@ -1624,7 +1624,7 @@ func (s *NexusStandaloneTestSuite) TestCountStandaloneNexusOperation() {
 		}
 
 		s.EventuallyWithT(func(t *assert.CollectT) {
-			resp, err := env.FrontendClient().CountNexusOperationExecutions(env.Context(), &workflowservice.CountNexusOperationExecutionsRequest{
+			resp, err := env.FrontendClient().CountNexusOperationExecutions(s.Context(), &workflowservice.CountNexusOperationExecutionsRequest{
 				Namespace: env.Namespace().String(),
 				Query:     "CustomKeywordField = 'count-sa-value'",
 			})
@@ -1636,7 +1636,7 @@ func (s *NexusStandaloneTestSuite) TestCountStandaloneNexusOperation() {
 	s.Run("GroupByUnsupportedField", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
 
-		_, err := env.FrontendClient().CountNexusOperationExecutions(env.Context(), &workflowservice.CountNexusOperationExecutionsRequest{
+		_, err := env.FrontendClient().CountNexusOperationExecutions(s.Context(), &workflowservice.CountNexusOperationExecutionsRequest{
 			Namespace: env.Namespace().String(),
 			Query:     "GROUP BY Endpoint",
 		})
@@ -1647,7 +1647,7 @@ func (s *NexusStandaloneTestSuite) TestCountStandaloneNexusOperation() {
 	s.Run("InvalidQuery", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
 
-		_, err := env.FrontendClient().CountNexusOperationExecutions(env.Context(), &workflowservice.CountNexusOperationExecutionsRequest{
+		_, err := env.FrontendClient().CountNexusOperationExecutions(s.Context(), &workflowservice.CountNexusOperationExecutionsRequest{
 			Namespace: env.Namespace().String(),
 			Query:     "invalid query syntax !!!",
 		})
@@ -1658,7 +1658,7 @@ func (s *NexusStandaloneTestSuite) TestCountStandaloneNexusOperation() {
 	s.Run("InvalidSearchAttribute", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
 
-		_, err := env.FrontendClient().CountNexusOperationExecutions(env.Context(), &workflowservice.CountNexusOperationExecutionsRequest{
+		_, err := env.FrontendClient().CountNexusOperationExecutions(s.Context(), &workflowservice.CountNexusOperationExecutionsRequest{
 			Namespace: env.Namespace().String(),
 			Query:     "NonExistentField = 'value'",
 		})
@@ -1669,7 +1669,7 @@ func (s *NexusStandaloneTestSuite) TestCountStandaloneNexusOperation() {
 	s.Run("NamespaceNotFound", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
 
-		_, err := env.FrontendClient().CountNexusOperationExecutions(env.Context(), &workflowservice.CountNexusOperationExecutionsRequest{
+		_, err := env.FrontendClient().CountNexusOperationExecutions(s.Context(), &workflowservice.CountNexusOperationExecutionsRequest{
 			Namespace: "non-existent-namespace",
 		})
 		s.ErrorAs(err, new(*serviceerror.NamespaceNotFound))
@@ -1680,7 +1680,7 @@ func (s *NexusStandaloneTestSuite) TestCountStandaloneNexusOperation() {
 func (s *NexusStandaloneTestSuite) TestDeleteStandaloneNexusOperation() {
 	s.Run("Scheduled", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -1688,7 +1688,7 @@ func (s *NexusStandaloneTestSuite) TestDeleteStandaloneNexusOperation() {
 		})
 		s.NoError(err)
 
-		_, err = env.FrontendClient().DeleteNexusOperationExecution(env.Context(), &workflowservice.DeleteNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().DeleteNexusOperationExecution(s.Context(), &workflowservice.DeleteNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -1700,7 +1700,7 @@ func (s *NexusStandaloneTestSuite) TestDeleteStandaloneNexusOperation() {
 
 	s.Run("NoRunID", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -1709,7 +1709,7 @@ func (s *NexusStandaloneTestSuite) TestDeleteStandaloneNexusOperation() {
 		})
 		s.NoError(err)
 
-		_, err = env.FrontendClient().DeleteNexusOperationExecution(env.Context(), &workflowservice.DeleteNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().DeleteNexusOperationExecution(s.Context(), &workflowservice.DeleteNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 		})
@@ -1721,7 +1721,7 @@ func (s *NexusStandaloneTestSuite) TestDeleteStandaloneNexusOperation() {
 	s.Run("NotFound", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
 
-		_, err := env.FrontendClient().DeleteNexusOperationExecution(env.Context(), &workflowservice.DeleteNexusOperationExecutionRequest{
+		_, err := env.FrontendClient().DeleteNexusOperationExecution(s.Context(), &workflowservice.DeleteNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "does-not-exist",
 		})
@@ -1730,7 +1730,7 @@ func (s *NexusStandaloneTestSuite) TestDeleteStandaloneNexusOperation() {
 
 	s.Run("AlreadyDeleted", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -1738,7 +1738,7 @@ func (s *NexusStandaloneTestSuite) TestDeleteStandaloneNexusOperation() {
 		})
 		s.NoError(err)
 
-		_, err = env.FrontendClient().DeleteNexusOperationExecution(env.Context(), &workflowservice.DeleteNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().DeleteNexusOperationExecution(s.Context(), &workflowservice.DeleteNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -1747,7 +1747,7 @@ func (s *NexusStandaloneTestSuite) TestDeleteStandaloneNexusOperation() {
 
 		s.eventuallyDeleted(env, s.T(), "test-op", startResp.RunId)
 
-		_, err = env.FrontendClient().DeleteNexusOperationExecution(env.Context(), &workflowservice.DeleteNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().DeleteNexusOperationExecution(s.Context(), &workflowservice.DeleteNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -1760,7 +1760,7 @@ func (s *NexusStandaloneTestSuite) TestDeleteStandaloneNexusOperation() {
 	s.Run("Validation", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
 
-		_, err := env.FrontendClient().DeleteNexusOperationExecution(env.Context(), &workflowservice.DeleteNexusOperationExecutionRequest{
+		_, err := env.FrontendClient().DeleteNexusOperationExecution(s.Context(), &workflowservice.DeleteNexusOperationExecutionRequest{
 			Namespace: env.Namespace().String(),
 		})
 		s.Error(err)
@@ -1772,7 +1772,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 	s.Run("WaitStageStarted", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
 		taskQueue := testcore.RandomizedNexusEndpoint(s.T().Name())
-		endpointName := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
+		endpointName := env.createNexusEndpoint(s.Context(), s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
 		handlerLink := &commonpb.Link_WorkflowEvent{
 			Namespace:  env.Namespace().String(),
 			WorkflowId: "handler-workflow",
@@ -1800,7 +1800,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 
 		go func() {
 			pollStartedCh <- struct{}{}
-			resp, err := env.FrontendClient().PollNexusOperationExecution(env.Context(), &workflowservice.PollNexusOperationExecutionRequest{
+			resp, err := env.FrontendClient().PollNexusOperationExecution(s.Context(), &workflowservice.PollNexusOperationExecutionRequest{
 				Namespace:   env.Namespace().String(),
 				OperationId: "test-op",
 				RunId:       startResp.RunId,
@@ -1811,7 +1811,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 
 		select {
 		case <-pollStartedCh:
-		case <-env.Context().Done():
+		case <-s.Context().Done():
 			s.T().Fatal("PollNexusOperationExecution did not start before timeout")
 		}
 
@@ -1823,7 +1823,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 		default:
 		}
 
-		task, err := env.FrontendClient().PollNexusTaskQueue(env.Context(), &workflowservice.PollNexusTaskQueueRequest{
+		task, err := env.FrontendClient().PollNexusTaskQueue(s.Context(), &workflowservice.PollNexusTaskQueueRequest{
 			Namespace: env.Namespace().String(),
 			Identity:  "test-worker",
 			TaskQueue: &taskqueuepb.TaskQueue{
@@ -1843,7 +1843,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 		s.Equal(expectedLink.URL.String(), startRequest.GetLinks()[0].GetUrl())
 		s.Equal(expectedLink.Type, startRequest.GetLinks()[0].GetType())
 
-		_, err = env.FrontendClient().RespondNexusTaskCompleted(env.Context(), &workflowservice.RespondNexusTaskCompletedRequest{
+		_, err = env.FrontendClient().RespondNexusTaskCompleted(s.Context(), &workflowservice.RespondNexusTaskCompletedRequest{
 			Namespace: env.Namespace().String(),
 			Identity:  "test-worker",
 			TaskToken: task.GetTaskToken(),
@@ -1873,11 +1873,11 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 				WaitStage:      enumspb.NEXUS_OPERATION_WAIT_STAGE_STARTED,
 				OperationToken: "test-operation-token",
 			}, result.resp)
-		case <-env.Context().Done():
+		case <-s.Context().Done():
 			s.T().Fatal("PollNexusOperationExecution did not resolve before timeout")
 		}
 
-		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(env.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -1902,7 +1902,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 		} {
 			s.Run(tc.name, func(s *NexusStandaloneTestSuite) {
 				env := s.newTestEnv()
-				endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+				endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 				startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 					OperationId: "test-op",
@@ -1925,7 +1925,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 					}
 
 					pollStartedCh <- struct{}{}
-					resp, err := env.FrontendClient().PollNexusOperationExecution(env.Context(), &workflowservice.PollNexusOperationExecutionRequest{
+					resp, err := env.FrontendClient().PollNexusOperationExecution(s.Context(), &workflowservice.PollNexusOperationExecutionRequest{
 						Namespace:   env.Namespace().String(),
 						OperationId: "test-op",
 						RunId:       runID,
@@ -1936,7 +1936,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 
 				select {
 				case <-pollStartedCh:
-				case <-env.Context().Done():
+				case <-s.Context().Done():
 					s.T().Fatal("PollNexusOperationExecution did not start before timeout")
 				}
 
@@ -1951,7 +1951,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 				// Terminate the operation.
 				terminateErrCh := make(chan error, 1)
 				go func() {
-					_, err := env.FrontendClient().TerminateNexusOperationExecution(env.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
+					_, err := env.FrontendClient().TerminateNexusOperationExecution(s.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
 						Namespace:   env.Namespace().String(),
 						OperationId: "test-op",
 						RunId:       startResp.RunId,
@@ -1963,7 +1963,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 				select {
 				case err := <-terminateErrCh:
 					s.NoError(err)
-				case <-env.Context().Done():
+				case <-s.Context().Done():
 					s.T().Fatal("TerminateNexusOperationExecution timed out")
 				}
 
@@ -1971,7 +1971,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 				var result pollResult
 				select {
 				case result = <-pollResultCh:
-				case <-env.Context().Done():
+				case <-s.Context().Done():
 					s.T().Fatal("PollNexusOperationExecution did not resolve before timeout")
 				}
 				s.NoError(result.err)
@@ -1992,7 +1992,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 
 	s.Run("UnspecifiedWaitStageDefaultsToClosed", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -2001,7 +2001,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 		s.NoError(err)
 
 		// Terminate the operation.
-		_, err = env.FrontendClient().TerminateNexusOperationExecution(env.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().TerminateNexusOperationExecution(s.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -2010,7 +2010,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 		s.NoError(err)
 
 		// Poll with UNSPECIFIED WaitStage — should behave the same as CLOSED.
-		pollResp, err := env.FrontendClient().PollNexusOperationExecution(env.Context(), &workflowservice.PollNexusOperationExecutionRequest{
+		pollResp, err := env.FrontendClient().PollNexusOperationExecution(s.Context(), &workflowservice.PollNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -2031,7 +2031,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 	s.Run("ReturnsLastAttemptFailure", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
 		taskQueue := testcore.RandomizedNexusEndpoint(s.T().Name())
-		endpointName := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
+		endpointName := env.createNexusEndpoint(s.Context(), s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), taskQueue).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId:            "test-op",
@@ -2042,7 +2042,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 
 		pollerErrCh := make(chan error, 1)
 		go func() {
-			task, err := env.FrontendClient().PollNexusTaskQueue(env.Context(), &workflowservice.PollNexusTaskQueueRequest{
+			task, err := env.FrontendClient().PollNexusTaskQueue(s.Context(), &workflowservice.PollNexusTaskQueueRequest{
 				Namespace: env.Namespace().String(),
 				Identity:  "test-worker",
 				TaskQueue: &taskqueuepb.TaskQueue{
@@ -2054,7 +2054,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 				pollerErrCh <- err
 				return
 			}
-			_, err = env.FrontendClient().RespondNexusTaskFailed(env.Context(), &workflowservice.RespondNexusTaskFailedRequest{
+			_, err = env.FrontendClient().RespondNexusTaskFailed(s.Context(), &workflowservice.RespondNexusTaskFailedRequest{
 				Namespace: env.Namespace().String(),
 				Identity:  "test-worker",
 				TaskToken: task.GetTaskToken(),
@@ -2069,7 +2069,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 		}()
 
 		s.EventuallyWithT(func(t *assert.CollectT) {
-			pollResp, err := env.FrontendClient().PollNexusOperationExecution(env.Context(), &workflowservice.PollNexusOperationExecutionRequest{
+			pollResp, err := env.FrontendClient().PollNexusOperationExecution(s.Context(), &workflowservice.PollNexusOperationExecutionRequest{
 				Namespace:   env.Namespace().String(),
 				OperationId: "test-op",
 				RunId:       startResp.RunId,
@@ -2092,7 +2092,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 
 	s.Run("NamespaceNotFound", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -2100,7 +2100,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 		})
 		s.NoError(err)
 
-		_, err = env.FrontendClient().PollNexusOperationExecution(env.Context(), &workflowservice.PollNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().PollNexusOperationExecution(s.Context(), &workflowservice.PollNexusOperationExecutionRequest{
 			Namespace:   "non-existent-namespace",
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
@@ -2113,7 +2113,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 
 	s.Run("NotFound", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
-		endpointName := env.createRandomNexusEndpoint(env.Context(), s.T()).GetSpec().GetName()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId: "test-op",
@@ -2121,7 +2121,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 		})
 		s.NoError(err)
 
-		_, err = env.FrontendClient().PollNexusOperationExecution(env.Context(), &workflowservice.PollNexusOperationExecutionRequest{
+		_, err = env.FrontendClient().PollNexusOperationExecution(s.Context(), &workflowservice.PollNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "non-existent-op",
 			RunId:       startResp.RunId,
@@ -2137,7 +2137,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 	s.Run("Validation", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
 
-		_, err := env.FrontendClient().PollNexusOperationExecution(env.Context(), &workflowservice.PollNexusOperationExecutionRequest{
+		_, err := env.FrontendClient().PollNexusOperationExecution(s.Context(), &workflowservice.PollNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "", // required field
 			WaitStage:   enumspb.NEXUS_OPERATION_WAIT_STAGE_CLOSED,
@@ -2183,7 +2183,7 @@ func (s *NexusStandaloneTestSuite) TestAsyncCompletionIgnoresTransitionFieldsInC
 			return &nexus.HandlerStartOperationResultAsync{OperationToken: "test-operation-token"}, nil
 		},
 	}
-	endpointName := env.createRandomExternalNexusServer(env.Context(), s.T(), handler)
+	endpointName := env.createRandomExternalNexusServer(s.Context(), s.T(), handler)
 
 	startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 		OperationId: "test-op",
@@ -2196,8 +2196,8 @@ func (s *NexusStandaloneTestSuite) TestAsyncCompletionIgnoresTransitionFieldsInC
 	case callback := <-callbackCh:
 		callbackToken = callback.token
 		callbackURL = callback.url
-	case <-env.Context().Done():
-		s.FailNow("timed out waiting for Nexus callback details", env.Context().Err().Error())
+	case <-s.Context().Done():
+		s.FailNow("timed out waiting for Nexus callback details", s.Context().Err().Error())
 	}
 
 	gen := &commonnexus.CallbackTokenGenerator{}
@@ -2229,14 +2229,14 @@ func (s *NexusStandaloneTestSuite) TestAsyncCompletionIgnoresTransitionFieldsInC
 	c := nexusrpc.NewCompletionHTTPClient(nexusrpc.CompletionHTTPClientOptions{
 		Serializer: commonnexus.PayloadSerializer,
 	})
-	err = c.CompleteOperation(env.Context(), callbackURL, nexusrpc.CompleteOperationOptions{
+	err = c.CompleteOperation(s.Context(), callbackURL, nexusrpc.CompleteOperationOptions{
 		Result: payload.EncodeString("result"),
 		Header: nexus.Header{commonnexus.CallbackTokenHeader: callbackToken},
 	})
 	s.NoError(err)
 
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(env.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
 			Namespace:      env.Namespace().String(),
 			OperationId:    "test-op",
 			RunId:          startResp.RunId,
@@ -2267,13 +2267,13 @@ func (s *NexusStandaloneTestSuite) startNexusOperation(
 		req.ScheduleToCloseTimeout = durationpb.New(10 * time.Minute)
 	}
 
-	return env.FrontendClient().StartNexusOperationExecution(env.Context(), req)
+	return env.FrontendClient().StartNexusOperationExecution(s.Context(), req)
 }
 
 func (s *NexusStandaloneTestSuite) eventuallyDeleted(env *NexusTestEnv, t *testing.T, operationID, runID string) {
 	t.Helper()
 	require.Eventually(t, func() bool {
-		_, err := env.FrontendClient().DescribeNexusOperationExecution(env.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+		_, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: operationID,
 			RunId:       runID,


### PR DESCRIPTION
## What changed?

Use suite context instead of env context in Nexus standalone tests.

## Why?

I noticed some test flakes timed out after 0s, they were using the shared context from the env.

Example: https://github.com/temporalio/temporal/actions/runs/26300990266
