### PR TITLE
Stop history/matching membership watchers on resolver shutdown

### DIFF
--- a/client/history/client_test.go
+++ b/client/history/client_test.go
@@ -36,6 +36,7 @@ func TestErrLookup(t *testing.T) {
 	serviceResolver.EXPECT().AddListener(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	serviceResolver.EXPECT().RemoveListener(gomock.Any()).Return(nil).AnyTimes()
 	serviceResolver.EXPECT().Members().Return(nil).AnyTimes()
+	serviceResolver.EXPECT().Done().Return(nil).AnyTimes()
 	client := history.NewClient(
 		dynamicconfig.NewNoopCollection(),
 		serviceResolver,
@@ -110,6 +111,7 @@ func TestShardAgnosticConnectionStrategy(t *testing.T) {
 			serviceResolver.EXPECT().AddListener(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			serviceResolver.EXPECT().RemoveListener(gomock.Any()).Return(nil).AnyTimes()
 			serviceResolver.EXPECT().Members().Return(nil).AnyTimes()
+			serviceResolver.EXPECT().Done().Return(nil).AnyTimes()
 
 			// Create an in-memory gRPC server.
 			listener := nettest.NewListener(nettest.NewPipe())

--- a/client/history/connections.go
+++ b/client/history/connections.go
@@ -1,9 +1,7 @@
 package history
 
 import (
-	"context"
 	"fmt"
-	"runtime"
 	"sync"
 	"time"
 
@@ -61,15 +59,12 @@ func NewConnectionPool[C any](
 		logger:                 logger,
 	}
 
-	// Close cached conns whose host leaves the membership ring.
-	ctx, cancel := context.WithCancel(context.Background())
-	go watchMembershipForClose[C](ctx, historyServiceResolver, logger, conns, connectionCloseDelay)
-	runtime.AddCleanup(c, func(cancel context.CancelFunc) { cancel() }, cancel)
+	// Close cached conns whose host leaves the ring; exits when resolver stops.
+	go watchMembershipForClose[C](historyServiceResolver, logger, conns, connectionCloseDelay)
 	return c
 }
 
 func watchMembershipForClose[C any](
-	ctx context.Context,
 	resolver membership.ServiceResolver,
 	logger log.Logger,
 	conns *sync.Map,
@@ -88,10 +83,11 @@ func watchMembershipForClose[C any](
 	evictAt := make(map[rpcAddress]time.Time)
 	ticker := time.NewTicker(evictionCheckInterval)
 	defer ticker.Stop()
+	done := resolver.Done()
 	for {
 		select {
-		case <-ctx.Done():
-			return
+		case <-done:
+			return // resolver stopped
 		case event := <-ch:
 			for _, h := range event.HostsRemoved {
 				evictAt[rpcAddress(h.GetAddress())] = time.Now().Add(connectionCloseDelay())

--- a/client/history/historytest/clienttest.go
+++ b/client/history/historytest/clienttest.go
@@ -159,6 +159,7 @@ func createClient(ctrl *gomock.Controller, listener *nettest.PipeListener) histo
 	serviceResolver.EXPECT().Lookup(gomock.Any()).Return(address, nil).AnyTimes()
 	serviceResolver.EXPECT().AddListener(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	serviceResolver.EXPECT().RemoveListener(gomock.Any()).Return(nil).AnyTimes()
+	serviceResolver.EXPECT().Done().Return(nil).AnyTimes()
 	rpcFactory := nettest.NewRPCFactory(listener)
 	client := history.NewClient(
 		dynamicconfig.NewNoopCollection(),

--- a/client/matching/client.go
+++ b/client/matching/client.go
@@ -74,16 +74,13 @@ func NewClient(
 	c.partitionCache.Start()
 	runtime.AddCleanup(c, func(cache *partitionCache) { cache.Stop() }, c.partitionCache)
 
-	// Evict cached clients whose host leaves the membership ring.
-	ctx, cancel := context.WithCancel(context.Background())
-	go watchMembershipForEviction(ctx, resolver, clients, connectionCloseDelay, logger)
-	runtime.AddCleanup(c, func(cancel context.CancelFunc) { cancel() }, cancel)
+	// Evict cached clients whose host leaves the ring; exits when resolver stops.
+	go watchMembershipForEviction(resolver, clients, connectionCloseDelay, logger)
 
 	return c
 }
 
 func watchMembershipForEviction(
-	ctx context.Context,
 	resolver membership.ServiceResolver,
 	clients common.ClientCache,
 	connectionCloseDelay dynamicconfig.DurationPropertyFn,
@@ -102,10 +99,11 @@ func watchMembershipForEviction(
 	evictAt := make(map[string]time.Time)
 	ticker := time.NewTicker(evictionCheckInterval)
 	defer ticker.Stop()
+	done := resolver.Done()
 	for {
 		select {
-		case <-ctx.Done():
-			return
+		case <-done:
+			return // resolver stopped
 		case event := <-ch:
 			for _, h := range event.HostsRemoved {
 				evictAt[h.GetAddress()] = time.Now().Add(connectionCloseDelay())

--- a/common/membership/interfaces.go
+++ b/common/membership/interfaces.go
@@ -38,6 +38,10 @@ type (
 		// should not call Start until they are ready to receive requests from
 		// other cluster members.
 		Start()
+		// Stop shuts down the monitor, releasing resources tied to its lifetime
+		// such as the service resolvers (closing their Done channels). It is not
+		// a graceful ring departure; use EvictSelf for that.
+		Stop()
 		// EvictSelf evicts this member from the membership ring. After this method is
 		// called, other members will discover that this node is no longer part of the
 		// ring. This primitive is useful to carry out graceful host shutdown during deployments.

--- a/common/membership/interfaces.go
+++ b/common/membership/interfaces.go
@@ -88,6 +88,9 @@ type (
 		AvailableMembers() []HostInfo
 		// RequestRefresh requests that the membership information be refreshed.
 		RequestRefresh()
+		// Done returns a channel closed when the resolver stops, so listeners
+		// can exit.
+		Done() <-chan struct{}
 	}
 
 	HostInfoProvider interface {

--- a/common/membership/interfaces_mock.go
+++ b/common/membership/interfaces_mock.go
@@ -141,6 +141,18 @@ func (mr *MockMonitorMockRecorder) Start() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockMonitor)(nil).Start))
 }
 
+// Stop mocks base method.
+func (m *MockMonitor) Stop() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Stop")
+}
+
+// Stop indicates an expected call of Stop.
+func (mr *MockMonitorMockRecorder) Stop() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockMonitor)(nil).Stop))
+}
+
 // WaitUntilInitialized mocks base method.
 func (m *MockMonitor) WaitUntilInitialized(arg0 context.Context) error {
 	m.ctrl.T.Helper()

--- a/common/membership/interfaces_mock.go
+++ b/common/membership/interfaces_mock.go
@@ -221,6 +221,20 @@ func (mr *MockServiceResolverMockRecorder) AvailableMembers() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailableMembers", reflect.TypeOf((*MockServiceResolver)(nil).AvailableMembers))
 }
 
+// Done mocks base method.
+func (m *MockServiceResolver) Done() <-chan struct{} {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Done")
+	ret0, _ := ret[0].(<-chan struct{})
+	return ret0
+}
+
+// Done indicates an expected call of Done.
+func (mr *MockServiceResolverMockRecorder) Done() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Done", reflect.TypeOf((*MockServiceResolver)(nil).Done))
+}
+
 // Lookup mocks base method.
 func (m *MockServiceResolver) Lookup(key string) (HostInfo, error) {
 	m.ctrl.T.Helper()

--- a/common/membership/ringpop/service_resolver.go
+++ b/common/membership/ringpop/service_resolver.go
@@ -149,6 +149,10 @@ func (r *serviceResolver) Stop() {
 	}
 }
 
+func (r *serviceResolver) Done() <-chan struct{} {
+	return r.shutdownCh
+}
+
 func (r *serviceResolver) RequestRefresh() {
 	select {
 	case r.refreshChan <- struct{}{}:

--- a/common/membership/static/fx.go
+++ b/common/membership/static/fx.go
@@ -12,8 +12,10 @@ func MembershipModule(
 	hostsByService map[primitives.ServiceName]Hosts,
 ) fx.Option {
 	return fx.Options(
-		fx.Provide(func() membership.Monitor {
-			return newStaticMonitor(hostsByService)
+		fx.Provide(func(lc fx.Lifecycle) membership.Monitor {
+			m := newStaticMonitor(hostsByService)
+			lc.Append(fx.StopHook(m.Stop))
+			return m
 		}),
 		fx.Provide(func(serviceName primitives.ServiceName) membership.HostInfoProvider {
 			hosts := hostsByService[serviceName]

--- a/common/membership/static/monitor.go
+++ b/common/membership/static/monitor.go
@@ -26,7 +26,7 @@ func SingleLocalHost(host string) Hosts {
 	return Hosts{All: []string{host}, Self: host}
 }
 
-func newStaticMonitor(hosts map[primitives.ServiceName]Hosts) membership.Monitor {
+func newStaticMonitor(hosts map[primitives.ServiceName]Hosts) *staticMonitor {
 	resolvers := make(map[primitives.ServiceName]*staticResolver, len(hosts))
 	for service, hostList := range hosts {
 		resolvers[service] = newStaticResolver(hostList.All)
@@ -41,6 +41,13 @@ func newStaticMonitor(hosts map[primitives.ServiceName]Hosts) membership.Monitor
 func (s *staticMonitor) Start() {
 	for service, r := range s.resolvers {
 		r.start(s.hosts[service].All)
+	}
+}
+
+// Stop closes each resolver's Done channel so listeners exit.
+func (s *staticMonitor) Stop() {
+	for _, r := range s.resolvers {
+		r.stop()
 	}
 }
 

--- a/common/membership/static/monitor.go
+++ b/common/membership/static/monitor.go
@@ -26,7 +26,7 @@ func SingleLocalHost(host string) Hosts {
 	return Hosts{All: []string{host}, Self: host}
 }
 
-func newStaticMonitor(hosts map[primitives.ServiceName]Hosts) *staticMonitor {
+func newStaticMonitor(hosts map[primitives.ServiceName]Hosts) membership.Monitor {
 	resolvers := make(map[primitives.ServiceName]*staticResolver, len(hosts))
 	for service, hostList := range hosts {
 		resolvers[service] = newStaticResolver(hostList.All)

--- a/common/membership/static/service_resolver.go
+++ b/common/membership/static/service_resolver.go
@@ -12,6 +12,8 @@ type staticResolver struct {
 	mu        sync.Mutex
 	hostInfos []membership.HostInfo
 	listeners map[string]chan<- *membership.ChangedEvent
+	done      chan struct{}
+	stopOnce  sync.Once
 
 	hashfunc func([]byte) uint32
 }
@@ -25,7 +27,16 @@ func newStaticResolver(hosts []string) *staticResolver {
 		hostInfos: hostInfos,
 		hashfunc:  farm.Fingerprint32,
 		listeners: make(map[string]chan<- *membership.ChangedEvent),
+		done:      make(chan struct{}),
 	}
+}
+
+func (s *staticResolver) Done() <-chan struct{} {
+	return s.done
+}
+
+func (s *staticResolver) stop() {
+	s.stopOnce.Do(func() { close(s.done) })
 }
 
 func (s *staticResolver) start(hosts []string) {

--- a/tests/leakcheck/leak_test.go
+++ b/tests/leakcheck/leak_test.go
@@ -30,9 +30,7 @@ var goleakOpts = []goleak.Option{
 	goleak.IgnoreTopFunction("google.golang.org/grpc/internal/grpcsync.(*CallbackSerializer).run"),
 	goleak.IgnoreTopFunction("google.golang.org/grpc.(*addrConn).resetTransportAndUnlock"),
 	goleak.IgnoreTopFunction("google.golang.org/grpc/internal/balancer/gracefulswitch.(*Balancer).updateSubConnState"),
-	goleak.IgnoreTopFunction("go.temporal.io/server/client/history.watchMembershipForClose[...]"),
 	goleak.IgnoreTopFunction("go.temporal.io/server/client/matching.(*partitionCache).Start.func1"),
-	goleak.IgnoreTopFunction("go.temporal.io/server/client/matching.watchMembershipForEviction"),
 	goleak.IgnoreTopFunction("go.temporal.io/server/common/membership.(*grpcResolver).listen"),
 
 	// TODO: worker-service and persistence goroutine leaks.


### PR DESCRIPTION
## What changed?
Added `Done()` to the membership `ServiceResolver` (closed when the resolver stops) and made the history/matching connection-pool membership watchers exit on it instead of relying on `runtime.AddCleanup`. Wired the static membership monitor to close its resolvers' `Done()` channels on shutdown (it previously had no stop hook).

## Why?
The `watchMembershipForClose` and `watchMembershipForEviction` goroutines were cancelled only via GC finalizers, which never fire because fx retains the clients for the host's lifetime. They leaked per cluster, so the goroutine-leak test had to ignore them. They now stop deterministically on shutdown, and the two ignores are removed.

## How did you test it?
- [x] built
- [x] covered by existing tests
- [x] added new functional test(s)

TestClusterShutdownLeak now passes with both watcher ignores removed (0 of each goroutine remain; was 132 in an 8-iteration run).

