### PR TITLE
TS: side-effect options in UpdateWorkflowExecutionOptions

### DIFF
--- a/service/history/api/updateworkflowoptions/api.go
+++ b/service/history/api/updateworkflowoptions/api.go
@@ -123,6 +123,15 @@ func Invoke(
 	return ret, nil
 }
 
+type UpdateSideEffectOptions struct {
+	// nil = no change to time skipping; non-nil = apply this TSC (TSC changed or bound renewed).
+	timeSkippingConfig bool
+}
+
+func (u UpdateSideEffectOptions) hasChanges() bool {
+	return u.timeSkippingConfig
+}
+
 func validateTimeSkippingConfig(cfg *workflowpb.TimeSkippingConfig) error {
 	if !cfg.GetEnabled() {
 		if cfg.GetBound() != nil {
@@ -147,7 +156,7 @@ func MergeAndApply(
 	identity string,
 ) (*workflowpb.WorkflowExecutionOptions, bool, error) {
 	// Merge the requested options mentioned in the field mask with the current options in the mutable state
-	mergedOpts, err := mergeWorkflowExecutionOptions(
+	mergedOpts, sideEffects, err := mergeWorkflowExecutionOptions(
 		getOptionsFromMutableState(ms),
 		opts,
 		updateMask,
@@ -156,17 +165,15 @@ func MergeAndApply(
 		return nil, false, serviceerror.NewInvalidArgumentf("error applying update_options: %v", err)
 	}
 
-	// If there is no mutable state change at all, return with no new history event and Noop=true
-	hasChanges := !proto.Equal(mergedOpts, getOptionsFromMutableState(ms))
+	// sideEffects.hasChanges() forces hasChanges=true for bound renewals where proto.Equal sees no difference.
+	hasChanges := !proto.Equal(mergedOpts, getOptionsFromMutableState(ms)) || sideEffects.hasChanges()
 	if !hasChanges {
 		return mergedOpts, false, nil
 	}
 
-	unsetOverride := false
-	if mergedOpts.GetVersioningOverride() == nil {
-		unsetOverride = true
-	}
-	_, err = ms.AddWorkflowExecutionOptionsUpdatedEvent(mergedOpts.GetVersioningOverride(), unsetOverride, "", nil, nil, identity, mergedOpts.GetPriority(), mergedOpts.GetTimeSkippingConfig(), nil)
+	unsetOverride := mergedOpts.GetVersioningOverride() == nil
+	_, err = ms.AddWorkflowExecutionOptionsUpdatedEvent(
+		mergedOpts.GetVersioningOverride(), unsetOverride, "", nil, nil, identity, mergedOpts.GetPriority(), mergedOpts.GetTimeSkippingConfig(), nil)
 	if err != nil {
 		return nil, hasChanges, err
 	}
@@ -195,30 +202,32 @@ func getOptionsFromMutableState(ms historyi.MutableState) *workflowpb.WorkflowEx
 	return opts
 }
 
-// mergeWorkflowExecutionOptions copies the given paths in `src` struct to `dst` struct
+// mergeWorkflowExecutionOptions copies the given paths in `src` struct to `dst` struct and returns
+// the side-effect options for fields that produce side effects when applied (see UpdateSideEffectOptions).
 func mergeWorkflowExecutionOptions(
 	mergeInto, mergeFrom *workflowpb.WorkflowExecutionOptions,
 	updateMask *fieldmaskpb.FieldMask,
-) (*workflowpb.WorkflowExecutionOptions, error) {
+) (*workflowpb.WorkflowExecutionOptions, UpdateSideEffectOptions, error) {
 	_, err := fieldmaskpb.New(mergeInto, updateMask.GetPaths()...)
 	if err != nil { // errors if any paths are not valid for the struct we are merging into
-		return nil, err
+		return nil, UpdateSideEffectOptions{}, err
 	}
 	updateFields := util.ParseFieldMask(updateMask)
+
 	if _, ok := updateFields["versioningOverride"]; ok {
 		mergeInto.VersioningOverride = mergeFrom.GetVersioningOverride()
 	}
 
 	if _, ok := updateFields["versioningOverride.deployment"]; ok {
 		if _, ok := updateFields["versioningOverride.behavior"]; !ok {
-			return nil, serviceerror.NewInvalidArgument("versioning_override fields must be updated together")
+			return nil, UpdateSideEffectOptions{}, serviceerror.NewInvalidArgument("versioning_override fields must be updated together")
 		}
 		mergeInto.VersioningOverride = mergeFrom.GetVersioningOverride()
 	}
 
 	if _, ok := updateFields["versioningOverride.behavior"]; ok {
 		if _, ok := updateFields["versioningOverride.deployment"]; !ok {
-			return nil, serviceerror.NewInvalidArgument("versioning_override fields must be updated together")
+			return nil, UpdateSideEffectOptions{}, serviceerror.NewInvalidArgument("versioning_override fields must be updated together")
 		}
 		mergeInto.VersioningOverride = mergeFrom.GetVersioningOverride()
 	}
@@ -250,8 +259,17 @@ func mergeWorkflowExecutionOptions(
 		mergeInto.Priority.FairnessWeight = mergeFrom.Priority.GetFairnessWeight()
 	}
 
-	// ==== Time Skipping Config
-	// nil means "no change" — only update if the caller provided an explicit value.
+	// ==== Time Skipping Config (has side effects when applied)
+	var originalTsc *workflowpb.TimeSkippingConfig
+	if tsc := mergeInto.GetTimeSkippingConfig(); tsc != nil {
+		if cloned, ok := proto.Clone(tsc).(*workflowpb.TimeSkippingConfig); ok {
+			originalTsc = cloned
+		}
+	}
+	// whenever the bound is updated, it needs to be re-applied.
+	_, boundInMask := updateFields["timeSkippingConfig.maxElapsedDuration"]
+
+	// getting the new TSC config
 	if _, ok := updateFields["timeSkippingConfig"]; ok {
 		if mergeFrom.GetTimeSkippingConfig() != nil {
 			mergeInto.TimeSkippingConfig = mergeFrom.GetTimeSkippingConfig()
@@ -274,5 +292,13 @@ func mergeWorkflowExecutionOptions(
 		}
 	}
 
-	return mergeInto, nil
+	// time skipping config should be updated either the bound is used or the config contents are changed
+	var sideEffects UpdateSideEffectOptions
+	if !boundInMask && proto.Equal(mergeInto.GetTimeSkippingConfig(), originalTsc) {
+		mergeInto.TimeSkippingConfig = nil
+		sideEffects.timeSkippingConfig = false
+	} else {
+		sideEffects.timeSkippingConfig = true
+	}
+	return mergeInto, sideEffects, nil
 }

--- a/service/history/api/updateworkflowoptions/api_test.go
+++ b/service/history/api/updateworkflowoptions/api_test.go
@@ -88,28 +88,28 @@ func TestMergeOptions_VersionOverrideMask(t *testing.T) {
 	input := emptyOptions
 
 	// Merge unpinned into empty options
-	merged, err := mergeWorkflowExecutionOptions(input, unpinnedOverrideOptions, updateMask)
+	merged, _, err := mergeWorkflowExecutionOptions(input, unpinnedOverrideOptions, updateMask)
 	if err != nil {
 		t.Error(err)
 	}
 	require.EqualExportedValues(t, unpinnedOverrideOptions, merged)
 
 	// Merge pinned_A into unpinned options
-	merged, err = mergeWorkflowExecutionOptions(input, pinnedOverrideOptionsA, updateMask)
+	merged, _, err = mergeWorkflowExecutionOptions(input, pinnedOverrideOptionsA, updateMask)
 	if err != nil {
 		t.Error(err)
 	}
 	require.EqualExportedValues(t, pinnedOverrideOptionsA, merged)
 
 	// Merge pinned_B into pinned_A options
-	merged, err = mergeWorkflowExecutionOptions(input, pinnedOverrideOptionsB, updateMask)
+	merged, _, err = mergeWorkflowExecutionOptions(input, pinnedOverrideOptionsB, updateMask)
 	if err != nil {
 		t.Error(err)
 	}
 	require.EqualExportedValues(t, pinnedOverrideOptionsB, merged)
 
 	// Unset versioning override
-	merged, err = mergeWorkflowExecutionOptions(input, emptyOptions, updateMask)
+	merged, _, err = mergeWorkflowExecutionOptions(input, emptyOptions, updateMask)
 	if err != nil {
 		t.Error(err)
 	}
@@ -121,13 +121,13 @@ func TestMergeOptions_PartialMask(t *testing.T) {
 	behaviorOnlyUpdateMask := &fieldmaskpb.FieldMask{Paths: []string{"versioning_override.behavior"}}
 	deploymentOnlyUpdateMask := &fieldmaskpb.FieldMask{Paths: []string{"versioning_override.deployment"}}
 
-	_, err := mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, behaviorOnlyUpdateMask)
+	_, _, err := mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, behaviorOnlyUpdateMask)
 	require.Error(t, err)
 
-	_, err = mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, deploymentOnlyUpdateMask)
+	_, _, err = mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, deploymentOnlyUpdateMask)
 	require.Error(t, err)
 
-	merged, err := mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, bothUpdateMask)
+	merged, _, err := mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, bothUpdateMask)
 	require.NoError(t, err)
 	require.EqualExportedValues(t, unpinnedOverrideOptions, merged)
 }
@@ -137,25 +137,25 @@ func TestMergeOptions_EmptyMask(t *testing.T) {
 	input := pinnedOverrideOptionsB
 
 	// Don't merge anything
-	merged, err := mergeWorkflowExecutionOptions(input, pinnedOverrideOptionsA, emptyUpdateMask)
+	merged, _, err := mergeWorkflowExecutionOptions(input, pinnedOverrideOptionsA, emptyUpdateMask)
 	require.NoError(t, err)
 	require.EqualExportedValues(t, input, merged)
 
 	// Don't merge anything
-	merged, err = mergeWorkflowExecutionOptions(input, nil, emptyUpdateMask)
+	merged, _, err = mergeWorkflowExecutionOptions(input, nil, emptyUpdateMask)
 	require.NoError(t, err)
 	require.EqualExportedValues(t, input, merged)
 }
 
 func TestMergeOptions_AsteriskMask(t *testing.T) {
 	asteriskUpdateMask := &fieldmaskpb.FieldMask{Paths: []string{"*"}}
-	_, err := mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, asteriskUpdateMask)
+	_, _, err := mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, asteriskUpdateMask)
 	require.Error(t, err)
 }
 
 func TestMergeOptions_FooMask(t *testing.T) {
 	fooUpdateMask := &fieldmaskpb.FieldMask{Paths: []string{"foo"}}
-	_, err := mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, fooUpdateMask)
+	_, _, err := mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, fooUpdateMask)
 	require.Error(t, err)
 }
 
