### PR TITLE
Require request ID and a completion callback when attaching callbacks on StartActivityExecution conflict

### DIFF
--- a/chasm/lib/activity/frontend.go
+++ b/chasm/lib/activity/frontend.go
@@ -421,6 +421,10 @@ func (h *frontendHandler) validateAndPopulateStartRequest(
 		return nil, err
 	}
 
+	if err := validateOnConflictOptions(req); err != nil {
+		return nil, err
+	}
+
 	return req, nil
 }
 

--- a/chasm/lib/activity/validator.go
+++ b/chasm/lib/activity/validator.go
@@ -226,6 +226,31 @@ func validateAndNormalizeIDPolicy(req *workflowservice.StartActivityExecutionReq
 	return nil
 }
 
+// validateOnConflictOptions validates the on_conflict_options of a start request:
+//   - attach_completion_callbacks requires attach_request_id. A completion callback is recorded
+//     against the request ID (see addCompletionCallbacks, which keys the callback by request ID).
+//   - attach_request_id requires at least one completion callback or link, since attaching a
+//     request ID is only meaningful alongside something to attach.
+//
+// attach_links is independent and may be set on its own.
+func validateOnConflictOptions(req *workflowservice.StartActivityExecutionRequest) error {
+	onConflictOptions := req.GetOnConflictOptions()
+	if onConflictOptions == nil {
+		return nil
+	}
+	if onConflictOptions.GetAttachCompletionCallbacks() && !onConflictOptions.GetAttachRequestId() {
+		return serviceerror.NewInvalidArgument(
+			"on_conflict_options: attach_completion_callbacks requires attach_request_id to be set")
+	}
+	if onConflictOptions.GetAttachRequestId() &&
+		len(req.GetCompletionCallbacks()) == 0 &&
+		len(req.GetLinks()) == 0 {
+		return serviceerror.NewInvalidArgument(
+			"on_conflict_options: attach_request_id requires at least one completion callback or link")
+	}
+	return nil
+}
+
 func validateBlobSize(
 	activityID string,
 	blobSizeViolationTagValue string,

--- a/chasm/lib/activity/validator_test.go
+++ b/chasm/lib/activity/validator_test.go
@@ -718,6 +718,77 @@ func TestValidateStartDelay(t *testing.T) {
 	})
 }
 
