### PR TITLE
Exclude draining and stopping members from resolver lookup ring

### DIFF
--- a/common/membership/ringpop/monitor_test.go
+++ b/common/membership/ringpop/monitor_test.go
@@ -3,6 +3,7 @@ package ringpop
 import (
 	"fmt"
 	"math/rand"
+	"strconv"
 	"testing"
 	"time"
 
@@ -102,6 +103,11 @@ func (s *RpoSuite) TestMonitor() {
 
 	s.Equal(2, len(r.Members()))
 	s.Equal(1, len(r.AvailableMembers()))
+	for k := 0; k < 10; k++ {
+		host, err = r.Lookup(fmt.Sprintf("drain-key-%d", k))
+		s.Nil(err, "Ringpop monitor failed to find host for key after drain")
+		s.NotEqual(testService.hostAddrs[2], host.GetAddress(), "Ringpop monitor assigned key to draining host")
+	}
 
 	err = r.RemoveListener("test-listener")
 	s.Nil(err, "RemoveListener() failed")
@@ -220,6 +226,26 @@ func (s *RpoSuite) TestCompareMembersWithDraining() {
 	})
 	s.Equal(3, len(resolver.Members()))
 	s.Equal(2, len(resolver.AvailableMembers()))
+}
+
+func (s *RpoSuite) TestLookupSkipsStoppingHosts() {
+	running := newHostInfo("a", nil)
+	stopping := newHostInfo("b", map[string]string{stopAtKey: strconv.FormatInt(time.Now().Add(10*time.Second).Unix(), 10)})
+
+	resolver := &serviceResolver{}
+	resolver.ringAndHosts.Store(ringAndHosts{
+		ring:  buildLookupRing([]*hostInfo{running, stopping}, 100),
+		hosts: map[string]*hostInfo{running.GetAddress(): running, stopping.GetAddress(): stopping},
+	})
+
+	s.Equal(2, len(resolver.Members()))
+	s.Equal(1, len(resolver.AvailableMembers()))
+
+	for k := 0; k < 10; k++ {
+		host, err := resolver.Lookup(fmt.Sprintf("stop-key-%d", k))
+		s.NoError(err)
+		s.Equal("a", host.GetAddress())
+	}
 }
 
 func eventToString(event *membership.ChangedEvent) []string {

--- a/common/membership/ringpop/service_resolver.go
+++ b/common/membership/ringpop/service_resolver.go
@@ -78,8 +78,9 @@ type (
 	}
 
 	ringAndHosts struct {
-		// We need to store a separate map from address to hostInfo because HashRing doesn't
-		// return the rpmembership.Member that was passed to it, it only returns the address.
+		// ring contains only hosts that are eligible for new RPC traffic. hosts keeps the
+		// full currently known member set so membership change events still capture draining
+		// and stopping nodes until they fully disappear from ringpop gossip.
 		ring  *hashring.HashRing
 		hosts map[string]*hostInfo
 	}
@@ -216,7 +217,7 @@ func (r *serviceResolver) AvailableMemberCount() int {
 	_, hosts := r.ring()
 	n := 0
 	for _, host := range hosts {
-		if !isDraining(host) {
+		if isAvailableForLookup(host) {
 			n++
 		}
 	}
@@ -236,7 +237,7 @@ func (r *serviceResolver) AvailableMembers() []membership.HostInfo {
 	_, hosts := r.ring()
 	var servers []membership.HostInfo
 	for _, host := range hosts {
-		if !isDraining(host) {
+		if isAvailableForLookup(host) {
 			servers = append(servers, host)
 		}
 	}
@@ -295,8 +296,7 @@ func (r *serviceResolver) refreshLocked() (*membership.ChangedEvent, error) {
 		return nil, nil
 	}
 
-	ring := newHashRing(r.replicaPoints)
-	ring.AddMembers(util.MapSlice(hosts, func(h *hostInfo) rpmembership.Member { return h })...)
+	ring := buildLookupRing(hosts, r.replicaPoints)
 
 	r.lastRefreshTime = time.Now().UTC()
 	r.ringAndHosts.Store(ringAndHosts{
@@ -308,7 +308,28 @@ func (r *serviceResolver) refreshLocked() (*membership.ChangedEvent, error) {
 	slices.Sort(addrs)
 	r.logger.Info("Current reachable members", tag.Addresses(addrs))
 
+	dialableAddrs := util.MapSlice(filterHostsForLookup(hosts), func(h *hostInfo) string { return h.summary() })
+	slices.Sort(dialableAddrs)
+	r.logger.Info("Current dialable members", tag.Addresses(dialableAddrs))
+
 	return changedEvent, nil
+}
+
+func buildLookupRing(hosts []*hostInfo, replicaPoints int) *hashring.HashRing {
+	ring := newHashRing(replicaPoints)
+	dialable := util.MapSlice(filterHostsForLookup(hosts), func(host *hostInfo) rpmembership.Member { return host })
+	ring.AddMembers(dialable...)
+	return ring
+}
+
+func filterHostsForLookup(hosts []*hostInfo) []*hostInfo {
+	var dialable []*hostInfo
+	for _, host := range hosts {
+		if isAvailableForLookup(host) {
+			dialable = append(dialable, host)
+		}
+	}
+	return dialable
 }
 
 func (r *serviceResolver) scheduleRefresh(nextEvent int64) {
@@ -530,4 +551,13 @@ func isDraining(host *hostInfo) bool {
 		}
 	}
 	return false
+}
+
+func hasStopAt(host *hostInfo) bool {
+	_, ok := host.Label(stopAtKey)
+	return ok
+}
+
+func isAvailableForLookup(host *hostInfo) bool {
+	return !isDraining(host) && !hasStopAt(host)
 }


### PR DESCRIPTION
## What changed

This change makes `serviceResolver.Lookup()` and `LookupN()` stop routing new RPC traffic to members that are already leaving the ring.

The resolver now:
- keeps the full host set for membership visibility and change events
- builds the lookup ring only from hosts that are still eligible for new traffic
- excludes hosts marked as `draining=true`
- excludes hosts carrying a `stopAt` label
- logs both `Current reachable members` and `Current dialable members`

`AvailableMembers()` and `AvailableMemberCount()` are updated to match: they now also exclude hosts carrying a `stopAt` label, consistent with what `Lookup()` will route to.

The patch also adds tests covering:
- draining hosts being excluded from lookup
- stopping hosts being excluded from lookup

## Why

During rolling restarts on Kubernetes, membership can already know that a peer is draining or stopping, but the resolver still builds its hash ring from the full reachable member set. That makes new pods transiently route traffic to peers that are already leaving, which can cause rollout instability and readiness problems.

This PR follows the behavior described in #10730.

## Impact

Without this change, newly started pods can receive `connection refused`, `Not enough hosts to serve the request`, or `context canceled` errors during a rolling restart, because `Lookup()` may select a peer that membership already knows is draining or stopping. In the worst case, a new pod fails its readiness probe and gets restarted by Kubernetes, extending the rollout window.

With this change, a host is removed from the lookup ring as soon as its membership labels indicate it is leaving — without waiting for its `stopAt` timestamp to expire or for SWIM to mark it as faulty. Existing in-flight requests are unaffected; only new `Lookup()` / `LookupN()` calls are impacted.

## Testing

- `go test ./common/membership/ringpop/...`