### PR TITLE
Cherry-pick #10278: Rework DeleteSchedule dual-mode delete to not share context metadata (#10278)

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -48,6 +48,7 @@ import (
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/collection"
+	"go.temporal.io/server/common/contextutil"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/enums"
 	"go.temporal.io/server/common/failure"
@@ -4955,16 +4956,32 @@ func (wh *WorkflowHandler) DeleteSchedule(ctx context.Context, request *workflow
 	// Always attempt deletion in both stacks. A schedule may exist in either or
 	// both during dual-stack migration (and a V1 sentinel may linger after a
 	// CHASM-only create). Surface an error only when neither stack succeeded.
+	//
+	// Each path gets its own metadata context so that downstream gRPC trailers
+	// (propagated by TrailerToContextMetadataInterceptor) don't clobber each
+	// other. After both paths complete, the winning side's metadata is copied
+	// into the original context for upstream consumers (e.g. metering).
 	chasmEnabled := wh.chasmSchedulerEnabled(ctx, request.Namespace)
 
+	chasmCtx := contextutil.WithMetadataContext(ctx)
 	var chasmErr error
 	if chasmEnabled {
-		_, chasmErr = wh.deleteScheduleCHASM(ctx, request)
+		_, chasmErr = wh.deleteScheduleCHASM(chasmCtx, request)
 	}
-	_, v1Err := wh.deleteScheduleWorkflow(ctx, request)
+	v1Ctx := contextutil.WithMetadataContext(ctx)
+	_, v1Err := wh.deleteScheduleWorkflow(v1Ctx, request)
 
-	// At least one side actually deleted → success.
+	// At least one side actually deleted -> success.
 	if (chasmEnabled && chasmErr == nil) || v1Err == nil {
+		// CHASM owns the schedule unless it returned a routable error
+		// (NotFound/sentinel/closed), in which case V1 is the owner.
+		winnerCtx := v1Ctx
+		if chasmEnabled && (chasmErr == nil || !isSchedulerErrorLegacyRoutable(chasmErr)) {
+			winnerCtx = chasmCtx
+		}
+		for k, v := range contextutil.ContextMetadataGetAll(winnerCtx) {
+			contextutil.ContextMetadataSet(ctx, k, v)
+		}
 		return &workflowservice.DeleteScheduleResponse{}, nil
 	}
 

--- a/tests/schedule_migration_test.go
+++ b/tests/schedule_migration_test.go
@@ -23,11 +23,17 @@ import (
 	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/rpc/interceptor"
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/testing/parallelsuite"
+	"go.temporal.io/server/service/worker/dummy"
 	"go.temporal.io/server/service/worker/scheduler"
 	"go.temporal.io/server/tests/testcore"
+	"go.uber.org/fx"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -1304,157 +1310,368 @@ func TestScheduleMigrationV1ToV2NoDuplicateRecentActions(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestDeleteScheduleClearsBothStacks verifies that when a schedule exists in
-// both the CHASM (V2) and workflow-backed (V1) stacks for the same scheduleId
-// — as can happen during dual-stack migration — a single frontend
-// DeleteSchedule call removes it from both stacks.
-func (s *ScheduleMigrationTestSuite) TestDeleteScheduleClearsBothStacks() {
+// TestDeleteScheduleContextMetadata verifies that DeleteSchedule propagates the
+// correct context metadata (workflow-type, workflow-task-queue) for every
+// combination of CHASM and V1 state. This metadata is read by saas-temporal's
+// metering interceptor for action attribution.
+//
+// We assert by reading gRPC response trailers: the frontend's
+// ContextMetadataInterceptor is decorated to setTrailer=true for this test,
+// so any context metadata set during the handler is emitted as trailers that
+// the client can read directly.
+func (s *ScheduleMigrationTestSuite) TestDeleteScheduleContextMetadata() {
 	env := testcore.NewEnv(
 		s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerRouting, true),
+		testcore.WithFxOptions(primitives.FrontendService,
+			fx.Decorate(func(logger log.Logger) *interceptor.ContextMetadataInterceptor {
+				return interceptor.NewContextMetadataInterceptor(true, logger)
+			}),
+		),
 	)
 
-	ctx := testcore.NewContext()
-	sid := testcore.RandomizeStr("sched-delete-both-stacks")
-	wid := testcore.RandomizeStr("sched-delete-both-stacks-wf")
-	wt := testcore.RandomizeStr("sched-delete-both-stacks-wt")
-	tq := testcore.RandomizeStr("tq")
-
-	nsName := env.Namespace().String()
-	nsID := env.NamespaceID().String()
-	sched := &schedulepb.Schedule{
-		Spec: &schedulepb.ScheduleSpec{
-			Interval: []*schedulepb.IntervalSpec{
-				{Interval: durationpb.New(1 * time.Hour)},
-			},
-		},
-		Action: &schedulepb.ScheduleAction{
-			Action: &schedulepb.ScheduleAction_StartWorkflow{
-				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
-					WorkflowId:   wid,
-					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: tq, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+	newSched := func() (sid, wt, tq string, sched *schedulepb.Schedule) {
+		sid = testcore.RandomizeStr("sid")
+		wt = testcore.RandomizeStr("wt")
+		tq = testcore.RandomizeStr("tq")
+		sched = &schedulepb.Schedule{
+			Spec: &schedulepb.ScheduleSpec{
+				Interval: []*schedulepb.IntervalSpec{
+					{Interval: durationpb.New(1 * time.Hour)},
 				},
 			},
-		},
-	}
-
-	// Create the CHASM schedule directly.
-	_, err := env.GetTestCluster().SchedulerClient().CreateSchedule(
-		ctx,
-		&schedulerpb.CreateScheduleRequest{
-			NamespaceId: nsID,
-			FrontendRequest: &workflowservice.CreateScheduleRequest{
-				Namespace:  nsName,
-				ScheduleId: sid,
-				Schedule:   sched,
-				Identity:   "test",
-				RequestId:  testcore.RandomizeStr("request-id"),
+			Action: &schedulepb.ScheduleAction{
+				Action: &schedulepb.ScheduleAction_StartWorkflow{
+					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+						WorkflowId:   testcore.RandomizeStr("wid"),
+						WorkflowType: &commonpb.WorkflowType{Name: wt},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: tq, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					},
+				},
 			},
-		},
-	)
-	s.NoError(err)
-
-	// Create the V1 (workflow-backed) scheduler directly with the same ID.
-	startArgs := &schedulespb.StartScheduleArgs{
-		Schedule: sched,
-		State: &schedulespb.InternalState{
-			Namespace:     nsName,
-			NamespaceId:   nsID,
-			ScheduleId:    sid,
-			ConflictToken: scheduler.InitialConflictToken,
-		},
+		}
+		return
 	}
-	inputPayloads, err := sdk.PreferProtoDataConverter.ToPayloads(startArgs)
-	s.NoError(err)
-	v1WorkflowID := scheduler.WorkflowIDPrefix + sid
-	startReq := &workflowservice.StartWorkflowExecutionRequest{
-		Namespace:                nsName,
-		WorkflowId:               v1WorkflowID,
-		WorkflowType:             &commonpb.WorkflowType{Name: scheduler.WorkflowType},
-		TaskQueue:                &taskqueuepb.TaskQueue{Name: primitives.PerNSWorkerTaskQueue},
-		Input:                    inputPayloads,
-		Identity:                 "test",
-		RequestId:                testcore.RandomizeStr("request-id"),
-		WorkflowIdReusePolicy:    enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
-		WorkflowIdConflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL,
-	}
-	_, err = env.GetTestCluster().HistoryClient().StartWorkflowExecution(
-		ctx,
-		common.CreateHistoryStartWorkflowRequest(nsID, startReq, nil, nil, time.Now().UTC()),
-	)
-	s.NoError(err)
 
-	// Sanity-check: both stacks have an entry for this scheduleId.
-	_, err = env.GetTestCluster().SchedulerClient().DescribeSchedule(
-		ctx,
-		&schedulerpb.DescribeScheduleRequest{
-			NamespaceId:     nsID,
-			FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: nsName, ScheduleId: sid},
-		},
-	)
-	s.NoError(err)
-	v1Desc, err := env.GetTestCluster().HistoryClient().DescribeWorkflowExecution(
-		ctx,
-		&historyservice.DescribeWorkflowExecutionRequest{
-			NamespaceId: nsID,
-			Request: &workflowservice.DescribeWorkflowExecutionRequest{
-				Namespace: nsName,
-				Execution: &commonpb.WorkflowExecution{WorkflowId: v1WorkflowID},
-			},
-		},
-	)
-	s.NoError(err)
-	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, v1Desc.GetWorkflowExecutionInfo().GetStatus())
-
-	// Single frontend DeleteSchedule call should clear both stacks.
-	_, err = env.FrontendClient().DeleteSchedule(ctx, &workflowservice.DeleteScheduleRequest{
-		Namespace:  nsName,
-		ScheduleId: sid,
-		Identity:   "test",
-	})
-	s.NoError(err)
-
-	// CHASM side: the scheduler is marked closed; direct describe rejects with
-	// FailedPrecondition (ErrClosed).
-	_, err = env.GetTestCluster().SchedulerClient().DescribeSchedule(
-		ctx,
-		&schedulerpb.DescribeScheduleRequest{
-			NamespaceId:     nsID,
-			FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: nsName, ScheduleId: sid},
-		},
-	)
-	var failedPreconditionErr *serviceerror.FailedPrecondition
-	s.ErrorAs(err, &failedPreconditionErr)
-
-	// V1 side: the workflow is terminated.
-	s.Eventually(func() bool {
-		desc, descErr := env.GetTestCluster().HistoryClient().DescribeWorkflowExecution(
-			ctx,
-			&historyservice.DescribeWorkflowExecutionRequest{
-				NamespaceId: nsID,
-				Request: &workflowservice.DescribeWorkflowExecutionRequest{
-					Namespace: nsName,
-					Execution: &commonpb.WorkflowExecution{WorkflowId: v1WorkflowID},
+	createCHASMSchedule := func(t *testing.T, sid string, sched *schedulepb.Schedule) {
+		_, err := env.GetTestCluster().SchedulerClient().CreateSchedule(
+			testcore.NewContext(),
+			&schedulerpb.CreateScheduleRequest{
+				NamespaceId: env.NamespaceID().String(),
+				FrontendRequest: &workflowservice.CreateScheduleRequest{
+					Namespace:  env.Namespace().String(),
+					ScheduleId: sid,
+					Schedule:   sched,
+					Identity:   "test",
+					RequestId:  testcore.RandomizeStr("req"),
 				},
 			},
 		)
-		if descErr != nil {
-			return false
-		}
-		return desc.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED
-	}, 10*time.Second, 200*time.Millisecond, "V1 schedule workflow should be terminated")
+		require.NoError(t, err)
+	}
 
-	// Frontend describe should also report the schedule as gone.
-	var notFoundErr *serviceerror.NotFound
-	s.Eventually(func() bool {
-		_, descErr := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  nsName,
-			ScheduleId: sid,
-		})
-		return errors.As(descErr, &notFoundErr)
-	}, 10*time.Second, 200*time.Millisecond, "frontend DescribeSchedule should return NotFound")
+	createCHASMSentinel := func(t *testing.T, sid string) {
+		_, err := env.GetTestCluster().SchedulerClient().CreateSentinel(
+			testcore.NewContext(),
+			&schedulerpb.CreateSentinelRequest{
+				NamespaceId: env.NamespaceID().String(),
+				Namespace:   env.Namespace().String(),
+				ScheduleId:  sid,
+			},
+		)
+		require.NoError(t, err)
+	}
+
+	createV1Scheduler := func(t *testing.T, sid string, sched *schedulepb.Schedule) {
+		startArgs := &schedulespb.StartScheduleArgs{
+			Schedule: sched,
+			State: &schedulespb.InternalState{
+				Namespace:     env.Namespace().String(),
+				NamespaceId:   env.NamespaceID().String(),
+				ScheduleId:    sid,
+				ConflictToken: scheduler.InitialConflictToken,
+			},
+		}
+		inputPayloads, err := sdk.PreferProtoDataConverter.ToPayloads(startArgs)
+		require.NoError(t, err)
+		_, err = env.GetTestCluster().HistoryClient().StartWorkflowExecution(
+			testcore.NewContext(),
+			common.CreateHistoryStartWorkflowRequest(
+				env.NamespaceID().String(),
+				&workflowservice.StartWorkflowExecutionRequest{
+					Namespace:                env.Namespace().String(),
+					WorkflowId:               scheduler.WorkflowIDPrefix + sid,
+					WorkflowType:             &commonpb.WorkflowType{Name: scheduler.WorkflowType},
+					TaskQueue:                &taskqueuepb.TaskQueue{Name: primitives.PerNSWorkerTaskQueue},
+					Input:                    inputPayloads,
+					Identity:                 "test",
+					RequestId:                testcore.RandomizeStr("req"),
+					WorkflowIdReusePolicy:    enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+					WorkflowIdConflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL,
+				},
+				nil, nil, time.Now().UTC(),
+			),
+		)
+		require.NoError(t, err)
+	}
+
+	createV1DummySentinel := func(t *testing.T, sid string) {
+		_, err := env.GetTestCluster().HistoryClient().StartWorkflowExecution(
+			testcore.NewContext(),
+			common.CreateHistoryStartWorkflowRequest(
+				env.NamespaceID().String(),
+				&workflowservice.StartWorkflowExecutionRequest{
+					Namespace:                env.Namespace().String(),
+					WorkflowId:               scheduler.WorkflowIDPrefix + sid,
+					WorkflowType:             &commonpb.WorkflowType{Name: dummy.DummyWFTypeName},
+					TaskQueue:                &taskqueuepb.TaskQueue{Name: primitives.PerNSWorkerTaskQueue},
+					Identity:                 "test",
+					RequestId:                testcore.RandomizeStr("req"),
+					WorkflowIdReusePolicy:    enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+					WorkflowIdConflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL,
+				},
+				nil, nil, time.Now().UTC(),
+			),
+		)
+		require.NoError(t, err)
+	}
+
+	deleteAndAssertMetadata := func(t *testing.T, sid, expectedWfType, expectedTQ string) {
+		var trailer metadata.MD
+		_, err := env.FrontendClient().DeleteSchedule(
+			testcore.NewContext(),
+			&workflowservice.DeleteScheduleRequest{
+				Namespace:  env.Namespace().String(),
+				ScheduleId: sid,
+				Identity:   "test",
+			},
+			grpc.Trailer(&trailer),
+		)
+		require.NoError(t, err)
+		require.Equal(t, []string{expectedWfType}, trailer.Get("workflow-type"),
+			"workflow-type should match the owning stack's metadata")
+		require.Equal(t, []string{expectedTQ}, trailer.Get("workflow-task-queue"),
+			"workflow-task-queue should match the owning stack's metadata")
+	}
+
+	// Subtest: Both stacks have real entries. CHASM metadata wins.
+	s.Run("BothStacks", func(s *ScheduleMigrationTestSuite) {
+		sid, wt, tq, sched := newSched()
+		createCHASMSchedule(s.T(), sid, sched)
+		createV1Scheduler(s.T(), sid, sched)
+		deleteAndAssertMetadata(s.T(), sid, wt, tq)
+	})
+
+	// Subtest: CHASM has real schedule, V1 has dummy sentinel. CHASM metadata wins.
+	s.Run("CHASMOnly_V1Sentinel", func(s *ScheduleMigrationTestSuite) {
+		sid, wt, tq, sched := newSched()
+		createCHASMSchedule(s.T(), sid, sched)
+		createV1DummySentinel(s.T(), sid)
+		deleteAndAssertMetadata(s.T(), sid, wt, tq)
+	})
+
+	// Subtest: CHASM has sentinel, V1 has real scheduler. V1 metadata wins.
+	s.Run("CHASMSentinel_V1Real", func(s *ScheduleMigrationTestSuite) {
+		sid, _, _, sched := newSched()
+		createCHASMSentinel(s.T(), sid)
+		createV1Scheduler(s.T(), sid, sched)
+		deleteAndAssertMetadata(s.T(), sid, scheduler.WorkflowType, primitives.PerNSWorkerTaskQueue)
+	})
+
+	// Subtest: No CHASM entry, V1 has real scheduler. V1 metadata wins.
+	s.Run("V1Only_NoCHASM", func(s *ScheduleMigrationTestSuite) {
+		sid, _, _, sched := newSched()
+		createV1Scheduler(s.T(), sid, sched)
+		deleteAndAssertMetadata(s.T(), sid, scheduler.WorkflowType, primitives.PerNSWorkerTaskQueue)
+	})
+
+	// Subtest: CHASM has sentinel, V1 has nothing. Delete returns error.
+	// Metering skips error responses so metadata content is irrelevant.
+	s.Run("CHASMSentinel_V1Gone", func(s *ScheduleMigrationTestSuite) {
+		sid := testcore.RandomizeStr("sid")
+		createCHASMSentinel(s.T(), sid)
+		_, err := env.FrontendClient().DeleteSchedule(
+			testcore.NewContext(),
+			&workflowservice.DeleteScheduleRequest{
+				Namespace:  env.Namespace().String(),
+				ScheduleId: sid,
+				Identity:   "test",
+			},
+		)
+		var notFoundErr *serviceerror.NotFound
+		s.ErrorAs(err, &notFoundErr)
+		s.NotContains(notFoundErr.Message, "sentinel",
+			"sentinel error should not leak to the client")
+	})
+
+	// Subtest: Neither stack has the schedule. Delete returns error.
+	s.Run("NeitherStack", func(s *ScheduleMigrationTestSuite) {
+		sid := testcore.RandomizeStr("nonexistent")
+		_, err := env.FrontendClient().DeleteSchedule(
+			testcore.NewContext(),
+			&workflowservice.DeleteScheduleRequest{
+				Namespace:  env.Namespace().String(),
+				ScheduleId: sid,
+				Identity:   "test",
+			},
+		)
+		var notFoundErr *serviceerror.NotFound
+		s.ErrorAs(err, &notFoundErr)
+		s.NotContains(notFoundErr.Message, "sentinel",
+			"sentinel error should not leak to the client")
+	})
+}
+
+// TestPatchScheduleContextMetadata verifies that PatchSchedule propagates the
+// correct context metadata for CHASM and V1 schedules.
+func (s *ScheduleMigrationTestSuite) TestPatchScheduleContextMetadata() {
+	env := testcore.NewEnv(
+		s.T(),
+		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
+		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerRouting, true),
+		testcore.WithFxOptions(primitives.FrontendService,
+			fx.Decorate(func(logger log.Logger) *interceptor.ContextMetadataInterceptor {
+				return interceptor.NewContextMetadataInterceptor(true, logger)
+			}),
+		),
+	)
+
+	newSched := func() (sid, wt, tq string, sched *schedulepb.Schedule) {
+		sid = testcore.RandomizeStr("sid")
+		wt = testcore.RandomizeStr("wt")
+		tq = testcore.RandomizeStr("tq")
+		sched = &schedulepb.Schedule{
+			Spec: &schedulepb.ScheduleSpec{
+				Interval: []*schedulepb.IntervalSpec{
+					{Interval: durationpb.New(1 * time.Hour)},
+				},
+			},
+			Action: &schedulepb.ScheduleAction{
+				Action: &schedulepb.ScheduleAction_StartWorkflow{
+					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+						WorkflowId:   testcore.RandomizeStr("wid"),
+						WorkflowType: &commonpb.WorkflowType{Name: wt},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: tq, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					},
+				},
+			},
+		}
+		return
+	}
+
+	createCHASMSchedule := func(t *testing.T, sid string, sched *schedulepb.Schedule) {
+		_, err := env.GetTestCluster().SchedulerClient().CreateSchedule(
+			testcore.NewContext(),
+			&schedulerpb.CreateScheduleRequest{
+				NamespaceId: env.NamespaceID().String(),
+				FrontendRequest: &workflowservice.CreateScheduleRequest{
+					Namespace:  env.Namespace().String(),
+					ScheduleId: sid,
+					Schedule:   sched,
+					Identity:   "test",
+					RequestId:  testcore.RandomizeStr("req"),
+				},
+			},
+		)
+		require.NoError(t, err)
+	}
+
+	createV1Scheduler := func(t *testing.T, sid string, sched *schedulepb.Schedule) {
+		startArgs := &schedulespb.StartScheduleArgs{
+			Schedule: sched,
+			State: &schedulespb.InternalState{
+				Namespace:     env.Namespace().String(),
+				NamespaceId:   env.NamespaceID().String(),
+				ScheduleId:    sid,
+				ConflictToken: scheduler.InitialConflictToken,
+			},
+		}
+		inputPayloads, err := sdk.PreferProtoDataConverter.ToPayloads(startArgs)
+		require.NoError(t, err)
+		_, err = env.GetTestCluster().HistoryClient().StartWorkflowExecution(
+			testcore.NewContext(),
+			common.CreateHistoryStartWorkflowRequest(
+				env.NamespaceID().String(),
+				&workflowservice.StartWorkflowExecutionRequest{
+					Namespace:                env.Namespace().String(),
+					WorkflowId:               scheduler.WorkflowIDPrefix + sid,
+					WorkflowType:             &commonpb.WorkflowType{Name: scheduler.WorkflowType},
+					TaskQueue:                &taskqueuepb.TaskQueue{Name: primitives.PerNSWorkerTaskQueue},
+					Input:                    inputPayloads,
+					Identity:                 "test",
+					RequestId:                testcore.RandomizeStr("req"),
+					WorkflowIdReusePolicy:    enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+					WorkflowIdConflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL,
+				},
+				nil, nil, time.Now().UTC(),
+			),
+		)
+		require.NoError(t, err)
+	}
+
+	patchAndAssertMetadata := func(t *testing.T, sid, expectedWfType, expectedTQ string) {
+		var trailer metadata.MD
+		_, err := env.FrontendClient().PatchSchedule(
+			testcore.NewContext(),
+			&workflowservice.PatchScheduleRequest{
+				Namespace:  env.Namespace().String(),
+				ScheduleId: sid,
+				Patch:      &schedulepb.SchedulePatch{Pause: "test pause"},
+				Identity:   "test",
+				RequestId:  uuid.NewString(),
+			},
+			grpc.Trailer(&trailer),
+		)
+		require.NoError(t, err)
+		require.Equal(t, []string{expectedWfType}, trailer.Get("workflow-type"),
+			"workflow-type should match the owning stack's metadata")
+		require.Equal(t, []string{expectedTQ}, trailer.Get("workflow-task-queue"),
+			"workflow-task-queue should match the owning stack's metadata")
+	}
+
+	// CHASM schedule: metadata should reflect the schedule's action target.
+	s.Run("CHASMSchedule", func(s *ScheduleMigrationTestSuite) {
+		sid, wt, tq, sched := newSched()
+		createCHASMSchedule(s.T(), sid, sched)
+		patchAndAssertMetadata(s.T(), sid, wt, tq)
+	})
+
+	// V1 schedule: metadata should reflect the V1 scheduler workflow.
+	s.Run("V1Schedule", func(s *ScheduleMigrationTestSuite) {
+		sid, _, _, sched := newSched()
+		createV1Scheduler(s.T(), sid, sched)
+		patchAndAssertMetadata(s.T(), sid, scheduler.WorkflowType, primitives.PerNSWorkerTaskQueue)
+	})
+
+	// CHASM sentinel with no V1 workflow: patch should fail.
+	s.Run("CHASMSentinel_V1Gone", func(s *ScheduleMigrationTestSuite) {
+		sid := testcore.RandomizeStr("sid")
+		_, err := env.GetTestCluster().SchedulerClient().CreateSentinel(
+			testcore.NewContext(),
+			&schedulerpb.CreateSentinelRequest{
+				NamespaceId: env.NamespaceID().String(),
+				Namespace:   env.Namespace().String(),
+				ScheduleId:  sid,
+			},
+		)
+		s.NoError(err)
+
+		_, err = env.FrontendClient().PatchSchedule(
+			testcore.NewContext(),
+			&workflowservice.PatchScheduleRequest{
+				Namespace:  env.Namespace().String(),
+				ScheduleId: sid,
+				Patch:      &schedulepb.SchedulePatch{Pause: "test"},
+				Identity:   "test",
+				RequestId:  uuid.NewString(),
+			},
+		)
+		var notFoundErr *serviceerror.NotFound
+		s.ErrorAs(err, &notFoundErr)
+		s.NotContains(notFoundErr.Message, "sentinel",
+			"sentinel error should not leak to the client")
+	})
 }
 
 // TestScheduleMigration_StaleRunningDoesNotSkipPending guards the race fix in

--- a/tests/testcore/onebox.go
+++ b/tests/testcore/onebox.go
@@ -825,7 +825,7 @@ func (c *TemporalImpl) newRPCFactory(
 		int(httpPort),
 		frontendTLSConfig,
 		options,
-		map[primitives.ServiceName][]grpc.DialOption{},
+		resource.PerServiceDialOptionsProvider(logger),
 		monitor,
 	), nil
 }

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -136,24 +136,24 @@ type clusterPool struct {
 	dedicated *pool
 }
 
-func (p *clusterPool) get(t *testing.T, dedicated bool, dynamicConfig map[dynamicconfig.Key]any) *FunctionalTestBase {
-	if dedicated || len(dynamicConfig) > 0 {
-		return p.getDedicated(t, dynamicConfig)
+func (p *clusterPool) get(t *testing.T, dedicated bool, dynamicConfig map[dynamicconfig.Key]any, clusterOpts []TestClusterOption) *FunctionalTestBase {
+	if dedicated || len(dynamicConfig) > 0 || len(clusterOpts) > 0 {
+		return p.getDedicated(t, dynamicConfig, clusterOpts)
 	}
 	return p.getShared(t)
 }
 
 func (p *clusterPool) getShared(t *testing.T) *FunctionalTestBase {
 	return p.shared.get(t, func() *FunctionalTestBase {
-		return p.createCluster(t, nil, true)
+		return p.createCluster(t, nil, true, nil)
 	})
 }
 
-func (p *clusterPool) getDedicated(t *testing.T, dynamicConfig map[dynamicconfig.Key]any) *FunctionalTestBase {
-	if len(dynamicConfig) > 0 {
-		// Custom dynamic config requires a fresh cluster (can't reuse).
+func (p *clusterPool) getDedicated(t *testing.T, dynamicConfig map[dynamicconfig.Key]any, clusterOpts []TestClusterOption) *FunctionalTestBase {
+	if len(dynamicConfig) > 0 || len(clusterOpts) > 0 {
+		// Custom config or fx options require a fresh cluster (can't reuse).
 		p.dedicated.acquireSlot(t)
-		cluster := p.createCluster(t, dynamicConfig, false)
+		cluster := p.createCluster(t, dynamicConfig, false, clusterOpts)
 
 		// Register cleanup to tear down the cluster when the test completes.
 		t.Cleanup(func() {
@@ -165,13 +165,13 @@ func (p *clusterPool) getDedicated(t *testing.T, dynamicConfig map[dynamicconfig
 		return cluster
 	}
 
-	// If no custom dynamic config is provided, reuse an existing cluster.
+	// If no custom config is provided, reuse an existing cluster.
 	return p.dedicated.get(t, func() *FunctionalTestBase {
-		return p.createCluster(t, nil, false)
+		return p.createCluster(t, nil, false, nil)
 	})
 }
 
-func (p *clusterPool) createCluster(t *testing.T, dynamicConfig map[dynamicconfig.Key]any, shared bool) *FunctionalTestBase {
+func (p *clusterPool) createCluster(t *testing.T, dynamicConfig map[dynamicconfig.Key]any, shared bool, clusterOpts []TestClusterOption) *FunctionalTestBase {
 	tbase := &FunctionalTestBase{}
 	tbase.SetT(t)
 
@@ -182,6 +182,7 @@ func (p *clusterPool) createCluster(t *testing.T, dynamicConfig map[dynamicconfi
 	if len(dynamicConfig) > 0 {
 		opts = append(opts, WithDynamicConfigOverrides(dynamicConfig))
 	}
+	opts = append(opts, clusterOpts...)
 
 	tbase.setupCluster(opts...)
 

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -23,9 +23,11 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/testing/taskpoller"
 	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/common/testing/testvars"
+	"go.uber.org/fx"
 	"go.temporal.io/server/components/nexusoperations"
 	"google.golang.org/grpc"
 )
@@ -85,7 +87,9 @@ type TestOption func(*testOptions)
 
 type testOptions struct {
 	dedicatedCluster      bool
+	dedicatedReason       string
 	dynamicConfigSettings []dynamicConfigOverride
+	clusterOptions        []TestClusterOption
 	timeout               time.Duration
 }
 
@@ -105,6 +109,17 @@ func WithDedicatedCluster() TestOption {
 // Deprecated: this option is no longer required and will be removed once all callers have been updated.
 func WithSdkWorker() TestOption {
 	return func(o *testOptions) {
+	}
+}
+
+// WithFxOptions appends fx options to a specific service's fx graph. This
+// implies a dedicated cluster because custom fx options cannot be shared
+// across tests.
+func WithFxOptions(serviceName primitives.ServiceName, opts ...fx.Option) TestOption {
+	return func(o *testOptions) {
+		o.dedicatedCluster = true
+		o.clusterOptions = append(o.clusterOptions, WithFxOptionsForService(serviceName, opts...))
+		o.dedicatedReason = "custom fx options used"
 	}
 }
 
@@ -154,7 +169,7 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 	}
 
 	// Obtain the test cluster from the pool.
-	base := testClusterPool.get(t, options.dedicatedCluster, startupConfig)
+	base := testClusterPool.get(t, options.dedicatedCluster, startupConfig, options.clusterOptions)
 	cluster := base.GetTestCluster()
 
 	// Create a dedicated namespace for the test to help with test isolation.


### PR DESCRIPTION
## What changed?
This is the cleanup of https://github.com/chaptersix/temporal/pull/23 .

  Includes:
  - Isolate V1 cleanup context in DeleteSchedule
  - refactor: DeleteSchedule uses CHASM-first routing with V1 fallback
  - fix: isolate context metadata in dual-stack DeleteSchedule
  - Bit of test cleanup

 Cherry-picked from #10278 (commit 85e8db7) onto cloud/v1.32.0-155. Conflict resolution dropped two references to symbols not present on this branch:
  - `newDedicatedClusterGuard` in `tests/testcore/test_env.go` (test misuse detection only, no runtime impact)
  - `EnableCHASMSchedulerSentinels` dynamic config in `tests/schedule_migration_test.go` (flag does not exist on this branch; sentinels behavior is unconditional here)

  Verified: `go build ./...` clean, full `TestScheduleMigrationTestSuite` passes including the two new tests added by this PR
  (`TestDeleteScheduleContextMetadata`, `TestPatchScheduleContextMetadata`).

## Why?
Fixes a bug in the metadata trailer.

 (cherry picked from commit 85e8db7268708f8f3dcd9e95b5ab08b50c1a28c5)

