### PR TITLE
Build only Linux binaries for Docker

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -12,7 +12,34 @@ permissions:
   contents: read
 
 jobs:
+  build-binaries:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Build binaries
+        uses: ./.github/actions/build-binaries
+        with:
+          single-arch: ${{ matrix.arch }}
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: binaries-${{ matrix.arch }}
+          path: dist/*_linux_*
+          if-no-files-found: error
+          retention-days: 1
+
   build-and-push-docker:
+    needs: build-binaries
     runs-on: ubuntu-latest
     timeout-minutes: 90
     # Only push for main, cloud, release branches (not feature)
@@ -27,10 +54,18 @@ jobs:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
-      - name: Build binaries
-        uses: ./.github/actions/build-binaries
+      - name: Download binaries
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
-          snapshot: true
+          pattern: binaries-*
+          merge-multiple: true
+          path: dist
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "go.mod"
+          cache: true
 
       - name: Build and push Docker images
         uses: ./.github/actions/build-docker-images
@@ -42,6 +77,7 @@ jobs:
 
   # For feature branches, just build (no push)
   build-docker-feature:
+    needs: build-binaries
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/feature/')
     steps:
@@ -51,10 +87,18 @@ jobs:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
-      - name: Build binaries
-        uses: ./.github/actions/build-binaries
+      - name: Download binaries
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
-          snapshot: true
+          pattern: binaries-*
+          merge-multiple: true
+          path: dist
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "go.mod"
+          cache: true
 
       - name: Build Docker images
         uses: ./.github/actions/build-docker-images

--- a/.github/workflows/docker-build-manual.yml
+++ b/.github/workflows/docker-build-manual.yml
@@ -25,8 +25,12 @@ permissions:
   contents: read
 
 jobs:
-  build-docker:
+  build-binaries:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -36,7 +40,37 @@ jobs:
       - name: Build binaries
         uses: ./.github/actions/build-binaries
         with:
-          snapshot: true
+          single-arch: ${{ matrix.arch }}
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: binaries-${{ matrix.arch }}
+          path: dist/*_linux_*
+          if-no-files-found: error
+          retention-days: 1
+
+  build-docker:
+    needs: build-binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Download binaries
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          pattern: binaries-*
+          merge-multiple: true
+          path: dist
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "go.mod"
+          cache: true
 
       - name: Build Docker images
         id: build-docker


### PR DESCRIPTION
## What changed?

The existing GitHub Docker workflows are building binaries for all OSes but only use Linux. This changes it to only build the Linux binaries.

## Why?

1. The windows and OSX binaries aren't used; so this is faster.

2. Using the native arm64 runner is also than QEMU.

3. Recently [build have run out of space](https://github.com/temporalio/temporal/actions/runs/27667258696/job/81824007045).
```
    │ /opt/hostedtoolcache/go/1.26.4/x64/pkg/tool/linux_amd64/link: mapping output file failed: no space left on device
```

## Testing

Successfully triggered [manual run](https://github.com/temporalio/temporal/actions/runs/27697167809).
