### PR TITLE
Replace schedule migration Fx option with dynamic config

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -800,6 +800,11 @@ This config is EXPERIMENTAL and may be changed or removed in a later release.`,
 		true,
 		`MaskInternalOrUnknownErrors is whether to replace internal/unknown errors with default error`,
 	)
+	FrontendContextMetadataSetTrailer = NewGlobalBoolSetting(
+		"frontend.contextMetadataSetTrailer",
+		false,
+		`FrontendContextMetadataSetTrailer controls whether frontend gRPC handlers emit context metadata in response trailers. This is read when constructing the frontend ContextMetadataInterceptor.`,
+	)
 	HistoryHostErrorPercentage = NewGlobalFloatSetting(
 		"frontend.historyHostErrorPercentage",
 		0.5,

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -496,8 +496,12 @@ func RateLimitInterceptorProvider(
 	)
 }
 
-func ContextMetadataInterceptorProvider(logger log.Logger) *interceptor.ContextMetadataInterceptor {
-	return interceptor.NewContextMetadataInterceptor(false, logger)
+func ContextMetadataInterceptorProvider(
+	logger log.Logger,
+	dc *dynamicconfig.Collection,
+) *interceptor.ContextMetadataInterceptor {
+	setTrailer := dynamicconfig.FrontendContextMetadataSetTrailer.Get(dc)()
+	return interceptor.NewContextMetadataInterceptor(setTrailer, logger)
 }
 
 func MaskInternalErrorDetailsInterceptorProvider(

--- a/tests/schedule_migration_test.go
+++ b/tests/schedule_migration_test.go
@@ -23,15 +23,12 @@ import (
 	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
-	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/primitives"
-	"go.temporal.io/server/common/rpc/interceptor"
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/service/worker/dummy"
 	"go.temporal.io/server/service/worker/scheduler"
 	"go.temporal.io/server/tests/testcore"
-	"go.uber.org/fx"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -1328,10 +1325,10 @@ func TestScheduleMigrationV1ToV2NoDuplicateRecentActions(t *testing.T) {
 // combination of CHASM and V1 state. This metadata is read by saas-temporal's
 // metering interceptor for action attribution.
 //
-// We assert by reading gRPC response trailers: the frontend's
-// ContextMetadataInterceptor is decorated to setTrailer=true for this test,
-// so any context metadata set during the handler is emitted as trailers that
-// the client can read directly.
+// We assert by reading gRPC response trailers: this test enables the frontend
+// ContextMetadataInterceptor trailer path through startup dynamic config, so
+// any context metadata set during the handler is emitted as trailers that the
+// client can read directly.
 func (s *ScheduleMigrationTestSuite) TestDeleteScheduleContextMetadata() {
 	env := testcore.NewEnv(
 		s.T(),
@@ -1339,11 +1336,7 @@ func (s *ScheduleMigrationTestSuite) TestDeleteScheduleContextMetadata() {
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerRouting, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerSentinels, true),
-		testcore.WithFxOptions(primitives.FrontendService,
-			fx.Decorate(func(logger log.Logger) *interceptor.ContextMetadataInterceptor {
-				return interceptor.NewContextMetadataInterceptor(true, logger)
-			}),
-		),
+		testcore.WithDynamicConfig(dynamicconfig.FrontendContextMetadataSetTrailer, true),
 	)
 
 	newSched := func() (sid, wt, tq string, sched *schedulepb.Schedule) {
@@ -1547,11 +1540,7 @@ func (s *ScheduleMigrationTestSuite) TestPatchScheduleContextMetadata() {
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerRouting, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerSentinels, true),
-		testcore.WithFxOptions(primitives.FrontendService,
-			fx.Decorate(func(logger log.Logger) *interceptor.ContextMetadataInterceptor {
-				return interceptor.NewContextMetadataInterceptor(true, logger)
-			}),
-		),
+		testcore.WithDynamicConfig(dynamicconfig.FrontendContextMetadataSetTrailer, true),
 	)
 
 	newSched := func() (sid, wt, tq string, sched *schedulepb.Schedule) {


### PR DESCRIPTION
## What changed?

Replaces the `tests/schedule_migration_test.go` frontend `WithFxOptions` decoration with a new dynamic config `FrontendContextMetadataSetTrailer` option.


## Why

We want to eliminate `WithFxOptionsForService` as it is blocking us from migrating away from the `onebox.go` approach (which duplicates the fx setup) since we don't want to expose an equivalent method in `temporal/fx.go`.