### PR TITLE
fix: Ensure system and CHASM search attributes visible and available via the CLI

### DIFF
--- a/chasm/search_attribute.go
+++ b/chasm/search_attribute.go
@@ -425,6 +425,20 @@ func NewSearchAttributesMap(values map[string]VisibilityValue) SearchAttributesM
 	return SearchAttributesMap{values: values}
 }
 
+// IndexedFields re-encodes the (already-aliased) search attribute values into a map of
+// payloads keyed by alias, suitable for inclusion in a commonpb.SearchAttributes. Returns
+// nil if the map is empty.
+func (m SearchAttributesMap) IndexedFields() map[string]*commonpb.Payload {
+	if len(m.values) == 0 {
+		return nil
+	}
+	fields := make(map[string]*commonpb.Payload, len(m.values))
+	for name, value := range m.values {
+		fields[name] = value.MustEncode()
+	}
+	return fields
+}
+
 // newSearchAttributesMapFromProto creates a new SearchAttributesMap from commonpb.SearchAttributes.
 func newSearchAttributesMapFromProto(
 	searchAttributes *commonpb.SearchAttributes,

--- a/chasm/search_attribute_test.go
+++ b/chasm/search_attribute_test.go
@@ -83,6 +83,37 @@ func TestSearchAttributesMap_Get(t *testing.T) {
 	})
 }
 
