### PR TITLE
WCP 3/X: Use correct BatchID in Timeout, Terminated and ContinueAsNew events

### DIFF
--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -486,9 +486,7 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 			return nil, serviceerror.NewInvalidArgument(wtFailedCause.Message())
 		}
 
-		// wtFailedEventID must be used as the event batch ID for any following workflow termination events
-		var wtFailedEventID int64
-		ms, wtFailedEventID, err = failWorkflowTask(ctx, handler.shardContext, weContext, currentWorkflowTask, wtFailedCause, request)
+		ms, _, err = failWorkflowTask(ctx, handler.shardContext, weContext, currentWorkflowTask, wtFailedCause, request)
 		if err != nil {
 			return nil, err
 		}
@@ -500,7 +498,6 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 			ms.FlushBufferedEvents()
 
 			_, err := ms.AddWorkflowExecutionTerminatedEvent(
-				wtFailedEventID,
 				wtFailedCause.Message(),
 				nil,
 				consts.IdentityHistoryService,

--- a/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
+++ b/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
@@ -1120,7 +1120,6 @@ func (handler *workflowTaskCompletedHandler) handleCommandContinueAsNewWorkflow(
 	event, newMutableState, err := handler.mutableState.AddContinueAsNewEvent(
 		ctx,
 		handler.workflowTaskCompletedID,
-		handler.workflowTaskCompletedID,
 		parentNamespace,
 		attr,
 		worker_versioning.GetIsWFTaskQueueInVersionDetector(handler.matchingClient, handler.versionCache),

--- a/service/history/api/verifyfirstworkflowtaskscheduled/api_test.go
+++ b/service/history/api/verifyfirstworkflowtaskscheduled/api_test.go
@@ -132,7 +132,6 @@ func (s *VerifyFirstWorkflowTaskScheduledSuite) TestVerifyFirstWorkflowTaskSched
 		25*time.Second, 20*time.Second, 200*time.Second, nil, "identity")
 
 	_, err := ms.AddTimeoutWorkflowEvent(
-		ms.GetNextEventID(),
 		enumspb.RETRY_STATE_RETRY_POLICY_NOT_SET,
 		uuid.NewString(),
 	)

--- a/service/history/history_engine2_test.go
+++ b/service/history/history_engine2_test.go
@@ -2630,7 +2630,6 @@ func (s *engine2Suite) TestVerifyChildExecutionCompletionRecorded_ResendParent()
 		RunId:      tests.RunID,
 	}, "wType", "testTaskQueue", payloads.EncodeString("input"), 25*time.Second, 20*time.Second, 200*time.Second, "identity")
 	_, err := ms.AddTimeoutWorkflowEvent(
-		ms.GetNextEventID(),
 		enumspb.RETRY_STATE_RETRY_POLICY_NOT_SET,
 		uuid.NewString(),
 	)
@@ -2677,7 +2676,6 @@ func (s *engine2Suite) TestVerifyChildExecutionCompletionRecorded_WorkflowClosed
 		RunId:      tests.RunID,
 	}, "wType", "testTaskQueue", payloads.EncodeString("input"), 25*time.Second, 20*time.Second, 200*time.Second, "identity")
 	_, err := ms.AddTimeoutWorkflowEvent(
-		ms.GetNextEventID(),
 		enumspb.RETRY_STATE_RETRY_POLICY_NOT_SET,
 		uuid.NewString(),
 	)
