### PR TITLE
Fix HistorySize double-count when a failed write is retried

### DIFF
--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -69,10 +69,47 @@ func (m *executionManagerImpl) GetHistoryBranchUtil() HistoryBranchUtil {
 
 // The below three APIs are related to serialization/deserialization
 
+// historySizeRollback records HistorySize increments applied to caller-owned ExecutionStats
+// during a write so they can be reverted if the write fails. The persistence layer mutates
+// the caller's (shared) in-memory mutable state in place; without reverting on failure, a
+// failed write that is later retried with the same mutable state double-counts HistorySize
+// (e.g. workflow-id reuse, where createBrandNew fails and createAsCurrent retries the same
+// snapshot). HistorySize is the only stat accumulated in this layer, so it is the only one
+// that needs this treatment.
+type historySizeRollback struct {
+	applied []appliedHistorySize
+}
+
+type appliedHistorySize struct {
+	stats *persistencespb.ExecutionStats
+	delta int64
+}
+
+// add applies sizeDiff to stats.HistorySize and remembers it so it can be reverted.
+func (r *historySizeRollback) add(stats *persistencespb.ExecutionStats, sizeDiff int) {
+	delta := int64(sizeDiff)
+	stats.HistorySize += delta
+	r.applied = append(r.applied, appliedHistorySize{stats: stats, delta: delta})
+}
+
+// revertOnError undoes every applied increment if *err is non-nil. Intended to be deferred
+// against a function's named return error.
+func (r *historySizeRollback) revertOnError(err *error) {
+	if *err == nil {
+		return
+	}
+	for _, a := range r.applied {
+		a.stats.HistorySize -= a.delta
+	}
+}
+
 func (m *executionManagerImpl) CreateWorkflowExecution(
 	ctx context.Context,
 	request *CreateWorkflowExecutionRequest,
-) (*CreateWorkflowExecutionResponse, error) {
+) (_ *CreateWorkflowExecutionResponse, retErr error) {
+
+	var rollback historySizeRollback
+	defer rollback.revertOnError(&retErr)
 
 	newSnapshot := request.NewWorkflowSnapshot
 	newWorkflowXDCKVs, newWorkflowNewEvents, newHistoryDiff, err := m.serializeWorkflowEventBatches(
@@ -85,7 +122,7 @@ func (m *executionManagerImpl) CreateWorkflowExecution(
 		return nil, err
 	}
 
-	newSnapshot.ExecutionInfo.ExecutionStats.HistorySize += int64(newHistoryDiff.SizeDiff)
+	rollback.add(newSnapshot.ExecutionInfo.ExecutionStats, newHistoryDiff.SizeDiff)
 
 	if err := ValidateCreateWorkflowModeState(
 		request.Mode,
@@ -132,7 +169,10 @@ func (m *executionManagerImpl) CreateWorkflowExecution(
 func (m *executionManagerImpl) UpdateWorkflowExecution(
 	ctx context.Context,
 	request *UpdateWorkflowExecutionRequest,
-) (*UpdateWorkflowExecutionResponse, error) {
+) (_ *UpdateWorkflowExecutionResponse, retErr error) {
+
+	var rollback historySizeRollback
+	defer rollback.revertOnError(&retErr)
 
 	updateMutation := request.UpdateWorkflowMutation
 	newSnapshot := request.NewWorkflowSnapshot
@@ -146,7 +186,7 @@ func (m *executionManagerImpl) UpdateWorkflowExecution(
 	if err != nil {
 		return nil, err
 	}
-	updateMutation.ExecutionInfo.ExecutionStats.HistorySize += int64(updateWorkflowHistoryDiff.SizeDiff)
+	rollback.add(updateMutation.ExecutionInfo.ExecutionStats, updateWorkflowHistoryDiff.SizeDiff)
 
 	var newWorkflowXDCKVs map[XDCCacheKey]XDCCacheValue
 	var newWorkflowNewEvents []*InternalAppendHistoryNodesRequest
@@ -161,7 +201,7 @@ func (m *executionManagerImpl) UpdateWorkflowExecution(
 		if err != nil {
 			return nil, err
 		}
-		newSnapshot.ExecutionInfo.ExecutionStats.HistorySize += int64(newWorkflowHistoryDiff.SizeDiff)
+		rollback.add(newSnapshot.ExecutionInfo.ExecutionStats, newWorkflowHistoryDiff.SizeDiff)
 	}
 
 	if err := ValidateUpdateWorkflowModeState(
@@ -273,7 +313,10 @@ func (m *executionManagerImpl) deleteHistoryTasks(
 func (m *executionManagerImpl) ConflictResolveWorkflowExecution(
 	ctx context.Context,
 	request *ConflictResolveWorkflowExecutionRequest,
-) (*ConflictResolveWorkflowExecutionResponse, error) {
+) (_ *ConflictResolveWorkflowExecutionResponse, retErr error) {
+
+	var rollback historySizeRollback
+	defer rollback.revertOnError(&retErr)
 
 	resetSnapshot := request.ResetWorkflowSnapshot
 	newSnapshot := request.NewWorkflowSnapshot
@@ -288,7 +331,7 @@ func (m *executionManagerImpl) ConflictResolveWorkflowExecution(
 	if err != nil {
 		return nil, err
 	}
-	resetSnapshot.ExecutionInfo.ExecutionStats.HistorySize += int64(resetWorkflowHistoryDiff.SizeDiff)
+	rollback.add(resetSnapshot.ExecutionInfo.ExecutionStats, resetWorkflowHistoryDiff.SizeDiff)
 
 	var newWorkflowXDCKVs map[XDCCacheKey]XDCCacheValue
 	var newWorkflowEvents []*InternalAppendHistoryNodesRequest
@@ -303,7 +346,7 @@ func (m *executionManagerImpl) ConflictResolveWorkflowExecution(
 		if err != nil {
 			return nil, err
 		}
-		newSnapshot.ExecutionInfo.ExecutionStats.HistorySize += int64(newWorkflowHistoryDiff.SizeDiff)
+		rollback.add(newSnapshot.ExecutionInfo.ExecutionStats, newWorkflowHistoryDiff.SizeDiff)
 	}
 
 	var currentWorkflowXDCKVs map[XDCCacheKey]XDCCacheValue
@@ -319,7 +362,7 @@ func (m *executionManagerImpl) ConflictResolveWorkflowExecution(
 		if err != nil {
 			return nil, err
 		}
-		currentMutation.ExecutionInfo.ExecutionStats.HistorySize += int64(currentWorkflowHistoryDiff.SizeDiff)
+		rollback.add(currentMutation.ExecutionInfo.ExecutionStats, currentWorkflowHistoryDiff.SizeDiff)
 	}
 
 	if err := ValidateConflictResolveWorkflowModeState(

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -67,8 +67,6 @@ func (m *executionManagerImpl) GetHistoryBranchUtil() HistoryBranchUtil {
 	return m.persistence.GetHistoryBranchUtil()
 }
 
-// The below three APIs are related to serialization/deserialization
-
 // historySizeRollback records HistorySize increments applied to caller-owned ExecutionStats
 // during a write so they can be reverted if the write fails. The persistence layer mutates
 // the caller's (shared) in-memory mutable state in place; without reverting on failure, a
@@ -103,6 +101,7 @@ func (r *historySizeRollback) revertOnError(err *error) {
 	}
 }
 
+// The below three APIs are related to serialization/deserialization
 func (m *executionManagerImpl) CreateWorkflowExecution(
 	ctx context.Context,
 	request *CreateWorkflowExecutionRequest,

--- a/common/persistence/tests/execution_mutable_state.go
+++ b/common/persistence/tests/execution_mutable_state.go
@@ -152,10 +152,6 @@ func (s *ExecutionMutableStateSuite) TestCreate_BrandNew_CurrentConflict() {
 		rand.Int63(),
 	)
 
-	// Remember original execution stats because the CreateWorkflowExecution mutates the stats before failing to persist
-	executionStats, ok := proto.Clone(newSnapshot.ExecutionInfo.ExecutionStats).(*persistencespb.ExecutionStats)
-	s.True(ok)
-
 	_, err := s.ExecutionManager.CreateWorkflowExecution(s.Ctx, &p.CreateWorkflowExecutionRequest{
 		ShardID: s.ShardID,
 		RangeID: s.RangeID,
@@ -182,8 +178,9 @@ func (s *ExecutionMutableStateSuite) TestCreate_BrandNew_CurrentConflict() {
 		StartTime:        timestamp.TimeValuePtr(newSnapshot.ExecutionState.StartTime),
 	}, err)
 
-	// Restore origin execution stats so GetWorkflowExecution matches with the pre-failed snapshot stats above
-	newSnapshot.ExecutionInfo.ExecutionStats = executionStats
+	// A failed CreateWorkflowExecution must not mutate the caller's snapshot. It previously leaked
+	// its HistorySize increment into newSnapshot, which double-counted on a retry that reused it;
+	// AssertMSEqualWithDB fails if the snapshot diverges from the persisted state, guarding that.
 	s.AssertMSEqualWithDB(chasm.WorkflowArchetypeID, newSnapshot)
 	s.AssertHEEqualWithDB(branchToken, newEvents)
 }
@@ -285,10 +282,6 @@ func (s *ExecutionMutableStateSuite) TestCreate_Reuse_CurrentConflict() {
 		rand.Int63(),
 	)
 
-	// Remember original execution stats because the CreateWorkflowExecution mutates the stats before failing to persist
-	executionStats, ok := proto.Clone(prevSnapshot.ExecutionInfo.ExecutionStats).(*persistencespb.ExecutionStats)
-	s.True(ok)
-
 	_, err := s.ExecutionManager.CreateWorkflowExecution(s.Ctx, &p.CreateWorkflowExecutionRequest{
 		ShardID: s.ShardID,
 		RangeID: s.RangeID,
@@ -315,8 +308,9 @@ func (s *ExecutionMutableStateSuite) TestCreate_Reuse_CurrentConflict() {
 		StartTime:        timestamp.TimeValuePtr(prevSnapshot.ExecutionState.StartTime),
 	}, err)
 
-	// Restore origin execution stats so GetWorkflowExecution matches with the pre-failed snapshot stats above
-	prevSnapshot.ExecutionInfo.ExecutionStats = executionStats
+	// A failed CreateWorkflowExecution must not mutate the caller's snapshot. It previously leaked
+	// its HistorySize increment into prevSnapshot, which double-counted on a retry that reused it;
+	// AssertMSEqualWithDB fails if the snapshot diverges from the persisted state, guarding that.
 	s.AssertMSEqualWithDB(chasm.WorkflowArchetypeID, prevSnapshot)
 	s.AssertHEEqualWithDB(branchToken, prevEvents)
 }

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -802,6 +802,83 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_Terminate() {
 	}
 }
 
+func (s *WorkflowTestSuite) TestStartWorkflowExecution_HistorySizeNotDoubleCountedOnReuse() {
+	// Reusing a workflow ID after the previous run has closed goes through createBrandNew
+	// (which fails because the closed run is still the "current" record) and falls back to
+	// createAsCurrent. A bug previously leaked the failed attempt's first-batch HistorySize
+	// increment into the retry, so the reused-ID run double-counted its first event batch in
+	// ExecutionStats.HistorySize. A reused-ID run has byte-identical history to a fresh run, so
+	// its reported HistorySizeBytes must match a fresh control run.
+	s.OverrideDynamicConfig(dynamicconfig.WorkflowIdReuseMinimalInterval, 0)
+
+	tv := testvars.New(s.T())
+
+	startRun := func(wfID string) string {
+		we, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), &workflowservice.StartWorkflowExecutionRequest{
+			RequestId:             uuid.NewString(),
+			Namespace:             s.Namespace().String(),
+			WorkflowId:            wfID,
+			WorkflowType:          tv.WorkflowType(),
+			TaskQueue:             tv.TaskQueue(),
+			WorkflowRunTimeout:    durationpb.New(100 * time.Second),
+			Identity:              tv.WorkerIdentity(),
+			WorkflowIdReusePolicy: enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+		})
+		s.NoError(err)
+		return we.RunId
+	}
+	historySize := func(wfID, runID string) int64 {
+		descResp, err := s.FrontendClient().DescribeWorkflowExecution(testcore.NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: s.Namespace().String(),
+			Execution: &commonpb.WorkflowExecution{WorkflowId: wfID, RunId: runID},
+		})
+		s.NoError(err)
+		return descResp.WorkflowExecutionInfo.GetHistorySizeBytes()
+	}
+	terminate := func(wfID, runID string) {
+		_, err := s.FrontendClient().TerminateWorkflowExecution(testcore.NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
+			Namespace:         s.Namespace().String(),
+			WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: wfID, RunId: runID},
+			Reason:            "test cleanup",
+		})
+		s.NoError(err)
+	}
+
+	// Control: a brand-new workflow ID. createBrandNew succeeds on the first attempt.
+	freshWfID := tv.WorkflowID() + "-fresh"
+	freshRunID := startRun(freshWfID)
+	freshAfterStart := historySize(freshWfID, freshRunID) // size of batch 1 ([Started, WFTScheduled])
+	terminate(freshWfID, freshRunID)
+	freshFinal := historySize(freshWfID, freshRunID) // batch1 + batch2 (terminated)
+
+	// Repro: reuse the same workflow ID after the first run is closed.
+	reuseWfID := tv.WorkflowID() + "-reuse"
+	run1ID := startRun(reuseWfID)
+	run1AfterStart := historySize(reuseWfID, run1ID)
+	terminate(reuseWfID, run1ID)
+
+	run2ID := startRun(reuseWfID)
+	run2AfterStart := historySize(reuseWfID, run2ID)
+	terminate(reuseWfID, run2ID)
+	run2Final := historySize(reuseWfID, run2ID)
+
+	s.T().Logf("history size: fresh afterStart=%d final=%d; reuse run1AfterStart=%d run2AfterStart=%d run2Final=%d",
+		freshAfterStart, freshFinal, run1AfterStart, run2AfterStart, run2Final)
+
+	s.Positive(freshAfterStart)
+	// Structurally identical runs can differ by a few bytes (varint-encoded task IDs and
+	// timestamps), so compare with a small tolerance. The bug inflated the reused-ID run by a
+	// whole extra first batch (run1AfterStart bytes, hundreds), far outside this tolerance.
+	const tolerance = 32.0
+	// run1 and run2 share the workflow ID; run1 is a clean create, run2 reuses the closed ID.
+	// They must report essentially the same size — not ~2x.
+	s.InDelta(run1AfterStart, run2AfterStart, tolerance,
+		"reused-ID run must not double-count its first event batch in ExecutionStats.HistorySize")
+	// Cross-check the reused-ID run against an independent fresh run.
+	s.InDelta(freshAfterStart, run2AfterStart, tolerance, "reused-ID run should match a fresh run after start")
+	s.InDelta(freshFinal, run2Final, tolerance, "reused-ID run should match a fresh run after terminate")
+}
+
 func (s *WorkflowTestSuite) TestStartWorkflowExecutionWithDelay() {
 	env := testcore.NewEnv(s.T())
 	tv := testvars.New(s.T())

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -809,14 +809,14 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_HistorySizeNotDoubleCount
 	// increment into the retry, so the reused-ID run double-counted its first event batch in
 	// ExecutionStats.HistorySize. A reused-ID run has byte-identical history to a fresh run, so
 	// its reported HistorySizeBytes must match a fresh control run.
-	s.OverrideDynamicConfig(dynamicconfig.WorkflowIdReuseMinimalInterval, 0)
+	env := testcore.NewEnv(s.T(), testcore.WithDynamicConfig(dynamicconfig.WorkflowIdReuseMinimalInterval, 0))
 
 	tv := testvars.New(s.T())
 
 	startRun := func(wfID string) string {
-		we, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), &workflowservice.StartWorkflowExecutionRequest{
+		we, err := env.FrontendClient().StartWorkflowExecution(s.Context(), &workflowservice.StartWorkflowExecutionRequest{
 			RequestId:             uuid.NewString(),
-			Namespace:             s.Namespace().String(),
+			Namespace:             env.Namespace().String(),
 			WorkflowId:            wfID,
 			WorkflowType:          tv.WorkflowType(),
 			TaskQueue:             tv.TaskQueue(),
@@ -828,16 +828,16 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_HistorySizeNotDoubleCount
 		return we.RunId
 	}
 	historySize := func(wfID, runID string) int64 {
-		descResp, err := s.FrontendClient().DescribeWorkflowExecution(testcore.NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
-			Namespace: s.Namespace().String(),
+		descResp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
 			Execution: &commonpb.WorkflowExecution{WorkflowId: wfID, RunId: runID},
 		})
 		s.NoError(err)
 		return descResp.WorkflowExecutionInfo.GetHistorySizeBytes()
 	}
 	terminate := func(wfID, runID string) {
-		_, err := s.FrontendClient().TerminateWorkflowExecution(testcore.NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
-			Namespace:         s.Namespace().String(),
+		_, err := env.FrontendClient().TerminateWorkflowExecution(s.Context(), &workflowservice.TerminateWorkflowExecutionRequest{
+			Namespace:         env.Namespace().String(),
 			WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: wfID, RunId: runID},
 			Reason:            "test cleanup",
 		})


### PR DESCRIPTION
## What changed

`ExecutionManager.{Create,Update,ConflictResolve}WorkflowExecution` increment `ExecutionStats.HistorySize` on the caller's (shared) in-memory mutable state **before** the persistence write, and never roll it back when the write fails. When the failed call is retried with the same snapshot, the increment is applied twice.

This manifests on **workflow-id reuse**: starting a new run whose id still has a closed "current" record tries `createBrandNew` (which fails with `CurrentWorkflowConditionFailedError` *after* the in-memory increment) and falls back to `createAsCurrent`, reusing the same snapshot — so the first event batch is counted twice in `HistorySize` (e.g. 419 → 712), inflating the value reported by `DescribeWorkflowExecution`.

## Fix

Apply each `HistorySize` increment through a small `historySizeRollback` helper and revert it via a deferred check on the function's named return error, so a failed write leaves the caller's stats untouched. `HistorySize` is the only stat accumulated in this layer.

## Tests
- `tests/workflow_test.go`: end-to-end reuse repro asserting the reused-id run's `HistorySizeBytes` matches a fresh run.
- `common/persistence/tests/execution_mutable_state.go`: drop the clone/restore workaround in the two create `CurrentConflict` tests so `AssertMSEqualWithDB` now guards that a failed write does not leak the increment.