### PR TITLE
Cherry-pick: Close stale gRPC connections in downstream client caches (#10250)

### DIFF
--- a/chasm/lib/activity/gen/activitypb/v1/service_client.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/service_client.pb.go
@@ -39,7 +39,7 @@ func NewActivityServiceLayeredClient(
 	if err != nil {
 		return nil, err
 	}
-	connections := history.NewConnectionPool(resolver, rpcFactory, NewActivityServiceClient)
+	connections := history.NewConnectionPool(resolver, rpcFactory, NewActivityServiceClient, logger, dynamicconfig.HistoryConnectionCloseDelay.Get(dc))
 	var redirector history.Redirector[ActivityServiceClient]
 	if dynamicconfig.HistoryClientOwnershipCachingEnabled.Get(dc)() {
 		redirector = history.NewCachingRedirector(

--- a/chasm/lib/scheduler/gen/schedulerpb/v1/service_client.pb.go
+++ b/chasm/lib/scheduler/gen/schedulerpb/v1/service_client.pb.go
@@ -39,7 +39,7 @@ func NewSchedulerServiceLayeredClient(
 	if err != nil {
 		return nil, err
 	}
-	connections := history.NewConnectionPool(resolver, rpcFactory, NewSchedulerServiceClient)
+	connections := history.NewConnectionPool(resolver, rpcFactory, NewSchedulerServiceClient, logger, dynamicconfig.HistoryConnectionCloseDelay.Get(dc))
 	var redirector history.Redirector[SchedulerServiceClient]
 	if dynamicconfig.HistoryClientOwnershipCachingEnabled.Get(dc)() {
 		redirector = history.NewCachingRedirector(

--- a/chasm/lib/tests/gen/testspb/v1/service_client.pb.go
+++ b/chasm/lib/tests/gen/testspb/v1/service_client.pb.go
@@ -40,7 +40,7 @@ func NewTestServiceLayeredClient(
 	if err != nil {
 		return nil, err
 	}
-	connections := history.NewConnectionPool(resolver, rpcFactory, NewTestServiceClient)
+	connections := history.NewConnectionPool(resolver, rpcFactory, NewTestServiceClient, logger, dynamicconfig.HistoryConnectionCloseDelay.Get(dc))
 	var redirector history.Redirector[TestServiceClient]
 	if dynamicconfig.HistoryClientOwnershipCachingEnabled.Get(dc)() {
 		redirector = history.NewCachingRedirector(

--- a/client/clientfactory.go
+++ b/client/clientfactory.go
@@ -129,18 +129,20 @@ func (cf *rpcClientFactory) NewMatchingClientWithTimeout(
 	}
 
 	keyResolver := newServiceKeyResolver(resolver)
-	clientProvider := func(clientKey string) (any, error) {
+	clientProvider := func(clientKey string) (any, func() error, error) {
 		connection := cf.rpcFactory.CreateMatchingGRPCConnection(clientKey)
-		return matchingservice.NewMatchingServiceClient(connection), nil
+		return matchingservice.NewMatchingServiceClient(connection), connection.Close, nil
 	}
 	client := matching.NewClient(
 		timeout,
 		longPollTimeout,
-		common.NewClientCache(keyResolver, clientProvider),
+		common.NewClientCache(keyResolver, clientProvider, cf.logger),
 		cf.metricsHandler,
 		cf.logger,
 		matching.NewLoadBalancer(namespaceIDToName, cf.dynConfig, cf.testHooks),
 		dynamicconfig.MatchingSpreadRoutingBatchSize.Get(cf.dynConfig),
+		resolver,
+		dynamicconfig.MatchingConnectionCloseDelay.Get(cf.dynConfig),
 	)
 
 	if cf.metricsHandler != nil {

--- a/client/history/client.go
+++ b/client/history/client.go
@@ -51,7 +51,7 @@ func NewClient(
 	rpcFactory RPCFactory,
 	timeout time.Duration,
 ) historyservice.HistoryServiceClient {
-	connections := NewConnectionPool(historyServiceResolver, rpcFactory, historyservice.NewHistoryServiceClient)
+	connections := NewConnectionPool(historyServiceResolver, rpcFactory, historyservice.NewHistoryServiceClient, logger, dynamicconfig.HistoryConnectionCloseDelay.Get(dc))
 
 	var redirector Redirector[historyservice.HistoryServiceClient]
 	if dynamicconfig.HistoryClientOwnershipCachingEnabled.Get(dc)() {

--- a/client/history/client_test.go
+++ b/client/history/client_test.go
@@ -33,6 +33,9 @@ func TestErrLookup(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	serviceResolver := membership.NewMockServiceResolver(ctrl)
 	serviceResolver.EXPECT().Lookup(gomock.Any()).Return(nil, membership.ErrInsufficientHosts).AnyTimes()
+	serviceResolver.EXPECT().AddListener(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	serviceResolver.EXPECT().RemoveListener(gomock.Any()).Return(nil).AnyTimes()
+	serviceResolver.EXPECT().Members().Return(nil).AnyTimes()
 	client := history.NewClient(
 		dynamicconfig.NewNoopCollection(),
 		serviceResolver,
@@ -104,6 +107,9 @@ func TestShardAgnosticConnectionStrategy(t *testing.T) {
 			serviceResolver.EXPECT().Lookup(gomock.Any()).Return(membership.NewHostInfoFromAddress("localhost"), nil)
 			serviceResolver.EXPECT().Lookup(gomock.Any()).Return(membership.NewHostInfoFromAddress("127.0.0.1"), nil)
 			serviceResolver.EXPECT().Lookup(gomock.Any()).Return(membership.NewHostInfoFromAddress("localhost"), nil)
+			serviceResolver.EXPECT().AddListener(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			serviceResolver.EXPECT().RemoveListener(gomock.Any()).Return(nil).AnyTimes()
+			serviceResolver.EXPECT().Members().Return(nil).AnyTimes()
 
 			// Create an in-memory gRPC server.
 			listener := nettest.NewListener(nettest.NewPipe())

--- a/client/history/connections.go
+++ b/client/history/connections.go
@@ -1,11 +1,20 @@
 package history
 
 import (
+	"context"
+	"fmt"
+	"runtime"
 	"sync"
+	"time"
 
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/membership"
 	"google.golang.org/grpc"
 )
+
+const evictionCheckInterval = 30 * time.Second
 
 type (
 	clientConnection[C any] struct {
@@ -16,14 +25,11 @@ type (
 	rpcAddress string
 
 	connectionPoolImpl[C any] struct {
-		mu struct {
-			sync.RWMutex
-			conns map[rpcAddress]clientConnection[C]
-		}
-
+		conns                  *sync.Map // rpcAddress -> clientConnection[C]
 		historyServiceResolver membership.ServiceResolver
 		rpcFactory             RPCFactory
 		clientCtor             func(grpc.ClientConnInterface) C
+		logger                 log.Logger
 	}
 
 	// RPCFactory is a subset of the [go.temporal.io/server/common/rpc.RPCFactory] interface to make testing easier.
@@ -42,37 +48,109 @@ func NewConnectionPool[C any](
 	historyServiceResolver membership.ServiceResolver,
 	rpcFactory RPCFactory,
 	clientCtor func(grpc.ClientConnInterface) C,
+	logger log.Logger,
+	connectionCloseDelay dynamicconfig.DurationPropertyFn,
 ) *connectionPoolImpl[C] {
+	conns := &sync.Map{}
+
 	c := &connectionPoolImpl[C]{
+		conns:                  conns,
 		historyServiceResolver: historyServiceResolver,
 		rpcFactory:             rpcFactory,
 		clientCtor:             clientCtor,
+		logger:                 logger,
 	}
-	c.mu.conns = make(map[rpcAddress]clientConnection[C])
+
+	// Close cached conns whose host leaves the membership ring.
+	ctx, cancel := context.WithCancel(context.Background())
+	go watchMembershipForClose[C](ctx, historyServiceResolver, logger, conns, connectionCloseDelay)
+	runtime.AddCleanup(c, func(cancel context.CancelFunc) { cancel() }, cancel)
 	return c
 }
 
+func watchMembershipForClose[C any](
+	ctx context.Context,
+	resolver membership.ServiceResolver,
+	logger log.Logger,
+	conns *sync.Map,
+	connectionCloseDelay dynamicconfig.DurationPropertyFn,
+) {
+	listenerName := fmt.Sprintf("%p", conns)
+	ch := make(chan *membership.ChangedEvent, 1)
+	if err := resolver.AddListener(listenerName, ch); err != nil {
+		logger.Error("Failed to subscribe history connection pool to membership", tag.Error(err))
+		return
+	}
+	defer func() { _ = resolver.RemoveListener(listenerName) }()
+
+	// Reap departed hosts via a per-address deadline checked by a single ticker;
+	// a re-add resets it to the latest removal.
+	evictAt := make(map[rpcAddress]time.Time)
+	ticker := time.NewTicker(evictionCheckInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event := <-ch:
+			for _, h := range event.HostsRemoved {
+				evictAt[rpcAddress(h.GetAddress())] = time.Now().Add(connectionCloseDelay())
+			}
+			for _, h := range event.HostsAdded {
+				delete(evictAt, rpcAddress(h.GetAddress()))
+			}
+		case <-ticker.C:
+			reapClosableConns[C](resolver, logger, conns, evictAt)
+		}
+	}
+}
+
+func reapClosableConns[C any](
+	resolver membership.ServiceResolver,
+	logger log.Logger,
+	conns *sync.Map,
+	evictAt map[rpcAddress]time.Time,
+) {
+	if len(evictAt) == 0 {
+		return
+	}
+	members := make(map[rpcAddress]struct{})
+	for _, m := range resolver.Members() {
+		members[rpcAddress(m.GetAddress())] = struct{}{}
+	}
+	now := time.Now()
+	for addr, deadline := range evictAt {
+		if _, ok := members[addr]; ok {
+			delete(evictAt, addr) // back in the ring; cancel the eviction
+			continue
+		}
+		if now.Before(deadline) {
+			continue
+		}
+		if v, ok := conns.LoadAndDelete(addr); ok {
+			if err := v.(clientConnection[C]).grpcConn.Close(); err != nil {
+				logger.Warn("Error closing evicted gRPC connection", tag.Error(err))
+			}
+		}
+		delete(evictAt, addr)
+	}
+}
+
 func (c *connectionPoolImpl[C]) getOrCreateClientConn(addr rpcAddress) clientConnection[C] {
-	c.mu.RLock()
-	cc, ok := c.mu.conns[addr]
-	c.mu.RUnlock()
-	if ok {
-		return cc
+	if v, ok := c.conns.Load(addr); ok {
+		return v.(clientConnection[C]) // nolint:revive // unchecked-type-assertion
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if cc, ok = c.mu.conns[addr]; ok {
-		return cc
-	}
 	grpcConn := c.rpcFactory.CreateHistoryGRPCConnection(string(addr))
-	cc = clientConnection[C]{
+	cc := clientConnection[C]{
 		grpcClient: c.clientCtor(grpcConn),
 		grpcConn:   grpcConn,
 	}
 
-	c.mu.conns[addr] = cc
+	if actual, loaded := c.conns.LoadOrStore(addr, cc); loaded {
+		_ = grpcConn.Close()
+		return actual.(clientConnection[C]) // nolint:revive // unchecked-type-assertion
+	}
 	return cc
 }
 

--- a/client/history/historytest/clienttest.go
+++ b/client/history/historytest/clienttest.go
@@ -157,6 +157,8 @@ func createClient(ctrl *gomock.Controller, listener *nettest.PipeListener) histo
 		address,
 	}).AnyTimes()
 	serviceResolver.EXPECT().Lookup(gomock.Any()).Return(address, nil).AnyTimes()
+	serviceResolver.EXPECT().AddListener(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	serviceResolver.EXPECT().RemoveListener(gomock.Any()).Return(nil).AnyTimes()
 	rpcFactory := nettest.NewRPCFactory(listener)
 	client := history.NewClient(
 		dynamicconfig.NewNoopCollection(),

--- a/client/matching/client.go
+++ b/client/matching/client.go
@@ -5,8 +5,11 @@ package matching
 
 import (
 	"context"
+	"fmt"
+	"runtime"
 	"time"
 
+	"github.com/google/uuid"
 	enumspb "go.temporal.io/api/enums/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
@@ -15,6 +18,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/membership"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/tqid"
 	"google.golang.org/grpc"
@@ -27,6 +31,8 @@ const (
 	DefaultTimeout = time.Minute * debug.TimeoutMultiplier
 	// DefaultLongPollTimeout is the max timeout for long poll calls
 	DefaultLongPollTimeout = time.Minute * 5 * debug.TimeoutMultiplier
+	// evictionCheckInterval is how often departed hosts are reaped from the cache.
+	evictionCheckInterval = 30 * time.Second
 )
 
 type clientImpl struct {
@@ -48,8 +54,10 @@ func NewClient(
 	logger log.Logger,
 	lb LoadBalancer,
 	spreadRouting dynamicconfig.TypedPropertyFn[dynamicconfig.GradualChange[int]],
+	resolver membership.ServiceResolver,
+	connectionCloseDelay dynamicconfig.DurationPropertyFn,
 ) matchingservice.MatchingServiceClient {
-	return &clientImpl{
+	c := &clientImpl{
 		timeout:         timeout,
 		longPollTimeout: longPollTimeout,
 		clients:         clients,
@@ -57,6 +65,76 @@ func NewClient(
 		logger:          logger,
 		loadBalancer:    lb,
 		spreadRouting:   spreadRouting,
+	}
+
+	// Evict cached clients whose host leaves the membership ring.
+	ctx, cancel := context.WithCancel(context.Background())
+	go watchMembershipForEviction(ctx, resolver, clients, connectionCloseDelay, logger)
+	runtime.AddCleanup(c, func(cancel context.CancelFunc) { cancel() }, cancel)
+
+	return c
+}
+
+func watchMembershipForEviction(
+	ctx context.Context,
+	resolver membership.ServiceResolver,
+	clients common.ClientCache,
+	connectionCloseDelay dynamicconfig.DurationPropertyFn,
+	logger log.Logger,
+) {
+	listenerName := fmt.Sprintf("matchingClientCache-%s", uuid.New().String())
+	ch := make(chan *membership.ChangedEvent, 1)
+	if err := resolver.AddListener(listenerName, ch); err != nil {
+		logger.Error("Failed to subscribe matching cache to membership", tag.Error(err))
+		return
+	}
+	defer func() { _ = resolver.RemoveListener(listenerName) }()
+
+	// Reap departed hosts via a per-address deadline checked by a single ticker;
+	// a re-add resets it to the latest removal.
+	evictAt := make(map[string]time.Time)
+	ticker := time.NewTicker(evictionCheckInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event := <-ch:
+			for _, h := range event.HostsRemoved {
+				evictAt[h.GetAddress()] = time.Now().Add(connectionCloseDelay())
+			}
+			for _, h := range event.HostsAdded {
+				delete(evictAt, h.GetAddress())
+			}
+		case <-ticker.C:
+			reapEvictableClients(resolver, clients, evictAt)
+		}
+	}
+}
+
+func reapEvictableClients(
+	resolver membership.ServiceResolver,
+	clients common.ClientCache,
+	evictAt map[string]time.Time,
+) {
+	if len(evictAt) == 0 {
+		return
+	}
+	members := make(map[string]struct{})
+	for _, m := range resolver.Members() {
+		members[m.GetAddress()] = struct{}{}
+	}
+	now := time.Now()
+	for addr, deadline := range evictAt {
+		if _, ok := members[addr]; ok {
+			delete(evictAt, addr) // back in the ring; cancel the eviction
+			continue
+		}
+		if now.Before(deadline) {
+			continue
+		}
+		clients.Evict(addr)
+		delete(evictAt, addr)
 	}
 }
 

--- a/cmd/tools/protoc-gen-go-chasm/main.go
+++ b/cmd/tools/protoc-gen-go-chasm/main.go
@@ -209,7 +209,7 @@ func (p *Plugin) genClient(w *writer, svc *protogen.Service) error {
 	w.println("return nil, err")
 	w.unindent()
 	w.println("}")
-	w.println("connections := history.NewConnectionPool(resolver, rpcFactory, New%sClient)", svc.GoName)
+	w.println("connections := history.NewConnectionPool(resolver, rpcFactory, New%sClient, logger, dynamicconfig.HistoryConnectionCloseDelay.Get(dc))", svc.GoName)
 	w.println("var redirector history.Redirector[%sClient]", svc.GoName)
 	w.println("if dynamicconfig.HistoryClientOwnershipCachingEnabled.Get(dc)() {")
 	w.indent() // start if

--- a/common/client_cache.go
+++ b/common/client_cache.go
@@ -2,6 +2,9 @@ package common
 
 import (
 	"sync"
+
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
 )
 
 type (
@@ -11,6 +14,9 @@ type (
 		GetClientForKey(key string, index int) (any, error)
 		GetClientForClientKey(clientKey string) (any, error)
 		GetAllClients() ([]any, error)
+		// Evict removes the cached entry for the given key and runs its
+		// release fn.
+		Evict(clientKey string)
 	}
 
 	keyResolver interface {
@@ -18,14 +24,22 @@ type (
 		GetAllAddresses() ([]string, error)
 	}
 
-	clientProvider func(string) (any, error)
+	// The returned release fn (if non-nil) is invoked when the entry is evicted.
+	clientProvider func(clientKey string) (any, func() error, error)
+
+	cachedEntry struct {
+		client  any
+		release func() error
+	}
 
 	clientCacheImpl struct {
 		keyResolver    keyResolver
 		clientProvider clientProvider
 
 		cacheLock sync.RWMutex
-		clients   map[string]any
+		clients   map[string]cachedEntry
+
+		logger log.Logger
 	}
 )
 
@@ -33,13 +47,15 @@ type (
 func NewClientCache(
 	keyResolver keyResolver,
 	clientProvider clientProvider,
+	logger log.Logger,
 ) ClientCache {
 
 	return &clientCacheImpl{
 		keyResolver:    keyResolver,
 		clientProvider: clientProvider,
 
-		clients: make(map[string]any),
+		clients: make(map[string]cachedEntry),
+		logger:  logger,
 	}
 }
 
@@ -57,25 +73,25 @@ func (c *clientCacheImpl) GetClientForKey(key string, index int) (any, error) {
 
 func (c *clientCacheImpl) GetClientForClientKey(clientKey string) (any, error) {
 	c.cacheLock.RLock()
-	client, ok := c.clients[clientKey]
+	entry, ok := c.clients[clientKey]
 	c.cacheLock.RUnlock()
 	if ok {
-		return client, nil
+		return entry.client, nil
 	}
 
 	c.cacheLock.Lock()
 	defer c.cacheLock.Unlock()
 
-	client, ok = c.clients[clientKey]
+	entry, ok = c.clients[clientKey]
 	if ok {
-		return client, nil
+		return entry.client, nil
 	}
 
-	client, err := c.clientProvider(clientKey)
+	client, release, err := c.clientProvider(clientKey)
 	if err != nil {
 		return nil, err
 	}
-	c.clients[clientKey] = client
+	c.clients[clientKey] = cachedEntry{client: client, release: release}
 	return client, nil
 }
 
@@ -94,4 +110,19 @@ func (c *clientCacheImpl) GetAllClients() ([]any, error) {
 	}
 
 	return result, nil
+}
+
+func (c *clientCacheImpl) Evict(clientKey string) {
+	c.cacheLock.Lock()
+	entry, ok := c.clients[clientKey]
+	if ok {
+		delete(c.clients, clientKey)
+	}
+	c.cacheLock.Unlock()
+
+	if ok && entry.release != nil {
+		if err := entry.release(); err != nil {
+			c.logger.Warn("Error releasing evicted client resource", tag.Error(err))
+		}
+	}
 }

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1514,6 +1514,12 @@ to remove expired entries. Should be shorter than EntryTTL for timely cleanup. L
 Don't change this on a live cluster without using the gradual change mechanism.
 `,
 	)
+	MatchingConnectionCloseDelay = NewGlobalDurationSetting(
+		"matching.connectionCloseDelay",
+		30*time.Second,
+		`MatchingConnectionCloseDelay delays closing a cached matching client connection after its host
+leaves the membership ring, giving in-flight long-polls time to drain before the connection is closed.`,
+	)
 
 	// keys for history
 
@@ -1728,6 +1734,12 @@ to this require a restart to take effect.`,
 		30*time.Second,
 		`HistoryClientOwnershipCachingStaleTTL, if non-zero, configures the TTL
 for cached shard ownership entries after a membership update.`,
+	)
+	HistoryConnectionCloseDelay = NewGlobalDurationSetting(
+		"history.connectionCloseDelay",
+		30*time.Second,
+		`HistoryConnectionCloseDelay delays closing a cached history connection after its host leaves
+the membership ring, giving in-flight RPCs time to drain before the connection is closed.`,
 	)
 	ShardIOConcurrency = NewGlobalIntSetting(
 		"history.shardIOConcurrency",


### PR DESCRIPTION
## What changed?

Backport of #10250: both downstream client caches now close a cached `*grpc.ClientConn` when its host leaves the membership ring (after a configurable drain delay, default 30s) instead of holding it until gRPC's idle timeout.

### Original PRs

#10250

## Why is this necessary as a patch?

Without it, the history/matching client caches hold `*grpc.ClientConn`s to departed hosts until gRPC's idle timeout, producing the dial-timeout log spam (#8719) that #9277 pushed down to this layer. Fixing it on the release branch stops that noise for v1.31.x patch users.

## Testing

Covered by existing `client/matching` and `client/history` unit tests.