### PR TITLE
Always start worker service in test clusters

### DIFF
--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -99,7 +99,6 @@ type (
 		DynamicConfigOverrides          map[dynamicconfig.Key]any
 		ArchivalEnabled                 bool
 		EnableMTLS                      bool
-		EnableWorkerService             bool
 		FaultInjectionConfig            *config.FaultInjection
 		NumHistoryShards                int32
 		Logger                          log.Logger
@@ -161,12 +160,6 @@ func WithArchivalEnabled() TestClusterOption {
 func WithMTLS() TestClusterOption {
 	return func(params *TestClusterParams) {
 		params.EnableMTLS = true
-	}
-}
-
-func withWorkerService(enabled bool) TestClusterOption {
-	return func(params *TestClusterParams) {
-		params.EnableWorkerService = enabled
 	}
 }
 
@@ -324,7 +317,6 @@ func (s *FunctionalTestBase) setupCluster(options ...TestClusterOption) {
 		EnableMTLS:                      params.EnableMTLS,
 		CustomHistoryArchiverFactory:    params.CustomHistoryArchiverFactory,
 		CustomVisibilityArchiverFactory: params.CustomVisibilityArchiverFactory,
-		WorkerConfig:                    WorkerConfig{DisableWorker: !params.EnableWorkerService},
 	}
 
 	// Apply configuration for shared clusters.
@@ -402,8 +394,7 @@ func (s *FunctionalTestBase) checkTestShard() {
 
 func ApplyTestClusterOptions(options []TestClusterOption) TestClusterParams {
 	params := TestClusterParams{
-		ServiceOptions:      make(map[primitives.ServiceName][]fx.Option),
-		EnableWorkerService: true,
+		ServiceOptions: make(map[primitives.ServiceName][]fx.Option),
 	}
 	for _, opt := range options {
 		opt(&params)

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -13,8 +13,6 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 )
 
-const suiteDedicatedWorkerClusterMinEnvCount = 8
-
 var testClusterPool *clusterPool
 
 func init() {
@@ -241,8 +239,7 @@ func (p *clusterPool) createCluster(t *testing.T, dynamicConfig map[dynamicconfi
 	tbase := &FunctionalTestBase{}
 	tbase.SetT(t)
 
-	// Keep the worker service off unless explicitly enabled via WithWorkerService.
-	opts := []TestClusterOption{withWorkerService(false)}
+	opts := []TestClusterOption{}
 	if shared {
 		opts = append(opts, WithSharedCluster())
 	}
@@ -270,19 +267,6 @@ func (p *clusterPool) useSuiteScopedCluster(t *testing.T, reason string) {
 	})
 }
 
-func (p *clusterPool) recordEnvUsage(t *testing.T, workerServiceReason string, suiteShareableDedicated bool) {
-	t.Helper()
-	rootName := rootTestName(t)
-	p.suites.recordUsage(t, rootName, workerServiceReason, suiteShareableDedicated)
-}
-
-type suiteClusterUsage struct {
-	mu                     sync.Mutex
-	envCount               int
-	workerDedicatedCount   int
-	workerDedicatedReasons []string
-}
-
 type suiteScopedClusterConfig struct {
 	clusterOpts []TestClusterOption
 	params      TestClusterParams
@@ -300,7 +284,7 @@ type suiteState struct {
 }
 
 func newSuiteScopedClusterConfig(clusterOpts []TestClusterOption) suiteScopedClusterConfig {
-	opts := []TestClusterOption{withWorkerService(false), WithSharedCluster()}
+	opts := []TestClusterOption{WithSharedCluster()}
 	opts = append(opts, clusterOpts...)
 
 	return suiteScopedClusterConfig{
@@ -323,7 +307,6 @@ func UseSuiteScopedCluster(t *testing.T, reason string) {
 
 type suiteRegistry struct {
 	suites sync.Map
-	usage  sync.Map
 }
 
 func (s *suiteRegistry) register(t *testing.T, rootName string, reason string) {
@@ -382,7 +365,6 @@ func (s *suiteRegistry) cleanup(t *testing.T, rootName string) {
 		}
 	}
 	s.suites.Delete(rootName)
-	s.usage.Delete(rootName)
 }
 
 func (s *suiteState) getCluster(clusterOpts []TestClusterOption) *suiteScopedCluster {
@@ -400,36 +382,6 @@ func (s *suiteState) getCluster(clusterOpts []TestClusterOption) *suiteScopedClu
 	}
 	s.clusters = append(s.clusters, cluster)
 	return cluster
-}
-
-func (s *suiteRegistry) recordUsage(t *testing.T, rootName string, workerServiceReason string, suiteShareableDedicated bool) {
-	t.Helper()
-	usageAny, _ := s.usage.LoadOrStore(rootName, &suiteClusterUsage{})
-	usage := usageAny.(*suiteClusterUsage)
-	usage.mu.Lock()
-	defer usage.mu.Unlock()
-
-	usage.envCount++
-	if workerServiceReason != "" && suiteShareableDedicated {
-		usage.workerDedicatedCount++
-		usage.workerDedicatedReasons = append(usage.workerDedicatedReasons, workerServiceReason)
-	}
-
-	// Check for too many dedicated worker clusters.
-	if tooManyDedicatedWorkerClusters(usage.envCount, usage.workerDedicatedCount) {
-		t.Fatalf(
-			"suite %s created %d worker-service dedicated clusters across %d test envs (reasons: %s); if those clusters can be suite-owned, use testcore.UseSuiteScopedCluster(t, \"reason\")",
-			rootName,
-			usage.workerDedicatedCount,
-			usage.envCount,
-			strings.Join(usage.workerDedicatedReasons, "; "),
-		)
-	}
-}
-
-func tooManyDedicatedWorkerClusters(envCount int, workerDedicatedCount int) bool {
-	return envCount >= suiteDedicatedWorkerClusterMinEnvCount &&
-		workerDedicatedCount*2 > envCount
 }
 
 func rootTestName(t *testing.T) string {

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -270,10 +270,10 @@ func (p *clusterPool) useSuiteScopedCluster(t *testing.T, reason string) {
 	})
 }
 
-func (p *clusterPool) recordEnvUsage(t *testing.T, workerServiceReason string, workerServiceDedicated bool) {
+func (p *clusterPool) recordEnvUsage(t *testing.T, workerServiceReason string, suiteShareableDedicated bool) {
 	t.Helper()
 	rootName := rootTestName(t)
-	p.suites.recordUsage(t, rootName, workerServiceReason, workerServiceDedicated)
+	p.suites.recordUsage(t, rootName, workerServiceReason, suiteShareableDedicated)
 }
 
 type suiteClusterUsage struct {
@@ -402,7 +402,7 @@ func (s *suiteState) getCluster(clusterOpts []TestClusterOption) *suiteScopedClu
 	return cluster
 }
 
-func (s *suiteRegistry) recordUsage(t *testing.T, rootName string, workerServiceReason string, workerServiceDedicated bool) {
+func (s *suiteRegistry) recordUsage(t *testing.T, rootName string, workerServiceReason string, suiteShareableDedicated bool) {
 	t.Helper()
 	usageAny, _ := s.usage.LoadOrStore(rootName, &suiteClusterUsage{})
 	usage := usageAny.(*suiteClusterUsage)
@@ -410,7 +410,7 @@ func (s *suiteRegistry) recordUsage(t *testing.T, rootName string, workerService
 	defer usage.mu.Unlock()
 
 	usage.envCount++
-	if workerServiceDedicated {
+	if workerServiceReason != "" && suiteShareableDedicated {
 		usage.workerDedicatedCount++
 		usage.workerDedicatedReasons = append(usage.workerDedicatedReasons, workerServiceReason)
 	}

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -2,15 +2,18 @@ package testcore
 
 import (
 	"os"
+	"reflect"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 
 	"go.temporal.io/server/common/dynamicconfig"
 )
+
+const suiteDedicatedWorkerClusterMinEnvCount = 8
 
 var testClusterPool *clusterPool
 
@@ -40,160 +43,162 @@ func init() {
 		maxUsage = 50
 	}
 
-	sharedPool := newPool(sharedSize, false)
-	sharedPool.maxUsage = maxUsage
-
-	dedicatedPool := newPool(dedicatedSize, true)
-	dedicatedPool.maxUsage = maxUsage
-
 	testClusterPool = &clusterPool{
-		shared:    sharedPool,
-		dedicated: dedicatedPool,
+		shared:    newPool(sharedSize, false, maxUsage),
+		dedicated: newPool(dedicatedSize, true, maxUsage),
+		suites:    &suiteRegistry{},
 	}
 }
 
-// pool manages a fixed number of test clusters with lazy initialization.
+// pool manages a fixed number of test cluster slots.
 type pool struct {
-	clusters []*FunctionalTestBase
-	inits    []sync.Once
-	counter  atomic.Int64 // for round-robin (when slots is nil)
-	slots    chan int     // for exclusive access (nil means shared/concurrent access)
-
-	// For shared pools: track usage and support teardown/recreate after maxUsage tests
-	usageCounts []atomic.Int64
-	clusterMu   []sync.Mutex // protects cluster teardown/recreate
-	maxUsage    int          // max tests per cluster before recreate (0 = unlimited)
-	createFn    func() *FunctionalTestBase
+	slots     []*clusterSlot
+	next      int
+	mu        sync.Mutex
+	available chan *clusterSlot
 }
 
-func newPool(size int, exclusive bool) *pool {
+func newPool(size int, exclusive bool, maxUsage int) *pool {
 	p := &pool{
-		clusters:    make([]*FunctionalTestBase, size),
-		inits:       make([]sync.Once, size),
-		usageCounts: make([]atomic.Int64, size),
-		clusterMu:   make([]sync.Mutex, size),
+		slots: make([]*clusterSlot, size),
+	}
+	for i := range size {
+		p.slots[i] = &clusterSlot{idx: i, maxUsage: maxUsage}
 	}
 	if exclusive {
-		p.slots = make(chan int, size)
-		for i := range size {
-			p.slots <- i
+		p.available = make(chan *clusterSlot, size)
+		for _, slot := range p.slots {
+			p.available <- slot
 		}
 	}
 	return p
 }
 
-// get returns a cluster from the pool, creating it lazily if needed.
-// For exclusive pools, blocks until a slot is available and registers cleanup.
-// For shared pools, uses round-robin.
-// Both pool types may recreate clusters after maxUsage tests (in CI).
+// get returns a cluster from the pool, creating it lazily if needed. Exclusive
+// pools block until a slot is available. Shared pools choose slots round-robin.
+// Both pool types may recreate clusters after maxUsage tests once active users release them.
 func (p *pool) get(t *testing.T, createCluster func() *FunctionalTestBase) *FunctionalTestBase {
-	var idx int
-	if p.slots != nil {
-		idx = <-p.slots
-		t.Cleanup(func() { p.slots <- idx })
+	var slot *clusterSlot
+	if p.available != nil {
+		slot = <-p.available
 	} else {
-		idx = int(p.counter.Add(1)-1) % len(p.clusters)
+		slot = p.nextSlot()
 	}
 
-	// Check if we need to recreate the cluster after maxUsage tests
-	if p.maxUsage > 0 {
-		usage := p.usageCounts[idx].Add(1)
-		if usage > int64(p.maxUsage) {
-			p.clusterMu[idx].Lock()
-			// Double-check after acquiring lock
-			if p.usageCounts[idx].Load() > int64(p.maxUsage) && p.clusters[idx] != nil {
-				if err := p.clusters[idx].tearDownTestCluster(); err != nil {
-					t.Logf("Failed to tear down cluster %d: %v", idx, err)
-				}
-				p.clusters[idx] = createCluster()
-				p.usageCounts[idx].Store(1) // Reset to 1 (this test counts)
-			}
-			p.clusterMu[idx].Unlock()
+	cluster := slot.acquire(t, createCluster)
+	t.Cleanup(func() {
+		slot.release(t)
+		if p.available != nil {
+			p.available <- slot
 		}
-	}
-
-	// Lazy initialization for first use
-	p.inits[idx].Do(func() {
-		p.clusters[idx] = createCluster()
 	})
 
-	cluster := p.clusters[idx]
-
-	// Swap out poisoned clusters. The poisoned cluster will tear itself down during its last
-	// test run's cleanup.
-	if cluster.Poisoned() {
-		p.clusterMu[idx].Lock()
-		if p.clusters[idx].Poisoned() {
-			p.clusters[idx] = createCluster()
-			if p.maxUsage > 0 {
-				p.usageCounts[idx].Store(1)
-			}
-		}
-		cluster = p.clusters[idx]
-		p.clusterMu[idx].Unlock()
-	}
-
-	cluster.SetT(t)
 	return cluster
+}
+
+func (p *pool) nextSlot() *clusterSlot {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	slot := p.slots[p.next%len(p.slots)]
+	p.next++
+	return slot
 }
 
 // acquireSlot gets exclusive access to a slot without using a pooled cluster.
 // Used when a fresh cluster is needed (e.g., custom dynamic config).
 func (p *pool) acquireSlot(t *testing.T) {
-	if p.slots == nil {
+	if p.available == nil {
 		return
 	}
-	idx := <-p.slots
-	t.Cleanup(func() { p.slots <- idx })
+	slot := <-p.available
+	t.Cleanup(func() { p.available <- slot })
+}
+
+type clusterSlot struct {
+	idx     int
+	mu      sync.Mutex
+	cluster *FunctionalTestBase
+	usage   int
+	active  int
+	// maxUsage is the max tests per cluster before recreate (0 = unlimited).
+	maxUsage int
+}
+
+func (s *clusterSlot) acquire(t *testing.T, createCluster func() *FunctionalTestBase) *FunctionalTestBase {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.cluster != nil && s.cluster.Poisoned() {
+		s.cluster = createCluster()
+		s.usage = 0
+	}
+	if s.maxUsage > 0 && s.cluster != nil && s.usage >= s.maxUsage && s.active == 0 {
+		if err := s.cluster.tearDownTestCluster(); err != nil {
+			t.Logf("Failed to tear down cluster %d: %v", s.idx, err)
+		}
+		s.cluster = nil
+		s.usage = 0
+	}
+	if s.cluster == nil {
+		s.cluster = createCluster()
+	}
+
+	s.usage++
+	s.active++
+	s.cluster.SetT(t)
+	return s.cluster
+}
+
+func (s *clusterSlot) release(t *testing.T) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.active--
+	if s.active > 0 || s.maxUsage == 0 || s.usage < s.maxUsage || s.cluster == nil {
+		return
+	}
+
+	s.tearDownLocked(t)
+}
+
+func (s *clusterSlot) tearDown(t *testing.T) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tearDownLocked(t)
+}
+
+func (s *clusterSlot) tearDownLocked(t *testing.T) {
+	if s.cluster == nil {
+		return
+	}
+	if err := s.cluster.tearDownTestCluster(); err != nil {
+		if s.idx < 0 {
+			t.Logf("Failed to tear down suite-scoped cluster: %v", err)
+		} else {
+			t.Logf("Failed to tear down cluster %d: %v", s.idx, err)
+		}
+	}
+	s.cluster = nil
+	s.usage = 0
 }
 
 type clusterPool struct {
-	shared      *pool
-	dedicated   *pool
-	suiteScoped sync.Map
-}
-
-type suiteScopedCluster struct {
-	once    sync.Once
-	cluster *FunctionalTestBase
-}
-
-// UseSuiteScopedCluster makes NewEnv use one cluster for all tests under `t`.
-// The cluster is created on first use and torn down when `t` completes.
-//
-// Deprecated: this only exists for backwards-compatibility with legacy sequential
-// suite execution.
-func UseSuiteScopedCluster(t *testing.T) {
-	t.Helper()
-	rootName, _, _ := strings.Cut(t.Name(), "/")
-	if t.Name() != rootName {
-		t.Fatalf("UseSuiteScopedCluster must be called from a top-level test, got %q", t.Name())
-	}
-	testClusterPool.suiteScoped.LoadOrStore(rootName, &suiteScopedCluster{})
-
-	t.Cleanup(func() {
-		suiteClusterAny, ok := testClusterPool.suiteScoped.Load(rootName)
-		if ok {
-			suiteCluster := suiteClusterAny.(*suiteScopedCluster)
-			if suiteCluster.cluster != nil {
-				if err := suiteCluster.cluster.tearDownTestCluster(); err != nil {
-					t.Logf("Failed to tear down suite-scoped cluster: %v", err)
-				}
-			}
-		}
-		testClusterPool.suiteScoped.Delete(rootName)
-	})
+	shared    *pool
+	dedicated *pool
+	suites    *suiteRegistry
 }
 
 func (p *clusterPool) get(t *testing.T, dedicated bool, dynamicConfig map[dynamicconfig.Key]any, clusterOpts []TestClusterOption) (tb *FunctionalTestBase) {
 	defer func() {
 		tb.RegisterTest(t)
 	}()
+	if !dedicated && len(dynamicConfig) == 0 {
+		if cluster := p.getSuiteScoped(t, clusterOpts); cluster != nil {
+			return cluster
+		}
+	}
 	if dedicated || len(dynamicConfig) > 0 || len(clusterOpts) > 0 {
 		return p.getDedicated(t, dynamicConfig, clusterOpts)
-	}
-	if cluster := p.getSuiteScoped(t); cluster != nil {
-		return cluster
 	}
 	return p.getShared(t)
 }
@@ -204,19 +209,10 @@ func (p *clusterPool) getShared(t *testing.T) *FunctionalTestBase {
 	})
 }
 
-func (p *clusterPool) getSuiteScoped(t *testing.T) *FunctionalTestBase {
-	rootName, _, _ := strings.Cut(t.Name(), "/")
-	if _, ok := p.suiteScoped.Load(rootName); !ok {
-		return nil
-	}
-
-	suiteClusterAny, _ := p.suiteScoped.LoadOrStore(rootName, &suiteScopedCluster{})
-	suiteCluster := suiteClusterAny.(*suiteScopedCluster)
-	suiteCluster.once.Do(func() {
-		suiteCluster.cluster = p.createCluster(t, nil, true, nil)
+func (p *clusterPool) getSuiteScoped(t *testing.T, clusterOpts []TestClusterOption) *FunctionalTestBase {
+	return p.suites.get(t, rootTestName(t), clusterOpts, func(clusterOpts []TestClusterOption) *FunctionalTestBase {
+		return p.createCluster(t, nil, true, clusterOpts)
 	})
-	suiteCluster.cluster.SetT(t)
-	return suiteCluster.cluster
 }
 
 func (p *clusterPool) getDedicated(t *testing.T, dynamicConfig map[dynamicconfig.Key]any, clusterOpts []TestClusterOption) *FunctionalTestBase {
@@ -258,4 +254,185 @@ func (p *clusterPool) createCluster(t *testing.T, dynamicConfig map[dynamicconfi
 	tbase.setupCluster(opts...)
 
 	return tbase
+}
+
+func (p *clusterPool) canUseSuiteScopedCluster(t *testing.T, dedicated bool) bool {
+	return !dedicated && p.suites.registered(rootTestName(t))
+}
+
+func (p *clusterPool) useSuiteScopedCluster(t *testing.T, reason string) {
+	t.Helper()
+	rootName := rootTestName(t)
+	p.suites.register(t, rootName, reason)
+
+	t.Cleanup(func() {
+		p.suites.cleanup(t, rootName)
+	})
+}
+
+func (p *clusterPool) recordEnvUsage(t *testing.T, workerServiceReason string, workerServiceDedicated bool) {
+	t.Helper()
+	rootName := rootTestName(t)
+	p.suites.recordUsage(t, rootName, workerServiceReason, workerServiceDedicated)
+}
+
+type suiteClusterUsage struct {
+	mu                     sync.Mutex
+	envCount               int
+	workerDedicatedCount   int
+	workerDedicatedReasons []string
+}
+
+type suiteScopedClusterConfig struct {
+	clusterOpts []TestClusterOption
+	params      TestClusterParams
+}
+
+type suiteScopedCluster struct {
+	slot   *clusterSlot
+	config suiteScopedClusterConfig
+}
+
+type suiteState struct {
+	reason   string
+	mu       sync.Mutex
+	clusters []*suiteScopedCluster
+}
+
+func newSuiteScopedClusterConfig(clusterOpts []TestClusterOption) suiteScopedClusterConfig {
+	opts := []TestClusterOption{withWorkerService(false), WithSharedCluster()}
+	opts = append(opts, clusterOpts...)
+
+	return suiteScopedClusterConfig{
+		clusterOpts: slices.Clone(clusterOpts),
+		params:      ApplyTestClusterOptions(opts),
+	}
+}
+
+func (c suiteScopedClusterConfig) matches(other suiteScopedClusterConfig) bool {
+	return reflect.DeepEqual(c.params, other.params)
+}
+
+// UseSuiteScopedCluster makes NewEnv reuse suite-owned clusters for shareable
+// cluster configs under `t`. The reason documents why the suite should pool
+// those clusters instead of using the shared pool or one-off dedicated clusters.
+func UseSuiteScopedCluster(t *testing.T, reason string) {
+	t.Helper()
+	testClusterPool.useSuiteScopedCluster(t, reason)
+}
+
+type suiteRegistry struct {
+	suites sync.Map
+	usage  sync.Map
+}
+
+func (s *suiteRegistry) register(t *testing.T, rootName string, reason string) {
+	t.Helper()
+	if t.Name() != rootName {
+		t.Fatalf("UseSuiteScopedCluster must be called from a top-level test, got %q", t.Name())
+	}
+	if reason == "" {
+		t.Fatalf("UseSuiteScopedCluster requires a reason")
+	}
+	stateAny, loaded := s.suites.LoadOrStore(rootName, &suiteState{reason: reason})
+	if !loaded {
+		return
+	}
+	state := stateAny.(*suiteState)
+	if state.reason != reason {
+		t.Fatalf("suite-scoped cluster reason for %q differs from the registered reason", rootName)
+	}
+}
+
+func (s *suiteRegistry) get(
+	t *testing.T,
+	rootName string,
+	clusterOpts []TestClusterOption,
+	createCluster func([]TestClusterOption) *FunctionalTestBase,
+) *FunctionalTestBase {
+	stateAny, ok := s.suites.Load(rootName)
+	if !ok {
+		return nil
+	}
+	state := stateAny.(*suiteState)
+	suiteCluster := state.getCluster(clusterOpts)
+	cluster := suiteCluster.slot.acquire(t, func() *FunctionalTestBase {
+		return createCluster(suiteCluster.config.clusterOpts)
+	})
+	t.Cleanup(func() {
+		suiteCluster.slot.release(t)
+	})
+	return cluster
+}
+
+func (s *suiteRegistry) registered(rootName string) bool {
+	_, ok := s.suites.Load(rootName)
+	return ok
+}
+
+func (s *suiteRegistry) cleanup(t *testing.T, rootName string) {
+	stateAny, ok := s.suites.Load(rootName)
+	if ok {
+		state := stateAny.(*suiteState)
+		state.mu.Lock()
+		clusters := slices.Clone(state.clusters)
+		state.mu.Unlock()
+		for _, suiteCluster := range clusters {
+			suiteCluster.slot.tearDown(t)
+		}
+	}
+	s.suites.Delete(rootName)
+	s.usage.Delete(rootName)
+}
+
+func (s *suiteState) getCluster(clusterOpts []TestClusterOption) *suiteScopedCluster {
+	config := newSuiteScopedClusterConfig(clusterOpts)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, cluster := range s.clusters {
+		if cluster.config.matches(config) {
+			return cluster
+		}
+	}
+	cluster := &suiteScopedCluster{
+		slot:   &clusterSlot{idx: -1},
+		config: config,
+	}
+	s.clusters = append(s.clusters, cluster)
+	return cluster
+}
+
+func (s *suiteRegistry) recordUsage(t *testing.T, rootName string, workerServiceReason string, workerServiceDedicated bool) {
+	t.Helper()
+	usageAny, _ := s.usage.LoadOrStore(rootName, &suiteClusterUsage{})
+	usage := usageAny.(*suiteClusterUsage)
+	usage.mu.Lock()
+	defer usage.mu.Unlock()
+
+	usage.envCount++
+	if workerServiceDedicated {
+		usage.workerDedicatedCount++
+		usage.workerDedicatedReasons = append(usage.workerDedicatedReasons, workerServiceReason)
+	}
+
+	// Check for too many dedicated worker clusters.
+	if tooManyDedicatedWorkerClusters(usage.envCount, usage.workerDedicatedCount) {
+		t.Fatalf(
+			"suite %s created %d worker-service dedicated clusters across %d test envs (reasons: %s); if those clusters can be suite-owned, use testcore.UseSuiteScopedCluster(t, \"reason\")",
+			rootName,
+			usage.workerDedicatedCount,
+			usage.envCount,
+			strings.Join(usage.workerDedicatedReasons, "; "),
+		)
+	}
+}
+
+func tooManyDedicatedWorkerClusters(envCount int, workerDedicatedCount int) bool {
+	return envCount >= suiteDedicatedWorkerClusterMinEnvCount &&
+		workerDedicatedCount*2 > envCount
+}
+
+func rootTestName(t *testing.T) string {
+	rootName, _, _ := strings.Cut(t.Name(), "/")
+	return rootName
 }

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -332,7 +332,7 @@ func (s *suiteRegistry) register(t *testing.T, rootName string, reason string) {
 		t.Fatalf("UseSuiteScopedCluster must be called from a top-level test, got %q", t.Name())
 	}
 	if reason == "" {
-		t.Fatalf("UseSuiteScopedCluster requires a reason")
+		t.Fatal("UseSuiteScopedCluster requires a reason")
 	}
 	stateAny, loaded := s.suites.LoadOrStore(rootName, &suiteState{reason: reason})
 	if !loaded {

--- a/tests/testcore/test_cluster_pool_test.go
+++ b/tests/testcore/test_cluster_pool_test.go
@@ -26,19 +26,12 @@ func TestGlobalOverridesSurviveTestCleanup(t *testing.T) {
 	}
 }
 
-func TestSuiteScopedClusterConfigMatchesWorkerService(t *testing.T) {
+func TestSuiteScopedClusterConfigMatchesClusterOptions(t *testing.T) {
 	shared := newSuiteScopedClusterConfig(nil)
-	worker := newSuiteScopedClusterConfig([]TestClusterOption{withWorkerService(true)})
+	customShards := newSuiteScopedClusterConfig([]TestClusterOption{WithNumHistoryShards(8)})
 
-	require.True(t, worker.matches(newSuiteScopedClusterConfig([]TestClusterOption{withWorkerService(true)})))
-	require.False(t, shared.matches(worker))
-}
-
-func TestTooManyDedicatedWorkerClusters(t *testing.T) {
-	require.False(t, tooManyDedicatedWorkerClusters(1, 1))
-	require.False(t, tooManyDedicatedWorkerClusters(7, 7))
-	require.False(t, tooManyDedicatedWorkerClusters(8, 4))
-	require.True(t, tooManyDedicatedWorkerClusters(8, 5))
+	require.True(t, customShards.matches(newSuiteScopedClusterConfig([]TestClusterOption{WithNumHistoryShards(8)})))
+	require.False(t, shared.matches(customShards))
 }
 
 func TestPoolMaxUsageRecyclesAfterActiveTest(t *testing.T) {
@@ -96,14 +89,14 @@ func TestClusterSlotMaxUsageWaitsForActiveLeases(t *testing.T) {
 	require.Equal(t, 0, slot.usage)
 }
 
-func TestSuiteScopedWorkerServiceSharesClusterAndNamespaces(t *testing.T) {
-	UseSuiteScopedCluster(t, "reuse worker-service cluster")
+func TestSuiteScopedClusterSharesClusterAndNamespaces(t *testing.T) {
+	UseSuiteScopedCluster(t, "reuse suite cluster")
 
 	var firstCluster *TestCluster
 	var firstNamespace string
 
 	t.Run("first", func(t *testing.T) {
-		env := NewEnv(t, WithWorkerService("test"))
+		env := NewEnv(t)
 
 		firstCluster = env.GetTestCluster()
 		firstNamespace = env.Namespace().String()
@@ -112,7 +105,7 @@ func TestSuiteScopedWorkerServiceSharesClusterAndNamespaces(t *testing.T) {
 	})
 
 	t.Run("second", func(t *testing.T) {
-		env := NewEnv(t, WithWorkerService("test"))
+		env := NewEnv(t)
 
 		require.Same(t, firstCluster, env.GetTestCluster())
 		require.NotEqual(t, firstNamespace, env.Namespace().String())

--- a/tests/testcore/test_cluster_pool_test.go
+++ b/tests/testcore/test_cluster_pool_test.go
@@ -25,3 +25,98 @@ func TestGlobalOverridesSurviveTestCleanup(t *testing.T) {
 		require.Equal(t, v, got[0].Value, "key %s wrong after cleanup", k)
 	}
 }
+
+func TestSuiteScopedClusterConfigMatchesWorkerService(t *testing.T) {
+	shared := newSuiteScopedClusterConfig(nil)
+	worker := newSuiteScopedClusterConfig([]TestClusterOption{withWorkerService(true)})
+
+	require.True(t, worker.matches(newSuiteScopedClusterConfig([]TestClusterOption{withWorkerService(true)})))
+	require.False(t, shared.matches(worker))
+}
+
+func TestTooManyDedicatedWorkerClusters(t *testing.T) {
+	require.False(t, tooManyDedicatedWorkerClusters(1, 1))
+	require.False(t, tooManyDedicatedWorkerClusters(7, 7))
+	require.False(t, tooManyDedicatedWorkerClusters(8, 4))
+	require.True(t, tooManyDedicatedWorkerClusters(8, 5))
+}
+
+func TestPoolMaxUsageRecyclesAfterActiveTest(t *testing.T) {
+	p := newPool(1, false, 1)
+
+	var created int
+	createCluster := func() *FunctionalTestBase {
+		created++
+		return &FunctionalTestBase{}
+	}
+
+	t.Run("uses cluster", func(t *testing.T) {
+		cluster := p.get(t, createCluster)
+
+		require.Same(t, cluster, p.slots[0].cluster)
+		require.Equal(t, 1, p.slots[0].active)
+		require.Equal(t, 1, p.slots[0].usage)
+	})
+
+	require.Nil(t, p.slots[0].cluster)
+	require.Equal(t, 0, p.slots[0].active)
+	require.Equal(t, 0, p.slots[0].usage)
+
+	t.Run("recreates cluster", func(t *testing.T) {
+		cluster := p.get(t, createCluster)
+
+		require.Same(t, cluster, p.slots[0].cluster)
+		require.Equal(t, 2, created)
+	})
+}
+
+func TestClusterSlotMaxUsageWaitsForActiveLeases(t *testing.T) {
+	slot := &clusterSlot{maxUsage: 1}
+
+	var created int
+	createCluster := func() *FunctionalTestBase {
+		created++
+		return &FunctionalTestBase{}
+	}
+
+	first := slot.acquire(t, createCluster)
+	second := slot.acquire(t, createCluster)
+	require.Same(t, first, second)
+	require.Equal(t, 1, created)
+	require.Equal(t, 2, slot.active)
+	require.Equal(t, 2, slot.usage)
+
+	slot.release(t)
+	require.NotNil(t, slot.cluster)
+	require.Equal(t, 1, slot.active)
+
+	slot.release(t)
+	require.Nil(t, slot.cluster)
+	require.Equal(t, 0, slot.active)
+	require.Equal(t, 0, slot.usage)
+}
+
+func TestSuiteScopedWorkerServiceSharesClusterAndNamespaces(t *testing.T) {
+	UseSuiteScopedCluster(t, "reuse worker-service cluster")
+
+	var firstCluster *TestCluster
+	var firstNamespace string
+
+	t.Run("first", func(t *testing.T) {
+		env := NewEnv(t, WithWorkerService("test"))
+
+		firstCluster = env.GetTestCluster()
+		firstNamespace = env.Namespace().String()
+		require.True(t, env.isShared)
+		require.False(t, env.GetTestClusterConfig().WorkerConfig.DisableWorker)
+	})
+
+	t.Run("second", func(t *testing.T) {
+		env := NewEnv(t, WithWorkerService("test"))
+
+		require.Same(t, firstCluster, env.GetTestCluster())
+		require.NotEqual(t, firstNamespace, env.Namespace().String())
+		require.True(t, env.isShared)
+		require.False(t, env.GetTestClusterConfig().WorkerConfig.DisableWorker)
+	})
+}

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -208,13 +208,19 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 	for _, opt := range opts {
 		opt(&options)
 	}
-	suiteScopedCandidate := testClusterPool.canUseSuiteScopedCluster(t, options.dedicatedCluster)
-	workerServiceDedicated := options.workerServiceReason != "" && !suiteScopedCandidate
+	workerServiceDedicated := options.workerServiceReason != "" &&
+		!testClusterPool.canUseSuiteScopedCluster(t, options.dedicatedCluster)
+	if workerServiceDedicated {
+		options.dedicatedCluster = true
+		if options.dedicatedReason == "" {
+			options.dedicatedReason = "worker service required: " + options.workerServiceReason
+		}
+	}
 
 	// For dedicated clusters, pass all dynamic config settings at cluster creation.
 	var startupConfig map[dynamicconfig.Key]any
 	var globalDynamicConfigUsed bool
-	if (options.dedicatedCluster || workerServiceDedicated) && len(options.dynamicConfigSettings) > 0 {
+	if options.dedicatedCluster && len(options.dynamicConfigSettings) > 0 {
 		startupConfig = make(map[dynamicconfig.Key]any, len(options.dynamicConfigSettings))
 		for _, override := range options.dynamicConfigSettings {
 			if !canBeNamespaceScoped(override.setting.Precedence()) {
@@ -225,15 +231,12 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 	}
 	testClusterPool.recordEnvUsage(t, options.workerServiceReason, workerServiceDedicated)
 
-	dedicatedGuard := newDedicatedClusterGuard(options.dedicatedCluster || workerServiceDedicated)
+	dedicatedGuard := newDedicatedClusterGuard(options.dedicatedCluster)
 	if options.dedicatedReason != "" {
 		dedicatedGuard.record(options.dedicatedReason)
 	}
 	if globalDynamicConfigUsed {
 		dedicatedGuard.record("global dynamic config used")
-	}
-	if workerServiceDedicated {
-		dedicatedGuard.record("worker service required: " + options.workerServiceReason)
 	}
 
 	// Obtain the test cluster from the pool.

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -89,10 +89,20 @@ type TestEnv struct {
 
 type TestOption func(*testOptions)
 
+type clusterScope int
+
+const (
+	clusterScopeShared clusterScope = iota
+	clusterScopeSuiteShareable
+	clusterScopeDedicated
+)
+
 type testOptions struct {
 	dedicatedCluster         bool
 	dedicatedReason          string
 	workerServiceReason      string
+	clusterScope             clusterScope
+	clusterScopeReason       string
 	disableTestloggerFailure bool
 	dynamicConfigSettings    []dynamicConfigOverride
 	clusterOptions           []TestClusterOption
@@ -103,11 +113,22 @@ type dynamicConfigOverride struct {
 	value   any
 }
 
+func (o *testOptions) requireClusterScope(scope clusterScope, reason string) {
+	if scope > o.clusterScope {
+		o.clusterScope = scope
+		o.clusterScopeReason = reason
+	}
+	if scope == clusterScopeDedicated {
+		o.dedicatedCluster = true
+		o.dedicatedReason = reason
+	}
+}
+
 // WithDedicatedCluster requests a dedicated (non-shared) cluster for the test.
 // Use this for tests that have cluster-global side effects.
 func WithDedicatedCluster() TestOption {
 	return func(o *testOptions) {
-		o.dedicatedCluster = true
+		o.requireClusterScope(clusterScopeDedicated, "dedicated cluster requested")
 	}
 }
 
@@ -119,9 +140,8 @@ func WithDedicatedCluster() TestOption {
 // hide failures in concurrent tests.
 func WithDisableTestloggerFailure() TestOption {
 	return func(o *testOptions) {
-		o.dedicatedCluster = true
+		o.requireClusterScope(clusterScopeDedicated, "testlogger failures disabled")
 		o.disableTestloggerFailure = true
-		o.dedicatedReason = "testlogger failures disabled"
 	}
 }
 
@@ -136,9 +156,8 @@ func WithSdkWorker() TestOption {
 // across tests.
 func WithFxOptions(serviceName primitives.ServiceName, opts ...fx.Option) TestOption {
 	return func(o *testOptions) {
-		o.dedicatedCluster = true
+		o.requireClusterScope(clusterScopeDedicated, "custom fx options used")
 		o.clusterOptions = append(o.clusterOptions, WithFxOptionsForService(serviceName, opts...))
-		o.dedicatedReason = "custom fx options used"
 	}
 }
 
@@ -149,15 +168,15 @@ func WithWorkerService(reason string) TestOption {
 	return func(o *testOptions) {
 		o.clusterOptions = append(o.clusterOptions, withWorkerService(true))
 		o.workerServiceReason = reason
+		o.requireClusterScope(clusterScopeSuiteShareable, "worker service required: "+reason)
 	}
 }
 
 // WithPersistenceFaultInjection requests a dedicated cluster with the given persistence fault injection config.
 func WithPersistenceFaultInjection(cfg *config.FaultInjection) TestOption {
 	return func(o *testOptions) {
-		o.dedicatedCluster = true
+		o.requireClusterScope(clusterScopeDedicated, "fault injection config used")
 		o.clusterOptions = append(o.clusterOptions, WithFaultInjectionConfig(cfg))
-		o.dedicatedReason = "fault injection config used"
 	}
 }
 
@@ -166,9 +185,8 @@ func WithPersistenceFaultInjection(cfg *config.FaultInjection) TestOption {
 // be shared across tests.
 func WithLogger(logger log.Logger) TestOption {
 	return func(o *testOptions) {
-		o.dedicatedCluster = true
+		o.requireClusterScope(clusterScopeDedicated, "custom logger used")
 		o.clusterOptions = append(o.clusterOptions, WithClusterLogger(logger))
-		o.dedicatedReason = "custom logger used"
 	}
 }
 
@@ -176,9 +194,8 @@ func WithLogger(logger log.Logger) TestOption {
 // This implies a dedicated cluster, since shard count cannot be changed on a shared cluster.
 func WithHistoryShardCount(n int32) TestOption {
 	return func(o *testOptions) {
-		o.dedicatedCluster = true
+		o.requireClusterScope(clusterScopeDedicated, "custom history shard count used")
 		o.clusterOptions = append(o.clusterOptions, WithNumHistoryShards(n))
-		o.dedicatedReason = "custom history shard count used"
 	}
 }
 
@@ -191,7 +208,7 @@ func WithDynamicConfig(setting dynamicconfig.GenericSetting, value any) TestOpti
 			panic(fmt.Sprintf("invalid value for setting %s: %v", setting.Key(), err))
 		}
 		if !canBeNamespaceScoped(setting.Precedence()) {
-			o.dedicatedCluster = true
+			o.requireClusterScope(clusterScopeDedicated, "global dynamic config used")
 		}
 		o.dynamicConfigSettings = append(o.dynamicConfigSettings, dynamicConfigOverride{setting: setting, value: value})
 	}
@@ -208,12 +225,12 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 	for _, opt := range opts {
 		opt(&options)
 	}
-	workerServiceDedicated := options.workerServiceReason != "" &&
-		!testClusterPool.canUseSuiteScopedCluster(t, options.dedicatedCluster)
-	if workerServiceDedicated {
+	suiteScopedCandidate := testClusterPool.canUseSuiteScopedCluster(t, options.dedicatedCluster)
+	suiteShareableDedicated := options.clusterScope == clusterScopeSuiteShareable && !suiteScopedCandidate
+	if suiteShareableDedicated {
 		options.dedicatedCluster = true
 		if options.dedicatedReason == "" {
-			options.dedicatedReason = "worker service required: " + options.workerServiceReason
+			options.dedicatedReason = options.clusterScopeReason
 		}
 	}
 
@@ -229,7 +246,7 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 			startupConfig[override.setting.Key()] = override.value
 		}
 	}
-	testClusterPool.recordEnvUsage(t, options.workerServiceReason, workerServiceDedicated)
+	testClusterPool.recordEnvUsage(t, options.workerServiceReason, suiteShareableDedicated)
 
 	dedicatedGuard := newDedicatedClusterGuard(options.dedicatedCluster)
 	if options.dedicatedReason != "" {

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -93,16 +93,13 @@ type clusterScope int
 
 const (
 	clusterScopeShared clusterScope = iota
-	clusterScopeSuiteShareable
 	clusterScopeDedicated
 )
 
 type testOptions struct {
 	dedicatedCluster         bool
 	dedicatedReason          string
-	workerServiceReason      string
 	clusterScope             clusterScope
-	clusterScopeReason       string
 	disableTestloggerFailure bool
 	dynamicConfigSettings    []dynamicConfigOverride
 	clusterOptions           []TestClusterOption
@@ -116,7 +113,6 @@ type dynamicConfigOverride struct {
 func (o *testOptions) requireClusterScope(scope clusterScope, reason string) {
 	if scope > o.clusterScope {
 		o.clusterScope = scope
-		o.clusterScopeReason = reason
 	}
 	if scope == clusterScopeDedicated {
 		o.dedicatedCluster = true
@@ -161,14 +157,11 @@ func WithFxOptions(serviceName primitives.ServiceName, opts ...fx.Option) TestOp
 	}
 }
 
-// WithWorkerService enables the system worker service. The service is off by
-// default to avoid the worker overhead. This implies a dedicated cluster unless
-// the test belongs to a suite-scoped cluster.
-func WithWorkerService(reason string) TestOption {
-	return func(o *testOptions) {
-		o.clusterOptions = append(o.clusterOptions, withWorkerService(true))
-		o.workerServiceReason = reason
-		o.requireClusterScope(clusterScopeSuiteShareable, "worker service required: "+reason)
+// WithWorkerService is no longer required because test clusters start the
+// system worker service by default.
+// Deprecated: remove this option from callers.
+func WithWorkerService(string) TestOption {
+	return func(*testOptions) {
 	}
 }
 
@@ -225,14 +218,6 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 	for _, opt := range opts {
 		opt(&options)
 	}
-	suiteScopedCandidate := testClusterPool.canUseSuiteScopedCluster(t, options.dedicatedCluster)
-	suiteShareableDedicated := options.clusterScope == clusterScopeSuiteShareable && !suiteScopedCandidate
-	if suiteShareableDedicated {
-		options.dedicatedCluster = true
-		if options.dedicatedReason == "" {
-			options.dedicatedReason = options.clusterScopeReason
-		}
-	}
 
 	// For dedicated clusters, pass all dynamic config settings at cluster creation.
 	var startupConfig map[dynamicconfig.Key]any
@@ -246,7 +231,6 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 			startupConfig[override.setting.Key()] = override.value
 		}
 	}
-	testClusterPool.recordEnvUsage(t, options.workerServiceReason, suiteShareableDedicated)
 
 	dedicatedGuard := newDedicatedClusterGuard(options.dedicatedCluster)
 	if options.dedicatedReason != "" {

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -92,6 +92,7 @@ type TestOption func(*testOptions)
 type testOptions struct {
 	dedicatedCluster         bool
 	dedicatedReason          string
+	workerServiceReason      string
 	disableTestloggerFailure bool
 	dynamicConfigSettings    []dynamicConfigOverride
 	clusterOptions           []TestClusterOption
@@ -142,12 +143,12 @@ func WithFxOptions(serviceName primitives.ServiceName, opts ...fx.Option) TestOp
 }
 
 // WithWorkerService enables the system worker service. The service is off by
-// default to avoid the worker overhead. This implies a dedicated cluster.
+// default to avoid the worker overhead. This implies a dedicated cluster unless
+// the test belongs to a suite-scoped cluster.
 func WithWorkerService(reason string) TestOption {
 	return func(o *testOptions) {
-		o.dedicatedCluster = true
 		o.clusterOptions = append(o.clusterOptions, withWorkerService(true))
-		o.dedicatedReason = "worker service required: " + reason
+		o.workerServiceReason = reason
 	}
 }
 
@@ -207,21 +208,32 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 	for _, opt := range opts {
 		opt(&options)
 	}
-	dedicatedGuard := newDedicatedClusterGuard(options.dedicatedCluster)
-	if options.dedicatedReason != "" {
-		dedicatedGuard.record(options.dedicatedReason)
-	}
+	suiteScopedCandidate := testClusterPool.canUseSuiteScopedCluster(t, options.dedicatedCluster)
+	workerServiceDedicated := options.workerServiceReason != "" && !suiteScopedCandidate
 
 	// For dedicated clusters, pass all dynamic config settings at cluster creation.
 	var startupConfig map[dynamicconfig.Key]any
-	if options.dedicatedCluster && len(options.dynamicConfigSettings) > 0 {
+	var globalDynamicConfigUsed bool
+	if (options.dedicatedCluster || workerServiceDedicated) && len(options.dynamicConfigSettings) > 0 {
 		startupConfig = make(map[dynamicconfig.Key]any, len(options.dynamicConfigSettings))
 		for _, override := range options.dynamicConfigSettings {
 			if !canBeNamespaceScoped(override.setting.Precedence()) {
-				dedicatedGuard.record("global dynamic config used")
+				globalDynamicConfigUsed = true
 			}
 			startupConfig[override.setting.Key()] = override.value
 		}
+	}
+	testClusterPool.recordEnvUsage(t, options.workerServiceReason, workerServiceDedicated)
+
+	dedicatedGuard := newDedicatedClusterGuard(options.dedicatedCluster || workerServiceDedicated)
+	if options.dedicatedReason != "" {
+		dedicatedGuard.record(options.dedicatedReason)
+	}
+	if globalDynamicConfigUsed {
+		dedicatedGuard.record("global dynamic config used")
+	}
+	if workerServiceDedicated {
+		dedicatedGuard.record("worker service required: " + options.workerServiceReason)
 	}
 
 	// Obtain the test cluster from the pool.

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -82,12 +82,13 @@ type Versioning3Suite struct {
 }
 
 func TestVersioning3FunctionalSuite(t *testing.T) {
-	testcore.UseSuiteScopedCluster(t)                         //nolint:staticcheck // SA1019: suite still requires legacy sequential execution
+	testcore.UseSuiteScopedCluster(t, "reuse worker-service clusters")
 	parallelsuite.RunLegacySequential(t, &Versioning3Suite{}) //nolint:staticcheck // SA1019: suite still requires legacy sequential execution
 }
 
 func (s *Versioning3Suite) setupEnv(opts ...testcore.TestOption) *testcore.TestEnv {
 	opts = append([]testcore.TestOption{
+		testcore.WithWorkerService("worker-deployment version workflows"),
 		testcore.WithDynamicConfig(dynamicconfig.MatchingDeploymentWorkflowVersion, int(versioning3DeploymentWorkflowVersion)),
 
 		// Make sure we don't hit the rate limiter in tests
@@ -6058,7 +6059,7 @@ func (s *Versioning3Suite) TestPinnedCaN_FailedTransientNotificationRefiresDespi
 // made current again, then reset-by-build-ID resets the workflow before v2 usage
 // so the reset run resumes on v1.
 func (s *Versioning3Suite) TestPinnedCaN_ResetByBuildIDAfterRollback() {
-	env := s.setupEnv(testcore.WithWorkerService("batch operations"))
+	env := s.setupEnv()
 
 	tv1 := env.Tv().WithBuildIDNumber(1)
 	tv2 := tv1.WithBuildIDNumber(2)
@@ -6702,7 +6703,6 @@ func (s *Versioning3Suite) TestStalePartition_RevisionSuppressesTrampolining() {
 //     - targetWorkerDeploymentVersionChanged == false (the bug being fixed)
 func (s *Versioning3Suite) TestInlinePath_StableRouting_NoSpuriousFlag() {
 	env := s.setupEnv()
-	ctx := s.Context()
 	tv1 := env.Tv().WithBuildIDNumber(1)
 
 	// Async poller for first WFT, declares pinned behavior
@@ -6722,7 +6722,7 @@ func (s *Versioning3Suite) TestInlinePath_StableRouting_NoSpuriousFlag() {
 	s.verifyWorkflowVersioning(env, tv1, vbPinned, tv1.Deployment(), nil, nil)
 
 	// Trigger a regular WFT via a first signal.
-	_, err := env.FrontendClient().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
+	_, err := env.FrontendClient().SignalWorkflowExecution(s.Context(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace:         env.Namespace().String(),
 		WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: tv1.WorkflowID()},
 		SignalName:        "first-signal",
@@ -6736,7 +6736,7 @@ func (s *Versioning3Suite) TestInlinePath_StableRouting_NoSpuriousFlag() {
 	poller, resp := s.pollWftAndHandle(env, tv1, false, nil,
 		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
 			s.NotNil(task)
-			_, err := env.FrontendClient().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
+			_, err := env.FrontendClient().SignalWorkflowExecution(s.Context(), &workflowservice.SignalWorkflowExecutionRequest{
 				Namespace:         env.Namespace().String(),
 				WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: tv1.WorkflowID()},
 				SignalName:        "buffered-signal",


### PR DESCRIPTION
## Summary
- remove the testcore worker-service opt-out flag
- keep `WithWorkerService` as a compatibility no-op while clusters start the worker service by default
- remove obsolete dedicated worker-service cluster accounting

## Testing
- `go test -tags test_dep ./tests/testcore -run 'TestPoolMaxUsageRecyclesAfterActiveTest|TestClusterSlotMaxUsageWaitsForActiveLeases|Test.*SuiteScoped|TestTestEnvSuite' -count=1`
- `go test -race -tags test_dep ./tests/testcore -run 'TestPoolMaxUsageRecyclesAfterActiveTest|TestClusterSlotMaxUsageWaitsForActiveLeases|Test.*SuiteScoped' -count=1`
- `go test -tags 'test_dep integration' ./tests -run '^$'`
