### PR TITLE
test: migrate acquire_shard_test.go to parallelsuite.Suite

### DIFF
--- a/tests/acquire_shard_test.go
+++ b/tests/acquire_shard_test.go
@@ -6,35 +6,35 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/suite"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
 )
 
-// AcquireShardSuiteBase is the base test suite for testing acquire shard.
-type AcquireShardSuiteBase struct {
-	testcore.FunctionalTestBase
-	logRecorder *logRecorder
-	logs        chan logRecord
+// AcquireShardSuite tests the shard-acquisition retry behavior under injected
+// persistence faults. Each test method spins up its own dedicated single-shard
+// cluster wired to a custom logRecorder, so it can assert on shard-acquisition
+// log messages.
+type AcquireShardSuite struct {
+	parallelsuite.Suite[*AcquireShardSuite]
 }
 
-// SetupSuite sets up the test suite by setting the log recorder.
-func (s *AcquireShardSuiteBase) SetupSuite() {
-	// Server startup happens in Setup_Suite_, but we don't listen on the log channel until the
-	// _test_ runs. So this needs to be big enough to buffer all of the server startup logs,
-	// which are currently about 190 lines (October 2024).
-	s.logs = make(chan logRecord, 2000)
-	s.logRecorder = newLogRecorder(s.logs)
-	s.Logger = s.logRecorder
+func TestAcquireShardSuite(t *testing.T) {
+	parallelsuite.Run(t, &AcquireShardSuite{})
 }
 
-// TearDownSuite tears down the test suite by shutting down the test cluster after a short delay.
-func (s *AcquireShardSuiteBase) TearDownSuite() {
-	// we need to wait for all components to start before we can safely tear down
-	time.Sleep(time.Second * 5) //nolint:forbidigo
-	s.FunctionalTestBase.TearDownCluster()
+// logRecord represents a call to Info or Error.
+type logRecord struct {
+	msg  string
+	tags []tag.Tag
+}
+
+// logRecorder records log messages to a channel so tests can assert on them.
+type logRecorder struct {
+	log.Logger
+	logs chan logRecord
 }
 
 // newLogRecorder creates a new log recorder. It records all the logs to the given channel.
@@ -45,34 +45,22 @@ func newLogRecorder(logs chan logRecord) *logRecorder {
 	}
 }
 
-// logRecord represents a call to Info or Error.
-type logRecord struct {
-	msg  string
-	tags []tag.Tag
-}
-
-// logRecorder is used to record log messages
-type logRecorder struct {
-	log.Logger
-	logs chan logRecord
-}
-
-// Info records the info message
+// Info records the info message.
 func (r *logRecorder) Info(msg string, tags ...tag.Tag) {
 	r.Logger.Info(msg, tags...)
 	r.record(msg, tags...)
 }
 
-// Error records the error message
+// Error records the error message.
 func (r *logRecorder) Error(msg string, tags ...tag.Tag) {
 	r.Logger.Error(msg, tags...)
 	r.record(msg, tags...)
 }
 
-// Fatal ignores the fatal call
+// Fatal downgrades fatal calls so that cluster-teardown fatals from other
+// components do not abort the test process.
 func (r *logRecorder) Fatal(msg string, tags ...tag.Tag) {
 	r.Logger.Error("FATAL: "+msg, tags...)
-	// Fatal errors sometimes happen for other components we instantiate and tear down during this test.
 }
 
 // record sends a logRecord to the logs channel. If there is no active receiver, the logRecord will be dropped.
@@ -87,38 +75,36 @@ func (r *logRecorder) record(msg string, tags ...tag.Tag) {
 	}
 }
 
-// OwnershipLostErrorSuite is the test suite for testing what happens when acquire shard returns an ownership lost
-// error.
-type OwnershipLostErrorSuite struct {
-	AcquireShardSuiteBase
+// newEnv builds a logs channel + logRecorder and starts a dedicated single-shard
+// cluster wired to that recorder with the given fault injection config. The
+// cluster is torn down automatically via t.Cleanup inside NewEnv.
+func (s *AcquireShardSuite) newEnv(fi *config.FaultInjection) chan logRecord {
+	// Server startup happens when the cluster is created, but the test doesn't
+	// listen on the log channel until afterward. So the buffer needs to be big
+	// enough to hold all server-startup logs, which are currently about 190 lines.
+	logs := make(chan logRecord, 2000)
+	testcore.NewEnv(
+		s.T(),
+		testcore.WithLogger(newLogRecorder(logs)),
+		testcore.WithHistoryShardCount(1),
+		testcore.WithPersistenceFaultInjection(fi),
+	)
+	return logs
 }
 
-// TestAcquireShard_OwnershipLostErrorSuite tests what happens when acquire shard returns an ownership lost error.
-func TestAcquireShard_OwnershipLostErrorSuite(t *testing.T) {
-	t.Parallel()
-	s := new(OwnershipLostErrorSuite)
-	suite.Run(t, s)
-}
+// TestOwnershipLost_DoesNotRetry verifies that we do not retry acquiring the shard
+// when we get an ownership lost error.
+func (s *AcquireShardSuite) TestOwnershipLost_DoesNotRetry() {
+	logs := s.newEnv((&config.FaultInjection{}).
+		WithError(config.ShardStoreName, "UpdateShard", "ShardOwnershipLost", 1.0))
 
-// SetupSuite reads the shard ownership lost error fault injection config from the testdata folder.
-func (s *OwnershipLostErrorSuite) SetupSuite() {
-	s.AcquireShardSuiteBase.SetupSuite()
-	s.FunctionalTestBase.SetupSuiteWithCluster(
-		testcore.WithNumHistoryShards(1),
-		testcore.WithFaultInjectionConfig((&config.FaultInjection{}).
-			WithError(config.ShardStoreName, "UpdateShard", "ShardOwnershipLost", 1.0),
-		))
-}
-
-// TestDoesNotRetry verifies that we do not retry acquiring the shard when we get an ownership lost error.
-func (s *OwnershipLostErrorSuite) TestDoesNotRetry() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	ctx, cancel := context.WithTimeout(s.Context(), time.Second*10)
 	defer cancel()
 
 	numAttempts := 0
 	for {
 		select {
-		case record := <-s.logs:
+		case record := <-logs:
 			msg := strings.ToLower(record.msg)
 			if strings.Contains(msg, "error acquiring shard") {
 				numAttempts++
@@ -141,37 +127,18 @@ func (s *OwnershipLostErrorSuite) TestDoesNotRetry() {
 	}
 }
 
-// DeadlineExceededErrorSuite is the test suite for testing what happens when acquire shard returns a deadline exceeded.
-type DeadlineExceededErrorSuite struct {
-	AcquireShardSuiteBase
-}
+// TestDeadlineExceeded_DoesRetry verifies that we do retry acquiring the shard when
+// we get a deadline exceeded error because that should be considered a transient error.
+func (s *AcquireShardSuite) TestDeadlineExceeded_DoesRetry() {
+	logs := s.newEnv((&config.FaultInjection{}).
+		WithError(config.ShardStoreName, "UpdateShard", "DeadlineExceeded", 1.0))
 
-// TestAcquireShard_DeadlineExceededErrorSuite tests what happens when acquire shard returns a deadline exceeded error
-func TestAcquireShard_DeadlineExceededErrorSuite(t *testing.T) {
-	t.Parallel()
-	s := new(DeadlineExceededErrorSuite)
-	suite.Run(t, s)
-}
-
-// SetupSuite reads the deadline exceeded error targeted fault injection config from the test data folder.
-func (s *DeadlineExceededErrorSuite) SetupSuite() {
-	s.AcquireShardSuiteBase.SetupSuite()
-	s.FunctionalTestBase.SetupSuiteWithCluster(
-		testcore.WithNumHistoryShards(1),
-		testcore.WithFaultInjectionConfig((&config.FaultInjection{}).
-			WithError(config.ShardStoreName, "UpdateShard", "DeadlineExceeded", 1.0),
-		))
-}
-
-// TestDoesRetry verifies that we do retry acquiring the shard when we get a deadline exceeded error because that should
-// be considered a transient error.
-func (s *DeadlineExceededErrorSuite) TestDoesRetry() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	ctx, cancel := context.WithTimeout(s.Context(), time.Second*10)
 	defer cancel()
 
 	for numAttempts := 0; numAttempts < 2; {
 		select {
-		case record := <-s.logs:
+		case record := <-logs:
 			msg := strings.ToLower(record.msg)
 			if strings.Contains(msg, "error acquiring shard") {
 				numAttempts++
@@ -191,44 +158,21 @@ func (s *DeadlineExceededErrorSuite) TestDoesRetry() {
 	}
 }
 
-// EventualSuccessSuite is the test suite for testing what happens when acquire shard returns a deadline exceeded error
-// followed by a successful acquire shard call.
-type EventualSuccessSuite struct {
-	AcquireShardSuiteBase
-}
+// TestEventualSuccess verifies that we eventually succeed in acquiring the shard when
+// we get a deadline exceeded error followed by a successful acquire shard call.
+// To make this test deterministic, the fault injection method seed is fixed.
+func (s *AcquireShardSuite) TestEventualSuccess() {
+	logs := s.newEnv((&config.FaultInjection{}).
+		WithError(config.ShardStoreName, "UpdateShard", "DeadlineExceeded", 0.5).
+		WithMethodSeed(config.ShardStoreName, "UpdateShard", 43))
 
-// TestAcquireShard_EventualSuccess verifies that we eventually succeed in acquiring the shard when we get a deadline
-// exceeded error followed by a successful acquire shard call.
-// To make this test deterministic, we set the seed to in the config file to a fixed value.
-func TestAcquireShard_EventualSuccess(t *testing.T) {
-	t.Parallel()
-	s := new(EventualSuccessSuite)
-	suite.Run(t, s)
-}
-
-// SetupSuite reads the targeted eventual success fault injection config from the testdata folder.
-// This config deterministically causes the first acquire shard call to return a deadline exceeded error, and it causes
-// the next call to return a successful response.
-func (s *EventualSuccessSuite) SetupSuite() {
-	s.AcquireShardSuiteBase.SetupSuite()
-	s.FunctionalTestBase.SetupSuiteWithCluster(
-		testcore.WithNumHistoryShards(1),
-		testcore.WithFaultInjectionConfig((&config.FaultInjection{}).
-			WithError(config.ShardStoreName, "UpdateShard", "DeadlineExceeded", 0.5).
-			WithMethodSeed(config.ShardStoreName, "UpdateShard", 43),
-		))
-}
-
-// TestEventuallySucceeds verifies that we eventually succeed in acquiring the shard when we get a deadline exceeded
-// error followed by a successful acquire shard call.
-func (s *EventualSuccessSuite) TestEventuallySucceeds() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	ctx, cancel := context.WithTimeout(s.Context(), time.Second*10)
 	defer cancel()
 
 	numErrors := 0
 	for {
 		select {
-		case record := <-s.logs:
+		case record := <-logs:
 			msg := strings.ToLower(record.msg)
 			if strings.Contains(msg, "error acquiring shard") {
 				numErrors++

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -102,6 +102,7 @@ type (
 		EnableWorkerService             bool
 		FaultInjectionConfig            *config.FaultInjection
 		NumHistoryShards                int32
+		Logger                          log.Logger
 		SharedCluster                   bool
 		CustomHistoryArchiverFactory    provider.CustomHistoryArchiverFactory
 		CustomVisibilityArchiverFactory provider.CustomVisibilityArchiverFactory
@@ -178,6 +179,14 @@ func WithFaultInjectionConfig(cfg *config.FaultInjection) TestClusterOption {
 func WithNumHistoryShards(n int32) TestClusterOption {
 	return func(params *TestClusterParams) {
 		params.NumHistoryShards = n
+	}
+}
+
+// WithClusterLogger sets a custom logger for the test cluster, used instead of
+// the default test logger. Useful for intercepting server log output.
+func WithClusterLogger(logger log.Logger) TestClusterOption {
+	return func(params *TestClusterParams) {
+		params.Logger = logger
 	}
 }
 
@@ -282,6 +291,11 @@ func (s *FunctionalTestBase) SetupSuiteWithCluster(options ...TestClusterOption)
 
 func (s *FunctionalTestBase) setupCluster(options ...TestClusterOption) {
 	params := ApplyTestClusterOptions(options)
+
+	// A custom logger supplied via WithClusterLogger takes precedence.
+	if params.Logger != nil {
+		s.Logger = params.Logger
+	}
 
 	// NOTE: A suite might set its own logger. Example: AcquireShardSuiteBase.
 	if s.Logger == nil {

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -144,6 +144,27 @@ func WithPersistenceFaultInjection(cfg *config.FaultInjection) TestOption {
 	}
 }
 
+// WithLogger sets a custom logger for the test's cluster, letting a test intercept
+// server log output. This implies a dedicated cluster, since a custom logger cannot
+// be shared across tests.
+func WithLogger(logger log.Logger) TestOption {
+	return func(o *testOptions) {
+		o.dedicatedCluster = true
+		o.clusterOptions = append(o.clusterOptions, WithClusterLogger(logger))
+		o.dedicatedReason = "custom logger used"
+	}
+}
+
+// WithHistoryShardCount sets the number of history shards for the test's cluster.
+// This implies a dedicated cluster, since shard count cannot be changed on a shared cluster.
+func WithHistoryShardCount(n int32) TestOption {
+	return func(o *testOptions) {
+		o.dedicatedCluster = true
+		o.clusterOptions = append(o.clusterOptions, WithNumHistoryShards(n))
+		o.dedicatedReason = "custom history shard count used"
+	}
+}
+
 // WithDynamicConfig overrides a dynamic config setting for the test.
 // For settings that can be namespace-scoped, a namespace constraint is applied.
 // For all others that require a dedicated cluster, this implies `WithDedicatedCluster`.


### PR DESCRIPTION
## What changed?
Migrate `tests/acquire_shard_test.go` away from deprecated `testcore.FunctionalTestBase` and to `parallelsuite`

Adds the supporting `testcore` plumbing the new pattern was missing:
- `WithLogger(log.Logger)` — injects a custom cluster logger via `NewEnv` (wraps a new `WithClusterLogger` `TestClusterOption` + a `Logger` field on `TestClusterParams`, honored in `setupCluster`).
- `WithHistoryShardCount(int32)` — sets the history shard count via `NewEnv`.

## Why?
Part of our ongoing test flakes and migration work.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Could introduce additional flakes by parallelizing tests
