### PR TITLE
Remove dead proto compatibility code for pre-1.24.0-m3 in matching handler

### DIFF
--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -8,7 +8,6 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	workerpb "go.temporal.io/api/worker/v1"
-	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
@@ -29,8 +28,6 @@ import (
 	"go.temporal.io/server/service/matching/workers"
 	"go.temporal.io/server/service/worker/workerdeployment"
 	"go.uber.org/fx"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 type (
@@ -339,21 +336,6 @@ func (h *Handler) DescribeTaskQueue(
 	resp, err := h.engine.DescribeTaskQueue(ctx, request)
 	if err != nil {
 		return nil, err
-	}
-
-	// TODO: remove after 1.24.0-m3
-	if len(resp.DescResponse.Pollers) > 0 || resp.DescResponse.TaskQueueStatus != nil {
-		// Expand pollerinfo and task queue status into tags 1 and 2 for old frontend to handle
-		// proto incompatibility. This only works without ugly protowire code because
-		// workflowservice.DescribeTaskQueueResponse and the previous version of
-		// matchingservice.DescribeTaskQueueResponse have the same first two fields.
-		oldResp := &workflowservice.DescribeTaskQueueResponse{
-			Pollers:         resp.DescResponse.Pollers,
-			TaskQueueStatus: resp.DescResponse.TaskQueueStatus,
-		}
-		if b, err := proto.Marshal(oldResp); err == nil {
-			resp.ProtoReflect().SetUnknown(protoreflect.RawFields(b))
-		}
 	}
 
 	return resp, nil


### PR DESCRIPTION
The matching handler was writing unknown proto fields to support old frontend versions pre-1.24.0-m3. This is the counterpart to the similar cleanup in workflow_handler.go (PR #10496).

Current version is v1.32 — all frontends are past 1.24.0-m3. The code that read these unknown fields has been removed in #10496, making this write side dead code as well.

No behavior change for current deployments.

## What changed?
Removed dead code block in matching `handler.go` that wrote unknown 
proto fields to support old frontend versions pre-1.24.0-m3.

## Why?
This is the counterpart to PR #10496 which removed the read side 
of this proto compatibility code in `workflow_handler.go`.

The matching handler was writing unknown fields so old frontends 
could parse them. Since all frontends are now past v1.24.0-m3 
(current version is v1.32), the write side is also dead code.

Both sides of the proto compatibility handshake are now removed.

## How did you test it?
- [x] built
- [x] covered by existing tests

## Potential risks
None — dead code removal only. Current version is v1.32, well 
past the 1.24.0-m3 cutoff. No behavior change for current 
deployments.
