### PR TITLE
Pause component time when lifecycle state is paused

### DIFF
--- a/api/persistence/v1/chasm.go-helpers.pb.go
+++ b/api/persistence/v1/chasm.go-helpers.pb.go
@@ -116,6 +116,43 @@ func (this *ChasmComponentAttributes) Equal(that interface{}) bool {
 	return proto.Equal(this, that1)
 }
 
+// Marshal an object of type ChasmPauseInfo to the protobuf v3 wire format
+func (val *ChasmPauseInfo) Marshal() ([]byte, error) {
+	return proto.Marshal(val)
+}
+
+// Unmarshal an object of type ChasmPauseInfo from the protobuf v3 wire format
+func (val *ChasmPauseInfo) Unmarshal(buf []byte) error {
+	return proto.Unmarshal(buf, val)
+}
+
+// Size returns the size of the object, in bytes, once serialized
+func (val *ChasmPauseInfo) Size() int {
+	return proto.Size(val)
+}
+
+// Equal returns whether two ChasmPauseInfo values are equivalent by recursively
+// comparing the message's fields.
+// For more information see the documentation for
+// https://pkg.go.dev/google.golang.org/protobuf/proto#Equal
+func (this *ChasmPauseInfo) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	var that1 *ChasmPauseInfo
+	switch t := that.(type) {
+	case *ChasmPauseInfo:
+		that1 = t
+	case ChasmPauseInfo:
+		that1 = &t
+	default:
+		return false
+	}
+
+	return proto.Equal(this, that1)
+}
+
 // Marshal an object of type ChasmDataAttributes to the protobuf v3 wire format
 func (val *ChasmDataAttributes) Marshal() ([]byte, error) {
 	return proto.Marshal(val)

--- a/api/persistence/v1/chasm.pb.go
+++ b/api/persistence/v1/chasm.pb.go
@@ -16,6 +16,7 @@ import (
 	v11 "go.temporal.io/api/sdk/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -231,7 +232,10 @@ type ChasmComponentAttributes struct {
 	// request_id.
 	Requests map[string]*ChasmComponentAttributes_RequestMetadata `protobuf:"bytes,5,rep,name=requests,proto3" json:"requests,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// Caller-supplied user metadata (summary, details) attached to this component.
-	UserMetadata  *v11.UserMetadata `protobuf:"bytes,6,opt,name=user_metadata,json=userMetadata,proto3" json:"user_metadata,omitempty"`
+	UserMetadata *v11.UserMetadata `protobuf:"bytes,6,opt,name=user_metadata,json=userMetadata,proto3" json:"user_metadata,omitempty"`
+	// Tracks how long this component has spent paused so that Now() can be adjusted
+	// accordingly. Set when the component transitions into or out of LifecycleStatePaused.
+	PauseInfo     *ChasmPauseInfo `protobuf:"bytes,7,opt,name=pause_info,json=pauseInfo,proto3" json:"pause_info,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -308,6 +312,69 @@ func (x *ChasmComponentAttributes) GetUserMetadata() *v11.UserMetadata {
 	return nil
 }
 
+func (x *ChasmComponentAttributes) GetPauseInfo() *ChasmPauseInfo {
+	if x != nil {
+		return x.PauseInfo
+	}
+	return nil
+}
+
+// ChasmPauseInfo tracks the accumulated pause duration for a component so that
+// Now() can return a time that does not advance while the component is paused.
+type ChasmPauseInfo struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Set while the component is currently paused; cleared on unpause.
+	PausedTime *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=paused_time,json=pausedTime,proto3" json:"paused_time,omitempty"`
+	// Total duration accumulated from all completed pause/unpause cycles.
+	AccumulatedPauseDuration *durationpb.Duration `protobuf:"bytes,2,opt,name=accumulated_pause_duration,json=accumulatedPauseDuration,proto3" json:"accumulated_pause_duration,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
+}
+
+func (x *ChasmPauseInfo) Reset() {
+	*x = ChasmPauseInfo{}
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ChasmPauseInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ChasmPauseInfo) ProtoMessage() {}
+
+func (x *ChasmPauseInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ChasmPauseInfo.ProtoReflect.Descriptor instead.
+func (*ChasmPauseInfo) Descriptor() ([]byte, []int) {
+	return file_temporal_server_api_persistence_v1_chasm_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *ChasmPauseInfo) GetPausedTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.PausedTime
+	}
+	return nil
+}
+
+func (x *ChasmPauseInfo) GetAccumulatedPauseDuration() *durationpb.Duration {
+	if x != nil {
+		return x.AccumulatedPauseDuration
+	}
+	return nil
+}
+
 type ChasmDataAttributes struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -316,7 +383,7 @@ type ChasmDataAttributes struct {
 
 func (x *ChasmDataAttributes) Reset() {
 	*x = ChasmDataAttributes{}
-	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[3]
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -328,7 +395,7 @@ func (x *ChasmDataAttributes) String() string {
 func (*ChasmDataAttributes) ProtoMessage() {}
 
 func (x *ChasmDataAttributes) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[3]
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -341,7 +408,7 @@ func (x *ChasmDataAttributes) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChasmDataAttributes.ProtoReflect.Descriptor instead.
 func (*ChasmDataAttributes) Descriptor() ([]byte, []int) {
-	return file_temporal_server_api_persistence_v1_chasm_proto_rawDescGZIP(), []int{3}
+	return file_temporal_server_api_persistence_v1_chasm_proto_rawDescGZIP(), []int{4}
 }
 
 type ChasmCollectionAttributes struct {
@@ -352,7 +419,7 @@ type ChasmCollectionAttributes struct {
 
 func (x *ChasmCollectionAttributes) Reset() {
 	*x = ChasmCollectionAttributes{}
-	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[4]
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -364,7 +431,7 @@ func (x *ChasmCollectionAttributes) String() string {
 func (*ChasmCollectionAttributes) ProtoMessage() {}
 
 func (x *ChasmCollectionAttributes) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[4]
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -377,7 +444,7 @@ func (x *ChasmCollectionAttributes) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChasmCollectionAttributes.ProtoReflect.Descriptor instead.
 func (*ChasmCollectionAttributes) Descriptor() ([]byte, []int) {
-	return file_temporal_server_api_persistence_v1_chasm_proto_rawDescGZIP(), []int{4}
+	return file_temporal_server_api_persistence_v1_chasm_proto_rawDescGZIP(), []int{5}
 }
 
 type ChasmPointerAttributes struct {
@@ -389,7 +456,7 @@ type ChasmPointerAttributes struct {
 
 func (x *ChasmPointerAttributes) Reset() {
 	*x = ChasmPointerAttributes{}
-	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[5]
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -401,7 +468,7 @@ func (x *ChasmPointerAttributes) String() string {
 func (*ChasmPointerAttributes) ProtoMessage() {}
 
 func (x *ChasmPointerAttributes) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[5]
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -414,7 +481,7 @@ func (x *ChasmPointerAttributes) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChasmPointerAttributes.ProtoReflect.Descriptor instead.
 func (*ChasmPointerAttributes) Descriptor() ([]byte, []int) {
-	return file_temporal_server_api_persistence_v1_chasm_proto_rawDescGZIP(), []int{5}
+	return file_temporal_server_api_persistence_v1_chasm_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ChasmPointerAttributes) GetNodePath() []string {
@@ -458,7 +525,7 @@ type ChasmTaskInfo struct {
 
 func (x *ChasmTaskInfo) Reset() {
 	*x = ChasmTaskInfo{}
-	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[6]
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -470,7 +537,7 @@ func (x *ChasmTaskInfo) String() string {
 func (*ChasmTaskInfo) ProtoMessage() {}
 
 func (x *ChasmTaskInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[6]
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -483,7 +550,7 @@ func (x *ChasmTaskInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChasmTaskInfo.ProtoReflect.Descriptor instead.
 func (*ChasmTaskInfo) Descriptor() ([]byte, []int) {
-	return file_temporal_server_api_persistence_v1_chasm_proto_rawDescGZIP(), []int{6}
+	return file_temporal_server_api_persistence_v1_chasm_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ChasmTaskInfo) GetComponentInitialVersionedTransition() *VersionedTransition {
@@ -560,7 +627,7 @@ type ChasmComponentRef struct {
 
 func (x *ChasmComponentRef) Reset() {
 	*x = ChasmComponentRef{}
-	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[7]
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -572,7 +639,7 @@ func (x *ChasmComponentRef) String() string {
 func (*ChasmComponentRef) ProtoMessage() {}
 
 func (x *ChasmComponentRef) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[7]
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -585,7 +652,7 @@ func (x *ChasmComponentRef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChasmComponentRef.ProtoReflect.Descriptor instead.
 func (*ChasmComponentRef) Descriptor() ([]byte, []int) {
-	return file_temporal_server_api_persistence_v1_chasm_proto_rawDescGZIP(), []int{7}
+	return file_temporal_server_api_persistence_v1_chasm_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ChasmComponentRef) GetNamespaceId() string {
@@ -662,7 +729,7 @@ type ChasmNexusCompletion struct {
 
 func (x *ChasmNexusCompletion) Reset() {
 	*x = ChasmNexusCompletion{}
-	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[8]
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -674,7 +741,7 @@ func (x *ChasmNexusCompletion) String() string {
 func (*ChasmNexusCompletion) ProtoMessage() {}
 
 func (x *ChasmNexusCompletion) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[8]
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -687,7 +754,7 @@ func (x *ChasmNexusCompletion) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChasmNexusCompletion.ProtoReflect.Descriptor instead.
 func (*ChasmNexusCompletion) Descriptor() ([]byte, []int) {
-	return file_temporal_server_api_persistence_v1_chasm_proto_rawDescGZIP(), []int{8}
+	return file_temporal_server_api_persistence_v1_chasm_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ChasmNexusCompletion) GetOutcome() isChasmNexusCompletion_Outcome {
@@ -792,7 +859,7 @@ type ChasmComponentAttributes_Task struct {
 
 func (x *ChasmComponentAttributes_Task) Reset() {
 	*x = ChasmComponentAttributes_Task{}
-	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[9]
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -804,7 +871,7 @@ func (x *ChasmComponentAttributes_Task) String() string {
 func (*ChasmComponentAttributes_Task) ProtoMessage() {}
 
 func (x *ChasmComponentAttributes_Task) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[9]
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -883,7 +950,7 @@ type ChasmComponentAttributes_RequestMetadata struct {
 
 func (x *ChasmComponentAttributes_RequestMetadata) Reset() {
 	*x = ChasmComponentAttributes_RequestMetadata{}
-	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[10]
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -895,7 +962,7 @@ func (x *ChasmComponentAttributes_RequestMetadata) String() string {
 func (*ChasmComponentAttributes_RequestMetadata) ProtoMessage() {}
 
 func (x *ChasmComponentAttributes_RequestMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[10]
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -922,7 +989,7 @@ var File_temporal_server_api_persistence_v1_chasm_proto protoreflect.FileDescrip
 
 const file_temporal_server_api_persistence_v1_chasm_proto_rawDesc = "" +
 	"\n" +
-	".temporal/server/api/persistence/v1/chasm.proto\x12\"temporal.server.api.persistence.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a$temporal/api/common/v1/message.proto\x1a%temporal/api/failure/v1/message.proto\x1a'temporal/api/sdk/v1/user_metadata.proto\x1a,temporal/server/api/persistence/v1/hsm.proto\"\x94\x01\n" +
+	".temporal/server/api/persistence/v1/chasm.proto\x12\"temporal.server.api.persistence.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a$temporal/api/common/v1/message.proto\x1a%temporal/api/failure/v1/message.proto\x1a'temporal/api/sdk/v1/user_metadata.proto\x1a,temporal/server/api/persistence/v1/hsm.proto\"\x94\x01\n" +
 	"\tChasmNode\x12Q\n" +
 	"\bmetadata\x18\x01 \x01(\v25.temporal.server.api.persistence.v1.ChasmNodeMetadataR\bmetadata\x124\n" +
 	"\x04data\x18\x02 \x01(\v2 .temporal.api.common.v1.DataBlobR\x04data\"\xd9\x05\n" +
@@ -934,7 +1001,7 @@ const file_temporal_server_api_persistence_v1_chasm_proto_rawDesc = "" +
 	"\x15collection_attributes\x18\r \x01(\v2=.temporal.server.api.persistence.v1.ChasmCollectionAttributesH\x00R\x14collectionAttributes\x12k\n" +
 	"\x12pointer_attributes\x18\x0e \x01(\v2:.temporal.server.api.persistence.v1.ChasmPointerAttributesH\x00R\x11pointerAttributesB\f\n" +
 	"\n" +
-	"attributes\"\xbe\b\n" +
+	"attributes\"\x91\t\n" +
 	"\x18ChasmComponentAttributes\x12\x17\n" +
 	"\atype_id\x18\x01 \x01(\rR\x06typeId\x12m\n" +
 	"\x11side_effect_tasks\x18\x02 \x03(\v2A.temporal.server.api.persistence.v1.ChasmComponentAttributes.TaskR\x0fsideEffectTasks\x12`\n" +
@@ -942,7 +1009,9 @@ const file_temporal_server_api_persistence_v1_chasm_proto_rawDesc = "" +
 	"pure_tasks\x18\x03 \x03(\v2A.temporal.server.api.persistence.v1.ChasmComponentAttributes.TaskR\tpureTasks\x12\x1a\n" +
 	"\bdetached\x18\x04 \x01(\bR\bdetached\x12f\n" +
 	"\brequests\x18\x05 \x03(\v2J.temporal.server.api.persistence.v1.ChasmComponentAttributes.RequestsEntryR\brequests\x12F\n" +
-	"\ruser_metadata\x18\x06 \x01(\v2!.temporal.api.sdk.v1.UserMetadataR\fuserMetadata\x1a\x98\x03\n" +
+	"\ruser_metadata\x18\x06 \x01(\v2!.temporal.api.sdk.v1.UserMetadataR\fuserMetadata\x12Q\n" +
+	"\n" +
+	"pause_info\x18\a \x01(\v22.temporal.server.api.persistence.v1.ChasmPauseInfoR\tpauseInfo\x1a\x98\x03\n" +
 	"\x04Task\x12\x17\n" +
 	"\atype_id\x18\x01 \x01(\rR\x06typeId\x12 \n" +
 	"\vdestination\x18\x02 \x01(\tR\vdestination\x12A\n" +
@@ -955,7 +1024,11 @@ const file_temporal_server_api_persistence_v1_chasm_proto_rawDesc = "" +
 	"\x05links\x18\x01 \x03(\v2\x1c.temporal.api.common.v1.LinkR\x05links\x1a\x89\x01\n" +
 	"\rRequestsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12b\n" +
-	"\x05value\x18\x02 \x01(\v2L.temporal.server.api.persistence.v1.ChasmComponentAttributes.RequestMetadataR\x05value:\x028\x01\"\x15\n" +
+	"\x05value\x18\x02 \x01(\v2L.temporal.server.api.persistence.v1.ChasmComponentAttributes.RequestMetadataR\x05value:\x028\x01\"\xa6\x01\n" +
+	"\x0eChasmPauseInfo\x12;\n" +
+	"\vpaused_time\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"pausedTime\x12W\n" +
+	"\x1aaccumulated_pause_duration\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\x18accumulatedPauseDuration\"\x15\n" +
 	"\x13ChasmDataAttributes\"\x1b\n" +
 	"\x19ChasmCollectionAttributes\"5\n" +
 	"\x16ChasmPointerAttributes\x12\x1b\n" +
@@ -1003,62 +1076,67 @@ func file_temporal_server_api_persistence_v1_chasm_proto_rawDescGZIP() []byte {
 	return file_temporal_server_api_persistence_v1_chasm_proto_rawDescData
 }
 
-var file_temporal_server_api_persistence_v1_chasm_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_temporal_server_api_persistence_v1_chasm_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_temporal_server_api_persistence_v1_chasm_proto_goTypes = []any{
 	(*ChasmNode)(nil),                                // 0: temporal.server.api.persistence.v1.ChasmNode
 	(*ChasmNodeMetadata)(nil),                        // 1: temporal.server.api.persistence.v1.ChasmNodeMetadata
 	(*ChasmComponentAttributes)(nil),                 // 2: temporal.server.api.persistence.v1.ChasmComponentAttributes
-	(*ChasmDataAttributes)(nil),                      // 3: temporal.server.api.persistence.v1.ChasmDataAttributes
-	(*ChasmCollectionAttributes)(nil),                // 4: temporal.server.api.persistence.v1.ChasmCollectionAttributes
-	(*ChasmPointerAttributes)(nil),                   // 5: temporal.server.api.persistence.v1.ChasmPointerAttributes
-	(*ChasmTaskInfo)(nil),                            // 6: temporal.server.api.persistence.v1.ChasmTaskInfo
-	(*ChasmComponentRef)(nil),                        // 7: temporal.server.api.persistence.v1.ChasmComponentRef
-	(*ChasmNexusCompletion)(nil),                     // 8: temporal.server.api.persistence.v1.ChasmNexusCompletion
-	(*ChasmComponentAttributes_Task)(nil),            // 9: temporal.server.api.persistence.v1.ChasmComponentAttributes.Task
-	(*ChasmComponentAttributes_RequestMetadata)(nil), // 10: temporal.server.api.persistence.v1.ChasmComponentAttributes.RequestMetadata
-	nil,                           // 11: temporal.server.api.persistence.v1.ChasmComponentAttributes.RequestsEntry
-	(*v1.DataBlob)(nil),           // 12: temporal.api.common.v1.DataBlob
-	(*VersionedTransition)(nil),   // 13: temporal.server.api.persistence.v1.VersionedTransition
-	(*v11.UserMetadata)(nil),      // 14: temporal.api.sdk.v1.UserMetadata
-	(*v1.Payload)(nil),            // 15: temporal.api.common.v1.Payload
-	(*v12.Failure)(nil),           // 16: temporal.api.failure.v1.Failure
-	(*timestamppb.Timestamp)(nil), // 17: google.protobuf.Timestamp
-	(*v1.Link)(nil),               // 18: temporal.api.common.v1.Link
+	(*ChasmPauseInfo)(nil),                           // 3: temporal.server.api.persistence.v1.ChasmPauseInfo
+	(*ChasmDataAttributes)(nil),                      // 4: temporal.server.api.persistence.v1.ChasmDataAttributes
+	(*ChasmCollectionAttributes)(nil),                // 5: temporal.server.api.persistence.v1.ChasmCollectionAttributes
+	(*ChasmPointerAttributes)(nil),                   // 6: temporal.server.api.persistence.v1.ChasmPointerAttributes
+	(*ChasmTaskInfo)(nil),                            // 7: temporal.server.api.persistence.v1.ChasmTaskInfo
+	(*ChasmComponentRef)(nil),                        // 8: temporal.server.api.persistence.v1.ChasmComponentRef
+	(*ChasmNexusCompletion)(nil),                     // 9: temporal.server.api.persistence.v1.ChasmNexusCompletion
+	(*ChasmComponentAttributes_Task)(nil),            // 10: temporal.server.api.persistence.v1.ChasmComponentAttributes.Task
+	(*ChasmComponentAttributes_RequestMetadata)(nil), // 11: temporal.server.api.persistence.v1.ChasmComponentAttributes.RequestMetadata
+	nil,                           // 12: temporal.server.api.persistence.v1.ChasmComponentAttributes.RequestsEntry
+	(*v1.DataBlob)(nil),           // 13: temporal.api.common.v1.DataBlob
+	(*VersionedTransition)(nil),   // 14: temporal.server.api.persistence.v1.VersionedTransition
+	(*v11.UserMetadata)(nil),      // 15: temporal.api.sdk.v1.UserMetadata
+	(*timestamppb.Timestamp)(nil), // 16: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),   // 17: google.protobuf.Duration
+	(*v1.Payload)(nil),            // 18: temporal.api.common.v1.Payload
+	(*v12.Failure)(nil),           // 19: temporal.api.failure.v1.Failure
+	(*v1.Link)(nil),               // 20: temporal.api.common.v1.Link
 }
 var file_temporal_server_api_persistence_v1_chasm_proto_depIdxs = []int32{
 	1,  // 0: temporal.server.api.persistence.v1.ChasmNode.metadata:type_name -> temporal.server.api.persistence.v1.ChasmNodeMetadata
-	12, // 1: temporal.server.api.persistence.v1.ChasmNode.data:type_name -> temporal.api.common.v1.DataBlob
-	13, // 2: temporal.server.api.persistence.v1.ChasmNodeMetadata.initial_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	13, // 3: temporal.server.api.persistence.v1.ChasmNodeMetadata.last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	13, // 1: temporal.server.api.persistence.v1.ChasmNode.data:type_name -> temporal.api.common.v1.DataBlob
+	14, // 2: temporal.server.api.persistence.v1.ChasmNodeMetadata.initial_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	14, // 3: temporal.server.api.persistence.v1.ChasmNodeMetadata.last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
 	2,  // 4: temporal.server.api.persistence.v1.ChasmNodeMetadata.component_attributes:type_name -> temporal.server.api.persistence.v1.ChasmComponentAttributes
-	3,  // 5: temporal.server.api.persistence.v1.ChasmNodeMetadata.data_attributes:type_name -> temporal.server.api.persistence.v1.ChasmDataAttributes
-	4,  // 6: temporal.server.api.persistence.v1.ChasmNodeMetadata.collection_attributes:type_name -> temporal.server.api.persistence.v1.ChasmCollectionAttributes
-	5,  // 7: temporal.server.api.persistence.v1.ChasmNodeMetadata.pointer_attributes:type_name -> temporal.server.api.persistence.v1.ChasmPointerAttributes
-	9,  // 8: temporal.server.api.persistence.v1.ChasmComponentAttributes.side_effect_tasks:type_name -> temporal.server.api.persistence.v1.ChasmComponentAttributes.Task
-	9,  // 9: temporal.server.api.persistence.v1.ChasmComponentAttributes.pure_tasks:type_name -> temporal.server.api.persistence.v1.ChasmComponentAttributes.Task
-	11, // 10: temporal.server.api.persistence.v1.ChasmComponentAttributes.requests:type_name -> temporal.server.api.persistence.v1.ChasmComponentAttributes.RequestsEntry
-	14, // 11: temporal.server.api.persistence.v1.ChasmComponentAttributes.user_metadata:type_name -> temporal.api.sdk.v1.UserMetadata
-	13, // 12: temporal.server.api.persistence.v1.ChasmTaskInfo.component_initial_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	13, // 13: temporal.server.api.persistence.v1.ChasmTaskInfo.component_last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	12, // 14: temporal.server.api.persistence.v1.ChasmTaskInfo.data:type_name -> temporal.api.common.v1.DataBlob
-	13, // 15: temporal.server.api.persistence.v1.ChasmTaskInfo.task_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	13, // 16: temporal.server.api.persistence.v1.ChasmComponentRef.execution_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	13, // 17: temporal.server.api.persistence.v1.ChasmComponentRef.component_initial_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	15, // 18: temporal.server.api.persistence.v1.ChasmNexusCompletion.success:type_name -> temporal.api.common.v1.Payload
-	16, // 19: temporal.server.api.persistence.v1.ChasmNexusCompletion.failure:type_name -> temporal.api.failure.v1.Failure
-	17, // 20: temporal.server.api.persistence.v1.ChasmNexusCompletion.close_time:type_name -> google.protobuf.Timestamp
-	18, // 21: temporal.server.api.persistence.v1.ChasmNexusCompletion.links:type_name -> temporal.api.common.v1.Link
-	17, // 22: temporal.server.api.persistence.v1.ChasmNexusCompletion.start_time:type_name -> google.protobuf.Timestamp
-	17, // 23: temporal.server.api.persistence.v1.ChasmComponentAttributes.Task.scheduled_time:type_name -> google.protobuf.Timestamp
-	12, // 24: temporal.server.api.persistence.v1.ChasmComponentAttributes.Task.data:type_name -> temporal.api.common.v1.DataBlob
-	13, // 25: temporal.server.api.persistence.v1.ChasmComponentAttributes.Task.versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	18, // 26: temporal.server.api.persistence.v1.ChasmComponentAttributes.RequestMetadata.links:type_name -> temporal.api.common.v1.Link
-	10, // 27: temporal.server.api.persistence.v1.ChasmComponentAttributes.RequestsEntry.value:type_name -> temporal.server.api.persistence.v1.ChasmComponentAttributes.RequestMetadata
-	28, // [28:28] is the sub-list for method output_type
-	28, // [28:28] is the sub-list for method input_type
-	28, // [28:28] is the sub-list for extension type_name
-	28, // [28:28] is the sub-list for extension extendee
-	0,  // [0:28] is the sub-list for field type_name
+	4,  // 5: temporal.server.api.persistence.v1.ChasmNodeMetadata.data_attributes:type_name -> temporal.server.api.persistence.v1.ChasmDataAttributes
+	5,  // 6: temporal.server.api.persistence.v1.ChasmNodeMetadata.collection_attributes:type_name -> temporal.server.api.persistence.v1.ChasmCollectionAttributes
+	6,  // 7: temporal.server.api.persistence.v1.ChasmNodeMetadata.pointer_attributes:type_name -> temporal.server.api.persistence.v1.ChasmPointerAttributes
+	10, // 8: temporal.server.api.persistence.v1.ChasmComponentAttributes.side_effect_tasks:type_name -> temporal.server.api.persistence.v1.ChasmComponentAttributes.Task
+	10, // 9: temporal.server.api.persistence.v1.ChasmComponentAttributes.pure_tasks:type_name -> temporal.server.api.persistence.v1.ChasmComponentAttributes.Task
+	12, // 10: temporal.server.api.persistence.v1.ChasmComponentAttributes.requests:type_name -> temporal.server.api.persistence.v1.ChasmComponentAttributes.RequestsEntry
+	15, // 11: temporal.server.api.persistence.v1.ChasmComponentAttributes.user_metadata:type_name -> temporal.api.sdk.v1.UserMetadata
+	3,  // 12: temporal.server.api.persistence.v1.ChasmComponentAttributes.pause_info:type_name -> temporal.server.api.persistence.v1.ChasmPauseInfo
+	16, // 13: temporal.server.api.persistence.v1.ChasmPauseInfo.paused_time:type_name -> google.protobuf.Timestamp
+	17, // 14: temporal.server.api.persistence.v1.ChasmPauseInfo.accumulated_pause_duration:type_name -> google.protobuf.Duration
+	14, // 15: temporal.server.api.persistence.v1.ChasmTaskInfo.component_initial_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	14, // 16: temporal.server.api.persistence.v1.ChasmTaskInfo.component_last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	13, // 17: temporal.server.api.persistence.v1.ChasmTaskInfo.data:type_name -> temporal.api.common.v1.DataBlob
+	14, // 18: temporal.server.api.persistence.v1.ChasmTaskInfo.task_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	14, // 19: temporal.server.api.persistence.v1.ChasmComponentRef.execution_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	14, // 20: temporal.server.api.persistence.v1.ChasmComponentRef.component_initial_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	18, // 21: temporal.server.api.persistence.v1.ChasmNexusCompletion.success:type_name -> temporal.api.common.v1.Payload
+	19, // 22: temporal.server.api.persistence.v1.ChasmNexusCompletion.failure:type_name -> temporal.api.failure.v1.Failure
+	16, // 23: temporal.server.api.persistence.v1.ChasmNexusCompletion.close_time:type_name -> google.protobuf.Timestamp
+	20, // 24: temporal.server.api.persistence.v1.ChasmNexusCompletion.links:type_name -> temporal.api.common.v1.Link
+	16, // 25: temporal.server.api.persistence.v1.ChasmNexusCompletion.start_time:type_name -> google.protobuf.Timestamp
+	16, // 26: temporal.server.api.persistence.v1.ChasmComponentAttributes.Task.scheduled_time:type_name -> google.protobuf.Timestamp
+	13, // 27: temporal.server.api.persistence.v1.ChasmComponentAttributes.Task.data:type_name -> temporal.api.common.v1.DataBlob
+	14, // 28: temporal.server.api.persistence.v1.ChasmComponentAttributes.Task.versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	20, // 29: temporal.server.api.persistence.v1.ChasmComponentAttributes.RequestMetadata.links:type_name -> temporal.api.common.v1.Link
+	11, // 30: temporal.server.api.persistence.v1.ChasmComponentAttributes.RequestsEntry.value:type_name -> temporal.server.api.persistence.v1.ChasmComponentAttributes.RequestMetadata
+	31, // [31:31] is the sub-list for method output_type
+	31, // [31:31] is the sub-list for method input_type
+	31, // [31:31] is the sub-list for extension type_name
+	31, // [31:31] is the sub-list for extension extendee
+	0,  // [0:31] is the sub-list for field type_name
 }
 
 func init() { file_temporal_server_api_persistence_v1_chasm_proto_init() }
@@ -1073,7 +1151,7 @@ func file_temporal_server_api_persistence_v1_chasm_proto_init() {
 		(*ChasmNodeMetadata_CollectionAttributes)(nil),
 		(*ChasmNodeMetadata_PointerAttributes)(nil),
 	}
-	file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[8].OneofWrappers = []any{
+	file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[9].OneofWrappers = []any{
 		(*ChasmNexusCompletion_Success)(nil),
 		(*ChasmNexusCompletion_Failure)(nil),
 	}
@@ -1083,7 +1161,7 @@ func file_temporal_server_api_persistence_v1_chasm_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_temporal_server_api_persistence_v1_chasm_proto_rawDesc), len(file_temporal_server_api_persistence_v1_chasm_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   12,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/chasm/context.go
+++ b/chasm/context.go
@@ -21,9 +21,13 @@ type Context interface {
 	// NOTE: component created in the current transaction won't have a ref
 	// this is a Ref to the component state at the start of the transition
 	Ref(Component) ([]byte, error)
-	// Now returns the current time in the context of the given component.
-	// In a context of a transaction, this time must be used to allow for framework support of pause and time skipping.
+	// Now returns the current time for this transaction. Stable within a transaction.
+	// In a context of a transaction, this time must be used to allow for framework support of time skipping.
 	Now(Component) time.Time
+	// PauseInfo returns the accumulated pause information for the given component.
+	// The returned struct is a snapshot of the pause state as of the start of this transaction.
+	// Application logic can use this to compute a pause-adjusted time or implement SLA tracking.
+	PauseInfo(Component) ComponentPauseInfo
 	// ExecutionKey returns the execution key for the execution the context is operating on.
 	ExecutionKey() ExecutionKey
 	// ExecutionInfo returns metadata information about the execution.
@@ -66,6 +70,16 @@ type Context interface {
 	withValue(key any, value any) Context
 	structuredRef(Component) (ComponentRef, error)
 	goContext() context.Context
+}
+
+// ComponentPauseInfo is a snapshot of a component's pause accounting as of the start of a transaction.
+type ComponentPauseInfo struct {
+	// PausedSince is the wall-clock time when the component entered LifecycleStatePaused,
+	// or nil if the component is not currently paused.
+	PausedSince *time.Time
+	// AccumulatedPauseDuration is the total time spent paused across all completed pause/unpause cycles.
+	// Does not include the current ongoing pause interval (if any); add time.Since(*PausedSince) for that.
+	AccumulatedPauseDuration time.Duration
 }
 
 type ExecutionInfo struct {
@@ -172,11 +186,27 @@ func (c *immutableCtx) UserMetadata(component Component) *sdkpb.UserMetadata {
 	return c.root.componentUserMetadata(component)
 }
 
-func (c *immutableCtx) Now(component Component) time.Time {
+func (c *immutableCtx) Now(_ Component) time.Time {
+	return c.now
+}
+
+func (c *immutableCtx) PauseInfo(component Component) ComponentPauseInfo {
 	if component == nil {
-		return c.now
+		return ComponentPauseInfo{}
 	}
-	return c.root.componentNow(component, c.now)
+	info := c.root.componentPauseInfo(component)
+	if info == nil {
+		return ComponentPauseInfo{}
+	}
+	var pausedSince *time.Time
+	if pt := info.GetPausedTime(); pt != nil {
+		t := pt.AsTime()
+		pausedSince = &t
+	}
+	return ComponentPauseInfo{
+		PausedSince:              pausedSince,
+		AccumulatedPauseDuration: info.GetAccumulatedPauseDuration().AsDuration(),
+	}
 }
 
 func (c *immutableCtx) ExecutionKey() ExecutionKey {

--- a/chasm/context.go
+++ b/chasm/context.go
@@ -124,8 +124,6 @@ type immutableCtx struct {
 
 type mutableCtx struct {
 	*immutableCtx
-
-	now **time.Time
 }
 
 // NewContext creates a new Context from an existing Context and root Node.
@@ -174,8 +172,11 @@ func (c *immutableCtx) UserMetadata(component Component) *sdkpb.UserMetadata {
 	return c.root.componentUserMetadata(component)
 }
 
-func (c *immutableCtx) Now(_ Component) time.Time {
-	return c.now
+func (c *immutableCtx) Now(component Component) time.Time {
+	if component == nil {
+		return c.now
+	}
+	return c.root.componentNow(component, c.now)
 }
 
 func (c *immutableCtx) ExecutionKey() ExecutionKey {
@@ -258,26 +259,9 @@ func NewMutableContext(
 	ctx context.Context,
 	node *Node,
 ) MutableContext {
-	var now *time.Time
 	return &mutableCtx{
 		immutableCtx: newContext(ctx, node),
-		now:          &now,
 	}
-}
-
-func (c *mutableCtx) Now(component Component) time.Time {
-	if c.now == nil {
-		var now *time.Time
-		c.now = &now
-	}
-
-	if *c.now != nil {
-		return **c.now
-	}
-
-	now := c.root.Now(component)
-	*c.now = &now
-	return now
 }
 
 func (c *mutableCtx) AddTask(
@@ -297,14 +281,8 @@ func (c *mutableCtx) SetUserMetadata(component Component, md *sdkpb.UserMetadata
 }
 
 func (c *mutableCtx) withValue(key any, value any) Context {
-	if c.now == nil {
-		var now *time.Time
-		c.now = &now
-	}
-
 	return &mutableCtx{
 		immutableCtx: ContextWithValue(c.immutableCtx, key, value),
-		now:          c.now,
 	}
 }
 

--- a/chasm/context.go
+++ b/chasm/context.go
@@ -80,9 +80,18 @@ type ComponentPauseInfo struct {
 	// PausedSince is the wall-clock time when the component entered LifecycleStatePaused,
 	// or nil if the component is not currently paused.
 	PausedSince *time.Time
-	// AccumulatedPauseDuration is the total time spent paused across all completed pause/unpause cycles.
-	// Does not include the current ongoing pause interval; add time.Since(*PausedSince) for that.
-	AccumulatedPauseDuration time.Duration
+	// PastPausedDuration is the total time spent paused across all completed pause/unpause cycles.
+	// Does not include the current ongoing pause interval; use TotalPausedDuration for that.
+	PastPausedDuration time.Duration
+}
+
+// TotalPausedDuration returns the total time this component has been paused, including the
+// current ongoing pause interval if the component is currently paused.
+func (p ComponentPauseInfo) TotalPausedDuration(now time.Time) time.Duration {
+	if p.PausedSince == nil {
+		return p.PastPausedDuration
+	}
+	return p.PastPausedDuration + now.Sub(*p.PausedSince)
 }
 
 type ExecutionInfo struct {
@@ -208,7 +217,7 @@ func (c *immutableCtx) PauseInfo(component Component) ComponentPauseInfo {
 	}
 	return ComponentPauseInfo{
 		PausedSince:              pausedSince,
-		AccumulatedPauseDuration: info.GetAccumulatedPauseDuration().AsDuration(),
+		PastPausedDuration: info.GetAccumulatedPauseDuration().AsDuration(),
 	}
 }
 

--- a/chasm/context.go
+++ b/chasm/context.go
@@ -21,12 +21,15 @@ type Context interface {
 	// NOTE: component created in the current transaction won't have a ref
 	// this is a Ref to the component state at the start of the transition
 	Ref(Component) ([]byte, error)
-	// Now returns the current time for this transaction. Stable within a transaction.
-	// In a context of a transaction, this time must be used to allow for framework support of time skipping.
+	// Now returns the current time, stable for the lifetime of this context.
+	// Must be used within a transaction to allow for framework support of time skipping.
+	// Note: Now does not account for pause state; use PauseInfo to incorporate pause duration
+	// into time calculations.
 	Now(Component) time.Time
-	// PauseInfo returns the accumulated pause information for the given component.
-	// The returned struct is a snapshot of the pause state as of the start of this transaction.
-	// Application logic can use this to compute a pause-adjusted time or implement SLA tracking.
+	// PauseInfo returns pause accounting for the given component as of the start of this context.
+	// Because LifecycleStatePaused covers the entire component subtree, the framework accumulates
+	// pause duration on every component in the subtree, not only the one that returned the paused
+	// state. Application logic can use this to compute a pause-adjusted time or implement SLA tracking.
 	PauseInfo(Component) ComponentPauseInfo
 	// ExecutionKey returns the execution key for the execution the context is operating on.
 	ExecutionKey() ExecutionKey
@@ -72,13 +75,13 @@ type Context interface {
 	goContext() context.Context
 }
 
-// ComponentPauseInfo is a snapshot of a component's pause accounting as of the start of a transaction.
+// ComponentPauseInfo is a snapshot of a component's pause accounting as of the start of this context.
 type ComponentPauseInfo struct {
 	// PausedSince is the wall-clock time when the component entered LifecycleStatePaused,
 	// or nil if the component is not currently paused.
 	PausedSince *time.Time
 	// AccumulatedPauseDuration is the total time spent paused across all completed pause/unpause cycles.
-	// Does not include the current ongoing pause interval (if any); add time.Since(*PausedSince) for that.
+	// Does not include the current ongoing pause interval; add time.Since(*PausedSince) for that.
 	AccumulatedPauseDuration time.Duration
 }
 

--- a/chasm/context.go
+++ b/chasm/context.go
@@ -124,6 +124,8 @@ type immutableCtx struct {
 
 type mutableCtx struct {
 	*immutableCtx
+
+	nowByComponent map[*Node]time.Time
 }
 
 // NewContext creates a new Context from an existing Context and root Node.
@@ -257,8 +259,27 @@ func NewMutableContext(
 	node *Node,
 ) MutableContext {
 	return &mutableCtx{
-		immutableCtx: newContext(ctx, node),
+		immutableCtx:   newContext(ctx, node),
+		nowByComponent: make(map[*Node]time.Time),
 	}
+}
+
+func (c *mutableCtx) Now(component Component) time.Time {
+	node, ok := c.root.valueToNode[component]
+	if !ok || !node.isComponent() {
+		return c.root.Now(component)
+	}
+
+	if now, ok := c.nowByComponent[node]; ok {
+		return now
+	}
+
+	now := c.root.Now(component)
+	if c.nowByComponent == nil {
+		c.nowByComponent = make(map[*Node]time.Time)
+	}
+	c.nowByComponent[node] = now
+	return now
 }
 
 func (c *mutableCtx) AddTask(
@@ -279,7 +300,8 @@ func (c *mutableCtx) SetUserMetadata(component Component, md *sdkpb.UserMetadata
 
 func (c *mutableCtx) withValue(key any, value any) Context {
 	return &mutableCtx{
-		immutableCtx: ContextWithValue(c.immutableCtx, key, value),
+		immutableCtx:   ContextWithValue(c.immutableCtx, key, value),
+		nowByComponent: c.nowByComponent,
 	}
 }
 

--- a/chasm/context.go
+++ b/chasm/context.go
@@ -125,7 +125,7 @@ type immutableCtx struct {
 type mutableCtx struct {
 	*immutableCtx
 
-	nowByComponent map[*Node]time.Time
+	now **time.Time
 }
 
 // NewContext creates a new Context from an existing Context and root Node.
@@ -258,27 +258,25 @@ func NewMutableContext(
 	ctx context.Context,
 	node *Node,
 ) MutableContext {
+	var now *time.Time
 	return &mutableCtx{
-		immutableCtx:   newContext(ctx, node),
-		nowByComponent: make(map[*Node]time.Time),
+		immutableCtx: newContext(ctx, node),
+		now:          &now,
 	}
 }
 
 func (c *mutableCtx) Now(component Component) time.Time {
-	node, ok := c.root.valueToNode[component]
-	if !ok || !node.isComponent() {
-		return c.root.Now(component)
+	if c.now == nil {
+		var now *time.Time
+		c.now = &now
 	}
 
-	if now, ok := c.nowByComponent[node]; ok {
-		return now
+	if *c.now != nil {
+		return **c.now
 	}
 
 	now := c.root.Now(component)
-	if c.nowByComponent == nil {
-		c.nowByComponent = make(map[*Node]time.Time)
-	}
-	c.nowByComponent[node] = now
+	*c.now = &now
 	return now
 }
 
@@ -299,9 +297,14 @@ func (c *mutableCtx) SetUserMetadata(component Component, md *sdkpb.UserMetadata
 }
 
 func (c *mutableCtx) withValue(key any, value any) Context {
+	if c.now == nil {
+		var now *time.Time
+		c.now = &now
+	}
+
 	return &mutableCtx{
-		immutableCtx:   ContextWithValue(c.immutableCtx, key, value),
-		nowByComponent: c.nowByComponent,
+		immutableCtx: ContextWithValue(c.immutableCtx, key, value),
+		now:          c.now,
 	}
 }
 

--- a/chasm/context_mock.go
+++ b/chasm/context_mock.go
@@ -89,6 +89,10 @@ func (c *MockContext) Now(cmp Component) time.Time {
 	return time.Now()
 }
 
+func (c *MockContext) PauseInfo(_ Component) ComponentPauseInfo {
+	return ComponentPauseInfo{}
+}
+
 func (c *MockContext) Ref(cmp Component) ([]byte, error) {
 	if c.HandleRef != nil {
 		return c.HandleRef(cmp)

--- a/chasm/lib/tests/gen/testspb/v1/message.pb.go
+++ b/chasm/lib/tests/gen/testspb/v1/message.pb.go
@@ -31,6 +31,7 @@ type TestPayloadStore struct {
 	ExpirationTimes map[string]*timestamppb.Timestamp `protobuf:"bytes,3,rep,name=expiration_times,json=expirationTimes,proto3" json:"expiration_times,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Closed          bool                              `protobuf:"varint,4,opt,name=closed,proto3" json:"closed,omitempty"`
 	Canceled        bool                              `protobuf:"varint,5,opt,name=canceled,proto3" json:"canceled,omitempty"`
+	Paused          bool                              `protobuf:"varint,6,opt,name=paused,proto3" json:"paused,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -96,6 +97,13 @@ func (x *TestPayloadStore) GetClosed() bool {
 func (x *TestPayloadStore) GetCanceled() bool {
 	if x != nil {
 		return x.Canceled
+	}
+	return false
+}
+
+func (x *TestPayloadStore) GetPaused() bool {
+	if x != nil {
+		return x.Paused
 	}
 	return false
 }
@@ -192,7 +200,7 @@ var File_temporal_server_chasm_lib_tests_proto_v1_message_proto protoreflect.Fil
 
 const file_temporal_server_chasm_lib_tests_proto_v1_message_proto_rawDesc = "" +
 	"\n" +
-	"6temporal/server/chasm/lib/tests/proto/v1/message.proto\x12(temporal.server.chasm.lib.tests.proto.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xe2\x02\n" +
+	"6temporal/server/chasm/lib/tests/proto/v1/message.proto\x12(temporal.server.chasm.lib.tests.proto.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xfa\x02\n" +
 	"\x10TestPayloadStore\x12\x1f\n" +
 	"\vtotal_count\x18\x01 \x01(\x03R\n" +
 	"totalCount\x12\x1d\n" +
@@ -200,7 +208,8 @@ const file_temporal_server_chasm_lib_tests_proto_v1_message_proto_rawDesc = "" +
 	"total_size\x18\x02 \x01(\x03R\ttotalSize\x12z\n" +
 	"\x10expiration_times\x18\x03 \x03(\v2O.temporal.server.chasm.lib.tests.proto.v1.TestPayloadStore.ExpirationTimesEntryR\x0fexpirationTimes\x12\x16\n" +
 	"\x06closed\x18\x04 \x01(\bR\x06closed\x12\x1a\n" +
-	"\bcanceled\x18\x05 \x01(\bR\bcanceled\x1a^\n" +
+	"\bcanceled\x18\x05 \x01(\bR\bcanceled\x12\x16\n" +
+	"\x06paused\x18\x06 \x01(\bR\x06paused\x1a^\n" +
 	"\x14ExpirationTimesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x05value:\x028\x01\"9\n" +

--- a/chasm/lib/tests/handler.go
+++ b/chasm/lib/tests/handler.go
@@ -10,6 +10,11 @@ import (
 	"go.temporal.io/server/common/namespace"
 )
 
+// GetNowResponse holds the result of calling ctx.Now(component) on a PayloadStore.
+type GetNowResponse struct {
+	Now time.Time
+}
+
 type (
 	NewPayloadStoreRequest struct {
 		NamespaceID      namespace.ID
@@ -250,4 +255,60 @@ func RemovePayloadHandler(
 	return RemovePayloadResponse{
 		State: state,
 	}, nil
+}
+
+func PausePayloadStoreHandler(
+	ctx context.Context,
+	namespaceID namespace.ID,
+	storeID string,
+) error {
+	_, _, err := chasm.UpdateComponent(
+		ctx,
+		chasm.NewComponentRef[*PayloadStore](
+			chasm.ExecutionKey{
+				NamespaceID: namespaceID.String(),
+				BusinessID:  storeID,
+			},
+		),
+		(*PayloadStore).Pause,
+		nil,
+	)
+	return err
+}
+
+func UnpausePayloadStoreHandler(
+	ctx context.Context,
+	namespaceID namespace.ID,
+	storeID string,
+) error {
+	_, _, err := chasm.UpdateComponent(
+		ctx,
+		chasm.NewComponentRef[*PayloadStore](
+			chasm.ExecutionKey{
+				NamespaceID: namespaceID.String(),
+				BusinessID:  storeID,
+			},
+		),
+		(*PayloadStore).Unpause,
+		nil,
+	)
+	return err
+}
+
+func GetNowHandler(
+	ctx context.Context,
+	namespaceID namespace.ID,
+	storeID string,
+) (GetNowResponse, error) {
+	return chasm.ReadComponent(
+		ctx,
+		chasm.NewComponentRef[*PayloadStore](
+			chasm.ExecutionKey{
+				NamespaceID: namespaceID.String(),
+				BusinessID:  storeID,
+			},
+		),
+		(*PayloadStore).GetNow,
+		nil,
+	)
 }

--- a/chasm/lib/tests/handler.go
+++ b/chasm/lib/tests/handler.go
@@ -10,10 +10,6 @@ import (
 	"go.temporal.io/server/common/namespace"
 )
 
-// GetNowResponse holds the result of calling ctx.Now(component) on a PayloadStore.
-type GetNowResponse struct {
-	Now time.Time
-}
 
 type (
 	NewPayloadStoreRequest struct {
@@ -295,11 +291,11 @@ func UnpausePayloadStoreHandler(
 	return err
 }
 
-func GetNowHandler(
+func GetPauseInfoHandler(
 	ctx context.Context,
 	namespaceID namespace.ID,
 	storeID string,
-) (GetNowResponse, error) {
+) (chasm.ComponentPauseInfo, error) {
 	return chasm.ReadComponent(
 		ctx,
 		chasm.NewComponentRef[*PayloadStore](
@@ -308,7 +304,7 @@ func GetNowHandler(
 				BusinessID:  storeID,
 			},
 		),
-		(*PayloadStore).GetNow,
+		(*PayloadStore).GetPauseInfo,
 		nil,
 	)
 }

--- a/chasm/lib/tests/handler.go
+++ b/chasm/lib/tests/handler.go
@@ -10,7 +10,6 @@ import (
 	"go.temporal.io/server/common/namespace"
 )
 
-
 type (
 	NewPayloadStoreRequest struct {
 		NamespaceID      namespace.ID

--- a/chasm/lib/tests/payload.go
+++ b/chasm/lib/tests/payload.go
@@ -215,7 +215,42 @@ func (s *PayloadStore) LifecycleState(
 	if s.State.Closed {
 		return chasm.LifecycleStateCompleted
 	}
+	if s.State.Paused {
+		return chasm.LifecycleStatePaused
+	}
 	return chasm.LifecycleStateRunning
+}
+
+func (s *PayloadStore) Pause(
+	mutableContext chasm.MutableContext,
+	_ chasm.NoValue,
+) (chasm.NoValue, error) {
+	if err := assertContextValue(mutableContext); err != nil {
+		return nil, err
+	}
+	s.State.Paused = true
+	return nil, nil
+}
+
+func (s *PayloadStore) Unpause(
+	mutableContext chasm.MutableContext,
+	_ chasm.NoValue,
+) (chasm.NoValue, error) {
+	if err := assertContextValue(mutableContext); err != nil {
+		return nil, err
+	}
+	s.State.Paused = false
+	return nil, nil
+}
+
+func (s *PayloadStore) GetNow(
+	chasmContext chasm.Context,
+	_ chasm.NoValue,
+) (GetNowResponse, error) {
+	if err := assertContextValue(chasmContext); err != nil {
+		return GetNowResponse{}, err
+	}
+	return GetNowResponse{Now: chasmContext.Now(s)}, nil
 }
 
 func (s *PayloadStore) Terminate(

--- a/chasm/lib/tests/payload.go
+++ b/chasm/lib/tests/payload.go
@@ -243,14 +243,14 @@ func (s *PayloadStore) Unpause(
 	return nil, nil
 }
 
-func (s *PayloadStore) GetNow(
+func (s *PayloadStore) GetPauseInfo(
 	chasmContext chasm.Context,
 	_ chasm.NoValue,
-) (GetNowResponse, error) {
+) (chasm.ComponentPauseInfo, error) {
 	if err := assertContextValue(chasmContext); err != nil {
-		return GetNowResponse{}, err
+		return chasm.ComponentPauseInfo{}, err
 	}
-	return GetNowResponse{Now: chasmContext.Now(s)}, nil
+	return chasmContext.PauseInfo(s), nil
 }
 
 func (s *PayloadStore) Terminate(

--- a/chasm/lib/tests/proto/v1/message.proto
+++ b/chasm/lib/tests/proto/v1/message.proto
@@ -13,6 +13,7 @@ message TestPayloadStore {
   map<string, google.protobuf.Timestamp> expiration_times = 3;
   bool closed = 4;
   bool canceled = 5;
+  bool paused = 6;
 }
 
 message TestPayloadTTLPureTask {

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -32,6 +32,7 @@ import (
 	"go.temporal.io/server/service/history/tasks"
 	"golang.org/x/exp/maps"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -1565,6 +1566,68 @@ func (n *Node) applyPendingComponentMetadata() bool {
 	return dirty
 }
 
+// closeTransactionUpdatePauseInfo detects LifecycleStatePaused transitions for
+// every component node that was accessed (deserialized) in this transaction, and
+// updates ChasmPauseInfo accordingly so that Now(component) returns a stable,
+// pause-adjusted time in subsequent transactions.
+//
+// Called after closeTransactionApplyPendingComponentMetadata so that all
+// framework-managed metadata has already been written to serializedNode.
+func (n *Node) closeTransactionUpdatePauseInfo(immutableContext Context) error {
+	now := n.timeSource.Now()
+	for _, node := range n.andAllChildren() {
+		if !node.isComponent() {
+			continue
+		}
+		// Skip nodes that were never loaded; their lifecycle state cannot have changed.
+		if node.valueState == valueStateNeedDeserialize {
+			continue
+		}
+		component, ok := node.value.(Component)
+		if !ok {
+			continue
+		}
+
+		attrs := node.serializedNode.GetMetadata().GetComponentAttributes()
+		if attrs == nil {
+			continue
+		}
+
+		currentState := component.LifecycleState(immutableContext)
+		pauseInfo := attrs.GetPauseInfo()
+		wasPaused := pauseInfo != nil && pauseInfo.PausedTime != nil
+		isPaused := currentState.IsPaused()
+
+		switch {
+		case !wasPaused && isPaused:
+			// Transition into paused: record the start of this pause interval.
+			if attrs.PauseInfo == nil {
+				attrs.PauseInfo = &persistencespb.ChasmPauseInfo{}
+			}
+			attrs.PauseInfo.PausedTime = timestamppb.New(now)
+		case wasPaused && !isPaused:
+			// Transition out of paused: accumulate the duration of this pause interval.
+			elapsed := now.Sub(pauseInfo.PausedTime.AsTime())
+			prev := pauseInfo.GetAccumulatedPauseDuration().AsDuration()
+			attrs.PauseInfo.AccumulatedPauseDuration = durationpb.New(prev + elapsed)
+			attrs.PauseInfo.PausedTime = nil
+		default:
+			continue
+		}
+
+		encodedPath, err := node.getEncodedPath()
+		if err != nil {
+			return err
+		}
+		if _, exists := n.mutation.UpdatedNodes[encodedPath]; !exists {
+			node.updateLastUpdateVersionedTransition()
+			n.mutation.UpdatedNodes[encodedPath] = node.serializedNode
+			delete(n.mutation.DeletedNodes, encodedPath)
+		}
+	}
+	return nil
+}
+
 // componentNodePath implements the CHASM Context interface
 func (n *Node) componentNodePath(
 	component Component,
@@ -1595,12 +1658,44 @@ func (n *Node) dataNodePath(
 	return refNode.path(), nil
 }
 
-// Now implements the CHASM Context interface
+// Now returns the current wall-clock time for non-component callers.
 func (n *Node) Now(
 	_ Component,
 ) time.Time {
-	// TODO: Now() could be different for components after we support Pause for CHASM components.
 	return n.timeSource.Now()
+}
+
+// componentNow returns the effective current time for the given component,
+// adjusting for any accumulated pause duration so that time does not advance
+// while a component is in LifecycleStatePaused.
+//
+// If the component is currently paused (pausedTime is set), its logical time is
+// frozen at the moment the pause began. If the component has been paused before
+// but is now running, the accumulated pause duration is subtracted from baseNow
+// so that logical time resumes from where it left off.
+func (n *Node) componentNow(component Component, baseNow time.Time) time.Time {
+	node, ok := n.valueToNode[component]
+	if !ok {
+		// Component not yet registered as a tree node (created in this transaction).
+		return baseNow
+	}
+	attrs := node.serializedNode.GetMetadata().GetComponentAttributes()
+	if attrs == nil {
+		return baseNow
+	}
+	pauseInfo := attrs.GetPauseInfo()
+	if pauseInfo == nil {
+		return baseNow
+	}
+	if pt := pauseInfo.GetPausedTime(); pt != nil {
+		// Frozen at the time the pause began.
+		return pt.AsTime()
+	}
+	accum := pauseInfo.GetAccumulatedPauseDuration().AsDuration()
+	if accum == 0 {
+		return baseNow
+	}
+	return baseNow.Add(-accum)
 }
 
 // AddTask implements the CHASM MutableContext interface
@@ -1670,6 +1765,10 @@ func (n *Node) CloseTransaction() (NodesMutation, error) {
 	}
 
 	if err := n.closeTransactionApplyPendingComponentMetadata(); err != nil {
+		return NodesMutation{}, err
+	}
+
+	if err := n.closeTransactionUpdatePauseInfo(immutableContext); err != nil {
 		return NodesMutation{}, err
 	}
 

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -1566,21 +1566,12 @@ func (n *Node) applyPendingComponentMetadata() bool {
 	return dirty
 }
 
-// closeTransactionUpdatePauseInfo detects LifecycleStatePaused transitions for
-// every component node that was accessed (deserialized) in this transaction, and
-// updates ChasmPauseInfo accordingly so that Now(component) returns a stable,
-// pause-adjusted time in subsequent transactions.
-//
-// Called after closeTransactionApplyPendingComponentMetadata so that all
-// framework-managed metadata has already been written to serializedNode.
+// closeTransactionUpdatePauseInfo updates ChasmPauseInfo for components that
+// transitioned into or out of LifecycleStatePaused this transaction.
 func (n *Node) closeTransactionUpdatePauseInfo(immutableContext Context) error {
 	now := n.timeSource.Now()
 	for _, node := range n.andAllChildren() {
 		if !node.isComponent() {
-			continue
-		}
-		// Skip nodes that were never loaded; their lifecycle state cannot have changed.
-		if node.valueState == valueStateNeedDeserialize {
 			continue
 		}
 		component, ok := node.value.(Component)
@@ -1593,36 +1584,20 @@ func (n *Node) closeTransactionUpdatePauseInfo(immutableContext Context) error {
 			continue
 		}
 
-		currentState := component.LifecycleState(immutableContext)
 		pauseInfo := attrs.GetPauseInfo()
 		wasPaused := pauseInfo != nil && pauseInfo.PausedTime != nil
-		isPaused := currentState.IsPaused()
+		isPaused := component.LifecycleState(immutableContext).IsPaused()
 
 		switch {
 		case !wasPaused && isPaused:
-			// Transition into paused: record the start of this pause interval.
 			if attrs.PauseInfo == nil {
 				attrs.PauseInfo = &persistencespb.ChasmPauseInfo{}
 			}
 			attrs.PauseInfo.PausedTime = timestamppb.New(now)
 		case wasPaused && !isPaused:
-			// Transition out of paused: accumulate the duration of this pause interval.
 			elapsed := now.Sub(pauseInfo.PausedTime.AsTime())
-			prev := pauseInfo.GetAccumulatedPauseDuration().AsDuration()
-			attrs.PauseInfo.AccumulatedPauseDuration = durationpb.New(prev + elapsed)
+			attrs.PauseInfo.AccumulatedPauseDuration = durationpb.New(pauseInfo.GetAccumulatedPauseDuration().AsDuration() + elapsed)
 			attrs.PauseInfo.PausedTime = nil
-		default:
-			continue
-		}
-
-		encodedPath, err := node.getEncodedPath()
-		if err != nil {
-			return err
-		}
-		if _, exists := n.mutation.UpdatedNodes[encodedPath]; !exists {
-			node.updateLastUpdateVersionedTransition()
-			n.mutation.UpdatedNodes[encodedPath] = node.serializedNode
-			delete(n.mutation.DeletedNodes, encodedPath)
 		}
 	}
 	return nil
@@ -1658,44 +1633,19 @@ func (n *Node) dataNodePath(
 	return refNode.path(), nil
 }
 
-// Now returns the current wall-clock time for non-component callers.
 func (n *Node) Now(
 	_ Component,
 ) time.Time {
 	return n.timeSource.Now()
 }
 
-// componentNow returns the effective current time for the given component,
-// adjusting for any accumulated pause duration so that time does not advance
-// while a component is in LifecycleStatePaused.
-//
-// If the component is currently paused (pausedTime is set), its logical time is
-// frozen at the moment the pause began. If the component has been paused before
-// but is now running, the accumulated pause duration is subtracted from baseNow
-// so that logical time resumes from where it left off.
-func (n *Node) componentNow(component Component, baseNow time.Time) time.Time {
+// componentPauseInfo returns the persisted pause info for the given component, or nil if none.
+func (n *Node) componentPauseInfo(component Component) *persistencespb.ChasmPauseInfo {
 	node, ok := n.valueToNode[component]
 	if !ok {
-		// Component not yet registered as a tree node (created in this transaction).
-		return baseNow
+		return nil
 	}
-	attrs := node.serializedNode.GetMetadata().GetComponentAttributes()
-	if attrs == nil {
-		return baseNow
-	}
-	pauseInfo := attrs.GetPauseInfo()
-	if pauseInfo == nil {
-		return baseNow
-	}
-	if pt := pauseInfo.GetPausedTime(); pt != nil {
-		// Frozen at the time the pause began.
-		return pt.AsTime()
-	}
-	accum := pauseInfo.GetAccumulatedPauseDuration().AsDuration()
-	if accum == 0 {
-		return baseNow
-	}
-	return baseNow.Add(-accum)
+	return node.serializedNode.GetMetadata().GetComponentAttributes().GetPauseInfo()
 }
 
 // AddTask implements the CHASM MutableContext interface

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -1566,8 +1566,10 @@ func (n *Node) applyPendingComponentMetadata() bool {
 	return dirty
 }
 
-// closeTransactionUpdatePauseInfo updates ChasmPauseInfo for components that
-// transitioned into or out of LifecycleStatePaused this transaction.
+// closeTransactionUpdatePauseInfo updates ChasmPauseInfo for every component node
+// that transitioned into or out of an effective paused state this transaction.
+// A component is effectively paused if it or any ancestor returns LifecycleStatePaused,
+// since paused state covers the entire subtree below the paused component.
 func (n *Node) closeTransactionUpdatePauseInfo(immutableContext Context) error {
 	now := n.timeSource.Now()
 	for _, node := range n.andAllChildren() {
@@ -1586,7 +1588,7 @@ func (n *Node) closeTransactionUpdatePauseInfo(immutableContext Context) error {
 
 		pauseInfo := attrs.GetPauseInfo()
 		wasPaused := pauseInfo != nil && pauseInfo.PausedTime != nil
-		isPaused := component.LifecycleState(immutableContext).IsPaused()
+		isPaused := component.LifecycleState(immutableContext).IsPaused() || node.isAncestorPaused(immutableContext)
 
 		switch {
 		case !wasPaused && isPaused:
@@ -1601,6 +1603,28 @@ func (n *Node) closeTransactionUpdatePauseInfo(immutableContext Context) error {
 		}
 	}
 	return nil
+}
+
+// isAncestorPaused reports whether any ancestor component of this node is currently
+// paused — either by returning LifecycleStatePaused (if deserialized this transaction)
+// or by having PausedTime recorded in its persisted attrs from a prior transaction.
+func (n *Node) isAncestorPaused(ctx Context) bool {
+	for p := n.parent; p != nil; p = p.parent {
+		if !p.isComponent() {
+			continue
+		}
+		// If the ancestor was deserialized this transaction, ask its lifecycle state directly.
+		if c, ok := p.value.(Component); ok {
+			if c.LifecycleState(ctx).IsPaused() {
+				return true
+			}
+		}
+		// If the ancestor was not accessed this transaction, check its persisted pause info.
+		if p.serializedNode.GetMetadata().GetComponentAttributes().GetPauseInfo().GetPausedTime() != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // componentNodePath implements the CHASM Context interface

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -1600,6 +1600,18 @@ func (n *Node) closeTransactionUpdatePauseInfo(immutableContext Context) error {
 			elapsed := now.Sub(pauseInfo.PausedTime.AsTime())
 			attrs.PauseInfo.AccumulatedPauseDuration = durationpb.New(pauseInfo.GetAccumulatedPauseDuration().AsDuration() + elapsed)
 			attrs.PauseInfo.PausedTime = nil
+		default:
+			continue
+		}
+
+		encodedPath, err := node.getEncodedPath()
+		if err != nil {
+			return err
+		}
+		if _, exists := n.mutation.UpdatedNodes[encodedPath]; !exists {
+			node.updateLastUpdateVersionedTransition()
+			n.mutation.UpdatedNodes[encodedPath] = node.serializedNode
+			delete(n.mutation.DeletedNodes, encodedPath)
 		}
 	}
 	return nil

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -3276,7 +3276,7 @@ func (s *nodeSuite) TestContextPauseInfoWhilePaused() {
 
 	// Baseline: no pause info before any pause.
 	s.Nil(mutableCtx.PauseInfo(testComponent).PausedSince)
-	s.Zero(mutableCtx.PauseInfo(testComponent).AccumulatedPauseDuration)
+	s.Zero(mutableCtx.PauseInfo(testComponent).PastPausedDuration)
 
 	s.timeSource.Update(tPause)
 	testComponent.Pause(mutableCtx)
@@ -3292,7 +3292,7 @@ func (s *nodeSuite) TestContextPauseInfoWhilePaused() {
 	pi := mutableCtx2.PauseInfo(testComponent2)
 	s.Require().NotNil(pi.PausedSince)
 	s.Equal(tPause, *pi.PausedSince)
-	s.Zero(pi.AccumulatedPauseDuration)
+	s.Zero(pi.PastPausedDuration)
 
 	_, err = root.CloseTransaction()
 	s.NoError(err)
@@ -3307,7 +3307,7 @@ func (s *nodeSuite) TestContextPauseInfoWhilePaused() {
 	_, err = root.CloseTransaction()
 	s.NoError(err)
 
-	// After unpause: PausedSince is nil, AccumulatedPauseDuration reflects the pause interval.
+	// After unpause: PausedSince is nil, PastPausedDuration reflects the pause interval.
 	s.timeSource.Update(tAfterUnpause)
 	mutableCtx4 := NewMutableContext(context.Background(), root)
 	component4, err := root.Component(mutableCtx4, ComponentRef{})
@@ -3315,7 +3315,7 @@ func (s *nodeSuite) TestContextPauseInfoWhilePaused() {
 	testComponent4 := component4.(*TestComponent)
 	pi = mutableCtx4.PauseInfo(testComponent4)
 	s.Nil(pi.PausedSince)
-	s.Equal(tUnpause.Sub(tPause), pi.AccumulatedPauseDuration)
+	s.Equal(tUnpause.Sub(tPause), pi.PastPausedDuration)
 }
 
 func (s *nodeSuite) TestContextPauseInfoMultipleCycles() {
@@ -3368,7 +3368,7 @@ func (s *nodeSuite) TestContextPauseInfoMultipleCycles() {
 	s.NoError(err)
 	pi := mutableCtx5.PauseInfo(component5.(*TestComponent))
 	s.Nil(pi.PausedSince)
-	s.Equal(5*time.Minute+7*time.Minute, pi.AccumulatedPauseDuration)
+	s.Equal(5*time.Minute+7*time.Minute, pi.PastPausedDuration)
 }
 
 func (s *nodeSuite) TestExecuteImmediatePureTask() {

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -3258,9 +3258,7 @@ func (s *nodeSuite) TestContextNowStableWithinContext() {
 	s.Equal(laterTime, immutableContext.Now(component))
 }
 
-// TestContextNowFrozenWhilePaused verifies that Now(component) returns the time
-// the component entered LifecycleStatePaused and stays frozen until it is unpaused.
-func (s *nodeSuite) TestContextNowFrozenWhilePaused() {
+func (s *nodeSuite) TestContextPauseInfoWhilePaused() {
 	root := s.testComponentTree()
 
 	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -3271,69 +3269,63 @@ func (s *nodeSuite) TestContextNowFrozenWhilePaused() {
 
 	s.timeSource.Update(t0)
 
-	// Load root component in a transaction so the node is deserialized.
 	mutableCtx := NewMutableContext(context.Background(), root)
 	component, err := root.Component(mutableCtx, ComponentRef{})
 	s.NoError(err)
 	testComponent := component.(*TestComponent)
 
-	// Baseline: Now() before any pause is the context creation time.
-	s.Equal(t0, mutableCtx.Now(testComponent))
+	// Baseline: no pause info before any pause.
+	s.Nil(mutableCtx.PauseInfo(testComponent).PausedSince)
+	s.Zero(mutableCtx.PauseInfo(testComponent).AccumulatedPauseDuration)
 
-	// Simulate the component transitioning to Paused.
 	s.timeSource.Update(tPause)
 	testComponent.Pause(mutableCtx)
-
 	_, err = root.CloseTransaction()
 	s.NoError(err)
 
-	// Next transaction: component is paused, Now() should be frozen at tPause.
+	// Next transaction: PausedSince should be set to tPause.
 	s.timeSource.Update(tWhilePaused)
 	mutableCtx2 := NewMutableContext(context.Background(), root)
 	component2, err := root.Component(mutableCtx2, ComponentRef{})
 	s.NoError(err)
 	testComponent2 := component2.(*TestComponent)
-	s.Equal(tPause, mutableCtx2.Now(testComponent2), "Now() must be frozen at pause time")
+	pi := mutableCtx2.PauseInfo(testComponent2)
+	s.Require().NotNil(pi.PausedSince)
+	s.Equal(tPause, *pi.PausedSince)
+	s.Zero(pi.AccumulatedPauseDuration)
 
-	// Still paused: another transaction at a later time should still return tPause.
 	_, err = root.CloseTransaction()
 	s.NoError(err)
 
+	// Unpause.
 	s.timeSource.Update(tUnpause)
 	mutableCtx3 := NewMutableContext(context.Background(), root)
 	component3, err := root.Component(mutableCtx3, ComponentRef{})
 	s.NoError(err)
 	testComponent3 := component3.(*TestComponent)
-	s.Equal(tPause, mutableCtx3.Now(testComponent3), "Now() must remain frozen while still paused")
-
-	// Unpause within this transaction.
 	testComponent3.Unpause(mutableCtx3)
-
 	_, err = root.CloseTransaction()
 	s.NoError(err)
 
-	// After unpause, Now() should resume from where it was logically frozen.
-	// accumulated pause = (tUnpause - tPause), so Now() = tAfterUnpause - (tUnpause - tPause) = tPause + tAfterUnpause - tUnpause.
+	// After unpause: PausedSince is nil, AccumulatedPauseDuration reflects the pause interval.
 	s.timeSource.Update(tAfterUnpause)
 	mutableCtx4 := NewMutableContext(context.Background(), root)
 	component4, err := root.Component(mutableCtx4, ComponentRef{})
 	s.NoError(err)
 	testComponent4 := component4.(*TestComponent)
-	expectedNow := tAfterUnpause.Add(-(tUnpause.Sub(tPause)))
-	s.Equal(expectedNow, mutableCtx4.Now(testComponent4), "Now() should resume from pause time after unpause")
+	pi = mutableCtx4.PauseInfo(testComponent4)
+	s.Nil(pi.PausedSince)
+	s.Equal(tUnpause.Sub(tPause), pi.AccumulatedPauseDuration)
 }
 
-// TestContextNowMultiplePauseCycles verifies that accumulated pause duration
-// is correctly summed across multiple pause/unpause cycles.
-func (s *nodeSuite) TestContextNowMultiplePauseCycles() {
+func (s *nodeSuite) TestContextPauseInfoMultipleCycles() {
 	root := s.testComponentTree()
 
 	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	pause1At := t0.Add(10 * time.Minute)
-	unpause1At := pause1At.Add(5 * time.Minute) // paused for 5 min
+	unpause1At := pause1At.Add(5 * time.Minute)
 	pause2At := unpause1At.Add(3 * time.Minute)
-	unpause2At := pause2At.Add(7 * time.Minute) // paused for 7 min; total 12 min
-	checkAt := unpause2At.Add(2 * time.Minute)
+	unpause2At := pause2At.Add(7 * time.Minute)
 
 	s.timeSource.Update(t0)
 
@@ -3342,51 +3334,41 @@ func (s *nodeSuite) TestContextNowMultiplePauseCycles() {
 	s.NoError(err)
 	testComponent := component.(*TestComponent)
 
-	// Pause (cycle 1).
 	s.timeSource.Update(pause1At)
 	testComponent.Pause(mutableCtx)
 	_, err = root.CloseTransaction()
 	s.NoError(err)
 
-	// Unpause (cycle 1).
 	s.timeSource.Update(unpause1At)
 	mutableCtx2 := NewMutableContext(context.Background(), root)
 	component2, err := root.Component(mutableCtx2, ComponentRef{})
 	s.NoError(err)
-	testComponent2 := component2.(*TestComponent)
-	testComponent2.Unpause(mutableCtx2)
+	component2.(*TestComponent).Unpause(mutableCtx2)
 	_, err = root.CloseTransaction()
 	s.NoError(err)
 
-	// Pause (cycle 2).
 	s.timeSource.Update(pause2At)
 	mutableCtx3 := NewMutableContext(context.Background(), root)
 	component3, err := root.Component(mutableCtx3, ComponentRef{})
 	s.NoError(err)
-	testComponent3 := component3.(*TestComponent)
-	testComponent3.Pause(mutableCtx3)
+	component3.(*TestComponent).Pause(mutableCtx3)
 	_, err = root.CloseTransaction()
 	s.NoError(err)
 
-	// Unpause (cycle 2).
 	s.timeSource.Update(unpause2At)
 	mutableCtx4 := NewMutableContext(context.Background(), root)
 	component4, err := root.Component(mutableCtx4, ComponentRef{})
 	s.NoError(err)
-	testComponent4 := component4.(*TestComponent)
-	testComponent4.Unpause(mutableCtx4)
+	component4.(*TestComponent).Unpause(mutableCtx4)
 	_, err = root.CloseTransaction()
 	s.NoError(err)
 
-	// Verify: Now() = checkAt - totalPauseDuration (5 min + 7 min = 12 min).
-	s.timeSource.Update(checkAt)
 	mutableCtx5 := NewMutableContext(context.Background(), root)
 	component5, err := root.Component(mutableCtx5, ComponentRef{})
 	s.NoError(err)
-	testComponent5 := component5.(*TestComponent)
-	totalPaused := 5*time.Minute + 7*time.Minute
-	expected := checkAt.Add(-totalPaused)
-	s.Equal(expected, mutableCtx5.Now(testComponent5), "Now() should subtract total accumulated pause duration")
+	pi := mutableCtx5.PauseInfo(component5.(*TestComponent))
+	s.Nil(pi.PausedSince)
+	s.Equal(5*time.Minute+7*time.Minute, pi.AccumulatedPauseDuration)
 }
 
 func (s *nodeSuite) TestExecuteImmediatePureTask() {

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -3258,6 +3258,137 @@ func (s *nodeSuite) TestContextNowStableWithinContext() {
 	s.Equal(laterTime, immutableContext.Now(component))
 }
 
+// TestContextNowFrozenWhilePaused verifies that Now(component) returns the time
+// the component entered LifecycleStatePaused and stays frozen until it is unpaused.
+func (s *nodeSuite) TestContextNowFrozenWhilePaused() {
+	root := s.testComponentTree()
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tPause := t0.Add(time.Minute)
+	tWhilePaused := tPause.Add(time.Hour)
+	tUnpause := tWhilePaused.Add(time.Hour)
+	tAfterUnpause := tUnpause.Add(time.Minute)
+
+	s.timeSource.Update(t0)
+
+	// Load root component in a transaction so the node is deserialized.
+	mutableCtx := NewMutableContext(context.Background(), root)
+	component, err := root.Component(mutableCtx, ComponentRef{})
+	s.NoError(err)
+	testComponent := component.(*TestComponent)
+
+	// Baseline: Now() before any pause is the context creation time.
+	s.Equal(t0, mutableCtx.Now(testComponent))
+
+	// Simulate the component transitioning to Paused.
+	s.timeSource.Update(tPause)
+	testComponent.Pause(mutableCtx)
+
+	_, err = root.CloseTransaction()
+	s.NoError(err)
+
+	// Next transaction: component is paused, Now() should be frozen at tPause.
+	s.timeSource.Update(tWhilePaused)
+	mutableCtx2 := NewMutableContext(context.Background(), root)
+	component2, err := root.Component(mutableCtx2, ComponentRef{})
+	s.NoError(err)
+	testComponent2 := component2.(*TestComponent)
+	s.Equal(tPause, mutableCtx2.Now(testComponent2), "Now() must be frozen at pause time")
+
+	// Still paused: another transaction at a later time should still return tPause.
+	_, err = root.CloseTransaction()
+	s.NoError(err)
+
+	s.timeSource.Update(tUnpause)
+	mutableCtx3 := NewMutableContext(context.Background(), root)
+	component3, err := root.Component(mutableCtx3, ComponentRef{})
+	s.NoError(err)
+	testComponent3 := component3.(*TestComponent)
+	s.Equal(tPause, mutableCtx3.Now(testComponent3), "Now() must remain frozen while still paused")
+
+	// Unpause within this transaction.
+	testComponent3.Unpause(mutableCtx3)
+
+	_, err = root.CloseTransaction()
+	s.NoError(err)
+
+	// After unpause, Now() should resume from where it was logically frozen.
+	// accumulated pause = (tUnpause - tPause), so Now() = tAfterUnpause - (tUnpause - tPause) = tPause + tAfterUnpause - tUnpause.
+	s.timeSource.Update(tAfterUnpause)
+	mutableCtx4 := NewMutableContext(context.Background(), root)
+	component4, err := root.Component(mutableCtx4, ComponentRef{})
+	s.NoError(err)
+	testComponent4 := component4.(*TestComponent)
+	expectedNow := tAfterUnpause.Add(-(tUnpause.Sub(tPause)))
+	s.Equal(expectedNow, mutableCtx4.Now(testComponent4), "Now() should resume from pause time after unpause")
+}
+
+// TestContextNowMultiplePauseCycles verifies that accumulated pause duration
+// is correctly summed across multiple pause/unpause cycles.
+func (s *nodeSuite) TestContextNowMultiplePauseCycles() {
+	root := s.testComponentTree()
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	pause1At := t0.Add(10 * time.Minute)
+	unpause1At := pause1At.Add(5 * time.Minute) // paused for 5 min
+	pause2At := unpause1At.Add(3 * time.Minute)
+	unpause2At := pause2At.Add(7 * time.Minute) // paused for 7 min; total 12 min
+	checkAt := unpause2At.Add(2 * time.Minute)
+
+	s.timeSource.Update(t0)
+
+	mutableCtx := NewMutableContext(context.Background(), root)
+	component, err := root.Component(mutableCtx, ComponentRef{})
+	s.NoError(err)
+	testComponent := component.(*TestComponent)
+
+	// Pause (cycle 1).
+	s.timeSource.Update(pause1At)
+	testComponent.Pause(mutableCtx)
+	_, err = root.CloseTransaction()
+	s.NoError(err)
+
+	// Unpause (cycle 1).
+	s.timeSource.Update(unpause1At)
+	mutableCtx2 := NewMutableContext(context.Background(), root)
+	component2, err := root.Component(mutableCtx2, ComponentRef{})
+	s.NoError(err)
+	testComponent2 := component2.(*TestComponent)
+	testComponent2.Unpause(mutableCtx2)
+	_, err = root.CloseTransaction()
+	s.NoError(err)
+
+	// Pause (cycle 2).
+	s.timeSource.Update(pause2At)
+	mutableCtx3 := NewMutableContext(context.Background(), root)
+	component3, err := root.Component(mutableCtx3, ComponentRef{})
+	s.NoError(err)
+	testComponent3 := component3.(*TestComponent)
+	testComponent3.Pause(mutableCtx3)
+	_, err = root.CloseTransaction()
+	s.NoError(err)
+
+	// Unpause (cycle 2).
+	s.timeSource.Update(unpause2At)
+	mutableCtx4 := NewMutableContext(context.Background(), root)
+	component4, err := root.Component(mutableCtx4, ComponentRef{})
+	s.NoError(err)
+	testComponent4 := component4.(*TestComponent)
+	testComponent4.Unpause(mutableCtx4)
+	_, err = root.CloseTransaction()
+	s.NoError(err)
+
+	// Verify: Now() = checkAt - totalPauseDuration (5 min + 7 min = 12 min).
+	s.timeSource.Update(checkAt)
+	mutableCtx5 := NewMutableContext(context.Background(), root)
+	component5, err := root.Component(mutableCtx5, ComponentRef{})
+	s.NoError(err)
+	testComponent5 := component5.(*TestComponent)
+	totalPaused := 5*time.Minute + 7*time.Minute
+	expected := checkAt.Add(-totalPaused)
+	s.Equal(expected, mutableCtx5.Now(testComponent5), "Now() should subtract total accumulated pause duration")
+}
+
 func (s *nodeSuite) TestExecuteImmediatePureTask() {
 	root := s.testComponentTree()
 

--- a/proto/internal/temporal/server/api/persistence/v1/chasm.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/chasm.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package temporal.server.api.persistence.v1;
 
+import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 import "temporal/api/common/v1/message.proto";
 import "temporal/api/failure/v1/message.proto";
@@ -78,6 +79,18 @@ message ChasmComponentAttributes {
   map<string, RequestMetadata> requests = 5;
   // Caller-supplied user metadata (summary, details) attached to this component.
   temporal.api.sdk.v1.UserMetadata user_metadata = 6;
+  // Tracks how long this component has spent paused so that Now() can be adjusted
+  // accordingly. Set when the component transitions into or out of LifecycleStatePaused.
+  ChasmPauseInfo pause_info = 7;
+}
+
+// ChasmPauseInfo tracks the accumulated pause duration for a component so that
+// Now() can return a time that does not advance while the component is paused.
+message ChasmPauseInfo {
+  // Set while the component is currently paused; cleared on unpause.
+  google.protobuf.Timestamp paused_time = 1;
+  // Total duration accumulated from all completed pause/unpause cycles.
+  google.protobuf.Duration accumulated_pause_duration = 2;
 }
 
 message ChasmDataAttributes {}

--- a/proto/internal/temporal/server/api/persistence/v1/chasm.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/chasm.proto
@@ -79,17 +79,15 @@ message ChasmComponentAttributes {
   map<string, RequestMetadata> requests = 5;
   // Caller-supplied user metadata (summary, details) attached to this component.
   temporal.api.sdk.v1.UserMetadata user_metadata = 6;
-  // Tracks how long this component has spent paused so that Now() can be adjusted
-  // accordingly. Set when the component transitions into or out of LifecycleStatePaused.
+  // Pause tracking for Now() adjustment; updated on pause/unpause transitions.
   ChasmPauseInfo pause_info = 7;
 }
 
-// ChasmPauseInfo tracks the accumulated pause duration for a component so that
-// Now() can return a time that does not advance while the component is paused.
+// ChasmPauseInfo tracks accumulated pause duration so Now() does not advance while paused.
 message ChasmPauseInfo {
-  // Set while the component is currently paused; cleared on unpause.
+  // Set while paused; cleared on unpause.
   google.protobuf.Timestamp paused_time = 1;
-  // Total duration accumulated from all completed pause/unpause cycles.
+  // Total pause duration from all completed pause/unpause cycles.
   google.protobuf.Duration accumulated_pause_duration = 2;
 }
 

--- a/tests/chasm_test.go
+++ b/tests/chasm_test.go
@@ -1119,15 +1119,9 @@ func (s *ChasmSuite) TestNamespaceDelete_WithChasmExecutions() {
 	})
 }
 
-// TestPauseUnpauseNow verifies that ctx.Now(component) accounts for pause state:
-//   - While a component is paused, Now() returns the time the pause began (frozen).
-//   - After an unpause, Now() resumes from where it was logically (real time minus
-//     accumulated pause duration), so the component's logical clock does not advance
-//     during the pause interval.
-//
-// The test also exercises persistence by relying on the engine loading state from
-// the database between each handler call (each call is an independent transaction).
-func (s *ChasmSuite) TestPauseUnpauseNow() {
+// TestPauseUnpauseInfo verifies that ctx.PauseInfo(component) correctly tracks pause state
+// across transactions loaded from the database.
+func (s *ChasmSuite) TestPauseUnpauseInfo() {
 	s.forBothConverters(func(ss *ChasmSuite, cenv chasmTestEnv) {
 		tv := testvars.New(ss.T())
 
@@ -1144,43 +1138,37 @@ func (s *ChasmSuite) TestPauseUnpauseNow() {
 		})
 		ss.NoError(err)
 
-		// Baseline: Now() before any pause.
-		nowResp, err := tests.GetNowHandler(ctx, cenv.NamespaceID(), storeID)
+		// Baseline: no pause info before any pause.
+		pi, err := tests.GetPauseInfoHandler(ctx, cenv.NamespaceID(), storeID)
 		ss.NoError(err)
-		baseNow := nowResp.Now
+		ss.Nil(pi.PausedSince)
+		ss.Zero(pi.AccumulatedPauseDuration)
 
-		// Pause the component. The framework records the pause time in CloseTransaction.
+		// Pause the component.
 		err = tests.PausePayloadStoreHandler(ctx, cenv.NamespaceID(), storeID)
 		ss.NoError(err)
 
-		// Now() while paused must be frozen at the pause time (loaded from persistence).
-		nowWhilePaused, err := tests.GetNowHandler(ctx, cenv.NamespaceID(), storeID)
+		// While paused: PausedSince should be set, accumulated should be zero.
+		pi, err = tests.GetPauseInfoHandler(ctx, cenv.NamespaceID(), storeID)
 		ss.NoError(err)
-		// The frozen time should be >= the baseline (pause happened after the baseline read)
-		// and should not be the current wall time.
-		ss.False(nowWhilePaused.Now.IsZero(), "expected non-zero Now() while paused")
-		ss.False(nowWhilePaused.Now.Before(baseNow), "paused time should be >= baseline")
+		ss.Require().NotNil(pi.PausedSince, "PausedSince must be set while paused")
+		ss.Zero(pi.AccumulatedPauseDuration)
+		pausedSince := *pi.PausedSince
 
-		// A second read while still paused must return the same frozen time.
-		nowWhilePaused2, err := tests.GetNowHandler(ctx, cenv.NamespaceID(), storeID)
+		// Second read while still paused: PausedSince must remain the same.
+		pi, err = tests.GetPauseInfoHandler(ctx, cenv.NamespaceID(), storeID)
 		ss.NoError(err)
-		ss.Equal(nowWhilePaused.Now, nowWhilePaused2.Now, "Now() must remain frozen while paused")
+		ss.Require().NotNil(pi.PausedSince)
+		ss.Equal(pausedSince, *pi.PausedSince)
 
-		// Unpause. CloseTransaction will accumulate the pause duration and clear PausedTime.
+		// Unpause.
 		err = tests.UnpausePayloadStoreHandler(ctx, cenv.NamespaceID(), storeID)
 		ss.NoError(err)
 
-		// Now() after unpause should reflect the accumulated pause duration subtracted from
-		// the current wall time, so it resumes logically from roughly where it was frozen.
-		// That means it should be close to (but may be slightly after) the frozen time.
-		const tolerance = 5 * time.Second
-		nowAfterUnpause, err := tests.GetNowHandler(ctx, cenv.NamespaceID(), storeID)
+		// After unpause: PausedSince is nil, AccumulatedPauseDuration is positive.
+		pi, err = tests.GetPauseInfoHandler(ctx, cenv.NamespaceID(), storeID)
 		ss.NoError(err)
-		ss.False(nowAfterUnpause.Now.IsZero(), "expected non-zero Now() after unpause")
-		// Logical time after unpause should be roughly where the freeze started.
-		diff := nowAfterUnpause.Now.Sub(nowWhilePaused.Now)
-		ss.True(diff >= 0 && diff <= tolerance,
-			"Now() after unpause (%v) should be within %v of the frozen time (%v), got diff=%v",
-			nowAfterUnpause.Now, tolerance, nowWhilePaused.Now, diff)
+		ss.Nil(pi.PausedSince)
+		ss.Positive(pi.AccumulatedPauseDuration)
 	})
 }

--- a/tests/chasm_test.go
+++ b/tests/chasm_test.go
@@ -1142,7 +1142,7 @@ func (s *ChasmSuite) TestPauseUnpauseInfo() {
 		pi, err := tests.GetPauseInfoHandler(ctx, cenv.NamespaceID(), storeID)
 		ss.NoError(err)
 		ss.Nil(pi.PausedSince)
-		ss.Zero(pi.AccumulatedPauseDuration)
+		ss.Zero(pi.PastPausedDuration)
 
 		// Pause the component.
 		err = tests.PausePayloadStoreHandler(ctx, cenv.NamespaceID(), storeID)
@@ -1152,7 +1152,7 @@ func (s *ChasmSuite) TestPauseUnpauseInfo() {
 		pi, err = tests.GetPauseInfoHandler(ctx, cenv.NamespaceID(), storeID)
 		ss.NoError(err)
 		ss.Require().NotNil(pi.PausedSince, "PausedSince must be set while paused")
-		ss.Zero(pi.AccumulatedPauseDuration)
+		ss.Zero(pi.PastPausedDuration)
 		pausedSince := *pi.PausedSince
 
 		// Second read while still paused: PausedSince must remain the same.
@@ -1165,10 +1165,10 @@ func (s *ChasmSuite) TestPauseUnpauseInfo() {
 		err = tests.UnpausePayloadStoreHandler(ctx, cenv.NamespaceID(), storeID)
 		ss.NoError(err)
 
-		// After unpause: PausedSince is nil, AccumulatedPauseDuration is positive.
+		// After unpause: PausedSince is nil, PastPausedDuration is positive.
 		pi, err = tests.GetPauseInfoHandler(ctx, cenv.NamespaceID(), storeID)
 		ss.NoError(err)
 		ss.Nil(pi.PausedSince)
-		ss.Positive(pi.AccumulatedPauseDuration)
+		ss.Positive(pi.PastPausedDuration)
 	})
 }

--- a/tests/chasm_test.go
+++ b/tests/chasm_test.go
@@ -1119,4 +1119,68 @@ func (s *ChasmSuite) TestNamespaceDelete_WithChasmExecutions() {
 	})
 }
 
-// TODO: More tests here...
+// TestPauseUnpauseNow verifies that ctx.Now(component) accounts for pause state:
+//   - While a component is paused, Now() returns the time the pause began (frozen).
+//   - After an unpause, Now() resumes from where it was logically (real time minus
+//     accumulated pause duration), so the component's logical clock does not advance
+//     during the pause interval.
+//
+// The test also exercises persistence by relying on the engine loading state from
+// the database between each handler call (each call is an independent transaction).
+func (s *ChasmSuite) TestPauseUnpauseNow() {
+	s.forBothConverters(func(ss *ChasmSuite, cenv chasmTestEnv) {
+		tv := testvars.New(ss.T())
+
+		ctx, cancel := context.WithTimeout(cenv.chasmCtx, chasmTestTimeout)
+		defer cancel()
+
+		storeID := tv.Any().String()
+
+		_, err := tests.NewPayloadStoreHandler(ctx, tests.NewPayloadStoreRequest{
+			NamespaceID:      cenv.NamespaceID(),
+			StoreID:          storeID,
+			IDReusePolicy:    chasm.BusinessIDReusePolicyRejectDuplicate,
+			IDConflictPolicy: chasm.BusinessIDConflictPolicyFail,
+		})
+		ss.NoError(err)
+
+		// Baseline: Now() before any pause.
+		nowResp, err := tests.GetNowHandler(ctx, cenv.NamespaceID(), storeID)
+		ss.NoError(err)
+		baseNow := nowResp.Now
+
+		// Pause the component. The framework records the pause time in CloseTransaction.
+		err = tests.PausePayloadStoreHandler(ctx, cenv.NamespaceID(), storeID)
+		ss.NoError(err)
+
+		// Now() while paused must be frozen at the pause time (loaded from persistence).
+		nowWhilePaused, err := tests.GetNowHandler(ctx, cenv.NamespaceID(), storeID)
+		ss.NoError(err)
+		// The frozen time should be >= the baseline (pause happened after the baseline read)
+		// and should not be the current wall time.
+		ss.False(nowWhilePaused.Now.IsZero(), "expected non-zero Now() while paused")
+		ss.False(nowWhilePaused.Now.Before(baseNow), "paused time should be >= baseline")
+
+		// A second read while still paused must return the same frozen time.
+		nowWhilePaused2, err := tests.GetNowHandler(ctx, cenv.NamespaceID(), storeID)
+		ss.NoError(err)
+		ss.Equal(nowWhilePaused.Now, nowWhilePaused2.Now, "Now() must remain frozen while paused")
+
+		// Unpause. CloseTransaction will accumulate the pause duration and clear PausedTime.
+		err = tests.UnpausePayloadStoreHandler(ctx, cenv.NamespaceID(), storeID)
+		ss.NoError(err)
+
+		// Now() after unpause should reflect the accumulated pause duration subtracted from
+		// the current wall time, so it resumes logically from roughly where it was frozen.
+		// That means it should be close to (but may be slightly after) the frozen time.
+		const tolerance = 5 * time.Second
+		nowAfterUnpause, err := tests.GetNowHandler(ctx, cenv.NamespaceID(), storeID)
+		ss.NoError(err)
+		ss.False(nowAfterUnpause.Now.IsZero(), "expected non-zero Now() after unpause")
+		// Logical time after unpause should be roughly where the freeze started.
+		diff := nowAfterUnpause.Now.Sub(nowWhilePaused.Now)
+		ss.True(diff >= 0 && diff <= tolerance,
+			"Now() after unpause (%v) should be within %v of the frozen time (%v), got diff=%v",
+			nowAfterUnpause.Now, tolerance, nowWhilePaused.Now, diff)
+	})
+}


### PR DESCRIPTION
## What changed?
Pause component time when lifecycle state is paused.

## Why?
Currently, when a component enters LifecycleStatePaused, it only drops all logical tasks. There can be local timers like `start_delay` the component tracks that should not progress when the component is paused. Ideally, when a component is paused, the time of the component should not progress until it is unpaused, to support these duration use cases.

To do this, each component now tracks the pause time in the ComponentAttributes, and uses this value along with when the component is unpaused to count the accumulated pause duration. This will be used to keep the component's timestamp relative to when it was originally paused.

To then support this with constant timestamps in MutableCtx.Now(), we need to move the snapshot of timestamps to be a map from node -> now timestamp.

## How did you test it?
- [x] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)
