### PR TITLE
fix: write callback request ID to mutable state for CaN (#10605)

### DIFF
--- a/chasm/lib/callback/invocable_internal.go
+++ b/chasm/lib/callback/invocable_internal.go
@@ -2,7 +2,6 @@ package callback
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -63,25 +62,28 @@ func (c invocableInternal) Invoke(
 		header = nexus.Header{}
 	}
 
-	// Get back the base64-encoded ComponentRef from the header.
-	encodedRef := header.Get(commonnexus.CallbackTokenHeader)
-	if encodedRef == "" {
+	// Get back the component ref and (optional) request ID from the callback token in the header.
+	encodedToken := header.Get(commonnexus.CallbackTokenHeader)
+	if encodedToken == "" {
 		return invocationResultFail{logInternalError(h.logger, "callback missing token", nil)}
 	}
 
-	decodedRef, err := base64.RawURLEncoding.DecodeString(encodedRef)
+	decodedRef, requestID, err := chasm.UnpackNexusCallbackToken(encodedToken)
 	if err != nil {
-		return invocationResultFail{logInternalError(h.logger, "failed to decode CHASM ComponentRef", err)}
+		return invocationResultFail{logInternalError(h.logger, "failed to decode CHASM callback token", err)}
+	}
+	// Older tokens don't carry a request ID; fall back to the one on the callback state machine.
+	if requestID == "" {
+		requestID = c.requestID
 	}
 
 	// Validate that the bytes are a valid ChasmComponentRef
 	ref := &persistencespb.ChasmComponentRef{}
-	err = proto.Unmarshal(decodedRef, ref)
-	if err != nil {
+	if err := proto.Unmarshal(decodedRef, ref); err != nil {
 		return invocationResultFail{logInternalError(h.logger, "failed to unmarshal CHASM ComponentRef", err)}
 	}
 
-	request, err := c.getHistoryRequest(decodedRef)
+	request, err := c.getHistoryRequest(decodedRef, requestID)
 	if err != nil {
 		return invocationResultFail{logInternalError(h.logger, "failed to build history request", err)}
 	}
@@ -128,12 +130,13 @@ func isRetryableRPCResponse(err error) bool {
 
 func (c invocableInternal) getHistoryRequest(
 	refBytes []byte,
+	requestID string,
 ) (*historyservice.CompleteNexusOperationChasmRequest, error) {
 	var req *historyservice.CompleteNexusOperationChasmRequest
 
 	completion := &tokenspb.NexusOperationCompletion{
 		ComponentRef: refBytes,
-		RequestId:    c.requestID,
+		RequestId:    requestID,
 	}
 
 	if c.completion.Error == nil {

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -137,7 +137,7 @@ func (h *InvokerExecuteTaskHandler) Execute(
 	var invoker *Invoker
 	var scheduler *Scheduler
 	var lastCompletionState *schedulerpb.LastCompletionResult
-	var callback *commonpb.Callback
+	var schedulerRef []byte
 
 	// Read and deep copy returned components, since we'll continue to access them
 	// outside of this function (outside of the MS lock).
@@ -159,12 +159,13 @@ func (h *InvokerExecuteTaskHandler) Execute(
 			lcs := s.LastCompletionResult.Get(ctx)
 			lastCompletionState = common.CloneProto(lcs)
 
-			// Set up the completion callback to handle workflow results.
-			cb, err := chasm.GenerateNexusCallback(ctx, s)
+			// Capture the scheduler's component ref so a per-start completion callback (carrying that
+			// start's request ID in its token) can be built outside the MS lock.
+			ref, err := ctx.Ref(s)
 			if err != nil {
 				return struct{}{}, err
 			}
-			callback = common.CloneProto(cb)
+			schedulerRef = ref
 
 			return struct{}{}, nil
 		},
@@ -186,7 +187,7 @@ func (h *InvokerExecuteTaskHandler) Execute(
 	ictx := h.newInvokerTaskHandlerContext(ctx, scheduler)
 	result = result.Append(h.terminateWorkflows(ictx, logger, metricsHandler, scheduler, invoker.GetTerminateWorkflows()))
 	result = result.Append(h.cancelWorkflows(ictx, logger, metricsHandler, scheduler, invoker.GetCancelWorkflows()))
-	sres, startResults := h.startWorkflows(ictx, logger, metricsHandler, scheduler, invoker, lastCompletionState, callback)
+	sres, startResults := h.startWorkflows(ictx, logger, metricsHandler, scheduler, invoker, lastCompletionState, schedulerRef)
 	result = result.Append(sres)
 
 	// Record action results on the Invoker (internal state), as well as the
@@ -305,7 +306,7 @@ func (h *InvokerExecuteTaskHandler) startWorkflows(
 	scheduler *Scheduler,
 	invoker *Invoker,
 	lastCompletionState *schedulerpb.LastCompletionResult,
-	callback *commonpb.Callback,
+	schedulerRef []byte,
 ) (result executeResult, startResults []*schedulepb.ScheduleActionResult) {
 	metricsWithTag := metricsHandler.WithTags(
 		metrics.StringTag(metrics.ScheduleActionTypeTag, metrics.ScheduleActionStartWorkflow))
@@ -335,7 +336,7 @@ func (h *InvokerExecuteTaskHandler) startWorkflows(
 		// Run all starts concurrently.
 		newCtx := ctx.Clone()
 		wg.Go(func() {
-			startResult, err := h.startWorkflow(newCtx, metricsHandler, scheduler, start, lastCompletionState, callback)
+			startResult, err := h.startWorkflow(newCtx, metricsHandler, scheduler, start, lastCompletionState, schedulerRef)
 
 			resultMutex.Lock()
 			defer resultMutex.Unlock()
@@ -535,7 +536,7 @@ func (h *InvokerExecuteTaskHandler) startWorkflow(
 	scheduler *Scheduler,
 	start *schedulespb.BufferedStart,
 	lastCompletionState *schedulerpb.LastCompletionResult,
-	callback *commonpb.Callback,
+	schedulerRef []byte,
 ) (*schedulepb.ScheduleActionResult, error) {
 	requestSpec := scheduler.GetSchedule().GetAction().GetStartWorkflow()
 
@@ -562,6 +563,14 @@ func (h *InvokerExecuteTaskHandler) startWorkflow(
 	var lcr []*commonpb.Payload
 	if lastCompletionState.Success != nil {
 		lcr = append(lcr, lastCompletionState.Success)
+	}
+	// Build the completion callback with this start's request ID packed into its token, so the
+	// completion is matched by a request ID that rides in the callback header and survives
+	// continue-as-new, rather than the started workflow's callback state which is re-stamped on each
+	// new run.
+	callback, err := chasm.GenerateNexusCallback(schedulerRef, start.RequestId)
+	if err != nil {
+		return nil, err
 	}
 	request := &workflowservice.StartWorkflowExecutionRequest{
 		CompletionCallbacks:      []*commonpb.Callback{callback},

--- a/chasm/lib/scheduler/scheduler_tasks.go
+++ b/chasm/lib/scheduler/scheduler_tasks.go
@@ -112,9 +112,9 @@ func (r *SchedulerCallbacksTaskHandler) Execute(
 ) error {
 	var scheduler *Scheduler
 	var starts []*schedulespb.BufferedStart
-	var callback *commonpb.Callback
+	var componentRef []byte
 
-	// Read scheduler state and generate the Nexus callback token.
+	// Read scheduler state and capture the scheduler's component ref.
 	_, err := chasm.ReadComponent(
 		ctx,
 		schedulerRef,
@@ -130,11 +130,11 @@ func (r *SchedulerCallbacksTaskHandler) Execute(
 				}
 			}
 
-			cb, err := chasm.GenerateNexusCallback(ctx, s)
+			ref, err := ctx.Ref(s)
 			if err != nil {
 				return struct{}{}, err
 			}
-			callback = common.CloneProto(cb)
+			componentRef = ref
 
 			return struct{}{}, nil
 		},
@@ -147,7 +147,7 @@ func (r *SchedulerCallbacksTaskHandler) Execute(
 	// Attach callbacks and check workflow status.
 	results := make(map[string]*watchResult, len(starts))
 	for _, start := range starts {
-		result, err := r.watchRunningStart(ctx, scheduler, start, callback)
+		result, err := r.watchRunningStart(ctx, scheduler, start, componentRef)
 		if err != nil {
 			return err
 		}
@@ -194,7 +194,7 @@ func (r *SchedulerCallbacksTaskHandler) watchRunningStart(
 	ctx context.Context,
 	scheduler *Scheduler,
 	start *schedulespb.BufferedStart,
-	callback *commonpb.Callback,
+	schedulerRef []byte,
 ) (*watchResult, error) {
 	// Describe the workflow to ensure it exists and is still running.
 	descResp, err := r.historyClient.DescribeWorkflowExecution(ctx, &historyservice.DescribeWorkflowExecutionRequest{
@@ -238,6 +238,13 @@ func (r *SchedulerCallbacksTaskHandler) watchRunningStart(
 	// reuse policy prevents accidentally starting a new workflow if the original
 	// completes between the describe and this call.
 	requestSpec := scheduler.GetSchedule().GetAction().GetStartWorkflow()
+
+	// Pack this start's request ID into the callback token so completions are matched from the token
+	// (which survives continue-as-new) rather than the started workflow's callback state.
+	callback, err := chasm.GenerateNexusCallback(schedulerRef, start.RequestId)
+	if err != nil {
+		return nil, err
+	}
 
 	_, err = r.frontendClient.StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
 		Namespace:                scheduler.Namespace,

--- a/chasm/nexus_completion.go
+++ b/chasm/nexus_completion.go
@@ -5,43 +5,67 @@ import (
 
 	commonpb "go.temporal.io/api/common/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	tokenspb "go.temporal.io/server/api/token/v1"
+	"google.golang.org/protobuf/proto"
 )
 
 // NexusCompletionHandlerURL is the user-visible URL for Nexus->CHASM callbacks.
 const NexusCompletionHandlerURL = "temporal://internal"
+
+// nexusCallbackTokenHeader is the callback header key carrying the completion token.
+// NOTE: There's a constant defined for this in common/nexus but to avoid circular dependencies we
+// redefine it here. nexus.Header lookups are case-insensitive, so this matches the canonical key.
+const nexusCallbackTokenHeader = "temporal-callback-token"
 
 // NexusCompletionHandler is implemented by CHASM components that want to handle Nexus operation completion callbacks.
 type NexusCompletionHandler interface {
 	HandleNexusCompletion(ctx MutableContext, completion *persistencespb.ChasmNexusCompletion) error
 }
 
-// NexusCompletionHandlerComponent is a CHASM [Component] that also implements [NexusCompletionHandler].
-type NexusCompletionHandlerComponent interface {
-	Component
-	NexusCompletionHandler
-}
-
-// GenerateNexusCallback generates a Callback message indicating a CHASM component to receive Nexus operation completion
-// callbacks. Particularly useful for components that want to track a workflow start with StartWorkflowExecution.
-func GenerateNexusCallback(ctx Context, component NexusCompletionHandlerComponent) (*commonpb.Callback, error) {
-	ref, err := ctx.Ref(component)
+// GenerateNexusCallback builds a Nexus completion callback targeting the CHASM component identified by
+// serializedRef (obtained from Context.Ref). The request ID is packed into the callback token, so the
+// completion is matched by a request ID that rides in the callback header and survives
+// continue-as-new, rather than one read from mutable state.
+func GenerateNexusCallback(serializedRef []byte, requestID string) (*commonpb.Callback, error) {
+	token, err := packNexusCallbackToken(serializedRef, requestID)
 	if err != nil {
 		return nil, err
 	}
-
-	encodedRef := base64.RawURLEncoding.EncodeToString(ref)
-	headers := map[string]string{
-		// NOTE: There's a constant defined for this in common/nexus but to avoid circular dependencies we redefine it here.
-		// This is acceptable since we are going to eventually have a strongly typed field for passing tokens around.
-		"temporal-callback-token": encodedRef,
-	}
-
 	return &commonpb.Callback{
 		Variant: &commonpb.Callback_Nexus_{
 			Nexus: &commonpb.Callback_Nexus{
 				Url:    NexusCompletionHandlerURL,
-				Header: headers,
+				Header: map[string]string{nexusCallbackTokenHeader: token},
 			},
 		},
 	}, nil
+}
+
+// packNexusCallbackToken encodes a CHASM component ref and request ID into a callback token.
+func packNexusCallbackToken(componentRef []byte, requestID string) (string, error) {
+	b, err := proto.Marshal(&tokenspb.NexusOperationCompletion{
+		ComponentRef: componentRef,
+		RequestId:    requestID,
+	})
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// UnpackNexusCallbackToken decodes a callback token produced by GenerateNexusCallback, returning the
+// component ref and request ID. For backward compatibility it also accepts the legacy format where the
+// token is the bare base64-encoded ChasmComponentRef (in which case the request ID is empty).
+func UnpackNexusCallbackToken(encoded string) (componentRef []byte, requestID string, err error) {
+	raw, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, "", err
+	}
+	completion := &tokenspb.NexusOperationCompletion{}
+	if proto.Unmarshal(raw, completion) == nil && len(completion.GetComponentRef()) > 0 &&
+		proto.Unmarshal(completion.GetComponentRef(), &persistencespb.ChasmComponentRef{}) == nil {
+		return completion.GetComponentRef(), completion.GetRequestId(), nil
+	}
+	// Legacy format: the raw bytes are the ChasmComponentRef directly.
+	return raw, "", nil
 }

--- a/components/callbacks/chasm_invocation.go
+++ b/components/callbacks/chasm_invocation.go
@@ -2,7 +2,6 @@ package callbacks
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -11,6 +10,7 @@ import (
 	"go.temporal.io/server/api/historyservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
+	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/namespace"
@@ -42,23 +42,27 @@ func logInternalError(logger log.Logger, internalMsg string, internalErr error) 
 }
 
 func (c chasmInvocation) Invoke(ctx context.Context, ns *namespace.Namespace, e taskExecutor, task InvocationTask) invocationResult {
-	// Get back the base64-encoded ComponentRef from the header.
+	// Get back the component ref and (optional) request ID from the callback token in the header.
 	header := nexus.Header(c.nexus.GetHeader())
 	if header == nil {
 		header = nexus.Header{}
 	}
 
-	encodedRef := header.Get(commonnexus.CallbackTokenHeader)
-	if encodedRef == "" {
+	encodedToken := header.Get(commonnexus.CallbackTokenHeader)
+	if encodedToken == "" {
 		return invocationResultFail{logInternalError(e.Logger, "callback missing token", nil)}
 	}
 
-	decodedRef, err := base64.RawURLEncoding.DecodeString(encodedRef)
+	ref, requestID, err := chasm.UnpackNexusCallbackToken(encodedToken)
 	if err != nil {
-		return invocationResultFail{logInternalError(e.Logger, "failed to decode CHASM ComponentRef", err)}
+		return invocationResultFail{logInternalError(e.Logger, "failed to decode CHASM callback token", err)}
+	}
+	// Older tokens don't carry a request ID; fall back to the one on the callback state machine.
+	if requestID == "" {
+		requestID = c.requestID
 	}
 
-	request, err := c.getHistoryRequest(decodedRef)
+	request, err := c.getHistoryRequest(ref, requestID)
 	if err != nil {
 		return invocationResultFail{logInternalError(e.Logger, "failed to build history request: %v", err)}
 	}
@@ -78,12 +82,13 @@ func (c chasmInvocation) Invoke(ctx context.Context, ns *namespace.Namespace, e 
 
 func (c chasmInvocation) getHistoryRequest(
 	ref []byte,
+	requestID string,
 ) (*historyservice.CompleteNexusOperationChasmRequest, error) {
 	var req *historyservice.CompleteNexusOperationChasmRequest
 
 	completion := &tokenspb.NexusOperationCompletion{
 		ComponentRef: ref,
-		RequestId:    c.requestID,
+		RequestId:    requestID,
 	}
 
 	if c.completion.Error == nil {

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
 	schedulepb "go.temporal.io/api/schedule/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
@@ -25,6 +26,7 @@ import (
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 	schedulespb "go.temporal.io/server/api/schedule/v1"
+	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/callback"
 	chasmscheduler "go.temporal.io/server/chasm/lib/scheduler"
 	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
@@ -93,6 +95,7 @@ func TestScheduleCHASM(t *testing.T) {
 	t.Run("TestSingleDateScheduleCloses", func(t *testing.T) { testSingleDateScheduleCloses(t, newContext) })
 	t.Run("TestMultiDateScheduleCloses", func(t *testing.T) { testMultiDateScheduleCloses(t, newContext) })
 	t.Run("TestNextActionTimeVisibility", func(t *testing.T) { testScheduleNextActionTimeVisibility(t, newContext) })
+	t.Run("TestScheduledWorkflowContinueAsNewCompletion", func(t *testing.T) { testScheduledWorkflowContinueAsNewCompletion(t, newContext) })
 }
 
 func TestScheduleV1(t *testing.T) {
@@ -820,6 +823,127 @@ func testLastCompletionAndError(t *testing.T, newContext contextFactory) {
 	s.NoError(err)
 
 	s.Eventually(func() bool { return atomic.LoadInt32(&testComplete) == 1 }, 20*time.Second, 200*time.Millisecond)
+}
+
+// testScheduledWorkflowContinueAsNewCompletion validates that the CHASM scheduler observes the
+// completion of a scheduled workflow that continues-as-new before completing. The scheduler matches
+// completions by the request ID on the Nexus completion callback it attaches at start; if that ID is
+// lost across continue-as-new the completion is silently dropped, so with a buffering overlap policy
+// the scheduler believes the action is still running and never starts the buffered actions.
+//
+// It asserts the schedule records several COMPLETED actions (the buffer only drains as completions
+// are observed) and that the completion callback is written intact into both the original and the
+// continued-as-new run. CHASM-only: V1 uses no Nexus completion callbacks.
+func testScheduledWorkflowContinueAsNewCompletion(t *testing.T, newContext contextFactory) {
+	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+
+	sid := testcore.RandomizeStr("sched-can-completion")
+	wid := testcore.RandomizeStr("sched-can-completion-wf")
+	wt := testcore.RandomizeStr("sched-can-completion-wt")
+
+	// Continue-as-new once, then complete: the completion is delivered from the continued run,
+	// exercising completion-callback propagation across continue-as-new.
+	workflowFn := func(ctx workflow.Context) error {
+		if workflow.GetInfo(ctx).ContinuedExecutionRunID == "" {
+			return workflow.NewContinueAsNewError(ctx, wt)
+		}
+		return nil
+	}
+	s.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+
+	schedule := &schedulepb.Schedule{
+		Spec: &schedulepb.ScheduleSpec{
+			Interval: []*schedulepb.IntervalSpec{
+				{Interval: durationpb.New(1 * time.Second)},
+			},
+		},
+		// BUFFER_ALL gates each start on the previous action completing. If a completion is dropped
+		// because request ID is not carried over on continue-as-newthe scheduler believes the action
+		// is still running and the buffered actions never start, so only the first action ever completes.
+		Policies: &schedulepb.SchedulePolicies{
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL,
+		},
+		Action: &schedulepb.ScheduleAction{
+			Action: &schedulepb.ScheduleAction_StartWorkflow{
+				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+					WorkflowId:   wid,
+					WorkflowType: &commonpb.WorkflowType{Name: wt},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				},
+			},
+		},
+	}
+	req := &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Schedule:   schedule,
+		Identity:   "test",
+		RequestId:  uuid.NewString(),
+	}
+
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, req)
+	require.NoError(t, err)
+
+	// getCompletionCallback returns the Nexus completion callback the scheduler attached, found in the
+	// run's WorkflowExecutionStarted event.
+	getCompletionCallback := func(events []*historypb.HistoryEvent) *commonpb.Callback {
+		for _, e := range events {
+			for _, cb := range e.GetWorkflowExecutionStartedEventAttributes().GetCompletionCallbacks() {
+				if cb.GetNexus().GetUrl() == chasm.NexusCompletionHandlerURL {
+					return cb
+				}
+			}
+		}
+		return nil
+	}
+
+	// The scheduler only starts the next buffered action after observing the previous one complete,
+	// so it records multiple COMPLETED actions only if continue-as-new completions are delivered. With
+	// the bug it stalls after the first. (StartWorkflowStatus is set solely from the completion
+	// callback the scheduler records, not from visibility.)
+	const wantCompleted = 3
+	var completedWFID string
+	s.Eventually(func() bool {
+		desc, descErr := s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+		})
+		if descErr != nil {
+			return false
+		}
+		completed := 0
+		for _, a := range desc.GetInfo().GetRecentActions() {
+			if a.GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED {
+				completed++
+				completedWFID = a.GetStartWorkflowResult().GetWorkflowId()
+			}
+		}
+		return completed >= wantCompleted
+	}, 15*time.Second, 200*time.Millisecond,
+		"scheduler should record %d completed actions", wantCompleted)
+
+	// Verify the completion callback was written into both runs of a completed action: the
+	// continued-as-new run (latest) and the original run it continued from. The header (callback
+	// token) must be identical, confirming the callback was propagated intact across continue-as-new.
+	s.NotEmpty(completedWFID)
+	canHist := s.GetHistory(s.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: completedWFID})
+	canCB := getCompletionCallback(canHist)
+	s.NotNil(canCB, "continued-as-new run must carry the completion callback")
+
+	var continuedFromRunID string
+	for _, e := range canHist {
+		if a := e.GetWorkflowExecutionStartedEventAttributes(); a != nil {
+			continuedFromRunID = a.GetContinuedExecutionRunId()
+			break
+		}
+	}
+	s.NotEmpty(continuedFromRunID, "completed action should have continued-as-new")
+
+	origHist := s.GetHistory(s.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: completedWFID, RunId: continuedFromRunID})
+	origCB := getCompletionCallback(origHist)
+	s.NotNil(origCB, "original run must carry the completion callback")
+	s.Equal(origCB.GetNexus().GetHeader(), canCB.GetNexus().GetHeader(), "completion callback must be propagated intact across continue-as-new")
 }
 
 func testListSchedulesReturnsWorkflowStatus(t *testing.T, newContext contextFactory) {


### PR DESCRIPTION
`getCompletionCallbacksAsProtoSlice` now returns the callbacks' original request IDs alongside the `commonpb.Callback`, and the continue-as-new paths preserve them when re-registering the inherited callbacks on the new run.

When a workflow continues-as-new, its completion callbacks are propagated to the new run via the `WorkflowExecutionStarted` event's CompletionCallbacks. That public type has no request-ID field, so the request ID was dropped and the new run re-stamped each inherited callback with its own start request ID.

Completions that are validated by request ID then break. Concretely, when a CHASM scheduler-started workflow continues-as-new, the completion callback (`temporal://internal`) fires with the regenerated request ID; `Scheduler.HandleNexusCompletion` looks the action up by request ID via `Invoker.runningWorkflowID`, finds no match, and silently drops the completion — so the action and LastCompletionResult never propagates.

- [x] built
- [x] covered by existing tests
- [x] added new functional test(s)
- New functional test `TestScheduleCHASM/TestScheduledWorkflowContinueAsNewCompletion`: a scheduled workflow continues-as-new once then completes; asserts a later action observes a non-empty LastCompletionResult. Fails without thns dropped) and passes with it (~4s).
