### PR TITLE
Fix concurrent map write when cacheSizeBasedLimit is enabled

### DIFF
--- a/service/history/interfaces/workflow_context.go
+++ b/service/history/interfaces/workflow_context.go
@@ -33,6 +33,11 @@ type (
 
 		IsDirty() bool
 
+		// RefreshCacheSize recomputes this context's cached size estimate for
+		// size-based cache limits. It reads lock-guarded state, so it must be
+		// called under the workflow lock.
+		RefreshCacheSize()
+
 		RefreshTasks(ctx context.Context, shardContext ShardContext) error
 
 		ReapplyEvents(

--- a/service/history/interfaces/workflow_context.go
+++ b/service/history/interfaces/workflow_context.go
@@ -35,6 +35,11 @@ type (
 
 		IsDirty() bool
 
+		// RefreshCacheSize recomputes this context's cached size estimate for
+		// size-based cache limits. It reads lock-guarded state, so it must be
+		// called under the workflow lock.
+		RefreshCacheSize()
+
 		RefreshTasks(ctx context.Context, shardContext ShardContext) error
 
 		ReapplyEvents(

--- a/service/history/interfaces/workflow_context_mock.go
+++ b/service/history/interfaces/workflow_context_mock.go
@@ -206,6 +206,18 @@ func (mr *MockWorkflowContextMockRecorder) ReapplyEvents(ctx, shardContext, even
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReapplyEvents", reflect.TypeOf((*MockWorkflowContext)(nil).ReapplyEvents), ctx, shardContext, eventBatches)
 }
 
+// RefreshCacheSize mocks base method.
+func (m *MockWorkflowContext) RefreshCacheSize() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RefreshCacheSize")
+}
+
+// RefreshCacheSize indicates an expected call of RefreshCacheSize.
+func (mr *MockWorkflowContextMockRecorder) RefreshCacheSize() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshCacheSize", reflect.TypeOf((*MockWorkflowContext)(nil).RefreshCacheSize))
+}
+
 // RefreshTasks mocks base method.
 func (m *MockWorkflowContext) RefreshTasks(ctx context.Context, shardContext ShardContext) error {
 	m.ctrl.T.Helper()

--- a/service/history/interfaces/workflow_context_mock.go
+++ b/service/history/interfaces/workflow_context_mock.go
@@ -237,6 +237,18 @@ func (mr *MockWorkflowContextMockRecorder) ReapplyEvents(ctx, shardContext, even
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReapplyEvents", reflect.TypeOf((*MockWorkflowContext)(nil).ReapplyEvents), ctx, shardContext, eventBatches)
 }
 
+// RefreshCacheSize mocks base method.
+func (m *MockWorkflowContext) RefreshCacheSize() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RefreshCacheSize")
+}
+
+// RefreshCacheSize indicates an expected call of RefreshCacheSize.
+func (mr *MockWorkflowContextMockRecorder) RefreshCacheSize() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshCacheSize", reflect.TypeOf((*MockWorkflowContext)(nil).RefreshCacheSize))
+}
+
 // RefreshTasks mocks base method.
 func (m *MockWorkflowContext) RefreshTasks(ctx context.Context, shardContext ShardContext) error {
 	m.ctrl.T.Helper()

--- a/service/history/ndc/activity_state_replicator_test.go
+++ b/service/history/ndc/activity_state_replicator_test.go
@@ -643,6 +643,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivity_WorkflowClosed() {
 	weContext.EXPECT().LoadMutableState(gomock.Any(), s.mockShard).Return(s.mockMutableState, nil)
 	weContext.EXPECT().Lock(gomock.Any(), locks.PriorityHigh).Return(nil)
 	weContext.EXPECT().Clear().AnyTimes()
+	weContext.EXPECT().RefreshCacheSize()
 	weContext.EXPECT().Unlock()
 	weContext.EXPECT().IsDirty().Return(false).AnyTimes()
 
@@ -723,6 +724,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivities_WorkflowClosed() {
 	weContext := historyi.NewMockWorkflowContext(s.controller)
 	weContext.EXPECT().LoadMutableState(gomock.Any(), s.mockShard).Return(s.mockMutableState, nil)
 	weContext.EXPECT().Lock(gomock.Any(), locks.PriorityHigh).Return(nil)
+	weContext.EXPECT().RefreshCacheSize()
 	weContext.EXPECT().Unlock()
 	weContext.EXPECT().IsDirty().Return(false).AnyTimes()
 	weContext.EXPECT().Clear().AnyTimes()
@@ -809,6 +811,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivity_ActivityNotFound() {
 	weContext.EXPECT().LoadMutableState(gomock.Any(), s.mockShard).Return(s.mockMutableState, nil)
 	weContext.EXPECT().Lock(gomock.Any(), locks.PriorityHigh).Return(nil)
 	weContext.EXPECT().Clear().AnyTimes()
+	weContext.EXPECT().RefreshCacheSize()
 	weContext.EXPECT().Unlock()
 	weContext.EXPECT().IsDirty().Return(false).AnyTimes()
 
@@ -890,6 +893,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivities_ActivityNotFound() {
 	weContext := historyi.NewMockWorkflowContext(s.controller)
 	weContext.EXPECT().LoadMutableState(gomock.Any(), s.mockShard).Return(s.mockMutableState, nil)
 	weContext.EXPECT().Lock(gomock.Any(), locks.PriorityHigh).Return(nil)
+	weContext.EXPECT().RefreshCacheSize()
 	weContext.EXPECT().Unlock()
 	weContext.EXPECT().IsDirty().Return(false).AnyTimes()
 	weContext.EXPECT().Clear().AnyTimes()
@@ -976,6 +980,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivity_ActivityFound_Zombie() {
 	weContext := historyi.NewMockWorkflowContext(s.controller)
 	weContext.EXPECT().LoadMutableState(gomock.Any(), s.mockShard).Return(s.mockMutableState, nil)
 	weContext.EXPECT().Lock(gomock.Any(), locks.PriorityHigh).Return(nil)
+	weContext.EXPECT().RefreshCacheSize()
 	weContext.EXPECT().Unlock()
 	weContext.EXPECT().IsDirty().Return(false).AnyTimes()
 
@@ -1079,6 +1084,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivities_ActivityFound_Zombie()
 	weContext := historyi.NewMockWorkflowContext(s.controller)
 	weContext.EXPECT().LoadMutableState(gomock.Any(), s.mockShard).Return(s.mockMutableState, nil)
 	weContext.EXPECT().Lock(gomock.Any(), locks.PriorityHigh).Return(nil)
+	weContext.EXPECT().RefreshCacheSize()
 	weContext.EXPECT().Unlock()
 	weContext.EXPECT().IsDirty().Return(false).AnyTimes()
 
@@ -1185,6 +1191,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivity_ActivityFound_NonZombie(
 	weContext := historyi.NewMockWorkflowContext(s.controller)
 	weContext.EXPECT().LoadMutableState(gomock.Any(), s.mockShard).Return(s.mockMutableState, nil)
 	weContext.EXPECT().Lock(gomock.Any(), locks.PriorityHigh).Return(nil)
+	weContext.EXPECT().RefreshCacheSize()
 	weContext.EXPECT().Unlock()
 	weContext.EXPECT().IsDirty().Return(false).AnyTimes()
 
@@ -1287,6 +1294,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivities_ActivityFound_NonZombi
 	weContext := historyi.NewMockWorkflowContext(s.controller)
 	weContext.EXPECT().LoadMutableState(gomock.Any(), s.mockShard).Return(s.mockMutableState, nil)
 	weContext.EXPECT().Lock(gomock.Any(), locks.PriorityHigh).Return(nil)
+	weContext.EXPECT().RefreshCacheSize()
 	weContext.EXPECT().Unlock()
 	weContext.EXPECT().IsDirty().Return(false).AnyTimes()
 

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -720,6 +720,7 @@ func (s *workflowResetterSuite) TestReapplyContinueAsNewWorkflowEvents_WithConti
 
 	resetContext := historyi.NewMockWorkflowContext(s.controller)
 	resetContext.EXPECT().Lock(gomock.Any(), locks.PriorityHigh).Return(nil)
+	resetContext.EXPECT().RefreshCacheSize()
 	resetContext.EXPECT().Unlock()
 	resetContext.EXPECT().IsDirty().Return(false).AnyTimes()
 	resetMutableState := historyi.NewMockMutableState(s.controller)

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -812,6 +812,7 @@ func (s *workflowResetterSuite) TestReapplyContinueAsNewWorkflowEvents_WithConti
 
 	resetContext := historyi.NewMockWorkflowContext(s.controller)
 	resetContext.EXPECT().Lock(gomock.Any(), locks.PriorityHigh).Return(nil)
+	resetContext.EXPECT().RefreshCacheSize()
 	resetContext.EXPECT().Unlock()
 	resetContext.EXPECT().IsDirty().Return(false).AnyTimes()
 	resetMutableState := historyi.NewMockMutableState(s.controller)
@@ -906,6 +907,7 @@ func (s *workflowResetterSuite) TestReapplyContinueAsNewWorkflowEvents_MissingCu
 	// runB survives and loads.
 	runBContext := historyi.NewMockWorkflowContext(s.controller)
 	runBContext.EXPECT().Lock(gomock.Any(), locks.PriorityHigh).Return(nil)
+	runBContext.EXPECT().RefreshCacheSize()
 	runBContext.EXPECT().Unlock()
 	runBContext.EXPECT().IsDirty().Return(false).AnyTimes()
 	runBMutableState := historyi.NewMockMutableState(s.controller)
@@ -917,6 +919,7 @@ func (s *workflowResetterSuite) TestReapplyContinueAsNewWorkflowEvents_MissingCu
 	// runC was deleted; loading it truncates the chain.
 	runCContext := historyi.NewMockWorkflowContext(s.controller)
 	runCContext.EXPECT().Lock(gomock.Any(), locks.PriorityHigh).Return(nil)
+	runCContext.EXPECT().RefreshCacheSize()
 	runCContext.EXPECT().Unlock()
 	runCContext.EXPECT().IsDirty().Return(false).AnyTimes()
 	runCContext.EXPECT().Clear().AnyTimes()
@@ -971,6 +974,7 @@ func (s *workflowResetterSuite) TestReapplyContinueAsNewWorkflowEvents_MissingCu
 
 	runBContext := historyi.NewMockWorkflowContext(s.controller)
 	runBContext.EXPECT().Lock(gomock.Any(), locks.PriorityHigh).Return(nil)
+	runBContext.EXPECT().RefreshCacheSize()
 	runBContext.EXPECT().Unlock()
 	runBContext.EXPECT().IsDirty().Return(false).AnyTimes()
 	runBContext.EXPECT().Clear().AnyTimes()

--- a/service/history/workflow/cache/cache.go
+++ b/service/history/workflow/cache/cache.go
@@ -364,6 +364,7 @@ func (c *cacheImpl) makeReleaseFunc(
 			}()
 			if rec := recover(); rec != nil {
 				wfContext.Clear()
+				wfContext.RefreshCacheSize()
 				wfContext.Unlock()
 				c.Release(cacheKey)
 				panic(rec)
@@ -371,6 +372,7 @@ func (c *cacheImpl) makeReleaseFunc(
 				if err != nil || forceClearContext {
 					// TODO see issue #668, there are certain type or errors which can bypass the clear
 					wfContext.Clear()
+					wfContext.RefreshCacheSize()
 					wfContext.Unlock()
 					c.Release(cacheKey)
 				} else {
@@ -384,6 +386,7 @@ func (c *cacheImpl) makeReleaseFunc(
 							tag.WorkflowRunID(wfContext.GetWorkflowKey().RunID),
 						)
 					}
+					wfContext.RefreshCacheSize()
 					wfContext.Unlock()
 					c.Release(cacheKey)
 					if isDirty {

--- a/service/history/workflow/cache/cache.go
+++ b/service/history/workflow/cache/cache.go
@@ -373,6 +373,7 @@ func (c *cacheImpl) makeReleaseFunc(
 			}()
 			if rec := recover(); rec != nil {
 				wfContext.Clear()
+				wfContext.RefreshCacheSize()
 				wfContext.Unlock()
 				c.Release(cacheKey)
 				panic(rec)
@@ -380,6 +381,7 @@ func (c *cacheImpl) makeReleaseFunc(
 				if err != nil || forceClearContext {
 					// TODO see issue #668, there are certain type or errors which can bypass the clear
 					wfContext.Clear()
+					wfContext.RefreshCacheSize()
 					wfContext.Unlock()
 					c.Release(cacheKey)
 				} else {
@@ -393,6 +395,7 @@ func (c *cacheImpl) makeReleaseFunc(
 							tag.WorkflowRunID(wfContext.GetWorkflowKey().RunID),
 						)
 					}
+					wfContext.RefreshCacheSize()
 					wfContext.Unlock()
 					c.Release(cacheKey)
 					if isDirty {

--- a/service/history/workflow/cache/cache_test.go
+++ b/service/history/workflow/cache/cache_test.go
@@ -891,3 +891,43 @@ func (s *workflowCacheSuite) TestCacheImpl_GetCurrentRunID_NoCurrentRun() {
 	s.Nil(ctx)
 	s.Nil(release)
 }
+
+func (s *workflowCacheSuite) TestMakeReleaseFunc_RefreshesCacheSizeBeforeUnlock() {
+	c := NewHostLevelCache(s.mockShard.GetConfig(), s.mockShard.GetLogger(), metrics.NoopMetricsHandler).(*cacheImpl)
+	key := Key{WorkflowKey: tests.WorkflowKey}
+
+	// RefreshCacheSize must run before Unlock in every release path: the LRU reads
+	// CacheSize lock-free on release, so refreshing after Unlock would reintroduce
+	// the concurrent-map-write crash. Assert the ordering for all three paths.
+
+	// Clean path: not dirty, no error.
+	cleanCtx := historyi.NewMockWorkflowContext(s.controller)
+	gomock.InOrder(
+		cleanCtx.EXPECT().IsDirty().Return(false),
+		cleanCtx.EXPECT().RefreshCacheSize(),
+		cleanCtx.EXPECT().Unlock(),
+	)
+	c.makeReleaseFunc(key, s.mockShard, cleanCtx, false, metrics.NoopMetricsHandler, time.Now())(nil)
+
+	// Error path: Clear runs first, but the refresh still happens before Unlock.
+	errCtx := historyi.NewMockWorkflowContext(s.controller)
+	gomock.InOrder(
+		errCtx.EXPECT().Clear(),
+		errCtx.EXPECT().RefreshCacheSize(),
+		errCtx.EXPECT().Unlock(),
+	)
+	c.makeReleaseFunc(key, s.mockShard, errCtx, false, metrics.NoopMetricsHandler, time.Now())(errors.New("release error"))
+
+	// Panic path: refresh under the lock before Unlock, then re-raise.
+	panicCtx := historyi.NewMockWorkflowContext(s.controller)
+	gomock.InOrder(
+		panicCtx.EXPECT().Clear(),
+		panicCtx.EXPECT().RefreshCacheSize(),
+		panicCtx.EXPECT().Unlock(),
+	)
+	s.PanicsWithValue("boom", func() {
+		release := c.makeReleaseFunc(key, s.mockShard, panicCtx, false, metrics.NoopMetricsHandler, time.Now())
+		defer release(nil)
+		panic("boom")
+	})
+}

--- a/service/history/workflow/cache/cache_test.go
+++ b/service/history/workflow/cache/cache_test.go
@@ -974,3 +974,43 @@ func (s *workflowCacheSuite) TestCacheImpl_GetCurrentRunID_NoCurrentRun() {
 	s.Nil(ctx)
 	s.Nil(release)
 }
+
+func (s *workflowCacheSuite) TestMakeReleaseFunc_RefreshesCacheSizeBeforeUnlock() {
+	c := NewHostLevelCache(s.mockShard.GetConfig(), s.mockShard.GetLogger(), metrics.NoopMetricsHandler).(*cacheImpl)
+	key := Key{WorkflowKey: tests.WorkflowKey}
+
+	// RefreshCacheSize must run before Unlock in every release path: the LRU reads
+	// CacheSize lock-free on release, so refreshing after Unlock would reintroduce
+	// the concurrent-map-write crash. Assert the ordering for all three paths.
+
+	// Clean path: not dirty, no error.
+	cleanCtx := historyi.NewMockWorkflowContext(s.controller)
+	gomock.InOrder(
+		cleanCtx.EXPECT().IsDirty().Return(false),
+		cleanCtx.EXPECT().RefreshCacheSize(),
+		cleanCtx.EXPECT().Unlock(),
+	)
+	c.makeReleaseFunc(key, s.mockShard, cleanCtx, false, metrics.NoopMetricsHandler, time.Now())(nil)
+
+	// Error path: Clear runs first, but the refresh still happens before Unlock.
+	errCtx := historyi.NewMockWorkflowContext(s.controller)
+	gomock.InOrder(
+		errCtx.EXPECT().Clear(),
+		errCtx.EXPECT().RefreshCacheSize(),
+		errCtx.EXPECT().Unlock(),
+	)
+	c.makeReleaseFunc(key, s.mockShard, errCtx, false, metrics.NoopMetricsHandler, time.Now())(errors.New("release error"))
+
+	// Panic path: refresh under the lock before Unlock, then re-raise.
+	panicCtx := historyi.NewMockWorkflowContext(s.controller)
+	gomock.InOrder(
+		panicCtx.EXPECT().Clear(),
+		panicCtx.EXPECT().RefreshCacheSize(),
+		panicCtx.EXPECT().Unlock(),
+	)
+	s.PanicsWithValue("boom", func() {
+		release := c.makeReleaseFunc(key, s.mockShard, panicCtx, false, metrics.NoopMetricsHandler, time.Now())
+		defer release(nil)
+		panic("boom")
+	})
+}

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"strconv"
+	"sync/atomic"
 
 	"go.opentelemetry.io/otel/trace"
 	commonpb "go.temporal.io/api/common/v1"
@@ -42,6 +43,10 @@ type (
 		lock           locks.PrioritySemaphore
 		MutableState   historyi.MutableState
 		updateRegistry update.Registry
+
+		// cacheSize holds the size last computed by RefreshCacheSize. CacheSize
+		// reads it without the workflow lock, so access must be atomic.
+		cacheSize atomic.Int64
 	}
 )
 
@@ -76,6 +81,10 @@ func NewContext(
 		contextImpl.archetypeID != chasm.UnspecifiedArchetypeID,
 		"Creating execution context with unspecified archetype ID",
 	)
+
+	// Seed the size while the context is unshared; MutableState and the update
+	// registry are still nil, so this reads no lock-guarded state.
+	contextImpl.RefreshCacheSize()
 
 	return contextImpl
 }
@@ -1204,11 +1213,23 @@ func (c *ContextImpl) forceTerminateWorkflow(
 	)
 }
 
-// CacheSize estimates the in-memory size of the object for cache limits. For proto objects, it uses proto.Size()
-// which returns the serialized size. Note: In-memory size will be slightly larger than the serialized size.
+// CacheSize returns the cache-limit size estimate. It runs without the workflow
+// lock, so it returns the value last computed by RefreshCacheSize rather than
+// reading mutable state or the update registry live.
 func (c *ContextImpl) CacheSize() int {
 	if !c.config.HistoryCacheLimitSizeBased {
 		return 1
+	}
+	return int(c.cacheSize.Load())
+}
+
+// RefreshCacheSize recomputes the cache-limit size estimate and stores it for
+// CacheSize to read lock-free. It reads mutable state and the update registry,
+// so it must run under the workflow lock, or before the context is shared.
+// The estimate uses serialized proto sizes, a bit under the in-memory size.
+func (c *ContextImpl) RefreshCacheSize() {
+	if !c.config.HistoryCacheLimitSizeBased {
+		return
 	}
 	size := len(c.workflowKey.WorkflowID) + len(c.workflowKey.RunID) + len(c.workflowKey.NamespaceID)
 	if c.MutableState != nil {
@@ -1217,7 +1238,7 @@ func (c *ContextImpl) CacheSize() int {
 	if c.updateRegistry != nil {
 		size += c.updateRegistry.GetSize()
 	}
-	return size
+	c.cacheSize.Store(int64(size))
 }
 
 func emitStateTransitionCount(

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strconv"
+	"sync/atomic"
 
 	"go.opentelemetry.io/otel/trace"
 	commandpb "go.temporal.io/api/command/v1"
@@ -55,6 +56,10 @@ type (
 		// paginationLimiter enforces the process-wide and per-namespace limits on the
 		// total size of all in-flight pagination buffers. nil is treated as "no limit".
 		paginationLimiter *limiter.KeyedBytesLimiter
+
+		// cacheSize holds the size last computed by RefreshCacheSize. CacheSize
+		// reads it without the workflow lock, so access must be atomic.
+		cacheSize atomic.Int64
 	}
 
 	// workflowTaskIdentity identifies a specific workflow task attempt
@@ -120,6 +125,10 @@ func NewContext(
 		contextImpl.archetypeID != chasm.UnspecifiedArchetypeID,
 		"Creating execution context with unspecified archetype ID",
 	)
+
+	// Seed the size while the context is unshared; MutableState and the update
+	// registry are still nil, so this reads no lock-guarded state.
+	contextImpl.RefreshCacheSize()
 
 	return contextImpl
 }
@@ -1451,11 +1460,23 @@ func (c *ContextImpl) forceTerminateWorkflow(
 	)
 }
 
-// CacheSize estimates the in-memory size of the object for cache limits. For proto objects, it uses proto.Size()
-// which returns the serialized size. Note: In-memory size will be slightly larger than the serialized size.
+// CacheSize returns the cache-limit size estimate. It runs without the workflow
+// lock, so it returns the value last computed by RefreshCacheSize rather than
+// reading mutable state or the update registry live.
 func (c *ContextImpl) CacheSize() int {
 	if !c.config.HistoryCacheLimitSizeBased {
 		return 1
+	}
+	return int(c.cacheSize.Load())
+}
+
+// RefreshCacheSize recomputes the cache-limit size estimate and stores it for
+// CacheSize to read lock-free. It reads mutable state and the update registry,
+// so it must run under the workflow lock, or before the context is shared.
+// The estimate uses serialized proto sizes, a bit under the in-memory size.
+func (c *ContextImpl) RefreshCacheSize() {
+	if !c.config.HistoryCacheLimitSizeBased {
+		return
 	}
 	size := len(c.workflowKey.WorkflowID) + len(c.workflowKey.RunID) + len(c.workflowKey.NamespaceID)
 	if c.MutableState != nil {
@@ -1464,7 +1485,7 @@ func (c *ContextImpl) CacheSize() int {
 	if c.updateRegistry != nil {
 		size += c.updateRegistry.GetSize()
 	}
-	return size
+	c.cacheSize.Store(int64(size))
 }
 
 func emitStateTransitionCount(

--- a/service/history/workflow/context_test.go
+++ b/service/history/workflow/context_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -10,6 +11,8 @@ import (
 	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
+	"go.temporal.io/api/serviceerror"
+	updatepb "go.temporal.io/api/update/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	historyspb "go.temporal.io/server/api/history/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
@@ -25,6 +28,7 @@ import (
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/service/history/tests"
+	"go.temporal.io/server/service/history/workflow/update"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -649,4 +653,114 @@ func (s *contextSuite) TestUpdateWorkflowExecutionWithNew_ChasmNoopSkipsPersiste
 		nil,
 	)
 	s.NoError(err)
+}
+
+func (s *contextSuite) TestCacheSize_CountBasedLimit() {
+	// Size-based limit off (default): CacheSize is the constant 1, RefreshCacheSize a no-op.
+	s.False(s.workflowContext.config.HistoryCacheLimitSizeBased)
+	s.Equal(1, s.workflowContext.CacheSize())
+	s.workflowContext.RefreshCacheSize()
+	s.Equal(1, s.workflowContext.CacheSize())
+}
+
+func (s *contextSuite) TestCacheSize_SizeBasedLimit() {
+	config := tests.NewDynamicConfig()
+	config.HistoryCacheLimitSizeBased = true
+	wfContext := NewContext(
+		config,
+		tests.WorkflowKey,
+		chasm.WorkflowArchetypeID,
+		log.NewNoopLogger(),
+		log.NewNoopLogger(),
+		metrics.NoopMetricsHandler,
+	)
+
+	// NewContext seeds the size from the workflow key (mutable state/registry not loaded yet).
+	baseline := len(tests.WorkflowKey.WorkflowID) + len(tests.WorkflowKey.RunID) + len(tests.WorkflowKey.NamespaceID)
+	s.Equal(baseline, wfContext.CacheSize())
+
+	// CacheSize must stay at baseline until RefreshCacheSize runs: it returns the
+	// cached value lock-free, never reading mutable state live. So
+	// GetApproximatePersistedSize is expected exactly once, from RefreshCacheSize.
+	controller := gomock.NewController(s.T())
+	mockMS := historyi.NewMockMutableState(controller)
+	mockMS.EXPECT().GetApproximatePersistedSize().Return(900).Times(1)
+	wfContext.MutableState = mockMS
+
+	s.Equal(baseline, wfContext.CacheSize())
+
+	wfContext.RefreshCacheSize()
+	s.Equal(baseline+900, wfContext.CacheSize())
+}
+
+func (s *contextSuite) TestCacheSize_ConcurrentReadWriteIsRaceFree() {
+	// CacheSize reads lock-free while RefreshCacheSize writes under the lock, so
+	// cacheSize must be atomic. Run with -race to catch non-atomic regressions.
+	config := tests.NewDynamicConfig()
+	config.HistoryCacheLimitSizeBased = true
+	wfContext := NewContext(
+		config,
+		tests.WorkflowKey,
+		chasm.WorkflowArchetypeID,
+		log.NewNoopLogger(),
+		log.NewNoopLogger(),
+		metrics.NoopMetricsHandler,
+	)
+
+	const iterations = 1000
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			wfContext.RefreshCacheSize()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = wfContext.CacheSize()
+		}
+	}()
+	wg.Wait()
+}
+
+// fakeUpdateStore is a no-op update.UpdateStore for building a real update.Registry
+// in tests, mirroring the update package's own emptyUpdateStore. GetUpdateOutcome
+// returns NotFound so the registry treats an unknown ID as new and creates it.
+type fakeUpdateStore struct{}
+
+func (fakeUpdateStore) VisitUpdates(func(updID string, updInfo *persistencespb.UpdateInfo)) {}
+func (fakeUpdateStore) GetUpdateOutcome(context.Context, string) (*updatepb.Outcome, error) {
+	return nil, serviceerror.NewNotFound("not found")
+}
+func (fakeUpdateStore) GetCurrentVersion() int64         { return 0 }
+func (fakeUpdateStore) IsWorkflowExecutionRunning() bool { return true }
+
+func (s *contextSuite) TestCacheSize_IncludesUpdateRegistry() {
+	config := tests.NewDynamicConfig()
+	config.HistoryCacheLimitSizeBased = true
+	wfContext := NewContext(
+		config,
+		tests.WorkflowKey,
+		chasm.WorkflowArchetypeID,
+		log.NewNoopLogger(),
+		log.NewNoopLogger(),
+		metrics.NoopMetricsHandler,
+	)
+	baseline := len(tests.WorkflowKey.WorkflowID) + len(tests.WorkflowKey.RunID) + len(tests.WorkflowKey.NamespaceID)
+
+	// The update registry is the state whose lock-free iteration caused the crash.
+	// CacheSize must keep returning the seeded baseline until RefreshCacheSize folds
+	// the registry size in under the workflow lock — never reading the registry live.
+	reg := update.NewRegistry(fakeUpdateStore{})
+	_, _, err := reg.FindOrCreate(context.Background(), "update-id")
+	s.NoError(err)
+	wfContext.updateRegistry = reg
+	s.NotZero(reg.GetSize())
+
+	s.Equal(baseline, wfContext.CacheSize())
+
+	wfContext.RefreshCacheSize()
+	s.Equal(baseline+reg.GetSize(), wfContext.CacheSize())
 }

--- a/service/history/workflow/context_test.go
+++ b/service/history/workflow/context_test.go
@@ -2,6 +2,8 @@ package workflow
 
 import (
 	"context"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -12,6 +14,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
+	updatepb "go.temporal.io/api/update/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	historyspb "go.temporal.io/server/api/history/v1"
@@ -21,6 +24,7 @@ import (
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/limiter"
+	"go.temporal.io/server/common/locks"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
@@ -29,6 +33,7 @@ import (
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/service/history/tests"
+	"go.temporal.io/server/service/history/workflow/update"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -846,4 +851,129 @@ func (s *contextSuite) TestTaskCompletionBuffer_BudgetReleasedOnMergeAndClear() 
 	s.Positive(budget.Used())
 	s.workflowContext.Clear()
 	s.Equal(int64(0), budget.Used())
+}
+
+func (s *contextSuite) TestCacheSize_CountBasedLimit() {
+	// Size-based limit off (default): CacheSize is the constant 1, RefreshCacheSize a no-op.
+	s.False(s.workflowContext.config.HistoryCacheLimitSizeBased)
+	s.Equal(1, s.workflowContext.CacheSize())
+	s.workflowContext.RefreshCacheSize()
+	s.Equal(1, s.workflowContext.CacheSize())
+}
+
+func (s *contextSuite) TestCacheSize_SizeBasedLimit() {
+	config := tests.NewDynamicConfig()
+	config.HistoryCacheLimitSizeBased = true
+	wfContext := NewContext(
+		config,
+		tests.WorkflowKey,
+		chasm.WorkflowArchetypeID,
+		log.NewNoopLogger(),
+		log.NewNoopLogger(),
+		metrics.NoopMetricsHandler,
+		nil,
+	)
+
+	// NewContext seeds the size from the workflow key (mutable state/registry not loaded yet).
+	baseline := len(tests.WorkflowKey.WorkflowID) + len(tests.WorkflowKey.RunID) + len(tests.WorkflowKey.NamespaceID)
+	s.Equal(baseline, wfContext.CacheSize())
+
+	// CacheSize must stay at baseline until RefreshCacheSize runs: it returns the
+	// cached value lock-free, never reading mutable state live. So
+	// GetApproximatePersistedSize is expected exactly once, from RefreshCacheSize.
+	controller := gomock.NewController(s.T())
+	mockMS := historyi.NewMockMutableState(controller)
+	mockMS.EXPECT().GetApproximatePersistedSize().Return(900).Times(1)
+	wfContext.MutableState = mockMS
+
+	s.Equal(baseline, wfContext.CacheSize())
+
+	wfContext.RefreshCacheSize()
+	s.Equal(baseline+900, wfContext.CacheSize())
+}
+
+func (s *contextSuite) TestCacheSize_ConcurrentReadWriteIsRaceFree() {
+	// CacheSize reads lock-free while RefreshCacheSize writes under the lock, so
+	// cacheSize must be atomic. Run with -race to catch non-atomic regressions.
+	config := tests.NewDynamicConfig()
+	config.HistoryCacheLimitSizeBased = true
+	wfContext := NewContext(
+		config,
+		tests.WorkflowKey,
+		chasm.WorkflowArchetypeID,
+		log.NewNoopLogger(),
+		log.NewNoopLogger(),
+		metrics.NoopMetricsHandler,
+		nil,
+	)
+	reg := update.NewRegistry(fakeUpdateStore{})
+	wfContext.updateRegistry = reg
+
+	const iterations = 1000
+	var wg sync.WaitGroup
+	writerErr := make(chan error, 1)
+	wg.Go(func() {
+		for i := 0; i < iterations; i++ {
+			if err := wfContext.Lock(context.Background(), locks.PriorityHigh); err != nil {
+				writerErr <- err
+				return
+			}
+			if _, _, err := reg.FindOrCreate(context.Background(), strconv.Itoa(i)); err != nil {
+				wfContext.Unlock()
+				writerErr <- err
+				return
+			}
+			wfContext.RefreshCacheSize()
+			wfContext.Unlock()
+		}
+		writerErr <- nil
+	})
+	wg.Go(func() {
+		for i := 0; i < iterations; i++ {
+			_ = wfContext.CacheSize()
+		}
+	})
+	wg.Wait()
+	s.Require().NoError(<-writerErr)
+}
+
+// fakeUpdateStore is a no-op update.UpdateStore for building a real update.Registry
+// in tests, mirroring the update package's own emptyUpdateStore. GetUpdateOutcome
+// returns NotFound so the registry treats an unknown ID as new and creates it.
+type fakeUpdateStore struct{}
+
+func (fakeUpdateStore) VisitUpdates(func(updID string, updInfo *persistencespb.UpdateInfo)) {}
+func (fakeUpdateStore) GetUpdateOutcome(context.Context, string) (*updatepb.Outcome, error) {
+	return nil, serviceerror.NewNotFound("not found")
+}
+func (fakeUpdateStore) GetCurrentVersion() int64         { return 0 }
+func (fakeUpdateStore) IsWorkflowExecutionRunning() bool { return true }
+
+func (s *contextSuite) TestCacheSize_IncludesUpdateRegistry() {
+	config := tests.NewDynamicConfig()
+	config.HistoryCacheLimitSizeBased = true
+	wfContext := NewContext(
+		config,
+		tests.WorkflowKey,
+		chasm.WorkflowArchetypeID,
+		log.NewNoopLogger(),
+		log.NewNoopLogger(),
+		metrics.NoopMetricsHandler,
+		nil,
+	)
+	baseline := len(tests.WorkflowKey.WorkflowID) + len(tests.WorkflowKey.RunID) + len(tests.WorkflowKey.NamespaceID)
+
+	// The update registry is the state whose lock-free iteration caused the crash.
+	// CacheSize must keep returning the seeded baseline until RefreshCacheSize folds
+	// the registry size in under the workflow lock — never reading the registry live.
+	reg := update.NewRegistry(fakeUpdateStore{})
+	_, _, err := reg.FindOrCreate(context.Background(), "update-id")
+	s.Require().NoError(err)
+	wfContext.updateRegistry = reg
+	s.NotZero(reg.GetSize())
+
+	s.Equal(baseline, wfContext.CacheSize())
+
+	wfContext.RefreshCacheSize()
+	s.Equal(baseline+reg.GetSize(), wfContext.CacheSize())
 }


### PR DESCRIPTION
## What changed?

Fixes #10548.

Recompute the workflow cache size while the workflow lock is held and cache it for lock-free reads, instead of computing it after the lock is released.

- `ContextImpl.RefreshCacheSize()` recomputes the estimate into an `atomic.Int64`; `CacheSize()` returns that cached value.
- `makeReleaseFunc` calls it before `Unlock()` in every release path; `NewContext` seeds it.
- Added to the `WorkflowContext` interface (and its generated mock).

## Why?

With `history.cacheSizeBasedLimit` enabled, the release path computed `CacheSize()` after `Unlock()`. `CacheSize()` iterates the update registry's `updates` map, which is guarded only by the workflow lock, so once the lock was released a concurrent writer could race the iteration:

```
fatal error: concurrent map iteration and map write
```

Go raises this as a runtime fatal, not a recoverable panic, so the `recover()` in `makeReleaseFunc` cannot catch it and the history service crashes. Computing the size while the lock is held removes the lock-free read. The limit is off by default.

## How did you test it?
- [x] built
  - `go build`, `go vet`, and `gofmt` are clean for the affected packages, and `go test -race ./service/history/...` passes; the full temporal-server binary was built for the manual run.
- [x] run locally and tested manually
  - Ran the history service locally (SQLite) with `history.cacheSizeBasedLimit` enabled and drove 2000 concurrent updates against a single workflow, so the update registry grew to 2000 entries and `GetSize()` iterated a large map under contention.
  - All updates succeeded, the service stayed up, and no `concurrent map` fatal appeared in the logs.
- [x] covered by existing tests
- [x] added new unit test(s)
  - `TestMakeReleaseFunc_RefreshesCacheSizeBeforeUnlock`: pins `RefreshCacheSize()` before `Unlock()` in every release path (the ordering that prevents the crash).
  - `TestCacheSize_SizeBasedLimit` and `TestCacheSize_IncludesUpdateRegistry`: `CacheSize()` returns the cached value and never reads mutable state or the registry live (each backing read happens once, from `RefreshCacheSize()`).
  - `TestCacheSize_ConcurrentReadWriteIsRaceFree`: concurrent read and write of the cached size is race-free under `-race`.
  - `TestCacheSize_CountBasedLimit`: when the limit is off, `CacheSize()` stays `1` and `RefreshCacheSize()` is a no-op.
  - Also updated existing ndc tests (`activity_state_replicator_test.go`, `workflow_resetter_test.go`) to expect the new `RefreshCacheSize()` call on the release path.
- [ ] added new functional test(s)

## Potential risks

The existing cache-sizing design is preserved:

- `CacheSize()` is now a cached read, but the LRU only samples entry size at `Put` and `Release`, so cache accounting is unchanged.
- No-op when `history.cacheSizeBasedLimit` is disabled (the default).

The one behavioral change is that the size is computed inside the workflow lock instead of after release, which marginally increases lock-hold time for workflows with a large update registry or mutable state.
