### PR TITLE
[spike] alt: emit caller metrics inside transitions — for comparison, do not merge

### DIFF
--- a/components/nexusoperations/completion.go
+++ b/components/nexusoperations/completion.go
@@ -22,6 +22,7 @@ func handleSuccessfulOperationResult(
 	operation Operation,
 	result *commonpb.Payload,
 	links []*commonpb.Link,
+	cm callerMetrics,
 ) error {
 	eventID, err := hsm.EventIDFromToken(operation.ScheduledEventToken)
 	if err != nil {
@@ -39,13 +40,14 @@ func handleSuccessfulOperationResult(
 		}
 		e.Links = links
 	})
-	return CompletedEventDefinition{}.Apply(node.Parent, event)
+	return CompletedEventDefinition{metrics: cm}.Apply(node.Parent, event)
 }
 
 func handleOperationError(
 	node *hsm.Node,
 	operation Operation,
 	opErr *nexus.OperationError,
+	cm callerMetrics,
 ) error {
 	eventID, err := hsm.EventIDFromToken(operation.ScheduledEventToken)
 	if err != nil {
@@ -85,7 +87,7 @@ func handleOperationError(
 			}
 		})
 
-		return FailedEventDefinition{}.Apply(node.Parent, event)
+		return FailedEventDefinition{metrics: cm}.Apply(node.Parent, event)
 	case nexus.OperationStateCanceled:
 		if originalCause.GetCanceledFailureInfo() == nil {
 			// Old SDKs may send an ApplicationFailure for canceled operation causes.
@@ -110,7 +112,7 @@ func handleOperationError(
 			}
 		})
 
-		return CanceledEventDefinition{}.Apply(node.Parent, event)
+		return CanceledEventDefinition{metrics: cm}.Apply(node.Parent, event)
 	default:
 		// Both the Nexus Client and CompletionHandler reject invalid states, but just in case, we return this as a
 		// transition error.
@@ -128,6 +130,7 @@ func fabricateStartedEventIfMissing(
 	operationToken string,
 	startTime *timestamppb.Timestamp,
 	links []*commonpb.Link,
+	cm callerMetrics,
 ) error {
 	operation, err := hsm.MachineData[Operation](node)
 	if err != nil {
@@ -159,7 +162,7 @@ func fabricateStartedEventIfMissing(
 			e.EventTime = startTime
 		}
 	})
-	return (StartedEventDefinition{}).Apply(node.Parent, event)
+	return (StartedEventDefinition{metrics: cm}).Apply(node.Parent, event)
 }
 
 // CompletionHandler resolves async Nexus operation completions delivered to the history service
