### PR TITLE
Prepare Go GitHub action

### DIFF
--- a/.github/actions/prepare-go/action.yml
+++ b/.github/actions/prepare-go/action.yml
@@ -1,0 +1,81 @@
+name: Prepare Go
+description: Set up Go, restore caches, and download modules with retry.
+
+outputs:
+  build_cache_hit:
+    description: Whether the Go build cache was restored from an exact match.
+    value: ${{ steps.restore-build.outputs.cache-hit }}
+  build_cache_path:
+    description: Go build cache path.
+    value: ${{ steps.go-env.outputs.gocache }}
+  build_cache_primary_key:
+    description: Primary key used for the Go build cache restore.
+    value: ${{ steps.restore-build.outputs.cache-primary-key }}
+  dependency_cache_hit:
+    description: Whether the Go module cache was restored from an exact match.
+    value: ${{ steps.restore-deps.outputs.cache-hit }}
+  dependency_cache_path:
+    description: Go module cache path.
+    value: ${{ steps.go-env.outputs.gomodcache }}
+  dependency_cache_primary_key:
+    description: Primary key used for the Go module cache restore.
+    value: ${{ steps.restore-deps.outputs.cache-primary-key }}
+  tools_cache_hit:
+    description: Whether the Go tools cache was restored from an exact match.
+    value: ${{ steps.restore-tools.outputs.cache-hit }}
+  tools_cache_path:
+    description: Go tools cache path.
+    value: .bin
+  tools_cache_primary_key:
+    description: Primary key used for the Go tools cache restore.
+    value: ${{ steps.restore-tools.outputs.cache-primary-key }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      id: setup-go
+      with:
+        go-version-file: "go.mod"
+        cache: false # do our own caching
+
+    - name: Resolve Go cache paths
+      id: go-env
+      shell: bash
+      run: |
+        echo "gocache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+        echo "gomodcache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+
+    - name: Restore dependencies
+      id: restore-deps
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ${{ steps.go-env.outputs.gomodcache }}
+        key: go-${{ runner.os }}${{ runner.arch }}-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.mod') }}-deps-${{ hashFiles('go.sum') }}
+
+    - name: Restore Go tools
+      id: restore-tools
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: .bin
+        key: go-${{ runner.os }}${{ runner.arch }}-${{ steps.setup-go.outputs.go-version }}-tools-${{ hashFiles('Makefile') }}
+
+    # Cache restore can miss modules after go.sum changes or partial cache saves.
+    # Retrying download here isolates transient Go proxy failures from the Go command.
+    - name: Download Go modules
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      with:
+        max_attempts: 3
+        retry_wait_seconds: 10
+        timeout_minutes: 5
+        shell: bash
+        command: go mod download
+
+    - name: Restore build outputs
+      id: restore-build
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ${{ steps.go-env.outputs.gocache }}
+        key: go-${{ runner.os }}${{ runner.arch }}-${{ steps.setup-go.outputs.go-version }}-build-${{ env.COMMIT }}
+        restore-keys: |
+          go-${{ runner.os }}${{ runner.arch }}-${{ steps.setup-go.outputs.go-version }}-build-

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -222,32 +222,32 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ env.COMMIT }}
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: "go.mod"
-          cache: false # do our own caching
-
-      - name: Restore dependencies
-        id: restore-deps
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ runner.os }}${{ runner.arch }}-${{ hashFiles('go.mod') }}-deps-${{ hashFiles('go.sum') }}
+      - name: Prepare Go
+        id: prepare-go
+        uses: ./.github/actions/prepare-go
 
       - run: make pre-build-functional-test-coverage
 
-      - name: Save dependencies
+      - name: Save Go dependencies
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        if: ${{ steps.restore-deps.outputs.cache-hit != 'true' }}
+        if: ${{ steps.prepare-go.outputs.dependency_cache_hit != 'true' }}
         with:
-          path: ~/go/pkg/mod
-          key: ${{ steps.restore-deps.outputs.cache-primary-key }}
+          path: ${{ steps.prepare-go.outputs.dependency_cache_path }}
+          key: ${{ steps.prepare-go.outputs.dependency_cache_primary_key }}
 
-      - name: Save build outputs
+      - name: Save Go tools
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        if: ${{ steps.prepare-go.outputs.tools_cache_hit != 'true' }}
         with:
-          path: ~/.cache/go-build
-          key: go-${{ runner.os }}${{ runner.arch }}-build-${{ env.COMMIT }}
+          path: ${{ steps.prepare-go.outputs.tools_cache_path }}
+          key: ${{ steps.prepare-go.outputs.tools_cache_primary_key }}
+
+      - name: Save Go build outputs
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        if: ${{ steps.prepare-go.outputs.build_cache_hit != 'true' }}
+        with:
+          path: ${{ steps.prepare-go.outputs.build_cache_path }}
+          key: ${{ steps.prepare-go.outputs.build_cache_primary_key }}
 
   misc-checks:
     name: Misc checks
