### PR TITLE
Populate HistorySizeBytes with Approx. StateSize

### DIFF
--- a/chasm/lib/nexusoperation/frontend.go
+++ b/chasm/lib/nexusoperation/frontend.go
@@ -195,6 +195,7 @@ func (h *frontendHandler) ListNexusOperationExecutions(
 			CloseTime:            closeTime,
 			ExecutionDuration:    executionDuration,
 			StateTransitionCount: exec.StateTransitionCount,
+			StateSizeBytes:       exec.HistorySizeBytes,
 			SearchAttributes:     &commonpb.SearchAttributes{IndexedFields: exec.CustomSearchAttributes},
 		})
 	}

--- a/service/history/visibility_queue_task_executor.go
+++ b/service/history/visibility_queue_task_executor.go
@@ -497,6 +497,9 @@ func (t *visibilityQueueTaskExecutor) processChasmTask(
 	if err != nil {
 		return err
 	}
+	// CHASM executions don't track event-history size, so reuse the HistorySizeBytes
+	// visibility field to report the approximate persisted state size instead.
+	closedRequest.HistorySizeBytes = int64(visTaskContext.ExecutionInfo().ApproximateStateSize)
 
 	release(nil)
 	return t.visibilityMgr.RecordWorkflowExecutionClosed(ctx, closedRequest)

--- a/service/history/visibility_queue_task_executor_test.go
+++ b/service/history/visibility_queue_task_executor_test.go
@@ -682,7 +682,7 @@ func (s *visibilityQueueTaskExecutorSuite) TestProcessChasmTask_ClosedExecution(
 			s.True(closeTime.Equal(request.CloseTime))
 			s.NotEmpty(request.ExecutionDuration)
 			s.Zero(request.HistoryLength)
-			s.Zero(request.HistorySizeBytes)
+			s.Positive(request.HistorySizeBytes)
 			s.NotEmpty(request.StateTransitionCount)
 
 			// Other fields are tested in TestProcessChasmTask_RunningExecution


### PR DESCRIPTION
## What changed?
Populate HistorySizeBytes with ApproximateStateSizeBytes on execution close.

## Why?
So size is available, e.g., when listing standalone operations or activities later.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
