### PR TITLE
Replace AddTasks Fx wrapper with history task hook

### DIFF
--- a/common/testing/testhooks/hooks.go
+++ b/common/testing/testhooks/hooks.go
@@ -7,6 +7,7 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common/namespace"
+	historytasks "go.temporal.io/server/service/history/tasks"
 )
 
 // Test hook keys with their return type and scope.
@@ -23,6 +24,7 @@ var (
 	MatchingForwardTaskDelay                 = newKey[time.Duration, namespace.ID]()
 	HistoryReplicationTaskInterceptor        = newKey[func(*replicationspb.ReplicationTask, func() error) error, global]()
 	HistoryReplicationDLQWriteInterceptor    = newKey[func(*persistencespb.ReplicationTaskInfo, func() error) error, global]()
+	HistoryTransferTaskInterceptor           = newKey[func(historytasks.Task, func()), namespace.ID]()
 	NamespaceReplicationTaskInterceptor      = newKey[func(context.Context, *replicationspb.NamespaceTaskAttributes, func() error) error, namespace.Name]()
 )
 

--- a/service/history/queue_factory_base_test.go
+++ b/service/history/queue_factory_base_test.go
@@ -21,6 +21,7 @@ import (
 	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/telemetry"
+	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/common/worker_versioning"
 	"go.temporal.io/server/service/history/archival"
 	"go.temporal.io/server/service/history/configs"
@@ -68,6 +69,7 @@ func (c *moduleTestCase) Run(t *testing.T) {
 
 	app := fx.New(
 		dependencies,
+		testhooks.Module,
 		QueueModule,
 		fx.Invoke(func(params QueueFactoriesLifetimeHookParams) {
 			factories = params.Factories

--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -35,6 +35,7 @@ import (
 	"go.temporal.io/server/common/rpc"
 	"go.temporal.io/server/common/sdk"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
+	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/common/worker_versioning"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/consts"
@@ -55,6 +56,7 @@ type (
 		workflowResetter        ndc.WorkflowResetter
 		parentClosePolicyClient parentclosepolicy.Client
 		versionCache            worker_versioning.VersionMembershipAndReactivationStatusCache
+		testHooks               testhooks.TestHooks
 	}
 )
 
@@ -70,6 +72,7 @@ func newTransferQueueActiveTaskExecutor(
 	visibilityManager manager.VisibilityManager,
 	chasmEngine chasm.Engine,
 	versionCache worker_versioning.VersionMembershipAndReactivationStatusCache,
+	testHooks testhooks.TestHooks,
 ) queues.Executor {
 	return &transferQueueActiveTaskExecutor{
 		transferQueueTaskExecutorBase: newTransferQueueTaskExecutorBase(
@@ -94,6 +97,7 @@ func newTransferQueueActiveTaskExecutor(
 			config.NumParentClosePolicySystemWorkflows(),
 		),
 		versionCache: versionCache,
+		testHooks:    testHooks,
 	}
 }
 
@@ -102,6 +106,28 @@ func (t *transferQueueActiveTaskExecutor) Execute(
 	executable queues.Executable,
 ) queues.ExecuteResponse {
 	task := executable.GetTask()
+
+	// Tests use this hook to intercept tasks.
+	if hook, ok := testhooks.Get(
+		t.testHooks,
+		testhooks.HistoryTransferTaskInterceptor,
+		namespace.ID(task.GetNamespaceID()),
+	); ok {
+		var response queues.ExecuteResponse
+		hook(task, func() {
+			response = t.execute(ctx, executable, task)
+		})
+		return response
+	}
+
+	return t.execute(ctx, executable, task)
+}
+
+func (t *transferQueueActiveTaskExecutor) execute(
+	ctx context.Context,
+	executable queues.Executable,
+	task tasks.Task,
+) queues.ExecuteResponse {
 	taskType := queues.GetActiveTransferTaskTypeTagValue(task, t.shardContext.ChasmRegistry())
 	namespaceTag, replicationState := getNamespaceTagAndReplicationStateByID(
 		t.shardContext.GetNamespaceRegistry(),

--- a/service/history/transfer_queue_active_task_executor_test.go
+++ b/service/history/transfer_queue_active_task_executor_test.go
@@ -46,6 +46,7 @@ import (
 	"go.temporal.io/server/common/tasktoken"
 	"go.temporal.io/server/common/telemetry"
 	"go.temporal.io/server/common/testing/protomock"
+	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/common/worker_versioning"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/consts"
@@ -229,6 +230,7 @@ func (s *transferQueueActiveTaskExecutorSuite) SetupTest() {
 		s.mockVisibilityManager,
 		s.mockChasmEngine,
 		nil,
+		testhooks.TestHooks{},
 	).(*transferQueueActiveTaskExecutor)
 	s.transferQueueActiveTaskExecutor.parentClosePolicyClient = s.mockParentClosePolicyClient
 }
@@ -363,6 +365,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestExecuteChasmSideEffectTransfe
 		s.mockVisibilityManager,
 		s.mockChasmEngine,
 		nil,
+		testhooks.TestHooks{},
 	).(*transferQueueActiveTaskExecutor)
 
 	// Execution should succeed.

--- a/service/history/transfer_queue_factory.go
+++ b/service/history/transfer_queue_factory.go
@@ -10,6 +10,7 @@ import (
 	"go.temporal.io/server/common/sdk"
 	ctasks "go.temporal.io/server/common/tasks"
 	"go.temporal.io/server/common/telemetry"
+	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/common/worker_versioning"
 	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/queues"
@@ -33,6 +34,7 @@ type (
 		MatchingRawClient      resource.MatchingRawClient
 		VisibilityManager      manager.VisibilityManager
 		VersionMembershipCache worker_versioning.VersionMembershipAndReactivationStatusCache
+		TestHooks              testhooks.TestHooks
 	}
 
 	transferQueueFactory struct {
@@ -126,6 +128,7 @@ func (f *transferQueueFactory) CreateQueue(
 		f.VisibilityManager,
 		f.ChasmEngine,
 		f.VersionMembershipCache,
+		f.TestHooks,
 	)
 
 	standbyExecutor := newTransferQueueStandbyTaskExecutor(

--- a/tests/add_tasks_test.go
+++ b/tests/add_tasks_test.go
@@ -8,20 +8,17 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/suite"
 	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
 	"go.temporal.io/server/api/adminservice/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/historyservice/v1"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/persistence/serialization"
-	"go.temporal.io/server/common/primitives"
-	"go.temporal.io/server/service/history/queues"
+	"go.temporal.io/server/common/testing/parallelsuite"
+	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/tests/testcore"
-	"go.uber.org/fx"
 )
 
 // This file tests the HistoryService's AddTasks API. It does this by starting a workflow, skipping its workflow task,
@@ -29,75 +26,13 @@ import (
 // retried.
 
 type (
-	// AddTasksSuite is a separate suite because we need to override the history service's executable wrapper.
 	AddTasksSuite struct {
-		testcore.FunctionalTestBase
-
-		worker       worker.Worker
-		skippedTasks chan tasks.Task
-
-		shouldSkip atomic.Bool
-		workflowID atomic.Pointer[string]
-	}
-	// executorWrapper is used to wrap any [queues.Executable] that the history service makes so that we can intercept
-	// workflow tasks.
-	executorWrapper struct {
-		s *AddTasksSuite
-	}
-	// noopExecutor skips any workflow task which meets the criteria specified in shouldExecute and records them to
-	// the tasks channel.
-	noopExecutor struct {
-		base  queues.Executor
-		suite *AddTasksSuite
+		parallelsuite.Suite[*AddTasksSuite]
 	}
 )
 
 func TestAddTasksSuite(t *testing.T) {
-	t.Parallel()
-	suite.Run(t, new(AddTasksSuite))
-}
-
-// Wrap a [queues.Executable] with the noopExecutor.
-func (w *executorWrapper) Wrap(e queues.Executor) queues.Executor {
-	return &noopExecutor{
-		base:  e,
-		suite: w.s,
-	}
-}
-
-// Execute will skip any workflow task initiated by this test suite, so that we can add it back to the queue to see if
-// that workflow task is retried.
-func (e *noopExecutor) Execute(ctx context.Context, executable queues.Executable) queues.ExecuteResponse {
-	task := executable.GetTask()
-	if e.shouldExecute(task) {
-		return e.base.Execute(ctx, executable)
-	}
-	// If we don't execute the task, just record it.
-	e.suite.skippedTasks <- task
-	return queues.ExecuteResponse{}
-}
-
-// shouldExecute returns true if the task is not a workflow task, or if the workflow task is not from this test suite
-// (e.g. from the history scanner), or if we've turned off skipping (which we do when we re-add the task).
-func (e *noopExecutor) shouldExecute(task tasks.Task) bool {
-	suiteWorkflowID := e.suite.workflowID.Load()
-	return (suiteWorkflowID != nil && task.GetWorkflowID() != *suiteWorkflowID) ||
-		task.GetType() != enumsspb.TASK_TYPE_TRANSFER_WORKFLOW_TASK ||
-		!e.suite.shouldSkip.Load()
-}
-
-// SetupSuite creates the test cluster and registers the executorWrapper with the history service.
-func (s *AddTasksSuite) SetupSuite() {
-	// Set up the test cluster and register our executable wrapper.
-	s.FunctionalTestBase.SetupSuiteWithCluster(testcore.WithFxOptionsForService(
-		primitives.HistoryService,
-		fx.Provide(
-			func() queues.ExecutorWrapper {
-				return &executorWrapper{s: s}
-			},
-		),
-	),
-	)
+	parallelsuite.Run(t, &AddTasksSuite{})
 }
 
 func (s *AddTasksSuite) TestAddTasks_Ok() {
@@ -114,9 +49,25 @@ func (s *AddTasksSuite) TestAddTasks_Ok() {
 			shouldCallAddTasks: false,
 		},
 	} {
-		s.Run(tc.name, func() {
+		s.Run(tc.name, func(s *AddTasksSuite) {
+			env := testcore.NewEnv(s.T())
+
+			// Inject a history task interceptor that skips transfer workflow tasks.
+			var shouldSkip atomic.Bool
+			skippedTasks := make(chan tasks.Task)
+			env.InjectHook(testhooks.NewHook(
+				testhooks.HistoryTransferTaskInterceptor,
+				func(task tasks.Task, execute func()) {
+					if task.GetType() != enumsspb.TASK_TYPE_TRANSFER_WORKFLOW_TASK || !shouldSkip.Load() {
+						execute()
+						return
+					}
+					skippedTasks <- task
+				},
+			))
+
 			// Register a workflow which does nothing.
-			w := worker.New(s.SdkClient(), s.TaskQueue(), worker.Options{DeadlockDetectionTimeout: 0})
+			w := worker.New(env.SdkClient(), env.WorkerTaskQueue(), worker.Options{DeadlockDetectionTimeout: 0})
 			myWorkflow := func(ctx workflow.Context) error {
 				return nil
 			}
@@ -124,34 +75,28 @@ func (s *AddTasksSuite) TestAddTasks_Ok() {
 			defer w.Stop()
 			w.RegisterWorkflow(myWorkflow)
 
-			// Execute that workflow
-			// We need to track the workflow ID so that we can filter out tasks from this test suite
+			// Execute that workflow.
 			workflowID := uuid.NewString()
-			s.workflowID.Store(&workflowID)
-			s.shouldSkip.Store(true)
-			s.skippedTasks = make(chan tasks.Task)
-			ctx := context.Background()
-			timeout := 5 * debug.TimeoutMultiplier * time.Second
-			ctx, cancel := context.WithTimeout(ctx, timeout)
-			defer cancel()
-			run, err := s.SdkClient().ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
+			shouldSkip.Store(true)
+
+			run, err := env.SdkClient().ExecuteWorkflow(s.Context(), sdkclient.StartWorkflowOptions{
 				ID:        workflowID,
-				TaskQueue: s.TaskQueue(),
+				TaskQueue: env.WorkerTaskQueue(),
 			}, myWorkflow)
 			s.NoError(err)
 
 			// Get the task that we skipped, and add it back
 			var task tasks.Task
 			select {
-			case task = <-s.skippedTasks:
-			case <-ctx.Done():
+			case task = <-skippedTasks:
+			case <-s.Context().Done():
 				s.FailNow("timed out waiting for skipped task")
 			}
 
-			s.shouldSkip.Store(false)
+			shouldSkip.Store(false)
 			blob, err := serialization.NewSerializer().SerializeTask(task)
 			s.NoError(err)
-			shardID := tasks.GetShardIDForTask(task, int(s.GetTestClusterConfig().HistoryConfig.NumHistoryShards))
+			shardID := tasks.GetShardIDForTask(task, int(env.GetTestClusterConfig().HistoryConfig.NumHistoryShards))
 			request := &adminservice.AddTasksRequest{
 				ShardId: int32(shardID),
 				Tasks: []*adminservice.AddTasksRequest_Task{
@@ -162,12 +107,12 @@ func (s *AddTasksSuite) TestAddTasks_Ok() {
 				},
 			}
 			if tc.shouldCallAddTasks {
-				_, err = s.GetTestCluster().AdminClient().AddTasks(ctx, request)
+				_, err = env.GetTestCluster().AdminClient().AddTasks(s.Context(), request)
 				s.NoError(err)
 			}
 
 			// Wait for the workflow to complete
-			ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			err = run.Get(ctx, nil)
 			if tc.shouldCallAddTasks {
@@ -180,7 +125,8 @@ func (s *AddTasksSuite) TestAddTasks_Ok() {
 }
 
 func (s *AddTasksSuite) TestAddTasks_ErrGetShardByID() {
-	_, err := s.GetTestCluster().HistoryClient().AddTasks(context.Background(), &historyservice.AddTasksRequest{
+	env := testcore.NewEnv(s.T())
+	_, err := env.GetTestCluster().HistoryClient().AddTasks(s.Context(), &historyservice.AddTasksRequest{
 		ShardId: 0,
 	})
 	s.Error(err)


### PR DESCRIPTION
## What changed?

Replaces the `tests/add_tasks_test.go` `WithFxOptionsForService` executor-wrapper decoration with a focused, namespace-scoped history transfer task test hook.


## Why?

We want to eliminate `WithFxOptionsForService` as it is blocking us from migrating away from the `onebox.go` approach (which duplicates the fx setup) since we don't want to expose an equivalent method in `temporal/fx.go`.
