### PR TITLE
Add debug log for ResetWorkflowTask on standby cluster

### DIFF
--- a/service/history/transfer_queue_standby_task_executor.go
+++ b/service/history/transfer_queue_standby_task_executor.go
@@ -16,6 +16,7 @@ import (
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/visibility/manager"
@@ -100,7 +101,12 @@ func (t *transferQueueStandbyTaskExecutor) Execute(
 		err = t.processStartChildExecution(ctx, task)
 	case *tasks.ResetWorkflowTask:
 		// no reset needed for standby
-		// TODO: add error logs
+		t.logger.Debug("Skipping ResetWorkflowTask on standby cluster",
+			tag.WorkflowNamespaceID(task.NamespaceID),
+			tag.WorkflowID(task.WorkflowID),
+			tag.WorkflowRunID(task.RunID),
+			tag.TaskID(task.TaskID),
+		)
 		err = nil
 	case *tasks.CloseExecutionTask:
 		err = t.processCloseExecution(ctx, task)


### PR DESCRIPTION
ResetWorkflowTask is a no-op on standby clusters since reset is only handled on the active cluster. Previously this had no visibility. Added a debug log to make this explicit and aid troubleshooting if this case fires unexpectedly.

## What changed?
Added a debug log statement for ResetWorkflowTask handling on 
standby clusters, including namespace ID, workflow ID, run ID, 
and task ID.

## Why?
ResetWorkflowTask is intentionally a no-op on standby clusters 
since reset is only performed on the active cluster. However, 
this had no logging, leaving a TODO comment ("add error logs") 
with no visibility into this code path. Added a debug log to 
make this explicit, aiding troubleshooting if this case 
behaves unexpectedly.

## How did you test it?
✅ built
✅ covered by existing tests

## Potential risks
None — additive debug logging only, no behavior change.
