### PR TITLE
Usage of `ActiveInCluster` should be justified

### DIFF
--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -52,6 +52,8 @@ linters:
           msg: "Use await.Require / s.Await for assertion conditions, or await.RequireTrue / s.AwaitTrue for bool predicates, instead of testify Eventually helpers"
         - pattern: 'assert\.\w+'
           msg: "Use require.X / protorequire.X instead of assert.X / protoassert.X — assert doesn't stop the test on failure."
+        - pattern: ActiveInCluster
+          msg: "ActiveInCluster is not businessID-aware. For any decision tied to a workflow / businessID, use ns.ActiveClusterName(routingKey) instead. For genuine namespace-level checks (no workflow context), suppress with //nolint:forbidigo // <justification>."
     depguard:
       rules:
         main:
@@ -198,6 +200,10 @@ linters:
           - forbidigo
       - path: tests/testcore/.*\.go$ # still needed in tests/testcore/ until we remove testify suites entirely
         text: "FunctionalTestBase"
+        linters:
+          - forbidigo
+      - path: common/namespace/(namespace|replication_resolver)(_test)?\.go$ # ActiveInCluster definition and direct unit tests
+        text: "ActiveInCluster"
         linters:
           - forbidigo
       - path-except: tests/.+_test\.go # only enforce in test files

--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -52,7 +52,7 @@ linters:
           msg: "Use await.Require / s.Await for assertion conditions, or await.RequireTrue / s.AwaitTrue for bool predicates, instead of testify Eventually helpers"
         - pattern: 'assert\.\w+'
           msg: "Use require.X / protorequire.X instead of assert.X / protoassert.X — assert doesn't stop the test on failure."
-        - pattern: ActiveInCluster
+        - pattern: '\bActiveInCluster\b'
           msg: "ActiveInCluster is not businessID-aware. For any decision tied to a workflow / businessID, use ns.ActiveClusterName(routingKey) instead. For genuine namespace-level checks (no workflow context), suppress with //nolint:forbidigo // <justification>."
     depguard:
       rules:

--- a/common/namespace/nsregistry/registry.go
+++ b/common/namespace/nsregistry/registry.go
@@ -185,7 +185,7 @@ func DefaultNamespaceStateChanged(currentClusterName string, oldNS *namespace.Na
 		oldNS.State() != newNS.State() ||
 		oldNS.Name() != newNS.Name() ||
 		oldNS.IsGlobalNamespace() != newNS.IsGlobalNamespace() ||
-		oldNS.ActiveInCluster(currentClusterName) != newNS.ActiveInCluster(currentClusterName) ||
+		oldNS.ActiveInCluster(currentClusterName) != newNS.ActiveInCluster(currentClusterName) || //nolint:forbidigo // ns-wide state diff for cache invalidation.
 		oldNS.ReplicationState("") != newNS.ReplicationState("")
 }
 

--- a/common/namespace/nsregistry/registry.go
+++ b/common/namespace/nsregistry/registry.go
@@ -185,7 +185,8 @@ func DefaultNamespaceStateChanged(currentClusterName string, oldNS *namespace.Na
 		oldNS.State() != newNS.State() ||
 		oldNS.Name() != newNS.Name() ||
 		oldNS.IsGlobalNamespace() != newNS.IsGlobalNamespace() ||
-		oldNS.ActiveInCluster(currentClusterName) != newNS.ActiveInCluster(currentClusterName) || //nolint:forbidigo // ns-wide state diff for cache invalidation.
+		//nolint:forbidigo // ns-wide state diff for cache invalidation.
+		oldNS.ActiveInCluster(currentClusterName) != newNS.ActiveInCluster(currentClusterName) ||
 		oldNS.ReplicationState("") != newNS.ReplicationState("")
 }
 

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -187,7 +187,8 @@ func (c *operationContext) interceptRequest(
 		return commonnexus.ConvertGRPCError(err, false)
 	}
 
