### PR TITLE
 check-dependencies: use "main" as default branch for api-go and sdk-go

### DIFF
--- a/cmd/tools/check-dependencies/main.go
+++ b/cmd/tools/check-dependencies/main.go
@@ -34,12 +34,12 @@ var knownModules = []moduleSpec{
 	{
 		modulePath:    "go.temporal.io/api",
 		repoURL:       "https://github.com/temporalio/api-go.git",
-		defaultBranch: "master",
+		defaultBranch: "main",
 	},
 	{
 		modulePath:    "go.temporal.io/sdk",
 		repoURL:       "https://github.com/temporalio/sdk-go.git",
-		defaultBranch: "master",
+		defaultBranch: "main",
 	},
 }
 


### PR DESCRIPTION
## What changed?
Updated cmd/tools/check-dependencies to use main (not master) as the default branch for both go.temporal.io/api and go.temporal.io/sdk when resolving pseudo-version origins.

## Why?
Both temporalio/api-go and temporalio/sdk-go have renamed their default branch from master to main.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

