### PR TITLE
Improve testrunner timeout behavior

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -153,20 +153,24 @@ jobs:
             functest:
               cmd: make functional-test-coverage
               test_timeout: 35m
+              test_runner_timeout: 39m
               github_timeout: 40
               sharded: true
             smoke:
               cmd: make functional-test-coverage
               test_timeout: 5m
+              test_runner_timeout: 9m
               github_timeout: 10
               test_args: '"-run=TestActivityTestSuite|TestSignalWorkflowTestSuite|TestWorkflowTestSuite"'
             ndc:
               cmd: make functional-test-ndc-coverage
               test_timeout: 10m
+              test_runner_timeout: 14m
               github_timeout: 15
             xdc:
               cmd: make functional-test-xdc-coverage
               test_timeout: 30m
+              test_runner_timeout: 34m
               github_timeout: 35
         run: |
           # Convert YAML inputs to JSON for jq.
@@ -405,6 +409,7 @@ jobs:
       PERSISTENCE_TYPE: ${{ matrix.persistence_type }}
       PERSISTENCE_DRIVER: ${{ matrix.persistence_driver }}
       TEST_TIMEOUT: ${{ matrix.test_timeout }}
+      TEST_RUNNER_TIMEOUT: ${{ matrix.test_runner_timeout }}
       CONTAINERS: ${{ join(matrix.containers, ' ') }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -153,24 +153,20 @@ jobs:
             functest:
               cmd: make functional-test-coverage
               test_timeout: 35m
-              test_runner_timeout: 39m
               github_timeout: 40
               sharded: true
             smoke:
               cmd: make functional-test-coverage
               test_timeout: 5m
-              test_runner_timeout: 9m
               github_timeout: 10
               test_args: '"-run=TestActivityTestSuite|TestSignalWorkflowTestSuite|TestWorkflowTestSuite"'
             ndc:
               cmd: make functional-test-ndc-coverage
               test_timeout: 10m
-              test_runner_timeout: 14m
               github_timeout: 15
             xdc:
               cmd: make functional-test-xdc-coverage
               test_timeout: 30m
-              test_runner_timeout: 34m
               github_timeout: 35
         run: |
           # Convert YAML inputs to JSON for jq.
@@ -409,7 +405,6 @@ jobs:
       PERSISTENCE_TYPE: ${{ matrix.persistence_type }}
       PERSISTENCE_DRIVER: ${{ matrix.persistence_driver }}
       TEST_TIMEOUT: ${{ matrix.test_timeout }}
-      TEST_RUNNER_TIMEOUT: ${{ matrix.test_runner_timeout }}
       CONTAINERS: ${{ join(matrix.containers, ' ') }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -452,7 +447,7 @@ jobs:
 
       - name: Run functional test
         timeout-minutes: ${{ matrix.github_timeout }}
-        run: ./develop/github/monitor_test.sh ${{ matrix.cmd }}
+        run: TEST_RUNNER_TIMEOUT="$((${{ matrix.github_timeout }} - 1))m" ./develop/github/monitor_test.sh ${{ matrix.cmd }}
         env:
           TEST_TOTAL_SHARDS: ${{ matrix.total_shards }}
           TEST_SHARD_INDEX: ${{ matrix.total_shards && matrix.shard_index }} # guard with total_shards to avoid falsy eval of shard_index=0

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -445,9 +445,12 @@ jobs:
           compose_file: ${{ env.DOCKER_COMPOSE_FILE }}
           services: ${{ env.CONTAINERS }}
 
+      - name: Configure testrunner timeout
+        run: echo "TEST_RUNNER_TIMEOUT=$((${{ matrix.github_timeout }} - 1))m" >> "$GITHUB_ENV"
+
       - name: Run functional test
         timeout-minutes: ${{ matrix.github_timeout }}
-        run: TEST_RUNNER_TIMEOUT="$((${{ matrix.github_timeout }} - 1))m" ./develop/github/monitor_test.sh ${{ matrix.cmd }}
+        run: ./develop/github/monitor_test.sh ${{ matrix.cmd }}
         env:
           TEST_TOTAL_SHARDS: ${{ matrix.total_shards }}
           TEST_SHARD_INDEX: ${{ matrix.total_shards && matrix.shard_index }} # guard with total_shards to avoid falsy eval of shard_index=0

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -445,12 +445,11 @@ jobs:
           compose_file: ${{ env.DOCKER_COMPOSE_FILE }}
           services: ${{ env.CONTAINERS }}
 
-      - name: Configure testrunner timeout
-        run: echo "TEST_RUNNER_TIMEOUT=$((${{ matrix.github_timeout }} - 1))m" >> "$GITHUB_ENV"
-
       - name: Run functional test
         timeout-minutes: ${{ matrix.github_timeout }}
-        run: ./develop/github/monitor_test.sh ${{ matrix.cmd }}
+        run: |
+          export TEST_RUNNER_TIMEOUT="$((${{ matrix.github_timeout }} - 1))m"
+          ./develop/github/monitor_test.sh ${{ matrix.cmd }}
         env:
           TEST_TOTAL_SHARDS: ${{ matrix.total_shards }}
           TEST_SHARD_INDEX: ${{ matrix.total_shards && matrix.shard_index }} # guard with total_shards to avoid falsy eval of shard_index=0

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ TEST_TIMEOUT ?= 35m
 
 # Number of retries for *-coverage targets.
 MAX_TEST_ATTEMPTS ?= 3
+TEST_RUNNER_TIMEOUT_ARG := $(if $(TEST_RUNNER_TIMEOUT),--total-timeout=$(TEST_RUNNER_TIMEOUT),)
 
 # Whether or not to test with the race detector. All of (1 on y yes t true) are true values.
 TEST_RACE_FLAG ?= on
@@ -523,12 +524,12 @@ prepare-coverage-test: $(GOTESTSUM) $(TEST_OUTPUT_ROOT)
 
 unit-test-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run unit tests with coverage..."
-	go run ./cmd/tools/test-runner test --gotestsum-path=$(GOTESTSUM) --max-attempts=$(MAX_TEST_ATTEMPTS) --junitfile=$(NEW_REPORT) -- \
+	go run ./cmd/tools/test-runner test --gotestsum-path=$(GOTESTSUM) --max-attempts=$(MAX_TEST_ATTEMPTS) $(TEST_RUNNER_TIMEOUT_ARG) --junitfile=$(NEW_REPORT) -- \
 		$(COMPILED_TEST_ARGS) -coverprofile=$(NEW_COVER_PROFILE) $(UNIT_TEST_DIRS)
 
 integration-test-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run integration tests with coverage..."
-	go run ./cmd/tools/test-runner test --gotestsum-path=$(GOTESTSUM) --max-attempts=$(MAX_TEST_ATTEMPTS) --junitfile=$(NEW_REPORT) -- \
+	go run ./cmd/tools/test-runner test --gotestsum-path=$(GOTESTSUM) --max-attempts=$(MAX_TEST_ATTEMPTS) $(TEST_RUNNER_TIMEOUT_ARG) --junitfile=$(NEW_REPORT) -- \
 		$(COMPILED_TEST_ARGS) -coverprofile=$(NEW_COVER_PROFILE) $(INTEGRATION_TEST_DIRS)
 
 # This should use the same build flags as functional-test-coverage and functional-test-{xdc,ndc}-coverage for best build caching.
@@ -537,19 +538,19 @@ pre-build-functional-test-coverage: prepare-coverage-test
 
 functional-test-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run functional tests with coverage with $(PERSISTENCE_DRIVER) driver..."
-	go run ./cmd/tools/test-runner test --gotestsum-path=$(GOTESTSUM) --max-attempts=$(MAX_TEST_ATTEMPTS) --junitfile=$(NEW_REPORT) -- \
+	go run ./cmd/tools/test-runner test --gotestsum-path=$(GOTESTSUM) --max-attempts=$(MAX_TEST_ATTEMPTS) $(TEST_RUNNER_TIMEOUT_ARG) --junitfile=$(NEW_REPORT) -- \
 		$(COMPILED_TEST_ARGS) -coverprofile=$(NEW_COVER_PROFILE) $(COVERPKG_FLAG) $(FUNCTIONAL_TEST_ROOT) \
 		-args -persistenceType=$(PERSISTENCE_TYPE) -persistenceDriver=$(PERSISTENCE_DRIVER)
 
 functional-test-xdc-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run functional test for cross DC with coverage with $(PERSISTENCE_DRIVER) driver..."
-	go run ./cmd/tools/test-runner test --gotestsum-path=$(GOTESTSUM) --max-attempts=$(MAX_TEST_ATTEMPTS) --junitfile=$(NEW_REPORT) -- \
+	go run ./cmd/tools/test-runner test --gotestsum-path=$(GOTESTSUM) --max-attempts=$(MAX_TEST_ATTEMPTS) $(TEST_RUNNER_TIMEOUT_ARG) --junitfile=$(NEW_REPORT) -- \
 		$(COMPILED_TEST_ARGS) -coverprofile=$(NEW_COVER_PROFILE) $(COVERPKG_FLAG) $(FUNCTIONAL_TEST_XDC_ROOT) \
 		-args -persistenceType=$(PERSISTENCE_TYPE) -persistenceDriver=$(PERSISTENCE_DRIVER)
 
 functional-test-ndc-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run functional test for NDC with coverage with $(PERSISTENCE_DRIVER) driver..."
-	go run ./cmd/tools/test-runner test --gotestsum-path=$(GOTESTSUM) --max-attempts=$(MAX_TEST_ATTEMPTS) --junitfile=$(NEW_REPORT) -- \
+	go run ./cmd/tools/test-runner test --gotestsum-path=$(GOTESTSUM) --max-attempts=$(MAX_TEST_ATTEMPTS) $(TEST_RUNNER_TIMEOUT_ARG) --junitfile=$(NEW_REPORT) -- \
 		$(COMPILED_TEST_ARGS) -coverprofile=$(NEW_COVER_PROFILE) $(COVERPKG_FLAG) $(FUNCTIONAL_TEST_NDC_ROOT) \
 		-args -persistenceType=$(PERSISTENCE_TYPE) -persistenceDriver=$(PERSISTENCE_DRIVER)
 

--- a/tools/testrunner/testrunner.go
+++ b/tools/testrunner/testrunner.go
@@ -35,7 +35,7 @@ const (
 
 	// goTestTimeoutGrace lets go test print its timeout panic before the
 	// testrunner kills gotestsum and writes partial results.
-	goTestTimeoutGrace = time.Minute
+	goTestTimeoutGrace = 30 * time.Second
 
 	// fullRerunThreshold is the number of test failures above which we do a full
 	// rerun instead of retrying only the failed tests.
@@ -360,7 +360,7 @@ func (r *runner) runTests(ctx context.Context, args []string) {
 			currentAttempt.junitReport.appendSyntheticFailure(
 				"testrunner.TotalTimeout",
 				failureTypeTimeout,
-				totalTimeoutFailureDetail(r.totalTimeout, stdout),
+				fmt.Sprintf("test-runner total timeout (%s) reached before all tests completed", r.totalTimeout),
 			)
 			break
 		}
@@ -453,16 +453,6 @@ func (r *runner) runTests(ctx context.Context, args []string) {
 		log.Printf("exiting with failure: total timeout (%s) reached", r.totalTimeout)
 		os.Exit(1)
 	}
-}
-
-func totalTimeoutFailureDetail(timeout time.Duration, stdout string) string {
-	var detail strings.Builder
-	fmt.Fprintf(&detail, "test-runner total timeout (%s) reached before all tests completed", timeout)
-	if strings.TrimSpace(stdout) != "" {
-		detail.WriteString("\n\nCaptured output before timeout:\n")
-		detail.WriteString(truncateAlertDetails(sanitizeXML(stdout)))
-	}
-	return detail.String()
 }
 
 func stripRunFromArgs(args []string) (argsNoRun []string) {

--- a/tools/testrunner/testrunner.go
+++ b/tools/testrunner/testrunner.go
@@ -33,6 +33,10 @@ const (
 	// kill such as a GitHub Actions timeout).
 	goTestTimeoutFlagEq = "-timeout="
 
+	// goTestTimeoutGrace lets go test print its timeout panic before the
+	// testrunner kills gotestsum and writes partial results.
+	goTestTimeoutGrace = time.Minute
+
 	// fullRerunThreshold is the number of test failures above which we do a full
 	// rerun instead of retrying only the failed tests.
 	fullRerunThreshold = 20
@@ -99,7 +103,7 @@ func (r *runner) sanitizeAndParseArgs(command string, args []string) ([]string, 
 	for _, arg := range args {
 		if strings.HasPrefix(arg, goTestTimeoutFlagEq) {
 			if d, err := time.ParseDuration(strings.TrimPrefix(arg, goTestTimeoutFlagEq)); err == nil {
-				r.totalTimeout = d
+				r.totalTimeout = d + goTestTimeoutGrace
 			}
 		}
 	}

--- a/tools/testrunner/testrunner.go
+++ b/tools/testrunner/testrunner.go
@@ -27,15 +27,7 @@ const (
 	summaryOutputDirFlag  = "--summary-output-dir="
 	crashReportNameFlag   = "--crashreportname="
 	gotestsumPathFlag     = "--gotestsum-path="
-
-	// goTestTimeoutFlag is the go test flag whose value is also used as the
-	// testrunner's total-run deadline (so results are flushed before an external
-	// kill such as a GitHub Actions timeout).
-	goTestTimeoutFlagEq = "-timeout="
-
-	// goTestTimeoutGrace lets go test print its timeout panic before the
-	// testrunner kills gotestsum and writes partial results.
-	goTestTimeoutGrace = 30 * time.Second
+	totalTimeoutFlag      = "--total-timeout="
 
 	// fullRerunThreshold is the number of test failures above which we do a full
 	// rerun instead of retrying only the failed tests.
@@ -85,7 +77,7 @@ type runner struct {
 	junitGlob        string
 	summaryOutputDir string
 	alerts           []alert
-	totalTimeout     time.Duration // derived from the -timeout go test flag
+	totalTimeout     time.Duration
 }
 
 func newRunner() *runner {
@@ -97,17 +89,6 @@ func newRunner() *runner {
 
 // nolint:revive,cognitive-complexity
 func (r *runner) sanitizeAndParseArgs(command string, args []string) ([]string, error) {
-	// Pre-pass: read the go test -timeout value and use it as the testrunner's
-	// total deadline so results are flushed before an external kill (e.g. GitHub
-	// Actions timeout). The flag is NOT consumed — it still passes through to gotestsum.
-	for _, arg := range args {
-		if strings.HasPrefix(arg, goTestTimeoutFlagEq) {
-			if d, err := time.ParseDuration(strings.TrimPrefix(arg, goTestTimeoutFlagEq)); err == nil {
-				r.totalTimeout = d + goTestTimeoutGrace
-			}
-		}
-	}
-
 	var sanitizedArgs []string
 	for _, arg := range args {
 		if strings.HasPrefix(arg, maxAttemptsFlag) {
@@ -120,6 +101,18 @@ func (r *runner) sanitizeAndParseArgs(command string, args []string) ([]string, 
 				return nil, fmt.Errorf("invalid argument %q: must be greater than zero", maxAttemptsFlag)
 			}
 			continue // this is a `testrunner` only arg and not passed through
+		}
+
+		if strings.HasPrefix(arg, totalTimeoutFlag) {
+			var err error
+			r.totalTimeout, err = time.ParseDuration(strings.TrimPrefix(arg, totalTimeoutFlag))
+			if err != nil {
+				return nil, fmt.Errorf("invalid argument %q: %w", totalTimeoutFlag, err)
+			}
+			if r.totalTimeout == 0 {
+				return nil, fmt.Errorf("invalid argument %q: must be greater than zero", totalTimeoutFlag)
+			}
+			continue
 		}
 
 		if strings.HasPrefix(arg, gotestsumPathFlag) {

--- a/tools/testrunner/testrunner.go
+++ b/tools/testrunner/testrunner.go
@@ -356,7 +356,7 @@ func (r *runner) runTests(ctx context.Context, args []string) {
 			currentAttempt.junitReport.appendSyntheticFailure(
 				"testrunner.TotalTimeout",
 				failureTypeTimeout,
-				fmt.Sprintf("test-runner total timeout (%s) reached before all tests completed", r.totalTimeout),
+				totalTimeoutFailureDetail(r.totalTimeout, stdout),
 			)
 			break
 		}
@@ -449,6 +449,16 @@ func (r *runner) runTests(ctx context.Context, args []string) {
 		log.Printf("exiting with failure: total timeout (%s) reached", r.totalTimeout)
 		os.Exit(1)
 	}
+}
+
+func totalTimeoutFailureDetail(timeout time.Duration, stdout string) string {
+	var detail strings.Builder
+	fmt.Fprintf(&detail, "test-runner total timeout (%s) reached before all tests completed", timeout)
+	if strings.TrimSpace(stdout) != "" {
+		detail.WriteString("\n\nCaptured output before timeout:\n")
+		detail.WriteString(truncateAlertDetails(sanitizeXML(stdout)))
+	}
+	return detail.String()
 }
 
 func stripRunFromArgs(args []string) (argsNoRun []string) {

--- a/tools/testrunner/testrunner_test.go
+++ b/tools/testrunner/testrunner_test.go
@@ -48,8 +48,9 @@ func TestRunnerSanitizeAndParseArgs(t *testing.T) {
 			"-coverprofile=test.cover.out",
 		})
 		require.NoError(t, err)
-		// The testrunner should derive its total deadline from the go test -timeout flag.
-		require.Equal(t, 35*time.Minute, r.totalTimeout)
+		// The testrunner should derive its total deadline from the go test -timeout flag,
+		// with grace for go test to print its timeout panic before gotestsum is killed.
+		require.Equal(t, 36*time.Minute, r.totalTimeout)
 		// The flag must still be present in the passthrough args so gotestsum/go test
 		// also honour it.
 		require.Contains(t, args, "-timeout=35m")

--- a/tools/testrunner/testrunner_test.go
+++ b/tools/testrunner/testrunner_test.go
@@ -38,22 +38,6 @@ func TestRunnerSanitizeAndParseArgs(t *testing.T) {
 		require.Equal(t, "test.cover.out", r.coverProfilePath)
 	})
 
-	t.Run("GoTestTimeoutDoesNotSetTotalTimeout", func(t *testing.T) {
-		r := newRunner()
-		args, err := r.sanitizeAndParseArgs(testCommand, []string{
-			"--gotestsum-path=/bin/gotestsum",
-			"--junitfile=test.xml",
-			"--",
-			"-timeout=35m",
-			"-coverprofile=test.cover.out",
-		})
-		require.NoError(t, err)
-		require.Zero(t, r.totalTimeout)
-		// The flag must still be present in the passthrough args so gotestsum/go test
-		// also honour it.
-		require.Contains(t, args, "-timeout=35m")
-	})
-
 	t.Run("TotalTimeout", func(t *testing.T) {
 		r := newRunner()
 		args, err := r.sanitizeAndParseArgs(testCommand, []string{

--- a/tools/testrunner/testrunner_test.go
+++ b/tools/testrunner/testrunner_test.go
@@ -38,7 +38,7 @@ func TestRunnerSanitizeAndParseArgs(t *testing.T) {
 		require.Equal(t, "test.cover.out", r.coverProfilePath)
 	})
 
-	t.Run("TotalTimeoutDerivedFromGoTestTimeout", func(t *testing.T) {
+	t.Run("GoTestTimeoutDoesNotSetTotalTimeout", func(t *testing.T) {
 		r := newRunner()
 		args, err := r.sanitizeAndParseArgs(testCommand, []string{
 			"--gotestsum-path=/bin/gotestsum",
@@ -48,11 +48,25 @@ func TestRunnerSanitizeAndParseArgs(t *testing.T) {
 			"-coverprofile=test.cover.out",
 		})
 		require.NoError(t, err)
-		// The testrunner should derive its total deadline from the go test -timeout flag,
-		// with grace for go test to print its timeout panic before gotestsum is killed.
-		require.Equal(t, 35*time.Minute+goTestTimeoutGrace, r.totalTimeout)
+		require.Zero(t, r.totalTimeout)
 		// The flag must still be present in the passthrough args so gotestsum/go test
 		// also honour it.
+		require.Contains(t, args, "-timeout=35m")
+	})
+
+	t.Run("TotalTimeout", func(t *testing.T) {
+		r := newRunner()
+		args, err := r.sanitizeAndParseArgs(testCommand, []string{
+			"--gotestsum-path=/bin/gotestsum",
+			"--junitfile=test.xml",
+			"--total-timeout=39m",
+			"--",
+			"-timeout=35m",
+			"-coverprofile=test.cover.out",
+		})
+		require.NoError(t, err)
+		require.Equal(t, 39*time.Minute, r.totalTimeout)
+		require.NotContains(t, args, "--total-timeout=39m")
 		require.Contains(t, args, "-timeout=35m")
 	})
 
@@ -66,6 +80,18 @@ func TestRunnerSanitizeAndParseArgs(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Zero(t, r.totalTimeout)
+	})
+
+	t.Run("TotalTimeoutInvalid", func(t *testing.T) {
+		r := newRunner()
+		_, err := r.sanitizeAndParseArgs(testCommand, []string{
+			"--gotestsum-path=/bin/gotestsum",
+			"--junitfile=test.xml",
+			"--total-timeout=invalid",
+			"--",
+			"-coverprofile=test.cover.out",
+		})
+		require.ErrorContains(t, err, `invalid argument "--total-timeout="`)
 	})
 
 	t.Run("GoTestSumPathMissing", func(t *testing.T) {

--- a/tools/testrunner/testrunner_test.go
+++ b/tools/testrunner/testrunner_test.go
@@ -205,6 +205,20 @@ func TestWriteCurrentReport(t *testing.T) {
 	require.Len(t, result2.Suites, 2)
 }
 
+func TestTotalTimeoutFailureDetail(t *testing.T) {
+	detail := totalTimeoutFailureDetail(35*time.Minute, "=== RUN   TestExample\npartial log\u0001\n")
+	require.Contains(t, detail, "test-runner total timeout (35m0s) reached before all tests completed")
+	require.Contains(t, detail, "Captured output before timeout:")
+	require.Contains(t, detail, "=== RUN   TestExample")
+	require.Contains(t, detail, "partial log")
+	require.NotContains(t, detail, "\u0001")
+}
+
+func TestTotalTimeoutFailureDetailWithoutOutput(t *testing.T) {
+	detail := totalTimeoutFailureDetail(35*time.Minute, "")
+	require.Equal(t, "test-runner total timeout (35m0s) reached before all tests completed", detail)
+}
+
 func TestRunnerReportCrash(t *testing.T) {
 	dir := t.TempDir()
 	out := filepath.Join(dir, "junit-report.xml")

--- a/tools/testrunner/testrunner_test.go
+++ b/tools/testrunner/testrunner_test.go
@@ -50,7 +50,7 @@ func TestRunnerSanitizeAndParseArgs(t *testing.T) {
 		require.NoError(t, err)
 		// The testrunner should derive its total deadline from the go test -timeout flag,
 		// with grace for go test to print its timeout panic before gotestsum is killed.
-		require.Equal(t, 36*time.Minute, r.totalTimeout)
+		require.Equal(t, 35*time.Minute+goTestTimeoutGrace, r.totalTimeout)
 		// The flag must still be present in the passthrough args so gotestsum/go test
 		// also honour it.
 		require.Contains(t, args, "-timeout=35m")
@@ -204,20 +204,6 @@ func TestWriteCurrentReport(t *testing.T) {
 	require.NoError(t, result2.read())
 	require.Equal(t, 4, result2.Failures) // 2 from attempt 1 + 2 from attempt 2
 	require.Len(t, result2.Suites, 2)
-}
-
-func TestTotalTimeoutFailureDetail(t *testing.T) {
-	detail := totalTimeoutFailureDetail(35*time.Minute, "=== RUN   TestExample\npartial log\u0001\n")
-	require.Contains(t, detail, "test-runner total timeout (35m0s) reached before all tests completed")
-	require.Contains(t, detail, "Captured output before timeout:")
-	require.Contains(t, detail, "=== RUN   TestExample")
-	require.Contains(t, detail, "partial log")
-	require.NotContains(t, detail, "\u0001")
-}
-
-func TestTotalTimeoutFailureDetailWithoutOutput(t *testing.T) {
-	detail := totalTimeoutFailureDetail(35*time.Minute, "")
-	require.Equal(t, "test-runner total timeout (35m0s) reached before all tests completed", detail)
 }
 
 func TestRunnerReportCrash(t *testing.T) {


### PR DESCRIPTION
## What changed?

Old behavior was
```
 10m    GitHub step timeout
  5m    --total-timeout (derived from -timeout)
  5m    go test -timeout
```

New behavior is 

```
 10m  GitHub step timeout
  9m  TEST_RUNNER_TIMEOUT / --total-timeout
  5m  go test -timeout
```

ie attach the testrunner timeout to the ceiling not the floor.

Example now with logs: https://github.com/temporalio/temporal/actions/runs/27570791993/job/81507067577?pr=10713#step:9:46

## Why?

(1) We don't see any logs when the testrunner out.
(2) testrunner has no time anymore to do a retry when `go test` times out.
