### PR TITLE
support background entry removal for events cache

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1755,6 +1755,13 @@ This can help reduce effects of shard movement.`,
 		false,
 		`EnableHostLevelEventsCache controls if the events cache is host level. Requires service restart to take effect.`,
 	)
+	EventsCacheBackgroundEvict = NewGlobalTypedSetting(
+		"history.eventsCacheBackgroundEvict",
+		DefaultEventsCacheBackgroundEvictSettings,
+		`EventsCacheBackgroundEvict configures background processing to purge expired entries from the events cache.
+Requires service restart to take effect.`,
+	)
+
 	AcquireShardInterval = NewGlobalDurationSetting(
 		"history.acquireShardInterval",
 		time.Minute,

--- a/common/dynamicconfig/shared_constants.go
+++ b/common/dynamicconfig/shared_constants.go
@@ -118,6 +118,12 @@ var DefaultHistoryCacheBackgroundEvictSettings = CacheBackgroundEvictSettings{
 	MaxEntryPerCall: 1024,
 }
 
+var DefaultEventsCacheBackgroundEvictSettings = CacheBackgroundEvictSettings{
+	Enabled:         false,
+	LoopInterval:    1 * time.Minute,
+	MaxEntryPerCall: 1024,
+}
+
 type PartitionScaleAllowedDrift struct {
 	// Delta and Ratio controls how far off client counts can be before we reject an RPC.
 	// If the client count is within the delta, it's allowed. Also, if the ratio of

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -84,6 +84,7 @@ type Config struct {
 	// Change of these configs require service restart
 	EnableHostLevelEventsCache       dynamicconfig.BoolPropertyFn
 	EventsHostLevelCacheMaxSizeBytes dynamicconfig.IntPropertyFn
+	EventsCacheBackgroundEvict       dynamicconfig.TypedPropertyFn[dynamicconfig.CacheBackgroundEvictSettings]
 
 	// ShardController settings
 	RangeSizeBits                uint
@@ -507,6 +508,7 @@ func NewConfig(
 		EventsHostLevelCacheMaxSizeBytes:  dynamicconfig.EventsHostLevelCacheMaxSizeBytes.Get(dc), // 256MB
 		EventsCacheTTL:                    dynamicconfig.EventsCacheTTL.Get(dc),
 		EnableHostLevelEventsCache:        dynamicconfig.EnableHostLevelEventsCache.Get(dc),
+		EventsCacheBackgroundEvict:        dynamicconfig.EventsCacheBackgroundEvict.Get(dc),
 
 		RangeSizeBits: 20, // 20 bits for sequencer, 2^20 sequence number for any range
 

--- a/service/history/events/cache.go
+++ b/service/history/events/cache.go
@@ -10,6 +10,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cache"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -60,7 +61,7 @@ func NewHostLevelEventsCache(
 	logger log.Logger,
 	disabled bool,
 ) Cache {
-	return newEventsCache(executionManager, handler, logger, config.EventsHostLevelCacheMaxSizeBytes(), config.EventsCacheTTL(), disabled)
+	return newEventsCache(executionManager, handler, logger, config.EventsHostLevelCacheMaxSizeBytes(), config.EventsCacheTTL(), config.EventsCacheBackgroundEvict, disabled)
 }
 
 func NewShardLevelEventsCache(
@@ -70,7 +71,7 @@ func NewShardLevelEventsCache(
 	logger log.Logger,
 	disabled bool,
 ) Cache {
-	return newEventsCache(executionManager, handler, logger, config.EventsShardLevelCacheMaxSizeBytes(), config.EventsCacheTTL(), disabled)
+	return newEventsCache(executionManager, handler, logger, config.EventsShardLevelCacheMaxSizeBytes(), config.EventsCacheTTL(), config.EventsCacheBackgroundEvict, disabled)
 }
 
 func newEventsCache(
@@ -79,10 +80,12 @@ func newEventsCache(
 	logger log.Logger,
 	maxSize int,
 	ttl time.Duration,
+	backgroundEvict dynamicconfig.TypedPropertyFn[dynamicconfig.CacheBackgroundEvictSettings],
 	disabled bool,
 ) *CacheImpl {
 	opts := &cache.Options{}
 	opts.TTL = ttl
+	opts.BackgroundEvict = backgroundEvict
 
 	taggedMetricHandler := metricsHandler.WithTags(metrics.CacheTypeTag(metrics.EventsCacheTypeTagValue))
 	return &CacheImpl{

--- a/service/history/events/cache_test.go
+++ b/service/history/events/cache_test.go
@@ -11,6 +11,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
@@ -66,6 +67,9 @@ func (s *eventsCacheSuite) newTestEventsCache() *CacheImpl {
 		s.logger,
 		32,
 		time.Minute,
+		func() dynamicconfig.CacheBackgroundEvictSettings {
+			return dynamicconfig.DefaultEventsCacheBackgroundEvictSettings
+		},
 		false)
 }
 


### PR DESCRIPTION
## What changed?
Using what was contributed in #7902, this adds a background eviction goroutine + config for the events cache.

## Why?
I think the reason this PR (and the original) are useful is how cache size is computed. The amount of heap used by the MS/events cache reaches well beyond the bytes limit set in the config (more below), which I think is partly due to how cache size is computed against the entry's serialized size. For events its `historyEventCacheItemImpl.CacheSize()` returning `event.Size()`, which is the protobuf wire size rather than the size of the unmarshalled `*HistoryEvent` (with its nested duration/timestamp messages, maps, etc), which is presumably much larger than its serialized bytes, so the cache's upper bound is seemingly much higher than what is set in config. This lets cache that's past its TTL eat into the rest of the heap, potentially consuming most or all of it.

In our case, we were running 2500 concurrent workflows as a benchmark (e.g. as one workflow completes another is scheduled to maintain this number) with 1GB events cache limit, and after ~6 hours of monotonic heap growth the GOMEMLIMIT of 10GB was reached for all three history service pods, with the inuse_space memory profile showing nearly all of the heap consumed by events-related call stacks. `cache_usage{cache_type="events"}` counter showed only ~730MB used.  Rerunning the benchmark with the change in this PR enabled avoided the monotonic heap growth once the 1h TTL was reached, since stale entries were evicted at the rate new ones were created, and our 2500 concurrent workflow benchmark has now been running indefinitely at 5GB heap consumed and ~130MB cache usage per pod.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] updated existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

Also benchmarked the change as mentioned above.

## Potential risks
Off by default, so behavior is unchanged unless explicitly enabled, and it reuses the same background-eviction machinery already proven for the workflow cache in #7902. When enabled, the only side effect is that an evicted event is re-read from persistence if a workflow genuinely needs it again. The TTL provides the grace window for near-term reads (e.g. start/completion events read by transfer tasks shortly after close), so this should be rare. As with the workflow cache setting, it requires a service restart to take effect.

