### PR TITLE
Fix stale SQLite visibility schema version (0.1 → 1.14)

### DIFF
--- a/schema/sqlite/version.go
+++ b/schema/sqlite/version.go
@@ -4,4 +4,7 @@ package sqlite
 const Version = "0.11"
 
 // VisibilityVersion is the SQLite visibility database release version
-const VisibilityVersion = "0.1"
+// VisibilityVersion is the current version of the SQLite visibility schema.
+// Note: SQLite is used for development only and does not support incremental
+// schema migrations — schema.sql reflects the complete current schema.
+const VisibilityVersion = "1.14"


### PR DESCRIPTION
SQLite VisibilityVersion was stale at 0.1 while MySQL and PostgreSQL are at 1.14. The SQLite schema.sql already contains all columns and indexes added through v1.14 including TemporalExternalPayloadSizeBytes, TemporalWorkerDeploymentVersion, TemporalScheduledStartTime, etc.

SQLite is used for development only and does not use versioned migrations. This corrects the version constant to accurately reflect the current schema state.

Note: No schema changes — version number correction only.

## What changed?
Updated `VisibilityVersion` constant in `schema/sqlite/version.go` 
from `0.1` to `1.14` to match MySQL and PostgreSQL.

Added a comment clarifying SQLite's dev-only usage and lack of 
versioned migrations.

## Why?
SQLite visibility schema version was stale at `0.1` while the 
actual `schema.sql` already contains all columns and indexes 
added through v1.14 including:
- TemporalExternalPayloadSizeBytes / Count
- TemporalWorkerDeploymentVersion
- TemporalScheduledStartTime / TemporalScheduledById
- All corresponding indexes

The version constant did not reflect the actual schema state, 
which could confuse developers checking schema versions.

## How did you test it?
- [x] built
- [x] covered by existing tests

Note: Version constant correction only — no schema or logic changes.

## Potential risks
None — SQLite is used for development only (not production). 
No migration files are affected.