### PR TITLE
Allow handover interceptor method extensions

### DIFF
--- a/common/rpc/interceptor/namespace_handover.go
+++ b/common/rpc/interceptor/namespace_handover.go
@@ -26,13 +26,14 @@ var _ grpc.UnaryServerInterceptor = (*NamespaceHandoverInterceptor)(nil).Interce
 type (
 	// NamespaceHandoverInterceptor handles the namespace in handover replication state
 	NamespaceHandoverInterceptor struct {
-		namespaceRegistry      namespace.Registry
-		timeSource             clock.TimeSource
-		enabledForNS           dynamicconfig.BoolPropertyFnWithNamespaceFilter
-		nsCacheRefreshInterval dynamicconfig.DurationPropertyFn
-		metricsHandler         metrics.Handler
-		logger                 log.Logger
-		requestErrorHandler    ErrorHandler
+		namespaceRegistry                      namespace.Registry
+		timeSource                             clock.TimeSource
+		enabledForNS                           dynamicconfig.BoolPropertyFnWithNamespaceFilter
+		nsCacheRefreshInterval                 dynamicconfig.DurationPropertyFn
+		metricsHandler                         metrics.Handler
+		logger                                 log.Logger
+		requestErrorHandler                    ErrorHandler
+		additionalAllowedMethodsDuringHandover map[string]struct{}
 	}
 )
 
@@ -43,16 +44,23 @@ func NewNamespaceHandoverInterceptor(
 	logger log.Logger,
 	timeSource clock.TimeSource,
 	requestErrorHandler ErrorHandler,
+	additionalAllowedMethodsDuringHandover []string,
 ) *NamespaceHandoverInterceptor {
 
+	additional := make(map[string]struct{}, len(additionalAllowedMethodsDuringHandover))
+	for _, m := range additionalAllowedMethodsDuringHandover {
+		additional[m] = struct{}{}
+	}
+
 	return &NamespaceHandoverInterceptor{
-		enabledForNS:           dynamicconfig.EnableNamespaceHandoverWait.Get(dc),
-		nsCacheRefreshInterval: dynamicconfig.NamespaceCacheRefreshInterval.Get(dc),
-		namespaceRegistry:      namespaceRegistry,
-		metricsHandler:         metricsHandler,
-		logger:                 logger,
-		timeSource:             timeSource,
-		requestErrorHandler:    requestErrorHandler,
+		enabledForNS:                           dynamicconfig.EnableNamespaceHandoverWait.Get(dc),
+		nsCacheRefreshInterval:                 dynamicconfig.NamespaceCacheRefreshInterval.Get(dc),
+		namespaceRegistry:                      namespaceRegistry,
+		metricsHandler:                         metricsHandler,
+		logger:                                 logger,
+		timeSource:                             timeSource,
+		requestErrorHandler:                    requestErrorHandler,
+		additionalAllowedMethodsDuringHandover: additional,
 	}
 }
 
@@ -112,6 +120,9 @@ func (i *NamespaceHandoverInterceptor) waitNamespaceHandoverUpdate(
 	methodName string,
 ) (waitTime *time.Duration, retErr error) {
 	if _, ok := allowedMethodsDuringHandover[methodName]; ok {
+		return nil, nil
+	}
+	if _, ok := i.additionalAllowedMethodsDuringHandover[methodName]; ok {
 		return nil, nil
 	}
 

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -410,21 +410,28 @@ func BusinessIDInterceptorProvider(
 	)
 }
 
+type NamespaceHandoverInterceptorParams struct {
+	fx.In
+	DynamicConfig                          *dynamicconfig.Collection
+	NamespaceRegistry                      namespace.Registry
+	Logger                                 log.Logger
+	MetricsHandler                         metrics.Handler
+	TimeSource                             clock.TimeSource
+	RequestErrorHandler                    *interceptor.RequestErrorHandler
+	AdditionalAllowedMethodsDuringHandover []string `group:"additionalAllowedMethodsDuringHandover"`
+}
+
 func NamespaceHandoverInterceptorProvider(
-	dc *dynamicconfig.Collection,
-	namespaceCache namespace.Registry,
-	logger log.Logger,
-	metricsHandler metrics.Handler,
-	timeSource clock.TimeSource,
-	requestErrorHandler *interceptor.RequestErrorHandler,
+	params NamespaceHandoverInterceptorParams,
 ) *interceptor.NamespaceHandoverInterceptor {
 	return interceptor.NewNamespaceHandoverInterceptor(
-		dc,
-		namespaceCache,
-		metricsHandler,
-		logger,
-		timeSource,
-		requestErrorHandler,
+		params.DynamicConfig,
+		params.NamespaceRegistry,
+		params.MetricsHandler,
+		params.Logger,
+		params.TimeSource,
+		params.RequestErrorHandler,
+		params.AdditionalAllowedMethodsDuringHandover,
 	)
 }
 


### PR DESCRIPTION
## What changed?

`NamespaceHandoverInterceptor` now honors the existing `additionalAllowedMethodsDuringHandover` Fx group, same as `NamespaceValidatorInterceptor`, to allow additional methods through during HANDOVER.

## Why?
When `system.enableNamespaceHandoverWait=true`, methods suppose to be allowed through by `namespace_validator` can still be blocked by namespace_handover interceptor. This change keep both interceptors agree on same group of methods through HANDOVER. 

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
