### PR TITLE
Stop matching client deterministically on cluster shutdown

### DIFF
--- a/client/client_bean.go
+++ b/client/client_bean.go
@@ -28,6 +28,10 @@ type (
 		GetFrontendClient() workflowservice.WorkflowServiceClient
 		GetRemoteAdminClient(string) (adminservice.AdminServiceClient, error)
 		GetRemoteFrontendClient(string) (grpc.ClientConnInterface, workflowservice.WorkflowServiceClient, error)
+		// Close deterministically releases bean-held resources on shutdown: it
+		// stops the matching client (its daemon goroutines and cached gRPC
+		// connections) and unregisters the cluster metadata change callback.
+		Close()
 	}
 
 	frontendClient struct {
@@ -110,6 +114,20 @@ func (h *clientBeanImpl) registerClientEviction() {
 				h.frontendClientsLock.Unlock()
 			}
 		})
+}
+
+// Close releases the resources held by the bean's clients. See the Bean
+// interface for details. It is safe to call more than once.
+func (h *clientBeanImpl) Close() {
+	h.clusterMetadata.UnRegisterMetadataChangeCallback(h)
+
+	// The matching client wrapper chain implements Stop(); stopping it
+	// releases its daemon goroutines and cached gRPC connections.
+	if mc := h.matchingClient.Load(); mc != nil {
+		if s, ok := mc.(interface{ Stop() }); ok {
+			s.Stop()
+		}
+	}
 }
 
 func (h *clientBeanImpl) GetHistoryClient() historyservice.HistoryServiceClient {

--- a/client/client_bean_mock.go
+++ b/client/client_bean_mock.go
@@ -44,6 +44,18 @@ func (m *MockBean) EXPECT() *MockBeanMockRecorder {
 	return m.recorder
 }
 
+// Close mocks base method.
+func (m *MockBean) Close() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Close")
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockBeanMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockBean)(nil).Close))
+}
+
 // GetFrontendClient mocks base method.
 func (m *MockBean) GetFrontendClient() workflowservice.WorkflowServiceClient {
 	m.ctrl.T.Helper()

--- a/client/matching/client.go
+++ b/client/matching/client.go
@@ -44,6 +44,7 @@ type clientImpl struct {
 	loadBalancer    LoadBalancer
 	spreadRouting   dynamicconfig.TypedPropertyFn[dynamicconfig.GradualChange[int]]
 	partitionCache  *partitionCache
+	evictionCancel  context.CancelFunc
 }
 
 // NewClient creates a new matching service gRPC client
@@ -76,10 +77,21 @@ func NewClient(
 
 	// Evict cached clients whose host leaves the membership ring.
 	ctx, cancel := context.WithCancel(context.Background())
+	c.evictionCancel = cancel
 	go watchMembershipForEviction(ctx, resolver, clients, connectionCloseDelay, logger)
 	runtime.AddCleanup(c, func(cancel context.CancelFunc) { cancel() }, cancel)
 
 	return c
+}
+
+// Stop deterministically releases the resources started by NewClient: it stops
+// the eviction watcher and partition-cache rotation goroutines and closes every
+// cached gRPC connection. It is safe to call more than once (the runtime
+// cleanups registered in NewClient remain as a GC backstop).
+func (c *clientImpl) Stop() {
+	c.evictionCancel()
+	c.partitionCache.Stop()
+	c.clients.EvictAll()
 }
 
 func watchMembershipForEviction(

--- a/client/matching/client.go
+++ b/client/matching/client.go
@@ -6,7 +6,6 @@ package matching
 import (
 	"context"
 	"fmt"
-	"runtime"
 	"time"
 
 	"github.com/google/uuid"
@@ -16,6 +15,7 @@ import (
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/goro"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/membership"
@@ -44,7 +44,7 @@ type clientImpl struct {
 	loadBalancer    LoadBalancer
 	spreadRouting   dynamicconfig.TypedPropertyFn[dynamicconfig.GradualChange[int]]
 	partitionCache  *partitionCache
-	evictionCancel  context.CancelFunc
+	evictionWatcher *goro.Handle
 }
 
 // NewClient creates a new matching service gRPC client
@@ -70,26 +70,24 @@ func NewClient(
 		partitionCache:  newPartitionCache(metricsHandler),
 	}
 
-	// Start goroutine to prune partition count cache.
-	// Clean up on gc, since we can't easily hook into fx here.
+	// Start goroutine to prune partition count cache. Stopped by Stop().
 	c.partitionCache.Start()
-	runtime.AddCleanup(c, func(cache *partitionCache) { cache.Stop() }, c.partitionCache)
 
-	// Evict cached clients whose host leaves the membership ring.
-	ctx, cancel := context.WithCancel(context.Background())
-	c.evictionCancel = cancel
-	go watchMembershipForEviction(ctx, resolver, clients, connectionCloseDelay, logger)
-	runtime.AddCleanup(c, func(cancel context.CancelFunc) { cancel() }, cancel)
+	// Evict cached clients whose host leaves the membership ring. Stopped by Stop().
+	c.evictionWatcher = goro.NewHandle(context.Background()).Go(func(ctx context.Context) error {
+		watchMembershipForEviction(ctx, resolver, clients, connectionCloseDelay, logger)
+		return nil
+	})
 
 	return c
 }
 
 // Stop deterministically releases the resources started by NewClient: it stops
 // the eviction watcher and partition-cache rotation goroutines and closes every
-// cached gRPC connection. It is safe to call more than once (the runtime
-// cleanups registered in NewClient remain as a GC backstop).
+// cached gRPC connection. It is safe to call more than once.
 func (c *clientImpl) Stop() {
-	c.evictionCancel()
+	c.evictionWatcher.Cancel()
+	<-c.evictionWatcher.Done()
 	c.partitionCache.Stop()
 	c.clients.EvictAll()
 }

--- a/client/matching/client.go
+++ b/client/matching/client.go
@@ -36,15 +36,17 @@ const (
 )
 
 type clientImpl struct {
-	timeout         time.Duration
-	longPollTimeout time.Duration
-	clients         common.ClientCache
-	metricsHandler  metrics.Handler
-	logger          log.Logger
-	loadBalancer    LoadBalancer
-	spreadRouting   dynamicconfig.TypedPropertyFn[dynamicconfig.GradualChange[int]]
-	partitionCache  *partitionCache
-	evictionWatcher *goro.Handle
+	timeout              time.Duration
+	longPollTimeout      time.Duration
+	clients              common.ClientCache
+	resolver             membership.ServiceResolver
+	connectionCloseDelay dynamicconfig.DurationPropertyFn
+	metricsHandler       metrics.Handler
+	logger               log.Logger
+	loadBalancer         LoadBalancer
+	spreadRouting        dynamicconfig.TypedPropertyFn[dynamicconfig.GradualChange[int]]
+	partitionCache       *partitionCache
+	evictionWatcher      *goro.Handle
 }
 
 // NewClient creates a new matching service gRPC client
@@ -60,24 +62,23 @@ func NewClient(
 	connectionCloseDelay dynamicconfig.DurationPropertyFn,
 ) matchingservice.MatchingServiceClient {
 	c := &clientImpl{
-		timeout:         timeout,
-		longPollTimeout: longPollTimeout,
-		clients:         clients,
-		metricsHandler:  metricsHandler,
-		logger:          logger,
-		loadBalancer:    lb,
-		spreadRouting:   spreadRouting,
-		partitionCache:  newPartitionCache(metricsHandler),
+		timeout:              timeout,
+		longPollTimeout:      longPollTimeout,
+		clients:              clients,
+		resolver:             resolver,
+		connectionCloseDelay: connectionCloseDelay,
+		metricsHandler:       metricsHandler,
+		logger:               logger,
+		loadBalancer:         lb,
+		spreadRouting:        spreadRouting,
+		partitionCache:       newPartitionCache(metricsHandler),
 	}
 
 	// Start goroutine to prune partition count cache. Stopped by Stop().
 	c.partitionCache.Start()
 
 	// Evict cached clients whose host leaves the membership ring. Stopped by Stop().
-	c.evictionWatcher = goro.NewHandle(context.Background()).Go(func(ctx context.Context) error {
-		watchMembershipForEviction(ctx, resolver, clients, connectionCloseDelay, logger)
-		return nil
-	})
+	c.evictionWatcher = goro.NewHandle(context.Background()).Go(c.watchMembership)
 
 	return c
 }
@@ -92,20 +93,16 @@ func (c *clientImpl) Stop() {
 	c.clients.EvictAll()
 }
 
-func watchMembershipForEviction(
-	ctx context.Context,
-	resolver membership.ServiceResolver,
-	clients common.ClientCache,
-	connectionCloseDelay dynamicconfig.DurationPropertyFn,
-	logger log.Logger,
-) {
+// watchMembership evicts cached clients whose host leaves the membership ring.
+// It runs until ctx is cancelled (by Stop).
+func (c *clientImpl) watchMembership(ctx context.Context) error {
 	listenerName := fmt.Sprintf("matchingClientCache-%s", uuid.New().String())
 	ch := make(chan *membership.ChangedEvent, 1)
-	if err := resolver.AddListener(listenerName, ch); err != nil {
-		logger.Error("Failed to subscribe matching cache to membership", tag.Error(err))
-		return
+	if err := c.resolver.AddListener(listenerName, ch); err != nil {
+		c.logger.Error("Failed to subscribe matching cache to membership", tag.Error(err))
+		return err
 	}
-	defer func() { _ = resolver.RemoveListener(listenerName) }()
+	defer func() { _ = c.resolver.RemoveListener(listenerName) }()
 
 	// Reap departed hosts via a per-address deadline checked by a single ticker;
 	// a re-add resets it to the latest removal.
@@ -115,16 +112,16 @@ func watchMembershipForEviction(
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		case event := <-ch:
 			for _, h := range event.HostsRemoved {
-				evictAt[h.GetAddress()] = time.Now().Add(connectionCloseDelay())
+				evictAt[h.GetAddress()] = time.Now().Add(c.connectionCloseDelay())
 			}
 			for _, h := range event.HostsAdded {
 				delete(evictAt, h.GetAddress())
 			}
 		case <-ticker.C:
-			reapEvictableClients(resolver, clients, evictAt)
+			reapEvictableClients(c.resolver, c.clients, evictAt)
 		}
 	}
 }

--- a/client/matching/metric_client.go
+++ b/client/matching/metric_client.go
@@ -253,3 +253,11 @@ func (c *metricClient) Route(p tqid.Partition) (string, error) {
 	}
 	return rc.Route(p)
 }
+
+// Stop forwards a deterministic shutdown to the wrapped client. See
+// clientImpl.Stop. It is only invoked via client.Bean.Close.
+func (c *metricClient) Stop() {
+	if s, ok := c.client.(interface{ Stop() }); ok {
+		s.Stop()
+	}
+}

--- a/common/client_cache.go
+++ b/common/client_cache.go
@@ -17,6 +17,9 @@ type (
 		// Evict removes the cached entry for the given key and runs its
 		// release fn.
 		Evict(clientKey string)
+		// EvictAll removes every cached entry and runs each one's release fn.
+		// Used to deterministically release cached gRPC connections on shutdown.
+		EvictAll()
 	}
 
 	keyResolver interface {
@@ -123,6 +126,21 @@ func (c *clientCacheImpl) Evict(clientKey string) {
 	if ok && entry.release != nil {
 		if err := entry.release(); err != nil {
 			c.logger.Warn("Error releasing evicted client resource", tag.Error(err))
+		}
+	}
+}
+
+func (c *clientCacheImpl) EvictAll() {
+	c.cacheLock.Lock()
+	entries := c.clients
+	c.clients = make(map[string]cachedEntry)
+	c.cacheLock.Unlock()
+
+	for _, entry := range entries {
+		if entry.release != nil {
+			if err := entry.release(); err != nil {
+				c.logger.Warn("Error releasing evicted client resource", tag.Error(err))
+			}
 		}
 	}
 }

--- a/common/resource/fx.go
+++ b/common/resource/fx.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -272,13 +273,26 @@ func ClientFactoryProvider(
 }
 
 func ClientBeanProvider(
+	lc fx.Lifecycle,
 	clientFactory client.Factory,
 	clusterMetadata cluster.Metadata,
 ) (client.Bean, error) {
-	return client.NewClientBean(
+	bean, err := client.NewClientBean(
 		clientFactory,
 		clusterMetadata,
 	)
+	if err != nil {
+		return nil, err
+	}
+	// Deterministically release the bean's clients (daemon goroutines and
+	// cached gRPC connections) on shutdown.
+	lc.Append(fx.Hook{
+		OnStop: func(context.Context) error {
+			bean.Close()
+			return nil
+		},
+	})
+	return bean, nil
 }
 
 func FrontendClientProvider(clientBean client.Bean) workflowservice.WorkflowServiceClient {

--- a/common/resource/fx.go
+++ b/common/resource/fx.go
@@ -1,7 +1,6 @@
 package resource
 
 import (
-	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -286,12 +285,7 @@ func ClientBeanProvider(
 	}
 	// Deterministically release the bean's clients (daemon goroutines and
 	// cached gRPC connections) on shutdown.
-	lc.Append(fx.Hook{
-		OnStop: func(context.Context) error {
-			bean.Close()
-			return nil
-		},
-	})
+	lc.Append(fx.StopHook(bean.Close))
 	return bean, nil
 }
 

--- a/tests/leakcheck/leak_test.go
+++ b/tests/leakcheck/leak_test.go
@@ -25,14 +25,22 @@ var goleakOpts = []goleak.Option{
 	// By design: sqlite keeps one *sql.DB per file DSN for the process lifetime.
 	goleak.IgnoreTopFunction("database/sql.(*DB).connectionOpener"),
 
-	// TODO: gRPC connection goroutines leaked because history/matching
-	// connection pools are not closed on cluster shutdown.
+	// TODO: gRPC connection goroutines leaked because some inter-service client
+	// connection caches are not closed on cluster shutdown. An open
+	// *grpc.ClientConn keeps its own background goroutines alive (the
+	// CallbackSerializer, the transport, and the membership resolver's
+	// listener), so the garbage collector can never reclaim it; the connection
+	// must be closed explicitly. The caches that still hold connections open
+	// past shutdown are the history client's connection pool, the CHASM
+	// history-shard-routed service clients (scheduler/activity/nexus, which
+	// reuse history.NewConnectionPool), and the client bean's frontend/admin
+	// connections. Each needs a deterministic close on shutdown (as the
+	// matching client's connection cache now does) before these ignores can be
+	// removed.
 	goleak.IgnoreTopFunction("google.golang.org/grpc/internal/grpcsync.(*CallbackSerializer).run"),
 	goleak.IgnoreTopFunction("google.golang.org/grpc.(*addrConn).resetTransportAndUnlock"),
 	goleak.IgnoreTopFunction("google.golang.org/grpc/internal/balancer/gracefulswitch.(*Balancer).updateSubConnState"),
 	goleak.IgnoreTopFunction("go.temporal.io/server/client/history.watchMembershipForClose[...]"),
-	goleak.IgnoreTopFunction("go.temporal.io/server/client/matching.(*partitionCache).Start.func1"),
-	goleak.IgnoreTopFunction("go.temporal.io/server/client/matching.watchMembershipForEviction"),
 	goleak.IgnoreTopFunction("go.temporal.io/server/common/membership.(*grpcResolver).listen"),
 
 	// TODO: worker-service and persistence goroutine leaks.

--- a/tests/leakcheck/leak_test.go
+++ b/tests/leakcheck/leak_test.go
@@ -25,18 +25,8 @@ var goleakOpts = []goleak.Option{
 	// By design: sqlite keeps one *sql.DB per file DSN for the process lifetime.
 	goleak.IgnoreTopFunction("database/sql.(*DB).connectionOpener"),
 
-	// TODO: gRPC connection goroutines leaked because some inter-service client
-	// connection caches are not closed on cluster shutdown. An open
-	// *grpc.ClientConn keeps its own background goroutines alive (the
-	// CallbackSerializer, the transport, and the membership resolver's
-	// listener), so the garbage collector can never reclaim it; the connection
-	// must be closed explicitly. The caches that still hold connections open
-	// past shutdown are the history client's connection pool, the CHASM
-	// history-shard-routed service clients (scheduler/activity/nexus, which
-	// reuse history.NewConnectionPool), and the client bean's frontend/admin
-	// connections. Each needs a deterministic close on shutdown (as the
-	// matching client's connection cache now does) before these ignores can be
-	// removed.
+	// TODO: gRPC connection goroutines leaked because history/matching
+	// connection pools are not closed on cluster shutdown.
 	goleak.IgnoreTopFunction("google.golang.org/grpc/internal/grpcsync.(*CallbackSerializer).run"),
 	goleak.IgnoreTopFunction("google.golang.org/grpc.(*addrConn).resetTransportAndUnlock"),
 	goleak.IgnoreTopFunction("google.golang.org/grpc/internal/balancer/gracefulswitch.(*Balancer).updateSubConnState"),


### PR DESCRIPTION
## What changed?
Give the matching client a deterministic Stop() and drive it from the fx lifecycle:

- common.ClientCache gains EvictAll() to close every cached gRPC connection.
- matching clientImpl.Stop() cancels the eviction watcher, stops the partition cache, and evicts all connections; metricClient forwards it. The runtime.AddCleanup calls remain as a GC backstop.
- client.Bean.Close() stops the matching client and unregisters the cluster metadata change callback; ClientBeanProvider registers it as an fx OnStop hook.

Removes the two matching goroutine-leak ignores from the leak regression test (partitionCache.Start.func1, watchMembershipForEviction); both are 0 after teardown. The remaining gRPC-connection ignores (history connection pool, CHASM history-shard-routed clients, frontend/admin and SDK worker connections) are documented in leak_test.go as follow-ups.
## Why?
The functional test suite stands up and tears down many testcore clusters in a single long-lived process. The matching service client started two long-lived goroutines (the membership eviction watcher and the partition cache rotation loop) and tied their shutdown only to GC via runtime.AddCleanup; its cached gRPC connections were likewise only closed on membership eviction, never on shutdown.

An open *grpc.ClientConn is rooted by its own background goroutines, so it can never be reclaimed by GC, and the client itself was pinned by a leaked worker-service SDK worker, so the AddCleanup hooks never fired. These per-cluster goroutines therefore accumulated across clusters until the process was OOM-killed in CI.
## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
