### PR TITLE
Use `ActiveClusterName` to assert on active cluster

### DIFF
--- a/service/history/replication/executable_delete_execution_task.go
+++ b/service/history/replication/executable_delete_execution_task.go
@@ -103,6 +103,21 @@ func (e *ExecutableDeleteExecutionTask) Execute() error {
 		)
 		return nil
 	}
+	namespaceEntry, err := e.NamespaceCache.GetNamespaceByID(namespace.ID(e.NamespaceID))
+	if err != nil {
+		return err
+	}
+	currentCluster := e.ClusterMetadata.GetCurrentClusterName()
+	if namespaceEntry.ActiveClusterName(namespace.RoutingKey{ID: e.BusinessID}) == currentCluster {
+		e.Logger.Warn("Skipping delete execution replication task on active cluster",
+			tag.WorkflowNamespaceID(e.NamespaceID),
+			tag.WorkflowID(e.BusinessID),
+			tag.WorkflowRunID(e.RunID),
+			tag.TaskID(e.TaskID()),
+			tag.ClusterName(currentCluster),
+		)
+		return nil
+	}
 
 	ctx, cancel := newTaskContext(namespaceName, e.Config.ReplicationTaskApplyTimeout(), callerInfo)
 	defer cancel()

--- a/service/history/replication/executable_delete_execution_task.go
+++ b/service/history/replication/executable_delete_execution_task.go
@@ -116,6 +116,11 @@ func (e *ExecutableDeleteExecutionTask) Execute() error {
 			tag.TaskID(e.TaskID()),
 			tag.ClusterName(currentCluster),
 		)
+		metrics.ReplicationTasksSkipped.With(e.MetricsHandler).Record(
+			1,
+			metrics.OperationTag(metrics.DeleteExecutionReplicationTaskScope),
+			metrics.NamespaceTag(namespaceName),
+		)
 		return nil
 	}
 

