### PR TITLE
Expose CHASM schedule next action visibility

### DIFF
--- a/chasm/search_attribute.go
+++ b/chasm/search_attribute.go
@@ -425,6 +425,19 @@ func NewSearchAttributesMap(values map[string]VisibilityValue) SearchAttributesM
 	return SearchAttributesMap{values: values}
 }
 
+// ToPayloads encodes search attribute values keyed by their aliases.
+func (m SearchAttributesMap) ToPayloads() map[string]*commonpb.Payload {
+	if len(m.values) == 0 {
+		return nil
+	}
+
+	result := make(map[string]*commonpb.Payload, len(m.values))
+	for name, value := range m.values {
+		result[name] = value.MustEncode()
+	}
+	return result
+}
+
 // newSearchAttributesMapFromProto creates a new SearchAttributesMap from commonpb.SearchAttributes.
 func newSearchAttributesMapFromProto(
 	searchAttributes *commonpb.SearchAttributes,

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -5124,7 +5124,7 @@ func (wh *WorkflowHandler) listSchedulesChasm(
 			Memo:       customMemo,
 			// cleanScheduleSearchAttributes is only needed for V1 schedules
 			SearchAttributes: wh.cleanScheduleSearchAttributes(searchAttributes),
-			Info: listInfo,
+			Info:             listInfo,
 		}
 	}
 

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -5109,14 +5109,21 @@ func (wh *WorkflowHandler) listSchedulesChasm(
 
 		workflowID := ex.BusinessID
 		scheduleID := strings.TrimPrefix(workflowID, scheduler.WorkflowIDPrefix) // needed for V1 schedules, not CHASM
+		searchAttributes := &commonpb.SearchAttributes{
+			IndexedFields: make(map[string]*commonpb.Payload),
+		}
+		for key, value := range ex.CustomSearchAttributes {
+			searchAttributes.IndexedFields[key] = value
+		}
+		for key, value := range ex.ChasmSearchAttributes.ToPayloads() {
+			searchAttributes.IndexedFields[key] = value
+		}
 
 		schedules[i] = &schedulepb.ScheduleListEntry{
 			ScheduleId: scheduleID,
 			Memo:       customMemo,
 			// cleanScheduleSearchAttributes is only needed for V1 schedules
-			SearchAttributes: wh.cleanScheduleSearchAttributes(&commonpb.SearchAttributes{
-				IndexedFields: ex.CustomSearchAttributes,
-			}),
+			SearchAttributes: wh.cleanScheduleSearchAttributes(searchAttributes),
 			Info: listInfo,
 		}
 	}

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -3865,20 +3865,21 @@ func testScheduleNextActionTimeVisibility(t *testing.T, newContext contextFactor
 		s.NoError(err)
 	}
 
-	paused := func(e *schedulepb.ScheduleListEntry) bool {
-		return e.GetInfo().GetPaused()
+	pausedWithNextActionTime := func(e *schedulepb.ScheduleListEntry) bool {
+		return e.GetInfo().GetPaused() &&
+			e.GetSearchAttributes().GetIndexedFields()[chasmscheduler.ScheduleNextActionTimeName] != nil
 	}
 
 	// V2: TemporalScheduleNextActionTime must be present and decode to a
 	// timestamp at or after the create time.
-	v2Entry := getScheduleEntryFromVisibility(s, v2Sid, chasmContextFactory, paused)
+	v2Entry := getScheduleEntryFromVisibility(s, v2Sid, chasmContextFactory, pausedWithNextActionTime)
 	s.NotNil(v2Entry)
 	v2Pl := v2Entry.GetSearchAttributes().GetIndexedFields()[chasmscheduler.ScheduleNextActionTimeName]
+	s.NotNil(v2Pl, "V2 schedule must publish TemporalScheduleNextActionTime")
 
 	var v2Next time.Time
 	s.NoError(payload.Decode(v2Pl, &v2Next))
 	require.Equal(t, 23, v2Next.Minute()) // see the 'Phase' section of the spec
-	s.NotNil(v2Pl, "V2 schedule must publish TemporalScheduleNextActionTime")
 	s.True(v2Next.After(createTime.Add(-time.Second)),
 		"next action time must be >= createTime; got %v, createTime %v", v2Next, createTime)
 }


### PR DESCRIPTION
## Summary
- merge CHASM-managed search attributes into CHASM ListSchedules entries
- expose ScheduleNextActionTime through ListSchedules for CHASM schedules
- make the next-action visibility test wait for the payload before decoding it

## Tests
- CGO_ENABLED=0 go test ./tests -timeout=35m -race -shuffle on -tags disable_grpc_modules,test_dep -run '^TestScheduleCHASM/TestNextActionTimeVisibility$' -count=1 -persistenceType=sql -persistenceDriver=sqlite