### PR TITLE
Add Event Groups

### DIFF
--- a/cmd/tools/getproto/files.go
+++ b/cmd/tools/getproto/files.go
@@ -85,6 +85,7 @@ func init() {
 	importMap["temporal/api/replication/v1/message.proto"] = replication.File_temporal_api_replication_v1_message_proto
 	importMap["temporal/api/rules/v1/message.proto"] = rules.File_temporal_api_rules_v1_message_proto
 	importMap["temporal/api/schedule/v1/message.proto"] = schedule.File_temporal_api_schedule_v1_message_proto
+	importMap["temporal/api/sdk/v1/event_group_marker.proto"] = sdk.File_temporal_api_sdk_v1_event_group_marker_proto
 	importMap["temporal/api/sdk/v1/task_complete_metadata.proto"] = sdk.File_temporal_api_sdk_v1_task_complete_metadata_proto
 	importMap["temporal/api/sdk/v1/user_metadata.proto"] = sdk.File_temporal_api_sdk_v1_user_metadata_proto
 	importMap["temporal/api/sdk/v1/worker_config.proto"] = sdk.File_temporal_api_sdk_v1_worker_config_proto

--- a/components/nexusoperations/workflow/commands.go
+++ b/components/nexusoperations/workflow/commands.go
@@ -234,6 +234,7 @@ func (ch *commandHandler) HandleScheduleCommand(
 			},
 		}
 		he.UserMetadata = command.UserMetadata
+		he.EventGroupMarkers = command.EventGroupMarkers
 	})
 
 	return nexusoperations.ScheduledEventDefinition{}.Apply(root, event)
@@ -303,6 +304,7 @@ func (ch *commandHandler) HandleCancelCommand(
 			},
 		}
 		he.UserMetadata = command.UserMetadata
+		he.EventGroupMarkers = command.EventGroupMarkers
 	})
 
 	err = nexusoperations.CancelRequestedEventDefinition{}.Apply(ms.HSM(), event)

--- a/components/nexusoperations/workflow/commands_test.go
+++ b/components/nexusoperations/workflow/commands_test.go
@@ -610,6 +610,36 @@ func TestHandleScheduleCommand(t *testing.T) {
 		require.NotNil(t, child)
 		require.EqualExportedValues(t, userMetadata, event.UserMetadata)
 	})
