### PR TITLE
Detect and mitigate stuck fair task reader on write path

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1557,6 +1557,14 @@ default as namespace cardinality can be high and this requires a metrics collect
 		`Settings for partition scale manager.`,
 	)
 
+	MatchingForceReadTasksOnWrite = NewTaskQueueBoolSetting(
+		"matching.forceReadTasksOnWrite",
+		false,
+		`When true and the fair task reader detects a stuck state (atEnd=false, loadedTasks=0, no
+read goroutine running), the write path calls maybeReadTasksLocked to attempt to unblock it.
+This is a diagnostic flag — the root cause of the stuck state is still under investigation.`,
+	)
+
 	// Worker registry settings
 	MatchingWorkerRegistryNumBuckets = NewGlobalIntSetting(
 		"matching.workerRegistryNumBuckets",

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1252,6 +1252,10 @@ var (
 		"task_retry_transient",
 		WithDescription("Count of tasks that hit a transient error during match or forward and are retried immediately"),
 	)
+	FairReaderStuckDetected = NewCounterDef(
+		"fair_reader_stuck_detected",
+		WithDescription("Count of times the fair task reader detected a stuck state (atEnd=false, loadedTasks=0, readPending=false, backoffTimer=nil) on the write path"),
+	)
 	PartitionScaleEvents = NewCounterDef("partition_scale_events")
 	PartitionScaleRead   = NewGaugeDef("partition_scale_read")
 	PartitionScaleWrite  = NewGaugeDef("partition_scale_write")

--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -19,9 +19,11 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/primitives/timestamp"
 	testutil "go.temporal.io/server/common/testing"
+	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/common/tqid"
 	"go.temporal.io/server/common/util"
@@ -880,4 +882,86 @@ func (s *BacklogManagerTestSuite) testStandingBacklog(p standingBacklogParams) {
 	s.T().Logf("reads %d, writes %d", s.taskMgr.getGetTasksCount(qkey), s.taskMgr.getCreateTaskBatchCount(qkey))
 	elapsed := time.Since(start)
 	s.T().Logf("processed %d tasks, %.3f/s", processed.Load(), float64(processed.Load())/elapsed.Seconds())
+}
+
+// TestBacklogDelivery_WritePathWakesStuckReader verifies the write-path recovery for stuck fair readers.
+// When the fair task reader is in state {atEnd=false, readPending=false, backoffTimer=nil},
+// a write via SpoolTask calls wroteNewTasks -> mergeTasks(mergeWrite). The fix adds a call
+// to maybeReadTasksLocked() in the write path, which triggers a DB read that picks up the
+// task and delivers it to the matcher.
+func (s *BacklogManagerTestSuite) TestBacklogDelivery_WritePathWakesStuckReader() {
+	if !s.fairness {
+		s.T().Skip("only applies to fair backlog manager")
+	}
+
+	s.setupToCaptureTasks()
+
+	// Enable the write-path recovery dynamic config for this test.
+	s.cfgcli.OverrideValue(dynamicconfig.MatchingForceReadTasksOnWrite.Key(), true)
+
+	// Set up initial qkey in DB so the initial read finds an empty queue.
+	qkey := s.ptqMgr.QueueKey()
+	_, err := s.taskMgr.CreateTaskQueue(context.Background(), &persistence.CreateTaskQueueRequest{
+		RangeID: 1,
+		TaskQueueInfo: &persistencespb.TaskQueueInfo{
+			NamespaceId: qkey.NamespaceId(),
+			Name:        qkey.PersistenceName(),
+			TaskType:    qkey.TaskType(),
+		},
+	})
+	s.Require().NoError(err)
+
+	s.blm.Start()
+	defer s.blm.Stop()
+	s.Require().NoError(s.blm.WaitUntilInitialized(context.Background()))
+
+	// Wait for the initial empty read to complete (reader reaches atEnd=true).
+	await.RequireTrue(s.T(), func() bool {
+		return s.taskMgr.getGetTasksCount(qkey) == 1
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Put the reader into the stuck state: atEnd=false, readPending=false, backoffTimer=nil.
+	blm := s.blm.(*fairBacklogManagerImpl)
+	blm.subqueueLock.Lock()
+	reader := blm.subqueues[subqueueZero]
+	blm.subqueueLock.Unlock()
+
+	reader.lock.Lock()
+	reader.atEnd = false
+	reader.lock.Unlock()
+
+	// Install a capturing metrics handler with namespace tag to verify the stuck metric
+	// is emitted with the correct namespace (as it would be in production).
+	captureHandler := metricstest.NewCaptureHandler()
+	capture := captureHandler.StartCapture()
+	defer captureHandler.StopCapture(capture)
+	blm.metricsHandler = captureHandler.WithTags(metrics.NamespaceTag("test-namespace"))
+
+	// Record the current DB read count before writing.
+	readCountBefore := s.taskMgr.getGetTasksCount(qkey)
+	capturedBefore := s.capturedTasksLen()
+
+	// Write a task via SpoolTask. The writer calls wroteNewTasks -> mergeTasks(mergeWrite).
+	// With the fix, mergeTasks now calls maybeReadTasksLocked() for write-mode merges,
+	// which triggers a DB read to pick up the task.
+	s.Require().NoError(s.blm.SpoolTask(&persistencespb.TaskInfo{
+		ExpiryTime: timestamp.TimeNowPtrUtcAddSeconds(3000),
+		CreateTime: timestamp.TimeNowPtrUtc(),
+	}))
+
+	// Assert the fix: the write path triggers a DB read and the task reaches the matcher.
+	await.RequireTrue(s.T(), func() bool {
+		return s.capturedTasksLen() > capturedBefore
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Assert that additional DB reads were triggered by the write path.
+	s.Require().Greater(s.taskMgr.getGetTasksCount(qkey), readCountBefore,
+		"DB reads should have been triggered after SpoolTask to pick up the written task")
+
+	// Assert that the stuck detection metric was emitted exactly once with namespace tag.
+	snap := capture.Snapshot()
+	recordings := snap[metrics.FairReaderStuckDetected.Name()]
+	s.Require().Len(recordings, 1, "fair_reader_stuck_detected metric should have been emitted exactly once")
+	s.Require().Equal(int64(1), recordings[0].Value)
+	s.Require().Equal("test-namespace", recordings[0].Tags["namespace"])
 }

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -48,6 +48,7 @@ type (
 		AutoEnableV2Sub                          dynamicconfig.TypedSubscribableWithTaskQueueFilter[bool]
 		GetTasksBatchSize                        dynamicconfig.IntPropertyFnWithTaskQueueFilter
 		GetTasksReloadAt                         dynamicconfig.IntPropertyFnWithTaskQueueFilter
+		ForceReadTasksOnWrite                    dynamicconfig.BoolPropertyFnWithTaskQueueFilter
 		UpdateAckInterval                        dynamicconfig.DurationPropertyFnWithTaskQueueFilter
 		MetadataUpdateOnAppendInterval           dynamicconfig.DurationPropertyFnWithTaskQueueFilter
 		MaxTaskQueueIdleTime                     dynamicconfig.DurationPropertyFnWithTaskQueueFilter
@@ -172,6 +173,7 @@ type (
 		AutoEnableV2Sub                func(func(bool)) (bool, func())
 		GetTasksBatchSize              func() int
 		GetTasksReloadAt               func() int
+		ForceReadTasksOnWrite          func() bool
 		UpdateAckInterval              func() time.Duration
 		MetadataUpdateOnAppendInterval func() time.Duration
 		MaxTaskQueueIdleTime           func() time.Duration
@@ -290,6 +292,7 @@ func NewConfig(
 		AutoEnableV2Sub:                          dynamicconfig.MatchingAutoEnableV2.Subscribe(dc),
 		GetTasksBatchSize:                        dynamicconfig.MatchingGetTasksBatchSize.Get(dc),
 		GetTasksReloadAt:                         dynamicconfig.MatchingGetTasksReloadAt.Get(dc),
+		ForceReadTasksOnWrite:                    dynamicconfig.MatchingForceReadTasksOnWrite.Get(dc),
 		UpdateAckInterval:                        dynamicconfig.MatchingUpdateAckInterval.Get(dc),
 		MetadataUpdateOnAppendInterval:           dynamicconfig.MatchingMetadataUpdateOnAppendInterval.Get(dc),
 		MaxTaskQueueIdleTime:                     dynamicconfig.MatchingMaxTaskQueueIdleTime.Get(dc),
@@ -411,6 +414,9 @@ func newTaskQueueConfig(tq *tqid.TaskQueue, config *Config, ns namespace.Name) *
 		},
 		GetTasksReloadAt: func() int {
 			return config.GetTasksReloadAt(ns.String(), taskQueueName, taskType)
+		},
+		ForceReadTasksOnWrite: func() bool {
+			return config.ForceReadTasksOnWrite(ns.String(), taskQueueName, taskType)
 		},
 		UpdateAckInterval: func() time.Duration {
 			return config.UpdateAckInterval(ns.String(), taskQueueName, taskType)

--- a/service/matching/fair_task_reader.go
+++ b/service/matching/fair_task_reader.go
@@ -384,6 +384,18 @@ func (tr *fairTaskReader) mergeTasks(tasks []*persistencespb.AllocatedTaskInfo, 
 
 	newTasks := tr.mergeTasksLocked(tasks, mode)
 
+	// Detect stuck reader: no tasks in memory, not at end, no read goroutine running, no
+	// retry pending. In this state, written tasks go only to DB (filtered above readLevel)
+	// and nothing will trigger a read. The root cause is still under investigation.
+	// TODO: remove this once the root cause is found and fixed.
+	if mode == mergeWrite && !tr.atEnd && tr.loadedTasks == 0 && !tr.readPending && tr.backoffTimer == nil {
+		metrics.FairReaderStuckDetected.With(tr.backlogMgr.metricsHandler).Record(1)
+		tr.backlogMgr.throttledLogger.Warn("fair task reader stuck: atEnd=false, loadedTasks=0, no read pending")
+		if tr.backlogMgr.config.ForceReadTasksOnWrite() {
+			tr.maybeReadTasksLocked()
+		}
+	}
+
 	// unlock before calling addTaskToMatcher
 	tr.lock.Unlock()
 


### PR DESCRIPTION
## What

Cherry-pick of #10814 onto `cloud/v1.32.0-157`.

Adds detection and gated corrective action for a stuck fair task reader state (`atEnd=false, loadedTasks=0, readPending=false, backoffTimer=nil`). Emits a `fair_reader_stuck_detected` metric (per namespace/task queue) and a throttled Warn log (with partition info). When `matching.forceReadTasksOnWrite` is enabled and stuck state is detected, calls `maybeReadTasksLocked` to attempt recovery.

## Why

Production task queue partitions can get stuck in this state — pollers wait, DB backlog grows, but no tasks are dispatched. Root cause is still under investigation.

## How did you test it?

- Unit test (`TestBacklogDelivery_WritePathWakesStuckReader`): simulates stuck state, writes a task, asserts task delivery, DB read triggered, and metric emitted with namespace tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)