### PR TITLE
TS: delete validate time skipping config in history service

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -700,19 +700,30 @@ func (wh *WorkflowHandler) prepareStartWorkflowRequest(
 }
 
 func (wh *WorkflowHandler) validateTimeSkippingConfig(
-	timeSkippingConfig *workflowpb.TimeSkippingConfig,
-	namespaceName namespace.Name,
+	tsc *workflowpb.TimeSkippingConfig,
+	ns namespace.Name,
 ) error {
-	if timeSkippingConfig == nil {
+	if tsc == nil {
 		return nil
 	}
-
 	// if this feature is not enabled, we don't allow setting any related config
-	if !wh.config.TimeSkippingEnabled(namespaceName.String()) {
+	if !wh.config.TimeSkippingEnabled(ns.String()) {
 		return serviceerror.NewUnimplementedf(
 			"The Time-Skipping feature is not enabled for namespace %s",
-			namespaceName,
+			ns.String(),
 		)
+	}
+
+	if !tsc.GetEnabled() {
+		if tsc.GetBound() != nil {
+			return serviceerror.NewInvalidArgument("time_skipping_config: cannot set bound when enabled is false")
+		}
+		return nil
+	}
+	if b, ok := tsc.GetBound().(*workflowpb.TimeSkippingConfig_MaxElapsedDuration); ok {
+		if b.MaxElapsedDuration.AsDuration() < 0 {
+			return serviceerror.NewInvalidArgument("time_skipping_config: max_elapsed_duration must be positive")
+		}
 	}
 
 	return nil

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -3398,6 +3398,7 @@ func (s *WorkflowHandlerSuite) TestValidateTimeSkippingConfig() {
 	config := s.newConfig()
 	wh := s.getWorkflowHandler(config)
 	var unimplementedErr *serviceerror.Unimplemented
+	var invalidArgumentErr *serviceerror.InvalidArgument
 
 	// nil config is valid
 	s.Require().NoError(wh.validateTimeSkippingConfig(nil, s.testNamespace))
@@ -3415,6 +3416,12 @@ func (s *WorkflowHandlerSuite) TestValidateTimeSkippingConfig() {
 
 	// config with enabled=true and dynamic config enabled is valid
 	s.Require().NoError(wh.validateTimeSkippingConfig(&workflowpb.TimeSkippingConfig{Enabled: true}, s.testNamespace))
+
+	s.Require().ErrorAs(wh.validateTimeSkippingConfig(&workflowpb.TimeSkippingConfig{
+		Enabled: false, Bound: &workflowpb.TimeSkippingConfig_MaxElapsedDuration{MaxElapsedDuration: durationpb.New(time.Second * 10)}}, s.testNamespace), &invalidArgumentErr)
+
+	s.Require().ErrorAs(wh.validateTimeSkippingConfig(&workflowpb.TimeSkippingConfig{
+		Enabled: true, Bound: &workflowpb.TimeSkippingConfig_MaxElapsedDuration{MaxElapsedDuration: durationpb.New(time.Second * -10)}}, s.testNamespace), &invalidArgumentErr)
 }
 
 // TestExecuteMultiOperation_TimeSkipping_DCDisabled verifies that when the DC gate is off,

--- a/service/history/api/updateworkflowoptions/api.go
+++ b/service/history/api/updateworkflowoptions/api.go
@@ -123,21 +123,6 @@ func Invoke(
 	return ret, nil
 }
 
-func validateTimeSkippingConfig(cfg *workflowpb.TimeSkippingConfig) error {
-	if !cfg.GetEnabled() {
-		if cfg.GetBound() != nil {
-			return serviceerror.NewInvalidArgument("time_skipping_config: cannot set bound when enabled is false")
-		}
-		return nil
-	}
-	if b, ok := cfg.GetBound().(*workflowpb.TimeSkippingConfig_MaxElapsedDuration); ok {
-		if b.MaxElapsedDuration.AsDuration() < 0 {
-			return serviceerror.NewInvalidArgument("time_skipping_config: max_elapsed_duration must be positive")
-		}
-	}
-	return nil
-}
-
 // MergeAndApply merges the requested options mentioned in the field mask with the current options in the mutable state
 // and applies the changes to the mutable state. Returns the merged options and a boolean indicating if there were any changes.
 func MergeAndApply(

--- a/service/history/api/updateworkflowoptions/api_test.go
+++ b/service/history/api/updateworkflowoptions/api_test.go
@@ -11,7 +11,6 @@ import (
 	deploymentpb "go.temporal.io/api/deployment/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
-	"go.temporal.io/api/serviceerror"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/historyservice/v1"
@@ -332,58 +331,6 @@ func (s *updateWorkflowOptionsSuite) TestInvoke_Success() {
 	s.NoError(err)
 	s.NotNil(resp)
 	proto.Equal(expectedOverrideOptions, resp.GetWorkflowExecutionOptions())
-}
-
-func TestValidateTimeSkippingConfig(t *testing.T) {
-	tenMin := durationpb.New(10 * time.Minute)
-	negativeElapsed := durationpb.New(-1 * time.Minute)
-	maxElapsedTen := &workflowpb.TimeSkippingConfig_MaxElapsedDuration{MaxElapsedDuration: tenMin}
-	maxElapsedNegative := &workflowpb.TimeSkippingConfig_MaxElapsedDuration{MaxElapsedDuration: negativeElapsed}
-
-	tcs := []struct {
-		name    string
-		config  *workflowpb.TimeSkippingConfig
-		wantErr bool
-	}{
-		{
-			name:   "nil config",
-			config: nil,
-		},
-		{
-			name:    "disabled with bound is rejected",
-			config:  &workflowpb.TimeSkippingConfig{Enabled: false, Bound: maxElapsedTen},
-			wantErr: true,
-		},
-		{
-			name:   "disabled with no bound",
-			config: &workflowpb.TimeSkippingConfig{Enabled: false},
-		},
-		{
-			name:   "enabled, no bound",
-			config: &workflowpb.TimeSkippingConfig{Enabled: true},
-		},
-		{
-			name:   "enabled, positive max_elapsed_duration",
-			config: &workflowpb.TimeSkippingConfig{Enabled: true, Bound: maxElapsedTen},
-		},
-		{
-			name:    "enabled, negative max_elapsed_duration",
-			config:  &workflowpb.TimeSkippingConfig{Enabled: true, Bound: maxElapsedNegative},
-			wantErr: true,
-		},
-	}
-
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			err := validateTimeSkippingConfig(tc.config)
-			if tc.wantErr {
-				var invalidArg *serviceerror.InvalidArgument
-				require.ErrorAs(t, err, &invalidArg)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
 }
 
 func TestMergeAndApply_TimeSkippingConfig(t *testing.T) {


### PR DESCRIPTION
## What changed?
Migrated the time skipping config validation from the history service to the frontend service.


## Why?
This validation was originally introduced to check the max skip duration in the time skipping config against the accumulated skip duration in mutable state. Now that the max skip duration field has been removed, the remaining validation logic belongs in the frontend service as standard input validation.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [X] added new unit test(s)
- [X] added new functional test(s)

