### PR TITLE
Make system.enableCancelActivityWorkerCommand namespace-scoped

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -200,7 +200,7 @@ in the consistent hash ring used by ringpop. Changing it may cause service disru
 		false,
 		`EnableActivityEagerExecution indicates if activity eager execution is enabled per namespace`,
 	)
-	EnableCancelActivityWorkerCommand = NewGlobalBoolSetting(
+	EnableCancelActivityWorkerCommand = NewNamespaceBoolSetting(
 		"system.enableCancelActivityWorkerCommand",
 		false,
 		`EnableCancelActivityWorkerCommand enables pushing activity cancellation to workers via Nexus worker commands`,

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -372,7 +372,7 @@ type Config struct {
 	EnableCrossNamespaceCommands      dynamicconfig.BoolPropertyFn
 	EnableActivityEagerExecution      dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	EnableActivityRetryStampIncrement dynamicconfig.BoolPropertyFn
-	EnableCancelActivityWorkerCommand dynamicconfig.BoolPropertyFn
+	EnableCancelActivityWorkerCommand dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	EnableEagerWorkflowStart          dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	NamespaceCacheRefreshInterval     dynamicconfig.DurationPropertyFn
 

--- a/service/history/outbound_queue_active_task_executor.go
+++ b/service/history/outbound_queue_active_task_executor.go
@@ -104,7 +104,7 @@ func (e *outboundQueueActiveTaskExecutor) Execute(
 	case *tasks.ChasmTask:
 		return respond(e.executeChasmSideEffectTask(ctx, task))
 	case *tasks.WorkerCommandsTask:
-		return respond(e.workerCommandsTaskDispatcher.execute(ctx, task, executable.Attempt()))
+		return respond(e.workerCommandsTaskDispatcher.execute(ctx, task, executable.Attempt(), namespaceTag.Value))
 	}
 
 	return respond(queueserrors.NewUnprocessableTaskError(fmt.Sprintf("unknown task type '%T'", task)))

--- a/service/history/worker_commands_task_dispatcher.go
+++ b/service/history/worker_commands_task_dispatcher.go
@@ -77,6 +77,7 @@ func (d *workerCommandsTaskDispatcher) execute(
 	ctx context.Context,
 	task *tasks.WorkerCommandsTask,
 	attempt int,
+	namespaceName string,
 ) error {
 	if attempt > workerCommandsMaxTaskAttempt {
 		d.logger.Info("Worker commands task exceeded max attempts, dropping",
@@ -89,7 +90,7 @@ func (d *workerCommandsTaskDispatcher) execute(
 		return nil
 	}
 
-	if !d.config.EnableCancelActivityWorkerCommand() {
+	if !d.config.EnableCancelActivityWorkerCommand(namespaceName) {
 		d.logger.Info("Worker commands feature disabled, dropping task",
 			tag.WorkflowID(task.WorkflowID),
 			tag.WorkflowRunID(task.RunID),

--- a/service/history/worker_commands_task_dispatcher.go
+++ b/service/history/worker_commands_task_dispatcher.go
@@ -92,6 +92,7 @@ func (d *workerCommandsTaskDispatcher) execute(
 
 	if !d.config.EnableCancelActivityWorkerCommand(namespaceName) {
 		d.logger.Info("Worker commands feature disabled, dropping task",
+			tag.WorkflowNamespace(namespaceName),
 			tag.WorkflowID(task.WorkflowID),
 			tag.WorkflowRunID(task.RunID),
 			tag.NewStringTag("control_queue", task.Destination),

--- a/service/history/worker_commands_task_dispatcher_test.go
+++ b/service/history/worker_commands_task_dispatcher_test.go
@@ -44,27 +44,27 @@ func requireMetricValue(t *testing.T, snap map[string][]*metricstest.CapturedRec
 func TestExecute_FeatureFlagOff_DropsTask(t *testing.T) {
 	d := &workerCommandsTaskDispatcher{
 		config: &configs.Config{
-			EnableCancelActivityWorkerCommand: func() bool { return false },
+			EnableCancelActivityWorkerCommand: func(string) bool { return false },
 		},
 		logger: log.NewNoopLogger(),
 	}
 
 	task := testWorkerCommandsTask()
-	err := d.execute(context.Background(), task, 1 /* attempt */)
+	err := d.execute(context.Background(), task, 1 /* attempt */, "test-namespace")
 	require.NoError(t, err, "task should be silently dropped when feature flag is off")
 }
 
 func TestExecute_EmptyCommands_DropsTask(t *testing.T) {
 	d := &workerCommandsTaskDispatcher{
 		config: &configs.Config{
-			EnableCancelActivityWorkerCommand: func() bool { return true },
+			EnableCancelActivityWorkerCommand: func(string) bool { return true },
 		},
 		logger: log.NewNoopLogger(),
 	}
 
 	task := testWorkerCommandsTask()
 	task.Commands = nil
-	err := d.execute(context.Background(), task, 1 /* attempt */)
+	err := d.execute(context.Background(), task, 1 /* attempt */, "test-namespace")
 	require.NoError(t, err, "task with no commands should be dropped")
 }
 
@@ -75,14 +75,14 @@ func TestExecute_ExceedsMaxAttempts_DropsTask(t *testing.T) {
 
 	d := &workerCommandsTaskDispatcher{
 		config: &configs.Config{
-			EnableCancelActivityWorkerCommand: func() bool { return true },
+			EnableCancelActivityWorkerCommand: func(string) bool { return true },
 		},
 		metricsHandler: metricsHandler,
 		logger:         log.NewNoopLogger(),
 	}
 
 	task := testWorkerCommandsTask()
-	err := d.execute(context.Background(), task, workerCommandsMaxTaskAttempt+1)
+	err := d.execute(context.Background(), task, workerCommandsMaxTaskAttempt+1, "test-namespace")
 	require.NoError(t, err, "task should be dropped when max attempts exceeded")
 
 	requireMetricValue(t, capture.Snapshot(), "max_attempts_exceeded")
@@ -98,7 +98,7 @@ func TestExecute_AtMaxAttempt_StillExecutes(t *testing.T) {
 	d := &workerCommandsTaskDispatcher{
 		matchingClient: mockClient,
 		config: &configs.Config{
-			EnableCancelActivityWorkerCommand: func() bool { return true },
+			EnableCancelActivityWorkerCommand: func(string) bool { return true },
 		},
 		metricsHandler: metricsHandler,
 		logger:         log.NewNoopLogger(),
@@ -120,7 +120,7 @@ func TestExecute_AtMaxAttempt_StillExecutes(t *testing.T) {
 		}, nil)
 
 	task := testWorkerCommandsTask()
-	err := d.execute(context.Background(), task, workerCommandsMaxTaskAttempt)
+	err := d.execute(context.Background(), task, workerCommandsMaxTaskAttempt, "test-namespace")
 	require.NoError(t, err, "task at exactly max attempt should still execute")
 
 	requireMetricValue(t, capture.Snapshot(), "success")
@@ -136,7 +136,7 @@ func TestExecute_DispatchSuccess(t *testing.T) {
 	d := &workerCommandsTaskDispatcher{
 		matchingClient: mockClient,
 		config: &configs.Config{
-			EnableCancelActivityWorkerCommand: func() bool { return true },
+			EnableCancelActivityWorkerCommand: func(string) bool { return true },
 		},
 		metricsHandler: metricsHandler,
 		logger:         log.NewNoopLogger(),
@@ -162,7 +162,7 @@ func TestExecute_DispatchSuccess(t *testing.T) {
 		})
 
 	task := testWorkerCommandsTask()
-	err := d.execute(context.Background(), task, 1 /* attempt */)
+	err := d.execute(context.Background(), task, 1 /* attempt */, "test-namespace")
 	require.NoError(t, err)
 
 	require.NotNil(t, capturedReq)
@@ -183,7 +183,7 @@ func TestExecute_DispatchRPCError(t *testing.T) {
 	d := &workerCommandsTaskDispatcher{
 		matchingClient: mockClient,
 		config: &configs.Config{
-			EnableCancelActivityWorkerCommand: func() bool { return true },
+			EnableCancelActivityWorkerCommand: func(string) bool { return true },
 		},
 		metricsHandler: metricsHandler,
 		logger:         log.NewNoopLogger(),
@@ -193,7 +193,7 @@ func TestExecute_DispatchRPCError(t *testing.T) {
 		nil, errors.New("connection refused"))
 
 	task := testWorkerCommandsTask()
-	err := d.execute(context.Background(), task, 1 /* attempt */)
+	err := d.execute(context.Background(), task, 1 /* attempt */, "test-namespace")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "connection refused")
 
@@ -210,7 +210,7 @@ func TestExecute_UpstreamTimeout(t *testing.T) {
 	d := &workerCommandsTaskDispatcher{
 		matchingClient: mockClient,
 		config: &configs.Config{
-			EnableCancelActivityWorkerCommand: func() bool { return true },
+			EnableCancelActivityWorkerCommand: func(string) bool { return true },
 		},
 		metricsHandler: metricsHandler,
 		logger:         log.NewNoopLogger(),
@@ -224,7 +224,7 @@ func TestExecute_UpstreamTimeout(t *testing.T) {
 		}, nil)
 
 	task := testWorkerCommandsTask()
-	err := d.execute(context.Background(), task, 1 /* attempt */)
+	err := d.execute(context.Background(), task, 1 /* attempt */, "test-namespace")
 	require.Error(t, err)
 
 	var he *nexus.HandlerError

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -4672,7 +4672,7 @@ func (ms *MutableStateImpl) AddWorkerCommandsTasks(commands []*workerpb.WorkerCo
 // GenerateActivityCancelCommandsForClose generates WorkerCommandsTasks to cancel all
 // in-flight activities that have a worker control queue.
 func (ms *MutableStateImpl) GenerateActivityCancelCommandsForClose() error {
-	if !ms.config.EnableCancelActivityWorkerCommand() {
+	if !ms.config.EnableCancelActivityWorkerCommand(ms.namespaceEntry.Name().String()) {
 		return nil
 	}
 

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -8094,7 +8094,7 @@ func TestGenerateActivityCancelCommandsForClose(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockEventsCache := events.NewMockCache(ctrl)
 			mockConfig := tests.NewDynamicConfig()
-			mockConfig.EnableCancelActivityWorkerCommand = dynamicconfig.GetBoolPropertyFn(tc.featureEnabled)
+			mockConfig.EnableCancelActivityWorkerCommand = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(tc.featureEnabled)
 
 			mockShard := shard.NewTestContext(
 				ctrl,

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -584,7 +584,7 @@ func (r *TaskGeneratorImpl) GenerateActivityRetryTasks(activityInfo *persistence
 }
 
 func (r *TaskGeneratorImpl) GenerateWorkerCommandsTasks(commands []*workerpb.WorkerCommand, controlQueue string) error {
-	if !r.config.EnableCancelActivityWorkerCommand() {
+	if !r.config.EnableCancelActivityWorkerCommand(r.mutableState.GetNamespaceEntry().Name().String()) {
 		return nil
 	}
 

--- a/service/history/workflow/task_generator_test.go
+++ b/service/history/workflow/task_generator_test.go
@@ -1148,6 +1148,7 @@ func TestGenerateWorkerCommandsTasks(t *testing.T) {
 			mutableState.EXPECT().GetWorkflowKey().Return(definition.NewWorkflowKey(
 				tests.NamespaceID.String(), tests.WorkflowID, tests.RunID,
 			)).AnyTimes()
+			mutableState.EXPECT().GetNamespaceEntry().Return(tests.GlobalNamespaceEntry).AnyTimes()
 
 			var capturedTasks []tasks.Task
 			if tc.expectTask {
@@ -1157,7 +1158,7 @@ func TestGenerateWorkerCommandsTasks(t *testing.T) {
 			}
 
 			cfg := &configs.Config{
-				EnableCancelActivityWorkerCommand: func() bool { return tc.featureEnabled },
+				EnableCancelActivityWorkerCommand: func(string) bool { return tc.featureEnabled },
 			}
 
 			taskGenerator := NewTaskGenerator(nil, mutableState, cfg, nil, log.NewTestLogger())


### PR DESCRIPTION
## What
Changes `system.enableCancelActivityWorkerCommand` from a global dynamic config setting to a namespace-scoped setting.

## Why
To control rollout per namespace.

## How did you test it?
Updated unit tests.