+func TestSearchAttributesMap_IndexedFields(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		require.Nil(t, NewSearchAttributesMap(nil).IndexedFields())
+		require.Nil(t, NewSearchAttributesMap(map[string]VisibilityValue{}).IndexedFields())
+	})
+
+	t.Run("ReEncodesAndRoundTrips", func(t *testing.T) {
+		now := time.Now().UTC().Truncate(time.Millisecond)
+		values := map[string]VisibilityValue{
+			"ScheduleNextActionTime": VisibilityValueTime(now),
+			"ExecutionStatus":        VisibilityValueKeyword("Running"),
+			"Count":                  VisibilityValueInt64(7),
+		}
+		m := NewSearchAttributesMap(values)
+
+		fields := m.IndexedFields()
+		require.Len(t, fields, len(values))
+		for name := range values {
+			require.Contains(t, fields, name)
+			require.NotNil(t, fields[name])
+		}
+
+		// Round-trip: decoding the payloads back yields the original values.
+		roundTripped, err := newSearchAttributesMapFromProto(&commonpb.SearchAttributes{IndexedFields: fields})
+		require.NoError(t, err)
+		for name, want := range values {
+			require.True(t, want.Equal(roundTripped.values[name]), "value for %q changed across re-encode", name)
+		}
+	})
+}
+
 func TestNewSearchAttributesMapFromProto(t *testing.T) {
 	t.Run("NilSearchAttributes", func(t *testing.T) {
 		m, err := newSearchAttributesMapFromProto(nil)

--- a/service/frontend/schedule_search_attributes_test.go
+++ b/service/frontend/schedule_search_attributes_test.go
@@ -1,0 +1,117 @@
+package frontend
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/server/chasm"
+	chasmscheduler "go.temporal.io/server/chasm/lib/scheduler"
+	"go.temporal.io/server/common/searchattribute/sadefs"
+)
+
+func keywordPayload(t *testing.T, v string) *commonpb.Payload {
+	t.Helper()
+	return chasm.VisibilityValueKeyword(v).MustEncode()
+}
+
+// TestMergeChasmSearchAttributes covers the field-mapping merge that folds a CHASM execution's
+// separately-stored (already-aliased) CHASM search attributes into the entry's custom search
+// attributes for ListSchedules.
+func TestMergeChasmSearchAttributes(t *testing.T) {
+	t.Parallel()
+
+	nextActionTime := time.Date(2026, 5, 30, 0, 44, 0, 0, time.UTC)
+
+	t.Run("no chasm fields returns custom unchanged", func(t *testing.T) {
+		custom := map[string]*commonpb.Payload{"CustomKeyword": keywordPayload(t, "v")}
+		got := mergeChasmSearchAttributes(custom, chasm.NewSearchAttributesMap(nil))
+		require.Equal(t, custom, got)
+	})
+
+	t.Run("nil custom with chasm fields", func(t *testing.T) {
+		chasmSAs := chasm.NewSearchAttributesMap(map[string]chasm.VisibilityValue{
+			chasmscheduler.ScheduleNextActionTimeName: chasm.VisibilityValueTime(nextActionTime),
+		})
+		got := mergeChasmSearchAttributes(nil, chasmSAs)
+		require.Len(t, got, 1)
+		require.Contains(t, got, chasmscheduler.ScheduleNextActionTimeName)
+	})
+
+	t.Run("merges chasm into custom", func(t *testing.T) {
+		custom := map[string]*commonpb.Payload{"CustomKeyword": keywordPayload(t, "v")}
+		chasmSAs := chasm.NewSearchAttributesMap(map[string]chasm.VisibilityValue{
+			chasmscheduler.ScheduleNextActionTimeName: chasm.VisibilityValueTime(nextActionTime),
+			sadefs.ExecutionStatus:                    chasm.VisibilityValueKeyword("Running"),
+		})
+
+		got := mergeChasmSearchAttributes(custom, chasmSAs)
+
+		require.Len(t, got, 3)
+		require.Contains(t, got, "CustomKeyword")
+		require.Contains(t, got, chasmscheduler.ScheduleNextActionTimeName)
+		require.Contains(t, got, sadefs.ExecutionStatus)
+		// Values are re-encoded from the CHASM map.
+		require.Equal(t,
+			chasm.VisibilityValueTime(nextActionTime).MustEncode().GetData(),
+			got[chasmscheduler.ScheduleNextActionTimeName].GetData())
+
+		// Inputs are not mutated.
+		require.Len(t, custom, 1)
+	})
+
+	t.Run("chasm value wins on key collision", func(t *testing.T) {
+		custom := map[string]*commonpb.Payload{
+			sadefs.ExecutionStatus: keywordPayload(t, "Completed"),
+		}
+		chasmSAs := chasm.NewSearchAttributesMap(map[string]chasm.VisibilityValue{
+			sadefs.ExecutionStatus: chasm.VisibilityValueKeyword("Running"),
+		})
+
+		got := mergeChasmSearchAttributes(custom, chasmSAs)
+
+		require.Len(t, got, 1)
+		require.Equal(t,
+			keywordPayload(t, "Running").GetData(),
+			got[sadefs.ExecutionStatus].GetData())
+		// Original custom map untouched.
+		require.Equal(t, keywordPayload(t, "Completed").GetData(), custom[sadefs.ExecutionStatus].GetData())
+	})
+}
+
+// TestScheduleSearchAttributes_MergeThenClean verifies the end-to-end field-mapping behavior of a
+// ListSchedules entry: CHASM search attributes (ScheduleNextActionTime, ExecutionStatus) are
+// surfaced, while cleanScheduleSearchAttributes still strips the internal ones that should not be
+// shown to clients (TemporalSchedulePaused, TemporalNamespaceDivision, BuildIds).
+func TestScheduleSearchAttributes_MergeThenClean(t *testing.T) {
+	t.Parallel()
+
+	nextActionTime := time.Date(2026, 5, 30, 0, 44, 0, 0, time.UTC)
+
+	custom := map[string]*commonpb.Payload{
+		"CustomKeyword":                  keywordPayload(t, "v"),
+		sadefs.TemporalSchedulePaused:    chasm.VisibilityValueBool(false).MustEncode(),
+		sadefs.TemporalNamespaceDivision: keywordPayload(t, "TemporalScheduler"),
+		sadefs.BuildIds:                  keywordPayload(t, "unversioned"),
+	}
+	chasmSAs := chasm.NewSearchAttributesMap(map[string]chasm.VisibilityValue{
+		chasmscheduler.ScheduleNextActionTimeName: chasm.VisibilityValueTime(nextActionTime),
+		sadefs.ExecutionStatus:                    chasm.VisibilityValueKeyword("Running"),
+	})
+
+	merged := mergeChasmSearchAttributes(custom, chasmSAs)
+
+	wh := &WorkflowHandler{}
+	cleaned := wh.cleanScheduleSearchAttributes(&commonpb.SearchAttributes{IndexedFields: merged})
+
+	fields := cleaned.GetIndexedFields()
+	// Surfaced to the client.
+	require.Contains(t, fields, chasmscheduler.ScheduleNextActionTimeName)
+	require.Contains(t, fields, sadefs.ExecutionStatus)
+	require.Contains(t, fields, "CustomKeyword")
+	// Stripped by cleanScheduleSearchAttributes.
+	require.NotContains(t, fields, sadefs.TemporalSchedulePaused)
+	require.NotContains(t, fields, sadefs.TemporalNamespaceDivision)
+	require.NotContains(t, fields, sadefs.BuildIds)
+}

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -5036,12 +5036,27 @@ func (wh *WorkflowHandler) prepareSchedulerQuery(
 			return "", serviceerror.NewUnavailablef(errUnableToGetSearchAttributesMessage, err)
 		}
 
+		// On the CHASM path, resolve the Scheduler component's search-attribute mapper so
+		// CHASM search attributes (e.g. ScheduleNextActionTime, which maps to a reserved
+		// predefined field) validate and convert correctly. Without it, validation runs with
+		// no CHASM mapper and rejects these aliases as "invalid search attribute".
+		var chasmMapper *chasm.VisibilitySearchAttributesMapper
+		archetypeID := chasm.UnspecifiedArchetypeID
+		if chasmEnabled {
+			if rc, ok := wh.registry.ComponentByID(chasm.SchedulerArchetypeID); ok {
+				chasmMapper = rc.SearchAttributesMapper()
+				archetypeID = chasm.SchedulerArchetypeID
+			}
+		}
+
 		if err := scheduler.ValidateVisibilityQuery(
 			namespaceName,
 			saNameType,
 			wh.saMapperProvider,
 			wh.config.VisibilityEnableUnifiedQueryConverter,
 			query,
+			chasmMapper,
+			archetypeID,
 		); err != nil {
 			return "", err
 		}
@@ -5059,6 +5074,29 @@ func (wh *WorkflowHandler) prepareSchedulerQuery(
 	}
 
 	return result, nil
+}
+
+// mergeChasmSearchAttributes combines a CHASM execution's custom search attributes with its
+// (already-aliased) CHASM search attributes into a single indexed-fields map for a schedule list
+// entry. CHASM search attributes are stored separately from custom ones on the execution info, so
+// they must be folded in here to be surfaced to clients. On key collision the CHASM value wins.
+// The inputs are never mutated; when there are no CHASM fields the custom map is returned as-is.
+func mergeChasmSearchAttributes(
+	custom map[string]*commonpb.Payload,
+	chasmSAs chasm.SearchAttributesMap,
+) map[string]*commonpb.Payload {
+	chasmFields := chasmSAs.IndexedFields()
+	if len(chasmFields) == 0 {
+		return custom
+	}
+	merged := make(map[string]*commonpb.Payload, len(custom)+len(chasmFields))
+	for k, v := range custom {
+		merged[k] = v
+	}
+	for k, v := range chasmFields {
+		merged[k] = v
+	}
+	return merged
 }
 
 func (wh *WorkflowHandler) listSchedulesChasm(
@@ -5095,12 +5133,18 @@ func (wh *WorkflowHandler) listSchedulesChasm(
 		workflowID := ex.BusinessID
 		scheduleID := strings.TrimPrefix(workflowID, scheduler.WorkflowIDPrefix) // needed for V1 schedules, not CHASM
 
+		// Merge the V2/CHASM search attributes (e.g. ScheduleNextActionTime, which the
+		// visibility manager has already aliased from its reserved predefined field) into the
+		// entry's custom search attributes so they are surfaced to the client. They are stored
+		// separately on the execution info; without this merge they'd be queryable but invisible.
+		indexedFields := mergeChasmSearchAttributes(ex.CustomSearchAttributes, ex.ChasmSearchAttributes)
+
 		schedules[i] = &schedulepb.ScheduleListEntry{
 			ScheduleId: scheduleID,
 			Memo:       customMemo,
 			// cleanScheduleSearchAttributes is only needed for V1 schedules
 			SearchAttributes: wh.cleanScheduleSearchAttributes(&commonpb.SearchAttributes{
-				IndexedFields: ex.CustomSearchAttributes,
+				IndexedFields: indexedFields,
 			}),
 			Info: listInfo,
 		}

--- a/service/worker/scheduler/query.go
+++ b/service/worker/scheduler/query.go
@@ -33,9 +33,11 @@ func newFieldNameAggInterceptor(
 	namespaceName namespace.Name,
 	saNameType searchattribute.NameTypeMap,
 	saMapperProvider searchattribute.MapperProvider,
+	chasmMapper *chasm.VisibilitySearchAttributesMapper,
+	archetypeID chasm.ArchetypeID,
 ) *fieldNameAggInterceptor {
 	return &fieldNameAggInterceptor{
-		baseInterceptor: elasticsearch.NewNameInterceptor(namespaceName, saNameType, saMapperProvider, nil, chasm.UnspecifiedArchetypeID),
+		baseInterceptor: elasticsearch.NewNameInterceptor(namespaceName, saNameType, saMapperProvider, chasmMapper, archetypeID),
 		names:           make(map[string]bool),
 	}
 }
@@ -63,6 +65,8 @@ func ValidateVisibilityQuery(
 	saMapperProvider searchattribute.MapperProvider,
 	enableUnifiedQueryConverter dynamicconfig.BoolPropertyFn,
 	queryString string,
+	chasmMapper *chasm.VisibilitySearchAttributesMapper,
+	archetypeID chasm.ArchetypeID,
 ) error {
 	var fields []string
 	var err error
@@ -72,9 +76,11 @@ func ValidateVisibilityQuery(
 			saNameType,
 			saMapperProvider,
 			queryString,
+			chasmMapper,
+			archetypeID,
 		)
 	} else {
-		fields, err = getQueryFieldsLegacy(namespaceName, saNameType, saMapperProvider, queryString)
+		fields, err = getQueryFieldsLegacy(namespaceName, saNameType, saMapperProvider, queryString, chasmMapper, archetypeID)
 	}
 	if err != nil {
 		return err
@@ -94,6 +100,8 @@ func getQueryFields(
 	saNameType searchattribute.NameTypeMap,
 	saMapperProvider searchattribute.MapperProvider,
 	queryString string,
+	chasmMapper *chasm.VisibilitySearchAttributesMapper,
+	archetypeID chasm.ArchetypeID,
 ) ([]string, error) {
 	saMapper, err := saMapperProvider.GetMapper(namespaceName)
 	if err != nil {
@@ -104,7 +112,9 @@ func getQueryFields(
 		namespaceName,
 		saNameType,
 		saMapper,
-	).WithSearchAttributeInterceptor(saInterceptor)
+	).WithSearchAttributeInterceptor(saInterceptor).
+		WithChasmMapper(chasmMapper).
+		WithArchetypeID(archetypeID)
 	_, err = queryConverter.Convert(queryString)
 	if err != nil {
 		var converterErr *query.ConverterError
@@ -124,9 +134,11 @@ func getQueryFieldsLegacy(
 	saNameType searchattribute.NameTypeMap,
 	saMapperProvider searchattribute.MapperProvider,
 	queryString string,
+	chasmMapper *chasm.VisibilitySearchAttributesMapper,
+	archetypeID chasm.ArchetypeID,
 ) ([]string, error) {
-	fnInterceptor := newFieldNameAggInterceptor(namespaceName, saNameType, saMapperProvider)
-	queryConverter := elasticsearch.NewQueryConverterLegacy(fnInterceptor, nil, saNameType, nil)
+	fnInterceptor := newFieldNameAggInterceptor(namespaceName, saNameType, saMapperProvider, chasmMapper, archetypeID)
+	queryConverter := elasticsearch.NewQueryConverterLegacy(fnInterceptor, nil, saNameType, chasmMapper)
 	_, err := queryConverter.ConvertWhereOrderBy(queryString)
 	if err != nil {
 		var converterErr *query.ConverterError

--- a/service/worker/scheduler/query_test.go
+++ b/service/worker/scheduler/query_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
@@ -23,6 +24,8 @@ func TestFieldNameAggInterceptor(t *testing.T) {
 		testNamespace,
 		searchattribute.TestEsNameTypeMap(),
 		searchattribute.NewTestMapperProvider(nil),
+		nil,
+		chasm.UnspecifiedArchetypeID,
 	)
 
 	_, err := fnInterceptor.Name("CustomIntField", query.FieldNameFilter)
@@ -169,6 +172,8 @@ func TestGetQueryFieldsLegacy(t *testing.T) {
 					searchattribute.TestEsNameTypeMap(),
 					searchattribute.NewTestMapperProvider(nil),
 					tc.input,
+					nil,
+					chasm.UnspecifiedArchetypeID,
 				)
 				if tc.expectedErrMsg == "" {
 					s.NoError(err)
@@ -259,6 +264,8 @@ func TestGetQueryFields(t *testing.T) {
 					searchattribute.TestNameTypeMap(),
 					searchattribute.NewTestMapperProvider(&searchattribute.TestMapper{}),
 					tc.input,
+					nil,
+					chasm.UnspecifiedArchetypeID,
 				)
 				if tc.expectedErrMsg == "" {
 					s.NoError(err)
@@ -340,6 +347,8 @@ func TestValidateVisibilityQuery(t *testing.T) {
 					searchattribute.NewTestMapperProvider(&searchattribute.TestMapper{}),
 					dynamicconfig.GetBoolPropertyFn(true),
 					tc.input,
+					nil,
+					chasm.UnspecifiedArchetypeID,
 				)
 				if tc.expectedErrMsg == "" {
 					s.NoError(err)


### PR DESCRIPTION
## What changed?

This fixes two problems: 
- The Cli was not able to query the CHASM search-attribute 'ScheduleNextActionTime' due to failing validation
- Heretofor I couldn't find a way to find associated system search attributes present on schedules. (see testing section).

## Why?

The ScheduleNextActionTime is a useful search attribute to surface and it's easier to be able to use the CLI to test with it, but this is likely true of other SA too. 

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- I'm not sure if it's desirable to expose system search attibutes to customers, on the face of it I'd say that it is, but not 100% sure here. 
- A bug could impact visibility listing

#### Local Verification:

Before:
```
$ temporal schedule list -q 'ScheduleNextActionTime < "2026-05-30T19:58:27Z"'
time=2026-05-30T12:59:05.899 level=ERROR msg="invalid query: unable to convert filter expression: unable to convert left side of \"ScheduleNextActionTime < '2026-05-30T19:58:27Z'\": invalid search attribute: ScheduleNextActionTime"
```

After
```
$ temporal schedule list -q 'ScheduleNextActionTime < "2026-05-30T19:58:27Z"'
                   ScheduleId                                   Action                  Paused  NextRunTime   LastRunTime
schedule_41f5d4ef-000b-44d7-bd5a-2038bb3ce445  {"Workflow":"SampleScheduleWorkflow"}  true    19 hours ago  19 hours ago
```

### Adding the ability to list associated search attributes

Before
```
temporal schedule list --output json  | jq '.[].searchAttributes' -c
{"indexedFields":{"hasFoo":{"metadata":{"encoding":"anNvbi9wbGFpbg==","type":"Qm9vbA=="},"data":"dHJ1ZQ=="}}} # custom user defined search attribute
null
null
null
null
null
null
```
After
```
➜  temporal git:(bugfix/search-attributes-make-visible) ✗ temporal schedule list --output json  | jq '.[].searchAttributes' -c
{"indexedFields":{"TaskQueue":{"metadata":{"encoding":"anNvbi9wbGFpbg==","type":"S2V5d29yZA=="},"data":"InRlbXBvcmFsLXN5cy1wZXItbnMtdHEi"},"hasFoo":{"metadata":{"encoding":"anNvbi9wbGFpbg==","type":"Qm9vbA=="},"data":"dHJ1ZQ=="}}}
{"indexedFields":{"ExecutionStatus":{"metadata":{"encoding":"anNvbi9wbGFpbg==","type":"S2V5d29yZA=="},"data":"IlJ1bm5pbmci"},"ScheduleNextActionTime":{"metadata":{"encoding":"anNvbi9wbGFpbg==","type":"RGF0ZXRpbWU="},"data":"IjIwMjYtMDUtMzBUMDA6NDE6NDdaIg=="}}}
{"indexedFields":{"ExecutionStatus":{"metadata":{"encoding":"anNvbi9wbGFpbg==","type":"S2V5d29yZA=="},"data":"IlJ1bm5pbmci"},"ScheduleNextActionTime":{"metadata":{"encoding":"anNvbi9wbGFpbg==","type":"RGF0ZXRpbWU="},"data":"IjIwMjYtMDUtMzBUMjE6MjE6MDBaIg=="}}}
{"indexedFields":{"ExecutionStatus":{"metadata":{"encoding":"anNvbi9wbGFpbg==","type":"S2V5d29yZA=="},"data":"IlJ1bm5pbmci"}}}
{"indexedFields":{"ExecutionStatus":{"metadata":{"encoding":"anNvbi9wbGFpbg==","type":"S2V5d29yZA=="},"data":"IlJ1bm5pbmci"}}}
{"indexedFields":{"TaskQueue":{"metadata":{"encoding":"anNvbi9wbGFpbg==","type":"S2V5d29yZA=="},"data":"InRlbXBvcmFsLXN5cy1wZXItbnMtdHEi"}}}
{"indexedFields":{"TaskQueue":{"metadata":{"encoding":"anNvbi9wbGFpbg==","type":"S2V5d29yZA=="},"data":"InRlbXBvcmFsLXN5cy1wZXItbnMtdHEi"}}}
```
