### PR TITLE
Return early from long poll when shard moves off host

### DIFF
--- a/service/history/api/get_workflow_util.go
+++ b/service/history/api/get_workflow_util.go
@@ -247,6 +247,8 @@ func GetOrPollWorkflowMutableState(
 				}
 			case <-longPollCtx.Done():
 				return response, nil
+			case <-shardContext.GetLifecycleContext().Done():
+				return response, nil
 			case <-ctx.Done():
 				// Fallback for when ctx.Deadline() returns false but ctx is still cancelled.
 				// This can happen when gRPC timeout header isn't propagated (e.g., stripped

--- a/service/history/history_engine_test.go
+++ b/service/history/history_engine_test.go
@@ -380,6 +380,50 @@ func (s *engineSuite) TestGetMutableStateLongPoll() {
 	waitGroup.Wait()
 }
 
+func (s *engineSuite) TestGetMutableStateLongPoll_ShardClosed() {
+	ctx := context.Background()
+
+	execution := commonpb.WorkflowExecution{
+		WorkflowId: "test-get-workflow-execution-shard-closed",
+		RunId:      tests.RunID,
+	}
+	taskqueue := "testTaskQueue"
+	identity := "testIdentity"
+
+	ms := workflow.TestLocalMutableState(s.historyEngine.shardContext, s.eventsCache, tests.LocalNamespaceEntry,
+		execution.GetWorkflowId(), execution.GetRunId(), log.NewTestLogger())
+	addWorkflowExecutionStartedEvent(ms, &execution, "wType", taskqueue, payloads.EncodeString("input"), 100*time.Second, 50*time.Second, 200*time.Second, identity)
+	wt := addWorkflowTaskScheduledEvent(ms)
+	addWorkflowTaskStartedEvent(ms, wt.ScheduledEventID, taskqueue, identity)
+	wfMs := workflow.TestCloneToProto(context.Background(), ms)
+	gweResponse := &persistence.GetWorkflowExecutionResponse{State: wfMs}
+	// right now the next event ID is 4
+	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(gweResponse, nil).AnyTimes()
+
+	// Prime the workflow cache so the later poll reads from cache, not persistence.
+	_, err := s.historyEngine.GetMutableState(ctx, &historyservice.GetMutableStateRequest{
+		NamespaceId:         tests.NamespaceID.String(),
+		Execution:           &execution,
+		ExpectedNextEventId: 3,
+	})
+	s.NoError(err)
+
+	// Shard moves off this host. A poll blocked for new events must return promptly
+	// with the unchanged next event ID instead of waiting out the long-poll timeout.
+	s.mockShard.UnloadForOwnershipLost()
+
+	start := time.Now().UTC()
+	pollResponse, err := s.historyEngine.PollMutableState(ctx, &historyservice.PollMutableStateRequest{
+		NamespaceId:         tests.NamespaceID.String(),
+		Execution:           &execution,
+		ExpectedNextEventId: 4,
+	})
+	elapsed := time.Since(start)
+	s.NoError(err)
+	s.Equal(int64(4), pollResponse.GetNextEventId())
+	s.Less(elapsed, 10*time.Second, "poll should return on shard close, not wait out the long-poll timeout")
+}
+
 func (s *engineSuite) TestGetMutableStateLongPoll_CurrentBranchChanged() {
 	ctx := context.Background()
 

--- a/service/history/interfaces/shard_context.go
+++ b/service/history/interfaces/shard_context.go
@@ -58,6 +58,8 @@ type (
 
 		GetEngine(ctx context.Context) (Engine, error)
 
+		GetLifecycleContext() context.Context
+
 		AssertOwnership(ctx context.Context) error
 		NewVectorClock() (*clockspb.VectorClock, error)
 		CurrentVectorClock() *clockspb.VectorClock

--- a/service/history/interfaces/shard_context_mock.go
+++ b/service/history/interfaces/shard_context_mock.go
@@ -440,6 +440,20 @@ func (mr *MockShardContextMockRecorder) GetHistoryTasks(ctx, request any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryTasks", reflect.TypeOf((*MockShardContext)(nil).GetHistoryTasks), ctx, request)
 }
 
+// GetLifecycleContext mocks base method.
+func (m *MockShardContext) GetLifecycleContext() context.Context {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLifecycleContext")
+	ret0, _ := ret[0].(context.Context)
+	return ret0
+}
+
+// GetLifecycleContext indicates an expected call of GetLifecycleContext.
+func (mr *MockShardContextMockRecorder) GetLifecycleContext() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLifecycleContext", reflect.TypeOf((*MockShardContext)(nil).GetLifecycleContext))
+}
+
 // GetLogger mocks base method.
 func (m *MockShardContext) GetLogger() log.Logger {
 	m.ctrl.T.Helper()
@@ -1255,6 +1269,20 @@ func (m *MockControllableContext) GetHistoryTasks(ctx context.Context, request *
 func (mr *MockControllableContextMockRecorder) GetHistoryTasks(ctx, request any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryTasks", reflect.TypeOf((*MockControllableContext)(nil).GetHistoryTasks), ctx, request)
+}
+
+// GetLifecycleContext mocks base method.
+func (m *MockControllableContext) GetLifecycleContext() context.Context {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLifecycleContext")
+	ret0, _ := ret[0].(context.Context)
+	return ret0
+}
+
+// GetLifecycleContext indicates an expected call of GetLifecycleContext.
+func (mr *MockControllableContextMockRecorder) GetLifecycleContext() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLifecycleContext", reflect.TypeOf((*MockControllableContext)(nil).GetLifecycleContext))
 }
 
 // GetLogger mocks base method.

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -1490,6 +1490,10 @@ func (s *ContextImpl) IsValid() bool {
 	return s.state < contextStateStopping
 }
 
+func (s *ContextImpl) GetLifecycleContext() context.Context {
+	return s.lifecycleCtx
+}
+
 func (s *ContextImpl) stoppedForOwnershipLost() bool {
 	s.stateLock.Lock()
 	defer s.stateLock.Unlock()


### PR DESCRIPTION
## What changed?
A blocked `GetMutableState` / `GetWorkflowExecutionHistory` long poll now returns as soon as its shard moves off this host, by adding a `select` case on the shard's lifecycle context (exposed via a new `GetLifecycleContext()` accessor). Previously nothing in the poll loop was tied to shard lifecycle, so the poll waited out the full long-poll timeout.

## Why?
Lets the client re-poll the new shard owner immediately rather than stalling for up to the full long-poll interval whenever a shard moves (e.g. during rebalances and deploys). The returned page carries the unchanged continuation token, so no events are missed or duplicated.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

