### PR TITLE
Fix Nexus failure conversion data race

### DIFF
--- a/chasm/lib/nexusoperation/invocation.go
+++ b/chasm/lib/nexusoperation/invocation.go
@@ -239,7 +239,7 @@ func (i *invocationSystem) Start(
 		if v.Failure.GetCanceledFailureInfo() != nil {
 			state = nexus.OperationStateCanceled
 		}
-		nexusFailure, convErr := commonnexus.TemporalFailureToNexusFailure(v.Failure)
+		nexusFailure, convErr := commonnexus.TemporalFailureToNexusFailureInPlace(v.Failure)
 		if convErr != nil {
 			i.logger.Error("failed to convert temporal failure to nexus failure", tag.Error(convErr), tag.RequestID(args.requestID))
 			he := nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error (request ID: %s)", args.requestID)

--- a/common/nexus/failure.go
+++ b/common/nexus/failure.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -92,15 +93,25 @@ type serializedHandlerError struct {
 // TemporalFailureToNexusFailure converts an API proto Failure to a Nexus SDK Failure setting the metadata "type" field to
 // the proto fullname of the temporal API Failure message or the standard Nexus SDK failure types.
 // Returns an error if the failure cannot be converted.
-// Mutates the failure temporarily, unsetting the Message and StackTrace fields to avoid duplicating the information in
-// the serialized failure. Mutating was chosen over cloning for performance reasons since this function may be called
-// frequently.
+//
+// Compared to TemporalFailureToNexusFailureInPlace, this function clones the failure before converting it to avoid
+// mutating a shared proto.
 func TemporalFailureToNexusFailure(failure *failurepb.Failure) (nexus.Failure, error) {
+	return TemporalFailureToNexusFailureInPlace(proto.Clone(failure).(*failurepb.Failure))
+}
+
+// TemporalFailureToNexusFailureInPlace converts an API proto Failure to a Nexus SDK Failure setting the metadata
+// "type" field to the proto fullname of the temporal API Failure message or the standard Nexus SDK failure types.
+// Returns an error if the failure cannot be converted.
+//
+// Compared to TemporalFailureToNexusFailure, this function converts the failure in place to avoid cloning. This
+// is only safe for callers who exclusively own the failure.
+func TemporalFailureToNexusFailureInPlace(failure *failurepb.Failure) (nexus.Failure, error) {
 	var causep *nexus.Failure
 	if failure.GetCause() != nil {
 		var cause nexus.Failure
 		var err error
-		cause, err = TemporalFailureToNexusFailure(failure.GetCause())
+		cause, err = TemporalFailureToNexusFailureInPlace(failure.GetCause())
 		if err != nil {
 			return nexus.Failure{}, err
 		}

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -1076,7 +1076,7 @@ func (e taskExecutor) startOnHistoryService(
 		if v.Failure.GetCanceledFailureInfo() != nil {
 			state = nexus.OperationStateCanceled
 		}
-		nexusFailure, convErr := commonnexus.TemporalFailureToNexusFailure(v.Failure)
+		nexusFailure, convErr := commonnexus.TemporalFailureToNexusFailureInPlace(v.Failure)
 		if convErr != nil {
 			e.Logger.Error("failed to convert temporal failure to nexus failure", tag.Error(convErr), tag.RequestID(args.requestID))
 			he := nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error (request ID: %s)", args.requestID)

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -461,7 +461,7 @@ func (h *nexusHandler) StartOperation(
 		// the worker.
 		oc.setFailureSource(commonnexus.FailureSourceWorker)
 		oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("handler_error:" + t.Failure.GetNexusHandlerFailureInfo().GetType()))
-		nf, err := commonnexus.TemporalFailureToNexusFailure(t.Failure)
+		nf, err := commonnexus.TemporalFailureToNexusFailureInPlace(t.Failure)
 		if err != nil {
 			oc.logger.Error("error converting Temporal failure to Nexus failure", tag.Error(err), tag.Operation(operation), tag.WorkflowNamespace(oc.namespaceName))
 			return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
@@ -531,7 +531,7 @@ func (h *nexusHandler) StartOperation(
 			// the worker.
 			oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("failure"))
 			oc.setFailureSource(commonnexus.FailureSourceWorker)
-			nf, err := commonnexus.TemporalFailureToNexusFailure(t.Failure)
+			nf, err := commonnexus.TemporalFailureToNexusFailureInPlace(t.Failure)
 			if err != nil {
 				oc.logger.Error("error converting Temporal failure to Nexus failure", tag.Error(err), tag.Operation(operation), tag.WorkflowNamespace(oc.namespaceName))
 				return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
@@ -679,7 +679,7 @@ func (h *nexusHandler) CancelOperation(ctx context.Context, service, operation, 
 		// Failure conversions errors below are the user's fault, as it implies that malformed completions were sent from
 		// the worker.
 		oc.setFailureSource(commonnexus.FailureSourceWorker)
-		nf, err := commonnexus.TemporalFailureToNexusFailure(t.Failure)
+		nf, err := commonnexus.TemporalFailureToNexusFailureInPlace(t.Failure)
 		if err != nil {
 			oc.logger.Error("error converting Temporal failure to Nexus failure", tag.Error(err), tag.Operation(operation), tag.WorkflowNamespace(oc.namespaceName))
 			return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")


### PR DESCRIPTION
## What changed?

1. Adding new `TemporalFailureToNexusFailureInPlace` for in-place, non-cloned conversion to Nexus failure
2. Updating `TemporalFailureToNexusFailureInPlace` to clone failure before mutating for conversion

## Why?

Passing in a shared failure, like from the event history cache, can cause a data race.

Why not always clone? We don't want to give up the performance benefit.

## How did you test it?

Not adding a test as the behavior is not possible to verify deterministically.