### PR TITLE
Cherry-pick: PGX SimpleProtocol test suite (#10198)

### DIFF
--- a/common/persistence/persistencetest/queues.go
+++ b/common/persistence/persistencetest/queues.go
@@ -43,8 +43,8 @@ func GetQueueKey(t *testing.T, opts ...func(p *getQueueKeyParams)) persistence.Q
 	return persistence.QueueKey{
 		QueueType:     params.QueueType,
 		Category:      params.Category,
-		SourceCluster: "test-source-cluster-" + t.Name(),
-		TargetCluster: "test-target-cluster-" + t.Name(),
+		SourceCluster: "src-" + t.Name(),
+		TargetCluster: "tgt-" + t.Name(),
 	}
 }
 

--- a/common/persistence/persistencetest/queues_test.go
+++ b/common/persistence/persistencetest/queues_test.go
@@ -3,7 +3,7 @@ package persistencetest_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/persistencetest"
 	"go.temporal.io/server/service/history/tasks"
@@ -13,10 +13,10 @@ func TestGetQueueKey_Default(t *testing.T) {
 	t.Parallel()
 
 	queueKey := persistencetest.GetQueueKey(t)
-	assert.Equal(t, persistence.QueueTypeHistoryNormal, queueKey.QueueType)
-	assert.Equal(t, tasks.CategoryTransfer, queueKey.Category)
-	assert.Equal(t, "test-source-cluster-TestGetQueueKey_Default", queueKey.SourceCluster)
-	assert.Equal(t, "test-target-cluster-TestGetQueueKey_Default", queueKey.TargetCluster)
+	require.Equal(t, persistence.QueueTypeHistoryNormal, queueKey.QueueType)
+	require.Equal(t, tasks.CategoryTransfer, queueKey.Category)
+	require.Equal(t, "src-TestGetQueueKey_Default", queueKey.SourceCluster)
+	require.Equal(t, "tgt-TestGetQueueKey_Default", queueKey.TargetCluster)
 }
 
 func TestGetQueueKey_WithOptions(t *testing.T) {
@@ -26,8 +26,8 @@ func TestGetQueueKey_WithOptions(t *testing.T) {
 		persistencetest.WithQueueType(persistence.QueueTypeHistoryDLQ),
 		persistencetest.WithCategory(tasks.CategoryTimer),
 	)
-	assert.Equal(t, persistence.QueueTypeHistoryDLQ, queueKey.QueueType)
-	assert.Equal(t, tasks.CategoryTimer, queueKey.Category)
-	assert.Equal(t, "test-source-cluster-TestGetQueueKey_WithOptions", queueKey.SourceCluster)
-	assert.Equal(t, "test-target-cluster-TestGetQueueKey_WithOptions", queueKey.TargetCluster)
+	require.Equal(t, persistence.QueueTypeHistoryDLQ, queueKey.QueueType)
+	require.Equal(t, tasks.CategoryTimer, queueKey.Category)
+	require.Equal(t, "src-TestGetQueueKey_WithOptions", queueKey.SourceCluster)
+	require.Equal(t, "tgt-TestGetQueueKey_WithOptions", queueKey.TargetCluster)
 }

--- a/common/persistence/query_util.go
+++ b/common/persistence/query_util.go
@@ -14,14 +14,22 @@ const (
 	queryDelimiter        = ';'
 	querySliceDefaultSize = 100
 
-	sqlLeftParenthesis  = '('
-	sqlRightParenthesis = ')'
-	sqlIfKeyword        = "if"
-	sqlBeginKeyword     = "begin"
-	sqlEndKeyword       = "end"
-	sqlLineComment      = "--"
-	sqlSingleQuote      = '\''
-	sqlDoubleQuote      = '"'
+	sqlLeftParenthesis     = '('
+	sqlRightParenthesis    = ')'
+	sqlCreateKeyword       = "create"
+	sqlTableKeyword        = "table"
+	sqlIndexKeyword        = "index"
+	sqlConcurrentlyKeyword = "concurrently"
+	sqlAddKeyword          = "add"
+	sqlColumnKeyword       = "column"
+	sqlDoubleDollarKeyword = "$$"
+	sqlIfKeyword           = "if"
+	sqlLoopKeyword         = "loop"
+	sqlBeginKeyword        = "begin"
+	sqlEndKeyword          = "end"
+	sqlLineComment         = "--"
+	sqlSingleQuote         = '\''
+	sqlDoubleQuote         = '"'
 )
 
 // LoadAndSplitQuery loads and split cql / sql query into one statement per string.
