### PR TITLE
[WIP] Nexus metrics backport (3/3): completion-path emission + impl=chasm + functional test

### DIFF
--- a/chasm/lib/nexusoperation/operation.go
+++ b/chasm/lib/nexusoperation/operation.go
@@ -589,6 +589,9 @@ func (o *Operation) metricsHandler(ctx chasm.Context) metrics.Handler {
 		metrics.NamespaceTag(namespaceName),
 		metrics.NexusEndpointTag(o.GetEndpoint()),
 		metrics.WorkflowTypeTag(wftt),
+		// impl distinguishes CHASM operations from legacy HSM operations during the HSM->CHASM
+		// migration. Intended for internal use only; stripped at the external-observability boundary.
+		metrics.StringTag("impl", "chasm"),
 	}
 
 	opCtx, ok := ctx.Value(OperationContextKey).(*OperationContext)

--- a/chasm/lib/nexusoperation/operation_statemachine_test.go
+++ b/chasm/lib/nexusoperation/operation_statemachine_test.go
@@ -416,6 +416,7 @@ func TestTransitionSucceeded(t *testing.T) {
 				"nexus_service":   "test-service",
 				"nexus_operation": "test-operation",
 				"workflowType":    standaloneOperationWorkflowTypeName,
+				"impl":            "chasm",
 			}
 			latencyTags := maps.Clone(countTags)
 			latencyTags["outcome"] = "succeeded"
@@ -524,6 +525,7 @@ func TestTransitionFailed(t *testing.T) {
 				"nexus_service":   "test-service",
 				"nexus_operation": "test-operation",
 				"workflowType":    standaloneOperationWorkflowTypeName,
+				"impl":            "chasm",
 			}
 			latencyTags := maps.Clone(countTags)
 			latencyTags["outcome"] = "failed"
@@ -632,6 +634,7 @@ func TestTransitionCanceled(t *testing.T) {
 				"nexus_service":   "test-service",
 				"nexus_operation": "test-operation",
 				"workflowType":    standaloneOperationWorkflowTypeName,
+				"impl":            "chasm",
 			}
 			latencyTags := maps.Clone(countTags)
 			latencyTags["outcome"] = "canceled"
@@ -733,6 +736,7 @@ func TestTransitionTimedOut(t *testing.T) {
 				"nexus_service":   "test-service",
 				"nexus_operation": "test-operation",
 				"workflowType":    standaloneOperationWorkflowTypeName,
+				"impl":            "chasm",
 			}
 			timeoutCountTags := maps.Clone(countTags)
 			timeoutCountTags["timeout_type"] = tc.event.Failure.GetTimeoutFailureInfo().GetTimeoutType().String()
@@ -851,6 +855,7 @@ func TestTransitionTerminated(t *testing.T) {
 				"nexus_service":   "test-service",
 				"nexus_operation": "test-operation",
 				"workflowType":    standaloneOperationWorkflowTypeName,
+				"impl":            "chasm",
 			}
 			latencyTags := maps.Clone(countTags)
 			latencyTags["outcome"] = "terminated"

--- a/components/nexusoperations/completion.go
+++ b/components/nexusoperations/completion.go
@@ -11,6 +11,8 @@ import (
 	failurepb "go.temporal.io/api/failure/v1"
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
+	chasmnexus "go.temporal.io/server/chasm/lib/nexusoperation"
+	"go.temporal.io/server/common/metrics"
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/service/history/hsm"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -117,28 +119,30 @@ func handleOperationError(
 	}
 }
 
