### PR TITLE
feat(sdk): wire auth.TokenProvider into SdkClientFactoryProvider

### DIFF
--- a/common/resource/fx.go
+++ b/common/resource/fx.go
@@ -372,24 +372,30 @@ func ArchiverProviderProvider(
 	)
 }
 
-func SdkClientFactoryProvider(
-	cfg *config.Config,
-	tlsConfigProvider encryption.TLSConfigProvider,
-	metricsHandler metrics.Handler,
-	logger log.SnTaggedLogger,
-	resolver *membership.GRPCResolver,
-	dc *dynamicconfig.Collection,
-) (sdk.ClientFactory, error) {
-	frontendURL, _, _, frontendTLSConfig, err := getFrontendConnectionDetails(cfg, tlsConfigProvider, resolver)
+type sdkClientFactoryParams struct {
+	fx.In
+
+	Cfg               *config.Config
+	TLSConfigProvider encryption.TLSConfigProvider
+	MetricsHandler    metrics.Handler
+	Logger            log.SnTaggedLogger
+	Resolver          *membership.GRPCResolver
+	DC                *dynamicconfig.Collection
+	TokenProvider     auth.TokenProvider `optional:"true"`
+}
+
+func SdkClientFactoryProvider(p sdkClientFactoryParams) (sdk.ClientFactory, error) {
+	frontendURL, _, _, frontendTLSConfig, err := getFrontendConnectionDetails(p.Cfg, p.TLSConfigProvider, p.Resolver)
 	if err != nil {
 		return nil, err
 	}
 	return sdk.NewClientFactory(
 		frontendURL,
 		frontendTLSConfig,
-		metricsHandler,
-		logger,
-		dynamicconfig.WorkerStickyCacheSize.Get(dc),
+		p.MetricsHandler,
+		p.Logger,
+		dynamicconfig.WorkerStickyCacheSize.Get(p.DC),
+		p.TokenProvider,
 	), nil
 }
 

--- a/common/sdk/factory.go
+++ b/common/sdk/factory.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"sync"
 
 	"go.temporal.io/api/serviceerror"
@@ -20,6 +21,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/rpc/auth"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -33,15 +35,27 @@ type (
 		NewWorker(client sdkclient.Client, taskQueue string, options sdkworker.Options) sdkworker.Worker
 	}
 
+	// headersProvider mirrors go.temporal.io/sdk/internal.HeadersProvider. It is
+	// redefined here because sdk/internal is not importable outside the SDK module.
+	headersProviderIface interface {
+		GetHeaders(ctx context.Context) (map[string]string, error)
+	}
+
 	clientFactory struct {
 		hostPort        string
 		tlsConfig       *tls.Config
 		metricsHandler  *MetricsHandler
 		logger          log.Logger
 		sdklogger       sdklog.Logger
+		headersProvider headersProviderIface
 		systemSdkClient sdkclient.Client
 		stickyCacheSize dynamicconfig.IntPropertyFn
 		once            sync.Once
+	}
+
+	tokenProviderHeadersAdapter struct {
+		tp       auth.TokenProvider
+		hostPort string
 	}
 )
 
@@ -55,15 +69,32 @@ func NewClientFactory(
 	metricsHandler metrics.Handler,
 	logger log.Logger,
 	stickyCacheSize dynamicconfig.IntPropertyFn,
+	tp auth.TokenProvider,
 ) *clientFactory {
+	var hp headersProviderIface
+	if tp != nil {
+		hp = &tokenProviderHeadersAdapter{tp: tp, hostPort: hostPort}
+	}
 	return &clientFactory{
 		hostPort:        hostPort,
 		tlsConfig:       tlsConfig,
 		metricsHandler:  NewMetricsHandler(metricsHandler),
 		logger:          logger,
 		sdklogger:       log.NewSdkLogger(logger),
+		headersProvider: hp,
 		stickyCacheSize: stickyCacheSize,
 	}
+}
+
+func (a *tokenProviderHeadersAdapter) GetHeaders(ctx context.Context) (map[string]string, error) {
+	token, err := a.tp.GetToken(ctx, a.hostPort)
+	if err != nil {
+		return nil, fmt.Errorf("sdk auth: %w", err)
+	}
+	if token == "" {
+		return nil, nil
+	}
+	return map[string]string{"authorization": "Bearer " + token}, nil
 }
 
 func (f *clientFactory) options(options sdkclient.Options) sdkclient.Options {
@@ -75,6 +106,9 @@ func (f *clientFactory) options(options sdkclient.Options) sdkclient.Options {
 		DialOptions: []grpc.DialOption{
 			grpc.WithUnaryInterceptor(sdkClientNameHeadersInjectorInterceptor()),
 		},
+	}
+	if f.headersProvider != nil {
+		options.HeadersProvider = f.headersProvider // satisfies internal.HeadersProvider by structural typing
 	}
 	return options
 }

