### PR TITLE
Add CurrentRunOnly tests in batch reset

### DIFF
--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -484,23 +484,21 @@ func (a *activities) startTaskProcessor(
 					func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
 						var eventId int64
 						var err error
-						//nolint:staticcheck // SA1019: worker versioning v0.31
+						//nolint:staticcheck - ResetReapplyType deprecated in favor of ResetReapplyExcludeType
 						var resetReapplyType enumspb.ResetReapplyType
 						var resetReapplyExcludeTypes []enumspb.ResetReapplyExcludeType
 						if operation.ResetOperation.Options != nil {
 							// Using ResetOptions
 							// Note: getResetEventIDByOptions may modify workflowExecution.RunId, if reset should be to a prior run
-							//nolint:staticcheck // SA1019: worker versioning v0.31
 							eventId, err = getResetEventIDByOptions(ctx, operation.ResetOperation.Options, namespace, executionInfo.Execution, frontendClient, logger)
-							//nolint:staticcheck // SA1019: worker versioning v0.31
+							//nolint:staticcheck - ResetReapplyType deprecated in favor of ResetReapplyExcludeType
 							resetReapplyType = operation.ResetOperation.Options.ResetReapplyType
-							//nolint:staticcheck // SA1019: worker versioning v0.31
 							resetReapplyExcludeTypes = operation.ResetOperation.Options.ResetReapplyExcludeTypes
 						} else {
-							// Old fields
-							//nolint:staticcheck // SA1019: worker versioning v0.31
+							// Using ResetType
+							//nolint:staticcheck - ResetReapplyType deprecated in favor of ResetReapplyExcludeType
 							eventId, err = getResetEventIDByType(ctx, operation.ResetOperation.ResetType, namespace, executionInfo.Execution, frontendClient, logger)
-							//nolint:staticcheck // SA1019: worker versioning v0.31
+							//nolint:staticcheck - ResetReapplyType deprecated in favor of ResetReapplyExcludeType
 							resetReapplyType = operation.ResetOperation.ResetReapplyType
 						}
 						if err != nil {

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -6194,6 +6194,207 @@ func (s *Versioning3Suite) TestPinnedCaN_ResetByBuildIDAfterRollback() {
 	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED, desc.GetWorkflowExecutionInfo().GetStatus())
 }
 
+// TestPinnedCaN_ResetByPreviousRunBuildID_AllRuns covers the CurrentRunOnly: false
+// path: when the reset point for the targeted build ID lives in a previous run,
+// the batcher walks back and resets that prior run. See
+// resetByPreviousRunBuildIDHelper for the shared setup.
+func (s *Versioning3Suite) TestPinnedCaN_ResetByPreviousRunBuildID_AllRuns() {
+	s.resetByPreviousRunBuildIDHelper(false)
+}
+
+// TestPinnedCaN_ResetByPreviousRunBuildID_CurrentRunOnly covers the
+// CurrentRunOnly: true path: when the reset point for the targeted build ID
+// lives in a previous run, the batcher must refuse to walk back into that run.
+// See resetByPreviousRunBuildIDHelper for the shared setup.
+func (s *Versioning3Suite) TestPinnedCaN_ResetByPreviousRunBuildID_CurrentRunOnly() {
+	s.resetByPreviousRunBuildIDHelper(true)
+}
+
+// resetByPreviousRunBuildIDHelper exercises a batch reset that targets a build
+// ID whose reset point lives in a previous run, not the current one. The setup
+// mirrors TestPinnedCaN_ResetByBuildIDAfterRollback: the workflow runs on v1,
+// continues as new onto v2, then v1 is reinstated as current. The reset target
+// is v1's BuildID, whose reset point references runID (the previous run), not
+// canRunID. The currentRunOnly parameter selects between:
+//   - false: the batcher walks back to runID and resets it; the test asserts
+//     zero batch failures and that a new run was produced from runID.
+//   - true: the batcher refuses to walk back; the test asserts one batch
+//     failure and that no run was modified.
+func (s *Versioning3Suite) resetByPreviousRunBuildIDHelper(currentRunOnly bool) {
+	env := s.setupEnv(testcore.WithWorkerService("batch operations"))
+
+	tv1 := env.Tv().WithBuildIDNumber(1)
+	tv2 := tv1.WithBuildIDNumber(2)
+
+	revision := int64(1)
+	setCurrentVersion := func(current *testvars.TestVars, draining ...*testvars.TestVars) {
+		versions := map[string]*deploymentspb.WorkerDeploymentVersionData{
+			current.DeploymentVersion().GetBuildId(): {
+				Status: enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT,
+			},
+		}
+		for _, version := range draining {
+			versions[version.DeploymentVersion().GetBuildId()] = &deploymentspb.WorkerDeploymentVersionData{
+				Status: enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINING,
+			}
+		}
+		s.updateTaskQueueDeploymentDataWithRoutingConfig(env, current, &deploymentpb.RoutingConfig{
+			CurrentDeploymentVersion:  worker_versioning.ExternalWorkerDeploymentVersionFromStringV31(current.DeploymentVersionString()),
+			CurrentVersionChangedTime: timestamp.TimePtr(time.Now()),
+			RevisionNumber:            revision,
+		}, versions, []string{}, tqTypeWf)
+		revision++
+	}
+
+	setCurrentVersion(tv1)
+
+	runID := s.startWorkflow(env, tv1, nil)
+	execution := tv1.WithRunID(runID).WorkflowExecution()
+	s.pollWftAndHandle(env, tv1, false, nil,
+		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+			s.NotNil(task)
+			return respondEmptyWft(tv1, false, vbPinned), nil
+		})
+	s.verifyWorkflowVersioning(env, tv1, vbPinned, tv1.Deployment(), nil, nil)
+
+	setCurrentVersion(tv2, tv1)
+
+	s.triggerNormalWFT(env, tv1, execution)
+	s.pollWftAndHandle(env, tv1, false, nil,
+		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+			s.NotNil(task)
+			return &workflowservice.RespondWorkflowTaskCompletedRequest{
+				Commands: []*commandpb.Command{
+					{
+						CommandType: enumspb.COMMAND_TYPE_CONTINUE_AS_NEW_WORKFLOW_EXECUTION,
+						Attributes: &commandpb.Command_ContinueAsNewWorkflowExecutionCommandAttributes{
+							ContinueAsNewWorkflowExecutionCommandAttributes: &commandpb.ContinueAsNewWorkflowExecutionCommandAttributes{
+								WorkflowType:              tv1.WorkflowType(),
+								TaskQueue:                 tv1.TaskQueue(),
+								Input:                     tv1.Any().Payloads(),
+								InitialVersioningBehavior: enumspb.CONTINUE_AS_NEW_VERSIONING_BEHAVIOR_AUTO_UPGRADE,
+							},
+						},
+					},
+				},
+				VersioningBehavior: vbPinned,
+				DeploymentOptions:  tv1.WorkerDeploymentOptions(true),
+			}, nil
+		})
+
+	var canRunID string
+	s.pollWftAndHandle(env, tv2, false, nil,
+		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+			s.NotNil(task)
+			canRunID = task.WorkflowExecution.GetRunId()
+			s.NotEqual(runID, canRunID)
+			return respondEmptyWft(tv2, false, vbPinned), nil
+		})
+	s.verifyWorkflowVersioning(env, tv2, vbPinned, tv2.Deployment(), nil, nil)
+
+	query := fmt.Sprintf(
+		"WorkflowId = '%s' AND ExecutionStatus = 'Running' AND TemporalUsedWorkerDeploymentVersions = '%s'",
+		tv1.WorkflowID(),
+		tv2.DeploymentVersionStringV32(),
+	)
+	s.Await(func(s *Versioning3Suite) {
+		resp, err := env.FrontendClient().ListWorkflowExecutions(s.Context(), &workflowservice.ListWorkflowExecutionsRequest{
+			Namespace: env.Namespace().String(),
+			Query:     query,
+		})
+		s.NoError(err)
+		s.Len(resp.GetExecutions(), 1)
+	}, 10*time.Second, 200*time.Millisecond)
+
+	setCurrentVersion(tv1, tv2)
+
+	jobID := tv1.Any().String()
+	_, err := env.FrontendClient().StartBatchOperation(s.Context(), &workflowservice.StartBatchOperationRequest{
+		Namespace:       env.Namespace().String(),
+		VisibilityQuery: query,
+		JobId:           jobID,
+		Reason:          "reset by v1 build ID",
+		Operation: &workflowservice.StartBatchOperationRequest_ResetOperation{
+			ResetOperation: &batchpb.BatchOperationReset{
+				Options: &commonpb.ResetOptions{
+					CurrentRunOnly: currentRunOnly,
+					Target: &commonpb.ResetOptions_BuildId{
+						BuildId: tv1.BuildID(),
+					},
+				},
+			},
+		},
+	})
+	s.NoError(err)
+
+	expectedFailures := int64(0)
+	expectedCompletes := int64(1)
+	if currentRunOnly {
+		expectedFailures, expectedCompletes = 1, 0
+	}
+	s.Await(func(s *Versioning3Suite) {
+		resp, err := env.FrontendClient().DescribeBatchOperation(s.Context(), &workflowservice.DescribeBatchOperationRequest{
+			Namespace: env.Namespace().String(),
+			JobId:     jobID,
+		})
+		s.NoError(err)
+		s.Equal(enumspb.BATCH_OPERATION_STATE_COMPLETED, resp.GetState())
+		s.Equal(expectedFailures, resp.GetFailureOperationCount())
+		s.Equal(expectedCompletes, resp.GetCompleteOperationCount())
+	}, 60*time.Second, 500*time.Millisecond)
+
+	if currentRunOnly {
+		// Nothing was reset: the current run is still running on v2, and the
+		// previous run still shows CONTINUED_AS_NEW.
+		canDesc, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
+			Execution: &commonpb.WorkflowExecution{
+				WorkflowId: tv1.WorkflowID(),
+				RunId:      canRunID,
+			},
+		})
+		s.NoError(err)
+		s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, canDesc.GetWorkflowExecutionInfo().GetStatus())
+
+		origDesc, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
+			Execution: &commonpb.WorkflowExecution{
+				WorkflowId: tv1.WorkflowID(),
+				RunId:      runID,
+			},
+		})
+		s.NoError(err)
+		s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW, origDesc.GetWorkflowExecutionInfo().GetStatus())
+		return
+	}
+
+	// CurrentRunOnly=false: the batcher walked back to runID and reset it.
+	// A new run is now scheduled on v1 (current), descended from runID.
+	var resetRunID string
+	s.pollWftAndHandle(env, tv1, false, nil,
+		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+			s.NotNil(task)
+			resetRunID = task.WorkflowExecution.GetRunId()
+			s.NotEqual(runID, resetRunID)
+			s.NotEqual(canRunID, resetRunID)
+			return respondCompleteWorkflow(tv1, vbPinned), nil
+		})
+
+	// Confirm the reset was applied to runID (the previous run) rather than
+	// canRunID: the new run's WorkflowExecutionStarted event preserves the
+	// reset target's OriginalExecutionRunId, which equals runID.
+	history, err := env.FrontendClient().GetWorkflowExecutionHistory(s.Context(), &workflowservice.GetWorkflowExecutionHistoryRequest{
+		Namespace:       env.Namespace().String(),
+		Execution:       &commonpb.WorkflowExecution{WorkflowId: tv1.WorkflowID(), RunId: resetRunID},
+		MaximumPageSize: 1,
+	})
+	s.NoError(err)
+	s.NotEmpty(history.GetHistory().GetEvents())
+	startedAttrs := history.GetHistory().GetEvents()[0].GetWorkflowExecutionStartedEventAttributes()
+	s.NotNil(startedAttrs)
+	s.Equal(runID, startedAttrs.GetOriginalExecutionRunId())
+}
+
 // TestOverride_SuppressesTargetVersionChangedSignal tests that a versioning override
 // suppresses the target_worker_deployment_version_changed signal. When an operator
 // explicitly pins a workflow via override, routing changes should be irrelevant.

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -6054,10 +6054,53 @@ func (s *Versioning3Suite) TestPinnedCaN_FailedTransientNotificationRefiresDespi
 		"outstanding notification should re-fire even when matching is rolled back to v1")
 }
 
