### PR TITLE
TS: supports skipping activity retry backoff

### DIFF
--- a/service/history/workflow/activity.go
+++ b/service/history/workflow/activity.go
@@ -60,6 +60,15 @@ func GetActivityState(ai *persistencespb.ActivityInfo) enumspb.PendingActivitySt
 	return enumspb.PENDING_ACTIVITY_STATE_SCHEDULED
 }
 
+// activityPendingRetry returns true if an activity has failed
+// and retry has scheduled but not yet started
+func activityPendingRetry(ai *persistencespb.ActivityInfo) bool {
+	return GetActivityState(ai) == enumspb.PENDING_ACTIVITY_STATE_SCHEDULED &&
+		!ai.Paused &&
+		ai.HasRetryPolicy &&
+		ai.Attempt > 1
+}
+
 // ClearActivityStartedState resets the per-attempt "started" fields on an ActivityInfo.
 // Called when an activity leaves the started state (retry, pause, etc.) so that stale
 // values from the previous attempt don't leak into the next one.

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -10080,7 +10080,16 @@ func (ms *MutableStateImpl) hasInflightWorkToPreventTimeSkipping() (bool, string
 	if ms.HasPendingWorkflowTask() {
 		return true, "has pending workflow task"
 	}
-	if len(ms.GetPendingActivityInfos()) > 0 {
+	// A pending activity blocks time skipping unless it has failed and is still
+	// waiting out its retry backoff (next attempt strictly in the future) — that one
+	// is a skip target, not in-flight work (see calculateTimeSkippingTransition). The
+	// strict future check is what keeps a just-scheduled or already-due activity (next
+	// attempt <= now) blocking.
+	for _, ai := range ms.GetPendingActivityInfos() {
+		// if this activity is just a retry with backoff scheduled in the future
+		if activityPendingRetry(ai) && ms.Now().Before(ai.GetScheduledTime().AsTime()) {
+			continue
+		}
 		return true, "has pending activity"
 	}
 	if nexusoperations.MachineCollection(ms.HSM()).Size() > 0 {
@@ -10166,10 +10175,10 @@ func (d timeSkippingTransition) isValid() bool {
 // 1. targetTime: the time to skip to
 // 2. disabledAfterBound: a flag indicating whether the time skipping should be flipped off
 // right now the time points considered for target time are:
-// 1. the first expiry time of the pending user timers
-// 2. the start delay of the workflow execution
-// 3. the current elapsed duration bound of the time skipping config
-// 4. the remaining time to skip to the max skipped duration bound
+// - the first expiry time of the pending user timers
+// - the workflow execution retry backoff
+// - the current elapsed duration bound of the time skipping config
+// - the activity retry backoff
 func (ms *MutableStateImpl) calculateTimeSkippingTransition() (timeSkippingTransition, error) {
 	var transition timeSkippingTransition
 	advance := func(candidate time.Time, dueToBound bool) {
@@ -10181,6 +10190,15 @@ func (ms *MutableStateImpl) calculateTimeSkippingTransition() (timeSkippingTrans
 
 	for _, timerInfo := range ms.GetPendingTimerInfos() {
 		advance(timerInfo.ExpiryTime.AsTime(), false)
+	}
+
+	// Activities waiting out a retry backoff are skip targets: advance to the earliest
+	// next-attempt time. No clock comparison is needed here — the idle check already
+	// guarantees each pending activity's next attempt is in the future when we get here.
+	for _, ai := range ms.GetPendingActivityInfos() {
+		if activityPendingRetry(ai) && ms.Now().Before(ai.GetScheduledTime().AsTime()) {
+			advance(ai.ScheduledTime.AsTime(), false)
+		}
 	}
 
 	if !ms.HadOrHasWorkflowTask() {

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -6598,6 +6598,88 @@ func (s *mutableStateSuite) TestHasInflightWorkToPreventTimeSkipping() {
 		s.Equal("has pending activity", reason)
 	})
 
+	s.Run("FalseWhenPendingActivityInRetryBackoff", func() {
+		now := s.mutableState.Now()
+		s.mutableState.pendingActivityInfoIDs[1] = &persistencespb.ActivityInfo{
+			ScheduledEventId: 1,
+			HasRetryPolicy:   true,
+			Attempt:          2,
+			ScheduledTime:    timestamppb.New(now.Add(time.Hour)),
+		}
+		hasPendingWork, reason := s.mutableState.hasInflightWorkToPreventTimeSkipping()
+		s.False(hasPendingWork)
+		s.Empty(reason)
+	})
+
+	s.Run("TrueWhenActivityStarted", func() {
+		now := s.mutableState.Now()
+		s.mutableState.pendingActivityInfoIDs[1] = &persistencespb.ActivityInfo{
+			ScheduledEventId: 1,
+			HasRetryPolicy:   true,
+			Attempt:          2,
+			ScheduledTime:    timestamppb.New(now.Add(time.Hour)),
+			StartedEventId:   10,
+		}
+		hasPendingWork, reason := s.mutableState.hasInflightWorkToPreventTimeSkipping()
+		s.True(hasPendingWork)
+		s.Equal("has pending activity", reason)
+	})
+
+	// A running activity that cannot be retried (no retry policy) must still block:
+	// the STARTED state short-circuits before the retry-policy check.
+	s.Run("TrueWhenActivityStartedNotRetryable", func() {
+		s.mutableState.pendingActivityInfoIDs[1] = &persistencespb.ActivityInfo{
+			ScheduledEventId: 1,
+			HasRetryPolicy:   false,
+			Attempt:          1,
+			StartedEventId:   10,
+		}
+		hasPendingWork, reason := s.mutableState.hasInflightWorkToPreventTimeSkipping()
+		s.True(hasPendingWork)
+		s.Equal("has pending activity", reason)
+	})
+
+	// A first-attempt scheduled activity that has not failed yet (attempt 1) is not
+	// in backoff and must block even if it has a retry policy.
+	s.Run("TrueWhenActivityFirstAttemptScheduled", func() {
+		now := s.mutableState.Now()
+		s.mutableState.pendingActivityInfoIDs[1] = &persistencespb.ActivityInfo{
+			ScheduledEventId: 1,
+			HasRetryPolicy:   true,
+			Attempt:          1,
+			ScheduledTime:    timestamppb.New(now.Add(time.Hour)),
+		}
+		hasPendingWork, reason := s.mutableState.hasInflightWorkToPreventTimeSkipping()
+		s.True(hasPendingWork)
+		s.Equal("has pending activity", reason)
+	})
+
+	s.Run("TrueWhenActivityPausedInBackoff", func() {
+		now := s.mutableState.Now()
+		s.mutableState.pendingActivityInfoIDs[1] = &persistencespb.ActivityInfo{
+			ScheduledEventId: 1,
+			HasRetryPolicy:   true,
+			Attempt:          2,
+			ScheduledTime:    timestamppb.New(now.Add(time.Hour)),
+			Paused:           true,
+		}
+		hasPendingWork, reason := s.mutableState.hasInflightWorkToPreventTimeSkipping()
+		s.True(hasPendingWork)
+		s.Equal("has pending activity", reason)
+	})
+
+	s.Run("TrueWhenActivityScheduledNow", func() {
+		now := s.mutableState.Now()
+		s.mutableState.pendingActivityInfoIDs[1] = &persistencespb.ActivityInfo{
+			ScheduledEventId: 1,
+			HasRetryPolicy:   true,
+			ScheduledTime:    timestamppb.New(now.Add(-time.Hour)),
+		}
+		hasPendingWork, reason := s.mutableState.hasInflightWorkToPreventTimeSkipping()
+		s.True(hasPendingWork)
+		s.Equal("has pending activity", reason)
+	})
+
 	s.Run("TrueWhenPendingChildExecution", func() {
 		s.mutableState.pendingChildExecutionInfoIDs[1] = &persistencespb.ChildExecutionInfo{}
 		hasPendingWork, reason := s.mutableState.hasInflightWorkToPreventTimeSkipping()
@@ -6758,6 +6840,20 @@ func (s *mutableStateSuite) TestShouldExecuteTimeSkipping() {
 		}
 		s.mutableState.pendingTimerInfoIDs["t1"] = &persistencespb.TimerInfo{TimerId: "t1"}
 		s.False(s.mutableState.shouldExecuteTimeSkipping())
+	})
+
+	s.Run("TrueWhenOnlyActivityInRetryBackoff", func() {
+		s.mutableState.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
+			Config: &workflowpb.TimeSkippingConfig{Enabled: true},
+		}
+		now := s.mutableState.Now()
+		s.mutableState.pendingActivityInfoIDs[1] = &persistencespb.ActivityInfo{
+			ScheduledEventId: 1,
+			HasRetryPolicy:   true,
+			Attempt:          2,
+			ScheduledTime:    timestamppb.New(now.Add(time.Hour)),
+		}
+		s.True(s.mutableState.shouldExecuteTimeSkipping())
 	})
 }
 
@@ -8387,6 +8483,7 @@ func (s *mutableStateSuite) TestCalculateTimeSkippingTransition() {
 		ts := clock.NewEventTimeSource().Update(baseTime)
 		s.mutableState.timeSource = ts
 		s.mutableState.pendingTimerInfoIDs = make(map[string]*persistencespb.TimerInfo)
+		s.mutableState.pendingActivityInfoIDs = make(map[int64]*persistencespb.ActivityInfo)
 		s.mutableState.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
 			Config: &workflowpb.TimeSkippingConfig{Enabled: true},
 		}
@@ -8545,6 +8642,55 @@ func (s *mutableStateSuite) TestCalculateTimeSkippingTransition() {
 		s.Require().NoError(err)
 		s.False(tr.isValid(),
 			"backoff in the virtual past must not produce a transition candidate")
+	})
+
+	s.Run("ActivityInRetryBackoff_IsCandidate", func() {
+		resetMS()
+		schedTime := baseTime.Add(30 * time.Minute)
+		s.mutableState.pendingActivityInfoIDs[1] = &persistencespb.ActivityInfo{
+			ScheduledEventId: 1,
+			HasRetryPolicy:   true,
+			Attempt:          2,
+			ScheduledTime:    timestamppb.New(schedTime),
+		}
+
+		tr, err := s.mutableState.calculateTimeSkippingTransition()
+		s.Require().NoError(err)
+		s.Equal(schedTime, tr.targetTime)
+		s.False(tr.disabledAfterBound)
+	})
+
+	s.Run("TwoActivitiesInBackoff_TargetIsEarliest", func() {
+		resetMS()
+		early := baseTime.Add(30 * time.Minute)
+		late := baseTime.Add(2 * time.Hour)
+		s.mutableState.pendingActivityInfoIDs[1] = &persistencespb.ActivityInfo{
+			ScheduledEventId: 1, HasRetryPolicy: true, Attempt: 2,
+			ScheduledTime: timestamppb.New(late),
+		}
+		s.mutableState.pendingActivityInfoIDs[2] = &persistencespb.ActivityInfo{
+			ScheduledEventId: 2, HasRetryPolicy: true, Attempt: 2,
+			ScheduledTime: timestamppb.New(early),
+		}
+
+		tr, err := s.mutableState.calculateTimeSkippingTransition()
+		s.Require().NoError(err)
+		s.Equal(early, tr.targetTime)
+	})
+
+	s.Run("ActivityBackoff_PlusEarlierTimer_TargetIsTimer", func() {
+		resetMS()
+		schedTime := baseTime.Add(2 * time.Hour)
+		timerTime := baseTime.Add(time.Hour)
+		addTimer("t1", timerTime)
+		s.mutableState.pendingActivityInfoIDs[1] = &persistencespb.ActivityInfo{
+			ScheduledEventId: 1, HasRetryPolicy: true, Attempt: 2,
+			ScheduledTime: timestamppb.New(schedTime),
+		}
+
+		tr, err := s.mutableState.calculateTimeSkippingTransition()
+		s.Require().NoError(err)
+		s.Equal(timerTime, tr.targetTime)
 	})
 }
 

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -1047,8 +1047,10 @@ func (r *TaskGeneratorImpl) RegenerateTimerTasksForTimeSkipping() error {
 	}
 
 	// Task regeneration: mutableState.AddTask will adapt virtual time to wall time.
-	// WorkflowTask, Activity, HSM(only nexusoperations) timer tasks won't be regenerated
-	// because time skipping pauses when there are in-flight work.
+	// WorkflowTask and HSM(only nexusoperations) timer tasks won't be regenerated
+	// because time skipping pauses when there is in-flight work. Activity retry
+	// timers are the exception: an activity in retry backoff does not block skipping,
+	// so its retry timer must be re-stamped against the new accumulated skip (see (5)).
 
 	// (1) user timers — regenerate one task per pending user timer. User timers
 	// are only one of the task types that may need regeneration, so continue to
@@ -1134,6 +1136,19 @@ func (r *TaskGeneratorImpl) RegenerateTimerTasksForTimeSkipping() error {
 			})
 		}
 	}
