### PR TITLE
Remove childInfo.NamespaceId backfill code

### DIFF
--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -1822,25 +1822,9 @@ func (t *transferQueueActiveTaskExecutor) processParentClosePolicy(
 				continue
 			}
 
-			childNamespaceID := namespace.ID(childInfo.GetNamespaceId())
-			if childNamespaceID.IsEmpty() {
-				// TODO (alex): Remove after childInfo.NamespaceId is back filled. Backward compatibility: old childInfo doesn't have NamespaceId set.
-				// TODO (alex): consider reverse lookup of namespace name from ID but namespace name is not actually used.
-				var err error
-				childNamespaceID, err = t.registry.GetNamespaceID(namespace.Name(childInfo.GetNamespace()))
-				switch err.(type) {
-				case nil:
-				case *serviceerror.NamespaceNotFound:
-					// If child namespace is deleted there is nothing to close.
-					continue
-				default:
-					return err
-				}
-			}
-
 			executions = append(executions, parentclosepolicy.RequestDetail{
 				Namespace:   childInfo.Namespace,
-				NamespaceID: childNamespaceID.String(),
+				NamespaceID: childInfo.GetNamespaceId(),
 				WorkflowID:  childInfo.StartedWorkflowId,
 				RunID:       childInfo.StartedRunId,
 				Policy:      childInfo.ParentClosePolicy,
@@ -1886,18 +1870,8 @@ func (t *transferQueueActiveTaskExecutor) applyParentClosePolicy(
 		return nil
 
 	case enumspb.PARENT_CLOSE_POLICY_TERMINATE:
-		childNamespaceID := namespace.ID(childInfo.GetNamespaceId())
-		if childNamespaceID.IsEmpty() {
-			// TODO (alex): Remove after childInfo.NamespaceId is back filled. Backward compatibility: old childInfo doesn't have NamespaceId set.
-			// TODO (alex): consider reverse lookup of namespace name from ID but namespace name is not actually used.
-			var err error
-			childNamespaceID, err = t.registry.GetNamespaceID(namespace.Name(childInfo.GetNamespace()))
-			if err != nil {
-				return err
-			}
-		}
 		_, err := t.historyRawClient.TerminateWorkflowExecution(ctx, &historyservice.TerminateWorkflowExecutionRequest{
-			NamespaceId: childNamespaceID.String(),
+			NamespaceId: childInfo.GetNamespaceId(),
 			TerminateRequest: &workflowservice.TerminateWorkflowExecutionRequest{
 				Namespace: childInfo.GetNamespace(),
 				WorkflowExecution: &commonpb.WorkflowExecution{
@@ -1915,19 +1889,8 @@ func (t *transferQueueActiveTaskExecutor) applyParentClosePolicy(
 		return err
 
 	case enumspb.PARENT_CLOSE_POLICY_REQUEST_CANCEL:
-		childNamespaceID := namespace.ID(childInfo.GetNamespaceId())
-		if childNamespaceID.IsEmpty() {
-			// TODO (alex): Remove after childInfo.NamespaceId is back filled. Backward compatibility: old childInfo doesn't have NamespaceId set.
-			// TODO (alex): consider reverse lookup of namespace name from ID but namespace name is not actually used.
-			var err error
-			childNamespaceID, err = t.registry.GetNamespaceID(namespace.Name(childInfo.GetNamespace()))
-			if err != nil {
-				return err
-			}
-		}
-
 		_, err := t.historyRawClient.RequestCancelWorkflowExecution(ctx, &historyservice.RequestCancelWorkflowExecutionRequest{
-			NamespaceId: childNamespaceID.String(),
+			NamespaceId: childInfo.GetNamespaceId(),
 			CancelRequest: &workflowservice.RequestCancelWorkflowExecutionRequest{
 				Namespace: childInfo.GetNamespace(),
 				WorkflowExecution: &commonpb.WorkflowExecution{

--- a/service/history/transfer_queue_active_task_executor_test.go
+++ b/service/history/transfer_queue_active_task_executor_test.go
@@ -961,10 +961,6 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 	workflowType := "some random workflow type"
 	taskQueueName := "some random task queue"
 
-	s.mockNamespaceCache.EXPECT().GetNamespace(namespace.Name("child namespace1")).Return(tests.GlobalNamespaceEntry, nil).AnyTimes()
-	s.mockNamespaceCache.EXPECT().GetNamespace(namespace.Name("child namespace2")).Return(tests.GlobalNamespaceEntry, nil).AnyTimes()
-	s.mockNamespaceCache.EXPECT().GetNamespace(namespace.Name("child namespace3")).Return(tests.GlobalNamespaceEntry, nil).AnyTimes()
-
 	mutableState := workflow.TestGlobalMutableState(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetWorkflowId(), execution.GetRunId())
 	_, err := mutableState.AddWorkflowExecutionStartedEvent(
 		execution,
@@ -1389,8 +1385,6 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 	}
 	workflowType := "some random workflow type"
 	taskQueueName := "some random task queue"
-
-	s.mockNamespaceCache.EXPECT().GetNamespace(namespace.Name("child namespace1")).Return(tests.GlobalNamespaceEntry, nil).AnyTimes()
 
 	mutableState := workflow.TestGlobalMutableState(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetWorkflowId(), execution.GetRunId())
 	_, err := mutableState.AddWorkflowExecutionStartedEvent(


### PR DESCRIPTION
### What changed?
Remove backward compatibility fallback for `childInfo.NamespaceId` in parent close policy processing.

### Why?
TODOs (by @alexshtin) have been in the codebase for 3+ years. The team has a pattern of removing backward compatibility code after shorter periods (e.g., PR #3330 and #3329 in Sep 2022 removed deprecated namespace fields just months after `namespace_id` was introduced).

### How did you test it?
Existing tests.

### Potential risks
No risks.

### Is hotfix candidate?
No.