-// Scenario: a pinned v1 workflow auto-upgrades to v2 via Continue-As-New, v1 is
-// made current again, then reset-by-build-ID resets the workflow before v2 usage
-// so the reset run resumes on v1.
+// resetByBuildIDMode selects which scenario resetByBuildIDAfterRollbackHelper
+// exercises. The shared setup (v1 → CaN to v2 → rollback to v1) leaves v2's
+// reset point in the current run (canRunID) and v1's reset point in the
+// previous run (runID); each mode picks a different combination of reset
+// target and CurrentRunOnly.
+type resetByBuildIDMode int
+
+const (
+	// Target v2's BuildID. v2's reset point lives in canRunID (current run),
+	// so the batcher resets canRunID directly — no walk-back is needed and
+	// CurrentRunOnly is moot. Same scenario as the original
+	// TestPinnedCaN_ResetByBuildIDAfterRollback.
+	modeResetCurrentRunBuild resetByBuildIDMode = iota
+	// Target v1's BuildID with CurrentRunOnly=false. v1's reset point lives
+	// in runID (previous run), so the batcher walks back and resets runID.
+	modeWalkBackToPreviousRun
+	// Target v1's BuildID with CurrentRunOnly=true. The batcher refuses to
+	// walk back, so no run is modified.
+	modeBlockedByCurrentRunOnly
+)
+
+// TestPinnedCaN_ResetByBuildIDAfterRollback covers the "reset target is in the
+// current run" path: targeting v2's BuildID resets canRunID directly. See
+// resetByBuildIDAfterRollbackHelper for the shared setup.
 func (s *Versioning3Suite) TestPinnedCaN_ResetByBuildIDAfterRollback() {
+	s.resetByBuildIDAfterRollbackHelper(modeResetCurrentRunBuild)
+}
+
+// TestPinnedCaN_ResetByPreviousRunBuildID_AllRuns covers the CurrentRunOnly: false
+// path: when the reset point for the targeted build ID lives in a previous run,
+// the batcher walks back and resets that prior run.
+func (s *Versioning3Suite) TestPinnedCaN_ResetByPreviousRunBuildID_AllRuns() {
+	s.resetByBuildIDAfterRollbackHelper(modeWalkBackToPreviousRun)
+}
+
+// TestPinnedCaN_ResetByPreviousRunBuildID_CurrentRunOnly covers the
+// CurrentRunOnly: true path: when the reset point for the targeted build ID
+// lives in a previous run, the batcher must refuse to walk back into that run.
+func (s *Versioning3Suite) TestPinnedCaN_ResetByPreviousRunBuildID_CurrentRunOnly() {
+	s.resetByBuildIDAfterRollbackHelper(modeBlockedByCurrentRunOnly)
+}
+
+// resetByBuildIDAfterRollbackHelper sets up a pinned workflow that runs on v1,
+// continues as new onto v2, then rolls back to v1 as current — and then issues
+// a batch reset by build ID whose target and CurrentRunOnly flag are chosen by
+// mode. See resetByBuildIDMode for the three scenarios covered.
+func (s *Versioning3Suite) resetByBuildIDAfterRollbackHelper(mode resetByBuildIDMode) {
 	env := s.setupEnv(testcore.WithWorkerService("batch operations"))
 
 	tv1 := env.Tv().WithBuildIDNumber(1)
@@ -6144,6 +6187,15 @@ func (s *Versioning3Suite) TestPinnedCaN_ResetByBuildIDAfterRollback() {
 	}, 10*time.Second, 200*time.Millisecond)
 
 	setCurrentVersion(tv1, tv2)
