### PR TITLE
Dither initial fairness pass

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1519,6 +1519,14 @@ second per poller by one physical queue manager`,
 		counter.DefaultCounterParams,
 		`Configuration for counter used in matching fairness.`,
 	)
+	MatchingFairnessPassDither = NewTaskQueueBoolSetting(
+		"matching.fairnessPassDither",
+		false,
+		`When true, dither the starting pass of new/reset fairness keys over their initial
+stride instead of starting them all at the ack level. This spreads low-weight keys ahead
+in pass-space so they don't clump at the front after a counter reset (e.g. partition
+movement), at the cost of cross-key FIFO ordering for bursts of equal-weight new keys.`,
+	)
 	MatchingFairnessKeyRateLimitCacheSize = NewTaskQueueIntSetting(
 		"matching.fairnessKeyRateLimitCacheSize",
 		2000,

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -136,6 +136,7 @@ type (
 		PollerScalingDecisionsPerSecond dynamicconfig.FloatPropertyFnWithTaskQueueFilter
 
 		FairnessCounter               dynamicconfig.TypedPropertyFnWithTaskQueueFilter[counter.CounterParams]
+		FairnessPassDither            dynamicconfig.BoolPropertyFnWithTaskQueueFilter
 		PartitionScaleAllowedDrift    dynamicconfig.TypedPropertyFnWithTaskQueueFilter[dynamicconfig.PartitionScaleAllowedDrift]
 		PartitionScaleManagerSettings dynamicconfig.TypedPropertyFnWithTaskQueueFilter[dynamicconfig.PartitionScaleManagerSettings]
 
@@ -227,6 +228,7 @@ type (
 		PollerScalingDecisionsPerSecond func() float64
 
 		FairnessCounter               func() counter.CounterParams
+		FairnessPassDither            func() bool
 		PartitionScaleAllowedDrift    func() dynamicconfig.PartitionScaleAllowedDrift
 		PartitionScaleManagerSettings func() dynamicconfig.PartitionScaleManagerSettings
 
@@ -377,6 +379,7 @@ func NewConfig(
 		PollerScalingDecisionsPerSecond: dynamicconfig.MatchingPollerScalingDecisionsPerSecond.Get(dc),
 
 		FairnessCounter:               dynamicconfig.MatchingFairnessCounter.Get(dc),
+		FairnessPassDither:            dynamicconfig.MatchingFairnessPassDither.Get(dc),
 		PartitionScaleAllowedDrift:    dynamicconfig.MatchingPartitionScaleAllowedDrift.Get(dc),
 		PartitionScaleManagerSettings: dynamicconfig.MatchingPartitionScaleManager.Get(dc),
 
@@ -547,6 +550,9 @@ func newTaskQueueConfig(tq *tqid.TaskQueue, config *Config, ns namespace.Name) *
 		},
 		FairnessCounter: func() counter.CounterParams {
 			return config.FairnessCounter(ns.String(), taskQueueName, taskType)
+		},
+		FairnessPassDither: func() bool {
+			return config.FairnessPassDither(ns.String(), taskQueueName, taskType)
 		},
 		PartitionScaleAllowedDrift: func() dynamicconfig.PartitionScaleAllowedDrift {
 			return config.PartitionScaleAllowedDrift(ns.String(), taskQueueName, taskType)

--- a/service/matching/fair_task_writer.go
+++ b/service/matching/fair_task_writer.go
@@ -2,6 +2,7 @@ package matching
 
 import (
 	"context"
+	"hash/maphash"
 	"sync/atomic"
 	"time"
 
@@ -31,6 +32,7 @@ type (
 		taskIDBlock        taskIDBlock
 		currentTaskIDBlock taskIDBlock                       // copy of taskIDBlock for safe concurrent access via getCurrentTaskIDBlock()
 		counters           map[subqueueIndex]counter.Counter // only used in taskWriterLoop.
+		ditherSeed         maphash.Seed                      // seed for fairness pass dither (see pickPasses).
 	}
 )
 
@@ -48,6 +50,7 @@ func newFairTaskWriter(
 
 		taskIDBlock: noTaskIDs,
 		counters:    make(map[subqueueIndex]counter.Counter),
+		ditherSeed:  maphash.MakeSeed(),
 	}
 }
 
@@ -115,6 +118,7 @@ func (w *fairTaskWriter) allocTaskIDs(reqs []*writeTaskRequest) error {
 func (w *fairTaskWriter) pickPasses(tasks []*writeTaskRequest, bases []fairLevel) {
 	// Fetch latest fairness weight overrides from the partition's rate limit manager via pqMgr
 	overrides := w.backlogMgr.pqMgr.GetFairnessWeightOverrides()
+	dither := w.config.FairnessPassDither()
 
 	for i, task := range tasks {
 		pri := task.taskInfo.Priority
@@ -122,6 +126,9 @@ func (w *fairTaskWriter) pickPasses(tasks []*writeTaskRequest, bases []fairLevel
 		weight := getEffectiveWeight(overrides, pri)
 		inc := max(1, int64(strideFactor/weight))
 		base := bases[task.subqueue].pass
+		if dither {
+			base = ditherPass(w.ditherSeed, key, base, inc)
+		}
 		cntr := w.counters[task.subqueue]
 		if cntr == nil {
 			cntr = w.counterFactory(task.subqueue)

--- a/service/matching/fairness_util.go
+++ b/service/matching/fairness_util.go
@@ -1,6 +1,7 @@
 package matching
 
 import (
+	"hash/maphash"
 	"maps"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -27,6 +28,16 @@ func getEffectiveWeight(overrides fairnessWeightOverrides, pri *commonpb.Priorit
 		weight = max(weight, minWeight)
 	}
 	return weight
+}
+
+// ditherPass spreads a new/reset key's starting pass deterministically over its initial
+// stride [base, base+inc), based on a stable hash of the key. This keeps low-weight
+// (large-stride) keys from all clumping at the ack level after a counter reset (e.g.
+// partition movement), which would otherwise let them block dispatch of higher-weight
+// keys. Established keys are unaffected: GetPass returns max(base, prev+inc), and a key
+// already above the ack level has prev >= base, so prev+inc > base+(inc-1) always wins.
+func ditherPass(seed maphash.Seed, key string, base, inc int64) int64 {
+	return base + int64(maphash.Comparable(seed, key)%uint64(inc))
 }
 
 func mergeFairnessWeightOverrides(

--- a/service/matching/fairness_util_test.go
+++ b/service/matching/fairness_util_test.go
@@ -1,9 +1,11 @@
 package matching
 
 import (
+	"hash/maphash"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/service/matching/counter"
 )
 
 func TestMergeFairnessWeightOverrides(t *testing.T) {
@@ -74,5 +76,56 @@ func TestMergeFairnessWeightOverrides(t *testing.T) {
 		out, err := mergeFairnessWeightOverrides(existing, set, unset, 2)
 		require.NoError(t, err)
 		require.Equal(t, fairnessWeightOverrides{"a": 1.0, "c": 5.0}, out)
+	})
+}
+
+func TestDitherPass(t *testing.T) {
+	seed := maphash.MakeSeed()
+	const base, inc = 1_000_000, 2000
+
+	t.Run("stays within initial stride", func(t *testing.T) {
+		for i := range 10_000 {
+			key := string(rune('a'+i%26)) + string(rune('0'+i/26%10)) + string(rune(i))
+			p := ditherPass(seed, key, base, inc)
+			require.GreaterOrEqual(t, p, int64(base))
+			require.Less(t, p, int64(base+inc))
+		}
+	})
+
+	t.Run("deterministic for a given key and seed", func(t *testing.T) {
+		p1 := ditherPass(seed, "key-1", base, inc)
+		p2 := ditherPass(seed, "key-1", base, inc)
+		require.Equal(t, p1, p2)
+	})
+
+	t.Run("spreads distinct keys across the stride", func(t *testing.T) {
+		// With many keys we should land in more than a handful of distinct buckets.
+		buckets := map[int64]struct{}{}
+		for i := range 1000 {
+			p := ditherPass(seed, "spread-"+string(rune(i)), base, inc)
+			buckets[(p-base)/100] = struct{}{}
+		}
+		require.Greater(t, len(buckets), 10)
+	})
+
+	t.Run("inc of 1 (max weight) does not panic and yields base", func(t *testing.T) {
+		require.Equal(t, int64(base), ditherPass(seed, "anything", base, 1))
+	})
+
+	t.Run("only fresh/reset keys are moved, established keys untouched", func(t *testing.T) {
+		// Mirror pickPasses: dither the base, then ask the counter for the pass. A fresh key
+		// lands in the dithered stride; once established, subsequent passes step by inc from
+		// its own history and ignore the (lower) dithered base.
+		cntr := counter.NewMapCounter(100)
+		key := "established"
+
+		first := cntr.GetPass(key, ditherPass(seed, key, base, inc), inc)
+		require.GreaterOrEqual(t, first, int64(base))
+		require.Less(t, first, int64(base+inc))
+
+		// Next task for the same key steps exactly one stride past the first, regardless of
+		// what the dithered base would have been.
+		second := cntr.GetPass(key, ditherPass(seed, key, base, inc), inc)
+		require.Equal(t, first+inc, second)
 	})
 }


### PR DESCRIPTION
## What changed?
Add optional dithering for initial fairness pass number over the full stride.

## Why?
This helps in situations with lots of fairness keys and also varying key weights used for prioritization. There's a potential downside that in equal-weight situations, tasks would get shuffled more away from fifo, so it's off by default.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
