### PR TITLE
Fix Schedules V1 behavior with Pause

### DIFF
--- a/service/worker/scheduler/activities.go
+++ b/service/worker/scheduler/activities.go
@@ -151,13 +151,25 @@ func (a *activities) tryWatchWorkflow(ctx context.Context, req *schedulespb.Watc
 		return nil, errWrongChain
 	}
 
+	// A paused workflow is still open and still occupies the schedule's overlap
+	// slot, so treat it as running for watch purposes (mirroring the CHASM
+	// scheduler, which considers PAUSED "still progressing"). Otherwise we would
+	// fall through and look for a close event that never arrives, stalling the
+	// schedule. Treating it as running lets the scheduler apply the overlap
+	// policy against it - e.g. TERMINATE_OTHER terminates it and starts the next
+	// run.
+	workflowStatus := pollRes.WorkflowStatus
+	if workflowStatus == enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED {
+		workflowStatus = enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
+	}
+
 	rb := newResponseBuilder(
 		req,
-		pollRes.WorkflowStatus,
+		workflowStatus,
 		a.Logger,
 		a.maxBlobSize()-recordOverheadSize,
 	)
-	if pollRes.WorkflowStatus == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING {
+	if workflowStatus == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING {
 		return rb.Build(nil)
 	}
 

--- a/tests/schedule_pause_interaction_test.go
+++ b/tests/schedule_pause_interaction_test.go
@@ -32,29 +32,21 @@ var allOverlapPolicies = []enumspb.ScheduleOverlapPolicy{
 
 // expectScheduleProgressesWhilePaused returns whether a schedule using the given
 // overlap policy continues to take new scheduled actions while the workflow it
-// started is paused. This encodes the observed, current behavior of each
-// scheduler implementation.
+// started is paused. The V1 and CHASM schedulers both treat a paused workflow as
+// still occupying the overlap slot, so behavior is identical across them:
 //
-//   - ALLOW_ALL never inspects the running workflow, so it always starts new
-//     runs regardless of pause (both schedulers).
-//   - TERMINATE_OTHER terminates the running workflow (a hard close that does
-//     not require the workflow to process a workflow task) and then starts the
-//     next run. CHASM does this even when the workflow is paused. The V1
-//     scheduler does NOT — it stalls. This V1 stall is a bug: the V1 watcher
-//     does not understand the PAUSED status and never observes the paused
-//     workflow close, so it never gets to start the buffered run.
-//   - SKIP / BUFFER_ONE / BUFFER_ALL / CANCEL_OTHER all keep the slot occupied
-//     by the paused workflow, so no new run is taken under either scheduler.
-//     (For CANCEL_OTHER the schedule additionally never makes progress on its
-//     own because a paused workflow cannot process the cancellation request -
-//     it has no workflow task - so the cancel never completes.)
-func expectScheduleProgressesWhilePaused(isCHASM bool, policy enumspb.ScheduleOverlapPolicy) bool {
+//   - ALLOW_ALL never inspects the running workflow, so it always starts new runs.
+//   - TERMINATE_OTHER terminates the paused workflow (a hard close that does not
+//     require the workflow to process a workflow task) and then starts the next run.
+//   - SKIP / BUFFER_ONE / BUFFER_ALL / CANCEL_OTHER keep the slot occupied by the
+//     paused workflow, so no new run is taken. (For CANCEL_OTHER the cancellation
+//     additionally never completes while paused, because a paused workflow has no
+//     workflow task to process the cancel; it completes once unpaused.)
+func expectScheduleProgressesWhilePaused(policy enumspb.ScheduleOverlapPolicy) bool {
 	switch policy {
-	case enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL:
+	case enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+		enumspb.SCHEDULE_OVERLAP_POLICY_TERMINATE_OTHER:
 		return true
-	case enumspb.SCHEDULE_OVERLAP_POLICY_TERMINATE_OTHER:
-		// CHASM terminates the paused workflow and continues; V1 stalls (bug).
-		return isCHASM
 	default:
 		// SKIP, BUFFER_ONE, BUFFER_ALL, CANCEL_OTHER: the paused workflow keeps
 		// the slot, so the schedule does not take new actions.
@@ -63,40 +55,40 @@ func expectScheduleProgressesWhilePaused(isCHASM bool, policy enumspb.ScheduleOv
 }
 
 func TestScheduleV1PauseInteraction(t *testing.T) {
-	t.Run("Overlap", func(t *testing.T) { runSchedulePauseOverlapMatrix(t, v1ContextFactory, false) })
-	t.Run("UnpauseRecovery", func(t *testing.T) { runSchedulePauseRecoveryMatrix(t, v1ContextFactory, false) })
-	t.Run("ContinueAsNew", func(t *testing.T) { testSchedulePauseContinueAsNew(t, v1ContextFactory, false) })
-	t.Run("Reset", func(t *testing.T) { testSchedulePauseReset(t, v1ContextFactory, false) })
+	t.Run("Overlap", func(t *testing.T) { runSchedulePauseOverlapMatrix(t, v1ContextFactory) })
+	t.Run("UnpauseRecovery", func(t *testing.T) { runSchedulePauseRecoveryMatrix(t, v1ContextFactory) })
+	t.Run("ContinueAsNew", func(t *testing.T) { testSchedulePauseContinueAsNew(t, v1ContextFactory) })
+	t.Run("Reset", func(t *testing.T) { testSchedulePauseReset(t, v1ContextFactory) })
 }
 
 func TestScheduleCHASMPauseInteraction(t *testing.T) {
-	t.Run("Overlap", func(t *testing.T) { runSchedulePauseOverlapMatrix(t, chasmContextFactory, true) })
-	t.Run("UnpauseRecovery", func(t *testing.T) { runSchedulePauseRecoveryMatrix(t, chasmContextFactory, true) })
-	t.Run("ContinueAsNew", func(t *testing.T) { testSchedulePauseContinueAsNew(t, chasmContextFactory, true) })
-	t.Run("Reset", func(t *testing.T) { testSchedulePauseReset(t, chasmContextFactory, true) })
+	t.Run("Overlap", func(t *testing.T) { runSchedulePauseOverlapMatrix(t, chasmContextFactory) })
+	t.Run("UnpauseRecovery", func(t *testing.T) { runSchedulePauseRecoveryMatrix(t, chasmContextFactory) })
+	t.Run("ContinueAsNew", func(t *testing.T) { testSchedulePauseContinueAsNew(t, chasmContextFactory) })
+	t.Run("Reset", func(t *testing.T) { testSchedulePauseReset(t, chasmContextFactory) })
 }
 
-func runSchedulePauseOverlapMatrix(t *testing.T, newContext contextFactory, isCHASM bool) {
+func runSchedulePauseOverlapMatrix(t *testing.T, newContext contextFactory) {
 	for _, policy := range allOverlapPolicies {
 		policy := policy
 		t.Run(policy.String(), func(t *testing.T) {
-			testSchedulePauseOverlap(t, newContext, isCHASM, policy)
+			testSchedulePauseOverlap(t, newContext, policy)
 		})
 	}
 }
 
-func runSchedulePauseRecoveryMatrix(t *testing.T, newContext contextFactory, isCHASM bool) {
+func runSchedulePauseRecoveryMatrix(t *testing.T, newContext contextFactory) {
 	for _, policy := range allOverlapPolicies {
 		policy := policy
 		// Recovery is only interesting for policies whose schedule was blocked
 		// by the paused workflow. Policies that keep progressing never stall,
-		// and may have already closed the paused workflow (e.g. CHASM
-		// TERMINATE_OTHER terminates it), so there is nothing to recover.
-		if expectScheduleProgressesWhilePaused(isCHASM, policy) {
+		// and may have already closed the paused workflow (e.g. TERMINATE_OTHER
+		// terminates it), so there is nothing to recover.
+		if expectScheduleProgressesWhilePaused(policy) {
 			continue
 		}
 		t.Run(policy.String(), func(t *testing.T) {
-			testSchedulePauseUnpauseRecovery(t, newContext, isCHASM, policy)
+			testSchedulePauseUnpauseRecovery(t, newContext, policy)
 		})
 	}
 }
@@ -250,10 +242,10 @@ func registerSignalCompletableWorkflow(s *testcore.TestEnv, wt string) {
 // testSchedulePauseOverlap creates a schedule (1s interval) that starts a single
 // long-running workflow, pauses that workflow, and then asserts whether the
 // schedule keeps taking scheduled actions, per expectScheduleProgressesWhilePaused.
-func testSchedulePauseOverlap(t *testing.T, newContext contextFactory, isCHASM bool, policy enumspb.ScheduleOverlapPolicy) {
+func testSchedulePauseOverlap(t *testing.T, newContext contextFactory, policy enumspb.ScheduleOverlapPolicy) {
 	f := setupPausedScheduledWorkflow(t, newContext, policy, registerForeverWorkflow)
 
-	if expectScheduleProgressesWhilePaused(isCHASM, policy) {
+	if expectScheduleProgressesWhilePaused(policy) {
 		// The schedule should keep taking new actions despite the paused workflow.
 		await.RequireTruef(t, func() bool {
 			c, cErr := scheduleActionCount(f.ctx, f.s, f.sid)
@@ -279,7 +271,7 @@ func testSchedulePauseOverlap(t *testing.T, newContext contextFactory, isCHASM b
 // a paused workflow resumes taking actions once that workflow is unpaused and
 // allowed to close (by signalling it, and/or via the scheduler's own
 // cancellation for CANCEL_OTHER).
-func testSchedulePauseUnpauseRecovery(t *testing.T, newContext contextFactory, isCHASM bool, policy enumspb.ScheduleOverlapPolicy) {
+func testSchedulePauseUnpauseRecovery(t *testing.T, newContext contextFactory, policy enumspb.ScheduleOverlapPolicy) {
 	f := setupPausedScheduledWorkflow(t, newContext, policy, registerSignalCompletableWorkflow)
 
 	// Unpause the workflow.
@@ -299,10 +291,8 @@ func testSchedulePauseUnpauseRecovery(t *testing.T, newContext contextFactory, i
 	err = f.s.SdkClient().SignalWorkflow(f.ctx, f.execution.GetWorkflowId(), f.execution.GetRunId(), "complete", nil)
 	require.NoError(t, err)
 
-	// Once the slot frees, the schedule should resume taking actions. This
-	// confirms the V1 stall (see expectScheduleProgressesWhilePaused) is
-	// recoverable - the schedule is blocked only while the workflow is paused,
-	// not permanently.
+	// Once the slot frees, the schedule should resume taking actions - the
+	// schedule is blocked only while the workflow is paused, not permanently.
 	await.RequireTruef(t, func() bool {
 		c, cErr := scheduleActionCount(f.ctx, f.s, f.sid)
 		return cErr == nil && c > f.actionsAtPause
@@ -317,7 +307,7 @@ func testSchedulePauseUnpauseRecovery(t *testing.T, newContext contextFactory, i
 //   - After unpause, the workflow continues-as-new and the continued run
 //     completes, and the scheduler observes that completion across the
 //     continue-as-new boundary.
-func testSchedulePauseContinueAsNew(t *testing.T, newContext contextFactory, isCHASM bool) {
+func testSchedulePauseContinueAsNew(t *testing.T, newContext contextFactory) {
 	// The scheduler matches the continued run's completion by the request ID in
 	// the completion callback token, which only survives continue-as-new in the
 	// envelope token format (gated off by default).
@@ -466,7 +456,7 @@ func testSchedulePauseContinueAsNew(t *testing.T, newContext contextFactory, isC
 // to a point before the pause. The reset run is no longer paused (the pause
 // event is not part of the reset history), and the scheduler keeps tracking the
 // reset run through to completion.
-func testSchedulePauseReset(t *testing.T, newContext contextFactory, isCHASM bool) {
+func testSchedulePauseReset(t *testing.T, newContext contextFactory) {
 	s := testcore.NewEnv(t, pauseInteractionOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-pause-reset")

--- a/tests/schedule_pause_interaction_test.go
+++ b/tests/schedule_pause_interaction_test.go
@@ -15,6 +15,7 @@ import (
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/tests/testcore"
@@ -63,11 +64,17 @@ func expectScheduleProgressesWhilePaused(isCHASM bool, policy enumspb.ScheduleOv
 }
 
 func TestScheduleV1PauseInteraction(t *testing.T) {
-	runSchedulePauseOverlapMatrix(t, v1ContextFactory, false /* isCHASM */)
+	t.Run("Overlap", func(t *testing.T) { runSchedulePauseOverlapMatrix(t, v1ContextFactory, false) })
+	t.Run("UnpauseRecovery", func(t *testing.T) { runSchedulePauseRecoveryMatrix(t, v1ContextFactory, false) })
+	t.Run("ContinueAsNew", func(t *testing.T) { testSchedulePauseContinueAsNew(t, v1ContextFactory, false) })
+	t.Run("Reset", func(t *testing.T) { testSchedulePauseReset(t, v1ContextFactory, false) })
 }
 
 func TestScheduleCHASMPauseInteraction(t *testing.T) {
-	runSchedulePauseOverlapMatrix(t, chasmContextFactory, true /* isCHASM */)
+	t.Run("Overlap", func(t *testing.T) { runSchedulePauseOverlapMatrix(t, chasmContextFactory, true) })
+	t.Run("UnpauseRecovery", func(t *testing.T) { runSchedulePauseRecoveryMatrix(t, chasmContextFactory, true) })
+	t.Run("ContinueAsNew", func(t *testing.T) { testSchedulePauseContinueAsNew(t, chasmContextFactory, true) })
+	t.Run("Reset", func(t *testing.T) { testSchedulePauseReset(t, chasmContextFactory, true) })
 }
 
 func runSchedulePauseOverlapMatrix(t *testing.T, newContext contextFactory, isCHASM bool) {
@@ -75,6 +82,22 @@ func runSchedulePauseOverlapMatrix(t *testing.T, newContext contextFactory, isCH
 		policy := policy
 		t.Run(policy.String(), func(t *testing.T) {
 			testSchedulePauseOverlap(t, newContext, isCHASM, policy)
+		})
+	}
+}
+
+func runSchedulePauseRecoveryMatrix(t *testing.T, newContext contextFactory, isCHASM bool) {
+	for _, policy := range allOverlapPolicies {
+		policy := policy
+		// Recovery is only interesting for policies whose schedule was blocked
+		// by the paused workflow. Policies that keep progressing never stall,
+		// and may have already closed the paused workflow (e.g. CHASM
+		// TERMINATE_OTHER terminates it), so there is nothing to recover.
+		if expectScheduleProgressesWhilePaused(isCHASM, policy) {
+			continue
+		}
+		t.Run(policy.String(), func(t *testing.T) {
+			testSchedulePauseUnpauseRecovery(t, newContext, isCHASM, policy)
 		})
 	}
 }
@@ -87,52 +110,60 @@ func pauseInteractionOpts(t *testing.T) []testcore.TestOption {
 	)
 }
 
-// testSchedulePauseOverlap creates a schedule (1s interval) that starts a single
-// long-running workflow, pauses that workflow, and then asserts whether the
-// schedule keeps taking scheduled actions, per expectScheduleProgressesWhilePaused.
-func testSchedulePauseOverlap(t *testing.T, newContext contextFactory, isCHASM bool, policy enumspb.ScheduleOverlapPolicy) {
+// scheduledPauseFixture holds the handles produced by setupPausedScheduledWorkflow.
+type scheduledPauseFixture struct {
+	s              *testcore.TestEnv
+	ctx            context.Context
+	sid            string
+	wid            string
+	wt             string
+	execution      *commonpb.WorkflowExecution
+	actionsAtPause int64
+}
+
+// setupPausedScheduledWorkflow creates a 1s-interval schedule with the given
+// overlap policy that runs a workflow registered by register, waits for the
+// first run to start, pauses it, and waits for it to reach PAUSED. It returns
+// the handles needed to drive the rest of a pause-interaction test.
+func setupPausedScheduledWorkflow(
+	t *testing.T,
+	newContext contextFactory,
+	policy enumspb.ScheduleOverlapPolicy,
+	register func(s *testcore.TestEnv, wt string),
+) *scheduledPauseFixture {
 	s := testcore.NewEnv(t, pauseInteractionOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-pause-" + policy.String())
 	wid := testcore.RandomizeStr("sched-pause-wf-" + policy.String())
 	wt := testcore.RandomizeStr("sched-pause-wt-" + policy.String())
 
-	// A workflow that runs (effectively) forever, so it stays in the
-	// schedule's running set until the schedule terminates it.
-	s.SdkWorker().RegisterWorkflowWithOptions(
-		func(ctx workflow.Context) error {
-			return workflow.Sleep(ctx, time.Hour)
-		},
-		workflow.RegisterOptions{Name: wt},
-	)
-
-	schedule := &schedulepb.Schedule{
-		Spec: &schedulepb.ScheduleSpec{
-			Interval: []*schedulepb.IntervalSpec{
-				{Interval: durationpb.New(1 * time.Second)},
-			},
-		},
-		Action: &schedulepb.ScheduleAction{
-			Action: &schedulepb.ScheduleAction_StartWorkflow{
-				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
-					WorkflowId:   wid,
-					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-				},
-			},
-		},
-		Policies: &schedulepb.SchedulePolicies{
-			OverlapPolicy: policy,
-		},
-	}
+	register(s, wt)
 
 	ctx := newContext(s.Context())
 	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
 		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
-		Schedule:   schedule,
-		Identity:   "test",
-		RequestId:  uuid.NewString(),
+		Schedule: &schedulepb.Schedule{
+			Spec: &schedulepb.ScheduleSpec{
+				Interval: []*schedulepb.IntervalSpec{
+					{Interval: durationpb.New(1 * time.Second)},
+				},
+			},
+			Action: &schedulepb.ScheduleAction{
+				Action: &schedulepb.ScheduleAction_StartWorkflow{
+					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+						WorkflowId:   wid,
+						WorkflowType: &commonpb.WorkflowType{Name: wt},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					},
+				},
+			},
+			Policies: &schedulepb.SchedulePolicies{
+				OverlapPolicy: policy,
+			},
+		},
+		Identity:  "test",
+		RequestId: uuid.NewString(),
 	})
 	require.NoError(t, err)
 
@@ -164,7 +195,7 @@ func testSchedulePauseOverlap(t *testing.T, newContext contextFactory, isCHASM b
 		WorkflowId: execution.GetWorkflowId(),
 		RunId:      execution.GetRunId(),
 		Identity:   "functional-test",
-		Reason:     "schedule-pause-overlap-interaction",
+		Reason:     "schedule-pause-interaction",
 		RequestId:  uuid.NewString(),
 	})
 	require.NoError(t, err)
@@ -180,14 +211,56 @@ func testSchedulePauseOverlap(t *testing.T, newContext contextFactory, isCHASM b
 
 	actionsAtPause, err := scheduleActionCount(ctx, s, sid)
 	require.NoError(t, err)
-	fmt.Printf("[DEBUGGING] [chasm=%t %s] paused wf=%s actionsAtPause=%d\n",
-		isCHASM, policy, execution.GetRunId(), actionsAtPause)
+
+	return &scheduledPauseFixture{
+		s:              s,
+		ctx:            ctx,
+		sid:            sid,
+		wid:            wid,
+		wt:             wt,
+		execution:      execution,
+		actionsAtPause: actionsAtPause,
+	}
+}
+
+// registerForeverWorkflow registers a workflow that runs (effectively) forever,
+// so it stays in the schedule's running set until the schedule closes it.
+func registerForeverWorkflow(s *testcore.TestEnv, wt string) {
+	s.SdkWorker().RegisterWorkflowWithOptions(
+		func(ctx workflow.Context) error {
+			return workflow.Sleep(ctx, time.Hour)
+		},
+		workflow.RegisterOptions{Name: wt},
+	)
+}
+
+// registerSignalCompletableWorkflow registers a workflow that blocks until it
+// receives the "complete" signal or its context is cancelled, then closes. This
+// lets a test free the schedule's overlap slot on demand (by signalling) or via
+// the scheduler's own cancellation (CANCEL_OTHER).
+func registerSignalCompletableWorkflow(s *testcore.TestEnv, wt string) {
+	s.SdkWorker().RegisterWorkflowWithOptions(
+		func(ctx workflow.Context) error {
+			workflow.GetSignalChannel(ctx, "complete").Receive(ctx, nil)
+			return ctx.Err()
+		},
+		workflow.RegisterOptions{Name: wt},
+	)
+}
+
+// testSchedulePauseOverlap creates a schedule (1s interval) that starts a single
+// long-running workflow, pauses that workflow, and then asserts whether the
+// schedule keeps taking scheduled actions, per expectScheduleProgressesWhilePaused.
+func testSchedulePauseOverlap(t *testing.T, newContext contextFactory, isCHASM bool, policy enumspb.ScheduleOverlapPolicy) {
+	f := setupPausedScheduledWorkflow(t, newContext, policy, registerForeverWorkflow)
+	t.Logf("[chasm=%t %s] paused wf=%s actionsAtPause=%d\n",
+		isCHASM, policy, f.execution.GetRunId(), f.actionsAtPause)
 
 	if expectScheduleProgressesWhilePaused(isCHASM, policy) {
 		// The schedule should keep taking new actions despite the paused workflow.
 		await.RequireTruef(t, func() bool {
-			c, cErr := scheduleActionCount(ctx, s, sid)
-			return cErr == nil && c > actionsAtPause
+			c, cErr := scheduleActionCount(f.ctx, f.s, f.sid)
+			return cErr == nil && c > f.actionsAtPause
 		}, 20*time.Second, 500*time.Millisecond,
 			"schedule with %s should keep taking actions while its workflow is paused", policy)
 	} else {
@@ -198,11 +271,341 @@ func testSchedulePauseOverlap(t *testing.T, newContext contextFactory, isCHASM b
 		// times, then assert ActionCount did not advance.
 		//nolint:forbidigo // asserting absence of scheduled actions over a fixed window
 		time.Sleep(8 * time.Second)
-		got, gErr := scheduleActionCount(ctx, s, sid)
+		got, gErr := scheduleActionCount(f.ctx, f.s, f.sid)
 		require.NoError(t, gErr)
-		require.Equal(t, actionsAtPause, got,
+		require.Equal(t, f.actionsAtPause, got,
 			"schedule with %s must not take new actions while its workflow is paused", policy)
 	}
+}
+
+// testSchedulePauseUnpauseRecovery verifies that a schedule that was blocked by
+// a paused workflow resumes taking actions once that workflow is unpaused and
+// allowed to close (by signalling it, and/or via the scheduler's own
+// cancellation for CANCEL_OTHER).
+func testSchedulePauseUnpauseRecovery(t *testing.T, newContext contextFactory, isCHASM bool, policy enumspb.ScheduleOverlapPolicy) {
+	f := setupPausedScheduledWorkflow(t, newContext, policy, registerSignalCompletableWorkflow)
+	t.Logf("[chasm=%t %s recovery] paused wf=%s actionsAtPause=%d\n",
+		isCHASM, policy, f.execution.GetRunId(), f.actionsAtPause)
+
+	// Unpause the workflow.
+	_, err := f.s.FrontendClient().UnpauseWorkflowExecution(f.ctx, &workflowservice.UnpauseWorkflowExecutionRequest{
+		Namespace:  f.s.Namespace().String(),
+		WorkflowId: f.execution.GetWorkflowId(),
+		RunId:      f.execution.GetRunId(),
+		Identity:   "functional-test",
+		Reason:     "schedule-pause-interaction-recovery",
+		RequestId:  uuid.NewString(),
+	})
+	require.NoError(t, err)
+
+	// Free the overlap slot: signal the workflow so it can complete. For
+	// CANCEL_OTHER the scheduler's pending cancellation will also close it; the
+	// signal is harmless either way.
+	err = f.s.SdkClient().SignalWorkflow(f.ctx, f.execution.GetWorkflowId(), f.execution.GetRunId(), "complete", nil)
+	require.NoError(t, err)
+
+	// Once the slot frees, the schedule should resume taking actions. This
+	// confirms the V1 stall (see expectScheduleProgressesWhilePaused) is
+	// recoverable - the schedule is blocked only while the workflow is paused,
+	// not permanently.
+	await.RequireTruef(t, func() bool {
+		c, cErr := scheduleActionCount(f.ctx, f.s, f.sid)
+		return cErr == nil && c > f.actionsAtPause
+	}, 30*time.Second, 1*time.Second,
+		"schedule with %s should resume taking actions after the workflow is unpaused", policy)
+}
+
+// testSchedulePauseContinueAsNew verifies the interaction between pause and
+// continue-as-new for a scheduled workflow:
+//   - A paused workflow does not process buffered signals, so it cannot
+//     continue-as-new until it is unpaused.
+//   - After unpause, the workflow continues-as-new and the continued run
+//     completes, and the scheduler observes that completion across the
+//     continue-as-new boundary.
+func testSchedulePauseContinueAsNew(t *testing.T, newContext contextFactory, isCHASM bool) {
+	// The scheduler matches the continued run's completion by the request ID in
+	// the completion callback token, which only survives continue-as-new in the
+	// envelope token format (gated off by default).
+	opts := append(pauseInteractionOpts(t), testcore.WithDynamicConfig(callback.EncodeInternalTokenWithEnvelope, true))
+	s := testcore.NewEnv(t, opts...)
+
+	sid := testcore.RandomizeStr("sched-pause-can")
+	wid := testcore.RandomizeStr("sched-pause-can-wf")
+	wt := testcore.RandomizeStr("sched-pause-can-wt")
+
+	// First run waits for the "go" signal, then continues-as-new; the continued
+	// run completes immediately.
+	s.SdkWorker().RegisterWorkflowWithOptions(func(ctx workflow.Context) error {
+		if workflow.GetInfo(ctx).ContinuedExecutionRunID == "" {
+			workflow.GetSignalChannel(ctx, "go").Receive(ctx, nil)
+			return workflow.NewContinueAsNewError(ctx, wt)
+		}
+		return nil
+	}, workflow.RegisterOptions{Name: wt})
+
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Schedule: &schedulepb.Schedule{
+			// Long interval + trigger-immediately so exactly one run starts.
+			Spec: &schedulepb.ScheduleSpec{
+				Interval: []*schedulepb.IntervalSpec{
+					{Interval: durationpb.New(24 * time.Hour)},
+				},
+			},
+			Action: &schedulepb.ScheduleAction{
+				Action: &schedulepb.ScheduleAction_StartWorkflow{
+					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+						WorkflowId:   wid,
+						WorkflowType: &commonpb.WorkflowType{Name: wt},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					},
+				},
+			},
+			Policies: &schedulepb.SchedulePolicies{
+				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP,
+			},
+		},
+		InitialPatch: &schedulepb.SchedulePatch{
+			TriggerImmediately: &schedulepb.TriggerImmediatelyRequest{},
+		},
+		Identity:  "test",
+		RequestId: uuid.NewString(),
+	})
+	require.NoError(t, err)
+
+	// Wait for the first run to start.
+	var firstRun *commonpb.WorkflowExecution
+	await.RequireTruef(t, func() bool {
+		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+		})
+		if descErr != nil {
+			return false
+		}
+		for _, ra := range desc.GetInfo().GetRecentActions() {
+			if ex := ra.GetStartWorkflowResult(); ex.GetRunId() != "" {
+				firstRun = ex
+				return true
+			}
+		}
+		return false
+	}, 30*time.Second, 250*time.Millisecond, "schedule should start its first workflow")
+
+	// Pause the first run.
+	_, err = s.FrontendClient().PauseWorkflowExecution(ctx, &workflowservice.PauseWorkflowExecutionRequest{
+		Namespace:  s.Namespace().String(),
+		WorkflowId: firstRun.GetWorkflowId(),
+		RunId:      firstRun.GetRunId(),
+		Identity:   "functional-test",
+		Reason:     "schedule-pause-can",
+		RequestId:  uuid.NewString(),
+	})
+	require.NoError(t, err)
+	await.RequireTrue(t, func() bool {
+		d, dErr := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: s.Namespace().String(),
+			Execution: firstRun,
+		})
+		return dErr == nil && d.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED
+	}, 15*time.Second, 200*time.Millisecond)
+
+	// Signal "go" while paused. The signal is recorded but not processed, so the
+	// workflow must not continue-as-new: it stays on the same run, still PAUSED.
+	err = s.SdkClient().SignalWorkflow(ctx, firstRun.GetWorkflowId(), firstRun.GetRunId(), "go", nil)
+	require.NoError(t, err)
+	//nolint:forbidigo // confirming the paused workflow does NOT act on the signal over a fixed window
+	time.Sleep(3 * time.Second)
+	d, err := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: s.Namespace().String(),
+		Execution: firstRun,
+	})
+	require.NoError(t, err)
+	require.Equal(t, enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED, d.GetWorkflowExecutionInfo().GetStatus(),
+		"paused workflow must not continue-as-new while paused")
+
+	// Unpause: the buffered signal is processed, the workflow continues-as-new,
+	// and the continued run completes.
+	_, err = s.FrontendClient().UnpauseWorkflowExecution(ctx, &workflowservice.UnpauseWorkflowExecutionRequest{
+		Namespace:  s.Namespace().String(),
+		WorkflowId: firstRun.GetWorkflowId(),
+		RunId:      firstRun.GetRunId(),
+		Identity:   "functional-test",
+		Reason:     "schedule-pause-can-recovery",
+		RequestId:  uuid.NewString(),
+	})
+	require.NoError(t, err)
+
+	// The latest run of the chain (the continued-as-new run) should complete.
+	await.RequireTruef(t, func() bool {
+		d, dErr := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: s.Namespace().String(),
+			Execution: &commonpb.WorkflowExecution{WorkflowId: firstRun.GetWorkflowId()},
+		})
+		return dErr == nil && d.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
+	}, 30*time.Second, 500*time.Millisecond, "continued-as-new run should complete after unpause")
+
+	// The scheduler should observe the completion across the continue-as-new
+	// boundary and record it as a COMPLETED action.
+	await.RequireTruef(t, func() bool {
+		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+		})
+		if descErr != nil {
+			return false
+		}
+		for _, ra := range desc.GetInfo().GetRecentActions() {
+			if ra.GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED {
+				return true
+			}
+		}
+		return false
+	}, 30*time.Second, 500*time.Millisecond, "scheduler should record the continued-as-new workflow as COMPLETED")
+}
+
+// testSchedulePauseReset verifies the interaction between pause and resetting a
+// scheduled workflow. A workflow is started by a schedule, paused, then reset
+// to a point before the pause. The reset run is no longer paused (the pause
+// event is not part of the reset history), and the scheduler keeps tracking the
+// reset run through to completion.
+func testSchedulePauseReset(t *testing.T, newContext contextFactory, isCHASM bool) {
+	s := testcore.NewEnv(t, pauseInteractionOpts(t)...)
+
+	sid := testcore.RandomizeStr("sched-pause-reset")
+	wid := testcore.RandomizeStr("sched-pause-reset-wf")
+	wt := testcore.RandomizeStr("sched-pause-reset-wt")
+
+	s.SdkWorker().RegisterWorkflowWithOptions(func(ctx workflow.Context) error {
+		workflow.GetSignalChannel(ctx, "complete").Receive(ctx, nil)
+		return nil
+	}, workflow.RegisterOptions{Name: wt})
+
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Schedule: &schedulepb.Schedule{
+			// Long interval + trigger-immediately so exactly one run starts.
+			Spec: &schedulepb.ScheduleSpec{
+				Interval: []*schedulepb.IntervalSpec{
+					{Interval: durationpb.New(24 * time.Hour)},
+				},
+			},
+			Action: &schedulepb.ScheduleAction{
+				Action: &schedulepb.ScheduleAction_StartWorkflow{
+					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+						WorkflowId:   wid,
+						WorkflowType: &commonpb.WorkflowType{Name: wt},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					},
+				},
+			},
+			Policies: &schedulepb.SchedulePolicies{
+				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP,
+			},
+		},
+		InitialPatch: &schedulepb.SchedulePatch{
+			TriggerImmediately: &schedulepb.TriggerImmediatelyRequest{},
+		},
+		Identity:  "test",
+		RequestId: uuid.NewString(),
+	})
+	require.NoError(t, err)
+
+	// Wait for the first run to start.
+	var firstRun *commonpb.WorkflowExecution
+	await.RequireTruef(t, func() bool {
+		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+		})
+		if descErr != nil {
+			return false
+		}
+		for _, ra := range desc.GetInfo().GetRecentActions() {
+			if ex := ra.GetStartWorkflowResult(); ex.GetRunId() != "" {
+				firstRun = ex
+				return true
+			}
+		}
+		return false
+	}, 30*time.Second, 250*time.Millisecond, "schedule should start its first workflow")
+
+	// Wait until the first workflow task is complete so event 3 is a valid reset point.
+	s.WaitForHistoryEvents(`
+		1 WorkflowExecutionStarted
+		2 WorkflowTaskScheduled
+		3 WorkflowTaskStarted
+		4 WorkflowTaskCompleted`,
+		s.GetHistoryFunc(s.Namespace().String(), firstRun),
+		10*time.Second,
+		250*time.Millisecond,
+	)
+
+	// Pause the first run.
+	_, err = s.FrontendClient().PauseWorkflowExecution(ctx, &workflowservice.PauseWorkflowExecutionRequest{
+		Namespace:  s.Namespace().String(),
+		WorkflowId: firstRun.GetWorkflowId(),
+		RunId:      firstRun.GetRunId(),
+		Identity:   "functional-test",
+		Reason:     "schedule-pause-reset",
+		RequestId:  uuid.NewString(),
+	})
+	require.NoError(t, err)
+	await.RequireTrue(t, func() bool {
+		d, dErr := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: s.Namespace().String(),
+			Execution: firstRun,
+		})
+		return dErr == nil && d.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED
+	}, 15*time.Second, 200*time.Millisecond)
+
+	// Reset the paused workflow to a point before it was paused.
+	resetResp, err := s.FrontendClient().ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
+		Namespace:                 s.Namespace().String(),
+		WorkflowExecution:         firstRun,
+		Reason:                    "schedule-pause-reset",
+		WorkflowTaskFinishEventId: 3,
+		RequestId:                 uuid.NewString(),
+	})
+	require.NoError(t, err)
+	resetRun := &commonpb.WorkflowExecution{
+		WorkflowId: firstRun.GetWorkflowId(),
+		RunId:      resetResp.GetRunId(),
+	}
+
+	// The reset run is created from history before the pause event, so it is
+	// running, not paused: reset clears the pause.
+	await.RequireTruef(t, func() bool {
+		d, dErr := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: s.Namespace().String(),
+			Execution: resetRun,
+		})
+		return dErr == nil && d.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
+	}, 15*time.Second, 200*time.Millisecond, "reset run should be RUNNING (pause cleared by reset)")
+
+	// The scheduler keeps tracking the reset run: signalling it to completion
+	// should be observed and recorded as a COMPLETED action.
+	err = s.SdkClient().SignalWorkflow(ctx, resetRun.GetWorkflowId(), resetRun.GetRunId(), "complete", nil)
+	require.NoError(t, err)
+	await.RequireTruef(t, func() bool {
+		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+		})
+		if descErr != nil {
+			return false
+		}
+		for _, ra := range desc.GetInfo().GetRecentActions() {
+			if ra.GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED {
+				return true
+			}
+		}
+		return false
+	}, 30*time.Second, 500*time.Millisecond, "scheduler should record the reset run as COMPLETED")
 }
 
 // scheduleActionCount returns the schedule's total ActionCount (number of

--- a/tests/schedule_pause_interaction_test.go
+++ b/tests/schedule_pause_interaction_test.go
@@ -1,0 +1,219 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	schedulepb "go.temporal.io/api/schedule/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	workflowpb "go.temporal.io/api/workflow/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/testing/await"
+	"go.temporal.io/server/tests/testcore"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+var allOverlapPolicies = []enumspb.ScheduleOverlapPolicy{
+	enumspb.SCHEDULE_OVERLAP_POLICY_SKIP,
+	enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
+	enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL,
+	enumspb.SCHEDULE_OVERLAP_POLICY_CANCEL_OTHER,
+	enumspb.SCHEDULE_OVERLAP_POLICY_TERMINATE_OTHER,
+	enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+}
+
+// expectScheduleProgressesWhilePaused returns whether a schedule using the given
+// overlap policy continues to take new scheduled actions while the workflow it
+// started is paused. This encodes the observed, current behavior of each
+// scheduler implementation.
+//
+//   - ALLOW_ALL never inspects the running workflow, so it always starts new
+//     runs regardless of pause (both schedulers).
+//   - TERMINATE_OTHER terminates the running workflow (a hard close that does
+//     not require the workflow to process a workflow task) and then starts the
+//     next run. CHASM does this even when the workflow is paused. The V1
+//     scheduler does NOT — it stalls. This V1 stall is a bug: the V1 watcher
+//     does not understand the PAUSED status and never observes the paused
+//     workflow close, so it never gets to start the buffered run.
+//   - SKIP / BUFFER_ONE / BUFFER_ALL / CANCEL_OTHER all keep the slot occupied
+//     by the paused workflow, so no new run is taken under either scheduler.
+//     (For CANCEL_OTHER the schedule additionally never makes progress on its
+//     own because a paused workflow cannot process the cancellation request -
+//     it has no workflow task - so the cancel never completes.)
+func expectScheduleProgressesWhilePaused(isCHASM bool, policy enumspb.ScheduleOverlapPolicy) bool {
+	switch policy {
+	case enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL:
+		return true
+	case enumspb.SCHEDULE_OVERLAP_POLICY_TERMINATE_OTHER:
+		// CHASM terminates the paused workflow and continues; V1 stalls (bug).
+		return isCHASM
+	default:
+		// SKIP, BUFFER_ONE, BUFFER_ALL, CANCEL_OTHER: the paused workflow keeps
+		// the slot, so the schedule does not take new actions.
+		return false
+	}
+}
+
+func TestScheduleV1PauseInteraction(t *testing.T) {
+	runSchedulePauseOverlapMatrix(t, v1ContextFactory, false /* isCHASM */)
+}
+
+func TestScheduleCHASMPauseInteraction(t *testing.T) {
+	runSchedulePauseOverlapMatrix(t, chasmContextFactory, true /* isCHASM */)
+}
+
+func runSchedulePauseOverlapMatrix(t *testing.T, newContext contextFactory, isCHASM bool) {
+	for _, policy := range allOverlapPolicies {
+		policy := policy
+		t.Run(policy.String(), func(t *testing.T) {
+			testSchedulePauseOverlap(t, newContext, isCHASM, policy)
+		})
+	}
+}
+
+// pauseInteractionOpts returns the schedule test options plus the dynamic config
+// required to enable the workflow pause feature.
+func pauseInteractionOpts(t *testing.T) []testcore.TestOption {
+	return append(scheduleCommonOpts(t),
+		testcore.WithDynamicConfig(dynamicconfig.WorkflowPauseEnabled, true),
+	)
+}
+
+// testSchedulePauseOverlap creates a schedule (1s interval) that starts a single
+// long-running workflow, pauses that workflow, and then asserts whether the
+// schedule keeps taking scheduled actions, per expectScheduleProgressesWhilePaused.
+func testSchedulePauseOverlap(t *testing.T, newContext contextFactory, isCHASM bool, policy enumspb.ScheduleOverlapPolicy) {
+	s := testcore.NewEnv(t, pauseInteractionOpts(t)...)
+
+	sid := testcore.RandomizeStr("sched-pause-" + policy.String())
+	wid := testcore.RandomizeStr("sched-pause-wf-" + policy.String())
+	wt := testcore.RandomizeStr("sched-pause-wt-" + policy.String())
+
+	// A workflow that runs (effectively) forever, so it stays in the
+	// schedule's running set until the schedule terminates it.
+	s.SdkWorker().RegisterWorkflowWithOptions(
+		func(ctx workflow.Context) error {
+			return workflow.Sleep(ctx, time.Hour)
+		},
+		workflow.RegisterOptions{Name: wt},
+	)
+
+	schedule := &schedulepb.Schedule{
+		Spec: &schedulepb.ScheduleSpec{
+			Interval: []*schedulepb.IntervalSpec{
+				{Interval: durationpb.New(1 * time.Second)},
+			},
+		},
+		Action: &schedulepb.ScheduleAction{
+			Action: &schedulepb.ScheduleAction_StartWorkflow{
+				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+					WorkflowId:   wid,
+					WorkflowType: &commonpb.WorkflowType{Name: wt},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				},
+			},
+		},
+		Policies: &schedulepb.SchedulePolicies{
+			OverlapPolicy: policy,
+		},
+	}
+
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Schedule:   schedule,
+		Identity:   "test",
+		RequestId:  uuid.NewString(),
+	})
+	require.NoError(t, err)
+
+	// Wait for the schedule to start its first workflow. RecentActions is
+	// populated for every overlap policy (including ALLOW_ALL) and by both
+	// schedulers, unlike RunningWorkflows which V1 does not populate for
+	// ALLOW_ALL.
+	var execution *commonpb.WorkflowExecution
+	await.RequireTruef(t, func() bool {
+		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+		})
+		if descErr != nil {
+			return false
+		}
+		for _, ra := range desc.GetInfo().GetRecentActions() {
+			if ex := ra.GetStartWorkflowResult(); ex.GetRunId() != "" {
+				execution = ex
+				return true
+			}
+		}
+		return false
+	}, 30*time.Second, 250*time.Millisecond, "schedule should start its first workflow")
+
+	// Pause that workflow.
+	_, err = s.FrontendClient().PauseWorkflowExecution(ctx, &workflowservice.PauseWorkflowExecutionRequest{
+		Namespace:  s.Namespace().String(),
+		WorkflowId: execution.GetWorkflowId(),
+		RunId:      execution.GetRunId(),
+		Identity:   "functional-test",
+		Reason:     "schedule-pause-overlap-interaction",
+		RequestId:  uuid.NewString(),
+	})
+	require.NoError(t, err)
+
+	// Confirm the workflow reaches PAUSED.
+	await.RequireTrue(t, func() bool {
+		d, dErr := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: s.Namespace().String(),
+			Execution: execution,
+		})
+		return dErr == nil && d.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED
+	}, 15*time.Second, 200*time.Millisecond)
+
+	actionsAtPause, err := scheduleActionCount(ctx, s, sid)
+	require.NoError(t, err)
+	fmt.Printf("[DEBUGGING] [chasm=%t %s] paused wf=%s actionsAtPause=%d\n",
+		isCHASM, policy, execution.GetRunId(), actionsAtPause)
+
+	if expectScheduleProgressesWhilePaused(isCHASM, policy) {
+		// The schedule should keep taking new actions despite the paused workflow.
+		await.RequireTruef(t, func() bool {
+			c, cErr := scheduleActionCount(ctx, s, sid)
+			return cErr == nil && c > actionsAtPause
+		}, 20*time.Second, 500*time.Millisecond,
+			"schedule with %s should keep taking actions while its workflow is paused", policy)
+	} else {
+		// The schedule must not take any new action while the workflow is
+		// paused: the paused workflow keeps the overlap slot occupied. There is
+		// no await helper for asserting the *absence* of progress, so wait a
+		// fixed window during which the 1s schedule would otherwise fire ~8
+		// times, then assert ActionCount did not advance.
+		//nolint:forbidigo // asserting absence of scheduled actions over a fixed window
+		time.Sleep(8 * time.Second)
+		got, gErr := scheduleActionCount(ctx, s, sid)
+		require.NoError(t, gErr)
+		require.Equal(t, actionsAtPause, got,
+			"schedule with %s must not take new actions while its workflow is paused", policy)
+	}
+}
+
+// scheduleActionCount returns the schedule's total ActionCount (number of
+// workflows it has started).
+func scheduleActionCount(ctx context.Context, s *testcore.TestEnv, sid string) (int64, error) {
+	desc, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+	})
+	if err != nil {
+		return 0, err
+	}
+	return desc.GetInfo().GetActionCount(), nil
+}

