### PR TITLE
replace arduino/setup-protoc@v3

### DIFF
--- a/.github/mise.toml
+++ b/.github/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+protoc = "23.4"

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -37,15 +37,9 @@ jobs:
           check-latest: true
           cache: true
 
-      - name: read protoc version
-        id: protoc-version
-        run: echo "version=$(make protoc-version)" >> "$GITHUB_OUTPUT"
-
       - uses: jdx/mise-action@v4
         with:
-          mise_toml: |
-            [tools]
-            protoc = "${{ steps.protoc-version.outputs.version }}"
+          working_directory: .github
           install_args: protoc
 
       - name: lint protobuf definitions
@@ -65,15 +59,9 @@ jobs:
           check-latest: true
           cache: true
 
-      - name: read protoc version
-        id: protoc-version
-        run: echo "version=$(make protoc-version)" >> "$GITHUB_OUTPUT"
-
       - uses: jdx/mise-action@v4
         with:
-          mise_toml: |
-            [tools]
-            protoc = "${{ steps.protoc-version.outputs.version }}"
+          working_directory: .github
           install_args: protoc
 
       - name: lint protobuf API definitions
@@ -93,15 +81,9 @@ jobs:
           check-latest: true
           cache: true
 
-      - name: read protoc version
-        id: protoc-version
-        run: echo "version=$(make protoc-version)" >> "$GITHUB_OUTPUT"
-
       - uses: jdx/mise-action@v4
         with:
-          mise_toml: |
-            [tools]
-            protoc = "${{ steps.protoc-version.outputs.version }}"
+          working_directory: .github
           install_args: protoc
 
       - name: lint system workflows with workflowcheck

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -37,9 +37,16 @@ jobs:
           check-latest: true
           cache: true
 
-      - uses: arduino/setup-protoc@v3
+      - name: read protoc version
+        id: protoc-version
+        run: echo "version=$(make protoc-version)" >> "$GITHUB_OUTPUT"
+
+      - uses: jdx/mise-action@v4
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          mise_toml: |
+            [tools]
+            protoc = "${{ steps.protoc-version.outputs.version }}"
+          install_args: protoc
 
       - name: lint protobuf definitions
         run: |
@@ -58,9 +65,16 @@ jobs:
           check-latest: true
           cache: true
 
-      - uses: arduino/setup-protoc@v3
+      - name: read protoc version
+        id: protoc-version
+        run: echo "version=$(make protoc-version)" >> "$GITHUB_OUTPUT"
+
+      - uses: jdx/mise-action@v4
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          mise_toml: |
+            [tools]
+            protoc = "${{ steps.protoc-version.outputs.version }}"
+          install_args: protoc
 
       - name: lint protobuf API definitions
         run: |
@@ -79,9 +93,16 @@ jobs:
           check-latest: true
           cache: true
 
-      - uses: arduino/setup-protoc@v3
+      - name: read protoc version
+        id: protoc-version
+        run: echo "version=$(make protoc-version)" >> "$GITHUB_OUTPUT"
+
+      - uses: jdx/mise-action@v4
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          mise_toml: |
+            [tools]
+            protoc = "${{ steps.protoc-version.outputs.version }}"
+          install_args: protoc
 
       - name: lint system workflows with workflowcheck
         run: make workflowcheck

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -277,9 +277,16 @@ jobs:
           path: ~/.cache/go-build
           key: go-${{ runner.os }}${{ runner.arch }}-build-${{ env.COMMIT }}
 
-      - uses: arduino/setup-protoc@v3
+      - name: read protoc version
+        id: protoc-version
+        run: echo "version=$(make protoc-version)" >> "$GITHUB_OUTPUT"
+
+      - uses: jdx/mise-action@v4
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          mise_toml: |
+            [tools]
+            protoc = "${{ steps.protoc-version.outputs.version }}"
+          install_args: protoc
 
       - run: GOOS=windows GOARCH=amd64 make clean-bins bins
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -277,15 +277,9 @@ jobs:
           path: ~/.cache/go-build
           key: go-${{ runner.os }}${{ runner.arch }}-build-${{ env.COMMIT }}
 
-      - name: read protoc version
-        id: protoc-version
-        run: echo "version=$(make protoc-version)" >> "$GITHUB_OUTPUT"
-
       - uses: jdx/mise-action@v4
         with:
-          mise_toml: |
-            [tools]
-            protoc = "${{ steps.protoc-version.outputs.version }}"
+          working_directory: .github
           install_args: protoc
 
       - run: GOOS=windows GOARCH=amd64 make clean-bins bins

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ clean: clean-bins clean-tools clean-test-output
 proto: lint-protos lint-api protoc proto-codegen
 ########################################################################
 
-.PHONY: proto protoc protoc-version install bins ci-build-misc clean
+.PHONY: proto protoc install bins ci-build-misc clean
 
 ##### Arguments ######
 GOOS        ?= $(shell go env GOOS)
@@ -78,7 +78,6 @@ COMPILED_TEST_ARGS := -timeout=$(TEST_TIMEOUT) \
 ROOT := $(shell git rev-parse --show-toplevel)
 LOCALBIN := .bin
 STAMPDIR := .stamp
-PROTOC_VER := 23.4
 export PATH := $(ROOT)/$(LOCALBIN):$(PATH)
 GOINSTALL := GOBIN=$(ROOT)/$(LOCALBIN) go install
 
@@ -337,9 +336,6 @@ proto-codegen:
 	@go generate -run genroutingkeyextractor ./common/rpc/interceptor/...
 	@printf $(COLOR) "Generate search attributes helpers..."
 	@go generate -run gensearchattributehelpers ./common/searchattribute/...
-
-protoc-version:
-	@printf '%s\n' "$(PROTOC_VER)"
 
 update-go-api:
 	@printf $(COLOR) "Update go.temporal.io/api@master..."

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ clean: clean-bins clean-tools clean-test-output
 proto: lint-protos lint-api protoc proto-codegen
 ########################################################################
 
-.PHONY: proto protoc install bins ci-build-misc clean
+.PHONY: proto protoc protoc-version install bins ci-build-misc clean
 
 ##### Arguments ######
 GOOS        ?= $(shell go env GOOS)
@@ -78,6 +78,7 @@ COMPILED_TEST_ARGS := -timeout=$(TEST_TIMEOUT) \
 ROOT := $(shell git rev-parse --show-toplevel)
 LOCALBIN := .bin
 STAMPDIR := .stamp
+PROTOC_VER := 23.4
 export PATH := $(ROOT)/$(LOCALBIN):$(PATH)
 GOINSTALL := GOBIN=$(ROOT)/$(LOCALBIN) go install
 
@@ -336,6 +337,9 @@ proto-codegen:
 	@go generate -run genroutingkeyextractor ./common/rpc/interceptor/...
 	@printf $(COLOR) "Generate search attributes helpers..."
 	@go generate -run gensearchattributehelpers ./common/searchattribute/...
+
+protoc-version:
+	@printf '%s\n' "$(PROTOC_VER)"
 
 update-go-api:
 	@printf $(COLOR) "Update go.temporal.io/api@master..."


### PR DESCRIPTION
## What changed?

Replacing `arduino/setup-protoc` GitHub action.

## Why?

https://github.com/arduino/setup-protoc hasn't been updated in 2y and is causing this warning:
```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: arduino/setup-protoc@v3. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```