### PR TITLE
[DO NOT MERGE] debug: log AddTasks callers for replication phase-shift investigation

### DIFF
--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"math"
 	"net"
+	rtdebug "runtime/debug"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -73,6 +74,7 @@ import (
 	"go.temporal.io/server/service/worker/scheduler"
 	"google.golang.org/grpc/health"
 	grpchealthspb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -2316,6 +2318,32 @@ func (adh *AdminHandler) AddTasks(
 		ShardId: request.ShardId,
 		Tasks:   historyTasks,
 	}
+
+	// ADDTASKS_DEBUG (temporary, malik): identify who calls the AddTasks admin RPC on the
+	// source cell during replication start/stop. The stack here is only gRPC plumbing because
+	// the caller is remote, so the real signal is the caller info + peer + task categories.
+	{
+		categoryIDs := make([]int32, len(request.Tasks))
+		for i, t := range request.Tasks {
+			categoryIDs[i] = t.CategoryId
+		}
+		callerInfo := headers.GetCallerInfo(ctx)
+		peerAddr := "unknown"
+		if p, ok := peer.FromContext(ctx); ok && p.Addr != nil {
+			peerAddr = p.Addr.String()
+		}
+		adh.logger.Info("ADDTASKS_DEBUG admin AddTasks received",
+			tag.NewInt32("shard-id", request.ShardId),
+			tag.NewInt("task-count", len(request.Tasks)),
+			tag.NewStringTag("category-ids", fmt.Sprintf("%v", categoryIDs)),
+			tag.NewStringTag("caller-name", callerInfo.CallerName),
+			tag.NewStringTag("caller-type", callerInfo.CallerType),
+			tag.NewStringTag("caller-origin", callerInfo.CallOrigin),
+			tag.NewStringTag("peer-addr", peerAddr),
+			tag.SysStackTrace(string(rtdebug.Stack())),
+		)
+	}
+
 	_, err := adh.historyClient.AddTasks(ctx, historyServiceRequest)
 	if err != nil {
 		return nil, err

--- a/service/history/api/addtasks/api.go
+++ b/service/history/api/addtasks/api.go
@@ -2,11 +2,14 @@ package addtasks
 
 import (
 	"context"
+	"fmt"
+	rtdebug "runtime/debug"
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/service/history/api"
 	historyi "go.temporal.io/server/service/history/interfaces"
@@ -56,6 +59,21 @@ func Invoke(
 
 	if len(req.Tasks) == 0 {
 		return nil, serviceerror.NewInvalidArgument("No tasks in request")
+	}
+
+	// ADDTASKS_DEBUG (temporary, malik): confirms the admin->history hop and the categories
+	// landing on this shard. Stack is plumbing only (remote caller); category is the fingerprint.
+	{
+		categoryIDs := make([]int32, len(req.Tasks))
+		for i, t := range req.Tasks {
+			categoryIDs[i] = t.CategoryId
+		}
+		shardContext.GetLogger().Info("ADDTASKS_DEBUG history AddTasks invoke",
+			tag.NewInt32("shard-id", req.ShardId),
+			tag.NewInt("task-count", len(req.Tasks)),
+			tag.NewStringTag("category-ids", fmt.Sprintf("%v", categoryIDs)),
+			tag.SysStackTrace(string(rtdebug.Stack())),
+		)
 	}
 
 	taskGroups := make(map[taskGroupKey]map[tasks.Category][]tasks.Task)

--- a/service/history/api/replication/generate_task.go
+++ b/service/history/api/replication/generate_task.go
@@ -2,11 +2,13 @@ package replication
 
 import (
 	"context"
+	rtdebug "runtime/debug"
 
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/locks"
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/service/history/api"
@@ -52,6 +54,16 @@ func GenerateTask(
 	if err != nil {
 		return nil, err
 	}
+
+	// ADDTASKS_DEBUG (temporary, malik): rule-out marker. This is the in-process migration/force-
+	// replication task generator writing replication tasks to the source shard. If the source-side
+	// task-write delta is driven by generation rather than the backfill RPC, this fires.
+	shardContext.GetLogger().Info("ADDTASKS_DEBUG generate migration tasks -> AddTasks",
+		tag.NewInt32("shard-id", shardContext.GetShardID()),
+		tag.NewStringTag("workflow-id", request.Execution.WorkflowId),
+		tag.NewInt("repl-task-count", len(replicationTasks)),
+		tag.SysStackTrace(string(rtdebug.Stack())),
+	)
 
 	err = shardContext.AddTasks(ctx, &persistence.AddHistoryTasksRequest{
 		ShardID: shardContext.GetShardID(),

--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	rtdebug "runtime/debug"
 	"sync/atomic"
 	"time"
 
@@ -786,6 +787,16 @@ func (e *ExecutableTaskImpl) SyncState(
 				Blob:       blob,
 			})
 		}
+
+		// ADDTASKS_DEBUG (temporary, malik): this is the leading hypothesis for the source-side
+		// AddTasks calls. The passive re-adds task equivalents back to the SOURCE cluster when
+		// sync-state cannot apply (FailedPrecondition). This stack is the real caller chain.
+		logger.Info("ADDTASKS_DEBUG replication backfill -> source AddTasks",
+			tag.NewStringTag("source-cluster", e.sourceClusterName),
+			tag.NewInt32("source-shard-id", e.sourceShardKey.ShardID),
+			tag.NewInt("task-equivalent-count", len(tasksToAdd)),
+			tag.SysStackTrace(string(rtdebug.Stack())),
+		)
 
 		_, err := remoteAdminClient.AddTasks(ctx, &adminservice.AddTasksRequest{
 			ShardId: e.sourceShardKey.ShardID,

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	rtdebug "runtime/debug"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -481,6 +482,20 @@ func (s *ContextImpl) AddTasks(
 	ctx context.Context,
 	request *persistence.AddHistoryTasksRequest,
 ) error {
+	// ADDTASKS_DEBUG (temporary, malik): catch-all for the source-side task-write delta during
+	// replication start/stop. Gated to replication-category writes only (the delta we care about)
+	// so this hot path is not flooded. This stack DOES show the real in-process caller, unlike the
+	// RPC handlers. Catches paths that drive task writes WITHOUT going through the AddTasks RPC.
+	if replTasks, ok := request.Tasks[tasks.CategoryReplication]; ok && len(replTasks) > 0 {
+		s.GetLogger().Info("ADDTASKS_DEBUG shard AddTasks (replication category)",
+			tag.NewInt32("shard-id", request.ShardID),
+			tag.NewStringTag("namespace-id", request.NamespaceID),
+			tag.NewStringTag("workflow-id", request.WorkflowID),
+			tag.NewInt("repl-task-count", len(replTasks)),
+			tag.SysStackTrace(string(rtdebug.Stack())),
+		)
+	}
+
 	engine, err := s.GetEngine(ctx)
 	if err != nil {
 		return err

--- a/service/worker/dlq/workflow.go
+++ b/service/worker/dlq/workflow.go
@@ -398,6 +398,13 @@ func (c *workerComponent) reEnqueueTasks(
 	}
 
 	for shardID, batch := range tasksByShard {
+		// ADDTASKS_DEBUG (temporary, malik): rule-out marker. If the source-side AddTasks calls
+		// are coming from DLQ re-enqueue rather than the replication backfill, this fires.
+		activity.GetLogger(ctx).Info("ADDTASKS_DEBUG dlq reEnqueue -> AddTasks",
+			"source-cluster", params.SourceCluster,
+			"shard-id", shardID,
+			"task-count", len(batch),
+		)
 		_, err := taskClient.AddTasks(ctx, &adminservice.AddTasksRequest{
 			ShardId: shardID,
 			Tasks:   batch,


### PR DESCRIPTION
**Temporary debug build. Do not merge.**

For investigating the source cell phase shift seen when shadow replication is stopped and started, specifically the `AddTasks` calls landing on the source cell that CGS could not account for.

Based on `v1.32.0-157.2`, the OSS server bundled in the cell's `v3.157.4_oss1.32.0_157.2` build, so the diff is only the added log lines. Every line is prefixed `ADDTASKS_DEBUG` for grepping.

### Deploy to both cells

The caller and the receiver of the `AddTasks` RPC run on different cells, so this build has to go on **both** the source and the passive to capture both sides and line them up by timestamp.

- Source cell alone gives you who got called and with what task category, but not the caller stack.
- Passive cell alone gives you the caller stack, but not the inbound request metadata.

### What it logs

**Receiver side** (the cell that serves the `AddTasks` RPC, which is the source):

| Site | What it logs |
|---|---|
| `admin_handler.AddTasks` (admin RPC entry) | caller info, gRPC peer, task categories, count, shard |
| `addtasks.Invoke` (history handler) | categories and shard, confirms the admin to history hop |
| `shard.ContextImpl.AddTasks` (the write sink) | stack of the in-process writer, gated to replication-category writes so this hot path is not flooded. Catches writers that never go through the `AddTasks` RPC |

**Caller side** (the cell that initiates the `AddTasks` RPC, which is the passive):

| Site | What it logs |
|---|---|
| `replication.executable_task` | the leading hypothesis. The passive adds task equivalents back to the source when sync-state cannot apply. This stack is the real caller chain |

**Rule-out markers** (fire only if a different path turns out to be the driver):

| Site | Fires if |
|---|---|
| `dlq.reEnqueueTasks` | DLQ re-enqueue is the source of the `AddTasks` calls |
| `replication.GenerateTask` | in-process migration or force-replication generation is the driver |

### Note on the stack traces

A stack trace at the receiver-side `AddTasks` handler only shows gRPC plumbing, because the caller is in a different process. The identifying signal on the receiver side is the task category plus the caller info. The real caller stack comes from the passive-side `executable_task` log.
