### PR TITLE
WCP 2/X: Thread batchID through HistoryBuilder AddEvent methods

### DIFF
--- a/service/history/historybuilder/history_builder.go
+++ b/service/history/historybuilder/history_builder.go
@@ -317,9 +317,9 @@ func (b *HistoryBuilder) AddActivityTaskScheduledEvent(
 	workflowTaskCompletedEventID int64,
 	command *commandpb.ScheduleActivityTaskCommandAttributes,
 	ns namespace.Name,
-) *historypb.HistoryEvent {
+) (*historypb.HistoryEvent, int64) {
 	event := b.EventFactory.CreateActivityTaskScheduledEvent(workflowTaskCompletedEventID, command)
-	event, _ = b.EventStore.add(event)
+	event, batchID := b.EventStore.add(event)
 
 	if payloadSize := command.Input.Size(); payloadSize > 0 {
 		b.metricsHandler.Counter(metrics.ActivityPayloadSize.Name()).Record(
@@ -328,7 +328,7 @@ func (b *HistoryBuilder) AddActivityTaskScheduledEvent(
 			metrics.NamespaceTag(ns.String()))
 	}
 
-	return event
+	return event, batchID
 }
 
 func (b *HistoryBuilder) AddWorkflowExecutionTimeSkippingTransitionedEvent(
@@ -425,11 +425,10 @@ func (b *HistoryBuilder) AddCompletedWorkflowEvent(
 	workflowTaskCompletedEventID int64,
 	command *commandpb.CompleteWorkflowExecutionCommandAttributes,
 	newExecutionRunID string,
-) *historypb.HistoryEvent {
+) (*historypb.HistoryEvent, int64) {
 	event := b.EventFactory.CreateCompletedWorkflowEvent(workflowTaskCompletedEventID, command, newExecutionRunID)
 
-	event, _ = b.EventStore.add(event)
-	return event
+	return b.EventStore.add(event)
 }
 
 func (b *HistoryBuilder) AddFailWorkflowEvent(
@@ -607,24 +606,22 @@ func (b *HistoryBuilder) AddWorkflowExecutionCancelRequestedEvent(
 func (b *HistoryBuilder) AddWorkflowExecutionCanceledEvent(
 	workflowTaskCompletedEventID int64,
 	command *commandpb.CancelWorkflowExecutionCommandAttributes,
-) *historypb.HistoryEvent {
+) (*historypb.HistoryEvent, int64) {
 	event := b.EventFactory.CreateWorkflowExecutionCanceledEvent(workflowTaskCompletedEventID, command)
-	event, _ = b.EventStore.add(event)
-	return event
+	return b.EventStore.add(event)
 }
 
 func (b *HistoryBuilder) AddRequestCancelExternalWorkflowExecutionInitiatedEvent(
 	workflowTaskCompletedEventID int64,
 	command *commandpb.RequestCancelExternalWorkflowExecutionCommandAttributes,
 	targetNamespaceID namespace.ID,
-) *historypb.HistoryEvent {
+) (*historypb.HistoryEvent, int64) {
 	event := b.EventFactory.CreateRequestCancelExternalWorkflowExecutionInitiatedEvent(
 		workflowTaskCompletedEventID,
 		command,
 		targetNamespaceID,
 	)
-	event, _ = b.EventStore.add(event)
-	return event
+	return b.EventStore.add(event)
 }
 
 func (b *HistoryBuilder) AddRequestCancelExternalWorkflowExecutionFailedEvent(
@@ -671,14 +668,13 @@ func (b *HistoryBuilder) AddSignalExternalWorkflowExecutionInitiatedEvent(
 	workflowTaskCompletedEventID int64,
 	command *commandpb.SignalExternalWorkflowExecutionCommandAttributes,
 	targetNamespaceID namespace.ID,
-) *historypb.HistoryEvent {
+) (*historypb.HistoryEvent, int64) {
 	event := b.EventFactory.CreateSignalExternalWorkflowExecutionInitiatedEvent(
 		workflowTaskCompletedEventID,
 		command,
 		targetNamespaceID,
 	)
-	event, _ = b.EventStore.add(event)
-	return event
+	return b.EventStore.add(event)
 }
 
 func (b *HistoryBuilder) AddUpsertWorkflowSearchAttributesEvent(
@@ -780,7 +776,7 @@ func (b *HistoryBuilder) AddStartChildWorkflowExecutionInitiatedEvent(
 	targetNamespaceID namespace.ID,
 	timeSkippingConfig *workflowpb.TimeSkippingConfig,
 	initialSkippedDuration *durationpb.Duration,
-) *historypb.HistoryEvent {
+) (*historypb.HistoryEvent, int64) {
 	event := b.EventFactory.CreateStartChildWorkflowExecutionInitiatedEvent(
 		workflowTaskCompletedEventID,
 		command,
@@ -788,8 +784,7 @@ func (b *HistoryBuilder) AddStartChildWorkflowExecutionInitiatedEvent(
 		timeSkippingConfig,
 		initialSkippedDuration,
 	)
-	event, _ = b.EventStore.add(event)
-	return event
+	return b.EventStore.add(event)
 }
 
 func (b *HistoryBuilder) AddChildWorkflowExecutionStartedEvent(

--- a/service/history/historybuilder/history_builder.go
+++ b/service/history/historybuilder/history_builder.go
@@ -182,7 +182,7 @@ func (b *HistoryBuilder) AddWorkflowExecutionStartedEvent(
 	if len(request.StartRequest.GetLinks()) > 0 {
 		event.Links = request.StartRequest.GetLinks()
 	}
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -193,7 +193,7 @@ func (b *HistoryBuilder) AddWorkflowTaskScheduledEvent(
 	scheduleTime time.Time,
 ) *historypb.HistoryEvent {
 	event := b.EventFactory.CreateWorkflowTaskScheduledEvent(taskQueue, startToCloseTimeout, attempt, scheduleTime)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -221,7 +221,7 @@ func (b *HistoryBuilder) AddWorkflowTaskStartedEvent(
 		suggestContinueAsNewReasons,
 		targetWorkerDeploymentVersionChanged,
 	)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -249,7 +249,7 @@ func (b *HistoryBuilder) AddWorkflowTaskCompletedEvent(
 		deployment,
 		behavior,
 	)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -259,7 +259,7 @@ func (b *HistoryBuilder) AddWorkflowTaskTimedOutEvent(
 	timeoutType enumspb.TimeoutType,
 ) *historypb.HistoryEvent {
 	event := b.EventFactory.CreateWorkflowTaskTimedOutEvent(scheduledEventID, startedEventID, timeoutType)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -285,7 +285,7 @@ func (b *HistoryBuilder) AddWorkflowTaskFailedEvent(
 		forkEventVersion,
 		checksum,
 	)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -319,7 +319,7 @@ func (b *HistoryBuilder) AddActivityTaskScheduledEvent(
 	ns namespace.Name,
 ) (*historypb.HistoryEvent, int64) {
 	event := b.EventFactory.CreateActivityTaskScheduledEvent(workflowTaskCompletedEventID, command)
-	event, batchID := b.EventStore.add(event)
+	event, batchID := b.add(event)
 
 	if payloadSize := command.Input.Size(); payloadSize > 0 {
 		b.metricsHandler.Counter(metrics.ActivityPayloadSize.Name()).Record(
@@ -352,7 +352,7 @@ func (b *HistoryBuilder) AddActivityTaskStartedEvent(
 	redirectCounter int64,
 ) *historypb.HistoryEvent {
 	event := b.EventFactory.CreateActivityTaskStartedEvent(scheduledEventID, attempt, requestID, identity, lastFailure, versioningStamp, redirectCounter)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -364,7 +364,7 @@ func (b *HistoryBuilder) AddActivityTaskCompletedEvent(
 	ns namespace.Name,
 ) *historypb.HistoryEvent {
 	event := b.EventFactory.CreateActivityTaskCompletedEvent(scheduledEventID, startedEventID, identity, result)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 
 	if payloadSize := result.Size(); payloadSize > 0 {
 		b.metricsHandler.Counter(metrics.ActivityPayloadSize.Name()).Record(
@@ -392,7 +392,7 @@ func (b *HistoryBuilder) AddActivityTaskFailedEvent(
 		identity,
 	)
 
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 
 	if payloadSize := failure.Size(); payloadSize > 0 {
 		b.metricsHandler.Counter(metrics.ActivityPayloadSize.Name()).Record(
@@ -417,7 +417,7 @@ func (b *HistoryBuilder) AddActivityTaskTimedOutEvent(
 		retryState,
 	)
 
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -428,7 +428,7 @@ func (b *HistoryBuilder) AddCompletedWorkflowEvent(
 ) (*historypb.HistoryEvent, int64) {
 	event := b.EventFactory.CreateCompletedWorkflowEvent(workflowTaskCompletedEventID, command, newExecutionRunID)
 
-	return b.EventStore.add(event)
+	return b.add(event)
 }
 
 func (b *HistoryBuilder) AddFailWorkflowEvent(
@@ -444,7 +444,7 @@ func (b *HistoryBuilder) AddFailWorkflowEvent(
 		newExecutionRunID,
 	)
 
-	return b.EventStore.add(event)
+	return b.add(event)
 }
 
 func (b *HistoryBuilder) AddTimeoutWorkflowEvent(
@@ -453,7 +453,7 @@ func (b *HistoryBuilder) AddTimeoutWorkflowEvent(
 ) *historypb.HistoryEvent {
 	event := b.EventFactory.CreateTimeoutWorkflowEvent(retryState, newExecutionRunID)
 
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -465,7 +465,7 @@ func (b *HistoryBuilder) AddWorkflowExecutionTerminatedEvent(
 ) *historypb.HistoryEvent {
 	event := b.EventFactory.CreateWorkflowExecutionTerminatedEvent(reason, details, identity, links)
 
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -491,7 +491,7 @@ func (b *HistoryBuilder) AddWorkflowExecutionOptionsUpdatedEvent(
 		timeSkippingConfig,
 		workflowUpdateOptions,
 	)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -507,7 +507,7 @@ func (b *HistoryBuilder) AddWorkflowExecutionUpdateAcceptedEvent(
 		acceptedRequestSequencingEventId,
 		acceptedRequest,
 	)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -516,12 +516,12 @@ func (b *HistoryBuilder) AddWorkflowExecutionUpdateCompletedEvent(
 	updResp *updatepb.Response,
 ) (*historypb.HistoryEvent, int64) {
 	event := b.EventFactory.CreateWorkflowExecutionUpdateCompletedEvent(acceptedEventID, updResp)
-	return b.EventStore.add(event)
+	return b.add(event)
 }
 
 func (b *HistoryBuilder) AddWorkflowExecutionUpdateAdmittedEvent(request *updatepb.Request, origin enumspb.UpdateAdmittedEventOrigin) (*historypb.HistoryEvent, int64) {
 	event := b.EventFactory.CreateWorkflowExecutionUpdateAdmittedEvent(request, origin)
-	return b.EventStore.add(event)
+	return b.add(event)
 }
 
 func (b *HistoryBuilder) AddContinuedAsNewEvent(
@@ -530,7 +530,7 @@ func (b *HistoryBuilder) AddContinuedAsNewEvent(
 	command *commandpb.ContinueAsNewWorkflowExecutionCommandAttributes,
 ) *historypb.HistoryEvent {
 	event := b.EventFactory.CreateContinuedAsNewEvent(workflowTaskCompletedEventID, newRunID, command)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -540,7 +540,7 @@ func (b *HistoryBuilder) AddTimerStartedEvent(
 ) *historypb.HistoryEvent {
 	event := b.EventFactory.CreateTimerStartedEvent(workflowTaskCompletedEventID, command)
 
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -550,7 +550,7 @@ func (b *HistoryBuilder) AddTimerFiredEvent(
 ) *historypb.HistoryEvent {
 	event := b.EventFactory.CreateTimerFiredEvent(startedEventID, timerID)
 
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -560,7 +560,7 @@ func (b *HistoryBuilder) AddActivityTaskCancelRequestedEvent(
 ) *historypb.HistoryEvent {
 	event := b.EventFactory.CreateActivityTaskCancelRequestedEvent(workflowTaskCompletedEventID, scheduledEventID)
 
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -579,7 +579,7 @@ func (b *HistoryBuilder) AddActivityTaskCanceledEvent(
 		identity,
 	)
 
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -591,7 +591,7 @@ func (b *HistoryBuilder) AddTimerCanceledEvent(
 ) *historypb.HistoryEvent {
 	event := b.EventFactory.CreateTimerCanceledEvent(workflowTaskCompletedEventID, startedEventID, timerID, identity)
 
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -599,7 +599,7 @@ func (b *HistoryBuilder) AddWorkflowExecutionCancelRequestedEvent(
 	request *historyservice.RequestCancelWorkflowExecutionRequest,
 ) *historypb.HistoryEvent {
 	event := b.EventFactory.CreateWorkflowExecutionCancelRequestedEvent(request)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -608,7 +608,7 @@ func (b *HistoryBuilder) AddWorkflowExecutionCanceledEvent(
 	command *commandpb.CancelWorkflowExecutionCommandAttributes,
 ) (*historypb.HistoryEvent, int64) {
 	event := b.EventFactory.CreateWorkflowExecutionCanceledEvent(workflowTaskCompletedEventID, command)
-	return b.EventStore.add(event)
+	return b.add(event)
 }
 
 func (b *HistoryBuilder) AddRequestCancelExternalWorkflowExecutionInitiatedEvent(
@@ -621,7 +621,7 @@ func (b *HistoryBuilder) AddRequestCancelExternalWorkflowExecutionInitiatedEvent
 		command,
 		targetNamespaceID,
 	)
-	return b.EventStore.add(event)
+	return b.add(event)
 }
 
 func (b *HistoryBuilder) AddRequestCancelExternalWorkflowExecutionFailedEvent(
@@ -642,7 +642,7 @@ func (b *HistoryBuilder) AddRequestCancelExternalWorkflowExecutionFailedEvent(
 		runID,
 		cause,
 	)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -660,7 +660,7 @@ func (b *HistoryBuilder) AddExternalWorkflowExecutionCancelRequested(
 		workflowID,
 		runID,
 	)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -674,7 +674,7 @@ func (b *HistoryBuilder) AddSignalExternalWorkflowExecutionInitiatedEvent(
 		command,
 		targetNamespaceID,
 	)
-	return b.EventStore.add(event)
+	return b.add(event)
 }
 
 func (b *HistoryBuilder) AddUpsertWorkflowSearchAttributesEvent(
@@ -682,7 +682,7 @@ func (b *HistoryBuilder) AddUpsertWorkflowSearchAttributesEvent(
 	command *commandpb.UpsertWorkflowSearchAttributesCommandAttributes,
 ) *historypb.HistoryEvent {
 	event := b.EventFactory.CreateUpsertWorkflowSearchAttributesEvent(workflowTaskCompletedEventID, command)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -691,7 +691,7 @@ func (b *HistoryBuilder) AddWorkflowPropertiesModifiedEvent(
 	command *commandpb.ModifyWorkflowPropertiesCommandAttributes,
 ) *historypb.HistoryEvent {
 	event := b.EventFactory.CreateWorkflowPropertiesModifiedEvent(workflowTaskCompletedEventID, command)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -715,7 +715,7 @@ func (b *HistoryBuilder) AddSignalExternalWorkflowExecutionFailedEvent(
 		control,
 		cause,
 	)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -735,7 +735,7 @@ func (b *HistoryBuilder) AddExternalWorkflowExecutionSignaled(
 		runID,
 		control,
 	)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -744,7 +744,7 @@ func (b *HistoryBuilder) AddMarkerRecordedEvent(
 	command *commandpb.RecordMarkerCommandAttributes,
 ) *historypb.HistoryEvent {
 	event := b.EventFactory.CreateMarkerRecordedEvent(workflowTaskCompletedEventID, command)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -766,7 +766,7 @@ func (b *HistoryBuilder) AddWorkflowExecutionSignaledEvent(
 		requestID,
 		links,
 	)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -784,7 +784,7 @@ func (b *HistoryBuilder) AddStartChildWorkflowExecutionInitiatedEvent(
 		timeSkippingConfig,
 		initialSkippedDuration,
 	)
-	return b.EventStore.add(event)
+	return b.add(event)
 }
 
 func (b *HistoryBuilder) AddChildWorkflowExecutionStartedEvent(
@@ -803,7 +803,7 @@ func (b *HistoryBuilder) AddChildWorkflowExecutionStartedEvent(
 		workflowType,
 		header,
 	)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -827,7 +827,7 @@ func (b *HistoryBuilder) AddChildWorkflowExecutionFailedEvent(
 		failure,
 		retryState,
 	)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -849,7 +849,7 @@ func (b *HistoryBuilder) AddChildWorkflowExecutionCompletedEvent(
 		workflowType,
 		result,
 	)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -873,7 +873,7 @@ func (b *HistoryBuilder) AddStartChildWorkflowExecutionFailedEvent(
 		workflowType,
 		control,
 	)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -895,7 +895,7 @@ func (b *HistoryBuilder) AddChildWorkflowExecutionCanceledEvent(
 		workflowType,
 		details,
 	)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -915,7 +915,7 @@ func (b *HistoryBuilder) AddChildWorkflowExecutionTerminatedEvent(
 		execution,
 		workflowType,
 	)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -937,7 +937,7 @@ func (b *HistoryBuilder) AddChildWorkflowExecutionTimedOutEvent(
 		workflowType,
 		retryState,
 	)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }
 
@@ -947,6 +947,6 @@ func (b *HistoryBuilder) AddHistoryEvent(
 ) *historypb.HistoryEvent {
 	event := b.EventFactory.createHistoryEvent(eventType, b.EventFactory.timeSource.Now())
 	setAttributes(event)
-	event, _ = b.EventStore.add(event)
+	event, _ = b.add(event)
 	return event
 }

--- a/service/history/historybuilder/history_builder_categorization_test.go
+++ b/service/history/historybuilder/history_builder_categorization_test.go
@@ -1293,11 +1293,12 @@ func (s *sutTestingAdapter) AddActivityTaskFailedEvent(optionalConfig ...eventCo
 }
 
 func (s *sutTestingAdapter) AddActivityTaskScheduledEvent(_ ...eventConfig) *historypb.HistoryEvent {
-	return s.HistoryBuilder.AddActivityTaskScheduledEvent(
+	event, _ := s.HistoryBuilder.AddActivityTaskScheduledEvent(
 		64,
 		&commandpb.ScheduleActivityTaskCommandAttributes{},
 		defaultNamespace,
 	)
+	return event
 }
 
 func (s *sutTestingAdapter) AddWorkflowTaskFailedEvent(_ ...eventConfig) *historypb.HistoryEvent {
@@ -1340,7 +1341,8 @@ func (s *sutTestingAdapter) AddCompletedWorkflowEvent(_ ...eventConfig) *history
 	attrs := &commandpb.CompleteWorkflowExecutionCommandAttributes{
 		Result: nil,
 	}
-	return s.HistoryBuilder.AddCompletedWorkflowEvent(64, attrs, "new-run-1")
+	event, _ := s.HistoryBuilder.AddCompletedWorkflowEvent(64, attrs, "new-run-1")
+	return event
 }
 
 func (s *sutTestingAdapter) AddFailWorkflowEvent(_ ...eventConfig) *historypb.HistoryEvent {
@@ -1414,12 +1416,14 @@ func (s *sutTestingAdapter) AddWorkflowExecutionCancelRequestedEvent(_ ...eventC
 
 func (s *sutTestingAdapter) AddWorkflowExecutionCanceledEvent(_ ...eventConfig) *historypb.HistoryEvent {
 	attrs := &commandpb.CancelWorkflowExecutionCommandAttributes{}
-	return s.HistoryBuilder.AddWorkflowExecutionCanceledEvent(64, attrs)
+	event, _ := s.HistoryBuilder.AddWorkflowExecutionCanceledEvent(64, attrs)
+	return event
 }
 
 func (s *sutTestingAdapter) AddRequestCancelExternalWorkflowExecutionInitiatedEvent(_ ...eventConfig) *historypb.HistoryEvent {
 	attrs := &commandpb.RequestCancelExternalWorkflowExecutionCommandAttributes{}
-	return s.HistoryBuilder.AddRequestCancelExternalWorkflowExecutionInitiatedEvent(64, attrs, namespace.ID("some-id"))
+	event, _ := s.HistoryBuilder.AddRequestCancelExternalWorkflowExecutionInitiatedEvent(64, attrs, namespace.ID("some-id"))
+	return event
 }
 
 func (s *sutTestingAdapter) AddRequestCancelExternalWorkflowExecutionFailedEvent(_ ...eventConfig) *historypb.HistoryEvent {
@@ -1448,7 +1452,8 @@ func (s *sutTestingAdapter) AddSignalExternalWorkflowExecutionInitiatedEvent(_ .
 	attrs := &commandpb.SignalExternalWorkflowExecutionCommandAttributes{
 		Execution: &commonpb.WorkflowExecution{},
 	}
-	return s.HistoryBuilder.AddSignalExternalWorkflowExecutionInitiatedEvent(64, attrs, namespace.ID("ns-target"))
+	event, _ := s.HistoryBuilder.AddSignalExternalWorkflowExecutionInitiatedEvent(64, attrs, namespace.ID("ns-target"))
+	return event
 }
 
 func (s *sutTestingAdapter) AddUpsertWorkflowSearchAttributesEvent(_ ...eventConfig) *historypb.HistoryEvent {
@@ -1504,7 +1509,8 @@ func (s *sutTestingAdapter) AddWorkflowExecutionSignaledEvent(_ ...eventConfig) 
 
 func (s *sutTestingAdapter) AddStartChildWorkflowExecutionInitiatedEvent(_ ...eventConfig) *historypb.HistoryEvent {
 	attrs := &commandpb.StartChildWorkflowExecutionCommandAttributes{}
-	return s.HistoryBuilder.AddStartChildWorkflowExecutionInitiatedEvent(64, attrs, namespace.ID("ns-target"), nil, nil)
+	event, _ := s.HistoryBuilder.AddStartChildWorkflowExecutionInitiatedEvent(64, attrs, namespace.ID("ns-target"), nil, nil)
+	return event
 }
 
 func (s *sutTestingAdapter) AddChildWorkflowExecutionStartedEvent(optionalConfig ...eventConfig) *historypb.HistoryEvent {

--- a/service/history/historybuilder/history_builder_test.go
+++ b/service/history/historybuilder/history_builder_test.go
@@ -444,7 +444,7 @@ func (s *historyBuilderSuite) TestWorkflowExecutionCompleted() {
 	attributes := &commandpb.CompleteWorkflowExecutionCommandAttributes{
 		Result: testPayloads,
 	}
-	event := s.historyBuilder.AddCompletedWorkflowEvent(
+	event, _ := s.historyBuilder.AddCompletedWorkflowEvent(
 		workflowTaskCompletionEventID,
 		attributes,
 		"",
@@ -521,7 +521,7 @@ func (s *historyBuilderSuite) TestWorkflowExecutionCancelled() {
 	attributes := &commandpb.CancelWorkflowExecutionCommandAttributes{
 		Details: testPayloads,
 	}
-	event := s.historyBuilder.AddWorkflowExecutionCanceledEvent(
+	event, _ := s.historyBuilder.AddWorkflowExecutionCanceledEvent(
 		workflowTaskCompletionEventID,
 		attributes,
 	)
@@ -816,7 +816,7 @@ func (s *historyBuilderSuite) TestActivityTaskScheduled() {
 		StartToCloseTimeout:    startToCloseTimeout,
 		HeartbeatTimeout:       heartbeatTimeout,
 	}
-	event := s.historyBuilder.AddActivityTaskScheduledEvent(
+	event, _ := s.historyBuilder.AddActivityTaskScheduledEvent(
 		workflowTaskCompletionEventID,
 		attributes,
 		defaultNamespace,
@@ -1116,7 +1116,7 @@ func (s *historyBuilderSuite) TestRequestCancelExternalWorkflowExecutionInitiate
 		Control:           control,
 		ChildWorkflowOnly: childWorkflowOnly,
 	}
-	event := s.historyBuilder.AddRequestCancelExternalWorkflowExecutionInitiatedEvent(
+	event, _ := s.historyBuilder.AddRequestCancelExternalWorkflowExecutionInitiatedEvent(
 		workflowTaskCompletionEventID,
 		attributes,
 		testNamespaceID,
@@ -1230,7 +1230,7 @@ func (s *historyBuilderSuite) TestSignalExternalWorkflowExecutionInitiated() {
 		ChildWorkflowOnly: childWorkflowOnly,
 		Header:            testHeader,
 	}
-	event := s.historyBuilder.AddSignalExternalWorkflowExecutionInitiatedEvent(
+	event, _ := s.historyBuilder.AddSignalExternalWorkflowExecutionInitiatedEvent(
 		workflowTaskCompletionEventID,
 		attributes,
 		testNamespaceID,
@@ -1363,7 +1363,7 @@ func (s *historyBuilderSuite) TestStartChildWorkflowExecutionInitiated() {
 		SearchAttributes:         testSearchAttributes,
 		Header:                   testHeader,
 	}
-	event := s.historyBuilder.AddStartChildWorkflowExecutionInitiatedEvent(
+	event, _ := s.historyBuilder.AddStartChildWorkflowExecutionInitiatedEvent(
 		workflowTaskCompletionEventID,
 		attributes,
 		testNamespaceID,
@@ -2571,7 +2571,7 @@ func (s *historyBuilderSuite) TestStartChildWorkflowExecutionInitiated_NilSearch
 		},
 	}
 
-	event := s.historyBuilder.AddStartChildWorkflowExecutionInitiatedEvent(
+	event, _ := s.historyBuilder.AddStartChildWorkflowExecutionInitiatedEvent(
 		rand.Int63(),
 		command,
 		testNamespaceID,

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -4212,8 +4212,8 @@ func (ms *MutableStateImpl) AddActivityTaskScheduledEvent(
 		return nil, nil, ms.createCallerError(opTag, "ActivityID: "+command.GetActivityId())
 	}
 
-	event := ms.hBuilder.AddActivityTaskScheduledEvent(workflowTaskCompletedEventID, command, ms.namespaceEntry.Name())
-	ai, err := ms.ApplyActivityTaskScheduledEvent(workflowTaskCompletedEventID, event)
+	event, batchID := ms.hBuilder.AddActivityTaskScheduledEvent(workflowTaskCompletedEventID, command, ms.namespaceEntry.Name())
+	ai, err := ms.ApplyActivityTaskScheduledEvent(batchID, event)
 	// TODO merge active & passive task generation
 	if !bypassTaskGeneration {
 		if err := ms.taskGenerator.GenerateActivityTasks(
@@ -4227,7 +4227,7 @@ func (ms *MutableStateImpl) AddActivityTaskScheduledEvent(
 }
 
 func (ms *MutableStateImpl) ApplyActivityTaskScheduledEvent(
-	firstEventID int64,
+	batchID int64,
 	event *historypb.HistoryEvent,
 ) (*persistencespb.ActivityInfo, error) {
 
@@ -4239,7 +4239,7 @@ func (ms *MutableStateImpl) ApplyActivityTaskScheduledEvent(
 	ai := &persistencespb.ActivityInfo{
 		Version:                 event.GetVersion(),
 		ScheduledEventId:        scheduledEventID,
-		ScheduledEventBatchId:   firstEventID,
+		ScheduledEventBatchId:   batchID,
 		ScheduledTime:           event.GetEventTime(),
 		FirstScheduledTime:      event.GetEventTime(),
 		StartedEventId:          common.EmptyEventID,
@@ -4841,8 +4841,8 @@ func (ms *MutableStateImpl) AddCompletedWorkflowEvent(
 		return nil, err
 	}
 
-	event := ms.hBuilder.AddCompletedWorkflowEvent(workflowTaskCompletedEventID, command, newExecutionRunID)
-	if err := ms.ApplyWorkflowExecutionCompletedEvent(workflowTaskCompletedEventID, event); err != nil {
+	event, batchID := ms.hBuilder.AddCompletedWorkflowEvent(workflowTaskCompletedEventID, command, newExecutionRunID)
+	if err := ms.ApplyWorkflowExecutionCompletedEvent(batchID, event); err != nil {
 		return nil, err
 	}
 	// TODO merge active & passive task generation
@@ -4857,7 +4857,7 @@ func (ms *MutableStateImpl) AddCompletedWorkflowEvent(
 }
 
 func (ms *MutableStateImpl) ApplyWorkflowExecutionCompletedEvent(
-	firstEventID int64,
+	batchID int64,
 	event *historypb.HistoryEvent,
 ) error {
 	if _, err := ms.UpdateWorkflowStateStatus(
@@ -4866,7 +4866,7 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionCompletedEvent(
 	); err != nil {
 		return err
 	}
-	ms.executionInfo.CompletionEventBatchId = firstEventID // Used when completion event needs to be loaded from database
+	ms.executionInfo.CompletionEventBatchId = batchID // Used when completion event needs to be loaded from database
 	ms.executionInfo.NewExecutionRunId = event.GetWorkflowExecutionCompletedEventAttributes().GetNewExecutionRunId()
 	ms.executionInfo.CloseTime = event.GetEventTime()
 	ms.ClearStickyTaskQueue()
@@ -4901,7 +4901,7 @@ func (ms *MutableStateImpl) AddFailWorkflowEvent(
 }
 
 func (ms *MutableStateImpl) ApplyWorkflowExecutionFailedEvent(
-	firstEventID int64,
+	batchID int64,
 	event *historypb.HistoryEvent,
 ) error {
 	if _, err := ms.UpdateWorkflowStateStatus(
@@ -4910,7 +4910,7 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionFailedEvent(
 	); err != nil {
 		return err
 	}
-	ms.executionInfo.CompletionEventBatchId = firstEventID // Used when completion event needs to be loaded from database
+	ms.executionInfo.CompletionEventBatchId = batchID // Used when completion event needs to be loaded from database
 	ms.executionInfo.NewExecutionRunId = event.GetWorkflowExecutionFailedEventAttributes().GetNewExecutionRunId()
 	ms.executionInfo.CloseTime = event.GetEventTime()
 	ms.ClearStickyTaskQueue()
@@ -5020,8 +5020,8 @@ func (ms *MutableStateImpl) AddWorkflowExecutionCanceledEvent(
 		return nil, err
 	}
 
-	event := ms.hBuilder.AddWorkflowExecutionCanceledEvent(workflowTaskCompletedEventID, command)
-	if err := ms.ApplyWorkflowExecutionCanceledEvent(workflowTaskCompletedEventID, event); err != nil {
+	event, batchID := ms.hBuilder.AddWorkflowExecutionCanceledEvent(workflowTaskCompletedEventID, command)
+	if err := ms.ApplyWorkflowExecutionCanceledEvent(batchID, event); err != nil {
 		return nil, err
 	}
 	// TODO merge active & passive task generation
@@ -5036,7 +5036,7 @@ func (ms *MutableStateImpl) AddWorkflowExecutionCanceledEvent(
 }
 
 func (ms *MutableStateImpl) ApplyWorkflowExecutionCanceledEvent(
-	firstEventID int64,
+	batchID int64,
 	event *historypb.HistoryEvent,
 ) error {
 	if _, err := ms.UpdateWorkflowStateStatus(
@@ -5045,7 +5045,7 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionCanceledEvent(
 	); err != nil {
 		return err
 	}
-	ms.executionInfo.CompletionEventBatchId = firstEventID // Used when completion event needs to be loaded from database
+	ms.executionInfo.CompletionEventBatchId = batchID // Used when completion event needs to be loaded from database
 	ms.executionInfo.NewExecutionRunId = ""
 	ms.executionInfo.CloseTime = event.GetEventTime()
 	ms.ClearStickyTaskQueue()
@@ -5064,8 +5064,8 @@ func (ms *MutableStateImpl) AddRequestCancelExternalWorkflowExecutionInitiatedEv
 		return nil, nil, err
 	}
 
-	event := ms.hBuilder.AddRequestCancelExternalWorkflowExecutionInitiatedEvent(workflowTaskCompletedEventID, command, targetNamespaceID)
-	rci, err := ms.ApplyRequestCancelExternalWorkflowExecutionInitiatedEvent(workflowTaskCompletedEventID, event, cancelRequestID)
+	event, batchID := ms.hBuilder.AddRequestCancelExternalWorkflowExecutionInitiatedEvent(workflowTaskCompletedEventID, command, targetNamespaceID)
+	rci, err := ms.ApplyRequestCancelExternalWorkflowExecutionInitiatedEvent(batchID, event, cancelRequestID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -5079,7 +5079,7 @@ func (ms *MutableStateImpl) AddRequestCancelExternalWorkflowExecutionInitiatedEv
 }
 
 func (ms *MutableStateImpl) ApplyRequestCancelExternalWorkflowExecutionInitiatedEvent(
-	firstEventID int64,
+	batchID int64,
 	event *historypb.HistoryEvent,
 	cancelRequestID string,
 ) (*persistencespb.RequestCancelInfo, error) {
@@ -5087,7 +5087,7 @@ func (ms *MutableStateImpl) ApplyRequestCancelExternalWorkflowExecutionInitiated
 	initiatedEventID := event.GetEventId()
 	rci := &persistencespb.RequestCancelInfo{
 		Version:               event.GetVersion(),
-		InitiatedEventBatchId: firstEventID,
+		InitiatedEventBatchId: batchID,
 		InitiatedEventId:      initiatedEventID,
 		CancelRequestId:       cancelRequestID,
 	}
@@ -5199,8 +5199,8 @@ func (ms *MutableStateImpl) AddSignalExternalWorkflowExecutionInitiatedEvent(
 		return nil, nil, err
 	}
 
-	event := ms.hBuilder.AddSignalExternalWorkflowExecutionInitiatedEvent(workflowTaskCompletedEventID, command, targetNamespaceID)
-	si, err := ms.ApplySignalExternalWorkflowExecutionInitiatedEvent(workflowTaskCompletedEventID, event, signalRequestID)
+	event, batchID := ms.hBuilder.AddSignalExternalWorkflowExecutionInitiatedEvent(workflowTaskCompletedEventID, command, targetNamespaceID)
+	si, err := ms.ApplySignalExternalWorkflowExecutionInitiatedEvent(batchID, event, signalRequestID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -5214,7 +5214,7 @@ func (ms *MutableStateImpl) AddSignalExternalWorkflowExecutionInitiatedEvent(
 }
 
 func (ms *MutableStateImpl) ApplySignalExternalWorkflowExecutionInitiatedEvent(
-	firstEventID int64,
+	batchID int64,
 	event *historypb.HistoryEvent,
 	signalRequestID string,
 ) (*persistencespb.SignalInfo, error) {
@@ -5222,7 +5222,7 @@ func (ms *MutableStateImpl) ApplySignalExternalWorkflowExecutionInitiatedEvent(
 	initiatedEventID := event.GetEventId()
 	si := &persistencespb.SignalInfo{
 		Version:               event.GetVersion(),
-		InitiatedEventBatchId: firstEventID,
+		InitiatedEventBatchId: batchID,
 		InitiatedEventId:      initiatedEventID,
 		RequestId:             signalRequestID,
 	}
@@ -6350,14 +6350,14 @@ func (ms *MutableStateImpl) AddStartChildWorkflowExecutionInitiatedEvent(
 	}
 
 	childTSConfig, childInitialSkipped := snapshotTimeSkippingInfo(ms.executionInfo)
-	event := ms.hBuilder.AddStartChildWorkflowExecutionInitiatedEvent(
+	event, batchID := ms.hBuilder.AddStartChildWorkflowExecutionInitiatedEvent(
 		workflowTaskCompletedEventID,
 		command,
 		targetNamespaceID,
 		childTSConfig,
 		childInitialSkipped,
 	)
-	ci, err := ms.ApplyStartChildWorkflowExecutionInitiatedEvent(workflowTaskCompletedEventID, event)
+	ci, err := ms.ApplyStartChildWorkflowExecutionInitiatedEvent(batchID, event)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -6376,7 +6376,7 @@ func (ms *MutableStateImpl) generateChildWorkflowRequestID(event *historypb.Hist
 }
 
 func (ms *MutableStateImpl) ApplyStartChildWorkflowExecutionInitiatedEvent(
-	firstEventID int64,
+	batchID int64,
 	event *historypb.HistoryEvent,
 ) (*persistencespb.ChildExecutionInfo, error) {
 	initiatedEventID := event.GetEventId()
@@ -6384,7 +6384,7 @@ func (ms *MutableStateImpl) ApplyStartChildWorkflowExecutionInitiatedEvent(
 	ci := &persistencespb.ChildExecutionInfo{
 		Version:               event.GetVersion(),
 		InitiatedEventId:      initiatedEventID,
-		InitiatedEventBatchId: firstEventID,
+		InitiatedEventBatchId: batchID,
 		StartedEventId:        common.EmptyEventID,
 		StartedWorkflowId:     attributes.GetWorkflowId(),
 		CreateRequestId:       ms.generateChildWorkflowRequestID(event),

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -4127,7 +4127,7 @@ func (s *mutableStateSuite) TestCollapseVisibilityTasks() {
 func (s *mutableStateSuite) TestStartChildWorkflowRequestID() {
 	workflowTaskCompletionEventID := rand.Int63()
 	attributes := &commandpb.StartChildWorkflowExecutionCommandAttributes{}
-	event := s.mutableState.hBuilder.AddStartChildWorkflowExecutionInitiatedEvent(
+	event, _ := s.mutableState.hBuilder.AddStartChildWorkflowExecutionInitiatedEvent(
 		workflowTaskCompletionEventID,
 		attributes,
 		tests.NamespaceID,
@@ -8794,4 +8794,118 @@ func (s *mutableStateSuite) TestUpdateActivityProgress_HeartbeatCountMetric() {
 	// Heartbeat without details.
 	s.mutableState.UpdateActivityProgress(ai, &workflowservice.RecordActivityTaskHeartbeatRequest{})
 	s.Contains(s.testScope.Snapshot().Counters(), counterKey("false"))
+}
+
+// scheduleCompletedWFTForBatchIDTest puts the suite's mutable state into a
+// configuration where the next Add*Event call lands in its own size-rolled
+// batch, then completes a WFT and returns the WFT-completed event
+//
+// MaximumEventBatchSizeInBytes=1 forces every event into its own batch, so
+// the next event's correct batchID equals its own EventID — distinct from
+// completedEvent.GetEventId(), making the buggy behavior observable.
+func (s *mutableStateSuite) scheduleCompletedWFTForBatchIDTest() (
+	*taskqueuepb.TaskQueue,
+	*historypb.HistoryEvent,
+) {
+	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
+	s.mockConfig.MaximumEventBatchSizeInBytes = dynamicconfig.GetIntPropertyFn(1)
+
+	tq := &taskqueuepb.TaskQueue{Name: "tq"}
+	s.createVersionedMutableStateWithCompletedWFT(tq)
+
+	wft, err := s.mutableState.AddWorkflowTaskScheduledEvent(false, enumsspb.WORKFLOW_TASK_TYPE_NORMAL)
+	s.NoError(err)
+	_, wft, err = s.mutableState.AddWorkflowTaskStartedEvent(
+		wft.ScheduledEventID, "", tq, "",
+		worker_versioning.StampFromBuildId("b1"),
+		nil, nil, false, nil, 0,
+	)
+	s.NoError(err)
+	completedEvent, err := s.mutableState.AddWorkflowTaskCompletedEvent(
+		wft, &workflowservice.RespondWorkflowTaskCompletedRequest{}, workflowTaskCompletionLimits,
+	)
+	s.NoError(err)
+	return tq, completedEvent
+}
+
+func (s *mutableStateSuite) TestAddActivityTaskScheduledEvent_ScheduledEventBatchID() {
+	tq, completedEvent := s.scheduleCompletedWFTForBatchIDTest()
+
+	event, activityInfo, err := s.mutableState.AddActivityTaskScheduledEvent(
+		completedEvent.GetEventId(),
+		&commandpb.ScheduleActivityTaskCommandAttributes{
+			ActivityId:   "act-1",
+			ActivityType: &commonpb.ActivityType{Name: "activity-type"},
+			TaskQueue:    tq,
+		},
+		true,
+	)
+	s.NoError(err)
+	s.Equal(event.GetEventId(), activityInfo.ScheduledEventBatchId)
+}
+
+func (s *mutableStateSuite) TestAddCompletedWorkflowEvent_CompletionEventBatchID() {
+	_, completedEvent := s.scheduleCompletedWFTForBatchIDTest()
+
+	event, err := s.mutableState.AddCompletedWorkflowEvent(
+		completedEvent.GetEventId(),
+		&commandpb.CompleteWorkflowExecutionCommandAttributes{},
+		"",
+	)
+	s.NoError(err)
+	s.Equal(event.GetEventId(), s.mutableState.GetExecutionInfo().CompletionEventBatchId)
+}
+
+func (s *mutableStateSuite) TestAddWorkflowExecutionCanceledEvent_CompletionEventBatchID() {
+	_, completedEvent := s.scheduleCompletedWFTForBatchIDTest()
+
+	event, err := s.mutableState.AddWorkflowExecutionCanceledEvent(
+		completedEvent.GetEventId(),
+		&commandpb.CancelWorkflowExecutionCommandAttributes{},
+	)
+	s.NoError(err)
+	s.Equal(event.GetEventId(), s.mutableState.GetExecutionInfo().CompletionEventBatchId)
+}
+
+func (s *mutableStateSuite) TestAddRequestCancelExternalWorkflowExecutionInitiatedEvent_InitiatedEventBatchID() {
+	_, completedEvent := s.scheduleCompletedWFTForBatchIDTest()
+
+	event, rci, err := s.mutableState.AddRequestCancelExternalWorkflowExecutionInitiatedEvent(
+		completedEvent.GetEventId(),
+		uuid.NewString(),
+		&commandpb.RequestCancelExternalWorkflowExecutionCommandAttributes{},
+		namespace.ID(uuid.NewString()),
+	)
+	s.NoError(err)
+	s.Equal(event.GetEventId(), rci.InitiatedEventBatchId)
+}
+
+func (s *mutableStateSuite) TestAddSignalExternalWorkflowExecutionInitiatedEvent_InitiatedEventBatchID() {
+	_, completedEvent := s.scheduleCompletedWFTForBatchIDTest()
+
+	event, si, err := s.mutableState.AddSignalExternalWorkflowExecutionInitiatedEvent(
+		completedEvent.GetEventId(),
+		uuid.NewString(),
+		&commandpb.SignalExternalWorkflowExecutionCommandAttributes{
+			Execution: &commonpb.WorkflowExecution{
+				WorkflowId: tests.WorkflowID,
+				RunId:      tests.RunID,
+			},
+		},
+		namespace.ID(uuid.NewString()),
+	)
+	s.NoError(err)
+	s.Equal(event.GetEventId(), si.InitiatedEventBatchId)
+}
+
+func (s *mutableStateSuite) TestAddStartChildWorkflowExecutionInitiatedEvent_InitiatedEventBatchID() {
+	_, completedEvent := s.scheduleCompletedWFTForBatchIDTest()
+
+	event, ci, err := s.mutableState.AddStartChildWorkflowExecutionInitiatedEvent(
+		completedEvent.GetEventId(),
+		&commandpb.StartChildWorkflowExecutionCommandAttributes{},
+		namespace.ID(uuid.NewString()),
+	)
+	s.NoError(err)
+	s.Equal(event.GetEventId(), ci.InitiatedEventBatchId)
 }


### PR DESCRIPTION
## What changed?
`HistoryBuilder.Add*` methods that previously returned just the event now also return the `batchID`. `MutableStateImpl` threads that `batchID` into the corresponding `Apply*` calls, which use it to populate the batchID back reference set on the event fields. 

This is stacked on top of https://github.com/temporalio/temporal/pull/10357. 

## Why?
https://github.com/temporalio/temporal/pull/10357 adds batch splitting in EventStore based on the size, which results in looser guarantees as to what batchId the event falls into. Previously these fields were set to `workflowTaskCompletedEventID`, which only happens to equal the new event's batch ID when the new event ends up in the same batch as the WorkflowTaskCompleted event.


## How did you test it?
- [X] built
- [X] run locally and tested manually
- [ ] covered by existing tests
- [X] added new unit test(s)
- [X] added new functional test(s)

## Potential risks
[Very low risk] The risk with this particular change is that in some cases we actually split the event with the WorkflowTaskCompleted event batches and we happen to expect WorkflowTaskCompleted present there instead of the event. This is very unlikely, since WorkflowTaskCompleted event ID is already set on some events and the naming such as ScheduledEventBatchId suggests the opposite.
