### PR TITLE
Replace payload.Encode with sadefs.MustEncodeValue

### DIFF
--- a/chasm/lib/nexusoperation/validator_test.go
+++ b/chasm/lib/nexusoperation/validator_test.go
@@ -14,9 +14,9 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
-	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
@@ -299,9 +299,9 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.SearchAttributes = &commonpb.SearchAttributes{
 					IndexedFields: map[string]*commonpb.Payload{
-						"CustomKeywordField": payload.EncodeString("v1"),
-						"CustomTextField":    payload.EncodeString("v2"),
-						"CustomIntField":     payload.EncodeString("3"),
+						"CustomKeywordField": sadefs.MustEncodeValue("v1", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
+						"CustomTextField":    sadefs.MustEncodeValue("v2", enumspb.INDEXED_VALUE_TYPE_TEXT),
+						"CustomIntField":     sadefs.MustEncodeValue(3, enumspb.INDEXED_VALUE_TYPE_INT),
 					},
 				}
 			},
@@ -312,7 +312,10 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.SearchAttributes = &commonpb.SearchAttributes{
 					IndexedFields: map[string]*commonpb.Payload{
-						"CustomKeywordField": payload.EncodeString(strings.Repeat("x", 100)),
+						"CustomKeywordField": sadefs.MustEncodeValue(
+							strings.Repeat("x", 100),
+							enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+						),
 					},
 				}
 			},
@@ -329,7 +332,7 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 				Operation:   "operation",
 				SearchAttributes: &commonpb.SearchAttributes{
 					IndexedFields: map[string]*commonpb.Payload{
-						"CustomKeywordField": payload.EncodeString("val"),
+						"CustomKeywordField": sadefs.MustEncodeValue("val", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 					},
 				},
 			}

