### PR TITLE
Fix per-namespace worker shutdown go-routine leak!

### DIFF
--- a/service/worker/pernamespaceworker.go
+++ b/service/worker/pernamespaceworker.go
@@ -19,6 +19,7 @@ import (
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/goro"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -58,6 +59,7 @@ type (
 		startLimiter      quotas.RateLimiter
 
 		membershipChangedCh chan *membership.ChangedEvent
+		backgroundLoops     goro.Group
 
 		lock    sync.Mutex
 		workers map[namespace.ID]*perNamespaceWorker
@@ -154,8 +156,8 @@ func (wm *PerNamespaceWorkerManager) Start(
 	if err != nil {
 		wm.logger.Fatal("Unable to register membership listener", tag.Error(err))
 	}
-	go wm.membershipChangedListener()
-	go wm.periodicRefresh()
+	wm.backgroundLoops.Go(wm.membershipChangedListener)
+	wm.backgroundLoops.Go(wm.periodicRefreshLoop)
 
 	wm.logger.Info("", tag.LifeCycleStarted)
 }
@@ -176,7 +178,8 @@ func (wm *PerNamespaceWorkerManager) Stop() {
 	if err != nil {
 		wm.logger.Error("Unable to unregister membership listener", tag.Error(err))
 	}
-	close(wm.membershipChangedCh)
+	wm.backgroundLoops.Cancel()
+	wm.backgroundLoops.Wait()
 
 	wm.lock.Lock()
 	workers := expmaps.Values(wm.workers)
@@ -203,18 +206,28 @@ func (wm *PerNamespaceWorkerManager) refreshAll() {
 	}
 }
 
-func (wm *PerNamespaceWorkerManager) membershipChangedListener() {
-	for range wm.membershipChangedCh {
-		wm.refreshAll()
+func (wm *PerNamespaceWorkerManager) membershipChangedListener(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-wm.membershipChangedCh:
+			wm.refreshAll()
+		}
 	}
 }
 
-func (wm *PerNamespaceWorkerManager) periodicRefresh() {
-	for range time.NewTicker(refreshInterval).C {
-		if atomic.LoadInt32(&wm.status) != common.DaemonStatusStarted {
-			return
+func (wm *PerNamespaceWorkerManager) periodicRefreshLoop(ctx context.Context) error {
+	ticker := time.NewTicker(refreshInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			wm.refreshAll()
 		}
-		wm.refreshAll()
 	}
 }
 

--- a/service/worker/pernamespaceworker_test.go
+++ b/service/worker/pernamespaceworker_test.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
 	sdkclient "go.temporal.io/sdk/client"
@@ -44,6 +46,51 @@ type perNsWorkerManagerSuite struct {
 
 func TestPerNsWorkerManager(t *testing.T) {
 	suite.Run(t, new(perNsWorkerManagerSuite))
+}
+
+func TestPerNsWorkerManagerStopStopsBackgroundLoops(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		controller := gomock.NewController(t)
+		logger := log.NewTestLogger()
+		cfactory := sdk.NewMockClientFactory(controller)
+		registry := namespace.NewMockRegistry(controller)
+		hostInfo := membership.NewHostInfoFromAddress("self")
+		serviceResolver := membership.NewMockServiceResolver(controller)
+
+		manager := PerNamespaceWorkerManagerProvider(perNamespaceWorkerManagerInitParams{
+			Logger:            logger,
+			SdkClientFactory:  cfactory,
+			NamespaceRegistry: registry,
+			HostName:          "self",
+			Config: &Config{
+				PerNamespaceWorkerStartRate: dynamicconfig.GetFloatPropertyFn(10),
+			},
+			ClusterMetadata: clustertest.NewMetadataForTest(cluster.NewTestClusterMetadataConfig(false, true)),
+		})
+
+		registry.EXPECT().RegisterStateChangeCallback(gomock.Any(), gomock.Any())
+		serviceResolver.EXPECT().AddListener(gomock.Any(), gomock.Any())
+		manager.Start(hostInfo, serviceResolver)
+
+		registry.EXPECT().UnregisterStateChangeCallback(gomock.Any())
+		serviceResolver.EXPECT().RemoveListener(gomock.Any())
+		stopManager(t, manager)
+	})
+}
+
+func stopManager(t *testing.T, manager *PerNamespaceWorkerManager) {
+	t.Helper()
+
+	stopped := make(chan struct{})
+	go func() {
+		manager.Stop()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		require.FailNow(t, "manager stop timed out")
+	}
 }
 
 func (s *perNsWorkerManagerSuite) SetupTest() {
@@ -97,7 +144,7 @@ func (s *perNsWorkerManagerSuite) SetupTest() {
 func (s *perNsWorkerManagerSuite) TearDownTest() {
 	s.registry.EXPECT().UnregisterStateChangeCallback(gomock.Any())
 	s.serviceResolver.EXPECT().RemoveListener(gomock.Any())
-	s.manager.Stop()
+	stopManager(s.T(), s.manager)
 }
 
 func (s *perNsWorkerManagerSuite) TestDisabled() {

--- a/tests/leakcheck/leak_test.go
+++ b/tests/leakcheck/leak_test.go
@@ -38,7 +38,6 @@ var goleakOpts = []goleak.Option{
 	// TODO: worker-service and persistence goroutine leaks.
 	goleak.IgnoreTopFunction("go.temporal.io/server/common/persistence.(*healthSignalAggregatorImpl).emitMetricsLoop"),
 	goleak.IgnoreTopFunction("go.temporal.io/server/common/quotas.(*MapRequestRateLimiterImpl[...]).cleanupLoop"),
-	goleak.IgnoreTopFunction("go.temporal.io/server/service/worker.(*PerNamespaceWorkerManager).periodicRefresh"),
 	goleak.IgnoreTopFunction("net/http.(*persistConn).readLoop"),
 	goleak.IgnoreTopFunction("net/http.(*persistConn).writeLoop"),
 


### PR DESCRIPTION
## What changed?
- WISOTT

## Why?
- Not impacting prod, but @stephanos 🐐 noticed that there were some OOM kills that were happening in our test clusters.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- Not sure honestly, this should make life easier not tougher.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Shutdown-path change in worker service only; behavior of refresh/membership handling is unchanged aside from proper goroutine teardown.
> 
> **Overview**
> Fixes a **goroutine leak** in `PerNamespaceWorkerManager` where the membership listener and periodic refresh loops never exited on shutdown.
> 
> **Lifecycle:** Background work now runs under `goro.Group` instead of bare `go` calls. `Stop()` **cancels** that group and **waits** for both loops to finish, replacing `close(membershipChangedCh)` and removing status polling from the periodic ticker loop (loops exit on `ctx.Done()`).
> 
> **Tests:** Adds `TestPerNsWorkerManagerStopStopsBackgroundLoops` and a `stopManager` helper with a timeout so suite teardown cannot hang; functional leak tests drop the `periodicRefresh` goleak ignore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d09d97261f1381c83d0a456e061a70f336cb1c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->