### PR TITLE
Restore start_delay on Reset+RestoreOriginalOptions for standalone activities

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1,3 +1,21 @@
+// A note on times and terminology:
+//
+// We name 3 times in the lifecycle of an activity attempt:
+//
+// schedule time - the time at which the activity entered SCHEDULED state
+// dispatch time - the time at which the activity task will be dispatched to Matching (AddActivityTask)
+// start time    - the time at which the activity enters STARTED state (Matching task picked up by poller)
+//
+// They are always ordered as: (schedule time) <= (dispatch time) < (start time).
+//
+// A ScheduleToStart timeout applies to the time between dispatch and start. If there is a delay
+// before dispatch (i.e. a start delay on the first attempt, or a backoff interval / next retry
+// delay on a second or subsequent attempt) then schedule time < dispatch time. Otherwise, they are
+// equal.
+//
+// The main Activity struct has a.ScheduleTime which is the schedule time of the first
+// attempt; i.e. the time at which the activity was created. This is never changed.
+
 package activity
 
 import (
@@ -303,17 +321,17 @@ func (a *Activity) GenerateRecordActivityTaskStartedResponse(
 
 // attemptScheduleTime returns when the given attempt was scheduled to run:
 // the activity's schedule time plus start delay for the first attempt, or
-// calculated from attemptScheduleTimeForRetry on retries.
+// calculated from dispatchTimeForRetry on retries.
 func (a *Activity) attemptScheduleTime(attempt *activitypb.ActivityAttemptState) *timestamppb.Timestamp {
 	if attempt.GetCount() == 1 {
 		return timestamppb.New(a.firstDispatchTime())
 	}
-	return attemptScheduleTimeForRetry(attempt)
+	return dispatchTimeForRetry(attempt)
 }
 
-// attemptScheduleTimeForRetry computes the time a retried attempt is scheduled to start,
+// dispatchTimeForRetry computes the time a retried attempt will be dispatched to Matching,
 // as complete_time + retry_interval. Returns nil if either field is missing or zero.
-func attemptScheduleTimeForRetry(attempt *activitypb.ActivityAttemptState) *timestamppb.Timestamp {
+func dispatchTimeForRetry(attempt *activitypb.ActivityAttemptState) *timestamppb.Timestamp {
 	retryInterval := attempt.GetCurrentRetryInterval()
 	completeTime := attempt.GetCompleteTime()
 	if retryInterval != nil && retryInterval.AsDuration() > 0 && completeTime != nil {
@@ -692,7 +710,7 @@ func (a *Activity) UpdateActivityExecutionOptions(
 
 	a.reissueRunningAttemptTimers(ctx, attempt)
 	if a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED {
-		a.reissueScheduledDispatch(ctx, attempt)
+		a.reissueDispatchAndScheduleToStart(ctx, attempt)
 	}
 
 	metricsHandler, err := a.enrichMetricsHandler(ctx, metrics.ActivityUpdateOptionsScope)
@@ -918,19 +936,20 @@ func (a *Activity) unpause(
 	}
 	attempt.Stamp++
 	attempt.CurrentRetryInterval = nil
-	scheduleTime := ctx.Now(a)
+	unpauseTime := ctx.Now(a)
 	if jitter := event.req.GetJitter().AsDuration(); jitter > 0 {
-		scheduleTime = scheduleTime.Add(time.Duration(rand.Int63n(int64(jitter)))) //nolint:gosec
+		unpauseTime = unpauseTime.Add(time.Duration(rand.Int63n(int64(jitter)))) //nolint:gosec
 	}
+	dispatchTime := a.dispatchTimeRespectingStartDelay(unpauseTime)
 	if timeout := a.GetScheduleToStartTimeout().AsDuration(); timeout > 0 {
 		ctx.AddTask(
 			a,
-			chasm.TaskAttributes{ScheduledTime: scheduleTime.Add(timeout)},
+			chasm.TaskAttributes{ScheduledTime: dispatchTime.Add(timeout)},
 			&activitypb.ScheduleToStartTimeoutTask{Stamp: attempt.GetStamp()})
 	}
 	ctx.AddTask(
 		a,
-		chasm.TaskAttributes{ScheduledTime: scheduleTime},
+		chasm.TaskAttributes{ScheduledTime: dispatchTime},
 		&activitypb.ActivityDispatchTask{Stamp: attempt.GetStamp()})
 }
 
@@ -965,13 +984,13 @@ func (a *Activity) reset(ctx chasm.MutableContext, event resetEvent) {
 	if timeout := a.GetScheduleToStartTimeout().AsDuration(); timeout > 0 {
 		ctx.AddTask(
 			a,
-			chasm.TaskAttributes{ScheduledTime: event.scheduleTime.Add(timeout)},
+			chasm.TaskAttributes{ScheduledTime: event.resetTime.Add(timeout)},
 			&activitypb.ScheduleToStartTimeoutTask{Stamp: attempt.GetStamp()},
 		)
 	}
 	ctx.AddTask(
 		a,
-		chasm.TaskAttributes{ScheduledTime: event.scheduleTime},
+		chasm.TaskAttributes{ScheduledTime: event.resetTime},
 		&activitypb.ActivityDispatchTask{Stamp: attempt.GetStamp()},
 	)
 	a.emitOnResetMetrics(event.handler)
@@ -993,9 +1012,9 @@ func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetAc
 		return nil, err
 	}
 
-	scheduleTime := ctx.Now(a)
+	resetTime := ctx.Now(a)
 	if jitter := frontendReq.GetJitter().AsDuration(); jitter > 0 {
-		scheduleTime = scheduleTime.Add(time.Duration(rand.Int63n(int64(jitter)))) //nolint:gosec
+		resetTime = resetTime.Add(time.Duration(rand.Int63n(int64(jitter)))) //nolint:gosec
 	}
 
 	if frontendReq.GetRestoreOriginalOptions() {
@@ -1012,7 +1031,7 @@ func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetAc
 		// the original value would shift ScheduleToClose without affecting dispatch timing.
 		if a.GetFirstAttemptStartedTime() == nil {
 			a.StartDelay = common.CloneProto(ogOptions.GetStartDelay())
-			scheduleTime = a.respectStartDelay(scheduleTime)
+			resetTime = a.dispatchTimeRespectingStartDelay(resetTime)
 		}
 	}
 
@@ -1062,9 +1081,9 @@ func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetAc
 
 	case activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED:
 		if err := TransitionReset.Apply(a, ctx, resetEvent{
-			req:          frontendReq,
-			scheduleTime: scheduleTime,
-			handler:      metricsHandler,
+			req:       frontendReq,
+			resetTime: resetTime,
+			handler:   metricsHandler,
 		}); err != nil {
 			return nil, err
 		}
@@ -1201,25 +1220,25 @@ func (a *Activity) firstDispatchTime() time.Time {
 	return a.ScheduleTime.AsTime().Add(a.GetStartDelay().AsDuration())
 }
 
-// reissueScheduledDispatch re-emits the ActivityDispatchTask and ScheduleToStart timeout task for
+// reissueDispatchAndScheduleToStart re-emits the ActivityDispatchTask and ScheduleToStart timeout task for
 // a SCHEDULED activity. Retries fire at the retry time; first attempts dispatch now, lifted to
 // honor any pending start_delay.
-func (a *Activity) reissueScheduledDispatch(ctx chasm.MutableContext, attempt *activitypb.ActivityAttemptState) {
-	var scheduleTime time.Time
-	if retryTime := attemptScheduleTimeForRetry(attempt); retryTime != nil {
-		scheduleTime = retryTime.AsTime()
+func (a *Activity) reissueDispatchAndScheduleToStart(ctx chasm.MutableContext, attempt *activitypb.ActivityAttemptState) {
+	var dispatchTime time.Time
+	if retryDispatchTime := dispatchTimeForRetry(attempt); retryDispatchTime != nil {
+		dispatchTime = retryDispatchTime.AsTime()
 	} else {
-		scheduleTime = a.respectStartDelay(ctx.Now(a))
+		dispatchTime = a.dispatchTimeRespectingStartDelay(ctx.Now(a))
 	}
 	ctx.AddTask(
 		a,
-		chasm.TaskAttributes{ScheduledTime: scheduleTime},
+		chasm.TaskAttributes{ScheduledTime: dispatchTime},
 		&activitypb.ActivityDispatchTask{Stamp: attempt.GetStamp()},
 	)
 	if timeout := a.GetScheduleToStartTimeout().AsDuration(); timeout > 0 {
 		ctx.AddTask(
 			a,
-			chasm.TaskAttributes{ScheduledTime: scheduleTime.Add(timeout)},
+			chasm.TaskAttributes{ScheduledTime: dispatchTime.Add(timeout)},
 			&activitypb.ScheduleToStartTimeoutTask{Stamp: attempt.GetStamp()},
 		)
 	}
@@ -1260,17 +1279,18 @@ func (a *Activity) reissueRunningAttemptTimers(ctx chasm.MutableContext, attempt
 	}
 }
 
-// respectStartDelay lifts a candidate dispatch time up to scheduleTime + start_delay when the
-// activity has not yet been picked up by a worker, so pre-dispatch re-scheduling (unpause, Reset+
-// RestoreOriginalOptions, options update) honors start_delay. No-op once dispatched.
-func (a *Activity) respectStartDelay(scheduleTime time.Time) time.Time {
+// dispatchTimeRespectingStartDelay advances a candidate dispatch time t to the first dispatch time
+// (ScheduleTime + start_delay) while the activity has not yet been picked up by a worker, so that
+// pre-dispatch re-scheduling (unpause, reset, options update) honors any remaining start_delay.
+// Returns t unchanged if the first attempt has already started.
+func (a *Activity) dispatchTimeRespectingStartDelay(t time.Time) time.Time {
 	if a.GetFirstAttemptStartedTime() != nil {
-		return scheduleTime
+		return t
 	}
-	if firstDispatch := a.firstDispatchTime(); firstDispatch.After(scheduleTime) {
-		return firstDispatch
+	if dispatchTime := a.firstDispatchTime(); dispatchTime.After(t) {
+		return dispatchTime
 	}
-	return scheduleTime
+	return t
 }
 
 // scheduleToCloseDeadline returns the absolute time at which the ScheduleToClose timeout expires,
@@ -1422,6 +1442,7 @@ func (a *Activity) buildActivityExecutionInfo(ctx chasm.Context) *apiactivitypb.
 	info := &apiactivitypb.ActivityExecutionInfo{
 		ActivityId:              key.BusinessID,
 		ActivityType:            a.GetActivityType(),
+		ActualStartTime:         a.GetFirstAttemptStartedTime(),
 		Attempt:                 attempt.GetCount(),
 		CanceledReason:          a.CancelState.GetReason(),
 		CloseTime:               closeTime,
@@ -1440,9 +1461,10 @@ func (a *Activity) buildActivityExecutionInfo(ctx chasm.Context) *apiactivitypb.
 		LastWorkerIdentity:      attempt.GetLastWorkerIdentity(),
 		SdkName:                 attempt.GetSdkName(),
 		SdkVersion:              attempt.GetSdkVersion(),
-		NextAttemptScheduleTime: attemptScheduleTimeForRetry(attempt),
+		NextAttemptScheduleTime: dispatchTimeForRetry(attempt),
 		Priority:                a.GetPriority(),
 		RetryPolicy:             a.GetRetryPolicy(),
+		RequestedStartTime:      timestamppb.New(a.firstDispatchTime()),
 		RunId:                   key.RunID,
 		RunState:                runState,
 		ScheduleTime:            a.GetScheduleTime(),

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -993,6 +993,11 @@ func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetAc
 		return nil, err
 	}
 
+	scheduleTime := ctx.Now(a)
+	if jitter := frontendReq.GetJitter().AsDuration(); jitter > 0 {
+		scheduleTime = scheduleTime.Add(time.Duration(rand.Int63n(int64(jitter)))) //nolint:gosec
+	}
+
 	if frontendReq.GetRestoreOriginalOptions() {
 		ogOptions := a.GetOriginalOptions()
 		a.TaskQueue = common.CloneProto(ogOptions.GetTaskQueue())
@@ -1002,11 +1007,13 @@ func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetAc
 		a.HeartbeatTimeout = common.CloneProto(ogOptions.GetHeartbeatTimeout())
 		a.RetryPolicy = common.CloneProto(ogOptions.GetRetryPolicy())
 		a.Priority = common.CloneProto(ogOptions.GetPriority())
-	}
 
-	scheduleTime := ctx.Now(a)
-	if jitter := frontendReq.GetJitter().AsDuration(); jitter > 0 {
-		scheduleTime = scheduleTime.Add(time.Duration(rand.Int63n(int64(jitter)))) //nolint:gosec
+		// start_delay only governs the first dispatch. Once the first attempt has started, restoring
+		// the original value would shift ScheduleToClose without affecting dispatch timing.
+		if a.GetFirstAttemptStartedTime() == nil {
+			a.StartDelay = common.CloneProto(ogOptions.GetStartDelay())
+			scheduleTime = a.respectStartDelay(scheduleTime)
+		}
 	}
 
 	switch a.Status {
@@ -1032,11 +1039,7 @@ func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetAc
 		// keepPaused on a paused (PAUSE_REQUESTED) activity preserves the pause: when the worker
 		// yields the activity lands back in PAUSED rather than SCHEDULED.
 		a.ResetKeepPaused = keepPaused && a.Status == activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED
-		if err := TransitionResetRequested.Apply(a, ctx, resetEvent{
-			req:          frontendReq,
-			scheduleTime: scheduleTime,
-			handler:      metricsHandler,
-		}); err != nil {
+		if err := TransitionResetRequested.Apply(a, ctx, nil); err != nil {
 			return nil, err
 		}
 		a.emitOnResetMetrics(metricsHandler)

--- a/chasm/lib/activity/frontend.go
+++ b/chasm/lib/activity/frontend.go
@@ -392,7 +392,6 @@ func (h *frontendHandler) validateAndPopulateStartRequest(
 		namespaceID,
 		opts,
 		req.Priority,
-		durationpb.New(0),
 	)
 	if err != nil {
 		return nil, err

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -524,7 +524,7 @@ var TransitionResetRequested = chasm.NewTransition(
 		activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED,
 	},
 	activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
-	func(a *Activity, ctx chasm.MutableContext, _ resetEvent) error {
+	func(a *Activity, ctx chasm.MutableContext, _ any) error {
 		return nil
 	},
 )

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -42,39 +42,38 @@ var TransitionScheduled = chasm.NewTransition(
 	activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
 	func(a *Activity, ctx chasm.MutableContext, _ any) error {
 		attempt := a.LastAttempt.Get(ctx)
-		currentTime := ctx.Now(a)
+
 		attempt.Count++
 		attempt.Stamp++
 
 		// Start delay defers the dispatch and extends ScheduleToClose and ScheduleToStart timeouts. StartToClose and
 		// Heartbeat timeouts are unaffected as they only start when a worker picks up the task.
-		startDelay := a.GetStartDelay().AsDuration()
-		startDelayEnd := currentTime.Add(startDelay)
+		dispatchTime := a.firstDispatchTime()
 
 		if timeout := a.GetScheduleToStartTimeout().AsDuration(); timeout > 0 {
 			ctx.AddTask(
 				a,
 				chasm.TaskAttributes{
-					ScheduledTime: startDelayEnd.Add(timeout),
+					ScheduledTime: dispatchTime.Add(timeout),
 				},
 				&activitypb.ScheduleToStartTimeoutTask{
 					Stamp: attempt.GetStamp(),
 				})
 		}
 
-		if timeout := a.GetScheduleToCloseTimeout().AsDuration(); timeout > 0 {
+		if deadline := a.scheduleToCloseDeadline(); !deadline.IsZero() {
 			a.ScheduleToCloseStamp++
 			ctx.AddTask(
 				a,
 				chasm.TaskAttributes{
-					ScheduledTime: startDelayEnd.Add(timeout),
+					ScheduledTime: deadline,
 				},
 				&activitypb.ScheduleToCloseTimeoutTask{Stamp: a.GetScheduleToCloseStamp()})
 		}
 
 		dispatchAttrs := chasm.TaskAttributes{}
-		if startDelay > 0 {
-			dispatchAttrs.ScheduledTime = startDelayEnd
+		if dispatchTime.After(a.ScheduleTime.AsTime()) {
+			dispatchAttrs.ScheduledTime = dispatchTime
 		}
 		ctx.AddTask(
 			a,
@@ -106,7 +105,7 @@ var TransitionRescheduled = chasm.NewTransition(
 		}
 
 		attempt := a.LastAttempt.Get(ctx)
-		retryScheduledTime := attemptScheduleTimeForRetry(attempt).AsTime()
+		retryScheduledTime := dispatchTimeForRetry(attempt).AsTime()
 
 		if timeout := a.GetScheduleToStartTimeout().AsDuration(); timeout > 0 {
 			ctx.AddTask(
@@ -489,9 +488,9 @@ var TransitionAttemptFailedWhilePauseRequested = chasm.NewTransition(
 )
 
 type resetEvent struct {
-	req          *workflowservice.ResetActivityExecutionRequest
-	scheduleTime time.Time
-	handler      metrics.Handler
+	req       *workflowservice.ResetActivityExecutionRequest
+	resetTime time.Time
+	handler   metrics.Handler
 }
 
 // TransitionReset resets a SCHEDULED or PAUSED activity back to attempt 1. The stamp is bumped to
@@ -579,7 +578,7 @@ var TransitionResetAttemptFailedToScheduled = chasm.NewTransition(
 			return err
 		}
 
-		retryScheduledTime := attemptScheduleTimeForRetry(attempt).AsTime()
+		retryScheduledTime := dispatchTimeForRetry(attempt).AsTime()
 		if timeout := a.GetScheduleToStartTimeout().AsDuration(); timeout > 0 {
 			ctx.AddTask(
 				a,

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -93,6 +93,7 @@ func TestTransitionScheduled(t *testing.T) {
 				ActivityState: &activitypb.ActivityState{
 					ActivityType:           &commonpb.ActivityType{Name: "test-activity-type"},
 					RetryPolicy:            defaultRetryPolicy,
+					ScheduleTime:           timestamppb.New(defaultTime),
 					ScheduleToCloseTimeout: durationpb.New(tc.scheduleToCloseTimeout),
 					ScheduleToStartTimeout: durationpb.New(tc.scheduleToStartTimeout),
 					StartToCloseTimeout:    durationpb.New(defaultStartToCloseTimeout),
@@ -932,7 +933,7 @@ func TestTransitionResetFromPaused(t *testing.T) {
 				Outcome:     chasm.NewDataField(ctx, &activitypb.ActivityOutcome{}),
 			}
 
-			err := TransitionReset.Apply(act, ctx, resetEvent{scheduleTime: defaultTime, handler: metrics.NoopMetricsHandler})
+			err := TransitionReset.Apply(act, ctx, resetEvent{resetTime: defaultTime, handler: metrics.NoopMetricsHandler})
 			require.NoError(t, err)
 			require.Equal(t, activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED, act.Status)
 			require.Equal(t, int32(1), attemptState.Count)
@@ -970,7 +971,7 @@ func TestTransitionResetClearsCurrentRetryInterval(t *testing.T) {
 		Outcome:     chasm.NewDataField(ctx, &activitypb.ActivityOutcome{}),
 	}
 
-	err := TransitionReset.Apply(act, ctx, resetEvent{scheduleTime: defaultTime, handler: metrics.NoopMetricsHandler})
+	err := TransitionReset.Apply(act, ctx, resetEvent{resetTime: defaultTime, handler: metrics.NoopMetricsHandler})
 	require.NoError(t, err)
 	require.Nil(t, attemptState.GetCurrentRetryInterval(), "TransitionReset must clear CurrentRetryInterval")
 	require.Equal(t, int32(1), attemptState.Count, "TransitionReset must reset Count to 1")

--- a/chasm/lib/activity/validator.go
+++ b/chasm/lib/activity/validator.go
@@ -30,7 +30,6 @@ func ValidateAndNormalizeStandaloneActivity(
 	namespaceID namespace.ID,
 	options *activitypb.ActivityOptions,
 	priority *commonpb.Priority,
-	runTimeout *durationpb.Duration,
 ) error {
 	// Standalone activities always use user defined task queues, so we can enforce user defined task queue validation
 	if err := tqid.NormalizeAndValidateUserDefined(options.TaskQueue, "", "", maxIDLengthLimit); err != nil {
@@ -45,7 +44,7 @@ func ValidateAndNormalizeStandaloneActivity(
 		namespaceID,
 		options,
 		priority,
-		runTimeout)
+		durationpb.New(0))
 }
 
 // ValidateAndNormalizeEmbeddedActivity validates and normalizes the attributes for an embedded activity.
@@ -190,10 +189,10 @@ func validateAndNormalizeTimeouts(
 		}
 	} else {
 		// Deduction failed as there's not enough information to fill in missing timeouts.
-		return serviceerror.NewInvalidArgumentf("a valid StartToClose or ScheduleToCloseTimeout is not set on ScheduleActivityTaskCommand. ActivityId=%s ActivityType=%s",
+		return serviceerror.NewInvalidArgumentf("a valid StartToCloseTimeout or ScheduleToCloseTimeout must be set on the activity. ActivityId=%s ActivityType=%s",
 			activityID, activityType)
 	}
-	// ensure activity timeout never larger than workflow timeout
+	// ensure activity timeout never exceeds runTimeout
 	if runTimeout.AsDuration() > 0 {
 		runTimeoutDur := runTimeout.AsDuration()
 		if options.ScheduleToCloseTimeout.AsDuration() > runTimeoutDur {

--- a/chasm/lib/activity/validator_test.go
+++ b/chasm/lib/activity/validator_test.go
@@ -64,8 +64,7 @@ func TestValidateSuccess(t *testing.T) {
 			defaultMaxIDLengthLimit,
 			defaultNamespaceID,
 			&defaultActivityOptions,
-			&defaultPriority,
-			durationpb.New(0))
+			&defaultPriority)
 		require.NoError(t, err)
 	})
 
@@ -310,8 +309,7 @@ func TestStandaloneActivityTaskQueueValidations(t *testing.T) {
 				tc.maxIDLengthLimit,
 				tc.namespaceID,
 				tc.options,
-				tc.priority,
-				durationpb.New(0))
+				tc.priority)
 			var invalidArgErr *serviceerror.InvalidArgument
 			require.ErrorAs(t, err, &invalidArgErr)
 			require.Contains(t, invalidArgErr.Error(), tc.expectedErrMessage)

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
-	go.temporal.io/api v1.62.15-0.20260616185333-4e489f426ebb // TODO: get off dev branch
+	go.temporal.io/api v1.62.15-0.20260617201018-baf55f959c5e // TODO: get off dev branch
 	go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2
 	go.temporal.io/sdk v1.41.1
 	go.uber.org/fx v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -471,8 +471,8 @@ go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0 h1:R
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0/go.mod h1:I89cynRj8y+383o7tEQVg2SVA6SRgDVIouWPUVXjx0U=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0 h1:CQvJSldHRUN6Z8jsUeYv8J0lXRvygALXIzsmAeCcZE0=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0/go.mod h1:xSQ+mEfJe/GjK1LXEyVOoSI1N9JV9ZI923X5kup43W4=
-go.temporal.io/api v1.62.15-0.20260616185333-4e489f426ebb h1:B6JLjw425iG75kHGYfHYzwqlbYiMJrpYooorBJA8mnA=
-go.temporal.io/api v1.62.15-0.20260616185333-4e489f426ebb/go.mod h1:0k75tRljEuELWGeXjEZZO7zYqBln4+1FrG6+IMOMy7Q=
+go.temporal.io/api v1.62.15-0.20260617201018-baf55f959c5e h1:M9o/o5NJxjJAwiuQbRvjxp4Zi1v2GyMX0T2Cha6iU0w=
+go.temporal.io/api v1.62.15-0.20260617201018-baf55f959c5e/go.mod h1:0k75tRljEuELWGeXjEZZO7zYqBln4+1FrG6+IMOMy7Q=
 go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2 h1:1hKeH3GyR6YD6LKMHGCZ76t6h1Sgha0hXVQBxWi3dlQ=
 go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2/go.mod h1:T8dnzVPeO+gaUTj9eDgm/lT2lZH4+JXNvrGaQGyVi50=
 go.temporal.io/sdk v1.41.1 h1:yOpvsHyDD1lNuwlGBv/SUodCPhjv9nDeC9lLHW/fJUA=

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -6681,6 +6681,235 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 			"close-deadline should not shift when start_delay is left untouched")
 	})
 
+	s.Run("ResetRestoreOriginal_RestoresStartDelay", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+		originalDelay := 1 * time.Second
+		updatedDelay := 30 * time.Second
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
+			Input:               defaultInput,
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			StartDelay:          durationpb.New(originalDelay),
+		})
+		require.NoError(t, err)
+
+		// Mutate start_delay via update to a much longer value so the activity would not naturally dispatch before reset.
+		_, err = env.FrontendClient().UpdateActivityExecutionOptions(s.Context(), &workflowservice.UpdateActivityExecutionOptionsRequest{
+			Namespace:       env.Namespace().String(),
+			ActivityId:      activityID,
+			RunId:           startResp.RunId,
+			ActivityOptions: &activitypb.ActivityOptions{StartDelay: durationpb.New(updatedDelay)},
+			UpdateMask:      &fieldmaskpb.FieldMask{Paths: []string{"start_delay"}},
+		})
+		require.NoError(t, err)
+		descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		require.Equal(t, updatedDelay, descResp.GetInfo().GetStartDelay().AsDuration())
+
+		// Reset with RestoreOriginalOptions=true so start_delay is restored alongside the other options.
+		_, err = env.FrontendClient().ResetActivityExecution(s.Context(), &workflowservice.ResetActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			RunId:                  startResp.RunId,
+			RestoreOriginalOptions: true,
+		})
+		require.NoError(t, err)
+
+		descResp, err = env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		require.Equal(t, originalDelay, descResp.GetInfo().GetStartDelay().AsDuration())
+
+		// Activity should be pollable after reset. The original delay was 1s so the poll succeeds well within
+		// the 10s timeout (and well before updatedDelay would have allowed dispatch).
+		pollCtx, cancel := context.WithTimeout(s.Context(), 10*time.Second)
+		defer cancel()
+		pollResp, err := env.pollActivityTaskQueue(pollCtx, taskQueue)
+		require.NoError(t, err)
+		require.NotEmpty(t, pollResp.GetTaskToken())
+		require.EqualValues(t, 1, pollResp.GetAttempt())
+	})
+
+	s.Run("ResetRestoreOriginal_PreservesOriginalWallClockTarget", func(s *standaloneActivityTestSuite) {
+		s.T().Skip("TODO: implement once ActivityExecutionInfo exposes RequestedStartTime and ActualStartTime. " +
+			"Assertion will be actualStartTime >= requestedStartTime (within timerSafetyMargin) after a " +
+			"Reset+RestoreOriginalOptions on an activity whose start_delay was zeroed out mid-delay.")
+	})
+
+	s.Run("ResetRestoreOriginal_AfterDelayElapsed_DispatchesImmediately", func(s *standaloneActivityTestSuite) {
+		s.T().Skip("TODO: implement once ActivityExecutionInfo exposes RequestedStartTime and ActualStartTime. " +
+			"Assertion will be actualStartTime - resetTime within timerSafetyMargin after a " +
+			"Reset+RestoreOriginalOptions on an activity whose original delay has already elapsed.")
+	})
+
+	// Reset+RestoreOriginalOptions on a STARTED activity must NOT touch start_delay. The first dispatch
+	// has already happened so altering the value has no actual effect on dispatch timing.
+	s.Run("ResetRestoreOriginal_OnStartedActivity_LeavesStartDelayUnchanged", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+		originalDelay := 5 * time.Second
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
+			Input:               defaultInput,
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout: durationpb.New(30 * time.Second),
+			StartDelay:          durationpb.New(originalDelay),
+		})
+		require.NoError(t, err)
+
+		// While still in delay window, set start_delay=0 so the activity dispatches immediately.
+		_, err = env.FrontendClient().UpdateActivityExecutionOptions(s.Context(), &workflowservice.UpdateActivityExecutionOptionsRequest{
+			Namespace:       env.Namespace().String(),
+			ActivityId:      activityID,
+			RunId:           startResp.RunId,
+			ActivityOptions: &activitypb.ActivityOptions{StartDelay: durationpb.New(0)},
+			UpdateMask:      &fieldmaskpb.FieldMask{Paths: []string{"start_delay"}},
+		})
+		require.NoError(t, err)
+
+		// Poll: activity dispatches and worker picks up, so the status moves to STARTED.
+		pollResp, err := env.pollActivityTaskQueue(s.Context(), taskQueue)
+		require.NoError(t, err)
+		require.NotEmpty(t, pollResp.GetTaskToken())
+
+		descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, descResp.GetInfo().GetRunState())
+		require.EqualValues(t, 0, descResp.GetInfo().GetStartDelay().AsDuration(), "start_delay should be 0 after the update")
+
+		// Reset+RestoreOriginalOptions while STARTED.
+		_, err = env.FrontendClient().ResetActivityExecution(s.Context(), &workflowservice.ResetActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			RunId:                  startResp.RunId,
+			RestoreOriginalOptions: true,
+		})
+		require.NoError(t, err)
+
+		// start_delay should remain at the post-update value (0).
+		descResp, err = env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		require.EqualValues(t, 0, descResp.GetInfo().GetStartDelay().AsDuration(),
+			"start_delay should not be restored when the activity has already dispatched")
+	})
+
+	// Same invariant as the STARTED case, but exercises the retry-backoff path: after the first
+	// attempt dispatched and failed, the activity is back in SCHEDULED. Reset+RestoreOriginalOptions
+	// must not rewrite start_delay since the first dispatch already happened.
+	s.Run("ResetRestoreOriginal_OnRetryBackoff_LeavesStartDelayUnchanged", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+		originalDelay := 5 * time.Second
+		scheduleToCloseTimeout := 5 * time.Minute
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			ActivityType:           env.Tv().ActivityType(),
+			Identity:               env.Tv().WorkerIdentity(),
+			Input:                  defaultInput,
+			TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout:    durationpb.New(defaultStartToCloseTimeout),
+			ScheduleToCloseTimeout: durationpb.New(scheduleToCloseTimeout),
+			StartDelay:             durationpb.New(originalDelay),
+			RetryPolicy: &commonpb.RetryPolicy{
+				// Retry interval long enough to keep the activity in backoff through the Reset call,
+				// short enough to fit comfortably inside ScheduleToCloseTimeout so the activity is
+				// not pre-emptively timed out instead of scheduled for retry.
+				InitialInterval: durationpb.New(1 * time.Minute),
+				MaximumAttempts: 3,
+			},
+		})
+		require.NoError(t, err)
+
+		// Drop start_delay so the activity dispatches immediately.
+		_, err = env.FrontendClient().UpdateActivityExecutionOptions(s.Context(), &workflowservice.UpdateActivityExecutionOptionsRequest{
+			Namespace:       env.Namespace().String(),
+			ActivityId:      activityID,
+			RunId:           startResp.RunId,
+			ActivityOptions: &activitypb.ActivityOptions{StartDelay: durationpb.New(0)},
+			UpdateMask:      &fieldmaskpb.FieldMask{Paths: []string{"start_delay"}},
+		})
+		require.NoError(t, err)
+
+		pollResp, err := env.pollActivityTaskQueue(s.Context(), taskQueue)
+		require.NoError(t, err)
+		require.NotEmpty(t, pollResp.GetTaskToken())
+
+		// Fail the attempt with a retryable failure to drive the activity back to SCHEDULED.
+		_, err = env.FrontendClient().RespondActivityTaskFailed(s.Context(), &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
+			TaskToken: pollResp.GetTaskToken(),
+			Failure: &failurepb.Failure{
+				Message: "retryable failure",
+				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+					ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{NonRetryable: false},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, descResp.GetInfo().GetRunState(),
+			"activity should be in retry backoff (SCHEDULED) after a retryable failure")
+
+		_, err = env.FrontendClient().ResetActivityExecution(s.Context(), &workflowservice.ResetActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			RunId:                  startResp.RunId,
+			RestoreOriginalOptions: true,
+		})
+		require.NoError(t, err)
+
+		descResp, err = env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		require.EqualValues(t, 0, descResp.GetInfo().GetStartDelay().AsDuration(),
+			"start_delay should not be restored when the activity has already dispatched")
+	})
+
 	// The guard accepts the field mask path in either snake_case or camelCase form.
 	s.Run("UpdateCamelCaseFieldMask_Rejected", func(s *standaloneActivityTestSuite) {
 		t := s.T()

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -3628,6 +3628,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution() {
 			protorequire.ProtoEqual(t, expected, respInfo,
 				protorequire.IgnoreFields(
 					"execution_duration",
+					"requested_start_time",
 					"schedule_time",
 					"state_size_bytes",
 					"state_transition_count",
@@ -3675,6 +3676,11 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution() {
 		})
 		require.NoError(t, err)
 		protorequire.ProtoEqual(t, startDelay, describeResp.GetInfo().GetStartDelay())
+		expectedRequested := describeResp.GetInfo().GetScheduleTime().AsTime().Add(startDelay.AsDuration())
+		require.Equal(t, expectedRequested, describeResp.GetInfo().GetRequestedStartTime().AsTime(),
+			"requested_start_time should equal scheduleTime + start_delay")
+		require.Nil(t, describeResp.GetInfo().GetActualStartTime(),
+			"actual_start_time should be unset before any worker pickup")
 	})
 
 	s.Run("WaitAnyStateChange", func(s *standaloneActivityTestSuite) {
@@ -3720,6 +3726,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution() {
 		protorequire.ProtoEqual(t, expected, firstDescribeResp.GetInfo(),
 			protorequire.IgnoreFields(
 				"execution_duration",
+				"requested_start_time",
 				"schedule_time",
 				"state_size_bytes",
 				"state_transition_count",
@@ -3778,8 +3785,10 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution() {
 			// Ignore non-deterministic fields. Validated separately.
 			protorequire.ProtoEqual(t, expected, describeResp.GetInfo(),
 				protorequire.IgnoreFields(
+					"actual_start_time",
 					"execution_duration",
 					"last_started_time",
+					"requested_start_time",
 					"schedule_time",
 					"state_size_bytes",
 					"state_transition_count",
@@ -5806,6 +5815,8 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 		requestID := testcore.RandomizeStr("request-id")
+		// 3s > timerSafetyMargin so the require.Never below has a non-trivial window
+		// (startDelay - timerSafetyMargin = 1.5s) to assert the activity stays SCHEDULED.
 		startDelay := 3 * time.Second
 
 		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
@@ -5850,6 +5861,7 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 		requestID := testcore.RandomizeStr("request-id")
+		// Short so the test waits ~1s for dispatch; the value isn't load-bearing for this test.
 		startDelay := 1 * time.Second
 
 		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
@@ -5894,6 +5906,8 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 		requestID := testcore.RandomizeStr("request-id")
+		// require.Never window = startDelay + scheduleToStart - timerSafetyMargin = 2.5s. Total wait is
+		// startDelay + scheduleToStart = 4s; 3s+1s keeps the test fast while leaving a comfortable margin.
 		startDelay := 3 * time.Second
 		scheduleToStartTimeout := 1 * time.Second
 
@@ -5932,6 +5946,8 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 			})
 			require.NoError(c, err)
 			require.Equal(c, enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT, resp.GetInfo().GetStatus())
+			require.Nil(c, resp.GetInfo().GetActualStartTime(),
+				"actual_start_time should remain unset when the activity times out before any worker pickup")
 		}, 10*time.Second, 100*time.Millisecond)
 	})
 
@@ -5940,6 +5956,7 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 		requestID := testcore.RandomizeStr("request-id")
+		// Same shape as ScheduleToStartTimeoutExtended; require.Never window = 2.5s, total wait ~4s.
 		startDelay := 3 * time.Second
 		scheduleToCloseTimeout := 1 * time.Second
 
@@ -6030,6 +6047,8 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_CANCELED, descResp.GetInfo().GetStatus())
+		require.Nil(t, descResp.GetInfo().GetActualStartTime(),
+			"actual_start_time should remain unset when the activity is cancelled before any worker pickup")
 	})
 
 	t.Run("TerminateDuringDelay", func(t *testing.T) {
@@ -6070,6 +6089,8 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_TERMINATED, descResp.GetInfo().GetStatus())
+		require.Nil(t, descResp.GetInfo().GetActualStartTime(),
+			"actual_start_time should remain unset when the activity is terminated before any worker pickup")
 	})
 
 	// Validates that the retry deadline accounts for start delay: the effective ScheduleToClose
@@ -6082,6 +6103,9 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 		requestID := testcore.RandomizeStr("request-id")
+		// scheduleToClose < startDelay would reject the retry if the deadline didn't extend by
+		// startDelay. 2s+3s makes the bug case (deadline = T+3s) reject the retry, while the
+		// correct extended deadline (T+5s) allows attempt 2.
 		startDelay := 2 * time.Second
 		scheduleToCloseTimeout := 3 * time.Second
 
@@ -6161,6 +6185,8 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
+		// 60s is much larger than the 10s poll context below: if start_delay weren't actually updated
+		// to 0, the poll would time out, failing the test.
 		startDelay := 60 * time.Second
 
 		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
@@ -6200,6 +6226,8 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
+		// require.Never below asserts SCHEDULED past originalDelay+timerSafetyMargin = 2.5s, which only
+		// holds if the extended delay is in effect; newDelay = 3s > 2.5s so the assertion is meaningful.
 		originalDelay := 1 * time.Second
 		newDelay := 3 * time.Second
 
@@ -6249,6 +6277,8 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
+		// 30s is well past the 5s poll context: if the update didn't shorten start_delay, the poll
+		// would time out. 2s is short enough that the poll returns quickly under the new delay.
 		originalDelay := 30 * time.Second
 		newDelay := 2 * time.Second
 
@@ -6289,6 +6319,7 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
+		// 60s is much larger than the 10s poll context: if start_delay weren't reduced, the poll fails.
 		originalDelay := 60 * time.Second
 
 		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
@@ -6397,9 +6428,11 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
+		// Effective deadline = scheduleTime + startDelay + scheduleToClose = T+4s. require.Never window
+		// = 4-timerSafetyMargin = 2.5s. A bug that anchored the deadline to scheduleTime alone would
+		// time out at T+1s, well inside the window.
 		startDelay := 3 * time.Second
 		scheduleToCloseTimeout := 1 * time.Second
-		// Effective deadline = scheduleTime + startDelay + scheduleToClose = T+4s.
 
 		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
 			Namespace:              env.Namespace().String(),
@@ -6462,6 +6495,8 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
+		// Long enough that the activity never actually dispatches during the test; we only assert that
+		// the restored start_delay value matches the original via Describe.
 		originalDelay := 30 * time.Second
 
 		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
@@ -6520,6 +6555,8 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
+		// originalDelay just needs to be non-zero so we can detect a buggy restore. scheduleToClose
+		// is large enough that the activity doesn't time out during the test.
 		originalDelay := 5 * time.Second
 		scheduleToCloseTimeout := 30 * time.Second
 
@@ -6687,6 +6724,9 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
+		// originalDelay short so the poll below succeeds quickly after reset. updatedDelay must be
+		// much larger than the 10s poll context: if the reset didn't restore start_delay, the poll
+		// would time out under the larger updated delay.
 		originalDelay := 1 * time.Second
 		updatedDelay := 30 * time.Second
 
@@ -6746,16 +6786,125 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		require.EqualValues(t, 1, pollResp.GetAttempt())
 	})
 
+	// Reset+RestoreOriginalOptions restores start_delay AND clamps the next dispatch to the original
+	// scheduleTime + start_delay. Without the clamp, zeroing start_delay then resetting would dispatch
+	// immediately, defeating the "undo my mistake" intent.
 	s.Run("ResetRestoreOriginal_PreservesOriginalWallClockTarget", func(s *standaloneActivityTestSuite) {
-		s.T().Skip("TODO: implement once ActivityExecutionInfo exposes RequestedStartTime and ActualStartTime. " +
-			"Assertion will be actualStartTime >= requestedStartTime (within timerSafetyMargin) after a " +
-			"Reset+RestoreOriginalOptions on an activity whose start_delay was zeroed out mid-delay.")
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+		// 3s > timerSafetyMargin so a buggy "dispatch at reset time" produces actualStart ≈ T0+ε,
+		// while expectedRequested = T0+3s. The assertion (actualStart + 1.5s ≥ T0+3s) fails by ~1.5s.
+		originalDelay := 3 * time.Second
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
+			Input:               defaultInput,
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			StartDelay:          durationpb.New(originalDelay),
+		})
+		require.NoError(t, err)
+
+		// Zero out start_delay so the activity would dispatch immediately.
+		_, err = env.FrontendClient().UpdateActivityExecutionOptions(s.Context(), &workflowservice.UpdateActivityExecutionOptionsRequest{
+			Namespace:       env.Namespace().String(),
+			ActivityId:      activityID,
+			RunId:           startResp.RunId,
+			ActivityOptions: &activitypb.ActivityOptions{StartDelay: durationpb.New(0)},
+			UpdateMask:      &fieldmaskpb.FieldMask{Paths: []string{"start_delay"}},
+		})
+		require.NoError(t, err)
+
+		// Reset+RestoreOriginalOptions: restores start_delay AND should clamp dispatch to original target.
+		_, err = env.FrontendClient().ResetActivityExecution(s.Context(), &workflowservice.ResetActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			RunId:                  startResp.RunId,
+			RestoreOriginalOptions: true,
+		})
+		require.NoError(t, err)
+
+		// Worker eventually picks up.
+		pollCtx, cancel := context.WithTimeout(s.Context(), 10*time.Second)
+		defer cancel()
+		pollResp, err := env.pollActivityTaskQueue(pollCtx, taskQueue)
+		require.NoError(t, err)
+		require.NotEmpty(t, pollResp.GetTaskToken())
+
+		// actualStartTime should be at-or-after the original target (scheduleTime + originalDelay), within a small safety
+		// margin to absorb timer firing imprecision.
+		descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		requestedStart := descResp.GetInfo().GetRequestedStartTime().AsTime()
+		actualStart := descResp.GetInfo().GetActualStartTime().AsTime()
+		require.False(t, requestedStart.IsZero(), "requested_start_time should be populated")
+		require.False(t, actualStart.IsZero(), "actual_start_time should be populated after pickup")
+		require.GreaterOrEqual(t, actualStart.Add(timerSafetyMargin).UnixNano(), requestedStart.UnixNano(),
+			"activity dispatched before its original requested_start_time; RestoreOriginalOptions did not honor the original delay")
 	})
 
+	// If the original delay has already elapsed when Reset+RestoreOriginalOptions is called, the clamp
+	// doesn't apply and dispatch fires at "now" (the reset time).
 	s.Run("ResetRestoreOriginal_AfterDelayElapsed_DispatchesImmediately", func(s *standaloneActivityTestSuite) {
-		s.T().Skip("TODO: implement once ActivityExecutionInfo exposes RequestedStartTime and ActualStartTime. " +
-			"Assertion will be actualStartTime - resetTime within timerSafetyMargin after a " +
-			"Reset+RestoreOriginalOptions on an activity whose original delay has already elapsed.")
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+		// Short so the Sleep below (2s) doesn't make the test slow; only needs to elapse before reset.
+		originalDelay := 1 * time.Second
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
+			Input:               defaultInput,
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			StartDelay:          durationpb.New(originalDelay),
+		})
+		require.NoError(t, err)
+
+		// Wait past the original delay so firstDispatchTime is in the past when we reset.
+		time.Sleep(2 * time.Second) //nolint:forbidigo
+
+		resetTime := time.Now()
+		_, err = env.FrontendClient().ResetActivityExecution(s.Context(), &workflowservice.ResetActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			RunId:                  startResp.RunId,
+			RestoreOriginalOptions: true,
+		})
+		require.NoError(t, err)
+
+		pollCtx, cancel := context.WithTimeout(s.Context(), 10*time.Second)
+		defer cancel()
+		pollResp, err := env.pollActivityTaskQueue(pollCtx, taskQueue)
+		require.NoError(t, err)
+		require.NotEmpty(t, pollResp.GetTaskToken())
+
+		// actualStartTime should be close to the reset time since the delay was already in the past.
+		descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		actualStart := descResp.GetInfo().GetActualStartTime().AsTime()
+		require.False(t, actualStart.IsZero(), "actual_start_time should be populated after pickup")
+		require.WithinDuration(t, resetTime, actualStart, timerSafetyMargin,
+			"dispatch did not fire promptly after reset; expected close to resetTime since delay was already in the past")
 	})
 
 	// Reset+RestoreOriginalOptions on a STARTED activity must NOT touch start_delay. The first dispatch
