### PR TITLE
Add tasks_dropped observability metric to the matching service

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -629,6 +629,16 @@ const (
 	ScheduleMigrationDirectionToWorkflow = "to_workflow"
 )
 
+// Matching task dropped reason tag values
+const (
+	DroppedTaskReasonNotFound      = "not_found"
+	DroppedTaskReasonInternalError = "internal_error"
+	DroppedTaskReasonDataLoss      = "data_loss"
+	DroppedTaskReasonExpiredRead   = "expired_read"
+	DroppedTaskReasonExpiredMemory = "expired_memory"
+	DroppedTaskReasonInvalid       = "invalid"
+)
+
 var (
 	ServiceRequests = NewCounterDef(
 		"service_requests",
@@ -1204,7 +1214,7 @@ var (
 	)
 	SyncThrottlePerTaskQueueCounter                   = NewCounterDef("sync_throttle_count")
 	BufferThrottlePerTaskQueueCounter                 = NewCounterDef("buffer_throttle_count")
-	ExpiredTasksPerTaskQueueCounter                   = NewCounterDef("tasks_expired")
+	ExpiredTasksPerTaskQueueCounter                   = NewCounterDef("tasks_expired") // TODO: remove tasks_expired since it is superseded by tasks_dropped (expired_read / expired_memory reasons).
 	ForwardedPerTaskQueueCounter                      = NewCounterDef("forwarded_per_tl")
 	PriorityBacklogForwardedPerTaskQueueCounter       = NewCounterDef("priority_backlog_forwarded")
 	ForwardTaskErrorsPerTaskQueue                     = NewCounterDef("forward_task_errors")
@@ -1243,6 +1253,10 @@ var (
 	NonRetryableTasks                      = NewCounterDef(
 		"non_retryable_tasks",
 		WithDescription("The number of non-retryable matching tasks which are dropped due to specific errors"),
+	)
+	DroppedTasksCounter = NewCounterDef(
+		"tasks_dropped",
+		WithDescription("Backlog/spooled tasks dropped by matching (e.g. a Record(Workflow|Activity)TaskStarted call to history failed, the task expired, or it failed validation). Sync-match tasks are excluded. Per-task-queue, tagged with `reason` identifying the failure mode."),
 	)
 	TaskCompletedMissing = NewCounterDef(
 		"task_completed_dropped",

--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -19,9 +19,11 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/primitives/timestamp"
 	testutil "go.temporal.io/server/common/testing"
+	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/common/tqid"
 	"go.temporal.io/server/common/util"
@@ -43,6 +45,7 @@ type BacklogManagerTestSuite struct {
 	cancelCtx  context.CancelFunc
 	taskMgr    *testTaskManager
 	ptqMgr     *MockphysicalTaskQueueManager
+	metricsCap *metricstest.CaptureHandler
 
 	capturedTasksLock  sync.Mutex
 	capturedTasksSlice []*internalTask
@@ -73,6 +76,11 @@ func (s *BacklogManagerTestSuite) SetupTest() {
 		s.taskMgr = newTestTaskManager(s.logger)
 	}
 
+	// A capture handler discards recordings while no capture is active (see
+	// CaptureHandler.record), so it behaves like a noop handler for tests that
+	// don't call StartCapture.
+	s.metricsCap = metricstest.NewCaptureHandler()
+
 	s.cfgcli = dynamicconfig.NewMemoryClient()
 	s.cfgcol = dynamicconfig.NewCollection(s.cfgcli, s.logger)
 
@@ -100,7 +108,7 @@ func (s *BacklogManagerTestSuite) SetupTest() {
 			s.logger,
 			s.logger,
 			nil,
-			metrics.NoopMetricsHandler,
+			s.metricsCap,
 			func() counter.Counter { return counter.NewMapCounter(1000) },
 			false,
 		)
@@ -113,7 +121,7 @@ func (s *BacklogManagerTestSuite) SetupTest() {
 			s.logger,
 			s.logger,
 			nil,
-			metrics.NoopMetricsHandler,
+			s.metricsCap,
 			false,
 		)
 	} else {
@@ -125,7 +133,7 @@ func (s *BacklogManagerTestSuite) SetupTest() {
 			s.logger,
 			s.logger,
 			nil,
-			metrics.NoopMetricsHandler,
+			s.metricsCap,
 		)
 	}
 }
@@ -436,7 +444,7 @@ func (s *BacklogManagerTestSuite) TestApproximateBacklogCount_ResetOnDrained() {
 	// - ackLevel gets set to maxReadLevel
 	// - backlog counts reset to 0
 	for _, t := range s.capturedTasks() {
-		t.finish(nil, true)
+		t.finish(taskFinishResult{consumedToken: true})
 	}
 
 	_, ackLevel := blm.subqueues[subqueueZero].getLevels()
@@ -568,7 +576,7 @@ func (s *BacklogManagerTestSuite) testSkipExpiredTasks(batchSize int, blocks ...
 
 	// Complete the delivered tasks.
 	for _, t := range s.capturedTasks() {
-		t.finish(nil, true)
+		t.finish(taskFinishResult{consumedToken: true})
 	}
 
 	// Verify the ack level advances past all tasks (expired + valid).
@@ -582,6 +590,104 @@ func (s *BacklogManagerTestSuite) testSkipExpiredTasks(batchSize int, blocks ...
 		}
 		return db.subqueues[subqueueZero].AckLevel >= lastID
 	}, 2*time.Second, 10*time.Millisecond, "ack level did not advance past all tasks")
+}
+
+// TestExpiredTasksOnRead_EmitTasksDropped verifies tasks_dropped is emitted once per
+// task that has already expired when read from persistence, with reason=expired_read.
+func (s *BacklogManagerTestSuite) TestExpiredTasksOnRead_EmitTasksDropped() {
+	const numExpired = 3
+
+	capture := s.metricsCap.StartCapture()
+	defer s.metricsCap.StopCapture(capture)
+
+	droppedReasons := func() []string {
+		var reasons []string
+		for _, r := range capture.Snapshot()[metrics.DroppedTasksCounter.Name()] {
+			reasons = append(reasons, r.Tags["reason"])
+		}
+		return reasons
+	}
+
+	if !s.newMatcher {
+		// Classic reader: drive addTasksToBuffer directly, mirroring
+		// TestReadLevelForAllExpiredTasksInBatch. The emission is synchronous.
+		blm := s.blm.(*backlogManagerImpl)
+		s.Require().NoError(blm.taskWriter.initReadWriteState())
+
+		expired := make([]*persistencespb.AllocatedTaskInfo, numExpired)
+		for i := range expired {
+			expired[i] = &persistencespb.AllocatedTaskInfo{
+				TaskId: int64(i + 1),
+				Data: &persistencespb.TaskInfo{
+					CreateTime: timestamp.TimeNowPtrUtcAddSeconds(-3600),
+					ExpiryTime: timestamp.TimeNowPtrUtcAddSeconds(-60),
+				},
+			}
+		}
+		s.Require().NoError(blm.taskReader.addTasksToBuffer(context.TODO(), expired))
+
+		reasons := droppedReasons()
+		s.Require().Len(reasons, numExpired)
+		for _, reason := range reasons {
+			s.Equal(dropReasonExpiredRead.tag().Value, reason)
+		}
+		return
+	}
+
+	// Pri/fair readers read the backlog from the DB asynchronously after Start.
+	// Pre-populate the DB with already-expired tasks plus one valid task (a trailing
+	// valid task keeps this off the priTaskReader all-expired edge case).
+	ctx := context.Background()
+	queue := s.ptqMgr.QueueKey()
+	queueInfo := &persistencespb.TaskQueueInfo{
+		NamespaceId: queue.NamespaceId(),
+		Name:        queue.PersistenceName(),
+		TaskType:    queue.TaskType(),
+	}
+	_, err := s.taskMgr.CreateTaskQueue(ctx, &persistence.CreateTaskQueueRequest{
+		RangeID:       1,
+		TaskQueueInfo: queueInfo,
+	})
+	s.Require().NoError(err)
+
+	var dbTasks []*persistencespb.AllocatedTaskInfo
+	for id := int64(1); id <= numExpired+1; id++ {
+		t := &persistencespb.AllocatedTaskInfo{
+			TaskId: id,
+			Data: &persistencespb.TaskInfo{
+				CreateTime: timestamp.TimeNowPtrUtcAddSeconds(-3600),
+			},
+		}
+		if id <= numExpired {
+			t.Data.ExpiryTime = timestamp.TimeNowPtrUtcAddSeconds(-60) // expired
+		} else {
+			t.Data.ExpiryTime = timestamp.TimeNowPtrUtcAddSeconds(3600) // valid
+		}
+		if s.fairness {
+			t.TaskPass = id * 1000 // spread out pass numbers
+		}
+		dbTasks = append(dbTasks, t)
+	}
+	_, err = s.taskMgr.CreateTasks(ctx, &persistence.CreateTasksRequest{
+		TaskQueueInfo: &persistence.PersistedTaskQueueInfo{Data: queueInfo, RangeID: 1},
+		Tasks:         dbTasks,
+	})
+	s.Require().NoError(err)
+
+	s.setupToCaptureTasks()
+
+	s.blm.Start()
+	defer s.blm.Stop()
+	s.Require().NoError(s.blm.WaitUntilInitialized(context.Background()))
+
+	// Wait for the expired tasks to be read and dropped.
+	await.RequireTrue(s.T(), func() bool {
+		return len(droppedReasons()) == numExpired
+	}, 2*time.Second, 10*time.Millisecond)
+
+	for _, reason := range droppedReasons() {
+		s.Equal(dropReasonExpiredRead.tag().Value, reason)
+	}
 }
 
 func totalApproximateBacklogCount(c backlogManager) (total int64) {
@@ -836,7 +942,7 @@ func (s *BacklogManagerTestSuite) testStandingBacklog(p standingBacklogParams) {
 		for sleepUntil(func() bool { return delta() >= -p.gap }) {
 			if t := getTask(); t != nil {
 				// TODO: error sometimes?
-				t.finish(nil, true)
+				t.finish(taskFinishResult{consumedToken: true})
 
 				tindex := t.event.Data.ScheduledEventId
 				if _, loaded := tracker.LoadAndDelete(tindex); loaded {

--- a/service/matching/fair_task_reader.go
+++ b/service/matching/fair_task_reader.go
@@ -128,6 +128,8 @@ func (tr *fairTaskReader) getOldestBacklogTime() time.Time {
 }
 
 func (tr *fairTaskReader) completeTask(task *internalTask, res taskResponse) {
+	recordDroppedTask(tr.backlogMgr.metricsHandler, res.dropReason)
+
 	tr.lock.Lock()
 
 	// We might have a race where mergeTasks tries to read a task from matcher (because new tasks
@@ -301,7 +303,7 @@ func (tr *fairTaskReader) addTaskToMatcher(task *internalTask) {
 	}
 
 	if drop, retry := tr.addErrorBehavior(err); drop {
-		task.finish(nil, false)
+		task.finish(taskFinishResult{})
 	} else if retry {
 		// This should only be due to persistence problems. Retry in a new goroutine
 		// to not block other tasks, up to some concurrency limit.
@@ -350,12 +352,12 @@ func (tr *fairTaskReader) retryAddAfterError(task *internalTask) {
 		tr.backlogMgr.tqCtx,
 		func(context.Context) error {
 			if IsTaskExpired(task.event.AllocatedTaskInfo) {
-				task.finish(nil, false)
+				task.finish(taskFinishResult{})
 				return nil
 			}
 			err := tr.backlogMgr.addSpooledTask(task)
 			if drop, retry := tr.addErrorBehavior(err); drop {
-				task.finish(nil, false)
+				task.finish(taskFinishResult{})
 			} else if retry {
 				metrics.BufferThrottlePerTaskQueueCounter.With(tr.backlogMgr.metricsHandler).Record(1)
 				return err
@@ -490,6 +492,7 @@ func (tr *fairTaskReader) mergeTasksLocked(tasks []*persistencespb.AllocatedTask
 			// readLevel calculation above and advance ackLevel + get GC'd below.
 			tr.outstandingTasks.Put(level, nil)
 			metrics.ExpiredTasksPerTaskQueueCounter.With(tr.backlogMgr.metricsHandler).Record(1, metrics.TaskExpireStageReadTag)
+			recordDroppedTask(tr.backlogMgr.metricsHandler, dropReasonExpiredRead)
 			hasExpired = true
 			continue
 		}

--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -359,7 +359,7 @@ forLoop:
 			// at this point, we forwarded the task to a parent partition which
 			// in turn dispatched the task to a poller, because there was no error.
 			// Make sure we delete the task from the database.
-			task.finish(nil, true)
+			task.finish(taskFinishResult{consumedToken: true})
 			tm.emitDispatchLatency(task, true)
 			return nil
 		case <-ctx.Done():

--- a/service/matching/matcher_data_test.go
+++ b/service/matching/matcher_data_test.go
@@ -174,7 +174,7 @@ func (s *MatcherDataSuite) TestMatchBacklogTask() {
 	s.Equal(t, pres.task)
 
 	// finish task
-	pres.task.finish(nil, true)
+	pres.task.finish(taskFinishResult{consumedToken: true})
 	s.True(gotResponse)
 
 	// one more, context should time out again. note two contexts this time.
@@ -244,7 +244,7 @@ func (s *MatcherDataSuite) TestQuery() {
 	s.True(pres.task.isQuery())
 	// wake up getResponse. use some error just to check it's passed through.
 	someError := errors.New("some error")
-	pres.task.finish(someError, true)
+	pres.task.finish(taskFinishResult{err: someError, consumedToken: true})
 
 	resp := <-respC
 	s.False(resp.forwarded)
@@ -1044,7 +1044,7 @@ func FuzzMatcherData(f *testing.F) {
 					},
 					TaskId: tid,
 				}
-				md.EnqueueTaskNoWait(newInternalTaskFromBacklog(ati, nil))
+				_ = md.EnqueueTaskNoWait(newInternalTaskFromBacklog(ati, nil))
 
 			case 2: // add backlog task with priority
 				tid++
@@ -1057,7 +1057,7 @@ func FuzzMatcherData(f *testing.F) {
 					},
 					TaskId: tid,
 				}
-				md.EnqueueTaskNoWait(newInternalTaskFromBacklog(ati, nil))
+				_ = md.EnqueueTaskNoWait(newInternalTaskFromBacklog(ati, nil))
 
 			case 3: // add poller
 				timeout := randms(100)

--- a/service/matching/matcher_test.go
+++ b/service/matching/matcher_test.go
@@ -115,7 +115,7 @@ func (t *MatcherTestSuite) TestLocalSyncMatch() {
 		task, err := t.childMatcher.Poll(ctx, &pollMetadata{})
 		cancel()
 		if err == nil {
-			task.finish(nil, true)
+			task.finish(taskFinishResult{consumedToken: true})
 		}
 	}()
 
@@ -151,7 +151,7 @@ func (t *MatcherTestSuite) testRemoteSyncMatch(taskSource enumsspb.TaskSource) {
 		task, err := t.childMatcher.Poll(ctx, &pollMetadata{})
 		cancel()
 		if err == nil && !task.isStarted() {
-			task.finish(nil, true)
+			task.finish(taskFinishResult{consumedToken: true})
 		}
 	}()
 
@@ -163,7 +163,7 @@ func (t *MatcherTestSuite) testRemoteSyncMatch(taskSource enumsspb.TaskSource) {
 			if err != nil {
 				remotePollErr = err
 			} else {
-				task.finish(nil, true)
+				task.finish(taskFinishResult{consumedToken: true})
 				remotePollResp = matchingservice.PollWorkflowTaskQueueResponse{
 					TaskToken:         []byte("token1"),
 					WorkflowExecution: task.workflowExecution(),
@@ -574,7 +574,7 @@ func (t *MatcherTestSuite) TestQueryLocalSyncMatch() {
 		task, err := t.childMatcher.PollForQuery(ctx, &pollMetadata{})
 		cancel()
 		if err == nil && task.isQuery() {
-			task.finish(nil, true)
+			task.finish(taskFinishResult{consumedToken: true})
 		}
 	}()
 
@@ -597,7 +597,7 @@ func (t *MatcherTestSuite) TestQueryRemoteSyncMatch() {
 		task, err := t.childMatcher.PollForQuery(ctx, &pollMetadata{})
 		cancel()
 		if err == nil && task.isQuery() {
-			task.finish(nil, true)
+			task.finish(taskFinishResult{consumedToken: true})
 		}
 	}()
 
@@ -608,7 +608,7 @@ func (t *MatcherTestSuite) TestQueryRemoteSyncMatch() {
 			if err != nil {
 				return nil, err
 			} else if task.isQuery() {
-				task.finish(nil, true)
+				task.finish(taskFinishResult{consumedToken: true})
 				querySet.Store(true)
 				return &matchingservice.PollWorkflowTaskQueueResponse{
 					TaskToken: []byte("token1"),
@@ -661,7 +661,7 @@ func (t *MatcherTestSuite) TestQueryRemoteSyncMatchError() {
 		cancel()
 		if err == nil && task.isQuery() {
 			matched = true
-			task.finish(nil, true)
+			task.finish(taskFinishResult{consumedToken: true})
 		}
 	}()
 
@@ -699,7 +699,7 @@ func (t *MatcherTestSuite) TestMustOfferLocalMatch() {
 		task, err := t.childMatcher.Poll(ctx, &pollMetadata{})
 		cancel()
 		if err == nil {
-			task.finish(nil, true)
+			task.finish(taskFinishResult{consumedToken: true})
 		}
 	}()
 
@@ -727,7 +727,7 @@ func (t *MatcherTestSuite) TestMustOfferRemoteMatch() {
 			if err != nil {
 				return nil, err
 			} else {
-				task.finish(nil, true)
+				task.finish(taskFinishResult{consumedToken: true})
 				return &matchingservice.PollWorkflowTaskQueueResponse{
 					TaskToken:         []byte("token1"),
 					WorkflowExecution: task.workflowExecution(),

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -721,7 +721,7 @@ pollLoop:
 		}
 
 		if task.isQuery() {
-			task.finish(nil, true) // this only means query task sync match succeed.
+			task.finish(taskFinishResult{consumedToken: true}) // this only means query task sync match succeed.
 
 			// for query task, we don't need to update history to record workflow task started. but we need to know
 			// the NextEventID and the currently set sticky task queue.
@@ -780,10 +780,14 @@ pollLoop:
 		resp, err := e.recordWorkflowTaskStarted(ctx, requestClone, task)
 		if err != nil {
 			switch err := err.(type) {
-			case *serviceerror.Internal, *serviceerror.DataLoss:
+			case *serviceerror.Internal:
 				e.nonRetryableErrorsDropTask(task, taskQueueName, err)
 				// drop the task as otherwise task would be stuck in a retry-loop
-				task.finish(nil, false)
+				task.finish(taskFinishResult{dropReason: dropReasonInternalError})
+			case *serviceerror.DataLoss:
+				e.nonRetryableErrorsDropTask(task, taskQueueName, err)
+				// drop the task as otherwise task would be stuck in a retry-loop
+				task.finish(taskFinishResult{dropReason: dropReasonDataLoss})
 			case *serviceerror.NotFound: // mutable state not found, workflow not running or workflow task not found
 				e.logger.Info("Workflow task not found",
 					tag.WorkflowTaskQueueName(taskQueueName),
@@ -795,10 +799,10 @@ pollLoop:
 					tag.WorkflowEventID(task.event.Data.GetScheduledEventId()),
 					tag.Error(err),
 				)
-				task.finish(nil, false)
+				task.finish(taskFinishResult{dropReason: dropReasonNotFound})
 			case *serviceerrors.TaskAlreadyStarted:
 				e.logger.Debug("Duplicated workflow task", tag.WorkflowTaskQueueName(taskQueueName), tag.TaskID(task.event.GetTaskId()))
-				task.finish(nil, false)
+				task.finish(taskFinishResult{dropReason: dropReasonInvalid})
 			case *serviceerrors.ObsoleteDispatchBuildId:
 				// history should've scheduled another task on the right build ID. dropping this one.
 				e.logger.Info("dropping workflow task due to invalid build ID",
@@ -810,7 +814,7 @@ pollLoop:
 					tag.TaskVisibilityTimestamp(timestamp.TimeValue(task.event.Data.GetCreateTime())),
 					tag.BuildId(requestClone.WorkerVersionCapabilities.GetBuildId()),
 				)
-				task.finish(nil, false)
+				task.finish(taskFinishResult{dropReason: dropReasonInvalid})
 			case *serviceerrors.ObsoleteMatchingTask:
 				// History should've scheduled another task on the right task queue and deployment.
 				// Dropping this one.
@@ -829,17 +833,17 @@ pollLoop:
 					tag.BuildId(worker_versioning.BuildIdFromCapabilities(requestClone.WorkerVersionCapabilities, requestClone.DeploymentOptions)),
 					tag.Error(err),
 				)
-				task.finish(nil, false)
+				task.finish(taskFinishResult{dropReason: dropReasonInvalid})
 			case *serviceerror.ResourceExhausted:
 				// If history returns one ResourceExhausted, it's likely to return more if we retry
 				// immediately. Instead, return the error to the client which will back off.
 				// BUSY_WORKFLOW is limited to one workflow and is okay to retry.
-				task.finish(err, false)
+				task.finish(taskFinishResult{err: err})
 				if err.Cause != enumspb.RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW {
 					return nil, err
 				}
 			default:
-				task.finish(err, false)
+				task.finish(taskFinishResult{err: err})
 				if err.Error() == common.ErrNamespaceHandover.Error() {
 					// do not keep polling new tasks when namespace is in handover state
 					// as record start request will be rejected by history service
@@ -850,7 +854,7 @@ pollLoop:
 			continue pollLoop
 		}
 
-		task.finish(nil, true)
+		task.finish(taskFinishResult{consumedToken: true})
 		e.emitTaskDispatchLatency(task, partition, req.GetNamespaceId(), request.Namespace, pollMetadata)
 		return e.createPollWorkflowTaskQueueResponse(task, resp, opMetrics), nil
 	}
@@ -1003,10 +1007,14 @@ pollLoop:
 		resp, err := e.recordActivityTaskStarted(ctx, requestClone, task)
 		if err != nil {
 			switch err := err.(type) {
-			case *serviceerror.Internal, *serviceerror.DataLoss:
+			case *serviceerror.Internal:
 				e.nonRetryableErrorsDropTask(task, taskQueueName, err)
 				// drop the task as otherwise task would be stuck in a retry-loop
-				task.finish(nil, false)
+				task.finish(taskFinishResult{dropReason: dropReasonInternalError})
+			case *serviceerror.DataLoss:
+				e.nonRetryableErrorsDropTask(task, taskQueueName, err)
+				// drop the task as otherwise task would be stuck in a retry-loop
+				task.finish(taskFinishResult{dropReason: dropReasonDataLoss})
 			case *serviceerror.NotFound: // mutable state not found, workflow not running or activity info not found
 				e.logger.Info("Activity task not found",
 					tag.WorkflowNamespaceID(task.event.Data.GetNamespaceId()),
@@ -1018,10 +1026,10 @@ pollLoop:
 					tag.WorkflowEventID(task.event.Data.GetScheduledEventId()),
 					tag.Error(err),
 				)
-				task.finish(nil, false)
+				task.finish(taskFinishResult{dropReason: dropReasonNotFound})
 			case *serviceerrors.TaskAlreadyStarted:
 				e.logger.Debug("Duplicated activity task", tag.WorkflowTaskQueueName(taskQueueName), tag.TaskID(task.event.GetTaskId()))
-				task.finish(nil, false)
+				task.finish(taskFinishResult{dropReason: dropReasonInvalid})
 			case *serviceerrors.ObsoleteDispatchBuildId:
 				// history should've scheduled another task on the right build ID. dropping this one.
 				e.logger.Info("dropping activity task due to invalid build ID",
@@ -1033,7 +1041,7 @@ pollLoop:
 					tag.TaskVisibilityTimestamp(timestamp.TimeValue(task.event.Data.GetCreateTime())),
 					tag.BuildId(requestClone.WorkerVersionCapabilities.GetBuildId()),
 				)
-				task.finish(nil, false)
+				task.finish(taskFinishResult{dropReason: dropReasonInvalid})
 			case *serviceerrors.ObsoleteMatchingTask:
 				// History should've scheduled another task on the right task queue and deployment.
 				// Dropping this one.
@@ -1052,7 +1060,7 @@ pollLoop:
 					tag.BuildId(worker_versioning.BuildIdFromCapabilities(requestClone.WorkerVersionCapabilities, requestClone.DeploymentOptions)),
 					tag.Error(err),
 				)
-				task.finish(nil, false)
+				task.finish(taskFinishResult{dropReason: dropReasonInvalid})
 			case *serviceerrors.ActivityStartDuringTransition:
 				// History will schedule another task once transition ends. Dropping this one.
 				e.logger.Info("dropping activity task during transition",
@@ -1069,17 +1077,17 @@ pollLoop:
 					//nolint:staticcheck // SA1019 deprecated WorkerVersionCapabilities will clean up later
 					tag.BuildId(worker_versioning.BuildIdFromCapabilities(requestClone.WorkerVersionCapabilities, requestClone.DeploymentOptions)),
 				)
-				task.finish(nil, false)
+				task.finish(taskFinishResult{dropReason: dropReasonInvalid})
 			case *serviceerror.ResourceExhausted:
 				// If history returns one ResourceExhausted, it's likely to return more if we retry
 				// immediately. Instead, return the error to the client which will back off.
 				// BUSY_WORKFLOW is limited to one workflow and is okay to retry.
-				task.finish(err, false)
+				task.finish(taskFinishResult{err: err})
 				if err.Cause != enumspb.RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW {
 					return nil, err
 				}
 			default:
-				task.finish(err, false)
+				task.finish(taskFinishResult{err: err})
 				if err.Error() == common.ErrNamespaceHandover.Error() {
 					// do not keep polling new tasks when namespace is in handover state
 					// as record start request will be rejected by history service
@@ -1089,7 +1097,7 @@ pollLoop:
 
 			continue pollLoop
 		}
-		task.finish(nil, true)
+		task.finish(taskFinishResult{consumedToken: true})
 		e.emitTaskDispatchLatency(task, partition, req.GetNamespaceId(), request.Namespace, pollMetadata)
 		return e.createPollActivityTaskQueueResponse(task, resp, opMetrics), nil
 	}
@@ -2591,7 +2599,7 @@ pollLoop:
 			return task.pollNexusTaskQueueResponse(), nil
 		}
 
-		task.finish(err, true)
+		task.finish(taskFinishResult{err: err, consumedToken: true})
 		if err != nil {
 			continue pollLoop
 		}

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -65,6 +65,7 @@ import (
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/tasktoken"
 	"go.temporal.io/server/common/testing/protoassert"
+	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/common/testing/testvars"
 	"go.temporal.io/server/common/tqid"
@@ -697,6 +698,286 @@ func (s *matchingEngineSuite) TestPollWorkflowTaskQueues_NamespaceHandover() {
 	}, metrics.NoopMetricsHandler)
 	s.Nil(resp)
 	s.Equal(common.ErrNamespaceHandover.Error(), err.Error())
+}
+
+// captureDroppedOnEngine points the engine's root metrics handler at a capture handler
+// so drops emitted down the partition handler chain are recorded. Must be called before
+// the task queue partition is created (i.e. before AddActivity/WorkflowTask).
+func (s *matchingEngineSuite) captureDroppedOnEngine() *metricstest.CaptureHandler {
+	capture := metricstest.NewCaptureHandler()
+	s.matchingEngine.metricsHandler = capture
+	return capture
+}
+
+// TestPollActivityTaskQueues_DroppedTaskMetric asserts each error path that drops an
+// activity task emits tasks_dropped with the right `reason` tag.
+func (s *matchingEngineSuite) TestPollActivityTaskQueues_DroppedTaskMetric() {
+	cases := []struct {
+		name       string
+		err        error
+		wantReason string
+		expectLog  bool // Internal/DataLoss log at Error level via nonRetryableErrorsDropTask
+	}{
+		{"Internal", serviceerror.NewInternal("boom"), dropReasonInternalError.tag().Value, true},
+		{"DataLoss", serviceerror.NewDataLoss("boom"), dropReasonDataLoss.tag().Value, true},
+		{"NotFound", serviceerror.NewNotFound("gone"), dropReasonNotFound.tag().Value, false},
+		{"TaskAlreadyStarted", serviceerrors.NewTaskAlreadyStarted("activity"), dropReasonInvalid.tag().Value, false},
+		{"ObsoleteDispatchBuildId", serviceerrors.NewObsoleteDispatchBuildId("bad build id"), dropReasonInvalid.tag().Value, false},
+		{"ObsoleteMatchingTask", serviceerrors.NewObsoleteMatchingTask("obsolete"), dropReasonInvalid.tag().Value, false},
+		{"ActivityStartDuringTransition", serviceerrors.NewActivityStartDuringTransition(), dropReasonInvalid.tag().Value, false},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			if tc.expectLog {
+				s.logger.Expect(testlogger.Error, "dropping task due to non-nonretryable errors")
+			}
+
+			capture := s.captureDroppedOnEngine()
+
+			namespaceID := uuid.NewString()
+			taskQueue := &taskqueuepb.TaskQueue{Name: "queue-" + tc.name, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
+
+			_, _, err := s.matchingEngine.AddActivityTask(context.Background(), &matchingservice.AddActivityTaskRequest{
+				NamespaceId:            namespaceID,
+				Execution:              &commonpb.WorkflowExecution{WorkflowId: "wf", RunId: uuid.NewString()},
+				ScheduledEventId:       int64(5),
+				TaskQueue:              taskQueue,
+				ScheduleToStartTimeout: timestamp.DurationFromSeconds(0),
+			})
+			s.NoError(err)
+
+			s.mockHistoryClient.EXPECT().RecordActivityTaskStarted(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, tc.err).Times(1)
+
+			c := capture.StartCapture()
+
+			resp, err := s.matchingEngine.PollActivityTaskQueue(context.Background(), &matchingservice.PollActivityTaskQueueRequest{
+				NamespaceId: namespaceID,
+				PollRequest: &workflowservice.PollActivityTaskQueueRequest{
+					TaskQueue: taskQueue,
+					Identity:  "identity",
+				},
+			}, metrics.NoopMetricsHandler)
+			protorequire.ProtoEqual(s.T(), emptyPollActivityTaskQueueResponse, resp)
+			s.NoError(err)
+
+			recordings := c.Snapshot()[metrics.DroppedTasksCounter.Name()]
+			s.Len(recordings, 1, "expected one tasks_dropped emission for %s", tc.name)
+			s.Equal(tc.wantReason, recordings[0].Tags["reason"])
+			capture.StopCapture(c)
+		})
+	}
+}
+
+// TestPollWorkflowTaskQueues_DroppedTaskMetric is the workflow counterpart of
+// TestPollActivityTaskQueues_DroppedTaskMetric (no ActivityStartDuringTransition arm).
+func (s *matchingEngineSuite) TestPollWorkflowTaskQueues_DroppedTaskMetric() {
+	cases := []struct {
+		name       string
+		err        error
+		wantReason string
+		expectLog  bool
+	}{
+		{"Internal", serviceerror.NewInternal("boom"), dropReasonInternalError.tag().Value, true},
+		{"DataLoss", serviceerror.NewDataLoss("boom"), dropReasonDataLoss.tag().Value, true},
+		{"NotFound", serviceerror.NewNotFound("gone"), dropReasonNotFound.tag().Value, false},
+		{"TaskAlreadyStarted", serviceerrors.NewTaskAlreadyStarted("workflow"), dropReasonInvalid.tag().Value, false},
+		{"ObsoleteDispatchBuildId", serviceerrors.NewObsoleteDispatchBuildId("bad build id"), dropReasonInvalid.tag().Value, false},
+		{"ObsoleteMatchingTask", serviceerrors.NewObsoleteMatchingTask("obsolete"), dropReasonInvalid.tag().Value, false},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			if tc.expectLog {
+				s.logger.Expect(testlogger.Error, "dropping task due to non-nonretryable errors")
+			}
+
+			capture := s.captureDroppedOnEngine()
+
+			namespaceID := uuid.NewString()
+			taskQueue := &taskqueuepb.TaskQueue{Name: "wf-queue-" + tc.name, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
+
+			_, _, err := s.matchingEngine.AddWorkflowTask(context.Background(), &matchingservice.AddWorkflowTaskRequest{
+				NamespaceId:            namespaceID,
+				Execution:              &commonpb.WorkflowExecution{WorkflowId: "wf-" + tc.name, RunId: uuid.NewString()},
+				ScheduledEventId:       int64(0),
+				TaskQueue:              taskQueue,
+				ScheduleToStartTimeout: timestamp.DurationFromSeconds(100),
+			})
+			s.NoError(err)
+
+			s.mockHistoryClient.EXPECT().RecordWorkflowTaskStarted(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, tc.err).Times(1)
+
+			c := capture.StartCapture()
+
+			resp, err := s.matchingEngine.PollWorkflowTaskQueue(context.Background(), &matchingservice.PollWorkflowTaskQueueRequest{
+				NamespaceId: namespaceID,
+				PollRequest: &workflowservice.PollWorkflowTaskQueueRequest{
+					TaskQueue: taskQueue,
+					Identity:  "identity",
+				},
+			}, metrics.NoopMetricsHandler)
+			protorequire.ProtoEqual(s.T(), emptyPollWorkflowTaskQueueResponse, resp)
+			s.NoError(err)
+
+			recordings := c.Snapshot()[metrics.DroppedTasksCounter.Name()]
+			s.Len(recordings, 1, "expected one tasks_dropped emission for %s", tc.name)
+			s.Equal(tc.wantReason, recordings[0].Tags["reason"])
+			capture.StopCapture(c)
+		})
+	}
+}
+
+// TestPoll{Activity,Workflow}TaskQueues_DroppedTaskMetric_NoEmissionOnPropagatedErrors
+// asserts errors propagated back to the caller (ResourceExhausted, NamespaceHandover) do
+// not increment tasks_dropped.
+func (s *matchingEngineSuite) TestPollActivityTaskQueues_DroppedTaskMetric_NoEmissionOnPropagatedErrors() {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"ResourceExhausted", serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_RPS_LIMIT, "throttled")},
+		{"NamespaceHandover", common.ErrNamespaceHandover},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			capture := s.captureDroppedOnEngine()
+
+			namespaceID := uuid.NewString()
+			taskQueue := &taskqueuepb.TaskQueue{Name: "queue-noemit-" + tc.name, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
+
+			_, _, err := s.matchingEngine.AddActivityTask(context.Background(), &matchingservice.AddActivityTaskRequest{
+				NamespaceId:            namespaceID,
+				Execution:              &commonpb.WorkflowExecution{WorkflowId: "wf", RunId: uuid.NewString()},
+				ScheduledEventId:       int64(5),
+				TaskQueue:              taskQueue,
+				ScheduleToStartTimeout: timestamp.DurationFromSeconds(100),
+			})
+			s.NoError(err)
+
+			s.mockHistoryClient.EXPECT().RecordActivityTaskStarted(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, tc.err).Times(1)
+
+			c := capture.StartCapture()
+
+			_, err = s.matchingEngine.PollActivityTaskQueue(context.Background(), &matchingservice.PollActivityTaskQueueRequest{
+				NamespaceId: namespaceID,
+				PollRequest: &workflowservice.PollActivityTaskQueueRequest{
+					TaskQueue: taskQueue,
+					Identity:  "identity",
+				},
+			}, metrics.NoopMetricsHandler)
+			s.Error(err, "%s should be propagated to the caller", tc.name)
+
+			recordings := c.Snapshot()[metrics.DroppedTasksCounter.Name()]
+			s.Empty(recordings, "tasks_dropped must not fire when the error is returned to the caller (%s)", tc.name)
+			capture.StopCapture(c)
+		})
+	}
+}
+
+func (s *matchingEngineSuite) TestPollWorkflowTaskQueues_DroppedTaskMetric_NoEmissionOnPropagatedErrors() {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"ResourceExhausted", serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_RPS_LIMIT, "throttled")},
+		{"NamespaceHandover", common.ErrNamespaceHandover},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			capture := s.captureDroppedOnEngine()
+
+			namespaceID := uuid.NewString()
+			taskQueue := &taskqueuepb.TaskQueue{Name: "wf-queue-noemit-" + tc.name, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
+
+			_, _, err := s.matchingEngine.AddWorkflowTask(context.Background(), &matchingservice.AddWorkflowTaskRequest{
+				NamespaceId:            namespaceID,
+				Execution:              &commonpb.WorkflowExecution{WorkflowId: "wf-" + tc.name, RunId: uuid.NewString()},
+				ScheduledEventId:       int64(0),
+				TaskQueue:              taskQueue,
+				ScheduleToStartTimeout: timestamp.DurationFromSeconds(100),
+			})
+			s.NoError(err)
+
+			s.mockHistoryClient.EXPECT().RecordWorkflowTaskStarted(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, tc.err).Times(1)
+
+			c := capture.StartCapture()
+
+			_, err = s.matchingEngine.PollWorkflowTaskQueue(context.Background(), &matchingservice.PollWorkflowTaskQueueRequest{
+				NamespaceId: namespaceID,
+				PollRequest: &workflowservice.PollWorkflowTaskQueueRequest{
+					TaskQueue: taskQueue,
+					Identity:  "identity",
+				},
+			}, metrics.NoopMetricsHandler)
+			s.Error(err, "%s should be propagated to the caller", tc.name)
+
+			recordings := c.Snapshot()[metrics.DroppedTasksCounter.Name()]
+			s.Empty(recordings, "tasks_dropped must not fire when the error is returned to the caller (%s)", tc.name)
+			capture.StopCapture(c)
+		})
+	}
+}
+
+// TestDroppedTaskMetric_LabelKeysAreVersionScoped asserts a poll-path drop carries the
+// full per-physical-queue (version-scoped) label-key set, matching every other
+// tasks_dropped emission so the metric registers with a single, stable label set.
+func (s *matchingEngineSuite) TestDroppedTaskMetric_LabelKeysAreVersionScoped() {
+	capture := s.captureDroppedOnEngine()
+
+	namespaceID := uuid.NewString()
+	taskQueue := &taskqueuepb.TaskQueue{Name: "queue-labelkeys", Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
+
+	_, _, err := s.matchingEngine.AddActivityTask(context.Background(), &matchingservice.AddActivityTaskRequest{
+		NamespaceId:            namespaceID,
+		Execution:              &commonpb.WorkflowExecution{WorkflowId: "wf", RunId: uuid.NewString()},
+		ScheduledEventId:       int64(5),
+		TaskQueue:              taskQueue,
+		ScheduleToStartTimeout: timestamp.DurationFromSeconds(0),
+	})
+	s.NoError(err)
+
+	s.mockHistoryClient.EXPECT().RecordActivityTaskStarted(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, serviceerror.NewNotFound("gone")).Times(1)
+
+	c := capture.StartCapture()
+	_, err = s.matchingEngine.PollActivityTaskQueue(context.Background(), &matchingservice.PollActivityTaskQueueRequest{
+		NamespaceId: namespaceID,
+		PollRequest: &workflowservice.PollActivityTaskQueueRequest{
+			TaskQueue: taskQueue,
+			Identity:  "identity",
+		},
+	}, metrics.NoopMetricsHandler)
+	s.NoError(err)
+
+	recordings := c.Snapshot()[metrics.DroppedTasksCounter.Name()]
+	s.Require().Len(recordings, 1)
+	capture.StopCapture(c)
+
+	gotKeys := make([]string, 0, len(recordings[0].Tags))
+	for k := range recordings[0].Tags {
+		gotKeys = append(gotKeys, k)
+	}
+
+	// The full per-physical-queue label-key set.
+	s.ElementsMatch([]string{
+		"namespace",
+		"namespace_state",
+		"operation",
+		"partition",
+		"reason",
+		metrics.TaskTypeTagName,
+		"taskqueue",
+		"worker_build_id",
+		"worker_deployment_name",
+		"worker_version",
+	}, gotKeys)
 }
 
 func (s *matchingEngineSuite) TestPollActivityTaskQueues_InternalError() {
@@ -2236,7 +2517,7 @@ func (s *matchingEngineSuite) TestAddTaskAfterStartFailure() {
 	task1, _, err := s.matchingEngine.pollTask(context.Background(), dbq.partition, &pollMetadata{})
 	s.NoError(err)
 
-	task1.finish(serviceerror.NewInternal("test error"), true)
+	task1.finish(taskFinishResult{err: serviceerror.NewInternal("test error"), consumedToken: true})
 	s.EqualValues(1, s.taskManager.getTaskCount(dbq))
 
 	task2, _, err := s.matchingEngine.pollTask(context.Background(), dbq.partition, &pollMetadata{})
@@ -2244,7 +2525,7 @@ func (s *matchingEngineSuite) TestAddTaskAfterStartFailure() {
 	protoassert.ProtoEqual(s.T(), task1.event.Data, task2.event.Data)
 	s.NotEqual(task1.event.GetTaskId(), task2.event.GetTaskId(), "IDs should not match")
 
-	task2.finish(nil, true)
+	task2.finish(taskFinishResult{consumedToken: true})
 	s.EqualValues(0, s.taskManager.getTaskCount(dbq))
 }
 
@@ -2888,7 +3169,7 @@ func (s *matchingEngineSuite) TestUnknownBuildId_Match() {
 		s.NoError(err)
 		s.Equal("wf", task.event.Data.WorkflowId)
 		s.Equal(int64(123), task.event.Data.ScheduledEventId)
-		task.finish(nil, true)
+		task.finish(taskFinishResult{consumedToken: true})
 		wg.Done()
 	}()
 
@@ -2997,7 +3278,7 @@ func (s *matchingEngineSuite) TestDemotedMatch() {
 	s.Require().NoError(err)
 	s.Equal("wf", task.event.Data.WorkflowId)
 	s.Equal(int64(123), task.event.Data.ScheduledEventId)
-	task.finish(nil, true)
+	task.finish(taskFinishResult{consumedToken: true})
 }
 
 type mockRoutingMatchingClient struct {

--- a/service/matching/metrics_util.go
+++ b/service/matching/metrics_util.go
@@ -1,0 +1,64 @@
+package matching
+
+import (
+	"go.temporal.io/server/common/metrics"
+)
+
+// dropReason is why a backlog task was dropped; it is recorded as the `reason` tag on
+// tasks_dropped. The zero value (dropReasonUnspecified) means the task was not dropped.
+type dropReason int
+
+const (
+	dropReasonUnspecified dropReason = iota
+	dropReasonNotFound
+	dropReasonInternalError
+	dropReasonDataLoss
+	dropReasonExpiredRead
+	dropReasonExpiredMemory
+	dropReasonInvalid
+)
+
+// tag maps the drop reason to its tasks_dropped `reason` metric tag.
+func (r dropReason) tag() metrics.Tag {
+	switch r {
+	case dropReasonNotFound:
+		return metrics.ReasonTag(metrics.DroppedTaskReasonNotFound)
+	case dropReasonInternalError:
+		return metrics.ReasonTag(metrics.DroppedTaskReasonInternalError)
+	case dropReasonDataLoss:
+		return metrics.ReasonTag(metrics.DroppedTaskReasonDataLoss)
+	case dropReasonExpiredRead:
+		return metrics.ReasonTag(metrics.DroppedTaskReasonExpiredRead)
+	case dropReasonExpiredMemory:
+		return metrics.ReasonTag(metrics.DroppedTaskReasonExpiredMemory)
+	default:
+		return metrics.ReasonTag(metrics.DroppedTaskReasonInvalid)
+	}
+}
+
+// getInvalidTaskTag returns the tasks_expired stage tag for a task being dropped
+// due to in-memory expiry or validation failure.
+func getInvalidTaskTag(task *internalTask) metrics.Tag {
+	if IsTaskExpired(task.event.AllocatedTaskInfo) {
+		return metrics.TaskExpireStageMemoryTag
+	}
+	return metrics.TaskInvalidTag
+}
+
+// getDroppedTaskExpiryReason returns the drop reason for a task being dropped due to
+// in-memory expiry or validation failure.
+func getDroppedTaskExpiryReason(task *internalTask) dropReason {
+	if IsTaskExpired(task.event.AllocatedTaskInfo) {
+		return dropReasonExpiredMemory
+	}
+	return dropReasonInvalid
+}
+
+// recordDroppedTask records the tasks_dropped counter on the given physical-queue
+// handler. It is a no-op when reason is dropReasonUnspecified (a non-drop completion).
+func recordDroppedTask(handler metrics.Handler, reason dropReason) {
+	if reason == dropReasonUnspecified {
+		return
+	}
+	metrics.DroppedTasksCounter.With(handler).Record(1, reason.tag())
+}

--- a/service/matching/metrics_util_test.go
+++ b/service/matching/metrics_util_test.go
@@ -1,0 +1,65 @@
+package matching
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func backlogTaskWithExpiry(t *testing.T, expiry *timestamppb.Timestamp) *internalTask {
+	t.Helper()
+	return newInternalTaskFromBacklog(&persistencespb.AllocatedTaskInfo{
+		TaskId: 1,
+		Data: &persistencespb.TaskInfo{
+			CreateTime: timestamppb.Now(),
+			ExpiryTime: expiry,
+		},
+	}, func(*internalTask, taskResponse) {})
+}
+
+func TestGetInvalidTaskTag(t *testing.T) {
+	t.Run("expired -> memory stage", func(t *testing.T) {
+		task := backlogTaskWithExpiry(t, timestamppb.New(time.Now().Add(-time.Minute)))
+		require.Equal(t, metrics.TaskExpireStageMemoryTag, getInvalidTaskTag(task))
+	})
+
+	t.Run("not expired -> invalid", func(t *testing.T) {
+		task := backlogTaskWithExpiry(t, nil)
+		require.Equal(t, metrics.TaskInvalidTag, getInvalidTaskTag(task))
+	})
+}
+
+func TestGetDroppedTaskExpiryReason(t *testing.T) {
+	t.Run("expired -> expired_memory", func(t *testing.T) {
+		task := backlogTaskWithExpiry(t, timestamppb.New(time.Now().Add(-time.Minute)))
+		require.Equal(t, dropReasonExpiredMemory, getDroppedTaskExpiryReason(task))
+	})
+
+	t.Run("not expired -> invalid", func(t *testing.T) {
+		task := backlogTaskWithExpiry(t, nil)
+		require.Equal(t, dropReasonInvalid, getDroppedTaskExpiryReason(task))
+	})
+}
+
+// TestRecordDroppedTask verifies the single tasks_dropped entry point records the counter
+// with the reason's tag, and is a no-op when the reason is dropReasonUnspecified.
+func TestRecordDroppedTask(t *testing.T) {
+	capture := metricstest.NewCaptureHandler()
+	c := capture.StartCapture()
+	defer capture.StopCapture(c)
+
+	// not dropped (normal completion): no-op.
+	recordDroppedTask(capture, dropReasonUnspecified)
+	require.Empty(t, c.Snapshot()[metrics.DroppedTasksCounter.Name()])
+
+	// dropped: counted with the reason's tag.
+	recordDroppedTask(capture, dropReasonNotFound)
+	recordings := c.Snapshot()[metrics.DroppedTasksCounter.Name()]
+	require.Len(t, recordings, 1)
+	require.Equal(t, dropReasonNotFound.tag().Value, recordings[0].Tags["reason"])
+}

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -521,7 +521,7 @@ func (c *physicalTaskQueueManagerImpl) PollTask(
 		if task.event != nil && IsTaskExpired(task.event.AllocatedTaskInfo) {
 			// task is expired while polling
 			c.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1, metrics.TaskExpireStageMemoryTag)
-			task.finish(nil, false)
+			task.finish(taskFinishResult{dropReason: dropReasonExpiredMemory})
 			continue
 		}
 
@@ -568,10 +568,9 @@ func (c *physicalTaskQueueManagerImpl) ProcessSpooledTask(
 	task *internalTask,
 ) error {
 	if !c.taskValidator.maybeValidate(task.event.AllocatedTaskInfo, c.queue.TaskType()) {
-		task.finish(nil, false)
-
 		var invalidTaskTag = getInvalidTaskTag(task)
 		c.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1, invalidTaskTag)
+		task.finish(taskFinishResult{dropReason: getDroppedTaskExpiryReason(task)})
 		// Don't try to set read level here because it may have been advanced already.
 
 		// Stay alive as long as we're invalidating tasks

--- a/service/matching/physical_task_queue_manager_test.go
+++ b/service/matching/physical_task_queue_manager_test.go
@@ -160,7 +160,7 @@ func runOneShotPoller(ctx context.Context, tqm physicalTaskQueueManager) (*goro.
 			out <- err
 			return nil
 		}
-		task.finish(err, true)
+		task.finish(taskFinishResult{err: err, consumedToken: true})
 		out <- task
 		return nil
 	})

--- a/service/matching/pri_matcher.go
+++ b/service/matching/pri_matcher.go
@@ -209,11 +209,11 @@ func (tm *priTaskMatcher) forwardTask(task *internalTask) (bool, error) {
 		// to the head of the backlog, which is what taskValidator expects.
 		maybeValid := tm.validator.maybeValidate(task.event.AllocatedTaskInfo, tm.fwdr.partition.TaskType())
 		if !maybeValid {
-			task.finish(nil, false)
 			var invalidTaskTag = getInvalidTaskTag(task)
 
 			// consider this task expired while processing.
 			tm.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1, invalidTaskTag)
+			task.finish(taskFinishResult{dropReason: getDroppedTaskExpiryReason(task)})
 
 			// Stay alive as long as we're invalidating tasks
 			tm.markAlive()
@@ -268,9 +268,9 @@ func (tm *priTaskMatcher) validateTasksOnRoot(retrier backoff.Retrier) {
 		maybeValid := tm.validator == nil || tm.validator.maybeValidate(task.event.AllocatedTaskInfo, tm.partition.TaskType())
 		if !maybeValid {
 			// We found an invalid one, complete it and go back for another immediately.
-			task.finish(nil, false)
 			var invalidStageTag = getInvalidTaskTag(task)
 			tm.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1, invalidStageTag)
+			task.finish(taskFinishResult{dropReason: getDroppedTaskExpiryReason(task)})
 
 			// Stay alive as long as we're invalidating tasks
 			tm.markAlive()
@@ -278,7 +278,7 @@ func (tm *priTaskMatcher) validateTasksOnRoot(retrier backoff.Retrier) {
 			retrier.Reset()
 		} else {
 			// Task was valid, put it back and slow down checking.
-			task.finish(errReprocessTask, true)
+			task.finish(taskFinishResult{err: errReprocessTask, consumedToken: true})
 			// retrier's max interval is backlogTaskForwardTimeout, so for just valid tasks,
 			// this loop will essentially be limited to that interval.
 			util.InterruptibleSleep(tm.tqCtx, retrier.NextBackOff(nil))
@@ -559,7 +559,7 @@ func (tm *priTaskMatcher) ReprocessAllTasks() {
 	// ReprocessTasks will have woken sync tasks, but for backlog we also need to call finish.
 	for _, task := range tasks {
 		if !task.isSyncMatchTask() {
-			task.finish(errReprocessTask, true)
+			task.finish(taskFinishResult{err: errReprocessTask, consumedToken: true})
 		}
 	}
 }
@@ -576,7 +576,7 @@ func (tm *priTaskMatcher) ReprocessRedirectedTasksAfterStop() {
 			for _, task := range tasks {
 				// these should all be from backlog (not sync-match) but check again to be sure
 				if !task.isSyncMatchTask() {
-					task.finish(errReprocessTask, true)
+					task.finish(taskFinishResult{err: errReprocessTask, consumedToken: true})
 				}
 			}
 		}()
@@ -696,13 +696,6 @@ func (tm *priTaskMatcher) emitForwardedSourceStats(
 	default:
 		metrics.LocalToLocalMatchPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
 	}
-}
-
-func getInvalidTaskTag(task *internalTask) metrics.Tag {
-	if IsTaskExpired(task.event.AllocatedTaskInfo) {
-		return metrics.TaskExpireStageMemoryTag
-	}
-	return metrics.TaskInvalidTag
 }
 
 func (p *waitingPoller) minPriority() priorityKey {

--- a/service/matching/pri_matcher_test.go
+++ b/service/matching/pri_matcher_test.go
@@ -192,3 +192,76 @@ func (s *PriMatcherSuite) TestForwardPollRetriesOnResourceExhausted() {
 		require.Equal(t, taskToken, task.started.workflowTaskInfo.TaskToken)
 	})
 }
+
+// TestValidatorDrop_SetsDropReason verifies that when the root-partition validator
+// rejects a backlog task, it finishes the task with the right drop reason — which
+// reader.completeTask records in tasks_dropped: expired_memory for a time-expired task,
+// invalid for one that only failed validation.
+func (s *PriMatcherSuite) TestValidatorDrop_SetsDropReason() {
+	cases := []struct {
+		name       string
+		expiryTime *timestamppb.Timestamp
+		wantReason dropReason
+	}{
+		{"ExpiredMemory", timestamppb.New(time.Now().Add(-time.Hour)), dropReasonExpiredMemory},
+		{"Invalid", nil, dropReasonInvalid},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			cfg := newTaskQueueConfig(
+				tqid.UnsafeTaskQueueFamily("nsid", "tq").TaskQueue(enumspb.TASK_QUEUE_TYPE_WORKFLOW),
+				NewConfig(dynamicconfig.NewNoopCollection()),
+				"nsname",
+			)
+			partition := tqid.UnsafeTaskQueueFamily("nsid", "tq").
+				TaskQueue(enumspb.TASK_QUEUE_TYPE_WORKFLOW).
+				RootPartition()
+
+			// Validator rejects every task it sees, forcing the drop path.
+			mockValidator := NewMocktaskValidator(s.controller)
+			mockValidator.EXPECT().maybeValidate(gomock.Any(), gomock.Any()).Return(false).AnyTimes()
+
+			rateLimitManager := newRateLimitManager(&mockUserDataManager{}, cfg, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
+			tm := newPriTaskMatcher(
+				ctx,
+				cfg,
+				partition,
+				nil, // nil forwarder = root partition -> validateTasksOnRoot path
+				nil,
+				mockValidator,
+				s.logger,
+				metrics.NoopMetricsHandler,
+				rateLimitManager,
+				func() {},
+			)
+			tm.Start()
+			defer tm.Stop()
+
+			completionCalled := make(chan taskResponse, 1)
+			task := newInternalTaskFromBacklog(&persistencespb.AllocatedTaskInfo{
+				TaskId: 1,
+				Data: &persistencespb.TaskInfo{
+					CreateTime: timestamppb.Now(),
+					ExpiryTime: tc.expiryTime,
+				},
+			}, func(_ *internalTask, res taskResponse) {
+				completionCalled <- res
+			})
+
+			task.resetMatcherState()
+			_ = tm.AddTask(task)
+
+			select {
+			case res := <-completionCalled:
+				s.Require().NoError(res.err()) // task is dropped, not reprocessed
+				s.Equal(tc.wantReason, res.dropReason)
+			case <-time.After(2 * time.Second):
+				s.Fail("timed out waiting for validator to drop task")
+			}
+		})
+	}
+}

--- a/service/matching/pri_task_reader.go
+++ b/service/matching/pri_task_reader.go
@@ -109,6 +109,8 @@ func (tr *priTaskReader) getOldestBacklogTime() time.Time {
 }
 
 func (tr *priTaskReader) completeTask(task *internalTask, res taskResponse) {
+	recordDroppedTask(tr.backlogMgr.metricsHandler, res.dropReason)
+
 	err := res.err()
 
 	// We can handle some transient errors by just putting the task back in the matcher to
@@ -249,6 +251,7 @@ func (tr *priTaskReader) processTaskBatch(tasks []*persistencespb.AllocatedTaskI
 		if IsTaskExpired(t) {
 			// task expired when we read it
 			metrics.ExpiredTasksPerTaskQueueCounter.With(tr.backlogMgr.metricsHandler).Record(1, metrics.TaskExpireStageReadTag)
+			recordDroppedTask(tr.backlogMgr.metricsHandler, dropReasonExpiredRead)
 			return true
 		}
 
@@ -298,7 +301,7 @@ func (tr *priTaskReader) addTaskToMatcher(task *internalTask) {
 	}
 
 	if drop, retry := tr.addErrorBehavior(err); drop {
-		task.finish(nil, false)
+		task.finish(taskFinishResult{})
 	} else if retry {
 		// This should only be due to persistence problems. Retry in a new goroutine
 		// to not block other tasks, up to some concurrency limit.
@@ -347,12 +350,12 @@ func (tr *priTaskReader) retryAddAfterError(task *internalTask) {
 		tr.backlogMgr.tqCtx,
 		func(context.Context) error {
 			if IsTaskExpired(task.event.AllocatedTaskInfo) {
-				task.finish(nil, false)
+				task.finish(taskFinishResult{})
 				return nil
 			}
 			err := tr.backlogMgr.addSpooledTask(task)
 			if drop, retry := tr.addErrorBehavior(err); drop {
-				task.finish(nil, false)
+				task.finish(taskFinishResult{})
 			} else if retry {
 				metrics.BufferThrottlePerTaskQueueCounter.With(tr.backlogMgr.metricsHandler).Record(1)
 				return err

--- a/service/matching/task.go
+++ b/service/matching/task.go
@@ -99,6 +99,20 @@ type (
 		forwardRes any // note this may be a non-nil "any" containing a nil pointer
 		forwardErr error
 		startErr   error
+		// dropReason, when set, marks a dropped backlog task;
+		// reader.completeTask records it in tasks_dropped.
+		dropReason dropReason
+	}
+
+	// taskFinishResult describes how a task finished. It is passed to internalTask.finish.
+	taskFinishResult struct {
+		// err is the result of RecordTaskStarted (or forwarding); nil on success or drop.
+		err error
+		// consumedToken reports whether the task consumed its rate-limit token (see finish).
+		consumedToken bool
+		// dropReason, when set, indicates the task is being dropped rather than dispatched
+		// and is recorded in tasks_dropped.
+		dropReason dropReason
 	}
 )
 
@@ -346,22 +360,27 @@ func (task *internalTask) setEvicted() {
 // method should be called with a non-nil error argument.
 //
 // If the task took a rate limit token and didn't "use" it by actually dispatching the task,
-// finish will be called with wasValid=false and task.recycleToken=clockedRateLimiter.RecycleToken,
+// finish will be called with consumedToken=false and task.recycleToken=clockedRateLimiter.RecycleToken,
 // so finish will call the rate limiter's RecycleToken to give the unused token back to any process
 // that is waiting on the token, if one exists.
-func (task *internalTask) finish(err error, wasValid bool) {
-	res := taskResponse{startErr: err}
-	task.finishInternal(res, wasValid)
+//
+// When a backlog task is being dropped rather than dispatched, set r.dropReason; it is
+// carried on the taskResponse and counted in tasks_dropped by the backlog completion
+// callback (reader.completeTask).
+func (task *internalTask) finish(r taskFinishResult) {
+	task.finishInternal(taskResponse{
+		startErr:   r.err,
+		dropReason: r.dropReason,
+	}, r.consumedToken)
 }
 
 // finishForward must be called after forwarding a task.
-func (task *internalTask) finishForward(forwardRes any, forwardErr error, wasValid bool) {
-	res := taskResponse{forwarded: true, forwardRes: forwardRes, forwardErr: forwardErr}
-	task.finishInternal(res, wasValid)
+func (task *internalTask) finishForward(forwardRes any, forwardErr error, consumedToken bool) {
+	task.finishInternal(taskResponse{forwarded: true, forwardRes: forwardRes, forwardErr: forwardErr}, consumedToken)
 }
 
-func (task *internalTask) finishInternal(res taskResponse, wasValid bool) {
-	if !wasValid && task.recycleToken != nil {
+func (task *internalTask) finishInternal(res taskResponse, consumedToken bool) {
+	if !consumedToken && task.recycleToken != nil {
 		task.recycleToken(task)
 	}
 

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -927,7 +927,7 @@ func (pm *taskQueuePartitionManagerImpl) ProcessSpooledTask(
 			}
 			// Finish the task because now it is copied to the other backlog. It should be considered
 			// invalid because a poller did not receive the task.
-			task.finish(nil, false)
+			task.finish(taskFinishResult{})
 			return nil
 		}
 		err = syncMatchQueue.DispatchSpooledTask(ctx, task, userDataChanged)
@@ -992,7 +992,7 @@ func (pm *taskQueuePartitionManagerImpl) AddSpooledTask(
 		}
 		// Finish the task because now it is copied to the other backlog. It should be considered
 		// invalid because a poller did not receive the task.
-		task.finish(nil, false)
+		task.finish(taskFinishResult{})
 		return nil
 	}
 	return syncMatchQueue.AddSpooledTaskToMatcher(task)

--- a/service/matching/task_reader.go
+++ b/service/matching/task_reader.go
@@ -124,6 +124,7 @@ dispatchLoop:
 }
 
 func (tr *taskReader) completeTask(task *internalTask, res taskResponse) {
+	recordDroppedTask(tr.taggedMetricsHandler(), res.dropReason)
 	tr.backlogMgr.completeTask(task, res.startErr)
 }
 
@@ -256,6 +257,7 @@ func (tr *taskReader) addTasksToBuffer(
 		if IsTaskExpired(t) {
 			// task is expired when "add tasks to buffer" is called, so when we read it
 			metrics.ExpiredTasksPerTaskQueueCounter.With(tr.taggedMetricsHandler()).Record(1, metrics.TaskExpireStageReadTag)
+			recordDroppedTask(tr.taggedMetricsHandler(), dropReasonExpiredRead)
 			// Also increment readLevel for expired tasks otherwise it could result in
 			// looping over the same tasks if all tasks read in the batch are expired
 			tr.backlogMgr.taskAckManager.setReadLevel(t.GetTaskId())


### PR DESCRIPTION
## What changed?
Adds a per-task-queue `tasks_dropped` counter to the matching service, tagged with a `reason` enum (`internal_error`, `data_loss`, `not_found`, `invalid`, `expired_read`, `expired_memory`). It fires whenever matching throws away a backlog/spooled task — a `Record(Workflow|Activity)TaskStarted` call failing non-retryably, the task expiring, or failing validation. Sync-match tasks are excluded; `ResourceExhausted`/`NamespaceHandover` (propagated to the caller) are not counted. All task-based drops funnel through `internalTask.finish` and are emitted from a single point (`finishInternal`) on the physical queue's version-scoped handler, so every emission carries the same label set.

## Why?
The only prior signal for non-retryable drops was `non_retryable_tasks`, emitted at engine scope (no namespace/taskqueue/task_type labels) and only for `Internal`/`DataLoss`. Operators couldn't see which task queues were bleeding tasks, or why. `tasks_dropped` gives a per-task-queue, reason-tagged view across all silent-drop paths.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)