### PR TITLE
Make defensive copies of Nexus request headers

### DIFF
--- a/chasm/lib/nexusoperation/cancellation.go
+++ b/chasm/lib/nexusoperation/cancellation.go
@@ -1,6 +1,7 @@
 package nexusoperation
 
 import (
+	"maps"
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -122,7 +123,7 @@ func (c *Cancellation) loadArgs(
 		startedTime:            op.GetStartedTime().AsTime(),
 		scheduleToCloseTimeout: op.GetScheduleToCloseTimeout().AsDuration(),
 		startToCloseTimeout:    op.GetStartToCloseTimeout().AsDuration(),
-		headers:                invocationData.Header,
+		headers:                maps.Clone(invocationData.Header),
 		payload:                invocationData.Input,
 	}, nil
 }

--- a/chasm/lib/nexusoperation/cancellation_tasks_test.go
+++ b/chasm/lib/nexusoperation/cancellation_tasks_test.go
@@ -299,7 +299,8 @@ func TestCancellationLoadArgs_StandaloneFallsBackToRequestData(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 	protorequire.ProtoEqual(t, input, args.payload)
-	require.Equal(t, headers, args.headers)
+	require.NotSame(t, &headers, &args.headers) // Confirm we make a copy.
+	require.Equal(t, headers, args.headers)     // But they are structually equivalent.
 }
 
 func TestCancellationInvocationTaskHandler_HTTP(t *testing.T) {

--- a/chasm/lib/nexusoperation/operation.go
+++ b/chasm/lib/nexusoperation/operation.go
@@ -327,7 +327,7 @@ func (o *Operation) loadStartArgs(
 		scheduleToStartTimeout: o.GetScheduleToStartTimeout().AsDuration(),
 		startToCloseTimeout:    o.GetStartToCloseTimeout().AsDuration(),
 		payload:                invocationData.Input,
-		header:                 invocationData.Header,
+		header:                 maps.Clone(invocationData.Header),
 		nexusLinks:             invocationData.NexusLinks,
 		serializedRef:          serializedRef,
 	}, nil

--- a/chasm/lib/nexusoperation/operation_tasks.go
+++ b/chasm/lib/nexusoperation/operation_tasks.go
@@ -215,6 +215,7 @@ func (h *operationInvocationTaskHandler) Execute(
 	return saveErr
 }
 
+// buildRequestHeader returns a copy of the supplied header, or a new map if nil.
 func buildRequestHeader(header map[string]string) nexus.Header {
 	if header == nil {
 		return make(nexus.Header, 2) // To set the failure support and timeout headers.


### PR DESCRIPTION
## What changed?

Make copies of the HTTP headers for the Nexus Operation CHASM component.

## Why?

It's possible that the headers we load are just a pointer to some lower-level component. And since we mutate those headers in some situations, it can theoretically lead to a panic.

This was addressed in the HSM-implementation in https://github.com/temporalio/temporal/pull/10720. This PR just covers the CHASM version.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

None I can think of.
