### PR TITLE
Adds StateSizeBytes to DescribeNexusOperation

### DIFF
--- a/chasm/lib/nexusoperation/operation.go
+++ b/chasm/lib/nexusoperation/operation.go
@@ -539,6 +539,7 @@ func (o *Operation) buildExecutionInfo(ctx chasm.Context) *nexuspb.NexusOperatio
 		RequestId:               o.RequestId,
 		OperationToken:          o.OperationToken,
 		StateTransitionCount:    ctx.ExecutionInfo().StateTransitionCount,
+		StateSizeBytes:          int64(ctx.ExecutionInfo().ApproximateStateSize),
 		SearchAttributes: &commonpb.SearchAttributes{
 			IndexedFields: o.Visibility.Get(ctx).CustomSearchAttributes(ctx),
 		},

--- a/chasm/lib/workflow/nexus_service.go
+++ b/chasm/lib/workflow/nexus_service.go
@@ -63,9 +63,9 @@ func (h *workflowServiceNexusHandler) signalWithStartWorkflowExecution(
 func mustNewWorkflowServiceNexusHandler(
 	handler *workflowServiceNexusHandler,
 ) *nexus.Service {
-	svc := nexus.NewService(workflowservicenexus.WorkflowService.ServiceName)
+	svc := nexus.NewService(workflowservicenexus.TemporalAPIWorkflowserviceV1WorkflowService.ServiceName)
 	svc.MustRegister(nexus.NewSyncOperation(
-		workflowservicenexus.WorkflowService.SignalWithStartWorkflowExecution.Name(),
+		workflowservicenexus.TemporalAPIWorkflowserviceV1WorkflowService.SignalWithStartWorkflowExecution.Name(),
 		handler.signalWithStartWorkflowExecution,
 	))
 	return svc
@@ -130,10 +130,10 @@ func NewWorkflowServiceNexusServiceProcessor(
 	saMapperProvider searchattribute.MapperProvider,
 	saValidator *searchattribute.Validator,
 ) *chasm.NexusServiceProcessor {
-	sp := chasm.NewNexusServiceProcessor(workflowservicenexus.WorkflowService.ServiceName)
+	sp := chasm.NewNexusServiceProcessor(workflowservicenexus.TemporalAPIWorkflowserviceV1WorkflowService.ServiceName)
 	op := SignalWithStartOperationProcessor{validator: NewValidator(config, saMapperProvider, saValidator)}
 	sp.MustRegisterOperation(
-		workflowservicenexus.WorkflowService.SignalWithStartWorkflowExecution.Name(),
+		workflowservicenexus.TemporalAPIWorkflowserviceV1WorkflowService.SignalWithStartWorkflowExecution.Name(),
 		chasm.NewRegisterableNexusOperationProcessor(op),
 	)
 	return sp

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
-	go.temporal.io/api v1.62.13-0.20260522153111-260c04482807
+	go.temporal.io/api v1.62.13-0.20260528183409-9a920e9052f9
 	go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2
 	go.temporal.io/sdk v1.41.1
 	go.uber.org/fx v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -471,8 +471,12 @@ go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0 h1:R
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0/go.mod h1:I89cynRj8y+383o7tEQVg2SVA6SRgDVIouWPUVXjx0U=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0 h1:CQvJSldHRUN6Z8jsUeYv8J0lXRvygALXIzsmAeCcZE0=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0/go.mod h1:xSQ+mEfJe/GjK1LXEyVOoSI1N9JV9ZI923X5kup43W4=
+go.temporal.io/api v1.62.12 h1:627rVnItegQmrszg1bH4vfyc/1uNo5qCereCNkvZefw=
+go.temporal.io/api v1.62.12/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/api v1.62.13-0.20260522153111-260c04482807 h1:/w/PvtpSFE7WcBOxHgC1MpZ8SC8GVMjsGK+pstKnYFA=
 go.temporal.io/api v1.62.13-0.20260522153111-260c04482807/go.mod h1:0k75tRljEuELWGeXjEZZO7zYqBln4+1FrG6+IMOMy7Q=
+go.temporal.io/api v1.62.13-0.20260528183409-9a920e9052f9 h1:iTBajUOTXPHuhSsr4ao5rrSX5ASxenaRBgl2vcvnHrY=
+go.temporal.io/api v1.62.13-0.20260528183409-9a920e9052f9/go.mod h1:0k75tRljEuELWGeXjEZZO7zYqBln4+1FrG6+IMOMy7Q=
 go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2 h1:1hKeH3GyR6YD6LKMHGCZ76t6h1Sgha0hXVQBxWi3dlQ=
 go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2/go.mod h1:T8dnzVPeO+gaUTj9eDgm/lT2lZH4+JXNvrGaQGyVi50=
 go.temporal.io/sdk v1.41.1 h1:yOpvsHyDD1lNuwlGBv/SUodCPhjv9nDeC9lLHW/fJUA=

--- a/go.sum
+++ b/go.sum
@@ -471,10 +471,6 @@ go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0 h1:R
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0/go.mod h1:I89cynRj8y+383o7tEQVg2SVA6SRgDVIouWPUVXjx0U=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0 h1:CQvJSldHRUN6Z8jsUeYv8J0lXRvygALXIzsmAeCcZE0=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0/go.mod h1:xSQ+mEfJe/GjK1LXEyVOoSI1N9JV9ZI923X5kup43W4=
-go.temporal.io/api v1.62.12 h1:627rVnItegQmrszg1bH4vfyc/1uNo5qCereCNkvZefw=
-go.temporal.io/api v1.62.12/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
-go.temporal.io/api v1.62.13-0.20260522153111-260c04482807 h1:/w/PvtpSFE7WcBOxHgC1MpZ8SC8GVMjsGK+pstKnYFA=
-go.temporal.io/api v1.62.13-0.20260522153111-260c04482807/go.mod h1:0k75tRljEuELWGeXjEZZO7zYqBln4+1FrG6+IMOMy7Q=
 go.temporal.io/api v1.62.13-0.20260528183409-9a920e9052f9 h1:iTBajUOTXPHuhSsr4ao5rrSX5ASxenaRBgl2vcvnHrY=
 go.temporal.io/api v1.62.13-0.20260528183409-9a920e9052f9/go.mod h1:0k75tRljEuELWGeXjEZZO7zYqBln4+1FrG6+IMOMy7Q=
 go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2 h1:1hKeH3GyR6YD6LKMHGCZ76t6h1Sgha0hXVQBxWi3dlQ=

--- a/tests/nexus_standalone_test.go
+++ b/tests/nexus_standalone_test.go
@@ -127,7 +127,7 @@ func (s *NexusStandaloneTestSuite) TestStartStandaloneNexusOperation() {
 					UserMetadata:           testUserMetadata,
 					SearchAttributes:       testSearchAttributes,
 					Attempt:                1,
-				}, info, protorequire.IgnoreFields("state_transition_count", "operation_token", "last_attempt_complete_time", "request_id", "schedule_time", "expiration_time", "execution_duration"))
+				}, info, protorequire.IgnoreFields("state_transition_count", "state_size_bytes", "operation_token", "last_attempt_complete_time", "request_id", "schedule_time", "expiration_time", "execution_duration"))
 				s.NotEmpty(descResp.GetLongPollToken())
 				s.NotEmpty(info.GetRequestId())
 				s.NotNil(info.GetScheduleTime())
