### PR TITLE
[WIP] Nexus metrics backport (2/3): emit caller metrics from HSM executor paths

### DIFF
--- a/components/nexusoperations/config.go
+++ b/components/nexusoperations/config.go
@@ -179,6 +179,7 @@ type Config struct {
 	UseSystemCallbackURL                dynamicconfig.BoolPropertyFn
 	UseNewFailureWireFormat             dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	RecordCancelRequestCompletionEvents dynamicconfig.BoolPropertyFn
+	MetricTagConfig                     dynamicconfig.TypedPropertyFn[chasmnexus.NexusMetricTagConfig]
 	RetryPolicy                         func() backoff.RetryPolicy
 }
 
@@ -198,6 +199,7 @@ func ConfigProvider(dc *dynamicconfig.Collection, cfg *config.Persistence) *Conf
 		UseSystemCallbackURL:                UseSystemCallbackURL.Get(dc),
 		UseNewFailureWireFormat:             chasmnexus.UseNewFailureWireFormat.Get(dc),
 		RecordCancelRequestCompletionEvents: RecordCancelRequestCompletionEvents.Get(dc),
+		MetricTagConfig:                     MetricTagConfiguration.Get(dc),
 		RetryPolicy: func() backoff.RetryPolicy {
 			return backoff.NewExponentialRetryPolicy(
 				RetryPolicyInitialInterval.Get(dc)(),

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -445,16 +445,25 @@ func (e taskExecutor) saveResult(ctx context.Context, env hsm.Environment, ref h
 				// nolint:revive // We must mutate here even if the linter doesn't like it.
 				e.Links = links
 			})
-			return hsm.MachineTransition(node, func(operation Operation) (hsm.TransitionOutput, error) {
+			startedTime := env.Now()
+			if err := hsm.MachineTransition(node, func(operation Operation) (hsm.TransitionOutput, error) {
 				return TransitionStarted.Apply(operation, EventStarted{
-					Time:       env.Now(),
+					Time:       startedTime,
 					Node:       node,
 					Attributes: event.GetNexusOperationStartedEventAttributes(),
 				})
-			})
+			}); err != nil {
+				return err
+			}
+			e.recordScheduleToStartLatency(operation, node.NamespaceName(), node.WorkflowTypeName(), startedTime)
+			return nil
 		}
 		// Operation completed synchronously. Store the result and update the state machine.
-		return handleSuccessfulOperationResult(node, operation, result.Successful, links)
+		if err := handleSuccessfulOperationResult(node, operation, result.Successful, links); err != nil {
+			return err
+		}
+		e.recordOperationSucceeded(operation, node.NamespaceName(), node.WorkflowTypeName(), env.Now())
+		return nil
 	})
 }
 
