### PR TITLE
Bump defaultCliVersion to 1.7.2 for v1.31.1 admin-tools

### DIFF
--- a/.github/actions/build-docker-images/scripts/main.go
+++ b/.github/actions/build-docker-images/scripts/main.go
@@ -14,7 +14,7 @@ import (
 var validArchs = []string{"amd64", "arm64"}
 
 // defaultCliVersion should be updated to the latest cli version
-const defaultCliVersion = "1.7.1"
+const defaultCliVersion = "1.7.2"
 
 func main() {
 	if len(os.Args) < 2 {


### PR DESCRIPTION
## What changed?
Bumps `defaultCliVersion` from `"1.7.1"` to `"1.7.2"` in `.github/actions/build-docker-images/scripts/main.go`.
This is the version of the `temporal` CLI binary downloaded and bundled into the admin-tools Docker image at build time.

## Why?
Final step of the OSS server v1.31.1 patch. CLI v1.7.2 was just released ([temporalio/cli#1088](https://github.com/temporalio/cli/pull/1088)) and bumps `go.temporal.io/server v1.31.0 → v1.31.1`, picking up the v1.31.1 security fixes transitively:

  - `apache/thrift v0.21.0 → v0.23.0` (CVE-2026-41602)
  - `golang.org/x/crypto v0.46.0 → v0.52.0` (GO-2026-5005..5023)
  - `golang.org/x/net v0.48.0 → v0.55.0` (GO-2026-5026, etc.)
  - Go toolchain `1.26.3 → 1.26.4` (stdlib HIGH CVEs)

 These findings show up in grype scans of `temporaliotest/admin-tools:sha-<latest>` because the bundled CLI binary at v1.7.1 was built before our v1.31.1 cherry-picks. Bumping to v1.7.2 clears them.


## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