--- a/common/sdk/factory_test.go
+++ b/common/sdk/factory_test.go
@@ -1,0 +1,81 @@
+package sdk
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	sdkclient "go.temporal.io/sdk/client"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/rpc/auth"
+	"go.temporal.io/server/common/rpc/auth/authtest"
+)
+
+func newTestFactory(tp auth.TokenProvider) *clientFactory {
+	return NewClientFactory(
+		"localhost:7233",
+		nil,
+		metrics.NoopMetricsHandler,
+		log.NewNoopLogger(),
+		dynamicconfig.GetIntPropertyFn(0),
+		tp,
+	)
+}
+
+func TestNewClientFactory_withTokenProvider_setsHeadersProvider(t *testing.T) {
+	t.Parallel()
+	f := newTestFactory(authtest.StaticTokenProvider("tok"))
+	require.NotNil(t, f.headersProvider)
+}
+
+func TestNewClientFactory_nilTokenProvider_leavesHeadersProviderNil(t *testing.T) {
+	t.Parallel()
+	f := newTestFactory(nil)
+	require.Nil(t, f.headersProvider)
+}
+
+func TestOptions_withHeadersProvider_setsOnOptions(t *testing.T) {
+	t.Parallel()
+	f := newTestFactory(authtest.StaticTokenProvider("tok"))
+	opts := f.options(sdkclient.Options{Namespace: "test"})
+	require.NotNil(t, opts.HeadersProvider)
+}
+
+func TestOptions_withoutHeadersProvider_leavesHeadersProviderNil(t *testing.T) {
+	t.Parallel()
+	f := newTestFactory(nil)
+	opts := f.options(sdkclient.Options{Namespace: "test"})
+	require.Nil(t, opts.HeadersProvider)
+}
+
+func TestTokenProviderHeadersAdapter_returnsBearer(t *testing.T) {
+	t.Parallel()
+	a := &tokenProviderHeadersAdapter{tp: authtest.StaticTokenProvider("mytoken"), hostPort: "h:1"}
+	hdrs, err := a.GetHeaders(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "Bearer mytoken", hdrs["authorization"])
+}
+
+func TestTokenProviderHeadersAdapter_emptyToken_returnsNilMap(t *testing.T) {
+	t.Parallel()
+	a := &tokenProviderHeadersAdapter{tp: authtest.StaticTokenProvider(""), hostPort: "h:1"}
+	hdrs, err := a.GetHeaders(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, hdrs)
+}
+
+func TestTokenProviderHeadersAdapter_providerError_wrapsErr(t *testing.T) {
+	t.Parallel()
+	a := &tokenProviderHeadersAdapter{tp: errorTokenProvider{}, hostPort: "h:1"}
+	_, err := a.GetHeaders(context.Background())
+	require.ErrorContains(t, err, "sdk auth:")
+}
+
+type errorTokenProvider struct{}
+
+func (errorTokenProvider) GetToken(context.Context, string) (string, error) {
+	return "", errors.New("idp unavailable")
+}

--- a/tests/testcore/onebox.go
+++ b/tests/testcore/onebox.go
@@ -932,6 +932,7 @@ func sdkClientFactoryProvider(
 		metricsHandler,
 		logger,
 		dynamicconfig.WorkerStickyCacheSize.Get(dc),
+		nil,
 	)
 }
 


### PR DESCRIPTION
## What changed?
- Adds an optional fx.In TokenProvider field to SdkClientFactoryProvider (optional:"true" so clusters not using WithTokenProvider are unaffected).
- Threads the provider into sdk.NewClientFactory as a new parameter.
- Implements tokenProviderHeadersAdapter, which bridges auth.TokenProvider to the SDK's HeadersProvider interface and attaches a bearer token to every outbound SDK RPC.
- Because both GetSystemClient() and NewClient() route through options(), a single change to options() covers both code paths.

## Why?
The worker service's per-namespace workers and history scanner start workflows via the SDK client. On clusters with a JWT-based frontend authorizer, those outbound RPCs are rejected because the SDK client dials without auth headers.

PR #10165 bridged TokenProvider through GetCommonServiceOptions into the child app's fx graph and consumed it in RPCFactoryProvider for cross-cluster gRPC.

Related [issue](https://github.com/temporalio/temporal/issues/10005)

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
_Any change is risky. Identify all risks you are aware of. If none, remove this section._
