### PR TITLE
[Scheduler] Remove stateSizeBytes from ListInfo/Visibility

### DIFF
--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -989,7 +989,6 @@ func (s *Scheduler) ListInfo(
 	ctx chasm.Context,
 ) *schedulepb.ScheduleListInfo {
 	spec := common.CloneProto(s.Schedule.Spec)
-	executionInfo := ctx.ExecutionInfo()
 
 	// Clear fields that are too large/not useful for the list view.
 	spec.TimezoneData = nil
@@ -1009,7 +1008,6 @@ func (s *Scheduler) ListInfo(
 		Paused:            s.Schedule.State.Paused,
 		RecentActions:     invoker.recentActions(),
 		FutureActionTimes: generator.FutureActionTimes,
-		StateSizeBytes:    int64(executionInfo.ApproximateStateSize),
 	}
 }
 

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -2216,11 +2216,6 @@ func testStateSizeBytesReported(t *testing.T, newContext contextFactory) {
 	})
 	s.NoError(err)
 	s.Positive(desc.GetInfo().GetStateSizeBytes(), "Describe should report a non-zero StateSizeBytes")
-
-	entry := getScheduleEntryFromVisibility(s, sid, newContext, func(e *schedulepb.ScheduleListEntry) bool {
-		return e.GetInfo().GetStateSizeBytes() > 0
-	})
-	s.Positive(entry.GetInfo().GetStateSizeBytes(), "ListSchedules entry should report a non-zero StateSizeBytes")
 }
 
 // testCreatesCHASMSentinel tests that creating a V1 schedule also creates a


### PR DESCRIPTION
## What changed?
- Title
- Still exposed in the `Describe` handler as an exact number

## Why?
- Not needed for metering validation; having it in visibility causes us to oscillate the memo field whenever state size changes (which is often).

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
