### PR TITLE
Add DC to disable attaching callbacks to standalone activities

### DIFF
--- a/chasm/lib/activity/config.go
+++ b/chasm/lib/activity/config.go
@@ -33,12 +33,19 @@ var (
 		false,
 		`Allows non-zero start_delay on StartActivityExecution requests.`,
 	)
+
+	EnableCallbacks = dynamicconfig.NewNamespaceBoolSetting(
+		"activity.enableCallbacks",
+		false,
+		`Allows attaching completion callbacks to standalone activity executions.`,
+	)
 )
 
 type Config struct {
 	BlobSizeLimitError          dynamicconfig.IntPropertyFnWithNamespaceFilter
 	BlobSizeLimitWarn           dynamicconfig.IntPropertyFnWithNamespaceFilter
 	BreakdownMetricsByTaskQueue dynamicconfig.TypedPropertyFnWithTaskQueueFilter[bool]
+	EnableCallbacks             dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	Enabled                     dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	LongPollBuffer              dynamicconfig.DurationPropertyFnWithNamespaceFilter
 	LongPollTimeout             dynamicconfig.DurationPropertyFnWithNamespaceFilter
@@ -55,6 +62,7 @@ func ConfigProvider(dc *dynamicconfig.Collection) *Config {
 		BlobSizeLimitWarn:           dynamicconfig.BlobSizeLimitWarn.Get(dc),
 		BreakdownMetricsByTaskQueue: dynamicconfig.MetricsBreakdownByTaskQueue.Get(dc),
 		DefaultActivityRetryPolicy:  dynamicconfig.DefaultActivityRetryPolicy.Get(dc),
+		EnableCallbacks:             EnableCallbacks.Get(dc),
 		Enabled:                     Enabled.Get(dc),
 		LongPollBuffer:              LongPollBuffer.Get(dc),
 		LongPollTimeout:             LongPollTimeout.Get(dc),

--- a/chasm/lib/activity/frontend.go
+++ b/chasm/lib/activity/frontend.go
@@ -409,6 +409,9 @@ func (h *frontendHandler) validateAndPopulateStartRequest(
 	}
 
 	if cbs := req.GetCompletionCallbacks(); len(cbs) > 0 {
+		if !h.config.EnableCallbacks(req.GetNamespace()) {
+			return nil, serviceerror.NewInvalidArgument("completion callbacks are not enabled for this namespace")
+		}
 		if err := h.callbackValidator.Validate(ctx, req.GetNamespace(), cbs); err != nil {
 			return nil, err
 		}

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -110,6 +110,7 @@ func (s *standaloneActivityTestSuite) newTestEnv(opts ...testcore.TestOption) *s
 	cluster := env.GetTestCluster()
 	cluster.OverrideDynamicConfig(s.T(), dynamicconfig.EnableChasm, nsValues(true))
 	cluster.OverrideDynamicConfig(s.T(), activity.Enabled, nsValues(true))
+	cluster.OverrideDynamicConfig(s.T(), activity.EnableCallbacks, nsValues(true))
 	cluster.OverrideDynamicConfig(s.T(), activity.StartDelayEnabled, nsValues(true))
 	return env
 }
@@ -6844,5 +6845,52 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT, descResp.GetInfo().GetStatus())
+	})
+}
+
+func (s *standaloneActivityTestSuite) TestCallbacksDisabled() {
+	env := s.newTestEnv()
+	t := s.T()
+
+	// Override EnableCallbacks back to false to simulate a namespace where the feature is off.
+	nsValues := []dynamicconfig.ConstrainedValue{
+		{Constraints: dynamicconfig.Constraints{Namespace: env.Namespace().String()}, Value: false},
+	}
+	env.GetTestCluster().OverrideDynamicConfig(t, activity.EnableCallbacks, nsValues)
+
+	cb := []*commonpb.Callback{{
+		Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: "http://localhost/cb"}},
+	}}
+
+	t.Run("StartWithCallbacksFails", func(t *testing.T) {
+		_, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          testcore.RandomizeStr(t.Name()),
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
+			Input:               defaultInput,
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: testcore.RandomizeStr(t.Name())},
+			StartToCloseTimeout: durationpb.New(time.Minute),
+			RequestId:           env.Tv().Any().String(),
+			CompletionCallbacks: cb,
+		})
+		require.ErrorContains(t, err, "completion callbacks are not enabled for this namespace")
+	})
+
+	t.Run("OnConflictAttachCallbacksFails", func(t *testing.T) {
+		_, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          testcore.RandomizeStr(t.Name()),
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
+			Input:               defaultInput,
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: testcore.RandomizeStr(t.Name())},
+			StartToCloseTimeout: durationpb.New(time.Minute),
+			RequestId:           env.Tv().Any().String(),
+			CompletionCallbacks: cb,
+			IdConflictPolicy:    enumspb.ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING,
+			OnConflictOptions:   &commonpb.OnConflictOptions{AttachCompletionCallbacks: true},
+		})
+		require.ErrorContains(t, err, "completion callbacks are not enabled for this namespace")
 	})
 }

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -471,6 +471,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncStandaloneActivityComple
 		{Constraints: dynamicconfig.Constraints{Namespace: env.Namespace().String()}, Value: true},
 	}
 	cluster.OverrideDynamicConfig(s.T(), activity.Enabled, nsValues)
+	cluster.OverrideDynamicConfig(s.T(), activity.EnableCallbacks, nsValues)
 	ctx := env.Context()
 
 	callerTQ := testcore.RandomizeStr(s.T().Name() + "-caller")


### PR DESCRIPTION
## What changed?

Add DC to disable attaching callbacks to standalone activities

## Why?

Talking with Product we want pre-release to be opt-in to follow proper procedure.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive namespace feature flag with default off; only affects standalone activity start validation when callbacks are present.
> 
> **Overview**
> Adds a **namespace-scoped dynamic config** `activity.enableCallbacks` (default **off**) so attaching **completion callbacks** to standalone activity starts is **opt-in** before release.
> 
> `StartActivityExecution` validation now rejects requests with `completion_callbacks` (including **on-conflict attach**) when the flag is false, with `completion callbacks are not enabled for this namespace`. Existing callback validation still runs when enabled.
> 
> Functional tests turn the flag **on** in the default suite setup and add **`TestCallbacksDisabled`** for start and on-conflict attach paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5758bcf18b90b2576b51168d6c79aa4c7996838. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->