--- a/tests/schedule_pause_interaction_test.go
+++ b/tests/schedule_pause_interaction_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -253,8 +252,6 @@ func registerSignalCompletableWorkflow(s *testcore.TestEnv, wt string) {
 // schedule keeps taking scheduled actions, per expectScheduleProgressesWhilePaused.
 func testSchedulePauseOverlap(t *testing.T, newContext contextFactory, isCHASM bool, policy enumspb.ScheduleOverlapPolicy) {
 	f := setupPausedScheduledWorkflow(t, newContext, policy, registerForeverWorkflow)
-	t.Logf("[chasm=%t %s] paused wf=%s actionsAtPause=%d\n",
-		isCHASM, policy, f.execution.GetRunId(), f.actionsAtPause)
 
 	if expectScheduleProgressesWhilePaused(isCHASM, policy) {
 		// The schedule should keep taking new actions despite the paused workflow.
@@ -284,8 +281,6 @@ func testSchedulePauseOverlap(t *testing.T, newContext contextFactory, isCHASM b
 // cancellation for CANCEL_OTHER).
 func testSchedulePauseUnpauseRecovery(t *testing.T, newContext contextFactory, isCHASM bool, policy enumspb.ScheduleOverlapPolicy) {
 	f := setupPausedScheduledWorkflow(t, newContext, policy, registerSignalCompletableWorkflow)
-	t.Logf("[chasm=%t %s recovery] paused wf=%s actionsAtPause=%d\n",
-		isCHASM, policy, f.execution.GetRunId(), f.actionsAtPause)
 
 	// Unpause the workflow.
 	_, err := f.s.FrontendClient().UnpauseWorkflowExecution(f.ctx, &workflowservice.UnpauseWorkflowExecutionRequest{

--- a/tests/schedule_pause_interaction_test.go
+++ b/tests/schedule_pause_interaction_test.go
@@ -70,7 +70,6 @@ func TestScheduleCHASMPauseInteraction(t *testing.T) {
 
 func runSchedulePauseOverlapMatrix(t *testing.T, newContext contextFactory) {
 	for _, policy := range allOverlapPolicies {
-		policy := policy
 		t.Run(policy.String(), func(t *testing.T) {
 			testSchedulePauseOverlap(t, newContext, policy)
 		})
@@ -79,7 +78,6 @@ func runSchedulePauseOverlapMatrix(t *testing.T, newContext contextFactory) {
 
 func runSchedulePauseRecoveryMatrix(t *testing.T, newContext contextFactory) {
 	for _, policy := range allOverlapPolicies {
-		policy := policy
 		// Recovery is only interesting for policies whose schedule was blocked
 		// by the paused workflow. Policies that keep progressing never stall,
 		// and may have already closed the paused workflow (e.g. TERMINATE_OTHER

--- a/tests/schedule_workflow_pause_interaction_test.go
+++ b/tests/schedule_workflow_pause_interaction_test.go
@@ -21,6 +21,24 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
+const (
+	// scheduleStartWait/scheduleStartPoll bound waiting for a schedule to
+	// record a recent action for the workflow it just started.
+	scheduleStartWait = 30 * time.Second
+	scheduleStartPoll = 250 * time.Millisecond
+
+	// workflowStatusWait/workflowStatusPoll bound waiting for a workflow to
+	// reach a pause-related status (PAUSED, or RUNNING again after reset).
+	workflowStatusWait = 15 * time.Second
+	workflowStatusPoll = 200 * time.Millisecond
+
+	// scheduleCompletionWait/scheduleCompletionPoll bound waiting for the
+	// scheduler to observe a workflow's completion and record it as a
+	// COMPLETED action.
+	scheduleCompletionWait = 30 * time.Second
+	scheduleCompletionPoll = 500 * time.Millisecond
+)
+
 var allOverlapPolicies = []enumspb.ScheduleOverlapPolicy{
 	enumspb.SCHEDULE_OVERLAP_POLICY_SKIP,
 	enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
@@ -54,14 +72,16 @@ func expectScheduleProgressesWhilePaused(policy enumspb.ScheduleOverlapPolicy) b
 	}
 }
 
-func TestScheduleV1PauseInteraction(t *testing.T) {
+func TestScheduleV1WorkflowPauseInteraction(t *testing.T) {
+	t.Parallel()
 	t.Run("Overlap", func(t *testing.T) { runSchedulePauseOverlapMatrix(t, v1ContextFactory) })
 	t.Run("UnpauseRecovery", func(t *testing.T) { runSchedulePauseRecoveryMatrix(t, v1ContextFactory) })
 	t.Run("ContinueAsNew", func(t *testing.T) { testSchedulePauseContinueAsNew(t, v1ContextFactory) })
 	t.Run("Reset", func(t *testing.T) { testSchedulePauseReset(t, v1ContextFactory) })
 }
 
-func TestScheduleCHASMPauseInteraction(t *testing.T) {
+func TestScheduleCHASMWorkflowPauseInteraction(t *testing.T) {
+	t.Parallel()
 	t.Run("Overlap", func(t *testing.T) { runSchedulePauseOverlapMatrix(t, chasmContextFactory) })
 	t.Run("UnpauseRecovery", func(t *testing.T) { runSchedulePauseRecoveryMatrix(t, chasmContextFactory) })
 	t.Run("ContinueAsNew", func(t *testing.T) { testSchedulePauseContinueAsNew(t, chasmContextFactory) })
@@ -157,9 +177,7 @@ func setupPausedScheduledWorkflow(
 	require.NoError(t, err)
 
 	// Wait for the schedule to start its first workflow. RecentActions is
-	// populated for every overlap policy (including ALLOW_ALL) and by both
-	// schedulers, unlike RunningWorkflows which V1 does not populate for
-	// ALLOW_ALL.
+	// populated for every overlap policy (including ALLOW_ALL).
 	var execution *commonpb.WorkflowExecution
 	await.RequireTruef(t, func() bool {
 		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
@@ -176,7 +194,7 @@ func setupPausedScheduledWorkflow(
 			}
 		}
 		return false
-	}, 30*time.Second, 250*time.Millisecond, "schedule should start its first workflow")
+	}, scheduleStartWait, scheduleStartPoll, "schedule should start its first workflow")
 
 	// Pause that workflow.
 	_, err = s.FrontendClient().PauseWorkflowExecution(ctx, &workflowservice.PauseWorkflowExecutionRequest{
@@ -196,7 +214,7 @@ func setupPausedScheduledWorkflow(
 			Execution: execution,
 		})
 		return dErr == nil && d.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED
-	}, 15*time.Second, 200*time.Millisecond)
+	}, workflowStatusWait, workflowStatusPoll)
 
 	actionsAtPause, err := scheduleActionCount(ctx, s, sid)
 	require.NoError(t, err)
@@ -252,15 +270,17 @@ func testSchedulePauseOverlap(t *testing.T, newContext contextFactory, policy en
 			"schedule with %s should keep taking actions while its workflow is paused", policy)
 	} else {
 		// The schedule must not take any new action while the workflow is
-		// paused: the paused workflow keeps the overlap slot occupied. There is
-		// no await helper for asserting the *absence* of progress, so wait a
-		// fixed window during which the 1s schedule would otherwise fire ~8
-		// times, then assert ActionCount did not advance.
-		//nolint:forbidigo // asserting absence of scheduled actions over a fixed window
-		time.Sleep(8 * time.Second)
-		got, gErr := scheduleActionCount(f.ctx, f.s, f.sid)
-		require.NoError(t, gErr)
-		require.Equal(t, f.actionsAtPause, got,
+		// paused: the paused workflow keeps the overlap slot occupied. Poll
+		// over a window during which the 1s schedule would otherwise fire ~8
+		// times, confirming ActionCount never advances.
+		require.Never(
+			t,
+			func() bool {
+				c, cErr := scheduleActionCount(f.ctx, f.s, f.sid)
+				return cErr == nil && c > f.actionsAtPause
+			},
+			8*time.Second,
+			500*time.Millisecond,
 			"schedule with %s must not take new actions while its workflow is paused", policy)
 	}
 }
@@ -283,9 +303,7 @@ func testSchedulePauseUnpauseRecovery(t *testing.T, newContext contextFactory, p
 	})
 	require.NoError(t, err)
 
-	// Free the overlap slot: signal the workflow so it can complete. For
-	// CANCEL_OTHER the scheduler's pending cancellation will also close it; the
-	// signal is harmless either way.
+	// Free the overlap slot so the schedule can progress again.
 	err = f.s.SdkClient().SignalWorkflow(f.ctx, f.execution.GetWorkflowId(), f.execution.GetRunId(), "complete", nil)
 	require.NoError(t, err)
 
@@ -296,6 +314,111 @@ func testSchedulePauseUnpauseRecovery(t *testing.T, newContext contextFactory, p
 		return cErr == nil && c > f.actionsAtPause
 	}, 30*time.Second, 1*time.Second,
 		"schedule with %s should resume taking actions after the workflow is unpaused", policy)
+}
+
+// setupPausedTriggeredWorkflow creates a schedule with a long interval and
+// trigger-immediately (so exactly one run starts), registers the workflow via
+// register, waits for that run to start, optionally runs afterStart (e.g. to
+// wait for a specific point in history), pauses the run, and waits for it to
+// reach PAUSED. It is shared by the pause/continue-as-new and pause/reset
+// tests, which both need a single triggered run to pause.
+func setupPausedTriggeredWorkflow(
+	t *testing.T,
+	newContext contextFactory,
+	opts []testcore.TestOption,
+	idPrefix string,
+	register func(s *testcore.TestEnv, wt string),
+	afterStart func(s *testcore.TestEnv, firstRun *commonpb.WorkflowExecution),
+) *scheduledPauseFixture {
+	s := testcore.NewEnv(t, opts...)
+
+	sid := testcore.RandomizeStr(idPrefix)
+	wid := testcore.RandomizeStr(idPrefix + "-wf")
+	wt := testcore.RandomizeStr(idPrefix + "-wt")
+
+	register(s, wt)
+
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Schedule: &schedulepb.Schedule{
+			// Long interval + trigger-immediately so exactly one run starts.
+			Spec: &schedulepb.ScheduleSpec{
+				Interval: []*schedulepb.IntervalSpec{
+					{Interval: durationpb.New(24 * time.Hour)},
+				},
+			},
+			Action: &schedulepb.ScheduleAction{
+				Action: &schedulepb.ScheduleAction_StartWorkflow{
+					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+						WorkflowId:   wid,
+						WorkflowType: &commonpb.WorkflowType{Name: wt},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					},
+				},
+			},
+			Policies: &schedulepb.SchedulePolicies{
+				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP,
+			},
+		},
+		InitialPatch: &schedulepb.SchedulePatch{
+			TriggerImmediately: &schedulepb.TriggerImmediatelyRequest{},
+		},
+		Identity:  "test",
+		RequestId: uuid.NewString(),
+	})
+	require.NoError(t, err)
+
+	// Wait for the first run to start.
+	var firstRun *commonpb.WorkflowExecution
+	await.RequireTruef(t, func() bool {
+		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+		})
+		if descErr != nil {
+			return false
+		}
+		for _, ra := range desc.GetInfo().GetRecentActions() {
+			if ex := ra.GetStartWorkflowResult(); ex.GetRunId() != "" {
+				firstRun = ex
+				return true
+			}
+		}
+		return false
+	}, scheduleStartWait, scheduleStartPoll, "schedule should start its first workflow")
+
+	if afterStart != nil {
+		afterStart(s, firstRun)
+	}
+
+	// Pause the first run.
+	_, err = s.FrontendClient().PauseWorkflowExecution(ctx, &workflowservice.PauseWorkflowExecutionRequest{
+		Namespace:  s.Namespace().String(),
+		WorkflowId: firstRun.GetWorkflowId(),
+		RunId:      firstRun.GetRunId(),
+		Identity:   "functional-test",
+		Reason:     idPrefix,
+		RequestId:  uuid.NewString(),
+	})
+	require.NoError(t, err)
+	await.RequireTrue(t, func() bool {
+		d, dErr := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: s.Namespace().String(),
+			Execution: firstRun,
+		})
+		return dErr == nil && d.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED
+	}, workflowStatusWait, workflowStatusPoll)
+
+	return &scheduledPauseFixture{
+		s:         s,
+		ctx:       ctx,
+		sid:       sid,
+		wid:       wid,
+		wt:        wt,
+		execution: firstRun,
+	}
 }
 
 // testSchedulePauseContinueAsNew verifies the interaction between pause and
