### PR TITLE
Skip entire mutable state transaction if chasm transaction was skipped

### DIFF
--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -252,6 +252,11 @@ type (
 	}
 )
 
+// IsEmpty reports whether the mutation contains no node updates or deletions.
+func (m NodesMutation) IsEmpty() bool {
+	return len(m.UpdatedNodes) == 0 && len(m.DeletedNodes) == 0
+}
+
 // NewTreeFromDB creates a new in-memory CHASM tree from a collection of flattened persistence CHASM nodes.
 // This method should only be used when loading an existing CHASM tree from database.
 // If serializedNodes is empty, the tree will be considered as a legacy Workflow execution without any CHASM nodes.

--- a/service/history/interfaces/mutable_state.go
+++ b/service/history/interfaces/mutable_state.go
@@ -340,6 +340,7 @@ type (
 		// StartTransaction sets up the mutable state for transacting.
 		StartTransaction(entry *namespace.Namespace) (bool, error)
 		// CloseTransactionAsMutation closes the mutable state transaction (different from DB transaction) and prepares the whole state mutation to be persisted and bumps the DBRecordVersion.
+		// It returns a nil mutation for CHASM executions when the transaction has no durable changes to persist.
 		// You should ideally not make any changes to the mutable state after this call.
 		CloseTransactionAsMutation(ctx context.Context, transactionPolicy TransactionPolicy) (*persistence.WorkflowMutation, []*persistence.WorkflowEvents, error)
 		// CloseTransactionAsSnapshot closes the mutable state transaction (different from DB transaction) and prepares the current snapshot of the state to be persisted and bumps the DBRecordVersion.

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -604,6 +604,13 @@ func (c *ContextImpl) UpdateWorkflowExecutionWithNew(
 		}
 	}
 
+	if updateWorkflow == nil {
+		if newWorkflow != nil || len(newWorkflowEventsSeq) != 0 {
+			return serviceerror.NewInternal("current workflow mutation skipped with new workflow snapshot")
+		}
+		return nil
+	}
+
 	if err := c.mergeUpdateWithNewReplicationTasks(
 		updateWorkflow,
 		newWorkflow,

--- a/service/history/workflow/context_test.go
+++ b/service/history/workflow/context_test.go
@@ -579,3 +579,74 @@ func (s *contextSuite) TestRefreshTask() {
 		})
 	}
 }
+
+func (s *contextSuite) TestUpdateWorkflowExecutionWithNew_ChasmNoopSkipsPersistence() {
+	now := time.Now().UTC()
+	chasmArchetypeID := chasm.WorkflowArchetypeID + 101
+	dbState := &persistencespb.WorkflowMutableState{
+		ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
+			NamespaceId: tests.NamespaceID.String(),
+			WorkflowId:  tests.WorkflowID,
+			VersionHistories: &historyspb.VersionHistories{
+				CurrentVersionHistoryIndex: 0,
+				Histories: []*historyspb.VersionHistory{
+					{
+						BranchToken: []byte("token#1"),
+						Items: []*historyspb.VersionHistoryItem{
+							{EventId: 1, Version: common.EmptyVersion},
+						},
+					},
+				},
+			},
+			TransitionHistory: []*persistencespb.VersionedTransition{
+				{
+					NamespaceFailoverVersion: common.EmptyVersion,
+					TransitionCount:          1,
+				},
+			},
+			ExecutionStats: &persistencespb.ExecutionStats{
+				HistorySize: 128,
+			},
+		},
+		ExecutionState: &persistencespb.WorkflowExecutionState{
+			RunId:     tests.RunID,
+			State:     enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING,
+			Status:    enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			StartTime: timestamppb.New(now),
+		},
+		NextEventId: 2,
+	}
+
+	mutableState, err := NewMutableStateFromDB(
+		s.mockShard,
+		s.mockShard.MockEventsCache,
+		s.mockShard.GetLogger(),
+		tests.LocalNamespaceEntry,
+		dbState,
+		1,
+	)
+	s.NoError(err)
+	_, err = mutableState.StartTransaction(tests.LocalNamespaceEntry)
+	s.NoError(err)
+
+	mockChasmTree := historyi.NewMockChasmTree(gomock.NewController(s.T()))
+	mutableState.chasmTree = mockChasmTree
+	mockChasmTree.EXPECT().ArchetypeID().Return(chasmArchetypeID).AnyTimes()
+	mockChasmTree.EXPECT().IsStateDirty().Return(false).AnyTimes()
+	mockChasmTree.EXPECT().IsDirty().Return(false).AnyTimes()
+	mockChasmTree.EXPECT().CloseTransaction().Return(chasm.NodesMutation{}, nil).Times(1)
+
+	s.workflowContext.archetypeID = chasmArchetypeID
+	s.workflowContext.MutableState = mutableState
+
+	err = s.workflowContext.UpdateWorkflowExecutionWithNew(
+		context.Background(),
+		s.mockShard,
+		persistence.UpdateWorkflowModeIgnoreCurrent,
+		nil,
+		nil,
+		historyi.TransactionPolicyActive,
+		nil,
+	)
+	s.NoError(err)
+}

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -7488,6 +7488,13 @@ func (ms *MutableStateImpl) CloseTransactionAsMutation(
 		return nil, nil, err
 	}
 
