### PR TITLE
Cherry-pick: Encode duration as bigint for pgx simple protocol (#10529)

### DIFF
--- a/common/persistence/sql/sqlplugin/postgresql/driver/pgx.go
+++ b/common/persistence/sql/sqlplugin/postgresql/driver/pgx.go
@@ -1,15 +1,46 @@
 package driver
 
 import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
-	_ "github.com/jackc/pgx/v5/stdlib" // register pgx driver for sqlx
+	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/jmoiron/sqlx"
 )
 
 type PGXDriver struct{}
 
 func (p *PGXDriver) CreateConnection(dsn string) (*sqlx.DB, error) {
-	return sqlx.Connect("pgx", dsn)
+	cfg, err := pgx.ParseConfig(dsn)
+	if err != nil {
+		return nil, err
+	}
+	connector := stdlib.GetConnector(*cfg, stdlib.OptionAfterConnect(registerCustomTypes))
+	db := sqlx.NewDb(sql.OpenDB(connector), "pgx")
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
+// registerCustomTypes overrides pgx's default type mapping.
+//
+// By default pgx maps time.Duration to the interval type. Under the simple
+// query protocol (the path users land on behind PgBouncer in transaction
+// pooling) a time.Duration is encoded as an interval literal like "00:00:05".
+// Temporal stores all durations as bigint nanoseconds, so that literal is
+// rejected. Encoding time.Duration as int8 (bigint in PostgreSQL) instead
+// results in the integer nanosecond count
+func registerCustomTypes(_ context.Context, conn *pgx.Conn) error {
+	// pgx tracks the value type and the pointer type separately, so
+	// both must be remapped.
+	conn.TypeMap().RegisterDefaultPgType(time.Duration(0), "int8")
+	conn.TypeMap().RegisterDefaultPgType((*time.Duration)(nil), "int8")
+	return nil
 }
 
 func (p *PGXDriver) IsDupEntryError(err error) bool {

--- a/common/persistence/sql/sqlplugin/tests/visibility.go
+++ b/common/persistence/sql/sqlplugin/tests/visibility.go
@@ -1341,19 +1341,25 @@ func (s *visibilitySuite) newRandomVisibilityRow(
 	historyLength *int64,
 ) sqlplugin.VisibilityRow {
 	s.version++
+	var executionDuration *time.Duration
+	if closeTime != nil {
+		d := closeTime.Sub(executionTime)
+		executionDuration = &d
+	}
 	return sqlplugin.VisibilityRow{
-		NamespaceID:      namespaceID.String(),
-		RunID:            runID.String(),
-		WorkflowTypeName: workflowTypeName,
-		WorkflowID:       workflowID,
-		StartTime:        startTime,
-		ExecutionTime:    executionTime,
-		Status:           status,
-		CloseTime:        closeTime,
-		HistoryLength:    historyLength,
-		Memo:             shuffle.Bytes(testVisibilityData),
-		Encoding:         testVisibilityEncoding,
-		Version:          s.version,
+		NamespaceID:       namespaceID.String(),
+		RunID:             runID.String(),
+		WorkflowTypeName:  workflowTypeName,
+		WorkflowID:        workflowID,
+		StartTime:         startTime,
+		ExecutionTime:     executionTime,
+		Status:            status,
+		CloseTime:         closeTime,
+		HistoryLength:     historyLength,
+		ExecutionDuration: executionDuration,
+		Memo:              shuffle.Bytes(testVisibilityData),
+		Encoding:          testVisibilityEncoding,
+		Version:           s.version,
 	}
 }
 

--- a/common/persistence/tests/visibility_persistence_suite.go
+++ b/common/persistence/tests/visibility_persistence_suite.go
@@ -1138,6 +1138,7 @@ func (s *VisibilityPersistenceSuite) assertClosedExecutionEquals(
 	s.Equal(persistence.UnixMilliseconds(req.CloseTime), persistence.UnixMilliseconds(timestamp.TimeValue(resp.GetCloseTime())))
 	s.Equal(req.Status, resp.GetStatus())
 	s.Equal(req.HistoryLength, resp.HistoryLength)
+	s.Equal(req.ExecutionDuration, resp.GetExecutionDuration().AsDuration())
 }
 
 func (s *VisibilityPersistenceSuite) assertOpenExecutionEquals(


### PR DESCRIPTION
## What changed?
Cherry-pick of upstream main commit 3c7e505e05b31f732ba7124fdf5154a11c06173a onto release/v1.29.x

See https://github.com/temporalio/temporal/pull/10529

## Why?
See https://github.com/temporalio/temporal/pull/10529. Cherry-pick was not clean, so there were some changes here:
1. pgx.go: release branch has no CreateRefreshableConnection
2. visibility.go: rewrote new(closeTime.Sub(executionTime)) (Go 1.26 new(expr))
3. setup.go / postgresql_test.go: dropped test only changes that conflicted

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Main risk is that some of the conflicting changes were not merged right