-	if !c.namespace.ActiveInCluster(c.clusterMetadata.GetCurrentClusterName()) { //nolint:forbidigo // Nexus requests are not tied to a business ID by design (see line 184)
+	//nolint:forbidigo // Nexus requests are not tied to a business ID by design (see line 184)
+	if !c.namespace.ActiveInCluster(c.clusterMetadata.GetCurrentClusterName()) {
 		if c.shouldForwardRequest(ctx, header) {
 			// Handler methods should have special logic to forward requests if this method returns
 			// a serviceerror.NamespaceNotActive error.

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -187,7 +187,7 @@ func (c *operationContext) interceptRequest(
 		return commonnexus.ConvertGRPCError(err, false)
 	}
 
-	if !c.namespace.ActiveInCluster(c.clusterMetadata.GetCurrentClusterName()) {
+	if !c.namespace.ActiveInCluster(c.clusterMetadata.GetCurrentClusterName()) { //nolint:forbidigo // Nexus requests are not tied to a business ID by design (see line 184)
 		if c.shouldForwardRequest(ctx, header) {
 			// Handler methods should have special logic to forward requests if this method returns
 			// a serviceerror.NamespaceNotActive error.

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -413,7 +413,8 @@ func (wh *WorkflowHandler) Start() {
 
 			if ns.IsGlobalNamespace() &&
 				ns.ReplicationPolicy() == namespace.ReplicationPolicyMultiCluster &&
-				!ns.ActiveInCluster(wh.clusterMetadata.GetCurrentClusterName()) { //nolint:forbidigo // namespace state-change callback; cancels all pollers on ns deactivation
+				//nolint:forbidigo // namespace state-change callback; cancels all pollers on ns deactivation
+				!ns.ActiveInCluster(wh.clusterMetadata.GetCurrentClusterName()) {
 				pollers, ok := wh.outstandingPollers.Get(ns.ID().String())
 				if ok {
 					for _, cancelFn := range pollers.PopAll() {

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -413,7 +413,7 @@ func (wh *WorkflowHandler) Start() {
 
 			if ns.IsGlobalNamespace() &&
 				ns.ReplicationPolicy() == namespace.ReplicationPolicyMultiCluster &&
-				!ns.ActiveInCluster(wh.clusterMetadata.GetCurrentClusterName()) {
+				!ns.ActiveInCluster(wh.clusterMetadata.GetCurrentClusterName()) { //nolint:forbidigo // namespace state-change callback; cancels all pollers on ns deactivation
 				pollers, ok := wh.outstandingPollers.Get(ns.ID().String())
 				if ok {
 					for _, cancelFn := range pollers.PopAll() {

--- a/service/history/api/deleteworkflow/api.go
+++ b/service/history/api/deleteworkflow/api.go
@@ -56,7 +56,7 @@ func Invoke(
 		if err != nil {
 			return nil, err
 		}
-		if ns.ActiveInCluster(shardContext.GetClusterMetadata().GetCurrentClusterName()) {
+		if ns.ActiveClusterName(namespace.RoutingKey{ID: request.WorkflowExecution.GetWorkflowId()}) == shardContext.GetClusterMetadata().GetCurrentClusterName() {
 			// If workflow execution is running and in active cluster.
 			if err := api.UpdateWorkflowWithNew(
 				shardContext,

--- a/service/history/api/queryworkflow/api.go
+++ b/service/history/api/queryworkflow/api.go
@@ -156,7 +156,7 @@ func Invoke(
 		// 1. the namespace is not active, in this case history is immutable so a query dispatched at any time is consistent
 		// 2. the workflow is not running, whenever a workflow is not running dispatching query directly is consistent
 		// 3. if there is no pending or started workflow tasks it means no events came before query arrived, so its safe to dispatch directly
-		safeToDispatchDirectly := !nsEntry.ActiveInCluster(shardContext.GetClusterMetadata().GetCurrentClusterName()) ||
+		safeToDispatchDirectly := nsEntry.ActiveClusterName(namespace.RoutingKey{ID: workflowKey.WorkflowID}) != shardContext.GetClusterMetadata().GetCurrentClusterName() ||
 			!mutableState.IsWorkflowExecutionRunning() ||
 			(!mutableState.HasPendingWorkflowTask() && !mutableState.HasStartedWorkflowTask())
 		if safeToDispatchDirectly {

--- a/service/history/chasm_engine.go
+++ b/service/history/chasm_engine.go
@@ -585,7 +585,7 @@ func (e *ChasmEngine) deleteExecution(
 		if err != nil {
 			return err
 		}
-		if ns.ActiveInCluster(shardContext.GetClusterMetadata().GetCurrentClusterName()) {
+		if ns.ActiveClusterName(namespace.RoutingKey{ID: ref.BusinessID}) == shardContext.GetClusterMetadata().GetCurrentClusterName() {
 			chasmTree, ok := mutableState.ChasmTree().(*chasm.Node)
 			if !ok {
 				return serviceerror.NewInternalf(

--- a/service/history/history_engine.go
+++ b/service/history/history_engine.go
@@ -393,7 +393,8 @@ func (e *historyEngineImpl) registerNamespaceStateChangeCallback() {
 
 		if ns.IsGlobalNamespace() &&
 			ns.ReplicationPolicy() == namespace.ReplicationPolicyMultiCluster &&
-			ns.ActiveInCluster(e.currentClusterName) { //nolint:forbidigo // namespace state-change callback; FailoverNamespace operates per-namespace, no workflow context
+			//nolint:forbidigo // namespace state-change callback; FailoverNamespace operates per-namespace, no workflow context
+			ns.ActiveInCluster(e.currentClusterName) {
 
 			for _, queueProcessor := range e.queueProcessors {
 				queueProcessor.FailoverNamespace(ns.ID().String())

--- a/service/history/history_engine.go
+++ b/service/history/history_engine.go
@@ -393,7 +393,7 @@ func (e *historyEngineImpl) registerNamespaceStateChangeCallback() {
 
 		if ns.IsGlobalNamespace() &&
 			ns.ReplicationPolicy() == namespace.ReplicationPolicyMultiCluster &&
-			ns.ActiveInCluster(e.currentClusterName) {
+			ns.ActiveInCluster(e.currentClusterName) { //nolint:forbidigo // namespace state-change callback; FailoverNamespace operates per-namespace, no workflow context
 
 			for _, queueProcessor := range e.queueProcessors {
 				queueProcessor.FailoverNamespace(ns.ID().String())

--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -1218,7 +1218,7 @@ func (r *WorkflowStateReplicatorImpl) bringLocalEventsUpToSourceCurrentBranch(
 	}
 	// In standby cluster, use a background low priority which is higher than the standby task processing
 	callerType := headers.CallerTypeBackgroundLow
-	if ns.ActiveInCluster(r.clusterMetadata.GetCurrentClusterName()) {
+	if ns.ActiveClusterName(namespace.RoutingKey{ID: workflowID}) == r.clusterMetadata.GetCurrentClusterName() {
 		// In active cluster, use lowest priority to minimize the impact to live traffic
 		callerType = headers.CallerTypePreemptable
 	}
@@ -1727,7 +1727,7 @@ func (r *WorkflowStateReplicatorImpl) backfillHistory(
 	}
 	// In standby cluster, use a background low priority which is higher than the standby task processing
 	callerType := headers.CallerTypeBackgroundLow
-	if ns.ActiveInCluster(r.clusterMetadata.GetCurrentClusterName()) {
+	if ns.ActiveClusterName(namespace.RoutingKey{ID: workflowID}) == r.clusterMetadata.GetCurrentClusterName() {
 		// In active cluster, use lowest priority to minimize the impact to live traffic
 		callerType = headers.CallerTypePreemptable
 	}

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -861,7 +861,7 @@ func taskBaseMetricTagsWithoutArchetype(
 	ns, err := namespaceRegistry.GetNamespaceByID(namespace.ID(task.GetNamespaceID()))
 	if err == nil {
 		namespaceTag = metrics.NamespaceTag(ns.Name().String())
-		isActive = ns.ActiveInCluster(currentClusterName)
+		isActive = ns.ActiveClusterName(namespace.RoutingKey{ID: task.GetWorkflowID()}) == currentClusterName
 	}
 
 	taskType := taskTypeTagProvider(task, isActive, chasmRegistry)

--- a/service/history/queues/priority_assigner.go
+++ b/service/history/queues/priority_assigner.go
@@ -33,7 +33,7 @@ func (a *priorityAssignerImpl) Assign(executable Executable) tasks.Priority {
 	ns, err := a.nsRegistry.GetNamespaceByID(namespace.ID(executable.GetNamespaceID()))
 	if ns != nil && err == nil {
 		// Use lowest priority level for standby task processing
-		if !ns.ActiveInCluster(a.currentClusterName) {
+		if ns.ActiveClusterName(namespace.RoutingKey{ID: executable.GetWorkflowID()}) != a.currentClusterName {
 			return tasks.PriorityPreemptable
 		}
 	}

--- a/service/history/queues/scheduler.go
+++ b/service/history/queues/scheduler.go
@@ -115,7 +115,8 @@ func NewScheduler(
 		ns, err := namespaceRegistry.GetNamespaceByID(namespace.ID(key.NamespaceID))
 		if err == nil {
 			namespaceName = ns.Name()
-			if !ns.ActiveInCluster(currentClusterName) { //nolint:forbidigo // scheduler is namespace-scoped
+			//nolint:forbidigo // scheduler is namespace-scoped
+			if !ns.ActiveInCluster(currentClusterName) {
 				namespaceWeights = options.StandbyNamespaceWeights
 			}
 		} else {

--- a/service/history/queues/scheduler.go
+++ b/service/history/queues/scheduler.go
@@ -115,7 +115,7 @@ func NewScheduler(
 		ns, err := namespaceRegistry.GetNamespaceByID(namespace.ID(key.NamespaceID))
 		if err == nil {
 			namespaceName = ns.Name()
-			if !ns.ActiveInCluster(currentClusterName) {
+			if !ns.ActiveInCluster(currentClusterName) { //nolint:forbidigo // scheduler is namespace-scoped
 				namespaceWeights = options.StandbyNamespaceWeights
 			}
 		} else {

--- a/service/history/shard/handover_tracker.go
+++ b/service/history/shard/handover_tracker.go
@@ -81,7 +81,7 @@ func (t *defaultHandoverTracker) UpdateHandoverState(newNs *namespace.Namespace,
 	// to handover state from active cluster, so the second condition will always be true. Adding
 	// it here to be more safe in case above assumption no longer holds in the future.
 	isHandoverNamespace := newNs.IsGlobalNamespace() &&
-		newNs.ActiveInCluster(t.clusterMetadata.GetCurrentClusterName()) &&
+		newNs.ActiveInCluster(t.clusterMetadata.GetCurrentClusterName()) && //nolint:forbidigo // namespace-wide handover tracking; ReplicationState("") below is also ns-level
 		newNs.ReplicationState("") == enumspb.REPLICATION_STATE_HANDOVER
 
 	if deletedFromDB || !isHandoverNamespace {

--- a/service/history/shard/handover_tracker.go
+++ b/service/history/shard/handover_tracker.go
@@ -81,7 +81,8 @@ func (t *defaultHandoverTracker) UpdateHandoverState(newNs *namespace.Namespace,
 	// to handover state from active cluster, so the second condition will always be true. Adding
 	// it here to be more safe in case above assumption no longer holds in the future.
 	isHandoverNamespace := newNs.IsGlobalNamespace() &&
-		newNs.ActiveInCluster(t.clusterMetadata.GetCurrentClusterName()) && //nolint:forbidigo // namespace-wide handover tracking; ReplicationState("") below is also ns-level
+		//nolint:forbidigo // namespace-wide handover tracking; ReplicationState("") below is also ns-level
+		newNs.ActiveInCluster(t.clusterMetadata.GetCurrentClusterName()) &&
 		newNs.ReplicationState("") == enumspb.REPLICATION_STATE_HANDOVER
 
 	if deletedFromDB || !isHandoverNamespace {

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -542,7 +542,8 @@ func (e *matchingEngineImpl) loggerAndMetricsForPartition(
 ) (log.Logger, log.Logger, metrics.Handler) {
 	nsName := nsEntry.Name().String()
 	var nsState string
-	if nsEntry.ActiveInCluster(e.clusterMeta.GetCurrentClusterName()) { //nolint:forbidigo // metric tag for namespace state, not per-workflow
+	//nolint:forbidigo // metric tag for namespace state, not per-workflow
+	if nsEntry.ActiveInCluster(e.clusterMeta.GetCurrentClusterName()) {
 		nsState = metrics.ActiveNamespaceStateTagValue
 	} else {
 		nsState = metrics.PassiveNamespaceStateTagValue

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -542,7 +542,7 @@ func (e *matchingEngineImpl) loggerAndMetricsForPartition(
 ) (log.Logger, log.Logger, metrics.Handler) {
 	nsName := nsEntry.Name().String()
 	var nsState string
-	if nsEntry.ActiveInCluster(e.clusterMeta.GetCurrentClusterName()) {
+	if nsEntry.ActiveInCluster(e.clusterMeta.GetCurrentClusterName()) { //nolint:forbidigo // metric tag for namespace state, not per-workflow
 		nsState = metrics.ActiveNamespaceStateTagValue
 	} else {
 		nsState = metrics.PassiveNamespaceStateTagValue

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -487,7 +487,8 @@ func (c *physicalTaskQueueManagerImpl) PollTask(
 		}
 	}
 
-	if !namespaceEntry.ActiveInCluster(c.clusterMeta.GetCurrentClusterName()) { //nolint:forbidigo // physical task queue lifecycle is namespace-scoped
+	//nolint:forbidigo // physical task queue lifecycle is namespace-scoped
+	if !namespaceEntry.ActiveInCluster(c.clusterMeta.GetCurrentClusterName()) {
 		return c.matcher.PollForQuery(ctx, pollMetadata)
 	}
 

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -487,7 +487,7 @@ func (c *physicalTaskQueueManagerImpl) PollTask(
 		}
 	}
 
-	if !namespaceEntry.ActiveInCluster(c.clusterMeta.GetCurrentClusterName()) {
+	if !namespaceEntry.ActiveInCluster(c.clusterMeta.GetCurrentClusterName()) { //nolint:forbidigo // physical task queue lifecycle is namespace-scoped
 		return c.matcher.PollForQuery(ctx, pollMetadata)
 	}
 

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -645,7 +645,7 @@ func (pm *taskQueuePartitionManagerImpl) shouldBacklogSyncMatchTaskOnError(err e
 func (pm *taskQueuePartitionManagerImpl) isActiveInCluster() (bool, error) {
 	ns, err := pm.engine.namespaceRegistry.GetNamespaceByID(pm.ns.ID())
 	if err == nil {
-		return ns.ActiveInCluster(pm.engine.clusterMeta.GetCurrentClusterName()), nil
+		return ns.ActiveInCluster(pm.engine.clusterMeta.GetCurrentClusterName()), nil //nolint:forbidigo // partition manager is namespace-scoped
 	}
 	return false, err
 }

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -645,7 +645,8 @@ func (pm *taskQueuePartitionManagerImpl) shouldBacklogSyncMatchTaskOnError(err e
 func (pm *taskQueuePartitionManagerImpl) isActiveInCluster() (bool, error) {
 	ns, err := pm.engine.namespaceRegistry.GetNamespaceByID(pm.ns.ID())
 	if err == nil {
-		return ns.ActiveInCluster(pm.engine.clusterMeta.GetCurrentClusterName()), nil //nolint:forbidigo // partition manager is namespace-scoped
+		//nolint:forbidigo // partition manager is namespace-scoped
+		return ns.ActiveInCluster(pm.engine.clusterMeta.GetCurrentClusterName()), nil
 	}
 	return false, err
 }

--- a/service/worker/pernamespaceworker.go
+++ b/service/worker/pernamespaceworker.go
@@ -373,7 +373,8 @@ func (w *perNamespaceWorker) refresh(args refreshArgs) (retErr error) {
 
 	if !w.wm.Running() ||
 		args.ns.State() == enumspb.NAMESPACE_STATE_DELETED ||
-		!args.ns.ActiveInCluster(w.wm.thisClusterName) {
+		!args.ns.ActiveInCluster(w.wm.thisClusterName) { //nolint:forbidigo // per-namespace worker lifecycle, no workflow context
+
 		return errNoWorkerNeeded
 	}
 

--- a/service/worker/pernamespaceworker.go
+++ b/service/worker/pernamespaceworker.go
@@ -373,7 +373,8 @@ func (w *perNamespaceWorker) refresh(args refreshArgs) (retErr error) {
 
 	if !w.wm.Running() ||
 		args.ns.State() == enumspb.NAMESPACE_STATE_DELETED ||
-		!args.ns.ActiveInCluster(w.wm.thisClusterName) { //nolint:forbidigo // per-namespace worker lifecycle, no workflow context
+		//nolint:forbidigo // per-namespace worker lifecycle, no workflow context
+		!args.ns.ActiveInCluster(w.wm.thisClusterName) {
 
 		return errNoWorkerNeeded
 	}

--- a/service/worker/scanner/build_ids/scavenger.go
+++ b/service/worker/scanner/build_ids/scavenger.go
@@ -170,7 +170,8 @@ func (a *Activities) processNamespaceEntry(
 		return err
 	}
 	// Only the active cluster for this namespace should perform the cleanup.
-	if !ns.ActiveInCluster(a.currentClusterName) { //nolint:forbidigo // scavenger scans entire namespace, not per workflow.
+	//nolint:forbidigo // scavenger scans entire namespace, not per workflow.
+	if !ns.ActiveInCluster(a.currentClusterName) {
 		return nil
 	}
 	for {

--- a/service/worker/scanner/build_ids/scavenger.go
+++ b/service/worker/scanner/build_ids/scavenger.go
@@ -170,7 +170,7 @@ func (a *Activities) processNamespaceEntry(
 		return err
 	}
 	// Only the active cluster for this namespace should perform the cleanup.
-	if !ns.ActiveInCluster(a.currentClusterName) {
+	if !ns.ActiveInCluster(a.currentClusterName) { //nolint:forbidigo // scavenger scans entire namespace, not per workflow.
 		return nil
 	}
 	for {


### PR DESCRIPTION
## What changed?

1. Add linter rule to guard`ActiveInCluster` usage.
2. Fixed the callsites for `ActiveInCluster` where should use `ActiveClusterName` instead.
3. Add explicit `//nolint:forbidigo justifications` for genuine namespace-level checks.

## Why?

ActiveInCluster is namespace-level and not businessID-aware. For workflow-scoped decisions, the active cluster must be resolved with `ActiveClusterName(routingKey)` so future businessID-aware routing does not incorrectly treat an entire namespace as active or standby.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

