### PR TITLE
Fix version registration test IDs for SQL persistence

### DIFF
--- a/tests/poller_scaling_test.go
+++ b/tests/poller_scaling_test.go
@@ -20,6 +20,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/testing/parallelsuite"
+	"go.temporal.io/server/common/testing/testvars"
 	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -200,11 +201,11 @@ func (s *PollerScalingIntegSuite) TestPollerScalingDecisionsAreSeenProbabilistic
 func (s *PollerScalingIntegSuite) TestPollerScalingOnCurrentVersionConsidersUnversionedQueueBacklog() {
 	s.testPollerScalingOnPromotedVersionConsidersUnversionedQueueBacklog(
 		enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT,
-		func(env *testcore.TestEnv) error {
+		func(env *testcore.TestEnv, tv *testvars.TestVars) error {
 			_, err := env.FrontendClient().SetWorkerDeploymentCurrentVersion(s.Context(), &workflowservice.SetWorkerDeploymentCurrentVersionRequest{
 				Namespace:      env.Namespace().String(),
-				DeploymentName: env.Tv().DeploymentSeries(),
-				BuildId:        env.Tv().BuildID(),
+				DeploymentName: tv.DeploymentSeries(),
+				BuildId:        tv.BuildID(),
 			})
 			return err
 		},
@@ -216,11 +217,11 @@ func (s *PollerScalingIntegSuite) TestPollerScalingOnRampingVersionConsidersUnve
 	const rampPercentage = float32(100)
 	s.testPollerScalingOnPromotedVersionConsidersUnversionedQueueBacklog(
 		enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_RAMPING,
-		func(env *testcore.TestEnv) error {
+		func(env *testcore.TestEnv, tv *testvars.TestVars) error {
 			_, err := env.FrontendClient().SetWorkerDeploymentRampingVersion(s.Context(), &workflowservice.SetWorkerDeploymentRampingVersionRequest{
 				Namespace:      env.Namespace().String(),
-				DeploymentName: env.Tv().DeploymentSeries(),
-				BuildId:        env.Tv().BuildID(),
+				DeploymentName: tv.DeploymentSeries(),
+				BuildId:        tv.BuildID(),
 				Percentage:     rampPercentage,
 			})
 			return err
@@ -230,7 +231,7 @@ func (s *PollerScalingIntegSuite) TestPollerScalingOnRampingVersionConsidersUnve
 
 func (s *PollerScalingIntegSuite) testPollerScalingOnPromotedVersionConsidersUnversionedQueueBacklog(
 	expectedStatus enumspb.WorkerDeploymentVersionStatus,
-	promoteDeploymentVersion func(env *testcore.TestEnv) error,
+	promoteDeploymentVersion func(env *testcore.TestEnv, tv *testvars.TestVars) error,
 ) {
 	// 1. Create a backlog of unversioned workflows.
 	// 2. Set the current/ramping version for a worker-deployment (depending on the test case)
@@ -238,6 +239,7 @@ func (s *PollerScalingIntegSuite) testPollerScalingOnPromotedVersionConsidersUnv
 
 	env := s.setupEnv()
 	tq := testcore.RandomizeStr("test-poller-scaling-tq")
+	tv := env.Tv().WithDeploymentSeries("poller-scaling").WithBuildID("v1")
 
 	// Queueing up unversioned workflows
 	for range 5 {
@@ -258,8 +260,8 @@ func (s *PollerScalingIntegSuite) testPollerScalingOnPromotedVersionConsidersUnv
 			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: tq, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 			DeploymentOptions: &deploymentpb.WorkerDeploymentOptions{
-				DeploymentName:       env.Tv().DeploymentSeries(),
-				BuildId:              env.Tv().BuildID(),
+				DeploymentName:       tv.DeploymentSeries(),
+				BuildId:              tv.BuildID(),
 				WorkerVersioningMode: enumspb.WORKER_VERSIONING_MODE_VERSIONED,
 			},
 		})
@@ -273,8 +275,8 @@ func (s *PollerScalingIntegSuite) testPollerScalingOnPromotedVersionConsidersUnv
 			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: tq, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 			DeploymentOptions: &deploymentpb.WorkerDeploymentOptions{
-				DeploymentName:       env.Tv().DeploymentSeries(),
-				BuildId:              env.Tv().BuildID(),
+				DeploymentName:       tv.DeploymentSeries(),
+				BuildId:              tv.BuildID(),
 				WorkerVersioningMode: enumspb.WORKER_VERSIONING_MODE_VERSIONED,
 			},
 		})
@@ -288,8 +290,8 @@ func (s *PollerScalingIntegSuite) testPollerScalingOnPromotedVersionConsidersUnv
 		descResp, err := env.FrontendClient().DescribeWorkerDeploymentVersion(s.Context(), &workflowservice.DescribeWorkerDeploymentVersionRequest{
 			Namespace: env.Namespace().String(),
 			DeploymentVersion: &deploymentpb.WorkerDeploymentVersion{
-				DeploymentName: env.Tv().DeploymentSeries(),
-				BuildId:        env.Tv().BuildID(),
+				DeploymentName: tv.DeploymentSeries(),
+				BuildId:        tv.BuildID(),
 			},
 		})
 		a.NoError(err)
@@ -298,15 +300,15 @@ func (s *PollerScalingIntegSuite) testPollerScalingOnPromotedVersionConsidersUnv
 		a.Len(descResp.GetVersionTaskQueues(), 2) // one for workflow TQ, one for activity TQ
 
 		// Promote the deployment version to either current or ramping.
-		err = promoteDeploymentVersion(env)
+		err = promoteDeploymentVersion(env, tv)
 		a.NoError(err)
 
 		// Verify the version status is the expected status.
 		descResp, err = env.FrontendClient().DescribeWorkerDeploymentVersion(s.Context(), &workflowservice.DescribeWorkerDeploymentVersionRequest{
 			Namespace: env.Namespace().String(),
 			DeploymentVersion: &deploymentpb.WorkerDeploymentVersion{
-				DeploymentName: env.Tv().DeploymentSeries(),
-				BuildId:        env.Tv().BuildID(),
+				DeploymentName: tv.DeploymentSeries(),
+				BuildId:        tv.BuildID(),
 			},
 		})
 		a.NoError(err)
@@ -348,8 +350,8 @@ func (s *PollerScalingIntegSuite) testPollerScalingOnPromotedVersionConsidersUnv
 		// complete the transition task.
 		VersioningBehavior: enumspb.VERSIONING_BEHAVIOR_AUTO_UPGRADE,
 		DeploymentOptions: &deploymentpb.WorkerDeploymentOptions{
-			DeploymentName:       env.Tv().DeploymentSeries(),
-			BuildId:              env.Tv().BuildID(),
+			DeploymentName:       tv.DeploymentSeries(),
+			BuildId:              tv.BuildID(),
 			WorkerVersioningMode: enumspb.WORKER_VERSIONING_MODE_VERSIONED,
 		},
 	})
@@ -373,8 +375,8 @@ func (s *PollerScalingIntegSuite) testPollerScalingOnPromotedVersionConsidersUnv
 		versionDescResp, err := env.FrontendClient().DescribeWorkerDeploymentVersion(s.Context(), &workflowservice.DescribeWorkerDeploymentVersionRequest{
 			Namespace: env.Namespace().String(),
 			DeploymentVersion: &deploymentpb.WorkerDeploymentVersion{
-				DeploymentName: env.Tv().DeploymentSeries(),
-				BuildId:        env.Tv().BuildID(),
+				DeploymentName: tv.DeploymentSeries(),
+				BuildId:        tv.BuildID(),
 			},
 			ReportTaskQueueStats: true,
 		})
@@ -397,8 +399,8 @@ func (s *PollerScalingIntegSuite) testPollerScalingOnPromotedVersionConsidersUnv
 		Namespace: env.Namespace().String(),
 		TaskQueue: &taskqueuepb.TaskQueue{Name: tq, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		DeploymentOptions: &deploymentpb.WorkerDeploymentOptions{
-			DeploymentName:       env.Tv().DeploymentSeries(),
-			BuildId:              env.Tv().BuildID(),
+			DeploymentName:       tv.DeploymentSeries(),
+			BuildId:              tv.BuildID(),
 			WorkerVersioningMode: enumspb.WORKER_VERSIONING_MODE_VERSIONED,
 		},
 	})

--- a/tests/poller_scaling_test.go
+++ b/tests/poller_scaling_test.go
@@ -239,6 +239,7 @@ func (s *PollerScalingIntegSuite) testPollerScalingOnPromotedVersionConsidersUnv
 
 	env := s.setupEnv()
 	tq := testcore.RandomizeStr("test-poller-scaling-tq")
+	// Keep the deployment version short because its system workflow ID must fit into 255 characters.
 	tv := env.Tv().WithDeploymentSeries("poller-scaling").WithBuildID("v1")
 
 	// Queueing up unversioned workflows

--- a/tests/workflow_alias_search_attribute_test.go
+++ b/tests/workflow_alias_search_attribute_test.go
@@ -19,6 +19,7 @@ import (
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/testing/parallelsuite"
+	"go.temporal.io/server/common/testing/testvars"
 	"go.temporal.io/server/tests/testcore"
 )
 
@@ -30,14 +31,15 @@ func TestWorkflowAliasSearchAttributeTestSuite(t *testing.T) {
 	parallelsuite.Run(t, &WorkflowAliasSearchAttributeTestSuite{})
 }
 
-func (s *WorkflowAliasSearchAttributeTestSuite) newTestEnv(opts ...testcore.TestOption) *testcore.TestEnv {
+func (s *WorkflowAliasSearchAttributeTestSuite) newTestEnv(opts ...testcore.TestOption) (*testcore.TestEnv, *testvars.TestVars) {
 	opts = append([]testcore.TestOption{
 		testcore.WithWorkerService("worker-deployment version workflows must run for versioned-poller membership checks"),
 	}, opts...)
 
 	env := testcore.NewEnv(s.T(), opts...)
 	env.SdkWorker().RegisterWorkflow(s.workflowFunc)
-	return env
+	tv := env.Tv().WithDeploymentSeries("alias-sa").WithBuildID("v1")
+	return env, tv
 }
 
 func (s *WorkflowAliasSearchAttributeTestSuite) workflowFunc(ctx workflow.Context) (string, error) {
@@ -46,8 +48,8 @@ func (s *WorkflowAliasSearchAttributeTestSuite) workflowFunc(ctx workflow.Contex
 
 func (s *WorkflowAliasSearchAttributeTestSuite) startVersionedPollerAndValidate(
 	env *testcore.TestEnv,
+	tv *testvars.TestVars,
 ) {
-	tv := env.Tv()
 	taskQueue := &taskqueuepb.TaskQueue{
 		Name: tv.TaskQueue().Name,
 		Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
@@ -90,11 +92,11 @@ func (s *WorkflowAliasSearchAttributeTestSuite) startVersionedPollerAndValidate(
 
 func (s *WorkflowAliasSearchAttributeTestSuite) createWorkflow(
 	env *testcore.TestEnv,
+	tv *testvars.TestVars,
 	sa *commonpb.SearchAttributes,
 ) (*workflowservice.StartWorkflowExecutionResponse, error) {
-	tv := env.Tv()
 	// Start a versioned poller so that the version, which will be set as an override, is present in the task queue.
-	s.startVersionedPollerAndValidate(env)
+	s.startVersionedPollerAndValidate(env, tv)
 
 	request := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:          tv.Any().String(),
@@ -122,9 +124,9 @@ func (s *WorkflowAliasSearchAttributeTestSuite) terminateWorkflow(
 }
 
 func (s *WorkflowAliasSearchAttributeTestSuite) TestWorkflowAliasSearchAttribute() {
-	env := s.newTestEnv()
+	env, tv := s.newTestEnv()
 
-	_, err := s.createWorkflow(env, nil)
+	_, err := s.createWorkflow(env, tv, nil)
 	s.NoError(err)
 
 	s.EventuallyWithT(
@@ -163,7 +165,7 @@ func (s *WorkflowAliasSearchAttributeTestSuite) TestWorkflowAliasSearchAttribute
 }
 
 func (s *WorkflowAliasSearchAttributeTestSuite) TestWorkflowAliasSearchAttribute_CustomSearchAttributeOverride() {
-	env := s.newTestEnv()
+	env, tv := s.newTestEnv()
 
 	_, err := env.SdkClient().OperatorService().AddSearchAttributes(s.Context(), &operatorservice.AddSearchAttributesRequest{
 		Namespace: env.Namespace().String(),
@@ -179,7 +181,7 @@ func (s *WorkflowAliasSearchAttributeTestSuite) TestWorkflowAliasSearchAttribute
 		},
 	}
 
-	_, err = s.createWorkflow(env, sa)
+	_, err = s.createWorkflow(env, tv, sa)
 	s.NoError(err)
 
 	s.EventuallyWithT(

--- a/tests/workflow_alias_search_attribute_test.go
+++ b/tests/workflow_alias_search_attribute_test.go
@@ -38,6 +38,7 @@ func (s *WorkflowAliasSearchAttributeTestSuite) newTestEnv(opts ...testcore.Test
 
 	env := testcore.NewEnv(s.T(), opts...)
 	env.SdkWorker().RegisterWorkflow(s.workflowFunc)
+	// Keep the deployment version short because its system workflow ID must fit into 255 characters.
 	tv := env.Tv().WithDeploymentSeries("alias-sa").WithBuildID("v1")
 	return env, tv
 }


### PR DESCRIPTION
## What changed?

Fixed issue where worker deployment was rejected by postgres for being longer than 255 chars.