### PR TITLE
Add singleton registrable task option

### DIFF
--- a/chasm/registrable_task.go
+++ b/chasm/registrable_task.go
@@ -6,6 +6,17 @@ import (
 	"reflect"
 )
 
+// SingletonTaskMode controls how the framework handles a new task of a singleton type
+// when a task of the same type already exists on the component instance.
+type SingletonTaskMode int
+
+const (
+	// SingletonTaskModeReplace removes the existing task and schedules the new one in its place.
+	SingletonTaskModeReplace SingletonTaskMode = iota + 1
+	// SingletonTaskModeIgnore keeps the existing task and discards the new one.
+	SingletonTaskModeIgnore
+)
+
 type (
 	RegistrableTask struct {
 		taskType                string
@@ -16,7 +27,8 @@ type (
 		sideEffectTaskExecuteFn sideEffectTaskExecuteFn
 		sideEffectTaskDiscardFn sideEffectTaskDiscardFn
 		isPureTask              bool
-		outboundTaskGroup       string // For grouping on the outbound queue. See [WithTaskGroup] for details.
+		outboundTaskGroup       string            // For grouping on the outbound queue. See [WithTaskGroup] for details.
+		singletonMode           SingletonTaskMode // If non-zero, at most one task of this type may exist per component instance.
 
 		// Those two fields are initialized when the component is registered to a library.
 		library    namer
@@ -192,5 +204,19 @@ func (rt *RegistrableTask) fqType() string {
 func WithTaskGroup(taskgroup string) RegistrableTaskOption {
 	return func(rt *RegistrableTask) {
 		rt.outboundTaskGroup = taskgroup
+	}
+}
+
+// WithSingletonTask configures the task type as a singleton: at most one task of this type
+// may exist per component instance at any time. The mode controls what happens when a new
+// task is added while one already exists:
+//   - [SingletonTaskModeReplace]: the existing task is removed and the new one takes its place.
+//   - [SingletonTaskModeIgnore]: the existing task is kept and the new one is discarded.
+//
+// Singleton semantics are enforced after task validation, so an invalid new task is dropped
+// before any replacement or ignore logic applies.
+func WithSingletonTask(mode SingletonTaskMode) RegistrableTaskOption {
+	return func(rt *RegistrableTask) {
+		rt.singletonMode = mode
 	}
 }

--- a/chasm/test_library_test.go
+++ b/chasm/test_library_test.go
@@ -10,10 +10,14 @@ type TestLibrary struct {
 
 	controller *gomock.Controller
 
-	mockSideEffectTaskHandler         *MockSideEffectTaskHandler[any, *TestSideEffectTask]
-	mockDiscardableSideEffectHandler  *MockSideEffectTaskHandler[any, *TestDiscardableSideEffectTask]
-	mockOutboundSideEffectTaskHandler *MockSideEffectTaskHandler[any, TestOutboundSideEffectTask]
-	mockPureTaskHandler               *MockPureTaskHandler[any, *TestPureTask]
+	mockSideEffectTaskHandler                *MockSideEffectTaskHandler[any, *TestSideEffectTask]
+	mockDiscardableSideEffectHandler         *MockSideEffectTaskHandler[any, *TestDiscardableSideEffectTask]
+	mockOutboundSideEffectTaskHandler        *MockSideEffectTaskHandler[any, TestOutboundSideEffectTask]
+	mockPureTaskHandler                      *MockPureTaskHandler[any, *TestPureTask]
+	mockSingletonReplaceSideEffectTaskHandler *MockSideEffectTaskHandler[any, *TestSingletonReplaceSideEffectTask]
+	mockSingletonIgnoreSideEffectTaskHandler  *MockSideEffectTaskHandler[any, *TestSingletonIgnoreSideEffectTask]
+	mockSingletonReplacePureTaskHandler       *MockPureTaskHandler[any, *TestSingletonReplacePureTask]
+	mockSingletonIgnorePureTaskHandler        *MockPureTaskHandler[any, *TestSingletonIgnorePureTask]
 }
 
 func newTestLibrary(
@@ -22,10 +26,14 @@ func newTestLibrary(
 	return &TestLibrary{
 		controller: controller,
 
-		mockSideEffectTaskHandler:         NewMockSideEffectTaskHandler[any, *TestSideEffectTask](controller),
-		mockDiscardableSideEffectHandler:  NewMockSideEffectTaskHandler[any, *TestDiscardableSideEffectTask](controller),
-		mockOutboundSideEffectTaskHandler: NewMockSideEffectTaskHandler[any, TestOutboundSideEffectTask](controller),
-		mockPureTaskHandler:               NewMockPureTaskHandler[any, *TestPureTask](controller),
+		mockSideEffectTaskHandler:                NewMockSideEffectTaskHandler[any, *TestSideEffectTask](controller),
+		mockDiscardableSideEffectHandler:         NewMockSideEffectTaskHandler[any, *TestDiscardableSideEffectTask](controller),
+		mockOutboundSideEffectTaskHandler:        NewMockSideEffectTaskHandler[any, TestOutboundSideEffectTask](controller),
+		mockPureTaskHandler:                      NewMockPureTaskHandler[any, *TestPureTask](controller),
+		mockSingletonReplaceSideEffectTaskHandler: NewMockSideEffectTaskHandler[any, *TestSingletonReplaceSideEffectTask](controller),
+		mockSingletonIgnoreSideEffectTaskHandler:  NewMockSideEffectTaskHandler[any, *TestSingletonIgnoreSideEffectTask](controller),
+		mockSingletonReplacePureTaskHandler:       NewMockPureTaskHandler[any, *TestSingletonReplacePureTask](controller),
+		mockSingletonIgnorePureTaskHandler:        NewMockPureTaskHandler[any, *TestSingletonIgnorePureTask](controller),
 	}
 }
 
@@ -64,6 +72,26 @@ func (l *TestLibrary) Tasks() []*RegistrableTask {
 		NewRegistrablePureTask(
 			testPureTaskName,
 			l.mockPureTaskHandler,
+		),
+		NewRegistrableSideEffectTask[any, *TestSingletonReplaceSideEffectTask](
+			testSingletonReplaceSideEffectTaskName,
+			l.mockSingletonReplaceSideEffectTaskHandler,
+			WithSingletonTask(SingletonTaskModeReplace),
+		),
+		NewRegistrableSideEffectTask[any, *TestSingletonIgnoreSideEffectTask](
+			testSingletonIgnoreSideEffectTaskName,
+			l.mockSingletonIgnoreSideEffectTaskHandler,
+			WithSingletonTask(SingletonTaskModeIgnore),
+		),
+		NewRegistrablePureTask[any, *TestSingletonReplacePureTask](
+			testSingletonReplacePureTaskName,
+			l.mockSingletonReplacePureTaskHandler,
+			WithSingletonTask(SingletonTaskModeReplace),
+		),
+		NewRegistrablePureTask[any, *TestSingletonIgnorePureTask](
+			testSingletonIgnorePureTaskName,
+			l.mockSingletonIgnorePureTaskHandler,
+			WithSingletonTask(SingletonTaskModeIgnore),
 		),
 	}
 }

--- a/chasm/test_library_test.go
+++ b/chasm/test_library_test.go
@@ -10,10 +10,10 @@ type TestLibrary struct {
 
 	controller *gomock.Controller
 
-	mockSideEffectTaskHandler                *MockSideEffectTaskHandler[any, *TestSideEffectTask]
-	mockDiscardableSideEffectHandler         *MockSideEffectTaskHandler[any, *TestDiscardableSideEffectTask]
-	mockOutboundSideEffectTaskHandler        *MockSideEffectTaskHandler[any, TestOutboundSideEffectTask]
-	mockPureTaskHandler                      *MockPureTaskHandler[any, *TestPureTask]
+	mockSideEffectTaskHandler                 *MockSideEffectTaskHandler[any, *TestSideEffectTask]
+	mockDiscardableSideEffectHandler          *MockSideEffectTaskHandler[any, *TestDiscardableSideEffectTask]
+	mockOutboundSideEffectTaskHandler         *MockSideEffectTaskHandler[any, TestOutboundSideEffectTask]
+	mockPureTaskHandler                       *MockPureTaskHandler[any, *TestPureTask]
 	mockSingletonReplaceSideEffectTaskHandler *MockSideEffectTaskHandler[any, *TestSingletonReplaceSideEffectTask]
 	mockSingletonIgnoreSideEffectTaskHandler  *MockSideEffectTaskHandler[any, *TestSingletonIgnoreSideEffectTask]
 	mockSingletonReplacePureTaskHandler       *MockPureTaskHandler[any, *TestSingletonReplacePureTask]
@@ -26,10 +26,10 @@ func newTestLibrary(
 	return &TestLibrary{
 		controller: controller,
 
-		mockSideEffectTaskHandler:                NewMockSideEffectTaskHandler[any, *TestSideEffectTask](controller),
-		mockDiscardableSideEffectHandler:         NewMockSideEffectTaskHandler[any, *TestDiscardableSideEffectTask](controller),
-		mockOutboundSideEffectTaskHandler:        NewMockSideEffectTaskHandler[any, TestOutboundSideEffectTask](controller),
-		mockPureTaskHandler:                      NewMockPureTaskHandler[any, *TestPureTask](controller),
+		mockSideEffectTaskHandler:                 NewMockSideEffectTaskHandler[any, *TestSideEffectTask](controller),
+		mockDiscardableSideEffectHandler:          NewMockSideEffectTaskHandler[any, *TestDiscardableSideEffectTask](controller),
+		mockOutboundSideEffectTaskHandler:         NewMockSideEffectTaskHandler[any, TestOutboundSideEffectTask](controller),
+		mockPureTaskHandler:                       NewMockPureTaskHandler[any, *TestPureTask](controller),
 		mockSingletonReplaceSideEffectTaskHandler: NewMockSideEffectTaskHandler[any, *TestSingletonReplaceSideEffectTask](controller),
 		mockSingletonIgnoreSideEffectTaskHandler:  NewMockSideEffectTaskHandler[any, *TestSingletonIgnoreSideEffectTask](controller),
 		mockSingletonReplacePureTaskHandler:       NewMockPureTaskHandler[any, *TestSingletonReplacePureTask](controller),

--- a/chasm/test_task_test.go
+++ b/chasm/test_task_test.go
@@ -15,6 +15,12 @@ type (
 	TestOutboundSideEffectTask struct{}
 
 	TestPureTask commonpb.Payload
+
+	// Singleton task types — distinct Go types so the registry can tell them apart.
+	TestSingletonReplaceSideEffectTask commonpb.Payload
+	TestSingletonIgnoreSideEffectTask  commonpb.Payload
+	TestSingletonReplacePureTask       commonpb.Payload
+	TestSingletonIgnorePureTask        commonpb.Payload
 )
 
 // ProtoReflect implements [protoreflect.ProtoMessage].
@@ -22,4 +28,26 @@ func (t *TestPureTask) ProtoReflect() protoreflect.Message {
 	return (*commonpb.Payload)(t).ProtoReflect()
 }
 
-var _ proto.Message = (*TestPureTask)(nil)
+func (t *TestSingletonReplaceSideEffectTask) ProtoReflect() protoreflect.Message {
+	return (*commonpb.Payload)(t).ProtoReflect()
+}
+
+func (t *TestSingletonIgnoreSideEffectTask) ProtoReflect() protoreflect.Message {
+	return (*commonpb.Payload)(t).ProtoReflect()
+}
+
+func (t *TestSingletonReplacePureTask) ProtoReflect() protoreflect.Message {
+	return (*commonpb.Payload)(t).ProtoReflect()
+}
+
+func (t *TestSingletonIgnorePureTask) ProtoReflect() protoreflect.Message {
+	return (*commonpb.Payload)(t).ProtoReflect()
+}
+
+var (
+	_ proto.Message = (*TestPureTask)(nil)
+	_ proto.Message = (*TestSingletonReplaceSideEffectTask)(nil)
+	_ proto.Message = (*TestSingletonIgnoreSideEffectTask)(nil)
+	_ proto.Message = (*TestSingletonReplacePureTask)(nil)
+	_ proto.Message = (*TestSingletonIgnorePureTask)(nil)
+)

--- a/chasm/test_var_test.go
+++ b/chasm/test_var_test.go
@@ -47,7 +47,5 @@ var (
 	testPureTaskTypeID                  = GenerateTypeID(testPureTaskFQN)
 
 	testSingletonReplaceSideEffectTaskTypeID = GenerateTypeID(testSingletonReplaceSideEffectTaskFQN)
-	testSingletonIgnoreSideEffectTaskTypeID  = GenerateTypeID(testSingletonIgnoreSideEffectTaskFQN)
 	testSingletonReplacePureTaskTypeID       = GenerateTypeID(testSingletonReplacePureTaskFQN)
-	testSingletonIgnorePureTaskTypeID        = GenerateTypeID(testSingletonIgnorePureTaskFQN)
 )

--- a/chasm/test_var_test.go
+++ b/chasm/test_var_test.go
@@ -11,6 +11,11 @@ const (
 	testDiscardableSideEffectTaskName = "test_discardable_side_effect_task"
 	testOutboundSideEffectTaskName    = "test_outbound_side_effect_task"
 	testPureTaskName                  = "test_pure_task"
+
+	testSingletonReplaceSideEffectTaskName = "test_singleton_replace_side_effect_task"
+	testSingletonIgnoreSideEffectTaskName  = "test_singleton_ignore_side_effect_task"
+	testSingletonReplacePureTaskName       = "test_singleton_replace_pure_task"
+	testSingletonIgnorePureTaskName        = "test_singleton_ignore_pure_task"
 )
 
 var (
@@ -23,6 +28,11 @@ var (
 	testDiscardableSideEffectTaskFQN = FullyQualifiedName(testLibraryName, testDiscardableSideEffectTaskName)
 	testOutboundSideEffectTaskFQN    = FullyQualifiedName(testLibraryName, testOutboundSideEffectTaskName)
 	testPureTaskFQN                  = FullyQualifiedName(testLibraryName, testPureTaskName)
+
+	testSingletonReplaceSideEffectTaskFQN = FullyQualifiedName(testLibraryName, testSingletonReplaceSideEffectTaskName)
+	testSingletonIgnoreSideEffectTaskFQN  = FullyQualifiedName(testLibraryName, testSingletonIgnoreSideEffectTaskName)
+	testSingletonReplacePureTaskFQN       = FullyQualifiedName(testLibraryName, testSingletonReplacePureTaskName)
+	testSingletonIgnorePureTaskFQN        = FullyQualifiedName(testLibraryName, testSingletonIgnorePureTaskName)
 )
 
 var (
@@ -35,4 +45,9 @@ var (
 	testDiscardableSideEffectTaskTypeID = GenerateTypeID(testDiscardableSideEffectTaskFQN)
 	testOutboundSideEffectTaskTypeID    = GenerateTypeID(testOutboundSideEffectTaskFQN)
 	testPureTaskTypeID                  = GenerateTypeID(testPureTaskFQN)
+
+	testSingletonReplaceSideEffectTaskTypeID = GenerateTypeID(testSingletonReplaceSideEffectTaskFQN)
+	testSingletonIgnoreSideEffectTaskTypeID  = GenerateTypeID(testSingletonIgnoreSideEffectTaskFQN)
+	testSingletonReplacePureTaskTypeID       = GenerateTypeID(testSingletonReplacePureTaskFQN)
+	testSingletonIgnorePureTaskTypeID        = GenerateTypeID(testSingletonIgnorePureTaskFQN)
 )

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -1619,7 +1619,7 @@ func (n *Node) AddTask(
 		return
 	}
 
-	n.nodeBase.newTasks[component] = append(n.nodeBase.newTasks[component], taskWithAttributes{
+	n.newTasks[component] = append(n.newTasks[component], taskWithAttributes{
 		task:       task,
 		attributes: taskAttributes,
 	})
@@ -2118,6 +2118,36 @@ func (n *Node) closeTransactionCleanupInvalidTasks(
 	return cleanedUp, nil
 }
 
+// applySingletonMode enforces singleton semantics for tasks registered with [WithSingletonTask].
+// It is called after task validation, so only valid new tasks reach this point.
+// Returns true if the new task should be skipped (SingletonTaskModeIgnore with existing task).
+func (n *Node) applySingletonMode(
+	rt *RegistrableTask,
+	taskList *[]*persistencespb.ChasmComponentAttributes_Task,
+) (skip bool) {
+	if rt.singletonMode == 0 {
+		return false
+	}
+
+	idx := slices.IndexFunc(*taskList, func(t *persistencespb.ChasmComponentAttributes_Task) bool {
+		return t.TypeId == rt.taskTypeID
+	})
+	if idx == -1 {
+		return false
+	}
+
+	switch rt.singletonMode {
+	case SingletonTaskModeReplace:
+		delete(n.taskValueCache, (*taskList)[idx].Data)
+		*taskList = slices.Delete(*taskList, idx, idx+1)
+		return false
+	case SingletonTaskModeIgnore:
+		return true
+	default:
+		return false
+	}
+}
+
 func (n *Node) closeTransactionHandleNewTasks(
 	nextVersionedTransition *persistencespb.VersionedTransition,
 	validateContext Context,
@@ -2175,9 +2205,15 @@ func (n *Node) closeTransactionHandleNewTasks(
 		}
 
 		if registrableTask.isPureTask {
+			if skip := n.applySingletonMode(registrableTask, &componentAttr.PureTasks); skip {
+				continue
+			}
 			componentAttr.PureTasks = append(componentAttr.PureTasks, componentTask)
 			sortPureTasks = true
 		} else {
+			if skip := n.applySingletonMode(registrableTask, &componentAttr.SideEffectTasks); skip {
+				continue
+			}
 			componentAttr.SideEffectTasks = append(componentAttr.SideEffectTasks, componentTask)
 		}
 

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -4369,3 +4369,291 @@ func (s *nodeSuite) TestSetUserMetadata_NilClearsPersistedValue() {
 	s.NoError(err)
 	s.Nil(mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes().GetUserMetadata())
 }
+
+func (s *nodeSuite) TestCloseTransaction_SingletonTask_Replace_SideEffect() {
+	persistenceNodes := map[string]*persistencespb.ChasmNode{
+		"": {
+			Metadata: &persistencespb.ChasmNodeMetadata{
+				InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+				LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+				Attributes: &persistencespb.ChasmNodeMetadata_ComponentAttributes{
+					ComponentAttributes: &persistencespb.ChasmComponentAttributes{
+						TypeId: testComponentTypeID,
+					},
+				},
+			},
+		},
+	}
+
+	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 2 }
+	root, err := s.newTestTree(persistenceNodes)
+	s.NoError(err)
+
+	// First transaction: add an initial singleton side-effect task.
+	mutableContext := NewMutableContext(context.Background(), root)
+	c, err := root.Component(mutableContext, ComponentRef{})
+	s.NoError(err)
+	testComponent := c.(*TestComponent)
+
+	s.testLibrary.mockSingletonReplaceSideEffectTaskHandler.EXPECT().
+		Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
+	mutableContext.AddTask(testComponent, TaskAttributes{}, &TestSingletonReplaceSideEffectTask{Data: []byte("first")})
+
+	mutation, err := root.CloseTransaction()
+	s.NoError(err)
+	rootAttr := mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes()
+	s.Len(rootAttr.SideEffectTasks, 1)
+	s.Equal(testSingletonReplaceSideEffectTaskTypeID, rootAttr.SideEffectTasks[0].TypeId)
+
+	// Second transaction: add a second singleton task — it should replace the first.
+	// closeTransactionCleanupInvalidTasks re-validates the existing task (returns true to keep it),
+	// then closeTransactionHandleNewTasks validates the new task.
+	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 3 }
+	mutableContext = NewMutableContext(context.Background(), root)
+	c, err = root.Component(mutableContext, ComponentRef{})
+	s.NoError(err)
+	testComponent = c.(*TestComponent)
+
+	s.testLibrary.mockSingletonReplaceSideEffectTaskHandler.EXPECT().
+		Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(2)
+	mutableContext.AddTask(testComponent, TaskAttributes{}, &TestSingletonReplaceSideEffectTask{Data: []byte("second")})
+
+	mutation, err = root.CloseTransaction()
+	s.NoError(err)
+	rootAttr = mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes()
+	s.Len(rootAttr.SideEffectTasks, 1, "replace mode must keep exactly one task")
+	s.Equal(testSingletonReplaceSideEffectTaskTypeID, rootAttr.SideEffectTasks[0].TypeId)
+}
+
+func (s *nodeSuite) TestCloseTransaction_SingletonTask_Ignore_SideEffect() {
+	persistenceNodes := map[string]*persistencespb.ChasmNode{
+		"": {
+			Metadata: &persistencespb.ChasmNodeMetadata{
+				InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+				LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+				Attributes: &persistencespb.ChasmNodeMetadata_ComponentAttributes{
+					ComponentAttributes: &persistencespb.ChasmComponentAttributes{
+						TypeId: testComponentTypeID,
+					},
+				},
+			},
+		},
+	}
+
+	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 2 }
+	root, err := s.newTestTree(persistenceNodes)
+	s.NoError(err)
+
+	// First transaction: add the initial singleton side-effect task.
+	mutableContext := NewMutableContext(context.Background(), root)
+	c, err := root.Component(mutableContext, ComponentRef{})
+	s.NoError(err)
+	testComponent := c.(*TestComponent)
+
+	s.testLibrary.mockSingletonIgnoreSideEffectTaskHandler.EXPECT().
+		Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
+	mutableContext.AddTask(testComponent, TaskAttributes{}, &TestSingletonIgnoreSideEffectTask{Data: []byte("first")})
+
+	mutation, err := root.CloseTransaction()
+	s.NoError(err)
+	rootAttr := mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes()
+	s.Len(rootAttr.SideEffectTasks, 1)
+	firstTask := rootAttr.SideEffectTasks[0]
+
+	// Second transaction: add a second singleton task — it should be discarded.
+	// closeTransactionCleanupInvalidTasks re-validates the existing task (1 call),
+	// then closeTransactionHandleNewTasks validates the new task (1 call).
+	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 3 }
+	mutableContext = NewMutableContext(context.Background(), root)
+	c, err = root.Component(mutableContext, ComponentRef{})
+	s.NoError(err)
+	testComponent = c.(*TestComponent)
+
+	s.testLibrary.mockSingletonIgnoreSideEffectTaskHandler.EXPECT().
+		Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(2)
+	mutableContext.AddTask(testComponent, TaskAttributes{}, &TestSingletonIgnoreSideEffectTask{Data: []byte("second")})
+
+	mutation, err = root.CloseTransaction()
+	s.NoError(err)
+	rootAttr = mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes()
+	s.Len(rootAttr.SideEffectTasks, 1, "ignore mode must keep exactly one task")
+	s.Equal(firstTask.VersionedTransition, rootAttr.SideEffectTasks[0].VersionedTransition,
+		"ignore mode must keep the original task, not replace it")
+}
+
+func (s *nodeSuite) TestCloseTransaction_SingletonTask_Replace_Pure() {
+	persistenceNodes := map[string]*persistencespb.ChasmNode{
+		"": {
+			Metadata: &persistencespb.ChasmNodeMetadata{
+				InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+				LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+				Attributes: &persistencespb.ChasmNodeMetadata_ComponentAttributes{
+					ComponentAttributes: &persistencespb.ChasmComponentAttributes{
+						TypeId: testComponentTypeID,
+					},
+				},
+			},
+		},
+	}
+
+	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 2 }
+	root, err := s.newTestTree(persistenceNodes)
+	s.NoError(err)
+
+	t1 := s.timeSource.Now()
+	t2 := t1.Add(time.Minute)
+
+	// First transaction: add an initial singleton pure task.
+	mutableContext := NewMutableContext(context.Background(), root)
+	c, err := root.Component(mutableContext, ComponentRef{})
+	s.NoError(err)
+	testComponent := c.(*TestComponent)
+
+	s.testLibrary.mockSingletonReplacePureTaskHandler.EXPECT().
+		Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
+	mutableContext.AddTask(testComponent, TaskAttributes{ScheduledTime: t1}, &TestSingletonReplacePureTask{Data: []byte("first")})
+
+	mutation, err := root.CloseTransaction()
+	s.NoError(err)
+	rootAttr := mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes()
+	s.Len(rootAttr.PureTasks, 1)
+	s.Equal(testSingletonReplacePureTaskTypeID, rootAttr.PureTasks[0].TypeId)
+
+	// Second transaction: add a second singleton pure task with a different scheduled time.
+	// closeTransactionCleanupInvalidTasks re-validates the existing task (1 call),
+	// then closeTransactionHandleNewTasks validates the new task (1 call).
+	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 3 }
+	mutableContext = NewMutableContext(context.Background(), root)
+	c, err = root.Component(mutableContext, ComponentRef{})
+	s.NoError(err)
+	testComponent = c.(*TestComponent)
+
+	s.testLibrary.mockSingletonReplacePureTaskHandler.EXPECT().
+		Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(2)
+	mutableContext.AddTask(testComponent, TaskAttributes{ScheduledTime: t2}, &TestSingletonReplacePureTask{Data: []byte("second")})
+
+	mutation, err = root.CloseTransaction()
+	s.NoError(err)
+	rootAttr = mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes()
+	s.Len(rootAttr.PureTasks, 1, "replace mode must keep exactly one task")
+	s.Equal(testSingletonReplacePureTaskTypeID, rootAttr.PureTasks[0].TypeId)
+	s.Equal(t2.UTC(), rootAttr.PureTasks[0].ScheduledTime.AsTime(), "replace mode must use the new task's scheduled time")
+}
+
+func (s *nodeSuite) TestCloseTransaction_SingletonTask_Ignore_Pure() {
+	persistenceNodes := map[string]*persistencespb.ChasmNode{
+		"": {
+			Metadata: &persistencespb.ChasmNodeMetadata{
+				InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+				LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+				Attributes: &persistencespb.ChasmNodeMetadata_ComponentAttributes{
+					ComponentAttributes: &persistencespb.ChasmComponentAttributes{
+						TypeId: testComponentTypeID,
+					},
+				},
+			},
+		},
+	}
+
+	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 2 }
+	root, err := s.newTestTree(persistenceNodes)
+	s.NoError(err)
+
+	t1 := s.timeSource.Now()
+	t2 := t1.Add(time.Minute)
+
+	// First transaction: add the initial singleton pure task.
+	mutableContext := NewMutableContext(context.Background(), root)
+	c, err := root.Component(mutableContext, ComponentRef{})
+	s.NoError(err)
+	testComponent := c.(*TestComponent)
+
+	s.testLibrary.mockSingletonIgnorePureTaskHandler.EXPECT().
+		Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
+	mutableContext.AddTask(testComponent, TaskAttributes{ScheduledTime: t1}, &TestSingletonIgnorePureTask{Data: []byte("first")})
+
+	mutation, err := root.CloseTransaction()
+	s.NoError(err)
+	rootAttr := mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes()
+	s.Len(rootAttr.PureTasks, 1)
+	firstTask := rootAttr.PureTasks[0]
+
+	// Second transaction: add a second singleton pure task — it should be discarded.
+	// closeTransactionCleanupInvalidTasks re-validates the existing task (1 call),
+	// then closeTransactionHandleNewTasks validates the new task (1 call).
+	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 3 }
+	mutableContext = NewMutableContext(context.Background(), root)
+	c, err = root.Component(mutableContext, ComponentRef{})
+	s.NoError(err)
+	testComponent = c.(*TestComponent)
+
+	s.testLibrary.mockSingletonIgnorePureTaskHandler.EXPECT().
+		Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(2)
+	mutableContext.AddTask(testComponent, TaskAttributes{ScheduledTime: t2}, &TestSingletonIgnorePureTask{Data: []byte("second")})
+
+	mutation, err = root.CloseTransaction()
+	s.NoError(err)
+	rootAttr = mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes()
+	s.Len(rootAttr.PureTasks, 1, "ignore mode must keep exactly one task")
+	s.Equal(firstTask.ScheduledTime.AsTime(), rootAttr.PureTasks[0].ScheduledTime.AsTime(),
+		"ignore mode must keep the original task's scheduled time")
+}
+
+func (s *nodeSuite) TestCloseTransaction_SingletonTask_InvalidNewTask_DoesNotDisplaceExisting() {
+	persistenceNodes := map[string]*persistencespb.ChasmNode{
+		"": {
+			Metadata: &persistencespb.ChasmNodeMetadata{
+				InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+				LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+				Attributes: &persistencespb.ChasmNodeMetadata_ComponentAttributes{
+					ComponentAttributes: &persistencespb.ChasmComponentAttributes{
+						TypeId: testComponentTypeID,
+					},
+				},
+			},
+		},
+	}
+
+	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 2 }
+	root, err := s.newTestTree(persistenceNodes)
+	s.NoError(err)
+
+	// First transaction: add a valid singleton replace side-effect task.
+	mutableContext := NewMutableContext(context.Background(), root)
+	c, err := root.Component(mutableContext, ComponentRef{})
+	s.NoError(err)
+	testComponent := c.(*TestComponent)
+
+	s.testLibrary.mockSingletonReplaceSideEffectTaskHandler.EXPECT().
+		Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
+	mutableContext.AddTask(testComponent, TaskAttributes{}, &TestSingletonReplaceSideEffectTask{Data: []byte("first")})
+
+	mutation, err := root.CloseTransaction()
+	s.NoError(err)
+	rootAttr := mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes()
+	s.Len(rootAttr.SideEffectTasks, 1)
+	firstTask := rootAttr.SideEffectTasks[0]
+
+	// Second transaction: add an invalid singleton task — validation drops it before singleton logic runs,
+	// so the existing task must be unaffected.
+	// closeTransactionCleanupInvalidTasks re-validates the existing task first (returns true to keep it),
+	// then closeTransactionHandleNewTasks validates the new task (returns false to drop it).
+	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 3 }
+	mutableContext = NewMutableContext(context.Background(), root)
+	c, err = root.Component(mutableContext, ComponentRef{})
+	s.NoError(err)
+	testComponent = c.(*TestComponent)
+
+	s.testLibrary.mockSingletonReplaceSideEffectTaskHandler.EXPECT().
+		Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
+	s.testLibrary.mockSingletonReplaceSideEffectTaskHandler.EXPECT().
+		Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
+	mutableContext.AddTask(testComponent, TaskAttributes{}, &TestSingletonReplaceSideEffectTask{Data: []byte("invalid-second")})
+
+	mutation, err = root.CloseTransaction()
+	s.NoError(err)
+	rootAttr = mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes()
+	s.Len(rootAttr.SideEffectTasks, 1, "invalid new task must not displace existing singleton")
+	s.Equal(firstTask.VersionedTransition, rootAttr.SideEffectTasks[0].VersionedTransition,
+		"existing task must be unchanged")
+}


### PR DESCRIPTION
## What changed?
Add singleton registrable task option

## Why?
Add task registration option to specify as singleton. For singleton tasks, there are two conflict resolution options if task already exists: Replace or Ignore. Replace is used for cases where the task info has updated fields such as something like scheduled_time, or for use cases like visibility, where only the last task is required, since all information for execution is in the visibility component. This can replace any validation logic that checks the "stamp" of the task to check if it's stale.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)