+
+	targetBuildID := tv2.BuildID()
+	currentRunOnly := false
+	if mode != modeResetCurrentRunBuild {
+		targetBuildID = tv1.BuildID()
+	}
+	if mode == modeBlockedByCurrentRunOnly {
+		currentRunOnly = true
+	}
 
 	jobID := tv1.Any().String()
 	_, err := env.FrontendClient().StartBatchOperation(s.Context(), &workflowservice.StartBatchOperationRequest{
@@ -6154,172 +6206,9 @@ func (s *Versioning3Suite) TestPinnedCaN_ResetByBuildIDAfterRollback() {
 		Operation: &workflowservice.StartBatchOperationRequest_ResetOperation{
 			ResetOperation: &batchpb.BatchOperationReset{
 				Options: &commonpb.ResetOptions{
-					Target: &commonpb.ResetOptions_BuildId{
-						BuildId: tv2.BuildID(),
-					},
-				},
-			},
-		},
-	})
-	s.NoError(err)
-
-	s.Await(func(s *Versioning3Suite) {
-		resp, err := env.FrontendClient().DescribeBatchOperation(s.Context(), &workflowservice.DescribeBatchOperationRequest{
-			Namespace: env.Namespace().String(),
-			JobId:     jobID,
-		})
-		s.NoError(err)
-		s.Equal(enumspb.BATCH_OPERATION_STATE_COMPLETED, resp.GetState())
-	}, 20*time.Second, 500*time.Millisecond)
-
-	var resetRunID string
-	s.pollWftAndHandle(env, tv1, false, nil,
-		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
-			s.NotNil(task)
-			resetRunID = task.WorkflowExecution.GetRunId()
-			s.NotEqual(runID, resetRunID)
-			s.NotEqual(canRunID, resetRunID)
-			return respondCompleteWorkflow(tv1, vbPinned), nil
-		})
-
-	s.verifyWorkflowVersioning(env, tv1, vbPinned, tv1.Deployment(), nil, nil)
-	desc, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
-		Namespace: env.Namespace().String(),
-		Execution: &commonpb.WorkflowExecution{
-			WorkflowId: tv1.WorkflowID(),
-			RunId:      canRunID,
-		},
-	})
-	s.NoError(err)
-	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED, desc.GetWorkflowExecutionInfo().GetStatus())
-}
-
-// TestPinnedCaN_ResetByPreviousRunBuildID_AllRuns covers the CurrentRunOnly: false
-// path: when the reset point for the targeted build ID lives in a previous run,
-// the batcher walks back and resets that prior run. See
-// resetByPreviousRunBuildIDHelper for the shared setup.
-func (s *Versioning3Suite) TestPinnedCaN_ResetByPreviousRunBuildID_AllRuns() {
-	s.resetByPreviousRunBuildIDHelper(false)
-}
-
-// TestPinnedCaN_ResetByPreviousRunBuildID_CurrentRunOnly covers the
-// CurrentRunOnly: true path: when the reset point for the targeted build ID
-// lives in a previous run, the batcher must refuse to walk back into that run.
-// See resetByPreviousRunBuildIDHelper for the shared setup.
-func (s *Versioning3Suite) TestPinnedCaN_ResetByPreviousRunBuildID_CurrentRunOnly() {
-	s.resetByPreviousRunBuildIDHelper(true)
-}
-
-// resetByPreviousRunBuildIDHelper exercises a batch reset that targets a build
-// ID whose reset point lives in a previous run, not the current one. The setup
-// mirrors TestPinnedCaN_ResetByBuildIDAfterRollback: the workflow runs on v1,
-// continues as new onto v2, then v1 is reinstated as current. The reset target
-// is v1's BuildID, whose reset point references runID (the previous run), not
-// canRunID. The currentRunOnly parameter selects between:
-//   - false: the batcher walks back to runID and resets it; the test asserts
-//     zero batch failures and that a new run was produced from runID.
-//   - true: the batcher refuses to walk back; the test asserts one batch
-//     failure and that no run was modified.
-func (s *Versioning3Suite) resetByPreviousRunBuildIDHelper(currentRunOnly bool) {
-	env := s.setupEnv(testcore.WithWorkerService("batch operations"))
-
-	tv1 := env.Tv().WithBuildIDNumber(1)
-	tv2 := tv1.WithBuildIDNumber(2)
-
-	revision := int64(1)
-	setCurrentVersion := func(current *testvars.TestVars, draining ...*testvars.TestVars) {
-		versions := map[string]*deploymentspb.WorkerDeploymentVersionData{
-			current.DeploymentVersion().GetBuildId(): {
-				Status: enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT,
-			},
-		}
-		for _, version := range draining {
-			versions[version.DeploymentVersion().GetBuildId()] = &deploymentspb.WorkerDeploymentVersionData{
-				Status: enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINING,
-			}
-		}
-		s.updateTaskQueueDeploymentDataWithRoutingConfig(env, current, &deploymentpb.RoutingConfig{
-			CurrentDeploymentVersion:  worker_versioning.ExternalWorkerDeploymentVersionFromStringV31(current.DeploymentVersionString()),
-			CurrentVersionChangedTime: timestamp.TimePtr(time.Now()),
-			RevisionNumber:            revision,
-		}, versions, []string{}, tqTypeWf)
-		revision++
-	}
-
-	setCurrentVersion(tv1)
-
-	runID := s.startWorkflow(env, tv1, nil)
-	execution := tv1.WithRunID(runID).WorkflowExecution()
-	s.pollWftAndHandle(env, tv1, false, nil,
-		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
-			s.NotNil(task)
-			return respondEmptyWft(tv1, false, vbPinned), nil
-		})
-	s.verifyWorkflowVersioning(env, tv1, vbPinned, tv1.Deployment(), nil, nil)
-
-	setCurrentVersion(tv2, tv1)
-
-	s.triggerNormalWFT(env, tv1, execution)
-	s.pollWftAndHandle(env, tv1, false, nil,
-		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
-			s.NotNil(task)
-			return &workflowservice.RespondWorkflowTaskCompletedRequest{
-				Commands: []*commandpb.Command{
-					{
-						CommandType: enumspb.COMMAND_TYPE_CONTINUE_AS_NEW_WORKFLOW_EXECUTION,
-						Attributes: &commandpb.Command_ContinueAsNewWorkflowExecutionCommandAttributes{
-							ContinueAsNewWorkflowExecutionCommandAttributes: &commandpb.ContinueAsNewWorkflowExecutionCommandAttributes{
-								WorkflowType:              tv1.WorkflowType(),
-								TaskQueue:                 tv1.TaskQueue(),
-								Input:                     tv1.Any().Payloads(),
-								InitialVersioningBehavior: enumspb.CONTINUE_AS_NEW_VERSIONING_BEHAVIOR_AUTO_UPGRADE,
-							},
-						},
-					},
-				},
-				VersioningBehavior: vbPinned,
-				DeploymentOptions:  tv1.WorkerDeploymentOptions(true),
-			}, nil
-		})
-
-	var canRunID string
-	s.pollWftAndHandle(env, tv2, false, nil,
-		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
-			s.NotNil(task)
-			canRunID = task.WorkflowExecution.GetRunId()
-			s.NotEqual(runID, canRunID)
-			return respondEmptyWft(tv2, false, vbPinned), nil
-		})
-	s.verifyWorkflowVersioning(env, tv2, vbPinned, tv2.Deployment(), nil, nil)
-
-	query := fmt.Sprintf(
-		"WorkflowId = '%s' AND ExecutionStatus = 'Running' AND TemporalUsedWorkerDeploymentVersions = '%s'",
-		tv1.WorkflowID(),
-		tv2.DeploymentVersionStringV32(),
-	)
-	s.Await(func(s *Versioning3Suite) {
-		resp, err := env.FrontendClient().ListWorkflowExecutions(s.Context(), &workflowservice.ListWorkflowExecutionsRequest{
-			Namespace: env.Namespace().String(),
-			Query:     query,
-		})
-		s.NoError(err)
-		s.Len(resp.GetExecutions(), 1)
-	}, 10*time.Second, 200*time.Millisecond)
-
-	setCurrentVersion(tv1, tv2)
-
-	jobID := tv1.Any().String()
-	_, err := env.FrontendClient().StartBatchOperation(s.Context(), &workflowservice.StartBatchOperationRequest{
-		Namespace:       env.Namespace().String(),
-		VisibilityQuery: query,
-		JobId:           jobID,
-		Reason:          "reset by v1 build ID",
-		Operation: &workflowservice.StartBatchOperationRequest_ResetOperation{
-			ResetOperation: &batchpb.BatchOperationReset{
-				Options: &commonpb.ResetOptions{
 					CurrentRunOnly: currentRunOnly,
 					Target: &commonpb.ResetOptions_BuildId{
-						BuildId: tv1.BuildID(),
+						BuildId: targetBuildID,
 					},
 				},
 			},
@@ -6329,7 +6218,7 @@ func (s *Versioning3Suite) resetByPreviousRunBuildIDHelper(currentRunOnly bool) 
 
 	expectedFailures := int64(0)
 	expectedCompletes := int64(1)
-	if currentRunOnly {
+	if mode == modeBlockedByCurrentRunOnly {
 		expectedFailures, expectedCompletes = 1, 0
 	}
 	s.Await(func(s *Versioning3Suite) {
@@ -6343,7 +6232,7 @@ func (s *Versioning3Suite) resetByPreviousRunBuildIDHelper(currentRunOnly bool) 
 		s.Equal(expectedCompletes, resp.GetCompleteOperationCount())
 	}, 60*time.Second, 500*time.Millisecond)
 
-	if currentRunOnly {
+	if mode == modeBlockedByCurrentRunOnly {
 		// Nothing was reset: the current run is still running on v2, and the
 		// previous run still shows CONTINUED_AS_NEW.
 		canDesc, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
@@ -6368,8 +6257,8 @@ func (s *Versioning3Suite) resetByPreviousRunBuildIDHelper(currentRunOnly bool) 
 		return
 	}
 
-	// CurrentRunOnly=false: the batcher walked back to runID and reset it.
-	// A new run is now scheduled on v1 (current), descended from runID.
+	// A reset run was produced. Poll its first WFT on tv1 (current after
+	// rollback) and confirm it is a fresh run.
 	var resetRunID string
 	s.pollWftAndHandle(env, tv1, false, nil,
 		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
@@ -6380,19 +6269,35 @@ func (s *Versioning3Suite) resetByPreviousRunBuildIDHelper(currentRunOnly bool) 
 			return respondCompleteWorkflow(tv1, vbPinned), nil
 		})
 
-	// Confirm the reset was applied to runID (the previous run) rather than
-	// canRunID: the new run's WorkflowExecutionStarted event preserves the
-	// reset target's OriginalExecutionRunId, which equals runID.
-	history, err := env.FrontendClient().GetWorkflowExecutionHistory(s.Context(), &workflowservice.GetWorkflowExecutionHistoryRequest{
-		Namespace:       env.Namespace().String(),
-		Execution:       &commonpb.WorkflowExecution{WorkflowId: tv1.WorkflowID(), RunId: resetRunID},
-		MaximumPageSize: 1,
-	})
-	s.NoError(err)
-	s.NotEmpty(history.GetHistory().GetEvents())
-	startedAttrs := history.GetHistory().GetEvents()[0].GetWorkflowExecutionStartedEventAttributes()
-	s.NotNil(startedAttrs)
-	s.Equal(runID, startedAttrs.GetOriginalExecutionRunId())
+	switch mode {
+	case modeResetCurrentRunBuild:
+		// Reset hit canRunID directly, so canRunID is now TERMINATED.
+		s.verifyWorkflowVersioning(env, tv1, vbPinned, tv1.Deployment(), nil, nil)
+		desc, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
+			Execution: &commonpb.WorkflowExecution{
+				WorkflowId: tv1.WorkflowID(),
+				RunId:      canRunID,
+			},
+		})
+		s.NoError(err)
+		s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED, desc.GetWorkflowExecutionInfo().GetStatus())
+	case modeWalkBackToPreviousRun:
+		// Reset walked back to runID. The new run's WorkflowExecutionStarted
+		// event preserves the reset target's OriginalExecutionRunId, which
+		// equals runID — proof that the reset hit the previous run rather
+		// than canRunID.
+		history, err := env.FrontendClient().GetWorkflowExecutionHistory(s.Context(), &workflowservice.GetWorkflowExecutionHistoryRequest{
+			Namespace:       env.Namespace().String(),
+			Execution:       &commonpb.WorkflowExecution{WorkflowId: tv1.WorkflowID(), RunId: resetRunID},
+			MaximumPageSize: 1,
+		})
+		s.NoError(err)
+		s.NotEmpty(history.GetHistory().GetEvents())
+		startedAttrs := history.GetHistory().GetEvents()[0].GetWorkflowExecutionStartedEventAttributes()
+		s.NotNil(startedAttrs)
+		s.Equal(runID, startedAttrs.GetOriginalExecutionRunId())
+	}
 }
 
 // TestOverride_SuppressesTargetVersionChangedSignal tests that a versioning override

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -6225,6 +6225,8 @@ func (s *Versioning3Suite) resetByBuildIDAfterRollbackHelper(mode resetByBuildID
 		expectedFailures, expectedCompletes = 0, 1
 	case modeResetBlockedByCurrentRunOnly:
 		expectedFailures, expectedCompletes = 1, 0
+	default:
+		s.Fail("unrecognized mode")
 	}
 
 	s.Await(func(s *Versioning3Suite) {
@@ -6238,12 +6240,7 @@ func (s *Versioning3Suite) resetByBuildIDAfterRollbackHelper(mode resetByBuildID
 		s.Equal(expectedCompletes, resp.GetCompleteOperationCount())
 	}, 60*time.Second, 500*time.Millisecond)
 
-	switch mode {
-	case modeResetCurrentRunBuild:
-		targetBuildID = tv2.BuildID()
-	case modeResetPreviousRunBuild:
-		targetBuildID = tv1.BuildID()
-	case modeResetBlockedByCurrentRunOnly:
+	if mode == modeResetBlockedByCurrentRunOnly {
 		// Nothing was reset: the current run is still RUNNING (a successful
 		// walk-back-and-reset would have terminated it), and no new run was
 		// created — the latest run for the workflow ID is still canRunID.

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -6069,10 +6069,10 @@ const (
 	modeResetCurrentRunBuild resetByBuildIDMode = iota
 	// Target v1's BuildID with CurrentRunOnly=false. v1's reset point lives
 	// in runID (previous run), so the batcher walks back and resets runID.
-	modeWalkBackToPreviousRun
+	modeResetPreviousRunBuild
 	// Target v1's BuildID with CurrentRunOnly=true. The batcher refuses to
 	// walk back, so no run is modified.
-	modeBlockedByCurrentRunOnly
+	modeResetBlockedByCurrentRunOnly
 )
 
 // TestPinnedCaN_ResetByBuildIDAfterRollback covers the "reset target is in the
@@ -6086,14 +6086,14 @@ func (s *Versioning3Suite) TestPinnedCaN_ResetByBuildIDAfterRollback() {
 // path: when the reset point for the targeted build ID lives in a previous run,
 // the batcher walks back and resets that prior run.
 func (s *Versioning3Suite) TestPinnedCaN_ResetByPreviousRunBuildID_AllRuns() {
-	s.resetByBuildIDAfterRollbackHelper(modeWalkBackToPreviousRun)
+	s.resetByBuildIDAfterRollbackHelper(modeResetPreviousRunBuild)
 }
 
 // TestPinnedCaN_ResetByPreviousRunBuildID_CurrentRunOnly covers the
 // CurrentRunOnly: true path: when the reset point for the targeted build ID
 // lives in a previous run, the batcher must refuse to walk back into that run.
 func (s *Versioning3Suite) TestPinnedCaN_ResetByPreviousRunBuildID_CurrentRunOnly() {
-	s.resetByBuildIDAfterRollbackHelper(modeBlockedByCurrentRunOnly)
+	s.resetByBuildIDAfterRollbackHelper(modeResetBlockedByCurrentRunOnly)
 }
 
 // resetByBuildIDAfterRollbackHelper sets up a pinned workflow that runs on v1,
@@ -6188,12 +6188,15 @@ func (s *Versioning3Suite) resetByBuildIDAfterRollbackHelper(mode resetByBuildID
 
 	setCurrentVersion(tv1, tv2)
 
-	targetBuildID := tv2.BuildID()
-	currentRunOnly := false
-	if mode != modeResetCurrentRunBuild {
+	var targetBuildID string
+	var currentRunOnly bool
+	switch mode {
+	case modeResetCurrentRunBuild:
+		targetBuildID = tv2.BuildID()
+	case modeResetPreviousRunBuild:
 		targetBuildID = tv1.BuildID()
-	}
-	if mode == modeBlockedByCurrentRunOnly {
+	case modeResetBlockedByCurrentRunOnly:
+		targetBuildID = tv1.BuildID()
 		currentRunOnly = true
 	}
 
@@ -6216,11 +6219,14 @@ func (s *Versioning3Suite) resetByBuildIDAfterRollbackHelper(mode resetByBuildID
 	})
 	s.NoError(err)
 
-	expectedFailures := int64(0)
-	expectedCompletes := int64(1)
-	if mode == modeBlockedByCurrentRunOnly {
+	var expectedFailures, expectedCompletes int64
+	switch mode {
+	case modeResetCurrentRunBuild, modeResetPreviousRunBuild:
+		expectedFailures, expectedCompletes = 0, 1
+	case modeResetBlockedByCurrentRunOnly:
 		expectedFailures, expectedCompletes = 1, 0
 	}
+
 	s.Await(func(s *Versioning3Suite) {
 		resp, err := env.FrontendClient().DescribeBatchOperation(s.Context(), &workflowservice.DescribeBatchOperationRequest{
 			Namespace: env.Namespace().String(),
@@ -6232,7 +6238,12 @@ func (s *Versioning3Suite) resetByBuildIDAfterRollbackHelper(mode resetByBuildID
 		s.Equal(expectedCompletes, resp.GetCompleteOperationCount())
 	}, 60*time.Second, 500*time.Millisecond)
 
-	if mode == modeBlockedByCurrentRunOnly {
+	switch mode {
+	case modeResetCurrentRunBuild:
+		targetBuildID = tv2.BuildID()
+	case modeResetPreviousRunBuild:
+		targetBuildID = tv1.BuildID()
+	case modeResetBlockedByCurrentRunOnly:
 		// Nothing was reset: the current run is still RUNNING (a successful
 		// walk-back-and-reset would have terminated it), and no new run was
 		// created — the latest run for the workflow ID is still canRunID.
@@ -6280,7 +6291,7 @@ func (s *Versioning3Suite) resetByBuildIDAfterRollbackHelper(mode resetByBuildID
 		})
 		s.NoError(err)
 		s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED, desc.GetWorkflowExecutionInfo().GetStatus())
-	case modeWalkBackToPreviousRun:
+	case modeResetPreviousRunBuild:
 		// Reset walked back to runID. The new run's WorkflowExecutionStarted
 		// event preserves the reset target's OriginalExecutionRunId, which
 		// equals runID — proof that the reset hit the previous run rather
@@ -6295,6 +6306,8 @@ func (s *Versioning3Suite) resetByBuildIDAfterRollbackHelper(mode resetByBuildID
 		startedAttrs := history.GetHistory().GetEvents()[0].GetWorkflowExecutionStartedEventAttributes()
 		s.NotNil(startedAttrs)
 		s.Equal(runID, startedAttrs.GetOriginalExecutionRunId())
+	default:
+		s.Fail("unrecognized mode")
 	}
 }
 

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -6233,8 +6233,9 @@ func (s *Versioning3Suite) resetByBuildIDAfterRollbackHelper(mode resetByBuildID
 	}, 60*time.Second, 500*time.Millisecond)
 
 	if mode == modeBlockedByCurrentRunOnly {
-		// Nothing was reset: the current run is still running on v2, and the
-		// previous run still shows CONTINUED_AS_NEW.
+		// Nothing was reset: the current run is still RUNNING (a successful
+		// walk-back-and-reset would have terminated it), and no new run was
+		// created — the latest run for the workflow ID is still canRunID.
 		canDesc, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
 			Namespace: env.Namespace().String(),
 			Execution: &commonpb.WorkflowExecution{
@@ -6245,15 +6246,12 @@ func (s *Versioning3Suite) resetByBuildIDAfterRollbackHelper(mode resetByBuildID
 		s.NoError(err)
 		s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, canDesc.GetWorkflowExecutionInfo().GetStatus())
 
-		origDesc, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+		latestDesc, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
 			Namespace: env.Namespace().String(),
-			Execution: &commonpb.WorkflowExecution{
-				WorkflowId: tv1.WorkflowID(),
-				RunId:      runID,
-			},
+			Execution: &commonpb.WorkflowExecution{WorkflowId: tv1.WorkflowID()},
 		})
 		s.NoError(err)
-		s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW, origDesc.GetWorkflowExecutionInfo().GetStatus())
+		s.Equal(canRunID, latestDesc.GetWorkflowExecutionInfo().GetExecution().GetRunId())
 		return
 	}
 


### PR DESCRIPTION
## What changed?
- `service/worker/batcher/activities.go`: Replaced misleading `//nolint:staticcheck // SA1019: worker versioning v0.31` comments around the reset-operation block — the suppressions are actually for `ResetReapplyType` being deprecated in favor of `ResetReapplyExcludeType`, not anything versioning-related. Also dropped redundant directives on lines that didn't reference deprecated symbols.
- `tests/versioning_3_test.go`: Folded `TestPinnedCaN_ResetByBuildIDAfterRollback` and two new `CurrentRunOnly` tests into a shared `resetByBuildIDAfterRollbackHelper` parameterized by a mode enum:
  - `modeResetCurrentRunBuild` — target v2's BuildID, reset hits the current run directly (the original scenario).
  - `modeResetPreviousRunBuild` — target v1's BuildID with `CurrentRunOnly=false`, batcher walks back and resets the previous run; asserted via the new run's `OriginalExecutionRunId`.
  - `modeResetBlockedByCurrentRunOnly` — target v1's BuildID with `CurrentRunOnly=true`, batcher refuses to walk back; asserted via one batch failure and unchanged run statuses.

## Why?
The old `// SA1019: worker versioning v0.31` comments were inherited from neighboring code but didn't describe what was being suppressed here, making future cleanup of those nolints risky. While auditing the block I also noticed `CurrentRunOnly` had no coverage exercising the walk-back-to-previous-run path that actually makes the flag load-bearing — only the same-run path (where the flag is moot) was tested.

## How did you test it?
- [x] built
- [x] covered by existing tests
- [x] added new functional test(s)

`go test ./tests/ -run 'TestVersioning3FunctionalSuite/TestPinnedCaN_ResetByBuildIDAfterRollback|TestVersioning3FunctionalSuite/TestPinnedCaN_ResetByPreviousRunBuildID' -count 1` — all three scenarios pass in ~9s. I also sanity-checked the new walk-back assertion by flipping `CurrentRunOnly` and confirming the test fails in the expected way (no batch failure registered, assertion times out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Production batch reset logic is unchanged; only comment fixes and new integration tests document existing `CurrentRunOnly` / walk-back behavior.
> 
> **Overview**
> This PR does **not** change batch reset behavior in production code. In `service/worker/batcher/activities.go`, it only **corrects `//nolint:staticcheck` comments** around reset handling so they describe **`ResetReapplyType` deprecation** (not worker versioning) and trims redundant suppressions.
> 
> In `tests/versioning_3_test.go`, it **refactors** the pinned CaN + rollback + batch reset-by-build-ID scenario into **`resetByBuildIDAfterRollbackHelper`** with three modes: reset when the build ID’s point is on the **current run**, reset on a **previous run** with `CurrentRunOnly=false` (walk-back, checked via `OriginalExecutionRunId`), and **blocked** reset with `CurrentRunOnly=true` when the point is on a prior run (expects a batch failure and unchanged runs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1af989dc604d1268342fbef5a2a025afb2235467. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->