### PR TITLE
Fix: Remove careless test-case failing and flaking

### DIFF
--- a/tools/tdbg/schedule_migrate_test.go
+++ b/tools/tdbg/schedule_migrate_test.go
@@ -318,13 +318,14 @@ func TestMigrateSchedule_Stdin_Execute(t *testing.T) {
 	})
 
 	require.Len(t, admin.requests, 2)
-	require.Equal(t, "ns-1", admin.requests[0].Namespace)
-	require.Equal(t, "sched-1", admin.requests[0].ScheduleId)
-	require.Equal(t, "ns-2", admin.requests[1].Namespace)
-	require.Equal(t, "sched-2", admin.requests[1].ScheduleId)
+	// Order is not guaranteed: the default worker pool migrates lines concurrently, so match
+	// each schedule id to its namespace as a pair rather than asserting by index.
+	byID := map[string]string{}
 	for _, req := range admin.requests {
+		byID[req.ScheduleId] = req.Namespace
 		require.Equal(t, adminservice.MigrateScheduleRequest_SCHEDULER_TARGET_WORKFLOW, req.Target)
 	}
+	require.Equal(t, map[string]string{"sched-1": "ns-1", "sched-2": "ns-2"}, byID)
 }
 
 func TestMigrateSchedule_Stdin_Workers(t *testing.T) {


### PR DESCRIPTION
## What changed?
The CLI command users a set of workers to perform the migration. It's nondeterministic in the output and the test was relying on order because careless. This removes the ordering

## Why?
Some folks were kind enough to point out flakiness I'd caused. 

## How did you test it?
- [ ] built
- [X] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
no identified risks