@@ -2856,7 +2854,6 @@ func (s *engine2Suite) TestRefreshWorkflowTasks() {
 	startEvent := addWorkflowExecutionStartedEvent(ms, execution, "wType", "testTaskQueue", payloads.EncodeString("input"), 25*time.Second, 20*time.Second, 200*time.Second, "identity")
 	startVersion := startEvent.GetVersion()
 	timeoutEvent, err := ms.AddTimeoutWorkflowEvent(
-		ms.GetNextEventID(),
 		enumspb.RETRY_STATE_RETRY_POLICY_NOT_SET,
 		uuid.NewString(),
 	)

--- a/service/history/historybuilder/history_builder.go
+++ b/service/history/historybuilder/history_builder.go
@@ -450,11 +450,9 @@ func (b *HistoryBuilder) AddFailWorkflowEvent(
 func (b *HistoryBuilder) AddTimeoutWorkflowEvent(
 	retryState enumspb.RetryState,
 	newExecutionRunID string,
-) *historypb.HistoryEvent {
+) (*historypb.HistoryEvent, int64) {
 	event := b.EventFactory.CreateTimeoutWorkflowEvent(retryState, newExecutionRunID)
-
-	event, _ = b.add(event)
-	return event
+	return b.add(event)
 }
 
 func (b *HistoryBuilder) AddWorkflowExecutionTerminatedEvent(
@@ -462,11 +460,9 @@ func (b *HistoryBuilder) AddWorkflowExecutionTerminatedEvent(
 	details *commonpb.Payloads,
 	identity string,
 	links []*commonpb.Link,
-) *historypb.HistoryEvent {
+) (*historypb.HistoryEvent, int64) {
 	event := b.EventFactory.CreateWorkflowExecutionTerminatedEvent(reason, details, identity, links)
-
-	event, _ = b.add(event)
-	return event
+	return b.add(event)
 }
 
 func (b *HistoryBuilder) AddWorkflowExecutionOptionsUpdatedEvent(
@@ -528,10 +524,9 @@ func (b *HistoryBuilder) AddContinuedAsNewEvent(
 	workflowTaskCompletedEventID int64,
 	newRunID string,
 	command *commandpb.ContinueAsNewWorkflowExecutionCommandAttributes,
-) *historypb.HistoryEvent {
+) (*historypb.HistoryEvent, int64) {
 	event := b.EventFactory.CreateContinuedAsNewEvent(workflowTaskCompletedEventID, newRunID, command)
-	event, _ = b.add(event)
-	return event
+	return b.add(event)
 }
 
 func (b *HistoryBuilder) AddTimerStartedEvent(

--- a/service/history/historybuilder/history_builder_categorization_test.go
+++ b/service/history/historybuilder/history_builder_categorization_test.go
@@ -1357,11 +1357,13 @@ func (s *sutTestingAdapter) AddFailWorkflowEvent(_ ...eventConfig) *historypb.Hi
 }
 
 func (s *sutTestingAdapter) AddTimeoutWorkflowEvent(_ ...eventConfig) *historypb.HistoryEvent {
-	return s.HistoryBuilder.AddTimeoutWorkflowEvent(enumspb.RETRY_STATE_IN_PROGRESS, "new-rung-1")
+	event, _ := s.HistoryBuilder.AddTimeoutWorkflowEvent(enumspb.RETRY_STATE_IN_PROGRESS, "new-rung-1")
+	return event
 }
 
 func (s *sutTestingAdapter) AddWorkflowExecutionTerminatedEvent(_ ...eventConfig) *historypb.HistoryEvent {
-	return s.HistoryBuilder.AddWorkflowExecutionTerminatedEvent("no reason to terminate", nil, "identity-secret", nil)
+	event, _ := s.HistoryBuilder.AddWorkflowExecutionTerminatedEvent("no reason to terminate", nil, "identity-secret", nil)
+	return event
 }
 
 func (s *sutTestingAdapter) AddWorkflowExecutionUpdateAcceptedEvent(_ ...eventConfig) *historypb.HistoryEvent {
@@ -1375,7 +1377,8 @@ func (s *sutTestingAdapter) AddWorkflowExecutionUpdateCompletedEvent(_ ...eventC
 
 func (s *sutTestingAdapter) AddContinuedAsNewEvent(_ ...eventConfig) *historypb.HistoryEvent {
 	attrs := &commandpb.ContinueAsNewWorkflowExecutionCommandAttributes{}
-	return s.HistoryBuilder.AddContinuedAsNewEvent(64, "new-run-5", attrs)
+	event, _ := s.HistoryBuilder.AddContinuedAsNewEvent(64, "new-run-5", attrs)
+	return event
 }
 
 func (s *sutTestingAdapter) AddTimerStartedEvent(_ ...eventConfig) *historypb.HistoryEvent {

--- a/service/history/historybuilder/history_builder_test.go
+++ b/service/history/historybuilder/history_builder_test.go
@@ -497,7 +497,7 @@ func (s *historyBuilderSuite) TestWorkflowExecutionFailed() {
 
 func (s *historyBuilderSuite) TestWorkflowExecutionTimeout() {
 	retryState := enumspb.RetryState(rand.Int31n(int32(len(enumspb.RetryState_name))))
-	event := s.historyBuilder.AddTimeoutWorkflowEvent(
+	event, _ := s.historyBuilder.AddTimeoutWorkflowEvent(
 		retryState,
 		"",
 	)
@@ -543,7 +543,7 @@ func (s *historyBuilderSuite) TestWorkflowExecutionCancelled() {
 
 func (s *historyBuilderSuite) TestWorkflowExecutionTerminated() {
 	reason := "random reason"
-	event := s.historyBuilder.AddWorkflowExecutionTerminatedEvent(
+	event, _ := s.historyBuilder.AddWorkflowExecutionTerminatedEvent(
 		reason,
 		testPayloads,
 		testIdentity,
@@ -589,7 +589,7 @@ func (s *historyBuilderSuite) TestWorkflowExecutionContinueAsNew() {
 		Memo:                 testMemo,
 		SearchAttributes:     testSearchAttributes,
 	}
-	event := s.historyBuilder.AddContinuedAsNewEvent(
+	event, _ := s.historyBuilder.AddContinuedAsNewEvent(
 		workflowTaskCompletionEventID,
 		testRunID,
 		attributes,
@@ -2537,7 +2537,7 @@ func (s *historyBuilderSuite) TestContinuedAsNew_NilSearchAttributesFiltered() {
 		},
 	}
 
-	event := s.historyBuilder.AddContinuedAsNewEvent(
+	event, _ := s.historyBuilder.AddContinuedAsNewEvent(
 		rand.Int63(),
 		testRunID,
 		command,

--- a/service/history/interfaces/mutable_state.go
+++ b/service/history/interfaces/mutable_state.go
@@ -71,7 +71,7 @@ type (
 		AddChildWorkflowExecutionTerminatedEvent(int64, *commonpb.WorkflowExecution) (*historypb.HistoryEvent, error)
 		AddChildWorkflowExecutionTimedOutEvent(int64, *commonpb.WorkflowExecution, *historypb.WorkflowExecutionTimedOutEventAttributes) (*historypb.HistoryEvent, error)
 		AddCompletedWorkflowEvent(int64, *commandpb.CompleteWorkflowExecutionCommandAttributes, string) (*historypb.HistoryEvent, error)
-		AddContinueAsNewEvent(context.Context, int64, int64, namespace.Name, *commandpb.ContinueAsNewWorkflowExecutionCommandAttributes, worker_versioning.IsWFTaskQueueInVersionDetector) (*historypb.HistoryEvent, MutableState, error)
+		AddContinueAsNewEvent(context.Context, int64, namespace.Name, *commandpb.ContinueAsNewWorkflowExecutionCommandAttributes, worker_versioning.IsWFTaskQueueInVersionDetector) (*historypb.HistoryEvent, MutableState, error)
 		AddWorkflowTaskCompletedEvent(*WorkflowTaskInfo, *workflowservice.RespondWorkflowTaskCompletedRequest, WorkflowTaskCompletionLimits) (*historypb.HistoryEvent, error)
 		AddWorkflowTaskFailedEvent(workflowTask *WorkflowTaskInfo, cause enumspb.WorkflowTaskFailedCause, failure *failurepb.Failure, identity string, versioningStamp *commonpb.WorkerVersionStamp, binChecksum, baseRunID, newRunID string, forkEventVersion int64) (*historypb.HistoryEvent, error)
 		AddWorkflowTaskScheduleToStartTimeoutEvent(workflowTask *WorkflowTaskInfo) (*historypb.HistoryEvent, error)
@@ -91,7 +91,7 @@ type (
 		AddSignalRequested(requestID string)
 		AddStartChildWorkflowExecutionFailedEvent(int64, enumspb.StartChildWorkflowExecutionFailedCause, *historypb.StartChildWorkflowExecutionInitiatedEventAttributes) (*historypb.HistoryEvent, error)
 		AddStartChildWorkflowExecutionInitiatedEvent(int64, *commandpb.StartChildWorkflowExecutionCommandAttributes, namespace.ID) (*historypb.HistoryEvent, *persistencespb.ChildExecutionInfo, error)
-		AddTimeoutWorkflowEvent(int64, enumspb.RetryState, string) (*historypb.HistoryEvent, error)
+		AddTimeoutWorkflowEvent(enumspb.RetryState, string) (*historypb.HistoryEvent, error)
 		AddTimerCanceledEvent(int64, *commandpb.CancelTimerCommandAttributes, string) (*historypb.HistoryEvent, error)
 		AddTimerFiredEvent(string) (*historypb.HistoryEvent, error)
 		AddTimerStartedEvent(int64, *commandpb.StartTimerCommandAttributes) (*historypb.HistoryEvent, *persistencespb.TimerInfo, error)
@@ -118,7 +118,7 @@ type (
 		) (*historypb.HistoryEvent, error)
 		AddWorkflowExecutionStartedEvent(*commonpb.WorkflowExecution, *historyservice.StartWorkflowExecutionRequest) (*historypb.HistoryEvent, error)
 		AddWorkflowExecutionStartedEventWithOptions(*commonpb.WorkflowExecution, *historyservice.StartWorkflowExecutionRequest, *workflowpb.ResetPoints, string, string) (*historypb.HistoryEvent, error)
-		AddWorkflowExecutionTerminatedEvent(firstEventID int64, reason string, details *commonpb.Payloads, identity string, deleteAfterTerminate bool, links []*commonpb.Link) (*historypb.HistoryEvent, error)
+		AddWorkflowExecutionTerminatedEvent(reason string, details *commonpb.Payloads, identity string, deleteAfterTerminate bool, links []*commonpb.Link) (*historypb.HistoryEvent, error)
 		AddWorkflowExecutionOptionsUpdatedEvent(
 			versioningOverride *workflowpb.VersioningOverride,
 			unsetVersioningOverride bool,

--- a/service/history/interfaces/mutable_state_mock.go
+++ b/service/history/interfaces/mutable_state_mock.go
@@ -284,9 +284,9 @@ func (mr *MockMutableStateMockRecorder) AddCompletedWorkflowEvent(arg0, arg1, ar
 }
 
 // AddContinueAsNewEvent mocks base method.
-func (m *MockMutableState) AddContinueAsNewEvent(arg0 context.Context, arg1, arg2 int64, arg3 namespace.Name, arg4 *command.ContinueAsNewWorkflowExecutionCommandAttributes, arg5 worker_versioning.IsWFTaskQueueInVersionDetector) (*history.HistoryEvent, MutableState, error) {
+func (m *MockMutableState) AddContinueAsNewEvent(arg0 context.Context, arg1 int64, arg2 namespace.Name, arg3 *command.ContinueAsNewWorkflowExecutionCommandAttributes, arg4 worker_versioning.IsWFTaskQueueInVersionDetector) (*history.HistoryEvent, MutableState, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddContinueAsNewEvent", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "AddContinueAsNewEvent", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*history.HistoryEvent)
 	ret1, _ := ret[1].(MutableState)
 	ret2, _ := ret[2].(error)
@@ -294,9 +294,9 @@ func (m *MockMutableState) AddContinueAsNewEvent(arg0 context.Context, arg1, arg
 }
 
 // AddContinueAsNewEvent indicates an expected call of AddContinueAsNewEvent.
-func (mr *MockMutableStateMockRecorder) AddContinueAsNewEvent(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
+func (mr *MockMutableStateMockRecorder) AddContinueAsNewEvent(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddContinueAsNewEvent", reflect.TypeOf((*MockMutableState)(nil).AddContinueAsNewEvent), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddContinueAsNewEvent", reflect.TypeOf((*MockMutableState)(nil).AddContinueAsNewEvent), arg0, arg1, arg2, arg3, arg4)
 }
 
 // AddExternalPayloadCount mocks base method.
@@ -558,18 +558,18 @@ func (mr *MockMutableStateMockRecorder) AddTasks(arg0 ...any) *gomock.Call {
 }
 
 // AddTimeoutWorkflowEvent mocks base method.
-func (m *MockMutableState) AddTimeoutWorkflowEvent(arg0 int64, arg1 enums.RetryState, arg2 string) (*history.HistoryEvent, error) {
+func (m *MockMutableState) AddTimeoutWorkflowEvent(arg0 enums.RetryState, arg1 string) (*history.HistoryEvent, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddTimeoutWorkflowEvent", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "AddTimeoutWorkflowEvent", arg0, arg1)
 	ret0, _ := ret[0].(*history.HistoryEvent)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddTimeoutWorkflowEvent indicates an expected call of AddTimeoutWorkflowEvent.
-func (mr *MockMutableStateMockRecorder) AddTimeoutWorkflowEvent(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockMutableStateMockRecorder) AddTimeoutWorkflowEvent(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTimeoutWorkflowEvent", reflect.TypeOf((*MockMutableState)(nil).AddTimeoutWorkflowEvent), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTimeoutWorkflowEvent", reflect.TypeOf((*MockMutableState)(nil).AddTimeoutWorkflowEvent), arg0, arg1)
 }
 
 // AddTimerCanceledEvent mocks base method.
@@ -768,18 +768,18 @@ func (mr *MockMutableStateMockRecorder) AddWorkflowExecutionStartedEventWithOpti
 }
 
 // AddWorkflowExecutionTerminatedEvent mocks base method.
-func (m *MockMutableState) AddWorkflowExecutionTerminatedEvent(firstEventID int64, reason string, details *common.Payloads, identity string, deleteAfterTerminate bool, links []*common.Link) (*history.HistoryEvent, error) {
+func (m *MockMutableState) AddWorkflowExecutionTerminatedEvent(reason string, details *common.Payloads, identity string, deleteAfterTerminate bool, links []*common.Link) (*history.HistoryEvent, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddWorkflowExecutionTerminatedEvent", firstEventID, reason, details, identity, deleteAfterTerminate, links)
+	ret := m.ctrl.Call(m, "AddWorkflowExecutionTerminatedEvent", reason, details, identity, deleteAfterTerminate, links)
 	ret0, _ := ret[0].(*history.HistoryEvent)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddWorkflowExecutionTerminatedEvent indicates an expected call of AddWorkflowExecutionTerminatedEvent.
-func (mr *MockMutableStateMockRecorder) AddWorkflowExecutionTerminatedEvent(firstEventID, reason, details, identity, deleteAfterTerminate, links any) *gomock.Call {
+func (mr *MockMutableStateMockRecorder) AddWorkflowExecutionTerminatedEvent(reason, details, identity, deleteAfterTerminate, links any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddWorkflowExecutionTerminatedEvent", reflect.TypeOf((*MockMutableState)(nil).AddWorkflowExecutionTerminatedEvent), firstEventID, reason, details, identity, deleteAfterTerminate, links)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddWorkflowExecutionTerminatedEvent", reflect.TypeOf((*MockMutableState)(nil).AddWorkflowExecutionTerminatedEvent), reason, details, identity, deleteAfterTerminate, links)
 }
 
 // AddWorkflowExecutionTimeSkippingTransitionedEvent mocks base method.

--- a/service/history/ndc/events_reapplier_test.go
+++ b/service/history/ndc/events_reapplier_test.go
@@ -454,10 +454,8 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Termination(
 	dedupResource := definition.NewEventReappliedID(runID, event.GetEventId(), event.GetVersion())
 	msCurrent.EXPECT().IsResourceDuplicated(dedupResource).Return(false)
 	msCurrent.EXPECT().UpdateDuplicatedResource(dedupResource)
-	msCurrent.EXPECT().GetNextEventID().Return(int64(2))
 	msCurrent.EXPECT().GetStartedWorkflowTask().Return(nil)
 	msCurrent.EXPECT().AddWorkflowExecutionTerminatedEvent(
-		int64(2),
 		event.GetWorkflowExecutionTerminatedEventAttributes().GetReason(),
 		event.GetWorkflowExecutionTerminatedEventAttributes().GetDetails(),
 		event.GetWorkflowExecutionTerminatedEventAttributes().GetIdentity(),

--- a/service/history/ndc/workflow.go
+++ b/service/history/ndc/workflow.go
@@ -281,19 +281,12 @@ func (r *WorkflowImpl) terminateMutableState(
 		})
 	}
 
-	eventBatchFirstEventID := r.GetMutableState().GetNextEventID()
-	wtFailedEvent, err := r.failWorkflowTask()
-	if err != nil {
+	if _, err := r.failWorkflowTask(); err != nil {
 		return err
 	}
 
-	if wtFailedEvent != nil {
-		eventBatchFirstEventID = wtFailedEvent.GetEventId()
-	}
-
 	// do not persist the change right now, Workflow requires transaction
-	_, err = r.mutableState.AddWorkflowExecutionTerminatedEvent(
-		eventBatchFirstEventID,
+	_, err := r.mutableState.AddWorkflowExecutionTerminatedEvent(
 		common.FailureReasonWorkflowTerminationDueToVersionConflict,
 		payloads.EncodeString(fmt.Sprintf("terminated by version: %v", incomingLastWriteVersion)),
 		consts.IdentityHistoryService,

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -555,7 +555,6 @@ func (s *workflowResetterSuite) TestTerminateWorkflow() {
 	).Return(&historypb.HistoryEvent{EventId: wtFailedEventID}, nil)
 	mutableState.EXPECT().FlushBufferedEvents()
 	mutableState.EXPECT().AddWorkflowExecutionTerminatedEvent(
-		wtFailedEventID,
 		terminateReason,
 		nil,
 		consts.IdentityResetter,
@@ -1249,11 +1248,9 @@ func (s *workflowResetterSuite) TestReapplyEvents() {
 					}
 				case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED:
 					if !tc.isReset {
-						ms.EXPECT().GetNextEventID().Return(event.GetEventId() + 1)
 						ms.EXPECT().GetStartedWorkflowTask().Return(nil)
 						attr := event.GetWorkflowExecutionTerminatedEventAttributes()
 						ms.EXPECT().AddWorkflowExecutionTerminatedEvent(
-							event.GetEventId()+1,
 							attr.GetReason(),
 							attr.GetDetails(),
 							attr.GetIdentity(),

--- a/service/history/ndc/workflow_test.go
+++ b/service/history/ndc/workflow_test.go
@@ -266,7 +266,7 @@ func (s *workflowSuite) TestSuppressWorkflowBy_Terminate() {
 	s.mockMutableState.EXPECT().FlushBufferedEvents()
 
 	s.mockMutableState.EXPECT().AddWorkflowExecutionTerminatedEvent(
-		wtFailedEventID, common.FailureReasonWorkflowTerminationDueToVersionConflict, gomock.Any(), consts.IdentityHistoryService, false, nil,
+		common.FailureReasonWorkflowTerminationDueToVersionConflict, gomock.Any(), consts.IdentityHistoryService, false, nil,
 	).Return(&historypb.HistoryEvent{}, nil)
 
 	// if workflow is in zombie or finished state, keep as is

--- a/service/history/transfer_queue_active_task_executor_test.go
+++ b/service/history/transfer_queue_active_task_executor_test.go
@@ -1276,7 +1276,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_ParentW
 
 	taskID := s.mustGenerateTaskID()
 	// Simulate termination due to reset.
-	event, err = mutableState.AddWorkflowExecutionTerminatedEvent(event.GetEventId(), "some reason", nil, consts.IdentityResetter, false, nil)
+	event, err = mutableState.AddWorkflowExecutionTerminatedEvent("some reason", nil, consts.IdentityResetter, false, nil)
 	s.NoError(err)
 
 	transferTask := &tasks.CloseExecutionTask{

--- a/service/history/transfer_queue_standby_task_executor_test.go
+++ b/service/history/transfer_queue_standby_task_executor_test.go
@@ -1289,7 +1289,6 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessStartChildExecution_S
 
 	// workflow closed && child started && parent close policy is abandon
 	event, err = mutableState.AddTimeoutWorkflowEvent(
-		mutableState.GetNextEventID(),
 		enumspb.RETRY_STATE_RETRY_POLICY_NOT_SET,
 		uuid.NewString(),
 	)

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -4926,7 +4926,6 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionFailedEvent(
 }
 
 func (ms *MutableStateImpl) AddTimeoutWorkflowEvent(
-	firstEventID int64,
 	retryState enumspb.RetryState,
 	newExecutionRunID string,
 ) (*historypb.HistoryEvent, error) {
@@ -4935,8 +4934,8 @@ func (ms *MutableStateImpl) AddTimeoutWorkflowEvent(
 		return nil, err
 	}
 
-	event := ms.hBuilder.AddTimeoutWorkflowEvent(retryState, newExecutionRunID)
-	if err := ms.ApplyWorkflowExecutionTimedoutEvent(firstEventID, event); err != nil {
+	event, batchID := ms.hBuilder.AddTimeoutWorkflowEvent(retryState, newExecutionRunID)
+	if err := ms.ApplyWorkflowExecutionTimedoutEvent(batchID, event); err != nil {
 		return nil, err
 	}
 	// TODO merge active & passive task generation
@@ -4951,7 +4950,7 @@ func (ms *MutableStateImpl) AddTimeoutWorkflowEvent(
 }
 
 func (ms *MutableStateImpl) ApplyWorkflowExecutionTimedoutEvent(
-	firstEventID int64,
+	batchID int64,
 	event *historypb.HistoryEvent,
 ) error {
 	if _, err := ms.UpdateWorkflowStateStatus(
@@ -4960,7 +4959,7 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionTimedoutEvent(
 	); err != nil {
 		return err
 	}
-	ms.executionInfo.CompletionEventBatchId = firstEventID // Used when completion event needs to be loaded from database
+	ms.executionInfo.CompletionEventBatchId = batchID // Used when completion event needs to be loaded from database
 	ms.executionInfo.NewExecutionRunId = event.GetWorkflowExecutionTimedOutEventAttributes().GetNewExecutionRunId()
 	ms.executionInfo.CloseTime = event.GetEventTime()
 	ms.ClearStickyTaskQueue()
@@ -5541,7 +5540,6 @@ func (ms *MutableStateImpl) AddRecordMarkerEvent(
 }
 
 func (ms *MutableStateImpl) AddWorkflowExecutionTerminatedEvent(
-	firstEventID int64,
 	reason string,
 	details *commonpb.Payloads,
 	identity string,
@@ -5553,8 +5551,8 @@ func (ms *MutableStateImpl) AddWorkflowExecutionTerminatedEvent(
 		return nil, err
 	}
 
-	event := ms.hBuilder.AddWorkflowExecutionTerminatedEvent(reason, details, identity, links)
-	if err := ms.ApplyWorkflowExecutionTerminatedEvent(firstEventID, event); err != nil {
+	event, batchID := ms.hBuilder.AddWorkflowExecutionTerminatedEvent(reason, details, identity, links)
+	if err := ms.ApplyWorkflowExecutionTerminatedEvent(batchID, event); err != nil {
 		return nil, err
 	}
 	// TODO merge active & passive task generation
@@ -6077,7 +6075,7 @@ func (ms *MutableStateImpl) updateVersioningOverride(
 }
 
 func (ms *MutableStateImpl) ApplyWorkflowExecutionTerminatedEvent(
-	firstEventID int64,
+	batchID int64,
 	event *historypb.HistoryEvent,
 ) error {
 	if _, err := ms.UpdateWorkflowStateStatus(
@@ -6086,7 +6084,7 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionTerminatedEvent(
 	); err != nil {
 		return err
 	}
-	ms.executionInfo.CompletionEventBatchId = firstEventID // Used when completion event needs to be loaded from database
+	ms.executionInfo.CompletionEventBatchId = batchID // Used when completion event needs to be loaded from database
 	ms.executionInfo.NewExecutionRunId = ""
 	ms.executionInfo.CloseTime = event.GetEventTime()
 	ms.ClearStickyTaskQueue()
@@ -6183,7 +6181,6 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionSignaled(
 
 func (ms *MutableStateImpl) AddContinueAsNewEvent(
 	ctx context.Context,
-	firstEventID int64,
 	workflowTaskCompletedEventID int64,
 	parentNamespace namespace.Name,
 	command *commandpb.ContinueAsNewWorkflowExecutionCommandAttributes,
@@ -6224,7 +6221,7 @@ func (ms *MutableStateImpl) AddContinueAsNewEvent(
 		}
 	}
 
-	continueAsNewEvent := ms.hBuilder.AddContinuedAsNewEvent(
+	continueAsNewEvent, batchID := ms.hBuilder.AddContinuedAsNewEvent(
 		workflowTaskCompletedEventID,
 		newRunID,
 		command,
@@ -6277,7 +6274,7 @@ func (ms *MutableStateImpl) AddContinueAsNewEvent(
 	}
 
 	if err = ms.ApplyWorkflowExecutionContinuedAsNewEvent(
-		firstEventID,
+		batchID,
 		continueAsNewEvent,
 	); err != nil {
 		return nil, nil, err
@@ -6320,7 +6317,7 @@ func rolloverAutoResetPointsWithExpiringTime(
 }
 
 func (ms *MutableStateImpl) ApplyWorkflowExecutionContinuedAsNewEvent(
-	firstEventID int64,
+	batchID int64,
 	continueAsNewEvent *historypb.HistoryEvent,
 ) error {
 	if _, err := ms.UpdateWorkflowStateStatus(
@@ -6329,7 +6326,7 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionContinuedAsNewEvent(
 	); err != nil {
 		return err
 	}
-	ms.executionInfo.CompletionEventBatchId = firstEventID // Used when completion event needs to be loaded from database
+	ms.executionInfo.CompletionEventBatchId = batchID // Used when completion event needs to be loaded from database
 	ms.executionInfo.NewExecutionRunId = continueAsNewEvent.GetWorkflowExecutionContinuedAsNewEventAttributes().GetNewExecutionRunId()
 	ms.executionInfo.CloseTime = continueAsNewEvent.GetEventTime()
 	ms.ClearStickyTaskQueue()

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -2672,7 +2672,6 @@ func (s *mutableStateSuite) TestAddContinueAsNewEvent_Default() {
 	_, newRunMutableState, err := s.mutableState.AddContinueAsNewEvent(
 		context.Background(),
 		workflowTaskCompletedEvent.GetEventId(),
-		workflowTaskCompletedEvent.GetEventId(),
 		"",
 		&commandpb.ContinueAsNewWorkflowExecutionCommandAttributes{
 			// All other fields will default to those in the current run.
@@ -8908,4 +8907,44 @@ func (s *mutableStateSuite) TestAddStartChildWorkflowExecutionInitiatedEvent_Ini
 	)
 	s.NoError(err)
 	s.Equal(event.GetEventId(), ci.InitiatedEventBatchId)
+}
+
+func (s *mutableStateSuite) TestAddTimeoutWorkflowEvent_CompletionEventBatchID() {
+	s.scheduleCompletedWFTForBatchIDTest()
+
+	event, err := s.mutableState.AddTimeoutWorkflowEvent(
+		enumspb.RETRY_STATE_RETRY_POLICY_NOT_SET,
+		"",
+	)
+	s.NoError(err)
+	s.Equal(event.GetEventId(), s.mutableState.GetExecutionInfo().CompletionEventBatchId)
+}
+
+func (s *mutableStateSuite) TestAddWorkflowExecutionTerminatedEvent_CompletionEventBatchID() {
+	s.scheduleCompletedWFTForBatchIDTest()
+
+	event, err := s.mutableState.AddWorkflowExecutionTerminatedEvent(
+		"some reason", nil, "identity", false, nil,
+	)
+	s.NoError(err)
+	s.Equal(event.GetEventId(), s.mutableState.GetExecutionInfo().CompletionEventBatchId)
+}
+
+func (s *mutableStateSuite) TestAddContinueAsNewEvent_CompletionEventBatchID() {
+	_, completedEvent := s.scheduleCompletedWFTForBatchIDTest()
+
+	s.mockEventsCache.EXPECT().GetEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&historypb.HistoryEvent{}, nil).AnyTimes()
+
+	event, _, err := s.mutableState.AddContinueAsNewEvent(
+		context.Background(),
+		completedEvent.GetEventId(),
+		"",
+		&commandpb.ContinueAsNewWorkflowExecutionCommandAttributes{
+			WorkflowRunTimeout: s.mutableState.GetExecutionInfo().WorkflowRunTimeout,
+		},
+		nil,
+	)
+	s.NoError(err)
+	s.Equal(event.GetEventId(), s.mutableState.GetExecutionInfo().CompletionEventBatchId)
 }

--- a/service/history/workflow/util.go
+++ b/service/history/workflow/util.go
@@ -75,34 +75,26 @@ func TimeoutWorkflow(
 	continuedRunID string,
 ) error {
 
-	// Check TerminateWorkflow comment bellow.
-	eventBatchFirstEventID := mutableState.GetNextEventID()
 	if workflowTask := mutableState.GetStartedWorkflowTask(); workflowTask != nil {
-		wtFailedEvent, err := failWorkflowTask(
+		if _, err := failWorkflowTask(
 			mutableState,
 			workflowTask,
 			enumspb.WORKFLOW_TASK_FAILED_CAUSE_FORCE_CLOSE_COMMAND,
-		)
-		if err != nil {
+		); err != nil {
 			return err
-		}
-		if wtFailedEvent != nil {
-			eventBatchFirstEventID = wtFailedEvent.GetEventId()
 		}
 	}
 
 	_, err := mutableState.AddTimeoutWorkflowEvent(
-		eventBatchFirstEventID,
 		retryState,
 		continuedRunID,
 	)
 	return err
 }
 
-// TerminateWorkflow will write a WorkflowExecutionTerminated event with a fresh
-// batch ID. Do not use for situations where the WorkflowExecutionTerminated
-// event must fall within an existing event batch (for example, if you've already
-// failed a workflow task via `failWorkflowTask` and have an event batch ID).
+// TerminateWorkflow writes a WorkflowExecutionTerminated event. If a workflow
+// task is currently started it is failed first, and then the terminate event
+// is added.
 func TerminateWorkflow(
 	mutableState historyi.MutableState,
 	terminateReason string,
@@ -112,31 +104,17 @@ func TerminateWorkflow(
 	links []*commonpb.Link,
 ) error {
 
-	// Terminate workflow is written as a separate batch and might result in more than one event
-	// if there is started WT which needs to be failed before.
-	// Failing speculative WT creates 3 events: WTScheduled, WTStarted, and WTFailed.
-	// First 2 goes to separate batch and eventBatchFirstEventID has to point to WTFailed event.
-	// Failing transient WT doesn't create any events at all and wtFailedEvent is nil.
-	// WTFailed event wasn't created (because there were no WT or WT was transient),
-	// then eventBatchFirstEventID points to TerminateWorkflow event (which is next event).
-	eventBatchFirstEventID := mutableState.GetNextEventID()
-
 	if workflowTask := mutableState.GetStartedWorkflowTask(); workflowTask != nil {
-		wtFailedEvent, err := failWorkflowTask(
+		if _, err := failWorkflowTask(
 			mutableState,
 			workflowTask,
 			enumspb.WORKFLOW_TASK_FAILED_CAUSE_FORCE_CLOSE_COMMAND,
-		)
-		if err != nil {
+		); err != nil {
 			return err
-		}
-		if wtFailedEvent != nil {
-			eventBatchFirstEventID = wtFailedEvent.GetEventId()
 		}
 	}
 
 	_, err := mutableState.AddWorkflowExecutionTerminatedEvent(
-		eventBatchFirstEventID,
 		terminateReason,
 		terminateDetails,
 		terminateIdentity,

--- a/service/history/workflow/workflow_test/mutable_state_impl_test.go
+++ b/service/history/workflow/workflow_test/mutable_state_impl_test.go
@@ -411,7 +411,7 @@ func TestGetNexusCompletion(t *testing.T) {
 		{
 			name: "termination",
 			mutateState: func(mutableState historyi.MutableState) (*historypb.HistoryEvent, error) {
-				return mutableState.AddWorkflowExecutionTerminatedEvent(mutableState.GetNextEventID(), "dont care", nil, "identity", false, nil)
+				return mutableState.AddWorkflowExecutionTerminatedEvent("dont care", nil, "identity", false, nil)
 			},
 			verifyCompletion: func(t *testing.T, event *historypb.HistoryEvent, completion nexusrpc.CompleteOperationOptions) {
 				require.NotNil(t, completion.Error)


### PR DESCRIPTION
## What changed?
Change `HistoryBuilder.Add*Event` for Terminate, Timeout and ContinueAsNew events to return batchID alongside the event, so that the callers that previously computed their own batchID just read it from there. Simplifies `TerminateWorkflow` and `TimeoutWorkflow` as they no longer have to track `eventBatchFirstEventID`.

Stacked on https://github.com/temporalio/temporal/pull/10412

## Why?
Pushing batching knowledge to every caller was already error-prone, but after https://github.com/temporalio/temporal/pull/10357 it is also wrong, since the event may fall on an unexpected batch.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [ ] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
It's a bit hard to track why the code in TerminateWorkflow guesses the batch id, even though it could have get it from the EventStore, like this PR does. So the risk is that there is some case that I'm not taking into the account.
