### PR TITLE
fix: prevent batcher activity deadlock when retrying failed tasks

### DIFF
--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -690,7 +690,7 @@ func isNonRetryableError(err error, batchType enumspb.BatchOperationType) bool {
 func (a *activities) processTaskWithRetries(
 	ctx context.Context,
 	batchOperation *batchspb.BatchOperationInput,
-	namespace string,
+	ns string,
 	task task,
 	respCh chan taskResponse,
 	limiter quotas.RequestRateLimiter,
@@ -701,7 +701,7 @@ func (a *activities) processTaskWithRetries(
 ) {
 	var err error
 	for {
-		err = a.processSingleTask(ctx, batchOperation, namespace, task, limiter, sdkClient, frontendClient, logger)
+		err = a.processSingleTask(ctx, batchOperation, ns, task, limiter, sdkClient, frontendClient, logger)
 		if err == nil {
 			metrics.BatcherProcessorSuccess.With(metricsHandler).Record(1)
 			break
@@ -727,9 +727,10 @@ func (a *activities) processTaskWithRetries(
 // isRetryableTaskError reports whether a failed task's error permits a retry.
 func isRetryableTaskError(err error, batchOperation *batchspb.BatchOperationInput) bool {
 	var appErr *temporal.ApplicationError
-	return !((errors.As(err, &appErr) && appErr.NonRetryable()) ||
+	nonRetryable := (errors.As(err, &appErr) && appErr.NonRetryable()) ||
 		isNonRetryableError(err, batchOperation.BatchType) ||
-		slices.Contains(batchOperation.NonRetryableErrors, err.Error()))
+		slices.Contains(batchOperation.NonRetryableErrors, err.Error())
+	return !nonRetryable
 }
 
 func (a *activities) processAdminTask(

--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -117,6 +117,25 @@ func (p *page) done() bool {
 	return p.successCount+p.errorCount == len(p.executionInfos)
 }
 
+// recordCompletedPages accumulates stats for every page that is now fully done — the given
+// page and, transitively, all earlier ones — and advances the heartbeat resume point to just
+// past the last fully-done page, i.e. the oldest page that is NOT yet done.
+//
+// The resume point must not run ahead of completion. Pages are fetched ahead as soon as the
+// current page is fully *submitted* (not *done*), so advancing PageToken at fetch time would
+// let a restart resume past still-in-flight pages and silently skip them. Advancing only
+// through the contiguous fully-done prefix here guarantees a restart re-fetches the oldest
+// incomplete page; already-counted pages are not re-fetched, so stats are not double-counted.
+func recordCompletedPages(hbd *HeartBeatDetails, resultPage *page) {
+	for pg := resultPage; pg != nil && pg.done(); pg = pg.next {
+		hbd.SuccessCount += pg.successCount
+		hbd.ErrorCount += pg.errorCount
+		hbd.CurrentPage = pg.pageNumber + 1
+		hbd.PageToken = pg.nextPageToken
+		pg.prev = nil
+	}
+}
+
 // fetchPage fetches a new page of workflow executions
 func fetchPage(
 	ctx context.Context,
@@ -181,8 +200,10 @@ func (a *activities) processWorkflowsWithProactiveFetching(
 	heartbeatTicker := time.NewTicker(defaultActivityHeartBeatTimeout / 4)
 	defer heartbeatTicker.Stop()
 
-	// Start worker processors
-	for range config.concurrency {
+	// Start worker processors. Use the clamped `concurrency` (min 1), not config.concurrency:
+	// if the dynamic config resolves concurrency to 0, no workers would start and the activity
+	// would wait forever.
+	for range concurrency {
 		go startWorkerProcessor(ctx, taskCh, respCh, rateLimiter, sdkClient, a.FrontendClient, metricsHandler, logger)
 	}
 
@@ -223,13 +244,21 @@ func (a *activities) processWorkflowsWithProactiveFetching(
 			p.next = nextPage
 			nextPage.prev = p
 			p = nextPage
+		}
 
-			hbd.CurrentPage = p.pageNumber
-			hbd.PageToken = p.nextPageToken
+		// Only offer work to the pool while the current page still has unsubmitted
+		// executions; otherwise disable this case with a nil channel so the loop does not
+		// spin submitting empty tasks (which would also push submittedCount past the page size)
+		// while waiting for in-flight tasks and earlier pages to finish.
+		var submitCh chan task
+		var nextTask task
+		if p.submittedCount < len(p.executionInfos) {
+			submitCh = taskCh
+			nextTask = p.nextTask()
 		}
 
 		select {
-		case taskCh <- p.nextTask():
+		case submitCh <- nextTask:
 			p.submittedCount++
 
 		case result := <-respCh:
@@ -240,13 +269,7 @@ func (a *activities) processWorkflowsWithProactiveFetching(
 				resultPage.errorCount++
 			}
 
-			// Update heartbeat details if this page and all previous pages are complete
-			// Find all pages from the current one on that are done, record their stats, and unlink them.
-			for page := resultPage; page != nil && page.done(); page = page.next {
-				hbd.SuccessCount += page.successCount
-				hbd.ErrorCount += page.errorCount
-				page.prev = nil
-			}
+			recordCompletedPages(&hbd, resultPage)
 
 		case <-heartbeatTicker.C:
 			// Send periodic heartbeat to prevent timeout during slow processing
@@ -459,7 +482,7 @@ func (a *activities) startTaskProcessor(
 				continue
 			}
 
-			a.processSingleTask(ctx, batchOperation, namespace, task, taskCh, respCh, limiter, sdkClient, frontendClient, metricsHandler, logger)
+			a.processTaskWithRetries(ctx, batchOperation, namespace, task, respCh, limiter, sdkClient, frontendClient, metricsHandler, logger)
 		}
 	}
 }
@@ -472,14 +495,11 @@ func (a *activities) processSingleTask(
 	batchOperation *batchspb.BatchOperationInput,
 	namespace string,
 	task task,
-	taskCh chan task,
-	respCh chan taskResponse,
 	limiter quotas.RequestRateLimiter,
 	sdkClient sdkclient.Client,
 	frontendClient workflowservice.WorkflowServiceClient,
-	metricsHandler metrics.Handler,
 	logger log.Logger,
-) {
+) error {
 	var err error
 
 	// Bound the processing of each individual task so a single hung operation
@@ -489,9 +509,7 @@ func (a *activities) processSingleTask(
 
 	// Handle admin batch operations
 	if batchOperation.AdminRequest != nil {
-		err = a.processAdminTask(ctx, batchOperation, task, limiter)
-		a.handleTaskResult(batchOperation, task, err, taskCh, respCh, metricsHandler, logger)
-		return
+		return a.processAdminTask(ctx, batchOperation, task, limiter)
 	}
 
 	switch operation := batchOperation.Request.Operation.(type) {
@@ -658,7 +676,7 @@ func (a *activities) processSingleTask(
 	default:
 		err = fmt.Errorf("unknown batch type: %v", batchOperation.BatchType)
 	}
-	a.handleTaskResult(batchOperation, task, err, taskCh, respCh, metricsHandler, logger)
+	return err
 }
 
 // isNonRetryableError determines if an error should not be retried based on the operation type
@@ -679,39 +697,63 @@ func isNonRetryableError(err error, batchType enumspb.BatchOperationType) bool {
 	}
 }
 
-func (a *activities) handleTaskResult(
+// processTaskWithRetries runs a task's operation, retrying retryable failures in place on
+// this worker goroutine, and sends exactly one response on respCh.
+//
+// Retries are deliberately NOT re-queued onto taskCh: the worker goroutines are the only
+// consumers of taskCh, so under a burst of retryable errors they would all block on the
+// re-enqueue send with the buffer full and no consumer left to drain it -> the activity
+// wedges (it keeps heartbeating but makes no progress). Emitting exactly one response per
+// dispatched task also guarantees a page can always reach completion, instead of a single
+// never-acknowledged task wedging the whole batch.
+func (a *activities) processTaskWithRetries(
+	ctx context.Context,
 	batchOperation *batchspb.BatchOperationInput,
+	namespace string,
 	task task,
-	err error,
-	taskCh chan task,
 	respCh chan taskResponse,
+	limiter quotas.RequestRateLimiter,
+	sdkClient sdkclient.Client,
+	frontendClient workflowservice.WorkflowServiceClient,
 	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) {
-	if err != nil {
+	var err error
+	for {
+		err = a.processSingleTask(ctx, batchOperation, namespace, task, limiter, sdkClient, frontendClient, logger)
+		if err == nil {
+			metrics.BatcherProcessorSuccess.With(metricsHandler).Record(1)
+			break
+		}
+
 		metrics.BatcherProcessorFailures.With(metricsHandler).Record(1)
 		logger.Error("Failed to process batch operation task", tag.Error(err))
 
-		// Check if error is non-retryable:
-		// 1. ApplicationError marked as NonRetryable
-		// 2. Operation-specific non-retryable errors
-		// 3. List of non-retryable errors from frontend
-		var appErr *temporal.ApplicationError
-		nonRetryable := (errors.As(err, &appErr) && appErr.NonRetryable()) ||
-			isNonRetryableError(err, batchOperation.BatchType) ||
-			slices.Contains(batchOperation.NonRetryableErrors, err.Error())
-
-		if nonRetryable || task.attempts > int(batchOperation.AttemptsOnRetryableError) {
-			respCh <- taskResponse{err: err, page: task.page}
-		} else {
-			// put back to the channel if less than attemptsOnError
+		if isRetryableTaskError(err, batchOperation) && task.attempts <= int(batchOperation.AttemptsOnRetryableError) && !isDone(ctx) {
 			task.attempts++
-			taskCh <- task
+			continue
 		}
-	} else {
-		metrics.BatcherProcessorSuccess.With(metricsHandler).Record(1)
-		respCh <- taskResponse{err: nil, page: task.page}
+		break
 	}
+
+	// Emit exactly one response per task. Guard the send with ctx so the worker does not
+	// block here if the coordinator loop has already exited.
+	select {
+	case respCh <- taskResponse{err: err, page: task.page}:
+	case <-ctx.Done():
+	}
+}
+
+// isRetryableTaskError reports whether a failed task should be retried. A task is retryable
+// unless its error is explicitly non-retryable:
+//  1. an ApplicationError marked NonRetryable,
+//  2. an operation-specific non-retryable error, or
+//  3. an error listed in the batch's NonRetryableErrors.
+func isRetryableTaskError(err error, batchOperation *batchspb.BatchOperationInput) bool {
+	var appErr *temporal.ApplicationError
+	return !((errors.As(err, &appErr) && appErr.NonRetryable()) ||
+		isNonRetryableError(err, batchOperation.BatchType) ||
+		slices.Contains(batchOperation.NonRetryableErrors, err.Error()))
 }
 
 func (a *activities) processAdminTask(

--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -117,15 +117,8 @@ func (p *page) done() bool {
 	return p.successCount+p.errorCount == len(p.executionInfos)
 }
 
-// recordCompletedPages accumulates stats for every page that is now fully done — the given
-// page and, transitively, all earlier ones — and advances the heartbeat resume point to just
-// past the last fully-done page, i.e. the oldest page that is NOT yet done.
-//
-// The resume point must not run ahead of completion. Pages are fetched ahead as soon as the
-// current page is fully *submitted* (not *done*), so advancing PageToken at fetch time would
-// let a restart resume past still-in-flight pages and silently skip them. Advancing only
-// through the contiguous fully-done prefix here guarantees a restart re-fetches the oldest
-// incomplete page; already-counted pages are not re-fetched, so stats are not double-counted.
+// recordCompletedPages records stats for each page that is now fully done and advances the
+// heartbeat resume point to the oldest page that is not yet done.
 func recordCompletedPages(hbd *HeartBeatDetails, resultPage *page) {
 	for pg := resultPage; pg != nil && pg.done(); pg = pg.next {
 		hbd.SuccessCount += pg.successCount
@@ -200,9 +193,7 @@ func (a *activities) processWorkflowsWithProactiveFetching(
 	heartbeatTicker := time.NewTicker(defaultActivityHeartBeatTimeout / 4)
 	defer heartbeatTicker.Stop()
 
-	// Start worker processors. Use the clamped `concurrency` (min 1), not config.concurrency:
-	// if the dynamic config resolves concurrency to 0, no workers would start and the activity
-	// would wait forever.
+	// concurrency is clamped to at least 1, so a zero configured value still starts a worker.
 	for range concurrency {
 		go startWorkerProcessor(ctx, taskCh, respCh, rateLimiter, sdkClient, a.FrontendClient, metricsHandler, logger)
 	}
@@ -246,10 +237,8 @@ func (a *activities) processWorkflowsWithProactiveFetching(
 			p = nextPage
 		}
 
-		// Only offer work to the pool while the current page still has unsubmitted
-		// executions; otherwise disable this case with a nil channel so the loop does not
-		// spin submitting empty tasks (which would also push submittedCount past the page size)
-		// while waiting for in-flight tasks and earlier pages to finish.
+		// Disable this send case (nil channel) once the page is fully submitted, so the loop
+		// waits on results instead of offering empty tasks.
 		var submitCh chan task
 		var nextTask task
 		if p.submittedCount < len(p.executionInfos) {
@@ -697,15 +686,8 @@ func isNonRetryableError(err error, batchType enumspb.BatchOperationType) bool {
 	}
 }
 
-// processTaskWithRetries runs a task's operation, retrying retryable failures in place on
-// this worker goroutine, and sends exactly one response on respCh.
-//
-// Retries are deliberately NOT re-queued onto taskCh: the worker goroutines are the only
-// consumers of taskCh, so under a burst of retryable errors they would all block on the
-// re-enqueue send with the buffer full and no consumer left to drain it -> the activity
-// wedges (it keeps heartbeating but makes no progress). Emitting exactly one response per
-// dispatched task also guarantees a page can always reach completion, instead of a single
-// never-acknowledged task wedging the whole batch.
+// processTaskWithRetries runs the task's operation, retrying retryable failures in place on
+// this goroutine, and sends exactly one response on respCh per task.
 func (a *activities) processTaskWithRetries(
 	ctx context.Context,
 	batchOperation *batchspb.BatchOperationInput,
@@ -736,19 +718,14 @@ func (a *activities) processTaskWithRetries(
 		break
 	}
 
-	// Emit exactly one response per task. Guard the send with ctx so the worker does not
-	// block here if the coordinator loop has already exited.
+	// Send one response per task; stop early if the context is cancelled.
 	select {
 	case respCh <- taskResponse{err: err, page: task.page}:
 	case <-ctx.Done():
 	}
 }
 
-// isRetryableTaskError reports whether a failed task should be retried. A task is retryable
-// unless its error is explicitly non-retryable:
-//  1. an ApplicationError marked NonRetryable,
-//  2. an operation-specific non-retryable error, or
-//  3. an error listed in the batch's NonRetryableErrors.
+// isRetryableTaskError reports whether a failed task's error permits a retry.
 func isRetryableTaskError(err error, batchOperation *batchspb.BatchOperationInput) bool {
 	var appErr *temporal.ApplicationError
 	return !((errors.As(err, &appErr) && appErr.NonRetryable()) ||

--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -193,7 +193,6 @@ func (a *activities) processWorkflowsWithProactiveFetching(
 	heartbeatTicker := time.NewTicker(defaultActivityHeartBeatTimeout / 4)
 	defer heartbeatTicker.Stop()
 
-	// concurrency is clamped to at least 1, so a zero configured value still starts a worker.
 	for range concurrency {
 		go startWorkerProcessor(ctx, taskCh, respCh, rateLimiter, sdkClient, a.FrontendClient, metricsHandler, logger)
 	}

--- a/service/worker/batcher/activities_test.go
+++ b/service/worker/batcher/activities_test.go
@@ -722,7 +722,7 @@ func (s *activitiesSuite) TestStartTaskProcessor_RetryableErrorsDoNotDeadlock() 
 
 	// Feed tasks from a separate goroutine so the test can drain responses concurrently.
 	go func() {
-		for i := 0; i < numTasks; i++ {
+		for i := range numTasks {
 			p := &page{
 				executionInfos: []*workflowpb.WorkflowExecutionInfo{
 					{Execution: &commonpb.WorkflowExecution{WorkflowId: fmt.Sprintf("wf-%d", i), RunId: "run"}},
@@ -733,10 +733,10 @@ func (s *activitiesSuite) TestStartTaskProcessor_RetryableErrorsDoNotDeadlock() 
 	}()
 
 	// Every task must produce exactly one error response; the activity must not deadlock.
-	for i := 0; i < numTasks; i++ {
+	for range numTasks {
 		select {
 		case resp := <-respCh:
-			s.Error(resp.err)
+			s.Require().Error(resp.err)
 		case <-time.After(10 * time.Second):
 			s.FailNow("timed out waiting for task response: worker is deadlocked")
 		}

--- a/service/worker/batcher/activities_test.go
+++ b/service/worker/batcher/activities_test.go
@@ -678,12 +678,9 @@ func (s *activitiesSuite) TestStartTaskProcessor_SignalUsesWorkerNamespace() {
 	s.NoError(resp.err)
 }
 
-// TestStartTaskProcessor_RetryableErrorsDoNotDeadlock verifies that when an operation keeps
-// failing with a retryable error, the worker retries it in place (on its own goroutine) and
-// emits exactly one response per task, instead of re-queuing the task onto taskCh.
-// Re-queuing deadlocked the pool: the worker goroutines are the only consumers of taskCh, so
-// a burst of retryable errors made them all block on the re-enqueue send with the buffer full
-// and no drainer left, leaving the activity heartbeating but stuck with no progress.
+// TestStartTaskProcessor_RetryableErrorsDoNotDeadlock verifies that repeated retryable
+// failures are retried in place and each task still yields exactly one response, so the
+// worker pool keeps making progress.
 func (s *activitiesSuite) TestStartTaskProcessor_RetryableErrorsDoNotDeadlock() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -746,11 +743,8 @@ func (s *activitiesSuite) TestStartTaskProcessor_RetryableErrorsDoNotDeadlock() 
 	}
 }
 
-// TestRecordCompletedPages_ResumeTracksOldestIncompletePage verifies that the heartbeat
-// resume point (PageToken/CurrentPage) only advances across the contiguous fully-done prefix
-// of pages and never past a still-in-flight earlier page. Pages are fetched ahead once
-// submitted (not done), so a resume point that ran ahead of completion would skip in-flight
-// pages on restart and silently drop their workflows.
+// TestRecordCompletedPages_ResumeTracksOldestIncompletePage verifies the resume point only
+// advances across the contiguous run of completed pages, never past a page still in flight.
 func (s *activitiesSuite) TestRecordCompletedPages_ResumeTracksOldestIncompletePage() {
 	mkPage := func(num, size int, next string) *page {
 		return &page{
@@ -794,11 +788,8 @@ func (s *activitiesSuite) TestRecordCompletedPages_ResumeTracksOldestIncompleteP
 	s.Equal(1, hbd.ErrorCount)   // p1:1
 }
 
-// TestProcessWorkflowsWithProactiveFetching_ProcessesAllPages drives the full coordinator
-// loop end to end with a mock visibility client (multi-page) and a fake worker pool. It
-// guards that the coordinator fetches every page, submits and accounts for every workflow
-// exactly once, the empty-task submit guard prevents a spin/hang once a page is fully
-// submitted, and the activity completes with the correct counts.
+// TestProcessWorkflowsWithProactiveFetching_ProcessesAllPages drives the coordinator over
+// several pages and checks every workflow is processed exactly once and the activity completes.
 func (s *activitiesSuite) TestProcessWorkflowsWithProactiveFetching_ProcessesAllPages() {
 	type pageSpec struct {
 		size       int
@@ -829,8 +820,7 @@ func (s *activitiesSuite) TestProcessWorkflowsWithProactiveFetching_ProcessesAll
 		}, nil).Once()
 	}
 
-	// Fake worker pool: drain taskCh and report success for every real task. A broken
-	// empty-task guard would surface here as the activity never completing.
+	// Fake worker pool: drain taskCh and report success for every real task.
 	var processed int64
 	fakeWorker := func(
 		ctx context.Context,

--- a/service/worker/batcher/activities_test.go
+++ b/service/worker/batcher/activities_test.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sync/atomic"
 	"testing"
 	"time"
 	"unicode"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	batchpb "go.temporal.io/api/batch/v1"
 	commonpb "go.temporal.io/api/common/v1"
@@ -16,6 +18,8 @@ import (
 	historypb "go.temporal.io/api/history/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	sdkclient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/mocks"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/server/api/adminservice/v1"
@@ -788,6 +792,99 @@ func (s *activitiesSuite) TestRecordCompletedPages_ResumeTracksOldestIncompleteP
 	s.Equal(3, hbd.CurrentPage)
 	s.Equal(4, hbd.SuccessCount) // p1:1 + p2:2 + p3:1
 	s.Equal(1, hbd.ErrorCount)   // p1:1
+}
+
+// TestProcessWorkflowsWithProactiveFetching_ProcessesAllPages drives the full coordinator
+// loop end to end with a mock visibility client (multi-page) and a fake worker pool. It
+// guards that the coordinator fetches every page, submits and accounts for every workflow
+// exactly once, the empty-task submit guard prevents a spin/hang once a page is fully
+// submitted, and the activity completes with the correct counts.
+func (s *activitiesSuite) TestProcessWorkflowsWithProactiveFetching_ProcessesAllPages() {
+	type pageSpec struct {
+		size       int
+		fetchToken string // NextPageToken used to fetch this page
+		nextToken  string // NextPageToken this page returns
+	}
+	pages := []pageSpec{
+		{size: 5, fetchToken: "", nextToken: "p2"},
+		{size: 5, fetchToken: "p2", nextToken: "p3"},
+		{size: 3, fetchToken: "p3", nextToken: ""},
+	}
+	const total = 13
+
+	mockSdk := &mocks.Client{}
+	for i, pg := range pages {
+		execs := make([]*workflowpb.WorkflowExecutionInfo, pg.size)
+		for j := range execs {
+			execs[j] = &workflowpb.WorkflowExecutionInfo{
+				Execution: &commonpb.WorkflowExecution{WorkflowId: fmt.Sprintf("p%d-wf%d", i, j)},
+			}
+		}
+		fetchToken := pg.fetchToken
+		mockSdk.On("ListWorkflow", mock.Anything, mock.MatchedBy(func(r *workflowservice.ListWorkflowExecutionsRequest) bool {
+			return string(r.NextPageToken) == fetchToken
+		})).Return(&workflowservice.ListWorkflowExecutionsResponse{
+			Executions:    execs,
+			NextPageToken: []byte(pg.nextToken),
+		}, nil).Once()
+	}
+
+	// Fake worker pool: drain taskCh and report success for every real task. A broken
+	// empty-task guard would surface here as the activity never completing.
+	var processed int64
+	fakeWorker := func(
+		ctx context.Context,
+		taskCh chan task,
+		respCh chan taskResponse,
+		_ quotas.RequestRateLimiter,
+		_ sdkclient.Client,
+		_ workflowservice.WorkflowServiceClient,
+		_ metrics.Handler,
+		_ log.Logger,
+	) {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case t := <-taskCh:
+				if t.executionInfo == nil {
+					continue
+				}
+				atomic.AddInt64(&processed, 1)
+				select {
+				case respCh <- taskResponse{err: nil, page: t.page}:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}
+
+	a := &activities{}
+	config := batchProcessorConfig{
+		adjustedQuery: "ExecutionStatus = 'Completed'",
+		concurrency:   3,
+	}
+	limiter := quotas.NewRequestRateLimiterAdapter(quotas.NewDefaultOutgoingRateLimiter(func() float64 { return 10000 }))
+
+	// Run inside an activity environment so the coordinator's RecordHeartbeat call is valid.
+	env := s.NewTestActivityEnvironment()
+	runner := func(ctx context.Context) (HeartBeatDetails, error) {
+		return a.processWorkflowsWithProactiveFetching(
+			ctx, config, fakeWorker, limiter, mockSdk, metrics.NoopMetricsHandler, log.NewTestLogger(), HeartBeatDetails{},
+		)
+	}
+	env.RegisterActivity(runner)
+
+	encoded, err := env.ExecuteActivity(runner)
+	s.NoError(err)
+
+	var hbd HeartBeatDetails
+	s.NoError(encoded.Get(&hbd))
+	s.Equal(total, hbd.SuccessCount)
+	s.Equal(0, hbd.ErrorCount)
+	s.Equal(int64(total), atomic.LoadInt64(&processed))
+	mockSdk.AssertExpectations(s.T())
 }
 
 func (s *activitiesSuite) TestProcessAdminTask_UnknownOperation() {

--- a/service/worker/batcher/activities_test.go
+++ b/service/worker/batcher/activities_test.go
@@ -674,6 +674,122 @@ func (s *activitiesSuite) TestStartTaskProcessor_SignalUsesWorkerNamespace() {
 	s.NoError(resp.err)
 }
 
+// TestStartTaskProcessor_RetryableErrorsDoNotDeadlock verifies that when an operation keeps
+// failing with a retryable error, the worker retries it in place (on its own goroutine) and
+// emits exactly one response per task, instead of re-queuing the task onto taskCh.
+// Re-queuing deadlocked the pool: the worker goroutines are the only consumers of taskCh, so
+// a burst of retryable errors made them all block on the re-enqueue send with the buffer full
+// and no drainer left, leaving the activity heartbeating but stuck with no progress.
+func (s *activitiesSuite) TestStartTaskProcessor_RetryableErrorsDoNotDeadlock() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	a := &activities{
+		activityDeps: activityDeps{
+			FrontendClient: s.mockFrontendClient,
+			Logger:         log.NewTestLogger(),
+			MetricsHandler: metrics.NoopMetricsHandler,
+		},
+	}
+
+	const numTasks = 5
+	batchOperation := &batchspb.BatchOperationInput{
+		NamespaceId: "some-namespace-id",
+		// Bounded retries keep the test fast; each task is attempted a few times.
+		AttemptsOnRetryableError: 2,
+		Request: &workflowservice.StartBatchOperationRequest{
+			Namespace: "ns",
+			Operation: &workflowservice.StartBatchOperationRequest_SignalOperation{
+				SignalOperation: &batchpb.BatchOperationSignal{Signal: "test-signal"},
+			},
+		},
+	}
+
+	// Every signal fails with a retryable error, forcing the worker down the retry path.
+	s.mockFrontendClient.EXPECT().
+		SignalWorkflowExecution(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("transient error")).
+		AnyTimes()
+
+	// A single worker with a small buffer is the configuration that wedged when retries
+	// were re-queued onto taskCh.
+	taskCh := make(chan task, 1)
+	respCh := make(chan taskResponse, 1)
+	limiter := quotas.NewRequestRateLimiterAdapter(quotas.NewDefaultOutgoingRateLimiter(func() float64 { return 1000 }))
+
+	go a.startTaskProcessor(ctx, batchOperation, "ns", taskCh, respCh, limiter, nil, s.mockFrontendClient, metrics.NoopMetricsHandler, log.NewTestLogger())
+
+	// Feed tasks from a separate goroutine so the test can drain responses concurrently.
+	go func() {
+		for i := 0; i < numTasks; i++ {
+			p := &page{
+				executionInfos: []*workflowpb.WorkflowExecutionInfo{
+					{Execution: &commonpb.WorkflowExecution{WorkflowId: fmt.Sprintf("wf-%d", i), RunId: "run"}},
+				},
+			}
+			taskCh <- task{executionInfo: p.executionInfos[0], attempts: 1, page: p}
+		}
+	}()
+
+	// Every task must produce exactly one error response; the activity must not deadlock.
+	for i := 0; i < numTasks; i++ {
+		select {
+		case resp := <-respCh:
+			s.Error(resp.err)
+		case <-time.After(10 * time.Second):
+			s.FailNow("timed out waiting for task response: worker is deadlocked")
+		}
+	}
+}
+
+// TestRecordCompletedPages_ResumeTracksOldestIncompletePage verifies that the heartbeat
+// resume point (PageToken/CurrentPage) only advances across the contiguous fully-done prefix
+// of pages and never past a still-in-flight earlier page. Pages are fetched ahead once
+// submitted (not done), so a resume point that ran ahead of completion would skip in-flight
+// pages on restart and silently drop their workflows.
+func (s *activitiesSuite) TestRecordCompletedPages_ResumeTracksOldestIncompletePage() {
+	mkPage := func(num, size int, next string) *page {
+		return &page{
+			executionInfos: make([]*workflowpb.WorkflowExecutionInfo, size),
+			nextPageToken:  []byte(next),
+			pageNumber:     num,
+		}
+	}
+	p1 := mkPage(0, 2, "tok-p2")
+	p2 := mkPage(1, 2, "tok-p3")
+	p3 := mkPage(2, 1, "")
+	p1.next, p2.prev = p2, p1
+	p2.next, p3.prev = p3, p2
+
+	hbd := &HeartBeatDetails{PageToken: []byte("tok-p1")}
+
+	// Page 3 finishes first, while pages 1 and 2 are still in flight.
+	p3.successCount = 1
+	recordCompletedPages(hbd, p3)
+	// Resume point must NOT move: page 1 (the oldest) is still in flight.
+	s.Equal([]byte("tok-p1"), hbd.PageToken, "must not advance past in-flight earlier pages")
+	s.Equal(0, hbd.CurrentPage)
+	s.Equal(0, hbd.SuccessCount)
+	s.Equal(0, hbd.ErrorCount)
+
+	// Page 1 finishes; page 2 still in flight.
+	p1.successCount, p1.errorCount = 1, 1
+	recordCompletedPages(hbd, p1)
+	// Resume point advances to page 2 (now the oldest incomplete); only page 1 is counted.
+	s.Equal([]byte("tok-p2"), hbd.PageToken)
+	s.Equal(1, hbd.CurrentPage)
+	s.Equal(1, hbd.SuccessCount)
+	s.Equal(1, hbd.ErrorCount)
+
+	// Page 2 finishes; the done prefix now extends through the already-complete page 3.
+	p2.successCount = 2
+	recordCompletedPages(hbd, p2)
+	s.Empty(hbd.PageToken, "all pages done -> resume token is the last page's (empty) next token")
+	s.Equal(3, hbd.CurrentPage)
+	s.Equal(4, hbd.SuccessCount) // p1:1 + p2:2 + p3:1
+	s.Equal(1, hbd.ErrorCount)   // p1:1
+}
+
 func (s *activitiesSuite) TestProcessAdminTask_UnknownOperation() {
 	ctx := context.Background()
 


### PR DESCRIPTION
## What changed?
Batch worker retries now run in place on the worker goroutine instead of being re-queued onto the task channel, and the heartbeat resume point now tracks the oldest not-yet-done page. Also clamps the worker count to at least 1 and stops offering empty tasks once a page is fully submitted.

## Why?
Re-queuing retries onto the worker-only task channel could deadlock the worker pool under a burst of retryable errors, leaving the activity heartbeating with no progress. Advancing the resume token while fetching ahead could also skip still-in-flight pages on restart.

## How did you test it?
- [x] built
- [x] covered by existing tests
- [x] added new unit test(s)

## Potential risks
Retries hold a worker slot while retrying, bounded by AttemptsOnRetryableError and the per-task timeout.