-// Adds a NEXUS_OPERATION_STARTED history event and sets the operation state machine to NEXUS_OPERATION_STATE_STARTED.
-// Necessary if the completion is received before the start response.
+// fabricateStartedEventIfMissing adds a NEXUS_OPERATION_STARTED history event and transitions the
+// operation to NEXUS_OPERATION_STATE_STARTED if it has not started yet. It is necessary if the
+// completion is received before the start response. It returns true when it fabricated the started
+// transition, so the caller can emit the schedule-to-start metric.
 func fabricateStartedEventIfMissing(
 	node *hsm.Node,
 	requestID string,
 	operationToken string,
 	startTime *timestamppb.Timestamp,
 	links []*commonpb.Link,
-) error {
+) (bool, error) {
 	operation, err := hsm.MachineData[Operation](node)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// The operation was already started, ignore.
 	if !TransitionStarted.Possible(operation) {
-		return nil
+		return false, nil
 	}
 
 	eventID, err := hsm.EventIDFromToken(operation.ScheduledEventToken)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	event := node.AddHistoryEvent(enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED, func(e *historypb.HistoryEvent) {
@@ -156,7 +160,10 @@ func fabricateStartedEventIfMissing(
 			e.EventTime = startTime
 		}
 	})
-	return StartedEventDefinition{}.Apply(node.Parent, event)
+	if err := (StartedEventDefinition{}).Apply(node.Parent, event); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func CompletionHandler(
@@ -169,6 +176,8 @@ func CompletionHandler(
 	links []*commonpb.Link,
 	result *commonpb.Payload,
 	opFailedError *nexus.OperationError,
+	metricsHandler metrics.Handler,
+	metricTagConfig chasmnexus.NexusMetricTagConfig,
 ) error {
 	// The initial version of the completion token did not include a request ID.
 	// Only retry Access without a run ID if the request ID is not empty.
@@ -177,7 +186,8 @@ func CompletionHandler(
 		if err := node.CheckRunning(); err != nil {
 			return err
 		}
-		if err := fabricateStartedEventIfMissing(node, requestID, operationToken, startTime, links); err != nil {
+		started, err := fabricateStartedEventIfMissing(node, requestID, operationToken, startTime, links)
+		if err != nil {
 			return err
 		}
 		operation, err := hsm.MachineData[Operation](node)
@@ -188,6 +198,10 @@ func CompletionHandler(
 			isRetryableNotFoundErr = false
 			return serviceerror.NewNotFound("operation not found")
 		}
+		if started && operation.StartedTime != nil {
+			recordScheduleToStartLatency(metricsHandler, metricTagConfig, operation, node.NamespaceName(), node.WorkflowTypeName(), operation.StartedTime.AsTime())
+		}
+
 		if opFailedError != nil {
 			err = handleOperationError(node, operation, opFailedError)
 		} else {
@@ -199,7 +213,20 @@ func CompletionHandler(
 			isRetryableNotFoundErr = false
 			return serviceerror.NewNotFound("operation not found")
 		}
-		return err
+		if err != nil {
+			return err
+		}
+		// Emit the terminal outcome metric. The canceled vs failed split mirrors handleOperationError
+		// so the metric outcome matches the recorded transition.
+		switch {
+		case opFailedError == nil:
+			recordOperationSucceeded(metricsHandler, metricTagConfig, operation, node.NamespaceName(), node.WorkflowTypeName(), env.Now())
+		case opFailedError.State == nexus.OperationStateCanceled:
+			recordOperationCanceled(metricsHandler, metricTagConfig, operation, node.NamespaceName(), node.WorkflowTypeName(), env.Now())
+		default:
+			recordOperationFailed(metricsHandler, metricTagConfig, operation, node.NamespaceName(), node.WorkflowTypeName(), env.Now())
+		}
+		return nil
 	})
 	if errors.As(err, new(*serviceerror.NotFound)) && isRetryableNotFoundErr && ref.WorkflowKey.RunID != "" {
 		// Try again without a run ID in case the original run was reset.
@@ -210,7 +237,7 @@ func CompletionHandler(
 		ref.StateMachineRef.MutableStateVersionedTransition = nil
 		ref.StateMachineRef.MachineInitialVersionedTransition.TransitionCount = 0
 		ref.StateMachineRef.MachineLastUpdateVersionedTransition.TransitionCount = 0
-		return CompletionHandler(ctx, env, ref, requestID, operationToken, startTime, links, result, opFailedError)
+		return CompletionHandler(ctx, env, ref, requestID, operationToken, startTime, links, result, opFailedError, metricsHandler, metricTagConfig)
 	}
 	return err
 }

--- a/components/nexusoperations/completion_test.go
+++ b/components/nexusoperations/completion_test.go
@@ -1,0 +1,58 @@
+package nexusoperations_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	historypb "go.temporal.io/api/history/v1"
+	chasmnexus "go.temporal.io/server/chasm/lib/nexusoperation"
+	"go.temporal.io/server/common/metrics/metricstest"
+	"go.temporal.io/server/components/nexusoperations"
+	"go.temporal.io/server/service/history/hsm"
+	"go.temporal.io/server/service/history/hsm/hsmtest"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+func TestCompletionHandler_EmitsCallerMetrics(t *testing.T) {
+	backend := &hsmtest.NodeBackend{}
+	node := newOperationNode(t, backend, mustNewScheduledEvent(time.Now(), &historypb.NexusOperationScheduledEventAttributes{
+		ScheduleToCloseTimeout: durationpb.New(time.Hour),
+	}))
+
+	captureHandler := metricstest.NewCaptureHandler()
+	capture := captureHandler.StartCapture()
+	defer captureHandler.StopCapture(capture)
+
+	// Completion arrives before the start response: the handler fabricates the started transition
+	// (emitting schedule-to-start) and then resolves the operation as succeeded.
+	require.NoError(t, nexusoperations.CompletionHandler(
+		context.Background(),
+		fakeEnv{node},
+		hsm.Ref{},
+		"",                  // requestID (empty skips the request-id match check)
+		"token",             // operationToken
+		nil,                 // startTime
+		nil,                 // links
+		&commonpb.Payload{}, // success result
+		nil,                 // opFailedError
+		captureHandler,
+		chasmnexus.NexusMetricTagConfig{},
+	))
+
+	snapshot := capture.Snapshot()
+
+	successCount := snapshot[chasmnexus.NexusOperationSuccessCount.Name()]
+	require.Len(t, successCount, 1)
+	require.Equal(t, int64(1), successCount[0].Value)
+	require.Equal(t, "namespace-name", successCount[0].Tags["namespace"])
+	require.Equal(t, "workflow-type", successCount[0].Tags["workflowType"])
+	require.Equal(t, "endpoint", successCount[0].Tags["nexus_endpoint"])
+	require.Equal(t, "hsm", successCount[0].Tags["impl"])
+
+	// Both the schedule-to-start (from the fabricated start) and schedule-to-close latencies are recorded.
+	require.Len(t, snapshot[chasmnexus.NexusOperationScheduleToStartLatency.Name()], 1)
+	require.Len(t, snapshot[chasmnexus.NexusOperationScheduleToCloseLatency.Name()], 1)
+}

--- a/components/nexusoperations/config.go
+++ b/components/nexusoperations/config.go
@@ -212,3 +212,13 @@ func ConfigProvider(dc *dynamicconfig.Collection, cfg *config.Persistence) *Conf
 		NumHistoryShards: cfg.NumHistoryShards,
 	}
 }
+
+// ResolvedMetricTagConfig returns the configured metric tag config, defaulting to an empty config
+// when the receiver or the setting is nil (e.g. in tests that construct a bare Config). It is
+// nil-receiver safe.
+func (c *Config) ResolvedMetricTagConfig() chasmnexus.NexusMetricTagConfig {
+	if c == nil || c.MetricTagConfig == nil {
+		return chasmnexus.NexusMetricTagConfig{}
+	}
+	return c.MetricTagConfig()
+}

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -455,14 +455,14 @@ func (e taskExecutor) saveResult(ctx context.Context, env hsm.Environment, ref h
 			}); err != nil {
 				return err
 			}
-			e.recordScheduleToStartLatency(operation, node.NamespaceName(), node.WorkflowTypeName(), startedTime)
+			recordScheduleToStartLatency(e.MetricsHandler, e.metricTagConfig(), operation, node.NamespaceName(), node.WorkflowTypeName(), startedTime)
 			return nil
 		}
 		// Operation completed synchronously. Store the result and update the state machine.
 		if err := handleSuccessfulOperationResult(node, operation, result.Successful, links); err != nil {
 			return err
 		}