@@ -201,25 +204,24 @@ func (h *CompletionHandler) Handle(
 		if err != nil {
 			return err
 		}
-		// If the operation has not started yet, this completion arrived before the start response and
-		// fabricateStartedEventIfMissing will transition it to started below; the executor never emitted
-		// schedule-to-start in that case, so we emit it here.
-		fabricatedStart := TransitionStarted.Possible(operation)
-		if err := fabricateStartedEventIfMissing(node, requestID, operationToken, startTime, links); err != nil {
-			return err
-		}
 		if requestID != "" && operation.RequestId != requestID {
 			isRetryableNotFoundErr = false
 			return serviceerror.NewNotFound("operation not found")
 		}
-		if fabricatedStart && operation.StartedTime != nil {
-			recordScheduleToStartLatency(metricsHandler, metricTagConfig, operation, node.NamespaceName(), node.WorkflowTypeName(), operation.StartedTime.AsTime())
+
+		// The terminal transitions emit the caller-side metric themselves when handed this live-path
+		// carrier; the registered (replay) event definitions leave it disabled. The transition picks
+		// the right outcome (succeeded/failed/canceled) and schedule-to-start (when this completion
+		// fabricates the start), so nothing needs to be decided here.
+		cm := callerMetrics{handler: metricsHandler, tagConfig: metricTagConfig}
+		if err := fabricateStartedEventIfMissing(node, requestID, operationToken, startTime, links, cm); err != nil {
+			return err
 		}
 
 		if opFailedError != nil {
-			err = handleOperationError(node, operation, opFailedError)
+			err = handleOperationError(node, operation, opFailedError, cm)
 		} else {
-			err = handleSuccessfulOperationResult(node, operation, result, nil)
+			err = handleSuccessfulOperationResult(node, operation, result, nil, cm)
 		}
 		// TODO(bergundy): Remove this once the operation auto-deletes itself from the tree on completion with state
 		// based replication.
@@ -227,20 +229,7 @@ func (h *CompletionHandler) Handle(
 			isRetryableNotFoundErr = false
 			return serviceerror.NewNotFound("operation not found")
 		}
-		if err != nil {
-			return err
-		}
-		// Emit the terminal outcome metric. The canceled vs failed split mirrors handleOperationError
-		// so the metric outcome matches the recorded transition.
-		switch {
-		case opFailedError == nil:
-			recordOperationSucceeded(metricsHandler, metricTagConfig, operation, node.NamespaceName(), node.WorkflowTypeName(), env.Now())
-		case opFailedError.State == nexus.OperationStateCanceled:
-			recordOperationCanceled(metricsHandler, metricTagConfig, operation, node.NamespaceName(), node.WorkflowTypeName(), env.Now())
-		default:
-			recordOperationFailed(metricsHandler, metricTagConfig, operation, node.NamespaceName(), node.WorkflowTypeName(), env.Now())
-		}
-		return nil
+		return err
 	})
 	if errors.As(err, new(*serviceerror.NotFound)) && isRetryableNotFoundErr && ref.WorkflowKey.RunID != "" {
 		// Try again without a run ID in case the original run was reset.

--- a/components/nexusoperations/events.go
+++ b/components/nexusoperations/events.go
@@ -126,7 +126,10 @@ func (d CancelRequestFailedEventDefinition) CherryPick(root *hsm.Node, event *hi
 	return hsm.ErrNotCherryPickable
 }
 
-type StartedEventDefinition struct{}
+// StartedEventDefinition applies a NEXUS_OPERATION_STARTED event. Its metrics carrier is set only
+// when the live executor/completion path constructs the definition; the registered (replay) instance
+// leaves it disabled, so the transition emits the caller-side metric exactly once.
+type StartedEventDefinition struct{ metrics callerMetrics }
 
 func (d StartedEventDefinition) IsWorkflowTaskTrigger() bool {
 	return true
@@ -142,6 +145,7 @@ func (d StartedEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEv
 			Time:       event.EventTime.AsTime(),
 			Node:       node,
 			Attributes: event.GetNexusOperationStartedEventAttributes(),
+			metrics:    d.metrics,
 		})
 	})
 
@@ -155,7 +159,7 @@ func (d StartedEventDefinition) CherryPick(root *hsm.Node, event *historypb.Hist
 	return d.Apply(root, event)
 }
 