@@ -135,6 +135,7 @@ func (s *NexusStandaloneTestSuite) TestStartStandaloneNexusOperation() {
 				s.NotNil(info.GetExecutionDuration())
 				s.NotEmpty(info.GetOperationToken())
 				s.NotNil(info.GetLastAttemptCompleteTime())
+				s.NotZero(info.GetStateSizeBytes())
 			})
 		}
 
@@ -890,6 +891,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 			SearchAttributes:       &commonpb.SearchAttributes{},
 			Attempt:                1,
 			StateTransitionCount:   descResp.GetInfo().GetStateTransitionCount(),
+			StateSizeBytes:         descResp.GetInfo().GetStateSizeBytes(),
 		}, descResp.GetInfo(), protorequire.IgnoreFields("operation_token", "last_attempt_complete_time", "request_id", "schedule_time", "expiration_time", "execution_duration"))
 		s.Equal(enumspb.NEXUS_OPERATION_EXECUTION_STATUS_RUNNING, descResp.GetInfo().GetStatus())
 	})

--- a/tests/signal_with_start_from_workflow_test.go
+++ b/tests/signal_with_start_from_workflow_test.go
@@ -35,8 +35,8 @@ import (
 // target workflow. It is used by TestBothWorkflowsVisibleAfterSWSFromWorkflow to verify
 // end-to-end SDK serialization against the real server.
 func systemNexusSWSWorkflow(ctx workflow.Context, req *workflowservice.SignalWithStartWorkflowExecutionRequest) (string, error) {
-	nc := workflow.NewNexusClient(commonnexus.SystemEndpoint, workflowservicenexus.WorkflowService.ServiceName)
-	fut := nc.ExecuteOperation(ctx, workflowservicenexus.WorkflowService.SignalWithStartWorkflowExecution,
+	nc := workflow.NewNexusClient(commonnexus.SystemEndpoint, workflowservicenexus.TemporalAPIWorkflowserviceV1WorkflowService.ServiceName)
+	fut := nc.ExecuteOperation(ctx, workflowservicenexus.TemporalAPIWorkflowserviceV1WorkflowService.SignalWithStartWorkflowExecution,
 		req,
 		workflow.NexusOperationOptions{})
 	var result workflowservice.SignalWithStartWorkflowExecutionResponse


### PR DESCRIPTION
## What changed?
Add StateSizeBytes to NexusOperationInfo set to ApproximateStateSize
## Why?
Enables storage estimations

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
