### PR TITLE
Fixed reading of Nexus namespace ID

### DIFF
--- a/common/nexus/callback_token.go
+++ b/common/nexus/callback_token.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	"go.temporal.io/api/serviceerror"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -89,6 +90,28 @@ func validateCompletion(completion *tokenspb.NexusOperationCompletion) error {
 	default:
 		return serviceerror.NewInvalidArgument("callback token must contain either all HSM fields or a component ref")
 	}
+}
+
+// CompletionTarget resolves the target namespace ID, business (workflow) ID, and run ID from a
+// completion token. For CHASM completions the ComponentRef is canonical and embeds all three; for
+// HSM/workflow completions the top-level fields are used. The system-callback router and the
+// frontend completion handler must resolve these identically, so they share this helper rather than
+// each cracking the ComponentRef on their own (which is how the router previously missed the
+// namespace and dropped standalone-operation completions).
+func CompletionTarget(completion *tokenspb.NexusOperationCompletion) (namespaceID, businessID, runID string, err error) {
+	namespaceID = completion.GetNamespaceId()
+	businessID = completion.GetWorkflowId()
+	runID = completion.GetRunId()
+	if len(completion.GetComponentRef()) > 0 {
+		ref := &persistencespb.ChasmComponentRef{}
+		if err := ref.Unmarshal(completion.GetComponentRef()); err != nil {
+			return "", "", "", err
+		}
+		namespaceID = ref.GetNamespaceId()
+		businessID = ref.GetBusinessId()
+		runID = ref.GetRunId()
+	}
+	return namespaceID, businessID, runID, nil
 }
 
 // DecodeCallbackToken unmarshals the given token applying minimal data verification.

--- a/components/callbacks/request.go
+++ b/components/callbacks/request.go
@@ -42,16 +42,25 @@ func routeSystemCallbackRequest(
 			logger.Error("failed to decode completion from token", tag.Error(err))
 			return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid callback token")
 		}
-		ns, err := namespaceRegistry.GetNamespaceByID(namespace.ID(completion.NamespaceId))
+		// Resolve the target namespace/workflow from the token. For CHASM completions (e.g.
+		// standalone Nexus operations) the namespace lives inside the ComponentRef, not the
+		// top-level field, so use the shared helper rather than reading completion.NamespaceId
+		// directly.
+		namespaceID, businessID, _, err := commonnexus.CompletionTarget(completion)
 		if err != nil {
-			logger.Error("failed to get namespace for nexus completion request", tag.WorkflowNamespaceID(completion.NamespaceId), tag.Error(err))
+			logger.Error("failed to extract target from nexus completion token", tag.Error(err))
+			return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid callback token")
+		}
+		ns, err := namespaceRegistry.GetNamespaceByID(namespace.ID(namespaceID))
+		if err != nil {
+			logger.Error("failed to get namespace for nexus completion request", tag.WorkflowNamespaceID(namespaceID), tag.Error(err))
 			var nfe *serviceerror.NamespaceNotFound
 			if errors.As(err, &nfe) {
-				return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeNotFound, "namespace %q not found", completion.NamespaceId)
+				return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeNotFound, "namespace %q not found", namespaceID)
 			}
 			return nil, commonnexus.ConvertGRPCError(err, false)
 		}
-		clusterName := ns.ActiveClusterName(namespace.RoutingKey{ID: completion.GetWorkflowId()})
+		clusterName := ns.ActiveClusterName(namespace.RoutingKey{ID: businessID})
 		if clusterMetadata.GetCurrentClusterName() == clusterName {
 			frontendClient = localClient
 		} else {

--- a/service/frontend/nexus_completion_http_handler.go
+++ b/service/frontend/nexus_completion_http_handler.go
@@ -17,7 +17,6 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/api/historyservice/v1"
-	persistencespb "go.temporal.io/server/api/persistence/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/authorization"
@@ -35,7 +34,6 @@ import (
 	"go.temporal.io/server/service/frontend/configs"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -136,19 +134,13 @@ func (h *nexusCompletionHandler) CompleteOperation(ctx context.Context, r *nexus
 		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid callback token")
 	}
 
-	// Determine the target namespace, workflow, and run ID from the completion token.
-	targetNamespaceID := completion.GetNamespaceId()
-	targetBusinessID := completion.GetWorkflowId()
-	targetRunID := completion.GetRunId()
-	if len(completion.GetComponentRef()) > 0 {
-		ref := &persistencespb.ChasmComponentRef{}
-		if err := proto.Unmarshal(completion.GetComponentRef(), ref); err != nil {
-			h.Logger.Error("failed to unmarshal CHASM component ref", tag.Error(err))
-			return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid callback token")
-		}
-		targetNamespaceID = ref.GetNamespaceId()
-		targetBusinessID = ref.GetBusinessId()
-		targetRunID = ref.GetRunId()
+	// Determine the target namespace, workflow, and run ID from the completion token. The CHASM
+	// ComponentRef is canonical when present; otherwise the top-level HSM fields are used. Shared
+	// with the system-callback router via commonnexus.CompletionTarget so the two can't drift.
+	targetNamespaceID, targetBusinessID, targetRunID, err := commonnexus.CompletionTarget(completion)
+	if err != nil {
+		h.Logger.Error("failed to unmarshal CHASM component ref", tag.Error(err))
+		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid callback token")
 	}
 
 	ns, err := h.NamespaceRegistry.GetNamespaceByID(namespace.ID(targetNamespaceID))


### PR DESCRIPTION
A workflow-backed standalone Nexus operation's completion callback token was built with only ComponentRef + RequestId, no top-level NamespaceId. The in-process system-callback router (routeSystemCallbackRequest) read completion.NamespaceId directly, got empty, failed namespace lookup, and dropped the completion, then the operation timed out at schedule-to-close. 

The namespace was always present inside the ComponentRef; the router just wasn't reading that copy. So I pulled out some common code and unified the behavior.                                                                                                                                           
                