### PR TITLE
Fix MergeMapOfPayload to account for null encoded values

### DIFF
--- a/common/payload/payload.go
+++ b/common/payload/payload.go
@@ -12,8 +12,9 @@ import (
 var (
 	defaultDataConverter = converter.GetDefaultDataConverter()
 
-	nilPayload, _        = Encode(nil)
-	emptySlicePayload, _ = Encode([]string{})
+	nilPayload, _        = Encode(nil)           // Data: nil
+	nilSlicePayload, _   = Encode([]string(nil)) // Data: "null" (nil value is json encoded as null)
+	emptySlicePayload, _ = Encode([]string{})    // Data: "[]"
 )
 
 func EncodeString(str string) *commonpb.Payload {
@@ -71,7 +72,7 @@ func MergeMapOfPayload(
 	}
 	res := util.CloneMapNonNil(dst)
 	for k, v := range src {
-		if isEqual(v, nilPayload) || isEqual(v, emptySlicePayload) {
+		if isNilPayload(v) {
 			delete(res, k)
 		} else {
 			res[k] = v
@@ -80,15 +81,17 @@ func MergeMapOfPayload(
 	return res
 }
 
-// isEqual returns true if both have the same encoding and data.
-// It does not take additional metadata into consideration.
-// Note that data equality it's not the same as semantic equality, ie.,
-// `[]` and `[ ]` are semantically the same, but different not data-wise.
-// Only use if you know that the data is encoded the same way.
-func isEqual(a, b *commonpb.Payload) bool {
-	aEnc := a.GetMetadata()[converter.MetadataEncoding]
-	bEnc := a.GetMetadata()[converter.MetadataEncoding]
-	return bytes.Equal(aEnc, bEnc) && bytes.Equal(a.GetData(), b.GetData())
+// isNilPayload checks if the payload is equivalent to nil.
+// There are four cases:
+// - payload object is nil
+// - payload's data is nil
+// - payload's data is "null" (json encoded value for nil objects)
+// - payload's data is "[]" (empty slice for backwards compatibility)
+func isNilPayload(p *commonpb.Payload) bool {
+	return p == nil ||
+		bytes.Equal(p.Data, nilPayload.Data) ||
+		bytes.Equal(p.Data, nilSlicePayload.Data) ||
+		bytes.Equal(p.Data, emptySlicePayload.Data)
 }
 
 // FilterNilSearchAttributes returns a new SearchAttributes with nil/empty payload values filtered out.

--- a/common/payload/payload_test.go
+++ b/common/payload/payload_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 )
 
@@ -89,70 +90,49 @@ func TestEncodeDecode(t *testing.T) {
 }
 
 func TestMergeMapOfPayload(t *testing.T) {
-	s := assert.New(t)
+	t.Run("nil map", func(t *testing.T) {
+		var currentMap map[string]*commonpb.Payload
+		var newMap map[string]*commonpb.Payload
+		resultMap := MergeMapOfPayload(currentMap, newMap)
+		require.Equal(t, newMap, resultMap)
+	})
 
-	var currentMap map[string]*commonpb.Payload
-	var newMap map[string]*commonpb.Payload
-	resultMap := MergeMapOfPayload(currentMap, newMap)
-	s.Equal(newMap, resultMap)
+	t.Run("empty map", func(t *testing.T) {
+		var currentMap map[string]*commonpb.Payload
+		newMap := make(map[string]*commonpb.Payload)
+		resultMap := MergeMapOfPayload(currentMap, newMap)
+		require.Equal(t, newMap, resultMap)
+	})
 
-	newMap = make(map[string]*commonpb.Payload)
-	resultMap = MergeMapOfPayload(currentMap, newMap)
-	s.Equal(newMap, resultMap)
+	t.Run("nil map merging key with string value", func(t *testing.T) {
+		var currentMap map[string]*commonpb.Payload
+		newMap := map[string]*commonpb.Payload{"key": EncodeString("val")}
+		resultMap := MergeMapOfPayload(currentMap, newMap)
+		require.Equal(t, newMap, resultMap)
+	})
 
-	newMap = map[string]*commonpb.Payload{"key": EncodeString("val")}
-	resultMap = MergeMapOfPayload(currentMap, newMap)
-	s.Equal(newMap, resultMap)
+	t.Run("non nil maps", func(t *testing.T) {
+		currentMap := map[string]*commonpb.Payload{"number": EncodeString("1")}
+		newMap := map[string]*commonpb.Payload{"key": EncodeString("val")}
+		resultMap := MergeMapOfPayload(currentMap, newMap)
+		require.Equal(
+			t,
+			map[string]*commonpb.Payload{"number": EncodeString("1"), "key": EncodeString("val")},
+			resultMap,
+		)
+	})
 
-	newMap = map[string]*commonpb.Payload{
-		"key":        EncodeString("val"),
-		"nil":        nilPayload,
-		"emptyArray": emptySlicePayload,
-	}
-	resultMap = MergeMapOfPayload(currentMap, newMap)
-	s.Equal(map[string]*commonpb.Payload{"key": EncodeString("val")}, resultMap)
-
-	currentMap = map[string]*commonpb.Payload{"number": EncodeString("1")}
-	resultMap = MergeMapOfPayload(currentMap, newMap)
-	s.Equal(
-		map[string]*commonpb.Payload{"number": EncodeString("1"), "key": EncodeString("val")},
-		resultMap,
-	)
-
-	newValue, _ := Encode(nil)
-	newMap = map[string]*commonpb.Payload{"number": newValue}
-	resultMap = MergeMapOfPayload(currentMap, newMap)
-	s.Equal(0, len(resultMap))
-
-	newValue, _ = Encode([]int{})
-	newValue.Metadata["key"] = []byte("foo")
-	newMap = map[string]*commonpb.Payload{"number": newValue}
-	resultMap = MergeMapOfPayload(currentMap, newMap)
-	s.Equal(0, len(resultMap))
-}
-
-func TestIsEqual(t *testing.T) {
-	s := assert.New(t)
-
-	a, _ := Encode(nil)
-	b, _ := Encode(nil)
-	s.True(isEqual(a, b))
-
-	a, _ = Encode([]string{})
-	b, _ = Encode([]string{})
-	s.True(isEqual(a, b))
-
-	a.Metadata["key"] = []byte("foo")
-	b.Metadata["key"] = []byte("bar")
-	s.True(isEqual(a, b))
-
-	a, _ = Encode(nil)
-	b, _ = Encode([]string{})
-	s.False(isEqual(a, b))
-
-	a, _ = Encode([]string{})
-	b, _ = Encode("foo")
-	s.False(isEqual(a, b))
+	t.Run("nil payloads are filtered", func(t *testing.T) {
+		var currentMap map[string]*commonpb.Payload
+		newMap := map[string]*commonpb.Payload{
+			"key":        EncodeString("val"),
+			"nil":        {},
+			"nilSlice":   {Data: []byte("null")}, // nil slice is encoded as null json value
+			"emptySlice": {Data: []byte("[]")},
+		}
+		resultMap := MergeMapOfPayload(currentMap, newMap)
+		require.Equal(t, map[string]*commonpb.Payload{"key": EncodeString("val")}, resultMap)
+	})
 }
 
 func TestFilterNilSearchAttributes(t *testing.T) {


### PR DESCRIPTION
## What changed?
Fix MergeMapOfPayload to account for null encoded values.

## Why?
The payload encoder encodes the value of `var s []string` using JSON as `"null"`.
It doesn't actually uses the `NilEncoder`.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

