### PR TITLE
Run all gofix analyzers by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -420,7 +420,7 @@ fmt: fmt-gofix fmt-imports fmt-protos fmt-yaml
 # on the exit code alone, since go fix can exit non-zero without actually
 # modifying any files (see https://github.com/golang/go/issues/77482).
 # Note: go fix automatically skips generated files.
-GOFIX_FLAGS ?= -any -rangeint
+GOFIX_FLAGS ?=
 GOFIX_MAX_ITERATIONS ?= 5
 fmt-gofix:
 	@printf $(COLOR) "Run go fix..."

--- a/cmd/tools/genrpcserverinterceptors/main.go
+++ b/cmd/tools/genrpcserverinterceptors/main.go
@@ -152,7 +152,6 @@ func workflowTagGetters(messageType reflect.Type, depth int) messageData {
 	// Iterates over fields in order they defined in proto file, not proto index.
 	// Order is important because the first match wins.
 	for nestedRequest := range messageType.Elem().Fields() {
-		nestedRequest := nestedRequest
 		if nestedRequest.Type.Kind() != reflect.Pointer {
 			continue
 		}

--- a/cmd/tools/genrpcwrappers/main.go
+++ b/cmd/tools/genrpcwrappers/main.go
@@ -173,7 +173,6 @@ func findNestedField(t reflect.Type, name string, path string, maxDepth int) []f
 	}
 	var out []fieldWithPath
 	for f := range t.Fields() {
-		f := f
 		if ignoreField[t.Name()+"."+f.Name] {
 			continue
 		}

--- a/cmd/tools/gensearchattributehelpers/main.go
+++ b/cmd/tools/gensearchattributehelpers/main.go
@@ -41,7 +41,6 @@ func getSearchAttributesHelpersData() searchAttributesHelpersData {
 	historyEventT := reflect.TypeFor[*historypb.HistoryEvent]()
 
 	for attributesGetter := range historyEventT.Methods() {
-		attributesGetter := attributesGetter
 		matches := attributesGetterRegex.FindStringSubmatch(attributesGetter.Name)
 		if len(matches) < 2 {
 			continue

--- a/common/rpc/interceptor/namespace_test.go
+++ b/common/rpc/interceptor/namespace_test.go
@@ -79,7 +79,6 @@ func (s *namespaceSuite) TestFrontendAPIMetrics() {
 
 	t := reflect.TypeFor[workflowservice.WorkflowServiceServer]()
 	for method := range t.Methods() {
-		method := method
 		methodName := method.Name
 		methodType := method.Type
 
@@ -103,7 +102,6 @@ func (s *namespaceSuite) TestMatchingAPIMetrics() {
 
 	t := reflect.TypeFor[matchingservice.MatchingServiceServer]()
 	for method := range t.Methods() {
-		method := method
 		methodName := method.Name
 		methodType := method.Type
 
@@ -127,7 +125,6 @@ func (s *namespaceSuite) TestHistoryAPIMetrics() {
 
 	t := reflect.TypeFor[historyservice.HistoryServiceServer]()
 	for method := range t.Methods() {
-		method := method
 		methodName := method.Name
 		methodType := method.Type
 

--- a/service/frontend/http_api_server.go
+++ b/service/frontend/http_api_server.go
@@ -365,7 +365,6 @@ func newInlineClientConn(
 	for qualifiedServerName, server := range servers {
 		serverVal := reflect.ValueOf(server)
 		for reflectMethod := range serverVal.Type().Methods() {
-			reflectMethod := reflectMethod
 			// We intentionally look this up by name to not assume method indexes line
 			// up from type to value
 			methodVal := serverVal.MethodByName(reflectMethod.Name)

--- a/service/worker/scanner/executor/executor_test.go
+++ b/service/worker/scanner/executor/executor_test.go
@@ -39,9 +39,7 @@ func (s *ExecutorTestSuite) TestTaskExecution() {
 	var runCounter int64
 	var startWG sync.WaitGroup
 	for range 5 {
-		startWG.Add(1)
-		go func() {
-			defer startWG.Done()
+		startWG.Go(func() {
 			for i := range 20 {
 				if i%2 == 0 {
 					e.Submit(&testTask{TaskStatusDefer, &runCounter})
@@ -49,7 +47,7 @@ func (s *ExecutorTestSuite) TestTaskExecution() {
 				}
 				e.Submit(&testTask{TaskStatusDone, &runCounter})
 			}
-		}()
+		})
 	}
 	s.True(common.AwaitWaitGroup(&startWG, time.Second*10))
 	s.True(s.awaitCompletion(e))


### PR DESCRIPTION
## What changed?

Set `GOFIX_FLAGS` to empty so `make fmt` runs all `go fix` analyzers.