@@ -467,7 +476,7 @@ func (e taskExecutor) handleStartOperationError(env hsm.Environment, node *hsm.N
 	switch {
 	case errors.As(callErr, &serviceErr):
 		if !common.IsRetryableRPCError(callErr) {
-			return handleNonRetryableStartOperationError(node, operation, callErr)
+			return e.failNonRetryable(env, node, operation, callErr)
 		}
 		// Fall through all uncaught errors to retryable
 	case errors.As(callErr, &opErr):
@@ -475,18 +484,18 @@ func (e taskExecutor) handleStartOperationError(env hsm.Environment, node *hsm.N
 	case errors.As(callErr, &handlerErr) && !handlerErr.Retryable():
 		// The StartOperation request got an unexpected response that is not retryable, fail the operation.
 		// Although Failure is nullable, Nexus SDK is expected to always populate this field
-		return handleNonRetryableStartOperationError(node, operation, handlerErr)
+		return e.failNonRetryable(env, node, operation, handlerErr)
 	case errors.Is(callErr, ErrResponseBodyTooLarge):
 		// Following practices from workflow task completion payload size limit enforcement, we do not retry this
 		// operation if the response body is too large.
-		return handleNonRetryableStartOperationError(node, operation, callErr)
+		return e.failNonRetryable(env, node, operation, callErr)
 	case errors.Is(callErr, ErrInvalidOperationToken):
 		// Following practices from workflow task completion payload size limit enforcement, we do not retry this
 		// operation if the response's operation token is too large.
-		return handleNonRetryableStartOperationError(node, operation, callErr)
+		return e.failNonRetryable(env, node, operation, callErr)
 	case errors.As(callErr, &opTimeoutBelowMinErr):
 		// Not enough time to execute another request, resolve the operation with a timeout.
-		return e.recordOperationTimeout(node, opTimeoutBelowMinErr.timeoutType)
+		return e.recordOperationTimeout(env, node, opTimeoutBelowMinErr.timeoutType)
 	case errors.Is(callErr, context.DeadlineExceeded) || errors.Is(callErr, context.Canceled):
 		// If timed out, we don't leak internal info to the user
 		callErr = errRequestTimedOut
@@ -536,6 +545,17 @@ func handleNonRetryableStartOperationError(node *hsm.Node, operation Operation, 
 	return FailedEventDefinition{}.Apply(node.Parent, event)
 }
 
+// failNonRetryable resolves the operation as failed (non-retryable) and emits the terminal
+// failure metric. It wraps handleNonRetryableStartOperationError so emission happens once, at
+// this live processing site, rather than in the event-application path (which also runs on replay).
+func (e taskExecutor) failNonRetryable(env hsm.Environment, node *hsm.Node, operation Operation, callErr error) error {
+	if err := handleNonRetryableStartOperationError(node, operation, callErr); err != nil {
+		return err
+	}
+	e.recordOperationFailed(operation, node.NamespaceName(), node.WorkflowTypeName(), env.Now())
+	return nil
+}
+
 func (e taskExecutor) executeBackoffTask(env hsm.Environment, node *hsm.Node, task BackoffTask) error {
 	return hsm.MachineTransition(node, func(op Operation) (hsm.TransitionOutput, error) {
 		return TransitionRescheduled.Apply(op, EventRescheduled{
@@ -545,19 +565,21 @@ func (e taskExecutor) executeBackoffTask(env hsm.Environment, node *hsm.Node, ta
 }
 
 func (e taskExecutor) executeScheduleToCloseTimeoutTask(env hsm.Environment, node *hsm.Node, task ScheduleToCloseTimeoutTask) error {
-	return e.recordOperationTimeout(node, enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE)
+	return e.recordOperationTimeout(env, node, enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE)
 }
 
 func (e taskExecutor) executeScheduleToStartTimeoutTask(env hsm.Environment, node *hsm.Node, task ScheduleToStartTimeoutTask) error {
-	return e.recordOperationTimeout(node, enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START)
+	return e.recordOperationTimeout(env, node, enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START)
 }
 
 func (e taskExecutor) executeStartToCloseTimeoutTask(env hsm.Environment, node *hsm.Node, task StartToCloseTimeoutTask) error {
-	return e.recordOperationTimeout(node, enumspb.TIMEOUT_TYPE_START_TO_CLOSE)
+	return e.recordOperationTimeout(env, node, enumspb.TIMEOUT_TYPE_START_TO_CLOSE)
 }
 
-func (e taskExecutor) recordOperationTimeout(node *hsm.Node, timeoutType enumspb.TimeoutType) error {
-	return hsm.MachineTransition(node, func(op Operation) (hsm.TransitionOutput, error) {
+func (e taskExecutor) recordOperationTimeout(env hsm.Environment, node *hsm.Node, timeoutType enumspb.TimeoutType) error {
+	var timedOutOp Operation
+	if err := hsm.MachineTransition(node, func(op Operation) (hsm.TransitionOutput, error) {
+		timedOutOp = op
 		eventID, err := hsm.EventIDFromToken(op.ScheduledEventToken)
 		if err != nil {
 			return hsm.TransitionOutput{}, err
@@ -587,7 +609,13 @@ func (e taskExecutor) recordOperationTimeout(node *hsm.Node, timeoutType enumspb
 		return TransitionTimedOut.Apply(op, EventTimedOut{
 			Node: node,
 		})
-	})
+	}); err != nil {
+		return err
+	}
+	// timedOutOp was captured from the transition closure above (the same Operation that
+	// MachineData would return); the timeout transition leaves the metric fields unchanged.
+	e.recordOperationTimedOut(timedOutOp, node.NamespaceName(), node.WorkflowTypeName(), timeoutType.String(), env.Now())
+	return nil
 }
 
 func (e taskExecutor) executeCancelationTask(ctx context.Context, env hsm.Environment, ref hsm.Ref, task CancelationTask) error {

--- a/components/nexusoperations/executors_test.go
+++ b/components/nexusoperations/executors_test.go
@@ -29,6 +29,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/namespace"
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexusrpc"
@@ -542,6 +543,9 @@ func TestProcessInvocationTask(t *testing.T) {
 				namespace.NewNamespaceForTest(&persistencespb.NamespaceInfo{Name: "ns-name"}, nil, false, nil, 0), nil)
 
 			metricsHandler := metrics.NewMockHandler(ctrl)
+			// Caller-side operation metrics are emitted via a tagged handler; route them to noop
+			// here so these tests keep asserting only the outbound-request metrics.
+			metricsHandler.EXPECT().WithTags(gomock.Any()).Return(metrics.NoopMetricsHandler).AnyTimes()
 			if tc.expectedMetricOutcome != "" {
 				counter := metrics.NewMockCounterIface(ctrl)
 				timer := metrics.NewMockTimerIface(ctrl)
@@ -641,7 +645,7 @@ func TestProcessBackoffTask(t *testing.T) {
 	}))
 	env := fakeEnv{node}
 
-	require.NoError(t, nexusoperations.RegisterExecutor(reg, nexusoperations.TaskExecutorOptions{}))
+	require.NoError(t, nexusoperations.RegisterExecutor(reg, nexusoperations.TaskExecutorOptions{MetricsHandler: metrics.NoopMetricsHandler, Config: &nexusoperations.Config{}}))
 	err := hsm.MachineTransition(node, func(op nexusoperations.Operation) (hsm.TransitionOutput, error) {
 		return nexusoperations.TransitionAttemptFailed.Apply(op, nexusoperations.EventAttemptFailed{
 			Node:        node,
@@ -672,7 +676,7 @@ func TestProcessTimeoutTask(t *testing.T) {
 	}))
 	env := fakeEnv{node}
 
-	require.NoError(t, nexusoperations.RegisterExecutor(reg, nexusoperations.TaskExecutorOptions{}))
+	require.NoError(t, nexusoperations.RegisterExecutor(reg, nexusoperations.TaskExecutorOptions{MetricsHandler: metrics.NoopMetricsHandler, Config: &nexusoperations.Config{}}))
 
 	err := reg.ExecuteTimerTask(
 		env,
@@ -710,6 +714,40 @@ func TestProcessTimeoutTask(t *testing.T) {
 	}, backend.Events[0].GetNexusOperationTimedOutEventAttributes())
 }
 
+func TestProcessTimeoutTask_EmitsCallerMetrics(t *testing.T) {
+	reg := newRegistry(t)
+	backend := &hsmtest.NodeBackend{}
+	node := newOperationNode(t, backend, mustNewScheduledEvent(time.Now(), &historypb.NexusOperationScheduledEventAttributes{
+		ScheduleToCloseTimeout: durationpb.New(time.Hour),
+	}))
+	env := fakeEnv{node}
+
+	captureHandler := metricstest.NewCaptureHandler()
+	capture := captureHandler.StartCapture()
+	defer captureHandler.StopCapture(capture)
+
+	require.NoError(t, nexusoperations.RegisterExecutor(reg, nexusoperations.TaskExecutorOptions{
+		MetricsHandler: captureHandler,
+		Config:         &nexusoperations.Config{},
+	}))
+
+	require.NoError(t, reg.ExecuteTimerTask(env, node, nexusoperations.ScheduleToCloseTimeoutTask{}))
+
+	snapshot := capture.Snapshot()
+
+	timeoutCount := snapshot[chasmnexus.NexusOperationTimeoutCount.Name()]
+	require.Len(t, timeoutCount, 1)
+	require.Equal(t, int64(1), timeoutCount[0].Value)
+	require.Equal(t, "namespace-name", timeoutCount[0].Tags["namespace"])
+	require.Equal(t, "endpoint", timeoutCount[0].Tags["nexus_endpoint"])
+	require.Equal(t, "workflow-type", timeoutCount[0].Tags["workflowType"])
+	require.Equal(t, "hsm", timeoutCount[0].Tags["impl"])
+	require.Equal(t, enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE.String(), timeoutCount[0].Tags["timeout_type"])
+
+	// Latency is also recorded for the terminal state.
+	require.Len(t, snapshot[chasmnexus.NexusOperationScheduleToCloseLatency.Name()], 1)
+}
+
 func TestProcessScheduleToStartTimeoutTask(t *testing.T) {
 	reg := newRegistry(t)
 	backend := &hsmtest.NodeBackend{}
@@ -718,7 +756,7 @@ func TestProcessScheduleToStartTimeoutTask(t *testing.T) {
 	}))
 	env := fakeEnv{node}
 
-	require.NoError(t, nexusoperations.RegisterExecutor(reg, nexusoperations.TaskExecutorOptions{}))
+	require.NoError(t, nexusoperations.RegisterExecutor(reg, nexusoperations.TaskExecutorOptions{MetricsHandler: metrics.NoopMetricsHandler, Config: &nexusoperations.Config{}}))
 
 	err := reg.ExecuteTimerTask(
 		env,
@@ -764,7 +802,7 @@ func TestProcessStartToCloseTimeoutTask(t *testing.T) {
 	}))
 	env := fakeEnv{node}
 
-	require.NoError(t, nexusoperations.RegisterExecutor(reg, nexusoperations.TaskExecutorOptions{}))
+	require.NoError(t, nexusoperations.RegisterExecutor(reg, nexusoperations.TaskExecutorOptions{MetricsHandler: metrics.NoopMetricsHandler, Config: &nexusoperations.Config{}}))
 
 	// Transition to STARTED state first
 	err := hsm.MachineTransition(node, func(op nexusoperations.Operation) (hsm.TransitionOutput, error) {
@@ -976,6 +1014,9 @@ func TestProcessCancelationTask(t *testing.T) {
 				namespace.NewNamespaceForTest(&persistencespb.NamespaceInfo{Name: "ns-name"}, nil, false, nil, 0), nil)
 
 			metricsHandler := metrics.NewMockHandler(ctrl)
+			// Caller-side operation metrics are emitted via a tagged handler; route them to noop
+			// here so these tests keep asserting only the outbound-request metrics.
+			metricsHandler.EXPECT().WithTags(gomock.Any()).Return(metrics.NoopMetricsHandler).AnyTimes()
 			if tc.expectedMetricOutcome != "" {
 				counter := metrics.NewMockCounterIface(ctrl)
 				timer := metrics.NewMockTimerIface(ctrl)
@@ -1276,6 +1317,9 @@ func TestProcessCancelationTask_SystemEndpoint(t *testing.T) {
 				namespace.NewNamespaceForTest(&persistencespb.NamespaceInfo{Name: "ns-name"}, nil, false, nil, 0), nil)
 
 			metricsHandler := metrics.NewMockHandler(ctrl)
+			// Caller-side operation metrics are emitted via a tagged handler; route them to noop
+			// here so these tests keep asserting only the outbound-request metrics.
+			metricsHandler.EXPECT().WithTags(gomock.Any()).Return(metrics.NoopMetricsHandler).AnyTimes()
 			if tc.expectedMetricOutcome != "" {
 				counter := metrics.NewMockCounterIface(ctrl)
 				timer := metrics.NewMockTimerIface(ctrl)
@@ -1368,7 +1412,7 @@ func TestProcessCancelationBackoffTask(t *testing.T) {
 
 	env := fakeEnv{node}
 
-	require.NoError(t, nexusoperations.RegisterExecutor(reg, nexusoperations.TaskExecutorOptions{}))
+	require.NoError(t, nexusoperations.RegisterExecutor(reg, nexusoperations.TaskExecutorOptions{MetricsHandler: metrics.NoopMetricsHandler, Config: &nexusoperations.Config{}}))
 
 	err = reg.ExecuteTimerTask(
 		env,
@@ -1660,6 +1704,9 @@ func TestProcessInvocationTask_SystemEndpoint(t *testing.T) {
 				namespace.NewNamespaceForTest(&persistencespb.NamespaceInfo{Name: "ns-name"}, nil, false, nil, 0), nil)
 
 			metricsHandler := metrics.NewMockHandler(ctrl)
+			// Caller-side operation metrics are emitted via a tagged handler; route them to noop
+			// here so these tests keep asserting only the outbound-request metrics.
+			metricsHandler.EXPECT().WithTags(gomock.Any()).Return(metrics.NoopMetricsHandler).AnyTimes()
 			if tc.expectedMetricOutcome != "" {
 				counter := metrics.NewMockCounterIface(ctrl)
 				timer := metrics.NewMockTimerIface(ctrl)

--- a/components/nexusoperations/metrics.go
+++ b/components/nexusoperations/metrics.go
@@ -1,0 +1,103 @@
+package nexusoperations
+
+import (
+	"strings"
+	"time"
+
+	chasmnexus "go.temporal.io/server/chasm/lib/nexusoperation"
+	nexusoperationpb "go.temporal.io/server/chasm/lib/nexusoperation/gen/nexusoperationpb/v1"
+	"go.temporal.io/server/common/metrics"
+)
+
+// nexusEngineTagValue marks caller-side metrics emitted by the legacy HSM implementation, so
+// operators can distinguish in-workflow HSM operations from CHASM operations during the
+// HSM->CHASM migration. It is intended for internal use only and should be stripped at the
+// external-observability boundary so the customer-facing rollup aggregates across engines.
+const nexusEngineTagValue = "hsm"
+
+// operationMetricsHandler returns a metrics handler enriched with caller-side Nexus operation
+// tags. It mirrors chasm/lib/nexusoperation Operation.metricsHandler so the HSM and CHASM
+// implementations emit identical metric names and labels (see the HSM->CHASM migration). Unlike
+// CHASM, HSM Nexus operations are always in-workflow, so workflowType is always the real parent
+// workflow type (there is no standalone placeholder case).
+func (e taskExecutor) operationMetricsHandler(op Operation, namespaceName, workflowType string) metrics.Handler {
+	tags := []metrics.Tag{
+		metrics.NamespaceTag(namespaceName),
+		metrics.NexusEndpointTag(op.Endpoint),
+		metrics.WorkflowTypeTag(workflowType),
+		metrics.StringTag("impl", nexusEngineTagValue),
+	}
+	var conf chasmnexus.NexusMetricTagConfig
+	if e.Config.MetricTagConfig != nil {
+		conf = e.Config.MetricTagConfig()
+	}
+	if conf.IncludeServiceTag {
+		tags = append(tags, metrics.NexusServiceTag(op.Service))
+	}
+	if conf.IncludeOperationTag {
+		tags = append(tags, metrics.NexusOperationTag(op.Operation))
+	}
+	return e.MetricsHandler.WithTags(tags...)
+}
+
+// recordOperationSucceeded emits the success counter and latency metrics for an operation that
+// completed successfully.
+func (e taskExecutor) recordOperationSucceeded(op Operation, namespaceName, workflowType string, closeTime time.Time) {
+	e.recordOperationOutcome(op, namespaceName, workflowType, nexusoperationpb.OPERATION_STATUS_SUCCEEDED, closeTime, chasmnexus.NexusOperationSuccessCount.With)
+}
+
+// recordOperationFailed emits the failure counter and latency metrics for an operation that
+// failed non-retryably.
+func (e taskExecutor) recordOperationFailed(op Operation, namespaceName, workflowType string, closeTime time.Time) {
+	e.recordOperationOutcome(op, namespaceName, workflowType, nexusoperationpb.OPERATION_STATUS_FAILED, closeTime, chasmnexus.NexusOperationFailedCount.With)
+}
+
+// recordOperationTimedOut emits the timeout counter (tagged with the timeout type) and latency
+// metrics for an operation that timed out.
+func (e taskExecutor) recordOperationTimedOut(op Operation, namespaceName, workflowType, timeoutType string, closeTime time.Time) {
+	e.recordOperationOutcome(op, namespaceName, workflowType, nexusoperationpb.OPERATION_STATUS_TIMED_OUT, closeTime, chasmnexus.NexusOperationTimeoutCount.With, metrics.TimeoutTypeTag(timeoutType))
+}
+
+// recordOperationOutcome records the terminal outcome counter and the shared latency metrics for a
+// closed operation. The outcome-specific counter is supplied as a metric definition's With method
+// (e.g. NexusOperationSuccessCount.With), so each per-outcome recorder differs only by its counter
+// and any extra counter tags (the timeout type, for timeouts).
+func (e taskExecutor) recordOperationOutcome(
+	op Operation,
+	namespaceName, workflowType string,
+	status nexusoperationpb.OperationStatus,
+	closeTime time.Time,
+	withCounter func(metrics.Handler) metrics.CounterIface,
+	counterTags ...metrics.Tag,
+) {
+	handler := e.operationMetricsHandler(op, namespaceName, workflowType)
+	withCounter(handler).Record(1, counterTags...)
+	e.recordCompletionLatencies(handler, op, closeTime, metrics.OutcomeTag(strings.ToLower(status.String())))
+}
+
+// recordCompletionLatencies emits schedule-to-close plus either start-to-close (operations that
+// started) or schedule-to-start (sync / never-started), mirroring chasm/lib/nexusoperation's
+// emitLatencyMetrics. It is shared by the per-outcome recorders above.
+func (e taskExecutor) recordCompletionLatencies(handler metrics.Handler, op Operation, closeTime time.Time, outcomeTag metrics.Tag) {
+	if op.ScheduledTime == nil {
+		return
+	}
+	scheduledTime := op.ScheduledTime.AsTime()
+	chasmnexus.NexusOperationScheduleToCloseLatency.With(handler).Record(closeTime.Sub(scheduledTime), outcomeTag)
+	if op.StartedTime != nil {
+		// Async operation that was started; schedule-to-start latency was emitted at start time.
+		chasmnexus.NexusOperationStartToCloseLatency.With(handler).Record(closeTime.Sub(op.StartedTime.AsTime()), outcomeTag)
+	} else {
+		// Sync operation or operation that never started.
+		chasmnexus.NexusOperationScheduleToStartLatency.With(handler).Record(closeTime.Sub(scheduledTime))
+	}
+}
+
+// recordScheduleToStartLatency emits the schedule-to-start latency when an async operation starts.
+func (e taskExecutor) recordScheduleToStartLatency(op Operation, namespaceName, workflowType string, startedTime time.Time) {
+	if op.ScheduledTime == nil {
+		return
+	}
+	handler := e.operationMetricsHandler(op, namespaceName, workflowType)
+	chasmnexus.NexusOperationScheduleToStartLatency.With(handler).Record(startedTime.Sub(op.ScheduledTime.AsTime()))
+}


### PR DESCRIPTION
**WIP / draft — for review, not ready to merge.**

Stacked on #10786 (base branch `gokhan/hsm-nodebackend-workflowtype`). Review PR #10786 first.

### This PR (2/3)
Emits the caller-side Nexus operation metrics from the legacy HSM **executor** paths:
- counters: `nexus_operation_success` / `_fail` / `_timeout`
- latency histograms: `nexus_operation_schedule_to_close_latency` / `_schedule_to_start_latency` / `_start_to_close_latency`

Emission sites (all once-only, live processing — **never** in transitions or `EventDefinition.Apply`, which re-run on replay, so no double counting):
- `saveResult`: sync success, async start (schedule-to-start)
- `handleStartOperationError` / `handleNonRetryableStartOperationError`: non-retryable start failure
- `recordOperationTimeout`: schedule-to-close / schedule-to-start / start-to-close timeout timer tasks

Metric definitions are **reused** from `chasm/lib/nexusoperation` so HSM and CHASM emit identical names and labels. `namespace`/`workflow_type` come from the node accessors added in 1/3. An internal `impl="hsm"` tag distinguishes the engine during the migration (intended to be stripped at the external-observability boundary).

The async completion path and the `impl="chasm"` tag follow in 3/3.

Chronicle/extobs ingestion is tracked in DEVPROD-1804.

### Stack
1. #10786 — HSM `NodeBackend` accessors
2. **(this PR)** executor-side emission
3. completion-path emission + `impl=chasm` + functional test

🤖 Generated with [Claude Code](https://claude.com/claude-code)