### PR TITLE
WCP 4/X: Use correct batch ID in event load tokens

### DIFF
--- a/components/nexusoperations/events.go
+++ b/components/nexusoperations/events.go
@@ -21,7 +21,7 @@ func (d ScheduledEventDefinition) Type() enumspb.EventType {
 }
 
 func (d ScheduledEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
-	token, err := hsm.GenerateEventLoadToken(event)
+	token, err := root.GenerateEventLoadToken(event)
 	if err != nil {
 		return err
 	}

--- a/components/nexusoperations/helpers_test.go
+++ b/components/nexusoperations/helpers_test.go
@@ -55,7 +55,7 @@ func newRoot(t *testing.T, backend *hsmtest.NodeBackend) *hsm.Node {
 
 func newOperationNode(t *testing.T, backend *hsmtest.NodeBackend, event *historypb.HistoryEvent) *hsm.Node {
 	root := newRoot(t, backend)
-	token, err := hsm.GenerateEventLoadToken(event)
+	token, err := root.GenerateEventLoadToken(event)
 	require.NoError(t, err)
 	node, err := nexusoperations.AddChild(root, fmt.Sprintf("%d", event.EventId), event, token)
 	require.NoError(t, err)

--- a/components/nexusoperations/workflow/commands_test.go
+++ b/components/nexusoperations/workflow/commands_test.go
@@ -97,6 +97,7 @@ func newTestContext(t *testing.T, cfg *nexusoperations.Config) testContext {
 		history.Events = append(history.Events, e)
 		return e
 	}).AnyTimes()
+	ms.EXPECT().GenerateEventLoadToken(gomock.Any()).Return([]byte("token"), nil).AnyTimes()
 
 	execInfo := &persistencespb.WorkflowExecutionInfo{}
 	ms.EXPECT().GetNamespaceEntry().Return(tests.GlobalNamespaceEntry).AnyTimes()

--- a/service/history/historybuilder/event_store.go
+++ b/service/history/historybuilder/event_store.go
@@ -38,6 +38,12 @@ type EventStore struct {
 
 	maxEventBatchSizeInBytes dynamicconfig.IntPropertyFn
 
+	// latestEventBatchID is the first event ID of the latest batch an event was added
+	// to (live path), or the batch currently being applied (during replay via
+	// SetLatestEventBatchID). It is common.EmptyEventID until the first non-buffered event is
+	// added. Unlike memLatestBatch, it is not cleared on Flush.
+	latestEventBatchID int64
+
 	// scheduled to started event ID mapping
 	scheduledIDToStartedID map[int64]int64
 	// request id to event ID mapping
@@ -99,8 +105,21 @@ func (b *EventStore) add(
 		event.EventId = b.AllocateEventID()
 		b.appendToLatestBatch(event)
 		batchID = b.memLatestBatch[0].EventId
+		b.latestEventBatchID = batchID
 	}
 	return event, batchID
+}
+
+// LatestEventBatchID returns the first event ID of the latest batch an event was added to, or the
+// batch set via SetLatestEventBatchID during replay. See the latestEventBatchID field.
+func (b *EventStore) LatestEventBatchID() int64 {
+	return b.latestEventBatchID
+}
+
+// SetLatestEventBatchID overrides the latest event batch ID. Used by the rebuilder, which
+// applies events without going through add and must supply the batch ID.
+func (b *EventStore) SetLatestEventBatchID(batchID int64) {
+	b.latestEventBatchID = batchID
 }
 
 // appendToLatestBatch appends event to memLatestBatch, rolling into a new batch

--- a/service/history/historybuilder/event_store.go
+++ b/service/history/historybuilder/event_store.go
@@ -38,12 +38,6 @@ type EventStore struct {
 
 	maxEventBatchSizeInBytes dynamicconfig.IntPropertyFn
 
-	// latestEventBatchID is the first event ID of the latest batch an event was added
-	// to (live path), or the batch currently being applied (during replay via
-	// SetLatestEventBatchID). It is common.EmptyEventID until the first non-buffered event is
-	// added. Unlike memLatestBatch, it is not cleared on Flush.
-	latestEventBatchID int64
-
 	// scheduled to started event ID mapping
 	scheduledIDToStartedID map[int64]int64
 	// request id to event ID mapping
@@ -105,21 +99,17 @@ func (b *EventStore) add(
 		event.EventId = b.AllocateEventID()
 		b.appendToLatestBatch(event)
 		batchID = b.memLatestBatch[0].EventId
-		b.latestEventBatchID = batchID
 	}
 	return event, batchID
 }
 
-// LatestEventBatchID returns the first event ID of the latest batch an event was added to, or the
-// batch set via SetLatestEventBatchID during replay. See the latestEventBatchID field.
+// LatestEventBatchID returns the first event ID of the batch currently being built, or
+// common.EmptyEventID if the current batch is empty, e.g. after a Flush.
 func (b *EventStore) LatestEventBatchID() int64 {
-	return b.latestEventBatchID
-}
-
-// SetLatestEventBatchID overrides the latest event batch ID. Used by the rebuilder, which
-// applies events without going through add and must supply the batch ID.
-func (b *EventStore) SetLatestEventBatchID(batchID int64) {
-	b.latestEventBatchID = batchID
+	if len(b.memLatestBatch) > 0 {
+		return b.memLatestBatch[0].EventId
+	}
+	return common.EmptyEventID
 }
 
 // appendToLatestBatch appends event to memLatestBatch, rolling into a new batch

--- a/service/history/hsm/tree.go
+++ b/service/history/hsm/tree.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"slices"
 	"strings"
 
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
-	"go.temporal.io/api/serviceerror"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/service/history/consts"
@@ -154,6 +152,9 @@ func (ol OperationLog) String() string {
 type NodeBackend interface {
 	// AddHistoryEvent adds a history event to be committed at the end of the current transaction.
 	AddHistoryEvent(t enumspb.EventType, setAttributes func(*historypb.HistoryEvent)) *historypb.HistoryEvent
+	// GenerateEventLoadToken generates a token for loading the given history event later via LoadHistoryEvent.
+	// Must be called for an event that was just added.
+	GenerateEventLoadToken(event *historypb.HistoryEvent) ([]byte, error)
 	// LoadHistoryEvent loads a history event by token generated via [GenerateEventLoadToken].
 	LoadHistoryEvent(ctx context.Context, token []byte) (*historypb.HistoryEvent, error)
 	// GetCurrentVersion returns the current namespace failover version.
@@ -443,6 +444,13 @@ func (n *Node) AddHistoryEvent(t enumspb.EventType, setAttributes func(*historyp
 	return n.backend.AddHistoryEvent(t, setAttributes)
 }
 
+// GenerateEventLoadToken generates a token for loading the given history event via [LoadHistoryEvent].
+// Must be called within an [Environment.Access] function block for an event that was just added or is currently
+// being applied in the active transaction.
+func (n *Node) GenerateEventLoadToken(event *historypb.HistoryEvent) ([]byte, error) {
+	return n.backend.GenerateEventLoadToken(event)
+}
+
 // Load a history event by token generated via [GenerateEventLoadToken].
 // Must be called within an [Environment.Access] function block with either read or write access.
 func (n *Node) LoadHistoryEvent(ctx context.Context, token []byte) (*historypb.HistoryEvent, error) {
@@ -688,37 +696,6 @@ func (c Collection[T]) Transition(stateMachineID string, transitionFn func(T) (T
 		return err
 	}
 	return MachineTransition(node, transitionFn)
-}
-
-// GenerateEventLoadToken generates a token for loading a history event from an [Environment].
-// Events should typically be immutable making this function safe to call outside of an [Environment.Access] call.
-func GenerateEventLoadToken(event *historypb.HistoryEvent) ([]byte, error) {
-	attrs := reflect.ValueOf(event.Attributes).Elem()
-
-	// Attributes is always a struct with a single field (e.g: HistoryEvent_NexusOperationScheduledEventAttributes)
-	if attrs.Kind() != reflect.Struct || attrs.NumField() != 1 {
-		return nil, serviceerror.NewInternalf("got an invalid event structure: %v", event.EventType)
-	}
-
-	f := attrs.Field(0).Interface()
-
-	var eventBatchID int64
-	if getter, ok := f.(interface{ GetWorkflowTaskCompletedEventId() int64 }); ok {
-		// Command-Events always have a WorkflowTaskCompletedEventId field that is equal to the batch ID.
-		eventBatchID = getter.GetWorkflowTaskCompletedEventId()
-	} else if attrs := event.GetWorkflowExecutionStartedEventAttributes(); attrs != nil {
-		// WFEStarted is always stored in the first batch of events.
-		eventBatchID = 1
-	} else {
-		// By default, events aren't referenceable as they may end up buffered.
-		// This limitation may be relaxed later and the platform would need a way to fix references to buffered events.
-		return nil, serviceerror.NewInternalf("cannot reference event: %v", event.EventType)
-	}
-	ref := &tokenspb.HistoryEventRef{
-		EventId:      event.EventId,
-		EventBatchId: eventBatchID,
-	}
-	return proto.Marshal(ref)
 }
 
 func (n *Node) root() *Node {

--- a/service/history/interfaces/mutable_state.go
+++ b/service/history/interfaces/mutable_state.go
@@ -44,7 +44,7 @@ type (
 	MutableState interface {
 		AddHistoryEvent(t enumspb.EventType, setAttributes func(*historypb.HistoryEvent)) *historypb.HistoryEvent
 		GenerateEventLoadToken(event *historypb.HistoryEvent) ([]byte, error)
-		SetLatestEventBatchID(batchID int64)
+		SetReplayEventBatchID(batchID int64)
 		LoadHistoryEvent(ctx context.Context, token []byte) (*historypb.HistoryEvent, error)
 
 		AddActivityTaskCancelRequestedEvent(int64, int64, string) (*historypb.HistoryEvent, *persistencespb.ActivityInfo, error)

--- a/service/history/interfaces/mutable_state.go
+++ b/service/history/interfaces/mutable_state.go
@@ -44,6 +44,7 @@ type (
 	MutableState interface {
 		AddHistoryEvent(t enumspb.EventType, setAttributes func(*historypb.HistoryEvent)) *historypb.HistoryEvent
 		GenerateEventLoadToken(event *historypb.HistoryEvent) ([]byte, error)
+		SetLatestEventBatchID(batchID int64)
 		LoadHistoryEvent(ctx context.Context, token []byte) (*historypb.HistoryEvent, error)
 
 		AddActivityTaskCancelRequestedEvent(int64, int64, string) (*historypb.HistoryEvent, *persistencespb.ActivityInfo, error)

--- a/service/history/interfaces/mutable_state_mock.go
+++ b/service/history/interfaces/mutable_state_mock.go
@@ -3561,6 +3561,18 @@ func (mr *MockMutableStateMockRecorder) SetHistoryTree(executionTimeout, runTime
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHistoryTree", reflect.TypeOf((*MockMutableState)(nil).SetHistoryTree), executionTimeout, runTimeout, treeID)
 }
 
+// SetLatestEventBatchID mocks base method.
+func (m *MockMutableState) SetLatestEventBatchID(batchID int64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetLatestEventBatchID", batchID)
+}
+
+// SetLatestEventBatchID indicates an expected call of SetLatestEventBatchID.
+func (mr *MockMutableStateMockRecorder) SetLatestEventBatchID(batchID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLatestEventBatchID", reflect.TypeOf((*MockMutableState)(nil).SetLatestEventBatchID), batchID)
+}
+
 // SetSpeculativeWorkflowTaskTimeoutTask mocks base method.
 func (m *MockMutableState) SetSpeculativeWorkflowTaskTimeoutTask(task *tasks.WorkflowTaskTimeoutTask) error {
 	m.ctrl.T.Helper()

--- a/service/history/interfaces/mutable_state_mock.go
+++ b/service/history/interfaces/mutable_state_mock.go
@@ -3561,16 +3561,16 @@ func (mr *MockMutableStateMockRecorder) SetHistoryTree(executionTimeout, runTime
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHistoryTree", reflect.TypeOf((*MockMutableState)(nil).SetHistoryTree), executionTimeout, runTimeout, treeID)
 }
 
-// SetLatestEventBatchID mocks base method.
-func (m *MockMutableState) SetLatestEventBatchID(batchID int64) {
+// SetReplayEventBatchID mocks base method.
+func (m *MockMutableState) SetReplayEventBatchID(batchID int64) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetLatestEventBatchID", batchID)
+	m.ctrl.Call(m, "SetReplayEventBatchID", batchID)
 }
 
-// SetLatestEventBatchID indicates an expected call of SetLatestEventBatchID.
-func (mr *MockMutableStateMockRecorder) SetLatestEventBatchID(batchID any) *gomock.Call {
+// SetReplayEventBatchID indicates an expected call of SetReplayEventBatchID.
+func (mr *MockMutableStateMockRecorder) SetReplayEventBatchID(batchID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLatestEventBatchID", reflect.TypeOf((*MockMutableState)(nil).SetLatestEventBatchID), batchID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetReplayEventBatchID", reflect.TypeOf((*MockMutableState)(nil).SetReplayEventBatchID), batchID)
 }
 
 // SetSpeculativeWorkflowTaskTimeoutTask mocks base method.

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -1361,33 +1361,35 @@ func (ms *MutableStateImpl) AddHistoryEvent(t enumspb.EventType, setAttributes f
 	return event
 }
 
+// SetLatestEventBatchID records the first event ID of the persistence batch that subsequent
+// GenerateEventLoadToken calls should reference. The live path sets this automatically when an
+// event is added. The rebuilder sets it for each batch before replaying its events.
+func (ms *MutableStateImpl) SetLatestEventBatchID(batchID int64) {
+	ms.hBuilder.SetLatestEventBatchID(batchID)
+}
+
 // GenerateEventLoadToken generates a token for loading a history event at a later time. The token encodes the event ID
 // and the batch ID (if applicable) which can be used to load the event from the events cache.
+//
+// The batch ID comes from the latest event batch (see [MutableStateImpl.SetLatestEventBatchID]), which assumes the
+// token is generated for the event that was just added (live path) or is currently being applied during replay. This must
+// be called after adding the event and not for an arbitrary historical event.
 func (ms *MutableStateImpl) GenerateEventLoadToken(event *historypb.HistoryEvent) ([]byte, error) {
-	attrs := reflect.ValueOf(event.Attributes).Elem()
-
-	// Attributes is always a struct with a single field (e.g: HistoryEvent_NexusOperationScheduledEventAttributes)
-	if attrs.Kind() != reflect.Struct || attrs.NumField() != 1 {
-		return nil, serviceerror.NewInternalf("got an invalid event structure: %v", event.EventType)
-	}
-
-	f := attrs.Field(0).Interface()
-
-	var eventBatchID int64
-	if getter, ok := f.(interface{ GetWorkflowTaskCompletedEventId() int64 }); ok {
-		// Command-Events always have a WorkflowTaskCompletedEventId field that is equal to the batch ID.
-		eventBatchID = getter.GetWorkflowTaskCompletedEventId()
-	} else if attrs := event.GetWorkflowExecutionStartedEventAttributes(); attrs != nil {
-		// WFEStarted is always stored in the first batch of events.
-		eventBatchID = 1
-	} else {
-		// By default, events aren't referenceable as they may end up buffered.
-		// This limitation may be relaxed later and the platform would need a way to fix references to buffered events.
+	batchID := ms.hBuilder.LatestEventBatchID()
+	if batchID == common.EmptyEventID {
 		return nil, serviceerror.NewInternalf("cannot reference event: %v", event.EventType)
+	}
+	if batchID > event.EventId {
+		// The batch ID is the first event ID of the event's own batch, so it can never exceed the
+		// event's ID. A larger value means the cursor advanced past this event (token generated
+		// after a later event rolled the batch).
+		return nil, serviceerror.NewInternalf(
+			"event load token batch ID %d exceeds event ID %d",
+			batchID, event.EventId)
 	}
 	ref := &tokenspb.HistoryEventRef{
 		EventId:      event.EventId,
-		EventBatchId: eventBatchID,
+		EventBatchId: batchID,
 	}
 	return proto.Marshal(ref)
 }

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -274,6 +274,11 @@ type (
 
 		// Tracks all events added via the AddHistoryEvent method that is used by the state machine framework.
 		currentTransactionAddedStateMachineEventTypes []enumspb.EventType
+
+		// replayEventBatchID is the first event ID of the history batch currently being applied
+		// during replay, set via SetReplayEventBatchID by the rebuilder. It is common.EmptyEventID
+		// on the live path, where the batch ID is derived from the batch being built instead.
+		replayEventBatchID int64
 	}
 
 	lastUpdatedStateTransitionGetter interface {
@@ -1361,28 +1366,29 @@ func (ms *MutableStateImpl) AddHistoryEvent(t enumspb.EventType, setAttributes f
 	return event
 }
 
-// SetLatestEventBatchID records the first event ID of the persistence batch that subsequent
-// GenerateEventLoadToken calls should reference. The live path sets this automatically when an
-// event is added. The rebuilder sets it for each batch before replaying its events.
-func (ms *MutableStateImpl) SetLatestEventBatchID(batchID int64) {
-	ms.hBuilder.SetLatestEventBatchID(batchID)
+// SetReplayEventBatchID records the first event ID of the history batch that subsequent
+// GenerateEventLoadToken calls should reference. Only needed during replay. The rebuilder sets it
+// for each batch before applying its events.
+func (ms *MutableStateImpl) SetReplayEventBatchID(batchID int64) {
+	ms.replayEventBatchID = batchID
 }
 
 // GenerateEventLoadToken generates a token for loading a history event at a later time. The token encodes the event ID
 // and the batch ID (if applicable) which can be used to load the event from the events cache.
-//
-// The batch ID comes from the latest event batch (see [MutableStateImpl.SetLatestEventBatchID]), which assumes the
-// token is generated for the event that was just added (live path) or is currently being applied during replay. This must
-// be called after adding the event and not for an arbitrary historical event.
 func (ms *MutableStateImpl) GenerateEventLoadToken(event *historypb.HistoryEvent) ([]byte, error) {
+	if event.EventId == common.BufferedEventID {
+		return nil, serviceerror.NewInternalf("cannot reference buffered event: %v", event.EventType)
+	}
 	batchID := ms.hBuilder.LatestEventBatchID()
+	if batchID == common.EmptyEventID {
+		batchID = ms.replayEventBatchID
+	}
 	if batchID == common.EmptyEventID {
 		return nil, serviceerror.NewInternalf("cannot reference event: %v", event.EventType)
 	}
 	if batchID > event.EventId {
 		// The batch ID is the first event ID of the event's own batch, so it can never exceed the
-		// event's ID. A larger value means the cursor advanced past this event (token generated
-		// after a later event rolled the batch).
+		// event's ID.
 		return nil, serviceerror.NewInternalf(
 			"event load token batch ID %d exceeds event ID %d",
 			batchID, event.EventId)
@@ -8347,6 +8353,7 @@ func (ms *MutableStateImpl) cleanupTransaction() error {
 	ms.activityInfosUserDataUpdated = make(map[int64]struct{})
 	ms.reapplyEventsCandidate = nil
 	ms.subStateMachineDeleted = false
+	ms.replayEventBatchID = common.EmptyEventID
 
 	ms.stateInDB = ms.executionState.State
 	ms.nextEventIDInDB = ms.GetNextEventID()

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -31,6 +31,7 @@ import (
 	"go.temporal.io/server/api/historyservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
+	tokenspb "go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/clock"
@@ -8908,6 +8909,33 @@ func (s *mutableStateSuite) TestAddActivityTaskScheduledEvent_ScheduledEventBatc
 	)
 	s.NoError(err)
 	s.Equal(event.GetEventId(), activityInfo.ScheduledEventBatchId)
+}
+
+func (s *mutableStateSuite) TestGenerateEventLoadToken_MultiBatch() {
+	_, completedEvent := s.scheduleCompletedWFTForBatchIDTest()
+
+	event := s.mutableState.AddHistoryEvent(enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED, func(he *historypb.HistoryEvent) {
+		he.Attributes = &historypb.HistoryEvent_NexusOperationScheduledEventAttributes{
+			NexusOperationScheduledEventAttributes: &historypb.NexusOperationScheduledEventAttributes{
+				Endpoint:                     "endpoint",
+				Service:                      "service",
+				Operation:                    "operation",
+				Input:                        &commonpb.Payload{Data: []byte("input")},
+				WorkflowTaskCompletedEventId: completedEvent.GetEventId(),
+			},
+		}
+	})
+
+	token, err := s.mutableState.GenerateEventLoadToken(event)
+	s.NoError(err)
+
+	ref := &tokenspb.HistoryEventRef{}
+	s.NoError(proto.Unmarshal(token, ref))
+	s.Equal(event.GetEventId(), ref.EventId)
+	// The event rolled into its own batch, so the token must reference that batch,
+	// not the batch of the WFT-completed event that added this command.
+	s.Equal(event.GetEventId(), ref.EventBatchId)
+	s.NotEqual(completedEvent.GetEventId(), ref.EventBatchId)
 }
 
 func (s *mutableStateSuite) TestAddCompletedWorkflowEvent_CompletionEventBatchID() {

--- a/service/history/workflow/mutable_state_rebuilder.go
+++ b/service/history/workflow/mutable_state_rebuilder.go
@@ -147,7 +147,7 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 	// [history] is a single persistence batch, so firstEvent.EventId is the batch ID for every
 	// event applied below. Event definitions that generate load tokens (e.g. NexusOperationScheduled)
 	// read this via GenerateEventLoadToken to find the original batch ID.
-	b.mutableState.SetLatestEventBatchID(firstEvent.GetEventId())
+	b.mutableState.SetReplayEventBatchID(firstEvent.GetEventId())
 
 	for _, event := range history {
 		switch event.GetEventType() {

--- a/service/history/workflow/mutable_state_rebuilder.go
+++ b/service/history/workflow/mutable_state_rebuilder.go
@@ -144,6 +144,11 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 	}
 	executionInfo.LastRunningClock = lastEvent.GetTaskId()
 
+	// [history] is a single persistence batch, so firstEvent.EventId is the batch ID for every
+	// event applied below. Event definitions that generate load tokens (e.g. NexusOperationScheduled)
+	// read this via GenerateEventLoadToken to find the original batch ID.
+	b.mutableState.SetLatestEventBatchID(firstEvent.GetEventId())
+
 	for _, event := range history {
 		switch event.GetEventType() {
 		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED:

--- a/service/history/workflow/mutable_state_rebuilder_test.go
+++ b/service/history/workflow/mutable_state_rebuilder_test.go
@@ -125,7 +125,7 @@ func (s *stateBuilderSuite) SetupTest() {
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(s.executionInfo).AnyTimes()
 	s.mockMutableState.EXPECT().GetCurrentVersion().Return(int64(1)).AnyTimes()
 	s.mockMutableState.EXPECT().NextTransitionCount().Return(int64(2)).AnyTimes()
-	s.mockMutableState.EXPECT().SetLatestEventBatchID(gomock.Any()).AnyTimes()
+	s.mockMutableState.EXPECT().SetReplayEventBatchID(gomock.Any()).AnyTimes()
 	s.mockMutableState.EXPECT().GenerateEventLoadToken(gomock.Any()).Return([]byte("token"), nil).AnyTimes()
 
 	populateTaskGeneratorProvider(&testTaskGeneratorProvider{

--- a/service/history/workflow/mutable_state_rebuilder_test.go
+++ b/service/history/workflow/mutable_state_rebuilder_test.go
@@ -125,6 +125,8 @@ func (s *stateBuilderSuite) SetupTest() {
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(s.executionInfo).AnyTimes()
 	s.mockMutableState.EXPECT().GetCurrentVersion().Return(int64(1)).AnyTimes()
 	s.mockMutableState.EXPECT().NextTransitionCount().Return(int64(2)).AnyTimes()
+	s.mockMutableState.EXPECT().SetLatestEventBatchID(gomock.Any()).AnyTimes()
+	s.mockMutableState.EXPECT().GenerateEventLoadToken(gomock.Any()).Return([]byte("token"), nil).AnyTimes()
 
 	populateTaskGeneratorProvider(&testTaskGeneratorProvider{
 		mockMutableState:  s.mockMutableState,

--- a/service/history/workflow/workflow_test/mutable_state_impl_test.go
+++ b/service/history/workflow/workflow_test/mutable_state_impl_test.go
@@ -23,6 +23,7 @@ import (
 	historyspb "go.temporal.io/server/api/history/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
@@ -478,8 +479,9 @@ func TestLoadHistoryEventFromToken(t *testing.T) {
 	branchToken, err := ms.GetCurrentBranchToken()
 	require.NoError(t, err)
 	firstEventID := event.EventId
+	require.Equal(t, common.FirstEventID, firstEventID)
 
-	token, err := hsm.GenerateEventLoadToken(event)
+	token, err := ms.GenerateEventLoadToken(event)
 	require.NoError(t, err)
 
 	wfKey := ms.GetWorkflowKey()


### PR DESCRIPTION
## What changed?
Event load token generate with `GenerateEventLoadToken` now returns the correct ID of the persistence batch the event was written to. The history builder tracks the latest batch ID on the live path, and the rebuilder sets it per batch during replay. Both the HSM and CHASM Nexus paths now generate tokens through the mutable state.

`GenerateEventLoadToken` only supports the token generation for events that were just added or are currently applied during replay. Existing caller (NexusOperationScheduled) already satisfy that.

## Why?
With command pagination, a single workflow task can span multiple persistence batches, so a command event no longer always lands in the batch starting at `WorkflowTaskCompletedEventId`.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
New test forces every event into its own batch (`MaximumEventBatchSizeInBytes=1`) and asserts the token references the scheduled event's own batch rather than the WFT-completed event's.

## Potential risks
* Token generation now reads mutable state. A future caller that tokenizes anything other than the just-added / currently-applied event would get a wrong batch ID. Added a sanity check that rejects tokens whose batch ID exceeds the event ID

