### PR TITLE
fix: small nil-check for schedules during migration

### DIFF
--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -274,11 +274,19 @@ func CreateSchedulerFromMigration(
 ) (*Scheduler, error) {
 	state := req.GetState()
 
+	// Default to a non-nil empty result, matching NewScheduler. Migrated state
+	// may carry no completion result (e.g. a schedule migrated before its first
+	// action), and startWorkflow dereferences LastCompletionResult unconditionally.
+	lastCompletion := state.GetLastCompletionResult()
+	if lastCompletion == nil {
+		lastCompletion = &schedulerpb.LastCompletionResult{}
+	}
+
 	sched := &Scheduler{
 		SchedulerState:       state.GetSchedulerState(),
 		cacheConflictToken:   state.GetSchedulerState().GetConflictToken(),
 		Backfillers:          make(chasm.Map[string, *Backfiller]),
-		LastCompletionResult: chasm.NewDataField(ctx, state.GetLastCompletionResult()),
+		LastCompletionResult: chasm.NewDataField(ctx, lastCompletion),
 		EventLog:             chasm.NewComponentField(ctx, NewEventLog(ctx)),
 	}
 	sched.setNullableFields()


### PR DESCRIPTION
## What

`CreateSchedulerFromMigration` stored whatever `LastCompletionResult` the migrated V1 state carried, which is `nil` when the schedule had no prior completion (e.g. migrated before its first action) — `convertLastCompletionLegacyToCHASM` returns nil in that case. `InvokerExecuteTaskHandler.startWorkflow` then dereferences `lastCompletionState.Success`/`.Failure` unconditionally, panicking on the first workflow start after migration.

The normal `CreateScheduler`/`NewScheduler` path defaults to a non-nil empty `&schedulerpb.LastCompletionResult{}`, so it never hit this. This change defaults to the same non-nil empty value in `CreateSchedulerFromMigration`.

## How found

Surfaced by the V2→V1→V2 migration round-trip test (top of the stack below).

## Stack

This is the **base** of a stack of scheduler test-coverage PRs (review in order):
1. **this PR** — production fix
2. chasm-scheduler-test-harness
3. chasm-scheduler-invariants
4. chasm-scheduler-property-tests / chasm-scheduler-migration-roundtrip (siblings)

## Test plan

- `go build ./chasm/lib/scheduler/...`
- Covered end-to-end by the migration round-trip test in the stack.