### PR TITLE
[WIP] Nexus metrics backport (1/3): HSM NodeBackend workflow-type + namespace accessors

### DIFF
--- a/service/history/hsm/hsmtest/backend.go
+++ b/service/history/hsm/hsmtest/backend.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 
+	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
@@ -22,6 +23,10 @@ func (n *NodeBackend) GetCurrentVersion() int64 {
 
 func (n *NodeBackend) NextTransitionCount() int64 {
 	return 3
+}
+
+func (n *NodeBackend) GetWorkflowType() *commonpb.WorkflowType {
+	return &commonpb.WorkflowType{Name: "workflow-type"}
 }
 
 func (n *NodeBackend) AddHistoryEvent(t enumspb.EventType, setAttributes func(*historypb.HistoryEvent)) *historypb.HistoryEvent {

--- a/service/history/hsm/hsmtest/backend.go
+++ b/service/history/hsm/hsmtest/backend.go
@@ -8,7 +8,9 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/service/history/hsm"
 	"google.golang.org/protobuf/proto"
 )
@@ -27,6 +29,10 @@ func (n *NodeBackend) NextTransitionCount() int64 {
 
 func (n *NodeBackend) GetWorkflowType() *commonpb.WorkflowType {
 	return &commonpb.WorkflowType{Name: "workflow-type"}
+}
+
+func (n *NodeBackend) GetNamespaceEntry() *namespace.Namespace {
+	return namespace.NewNamespaceForTest(&persistencespb.NamespaceInfo{Name: "namespace-name"}, nil, false, nil, 0)
 }
 
 func (n *NodeBackend) AddHistoryEvent(t enumspb.EventType, setAttributes func(*historypb.HistoryEvent)) *historypb.HistoryEvent {

--- a/service/history/hsm/tree.go
+++ b/service/history/hsm/tree.go
@@ -12,6 +12,7 @@ import (
 	historypb "go.temporal.io/api/history/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/service/history/consts"
 	"google.golang.org/protobuf/proto"
 )
@@ -164,6 +165,8 @@ type NodeBackend interface {
 	NextTransitionCount() int64
 	// GetWorkflowType returns the type of the workflow that owns this state machine tree.
 	GetWorkflowType() *commonpb.WorkflowType
+	// GetNamespaceEntry returns the namespace entry that owns this state machine tree.
+	GetNamespaceEntry() *namespace.Namespace
 }
 
 // EventIDFromToken gets the event ID associated with an event load token.
@@ -712,6 +715,11 @@ func (n *Node) root() *Node {
 // WorkflowTypeName returns the type name of the workflow that owns this node's state machine tree.
 func (n *Node) WorkflowTypeName() string {
 	return n.root().backend.GetWorkflowType().GetName()
+}
+
+// NamespaceName returns the name of the namespace that owns this node's state machine tree.
+func (n *Node) NamespaceName() string {
+	return n.root().backend.GetNamespaceEntry().Name().String()
 }
 
 // compact filters the operation log based on deletion status. For any operation path:

--- a/service/history/hsm/tree.go
+++ b/service/history/hsm/tree.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 
+	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
@@ -161,6 +162,8 @@ type NodeBackend interface {
 	GetCurrentVersion() int64
 	// NextTransitionCount returns the current state transition count from the state transition history.
 	NextTransitionCount() int64
+	// GetWorkflowType returns the type of the workflow that owns this state machine tree.
+	GetWorkflowType() *commonpb.WorkflowType
 }
 
 // EventIDFromToken gets the event ID associated with an event load token.
@@ -704,6 +707,11 @@ func (n *Node) root() *Node {
 		root = root.Parent
 	}
 	return root
+}
+
+// WorkflowTypeName returns the type name of the workflow that owns this node's state machine tree.
+func (n *Node) WorkflowTypeName() string {
+	return n.root().backend.GetWorkflowType().GetName()
 }
 
 // compact filters the operation log based on deletion status. For any operation path:

--- a/service/history/hsm/tree_test.go
+++ b/service/history/hsm/tree_test.go
@@ -12,6 +12,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/service/history/hsm"
 	"go.temporal.io/server/service/history/hsm/hsmtest"
@@ -34,6 +35,10 @@ func (b *backend) NextTransitionCount() int64 {
 
 func (b *backend) GetWorkflowType() *commonpb.WorkflowType {
 	return &commonpb.WorkflowType{Name: "workflow-type"}
+}
+
+func (b *backend) GetNamespaceEntry() *namespace.Namespace {
+	return namespace.NewNamespaceForTest(&persistencespb.NamespaceInfo{Name: "namespace-name"}, nil, false, nil, 0)
 }
 
 func (b *backend) AddHistoryEvent(t enumspb.EventType, setAttributes func(*historypb.HistoryEvent)) *historypb.HistoryEvent {
@@ -186,10 +191,13 @@ func TestNode_WorkflowTypeName(t *testing.T) {
 	l2, err := l1.AddChild(hsm.Key{Type: def1.Type(), ID: "l2"}, hsmtest.NewData(hsmtest.State1))
 	require.NoError(t, err)
 
-	// All nodes resolve the workflow type via the root backend.
+	// All nodes resolve the workflow type and namespace via the root backend.
 	require.Equal(t, "workflow-type", root.WorkflowTypeName())
 	require.Equal(t, "workflow-type", l1.WorkflowTypeName())
 	require.Equal(t, "workflow-type", l2.WorkflowTypeName())
+	require.Equal(t, "namespace-name", root.NamespaceName())
+	require.Equal(t, "namespace-name", l1.NamespaceName())
+	require.Equal(t, "namespace-name", l2.NamespaceName())
 }
 
 func TestNode_AddChild(t *testing.T) {

--- a/service/history/hsm/tree_test.go
+++ b/service/history/hsm/tree_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
@@ -29,6 +30,10 @@ func (b *backend) GetCurrentVersion() int64 {
 
 func (b *backend) NextTransitionCount() int64 {
 	return 3
+}
+
+func (b *backend) GetWorkflowType() *commonpb.WorkflowType {
+	return &commonpb.WorkflowType{Name: "workflow-type"}
 }
 
 func (b *backend) AddHistoryEvent(t enumspb.EventType, setAttributes func(*historypb.HistoryEvent)) *historypb.HistoryEvent {
@@ -171,6 +176,20 @@ func TestNode_Path(t *testing.T) {
 	require.Equal(t, []hsm.Key{}, root.Path())
 	require.Equal(t, []hsm.Key{l1.Key}, l1.Path())
 	require.Equal(t, []hsm.Key{l1.Key, l2.Key}, l2.Path())
+}
+
+func TestNode_WorkflowTypeName(t *testing.T) {
+	root, err := hsm.NewRoot(reg, def1.Type(), hsmtest.NewData(hsmtest.State1), make(map[string]*persistencespb.StateMachineMap), &backend{})
+	require.NoError(t, err)
+	l1, err := root.AddChild(hsm.Key{Type: def1.Type(), ID: "l1"}, hsmtest.NewData(hsmtest.State1))
+	require.NoError(t, err)
+	l2, err := l1.AddChild(hsm.Key{Type: def1.Type(), ID: "l2"}, hsmtest.NewData(hsmtest.State1))
+	require.NoError(t, err)
+
+	// All nodes resolve the workflow type via the root backend.
+	require.Equal(t, "workflow-type", root.WorkflowTypeName())
+	require.Equal(t, "workflow-type", l1.WorkflowTypeName())
+	require.Equal(t, "workflow-type", l2.WorkflowTypeName())
 }
 
 func TestNode_AddChild(t *testing.T) {


### PR DESCRIPTION
**WIP / draft — for review, not ready to merge.**

First of a 3-PR stack backporting the **caller-side Nexus operation metrics** from the CHASM implementation to the legacy **HSM (in-workflow)** implementation, so in-workflow Nexus operations report the same metrics as standalone (CHASM) operations ahead of the HSM→CHASM migration.

### This PR
Lets HSM components read the owning workflow's type and namespace from a node **without importing the workflow package** (the `components/nexusoperations` package cannot import `service/history/workflow` — it's a dependency cycle). This mirrors what `chasm.NodeBackend` already exposes.

Rather than add new string accessors, it declares the **existing** rich-typed methods on the `hsm.NodeBackend` interface (they are already implemented by `MutableState`, so no implementation changes are needed):

- `GetWorkflowType() *commonpb.WorkflowType` — surfaced via `Node.WorkflowTypeName()`
- `GetNamespaceEntry() *namespace.Namespace` — surfaced via `Node.NamespaceName()`

Only the two HSM test backends gain these methods; `TestNode_WorkflowTypeName` is extended to cover both. The component-facing `Node.WorkflowTypeName()` / `Node.NamespaceName()` helpers (used by PRs 2 and 3) are unchanged.

These node helpers are temporary — they exist only for the HSM bridge and are removed when the HSM nexus component is deleted during migration cleanup.

### Stack
1. **(this PR)** HSM `NodeBackend` accessors → base `main`
2. Executor-side metric emission
3. Completion-path emission + `impl=chasm` + functional test

🤖 Generated with [Claude Code](https://claude.com/claude-code)