### PR TITLE
Bump RecordWorkerHeartbeat rate limit priority to P1

### DIFF
--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -106,6 +106,7 @@ var (
 		"/temporal.api.workflowservice.v1.WorkflowService/RespondQueryTaskCompleted":        1,
 		"/temporal.api.workflowservice.v1.WorkflowService/RespondNexusTaskCompleted":        1,
 		CompleteNexusOperation: 1,
+		"/temporal.api.workflowservice.v1.WorkflowService/RecordWorkerHeartbeat": 1,
 
 		// P2: Change State APIs
 		"/temporal.api.workflowservice.v1.WorkflowService/RequestCancelWorkflowExecution":             2,
@@ -189,7 +190,6 @@ var (
 		"/temporal.api.workflowservice.v1.WorkflowService/ResetStickyTaskQueue":               4,
 		"/temporal.api.workflowservice.v1.WorkflowService/ShutdownWorker":                     4,
 		"/temporal.api.workflowservice.v1.WorkflowService/GetWorkflowExecutionHistoryReverse": 4,
-		"/temporal.api.workflowservice.v1.WorkflowService/RecordWorkerHeartbeat":              4,
 		"/temporal.api.workflowservice.v1.WorkflowService/FetchWorkerConfig":                  4,
 		"/temporal.api.workflowservice.v1.WorkflowService/UpdateWorkerConfig":                 4,
 


### PR DESCRIPTION
## What
Move `RecordWorkerHeartbeat` from P4 to P1 in the frontend rate limiter, alongside `RecordActivityTaskHeartbeat`.

## Why
Worker heartbeats will be eventually used for activity rescheduling, making them critical-path like activity heartbeats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)