+
+	t.Run("attaches event group markers to the scheduled event", func(t *testing.T) {
+		tcx := newTestContext(t, defaultConfig)
+		groupMarkers := []*sdkpb.EventGroupMarker{
+			{
+				Variant: &sdkpb.EventGroupMarker_Label_{
+					Label: &sdkpb.EventGroupMarker_Label{
+						Id: "explicit-marker-id",
+						Label: &commonpb.Payload{
+							Metadata: map[string][]byte{"encoding": []byte("json/plain")},
+							Data:     []byte(`"payment"`),
+						},
+					},
+				},
+			},
+		}
+		err := tcx.scheduleHandler(context.Background(), tcx.ms, commandValidator{maxPayloadSize: 1}, 1, &commandpb.Command{
+			Attributes: &commandpb.Command_ScheduleNexusOperationCommandAttributes{
+				ScheduleNexusOperationCommandAttributes: &commandpb.ScheduleNexusOperationCommandAttributes{
+					Endpoint:  "endpoint",
+					Service:   "service",
+					Operation: "op",
+				},
+			},
+			EventGroupMarkers: groupMarkers,
+		})
+		require.NoError(t, err)
+		require.Len(t, tcx.history.Events, 1)
+		require.Equal(t, groupMarkers, tcx.history.Events[0].EventGroupMarkers)
+	})
 }
 
 func TestHandleCancelCommand(t *testing.T) {
@@ -776,6 +806,44 @@ func TestHandleCancelCommand(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, child)
 		userMetadata = nil
+	})
+
+	t.Run("attaches event group markers to the cancel-requested event", func(t *testing.T) {
+		tcx := newTestContext(t, defaultConfig)
+		tcx.ms.EXPECT().HasAnyBufferedEvent(gomock.Any()).Return(false).AnyTimes()
+		err := tcx.scheduleHandler(context.Background(), tcx.ms, commandValidator{maxPayloadSize: 1}, 1, &commandpb.Command{
+			Attributes: &commandpb.Command_ScheduleNexusOperationCommandAttributes{
+				ScheduleNexusOperationCommandAttributes: &commandpb.ScheduleNexusOperationCommandAttributes{
+					Endpoint:  "endpoint",
+					Service:   "service",
+					Operation: "op",
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, tcx.history.Events, 1)
+		scheduledEvent := tcx.history.Events[0]
+
+		groupMarkers := []*sdkpb.EventGroupMarker{
+			{
+				Variant: &sdkpb.EventGroupMarker_InboundUpdate_{
+					InboundUpdate: &sdkpb.EventGroupMarker_InboundUpdate{
+						InboundUpdateId: "fire-update-1",
+					},
+				},
+			},
+		}
+		err = tcx.cancelHandler(context.Background(), tcx.ms, commandValidator{maxPayloadSize: 1}, 1, &commandpb.Command{
+			Attributes: &commandpb.Command_RequestCancelNexusOperationCommandAttributes{
+				RequestCancelNexusOperationCommandAttributes: &commandpb.RequestCancelNexusOperationCommandAttributes{
+					ScheduledEventId: scheduledEvent.EventId,
+				},
+			},
+			EventGroupMarkers: groupMarkers,
+		})
+		require.NoError(t, err)
+		require.Len(t, tcx.history.Events, 2)
+		require.Equal(t, groupMarkers, tcx.history.Events[1].EventGroupMarkers)
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
-	go.temporal.io/api v1.62.14-0.20260605195506-b526f51bd9f1
+	go.temporal.io/api v1.62.14-0.20260609212628-1584598228d8
 	go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2
 	go.temporal.io/sdk v1.41.1
 	go.uber.org/fx v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -471,8 +471,8 @@ go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0 h1:R
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0/go.mod h1:I89cynRj8y+383o7tEQVg2SVA6SRgDVIouWPUVXjx0U=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0 h1:CQvJSldHRUN6Z8jsUeYv8J0lXRvygALXIzsmAeCcZE0=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0/go.mod h1:xSQ+mEfJe/GjK1LXEyVOoSI1N9JV9ZI923X5kup43W4=
-go.temporal.io/api v1.62.14-0.20260605195506-b526f51bd9f1 h1:wfFawXpXcBwfIFoYw8rF48eonRmE1KtYcWgrw6OY1/c=
-go.temporal.io/api v1.62.14-0.20260605195506-b526f51bd9f1/go.mod h1:0k75tRljEuELWGeXjEZZO7zYqBln4+1FrG6+IMOMy7Q=
+go.temporal.io/api v1.62.14-0.20260609212628-1584598228d8 h1:i3eIlnuEd9KoKkQVKDcx3+Vv/fYNpmNo0cIc/MlWzzs=
+go.temporal.io/api v1.62.14-0.20260609212628-1584598228d8/go.mod h1:0k75tRljEuELWGeXjEZZO7zYqBln4+1FrG6+IMOMy7Q=
 go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2 h1:1hKeH3GyR6YD6LKMHGCZ76t6h1Sgha0hXVQBxWi3dlQ=
 go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2/go.mod h1:T8dnzVPeO+gaUTj9eDgm/lT2lZH4+JXNvrGaQGyVi50=
 go.temporal.io/sdk v1.41.1 h1:yOpvsHyDD1lNuwlGBv/SUodCPhjv9nDeC9lLHW/fJUA=

--- a/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
+++ b/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
@@ -378,6 +378,9 @@ func (handler *workflowTaskCompletedHandler) handleCommand(
 	if historyEvent != nil && command.UserMetadata != nil {
 		historyEvent.UserMetadata = command.UserMetadata
 	}
+	if historyEvent != nil && len(command.EventGroupMarkers) > 0 {
+		historyEvent.EventGroupMarkers = command.EventGroupMarkers
+	}
 	return response, nil
 }
 

--- a/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler_test.go
+++ b/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler_test.go
@@ -196,6 +196,74 @@ func TestCommandProtocolMessage(t *testing.T) {
 		require.Equal(t, event.UserMetadata, command.UserMetadata)
 	})
 
+	// Verifies that event group markers attached to a command are passed through to the newly created event.
+	t.Run("Attach event group markers", func(t *testing.T) {
+		var tc testconf
+		setup(t, &tc, setupOpts{blobSizeLimit: defaultBlobSizeLimit})
+		msgID := t.Name() + "-message-id"
+		command := msgCommand(msgID)
+		startTimerCommandAttributes := &commandpb.StartTimerCommandAttributes{
+			TimerId: fmt.Sprintf("random-timer-id-%d", rand.Int63()),
+		}
+		command.EventGroupMarkers = []*sdkpb.EventGroupMarker{
+			{
+				Variant: &sdkpb.EventGroupMarker_Label_{
+					Label: &sdkpb.EventGroupMarker_Label{
+						Id: "explicit-marker-id",
+						Label: &commonpb.Payload{
+							Metadata: map[string][]byte{"encoding": []byte("json/plain")},
+							Data:     []byte(`"payment"`),
+						},
+					},
+				},
+			},
+			{
+				Variant: &sdkpb.EventGroupMarker_InboundUpdate_{
+					InboundUpdate: &sdkpb.EventGroupMarker_InboundUpdate{
+						InboundUpdateId: "fire-update-1",
+					},
+				},
+			},
+		}
+
+		command.CommandType = enumspb.COMMAND_TYPE_START_TIMER
+		command.Attributes = &commandpb.Command_StartTimerCommandAttributes{
+			StartTimerCommandAttributes: startTimerCommandAttributes,
+		}
+
+		event := &historypb.HistoryEvent{}
+		tc.ms.EXPECT().AddTimerStartedEvent(tc.handler.workflowTaskCompletedID, startTimerCommandAttributes).MaxTimes(1).Return(event, nil, nil)
+
+		_, err := tc.handler.handleCommand(context.Background(), command, newMsgList())
+		require.NoError(t, err)
+
+		require.Equal(t, command.EventGroupMarkers, event.EventGroupMarkers)
+	})
+
+	// Verifies that an empty or nil EventGroupMarkers slice does not result in any unintended
+	// field being set on the produced history event.
+	t.Run("No event group markers leaves field unset", func(t *testing.T) {
+		var tc testconf
+		setup(t, &tc, setupOpts{blobSizeLimit: defaultBlobSizeLimit})
+		msgID := t.Name() + "-message-id"
+		command := msgCommand(msgID)
+		startTimerCommandAttributes := &commandpb.StartTimerCommandAttributes{
+			TimerId: fmt.Sprintf("random-timer-id-%d", rand.Int63()),
+		}
+		command.CommandType = enumspb.COMMAND_TYPE_START_TIMER
+		command.Attributes = &commandpb.Command_StartTimerCommandAttributes{
+			StartTimerCommandAttributes: startTimerCommandAttributes,
+		}
+
+		event := &historypb.HistoryEvent{}
+		tc.ms.EXPECT().AddTimerStartedEvent(tc.handler.workflowTaskCompletedID, startTimerCommandAttributes).MaxTimes(1).Return(event, nil, nil)
+
+		_, err := tc.handler.handleCommand(context.Background(), command, newMsgList())
+		require.NoError(t, err)
+
+		require.Nil(t, event.EventGroupMarkers)
+	})
+
 	// Verifies that the error is properly handled when event creation fails.
 	t.Run("Event creation failure", func(t *testing.T) {
 		var tc testconf


### PR DESCRIPTION
## What changed?

Introduces support for Event Groups.

More specifically, this PR adds the required copy of the `event_groups` field from `Command` → `HistoryEvent`.

## Why?

Event Groups is a new form of metadata that allows regrouping of logically related Workflow Events, according to user-defined or system-inferred criteria, providing users with improved visibility, analysis, and debugging capabilities.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