@@ -168,46 +168,51 @@ func TestMergeOptions_TimeSkippingConfig(t *testing.T) {
 	}
 
 	tcs := []struct {
-		name        string
-		current     *workflowpb.WorkflowExecutionOptions
-		update      *workflowpb.WorkflowExecutionOptions
-		wantChanged bool
-		wantConfig  *workflowpb.TimeSkippingConfig
+		name         string
+		current      *workflowpb.WorkflowExecutionOptions
+		update       *workflowpb.WorkflowExecutionOptions
+		wantChanged  bool
+		wantConfig   *workflowpb.TimeSkippingConfig
+		wantDeltaTsc *workflowpb.TimeSkippingConfig
 	}{
 		// nil update means "don't touch" even when mask is present
 		{
-			name:        "nil update - existing config preserved",
-			current:     &workflowpb.WorkflowExecutionOptions{TimeSkippingConfig: cfgA},
-			update:      &workflowpb.WorkflowExecutionOptions{},
-			wantChanged: false,
-			wantConfig:  cfgA,
+			name:         "nil update - existing config preserved",
+			current:      &workflowpb.WorkflowExecutionOptions{TimeSkippingConfig: cfgA},
+			update:       &workflowpb.WorkflowExecutionOptions{},
+			wantChanged:  false,
+			wantConfig:   cfgA,
+			wantDeltaTsc: nil,
 		},
 		// non-nil update replaces and is detected as a change
 		{
-			name:        "new config - changed",
-			current:     &workflowpb.WorkflowExecutionOptions{},
-			update:      &workflowpb.WorkflowExecutionOptions{TimeSkippingConfig: cfgB},
-			wantChanged: true,
-			wantConfig:  cfgB,
+			name:         "new config - changed",
+			current:      &workflowpb.WorkflowExecutionOptions{},
+			update:       &workflowpb.WorkflowExecutionOptions{TimeSkippingConfig: cfgB},
+			wantChanged:  true,
+			wantConfig:   cfgB,
+			wantDeltaTsc: cfgB,
 		},
 		// identical config is not detected as a change
 		{
-			name:        "same config - no change",
-			current:     &workflowpb.WorkflowExecutionOptions{TimeSkippingConfig: cfgB},
-			update:      &workflowpb.WorkflowExecutionOptions{TimeSkippingConfig: cfgB},
-			wantChanged: false,
-			wantConfig:  cfgB,
+			name:         "same config - no change",
+			current:      &workflowpb.WorkflowExecutionOptions{TimeSkippingConfig: cfgB},
+			update:       &workflowpb.WorkflowExecutionOptions{TimeSkippingConfig: cfgB},
+			wantChanged:  false,
+			wantConfig:   cfgB,
+			wantDeltaTsc: nil,
 		},
 	}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			original := proto.Clone(tc.current).(*workflowpb.WorkflowExecutionOptions)
