### PR TITLE
Forward CallerName header in host RPS rate limit interceptor

### DIFF
--- a/common/rpc/interceptor/rate_limit.go
+++ b/common/rpc/interceptor/rate_limit.go
@@ -81,7 +81,7 @@ func (i *RateLimitInterceptor) Allow(
 	if !i.rateLimiter.Allow(time.Now().UTC(), quotas.NewRequest(
 		methodName,
 		token,
-		"", // this interceptor layer does not throttle based on caller name
+		headerGetter.Get(headers.CallerNameHeaderName),
 		headerGetter.Get(headers.CallerTypeHeaderName),
 		0,  // this interceptor layer does not throttle based on caller segment
 		"", // this interceptor layer does not throttle based on call initiation


### PR DESCRIPTION
## What changed?
`RateLimitInterceptor.Allow` now forwards `headers.CallerNameHeaderName` into `quotas.NewRequest` instead of hard-coding `""`.

## Why?
Rate limiter can make throttling decisions based on namespace name if it has this info.

## How did you test it?
- [x] built
- [x] covered by existing tests (`./common/rpc/interceptor`)