### PR TITLE
Assign generated files to default code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -93,3 +93,10 @@
 /service/worker/parentclosepolicy/ @temporalio/oss-foundations @temporalio/act
 
 /tools/ @temporalio/server
+
+# Generated code
+*.pb.go        @temporalio/server @temporalio/cgs @temporalio/nexus
+*.pb.mock.go   @temporalio/server @temporalio/cgs @temporalio/nexus
+*_mock.go      @temporalio/server @temporalio/cgs @temporalio/nexus
+*_gen.go       @temporalio/server @temporalio/cgs @temporalio/nexus
+*.gen.go       @temporalio/server @temporalio/cgs @temporalio/nexus


### PR DESCRIPTION
## What changed?

Added trailing CODEOWNERS patterns so generated files (`*.pb.go`, `*.pb.mock.go`, `*_mock.go`, `*_gen.go`, `*.gen.go`) are owned by the default reviewers (`@temporalio/server @temporalio/cgs @temporalio/nexus`) rather than the per-area teams. Being last, they take precedence over the area rules; `.proto` source files are unaffected.

## Why?

Regenerating generated code (e.g. a client signature change forcing a proto regen) currently pulls in team-specific approvals just for the generated output. Those files shouldn't need a per-area sign-off.

## Potential risks

Reassigns ownership of generated files across several teams (matching, foundations, act, ...) to the default set — heads-up to those teams.