@@ -78,11 +86,37 @@ func LoadAndSplitQueryFromReaders(
 					}
 					st = st[:len(st)-1]
 
-				case sqlIfKeyword[0]:
-					if hasWordAt(contentStr, sqlIfKeyword, j) {
-						st = append(st, sqlIfKeyword[0])
-						j += len(sqlIfKeyword) - 1
+				case sqlDoubleDollarKeyword[0]:
+					if !hasWordAt(contentStr, sqlDoubleDollarKeyword, j) {
+						continue
 					}
+					if len(st) == 0 || st[len(st)-1] != sqlDoubleDollarKeyword[0] {
+						st = append(st, sqlDoubleDollarKeyword[0])
+						j += len(sqlDoubleDollarKeyword) - 1
+					} else {
+						st = st[:len(st)-1]
+						j += len(sqlDoubleDollarKeyword) - 1
+					}
+
+				case sqlIfKeyword[0]:
+					if !hasWordAt(contentStr, sqlIfKeyword, j) {
+						continue
+					}
+					if hasWordsBefore(contentStr, j-1, sqlAddKeyword, sqlColumnKeyword) ||
+						hasWordsBefore(contentStr, j-1, sqlCreateKeyword, sqlIndexKeyword) ||
+						hasWordsBefore(contentStr, j-1, sqlCreateKeyword, sqlIndexKeyword, sqlConcurrentlyKeyword) ||
+						hasWordsBefore(contentStr, j-1, sqlCreateKeyword, sqlTableKeyword) {
+						continue
+					}
+					st = append(st, sqlIfKeyword[0])
+					j += len(sqlIfKeyword) - 1
+
+				case sqlLoopKeyword[0]:
+					if !hasWordAt(contentStr, sqlLoopKeyword, j) {
+						continue
+					}
+					st = append(st, sqlLoopKeyword[0])
+					j += len(sqlLoopKeyword) - 1
 
 				case sqlBeginKeyword[0]:
 					if hasWordAt(contentStr, sqlBeginKeyword, j) {
@@ -100,6 +134,13 @@ func LoadAndSplitQueryFromReaders(
 						}
 						st = st[:len(st)-1]
 						j = after + len(sqlIfKeyword) - 1
+					} else if ok, after := hasWordAfter(contentStr, sqlLoopKeyword, j+len(sqlEndKeyword)); ok {
+						//nolint:revive
+						if len(st) == 0 || st[len(st)-1] != sqlLoopKeyword[0] {
+							return nil, errors.New("error reading contents: unmatched `END LOOP` keyword")
+						}
+						st = st[:len(st)-1]
+						j = after + len(sqlLoopKeyword) - 1
 					} else {
 						if len(st) == 0 || st[len(st)-1] != sqlBeginKeyword[0] {
 							return nil, errors.New("error reading contents: unmatched `END` keyword")
@@ -181,6 +222,35 @@ func hasWordAfter(s, word string, pos int) (bool, int) {
 		return false, after
 	}
 	return hasWordAt(s, word, after), after
+}
+
+// hasWordsBefore checks if the given words appears before position pos in s,
+// separated by at least one space, and each word is a whole word.
+// Words must appear is the given order.
+// Eg: hasWordsBefore("CREATE TABLE IF", 12, "CREATE", "TABLE") returns true.
+func hasWordsBefore(s string, pos int, words ...string) bool {
+	if len(words) == 0 {
+		return true
+	}
+	if pos <= 0 || !unicode.IsSpace(rune(s[pos])) {
+		return false
+	}
+	for i := len(words) - 1; i >= 0; i-- {
+		// skip spaces
+		for pos >= 0 && unicode.IsSpace(rune(s[pos])) {
+			pos--
+		}
+		// go to first char of word
+		for pos > 0 && isAlphanumeric(s[pos-1]) {
+			pos--
+		}
+		// check if current pos matches the word
+		if pos < 0 || !hasWordAt(s, words[i], pos) {
+			return false
+		}
+		pos--
+	}
+	return true
 }
 
 func isAlphanumeric(c byte) bool {

--- a/common/persistence/query_util_test.go
+++ b/common/persistence/query_util_test.go
@@ -128,3 +128,54 @@ func (s *queryUtilSuite) TestHasWordAt() {
 	s.False(hasWordAt("7BEGIN", "BEGIN", 1))
 	s.False(hasWordAt("BEGIN7", "BEGIN", 0))
 }
+
+func (s *queryUtilSuite) TestHasWordsBefore() {
+	// example from the function's doc comment
+	s.True(hasWordsBefore("CREATE TABLE IF", 12, "CREATE", "TABLE"))
+
+	// empty words slice always returns true, regardless of pos
+	s.True(hasWordsBefore("CREATE TABLE", 6))
+	s.True(hasWordsBefore("", 0))
+	s.True(hasWordsBefore("anything", 3))
+
+	// pos <= 0 returns false when words are provided
+	s.False(hasWordsBefore("CREATE TABLE", 0, "CREATE"))
+	s.False(hasWordsBefore(" CREATE", 0, "CREATE"))
+	s.False(hasWordsBefore("    CREATE", 2, "CREATE"))
+
+	// pos must point to a whitespace character
+	s.False(hasWordsBefore("CREATE TABLE", 5, "CREATE")) // s[5]='E'
+	s.False(hasWordsBefore("CREATE TABLE", 4, "CREATE")) // s[4]='T'
+
+	// single word matches
+	s.True(hasWordsBefore("CREATE TABLE", 6, "CREATE"))
+	s.True(hasWordsBefore("  CREATE ", 8, "CREATE"))  // leading whitespace ok
+	s.True(hasWordsBefore("(CREATE ", 7, "CREATE"))   // preceded by non-alphanumeric
+	s.True(hasWordsBefore("CREATE\tIF", 6, "CREATE")) // tab counts as whitespace
+	s.True(hasWordsBefore("CREATE   ", 8, "CREATE"))  // multiple trailing spaces ok
+
+	// single word - wrong word at that position
+	s.False(hasWordsBefore("CREATE TABLE", 6, "TABLE"))
+
+	// word must be a whole word (alphanumeric adjacency rejected)
+	s.False(hasWordsBefore("XCREATE ", 7, "CREATE"))
+	s.False(hasWordsBefore("7CREATE ", 7, "CREATE"))
+
+	// multiple words match in order
+	s.True(hasWordsBefore("ADD COLUMN IF", 10, "ADD", "COLUMN"))
+	s.True(hasWordsBefore("CREATE INDEX IF", 12, "CREATE", "INDEX"))
+
+	// multiple words with extra whitespace between them
+	s.True(hasWordsBefore("CREATE  TABLE  IF", 14, "CREATE", "TABLE"))
+	s.True(hasWordsBefore("CREATE\tTABLE\tIF", 12, "CREATE", "TABLE"))
+
+	// words in wrong order
+	s.False(hasWordsBefore("CREATE TABLE IF", 12, "TABLE", "CREATE"))
+
+	// one of the words is missing / different
+	s.False(hasWordsBefore("CREATE FOO IF", 10, "CREATE", "TABLE"))
+	s.False(hasWordsBefore("DROP TABLE IF", 10, "CREATE", "TABLE"))
+
+	// more words requested than are available before pos
+	s.False(hasWordsBefore("TABLE ", 5, "CREATE", "TABLE"))
+}

--- a/common/persistence/tests/postgresql_test.go
+++ b/common/persistence/tests/postgresql_test.go
@@ -18,11 +18,12 @@ import (
 
 type PostgreSQLSuite struct {
 	suite.Suite
-	pluginName string
+	pluginName   string
+	connectAttrs map[string]string
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLShardStoreSuite() {
-	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName)
+	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName, p.connectAttrs)
 	defer tearDown()
 
 	shardStore, err := testData.Factory.NewShardStore()
@@ -40,7 +41,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLShardStoreSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLExecutionMutableStateStoreSuite() {
-	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName)
+	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName, p.connectAttrs)
 	defer tearDown()
 
 	shardStore, err := testData.Factory.NewShardStore()
@@ -64,7 +65,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLExecutionMutableStateStoreSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLExecutionMutableStateTaskStoreSuite() {
-	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName)
+	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName, p.connectAttrs)
 	defer tearDown()
 
 	shardStore, err := testData.Factory.NewShardStore()
@@ -87,7 +88,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLExecutionMutableStateTaskStoreSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryStoreSuite() {
-	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName)
+	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName, p.connectAttrs)
 	defer tearDown()
 
 	store, err := testData.Factory.NewExecutionStore()
@@ -100,7 +101,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryStoreSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLTaskQueueSuite() {
-	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName)
+	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName, p.connectAttrs)
 	defer tearDown()
 
 	taskQueueStore, err := testData.Factory.NewTaskStore()
