### PR TITLE
Apply lint fixes for oss-matching

### DIFF
--- a/common/tqid/task_queue_id_test.go
+++ b/common/tqid/task_queue_id_test.go
@@ -1,7 +1,6 @@
 package tqid
 
 import (
-	"errors"
 	"math/rand"
 	"strconv"
 	"testing"
@@ -45,7 +44,7 @@ func TestFromProtoPartition_Sticky(t *testing.T) {
 	a.Equal(nsid, p.NamespaceId())
 	a.Equal(taskType, p.TaskType())
 	a.Equal(kind, p.Kind())
-	a.Equal("", p.TaskQueue().Name())
+	a.Empty(p.TaskQueue().Name())
 	a.Equal(stickyName, p.(*StickyPartition).StickyName())
 	a.Equal(stickyName, p.RpcName())
 	a.False(p.IsRoot())
@@ -54,7 +53,7 @@ func TestFromProtoPartition_Sticky(t *testing.T) {
 	proto.Name = "/_sys/my-basic-tq-name/23"
 	_, err = PartitionFromProto(proto, nsid, taskType)
 	// sticky queue cannot have non-zero prtn
-	a.True(errors.Is(err, ErrNonZeroSticky))
+	a.ErrorIs(err, ErrNonZeroSticky)
 }
 
 func TestFromProtoPartition_WorkerCommands(t *testing.T) {

--- a/common/worker_versioning/routing_info_cache_test.go
+++ b/common/worker_versioning/routing_info_cache_test.go
@@ -257,9 +257,7 @@ func TestRoutingInfoCache_Concurrent(t *testing.T) {
 	// Concurrent writes
 	for i := range numGoroutines {
 		idx := i
-		wg.Add(1) //nolint:revive // use-waitgroup-go: standard sync.WaitGroup doesn't have Go() method
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for j := range numOperations {
 				version := &deploymentspb.WorkerDeploymentVersion{
 					DeploymentName: "deployment",
@@ -276,18 +274,16 @@ func TestRoutingInfoCache_Concurrent(t *testing.T) {
 					0,
 				)
 			}
-		}()
+		})
 	}
 
 	// Concurrent reads
 	for range numGoroutines {
-		wg.Add(1) //nolint:revive // use-waitgroup-go: standard sync.WaitGroup doesn't have Go() method
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range numOperations {
 				routingCache.Get(namespace, taskQueue, taskQueueType)
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/common/worker_versioning/worker_versioning_test.go
+++ b/common/worker_versioning/worker_versioning_test.go
@@ -2,6 +2,7 @@ package worker_versioning
 
 import (
 	"context"
+	"slices"
 	"strconv"
 	"sync"
 	"testing"
@@ -1861,13 +1862,7 @@ func TestCleanupOldDeletedVersions(t *testing.T) {
 			// Check that only expected versions were removed
 			for k := range originalKeys {
 				_, exists := deploymentData.Versions[k]
-				shouldBeRemoved := false
-				for _, removed := range tt.wantRemoved {
-					if k == removed {
-						shouldBeRemoved = true
-						break
-					}
-				}
+				shouldBeRemoved := slices.Contains(tt.wantRemoved, k)
 				if shouldBeRemoved {
 					assert.False(t, exists, "version %s should have been removed", k)
 				} else {

--- a/service/matching/ack_manager_test.go
+++ b/service/matching/ack_manager_test.go
@@ -33,10 +33,10 @@ func (s *AckManagerTestSuite) AddingTasksIncreasesBacklogCounter() {
 	ackMgr := newTestAckMgr(s.logger)
 
 	ackMgr.addTask(1)
-	s.Equal(ackMgr.getBacklogCountHint(), int64(1))
+	s.Equal(int64(1), ackMgr.getBacklogCountHint())
 
 	ackMgr.addTask(12)
-	s.Equal(ackMgr.getBacklogCountHint(), int64(2))
+	s.Equal(int64(2), ackMgr.getBacklogCountHint())
 }
 
 func (s *AckManagerTestSuite) CompleteTaskMovesAckLevelUpToGap() {

--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -811,9 +811,7 @@ func (s *BacklogManagerTestSuite) testStandingBacklog(p standingBacklogParams) {
 	s.NoError(s.blm.WaitUntilInitialized(context.Background()))
 
 	// writer
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for sleepUntil(func() bool { return delta() <= p.gap }) {
 			info := makeNewTask()
 			tracker.Store(info.ScheduledEventId, info.Priority.FairnessKey)
@@ -827,12 +825,10 @@ func (s *BacklogManagerTestSuite) testStandingBacklog(p standingBacklogParams) {
 				sleep()
 			}
 		}
-	}()
+	})
 
 	// poller
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for sleepUntil(func() bool { return delta() >= -p.gap }) {
 			if t := getTask(); t != nil {
 				// TODO: error sometimes?
@@ -851,7 +847,7 @@ func (s *BacklogManagerTestSuite) testStandingBacklog(p standingBacklogParams) {
 				sleep()
 			}
 		}
-	}()
+	})
 
 	// adjust target over time
 	for t := target.Load(); time.Since(start) < p.duration; sleep() {

--- a/service/matching/configs/quotas_test.go
+++ b/service/matching/configs/quotas_test.go
@@ -48,7 +48,7 @@ func (s *quotasSuite) TestAPIToPriorityMapping() {
 
 func (s *quotasSuite) TestAPIPrioritiesOrdered() {
 	for idx := range APIPrioritiesOrdered[1:] {
-		s.True(APIPrioritiesOrdered[idx] < APIPrioritiesOrdered[idx+1])
+		s.Less(APIPrioritiesOrdered[idx], APIPrioritiesOrdered[idx+1])
 	}
 }
 

--- a/service/matching/forwarder_test.go
+++ b/service/matching/forwarder_test.go
@@ -426,8 +426,7 @@ func (t *ForwarderTestSuite) TestMaxOutstandingConcurrency() {
 		polls = 0
 		t.Run(tc.name, func() {
 			for range concurrency {
-				wg.Add(1)
-				go func() {
+				wg.Go(func() {
 					timer := time.NewTimer(time.Millisecond * 200)
 					select {
 					case token := <-fwdr.AddReqTokenC():
@@ -449,8 +448,7 @@ func (t *ForwarderTestSuite) TestMaxOutstandingConcurrency() {
 						atomic.AddInt32(&polls, 1)
 					case <-timer.C:
 					}
-					wg.Done()
-				}()
+				})
 			}
 			t.True(common.AwaitWaitGroup(&wg, time.Second))
 			t.Equal(tc.output, adds)
@@ -474,15 +472,13 @@ func (t *ForwarderTestSuite) TestMaxOutstandingConfigUpdate() {
 	startC := make(chan struct{})
 	doneWG := sync.WaitGroup{}
 	for range 10 {
-		doneWG.Add(1)
-		go func() {
+		doneWG.Go(func() {
 			<-startC
 			token1 := <-fwdr.AddReqTokenC()
 			token1.release()
 			token2 := <-fwdr.PollReqTokenC()
 			token2.release()
-			doneWG.Done()
-		}()
+		})
 	}
 
 	maxOutstandingTasks = 10

--- a/service/matching/forwarder_test.go
+++ b/service/matching/forwarder_test.go
@@ -107,7 +107,7 @@ func (t *ForwarderTestSuite) TestForwardWorkflowTask() {
 
 	schedToStart := int32(request.GetScheduleToStartTimeout().AsDuration().Seconds())
 	rewritten := convert.Int32Ceil(time.Until(taskInfo.Data.ExpiryTime.AsTime()).Seconds())
-	t.EqualValues(schedToStart, rewritten)
+	t.Equal(schedToStart, rewritten)
 	t.Equal(t.partition.RpcName(), request.GetForwardInfo().GetSourcePartition())
 	t.Equal(enumsspb.TASK_SOURCE_DB_BACKLOG, request.GetForwardInfo().GetTaskSource())
 }
@@ -137,7 +137,7 @@ func (t *ForwarderTestSuite) TestForwardWorkflowTask_WithBuildId() {
 
 	schedToStart := int32(request.GetScheduleToStartTimeout().AsDuration().Seconds())
 	rewritten := convert.Int32Ceil(time.Until(taskInfo.Data.ExpiryTime.AsTime()).Seconds())
-	t.EqualValues(schedToStart, rewritten)
+	t.Equal(schedToStart, rewritten)
 	t.Equal(t.partition.RpcName(), request.GetForwardInfo().GetSourcePartition())
 	t.Equal(enumsspb.TASK_SOURCE_HISTORY, request.GetForwardInfo().GetTaskSource())
 }
@@ -162,7 +162,7 @@ func (t *ForwarderTestSuite) TestForwardActivityTask() {
 	t.Equal(taskInfo.Data.GetWorkflowId(), request.GetExecution().GetWorkflowId())
 	t.Equal(taskInfo.Data.GetRunId(), request.GetExecution().GetRunId())
 	t.Equal(taskInfo.Data.GetScheduledEventId(), request.GetScheduledEventId())
-	t.EqualValues(convert.Int32Ceil(time.Until(taskInfo.Data.ExpiryTime.AsTime()).Seconds()),
+	t.Equal(convert.Int32Ceil(time.Until(taskInfo.Data.ExpiryTime.AsTime()).Seconds()),
 		int32(request.GetScheduleToStartTimeout().AsDuration().Seconds()))
 	t.Equal(t.partition.RpcName(), request.GetForwardInfo().GetSourcePartition())
 	t.Equal(enumsspb.TASK_SOURCE_DB_BACKLOG, request.GetForwardInfo().GetTaskSource())
@@ -190,7 +190,7 @@ func (t *ForwarderTestSuite) TestForwardActivityTask_WithBuildId() {
 	t.Equal(taskInfo.Data.GetWorkflowId(), request.GetExecution().GetWorkflowId())
 	t.Equal(taskInfo.Data.GetRunId(), request.GetExecution().GetRunId())
 	t.Equal(taskInfo.Data.GetScheduledEventId(), request.GetScheduledEventId())
-	t.EqualValues(convert.Int32Ceil(time.Until(taskInfo.Data.ExpiryTime.AsTime()).Seconds()),
+	t.Equal(convert.Int32Ceil(time.Until(taskInfo.Data.ExpiryTime.AsTime()).Seconds()),
 		int32(request.GetScheduleToStartTimeout().AsDuration().Seconds()))
 	t.Equal(t.partition.RpcName(), request.GetForwardInfo().GetSourcePartition())
 	t.Equal(enumsspb.TASK_SOURCE_DB_BACKLOG, request.GetForwardInfo().GetTaskSource())
@@ -499,7 +499,7 @@ func (t *ForwarderTestSuite) usingTaskqueuePartition(taskType enumspb.TaskQueueT
 	t.NoError(err)
 	t.partition = f.TaskQueue(taskType).NormalPartition(1)
 	t.fwdr, err = newForwarder(t.cfg, UnversionedQueueKey(t.partition), t.client)
-	t.Nil(err)
+	t.NoError(err)
 }
 
 func (t *ForwarderTestSuite) usingBuildIdQueue(taskType enumspb.TaskQueueType, buildId string) {
@@ -507,7 +507,7 @@ func (t *ForwarderTestSuite) usingBuildIdQueue(taskType enumspb.TaskQueueType, b
 	t.NoError(err)
 	t.partition = f.TaskQueue(taskType).NormalPartition(1)
 	t.fwdr, err = newForwarder(t.cfg, BuildIdQueueKey(t.partition, buildId), t.client)
-	t.Nil(err)
+	t.NoError(err)
 }
 
 func mustParent(tn *tqid.NormalPartition, n int) *tqid.NormalPartition {

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -520,14 +520,12 @@ func (s *matchingEngineSuite) testFailAddTaskWithHistoryError(
 	}
 
 	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		_, err := s.matchingEngine.PollWorkflowTaskQueue(context.Background(), &pollRequest, metrics.NoopMetricsHandler)
 		if err != nil {
 			s.logger.Info(err.Error())
 		}
-		wg.Done()
-	}()
+	})
 
 	partitionReady := func() bool {
 		return len(s.matchingEngine.getTaskQueuePartitions(10)) >= 1
@@ -1248,11 +1246,9 @@ func (s *matchingEngineSuite) TestSyncMatchActivities() {
 		if i == taskCount/2 {
 			maxDispatch = 0
 		}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			result, pollErr = pollFunc(maxDispatch)
-		}()
+		})
 		time.Sleep(20 * time.Millisecond) // Necessary for sync match to happen
 
 		addRequest := matchingservice.AddActivityTaskRequest{
@@ -1274,11 +1270,9 @@ func (s *matchingEngineSuite) TestSyncMatchActivities() {
 			s.logger.Debug("empty poll returned")
 			s.Equal(float64(0), maxDispatch)
 			maxDispatch = defaultTaskDispatchRPS
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				result, pollErr = pollFunc(maxDispatch)
-			}()
+			})
 			wg.Wait()
 			s.NoError(err)
 			s.NoError(pollErr)

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -5536,7 +5536,6 @@ func TestConvertPollWorkflowTaskQueueResponse(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -5705,7 +5704,6 @@ func TestGetHistoryForQueryTask(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)

--- a/service/matching/physical_task_queue_key_test.go
+++ b/service/matching/physical_task_queue_key_test.go
@@ -19,7 +19,7 @@ func TestVersionSetQueueKey(t *testing.T) {
 	key := VersionSetQueueKey(p, "abc3")
 	a.Equal(p, key.Partition())
 	a.Equal("abc3", key.Version().VersionSet())
-	a.Equal("", key.Version().BuildId())
+	a.Empty(key.Version().BuildId())
 	a.Nil(key.Version().Deployment())
 }
 
@@ -31,7 +31,7 @@ func TestBuildIDQueueKey(t *testing.T) {
 	p := f.TaskQueue(enumspb.TASK_QUEUE_TYPE_WORKFLOW).NormalPartition(2)
 	key := BuildIdQueueKey(p, "abc3")
 	a.Equal(p, key.Partition())
-	a.Equal("", key.Version().VersionSet())
+	a.Empty(key.Version().VersionSet())
 	a.Equal("abc3", key.Version().BuildId())
 	a.Nil(key.Version().Deployment())
 }
@@ -48,8 +48,8 @@ func TestDeploymentQueueKey(t *testing.T) {
 	}
 	key := DeploymentQueueKey(p, d)
 	a.Equal(p, key.Partition())
-	a.Equal("", key.Version().VersionSet())
-	a.Equal("", key.Version().BuildId())
+	a.Empty(key.Version().VersionSet())
+	a.Empty(key.Version().BuildId())
 	a.True(d.Equal(key.Version().Deployment()))
 }
 
@@ -61,8 +61,8 @@ func TestUnversionedQueueKey(t *testing.T) {
 	p := f.TaskQueue(enumspb.TASK_QUEUE_TYPE_WORKFLOW).NormalPartition(2)
 	key := UnversionedQueueKey(p)
 	a.Equal(p, key.Partition())
-	a.Equal("", key.Version().VersionSet())
-	a.Equal("", key.Version().BuildId())
+	a.Empty(key.Version().VersionSet())
+	a.Empty(key.Version().BuildId())
 	a.Nil(key.Version().Deployment())
 }
 

--- a/service/matching/physical_task_queue_manager_test.go
+++ b/service/matching/physical_task_queue_manager_test.go
@@ -258,7 +258,7 @@ func (s *PhysicalTaskQueueManagerTestSuite) TestLegacyDescribeTaskQueue() {
 
 	includeTaskStatus := false
 	descResp := s.tqMgr.LegacyDescribeTaskQueue(includeTaskStatus)
-	s.Equal(0, len(descResp.DescResponse.GetPollers()))
+	s.Empty(descResp.DescResponse.GetPollers())
 	s.Nil(descResp.DescResponse.GetTaskQueueStatus())
 
 	includeTaskStatus = true
@@ -280,14 +280,14 @@ func (s *PhysicalTaskQueueManagerTestSuite) TestLegacyDescribeTaskQueue() {
 	}
 
 	descResp = s.tqMgr.LegacyDescribeTaskQueue(includeTaskStatus)
-	s.Equal(1, len(descResp.DescResponse.GetPollers()))
+	s.Len(descResp.DescResponse.GetPollers(), 1)
 	s.Equal(string(pollerIdent), descResp.DescResponse.Pollers[0].GetIdentity())
 	s.NotEmpty(descResp.DescResponse.Pollers[0].GetLastAccessTime())
 
 	rps := 5.0
 	s.tqMgr.pollerHistory.updatePollerInfo(pollerIdent, makePollMetadata(rps))
 	descResp = s.tqMgr.LegacyDescribeTaskQueue(includeTaskStatus)
-	s.Equal(1, len(descResp.DescResponse.GetPollers()))
+	s.Len(descResp.DescResponse.GetPollers(), 1)
 	s.Equal(string(pollerIdent), descResp.DescResponse.Pollers[0].GetIdentity())
 	s.True(descResp.DescResponse.Pollers[0].GetRatePerSecond() > 4.0 && descResp.DescResponse.Pollers[0].GetRatePerSecond() < 6.0)
 
@@ -310,7 +310,7 @@ func (s *PhysicalTaskQueueManagerTestSuite) TestCheckIdleTaskQueue() {
 	// Active poll-er
 	s.tqMgr.Start()
 	s.tqMgr.pollerHistory.updatePollerInfo("test-poll", &pollMetadata{})
-	s.Equal(1, len(s.tqMgr.GetAllPollerInfo()))
+	s.Len(s.tqMgr.GetAllPollerInfo(), 1)
 	time.Sleep(50 * time.Millisecond) // nolint:forbidigo
 	s.Equal(common.DaemonStatusStarted, atomic.LoadInt32(&s.tqMgr.status))
 	s.tqMgr.Stop(unloadCauseUnspecified)
@@ -320,7 +320,7 @@ func (s *PhysicalTaskQueueManagerTestSuite) TestCheckIdleTaskQueue() {
 
 	// Active adding task
 	s.tqMgr.Start()
-	s.Equal(0, len(s.tqMgr.GetAllPollerInfo()))
+	s.Empty(s.tqMgr.GetAllPollerInfo())
 	time.Sleep(50 * time.Millisecond) // nolint:forbidigo
 	s.Equal(common.DaemonStatusStarted, atomic.LoadInt32(&s.tqMgr.status))
 	s.tqMgr.Stop(unloadCauseUnspecified)

--- a/service/matching/pri_task_reader.go
+++ b/service/matching/pri_task_reader.go
@@ -137,7 +137,7 @@ func (tr *priTaskReader) completeTask(task *internalTask, res taskResponse) {
 	tr.lock.Lock()
 	defer tr.lock.Unlock()
 
-	tr.backlogAge.record(task.event.AllocatedTaskInfo.Data.CreateTime, -1)
+	tr.backlogAge.record(task.event.Data.CreateTime, -1)
 
 	numAcked := tr.ackTaskLocked(task.event.TaskId)
 

--- a/service/matching/reachability.go
+++ b/service/matching/reachability.go
@@ -117,10 +117,8 @@ func (rc *reachabilityCalculator) run(ctx context.Context, buildId string) (enum
 
 	// 2. Cases for REACHABLE
 	// 2a. If buildId is assignable to new tasks
-	for _, bid := range buildIdsOfInterest {
-		if rc.isReachableActiveAssignmentRuleTargetOrDefault(bid) {
-			return enumspb.BUILD_ID_TASK_REACHABILITY_REACHABLE, checkedRuleTargetsForUpstream, nil
-		}
+	if slices.ContainsFunc(buildIdsOfInterest, rc.isReachableActiveAssignmentRuleTargetOrDefault) {
+		return enumspb.BUILD_ID_TASK_REACHABILITY_REACHABLE, checkedRuleTargetsForUpstream, nil
 	}
 
 	// 2b. If buildId could be reached from the backlog

--- a/service/matching/task_reader.go
+++ b/service/matching/task_reader.go
@@ -223,10 +223,7 @@ func (tr *taskReader) getTaskBatch(ctx context.Context) (*getTasksBatchResponse,
 
 	// counter i is used to break and let caller check whether taskqueue is still alive and needs to resume read.
 	for i := 0; i < 10 && readLevel < maxReadLevel; i++ {
-		upper := readLevel + tr.backlogMgr.config.RangeSize
-		if upper > maxReadLevel {
-			upper = maxReadLevel
-		}
+		upper := min(readLevel+tr.backlogMgr.config.RangeSize, maxReadLevel)
 		tasks, err := tr.getTaskBatchWithRange(ctx, readLevel, upper)
 		if err != nil {
 			return nil, err

--- a/service/matching/version_sets_merge.go
+++ b/service/matching/version_sets_merge.go
@@ -89,7 +89,6 @@ func collectBuildIdInfo(sets []*persistencespb.CompatibleVersionSet) map[string]
 func intoVersionSets(buildIDToInfo map[string]buildIDInfo) []*persistencespb.CompatibleVersionSet {
 	sets := make([]*persistencespb.CompatibleVersionSet, 0)
 	for id, info := range buildIDToInfo {
-		info := info
 		set := findSetWithSetIDs(sets, info.setIDs)
 		if set == nil {
 			set = &persistencespb.CompatibleVersionSet{

--- a/service/matching/version_sets_merge.go
+++ b/service/matching/version_sets_merge.go
@@ -1,6 +1,7 @@
 package matching
 
 import (
+	"slices"
 	"sort"
 
 	persistencespb "go.temporal.io/server/api/persistence/v1"
@@ -27,10 +28,8 @@ func mergeSetIDs(a []string, b []string) []string {
 // Check if a set contains any of the given set IDs.
 func setContainsSetIDs(set *persistencespb.CompatibleVersionSet, ids []string) bool {
 	for _, needle := range ids {
-		for _, id := range set.SetIds {
-			if needle == id {
-				return true
-			}
+		if slices.Contains(set.SetIds, needle) {
+			return true
 		}
 	}
 	return false

--- a/service/worker/scanner/taskqueue/scavenger_test.go
+++ b/service/worker/scanner/taskqueue/scavenger_test.go
@@ -62,7 +62,7 @@ func (s *ScavengerTestSuite) TestAllExpiredTasks() {
 	s.runScavenger()
 	for tl, tbl := range s.taskTables {
 		tasks := tbl.get(100)
-		s.Equal(0, len(tasks), "failed to delete all expired tasks")
+		s.Empty(tasks, "failed to delete all expired tasks")
 		s.Nil(s.taskQueueTable.get(tl), "failed to delete expired executorTask queue")
 	}
 }
@@ -81,7 +81,7 @@ func (s *ScavengerTestSuite) TestAllAliveTasks() {
 	s.runScavenger()
 	for tl, tbl := range s.taskTables {
 		tasks := tbl.get(100)
-		s.Equal(nTasks, len(tasks), "scavenger deleted a non-expired executorTask")
+		s.Len(tasks, nTasks, "scavenger deleted a non-expired executorTask")
 		s.NotNil(s.taskQueueTable.get(tl), "scavenger deleted a non-expired executorTask queue")
 	}
 }
@@ -101,7 +101,7 @@ func (s *ScavengerTestSuite) TestExpiredTasksFollowedByAlive() {
 	s.runScavenger()
 	for tl, tbl := range s.taskTables {
 		tasks := tbl.get(100)
-		s.Equal(nTasks/2, len(tasks), "scavenger deleted non-expired tasks")
+		s.Len(tasks, nTasks/2, "scavenger deleted non-expired tasks")
 		s.Equal(int64(nTasks/2), tasks[0].GetTaskId(), "scavenger deleted wrong set of tasks")
 		s.NotNil(s.taskQueueTable.get(tl), "scavenger deleted a non-expired executorTask queue")
 	}
@@ -122,7 +122,7 @@ func (s *ScavengerTestSuite) TestAliveTasksFollowedByExpired() {
 	s.runScavenger()
 	for tl, tbl := range s.taskTables {
 		tasks := tbl.get(100)
-		s.Equal(nTasks, len(tasks), "scavenger deleted non-expired tasks")
+		s.Len(tasks, nTasks, "scavenger deleted non-expired tasks")
 		s.NotNil(s.taskQueueTable.get(tl), "scavenger deleted a non-expired executorTask queue")
 	}
 }
@@ -141,10 +141,10 @@ func (s *ScavengerTestSuite) TestAllExpiredTasksWithErrors() {
 	s.runScavenger()
 	for _, tbl := range s.taskTables {
 		tasks := tbl.get(100)
-		s.Equal(0, len(tasks), "failed to delete all expired tasks")
+		s.Empty(tasks, "failed to delete all expired tasks")
 	}
 	result, _ := s.taskQueueTable.list(nil, 10)
-	s.Equal(1, len(result), "expected partial deletion due to transient errors")
+	s.Len(result, 1, "expected partial deletion due to transient errors")
 }
 
 func (s *ScavengerTestSuite) runScavenger() {

--- a/service/worker/workerdeployment/replaytester/replay_test.go
+++ b/service/worker/workerdeployment/replaytester/replay_test.go
@@ -130,14 +130,12 @@ func readExpectedCounts(runDir string) (deploymentCount, versionCount int, err e
 			continue // Skip comments and empty lines
 		}
 
-		if after, ok := strings.CutPrefix(line, "EXPECTED_DEPLOYMENT_WORKFLOWS="); ok {
-			value := after
+		if value, ok := strings.CutPrefix(line, "EXPECTED_DEPLOYMENT_WORKFLOWS="); ok {
 			deploymentCount, err = strconv.Atoi(value)
 			if err != nil {
 				return 0, 0, fmt.Errorf("invalid deployment count: %w", err)
 			}
-		} else if after, ok := strings.CutPrefix(line, "EXPECTED_VERSION_WORKFLOWS="); ok {
-			value := after
+		} else if value, ok := strings.CutPrefix(line, "EXPECTED_VERSION_WORKFLOWS="); ok {
 			versionCount, err = strconv.Atoi(value)
 			if err != nil {
 				return 0, 0, fmt.Errorf("invalid version count: %w", err)

--- a/service/worker/workerdeployment/replaytester/replay_test.go
+++ b/service/worker/workerdeployment/replaytester/replay_test.go
@@ -130,14 +130,14 @@ func readExpectedCounts(runDir string) (deploymentCount, versionCount int, err e
 			continue // Skip comments and empty lines
 		}
 
-		if strings.HasPrefix(line, "EXPECTED_DEPLOYMENT_WORKFLOWS=") {
-			value := strings.TrimPrefix(line, "EXPECTED_DEPLOYMENT_WORKFLOWS=")
+		if after, ok := strings.CutPrefix(line, "EXPECTED_DEPLOYMENT_WORKFLOWS="); ok {
+			value := after
 			deploymentCount, err = strconv.Atoi(value)
 			if err != nil {
 				return 0, 0, fmt.Errorf("invalid deployment count: %w", err)
 			}
-		} else if strings.HasPrefix(line, "EXPECTED_VERSION_WORKFLOWS=") {
-			value := strings.TrimPrefix(line, "EXPECTED_VERSION_WORKFLOWS=")
+		} else if after, ok := strings.CutPrefix(line, "EXPECTED_VERSION_WORKFLOWS="); ok {
+			value := after
 			versionCount, err = strconv.Atoi(value)
 			if err != nil {
 				return 0, 0, fmt.Errorf("invalid version count: %w", err)

--- a/service/worker/workerdeployment/version_workflow.go
+++ b/service/worker/workerdeployment/version_workflow.go
@@ -1072,7 +1072,7 @@ func (d *VersionWorkflowRunner) refreshDrainageInfo(ctx workflow.Context) {
 	drainage := d.VersionState.GetDrainageInfo()
 	var interval time.Duration
 	var err error
-	if drainage.LastCheckedTime.AsTime() == drainage.LastChangedTime.AsTime() {
+	if drainage.LastCheckedTime.AsTime().Equal(drainage.LastChangedTime.AsTime()) {
 		// this is the first update, so we wait according to the grace period config
 		interval, err = getSafeDurationConfig(ctx, "getVisibilityGracePeriod", d.unsafeVisibilityGracePeriodGetter, defaultVisibilityGrace)
 	} else {
@@ -1176,11 +1176,12 @@ func (d *VersionWorkflowRunner) findNewVersionStatus(args *deploymentspb.SyncVer
 }
 
 func (d *VersionWorkflowRunner) updateVersionStatusAfterDrainageStatusChange(ctx workflow.Context, newStatus enumspb.VersionDrainageStatus) {
-	if newStatus == enumspb.VERSION_DRAINAGE_STATUS_DRAINED {
+	switch newStatus {
+	case enumspb.VERSION_DRAINAGE_STATUS_DRAINED:
 		d.VersionState.Status = enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINED
-	} else if newStatus == enumspb.VERSION_DRAINAGE_STATUS_DRAINING {
+	case enumspb.VERSION_DRAINAGE_STATUS_DRAINING:
 		d.VersionState.Status = enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINING
-	} else {
+	default:
 		// This should only happen if we encounter an error while checking the drainage status of the version
 		d.VersionState.Status = enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_UNSPECIFIED
 	}

--- a/service/worker/workerdeployment/version_workflow_test.go
+++ b/service/worker/workerdeployment/version_workflow_test.go
@@ -41,7 +41,7 @@ func TestVersionWorkflowSuite(t *testing.T) {
 func (s *VersionWorkflowSuite) SetupTest() {
 	s.ProtoAssertions = protorequire.New(s.T())
 	s.controller = gomock.NewController(s.T())
-	s.env = s.WorkflowTestSuite.NewTestWorkflowEnvironment()
+	s.env = s.NewTestWorkflowEnvironment()
 
 	// Provide getter functions for drainage refresh interval and visibility grace period
 	drainageRefreshGetter := func() time.Duration { return 5 * time.Minute }


### PR DESCRIPTION
## What changed?

- Applied testifylint, staticcheck, and gofix auto-fixes.
- Exact commands that were run:

```sh
.bin/golangci-lint-v2.9.0 run --allow-parallel-runners --concurrency 4 --fix --enable-only testifylint --build-tags disable_grpc_modules,test_dep --timeout 20m --config=.github/.golangci.yml
.bin/golangci-lint-v2.9.0 run --allow-parallel-runners --concurrency 4 --fix --enable-only staticcheck --build-tags disable_grpc_modules,test_dep --timeout 20m --config=.github/.golangci.yml
make fmt-gofix
make fmt-gofix GOFIX_FLAGS=""
make goimports
git diff --check
```

- No manual or AI changes were made.
- Some fixes caused lint errors; those were reverted again.
- Changes were all reviewed by me.
