### PR TITLE
Fix standalone activity USE_EXISTING link validation

### DIFF
--- a/chasm/lib/activity/handler.go
+++ b/chasm/lib/activity/handler.go
@@ -3,6 +3,7 @@ package activity
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -72,43 +73,102 @@ func (h *handler) StartActivityExecution(ctx context.Context, req *activitypb.St
 
 	maxCallbacks := h.config.MaxCallbacksPerExecution(frontendReq.GetNamespace())
 
-	result, err := chasm.StartExecution(
-		ctx,
-		chasm.ExecutionKey{
-			NamespaceID: req.GetNamespaceId(),
-			BusinessID:  frontendReq.GetActivityId(),
-		},
-		func(mutableContext chasm.MutableContext, request *workflowservice.StartActivityExecutionRequest) (*Activity, error) {
-			// Only enforce the per-component cap when we'll actually persist the links —
-			// i.e., when creating a new activity. On returning an existing activity
-			// without attach_links the request.Links field is dropped, so the cap check
-			// is skipped to avoid false rejects. Per-request shape/size/count is already
-			// validated by the frontend (the only caller of this handler).
-			if err := h.linkValidator.ValidateComponentTotal(request.GetNamespace(), 0, len(request.GetLinks())); err != nil {
+	startFn := func(mutableContext chasm.MutableContext, request *workflowservice.StartActivityExecutionRequest) (*Activity, error) {
+		// Only enforce the per-component cap when we'll actually persist the links —
+		// i.e., when creating a new activity. On returning an existing activity
+		// without attach_links the request.Links field is dropped, so the cap check
+		// is skipped to avoid false rejects. Per-request shape/size/count is already
+		// validated by the frontend (the only caller of this handler).
+		if err := h.linkValidator.ValidateComponentTotal(request.GetNamespace(), 0, len(request.GetLinks())); err != nil {
+			return nil, err
+		}
+		newActivity, err := NewStandaloneActivity(mutableContext, request)
+		if err != nil {
+			return nil, err
+		}
+
+		if cbs := request.GetCompletionCallbacks(); len(cbs) > 0 {
+			if err := newActivity.addCompletionCallbacks(mutableContext, request.GetRequestId(), cbs, maxCallbacks); err != nil {
 				return nil, err
 			}
-			newActivity, err := NewStandaloneActivity(mutableContext, request)
-			if err != nil {
-				return nil, err
-			}
+		}
 
-			if cbs := request.GetCompletionCallbacks(); len(cbs) > 0 {
-				if err := newActivity.addCompletionCallbacks(mutableContext, request.GetRequestId(), cbs, maxCallbacks); err != nil {
-					return nil, err
-				}
-			}
+		err = TransitionScheduled.Apply(newActivity, mutableContext, nil)
+		if err != nil {
+			return nil, err
+		}
 
-			err = TransitionScheduled.Apply(newActivity, mutableContext, nil)
-			if err != nil {
-				return nil, err
-			}
+		return newActivity, nil
+	}
 
-			return newActivity, nil
-		},
-		frontendReq,
+	cbs := frontendReq.GetCompletionCallbacks()
+	links := frontendReq.GetLinks()
+	onConflict := frontendReq.GetOnConflictOptions()
+	attachCallbacks := onConflict.GetAttachCompletionCallbacks() && len(cbs) > 0
+	attachLinks := onConflict.GetAttachLinks() && len(links) > 0
+	requestID := frontendReq.GetRequestId()
+	callbacksAlreadyAttached := func(a *Activity) bool {
+		if len(cbs) == 0 {
+			return false
+		}
+		for idx := range cbs {
+			if _, ok := a.Callbacks[fmt.Sprintf("%s-%d", requestID, idx)]; !ok {
+				return false
+			}
+		}
+		return true
+	}
+	applyOnConflictOptions := func(a *Activity, ctx chasm.MutableContext) error {
+		if attachCallbacks && !callbacksAlreadyAttached(a) {
+			if err := a.addCompletionCallbacks(ctx, requestID, cbs, maxCallbacks); err != nil {
+				return err
+			}
+		}
+		if attachLinks {
+			if err := a.attachLinks(ctx, links, requestID, h.linkValidator, frontendReq.GetNamespace()); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	executionKey := chasm.ExecutionKey{
+		NamespaceID: req.GetNamespaceId(),
+		BusinessID:  frontendReq.GetActivityId(),
+	}
+	transitionOptions := []chasm.TransitionOption{
 		chasm.WithRequestID(frontendReq.GetRequestId()),
 		chasm.WithBusinessIDPolicy(reusePolicy, conflictPolicy),
-	)
+	}
+
+	var result chasm.StartExecutionResult
+	var err error
+	if conflictPolicy == chasm.BusinessIDConflictPolicyUseExisting {
+		updateResult, updateErr := chasm.UpdateWithStartExecution(
+			ctx,
+			executionKey,
+			startFn,
+			func(a *Activity, ctx chasm.MutableContext, _ *workflowservice.StartActivityExecutionRequest) (any, error) {
+				return nil, applyOnConflictOptions(a, ctx)
+			},
+			frontendReq,
+			transitionOptions...,
+		)
+		err = updateErr
+		result = chasm.StartExecutionResult{
+			ExecutionKey: updateResult.ExecutionKey,
+			ExecutionRef: updateResult.ExecutionRef,
+			Created:      updateResult.Created,
+		}
+	} else {
+		result, err = chasm.StartExecution(
+			ctx,
+			executionKey,
+			startFn,
+			frontendReq,
+			transitionOptions...,
+		)
+	}
 
 	if err != nil {
 		var alreadyStartedErr *chasm.ExecutionAlreadyStartedError
@@ -121,29 +181,13 @@ func (h *handler) StartActivityExecution(ctx context.Context, req *activitypb.St
 
 	// Apply on_conflict_options to an existing activity.
 	// TODO: Use chasm.UpdateWithStartExecution to avoid a second transaction once the engine supports BusinessIDConflictPolicyFail in the updateFn path.
-	cbs := frontendReq.GetCompletionCallbacks()
-	links := frontendReq.GetLinks()
-	onConflict := frontendReq.GetOnConflictOptions()
-	attachCallbacks := onConflict.GetAttachCompletionCallbacks() && len(cbs) > 0
-	attachLinks := onConflict.GetAttachLinks() && len(links) > 0
-	if !result.Created && (attachCallbacks || attachLinks) {
-		requestID := frontendReq.GetRequestId()
+	if conflictPolicy != chasm.BusinessIDConflictPolicyUseExisting && !result.Created && (attachCallbacks || attachLinks) {
 		ref := chasm.NewComponentRef[*Activity](result.ExecutionKey)
 		_, _, err := chasm.UpdateComponent(
 			ctx,
 			ref,
 			func(a *Activity, ctx chasm.MutableContext, _ any) (any, error) {
-				if attachCallbacks {
-					if err := a.addCompletionCallbacks(ctx, requestID, cbs, maxCallbacks); err != nil {
-						return nil, err
-					}
-				}
-				if attachLinks {
-					if err := a.attachLinks(ctx, links, requestID, h.linkValidator, frontendReq.GetNamespace()); err != nil {
-						return nil, err
-					}
-				}
-				return nil, nil
+				return nil, applyOnConflictOptions(a, ctx)
 			},
 			nil,
 		)


### PR DESCRIPTION
## Summary
- route standalone activity USE_EXISTING starts through UpdateWithStartExecution
- avoid create-time link-cap validation when an existing activity will drop request links
- preserve create-time validation for newly created activities and attach validation for conflict updates

## Tests
- CGO_ENABLED=0 go test ./tests -timeout=35m -race -shuffle on -tags disable_grpc_modules,test_dep -run '^TestStandaloneActivityTestSuite$' -count=1 -persistenceType=sql -persistenceDriver=sqlite