### PR TITLE
Fix evicted ack cache handling

### DIFF
--- a/service/matching/fair_task_reader.go
+++ b/service/matching/fair_task_reader.go
@@ -430,10 +430,10 @@ func (tr *fairTaskReader) mergeTasksLocked(tasks []*persistencespb.AllocatedTask
 			// If write/read race or we have to re-read a range, we may read something we had
 			// already added to the matcher or acked. Ignore tasks we already have.
 			continue
-		} else if _, have := tr.evictedAcks.Delete(level); have {
-			// This task was already acked but the ack was evicted. Skip it.
-			continue
 		}
+		// Note: tasks whose acks were evicted (present in evictedAcks) flow through here as
+		// regular tasks and are turned back into acks in the final loop below, the same way
+		// expired tasks are handled.
 		merged.Put(level, t)
 	}
 
@@ -495,17 +495,26 @@ func (tr *fairTaskReader) mergeTasksLocked(tasks []*persistencespb.AllocatedTask
 		tr.evictedAcks.PopMax()
 	}
 
-	var hasExpired bool
 	internalTasks := make([]*internalTask, 0, len(tasks))
 	for _, t := range tasks {
 		level := fairLevelFromAllocatedTask(t)
+		if _, have := tr.evictedAcks.Delete(level); have {
+			// This task was already acked, but its ack was evicted from memory before it could
+			// advance the ack level, and now we've re-read it. Add it back as a pre-acked (nil)
+			// entry (like an expired task) so it advances the ack level, instead of re-delivering
+			// it to the matcher. We remove it from the cache since it's tracked in
+			// outstandingTasks again; if it later gets evicted above the read level, it'll be
+			// re-cached then. Note its level is <= readLevel here (it made the in-memory cut), so
+			// the eviction above won't have touched it.
+			tr.outstandingTasks.Put(level, nil)
+			continue
+		}
 		if IsTaskExpired(t) {
 			// Expired tasks are added as pre-acked (nil) so they participate in
 			// readLevel calculation above and advance ackLevel + get GC'd below.
 			tr.outstandingTasks.Put(level, nil)
 			metrics.ExpiredTasksPerTaskQueueCounter.With(tr.backlogMgr.metricsHandler).Record(1, metrics.TaskExpireStageReadTag)
 			recordDroppedTask(tr.backlogMgr.metricsHandler, dropReasonExpiredRead)
-			hasExpired = true
 			continue
 		}
 		task := newInternalTaskFromBacklog(t, tr.completeTask)
@@ -518,10 +527,9 @@ func (tr *fairTaskReader) mergeTasksLocked(tasks []*persistencespb.AllocatedTask
 		internalTasks = append(internalTasks, task)
 	}
 
-	if hasExpired {
-		// Advance ack level past any expired tasks we just added as pre-acked.
-		tr.advanceAckLevelLocked()
-	}
+	// Advance the ack level past any pre-acked (nil) entries we just added: expired tasks and
+	// acks we re-inserted from the evicted-ack cache. Harmless if we added none.
+	tr.advanceAckLevelLocked()
 
 	// Update atEnd:
 	// If we did a read and didn't get to the end, we can't possibly be at the end.


### PR DESCRIPTION
## What changed?
Treat tasks that match evicted acks as similar to expired tasks, instead of dropping them completely.

## Why?
This lets the ack level move past them properly.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