@@ -6766,6 +6915,7 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
+		// Just needs to be non-zero so we can detect a buggy restore; value isn't load-bearing.
 		originalDelay := 5 * time.Second
 
 		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
@@ -6953,6 +7103,9 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
+		// originalDelay short so the update happens while in delay window. updatedDelay+scheduleToStart
+		// must comfortably exceed (originalDelay+scheduleToStart+timerSafetyMargin) so a buggy "anchored
+		// to originalDelay" would time out at T+2s, well before the correct T+5s deadline.
 		originalDelay := 1 * time.Second
 		updatedDelay := 4 * time.Second
 		scheduleToStartTimeout := 1 * time.Second
@@ -7010,6 +7163,8 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
+		// Equal so the upper bound (retryInterval+startDelay = 4s) is meaningful: a bug that re-applied
+		// start_delay would push retry to ~4s after fail, missing the upper bound.
 		startDelay := 2 * time.Second
 		retryInterval := 2 * time.Second
 
@@ -7066,6 +7221,555 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		require.EqualValues(t, 2, pollResp2.GetAttempt())
 		require.Less(t, time.Since(failTime), retryInterval+startDelay,
 			"retry was delayed beyond the retry interval, suggesting start_delay was incorrectly re-applied")
+	})
+
+	// Describe should expose both requested_start_time (= scheduleTime + start_delay) and
+	// actual_start_time (= when worker first picked up the activity).
+	s.Run("DescribeExposesRequestedAndActualStartTime", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+		// > timerSafetyMargin so actualStart is meaningfully later than scheduleTime (lets the
+		// WithinDuration check below distinguish "near requested target" from "fired immediately").
+		startDelay := 2 * time.Second
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
+			Input:               defaultInput,
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			StartDelay:          durationpb.New(startDelay),
+		})
+		require.NoError(t, err)
+
+		// Before pickup: requested_start_time set, actual_start_time still nil.
+		descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		expectedRequested := descResp.GetInfo().GetScheduleTime().AsTime().Add(startDelay)
+		require.Equal(t, expectedRequested, descResp.GetInfo().GetRequestedStartTime().AsTime(),
+			"requested_start_time should equal scheduleTime + start_delay")
+		require.Nil(t, descResp.GetInfo().GetActualStartTime(), "actual_start_time should be unset before first pickup")
+
+		// Poll and let worker pick up.
+		pollResp, err := env.pollActivityTaskQueue(s.Context(), taskQueue)
+		require.NoError(t, err)
+		require.NotEmpty(t, pollResp.GetTaskToken())
+
+		// After pickup: actual_start_time populated, close to requested_start_time.
+		descResp, err = env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		require.Equal(t, expectedRequested, descResp.GetInfo().GetRequestedStartTime().AsTime(),
+			"requested_start_time should be stable across pickups")
+		actualStart := descResp.GetInfo().GetActualStartTime().AsTime()
+		require.False(t, actualStart.IsZero(), "actual_start_time should be populated after pickup")
+		require.WithinDuration(t, expectedRequested, actualStart, timerSafetyMargin,
+			"actual_start_time should be near requested_start_time on the happy path")
+	})
+
+	// actual_start_time records the FIRST pickup and does not move on subsequent retry attempts.
+	s.Run("ActualStartTime_StableAcrossRetries", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+		// Short so the test waits ~1s between attempts; only needs to be > 0 for a real retry path.
+		retryInterval := 1 * time.Second
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
+			Input:               defaultInput,
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout: durationpb.New(30 * time.Second),
+			RetryPolicy: &commonpb.RetryPolicy{
+				InitialInterval:    durationpb.New(retryInterval),
+				BackoffCoefficient: 1.0,
+				MaximumAttempts:    3,
+			},
+		})
+		require.NoError(t, err)
+
+		// Attempt 1: pickup, capture actual_start_time, fail.
+		pollResp1, err := env.pollActivityTaskQueue(s.Context(), taskQueue)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, pollResp1.GetAttempt())
+
+		descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		actualStartAttempt1 := descResp.GetInfo().GetActualStartTime().AsTime()
+		require.False(t, actualStartAttempt1.IsZero())
+		require.Equal(t, descResp.GetInfo().GetScheduleTime().AsTime(), descResp.GetInfo().GetRequestedStartTime().AsTime(),
+			"requested_start_time should equal schedule_time when start_delay is unset")
+
+		_, err = env.FrontendClient().RespondActivityTaskFailed(s.Context(), &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
+			TaskToken: pollResp1.TaskToken,
+			Failure: &failurepb.Failure{
+				Message: "retryable failure",
+				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+					ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{NonRetryable: false},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// Attempt 2: pickup, actual_start_time should be unchanged from attempt 1.
+		pollResp2, err := env.pollActivityTaskQueue(s.Context(), taskQueue)
+		require.NoError(t, err)
+		require.EqualValues(t, 2, pollResp2.GetAttempt())
+
+		descResp, err = env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		require.Equal(t, actualStartAttempt1, descResp.GetInfo().GetActualStartTime().AsTime(),
+			"actual_start_time should record the first pickup only and not move on retries")
+
+		// Complete attempt 2 and verify actual_start_time still reflects the first attempt's pickup.
+		_, err = env.FrontendClient().RespondActivityTaskCompleted(s.Context(), &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
+			TaskToken: pollResp2.TaskToken,
+			Result:    defaultResult,
+			Identity:  defaultIdentity,
+		})
+		require.NoError(t, err)
+
+		descResp, err = env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, descResp.GetInfo().GetStatus())
+		require.Equal(t, actualStartAttempt1, descResp.GetInfo().GetActualStartTime().AsTime(),
+			"actual_start_time should still reflect the first pickup after the activity has completed")
+	})
+
+	// actual_start_time persists across Reset+RestoreOriginalOptions on a STARTED activity. The reset
+	// must not unset the field; it records the original first-pickup wall-clock time for the lifetime
+	// of the activity.
+	s.Run("ActualStartTime_PreservedAcrossReset", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
+			Input:               defaultInput,
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout: durationpb.New(30 * time.Second),
+		})
+		require.NoError(t, err)
+
+		pollResp, err := env.pollActivityTaskQueue(s.Context(), taskQueue)
+		require.NoError(t, err)
+		require.NotEmpty(t, pollResp.GetTaskToken())
+
+		descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		actualStartBeforeReset := descResp.GetInfo().GetActualStartTime().AsTime()
+		require.False(t, actualStartBeforeReset.IsZero())
+
+		_, err = env.FrontendClient().ResetActivityExecution(s.Context(), &workflowservice.ResetActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			RunId:                  startResp.RunId,
+			RestoreOriginalOptions: true,
+		})
+		require.NoError(t, err)
+
+		descResp, err = env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		require.Equal(t, actualStartBeforeReset, descResp.GetInfo().GetActualStartTime().AsTime(),
+			"actual_start_time should persist across Reset+RestoreOriginalOptions")
+	})
+
+	// Pause during the delay window must not let unpause dispatch before the original wall-clock
+	// target. Without respectStartDelay in unpause(), pausing then quickly unpausing would let
+	// the activity dispatch at "now," skipping the rest of the original delay.
+	s.Run("PauseDuringDelay_UnpauseHonorsWallClockTarget", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+		// The assertion below allows actualStart to land within timerSafetyMargin (1.5s) of the original
+		// target (T0+3s). 3s leaves room for a regression that dispatches immediately on unpause to fall
+		// well below T0+1.5s and fail visibly.
+		startDelay := 3 * time.Second
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
+			Input:               defaultInput,
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			StartDelay:          durationpb.New(startDelay),
+		})
+		require.NoError(t, err)
+		descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		expectedRequested := descResp.GetInfo().GetScheduleTime().AsTime().Add(startDelay)
+
+		_, err = env.FrontendClient().PauseActivityExecution(s.Context(), &workflowservice.PauseActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+			Identity:   defaultIdentity,
+			Reason:     "test-pause",
+		})
+		require.NoError(t, err)
+
+		_, err = env.FrontendClient().UnpauseActivityExecution(s.Context(), &workflowservice.UnpauseActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+			Identity:   defaultIdentity,
+		})
+		require.NoError(t, err)
+
+		pollCtx, cancel := context.WithTimeout(s.Context(), 10*time.Second)
+		defer cancel()
+		pollResp, err := env.pollActivityTaskQueue(pollCtx, taskQueue)
+		require.NoError(t, err)
+		require.NotEmpty(t, pollResp.GetTaskToken())
+
+		descResp, err = env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		actualStart := descResp.GetInfo().GetActualStartTime().AsTime()
+		require.False(t, actualStart.IsZero())
+		require.GreaterOrEqual(t, actualStart.Add(timerSafetyMargin).UnixNano(), expectedRequested.UnixNano(),
+			"activity dispatched before its original requested_start_time; unpause did not honor the original delay")
+	})
+
+	// If the delay window has already elapsed by the time the activity is unpaused, the activity
+	// should dispatch immediately (no leftover delay to honor).
+	s.Run("PauseDuringDelay_UnpauseAfterDelay_DispatchesImmediately", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+		// Short so the sleep below doesn't make the test slow; only needs to be > 0.
+		startDelay := 1 * time.Second
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
+			Input:               defaultInput,
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			StartDelay:          durationpb.New(startDelay),
+		})
+		require.NoError(t, err)
+
+		_, err = env.FrontendClient().PauseActivityExecution(s.Context(), &workflowservice.PauseActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+			Identity:   defaultIdentity,
+			Reason:     "test-pause",
+		})
+		require.NoError(t, err)
+
+		// 2s > startDelay (1s) to ensure firstDispatchTime is firmly in the past at unpause time,
+		// even accounting for clock variance.
+		time.Sleep(2 * time.Second) //nolint:forbidigo
+
+		unpauseTime := time.Now()
+		_, err = env.FrontendClient().UnpauseActivityExecution(s.Context(), &workflowservice.UnpauseActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+			Identity:   defaultIdentity,
+		})
+		require.NoError(t, err)
+
+		pollCtx, cancel := context.WithTimeout(s.Context(), 5*time.Second)
+		defer cancel()
+		pollResp, err := env.pollActivityTaskQueue(pollCtx, taskQueue)
+		require.NoError(t, err)
+		require.NotEmpty(t, pollResp.GetTaskToken())
+
+		descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		actualStart := descResp.GetInfo().GetActualStartTime().AsTime()
+		require.False(t, actualStart.IsZero())
+		require.WithinDuration(t, unpauseTime, actualStart, timerSafetyMargin,
+			"expected near-immediate dispatch on unpause when the original delay had already elapsed")
+	})
+
+	// Pause/unpause after the first dispatch must NOT re-apply start_delay to the next attempt.
+	// Verifies that respectStartDelay in unpause() correctly no-ops on the post-dispatch path
+	// via FirstAttemptStartedTime.
+	s.Run("PausePostDispatch_NoStartDelayReapplied", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+		// Must exceed timerSafetyMargin so a re-applied delay would visibly miss the margin below.
+		startDelay := 2 * time.Second
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
+			Input:               defaultInput,
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout: durationpb.New(30 * time.Second),
+			RetryPolicy: &commonpb.RetryPolicy{
+				// Short so the retry would normally fire right away post-yield; the pause is what keeps it
+				// from dispatching. Keeps the test fast without zeroing the interval.
+				InitialInterval:    durationpb.New(100 * time.Millisecond),
+				BackoffCoefficient: 1.0,
+				MaximumAttempts:    3,
+			},
+			StartDelay: durationpb.New(startDelay),
+		})
+		require.NoError(t, err)
+
+		// Wait for first dispatch and have the worker pick up attempt 1.
+		pollResp1, err := env.pollActivityTaskQueue(s.Context(), taskQueue)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, pollResp1.GetAttempt())
+
+		_, err = env.FrontendClient().PauseActivityExecution(s.Context(), &workflowservice.PauseActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+			Identity:   defaultIdentity,
+			Reason:     "test-pause",
+		})
+		require.NoError(t, err)
+
+		// Worker yields (attempt 1 fails). Activity transitions PAUSE_REQUESTED -> PAUSED.
+		_, err = env.FrontendClient().RespondActivityTaskFailed(s.Context(), &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
+			TaskToken: pollResp1.TaskToken,
+			Failure: &failurepb.Failure{
+				Message: "retryable failure",
+				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+					ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{NonRetryable: false},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		unpauseTime := time.Now()
+		_, err = env.FrontendClient().UnpauseActivityExecution(s.Context(), &workflowservice.UnpauseActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+			Identity:   defaultIdentity,
+		})
+		require.NoError(t, err)
+
+		// Attempt 2 should dispatch close to unpause time, NOT after an additional start_delay duration.
+		pollResp2, err := env.pollActivityTaskQueue(s.Context(), taskQueue)
+		require.NoError(t, err)
+		require.EqualValues(t, 2, pollResp2.GetAttempt())
+
+		descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		lastStarted := descResp.GetInfo().GetLastStartedTime().AsTime()
+		require.False(t, lastStarted.IsZero())
+		require.WithinDuration(t, unpauseTime, lastStarted, timerSafetyMargin,
+			"attempt 2 was delayed beyond unpause time; start_delay should not re-apply post-dispatch")
+	})
+
+	// ScheduleToStart counts from when the activity is dispatched, so on unpause it must be re-anchored
+	// to scheduleTime + start_delay + scheduleToStart, not to unpauseTime + scheduleToStart (which
+	// would fire prematurely while the activity is still inside its delay window).
+	s.Run("PauseDuringDelay_ScheduleToStartReanchored", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+		// Window for the require.Never below is startDelay+scheduleToStart-timerSafetyMargin = 2.5s.
+		// A buggy "anchored to unpauseTime" would fire ScheduleToStart at ~unpauseTime+1s ≈ T0+1.5s,
+		// well inside the 2.5s window even on slow CI.
+		startDelay := 3 * time.Second
+		scheduleToStartTimeout := 1 * time.Second // Small but non-zero so the deadline is meaningful.
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			ActivityType:           env.Tv().ActivityType(),
+			Identity:               env.Tv().WorkerIdentity(),
+			Input:                  defaultInput,
+			TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout:    durationpb.New(30 * time.Second),
+			ScheduleToStartTimeout: durationpb.New(scheduleToStartTimeout),
+			StartDelay:             durationpb.New(startDelay),
+		})
+		require.NoError(t, err)
+
+		// Pause + unpause quickly within the delay window.
+		_, err = env.FrontendClient().PauseActivityExecution(s.Context(), &workflowservice.PauseActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+			Identity:   defaultIdentity,
+			Reason:     "test-pause",
+		})
+		require.NoError(t, err)
+		_, err = env.FrontendClient().UnpauseActivityExecution(s.Context(), &workflowservice.UnpauseActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+			Identity:   defaultIdentity,
+		})
+		require.NoError(t, err)
+
+		// No worker polls. ScheduleToStart should fire at scheduleTime + start_delay + scheduleToStart,
+		// not at unpauseTime + scheduleToStart. Verify no timeout before the correct deadline.
+		require.Never(t, func() bool {
+			descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
+				ActivityId: activityID,
+				RunId:      startResp.RunId,
+			})
+			return err != nil || descResp.GetInfo().GetStatus() == enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT
+		}, startDelay+scheduleToStartTimeout-timerSafetyMargin, 100*time.Millisecond,
+			"activity timed out before scheduleTime + start_delay + scheduleToStart; ScheduleToStart was not re-anchored")
+
+		// Eventually times out at the correct deadline.
+		await.Require(s.Context(), t, func(c *await.T) {
+			resp, err := env.FrontendClient().DescribeActivityExecution(c.Context(), &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
+				ActivityId: activityID,
+				RunId:      startResp.RunId,
+			})
+			require.NoError(c, err)
+			require.Equal(c, enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT, resp.GetInfo().GetStatus())
+		}, 10*time.Second, 100*time.Millisecond)
+	})
+
+	// Multiple pause/unpause cycles in the delay window must not drift the wall-clock target. The
+	// dispatch should still fire at scheduleTime + start_delay regardless of how many cycles
+	// happened, since the target is anchored to schedule_time (not to the most recent unpause).
+	s.Run("PauseDuringDelay_MultipleCyclesHonorWallClockTarget", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+		// Lower-bound margin below is startDelay-timerSafetyMargin = 3.5s. A buggy "dispatch at last
+		// unpauseTime" would produce actualStart at most a few seconds in (cycle latency), well below
+		// T0+3.5s. 5s keeps the catch reliable even if pause+unpause cycles take ~3s on slow CI.
+		startDelay := 5 * time.Second
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
+			Input:               defaultInput,
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			StartDelay:          durationpb.New(startDelay),
+		})
+		require.NoError(t, err)
+		descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		expectedRequested := descResp.GetInfo().GetScheduleTime().AsTime().Add(startDelay)
+
+		for range 2 {
+			_, err = env.FrontendClient().PauseActivityExecution(s.Context(), &workflowservice.PauseActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
+				ActivityId: activityID,
+				RunId:      startResp.RunId,
+				Identity:   defaultIdentity,
+				Reason:     "test-pause",
+			})
+			require.NoError(t, err)
+			_, err = env.FrontendClient().UnpauseActivityExecution(s.Context(), &workflowservice.UnpauseActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
+				ActivityId: activityID,
+				RunId:      startResp.RunId,
+				Identity:   defaultIdentity,
+			})
+			require.NoError(t, err)
+		}
+
+		pollCtx, cancel := context.WithTimeout(s.Context(), 10*time.Second)
+		defer cancel()
+		pollResp, err := env.pollActivityTaskQueue(pollCtx, taskQueue)
+		require.NoError(t, err)
+		require.NotEmpty(t, pollResp.GetTaskToken())
+
+		descResp, err = env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		actualStart := descResp.GetInfo().GetActualStartTime().AsTime()
+		require.False(t, actualStart.IsZero())
+		require.GreaterOrEqual(t, actualStart.Add(timerSafetyMargin).UnixNano(), expectedRequested.UnixNano(),
+			"activity dispatched before its original requested_start_time; multiple pause cycles let the target drift")
 	})
 }
 