+func TestValidateOnConflictOptions(t *testing.T) {
+	t.Run("NilOptions", func(t *testing.T) {
+		require.NoError(t, validateOnConflictOptions(&workflowservice.StartActivityExecutionRequest{}))
+	})
+
+	t.Run("AttachRequestIdAndCallbacksWithCallback", func(t *testing.T) {
+		req := &workflowservice.StartActivityExecutionRequest{
+			CompletionCallbacks: []*commonpb.Callback{{}},
+			OnConflictOptions: &commonpb.OnConflictOptions{
+				AttachRequestId:           true,
+				AttachCompletionCallbacks: true,
+			},
+		}
+		require.NoError(t, validateOnConflictOptions(req))
+	})
+
+	t.Run("AttachLinksOnly", func(t *testing.T) {
+		// Links do not require a request ID; this combination must remain valid.
+		req := &workflowservice.StartActivityExecutionRequest{
+			OnConflictOptions: &commonpb.OnConflictOptions{AttachLinks: true},
+		}
+		require.NoError(t, validateOnConflictOptions(req))
+	})
+
+	t.Run("AttachRequestIdWithLink", func(t *testing.T) {
+		// A request ID alongside a link is valid (request ID has something to attach to).
+		req := &workflowservice.StartActivityExecutionRequest{
+			Links: []*commonpb.Link{{}},
+			OnConflictOptions: &commonpb.OnConflictOptions{
+				AttachRequestId: true,
+				AttachLinks:     true,
+			},
+		}
+		require.NoError(t, validateOnConflictOptions(req))
+	})
+
+	t.Run("AttachCallbacksWithoutRequestId", func(t *testing.T) {
+		req := &workflowservice.StartActivityExecutionRequest{
+			CompletionCallbacks: []*commonpb.Callback{{}},
+			OnConflictOptions:   &commonpb.OnConflictOptions{AttachCompletionCallbacks: true},
+		}
+		err := validateOnConflictOptions(req)
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Contains(t, invalidArgErr.Message, "attach_completion_callbacks requires attach_request_id")
+	})
+
+	t.Run("AttachRequestIdWithoutCallbackOrLink", func(t *testing.T) {
+		req := &workflowservice.StartActivityExecutionRequest{
+			OnConflictOptions: &commonpb.OnConflictOptions{AttachRequestId: true},
+		}
+		err := validateOnConflictOptions(req)
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Contains(t, invalidArgErr.Message, "attach_request_id requires at least one completion callback or link")
+	})
+
+	t.Run("AttachRequestIdAndCallbacksWithoutCallbackProvided", func(t *testing.T) {
+		req := &workflowservice.StartActivityExecutionRequest{
+			OnConflictOptions: &commonpb.OnConflictOptions{
+				AttachRequestId:           true,
+				AttachCompletionCallbacks: true,
+			},
+		}
+		err := validateOnConflictOptions(req)
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Contains(t, invalidArgErr.Message, "attach_request_id requires at least one completion callback or link")
+	})
+}
+
 func getDefaultRetrySettings(_ string) retrypolicy.DefaultRetrySettings {
 	return retrypolicy.DefaultRetrySettings{
 		InitialInterval:            time.Second,


### PR DESCRIPTION
## What changed?

`StartActivityExecution` now validates `on_conflict_options` (`chasm/lib/activity/validator.go`, called from `validateAndPopulateStartRequest` in `chasm/lib/activity/frontend.go`):

- When `attach_completion_callbacks` is set, the request must also set `attach_request_id` **and** include at least one `completion_callbacks` entry; otherwise the request fails with `InvalidArgument`.
- `attach_links` and `attach_request_id` remain independently valid.

Added unit tests in `chasm/lib/activity/validator_test.go` (nil, request-id+callbacks+callback, links-only, request-id-only → ok; callbacks-without-request-id, callbacks-flag-without-callbacks → error).

## Why?

On the `USE_EXISTING` conflict path, `on_conflict_options` can attach completion callbacks to the already-running activity. A completion callback is keyed to the request ID, but the request ID is only recorded on the existing execution when `attach_request_id` is set — so attaching callbacks without the request ID orphans the callback, and `attach_completion_callbacks` with no callbacks provided is a no-op (the handler gates on `attach_completion_callbacks && len(callbacks) > 0`). Per review feedback, the server should reject these invalid combinations instead of silently accepting them.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

Ran `go test ./chasm/lib/activity/` and the standalone-activity functional tests locally: `TestStandaloneActivityTestSuite/TestStart` (covers `AttachLinksOnConflictUnionsLinks` and the `OnConflictOptions` subtest) and `.../TestCallbacksDisabled` both pass. All CI functional tests pass.

## Potential risks

- **Rejects previously-accepted (no-op) requests:** callbacks-without-request-id and callbacks-flag-without-callbacks now return `InvalidArgument`. These did nothing useful before, but any caller relying on the silent no-op behavior would now get an error.
- **Links scope:** the rule is intentionally scoped to callbacks; `attach_links`-only stays valid. An earlier stricter version rejected everything except `{request_id + callbacks}` and broke `AttachLinksOnConflictUnionsLinks`. If links should also be restricted, that's a follow-up that changes those existing tests.
- **Related gap (not addressed here):** `AttachRequestId` is currently a no-op on the activity conflict path (no references to it in `chasm/lib/activity/`; the conflict block only attaches callbacks/links). With this validation in place, the handler should also record the request ID on the existing execution when `AttachRequestId` is set, mirroring the workflow path's `AddWorkflowExecutionOptionsUpdatedEvent(..., requestID, completionCallbacks, ...)`. Can be folded in here or as a follow-up.