### PR TITLE
Bump Go toolchain to 1.26.3, thrift to 0.23.0, cli to 1.7.1 (security patch) (#10395)

### DIFF
--- a/.github/actions/build-docker-images/scripts/main.go
+++ b/.github/actions/build-docker-images/scripts/main.go
@@ -14,7 +14,7 @@ import (
 var validArchs = []string{"amd64", "arm64"}
 
 // defaultCliVersion should be updated to the latest cli version
-const defaultCliVersion = "1.7.0"
+const defaultCliVersion = "1.7.1"
 
 func main() {
 	if len(os.Args) < 2 {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.temporal.io/server
 
-go 1.26.2
+go 1.26.3
 
 retract (
 	v1.30.0
@@ -100,7 +100,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
-	github.com/apache/thrift v0.21.0 // indirect
+	github.com/apache/thrift v0.23.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,8 @@ github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
-github.com/apache/thrift v0.21.0 h1:tdPmh/ptjE1IJnhbhrcl2++TauVjy242rkV/UzJChnE=
-github.com/apache/thrift v0.21.0/go.mod h1:W1H8aR/QRtYNvrPeFXBtobyRkd0/YVhTc6i07XIAgDw=
+github.com/apache/thrift v0.23.0 h1:wKR6YnefQSEnxpEfmgTPuJibNG4bF0p2TK34tHLWi3s=
+github.com/apache/thrift v0.23.0/go.mod h1:zPt6WxgvTOM6hF92y8C+MkEM5LMxZuk4JcQOiU4Esvs=
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
 github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=


### PR DESCRIPTION
## What changed?
Two security-focused dependency bumps backported to `release/v1.31.x` for the v1.31.1 patch:

1. **Cherry-pick of #10395** — bumps Go toolchain `1.26.2 → 1.26.3` and `github.com/apache/thrift v0.21.0 → v0.23.0`. AWS SDK lines on this branch were kept as-is during conflict resolution (main has drifted forward independently and that drift is not in scope for this security patch).
2. **`defaultCliVersion` bump `1.7.0 → 1.7.1`** in `.github/actions/build-docker-images/scripts/main.go`. CLI v1.7.1 (just released from `temporalio/cli release/1.7.x`, security-only patch) ships `gomarkdown` and Go 1.26.3 bumps that clear the remaining HIGH findings in the bundled CLI binary inside admin-tools.

## Why?
Clears the HIGH/CRITICAL findings that gate the v1.31.1 patch release per the OSS server release runbook (`grype --only-fixed --fail-on high`
  must exit 0 on both `temporaliotest/server` and `temporaliotest/admin-tools`):

  | CVE / GHSA | Severity | Source | Fixed by |
  | --- | --- | --- | --- |
  | CVE-2026-41602 / GHSA-wf45-q9ch-q8gh (`apache/thrift`) | HIGH | server binaries | thrift v0.23.0 |
  | CVE-2026-39820, -42499, -39836, -33814, -33811, -42501 (Go stdlib) | HIGH | server + CLI binaries | Go 1.26.3 |
  | CVE-2026-40890 / GHSA-77fj-vx54-gvh7 (`gomarkdown/markdown`) | HIGH | bundled CLI binary in admin-tools | CLI v1.7.1 (bumps gomarkdown via direct override; ui-server v2.49.x still on the older version) |


## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