@@ -310,111 +433,40 @@ func testSchedulePauseContinueAsNew(t *testing.T, newContext contextFactory) {
 	// the completion callback token, which only survives continue-as-new in the
 	// envelope token format (gated off by default).
 	opts := append(pauseInteractionOpts(t), testcore.WithDynamicConfig(callback.EncodeInternalTokenWithEnvelope, true))
-	s := testcore.NewEnv(t, opts...)
-
-	sid := testcore.RandomizeStr("sched-pause-can")
-	wid := testcore.RandomizeStr("sched-pause-can-wf")
-	wt := testcore.RandomizeStr("sched-pause-can-wt")
 
 	// First run waits for the "go" signal, then continues-as-new; the continued
 	// run completes immediately.
-	s.SdkWorker().RegisterWorkflowWithOptions(func(ctx workflow.Context) error {
-		if workflow.GetInfo(ctx).ContinuedExecutionRunID == "" {
-			workflow.GetSignalChannel(ctx, "go").Receive(ctx, nil)
-			return workflow.NewContinueAsNewError(ctx, wt)
-		}
-		return nil
-	}, workflow.RegisterOptions{Name: wt})
-
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
-		ScheduleId: sid,
-		Schedule: &schedulepb.Schedule{
-			// Long interval + trigger-immediately so exactly one run starts.
-			Spec: &schedulepb.ScheduleSpec{
-				Interval: []*schedulepb.IntervalSpec{
-					{Interval: durationpb.New(24 * time.Hour)},
-				},
-			},
-			Action: &schedulepb.ScheduleAction{
-				Action: &schedulepb.ScheduleAction_StartWorkflow{
-					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
-						WorkflowId:   wid,
-						WorkflowType: &commonpb.WorkflowType{Name: wt},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-					},
-				},
-			},
-			Policies: &schedulepb.SchedulePolicies{
-				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP,
-			},
-		},
-		InitialPatch: &schedulepb.SchedulePatch{
-			TriggerImmediately: &schedulepb.TriggerImmediatelyRequest{},
-		},
-		Identity:  "test",
-		RequestId: uuid.NewString(),
-	})
-	require.NoError(t, err)
-
-	// Wait for the first run to start.
-	var firstRun *commonpb.WorkflowExecution
-	await.RequireTruef(t, func() bool {
-		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  s.Namespace().String(),
-			ScheduleId: sid,
-		})
-		if descErr != nil {
-			return false
-		}
-		for _, ra := range desc.GetInfo().GetRecentActions() {
-			if ex := ra.GetStartWorkflowResult(); ex.GetRunId() != "" {
-				firstRun = ex
-				return true
+	register := func(s *testcore.TestEnv, wt string) {
+		s.SdkWorker().RegisterWorkflowWithOptions(func(ctx workflow.Context) error {
+			if workflow.GetInfo(ctx).ContinuedExecutionRunID == "" {
+				workflow.GetSignalChannel(ctx, "go").Receive(ctx, nil)
+				return workflow.NewContinueAsNewError(ctx, wt)
 			}
-		}
-		return false
-	}, 30*time.Second, 250*time.Millisecond, "schedule should start its first workflow")
+			return nil
+		}, workflow.RegisterOptions{Name: wt})
+	}
 
