### PR TITLE
Remove stale TODO comment referencing closed issue #668

### DIFF
--- a/service/history/workflow/cache/cache.go
+++ b/service/history/workflow/cache/cache.go
@@ -369,7 +369,6 @@ func (c *cacheImpl) makeReleaseFunc(
 				panic(rec)
 			} else {
 				if err != nil || forceClearContext {
-					// TODO see issue #668, there are certain type or errors which can bypass the clear
 					wfContext.Clear()
 					wfContext.Unlock()
 					c.Release(cacheKey)


### PR DESCRIPTION
The error handling referenced in the TODO has been implemented. Errors properly trigger wfContext.Clear(), Unlock(), and Release(). Issue #668 was closed in August 2020.

## What changed?
Removed a stale TODO comment in `cache.go` that referenced 
closed issue #668.

## Why?
The TODO referenced a concern from 2020 about certain error types 
bypassing the cache clear operation. The surrounding code now 
properly handles this — errors trigger wfContext.Clear(), 
Unlock(), and Release(). The comment is no longer accurate 
and adds noise to the codebase.

## How did you test it?
✅ built
✅ covered by existing tests (comment removal only, no logic change)

## Potential risks
None — this is a comment-only removal with no logic changes.
