### PR TITLE
use dynamic rate limiter for batch worker RPS (#10533)

### DIFF
--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -29,10 +29,10 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/quotas"
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/worker_versioning"
 	workercommon "go.temporal.io/server/service/worker/common"
-	"golang.org/x/time/rate"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
@@ -49,7 +49,7 @@ var (
 type batchProcessorConfig struct {
 	namespace         string
 	adjustedQuery     string
-	rps               float64
+	rps               dynamicconfig.IntPropertyFnWithNamespaceFilter
 	concurrency       int
 	initialPageToken  []byte
 	initialExecutions []*commonpb.WorkflowExecution
@@ -60,7 +60,7 @@ type batchWorkerProcessor func(
 	ctx context.Context,
 	taskCh chan task,
 	respCh chan taskResponse,
-	rateLimiter *rate.Limiter,
+	rateLimiter quotas.RateLimiter,
 	sdkClient sdkclient.Client,
 	frontendClient workflowservice.WorkflowServiceClient,
 	metricsHandler metrics.Handler,
@@ -163,9 +163,9 @@ func (a *activities) processWorkflowsWithProactiveFetching(
 	logger log.Logger,
 	hbd HeartBeatDetails,
 ) (HeartBeatDetails, error) {
-	rateLimit := rate.Limit(config.rps)
-	burstLimit := int(math.Ceil(config.rps)) // should never be zero because everything would be rejected
-	rateLimiter := rate.NewLimiter(rateLimit, burstLimit)
+	rateLimiter := quotas.NewDefaultOutgoingRateLimiter(func() float64 {
+		return float64(config.rps(config.namespace))
+	})
 
 	concurrency := int(math.Max(1, float64(config.concurrency)))
 
@@ -353,7 +353,7 @@ func (a *activities) BatchActivityWithProtobuf(ctx context.Context, batchParams 
 	config := batchProcessorConfig{
 		namespace:         ns,
 		adjustedQuery:     visibilityQuery,
-		rps:               float64(a.rps(ns)),
+		rps:               a.rps,
 		concurrency:       a.getOperationConcurrency(int(batchParams.Concurrency)),
 		initialPageToken:  hbd.PageToken,
 		initialExecutions: executions,
@@ -364,7 +364,7 @@ func (a *activities) BatchActivityWithProtobuf(ctx context.Context, batchParams 
 		ctx context.Context,
 		taskCh chan task,
 		respCh chan taskResponse,
-		rateLimiter *rate.Limiter,
+		rateLimiter quotas.RateLimiter,
 		sdkClient sdkclient.Client,
 		frontendClient workflowservice.WorkflowServiceClient,
 		metricsHandler metrics.Handler,
@@ -420,7 +420,7 @@ func (a *activities) startTaskProcessor(
 	namespace string,
 	taskCh chan task,
 	respCh chan taskResponse,
-	limiter *rate.Limiter,
+	limiter quotas.RateLimiter,
 	sdkClient sdkclient.Client,
 	frontendClient workflowservice.WorkflowServiceClient,
 	metricsHandler metrics.Handler,
@@ -673,7 +673,7 @@ func (a *activities) processAdminTask(
 	ctx context.Context,
 	batchOperation *batchspb.BatchOperationInput,
 	task task,
-	limiter *rate.Limiter,
+	limiter quotas.RateLimiter,
 ) error {
 	adminReq := batchOperation.AdminRequest
 	switch adminReq.Operation.(type) {
@@ -701,7 +701,7 @@ func (a *activities) processAdminTask(
 
 func processTask(
 	ctx context.Context,
-	limiter *rate.Limiter,
+	limiter quotas.RateLimiter,
 	task task,
 	procFn func(*workflowpb.WorkflowExecutionInfo) error,
 ) error {

--- a/service/worker/batcher/activities_namespace_test.go
+++ b/service/worker/batcher/activities_namespace_test.go
@@ -16,9 +16,9 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/quotas"
 	"go.temporal.io/server/common/testing/mockapi/workflowservicemock/v1"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/time/rate"
 )
 
 // These tests guard against cross-namespace escalation via the batcher activity.
@@ -142,7 +142,7 @@ func TestStartTaskProcessor_UsesWorkerBoundNamespaceForSignal(t *testing.T) {
 	go func() {
 		defer close(done)
 		a.startTaskProcessor(ctx, batchOp, ns, taskCh, respCh,
-			rate.NewLimiter(rate.Inf, 1), nil, mockFE,
+			quotas.NewDefaultOutgoingRateLimiter(func() float64 { return 1e9 }), nil, mockFE,
 			metrics.NoopMetricsHandler, log.NewTestLogger())
 	}()
 

--- a/service/worker/batcher/activities_test.go
+++ b/service/worker/batcher/activities_test.go
@@ -25,9 +25,9 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/common/quotas"
 	"go.temporal.io/server/common/testing/mockapi/workflowservicemock/v1"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/time/rate"
 )
 
 type activitiesSuite struct {
@@ -451,7 +451,7 @@ func (s *activitiesSuite) TestProcessAdminTask_RefreshWorkflowTasks() {
 		},
 	}
 
-	limiter := rate.NewLimiter(rate.Limit(100), 1)
+	limiter := quotas.NewDefaultOutgoingRateLimiter(func() float64 { return 100 })
 
 	// Expect RefreshWorkflowTasks to be called with correct parameters
 	mockHistoryClient.EXPECT().RefreshWorkflowTasks(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -497,7 +497,7 @@ func (s *activitiesSuite) TestProcessAdminTask_RefreshWorkflowTasks_Error() {
 		},
 	}
 
-	limiter := rate.NewLimiter(rate.Limit(100), 1)
+	limiter := quotas.NewDefaultOutgoingRateLimiter(func() float64 { return 100 })
 
 	expectedErr := errors.New("refresh failed")
 	// Use gomock.Any() for context since it's modified with CallerTypePreemptable header
@@ -617,7 +617,7 @@ func (s *activitiesSuite) TestStartTaskProcessor_SignalUsesWorkerNamespace() {
 
 	taskCh := make(chan task, 1)
 	respCh := make(chan taskResponse, 1)
-	limiter := rate.NewLimiter(rate.Limit(100), 1)
+	limiter := quotas.NewDefaultOutgoingRateLimiter(func() float64 { return 100 })
 
 	// The signal must be executed with the worker's trusted namespace, not the user-supplied one.
 	s.mockFrontendClient.EXPECT().
@@ -657,7 +657,7 @@ func (s *activitiesSuite) TestProcessAdminTask_UnknownOperation() {
 		},
 	}
 
-	limiter := rate.NewLimiter(rate.Limit(100), 1)
+	limiter := quotas.NewDefaultOutgoingRateLimiter(func() float64 { return 100 })
 
 	err := a.processAdminTask(ctx, batchOperation, testTask, limiter)
 	s.Require().Error(err)


### PR DESCRIPTION
## What changed?
Use the dynamic rate limiter for the service/worker/batcher

## Why?
This allows operators to tune the RPS live while a single batch job is overloading.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Minimal, this only changes the type of rate limiter