### PR TITLE
Fix cluster pool max-usage recycling

### DIFF
--- a/tests/testcore/cluster_poison_test.go
+++ b/tests/testcore/cluster_poison_test.go
@@ -37,6 +37,17 @@ func (f *mockSubtestT) Errorf(format string, args ...any) {
 func (f *mockSubtestT) Fail()    {}
 func (f *mockSubtestT) FailNow() {}
 
+type blockingLogT struct {
+	mockSubtestT
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (f *blockingLogT) Logf(string, ...any) {
+	close(f.entered)
+	<-f.release
+}
+
 // finish runs registered cleanups in LIFO order, mirroring *testing.T.
 func (f *mockSubtestT) finish() {
 	f.mu.Lock()
@@ -46,6 +57,33 @@ func (f *mockSubtestT) finish() {
 	for i := len(cleanups) - 1; i >= 0; i-- {
 		cleanups[i]()
 	}
+}
+
+func TestSharedClusterT_LogfForwardsWhileLocked(t *testing.T) {
+	s := &sharedClusterT{name: t.Name(), logFanout: true}
+	sub := &blockingLogT{
+		mockSubtestT: mockSubtestT{T: t},
+		entered:      make(chan struct{}),
+		release:      make(chan struct{}),
+	}
+	s.addTest(sub)
+
+	done := make(chan struct{})
+	go func() {
+		s.Logf("test log")
+		close(done)
+	}()
+
+	<-sub.entered
+	if s.mu.TryLock() {
+		s.mu.Unlock()
+		close(sub.release)
+		<-done
+		t.Fatal("Logf released sharedClusterT lock while forwarding to an active test")
+	}
+
+	close(sub.release)
+	<-done
 }
 
 func TestSharedClusterPoison(t *testing.T) {

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -758,7 +758,7 @@ func (s *FunctionalTestBase) SendSignal(nsName string, execution *commonpb.Workf
 // RegisterTest records t as currently using this cluster. At t's Cleanup it
 // fails t if the cluster was poisoned during t's window. This fails all active tests
 // currently running. The cluster will be torn down if t was the last active test on a poisoned cluster.
-// The pool's slot reference is replaced as soon as poison is observed.
+// The cluster pool's slot reference is replaced as soon as poison is observed.
 func (s *FunctionalTestBase) RegisterTest(t testlogger.CleanupCapableT) {
 	if s.t != nil {
 		s.t.addTest(t)

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -285,7 +285,7 @@ func (s *FunctionalTestBase) TearDownSuite() {
 
 func (s *FunctionalTestBase) SetupSuiteWithCluster(options ...TestClusterOption) {
 	// Reserve a slot from the dedicated test cluster pool.
-	testClusterPool.dedicated.reserveSlot(s.T())
+	testClusterRouter.dedicated.reserveSlot(s.T())
 	s.setupCluster(options...)
 }
 

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -284,8 +284,8 @@ func (s *FunctionalTestBase) TearDownSuite() {
 }
 
 func (s *FunctionalTestBase) SetupSuiteWithCluster(options ...TestClusterOption) {
-	// Acquire a slot from the dedicated test cluster pool.
-	testClusterPool.dedicated.acquireSlot(s.T())
+	// Reserve a slot from the dedicated test cluster pool.
+	testClusterPool.dedicated.reserveSlot(s.T())
 	s.setupCluster(options...)
 }
 

--- a/tests/testcore/shared_cluster_t.go
+++ b/tests/testcore/shared_cluster_t.go
@@ -46,42 +46,25 @@ func (s *sharedClusterT) removeTest(t testlogger.CleanupCapableT) (wasLast bool)
 	return len(s.activeTests) == 0
 }
 
-// currentT returns the sole registered test, or nil if zero or many.
-func (s *sharedClusterT) currentT() testlogger.CleanupCapableT {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if len(s.activeTests) == 1 {
-		return s.activeTests[0]
-	}
-	return nil
-}
-
-// activeTestsSnapshot copies activeTests so callers can iterate without
-// holding the lock while forwarding.
-func (s *sharedClusterT) activeTestsSnapshot() []testlogger.CleanupCapableT {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	snap := make([]testlogger.CleanupCapableT, len(s.activeTests))
-	copy(snap, s.activeTests)
-	return snap
-}
-
 // logTargets returns the tests that should receive Log/Logf, or nil when no
-// test target applies and the caller should write to stderr.
+// test target applies and the caller should write to stderr. The caller must
+// hold s.mu while using the returned slice.
 func (s *sharedClusterT) logTargets() []testlogger.CleanupCapableT {
 	if s.logFanout {
-		if snap := s.activeTestsSnapshot(); len(snap) > 0 {
-			return snap
+		if len(s.activeTests) > 0 {
+			return s.activeTests
 		}
 		return nil
 	}
-	if t := s.currentT(); t != nil {
-		return []testlogger.CleanupCapableT{t}
+	if len(s.activeTests) == 1 {
+		return s.activeTests[:1]
 	}
 	return nil
 }
 
 func (s *sharedClusterT) Logf(format string, args ...any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	targets := s.logTargets()
 	if targets == nil {
 		fmt.Fprintf(os.Stderr, format+"\n", args...)
@@ -93,6 +76,8 @@ func (s *sharedClusterT) Logf(format string, args ...any) {
 }
 
 func (s *sharedClusterT) Log(args ...any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	targets := s.logTargets()
 	if targets == nil {
 		fmt.Fprintln(os.Stderr, args...)
@@ -104,13 +89,17 @@ func (s *sharedClusterT) Log(args ...any) {
 }
 
 func (s *sharedClusterT) Errorf(format string, args ...any) {
-	for _, t := range s.activeTestsSnapshot() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, t := range s.activeTests {
 		t.Errorf(format, args...)
 	}
 }
 
 func (s *sharedClusterT) Fail() {
-	for _, t := range s.activeTestsSnapshot() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, t := range s.activeTests {
 		t.Fail()
 	}
 }

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -47,17 +47,16 @@ func init() {
 
 // clusterPool manages a fixed number of test [clusterPoolSlot]s.
 type clusterPool struct {
+	sync.Mutex
 	allSlots       []*clusterPoolSlot
 	availableSlots chan *clusterPoolSlot // for exclusive access (nil means shared/concurrent access)
-
-	lock        sync.Mutex // protects nextSlotIdx
-	nextSlotIdx int
+	nextSlotIdx    int
 }
 
 // clusterPoolSlot owns one pooled cluster and its lease state.
 type clusterPoolSlot struct {
+	sync.Mutex
 	idx          int
-	lock         sync.Mutex
 	cluster      *FunctionalTestBase
 	activeLeases int // how many tests are currently using this cluster
 	leaseCount   int // how often it has been leased
@@ -103,16 +102,16 @@ func (p *clusterPool) reserveSlot(t *testing.T) *clusterPoolSlot {
 }
 
 func (p *clusterPool) nextSlot() *clusterPoolSlot {
-	p.lock.Lock()
-	defer p.lock.Unlock()
+	p.Lock()
+	defer p.Unlock()
 	slot := p.allSlots[p.nextSlotIdx]
 	p.nextSlotIdx = (p.nextSlotIdx + 1) % len(p.allSlots)
 	return slot
 }
 
 func (s *clusterPoolSlot) acquire(t *testing.T, createCluster func() *FunctionalTestBase) *FunctionalTestBase {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	s.Lock()
+	defer s.Unlock()
 
 	// Lazy initialization for first use
 	if s.cluster == nil {
@@ -145,8 +144,8 @@ func (s *clusterPoolSlot) acquire(t *testing.T, createCluster func() *Functional
 }
 
 func (s *clusterPoolSlot) release() {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	s.Lock()
+	defer s.Unlock()
 	if s.activeLeases == 0 {
 		panic("release called without matching acquire")
 	}

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -34,14 +34,14 @@ func init() {
 
 	// In CI, recreate clusters after 50 tests to prevent resource accumulation.
 	// Locally, clusters are reused indefinitely for faster iteration.
-	var maxUsage int
+	var maxLeases int
 	if os.Getenv("CI") != "" {
-		maxUsage = 50
+		maxLeases = 50
 	}
 
 	testClusterRouter = &clusterRouter{
-		shared:    newClusterPool(sharedSize, false, maxUsage),
-		dedicated: newClusterPool(dedicatedSize, true, maxUsage),
+		shared:    newClusterPool(sharedSize, false, maxLeases),
+		dedicated: newClusterPool(dedicatedSize, true, maxLeases),
 	}
 }
 
@@ -61,20 +61,20 @@ type clusterPoolSlot struct {
 
 	cluster *FunctionalTestBase
 
-	// Track leases and max-usage recycling under the slot lock.
-	useCount     int
+	// Track leases and lease-limit recycling under the slot lock.
+	leaseCount   int
 	activeLeases int
-	maxUsage     int // max tests per cluster before recreate (0 = unlimited)
+	maxLeases    int // max tests per cluster before recreate (0 = unlimited)
 }
 
-func newClusterPool(size int, exclusive bool, maxUsage int) *clusterPool {
+func newClusterPool(size int, exclusive bool, maxLeases int) *clusterPool {
 	p := &clusterPool{
 		slots: make([]*clusterPoolSlot, size),
 	}
 	for i := range size {
 		p.slots[i] = &clusterPoolSlot{
-			idx:      i,
-			maxUsage: maxUsage,
+			idx:       i,
+			maxLeases: maxLeases,
 		}
 	}
 	if exclusive {
@@ -130,18 +130,18 @@ func (s *clusterPoolSlot) acquire(t *testing.T, createCluster func() *Functional
 			s.tearDownLocked(t)
 		}
 		s.cluster = createCluster()
-		s.useCount = 0
+		s.leaseCount = 0
 		cluster = s.cluster
 	}
 
-	// Recreate idle clusters after maxUsage tests.
-	if s.maxUsage > 0 && s.useCount >= s.maxUsage && s.activeLeases == 0 {
+	// Recreate idle clusters after the lease limit is reached.
+	if s.maxLeases > 0 && s.leaseCount >= s.maxLeases && s.activeLeases == 0 {
 		s.tearDownLocked(t)
 		s.cluster = createCluster()
 		cluster = s.cluster
 	}
 
-	s.useCount++
+	s.leaseCount++
 	s.activeLeases++
 	cluster.SetT(t)
 	return cluster
@@ -164,7 +164,7 @@ func (s *clusterPoolSlot) tearDownLocked(t *testing.T) {
 		t.Logf("Failed to tear down cluster %d: %v", s.idx, err)
 	}
 	s.cluster = nil
-	s.useCount = 0
+	s.leaseCount = 0
 }
 
 // clusterRouter routes tests to shared/dedicated [clusterPool] or [suiteScopedCluster]s.

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -45,7 +45,7 @@ func init() {
 	}
 }
 
-// pool manages a fixed number of test cluster slots.
+// pool manages a fixed number of test [clusterSlot]s.
 type pool struct {
 	slots []*clusterSlot
 	next  int
@@ -168,7 +168,7 @@ func (s *clusterSlot) tearDownLocked(t *testing.T) {
 	s.usage = 0
 }
 
-// clusterPool routes tests to shared, dedicated, or suite-scoped clusters.
+// clusterPool routes tests to shared, dedicated, or [suiteScopedCluster]s.
 type clusterPool struct {
 	shared      *pool
 	dedicated   *pool

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -60,7 +60,7 @@ type clusterSlot struct {
 
 	cluster *FunctionalTestBase
 
-	// For shared pools: track usage and support teardown/recreate after maxUsage tests
+	// Track leases and max-usage recycling under the slot lock.
 	usage    int
 	active   int
 	maxUsage int // max tests per cluster before recreate (0 = unlimited)
@@ -88,7 +88,7 @@ func newPool(size int, exclusive bool, maxUsage int) *pool {
 // get returns a cluster from the pool, creating it lazily if needed.
 // For exclusive pools, blocks until a slot is available and registers cleanup.
 // For shared pools, uses round-robin.
-// Both pool types may recreate clusters after maxUsage tests (in CI).
+// Both pool types may recreate idle clusters after maxUsage tests (in CI).
 func (p *pool) get(t *testing.T, createCluster func() *FunctionalTestBase) *FunctionalTestBase {
 	slot := p.reserveSlot(t)
 	cluster := slot.acquire(t, createCluster)
@@ -123,8 +123,8 @@ func (s *clusterSlot) acquire(t *testing.T, createCluster func() *FunctionalTest
 	}
 	cluster := s.cluster
 
-	// Swap out poisoned clusters. The poisoned cluster will tear itself down during its last
-	// test run's cleanup.
+	// Swap out poisoned clusters. An active poisoned cluster will tear itself down during its
+	// last test run's cleanup; an idle poisoned cluster can be torn down here.
 	if cluster.Poisoned() {
 		if s.active == 0 {
 			s.tearDownLocked(t)
@@ -134,7 +134,7 @@ func (s *clusterSlot) acquire(t *testing.T, createCluster func() *FunctionalTest
 		cluster = s.cluster
 	}
 
-	// Check if we need to recreate the cluster after maxUsage tests
+	// Recreate idle clusters after maxUsage tests.
 	if s.maxUsage > 0 && s.usage >= s.maxUsage && s.active == 0 {
 		s.tearDownLocked(t)
 		s.cluster = createCluster()

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 
 	"go.temporal.io/server/common/dynamicconfig"
@@ -40,43 +39,47 @@ func init() {
 		maxUsage = 50
 	}
 
-	sharedPool := newPool(sharedSize, false)
-	sharedPool.maxUsage = maxUsage
-
-	dedicatedPool := newPool(dedicatedSize, true)
-	dedicatedPool.maxUsage = maxUsage
-
 	testClusterPool = &clusterPool{
-		shared:    sharedPool,
-		dedicated: dedicatedPool,
+		shared:    newPool(sharedSize, false, maxUsage),
+		dedicated: newPool(dedicatedSize, true, maxUsage),
 	}
 }
 
 // pool manages a fixed number of test clusters with lazy initialization.
 type pool struct {
-	clusters []*FunctionalTestBase
-	inits    []sync.Once
-	counter  atomic.Int64 // for round-robin (when slots is nil)
-	slots    chan int     // for exclusive access (nil means shared/concurrent access)
+	slots []*clusterSlot
+	next  int
+	mu    sync.Mutex
 
-	// For shared pools: track usage and support teardown/recreate after maxUsage tests
-	usageCounts []atomic.Int64
-	clusterMu   []sync.Mutex // protects cluster teardown/recreate
-	maxUsage    int          // max tests per cluster before recreate (0 = unlimited)
-	createFn    func() *FunctionalTestBase
+	available chan *clusterSlot // for exclusive access (nil means shared/concurrent access)
 }
 
-func newPool(size int, exclusive bool) *pool {
+type clusterSlot struct {
+	idx int
+	mu  sync.Mutex
+
+	cluster *FunctionalTestBase
+
+	// For shared pools: track usage and support teardown/recreate after maxUsage tests
+	usage    int
+	active   int
+	maxUsage int // max tests per cluster before recreate (0 = unlimited)
+}
+
+func newPool(size int, exclusive bool, maxUsage int) *pool {
 	p := &pool{
-		clusters:    make([]*FunctionalTestBase, size),
-		inits:       make([]sync.Once, size),
-		usageCounts: make([]atomic.Int64, size),
-		clusterMu:   make([]sync.Mutex, size),
+		slots: make([]*clusterSlot, size),
+	}
+	for i := range size {
+		p.slots[i] = &clusterSlot{
+			idx:      i,
+			maxUsage: maxUsage,
+		}
 	}
 	if exclusive {
-		p.slots = make(chan int, size)
-		for i := range size {
-			p.slots <- i
+		p.available = make(chan *clusterSlot, size)
+		for _, slot := range p.slots {
+			p.available <- slot
 		}
 	}
 	return p
@@ -87,64 +90,80 @@ func newPool(size int, exclusive bool) *pool {
 // For shared pools, uses round-robin.
 // Both pool types may recreate clusters after maxUsage tests (in CI).
 func (p *pool) get(t *testing.T, createCluster func() *FunctionalTestBase) *FunctionalTestBase {
-	var idx int
-	if p.slots != nil {
-		idx = <-p.slots
-		t.Cleanup(func() { p.slots <- idx })
-	} else {
-		idx = int(p.counter.Add(1)-1) % len(p.clusters)
-	}
-
-	// Check if we need to recreate the cluster after maxUsage tests
-	if p.maxUsage > 0 {
-		usage := p.usageCounts[idx].Add(1)
-		if usage > int64(p.maxUsage) {
-			p.clusterMu[idx].Lock()
-			// Double-check after acquiring lock
-			if p.usageCounts[idx].Load() > int64(p.maxUsage) && p.clusters[idx] != nil {
-				if err := p.clusters[idx].tearDownTestCluster(); err != nil {
-					t.Logf("Failed to tear down cluster %d: %v", idx, err)
-				}
-				p.clusters[idx] = createCluster()
-				p.usageCounts[idx].Store(1) // Reset to 1 (this test counts)
-			}
-			p.clusterMu[idx].Unlock()
-		}
-	}
-
-	// Lazy initialization for first use
-	p.inits[idx].Do(func() {
-		p.clusters[idx] = createCluster()
-	})
-
-	cluster := p.clusters[idx]
-
-	// Swap out poisoned clusters. The poisoned cluster will tear itself down during its last
-	// test run's cleanup.
-	if cluster.Poisoned() {
-		p.clusterMu[idx].Lock()
-		if p.clusters[idx].Poisoned() {
-			p.clusters[idx] = createCluster()
-			if p.maxUsage > 0 {
-				p.usageCounts[idx].Store(1)
-			}
-		}
-		cluster = p.clusters[idx]
-		p.clusterMu[idx].Unlock()
-	}
-
-	cluster.SetT(t)
+	slot := p.acquireSlot(t)
+	cluster := slot.acquire(t, createCluster)
+	t.Cleanup(slot.release)
 	return cluster
 }
 
 // acquireSlot gets exclusive access to a slot without using a pooled cluster.
 // Used when a fresh cluster is needed (e.g., custom dynamic config).
-func (p *pool) acquireSlot(t *testing.T) {
-	if p.slots == nil {
+func (p *pool) acquireSlot(t *testing.T) *clusterSlot {
+	if p.available != nil {
+		slot := <-p.available
+		t.Cleanup(func() { p.available <- slot })
+		return slot
+	}
+
+	p.mu.Lock()
+	slot := p.slots[p.next]
+	p.next = (p.next + 1) % len(p.slots)
+	p.mu.Unlock()
+	return slot
+}
+
+func (s *clusterSlot) acquire(t *testing.T, createCluster func() *FunctionalTestBase) *FunctionalTestBase {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Lazy initialization for first use
+	if s.cluster == nil {
+		s.cluster = createCluster()
+	}
+	cluster := s.cluster
+
+	// Swap out poisoned clusters. The poisoned cluster will tear itself down during its last
+	// test run's cleanup.
+	if cluster.Poisoned() {
+		if s.active == 0 {
+			s.tearDownLocked(t)
+		}
+		s.cluster = createCluster()
+		s.usage = 0
+		cluster = s.cluster
+	}
+
+	// Check if we need to recreate the cluster after maxUsage tests
+	if s.maxUsage > 0 && s.usage >= s.maxUsage && s.active == 0 {
+		s.tearDownLocked(t)
+		s.cluster = createCluster()
+		cluster = s.cluster
+	}
+
+	s.usage++
+	s.active++
+	cluster.SetT(t)
+	return cluster
+}
+
+func (s *clusterSlot) release() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.active == 0 {
+		panic("release called without matching acquire")
+	}
+	s.active--
+}
+
+func (s *clusterSlot) tearDownLocked(t *testing.T) {
+	if s.cluster == nil {
 		return
 	}
-	idx := <-p.slots
-	t.Cleanup(func() { p.slots <- idx })
+	if err := s.cluster.tearDownTestCluster(); err != nil {
+		t.Logf("Failed to tear down cluster %d: %v", s.idx, err)
+	}
+	s.cluster = nil
+	s.usage = 0
 }
 
 type clusterPool struct {

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -11,7 +11,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 )
 
-var testClusterPool *clusterPool
+var testClusterRouter *clusterRouter
 
 func init() {
 	sharedSize := max(1, runtime.GOMAXPROCS(0)/2)
@@ -39,23 +39,23 @@ func init() {
 		maxUsage = 50
 	}
 
-	testClusterPool = &clusterPool{
+	testClusterRouter = &clusterRouter{
 		shared:    newPool(sharedSize, false, maxUsage),
 		dedicated: newPool(dedicatedSize, true, maxUsage),
 	}
 }
 
-// pool manages a fixed number of test [clusterSlot]s.
+// pool manages a fixed number of test [poolSlot]s.
 type pool struct {
-	slots []*clusterSlot
+	slots []*poolSlot
 	next  int
 	mu    sync.Mutex
 
-	available chan *clusterSlot // for exclusive access (nil means shared/concurrent access)
+	available chan *poolSlot // for exclusive access (nil means shared/concurrent access)
 }
 
-// clusterSlot owns one pooled cluster and its lease state.
-type clusterSlot struct {
+// poolSlot owns one pooled cluster and its lease state.
+type poolSlot struct {
 	idx int
 	mu  sync.Mutex
 
@@ -69,16 +69,16 @@ type clusterSlot struct {
 
 func newPool(size int, exclusive bool, maxUsage int) *pool {
 	p := &pool{
-		slots: make([]*clusterSlot, size),
+		slots: make([]*poolSlot, size),
 	}
 	for i := range size {
-		p.slots[i] = &clusterSlot{
+		p.slots[i] = &poolSlot{
 			idx:      i,
 			maxUsage: maxUsage,
 		}
 	}
 	if exclusive {
-		p.available = make(chan *clusterSlot, size)
+		p.available = make(chan *poolSlot, size)
 		for _, slot := range p.slots {
 			p.available <- slot
 		}
@@ -97,7 +97,7 @@ func (p *pool) get(t *testing.T, createCluster func() *FunctionalTestBase) *Func
 	return cluster
 }
 
-func (p *pool) reserveSlot(t *testing.T) *clusterSlot {
+func (p *pool) reserveSlot(t *testing.T) *poolSlot {
 	if p.available != nil {
 		slot := <-p.available
 		t.Cleanup(func() { p.available <- slot })
@@ -106,7 +106,7 @@ func (p *pool) reserveSlot(t *testing.T) *clusterSlot {
 	return p.nextSlot()
 }
 
-func (p *pool) nextSlot() *clusterSlot {
+func (p *pool) nextSlot() *poolSlot {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	slot := p.slots[p.next]
@@ -114,7 +114,7 @@ func (p *pool) nextSlot() *clusterSlot {
 	return slot
 }
 
-func (s *clusterSlot) acquire(t *testing.T, createCluster func() *FunctionalTestBase) *FunctionalTestBase {
+func (s *poolSlot) acquire(t *testing.T, createCluster func() *FunctionalTestBase) *FunctionalTestBase {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -148,7 +148,7 @@ func (s *clusterSlot) acquire(t *testing.T, createCluster func() *FunctionalTest
 	return cluster
 }
 
-func (s *clusterSlot) release() {
+func (s *poolSlot) release() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.active == 0 {
@@ -157,7 +157,7 @@ func (s *clusterSlot) release() {
 	s.active--
 }
 
-func (s *clusterSlot) tearDownLocked(t *testing.T) {
+func (s *poolSlot) tearDownLocked(t *testing.T) {
 	if s.cluster == nil {
 		return
 	}
@@ -168,8 +168,8 @@ func (s *clusterSlot) tearDownLocked(t *testing.T) {
 	s.usage = 0
 }
 
-// clusterPool routes tests to shared, dedicated, or [suiteScopedCluster]s.
-type clusterPool struct {
+// clusterRouter routes tests to shared, dedicated, or [suiteScopedCluster]s.
+type clusterRouter struct {
 	shared      *pool
 	dedicated   *pool
 	suiteScoped sync.Map
@@ -192,10 +192,10 @@ func UseSuiteScopedCluster(t *testing.T) {
 	if t.Name() != rootName {
 		t.Fatalf("UseSuiteScopedCluster must be called from a top-level test, got %q", t.Name())
 	}
-	testClusterPool.suiteScoped.LoadOrStore(rootName, &suiteScopedCluster{})
+	testClusterRouter.suiteScoped.LoadOrStore(rootName, &suiteScopedCluster{})
 
 	t.Cleanup(func() {
-		suiteClusterAny, ok := testClusterPool.suiteScoped.Load(rootName)
+		suiteClusterAny, ok := testClusterRouter.suiteScoped.Load(rootName)
 		if ok {
 			suiteCluster := suiteClusterAny.(*suiteScopedCluster)
 			if suiteCluster.cluster != nil {
@@ -204,11 +204,11 @@ func UseSuiteScopedCluster(t *testing.T) {
 				}
 			}
 		}
-		testClusterPool.suiteScoped.Delete(rootName)
+		testClusterRouter.suiteScoped.Delete(rootName)
 	})
 }
 
-func (p *clusterPool) get(t *testing.T, dedicated bool, dynamicConfig map[dynamicconfig.Key]any, clusterOpts []TestClusterOption) (tb *FunctionalTestBase) {
+func (p *clusterRouter) get(t *testing.T, dedicated bool, dynamicConfig map[dynamicconfig.Key]any, clusterOpts []TestClusterOption) (tb *FunctionalTestBase) {
 	defer func() {
 		tb.RegisterTest(t)
 	}()
@@ -221,13 +221,13 @@ func (p *clusterPool) get(t *testing.T, dedicated bool, dynamicConfig map[dynami
 	return p.getShared(t)
 }
 
-func (p *clusterPool) getShared(t *testing.T) *FunctionalTestBase {
+func (p *clusterRouter) getShared(t *testing.T) *FunctionalTestBase {
 	return p.shared.get(t, func() *FunctionalTestBase {
 		return p.createCluster(t, nil, true, nil)
 	})
 }
 
-func (p *clusterPool) getSuiteScoped(t *testing.T) *FunctionalTestBase {
+func (p *clusterRouter) getSuiteScoped(t *testing.T) *FunctionalTestBase {
 	rootName, _, _ := strings.Cut(t.Name(), "/")
 	if _, ok := p.suiteScoped.Load(rootName); !ok {
 		return nil
@@ -242,7 +242,7 @@ func (p *clusterPool) getSuiteScoped(t *testing.T) *FunctionalTestBase {
 	return suiteCluster.cluster
 }
 
-func (p *clusterPool) getDedicated(t *testing.T, dynamicConfig map[dynamicconfig.Key]any, clusterOpts []TestClusterOption) *FunctionalTestBase {
+func (p *clusterRouter) getDedicated(t *testing.T, dynamicConfig map[dynamicconfig.Key]any, clusterOpts []TestClusterOption) *FunctionalTestBase {
 	if len(dynamicConfig) > 0 || len(clusterOpts) > 0 {
 		// Custom config or fx options require a fresh cluster (can't reuse).
 		p.dedicated.reserveSlot(t)
@@ -264,7 +264,7 @@ func (p *clusterPool) getDedicated(t *testing.T, dynamicConfig map[dynamicconfig
 	})
 }
 
-func (p *clusterPool) createCluster(t *testing.T, dynamicConfig map[dynamicconfig.Key]any, shared bool, clusterOpts []TestClusterOption) *FunctionalTestBase {
+func (p *clusterRouter) createCluster(t *testing.T, dynamicConfig map[dynamicconfig.Key]any, shared bool, clusterOpts []TestClusterOption) *FunctionalTestBase {
 	tbase := &FunctionalTestBase{}
 	tbase.SetT(t)
 

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -89,7 +89,6 @@ func newClusterPool(size int, exclusive bool, maxUsage int) *clusterPool {
 // get returns a cluster from the [clusterPool], creating it lazily if needed.
 // For exclusive pools, blocks until a slot is available and registers cleanup.
 // For shared pools, uses round-robin.
-// Both [clusterPool] variants may recreate idle clusters after maxUsage tests (in CI).
 func (p *clusterPool) get(t *testing.T, createCluster func() *FunctionalTestBase) *FunctionalTestBase {
 	slot := p.reserveSlot(t)
 	cluster := slot.acquire(t, createCluster)

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -90,15 +90,13 @@ func newPool(size int, exclusive bool, maxUsage int) *pool {
 // For shared pools, uses round-robin.
 // Both pool types may recreate clusters after maxUsage tests (in CI).
 func (p *pool) get(t *testing.T, createCluster func() *FunctionalTestBase) *FunctionalTestBase {
-	slot := p.acquireSlot(t)
+	slot := p.reserveSlot(t)
 	cluster := slot.acquire(t, createCluster)
 	t.Cleanup(slot.release)
 	return cluster
 }
 
-// acquireSlot gets exclusive access to a slot without using a pooled cluster.
-// Used when a fresh cluster is needed (e.g., custom dynamic config).
-func (p *pool) acquireSlot(t *testing.T) *clusterSlot {
+func (p *pool) reserveSlot(t *testing.T) *clusterSlot {
 	if p.available != nil {
 		slot := <-p.available
 		t.Cleanup(func() { p.available <- slot })
@@ -241,7 +239,7 @@ func (p *clusterPool) getSuiteScoped(t *testing.T) *FunctionalTestBase {
 func (p *clusterPool) getDedicated(t *testing.T, dynamicConfig map[dynamicconfig.Key]any, clusterOpts []TestClusterOption) *FunctionalTestBase {
 	if len(dynamicConfig) > 0 || len(clusterOpts) > 0 {
 		// Custom config or fx options require a fresh cluster (can't reuse).
-		p.dedicated.acquireSlot(t)
+		p.dedicated.reserveSlot(t)
 		cluster := p.createCluster(t, dynamicConfig, false, clusterOpts)
 
 		// Register cleanup to tear down the cluster when the test completes.

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -49,22 +49,22 @@ func init() {
 type clusterPool struct {
 	slots []*clusterPoolSlot
 	next  int
-	mu    sync.Mutex
+	lock  sync.Mutex
 
 	available chan *clusterPoolSlot // for exclusive access (nil means shared/concurrent access)
 }
 
 // clusterPoolSlot owns one pooled cluster and its lease state.
 type clusterPoolSlot struct {
-	idx int
-	mu  sync.Mutex
+	idx  int
+	lock sync.Mutex
 
 	cluster *FunctionalTestBase
 
 	// Track leases and max-usage recycling under the slot lock.
-	usage    int
-	active   int
-	maxUsage int // max tests per cluster before recreate (0 = unlimited)
+	useCount     int
+	activeLeases int
+	maxUsage     int // max tests per cluster before recreate (0 = unlimited)
 }
 
 func newClusterPool(size int, exclusive bool, maxUsage int) *clusterPool {
@@ -106,16 +106,16 @@ func (p *clusterPool) reserveSlot(t *testing.T) *clusterPoolSlot {
 }
 
 func (p *clusterPool) nextSlot() *clusterPoolSlot {
-	p.mu.Lock()
-	defer p.mu.Unlock()
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	slot := p.slots[p.next]
 	p.next = (p.next + 1) % len(p.slots)
 	return slot
 }
 
 func (s *clusterPoolSlot) acquire(t *testing.T, createCluster func() *FunctionalTestBase) *FunctionalTestBase {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.lock.Lock()
+	defer s.lock.Unlock()
 
 	// Lazy initialization for first use
 	if s.cluster == nil {
@@ -126,34 +126,34 @@ func (s *clusterPoolSlot) acquire(t *testing.T, createCluster func() *Functional
 	// Swap out poisoned clusters. An active poisoned cluster will tear itself down during its
 	// last test run's cleanup; an idle poisoned cluster can be torn down here.
 	if cluster.Poisoned() {
-		if s.active == 0 {
+		if s.activeLeases == 0 {
 			s.tearDownLocked(t)
 		}
 		s.cluster = createCluster()
-		s.usage = 0
+		s.useCount = 0
 		cluster = s.cluster
 	}
 
 	// Recreate idle clusters after maxUsage tests.
-	if s.maxUsage > 0 && s.usage >= s.maxUsage && s.active == 0 {
+	if s.maxUsage > 0 && s.useCount >= s.maxUsage && s.activeLeases == 0 {
 		s.tearDownLocked(t)
 		s.cluster = createCluster()
 		cluster = s.cluster
 	}
 
-	s.usage++
-	s.active++
+	s.useCount++
+	s.activeLeases++
 	cluster.SetT(t)
 	return cluster
 }
 
 func (s *clusterPoolSlot) release() {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.active == 0 {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.activeLeases == 0 {
 		panic("release called without matching acquire")
 	}
-	s.active--
+	s.activeLeases--
 }
 
 func (s *clusterPoolSlot) tearDownLocked(t *testing.T) {
@@ -164,10 +164,10 @@ func (s *clusterPoolSlot) tearDownLocked(t *testing.T) {
 		t.Logf("Failed to tear down cluster %d: %v", s.idx, err)
 	}
 	s.cluster = nil
-	s.usage = 0
+	s.useCount = 0
 }
 
-// clusterRouter routes tests to shared, dedicated, or [suiteScopedCluster]s.
+// clusterRouter routes tests to shared/dedicated [clusterPool] or [suiteScopedCluster]s.
 type clusterRouter struct {
 	shared      *clusterPool
 	dedicated   *clusterPool

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -205,7 +205,9 @@ func UseSuiteScopedCluster(t *testing.T) {
 
 func (p *clusterRouter) get(t *testing.T, dedicated bool, dynamicConfig map[dynamicconfig.Key]any, clusterOpts []TestClusterOption) (tb *FunctionalTestBase) {
 	defer func() {
-		tb.RegisterTest(t)
+		if tb != nil {
+			tb.RegisterTest(t)
+		}
 	}()
 	if dedicated || len(dynamicConfig) > 0 || len(clusterOpts) > 0 {
 		return p.getDedicated(t, dynamicConfig, clusterOpts)

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -47,23 +47,21 @@ func init() {
 
 // clusterPool manages a fixed number of test [clusterPoolSlot]s.
 type clusterPool struct {
-	slots []*clusterPoolSlot
-	next  int
-	lock  sync.Mutex
-
+	slots     []*clusterPoolSlot
 	available chan *clusterPoolSlot // for exclusive access (nil means shared/concurrent access)
+
+	lock sync.Mutex // protects next
+	next int
 }
 
 // clusterPoolSlot owns one pooled cluster and its lease state.
 type clusterPoolSlot struct {
-	idx  int
-	lock sync.Mutex
+	idx int
 
-	cluster *FunctionalTestBase
-
-	// Track leases and lease-limit recycling under the slot lock.
-	leaseCount   int
-	activeLeases int
+	lock         sync.Mutex
+	cluster      *FunctionalTestBase
+	activeLeases int // how many tests are currently using this cluster
+	leaseCount   int // how often it has been leased
 	maxLeases    int // max tests per cluster before recreate (0 = unlimited)
 }
 

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -54,6 +54,7 @@ type pool struct {
 	available chan *clusterSlot // for exclusive access (nil means shared/concurrent access)
 }
 
+// clusterSlot owns one pooled cluster and its lease state.
 type clusterSlot struct {
 	idx int
 	mu  sync.Mutex
@@ -167,12 +168,14 @@ func (s *clusterSlot) tearDownLocked(t *testing.T) {
 	s.usage = 0
 }
 
+// clusterPool routes tests to shared, dedicated, or suite-scoped clusters.
 type clusterPool struct {
 	shared      *pool
 	dedicated   *pool
 	suiteScoped sync.Map
 }
 
+// suiteScopedCluster owns one lazily created legacy suite cluster.
 type suiteScopedCluster struct {
 	once    sync.Once
 	cluster *FunctionalTestBase

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -45,7 +45,7 @@ func init() {
 	}
 }
 
-// pool manages a fixed number of test clusters with lazy initialization.
+// pool manages a fixed number of test cluster slots.
 type pool struct {
 	slots []*clusterSlot
 	next  int
@@ -102,11 +102,14 @@ func (p *pool) reserveSlot(t *testing.T) *clusterSlot {
 		t.Cleanup(func() { p.available <- slot })
 		return slot
 	}
+	return p.nextSlot()
+}
 
+func (p *pool) nextSlot() *clusterSlot {
 	p.mu.Lock()
+	defer p.mu.Unlock()
 	slot := p.slots[p.next]
 	p.next = (p.next + 1) % len(p.slots)
-	p.mu.Unlock()
 	return slot
 }
 

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -40,22 +40,22 @@ func init() {
 	}
 
 	testClusterRouter = &clusterRouter{
-		shared:    newPool(sharedSize, false, maxUsage),
-		dedicated: newPool(dedicatedSize, true, maxUsage),
+		shared:    newClusterPool(sharedSize, false, maxUsage),
+		dedicated: newClusterPool(dedicatedSize, true, maxUsage),
 	}
 }
 
-// pool manages a fixed number of test [poolSlot]s.
-type pool struct {
-	slots []*poolSlot
+// clusterPool manages a fixed number of test [clusterPoolSlot]s.
+type clusterPool struct {
+	slots []*clusterPoolSlot
 	next  int
 	mu    sync.Mutex
 
-	available chan *poolSlot // for exclusive access (nil means shared/concurrent access)
+	available chan *clusterPoolSlot // for exclusive access (nil means shared/concurrent access)
 }
 
-// poolSlot owns one pooled cluster and its lease state.
-type poolSlot struct {
+// clusterPoolSlot owns one pooled cluster and its lease state.
+type clusterPoolSlot struct {
 	idx int
 	mu  sync.Mutex
 
@@ -67,18 +67,18 @@ type poolSlot struct {
 	maxUsage int // max tests per cluster before recreate (0 = unlimited)
 }
 
-func newPool(size int, exclusive bool, maxUsage int) *pool {
-	p := &pool{
-		slots: make([]*poolSlot, size),
+func newClusterPool(size int, exclusive bool, maxUsage int) *clusterPool {
+	p := &clusterPool{
+		slots: make([]*clusterPoolSlot, size),
 	}
 	for i := range size {
-		p.slots[i] = &poolSlot{
+		p.slots[i] = &clusterPoolSlot{
 			idx:      i,
 			maxUsage: maxUsage,
 		}
 	}
 	if exclusive {
-		p.available = make(chan *poolSlot, size)
+		p.available = make(chan *clusterPoolSlot, size)
 		for _, slot := range p.slots {
 			p.available <- slot
 		}
@@ -86,18 +86,18 @@ func newPool(size int, exclusive bool, maxUsage int) *pool {
 	return p
 }
 
-// get returns a cluster from the pool, creating it lazily if needed.
+// get returns a cluster from the [clusterPool], creating it lazily if needed.
 // For exclusive pools, blocks until a slot is available and registers cleanup.
 // For shared pools, uses round-robin.
-// Both pool types may recreate idle clusters after maxUsage tests (in CI).
-func (p *pool) get(t *testing.T, createCluster func() *FunctionalTestBase) *FunctionalTestBase {
+// Both [clusterPool] variants may recreate idle clusters after maxUsage tests (in CI).
+func (p *clusterPool) get(t *testing.T, createCluster func() *FunctionalTestBase) *FunctionalTestBase {
 	slot := p.reserveSlot(t)
 	cluster := slot.acquire(t, createCluster)
 	t.Cleanup(slot.release)
 	return cluster
 }
 
-func (p *pool) reserveSlot(t *testing.T) *poolSlot {
+func (p *clusterPool) reserveSlot(t *testing.T) *clusterPoolSlot {
 	if p.available != nil {
 		slot := <-p.available
 		t.Cleanup(func() { p.available <- slot })
@@ -106,7 +106,7 @@ func (p *pool) reserveSlot(t *testing.T) *poolSlot {
 	return p.nextSlot()
 }
 
-func (p *pool) nextSlot() *poolSlot {
+func (p *clusterPool) nextSlot() *clusterPoolSlot {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	slot := p.slots[p.next]
@@ -114,7 +114,7 @@ func (p *pool) nextSlot() *poolSlot {
 	return slot
 }
 
-func (s *poolSlot) acquire(t *testing.T, createCluster func() *FunctionalTestBase) *FunctionalTestBase {
+func (s *clusterPoolSlot) acquire(t *testing.T, createCluster func() *FunctionalTestBase) *FunctionalTestBase {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -148,7 +148,7 @@ func (s *poolSlot) acquire(t *testing.T, createCluster func() *FunctionalTestBas
 	return cluster
 }
 
-func (s *poolSlot) release() {
+func (s *clusterPoolSlot) release() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.active == 0 {
@@ -157,7 +157,7 @@ func (s *poolSlot) release() {
 	s.active--
 }
 
-func (s *poolSlot) tearDownLocked(t *testing.T) {
+func (s *clusterPoolSlot) tearDownLocked(t *testing.T) {
 	if s.cluster == nil {
 		return
 	}
@@ -170,8 +170,8 @@ func (s *poolSlot) tearDownLocked(t *testing.T) {
 
 // clusterRouter routes tests to shared, dedicated, or [suiteScopedCluster]s.
 type clusterRouter struct {
-	shared      *pool
-	dedicated   *pool
+	shared      *clusterPool
+	dedicated   *clusterPool
 	suiteScoped sync.Map
 }
 

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -47,17 +47,16 @@ func init() {
 
 // clusterPool manages a fixed number of test [clusterPoolSlot]s.
 type clusterPool struct {
-	slots     []*clusterPoolSlot
-	available chan *clusterPoolSlot // for exclusive access (nil means shared/concurrent access)
+	allSlots       []*clusterPoolSlot
+	availableSlots chan *clusterPoolSlot // for exclusive access (nil means shared/concurrent access)
 
-	lock sync.Mutex // protects next
-	next int
+	lock        sync.Mutex // protects nextSlotIdx
+	nextSlotIdx int
 }
 
 // clusterPoolSlot owns one pooled cluster and its lease state.
 type clusterPoolSlot struct {
-	idx int
-
+	idx          int
 	lock         sync.Mutex
 	cluster      *FunctionalTestBase
 	activeLeases int // how many tests are currently using this cluster
@@ -67,18 +66,18 @@ type clusterPoolSlot struct {
 
 func newClusterPool(size int, exclusive bool, maxLeases int) *clusterPool {
 	p := &clusterPool{
-		slots: make([]*clusterPoolSlot, size),
+		allSlots: make([]*clusterPoolSlot, size),
 	}
 	for i := range size {
-		p.slots[i] = &clusterPoolSlot{
+		p.allSlots[i] = &clusterPoolSlot{
 			idx:       i,
 			maxLeases: maxLeases,
 		}
 	}
 	if exclusive {
-		p.available = make(chan *clusterPoolSlot, size)
-		for _, slot := range p.slots {
-			p.available <- slot
+		p.availableSlots = make(chan *clusterPoolSlot, size)
+		for _, slot := range p.allSlots {
+			p.availableSlots <- slot
 		}
 	}
 	return p
@@ -95,9 +94,9 @@ func (p *clusterPool) get(t *testing.T, createCluster func() *FunctionalTestBase
 }
 
 func (p *clusterPool) reserveSlot(t *testing.T) *clusterPoolSlot {
-	if p.available != nil {
-		slot := <-p.available
-		t.Cleanup(func() { p.available <- slot })
+	if p.availableSlots != nil {
+		slot := <-p.availableSlots
+		t.Cleanup(func() { p.availableSlots <- slot })
 		return slot
 	}
 	return p.nextSlot()
@@ -106,8 +105,8 @@ func (p *clusterPool) reserveSlot(t *testing.T) *clusterPoolSlot {
 func (p *clusterPool) nextSlot() *clusterPoolSlot {
 	p.lock.Lock()
 	defer p.lock.Unlock()
-	slot := p.slots[p.next]
-	p.next = (p.next + 1) % len(p.slots)
+	slot := p.allSlots[p.nextSlotIdx]
+	p.nextSlotIdx = (p.nextSlotIdx + 1) % len(p.allSlots)
 	return slot
 }
 

--- a/tests/testcore/test_cluster_pool_test.go
+++ b/tests/testcore/test_cluster_pool_test.go
@@ -26,9 +26,9 @@ func TestGlobalOverridesSurviveTestCleanup(t *testing.T) {
 	}
 }
 
-func TestPool_MaxUsageRecyclesOnNextAcquire(t *testing.T) {
+func TestClusterPool_MaxUsageRecyclesOnNextAcquire(t *testing.T) {
 	// maxUsage 1 makes the first completed lease immediately eligible for recycling.
-	p := newPool(1, false, 1)
+	p := newClusterPool(1, false, 1)
 	slot := p.slots[0]
 	var created int
 	createCluster := func() *FunctionalTestBase {
@@ -58,9 +58,9 @@ func TestPool_MaxUsageRecyclesOnNextAcquire(t *testing.T) {
 	})
 }
 
-func TestPoolSlot_MaxUsageWaitsForActiveLeases(t *testing.T) {
+func TestClusterPoolSlot_MaxUsageWaitsForActiveLeases(t *testing.T) {
 	// maxUsage is already reached after the first acquire, but the slot is still active.
-	slot := &poolSlot{maxUsage: 1}
+	slot := &clusterPoolSlot{maxUsage: 1}
 	var created int
 	createCluster := func() *FunctionalTestBase {
 		created++
@@ -92,9 +92,9 @@ func TestPoolSlot_MaxUsageWaitsForActiveLeases(t *testing.T) {
 	require.Equal(t, 2, created)
 }
 
-func TestPoolSlot_PoisonedActiveClusterSwapsWithoutRecycling(t *testing.T) {
+func TestClusterPoolSlot_PoisonedActiveClusterSwapsWithoutRecycling(t *testing.T) {
 	// Use maxUsage 1 to prove poison replacement wins over max-usage recycling.
-	slot := &poolSlot{maxUsage: 1}
+	slot := &clusterPoolSlot{maxUsage: 1}
 	var created int
 	createCluster := func() *FunctionalTestBase {
 		created++

--- a/tests/testcore/test_cluster_pool_test.go
+++ b/tests/testcore/test_cluster_pool_test.go
@@ -29,6 +29,7 @@ func TestGlobalOverridesSurviveTestCleanup(t *testing.T) {
 func TestPool_MaxUsageRecyclesOnNextAcquire(t *testing.T) {
 	// maxUsage 1 makes the first completed lease immediately eligible for recycling.
 	p := newPool(1, false, 1)
+	slot := p.slots[0]
 	var created int
 	createCluster := func() *FunctionalTestBase {
 		created++
@@ -37,20 +38,21 @@ func TestPool_MaxUsageRecyclesOnNextAcquire(t *testing.T) {
 
 	t.Run("uses cluster", func(t *testing.T) {
 		cluster := p.get(t, createCluster)
-		require.Same(t, cluster, p.slots[0].cluster)
-		require.Equal(t, 1, p.slots[0].active)
-		require.Equal(t, 1, p.slots[0].usage)
+		require.Same(t, cluster, slot.cluster)
+		require.Equal(t, 1, slot.active)
+		require.Equal(t, 1, slot.usage)
 	})
 
-	firstCluster := p.slots[0].cluster
+	// The subtest cleanup has released the only active lease.
+	firstCluster := slot.cluster
 	require.NotNil(t, firstCluster)
-	require.Equal(t, 0, p.slots[0].active)
-	require.Equal(t, 1, p.slots[0].usage)
+	require.Equal(t, 0, slot.active)
+	require.Equal(t, 1, slot.usage)
 
 	// Max-usage recycling happens on the next acquire after the prior lease releases.
 	t.Run("recreates cluster", func(t *testing.T) {
 		cluster := p.get(t, createCluster)
-		require.Same(t, cluster, p.slots[0].cluster)
+		require.Same(t, cluster, slot.cluster)
 		require.NotSame(t, firstCluster, cluster)
 		require.Equal(t, 2, created)
 	})
@@ -65,11 +67,11 @@ func TestClusterSlot_MaxUsageWaitsForActiveLeases(t *testing.T) {
 		return &FunctionalTestBase{}
 	}
 
-	first := slot.acquire(t, createCluster)
-	second := slot.acquire(t, createCluster)
+	activeCluster := slot.acquire(t, createCluster)
+	concurrentCluster := slot.acquire(t, createCluster)
 
 	// Concurrent leases share the current cluster even after usage crosses maxUsage.
-	require.Same(t, first, second)
+	require.Same(t, activeCluster, concurrentCluster)
 	require.Equal(t, 1, created)
 	require.Equal(t, 2, slot.active)
 	require.Equal(t, 2, slot.usage)
@@ -85,8 +87,8 @@ func TestClusterSlot_MaxUsageWaitsForActiveLeases(t *testing.T) {
 	require.Equal(t, 2, slot.usage)
 
 	// Once all leases are gone, the next acquire can recycle the overused cluster.
-	third := slot.acquire(t, createCluster)
-	require.NotSame(t, first, third)
+	recycledCluster := slot.acquire(t, createCluster)
+	require.NotSame(t, activeCluster, recycledCluster)
 	require.Equal(t, 2, created)
 }
 
@@ -101,14 +103,14 @@ func TestClusterSlot_PoisonedActiveClusterSwapsWithoutRecycling(t *testing.T) {
 		}
 	}
 
-	first := slot.acquire(t, createCluster)
-	first.t.failed.Store(true)
+	poisonedCluster := slot.acquire(t, createCluster)
+	poisonedCluster.t.failed.Store(true)
 
 	// Poison swaps the slot immediately, but the old active lease still has to release.
-	second := slot.acquire(t, createCluster)
+	replacementCluster := slot.acquire(t, createCluster)
 
-	require.NotSame(t, first, second)
-	require.Same(t, second, slot.cluster)
+	require.NotSame(t, poisonedCluster, replacementCluster)
+	require.Same(t, replacementCluster, slot.cluster)
 	require.Equal(t, 2, created)
 	// The old poisoned lease remains active, while usage restarts on the replacement.
 	require.Equal(t, 2, slot.active)

--- a/tests/testcore/test_cluster_pool_test.go
+++ b/tests/testcore/test_cluster_pool_test.go
@@ -26,7 +26,8 @@ func TestGlobalOverridesSurviveTestCleanup(t *testing.T) {
 	}
 }
 
-func TestPoolMaxUsageRecyclesOnNextAcquire(t *testing.T) {
+func TestPool_MaxUsageRecyclesOnNextAcquire(t *testing.T) {
+	// maxUsage 1 makes the first completed lease immediately eligible for recycling.
 	p := newPool(1, false, 1)
 	var created int
 	createCluster := func() *FunctionalTestBase {
@@ -55,7 +56,8 @@ func TestPoolMaxUsageRecyclesOnNextAcquire(t *testing.T) {
 	})
 }
 
-func TestClusterSlotMaxUsageWaitsForActiveLeases(t *testing.T) {
+func TestClusterSlot_MaxUsageWaitsForActiveLeases(t *testing.T) {
+	// maxUsage is already reached after the first acquire, but the slot is still active.
 	slot := &clusterSlot{maxUsage: 1}
 	var created int
 	createCluster := func() *FunctionalTestBase {
@@ -66,6 +68,7 @@ func TestClusterSlotMaxUsageWaitsForActiveLeases(t *testing.T) {
 	first := slot.acquire(t, createCluster)
 	second := slot.acquire(t, createCluster)
 
+	// Concurrent leases share the current cluster even after usage crosses maxUsage.
 	require.Same(t, first, second)
 	require.Equal(t, 1, created)
 	require.Equal(t, 2, slot.active)
@@ -81,12 +84,14 @@ func TestClusterSlotMaxUsageWaitsForActiveLeases(t *testing.T) {
 	require.Equal(t, 0, slot.active)
 	require.Equal(t, 2, slot.usage)
 
+	// Once all leases are gone, the next acquire can recycle the overused cluster.
 	third := slot.acquire(t, createCluster)
 	require.NotSame(t, first, third)
 	require.Equal(t, 2, created)
 }
 
-func TestClusterSlotPoisonedActiveClusterSwapsWithoutRecycling(t *testing.T) {
+func TestClusterSlot_PoisonedActiveClusterSwapsWithoutRecycling(t *testing.T) {
+	// Use maxUsage 1 to prove poison replacement wins over max-usage recycling.
 	slot := &clusterSlot{maxUsage: 1}
 	var created int
 	createCluster := func() *FunctionalTestBase {
@@ -105,6 +110,7 @@ func TestClusterSlotPoisonedActiveClusterSwapsWithoutRecycling(t *testing.T) {
 	require.NotSame(t, first, second)
 	require.Same(t, second, slot.cluster)
 	require.Equal(t, 2, created)
+	// The old poisoned lease remains active, while usage restarts on the replacement.
 	require.Equal(t, 2, slot.active)
 	require.Equal(t, 1, slot.usage)
 

--- a/tests/testcore/test_cluster_pool_test.go
+++ b/tests/testcore/test_cluster_pool_test.go
@@ -25,3 +25,61 @@ func TestGlobalOverridesSurviveTestCleanup(t *testing.T) {
 		require.Equal(t, v, got[0].Value, "key %s wrong after cleanup", k)
 	}
 }
+
+func TestPoolMaxUsageRecyclesOnNextAcquire(t *testing.T) {
+	p := newPool(1, false, 1)
+	var created int
+	createCluster := func() *FunctionalTestBase {
+		created++
+		return &FunctionalTestBase{}
+	}
+
+	t.Run("uses cluster", func(t *testing.T) {
+		cluster := p.get(t, createCluster)
+		require.Same(t, cluster, p.slots[0].cluster)
+		require.Equal(t, 1, p.slots[0].active)
+		require.Equal(t, 1, p.slots[0].usage)
+	})
+
+	firstCluster := p.slots[0].cluster
+	require.NotNil(t, firstCluster)
+	require.Equal(t, 0, p.slots[0].active)
+	require.Equal(t, 1, p.slots[0].usage)
+
+	t.Run("recreates cluster", func(t *testing.T) {
+		cluster := p.get(t, createCluster)
+		require.Same(t, cluster, p.slots[0].cluster)
+		require.NotSame(t, firstCluster, cluster)
+		require.Equal(t, 2, created)
+	})
+}
+
+func TestClusterSlotMaxUsageWaitsForActiveLeases(t *testing.T) {
+	slot := &clusterSlot{maxUsage: 1}
+	var created int
+	createCluster := func() *FunctionalTestBase {
+		created++
+		return &FunctionalTestBase{}
+	}
+
+	first := slot.acquire(t, createCluster)
+	second := slot.acquire(t, createCluster)
+
+	require.Same(t, first, second)
+	require.Equal(t, 1, created)
+	require.Equal(t, 2, slot.active)
+	require.Equal(t, 2, slot.usage)
+
+	slot.release()
+	require.NotNil(t, slot.cluster)
+	require.Equal(t, 1, slot.active)
+
+	slot.release()
+	require.NotNil(t, slot.cluster)
+	require.Equal(t, 0, slot.active)
+	require.Equal(t, 2, slot.usage)
+
+	third := slot.acquire(t, createCluster)
+	require.NotSame(t, first, third)
+	require.Equal(t, 2, created)
+}

--- a/tests/testcore/test_cluster_pool_test.go
+++ b/tests/testcore/test_cluster_pool_test.go
@@ -26,8 +26,8 @@ func TestGlobalOverridesSurviveTestCleanup(t *testing.T) {
 	}
 }
 
-func TestClusterPool_MaxUsageRecyclesOnNextAcquire(t *testing.T) {
-	// maxUsage 1 makes the first completed lease immediately eligible for recycling.
+func TestClusterPool_MaxLeasesRecyclesOnNextAcquire(t *testing.T) {
+	// maxLeases 1 makes the first completed lease immediately eligible for recycling.
 	p := newClusterPool(1, false, 1)
 	slot := p.slots[0]
 	var created int
@@ -40,16 +40,16 @@ func TestClusterPool_MaxUsageRecyclesOnNextAcquire(t *testing.T) {
 		cluster := p.get(t, createCluster)
 		require.Same(t, cluster, slot.cluster)
 		require.Equal(t, 1, slot.activeLeases)
-		require.Equal(t, 1, slot.useCount)
+		require.Equal(t, 1, slot.leaseCount)
 	})
 
 	// The subtest cleanup has released the only active lease.
 	firstCluster := slot.cluster
 	require.NotNil(t, firstCluster)
 	require.Equal(t, 0, slot.activeLeases)
-	require.Equal(t, 1, slot.useCount)
+	require.Equal(t, 1, slot.leaseCount)
 
-	// Max-usage recycling happens on the next acquire after the prior lease releases.
+	// Lease-limit recycling happens on the next acquire after the prior lease releases.
 	t.Run("recreates cluster", func(t *testing.T) {
 		cluster := p.get(t, createCluster)
 		require.Same(t, cluster, slot.cluster)
@@ -58,8 +58,8 @@ func TestClusterPool_MaxUsageRecyclesOnNextAcquire(t *testing.T) {
 	})
 }
 
-func TestClusterPool_MaxUsageWaitsForActiveLeases(t *testing.T) {
-	// maxUsage is already reached after the first acquire, but the slot is still active.
+func TestClusterPool_MaxLeasesWaitsForActiveLeases(t *testing.T) {
+	// maxLeases is already reached after the first acquire, but the slot is still active.
 	p := newClusterPool(1, false, 1)
 	slot := p.slots[0]
 	var created int
@@ -71,16 +71,16 @@ func TestClusterPool_MaxUsageWaitsForActiveLeases(t *testing.T) {
 	activeCluster := p.get(t, createCluster)
 	concurrentCluster := p.get(t, createCluster)
 
-	// Concurrent leases share the current cluster even after usage crosses maxUsage.
+	// Concurrent leases share the current cluster even after usage crosses maxLeases.
 	require.Same(t, activeCluster, concurrentCluster)
 	require.Equal(t, 1, created)
 	require.Equal(t, 2, slot.activeLeases)
-	require.Equal(t, 2, slot.useCount)
+	require.Equal(t, 2, slot.leaseCount)
 	require.NotNil(t, slot.cluster)
 }
 
 func TestClusterPool_PoisonedActiveClusterSwapsWithoutRecycling(t *testing.T) {
-	// Use maxUsage 1 to prove poison replacement wins over max-usage recycling.
+	// Use maxLeases 1 to prove poison replacement wins over lease-limit recycling.
 	p := newClusterPool(1, false, 1)
 	slot := p.slots[0]
 	var created int
@@ -100,7 +100,7 @@ func TestClusterPool_PoisonedActiveClusterSwapsWithoutRecycling(t *testing.T) {
 	require.NotSame(t, poisonedCluster, replacementCluster)
 	require.Same(t, replacementCluster, slot.cluster)
 	require.Equal(t, 2, created)
-	// The old poisoned lease remains active, while useCount restarts on the replacement.
+	// The old poisoned lease remains active, while leaseCount restarts on the replacement.
 	require.Equal(t, 2, slot.activeLeases)
-	require.Equal(t, 1, slot.useCount)
+	require.Equal(t, 1, slot.leaseCount)
 }

--- a/tests/testcore/test_cluster_pool_test.go
+++ b/tests/testcore/test_cluster_pool_test.go
@@ -29,7 +29,7 @@ func TestGlobalOverridesSurviveTestCleanup(t *testing.T) {
 func TestClusterPool_MaxLeasesRecyclesOnNextAcquire(t *testing.T) {
 	// maxLeases 1 makes the first completed lease immediately eligible for recycling.
 	p := newClusterPool(1, false, 1)
-	slot := p.slots[0]
+	slot := p.allSlots[0]
 	var created int
 	createCluster := func() *FunctionalTestBase {
 		created++
@@ -61,7 +61,7 @@ func TestClusterPool_MaxLeasesRecyclesOnNextAcquire(t *testing.T) {
 func TestClusterPool_MaxLeasesWaitsForActiveLeases(t *testing.T) {
 	// maxLeases is already reached after the first acquire, but the slot is still active.
 	p := newClusterPool(1, false, 1)
-	slot := p.slots[0]
+	slot := p.allSlots[0]
 	var created int
 	createCluster := func() *FunctionalTestBase {
 		created++
@@ -82,7 +82,7 @@ func TestClusterPool_MaxLeasesWaitsForActiveLeases(t *testing.T) {
 func TestClusterPool_PoisonedActiveClusterSwapsWithoutRecycling(t *testing.T) {
 	// Use maxLeases 1 to prove poison replacement wins over lease-limit recycling.
 	p := newClusterPool(1, false, 1)
-	slot := p.slots[0]
+	slot := p.allSlots[0]
 	var created int
 	createCluster := func() *FunctionalTestBase {
 		created++

--- a/tests/testcore/test_cluster_pool_test.go
+++ b/tests/testcore/test_cluster_pool_test.go
@@ -39,15 +39,15 @@ func TestClusterPool_MaxUsageRecyclesOnNextAcquire(t *testing.T) {
 	t.Run("uses cluster", func(t *testing.T) {
 		cluster := p.get(t, createCluster)
 		require.Same(t, cluster, slot.cluster)
-		require.Equal(t, 1, slot.active)
-		require.Equal(t, 1, slot.usage)
+		require.Equal(t, 1, slot.activeLeases)
+		require.Equal(t, 1, slot.useCount)
 	})
 
 	// The subtest cleanup has released the only active lease.
 	firstCluster := slot.cluster
 	require.NotNil(t, firstCluster)
-	require.Equal(t, 0, slot.active)
-	require.Equal(t, 1, slot.usage)
+	require.Equal(t, 0, slot.activeLeases)
+	require.Equal(t, 1, slot.useCount)
 
 	// Max-usage recycling happens on the next acquire after the prior lease releases.
 	t.Run("recreates cluster", func(t *testing.T) {
@@ -74,8 +74,8 @@ func TestClusterPool_MaxUsageWaitsForActiveLeases(t *testing.T) {
 	// Concurrent leases share the current cluster even after usage crosses maxUsage.
 	require.Same(t, activeCluster, concurrentCluster)
 	require.Equal(t, 1, created)
-	require.Equal(t, 2, slot.active)
-	require.Equal(t, 2, slot.usage)
+	require.Equal(t, 2, slot.activeLeases)
+	require.Equal(t, 2, slot.useCount)
 	require.NotNil(t, slot.cluster)
 }
 
@@ -100,7 +100,7 @@ func TestClusterPool_PoisonedActiveClusterSwapsWithoutRecycling(t *testing.T) {
 	require.NotSame(t, poisonedCluster, replacementCluster)
 	require.Same(t, replacementCluster, slot.cluster)
 	require.Equal(t, 2, created)
-	// The old poisoned lease remains active, while usage restarts on the replacement.
-	require.Equal(t, 2, slot.active)
-	require.Equal(t, 1, slot.usage)
+	// The old poisoned lease remains active, while useCount restarts on the replacement.
+	require.Equal(t, 2, slot.activeLeases)
+	require.Equal(t, 1, slot.useCount)
 }

--- a/tests/testcore/test_cluster_pool_test.go
+++ b/tests/testcore/test_cluster_pool_test.go
@@ -46,6 +46,7 @@ func TestPoolMaxUsageRecyclesOnNextAcquire(t *testing.T) {
 	require.Equal(t, 0, p.slots[0].active)
 	require.Equal(t, 1, p.slots[0].usage)
 
+	// Max-usage recycling happens on the next acquire after the prior lease releases.
 	t.Run("recreates cluster", func(t *testing.T) {
 		cluster := p.get(t, createCluster)
 		require.Same(t, cluster, p.slots[0].cluster)
@@ -70,6 +71,7 @@ func TestClusterSlotMaxUsageWaitsForActiveLeases(t *testing.T) {
 	require.Equal(t, 2, slot.active)
 	require.Equal(t, 2, slot.usage)
 
+	// Releasing one of multiple active leases must not tear down the shared cluster.
 	slot.release()
 	require.NotNil(t, slot.cluster)
 	require.Equal(t, 1, slot.active)
@@ -97,6 +99,7 @@ func TestClusterSlotPoisonedActiveClusterSwapsWithoutRecycling(t *testing.T) {
 	first := slot.acquire(t, createCluster)
 	first.t.failed.Store(true)
 
+	// Poison swaps the slot immediately, but the old active lease still has to release.
 	second := slot.acquire(t, createCluster)
 
 	require.NotSame(t, first, second)

--- a/tests/testcore/test_cluster_pool_test.go
+++ b/tests/testcore/test_cluster_pool_test.go
@@ -58,9 +58,9 @@ func TestPool_MaxUsageRecyclesOnNextAcquire(t *testing.T) {
 	})
 }
 
-func TestClusterSlot_MaxUsageWaitsForActiveLeases(t *testing.T) {
+func TestPoolSlot_MaxUsageWaitsForActiveLeases(t *testing.T) {
 	// maxUsage is already reached after the first acquire, but the slot is still active.
-	slot := &clusterSlot{maxUsage: 1}
+	slot := &poolSlot{maxUsage: 1}
 	var created int
 	createCluster := func() *FunctionalTestBase {
 		created++
@@ -92,9 +92,9 @@ func TestClusterSlot_MaxUsageWaitsForActiveLeases(t *testing.T) {
 	require.Equal(t, 2, created)
 }
 
-func TestClusterSlot_PoisonedActiveClusterSwapsWithoutRecycling(t *testing.T) {
+func TestPoolSlot_PoisonedActiveClusterSwapsWithoutRecycling(t *testing.T) {
 	// Use maxUsage 1 to prove poison replacement wins over max-usage recycling.
-	slot := &clusterSlot{maxUsage: 1}
+	slot := &poolSlot{maxUsage: 1}
 	var created int
 	createCluster := func() *FunctionalTestBase {
 		created++

--- a/tests/testcore/test_cluster_pool_test.go
+++ b/tests/testcore/test_cluster_pool_test.go
@@ -83,3 +83,29 @@ func TestClusterSlotMaxUsageWaitsForActiveLeases(t *testing.T) {
 	require.NotSame(t, first, third)
 	require.Equal(t, 2, created)
 }
+
+func TestClusterSlotPoisonedActiveClusterSwapsWithoutRecycling(t *testing.T) {
+	slot := &clusterSlot{maxUsage: 1}
+	var created int
+	createCluster := func() *FunctionalTestBase {
+		created++
+		return &FunctionalTestBase{
+			t: &sharedClusterT{name: t.Name()},
+		}
+	}
+
+	first := slot.acquire(t, createCluster)
+	first.t.failed.Store(true)
+
+	second := slot.acquire(t, createCluster)
+
+	require.NotSame(t, first, second)
+	require.Same(t, second, slot.cluster)
+	require.Equal(t, 2, created)
+	require.Equal(t, 2, slot.active)
+	require.Equal(t, 1, slot.usage)
+
+	slot.release()
+	slot.release()
+	require.Equal(t, 0, slot.active)
+}

--- a/tests/testcore/test_cluster_pool_test.go
+++ b/tests/testcore/test_cluster_pool_test.go
@@ -58,43 +58,31 @@ func TestClusterPool_MaxUsageRecyclesOnNextAcquire(t *testing.T) {
 	})
 }
 
-func TestClusterPoolSlot_MaxUsageWaitsForActiveLeases(t *testing.T) {
+func TestClusterPool_MaxUsageWaitsForActiveLeases(t *testing.T) {
 	// maxUsage is already reached after the first acquire, but the slot is still active.
-	slot := &clusterPoolSlot{maxUsage: 1}
+	p := newClusterPool(1, false, 1)
+	slot := p.slots[0]
 	var created int
 	createCluster := func() *FunctionalTestBase {
 		created++
 		return &FunctionalTestBase{}
 	}
 
-	activeCluster := slot.acquire(t, createCluster)
-	concurrentCluster := slot.acquire(t, createCluster)
+	activeCluster := p.get(t, createCluster)
+	concurrentCluster := p.get(t, createCluster)
 
 	// Concurrent leases share the current cluster even after usage crosses maxUsage.
 	require.Same(t, activeCluster, concurrentCluster)
 	require.Equal(t, 1, created)
 	require.Equal(t, 2, slot.active)
 	require.Equal(t, 2, slot.usage)
-
-	// Releasing one of multiple active leases must not tear down the shared cluster.
-	slot.release()
 	require.NotNil(t, slot.cluster)
-	require.Equal(t, 1, slot.active)
-
-	slot.release()
-	require.NotNil(t, slot.cluster)
-	require.Equal(t, 0, slot.active)
-	require.Equal(t, 2, slot.usage)
-
-	// Once all leases are gone, the next acquire can recycle the overused cluster.
-	recycledCluster := slot.acquire(t, createCluster)
-	require.NotSame(t, activeCluster, recycledCluster)
-	require.Equal(t, 2, created)
 }
 
-func TestClusterPoolSlot_PoisonedActiveClusterSwapsWithoutRecycling(t *testing.T) {
+func TestClusterPool_PoisonedActiveClusterSwapsWithoutRecycling(t *testing.T) {
 	// Use maxUsage 1 to prove poison replacement wins over max-usage recycling.
-	slot := &clusterPoolSlot{maxUsage: 1}
+	p := newClusterPool(1, false, 1)
+	slot := p.slots[0]
 	var created int
 	createCluster := func() *FunctionalTestBase {
 		created++
@@ -103,11 +91,11 @@ func TestClusterPoolSlot_PoisonedActiveClusterSwapsWithoutRecycling(t *testing.T
 		}
 	}
 
-	poisonedCluster := slot.acquire(t, createCluster)
+	poisonedCluster := p.get(t, createCluster)
 	poisonedCluster.t.failed.Store(true)
 
 	// Poison swaps the slot immediately, but the old active lease still has to release.
-	replacementCluster := slot.acquire(t, createCluster)
+	replacementCluster := p.get(t, createCluster)
 
 	require.NotSame(t, poisonedCluster, replacementCluster)
 	require.Same(t, replacementCluster, slot.cluster)
@@ -115,8 +103,4 @@ func TestClusterPoolSlot_PoisonedActiveClusterSwapsWithoutRecycling(t *testing.T
 	// The old poisoned lease remains active, while usage restarts on the replacement.
 	require.Equal(t, 2, slot.active)
 	require.Equal(t, 1, slot.usage)
-
-	slot.release()
-	slot.release()
-	require.Equal(t, 0, slot.active)
 }

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -227,7 +227,7 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 	}
 
 	// Obtain the test cluster from the pool.
-	base := testClusterPool.get(t, options.dedicatedCluster, startupConfig, options.clusterOptions)
+	base := testClusterRouter.get(t, options.dedicatedCluster, startupConfig, options.clusterOptions)
 	cluster := base.GetTestCluster()
 
 	// Create a dedicated namespace for the test to help with test isolation.

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -226,7 +226,7 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 		}
 	}
 
-	// Obtain the test cluster from the pool.
+	// Obtain the test cluster from the router.
 	base := testClusterRouter.get(t, options.dedicatedCluster, startupConfig, options.clusterOptions)
 	cluster := base.GetTestCluster()
 


### PR DESCRIPTION
## What changed

Reworks the test cluster pool.

- `clusterRouter`: routes cluster request a test to shared, dedicated, or suite-scoped cluster handling.
- `clusterPool`: collection of `clusterPoolSlot`s
- `clusterPoolSlot`: owns actual cluster`FunctionalTestBase`, plus metadata