+	// (5) activity retry backoff timers — no time comparison here. Regen runs after
+	// the skip transaction has advanced virtual now past the next-attempt time, so any
+	// now-relative check would wrongly exclude the activity whose timer needs re-stamping.
+	// The structural check (not started, has retry policy, attempt > 1) is sufficient:
+	// the idle gate already ensures every pending activity is a failed retry when we get here.
+	for _, ai := range r.mutableState.GetPendingActivityInfos() {
+		if activityPendingRetry(ai) {
+			if err := r.GenerateActivityRetryTasks(ai); err != nil {
+				return err
+			}
+		}
+	}
+
 	// todo@time-skipping: ChasmTaskPure is not supported yet.
 	return nil
 }

--- a/service/history/workflow/task_generator_test.go
+++ b/service/history/workflow/task_generator_test.go
@@ -1190,6 +1190,8 @@ func TestTaskGeneratorImpl_RegenerateTimerTasksForTimeSkipping(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	mutableState := historyi.NewMockMutableState(ctrl)
+	mutableState.EXPECT().GetPendingActivityInfos().Return(nil).AnyTimes()
+	mutableState.EXPECT().Now().Return(now).AnyTimes()
 	mutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
 		TimeSkippingInfo: &persistencespb.TimeSkippingInfo{
 			AccumulatedSkippedDuration: durationpb.New(skippedDuration),
@@ -1283,6 +1285,8 @@ func TestTaskGeneratorImpl_RegenerateTimerTasksForTimeSkipping_EdgeCases(t *test
 
 			ctrl := gomock.NewController(t)
 			mutableState := historyi.NewMockMutableState(ctrl)
+			mutableState.EXPECT().GetPendingActivityInfos().Return(nil).AnyTimes()
+			mutableState.EXPECT().Now().Return(time.Now().UTC()).AnyTimes()
 			mutableState.EXPECT().GetExecutionInfo().Return(tc.execInfo).AnyTimes()
 			// HadOrHasWorkflowTask is consulted by the backoff-timer regen path. These edge
 			// cases don't exercise that path, so it can return true to short-circuit.
@@ -1342,6 +1346,8 @@ func TestTaskGeneratorImpl_RegenerateTimerTasksForTimeSkipping_ExecutionTimers(t
 
 			ctrl := gomock.NewController(t)
 			mutableState := historyi.NewMockMutableState(ctrl)
+			mutableState.EXPECT().GetPendingActivityInfos().Return(nil).AnyTimes()
+			mutableState.EXPECT().Now().Return(time.Now().UTC()).AnyTimes()
 			mutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
 				NamespaceId:                     namespaceID,
 				WorkflowId:                      workflowID,
@@ -1497,6 +1503,8 @@ func TestTaskGeneratorImpl_RegenerateTimerTasksForTimeSkipping_BoundTimer(t *tes
 
 			ctrl := gomock.NewController(t)
 			mutableState := historyi.NewMockMutableState(ctrl)
+			mutableState.EXPECT().GetPendingActivityInfos().Return(nil).AnyTimes()
+			mutableState.EXPECT().Now().Return(time.Now().UTC()).AnyTimes()
 			mutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
 				TimeSkippingInfo: tc.tsi,
 			}).AnyTimes()
@@ -1618,6 +1626,8 @@ func TestTaskGeneratorImpl_RegenerateTimerTasksForTimeSkipping_BackoffTimer(t *t
 
 			ctrl := gomock.NewController(t)
 			mutableState := historyi.NewMockMutableState(ctrl)
+			mutableState.EXPECT().GetPendingActivityInfos().Return(nil).AnyTimes()
+			mutableState.EXPECT().Now().Return(time.Now().UTC()).AnyTimes()
 			mutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
 				StartTime:     timestamppb.New(tc.startTime),
 				ExecutionTime: timestamppb.New(tc.executionTime),
@@ -1665,6 +1675,73 @@ func TestTaskGeneratorImpl_RegenerateTimerTasksForTimeSkipping_BackoffTimer(t *t
 	}
 }
 
+// TestTaskGeneratorImpl_RegenerateTimerTasksForTimeSkipping_ActivityRetry covers step (5):
+// activity retry timers are re-stamped only for activities in retry backoff, so their
+// wall-clock firing time tracks the new accumulated skip. Activities that are started
+// (actively in flight) must not be regenerated.
+func TestTaskGeneratorImpl_RegenerateTimerTasksForTimeSkipping_ActivityRetry(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	backoffScheduledTime := now.Add(time.Hour)
+
+	ctrl := gomock.NewController(t)
+	mutableState := historyi.NewMockMutableState(ctrl)
+	mutableState.EXPECT().Now().Return(now).AnyTimes()
+	mutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
+		TimeSkippingInfo: &persistencespb.TimeSkippingInfo{
+			AccumulatedSkippedDuration: durationpb.New(time.Hour),
+		},
+	}).AnyTimes()
+	mutableState.EXPECT().GetPendingTimerInfos().Return(map[string]*persistencespb.TimerInfo{}).AnyTimes()
+	mutableState.EXPECT().GetWorkflowKey().Return(tests.WorkflowKey).AnyTimes()
+	mutableState.EXPECT().HadOrHasWorkflowTask().Return(true).AnyTimes()
+	mutableState.EXPECT().GetPendingActivityInfos().Return(map[int64]*persistencespb.ActivityInfo{
+		1: { // in retry backoff -> regenerated
+			ScheduledEventId: 1,
+			HasRetryPolicy:   true,
+			Attempt:          3,
+			Stamp:            7,
+			Version:          42,
+			ScheduledTime:    timestamppb.New(backoffScheduledTime),
+		},
+		2: { // started -> not regenerated
+			ScheduledEventId: 2,
+			HasRetryPolicy:   true,
+			Attempt:          2,
+			StartedEventId:   10,
+			ScheduledTime:    timestamppb.New(backoffScheduledTime),
+		},
+	}).AnyTimes()
+
+	var captured []tasks.Task
+	mutableState.EXPECT().AddTasks(gomock.Any()).Do(func(ts ...tasks.Task) {
+		captured = append(captured, ts...)
+	}).AnyTimes()
+
+	taskGenerator := NewTaskGenerator(nil, mutableState, &configs.Config{}, nil, log.NewTestLogger())
+	require.NoError(t, taskGenerator.RegenerateTimerTasksForTimeSkipping())
+
+	var retryTasks []*tasks.ActivityRetryTimerTask
+	for _, task := range captured {
+		if rt, ok := task.(*tasks.ActivityRetryTimerTask); ok {
+			retryTasks = append(retryTasks, rt)
+		}
+	}
+
+	require.Len(t, retryTasks, 1, "only the backoff activity should be regenerated")
+	rt := retryTasks[0]
+	require.Equal(t, tests.WorkflowKey, rt.WorkflowKey)
+	require.Equal(t, int64(1), rt.EventID)
+	// VisibilityTimestamp is emitted in the virtual frame; the virtual-to-wallclock
+	// subtraction happens inside MutableState.AddTasks, mocked here.
+	require.Equal(t, backoffScheduledTime, rt.VisibilityTimestamp)
+	require.Equal(t, int32(3), rt.Attempt)
+	require.Equal(t, int32(7), rt.Stamp)
+	require.Equal(t, int64(42), rt.Version)
+	require.Equal(t, int64(0), rt.TaskID, "TaskID must be zero (set by shard)")
+}
+
 // TestTaskGeneratorImpl_RegenerateTimerTasksForTimeSkipping_BackoffTimer_StartVersionError
 // verifies that an error from GetStartVersion in step (4) propagates out of
 // RegenerateTimerTasksForTimeSkipping.
@@ -1674,6 +1751,8 @@ func TestTaskGeneratorImpl_RegenerateTimerTasksForTimeSkipping_BackoffTimer_Star
 	now := time.Now().UTC()
 	ctrl := gomock.NewController(t)
 	mutableState := historyi.NewMockMutableState(ctrl)
+	mutableState.EXPECT().GetPendingActivityInfos().Return(nil).AnyTimes()
+	mutableState.EXPECT().Now().Return(now).AnyTimes()
 	mutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
 		StartTime:     timestamppb.New(now),
 		ExecutionTime: timestamppb.New(now.Add(time.Hour)),

--- a/tests/timeskipping_test.go
+++ b/tests/timeskipping_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -496,6 +497,90 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_TimerAndActivity() {
 	s.True(hasEventType(history, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TIME_SKIPPING_TRANSITIONED),
 		"time-skipping transitioned event expected")
 	s.True(hasEventType(history, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED), "workflow must complete")
+}
+
+// TestTimeSkipping_ActivityRetryBackoff verifies that when the only in-flight work
+// is an activity waiting out a retry backoff, time-skipping fires: it advances virtual
+// time to the activity's next-attempt time and re-stamps the activity retry timer to
+// near-now wall, so the retry is dispatched promptly instead of after the full backoff.
+//
+// Sequence:
+//
+//	WT1 → schedule an activity with a 1h retry InitialInterval (MaximumAttempts=2)
+//	AT1 → fail attempt 1; the server schedules the retry 1h out (virtual). The workflow
+//	      is now idle except for the backoff activity, so the close transaction skips ~1h
+//	      and re-stamps the ActivityRetryTimerTask to ~now wall.
+//	AT2 → retry is dispatchable promptly (well under 1h wall); complete it.
+//	WT2 → activity completed → complete the workflow.
+func (s *TimeSkippingTestSuite) TestTimeSkipping_ActivityRetryBackoff() {
+	env := testcore.NewEnv(s.T())
+	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	tv := testvars.New(s.T())
+
+	wallStart := time.Now()
+	// Run timeout must exceed the (virtual) backoff so the skipped-forward run-timeout
+	// task doesn't fire the workflow before the activity retries.
+	runID := s.startWorkflowWithTimeSkipping(env, tv, 4*time.Hour)
+	poller := taskpoller.New(s.T(), env.FrontendClient(), env.Namespace().String())
+
+	// WT1: schedule an activity that backs off 1h between attempts. ScheduleToClose
+	// must exceed the backoff so the retry isn't cut off by the schedule-to-close deadline.
+	_, err := poller.PollAndHandleWorkflowTask(tv, func(_ *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{
+			Commands: []*commandpb.Command{
+				{
+					CommandType: enumspb.COMMAND_TYPE_SCHEDULE_ACTIVITY_TASK,
+					Attributes: &commandpb.Command_ScheduleActivityTaskCommandAttributes{
+						ScheduleActivityTaskCommandAttributes: &commandpb.ScheduleActivityTaskCommandAttributes{
+							ActivityId:             tv.ActivityID(),
+							ActivityType:           tv.ActivityType(),
+							TaskQueue:              tv.TaskQueue(),
+							ScheduleToCloseTimeout: durationpb.New(3 * time.Hour),
+							StartToCloseTimeout:    durationpb.New(30 * time.Second),
+							RetryPolicy: &commonpb.RetryPolicy{
+								InitialInterval:    durationpb.New(time.Hour),
+								BackoffCoefficient: 1.0,
+								MaximumAttempts:    2,
+							},
+						},
+					},
+				},
+			},
+		}, nil
+	})
+	s.NoError(err)
+
+	// AT1: fail the activity, triggering a 1h retry backoff and (because the workflow
+	// is otherwise idle) a time-skipping transition on the close transaction.
+	_, err = poller.PollAndHandleActivityTask(tv, func(_ *workflowservice.PollActivityTaskQueueResponse) (*workflowservice.RespondActivityTaskCompletedRequest, error) {
+		return nil, errors.New("fail attempt 1")
+	})
+	s.NoError(err)
+
+	// AT2: the retry is dispatchable promptly thanks to time-skipping; complete it.
+	_, err = poller.PollAndHandleActivityTask(tv, taskpoller.CompleteActivityTask(tv))
+	s.NoError(err)
+
+	// WT2: activity completed → complete the workflow.
+	_, err = poller.PollAndHandleWorkflowTask(tv, func(_ *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{
+			Commands: []*commandpb.Command{completeWorkflowCmd()},
+		}, nil
+	})
+	s.NoError(err)
+	wallElapsed := time.Since(wallStart)
+
+	history := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: tv.WorkflowID(), RunId: runID})
+	s.True(hasEventType(history, enumspb.EVENT_TYPE_ACTIVITY_TASK_COMPLETED),
+		"activity must complete on its retry attempt")
+	s.True(hasEventType(history, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TIME_SKIPPING_TRANSITIONED),
+		"time-skipping transitioned event expected (the activity retry backoff was skipped)")
+	s.True(hasEventType(history, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED), "workflow must complete")
+
+	// Wall elapsed must be well under the 1h backoff — the retry was skipped, not waited out.
+	s.Less(wallElapsed, 3*time.Second,
+		"test wall elapsed = %v; the activity retry should be dispatched promptly after skipping the 1h backoff",
+		wallElapsed)
 }
 
 func (s *TimeSkippingTestSuite) TestTimeSkipping_PendingSignalExternalBlocksSkip() {


### PR DESCRIPTION
## What changed?
  - gate (hasInflightWorkToPreventTimeSkipping)
  - skip target (calculateTimeSkippingTransition)
  - regen (RegenerateTimerTasksForTimeSkipping)

## Why?
1. in flight work shouldn't count failed activities that are waiting to be retried
5. activity retry backoff should be skipped

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

