### PR TITLE
Add NewCHASMActivityTaskToken for standalone activity tokens

### DIFF
--- a/common/tasktoken/token.go
+++ b/common/tasktoken/token.go
@@ -30,6 +30,28 @@ func NewWorkflowTaskToken(
 	}
 }
 
+// NewCHASMActivityTaskToken builds a task token for a CHASM (standalone) activity.
+// CHASM activities don't use ScheduledEventId, Clock, Version, or StartVersion.
+func NewCHASMActivityTaskToken(
+	namespaceID string,
+	workflowID string,
+	runID string,
+	activityId string,
+	activityType string,
+	attempt int32,
+	componentRef []byte,
+) *tokenspb.Task {
+	return NewActivityTaskToken(
+		namespaceID, workflowID, runID,
+		0, // scheduledEventId
+		activityId, activityType, attempt,
+		nil, // clock
+		0,   // version
+		0,   // startVersion
+		componentRef,
+	)
+}
+
 func NewActivityTaskToken(
 	namespaceID string,
 	workflowID string,

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -3222,19 +3222,32 @@ func (e *matchingEngineImpl) createPollActivityTaskQueueResponse(
 		metrics.AsyncMatchLatencyPerTaskQueue.With(metricsHandler).Record(time.Since(ct))
 	}
 
-	taskToken := tasktoken.NewActivityTaskToken(
-		task.event.Data.GetNamespaceId(),
-		task.event.Data.GetWorkflowId(),
-		task.event.Data.GetRunId(),
-		task.event.Data.GetScheduledEventId(),
-		attributes.GetActivityId(),
-		attributes.GetActivityType().GetName(),
-		historyResponse.GetAttempt(),
-		historyResponse.GetClock(),
-		historyResponse.GetVersion(),
-		historyResponse.GetStartVersion(),
-		task.event.GetData().GetComponentRef(),
-	)
+	var taskToken *tokenspb.Task
+	if componentRef := task.event.GetData().GetComponentRef(); len(componentRef) > 0 {
+		taskToken = tasktoken.NewCHASMActivityTaskToken(
+			task.event.Data.GetNamespaceId(),
+			task.event.Data.GetWorkflowId(),
+			task.event.Data.GetRunId(),
+			attributes.GetActivityId(),
+			attributes.GetActivityType().GetName(),
+			historyResponse.GetAttempt(),
+			componentRef,
+		)
+	} else {
+		taskToken = tasktoken.NewActivityTaskToken(
+			task.event.Data.GetNamespaceId(),
+			task.event.Data.GetWorkflowId(),
+			task.event.Data.GetRunId(),
+			task.event.Data.GetScheduledEventId(),
+			attributes.GetActivityId(),
+			attributes.GetActivityType().GetName(),
+			historyResponse.GetAttempt(),
+			historyResponse.GetClock(),
+			historyResponse.GetVersion(),
+			historyResponse.GetStartVersion(),
+			nil,
+		)
+	}
 	serializedToken, _ := e.tokenSerializer.Serialize(taskToken)
 
 	// This is here to ensure that this field is never nil as expected by the TS SDK.


### PR DESCRIPTION
## What
Adds a `NewCHASMActivityTaskToken` helper to `common/tasktoken` and uses it in matching for standalone activity poll tokens.

## Why
To reuse in the cancel command token builder in #10218.

## How did you test it?
Existing unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)