### PR TITLE
Add activity_heartbeat_count metric with has_details tag

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -940,6 +940,7 @@ var (
 	ActivityTaskTimeout                              = NewCounterDef("activity_task_timeout", WithDescription("Number of activity task timeouts (including retries)."))
 	ActivityTimeout                                  = NewCounterDef("activity_timeout", WithDescription("Number of terminal activity timeouts."))
 	ActivityPayloadSize                              = NewCounterDef("activity_payload_size", WithDescription("Size of activity payloads in bytes."))
+	ActivityHeartbeatCount                           = NewCounterDef("activity_heartbeat_count", WithDescription("Count of activity heartbeats, with has_details tag indicating whether the heartbeat carried a payload."))
 	AckLevelUpdateCounter                            = NewCounterDef("ack_level_update")
 	AckLevelUpdateFailedCounter                      = NewCounterDef("ack_level_update_failed")
 	CommandCounter                                   = NewCounterDef("command")

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -2094,12 +2094,19 @@ func (ms *MutableStateImpl) UpdateActivityProgress(
 	ms.approximateSize += ai.Size()
 	ms.syncActivityTasks[ai.ScheduledEventId] = struct{}{}
 
-	if payloadSize := request.Details.Size(); payloadSize > 0 {
+	payloadSize := request.Details.Size()
+	hasDetails := "false"
+	if payloadSize > 0 {
+		hasDetails = "true"
 		ms.metricsHandler.Counter(metrics.ActivityPayloadSize.Name()).Record(
 			int64(payloadSize),
 			metrics.OperationTag(metrics.HistoryRecordActivityTaskHeartbeatScope),
 			metrics.NamespaceTag(ms.namespaceEntry.Name().String()))
 	}
+	ms.metricsHandler.Counter(metrics.ActivityHeartbeatCount.Name()).Record(1,
+		metrics.OperationTag(metrics.HistoryRecordActivityTaskHeartbeatScope),
+		metrics.NamespaceTag(ms.namespaceEntry.Name().String()),
+		metrics.StringTag("has_details", hasDetails))
 }
 
 // UpdateActivityInfo applies the necessary activity information

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -2095,9 +2096,7 @@ func (ms *MutableStateImpl) UpdateActivityProgress(
 	ms.syncActivityTasks[ai.ScheduledEventId] = struct{}{}
 
 	payloadSize := request.Details.Size()
-	hasDetails := "false"
 	if payloadSize > 0 {
-		hasDetails = "true"
 		ms.metricsHandler.Counter(metrics.ActivityPayloadSize.Name()).Record(
 			int64(payloadSize),
 			metrics.OperationTag(metrics.HistoryRecordActivityTaskHeartbeatScope),
@@ -2106,7 +2105,7 @@ func (ms *MutableStateImpl) UpdateActivityProgress(
 	ms.metricsHandler.Counter(metrics.ActivityHeartbeatCount.Name()).Record(1,
 		metrics.OperationTag(metrics.HistoryRecordActivityTaskHeartbeatScope),
 		metrics.NamespaceTag(ms.namespaceEntry.Name().String()),
-		metrics.StringTag("has_details", hasDetails))
+		metrics.StringTag("has_details", strconv.FormatBool(payloadSize > 0)))
 }
 
 // UpdateActivityInfo applies the necessary activity information

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -8775,3 +8775,78 @@ func (s *mutableStateSuite) TestMutableStateImpl_Now() {
 		s.Equal(fixedBase.Add(skip), s.mutableState.Now())
 	})
 }
+
+func TestUpdateActivityProgress_HeartbeatCountMetric(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		details     *commonpb.Payloads
+		hasDetails  string
+		payloadSize bool
+	}{
+		{
+			name:        "with details",
+			details:     &commonpb.Payloads{Payloads: []*commonpb.Payload{{Data: []byte("progress")}}},
+			hasDetails:  "true",
+			payloadSize: true,
+		},
+		{
+			name:        "without details",
+			details:     nil,
+			hasDetails:  "false",
+			payloadSize: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			mockEventsCache := events.NewMockCache(controller)
+			mockConfig := tests.NewDynamicConfig()
+			mockConfig.MutableStateActivityFailureSizeLimitWarn = func(namespace string) int { return 1024 }
+			mockConfig.MutableStateActivityFailureSizeLimitError = func(namespace string) int { return 2048 }
+			mockConfig.EnableTransitionHistory = func(string) bool { return true }
+			mockShard := shard.NewTestContext(
+				controller,
+				&persistencespb.ShardInfo{ShardId: 0, RangeId: 1},
+				mockConfig,
+			)
+			defer mockShard.StopForTest()
+
+			reg := hsm.NewRegistry()
+			require.NoError(t, RegisterStateMachine(reg))
+			mockShard.SetStateMachineRegistry(reg)
+			mockShard.SetEventsCacheForTesting(mockEventsCache)
+
+			nsEntry := tests.GlobalNamespaceEntry
+			mockShard.Resource.NamespaceCache.EXPECT().GetNamespaceByID(tests.NamespaceID).Return(nsEntry, nil).AnyTimes()
+			mockShard.Resource.ClusterMetadata.EXPECT().ClusterNameForFailoverVersion(nsEntry.IsGlobalNamespace(), nsEntry.FailoverVersion(tests.WorkflowID)).Return(cluster.TestCurrentClusterName).AnyTimes()
+			mockShard.Resource.ClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
+			mockShard.Resource.ClusterMetadata.EXPECT().GetClusterID().Return(int64(1)).AnyTimes()
+			testScope := mockShard.Resource.MetricsScope.(tally.TestScope)
+
+			ms := NewMutableState(mockShard, mockEventsCache, mockShard.GetLogger(), nsEntry, tests.WorkflowID, tests.RunID, time.Now().UTC())
+
+			ai := &persistencespb.ActivityInfo{
+				ScheduledEventId: 1,
+				Version:          1,
+			}
+			ms.pendingActivityInfoIDs[1] = ai
+
+			ms.UpdateActivityProgress(ai, &workflowservice.RecordActivityTaskHeartbeatRequest{
+				Details: tc.details,
+			})
+
+			counters := testScope.Snapshot().Counters()
+
+			heartbeatKey := "test.activity_heartbeat_count+has_details=" + tc.hasDetails + ",namespace=" + nsEntry.Name().String() + ",operation=RecordActivityTaskHeartbeat,service_name=history"
+			require.Contains(t, counters, heartbeatKey)
+			require.Equal(t, int64(1), counters[heartbeatKey].Value())
+
+			payloadKey := "test.activity_payload_size+namespace=" + nsEntry.Name().String() + ",operation=RecordActivityTaskHeartbeat,service_name=history"
+			if tc.payloadSize {
+				require.Contains(t, counters, payloadKey)
+				require.Greater(t, counters[payloadKey].Value(), int64(0))
+			} else {
+				require.NotContains(t, counters, payloadKey)
+			}
+		})
+	}
+}

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -8776,77 +8776,22 @@ func (s *mutableStateSuite) TestMutableStateImpl_Now() {
 	})
 }
 
