### PR TITLE
[Scheduler] Plumb Tweakables through Scheduler's CHASM context values, use in EventLog

### DIFF
--- a/chasm/lib/scheduler/config.go
+++ b/chasm/lib/scheduler/config.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"time"
 
+	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/dynamicconfig"
 )
@@ -27,6 +28,30 @@ type (
 		RetryPolicy        func() backoff.RetryPolicy
 	}
 )
+
+// tweakablesCtxKey keys the namespace-filtered Tweakables accessor that scheduler
+// components read via the CHASM context (registered in Library.Components).
+type tweakablesCtxKeyType struct{}
+
+var tweakablesCtxKey = tweakablesCtxKeyType{}
+
+// tweakablesFromContext returns the scheduler Tweakables for the context's namespace,
+// falling back to DefaultTweakables when no config is registered.
+func tweakablesFromContext(ctx chasm.Context) Tweakables {
+	if fn, ok := ctx.Value(tweakablesCtxKey).(dynamicconfig.TypedPropertyFnWithNamespaceFilter[Tweakables]); ok && fn != nil {
+		return fn(ctx.NamespaceEntry().Name().String())
+	}
+	return DefaultTweakables
+}
+
+// contextValues builds the CHASM context values exposed to scheduler components.
+func (c *Config) contextValues() map[any]any {
+	var tweakables dynamicconfig.TypedPropertyFnWithNamespaceFilter[Tweakables]
+	if c != nil {
+		tweakables = c.Tweakables
+	}
+	return map[any]any{tweakablesCtxKey: tweakables}
+}
 
 var (
 	CurrentTweakables = dynamicconfig.NewNamespaceTypedSetting(

--- a/chasm/lib/scheduler/eventlog.go
+++ b/chasm/lib/scheduler/eventlog.go
@@ -30,10 +30,13 @@ func (e *EventLog) LifecycleState(ctx chasm.Context) chasm.LifecycleState {
 	return chasm.LifecycleStateRunning
 }
 
-// LogEvent appends an event with the given message. Messages longer than
-// maxMessageLen bytes are truncated at a UTF-8 rune boundary; once the log
-// has more than maxEntries entries, the earliest entries are dropped.
-func (e *EventLog) LogEvent(ctx chasm.MutableContext, msg string, maxEntries, maxMessageLen int) {
+// LogEvent appends an event with the given message. Messages longer than the
+// configured maximum length are truncated at a UTF-8 rune boundary; once the
+// log exceeds the configured maximum entries, the earliest entries are dropped.
+func (e *EventLog) LogEvent(ctx chasm.MutableContext, msg string) {
+	tw := tweakablesFromContext(ctx)
+	maxEntries, maxMessageLen := tw.EventLogMaxEntries, tw.EventLogMaxMessageLen
+
 	if len(msg) > maxMessageLen {
 		// Back off to the nearest UTF-8 rune boundary so we don't split a
 		// multibyte rune.

--- a/chasm/lib/scheduler/eventlog_test.go
+++ b/chasm/lib/scheduler/eventlog_test.go
@@ -9,12 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 	enumspb "go.temporal.io/api/enums/v1"
 	schedulepb "go.temporal.io/api/schedule/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/scheduler"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const (
-	testEventLogMaxEntries    = 30
-	testEventLogMaxMessageLen = 1000
+var (
+	testEventLogMaxEntries    = scheduler.DefaultTweakables.EventLogMaxEntries
+	testEventLogMaxMessageLen = scheduler.DefaultTweakables.EventLogMaxMessageLen
 )
 
 func TestEventLog_Accumulates(t *testing.T) {
@@ -24,7 +26,7 @@ func TestEventLog_Accumulates(t *testing.T) {
 
 	messages := []string{"first", "second", "third"}
 	for _, m := range messages {
-		eventLog.LogEvent(ctx, m, testEventLogMaxEntries, testEventLogMaxMessageLen)
+		eventLog.LogEvent(ctx, m)
 	}
 
 	require.Len(t, eventLog.Events, len(messages))
@@ -40,7 +42,7 @@ func TestEventLog_TruncatesLongMessages(t *testing.T) {
 	eventLog.Events = nil
 
 	long := strings.Repeat("x", testEventLogMaxMessageLen+50)
-	eventLog.LogEvent(ctx, long, testEventLogMaxEntries, testEventLogMaxMessageLen)
+	eventLog.LogEvent(ctx, long)
 
 	require.Len(t, eventLog.Events, 1)
 	require.Len(t, eventLog.Events[0].Message, testEventLogMaxMessageLen)
@@ -55,7 +57,7 @@ func TestEventLog_DropsEarliestWhenFull(t *testing.T) {
 	const overflow = 5
 	total := testEventLogMaxEntries + overflow
 	for i := range total {
-		eventLog.LogEvent(ctx, fmt.Sprintf("event-%d", i), testEventLogMaxEntries, testEventLogMaxMessageLen)
+		eventLog.LogEvent(ctx, fmt.Sprintf("event-%d", i))
 	}
 
 	require.Len(t, eventLog.Events, testEventLogMaxEntries)
@@ -63,6 +65,24 @@ func TestEventLog_DropsEarliestWhenFull(t *testing.T) {
 	// window starts at event-`overflow` and ends at the most recent event.
 	require.Equal(t, fmt.Sprintf("event-%d", overflow), eventLog.Events[0].Message)
 	require.Equal(t, fmt.Sprintf("event-%d", total-1), eventLog.Events[len(eventLog.Events)-1].Message)
+}
+
+// TestEventLog_NoConfigFallsBackToDefaults checks that LogEvent applies the
+// default retention limits instead of panicking when no config is reachable via
+// the context, as in tdbg's registration-only setup.
+func TestEventLog_NoConfigFallsBackToDefaults(t *testing.T) {
+	ctx := &chasm.MockMutableContext{}
+	eventLog := scheduler.NewEventLog(ctx)
+
+	require.NotPanics(t, func() {
+		eventLog.LogEvent(ctx, "logged without a registered config")
+	})
+	require.Len(t, eventLog.Events, 1)
+
+	long := strings.Repeat("x", scheduler.DefaultTweakables.EventLogMaxMessageLen+50)
+	eventLog.LogEvent(ctx, long)
+	require.Len(t, eventLog.Events, 2)
+	require.Len(t, eventLog.Events[1].Message, scheduler.DefaultTweakables.EventLogMaxMessageLen)
 }
 
 func TestEventLog_EachComponentHasOwn(t *testing.T) {
@@ -86,7 +106,7 @@ func TestEventLog_EachComponentHasOwn(t *testing.T) {
 	sched.Generator.Get(ctx).EventLog.Get(ctx).Events = nil
 	backfiller.EventLog.Get(ctx).Events = nil
 
-	sched.EventLog.Get(ctx).LogEvent(ctx, "scheduler-event", testEventLogMaxEntries, testEventLogMaxMessageLen)
+	sched.EventLog.Get(ctx).LogEvent(ctx, "scheduler-event")
 	require.Len(t, sched.EventLog.Get(ctx).Events, 1)
 	require.Empty(t, sched.Generator.Get(ctx).EventLog.Get(ctx).Events)
 	require.Empty(t, backfiller.EventLog.Get(ctx).Events)

--- a/chasm/lib/scheduler/generator_tasks.go
+++ b/chasm/lib/scheduler/generator_tasks.go
@@ -148,8 +148,7 @@ func (g *GeneratorTaskHandler) logSchedule(ctx chasm.MutableContext, logger log.
 	spec := jsonStringer{sched.Schedule.Spec}
 	policies := jsonStringer{sched.Schedule.Policies}
 
-	tw := g.config.Tweakables(sched.Namespace)
-	generator.EventLog.Get(ctx).LogEvent(ctx, fmt.Sprintf("%s:\nSpec: %s\nPolicies: %s\n", msg, spec, policies), tw.EventLogMaxEntries, tw.EventLogMaxMessageLen)
+	generator.EventLog.Get(ctx).LogEvent(ctx, fmt.Sprintf("%s:\nSpec: %s\nPolicies: %s\n", msg, spec, policies))
 	logger.Info(msg,
 		tag.Stringer("spec", spec),
 		tag.Stringer("policies", policies))

--- a/chasm/lib/scheduler/helper_test.go
+++ b/chasm/lib/scheduler/helper_test.go
@@ -88,6 +88,7 @@ func newTestLibrary(logger log.Logger, specProcessor scheduler.SpecProcessor) *s
 		SpecProcessor:  specProcessor,
 	}
 	return scheduler.NewLibrary(
+		config,
 		nil,
 		scheduler.NewSchedulerIdleTaskHandler(scheduler.SchedulerIdleTaskHandlerOptions{
 			Config: config,
@@ -209,6 +210,7 @@ func newTestEnv(t *testing.T, opts ...testEnvOption) *testEnv {
 		HandleGetCurrentVersion:   func() int64 { return 1 },
 		HandleGetWorkflowKey:      tv.Any().WorkflowKey,
 		HandleIsWorkflow:          func() bool { return false },
+		HandleGetNamespaceEntry:   tv.Namespace,
 		HandleCurrentVersionedTransition: func() *persistencespb.VersionedTransition {
 			return &persistencespb.VersionedTransition{
 				NamespaceFailoverVersion: 1,
@@ -346,6 +348,7 @@ func setupTestInfra(t *testing.T, specProcessor scheduler.SpecProcessor) *testIn
 	nodeBackend.HandleGetCurrentVersion = func() int64 { return 1 }
 	nodeBackend.HandleGetWorkflowKey = tv.Any().WorkflowKey
 	nodeBackend.HandleIsWorkflow = func() bool { return false }
+	nodeBackend.HandleGetNamespaceEntry = tv.Namespace
 	nodeBackend.HandleCurrentVersionedTransition = func() *persistencespb.VersionedTransition {
 		return &persistencespb.VersionedTransition{
 			NamespaceFailoverVersion: 1,

--- a/chasm/lib/scheduler/invoker.go
+++ b/chasm/lib/scheduler/invoker.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"fmt"
 	"slices"
 	"time"
 
@@ -49,6 +50,9 @@ func newInvokerWithState(ctx chasm.MutableContext, state *schedulerpb.InvokerSta
 // immediately kicking off a processing task.
 func (i *Invoker) EnqueueBufferedStarts(ctx chasm.MutableContext, starts []*schedulespb.BufferedStart) {
 	i.BufferedStarts = append(i.BufferedStarts, starts...)
+	if len(starts) > 0 {
+		i.EventLog.Get(ctx).LogEvent(ctx, fmt.Sprintf("enqueued %d buffered start(s)", len(starts)))
+	}
 	i.addTasks(ctx)
 }
 

--- a/chasm/lib/scheduler/library.go
+++ b/chasm/lib/scheduler/library.go
@@ -10,6 +10,7 @@ type (
 	Library struct {
 		chasm.UnimplementedLibrary
 
+		config  *Config
 		handler *handler
 
 		SchedulerIdleTaskHandler        *SchedulerIdleTaskHandler
@@ -29,6 +30,7 @@ func NewNilLibrary() *Library {
 }
 
 func NewLibrary(
+	config *Config,
 	handler *handler,
 	SchedulerIdleTaskHandler *SchedulerIdleTaskHandler,
 	SchedulerCallbacksTaskHandler *SchedulerCallbacksTaskHandler,
@@ -39,6 +41,7 @@ func NewLibrary(
 	MigrateToWorkflowTaskHandler *SchedulerMigrateToWorkflowTaskHandler,
 ) *Library {
 	return &Library{
+		config:                          config,
 		handler:                         handler,
 		SchedulerIdleTaskHandler:        SchedulerIdleTaskHandler,
 		SchedulerCallbacksTaskHandler:   SchedulerCallbacksTaskHandler,
@@ -63,6 +66,9 @@ func (l *Library) Components() []*chasm.RegistrableComponent {
 				executionStatusSearchAttribute,
 				scheduleNextActionTimeSearchAttribute,
 			),
+			// Exposes Tweakables to scheduler components via the CHASM context
+			// (see tweakablesFromContext).
+			chasm.WithContextValues(l.config.contextValues()),
 		),
 		chasm.NewRegistrableComponent[*Generator]("generator"),
 		chasm.NewRegistrableComponent[*Invoker]("invoker"),


### PR DESCRIPTION
## What changed?
- Tweakables is now available for access within any Scheduler function that has a CHASM context.
- EventLog now uses the Tweakables from CHASM context to determine dynamic config values.

## Why?
- It was looking real ugly to plumb through those numbers and that dynamic config everywhere else throughout.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