-	// Pause the first run.
-	_, err = s.FrontendClient().PauseWorkflowExecution(ctx, &workflowservice.PauseWorkflowExecutionRequest{
-		Namespace:  s.Namespace().String(),
-		WorkflowId: firstRun.GetWorkflowId(),
-		RunId:      firstRun.GetRunId(),
-		Identity:   "functional-test",
-		Reason:     "schedule-pause-can",
-		RequestId:  uuid.NewString(),
-	})
-	require.NoError(t, err)
-	await.RequireTrue(t, func() bool {
-		d, dErr := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-			Namespace: s.Namespace().String(),
-			Execution: firstRun,
-		})
-		return dErr == nil && d.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED
-	}, 15*time.Second, 200*time.Millisecond)
+	f := setupPausedTriggeredWorkflow(t, newContext, opts, "sched-pause-can", register, nil)
 
 	// Signal "go" while paused. The signal is recorded but not processed, so the
 	// workflow must not continue-as-new: it stays on the same run, still PAUSED.
-	err = s.SdkClient().SignalWorkflow(ctx, firstRun.GetWorkflowId(), firstRun.GetRunId(), "go", nil)
+	err := f.s.SdkClient().SignalWorkflow(f.ctx, f.execution.GetWorkflowId(), f.execution.GetRunId(), "go", nil)
 	require.NoError(t, err)
