### PR TITLE
fix: gate the token encoding with a dynamic config for mixed brain scenarios

### DIFF
--- a/chasm/lib/callback/config.go
+++ b/chasm/lib/callback/config.go
@@ -58,6 +58,16 @@ func configProvider(dc *dynamicconfig.Collection) *Config {
 	}
 }
 
+var EncodeInternalTokenWithEnvelope = dynamicconfig.NewNamespaceBoolSetting(
+	"callback.encodeInternalTokenWithEnvelope",
+	false,
+	`Controls how the internal CHASM Nexus completion callback token is encoded. When true the token is
+encoded as a NexusOperationCompletion envelope; when false (default) it is the legacy bare base64-encoded
+ChasmComponentRef. Gates a safe fleet-wide rollout of the envelope encoding: keep disabled until every
+server can read it (any server able to read the envelope also accepts the legacy form), then enable
+per-namespace.`,
+)
+
 var AllowedAddresses = dynamicconfig.NewNamespaceTypedSettingWithConverter(
 	"chasm.callback.allowedAddresses",
 	allowedAddressConverter,

--- a/chasm/lib/callback/invocable_internal.go
+++ b/chasm/lib/callback/invocable_internal.go
@@ -72,6 +72,7 @@ func (c invocableInternal) Invoke(
 	if err != nil {
 		return invocationResultFail{logInternalError(h.logger, "failed to decode CHASM callback token", err)}
 	}
+
 	// Older tokens don't carry a request ID; fall back to the one on the callback state machine.
 	if requestID == "" {
 		requestID = c.requestID

--- a/chasm/lib/scheduler/config.go
+++ b/chasm/lib/scheduler/config.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"time"
 
+	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/dynamicconfig"
 )
@@ -20,9 +21,10 @@ type (
 
 	// Config is the CHASM Scheduler dynamic config, shared among all sub-components.
 	Config struct {
-		Tweakables         dynamicconfig.TypedPropertyFnWithNamespaceFilter[Tweakables]
-		ServiceCallTimeout dynamicconfig.DurationPropertyFn
-		RetryPolicy        func() backoff.RetryPolicy
+		Tweakables                      dynamicconfig.TypedPropertyFnWithNamespaceFilter[Tweakables]
+		ServiceCallTimeout              dynamicconfig.DurationPropertyFn
+		RetryPolicy                     func() backoff.RetryPolicy
+		EncodeInternalTokenWithEnvelope dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	}
 )
 
@@ -68,8 +70,9 @@ var (
 
 func ConfigProvider(dc *dynamicconfig.Collection) *Config {
 	return &Config{
-		Tweakables:         CurrentTweakables.Get(dc),
-		ServiceCallTimeout: ServiceCallTimeout.Get(dc),
+		Tweakables:                      CurrentTweakables.Get(dc),
+		ServiceCallTimeout:              ServiceCallTimeout.Get(dc),
+		EncodeInternalTokenWithEnvelope: callback.EncodeInternalTokenWithEnvelope.Get(dc),
 		RetryPolicy: func() backoff.RetryPolicy {
 			return backoff.NewExponentialRetryPolicy(
 				RetryPolicyInitialInterval.Get(dc)(),

--- a/chasm/lib/scheduler/helper_test.go
+++ b/chasm/lib/scheduler/helper_test.go
@@ -72,6 +72,9 @@ func defaultConfig() *scheduler.Config {
 		ServiceCallTimeout: func() time.Duration {
 			return 5 * time.Second
 		},
+		EncodeInternalTokenWithEnvelope: func(string) bool {
+			return true
+		},
 		RetryPolicy: func() backoff.RetryPolicy {
 			return backoff.NewExponentialRetryPolicy(1 * time.Second)
 		},

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -568,7 +568,7 @@ func (h *InvokerExecuteTaskHandler) startWorkflow(
 	// completion is matched by a request ID that rides in the callback header and survives
 	// continue-as-new, rather than the started workflow's callback state which is re-stamped on each
 	// new run.
-	callback, err := chasm.GenerateNexusCallback(schedulerRef, start.RequestId)
+	callback, err := chasm.GenerateNexusCallback(schedulerRef, start.RequestId, h.config.EncodeInternalTokenWithEnvelope(scheduler.Namespace))
 	if err != nil {
 		return nil, err
 	}

--- a/chasm/lib/scheduler/scheduler_tasks.go
+++ b/chasm/lib/scheduler/scheduler_tasks.go
@@ -241,7 +241,7 @@ func (r *SchedulerCallbacksTaskHandler) watchRunningStart(
 
 	// Pack this start's request ID into the callback token so completions are matched from the token
 	// (which survives continue-as-new) rather than the started workflow's callback state.
-	callback, err := chasm.GenerateNexusCallback(schedulerRef, start.RequestId)
+	callback, err := chasm.GenerateNexusCallback(schedulerRef, start.RequestId, r.config.EncodeInternalTokenWithEnvelope(scheduler.Namespace))
 	if err != nil {
 		return nil, err
 	}

--- a/chasm/nexus_completion.go
+++ b/chasm/nexus_completion.go
@@ -23,13 +23,24 @@ type NexusCompletionHandler interface {
 }
 
 // GenerateNexusCallback builds a Nexus completion callback targeting the CHASM component identified by
-// serializedRef (obtained from Context.Ref). The request ID is packed into the callback token, so the
-// completion is matched by a request ID that rides in the callback header and survives
-// continue-as-new, rather than one read from mutable state.
-func GenerateNexusCallback(serializedRef []byte, requestID string) (*commonpb.Callback, error) {
-	token, err := packNexusCallbackToken(serializedRef, requestID)
-	if err != nil {
-		return nil, err
+// serializedRef (obtained from Context.Ref). When encodeToken is true, the request ID is packed into
+// the callback token (a NexusOperationCompletion envelope), so the completion is matched by a request
+// ID that rides in the callback header and survives continue-as-new, rather than one read from mutable
+// state. When encodeToken is false, the legacy format is emitted: the token is the bare base64-encoded
+// ChasmComponentRef with no request ID. The caller chooses encodeToken (e.g. gated behind dynamic
+// config) to keep the envelope format off the wire until the whole fleet can read it. Either format is
+// always decodable by UnpackNexusCallbackToken.
+func GenerateNexusCallback(serializedRef []byte, requestID string, encodeToken bool) (*commonpb.Callback, error) {
+	var token string
+	if encodeToken {
+		var err error
+		token, err = packNexusCallbackToken(serializedRef, requestID)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Legacy format: the token is the bare base64-encoded ChasmComponentRef.
+		token = base64.RawURLEncoding.EncodeToString(serializedRef)
 	}
 	return &commonpb.Callback{
 		Variant: &commonpb.Callback_Nexus_{
@@ -54,8 +65,9 @@ func packNexusCallbackToken(componentRef []byte, requestID string) (string, erro
 }
 
 // UnpackNexusCallbackToken decodes a callback token produced by GenerateNexusCallback, returning the
-// component ref and request ID. For backward compatibility it also accepts the legacy format where the
-// token is the bare base64-encoded ChasmComponentRef (in which case the request ID is empty).
+// component ref and request ID. It accepts both token formats regardless of how the token was written:
+// the NexusOperationCompletion envelope, and (for backward compatibility) the legacy bare base64-encoded
+// ChasmComponentRef, in which case the request ID is empty.
 func UnpackNexusCallbackToken(encoded string) (componentRef []byte, requestID string, err error) {
 	raw, err := base64.RawURLEncoding.DecodeString(encoded)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.temporal.io/server
 
-go 1.26.2
+go 1.26.4
 
 retract (
 	v1.30.0

--- a/tests/callbacks_test.go
+++ b/tests/callbacks_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	schedulepb "go.temporal.io/api/schedule/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
@@ -21,9 +22,12 @@ import (
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common/dynamicconfig"
+	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexusrpc"
+	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/protoassert"
 	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/common/testing/testvars"
@@ -75,6 +79,130 @@ func (s *CallbacksSuite) runNexusCompletionHTTPServer(t *testing.T, h *completio
 		srv.Close()
 	})
 	return srv.URL
+}
+
+// TestScheduledCallbackTokenMigration_LegacyWriteEnvelopeRead validates the backwards-compatible
+// rollout of the envelope completion-callback token format. A scheduled workflow is started while
+// the envelope gate is OFF (so its completion callback carries a legacy token with no embedded
+// request ID), and then the gate is flipped ON before the workflow completes. The scheduler must
+// still observe the completion of the legacy-token action, proving the read path tolerates both
+// token formats during a mixed-brain rollout.
+//
+// CHASM-only: it relies on the CHASM scheduler and CHASM completion callbacks.
+func (s *CallbacksSuite) TestScheduledCallbackTokenMigration_LegacyWriteEnvelopeRead() {
+	if !s.chasmEnabled {
+		s.T().Skip("requires the CHASM scheduler and CHASM completion callbacks")
+	}
+
+	// The CHASM scheduler needs sentinels and the experiment header allowed. The envelope token
+	// format is gated off here so the scheduled action is started with a legacy token.
+	s.OverrideDynamicConfig(dynamicconfig.EnableCHASMSchedulerSentinels, true)
+	s.OverrideDynamicConfig(dynamicconfig.FrontendAllowedExperiments, []string{"*"})
+	s.OverrideDynamicConfig(callback.EncodeInternalTokenWithEnvelope, false)
+
+	ctx := testcore.NewContext()
+	sid := testcore.RandomizeStr("sched-token-migration")
+	wid := testcore.RandomizeStr("sched-token-migration-wf")
+	wt := testcore.RandomizeStr("sched-token-migration-wt")
+
+	sdkClient, err := client.Dial(client.Options{
+		HostPort:  s.FrontendGRPCAddress(),
+		Namespace: s.Namespace().String(),
+	})
+	s.NoError(err)
+	defer sdkClient.Close()
+
+	taskQueue := testcore.RandomizeStr(s.T().Name())
+	w := worker.New(sdkClient, taskQueue, worker.Options{})
+	w.RegisterWorkflowWithOptions(func(ctx workflow.Context) error {
+		workflow.GetSignalChannel(ctx, "continue").Receive(ctx, nil)
+		return nil
+	}, workflow.RegisterOptions{Name: wt})
+	s.NoError(w.Start())
+	defer w.Stop()
+
+	schedule := &schedulepb.Schedule{
+		Spec: &schedulepb.ScheduleSpec{
+			Interval: []*schedulepb.IntervalSpec{{Interval: durationpb.New(1 * time.Second)}},
+		},
+		Policies: &schedulepb.SchedulePolicies{OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP},
+		Action: &schedulepb.ScheduleAction{
+			Action: &schedulepb.ScheduleAction_StartWorkflow{
+				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+					WorkflowId:   wid,
+					WorkflowType: &commonpb.WorkflowType{Name: wt},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				},
+			},
+		},
+	}
+	_, err = s.FrontendClient().CreateSchedule(chasmContextFactory(ctx), &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Schedule:   schedule,
+		Identity:   "test",
+		RequestId:  uuid.NewString(),
+	})
+	s.NoError(err)
+
+	var startedWFID string
+	await.RequireTruef(s.T(), func() bool {
+		desc, descErr := s.FrontendClient().DescribeSchedule(chasmContextFactory(ctx), &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+		})
+		if descErr != nil {
+			return false
+		}
+		for _, a := range desc.GetInfo().GetRecentActions() {
+			if wfid := a.GetStartWorkflowResult().GetWorkflowId(); wfid != "" {
+				startedWFID = wfid
+				return true
+			}
+		}
+		return false
+	}, 15*time.Second, 200*time.Millisecond, "scheduler should start a scheduled action")
+	s.NotEmpty(startedWFID)
+
+	var token string
+	for _, e := range s.GetHistory(s.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: startedWFID}) {
+		for _, cb := range e.GetWorkflowExecutionStartedEventAttributes().GetCompletionCallbacks() {
+			if cb.GetNexus().GetUrl() == chasm.NexusCompletionHandlerURL {
+				token = nexus.Header(cb.GetNexus().GetHeader()).Get(commonnexus.CallbackTokenHeader)
+			}
+		}
+	}
+	s.NotEmpty(token, "scheduled workflow must carry an internal completion callback token")
+	_, reqID, decErr := chasm.UnpackNexusCallbackToken(token)
+	s.NoError(decErr)
+	s.Empty(reqID, "gate OFF must write a legacy token with no embedded request ID")
+
+	s.OverrideDynamicConfig(callback.EncodeInternalTokenWithEnvelope, true)
+
+	_, err = s.FrontendClient().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
+		Namespace:         s.Namespace().String(),
+		WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: startedWFID},
+		SignalName:        "continue",
+	})
+	s.NoError(err)
+
+	await.RequireTruef(s.T(), func() bool {
+		desc, descErr := s.FrontendClient().DescribeSchedule(chasmContextFactory(ctx), &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+		})
+		if descErr != nil {
+			return false
+		}
+		for _, a := range desc.GetInfo().GetRecentActions() {
+			if a.GetStartWorkflowResult().GetWorkflowId() == startedWFID &&
+				a.GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED {
+				return true
+			}
+		}
+		return false
+	}, 20*time.Second, 200*time.Millisecond,
+		"scheduler must observe completion of the legacy-token action after enabling the envelope gate")
 }
 
 func (s *CallbacksSuite) TestWorkflowCallbacks_InvalidArgument() {

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -27,6 +27,7 @@ import (
 	"go.temporal.io/sdk/workflow"
 	schedulespb "go.temporal.io/server/api/schedule/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/callback"
 	chasmscheduler "go.temporal.io/server/chasm/lib/scheduler"
 	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -829,7 +830,11 @@ func testLastCompletionAndError(t *testing.T, newContext contextFactory) {
 // are observed) and that the completion callback is written intact into both the original and the
 // continued-as-new run. CHASM-only: V1 uses no Nexus completion callbacks.
 func testScheduledWorkflowContinueAsNewCompletion(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts()...)
+	// The scheduler matches the continued-as-new run's completion by the request ID carried in the
+	// completion callback token, which only survives continue-as-new in the envelope token format.
+	// That format is gated off by default for safe rollout, so enable it explicitly here.
+	opts := append(scheduleCommonOpts(), testcore.WithDynamicConfig(callback.EncodeInternalTokenWithEnvelope, true))
+	s := testcore.NewEnv(t, opts...)
 
 	sid := testcore.RandomizeStr("sched-can-completion")
 	wid := testcore.RandomizeStr("sched-can-completion-wf")


### PR DESCRIPTION
In #10605 a request ID was added to the encoded callback token to fix a bug with CaN callbacks not being find-able by schedules. This change will put this migration behind a dynamic config because the change is not backwards compatible.

scenario

- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [X] added new functional test(s)

Adding the dynamic config gating should reduce the risks, there is a functional test to validate turning this on will still have the callback trigger as expected