### PR TITLE
Add nexus operation archetype ID to force migration translation

### DIFF
--- a/chasm/lib/nexusoperation/library.go
+++ b/chasm/lib/nexusoperation/library.go
@@ -7,6 +7,16 @@ import (
 	"google.golang.org/grpc"
 )
 
+const (
+	libraryName   = "nexusoperation"
+	componentName = "operation"
+)
+
+var (
+	Archetype   = chasm.FullyQualifiedName(libraryName, componentName)
+	ArchetypeID = chasm.GenerateTypeID(Archetype)
+)
+
 type operationContextKeyType struct{}
 
 // OperationContextKey is the context key for OperationContext, registered as a CHASM component
@@ -32,13 +42,13 @@ func newComponentOnlyLibrary(dc *dynamicconfig.Collection) *componentOnlyLibrary
 }
 
 func (l *componentOnlyLibrary) Name() string {
-	return "nexusoperation"
+	return libraryName
 }
 
 func (l *componentOnlyLibrary) Components() []*chasm.RegistrableComponent {
 	return []*chasm.RegistrableComponent{
 		chasm.NewRegistrableComponent[*Operation](
-			"operation",
+			componentName,
 			chasm.WithSearchAttributes(
 				EndpointSearchAttribute,
 				ServiceSearchAttribute,

--- a/service/worker/migration/activities.go
+++ b/service/worker/migration/activities.go
@@ -20,6 +20,7 @@ import (
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/chasm"
 	chasmactivity "go.temporal.io/server/chasm/lib/activity"
+	chasmnexus "go.temporal.io/server/chasm/lib/nexusoperation"
 	serverClient "go.temporal.io/server/client"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -1198,11 +1199,15 @@ func (a *activities) archetypeIDToName(ctx context.Context, archetypeID chasm.Ar
 		return chasm.WorkflowArchetype, nil
 	}
 
-	// chasm activity library is not registered on worker service, so hardcoding the mapping here for now.
+	// chasm activity and nexus operation libraries are not registered on worker service, so hardcoding
+	// the mapping here for now.
 	// TODO: Accept archetypeID in admin apis directly and remove this translation logic which relies on
 	// chasm registry.
 	if archetypeID == chasmactivity.ArchetypeID {
 		return chasmactivity.Archetype, nil
+	}
+	if archetypeID == chasmnexus.ArchetypeID {
+		return chasmnexus.Archetype, nil
 	}
 
 	archetype, ok := a.chasmRegistry.ComponentFqnByID(archetypeID)


### PR DESCRIPTION
## What changed?
Add nexus operation hardcoded archetypeID for force migration handler. Worker service does not register Nexus operations in the chasm Registry, so we need a manual translation. Will fast follow up to use archetypeID directly in the future to avoid more hardcoding.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)