-			merged, err := mergeWorkflowExecutionOptions(tc.current, tc.update, tscMask)
+			merged, sideEffects, err := mergeWorkflowExecutionOptions(tc.current, tc.update, tscMask)
 			require.NoError(t, err)
 			require.True(t, proto.Equal(tc.wantConfig, merged.GetTimeSkippingConfig()),
 				"config mismatch: want %v, got %v", tc.wantConfig, merged.GetTimeSkippingConfig())
 			require.Equal(t, tc.wantChanged, !proto.Equal(merged, original))
+			require.Equal(t, tc.wantDeltaTsc, sideEffects.timeSkippingConfig)
 		})
 	}
 }
@@ -382,6 +387,89 @@ func TestValidateTimeSkippingConfig(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+// TestMergeAndApply_BoundRenewal verifies rule 1: setting the bound via mask always fires an event
+// and passes the TSC, even when the duration value is unchanged.
+func TestMergeAndApply_BoundRenewal(t *testing.T) {
+	oneHour := durationpb.New(time.Hour)
+	existingConfig := &workflowpb.TimeSkippingConfig{
+		Enabled: true,
+		Bound:   &workflowpb.TimeSkippingConfig_MaxElapsedDuration{MaxElapsedDuration: oneHour},
+	}
+
+	ctrl := gomock.NewController(t)
+	ms := historyi.NewMockMutableState(ctrl)
+	ms.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
+		TimeSkippingInfo: &persistencespb.TimeSkippingInfo{Config: existingConfig},
+	}).AnyTimes()
+	// TSC must be non-nil even though the duration value is the same as the current one.
+	ms.EXPECT().AddWorkflowExecutionOptionsUpdatedEvent(nil, true, "", nil, nil, "", nil, gomock.Not(gomock.Nil()), nil).
+		Return(&historypb.HistoryEvent{}, nil)
+
+	result, hasChanges, err := MergeAndApply(
+		ms,
+		&workflowpb.WorkflowExecutionOptions{
+			TimeSkippingConfig: &workflowpb.TimeSkippingConfig{
+				Enabled: true,
+				Bound:   &workflowpb.TimeSkippingConfig_MaxElapsedDuration{MaxElapsedDuration: oneHour},
+			},
+		},
+		&fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.max_elapsed_duration"}},
+		"",
+	)
+	require.NoError(t, err)
+	require.True(t, hasChanges)
+	require.True(t, proto.Equal(existingConfig, result.GetTimeSkippingConfig()))
+}
+
+// TestMergeAndApply_TscNotPassedWhenUnchanged verifies rule 3: when non-TSC fields change but
+// the TSC is unchanged (and the bound is not in the mask), TSC must not be passed to the event.
+func TestMergeAndApply_TscNotPassedWhenUnchanged(t *testing.T) {
+	tcs := []struct {
+		name string
+		tsc  *workflowpb.TimeSkippingConfig
+	}{
+		{
+			name: "tsc with bound unchanged",
+			tsc: &workflowpb.TimeSkippingConfig{
+				Enabled: true,
+				Bound:   &workflowpb.TimeSkippingConfig_MaxElapsedDuration{MaxElapsedDuration: durationpb.New(time.Hour)},
+			},
+		},
+		{
+			name: "tsc without bound unchanged",
+			tsc:  &workflowpb.TimeSkippingConfig{Enabled: true},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			newOverride := &workflowpb.VersioningOverride{
+				Behavior: enumspb.VERSIONING_BEHAVIOR_AUTO_UPGRADE,
+			}
+
+			ctrl := gomock.NewController(t)
+			ms := historyi.NewMockMutableState(ctrl)
+			ms.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
+				TimeSkippingInfo: &persistencespb.TimeSkippingInfo{Config: tc.tsc},
+			}).AnyTimes()
+			// TSC arg must be nil — passing unchanged TSC would reset a running countdown.
+			ms.EXPECT().AddWorkflowExecutionOptionsUpdatedEvent(
+				newOverride, false, "", nil, nil, "", nil, nil, nil,
+			).Return(&historypb.HistoryEvent{}, nil)
+
+			result, hasChanges, err := MergeAndApply(
+				ms,
+				&workflowpb.WorkflowExecutionOptions{VersioningOverride: newOverride},
+				&fieldmaskpb.FieldMask{Paths: []string{"versioning_override"}},
+				"",
+			)
+			require.NoError(t, err)
+			require.True(t, hasChanges)
+			require.True(t, proto.Equal(tc.tsc, result.GetTimeSkippingConfig()))
 		})
 	}
 }