--- a/service/history/replication/executable_delete_execution_task_test.go
+++ b/service/history/replication/executable_delete_execution_task_test.go
@@ -1,0 +1,165 @@
+package replication
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	commonpb "go.temporal.io/api/common/v1"
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	"go.temporal.io/server/api/historyservice/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	replicationspb "go.temporal.io/server/api/replication/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/service/history/configs"
+	historyi "go.temporal.io/server/service/history/interfaces"
+	"go.temporal.io/server/service/history/shard"
+	"go.temporal.io/server/service/history/tests"
+	"go.uber.org/mock/gomock"
+)
+
+type (
+	executableDeleteExecutionTaskSuite struct {
+		suite.Suite
+		*require.Assertions
+
+		controller      *gomock.Controller
+		clusterMetadata *cluster.MockMetadata
+		shardController *shard.MockController
+		namespaceCache  *namespace.MockRegistry
+		metricsHandler  metrics.Handler
+		logger          log.Logger
+		config          *configs.Config
+
+		namespaceID       namespace.ID
+		workflowID        string
+		runID             string
+		taskID            int64
+		taskCreationTime  time.Time
+		sourceClusterName string
+		sourceShardKey    ClusterShardKey
+		processToolBox    ProcessToolBox
+	}
+)
+
+func TestExecutableDeleteExecutionTaskSuite(t *testing.T) {
+	s := new(executableDeleteExecutionTaskSuite)
+	suite.Run(t, s)
+}
+
+func (s *executableDeleteExecutionTaskSuite) SetupSuite() {
+	s.Assertions = require.New(s.T())
+}
+
+func (s *executableDeleteExecutionTaskSuite) SetupTest() {
+	s.controller = gomock.NewController(s.T())
+	s.clusterMetadata = cluster.NewMockMetadata(s.controller)
+	s.shardController = shard.NewMockController(s.controller)
+	s.namespaceCache = namespace.NewMockRegistry(s.controller)
+	s.metricsHandler = metrics.NoopMetricsHandler
+	s.logger = log.NewNoopLogger()
+	s.config = tests.NewDynamicConfig()
+
+	s.namespaceID = namespace.NewID()
+	s.workflowID = uuid.NewString()
+	s.runID = uuid.NewString()
+	s.taskID = rand.Int63()
+	s.taskCreationTime = time.Unix(0, rand.Int63())
+	s.sourceClusterName = cluster.TestAlternativeClusterName
+	s.sourceShardKey = ClusterShardKey{
+		ClusterID: int32(cluster.TestAlternativeClusterInitialFailoverVersion),
+		ShardID:   rand.Int31(),
+	}
+	s.processToolBox = ProcessToolBox{
+		Config:          s.config,
+		ClusterMetadata: s.clusterMetadata,
+		ShardController: s.shardController,
+		NamespaceCache:  s.namespaceCache,
+		MetricsHandler:  s.metricsHandler,
+		Logger:          s.logger,
+		ThrottledLogger: s.logger,
+	}
+
+	s.clusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
+}
+
+func (s *executableDeleteExecutionTaskSuite) TearDownTest() {
+	s.controller.Finish()
+}
+
+func (s *executableDeleteExecutionTaskSuite) TestExecute_CurrentClusterActive_SkipsTask() {
+	namespaceEntry := s.namespaceEntry(cluster.TestCurrentClusterName)
+	s.namespaceCache.EXPECT().GetNamespaceByID(s.namespaceID).Return(namespaceEntry, nil).Times(3)
+
+	s.NoError(s.newTask().Execute())
+}
+
+func (s *executableDeleteExecutionTaskSuite) TestExecute_CurrentClusterPassive_DeletesWorkflowExecution() {
+	namespaceEntry := s.namespaceEntry(cluster.TestAlternativeClusterName)
+	s.namespaceCache.EXPECT().GetNamespaceByID(s.namespaceID).Return(namespaceEntry, nil).Times(3)
+
+	shardContext := historyi.NewMockShardContext(s.controller)
+	engine := historyi.NewMockEngine(s.controller)
+	s.shardController.EXPECT().GetShardByNamespaceWorkflow(s.namespaceID, s.workflowID).Return(shardContext, nil)
+	shardContext.EXPECT().GetEngine(gomock.Any()).Return(engine, nil)
+	engine.EXPECT().DeleteWorkflowExecution(gomock.Any(), &historyservice.DeleteWorkflowExecutionRequest{
+		NamespaceId: s.namespaceID.String(),
+		WorkflowExecution: &commonpb.WorkflowExecution{
+			WorkflowId: s.workflowID,
+			RunId:      s.runID,
+		},
+	}).Return(&historyservice.DeleteWorkflowExecutionResponse{}, nil)
+
+	s.NoError(s.newTask().Execute())
+}
+
+func (s *executableDeleteExecutionTaskSuite) newTask() *ExecutableDeleteExecutionTask {
+	return NewExecutableDeleteExecutionTask(
+		s.processToolBox,
+		s.taskID,
+		s.taskCreationTime,
+		s.sourceClusterName,
+		s.sourceShardKey,
+		&replicationspb.ReplicationTask{
+			TaskType: enumsspb.REPLICATION_TASK_TYPE_DELETE_EXECUTION_TASK,
+			RawTaskInfo: &persistencespb.ReplicationTaskInfo{
+				NamespaceId: s.namespaceID.String(),
+				WorkflowId:  s.workflowID,
+				RunId:       s.runID,
+				TaskId:      s.taskID,
+				ArchetypeId: chasm.WorkflowArchetypeID,
+			},
+		},
+	)
+}
+
+func (s *executableDeleteExecutionTaskSuite) namespaceEntry(activeCluster string) *namespace.Namespace {
+	detail := &persistencespb.NamespaceDetail{
+		Info: &persistencespb.NamespaceInfo{
+			Id:   s.namespaceID.String(),
+			Name: "namespace-name",
+		},
+		Config: &persistencespb.NamespaceConfig{},
+		ReplicationConfig: &persistencespb.NamespaceReplicationConfig{
+			ActiveClusterName: activeCluster,
+			Clusters: []string{
+				cluster.TestCurrentClusterName,
+				cluster.TestAlternativeClusterName,
+			},
+		},
+		FailoverVersion: cluster.TestCurrentClusterInitialFailoverVersion,
+	}
+	namespaceEntry, err := namespace.FromPersistentState(
+		detail,
+		namespace.NewDefaultReplicationResolverFactory()(detail),
+	)
+	s.NoError(err)
+	return namespaceEntry
+}

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -994,7 +994,7 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 					if nsEntry, err := s.GetNamespaceRegistry().GetNamespaceByID(
 						namespace.ID(key.NamespaceID),
 					); err == nil &&
