### PR TITLE
fix: prevent batcher activity deadlock when retrying failed tasks (#10630)

### DIFF
--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -113,6 +113,25 @@ func (p *page) done() bool {
 	return p.successCount+p.errorCount == len(p.executionInfos)
 }
 
+// recordCompletedPages accumulates stats for every page that is now fully done — the given
+// page and, transitively, all earlier ones — and advances the heartbeat resume point to
+// just past the last fully-done page, i.e. the oldest page that is NOT yet done.
+//
+// The resume point must not run ahead of completion. Pages are fetched ahead as soon as the
+// current page is fully *submitted* (not *done*), so advancing PageToken at fetch time would
+// let a restart resume past still-in-flight pages and silently skip them. Advancing only
+// through the contiguous fully-done prefix here guarantees a restart re-fetches the oldest
+// incomplete page; already-counted pages are not re-fetched, so stats are not double-counted.
+func recordCompletedPages(hbd *HeartBeatDetails, resultPage *page) {
+	for pg := resultPage; pg != nil && pg.done(); pg = pg.next {
+		hbd.SuccessCount += pg.successCount
+		hbd.ErrorCount += pg.errorCount
+		hbd.CurrentPage = pg.pageNumber + 1
+		hbd.PageToken = pg.nextPageToken
+		pg.prev = nil
+	}
+}
+
 // fetchPage fetches a new page of workflow executions
 func fetchPage(
 	ctx context.Context,
@@ -177,8 +196,10 @@ func (a *activities) processWorkflowsWithProactiveFetching(
 	heartbeatTicker := time.NewTicker(defaultActivityHeartBeatTimeout / 4)
 	defer heartbeatTicker.Stop()
 
-	// Start worker processors
-	for range config.concurrency {
+	// Start worker processors. Use the clamped `concurrency` (min 1), not
+	// config.concurrency: if the dynamic config resolves concurrency to 0, no workers
+	// would start and the activity would wait forever.
+	for range concurrency {
 		go startWorkerProcessor(ctx, taskCh, respCh, rateLimiter, sdkClient, a.FrontendClient, metricsHandler, logger)
 	}
 
@@ -219,13 +240,21 @@ func (a *activities) processWorkflowsWithProactiveFetching(
 			p.next = nextPage
 			nextPage.prev = p
 			p = nextPage
+		}
 
-			hbd.CurrentPage = p.pageNumber
-			hbd.PageToken = p.nextPageToken
+		// Only offer work to the pool while the current page still has unsubmitted
+		// executions. Otherwise disable this case with a nil channel so the loop does not
+		// spin submitting empty tasks (which would also push submittedCount past the page
+		// size) while waiting for in-flight tasks and earlier pages to finish.
+		var submitCh chan task
+		var nextTask task
+		if p.submittedCount < len(p.executionInfos) {
+			submitCh = taskCh
+			nextTask = p.nextTask()
 		}
 
 		select {
-		case taskCh <- p.nextTask():
+		case submitCh <- nextTask:
 			p.submittedCount++
 
 		case result := <-respCh:
@@ -236,13 +265,7 @@ func (a *activities) processWorkflowsWithProactiveFetching(
 				resultPage.errorCount++
 			}
 
-			// Update heartbeat details if this page and all previous pages are complete
-			// Find all pages from the current one on that are done, record their stats, and unlink them.
-			for page := resultPage; page != nil && page.done(); page = page.next {
-				hbd.SuccessCount += page.successCount
-				hbd.ErrorCount += page.errorCount
-				page.prev = nil
-			}
+			recordCompletedPages(&hbd, resultPage)
 
 		case <-heartbeatTicker.C:
 			// Send periodic heartbeat to prevent timeout during slow processing
@@ -440,184 +463,219 @@ func (a *activities) startTaskProcessor(
 			if isDone(ctx) {
 				return
 			}
-			var err error
-
 			if task.executionInfo == nil {
 				continue
 			}
 
-			// Handle admin batch operations
-			if batchOperation.AdminRequest != nil {
-				err = a.processAdminTask(ctx, batchOperation, task, limiter)
-				a.handleTaskResult(batchOperation, task, err, taskCh, respCh, metricsHandler, logger)
-				continue
+			// Retry retryable failures in place on this worker goroutine, then emit exactly
+			// one response per task below. We must NOT re-queue the task onto taskCh: the
+			// worker goroutines are the only consumers of taskCh, so under a burst of
+			// retryable errors they would all block on the re-enqueue send while the buffer
+			// is full and no consumer is left to drain it -> the activity wedges (it keeps
+			// heartbeating but makes no progress, with no operations issued). Emitting one
+			// response per dispatched task also guarantees the page can reach completion,
+			// instead of a single never-acknowledged task wedging the whole batch forever.
+			for {
+				var err error
+				if batchOperation.AdminRequest != nil {
+					err = a.processAdminTask(ctx, batchOperation, task, limiter)
+				} else {
+					switch operation := batchOperation.Request.Operation.(type) {
+					case *workflowservice.StartBatchOperationRequest_TerminationOperation:
+						err = processTask(ctx, limiter, task,
+							func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
+								return sdkClient.TerminateWorkflow(ctx, executionInfo.Execution.WorkflowId, executionInfo.Execution.RunId, batchOperation.Request.Reason)
+							})
+					case *workflowservice.StartBatchOperationRequest_CancellationOperation:
+						err = processTask(ctx, limiter, task,
+							func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
+								return sdkClient.CancelWorkflow(ctx, executionInfo.Execution.WorkflowId, executionInfo.Execution.RunId)
+							})
+					case *workflowservice.StartBatchOperationRequest_SignalOperation:
+						err = processTask(ctx, limiter, task,
+							func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
+								_, err = frontendClient.SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
+									Namespace:         namespace,
+									WorkflowExecution: executionInfo.Execution,
+									SignalName:        operation.SignalOperation.GetSignal(),
+									Input:             operation.SignalOperation.GetInput(),
+									Identity:          operation.SignalOperation.GetIdentity(),
+								})
+								return err
+							})
+					case *workflowservice.StartBatchOperationRequest_DeletionOperation:
+						err = processTask(ctx, limiter, task,
+							func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
+								_, err := frontendClient.DeleteWorkflowExecution(ctx, &workflowservice.DeleteWorkflowExecutionRequest{
+									Namespace:         namespace,
+									WorkflowExecution: executionInfo.Execution,
+								})
+								return err
+							})
+					case *workflowservice.StartBatchOperationRequest_ResetOperation:
+						err = processTask(ctx, limiter, task,
+							func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
+								var eventID int64
+								var err error
+								//nolint:staticcheck // SA1019: worker versioning v0.31
+								var resetReapplyType enumspb.ResetReapplyType
+								var resetReapplyExcludeTypes []enumspb.ResetReapplyExcludeType
+								if operation.ResetOperation.Options != nil {
+									// Using ResetOptions
+									// Note: getResetEventIDByOptions may modify workflowExecution.RunId, if reset should be to a prior run
+									//nolint:staticcheck // SA1019: worker versioning v0.31
+									eventID, err = getResetEventIDByOptions(ctx, operation.ResetOperation.Options, namespace, executionInfo.Execution, frontendClient, logger)
+									//nolint:staticcheck // SA1019: worker versioning v0.31
+									resetReapplyType = operation.ResetOperation.Options.ResetReapplyType
+									//nolint:staticcheck // SA1019: worker versioning v0.31
+									resetReapplyExcludeTypes = operation.ResetOperation.Options.ResetReapplyExcludeTypes
+								} else {
+									// Old fields
+									//nolint:staticcheck // SA1019: worker versioning v0.31
+									eventID, err = getResetEventIDByType(ctx, operation.ResetOperation.ResetType, namespace, executionInfo.Execution, frontendClient, logger)
+									//nolint:staticcheck // SA1019: worker versioning v0.31
+									resetReapplyType = operation.ResetOperation.ResetReapplyType
+								}
+								if err != nil {
+									return err
+								}
+								_, err = frontendClient.ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
+									Namespace:                 namespace,
+									WorkflowExecution:         executionInfo.Execution,
+									Reason:                    batchOperation.Request.Reason,
+									RequestId:                 uuid.NewString(),
+									WorkflowTaskFinishEventId: eventID,
+									ResetReapplyType:          resetReapplyType,
+									ResetReapplyExcludeTypes:  resetReapplyExcludeTypes,
+									PostResetOperations:       operation.ResetOperation.PostResetOperations,
+									Identity:                  operation.ResetOperation.Identity,
+								})
+								return err
+							})
+					case *workflowservice.StartBatchOperationRequest_UnpauseActivitiesOperation:
+						err = processTask(ctx, limiter, task,
+							func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
+								unpauseRequest := &workflowservice.UnpauseActivityRequest{
+									Namespace:      namespace,
+									Execution:      executionInfo.Execution,
+									Identity:       operation.UnpauseActivitiesOperation.Identity,
+									ResetAttempts:  operation.UnpauseActivitiesOperation.ResetAttempts,
+									ResetHeartbeat: operation.UnpauseActivitiesOperation.ResetHeartbeat,
+									Jitter:         operation.UnpauseActivitiesOperation.Jitter,
+								}
+
+								switch ao := operation.UnpauseActivitiesOperation.GetActivity().(type) {
+								case *batchpb.BatchOperationUnpauseActivities_Type:
+									unpauseRequest.Activity = &workflowservice.UnpauseActivityRequest_Type{
+										Type: ao.Type,
+									}
+								case *batchpb.BatchOperationUnpauseActivities_MatchAll:
+									unpauseRequest.Activity = &workflowservice.UnpauseActivityRequest_UnpauseAll{UnpauseAll: true}
+								default:
+									return fmt.Errorf("unknown activity type: %v", operation.UnpauseActivitiesOperation.GetActivity())
+								}
+
+								_, err = frontendClient.UnpauseActivity(ctx, unpauseRequest)
+								return err
+							})
+
+					case *workflowservice.StartBatchOperationRequest_UpdateWorkflowOptionsOperation:
+						err = processTask(ctx, limiter, task,
+							func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
+								var err error
+								_, err = frontendClient.UpdateWorkflowExecutionOptions(ctx, &workflowservice.UpdateWorkflowExecutionOptionsRequest{
+									Namespace:                namespace,
+									WorkflowExecution:        executionInfo.Execution,
+									WorkflowExecutionOptions: operation.UpdateWorkflowOptionsOperation.WorkflowExecutionOptions,
+									UpdateMask:               &fieldmaskpb.FieldMask{Paths: operation.UpdateWorkflowOptionsOperation.UpdateMask.Paths},
+									Identity:                 operation.UpdateWorkflowOptionsOperation.Identity,
+								})
+								return err
+							})
+					case *workflowservice.StartBatchOperationRequest_ResetActivitiesOperation:
+						err = processTask(ctx, limiter, task,
+							func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
+								resetRequest := &workflowservice.ResetActivityRequest{
+									Namespace:              namespace,
+									Execution:              executionInfo.Execution,
+									Identity:               operation.ResetActivitiesOperation.Identity,
+									ResetHeartbeat:         operation.ResetActivitiesOperation.ResetHeartbeat,
+									Jitter:                 operation.ResetActivitiesOperation.Jitter,
+									KeepPaused:             operation.ResetActivitiesOperation.KeepPaused,
+									RestoreOriginalOptions: operation.ResetActivitiesOperation.RestoreOriginalOptions,
+								}
+
+								switch ao := operation.ResetActivitiesOperation.GetActivity().(type) {
+								case *batchpb.BatchOperationResetActivities_Type:
+									resetRequest.Activity = &workflowservice.ResetActivityRequest_Type{Type: ao.Type}
+								case *batchpb.BatchOperationResetActivities_MatchAll:
+									resetRequest.Activity = &workflowservice.ResetActivityRequest_MatchAll{MatchAll: true}
+								default:
+									return fmt.Errorf("unknown activity type: %v", operation.ResetActivitiesOperation.GetActivity())
+								}
+
+								_, err = frontendClient.ResetActivity(ctx, resetRequest)
+								return err
+							})
+					case *workflowservice.StartBatchOperationRequest_UpdateActivityOptionsOperation:
+						err = processTask(ctx, limiter, task,
+							func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
+								updateRequest := &workflowservice.UpdateActivityOptionsRequest{
+									Namespace:       namespace,
+									Execution:       executionInfo.Execution,
+									UpdateMask:      &fieldmaskpb.FieldMask{Paths: operation.UpdateActivityOptionsOperation.UpdateMask.Paths},
+									RestoreOriginal: operation.UpdateActivityOptionsOperation.RestoreOriginal,
+									Identity:        operation.UpdateActivityOptionsOperation.Identity,
+								}
+
+								switch ao := operation.UpdateActivityOptionsOperation.GetActivity().(type) {
+								case *batchpb.BatchOperationUpdateActivityOptions_Type:
+									updateRequest.Activity = &workflowservice.UpdateActivityOptionsRequest_Type{Type: ao.Type}
+								case *batchpb.BatchOperationUpdateActivityOptions_MatchAll:
+									updateRequest.Activity = &workflowservice.UpdateActivityOptionsRequest_MatchAll{MatchAll: true}
+								default:
+									return fmt.Errorf("unknown activity type: %v", operation.UpdateActivityOptionsOperation.GetActivity())
+								}
+
+								updateRequest.ActivityOptions = operation.UpdateActivityOptionsOperation.GetActivityOptions()
+								_, err = frontendClient.UpdateActivityOptions(ctx, updateRequest)
+								return err
+							})
+					default:
+						err = fmt.Errorf("unknown batch type: %v", batchOperation.BatchType)
+					}
+				}
+
+				if err == nil {
+					metrics.BatcherProcessorSuccess.With(metricsHandler).Record(1)
+				} else {
+					metrics.BatcherProcessorFailures.With(metricsHandler).Record(1)
+					logger.Error("Failed to process batch operation task", tag.Error(err))
+
+					// Error is retryable unless it is explicitly marked non-retryable:
+					// 1. ApplicationError marked as NonRetryable
+					// 2. Operation-specific non-retryable errors
+					// 3. List of non-retryable errors from frontend
+					var appErr *temporal.ApplicationError
+					nonRetryable := (errors.As(err, &appErr) && appErr.NonRetryable()) ||
+						isNonRetryableError(err, batchOperation.BatchType) ||
+						slices.Contains(batchOperation.NonRetryableErrors, err.Error())
+					retryable := !nonRetryable
+
+					if retryable && task.attempts <= int(batchOperation.AttemptsOnRetryableError) && !isDone(ctx) {
+						task.attempts++
+						continue
+					}
+				}
+
+				// Emit exactly one response per task. Guard the send with ctx so the worker
+				// does not block here if the coordinator loop has already exited.
+				select {
+				case respCh <- taskResponse{err: err, page: task.page}:
+				case <-ctx.Done():
+				}
+				break
 			}
