### PR TITLE
Use buffered channel in task writers

### DIFF
--- a/service/matching/fair_task_writer.go
+++ b/service/matching/fair_task_writer.go
@@ -71,7 +71,7 @@ func (w *fairTaskWriter) appendTask(
 	}
 
 	startTime := time.Now().UTC()
-	ch := make(chan error)
+	ch := make(chan error, 1)
 	req := &writeTaskRequest{
 		taskInfo:   taskInfo,
 		responseCh: ch,

--- a/service/matching/pri_task_writer.go
+++ b/service/matching/pri_task_writer.go
@@ -77,7 +77,7 @@ func (w *priTaskWriter) appendTask(
 	}
 
 	startTime := time.Now().UTC()
-	ch := make(chan error)
+	ch := make(chan error, 1)
 	req := &writeTaskRequest{
 		taskInfo:   taskInfo,
 		responseCh: ch,

--- a/service/matching/task_writer.go
+++ b/service/matching/task_writer.go
@@ -94,7 +94,7 @@ func (w *taskWriter) appendTask(
 	}
 
 	startTime := time.Now().UTC()
-	ch := make(chan error)
+	ch := make(chan error, 1)
 	req := &writeTaskRequest{
 		taskInfo:   taskInfo,
 		responseCh: ch,


### PR DESCRIPTION
## What changed?
Use a channel with a buffer of 1 in all matching task writer implementations.

## Why?
With an unbuffered channel, if the channel waiter aborts due to task queue shutdown, the writer goroutine would end up blocked forever on the channel write. This is a harmless goroutine leak but it is a leak so we should clean it up.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
