### PR TITLE
Fix upgrade panic: Lazily initialize scheduler event logs

### DIFF
--- a/chasm/lib/scheduler/backfiller.go
+++ b/chasm/lib/scheduler/backfiller.go
@@ -46,7 +46,7 @@ func addBackfiller(
 		scheduler.Backfillers = make(chasm.Map[string, *Backfiller])
 	}
 	scheduler.Backfillers[id] = chasm.NewComponentField(ctx, backfiller)
-	scheduler.eventLog(ctx).LogEvent(ctx, fmt.Sprintf("added backfiller: %s", id))
+	scheduler.getOrCreateEventLog(ctx).LogEvent(ctx, fmt.Sprintf("added backfiller: %s", id))
 
 	return backfiller
 }
@@ -62,7 +62,7 @@ func newBackfillerWithState(ctx chasm.MutableContext, state *schedulerpb.Backfil
 
 // scheduleTask schedules a BackfillerTask at the given time.
 func (b *Backfiller) scheduleTask(ctx chasm.MutableContext, scheduledTime time.Time) {
-	b.eventLog(ctx).LogEvent(ctx,
+	b.getOrCreateEventLog(ctx).LogEvent(ctx,
 		fmt.Sprintf("scheduled backfillerTask for %s", scheduledTime.Format(time.RFC3339)))
 	ctx.AddTask(b, chasm.TaskAttributes{
 		ScheduledTime: scheduledTime,

--- a/chasm/lib/scheduler/backfiller.go
+++ b/chasm/lib/scheduler/backfiller.go
@@ -46,7 +46,7 @@ func addBackfiller(
 		scheduler.Backfillers = make(chasm.Map[string, *Backfiller])
 	}
 	scheduler.Backfillers[id] = chasm.NewComponentField(ctx, backfiller)
-	scheduler.EventLog.Get(ctx).LogEvent(ctx, fmt.Sprintf("added backfiller: %s", id))
+	scheduler.eventLog(ctx).LogEvent(ctx, fmt.Sprintf("added backfiller: %s", id))
 
 	return backfiller
 }
@@ -62,7 +62,7 @@ func newBackfillerWithState(ctx chasm.MutableContext, state *schedulerpb.Backfil
 
 // scheduleTask schedules a BackfillerTask at the given time.
 func (b *Backfiller) scheduleTask(ctx chasm.MutableContext, scheduledTime time.Time) {
-	b.EventLog.Get(ctx).LogEvent(ctx,
+	b.eventLog(ctx).LogEvent(ctx,
 		fmt.Sprintf("scheduled backfillerTask for %s", scheduledTime.Format(time.RFC3339)))
 	ctx.AddTask(b, chasm.TaskAttributes{
 		ScheduledTime: scheduledTime,

--- a/chasm/lib/scheduler/backfiller_tasks.go
+++ b/chasm/lib/scheduler/backfiller_tasks.go
@@ -82,7 +82,7 @@ func (b *BackfillerTaskHandler) Execute(
 
 	invoker := scheduler.Invoker.Get(ctx)
 
-	backfiller.EventLog.Get(ctx).LogEvent(ctx, "backfillerTask executed")
+	backfiller.eventLog(ctx).LogEvent(ctx, "backfillerTask executed")
 
 	// If the buffer is already full, don't move the watermark at all, just back off
 	// and retry.

--- a/chasm/lib/scheduler/backfiller_tasks.go
+++ b/chasm/lib/scheduler/backfiller_tasks.go
@@ -82,7 +82,7 @@ func (b *BackfillerTaskHandler) Execute(
 
 	invoker := scheduler.Invoker.Get(ctx)
 
-	backfiller.eventLog(ctx).LogEvent(ctx, "backfillerTask executed")
+	backfiller.getOrCreateEventLog(ctx).LogEvent(ctx, "backfillerTask executed")
 
 	// If the buffer is already full, don't move the watermark at all, just back off
 	// and retry.

--- a/chasm/lib/scheduler/eventlog.go
+++ b/chasm/lib/scheduler/eventlog.go
@@ -26,6 +26,46 @@ func NewEventLog(ctx chasm.MutableContext) *EventLog {
 	}
 }
 
+func (s *Scheduler) eventLog(ctx chasm.MutableContext) *EventLog {
+	eventLog, ok := s.EventLog.TryGet(ctx)
+	if ok {
+		return eventLog
+	}
+	eventLog = NewEventLog(ctx)
+	s.EventLog = chasm.NewComponentField(ctx, eventLog)
+	return eventLog
+}
+
+func (g *Generator) eventLog(ctx chasm.MutableContext) *EventLog {
+	eventLog, ok := g.EventLog.TryGet(ctx)
+	if ok {
+		return eventLog
+	}
+	eventLog = NewEventLog(ctx)
+	g.EventLog = chasm.NewComponentField(ctx, eventLog)
+	return eventLog
+}
+
+func (i *Invoker) eventLog(ctx chasm.MutableContext) *EventLog {
+	eventLog, ok := i.EventLog.TryGet(ctx)
+	if ok {
+		return eventLog
+	}
+	eventLog = NewEventLog(ctx)
+	i.EventLog = chasm.NewComponentField(ctx, eventLog)
+	return eventLog
+}
+
+func (b *Backfiller) eventLog(ctx chasm.MutableContext) *EventLog {
+	eventLog, ok := b.EventLog.TryGet(ctx)
+	if ok {
+		return eventLog
+	}
+	eventLog = NewEventLog(ctx)
+	b.EventLog = chasm.NewComponentField(ctx, eventLog)
+	return eventLog
+}
+
 func (e *EventLog) LifecycleState(ctx chasm.Context) chasm.LifecycleState {
 	return chasm.LifecycleStateRunning
 }

--- a/chasm/lib/scheduler/eventlog.go
+++ b/chasm/lib/scheduler/eventlog.go
@@ -26,7 +26,7 @@ func NewEventLog(ctx chasm.MutableContext) *EventLog {
 	}
 }
 
-func (s *Scheduler) eventLog(ctx chasm.MutableContext) *EventLog {
+func (s *Scheduler) getOrCreateEventLog(ctx chasm.MutableContext) *EventLog {
 	eventLog, ok := s.EventLog.TryGet(ctx)
 	if ok {
 		return eventLog
@@ -36,7 +36,7 @@ func (s *Scheduler) eventLog(ctx chasm.MutableContext) *EventLog {
 	return eventLog
 }
 
-func (g *Generator) eventLog(ctx chasm.MutableContext) *EventLog {
+func (g *Generator) getOrCreateEventLog(ctx chasm.MutableContext) *EventLog {
 	eventLog, ok := g.EventLog.TryGet(ctx)
 	if ok {
 		return eventLog
@@ -46,7 +46,7 @@ func (g *Generator) eventLog(ctx chasm.MutableContext) *EventLog {
 	return eventLog
 }
 
-func (i *Invoker) eventLog(ctx chasm.MutableContext) *EventLog {
+func (i *Invoker) getOrCreateEventLog(ctx chasm.MutableContext) *EventLog {
 	eventLog, ok := i.EventLog.TryGet(ctx)
 	if ok {
 		return eventLog
@@ -56,7 +56,7 @@ func (i *Invoker) eventLog(ctx chasm.MutableContext) *EventLog {
 	return eventLog
 }
 
-func (b *Backfiller) eventLog(ctx chasm.MutableContext) *EventLog {
+func (b *Backfiller) getOrCreateEventLog(ctx chasm.MutableContext) *EventLog {
 	eventLog, ok := b.EventLog.TryGet(ctx)
 	if ok {
 		return eventLog

--- a/chasm/lib/scheduler/generator.go
+++ b/chasm/lib/scheduler/generator.go
@@ -50,7 +50,7 @@ func (g *Generator) Generate(ctx chasm.MutableContext) {
 
 // scheduleTask schedules a GeneratorTask at the given time.
 func (g *Generator) scheduleTask(ctx chasm.MutableContext, scheduledTime time.Time) {
-	g.eventLog(ctx).LogEvent(ctx,
+	g.getOrCreateEventLog(ctx).LogEvent(ctx,
 		fmt.Sprintf("scheduled generatorTask for %s", scheduledTime.Format(time.RFC3339)))
 	ctx.AddTask(g, chasm.TaskAttributes{
 		ScheduledTime: scheduledTime,

--- a/chasm/lib/scheduler/generator.go
+++ b/chasm/lib/scheduler/generator.go
@@ -50,7 +50,7 @@ func (g *Generator) Generate(ctx chasm.MutableContext) {
 
 // scheduleTask schedules a GeneratorTask at the given time.
 func (g *Generator) scheduleTask(ctx chasm.MutableContext, scheduledTime time.Time) {
-	g.EventLog.Get(ctx).LogEvent(ctx,
+	g.eventLog(ctx).LogEvent(ctx,
 		fmt.Sprintf("scheduled generatorTask for %s", scheduledTime.Format(time.RFC3339)))
 	ctx.AddTask(g, chasm.TaskAttributes{
 		ScheduledTime: scheduledTime,

--- a/chasm/lib/scheduler/generator_tasks.go
+++ b/chasm/lib/scheduler/generator_tasks.go
@@ -60,7 +60,7 @@ func (g *GeneratorTaskHandler) Execute(
 
 	now := ctx.Now(generator)
 
-	generator.eventLog(ctx).LogEvent(ctx, "generatorTask executed")
+	generator.getOrCreateEventLog(ctx).LogEvent(ctx, "generatorTask executed")
 
 	// If we have no last processed time, this is a new schedule.
 	if generator.LastProcessedTime == nil {
@@ -106,7 +106,7 @@ func (g *GeneratorTaskHandler) Execute(
 
 	// Emit metrics and update state for any dropped actions.
 	if result.DroppedCount > 0 {
-		generator.eventLog(ctx).LogEvent(ctx,
+		generator.getOrCreateEventLog(ctx).LogEvent(ctx,
 			fmt.Sprintf("buffer overrun, dropped %d actions", result.DroppedCount))
 		logger.Warn("Buffer overrun, dropping actions",
 			tag.Int64("dropped-count", result.DroppedCount))
@@ -147,7 +147,7 @@ func (g *GeneratorTaskHandler) Execute(
 		// customer can describe/modify/restart the schedule.
 		//
 		// Once the idle timer expires, we close the component.
-		generator.eventLog(ctx).LogEvent(ctx,
+		generator.getOrCreateEventLog(ctx).LogEvent(ctx,
 			fmt.Sprintf("scheduled idle task for %s", idleExpiration.Format(time.RFC3339)))
 		ctx.AddTask(scheduler, chasm.TaskAttributes{
 			ScheduledTime: idleExpiration,
@@ -182,7 +182,7 @@ func (g *GeneratorTaskHandler) logSchedule(ctx chasm.MutableContext, logger log.
 	spec := jsonStringer{sched.Schedule.Spec}
 	policies := jsonStringer{sched.Schedule.Policies}
 
-	generator.eventLog(ctx).LogEvent(ctx, fmt.Sprintf("%s:\nSpec: %s\nPolicies: %s\n", msg, spec, policies))
+	generator.getOrCreateEventLog(ctx).LogEvent(ctx, fmt.Sprintf("%s:\nSpec: %s\nPolicies: %s\n", msg, spec, policies))
 	logger.Info(msg,
 		tag.Stringer("spec", spec),
 		tag.Stringer("policies", policies))

--- a/chasm/lib/scheduler/generator_tasks.go
+++ b/chasm/lib/scheduler/generator_tasks.go
@@ -60,7 +60,7 @@ func (g *GeneratorTaskHandler) Execute(
 
 	now := ctx.Now(generator)
 
-	generator.EventLog.Get(ctx).LogEvent(ctx, "generatorTask executed")
+	generator.eventLog(ctx).LogEvent(ctx, "generatorTask executed")
 
 	// If we have no last processed time, this is a new schedule.
 	if generator.LastProcessedTime == nil {
@@ -106,7 +106,7 @@ func (g *GeneratorTaskHandler) Execute(
 
 	// Emit metrics and update state for any dropped actions.
 	if result.DroppedCount > 0 {
-		generator.EventLog.Get(ctx).LogEvent(ctx,
+		generator.eventLog(ctx).LogEvent(ctx,
 			fmt.Sprintf("buffer overrun, dropped %d actions", result.DroppedCount))
 		logger.Warn("Buffer overrun, dropping actions",
 			tag.Int64("dropped-count", result.DroppedCount))
@@ -147,7 +147,7 @@ func (g *GeneratorTaskHandler) Execute(
 		// customer can describe/modify/restart the schedule.
 		//
 		// Once the idle timer expires, we close the component.
-		generator.EventLog.Get(ctx).LogEvent(ctx,
+		generator.eventLog(ctx).LogEvent(ctx,
 			fmt.Sprintf("scheduled idle task for %s", idleExpiration.Format(time.RFC3339)))
 		ctx.AddTask(scheduler, chasm.TaskAttributes{
 			ScheduledTime: idleExpiration,
@@ -182,7 +182,7 @@ func (g *GeneratorTaskHandler) logSchedule(ctx chasm.MutableContext, logger log.
 	spec := jsonStringer{sched.Schedule.Spec}
 	policies := jsonStringer{sched.Schedule.Policies}
 
-	generator.EventLog.Get(ctx).LogEvent(ctx, fmt.Sprintf("%s:\nSpec: %s\nPolicies: %s\n", msg, spec, policies))
+	generator.eventLog(ctx).LogEvent(ctx, fmt.Sprintf("%s:\nSpec: %s\nPolicies: %s\n", msg, spec, policies))
 	logger.Info(msg,
 		tag.Stringer("spec", spec),
 		tag.Stringer("policies", policies))

--- a/chasm/lib/scheduler/invoker.go
+++ b/chasm/lib/scheduler/invoker.go
@@ -51,7 +51,7 @@ func newInvokerWithState(ctx chasm.MutableContext, state *schedulerpb.InvokerSta
 func (i *Invoker) EnqueueBufferedStarts(ctx chasm.MutableContext, starts []*schedulespb.BufferedStart) {
 	i.BufferedStarts = append(i.BufferedStarts, starts...)
 	if len(starts) > 0 {
-		i.EventLog.Get(ctx).LogEvent(ctx, fmt.Sprintf("enqueued %d buffered start(s)", len(starts)))
+		i.eventLog(ctx).LogEvent(ctx, fmt.Sprintf("enqueued %d buffered start(s)", len(starts)))
 	}
 	i.addTasks(ctx)
 }
@@ -111,7 +111,7 @@ func (i *Invoker) recordProcessBufferResult(ctx chasm.MutableContext, result *pr
 	}
 
 	if readiedStarts > 0 || deferredStarts > 0 {
-		i.EventLog.Get(ctx).LogEvent(ctx,
+		i.eventLog(ctx).LogEvent(ctx,
 			fmt.Sprintf("recordProcessBufferResult readied %d starts, deferred %d starts", readiedStarts, deferredStarts))
 	}
 
@@ -217,7 +217,7 @@ func (i *Invoker) recordExecuteResult(ctx chasm.MutableContext, result *executeR
 		}
 	}
 
-	i.EventLog.Get(ctx).LogEvent(ctx,
+	i.eventLog(ctx).LogEvent(ctx,
 		fmt.Sprintf("recordExecuteResult kicked off %d starts, removed %d starts, retried %d starts",
 			newlyStarted,
 			removedStarts,
@@ -248,7 +248,7 @@ func (i *Invoker) recordCompletedAction(
 	completed *schedulespb.CompletedResult,
 	requestID string,
 ) (scheduleTime time.Time) {
-	i.EventLog.Get(ctx).LogEvent(ctx, fmt.Sprintf("recording completed action: %s", requestID))
+	i.eventLog(ctx).LogEvent(ctx, fmt.Sprintf("recording completed action: %s", requestID))
 
 	// Find the BufferedStart and mark it as completed.
 	for _, start := range i.BufferedStarts {
@@ -297,12 +297,12 @@ func (i *Invoker) addTasks(ctx chasm.MutableContext) {
 	// If we have Attempt = 0 starts, generate a ProcessBufferTask immediately. If we
 	// have starts that are backing off, add a timer task for the earliest backoff time.
 	if i.hasUnprocessedStarts() {
-		i.EventLog.Get(ctx).LogEvent(ctx, "scheduled processBufferTask immediately")
+		i.eventLog(ctx).LogEvent(ctx, "scheduled processBufferTask immediately")
 		ctx.AddTask(i, chasm.TaskAttributes{
 			ScheduledTime: chasm.TaskScheduledTimeImmediate,
 		}, &schedulerpb.InvokerProcessBufferTask{})
 	} else if deadline := i.nextBackoffDeadline(); !deadline.IsZero() {
-		i.EventLog.Get(ctx).LogEvent(ctx,
+		i.eventLog(ctx).LogEvent(ctx,
 			fmt.Sprintf("scheduled processBufferTask for %s", deadline.Format(time.RFC3339)))
 		ctx.AddTask(i, chasm.TaskAttributes{
 			ScheduledTime: deadline,
@@ -314,7 +314,7 @@ func (i *Invoker) addTasks(ctx chasm.MutableContext) {
 	if len(i.GetCancelWorkflows()) > 0 ||
 		len(i.GetTerminateWorkflows()) > 0 ||
 		len(i.getEligibleBufferedStarts()) > 0 {
-		i.EventLog.Get(ctx).LogEvent(ctx, "scheduled executeTask")
+		i.eventLog(ctx).LogEvent(ctx, "scheduled executeTask")
 		ctx.AddTask(i, chasm.TaskAttributes{}, &schedulerpb.InvokerExecuteTask{})
 	}
 }

--- a/chasm/lib/scheduler/invoker.go
+++ b/chasm/lib/scheduler/invoker.go
@@ -51,7 +51,7 @@ func newInvokerWithState(ctx chasm.MutableContext, state *schedulerpb.InvokerSta
 func (i *Invoker) EnqueueBufferedStarts(ctx chasm.MutableContext, starts []*schedulespb.BufferedStart) {
 	i.BufferedStarts = append(i.BufferedStarts, starts...)
 	if len(starts) > 0 {
-		i.eventLog(ctx).LogEvent(ctx, fmt.Sprintf("enqueued %d buffered start(s)", len(starts)))
+		i.getOrCreateEventLog(ctx).LogEvent(ctx, fmt.Sprintf("enqueued %d buffered start(s)", len(starts)))
 	}
 	i.addTasks(ctx)
 }
@@ -111,7 +111,7 @@ func (i *Invoker) recordProcessBufferResult(ctx chasm.MutableContext, result *pr
 	}
 
 	if readiedStarts > 0 || deferredStarts > 0 {
-		i.eventLog(ctx).LogEvent(ctx,
+		i.getOrCreateEventLog(ctx).LogEvent(ctx,
 			fmt.Sprintf("recordProcessBufferResult readied %d starts, deferred %d starts", readiedStarts, deferredStarts))
 	}
 
@@ -217,7 +217,7 @@ func (i *Invoker) recordExecuteResult(ctx chasm.MutableContext, result *executeR
 		}
 	}
 
-	i.eventLog(ctx).LogEvent(ctx,
+	i.getOrCreateEventLog(ctx).LogEvent(ctx,
 		fmt.Sprintf("recordExecuteResult kicked off %d starts, removed %d starts, retried %d starts",
 			newlyStarted,
 			removedStarts,
@@ -248,7 +248,7 @@ func (i *Invoker) recordCompletedAction(
 	completed *schedulespb.CompletedResult,
 	requestID string,
 ) (scheduleTime time.Time) {
-	i.eventLog(ctx).LogEvent(ctx, fmt.Sprintf("recording completed action: %s", requestID))
+	i.getOrCreateEventLog(ctx).LogEvent(ctx, fmt.Sprintf("recording completed action: %s", requestID))
 
 	// Find the BufferedStart and mark it as completed.
 	for _, start := range i.BufferedStarts {
@@ -297,12 +297,12 @@ func (i *Invoker) addTasks(ctx chasm.MutableContext) {
 	// If we have Attempt = 0 starts, generate a ProcessBufferTask immediately. If we
 	// have starts that are backing off, add a timer task for the earliest backoff time.
 	if i.hasUnprocessedStarts() {
-		i.eventLog(ctx).LogEvent(ctx, "scheduled processBufferTask immediately")
+		i.getOrCreateEventLog(ctx).LogEvent(ctx, "scheduled processBufferTask immediately")
 		ctx.AddTask(i, chasm.TaskAttributes{
 			ScheduledTime: chasm.TaskScheduledTimeImmediate,
 		}, &schedulerpb.InvokerProcessBufferTask{})
 	} else if deadline := i.nextBackoffDeadline(); !deadline.IsZero() {
-		i.eventLog(ctx).LogEvent(ctx,
+		i.getOrCreateEventLog(ctx).LogEvent(ctx,
 			fmt.Sprintf("scheduled processBufferTask for %s", deadline.Format(time.RFC3339)))
 		ctx.AddTask(i, chasm.TaskAttributes{
 			ScheduledTime: deadline,
@@ -314,7 +314,7 @@ func (i *Invoker) addTasks(ctx chasm.MutableContext) {
 	if len(i.GetCancelWorkflows()) > 0 ||
 		len(i.GetTerminateWorkflows()) > 0 ||
 		len(i.getEligibleBufferedStarts()) > 0 {
-		i.eventLog(ctx).LogEvent(ctx, "scheduled executeTask")
+		i.getOrCreateEventLog(ctx).LogEvent(ctx, "scheduled executeTask")
 		ctx.AddTask(i, chasm.TaskAttributes{}, &schedulerpb.InvokerExecuteTask{})
 	}
 }

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -435,7 +435,7 @@ func (h *InvokerProcessBufferTaskHandler) Execute(
 		Counter(metrics.ScheduleInvokerProcessBufferTask.Name()).
 		Record(1, metrics.OutcomeTag(outcomeFired), metrics.ReasonTag(reasonNone))
 
-	invoker.eventLog(ctx).LogEvent(ctx, "processBufferTask executed")
+	invoker.getOrCreateEventLog(ctx).LogEvent(ctx, "processBufferTask executed")
 
 	// Make sure we have something to start.
 	executionInfo := scheduler.Schedule.GetAction().GetStartWorkflow()

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -435,7 +435,7 @@ func (h *InvokerProcessBufferTaskHandler) Execute(
 		Counter(metrics.ScheduleInvokerProcessBufferTask.Name()).
 		Record(1, metrics.OutcomeTag(outcomeFired), metrics.ReasonTag(reasonNone))
 
-	invoker.EventLog.Get(ctx).LogEvent(ctx, "processBufferTask executed")
+	invoker.eventLog(ctx).LogEvent(ctx, "processBufferTask executed")
 
 	// Make sure we have something to start.
 	executionInfo := scheduler.Schedule.GetAction().GetStartWorkflow()

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -572,7 +572,7 @@ func (s *Scheduler) HandleNexusCompletion(
 		// If the request ID was removed, the request must have already been processed;
 		// fast-succeed.
 		msg := "handled Nexus completion with an unrecognized request ID"
-		s.eventLog(ctx).LogEvent(ctx,
+		s.getOrCreateEventLog(ctx).LogEvent(ctx,
 			fmt.Sprintf("%s: %s", msg, info.RequestId))
 		ctx.Logger().Warn(msg, tag.RequestID(info.RequestId))
 		return nil
@@ -809,7 +809,7 @@ func (s *Scheduler) MigrateToWorkflow(
 	s.Schedule.State.Paused = true
 	s.Schedule.State.Notes = "paused for migration to workflow-backed scheduler"
 
-	s.eventLog(ctx).LogEvent(ctx, "started migration to V1")
+	s.getOrCreateEventLog(ctx).LogEvent(ctx, "started migration to V1")
 
 	// Schedule a side-effect task to export state and start the V1 workflow.
 	ctx.AddTask(s, chasm.TaskAttributes{}, &schedulerpb.SchedulerMigrateToWorkflowTask{})
@@ -867,7 +867,7 @@ func (s *Scheduler) Update(
 
 	s.Info.UpdateTime = timestamppb.New(ctx.Now(s))
 	s.updateConflictToken()
-	s.eventLog(ctx).LogEvent(ctx, "updated via API")
+	s.getOrCreateEventLog(ctx).LogEvent(ctx, "updated via API")
 
 	// Since the spec may have been updated, kick off the generator.
 	s.Generator.Get(ctx).Generate(ctx)
@@ -894,7 +894,7 @@ func (s *Scheduler) Patch(
 	if req.FrontendRequest.Patch.Pause != "" {
 		s.Schedule.State.Paused = true
 		s.Schedule.State.Notes = req.FrontendRequest.Patch.Pause
-		s.eventLog(ctx).LogEvent(ctx, fmt.Sprintf("paused via API: %s", req.FrontendRequest.Patch.Pause))
+		s.getOrCreateEventLog(ctx).LogEvent(ctx, fmt.Sprintf("paused via API: %s", req.FrontendRequest.Patch.Pause))
 	}
 	if req.FrontendRequest.Patch.Unpause != "" {
 		if s.WorkflowMigration != nil {
@@ -902,7 +902,7 @@ func (s *Scheduler) Patch(
 		}
 		s.Schedule.State.Paused = false
 		s.Schedule.State.Notes = req.FrontendRequest.Patch.Unpause
-		s.eventLog(ctx).LogEvent(ctx, fmt.Sprintf("unpaused via API: %s", req.FrontendRequest.Patch.Unpause))
+		s.getOrCreateEventLog(ctx).LogEvent(ctx, fmt.Sprintf("unpaused via API: %s", req.FrontendRequest.Patch.Unpause))
 	}
 
 	if err := s.handlePatch(ctx, req.FrontendRequest.Patch); err != nil {

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -572,7 +572,7 @@ func (s *Scheduler) HandleNexusCompletion(
 		// If the request ID was removed, the request must have already been processed;
 		// fast-succeed.
 		msg := "handled Nexus completion with an unrecognized request ID"
-		s.EventLog.Get(ctx).LogEvent(ctx,
+		s.eventLog(ctx).LogEvent(ctx,
 			fmt.Sprintf("%s: %s", msg, info.RequestId))
 		ctx.Logger().Warn(msg, tag.RequestID(info.RequestId))
 		return nil
@@ -809,7 +809,7 @@ func (s *Scheduler) MigrateToWorkflow(
 	s.Schedule.State.Paused = true
 	s.Schedule.State.Notes = "paused for migration to workflow-backed scheduler"
 
-	s.EventLog.Get(ctx).LogEvent(ctx, "started migration to V1")
+	s.eventLog(ctx).LogEvent(ctx, "started migration to V1")
 
 	// Schedule a side-effect task to export state and start the V1 workflow.
 	ctx.AddTask(s, chasm.TaskAttributes{}, &schedulerpb.SchedulerMigrateToWorkflowTask{})
@@ -867,7 +867,7 @@ func (s *Scheduler) Update(
 
 	s.Info.UpdateTime = timestamppb.New(ctx.Now(s))
 	s.updateConflictToken()
-	s.EventLog.Get(ctx).LogEvent(ctx, "updated via API")
+	s.eventLog(ctx).LogEvent(ctx, "updated via API")
 
 	// Since the spec may have been updated, kick off the generator.
 	s.Generator.Get(ctx).Generate(ctx)
@@ -894,7 +894,7 @@ func (s *Scheduler) Patch(
 	if req.FrontendRequest.Patch.Pause != "" {
 		s.Schedule.State.Paused = true
 		s.Schedule.State.Notes = req.FrontendRequest.Patch.Pause
-		s.EventLog.Get(ctx).LogEvent(ctx, fmt.Sprintf("paused via API: %s", req.FrontendRequest.Patch.Pause))
+		s.eventLog(ctx).LogEvent(ctx, fmt.Sprintf("paused via API: %s", req.FrontendRequest.Patch.Pause))
 	}
 	if req.FrontendRequest.Patch.Unpause != "" {
 		if s.WorkflowMigration != nil {
@@ -902,7 +902,7 @@ func (s *Scheduler) Patch(
 		}
 		s.Schedule.State.Paused = false
 		s.Schedule.State.Notes = req.FrontendRequest.Patch.Unpause
-		s.EventLog.Get(ctx).LogEvent(ctx, fmt.Sprintf("unpaused via API: %s", req.FrontendRequest.Patch.Unpause))
+		s.eventLog(ctx).LogEvent(ctx, fmt.Sprintf("unpaused via API: %s", req.FrontendRequest.Patch.Unpause))
 	}
 
 	if err := s.handlePatch(ctx, req.FrontendRequest.Patch); err != nil {

--- a/chasm/lib/scheduler/scheduler_idle_tasks_test.go
+++ b/chasm/lib/scheduler/scheduler_idle_tasks_test.go
@@ -68,18 +68,22 @@ func TestIdleTask_Execute(t *testing.T) {
 	env := newTestEnv(t)
 	ctx := env.MutableContext()
 	sched := env.Scheduler
+	eventLog := sched.EventLog.Get(ctx)
 
 	handler := newIdleHandler(10 * time.Minute)
 	require.False(t, sched.Closed)
 	err := handler.Execute(ctx, sched, chasm.TaskAttributes{}, &schedulerpb.SchedulerIdleTask{})
 	require.NoError(t, err)
 	require.True(t, sched.Closed)
+	require.Len(t, eventLog.Events, 1)
+	require.Equal(t, "schedule closed from idle timer", eventLog.Events[0].Message)
 }
 
-func TestIdleTask_ExecuteInitializesMissingEventLog(t *testing.T) {
+func TestIdleTask_ExecuteInitializesEventLogMissingFromOlderTree(t *testing.T) {
 	env := newTestEnv(t)
 	ctx := env.MutableContext()
 	sched := env.Scheduler
+	// Simulate a Scheduler tree persisted before EventLog was introduced.
 	sched.EventLog = chasm.NewEmptyField[*scheduler.EventLog]()
 
 	handler := newIdleHandler(10 * time.Minute)

--- a/chasm/lib/scheduler/scheduler_idle_tasks_test.go
+++ b/chasm/lib/scheduler/scheduler_idle_tasks_test.go
@@ -85,6 +85,8 @@ func TestIdleTask_ExecuteInitializesEventLogMissingFromOlderTree(t *testing.T) {
 	sched := env.Scheduler
 	// Simulate a Scheduler tree persisted before EventLog was introduced.
 	sched.EventLog = chasm.NewEmptyField[*scheduler.EventLog]()
+	_, ok := sched.EventLog.TryGet(ctx)
+	require.False(t, ok)
 
 	handler := newIdleHandler(10 * time.Minute)
 	err := handler.Execute(ctx, sched, chasm.TaskAttributes{}, &schedulerpb.SchedulerIdleTask{})

--- a/chasm/lib/scheduler/scheduler_idle_tasks_test.go
+++ b/chasm/lib/scheduler/scheduler_idle_tasks_test.go
@@ -76,6 +76,22 @@ func TestIdleTask_Execute(t *testing.T) {
 	require.True(t, sched.Closed)
 }
 
+func TestIdleTask_ExecuteInitializesMissingEventLog(t *testing.T) {
+	env := newTestEnv(t)
+	ctx := env.MutableContext()
+	sched := env.Scheduler
+	sched.EventLog = chasm.NewEmptyField[*scheduler.EventLog]()
+
+	handler := newIdleHandler(10 * time.Minute)
+	err := handler.Execute(ctx, sched, chasm.TaskAttributes{}, &schedulerpb.SchedulerIdleTask{})
+	require.NoError(t, err)
+	require.True(t, sched.Closed)
+
+	eventLog := sched.EventLog.Get(ctx)
+	require.Len(t, eventLog.Events, 1)
+	require.Equal(t, "schedule closed from idle timer", eventLog.Events[0].Message)
+}
+
 func TestIdleTask_Validate_SchedulerNotIdle(t *testing.T) {
 	env := newTestEnv(t)
 	now := env.TimeSource.Now()

--- a/chasm/lib/scheduler/scheduler_tasks.go
+++ b/chasm/lib/scheduler/scheduler_tasks.go
@@ -53,7 +53,7 @@ func (r *SchedulerIdleTaskHandler) Execute(
 	_ chasm.TaskAttributes,
 	_ *schedulerpb.SchedulerIdleTask,
 ) error {
-	scheduler.eventLog(ctx).LogEvent(ctx, "schedule closed from idle timer")
+	scheduler.getOrCreateEventLog(ctx).LogEvent(ctx, "schedule closed from idle timer")
 	scheduler.Closed = true
 	newTaggedMetricsHandler(r.metricsHandler, scheduler).
 		Counter(metrics.ScheduleIdleTask.Name()).
@@ -214,7 +214,7 @@ func (r *SchedulerCallbacksTaskHandler) Execute(
 				}
 			}
 
-			s.eventLog(ctx).LogEvent(ctx,
+			s.getOrCreateEventLog(ctx).LogEvent(ctx,
 				fmt.Sprintf("attached callbacks to %d already-running workflow(s)", len(results)))
 
 			// Now that running workflow state has been refreshed, scheduler tasks can be

--- a/chasm/lib/scheduler/scheduler_tasks.go
+++ b/chasm/lib/scheduler/scheduler_tasks.go
@@ -53,7 +53,7 @@ func (r *SchedulerIdleTaskHandler) Execute(
 	_ chasm.TaskAttributes,
 	_ *schedulerpb.SchedulerIdleTask,
 ) error {
-	scheduler.EventLog.Get(ctx).LogEvent(ctx, "schedule closed from idle timer")
+	scheduler.eventLog(ctx).LogEvent(ctx, "schedule closed from idle timer")
 	scheduler.Closed = true
 	newTaggedMetricsHandler(r.metricsHandler, scheduler).
 		Counter(metrics.ScheduleIdleTask.Name()).
@@ -214,7 +214,7 @@ func (r *SchedulerCallbacksTaskHandler) Execute(
 				}
 			}
 
-			s.EventLog.Get(ctx).LogEvent(ctx,
+			s.eventLog(ctx).LogEvent(ctx,
 				fmt.Sprintf("attached callbacks to %d already-running workflow(s)", len(results)))
 
 			// Now that running workflow state has been refreshed, scheduler tasks can be


### PR DESCRIPTION
## What changed

Adds lazy `EventLog` initialization helpers for CHASM scheduler components and routes scheduler, generator, invoker, and backfiller event logging through those helpers. If an existing scheduler tree is missing the recently-added `EventLog` component, the next log write creates it instead of panicking.

Also adds a regression test for the idle-timer path that reproduced the nightly failure.

## Why

I first saw this in Nightlies on the morning of June 8, 2026, which tracks with #10530 merging on June 5, 2026 and no nightlies running over the June 6-7 weekend. The latest three Nightlies this week also failed in the same way. In between June 8 and this week, other earlier setup failures sometimes obscured the fact that this issue was still present, but it has been present since June 5th and should be fixed.

The failure is a panic at `scheduler_tasks.go:56` that comes after upgrading from a scheduler created in the latest OSS release where the `EventLog` component is nil:

```go
scheduler.EventLog.Get(ctx).LogEvent(ctx, "schedule closed from idle timer")
```

The same direct `EventLog.Get(ctx).LogEvent(...)` hazard existed in the other scheduler task handlers and scheduler mutation paths, so I fix those too in this PR.

`EventLog` is recent:

- Introduced on May 27, 2026 in #10258, "Introduce EventLog for internal history"
- Wired into CHASM scheduler task handlers in #10369 on June 4, 2026 and #10530 on June 5, 2026

`NewScheduler` initializes `EventLog`, but there is no migration/backfill that adds it to Scheduler trees created before the component existed.

## Upgrade-pipeline failure mode

`PipelineCassEsUpgrade` alternates between `temporaliotest/server` from latest main, which includes `EventLog`, and `temporalio/server` from the latest stable release, which predates the late-May EventLog work. A CHASM Scheduler created or persisted while the older release image is active has no `EventLog` component in its tree. After the swap to the newer image, the scheduler idle-timer pure task fires, calls `EventLog.Get()`, finds nothing, and panics repeatedly on retry for each affected Scheduler.

This is the forward/backward compatibility gap that the upgrade pipeline is meant to catch. Non-upgrade CHASM pipelines run a single version that always has `EventLog`, so they do not reproduce the issue. Canary errors are explicitly ignored for this upgrade pipeline, so the failure surfaces through the post-test unexpected log line check: `Panic is captured`.

## Validation

- `go test -tags test_dep ./chasm/lib/scheduler -run TestIdleTask_ExecuteInitializesMissingEventLog`
- `go test -tags test_dep ./chasm/lib/scheduler`
- `make lint-code`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many scheduler execution and API paths, but behavior for trees that already have EventLog is unchanged; risk is mainly missing a call site or subtle persistence side effects when auto-creating the component.
> 
> **Overview**
> Fixes **upgrade panics** when CHASM schedulers persisted **without** an `EventLog` component (pre–#10530 trees) hit code paths that logged via `EventLog.Get(ctx).LogEvent(...)`.
> 
> Adds **`getOrCreateEventLog`** on `Scheduler`, `Generator`, `Invoker`, and `Backfiller`: `TryGet` the existing log, or create one with `NewEventLog` and attach it to the field. **All scheduler event logging** in task handlers and API/mutation paths now goes through these helpers instead of bare `Get`.
> 
> Adds **`TestIdleTask_ExecuteInitializesEventLogMissingFromOlderTree`** (empty `EventLog` field) and tightens **`TestIdleTask_Execute`** to assert the idle-close message is recorded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65d1b3e8b0be5600d88143fdd08e34af83ab06b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->