-
-			switch operation := batchOperation.Request.Operation.(type) {
-			case *workflowservice.StartBatchOperationRequest_TerminationOperation:
-				err = processTask(ctx, limiter, task,
-					func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
-						return sdkClient.TerminateWorkflow(ctx, executionInfo.Execution.WorkflowId, executionInfo.Execution.RunId, batchOperation.Request.Reason)
-					})
-			case *workflowservice.StartBatchOperationRequest_CancellationOperation:
-				err = processTask(ctx, limiter, task,
-					func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
-						return sdkClient.CancelWorkflow(ctx, executionInfo.Execution.WorkflowId, executionInfo.Execution.RunId)
-					})
-			case *workflowservice.StartBatchOperationRequest_SignalOperation:
-				err = processTask(ctx, limiter, task,
-					func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
-						_, err = frontendClient.SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
-							Namespace:         namespace,
-							WorkflowExecution: executionInfo.Execution,
-							SignalName:        operation.SignalOperation.GetSignal(),
-							Input:             operation.SignalOperation.GetInput(),
-							Identity:          operation.SignalOperation.GetIdentity(),
-						})
-						return err
-					})
-			case *workflowservice.StartBatchOperationRequest_DeletionOperation:
-				err = processTask(ctx, limiter, task,
-					func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
-						_, err := frontendClient.DeleteWorkflowExecution(ctx, &workflowservice.DeleteWorkflowExecutionRequest{
-							Namespace:         namespace,
-							WorkflowExecution: executionInfo.Execution,
-						})
-						return err
-					})
-			case *workflowservice.StartBatchOperationRequest_ResetOperation:
-				err = processTask(ctx, limiter, task,
-					func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
-						var eventId int64
-						var err error
-						//nolint:staticcheck // SA1019: worker versioning v0.31
-						var resetReapplyType enumspb.ResetReapplyType
-						var resetReapplyExcludeTypes []enumspb.ResetReapplyExcludeType
-						if operation.ResetOperation.Options != nil {
-							// Using ResetOptions
-							// Note: getResetEventIDByOptions may modify workflowExecution.RunId, if reset should be to a prior run
-							//nolint:staticcheck // SA1019: worker versioning v0.31
-							eventId, err = getResetEventIDByOptions(ctx, operation.ResetOperation.Options, namespace, executionInfo.Execution, frontendClient, logger)
-							//nolint:staticcheck // SA1019: worker versioning v0.31
-							resetReapplyType = operation.ResetOperation.Options.ResetReapplyType
-							//nolint:staticcheck // SA1019: worker versioning v0.31
-							resetReapplyExcludeTypes = operation.ResetOperation.Options.ResetReapplyExcludeTypes
-						} else {
-							// Old fields
-							//nolint:staticcheck // SA1019: worker versioning v0.31
-							eventId, err = getResetEventIDByType(ctx, operation.ResetOperation.ResetType, namespace, executionInfo.Execution, frontendClient, logger)
-							//nolint:staticcheck // SA1019: worker versioning v0.31
-							resetReapplyType = operation.ResetOperation.ResetReapplyType
-						}
-						if err != nil {
-							return err
-						}
-						_, err = frontendClient.ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
-							Namespace:                 namespace,
-							WorkflowExecution:         executionInfo.Execution,
-							Reason:                    batchOperation.Request.Reason,
-							RequestId:                 uuid.NewString(),
-							WorkflowTaskFinishEventId: eventId,
-							ResetReapplyType:          resetReapplyType,
-							ResetReapplyExcludeTypes:  resetReapplyExcludeTypes,
-							PostResetOperations:       operation.ResetOperation.PostResetOperations,
-							Identity:                  operation.ResetOperation.Identity,
-						})
-						return err
-					})
-			case *workflowservice.StartBatchOperationRequest_UnpauseActivitiesOperation:
-				err = processTask(ctx, limiter, task,
-					func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
-						unpauseRequest := &workflowservice.UnpauseActivityRequest{
-							Namespace:      namespace,
-							Execution:      executionInfo.Execution,
-							Identity:       operation.UnpauseActivitiesOperation.Identity,
-							ResetAttempts:  operation.UnpauseActivitiesOperation.ResetAttempts,
-							ResetHeartbeat: operation.UnpauseActivitiesOperation.ResetHeartbeat,
-							Jitter:         operation.UnpauseActivitiesOperation.Jitter,
-						}
-
-						switch ao := operation.UnpauseActivitiesOperation.GetActivity().(type) {
-						case *batchpb.BatchOperationUnpauseActivities_Type:
-							unpauseRequest.Activity = &workflowservice.UnpauseActivityRequest_Type{
-								Type: ao.Type,
-							}
-						case *batchpb.BatchOperationUnpauseActivities_MatchAll:
-							unpauseRequest.Activity = &workflowservice.UnpauseActivityRequest_UnpauseAll{UnpauseAll: true}
-						default:
-							return errors.New(fmt.Sprintf("unknown activity type: %v", operation.UnpauseActivitiesOperation.GetActivity()))
-						}
-
-						_, err = frontendClient.UnpauseActivity(ctx, unpauseRequest)
-						return err
-					})
-
-			case *workflowservice.StartBatchOperationRequest_UpdateWorkflowOptionsOperation:
-				err = processTask(ctx, limiter, task,
-					func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
-						var err error
-						_, err = frontendClient.UpdateWorkflowExecutionOptions(ctx, &workflowservice.UpdateWorkflowExecutionOptionsRequest{
-							Namespace:                namespace,
-							WorkflowExecution:        executionInfo.Execution,
-							WorkflowExecutionOptions: operation.UpdateWorkflowOptionsOperation.WorkflowExecutionOptions,
-							UpdateMask:               &fieldmaskpb.FieldMask{Paths: operation.UpdateWorkflowOptionsOperation.UpdateMask.Paths},
-							Identity:                 operation.UpdateWorkflowOptionsOperation.Identity,
-						})
-						return err
-					})
-			case *workflowservice.StartBatchOperationRequest_ResetActivitiesOperation:
-				err = processTask(ctx, limiter, task,
-					func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
-						resetRequest := &workflowservice.ResetActivityRequest{
-							Namespace:              namespace,
-							Execution:              executionInfo.Execution,
-							Identity:               operation.ResetActivitiesOperation.Identity,
-							ResetHeartbeat:         operation.ResetActivitiesOperation.ResetHeartbeat,
-							Jitter:                 operation.ResetActivitiesOperation.Jitter,
-							KeepPaused:             operation.ResetActivitiesOperation.KeepPaused,
-							RestoreOriginalOptions: operation.ResetActivitiesOperation.RestoreOriginalOptions,
-						}
-
-						switch ao := operation.ResetActivitiesOperation.GetActivity().(type) {
-						case *batchpb.BatchOperationResetActivities_Type:
-							resetRequest.Activity = &workflowservice.ResetActivityRequest_Type{Type: ao.Type}
-						case *batchpb.BatchOperationResetActivities_MatchAll:
-							resetRequest.Activity = &workflowservice.ResetActivityRequest_MatchAll{MatchAll: true}
-						default:
-							return errors.New(fmt.Sprintf("unknown activity type: %v", operation.ResetActivitiesOperation.GetActivity()))
-						}
-
-						_, err = frontendClient.ResetActivity(ctx, resetRequest)
-						return err
-					})
-			case *workflowservice.StartBatchOperationRequest_UpdateActivityOptionsOperation:
-				err = processTask(ctx, limiter, task,
-					func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
-						updateRequest := &workflowservice.UpdateActivityOptionsRequest{
-							Namespace:       namespace,
-							Execution:       executionInfo.Execution,
-							UpdateMask:      &fieldmaskpb.FieldMask{Paths: operation.UpdateActivityOptionsOperation.UpdateMask.Paths},
-							RestoreOriginal: operation.UpdateActivityOptionsOperation.RestoreOriginal,
-							Identity:        operation.UpdateActivityOptionsOperation.Identity,
-						}
-
-						switch ao := operation.UpdateActivityOptionsOperation.GetActivity().(type) {
-						case *batchpb.BatchOperationUpdateActivityOptions_Type:
-							updateRequest.Activity = &workflowservice.UpdateActivityOptionsRequest_Type{Type: ao.Type}
-						case *batchpb.BatchOperationUpdateActivityOptions_MatchAll:
-							updateRequest.Activity = &workflowservice.UpdateActivityOptionsRequest_MatchAll{MatchAll: true}
-						default:
-							return errors.New(fmt.Sprintf("unknown activity type: %v", operation.UpdateActivityOptionsOperation.GetActivity()))
-						}
-
-						updateRequest.ActivityOptions = operation.UpdateActivityOptionsOperation.GetActivityOptions()
-						_, err = frontendClient.UpdateActivityOptions(ctx, updateRequest)
-						return err
-					})
-			default:
-				err = errors.New(fmt.Sprintf("unknown batch type: %v", batchOperation.BatchType))
-			}
-			a.handleTaskResult(batchOperation, task, err, taskCh, respCh, metricsHandler, logger)
 		}
 	}
 }
