### PR TITLE
Remove redundant default-worker activity registration

### DIFF
--- a/service/worker/worker.go
+++ b/service/worker/worker.go
@@ -79,9 +79,6 @@ func (wm *workerManager) Start() {
 			// use default worker
 			wc.RegisterActivities(defaultWorker)
 		} else {
-			// TODO: This is to prevent issues during upgrade/downgrade. Remove in 1.24 release.
-			wc.RegisterActivities(defaultWorker)
-
 			// this worker component requires a dedicated worker for activities
 			activityWorkerOptions.Options.DisableWorkflowWorker = true
 			activityWorkerOptions.Options.Identity = "temporal-system@" + wm.hostInfo.Identity()


### PR DESCRIPTION
Upgrade-compat shim from #5017, marked for removal in 1.24. Now on 1.30.

## What changed?
Removed a redundant `wc.RegisterActivities(defaultWorker)` call and its stale TODO in the dedicated-activity-worker branch of `workerManager.Start()`.

## Why?
The double-registration was an upgrade/downgrade compatibility measure added in #5017 (Oct 2023) and explicitly marked for removal in the 1.24 release. The current release line is 1.30, so the mixed-version window it protected has long since closed. Components that request a dedicated activity worker already register their activities on that dedicated worker, so the additional registration on the default worker is redundant.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
During a rolling upgrade from a pre-1.24 server, an old host could still enqueue a dedicated-worker component's activity tasks on the default task queue. The 1.24 → 1.30 gap is well beyond the supported upgrade-skew window, so supported upgrade paths are unaffected.