### PR TITLE
Evict closed connections in CachingRedirector

### DIFF
--- a/client/history/caching_redirector.go
+++ b/client/history/caching_redirector.go
@@ -16,6 +16,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/membership"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
+	"google.golang.org/grpc/connectivity"
 )
 
 type (
@@ -103,6 +104,11 @@ func (r *CachingRedirector[C]) redirectLoop(ctx context.Context, opEntry cacheEn
 		}
 		opErr := op(ctx, opEntry.connection.grpcClient)
 		if opErr == nil {
+			return opErr
+		}
+		// If the underlying connection was closed by the connection pool, remove it from the cache.
+		if opEntry.connection.grpcConn.GetState() == connectivity.Shutdown {
+			r.cacheDeleteByAddress(opEntry.address)
 			return opErr
 		}
 		if maybeHostDownError(opErr) {

--- a/client/history/caching_redirector_test.go
+++ b/client/history/caching_redirector_test.go
@@ -173,6 +173,56 @@ func (s *cachingRedirectorSuite) TestUnavailableError() {
 		})
 }
 
+func (s *cachingRedirectorSuite) TestClosedConn() {
+	testAddr := rpcAddress("testaddr")
+	shardID := int32(1)
+
+	// Resolver should see two lookups: One before connection pool eviction, one after.
+	s.resolver.EXPECT().
+		Lookup(convert.Int32ToString(shardID)).
+		Return(membership.NewHostInfoFromAddress(string(testAddr)), nil).
+		Times(2)
+
+	mockClient := historyservicemock.NewMockHistoryServiceClient(s.controller)
+	s.connections.client = mockClient
+
+	r := s.newCachingDirector(0)
+	defer r.stop()
+
+	// Populate the redirector cache
+	err := r.Execute(context.Background(), shardID,
+		func(_ context.Context, _ historyservice.HistoryServiceClient) error {
+			return nil
+		})
+	s.NoError(err)
+
+	// Emulate Close then evict on underlying connection pool.
+	conn := s.connections.getOrCreateClientConn(testAddr)
+	reaped := conn.grpcConn
+	s.NoError(reaped.Close())
+	s.connections.conn = nil
+
+	// Redirector should evict its reference to the closed connection and return an error.
+	err = r.Execute(context.Background(), shardID,
+		func(_ context.Context, _ historyservice.HistoryServiceClient) error {
+			// Emulate closed connection error behavior
+			return serviceerror.NewCanceled("grpc: the client connection is closing")
+		})
+	s.Error(err)
+
+	// Repopulate the cache
+	err = r.Execute(context.Background(), shardID,
+		func(_ context.Context, _ historyservice.HistoryServiceClient) error {
+			return nil
+		})
+	s.NoError(err)
+
+	// Inspect the redirector cache directly to confirm a new connection.
+	entry, err := r.getOrCreateEntry(shardID)
+	s.NoError(err)
+	s.NotSame(reaped, entry.connection.grpcConn)
+}
+
 func (s *cachingRedirectorSuite) TestShardOwnershipLostErrors() {
 	testAddr1 := rpcAddress("testaddr1")
 	testAddr2 := rpcAddress("testaddr2")

--- a/client/history/redirector_test.go
+++ b/client/history/redirector_test.go
@@ -15,6 +15,8 @@ import (
 	"go.temporal.io/server/common/membership"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 type (
@@ -32,10 +34,15 @@ type mockConnectionPool[C any] struct {
 	connectionPool[C]
 	client     C
 	resetCalls int
+	conn       *grpc.ClientConn
 }
 
 func (m *mockConnectionPool[C]) getOrCreateClientConn(testAddr rpcAddress) clientConnection[C] {
-	return clientConnection[C]{grpcClient: m.client}
+	if m.conn == nil {
+		m.conn, _ = grpc.NewClient("passthrough:///unused",
+			grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+	return clientConnection[C]{grpcClient: m.client, grpcConn: m.conn}
 }
 
 func (m *mockConnectionPool[C]) resetConnectBackoff(clientConnection[C]) {

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1826,13 +1826,17 @@ to this require a restart to take effect.`,
 		"history.clientOwnershipCachingUnusedTTL",
 		30*time.Second,
 		`HistoryClientOwnershipCachingStaleTTL, if non-zero, configures the TTL
-for cached shard ownership entries after a membership update.`,
+for cached shard ownership entries after a membership update.
+Should be less than history.connectionCloseDelay so that connections are not
+closed while still cached.`,
 	)
 	HistoryConnectionCloseDelay = NewGlobalDurationSetting(
 		"history.connectionCloseDelay",
-		30*time.Second,
+		60*time.Second,
 		`HistoryConnectionCloseDelay delays closing a cached history connection after its host leaves
-the membership ring, giving in-flight RPCs time to drain before the connection is closed.`,
+the membership ring, giving in-flight RPCs time to drain before the connection is closed.
+Should be greater than history.clientOwnershipCachingUnusedTTL so that connections are not closed
+while still cached.`,
 	)
 	ShardIOConcurrency = NewGlobalIntSetting(
 		"history.shardIOConcurrency",


### PR DESCRIPTION
## What changed?

This PR updates `CachingRedirector` to evict closed connections. 

## Why?

#10250 updated the connection pool to close conns when hosts leave the membership ring. `CachingRedirector` maintains its own cache of the `grpc.ClientConn` instances and receives `Canceled` errors when it attempts to use a closed connection. `maybeHostDownError` doesn't handle `Canceled`, so the corresponding redirector cache entry is not invalidated.

In rare cases, the `CachingRedirector` stale entry check also fails to detect the invalid cache entry, allowing it to persist indefinitely. Once this occurs, all client requests routed through that entry fail. 

## How did you test it?
- [x] built
- [x] added new unit test(s)