@@ -637,41 +695,6 @@ func isNonRetryableError(err error, batchType enumspb.BatchOperationType) bool {
 		return strings.Contains(errMsg, worker_versioning.ErrPinnedVersionNotInTaskQueueSubstring)
 	default:
 		return false
-	}
-}
-
-func (a *activities) handleTaskResult(
-	batchOperation *batchspb.BatchOperationInput,
-	task task,
-	err error,
-	taskCh chan task,
-	respCh chan taskResponse,
-	metricsHandler metrics.Handler,
-	logger log.Logger,
-) {
-	if err != nil {
-		metrics.BatcherProcessorFailures.With(metricsHandler).Record(1)
-		logger.Error("Failed to process batch operation task", tag.Error(err))
-
-		// Check if error is non-retryable:
-		// 1. ApplicationError marked as NonRetryable
-		// 2. Operation-specific non-retryable errors
-		// 3. List of non-retryable errors from frontend
-		var appErr *temporal.ApplicationError
-		nonRetryable := (errors.As(err, &appErr) && appErr.NonRetryable()) ||
-			isNonRetryableError(err, batchOperation.BatchType) ||
-			slices.Contains(batchOperation.NonRetryableErrors, err.Error())
-
-		if nonRetryable || task.attempts > int(batchOperation.AttemptsOnRetryableError) {
-			respCh <- taskResponse{err: err, page: task.page}
-		} else {
-			// put back to the channel if less than attemptsOnError
-			task.attempts++
-			taskCh <- task
-		}
-	} else {
-		metrics.BatcherProcessorSuccess.With(metricsHandler).Record(1)
-		respCh <- taskResponse{err: nil, page: task.page}
 	}
 }
 

