### PR TITLE
Adds Link_NexusOperation to link validation 

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -6432,6 +6432,16 @@ func (wh *WorkflowHandler) validateLinks(
 			if t.BatchJob.GetJobId() == "" {
 				return serviceerror.NewInvalidArgument("batch job link must not have an empty job ID")
 			}
+		case *commonpb.Link_NexusOperation_:
+			if t.NexusOperation.GetNamespace() == "" {
+				return serviceerror.NewInvalidArgument("nexus operation link must not have an empty namespace field")
+			}
+			if t.NexusOperation.GetOperationId() == "" {
+				return serviceerror.NewInvalidArgument("nexus operation link must not have an empty operation ID field")
+			}
+			if t.NexusOperation.GetRunId() == "" {
+				return serviceerror.NewInvalidArgument("nexus operation link must not have an empty run ID field")
+			}
 		default:
 			return serviceerror.NewInvalidArgument("unsupported link variant")
 		}

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -833,6 +833,47 @@ func (s *WorkflowHandlerSuite) TestStartWorkflowExecution_Failed_InvalidLinks() 
 	_, err = wh.StartWorkflowExecution(context.Background(), req)
 	s.ErrorAs(err, &invalidArgument)
 	s.ErrorContains(err, "batch job link must not have an empty job ID")
+
+	req.Links = []*commonpb.Link{
+		{
+			Variant: &commonpb.Link_NexusOperation_{
+				NexusOperation: &commonpb.Link_NexusOperation{},
+			},
+		},
+	}
+
+	_, err = wh.StartWorkflowExecution(context.Background(), req)
+	s.ErrorAs(err, &invalidArgument)
+	s.ErrorContains(err, "nexus operation link must not have an empty namespace field")
+
+	req.Links = []*commonpb.Link{
+		{
+			Variant: &commonpb.Link_NexusOperation_{
+				NexusOperation: &commonpb.Link_NexusOperation{
+					Namespace: "present",
+				},
+			},
+		},
+	}
+
+	_, err = wh.StartWorkflowExecution(context.Background(), req)
+	s.ErrorAs(err, &invalidArgument)
+	s.ErrorContains(err, "nexus operation link must not have an empty operation ID field")
+
+	req.Links = []*commonpb.Link{
+		{
+			Variant: &commonpb.Link_NexusOperation_{
+				NexusOperation: &commonpb.Link_NexusOperation{
+					Namespace:   "present",
+					OperationId: "present",
+				},
+			},
+		},
+	}
+
+	_, err = wh.StartWorkflowExecution(context.Background(), req)
+	s.ErrorAs(err, &invalidArgument)
+	s.ErrorContains(err, "nexus operation link must not have an empty run ID field")
 }
 
 func (s *WorkflowHandlerSuite) TestStartWorkflowExecution_Failed_InvalidCallbackLinks() {


### PR DESCRIPTION
## What changed?

Adds validation in workflow validator for NexusOperation links.

### Original PRs

https://github.com/temporalio/temporal/pull/10352

## Why is this necessary as a patch?

Without it, SDKs cannot attach a link to the workflow for the standalone nexus operation.

## What testing or retesting is appropriate for this patch after merge?

We don't need longhaul or VCR for this