### PR TITLE
Add dynamic partition shadow mode logging

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1559,10 +1559,11 @@ default as namespace cardinality can be high and this requires a metrics collect
 	MatchingPartitionScaleManager = NewTaskQueueTypedSetting(
 		"matching.partitionScaleManager",
 		PartitionScaleManagerSettings{
-			MaxRate:            0.33,
-			BatchSize:          100,
-			BackgroundInterval: 23 * time.Second,
-			DrainBufferTime:    15 * time.Second,
+			MaxRate:               0.33,
+			BatchSize:             100,
+			BackgroundInterval:    23 * time.Second,
+			DrainBufferTime:       15 * time.Second,
+			ShadowModeLogInterval: time.Minute,
 		},
 		`Settings for partition scale manager.`,
 	)

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1563,7 +1563,7 @@ default as namespace cardinality can be high and this requires a metrics collect
 			BatchSize:             100,
 			BackgroundInterval:    23 * time.Second,
 			DrainBufferTime:       15 * time.Second,
-			ShadowModeLogInterval: time.Minute,
+			ShadowModeLogInterval: 0,
 		},
 		`Settings for partition scale manager.`,
 	)

--- a/common/dynamicconfig/shared_constants.go
+++ b/common/dynamicconfig/shared_constants.go
@@ -185,6 +185,11 @@ type PartitionScaleManagerSettings struct {
 	// should be set to the maximum time of an AddTask call that may write to a backlog. Note
 	// that query/nexus tasks will be processed without interruption even after scale down.
 	DrainBufferTime time.Duration
+	// ShadowModeLogInterval controls how often shadow decisions are logged. If <= 0, shadow mode
+	// is disabled and enabled scaler decisions are applied normally. If > 0, the configured scaler
+	// is evaluated and logged at that cadence but decisions are not applied. If the partition
+	// scaler is disabled, shadow mode does not log.
+	ShadowModeLogInterval time.Duration
 }
 
 type SimplePartitionScalerSettings struct {

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -71,6 +71,7 @@ const (
 	falseValue                                     = "false"
 	trueValue                                      = "true"
 	errorPrefix                                    = "*"
+	ScalerShadowModeTagName                        = "scaler_shadow_mode"
 
 	queryTypeStackTrace       = "__stack_trace"
 	queryTypeOpenSessions     = "__open_sessions"
@@ -592,4 +593,12 @@ func HeaderCallsiteTag(kind string) Tag {
 
 func TimeoutTypeTag(timeoutType string) Tag {
 	return Tag{Key: timeoutTypeTagName, Value: timeoutType}
+}
+
+func ScalerShadowModeTag(enabled bool) Tag {
+	v := falseValue
+	if enabled {
+		v = trueValue
+	}
+	return Tag{Key: ScalerShadowModeTagName, Value: v}
 }

--- a/common/testing/testlogger/testlogger.go
+++ b/common/testing/testlogger/testlogger.go
@@ -63,7 +63,7 @@ type CleanupCapableT interface {
 	Cleanup(func())
 }
 
-// Expectations represent log calls we expect to happen in tests.
+// Expectation represents a log call we expect to happen in tests.
 // For error-level logs, expectations also influence whether the log fails the
 // test based on the logger mode.
 type Expectation struct {

--- a/common/testing/testlogger/testlogger.go
+++ b/common/testing/testlogger/testlogger.go
@@ -63,19 +63,28 @@ type CleanupCapableT interface {
 	Cleanup(func())
 }
 
-// Expectations represent errors we expect to happen in tests.
-// Their only purpose is to allow un-expecting (hah!) an error we've
-// marked as expected
+// Expectations represent log calls we expect to happen in tests.
+// For error-level logs, expectations also influence whether the log fails the
+// test based on the logger mode.
 type Expectation struct {
 	e          *list.Element
 	testLogger *TestLogger
 	lvl        Level
+	matches    atomic.Int64
 }
 
 // Forget removes a previously registered expectation.
-// A forgotten expectation will no longer be evaluated when errors are encountered.
+// A forgotten expectation will no longer be evaluated when logs are encountered.
 func (e *Expectation) Forget() {
 	e.testLogger.Forget(e)
+}
+
+func (e *Expectation) Matched() bool {
+	return e.MatchCount() > 0
+}
+
+func (e *Expectation) MatchCount() int64 {
+	return e.matches.Load()
 }
 
 type matcher struct {
@@ -319,9 +328,10 @@ func NewTestLogger(t TestingT, mode Mode, opts ...LoggerOption) *TestLogger {
 	return tl
 }
 
-// Expect instructs the logger to expect certain errors, as specified by the msg and tag arguments.
-// Depending on the Mode of the test logger, the expectation either acts as an entry in a
-// blocklist (FailOnExpectedErrorOnly) or an allowlist (FailOnAnyUnexpectedError).
+// Expect instructs the logger to track matching log calls, as specified by the
+// level, msg, and tag arguments. For error-level logs, depending on the Mode of
+// the test logger, the expectation either acts as an entry in a blocklist
+// (FailOnExpectedErrorOnly) or an allowlist (FailOnAnyUnexpectedError).
 func (tl *TestLogger) Expect(level Level, msg string, tags ...tag.Tag) *Expectation {
 	tl.state.mu.Lock()
 	defer tl.state.mu.Unlock()
@@ -343,7 +353,7 @@ func (tl *TestLogger) Expect(level Level, msg string, tags ...tag.Tag) *Expectat
 }
 
 // Forget removes a previously registered expectation.
-// A forgotten expectation will no longer be evaluated when errors are encountered.
+// A forgotten expectation will no longer be evaluated when logs are encountered.
 func (tl *TestLogger) Forget(e *Expectation) {
 	tl.state.mu.Lock()
 	defer tl.state.mu.Unlock()
@@ -368,6 +378,26 @@ func (tl *TestLogger) shouldFailTest(level Level, msg string, tags []tag.Tag) bo
 		return false
 	}
 	return tl.state.mode == FailOnAnyUnexpectedError
+}
+
+// recordExpectationMatches increments the match counter of every expectation
+// registered at the given level whose matcher matches this log call. It is purely
+// observational: it never affects whether the test fails (that remains the sole
+// job of shouldFailTest), so it is safe to call for any log at any level.
+func (tl *TestLogger) recordExpectationMatches(level Level, msg string, tags []tag.Tag) {
+	expectations, found := tl.state.mu.expectations[level]
+	if !found {
+		return
+	}
+	for e := expectations.Front(); e != nil; e = e.Next() {
+		m, ok := e.Value.(matcher)
+		if !ok {
+			tl.state.t.Fatalf("Bug in TestLogger: invalid %T value in matcher list", e.Value)
+		}
+		if m.Matches(msg, tags) {
+			m.expectation.matches.Add(1)
+		}
+	}
 }
 
 // FailOnDPanic overrides the behavior of this logger. It returns the previous value
@@ -443,6 +473,7 @@ func (tl *TestLogger) DPanic(msg string, tags ...tag.Tag) {
 		return
 	}
 	tags = tl.mergeWithLoggerTags(tags)
+	tl.recordExpectationMatches(DPanic, msg, tags)
 	// note, actual panic'ing in wrapped is turned off so we can control.
 	tl.wrapped.DPanic(msg, tags...)
 	if tl.state.failOnDPanic.Load() && tl.shouldFailTest(DPanic, msg, tags) {
@@ -458,7 +489,9 @@ func (tl *TestLogger) Debug(msg string, tags ...tag.Tag) {
 	if tl.state.mu.closed {
 		return
 	}
-	tl.wrapped.Debug(msg, tl.mergeWithLoggerTags(tags)...)
+	tags = tl.mergeWithLoggerTags(tags)
+	tl.recordExpectationMatches(Debug, msg, tags)
+	tl.wrapped.Debug(msg, tags...)
 }
 
 // Error implements log.Logger.
@@ -469,6 +502,7 @@ func (tl *TestLogger) Error(msg string, tags ...tag.Tag) {
 		return
 	}
 	tags = tl.mergeWithLoggerTags(tags)
+	tl.recordExpectationMatches(Error, msg, tags)
 	if !tl.shouldFailTest(Error, msg, tags) {
 		tl.wrapped.Error(msg, tags...)
 		tl.state.mu.RUnlock()
@@ -494,6 +528,7 @@ func (tl *TestLogger) Fatal(msg string, tags ...tag.Tag) {
 		return
 	}
 	tags = tl.mergeWithLoggerTags(tags)
+	tl.recordExpectationMatches(Fatal, msg, tags)
 	tl.state.t.Helper()
 	if tl.state.failOnFatal.Load() && tl.shouldFailTest(Fatal, msg, tags) {
 		tl.failTest(Fatal, msg, tags...)
@@ -515,7 +550,9 @@ func (tl *TestLogger) Info(msg string, tags ...tag.Tag) {
 	if tl.state.mu.closed {
 		return
 	}
-	tl.wrapped.Info(msg, tl.mergeWithLoggerTags(tags)...)
+	tags = tl.mergeWithLoggerTags(tags)
+	tl.recordExpectationMatches(Info, msg, tags)
+	tl.wrapped.Info(msg, tags...)
 }
 
 // Panic implements log.Logger.
@@ -526,6 +563,7 @@ func (tl *TestLogger) Panic(msg string, tags ...tag.Tag) {
 		return
 	}
 	tags = tl.mergeWithLoggerTags(tags)
+	tl.recordExpectationMatches(Panic, msg, tags)
 	tl.state.t.Helper()
 	// Forcibly fail the test when required as otherwise panics can be caught.
 	if tl.shouldFailTest(Panic, msg, tags) {
@@ -542,7 +580,9 @@ func (tl *TestLogger) Warn(msg string, tags ...tag.Tag) {
 	if tl.state.mu.closed {
 		return
 	}
-	tl.wrapped.Warn(msg, tl.mergeWithLoggerTags(tags)...)
+	tags = tl.mergeWithLoggerTags(tags)
+	tl.recordExpectationMatches(Warn, msg, tags)
+	tl.wrapped.Warn(msg, tags...)
 }
 
 // failTest fails the test while dumping the stack, allowing us to know where in the code

--- a/common/testing/testlogger/testlogger_test.go
+++ b/common/testing/testlogger/testlogger_test.go
@@ -92,6 +92,24 @@ func TestTestLogger_ExpectationsMatch(t *testing.T) {
 
 }
 
+func TestTestLogger_InfoExpectationMatchCount(t *testing.T) {
+	tl := testlogger.NewTestLogger(t, testlogger.FailOnAnyUnexpectedError)
+	expected := tl.Expect(testlogger.Info, "expected info", tag.String("key", "value"))
+	require.False(t, expected.Matched())
+	require.Zero(t, expected.MatchCount())
+
+	tl.Info("expected info", tag.String("key", "other"))
+	require.False(t, expected.Matched())
+	require.Zero(t, expected.MatchCount())
+
+	tl.Info("expected info", tag.String("key", "value"))
+	require.True(t, expected.Matched())
+	require.Equal(t, int64(1), expected.MatchCount())
+
+	tl.Info("expected info", tag.String("key", "value"))
+	require.Equal(t, int64(2), expected.MatchCount())
+}
+
 func assertFails(t *testing.T, level testlogger.Level, msg string, tags []tag.Tag) {
 	mt := &mockT{T: t}
 	tl := testlogger.NewTestLogger(mt, testlogger.FailOnAnyUnexpectedError)

--- a/service/matching/scale_manager.go
+++ b/service/matching/scale_manager.go
@@ -267,11 +267,11 @@ func (sm *scaleManager) callScaler() {
 			return
 		}
 
-		cooldown := time.Duration(float32(time.Second) / sm.settings().MaxRate)
-		sm.nextDecision = sm.timeSource.Now().Add(cooldown)
-
 		sm.setState(newState)
 	}
+
+	cooldown := time.Duration(float32(time.Second) / sm.settings().MaxRate)
+	sm.nextDecision = sm.timeSource.Now().Add(cooldown)
 
 	sm.logger.Info("new target",
 		tag.Int32("target", target),

--- a/service/matching/scale_manager.go
+++ b/service/matching/scale_manager.go
@@ -355,8 +355,10 @@ func (sm *scaleManager) updateDrainState(ctx context.Context) {
 		return
 	}
 
-	// If shadow mode observes an existing managed scale state, do not persist
-	// drain completion or mutate read partitions.
+	// Reachable only in the brief window after shadow mode is enabled but before
+	// releaseManagedState has zeroed a leftover target>0 (callScaler is still in
+	// cooldown). Shadow mode must not persist drain completion or mutate read
+	// partitions, so bail before applying toClear.
 	if settings.ShadowModeLogInterval > 0 {
 		return
 	}

--- a/service/matching/scale_manager.go
+++ b/service/matching/scale_manager.go
@@ -46,12 +46,54 @@ type scaleManager struct {
 	background         *goro.Handle
 
 	// owned by the worker goroutine after Start starts it
-	scaleState   *persistencespb.PartitionScaleState
-	scaleDB      scaleDB
-	nextDecision time.Time
+	scaleState          *persistencespb.PartitionScaleState
+	scaleDB             scaleDB
+	nextDecision        time.Time
+	nextShadowScaleLog  time.Time
+	nextShadowDrainLog  time.Time
+	prevShadowScaleInfo scaleLogInfo
+	prevShadowDrainInfo drainLogInfo
 
 	batch  atomic.Int64
 	wakeup chan struct{}
+}
+
+type scaleLogInfo struct {
+	target     int32
+	prevTarget int32
+	maxTarget  int32
+}
+
+func (i scaleLogInfo) Equal(other scaleLogInfo) bool {
+	return i.target == other.target &&
+		i.prevTarget == other.prevTarget &&
+		i.maxTarget == other.maxTarget
+}
+
+type drainLogInfo struct {
+	target            int32
+	read              int32
+	prevRead          int32
+	drainedPartitions []int32
+}
+
+func (i drainLogInfo) Equal(other drainLogInfo) bool {
+	return i.target == other.target &&
+		i.read == other.read &&
+		i.prevRead == other.prevRead &&
+		drainedEqual(i.drainedPartitions, other.drainedPartitions)
+}
+
+func drainedEqual(a, b []int32) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // scaleDB is used to write scale state to persistence. It's a sub-interface of
@@ -201,22 +243,51 @@ func (sm *scaleManager) callScaler() {
 		newState.BacklogState = bitSet(newState.BacklogState).set(i)
 	}
 
-	// we must succesfully write to the db before making new state active
-	if err := sm.scaleDB.UpdateScaleState(newState, true); err != nil {
-		sm.logger.Error("failed to update state", tag.Error(err), tag.Operation("scale"))
-		return
+	logInfo := scaleLogInfo{
+		target:     target,
+		prevTarget: prevTarget,
+		maxTarget:  newState.MaxTarget,
 	}
+	shadowMode := sm.shadowModeEnabled()
+	if shadowMode {
+		if sm.timeSource.Now().Before(sm.nextShadowScaleLog) || // too early
+			sm.prevShadowScaleInfo.Equal(logInfo) || // only log new changes
+			!sm.scalerIsDynamic(target) { // only log dynamic scale targets
+			// emit metric as a heartbeat even if no shadow log
+			metrics.PartitionScaleEvents.With(sm.metricsHandler.
+				WithTags(metrics.ScalerShadowModeTag(shadowMode))).Record(1)
+			return
+		}
+		sm.nextShadowScaleLog = sm.timeSource.Now().Add(sm.settings().ShadowModeLogInterval)
+		sm.prevShadowScaleInfo = logInfo
+	} else {
+		// we must successfully write to the db before making new state active
+		if err := sm.scaleDB.UpdateScaleState(newState, true); err != nil {
+			sm.logger.Error("failed to update state", tag.Error(err), tag.Operation("scale"))
+			return
+		}
 
-	cooldown := time.Duration(float32(time.Second) / sm.settings().MaxRate)
-	sm.nextDecision = sm.timeSource.Now().Add(cooldown)
+		cooldown := time.Duration(float32(time.Second) / sm.settings().MaxRate)
+		sm.nextDecision = sm.timeSource.Now().Add(cooldown)
+
+		sm.setState(newState)
+	}
 
 	sm.logger.Info("new target",
 		tag.Int32("target", target),
 		tag.Int32("prev-target", prevTarget),
-		tag.Int32("max-target", newState.MaxTarget))
-	metrics.PartitionScaleEvents.With(sm.metricsHandler).Record(1)
+		tag.Int32("max-target", newState.MaxTarget),
+		tag.Bool(metrics.ScalerShadowModeTagName, shadowMode))
+	metrics.PartitionScaleEvents.With(sm.metricsHandler.
+		WithTags(metrics.ScalerShadowModeTag(shadowMode))).Record(1)
+}
 
-	sm.setState(newState)
+func (sm *scaleManager) shadowModeEnabled() bool {
+	return sm.settings().ShadowModeLogInterval > 0
+}
+
+func (sm *scaleManager) scalerIsDynamic(target int32) bool {
+	return target > 0
 }
 
 // setState updates the current scale state and syncs it to ephemeral data.
@@ -303,19 +374,37 @@ func (sm *scaleManager) updateDrainState(ctx context.Context) {
 		newState.BacklogState = bitSet(newState.BacklogState).clear(i)
 	}
 
-	// sync to db (must be persisted before taking effect)
-	if err := sm.scaleDB.UpdateScaleState(newState, true); err != nil {
-		sm.logger.Error("failed to update state", tag.Error(err), tag.Operation("drain"))
-		return
+	logInfo := drainLogInfo{
+		target:            info.Write,
+		read:              bitSet(newState.BacklogState).len(),
+		prevRead:          info.Read,
+		drainedPartitions: toClear,
+	}
+	shadowMode := sm.shadowModeEnabled()
+	if shadowMode {
+		if sm.timeSource.Now().Before(sm.nextShadowDrainLog) || // too early
+			sm.prevShadowDrainInfo.Equal(logInfo) || // only log new changes
+			len(toClear) == 0 { // only log if partitions were cleared
+			return
+		}
+		sm.nextShadowDrainLog = sm.timeSource.Now().Add(sm.settings().ShadowModeLogInterval)
+		sm.prevShadowDrainInfo = logInfo
+	} else {
+		// sync to db (must be persisted before taking effect)
+		if err := sm.scaleDB.UpdateScaleState(newState, true); err != nil {
+			sm.logger.Error("failed to update state", tag.Error(err), tag.Operation("drain"))
+			return
+		}
+
+		sm.setState(newState)
 	}
 
 	sm.logger.Info("drain",
-		tag.Any("drained-partitions", toClear),
-		tag.Int32("target", info.Write),
-		tag.Int32("prev-read", info.Read),
-		tag.Int32("read", bitSet(newState.BacklogState).len()))
-
-	sm.setState(newState)
+		tag.Any("drained-partitions", logInfo.drainedPartitions),
+		tag.Int32("target", logInfo.target),
+		tag.Int32("prev-read", logInfo.prevRead),
+		tag.Int32("read", logInfo.read),
+		tag.Bool(metrics.ScalerShadowModeTagName, shadowMode))
 }
 
 func partitionIsFullyDrained(

--- a/service/matching/scale_manager.go
+++ b/service/matching/scale_manager.go
@@ -168,6 +168,20 @@ func (sm *scaleManager) callScaler() {
 		return
 	}
 
+	settings := sm.settings()
+	shadowMode := settings.ShadowModeLogInterval > 0
+
+	// Entering shadow mode on top of a previously-applied managed target releases
+	// control back to the dynamic-config baseline: zero the managed target once so
+	// the write side follows dynamic config again (and tracks future config
+	// changes), and cold-start the shadow simulation from the baseline. BacklogState
+	// is preserved, so read partitions are not dropped here (reclaiming them is left
+	// to the drain path). This is the only state shadow mode writes; it still never
+	// applies the scaler's hypothetical decisions.
+	if shadowMode && sm.scaleState.GetTarget() != 0 {
+		sm.releaseManagedState()
+	}
+
 	// grab current batch (may be zero)
 	tasks := int(sm.batch.Swap(0))
 
@@ -203,8 +217,6 @@ func (sm *scaleManager) callScaler() {
 		newState.BacklogState = bitSet(newState.BacklogState).set(i)
 	}
 
-	settings := sm.settings()
-	shadowMode := settings.ShadowModeLogInterval > 0
 	if shadowMode {
 		if sm.timeSource.Now().Before(sm.nextShadowLog) || // too early
 			sm.prevShadowTarget == target || // only log new changes
@@ -236,6 +248,34 @@ func (sm *scaleManager) callScaler() {
 		tag.Bool(metrics.ScalerShadowModeTagName, shadowMode))
 	metrics.PartitionScaleEvents.With(sm.metricsHandler.
 		WithTags(metrics.ScalerShadowModeTag(shadowMode))).Record(1)
+}
+
+// releaseManagedState relinquishes a previously-applied managed scale target back
+// to the dynamic-config baseline by zeroing Target and PrivateScalerState. With
+// Target == 0 the write side falls back to dynamic config (PartitionScaleInfo.Write
+// is 0), and the scaler simulates from a cold start on subsequent calls.
+// BacklogState is preserved, so read partitions are unchanged until drained.
+// Called from callScaler only, in shadow mode, once, when a managed target exists.
+func (sm *scaleManager) releaseManagedState() {
+	newState := common.CloneProto(sm.scaleState)
+	if newState == nil {
+		return
+	}
+	prevTarget := newState.Target
+	newState.Target = 0
+	newState.PrivateScalerState = nil
+	newState.TargetVersion = sm.timeSource.Now().UnixNano()
+
+	// we must successfully write to the db before making new state active
+	if err := sm.scaleDB.UpdateScaleState(newState, true); err != nil {
+		sm.logger.Error("failed to update state", tag.Error(err), tag.Operation("release"))
+		return
+	}
+	sm.setState(newState)
+
+	sm.logger.Info("released managed scale state to baseline",
+		tag.Int32("prev-target", prevTarget),
+		tag.Bool(metrics.ScalerShadowModeTagName, true))
 }
 
 // setState updates the current scale state and syncs it to ephemeral data.

--- a/service/matching/scale_manager.go
+++ b/service/matching/scale_manager.go
@@ -46,54 +46,14 @@ type scaleManager struct {
 	background         *goro.Handle
 
 	// owned by the worker goroutine after Start starts it
-	scaleState          *persistencespb.PartitionScaleState
-	scaleDB             scaleDB
-	nextDecision        time.Time
-	nextShadowScaleLog  time.Time
-	nextShadowDrainLog  time.Time
-	prevShadowScaleInfo scaleLogInfo
-	prevShadowDrainInfo drainLogInfo
+	scaleState       *persistencespb.PartitionScaleState
+	scaleDB          scaleDB
+	nextDecision     time.Time
+	nextShadowLog    time.Time
+	prevShadowTarget int32
 
 	batch  atomic.Int64
 	wakeup chan struct{}
-}
-
-type scaleLogInfo struct {
-	target     int32
-	prevTarget int32
-	maxTarget  int32
-}
-
-func (i scaleLogInfo) Equal(other scaleLogInfo) bool {
-	return i.target == other.target &&
-		i.prevTarget == other.prevTarget &&
-		i.maxTarget == other.maxTarget
-}
-
-type drainLogInfo struct {
-	target            int32
-	read              int32
-	prevRead          int32
-	drainedPartitions []int32
-}
-
-func (i drainLogInfo) Equal(other drainLogInfo) bool {
-	return i.target == other.target &&
-		i.read == other.read &&
-		i.prevRead == other.prevRead &&
-		drainedEqual(i.drainedPartitions, other.drainedPartitions)
-}
-
-func drainedEqual(a, b []int32) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }
 
 // scaleDB is used to write scale state to persistence. It's a sub-interface of
@@ -243,24 +203,19 @@ func (sm *scaleManager) callScaler() {
 		newState.BacklogState = bitSet(newState.BacklogState).set(i)
 	}
 
-	logInfo := scaleLogInfo{
-		target:     target,
-		prevTarget: prevTarget,
-		maxTarget:  newState.MaxTarget,
-	}
 	settings := sm.settings()
-	shadowMode := sm.shadowModeEnabled(settings)
+	shadowMode := settings.ShadowModeLogInterval > 0
 	if shadowMode {
-		if sm.timeSource.Now().Before(sm.nextShadowScaleLog) || // too early
-			sm.prevShadowScaleInfo.Equal(logInfo) || // only log new changes
-			!sm.scalerIsDynamic(target) { // only log dynamic scale targets
-			// emit metric as a heartbeat even if no shadow log
+		if sm.timeSource.Now().Before(sm.nextShadowLog) || // too early
+			sm.prevShadowTarget == target || // only log new changes
+			target <= 0 { // only log if scaler is enabled
+			// emit scale event metric as a heartbeat even if no shadow log
 			metrics.PartitionScaleEvents.With(sm.metricsHandler.
 				WithTags(metrics.ScalerShadowModeTag(shadowMode))).Record(1)
 			return
 		}
-		sm.nextShadowScaleLog = sm.timeSource.Now().Add(settings.ShadowModeLogInterval)
-		sm.prevShadowScaleInfo = logInfo
+		sm.nextShadowLog = sm.timeSource.Now().Add(settings.ShadowModeLogInterval)
+		sm.prevShadowTarget = target
 	} else {
 		// we must successfully write to the db before making new state active
 		if err := sm.scaleDB.UpdateScaleState(newState, true); err != nil {
@@ -281,14 +236,6 @@ func (sm *scaleManager) callScaler() {
 		tag.Bool(metrics.ScalerShadowModeTagName, shadowMode))
 	metrics.PartitionScaleEvents.With(sm.metricsHandler.
 		WithTags(metrics.ScalerShadowModeTag(shadowMode))).Record(1)
-}
-
-func (sm *scaleManager) shadowModeEnabled(settings dynamicconfig.PartitionScaleManagerSettings) bool {
-	return settings.ShadowModeLogInterval > 0
-}
-
-func (sm *scaleManager) scalerIsDynamic(target int32) bool {
-	return target > 0
 }
 
 // setState updates the current scale state and syncs it to ephemeral data.
@@ -337,9 +284,10 @@ func (sm *scaleManager) updateDrainState(ctx context.Context) {
 	}
 
 	// check if we should evaluate drain state
+	settings := sm.settings()
 	target := scaleState.GetTarget()
 	checkDrain := target > 0 &&
-		sm.timeSource.Since(time.Unix(0, scaleState.GetTargetVersion())) >= sm.settings().DrainBufferTime
+		sm.timeSource.Since(time.Unix(0, scaleState.GetTargetVersion())) >= settings.DrainBufferTime
 	info := scaleStateToInfo(scaleState)
 	var toClear []int32
 
@@ -367,6 +315,12 @@ func (sm *scaleManager) updateDrainState(ctx context.Context) {
 		return
 	}
 
+	// If shadow mode observes an existing managed scale state, do not persist
+	// drain completion or mutate read partitions.
+	if settings.ShadowModeLogInterval > 0 {
+		return
+	}
+
 	newState := common.CloneProto(scaleState)
 	if newState == nil {
 		newState = &persistencespb.PartitionScaleState{}
@@ -375,38 +329,19 @@ func (sm *scaleManager) updateDrainState(ctx context.Context) {
 		newState.BacklogState = bitSet(newState.BacklogState).clear(i)
 	}
 
-	logInfo := drainLogInfo{
-		target:            info.Write,
-		read:              bitSet(newState.BacklogState).len(),
-		prevRead:          info.Read,
-		drainedPartitions: toClear,
-	}
-	settings := sm.settings()
-	shadowMode := sm.shadowModeEnabled(settings)
-	if shadowMode {
-		if sm.timeSource.Now().Before(sm.nextShadowDrainLog) || // too early
-			sm.prevShadowDrainInfo.Equal(logInfo) || // only log new changes
-			len(toClear) == 0 { // only log if partitions were cleared
-			return
-		}
-		sm.nextShadowDrainLog = sm.timeSource.Now().Add(settings.ShadowModeLogInterval)
-		sm.prevShadowDrainInfo = logInfo
-	} else {
-		// sync to db (must be persisted before taking effect)
-		if err := sm.scaleDB.UpdateScaleState(newState, true); err != nil {
-			sm.logger.Error("failed to update state", tag.Error(err), tag.Operation("drain"))
-			return
-		}
-
-		sm.setState(newState)
+	// sync to db (must be persisted before taking effect)
+	if err := sm.scaleDB.UpdateScaleState(newState, true); err != nil {
+		sm.logger.Error("failed to update state", tag.Error(err), tag.Operation("drain"))
+		return
 	}
 
 	sm.logger.Info("drain",
-		tag.Any("drained-partitions", logInfo.drainedPartitions),
-		tag.Int32("target", logInfo.target),
-		tag.Int32("prev-read", logInfo.prevRead),
-		tag.Int32("read", logInfo.read),
-		tag.Bool(metrics.ScalerShadowModeTagName, shadowMode))
+		tag.Any("drained-partitions", toClear),
+		tag.Int32("target", info.Write),
+		tag.Int32("prev-read", info.Read),
+		tag.Int32("read", bitSet(newState.BacklogState).len()))
+
+	sm.setState(newState)
 }
 
 func partitionIsFullyDrained(

--- a/service/matching/scale_manager.go
+++ b/service/matching/scale_manager.go
@@ -248,7 +248,8 @@ func (sm *scaleManager) callScaler() {
 		prevTarget: prevTarget,
 		maxTarget:  newState.MaxTarget,
 	}
-	shadowMode := sm.shadowModeEnabled()
+	settings := sm.settings()
+	shadowMode := sm.shadowModeEnabled(settings)
 	if shadowMode {
 		if sm.timeSource.Now().Before(sm.nextShadowScaleLog) || // too early
 			sm.prevShadowScaleInfo.Equal(logInfo) || // only log new changes
@@ -258,7 +259,7 @@ func (sm *scaleManager) callScaler() {
 				WithTags(metrics.ScalerShadowModeTag(shadowMode))).Record(1)
 			return
 		}
-		sm.nextShadowScaleLog = sm.timeSource.Now().Add(sm.settings().ShadowModeLogInterval)
+		sm.nextShadowScaleLog = sm.timeSource.Now().Add(settings.ShadowModeLogInterval)
 		sm.prevShadowScaleInfo = logInfo
 	} else {
 		// we must successfully write to the db before making new state active
@@ -270,7 +271,7 @@ func (sm *scaleManager) callScaler() {
 		sm.setState(newState)
 	}
 
-	cooldown := time.Duration(float32(time.Second) / sm.settings().MaxRate)
+	cooldown := time.Duration(float32(time.Second) / settings.MaxRate)
 	sm.nextDecision = sm.timeSource.Now().Add(cooldown)
 
 	sm.logger.Info("new target",
@@ -282,8 +283,8 @@ func (sm *scaleManager) callScaler() {
 		WithTags(metrics.ScalerShadowModeTag(shadowMode))).Record(1)
 }
 
-func (sm *scaleManager) shadowModeEnabled() bool {
-	return sm.settings().ShadowModeLogInterval > 0
+func (sm *scaleManager) shadowModeEnabled(settings dynamicconfig.PartitionScaleManagerSettings) bool {
+	return settings.ShadowModeLogInterval > 0
 }
 
 func (sm *scaleManager) scalerIsDynamic(target int32) bool {
@@ -380,14 +381,15 @@ func (sm *scaleManager) updateDrainState(ctx context.Context) {
 		prevRead:          info.Read,
 		drainedPartitions: toClear,
 	}
-	shadowMode := sm.shadowModeEnabled()
+	settings := sm.settings()
+	shadowMode := sm.shadowModeEnabled(settings)
 	if shadowMode {
 		if sm.timeSource.Now().Before(sm.nextShadowDrainLog) || // too early
 			sm.prevShadowDrainInfo.Equal(logInfo) || // only log new changes
 			len(toClear) == 0 { // only log if partitions were cleared
 			return
 		}
-		sm.nextShadowDrainLog = sm.timeSource.Now().Add(sm.settings().ShadowModeLogInterval)
+		sm.nextShadowDrainLog = sm.timeSource.Now().Add(settings.ShadowModeLogInterval)
 		sm.prevShadowDrainInfo = logInfo
 	} else {
 		// sync to db (must be persisted before taking effect)

--- a/service/matching/scale_manager_test.go
+++ b/service/matching/scale_manager_test.go
@@ -292,9 +292,9 @@ func (s *ScaleManagerSuite) TestShadowDecisionDoesNotPersistOrPush() {
 	s.Equal(int32(1), s.sm.scaleState.GetTarget())
 }
 
-// TestShadowModeUsesRealStateOnEveryCall verifies that shadow mode does not feed
-// hypothetical target or private state back into later scaler calls.
-func (s *ScaleManagerSuite) TestShadowModeUsesRealStateOnEveryCall() {
+// TestShadowModeUsesRealStateOnEveryScalerCall verifies that shadow mode does
+// not feed hypothetical target or private state back into later scaler calls.
+func (s *ScaleManagerSuite) TestShadowModeUsesRealStateOnEveryScalerCall() {
 	s.settings.ShadowModeLogInterval = time.Minute
 	realPriv := protoutils.MarshalAny(s.T(), wrapperspb.String("real-state"))
 	priv1 := protoutils.MarshalAny(s.T(), wrapperspb.String("shadow-decision-1"))
@@ -319,6 +319,7 @@ func (s *ScaleManagerSuite) TestShadowModeUsesRealStateOnEveryCall() {
 	s.Equal(1, in1.CurrentTarget)
 	s.ProtoEqual(realPriv, in1.PrivateState)
 
+	s.timeSource.Advance(110 * time.Millisecond) // past the 100ms cooldown
 	s.sm.AddedTasks(1)
 	in2 := waitRecv(s, inputs, "second shadow call missing")
 	s.Equal(1, in2.CurrentTarget)
@@ -370,6 +371,10 @@ func (s *ScaleManagerSuite) TestShadowLoggingCadence() {
 	waitRecv(s, inputs, "first shadow call missing")
 	waitRecv(s, logger.shadowLogs, "first shadow log missing")
 
+	s.sm.AddedTasks(1)
+	assertNoRecv(s, inputs, 30*time.Millisecond, "shadow scaler called inside cooldown")
+
+	s.timeSource.Advance(110 * time.Millisecond) // past the 100ms cooldown
 	s.sm.AddedTasks(1)
 	waitRecv(s, inputs, "second shadow call missing")
 	assertNoRecv(s, logger.shadowLogs, 30*time.Millisecond, "shadow log repeated before cadence")

--- a/service/matching/scale_manager_test.go
+++ b/service/matching/scale_manager_test.go
@@ -17,11 +17,11 @@ import (
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
-	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/common/testing/protoutils"
+	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/common/tqid"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
@@ -137,28 +137,20 @@ func assertNoRecv[T any](s *ScaleManagerSuite, ch <-chan T, d time.Duration, msg
 	}
 }
 
-type recordingLogger struct {
-	shadowLogs chan struct{}
+func waitLogMatches(s *ScaleManagerSuite, e *testlogger.Expectation, count int64, msg string) {
+	s.T().Helper()
+	await.RequireTruef(s.T(), func() bool { return e.MatchCount() == count },
+		time.Second, time.Millisecond, "%s", msg)
 }
 
-func (l *recordingLogger) Debug(string, ...tag.Tag) {}
-func (l *recordingLogger) Info(msg string, _ ...tag.Tag) {
-	if msg != "new target" {
-		return
-	}
-	select {
-	case l.shadowLogs <- struct{}{}:
-	default:
-	}
-}
-func (l *recordingLogger) Warn(string, ...tag.Tag)   {}
-func (l *recordingLogger) Error(string, ...tag.Tag)  {}
-func (l *recordingLogger) DPanic(string, ...tag.Tag) {}
-func (l *recordingLogger) Panic(msg string, _ ...tag.Tag) {
-	panic(msg)
-}
-func (l *recordingLogger) Fatal(msg string, _ ...tag.Tag) {
-	panic(msg)
+// assertNoNewLogs asserts that no new matching log is emitted during d, i.e. the
+// expectation's match count stays at whatever it is when this is called. Unlike a
+// fixed expected count, this is robust to how many matches happened earlier in the test.
+func assertNoNewLogs(s *ScaleManagerSuite, e *testlogger.Expectation, d time.Duration, msg string) {
+	s.T().Helper()
+	before := e.MatchCount()
+	s.Require().Never(func() bool { return e.MatchCount() != before },
+		d, time.Millisecond, msg)
 }
 
 // --- tests ---
@@ -330,7 +322,8 @@ func (s *ScaleManagerSuite) TestShadowModeUsesRealStateOnEveryScalerCall() {
 func (s *ScaleManagerSuite) TestShadowModeDoesNotLogNoChange() {
 	s.settings.ShadowModeLogInterval = time.Minute
 
-	logger := &recordingLogger{shadowLogs: make(chan struct{}, 1)}
+	logger := testlogger.NewTestLogger(s.T(), testlogger.FailOnAnyUnexpectedError)
+	shadowLog := logger.Expect(testlogger.Info, "new target")
 	inputs := make(chan PartitionScalerInput, 1)
 	s.scaler.EXPECT().OnTasks(gomock.Any()).
 		Do(func(in PartitionScalerInput) { inputs <- in }).
@@ -340,7 +333,7 @@ func (s *ScaleManagerSuite) TestShadowModeDoesNotLogNoChange() {
 
 	s.sm.AddedTasks(1)
 	waitRecv(s, inputs, "shadow scaler call missing")
-	assertNoRecv(s, logger.shadowLogs, 30*time.Millisecond, "NoChange decision should not log")
+	assertNoNewLogs(s, shadowLog, 30*time.Millisecond, "NoChange decision should not log")
 }
 
 // TestShadowLoggingCadence verifies that shadow decisions are logged no more
@@ -348,7 +341,8 @@ func (s *ScaleManagerSuite) TestShadowModeDoesNotLogNoChange() {
 func (s *ScaleManagerSuite) TestShadowLoggingCadence() {
 	s.settings.ShadowModeLogInterval = time.Minute
 
-	logger := &recordingLogger{shadowLogs: make(chan struct{}, 4)}
+	logger := testlogger.NewTestLogger(s.T(), testlogger.FailOnAnyUnexpectedError)
+	shadowLog := logger.Expect(testlogger.Info, "new target")
 	inputs := make(chan PartitionScalerInput, 4)
 	gomock.InOrder(
 		s.scaler.EXPECT().OnTasks(gomock.Any()).
@@ -369,7 +363,7 @@ func (s *ScaleManagerSuite) TestShadowLoggingCadence() {
 
 	s.sm.AddedTasks(1)
 	waitRecv(s, inputs, "first shadow call missing")
-	waitRecv(s, logger.shadowLogs, "first shadow log missing")
+	waitLogMatches(s, shadowLog, 1, "first shadow log missing")
 
 	s.sm.AddedTasks(1)
 	assertNoRecv(s, inputs, 30*time.Millisecond, "shadow scaler called inside cooldown")
@@ -377,22 +371,23 @@ func (s *ScaleManagerSuite) TestShadowLoggingCadence() {
 	s.timeSource.Advance(110 * time.Millisecond) // past the 100ms cooldown
 	s.sm.AddedTasks(1)
 	waitRecv(s, inputs, "second shadow call missing")
-	assertNoRecv(s, logger.shadowLogs, 30*time.Millisecond, "shadow log repeated before cadence")
+	assertNoNewLogs(s, shadowLog, 30*time.Millisecond, "shadow log repeated before cadence")
 
 	s.timeSource.Advance(time.Minute)
 	s.sm.AddedTasks(1)
 	waitRecv(s, inputs, "third shadow call missing")
-	assertNoRecv(s, logger.shadowLogs, 30*time.Millisecond, "unchanged shadow decision logged after cadence")
+	assertNoNewLogs(s, shadowLog, 30*time.Millisecond, "unchanged shadow decision logged after cadence")
 
 	s.sm.AddedTasks(1)
 	waitRecv(s, inputs, "fourth shadow call missing")
-	waitRecv(s, logger.shadowLogs, "second shadow log missing")
+	waitLogMatches(s, shadowLog, 2, "second shadow log missing")
 }
 
 func (s *ScaleManagerSuite) TestShadowModeDoesNotLogDisabledScaler() {
 	s.settings.ShadowModeLogInterval = time.Minute
 
-	logger := &recordingLogger{shadowLogs: make(chan struct{}, 1)}
+	logger := testlogger.NewTestLogger(s.T(), testlogger.FailOnAnyUnexpectedError)
+	shadowLog := logger.Expect(testlogger.Info, "new target")
 	inputs := make(chan PartitionScalerInput, 1)
 	s.scaler.EXPECT().OnTasks(gomock.Any()).
 		Do(func(in PartitionScalerInput) { inputs <- in }).
@@ -403,7 +398,7 @@ func (s *ScaleManagerSuite) TestShadowModeDoesNotLogDisabledScaler() {
 	s.startManagerWithLogger(logger, 4, &persistencespb.PartitionScaleState{Target: 2})
 	s.sm.AddedTasks(1)
 	waitRecv(s, inputs, "shadow scaler call missing")
-	assertNoRecv(s, logger.shadowLogs, 30*time.Millisecond, "disabled scaler should not log")
+	assertNoNewLogs(s, shadowLog, 30*time.Millisecond, "disabled scaler should not log")
 }
 
 // TestShadowModeSkipsDrain verifies that shadow mode does not change real read

--- a/service/matching/scale_manager_test.go
+++ b/service/matching/scale_manager_test.go
@@ -263,7 +263,9 @@ func (s *ScaleManagerSuite) TestNonPositiveShadowLogIntervalDisabled() {
 }
 
 // TestShadowDecisionDoesNotPersistOrPush verifies that shadow mode observes the
-// scaler decision without applying it.
+// scaler decision without applying it. Entering shadow mode does release a prior
+// managed target to baseline (one write, Target=0), but the scaler's hypothetical
+// decision (2) is never persisted.
 func (s *ScaleManagerSuite) TestShadowDecisionDoesNotPersistOrPush() {
 	s.settings.ShadowModeLogInterval = time.Minute
 
@@ -272,21 +274,39 @@ func (s *ScaleManagerSuite) TestShadowDecisionDoesNotPersistOrPush() {
 		Do(func(in PartitionScalerInput) { inputs <- in }).
 		Return(PartitionScalerDecision{NewTarget: 2})
 
-	// Start publishes the initial real state once. The shadow decision must not
-	// publish another state or write to persistence.
-	s.userData.EXPECT().SetPartitionScale(gomock.Any()).Times(1)
+	// Exactly one DB write: the one-time release to baseline. The scaler decision
+	// (2) must never be persisted.
+	dbWrites := make(chan *persistencespb.PartitionScaleState, 2)
+	s.scaleDB.EXPECT().UpdateScaleState(gomock.Any(), gomock.Any()).
+		Do(func(state *persistencespb.PartitionScaleState, _ bool) {
+			dbWrites <- common.CloneProto(state)
+		}).
+		Return(nil).Times(1)
+
+	// Start publishes the initial state; the release publishes once more.
+	s.userData.EXPECT().SetPartitionScale(gomock.Any()).Times(2)
 
 	s.startManager(4, &persistencespb.PartitionScaleState{Target: 1})
 
 	s.sm.AddedTasks(1)
 	in := waitRecv(s, inputs, "shadow scaler call missing")
-	s.Equal(1, in.CurrentTarget)
-	s.Equal(int32(1), s.sm.scaleState.GetTarget())
+	// release happens before the scaler call, so it sees the baseline.
+	s.Equal(0, in.CurrentTarget)
+
+	w := waitRecv(s, dbWrites, "release write missing")
+	s.Equal(int32(0), w.Target)
+	s.Nil(w.PrivateScalerState)
+	s.Equal(int32(0), s.sm.scaleState.GetTarget())
+
+	// the scaler decision (2) must not be persisted
+	assertNoRecv(s, dbWrites, 30*time.Millisecond, "scaler decision must not be persisted")
 }
 
-// TestShadowModeUsesRealStateOnEveryScalerCall verifies that shadow mode does
-// not feed hypothetical target or private state back into later scaler calls.
-func (s *ScaleManagerSuite) TestShadowModeUsesRealStateOnEveryScalerCall() {
+// TestShadowModeColdStartsScalerFromBaseline verifies that after releasing a
+// prior managed target on entry, shadow mode feeds the scaler the baseline
+// (Target 0, nil private state) on every call and never feeds hypothetical
+// decisions back into the state.
+func (s *ScaleManagerSuite) TestShadowModeColdStartsScalerFromBaseline() {
 	s.settings.ShadowModeLogInterval = time.Minute
 	realPriv := protoutils.MarshalAny(s.T(), wrapperspb.String("real-state"))
 	priv1 := protoutils.MarshalAny(s.T(), wrapperspb.String("shadow-decision-1"))
@@ -302,21 +322,27 @@ func (s *ScaleManagerSuite) TestShadowModeUsesRealStateOnEveryScalerCall() {
 			Return(PartitionScalerDecision{NewTarget: 3, PrivateState: priv2}),
 	)
 
-	s.userData.EXPECT().SetPartitionScale(gomock.Any()).Times(1)
+	// One release write (Target=0) on entry; shadow decisions never write.
+	s.scaleDB.EXPECT().UpdateScaleState(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	// Start push + one release push.
+	s.userData.EXPECT().SetPartitionScale(gomock.Any()).Times(2)
 
 	s.startManager(4, &persistencespb.PartitionScaleState{Target: 1, PrivateScalerState: realPriv})
 
 	s.sm.AddedTasks(1)
 	in1 := waitRecv(s, inputs, "first shadow call missing")
-	s.Equal(1, in1.CurrentTarget)
-	s.ProtoEqual(realPriv, in1.PrivateState)
+	s.Equal(0, in1.CurrentTarget)
+	s.Nil(in1.PrivateState)
 
 	s.timeSource.Advance(110 * time.Millisecond) // past the 100ms cooldown
 	s.sm.AddedTasks(1)
 	in2 := waitRecv(s, inputs, "second shadow call missing")
-	s.Equal(1, in2.CurrentTarget)
-	s.ProtoEqual(realPriv, in2.PrivateState)
-	s.ProtoEqual(realPriv, s.sm.scaleState.GetPrivateScalerState())
+	s.Equal(0, in2.CurrentTarget)
+	s.Nil(in2.PrivateState)
+
+	// scaler decisions are never applied back into the state
+	s.Equal(int32(0), s.sm.scaleState.GetTarget())
+	s.Nil(s.sm.scaleState.GetPrivateScalerState())
 }
 
 func (s *ScaleManagerSuite) TestShadowModeDoesNotLogNoChange() {
@@ -393,7 +419,9 @@ func (s *ScaleManagerSuite) TestShadowModeDoesNotLogDisabledScaler() {
 		Do(func(in PartitionScalerInput) { inputs <- in }).
 		Return(PartitionScalerDecision{NewTarget: 0})
 
-	s.userData.EXPECT().SetPartitionScale(gomock.Any()).Times(1)
+	// entering shadow with a managed target releases it to baseline (one write/push).
+	s.scaleDB.EXPECT().UpdateScaleState(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	s.userData.EXPECT().SetPartitionScale(gomock.Any()).Times(2)
 
 	s.startManagerWithLogger(logger, 4, &persistencespb.PartitionScaleState{Target: 2})
 	s.sm.AddedTasks(1)
@@ -413,7 +441,10 @@ func (s *ScaleManagerSuite) TestShadowModeSkipsDrain() {
 		Do(func(in PartitionScalerInput) { inputs <- in }).
 		Return(PartitionScalerDecision{NoChange: true})
 
-	s.userData.EXPECT().SetPartitionScale(gomock.Any()).Times(1)
+	// entering shadow releases the managed target to baseline (one write/push);
+	// the drain path must not write or clear backlog bits.
+	s.scaleDB.EXPECT().UpdateScaleState(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	s.userData.EXPECT().SetPartitionScale(gomock.Any()).Times(2)
 
 	initial := &persistencespb.PartitionScaleState{
 		Target:        2,
@@ -449,6 +480,93 @@ func (s *ScaleManagerSuite) TestShadowModeSkipsDrain() {
 	}
 
 	s.Equal(int32(4), bitSet(s.sm.scaleState.BacklogState).len())
+}
+
+// TestShadowModeReleasesManagedTargetToBaseline verifies that enabling shadow
+// mode on top of an applied managed target zeroes the target and clears private
+// state (one write), dropping the write side to baseline (Write=0) while
+// preserving read partitions (BacklogState unchanged).
+func (s *ScaleManagerSuite) TestShadowModeReleasesManagedTargetToBaseline() {
+	s.settings.ShadowModeLogInterval = time.Minute
+	priv := protoutils.MarshalAny(s.T(), wrapperspb.String("managed-state"))
+
+	s.scaler.EXPECT().OnTasks(gomock.Any()).
+		Return(PartitionScalerDecision{NoChange: true}).AnyTimes()
+
+	dbWrites := make(chan *persistencespb.PartitionScaleState, 1)
+	s.scaleDB.EXPECT().UpdateScaleState(gomock.Any(), gomock.Any()).
+		Do(func(state *persistencespb.PartitionScaleState, _ bool) {
+			dbWrites <- common.CloneProto(state)
+		}).
+		Return(nil).Times(1)
+
+	scaleInfos := make(chan *taskqueuespb.PartitionScaleInfo, 2)
+	s.userData.EXPECT().SetPartitionScale(gomock.Any()).
+		Do(func(info *taskqueuespb.PartitionScaleInfo) { scaleInfos <- info }).Times(2)
+
+	initial := &persistencespb.PartitionScaleState{
+		Target:             10,
+		MaxTarget:          10,
+		BacklogState:       bitSet(nil).set(0).set(1).set(2).set(3).set(4).set(5).set(6).set(7).set(8).set(9),
+		PrivateScalerState: priv,
+	}
+	s.startManager(4, initial)
+
+	s.sm.AddedTasks(1)
+
+	w := waitRecv(s, dbWrites, "release write missing")
+	s.Equal(int32(0), w.Target)
+	s.Nil(w.PrivateScalerState)
+	s.Equal(int32(10), bitSet(w.BacklogState).len(), "read partitions must be preserved")
+
+	// Start push (Read=10/Write=10), then the release push (Read=10/Write=0).
+	waitRecv(s, scaleInfos, "start push missing")
+	released := waitRecv(s, scaleInfos, "release push missing")
+	s.Equal(int32(10), released.Read)
+	s.Equal(int32(0), released.Write)
+}
+
+// TestShadowModeLogsOscillationFromBaseline verifies that once a managed target
+// is released to baseline (0), shadow decisions oscillating among positive values
+// are all logged. Releasing removes the stale non-zero baseline that would
+// otherwise short-circuit a decision returning to the prior real target.
+func (s *ScaleManagerSuite) TestShadowModeLogsOscillationFromBaseline() {
+	s.settings.ShadowModeLogInterval = time.Minute
+
+	logger := testlogger.NewTestLogger(s.T(), testlogger.FailOnAnyUnexpectedError)
+	shadowLog := logger.Expect(testlogger.Info, "new target")
+	inputs := make(chan PartitionScalerInput, 3)
+	gomock.InOrder(
+		s.scaler.EXPECT().OnTasks(gomock.Any()).
+			Do(func(in PartitionScalerInput) { inputs <- in }).
+			Return(PartitionScalerDecision{NewTarget: 3}),
+		s.scaler.EXPECT().OnTasks(gomock.Any()).
+			Do(func(in PartitionScalerInput) { inputs <- in }).
+			Return(PartitionScalerDecision{NewTarget: 2}),
+		s.scaler.EXPECT().OnTasks(gomock.Any()).
+			Do(func(in PartitionScalerInput) { inputs <- in }).
+			Return(PartitionScalerDecision{NewTarget: 3}),
+	)
+
+	// one release write/push on entry (managed Target=2 -> 0)
+	s.scaleDB.EXPECT().UpdateScaleState(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	s.userData.EXPECT().SetPartitionScale(gomock.Any()).Times(2)
+
+	s.startManagerWithLogger(logger, 4, &persistencespb.PartitionScaleState{Target: 2})
+
+	s.sm.AddedTasks(1)
+	waitRecv(s, inputs, "first shadow call missing")
+	waitLogMatches(s, shadowLog, 1, "shadow target 3 not logged")
+
+	s.timeSource.Advance(time.Minute) // past cooldown and cadence
+	s.sm.AddedTasks(1)
+	waitRecv(s, inputs, "second shadow call missing")
+	waitLogMatches(s, shadowLog, 2, "shadow target 2 not logged")
+
+	s.timeSource.Advance(time.Minute)
+	s.sm.AddedTasks(1)
+	waitRecv(s, inputs, "third shadow call missing")
+	waitLogMatches(s, shadowLog, 3, "shadow target 3 after oscillation not logged")
 }
 
 // TestNoChangeDecisionSkipsWrite covers two skip paths: explicit NoChange, and

--- a/service/matching/scale_manager_test.go
+++ b/service/matching/scale_manager_test.go
@@ -17,12 +17,14 @@ import (
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/common/testing/protoutils"
 	"go.temporal.io/server/common/tqid"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -78,10 +80,18 @@ func (s *ScaleManagerSuite) TearDownTest() {
 // startManager builds and starts the scaleManager. Call this after configuring
 // EXPECTs and tweaking s.settings. Pass initial=nil to start with no prior state.
 func (s *ScaleManagerSuite) startManager(writePartitions int, initial *persistencespb.PartitionScaleState) {
+	s.startManagerWithLogger(log.NewTestLogger(), writePartitions, initial)
+}
+
+func (s *ScaleManagerSuite) startManagerWithLogger(
+	logger log.Logger,
+	writePartitions int,
+	initial *persistencespb.PartitionScaleState,
+) {
 	s.sm = newScaleManager(
 		context.Background(),
 		tqid.MustNormalPartitionFromRpcName("tq", "ns-id", enumspb.TASK_QUEUE_TYPE_WORKFLOW),
-		log.NewTestLogger(),
+		logger,
 		metrics.NoopMetricsHandler,
 		s.userData,
 		s.matching,
@@ -125,6 +135,30 @@ func assertNoRecv[T any](s *ScaleManagerSuite, ch <-chan T, d time.Duration, msg
 		s.FailNow("unexpected event", msg)
 	case <-time.After(d):
 	}
+}
+
+type recordingLogger struct {
+	shadowLogs chan struct{}
+}
+
+func (l *recordingLogger) Debug(string, ...tag.Tag) {}
+func (l *recordingLogger) Info(msg string, _ ...tag.Tag) {
+	if msg != "new target" {
+		return
+	}
+	select {
+	case l.shadowLogs <- struct{}{}:
+	default:
+	}
+}
+func (l *recordingLogger) Warn(string, ...tag.Tag)   {}
+func (l *recordingLogger) Error(string, ...tag.Tag)  {}
+func (l *recordingLogger) DPanic(string, ...tag.Tag) {}
+func (l *recordingLogger) Panic(msg string, _ ...tag.Tag) {
+	panic(msg)
+}
+func (l *recordingLogger) Fatal(msg string, _ ...tag.Tag) {
+	panic(msg)
 }
 
 // --- tests ---
@@ -205,6 +239,216 @@ func (s *ScaleManagerSuite) TestDecisionPersistsAndUpdatesEphemeralData() {
 	info := waitRecv(s, scaleInfos, "no ephemeral data update")
 	s.Equal(int32(4), info.Read)
 	s.Equal(int32(2), info.Write)
+}
+
+// TestNonPositiveShadowLogIntervalDisabled verifies that ShadowModeLogInterval
+// <= 0 uses the normal apply path.
+func (s *ScaleManagerSuite) TestNonPositiveShadowLogIntervalDisabled() {
+	s.settings.ShadowModeLogInterval = -time.Second
+
+	s.scaler.EXPECT().OnTasks(gomock.Any()).
+		Return(PartitionScalerDecision{NewTarget: 2})
+
+	dbWrites := make(chan *persistencespb.PartitionScaleState, 1)
+	s.scaleDB.EXPECT().UpdateScaleState(gomock.Any(), gomock.Any()).
+		Do(func(state *persistencespb.PartitionScaleState, _ bool) {
+			dbWrites <- common.CloneProto(state)
+		}).
+		Return(nil)
+
+	scaleInfos := make(chan *taskqueuespb.PartitionScaleInfo, 1)
+	s.userData.EXPECT().SetPartitionScale(gomock.Any()).
+		Do(func(info *taskqueuespb.PartitionScaleInfo) { scaleInfos <- info })
+
+	s.startManager(4, nil)
+
+	s.sm.AddedTasks(1)
+	state := waitRecv(s, dbWrites, "no db write")
+	s.Equal(int32(2), state.Target)
+	info := waitRecv(s, scaleInfos, "no ephemeral data update")
+	s.Equal(int32(4), info.Read)
+	s.Equal(int32(2), info.Write)
+}
+
+// TestShadowDecisionDoesNotPersistOrPush verifies that shadow mode observes the
+// scaler decision without applying it.
+func (s *ScaleManagerSuite) TestShadowDecisionDoesNotPersistOrPush() {
+	s.settings.ShadowModeLogInterval = time.Minute
+
+	inputs := make(chan PartitionScalerInput, 1)
+	s.scaler.EXPECT().OnTasks(gomock.Any()).
+		Do(func(in PartitionScalerInput) { inputs <- in }).
+		Return(PartitionScalerDecision{NewTarget: 2})
+
+	// Start publishes the initial real state once. The shadow decision must not
+	// publish another state or write to persistence.
+	s.userData.EXPECT().SetPartitionScale(gomock.Any()).Times(1)
+
+	s.startManager(4, &persistencespb.PartitionScaleState{Target: 1})
+
+	s.sm.AddedTasks(1)
+	in := waitRecv(s, inputs, "shadow scaler call missing")
+	s.Equal(1, in.CurrentTarget)
+	s.Equal(int32(1), s.sm.scaleState.GetTarget())
+}
+
+// TestShadowModeUsesRealStateOnEveryCall verifies that shadow mode does not feed
+// hypothetical target or private state back into later scaler calls.
+func (s *ScaleManagerSuite) TestShadowModeUsesRealStateOnEveryCall() {
+	s.settings.ShadowModeLogInterval = time.Minute
+	realPriv := protoutils.MarshalAny(s.T(), wrapperspb.String("real-state"))
+	priv1 := protoutils.MarshalAny(s.T(), wrapperspb.String("shadow-decision-1"))
+	priv2 := protoutils.MarshalAny(s.T(), wrapperspb.String("shadow-decision-2"))
+
+	inputs := make(chan PartitionScalerInput, 2)
+	gomock.InOrder(
+		s.scaler.EXPECT().OnTasks(gomock.Any()).
+			Do(func(in PartitionScalerInput) { inputs <- in }).
+			Return(PartitionScalerDecision{NewTarget: 2, PrivateState: priv1}),
+		s.scaler.EXPECT().OnTasks(gomock.Any()).
+			Do(func(in PartitionScalerInput) { inputs <- in }).
+			Return(PartitionScalerDecision{NewTarget: 3, PrivateState: priv2}),
+	)
+
+	s.userData.EXPECT().SetPartitionScale(gomock.Any()).Times(1)
+
+	s.startManager(4, &persistencespb.PartitionScaleState{Target: 1, PrivateScalerState: realPriv})
+
+	s.sm.AddedTasks(1)
+	in1 := waitRecv(s, inputs, "first shadow call missing")
+	s.Equal(1, in1.CurrentTarget)
+	s.ProtoEqual(realPriv, in1.PrivateState)
+
+	s.sm.AddedTasks(1)
+	in2 := waitRecv(s, inputs, "second shadow call missing")
+	s.Equal(1, in2.CurrentTarget)
+	s.ProtoEqual(realPriv, in2.PrivateState)
+	s.ProtoEqual(realPriv, s.sm.scaleState.GetPrivateScalerState())
+}
+
+func (s *ScaleManagerSuite) TestShadowModeDoesNotLogNoChange() {
+	s.settings.ShadowModeLogInterval = time.Minute
+
+	logger := &recordingLogger{shadowLogs: make(chan struct{}, 1)}
+	inputs := make(chan PartitionScalerInput, 1)
+	s.scaler.EXPECT().OnTasks(gomock.Any()).
+		Do(func(in PartitionScalerInput) { inputs <- in }).
+		Return(PartitionScalerDecision{NoChange: true})
+
+	s.startManagerWithLogger(logger, 4, nil)
+
+	s.sm.AddedTasks(1)
+	waitRecv(s, inputs, "shadow scaler call missing")
+	assertNoRecv(s, logger.shadowLogs, 30*time.Millisecond, "NoChange decision should not log")
+}
+
+// TestShadowLoggingCadence verifies that shadow decisions are logged no more
+// frequently than the configured cadence and unchanged decisions are not logged.
+func (s *ScaleManagerSuite) TestShadowLoggingCadence() {
+	s.settings.ShadowModeLogInterval = time.Minute
+
+	logger := &recordingLogger{shadowLogs: make(chan struct{}, 4)}
+	inputs := make(chan PartitionScalerInput, 4)
+	gomock.InOrder(
+		s.scaler.EXPECT().OnTasks(gomock.Any()).
+			Do(func(in PartitionScalerInput) { inputs <- in }).
+			Return(PartitionScalerDecision{NewTarget: 2}),
+		s.scaler.EXPECT().OnTasks(gomock.Any()).
+			Do(func(in PartitionScalerInput) { inputs <- in }).
+			Return(PartitionScalerDecision{NewTarget: 2}),
+		s.scaler.EXPECT().OnTasks(gomock.Any()).
+			Do(func(in PartitionScalerInput) { inputs <- in }).
+			Return(PartitionScalerDecision{NewTarget: 2}),
+		s.scaler.EXPECT().OnTasks(gomock.Any()).
+			Do(func(in PartitionScalerInput) { inputs <- in }).
+			Return(PartitionScalerDecision{NewTarget: 3}),
+	)
+
+	s.startManagerWithLogger(logger, 4, nil)
+
+	s.sm.AddedTasks(1)
+	waitRecv(s, inputs, "first shadow call missing")
+	waitRecv(s, logger.shadowLogs, "first shadow log missing")
+
+	s.sm.AddedTasks(1)
+	waitRecv(s, inputs, "second shadow call missing")
+	assertNoRecv(s, logger.shadowLogs, 30*time.Millisecond, "shadow log repeated before cadence")
+
+	s.timeSource.Advance(time.Minute)
+	s.sm.AddedTasks(1)
+	waitRecv(s, inputs, "third shadow call missing")
+	assertNoRecv(s, logger.shadowLogs, 30*time.Millisecond, "unchanged shadow decision logged after cadence")
+
+	s.sm.AddedTasks(1)
+	waitRecv(s, inputs, "fourth shadow call missing")
+	waitRecv(s, logger.shadowLogs, "second shadow log missing")
+}
+
+func (s *ScaleManagerSuite) TestShadowModeDoesNotLogDisabledScaler() {
+	s.settings.ShadowModeLogInterval = time.Minute
+
+	logger := &recordingLogger{shadowLogs: make(chan struct{}, 1)}
+	inputs := make(chan PartitionScalerInput, 1)
+	s.scaler.EXPECT().OnTasks(gomock.Any()).
+		Do(func(in PartitionScalerInput) { inputs <- in }).
+		Return(PartitionScalerDecision{NewTarget: 0})
+
+	s.userData.EXPECT().SetPartitionScale(gomock.Any()).Times(1)
+
+	s.startManagerWithLogger(logger, 4, &persistencespb.PartitionScaleState{Target: 2})
+	s.sm.AddedTasks(1)
+	waitRecv(s, inputs, "shadow scaler call missing")
+	assertNoRecv(s, logger.shadowLogs, 30*time.Millisecond, "disabled scaler should not log")
+}
+
+// TestShadowModeSkipsDrain verifies that shadow mode does not change real read
+// partitions by clearing backlog bits.
+func (s *ScaleManagerSuite) TestShadowModeSkipsDrain() {
+	s.settings.ShadowModeLogInterval = time.Minute
+	s.settings.BackgroundInterval = 50 * time.Millisecond
+	s.settings.DrainBufferTime = 0
+
+	inputs := make(chan PartitionScalerInput, 1)
+	s.scaler.EXPECT().OnTasks(gomock.Any()).
+		Do(func(in PartitionScalerInput) { inputs <- in }).
+		Return(PartitionScalerDecision{NoChange: true})
+
+	s.userData.EXPECT().SetPartitionScale(gomock.Any()).Times(1)
+
+	initial := &persistencespb.PartitionScaleState{
+		Target:        2,
+		MaxTarget:     4,
+		TargetVersion: 0,
+		BacklogState:  bitSet(nil).set(0).set(1).set(2).set(3),
+	}
+	drainedResp := &matchingservice.DescribeTaskQueuePartitionResponse{
+		ScaleInfo: &taskqueuespb.PartitionScaleInfo{Read: 4, Write: 2, Version: 0},
+		VersionsInfoInternal: map[string]*taskqueuespb.TaskQueueVersionInfoInternal{
+			"v1": {
+				PhysicalTaskQueueInfo: &taskqueuespb.PhysicalTaskQueueInfo{
+					InternalTaskQueueStatus: []*taskqueuespb.InternalTaskQueueStatus{
+						{BacklogDrained: true},
+					},
+				},
+			},
+		},
+	}
+	describeCalls := make(chan struct{}, 4)
+	s.matching.EXPECT().DescribeTaskQueuePartition(gomock.Any(), gomock.Any()).
+		Do(func(context.Context, *matchingservice.DescribeTaskQueuePartitionRequest, ...grpc.CallOption) {
+			describeCalls <- struct{}{}
+		}).
+		Return(drainedResp, nil).
+		Times(4)
+
+	s.startManager(4, initial)
+	s.fireBackgroundTimer()
+	waitRecv(s, inputs, "timer did not call scaler")
+	for range 4 {
+		waitRecv(s, describeCalls, "shadow drain did not describe read partition")
+	}
+
+	s.Equal(int32(4), bitSet(s.sm.scaleState.BacklogState).len())
 }
 
 // TestNoChangeDecisionSkipsWrite covers two skip paths: explicit NoChange, and


### PR DESCRIPTION
## What changed

- Adds `ShadowModeLogInterval` to partition scale manager settings, defaulting to one minute.
- Adds shadow-mode logging for dynamic partition scale decisions without applying persistence or partition-count side effects.
- Tags partition scale event metrics with `scaler_shadow_mode`
- Updates scale manager tests for shadow-mode observer behavior, including no logs for unchanged decisions.

### Note on existing log/metrics tags

scaleManager logger is already tagged with:
- task queue name
- task queue type
- namespace

scaleManager metrics handler is already tagged with:
- task queue name (conditional depending on BreakdownMetricsByTaskQueue)
- task queue type
- namespace
- partition (precision dependent on BreakdownMetricsByPartition)

## Validation

- `go test -tags test_dep ./service/matching -run TestScaleManagerSuite`
- `go test -tags test_dep ./common/dynamicconfig`
- `git diff --check`

More metrics to follow, also gated by this same flag!


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches matching partition scaling and persistence when shadow mode is on (including a one-time baseline release); default interval 0 leaves production behavior unchanged.
> 
> **Overview**
> Adds **`ShadowModeLogInterval`** to partition scale manager dynamic config. When **> 0**, the scaler still runs on task batches but **does not persist** hypothetical targets or run drain-side backlog clears; it **logs** new positive targets on that cadence and tags **`PartitionScaleEvents`** with **`scaler_shadow_mode`**.
> 
> Enabling shadow mode on a queue that already had a **managed target** performs a **one-time release** (`releaseManagedState`): persist **`Target=0`** and clear private scaler state so writes follow dynamic config again, while **read/backlog state is preserved**. Shadow calls always see baseline input (cold start) so decisions are not fed back into state.
> 
> **`TestLogger`** gains **expectation match counts** (`Matched` / `MatchCount`) so tests can assert shadow log cadence without failing the test. Scale manager tests cover apply vs shadow paths, release, drain skip, and logging behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef0c050a52da251eae831a232310f6ecb22efdb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->