--- a/service/worker/batcher/activities_test.go
+++ b/service/worker/batcher/activities_test.go
@@ -635,6 +635,122 @@ func (s *activitiesSuite) TestStartTaskProcessor_SignalUsesWorkerNamespace() {
 	s.NoError(resp.err)
 }
 
+// TestStartTaskProcessor_RetryableErrorsDoNotDeadlock verifies that when an operation keeps
+// failing with a retryable error, the worker retries it in place (on its own goroutine) and
+// emits exactly one response per task, instead of re-queuing the task onto taskCh.
+// Re-queuing deadlocked the pool: the worker goroutines are the only consumers of taskCh, so
+// a burst of retryable errors made them all block on the re-enqueue send with the buffer full
+// and no drainer left, leaving the activity heartbeating but stuck with no progress.
+func (s *activitiesSuite) TestStartTaskProcessor_RetryableErrorsDoNotDeadlock() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	a := &activities{
+		activityDeps: activityDeps{
+			FrontendClient: s.mockFrontendClient,
+			Logger:         log.NewTestLogger(),
+			MetricsHandler: metrics.NoopMetricsHandler,
+		},
+	}
+
+	const numTasks = 5
+	batchOperation := &batchspb.BatchOperationInput{
+		NamespaceId: "some-namespace-id",
+		// Bounded retries keep the test fast; each task is attempted a few times.
+		AttemptsOnRetryableError: 2,
+		Request: &workflowservice.StartBatchOperationRequest{
+			Namespace: "ns",
+			Operation: &workflowservice.StartBatchOperationRequest_SignalOperation{
+				SignalOperation: &batchpb.BatchOperationSignal{Signal: "test-signal"},
+			},
+		},
+	}
+
+	// Every signal fails with a retryable error, forcing the worker down the retry path.
+	s.mockFrontendClient.EXPECT().
+		SignalWorkflowExecution(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("transient error")).
+		AnyTimes()
+
+	// A single worker with a small buffer is the configuration that wedged when retries
+	// were re-queued onto taskCh.
+	taskCh := make(chan task, 1)
+	respCh := make(chan taskResponse, 1)
+	limiter := quotas.NewRequestRateLimiterAdapter(quotas.NewDefaultOutgoingRateLimiter(func() float64 { return 1000 }))
+
+	go a.startTaskProcessor(ctx, batchOperation, "ns", taskCh, respCh, limiter, nil, s.mockFrontendClient, metrics.NoopMetricsHandler, log.NewTestLogger())
+
+	// Feed tasks from a separate goroutine so the test can drain responses concurrently.
+	go func() {
+		for i := range numTasks {
+			p := &page{
+				executionInfos: []*workflowpb.WorkflowExecutionInfo{
+					{Execution: &commonpb.WorkflowExecution{WorkflowId: fmt.Sprintf("wf-%d", i), RunId: "run"}},
+				},
+			}
+			taskCh <- task{executionInfo: p.executionInfos[0], attempts: 1, page: p}
+		}
+	}()
+
+	// Every task must produce exactly one error response; the activity must not deadlock.
+	for range numTasks {
+		select {
+		case resp := <-respCh:
+			s.Require().Error(resp.err)
+		case <-time.After(10 * time.Second):
+			s.FailNow("timed out waiting for task response: worker is deadlocked")
+		}
+	}
+}
+
+// TestRecordCompletedPages_ResumeTracksOldestIncompletePage verifies that the heartbeat
+// resume point (PageToken/CurrentPage) only advances across the contiguous fully-done prefix
+// of pages and never past a still-in-flight earlier page. Pages are fetched ahead once
+// submitted (not done), so a resume point that ran ahead of completion would skip in-flight
+// pages on restart and silently drop their workflows.
+func (s *activitiesSuite) TestRecordCompletedPages_ResumeTracksOldestIncompletePage() {
+	mkPage := func(num, size int, next string) *page {
+		return &page{
+			executionInfos: make([]*workflowpb.WorkflowExecutionInfo, size),
+			nextPageToken:  []byte(next),
+			pageNumber:     num,
+		}
+	}
+	p1 := mkPage(0, 2, "tok-p2")
+	p2 := mkPage(1, 2, "tok-p3")
+	p3 := mkPage(2, 1, "")
+	p1.next, p2.prev = p2, p1
+	p2.next, p3.prev = p3, p2
+
+	hbd := &HeartBeatDetails{PageToken: []byte("tok-p1")}
+
+	// Page 3 finishes first, while pages 1 and 2 are still in flight.
+	p3.successCount = 1
+	recordCompletedPages(hbd, p3)
+	// Resume point must NOT move: page 1 (the oldest) is still in flight.
+	s.Equal([]byte("tok-p1"), hbd.PageToken, "must not advance past in-flight earlier pages")
+	s.Equal(0, hbd.CurrentPage)
+	s.Equal(0, hbd.SuccessCount)
+	s.Equal(0, hbd.ErrorCount)
+
+	// Page 1 finishes; page 2 still in flight.
+	p1.successCount, p1.errorCount = 1, 1
+	recordCompletedPages(hbd, p1)
+	// Resume point advances to page 2 (now the oldest incomplete); only page 1 is counted.
+	s.Equal([]byte("tok-p2"), hbd.PageToken)
+	s.Equal(1, hbd.CurrentPage)
+	s.Equal(1, hbd.SuccessCount)
+	s.Equal(1, hbd.ErrorCount)
+
+	// Page 2 finishes; the done prefix now extends through the already-complete page 3.
+	p2.successCount = 2
+	recordCompletedPages(hbd, p2)
+	s.Empty(hbd.PageToken, "all pages done -> resume token is the last page's (empty) next token")
+	s.Equal(3, hbd.CurrentPage)
+	s.Equal(4, hbd.SuccessCount) // p1:1 + p2:2 + p3:1
+	s.Equal(1, hbd.ErrorCount)   // p1:1
+}
+
 func (s *activitiesSuite) TestProcessAdminTask_UnknownOperation() {
 	ctx := context.Background()
 


### PR DESCRIPTION
## What changed?
Backports #10630 to `cloud/v1.32.0-157`. Workers now retry retryable task failures in place and emit exactly one response per task instead of re-queuing onto the worker-only task channel; the heartbeat resume point tracks the oldest incomplete page; the worker count is clamped to at least 1; and the loop stops submitting empty tasks once a page is fully submitted.

## Why?
Patch the 1.32.0-157 release: re-queuing retries onto the worker-only `taskCh` could deadlock the worker pool under a burst of retryable errors, leaving the admin/batch activity heartbeating with no progress.

Adapted, not a clean cherry-pick: 1.32.0-157 predates #10627, so this targets the pre-#10627 batcher structure (and converts the touched `errors.New(fmt.Sprintf)` sites to `fmt.Errorf` plus `eventId`→`eventID` to satisfy the linters on the moved code).

## How did you test it?
- [x] built (`go build ./service/worker/batcher/...`)
- [x] covered by existing tests
- [x] added new unit test(s)

## Potential risks
Retries hold a worker slot while retrying, bounded by AttemptsOnRetryableError. Scope limited to admin/batch operation processing.