### PR TITLE
CHASM Visibility for workflows

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -3110,6 +3110,19 @@ the CHASM implementation. When disabled, new update callbacks will not be regist
 but existing callbacks will still be processed and fired.`,
 	)
 
+	EnableCHASMVisibilityRatio = NewNamespaceFloatSetting(
+		"history.enableCHASMVisibilityRatio",
+		0.0,
+		`Controls whether workflows uses CHASM Visibility component to manage custom
+		search attributes and memo. Set ratio=0 to disable, set ratio=1 to enable,
+		set 0 < ratio < 1 to enable double write for a ratio of the workflows.
+		Notes: system.visibilityAllowList must be false to enable CHASM Visibility;
+		once the ratio is set to 1, the change is non-backwards compatible, ie., all
+		new workflows only write custom search attributes and memo to the CHASM
+		Visibility component, and setting the ratio back to a value < 1 will result
+		in unexpected effects.`,
+	)
+
 	VersionMembershipCacheTTL = NewGlobalDurationSetting(
 		"history.versionMembershipCacheTTL",
 		1*time.Second,

--- a/common/persistence/visibility/visibility_manager_impl.go
+++ b/common/persistence/visibility/visibility_manager_impl.go
@@ -576,9 +576,9 @@ func aliasChasmSearchAttributes(
 		aliasName, err := mapper.Alias(fieldName)
 		if err != nil {
 			// Silently ignore serviceerror.InvalidArgument because it indicates unregistered field.
-			// INFO: Chasm search attributes must be registered with the CHASM Registry using the WithSearchAttributes() option.
-			var invalidArgumentErr *serviceerror.InvalidArgument
-			if errors.As(err, &invalidArgumentErr) {
+			// INFO: Chasm search attributes must be registered with the CHASM Registry
+			// using the WithSearchAttributes() option.
+			if _, ok := errors.AsType[*serviceerror.InvalidArgument](err); ok {
 				continue
 			}
 			return nil, err

--- a/common/searchattribute/mapper.go
+++ b/common/searchattribute/mapper.go
@@ -163,8 +163,7 @@ func AliasFields(
 			// Silently ignore serviceerror.InvalidArgument because it indicates unmapped field (alias was deleted, for example).
 			// IMPORTANT: AliasFields should never return serviceerror.InvalidArgument because it is used by Poll API and the error
 			// goes through up to SDK, which shutdowns worker when it receives serviceerror.InvalidArgument as poll response.
-			var invalidArgumentErr *serviceerror.InvalidArgument
-			if errors.As(err, &invalidArgumentErr) {
+			if _, ok := errors.AsType[*serviceerror.InvalidArgument](err); ok {
 				continue
 			}
 			return nil, err

--- a/config/dynamicconfig/development-cass.yaml
+++ b/config/dynamicconfig/development-cass.yaml
@@ -35,6 +35,8 @@ system.enableDeployments:
   - value: true
 system.enableDeploymentVersions:
   - value: true
+system.visibilityAllowList:
+  - value: false
 frontend.workerVersioningRuleAPIs:
   - value: true
 component.nexusoperations.callback.endpoint.template:

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -727,21 +727,6 @@ func (wh *WorkflowHandler) validateTimeSkippingConfig(
 	return nil
 }
 
-func (wh *WorkflowHandler) unaliasedSearchAttributesFrom(
-	attributes *commonpb.SearchAttributes,
-	namespaceName namespace.Name,
-) (*commonpb.SearchAttributes, error) {
-	sa, err := searchattribute.UnaliasFields(wh.saMapperProvider, attributes, namespaceName.String())
-	if err != nil {
-		return nil, err
-	}
-
-	if err = wh.validator.ValidateSearchAttributes(sa, namespaceName.String()); err != nil {
-		return nil, err
-	}
-	return sa, nil
-}
-
 func (wh *WorkflowHandler) ExecuteMultiOperation(
 	ctx context.Context,
 	request *workflowservice.ExecuteMultiOperationRequest,

--- a/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
+++ b/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
@@ -1294,7 +1294,7 @@ func (handler *workflowTaskCompletedHandler) handleCommandSignalExternalWorkflow
 }
 
 func (handler *workflowTaskCompletedHandler) handleCommandUpsertWorkflowSearchAttributes(
-	_ context.Context,
+	ctx context.Context,
 	attr *commandpb.UpsertWorkflowSearchAttributesCommandAttributes,
 ) (*historypb.HistoryEvent, error) {
 	// get namespace name
@@ -1305,6 +1305,11 @@ func (handler *workflowTaskCompletedHandler) handleCommandUpsertWorkflowSearchAt
 		return nil, serviceerror.NewUnavailablef("Unable to get namespace for namespaceID: %v.", namespaceID)
 	}
 	namespace := namespaceEntry.Name()
+
+	currentSearchAttributes, err := handler.mutableState.GetSearchAttributes(ctx)
+	if err != nil {
+		return nil, serviceerror.NewUnavailablef("Unable to load current search attributes: %s", err.Error())
+	}
 
 	unaliasedSas, err := searchattribute.UnaliasFields(
 		handler.searchAttributesMapperProvider,
@@ -1345,7 +1350,7 @@ func (handler *workflowTaskCompletedHandler) handleCommandUpsertWorkflowSearchAt
 	err = handler.sizeLimitChecker.checkIfSearchAttributesSizeExceedsLimit(
 		&commonpb.SearchAttributes{
 			IndexedFields: payload.MergeMapOfPayload(
-				executionInfo.SearchAttributes,
+				currentSearchAttributes,
 				attr.GetSearchAttributes().GetIndexedFields(),
 			),
 		},
@@ -1362,7 +1367,7 @@ func (handler *workflowTaskCompletedHandler) handleCommandUpsertWorkflowSearchAt
 }
 
 func (handler *workflowTaskCompletedHandler) handleCommandModifyWorkflowProperties(
-	_ context.Context,
+	ctx context.Context,
 	attr *commandpb.ModifyWorkflowPropertiesCommandAttributes,
 ) (*historypb.HistoryEvent, error) {
 	// get namespace name
@@ -1371,6 +1376,11 @@ func (handler *workflowTaskCompletedHandler) handleCommandModifyWorkflowProperti
 	_, err := handler.namespaceRegistry.GetNamespaceByID(namespaceID)
 	if err != nil {
 		return nil, serviceerror.NewUnavailablef("Unable to get namespace for namespaceID: %v.", namespaceID)
+	}
+
+	currentMemo, err := handler.mutableState.GetMemo(ctx)
+	if err != nil {
+		return nil, serviceerror.NewUnavailablef("Unable to load current memo: %s", err.Error())
 	}
 
 	// valid properties
@@ -1394,7 +1404,7 @@ func (handler *workflowTaskCompletedHandler) handleCommandModifyWorkflowProperti
 	// new memo size limit check
 	err = handler.sizeLimitChecker.checkIfMemoSizeExceedsLimit(
 		&commonpb.Memo{
-			Fields: payload.MergeMapOfPayload(executionInfo.Memo, attr.GetUpsertedMemo().GetFields()),
+			Fields: payload.MergeMapOfPayload(currentMemo, attr.GetUpsertedMemo().GetFields()),
 		},
 		metrics.CommandTypeTag(enumspb.COMMAND_TYPE_MODIFY_WORKFLOW_PROPERTIES.String()),
 		"ModifyWorkflowPropertiesCommandAttributes. Memo exceeds size limit.",

--- a/service/history/archival_queue_task_executor_test.go
+++ b/service/history/archival_queue_task_executor_test.go
@@ -413,6 +413,8 @@ func TestArchivalQueueTaskExecutor(t *testing.T) {
 					RelocatableAttributesRemoved: p.RelocatableAttributesRemoved,
 				}
 				mutableState.EXPECT().GetExecutionInfo().Return(executionInfo).AnyTimes()
+				mutableState.EXPECT().GetSearchAttributes(gomock.Any()).Return(nil, nil).AnyTimes()
+				mutableState.EXPECT().GetMemo(gomock.Any()).Return(nil, nil).AnyTimes()
 				executionState := &persistencespb.WorkflowExecutionState{
 					State:     0,
 					Status:    0,

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -71,6 +71,7 @@ type Config struct {
 	EnableChasm                           dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	EnableCHASMCallbacks                  dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	EnableCHASMSignalBacklinks            dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	EnableCHASMVisibilityRatio            dynamicconfig.FloatPropertyFnWithNamespaceFilter
 	EnableWorkflowUpdateCallbacks         dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	ChasmMaxInMemoryPureTasks             dynamicconfig.IntPropertyFn
 	EnableCHASMSchedulerCreation          dynamicconfig.BoolPropertyFnWithNamespaceFilter
@@ -501,6 +502,7 @@ func NewConfig(
 
 		EnableCHASMCallbacks:          dynamicconfig.EnableCHASMCallbacks.Get(dc),
 		EnableCHASMSignalBacklinks:    dynamicconfig.EnableCHASMSignalBacklinks.Get(dc),
+		EnableCHASMVisibilityRatio:    dynamicconfig.EnableCHASMVisibilityRatio.Get(dc),
 		ExternalPayloadsEnabled:       dynamicconfig.ExternalPayloadsEnabled.Get(dc),
 		EnableWorkflowUpdateCallbacks: dynamicconfig.EnableWorkflowUpdateCallbacks.Get(dc),
 

--- a/service/history/interfaces/mutable_state.go
+++ b/service/history/interfaces/mutable_state.go
@@ -220,6 +220,8 @@ type (
 		IsNonCurrentWorkflowGuaranteed() (bool, error)
 		IsSignalRequested(requestID string) bool
 		GetApproximatePersistedSize() int
+		GetSearchAttributes(ctx context.Context) (map[string]*commonpb.Payload, error)
+		GetMemo(ctx context.Context) (map[string]*commonpb.Payload, error)
 
 		CurrentTaskQueue() *taskqueuepb.TaskQueue
 		SetStickyTaskQueue(name string, scheduleToStartTimeout *durationpb.Duration)
@@ -269,8 +271,8 @@ type (
 		ApplyTimerFiredEvent(*historypb.HistoryEvent) error
 		ApplyTimerStartedEvent(*historypb.HistoryEvent) (*persistencespb.TimerInfo, error)
 		ApplyTransientWorkflowTaskScheduled() (*WorkflowTaskInfo, error)
-		ApplyWorkflowPropertiesModifiedEvent(*historypb.HistoryEvent)
-		ApplyUpsertWorkflowSearchAttributesEvent(*historypb.HistoryEvent)
+		ApplyWorkflowPropertiesModifiedEvent(*historypb.HistoryEvent) error
+		ApplyUpsertWorkflowSearchAttributesEvent(*historypb.HistoryEvent) error
 		ApplyWorkflowExecutionCancelRequestedEvent(*historypb.HistoryEvent) error
 		ApplyWorkflowExecutionCanceledEvent(int64, *historypb.HistoryEvent) error
 		ApplyWorkflowExecutionCompletedEvent(int64, *historypb.HistoryEvent) error

--- a/service/history/interfaces/mutable_state_mock.go
+++ b/service/history/interfaces/mutable_state_mock.go
@@ -1377,9 +1377,11 @@ func (mr *MockMutableStateMockRecorder) ApplyTransientWorkflowTaskScheduled() *g
 }
 
 // ApplyUpsertWorkflowSearchAttributesEvent mocks base method.
-func (m *MockMutableState) ApplyUpsertWorkflowSearchAttributesEvent(arg0 *history.HistoryEvent) {
+func (m *MockMutableState) ApplyUpsertWorkflowSearchAttributesEvent(arg0 *history.HistoryEvent) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ApplyUpsertWorkflowSearchAttributesEvent", arg0)
+	ret := m.ctrl.Call(m, "ApplyUpsertWorkflowSearchAttributesEvent", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // ApplyUpsertWorkflowSearchAttributesEvent indicates an expected call of ApplyUpsertWorkflowSearchAttributesEvent.
@@ -1613,9 +1615,11 @@ func (mr *MockMutableStateMockRecorder) ApplyWorkflowExecutionUpdateCompletedEve
 }
 
 // ApplyWorkflowPropertiesModifiedEvent mocks base method.
-func (m *MockMutableState) ApplyWorkflowPropertiesModifiedEvent(arg0 *history.HistoryEvent) {
+func (m *MockMutableState) ApplyWorkflowPropertiesModifiedEvent(arg0 *history.HistoryEvent) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ApplyWorkflowPropertiesModifiedEvent", arg0)
+	ret := m.ctrl.Call(m, "ApplyWorkflowPropertiesModifiedEvent", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // ApplyWorkflowPropertiesModifiedEvent indicates an expected call of ApplyWorkflowPropertiesModifiedEvent.
@@ -2480,6 +2484,21 @@ func (mr *MockMutableStateMockRecorder) GetLastWriteVersion() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastWriteVersion", reflect.TypeOf((*MockMutableState)(nil).GetLastWriteVersion))
 }
 
+// GetMemo mocks base method.
+func (m *MockMutableState) GetMemo(ctx context.Context) (map[string]*common.Payload, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMemo", ctx)
+	ret0, _ := ret[0].(map[string]*common.Payload)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMemo indicates an expected call of GetMemo.
+func (mr *MockMutableStateMockRecorder) GetMemo(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMemo", reflect.TypeOf((*MockMutableState)(nil).GetMemo), ctx)
+}
+
 // GetMostRecentWorkerVersionStamp mocks base method.
 func (m *MockMutableState) GetMostRecentWorkerVersionStamp() *common.WorkerVersionStamp {
 	m.ctrl.T.Helper()
@@ -2705,6 +2724,21 @@ func (m *MockMutableState) GetRetryBackoffDuration(arg0 *failure.Failure) (time.
 func (mr *MockMutableStateMockRecorder) GetRetryBackoffDuration(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRetryBackoffDuration", reflect.TypeOf((*MockMutableState)(nil).GetRetryBackoffDuration), arg0)
+}
+
+// GetSearchAttributes mocks base method.
+func (m *MockMutableState) GetSearchAttributes(ctx context.Context) (map[string]*common.Payload, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSearchAttributes", ctx)
+	ret0, _ := ret[0].(map[string]*common.Payload)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSearchAttributes indicates an expected call of GetSearchAttributes.
+func (mr *MockMutableStateMockRecorder) GetSearchAttributes(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSearchAttributes", reflect.TypeOf((*MockMutableState)(nil).GetSearchAttributes), ctx)
 }
 
 // GetShouldUseRampingVersion mocks base method.

--- a/service/history/visibility_queue_task_executor.go
+++ b/service/history/visibility_queue_task_executor.go
@@ -1,13 +1,16 @@
 package history
 
 import (
+	"bytes"
 	"context"
+	"maps"
 	"strconv"
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/definition"
@@ -28,22 +31,22 @@ import (
 	wcache "go.temporal.io/server/service/history/workflow/cache"
 )
 
-type (
-	visibilityQueueTaskExecutor struct {
-		shardContext   historyi.ShardContext
-		cache          wcache.Cache
-		logger         log.Logger
-		metricProvider metrics.Handler
-		visibilityMgr  manager.VisibilityManager
-
-		ensureCloseBeforeDelete       dynamicconfig.BoolPropertyFn
-		enableCloseWorkflowCleanup    dynamicconfig.BoolPropertyFnWithNamespaceFilter
-		relocateAttributesMinBlobSize dynamicconfig.IntPropertyFnWithNamespaceFilter
-		externalPayloadsEnabled       dynamicconfig.BoolPropertyFnWithNamespaceFilter
-	}
-)
-
 var errUnknownVisibilityTask = serviceerror.NewInternal("unknown visibility task")
+
+var workflowChasmVisibilityMismatch = metrics.NewCounterDef("visibility_workflow_chasm_visibility_mismatch")
+
+type visibilityQueueTaskExecutor struct {
+	shardContext   historyi.ShardContext
+	cache          wcache.Cache
+	logger         log.Logger
+	metricProvider metrics.Handler
+	visibilityMgr  manager.VisibilityManager
+
+	ensureCloseBeforeDelete       dynamicconfig.BoolPropertyFn
+	enableCloseWorkflowCleanup    dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	relocateAttributesMinBlobSize dynamicconfig.IntPropertyFnWithNamespaceFilter
+	externalPayloadsEnabled       dynamicconfig.BoolPropertyFnWithNamespaceFilter
+}
 
 func newVisibilityQueueTaskExecutor(
 	shardContext historyi.ShardContext,
@@ -357,6 +360,12 @@ func (t *visibilityQueueTaskExecutor) processChasmTask(
 	ctx, cancel := context.WithTimeout(ctx, taskTimeout)
 	defer cancel()
 
+	namespaceEntry, err := t.shardContext.GetNamespaceRegistry().
+		GetNamespaceByID(namespace.ID(task.GetNamespaceID()))
+	if err != nil {
+		return err
+	}
+
 	weContext, release, err := getWorkflowExecutionContextForTask(ctx, t.shardContext, t.cache, task)
 	if err != nil {
 		return err
@@ -369,6 +378,36 @@ func (t *visibilityQueueTaskExecutor) processChasmTask(
 	}
 	if mutableState == nil {
 		return errNoChasmMutableState
+	}
+
+	isWorkflow := mutableState.IsWorkflow()
+	chasmVisEnabledRatio := t.shardContext.GetConfig().EnableCHASMVisibilityRatio(namespaceEntry.Name().String())
+	if isWorkflow && chasmVisEnabledRatio == 0 {
+		// CHASM Visibility was disabled, but workflow had already generated this
+		// CHASM Visibility task. Process as regular Visibility task.
+
+		if mutableState.IsWorkflowExecutionRunning() {
+			// Must release since processUpsertExecution will re-acquire the lock.
+			release(nil)
+			return t.processUpsertExecution(ctx, &tasks.UpsertExecutionVisibilityTask{
+				WorkflowKey:         task.WorkflowKey,
+				VisibilityTimestamp: task.VisibilityTimestamp,
+				TaskID:              task.TaskID,
+			})
+		}
+
+		closeVersion, err := mutableState.GetCloseVersion()
+		if err != nil {
+			return err
+		}
+		// Must release since processCloseExecution will re-acquire the lock.
+		release(nil)
+		return t.processCloseExecution(ctx, &tasks.CloseExecutionVisibilityTask{
+			WorkflowKey:         task.WorkflowKey,
+			VisibilityTimestamp: task.VisibilityTimestamp,
+			TaskID:              task.TaskID,
+			Version:             closeVersion,
+		})
 	}
 
 	isTaskInTree, isValidByComponent, err := validateChasmSideEffectTask(ctx, mutableState, task)
@@ -399,12 +438,6 @@ func (t *visibilityQueueTaskExecutor) processChasmTask(
 		return serviceerror.NewInternalf("expected visibility component, but got %T", visComponent)
 	}
 
-	namespaceEntry, err := t.shardContext.GetNamespaceRegistry().
-		GetNamespaceByID(namespace.ID(task.GetNamespaceID()))
-	if err != nil {
-		return err
-	}
-
 	customSaMapperProvider := t.shardContext.GetSearchAttributesMapperProvider()
 	customSaMapper, err := customSaMapperProvider.GetMapper(namespaceEntry.Name())
 	if err != nil {
@@ -417,9 +450,14 @@ func (t *visibilityQueueTaskExecutor) processChasmTask(
 	for alias, value := range aliasedCustomSearchAttributes {
 		fieldName, err := customSaMapper.GetFieldName(alias, namespaceEntry.Name().String())
 		if err != nil {
-			// To reach here, either the search attribute has been deregistered before task execution, which is valid behavior,
-			// or there are delays in propagating search attribute mappings to History.
-			t.logger.Warn("Failed to get field name for alias, ignoring search attribute", tag.String("alias", alias), tag.Error(err))
+			// To reach here, either the search attribute has been deregistered before task execution,
+			// which is valid behavior, or there are delays in propagating search attribute mappings to
+			// History.
+			t.logger.Warn(
+				"Failed to get field name for alias, ignoring search attribute",
+				tag.String("alias", alias),
+				tag.Error(err),
+			)
 			continue
 		}
 		searchAttributes[fieldName] = value
@@ -464,6 +502,15 @@ func (t *visibilityQueueTaskExecutor) processChasmTask(
 		}
 	}
 
+	if isWorkflow && chasmVisEnabledRatio < 1 {
+		// It's a workflow and CHASM Visibility is not 100% enabled.
+		t.validateChasmWorkflowVisibility(
+			mutableState.GetExecutionInfo(),
+			searchAttributes,
+			userMemoMap,
+		)
+	}
+
 	requestBase := t.getVisibilityRequestBase(
 		task,
 		namespaceEntry,
@@ -472,10 +519,13 @@ func (t *visibilityQueueTaskExecutor) processChasmTask(
 		searchAttributes,
 	)
 
-	// We reuse the TemporalNamespaceDivision column to store the string representation of ArchetypeID.
+	// We reuse the TemporalNamespaceDivision column to store the string
+	// representation of ArchetypeID.
 	searchattribute.AddSearchAttributes(
 		&requestBase.SearchAttributes,
-		chasm.SearchAttributeTemporalNamespaceDivision.Value(strconv.FormatUint(uint64(tree.ArchetypeID()), 10)),
+		chasm.SearchAttributeTemporalNamespaceDivision.Value(
+			strconv.FormatUint(uint64(tree.ArchetypeID()), 10),
+		),
 	)
 
 	// Override TaskQueue if provided by CHASM search attributes.
@@ -663,6 +713,28 @@ func (t *visibilityQueueTaskExecutor) cleanupExecutionInfo(
 	return weContext.SetWorkflowExecution(ctx, t.shardContext)
 }
 
+func (t *visibilityQueueTaskExecutor) validateChasmWorkflowVisibility(
+	executionInfo *persistencespb.WorkflowExecutionInfo,
+	chasmCustomSearchAttributes map[string]*commonpb.Payload,
+	chasmCustomMemo map[string]*commonpb.Payload,
+) {
+	csaMismatch := !isEqualMapPayload(executionInfo.GetSearchAttributes(), chasmCustomSearchAttributes)
+	memoMismatch := !isEqualMapPayload(executionInfo.GetMemo(), chasmCustomMemo)
+	if csaMismatch || memoMismatch {
+		// Log there is a difference, but do not fail the task.
+		t.logger.Warn(
+			"CHASM Visibility data does not match values in ExecutionInfo",
+			tag.Bool("csa_mismatch", csaMismatch),
+			tag.Bool("memo_mismatch", memoMismatch),
+		)
+		workflowChasmVisibilityMismatch.With(t.metricProvider).Record(
+			1,
+			metrics.StringTag("csa_mismatch", strconv.FormatBool(csaMismatch)),
+			metrics.StringTag("memo_mismatch", strconv.FormatBool(memoMismatch)),
+		)
+	}
+}
+
 func getWorkflowMemo(
 	memoFields map[string]*commonpb.Payload,
 ) *commonpb.Memo {
@@ -690,4 +762,10 @@ func copyMapPayload(input map[string]*commonpb.Payload) map[string]*commonpb.Pay
 		result[k] = common.CloneProto(v)
 	}
 	return result
+}
+
+func isEqualMapPayload(a, b map[string]*commonpb.Payload) bool {
+	return maps.EqualFunc(a, b, func(p1, p2 *commonpb.Payload) bool {
+		return bytes.Equal(p1.GetData(), p2.GetData())
+	})
 }

--- a/service/history/visibility_queue_task_executor_test.go
+++ b/service/history/visibility_queue_task_executor_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
@@ -38,6 +39,7 @@ import (
 	"go.temporal.io/server/common/telemetry"
 	"go.temporal.io/server/common/testing/protomock"
 	"go.temporal.io/server/common/worker_versioning"
+	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/events"
 	"go.temporal.io/server/service/history/hsm"
@@ -60,6 +62,7 @@ type (
 
 		controller *gomock.Controller
 		mockShard  *shard.ContextTest
+		config     *configs.Config
 
 		mockVisibilityMgr *manager.MockVisibilityManager
 		mockExecutionMgr  *persistence.MockExecutionManager
@@ -99,27 +102,31 @@ func (s *visibilityQueueTaskExecutorSuite) SetupTest() {
 
 	s.controller = gomock.NewController(s.T())
 
-	config := tests.NewDynamicConfig()
-	config.EnableChasm = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
+	s.config = tests.NewDynamicConfig()
+	s.config.VisibilityAllowList = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false)
+	s.config.EnableChasm = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
 	s.mockShard = shard.NewTestContext(
 		s.controller,
 		&persistencespb.ShardInfo{
 			ShardId: 1,
 			RangeId: 1,
 		},
-		config,
+		s.config,
 	)
 
 	// Set up expectations on the SearchAttributesMapper mocks created by NewTestContext
-	mockMapper := searchattribute.NewMockMapper(s.controller)
-	mockMapper.EXPECT().GetFieldName(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(alias string, _ string) (string, error) {
-			return alias, nil
-		},
-	).AnyTimes()
+	// mockMapper := searchattribute.NewMockMapper(s.controller)
+	// mockMapper.EXPECT().GetFieldName(gomock.Any(), gomock.Any()).DoAndReturn(
+	// 	func(alias string, _ string) (string, error) {
+	// 		return alias, nil
+	// 	},
+	// ).AnyTimes()
 
 	mockMapperProvider := s.mockShard.Resource.SearchAttributesMapperProvider
-	mockMapperProvider.EXPECT().GetMapper(gomock.Any()).Return(mockMapper, nil).AnyTimes()
+	mockMapperProvider.EXPECT().
+		GetMapper(gomock.Any()).
+		Return(&searchattribute.TestMapper{Namespace: s.namespace.String()}, nil).
+		AnyTimes()
 
 	reg := hsm.NewRegistry()
 	err := workflow.RegisterStateMachine(reg)
@@ -181,10 +188,10 @@ func (s *visibilityQueueTaskExecutorSuite) SetupTest() {
 		s.mockVisibilityMgr,
 		s.logger,
 		metrics.NoopMetricsHandler,
-		config.VisibilityProcessorEnsureCloseBeforeDelete,
+		s.config.VisibilityProcessorEnsureCloseBeforeDelete,
 		func(_ string) bool { return s.enableCloseWorkflowCleanup },
-		config.VisibilityProcessorRelocateAttributesMinBlobSize,
-		config.ExternalPayloadsEnabled,
+		s.config.VisibilityProcessorRelocateAttributesMinBlobSize,
+		s.config.ExternalPayloadsEnabled,
 	)
 }
 
@@ -459,7 +466,7 @@ func (s *visibilityQueueTaskExecutorSuite) TestProcessUpsertWorkflowSearchAttrib
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 	s.mockVisibilityMgr.EXPECT().UpsertWorkflowExecution(
 		gomock.Any(),
-		s.createUpsertWorkflowRequest(s.namespace, visibilityTask, mutableState, taskQueueName),
+		s.createUpsertWorkflowRequest(s.namespace, visibilityTask, mutableState, taskQueueName, nil),
 	).Return(nil)
 
 	resp := s.visibilityQueueTaskExecutor.Execute(context.Background(), s.newTaskExecutable(visibilityTask))
@@ -524,7 +531,7 @@ func (s *visibilityQueueTaskExecutorSuite) TestProcessModifyWorkflowProperties()
 	)
 	s.mockVisibilityMgr.EXPECT().UpsertWorkflowExecution(
 		gomock.Any(),
-		s.createUpsertWorkflowRequest(s.namespace, visibilityTask, mutableState, taskQueueName),
+		s.createUpsertWorkflowRequest(s.namespace, visibilityTask, mutableState, taskQueueName, nil),
 	).Return(nil)
 
 	resp := s.visibilityQueueTaskExecutor.Execute(
@@ -694,6 +701,215 @@ func (s *visibilityQueueTaskExecutorSuite) TestProcessChasmTask_ClosedExecution(
 	s.NoError(resp.ExecutionErr)
 }
 
+func (s *visibilityQueueTaskExecutorSuite) TestProcessChasmTask_ChasmWorkflow() {
+	s.config.EnableCHASMVisibilityRatio = dynamicconfig.GetFloatPropertyFnFilteredByNamespace(0.9999)
+	key := definition.NewWorkflowKey(
+		s.namespaceID.String(),
+		"some random ID",
+		uuid.NewString(),
+	)
+	execution := &commonpb.WorkflowExecution{
+		WorkflowId: key.WorkflowID,
+		RunId:      key.RunID,
+	}
+
+	mutableState := workflow.TestGlobalMutableState(
+		s.mockShard,
+		s.mockShard.GetEventsCache(),
+		s.logger,
+		s.version,
+		execution.GetWorkflowId(),
+		execution.GetRunId(),
+	)
+	workflowType := "some random workflow type"
+	taskQueueName := "some random task queue"
+
+	_, err := mutableState.AddWorkflowExecutionStartedEvent(
+		execution,
+		&historyservice.StartWorkflowExecutionRequest{
+			Attempt:     1,
+			NamespaceId: s.namespaceID.String(),
+			StartRequest: &workflowservice.StartWorkflowExecutionRequest{
+				WorkflowType:             &commonpb.WorkflowType{Name: workflowType},
+				TaskQueue:                &taskqueuepb.TaskQueue{Name: taskQueueName},
+				WorkflowExecutionTimeout: durationpb.New(2 * time.Second),
+				WorkflowTaskTimeout:      durationpb.New(1 * time.Second),
+			},
+		},
+	)
+	s.NoError(err)
+
+	wt := addWorkflowTaskScheduledEvent(mutableState)
+	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.NewString())
+	wt.StartedEventID = event.GetEventId()
+	event = addWorkflowTaskCompletedEvent(&s.Suite, mutableState, wt.ScheduledEventID, wt.StartedEventID, "some random identity")
+
+	_, err = mutableState.AddUpsertWorkflowSearchAttributesEvent(
+		event.GetEventId(),
+		&command.UpsertWorkflowSearchAttributesCommandAttributes{
+			SearchAttributes: &commonpb.SearchAttributes{
+				IndexedFields: map[string]*commonpb.Payload{
+					"Keyword01": sadefs.MustEncodeValue("foo", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
+				},
+			},
+		},
+	)
+	s.NoError(err)
+
+	_, err = mutableState.AddWorkflowPropertiesModifiedEvent(
+		event.GetEventId(),
+		&command.ModifyWorkflowPropertiesCommandAttributes{
+			UpsertedMemo: &commonpb.Memo{
+				Fields: map[string]*commonpb.Payload{
+					"random-key": payload.EncodeString("random-value"),
+				},
+			},
+		},
+	)
+	s.NoError(err)
+
+	persistenceMutableState := s.createPersistenceMutableState(
+		mutableState,
+		wt.ScheduledEventID,
+		wt.Version,
+	)
+
+	chasmVisTask := s.buildChasmVisTask(key, 4)
+	chasmVisTask.Info.ArchetypeId = chasm.WorkflowArchetypeID
+
+	s.mockExecutionMgr.EXPECT().
+		GetWorkflowExecution(gomock.Any(), gomock.Any()).
+		Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
+	s.mockVisibilityMgr.EXPECT().UpsertWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, request *manager.UpsertWorkflowExecutionRequest) error {
+			p, ok := request.SearchAttributes.IndexedFields["Keyword01"]
+			s.True(ok)
+			var val string
+			err := payload.Decode(p, &val)
+			s.NoError(err)
+			s.Equal("foo", val)
+
+			s.Len(request.Memo.Fields, 1)
+			userMemoPayload, ok := request.Memo.Fields[chasm.UserMemoKey]
+			s.True(ok)
+			var userMemo *commonpb.Memo
+			s.NoError(payload.Decode(userMemoPayload, &userMemo))
+			p, ok = userMemo.Fields["random-key"]
+			s.True(ok)
+			err = payload.Decode(p, &val)
+			s.Equal("random-value", val)
+
+			return nil
+		},
+	)
+
+	resp := s.visibilityQueueTaskExecutor.Execute(context.Background(), s.newTaskExecutable(chasmVisTask))
+	s.NoError(resp.ExecutionErr)
+}
+
+func (s *visibilityQueueTaskExecutorSuite) TestProcessChasmTask_ChasmWorkflow_FallbackUpsert() {
+	s.config.EnableCHASMVisibilityRatio = dynamicconfig.GetFloatPropertyFnFilteredByNamespace(0)
+	key := definition.NewWorkflowKey(
+		s.namespaceID.String(),
+		"some random ID",
+		uuid.NewString(),
+	)
+	execution := &commonpb.WorkflowExecution{
+		WorkflowId: key.WorkflowID,
+		RunId:      key.RunID,
+	}
+
+	mutableState := workflow.TestGlobalMutableState(
+		s.mockShard,
+		s.mockShard.GetEventsCache(),
+		s.logger,
+		s.version,
+		execution.GetWorkflowId(),
+		execution.GetRunId(),
+	)
+	workflowType := "some random workflow type"
+	taskQueueName := "some random task queue"
+
+	_, err := mutableState.AddWorkflowExecutionStartedEvent(
+		execution,
+		&historyservice.StartWorkflowExecutionRequest{
+			Attempt:     1,
+			NamespaceId: s.namespaceID.String(),
+			StartRequest: &workflowservice.StartWorkflowExecutionRequest{
+				WorkflowType:             &commonpb.WorkflowType{Name: workflowType},
+				TaskQueue:                &taskqueuepb.TaskQueue{Name: taskQueueName},
+				WorkflowExecutionTimeout: durationpb.New(2 * time.Second),
+				WorkflowTaskTimeout:      durationpb.New(1 * time.Second),
+			},
+		},
+	)
+	s.NoError(err)
+
+	wt := addWorkflowTaskScheduledEvent(mutableState)
+	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.NewString())
+	wt.StartedEventID = event.GetEventId()
+	event = addWorkflowTaskCompletedEvent(&s.Suite, mutableState, wt.ScheduledEventID, wt.StartedEventID, "some random identity")
+
+	_, err = mutableState.AddUpsertWorkflowSearchAttributesEvent(
+		event.GetEventId(),
+		&command.UpsertWorkflowSearchAttributesCommandAttributes{
+			SearchAttributes: &commonpb.SearchAttributes{
+				IndexedFields: map[string]*commonpb.Payload{
+					"Keyword01": sadefs.MustEncodeValue("foo", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
+				},
+			},
+		},
+	)
+	s.NoError(err)
+
+	_, err = mutableState.AddWorkflowPropertiesModifiedEvent(
+		event.GetEventId(),
+		&command.ModifyWorkflowPropertiesCommandAttributes{
+			UpsertedMemo: &commonpb.Memo{
+				Fields: map[string]*commonpb.Payload{
+					"random-key": payload.EncodeString("random-value"),
+				},
+			},
+		},
+	)
+	s.NoError(err)
+
+	persistenceMutableState := s.createPersistenceMutableState(
+		mutableState,
+		wt.ScheduledEventID,
+		wt.Version,
+	)
+
+	chasmVisTask := s.buildChasmVisTask(key, 5)
+	chasmVisTask.Info.ArchetypeId = chasm.WorkflowArchetypeID
+
+	s.mockExecutionMgr.EXPECT().
+		GetWorkflowExecution(gomock.Any(), gomock.Any()).
+		Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
+	s.mockVisibilityMgr.EXPECT().UpsertWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, request *manager.UpsertWorkflowExecutionRequest) error {
+			p, ok := request.SearchAttributes.IndexedFields["Keyword01"]
+			s.True(ok)
+			var val string
+			err := payload.Decode(p, &val)
+			s.NoError(err)
+			s.Equal("foo", val)
+
+			// If it is plain memo, it falled back to regular upsert task
+			s.Len(request.Memo.Fields, 1)
+			p, ok = request.Memo.Fields["random-key"]
+			s.True(ok)
+			err = payload.Decode(p, &val)
+			s.Equal("random-value", val)
+
+			return nil
+		},
+	)
+
+	resp := s.visibilityQueueTaskExecutor.Execute(context.Background(), s.newTaskExecutable(chasmVisTask))
+	s.NoError(resp.ExecutionErr)
+}
+
 func (s *visibilityQueueTaskExecutorSuite) buildChasmMutableState(
 	key definition.WorkflowKey,
 	visComponentTransitionCount int64,
@@ -706,6 +922,7 @@ func (s *visibilityQueueTaskExecutorSuite) buildChasmMutableState(
 		ExecutionTime:  timestamppb.Now(),
 		TransitionHistory: []*persistencespb.VersionedTransition{
 			{NamespaceFailoverVersion: s.version, TransitionCount: 1},
+			{NamespaceFailoverVersion: s.version, TransitionCount: 2},
 		},
 		StateTransitionCount: 10,
 	}
@@ -730,8 +947,8 @@ func (s *visibilityQueueTaskExecutorSuite) buildChasmMutableState(
 	chasmNodes := map[string]*persistencespb.ChasmNode{
 		"": {
 			Metadata: &persistencespb.ChasmNodeMetadata{
-				InitialVersionedTransition:    &persistencespb.VersionedTransition{NamespaceFailoverVersion: s.version, TransitionCount: 1},
-				LastUpdateVersionedTransition: &persistencespb.VersionedTransition{NamespaceFailoverVersion: s.version, TransitionCount: 1},
+				InitialVersionedTransition:    &persistencespb.VersionedTransition{NamespaceFailoverVersion: s.version, TransitionCount: 2},
+				LastUpdateVersionedTransition: &persistencespb.VersionedTransition{NamespaceFailoverVersion: s.version, TransitionCount: 2},
 				Attributes: &persistencespb.ChasmNodeMetadata_ComponentAttributes{
 					ComponentAttributes: &persistencespb.ChasmComponentAttributes{
 						TypeId: testComponentTypeID,
@@ -745,8 +962,8 @@ func (s *visibilityQueueTaskExecutorSuite) buildChasmMutableState(
 		},
 		"Visibility": {
 			Metadata: &persistencespb.ChasmNodeMetadata{
-				InitialVersionedTransition:    &persistencespb.VersionedTransition{NamespaceFailoverVersion: s.version, TransitionCount: 1},
-				LastUpdateVersionedTransition: &persistencespb.VersionedTransition{NamespaceFailoverVersion: s.version, TransitionCount: 1},
+				InitialVersionedTransition:    &persistencespb.VersionedTransition{NamespaceFailoverVersion: s.version, TransitionCount: 2},
+				LastUpdateVersionedTransition: &persistencespb.VersionedTransition{NamespaceFailoverVersion: s.version, TransitionCount: 2},
 				Attributes: &persistencespb.ChasmNodeMetadata_ComponentAttributes{
 					ComponentAttributes: &persistencespb.ChasmComponentAttributes{
 						TypeId:   visComponentTypeID,
@@ -790,8 +1007,8 @@ func (s *visibilityQueueTaskExecutorSuite) buildChasmVisTask(
 		TaskID:              int64(59),
 		Category:            tasks.CategoryVisibility,
 		Info: &persistencespb.ChasmTaskInfo{
-			ComponentInitialVersionedTransition:    &persistencespb.VersionedTransition{NamespaceFailoverVersion: s.version, TransitionCount: 1},
-			ComponentLastUpdateVersionedTransition: &persistencespb.VersionedTransition{NamespaceFailoverVersion: s.version, TransitionCount: 1},
+			ComponentInitialVersionedTransition:    &persistencespb.VersionedTransition{NamespaceFailoverVersion: s.version, TransitionCount: 2},
+			ComponentLastUpdateVersionedTransition: &persistencespb.VersionedTransition{NamespaceFailoverVersion: s.version, TransitionCount: 2},
 			Path:                                   []string{"Visibility"},
 			TypeId:                                 visTaskTypeID,
 			Data: &commonpb.DataBlob{
@@ -880,6 +1097,7 @@ func (s *visibilityQueueTaskExecutorSuite) createUpsertWorkflowRequest(
 	task *tasks.UpsertExecutionVisibilityTask,
 	mutableState historyi.MutableState,
 	taskQueueName string,
+	searchAttributes map[string]any,
 ) gomock.Matcher {
 	return protomock.Eq(&manager.UpsertWorkflowExecutionRequest{
 		VisibilityRequestBase: s.createVisibilityRequestBase(
@@ -889,7 +1107,7 @@ func (s *visibilityQueueTaskExecutorSuite) createUpsertWorkflowRequest(
 			taskQueueName,
 			nil,
 			nil,
-			nil,
+			searchAttributes,
 		),
 	})
 }

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"math/rand"
 	"reflect"
 	"slices"
@@ -12,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dgryski/go-farm"
 	"github.com/google/uuid"
 	"github.com/nexus-rpc/sdk-go/nexus"
 	commandpb "go.temporal.io/api/command/v1"
@@ -58,6 +60,7 @@ import (
 	"go.temporal.io/server/common/persistence/transitionhistory"
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/softassert"
@@ -430,6 +433,10 @@ func NewMutableState(
 			logger,
 			shard.GetMetricsHandler().WithTags(metrics.NamespaceTag(namespaceName)),
 		)
+
+		if s.enableChasmVisibility() {
+			s.ensureChasmVisibilityComponent(context.Background())
+		}
 	}
 
 	if s.executionInfo.GetTimeSkippingInfo() != nil {
@@ -696,6 +703,35 @@ func (ms *MutableStateImpl) ChasmSignalBacklinksEnabled() bool {
 	return ms.ChasmEnabled() && ms.shard.GetConfig().EnableCHASMSignalBacklinks(ms.GetNamespaceEntry().Name().String())
 }
 
+// enableChasmVisibility returns true if CHASM-based Visibility must be enabled for the workflow.
+func (ms *MutableStateImpl) enableChasmVisibility() bool {
+	nsName := ms.GetNamespaceEntry().Name()
+	if !ms.ChasmEnabled() || ms.config.VisibilityAllowList(nsName.String()) {
+		return false
+	}
+	ratio := ms.shard.GetConfig().EnableCHASMVisibilityRatio(nsName.String())
+	if ratio <= 0 {
+		return false
+	}
+	if ratio >= 1 {
+		return true
+	}
+	return float64(farm.Fingerprint32([]byte(ms.executionState.RunId))) < ratio*math.MaxUint32
+}
+
+// chasmVisibilityEnabled returns true if CHASM-based Visibility is enabled for the workflow.
+func (ms *MutableStateImpl) chasmVisibilityEnabled() bool {
+	if !ms.ChasmEnabled() {
+		return false
+	}
+	wf, chasmCtx, err := ms.ChasmWorkflowComponentReadOnly(context.Background())
+	if err != nil {
+		return false
+	}
+	_, ok := wf.Visibility.TryGet(chasmCtx)
+	return ok
+}
+
 // ChasmWorkflowComponent gets the root workflow component from the CHASM tree.
 // Returns the workflow component (which is *chasmworkflow.Workflow) and the CHASM mutable context.
 // This method is for write operations. Callers can type assert to *chasmworkflow.Workflow if needed.
@@ -741,6 +777,17 @@ func (ms *MutableStateImpl) ChasmWorkflowComponentReadOnly(ctx context.Context) 
 		return nil, nil, serviceerror.NewInternalf("expected workflow component, but got %T", rootComponent)
 	}
 	return wf, chasmCtx, nil
+}
+
+func (ms *MutableStateImpl) ensureChasmVisibilityComponent(ctx context.Context) {
+	ms.EnsureChasmWorkflowComponent(ctx)
+	wf, chasmCtx, err := ms.ChasmWorkflowComponent(ctx)
+	softassert.That(ms.logger, err == nil, "chasm workflow component not set")
+
+	if _, ok := wf.Visibility.TryGet(chasmCtx); !ok {
+		vis := chasm.NewVisibility(chasmCtx)
+		wf.Visibility = chasm.NewComponentField(chasmCtx, vis)
+	}
 }
 
 func (ms *MutableStateImpl) EndpointRegistry() chasm.EndpointRegistry {
@@ -3081,11 +3128,11 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionStartedEvent(
 		ms.namespaceEntry.Retention(),
 	)
 
-	if event.Memo != nil {
-		ms.executionInfo.Memo = event.Memo.GetFields()
+	if err := ms.updateSearchAttributes(event.SearchAttributes.GetIndexedFields()); err != nil {
+		return err
 	}
-	if event.SearchAttributes != nil {
-		ms.executionInfo.SearchAttributes = event.SearchAttributes.GetIndexedFields()
+	if err := ms.updateMemo(event.Memo.GetFields()); err != nil {
+		return err
 	}
 
 	if event.GetVersioningOverride() != nil {
@@ -3565,7 +3612,11 @@ func (ms *MutableStateImpl) updateBinaryChecksumSearchAttribute() error {
 	if proto.Equal(exeInfo.SearchAttributes[sadefs.BinaryChecksums], checksumsPayload) {
 		return nil // unchanged
 	}
-	ms.updateSearchAttributes(map[string]*commonpb.Payload{sadefs.BinaryChecksums: checksumsPayload})
+	if err := ms.updatePredefinedSearchAttributes(
+		map[string]*commonpb.Payload{sadefs.BinaryChecksums: checksumsPayload},
+	); err != nil {
+		return err
+	}
 	return ms.taskGenerator.GenerateUpsertVisibilityTask()
 }
 
@@ -3889,12 +3940,6 @@ func (ms *MutableStateImpl) addUsedDeploymentVersionToLoadedSearchAttribute(exis
 }
 
 func (ms *MutableStateImpl) saveBuildIds(buildIds []string, maxSearchAttributeValueSize int) error {
-	searchAttributes := ms.executionInfo.SearchAttributes
-	if searchAttributes == nil {
-		searchAttributes = make(map[string]*commonpb.Payload, 1)
-		ms.executionInfo.SearchAttributes = searchAttributes
-	}
-
 	hasUnversionedOrAssigned := false
 	if len(buildIds) > 0 { // len is 0 if we are removing the pinned search attribute and the workflow was never unversioned or assigned
 		hasUnversionedOrAssigned = worker_versioning.IsUnversionedOrAssignedBuildIdSearchAttribute(buildIds[0])
@@ -3905,8 +3950,9 @@ func (ms *MutableStateImpl) saveBuildIds(buildIds []string, maxSearchAttributeVa
 			return err
 		}
 		if len(buildIds) == 0 || len(saPayload.GetData()) <= maxSearchAttributeValueSize {
-			ms.updateSearchAttributes(map[string]*commonpb.Payload{sadefs.BuildIds: saPayload})
-			break
+			return ms.updatePredefinedSearchAttributes(
+				map[string]*commonpb.Payload{sadefs.BuildIds: saPayload},
+			)
 		}
 		if len(buildIds) == 1 {
 			buildIds = make([]string, 0)
@@ -3917,26 +3963,18 @@ func (ms *MutableStateImpl) saveBuildIds(buildIds []string, maxSearchAttributeVa
 			buildIds = buildIds[1:]
 		}
 	}
-	return nil
 }
 
 func (ms *MutableStateImpl) saveUsedDeploymentVersions(usedDeploymentVersions []string, maxSearchAttributeValueSize int) error {
-	searchAttributes := ms.executionInfo.SearchAttributes
-	if searchAttributes == nil {
-		searchAttributes = make(map[string]*commonpb.Payload, 1)
-		ms.executionInfo.SearchAttributes = searchAttributes
-	}
-
 	for {
 		saPayload, err := sadefs.EncodeValue(usedDeploymentVersions, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST)
 		if err != nil {
 			return err
 		}
 		if len(usedDeploymentVersions) == 0 || len(saPayload.GetData()) <= maxSearchAttributeValueSize {
-			ms.updateSearchAttributes(map[string]*commonpb.Payload{
-				sadefs.TemporalUsedWorkerDeploymentVersions: saPayload,
-			})
-			break
+			return ms.updatePredefinedSearchAttributes(
+				map[string]*commonpb.Payload{sadefs.TemporalUsedWorkerDeploymentVersions: saPayload},
+			)
 		}
 		// If too large, remove oldest entries
 		if len(usedDeploymentVersions) == 1 {
@@ -3945,7 +3983,6 @@ func (ms *MutableStateImpl) saveUsedDeploymentVersions(usedDeploymentVersions []
 			usedDeploymentVersions = usedDeploymentVersions[1:] // Remove oldest
 		}
 	}
-	return nil
 }
 
 // Note: If the encoding for one of these strings fails, none of them would get saved. But we really
@@ -3987,8 +4024,7 @@ func (ms *MutableStateImpl) saveDeploymentSearchAttributes(deployment, version, 
 			saPayloads[sadefs.TemporalWorkflowVersioningBehavior] = behaviorPayload
 		}
 	}
-	ms.updateSearchAttributes(saPayloads)
-	return nil
+	return ms.updatePredefinedSearchAttributes(saPayloads)
 }
 
 func (ms *MutableStateImpl) addBuildIDAndDeploymentInfoToSearchAttributesWithNoVisibilityTask(
@@ -4020,7 +4056,10 @@ func (ms *MutableStateImpl) addBuildIDAndDeploymentInfoToSearchAttributesWithNoV
 
 	// modify them
 	modifiedBuildIds := ms.addBuildIdToLoadedSearchAttribute(existingBuildIds, stamp)
-	modifiedUsedDeploymentVersions := ms.addUsedDeploymentVersionToLoadedSearchAttribute(existingUsedDeploymentVersions, usedVersion)
+	modifiedUsedDeploymentVersions := ms.addUsedDeploymentVersionToLoadedSearchAttribute(
+		existingUsedDeploymentVersions,
+		usedVersion,
+	)
 	modifiedDeployment := ms.GetWorkerDeploymentSA()
 	modifiedVersion := ms.GetWorkerDeploymentVersionSA()
 	modifiedBehavior := ""
@@ -4028,14 +4067,7 @@ func (ms *MutableStateImpl) addBuildIDAndDeploymentInfoToSearchAttributesWithNoV
 		modifiedBehavior = b.String()
 	}
 
-	// check equality
-	if slices.Equal(existingBuildIds, modifiedBuildIds) &&
-		slices.Equal(existingUsedDeploymentVersions, modifiedUsedDeploymentVersions) &&
-		existingDeployment == modifiedDeployment &&
-		existingVersion == modifiedVersion &&
-		existingBehavior == modifiedBehavior {
-		return false, nil
-	}
+	hasChanges := false
 
 	// save build ids if changed
 	if !slices.Equal(existingBuildIds, modifiedBuildIds) {
@@ -4043,6 +4075,7 @@ func (ms *MutableStateImpl) addBuildIDAndDeploymentInfoToSearchAttributesWithNoV
 		if err != nil {
 			return false, err // if err != nil, nothing will be written
 		}
+		hasChanges = true
 	}
 
 	// save used deployment versions if changed
@@ -4051,18 +4084,26 @@ func (ms *MutableStateImpl) addBuildIDAndDeploymentInfoToSearchAttributesWithNoV
 		if err != nil {
 			return false, err // if err != nil, nothing will be written
 		}
+		hasChanges = true
 	}
 
 	// save deployment search attributes if changed
 	if existingDeployment != modifiedDeployment ||
 		existingVersion != modifiedVersion ||
 		existingBehavior != modifiedBehavior {
-		err = ms.saveDeploymentSearchAttributes(modifiedDeployment, modifiedVersion, modifiedBehavior, maxSearchAttributeValueSize)
+		err = ms.saveDeploymentSearchAttributes(
+			modifiedDeployment,
+			modifiedVersion,
+			modifiedBehavior,
+			maxSearchAttributeValueSize,
+		)
 		if err != nil {
 			return false, err // if err != nil, nothing will be written
 		}
+		hasChanges = true
 	}
-	return true, nil
+
+	return hasChanges, nil
 }
 
 // TODO: we will release the restriction when reset API allow those pending
@@ -5206,7 +5247,9 @@ func (ms *MutableStateImpl) AddUpsertWorkflowSearchAttributesEvent(
 	}
 
 	event := ms.hBuilder.AddUpsertWorkflowSearchAttributesEvent(workflowTaskCompletedEventID, command)
-	ms.ApplyUpsertWorkflowSearchAttributesEvent(event)
+	if err := ms.ApplyUpsertWorkflowSearchAttributesEvent(event); err != nil {
+		return nil, err
+	}
 	// TODO merge active & passive task generation
 	if err := ms.taskGenerator.GenerateUpsertVisibilityTask(); err != nil {
 		return nil, err
@@ -5216,11 +5259,17 @@ func (ms *MutableStateImpl) AddUpsertWorkflowSearchAttributesEvent(
 
 func (ms *MutableStateImpl) ApplyUpsertWorkflowSearchAttributesEvent(
 	event *historypb.HistoryEvent,
-) {
-	upsertSearchAttr := event.GetUpsertWorkflowSearchAttributesEventAttributes().GetSearchAttributes().GetIndexedFields()
-	ms.approximateSize -= ms.executionInfo.Size()
-	ms.updateSearchAttributes(upsertSearchAttr)
-	ms.approximateSize += ms.executionInfo.Size()
+) error {
+	attr := event.GetUpsertWorkflowSearchAttributesEventAttributes()
+	if attr.SearchAttributes != nil {
+		upsertSearchAttr := attr.GetSearchAttributes().GetIndexedFields()
+		ms.approximateSize -= ms.executionInfo.Size()
+		if err := ms.updateSearchAttributes(upsertSearchAttr); err != nil {
+			return err
+		}
+		ms.approximateSize += ms.executionInfo.Size()
+	}
+	return nil
 }
 
 func (ms *MutableStateImpl) AddWorkflowPropertiesModifiedEvent(
@@ -5233,7 +5282,9 @@ func (ms *MutableStateImpl) AddWorkflowPropertiesModifiedEvent(
 	}
 
 	event := ms.hBuilder.AddWorkflowPropertiesModifiedEvent(workflowTaskCompletedEventID, command)
-	ms.ApplyWorkflowPropertiesModifiedEvent(event)
+	if err := ms.ApplyWorkflowPropertiesModifiedEvent(event); err != nil {
+		return nil, err
+	}
 	// TODO merge active & passive task generation
 	// TODO: only generate visibility task when memo is updated
 	if err := ms.taskGenerator.GenerateUpsertVisibilityTask(); err != nil {
@@ -5244,14 +5295,17 @@ func (ms *MutableStateImpl) AddWorkflowPropertiesModifiedEvent(
 
 func (ms *MutableStateImpl) ApplyWorkflowPropertiesModifiedEvent(
 	event *historypb.HistoryEvent,
-) {
+) error {
 	attr := event.GetWorkflowPropertiesModifiedEventAttributes()
 	if attr.UpsertedMemo != nil {
 		upsertMemo := attr.GetUpsertedMemo().GetFields()
 		ms.approximateSize -= ms.executionInfo.Size()
-		ms.updateMemo(upsertMemo)
+		if err := ms.updateMemo(upsertMemo); err != nil {
+			return err
+		}
 		ms.approximateSize += ms.executionInfo.Size()
 	}
+	return nil
 }
 
 func (ms *MutableStateImpl) AddExternalWorkflowExecutionSignaled(
@@ -6959,7 +7013,11 @@ func (ms *MutableStateImpl) updatePauseInfoSearchAttribute() error {
 		return nil // unchanged
 	}
 
-	ms.updateSearchAttributes(map[string]*commonpb.Payload{sadefs.TemporalPauseInfo: pauseInfoPayload})
+	if err := ms.updatePredefinedSearchAttributes(
+		map[string]*commonpb.Payload{sadefs.TemporalPauseInfo: pauseInfoPayload},
+	); err != nil {
+		return err
+	}
 	return ms.taskGenerator.GenerateUpsertVisibilityTask()
 }
 
@@ -7006,7 +7064,11 @@ func (ms *MutableStateImpl) UpdateReportedProblemsSearchAttribute() error {
 	// Log the search attribute change
 	ms.logReportedProblemsChange(existingProblems, reportedProblems)
 
-	ms.updateSearchAttributes(map[string]*commonpb.Payload{sadefs.TemporalReportedProblems: reportedProblemsPayload})
+	if err := ms.updatePredefinedSearchAttributes(
+		map[string]*commonpb.Payload{sadefs.TemporalReportedProblems: reportedProblemsPayload},
+	); err != nil {
+		return err
+	}
 	return ms.taskGenerator.GenerateUpsertVisibilityTask()
 }
 
@@ -7026,7 +7088,11 @@ func (ms *MutableStateImpl) RemoveReportedProblemsSearchAttribute() error {
 	ms.executionInfo.LastWorkflowTaskFailure = nil
 
 	// Just remove the search attribute entirely for now
-	ms.updateSearchAttributes(map[string]*commonpb.Payload{sadefs.TemporalReportedProblems: nil})
+	if err := ms.updatePredefinedSearchAttributes(
+		map[string]*commonpb.Payload{sadefs.TemporalReportedProblems: nil},
+	); err != nil {
+		return err
+	}
 	return ms.taskGenerator.GenerateUpsertVisibilityTask()
 }
 
@@ -7223,14 +7289,45 @@ func (ms *MutableStateImpl) AddTasks(
 	newTasks ...tasks.Task,
 ) {
 	now := ms.Now()
+	nsName := ms.GetNamespaceEntry().Name()
+	chasmVisEnabledRatio := ms.shard.GetConfig().EnableCHASMVisibilityRatio(nsName.String())
+	isWorkflow := ms.IsWorkflow()
 	for _, task := range newTasks {
-		if chasmTask, ok := task.(*tasks.ChasmTask); ok &&
-			chasmTask.GetCategory() == tasks.CategoryVisibility &&
-			ms.stateInDB == enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED {
-			softassert.Fail(ms.logger, "CHASM visibility task added on already-closed execution")
+		category := task.GetCategory()
+
+		if category == tasks.CategoryVisibility {
+			switch task.GetType() {
+			case enumsspb.TASK_TYPE_CHASM:
+				softassert.That(
+					ms.logger,
+					ms.stateInDB != enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
+					"CHASM visibility task added on already-closed execution",
+				)
+
+				// If this is a CHASM Visibility task, the mutable state is a workflow and
+				// the ratio is 0, then this workflow had CHASM Visibility enabled when the
+				// ratio was not 0, and now it's has been rolled back to 0. In this case,
+				// we want to ignore CHASM Visibility tasks, and let the regular Visibility
+				// tasks be added.
+				if isWorkflow && chasmVisEnabledRatio == 0 {
+					continue
+				}
+
+			case enumsspb.TASK_TYPE_VISIBILITY_START_EXECUTION,
+				enumsspb.TASK_TYPE_VISIBILITY_UPSERT_EXECUTION,
+				enumsspb.TASK_TYPE_VISIBILITY_CLOSE_EXECUTION:
+				// If the mutable state is a workflow with CHASM Visibility enabled and
+				// the ratio is not 0, then CHASM Visibility task is also generated and
+				// we can ignore the regular Visibility tasks.
+				if isWorkflow && ms.chasmVisibilityEnabled() && chasmVisEnabledRatio > 0 {
+					continue
+				}
+
+			default:
+				// no-op
+			}
 		}
 
-		category := task.GetCategory()
 		// Drop tasks scheduled too far in the future. VisibilityTime hasn't been
 		// shifted to wall-clock yet (the conversion runs below), so both sides are
 		// virtual here; the difference is frame-invariant (skip cancels). Keep
@@ -7557,24 +7654,164 @@ func (ms *MutableStateImpl) GenerateMigrationTasks(targetClusters []string) ([]t
 	return ms.taskGenerator.GenerateMigrationTasks(targetClusters)
 }
 
-func (ms *MutableStateImpl) updateSearchAttributes(
-	updatedPayloadMap map[string]*commonpb.Payload,
-) {
+func (ms *MutableStateImpl) getPredefinedSearchAttributes() map[string]*commonpb.Payload {
+	predefined := make(map[string]*commonpb.Payload)
+	for saFieldName, saPayload := range ms.executionInfo.GetSearchAttributes() {
+		if !sadefs.IsMappable(saFieldName) {
+			predefined[saFieldName] = saPayload
+		}
+	}
+	return predefined
+}
+
+func (ms *MutableStateImpl) GetSearchAttributes(
+	ctx context.Context,
+) (map[string]*commonpb.Payload, error) {
+	if ms.chasmVisibilityEnabled() {
+		wf, chasmCtx, err := ms.ChasmWorkflowComponentReadOnly(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return payload.MergeMapOfPayload(
+			ms.getPredefinedSearchAttributes(),
+			wf.CustomSearchAttributes(chasmCtx),
+		), nil
+	}
+	return ms.executionInfo.GetSearchAttributes(), nil
+}
+
+func (ms *MutableStateImpl) GetMemo(ctx context.Context) (map[string]*commonpb.Payload, error) {
+	if ms.chasmVisibilityEnabled() {
+		wf, chasmCtx, err := ms.ChasmWorkflowComponentReadOnly(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return wf.CustomMemo(chasmCtx), nil
+	}
+	return ms.executionInfo.GetMemo(), nil
+}
+
+func (ms *MutableStateImpl) updatePredefinedSearchAttributes(
+	updatedSearchAttributes map[string]*commonpb.Payload,
+) error {
+	if len(updatedSearchAttributes) == 0 {
+		return nil
+	}
+	for field := range updatedSearchAttributes {
+		if sadefs.IsMappable(field) {
+			return serviceerror.NewInternalf(
+				"cannot call updatePredefinedSearchAttributes with custom search attribute %q",
+				field,
+			)
+		}
+	}
 	ms.executionInfo.SearchAttributes = payload.MergeMapOfPayload(
 		ms.executionInfo.SearchAttributes,
-		updatedPayloadMap,
+		updatedSearchAttributes,
 	)
 	ms.visibilityUpdated = true
+	return nil
+}
+
+func (ms *MutableStateImpl) updateSearchAttributes(
+	updatedSearchAttributes map[string]*commonpb.Payload,
+) error {
+	if len(updatedSearchAttributes) == 0 {
+		return nil
+	}
+
+	// Split search attributes map since it contains both predefined and custom search attributes.
+	updatedCustom := make(map[string]*commonpb.Payload)
+	updatedPredefined := make(map[string]*commonpb.Payload)
+	for name, saPayload := range updatedSearchAttributes {
+		if sadefs.IsMappable(name) {
+			updatedCustom[name] = saPayload
+		} else {
+			updatedPredefined[name] = saPayload
+		}
+	}
+
+	chasmVisEnabled := ms.chasmVisibilityEnabled()
+	chasmVisRatio := ms.config.EnableCHASMVisibilityRatio(ms.GetNamespaceEntry().Name().String())
+	if !chasmVisEnabled || chasmVisRatio < 1 {
+		// CHASM Visibility is not 100% enabled, so write everything to execution info as backup.
+		ms.executionInfo.SearchAttributes = payload.MergeMapOfPayload(
+			ms.executionInfo.SearchAttributes,
+			updatedSearchAttributes,
+		)
+		ms.visibilityUpdated = true
+	} else if len(updatedPredefined) > 0 {
+		// CHASM Visibility is 100% enabled, so write only the predefined search
+		// attributes to execution info.
+		ms.executionInfo.SearchAttributes = payload.MergeMapOfPayload(
+			ms.executionInfo.SearchAttributes,
+			updatedPredefined,
+		)
+		ms.visibilityUpdated = true
+	}
+
+	if chasmVisEnabled && len(updatedCustom) > 0 {
+		return ms.updateCustomSearchAttributesChasm(updatedCustom)
+	}
+	return nil
+}
+
+func (ms *MutableStateImpl) updateCustomSearchAttributesChasm(
+	updatedSearchAttributes map[string]*commonpb.Payload,
+) error {
+	if len(updatedSearchAttributes) == 0 {
+		return nil
+	}
+	// CHASM Visibility stores custom search attributes using alias instead of field names.
+	aliasedSearchAttributes, err := searchattribute.AliasFields(
+		ms.shard.GetSearchAttributesMapperProvider(),
+		&commonpb.SearchAttributes{
+			IndexedFields: updatedSearchAttributes,
+		},
+		ms.GetNamespaceEntry().Name().String(),
+	)
+	if err != nil {
+		return err
+	}
+	wf, chasmCtx, err := ms.ChasmWorkflowComponent(context.Background())
+	if err != nil {
+		return err
+	}
+	return wf.UpsertCustomSearchAttributes(chasmCtx, aliasedSearchAttributes.GetIndexedFields())
 }
 
 func (ms *MutableStateImpl) updateMemo(
 	updatedMemo map[string]*commonpb.Payload,
-) {
-	ms.executionInfo.Memo = payload.MergeMapOfPayload(
-		ms.executionInfo.Memo,
-		updatedMemo,
-	)
-	ms.visibilityUpdated = true
+) error {
+	if len(updatedMemo) == 0 {
+		return nil
+	}
+
+	chasmVisEnabled := ms.chasmVisibilityEnabled()
+	chasmVisRatio := ms.config.EnableCHASMVisibilityRatio(ms.GetNamespaceEntry().Name().String())
+	if !chasmVisEnabled || chasmVisRatio < 1 {
+		// CHASM Visibility is not 100% enabled, so write to execution info as backup.
+		ms.executionInfo.Memo = payload.MergeMapOfPayload(
+			ms.executionInfo.Memo,
+			updatedMemo,
+		)
+		ms.visibilityUpdated = true
+	}
+
+	if chasmVisEnabled {
+		return ms.updateMemoChasm(updatedMemo)
+	}
+	return nil
+}
+
+func (ms *MutableStateImpl) updateMemoChasm(
+	updatedMemo map[string]*commonpb.Payload,
+) error {
+	wf, chasmCtx, err := ms.ChasmWorkflowComponent(context.Background())
+	if err != nil {
+		return err
+	}
+	return wf.UpsertCustomMemo(chasmCtx, updatedMemo)
 }
 
 type closeTransactionResult struct {

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -33,6 +33,7 @@ import (
 	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/chasm"
+	chasmworkflow "go.temporal.io/server/chasm/lib/workflow"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
@@ -4331,6 +4332,69 @@ func (s *mutableStateSuite) TestCollapseVisibilityTasks() {
 			},
 		)
 	}
+}
+
+func (s *mutableStateSuite) TestAddTasks_ChasmVisibility() {
+	registry := chasm.NewRegistry(s.logger)
+	s.NoError(registry.Register(chasmworkflow.NewLibrary(chasmworkflow.NewRegistry())))
+	s.mockShard.SetChasmRegistry(registry)
+	s.mockConfig.VisibilityAllowList = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false)
+	s.mockConfig.EnableChasm = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
+	s.mockConfig.EnableCHASMVisibilityRatio = dynamicconfig.GetFloatPropertyFnFilteredByNamespace(0.99)
+	ms := NewMutableState(
+		s.mockShard,
+		s.mockEventsCache,
+		s.logger,
+		s.namespaceEntry,
+		tests.WorkflowID,
+		tests.RunID,
+		time.Now().UTC(),
+	)
+	s.True(ms.ChasmEnabled())
+	s.True(ms.chasmVisibilityEnabled())
+
+	ms.AddTasks(
+		&tasks.StartExecutionVisibilityTask{},
+		&tasks.UpsertExecutionVisibilityTask{},
+		&tasks.CloseExecutionVisibilityTask{},
+	)
+	s.Empty(ms.InsertTasks[tasks.CategoryVisibility])
+
+	ms.AddTasks(&tasks.ChasmTask{
+		Category: tasks.CategoryVisibility,
+		TaskID:   1,
+	})
+	s.Len(ms.InsertTasks[tasks.CategoryVisibility], 1)
+	t0 := ms.InsertTasks[tasks.CategoryVisibility][0]
+	s.Equal(enumsspb.TASK_TYPE_CHASM, t0.GetType())
+	s.Equal(tasks.CategoryVisibility, t0.GetCategory())
+	s.Equal(int64(1), t0.GetTaskID())
+
+	// Disable CHASM Visibility
+	s.mockConfig.EnableCHASMVisibilityRatio = dynamicconfig.GetFloatPropertyFnFilteredByNamespace(0)
+	ms.AddTasks(&tasks.ChasmTask{
+		Category: tasks.CategoryVisibility,
+		TaskID:   2,
+	})
+	s.Len(ms.InsertTasks[tasks.CategoryVisibility], 1)
+	s.Equal(int64(1), ms.InsertTasks[tasks.CategoryVisibility][0].GetTaskID())
+
+	ms.AddTasks(
+		&tasks.StartExecutionVisibilityTask{TaskID: 2},
+		&tasks.UpsertExecutionVisibilityTask{TaskID: 3},
+		&tasks.CloseExecutionVisibilityTask{TaskID: 4},
+	)
+	s.Len(ms.InsertTasks[tasks.CategoryVisibility], 4)
+	s.Equal(int64(1), ms.InsertTasks[tasks.CategoryVisibility][0].GetTaskID())
+	t1 := ms.InsertTasks[tasks.CategoryVisibility][1]
+	s.Equal(enumsspb.TASK_TYPE_VISIBILITY_START_EXECUTION, t1.GetType())
+	s.Equal(int64(2), t1.GetTaskID())
+	t2 := ms.InsertTasks[tasks.CategoryVisibility][2]
+	s.Equal(enumsspb.TASK_TYPE_VISIBILITY_UPSERT_EXECUTION, t2.GetType())
+	s.Equal(int64(3), t2.GetTaskID())
+	t3 := ms.InsertTasks[tasks.CategoryVisibility][3]
+	s.Equal(enumsspb.TASK_TYPE_VISIBILITY_CLOSE_EXECUTION, t3.GetType())
+	s.Equal(int64(4), t3.GetTaskID())
 }
 
 func (s *mutableStateSuite) TestStartChildWorkflowRequestID() {

--- a/service/history/workflow/mutable_state_rebuilder.go
+++ b/service/history/workflow/mutable_state_rebuilder.go
@@ -527,13 +527,17 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 			}
 
 		case enumspb.EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES:
-			b.mutableState.ApplyUpsertWorkflowSearchAttributesEvent(event)
+			if err := b.mutableState.ApplyUpsertWorkflowSearchAttributesEvent(event); err != nil {
+				return nil, err
+			}
 			if err := taskGenerator.GenerateUpsertVisibilityTask(); err != nil {
 				return nil, err
 			}
 
 		case enumspb.EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED:
-			b.mutableState.ApplyWorkflowPropertiesModifiedEvent(event)
+			if err := b.mutableState.ApplyWorkflowPropertiesModifiedEvent(event); err != nil {
+				return nil, err
+			}
 			if err := taskGenerator.GenerateUpsertVisibilityTask(); err != nil {
 				return nil, err
 			}

--- a/service/history/workflow/mutable_state_rebuilder_test.go
+++ b/service/history/workflow/mutable_state_rebuilder_test.go
@@ -928,7 +928,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeUpsertWorkflowSearchAttribu
 			UpsertWorkflowSearchAttributesEventAttributes: &historypb.UpsertWorkflowSearchAttributesEventAttributes{},
 		},
 	}
-	s.mockMutableState.EXPECT().ApplyUpsertWorkflowSearchAttributesEvent(protomock.Eq(event)).Return()
+	s.mockMutableState.EXPECT().ApplyUpsertWorkflowSearchAttributesEvent(protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockTaskGenerator.EXPECT().GenerateUpsertVisibilityTask().Return(nil)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
@@ -959,7 +959,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowPropertiesModified(
 			WorkflowPropertiesModifiedEventAttributes: &historypb.WorkflowPropertiesModifiedEventAttributes{},
 		},
 	}
-	s.mockMutableState.EXPECT().ApplyWorkflowPropertiesModifiedEvent(protomock.Eq(event)).Return()
+	s.mockMutableState.EXPECT().ApplyWorkflowPropertiesModifiedEvent(protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockTaskGenerator.EXPECT().GenerateUpsertVisibilityTask().Return(nil)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()

--- a/service/history/workflow/relocatable_attributes_fetcher.go
+++ b/service/history/workflow/relocatable_attributes_fetcher.go
@@ -64,9 +64,17 @@ func (f *relocatableAttributesFetcher) Fetch(
 	// If the relocatable attributes were not removed from mutable state, then we can fetch the memo
 	// and search attributes from the mutable state.
 	if !executionInfo.GetRelocatableAttributesRemoved() {
+		searchAttributes, err := mutableState.GetSearchAttributes(ctx)
+		if err != nil {
+			return nil, err
+		}
+		memo, err := mutableState.GetMemo(ctx)
+		if err != nil {
+			return nil, err
+		}
 		return &RelocatableAttributes{
-			Memo:             &commonpb.Memo{Fields: executionInfo.Memo},
-			SearchAttributes: &commonpb.SearchAttributes{IndexedFields: executionInfo.SearchAttributes},
+			Memo:             &commonpb.Memo{Fields: memo},
+			SearchAttributes: &commonpb.SearchAttributes{IndexedFields: searchAttributes},
 		}, nil
 	}
 

--- a/service/history/workflow/relocatable_attributes_fetcher_test.go
+++ b/service/history/workflow/relocatable_attributes_fetcher_test.go
@@ -41,12 +41,16 @@ func TestRelocatableAttributesFetcher_Fetch(t *testing.T) {
 
 	require.NotEqual(t, mutableStateAttributes.Memo, persistenceAttributes.Memo)
 	require.NotEqual(t, mutableStateAttributes.SearchAttributes, persistenceAttributes.SearchAttributes)
-	testErr := errors.New("test error")
+	getWorkflowExecutionErr := errors.New("test get workflow execution error")
+	getSearchAttributesErr := errors.New("test get search attributes error")
+	getMemoErr := errors.New("test get memo error")
 	for _, c := range []*struct {
 		Name                         string
 		RelocatableAttributesRemoved bool
 		DisableFetchFromVisibility   bool
 		GetWorkflowExecutionErr      error
+		GetSearchAttributesErr       error
+		GetMemoErr                   error
 
 		ExpectedInfo *RelocatableAttributes
 		ExpectedErr  error
@@ -73,9 +77,23 @@ func TestRelocatableAttributesFetcher_Fetch(t *testing.T) {
 		{
 			Name:                         "GetWorkflowExecutionErr",
 			RelocatableAttributesRemoved: true,
-			GetWorkflowExecutionErr:      testErr,
+			GetWorkflowExecutionErr:      getWorkflowExecutionErr,
 
-			ExpectedErr: testErr,
+			ExpectedErr: getWorkflowExecutionErr,
+		},
+		{
+			Name:                         "GetSearchAttributesErr",
+			RelocatableAttributesRemoved: false,
+			GetSearchAttributesErr:       getSearchAttributesErr,
+
+			ExpectedErr: getSearchAttributesErr,
+		},
+		{
+			Name:                         "GetMemoErr",
+			RelocatableAttributesRemoved: false,
+			GetMemoErr:                   getMemoErr,
+
+			ExpectedErr: getMemoErr,
 		},
 	} {
 		t.Run(c.Name, func(t *testing.T) {
@@ -98,7 +116,14 @@ func TestRelocatableAttributesFetcher_Fetch(t *testing.T) {
 			mutableState.EXPECT().GetExecutionInfo().Return(executionInfo).AnyTimes()
 			mutableState.EXPECT().GetNamespaceEntry().Return(namespaceEntry).AnyTimes()
 			mutableState.EXPECT().GetExecutionState().Return(executionState).AnyTimes()
-			if c.RelocatableAttributesRemoved && !c.DisableFetchFromVisibility {
+			if !c.RelocatableAttributesRemoved {
+				mutableState.EXPECT().GetSearchAttributes(gomock.Any()).
+					Return(mutableStateAttributes.SearchAttributes.GetIndexedFields(), c.GetSearchAttributesErr)
+				if c.GetSearchAttributesErr == nil {
+					mutableState.EXPECT().GetMemo(gomock.Any()).
+						Return(mutableStateAttributes.Memo.GetFields(), c.GetMemoErr)
+				}
+			} else if !c.DisableFetchFromVisibility {
 				visibilityManager.EXPECT().GetWorkflowExecution(gomock.Any(), &manager.GetWorkflowExecutionRequest{
 					NamespaceID: namespaceEntry.ID(),
 					Namespace:   namespaceEntry.Name(),

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -242,6 +242,7 @@ func (r *TaskGeneratorImpl) GenerateWorkflowCloseTasks(
 				Version:     closeVersion,
 			},
 		)
+
 		if r.archivalEnabled() {
 			retention, err := r.getRetention()
 			if err != nil {
@@ -408,13 +409,10 @@ func (r *TaskGeneratorImpl) GenerateDelayedWorkflowTasks(
 func (r *TaskGeneratorImpl) GenerateRecordWorkflowStartedTasks(
 	startEvent *historypb.HistoryEvent,
 ) error {
-
-	startVersion := startEvent.GetVersion()
-
 	r.mutableState.AddTasks(&tasks.StartExecutionVisibilityTask{
 		// TaskID, VisibilityTimestamp is set by shard
 		WorkflowKey: r.mutableState.GetWorkflowKey(),
-		Version:     startVersion,
+		Version:     startEvent.GetVersion(),
 	})
 	return nil
 }

--- a/tests/workflow_visibility_migration_test.go
+++ b/tests/workflow_visibility_migration_test.go
@@ -1,0 +1,292 @@
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/searchattribute/sadefs"
+	"go.temporal.io/server/common/testing/parallelsuite"
+	"go.temporal.io/server/tests/testcore"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+type WorkflowVisibilityMigrationSuite struct {
+	parallelsuite.Suite[*WorkflowVisibilityMigrationSuite]
+}
+
+func TestWorkflowVisibilityMigrationSuite(t *testing.T) {
+	parallelsuite.Run(t, &WorkflowVisibilityMigrationSuite{})
+}
+
+func (s *WorkflowVisibilityMigrationSuite) newTestEnv() *testcore.TestEnv {
+	return testcore.NewEnv(
+		s.T(),
+		testcore.WithDynamicConfig(dynamicconfig.VisibilityAllowList, false),
+		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
+		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMVisibilityRatio, 0.0),
+	)
+}
+
+// TODO (rodrigozhou): This test can be removed once CHASM Visibility are the default
+func (s *WorkflowVisibilityMigrationSuite) TestWorkflowVisibility_CHASM_Enabled_Mid_WF() {
+	// This test verifies that when CHASM Visibility is enabled mid-workflow,
+	// visibility still work correctly.
+	// 1. Start a workflow with CHASM Visibility disabled
+	// 2. Workflow blocks waiting for a signal
+	// 3. Enable CHASM Visibility dynamically
+	// 4. Send signal to unblock workflow, upsert custom search attribute, and let it complete
+	// 5. Verify custom search attributes is correct
+
+	env := s.newTestEnv()
+
+	ctx := s.Context()
+	sdkClient := env.SdkClient()
+
+	customKeywordField := temporal.NewSearchAttributeKeyKeyword("CustomKeywordField")
+
+	workflowType := "blockingWorkflow"
+	workflowID := env.Tv().WorkflowID()
+
+	// Register workflow that blocks until it receives a signal
+	blockingWorkflow := func(ctx workflow.Context) (int, error) {
+		workflow.GetSignalChannel(ctx, "continue").Receive(ctx, nil)
+		if err := workflow.UpsertTypedSearchAttributes(
+			ctx,
+			customKeywordField.ValueSet("bar"),
+		); err != nil {
+			return 0, err
+		}
+		return 1, nil
+	}
+	env.SdkWorker().RegisterWorkflowWithOptions(blockingWorkflow, workflow.RegisterOptions{Name: workflowType})
+
+	request := &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:          uuid.NewString(),
+		Namespace:          env.Namespace().String(),
+		WorkflowId:         workflowID,
+		WorkflowType:       &commonpb.WorkflowType{Name: workflowType},
+		TaskQueue:          &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		Input:              nil,
+		WorkflowRunTimeout: durationpb.New(30 * time.Second),
+		Identity:           s.T().Name(),
+		SearchAttributes: &commonpb.SearchAttributes{
+			IndexedFields: map[string]*commonpb.Payload{
+				"CustomKeywordField": sadefs.MustEncodeValue("foo", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
+			},
+		},
+	}
+
+	response, err := env.FrontendClient().StartWorkflowExecution(ctx, request)
+	s.NoError(err)
+
+	workflowExecution := &commonpb.WorkflowExecution{
+		WorkflowId: workflowID,
+		RunId:      response.RunId,
+	}
+
+	// Wait for workflow to start and reach the blocking point
+	s.WaitForHistoryEvents(`
+		1 WorkflowExecutionStarted
+		2 WorkflowTaskScheduled
+		3 WorkflowTaskStarted
+		4 WorkflowTaskCompleted`,
+		env.GetHistoryFunc(env.Namespace().String(), workflowExecution),
+		5*time.Second,
+		10*time.Millisecond)
+
+	descResp, err := env.FrontendClient().DescribeWorkflowExecution(
+		ctx,
+		&workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
+			Execution: workflowExecution,
+		},
+	)
+	s.NoError(err)
+	csa := descResp.GetWorkflowExecutionInfo().GetSearchAttributes()
+	s.Contains(csa.IndexedFields, "CustomKeywordField")
+	val, err := sadefs.DecodeValue(
+		csa.IndexedFields["CustomKeywordField"],
+		enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		false,
+	)
+	s.NoError(err)
+	s.EqualValues("foo", val)
+
+	// Enable CHASM Visibility mid-workflow
+	env.OverrideDynamicConfig(dynamicconfig.EnableCHASMVisibilityRatio, 0.9999)
+
+	// Unblock the workflow by sending the continue signal
+	_, err = env.FrontendClient().SignalWorkflowExecution(
+		ctx,
+		&workflowservice.SignalWorkflowExecutionRequest{
+			Namespace:         env.Namespace().String(),
+			WorkflowExecution: workflowExecution,
+			SignalName:        "continue",
+		},
+	)
+	s.NoError(err)
+
+	// Wait for workflow to complete
+	run := sdkClient.GetWorkflow(ctx, workflowID, "")
+	var result int
+	s.NoError(run.Get(ctx, &result))
+	s.Equal(1, result)
+
+	descResp, err = env.FrontendClient().DescribeWorkflowExecution(
+		ctx,
+		&workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
+			Execution: workflowExecution,
+		},
+	)
+	s.NoError(err)
+	csa = descResp.GetWorkflowExecutionInfo().GetSearchAttributes()
+	s.Contains(csa.IndexedFields, "CustomKeywordField")
+	val, err = sadefs.DecodeValue(
+		csa.IndexedFields["CustomKeywordField"],
+		enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		false,
+	)
+	s.NoError(err)
+	s.EqualValues("bar", val)
+
+}
+
+// TODO (rodrigozhou): This test can be removed once CHASM Visibility are the default
+func (s *WorkflowVisibilityMigrationSuite) TestWorkflowVisibility_CHASM_Disabled_Mid_WF() {
+	// This test verifies that when CHASM Visibility is disabled mid-workflow
+	// visibility still work correctly.
+	// 1. Start a workflow with CHASM Visibility enabled
+	// 2. Workflow blocks waiting for a signal
+	// 3. Disable CHASM Visibility dynamically
+	// 4. Send signal to unblock workflow, upsert custom search attribute, and let it complete
+	// 5. Verify custom search attributes is correct
+
+	env := s.newTestEnv()
+
+	// Enable CHASM for this test (set value just below 1 to ensure Visibility
+	// data is still store in mutable state execution info). It's been manually
+	// verified that this test starts a workflow with CHASM Visibility enabled.
+	// If the test name is modified, a new verification might be needed.
+	env.OverrideDynamicConfig(dynamicconfig.EnableCHASMVisibilityRatio, 0.9999)
+
+	ctx := s.Context()
+	sdkClient := env.SdkClient()
+
+	customKeywordField := temporal.NewSearchAttributeKeyKeyword("CustomKeywordField")
+
+	workflowType := "blockingWorkflow"
+	workflowID := env.Tv().WorkflowID()
+
+	// Register workflow that blocks until it receives a signal
+	blockingWorkflow := func(ctx workflow.Context) (int, error) {
+		workflow.GetSignalChannel(ctx, "continue").Receive(ctx, nil)
+		if err := workflow.UpsertTypedSearchAttributes(
+			ctx,
+			customKeywordField.ValueSet("bar"),
+		); err != nil {
+			return 0, err
+		}
+		return 1, nil
+	}
+	env.SdkWorker().RegisterWorkflowWithOptions(blockingWorkflow, workflow.RegisterOptions{Name: workflowType})
+
+	request := &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:          uuid.NewString(),
+		Namespace:          env.Namespace().String(),
+		WorkflowId:         workflowID,
+		WorkflowType:       &commonpb.WorkflowType{Name: workflowType},
+		TaskQueue:          &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		Input:              nil,
+		WorkflowRunTimeout: durationpb.New(30 * time.Second),
+		Identity:           s.T().Name(),
+		SearchAttributes: &commonpb.SearchAttributes{
+			IndexedFields: map[string]*commonpb.Payload{
+				"CustomKeywordField": sadefs.MustEncodeValue("foo", enumspb.INDEXED_VALUE_TYPE_KEYWORD),
+			},
+		},
+	}
+
+	response, err := env.FrontendClient().StartWorkflowExecution(ctx, request)
+	s.NoError(err)
+
+	workflowExecution := &commonpb.WorkflowExecution{
+		WorkflowId: workflowID,
+		RunId:      response.RunId,
+	}
+
+	// Wait for workflow to start and reach the blocking point
+	s.WaitForHistoryEvents(`
+		1 WorkflowExecutionStarted
+		2 WorkflowTaskScheduled
+		3 WorkflowTaskStarted
+		4 WorkflowTaskCompleted`,
+		env.GetHistoryFunc(env.Namespace().String(), workflowExecution),
+		5*time.Second,
+		10*time.Millisecond)
+
+	descResp, err := env.FrontendClient().DescribeWorkflowExecution(
+		ctx,
+		&workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
+			Execution: workflowExecution,
+		},
+	)
+	s.NoError(err)
+	csa := descResp.GetWorkflowExecutionInfo().GetSearchAttributes()
+	s.Contains(csa.IndexedFields, "CustomKeywordField")
+	val, err := sadefs.DecodeValue(
+		csa.IndexedFields["CustomKeywordField"],
+		enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		false,
+	)
+	s.NoError(err)
+	s.EqualValues("foo", val)
+
+	// Disable CHASM Visibility mid-workflow
+	env.OverrideDynamicConfig(dynamicconfig.EnableCHASMVisibilityRatio, 0.0)
+
+	// Unblock the workflow by sending the continue signal
+	_, err = env.FrontendClient().SignalWorkflowExecution(
+		ctx,
+		&workflowservice.SignalWorkflowExecutionRequest{
+			Namespace:         env.Namespace().String(),
+			WorkflowExecution: workflowExecution,
+			SignalName:        "continue",
+		},
+	)
+	s.NoError(err)
+
+	// Wait for workflow to complete
+	run := sdkClient.GetWorkflow(ctx, workflowID, "")
+	var result int
+	s.NoError(run.Get(ctx, &result))
+	s.Equal(1, result)
+
+	descResp, err = env.FrontendClient().DescribeWorkflowExecution(
+		ctx,
+		&workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
+			Execution: workflowExecution,
+		},
+	)
+	s.NoError(err)
+	csa = descResp.GetWorkflowExecutionInfo().GetSearchAttributes()
+	s.Contains(csa.IndexedFields, "CustomKeywordField")
+	val, err = sadefs.DecodeValue(
+		csa.IndexedFields["CustomKeywordField"],
+		enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		false,
+	)
+	s.NoError(err)
+	s.EqualValues("bar", val)
+
+}


### PR DESCRIPTION
## What changed?
Introduce CHASM Visibility for workflows.
- Dynamic config `history.enableChasmVisibilityRatio` float value between `[0, 1]`: partially enables CHASM Visibility for new workflows.
- When `0 < ratio < 1`, custom search attributes and memo is duplicated in mutable state and CHASM Visibility. CHASM Visibility task is generated instead of the `Start/Upsert/Close` Visibility tasks. CHASM Visibility becomes the source of truth for custom search attributes and memo (eg: for `Describe` API`).
- When `ratio = 1`, custom search attributes and memo are no longer stored in mutable state.

## Why?
CHASM Visibility to store custom search attributes and memo replacing the storage in mutable state.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

