### PR TITLE
shorten deployment IDs in TestPinnedCaN_ResetByBuildIDAfterRollback

### DIFF
--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -6060,7 +6060,9 @@ func (s *Versioning3Suite) TestPinnedCaN_FailedTransientNotificationRefiresDespi
 func (s *Versioning3Suite) TestPinnedCaN_ResetByBuildIDAfterRollback() {
 	env := s.setupEnv(testcore.WithWorkerService("batch operations"))
 
-	tv1 := env.Tv().WithBuildIDNumber(1)
+	// Keep the deployment version short because its system workflow ID must fit into 255 characters.
+	tv := env.Tv().WithDeploymentSeries("rollback-reset").WithBuildID("v")
+	tv1 := tv.WithBuildIDNumber(1)
 	tv2 := tv1.WithBuildIDNumber(2)
 
 	revision := int64(1)


### PR DESCRIPTION
## What changed?
Overrides deployment series and build ID with short strings via `WithDeploymentSeries` / `WithBuildID`

## Why?
 Default values embed the full ~88-char test name, which after base64-encoding into the versioned `task_queue_id` exceeded MySQL's `VARBINARY(272)` cap. 

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

