### PR TITLE
migration: add namespace tag to catchup_ready_shard_count metric

### DIFF
--- a/service/worker/migration/activities.go
+++ b/service/worker/migration/activities.go
@@ -307,7 +307,8 @@ func (a *activities) checkReplicationOnce(ctx context.Context, waitRequest WaitR
 	a.MetricsHandler.Gauge(metrics.CatchUpReadyShardCountGauge.Name()).Record(
 		float64(readyShardCount),
 		metrics.OperationTag(metrics.MigrationWorkflowScope),
-		metrics.TargetClusterTag(waitRequest.RemoteCluster))
+		metrics.TargetClusterTag(waitRequest.RemoteCluster),
+		metrics.NamespaceTag(waitRequest.Namespace))
 
 	isReady := notReadyShardCount == 0
 


### PR DESCRIPTION
Fixes #10833

## What changed?
Add metrics.NamespaceTag to the catchup_ready_shard_count gauge emit in checkReplicationOnce.

## Why?
handover_ready_shard_count already carries a namespace tag (same file, checkHandoverOnce). catchup_ready_shard_count was missing it, making it impossible to filter by namespace in dashboards when monitoring multiple global namespaces. The Namespace field already exists on WaitReplicationRequest and is populated by the caller.

## How did you test it?
- [ x] built
- [x ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
none to my knowledge