--- a/chasm/lib/scheduler/scheduler_migrate_task.go
+++ b/chasm/lib/scheduler/scheduler_migrate_task.go
@@ -25,7 +25,6 @@ import (
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/common/sdk"
-	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	legacyscheduler "go.temporal.io/server/service/worker/scheduler"
 	"go.uber.org/fx"
@@ -182,8 +181,12 @@ func (h *SchedulerMigrateToWorkflowTaskHandler) Execute(
 	// Build the start request to match createScheduleWorkflow in the frontend
 	// as closely as possible. Include TemporalNamespaceDivision so the V1
 	// workflow is discoverable via ListSchedules.
-	sa := &commonpb.SearchAttributes{IndexedFields: maps.Clone(result.searchAttributes)}
-	searchattribute.AddSearchAttribute(&sa, sadefs.TemporalNamespaceDivision, payload.EncodeString(legacyscheduler.NamespaceDivision))
+	saMap := payload.MergeMapOfPayload(
+		result.searchAttributes,
+		map[string]*commonpb.Payload{
+			sadefs.TemporalNamespaceDivision: payload.EncodeString(legacyscheduler.NamespaceDivision),
+		},
+	)
 	workflowID := legacyscheduler.WorkflowIDPrefix + result.scheduleID
 	startReq := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:                uuid.NewString(),
@@ -196,7 +199,7 @@ func (h *SchedulerMigrateToWorkflowTaskHandler) Execute(
 		WorkflowIdReusePolicy:    enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
 		WorkflowIdConflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL,
 		Memo:                     &commonpb.Memo{Fields: maps.Clone(result.memo)},
-		SearchAttributes:         sa,
+		SearchAttributes:         &commonpb.SearchAttributes{IndexedFields: saMap},
 		Priority:                 &commonpb.Priority{},
 	}
 

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_write_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_write_test.go
@@ -10,7 +10,6 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/common/future"
-	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/persistence/visibility/store"
@@ -36,7 +35,7 @@ func (s *ESVisibilitySuite) TestRecordWorkflowExecutionStarted() {
 			TaskQueue:        "task-queue-name",
 			SearchAttributes: &commonpb.SearchAttributes{
 				IndexedFields: map[string]*commonpb.Payload{
-					"CustomTextField": payload.EncodeString("alex"),
+					"CustomTextField": sadefs.MustEncodeValue("alex", enumspb.INDEXED_VALUE_TYPE_TEXT),
 				},
 			},
 		},
@@ -128,7 +127,7 @@ func (s *ESVisibilitySuite) TestRecordWorkflowExecutionClosed() {
 			TaskQueue:        "task-queue-name",
 			SearchAttributes: &commonpb.SearchAttributes{
 				IndexedFields: map[string]*commonpb.Payload{
-					"CustomTextField": payload.EncodeString("alex"),
+					"CustomTextField": sadefs.MustEncodeValue("alex", enumspb.INDEXED_VALUE_TYPE_TEXT),
 				},
 			},
 		},

--- a/common/searchattribute/search_attirbute.go
+++ b/common/searchattribute/search_attirbute.go
@@ -7,6 +7,7 @@ import (
 
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 )
 
@@ -42,12 +43,14 @@ func ApplyTypeMap(searchAttributes *commonpb.SearchAttributes, typeMap NameTypeM
 }
 
 // This may mutate saPtr and *saPtr
-func AddSearchAttribute(saPtr **commonpb.SearchAttributes, key string, value *commonpb.Payload) {
+func AddSearchAttributes(saPtr **commonpb.SearchAttributes, sas ...chasm.SearchAttributeKeyValue) {
 	if *saPtr == nil {
 		*saPtr = &commonpb.SearchAttributes{}
 	}
 	if (*saPtr).IndexedFields == nil {
 		(*saPtr).IndexedFields = make(map[string]*commonpb.Payload)
 	}
-	(*saPtr).IndexedFields[key] = value
+	for _, sa := range sas {
+		(*saPtr).IndexedFields[sa.Field] = sa.Value.MustEncode()
+	}
 }

--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -1663,8 +1663,11 @@ func (adh *AdminHandler) StartAdminBatchOperation(
 	}
 
 	var searchAttributes *commonpb.SearchAttributes
-	searchattribute.AddSearchAttribute(&searchAttributes, sadefs.BatcherUser, payload.EncodeString(identity))
-	searchattribute.AddSearchAttribute(&searchAttributes, sadefs.TemporalNamespaceDivision, payload.EncodeString(batcher.AdminNamespaceDivision))
+	searchattribute.AddSearchAttributes(
+		&searchAttributes,
+		chasm.SearchAttributeBatcherUser.Value(identity),
+		chasm.SearchAttributeTemporalNamespaceDivision.Value(batcher.AdminNamespaceDivision),
+	)
 
 	startReq := &workflowservice.StartWorkflowExecutionRequest{
 		Namespace:                request.Namespace,

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -3554,9 +3554,17 @@ func (wh *WorkflowHandler) createScheduleWorkflow(
 	// Phase 2: Write real V1 scheduler workflow.
 
 	// Add namespace division before unaliasing search attributes.
-	searchattribute.AddSearchAttribute(&request.SearchAttributes, sadefs.TemporalNamespaceDivision, payload.EncodeString(scheduler.NamespaceDivision))
+	saMap := payload.MergeMapOfPayload(
+		request.SearchAttributes.GetIndexedFields(),
+		map[string]*commonpb.Payload{
+			sadefs.TemporalNamespaceDivision: payload.EncodeString(scheduler.NamespaceDivision),
+		},
+	)
 
-	sa, err := wh.validator.UnaliasedSearchAttributesFrom(request.GetSearchAttributes(), request.Namespace)
+	sa, err := wh.validator.UnaliasedSearchAttributesFrom(
+		&commonpb.SearchAttributes{IndexedFields: saMap},
+		request.Namespace,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -5737,10 +5745,13 @@ func (wh *WorkflowHandler) StartBatchOperation(
 		},
 	}
 
-	// Add pre-define search attributes
+	// Add predefined search attributes
 	var searchAttributes *commonpb.SearchAttributes
-	searchattribute.AddSearchAttribute(&searchAttributes, sadefs.BatcherUser, payload.EncodeString(identity))
-	searchattribute.AddSearchAttribute(&searchAttributes, sadefs.TemporalNamespaceDivision, payload.EncodeString(batcher.NamespaceDivision))
+	searchattribute.AddSearchAttributes(
+		&searchAttributes,
+		chasm.SearchAttributeBatcherUser.Value(identity),
+		chasm.SearchAttributeTemporalNamespaceDivision.Value(batcher.NamespaceDivision),
+	)
 
 	startReq := &workflowservice.StartWorkflowExecutionRequest{
 		Namespace:                request.Namespace,

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -2479,7 +2479,10 @@ func (s *WorkflowHandlerSuite) TestStartBatchOperation_Terminate() {
 			s.Equal(inputString, request.StartRequest.Identity)
 			s.ProtoEqual(payload.EncodeString(batcher.BatchTypeTerminate), request.StartRequest.Memo.Fields[batcher.BatchOperationTypeMemo])
 			s.ProtoEqual(payload.EncodeString(inputString), request.StartRequest.Memo.Fields[batcher.BatchReasonMemo])
-			s.ProtoEqual(payload.EncodeString(inputString), request.StartRequest.SearchAttributes.IndexedFields[sadefs.BatcherUser])
+			s.ProtoEqual(
+				sadefs.MustEncodeValue(inputString, enumspb.INDEXED_VALUE_TYPE_KEYWORD),
+				request.StartRequest.SearchAttributes.IndexedFields[sadefs.BatcherUser],
+			)
 			s.ProtoEqual(inputPayload, request.StartRequest.Input)
 			return &historyservice.StartWorkflowExecutionResponse{}, nil
 		},
@@ -2541,7 +2544,10 @@ func (s *WorkflowHandlerSuite) TestStartBatchOperation_Cancellation() {
 			s.Equal(inputString, request.StartRequest.Identity)
 			s.ProtoEqual(payload.EncodeString(batcher.BatchTypeCancel), request.StartRequest.Memo.Fields[batcher.BatchOperationTypeMemo])
 			s.ProtoEqual(payload.EncodeString(inputString), request.StartRequest.Memo.Fields[batcher.BatchReasonMemo])
-			s.ProtoEqual(payload.EncodeString(inputString), request.StartRequest.SearchAttributes.IndexedFields[sadefs.BatcherUser])
+			s.ProtoEqual(
+				sadefs.MustEncodeValue(inputString, enumspb.INDEXED_VALUE_TYPE_KEYWORD),
+				request.StartRequest.SearchAttributes.IndexedFields[sadefs.BatcherUser],
+			)
 			s.ProtoEqual(inputPayload, request.StartRequest.Input)
 			return &historyservice.StartWorkflowExecutionResponse{}, nil
 		},
@@ -2606,7 +2612,10 @@ func (s *WorkflowHandlerSuite) TestStartBatchOperation_Signal() {
 			s.Equal(inputString, request.StartRequest.Identity)
 			s.ProtoEqual(payload.EncodeString(batcher.BatchTypeSignal), request.StartRequest.Memo.Fields[batcher.BatchOperationTypeMemo])
 			s.ProtoEqual(payload.EncodeString(inputString), request.StartRequest.Memo.Fields[batcher.BatchReasonMemo])
-			s.ProtoEqual(payload.EncodeString(inputString), request.StartRequest.SearchAttributes.IndexedFields[sadefs.BatcherUser])
+			s.ProtoEqual(
+				sadefs.MustEncodeValue(inputString, enumspb.INDEXED_VALUE_TYPE_KEYWORD),
+				request.StartRequest.SearchAttributes.IndexedFields[sadefs.BatcherUser],
+			)
 			s.ProtoEqual(inputPayload, request.StartRequest.Input)
 			return &historyservice.StartWorkflowExecutionResponse{}, nil
 		},
@@ -2680,7 +2689,10 @@ func (s *WorkflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_Signal
 			s.Equal(identity, request.StartRequest.Identity)
 			s.ProtoEqual(payload.EncodeString(batcher.BatchTypeSignal), request.StartRequest.Memo.Fields[batcher.BatchOperationTypeMemo])
 			s.ProtoEqual(payload.EncodeString(reason), request.StartRequest.Memo.Fields[batcher.BatchReasonMemo])
-			s.ProtoEqual(payload.EncodeString(identity), request.StartRequest.SearchAttributes.IndexedFields[sadefs.BatcherUser])
+			s.ProtoEqual(
+				sadefs.MustEncodeValue(identity, enumspb.INDEXED_VALUE_TYPE_KEYWORD),
+				request.StartRequest.SearchAttributes.IndexedFields[sadefs.BatcherUser],
+			)
 			s.ProtoEqual(inputPayload, request.StartRequest.Input)
 			return &historyservice.StartWorkflowExecutionResponse{}, nil
 		},
@@ -2738,7 +2750,10 @@ func (s *WorkflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_Reset(
 			s.Equal(identity, request.StartRequest.Identity)
 			s.ProtoEqual(payload.EncodeString(batcher.BatchTypeReset), request.StartRequest.Memo.Fields[batcher.BatchOperationTypeMemo])
 			s.ProtoEqual(payload.EncodeString(reason), request.StartRequest.Memo.Fields[batcher.BatchReasonMemo])
-			s.ProtoEqual(payload.EncodeString(identity), request.StartRequest.SearchAttributes.IndexedFields[sadefs.BatcherUser])
+			s.ProtoEqual(
+				sadefs.MustEncodeValue(identity, enumspb.INDEXED_VALUE_TYPE_KEYWORD),
+				request.StartRequest.SearchAttributes.IndexedFields[sadefs.BatcherUser],
+			)
 			s.ProtoEqual(inputPayload, request.StartRequest.Input)
 			return &historyservice.StartWorkflowExecutionResponse{}, nil
 		},
@@ -2802,7 +2817,10 @@ func (s *WorkflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_Reset_
 			s.Equal(identity, request.StartRequest.Identity)
 			s.ProtoEqual(payload.EncodeString(batcher.BatchTypeReset), request.StartRequest.Memo.Fields[batcher.BatchOperationTypeMemo])
 			s.ProtoEqual(payload.EncodeString(reason), request.StartRequest.Memo.Fields[batcher.BatchReasonMemo])
-			s.ProtoEqual(payload.EncodeString(identity), request.StartRequest.SearchAttributes.IndexedFields[sadefs.BatcherUser])
+			s.ProtoEqual(
+				sadefs.MustEncodeValue(identity, enumspb.INDEXED_VALUE_TYPE_KEYWORD),
+				request.StartRequest.SearchAttributes.IndexedFields[sadefs.BatcherUser],
+			)
 
 			// Decode the input and verify PostResetOperations are correctly set
 			var batchParams batchspb.BatchOperationInput

--- a/service/history/archival/archiver_test.go
+++ b/service/history/archival/archiver_test.go
@@ -8,15 +8,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	carchiver "go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/archiver/provider"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
-	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/quotas"
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/testing/mocksdk"
 	"go.temporal.io/server/service/history/configs"
 	"go.uber.org/fx"
@@ -119,7 +120,7 @@ func TestArchiver(t *testing.T) {
 			Name:    "Search attribute with no embedded type information",
 			Targets: []Target{TargetVisibility},
 			SearchAttributes: &commonpb.SearchAttributes{IndexedFields: map[string]*commonpb.Payload{
-				"Text01": payload.EncodeString("value"),
+				"Text01": sadefs.MustEncodeValue("value", enumspb.INDEXED_VALUE_TYPE_TEXT),
 			}},
 			NameTypeMap: searchattribute.TestNameTypeMap(),
 
@@ -129,7 +130,7 @@ func TestArchiver(t *testing.T) {
 			Name:    "Search attribute missing in type map",
 			Targets: []Target{TargetVisibility},
 			SearchAttributes: &commonpb.SearchAttributes{IndexedFields: map[string]*commonpb.Payload{
-				"Text01": payload.EncodeString("value"),
+				"Text01": sadefs.MustEncodeValue("value", enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED),
 			}},
 			NameTypeMap: searchattribute.NameTypeMap{},
 
@@ -141,7 +142,7 @@ func TestArchiver(t *testing.T) {
 			Name:    "Error getting name type map from search attribute provider",
 			Targets: []Target{TargetVisibility},
 			SearchAttributes: &commonpb.SearchAttributes{IndexedFields: map[string]*commonpb.Payload{
-				"Text01": payload.EncodeString("value"),
+				"Text01": sadefs.MustEncodeValue("value", enumspb.INDEXED_VALUE_TYPE_TEXT),
 			}},
 			NameTypeMapErr: errors.New("name-type-map-err"),
 

--- a/service/history/history_engine2_test.go
+++ b/service/history/history_engine2_test.go
@@ -38,7 +38,6 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
-	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
@@ -46,6 +45,7 @@ import (
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/common/searchattribute/sadefs"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/tasktoken"
 	"go.temporal.io/server/common/testing/protorequire"
@@ -259,8 +259,8 @@ func (s *engine2Suite) TestRecordWorkflowTaskStartedSuccessStickyEnabled() {
 				WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{
 					SearchAttributes: &commonpb.SearchAttributes{
 						IndexedFields: map[string]*commonpb.Payload{
-							"Keyword01":             payload.EncodeString("random-keyword"),
-							"TemporalChangeVersion": payload.EncodeString("random-data"),
+							"Keyword01":             sadefs.MustEncodeValue("random-keyword", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
+							"TemporalChangeVersion": sadefs.MustEncodeValue("random-data", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 						},
 					},
 				},
@@ -365,8 +365,8 @@ func (s *engine2Suite) TestRecordWorkflowTaskStartedSuccessStickyEnabled_WithInt
 				WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{
 					SearchAttributes: &commonpb.SearchAttributes{
 						IndexedFields: map[string]*commonpb.Payload{
-							"Keyword01":             payload.EncodeString("random-keyword"),
-							"TemporalChangeVersion": payload.EncodeString("random-data"),
+							"Keyword01":             sadefs.MustEncodeValue("random-keyword", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
+							"TemporalChangeVersion": sadefs.MustEncodeValue("random-data", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 						},
 					},
 				},
@@ -683,8 +683,8 @@ func (s *engine2Suite) TestRecordWorkflowTaskStartedSuccess() {
 				WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{
 					SearchAttributes: &commonpb.SearchAttributes{
 						IndexedFields: map[string]*commonpb.Payload{
-							"Keyword01":             payload.EncodeString("random-keyword"),
-							"TemporalChangeVersion": payload.EncodeString("random-data"),
+							"Keyword01":             sadefs.MustEncodeValue("random-keyword", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
+							"TemporalChangeVersion": sadefs.MustEncodeValue("random-data", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 						},
 					},
 				},
@@ -780,8 +780,8 @@ func (s *engine2Suite) TestRecordWorkflowTaskStartedSuccessWithInternalRawHistor
 					WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{
 						SearchAttributes: &commonpb.SearchAttributes{
 							IndexedFields: map[string]*commonpb.Payload{
-								"Keyword01":             payload.EncodeString("random-keyword"),
-								"TemporalChangeVersion": payload.EncodeString("random-data"),
+								"Keyword01":             sadefs.MustEncodeValue("random-keyword", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
+								"TemporalChangeVersion": sadefs.MustEncodeValue("random-data", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 							},
 						},
 					},
@@ -1312,15 +1312,19 @@ func (s *engine2Suite) TestRespondWorkflowTaskCompleted_StartChildWithSearchAttr
 
 	commands := []*commandpb.Command{{
 		CommandType: enumspb.COMMAND_TYPE_START_CHILD_WORKFLOW_EXECUTION,
-		Attributes: &commandpb.Command_StartChildWorkflowExecutionCommandAttributes{StartChildWorkflowExecutionCommandAttributes: &commandpb.StartChildWorkflowExecutionCommandAttributes{
-			Namespace:    tests.Namespace.String(),
-			WorkflowId:   tests.WorkflowID,
-			WorkflowType: &commonpb.WorkflowType{Name: "wType"},
-			TaskQueue:    &taskqueuepb.TaskQueue{Name: tl},
-			SearchAttributes: &commonpb.SearchAttributes{IndexedFields: map[string]*commonpb.Payload{
-				"AliasForText01": payload.EncodeString("search attribute value")},
+		Attributes: &commandpb.Command_StartChildWorkflowExecutionCommandAttributes{
+			StartChildWorkflowExecutionCommandAttributes: &commandpb.StartChildWorkflowExecutionCommandAttributes{
+				Namespace:    tests.Namespace.String(),
+				WorkflowId:   tests.WorkflowID,
+				WorkflowType: &commonpb.WorkflowType{Name: "wType"},
+				TaskQueue:    &taskqueuepb.TaskQueue{Name: tl},
+				SearchAttributes: &commonpb.SearchAttributes{
+					IndexedFields: map[string]*commonpb.Payload{
+						"AliasForText01": sadefs.MustEncodeValue("search attribute value", enumspb.INDEXED_VALUE_TYPE_TEXT),
+					},
+				},
 			},
-		}},
+		},
 	}}
 
 	wfMs := workflow.TestCloneToProto(context.Background(), ms)
@@ -1337,7 +1341,7 @@ func (s *engine2Suite) TestRespondWorkflowTaskCompleted_StartChildWithSearchAttr
 		startChildEventAttributes := eventsToSave[1].GetStartChildWorkflowExecutionInitiatedEventAttributes()
 		// Search attribute name was mapped and saved under field name.
 		s.ProtoEqual(
-			payload.EncodeString("search attribute value"),
+			sadefs.MustEncodeValue("search attribute value", enumspb.INDEXED_VALUE_TYPE_TEXT),
 			startChildEventAttributes.GetSearchAttributes().GetIndexedFields()["Text01"])
 		return tests.UpdateWorkflowExecutionResponse, nil
 	})
@@ -1494,7 +1498,7 @@ func (s *engine2Suite) TestStartWorkflowExecution_BrandNew_SearchAttributes() {
 		startEventAttributes := eventsToSave[0].GetWorkflowExecutionStartedEventAttributes()
 		// Search attribute name was mapped and saved under field name.
 		s.ProtoEqual(
-			payload.EncodeString("test"),
+			sadefs.MustEncodeValue("test", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 			startEventAttributes.GetSearchAttributes().GetIndexedFields()["Keyword01"])
 		return tests.CreateWorkflowExecutionResponse, nil
 	})
@@ -1514,7 +1518,7 @@ func (s *engine2Suite) TestStartWorkflowExecution_BrandNew_SearchAttributes() {
 			Identity:                 identity,
 			RequestId:                requestID,
 			SearchAttributes: &commonpb.SearchAttributes{IndexedFields: map[string]*commonpb.Payload{
-				"Keyword01": payload.EncodeString("test"),
+				"Keyword01": sadefs.MustEncodeValue("test", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 			}}},
 	})
 	s.Nil(err)

--- a/service/history/history_engine3_eventsv2_test.go
+++ b/service/history/history_engine3_eventsv2_test.go
@@ -22,12 +22,12 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
-	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/tasktoken"
 	"go.temporal.io/server/service/history/api"
 	"go.temporal.io/server/service/history/configs"
@@ -175,8 +175,8 @@ func (s *engine3Suite) TestRecordWorkflowTaskStartedSuccessStickyEnabled() {
 				WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{
 					SearchAttributes: &commonpb.SearchAttributes{
 						IndexedFields: map[string]*commonpb.Payload{
-							"Keyword01":             payload.EncodeString("random-keyword"),
-							"TemporalChangeVersion": payload.EncodeString("random-data"),
+							"Keyword01":             sadefs.MustEncodeValue("random-keyword", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
+							"TemporalChangeVersion": sadefs.MustEncodeValue("random-data", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 						},
 					},
 				},
@@ -285,8 +285,8 @@ func (s *engine3Suite) TestRecordWorkflowTaskStartedSuccessStickyEnabled_WithInt
 					WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{
 						SearchAttributes: &commonpb.SearchAttributes{
 							IndexedFields: map[string]*commonpb.Payload{
-								"Keyword01":             payload.EncodeString("random-keyword"),
-								"TemporalChangeVersion": payload.EncodeString("random-data"),
+								"Keyword01":             sadefs.MustEncodeValue("random-keyword", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
+								"TemporalChangeVersion": sadefs.MustEncodeValue("random-data", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 							},
 						},
 					},

--- a/service/history/history_engine_test.go
+++ b/service/history/history_engine_test.go
@@ -54,6 +54,7 @@ import (
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/rpc/interceptor"
 	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/tasktoken"
 	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/service/history/api"
@@ -5590,7 +5591,7 @@ func (s *engineSuite) TestEagerWorkflowStart_WithSearchAttributes() {
 
 	searchAttributes := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payload{
-			"Keyword01": payload.EncodeString("random-keyword"),
+			"Keyword01": sadefs.MustEncodeValue("random-keyword", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 		},
 	}
 	i := interceptor.NewTelemetryInterceptor(s.mockShard.GetNamespaceRegistry(),
@@ -5655,8 +5656,8 @@ func (s *engineSuite) TestGetHistory() {
 					WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{
 						SearchAttributes: &commonpb.SearchAttributes{
 							IndexedFields: map[string]*commonpb.Payload{
-								"Keyword01":             payload.EncodeString("random-keyword"),
-								"TemporalChangeVersion": payload.EncodeString("random-data"),
+								"Keyword01":             sadefs.MustEncodeValue("random-keyword", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
+								"TemporalChangeVersion": sadefs.MustEncodeValue("random-data", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 							},
 						},
 					},

--- a/service/history/visibility_queue_task_executor.go
+++ b/service/history/visibility_queue_task_executor.go
@@ -19,6 +19,7 @@ import (
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/service/history/consts"
 	historyi "go.temporal.io/server/service/history/interfaces"
@@ -407,7 +408,7 @@ func (t *visibilityQueueTaskExecutor) processChasmTask(
 		return err
 	}
 
-	searchattributes := make(map[string]*commonpb.Payload)
+	searchAttributes := make(map[string]*commonpb.Payload)
 
 	aliasedCustomSearchAttributes := visComponent.CustomSearchAttributes(visTaskContext)
 	for alias, value := range aliasedCustomSearchAttributes {
@@ -418,7 +419,7 @@ func (t *visibilityQueueTaskExecutor) processChasmTask(
 			t.logger.Warn("Failed to get field name for alias, ignoring search attribute", tag.String("alias", alias), tag.Error(err))
 			continue
 		}
-		searchattributes[fieldName] = value
+		searchAttributes[fieldName] = value
 	}
 
 	rootComponent, err := tree.ComponentByPath(visTaskContext, nil)
@@ -435,7 +436,7 @@ func (t *visibilityQueueTaskExecutor) processChasmTask(
 				}
 				continue
 			}
-			searchattributes[chasmSA.Field] = chasmSA.Value.MustEncode()
+			searchAttributes[chasmSA.Field] = chasmSA.Value.MustEncode()
 		}
 	}
 
@@ -465,11 +466,14 @@ func (t *visibilityQueueTaskExecutor) processChasmTask(
 		namespaceEntry,
 		mutableState,
 		combinedMemo,
-		searchattributes,
+		searchAttributes,
 	)
 
 	// We reuse the TemporalNamespaceDivision column to store the string representation of ArchetypeID.
-	requestBase.SearchAttributes.IndexedFields[sadefs.TemporalNamespaceDivision] = payload.EncodeString(strconv.FormatUint(uint64(tree.ArchetypeID()), 10))
+	searchattribute.AddSearchAttributes(
+		&requestBase.SearchAttributes,
+		chasm.SearchAttributeTemporalNamespaceDivision.Value(strconv.FormatUint(uint64(tree.ArchetypeID()), 10)),
+	)
 
 	// Override TaskQueue if provided by CHASM search attributes.
 	if chasmTaskQueue != "" {

--- a/service/worker/common/chasm_util_test.go
+++ b/service/worker/common/chasm_util_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/server/chasm"
-	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 )
 
@@ -30,10 +30,12 @@ func TestArchetypeIDFromExecutionInfo(t *testing.T) {
 	})
 
 	t.Run("Scheduler", func(t *testing.T) {
-		p := payload.EncodeString("TemporalScheduler")
 		execInfo := &workflowpb.WorkflowExecutionInfo{
 			SearchAttributes: &commonpb.SearchAttributes{IndexedFields: map[string]*commonpb.Payload{
-				sadefs.TemporalNamespaceDivision: p,
+				sadefs.TemporalNamespaceDivision: sadefs.MustEncodeValue(
+					"TemporalScheduler",
+					enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+				),
 			}},
 		}
 		id, err := ArchetypeIDFromExecutionInfo(execInfo)
@@ -42,10 +44,12 @@ func TestArchetypeIDFromExecutionInfo(t *testing.T) {
 	})
 
 	t.Run("CHASM", func(t *testing.T) {
-		p := payload.EncodeString(strconv.FormatUint(42, 10))
 		execInfo := &workflowpb.WorkflowExecutionInfo{
 			SearchAttributes: &commonpb.SearchAttributes{IndexedFields: map[string]*commonpb.Payload{
-				sadefs.TemporalNamespaceDivision: p,
+				sadefs.TemporalNamespaceDivision: sadefs.MustEncodeValue(
+					strconv.FormatUint(42, 10),
+					enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+				),
 			}},
 		}
 		id, err := ArchetypeIDFromExecutionInfo(execInfo)
@@ -54,11 +58,12 @@ func TestArchetypeIDFromExecutionInfo(t *testing.T) {
 	})
 
 	t.Run("ErrorOnInvalidNumber", func(t *testing.T) {
-		p := payload.EncodeString("1x")
-
 		execInfo := &workflowpb.WorkflowExecutionInfo{
 			SearchAttributes: &commonpb.SearchAttributes{IndexedFields: map[string]*commonpb.Payload{
-				sadefs.TemporalNamespaceDivision: p,
+				sadefs.TemporalNamespaceDivision: sadefs.MustEncodeValue(
+					"1x",
+					enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+				),
 			}},
 		}
 		_, err := ArchetypeIDFromExecutionInfo(execInfo)

--- a/service/worker/deletenamespace/deleteexecutions/workflow_test.go
+++ b/service/worker/deletenamespace/deleteexecutions/workflow_test.go
@@ -23,7 +23,6 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
-	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/searchattribute/sadefs"
@@ -379,7 +378,10 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_ChasmExecutions(t *testing.T)
 				Execution: execution1,
 				SearchAttributes: &commonpb.SearchAttributes{
 					IndexedFields: map[string]*commonpb.Payload{
-						sadefs.TemporalNamespaceDivision: payload.EncodeString(strconv.FormatUint(uint64(archetypeID1), 10)),
+						sadefs.TemporalNamespaceDivision: sadefs.MustEncodeValue(
+							strconv.FormatUint(uint64(archetypeID1), 10),
+							enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+						),
 					},
 				},
 			},
@@ -388,7 +390,10 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_ChasmExecutions(t *testing.T)
 				Execution: execution2,
 				SearchAttributes: &commonpb.SearchAttributes{
 					IndexedFields: map[string]*commonpb.Payload{
-						sadefs.TemporalNamespaceDivision: payload.EncodeString(strconv.FormatUint(uint64(archetypeID2), 10)),
+						sadefs.TemporalNamespaceDivision: sadefs.MustEncodeValue(
+							strconv.FormatUint(uint64(archetypeID2), 10),
+							enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+						),
 					},
 				},
 			},

--- a/service/worker/workerdeployment/util.go
+++ b/service/worker/workerdeployment/util.go
@@ -20,9 +20,9 @@ import (
 	"go.temporal.io/sdk/workflow"
 	deploymentspb "go.temporal.io/server/api/deployment/v1"
 	"go.temporal.io/server/api/historyservice/v1"
+	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/namespace"
-	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/searchattribute"
@@ -437,7 +437,10 @@ func makeStartRequest(
 
 func buildSearchAttributes() *commonpb.SearchAttributes {
 	sa := &commonpb.SearchAttributes{}
-	searchattribute.AddSearchAttribute(&sa, sadefs.TemporalNamespaceDivision, payload.EncodeString(WorkerDeploymentNamespaceDivision))
+	searchattribute.AddSearchAttributes(
+		&sa,
+		chasm.SearchAttributeTemporalNamespaceDivision.Value(WorkerDeploymentNamespaceDivision),
+	)
 	return sa
 }
 

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -30,6 +30,7 @@ import (
 	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
+	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/tasktoken"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/common/testing/protorequire"
@@ -70,7 +71,7 @@ var (
 	}
 	defaultSearchAttributes = &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payload{
-			"CustomKeywordField": payload.EncodeString("value1"),
+			"CustomKeywordField": sadefs.MustEncodeValue("value1", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 		},
 	}
 	defaultUserMetadata = &sdkpb.UserMetadata{
@@ -696,7 +697,7 @@ func (s *standaloneActivityTestSuite) TestStart() {
 		t.Run("SearchAttributesInvalid", func(t *testing.T) {
 			invalidSearchAttributes := &commonpb.SearchAttributes{
 				IndexedFields: map[string]*commonpb.Payload{
-					"InvalidSearchAttributeKey": payload.EncodeString("value"),
+					"InvalidSearchAttributeKey": sadefs.MustEncodeValue("value", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 				},
 			}
 
@@ -4747,7 +4748,7 @@ func (s *standaloneActivityTestSuite) TestListActivityExecutions() {
 			RequestId:           env.Tv().RequestID(),
 			SearchAttributes: &commonpb.SearchAttributes{
 				IndexedFields: map[string]*commonpb.Payload{
-					customSAName: payload.EncodeString(customSAValue),
+					customSAName: sadefs.MustEncodeValue(customSAValue, enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 				},
 			},
 		})
@@ -4989,7 +4990,7 @@ func (s *standaloneActivityTestSuite) TestCountActivityExecutions() {
 				RequestId:           env.Tv().RequestID(),
 				SearchAttributes: &commonpb.SearchAttributes{
 					IndexedFields: map[string]*commonpb.Payload{
-						customSAName: payload.EncodeString(customSAValue),
+						customSAName: sadefs.MustEncodeValue(customSAValue, enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 					},
 				},
 			})

--- a/tests/advanced_visibility_test.go
+++ b/tests/advanced_visibility_test.go
@@ -121,7 +121,7 @@ func (s *AdvancedVisibilitySuite) TestListOpenWorkflow() {
 	tl := "es-functional-start-workflow-test-taskqueue"
 	request := s.createStartWorkflowExecutionRequest(id, wt, tl)
 
-	attrPayload, _ := payload.Encode(testSearchAttributeVal)
+	attrPayload := sadefs.MustEncodeValue(testSearchAttributeVal, enumspb.INDEXED_VALUE_TYPE_TEXT)
 	searchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payload{
 			testSearchAttributeKey: attrPayload,
@@ -227,7 +227,7 @@ func (s *AdvancedVisibilitySuite) TestListWorkflow_SearchAttribute() {
 	tl := "es-functional-list-workflow-by-search-attr-test-taskqueue"
 	request := s.createStartWorkflowExecutionRequest(id, wt, tl)
 
-	attrValBytes, _ := payload.Encode(testSearchAttributeVal)
+	attrValBytes := sadefs.MustEncodeValue(testSearchAttributeVal, enumspb.INDEXED_VALUE_TYPE_TEXT)
 	searchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payload{
 			testSearchAttributeKey: attrValBytes,
@@ -341,7 +341,7 @@ func (s *AdvancedVisibilitySuite) TestListWorkflow_OrQuery() {
 
 	// start 3 workflows
 	key := "CustomIntField"
-	attrValBytes, _ := payload.Encode(1)
+	attrValBytes := sadefs.MustEncodeValue(1, enumspb.INDEXED_VALUE_TYPE_INT)
 	searchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payload{
 			key: attrValBytes,
@@ -353,14 +353,14 @@ func (s *AdvancedVisibilitySuite) TestListWorkflow_OrQuery() {
 
 	request.RequestId = uuid.NewString()
 	request.WorkflowId = id + "-2"
-	attrValBytes, _ = payload.Encode(2)
+	attrValBytes = sadefs.MustEncodeValue(2, enumspb.INDEXED_VALUE_TYPE_INT)
 	searchAttr.IndexedFields[key] = attrValBytes
 	we2, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)
 	s.NoError(err)
 
 	request.RequestId = uuid.NewString()
 	request.WorkflowId = id + "-3"
-	attrValBytes, _ = payload.Encode(3)
+	attrValBytes = sadefs.MustEncodeValue(3, enumspb.INDEXED_VALUE_TYPE_INT)
 	searchAttr.IndexedFields[key] = attrValBytes
 	we3, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)
 	s.NoError(err)
@@ -537,7 +537,7 @@ func (s *AdvancedVisibilitySuite) TestListWorkflow_StringQuery() {
 
 	searchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payload{
-			"CustomTextField": payload.EncodeString("nothing else matters"),
+			"CustomTextField": sadefs.MustEncodeValue("nothing else matters", enumspb.INDEXED_VALUE_TYPE_TEXT),
 		},
 	}
 	request.SearchAttributes = searchAttr
@@ -655,10 +655,10 @@ func (s *AdvancedVisibilitySuite) TestListWorkflow_OrderBy() {
 		startRequest.WorkflowId = id + strconv.Itoa(i)
 
 		if i < testcore.DefaultPageSize-1 { // 4 workflows have search attributes.
-			intVal, _ := payload.Encode(i)
-			doubleVal, _ := payload.Encode(float64(i))
-			strVal, _ := payload.Encode(strconv.Itoa(i))
-			timeVal, _ := payload.Encode(initialTime.Add(time.Duration(i)))
+			intVal := sadefs.MustEncodeValue(int64(i), enumspb.INDEXED_VALUE_TYPE_INT)
+			doubleVal := sadefs.MustEncodeValue(float64(i), enumspb.INDEXED_VALUE_TYPE_DOUBLE)
+			strVal := sadefs.MustEncodeValue(strconv.Itoa(i), enumspb.INDEXED_VALUE_TYPE_KEYWORD)
+			timeVal := sadefs.MustEncodeValue(initialTime.Add(time.Duration(i)), enumspb.INDEXED_VALUE_TYPE_DATETIME)
 			startRequest.SearchAttributes = &commonpb.SearchAttributes{
 				IndexedFields: map[string]*commonpb.Payload{
 					"CustomIntField":      intVal,
@@ -670,7 +670,7 @@ func (s *AdvancedVisibilitySuite) TestListWorkflow_OrderBy() {
 		} else {
 			// To sort on CustomDatetimeField in single shard index on ES 7.10, there must be no null values in that field.
 			// Otherwise, ES returns internal server error.
-			timeVal, _ := payload.Encode(initialTime.Add(time.Duration(i)))
+			timeVal := sadefs.MustEncodeValue(initialTime.Add(time.Duration(i)), enumspb.INDEXED_VALUE_TYPE_DATETIME)
 			startRequest.SearchAttributes = &commonpb.SearchAttributes{
 				IndexedFields: map[string]*commonpb.Payload{
 					"CustomDatetimeField": timeVal,
@@ -884,7 +884,7 @@ func (s *AdvancedVisibilitySuite) TestCountWorkflow() {
 	tl := "es-functional-count-workflow-test-taskqueue"
 	request := s.createStartWorkflowExecutionRequest(id, wt, tl)
 
-	attrValBytes, _ := payload.Encode(testSearchAttributeVal)
+	attrValBytes := sadefs.MustEncodeValue(testSearchAttributeVal, enumspb.INDEXED_VALUE_TYPE_TEXT)
 	searchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payload{
 			testSearchAttributeKey: attrValBytes,
@@ -1056,7 +1056,7 @@ func (s *AdvancedVisibilitySuite) TestUpsertWorkflowExecutionSearchAttributes() 
 		// handle first upsert
 		if commandCount == 0 {
 			commandCount++
-			attrValPayload, _ := payload.Encode(testSearchAttributeVal)
+			attrValPayload := sadefs.MustEncodeValue(testSearchAttributeVal, enumspb.INDEXED_VALUE_TYPE_TEXT)
 			upsertSearchAttr := &commonpb.SearchAttributes{
 				IndexedFields: map[string]*commonpb.Payload{
 					testSearchAttributeKey: attrValPayload,
@@ -2592,7 +2592,7 @@ func (s *AdvancedVisibilitySuite) TestScheduleListingWithSearchAttributes() {
 	schedule.ScheduleId = customScheduleID
 	schedule.SearchAttributes = &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payload{
-			sadefs.ScheduleID: payload.EncodeString(customSearchAttrValue),
+			sadefs.ScheduleID: sadefs.MustEncodeValue(customSearchAttrValue, enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 		},
 	}
 

--- a/tests/child_workflow_test.go
+++ b/tests/child_workflow_test.go
@@ -21,6 +21,7 @@ import (
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/common/testing/taskpoller"
 	"go.temporal.io/server/common/testing/testvars"
@@ -97,10 +98,9 @@ func (s *ChildWorkflowSuite) TestChildWorkflowExecution() {
 			"Info": payload.EncodeString("memo"),
 		},
 	}
-	attrValPayload := payload.EncodeString("attrVal")
 	searchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payload{
-			saName: attrValPayload,
+			saName: sadefs.MustEncodeValue("attrVal", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 		},
 	}
 

--- a/tests/continue_as_new_test.go
+++ b/tests/continue_as_new_test.go
@@ -21,6 +21,7 @@ import (
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/common/testing/taskpoller"
 	"go.temporal.io/server/common/testing/testvars"
@@ -59,7 +60,7 @@ func (s *ContinueAsNewTestSuite) TestContinueAsNewWorkflow() {
 	}
 	searchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payload{
-			saName: payload.EncodeString("random"),
+			saName: sadefs.MustEncodeValue("random", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 		},
 	}
 

--- a/tests/cron_test.go
+++ b/tests/cron_test.go
@@ -22,6 +22,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
+	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -143,7 +144,7 @@ func (s *CronTestSuite) TestCronWorkflow() {
 	}
 	searchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payload{
-			"CustomKeywordField": payload.EncodeString("keyword-value"),
+			"CustomKeywordField": sadefs.MustEncodeValue("keyword-value", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 		},
 	}
 

--- a/tests/nexus_standalone_test.go
+++ b/tests/nexus_standalone_test.go
@@ -27,6 +27,7 @@ import (
 	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/common/nexus/nexustest"
 	"go.temporal.io/server/common/payload"
+	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/tests/testcore"
@@ -70,7 +71,7 @@ func (s *NexusStandaloneTestSuite) TestStartStandaloneNexusOperation() {
 		}
 		testSearchAttributes := &commonpb.SearchAttributes{
 			IndexedFields: map[string]*commonpb.Payload{
-				"CustomKeywordField": payload.EncodeString("test-value"),
+				"CustomKeywordField": sadefs.MustEncodeValue("test-value", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 			},
 		}
 		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
@@ -1226,7 +1227,7 @@ func (s *NexusStandaloneTestSuite) TestListStandaloneNexusOperation() {
 
 		testSA := &commonpb.SearchAttributes{
 			IndexedFields: map[string]*commonpb.Payload{
-				"CustomKeywordField": payload.EncodeString("list-sa-value"),
+				"CustomKeywordField": sadefs.MustEncodeValue("list-sa-value", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 			},
 		}
 		_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
@@ -1618,7 +1619,7 @@ func (s *NexusStandaloneTestSuite) TestCountStandaloneNexusOperation() {
 				Endpoint:    endpointName,
 				SearchAttributes: &commonpb.SearchAttributes{
 					IndexedFields: map[string]*commonpb.Payload{
-						"CustomKeywordField": payload.EncodeString("count-sa-value"),
+						"CustomKeywordField": sadefs.MustEncodeValue("count-sa-value", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 					},
 				},
 			})

--- a/tests/nil_search_attribute_test.go
+++ b/tests/nil_search_attribute_test.go
@@ -11,6 +11,7 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/common/payload"
+	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
@@ -23,7 +24,7 @@ func TestWorkflowStart_NilSearchAttributesFiltered(t *testing.T) {
 
 	nilPayload, err := payload.Encode(nil)
 	s.Require().NoError(err)
-	validPayload := payload.EncodeString("valid-value")
+	validPayload := sadefs.MustEncodeValue("valid-value", enumspb.INDEXED_VALUE_TYPE_KEYWORD)
 
 	searchAttributes := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payload{
@@ -153,7 +154,7 @@ func TestDescribeWorkflow_NilSearchAttributesNotVisible(t *testing.T) {
 
 	nilPayload, err := payload.Encode(nil)
 	s.Require().NoError(err)
-	validPayload := payload.EncodeString("valid-value")
+	validPayload := sadefs.MustEncodeValue("valid-value", enumspb.INDEXED_VALUE_TYPE_KEYWORD)
 
 	searchAttributes := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payload{
@@ -210,7 +211,7 @@ func TestWorkflowStart_NilMemoFiltered(t *testing.T) {
 
 	nilPayload, err := payload.Encode(nil)
 	s.Require().NoError(err)
-	validPayload := payload.EncodeString("valid-value")
+	validPayload := sadefs.MustEncodeValue("valid-value", enumspb.INDEXED_VALUE_TYPE_KEYWORD)
 
 	memo := &commonpb.Memo{
 		Fields: map[string]*commonpb.Payload{
@@ -331,7 +332,7 @@ func TestDescribeWorkflow_NilMemoNotVisible(t *testing.T) {
 
 	nilPayload, err := payload.Encode(nil)
 	s.Require().NoError(err)
-	validPayload := payload.EncodeString("valid-value")
+	validPayload := sadefs.MustEncodeValue("valid-value", enumspb.INDEXED_VALUE_TYPE_KEYWORD)
 
 	memo := &commonpb.Memo{
 		Fields: map[string]*commonpb.Payload{

--- a/tests/workflow_alias_search_attribute_test.go
+++ b/tests/workflow_alias_search_attribute_test.go
@@ -16,7 +16,6 @@ import (
 	"go.temporal.io/sdk/workflow"
 	deploymentspb "go.temporal.io/server/api/deployment/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
-	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/common/testing/testvars"
@@ -181,7 +180,7 @@ func (s *WorkflowAliasSearchAttributeTestSuite) TestWorkflowAliasSearchAttribute
 
 	sa := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payload{
-			"WorkflowVersioningBehavior": payload.EncodeString("user-defined"),
+			"WorkflowVersioningBehavior": sadefs.MustEncodeValue("user-defined", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 		},
 	}
 

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -25,7 +25,6 @@ import (
 	"go.temporal.io/server/common/failure"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log/tag"
-	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/primitives/timestamp"
@@ -1769,7 +1768,7 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_Invalid_DeploymentSearchA
 			Identity:           tv.WorkerIdentity(),
 			SearchAttributes: &commonpb.SearchAttributes{
 				IndexedFields: map[string]*commonpb.Payload{
-					saFieldName: payload.EncodeString("1.0.0"),
+					saFieldName: sadefs.MustEncodeValue("1.0.0", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 				},
 			},
 		}

--- a/tests/xdc/visibility_test.go
+++ b/tests/xdc/visibility_test.go
@@ -80,7 +80,7 @@ func (s *VisibilityTestSuite) TestSearchAttributes() {
 	taskQueue := &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
 	searchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payload{
-			"CustomTextField": payload.EncodeString("test value"),
+			"CustomTextField": sadefs.MustEncodeValue("test value", enumspb.INDEXED_VALUE_TYPE_TEXT),
 		},
 	}
 	startReq := &workflowservice.StartWorkflowExecutionRequest{
@@ -285,11 +285,10 @@ func (s *VisibilityTestSuite) TestSearchAttributes() {
 
 // TODO (alex): remove this func.
 func getUpsertSearchAttributes() *commonpb.SearchAttributes {
-	attrValPayload2, _ := payload.Encode(123)
 	upsertSearchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payload{
-			"CustomTextField": payload.EncodeString("another string"),
-			"CustomIntField":  attrValPayload2,
+			"CustomTextField": sadefs.MustEncodeValue("another string", enumspb.INDEXED_VALUE_TYPE_TEXT),
+			"CustomIntField":  sadefs.MustEncodeValue(123, enumspb.INDEXED_VALUE_TYPE_INT),
 		},
 	}
 	return upsertSearchAttr


### PR DESCRIPTION
## What changed?
Replace `payload.Encode` with `sadefs.MustEncodeValue` for encoding predefined search attributes used internally.

## Why?
`sadefs.MustEncodeValue` adds metadata type to the payload.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

