### PR TITLE
Bump ServerVersion to 1.29.7

### DIFF
--- a/common/headers/version_checker.go
+++ b/common/headers/version_checker.go
@@ -23,7 +23,7 @@ const (
 
 	// ServerVersion value can be changed by the create-tag Github workflow.
 	// If you change the var name or move it, be sure to update the workflow.
-	ServerVersion = "1.29.6"
+	ServerVersion = "1.29.7"
 
 	// SupportedServerVersions is used by CLI and inter role communication.
 	SupportedServerVersions = ">=1.0.0 <2.0.0"


### PR DESCRIPTION
## What changed?
Bumps `ServerVersion` from `1.29.6` to `1.29.7` in `common/headers/version_checker.go`

## Why?
Preparing for the v1.29.7 OSS patch release.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
