### PR TITLE
Wire passwordCommand config to docker environment variables

### DIFF
--- a/config/docker.yaml
+++ b/config/docker.yaml
@@ -56,6 +56,10 @@ persistence:
                 connectProtocol: "tcp"
                 user: {{ env "MYSQL_USER" | quote }}
                 password: {{ env "MYSQL_PWD" | quote }}
+                {{- if env "MYSQL_PASSWORD_COMMAND" }}
+                passwordCommand:
+                    command: {{ env "MYSQL_PASSWORD_COMMAND" | quote }}
+                {{- end }}
                 {{- if env "MYSQL_TX_ISOLATION_COMPAT" }}
                 connectAttributes:
                     tx_isolation: "'READ-COMMITTED'"
@@ -78,6 +82,10 @@ persistence:
                 connectProtocol: "tcp"
                 user: {{ env "POSTGRES_USER" | quote }}
                 password: {{ env "POSTGRES_PWD" | quote }}
+                {{- if env "POSTGRES_PASSWORD_COMMAND" }}
+                passwordCommand:
+                    command: {{ env "POSTGRES_PASSWORD_COMMAND" | quote }}
+                {{- end }}
                 maxConns: {{ default "20" (env "SQL_MAX_CONNS") }}
                 maxIdleConns: {{ default "20" (env "SQL_MAX_IDLE_CONNS") }}
                 maxConnLifetime: {{ default "1h" (env "SQL_MAX_CONN_TIME") }}
@@ -116,6 +124,10 @@ persistence:
                 connectProtocol: "tcp"
                 user: {{ $visibility_user | quote }}
                 password: {{ $visibility_pwd | quote }}
+                {{- if env "MYSQL_PASSWORD_COMMAND" }}
+                passwordCommand:
+                    command: {{ env "MYSQL_PASSWORD_COMMAND" | quote }}
+                {{- end }}
                 {{- if env "MYSQL_TX_ISOLATION_COMPAT" }}
                 connectAttributes:
                     tx_isolation: "'READ-COMMITTED'"
@@ -142,6 +154,10 @@ persistence:
                 connectProtocol: "tcp"
                 user: {{ $visibility_user | quote }}
                 password: {{ $visibility_pwd | quote }}
+                {{- if env "POSTGRES_PASSWORD_COMMAND" }}
+                passwordCommand:
+                    command: {{ env "POSTGRES_PASSWORD_COMMAND" | quote }}
+                {{- end }}
                 maxConns: {{ default "10" (env "SQL_VIS_MAX_CONNS") }}
                 maxIdleConns: {{ default "10" (env "SQL_VIS_MAX_IDLE_CONNS") }}
                 maxConnLifetime: {{ default "1h" (env "SQL_VIS_MAX_CONN_TIME") }}


### PR DESCRIPTION
## What changed?
Added `MYSQL_PASSWORD_COMMAND` and `POSTGRES_PASSWORD_COMMAND` 
environment variables to `config/docker.yaml` for both primary 
and visibility database stores (4 sections total).

## Why?
The `passwordCommand` feature was added in #9879 but was not wired 
into the docker environment variable configuration. Users running 
Temporal via Docker who want to use external commands for database 
password retrieval (e.g. cloud IAM tokens like Azure Entra) were 
forced to provide a manual config file override instead of using 
environment variables like other config options.

This change makes `passwordCommand` consistent with how other 
database config options (password, user, host) are exposed via 
environment variables.

Fixes #10245

## How did you test it?
- [x] built
- [x] covered by existing tests

Note: YAML template change only — no Go logic changed.

## Potential risks
Low — additive change only. The passwordCommand block is 
conditionally rendered with `{{- if env "..." }}` so existing 
deployments that don't set these env vars are completely unaffected.