### PR TITLE
Fix activity retry expiration time not recalculated on workflow reset

### DIFF
--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -571,8 +571,13 @@ func (r *workflowResetterImpl) failInflightActivity(
 	for _, ai := range mutableState.GetPendingActivityInfos() {
 		switch ai.StartedEventId {
 		case common.EmptyEventID:
-			// activity not started, noop
 			if err := mutableState.UpdateActivity(ai.ScheduledEventId, func(activityInfo *persistencespb.ActivityInfo, _ historyi.MutableState) error {
+				// Recalculate retry expiration time based on reset time.
+				// Must be done before overwriting ScheduledTime to preserve the original duration.
+				if activityInfo.RetryExpirationTime != nil && activityInfo.ScheduledTime != nil {
+					duration := activityInfo.RetryExpirationTime.AsTime().Sub(activityInfo.ScheduledTime.AsTime())
+					activityInfo.RetryExpirationTime = timestamppb.New(now.Add(duration))
+				}
 				// override the scheduled activity time to now
 				activityInfo.ScheduledTime = timestamppb.New(now)
 				activityInfo.FirstScheduledTime = timestamppb.New(now)


### PR DESCRIPTION
When failInflightActivity resets a workflow, it overwrites ScheduledTime and FirstScheduledTime to the reset time, but RetryExpirationTime was not recalculated. This caused the expiration time to be earlier than the new scheduled time, making activities appear expired immediately after reset.

Fix: compute the retry duration (RetryExpirationTime - ScheduledTime) before overwriting ScheduledTime, then set:
RetryExpirationTime = resetTime + duration

This preserves the original schedule-to-close timeout duration relative to the new scheduled time.

Fixes #6952

## What changed?
In `failInflightActivity`, recalculate `RetryExpirationTime` 
based on the reset time before overwriting `ScheduledTime`.

## Why?
When a workflow is reset, `failInflightActivity` overwrites 
`ScheduledTime` and `FirstScheduledTime` to the reset time, 
but `RetryExpirationTime` was left unchanged. This caused 
the expiration time to be earlier than the new scheduled time, 
making activities appear expired immediately after reset — 
preventing retries from occurring.

The fix preserves the original schedule-to-close timeout 
duration relative to the new reset time:

duration = RetryExpirationTime - ScheduledTime
RetryExpirationTime = resetTime + duration

This must be computed before `ScheduledTime` is overwritten 
to preserve the original duration.

Fixes #6952

## How did you test it?
- [x] built
- [x] covered by existing tests

## Potential risks
Low — only affects activities with a retry expiration time 
set (`RetryExpirationTime != nil`). Activities without a 
retry policy are unaffected. Preserves the original 
schedule-to-close timeout duration relative to reset time.