-	//nolint:forbidigo // confirming the paused workflow does NOT act on the signal over a fixed window
-	time.Sleep(3 * time.Second)
-	d, err := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-		Namespace: s.Namespace().String(),
-		Execution: firstRun,
-	})
-	require.NoError(t, err)
-	require.Equal(t, enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED, d.GetWorkflowExecutionInfo().GetStatus(),
+	require.Never(t, func() bool {
+		d, dErr := f.s.FrontendClient().DescribeWorkflowExecution(f.ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: f.s.Namespace().String(),
+			Execution: f.execution,
+		})
+		return dErr == nil && d.GetWorkflowExecutionInfo().GetStatus() != enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED
+	}, 3*time.Second, 500*time.Millisecond,
 		"paused workflow must not continue-as-new while paused")
 
 	// Unpause: the buffered signal is processed, the workflow continues-as-new,
 	// and the continued run completes.
-	_, err = s.FrontendClient().UnpauseWorkflowExecution(ctx, &workflowservice.UnpauseWorkflowExecutionRequest{
-		Namespace:  s.Namespace().String(),
-		WorkflowId: firstRun.GetWorkflowId(),
-		RunId:      firstRun.GetRunId(),
+	_, err = f.s.FrontendClient().UnpauseWorkflowExecution(f.ctx, &workflowservice.UnpauseWorkflowExecutionRequest{
+		Namespace:  f.s.Namespace().String(),
+		WorkflowId: f.execution.GetWorkflowId(),
+		RunId:      f.execution.GetRunId(),
 		Identity:   "functional-test",
 		Reason:     "schedule-pause-can-recovery",
 		RequestId:  uuid.NewString(),
@@ -423,19 +475,19 @@ func testSchedulePauseContinueAsNew(t *testing.T, newContext contextFactory) {
 
 	// The latest run of the chain (the continued-as-new run) should complete.
 	await.RequireTruef(t, func() bool {
-		d, dErr := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-			Namespace: s.Namespace().String(),
-			Execution: &commonpb.WorkflowExecution{WorkflowId: firstRun.GetWorkflowId()},
+		d, dErr := f.s.FrontendClient().DescribeWorkflowExecution(f.ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: f.s.Namespace().String(),
+			Execution: &commonpb.WorkflowExecution{WorkflowId: f.execution.GetWorkflowId()},
 		})
 		return dErr == nil && d.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
-	}, 30*time.Second, 500*time.Millisecond, "continued-as-new run should complete after unpause")
+	}, scheduleCompletionWait, scheduleCompletionPoll, "continued-as-new run should complete after unpause")
 
 	// The scheduler should observe the completion across the continue-as-new
 	// boundary and record it as a COMPLETED action.
 	await.RequireTruef(t, func() bool {
-		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  s.Namespace().String(),
-			ScheduleId: sid,
+		desc, descErr := f.s.FrontendClient().DescribeSchedule(f.ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  f.s.Namespace().String(),
+			ScheduleId: f.sid,
 		})
 		if descErr != nil {
 			return false
@@ -446,7 +498,7 @@ func testSchedulePauseContinueAsNew(t *testing.T, newContext contextFactory) {
 			}
 		}
 		return false
-	}, 30*time.Second, 500*time.Millisecond, "scheduler should record the continued-as-new workflow as COMPLETED")
+	}, scheduleCompletionWait, scheduleCompletionPoll, "scheduler should record the continued-as-new workflow as COMPLETED")
 }
 
 // testSchedulePauseReset verifies the interaction between pause and resetting a