@@ -113,7 +114,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLTaskQueueSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLFairTaskQueueSuite() {
-	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName)
+	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName, p.connectAttrs)
 	defer tearDown()
 
 	taskQueueStore, err := testData.Factory.NewFairTaskStore()
@@ -126,7 +127,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLFairTaskQueueSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLTaskQueueTaskSuite() {
-	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName)
+	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName, p.connectAttrs)
 	defer tearDown()
 
 	taskQueueStore, err := testData.Factory.NewTaskStore()
@@ -139,7 +140,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLTaskQueueTaskSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLTaskQueueFairTaskSuite() {
-	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName)
+	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName, p.connectAttrs)
 	defer tearDown()
 
 	taskQueueStore, err := testData.Factory.NewFairTaskStore()
@@ -152,7 +153,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLTaskQueueFairTaskSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLTaskQueueUserDataSuite() {
-	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName)
+	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName, p.connectAttrs)
 	defer tearDown()
 
 	taskQueueStore, err := testData.Factory.NewTaskStore()
@@ -204,7 +205,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLQueuePersistence() {
 // SQL store tests
 
 func (p *PostgreSQLSuite) TestPostgreSQLNamespaceSuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -221,7 +222,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLNamespaceSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLQueueMessageSuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -238,7 +239,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLQueueMessageSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLQueueMetadataSuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -255,7 +256,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLQueueMetadataSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLMatchingTaskSuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -272,7 +273,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLMatchingTaskSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLMatchingTaskV2Suite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -289,7 +290,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLMatchingTaskV2Suite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLMatchingTaskQueueSuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -306,7 +307,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLMatchingTaskQueueSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLMatchingFairTaskQueueSuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -323,7 +324,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLMatchingFairTaskQueueSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryShardSuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -340,7 +341,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryShardSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryNodeSuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -357,7 +358,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryNodeSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryTreeSuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -374,7 +375,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryTreeSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryCurrentExecutionSuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -391,7 +392,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryCurrentExecutionSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionSuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -408,7 +409,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryTransferTaskSuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -425,7 +426,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryTransferTaskSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryTimerTaskSuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -442,7 +443,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryTimerTaskSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryReplicationTaskSuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -459,7 +460,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryReplicationTaskSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryVisibilityTaskSuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -476,7 +477,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryVisibilityTaskSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryReplicationDLQTaskSuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -493,7 +494,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryReplicationDLQTaskSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionBufferSuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -510,7 +511,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionBufferSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionActivitySuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -527,7 +528,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionActivitySuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionChildWorkflowSuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -544,7 +545,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionChildWorkflowSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionTimerSuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -561,7 +562,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionTimerSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgresHistoryExecutionChasmSuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 
@@ -579,7 +580,7 @@ func (p *PostgreSQLSuite) TestPostgresHistoryExecutionChasmSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionRequestCancelSuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -596,7 +597,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionRequestCancelSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionSignalSuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -613,7 +614,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionSignalSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionSignalRequestSuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -630,7 +631,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionSignalRequestSuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLVisibilitySuite() {
-	cfg := NewPostgreSQLConfig(p.pluginName)
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
 	SetupPostgreSQLDatabase(p.T(), cfg)
 	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindVisibility, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -647,7 +648,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLVisibilitySuite() {
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLClosedConnectionError() {
-	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName)
+	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName, p.connectAttrs)
 	defer tearDown()
 
 	s := newConnectionSuite(p.T(), testData.Factory)
@@ -655,13 +656,13 @@ func (p *PostgreSQLSuite) TestPostgreSQLClosedConnectionError() {
 }
 
 func (p *PostgreSQLSuite) TestPGQueueV2() {
-	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName)
+	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName, p.connectAttrs)
 	p.T().Cleanup(tearDown)
 	RunQueueV2TestSuiteForSQL(p.T(), testData.Factory)
 }
 
 func (p *PostgreSQLSuite) TestPostgreSQLNexusEndpointPersistence() {
-	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName)
+	testData, tearDown := setUpPostgreSQLTest(p.T(), p.pluginName, p.connectAttrs)
 	p.T().Cleanup(tearDown)
 	RunNexusEndpointTestSuiteForSQL(p.T(), testData.Factory)
 }
