### PR TITLE
Unify test runner timeouts across jobs

### DIFF
--- a/.github/workflows/run-single-test.yml
+++ b/.github/workflows/run-single-test.yml
@@ -64,7 +64,9 @@ jobs:
 
       - name: Run unit test
         timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) }}
-        run: make unit-test-coverage
+        run: |
+          export TEST_RUNNER_TIMEOUT="$((${{ inputs.timeout_minutes }} - 1))m"
+          make unit-test-coverage
         env:
           UNIT_TEST_DIRS: ${{ inputs.unit_test_directory }}
           TEST_ARGS: "-run ${{ inputs.test_name }} -count ${{ inputs.n_runs }}"
@@ -154,7 +156,9 @@ jobs:
       - name: Run functional test
         if: ${{ contains(fromJSON(inputs.test_dbs), matrix.name) }}
         timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) }}
-        run: make functional-test-coverage
+        run: |
+          export TEST_RUNNER_TIMEOUT="$((${{ inputs.timeout_minutes }} - 1))m"
+          make functional-test-coverage
         env:
           TEST_ARGS: "-run ${{ inputs.test_name }} -count ${{ inputs.n_runs }}"
           TEST_TIMEOUT: "${{ inputs.timeout_minutes }}m"

--- a/.github/workflows/run-single-test.yml
+++ b/.github/workflows/run-single-test.yml
@@ -64,9 +64,7 @@ jobs:
 
       - name: Run unit test
         timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) }}
-        run: |
-          export TEST_RUNNER_TIMEOUT="$((${{ inputs.timeout_minutes }} - 1))m"
-          make unit-test-coverage
+        run: make unit-test-coverage
         env:
           UNIT_TEST_DIRS: ${{ inputs.unit_test_directory }}
           TEST_ARGS: "-run ${{ inputs.test_name }} -count ${{ inputs.n_runs }}"
@@ -156,9 +154,7 @@ jobs:
       - name: Run functional test
         if: ${{ contains(fromJSON(inputs.test_dbs), matrix.name) }}
         timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) }}
-        run: |
-          export TEST_RUNNER_TIMEOUT="$((${{ inputs.timeout_minutes }} - 1))m"
-          make functional-test-coverage
+        run: make functional-test-coverage
         env:
           TEST_ARGS: "-run ${{ inputs.test_name }} -count ${{ inputs.n_runs }}"
           TEST_TIMEOUT: "${{ inputs.timeout_minutes }}m"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -153,20 +153,24 @@ jobs:
             functest:
               cmd: make functional-test-coverage
               test_timeout: 35m
+              test_runner_timeout: 39m
               github_timeout: 40
               sharded: true
             smoke:
               cmd: make functional-test-coverage
               test_timeout: 5m
+              test_runner_timeout: 9m
               github_timeout: 10
               test_args: '"-run=TestActivityTestSuite|TestSignalWorkflowTestSuite|TestWorkflowTestSuite"'
             ndc:
               cmd: make functional-test-ndc-coverage
               test_timeout: 10m
+              test_runner_timeout: 14m
               github_timeout: 15
             xdc:
               cmd: make functional-test-xdc-coverage
               test_timeout: 30m
+              test_runner_timeout: 34m
               github_timeout: 35
         run: |
           # Convert YAML inputs to JSON for jq.
@@ -293,6 +297,9 @@ jobs:
     name: Unit test
     needs: [pre-build, test-setup]
     runs-on: ${{ needs.test-setup.outputs.runner_arm }}
+    env:
+      TEST_TIMEOUT: 15m
+      TEST_RUNNER_TIMEOUT: 19m
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -318,7 +325,7 @@ jobs:
 
       - name: Run unit tests
         timeout-minutes: 20
-        run: TEST_TIMEOUT=15m ./develop/github/monitor_test.sh make unit-test-coverage
+        run: ./develop/github/monitor_test.sh make unit-test-coverage
 
       - name: Post-test reporting
         if: always()
@@ -335,6 +342,7 @@ jobs:
     runs-on: ${{ needs.test-setup.outputs.runner_arm }}
     env:
       CONTAINERS: cassandra mysql postgresql
+      TEST_RUNNER_TIMEOUT: 14m
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -405,6 +413,7 @@ jobs:
       PERSISTENCE_TYPE: ${{ matrix.persistence_type }}
       PERSISTENCE_DRIVER: ${{ matrix.persistence_driver }}
       TEST_TIMEOUT: ${{ matrix.test_timeout }}
