### PR TITLE
Widen retry budget for namespace replication tasks

### DIFF
--- a/service/worker/replicator/replication_message_processor.go
+++ b/service/worker/replicator/replication_message_processor.go
@@ -31,6 +31,16 @@ const (
 	taskProcessorErrorRetryWait               = time.Second
 	taskProcessorErrorRetryBackoffCoefficient = 1
 	taskProcessorErrorRetryMaxAttampts        = 5
+
+	// Namespace replication tasks (failover, register, update) are gated on the
+	// cluster-global namespace metadata CAS, which can churn under contention.
+	// Give them a wider retry budget than other task types so a brief CAS burst
+	// or storage wobble doesn't drop them into the DLQ.
+	namespaceTaskRetryInitialInterval    = 2 * time.Second
+	namespaceTaskRetryBackoffCoefficient = 2.0
+	namespaceTaskRetryMaximumInterval    = 10 * time.Second
+	namespaceTaskRetryExpiration         = 1 * time.Minute
+	namespaceTaskRetryMaximumAttempts    = 15
 )
 
 func newReplicationMessageProcessor(
@@ -51,6 +61,12 @@ func newReplicationMessageProcessor(
 		WithBackoffCoefficient(taskProcessorErrorRetryBackoffCoefficient).
 		WithMaximumAttempts(taskProcessorErrorRetryMaxAttampts)
 
+	namespaceTaskRetryPolicy := backoff.NewExponentialRetryPolicy(namespaceTaskRetryInitialInterval).
+		WithBackoffCoefficient(namespaceTaskRetryBackoffCoefficient).
+		WithMaximumInterval(namespaceTaskRetryMaximumInterval).
+		WithExpirationInterval(namespaceTaskRetryExpiration).
+		WithMaximumAttempts(namespaceTaskRetryMaximumAttempts)
+
 	return &replicationMessageProcessor{
 		hostInfo:                  hostInfo,
 		serviceResolver:           serviceResolver,
@@ -63,6 +79,7 @@ func newReplicationMessageProcessor(
 		customTaskHandler:         customTaskHandler,
 		metricsHandler:            metricsHandler.WithTags(metrics.OperationTag(metrics.NamespaceReplicationTaskScope)),
 		retryPolicy:               retryPolicy,
+		namespaceTaskRetryPolicy:  namespaceTaskRetryPolicy,
 		lastProcessedMessageID:    -1,
 		lastRetrievedMessageID:    -1,
 		done:                      make(chan struct{}),
@@ -85,6 +102,7 @@ type (
 		customTaskHandler         func(ctx context.Context, task *replicationspb.ReplicationTask) error
 		metricsHandler            metrics.Handler
 		retryPolicy               backoff.RetryPolicy
+		namespaceTaskRetryPolicy  backoff.RetryPolicy
 		lastProcessedMessageID    int64
 		lastRetrievedMessageID    int64
 		done                      chan struct{}
@@ -155,9 +173,10 @@ func (p *replicationMessageProcessor) handleReplicationTasks() {
 	taskCtx := headers.SetCallerInfo(context.TODO(), headers.SystemPreemptableCallerInfo)
 	for taskIndex := range response.Messages.ReplicationTasks {
 		task := response.Messages.ReplicationTasks[taskIndex]
+		policy := p.retryPolicyForTask(task)
 		err := backoff.ThrottleRetry(func() error {
 			return p.handleReplicationTask(taskCtx, task)
-		}, p.retryPolicy, isTransientRetryableError)
+		}, policy, isTransientRetryableError)
 
 		if err != nil {
 			metrics.ReplicatorFailures.With(p.metricsHandler).Record(1)
@@ -166,7 +185,7 @@ func (p *replicationMessageProcessor) handleReplicationTasks() {
 			dlqErr := backoff.ThrottleRetry(func() error {
 
 				return p.putNamespaceReplicationTaskToDLQ(taskCtx, task)
-			}, p.retryPolicy, isTransientRetryableError)
+			}, policy, isTransientRetryableError)
 			if dlqErr != nil {
 				p.logger.Error("Failed to put replication tasks to DLQ", tag.Error(dlqErr))
 				metrics.ReplicatorDLQFailures.With(p.metricsHandler).Record(1)
@@ -177,6 +196,19 @@ func (p *replicationMessageProcessor) handleReplicationTasks() {
 
 	p.lastProcessedMessageID = response.Messages.GetLastRetrievedMessageId()
 	p.lastRetrievedMessageID = response.Messages.GetLastRetrievedMessageId()
+}
+
+// retryPolicyForTask selects the retry policy used for both task application
+// and DLQ publish. Namespace tasks get a longer budget because they're gated on
+// the cluster-global namespace metadata CAS; other task types stay on the
+// shorter default to keep the single-threaded loop responsive.
+func (p *replicationMessageProcessor) retryPolicyForTask(task *replicationspb.ReplicationTask) backoff.RetryPolicy {
+	switch task.TaskType {
+	case enumsspb.REPLICATION_TASK_TYPE_NAMESPACE_TASK:
+		return p.namespaceTaskRetryPolicy
+	default:
+		return p.retryPolicy
+	}
 }
 
 func (p *replicationMessageProcessor) putNamespaceReplicationTaskToDLQ(

--- a/service/worker/replicator/replication_message_processor.go
+++ b/service/worker/replicator/replication_message_processor.go
@@ -34,13 +34,9 @@ const (
 
 	// Namespace replication tasks (failover, register, update) are gated on the
 	// cluster-global namespace metadata CAS, which can churn under contention.
-	// Give them a wider retry budget than other task types so a brief CAS burst
-	// or storage wobble doesn't drop them into the DLQ.
-	namespaceTaskRetryInitialInterval    = 2 * time.Second
-	namespaceTaskRetryBackoffCoefficient = 2.0
-	namespaceTaskRetryMaximumInterval    = 10 * time.Second
-	namespaceTaskRetryExpiration         = 1 * time.Minute
-	namespaceTaskRetryMaximumAttempts    = 15
+	// Allow more attempts than other task types so a brief CAS burst or storage
+	// wobble doesn't drop them into the DLQ.
+	namespaceTaskRetryMaxAttempts = 30
 )
 
 func newReplicationMessageProcessor(
@@ -61,13 +57,11 @@ func newReplicationMessageProcessor(
 		WithBackoffCoefficient(taskProcessorErrorRetryBackoffCoefficient).
 		WithMaximumAttempts(taskProcessorErrorRetryMaxAttampts)
 
-	namespaceTaskRetryPolicy := backoff.NewExponentialRetryPolicy(namespaceTaskRetryInitialInterval).
-		WithBackoffCoefficient(namespaceTaskRetryBackoffCoefficient).
-		WithMaximumInterval(namespaceTaskRetryMaximumInterval).
-		WithExpirationInterval(namespaceTaskRetryExpiration).
-		WithMaximumAttempts(namespaceTaskRetryMaximumAttempts)
+	namespaceTaskRetryPolicy := backoff.NewExponentialRetryPolicy(taskProcessorErrorRetryWait).
+		WithBackoffCoefficient(taskProcessorErrorRetryBackoffCoefficient).
+		WithMaximumAttempts(namespaceTaskRetryMaxAttempts)
 
-	// Namespace tasks get a longer budget because they're gated on the
+	// Namespace tasks get more retry attempts because they're gated on the
 	// cluster-global namespace metadata CAS; other task types stay on the
 	// shorter default to keep the single-threaded loop responsive.
 	retryPolicyForTask := func(task *replicationspb.ReplicationTask) backoff.RetryPolicy {

--- a/service/worker/replicator/replication_message_processor.go
+++ b/service/worker/replicator/replication_message_processor.go
@@ -57,7 +57,7 @@ func newReplicationMessageProcessor(
 	matchingClient matchingservice.MatchingServiceClient,
 	namespaceRegistry namespace.Registry,
 ) *replicationMessageProcessor {
-	retryPolicy := backoff.NewExponentialRetryPolicy(taskProcessorErrorRetryWait).
+	defaultRetryPolicy := backoff.NewExponentialRetryPolicy(taskProcessorErrorRetryWait).
 		WithBackoffCoefficient(taskProcessorErrorRetryBackoffCoefficient).
 		WithMaximumAttempts(taskProcessorErrorRetryMaxAttampts)
 
@@ -66,6 +66,18 @@ func newReplicationMessageProcessor(
 		WithMaximumInterval(namespaceTaskRetryMaximumInterval).
 		WithExpirationInterval(namespaceTaskRetryExpiration).
 		WithMaximumAttempts(namespaceTaskRetryMaximumAttempts)
+
+	// Namespace tasks get a longer budget because they're gated on the
+	// cluster-global namespace metadata CAS; other task types stay on the
+	// shorter default to keep the single-threaded loop responsive.
+	retryPolicyForTask := func(task *replicationspb.ReplicationTask) backoff.RetryPolicy {
+		switch task.TaskType {
+		case enumsspb.REPLICATION_TASK_TYPE_NAMESPACE_TASK:
+			return namespaceTaskRetryPolicy
+		default:
+			return defaultRetryPolicy
+		}
+	}
 
 	return &replicationMessageProcessor{
 		hostInfo:                  hostInfo,
@@ -78,8 +90,7 @@ func newReplicationMessageProcessor(
 		namespaceTaskExecutor:     namespaceTaskExecutor,
 		customTaskHandler:         customTaskHandler,
 		metricsHandler:            metricsHandler.WithTags(metrics.OperationTag(metrics.NamespaceReplicationTaskScope)),
-		retryPolicy:               retryPolicy,
-		namespaceTaskRetryPolicy:  namespaceTaskRetryPolicy,
+		retryPolicyForTask:        retryPolicyForTask,
 		lastProcessedMessageID:    -1,
 		lastRetrievedMessageID:    -1,
 		done:                      make(chan struct{}),
@@ -101,8 +112,7 @@ type (
 		namespaceTaskExecutor     nsreplication.TaskExecutor
 		customTaskHandler         func(ctx context.Context, task *replicationspb.ReplicationTask) error
 		metricsHandler            metrics.Handler
-		retryPolicy               backoff.RetryPolicy
-		namespaceTaskRetryPolicy  backoff.RetryPolicy
+		retryPolicyForTask        func(*replicationspb.ReplicationTask) backoff.RetryPolicy
 		lastProcessedMessageID    int64
 		lastRetrievedMessageID    int64
 		done                      chan struct{}
@@ -196,19 +206,6 @@ func (p *replicationMessageProcessor) handleReplicationTasks() {
 
 	p.lastProcessedMessageID = response.Messages.GetLastRetrievedMessageId()
 	p.lastRetrievedMessageID = response.Messages.GetLastRetrievedMessageId()
-}
-
-// retryPolicyForTask selects the retry policy used for both task application
-// and DLQ publish. Namespace tasks get a longer budget because they're gated on
-// the cluster-global namespace metadata CAS; other task types stay on the
-// shorter default to keep the single-threaded loop responsive.
-func (p *replicationMessageProcessor) retryPolicyForTask(task *replicationspb.ReplicationTask) backoff.RetryPolicy {
-	switch task.TaskType {
-	case enumsspb.REPLICATION_TASK_TYPE_NAMESPACE_TASK:
-		return p.namespaceTaskRetryPolicy
-	default:
-		return p.retryPolicy
-	}
 }
 
 func (p *replicationMessageProcessor) putNamespaceReplicationTaskToDLQ(

--- a/service/worker/replicator/replication_message_processor_test.go
+++ b/service/worker/replicator/replication_message_processor_test.go
@@ -1,0 +1,49 @@
+package replicator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	replicationspb "go.temporal.io/server/api/replication/v1"
+	"go.temporal.io/server/common/metrics"
+)
+
+// TestRetryPolicyForTask verifies that the processor's per-task retry-policy
+// selector hands out a distinct policy for namespace tasks (which need the
+// wider CAS-tolerant budget) and a shared default policy for all other task
+// types.
+func TestRetryPolicyForTask(t *testing.T) {
+	p := newReplicationMessageProcessor(
+		"currentCluster",
+		"sourceCluster",
+		nil,                          // logger
+		nil,                          // remotePeer
+		metrics.NoopMetricsHandler,   // metricsHandler — actually used by constructor
+		nil,                          // namespaceTaskExecutor
+		nil,                          // customTaskHandler
+		nil,                          // hostInfo
+		nil,                          // serviceResolver
+		nil,                          // namespaceReplicationQueue
+		nil,                          // matchingClient
+		nil,                          // namespaceRegistry
+	)
+
+	nsTask := &replicationspb.ReplicationTask{TaskType: enumsspb.REPLICATION_TASK_TYPE_NAMESPACE_TASK}
+	tqTask := &replicationspb.ReplicationTask{TaskType: enumsspb.REPLICATION_TASK_TYPE_TASK_QUEUE_USER_DATA}
+	historyTask := &replicationspb.ReplicationTask{TaskType: enumsspb.REPLICATION_TASK_TYPE_HISTORY_TASK}
+	unspecifiedTask := &replicationspb.ReplicationTask{TaskType: enumsspb.REPLICATION_TASK_TYPE_UNSPECIFIED}
+
+	nsPolicy := p.retryPolicyForTask(nsTask)
+	defaultPolicy := p.retryPolicyForTask(tqTask)
+
+	assert.NotSame(t, nsPolicy, defaultPolicy,
+		"namespace task must use a different retry policy from other task types")
+
+	// All non-namespace task types share the same default policy instance.
+	assert.Same(t, defaultPolicy, p.retryPolicyForTask(historyTask))
+	assert.Same(t, defaultPolicy, p.retryPolicyForTask(unspecifiedTask))
+
+	// Selector is stable across calls.
+	assert.Same(t, nsPolicy, p.retryPolicyForTask(nsTask))
+}

--- a/service/worker/replicator/replication_message_processor_test.go
+++ b/service/worker/replicator/replication_message_processor_test.go
@@ -3,7 +3,7 @@ package replicator
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common/metrics"
@@ -17,16 +17,16 @@ func TestRetryPolicyForTask(t *testing.T) {
 	p := newReplicationMessageProcessor(
 		"currentCluster",
 		"sourceCluster",
-		nil,                          // logger
-		nil,                          // remotePeer
-		metrics.NoopMetricsHandler,   // metricsHandler — actually used by constructor
-		nil,                          // namespaceTaskExecutor
-		nil,                          // customTaskHandler
-		nil,                          // hostInfo
-		nil,                          // serviceResolver
-		nil,                          // namespaceReplicationQueue
-		nil,                          // matchingClient
-		nil,                          // namespaceRegistry
+		nil,                        // logger
+		nil,                        // remotePeer
+		metrics.NoopMetricsHandler, // metricsHandler — actually used by constructor
+		nil,                        // namespaceTaskExecutor
+		nil,                        // customTaskHandler
+		nil,                        // hostInfo
+		nil,                        // serviceResolver
+		nil,                        // namespaceReplicationQueue
+		nil,                        // matchingClient
+		nil,                        // namespaceRegistry
 	)
 
 	nsTask := &replicationspb.ReplicationTask{TaskType: enumsspb.REPLICATION_TASK_TYPE_NAMESPACE_TASK}
@@ -37,13 +37,13 @@ func TestRetryPolicyForTask(t *testing.T) {
 	nsPolicy := p.retryPolicyForTask(nsTask)
 	defaultPolicy := p.retryPolicyForTask(tqTask)
 
-	assert.NotSame(t, nsPolicy, defaultPolicy,
+	require.NotSame(t, nsPolicy, defaultPolicy,
 		"namespace task must use a different retry policy from other task types")
 
 	// All non-namespace task types share the same default policy instance.
-	assert.Same(t, defaultPolicy, p.retryPolicyForTask(historyTask))
-	assert.Same(t, defaultPolicy, p.retryPolicyForTask(unspecifiedTask))
+	require.Same(t, defaultPolicy, p.retryPolicyForTask(historyTask))
+	require.Same(t, defaultPolicy, p.retryPolicyForTask(unspecifiedTask))
 
 	// Selector is stable across calls.
-	assert.Same(t, nsPolicy, p.retryPolicyForTask(nsTask))
+	require.Same(t, nsPolicy, p.retryPolicyForTask(nsTask))
 }


### PR DESCRIPTION
## What changed?
Increase retry attempts for namespace replication to up to 30.

## Why?
We saw under heavy load of failing over namespaces the replication tasks gets DLQ'd after 5 retries .   Increasing the retry policy in namespace replication to reduce the likelihood of DLQ'ing

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

 