### PR TITLE
Add reset by build ID versioning test

### DIFF
--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	batchpb "go.temporal.io/api/batch/v1"
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	deploymentpb "go.temporal.io/api/deployment/v1"
@@ -5909,6 +5910,146 @@ func (s *Versioning3Suite) TestPinnedCaN_NoAUOnCaN_NoInfiniteLoop() {
 		})
 
 	s.verifyWorkflowVersioning(env, tv1, vbPinned, tv1.Deployment(), nil, nil)
+}
+
+// Scenario: a pinned v1 workflow auto-upgrades to v2 via Continue-As-New, v1 is
+// made current again, then reset-by-build-ID resets the workflow before v2 usage
+// so the reset run resumes on v1.
+func (s *Versioning3Suite) TestPinnedCaN_ResetByBuildIDAfterRollback() {
+	env := s.setupEnv(testcore.WithWorkerService("batch operations"))
+
+	tv1 := env.Tv().WithBuildIDNumber(1)
+	tv2 := tv1.WithBuildIDNumber(2)
+
+	revision := int64(1)
+	setCurrentVersion := func(current *testvars.TestVars, draining ...*testvars.TestVars) {
+		versions := map[string]*deploymentspb.WorkerDeploymentVersionData{
+			current.DeploymentVersion().GetBuildId(): {
+				Status: enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT,
+			},
+		}
+		for _, version := range draining {
+			versions[version.DeploymentVersion().GetBuildId()] = &deploymentspb.WorkerDeploymentVersionData{
+				Status: enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINING,
+			}
+		}
+		s.updateTaskQueueDeploymentDataWithRoutingConfig(env, current, &deploymentpb.RoutingConfig{
+			CurrentDeploymentVersion:  worker_versioning.ExternalWorkerDeploymentVersionFromStringV31(current.DeploymentVersionString()),
+			CurrentVersionChangedTime: timestamp.TimePtr(time.Now()),
+			RevisionNumber:            revision,
+		}, versions, []string{}, tqTypeWf)
+		revision++
+	}
+
+	setCurrentVersion(tv1)
+
+	runID := s.startWorkflow(env, tv1, nil)
+	execution := tv1.WithRunID(runID).WorkflowExecution()
+	s.pollWftAndHandle(env, tv1, false, nil,
+		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+			s.NotNil(task)
+			return respondEmptyWft(tv1, false, vbPinned), nil
+		})
+	s.verifyWorkflowVersioning(env, tv1, vbPinned, tv1.Deployment(), nil, nil)
+
+	setCurrentVersion(tv2, tv1)
+
+	s.triggerNormalWFT(env, tv1, execution)
+	s.pollWftAndHandle(env, tv1, false, nil,
+		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+			s.NotNil(task)
+			return &workflowservice.RespondWorkflowTaskCompletedRequest{
+				Commands: []*commandpb.Command{
+					{
+						CommandType: enumspb.COMMAND_TYPE_CONTINUE_AS_NEW_WORKFLOW_EXECUTION,
+						Attributes: &commandpb.Command_ContinueAsNewWorkflowExecutionCommandAttributes{
+							ContinueAsNewWorkflowExecutionCommandAttributes: &commandpb.ContinueAsNewWorkflowExecutionCommandAttributes{
+								WorkflowType:              tv1.WorkflowType(),
+								TaskQueue:                 tv1.TaskQueue(),
+								Input:                     tv1.Any().Payloads(),
+								InitialVersioningBehavior: enumspb.CONTINUE_AS_NEW_VERSIONING_BEHAVIOR_AUTO_UPGRADE,
+							},
+						},
+					},
+				},
+				VersioningBehavior: vbPinned,
+				DeploymentOptions:  tv1.WorkerDeploymentOptions(true),
+			}, nil
+		})
+
+	var canRunID string
+	s.pollWftAndHandle(env, tv2, false, nil,
+		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+			s.NotNil(task)
+			canRunID = task.WorkflowExecution.GetRunId()
+			s.NotEqual(runID, canRunID)
+			return respondEmptyWft(tv2, false, vbPinned), nil
+		})
+	s.verifyWorkflowVersioning(env, tv2, vbPinned, tv2.Deployment(), nil, nil)
+
+	query := fmt.Sprintf(
+		"WorkflowId = '%s' AND ExecutionStatus = 'Running' AND TemporalUsedWorkerDeploymentVersions = '%s'",
+		tv1.WorkflowID(),
+		tv2.DeploymentVersionStringV32(),
+	)
+	s.Await(func(s *Versioning3Suite) {
+		resp, err := env.FrontendClient().ListWorkflowExecutions(s.Context(), &workflowservice.ListWorkflowExecutionsRequest{
+			Namespace: env.Namespace().String(),
+			Query:     query,
+		})
+		s.NoError(err)
+		s.Len(resp.GetExecutions(), 1)
+	}, 10*time.Second, 200*time.Millisecond)
+
+	setCurrentVersion(tv1, tv2)
+
+	jobID := tv1.Any().String()
+	_, err := env.FrontendClient().StartBatchOperation(s.Context(), &workflowservice.StartBatchOperationRequest{
+		Namespace:       env.Namespace().String(),
+		VisibilityQuery: query,
+		JobId:           jobID,
+		Reason:          "reset by build ID after rollback",
+		Operation: &workflowservice.StartBatchOperationRequest_ResetOperation{
+			ResetOperation: &batchpb.BatchOperationReset{
+				Options: &commonpb.ResetOptions{
+					Target: &commonpb.ResetOptions_BuildId{
+						BuildId: tv2.BuildID(),
+					},
+				},
+			},
+		},
+	})
+	s.NoError(err)
+
+	s.Await(func(s *Versioning3Suite) {
+		resp, err := env.FrontendClient().DescribeBatchOperation(s.Context(), &workflowservice.DescribeBatchOperationRequest{
+			Namespace: env.Namespace().String(),
+			JobId:     jobID,
+		})
+		s.NoError(err)
+		s.Equal(enumspb.BATCH_OPERATION_STATE_COMPLETED, resp.GetState())
+	}, 20*time.Second, 500*time.Millisecond)
+
+	var resetRunID string
+	s.pollWftAndHandle(env, tv1, false, nil,
+		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+			s.NotNil(task)
+			resetRunID = task.WorkflowExecution.GetRunId()
+			s.NotEqual(runID, resetRunID)
+			s.NotEqual(canRunID, resetRunID)
+			return respondCompleteWorkflow(tv1, vbPinned), nil
+		})
+
+	s.verifyWorkflowVersioning(env, tv1, vbPinned, tv1.Deployment(), nil, nil)
+	desc, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{
+			WorkflowId: tv1.WorkflowID(),
+			RunId:      canRunID,
+		},
+	})
+	s.NoError(err)
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED, desc.GetWorkflowExecutionInfo().GetStatus())
 }
 
 // TestOverride_SuppressesTargetVersionChangedSignal tests that a versioning override


### PR DESCRIPTION
## What changed
- Added a Versioning3 functional test covering reset-by-build-ID after a pinned workflow auto-upgrades via Continue-As-New.
- The test verifies rollback to v1, batch reset targeting the v2 build ID, and resumed execution on v1.

## How tested
- `go test -tags test_dep ./tests -run 'TestVersioning3FunctionalSuite/TestPinnedCaN_ResetByBuildIDAfterRollback' -count=1`\n- `make lint-code`