### PR TITLE
TS: cap skip with execution timeout

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -10185,14 +10185,13 @@ func (d timeSkippingTransition) isValid() bool {
 	return !d.targetTime.IsZero() || d.disabledAfterBound
 }
 
-// calculateTimeSkippingTransition calculates the transition state which includes two fields:
-// 1. targetTime: the time to skip to
-// 2. disabledAfterBound: a flag indicating whether the time skipping should be flipped off
-// right now the time points considered for target time are:
-// - the first expiry time of the pending user timers
-// - the workflow execution retry backoff
-// - the current elapsed duration bound of the time skipping config
-// - the activity retry backoff
+// calculateTimeSkippingTransition determines the next skip target.
+// Candidates (in collection order): pending user timers, activity retry backoffs,
+// workflow start-with-delay/CaN/retry backoff, and the MaxElapsed bound.
+// The run/execution timeout is NOT a standalone candidate — it only applies as
+// a cap: if any candidate wins, the skip target is clamped to min(target,
+// runExpiry, execExpiry). This ensures we never advance virtual time past the
+// workflow timeout, even when a user timer or bound would otherwise overshoot.
 func (ms *MutableStateImpl) calculateTimeSkippingTransition() (timeSkippingTransition, error) {
 	var transition timeSkippingTransition
 	advance := func(candidate time.Time, dueToBound bool) {
@@ -10232,19 +10231,29 @@ func (ms *MutableStateImpl) calculateTimeSkippingTransition() (timeSkippingTrans
 	}
 
 	info := ms.GetExecutionInfo().GetTimeSkippingInfo()
-	bound := info.GetConfig().GetBound()
-	if bound == nil {
-		return transition, nil
+	if bound := info.GetConfig().GetBound(); bound != nil {
+		switch bound.(type) {
+		case *workflowpb.TimeSkippingConfig_MaxElapsedDuration:
+			if info.GetCurrentElapsedDurationBound() == nil {
+				return timeSkippingTransition{}, serviceerror.NewInternal("time skipping bound target time is not set for elapsed-duration bound")
+			}
+			advance(info.GetCurrentElapsedDurationBound().GetTargetTime().AsTime(), true)
+		default:
+			return timeSkippingTransition{}, serviceerror.NewInternal("unknown time skipping bound type")
+		}
 	}
 
-	switch bound.(type) {
-	case *workflowpb.TimeSkippingConfig_MaxElapsedDuration:
-		if info.GetCurrentElapsedDurationBound() == nil {
-			return timeSkippingTransition{}, serviceerror.NewInternal("time skipping bound target time is not set for elapsed-duration bound")
+	// Cap any skip target at the run/execution timeout: never advance virtual time past
+	// them. Timeouts alone do not create a skip target — only existing candidates
+	// (timers, backoffs, bound) do. This also handles the case where a user timer fires
+	// past the workflow timeout: we cap the skip so the timeout fires on schedule.
+	if !transition.targetTime.IsZero() {
+		if t := ms.executionInfo.GetWorkflowRunExpirationTime(); t != nil && !t.AsTime().IsZero() {
+			advance(t.AsTime(), false)
 		}
-		advance(info.GetCurrentElapsedDurationBound().GetTargetTime().AsTime(), true)
-	default:
-		return timeSkippingTransition{}, serviceerror.NewInternal("unknown time skipping bound type")
+		if t := ms.executionInfo.GetWorkflowExecutionExpirationTime(); t != nil && !t.AsTime().IsZero() {
+			advance(t.AsTime(), false)
+		}
 	}
 	return transition, nil
 }

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -8633,6 +8633,73 @@ func (s *mutableStateSuite) TestCalculateTimeSkippingTransition() {
 		s.Require().NoError(err)
 		s.Equal(timerTime, tr.targetTime)
 	})
+
+	// Universal cap: skip target must not exceed the run/execution timeout.
+	// MaxElapsedDuration's value is irrelevant to calculateTimeSkippingTransition;
+	// only CurrentElapsedDurationBound.TargetTime is read. We use a large dummy
+	// duration solely to configure the bound type.
+	const largeBound = 24 * time.Hour
+	setBoundAt := func(target time.Time) {
+		s.mutableState.executionInfo.TimeSkippingInfo.Config.Bound =
+			&workflowpb.TimeSkippingConfig_MaxElapsedDuration{MaxElapsedDuration: durationpb.New(largeBound)}
+		s.mutableState.executionInfo.TimeSkippingInfo.CurrentElapsedDurationBound =
+			&persistencespb.TimeSkippingBoundInfo{TargetTime: timestamppb.New(target)}
+	}
+
+	s.Run("Bound_LargerThanRunTimeout_CappedAtRunTimeout", func() {
+		resetMS()
+		runExpiry := baseTime.Add(30 * time.Minute)
+		boundTarget := baseTime.Add(2 * time.Hour) // bound > run timeout
+		setBoundAt(boundTarget)
+		s.mutableState.executionInfo.WorkflowRunExpirationTime = timestamppb.New(runExpiry)
+
+		tr, err := s.mutableState.calculateTimeSkippingTransition()
+		s.Require().NoError(err)
+		s.Equal(runExpiry, tr.targetTime, "skip must be capped at run timeout")
+		s.False(tr.disabledAfterBound, "cap fires before bound; bound must not be marked reached")
+	})
+
+	s.Run("Bound_SmallerThanRunTimeout_NoCap_TargetIsBound", func() {
+		resetMS()
+		boundTarget := baseTime.Add(30 * time.Minute)
+		runExpiry := baseTime.Add(2 * time.Hour) // run timeout > bound, no cap needed
+		setBoundAt(boundTarget)
+		s.mutableState.executionInfo.WorkflowRunExpirationTime = timestamppb.New(runExpiry)
+
+		tr, err := s.mutableState.calculateTimeSkippingTransition()
+		s.Require().NoError(err)
+		s.Equal(boundTarget, tr.targetTime, "bound is minimum; no cap applies")
+		s.True(tr.disabledAfterBound, "bound fires before run timeout; bound must be marked reached")
+	})
+
+	s.Run("Bound_LargerThanExecTimeout_NoRunTimeout_CappedAtExecTimeout", func() {
+		resetMS()
+		execExpiry := baseTime.Add(30 * time.Minute)
+		boundTarget := baseTime.Add(2 * time.Hour) // bound > execution timeout
+		setBoundAt(boundTarget)
+		// No WorkflowRunExpirationTime; only execution timeout.
+		s.mutableState.executionInfo.WorkflowExecutionExpirationTime = timestamppb.New(execExpiry)
+
+		tr, err := s.mutableState.calculateTimeSkippingTransition()
+		s.Require().NoError(err)
+		s.Equal(execExpiry, tr.targetTime, "skip must be capped at execution timeout")
+		s.False(tr.disabledAfterBound, "cap fires before bound; bound must not be marked reached")
+	})
+
+	s.Run("Bound_ZeroRunTimeout_TreatedAsNoTimeout_NoCap", func() {
+		// A zero-value timestamp means "no timeout configured". The cap must not
+		// fire: the bound target should be the skip destination unchanged.
+		resetMS()
+		boundTarget := baseTime.Add(time.Hour)
+		setBoundAt(boundTarget)
+		s.mutableState.executionInfo.WorkflowRunExpirationTime = timestamppb.New(time.Time{})
+		s.mutableState.executionInfo.WorkflowExecutionExpirationTime = timestamppb.New(time.Time{})
+
+		tr, err := s.mutableState.calculateTimeSkippingTransition()
+		s.Require().NoError(err)
+		s.Equal(boundTarget, tr.targetTime, "zero timeout must not cap the skip")
+		s.True(tr.disabledAfterBound)
+	})
 }
 
 // TestToRealTime tests ms.ToRealTime() exhaustively as this function is also used by executions that don't

--- a/tests/timeskipping_bound_test.go
+++ b/tests/timeskipping_bound_test.go
@@ -9,8 +9,11 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	sdktemporal "go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -20,6 +23,7 @@ import (
 	"go.temporal.io/server/common/testing/testvars"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 type TimeSkippingBoundFunctionalSuite struct {
@@ -389,4 +393,140 @@ func (s *TimeSkippingBoundFunctionalSuite) TestBound_MaxElapsed_NoUserTimer() {
 		WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: tv.WorkflowID(), RunId: runID},
 		Reason:            "test cleanup",
 	})
+}
+
+// blockingConditionWorkflow is used by the run-timeout/bound tests: it awaits a
+// condition that never becomes true, simulating a workflow blocked on an external
+// event with no inherent timeout.
+func blockingConditionWorkflow(ctx workflow.Context) error {
+	return workflow.Await(ctx, func() bool { return false })
+}
+
+// TestBound_MaxElapsed_BoundJustBeforeRunTimeout covers the case where MaxElapsed
+// is set 1ms less than WorkflowRunTimeout. The bound is always the minimum
+// candidate in the close-tx skip (1ms before the run expiry), so DisabledAfterBound
+// is deterministically true. The run-timeout timer then fires 1ms of real time
+// later and closes the execution with TIMED_OUT.
+func (s *TimeSkippingBoundFunctionalSuite) TestBound_MaxElapsed_BoundJustBeforeRunTimeout() {
+	env := testcore.NewEnv(s.T())
+	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	ctx := testcore.NewContext()
+
+	const (
+		runTimeout = 5 * time.Minute
+		bound      = runTimeout - time.Millisecond // bound < runTimeout by 1ms
+	)
+
+	env.SdkWorker().RegisterWorkflow(blockingConditionWorkflow)
+
+	cfg := &workflowpb.TimeSkippingConfig{
+		Enabled: true,
+		Bound:   &workflowpb.TimeSkippingConfig_MaxElapsedDuration{MaxElapsedDuration: durationpb.New(bound)},
+	}
+	workflowID := uuid.NewString()
+	startResp, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           uuid.NewString(),
+		Namespace:           env.Namespace().String(),
+		WorkflowId:          workflowID,
+		WorkflowType:        &commonpb.WorkflowType{Name: "blockingConditionWorkflow"},
+		TaskQueue:           &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue()},
+		WorkflowRunTimeout:  durationpb.New(runTimeout),
+		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+		TimeSkippingConfig:  cfg,
+	})
+	s.NoError(err)
+	runID := startResp.RunId
+
+	run := env.SdkClient().GetWorkflow(ctx, workflowID, runID)
+	err = run.Get(ctx, nil)
+	var timeoutErr *sdktemporal.TimeoutError
+	s.ErrorAs(err, &timeoutErr, "expected TimeoutError, got: %v", err)
+
+	hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: workflowID, RunId: runID})
+	transitions := s.findTransitionedEvents(hist)
+	s.Len(transitions, 1, "exactly one transition: skip to bound (1ms before run timeout)")
+	s.True(transitions[0].GetWorkflowExecutionTimeSkippingTransitionedEventAttributes().GetDisabledAfterBound(),
+		"bound fires before run timeout: DisabledAfterBound must be true")
+	s.True(hasEventType(hist, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT),
+		"run-timeout fires 1ms later and closes the workflow")
+}
+
+// TestBound_MaxElapsed_RunTimeoutBeforeBound is a two-phase test:
+//
+//  1. Workflow starts with time-skipping enabled but NO bound. The workflow is
+//     idle (blocking on a condition) so there are no skip candidates. The
+//     run/execution timeout alone must NOT advance virtual time — it is not a
+//     skip target. The workflow stays RUNNING indefinitely in real time.
+//
+//  2. A MaxElapsed bound larger than the run timeout is added via
+//     UpdateWorkflowExecutionOptions. The update's close-tx now finds the bound
+//     as the only skip candidate, which is then capped at the run timeout
+//     (5 min < 10 min bound). Virtual time advances to the run timeout and the
+//     workflow is TIMED_OUT. The single transition carries DisabledAfterBound=false
+//     (the cap fired before the bound was reached).
+func (s *TimeSkippingBoundFunctionalSuite) TestBound_MaxElapsed_RunTimeoutBeforeBound() {
+	env := testcore.NewEnv(s.T())
+	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	ctx := testcore.NewContext()
+
+	const (
+		runTimeout = 5 * time.Minute
+		bound      = 10 * time.Minute // larger than runTimeout
+	)
+
+	env.SdkWorker().RegisterWorkflow(blockingConditionWorkflow)
+
+	workflowID := uuid.NewString()
+	startResp, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           uuid.NewString(),
+		Namespace:           env.Namespace().String(),
+		WorkflowId:          workflowID,
+		WorkflowType:        &commonpb.WorkflowType{Name: "blockingConditionWorkflow"},
+		TaskQueue:           &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue()},
+		WorkflowRunTimeout:  durationpb.New(runTimeout),
+		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+		TimeSkippingConfig:  &workflowpb.TimeSkippingConfig{Enabled: true}, // no bound yet
+	})
+	s.NoError(err)
+	runID := startResp.RunId
+
+	// Phase 1: wait for the SDK worker to complete the first WFT (workflow blocks
+	// on Await). After the close-tx there are no skip candidates, so virtual time
+	// must not have advanced and no TimeSkippingTransitioned event should exist.
+	s.AwaitTruef(func() bool {
+		hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: workflowID, RunId: runID})
+		return hasEventType(hist, enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED)
+	}, 10*time.Second, 200*time.Millisecond, "first WFT must complete")
+
+	hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: workflowID, RunId: runID})
+	s.Empty(s.findTransitionedEvents(hist),
+		"run/execution timeout alone is not a skip target — no transition must have fired")
+
+	// Phase 2: add MaxElapsed bound > run timeout. The update's close-tx finds
+	// the bound as the skip candidate, caps it at the run timeout, and the
+	// workflow is timed out.
+	_, err = env.FrontendClient().UpdateWorkflowExecutionOptions(ctx, &workflowservice.UpdateWorkflowExecutionOptionsRequest{
+		Namespace:         env.Namespace().String(),
+		WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: workflowID, RunId: runID},
+		WorkflowExecutionOptions: &workflowpb.WorkflowExecutionOptions{
+			TimeSkippingConfig: &workflowpb.TimeSkippingConfig{
+				Enabled: true,
+				Bound:   &workflowpb.TimeSkippingConfig_MaxElapsedDuration{MaxElapsedDuration: durationpb.New(bound)},
+			},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config"}},
+	})
+	s.NoError(err)
+
+	run := env.SdkClient().GetWorkflow(ctx, workflowID, runID)
+	err = run.Get(ctx, nil)
+	var timeoutErr *sdktemporal.TimeoutError
+	s.ErrorAs(err, &timeoutErr, "expected TimeoutError, got: %v", err)
+
+	hist = env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: workflowID, RunId: runID})
+	transitions := s.findTransitionedEvents(hist)
+	s.Len(transitions, 1, "exactly one transition: skip to run timeout")
+	s.False(transitions[0].GetWorkflowExecutionTimeSkippingTransitionedEventAttributes().GetDisabledAfterBound(),
+		"run timeout caps the skip before bound is reached: DisabledAfterBound must be false")
+	s.True(hasEventType(hist, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT))
 }


### PR DESCRIPTION
## What changed?
1. cap the target time with workflow execution/run timeout (if this timeout is not nil and not zero)
2. add a test case to use time skipping to test execution/run timeouts 


## Why?
1. it doesn't make sense if we skip pass the completion of the workflow when it is per-execution timeout now but normally we don't regard `execution/run timeout` as a point to skip to
2. time skipping is also a tool to test execution timeouts 

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)