@@ -455,129 +507,60 @@ func testSchedulePauseContinueAsNew(t *testing.T, newContext contextFactory) {
 // event is not part of the reset history), and the scheduler keeps tracking the
 // reset run through to completion.
 func testSchedulePauseReset(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, pauseInteractionOpts(t)...)
-
-	sid := testcore.RandomizeStr("sched-pause-reset")
-	wid := testcore.RandomizeStr("sched-pause-reset-wf")
-	wt := testcore.RandomizeStr("sched-pause-reset-wt")
-
-	s.SdkWorker().RegisterWorkflowWithOptions(func(ctx workflow.Context) error {
-		workflow.GetSignalChannel(ctx, "complete").Receive(ctx, nil)
-		return nil
-	}, workflow.RegisterOptions{Name: wt})
-
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
-		ScheduleId: sid,
-		Schedule: &schedulepb.Schedule{
-			// Long interval + trigger-immediately so exactly one run starts.
-			Spec: &schedulepb.ScheduleSpec{
-				Interval: []*schedulepb.IntervalSpec{
-					{Interval: durationpb.New(24 * time.Hour)},
-				},
-			},
-			Action: &schedulepb.ScheduleAction{
-				Action: &schedulepb.ScheduleAction_StartWorkflow{
-					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
-						WorkflowId:   wid,
-						WorkflowType: &commonpb.WorkflowType{Name: wt},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-					},
-				},
-			},
-			Policies: &schedulepb.SchedulePolicies{
-				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP,
-			},
-		},
-		InitialPatch: &schedulepb.SchedulePatch{
-			TriggerImmediately: &schedulepb.TriggerImmediatelyRequest{},
-		},
-		Identity:  "test",
-		RequestId: uuid.NewString(),
-	})
-	require.NoError(t, err)
-
-	// Wait for the first run to start.
-	var firstRun *commonpb.WorkflowExecution
-	await.RequireTruef(t, func() bool {
-		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  s.Namespace().String(),
-			ScheduleId: sid,
-		})
-		if descErr != nil {
-			return false
-		}
-		for _, ra := range desc.GetInfo().GetRecentActions() {
-			if ex := ra.GetStartWorkflowResult(); ex.GetRunId() != "" {
-				firstRun = ex
-				return true
-			}
-		}
-		return false
-	}, 30*time.Second, 250*time.Millisecond, "schedule should start its first workflow")
+	register := func(s *testcore.TestEnv, wt string) {
+		s.SdkWorker().RegisterWorkflowWithOptions(func(ctx workflow.Context) error {
+			workflow.GetSignalChannel(ctx, "complete").Receive(ctx, nil)
+			return nil
+		}, workflow.RegisterOptions{Name: wt})
+	}
 
 	// Wait until the first workflow task is complete so event 3 is a valid reset point.
