### PR TITLE
TS: doesn't allow illogical tsc

### DIFF
--- a/service/history/api/updateworkflowoptions/api.go
+++ b/service/history/api/updateworkflowoptions/api.go
@@ -133,6 +133,9 @@ func Invoke(
 // retroactively violated. Validated against current MS state, before merge.
 func validateTimeSkippingConfig(cfg *workflowpb.TimeSkippingConfig, ms historyi.MutableState) error {
 	if !cfg.GetEnabled() {
+		if cfg.GetBound() != nil {
+			return serviceerror.NewInvalidArgument("time_skipping_config: cannot set bound when enabled is false")
+		}
 		return nil
 	}
 	bound, ok := cfg.GetBound().(*workflowpb.TimeSkippingConfig_MaxSkippedDuration)

--- a/service/history/api/updateworkflowoptions/api_test.go
+++ b/service/history/api/updateworkflowoptions/api_test.go
@@ -352,9 +352,13 @@ func TestValidateTimeSkippingConfig(t *testing.T) {
 			config: nil,
 		},
 		{
-			name:        "disabled short-circuits even when bound would be violated",
-			config:      &workflowpb.TimeSkippingConfig{Enabled: false, Bound: maxSkippedTen},
-			accumulated: twentyMin,
+			name:    "disabled with bound is rejected",
+			config:  &workflowpb.TimeSkippingConfig{Enabled: false, Bound: maxSkippedTen},
+			wantErr: true,
+		},
+		{
+			name:   "disabled with no bound",
+			config: &workflowpb.TimeSkippingConfig{Enabled: false},
 		},
 		{
 			name:   "enabled, no bound",
@@ -424,7 +428,7 @@ func TestMergeAndApply_TimeSkippingConfig(t *testing.T) {
 		expectedConfig *workflowpb.TimeSkippingConfig
 	}{
 		{
-			name: "update max_skipped_duration preserves enabled",
+			name: "update max_skipped_duration while enabled",
 			initialConfig: &workflowpb.TimeSkippingConfig{
 				Enabled: true,
 				Bound: &workflowpb.TimeSkippingConfig_MaxSkippedDuration{
@@ -433,6 +437,7 @@ func TestMergeAndApply_TimeSkippingConfig(t *testing.T) {
 			},
 			updateOptions: &workflowpb.WorkflowExecutionOptions{
 				TimeSkippingConfig: &workflowpb.TimeSkippingConfig{
+					Enabled: true,
 					Bound: &workflowpb.TimeSkippingConfig_MaxSkippedDuration{
 						MaxSkippedDuration: twoHours,
 					},
@@ -447,7 +452,7 @@ func TestMergeAndApply_TimeSkippingConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "change bound type to max_elapsed_duration preserves enabled",
+			name: "change bound type to max_elapsed_duration while enabled",
 			initialConfig: &workflowpb.TimeSkippingConfig{
 				Enabled: true,
 				Bound: &workflowpb.TimeSkippingConfig_MaxSkippedDuration{
@@ -456,6 +461,7 @@ func TestMergeAndApply_TimeSkippingConfig(t *testing.T) {
 			},
 			updateOptions: &workflowpb.WorkflowExecutionOptions{
 				TimeSkippingConfig: &workflowpb.TimeSkippingConfig{
+					Enabled: true,
 					Bound: &workflowpb.TimeSkippingConfig_MaxElapsedDuration{
 						MaxElapsedDuration: thirtyMin,
 					},


### PR DESCRIPTION
## What changed?
return argument error when users set illogical time skipping config

## Why?
this error can guide users to use this feature correctly than setting illogical config silently

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