-		e.recordOperationSucceeded(operation, node.NamespaceName(), node.WorkflowTypeName(), env.Now())
+		recordOperationSucceeded(e.MetricsHandler, e.metricTagConfig(), operation, node.NamespaceName(), node.WorkflowTypeName(), env.Now())
 		return nil
 	})
 }
@@ -552,7 +552,7 @@ func (e taskExecutor) failNonRetryable(env hsm.Environment, node *hsm.Node, oper
 	if err := handleNonRetryableStartOperationError(node, operation, callErr); err != nil {
 		return err
 	}
-	e.recordOperationFailed(operation, node.NamespaceName(), node.WorkflowTypeName(), env.Now())
+	recordOperationFailed(e.MetricsHandler, e.metricTagConfig(), operation, node.NamespaceName(), node.WorkflowTypeName(), env.Now())
 	return nil
 }
 
@@ -614,7 +614,7 @@ func (e taskExecutor) recordOperationTimeout(env hsm.Environment, node *hsm.Node
 	}
 	// timedOutOp was captured from the transition closure above (the same Operation that
 	// MachineData would return); the timeout transition leaves the metric fields unchanged.
-	e.recordOperationTimedOut(timedOutOp, node.NamespaceName(), node.WorkflowTypeName(), timeoutType.String(), env.Now())
+	recordOperationTimedOut(e.MetricsHandler, e.metricTagConfig(), timedOutOp, node.NamespaceName(), node.WorkflowTypeName(), timeoutType.String(), env.Now())
 	return nil
 }
 