-type CompletedEventDefinition struct{}
+type CompletedEventDefinition struct{ metrics callerMetrics }
 
 func (d CompletedEventDefinition) IsWorkflowTaskTrigger() bool {
 	return true
@@ -164,8 +168,9 @@ func (d CompletedEventDefinition) IsWorkflowTaskTrigger() bool {
 func (d CompletedEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
 	node, err := transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
 		return TransitionSucceeded.Apply(o, EventSucceeded{
-			Time: event.EventTime.AsTime(),
-			Node: node,
+			Time:    event.EventTime.AsTime(),
+			Node:    node,
+			metrics: d.metrics,
 		})
 	})
 	if err != nil {
@@ -186,7 +191,7 @@ func (d CompletedEventDefinition) CherryPick(root *hsm.Node, event *historypb.Hi
 	return d.Apply(root, event)
 }
 
-type FailedEventDefinition struct{}
+type FailedEventDefinition struct{ metrics callerMetrics }
 
 func (d FailedEventDefinition) IsWorkflowTaskTrigger() bool {
 	return true
@@ -202,6 +207,7 @@ func (d FailedEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEve
 			Time:       event.EventTime.AsTime(),
 			Attributes: event.GetNexusOperationFailedEventAttributes(),
 			Node:       node,
+			metrics:    d.metrics,
 		})
 	})
 	if err != nil {
@@ -218,7 +224,7 @@ func (d FailedEventDefinition) CherryPick(root *hsm.Node, event *historypb.Histo
 	return d.Apply(root, event)
 }
 
-type CanceledEventDefinition struct{}
+type CanceledEventDefinition struct{ metrics callerMetrics }
 
 func (d CanceledEventDefinition) IsWorkflowTaskTrigger() bool {
 	return true
@@ -231,8 +237,9 @@ func (d CanceledEventDefinition) Type() enumspb.EventType {
 func (d CanceledEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
 	node, err := transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
 		return TransitionCanceled.Apply(o, EventCanceled{
-			Time: event.EventTime.AsTime(),
-			Node: node,
+			Time:    event.EventTime.AsTime(),
+			Node:    node,
+			metrics: d.metrics,
 		})
 	})
 	if err != nil {
@@ -249,7 +256,7 @@ func (d CanceledEventDefinition) CherryPick(root *hsm.Node, event *historypb.His
 	return d.Apply(root, event)
 }
 
-type TimedOutEventDefinition struct{}
+type TimedOutEventDefinition struct{ metrics callerMetrics }
 
 func (d TimedOutEventDefinition) IsWorkflowTaskTrigger() bool {
 	return true
@@ -262,7 +269,8 @@ func (d TimedOutEventDefinition) Type() enumspb.EventType {
 func (d TimedOutEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
 	node, err := transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
 		return TransitionTimedOut.Apply(o, EventTimedOut{
-			Node: node,
+			Node:    node,
+			metrics: d.metrics,
 		})
 	})
 	if err != nil {

--- a/components/nexusoperations/events_test.go
+++ b/components/nexusoperations/events_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
+	chasmnexus "go.temporal.io/server/chasm/lib/nexusoperation"
+	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/components/nexusoperations"
 	"go.temporal.io/server/service/history/hsm"
 	"go.temporal.io/server/service/history/hsm/hsmtest"
@@ -122,6 +124,101 @@ func TestCherryPick(t *testing.T) {
 			require.ErrorIs(t, err, hsm.ErrNotCherryPickable, "%T should not be cherrypickable when shouldExcludeNexusEvent=true", nexusOperation)
 		}
 	})
+}
+
+// TestCallerMetricsNotEmittedOnReapply is the replay-safety evidence for the "emit inside the
+// transition" approach: re-applying a terminal event through the registered event definition (the
+// path replication and workflow reset use) must NOT emit caller-side metrics. The registered
+// definition carries no metrics hook, so the transition stays silent; emission happens only on the
+// live executor/completion path, which sets the hook. The live emission is covered by the executor
+// and completion tests, so together they show emit-once-on-live, zero-on-replay.
+func TestCallerMetricsNotEmittedOnReapply(t *testing.T) {
+	testCases := []struct {
+		name       string
+		def        hsm.EventDefinition
+		makeEvent  func(eventID int64) *historypb.HistoryEvent
+		metricName string
+	}{
+		{
+			name: "completed",
+			def:  nexusoperations.CompletedEventDefinition{},
+			makeEvent: func(eventID int64) *historypb.HistoryEvent {
+				return &historypb.HistoryEvent{
+					EventType: enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED,
+					EventTime: timestamppb.Now(),
+					Attributes: &historypb.HistoryEvent_NexusOperationCompletedEventAttributes{
+						NexusOperationCompletedEventAttributes: &historypb.NexusOperationCompletedEventAttributes{ScheduledEventId: eventID},
+					},
+				}
+			},
+			metricName: chasmnexus.NexusOperationSuccessCount.Name(),
+		},
+		{
+			name: "failed",
+			def:  nexusoperations.FailedEventDefinition{},
+			makeEvent: func(eventID int64) *historypb.HistoryEvent {
+				return &historypb.HistoryEvent{
+					EventType: enumspb.EVENT_TYPE_NEXUS_OPERATION_FAILED,
+					EventTime: timestamppb.Now(),
+					Attributes: &historypb.HistoryEvent_NexusOperationFailedEventAttributes{
+						NexusOperationFailedEventAttributes: &historypb.NexusOperationFailedEventAttributes{ScheduledEventId: eventID},
+					},
+				}
+			},
+			metricName: chasmnexus.NexusOperationFailedCount.Name(),
+		},
+		{
+			name: "canceled",
+			def:  nexusoperations.CanceledEventDefinition{},
+			makeEvent: func(eventID int64) *historypb.HistoryEvent {
+				return &historypb.HistoryEvent{
+					EventType: enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCELED,
+					EventTime: timestamppb.Now(),
+					Attributes: &historypb.HistoryEvent_NexusOperationCanceledEventAttributes{
+						NexusOperationCanceledEventAttributes: &historypb.NexusOperationCanceledEventAttributes{ScheduledEventId: eventID},
+					},
+				}
+			},
+			metricName: chasmnexus.NexusOperationCancelCount.Name(),
+		},
+		{
+			name: "timedout",
+			def:  nexusoperations.TimedOutEventDefinition{},
+			makeEvent: func(eventID int64) *historypb.HistoryEvent {
+				return &historypb.HistoryEvent{
+					EventType: enumspb.EVENT_TYPE_NEXUS_OPERATION_TIMED_OUT,
+					EventTime: timestamppb.Now(),
+					Attributes: &historypb.HistoryEvent_NexusOperationTimedOutEventAttributes{
+						NexusOperationTimedOutEventAttributes: &historypb.NexusOperationTimedOutEventAttributes{ScheduledEventId: eventID},
+					},
+				}
+			},
+			metricName: chasmnexus.NexusOperationTimeoutCount.Name(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			node := newOperationNode(t, &hsmtest.NodeBackend{}, mustNewScheduledEvent(time.Now(), &historypb.NexusOperationScheduledEventAttributes{
+				ScheduleToCloseTimeout: durationpb.New(time.Hour),
+			}))
+			op, err := hsm.MachineData[nexusoperations.Operation](node)
+			require.NoError(t, err)
+			eventID, err := hsm.EventIDFromToken(op.ScheduledEventToken)
+			require.NoError(t, err)
+
+			captureHandler := metricstest.NewCaptureHandler()
+			capture := captureHandler.StartCapture()
+			defer captureHandler.StopCapture(capture)
+
+			// Apply via the registered definition (nil hook) — the replication/reset re-apply path.
+			require.NoError(t, tc.def.Apply(node.Parent, tc.makeEvent(eventID)))
+
+			snapshot := capture.Snapshot()
+			require.Empty(t, snapshot[tc.metricName], "terminal counter must not be emitted on re-apply")
+			require.Empty(t, snapshot[chasmnexus.NexusOperationScheduleToCloseLatency.Name()], "latency must not be emitted on re-apply")
+		})
+	}
 }
 
 func TestTerminalStatesDeletion(t *testing.T) {

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -451,19 +451,15 @@ func (e taskExecutor) saveResult(ctx context.Context, env hsm.Environment, ref h
 					Time:       startedTime,
 					Node:       node,
 					Attributes: event.GetNexusOperationStartedEventAttributes(),
+					metrics:    e.callerMetrics(),
 				})
 			}); err != nil {
 				return err
 			}
