### PR TITLE
[Scheduler] Unalias search attributes during V2->V1 migration (rollback) case

### DIFF
--- a/chasm/lib/scheduler/scheduler_migrate_task.go
+++ b/chasm/lib/scheduler/scheduler_migrate_task.go
@@ -191,12 +191,11 @@ func (h *SchedulerMigrateToWorkflowTaskHandler) Execute(
 			sadefs.TemporalNamespaceDivision: payload.EncodeString(legacyscheduler.NamespaceDivision),
 		},
 	)
-	// The CHASM scheduler stores custom search attributes by their alias (the
-	// frontend passes the original request through unchanged), whereas V1
-	// scheduler workflows store them unaliased -- the V1 frontend create path
-	// unaliases via UnaliasedSearchAttributesFrom before starting the workflow.
-	// Mirror that here: without it the V1 visibility upsert can't resolve the
-	// aliased names and fails with "invalid search attribute type: Unspecified".
+
+	// The CHASM scheduler stores custom search attributes by their alias (the frontend
+	// passes the original request through unchanged), whereas V1 scheduler workflows
+	// store them unaliased/resolved. Mirror how V1 unaliases search attributes before
+	// starting the system scheduler workflow.
 	sa, err := searchattribute.UnaliasFields(
 		h.saMapperProvider,
 		&commonpb.SearchAttributes{IndexedFields: saMap},

--- a/chasm/lib/scheduler/scheduler_migrate_task.go
+++ b/chasm/lib/scheduler/scheduler_migrate_task.go
@@ -25,6 +25,7 @@ import (
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/common/sdk"
+	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	legacyscheduler "go.temporal.io/server/service/worker/scheduler"
 	"go.uber.org/fx"
@@ -34,18 +35,20 @@ type (
 	SchedulerMigrateToWorkflowTaskHandlerOptions struct {
 		fx.In
 
-		Config         *Config
-		MetricsHandler metrics.Handler
-		BaseLogger     log.Logger
-		HistoryClient  resource.HistoryClient
+		Config           *Config
+		MetricsHandler   metrics.Handler
+		BaseLogger       log.Logger
+		HistoryClient    resource.HistoryClient
+		SaMapperProvider searchattribute.MapperProvider
 	}
 
 	SchedulerMigrateToWorkflowTaskHandler struct {
 		chasm.SideEffectTaskHandlerBase[*schedulerpb.SchedulerMigrateToWorkflowTask]
-		config         *Config
-		metricsHandler metrics.Handler
-		baseLogger     log.Logger
-		historyClient  resource.HistoryClient
+		config           *Config
+		metricsHandler   metrics.Handler
+		baseLogger       log.Logger
+		historyClient    resource.HistoryClient
+		saMapperProvider searchattribute.MapperProvider
 	}
 )
 
@@ -53,10 +56,11 @@ func NewSchedulerMigrateToWorkflowTaskHandler(
 	opts SchedulerMigrateToWorkflowTaskHandlerOptions,
 ) *SchedulerMigrateToWorkflowTaskHandler {
 	return &SchedulerMigrateToWorkflowTaskHandler{
-		config:         opts.Config,
-		metricsHandler: opts.MetricsHandler,
-		baseLogger:     opts.BaseLogger,
-		historyClient:  opts.HistoryClient,
+		config:           opts.Config,
+		metricsHandler:   opts.MetricsHandler,
+		baseLogger:       opts.BaseLogger,
+		historyClient:    opts.HistoryClient,
+		saMapperProvider: opts.SaMapperProvider,
 	}
 }
 
@@ -187,6 +191,20 @@ func (h *SchedulerMigrateToWorkflowTaskHandler) Execute(
 			sadefs.TemporalNamespaceDivision: payload.EncodeString(legacyscheduler.NamespaceDivision),
 		},
 	)
+	// The CHASM scheduler stores custom search attributes by their alias (the
+	// frontend passes the original request through unchanged), whereas V1
+	// scheduler workflows store them unaliased -- the V1 frontend create path
+	// unaliases via UnaliasedSearchAttributesFrom before starting the workflow.
+	// Mirror that here: without it the V1 visibility upsert can't resolve the
+	// aliased names and fails with "invalid search attribute type: Unspecified".
+	sa, err := searchattribute.UnaliasFields(
+		h.saMapperProvider,
+		&commonpb.SearchAttributes{IndexedFields: saMap},
+		result.namespace,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to unalias search attributes: %w", err)
+	}
 	workflowID := legacyscheduler.WorkflowIDPrefix + result.scheduleID
 	startReq := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:                uuid.NewString(),
@@ -199,7 +217,7 @@ func (h *SchedulerMigrateToWorkflowTaskHandler) Execute(
 		WorkflowIdReusePolicy:    enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
 		WorkflowIdConflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL,
 		Memo:                     &commonpb.Memo{Fields: maps.Clone(result.memo)},
-		SearchAttributes:         &commonpb.SearchAttributes{IndexedFields: saMap},
+		SearchAttributes:         sa,
 		Priority:                 &commonpb.Priority{},
 	}
 

--- a/tests/schedule_migration_test.go
+++ b/tests/schedule_migration_test.go
@@ -24,6 +24,7 @@ import (
 	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/testing/await"
@@ -333,6 +334,15 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2() {
 
 	nsName := env.Namespace().String()
 	nsID := env.NamespaceID().String()
+
+	// Custom search attributes and memo must survive the migration.
+	csaKeyword := "CustomKeywordField"
+	csaInt := "CustomIntField"
+	schSAKeyword := payload.EncodeString("v1-to-v2 sa value")
+	schSAInt, err := payload.Encode(2025)
+	s.NoError(err)
+	schMemo := payload.EncodeString("v1-to-v2 memo value")
+
 	sched := &schedulepb.Schedule{
 		Spec: &schedulepb.ScheduleSpec{
 			Interval: []*schedulepb.IntervalSpec{
@@ -350,35 +360,26 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2() {
 		},
 	}
 
-	// Create the V1 (workflow-backed) scheduler directly.
-	startArgs := &schedulespb.StartScheduleArgs{
-		Schedule: sched,
-		State: &schedulespb.InternalState{
-			Namespace:     nsName,
-			NamespaceId:   nsID,
-			ScheduleId:    sid,
-			ConflictToken: scheduler.InitialConflictToken,
+	// Disable CHASM during creation so CreateSchedule routes to the V1 path.
+	env.OverrideDynamicConfig(dynamicconfig.EnableChasm, false)
+	_, err = env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  nsName,
+		ScheduleId: sid,
+		Schedule:   sched,
+		Identity:   "test",
+		RequestId:  uuid.NewString(),
+		SearchAttributes: &commonpb.SearchAttributes{
+			IndexedFields: map[string]*commonpb.Payload{
+				csaKeyword: schSAKeyword,
+				csaInt:     schSAInt,
+			},
 		},
-	}
-	inputPayloads, err := sdk.PreferProtoDataConverter.ToPayloads(startArgs)
+		Memo: &commonpb.Memo{
+			Fields: map[string]*commonpb.Payload{"schedmemo1": schMemo},
+		},
+	})
 	s.NoError(err)
 	v1WorkflowID := scheduler.WorkflowIDPrefix + sid
-	startReq := &workflowservice.StartWorkflowExecutionRequest{
-		Namespace:                nsName,
-		WorkflowId:               v1WorkflowID,
-		WorkflowType:             &commonpb.WorkflowType{Name: scheduler.WorkflowType},
-		TaskQueue:                &taskqueuepb.TaskQueue{Name: primitives.PerNSWorkerTaskQueue},
-		Input:                    inputPayloads,
-		Identity:                 "test",
-		RequestId:                uuid.NewString(),
-		WorkflowIdReusePolicy:    enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
-		WorkflowIdConflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL,
-	}
-	_, err = env.GetTestCluster().HistoryClient().StartWorkflowExecution(
-		ctx,
-		common.CreateHistoryStartWorkflowRequest(nsID, startReq, nil, nil, time.Now().UTC()),
-	)
-	s.NoError(err)
 
 	// Wait for the per-namespace worker to pick up the V1 workflow.
 	s.Eventually(func() bool {
@@ -396,9 +397,10 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2() {
 			return false
 		}
 		return desc.GetWorkflowExecutionInfo().GetHistoryLength() > 3
-	}, 10*time.Second, 500*time.Millisecond)
+	}, 30*time.Second, 500*time.Millisecond)
 
 	// Issue migration from V1 to V2.
+	env.OverrideDynamicConfig(dynamicconfig.EnableChasm, true)
 	env.OverrideDynamicConfig(dynamicconfig.EnableCHASMSchedulerMigration, true)
 	_, err = env.AdminClient().MigrateSchedule(ctx, &adminservice.MigrateScheduleRequest{
 		Namespace:  nsName,
@@ -427,8 +429,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2() {
 		return desc.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
 	}, 10*time.Second, 500*time.Millisecond)
 
-	// V2 schedule should now exist.
-	_, err = env.GetTestCluster().SchedulerClient().DescribeSchedule(
+	v2Desc, err := env.GetTestCluster().SchedulerClient().DescribeSchedule(
 		ctx,
 		&schedulerpb.DescribeScheduleRequest{
 			NamespaceId:     nsID,
@@ -436,6 +437,23 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2() {
 		},
 	)
 	s.NoError(err)
+	v2SA := v2Desc.GetFrontendResponse().GetSearchAttributes().GetIndexedFields()
+	s.Equal(schSAKeyword.Data, v2SA[csaKeyword].GetData())
+	s.Equal(schSAInt.Data, v2SA[csaInt].GetData())
+	s.Equal(schMemo.Data, v2Desc.GetFrontendResponse().GetMemo().GetFields()["schedmemo1"].GetData())
+
+	// Custom SAs must also be queryable on the CHASM visibility record.
+	var listResp *workflowservice.ListSchedulesResponse
+	s.Eventually(func() bool {
+		listResp, err = env.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
+			Namespace:       nsName,
+			MaximumPageSize: 10,
+			Query:           "CustomKeywordField = 'v1-to-v2 sa value'",
+		})
+		return err == nil && len(listResp.GetSchedules()) == 1
+	}, 30*time.Second, 500*time.Millisecond)
+	s.Equal(sid, listResp.GetSchedules()[0].GetScheduleId())
+	s.Equal(schSAKeyword.Data, listResp.GetSchedules()[0].GetSearchAttributes().GetIndexedFields()[csaKeyword].GetData())
 }
 
 func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1() {
@@ -479,8 +497,16 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1() {
 		},
 	}
 
+	// Custom search attributes and memo must survive the migration.
+	csaKeyword := "CustomKeywordField"
+	csaInt := "CustomIntField"
+	schSAKeyword := payload.EncodeString("v2-to-v1 sa value")
+	schSAInt, err := payload.Encode(2024)
+	s.NoError(err)
+	schMemo := payload.EncodeString("v2-to-v1 memo value")
+
 	// Create CHASM schedule directly.
-	_, err := env.GetTestCluster().SchedulerClient().CreateSchedule(
+	_, err = env.GetTestCluster().SchedulerClient().CreateSchedule(
 		ctx,
 		&schedulerpb.CreateScheduleRequest{
 			NamespaceId: nsID,
@@ -490,6 +516,15 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1() {
 				Schedule:   sched,
 				Identity:   "test",
 				RequestId:  uuid.NewString(),
+				SearchAttributes: &commonpb.SearchAttributes{
+					IndexedFields: map[string]*commonpb.Payload{
+						csaKeyword: schSAKeyword,
+						csaInt:     schSAInt,
+					},
+				},
+				Memo: &commonpb.Memo{
+					Fields: map[string]*commonpb.Payload{"schedmemo1": schMemo},
+				},
 			},
 		},
 	)
@@ -608,6 +643,24 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1() {
 		return err == nil && len(listResp.GetSchedules()) == 1
 	}, 30*time.Second, 500*time.Millisecond)
 	s.Equal(sid, listResp.GetSchedules()[0].GetScheduleId())
+
+	// Custom SAs and memo must have carried over to the V1 schedule.
+	s.Equal(schSAKeyword.Data, v1Desc.GetSearchAttributes().GetIndexedFields()[csaKeyword].GetData())
+	s.Equal(schSAInt.Data, v1Desc.GetSearchAttributes().GetIndexedFields()[csaInt].GetData())
+	s.Equal(schMemo.Data, v1Desc.GetMemo().GetFields()["schedmemo1"].GetData())
+
+	entry := listResp.GetSchedules()[0]
+	s.Equal(schSAKeyword.Data, entry.GetSearchAttributes().GetIndexedFields()[csaKeyword].GetData())
+	s.Equal(schSAInt.Data, entry.GetSearchAttributes().GetIndexedFields()[csaInt].GetData())
+
+	filtered, err := env.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
+		Namespace:       nsName,
+		MaximumPageSize: 10,
+		Query:           "CustomKeywordField = 'v2-to-v1 sa value'",
+	})
+	s.NoError(err)
+	s.Len(filtered.GetSchedules(), 1)
+	s.Equal(sid, filtered.GetSchedules()[0].GetScheduleId())
 }
 
 func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1Idempotent() {


### PR DESCRIPTION
## What changed?
- Added test coverage showing search attributes move V1<->V2 in functional testing (unit tests already in place).
- V2->V1 path now explicitly unaliases search attributes, mirroring how the `createScheduleWorkflow` frontend handler does so.

## Why?
- We found a case where custom SAs can cause V1's visibility task to fail (`"unable to decode search attributes: invalid search attribute type: Unspecified"`), because V1's path expected the alias to already be resolved. 

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)
