### PR TITLE
[ES Visibility] Disallow partial results and always populate page token if results is not empty

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/client/client_v7.go
+++ b/common/persistence/visibility/store/elasticsearch/client/client_v7.go
@@ -136,7 +136,10 @@ func (c *clientImpl) Search(ctx context.Context, p *SearchParameters) (*elastic.
 		searchSource.SearchAfter(p.SearchAfter...)
 	}
 
-	return c.esClient.Search(p.Index).SearchSource(searchSource).Do(ctx)
+	return c.esClient.Search(p.Index).
+		AllowPartialSearchResults(false).
+		SearchSource(searchSource).
+		Do(ctx)
 }
 
 func (c *clientImpl) Count(ctx context.Context, index string, query elastic.Query) (int64, error) {
@@ -155,7 +158,10 @@ func (c *clientImpl) CountGroupBy(
 		Size(0).
 		TrackTotalHits(false).
 		Aggregation(aggName, agg)
-	return c.esClient.Search(index).SearchSource(searchSource).Do(ctx)
+	return c.esClient.Search(index).
+		AllowPartialSearchResults(false).
+		SearchSource(searchSource).
+		Do(ctx)
 }
 
 func (c *clientImpl) RunBulkProcessor(ctx context.Context, p *BulkProcessorParameters) (BulkProcessor, error) {

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -880,7 +880,7 @@ func (s *VisibilityStore) GetListWorkflowExecutionsResponse(
 		lastHitSort = hit.Sort
 	}
 
-	if len(searchResult.Hits.Hits) == pageSize { // this means the response might not the last page
+	if len(searchResult.Hits.Hits) > 0 { // this means the response might not the last page
 		response.NextPageToken, err = s.serializePageToken(&visibilityPageToken{
 			SearchAfter: lastHitSort,
 		})

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -680,10 +680,10 @@ func (s *ESVisibilitySuite) TestGetListWorkflowExecutionsResponse() {
 	s.Equal(serializedToken, resp.NextPageToken)
 	s.Equal(1, len(resp.Executions))
 
-	// test for last page hits
+	// test page size > number of results
 	resp, err = s.visibilityStore.GetListWorkflowExecutionsResponse(searchResult, testNamespace, 2, nil)
 	s.NoError(err)
-	s.Equal(0, len(resp.NextPageToken))
+	s.Equal(serializedToken, resp.NextPageToken)
 	s.Equal(1, len(resp.Executions))
 
 	// test for search after
@@ -701,10 +701,10 @@ func (s *ESVisibilitySuite) TestGetListWorkflowExecutionsResponse() {
 	s.NoError(err)
 	s.Equal(int64(1547596872371234567), resultSortValue)
 	s.Equal("e481009e-14b3-45ae-91af-dce6e2a88365", nextPageToken.SearchAfter[1])
-	// for last page
+	// test page size > number of results
 	resp, err = s.visibilityStore.GetListWorkflowExecutionsResponse(searchResult, testNamespace, numOfHits+1, nil)
 	s.NoError(err)
-	s.Equal(0, len(resp.NextPageToken))
+	s.Equal(serializedToken, resp.NextPageToken)
 	s.Equal(numOfHits, len(resp.Executions))
 }
 


### PR DESCRIPTION
## What changed?
- Disable partial results from ES searches.
- Populate page token whenever the page results is non-empty.

## Why?
Prevent early termination when paginating over results: failed shards might produce partial results, which can produce page results to be smaller than the page size, and preventing the page token from being populated.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