@@ -261,22 +261,8 @@ jobs:
           # buf-breaking tries to compare HEAD against merge base so we need to be able to find it
           fetch-depth: 100
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: "go.mod"
-          cache: false # do our own caching
-
-      - name: Restore dependencies
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ runner.os }}${{ runner.arch }}-${{ hashFiles('go.mod') }}-deps-${{ hashFiles('go.sum') }}
-
-      - name: Restore build outputs
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/go-build
-          key: go-${{ runner.os }}${{ runner.arch }}-build-${{ env.COMMIT }}
+      - name: Prepare Go
+        uses: ./.github/actions/prepare-go
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
@@ -299,22 +285,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ env.COMMIT }}
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: "go.mod"
-          cache: false # do our own caching
-
-      - name: Restore dependencies
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ runner.os }}${{ runner.arch }}-${{ hashFiles('go.mod') }}-deps-${{ hashFiles('go.sum') }}
-
-      - name: Restore build outputs
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/go-build
-          key: go-${{ runner.os }}${{ runner.arch }}-build-${{ env.COMMIT }}
+      - name: Prepare Go
+        uses: ./.github/actions/prepare-go
 
       - name: Run unit tests
         timeout-minutes: 20
@@ -347,22 +319,8 @@ jobs:
           compose_file: ${{ env.DOCKER_COMPOSE_FILE }}
           services: ${{ env.CONTAINERS }}
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: "go.mod"
-          cache: false # do our own caching
-
-      - name: Restore dependencies
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ runner.os }}${{ runner.arch }}-${{ hashFiles('go.mod') }}-deps-${{ hashFiles('go.sum') }}
-
-      - name: Restore build outputs
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/go-build
-          key: go-${{ runner.os }}${{ runner.arch }}-build-${{ env.COMMIT }}
+      - name: Prepare Go
+        uses: ./.github/actions/prepare-go
 
       - name: Wait for containerized dependencies to be healthy
         uses: ./.github/actions/docker-compose-healthy
@@ -419,22 +377,8 @@ jobs:
           services: ${{ env.CONTAINERS }}
           cache: true
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: "go.mod"
-          cache: false # do our own caching
-
-      - name: Restore dependencies
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ runner.os }}${{ runner.arch }}-${{ hashFiles('go.mod') }}-deps-${{ hashFiles('go.sum') }}
-
-      - name: Restore build outputs
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/go-build
-          key: go-${{ runner.os }}${{ runner.arch }}-build-${{ env.COMMIT }}
+      - name: Prepare Go
+        uses: ./.github/actions/prepare-go
 
       - name: ${{ matrix.display_name == 'smoke' && 'ℹ️ Smoke test' || 'ℹ️ Full test' }}
         run: echo "::notice::${{ matrix.display_name == 'smoke' && 'This is a smoke test. Add the test-all-dbs label to run all tests on all DBs.' || needs.test-setup.outputs.full_test_reason }}"
@@ -493,22 +437,8 @@ jobs:
           compose_file: ${{ env.DOCKER_COMPOSE_FILE }}
           services: postgresql
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: "go.mod"
-          cache: false
-
-      - name: Restore dependencies
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ runner.os }}${{ runner.arch }}-${{ hashFiles('go.mod') }}-deps-${{ hashFiles('go.sum') }}
-
-      - name: Restore build outputs
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/go-build
-          key: go-${{ runner.os }}${{ runner.arch }}-build-${{ env.COMMIT }}
+      - name: Prepare Go
+        uses: ./.github/actions/prepare-go
 
       - name: Install PostgreSQL schema
         run: make install-schema-postgresql12

--- a/Makefile
+++ b/Makefile
@@ -531,9 +531,9 @@ integration-test-coverage: prepare-coverage-test
 	go run ./cmd/tools/test-runner test --gotestsum-path=$(GOTESTSUM) --max-attempts=$(MAX_TEST_ATTEMPTS) --junitfile=$(NEW_REPORT) -- \
 		$(COMPILED_TEST_ARGS) -coverprofile=$(NEW_COVER_PROFILE) $(INTEGRATION_TEST_DIRS)
 
-# This should use the same build flags as functional-test-coverage and functional-test-{xdc,ndc}-coverage for best build caching.
+# MUST use the same build flags as functional-test-coverage and functional-test-{xdc,ndc}-coverage for best build caching.
 pre-build-functional-test-coverage: prepare-coverage-test
-	go test -c -cover -o /dev/null $(FUNCTIONAL_TEST_ROOT) $(TEST_ARGS) $(TEST_TAG_FLAG) $(COVERPKG_FLAG)
+	go test -c -cover -o /dev/null $(COMPILED_TEST_ARGS) $(COVERPKG_FLAG) $(FUNCTIONAL_TEST_ROOT)
 
 functional-test-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run functional tests with coverage with $(PERSISTENCE_DRIVER) driver..."


### PR DESCRIPTION
## What changed?

Added an explicit `go download` step with retry.

Extracted a new GitHub action for the "setup Go" steps across test jobs; to reduce duplication.

## Why?

Sometimes the `go download` fails and could be retried: https://github.com/temporalio/temporal/actions/runs/27560870829/job/81473394249?pr=9160

```
go: go.opentelemetry.io/otel@v1.43.0: read "https://proxy.golang.org/go.opentelemetry.io/otel/@v/v1.43.0.zip": stream error: stream ID 1335; INTERNAL_ERROR; received from peer
Error: Process completed with exit code 1.
```

Also; pre-build is now faster.

<img width="1264" height="306" alt="image" src="https://github.com/user-attachments/assets/c90a5683-889c-48e6-a1bb-9bca695e23ae" />

It is usually [1-2min](https://github.com/temporalio/temporal/actions/runs/27565277131/job/81487709681#step:5:14).