--- a/service/history/interfaces/mutable_state.go
+++ b/service/history/interfaces/mutable_state.go
@@ -119,6 +119,10 @@ type (
 		AddWorkflowExecutionStartedEvent(*commonpb.WorkflowExecution, *historyservice.StartWorkflowExecutionRequest) (*historypb.HistoryEvent, error)
 		AddWorkflowExecutionStartedEventWithOptions(*commonpb.WorkflowExecution, *historyservice.StartWorkflowExecutionRequest, *workflowpb.ResetPoints, string, string) (*historypb.HistoryEvent, error)
 		AddWorkflowExecutionTerminatedEvent(reason string, details *commonpb.Payloads, identity string, deleteAfterTerminate bool, links []*commonpb.Link) (*historypb.HistoryEvent, error)
+		// AddWorkflowExecutionOptionsUpdatedEvent records a WorkflowExecutionOptionsUpdated event.
+		// Exception: nil timeSkippingConfig means "no change to time skipping" — it does NOT disable
+		// time skipping. Pass a non-nil value only when the TSC actually changed or the bound is being
+		// renewed; nil prevents applyTimeSkippingBound from resetting a running MaxElapsedDuration countdown.
 		AddWorkflowExecutionOptionsUpdatedEvent(
 			versioningOverride *workflowpb.VersioningOverride,
 			unsetVersioningOverride bool,

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -5940,6 +5940,8 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionOptionsUpdatedEvent(event *his
 		ms.executionInfo.Priority = attributes.GetPriority()
 	}
 
+	// TimeSkippingConfig is considered to be an option with side effects,
+	// so it is only nil if the config is unchanged.
 	if tsc := attributes.GetTimeSkippingConfig(); tsc != nil {
 		if ms.GetExecutionInfo().GetTimeSkippingInfo() == nil {
 			ms.initTimeSkippingInfo(tsc, nil, event.GetEventId())


### PR DESCRIPTION
## What changed and Why
 
UpdateWorkflowExecutionOptions uses a merge logic where the requested fields overwrite the current
options. This does not fit TimeSkippingConfig, which has side effects when applied (a timer task is
emitted and the bound target time is recalculated). We need a way to distinguish whether the config is changed. 
We therefore add side-effect update logic with two rules:
  ▎ 1. The workflow options event carries a nil TSC when time skipping is not being updated.
  ▎ 2. Whenever the bound is explicitly set in the request, it is always treated as a change — even if the
  ▎ value is the same as the current one — to renew the countdown.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