@@ -673,5 +674,21 @@ func TestPQ(t *testing.T) {
 
 func TestPGX(t *testing.T) {
 	s := &PostgreSQLSuite{pluginName: "postgres12_pgx"}
+	suite.Run(t, s)
+}
+
+// TestPGXSP exercises the pgx plugin in simple-protocol mode, the
+// configuration users land on when fronting Postgres with PgBouncer in
+// transaction pooling. In that mode pgx text-encodes parameters client-side
+// without OID hints, which previously caused proto enum fields (e.g.
+// CurrentExecutionsRow.State) to be serialized via fmt.Stringer, producing
+// values like "Created" instead of integers and breaking inserts into
+// integer columns. See temporalio/temporal#9804.
+func TestPGXSP(t *testing.T) {
+	t.Parallel()
+	s := &PostgreSQLSuite{
+		pluginName:   "postgres12_pgx",
+		connectAttrs: map[string]string{"default_query_exec_mode": "simple_protocol"},
+	}
 	suite.Run(t, s)
 }

--- a/common/persistence/tests/postgresql_test_util.go
+++ b/common/persistence/tests/postgresql_test_util.go
@@ -44,9 +44,9 @@ type (
 	}
 )
 
-func setUpPostgreSQLTest(t *testing.T, pluginName string) (PostgreSQLTestData, func()) {
+func setUpPostgreSQLTest(t *testing.T, pluginName string, connectAttrs map[string]string) (PostgreSQLTestData, func()) {
 	var testData PostgreSQLTestData
-	testData.Cfg = NewPostgreSQLConfig(pluginName)
+	testData.Cfg = NewPostgreSQLConfig(pluginName, connectAttrs)
 	testData.Logger = log.NewZapLogger(zaptest.NewLogger(t))
 	mh := metricstest.NewCaptureHandler()
 	testData.Metrics = mh.StartCapture()
@@ -71,7 +71,7 @@ func setUpPostgreSQLTest(t *testing.T, pluginName string) (PostgreSQLTestData, f
 }
 
 // NewPostgreSQLConfig returns a new MySQL config for test
-func NewPostgreSQLConfig(pluginName string) *config.SQL {
+func NewPostgreSQLConfig(pluginName string, connectAttrs map[string]string) *config.SQL {
 	return &config.SQL{
 		User:     testPostgreSQLUser,
 		Password: testPostgreSQLPassword,
@@ -79,9 +79,10 @@ func NewPostgreSQLConfig(pluginName string) *config.SQL {
 			environment.GetPostgreSQLAddress(),
 			strconv.Itoa(environment.GetPostgreSQLPort()),
 		),
-		ConnectProtocol: testPostgreSQLConnectionProtocol,
-		PluginName:      pluginName,
-		DatabaseName:    testPostgreSQLDatabaseNamePrefix + shuffle.String(testPostgreSQLDatabaseNameSuffix),
+		ConnectProtocol:   testPostgreSQLConnectionProtocol,
+		PluginName:        pluginName,
+		DatabaseName:      testPostgreSQLDatabaseNamePrefix + shuffle.String(testPostgreSQLDatabaseNameSuffix),
+		ConnectAttributes: connectAttrs,
 	}
 }
 

--- a/schema/postgresql/v12/visibility/versioned/v1.10/manifest.json
+++ b/schema/postgresql/v12/visibility/versioned/v1.10/manifest.json
@@ -2,7 +2,6 @@
     "CurrVersion": "1.10",
     "MinCompatibleVersion": "0.1",
     "Description": "add TemporalReportedProblems column",
-    "SchemaUpdateCqlFiles": [
-        "add_temporal_reported_columns.sql"
-    ]
+    "SchemaUpdateCqlFiles": [],
+    "AllowNoCqlFiles": true
 }

--- a/schema/postgresql/v12/visibility/versioned/v1.11/manifest.json
+++ b/schema/postgresql/v12/visibility/versioned/v1.11/manifest.json
@@ -2,7 +2,6 @@
   "CurrVersion": "1.11",
   "MinCompatibleVersion": "0.1",
   "Description": "add CHASM search attributes columns and indices",
-  "SchemaUpdateCqlFiles": [
-    "add_chasm_search_attributes.sql"
-  ]
+  "SchemaUpdateCqlFiles": [],
+  "AllowNoCqlFiles": true
 }

--- a/schema/postgresql/v12/visibility/versioned/v1.12/manifest.json
+++ b/schema/postgresql/v12/visibility/versioned/v1.12/manifest.json
@@ -2,7 +2,6 @@
   "CurrVersion": "1.12",
   "MinCompatibleVersion": "0.1",
   "Description": "add TemporalLowCardinalityKeyword01 to chasm_search_attributes",
-  "SchemaUpdateCqlFiles": [
-    "add_low_cardinality_keyword.sql"
-  ]
+  "SchemaUpdateCqlFiles": [],
+  "AllowNoCqlFiles": true
 }

