### PR TITLE
test: fix TestContinueAsNewWithDelayStart build after parallelsuite migration

### DIFF
--- a/tests/continue_as_new_test.go
+++ b/tests/continue_as_new_test.go
@@ -472,10 +472,12 @@ func (s *ContinueAsNewTestSuite) TestWorkflowContinueAsNewTaskID() {
 // The task poller sends this command over gRPC verbatim, which is how we simulate an SDK that does
 // support the flag.
 func (s *ContinueAsNewTestSuite) TestContinueAsNewWithDelayStart() {
+	env := testcore.NewEnv(s.T())
+
 	// Disable the minimal continue-as-new interval so the only backoff applied to the new run is the
 	// one we explicitly request. Otherwise the server enforces WorkflowIdReuseMinimalInterval and the
 	// observed backoff could come from there rather than from our requested delay.
-	s.OverrideDynamicConfig(dynamicconfig.WorkflowIdReuseMinimalInterval, time.Duration(0))
+	env.OverrideDynamicConfig(dynamicconfig.WorkflowIdReuseMinimalInterval, time.Duration(0))
 
 	id := "functional-continue-as-new-delay-start-test"
 	wt := "functional-continue-as-new-delay-start-test-type"
@@ -487,7 +489,7 @@ func (s *ContinueAsNewTestSuite) TestContinueAsNewWithDelayStart() {
 
 	request := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:           uuid.NewString(),
-		Namespace:           s.Namespace().String(),
+		Namespace:           env.Namespace().String(),
 		WorkflowId:          id,
 		WorkflowType:        workflowType,
 		TaskQueue:           taskQueue,
@@ -496,9 +498,9 @@ func (s *ContinueAsNewTestSuite) TestContinueAsNewWithDelayStart() {
 		Identity:            identity,
 	}
 
-	we, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)
+	we, err := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err)
-	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
+	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
 	const delayStart = 1 * time.Second
 
@@ -538,7 +540,7 @@ func (s *ContinueAsNewTestSuite) TestContinueAsNewWithDelayStart() {
 	}
 
 	tv := testvars.New(s.T()).WithTaskQueue(tl)
-	poller := taskpoller.New(s.T(), s.FrontendClient(), s.Namespace().String())
+	poller := taskpoller.New(s.T(), env.FrontendClient(), env.Namespace().String())
 
 	// Process the first workflow task: it issues a continue-as-new with a delayed start.
 	_, err = poller.PollAndHandleWorkflowTask(tv, wtHandler)
@@ -546,7 +548,7 @@ func (s *ContinueAsNewTestSuite) TestContinueAsNewWithDelayStart() {
 	s.False(workflowComplete)
 
 	// The original run's history must record the requested backoff on the continue-as-new event.
-	firstRunEvents := s.GetHistory(s.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: id, RunId: we.RunId})
+	firstRunEvents := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: id, RunId: we.RunId})
 	continuedAsNewEvent := firstRunEvents[len(firstRunEvents)-1]
 	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW, continuedAsNewEvent.GetEventType())
 	canAttrs := continuedAsNewEvent.GetWorkflowExecutionContinuedAsNewEventAttributes()
@@ -566,7 +568,7 @@ func (s *ContinueAsNewTestSuite) TestContinueAsNewWithDelayStart() {
 	s.True(workflowComplete)
 
 	// The new run started with the requested first-workflow-task backoff and ran to completion.
-	finalEvents := s.GetHistory(s.Namespace().String(), newRunExecution)
+	finalEvents := env.GetHistory(env.Namespace().String(), newRunExecution)
 	startedAttrs := finalEvents[0].GetWorkflowExecutionStartedEventAttributes()
 	s.Equal(delayStart, startedAttrs.GetFirstWorkflowTaskBackoff().AsDuration())
 	s.Equal(we.RunId, startedAttrs.GetContinuedExecutionRunId())


### PR DESCRIPTION
## Problem

`main` is currently failing to build the `tests` package:

```
tests/continue_as_new_test.go:478:4: s.OverrideDynamicConfig undefined (type *ContinueAsNewTestSuite has no field or method OverrideDynamicConfig)
```

`continue_as_new_test.go` was migrated to the `parallelsuite` / `testcore.NewEnv` pattern in a separate change that merged around the same time as #10435 (which added `TestContinueAsNewWithDelayStart`). Both touched this file, merged cleanly at the text level, but the combined result left the new test using the old suite helpers (`s.OverrideDynamicConfig`, `s.Namespace`, `s.FrontendClient`, `s.GetHistory`, `testcore.NewContext`) that no longer exist on the migrated suite — so the package no longer compiles.

## Fix

Migrate `TestContinueAsNewWithDelayStart` to the env-based pattern used by the rest of the file:
- obtain a per-test env via `testcore.NewEnv(s.T())`
- route namespace, frontend client, logger, history reads, and the dynamic config override through `env`
- use `s.Context()` instead of `testcore.NewContext()`

`WorkflowIdReuseMinimalInterval` is namespace-scoped, so `env.OverrideDynamicConfig` works on the shared cluster (it is automatically constrained to the per-test namespace). No change to what the test verifies.

## Testing

`go test ./tests/ -run 'TestContinueAsNewTestSuite/TestContinueAsNewWithDelayStart'` passes (1.1s).