### PR TITLE
Cherry-pick: Encode duration as bigint for pgx simple protocol (#10529)

### DIFF
--- a/common/persistence/persistence-tests/setup.go
+++ b/common/persistence/persistence-tests/setup.go
@@ -37,10 +37,8 @@ func GetTestClusterOption(storeType, driver string) *TestBaseOptions {
 		switch driver {
 		case mysql.PluginName:
 			return GetMySQLTestClusterOption()
-		case postgresql.PluginName:
-			return GetPostgreSQLTestClusterOption()
-		case postgresql.PluginNamePGX:
-			return GetPostgreSQLPGXTestClusterOption()
+		case postgresql.PluginName, postgresql.PluginNamePGX:
+			return GetPostgreSQLTestClusterOption(driver, nil)
 		case sqlite.PluginName:
 			return GetSQLiteMemoryTestClusterOption()
 		default:
@@ -79,30 +77,31 @@ func GetMySQLTestClusterOption() *TestBaseOptions {
 }
 
 // GetPostgreSQLTestClusterOption return test options
-func GetPostgreSQLTestClusterOption() *TestBaseOptions {
-	return &TestBaseOptions{
-		SQLDBPluginName: postgresql.PluginName,
-		DBName:          "test_" + GenerateRandomDBName(3),
-		DBUsername:      testPostgreSQLUser,
-		DBPassword:      testPostgreSQLPassword,
-		DBHost:          environment.GetPostgreSQLAddress(),
-		DBPort:          environment.GetPostgreSQLPort(),
-		SchemaDir:       testPostgreSQLSchemaDir,
-		StoreType:       config.StoreTypeSQL,
+func GetPostgreSQLTestClusterOption(
+	pluginName string,
+	connectAttributes map[string]string,
+) *TestBaseOptions {
+	switch pluginName {
+	case postgresql.PluginName, postgresql.PluginNamePGX:
+		// no-op
+	default:
+		panic(fmt.Sprintf(
+			"invalid postgresql plugin name: %s (valid options: %s, %s)",
+			pluginName,
+			postgresql.PluginName,
+			postgresql.PluginNamePGX,
+		))
 	}
-}
-
-// GetPostgreSQLPGXTestClusterOption return test options
-func GetPostgreSQLPGXTestClusterOption() *TestBaseOptions {
 	return &TestBaseOptions{
-		SQLDBPluginName: postgresql.PluginNamePGX,
-		DBName:          "test_" + GenerateRandomDBName(3),
-		DBUsername:      testPostgreSQLUser,
-		DBPassword:      testPostgreSQLPassword,
-		DBHost:          environment.GetPostgreSQLAddress(),
-		DBPort:          environment.GetPostgreSQLPort(),
-		SchemaDir:       testPostgreSQLSchemaDir,
-		StoreType:       config.StoreTypeSQL,
+		SQLDBPluginName:   pluginName,
+		DBName:            "test_" + GenerateRandomDBName(3),
+		DBUsername:        testPostgreSQLUser,
+		DBPassword:        testPostgreSQLPassword,
+		DBHost:            environment.GetPostgreSQLAddress(),
+		DBPort:            environment.GetPostgreSQLPort(),
+		SchemaDir:         testPostgreSQLSchemaDir,
+		StoreType:         config.StoreTypeSQL,
+		ConnectAttributes: connectAttributes,
 	}
 }
 

--- a/common/persistence/sql/sqlplugin/postgresql/driver/pgx.go
+++ b/common/persistence/sql/sqlplugin/postgresql/driver/pgx.go
@@ -1,8 +1,10 @@
 package driver
 
 import (
+	"context"
 	"database/sql"
 	sqldriver "database/sql/driver"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -16,7 +18,17 @@ type PGXDriver struct{}
 const pgxDriverName = "pgx"
 
 func (p *PGXDriver) CreateConnection(dsn string) (*sqlx.DB, error) {
-	return sqlx.Connect(pgxDriverName, dsn)
+	cfg, err := pgx.ParseConfig(dsn)
+	if err != nil {
+		return nil, err
+	}
+	connector := stdlib.GetConnector(*cfg, stdlib.OptionAfterConnect(registerCustomTypes))
+	db := sqlx.NewDb(sql.OpenDB(connector), pgxDriverName)
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
 }
 
 func (p *PGXDriver) CreateRefreshableConnection(buildDSN func() (string, error)) (*sqlx.DB, error) {
@@ -27,7 +39,7 @@ func (p *PGXDriver) CreateRefreshableConnection(buildDSN func() (string, error))
 			if err != nil {
 				return nil, err
 			}
-			return stdlib.GetConnector(*cfg), nil
+			return stdlib.GetConnector(*cfg, stdlib.OptionAfterConnect(registerCustomTypes)), nil
 		},
 		stdlib.GetDefaultDriver(),
 	)
@@ -37,6 +49,22 @@ func (p *PGXDriver) CreateRefreshableConnection(buildDSN func() (string, error))
 		return nil, err
 	}
 	return db, nil
+}
+
+// registerCustomTypes overrides pgx's default type mapping.
+//
+// By default pgx maps time.Duration to the interval type. Under the simple
+// query protocol (the path users land on behind PgBouncer in transaction
+// pooling) a time.Duration is encoded as an interval literal like "00:00:05".
+// Temporal stores all durations as bigint nanoseconds, so that literal is
+// rejected. Encoding time.Duration as int8 (bigint in PostgreSQL) instead
+// results in the integer nanosecond count
+func registerCustomTypes(_ context.Context, conn *pgx.Conn) error {
+	// pgx tracks the value type and the pointer type separately, so
+	// both must be remapped.
+	conn.TypeMap().RegisterDefaultPgType(time.Duration(0), "int8")
+	conn.TypeMap().RegisterDefaultPgType((*time.Duration)(nil), "int8")
+	return nil
 }
 
 func (p *PGXDriver) IsDupEntryError(err error) bool {

--- a/common/persistence/sql/sqlplugin/tests/visibility.go
+++ b/common/persistence/sql/sqlplugin/tests/visibility.go
@@ -1341,19 +1341,24 @@ func (s *visibilitySuite) newRandomVisibilityRow(
 	historyLength *int64,
 ) sqlplugin.VisibilityRow {
 	s.version++
+	var executionDuration *time.Duration
+	if closeTime != nil {
+		executionDuration = new(closeTime.Sub(executionTime))
+	}
 	return sqlplugin.VisibilityRow{
-		NamespaceID:      namespaceID.String(),
-		RunID:            runID.String(),
-		WorkflowTypeName: workflowTypeName,
-		WorkflowID:       workflowID,
-		StartTime:        startTime,
-		ExecutionTime:    executionTime,
-		Status:           status,
-		CloseTime:        closeTime,
-		HistoryLength:    historyLength,
-		Memo:             shuffle.Bytes(testVisibilityData),
-		Encoding:         testVisibilityEncoding,
-		Version:          s.version,
+		NamespaceID:       namespaceID.String(),
+		RunID:             runID.String(),
+		WorkflowTypeName:  workflowTypeName,
+		WorkflowID:        workflowID,
+		StartTime:         startTime,
+		ExecutionTime:     executionTime,
+		Status:            status,
+		CloseTime:         closeTime,
+		HistoryLength:     historyLength,
+		ExecutionDuration: executionDuration,
+		Memo:              shuffle.Bytes(testVisibilityData),
+		Encoding:          testVisibilityEncoding,
+		Version:           s.version,
 	}
 }
 

--- a/common/persistence/tests/postgresql_test.go
+++ b/common/persistence/tests/postgresql_test.go
@@ -166,7 +166,9 @@ func (p *PostgreSQLSuite) TestPostgreSQLTaskQueueUserDataSuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLVisibilityPersistenceSuite() {
 	s := &VisibilityPersistenceSuite{
-		TestBase: persistencetests.NewTestBaseWithSQL(persistencetests.GetPostgreSQLTestClusterOption()),
+		TestBase: persistencetests.NewTestBaseWithSQL(
+			persistencetests.GetPostgreSQLTestClusterOption(p.pluginName, p.connectAttrs),
+		),
 	}
 	suite.Run(p.T(), s)
 }
@@ -175,28 +177,36 @@ func (p *PostgreSQLSuite) TestPostgreSQLVisibilityPersistenceSuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryV2PersistenceSuite() {
 	s := new(persistencetests.HistoryV2PersistenceSuite)
-	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetPostgreSQLTestClusterOption())
+	s.TestBase = persistencetests.NewTestBaseWithSQL(
+		persistencetests.GetPostgreSQLTestClusterOption(p.pluginName, p.connectAttrs),
+	)
 	s.TestBase.Setup(nil)
 	suite.Run(p.T(), s)
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLMetadataPersistenceSuiteV2() {
 	s := new(persistencetests.MetadataPersistenceSuiteV2)
-	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetPostgreSQLTestClusterOption())
+	s.TestBase = persistencetests.NewTestBaseWithSQL(
+		persistencetests.GetPostgreSQLTestClusterOption(p.pluginName, p.connectAttrs),
+	)
 	s.TestBase.Setup(nil)
 	suite.Run(p.T(), s)
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLClusterMetadataPersistence() {
 	s := new(persistencetests.ClusterMetadataManagerSuite)
-	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetPostgreSQLTestClusterOption())
+	s.TestBase = persistencetests.NewTestBaseWithSQL(
+		persistencetests.GetPostgreSQLTestClusterOption(p.pluginName, p.connectAttrs),
+	)
 	s.TestBase.Setup(nil)
 	suite.Run(p.T(), s)
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLQueuePersistence() {
 	s := new(persistencetests.QueuePersistenceSuite)
-	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetPostgreSQLTestClusterOption())
+	s.TestBase = persistencetests.NewTestBaseWithSQL(
+		persistencetests.GetPostgreSQLTestClusterOption(p.pluginName, p.connectAttrs),
+	)
 	s.TestBase.Setup(nil)
 	suite.Run(p.T(), s)
 }

--- a/common/persistence/tests/visibility_persistence_suite.go
+++ b/common/persistence/tests/visibility_persistence_suite.go
@@ -1144,6 +1144,7 @@ func (s *VisibilityPersistenceSuite) assertClosedExecutionEquals(
 	s.Equal(persistence.UnixMilliseconds(req.CloseTime), persistence.UnixMilliseconds(timestamp.TimeValue(resp.GetCloseTime())))
 	s.Equal(req.Status, resp.GetStatus())
 	s.Equal(req.HistoryLength, resp.HistoryLength)
+	s.Equal(req.ExecutionDuration, resp.GetExecutionDuration().AsDuration())
 }
 
 func (s *VisibilityPersistenceSuite) assertOpenExecutionEquals(


### PR DESCRIPTION
Backport of #10529 to release/v1.31.x for the v1.31.1 patch.