-	s.WaitForHistoryEvents(`
-		1 WorkflowExecutionStarted
-		2 WorkflowTaskScheduled
-		3 WorkflowTaskStarted
-		4 WorkflowTaskCompleted`,
-		s.GetHistoryFunc(s.Namespace().String(), firstRun),
-		10*time.Second,
-		250*time.Millisecond,
-	)
+	afterStart := func(s *testcore.TestEnv, firstRun *commonpb.WorkflowExecution) {
+		s.WaitForHistoryEvents(`
+			1 WorkflowExecutionStarted
+			2 WorkflowTaskScheduled
+			3 WorkflowTaskStarted
+			4 WorkflowTaskCompleted`,
+			s.GetHistoryFunc(s.Namespace().String(), firstRun),
+			10*time.Second,
+			250*time.Millisecond,
+		)
+	}
 
-	// Pause the first run.
-	_, err = s.FrontendClient().PauseWorkflowExecution(ctx, &workflowservice.PauseWorkflowExecutionRequest{
-		Namespace:  s.Namespace().String(),
-		WorkflowId: firstRun.GetWorkflowId(),
-		RunId:      firstRun.GetRunId(),
-		Identity:   "functional-test",
-		Reason:     "schedule-pause-reset",
-		RequestId:  uuid.NewString(),
-	})
-	require.NoError(t, err)
-	await.RequireTrue(t, func() bool {
-		d, dErr := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-			Namespace: s.Namespace().String(),
-			Execution: firstRun,
-		})
-		return dErr == nil && d.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED
-	}, 15*time.Second, 200*time.Millisecond)
+	f := setupPausedTriggeredWorkflow(t, newContext, pauseInteractionOpts(t), "sched-pause-reset", register, afterStart)
 
 	// Reset the paused workflow to a point before it was paused.
