### PR TITLE
Remove test cluster recycling after 50 leases

### DIFF
--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -32,16 +32,9 @@ func init() {
 		dedicatedSize = n
 	}
 
-	// In CI, recreate clusters after 50 tests to prevent resource accumulation.
-	// Locally, clusters are reused indefinitely for faster iteration.
-	var maxLeases int
-	if os.Getenv("CI") != "" {
-		maxLeases = 50
-	}
-
 	testClusterRouter = &clusterRouter{
-		shared:    newClusterPool(sharedSize, false, maxLeases),
-		dedicated: newClusterPool(dedicatedSize, true, maxLeases),
+		shared:    newClusterPool(sharedSize, false, 0),
+		dedicated: newClusterPool(dedicatedSize, true, 0),
 	}
 }
 


### PR DESCRIPTION
## Summary

Remove the 50-lease recycling in `test_cluster_pool.go`.

## Why?

Relieve memory pressure by creating fewer clusters.