### PR TITLE
Enforce SQLite varchar length checks

### DIFF
--- a/common/persistence/sql/sqlplugin/interfaces.go
+++ b/common/persistence/sql/sqlplugin/interfaces.go
@@ -113,6 +113,11 @@ type (
 		VerifyVersion() error
 	}
 
+	// TestSchemaStatementRewriter lets SQL plugins adjust schema statements used by test clusters.
+	TestSchemaStatementRewriter interface {
+		RewriteTestSchemaStatements(statements []string) []string
+	}
+
 	GenericDB interface {
 		DbName() string
 		PluginName() string

--- a/common/persistence/sql/sqlplugin/interfaces.go
+++ b/common/persistence/sql/sqlplugin/interfaces.go
@@ -113,9 +113,9 @@ type (
 		VerifyVersion() error
 	}
 
-	// TestSchemaStatementRewriter lets SQL plugins adjust schema statements used by test clusters.
-	TestSchemaStatementRewriter interface {
-		RewriteTestSchemaStatements(statements []string) []string
+	// SchemaStatementRewriter lets SQL plugins adjust schema statements before execution.
+	SchemaStatementRewriter interface {
+		RewriteSchemaStatements(statements []string) []string
 	}
 
 	GenericDB interface {

--- a/common/persistence/sql/sqlplugin/sqlite/schema_rewriter.go
+++ b/common/persistence/sql/sqlplugin/sqlite/schema_rewriter.go
@@ -11,17 +11,17 @@ var (
 	testSchemaVarcharColumnPattern = regexp.MustCompile(`(?im)(?:^|,)\s*("?[a-z_][a-z0-9_]*"?)\s+varchar\s*\(\s*(\d+)\s*\)`)
 )
 
-// RewriteTestSchemaStatements makes SQLite test schemas catch values that would
+// RewriteSchemaStatements makes SQLite schemas catch values that would
 // fail against SQL databases that enforce VARCHAR(n), such as Postgres and MySQL.
-func (mdb *db) RewriteTestSchemaStatements(statements []string) []string {
+func (mdb *db) RewriteSchemaStatements(statements []string) []string {
 	rewritten := make([]string, len(statements))
 	for i, stmt := range statements {
-		rewritten[i] = addTestSchemaVarcharLengthChecks(stmt)
+		rewritten[i] = addSchemaVarcharLengthChecks(stmt)
 	}
 	return rewritten
 }
 
-func addTestSchemaVarcharLengthChecks(stmt string) string {
+func addSchemaVarcharLengthChecks(stmt string) string {
 	// Only CREATE TABLE statements can accept generated table constraints.
 	if !testSchemaCreateTablePattern.MatchString(stmt) {
 		return stmt

--- a/common/persistence/sql/sqlplugin/sqlite/schema_rewriter.go
+++ b/common/persistence/sql/sqlplugin/sqlite/schema_rewriter.go
@@ -1,0 +1,50 @@
+package sqlite
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	testSchemaCreateTablePattern   = regexp.MustCompile(`(?is)^\s*create\s+(?:temp(?:orary)?\s+)?table\b`)
+	testSchemaVarcharColumnPattern = regexp.MustCompile(`(?im)(?:^|,)\s*("?[a-z_][a-z0-9_]*"?)\s+varchar\s*\(\s*(\d+)\s*\)`)
+)
+
+// RewriteTestSchemaStatements makes SQLite test schemas catch values that would
+// fail against SQL databases that enforce VARCHAR(n), such as Postgres and MySQL.
+func (mdb *db) RewriteTestSchemaStatements(statements []string) []string {
+	rewritten := make([]string, len(statements))
+	for i, stmt := range statements {
+		rewritten[i] = addTestSchemaVarcharLengthChecks(stmt)
+	}
+	return rewritten
+}
+
+func addTestSchemaVarcharLengthChecks(stmt string) string {
+	// Only CREATE TABLE statements can accept generated table constraints.
+	if !testSchemaCreateTablePattern.MatchString(stmt) {
+		return stmt
+	}
+
+	varcharColumns := testSchemaVarcharColumnPattern.FindAllStringSubmatch(stmt, -1)
+	if len(varcharColumns) == 0 {
+		return stmt
+	}
+
+	// Append table-level CHECK constraints instead of editing column definitions.
+	trimmedStmt := strings.TrimSpace(stmt)
+	trimmedStmt = strings.TrimSuffix(trimmedStmt, ";")
+	trimmedStmt = strings.TrimSpace(trimmedStmt)
+	tableConstraintOffset := strings.LastIndex(trimmedStmt, ")")
+	if tableConstraintOffset < 0 {
+		return stmt
+	}
+
+	var constraints strings.Builder
+	for _, column := range varcharColumns {
+		fmt.Fprintf(&constraints, ",\n\tCHECK(length(%s) <= %s)", column[1], column[2])
+	}
+
+	return stmt[:tableConstraintOffset] + constraints.String() + stmt[tableConstraintOffset:]
+}

--- a/common/persistence/sql/sqlplugin/sqlite/schema_rewriter.go
+++ b/common/persistence/sql/sqlplugin/sqlite/schema_rewriter.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	testSchemaCreateTablePattern   = regexp.MustCompile(`(?is)^\s*create\s+(?:temp(?:orary)?\s+)?table\b`)
-	testSchemaVarcharColumnPattern = regexp.MustCompile(`(?im)(?:^|,)\s*("?[a-z_][a-z0-9_]*"?)\s+varchar\s*\(\s*(\d+)\s*\)`)
+	testSchemaCreateTablePattern   = regexp.MustCompile(`(?i)^\s*create\s+(?:temp(?:orary)?\s+)?table\b`)
+	testSchemaVarcharColumnPattern = regexp.MustCompile(`(?im)(?:^|[,(])\s*("?[a-z_][a-z0-9_]*"?)\s+varchar\s*\(\s*(\d+)\s*\)`)
 )
 
 // RewriteSchemaStatements makes SQLite schemas catch values that would

--- a/common/persistence/sql/sqlplugin/sqlite/schema_rewriter_test.go
+++ b/common/persistence/sql/sqlplugin/sqlite/schema_rewriter_test.go
@@ -12,7 +12,7 @@ import (
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 )
 
-func TestRewriteTestSchemaStatements_EnforcesVarcharLengthChecks(t *testing.T) {
+func TestRewriteSchemaStatements_EnforcesVarcharLengthChecks(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
@@ -69,7 +69,7 @@ func TestRewriteTestSchemaStatements_EnforcesVarcharLengthChecks(t *testing.T) {
 			t.Cleanup(func() { _ = sqlDB.Close() })
 
 			db := newDB(sqlplugin.DbKindUnknown, "test", sqlDB, nil, log.NewNoopLogger())
-			statements = db.RewriteTestSchemaStatements(statements)
+			statements = db.RewriteSchemaStatements(statements)
 			for _, stmt := range statements {
 				err = db.Exec(stmt)
 				require.NoError(t, err)

--- a/common/persistence/sql/sqlplugin/sqlite/schema_rewriter_test.go
+++ b/common/persistence/sql/sqlplugin/sqlite/schema_rewriter_test.go
@@ -1,0 +1,89 @@
+package sqlite
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/log"
+	p "go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+)
+
+func TestRewriteTestSchemaStatements_EnforcesVarcharLengthChecks(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                 string
+		createTableStatement string
+	}{
+		{
+			name: "create table",
+			createTableStatement: `CREATE TABLE test (
+				id BIGINT NOT NULL,
+				value VARCHAR(3),
+				PRIMARY KEY (id)
+			);`,
+		},
+		{
+			name: "mixed case without semicolon",
+			createTableStatement: `create table test (
+				id BIGINT NOT NULL,
+				value varchar(3),
+				PRIMARY KEY (id)
+			)`,
+		},
+		{
+			name: "temporary table",
+			createTableStatement: `CREATE TEMPORARY TABLE test (
+				id BIGINT NOT NULL,
+				value VARCHAR(3),
+				PRIMARY KEY (id)
+			);`,
+		},
+		{
+			name: "if not exists",
+			createTableStatement: `CREATE TABLE IF NOT EXISTS test (
+				id BIGINT NOT NULL,
+				value VARCHAR(3),
+				PRIMARY KEY (id)
+			);`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			schemaFile := filepath.Join(t.TempDir(), "schema.sql")
+			err := os.WriteFile(schemaFile, []byte(tc.createTableStatement), 0o600)
+			require.NoError(t, err)
+
+			statements, err := p.LoadAndSplitQuery([]string{schemaFile})
+			require.NoError(t, err)
+
+			sqlDB, err := sqlx.Open(goSQLDriverName, ":memory:")
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = sqlDB.Close() })
+
+			db := newDB(sqlplugin.DbKindUnknown, "test", sqlDB, nil, log.NewNoopLogger())
+			statements = db.RewriteTestSchemaStatements(statements)
+			for _, stmt := range statements {
+				err = db.Exec(stmt)
+				require.NoError(t, err)
+			}
+
+			err = db.Exec(`INSERT INTO test (id, value) VALUES (1, NULL)`)
+			require.NoError(t, err)
+
+			err = db.Exec(`INSERT INTO test (id, value) VALUES (2, 'abc')`)
+			require.NoError(t, err)
+
+			err = db.Exec(`INSERT INTO test (id, value) VALUES (3, 'abcd')`)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "CHECK constraint failed")
+		})
+	}
+}

--- a/common/persistence/sql/sqlplugin/sqlite/schema_rewriter_test.go
+++ b/common/persistence/sql/sqlplugin/sqlite/schema_rewriter_test.go
@@ -51,6 +51,10 @@ func TestRewriteSchemaStatements_EnforcesVarcharLengthChecks(t *testing.T) {
 				PRIMARY KEY (id)
 			);`,
 		},
+		{
+			name:                 "single-line first varchar column",
+			createTableStatement: `CREATE TABLE test (value VARCHAR(3), id BIGINT NOT NULL, PRIMARY KEY (id));`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/common/persistence/sql/test_sql_persistence.go
+++ b/common/persistence/sql/test_sql_persistence.go
@@ -197,6 +197,10 @@ func (s *TestCluster) LoadSchema(schemaFile string) {
 		}
 	}()
 
+	if rewriter, ok := db.(sqlplugin.TestSchemaStatementRewriter); ok {
+		statements = rewriter.RewriteTestSchemaStatements(statements)
+	}
+
 	for _, stmt := range statements {
 		if err = db.Exec(stmt); err != nil {
 			s.logger.Fatal("LoadSchema", tag.Error(err))

--- a/common/persistence/sql/test_sql_persistence.go
+++ b/common/persistence/sql/test_sql_persistence.go
@@ -197,8 +197,8 @@ func (s *TestCluster) LoadSchema(schemaFile string) {
 		}
 	}()
 
-	if rewriter, ok := db.(sqlplugin.TestSchemaStatementRewriter); ok {
-		statements = rewriter.RewriteTestSchemaStatements(statements)
+	if rewriter, ok := db.(sqlplugin.SchemaStatementRewriter); ok {
+		statements = rewriter.RewriteSchemaStatements(statements)
 	}
 
 	for _, stmt := range statements {

--- a/common/persistence/tests/sqlite_test.go
+++ b/common/persistence/tests/sqlite_test.go
@@ -80,6 +80,10 @@ func LoadSchema(t *testing.T, db sqlplugin.AdminDB, schemaFile string) {
 		t.Fatalf("Unable to load schema: %s", err)
 	}
 
+	if rewriter, ok := db.(sqlplugin.TestSchemaStatementRewriter); ok {
+		statements = rewriter.RewriteTestSchemaStatements(statements)
+	}
+
 	for _, stmt := range statements {
 		if err = db.Exec(stmt); err != nil {
 			t.Fatalf("Unable to load schema: %s", err)

--- a/common/persistence/tests/sqlite_test.go
+++ b/common/persistence/tests/sqlite_test.go
@@ -80,8 +80,8 @@ func LoadSchema(t *testing.T, db sqlplugin.AdminDB, schemaFile string) {
 		t.Fatalf("Unable to load schema: %s", err)
 	}
 
-	if rewriter, ok := db.(sqlplugin.TestSchemaStatementRewriter); ok {
-		statements = rewriter.RewriteTestSchemaStatements(statements)
+	if rewriter, ok := db.(sqlplugin.SchemaStatementRewriter); ok {
+		statements = rewriter.RewriteSchemaStatements(statements)
 	}
 
 	for _, stmt := range statements {

--- a/tests/poller_scaling_test.go
+++ b/tests/poller_scaling_test.go
@@ -42,6 +42,11 @@ func (s *PollerScalingIntegSuite) setupEnv(opts ...testcore.TestOption) *testcor
 		testcore.WithDynamicConfig(dynamicconfig.MatchingNumTaskqueueReadPartitions, 1),
 		testcore.WithDynamicConfig(dynamicconfig.MatchingNumTaskqueueWritePartitions, 1),
 		testcore.WithDynamicConfig(dynamicconfig.MatchingPollerScalingBacklogAgeScaleUp, 50*time.Millisecond),
+
+		// Keep deployment versions short because worker-deployment system workflow IDs must fit into 255 characters.
+		testcore.WithTestVars(func(tv *testvars.TestVars) *testvars.TestVars {
+			return tv.WithDeploymentSeries("poller-scaling").WithBuildID("v1")
+		}),
 	}, opts...)
 
 	return testcore.NewEnv(s.T(), opts...)
@@ -239,8 +244,7 @@ func (s *PollerScalingIntegSuite) testPollerScalingOnPromotedVersionConsidersUnv
 
 	env := s.setupEnv()
 	tq := testcore.RandomizeStr("test-poller-scaling-tq")
-	// Keep the deployment version short because its system workflow ID must fit into 255 characters.
-	tv := env.Tv().WithDeploymentSeries("poller-scaling").WithBuildID("v1")
+	tv := env.Tv()
 
 	// Queueing up unversioned workflows
 	for range 5 {

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -33,6 +33,7 @@ import (
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/persistence"
 	persistencetests "go.temporal.io/server/common/persistence/persistence-tests"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin/sqlite"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/rpc"
@@ -329,8 +330,7 @@ func (s *FunctionalTestBase) setupCluster(options ...TestClusterOption) {
 
 	// Apply configuration for shared clusters.
 	if params.SharedCluster {
-		// Use file-based SQLite for shared clusters to support parallel test access.
-		s.testClusterConfig.Persistence = *persistencetests.GetSQLiteFileTestClusterOption()
+		s.testClusterConfig.Persistence = sharedClusterPersistence(GetPersistenceTestDefaults())
 		s.isShared = true
 	}
 
@@ -359,6 +359,14 @@ func (s *FunctionalTestBase) setupCluster(options ...TestClusterOption) {
 	s.externalNamespace = namespace.Name(RandomizeStr("external-namespace"))
 	_, err = s.RegisterNamespace(s.ExternalNamespace(), 1, enumspb.ARCHIVAL_STATE_DISABLED, "", "")
 	s.Require().NoError(err)
+}
+
+func sharedClusterPersistence(defaults persistencetests.TestBaseOptions) persistencetests.TestBaseOptions {
+	if defaults.StoreType == config.StoreTypeSQL && defaults.SQLDBPluginName == sqlite.PluginName {
+		// Use file-based SQLite for shared clusters to support parallel test access.
+		return *persistencetests.GetSQLiteFileTestClusterOption()
+	}
+	return defaults
 }
 
 // All test suites that inherit FunctionalTestBase and overwrite SetupTest must

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -97,6 +97,7 @@ type testOptions struct {
 	disableTestloggerFailure bool
 	dynamicConfigSettings    []dynamicConfigOverride
 	clusterOptions           []TestClusterOption
+	testVars                 func(*testvars.TestVars) *testvars.TestVars
 }
 
 type dynamicConfigOverride struct {
@@ -129,6 +130,13 @@ func WithDisableTestloggerFailure() TestOption {
 // Deprecated: this option is no longer required and will be removed once all callers have been updated.
 func WithSdkWorker() TestOption {
 	return func(o *testOptions) {
+	}
+}
+
+// WithTestVars customizes the default test variables for the environment.
+func WithTestVars(fn func(*testvars.TestVars) *testvars.TestVars) TestOption {
+	return func(o *testOptions) {
+		o.testVars = fn
 	}
 }
 
@@ -244,6 +252,11 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 		t.Fatalf("Failed to register namespace: %v", err)
 	}
 
+	tv := testvars.New(t)
+	if options.testVars != nil {
+		tv = options.testVars(tv)
+	}
+
 	env := &TestEnv{
 		FunctionalTestBase: base,
 		Assertions:         require.New(t),
@@ -253,7 +266,7 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 		Logger:             base.Logger,
 		taskPoller:         taskpoller.New(t, cluster.FrontendClient(), ns.String()),
 		t:                  t,
-		tv:                 testvars.New(t),
+		tv:                 tv,
 		ctx:                setupTestTimeoutWithContext(t),
 		sdkWorkerTQ:        RandomizeStr("tq-" + t.Name()),
 		dedicatedGuard:     dedicatedGuard,

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -101,6 +101,11 @@ func (s *Versioning3Suite) setupEnv(opts ...testcore.TestOption) *testcore.TestE
 		// Overriding the number of deployments that can be registered in a single namespace. Done only for this test suite
 		// since it creates a large number of unique deployments in the test suite's namespace.
 		testcore.WithDynamicConfig(dynamicconfig.MatchingMaxDeployments, 1000),
+
+		// Keep deployment versions short because worker-deployment system workflow IDs must fit into 255 characters (database constraint).
+		testcore.WithTestVars(func(tv *testvars.TestVars) *testvars.TestVars {
+			return tv.WithDeploymentSeries("v3").WithBuildID("b")
+		}),
 	}, opts...)
 
 	return testcore.NewEnv(s.T(), opts...)
@@ -6060,8 +6065,7 @@ func (s *Versioning3Suite) TestPinnedCaN_FailedTransientNotificationRefiresDespi
 func (s *Versioning3Suite) TestPinnedCaN_ResetByBuildIDAfterRollback() {
 	env := s.setupEnv(testcore.WithWorkerService("batch operations"))
 
-	// Keep the deployment version short because its system workflow ID must fit into 255 characters.
-	tv := env.Tv().WithDeploymentSeries("rollback-reset").WithBuildID("v")
+	tv := env.Tv()
 	tv1 := tv.WithBuildIDNumber(1)
 	tv2 := tv1.WithBuildIDNumber(2)
 

--- a/tests/workflow_alias_search_attribute_test.go
+++ b/tests/workflow_alias_search_attribute_test.go
@@ -31,16 +31,19 @@ func TestWorkflowAliasSearchAttributeTestSuite(t *testing.T) {
 	parallelsuite.Run(t, &WorkflowAliasSearchAttributeTestSuite{})
 }
 
-func (s *WorkflowAliasSearchAttributeTestSuite) newTestEnv(opts ...testcore.TestOption) (*testcore.TestEnv, *testvars.TestVars) {
+func (s *WorkflowAliasSearchAttributeTestSuite) newTestEnv(opts ...testcore.TestOption) *testcore.TestEnv {
 	opts = append([]testcore.TestOption{
 		testcore.WithWorkerService("worker-deployment version workflows must run for versioned-poller membership checks"),
+
+		// Keep deployment versions short because worker-deployment system workflow IDs must fit into 255 characters.
+		testcore.WithTestVars(func(tv *testvars.TestVars) *testvars.TestVars {
+			return tv.WithDeploymentSeries("alias-sa").WithBuildID("v1")
+		}),
 	}, opts...)
 
 	env := testcore.NewEnv(s.T(), opts...)
 	env.SdkWorker().RegisterWorkflow(s.workflowFunc)
-	// Keep the deployment version short because its system workflow ID must fit into 255 characters.
-	tv := env.Tv().WithDeploymentSeries("alias-sa").WithBuildID("v1")
-	return env, tv
+	return env
 }
 
 func (s *WorkflowAliasSearchAttributeTestSuite) workflowFunc(ctx workflow.Context) (string, error) {
@@ -125,9 +128,9 @@ func (s *WorkflowAliasSearchAttributeTestSuite) terminateWorkflow(
 }
 
 func (s *WorkflowAliasSearchAttributeTestSuite) TestWorkflowAliasSearchAttribute() {
-	env, tv := s.newTestEnv()
+	env := s.newTestEnv()
 
-	_, err := s.createWorkflow(env, tv, nil)
+	_, err := s.createWorkflow(env, env.Tv(), nil)
 	s.NoError(err)
 
 	s.EventuallyWithT(
@@ -166,7 +169,7 @@ func (s *WorkflowAliasSearchAttributeTestSuite) TestWorkflowAliasSearchAttribute
 }
 
 func (s *WorkflowAliasSearchAttributeTestSuite) TestWorkflowAliasSearchAttribute_CustomSearchAttributeOverride() {
-	env, tv := s.newTestEnv()
+	env := s.newTestEnv()
 
 	_, err := env.SdkClient().OperatorService().AddSearchAttributes(s.Context(), &operatorservice.AddSearchAttributesRequest{
 		Namespace: env.Namespace().String(),
@@ -182,7 +185,7 @@ func (s *WorkflowAliasSearchAttributeTestSuite) TestWorkflowAliasSearchAttribute
 		},
 	}
 
-	_, err = s.createWorkflow(env, tv, sa)
+	_, err = s.createWorkflow(env, env.Tv(), sa)
 	s.NoError(err)
 
 	s.EventuallyWithT(


### PR DESCRIPTION
## What changed?

Add SQLite DDL rewriting for `CREATE TABLE` statements so `VARCHAR(n)` columns get generated `CHECK(length(column) <= n)` constraints.

## Why?

SQLite treats `VARCHAR(n)` as text affinity and ignores the length. That lets SQLite functional tests pass with values that fail on Postgres `varchar(n)` columns. This leads to extra work after only noticing the issue on CI.

## Risk

Intentionally focusing on only sqlite use in tests; excluding CLI use cases.

Also intentionally not changing the sqlite schema for that reason, as it could have unintended consequences outside of testing.