+      TEST_RUNNER_TIMEOUT: ${{ matrix.test_runner_timeout }}
       CONTAINERS: ${{ join(matrix.containers, ' ') }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -447,9 +456,7 @@ jobs:
 
       - name: Run functional test
         timeout-minutes: ${{ matrix.github_timeout }}
-        run: |
-          export TEST_RUNNER_TIMEOUT="$((${{ matrix.github_timeout }} - 1))m"
-          ./develop/github/monitor_test.sh ${{ matrix.cmd }}
+        run: ./develop/github/monitor_test.sh ${{ matrix.cmd }}
         env:
           TEST_TOTAL_SHARDS: ${{ matrix.total_shards }}
           TEST_SHARD_INDEX: ${{ matrix.total_shards && matrix.shard_index }} # guard with total_shards to avoid falsy eval of shard_index=0

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -320,7 +320,7 @@ jobs:
           key: go-${{ runner.os }}${{ runner.arch }}-build-${{ env.COMMIT }}
 
       - name: Run unit tests
-        timeout-minutes: 20
+        timeout-minutes: ${{ fromJSON(env.GITHUB_TIMEOUT) }}
         run: |
           export TEST_RUNNER_TIMEOUT="$(("$GITHUB_TIMEOUT" - 1))m"
           ./develop/github/monitor_test.sh make unit-test-coverage
@@ -378,7 +378,7 @@ jobs:
           services: ${{ env.CONTAINERS }}
 
       - name: Run integration test
-        timeout-minutes: 15
+        timeout-minutes: ${{ fromJSON(env.GITHUB_TIMEOUT) }}
         run: |
           export TEST_RUNNER_TIMEOUT="$(("$GITHUB_TIMEOUT" - 1))m"
           ./develop/github/monitor_test.sh make integration-test-coverage
@@ -456,7 +456,7 @@ jobs:
           services: ${{ env.CONTAINERS }}
 
       - name: Run functional test
-        timeout-minutes: ${{ matrix.github_timeout }}
+        timeout-minutes: ${{ fromJSON(env.GITHUB_TIMEOUT) }}
         run: |
           export TEST_RUNNER_TIMEOUT="$(("$GITHUB_TIMEOUT" - 1))m"
           ./develop/github/monitor_test.sh ${{ matrix.cmd }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -153,24 +153,20 @@ jobs:
             functest:
               cmd: make functional-test-coverage
               test_timeout: 35m
-              test_runner_timeout: 39m
               github_timeout: 40
               sharded: true
             smoke:
               cmd: make functional-test-coverage
               test_timeout: 5m
-              test_runner_timeout: 9m
               github_timeout: 10
               test_args: '"-run=TestActivityTestSuite|TestSignalWorkflowTestSuite|TestWorkflowTestSuite"'
             ndc:
               cmd: make functional-test-ndc-coverage
               test_timeout: 10m
-              test_runner_timeout: 14m
               github_timeout: 15
             xdc:
               cmd: make functional-test-xdc-coverage
               test_timeout: 30m
-              test_runner_timeout: 34m
               github_timeout: 35
         run: |
           # Convert YAML inputs to JSON for jq.
@@ -299,7 +295,7 @@ jobs:
     runs-on: ${{ needs.test-setup.outputs.runner_arm }}
     env:
       TEST_TIMEOUT: 15m
-      TEST_RUNNER_TIMEOUT: 19m
+      GITHUB_TIMEOUT: 20
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -325,7 +321,9 @@ jobs:
 
       - name: Run unit tests
         timeout-minutes: 20
-        run: ./develop/github/monitor_test.sh make unit-test-coverage
+        run: |
+          export TEST_RUNNER_TIMEOUT="$(("$GITHUB_TIMEOUT" - 1))m"
+          ./develop/github/monitor_test.sh make unit-test-coverage
 
       - name: Post-test reporting
         if: always()
@@ -342,7 +340,8 @@ jobs:
     runs-on: ${{ needs.test-setup.outputs.runner_arm }}
     env:
       CONTAINERS: cassandra mysql postgresql
-      TEST_RUNNER_TIMEOUT: 14m
+      TEST_TIMEOUT: 10m
+      GITHUB_TIMEOUT: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -380,7 +379,9 @@ jobs:
 
       - name: Run integration test
         timeout-minutes: 15
-        run: ./develop/github/monitor_test.sh make integration-test-coverage
+        run: |
+          export TEST_RUNNER_TIMEOUT="$(("$GITHUB_TIMEOUT" - 1))m"
+          ./develop/github/monitor_test.sh make integration-test-coverage
 
       - name: Post-test reporting
         if: always()
@@ -413,7 +414,7 @@ jobs:
       PERSISTENCE_TYPE: ${{ matrix.persistence_type }}
       PERSISTENCE_DRIVER: ${{ matrix.persistence_driver }}
       TEST_TIMEOUT: ${{ matrix.test_timeout }}
-      TEST_RUNNER_TIMEOUT: ${{ matrix.test_runner_timeout }}
+      GITHUB_TIMEOUT: ${{ matrix.github_timeout }}
       CONTAINERS: ${{ join(matrix.containers, ' ') }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -456,7 +457,9 @@ jobs:
 
       - name: Run functional test
         timeout-minutes: ${{ matrix.github_timeout }}
-        run: ./develop/github/monitor_test.sh ${{ matrix.cmd }}
+        run: |
+          export TEST_RUNNER_TIMEOUT="$(("$GITHUB_TIMEOUT" - 1))m"
+          ./develop/github/monitor_test.sh ${{ matrix.cmd }}
         env:
           TEST_TOTAL_SHARDS: ${{ matrix.total_shards }}
           TEST_SHARD_INDEX: ${{ matrix.total_shards && matrix.shard_index }} # guard with total_shards to avoid falsy eval of shard_index=0


### PR DESCRIPTION
## What Changed?

Follow-up to https://github.com/temporalio/temporal/pull/10713; unify the timeout setting across all test jobs.