### PR TITLE
Clone callback fields for API response

### DIFF
--- a/chasm/lib/callback/component.go
+++ b/chasm/lib/callback/component.go
@@ -2,6 +2,8 @@ package callback
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -146,7 +148,7 @@ func (c *Callback) ToAPICallback() (*commonpb.Callback, error) {
 	// Convert CHASM callback proto to API callback proto
 	chasmCB := c.GetCallback()
 	res := &commonpb.Callback{
-		Links: chasmCB.GetLinks(),
+		Links: slices.Clone(chasmCB.GetLinks()),
 	}
 
 	// CHASM currently only supports Nexus callbacks
@@ -154,7 +156,7 @@ func (c *Callback) ToAPICallback() (*commonpb.Callback, error) {
 		res.Variant = &commonpb.Callback_Nexus_{
 			Nexus: &commonpb.Callback_Nexus{
 				Url:    variant.Nexus.GetUrl(),
-				Header: variant.Nexus.GetHeader(),
+				Header: maps.Clone(variant.Nexus.GetHeader()),
 			},
 		}
 		return res, nil


### PR DESCRIPTION
## What changed?

Clone shared references before handing them off to gRPC.

## Why?

The response can outlive the method’s read of CHASM state while still pointing at the same underlying data since gRPC serialization happens outside of the lock. When it iterates over the collections _and_ another task mutates or replaces the related state concurrently, there's a data race. For maps it can crash with `concurrent map iteration and map write`.

PS: found via [experimental ownership linter](https://github.com/temporalio/temporal/pull/10734)