### PR TITLE
Suppress CHASM caller metrics during reset/conflict-resolution re-apply

### DIFF
--- a/chasm/context.go
+++ b/chasm/context.go
@@ -117,6 +117,12 @@ type immutableCtx struct {
 
 	executionKey ExecutionKey
 
+	// replaying indicates this context is driving a transition that is being re-applied from
+	// history rather than executed live (e.g. cherry-pick during workflow reset / conflict
+	// resolution). While set, MetricsHandler() returns a no-op handler so that metrics emitted
+	// inside a transition are not double-counted on re-apply. Child contexts inherit the value.
+	replaying bool
+
 	// Not embedding the Node here to avoid exposing AddTask() method on Node,
 	// so that ContextImpl won't implement MutableContext interface.
 	root *Node
@@ -133,7 +139,7 @@ func NewContext(
 	ctx context.Context,
 	node *Node,
 ) Context {
-	return newContext(ctx, node)
+	return newContext(ctx, node, false)
 }
 
 // newContext creates a new immutableCtx from an existing Context and root Node.
@@ -141,13 +147,15 @@ func NewContext(
 func newContext(
 	ctx context.Context,
 	node *Node,
+	replaying bool,
 ) *immutableCtx {
 	root := node.root()
 	workflowKey := node.backend.GetWorkflowKey()
 	return &immutableCtx{
-		ctx:  ctx,
-		now:  root.Now(nil),
-		root: root,
+		ctx:       ctx,
+		now:       root.Now(nil),
+		root:      root,
+		replaying: replaying,
 		executionKey: ExecutionKey{
 			NamespaceID: workflowKey.NamespaceID,
 			BusinessID:  workflowKey.WorkflowID,
@@ -201,6 +209,12 @@ func (c *immutableCtx) Logger() log.Logger {
 }
 
 func (c *immutableCtx) MetricsHandler() metrics.Handler {
+	if c.replaying {
+		// Suppress metrics while re-applying a transition from history (cherry-pick during reset /
+		// conflict resolution) so side-effect metrics emitted inside transitions are not
+		// double-counted. See the replaying field.
+		return metrics.NoopMetricsHandler
+	}
 	return c.root.metricsHandler
 }
 
@@ -217,6 +231,7 @@ func (c *immutableCtx) withValue(key any, value any) Context {
 		ctx:          context.WithValue(c.goContext(), key, value),
 		now:          c.now,
 		root:         c.root,
+		replaying:    c.replaying,
 		executionKey: c.executionKey,
 	}
 }
@@ -257,7 +272,24 @@ func NewMutableContext(
 	node *Node,
 ) MutableContext {
 	return &mutableCtx{
-		immutableCtx: newContext(ctx, node),
+		immutableCtx: newContext(ctx, node, false),
+	}
+}
+
+// NewMutableContextForReplay creates a MutableContext for re-applying a transition from history
+// (cherry-pick during workflow reset / conflict resolution) rather than executing it live. While a
+// transition runs under this context, MetricsHandler() returns a no-op handler so that metrics
+// emitted inside the transition are not double-counted on re-apply. This applies framework-wide to
+// any component's transitions, not just a specific event type.
+//
+// NOTE: Library authors should not invoke this constructor directly; it is intended for the
+// reset/conflict-resolution re-apply path.
+func NewMutableContextForReplay(
+	ctx context.Context,
+	node *Node,
+) MutableContext {
+	return &mutableCtx{
+		immutableCtx: newContext(ctx, node, true),
 	}
 }
 

--- a/chasm/lib/nexusoperation/operation_statemachine_test.go
+++ b/chasm/lib/nexusoperation/operation_statemachine_test.go
@@ -13,7 +13,9 @@ import (
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/nexusoperation/gen/nexusoperationpb/v1"
 	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/namespace"
@@ -433,6 +435,78 @@ func TestTransitionSucceeded(t *testing.T) {
 			}, capture.Snapshot())
 		})
 	}
+}
+
+// TestTransitionSucceeded_MetricsSuppressedDuringReplay drives a real TransitionSucceeded through a
+// real chasm context (not a mock) to verify that the framework-level cherry-pick guard
+// (chasm.NewMutableContextForReplay) suppresses the caller-side metric emission, while a live
+// context still emits.
+func TestTransitionSucceeded_MetricsSuppressedDuringReplay(t *testing.T) {
+	newTreeWithStartedOperation := func(t *testing.T, handler metrics.Handler) (*chasm.Node, *Operation) {
+		logger := log.NewNoopLogger()
+		registry := chasm.NewRegistry(logger)
+		require.NoError(t, registry.Register(&chasm.CoreLibrary{}))
+		require.NoError(t, registry.Register(&Library{}))
+
+		timeSource := clock.NewEventTimeSource()
+		timeSource.Update(defaultTime)
+		nodeBackend := &chasm.MockNodeBackend{
+			HandleNextTransitionCount: func() int64 { return 2 },
+			HandleGetCurrentVersion:   func() int64 { return 1 },
+			HandleCurrentVersionedTransition: func() *persistencespb.VersionedTransition {
+				return &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 1}
+			},
+			HandleGetNamespaceEntry: func() *namespace.Namespace {
+				return namespace.NewNamespaceForTest(&persistencespb.NamespaceInfo{Name: "ns-name"}, nil, false, nil, 0)
+			},
+		}
+
+		root := chasm.NewEmptyTree(registry, timeSource, nodeBackend, chasm.DefaultPathEncoder, logger, handler)
+		setupCtx := chasm.NewMutableContext(context.Background(), root)
+		op := NewOperation(&nexusoperationpb.OperationState{
+			Status:                 nexusoperationpb.OPERATION_STATUS_STARTED,
+			Endpoint:               "test-endpoint",
+			Service:                "test-service",
+			Operation:              "test-operation",
+			ScheduledTime:          timestamppb.New(defaultTime),
+			StartedTime:            timestamppb.New(defaultTime.Add(time.Second)),
+			ScheduleToCloseTimeout: durationpb.New(defaultScheduleToCloseTimeout),
+			RequestId:              "request-id",
+		})
+		op.RequestData = chasm.NewDataField(setupCtx, &nexusoperationpb.OperationRequestData{})
+		require.NoError(t, root.SetRootComponent(op))
+		_, err := root.CloseTransaction()
+		require.NoError(t, err)
+		return root, op
+	}
+
+	// Carries the OperationContext the metric tagging looks up; tag config is irrelevant here.
+	goCtx := context.WithValue(context.Background(), OperationContextKey, &OperationContext{
+		MetricTagConfig: dynamicconfig.GetTypedPropertyFn(NexusMetricTagConfig{}),
+	})
+
+	t.Run("replay context suppresses emission", func(t *testing.T) {
+		handler := metricstest.NewCaptureHandler()
+		capture := handler.StartCapture()
+		defer handler.StopCapture(capture)
+
+		root, op := newTreeWithStartedOperation(t, handler)
+		ctx := chasm.NewMutableContextForReplay(goCtx, root)
+		require.NoError(t, TransitionSucceeded.Apply(op, ctx, EventSucceeded{Result: mustToPayload(t, "result")}))
+		require.Equal(t, nexusoperationpb.OPERATION_STATUS_SUCCEEDED, op.Status)
+		require.Empty(t, capture.Snapshot(), "no caller metrics should be emitted while re-applying during cherry-pick")
+	})
+
+	t.Run("live context emits", func(t *testing.T) {
+		handler := metricstest.NewCaptureHandler()
+		capture := handler.StartCapture()
+		defer handler.StopCapture(capture)
+
+		root, op := newTreeWithStartedOperation(t, handler)
+		ctx := chasm.NewMutableContext(goCtx, root)
+		require.NoError(t, TransitionSucceeded.Apply(op, ctx, EventSucceeded{Result: mustToPayload(t, "result")}))
+		require.NotEmpty(t, capture.Snapshot()[NexusOperationSuccessCount.Name()], "live path should emit the success counter")
+	})
 }
 
 func TestTransitionFailed(t *testing.T) {

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -25,6 +25,7 @@ import (
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/testing/protoassert"
 	"go.temporal.io/server/common/testing/protorequire"
@@ -88,6 +89,27 @@ func (s *nodeSuite) initAssertions() {
 
 	s.Assertions = require.New(s.T())
 	s.ProtoAssertions = protorequire.New(s.T())
+}
+
+func (s *nodeSuite) TestContextMetricsHandler_SuppressedWhenReplaying() {
+	base := s.nodeBase()
+	liveHandler := metricstest.NewCaptureHandler()
+	base.metricsHandler = liveHandler
+	root := newNode(base, nil, "")
+
+	// A live context uses the configured handler.
+	liveCtx := NewMutableContext(context.Background(), root)
+	s.Equal(metrics.Handler(liveHandler), liveCtx.MetricsHandler())
+
+	// A replay context (cherry-pick re-apply) suppresses metrics with the no-op handler.
+	replayCtx := NewMutableContextForReplay(context.Background(), root)
+	s.Equal(metrics.NoopMetricsHandler, replayCtx.MetricsHandler())
+	s.NotEqual(liveCtx.MetricsHandler(), replayCtx.MetricsHandler())
+
+	// Child contexts derived via ContextWithValue inherit the replay flag.
+	type ctxKey struct{}
+	derived := ContextWithValue(replayCtx, ctxKey{}, "value")
+	s.Equal(metrics.NoopMetricsHandler, derived.MetricsHandler())
 }
 
 func (s *nodeSuite) TestNewTree() {

--- a/service/history/interfaces/mutable_state.go
+++ b/service/history/interfaces/mutable_state.go
@@ -361,6 +361,10 @@ type (
 		ChasmEnabled() bool
 		ChasmSignalBacklinksEnabled() bool
 		ChasmWorkflowComponent(ctx context.Context) (*chasmworkflow.Workflow, chasm.MutableContext, error)
+		// ChasmWorkflowComponentForReplay is like ChasmWorkflowComponent but returns a context in
+		// replay mode (metrics suppressed), for re-applying events from history during reset /
+		// cherry-pick / conflict resolution without double-counting caller-side metrics.
+		ChasmWorkflowComponentForReplay(ctx context.Context) (*chasmworkflow.Workflow, chasm.MutableContext, error)
 		ChasmWorkflowComponentReadOnly(ctx context.Context) (*chasmworkflow.Workflow, chasm.Context, error)
 		// Ensures that the chasm workflow component is installed in the mutable state CHASM tree.
 		// Must be called before adding any components to the tree.

--- a/service/history/interfaces/mutable_state_mock.go
+++ b/service/history/interfaces/mutable_state_mock.go
@@ -1766,6 +1766,22 @@ func (mr *MockMutableStateMockRecorder) ChasmWorkflowComponent(ctx any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChasmWorkflowComponent", reflect.TypeOf((*MockMutableState)(nil).ChasmWorkflowComponent), ctx)
 }
 
+// ChasmWorkflowComponentForReplay mocks base method.
+func (m *MockMutableState) ChasmWorkflowComponentForReplay(ctx context.Context) (*workflow1.Workflow, chasm.MutableContext, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ChasmWorkflowComponentForReplay", ctx)
+	ret0, _ := ret[0].(*workflow1.Workflow)
+	ret1, _ := ret[1].(chasm.MutableContext)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ChasmWorkflowComponentForReplay indicates an expected call of ChasmWorkflowComponentForReplay.
+func (mr *MockMutableStateMockRecorder) ChasmWorkflowComponentForReplay(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChasmWorkflowComponentForReplay", reflect.TypeOf((*MockMutableState)(nil).ChasmWorkflowComponentForReplay), ctx)
+}
+
 // ChasmWorkflowComponentReadOnly mocks base method.
 func (m *MockMutableState) ChasmWorkflowComponentReadOnly(ctx context.Context) (*workflow1.Workflow, chasm.Context, error) {
 	m.ctrl.T.Helper()

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -1121,7 +1121,9 @@ func cherryPickChasmEvent(
 	if !ok {
 		return cherryPickFallback, nil
 	}
-	wf, chasmCtx, err := mutableState.ChasmWorkflowComponent(ctx)
+	// Cherry-pick re-applies an event from history: use a replay context so transition side-effect
+	// metrics (e.g. caller-side Nexus operation metrics) are not re-emitted.
+	wf, chasmCtx, err := mutableState.ChasmWorkflowComponentForReplay(ctx)
 	if err != nil {
 		return cherryPickSkipped, err
 	}

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -1816,7 +1816,7 @@ func (s *workflowResetterSuite) TestCherryPickChasmEvent() {
 			registry: newChasmRegistryWithEvent(eventType, nil),
 			setupMock: func(ms *historyi.MockMutableState) {
 				ms.EXPECT().ChasmEnabled().Return(true)
-				ms.EXPECT().ChasmWorkflowComponent(gomock.Any()).Return(nil, nil, cherryPickErr)
+				ms.EXPECT().ChasmWorkflowComponentForReplay(gomock.Any()).Return(nil, nil, cherryPickErr)
 			},
 			wantOutcome: cherryPickSkipped,
 			wantErr:     cherryPickErr,
@@ -1826,7 +1826,7 @@ func (s *workflowResetterSuite) TestCherryPickChasmEvent() {
 			registry: newChasmRegistryWithEvent(eventType, chasmworkflow.ErrEventNotCherryPickable),
 			setupMock: func(ms *historyi.MockMutableState) {
 				ms.EXPECT().ChasmEnabled().Return(true)
-				ms.EXPECT().ChasmWorkflowComponent(gomock.Any()).Return(nil, nil, nil)
+				ms.EXPECT().ChasmWorkflowComponentForReplay(gomock.Any()).Return(nil, nil, nil)
 			},
 			wantOutcome: cherryPickSkipped,
 		},
@@ -1835,7 +1835,7 @@ func (s *workflowResetterSuite) TestCherryPickChasmEvent() {
 			registry: newChasmRegistryWithEvent(eventType, cherryPickErr),
 			setupMock: func(ms *historyi.MockMutableState) {
 				ms.EXPECT().ChasmEnabled().Return(true)
-				ms.EXPECT().ChasmWorkflowComponent(gomock.Any()).Return(nil, nil, nil)
+				ms.EXPECT().ChasmWorkflowComponentForReplay(gomock.Any()).Return(nil, nil, nil)
 			},
 			wantOutcome: cherryPickSkipped,
 			wantErr:     cherryPickErr,
@@ -1845,7 +1845,7 @@ func (s *workflowResetterSuite) TestCherryPickChasmEvent() {
 			registry: newChasmRegistryWithEvent(eventType, nil),
 			setupMock: func(ms *historyi.MockMutableState) {
 				ms.EXPECT().ChasmEnabled().Return(true)
-				ms.EXPECT().ChasmWorkflowComponent(gomock.Any()).Return(nil, nil, nil)
+				ms.EXPECT().ChasmWorkflowComponentForReplay(gomock.Any()).Return(nil, nil, nil)
 			},
 			wantOutcome: cherryPickApplied,
 		},
@@ -1876,7 +1876,7 @@ func (s *workflowResetterSuite) TestReapplyEventsHSMToChasmFallback() {
 	s.Run("falls back to chasm and reapplies when chasm owns the op", func() {
 		ms := historyi.NewMockMutableState(s.controller)
 		ms.EXPECT().ChasmEnabled().Return(true)
-		ms.EXPECT().ChasmWorkflowComponent(gomock.Any()).Return(nil, nil, nil)
+		ms.EXPECT().ChasmWorkflowComponentForReplay(gomock.Any()).Return(nil, nil, nil)
 		ms.EXPECT().AddHistoryEvent(eventType, gomock.Any()).Return(&historypb.HistoryEvent{})
 
 		applied, err := reapplyEvents(

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -700,7 +700,18 @@ func (ms *MutableStateImpl) ChasmSignalBacklinksEnabled() bool {
 // Returns the workflow component (which is *chasmworkflow.Workflow) and the CHASM mutable context.
 // This method is for write operations. Callers can type assert to *chasmworkflow.Workflow if needed.
 func (ms *MutableStateImpl) ChasmWorkflowComponent(ctx context.Context) (*chasmworkflow.Workflow, chasm.MutableContext, error) {
-	chasmCtx := chasm.NewMutableContext(ctx, ms.chasmTree.(*chasm.Node))
+	return ms.chasmWorkflowComponent(chasm.NewMutableContext(ctx, ms.chasmTree.(*chasm.Node)))
+}
+
+// ChasmWorkflowComponentForReplay is like ChasmWorkflowComponent but returns a context in replay
+// mode, so that metrics emitted inside transitions are suppressed while events are re-applied from
+// history (reset rebuild, cherry-pick, conflict resolution) rather than executed live. Used by the
+// reset/reapply paths to avoid double-counting caller-side metrics.
+func (ms *MutableStateImpl) ChasmWorkflowComponentForReplay(ctx context.Context) (*chasmworkflow.Workflow, chasm.MutableContext, error) {
+	return ms.chasmWorkflowComponent(chasm.NewMutableContextForReplay(ctx, ms.chasmTree.(*chasm.Node)))
+}
+
+func (ms *MutableStateImpl) chasmWorkflowComponent(chasmCtx chasm.MutableContext) (*chasmworkflow.Workflow, chasm.MutableContext, error) {
 	rootComponent, err := ms.chasmTree.ComponentByPath(chasmCtx, nil)
 	if err != nil {
 		return nil, nil, err

--- a/service/history/workflow/mutable_state_rebuilder.go
+++ b/service/history/workflow/mutable_state_rebuilder.go
@@ -809,7 +809,9 @@ func (b *MutableStateRebuilderImpl) applyChasmEvent(
 	}
 	// Ensure the root CHASM workflow component exists before applying.
 	b.mutableState.EnsureChasmWorkflowComponent(ctx)
-	wf, chasmCtx, err := b.mutableState.ChasmWorkflowComponent(ctx)
+	// Re-applying events from history: use a replay context so transition side-effect metrics
+	// (e.g. caller-side Nexus operation metrics) are not re-emitted during rebuild.
+	wf, chasmCtx, err := b.mutableState.ChasmWorkflowComponentForReplay(ctx)
 	if err != nil {
 		return false, err
 	}

--- a/service/history/workflow/mutable_state_rebuilder_test.go
+++ b/service/history/workflow/mutable_state_rebuilder_test.go
@@ -2237,7 +2237,7 @@ func (s *stateBuilderSuite) TestApplyEvents_NexusScheduled_ChasmCreateFallsBackT
 	s.mockMutableState.EXPECT().GetNamespaceEntry().Return(tests.GlobalNamespaceEntry).AnyTimes()
 	s.mockMutableState.EXPECT().EnsureChasmWorkflowComponent(gomock.Any()).AnyTimes()
 	// Force the CHASM create to fail so the HSM fallback path is taken.
-	s.mockMutableState.EXPECT().ChasmWorkflowComponent(gomock.Any()).
+	s.mockMutableState.EXPECT().ChasmWorkflowComponentForReplay(gomock.Any()).
 		Return(nil, nil, serviceerror.NewInternal("chasm unavailable")).AnyTimes()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
@@ -2377,7 +2377,7 @@ func (s *stateBuilderSuite) runApplyStateMachineEvent(
 	ms.EXPECT().ChasmEnabled().Return(tc.chasmEnabled).AnyTimes()
 	ms.EXPECT().GetNamespaceEntry().Return(tests.GlobalNamespaceEntry).AnyTimes()
 	ms.EXPECT().EnsureChasmWorkflowComponent(gomock.Any()).AnyTimes()
-	ms.EXPECT().ChasmWorkflowComponent(gomock.Any()).
+	ms.EXPECT().ChasmWorkflowComponentForReplay(gomock.Any()).
 		Return(&chasmworkflow.Workflow{}, nil, tc.chasmComponentErr).AnyTimes()
 
 	rebuilder := NewMutableStateRebuilder(s.mockShard, s.logger, ms)


### PR DESCRIPTION
## What changed?

Suppress CHASM caller-side metric emission while events are **re-applied from history** (reset rebuild, cherry-pick, conflict resolution), and wire it into the reset/reapply dispatch added by #10854.

CHASM components emit metrics inside their transition callbacks via `ctx.MetricsHandler()` (e.g. `nexusoperation.TransitionSucceeded` → `emitOnSucceededMetrics`). When the reset/conflict-resolution paths re-run those transitions, the metrics would be emitted again and double-counted.

**Framework guard (`chasm`):**
- `chasm.NewMutableContextForReplay(ctx, node)` builds a `MutableContext` with a `replaying` flag; `Context.MetricsHandler()` returns `metrics.NoopMetricsHandler` while replaying. Inherited by child contexts (`withValue`). Generic — suppresses metrics for any component's transitions, not just Nexus.

**Wiring (`service/history`):**
- New `MutableState.ChasmWorkflowComponentForReplay(ctx)` returns the workflow component with a replay context (shares a helper with `ChasmWorkflowComponent`; live callers unchanged).
- Used at the two sites:
  - `mutable_state_rebuilder` (`def.Apply`)
  - `workflow_resetter.cherryPickChasmEvent` (`def.CherryPick`)

## Why?

Mirrors the HSM caller-metrics work (#10808), where emission was kept out of `Apply` entirely. CHASM emits inside transitions, so the equivalent is a replay-aware no-op handler applied at the re-apply sites. Both re-apply sites must be guarded: the base rebuild re-emits metrics for operations that were already terminal before the reset point, and the cherry-pick re-emits for post-reset-point events.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- No behavior change on live paths (`replaying` defaults to false; live constructors/callers unchanged).
- Metric suppression is scoped to the re-apply sites and cherry pick sites
