### PR TITLE
Add slowest runs to CI digest

### DIFF
--- a/tools/ci-notify/app_test.go
+++ b/tools/ci-notify/app_test.go
@@ -197,3 +197,22 @@ func TestFilterCompleted(t *testing.T) {
 		})
 	}
 }
+
+func TestSlowestRuns(t *testing.T) {
+	report := &DigestReport{
+		Runs: []WorkflowRunSummary{
+			{DisplayTitle: "medium", Duration: 20 * time.Minute},
+			{DisplayTitle: "ignored", Duration: 0},
+			{DisplayTitle: "slowest", Duration: 45 * time.Minute},
+			{DisplayTitle: "fastest", Duration: 5 * time.Minute},
+			{DisplayTitle: "second slowest", Duration: 30 * time.Minute},
+		},
+	}
+
+	result := report.slowestRuns(3)
+
+	require.Len(t, result, 3)
+	require.Equal(t, "slowest", result[0].DisplayTitle)
+	require.Equal(t, "second slowest", result[1].DisplayTitle)
+	require.Equal(t, "medium", result[2].DisplayTitle)
+}

--- a/tools/ci-notify/slack.go
+++ b/tools/ci-notify/slack.go
@@ -219,6 +219,25 @@ func BuildSuccessReportMessage(report *DigestReport) *SlackMessage {
 	}
 
 	blocks := []SlackBlock{headerBlock, periodBlock, metricsBlock, timingBlock}
+	slowestRuns := report.slowestRuns(3)
+	if len(slowestRuns) > 0 {
+		var slowest []string
+		for _, run := range slowestRuns {
+			slowest = append(slowest, fmt.Sprintf("• <%s|%s> — %s (%s)",
+				run.URL,
+				run.shortSHA(),
+				formatDuration(run.Duration),
+				run.Conclusion,
+			))
+		}
+		blocks = append(blocks, SlackBlock{
+			Type: "section",
+			Text: &SlackText{
+				Type: "mrkdwn",
+				Text: fmt.Sprintf("*Slowest Runs:*\n%s", strings.Join(slowest, "\n")),
+			},
+		})
+	}
 
 	return &SlackMessage{
 		Text:   fmt.Sprintf("Weekly CI Report - %s Branch", report.Branch),
@@ -245,6 +264,19 @@ func FormatReportForDebug(report *DigestReport) string {
 	fmt.Fprintf(&sb, "  Under 20 minutes: %.1f%%\n", report.Under20MinutesPercent)
 	fmt.Fprintf(&sb, "  Under 25 minutes: %.1f%%\n", report.Under25MinutesPercent)
 	fmt.Fprintf(&sb, "  Under 30 minutes: %.1f%%\n", report.Under30MinutesPercent)
+
+	slowestRuns := report.slowestRuns(3)
+	if len(slowestRuns) > 0 {
+		fmt.Fprintln(&sb, "\nSlowest Runs:")
+		for _, run := range slowestRuns {
+			fmt.Fprintf(&sb, "  %s (%s): %s\n    %s\n",
+				formatDuration(run.Duration),
+				run.Conclusion,
+				run.shortSHA(),
+				run.URL,
+			)
+		}
+	}
 
 	return sb.String()
 }

--- a/tools/ci-notify/types.go
+++ b/tools/ci-notify/types.go
@@ -1,6 +1,9 @@
 package cinotify
 
-import "time"
+import (
+	"sort"
+	"time"
+)
 
 // Conclusion represents the conclusion status of a workflow run or job
 type Conclusion string
@@ -63,6 +66,13 @@ type WorkflowRunSummary struct {
 	URL          string        `json:"url"`
 }
 
+func (r WorkflowRunSummary) shortSHA() string {
+	if len(r.HeadSHA) > 7 {
+		return r.HeadSHA[:7]
+	}
+	return r.HeadSHA
+}
+
 // DigestReport aggregates success metrics for a time period
 type DigestReport struct {
 	Branch                string
@@ -79,4 +89,21 @@ type DigestReport struct {
 	Under25MinutesPercent float64
 	Under30MinutesPercent float64
 	Runs                  []WorkflowRunSummary
+}
+
+func (r *DigestReport) slowestRuns(limit int) []WorkflowRunSummary {
+	if limit <= 0 {
+		return nil
+	}
+
+	sorted := make([]WorkflowRunSummary, 0, len(r.Runs))
+	for _, run := range r.Runs {
+		if run.Duration > 0 {
+			sorted = append(sorted, run)
+		}
+	}
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Duration > sorted[j].Duration
+	})
+	return sorted[:min(limit, len(sorted))]
 }


### PR DESCRIPTION
## What changed?

Adds a "Slowest Runs" section to the ci-notify success report for the 3 longest completed workflow runs.

## Why?

Better insights into slow runs.