### PR TITLE
Drop zlib filter from apk upgrade and bump default CLI to v1.7.2 (security patches)

### DIFF
--- a/.github/actions/build-docker-images/scripts/main.go
+++ b/.github/actions/build-docker-images/scripts/main.go
@@ -14,7 +14,7 @@ import (
 var validArchs = []string{"amd64", "arm64"}
 
 // defaultCliVersion should be updated to the latest cli version
-const defaultCliVersion = "1.7.0"
+const defaultCliVersion = "1.7.2"
 
 func main() {
 	if len(os.Args) < 2 {

--- a/docker/targets/admin-tools.Dockerfile
+++ b/docker/targets/admin-tools.Dockerfile
@@ -12,7 +12,7 @@ ARG TARGETARCH
 RUN apk add --no-cache \
     ca-certificates \
     tzdata && \
-    apk upgrade --no-cache zlib && \
+    apk upgrade --no-cache && \
     addgroup -g 1000 temporal && \
     adduser -u 1000 -G temporal -D temporal
 

--- a/docker/targets/server.Dockerfile
+++ b/docker/targets/server.Dockerfile
@@ -12,7 +12,7 @@ ARG TARGETARCH
 RUN apk add --no-cache \
     ca-certificates \
     tzdata && \
-    apk upgrade --no-cache zlib && \
+    apk upgrade --no-cache && \
     addgroup -g 1000 temporal && \
     adduser -u 1000 -G temporal -D temporal
 


### PR DESCRIPTION
## What changed?

Three single-character edits, two fix categories:

1. `docker/targets/server.Dockerfile` and `docker/targets/admin-tools.Dockerfile`: change `apk upgrade --no-cache zlib` to `apk upgrade --no-cache`. Drops the `zlib` filter so apk refreshes every installed package, not just zlib.
2. `.github/actions/build-docker-images/scripts/main.go`: bump `defaultCliVersion` from `1.7.0` to `1.7.2`.

## Why?

### Alpine OpenSSL findings (server + admin-tools)

Grype scan on `temporaliotest/server:sha-c571329` and `temporaliotest/admin-tools:sha-c571329` flagged ~26 HIGH/CRITICAL findings, all in `libcrypto3`/`libssl3` at 3.5.6-r0. Fixed packages 3.5.7-r0 are already in the Alpine 3.23 apk repo; the Dockerfile just was not picking them up because the upgrade was scoped to `zlib`. Includes CVE-2026-34182 (Critical), CVE-2026-45445, CVE-2026-42764, CVE-2026-34183, CVE-2026-34181, CVE-2026-7383, CVE-2026-9076, CVE-2026-34180 (all High).

Verified locally:
- `alpine:3.23.4` + `apk upgrade --no-cache zlib` → libcrypto3 stays at 3.5.6-r0
- `alpine:3.23.4` + `apk upgrade --no-cache` → libcrypto3 bumps to 3.5.7-r0

### CLI v1.7.0 → v1.7.2 (admin-tools only)

The `temporal` CLI binary embedded in admin-tools is downloaded at build time; v1.7.0 was built with Go 1.26.2 + `x/crypto v0.46.0` + `x/sys v0.42.0`, which surface as HIGH/CRITICAL findings in the scan: CVE-2026-42501 (High), CVE-2026-27145, CVE-2026-39817-26, GO-2026-5016, GO-2026-5024, GO-2026-5037. v1.7.2 (released 2026-06-10) is built with Go 1.26.4, x/crypto v0.52.0, x/net v0.55.0, x/sys v0.45.0 — clears every listed advisory.

Verified locally by downloading both CLI release tarballs and running `go version -m` on the binaries.

After this PR, the build-and-publish workflow will re-fire and we will re-grype the resulting sha-XXX images before promoting v1.30.5.