-	resetResp, err := s.FrontendClient().ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
-		Namespace:                 s.Namespace().String(),
-		WorkflowExecution:         firstRun,
+	resetResp, err := f.s.FrontendClient().ResetWorkflowExecution(f.ctx, &workflowservice.ResetWorkflowExecutionRequest{
+		Namespace:                 f.s.Namespace().String(),
+		WorkflowExecution:         f.execution,
 		Reason:                    "schedule-pause-reset",
 		WorkflowTaskFinishEventId: 3,
 		RequestId:                 uuid.NewString(),
 	})
 	require.NoError(t, err)
 	resetRun := &commonpb.WorkflowExecution{
-		WorkflowId: firstRun.GetWorkflowId(),
+		WorkflowId: f.execution.GetWorkflowId(),
 		RunId:      resetResp.GetRunId(),
 	}
 
 	// The reset run is created from history before the pause event, so it is
 	// running, not paused: reset clears the pause.
 	await.RequireTruef(t, func() bool {
-		d, dErr := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-			Namespace: s.Namespace().String(),
+		d, dErr := f.s.FrontendClient().DescribeWorkflowExecution(f.ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: f.s.Namespace().String(),
 			Execution: resetRun,
 		})
 		return dErr == nil && d.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
-	}, 15*time.Second, 200*time.Millisecond, "reset run should be RUNNING (pause cleared by reset)")
+	}, workflowStatusWait, workflowStatusPoll, "reset run should be RUNNING (pause cleared by reset)")
 
 	// The scheduler keeps tracking the reset run: signalling it to completion
 	// should be observed and recorded as a COMPLETED action.
-	err = s.SdkClient().SignalWorkflow(ctx, resetRun.GetWorkflowId(), resetRun.GetRunId(), "complete", nil)
+	err = f.s.SdkClient().SignalWorkflow(f.ctx, resetRun.GetWorkflowId(), resetRun.GetRunId(), "complete", nil)
 	require.NoError(t, err)
 	await.RequireTruef(t, func() bool {
-		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  s.Namespace().String(),
-			ScheduleId: sid,
+		desc, descErr := f.s.FrontendClient().DescribeSchedule(f.ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  f.s.Namespace().String(),
+			ScheduleId: f.sid,
 		})
 		if descErr != nil {
 			return false
@@ -588,7 +571,7 @@ func testSchedulePauseReset(t *testing.T, newContext contextFactory) {
 			}
 		}
 		return false
-	}, 30*time.Second, 500*time.Millisecond, "scheduler should record the reset run as COMPLETED")
+	}, scheduleCompletionWait, scheduleCompletionPoll, "scheduler should record the reset run as COMPLETED")
 }
 
 // scheduleActionCount returns the schedule's total ActionCount (number of


### PR DESCRIPTION
## What changed?
* Treat PAUSED status the same as RUNNING in V1 scheduler, which allows the scheduler to terminate those workflows if the overlap policy requests that.
* Add tests to validate the `OverlapPolicy` behavior with paused workflows.

## Why?
In preparation for a workflow pause release, encoding the overlap policy and workflow pause interactions operate the same for CHASM and V1 schedules.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [X] added new functional test(s)

## Potential risks
Test changes only