+	if result.skipPersistence {
+		if err := ms.cleanupTransaction(); err != nil {
+			return nil, nil, err
+		}
+		return nil, nil, nil
+	}
+
 	workflowMutation := &persistence.WorkflowMutation{
 		ExecutionInfo:  ms.executionInfo,
 		ExecutionState: ms.executionState,
@@ -7613,6 +7620,7 @@ type closeTransactionResult struct {
 	workflowEventsSeq  []*persistence.WorkflowEvents
 	bufferEvents       []*historypb.HistoryEvent
 	clearBuffer        bool
+	skipPersistence    bool
 	checksum           *persistencespb.Checksum
 	chasmNodesMutation chasm.NodesMutation
 }
@@ -7749,6 +7757,12 @@ func (ms *MutableStateImpl) closeTransaction(
 		return closeTransactionResult{}, err
 	}
 
+	if ms.closeTransactionShouldSkipPersistence(chasmNodesMutation) {
+		return closeTransactionResult{
+			skipPersistence: true,
+		}, nil
+	}
+
 	ms.executionInfo.StateTransitionCount += 1
 	ms.executionInfo.LastUpdateTime = timestamppb.New(ms.timeSource.Now())
 
@@ -7772,6 +7786,10 @@ func (ms *MutableStateImpl) closeTransaction(
 		checksum:           checksum,
 		chasmNodesMutation: chasmNodesMutation,
 	}, nil
+}
+
+func (ms *MutableStateImpl) closeTransactionShouldSkipPersistence(chasmNodesMutation chasm.NodesMutation) bool {
+	return !ms.IsWorkflow() && chasmNodesMutation.IsEmpty()
 }
 
 func (ms *MutableStateImpl) closeTransactionHandleWorkflowTask(

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -7722,6 +7722,13 @@ func (ms *MutableStateImpl) closeTransaction(
 	if err != nil {
 		return closeTransactionResult{}, err
 	}
+
+	if ms.closeTransactionShouldSkipPersistence(isStateDirty, chasmNodesMutation) {
+		return closeTransactionResult{
+			skipPersistence: true,
+		}, nil
+	}
+
 	for nodePath := range chasmNodesMutation.DeletedNodes {
 		ms.approximateSize -= ms.chasmNodeSizes[nodePath]
 		delete(ms.chasmNodeSizes, nodePath)
@@ -7757,12 +7764,6 @@ func (ms *MutableStateImpl) closeTransaction(
 		return closeTransactionResult{}, err
 	}
 
-	if ms.closeTransactionShouldSkipPersistence(chasmNodesMutation) {
-		return closeTransactionResult{
-			skipPersistence: true,
-		}, nil
-	}
-
 	ms.executionInfo.StateTransitionCount += 1
 	ms.executionInfo.LastUpdateTime = timestamppb.New(ms.timeSource.Now())
 
@@ -7788,8 +7789,8 @@ func (ms *MutableStateImpl) closeTransaction(
 	}, nil
 }
 
-func (ms *MutableStateImpl) closeTransactionShouldSkipPersistence(chasmNodesMutation chasm.NodesMutation) bool {
-	return !ms.IsWorkflow() && chasmNodesMutation.IsEmpty()
+func (ms *MutableStateImpl) closeTransactionShouldSkipPersistence(isStateDirty bool, chasmNodesMutation chasm.NodesMutation) bool {
+	return !ms.IsWorkflow() && !isStateDirty && chasmNodesMutation.IsEmpty()
 }
 
 func (ms *MutableStateImpl) closeTransactionHandleWorkflowTask(

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -5024,6 +5024,87 @@ func (s *mutableStateSuite) TestCloseTransactionTrackTombstones_OnlyTrackFirstEm
 	s.Equal(int64(1), tombstoneBatches[0].VersionedTransition.TransitionCount)
 }
 
+func (s *mutableStateSuite) TestCloseTransactionAsMutation_ChasmNoopSkipsPersistence() {
+	dbState := s.buildWorkflowMutableState()
+
+	mutableState, err := NewMutableStateFromDB(s.mockShard, s.mockEventsCache, s.logger, s.namespaceEntry, dbState, 123)
+	s.NoError(err)
+
+	// First close transaction once to get rid of unrelated tasks like UserTimer and ActivityTimeout.
+	_, err = mutableState.StartTransaction(s.namespaceEntry)
+	s.NoError(err)
+	_, _, err = mutableState.CloseTransactionAsMutation(context.Background(), historyi.TransactionPolicyActive)
+	s.NoError(err)
+
+	_, err = mutableState.StartTransaction(s.namespaceEntry)
+	s.NoError(err)
+
+	mockChasmTree := historyi.NewMockChasmTree(s.controller)
+	mutableState.chasmTree = mockChasmTree
+	mockChasmTree.EXPECT().ArchetypeID().Return(chasm.WorkflowArchetypeID + 101).AnyTimes()
+	mockChasmTree.EXPECT().IsStateDirty().Return(false).AnyTimes()
+	mockChasmTree.EXPECT().IsDirty().Return(false).AnyTimes()
+	mockChasmTree.EXPECT().CloseTransaction().Return(chasm.NodesMutation{}, nil).Times(1)
+
+	stateTransitionCount := mutableState.executionInfo.StateTransitionCount
+	var lastUpdateTime *timestamppb.Timestamp
+	if mutableState.executionInfo.LastUpdateTime != nil {
+		lastUpdateTime = proto.Clone(mutableState.executionInfo.LastUpdateTime).(*timestamppb.Timestamp)
+	}
+	var checksum *persistencespb.Checksum
+	if mutableState.checksum != nil {
+		checksum = proto.Clone(mutableState.checksum).(*persistencespb.Checksum)
+	}
+	dbRecordVersion := mutableState.dbRecordVersion
+
+	mutation, eventsSeq, err := mutableState.CloseTransactionAsMutation(context.Background(), historyi.TransactionPolicyActive)
+	s.NoError(err)
+	s.Nil(mutation)
+	s.Empty(eventsSeq)
+	s.False(mutableState.IsDirty())
+	s.Equal(stateTransitionCount, mutableState.executionInfo.StateTransitionCount)
+	if lastUpdateTime == nil {
+		s.Nil(mutableState.executionInfo.LastUpdateTime)
+	} else {
+		protorequire.ProtoEqual(s.T(), lastUpdateTime, mutableState.executionInfo.LastUpdateTime)
+	}
+	if checksum == nil {
+		s.Nil(mutableState.checksum)
+	} else {
+		protorequire.ProtoEqual(s.T(), checksum, mutableState.checksum)
+	}
+	s.Equal(dbRecordVersion, mutableState.dbRecordVersion)
+}
+
+func (s *mutableStateSuite) TestCloseTransactionAsMutation_WorkflowChasmNoopDoesNotSkipPersistence() {
+	dbState := s.buildWorkflowMutableState()
+
+	mutableState, err := NewMutableStateFromDB(s.mockShard, s.mockEventsCache, s.logger, s.namespaceEntry, dbState, 123)
+	s.NoError(err)
+
+	// First close transaction once to get rid of unrelated tasks like UserTimer and ActivityTimeout.
+	_, err = mutableState.StartTransaction(s.namespaceEntry)
+	s.NoError(err)
+	_, _, err = mutableState.CloseTransactionAsMutation(context.Background(), historyi.TransactionPolicyActive)
+	s.NoError(err)
+
+	_, err = mutableState.StartTransaction(s.namespaceEntry)
+	s.NoError(err)
+
+	mockChasmTree := historyi.NewMockChasmTree(s.controller)
+	mutableState.chasmTree = mockChasmTree
+	mockChasmTree.EXPECT().ArchetypeID().Return(chasm.WorkflowArchetypeID).AnyTimes()
+	mockChasmTree.EXPECT().IsStateDirty().Return(false).AnyTimes()
+	mockChasmTree.EXPECT().CloseTransaction().Return(chasm.NodesMutation{}, nil).Times(1)
+
+	stateTransitionCount := mutableState.executionInfo.StateTransitionCount
+
+	mutation, _, err := mutableState.CloseTransactionAsMutation(context.Background(), historyi.TransactionPolicyActive)
+	s.NoError(err)
+	s.NotNil(mutation)
+	s.Equal(stateTransitionCount+1, mutableState.executionInfo.StateTransitionCount)
+}
+
 func (s *mutableStateSuite) TestCloseTransactionGenerateCHASMRetentionTask_Workflow() {
 	dbState := s.buildWorkflowMutableState()
 
@@ -5067,7 +5148,8 @@ func (s *mutableStateSuite) TestCloseTransactionGenerateCHASMRetentionTask_NonWo
 
 	mockChasmTree.EXPECT().IsStateDirty().Return(true).AnyTimes()
 	mockChasmTree.EXPECT().ArchetypeID().Return(chasm.WorkflowArchetypeID + 101).AnyTimes()
-	mockChasmTree.EXPECT().CloseTransaction().Return(chasm.NodesMutation{}, nil).AnyTimes()
+	nonEmptyMutation := chasm.NodesMutation{UpdatedNodes: map[string]*persistencespb.ChasmNode{"": {}}}
+	mockChasmTree.EXPECT().CloseTransaction().Return(nonEmptyMutation, nil).AnyTimes()
 	_, err = mutableState.UpdateWorkflowStateStatus(
 		enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
 		enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
@@ -5105,7 +5187,8 @@ func (s *mutableStateSuite) TestCloseTransactionGenerateCHASMRetentionTask_NonWo
 
 	mockChasmTree.EXPECT().IsStateDirty().Return(true).AnyTimes()
 	mockChasmTree.EXPECT().ArchetypeID().Return(chasm.WorkflowArchetypeID + 101).AnyTimes()
-	mockChasmTree.EXPECT().CloseTransaction().Return(chasm.NodesMutation{}, nil).AnyTimes()
+	nonEmptyMutation := chasm.NodesMutation{UpdatedNodes: map[string]*persistencespb.ChasmNode{"": {}}}
+	mockChasmTree.EXPECT().CloseTransaction().Return(nonEmptyMutation, nil).AnyTimes()
 	mockChasmTree.EXPECT().ApplyMutation(gomock.Any()).Return(nil).AnyTimes()
 
 	// On standby side, multiple transactions can be applied at the same time,


### PR DESCRIPTION
## What changed?
Needs more testing to see if this is safe

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
