### PR TITLE
Backport scheduler visibility counts (#10611) to cloud/v1.32.0-157

### DIFF
--- a/chasm/lib/scheduler/helper_test.go
+++ b/chasm/lib/scheduler/helper_test.go
@@ -18,6 +18,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/common/testing/testvars"
+	"go.temporal.io/server/service/history/tasks"
 	legacyscheduler "go.temporal.io/server/service/worker/scheduler"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -278,12 +279,25 @@ func (e *testEnv) CloseTransaction() error {
 // HasTask returns true if the given task type was added with the given visibilityTime.
 func (e *testEnv) HasTask(task any, visibilityTime time.Time) bool {
 	taskType := reflect.TypeOf(task)
-	for _, tasks := range e.NodeBackend.TasksByCategory {
-		for _, t := range tasks {
+	for _, categoryTasks := range e.NodeBackend.TasksByCategory {
+		for _, t := range categoryTasks {
 			if reflect.TypeOf(t) == taskType &&
 				t.GetVisibilityTime().Equal(visibilityTime) {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+// HasTaskInCategory is like HasTask but scoped to a single queue category, to
+// distinguish tasks that share a physical type but land in different queues.
+func (e *testEnv) HasTaskInCategory(task any, category tasks.Category, visibilityTime time.Time) bool {
+	taskType := reflect.TypeOf(task)
+	for _, t := range e.NodeBackend.TasksByCategory[category] {
+		if reflect.TypeOf(t) == taskType &&
+			t.GetVisibilityTime().Equal(visibilityTime) {
+			return true
 		}
 	}
 	return false

--- a/chasm/lib/scheduler/invoker_process_buffer_task_test.go
+++ b/chasm/lib/scheduler/invoker_process_buffer_task_test.go
@@ -17,10 +17,12 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// A buffer of only deferred starts (Attempt=-1) must NOT emit a
-// ProcessBufferTask. Deferred starts wait on completion events, not on a
+// A buffer of only deferred starts (Attempt=-1) must NOT start a workflow or
+// emit a ProcessBufferTask. Deferred starts wait on completion events, not on a
 // wall-clock deadline, so emitting an immediate ProcessBufferTask would
-// spin-loop on a no-op processBuffer call.
+// spin-loop on a no-op processBuffer call. (A visibility-update task may fire
+// because the buffered count changed; the assertions below are scoped to
+// exclude it.)
 func TestInvoker_AddTasks_AllDeferredEmitsNothing(t *testing.T) {
 	env := newTestEnv(t)
 	ctx := env.MutableContext()
@@ -39,8 +41,8 @@ func TestInvoker_AddTasks_AllDeferredEmitsNothing(t *testing.T) {
 	invoker.EnqueueBufferedStarts(ctx, nil)
 	require.NoError(t, env.CloseTransaction())
 
-	require.False(t, env.HasTask(&tasks.ChasmTask{}, chasm.TaskScheduledTimeImmediate),
-		"all-deferred buffer must not emit any side-effect task")
+	require.False(t, env.HasTaskInCategory(&tasks.ChasmTask{}, tasks.CategoryTransfer, chasm.TaskScheduledTimeImmediate),
+		"all-deferred buffer must not emit an immediate workflow-start (execute) task")
 	require.False(t, env.HasTask(&tasks.ChasmTaskPure{}, chasm.TaskScheduledTimeImmediate),
 		"all-deferred buffer must not emit an immediate ProcessBufferTask")
 }

--- a/chasm/lib/scheduler/library.go
+++ b/chasm/lib/scheduler/library.go
@@ -66,6 +66,8 @@ func (l *Library) Components() []*chasm.RegistrableComponent {
 				executionStatusSearchAttribute,
 				scheduleNextActionTimeSearchAttribute,
 				scheduleIdleCloseTimeSearchAttribute,
+				scheduleRunningWorkflowCountSearchAttribute,
+				scheduleBufferedStartsCountSearchAttribute,
 			),
 			// Exposes Tweakables to scheduler components via the CHASM context
 			// (see tweakablesFromContext).

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -71,11 +71,15 @@ var (
 
 const ScheduleNextActionTimeName = "ScheduleNextActionTime"
 const ScheduleIdleCloseTimeName = "ScheduleIdleCloseTime"
+const ScheduleRunningWorkflowCountName = "ScheduleRunningWorkflowCount"
+const ScheduleBufferedStartsCountName = "ScheduleBufferedStartsCount"
 
 var (
-	executionStatusSearchAttribute        = chasm.NewSearchAttributeKeyword("ExecutionStatus", chasm.SearchAttributeFieldLowCardinalityKeyword01)
-	scheduleNextActionTimeSearchAttribute = chasm.NewSearchAttributeDateTime(ScheduleNextActionTimeName, chasm.SearchAttributeFieldDateTime01)
-	scheduleIdleCloseTimeSearchAttribute  = chasm.NewSearchAttributeDateTime(ScheduleIdleCloseTimeName, chasm.SearchAttributeFieldDateTime02)
+	executionStatusSearchAttribute              = chasm.NewSearchAttributeKeyword("ExecutionStatus", chasm.SearchAttributeFieldLowCardinalityKeyword01)
+	scheduleNextActionTimeSearchAttribute       = chasm.NewSearchAttributeDateTime(ScheduleNextActionTimeName, chasm.SearchAttributeFieldDateTime01)
+	scheduleIdleCloseTimeSearchAttribute        = chasm.NewSearchAttributeDateTime(ScheduleIdleCloseTimeName, chasm.SearchAttributeFieldDateTime02)
+	scheduleRunningWorkflowCountSearchAttribute = chasm.NewSearchAttributeInt(ScheduleRunningWorkflowCountName, chasm.SearchAttributeFieldInt01)
+	scheduleBufferedStartsCountSearchAttribute  = chasm.NewSearchAttributeInt(ScheduleBufferedStartsCountName, chasm.SearchAttributeFieldInt02)
 )
 
 var initialSerializedConflictToken = serializeConflictToken(scheduler.InitialConflictToken)
@@ -949,6 +953,16 @@ func (s *Scheduler) SearchAttributes(ctx chasm.Context) []chasm.SearchAttributeK
 		if s.IdleCloseTime != nil {
 			out = append(out, scheduleIdleCloseTimeSearchAttribute.Value(s.IdleCloseTime.AsTime()))
 		}
+
+		invoker := s.Invoker.Get(ctx)
+		runningWorkflowCount := int64(len(invoker.runningWorkflowExecutions()))
+		bufferedStartsCount := int64(len(invoker.GetBufferedStarts()) - len(invoker.recentActions()))
+
+		// Emitted even when zero so that exact and range queries both work.
+		out = append(out,
+			scheduleRunningWorkflowCountSearchAttribute.Value(runningWorkflowCount),
+			scheduleBufferedStartsCountSearchAttribute.Value(bufferedStartsCount),
+		)
 	}
 	return out
 }

--- a/chasm/lib/scheduler/scheduler_test.go
+++ b/chasm/lib/scheduler/scheduler_test.go
@@ -457,6 +457,114 @@ func TestSearchAttributes_IdleCloseTime(t *testing.T) {
 	})
 }
 
+func TestSearchAttributes_RunningWorkflowCount(t *testing.T) {
+
+	t.Run("counts only started, not-yet-completed workflows", func(t *testing.T) {
+		sched, ctx, _ := setupSchedulerForTest(t)
+
+		invoker := sched.Invoker.Get(ctx)
+		invoker.BufferedStarts = []*schedulespb.BufferedStart{
+			{RequestId: "waiting-1"},
+			{RequestId: "running-1", RunId: "run-1"},
+			{RequestId: "running-2", RunId: "run-2"},
+			{RequestId: "done-1", RunId: "run-3", Completed: &schedulespb.CompletedResult{
+				Status: enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			}},
+		}
+
+		sas := sched.SearchAttributes(ctx)
+		val, ok := findSearchAttribute(t, sas, scheduler.ScheduleRunningWorkflowCountName)
+		require.True(t, ok, "expected %s to be present", scheduler.ScheduleRunningWorkflowCountName)
+		require.Equal(t, int64(2), val)
+	})
+
+	t.Run("emits zero when there are no running workflows", func(t *testing.T) {
+		sched, ctx, _ := setupSchedulerForTest(t)
+		sched.Invoker.Get(ctx).BufferedStarts = nil
+
+		sas := sched.SearchAttributes(ctx)
+		val, ok := findSearchAttribute(t, sas, scheduler.ScheduleRunningWorkflowCountName)
+		require.True(t, ok, "expected %s to be present even when zero", scheduler.ScheduleRunningWorkflowCountName)
+		require.Equal(t, int64(0), val)
+	})
+
+	t.Run("closed does not emit", func(t *testing.T) {
+		sched, ctx, _ := setupSchedulerForTest(t)
+
+		sched.Closed = true
+		sched.Invoker.Get(ctx).BufferedStarts = []*schedulespb.BufferedStart{
+			{RequestId: "running-1", RunId: "run-1"},
+		}
+
+		sas := sched.SearchAttributes(ctx)
+		_, ok := findSearchAttribute(t, sas, scheduler.ScheduleRunningWorkflowCountName)
+		require.False(t, ok, "expected %s to be absent once closed", scheduler.ScheduleRunningWorkflowCountName)
+	})
+
+	t.Run("sentinel does not emit", func(t *testing.T) {
+		sentinel, ctx, _ := setupSentinelForTest(t)
+
+		sas := sentinel.SearchAttributes(ctx)
+		_, ok := findSearchAttribute(t, sas, scheduler.ScheduleRunningWorkflowCountName)
+		require.False(t, ok)
+	})
+}
+
+func TestSearchAttributes_BufferedStartsCount(t *testing.T) {
+
+	t.Run("counts only the not-yet-started backlog", func(t *testing.T) {
+		sched, ctx, _ := setupSchedulerForTest(t)
+
+		invoker := sched.Invoker.Get(ctx)
+		invoker.BufferedStarts = []*schedulespb.BufferedStart{
+			{RequestId: "waiting-1"},
+			{RequestId: "waiting-2"},
+			{RequestId: "running-1", RunId: "run-1"},
+			{RequestId: "done-1", RunId: "run-2", Completed: &schedulespb.CompletedResult{
+				Status: enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			}},
+		}
+
+		sas := sched.SearchAttributes(ctx)
+		val, ok := findSearchAttribute(t, sas, scheduler.ScheduleBufferedStartsCountName)
+		require.True(t, ok, "expected %s to be present", scheduler.ScheduleBufferedStartsCountName)
+		require.Equal(t, int64(2), val)
+	})
+
+	t.Run("emits zero when nothing is buffered", func(t *testing.T) {
+		sched, ctx, _ := setupSchedulerForTest(t)
+		sched.Invoker.Get(ctx).BufferedStarts = []*schedulespb.BufferedStart{
+			{RequestId: "running-1", RunId: "run-1"},
+		}
+
+		sas := sched.SearchAttributes(ctx)
+		val, ok := findSearchAttribute(t, sas, scheduler.ScheduleBufferedStartsCountName)
+		require.True(t, ok, "expected %s to be present even when zero", scheduler.ScheduleBufferedStartsCountName)
+		require.Equal(t, int64(0), val)
+	})
+
+	t.Run("closed does not emit", func(t *testing.T) {
+		sched, ctx, _ := setupSchedulerForTest(t)
+
+		sched.Closed = true
+		sched.Invoker.Get(ctx).BufferedStarts = []*schedulespb.BufferedStart{
+			{RequestId: "waiting-1"},
+		}
+
+		sas := sched.SearchAttributes(ctx)
+		_, ok := findSearchAttribute(t, sas, scheduler.ScheduleBufferedStartsCountName)
+		require.False(t, ok, "expected %s to be absent once closed", scheduler.ScheduleBufferedStartsCountName)
+	})
+
+	t.Run("sentinel does not emit", func(t *testing.T) {
+		sentinel, ctx, _ := setupSentinelForTest(t)
+
+		sas := sentinel.SearchAttributes(ctx)
+		_, ok := findSearchAttribute(t, sas, scheduler.ScheduleBufferedStartsCountName)
+		require.False(t, ok)
+	})
+}
+
 func findSearchAttribute(t *testing.T, sas []chasm.SearchAttributeKeyValue, alias string) (any, bool) {
 	t.Helper()
 	for _, sa := range sas {

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -4006,3 +4006,88 @@ func testScheduleNextActionTimeVisibility(t *testing.T, newContext contextFactor
 	s.True(v2Next.After(createTime.Add(-time.Second)),
 		"next action time must be >= createTime; got %v, createTime %v", v2Next, createTime)
 }
+
+// TestScheduleCountsVisibility asserts that the CHASM scheduler's
+// ScheduleRunningWorkflowCount and ScheduleBufferedStartsCount search attributes
+// are published to visibility and queryable through the frontend ListSchedules
+// API. A schedule that fires every second under BUFFER_ONE, started with a
+// workflow that blocks, settles into one running workflow with one fire buffered
+// behind it. The counts aren't surfaced on the list entry, so we assert via the
+// query rather than by reading the entry's SAs.
+func TestScheduleCountsVisibility(t *testing.T) {
+	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	newContext := chasmContextFactory
+
+	sid := testcore.RandomizeStr("sched-counts-v2")
+	wid := testcore.RandomizeStr("sched-counts-wf")
+	wt := testcore.RandomizeStr("sched-counts-wt")
+
+	// A workflow that holds open so a fire stays running while later fires buffer.
+	s.SdkWorker().RegisterWorkflowWithOptions(
+		func(ctx workflow.Context) error {
+			return workflow.Sleep(ctx, time.Hour)
+		},
+		workflow.RegisterOptions{Name: wt},
+	)
+
+	schedule := &schedulepb.Schedule{
+		Spec: &schedulepb.ScheduleSpec{
+			Interval: []*schedulepb.IntervalSpec{
+				{Interval: durationpb.New(1 * time.Second)},
+			},
+		},
+		Action: &schedulepb.ScheduleAction{
+			Action: &schedulepb.ScheduleAction_StartWorkflow{
+				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+					WorkflowId:   wid,
+					WorkflowType: &commonpb.WorkflowType{Name: wt},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				},
+			},
+		},
+		Policies: &schedulepb.SchedulePolicies{
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
+		},
+	}
+
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Schedule:   schedule,
+		Identity:   "test",
+		RequestId:  uuid.NewString(),
+	})
+	require.NoError(t, err)
+
+	// matchesQuery reports whether the schedule is returned when filtering on the
+	// given search-attribute query.
+	matchesQuery := func(query string) bool {
+		listResp, listErr := s.FrontendClient().ListSchedules(newContext(s.Context()), &workflowservice.ListSchedulesRequest{
+			Namespace:       s.Namespace().String(),
+			MaximumPageSize: 5,
+			Query:           query,
+		})
+		if listErr != nil {
+			return false
+		}
+		for _, ent := range listResp.Schedules {
+			if ent.ScheduleId == sid {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Starting the workflow and buffering the next fire takes a few seconds on top
+	// of visibility propagation, so allow 30s for each count to become queryable.
+	require.Eventually(t, func() bool {
+		return matchesQuery(fmt.Sprintf("%s >= 1", chasmscheduler.ScheduleRunningWorkflowCountName))
+	}, 30*time.Second, 500*time.Millisecond,
+		"schedule must be queryable by ScheduleRunningWorkflowCount >= 1")
+
+	require.Eventually(t, func() bool {
+		return matchesQuery(fmt.Sprintf("%s >= 1", chasmscheduler.ScheduleBufferedStartsCountName))
+	}, 30*time.Second, 500*time.Millisecond,
+		"schedule must be queryable by ScheduleBufferedStartsCount >= 1")
+}


### PR DESCRIPTION
Backports PR #10611 onto `cloud/v1.32.0-157`, cherry-picked cleanly from `main` (squash commit `7da25f311`).

### Commit
| Upstream PR | Description |
|---|---|
| #10611 | [Scheduler] Add `RunningWorkflowCount`/`BufferedStartsCount` to visibility |

