### PR TITLE
Extend version compatibility check to Ruby DotNet SDKs

### DIFF
--- a/common/headers/version_checker.go
+++ b/common/headers/version_checker.go
@@ -20,6 +20,8 @@ const (
 	ClientNameCLI           = "temporal-cli"
 	ClientNameUI            = "temporal-ui"
 	ClientNameNexusGoSDK    = "Nexus-go-sdk"
+	ClientNameDotNetSDK     = "temporal-dotnet"
+	ClientNameRubySDK       = "temporal-ruby"
 
 	// ServerVersion value can be changed by the create-tag Github workflow.
 	// If you change the var name or move it, be sure to update the workflow.
@@ -41,6 +43,10 @@ var (
 		FeatureFollowsNextRunID,
 	}, SupportedFeaturesHeaderDelim)
 
+	// SupportedClients maps a client name to the range of versions this server supports.
+	// Listed clients have their version validated by semver.Parse, so only SDKs that always
+	// report valid semver may be added. Python is omitted, as it has versions like "0.1a1"
+	// which fail to parse
 	SupportedClients = map[string]string{
 		ClientNameGoSDK:         "<2.0.0",
 		ClientNameJavaSDK:       "<2.0.0",
@@ -50,6 +56,8 @@ var (
 		ClientNameServer:        "<2.0.0",
 		ClientNameUI:            "<3.0.0",
 		ClientNameNexusGoSDK:    "<2.0.0",
+		ClientNameDotNetSDK:     "<2.0.0",
+		ClientNameRubySDK:       "<2.0.0",
 	}
 
 	internalVersionHeaderPairs = []string{

--- a/common/headers/version_checker_test.go
+++ b/common/headers/version_checker_test.go
@@ -112,6 +112,32 @@ func (s *VersionCheckerSuite) TestClientSupported() {
 	}
 }
 
+func (s *VersionCheckerSuite) TestClientSupported_DefaultSupportedClients() {
+	versionChecker := NewDefaultVersionChecker()
+
+	testCases := []struct {
+		clientName    string
+		clientVersion string
+		expectErr     bool
+	}{
+		{ClientNameDotNetSDK, "1.14.0", false},
+		{ClientNameDotNetSDK, "2.0.0", true},
+		{ClientNameRubySDK, "1.5.0", false},
+		{ClientNameRubySDK, "2.0.0", true},
+	}
+
+	for caseIndex, tc := range testCases {
+		ctx := s.constructCallContext(tc.clientVersion, tc.clientName, "", "")
+		err := versionChecker.ClientSupported(ctx)
+		if tc.expectErr {
+			s.Errorf(err, "Case #%d (%s %s)", caseIndex, tc.clientName, tc.clientVersion)
+			s.IsType(&serviceerror.ClientVersionNotSupported{}, err, "Case #%d", caseIndex)
+		} else {
+			s.NoErrorf(err, "Case #%d (%s %s)", caseIndex, tc.clientName, tc.clientVersion)
+		}
+	}
+}
+
 func (s *VersionCheckerSuite) constructCallContext(clientVersion, clientName, supportedServerVersions, supportedFeatures string) context.Context {
 	return SetVersionsForTests(context.Background(), clientVersion, clientName, supportedServerVersions, supportedFeatures)
 }


### PR DESCRIPTION
## What changed?
Added Python, .NET, Ruby client names to version checker, each gated to <2.0.0. This brings these SDKs in line with the other clients, which were already version-checked. Added a unit test covering the new entries.

## Why?
These SDKs send a distinct client-name header (`temporal-python`, `temporal-dotnet`, `temporal-ruby`) but were absent from the SupportedClients map, so their client versions were never validated by ClientSupported. All three are on stable 1.x versions (Python 1.25, .NET 1.14, Ruby 1.5), so <2.0.0 matches and lets the server reject an incompatible future major. The Rust SDK is intentionally left out as it is not GA-ed yet.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
If the analysis is wrong, we may start rejecting valid SDK version of Python SDK or .NET SDK or Ruby SDK
