### PR TITLE
fix: gate the token encoding with a dynamic config for mixed brain scenarios (#10685)

### DIFF
--- a/chasm/lib/callback/config.go
+++ b/chasm/lib/callback/config.go
@@ -58,6 +58,16 @@ func configProvider(dc *dynamicconfig.Collection) *Config {
 	}
 }
 
+var EncodeInternalTokenWithEnvelope = dynamicconfig.NewNamespaceBoolSetting(
+	"callback.encodeInternalTokenWithEnvelope",
+	false,
+	`Controls how the internal CHASM Nexus completion callback token is encoded. When true the token is
+encoded as a NexusOperationCompletion envelope; when false (default) it is the legacy bare base64-encoded
+ChasmComponentRef. Gates a safe fleet-wide rollout of the envelope encoding: keep disabled until every
+server can read it (any server able to read the envelope also accepts the legacy form), then enable
+per-namespace.`,
+)
+
 var AllowedAddresses = dynamicconfig.NewNamespaceTypedSettingWithConverter(
 	"chasm.callback.allowedAddresses",
 	allowedAddressConverter,

--- a/chasm/lib/callback/invocable_internal.go
+++ b/chasm/lib/callback/invocable_internal.go
@@ -72,6 +72,7 @@ func (c invocableInternal) Invoke(
 	if err != nil {
 		return invocationResultFail{logInternalError(h.logger, "failed to decode CHASM callback token", err)}
 	}
+
 	// Older tokens don't carry a request ID; fall back to the one on the callback state machine.
 	if requestID == "" {
 		requestID = c.requestID

--- a/chasm/lib/scheduler/config.go
+++ b/chasm/lib/scheduler/config.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"time"
 
+	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/dynamicconfig"
 )
@@ -20,9 +21,10 @@ type (
 
 	// Config is the CHASM Scheduler dynamic config, shared among all sub-components.
 	Config struct {
-		Tweakables         dynamicconfig.TypedPropertyFnWithNamespaceFilter[Tweakables]
-		ServiceCallTimeout dynamicconfig.DurationPropertyFn
-		RetryPolicy        func() backoff.RetryPolicy
+		Tweakables                      dynamicconfig.TypedPropertyFnWithNamespaceFilter[Tweakables]
+		ServiceCallTimeout              dynamicconfig.DurationPropertyFn
+		RetryPolicy                     func() backoff.RetryPolicy
+		EncodeInternalTokenWithEnvelope dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	}
 )
 
@@ -68,8 +70,9 @@ var (
 
 func ConfigProvider(dc *dynamicconfig.Collection) *Config {
 	return &Config{
-		Tweakables:         CurrentTweakables.Get(dc),
-		ServiceCallTimeout: ServiceCallTimeout.Get(dc),
+		Tweakables:                      CurrentTweakables.Get(dc),
+		ServiceCallTimeout:              ServiceCallTimeout.Get(dc),
+		EncodeInternalTokenWithEnvelope: callback.EncodeInternalTokenWithEnvelope.Get(dc),
 		RetryPolicy: func() backoff.RetryPolicy {
 			return backoff.NewExponentialRetryPolicy(
 				RetryPolicyInitialInterval.Get(dc)(),

--- a/chasm/lib/scheduler/helper_test.go
+++ b/chasm/lib/scheduler/helper_test.go
@@ -72,6 +72,9 @@ func defaultConfig() *scheduler.Config {
 		ServiceCallTimeout: func() time.Duration {
 			return 5 * time.Second
 		},
+		EncodeInternalTokenWithEnvelope: func(string) bool {
+			return true
+		},
 		RetryPolicy: func() backoff.RetryPolicy {
 			return backoff.NewExponentialRetryPolicy(1 * time.Second)
 		},

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -568,7 +568,7 @@ func (h *InvokerExecuteTaskHandler) startWorkflow(
 	// completion is matched by a request ID that rides in the callback header and survives
 	// continue-as-new, rather than the started workflow's callback state which is re-stamped on each
 	// new run.
-	callback, err := chasm.GenerateNexusCallback(schedulerRef, start.RequestId)
+	callback, err := chasm.GenerateNexusCallback(schedulerRef, start.RequestId, h.config.EncodeInternalTokenWithEnvelope(scheduler.Namespace))
 	if err != nil {
 		return nil, err
 	}

--- a/chasm/lib/scheduler/scheduler_tasks.go
+++ b/chasm/lib/scheduler/scheduler_tasks.go
@@ -241,7 +241,7 @@ func (r *SchedulerCallbacksTaskHandler) watchRunningStart(
 
 	// Pack this start's request ID into the callback token so completions are matched from the token
 	// (which survives continue-as-new) rather than the started workflow's callback state.
-	callback, err := chasm.GenerateNexusCallback(schedulerRef, start.RequestId)
+	callback, err := chasm.GenerateNexusCallback(schedulerRef, start.RequestId, r.config.EncodeInternalTokenWithEnvelope(scheduler.Namespace))
 	if err != nil {
 		return nil, err
 	}

--- a/chasm/nexus_completion.go
+++ b/chasm/nexus_completion.go
@@ -23,13 +23,24 @@ type NexusCompletionHandler interface {
 }
 
 // GenerateNexusCallback builds a Nexus completion callback targeting the CHASM component identified by
-// serializedRef (obtained from Context.Ref). The request ID is packed into the callback token, so the
-// completion is matched by a request ID that rides in the callback header and survives
-// continue-as-new, rather than one read from mutable state.
-func GenerateNexusCallback(serializedRef []byte, requestID string) (*commonpb.Callback, error) {
-	token, err := packNexusCallbackToken(serializedRef, requestID)
-	if err != nil {
-		return nil, err
+// serializedRef (obtained from Context.Ref). When encodeToken is true, the request ID is packed into
+// the callback token (a NexusOperationCompletion envelope), so the completion is matched by a request
+// ID that rides in the callback header and survives continue-as-new, rather than one read from mutable
+// state. When encodeToken is false, the legacy format is emitted: the token is the bare base64-encoded
+// ChasmComponentRef with no request ID. The caller chooses encodeToken (e.g. gated behind dynamic
+// config) to keep the envelope format off the wire until the whole fleet can read it. Either format is
+// always decodable by UnpackNexusCallbackToken.
+func GenerateNexusCallback(serializedRef []byte, requestID string, encodeToken bool) (*commonpb.Callback, error) {
+	var token string
+	if encodeToken {
+		var err error
+		token, err = packNexusCallbackToken(serializedRef, requestID)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Legacy format: the token is the bare base64-encoded ChasmComponentRef.
+		token = base64.RawURLEncoding.EncodeToString(serializedRef)
 	}
 	return &commonpb.Callback{
 		Variant: &commonpb.Callback_Nexus_{
@@ -54,8 +65,9 @@ func packNexusCallbackToken(componentRef []byte, requestID string) (string, erro
 }
 
 // UnpackNexusCallbackToken decodes a callback token produced by GenerateNexusCallback, returning the
-// component ref and request ID. For backward compatibility it also accepts the legacy format where the
-// token is the bare base64-encoded ChasmComponentRef (in which case the request ID is empty).
+// component ref and request ID. It accepts both token formats regardless of how the token was written:
+// the NexusOperationCompletion envelope, and (for backward compatibility) the legacy bare base64-encoded
+// ChasmComponentRef, in which case the request ID is empty.
 func UnpackNexusCallbackToken(encoded string) (componentRef []byte, requestID string, err error) {
 	raw, err := base64.RawURLEncoding.DecodeString(encoded)
 	if err != nil {


### PR DESCRIPTION
## What changed?
Backport of #10685 onto the `cloud/v1.32.0-156` release branch.

Gates the CHASM Nexus completion callback **token encoding** behind a new
per-namespace dynamic config `callback.encodeInternalTokenWithEnvelope`
(`EncodeInternalTokenWithEnvelope`, default **false**). When enabled the token
is the `NexusOperationCompletion` envelope (carrying the request ID); when
disabled it is the legacy bare base64-encoded `ChasmComponentRef`. Either form
is always decodable by `UnpackNexusCallbackToken`.

## Why?
#10605 (present on this release branch) added a request ID to the encoded
callback token. That change is **not backwards compatible** and can cause
callbacks to fail to deliver in a split-brain / mixed-version fleet. Gating the
envelope encoding lets the new format stay off the wire until every server in
the fleet can read it, then it can be enabled per-namespace.

## Scope of this backport — production code only
This is a **production-source-only** cherry-pick of `09e706e10`. The test
changes from #10685 were intentionally **omitted**:

- This release branch is ~201 commits behind `main` and uses an older test
  architecture: `scheduleCommonOpts()` takes no `*testing.T`, `CallbacksSuite`
  uses plain-testify `TestXxx()` methods (not the parametrized
  `TestXxx(opts []testcore.TestOption)` form), and the `chasmContextFactory`
  helper does not exist here.
- #10685's tests depend on that main-only infrastructure and do not apply
  mechanically. Backporting the infrastructure would substantially widen the
  patch and raise risk.
- Test coverage for this change is validated on `main`.

Prerequisite #10605 (`bc93fd9c5`) is present on this branch, so the gate is
meaningful.

## Files
- `chasm/nexus_completion.go` — `GenerateNexusCallback` gains an `encodeToken bool`
- `chasm/lib/callback/config.go` — new `EncodeInternalTokenWithEnvelope` dynamic config
- `chasm/lib/callback/invocable_internal.go` — whitespace
- `chasm/lib/scheduler/config.go` — wire the gate into `Config`
- `chasm/lib/scheduler/{invoker_tasks,scheduler_tasks}.go` — pass the gate per namespace

## How did you test it?
- [x] `go build ./chasm/...`
- [x] `go vet ./chasm/...`
- [x] `tests` package compiles
- [x] gofmt clean

Default (false) preserves the existing legacy behavior on this release branch.

## Potential risks
Low. Default-off dynamic config; no behavior change until explicitly enabled
per-namespace. Both token formats remain decodable.

## Patch process
Self-service patch. Requires Manager+ approval covering patch justification,
customer impact, risk, and test plan, plus recording in the Cloud Releases
patch table before merge.
