### PR TITLE
Handle permission errors explicitly in readConfigFile

### DIFF
--- a/common/config/loader.go
+++ b/common/config/loader.go
@@ -217,8 +217,10 @@ func (opts *loadOptions) loadLegacy(config any) error {
 func readConfigFile(path string) ([]byte, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			return nil, fmt.Errorf("permission denied reading config file %s: %w", path, err)
+		}
 		return nil, fmt.Errorf("could not read config file: %s. error: %w", path, err)
-
 	}
 	return data, nil
 }


### PR DESCRIPTION
When os.ReadFile fails due to permission denied, return a specific error message instead of the generic 'could not read config file' message. This makes permission issues immediately identifiable without needing to inspect the wrapped error.

Fixes #7048

## What changed?
Added explicit handling for `os.ErrPermission` in `readConfigFile` 
to return a clear, specific error message when a config file cannot 
be read due to permission issues.

## Why?
Permission errors were wrapped in a generic "could not read config 
file" message, making it hard to distinguish permission issues from 
other read errors. Now permission errors return a specific 
"permission denied reading config file" message that immediately 
identifies the root cause.

## How did you test it?
- ✅ built
- ✅ covered by existing tests

## Potential risks
None — additive error handling only. No behavior change for 
non-permission errors. Permission denied errors now return a 
more descriptive message instead of the generic one.
