### PR TITLE
[Scheduler] Functional regression test for schedules whose actions timeout/fail in a chain of retries

### DIFF
--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -119,6 +119,7 @@ func runSharedScheduleTests(t *testing.T, newContext contextFactory) {
 	t.Run("TestBasics", func(t *testing.T) { testBasics(t, newContext) })
 	t.Run("TestInput", func(t *testing.T) { testInput(t, newContext) })
 	t.Run("TestLastCompletionAndError", func(t *testing.T) { testLastCompletionAndError(t, newContext) })
+	t.Run("TestScheduleContinuesAfterWorkflowRetryFailure", func(t *testing.T) { testScheduleContinuesAfterWorkflowRetryFailure(t, newContext) })
 	t.Run("TestListSchedulesReturnsWorkflowStatus", func(t *testing.T) { testListSchedulesReturnsWorkflowStatus(t, newContext) })
 	t.Run("TestUpdateIntervalTakesEffect", func(t *testing.T) { testUpdateIntervalTakesEffect(t, newContext) })
 	t.Run("TestListScheduleMatchingTimes", func(t *testing.T) { testListScheduleMatchingTimes(t, newContext) })
@@ -824,6 +825,84 @@ func testLastCompletionAndError(t *testing.T, newContext contextFactory) {
 	s.NoError(err)
 
 	s.Eventually(func() bool { return atomic.LoadInt32(&testComplete) == 1 }, 20*time.Second, 200*time.Millisecond)
+}
+
+// testScheduleContinuesAfterWorkflowRetryFailure verifies a schedule keeps firing actions
+// after a scheduled workflow exhausts its retry policy and fails.
+func testScheduleContinuesAfterWorkflowRetryFailure(t *testing.T, newContext contextFactory) {
+	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+
+	sid := testcore.RandomizeStr("sched-retry-fail")
+	wid := testcore.RandomizeStr("sched-retry-fail-wf")
+	wt := testcore.RandomizeStr("sched-retry-fail-wt")
+
+	var sawRetry int32
+	workflowFn := func(ctx workflow.Context) error {
+		if workflow.GetInfo(ctx).Attempt > 1 {
+			atomic.StoreInt32(&sawRetry, 1)
+		}
+		return errors.New("intentional failure to force a retry")
+	}
+	s.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+
+	schedule := &schedulepb.Schedule{
+		Spec: &schedulepb.ScheduleSpec{
+			Interval: []*schedulepb.IntervalSpec{
+				{Interval: durationpb.New(3 * time.Second)},
+			},
+		},
+		Action: &schedulepb.ScheduleAction{
+			Action: &schedulepb.ScheduleAction_StartWorkflow{
+				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+					WorkflowId:   wid,
+					WorkflowType: &commonpb.WorkflowType{Name: wt},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					RetryPolicy: &commonpb.RetryPolicy{
+						InitialInterval:    durationpb.New(1 * time.Second),
+						BackoffCoefficient: 1.0,
+						MaximumAttempts:    2,
+					},
+				},
+			},
+		},
+	}
+
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Schedule:   schedule,
+		Identity:   "test",
+		RequestId:  uuid.NewString(),
+	})
+	require.NoError(t, err)
+
+	// Two FAILED actions proves the schedule kept firing past the first retry-failure.
+	var failedActions int
+	var lastDescribe *workflowservice.DescribeScheduleResponse
+	s.Eventually(func() bool {
+		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+		})
+		if descErr != nil {
+			return false
+		}
+		lastDescribe = desc
+		failedActions = 0
+		for _, a := range desc.GetInfo().GetRecentActions() {
+			if a.GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_FAILED {
+				failedActions++
+			}
+		}
+		return atomic.LoadInt32(&sawRetry) == 1 && failedActions >= 2
+	}, 30*time.Second, 500*time.Millisecond,
+		"schedule should keep recording FAILED actions after the workflow retry-fails")
+
+	s.Equal(int32(1), atomic.LoadInt32(&sawRetry), "scheduled workflow should have retried (attempt > 1)")
+	s.GreaterOrEqual(failedActions, 2, "schedule should record multiple retry-failed actions")
+	s.GreaterOrEqual(lastDescribe.GetInfo().GetActionCount(), int64(2))
+	s.False(lastDescribe.GetSchedule().GetState().GetPaused(), "a retry-failed workflow must not pause the schedule")
 }
 
 // testScheduledWorkflowContinueAsNewCompletion validates that the CHASM scheduler observes the


### PR DESCRIPTION
## What changed?
- Adds a new functional test for TIMED_OUT/FAILED chains. 

## Why?
- This is similar (under the hood) to the CAN case, but we were missing coverage. Already passing.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)
