### PR TITLE
Apply gofix fixes for server-owned code

### DIFF
--- a/cmd/tools/genrpcserverinterceptors/main.go
+++ b/cmd/tools/genrpcserverinterceptors/main.go
@@ -152,7 +152,6 @@ func workflowTagGetters(messageType reflect.Type, depth int) messageData {
 	// Iterates over fields in order they defined in proto file, not proto index.
 	// Order is important because the first match wins.
 	for nestedRequest := range messageType.Elem().Fields() {
-		nestedRequest := nestedRequest
 		if nestedRequest.Type.Kind() != reflect.Pointer {
 			continue
 		}

--- a/cmd/tools/genrpcwrappers/main.go
+++ b/cmd/tools/genrpcwrappers/main.go
@@ -173,7 +173,6 @@ func findNestedField(t reflect.Type, name string, path string, maxDepth int) []f
 	}
 	var out []fieldWithPath
 	for f := range t.Fields() {
-		f := f
 		if ignoreField[t.Name()+"."+f.Name] {
 			continue
 		}

--- a/cmd/tools/gensearchattributehelpers/main.go
+++ b/cmd/tools/gensearchattributehelpers/main.go
@@ -41,7 +41,6 @@ func getSearchAttributesHelpersData() searchAttributesHelpersData {
 	historyEventT := reflect.TypeFor[*historypb.HistoryEvent]()
 
 	for attributesGetter := range historyEventT.Methods() {
-		attributesGetter := attributesGetter
 		matches := attributesGetterRegex.FindStringSubmatch(attributesGetter.Name)
 		if len(matches) < 2 {
 			continue

--- a/common/rpc/interceptor/namespace_test.go
+++ b/common/rpc/interceptor/namespace_test.go
@@ -79,7 +79,6 @@ func (s *namespaceSuite) TestFrontendAPIMetrics() {
 
 	t := reflect.TypeFor[workflowservice.WorkflowServiceServer]()
 	for method := range t.Methods() {
-		method := method
 		methodName := method.Name
 		methodType := method.Type
 
@@ -103,7 +102,6 @@ func (s *namespaceSuite) TestMatchingAPIMetrics() {
 
 	t := reflect.TypeFor[matchingservice.MatchingServiceServer]()
 	for method := range t.Methods() {
-		method := method
 		methodName := method.Name
 		methodType := method.Type
 
@@ -127,7 +125,6 @@ func (s *namespaceSuite) TestHistoryAPIMetrics() {
 
 	t := reflect.TypeFor[historyservice.HistoryServiceServer]()
 	for method := range t.Methods() {
-		method := method
 		methodName := method.Name
 		methodType := method.Type
 

--- a/service/frontend/http_api_server.go
+++ b/service/frontend/http_api_server.go
@@ -365,7 +365,6 @@ func newInlineClientConn(
 	for qualifiedServerName, server := range servers {
 		serverVal := reflect.ValueOf(server)
 		for reflectMethod := range serverVal.Type().Methods() {
-			reflectMethod := reflectMethod
 			// We intentionally look this up by name to not assume method indexes line
 			// up from type to value
 			methodVal := serverVal.MethodByName(reflectMethod.Name)


### PR DESCRIPTION
## What changed?

Applied all `go fix` analyzers and kept only generated changes in files whose CODEOWNERS include `@temporalio/server`.

Exact commands run:

```sh
make fmt-gofix GOFIX_FLAGS=""
gofmt -w cmd/tools/genrpcserverinterceptors/main.go cmd/tools/genrpcwrappers/main.go cmd/tools/gensearchattributehelpers/main.go common/rpc/interceptor/namespace_test.go service/frontend/http_api_server.go
go test ./cmd/tools/genrpcserverinterceptors ./cmd/tools/genrpcwrappers ./cmd/tools/gensearchattributehelpers ./common/rpc/interceptor ./service/frontend
```

No manual or AI changes were made.
Non-server-owned generated changes were reverted again.
Changes were all reviewed by me.