@@ -7654,6 +8358,59 @@ func (s *standaloneActivityTestSuite) TestUpdateActivityExecutionOptions() {
 			enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
 			pollOutcome.GetOutcome().GetFailure().GetTimeoutFailureInfo().GetTimeoutType(),
 		)
+	})
+
+	t.Run("ChangeTaskQueue_RedispatchesToNewQueue", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		queueA := testcore.RandomizeStr(t.Name() + "-A")
+		queueB := testcore.RandomizeStr(t.Name() + "-B")
+
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        &commonpb.ActivityType{Name: "test-activity"},
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: queueA},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			RetryPolicy:         &commonpb.RetryPolicy{MaximumAttempts: 1},
+		})
+		require.NoError(t, err)
+
+		// Update to queue B before any worker poll.
+		_, err = env.FrontendClient().UpdateActivityExecutionOptions(ctx, &workflowservice.UpdateActivityExecutionOptionsRequest{
+			Namespace:       env.Namespace().String(),
+			ActivityId:      activityID,
+			RunId:           startResp.RunId,
+			ActivityOptions: &activitypb.ActivityOptions{TaskQueue: &taskqueuepb.TaskQueue{Name: queueB}},
+			UpdateMask:      &fieldmaskpb.FieldMask{Paths: []string{"task_queue.name"}},
+		})
+		require.NoError(t, err)
+
+		// Poller on queue B picks it up.
+		pollResp, err := env.pollActivityTaskQueue(ctx, queueB)
+		require.NoError(t, err)
+		require.Equal(t, activityID, pollResp.GetActivityId(), "task was not dispatched from the updated task queue")
+		require.EqualValues(t, 1, pollResp.GetAttempt())
+
+		// Describe reports queue B.
+		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		require.Equal(t, queueB, descResp.GetInfo().GetTaskQueue())
+		require.False(t, descResp.GetInfo().GetActualStartTime().AsTime().IsZero())
+
+		// There are no tasks on queue A.
+		shortCtx, shortCancel := context.WithTimeout(ctx, 5*time.Second)
+		defer shortCancel()
+		oldQueueResp, err := env.pollActivityTaskQueue(shortCtx, queueA)
+		if err == nil {
+			require.Empty(t, oldQueueResp.GetActivityId(), "task should not be dispatchable from the old task queue after update")
+		}
 	})
 
 	t.Run("ChangeHeartbeatTimeout", func(t *testing.T) {


### PR DESCRIPTION
## What changed?
`Reset` with `RestoreOriginalOptions` now restores `start_delay` for standalone activities, gated on `FirstAttemptStartedTime == nil` (the first attempt has not been picked up yet). When restored, the next dispatch is clamped to the original wall-clock target (`scheduleTime + original_start_delay`) via `respectStartDelay`, so undoing a "zeroed out" delay lands at the moment originally requested instead of firing immediately. Once the activity has dispatched (`STARTED`, retry-backoff `SCHEDULED`, or post-dispatch `PAUSED`), `start_delay` is left untouched, since it only governs the first dispatch and restoring it afterward would just surface a stale value and shift the close deadline.
  
Also simplifies `TransitionResetRequested` to take no event payload, since it is a pure status flip and all state mutation happens in `handleReset` before `Apply`.

## Why?
`RestoreOriginalOptions` is the documented "back to original" path, so without restoring `start_delay` the undo was only half-honored: timeouts and retry policy snapped back but the dispatch target stayed at the updated value. Gating on `FirstAttemptStartedTime` (rather than status) keeps the contract consistent with the update path: `start_delay` is a first-attempt parameter, so it is only meaningful to restore before the first dispatch.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [X] added new functional test(s)