-func TestUpdateActivityProgress_HeartbeatCountMetric(t *testing.T) {
-	for _, tc := range []struct {
-		name        string
-		details     *commonpb.Payloads
-		hasDetails  string
-		payloadSize bool
-	}{
-		{
-			name:        "with details",
-			details:     &commonpb.Payloads{Payloads: []*commonpb.Payload{{Data: []byte("progress")}}},
-			hasDetails:  "true",
-			payloadSize: true,
-		},
-		{
-			name:        "without details",
-			details:     nil,
-			hasDetails:  "false",
-			payloadSize: false,
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			controller := gomock.NewController(t)
-			mockEventsCache := events.NewMockCache(controller)
-			mockConfig := tests.NewDynamicConfig()
-			mockConfig.MutableStateActivityFailureSizeLimitWarn = func(namespace string) int { return 1024 }
-			mockConfig.MutableStateActivityFailureSizeLimitError = func(namespace string) int { return 2048 }
-			mockConfig.EnableTransitionHistory = func(string) bool { return true }
-			mockShard := shard.NewTestContext(
-				controller,
-				&persistencespb.ShardInfo{ShardId: 0, RangeId: 1},
-				mockConfig,
-			)
-			defer mockShard.StopForTest()
+func (s *mutableStateSuite) TestUpdateActivityProgress_HeartbeatCountMetric() {
+	ai := &persistencespb.ActivityInfo{ScheduledEventId: 1, Version: 1}
+	s.mutableState.pendingActivityInfoIDs[1] = ai
+	nsName := s.namespaceEntry.Name().String()
 
-			reg := hsm.NewRegistry()
-			require.NoError(t, RegisterStateMachine(reg))
-			mockShard.SetStateMachineRegistry(reg)
-			mockShard.SetEventsCacheForTesting(mockEventsCache)
-
-			nsEntry := tests.GlobalNamespaceEntry
-			mockShard.Resource.NamespaceCache.EXPECT().GetNamespaceByID(tests.NamespaceID).Return(nsEntry, nil).AnyTimes()
-			mockShard.Resource.ClusterMetadata.EXPECT().ClusterNameForFailoverVersion(nsEntry.IsGlobalNamespace(), nsEntry.FailoverVersion(tests.WorkflowID)).Return(cluster.TestCurrentClusterName).AnyTimes()
-			mockShard.Resource.ClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
-			mockShard.Resource.ClusterMetadata.EXPECT().GetClusterID().Return(int64(1)).AnyTimes()
-			testScope := mockShard.Resource.MetricsScope.(tally.TestScope)
-
-			ms := NewMutableState(mockShard, mockEventsCache, mockShard.GetLogger(), nsEntry, tests.WorkflowID, tests.RunID, time.Now().UTC())
-
-			ai := &persistencespb.ActivityInfo{
-				ScheduledEventId: 1,
-				Version:          1,
-			}
-			ms.pendingActivityInfoIDs[1] = ai
-
-			ms.UpdateActivityProgress(ai, &workflowservice.RecordActivityTaskHeartbeatRequest{
-				Details: tc.details,
-			})
-
-			counters := testScope.Snapshot().Counters()
-
-			heartbeatKey := "test.activity_heartbeat_count+has_details=" + tc.hasDetails + ",namespace=" + nsEntry.Name().String() + ",operation=RecordActivityTaskHeartbeat,service_name=history"
-			require.Contains(t, counters, heartbeatKey)
-			require.Equal(t, int64(1), counters[heartbeatKey].Value())
-
-			payloadKey := "test.activity_payload_size+namespace=" + nsEntry.Name().String() + ",operation=RecordActivityTaskHeartbeat,service_name=history"
-			if tc.payloadSize {
-				require.Contains(t, counters, payloadKey)
-				require.Greater(t, counters[payloadKey].Value(), int64(0))
-			} else {
-				require.NotContains(t, counters, payloadKey)
-			}
-		})
+	counterKey := func(hasDetails string) string {
+		return "test.activity_heartbeat_count+has_details=" + hasDetails + ",namespace=" + nsName + ",operation=RecordActivityTaskHeartbeat,service_name=history"
 	}
+
+	// Heartbeat with details.
+	s.mutableState.UpdateActivityProgress(ai, &workflowservice.RecordActivityTaskHeartbeatRequest{
+		Details: &commonpb.Payloads{Payloads: []*commonpb.Payload{{Data: []byte("progress")}}},
+	})
+	s.Contains(s.testScope.Snapshot().Counters(), counterKey("true"))
+
+	// Heartbeat without details.
+	s.mutableState.UpdateActivityProgress(ai, &workflowservice.RecordActivityTaskHeartbeatRequest{})
+	s.Contains(s.testScope.Snapshot().Counters(), counterKey("false"))
 }


### PR DESCRIPTION
## What
Add a new `activity_heartbeat_count` counter metric with a `has_details` tag (`true`/`false`) indicating whether the heartbeat carried a payload.

## Why
There's no existing metric to determine what fraction of activity heartbeats include details vs are empty. This enables querying the ratio to understand usage patterns and inform optimization decisions.

## How did you test it?
Unit test (`TestUpdateActivityProgress_HeartbeatCountMetric`) covering both with-details and without-details cases, verifying the counter and tag values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)