### PR TITLE
Remove dead proto compatibility code for pre-1.24.0-m3 versions

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -87,7 +87,6 @@ import (
 	"go.temporal.io/server/service/worker/workerdeployment"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
-	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -3318,46 +3317,7 @@ func (wh *WorkflowHandler) DescribeTaskQueue(ctx context.Context, request *workf
 	}
 
 	resp := matchingResponse.DescResponse
-	// Manually parse unknown fields to handle proto incompatibility.
-	// TODO: remove this after 1.24.0-m3
-	if resp == nil {
-		resp = &workflowservice.DescribeTaskQueueResponse{}
-		unknown := []byte(matchingResponse.ProtoReflect().GetUnknown())
-		for len(unknown) > 0 {
-			num, typ, n := protowire.ConsumeTag(unknown)
-			if n < 0 {
-				break
-			}
-			unknown = unknown[n:]
-			if typ != protowire.BytesType {
-				break
-			}
-			msg, n := protowire.ConsumeBytes(unknown)
-			if n < 0 {
-				break
-			}
-			unknown = unknown[n:]
-			switch num {
-			case 1:
-				// msg is either a temporal.api.workflowservice.v1.DescribeTaskQueueResponse (new) or repeated temporal.api.taskqueue.v1.PollerInfo (old)
-				// try DescribeTaskQueueResponse first
-				var dtqr workflowservice.DescribeTaskQueueResponse
-				var pi taskqueuepb.PollerInfo
-				if err := proto.Unmarshal(msg, &dtqr); err == nil {
-					// merge this into the response, to avoid losing data in case this was a spurious success
-					proto.Merge(resp, &dtqr)
-				} else if err := proto.Unmarshal(msg, &pi); err == nil {
-					resp.Pollers = append(resp.Pollers, &pi)
-				}
-			case 2:
-				// msg should be a temporal.api.taskqueue.v1.TaskQueueStatus
-				var tqstatus taskqueuepb.TaskQueueStatus
-				if err := proto.Unmarshal(msg, &tqstatus); err == nil {
-					resp.TaskQueueStatus = &tqstatus
-				}
-			}
-		}
-	}
+
 	return resp, nil
 }
 


### PR DESCRIPTION
The manual unknown field parsing in DescribeTaskQueue was added to handle proto incompatibility between old and new versions of DescribeTaskQueueResponse. This code was marked for removal after 1.24.0-m3 but was never cleaned up.

Current version is v1.32 — the matching service always populates DescResponse (verified in task_queue_partition_manager.go and matching_engine.go). The nil check and proto parsing block are dead code and safe to remove.

No behavior change for current deployments.

## What changed?
Removed dead code block in `DescribeTaskQueue` handler that manually 
parsed unknown proto fields to handle incompatibility between old and 
new versions of `DescribeTaskQueueResponse`.

## Why?
The code was marked with `TODO: remove this after 1.24.0-m3` but 
was never cleaned up. Current version is v1.32 — 8 major versions 
later.

The matching service always populates `DescResponse` in current 
versions (verified in `task_queue_partition_manager.go:1119` and 
`matching_engine.go:1411`). The nil check and proto parsing block 
are dead code.

## How did you test it?
- [x] built
- [x] covered by existing tests

## Potential risks
Low — dead code removal only. The matching service always returns 
a populated `DescResponse` in v1.24+. No behavior change for 
current deployments.