### PR TITLE
add StartDelay into ActivityExecutionInfo

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -911,6 +911,7 @@ func (a *Activity) buildActivityExecutionInfo(ctx chasm.Context) *apiactivitypb.
 		ScheduleTime:            a.GetScheduleTime(),
 		ScheduleToCloseTimeout:  a.GetScheduleToCloseTimeout(),
 		ScheduleToStartTimeout:  a.GetScheduleToStartTimeout(),
+		StartDelay:              a.GetStartDelay(),
 		StartToCloseTimeout:     a.GetStartToCloseTimeout(),
 		StateSizeBytes:          int64(executionInfo.ApproximateStateSize),
 		StateTransitionCount:    executionInfo.StateTransitionCount,

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
-	go.temporal.io/api v1.62.13
+	go.temporal.io/api v1.62.14-0.20260605195506-b526f51bd9f1
 	go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2
 	go.temporal.io/sdk v1.41.1
 	go.uber.org/fx v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -471,8 +471,8 @@ go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0 h1:R
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0/go.mod h1:I89cynRj8y+383o7tEQVg2SVA6SRgDVIouWPUVXjx0U=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0 h1:CQvJSldHRUN6Z8jsUeYv8J0lXRvygALXIzsmAeCcZE0=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0/go.mod h1:xSQ+mEfJe/GjK1LXEyVOoSI1N9JV9ZI923X5kup43W4=
-go.temporal.io/api v1.62.13 h1:xMa8Nt5oAMX+LvlCJA44wjTCc1H09i2rG9poB1/xvH4=
-go.temporal.io/api v1.62.13/go.mod h1:0k75tRljEuELWGeXjEZZO7zYqBln4+1FrG6+IMOMy7Q=
+go.temporal.io/api v1.62.14-0.20260605195506-b526f51bd9f1 h1:wfFawXpXcBwfIFoYw8rF48eonRmE1KtYcWgrw6OY1/c=
+go.temporal.io/api v1.62.14-0.20260605195506-b526f51bd9f1/go.mod h1:0k75tRljEuELWGeXjEZZO7zYqBln4+1FrG6+IMOMy7Q=
 go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2 h1:1hKeH3GyR6YD6LKMHGCZ76t6h1Sgha0hXVQBxWi3dlQ=
 go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2/go.mod h1:T8dnzVPeO+gaUTj9eDgm/lT2lZH4+JXNvrGaQGyVi50=
 go.temporal.io/sdk v1.41.1 h1:yOpvsHyDD1lNuwlGBv/SUodCPhjv9nDeC9lLHW/fJUA=

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -3636,6 +3636,36 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution() {
 		})
 	})
 
+	s.Run("StartDelay", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := env.Tv().ActivityID()
+		taskQueue := env.Tv().TaskQueue()
+		startDelay := durationpb.New(300 * time.Second)
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
+			Input:               defaultInput,
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue.GetName()},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			StartDelay:          startDelay,
+			RequestId:           env.Tv().RequestID(),
+		})
+		require.NoError(t, err)
+
+		describeResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		protorequire.ProtoEqual(t, startDelay, describeResp.GetInfo().GetStartDelay())
+	})
+
 	s.Run("WaitAnyStateChange", func(s *standaloneActivityTestSuite) {
 		t := s.T()
 		// Long poll for any state change. PollActivityTaskQueue is used to cause a state change.


### PR DESCRIPTION
## What changed?
Populate ActivityExecutionInfo.StartDelay in buildActivityExecutionInfo so the configured start delay is echoed back by DescribeActivityExecution. 

## Why?
StartDelay was wired into the activity state but was missing from the Describe response, leaving clients unable to observe the configured delay after start. 

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [X] added new functional test(s)