-			recordScheduleToStartLatency(e.MetricsHandler, e.metricTagConfig(), operation, node.NamespaceName(), node.WorkflowTypeName(), startedTime)
 			return nil
 		}
 		// Operation completed synchronously. Store the result and update the state machine.
-		if err := handleSuccessfulOperationResult(node, operation, result.Successful, links); err != nil {
-			return err
-		}
-		recordOperationSucceeded(e.MetricsHandler, e.metricTagConfig(), operation, node.NamespaceName(), node.WorkflowTypeName(), env.Now())
-		return nil
+		return handleSuccessfulOperationResult(node, operation, result.Successful, links, e.callerMetrics())
 	})
 }
 
@@ -480,17 +476,9 @@ func (e taskExecutor) handleStartOperationError(env hsm.Environment, node *hsm.N
 		}
 		// Fall through all uncaught errors to retryable
 	case errors.As(callErr, &opErr):
-		if err := handleOperationError(node, operation, opErr); err != nil {
-			return err
-		}
-		// Emit the terminal outcome metric at this live, once-only site (handleOperationError also
-		// runs on the async completion path and on replay, so emission must not live inside it).
-		if opErr.State == nexus.OperationStateCanceled {
-			recordOperationCanceled(e.MetricsHandler, e.metricTagConfig(), operation, node.NamespaceName(), node.WorkflowTypeName(), env.Now())
-		} else {
-			recordOperationFailed(e.MetricsHandler, e.metricTagConfig(), operation, node.NamespaceName(), node.WorkflowTypeName(), env.Now())
-		}
-		return nil
+		// TransitionFailed/TransitionCanceled emit the matching outcome themselves; just hand over
+		// the live-path metrics carrier.
+		return handleOperationError(node, operation, opErr, e.callerMetrics())
 	case errors.As(callErr, &handlerErr) && !handlerErr.Retryable():
 		// The StartOperation request got an unexpected response that is not retryable, fail the operation.
 		// Although Failure is nullable, Nexus SDK is expected to always populate this field
