### PR TITLE
Change VisibilityRow execution duration type to int64

### DIFF
--- a/common/persistence/sql/sqlplugin/tests/visibility.go
+++ b/common/persistence/sql/sqlplugin/tests/visibility.go
@@ -1395,9 +1395,9 @@ func (s *visibilitySuite) newRandomVisibilityRow(
 	historyLength *int64,
 ) sqlplugin.VisibilityRow {
 	s.version++
-	var executionDuration *time.Duration
+	var executionDuration *int64
 	if closeTime != nil {
-		executionDuration = new(closeTime.Sub(executionTime))
+		executionDuration = new(closeTime.Sub(executionTime).Nanoseconds())
 	}
 	return sqlplugin.VisibilityRow{
 		NamespaceID:       namespaceID.String(),

--- a/common/persistence/sql/sqlplugin/visibility.go
+++ b/common/persistence/sql/sqlplugin/visibility.go
@@ -39,7 +39,7 @@ type (
 		CloseTime            *time.Time
 		HistoryLength        *int64
 		HistorySizeBytes     *int64
-		ExecutionDuration    *time.Duration
+		ExecutionDuration    *int64
 		StateTransitionCount *int64
 		Memo                 []byte
 		Encoding             string

--- a/common/persistence/visibility/store/sql/visibility_store.go
+++ b/common/persistence/visibility/store/sql/visibility_store.go
@@ -136,7 +136,7 @@ func (s *VisibilityStore) RecordWorkflowExecutionClosed(
 	row.CloseTime = &request.CloseTime
 	row.HistoryLength = &request.HistoryLength
 	row.HistorySizeBytes = &request.HistorySizeBytes
-	row.ExecutionDuration = &request.ExecutionDuration
+	row.ExecutionDuration = new(request.ExecutionDuration.Nanoseconds())
 	row.StateTransitionCount = &request.StateTransitionCount
 
 	result, err := s.sqlStore.DB.ReplaceIntoVisibility(ctx, row)
@@ -852,7 +852,7 @@ func (s *VisibilityStore) rowToInfo(
 		info.CloseTime = *row.CloseTime
 	}
 	if row.ExecutionDuration != nil {
-		info.ExecutionDuration = *row.ExecutionDuration
+		info.ExecutionDuration = time.Duration(*row.ExecutionDuration)
 	}
 	if row.HistoryLength != nil {
 		info.HistoryLength = *row.HistoryLength


### PR DESCRIPTION
## What changed?
Change `VisibilityRow.ExecutionDuration` type from `*time.Duration` to `*int64`.

## Why?
`time.Duration` is not always translated correctly to integer values when inserting into the database (eg: `jackc/pgx` module with connection attributes `default_query_exec_mode: simple_protocol` translates `time.Duration` into a string instead of an integer).
Furthermore, the VisibilityRow is meant to represent the values from DB, so making it `int64` also makes it more explicitly.
https://github.com/temporalio/temporal/issues/10514

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests (updated existing tests)
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Users implementing their own `VisibilityStore` based on the SQL implementation which uses the `VisibilityRow` might need to double check their code.
