### PR TITLE
Include workflow ID in busy workflow errors

### DIFF
--- a/service/history/consts/const.go
+++ b/service/history/consts/const.go
@@ -145,6 +145,25 @@ var (
 	}
 )
 
+type busyWorkflowWithWorkflowIDError struct {
+	workflowID string
+}
+
+func NewResourceExhaustedBusyWorkflow(workflowID string) error {
+	if workflowID == "" {
+		return ErrResourceExhaustedBusyWorkflow
+	}
+	return &busyWorkflowWithWorkflowIDError{workflowID: workflowID}
+}
+
+func (e *busyWorkflowWithWorkflowIDError) Error() string {
+	return fmt.Sprintf("Workflow is busy. WorkflowId: %s.", e.workflowID)
+}
+
+func (e *busyWorkflowWithWorkflowIDError) Unwrap() error {
+	return ErrResourceExhaustedBusyWorkflow
+}
+
 // StaleStateError is an indicator that after loading the state for a task it was detected as stale. It's possible that
 // state reload solves this issue but otherwise it is unexpected and considered terminal.
 type staleStateError struct {

--- a/service/history/consts/const_test.go
+++ b/service/history/consts/const_test.go
@@ -1,0 +1,34 @@
+package consts
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	"google.golang.org/grpc/codes"
+)
+
+func TestNewResourceExhaustedBusyWorkflowWithWorkflowID(t *testing.T) {
+	err := NewResourceExhaustedBusyWorkflow("test-workflow-id")
+
+	require.ErrorIs(t, err, ErrResourceExhaustedBusyWorkflow)
+	require.Equal(t, "Workflow is busy. WorkflowId: test-workflow-id.", err.Error())
+
+	st := serviceerror.ToStatus(err)
+	require.Equal(t, codes.ResourceExhausted, st.Code())
+	require.Equal(t, "Workflow is busy. WorkflowId: test-workflow-id.", st.Message())
+
+	roundTrippedErr := serviceerror.FromStatus(st)
+	var resourceExhaustedErr *serviceerror.ResourceExhausted
+	require.ErrorAs(t, roundTrippedErr, &resourceExhaustedErr)
+	require.Equal(t, enumspb.RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW, resourceExhaustedErr.Cause)
+	require.Equal(t, enumspb.RESOURCE_EXHAUSTED_SCOPE_NAMESPACE, resourceExhaustedErr.Scope)
+}
+
+func TestNewResourceExhaustedBusyWorkflowWithoutWorkflowID(t *testing.T) {
+	err := NewResourceExhaustedBusyWorkflow("")
+
+	require.Same(t, ErrResourceExhaustedBusyWorkflow, err)
+	require.Equal(t, "Workflow is busy.", err.Error())
+}

--- a/service/history/statemachine_environment.go
+++ b/service/history/statemachine_environment.go
@@ -95,7 +95,7 @@ func getWorkflowExecutionContext(
 	)
 	if common.IsContextDeadlineExceededErr(err) {
 		// TODO: make sure this doesn't count against our SLA if this happens while handling an API request.
-		err = consts.ErrResourceExhaustedBusyWorkflow
+		err = consts.NewResourceExhaustedBusyWorkflow(key.WorkflowID)
 	}
 	return weContext, release, err
 }

--- a/service/history/workflow/cache/cache.go
+++ b/service/history/workflow/cache/cache.go
@@ -342,7 +342,7 @@ func (c *cacheImpl) lockWorkflowExecution(
 	if err := workflowCtx.Lock(ctx, lockPriority); err != nil {
 		// ctx is done before lock can be acquired
 		c.Release(cacheKey)
-		return consts.ErrResourceExhaustedBusyWorkflow
+		return consts.NewResourceExhaustedBusyWorkflow(cacheKey.WorkflowKey.WorkflowID)
 	}
 	return nil
 }

--- a/service/history/workflow/cache/cache_test.go
+++ b/service/history/workflow/cache/cache_test.go
@@ -26,6 +26,7 @@ import (
 	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/service/history/consts"
 	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tests"
@@ -343,6 +344,42 @@ func (s *workflowCacheSuite) TestHistoryCacheConcurrentAccess_Release() {
 	// all we need is a fake MutableState
 	s.Nil(ctx.(*workflow.ContextImpl).MutableState)
 	release(nil)
+}
+
+func (s *workflowCacheSuite) TestHistoryCacheLockTimeoutIncludesWorkflowID() {
+	s.cache = NewHostLevelCache(s.mockShard.GetConfig(), s.mockShard.GetLogger(), metrics.NoopMetricsHandler)
+
+	namespaceID := namespace.ID("test_namespace_id")
+	execution := commonpb.WorkflowExecution{
+		WorkflowId: "busy-workflow-id",
+		RunId:      uuid.NewString(),
+	}
+
+	_, release, err := s.cache.GetOrCreateWorkflowExecution(
+		context.Background(),
+		s.mockShard,
+		namespaceID,
+		&execution,
+		locks.PriorityHigh,
+	)
+	s.NoError(err)
+	defer release(nil)
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ctx, release2, err := s.cache.GetOrCreateWorkflowExecution(
+		cancelledCtx,
+		s.mockShard,
+		namespaceID,
+		&execution,
+		locks.PriorityHigh,
+	)
+	s.Nil(ctx)
+	s.Nil(release2)
+	s.ErrorIs(err, consts.ErrResourceExhaustedBusyWorkflow)
+	s.Equal("Workflow is busy. WorkflowId: busy-workflow-id.", err.Error())
+	s.Equal("Workflow is busy. WorkflowId: busy-workflow-id.", serviceerror.ToStatus(err).Message())
 }
 
 /*


### PR DESCRIPTION
## What changed

- Added a workflow-ID-aware BusyWorkflow error wrapper that preserves the existing `ErrResourceExhaustedBusyWorkflow` sentinel via `errors.Is`.
- Returned that wrapper from workflow cache lock timeout paths when the workflow ID is known.
- Added tests covering the gRPC status message, ResourceExhausted cause/scope preservation, and the cache lock timeout return path.

## Why

Generic BusyWorkflow responses currently return `Workflow is busy.` with no workflow identity. That makes the `grpc_message` useful for finding BusyWorkflow responses, but not for identifying the specific workflow execution. This keeps the existing BusyWorkflow cause/scope semantics while returning messages like:

```text
Workflow is busy. WorkflowId: <workflow-id>.
```

## Validation

- `go test ./service/history/consts ./service/history/workflow/cache ./service/history/queues`
- `go test ./service/history -run TestDoesNotExist`
- `git diff --check`
