### PR TITLE
TS: add update flag for time skipping

### DIFF
--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -684,17 +684,17 @@ func (s *Starter) handleUseExistingWorkflowOnConflictOptions(
 				if !mutableState.IsWorkflowExecutionRunning() {
 					return nil, consts.ErrWorkflowCompleted
 				}
-
 				_, err := mutableState.AddWorkflowExecutionOptionsUpdatedEvent(
 					nil,
 					false,
 					requestID,
 					completionCallbacks,
 					links,
-					"",  // identity
-					nil, // priority
-					nil, // timeSkippingConfig
-					nil, // workflowUpdateOptions
+					"",    // identity
+					nil,   // priority
+					nil,   // timeSkippingConfig
+					false, // timeSkippingConfigUpdated
+					nil,   // workflowUpdateOptions
 				)
 				return api.UpdateWorkflowWithoutWorkflowTask, err
 			},

--- a/service/history/api/updateworkflowoptions/api.go
+++ b/service/history/api/updateworkflowoptions/api.go
@@ -2,6 +2,7 @@ package updateworkflowoptions
 
 import (
 	"context"
+	"strings"
 
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -126,6 +127,16 @@ func Invoke(
 	return ret, nil
 }
 
+// recomputedOptions is used to track options that need to be recomputed on every update,
+// whose changes cannot be detected simply by options equality check.
+type recomputedOptions struct {
+	timeSkippingConfigHasChanged bool
+}
+
+func (u recomputedOptions) hasChanges() bool {
+	return u.timeSkippingConfigHasChanged
+}
+
 // MergeAndApply merges the requested options mentioned in the field mask with the current options in the mutable state
 // and applies the changes to the mutable state. Returns the merged options and a boolean indicating if there were any changes.
 func MergeAndApply(
@@ -135,7 +146,7 @@ func MergeAndApply(
 	identity string,
 ) (*workflowpb.WorkflowExecutionOptions, bool, error) {
 	// Merge the requested options mentioned in the field mask with the current options in the mutable state
-	mergedOpts, err := mergeWorkflowExecutionOptions(
+	mergedOpts, recomputedEffects, err := mergeWorkflowExecutionOptions(
 		getOptionsFromMutableState(ms),
 		opts,
 		updateMask,
@@ -144,17 +155,16 @@ func MergeAndApply(
 		return nil, false, serviceerror.NewInvalidArgumentf("error applying update_options: %v", err)
 	}
 
-	// If there is no mutable state change at all, return with no new history event and Noop=true
-	hasChanges := !proto.Equal(mergedOpts, getOptionsFromMutableState(ms))
+	hasChanges := !proto.Equal(mergedOpts, getOptionsFromMutableState(ms)) || recomputedEffects.hasChanges()
 	if !hasChanges {
 		return mergedOpts, false, nil
 	}
 
-	unsetOverride := false
-	if mergedOpts.GetVersioningOverride() == nil {
-		unsetOverride = true
-	}
-	_, err = ms.AddWorkflowExecutionOptionsUpdatedEvent(mergedOpts.GetVersioningOverride(), unsetOverride, "", nil, nil, identity, mergedOpts.GetPriority(), mergedOpts.GetTimeSkippingConfig(), nil)
+	unsetOverride := mergedOpts.GetVersioningOverride() == nil
+	_, err = ms.AddWorkflowExecutionOptionsUpdatedEvent(
+		mergedOpts.GetVersioningOverride(), unsetOverride, "", nil, nil, identity, mergedOpts.GetPriority(),
+		mergedOpts.GetTimeSkippingConfig(),
+		recomputedEffects.timeSkippingConfigHasChanged, nil)
 	if err != nil {
 		return nil, hasChanges, err
 	}
@@ -183,30 +193,32 @@ func getOptionsFromMutableState(ms historyi.MutableState) *workflowpb.WorkflowEx
 	return opts
 }
 
-// mergeWorkflowExecutionOptions copies the given paths in `src` struct to `dst` struct
+// mergeWorkflowExecutionOptions copies the given paths in `src` struct to `dst` struct and returns
+// the merged opts and recomputed opts
 func mergeWorkflowExecutionOptions(
 	mergeInto, mergeFrom *workflowpb.WorkflowExecutionOptions,
 	updateMask *fieldmaskpb.FieldMask,
-) (*workflowpb.WorkflowExecutionOptions, error) {
+) (*workflowpb.WorkflowExecutionOptions, recomputedOptions, error) {
 	_, err := fieldmaskpb.New(mergeInto, updateMask.GetPaths()...)
 	if err != nil { // errors if any paths are not valid for the struct we are merging into
-		return nil, err
+		return nil, recomputedOptions{}, err
 	}
 	updateFields := util.ParseFieldMask(updateMask)
+
 	if _, ok := updateFields["versioningOverride"]; ok {
 		mergeInto.VersioningOverride = mergeFrom.GetVersioningOverride()
 	}
 
 	if _, ok := updateFields["versioningOverride.deployment"]; ok {
 		if _, ok := updateFields["versioningOverride.behavior"]; !ok {
-			return nil, serviceerror.NewInvalidArgument("versioning_override fields must be updated together")
+			return nil, recomputedOptions{}, serviceerror.NewInvalidArgument("versioning_override fields must be updated together")
 		}
 		mergeInto.VersioningOverride = mergeFrom.GetVersioningOverride()
 	}
 
 	if _, ok := updateFields["versioningOverride.behavior"]; ok {
 		if _, ok := updateFields["versioningOverride.deployment"]; !ok {
-			return nil, serviceerror.NewInvalidArgument("versioning_override fields must be updated together")
+			return nil, recomputedOptions{}, serviceerror.NewInvalidArgument("versioning_override fields must be updated together")
 		}
 		mergeInto.VersioningOverride = mergeFrom.GetVersioningOverride()
 	}
@@ -239,26 +251,31 @@ func mergeWorkflowExecutionOptions(
 	}
 
 	// ==== Time Skipping Config
-	// nil means "no change" — only update if the caller provided an explicit value.
+	// - has side effects when applied so equality check is not enough;
+	// - We only support validating and updating the TSC as a whole;
+	var originalTSC *commonpb.TimeSkippingConfig
+	if tsc := mergeInto.GetTimeSkippingConfig(); tsc != nil {
+		if cloned, ok := proto.Clone(tsc).(*commonpb.TimeSkippingConfig); ok {
+			originalTSC = cloned
+		}
+	}
+
+	var fastForwardSet bool
 	if _, ok := updateFields["timeSkippingConfig"]; ok {
-		if mergeFrom.GetTimeSkippingConfig() != nil {
-			mergeInto.TimeSkippingConfig = mergeFrom.GetTimeSkippingConfig()
+		mergeInto.TimeSkippingConfig = mergeFrom.GetTimeSkippingConfig()
+		if mergeFrom.GetTimeSkippingConfig().GetFastForward() != nil {
+			fastForwardSet = true
 		}
 	}
 
-	if _, ok := updateFields["timeSkippingConfig.enabled"]; ok {
-		if mergeInto.TimeSkippingConfig == nil {
-			mergeInto.TimeSkippingConfig = &commonpb.TimeSkippingConfig{}
+	for key := range updateFields {
+		if strings.HasPrefix(key, "timeSkippingConfig.") {
+			return nil, recomputedOptions{}, serviceerror.NewInvalidArgument(
+				"time_skipping_config doesn't support partial update")
 		}
-		mergeInto.TimeSkippingConfig.Enabled = mergeFrom.GetTimeSkippingConfig().GetEnabled()
 	}
 
-	if _, ok := updateFields["timeSkippingConfig.fastForward"]; ok {
-		if mergeInto.TimeSkippingConfig == nil {
-			mergeInto.TimeSkippingConfig = &commonpb.TimeSkippingConfig{}
-		}
-		mergeInto.TimeSkippingConfig.FastForward = mergeFrom.GetTimeSkippingConfig().GetFastForward()
-	}
-
-	return mergeInto, nil
+	var sideEffects recomputedOptions
+	sideEffects.timeSkippingConfigHasChanged = fastForwardSet || (!proto.Equal(mergeInto.GetTimeSkippingConfig(), originalTSC))
+	return mergeInto, sideEffects, nil
 }

--- a/service/history/api/updateworkflowoptions/api.go
+++ b/service/history/api/updateworkflowoptions/api.go
@@ -127,13 +127,13 @@ func Invoke(
 	return ret, nil
 }
 
-// recomputedOptions is used to track options that need to be recomputed on every update,
+// OptionsToReapply is used to track options that need to be reapplied on every update,
 // whose changes cannot be detected simply by options equality check.
-type recomputedOptions struct {
+type OptionsToReapply struct {
 	timeSkippingConfigHasChanged bool
 }
 
-func (u recomputedOptions) hasChanges() bool {
+func (u OptionsToReapply) hasChanges() bool {
 	return u.timeSkippingConfigHasChanged
 }
 
@@ -146,7 +146,7 @@ func MergeAndApply(
 	identity string,
 ) (*workflowpb.WorkflowExecutionOptions, bool, error) {
 	// Merge the requested options mentioned in the field mask with the current options in the mutable state
-	mergedOpts, recomputedEffects, err := mergeWorkflowExecutionOptions(
+	mergedOpts, optionsToReapply, err := mergeWorkflowExecutionOptions(
 		getOptionsFromMutableState(ms),
 		opts,
 		updateMask,
@@ -155,7 +155,7 @@ func MergeAndApply(
 		return nil, false, serviceerror.NewInvalidArgumentf("error applying update_options: %v", err)
 	}
 
-	hasChanges := !proto.Equal(mergedOpts, getOptionsFromMutableState(ms)) || recomputedEffects.hasChanges()
+	hasChanges := !proto.Equal(mergedOpts, getOptionsFromMutableState(ms)) || optionsToReapply.hasChanges()
 	if !hasChanges {
 		return mergedOpts, false, nil
 	}
@@ -164,7 +164,7 @@ func MergeAndApply(
 	_, err = ms.AddWorkflowExecutionOptionsUpdatedEvent(
 		mergedOpts.GetVersioningOverride(), unsetOverride, "", nil, nil, identity, mergedOpts.GetPriority(),
 		mergedOpts.GetTimeSkippingConfig(),
-		recomputedEffects.timeSkippingConfigHasChanged, nil)
+		optionsToReapply.timeSkippingConfigHasChanged, nil)
 	if err != nil {
 		return nil, hasChanges, err
 	}
@@ -194,14 +194,14 @@ func getOptionsFromMutableState(ms historyi.MutableState) *workflowpb.WorkflowEx
 }
 
 // mergeWorkflowExecutionOptions copies the given paths in `src` struct to `dst` struct and returns
-// the merged opts and recomputed opts
+// the merged opts and the options to reapply
 func mergeWorkflowExecutionOptions(
 	mergeInto, mergeFrom *workflowpb.WorkflowExecutionOptions,
 	updateMask *fieldmaskpb.FieldMask,
-) (*workflowpb.WorkflowExecutionOptions, recomputedOptions, error) {
+) (*workflowpb.WorkflowExecutionOptions, OptionsToReapply, error) {
 	_, err := fieldmaskpb.New(mergeInto, updateMask.GetPaths()...)
 	if err != nil { // errors if any paths are not valid for the struct we are merging into
-		return nil, recomputedOptions{}, err
+		return nil, OptionsToReapply{}, err
 	}
 	updateFields := util.ParseFieldMask(updateMask)
 
@@ -211,14 +211,14 @@ func mergeWorkflowExecutionOptions(
 
 	if _, ok := updateFields["versioningOverride.deployment"]; ok {
 		if _, ok := updateFields["versioningOverride.behavior"]; !ok {
-			return nil, recomputedOptions{}, serviceerror.NewInvalidArgument("versioning_override fields must be updated together")
+			return nil, OptionsToReapply{}, serviceerror.NewInvalidArgument("versioning_override fields must be updated together")
 		}
 		mergeInto.VersioningOverride = mergeFrom.GetVersioningOverride()
 	}
 
 	if _, ok := updateFields["versioningOverride.behavior"]; ok {
 		if _, ok := updateFields["versioningOverride.deployment"]; !ok {
-			return nil, recomputedOptions{}, serviceerror.NewInvalidArgument("versioning_override fields must be updated together")
+			return nil, OptionsToReapply{}, serviceerror.NewInvalidArgument("versioning_override fields must be updated together")
 		}
 		mergeInto.VersioningOverride = mergeFrom.GetVersioningOverride()
 	}
@@ -251,7 +251,7 @@ func mergeWorkflowExecutionOptions(
 	}
 
 	// ==== Time Skipping Config
-	// - has side effects when applied so equality check is not enough;
+	// - fast forward need reapplication so equality check is not enough;
 	// - We only support validating and updating the TSC as a whole;
 	var originalTSC *commonpb.TimeSkippingConfig
 	if tsc := mergeInto.GetTimeSkippingConfig(); tsc != nil {
@@ -270,12 +270,12 @@ func mergeWorkflowExecutionOptions(
 
 	for key := range updateFields {
 		if strings.HasPrefix(key, "timeSkippingConfig.") {
-			return nil, recomputedOptions{}, serviceerror.NewInvalidArgument(
+			return nil, OptionsToReapply{}, serviceerror.NewInvalidArgument(
 				"time_skipping_config doesn't support partial update")
 		}
 	}
 
-	var sideEffects recomputedOptions
-	sideEffects.timeSkippingConfigHasChanged = fastForwardSet || (!proto.Equal(mergeInto.GetTimeSkippingConfig(), originalTSC))
-	return mergeInto, sideEffects, nil
+	var optionsToReapply OptionsToReapply
+	optionsToReapply.timeSkippingConfigHasChanged = fastForwardSet || (!proto.Equal(mergeInto.GetTimeSkippingConfig(), originalTSC))
+	return mergeInto, optionsToReapply, nil
 }

--- a/service/history/api/updateworkflowoptions/api_test.go
+++ b/service/history/api/updateworkflowoptions/api_test.go
@@ -2,6 +2,7 @@ package updateworkflowoptions
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -61,6 +62,25 @@ func noopReactivationSignaler(_ context.Context, _ *namespace.Namespace, _, _ st
 	return nil
 }
 
+// tscProtoEq is a gomock.Matcher for *commonpb.TimeSkippingConfig that uses proto.Equal
+// instead of reflect.DeepEqual, which fails on proto messages with differing internal state.
+type tscProtoEq struct{ expected *commonpb.TimeSkippingConfig }
+
+func (m tscProtoEq) Matches(x any) bool {
+	got, _ := x.(*commonpb.TimeSkippingConfig)
+	if m.expected == nil && got == nil {
+		return true
+	}
+	if m.expected == nil || got == nil {
+		return false
+	}
+	return proto.Equal(m.expected, got)
+}
+
+func (m tscProtoEq) String() string {
+	return fmt.Sprintf("proto.Equal(%v)", m.expected)
+}
+
 var (
 	emptyOptions            = &workflowpb.WorkflowExecutionOptions{}
 	unpinnedOverrideOptions = &workflowpb.WorkflowExecutionOptions{
@@ -87,48 +107,58 @@ func TestMergeOptions_VersionOverrideMask(t *testing.T) {
 	input := emptyOptions
 
 	// Merge unpinned into empty options
-	merged, err := mergeWorkflowExecutionOptions(input, unpinnedOverrideOptions, updateMask)
+	merged, recomputedEffects, err := mergeWorkflowExecutionOptions(input, unpinnedOverrideOptions, updateMask)
 	if err != nil {
 		t.Error(err)
 	}
 	require.EqualExportedValues(t, unpinnedOverrideOptions, merged)
+	require.False(t, recomputedEffects.hasChanges())
 
 	// Merge pinned_A into unpinned options
-	merged, err = mergeWorkflowExecutionOptions(input, pinnedOverrideOptionsA, updateMask)
+	merged, recomputedEffects, err = mergeWorkflowExecutionOptions(input, pinnedOverrideOptionsA, updateMask)
 	if err != nil {
 		t.Error(err)
 	}
 	require.EqualExportedValues(t, pinnedOverrideOptionsA, merged)
+	require.False(t, recomputedEffects.hasChanges())
 
 	// Merge pinned_B into pinned_A options
-	merged, err = mergeWorkflowExecutionOptions(input, pinnedOverrideOptionsB, updateMask)
+	merged, recomputedEffects, err = mergeWorkflowExecutionOptions(input, pinnedOverrideOptionsB, updateMask)
 	if err != nil {
 		t.Error(err)
 	}
 	require.EqualExportedValues(t, pinnedOverrideOptionsB, merged)
+	require.False(t, recomputedEffects.hasChanges())
 
 	// Unset versioning override
-	merged, err = mergeWorkflowExecutionOptions(input, emptyOptions, updateMask)
+	merged, recomputedEffects, err = mergeWorkflowExecutionOptions(input, emptyOptions, updateMask)
 	if err != nil {
 		t.Error(err)
 	}
 	require.EqualExportedValues(t, emptyOptions, merged)
+	require.False(t, recomputedEffects.hasChanges())
 }
 
 func TestMergeOptions_PartialMask(t *testing.T) {
-	bothUpdateMask := &fieldmaskpb.FieldMask{Paths: []string{"versioning_override.behavior", "versioning_override.deployment"}}
+	allUpdateMask := &fieldmaskpb.FieldMask{Paths: []string{"versioning_override.behavior", "versioning_override.deployment"}}
 	behaviorOnlyUpdateMask := &fieldmaskpb.FieldMask{Paths: []string{"versioning_override.behavior"}}
 	deploymentOnlyUpdateMask := &fieldmaskpb.FieldMask{Paths: []string{"versioning_override.deployment"}}
 
-	_, err := mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, behaviorOnlyUpdateMask)
+	_, _, err := mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, behaviorOnlyUpdateMask)
 	require.Error(t, err)
 
-	_, err = mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, deploymentOnlyUpdateMask)
+	_, _, err = mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, deploymentOnlyUpdateMask)
 	require.Error(t, err)
 
-	merged, err := mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, bothUpdateMask)
+	merged, _, err := mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, allUpdateMask)
 	require.NoError(t, err)
 	require.EqualExportedValues(t, unpinnedOverrideOptions, merged)
+
+	// partial mask for time skipping config will return invalid argument error
+	timeSkippingPartialMask := &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.enabled"}}
+	_, _, err = mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, timeSkippingPartialMask)
+	require.Error(t, err)
+
 }
 
 func TestMergeOptions_EmptyMask(t *testing.T) {
@@ -136,77 +166,98 @@ func TestMergeOptions_EmptyMask(t *testing.T) {
 	input := pinnedOverrideOptionsB
 
 	// Don't merge anything
-	merged, err := mergeWorkflowExecutionOptions(input, pinnedOverrideOptionsA, emptyUpdateMask)
+	merged, recomputedEffects, err := mergeWorkflowExecutionOptions(input, pinnedOverrideOptionsA, emptyUpdateMask)
 	require.NoError(t, err)
+	require.False(t, recomputedEffects.hasChanges())
 	require.EqualExportedValues(t, input, merged)
 
 	// Don't merge anything
-	merged, err = mergeWorkflowExecutionOptions(input, nil, emptyUpdateMask)
+	merged, recomputedEffects, err = mergeWorkflowExecutionOptions(input, nil, emptyUpdateMask)
 	require.NoError(t, err)
+	require.False(t, recomputedEffects.hasChanges())
 	require.EqualExportedValues(t, input, merged)
 }
 
 func TestMergeOptions_AsteriskMask(t *testing.T) {
 	asteriskUpdateMask := &fieldmaskpb.FieldMask{Paths: []string{"*"}}
-	_, err := mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, asteriskUpdateMask)
+	_, _, err := mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, asteriskUpdateMask)
 	require.Error(t, err)
 }
 
 func TestMergeOptions_FooMask(t *testing.T) {
 	fooUpdateMask := &fieldmaskpb.FieldMask{Paths: []string{"foo"}}
-	_, err := mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, fooUpdateMask)
+	_, _, err := mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, fooUpdateMask)
 	require.Error(t, err)
 }
 
 func TestMergeOptions_TimeSkippingConfig(t *testing.T) {
+
+	// assuming the TSC is always in the mask -> meaning the user always updates the TSC
 	tscMask := &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config"}}
 	cfgA := &commonpb.TimeSkippingConfig{Enabled: true}
 	cfgB := &commonpb.TimeSkippingConfig{
 		Enabled:     true,
 		FastForward: durationpb.New(time.Hour),
 	}
+	cfgC := &commonpb.TimeSkippingConfig{Enabled: false}
 
 	tcs := []struct {
-		name        string
-		current     *workflowpb.WorkflowExecutionOptions
-		update      *workflowpb.WorkflowExecutionOptions
-		wantChanged bool
-		wantConfig  *commonpb.TimeSkippingConfig
+		name                 string
+		mergeInto            *workflowpb.WorkflowExecutionOptions
+		mergeFrom            *workflowpb.WorkflowExecutionOptions
+		configForUpdateEvent *commonpb.TimeSkippingConfig
+		configHasChanged     bool
 	}{
-		// nil update means "don't touch" even when mask is present
 		{
-			name:        "nil update - existing config preserved",
-			current:     &workflowpb.WorkflowExecutionOptions{TimeSkippingConfig: cfgA},
-			update:      &workflowpb.WorkflowExecutionOptions{},
-			wantChanged: false,
-			wantConfig:  cfgA,
+			name:                 "nil update - clears the TSC",
+			mergeInto:            &workflowpb.WorkflowExecutionOptions{TimeSkippingConfig: cfgA},
+			mergeFrom:            nil,
+			configForUpdateEvent: nil,
+			configHasChanged:     true,
 		},
-		// non-nil update replaces and is detected as a change
 		{
-			name:        "new config - changed",
-			current:     &workflowpb.WorkflowExecutionOptions{},
-			update:      &workflowpb.WorkflowExecutionOptions{TimeSkippingConfig: cfgB},
-			wantChanged: true,
-			wantConfig:  cfgB,
+			name:                 "same config with side-effect field change",
+			mergeInto:            &workflowpb.WorkflowExecutionOptions{TimeSkippingConfig: cfgB},
+			mergeFrom:            &workflowpb.WorkflowExecutionOptions{TimeSkippingConfig: cfgB},
+			configForUpdateEvent: cfgB,
+			configHasChanged:     true,
 		},
-		// identical config is not detected as a change
 		{
-			name:        "same config - no change",
-			current:     &workflowpb.WorkflowExecutionOptions{TimeSkippingConfig: cfgB},
-			update:      &workflowpb.WorkflowExecutionOptions{TimeSkippingConfig: cfgB},
-			wantChanged: false,
-			wantConfig:  cfgB,
+			name:                 "new config with side-effect field change",
+			mergeInto:            &workflowpb.WorkflowExecutionOptions{},
+			mergeFrom:            &workflowpb.WorkflowExecutionOptions{TimeSkippingConfig: cfgB},
+			configForUpdateEvent: cfgB,
+			configHasChanged:     true,
+		},
+		{
+			name:                 "same config with no side-effect field change",
+			mergeInto:            &workflowpb.WorkflowExecutionOptions{TimeSkippingConfig: cfgA},
+			mergeFrom:            &workflowpb.WorkflowExecutionOptions{TimeSkippingConfig: cfgA},
+			configForUpdateEvent: cfgA,
+			configHasChanged:     false,
+		},
+		{
+			name:                 "new config to disable time skipping",
+			mergeInto:            &workflowpb.WorkflowExecutionOptions{TimeSkippingConfig: cfgA},
+			mergeFrom:            &workflowpb.WorkflowExecutionOptions{TimeSkippingConfig: cfgC},
+			configForUpdateEvent: cfgC,
+			configHasChanged:     true,
+		},
+		{
+			name:                 "new config to enable time skipping",
+			mergeInto:            &workflowpb.WorkflowExecutionOptions{},
+			mergeFrom:            &workflowpb.WorkflowExecutionOptions{TimeSkippingConfig: cfgA},
+			configForUpdateEvent: cfgA,
+			configHasChanged:     true,
 		},
 	}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			original := proto.Clone(tc.current).(*workflowpb.WorkflowExecutionOptions)
-			merged, err := mergeWorkflowExecutionOptions(tc.current, tc.update, tscMask)
+			merged, sideEffects, err := mergeWorkflowExecutionOptions(tc.mergeInto, tc.mergeFrom, tscMask)
 			require.NoError(t, err)
-			require.True(t, proto.Equal(tc.wantConfig, merged.GetTimeSkippingConfig()),
-				"config mismatch: want %v, got %v", tc.wantConfig, merged.GetTimeSkippingConfig())
-			require.Equal(t, tc.wantChanged, !proto.Equal(merged, original))
+			require.True(t, proto.Equal(tc.configForUpdateEvent, merged.GetTimeSkippingConfig()))
+			require.Equal(t, tc.configHasChanged, sideEffects.timeSkippingConfigHasChanged)
 		})
 	}
 }
@@ -303,7 +354,9 @@ func (s *updateWorkflowOptionsSuite) TestInvoke_Success() {
 	).Return(&matchingservice.CheckTaskQueueVersionMembershipResponse{
 		IsMember: true,
 	}, nil)
-	s.currentMutableState.EXPECT().AddWorkflowExecutionOptionsUpdatedEvent(expectedOverrideOptions.VersioningOverride, false, "", nil, nil, "", expectedOverrideOptions.Priority, expectedOverrideOptions.TimeSkippingConfig, nil).Return(&historypb.HistoryEvent{}, nil)
+	s.currentMutableState.EXPECT().AddWorkflowExecutionOptionsUpdatedEvent(
+		expectedOverrideOptions.VersioningOverride, false, "", nil, nil, "",
+		expectedOverrideOptions.Priority, expectedOverrideOptions.TimeSkippingConfig, false, nil).Return(&historypb.HistoryEvent{}, nil)
 	s.currentMutableState.EXPECT().Now().Return(time.Time{})
 	s.currentContext.EXPECT().UpdateWorkflowExecutionAsActive(gomock.Any(), s.shardContext).Return(nil)
 
@@ -334,88 +387,164 @@ func (s *updateWorkflowOptionsSuite) TestInvoke_Success() {
 	proto.Equal(expectedOverrideOptions, resp.GetWorkflowExecutionOptions())
 }
 
-func TestMergeAndApply_TimeSkippingConfig(t *testing.T) {
+func TestMergeAndApply(t *testing.T) {
 	oneHour := durationpb.New(time.Hour)
-	twoHours := durationpb.New(2 * time.Hour)
-	thirtyMin := durationpb.New(30 * time.Minute)
+	newOverride := &workflowpb.VersioningOverride{Behavior: enumspb.VERSIONING_BEHAVIOR_AUTO_UPGRADE}
 
-	testCases := []struct {
-		name           string
-		initialConfig  *commonpb.TimeSkippingConfig
-		updateOptions  *workflowpb.WorkflowExecutionOptions
-		updateMask     *fieldmaskpb.FieldMask
-		expectedConfig *commonpb.TimeSkippingConfig
+	tscMask := &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config"}}
+	versioningMask := &fieldmaskpb.FieldMask{Paths: []string{"versioning_override"}}
+
+	tcs := []struct {
+		name          string
+		initialConfig *commonpb.TimeSkippingConfig
+		updateOptions *workflowpb.WorkflowExecutionOptions
+		updateMask    *fieldmaskpb.FieldMask
+
+		// use version as an unrelated option to test its impacts on TSC
+		expectVersioningOverride *workflowpb.VersioningOverride
+		unsetVersion             bool
+
+		// the values in WorkflowExecutionOptionsUpdatedEventAttributes
+		expectChanges    bool
+		expectTSCInEvent *commonpb.TimeSkippingConfig
+		expectTSCUpdated bool
+
+		// only checks the result when needed
+		needCheckResultTSC bool
+		resultTSC          *commonpb.TimeSkippingConfig
 	}{
 		{
-			name: "update max_elapsed_duration while enabled",
-			initialConfig: &commonpb.TimeSkippingConfig{
-				Enabled:     true,
-				FastForward: oneHour,
-			},
-			updateOptions: &workflowpb.WorkflowExecutionOptions{
-				TimeSkippingConfig: &commonpb.TimeSkippingConfig{
-					Enabled:     true,
-					FastForward: twoHours,
-				},
-			},
-			updateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.fast_forward"}},
-			expectedConfig: &commonpb.TimeSkippingConfig{
-				Enabled:     true,
-				FastForward: twoHours,
-			},
-		},
-		{
-			name: "set max_elapsed_duration while enabled",
-			initialConfig: &commonpb.TimeSkippingConfig{
-				Enabled: true,
-			},
-			updateOptions: &workflowpb.WorkflowExecutionOptions{
-				TimeSkippingConfig: &commonpb.TimeSkippingConfig{
-					Enabled:     true,
-					FastForward: thirtyMin,
-				},
-			},
-			updateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.fast_forward"}},
-			expectedConfig: &commonpb.TimeSkippingConfig{
-				Enabled:     true,
-				FastForward: thirtyMin,
-			},
-		},
-		{
-			name:          "enable from nil config",
+			name:          "basic: enable from nil config",
 			initialConfig: nil,
 			updateOptions: &workflowpb.WorkflowExecutionOptions{
 				TimeSkippingConfig: &commonpb.TimeSkippingConfig{Enabled: true},
 			},
-			updateMask:     &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.enabled"}},
-			expectedConfig: &commonpb.TimeSkippingConfig{Enabled: true},
+			updateMask:               tscMask,
+			expectChanges:            true,
+			expectVersioningOverride: nil,
+			unsetVersion:             true,
+			expectTSCInEvent:         &commonpb.TimeSkippingConfig{Enabled: true},
+			expectTSCUpdated:         true,
+			resultTSC:                &commonpb.TimeSkippingConfig{Enabled: true},
+			needCheckResultTSC:       true,
 		},
 		{
-			name:          "disable from enabled config",
+			name:          "basic: disable from enabled config",
 			initialConfig: &commonpb.TimeSkippingConfig{Enabled: true},
 			updateOptions: &workflowpb.WorkflowExecutionOptions{
 				TimeSkippingConfig: &commonpb.TimeSkippingConfig{Enabled: false},
 			},
-			updateMask:     &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config.enabled"}},
-			expectedConfig: &commonpb.TimeSkippingConfig{Enabled: false},
+			updateMask:               tscMask,
+			expectChanges:            true,
+			expectVersioningOverride: nil,
+			unsetVersion:             true,
+			expectTSCInEvent:         &commonpb.TimeSkippingConfig{Enabled: false},
+			expectTSCUpdated:         true,
+			resultTSC:                &commonpb.TimeSkippingConfig{Enabled: false},
+			needCheckResultTSC:       true,
+		},
+		{
+			name:          "basic: fast-forward from nil",
+			initialConfig: nil,
+			updateOptions: &workflowpb.WorkflowExecutionOptions{
+				TimeSkippingConfig: &commonpb.TimeSkippingConfig{Enabled: true, FastForward: oneHour},
+			},
+			updateMask:               tscMask,
+			expectChanges:            true,
+			expectVersioningOverride: nil,
+			unsetVersion:             true,
+			expectTSCInEvent:         &commonpb.TimeSkippingConfig{Enabled: true, FastForward: oneHour},
+			expectTSCUpdated:         true,
+			resultTSC:                &commonpb.TimeSkippingConfig{Enabled: true, FastForward: oneHour},
+			needCheckResultTSC:       true,
+		},
+		{
+			name:          "recompute: TSC updated with same fast-forward",
+			initialConfig: &commonpb.TimeSkippingConfig{Enabled: true, FastForward: oneHour},
+			updateOptions: &workflowpb.WorkflowExecutionOptions{
+				TimeSkippingConfig: &commonpb.TimeSkippingConfig{Enabled: true, FastForward: oneHour},
+			},
+			updateMask:               tscMask,
+			expectVersioningOverride: nil,
+			unsetVersion:             true,
+
+			expectChanges:      true,
+			expectTSCInEvent:   &commonpb.TimeSkippingConfig{Enabled: true, FastForward: oneHour},
+			expectTSCUpdated:   true,
+			resultTSC:          &commonpb.TimeSkippingConfig{Enabled: true, FastForward: oneHour},
+			needCheckResultTSC: true,
+		},
+		{
+			name:                     "TSC no change: version update with fast-forward untouched",
+			initialConfig:            &commonpb.TimeSkippingConfig{Enabled: true, FastForward: oneHour},
+			updateOptions:            &workflowpb.WorkflowExecutionOptions{VersioningOverride: newOverride},
+			updateMask:               versioningMask,
+			expectVersioningOverride: newOverride,
+			unsetVersion:             false,
+			// as we always put the merged TSC into the event, even if it is the same as the initial config
+			expectChanges:      true,
+			expectTSCInEvent:   &commonpb.TimeSkippingConfig{Enabled: true, FastForward: oneHour},
+			expectTSCUpdated:   false,
+			needCheckResultTSC: true,
+			resultTSC:          &commonpb.TimeSkippingConfig{Enabled: true, FastForward: oneHour},
+		},
+		{
+			name:                     "TSC no change: TSC without fast-forward are updated with same value",
+			initialConfig:            &commonpb.TimeSkippingConfig{Enabled: true},
+			updateOptions:            &workflowpb.WorkflowExecutionOptions{TimeSkippingConfig: &commonpb.TimeSkippingConfig{Enabled: true}},
+			updateMask:               tscMask,
+			expectVersioningOverride: nil,
+			unsetVersion:             false,
+			expectChanges:            false,
+		},
+		{
+			name:                     "nil allowed: nil with mask clears the TSC",
+			initialConfig:            &commonpb.TimeSkippingConfig{Enabled: true, FastForward: oneHour},
+			updateOptions:            &workflowpb.WorkflowExecutionOptions{VersioningOverride: newOverride},
+			updateMask:               &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config", "versioning_override"}},
+			expectChanges:            true,
+			expectVersioningOverride: newOverride,
+			unsetVersion:             false,
+			expectTSCInEvent:         nil,
+			expectTSCUpdated:         true,
+			resultTSC:                nil,
+			needCheckResultTSC:       true,
 		},
 	}
 
-	for _, tc := range testCases {
+	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			ms := historyi.NewMockMutableState(ctrl)
 			ms.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
-				TimeSkippingInfo: &persistencespb.TimeSkippingInfo{
-					Config: tc.initialConfig,
-				},
+				TimeSkippingInfo: &persistencespb.TimeSkippingInfo{Config: tc.initialConfig},
 			}).AnyTimes()
-			ms.EXPECT().AddWorkflowExecutionOptionsUpdatedEvent(nil, true, "", nil, nil, "", nil, gomock.Any(), gomock.Any()).Return(&historypb.HistoryEvent{}, nil)
+
+			if tc.expectChanges {
+				ms.EXPECT().AddWorkflowExecutionOptionsUpdatedEvent(
+					tc.expectVersioningOverride,
+					tc.unsetVersion,
+					"",
+					nil,
+					nil,
+					"",
+					nil,
+					tscProtoEq{tc.expectTSCInEvent},
+					tc.expectTSCUpdated,
+					nil,
+				).Return(&historypb.HistoryEvent{}, nil).Times(1)
+			}
 
 			result, hasChanges, err := MergeAndApply(ms, tc.updateOptions, tc.updateMask, "")
 			require.NoError(t, err)
-			require.True(t, hasChanges)
-			require.True(t, proto.Equal(tc.expectedConfig, result.GetTimeSkippingConfig()))
+			if tc.expectChanges {
+				require.True(t, hasChanges)
+				if tc.needCheckResultTSC {
+					require.True(t, proto.Equal(tc.resultTSC, result.GetTimeSkippingConfig()))
+				}
+			} else {
+				require.False(t, hasChanges)
+			}
 		})
 	}
 }

--- a/service/history/api/updateworkflowoptions/api_test.go
+++ b/service/history/api/updateworkflowoptions/api_test.go
@@ -107,36 +107,36 @@ func TestMergeOptions_VersionOverrideMask(t *testing.T) {
 	input := emptyOptions
 
 	// Merge unpinned into empty options
-	merged, recomputedEffects, err := mergeWorkflowExecutionOptions(input, unpinnedOverrideOptions, updateMask)
+	merged, optionsToReapply, err := mergeWorkflowExecutionOptions(input, unpinnedOverrideOptions, updateMask)
 	if err != nil {
 		t.Error(err)
 	}
 	require.EqualExportedValues(t, unpinnedOverrideOptions, merged)
-	require.False(t, recomputedEffects.hasChanges())
+	require.False(t, optionsToReapply.hasChanges())
 
 	// Merge pinned_A into unpinned options
-	merged, recomputedEffects, err = mergeWorkflowExecutionOptions(input, pinnedOverrideOptionsA, updateMask)
+	merged, optionsToReapply, err = mergeWorkflowExecutionOptions(input, pinnedOverrideOptionsA, updateMask)
 	if err != nil {
 		t.Error(err)
 	}
 	require.EqualExportedValues(t, pinnedOverrideOptionsA, merged)
-	require.False(t, recomputedEffects.hasChanges())
+	require.False(t, optionsToReapply.hasChanges())
 
 	// Merge pinned_B into pinned_A options
-	merged, recomputedEffects, err = mergeWorkflowExecutionOptions(input, pinnedOverrideOptionsB, updateMask)
+	merged, optionsToReapply, err = mergeWorkflowExecutionOptions(input, pinnedOverrideOptionsB, updateMask)
 	if err != nil {
 		t.Error(err)
 	}
 	require.EqualExportedValues(t, pinnedOverrideOptionsB, merged)
-	require.False(t, recomputedEffects.hasChanges())
+	require.False(t, optionsToReapply.hasChanges())
 
 	// Unset versioning override
-	merged, recomputedEffects, err = mergeWorkflowExecutionOptions(input, emptyOptions, updateMask)
+	merged, optionsToReapply, err = mergeWorkflowExecutionOptions(input, emptyOptions, updateMask)
 	if err != nil {
 		t.Error(err)
 	}
 	require.EqualExportedValues(t, emptyOptions, merged)
-	require.False(t, recomputedEffects.hasChanges())
+	require.False(t, optionsToReapply.hasChanges())
 }
 
 func TestMergeOptions_PartialMask(t *testing.T) {
@@ -166,15 +166,15 @@ func TestMergeOptions_EmptyMask(t *testing.T) {
 	input := pinnedOverrideOptionsB
 
 	// Don't merge anything
-	merged, recomputedEffects, err := mergeWorkflowExecutionOptions(input, pinnedOverrideOptionsA, emptyUpdateMask)
+	merged, optionsToReapply, err := mergeWorkflowExecutionOptions(input, pinnedOverrideOptionsA, emptyUpdateMask)
 	require.NoError(t, err)
-	require.False(t, recomputedEffects.hasChanges())
+	require.False(t, optionsToReapply.hasChanges())
 	require.EqualExportedValues(t, input, merged)
 
 	// Don't merge anything
-	merged, recomputedEffects, err = mergeWorkflowExecutionOptions(input, nil, emptyUpdateMask)
+	merged, optionsToReapply, err = mergeWorkflowExecutionOptions(input, nil, emptyUpdateMask)
 	require.NoError(t, err)
-	require.False(t, recomputedEffects.hasChanges())
+	require.False(t, optionsToReapply.hasChanges())
 	require.EqualExportedValues(t, input, merged)
 }
 
@@ -459,7 +459,7 @@ func TestMergeAndApply(t *testing.T) {
 			needCheckResultTSC:       true,
 		},
 		{
-			name:          "recompute: TSC updated with same fast-forward",
+			name:          "reapply: TSC updated with same fast-forward",
 			initialConfig: &commonpb.TimeSkippingConfig{Enabled: true, FastForward: oneHour},
 			updateOptions: &workflowpb.WorkflowExecutionOptions{
 				TimeSkippingConfig: &commonpb.TimeSkippingConfig{Enabled: true, FastForward: oneHour},

--- a/service/history/historybuilder/event_factory.go
+++ b/service/history/historybuilder/event_factory.go
@@ -407,6 +407,7 @@ func (b *EventFactory) CreateWorkflowExecutionOptionsUpdatedEvent(
 	identity string,
 	priority *commonpb.Priority,
 	timeSkippingConfig *commonpb.TimeSkippingConfig,
+	timeSkippingConfigUpdated bool,
 	workflowUpdateOptions []*historypb.WorkflowExecutionOptionsUpdatedEventAttributes_WorkflowUpdateOptionsUpdate,
 ) *historypb.HistoryEvent {
 	event := b.createHistoryEvent(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED, b.timeSource.Now())
@@ -419,6 +420,7 @@ func (b *EventFactory) CreateWorkflowExecutionOptionsUpdatedEvent(
 			Identity:                    identity,
 			Priority:                    priority,
 			TimeSkippingConfig:          timeSkippingConfig,
+			TimeSkippingConfigUpdated:   timeSkippingConfigUpdated,
 			WorkflowUpdateOptions:       workflowUpdateOptions,
 		},
 	}

--- a/service/history/historybuilder/history_builder.go
+++ b/service/history/historybuilder/history_builder.go
@@ -474,6 +474,7 @@ func (b *HistoryBuilder) AddWorkflowExecutionOptionsUpdatedEvent(
 	identity string,
 	priority *commonpb.Priority,
 	timeSkippingConfig *commonpb.TimeSkippingConfig,
+	timeSkippingConfigUpdated bool,
 	workflowUpdateOptions []*historypb.WorkflowExecutionOptionsUpdatedEventAttributes_WorkflowUpdateOptionsUpdate,
 ) *historypb.HistoryEvent {
 	event := b.EventFactory.CreateWorkflowExecutionOptionsUpdatedEvent(
@@ -485,6 +486,7 @@ func (b *HistoryBuilder) AddWorkflowExecutionOptionsUpdatedEvent(
 		identity,
 		priority,
 		timeSkippingConfig,
+		timeSkippingConfigUpdated,
 		workflowUpdateOptions,
 	)
 	event, _ = b.add(event)

--- a/service/history/historybuilder/history_builder_categorization_test.go
+++ b/service/history/historybuilder/history_builder_categorization_test.go
@@ -209,7 +209,7 @@ func TestHistoryBuilder_FlushBufferToCurrentBatch(t *testing.T) {
 			t.Errorf("expected 1 event in memBufferBatch got %d", len(hb.memBufferBatch))
 		}
 		// add another event to memBufferBatch
-		hb.AddWorkflowExecutionOptionsUpdatedEvent(nil, false, "request-id-1", nil, nil, "", nil, nil, nil)
+		hb.AddWorkflowExecutionOptionsUpdatedEvent(nil, false, "request-id-1", nil, nil, "", nil, nil, false, nil)
 		if len(hb.memBufferBatch) != 2 {
 			t.Errorf("expected 2 event in memBufferBatch got %d", len(hb.memBufferBatch))
 		}

--- a/service/history/interfaces/mutable_state.go
+++ b/service/history/interfaces/mutable_state.go
@@ -129,6 +129,7 @@ type (
 			identity string,
 			priority *commonpb.Priority,
 			timeSkippingConfig *commonpb.TimeSkippingConfig,
+			timeSkippingConfigUpdated bool,
 			workflowUpdateOptions []*historypb.WorkflowExecutionOptionsUpdatedEventAttributes_WorkflowUpdateOptionsUpdate,
 		) (*historypb.HistoryEvent, error)
 		AddWorkflowExecutionUpdateAcceptedEvent(updateID string, acceptedRequestMessageID string, acceptedRequestSequencingEventID int64, acceptedRequest *updatepb.Request) (*historypb.HistoryEvent, error)

--- a/service/history/interfaces/mutable_state_mock.go
+++ b/service/history/interfaces/mutable_state_mock.go
@@ -678,18 +678,18 @@ func (mr *MockMutableStateMockRecorder) AddWorkflowExecutionCanceledEvent(arg0, 
 }
 
 // AddWorkflowExecutionOptionsUpdatedEvent mocks base method.
-func (m *MockMutableState) AddWorkflowExecutionOptionsUpdatedEvent(versioningOverride *workflow.VersioningOverride, unsetVersioningOverride bool, attachRequestID string, attachCompletionCallbacks []*common.Callback, links []*common.Link, identity string, priority *common.Priority, timeSkippingConfig *common.TimeSkippingConfig, workflowUpdateOptions []*history.WorkflowExecutionOptionsUpdatedEventAttributes_WorkflowUpdateOptionsUpdate) (*history.HistoryEvent, error) {
+func (m *MockMutableState) AddWorkflowExecutionOptionsUpdatedEvent(versioningOverride *workflow.VersioningOverride, unsetVersioningOverride bool, attachRequestID string, attachCompletionCallbacks []*common.Callback, links []*common.Link, identity string, priority *common.Priority, timeSkippingConfig *common.TimeSkippingConfig, timeSkippingConfigUpdated bool, workflowUpdateOptions []*history.WorkflowExecutionOptionsUpdatedEventAttributes_WorkflowUpdateOptionsUpdate) (*history.HistoryEvent, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddWorkflowExecutionOptionsUpdatedEvent", versioningOverride, unsetVersioningOverride, attachRequestID, attachCompletionCallbacks, links, identity, priority, timeSkippingConfig, workflowUpdateOptions)
+	ret := m.ctrl.Call(m, "AddWorkflowExecutionOptionsUpdatedEvent", versioningOverride, unsetVersioningOverride, attachRequestID, attachCompletionCallbacks, links, identity, priority, timeSkippingConfig, timeSkippingConfigUpdated, workflowUpdateOptions)
 	ret0, _ := ret[0].(*history.HistoryEvent)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddWorkflowExecutionOptionsUpdatedEvent indicates an expected call of AddWorkflowExecutionOptionsUpdatedEvent.
-func (mr *MockMutableStateMockRecorder) AddWorkflowExecutionOptionsUpdatedEvent(versioningOverride, unsetVersioningOverride, attachRequestID, attachCompletionCallbacks, links, identity, priority, timeSkippingConfig, workflowUpdateOptions any) *gomock.Call {
+func (mr *MockMutableStateMockRecorder) AddWorkflowExecutionOptionsUpdatedEvent(versioningOverride, unsetVersioningOverride, attachRequestID, attachCompletionCallbacks, links, identity, priority, timeSkippingConfig, timeSkippingConfigUpdated, workflowUpdateOptions any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddWorkflowExecutionOptionsUpdatedEvent", reflect.TypeOf((*MockMutableState)(nil).AddWorkflowExecutionOptionsUpdatedEvent), versioningOverride, unsetVersioningOverride, attachRequestID, attachCompletionCallbacks, links, identity, priority, timeSkippingConfig, workflowUpdateOptions)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddWorkflowExecutionOptionsUpdatedEvent", reflect.TypeOf((*MockMutableState)(nil).AddWorkflowExecutionOptionsUpdatedEvent), versioningOverride, unsetVersioningOverride, attachRequestID, attachCompletionCallbacks, links, identity, priority, timeSkippingConfig, timeSkippingConfigUpdated, workflowUpdateOptions)
 }
 
 // AddWorkflowExecutionPausedEvent mocks base method.

--- a/service/history/ndc/events_reapplier_test.go
+++ b/service/history/ndc/events_reapplier_test.go
@@ -114,6 +114,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_WorkflowExec
 		attr.GetIdentity(),
 		attr.GetPriority(),
 		attr.GetTimeSkippingConfig(),
+		attr.GetTimeSkippingConfigUpdated(),
 		attr.GetWorkflowUpdateOptions(),
 	).Return(event, nil)
 	msCurrent.EXPECT().HSM().Return(s.hsmNode).AnyTimes()
@@ -163,6 +164,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_WorkflowExec
 		attr.GetIdentity(),
 		attr.GetPriority(),
 		timeSkippingConfig,
+		attr.GetTimeSkippingConfigUpdated(),
 		attr.GetWorkflowUpdateOptions(),
 	).Return(event, nil)
 	msCurrent.EXPECT().HSM().Return(s.hsmNode).AnyTimes()

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -972,6 +972,7 @@ func reapplyEvents(
 				attr.GetIdentity(),
 				attr.GetPriority(),
 				attr.GetTimeSkippingConfig(),
+				attr.GetTimeSkippingConfigUpdated(),
 				attr.GetWorkflowUpdateOptions(),
 			); err != nil {
 				return reappliedEvents, err

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -1206,6 +1206,7 @@ func (s *workflowResetterSuite) TestReapplyEvents() {
 						attr.GetIdentity(),
 						attr.GetPriority(),
 						attr.GetTimeSkippingConfig(),
+						attr.GetTimeSkippingConfigUpdated(),
 						attr.GetWorkflowUpdateOptions(),
 					).Return(&historypb.HistoryEvent{}, nil)
 				case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED:
@@ -1735,6 +1736,7 @@ func (s *workflowResetterSuite) TestReapplyEvents_WorkflowOptionsUpdated_WithTim
 		attr.GetIdentity(),
 		attr.GetPriority(),
 		timeSkippingConfig,
+		attr.GetTimeSkippingConfigUpdated(),
 		attr.GetWorkflowUpdateOptions(),
 	).Return(&historypb.HistoryEvent{}, nil)
 

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -5841,6 +5841,7 @@ func (ms *MutableStateImpl) AddWorkflowExecutionOptionsUpdatedEvent(
 	identity string,
 	priority *commonpb.Priority,
 	timeSkippingConfig *commonpb.TimeSkippingConfig,
+	timeSkippingConfigUpdated bool,
 	workflowUpdateOptions []*historypb.WorkflowExecutionOptionsUpdatedEventAttributes_WorkflowUpdateOptionsUpdate,
 ) (*historypb.HistoryEvent, error) {
 	if err := ms.checkMutability(tag.WorkflowActionWorkflowOptionsUpdated); err != nil {
@@ -5855,6 +5856,7 @@ func (ms *MutableStateImpl) AddWorkflowExecutionOptionsUpdatedEvent(
 		identity,
 		priority,
 		timeSkippingConfig,
+		timeSkippingConfigUpdated,
 		workflowUpdateOptions,
 	)
 	prevEffectiveVersioningBehavior := ms.GetEffectiveVersioningBehavior()
@@ -5943,8 +5945,16 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionOptionsUpdatedEvent(event *his
 		ms.executionInfo.Priority = attributes.GetPriority()
 	}
 
-	if tsc := attributes.GetTimeSkippingConfig(); tsc != nil {
-		if ms.GetExecutionInfo().GetTimeSkippingInfo() == nil {
+	// this flag of timeSkippingConfigUpdated is the source of the truth for if the TSC is updated or not
+	// the contents of the config cannot be used to judge if the config is updated or not, examples:
+	// (1) TSC=nil in handleUseExistingWorkflowOnConflictOptions means nothing is changed
+	// but TSC=nil in MergeAndApplyWorkflowExecutionOptions with update masks means users want to remove the TSC
+	// (2) same TSC with fast-forward in MergeAndApplyWorkflowExecutionOptions logic may
+	// either indicate the TSC is untouched or updated to the same value and should refresh related timer tasks
+	if attributes.GetTimeSkippingConfigUpdated() {
+		tsc := attributes.GetTimeSkippingConfig()
+		tsi := ms.GetExecutionInfo().GetTimeSkippingInfo()
+		if tsi == nil {
 			ms.initTimeSkippingInfo(tsc, nil, event.GetEventId())
 		} else {
 			ms.updateTimeSkippingInfo(tsc, event.GetEventId())
@@ -10005,6 +10015,9 @@ func (ms *MutableStateImpl) initTimeSkippingInfo(
 	ms.timeSkippingInfoUpdated = true
 }
 
+// updateTimeSkippingInfo updates the time skipping info with
+// with new config and the event ID that updates the config
+// we allow updating the config to nil when users want to remove the TSC
 func (ms *MutableStateImpl) updateTimeSkippingInfo(
 	config *commonpb.TimeSkippingConfig,
 	currentEventID int64,

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -1159,7 +1159,8 @@ func (s *mutableStateSuite) TestOverride_UnpinnedBase_SetPinnedAndUnsetWithEmpty
 	s.createMutableStateWithVersioningBehavior(baseBehavior, deployment1, tq)
 
 	// set pinned override
-	event, err := s.mutableState.AddWorkflowExecutionOptionsUpdatedEvent(pinnedOptions2.GetVersioningOverride(), false, "", nil, nil, id, nil, nil, nil)
+	event, err := s.mutableState.AddWorkflowExecutionOptionsUpdatedEvent(
+		pinnedOptions2.GetVersioningOverride(), false, "", nil, nil, id, nil, nil, false, nil)
 	s.NoError(err)
 	s.verifyEffectiveDeployment(deployment2, overrideBehavior)
 	s.verifyWorkflowOptionsUpdatedEventAttr(
@@ -1174,7 +1175,7 @@ func (s *mutableStateSuite) TestOverride_UnpinnedBase_SetPinnedAndUnsetWithEmpty
 
 	// unset pinned override with boolean
 	id = uuid.NewString()
-	event, err = s.mutableState.AddWorkflowExecutionOptionsUpdatedEvent(nil, true, "", nil, nil, id, nil, nil, nil)
+	event, err = s.mutableState.AddWorkflowExecutionOptionsUpdatedEvent(nil, true, "", nil, nil, id, nil, nil, false, nil)
 	s.NoError(err)
 	s.verifyEffectiveDeployment(deployment1, baseBehavior)
 	s.verifyWorkflowOptionsUpdatedEventAttr(
@@ -1196,7 +1197,8 @@ func (s *mutableStateSuite) TestOverride_PinnedBase_SetUnpinnedAndUnsetWithEmpty
 	s.createMutableStateWithVersioningBehavior(baseBehavior, deployment1, tq)
 
 	// set unpinned override
-	event, err := s.mutableState.AddWorkflowExecutionOptionsUpdatedEvent(unpinnedOptions.GetVersioningOverride(), false, "", nil, nil, id, nil, nil, nil)
+	event, err := s.mutableState.AddWorkflowExecutionOptionsUpdatedEvent(
+		unpinnedOptions.GetVersioningOverride(), false, "", nil, nil, id, nil, nil, false, nil)
 	s.NoError(err)
 	s.verifyEffectiveDeployment(deployment1, overrideBehavior)
 	s.verifyWorkflowOptionsUpdatedEventAttr(
@@ -1211,7 +1213,8 @@ func (s *mutableStateSuite) TestOverride_PinnedBase_SetUnpinnedAndUnsetWithEmpty
 
 	// unset pinned override with empty
 	id = uuid.NewString()
-	event, err = s.mutableState.AddWorkflowExecutionOptionsUpdatedEvent(nil, true, "", nil, nil, id, nil, nil, nil)
+	event, err = s.mutableState.AddWorkflowExecutionOptionsUpdatedEvent(
+		nil, true, "", nil, nil, id, nil, nil, false, nil)
 	s.NoError(err)
 	s.verifyEffectiveDeployment(deployment1, baseBehavior)
 	s.verifyWorkflowOptionsUpdatedEventAttr(
@@ -1232,7 +1235,8 @@ func (s *mutableStateSuite) TestOverride_RedirectFails() {
 	id := uuid.NewString()
 	s.createMutableStateWithVersioningBehavior(baseBehavior, deployment1, tq)
 
-	event, err := s.mutableState.AddWorkflowExecutionOptionsUpdatedEvent(pinnedOptions3.GetVersioningOverride(), false, "", nil, nil, id, nil, nil, nil)
+	event, err := s.mutableState.AddWorkflowExecutionOptionsUpdatedEvent(
+		pinnedOptions3.GetVersioningOverride(), false, "", nil, nil, id, nil, nil, false, nil)
 	s.NoError(err)
 	s.verifyEffectiveDeployment(deployment3, overrideBehavior)
 	s.verifyWorkflowOptionsUpdatedEventAttr(
@@ -1259,7 +1263,8 @@ func (s *mutableStateSuite) TestOverride_BaseDeploymentUpdatedOnCompletion() {
 	id := uuid.NewString()
 	s.createMutableStateWithVersioningBehavior(baseBehavior, deployment1, tq)
 
-	event, err := s.mutableState.AddWorkflowExecutionOptionsUpdatedEvent(pinnedOptions3.GetVersioningOverride(), false, "", nil, nil, id, nil, nil, nil)
+	event, err := s.mutableState.AddWorkflowExecutionOptionsUpdatedEvent(
+		pinnedOptions3.GetVersioningOverride(), false, "", nil, nil, id, nil, nil, false, nil)
 	s.NoError(err)
 	s.verifyEffectiveDeployment(deployment3, overrideBehavior)
 	s.verifyWorkflowOptionsUpdatedEventAttr(
@@ -1313,7 +1318,8 @@ func (s *mutableStateSuite) TestOverride_BaseDeploymentUpdatedOnCompletion() {
 
 	// now we unset the override and check that the base deployment/behavior is in effect
 	id = uuid.NewString()
-	event, err = s.mutableState.AddWorkflowExecutionOptionsUpdatedEvent(nil, true, "", nil, nil, id, nil, nil, nil)
+	event, err = s.mutableState.AddWorkflowExecutionOptionsUpdatedEvent(
+		nil, true, "", nil, nil, id, nil, nil, false, nil)
 	s.NoError(err)
 	s.verifyEffectiveDeployment(deployment2, baseBehavior)
 	s.verifyWorkflowOptionsUpdatedEventAttr(
@@ -7909,10 +7915,6 @@ func (s *mutableStateSuite) TestApplyWorkflowExecutionStartedEvent_TimeSkippingC
 	}
 }
 
-// TestApplyWorkflowExecutionOptionsUpdatedEvent_TimeSkippingConfig verifies that
-// replaying a WorkflowExecutionOptionsUpdated event with TimeSkippingConfig populates
-// or overwrites executionInfo.TimeSkippingInfo. This is the rebuild path for
-// time-skipping config that is set or changed after workflow start.
 func (s *mutableStateSuite) TestApplyWorkflowExecutionOptionsUpdatedEvent_TimeSkippingConfig() {
 	initialConfig := &commonpb.TimeSkippingConfig{
 		Enabled:     true,
@@ -7922,62 +7924,103 @@ func (s *mutableStateSuite) TestApplyWorkflowExecutionOptionsUpdatedEvent_TimeSk
 		FastForward: durationpb.New(2 * time.Hour)}
 
 	testCases := []struct {
-		name          string
-		existing      *commonpb.TimeSkippingConfig
-		eventConfig   *commonpb.TimeSkippingConfig
-		wantConfig    *commonpb.TimeSkippingConfig
-		wantInfoIsNil bool
+		name              string
+		existing          *commonpb.TimeSkippingConfig
+		eventConfig       *commonpb.TimeSkippingConfig
+		wantConfig        *commonpb.TimeSkippingConfig
+		updatedFlag       bool
+		wantInfoIsNil     bool
+		targetTimeRenewal bool
 	}{
 		{
-			name:        "sets when none exists",
-			existing:    nil,
-			eventConfig: initialConfig,
-			wantConfig:  initialConfig,
+			name:              "sets when none exists",
+			existing:          nil,
+			eventConfig:       initialConfig,
+			wantConfig:        initialConfig,
+			updatedFlag:       true,
+			targetTimeRenewal: true,
 		},
 		{
-			name:        "overwrites existing",
-			existing:    initialConfig,
-			eventConfig: updatedConfig,
-			wantConfig:  updatedConfig,
+			name:              "overwrites existing",
+			existing:          initialConfig,
+			eventConfig:       updatedConfig,
+			wantConfig:        updatedConfig,
+			updatedFlag:       true,
+			targetTimeRenewal: true,
 		},
 		{
-			name:          "nil config leaves info untouched",
-			existing:      nil,
-			eventConfig:   nil,
-			wantInfoIsNil: true,
+			name:              "nil with updated flag set to false",
+			existing:          initialConfig,
+			eventConfig:       nil,
+			wantConfig:        initialConfig,
+			wantInfoIsNil:     false,
+			targetTimeRenewal: false,
+			updatedFlag:       false,
 		},
 		{
-			name:        "nil config preserves existing",
-			existing:    initialConfig,
-			eventConfig: nil,
-			wantConfig:  initialConfig,
+			name:              "nil with updated flag set to true",
+			existing:          initialConfig,
+			eventConfig:       nil,
+			wantConfig:        nil,
+			wantInfoIsNil:     false,
+			targetTimeRenewal: true, // nil config clears FastForwardInfo, so target time changes from timestamp → nil
+			updatedFlag:       true,
+		},
+		{
+			name:              "same config will trigger target time renewal",
+			existing:          initialConfig,
+			eventConfig:       initialConfig,
+			wantInfoIsNil:     false,
+			targetTimeRenewal: true,
+			wantConfig:        initialConfig,
+			updatedFlag:       true,
 		},
 	}
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
-			if tc.existing != nil {
-				s.mutableState.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{Config: tc.existing}
-			}
-
-			event := &historypb.HistoryEvent{
+			// first init the existing TSC to get the TSI
+			initialEvent := &historypb.HistoryEvent{
 				EventId:   int64(2),
 				EventTime: timestamppb.New(time.Now().UTC()),
 				EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
 				Attributes: &historypb.HistoryEvent_WorkflowExecutionOptionsUpdatedEventAttributes{
 					WorkflowExecutionOptionsUpdatedEventAttributes: &historypb.WorkflowExecutionOptionsUpdatedEventAttributes{
-						TimeSkippingConfig: tc.eventConfig,
+						TimeSkippingConfig:        tc.existing,
+						TimeSkippingConfigUpdated: true, // always set to true for initial event
 					},
 				},
 			}
-
-			err := s.mutableState.ApplyWorkflowExecutionOptionsUpdatedEvent(event)
+			err := s.mutableState.ApplyWorkflowExecutionOptionsUpdatedEvent(initialEvent)
 			s.NoError(err)
+			initialTSI := common.CloneProto(s.mutableState.executionInfo.GetTimeSkippingInfo())
+			// apply the event config
+			updatedEvent := &historypb.HistoryEvent{
+				EventId:   int64(3),
+				EventTime: timestamppb.New(time.Now().UTC()),
+				EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
+				Attributes: &historypb.HistoryEvent_WorkflowExecutionOptionsUpdatedEventAttributes{
+					WorkflowExecutionOptionsUpdatedEventAttributes: &historypb.WorkflowExecutionOptionsUpdatedEventAttributes{
+						TimeSkippingConfig:        tc.eventConfig,
+						TimeSkippingConfigUpdated: tc.updatedFlag,
+					},
+				},
+			}
+			err = s.mutableState.ApplyWorkflowExecutionOptionsUpdatedEvent(updatedEvent)
+			s.NoError(err)
+			updatedTSI := s.mutableState.executionInfo.GetTimeSkippingInfo()
 
+			if tc.wantConfig != nil {
+				s.True(proto.Equal(tc.wantConfig, updatedTSI.GetConfig()))
+			}
 			if tc.wantInfoIsNil {
-				s.Nil(s.mutableState.executionInfo.GetTimeSkippingInfo())
+				s.Nil(updatedTSI)
 			} else {
-				s.True(proto.Equal(tc.wantConfig, s.mutableState.executionInfo.GetTimeSkippingInfo().GetConfig()))
+				if tc.targetTimeRenewal {
+					s.NotEqual(initialTSI.GetFastForwardInfo().GetTargetTime(), updatedTSI.GetFastForwardInfo().GetTargetTime())
+				} else {
+					s.Equal(initialTSI.GetFastForwardInfo().GetTargetTime(), updatedTSI.GetFastForwardInfo().GetTargetTime())
+				}
 			}
 		})
 	}
@@ -8248,7 +8291,10 @@ func (s *mutableStateSuite) TestApplyFastForward() {
 // TestInitTimeSkippingInfo covers 3 basic scenarios this function is called.
 func (s *mutableStateSuite) TestInitTimeSkippingInfo() {
 
-	s.Run("InitWithNil_ForExecutionsWithoutTS", func() {
+	// if the inputs are nil, the caller doesn't need to call the TSI
+	// yet we still add this test to ensure the function is safe with an noop implementation
+	// to call with nil inputs
+	s.Run("SafeInitWithNil_ForExecutionsWithoutTS", func() {
 		s.mutableState.timeSource = clock.NewEventTimeSource()
 		baseTime := s.mutableState.timeSource.Now()
 		s.NotPanics(func() {
@@ -8310,6 +8356,34 @@ func (s *mutableStateSuite) TestInitTimeSkippingInfo() {
 }
 
 func (s *mutableStateSuite) TestUpdateTimeSkippingInfo() {
+
+	s.Run("UpdateTimeSkippingInfo_UpdateWithNil", func() {
+		s.mutableState.timeSource = clock.NewEventTimeSource()
+		baseTime := s.mutableState.timeSource.Now()
+		currentTSI := &persistencespb.TimeSkippingInfo{
+			Config: &commonpb.TimeSkippingConfig{
+				Enabled:     true,
+				FastForward: durationpb.New(time.Hour),
+			},
+			AccumulatedSkippedDuration: durationpb.New(time.Hour),
+			FastForwardInfo: &persistencespb.FastForwardInfo{
+				TargetTime:    timestamppb.New(baseTime.Add(time.Hour)),
+				SourceEventId: 7,
+				HasReached:    false,
+			},
+		}
+		s.mutableState.executionInfo.TimeSkippingInfo = currentTSI
+		s.mutableState.timeSkippingInfoUpdated = false
+		newEventID := int64(8)
+		s.mutableState.updateTimeSkippingInfo(nil, newEventID)
+		newTSI := s.mutableState.executionInfo.GetTimeSkippingInfo()
+		s.Require().NotNil(newTSI)
+		s.Nil(newTSI.GetConfig())
+		s.Nil(newTSI.GetFastForwardInfo())
+		s.Equal(currentTSI.GetAccumulatedSkippedDuration(), newTSI.GetAccumulatedSkippedDuration())
+		s.True(s.mutableState.timeSkippingInfoUpdated)
+	})
+
 	s.Run("UpdateTimeSkippingInfo_EnableTS", func() {
 		s.mutableState.timeSource = clock.NewEventTimeSource()
 		baseTime := s.mutableState.timeSource.Now()

--- a/service/history/workflow/update/store.go
+++ b/service/history/workflow/update/store.go
@@ -59,6 +59,7 @@ type (
 			identity string,
 			priority *commonpb.Priority,
 			timeSkippingConfig *commonpb.TimeSkippingConfig,
+			timeSkippingUpdated bool,
 			workflowUpdateOptions []*historypb.WorkflowExecutionOptionsUpdatedEventAttributes_WorkflowUpdateOptionsUpdate,
 		) (*historypb.HistoryEvent, error)
 

--- a/service/history/workflow/update/store_mock_test.go
+++ b/service/history/workflow/update/store_mock_test.go
@@ -84,6 +84,7 @@ type mockEventStore struct {
 		identity string,
 		priority *commonpb.Priority,
 		timeSkippingConfig *commonpb.TimeSkippingConfig,
+		timeSkippingUpdated bool,
 		workflowUpdateOptions []*historypb.WorkflowExecutionOptionsUpdatedEventAttributes_WorkflowUpdateOptionsUpdate,
 	) (*historypb.HistoryEvent, error)
 
@@ -100,10 +101,11 @@ func (m mockEventStore) AddWorkflowExecutionOptionsUpdatedEvent(
 	identity string,
 	priority *commonpb.Priority,
 	timeSkippingConfig *commonpb.TimeSkippingConfig,
+	timeSkippingUpdated bool,
 	workflowUpdateOptions []*historypb.WorkflowExecutionOptionsUpdatedEventAttributes_WorkflowUpdateOptionsUpdate,
 ) (*historypb.HistoryEvent, error) {
 	if m.AddWorkflowExecutionOptionsUpdatedEventFunc != nil {
-		return m.AddWorkflowExecutionOptionsUpdatedEventFunc(versioningOverride, unsetVersioningOverride, attachRequestID, attachCompletionCallbacks, links, identity, priority, timeSkippingConfig, workflowUpdateOptions)
+		return m.AddWorkflowExecutionOptionsUpdatedEventFunc(versioningOverride, unsetVersioningOverride, attachRequestID, attachCompletionCallbacks, links, identity, priority, timeSkippingConfig, timeSkippingUpdated, workflowUpdateOptions)
 	}
 	return &historypb.HistoryEvent{}, nil
 }

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -485,7 +485,7 @@ func (u *Update) persistCallback(
 		return true, nil
 	}
 	_, err = eventStore.AddWorkflowExecutionOptionsUpdatedEvent(
-		nil, false, "", nil, nil, "", nil, nil,
+		nil, false, "", nil, nil, "", nil, nil, false,
 		[]*historypb.WorkflowExecutionOptionsUpdatedEventAttributes_WorkflowUpdateOptionsUpdate{{
 			UpdateId:                    u.id,
 			AttachedRequestId:           requestID,

--- a/service/history/workflow/update/update_test.go
+++ b/service/history/workflow/update/update_test.go
@@ -1215,7 +1215,7 @@ func TestAttachCallbacks(t *testing.T) {
 			Controller: effects,
 			AddWorkflowExecutionOptionsUpdatedEventFunc: func(
 				_ *workflowpb.VersioningOverride, _ bool, _ string, _ []*commonpb.Callback, _ []*commonpb.Link, _ string, _ *commonpb.Priority,
-				_ *commonpb.TimeSkippingConfig, workflowUpdateOptions []*historypb.WorkflowExecutionOptionsUpdatedEventAttributes_WorkflowUpdateOptionsUpdate,
+				_ *commonpb.TimeSkippingConfig, _ bool, workflowUpdateOptions []*historypb.WorkflowExecutionOptionsUpdatedEventAttributes_WorkflowUpdateOptionsUpdate,
 			) (*historypb.HistoryEvent, error) {
 				captured = workflowUpdateOptions
 				return &historypb.HistoryEvent{}, nil
@@ -1230,7 +1230,7 @@ func TestAttachCallbacks(t *testing.T) {
 			Controller: effects,
 			AddWorkflowExecutionOptionsUpdatedEventFunc: func(
 				_ *workflowpb.VersioningOverride, _ bool, _ string, _ []*commonpb.Callback, _ []*commonpb.Link, _ string, _ *commonpb.Priority,
-				_ *commonpb.TimeSkippingConfig, _ []*historypb.WorkflowExecutionOptionsUpdatedEventAttributes_WorkflowUpdateOptionsUpdate,
+				_ *commonpb.TimeSkippingConfig, _ bool, _ []*historypb.WorkflowExecutionOptionsUpdatedEventAttributes_WorkflowUpdateOptionsUpdate,
 			) (*historypb.HistoryEvent, error) {
 				eventCreated = true
 				return &historypb.HistoryEvent{}, nil
@@ -1245,7 +1245,7 @@ func TestAttachCallbacks(t *testing.T) {
 			Controller: effects,
 			AddWorkflowExecutionOptionsUpdatedEventFunc: func(
 				_ *workflowpb.VersioningOverride, _ bool, _ string, _ []*commonpb.Callback, _ []*commonpb.Link, _ string, _ *commonpb.Priority,
-				_ *commonpb.TimeSkippingConfig, _ []*historypb.WorkflowExecutionOptionsUpdatedEventAttributes_WorkflowUpdateOptionsUpdate,
+				_ *commonpb.TimeSkippingConfig, _ bool, _ []*historypb.WorkflowExecutionOptionsUpdatedEventAttributes_WorkflowUpdateOptionsUpdate,
 			) (*historypb.HistoryEvent, error) {
 				count++
 				return &historypb.HistoryEvent{}, nil
@@ -1403,7 +1403,7 @@ func TestAttachCallbacks(t *testing.T) {
 			Controller: effects,
 			AddWorkflowExecutionOptionsUpdatedEventFunc: func(
 				_ *workflowpb.VersioningOverride, _ bool, _ string, _ []*commonpb.Callback, _ []*commonpb.Link, _ string, _ *commonpb.Priority,
-				_ *commonpb.TimeSkippingConfig, _ []*historypb.WorkflowExecutionOptionsUpdatedEventAttributes_WorkflowUpdateOptionsUpdate,
+				_ *commonpb.TimeSkippingConfig, _ bool, _ []*historypb.WorkflowExecutionOptionsUpdatedEventAttributes_WorkflowUpdateOptionsUpdate,
 			) (*historypb.HistoryEvent, error) {
 				return nil, serviceerror.NewInternal("flush error")
 			},
@@ -1529,7 +1529,7 @@ func TestAttachCallbacks(t *testing.T) {
 			Controller: effects,
 			AddWorkflowExecutionOptionsUpdatedEventFunc: func(
 				_ *workflowpb.VersioningOverride, _ bool, _ string, _ []*commonpb.Callback, _ []*commonpb.Link, _ string, _ *commonpb.Priority,
-				_ *commonpb.TimeSkippingConfig, _ []*historypb.WorkflowExecutionOptionsUpdatedEventAttributes_WorkflowUpdateOptionsUpdate,
+				_ *commonpb.TimeSkippingConfig, _ bool, _ []*historypb.WorkflowExecutionOptionsUpdatedEventAttributes_WorkflowUpdateOptionsUpdate,
 			) (*historypb.HistoryEvent, error) {
 				return nil, serviceerror.NewInternal("store error")
 			},
@@ -1567,7 +1567,7 @@ func TestAttachCallbacks(t *testing.T) {
 			},
 			AddWorkflowExecutionOptionsUpdatedEventFunc: func(
 				_ *workflowpb.VersioningOverride, _ bool, _ string, _ []*commonpb.Callback, _ []*commonpb.Link, _ string, _ *commonpb.Priority,
-				_ *commonpb.TimeSkippingConfig, _ []*historypb.WorkflowExecutionOptionsUpdatedEventAttributes_WorkflowUpdateOptionsUpdate,
+				_ *commonpb.TimeSkippingConfig, _ bool, _ []*historypb.WorkflowExecutionOptionsUpdatedEventAttributes_WorkflowUpdateOptionsUpdate,
 			) (*historypb.HistoryEvent, error) {
 				eventCreated = true
 				return &historypb.HistoryEvent{}, nil


### PR DESCRIPTION
## What changed?
add an update flag in UpdateWorkflowExecutionOptions to distinguish if TSC is changed by a workflow update options 

## Why?
It is clear if we have a clear flag to mark if the option is updated in UpdateWorkflowExecutionOptions.
Examples:
```
(1) TSC=nil in handleUseExistingWorkflowOnConflictOptions means nothing is changed
but TSC=nil in MergeAndApplyWorkflowExecutionOptions with update masks means users want to remove the TSC
(2) same TSC with fast-forward in MergeAndApplyWorkflowExecutionOptions logic may
either indicate the TSC is untouched or updated to the same value and should refresh related timer tasks
```

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

