### PR TITLE
Make defensive copies of Nexus request headers

### DIFF
--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http/httptrace"
 	"strings"
 	"sync/atomic"
@@ -392,7 +393,7 @@ func (e taskExecutor) loadOperationArgs(
 		}
 		attrs := event.GetNexusOperationScheduledEventAttributes()
 		args.payload = attrs.GetInput()
-		args.header = attrs.GetNexusHeader()
+		args.header = maps.Clone(attrs.GetNexusHeader())
 		args.nexusLink = commonnexus.ConvertLinkWorkflowEventToNexusLink(&commonpb.Link_WorkflowEvent{
 			Namespace:  ns.Name().String(),
 			WorkflowId: ref.WorkflowKey.WorkflowID,
@@ -759,7 +760,7 @@ func (e taskExecutor) loadArgsForCancelation(ctx context.Context, env hsm.Enviro
 			return err
 		}
 		if attrs := event.GetNexusOperationScheduledEventAttributes(); attrs != nil {
-			args.headers = attrs.GetNexusHeader()
+			args.headers = maps.Clone(attrs.GetNexusHeader())
 			args.payload = attrs.GetInput()
 		}
 		return nil


### PR DESCRIPTION
## What changed?

Makes a shallow of the `map[string]string` returned from `NexusOperationScheduledEventAttributes::GetNexusHeaders()` method.

We call this method in two places:
- `func (e taskExecutor) loadOperationArgs(...) (startArgs, error)`
- `func (e taskExecutor) loadArgsForCancelation(...) (cancelArgs, error)`

## Why?

Within the `taskExecutor`, we mutate the `{ startArgs, cancelArgs }.header` field. e.g. to add a timeout header or other things in accordance to [the spec](https://github.com/nexus-rpc/api/blob/494165f890be9418c67dfce9c138694fe5c27855/SPEC.md#request-headers).

The problem is that there is no guarantee that the `taskExecutor` actually "owns" that map, and is safe to mutate it arbitrarily.

@djsweet has been looking into some runtime panics, it it _could_ be the case that the headers map were actually created by the workflow cache. And the Nexus machinary mutating it elsewhere, outside of a lock, could potentially be the source of some of those problems.

Simply making a defensive copy so the `taskExecutor`'s `startArgs` and `cancelArgs` manage their own header maps seems like a reasonable safe thing to do.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

Note that I can think of. Since there isn't any reasonable way the `Node::LoadHistoryEvent` could somehow take a dependency on the Nexus operation mutating the headers of the `HistoryEvent` it returned?
