### PR TITLE
Enabled ActivityEagerExecution By Default

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -197,7 +197,7 @@ in the consistent hash ring used by ringpop. Changing it may cause service disru
 	)
 	EnableActivityEagerExecution = NewNamespaceBoolSetting(
 		"system.enableActivityEagerExecution",
-		false,
+		true,
 		`EnableActivityEagerExecution indicates if activity eager execution is enabled per namespace`,
 	)
 	EnableCancelActivityWorkerCommand = NewNamespaceBoolSetting(

--- a/tests/versioning_test.go
+++ b/tests/versioning_test.go
@@ -2391,9 +2391,7 @@ func (s *VersioningIntegSuite) dispatchActivityCompatible(env *testcore.TestEnv)
 }
 
 func (s *VersioningIntegSuite) TestDispatchActivityEager() {
-	env := s.setupEnv(
-		testcore.WithDynamicConfig(dynamicconfig.EnableActivityEagerExecution, true),
-	)
+	env := s.setupEnv()
 
 	tq := testcore.RandomizeStr(s.T().Name())
 	v1 := s.prefixed("v1")

--- a/tests/xdc/stream_based_replication_test.go
+++ b/tests/xdc/stream_based_replication_test.go
@@ -1105,6 +1105,10 @@ func (s *streamBasedReplicationTestSuite) TestPassiveActivityRetryTimerReplicati
 	s.NoError(err)
 	defer sdkWorker.Stop()
 
+	// Override dynamic config to disable eager activity execution since we are asserting transfer active task creation in this test.
+	cleanup := s.clusters[0].OverrideDynamicConfig(s.T(), dynamicconfig.EnableActivityEagerExecution, false)
+	defer cleanup()
+
 	workflowRun, err := sdkClient.ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
 		ID:                 workflowID,
 		TaskQueue:          taskQueue,


### PR DESCRIPTION
## What changed?
- Set default value of EnableActivityEagerExecution dc flag to true

## Why?
- It has been enabled in production for a long time, now enabling it by default for OSS

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- EnableActivityEagerExecution is not compatible with versioning features. and need versioning crew to verify if existing check in the code is good enough and will reject eager activity execution request when versioning is used. If not, we need to explicit call out this breaking change in 1.32 release.
