### PR TITLE
Align the Nexus URL with the UI URL

### DIFF
--- a/chasm/lib/nexusoperation/operation_tasks_test.go
+++ b/chasm/lib/nexusoperation/operation_tasks_test.go
@@ -267,7 +267,7 @@ func TestInvocationTaskHandler_HTTP(t *testing.T) {
 				if protoLinks[1].GetType() != "temporal.api.common.v1.Link.NexusOperation" {
 					return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "unexpected nexus operation link type: %v", protoLinks[1].GetType())
 				}
-				if protoLinks[1].GetUrl() != "temporal:///namespaces/ns-name/nexus-operations/wf-id?runID=run-id" {
+				if protoLinks[1].GetUrl() != "temporal:///namespaces/ns-name/nexus-operations/wf-id/run-id/details" {
 					return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "unexpected nexus operation link URL: %v", protoLinks[1].GetUrl())
 				}
 				nexus.AddHandlerLinks(ctx, handlerNexusLink)

--- a/common/nexus/link_converter.go
+++ b/common/nexus/link_converter.go
@@ -44,7 +44,7 @@ const (
 	urlPathWorkflowIDKey          = "workflowID"
 	urlPathRunIDKey               = "runID"
 	urlPathWorkflowEventTemplate  = "/namespaces/%s/workflows/%s/%s/history"
-	urlPathNexusOperationTemplate = "/namespaces/%s/nexus-operations/%s"
+	urlPathNexusOperationTemplate = "/namespaces/%s/nexus-operations/%s/%s/details"
 
 	linkWorkflowEventReferenceTypeKey = "referenceType"
 	linkEventIDKey                    = "eventID"
@@ -68,18 +68,15 @@ var (
 
 // ConvertLinkNexusOperationToNexusLink converts a Link_NexusOperation type to Nexus Link.
 func ConvertLinkNexusOperationToNexusLink(no *commonpb.Link_NexusOperation) nexus.Link {
-	query := url.Values{}
-	query.Set(urlPathRunIDKey, no.GetRunId())
-
 	u := &url.URL{
 		Scheme: urlSchemeTemporalKey,
-		Path:   fmt.Sprintf(urlPathNexusOperationTemplate, no.GetNamespace(), no.GetOperationId()),
+		Path:   fmt.Sprintf(urlPathNexusOperationTemplate, no.GetNamespace(), no.GetOperationId(), no.GetRunId()),
 		RawPath: fmt.Sprintf(
 			urlPathNexusOperationTemplate,
 			url.PathEscape(no.GetNamespace()),
 			url.PathEscape(no.GetOperationId()),
+			url.PathEscape(no.GetRunId()),
 		),
-		RawQuery: query.Encode(),
 	}
 
 	return nexus.Link{

--- a/common/nexus/link_converter_test.go
+++ b/common/nexus/link_converter_test.go
@@ -46,7 +46,7 @@ func TestConvertLinkNexusOperationToNexusLink(t *testing.T) {
 	output := commonnexus.ConvertLinkNexusOperationToNexusLink(input)
 	require.Equal(t, nexus.Link{
 		URL: &url.URL{
-			Scheme:   "temporal",
+			Scheme:  "temporal",
 			Path:    "/namespaces/ns/nexus-operations/op-id/run-id/details",
 			RawPath: "/namespaces/ns/nexus-operations/op-id/run-id/details",
 		},

--- a/common/nexus/link_converter_test.go
+++ b/common/nexus/link_converter_test.go
@@ -47,13 +47,12 @@ func TestConvertLinkNexusOperationToNexusLink(t *testing.T) {
 	require.Equal(t, nexus.Link{
 		URL: &url.URL{
 			Scheme:   "temporal",
-			Path:     "/namespaces/ns/nexus-operations/op-id",
-			RawPath:  "/namespaces/ns/nexus-operations/op-id",
-			RawQuery: "runID=run-id",
+			Path:    "/namespaces/ns/nexus-operations/op-id/run-id/details",
+			RawPath: "/namespaces/ns/nexus-operations/op-id/run-id/details",
 		},
 		Type: "temporal.api.common.v1.Link.NexusOperation",
 	}, output)
-	require.Equal(t, "temporal:///namespaces/ns/nexus-operations/op-id?runID=run-id", output.URL.String())
+	require.Equal(t, "temporal:///namespaces/ns/nexus-operations/op-id/run-id/details", output.URL.String())
 }
 
 func TestConvertLinkWorkflowEventToNexusLink(t *testing.T) {


### PR DESCRIPTION
## What changed?

Align the Nexus URL with the UI URL

## Why?

Talking with @bergundy we want the Nexus link to match the UI link for consistency.

## How did you test it?
- [x] built
- [] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, intentional URL format change for Nexus operation links with test coverage only; no auth or execution logic changes.
> 
> **Overview**
> **Nexus operation** `temporal://` links now use the same path shape as the UI: run ID is a path segment under `/details` instead of a `runID` query parameter.
> 
> `ConvertLinkNexusOperationToNexusLink` in `common/nexus/link_converter.go` builds URLs like `temporal:///namespaces/{ns}/nexus-operations/{operationId}/{runId}/details` (with path escaping on `RawPath`). Unit tests and the async-start assertion in `operation_tasks_test.go` were updated to match.
> 
> **Note:** `link_converter.go` documents a duplicate in `sdk-go`; that mirror may need the same change outside this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 025b37b536dd788835ef49ab1080c276a72a1f46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->