### PR TITLE
UUID for test databases

### DIFF
--- a/common/persistence/persistence-tests/persistence_test_base.go
+++ b/common/persistence/persistence-tests/persistence_test_base.go
@@ -4,11 +4,11 @@ import (
 	"cmp"
 	"context"
 	"fmt"
-	"math/rand"
 	"strings"
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 	"go.opentelemetry.io/otel/trace"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
@@ -129,7 +129,7 @@ func NewTestBaseWithCassandra(options *TestBaseOptions) *TestBase {
 
 func NewTestClusterForCassandra(options *TestBaseOptions, logger log.Logger) *cassandra.TestCluster {
 	if options.DBName == "" {
-		options.DBName = "test_" + GenerateRandomDBName(3)
+		options.DBName = GenerateRandomDBName()
 	}
 	testCluster := cassandra.NewTestCluster(options.DBName, options.DBUsername, options.DBPassword, options.DBHost, options.DBPort, options.SchemaDir, options.FaultInjection, logger)
 	return testCluster
@@ -436,23 +436,10 @@ func (s *TestBase) RangeDeleteMessagesFromNamespaceDLQ(
 	return s.NamespaceReplicationQueue.RangeDeleteMessagesFromDLQ(ctx, firstMessageID, lastMessageID)
 }
 
-func randString(length int) string {
-	const lowercaseSet = "abcdefghijklmnopqrstuvwxyz"
-	b := make([]byte, length)
-	for i := range b {
-		b[i] = lowercaseSet[rand.Int63()%int64(len(lowercaseSet))]
-	}
-	return string(b)
-}
-
-// GenerateRandomDBName helper
-// Format: MMDDHHMMSS_abc
-func GenerateRandomDBName(n int) string {
-	var prefix strings.Builder
-	prefix.WriteString(time.Now().UTC().Format("0102150405"))
-	prefix.WriteRune('_')
-	prefix.WriteString(randString(n))
-	return prefix.String()
+func GenerateRandomDBName() string {
+	uuidPart := strings.ReplaceAll(uuid.NewString(), "-", "")
+	// Keep generated DB names short enough for Cassandra keyspaces after XDC tests append cluster suffixes.
+	return "test_" + uuidPart[:24]
 }
 
 func timeComparator(t1, t2 time.Time, timeTolerance time.Duration) bool {

--- a/common/persistence/persistence-tests/setup.go
+++ b/common/persistence/persistence-tests/setup.go
@@ -54,7 +54,7 @@ func GetTestClusterOption(storeType, driver string) *TestBaseOptions {
 // GetCassandraTestClusterOption returns test options
 func GetCassandraTestClusterOption() *TestBaseOptions {
 	return &TestBaseOptions{
-		DBName:    "test_" + GenerateRandomDBName(3),
+		DBName:    GenerateRandomDBName(),
 		DBHost:    environment.GetCassandraAddress(),
 		DBPort:    environment.GetCassandraPort(),
 		SchemaDir: testCassandraSchemaDir,
@@ -66,7 +66,7 @@ func GetCassandraTestClusterOption() *TestBaseOptions {
 func GetMySQLTestClusterOption() *TestBaseOptions {
 	return &TestBaseOptions{
 		SQLDBPluginName: mysql.PluginName,
-		DBName:          "test_" + GenerateRandomDBName(3),
+		DBName:          GenerateRandomDBName(),
 		DBUsername:      testMySQLUser,
 		DBPassword:      testMySQLPassword,
 		DBHost:          environment.GetMySQLAddress(),
@@ -94,7 +94,7 @@ func GetPostgreSQLTestClusterOption(
 	}
 	return &TestBaseOptions{
 		SQLDBPluginName:   pluginName,
-		DBName:            "test_" + GenerateRandomDBName(3),
+		DBName:            GenerateRandomDBName(),
 		DBUsername:        testPostgreSQLUser,
 		DBPassword:        testPostgreSQLPassword,
 		DBHost:            environment.GetPostgreSQLAddress(),
@@ -109,7 +109,7 @@ func GetPostgreSQLTestClusterOption(
 func GetSQLiteFileTestClusterOption() *TestBaseOptions {
 	return &TestBaseOptions{
 		SQLDBPluginName: sqlite.PluginName,
-		DBName:          filepath.Join(os.TempDir(), "test_"+GenerateRandomDBName(3)), // put files in temp to avoid cluttering the project
+		DBName:          filepath.Join(os.TempDir(), GenerateRandomDBName()), // put files in temp to avoid cluttering the project
 		DBUsername:      testSQLiteUser,
 		DBPassword:      testSQLitePassword,
 		DBHost:          environment.GetLocalhostIP(),
@@ -129,7 +129,7 @@ func GetSQLiteFileTestClusterOption() *TestBaseOptions {
 func GetSQLiteMemoryTestClusterOption() *TestBaseOptions {
 	return &TestBaseOptions{
 		SQLDBPluginName:   sqlite.PluginName,
-		DBName:            "test_" + GenerateRandomDBName(3),
+		DBName:            GenerateRandomDBName(),
 		DBUsername:        testSQLiteUser,
 		DBPassword:        testSQLitePassword,
 		DBHost:            environment.GetLocalhostIP(),

--- a/common/persistence/sql/test_sql_persistence.go
+++ b/common/persistence/sql/test_sql_persistence.go
@@ -175,7 +175,12 @@ func (s *TestCluster) DropDatabase() {
 func (s *TestCluster) LoadSchema(schemaFile string) {
 	statements, err := p.LoadAndSplitQuery([]string{schemaFile})
 	if err != nil {
-		s.logger.Fatal("LoadSchema", tag.Error(err))
+		s.logger.Fatal(
+			fmt.Sprintf("LoadSchema %s: %v", schemaFile, err),
+			tag.Error(err),
+			tag.String("database", s.cfg.DatabaseName),
+			tag.String("schema-file", schemaFile),
+		)
 	}
 
 	var db sqlplugin.AdminDB
@@ -201,9 +206,16 @@ func (s *TestCluster) LoadSchema(schemaFile string) {
 		statements = rewriter.RewriteSchemaStatements(statements)
 	}
 
-	for _, stmt := range statements {
+	for i, stmt := range statements {
 		if err = db.Exec(stmt); err != nil {
-			s.logger.Fatal("LoadSchema", tag.Error(err))
+			s.logger.Fatal(
+				fmt.Sprintf("LoadSchema statement %d for database %s: %v", i, s.cfg.DatabaseName, err),
+				tag.Error(err),
+				tag.String("database", s.cfg.DatabaseName),
+				tag.String("schema-file", schemaFile),
+				tag.Int("statement-index", i),
+				tag.String("statement", stmt),
+			)
 		}
 	}
 	s.logger.Info("loaded schema")

--- a/common/persistence/tests/sqlite_test.go
+++ b/common/persistence/tests/sqlite_test.go
@@ -53,7 +53,7 @@ func NewSQLiteFileConfig() *config.SQL {
 		ConnectAddr:       environment.GetLocalhostIP(),
 		ConnectProtocol:   "tcp",
 		PluginName:        "sqlite",
-		DatabaseName:      "test_" + persistencetests.GenerateRandomDBName(3),
+		DatabaseName:      persistencetests.GenerateRandomDBName(),
 		ConnectAttributes: map[string]string{"cache": "private"},
 	}
 }

--- a/tools/sql/clitest/version_tests.go
+++ b/tools/sql/clitest/version_tests.go
@@ -53,8 +53,8 @@ func (s *VersionTestSuite) SetupTest() {
 
 // TestVerifyCompatibleVersion test
 func (s *VersionTestSuite) TestVerifyCompatibleVersion() {
-	database := "temporal_ver_test_" + persistencetests.GenerateRandomDBName(3)
-	visDatabase := "temporal_vis_ver_test_" + persistencetests.GenerateRandomDBName(3)
+	database := persistencetests.GenerateRandomDBName()
+	visDatabase := persistencetests.GenerateRandomDBName()
 
 	defer s.createDatabase(database)()
 	defer s.createDatabase(visDatabase)()


### PR DESCRIPTION
## What changed?

Use UUID for database names.

## Why?

From https://github.com/temporalio/temporal/actions/runs/27384406387

```
panic: FATAL: LoadSchema [recovered, repanicked]
goroutine 928163 [running]:

testing.tRunner.func1.2({0x680fe20, 0xc06cafdb30})

/opt/hostedtoolcache/go/1.26.4/arm64/src/testing/testing.go:1974 +0x2b8

testing.tRunner.func1()

/opt/hostedtoolcache/go/1.26.4/arm64/src/testing/testing.go:1977 +0x460

panic({0x680fe20?, 0xc06cafdb30?})

/opt/hostedtoolcache/go/1.26.4/arm64/src/runtime/panic.go:860 +0x12c

go.uber.org/zap/zapcore.CheckWriteAction.OnWrite(0x2, 0xc073c7d110, {0x7e042e0?, 0x33?, 0xc035698000?})

/home/runner/go/pkg/mod/go.uber.org/zap@v1.27.1/zapcore/entry.go:196 +0xa8

go.uber.org/zap/zapcore.(*CheckedEntry).Write(0xc073c7d110, {0xc07be44680, 0x2, 0x2})

/home/runner/go/pkg/mod/go.uber.org/zap@v1.27.1/zapcore/entry.go:272 +0x278

go.uber.org/zap.(*Logger).Panic(0xc03360c400, {0xc075e3bda0, 0x11}, {0xc07be44680, 0x2, 0x2})

/home/runner/go/pkg/mod/go.uber.org/zap@v1.27.1/logger.go:285 +0x60

go.temporal.io/server/common/log.(*zapLogger).Panic(0xc0361fe750, {0xc075e3bda0, 0x11}, {0xc06cafdac0, 0x1, 0x1})

/home/runner/work/temporal/temporal/common/log/zap_logger.go:174 +0x1b4

go.temporal.io/server/common/testing/testlogger.(*TestLogger).Fatal(0xc0361fe5d0, {0x755ae1f, 0xa}, {0xc06cafdac0, 0x1, 0x1})

/home/runner/work/temporal/temporal/common/testing/testlogger/testlogger.go:506 +0x2c8

go.temporal.io/server/common/persistence/sql.(*TestCluster).LoadSchema(0xc0542a5ce0, {0xc074d4b680, 0x47})

/home/runner/work/temporal/temporal/common/persistence/sql/test_sql_persistence.go:206 +0x804

go.temporal.io/server/common/persistence/sql.(*TestCluster).SetupTestDatabase(0xc0542a5ce0)

/home/runner/work/temporal/temporal/common/persistence/sql/test_sql_persistence.go:84 +0x21c

go.temporal.io/server/common/persistence/persistence-tests.(*TestBase).Setup(0xc05af8d1e0, 0xc08d0b6040)

/home/runner/work/temporal/temporal/common/persistence/persistence-tests/persistence_test_base.go:206 +0x2b4

go.temporal.io/server/tests/testcore.newClusterWithPersistenceTestBaseFactory(0xc05dfe3208, 0xc05af8d040, {0x7
```

_might_ indicate a potential database name conflict. It's not 100% clear but this doesn't hurt IMO.
