### PR TITLE
Fix SyncState() to enforce retry limit via remainingAttempt

### DIFF
--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -699,7 +699,16 @@ func (e *ExecutableTaskImpl) SyncState(
 	remainingAttempt int,
 ) (bool, error) {
 
-	// TODO: check & update remainingAttempt
+	remainingAttempt--
+	if remainingAttempt < 0 {
+		e.Logger.Error("sync state attempts exceeded",
+			tag.WorkflowNamespaceID(syncStateErr.NamespaceId),
+			tag.WorkflowID(syncStateErr.WorkflowId),
+			tag.WorkflowRunID(syncStateErr.RunId),
+			tag.Error(ErrResendAttemptExceeded),
+		)
+		return false, ErrResendAttemptExceeded
+	}
 
 	remoteAdminClient, err := e.ClientBean.GetRemoteAdminClient(e.sourceClusterName)
 	if err != nil {


### PR DESCRIPTION
SyncState() accepted a remainingAttempt parameter but never checked or decremented it, unlike Resend() which correctly enforces the limit.

This fix applies the same pattern as Resend():
- Decrement remainingAttempt on each call
- Return ErrResendAttemptExceeded when limit is reached
- Log the error with workflow context tags

All callers pass ResendAttempt (= 2) constant so behavior is now consistent with Resend() - sync state operations are limited to 2 attempts before failing with ErrResendAttemptExceeded.

Fixes #10490

## What changed?
Added retry limit enforcement in `SyncState()` matching the 
existing pattern in `Resend()`.

## Why?
`SyncState()` accepted a `remainingAttempt` parameter but never 
checked or decremented it. Unlike `Resend()` which correctly 
enforces the retry limit, `SyncState()` could retry indefinitely 
on certain error types.

All callers pass `ResendAttempt = 2` constant but it was never 
used, making the retry limit ineffective for sync state operations.

Fixes #10490

## How did you test it?
- [x] built
- [x] covered by existing tests

## Potential risks
Low — mirrors exact pattern already used in `Resend()`. 
Callers already pass `ResendAttempt = 2` so maximum 2 attempts 
before returning `ErrResendAttemptExceeded`, consistent with 
existing retry behavior.