### PR TITLE
Clone scheduler future action times

### DIFF
--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -677,7 +677,7 @@ func (s *Scheduler) Describe(
 	info := common.CloneProto(s.Info)
 	info.RunningWorkflows = invoker.runningWorkflowExecutions()
 	info.RecentActions = invoker.recentActions()
-	info.FutureActionTimes = generator.GetFutureActionTimes()
+	info.FutureActionTimes = slices.Clone(generator.GetFutureActionTimes())
 	// BufferedStarts holds waiting, running, and recently-completed entries; only the
 	// waiting portion (those not yet surfaced via RecentActions) counts as buffered.
 	info.BufferSize = int64(len(invoker.GetBufferedStarts()) - len(info.RecentActions))
@@ -1007,7 +1007,7 @@ func (s *Scheduler) ListInfo(
 		Notes:             s.Schedule.State.Notes,
 		Paused:            s.Schedule.State.Paused,
 		RecentActions:     invoker.recentActions(),
-		FutureActionTimes: generator.FutureActionTimes,
+		FutureActionTimes: slices.Clone(generator.FutureActionTimes),
 	}
 }
 


### PR DESCRIPTION
## What changed?

Clone shared references before handing them off to gRPC.

## Why?

The response can outlive the method’s read of CHASM state while still pointing at the same underlying data since gRPC serialization happens outside of the lock. It iterates over the collections and if another task mutates or replaces the related state concurrently, map iteration can crash with `concurrent map iteration and map write`.

PS: found via [experimental ownership linter](https://github.com/temporalio/temporal/pull/10734)