### PR TITLE
Fix SAA max links check

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -181,11 +181,6 @@ func NewStandaloneActivity(
 			return nil, err
 		}
 	}
-	if len(request.GetLinks()) > 0 {
-		if err := ctx.SetRequestLinks(activity, request.GetRequestId(), request.GetLinks()); err != nil {
-			return nil, err
-		}
-	}
 
 	activity.ScheduleTime = timestamppb.New(ctx.Now(activity))
 

--- a/chasm/lib/activity/handler.go
+++ b/chasm/lib/activity/handler.go
@@ -79,14 +79,6 @@ func (h *handler) StartActivityExecution(ctx context.Context, req *activitypb.St
 			BusinessID:  frontendReq.GetActivityId(),
 		},
 		func(mutableContext chasm.MutableContext, request *workflowservice.StartActivityExecutionRequest) (*Activity, error) {
-			// Only enforce the per-component cap when we'll actually persist the links —
-			// i.e., when creating a new activity. On returning an existing activity
-			// without attach_links the request.Links field is dropped, so the cap check
-			// is skipped to avoid false rejects. Per-request shape/size/count is already
-			// validated by the frontend (the only caller of this handler).
-			if err := h.linkValidator.ValidateComponentTotal(request.GetNamespace(), 0, len(request.GetLinks())); err != nil {
-				return nil, err
-			}
 			newActivity, err := NewStandaloneActivity(mutableContext, request)
 			if err != nil {
 				return nil, err
@@ -94,6 +86,11 @@ func (h *handler) StartActivityExecution(ctx context.Context, req *activitypb.St
 
 			if cbs := request.GetCompletionCallbacks(); len(cbs) > 0 {
 				if err := newActivity.addCompletionCallbacks(mutableContext, request.GetRequestId(), cbs, maxCallbacks); err != nil {
+					return nil, err
+				}
+			}
+			if len(request.GetLinks()) > 0 {
+				if err := newActivity.attachLinks(mutableContext, request.GetLinks(), request.GetRequestId(), h.linkValidator, frontendReq.GetNamespace()); err != nil {
 					return nil, err
 				}
 			}

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -1000,9 +1000,7 @@ func (s *standaloneActivityTestSuite) TestStart() {
 		require.ErrorAs(t, err, new(*serviceerror.FailedPrecondition))
 	})
 
-	// TODO(quinn, #10569): un-skip after PR #10569 lands — fails deterministically on current main.
 	t.Run("PerExecutionCapNotEnforcedWhenLinksWillBeDropped", func(t *testing.T) {
-		t.Skip("known failure on current main; tracked by PR #10569 (TODO(quinn, #10569) above)")
 		// Reproduces the SAA Nexus-handler scenario: a benign retry of
 		// StartActivityExecution against an already-running activity with
 		// USE_EXISTING and no OnConflictOptions.attach_links must succeed and

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -1004,10 +1004,12 @@ func (s *standaloneActivityTestSuite) TestStart() {
 	t.Run("PerExecutionCapNotEnforcedWhenLinksWillBeDropped", func(t *testing.T) {
 		t.Skip("known failure on current main; tracked by PR #10569 (TODO(quinn, #10569) above)")
 		// Reproduces the SAA Nexus-handler scenario: a benign retry of
-		// StartActivityExecution against an already-running activity, without
-		// OnConflictOptions.attach_links, must not reject the request just because
-		// the Links field would push the activity over the per-execution cap — the
-		// links would be dropped anyway.
+		// StartActivityExecution against an already-running activity with
+		// USE_EXISTING and no OnConflictOptions.attach_links must succeed and
+		// silently drop the request's Links field. The per-component cap must
+		// not be enforced on the dropped links — without this carve-out, a
+		// retry that would have pushed the activity over the cap (if attach
+		// had been requested) would falsely reject.
 		const maxLinks = 1
 		cleanup := env.OverrideDynamicConfig(dynamicconfig.MaxLinksPerComponent, maxLinks)
 		defer cleanup()
@@ -1015,28 +1017,13 @@ func (s *standaloneActivityTestSuite) TestStart() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		firstResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
-			Namespace:           env.Namespace().String(),
-			ActivityId:          activityID,
-			ActivityType:        env.Tv().ActivityType(),
-			Identity:            env.Tv().WorkerIdentity(),
-			Input:               defaultInput,
-			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
-			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-			RequestId:           env.Tv().Any().String(),
-			IdConflictPolicy:    enumspb.ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING,
-		})
-		require.NoError(t, err)
-		require.True(t, firstResp.Started)
-
-		overCap := make([]*commonpb.Link, maxLinks+5)
-		for i := range overCap {
-			overCap[i] = &commonpb.Link{
+		makeLink := func(prefix string, i int) *commonpb.Link {
+			return &commonpb.Link{
 				Variant: &commonpb.Link_WorkflowEvent_{
 					WorkflowEvent: &commonpb.Link_WorkflowEvent{
 						Namespace:  env.Namespace().String(),
-						WorkflowId: fmt.Sprintf("drop-wf-%d", i),
-						RunId:      "drop-run",
+						WorkflowId: fmt.Sprintf("%s-wf-%d", prefix, i),
+						RunId:      fmt.Sprintf("%s-run", prefix),
 						Reference: &commonpb.Link_WorkflowEvent_EventRef{
 							EventRef: &commonpb.Link_WorkflowEvent_EventReference{
 								EventId:   1,
@@ -1048,6 +1035,25 @@ func (s *standaloneActivityTestSuite) TestStart() {
 			}
 		}
 
+		// First call seeds the activity at the per-component cap so any
+		// subsequent attach would exceed it.
+		firstLinks := []*commonpb.Link{makeLink("first", 0)}
+		firstResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
+			Input:               defaultInput,
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			RequestId:           env.Tv().Any().String(),
+			IdConflictPolicy:    enumspb.ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING,
+			Links:               firstLinks,
+		})
+		require.NoError(t, err)
+		require.True(t, firstResp.Started)
+
+		links := []*commonpb.Link{makeLink("drop", 0)}
 		secondResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
 			Namespace:           env.Namespace().String(),
 			ActivityId:          activityID,
@@ -1058,7 +1064,7 @@ func (s *standaloneActivityTestSuite) TestStart() {
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
 			RequestId:           env.Tv().Any().String(),
 			IdConflictPolicy:    enumspb.ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING,
-			Links:               overCap,
+			Links:               links,
 			// attach_links intentionally omitted — the Links field should be silently dropped.
 		})
 		require.NoError(t, err, "over-cap Links must be ignored when attach_links is unset")


### PR DESCRIPTION

## What changed?
Fix SAA max link check to move it outside of StartExecution

## Why?
Was causing `PerExecutionCapNotEnforcedWhenLinksWillBeDropped` to fail

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when link limits are enforced on standalone activity starts and on-conflict paths; wrong ordering could still reject valid attaches or accept invalid ones, but behavior is covered by an updated integration test.
> 
> **Overview**
> **Moves standalone-activity link persistence out of `NewStandaloneActivity` and into the start handler**, calling `attachLinks` only when a new execution is created inside `chasm.StartExecution` (alongside completion callbacks).
> 
> **Removes the per-component max-links check that ran at the start of the `StartExecution` closure**, which could reject benign `USE_EXISTING` retries that carried `Links` but no `OnConflictOptions.attach_links`—links that would be dropped anyway.
> 
> The functional test `PerExecutionCapNotEnforcedWhenLinksWillBeDropped` is enabled again and updated to seed the activity at the link cap on the first start, then assert a second `USE_EXISTING` call without `attach_links` succeeds while ignoring request links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit decbd1a8d02c782d1a6293364801533043dd7235. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->