### PR TITLE
Return shallow copy of CHASM custom search attributes and memo

### DIFF
--- a/chasm/lib/nexusoperation/operation.go
+++ b/chasm/lib/nexusoperation/operation.go
@@ -2,7 +2,6 @@ package nexusoperation
 
 import (
 	"fmt"
-	"maps"
 	"strings"
 	"time"
 
@@ -542,10 +541,7 @@ func (o *Operation) buildExecutionInfo(ctx chasm.Context) *nexuspb.NexusOperatio
 		StateTransitionCount:    ctx.ExecutionInfo().StateTransitionCount,
 		StateSizeBytes:          int64(ctx.ExecutionInfo().ApproximateStateSize),
 		SearchAttributes: &commonpb.SearchAttributes{
-			// CustomSearchAttributes returns the component's live map by reference; the
-			// describe response is marshalled after the read lease is released, so clone it
-			// to avoid racing a concurrent mutation (see Scheduler.Describe for the same fix).
-			IndexedFields: maps.Clone(o.Visibility.Get(ctx).CustomSearchAttributes(ctx)),
+			IndexedFields: o.Visibility.Get(ctx).CustomSearchAttributes(ctx),
 		},
 		NexusHeader:  requestData.GetNexusHeader(),
 		UserMetadata: requestData.GetUserMetadata(),

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -3,7 +3,6 @@ package scheduler
 import (
 	"bytes"
 	"fmt"
-	"maps"
 	"slices"
 	"strings"
 	"time"
@@ -651,10 +650,7 @@ func (s *Scheduler) Describe(
 
 	visibility := s.Visibility.Get(ctx)
 	// CustomMemo/CustomSearchAttributes return the component's live maps by reference.
-	// Clone before mutating or returning: the response is marshalled after the read lease
-	// is released, so an aliased map can be iterated by gRPC while a concurrent operation
-	// mutates it, tripping "concurrent map iteration and map write".
-	memo := maps.Clone(visibility.CustomMemo(ctx))
+	memo := visibility.CustomMemo(ctx)
 	delete(memo, visibilityMemoFieldInfo) // We don't need to return a redundant info block.
 
 	if s.Schedule.GetPolicies().GetOverlapPolicy() == enumspb.SCHEDULE_OVERLAP_POLICY_UNSPECIFIED {
@@ -695,7 +691,7 @@ func (s *Scheduler) Describe(
 			Info:             info,
 			ConflictToken:    s.generateConflictToken(),
 			Memo:             &commonpb.Memo{Fields: memo},
-			SearchAttributes: &commonpb.SearchAttributes{IndexedFields: maps.Clone(visibility.CustomSearchAttributes(ctx))},
+			SearchAttributes: &commonpb.SearchAttributes{IndexedFields: visibility.CustomSearchAttributes(ctx)},
 		},
 	}, nil
 }

--- a/chasm/lib/scheduler/scheduler_migrate_task.go
+++ b/chasm/lib/scheduler/scheduler_migrate_task.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"time"
 
 	"github.com/google/uuid"
@@ -215,7 +214,7 @@ func (h *SchedulerMigrateToWorkflowTaskHandler) Execute(
 		Identity:                 fmt.Sprintf("temporal-scheduler-migration-%s-%s", result.namespace, result.scheduleID),
 		WorkflowIdReusePolicy:    enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
 		WorkflowIdConflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL,
-		Memo:                     &commonpb.Memo{Fields: maps.Clone(result.memo)},
+		Memo:                     &commonpb.Memo{Fields: result.memo},
 		SearchAttributes:         sa,
 		Priority:                 &commonpb.Priority{},
 	}

--- a/chasm/visibility.go
+++ b/chasm/visibility.go
@@ -3,6 +3,7 @@ package chasm
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -193,14 +194,14 @@ func (v *Visibility) LifecycleState(_ Context) LifecycleState {
 // CustomSearchAttributes returns the stored custom search attribute fields.
 // Nil is returned if there are none.
 //
-// Returned map is NOT a deep copy of the underlying data, so do NOT modify it
-// directly, use Merge/ReplaceCustomSearchAttributes methods instead.
+// Returned map is a shallow copy: callers may add, delete, or reassign keys without
+// affecting the stored data, but the *commonpb.Payload values are shared.
 func (v *Visibility) CustomSearchAttributes(
 	chasmContext Context,
 ) map[string]*commonpb.Payload {
 	sa, _ := v.SA.TryGet(chasmContext)
 	// nil check handled by the proto getter.
-	return sa.GetIndexedFields()
+	return maps.Clone(sa.GetIndexedFields())
 }
 
 // MergeCustomSearchAttributes merges the provided custom search attribute fields into the existing ones.
@@ -266,14 +267,14 @@ func (v *Visibility) ReplaceCustomSearchAttributes(
 // CustomMemo returns the stored custom memo fields.
 // Nil is returned if there are none.
 //
-// Returned map is NOT a deep copy of the underlying data, so do NOT modify it
-// directly, use Merge/ReplaceCustomMemo methods instead.
+// Returned map is a shallow copy: callers may add, delete, or reassign keys without
+// affecting the stored data, but the *commonpb.Payload values are shared.
 func (v *Visibility) CustomMemo(
 	chasmContext Context,
 ) map[string]*commonpb.Payload {
 	memo, _ := v.Memo.TryGet(chasmContext)
 	// nil check handled by the proto getter.
-	return memo.GetFields()
+	return maps.Clone(memo.GetFields())
 }
 
 // MergeCustomMemo merges the provided custom memo fields into the existing ones.


### PR DESCRIPTION
## What changed?
Return shallow copy of CHASM custom search attributes and memo.

## Why?
Multiple caller sites needed to deep copy the CHASM Visibility provided search attributes and memo to address potential race conditions and avoid modifying the underlying search attributes.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)