@@ -527,7 +515,7 @@ func (e taskExecutor) handleStartOperationError(env hsm.Environment, node *hsm.N
 	})
 }
 
-func handleNonRetryableStartOperationError(node *hsm.Node, operation Operation, callErr error) error {
+func handleNonRetryableStartOperationError(node *hsm.Node, operation Operation, callErr error, cm callerMetrics) error {
 	eventID, err := hsm.EventIDFromToken(operation.ScheduledEventToken)
 	if err != nil {
 		return err
@@ -552,18 +540,14 @@ func handleNonRetryableStartOperationError(node *hsm.Node, operation Operation, 
 		}
 	})
 
-	return FailedEventDefinition{}.Apply(node.Parent, event)
+	return FailedEventDefinition{metrics: cm}.Apply(node.Parent, event)
 }
 
-// failNonRetryable resolves the operation as failed (non-retryable) and emits the terminal
-// failure metric. It wraps handleNonRetryableStartOperationError so emission happens once, at
-// this live processing site, rather than in the event-application path (which also runs on replay).
+// failNonRetryable resolves the operation as failed (non-retryable). TransitionFailed emits the
+// terminal failure metric itself when handed this live-path carrier (the registered/replay event
+// definition leaves it disabled).
 func (e taskExecutor) failNonRetryable(env hsm.Environment, node *hsm.Node, operation Operation, callErr error) error {
-	if err := handleNonRetryableStartOperationError(node, operation, callErr); err != nil {
-		return err
-	}
-	recordOperationFailed(e.MetricsHandler, e.metricTagConfig(), operation, node.NamespaceName(), node.WorkflowTypeName(), env.Now())
-	return nil
+	return handleNonRetryableStartOperationError(node, operation, callErr, e.callerMetrics())
 }
 
 func (e taskExecutor) executeBackoffTask(env hsm.Environment, node *hsm.Node, task BackoffTask) error {
@@ -587,9 +571,8 @@ func (e taskExecutor) executeStartToCloseTimeoutTask(env hsm.Environment, node *
 }
 
 func (e taskExecutor) recordOperationTimeout(env hsm.Environment, node *hsm.Node, timeoutType enumspb.TimeoutType) error {
-	var timedOutOp Operation
-	if err := hsm.MachineTransition(node, func(op Operation) (hsm.TransitionOutput, error) {
-		timedOutOp = op
+	closeTime := env.Now()
+	return hsm.MachineTransition(node, func(op Operation) (hsm.TransitionOutput, error) {
 		eventID, err := hsm.EventIDFromToken(op.ScheduledEventToken)
 		if err != nil {
 			return hsm.TransitionOutput{}, err
@@ -617,15 +600,12 @@ func (e taskExecutor) recordOperationTimeout(env hsm.Environment, node *hsm.Node
 		})
 
 		return TransitionTimedOut.Apply(op, EventTimedOut{
-			Node: node,
+			Node:        node,
+			Time:        closeTime,
+			TimeoutType: timeoutType,
+			metrics:     e.callerMetrics(),
 		})
-	}); err != nil {
-		return err
-	}
-	// timedOutOp was captured from the transition closure above (the same Operation that
-	// MachineData would return); the timeout transition leaves the metric fields unchanged.
-	recordOperationTimedOut(e.MetricsHandler, e.metricTagConfig(), timedOutOp, node.NamespaceName(), node.WorkflowTypeName(), timeoutType.String(), env.Now())
-	return nil
+	})
 }
 
 func (e taskExecutor) executeCancelationTask(ctx context.Context, env hsm.Environment, ref hsm.Ref, task CancelationTask) error {

--- a/components/nexusoperations/metrics.go
+++ b/components/nexusoperations/metrics.go
@@ -14,6 +14,25 @@ func (e taskExecutor) metricTagConfig() chasmnexus.NexusMetricTagConfig {
 	return e.Config.ResolvedMetricTagConfig()
 }
 
+// callerMetrics is injected into a terminal transition so it can emit the caller-side metric from
+// inside the transition. It is populated only on the live executor/completion path; the registered
+// (replay) event definitions leave it zero (enabled() == false), so the transition stays silent and
+// the metric is emitted exactly once even though *EventDefinition.Apply re-runs on replication/reset.
+type callerMetrics struct {
+	handler   metrics.Handler
+	tagConfig chasmnexus.NexusMetricTagConfig
+}
+
+// enabled reports whether metrics should be emitted (true only on the live path).
+func (m callerMetrics) enabled() bool {
+	return m.handler != nil
+}
+
+// callerMetrics returns the live-path metrics carrier for the executor.
+func (e taskExecutor) callerMetrics() callerMetrics {
+	return callerMetrics{handler: e.MetricsHandler, tagConfig: e.metricTagConfig()}
+}
+
 // operationMetricsHandler returns a metrics handler enriched with caller-side Nexus operation
 // tags. It mirrors chasm/lib/nexusoperation Operation.metricsHandler so the HSM and CHASM
 // implementations emit identical metric names and labels (see the HSM->CHASM migration). Unlike

--- a/components/nexusoperations/statemachine.go
+++ b/components/nexusoperations/statemachine.go
@@ -293,6 +293,8 @@ type EventFailed struct {
 	Time       time.Time
 	Node       *hsm.Node
 	Attributes *historypb.NexusOperationFailedEventAttributes
+	// metrics is set only on the live path; the registered (replay) definition leaves it disabled.
+	metrics callerMetrics
 }
 
 var TransitionFailed = hsm.NewTransition(
@@ -306,6 +308,9 @@ var TransitionFailed = hsm.NewTransition(
 		// Not recording the last attempt information here since the state machine will be deleted immediately after this transition.
 		// If we ever use this code for a standalone state machine implementation we will want to record the last
 		// attempt information in case the completion is a result of a synchronous operation.
+		if event.metrics.enabled() {
+			recordOperationFailed(event.metrics.handler, event.metrics.tagConfig, op, event.Node.NamespaceName(), event.Node.WorkflowTypeName(), event.Time)
+		}
 		return op.output()
 	},
 )
@@ -315,6 +320,8 @@ type EventSucceeded struct {
 	// Only set if the operation completed synchronously, as a response to a StartOperation RPC.
 	Time time.Time
 	Node *hsm.Node
+	// metrics is set only on the live path; the registered (replay) definition leaves it disabled.
+	metrics callerMetrics
 }
 
 var TransitionSucceeded = hsm.NewTransition(
@@ -328,6 +335,9 @@ var TransitionSucceeded = hsm.NewTransition(
 		// Not recording the last attempt information here since the state machine will be deleted immediately after this transition.
 		// If we ever use this code for a standalone state machine implementation we will want to record the last
 		// attempt information in case the completion is a result of a synchronous operation.
+		if event.metrics.enabled() {
+			recordOperationSucceeded(event.metrics.handler, event.metrics.tagConfig, op, event.Node.NamespaceName(), event.Node.WorkflowTypeName(), event.Time)
+		}
 		return op.output()
 	},
 )
@@ -336,6 +346,8 @@ var TransitionSucceeded = hsm.NewTransition(
 type EventCanceled struct {
 	Time time.Time
 	Node *hsm.Node
+	// metrics is set only on the live path; the registered (replay) definition leaves it disabled.
+	metrics callerMetrics
 }
 
 var TransitionCanceled = hsm.NewTransition(
@@ -349,6 +361,9 @@ var TransitionCanceled = hsm.NewTransition(
 		// Not recording the last attempt information here since the state machine will be deleted immediately after this transition.
 		// If we ever use this code for a standalone state machine implementation we will want to record the last
 		// attempt information in case the completion is a result of a synchronous operation.
+		if event.metrics.enabled() {
+			recordOperationCanceled(event.metrics.handler, event.metrics.tagConfig, op, event.Node.NamespaceName(), event.Node.WorkflowTypeName(), event.Time)
+		}
 		return op.output()
 	},
 )
@@ -359,6 +374,8 @@ type EventStarted struct {
 	Time       time.Time
 	Node       *hsm.Node
 	Attributes *historypb.NexusOperationStartedEventAttributes
+	// metrics is set only on the live path; the registered (replay) definition leaves it disabled.
+	metrics callerMetrics
 }
 
 var TransitionStarted = hsm.NewTransition(
@@ -374,6 +391,11 @@ var TransitionStarted = hsm.NewTransition(
 		}
 
 		op.StartedTime = timestamppb.New(event.Time)
+
+		// Emit schedule-to-start before the cancelation early-return below so it fires regardless.
+		if event.metrics.enabled() {
+			recordScheduleToStartLatency(event.metrics.handler, event.metrics.tagConfig, op, event.Node.NamespaceName(), event.Node.WorkflowTypeName(), event.Time)
+		}
 
 		// If cancelation is requested already, schedule sending the cancelation request.
 		child, err := op.CancelationNode(event.Node)
@@ -404,6 +426,12 @@ var TransitionStarted = hsm.NewTransition(
 // EventTimedOut is triggered when the schedule-to-close timeout is triggered for an operation.
 type EventTimedOut struct {
 	Node *hsm.Node
+	// Time and TimeoutType are set on the live path for the caller-side metric (close time and the
+	// timeout_type tag); the replay path leaves them zero since metrics is disabled there.
+	Time        time.Time
+	TimeoutType enumspb.TimeoutType
+	// metrics is set only on the live path; the registered (replay) definition leaves it disabled.
+	metrics callerMetrics
 }
 
 var TransitionTimedOut = hsm.NewTransition(
@@ -416,6 +444,9 @@ var TransitionTimedOut = hsm.NewTransition(
 	func(op Operation, event EventTimedOut) (hsm.TransitionOutput, error) {
 		// Keep attempt information as-is for debuggability.
 		// When used in a workflow, this machine node will be deleted from the tree after this transition.
+		if event.metrics.enabled() {
+			recordOperationTimedOut(event.metrics.handler, event.metrics.tagConfig, op, event.Node.NamespaceName(), event.Node.WorkflowTypeName(), event.TimeoutType.String(), event.Time)
+		}
 		return op.output()
 	},
 )


### PR DESCRIPTION
**Spike for comparison — do not merge.** Stacked on `gokhan/nexus-op-caller-metrics` so the diff here is *only* the approach change discussed in https://github.com/temporalio/temporal/pull/10808#discussion_r3463316046.

## What this shows
The alternative to the call-site emission on the main PR: the metrics handler is **injected into the terminal transitions** (started / succeeded / failed / canceled / timed-out), which each emit their own caller-side metric — mirroring how the CHASM implementation sources it.

A `callerMetrics{handler, tagConfig}` carrier is set **only on the live executor/completion path**; the registered event definitions used on the replication/reset re-apply path leave it disabled (`enabled() == false`), so a transition emits exactly once. The carrier rides on the `Event` structs for transitions applied directly (timeout, async start) and on the `EventDefinition` structs for those driven through the shared `*EventDefinition.Apply` (succeeded/failed/canceled). `TestCallerMetricsNotEmittedOnReapply` is the replay-safety evidence — re-applying each terminal event through the registered definition emits nothing.

## Effect on executor/completion (vs the main PR)
Because the transition owns the emit logic, the call sites get noticeably smaller:
- `CompletionHandler.Handle` drops the schedule-to-start block **and** the terminal-outcome `switch` — it just builds one carrier and passes it down.
- `handleStartOperationError`'s `opErr` case and `failNonRetryable` collapse to a single `handleOperationError(..., e.callerMetrics())` / `handleNonRetryableStartOperationError(..., e.callerMetrics())`; the failed-vs-canceled branch is gone (`TransitionFailed`/`TransitionCanceled` each know their outcome).
- `saveResult` sync-success / async-start become one-liners.

## The cost to weigh against the call-site approach
- The carrier has to ride on **both** the `Event` structs and the `EventDefinition` structs, and it relies on the invariant that the *registered* definition instance is the disabled (replay) one.
- It touches every event + transition + definition (the main PR touches only the live sites).

So: emission logic centralizes in the transitions and the call sites shrink, at the cost of threading the carrier through events + definitions. 