### PR TITLE
Clarify why Version field is unused in WorkflowBackoffTimerTask

### DIFF
--- a/service/history/tasks/workflow_delay_timer.go
+++ b/service/history/tasks/workflow_delay_timer.go
@@ -15,8 +15,12 @@ type (
 		definition.WorkflowKey
 		VisibilityTimestamp time.Time
 		TaskID              int64
-		// TODO: this is not used right now, but we should check it
-		// against workflow start version in timer task executor
+		// Version is included for task versioning infrastructure but is not
+		// explicitly checked against workflow start version in the timer task
+		// executors. For standby execution, this is safe because this task only
+		// fires when mutable state's next event ID is 2 (workflow started event
+		// only), meaning the start version is immutable and guaranteed to match.
+		// See executeWorkflowBackoffTimerTask in timer_queue_standby_task_executor.go.
 		Version             int64
 		WorkflowBackoffType enumsspb.WorkflowBackoffType
 	}


### PR DESCRIPTION
The TODO suggested Version should be checked against workflow start version in the timer task executor, but this check is unnecessary: this task only fires when mutable state's next event ID is 2 (workflow started event only), making the start version immutable and guaranteed to match. This reasoning was already documented in executeWorkflowBackoffTimerTask in timer_queue_standby_task_executor.go but not reflected here.

Updated the comment to reference that explanation and removed the open-ended TODO.

## What changed?
Replaced the open-ended TODO comment on the `Version` field in 
`WorkflowBackoffTimerTask` with an explanation of why version 
checking is unnecessary, referencing the existing reasoning in 
`executeWorkflowBackoffTimerTask` (timer_queue_standby_task_executor.go).

## Why?
The TODO suggested `Version` should be checked against workflow 
start version in the timer task executor, implying this was an 
open issue. However, `executeWorkflowBackoffTimerTask` already 
documents why this check is unnecessary: this task only fires 
when mutable state's next event ID is 2 (workflow started event 
only), making the start version immutable and guaranteed to 
match.

This PR updates the comment to reflect that this was already 
analyzed and resolved, removing the stale TODO and pointing to 
the relevant explanation for future readers.

## How did you test it?
✅ built
✅ covered by existing tests

## Potential risks
None — documentation/comment change only, no behavior change.