--- a/components/nexusoperations/metrics.go
+++ b/components/nexusoperations/metrics.go
@@ -9,60 +9,71 @@ import (
 	"go.temporal.io/server/common/metrics"
 )
 
-// nexusEngineTagValue marks caller-side metrics emitted by the legacy HSM implementation, so
-// operators can distinguish in-workflow HSM operations from CHASM operations during the
-// HSM->CHASM migration. It is intended for internal use only and should be stripped at the
-// external-observability boundary so the customer-facing rollup aggregates across engines.
-const nexusEngineTagValue = "hsm"
+// metricTagConfig returns the configured metric tag config (nil-safe).
+func (e taskExecutor) metricTagConfig() chasmnexus.NexusMetricTagConfig {
+	return e.Config.ResolvedMetricTagConfig()
+}
 
 // operationMetricsHandler returns a metrics handler enriched with caller-side Nexus operation
 // tags. It mirrors chasm/lib/nexusoperation Operation.metricsHandler so the HSM and CHASM
 // implementations emit identical metric names and labels (see the HSM->CHASM migration). Unlike
 // CHASM, HSM Nexus operations are always in-workflow, so workflowType is always the real parent
 // workflow type (there is no standalone placeholder case).
-func (e taskExecutor) operationMetricsHandler(op Operation, namespaceName, workflowType string) metrics.Handler {
+func operationMetricsHandler(
+	base metrics.Handler,
+	tagConfig chasmnexus.NexusMetricTagConfig,
+	op Operation,
+	namespaceName, workflowType string,
+) metrics.Handler {
 	tags := []metrics.Tag{
 		metrics.NamespaceTag(namespaceName),
 		metrics.NexusEndpointTag(op.Endpoint),
 		metrics.WorkflowTypeTag(workflowType),
-		metrics.StringTag("impl", nexusEngineTagValue),
+		// impl distinguishes legacy HSM operations from CHASM operations during the HSM->CHASM
+		// migration. Intended for internal use only; stripped at the external-observability boundary.
+		// Mirrors the impl="chasm" tag in chasm/lib/nexusoperation Operation.metricsHandler.
+		metrics.StringTag("impl", "hsm"),
 	}
-	var conf chasmnexus.NexusMetricTagConfig
-	if e.Config.MetricTagConfig != nil {
-		conf = e.Config.MetricTagConfig()
-	}
-	if conf.IncludeServiceTag {
+	if tagConfig.IncludeServiceTag {
 		tags = append(tags, metrics.NexusServiceTag(op.Service))
 	}
-	if conf.IncludeOperationTag {
+	if tagConfig.IncludeOperationTag {
 		tags = append(tags, metrics.NexusOperationTag(op.Operation))
 	}
-	return e.MetricsHandler.WithTags(tags...)
+	return base.WithTags(tags...)
 }
 
 // recordOperationSucceeded emits the success counter and latency metrics for an operation that
 // completed successfully.
-func (e taskExecutor) recordOperationSucceeded(op Operation, namespaceName, workflowType string, closeTime time.Time) {
-	e.recordOperationOutcome(op, namespaceName, workflowType, nexusoperationpb.OPERATION_STATUS_SUCCEEDED, closeTime, chasmnexus.NexusOperationSuccessCount.With)
+func recordOperationSucceeded(base metrics.Handler, tagConfig chasmnexus.NexusMetricTagConfig, op Operation, namespaceName, workflowType string, closeTime time.Time) {
+	recordOperationOutcome(base, tagConfig, op, namespaceName, workflowType, nexusoperationpb.OPERATION_STATUS_SUCCEEDED, closeTime, chasmnexus.NexusOperationSuccessCount.With)
 }
 
 // recordOperationFailed emits the failure counter and latency metrics for an operation that
 // failed non-retryably.
-func (e taskExecutor) recordOperationFailed(op Operation, namespaceName, workflowType string, closeTime time.Time) {
-	e.recordOperationOutcome(op, namespaceName, workflowType, nexusoperationpb.OPERATION_STATUS_FAILED, closeTime, chasmnexus.NexusOperationFailedCount.With)
+func recordOperationFailed(base metrics.Handler, tagConfig chasmnexus.NexusMetricTagConfig, op Operation, namespaceName, workflowType string, closeTime time.Time) {
+	recordOperationOutcome(base, tagConfig, op, namespaceName, workflowType, nexusoperationpb.OPERATION_STATUS_FAILED, closeTime, chasmnexus.NexusOperationFailedCount.With)
+}
+
+// recordOperationCanceled emits the cancel counter and latency metrics for an operation that
+// completed as canceled.
+func recordOperationCanceled(base metrics.Handler, tagConfig chasmnexus.NexusMetricTagConfig, op Operation, namespaceName, workflowType string, closeTime time.Time) {
+	recordOperationOutcome(base, tagConfig, op, namespaceName, workflowType, nexusoperationpb.OPERATION_STATUS_CANCELED, closeTime, chasmnexus.NexusOperationCancelCount.With)
 }
 
 // recordOperationTimedOut emits the timeout counter (tagged with the timeout type) and latency
 // metrics for an operation that timed out.
-func (e taskExecutor) recordOperationTimedOut(op Operation, namespaceName, workflowType, timeoutType string, closeTime time.Time) {
-	e.recordOperationOutcome(op, namespaceName, workflowType, nexusoperationpb.OPERATION_STATUS_TIMED_OUT, closeTime, chasmnexus.NexusOperationTimeoutCount.With, metrics.TimeoutTypeTag(timeoutType))
+func recordOperationTimedOut(base metrics.Handler, tagConfig chasmnexus.NexusMetricTagConfig, op Operation, namespaceName, workflowType, timeoutType string, closeTime time.Time) {
+	recordOperationOutcome(base, tagConfig, op, namespaceName, workflowType, nexusoperationpb.OPERATION_STATUS_TIMED_OUT, closeTime, chasmnexus.NexusOperationTimeoutCount.With, metrics.TimeoutTypeTag(timeoutType))
 }
 
 // recordOperationOutcome records the terminal outcome counter and the shared latency metrics for a
 // closed operation. The outcome-specific counter is supplied as a metric definition's With method
 // (e.g. NexusOperationSuccessCount.With), so each per-outcome recorder differs only by its counter
 // and any extra counter tags (the timeout type, for timeouts).
-func (e taskExecutor) recordOperationOutcome(
+func recordOperationOutcome(
+	base metrics.Handler,
+	tagConfig chasmnexus.NexusMetricTagConfig,
 	op Operation,
 	namespaceName, workflowType string,
 	status nexusoperationpb.OperationStatus,
@@ -70,15 +81,15 @@ func (e taskExecutor) recordOperationOutcome(
 	withCounter func(metrics.Handler) metrics.CounterIface,
 	counterTags ...metrics.Tag,
 ) {
-	handler := e.operationMetricsHandler(op, namespaceName, workflowType)
+	handler := operationMetricsHandler(base, tagConfig, op, namespaceName, workflowType)
 	withCounter(handler).Record(1, counterTags...)
-	e.recordCompletionLatencies(handler, op, closeTime, metrics.OutcomeTag(strings.ToLower(status.String())))
+	recordCompletionLatencies(handler, op, closeTime, metrics.OutcomeTag(strings.ToLower(status.String())))
 }
 
 // recordCompletionLatencies emits schedule-to-close plus either start-to-close (operations that
 // started) or schedule-to-start (sync / never-started), mirroring chasm/lib/nexusoperation's
 // emitLatencyMetrics. It is shared by the per-outcome recorders above.
-func (e taskExecutor) recordCompletionLatencies(handler metrics.Handler, op Operation, closeTime time.Time, outcomeTag metrics.Tag) {
+func recordCompletionLatencies(handler metrics.Handler, op Operation, closeTime time.Time, outcomeTag metrics.Tag) {
 	if op.ScheduledTime == nil {
 		return
 	}
@@ -94,10 +105,16 @@ func (e taskExecutor) recordCompletionLatencies(handler metrics.Handler, op Oper
 }
 
 // recordScheduleToStartLatency emits the schedule-to-start latency when an async operation starts.
-func (e taskExecutor) recordScheduleToStartLatency(op Operation, namespaceName, workflowType string, startedTime time.Time) {
+func recordScheduleToStartLatency(
+	base metrics.Handler,
+	tagConfig chasmnexus.NexusMetricTagConfig,
+	op Operation,
+	namespaceName, workflowType string,
+	startedTime time.Time,
+) {
 	if op.ScheduledTime == nil {
 		return
 	}
-	handler := e.operationMetricsHandler(op, namespaceName, workflowType)
+	handler := operationMetricsHandler(base, tagConfig, op, namespaceName, workflowType)
 	chasmnexus.NexusOperationScheduleToStartLatency.With(handler).Record(startedTime.Sub(op.ScheduledTime.AsTime()))
 }

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -133,9 +133,10 @@ func HandlerProvider(args NewHandlerArgs) (*Handler, error) {
 	}
 
 	handler := &Handler{
-		status:          common.DaemonStatusInitialized,
-		config:          args.Config,
-		tokenSerializer: tasktoken.NewSerializer(),
+		status:                common.DaemonStatusInitialized,
+		config:                args.Config,
+		nexusOperationsConfig: args.NexusOperationsConfig,
+		tokenSerializer:       tasktoken.NewSerializer(),
 		deepHealthCheckHandler: deepHealthCheckHandler{
 			healthServer:            args.HealthServer,
 			metricsHandler:          args.MetricsHandler,

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -81,6 +81,7 @@ type (
 
 		tokenSerializer              *tasktoken.Serializer
 		config                       *configs.Config
+		nexusOperationsConfig        *nexusoperations.Config
 		eventNotifier                events.Notifier
 		deepHealthCheckHandler       deepHealthCheckHandler
 		logger                       log.Logger
@@ -117,6 +118,7 @@ type (
 		fx.In
 
 		Config                       *configs.Config
+		NexusOperationsConfig        *nexusoperations.Config
 		Logger                       log.SnTaggedLogger
 		ThrottledLogger              log.ThrottledLogger
 		PersistenceExecutionManager  persistence.ExecutionManager
@@ -2161,6 +2163,8 @@ func (h *Handler) CompleteNexusOperation(ctx context.Context, request *historyse
 		request.Links,
 		request.GetSuccess(),
 		opErr,
+		h.metricsHandler,
+		h.nexusOperationsConfig.ResolvedMetricTagConfig(),
 	)
 	if err != nil {
 		return nil, h.convertError(err)

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -334,6 +334,68 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion(chasmEnabled b
 	s.Empty(desc.DatabaseMutableState.GetExecutionInfo().SubStateMachinesByType)
 }
 
+// TestNexusOperationCallerMetrics verifies that an in-workflow Nexus operation emits the
+// caller-side operation metrics (counter + latencies) tagged with the caller's namespace,
+// endpoint, real workflow type, and the engine ("impl") tag. It runs for both the HSM and CHASM
+// engines, asserting the engine-specific impl tag, which keeps the two implementations at parity.
+func (s *NexusWorkflowTestSuite) TestNexusOperationCallerMetrics(chasmEnabled bool) {
+	env := s.newTestEnv(chasmEnabled)
+	ctx := env.Context()
+	taskQueue := testcore.RandomizeStr(s.T().Name())
+
+	h := nexustest.Handler{
+		OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
+			return &nexus.HandlerStartOperationResultSync[any]{Value: "result"}, nil
+		},
+	}
+	endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
+
+	const callerWorkflowType = "NexusCallerMetricsWorkflow"
+	callerWF := func(ctx workflow.Context) (string, error) {
+		c := workflow.NewNexusClient(endpointName, "service")
+		fut := c.ExecuteOperation(ctx, "operation", "input", workflow.NexusOperationOptions{})
+		var result string
+		return result, fut.Get(ctx, &result)
+	}
+
+	w := worker.New(env.SdkClient(), taskQueue, worker.Options{})
+	w.RegisterWorkflowWithOptions(callerWF, workflow.RegisterOptions{Name: callerWorkflowType})
+	s.NoError(w.Start())
+	defer w.Stop()
+
+	capture := env.StartNamespaceMetricCapture()
+	// Execute by the registered workflow type name so the recorded workflow type is deterministic
+	// (passing the function value would record the anonymous closure's name instead).
+	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		TaskQueue: taskQueue,
+	}, callerWorkflowType)
+	s.NoError(err)
+	var result string
+	s.NoError(run.Get(ctx, &result))
+	s.Equal("result", result)
+
+	expectedImpl := "hsm"
+	if chasmEnabled {
+		expectedImpl = "chasm"
+	}
+
+	successCount := capture.Metric(chasmnexus.NexusOperationSuccessCount.Name())
+	s.Len(successCount, 1)
+	if len(successCount) != 1 {
+		return
+	}
+	s.Equal(int64(1), successCount[0].Value)
+	s.Subset(successCount[0].Tags, map[string]string{
+		"namespace":      env.Namespace().String(),
+		"nexus_endpoint": endpointName,
+		"workflowType":   callerWorkflowType,
+		"impl":           expectedImpl,
+	})
+
+	// A latency metric is also recorded for the terminal state.
+	s.NotEmpty(capture.Metric(chasmnexus.NexusOperationScheduleToCloseLatency.Name()))
+}
+
 // TestNexusOperationStartsStandaloneActivityBidirectionalLinks verifies the end-to-end
 // SAA-via-Nexus path: a workflow invokes a Nexus operation whose handler creates a
 // standalone activity, attaches the Nexus operation back-link to that activity, and


### PR DESCRIPTION
**WIP / draft — for review, not ready to merge.**

Stacked on #10787 (base branch `gokhan/nexus-op-caller-metrics-hsm`). Review #10786 → #10787 → this PR in order.

### This PR (3/3)
Completes the backport.

- **Async completion path** (`CompleteNexusOperation` callbacks): `CompletionHandler` now records the terminal outcome (succeeded/failed/canceled) and, when it fabricates a started transition for a completion that arrives before the start response, the schedule-to-start latency.
- The shared emit helpers are refactored into package functions used by both the executor and completion paths.
- The history `Handler` is given the `nexusoperations` Config via fx so it can resolve the metric tag config and pass it (with its metrics handler) into `CompletionHandler`.
- Adds `impl="chasm"` to the CHASM caller metrics so the two engines are distinguishable during the migration (HSM side emits `impl="hsm"`).
- **Functional test** `TestNexusOperationCallerMetrics`: runs an in-workflow Nexus operation to completion and asserts the caller metric is emitted with `namespace`, `nexus_endpoint`, the real `workflowType`, and the engine `impl` tag. Parameterized over both HSM and CHASM engines (asserts `impl=hsm` vs `impl=chasm`) — verifies both implementations at parity.

Chronicle/extobs ingestion is tracked in DEVPROD-1804. The internal `impl` tag is intended to be stripped at the external-observability boundary so the customer-facing rollup aggregates across engines.

### Stack
1. #10786 — HSM `NodeBackend` accessors
2. #10787 — executor-side emission
3. **(this PR)** completion-path emission + `impl=chasm` + functional test

🤖 Generated with [Claude Code](https://claude.com/claude-code)