-						nsEntry.ActiveInCluster(s.GetClusterMetadata().GetCurrentClusterName()) &&
+						nsEntry.ActiveClusterName(namespace.RoutingKey{ID: key.WorkflowID}) == s.GetClusterMetadata().GetCurrentClusterName() &&
 						nsEntry.ReplicationPolicy() == namespace.ReplicationPolicyMultiCluster {
 						newTasks[tasks.CategoryReplication] = []tasks.Task{
 							&tasks.DeleteExecutionReplicationTask{

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -19,6 +19,7 @@ import (
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/definition"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/primitives/timestamp"
@@ -327,6 +328,77 @@ func (s *contextSuite) TestDeleteWorkflowExecution_ErrorAndContinue_Success() {
 	)
 	s.NoError(err)
 	s.Equal(tasks.DeleteWorkflowExecutionStageCurrent|tasks.DeleteWorkflowExecutionStageMutableState|tasks.DeleteWorkflowExecutionStageVisibility|tasks.DeleteWorkflowExecutionStageHistory|tasks.DeleteWorkflowExecutionStageReplication, stage)
+}
+
+func (s *contextSuite) TestDeleteWorkflowExecution_EmitsReplicationTaskWhenWorkflowActiveInCurrentCluster() {
+	captured := s.runDeleteWorkflowExecutionForReplicationCheck(cluster.TestCurrentClusterName)
+
+	replicationTasks := captured.Tasks[tasks.CategoryReplication]
+	s.Require().Len(replicationTasks, 1, "expected a DeleteExecutionReplicationTask when workflow is active in current cluster")
+	deleteTask, ok := replicationTasks[0].(*tasks.DeleteExecutionReplicationTask)
+	s.True(ok, "task should be *DeleteExecutionReplicationTask")
+	s.Equal(captured.WorkflowID, deleteTask.WorkflowKey.WorkflowID)
+	s.Equal(captured.NamespaceID, deleteTask.WorkflowKey.NamespaceID)
+}
+
+func (s *contextSuite) TestDeleteWorkflowExecution_NoReplicationTaskWhenWorkflowActiveInOtherCluster() {
+	captured := s.runDeleteWorkflowExecutionForReplicationCheck(cluster.TestAlternativeClusterName)
+
+	s.Empty(captured.Tasks[tasks.CategoryReplication],
+		"expected no DeleteExecutionReplicationTask when workflow is active in another cluster")
+}
+
+func (s *contextSuite) runDeleteWorkflowExecutionForReplicationCheck(
+	workflowActiveCluster string,
+) *persistence.AddHistoryTasksRequest {
+	// Enable the dynamic-config gate the producer checks.
+	s.mockShard.GetConfig().EnableDeleteWorkflowExecutionReplication = dynamicconfig.GetBoolPropertyFn(true)
+
+	nsID := namespace.NewID()
+	nsEntry := namespace.NewGlobalNamespaceForTest(
+		&persistencespb.NamespaceInfo{Id: nsID.String(), Name: "global-ns-for-delete-replication"},
+		&persistencespb.NamespaceConfig{Retention: timestamp.DurationFromDays(1)},
+		&persistencespb.NamespaceReplicationConfig{
+			ActiveClusterName: workflowActiveCluster,
+			Clusters: []string{
+				cluster.TestCurrentClusterName,
+				cluster.TestAlternativeClusterName,
+			},
+		},
+		tests.Version,
+	)
+	s.mockNamespaceCache.EXPECT().GetNamespaceByID(nsID).Return(nsEntry, nil).AnyTimes()
+
+	workflowKey := definition.WorkflowKey{
+		NamespaceID: nsID.String(),
+		WorkflowID:  tests.WorkflowID,
+		RunID:       tests.RunID,
+	}
+
+	var captured *persistence.AddHistoryTasksRequest
+	s.mockExecutionManager.EXPECT().AddHistoryTasks(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *persistence.AddHistoryTasksRequest) error {
+			captured = req
+			return nil
+		})
+	s.mockHistoryEngine.EXPECT().NotifyNewTasks(gomock.Any())
+	s.mockExecutionManager.EXPECT().DeleteCurrentWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil)
+	s.mockExecutionManager.EXPECT().DeleteWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil)
+	s.mockExecutionManager.EXPECT().DeleteHistoryBranch(gomock.Any(), gomock.Any()).Return(nil)
+
+	stage := tasks.DeleteWorkflowExecutionStageNone
+	err := s.mockShard.DeleteWorkflowExecution(
+		context.Background(),
+		workflowKey,
+		chasm.WorkflowArchetypeID,
+		[]byte("branchToken"),
+		0,
+		time.Time{},
+		&stage,
+	)
+	s.NoError(err)
+	s.Require().NotNil(captured, "AddHistoryTasks was never called")
+	return captured
 }
 
 func (s *contextSuite) TestDeleteWorkflowExecution_DeleteVisibilityTaskNotifiction() {

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -337,8 +337,8 @@ func (s *contextSuite) TestDeleteWorkflowExecution_EmitsReplicationTaskWhenWorkf
 	s.Require().Len(replicationTasks, 1, "expected a DeleteExecutionReplicationTask when workflow is active in current cluster")
 	deleteTask, ok := replicationTasks[0].(*tasks.DeleteExecutionReplicationTask)
 	s.True(ok, "task should be *DeleteExecutionReplicationTask")
-	s.Equal(captured.WorkflowID, deleteTask.WorkflowKey.WorkflowID)
-	s.Equal(captured.NamespaceID, deleteTask.WorkflowKey.NamespaceID)
+	s.Equal(captured.WorkflowID, deleteTask.WorkflowID)
+	s.Equal(captured.NamespaceID, deleteTask.NamespaceID)
 }
 
 func (s *contextSuite) TestDeleteWorkflowExecution_NoReplicationTaskWhenWorkflowActiveInOtherCluster() {


### PR DESCRIPTION
## What changed?

- Use `ActiveClusterName(namespace.RoutingKey{ID: workflowID})` instead of `ActiveInCluster` when deciding whether to emit delete execution replication tasks.
- Skip delete execution replication task execution when the current cluster is active for the workflow/business ID.

## Why?

Delete execution replication should be produced by the workflow’s active cluster and applied only on passive clusters. 

`ActiveClusterName` should be used to determine active workflow.
```
// Note: Do not use this to determine if a workflow is active in the cluster.
// Use ActiveClusterName(businessID) instead.
```

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
