### PR TITLE
task validation should not be subject to forwarder rate limit

### DIFF
--- a/service/matching/pri_matcher.go
+++ b/service/matching/pri_matcher.go
@@ -165,13 +165,7 @@ func (tm *priTaskMatcher) Stop() {
 func (tm *priTaskMatcher) forwardTasks(lim quotas.RateLimiter, retrier backoff.Retrier) {
 	ctxs := []context.Context{tm.tqCtx}
 	poller := waitingPoller{taskForwarderType: parentTaskForwarder}
-	skipLimiter := false
-	var err error
 	for {
-		if !skipLimiter && lim.Wait(tm.tqCtx) != nil {
-			return
-		}
-
 		res := tm.data.EnqueuePollerAndWait(ctxs, &poller)
 		if res.ctxErr != nil {
 			return // task queue closing
@@ -180,7 +174,7 @@ func (tm *priTaskMatcher) forwardTasks(lim quotas.RateLimiter, retrier backoff.R
 			continue
 		}
 
-		skipLimiter, err = tm.forwardTask(res.task)
+		err := tm.forwardTask(res.task, lim)
 
 		// backoff on resource exhausted errors
 		if common.IsResourceExhausted(err) {
@@ -191,10 +185,14 @@ func (tm *priTaskMatcher) forwardTasks(lim quotas.RateLimiter, retrier backoff.R
 	}
 }
 
-func (tm *priTaskMatcher) forwardTask(task *internalTask) (bool, error) {
+func (tm *priTaskMatcher) forwardTask(task *internalTask, lim quotas.RateLimiter) error {
 	var ctx context.Context
 	var cancel context.CancelFunc
 	if task.forwardCtx != nil {
+		// Sync match task: subject to forwarder rate limit.
+		if err := lim.Wait(tm.tqCtx); err != nil {
+			return err
+		}
 		// Use sync match context if we have it (for deadline, headers, etc.)
 		// TODO(pri): does it make sense to subtract 1s from the context deadline here?
 		// Also arrange for this to be canceled on tqCtx closing.
@@ -205,7 +203,9 @@ func (tm *priTaskMatcher) forwardTask(task *internalTask) (bool, error) {
 	} else {
 		// Task is from local backlog.
 
-		// Before we forward, ask task validator. This will happen every BacklogTaskForwardTimeout
+		// Ask task validator before consuming a rate-limit token. This lets us
+		// invalidate stale tasks at full speed without being throttled by the
+		// forwarder rate limit. This will happen every BacklogTaskForwardTimeout
 		// to the head of the backlog, which is what taskValidator expects.
 		maybeValid := tm.validator.maybeValidate(task.event.AllocatedTaskInfo, tm.fwdr.partition.TaskType())
 		if !maybeValid {
@@ -218,7 +218,12 @@ func (tm *priTaskMatcher) forwardTask(task *internalTask) (bool, error) {
 			// Stay alive as long as we're invalidating tasks
 			tm.markAlive()
 
-			return true, nil
+			return nil
+		}
+
+		// Task is valid: apply forwarder rate limit before forwarding.
+		if err := lim.Wait(tm.tqCtx); err != nil {
+			return err
 		}
 
 		// Add a timeout for forwarding.
@@ -230,20 +235,20 @@ func (tm *priTaskMatcher) forwardTask(task *internalTask) (bool, error) {
 	if task.isQuery() {
 		res, err := tm.fwdr.ForwardQueryTask(ctx, task)
 		task.finishForward(res, err, true)
-		return false, err
+		return err
 	}
 
 	if task.isNexus() {
 		res, err := tm.fwdr.ForwardNexusTask(ctx, task)
 		task.finishForward(res, err, true)
-		return false, err
+		return err
 	}
 
 	// normal wf/activity task
 	err := tm.fwdr.ForwardTask(ctx, task)
 	task.finishForward(nil, err, true)
 
-	return false, err
+	return err
 }
 
 func (tm *priTaskMatcher) validateTasksOnRoot(retrier backoff.Retrier) {

--- a/service/matching/pri_matcher_test.go
+++ b/service/matching/pri_matcher_test.go
@@ -192,3 +192,78 @@ func (s *PriMatcherSuite) TestForwardPollRetriesOnResourceExhausted() {
 		require.Equal(t, taskToken, task.started.workflowTaskInfo.TaskToken)
 	})
 }
+
+// TestInvalidationBypassesForwarderRateLimit verifies that successfully
+// invalidating backlog tasks is not throttled by the forwarder rate limit.
+// With a very low rate limit, a stream of invalid backlog tasks should still
+// be drained quickly because invalidation should not consume rate-limit tokens.
+func (s *PriMatcherSuite) TestInvalidationBypassesForwarderRateLimit() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tq := tqid.UnsafeTaskQueueFamily("nsid", "tq").TaskQueue(enumspb.TASK_QUEUE_TYPE_WORKFLOW)
+	childPartition := tq.NormalPartition(1)
+
+	cfg := newTaskQueueConfig(tq, NewConfig(dynamicconfig.NewNoopCollection()), "nsname")
+	// Set a very low forwarder rate so that, if validation were subject to it,
+	// processing N tasks would take roughly N/rate seconds.
+	cfg.ForwarderMaxRatePerSecond = func() float64 { return 0.5 }
+
+	// All tasks are invalid: the validator returns false.
+	mockValidator := NewMocktaskValidator(s.controller)
+	mockValidator.EXPECT().
+		maybeValidate(gomock.Any(), gomock.Any()).
+		Return(false).
+		AnyTimes()
+
+	mockClient := matchingservicemock.NewMockMatchingServiceClient(s.controller)
+	queue := UnversionedQueueKey(childPartition)
+	fwdr, err := newPriForwarder(&cfg.forwarderConfig, queue, mockClient, testhooks.TestHooks{})
+	s.Require().NoError(err)
+
+	rateLimitManager := newRateLimitManager(&mockUserDataManager{}, cfg, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
+
+	tm := newPriTaskMatcher(
+		ctx,
+		cfg,
+		childPartition,
+		fwdr,
+		mockClient,
+		mockValidator,
+		s.logger,
+		metrics.NoopMetricsHandler,
+		rateLimitManager,
+		func() {},
+	)
+
+	tm.Start()
+	defer tm.Stop()
+
+	const numTasks = 10
+	done := make(chan struct{}, numTasks)
+	for i := range numTasks {
+		task := newInternalTaskFromBacklog(&persistencespb.AllocatedTaskInfo{
+			TaskId: int64(i + 1),
+			Data: &persistencespb.TaskInfo{
+				CreateTime: timestamppb.Now(),
+			},
+		}, func(t *internalTask, _ taskResponse) {
+			done <- struct{}{}
+		})
+		task.resetMatcherState()
+		s.Require().NoError(tm.AddTask(task))
+	}
+
+	// If invalidation were rate-limited at 0.5/s, draining 10 tasks would take
+	// ~18s. With validation exempt from the rate limit, it should complete in
+	// well under a second.
+	deadline := time.After(3 * time.Second)
+	for i := range numTasks {
+		select {
+		case <-done:
+		case <-deadline:
+			s.Failf("timeout", "only %d/%d invalid tasks finished before deadline", i, numTasks)
+			return
+		}
+	}
+}


### PR DESCRIPTION
## What changed?
Change logic of forwarded Tasks so that validation of backlog tasks are not subject to the rate limiter.

## Why?
If we grow a large number of invalid tasks in the backlog, we should be able to clear those out without being subject to the rate limit.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

