### PR TITLE
fix: Correct metrics tags for Prometheus

### DIFF
--- a/chasm/lib/scheduler/backfiller_tasks.go
+++ b/chasm/lib/scheduler/backfiller_tasks.go
@@ -78,7 +78,7 @@ func (b *BackfillerTaskHandler) Execute(
 	scheduler := backfiller.Scheduler.Get(ctx)
 	logger := newTaggedLogger(b.baseLogger, scheduler)
 	metricsHandler := newTaggedMetricsHandler(b.metricsHandler, scheduler)
-	metricsHandler.Counter(metrics.ScheduleBackfillerTask.Name()).Record(1, metrics.OutcomeTag(outcomeFired))
+	metricsHandler.Counter(metrics.ScheduleBackfillerTask.Name()).Record(1, metrics.OutcomeTag(outcomeFired), metrics.ReasonTag(reasonNone))
 
 	invoker := scheduler.Invoker.Get(ctx)
 

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -209,7 +209,7 @@ func (h *InvokerExecuteTaskHandler) Execute(
 
 	logger := newTaggedLogger(h.baseLogger, scheduler)
 	metricsHandler := newTaggedMetricsHandler(h.metricsHandler, scheduler)
-	metricsHandler.Counter(metrics.ScheduleInvokerExecuteTask.Name()).Record(1, metrics.OutcomeTag(outcomeFired))
+	metricsHandler.Counter(metrics.ScheduleInvokerExecuteTask.Name()).Record(1, metrics.OutcomeTag(outcomeFired), metrics.ReasonTag(reasonNone))
 
 	// Terminate, cancel, and start workflows. The result struct contains the
 	// complete outcome of all requests executed in a single batch.
@@ -433,7 +433,7 @@ func (h *InvokerProcessBufferTaskHandler) Execute(
 	scheduler := invoker.Scheduler.Get(ctx)
 	newTaggedMetricsHandler(h.metricsHandler, scheduler).
 		Counter(metrics.ScheduleInvokerProcessBufferTask.Name()).
-		Record(1, metrics.OutcomeTag(outcomeFired))
+		Record(1, metrics.OutcomeTag(outcomeFired), metrics.ReasonTag(reasonNone))
 
 	invoker.EventLog.Get(ctx).LogEvent(ctx, "processBufferTask executed")
 

--- a/chasm/lib/scheduler/metrics_consistency_test.go
+++ b/chasm/lib/scheduler/metrics_consistency_test.go
@@ -1,0 +1,199 @@
+package scheduler_test
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/api/enums/v1"
+	schedulepb "go.temporal.io/api/schedule/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/scheduler"
+	"go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// The scheduler task-lifecycle counters are emitted on two paths: "fired"
+// (Validate=true, the task executed) and "invalidated" (Validate=false, with a
+// ReasonTag explaining why). Prometheus binds a fixed label set to a metric
+// name on first emission and rejects later emissions whose label set differs,
+// logging a warn that CICD log-scraping treats as a failure. So both paths of a
+// given counter must carry an identical set of label keys.
+//
+// These tests drive each counter's fired and invalidated paths through a
+// capturing metrics handler and assert the recorded samples share the same
+// label keys (regression guard for the duplicate-descriptor bug where the fired
+// path omitted ReasonTag).
+
+// requireConsistentLabelKeys asserts that every sample recorded under metricName
+// carries an identical, sorted set of label keys, that at least wantSamples were
+// captured, and that the keys include both outcome and reason.
+func requireConsistentLabelKeys(t *testing.T, capture *metricstest.Capture, metricName string, wantSamples int) {
+	t.Helper()
+
+	recs := capture.Snapshot()[metricName]
+	require.GreaterOrEqual(t, len(recs), wantSamples,
+		"expected at least %d samples for %s", wantSamples, metricName)
+
+	var want []string
+	for i, r := range recs {
+		keys := make([]string, 0, len(r.Tags))
+		for k := range r.Tags {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		if i == 0 {
+			want = keys
+			require.Contains(t, keys, "outcome", "%s sample missing outcome label", metricName)
+			require.Contains(t, keys, "reason", "%s sample missing reason label", metricName)
+			continue
+		}
+		require.Equal(t, want, keys,
+			"%s emitted with inconsistent label keys (%v) for tags %v; Prometheus rejects a metric whose label set changes between emissions",
+			metricName, want, r.Tags)
+	}
+}
+
+func TestScheduleIdleTask_ConsistentLabels(t *testing.T) {
+	env := newTestEnv(t)
+	rec := metricstest.NewCaptureHandler()
+	capture := rec.StartCapture()
+	defer rec.StopCapture(capture)
+
+	h := scheduler.NewSchedulerIdleTaskHandler(scheduler.SchedulerIdleTaskHandlerOptions{
+		Config:         defaultConfig(),
+		MetricsHandler: rec,
+		BaseLogger:     env.Logger,
+	})
+
+	// fired: Execute closes the schedule and records outcome=fired.
+	require.NoError(t, h.Execute(env.MutableContext(), env.Scheduler,
+		chasm.TaskAttributes{}, &schedulerpb.SchedulerIdleTask{}))
+
+	// invalidated: Execute set Closed=true above, so Validate now rejects with
+	// reason=closed.
+	valid, err := h.Validate(env.MutableContext(), env.Scheduler,
+		chasm.TaskAttributes{ScheduledTime: env.TimeSource.Now()},
+		&schedulerpb.SchedulerIdleTask{IdleTimeTotal: durationpb.New(10 * time.Minute)})
+	require.NoError(t, err)
+	require.False(t, valid)
+
+	requireConsistentLabelKeys(t, capture, metrics.ScheduleIdleTask.Name(), 2)
+}
+
+func TestScheduleInvokerProcessBufferTask_ConsistentLabels(t *testing.T) {
+	env := newTestEnv(t)
+	rec := metricstest.NewCaptureHandler()
+	capture := rec.StartCapture()
+	defer rec.StopCapture(capture)
+
+	h := scheduler.NewInvokerProcessBufferTaskHandler(scheduler.InvokerTaskHandlerOptions{
+		Config:         defaultConfig(),
+		MetricsHandler: rec,
+		BaseLogger:     env.Logger,
+		SpecProcessor:  env.SpecProcessor,
+	})
+
+	ctx := env.MutableContext()
+	invoker := env.Scheduler.Invoker.Get(ctx)
+	invoker.LastProcessedTime = timestamppb.New(env.TimeSource.Now())
+
+	// fired: Execute with an empty buffer records outcome=fired.
+	require.NoError(t, h.Execute(ctx, invoker, chasm.TaskAttributes{}, &schedulerpb.InvokerProcessBufferTask{}))
+	require.NoError(t, env.CloseTransaction())
+
+	// invalidated: a task scheduled before the high water mark is stale.
+	valid, err := h.Validate(env.ReadContext(), invoker,
+		chasm.TaskAttributes{ScheduledTime: env.TimeSource.Now().Add(-time.Minute)},
+		&schedulerpb.InvokerProcessBufferTask{})
+	require.NoError(t, err)
+	require.False(t, valid)
+
+	requireConsistentLabelKeys(t, capture, metrics.ScheduleInvokerProcessBufferTask.Name(), 2)
+}
+
+func TestScheduleBackfillerTask_ConsistentLabels(t *testing.T) {
+	env := newTestEnv(t)
+	rec := metricstest.NewCaptureHandler()
+	capture := rec.StartCapture()
+	defer rec.StopCapture(capture)
+
+	h := scheduler.NewBackfillerTaskHandler(scheduler.BackfillerTaskHandlerOptions{
+		Config:         defaultConfig(),
+		MetricsHandler: rec,
+		BaseLogger:     env.Logger,
+		SpecProcessor:  env.SpecProcessor,
+	})
+
+	// Use a range larger than the backfiller's buffer limit so it does not
+	// complete (and delete itself) on the first auto-executed iteration; that
+	// leaves a live Backfiller we can drive Execute on through our capturing
+	// handler.
+	ctx := env.MutableContext()
+	schedComponent, err := env.Node.Component(ctx, chasm.ComponentRef{})
+	require.NoError(t, err)
+	sched := schedComponent.(*scheduler.Scheduler)
+	startTime := env.TimeSource.Now()
+	backfiller := sched.NewRangeBackfiller(ctx, &schedulepb.BackfillRequest{
+		StartTime:     timestamppb.New(startTime),
+		EndTime:       timestamppb.New(startTime.Add(1000 * defaultInterval)),
+		OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+	})
+	require.NoError(t, env.CloseTransaction())
+
+	// fired: Execute records outcome=fired.
+	ctx = env.MutableContext()
+	sched.Invoker.Get(ctx).BufferedStarts = nil // make room for the next batch
+	require.NoError(t, h.Execute(ctx, backfiller,
+		chasm.TaskAttributes{}, &schedulerpb.BackfillerTask{}))
+	require.NoError(t, env.CloseTransaction())
+
+	// invalidated: a task scheduled before the high water mark is stale.
+	backfiller.LastProcessedTime = timestamppb.New(env.TimeSource.Now())
+	valid, err := h.Validate(env.ReadContext(), backfiller,
+		chasm.TaskAttributes{ScheduledTime: env.TimeSource.Now().Add(-time.Hour)},
+		&schedulerpb.BackfillerTask{})
+	require.NoError(t, err)
+	require.False(t, valid)
+
+	requireConsistentLabelKeys(t, capture, metrics.ScheduleBackfillerTask.Name(), 2)
+}
+
+func TestScheduleInvokerExecuteTask_ConsistentLabels(t *testing.T) {
+	env := newInvokerExecuteTestEnv(t)
+	rec := metricstest.NewCaptureHandler()
+	capture := rec.StartCapture()
+	defer rec.StopCapture(capture)
+
+	h := scheduler.NewInvokerExecuteTaskHandler(scheduler.InvokerTaskHandlerOptions{
+		Config:         defaultConfig(),
+		MetricsHandler: rec,
+		BaseLogger:     env.Logger,
+		SpecProcessor:  env.SpecProcessor,
+		HistoryClient:  env.mockHistoryClient,
+		FrontendClient: env.mockFrontendClient,
+	})
+
+	ctx := env.MutableContext()
+	invoker := env.Scheduler.Invoker.Get(ctx)
+	invoker.LastProcessedTime = timestamppb.New(env.TimeSource.Now())
+
+	// invalidated: no terminate/cancel/eligible work records reason=no_work.
+	valid, err := h.Validate(ctx, invoker, chasm.TaskAttributes{}, &schedulerpb.InvokerExecuteTask{})
+	require.NoError(t, err)
+	require.False(t, valid)
+
+	// fired: Execute over an empty work set records outcome=fired (no RPCs).
+	env.ExpectReadComponent(ctx, invoker)
+	env.ExpectUpdateComponent(ctx, invoker)
+	require.NoError(t, h.Execute(env.EngineContext(), chasm.ComponentRef{},
+		chasm.TaskAttributes{}, &schedulerpb.InvokerExecuteTask{}))
+	require.NoError(t, env.CloseTransaction())
+
+	requireConsistentLabelKeys(t, capture, metrics.ScheduleInvokerExecuteTask.Name(), 2)
+}

--- a/chasm/lib/scheduler/scheduler_tasks.go
+++ b/chasm/lib/scheduler/scheduler_tasks.go
@@ -57,7 +57,7 @@ func (r *SchedulerIdleTaskHandler) Execute(
 	scheduler.Closed = true
 	newTaggedMetricsHandler(r.metricsHandler, scheduler).
 		Counter(metrics.ScheduleIdleTask.Name()).
-		Record(1, metrics.OutcomeTag(outcomeFired))
+		Record(1, metrics.OutcomeTag(outcomeFired), metrics.ReasonTag(reasonNone))
 	return nil
 }
 

--- a/chasm/lib/scheduler/util.go
+++ b/chasm/lib/scheduler/util.go
@@ -56,6 +56,13 @@ const (
 	outcomeInvalidated = "invalidated"
 )
 
+// reasonNone is the ReasonTag value emitted on the "fired" outcome. Prometheus
+// binds a fixed label set to a metric name, so the fired and invalidated paths
+// of a counter must carry the same labels; the invalidated path always sets a
+// ReasonTag, so the fired path sets this sentinel to keep the label set
+// identical.
+const reasonNone metrics.ReasonString = "none"
+
 // validateTaskHighWaterMark validates a component's lastProcessedTime against a
 // task timestamp. A task is valid if its scheduled time is after the high water mark.
 // Immediate tasks (zero scheduled time) are always valid since they execute inline.

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1480,19 +1480,19 @@ var (
 	)
 	ScheduleIdleTask = NewCounterDef(
 		"schedule_idle_task",
-		WithDescription("The number of times a schedule's idle task ran. Tagged with outcome."),
+		WithDescription("The number of times a schedule's idle task ran. Tagged with outcome and reason (reason is \"none\" when outcome is \"fired\")."),
 	)
 	ScheduleInvokerProcessBufferTask = NewCounterDef(
 		"schedule_invoker_process_buffer_task",
-		WithDescription("The number of times a scheduler's ProcessBuffer task ran. Tagged with outcome."),
+		WithDescription("The number of times a scheduler's ProcessBuffer task ran. Tagged with outcome and reason (reason is \"none\" when outcome is \"fired\")."),
 	)
 	ScheduleInvokerExecuteTask = NewCounterDef(
 		"schedule_invoker_execute_task",
-		WithDescription("The number of times a scheduler's Execute side-effect task ran. Tagged with outcome."),
+		WithDescription("The number of times a scheduler's Execute side-effect task ran. Tagged with outcome and reason (reason is \"none\" when outcome is \"fired\")."),
 	)
 	ScheduleBackfillerTask = NewCounterDef(
 		"schedule_backfiller_task",
-		WithDescription("The number of times a scheduler's Backfiller task ran. Tagged with outcome."),
+		WithDescription("The number of times a scheduler's Backfiller task ran. Tagged with outcome and reason (reason is \"none\" when outcome is \"fired\")."),
 	)
 	ScheduleBackfillerCompleted = NewCounterDef(
 		"schedule_backfiller_completed",


### PR DESCRIPTION
## What changed?

Prometheus doesn't like metrics with differing numbers of tags associated with them, just dropping them. 

Since an earlier PR introduced the `reason` tag, it needs to be filled out for all fields using it. This adds it. 

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
low, just metrics changes