### PR TITLE
Bump ServerVersion to 1.30.5

### DIFF
--- a/common/headers/version_checker.go
+++ b/common/headers/version_checker.go
@@ -23,7 +23,7 @@ const (
 
 	// ServerVersion value can be changed by the create-tag Github workflow.
 	// If you change the var name or move it, be sure to update the workflow.
-	ServerVersion = "1.30.4"
+	ServerVersion = "1.30.5"
 
 	// SupportedServerVersions is used by CLI and inter role communication.
 	SupportedServerVersions = ">=1.0.0 <2.0.0"


### PR DESCRIPTION
## What changed?

Bumps `ServerVersion` from `"1.30.4"` to `"1.30.5"` in `common/headers/version_checker.go`. Single-line change.

## Why?

Final source change for the v1.30.5 OSS security patch release. Once merged, builds tagged from `release/v1.30.x` will identify as v1.30.5 over gRPC and in metrics.

**HOLD MERGE until nightly validation passes** against the candidate `sha-XXX` image produced from `release/v1.30.x` HEAD (after the dep bumps PR #10686 merges). Same gating pattern as v1.29.7 (#10648).