### PR TITLE
[alt] Suppress CHASM metric emission while re-applying transitions (node method)

### DIFF
--- a/chasm/context.go
+++ b/chasm/context.go
@@ -201,6 +201,12 @@ func (c *immutableCtx) Logger() log.Logger {
 }
 
 func (c *immutableCtx) MetricsHandler() metrics.Handler {
+	if c.root.replaying {
+		// Suppress metrics while the tree is re-applying a transition from history (cherry-pick
+		// during reset / conflict resolution) so side-effect metrics emitted inside transitions are
+		// not double-counted. See nodeBase.replaying / Node.SetReplaying.
+		return metrics.NoopMetricsHandler
+	}
 	return c.root.metricsHandler
 }
 

--- a/chasm/lib/nexusoperation/operation_statemachine_test.go
+++ b/chasm/lib/nexusoperation/operation_statemachine_test.go
@@ -13,7 +13,9 @@ import (
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/nexusoperation/gen/nexusoperationpb/v1"
 	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/namespace"
@@ -433,6 +435,78 @@ func TestTransitionSucceeded(t *testing.T) {
 			}, capture.Snapshot())
 		})
 	}
+}
+
+// TestTransitionSucceeded_MetricsSuppressedDuringReplay drives a real TransitionSucceeded through a
+// real chasm context (not a mock) to verify that putting the tree into replay mode
+// (Node.SetReplaying) suppresses the caller-side metric emission, while live mode still emits.
+func TestTransitionSucceeded_MetricsSuppressedDuringReplay(t *testing.T) {
+	newTreeWithStartedOperation := func(t *testing.T, handler metrics.Handler) (*chasm.Node, *Operation) {
+		logger := log.NewNoopLogger()
+		registry := chasm.NewRegistry(logger)
+		require.NoError(t, registry.Register(&chasm.CoreLibrary{}))
+		require.NoError(t, registry.Register(&Library{}))
+
+		timeSource := clock.NewEventTimeSource()
+		timeSource.Update(defaultTime)
+		nodeBackend := &chasm.MockNodeBackend{
+			HandleNextTransitionCount: func() int64 { return 2 },
+			HandleGetCurrentVersion:   func() int64 { return 1 },
+			HandleCurrentVersionedTransition: func() *persistencespb.VersionedTransition {
+				return &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 1}
+			},
+			HandleGetNamespaceEntry: func() *namespace.Namespace {
+				return namespace.NewNamespaceForTest(&persistencespb.NamespaceInfo{Name: "ns-name"}, nil, false, nil, 0)
+			},
+		}
+
+		root := chasm.NewEmptyTree(registry, timeSource, nodeBackend, chasm.DefaultPathEncoder, logger, handler)
+		setupCtx := chasm.NewMutableContext(context.Background(), root)
+		op := NewOperation(&nexusoperationpb.OperationState{
+			Status:                 nexusoperationpb.OPERATION_STATUS_STARTED,
+			Endpoint:               "test-endpoint",
+			Service:                "test-service",
+			Operation:              "test-operation",
+			ScheduledTime:          timestamppb.New(defaultTime),
+			StartedTime:            timestamppb.New(defaultTime.Add(time.Second)),
+			ScheduleToCloseTimeout: durationpb.New(defaultScheduleToCloseTimeout),
+			RequestId:              "request-id",
+		})
+		op.RequestData = chasm.NewDataField(setupCtx, &nexusoperationpb.OperationRequestData{})
+		require.NoError(t, root.SetRootComponent(op))
+		_, err := root.CloseTransaction()
+		require.NoError(t, err)
+		return root, op
+	}
+
+	// Carries the OperationContext the metric tagging looks up; tag config is irrelevant here.
+	goCtx := context.WithValue(context.Background(), OperationContextKey, &OperationContext{
+		MetricTagConfig: dynamicconfig.GetTypedPropertyFn(NexusMetricTagConfig{}),
+	})
+
+	t.Run("replay mode suppresses emission", func(t *testing.T) {
+		handler := metricstest.NewCaptureHandler()
+		capture := handler.StartCapture()
+		defer handler.StopCapture(capture)
+
+		root, op := newTreeWithStartedOperation(t, handler)
+		root.SetReplaying(true)
+		ctx := chasm.NewMutableContext(goCtx, root)
+		require.NoError(t, TransitionSucceeded.Apply(op, ctx, EventSucceeded{Result: mustToPayload(t, "result")}))
+		require.Equal(t, nexusoperationpb.OPERATION_STATUS_SUCCEEDED, op.Status)
+		require.Empty(t, capture.Snapshot(), "no caller metrics should be emitted while re-applying during cherry-pick")
+	})
+
+	t.Run("live mode emits", func(t *testing.T) {
+		handler := metricstest.NewCaptureHandler()
+		capture := handler.StartCapture()
+		defer handler.StopCapture(capture)
+
+		root, op := newTreeWithStartedOperation(t, handler)
+		ctx := chasm.NewMutableContext(goCtx, root)
+		require.NoError(t, TransitionSucceeded.Apply(op, ctx, EventSucceeded{Result: mustToPayload(t, "result")}))
+		require.NotEmpty(t, capture.Snapshot()[NexusOperationSuccessCount.Name()], "live path should emit the success counter")
+	})
 }
 
 func TestTransitionFailed(t *testing.T) {

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -137,6 +137,12 @@ type (
 		logger         log.Logger
 		metricsHandler metrics.Handler
 
+		// replaying indicates the tree is re-applying transitions from history (cherry-pick during
+		// workflow reset / conflict resolution) rather than executing them live. While set,
+		// Context.MetricsHandler() returns a no-op handler so transition side-effect metrics are
+		// not double-counted on re-apply. Set via Node.SetReplaying; read via Node.Replaying.
+		replaying bool
+
 		// Following fields are changes accumulated in this transaction,
 		// and will get cleaned up after CloseTransaction().
 
@@ -2891,6 +2897,21 @@ func (n *Node) root() *Node {
 		return n
 	}
 	return n.parent.root()
+}
+
+// Replaying reports whether the tree is currently re-applying transitions from history
+// (cherry-pick during workflow reset / conflict resolution) rather than executing them live. While
+// true, Context.MetricsHandler() returns a no-op handler so that side-effect metrics emitted inside
+// a transition are not double-counted on re-apply.
+func (n *Node) Replaying() bool {
+	return n.root().replaying
+}
+
+// SetReplaying toggles replay mode for the whole tree. The reset/conflict-resolution re-apply path
+// should set it true around the cherry-pick and restore it to false afterwards. This applies
+// framework-wide to any component's transitions, not just a specific event type.
+func (n *Node) SetReplaying(replaying bool) {
+	n.root().replaying = replaying
 }
 
 // isComponentTaskExpired returns true when the task's scheduled time is equal

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -24,6 +24,7 @@ import (
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/testing/protoassert"
 	"go.temporal.io/server/common/testing/protorequire"
@@ -87,6 +88,25 @@ func (s *nodeSuite) initAssertions() {
 
 	s.Assertions = require.New(s.T())
 	s.ProtoAssertions = protorequire.New(s.T())
+}
+
+func (s *nodeSuite) TestContextMetricsHandler_SuppressedWhenReplaying() {
+	base := s.nodeBase()
+	liveHandler := metricstest.NewCaptureHandler()
+	base.metricsHandler = liveHandler
+	root := newNode(base, nil, "")
+
+	// The same context reflects the tree's replay state, no special constructor needed.
+	ctx := NewMutableContext(context.Background(), root)
+	s.Equal(metrics.Handler(liveHandler), ctx.MetricsHandler())
+
+	root.SetReplaying(true)
+	s.True(root.Replaying())
+	s.Equal(metrics.NoopMetricsHandler, ctx.MetricsHandler(), "metrics suppressed while replaying")
+
+	root.SetReplaying(false)
+	s.False(root.Replaying())
+	s.Equal(metrics.Handler(liveHandler), ctx.MetricsHandler(), "metrics restored after replay")
 }
 
 func (s *nodeSuite) TestNewTree() {


### PR DESCRIPTION
## What changed?
**Alternative to #10845** (per review feedback: "have a method on the node to express Replaying"). Same goal — suppress CHASM caller-side metric emission during cherry-pick re-apply — but the `replaying` state lives on the **node/tree** instead of on a per-context flag.

- `nodeBase.replaying bool` + `Node.SetReplaying(bool)` / `Node.Replaying() bool`.
- `Context.MetricsHandler()` returns `metrics.NoopMetricsHandler` while the tree is in replay mode.

## Why this shape
Because every context reads its handler from the root node, the reset/conflict-resolution re-apply path just flips the tree into replay mode around the cherry-pick — no special context constructor, no flag propagation through context derivation (`withValue`), and no way to accidentally create a live context during re-apply. "Replaying" is genuinely tree-wide state (the whole execution is being rebuilt), and the metrics handler already lives on the node, so this keeps it in one place.

Trade-off vs #10845: this introduces transient mutable state on the tree that must be paired (set true → restore false), whereas the context-flag version is immutable/explicit. CHASM execution is single-threaded under the workflow lock, so the mutation is safe; a scoped helper can be added if preferred.

## Scope / not-yet-wired
Guardrail only — the CHASM cherry-pick dispatch isn't wired yet, so there's no production caller today. When it lands, it wraps the cherry-pick in `node.SetReplaying(true)` (restored after), and a functional reset/double-count test should land with that wiring.

## How did you test it?
- [x] built
- [x] added new unit test(s)

`chasm`: `SetReplaying(true)` makes the same context's `MetricsHandler()` a no-op; restored after `SetReplaying(false)`.
`chasm/lib/nexusoperation`: a real `TransitionSucceeded.Apply` with the tree in replay mode emits nothing; live mode emits `nexus_operation_success` (exercises the real `emitOnSucceededMetrics` path; existing transition tests use a mock context that bypasses the guard).
