### PR TITLE
fix: schedule inactive after migration with no running workflows

### DIFF
--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"bytes"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -282,9 +283,13 @@ func CreateSchedulerFromMigration(
 	visibility.MergeCustomSearchAttributes(ctx, state.GetSearchAttributes())
 	visibility.MergeCustomMemo(ctx, state.GetMemo())
 
-	// Schedule a callbacks task to attach Nexus callbacks to any migrated
-	// running workflows. The task self-invalidates if there's no work to do.
-	ctx.AddTask(sched, chasm.TaskAttributes{}, &schedulerpb.SchedulerCallbacksTask{})
+	// Defer generation until SchedulerCallbacksTask resolves stale running-workflow
+	// state; if there are none, generate directly.
+	if slices.ContainsFunc(state.GetInvokerState().GetBufferedStarts(), needsCallback) {
+		ctx.AddTask(sched, chasm.TaskAttributes{}, &schedulerpb.SchedulerCallbacksTask{})
+	} else {
+		sched.Generator.Get(ctx).Generate(ctx)
+	}
 
 	return sched, nil
 }

--- a/chasm/lib/scheduler/scheduler_test.go
+++ b/chasm/lib/scheduler/scheduler_test.go
@@ -17,6 +17,9 @@ import (
 	"go.temporal.io/server/chasm/lib/scheduler"
 	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common/testing/protorequire"
+	"go.temporal.io/server/common/testing/testlogger"
+	"go.temporal.io/server/service/history/tasks"
+	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -274,6 +277,50 @@ func TestCreateSchedulerFromMigration_EmptyState(t *testing.T) {
 	require.NoError(t, node.SetRootComponent(sched))
 	_, err = node.CloseTransaction()
 	require.NoError(t, err)
+}
+
+func TestCreateSchedulerFromMigration_NoRunning(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	infra := setupTestInfra(t, newRealSpecProcessor(ctrl, testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)))
+	ctx := chasm.NewMutableContext(context.Background(), infra.node)
+
+	req := &schedulerpb.CreateFromMigrationStateRequest{
+		NamespaceId: namespaceID,
+		State: &schedulerpb.SchedulerMigrationState{
+			SchedulerState: &schedulerpb.SchedulerState{
+				Schedule:      defaultSchedule(),
+				Info:          &schedulepb.ScheduleInfo{},
+				Namespace:     namespace,
+				NamespaceId:   namespaceID,
+				ScheduleId:    scheduleID,
+				ConflictToken: 1,
+			},
+			GeneratorState: &schedulerpb.GeneratorState{
+				LastProcessedTime: timestamppb.New(time.Now().Add(-time.Hour)),
+			},
+			InvokerState: &schedulerpb.InvokerState{},
+		},
+	}
+
+	sched, err := scheduler.CreateSchedulerFromMigration(ctx, req)
+	require.NoError(t, err)
+	require.NoError(t, infra.node.SetRootComponent(sched))
+	_, err = infra.node.CloseTransaction()
+	require.NoError(t, err)
+
+	hasGeneratorTask := false
+outer:
+	for _, taskList := range infra.nodeBackend.TasksByCategory {
+		for _, task := range taskList {
+			chasmTask, ok := task.(*tasks.ChasmTask)
+			if ok && chasmTask.GetVisibilityTime().Equal(chasm.TaskScheduledTimeImmediate) {
+				hasGeneratorTask = true
+				break outer
+			}
+		}
+	}
+	require.True(t, hasGeneratorTask,
+		"expected an immediate GeneratorTask after migration with no running workflows")
 }
 
 func TestContextMetadata(t *testing.T) {

--- a/tests/schedule_migration_test.go
+++ b/tests/schedule_migration_test.go
@@ -20,11 +20,13 @@ import (
 	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	schedulespb "go.temporal.io/server/api/schedule/v1"
+	chasmscheduler "go.temporal.io/server/chasm/lib/scheduler"
 	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/sdk"
+	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/service/worker/dummy"
 	"go.temporal.io/server/service/worker/scheduler"
@@ -1836,4 +1838,83 @@ func TestScheduleMigration_StaleRunningDoesNotSkipPending(t *testing.T) {
 	// under SKIP overlap policy.
 	require.Equal(t, int64(0), lastDesc.GetFrontendResponse().GetInfo().GetOverlapSkipped(),
 		"stale running entry must not cause the pending start to be dropped under SKIP overlap policy")
+}
+
+func TestScheduleMigration_NoRunningWorkflows_GeneratorStarts(t *testing.T) {
+	// Use a very short idle time so the schedule closes quickly once the generator
+	// determines there's nothing to do (empty spec → no next wakeup time → idle).
+	shortIdleTime := 500 * time.Millisecond
+	tweakables := chasmscheduler.DefaultTweakables
+	tweakables.IdleTime = shortIdleTime
+
+	env := testcore.NewEnv(
+		t,
+		testcore.WithWorkerService("scheduler operations"),
+		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
+	)
+	env.OverrideDynamicConfig(chasmscheduler.CurrentTweakables, tweakables)
+
+	ctx := testcore.NewContext()
+	sid := testcore.RandomizeStr("sched-migrate-no-running")
+	wid := testcore.RandomizeStr("sched-migrate-no-running-wf")
+	wt := testcore.RandomizeStr("sched-migrate-no-running-wt")
+	tq := testcore.RandomizeStr("tq")
+
+	nsName := env.Namespace().String()
+	nsID := env.NamespaceID().String()
+
+	_, err := env.GetTestCluster().SchedulerClient().CreateFromMigrationState(
+		ctx,
+		&schedulerpb.CreateFromMigrationStateRequest{
+			NamespaceId: nsID,
+			State: &schedulerpb.SchedulerMigrationState{
+				SchedulerState: &schedulerpb.SchedulerState{
+					Namespace:   nsName,
+					NamespaceId: nsID,
+					ScheduleId:  sid,
+					// Empty spec: the generator runs, finds no future actions,
+					// and schedules an idle task.
+					Schedule: &schedulepb.Schedule{
+						Spec: &schedulepb.ScheduleSpec{},
+						Action: &schedulepb.ScheduleAction{
+							Action: &schedulepb.ScheduleAction_StartWorkflow{
+								StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+									WorkflowId:   wid,
+									WorkflowType: &commonpb.WorkflowType{Name: wt},
+									TaskQueue:    &taskqueuepb.TaskQueue{Name: tq, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+								},
+							},
+						},
+					},
+					Info:          &schedulepb.ScheduleInfo{},
+					ConflictToken: scheduler.InitialConflictToken,
+				},
+				GeneratorState: &schedulerpb.GeneratorState{
+					LastProcessedTime: timestamppb.Now(),
+				},
+				// No BufferedStarts: the common migration scenario — schedule was idle.
+				InvokerState: &schedulerpb.InvokerState{},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	descReq := &schedulerpb.DescribeScheduleRequest{
+		NamespaceId:     nsID,
+		FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: nsName, ScheduleId: sid},
+	}
+
+	// Confirm the schedule is live on the CHASM stack before polling for closure.
+	await.Require(testcore.NewContext(), t, func(t *await.T) {
+		_, err := env.GetTestCluster().SchedulerClient().DescribeSchedule(t.Context(), descReq)
+		require.NoError(t, err)
+	}, 6*time.Second, 100*time.Millisecond)
+
+	// If generator.Generate() was never called, the idle task is never scheduled
+	// and the schedule stays open indefinitely. Closing proves the generator ran.
+	var closedErr *serviceerror.FailedPrecondition
+	await.Require(testcore.NewContext(), t, func(t *await.T) {
+		_, err := env.GetTestCluster().SchedulerClient().DescribeSchedule(t.Context(), descReq)
+		require.ErrorAs(t, err, &closedErr)
+	}, 6*time.Second, 100*time.Millisecond)
 }


### PR DESCRIPTION
Schedules migrated from V1 to CHASM with no currently-running workflows (the common case) were left permanently inactive. `CreateSchedulerFromMigration` relied on `SchedulerCallbacksTask` to call `generator.Generate()`, but that task self-validates to false when there are no running workflows needing callbacks.

Fix: generate directly when no buffered starts need callbacks; defer to `SchedulerCallbacksTask` only when running workflows need their stale state resolved first.