--- a/schema/postgresql/v12/visibility/versioned/v1.13/combined_v1.10_v1.13.sql
+++ b/schema/postgresql/v12/visibility/versioned/v1.13/combined_v1.10_v1.13.sql
@@ -1,0 +1,94 @@
+-- Add new columns
+ALTER TABLE executions_visibility
+  -- v1.10
+  ADD COLUMN IF NOT EXISTS TemporalReportedProblems JSONB GENERATED ALWAYS AS (search_attributes->'TemporalReportedProblems') STORED,
+
+  -- v1.11
+  -- Pre-allocated CHASM search attributes
+  ADD COLUMN IF NOT EXISTS TemporalBool01         BOOLEAN         GENERATED ALWAYS AS ((search_attributes->'TemporalBool01')::boolean)        STORED,
+  ADD COLUMN IF NOT EXISTS TemporalBool02         BOOLEAN         GENERATED ALWAYS AS ((search_attributes->'TemporalBool02')::boolean)        STORED,
+  ADD COLUMN IF NOT EXISTS TemporalDatetime01     TIMESTAMP       GENERATED ALWAYS AS (convert_ts(search_attributes->>'TemporalDatetime01'))  STORED,
+  ADD COLUMN IF NOT EXISTS TemporalDatetime02     TIMESTAMP       GENERATED ALWAYS AS (convert_ts(search_attributes->>'TemporalDatetime02'))  STORED,
+  ADD COLUMN IF NOT EXISTS TemporalDouble01       DECIMAL(20, 5)  GENERATED ALWAYS AS ((search_attributes->'TemporalDouble01')::decimal)      STORED,
+  ADD COLUMN IF NOT EXISTS TemporalDouble02       DECIMAL(20, 5)  GENERATED ALWAYS AS ((search_attributes->'TemporalDouble02')::decimal)      STORED,
+  ADD COLUMN IF NOT EXISTS TemporalInt01          BIGINT          GENERATED ALWAYS AS ((search_attributes->'TemporalInt01')::bigint)          STORED,
+  ADD COLUMN IF NOT EXISTS TemporalInt02          BIGINT          GENERATED ALWAYS AS ((search_attributes->'TemporalInt02')::bigint)          STORED,
+  ADD COLUMN IF NOT EXISTS TemporalKeyword01      VARCHAR(255)    GENERATED ALWAYS AS (search_attributes->>'TemporalKeyword01')               STORED,
+  ADD COLUMN IF NOT EXISTS TemporalKeyword02      VARCHAR(255)    GENERATED ALWAYS AS (search_attributes->>'TemporalKeyword02')               STORED,
+  ADD COLUMN IF NOT EXISTS TemporalKeyword03      VARCHAR(255)    GENERATED ALWAYS AS (search_attributes->>'TemporalKeyword03')               STORED,
+  ADD COLUMN IF NOT EXISTS TemporalKeyword04      VARCHAR(255)    GENERATED ALWAYS AS (search_attributes->>'TemporalKeyword04')               STORED,
+  ADD COLUMN IF NOT EXISTS TemporalKeywordList01  JSONB           GENERATED ALWAYS AS (search_attributes->'TemporalKeywordList01')            STORED,
+  ADD COLUMN IF NOT EXISTS TemporalKeywordList02  JSONB           GENERATED ALWAYS AS (search_attributes->'TemporalKeywordList02')            STORED,
+
+  -- v1.12
+  ADD COLUMN IF NOT EXISTS TemporalLowCardinalityKeyword01 VARCHAR(255) GENERATED ALWAYS AS (search_attributes->>'TemporalLowCardinalityKeyword01') STORED,
+
+  -- v1.13
+  ADD COLUMN IF NOT EXISTS TemporalUsedWorkerDeploymentVersions JSONB GENERATED ALWAYS AS (search_attributes->'TemporalUsedWorkerDeploymentVersions') STORED;
+
+-- Drop invalid indices
+DO LANGUAGE 'plpgsql' $$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN
+    SELECT i.relname as indexname
+    FROM
+      pg_class i,
+      pg_index ix
+    WHERE
+      i.oid = ix.indexrelid
+      AND ix.indrelid = (SELECT oid FROM pg_class WHERE relname = 'executions_visibility')
+      AND i.relname IN (
+        'by_temporal_reported_problems',
+        'by_temporal_bool_01',
+        'by_temporal_bool_02',
+        'by_temporal_datetime_01',
+        'by_temporal_datetime_02',
+        'by_temporal_double_01',
+        'by_temporal_double_02',
+        'by_temporal_int_01',
+        'by_temporal_int_02',
+        'by_temporal_keyword_01',
+        'by_temporal_keyword_02',
+        'by_temporal_keyword_03',
+        'by_temporal_keyword_04',
+        'by_temporal_keyword_list_01',
+        'by_temporal_keyword_list_02',
+        'by_temporal_low_cardinality_keyword_01',
+        'by_used_deployment_versions'
+      )
+      AND NOT ix.indisvalid
+  LOOP
+    EXECUTE format('DROP INDEX %I', r.indexname);
+    RAISE NOTICE 'Dropped invalid index %', r.indexname;
+  END LOOP;
+END $$;
+
+-- Create new indices
+
+-- v1.10
+CREATE INDEX CONCURRENTLY IF NOT EXISTS by_temporal_reported_problems ON executions_visibility USING GIN (namespace_id, TemporalReportedProblems jsonb_path_ops);
+
+-- v1.11
+-- Indexes for the pre-allocated CHASM search attributes
+CREATE INDEX CONCURRENTLY IF NOT EXISTS by_temporal_bool_01          ON executions_visibility (namespace_id, TemporalBool01, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS by_temporal_bool_02          ON executions_visibility (namespace_id, TemporalBool02, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS by_temporal_datetime_01      ON executions_visibility (namespace_id, TemporalDatetime01, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS by_temporal_datetime_02      ON executions_visibility (namespace_id, TemporalDatetime02, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS by_temporal_double_01        ON executions_visibility (namespace_id, TemporalDouble01, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS by_temporal_double_02        ON executions_visibility (namespace_id, TemporalDouble02, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS by_temporal_int_01           ON executions_visibility (namespace_id, TemporalInt01, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS by_temporal_int_02           ON executions_visibility (namespace_id, TemporalInt02, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS by_temporal_keyword_01       ON executions_visibility (namespace_id, TemporalKeyword01, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS by_temporal_keyword_02       ON executions_visibility (namespace_id, TemporalKeyword02, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS by_temporal_keyword_03       ON executions_visibility (namespace_id, TemporalKeyword03, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS by_temporal_keyword_04       ON executions_visibility (namespace_id, TemporalKeyword04, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS by_temporal_keyword_list_01  ON executions_visibility USING GIN (namespace_id, TemporalKeywordList01 jsonb_path_ops);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS by_temporal_keyword_list_02  ON executions_visibility USING GIN (namespace_id, TemporalKeywordList02 jsonb_path_ops);
+
+-- v1.12
+CREATE INDEX CONCURRENTLY IF NOT EXISTS by_temporal_low_cardinality_keyword_01 ON executions_visibility (namespace_id, TemporalLowCardinalityKeyword01, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+
+-- v1.13
+CREATE INDEX CONCURRENTLY IF NOT EXISTS by_used_deployment_versions ON executions_visibility USING GIN (namespace_id, TemporalUsedWorkerDeploymentVersions jsonb_path_ops);

--- a/schema/postgresql/v12/visibility/versioned/v1.13/manifest.json
+++ b/schema/postgresql/v12/visibility/versioned/v1.13/manifest.json
@@ -1,8 +1,8 @@
 {
   "CurrVersion": "1.13",
   "MinCompatibleVersion": "0.1",
-  "Description": "add TemporalUsedWorkerDeploymentVersions search attribute",
+  "Description": "combined changed from v1.10 to v1.13 (add TemporalUsedWorkerDeploymentVersions search attribute)",
   "SchemaUpdateCqlFiles": [
-    "add_used_deployment_versions_search_attribute.sql"
+    "combined_v1.10_v1.13.sql"
   ]
 }


### PR DESCRIPTION
## What changed?
Cherry-picks #10198 to `release/v1.30.x` with one conflict resolved.

Conflict was in `common/persistence/tests/postgresql_test.go` inside `TestPostgreSQLHistoryCurrentExecutionSuite`. `release/v1.30.x` has the 2-arg `sqltests.NewHistoryCurrentExecutionSuite(t, store)` signature; #10198 calls the 3-arg form with `chasm.WorkflowArchetypeID` and adds a new `TestPostgreSQLHistoryCurrentChasmExecutionSuite` test that also uses the 3-arg form.

Resolved by keeping the existing 2-arg call and dropping the new `TestPostgreSQLHistoryCurrentChasmExecutionSuite` function. Everything else from #10198 lands as-is: the `connectAttrs` struct field, all `setUpPostgreSQLTest` and `NewPostgreSQLConfig` signature plumbing, and the new `TestPGXSP` regression test.

## Why?
Prerequisite for cherry-picking #10529 (`Encode duration as bigint for pgx simple protocol`) to `release/v1.30.x` for the v1.30.5 release. #10529 references `p.connectAttrs` and the 2-arg `GetPostgreSQLTestClusterOption(pluginName, connectAttrs)` signature, both introduced by #10198.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
