### PR TITLE
Add matching test client

### DIFF
--- a/common/membership/static/fx.go
+++ b/common/membership/static/fx.go
@@ -13,7 +13,7 @@ func MembershipModule(
 ) fx.Option {
 	return fx.Options(
 		fx.Provide(func() membership.Monitor {
-			return newStaticMonitor(hostsByService)
+			return NewMonitor(hostsByService)
 		}),
 		fx.Provide(func(serviceName primitives.ServiceName) membership.HostInfoProvider {
 			hosts := hostsByService[serviceName]

--- a/common/membership/static/monitor.go
+++ b/common/membership/static/monitor.go
@@ -26,7 +26,7 @@ func SingleLocalHost(host string) Hosts {
 	return Hosts{All: []string{host}, Self: host}
 }
 
-func newStaticMonitor(hosts map[primitives.ServiceName]Hosts) membership.Monitor {
+func NewMonitor(hosts map[primitives.ServiceName]Hosts) membership.Monitor {
 	resolvers := make(map[primitives.ServiceName]*staticResolver, len(hosts))
 	for service, hostList := range hosts {
 		resolvers[service] = newStaticResolver(hostList.All)

--- a/common/membership/static/monitor.go
+++ b/common/membership/static/monitor.go
@@ -26,6 +26,7 @@ func SingleLocalHost(host string) Hosts {
 	return Hosts{All: []string{host}, Self: host}
 }
 
+// NewMonitor creates a new Monitor with the given host mappings.
 func NewMonitor(hosts map[primitives.ServiceName]Hosts) membership.Monitor {
 	resolvers := make(map[primitives.ServiceName]*staticResolver, len(hosts))
 	for service, hostList := range hosts {

--- a/tests/testcore/clients.go
+++ b/tests/testcore/clients.go
@@ -25,6 +25,7 @@ type clients struct {
 	logger            log.Logger
 	hostsByService    map[primitives.ServiceName]static.Hosts
 	tlsConfigProvider *encryption.FixedTLSConfigProvider
+	newMatchingClient func() (matchingservice.MatchingServiceClient, error)
 
 	frontend frontendClients
 	history  historyClients
@@ -47,6 +48,7 @@ type historyClients struct {
 }
 
 type matchingClient struct {
+	once   sync.Once
 	client matchingservice.MatchingServiceClient
 }
 
@@ -54,11 +56,13 @@ func newClients(
 	logger log.Logger,
 	hostsByService map[primitives.ServiceName]static.Hosts,
 	tlsConfigProvider *encryption.FixedTLSConfigProvider,
+	newMatchingClient func() (matchingservice.MatchingServiceClient, error),
 ) clients {
 	return clients{
 		logger:            logger,
 		hostsByService:    hostsByService,
 		tlsConfigProvider: tlsConfigProvider,
+		newMatchingClient: newMatchingClient,
 	}
 }
 
@@ -113,6 +117,13 @@ func (c *clients) ensureHistory() {
 }
 
 func (c *clients) MatchingClient() matchingservice.MatchingServiceClient {
+	c.matching.once.Do(func() {
+		client, err := c.newMatchingClient()
+		if err != nil {
+			c.logger.Fatal("unable to create matching test client", tag.Error(err))
+		}
+		c.matching.client = client
+	})
 	return c.matching.client
 }
 

--- a/tests/testcore/clients.go
+++ b/tests/testcore/clients.go
@@ -25,6 +25,8 @@ type clients struct {
 	logger            log.Logger
 	hostsByService    map[primitives.ServiceName]static.Hosts
 	tlsConfigProvider *encryption.FixedTLSConfigProvider
+	// The matching client is built lazily because routing depends on the
+	// frontend membership address populated during startup.
 	newMatchingClient func() (matchingservice.MatchingServiceClient, error)
 
 	frontend frontendClients
@@ -117,6 +119,11 @@ func (c *clients) ensureHistory() {
 }
 
 func (c *clients) MatchingClient() matchingservice.MatchingServiceClient {
+	c.ensureMatching()
+	return c.matching.client
+}
+
+func (c *clients) ensureMatching() {
 	c.matching.once.Do(func() {
 		client, err := c.newMatchingClient()
 		if err != nil {
@@ -124,7 +131,6 @@ func (c *clients) MatchingClient() matchingservice.MatchingServiceClient {
 		}
 		c.matching.client = client
 	})
-	return c.matching.client
 }
 
 func (c *clients) close() []error {

--- a/tests/testcore/onebox.go
+++ b/tests/testcore/onebox.go
@@ -16,10 +16,12 @@ import (
 	"time"
 
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/chasm"
 	chasmnexus "go.temporal.io/server/chasm/lib/nexusoperation"
 	"go.temporal.io/server/client"
+	matchingclient "go.temporal.io/server/client/matching"
 	"go.temporal.io/server/common"
 	carchiver "go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/archiver/provider"
@@ -326,12 +328,11 @@ func (c *TemporalImpl) copyPersistenceConfig() config.Persistence {
 func (c *TemporalImpl) startFrontend() {
 	serviceName := primitives.FrontendService
 
-	var matchingRawClient resource.MatchingRawClient
-	var grpcResolver *membership.GRPCResolver
+	clientMembershipMonitor := static.NewMonitor(c.hostsByProtocolByService[grpcProtocol])
+	clientMembershipMonitor.Start()
 
 	for _, host := range c.hostsByProtocolByService[grpcProtocol][serviceName].All {
 		logger := log.With(c.logger, tag.Host(host))
-		var namespaceRegistry namespace.Registry
 		app := fx.New(
 			fx.Supply(
 				c.copyPersistenceConfig(),
@@ -388,7 +389,6 @@ func (c *TemporalImpl) startFrontend() {
 			temporal.TraceExportModule,
 			temporal.ServiceTracingModule,
 			frontend.Module,
-			fx.Populate(&namespaceRegistry, &grpcResolver, &matchingRawClient),
 			temporal.FxLogAdapter,
 			c.getFxOptionsForService(primitives.FrontendService),
 			chasm.Module,
@@ -399,8 +399,11 @@ func (c *TemporalImpl) startFrontend() {
 		}
 
 		c.fxApps = append(c.fxApps, app)
-		// TODO: create matching client without reaching into fx graph
-		c.matching.client = matchingRawClient
+		matchingClient, err := c.newMatchingClient(clientMembershipMonitor, logger)
+		if err != nil {
+			logger.Fatal("unable to create matching test client", tag.Error(err))
+		}
+		c.matching.client = matchingClient
 
 		if err := app.Start(context.Background()); err != nil {
 			logger.Fatal("unable to start frontend service", tag.Error(err))
@@ -408,7 +411,73 @@ func (c *TemporalImpl) startFrontend() {
 	}
 
 	// Address for SDKs
-	c.frontendMembershipAddress = grpcResolver.MakeURL(serviceName)
+	c.frontendMembershipAddress = membership.GRPCResolverURLForTesting(clientMembershipMonitor, serviceName)
+}
+
+func (c *TemporalImpl) newMatchingClient(
+	membershipMonitor membership.Monitor,
+	logger log.Logger,
+) (resource.MatchingRawClient, error) {
+	rpcFactory, err := c.newClientRPCFactory(membershipMonitor, logger)
+	if err != nil {
+		return nil, err
+	}
+	clientFactory := c.newClientFactoryProvider(c.clusterMetadataConfig, c.mockAdminClient).NewFactory(
+		rpcFactory,
+		membershipMonitor,
+		c.GetMetricsHandler(),
+		dynamicconfig.NewCollection(c.dcClient, c.logger),
+		c.testHooks,
+		c.historyConfig.NumHistoryShards,
+		logger,
+		logger,
+	)
+	return clientFactory.NewMatchingClientWithTimeout(
+		c.namespaceIDToName,
+		matchingclient.DefaultTimeout,
+		matchingclient.DefaultLongPollTimeout,
+	)
+}
+
+func (c *TemporalImpl) newClientRPCFactory(
+	membershipMonitor membership.Monitor,
+	logger log.Logger,
+) (common.RPCFactory, error) {
+	var frontendTLSConfig *tls.Config
+	var err error
+	if c.tlsConfigProvider != nil {
+		frontendTLSConfig, err = c.tlsConfigProvider.GetFrontendClientConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed getting client TLS config: %w", err)
+		}
+	}
+
+	frontendURL := membership.GRPCResolverURLForTesting(membershipMonitor, primitives.FrontendService)
+	return rpc.NewFactory(
+		&config.Config{},
+		primitives.FrontendService,
+		logger,
+		c.GetMetricsHandler(),
+		c.tlsConfigProvider,
+		frontendURL,
+		frontendURL,
+		int(mustPortFromAddress(c.FrontendHTTPAddress())),
+		frontendTLSConfig,
+		nil,
+		resource.PerServiceDialOptionsProvider(logger),
+		membershipMonitor,
+		c.tokenProvider,
+	), nil
+}
+
+func (c *TemporalImpl) namespaceIDToName(id namespace.ID) (namespace.Name, error) {
+	resp, err := c.FrontendClient().DescribeNamespace(NewContext(), &workflowservice.DescribeNamespaceRequest{
+		Id: id.String(),
+	})
+	if err != nil {
+		return "", err
+	}
+	return namespace.Name(resp.GetNamespaceInfo().GetName()), nil
 }
 
 func (c *TemporalImpl) startHistory() {

--- a/tests/testcore/onebox.go
+++ b/tests/testcore/onebox.go
@@ -16,8 +16,8 @@ import (
 	"time"
 
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/chasm"
 	chasmnexus "go.temporal.io/server/chasm/lib/nexusoperation"
 	"go.temporal.io/server/client"
@@ -225,6 +225,7 @@ func newTemporal(t *testing.T, params *TemporalParams) *TemporalImpl {
 		impl.logger,
 		impl.hostsByProtocolByService[grpcProtocol],
 		impl.tlsConfigProvider,
+		impl.newMatchingClient,
 	)
 
 	// Global defaults: applied without cleanup so they persist across cluster reuse.
@@ -239,6 +240,59 @@ func newTemporal(t *testing.T, params *TemporalParams) *TemporalImpl {
 		impl.overrideDynamicConfigForTest(t, k, v)
 	}
 	return impl
+}
+
+func (c *TemporalImpl) newMatchingClient() (matchingservice.MatchingServiceClient, error) {
+	var tlsConfigProvider encryption.TLSConfigProvider
+	var frontendTLSConfig *tls.Config
+	if c.tlsConfigProvider != nil {
+		var err error
+		tlsConfigProvider = c.tlsConfigProvider
+		frontendTLSConfig, err = c.tlsConfigProvider.GetFrontendClientConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed getting client TLS config: %w", err)
+		}
+	}
+
+	monitor := static.NewMonitor(c.hostsByProtocolByService[grpcProtocol])
+	monitor.Start()
+	rpcFactory := rpc.NewFactory(
+		&config.Config{},
+		primitives.FrontendService,
+		c.logger,
+		c.GetMetricsHandler(),
+		tlsConfigProvider,
+		c.frontendMembershipAddress,
+		c.frontendMembershipAddress,
+		0,
+		frontendTLSConfig,
+		nil,
+		nil,
+		monitor,
+		c.tokenProvider,
+	)
+	clientFactory := client.NewFactoryProvider().NewFactory(
+		rpcFactory,
+		monitor,
+		c.GetMetricsHandler(),
+		dynamicconfig.NewCollection(c.dcClient, c.logger),
+		c.testHooks,
+		c.historyConfig.NumHistoryShards,
+		c.logger,
+		c.logger,
+	)
+	namespaceIDToName := func(id namespace.ID) (namespace.Name, error) {
+		resp, err := c.metadataMgr.GetNamespace(NewContext(), &persistence.GetNamespaceRequest{ID: id.String()})
+		if err != nil {
+			return "", err
+		}
+		return namespace.Name(resp.Namespace.Info.Name), nil
+	}
+	return clientFactory.NewMatchingClientWithTimeout(
+		namespaceIDToName,
+		matchingclient.DefaultTimeout,
+		matchingclient.DefaultLongPollTimeout,
+	)
 }
 
 func (c *TemporalImpl) Start() error {
@@ -328,8 +382,7 @@ func (c *TemporalImpl) copyPersistenceConfig() config.Persistence {
 func (c *TemporalImpl) startFrontend() {
 	serviceName := primitives.FrontendService
 
-	clientMembershipMonitor := static.NewMonitor(c.hostsByProtocolByService[grpcProtocol])
-	clientMembershipMonitor.Start()
+	var grpcResolver *membership.GRPCResolver
 
 	for _, host := range c.hostsByProtocolByService[grpcProtocol][serviceName].All {
 		logger := log.With(c.logger, tag.Host(host))
@@ -389,6 +442,7 @@ func (c *TemporalImpl) startFrontend() {
 			temporal.TraceExportModule,
 			temporal.ServiceTracingModule,
 			frontend.Module,
+			fx.Populate(&grpcResolver),
 			temporal.FxLogAdapter,
 			c.getFxOptionsForService(primitives.FrontendService),
 			chasm.Module,
@@ -399,11 +453,6 @@ func (c *TemporalImpl) startFrontend() {
 		}
 
 		c.fxApps = append(c.fxApps, app)
-		matchingClient, err := c.newMatchingClient(clientMembershipMonitor, logger)
-		if err != nil {
-			logger.Fatal("unable to create matching test client", tag.Error(err))
-		}
-		c.matching.client = matchingClient
 
 		if err := app.Start(context.Background()); err != nil {
 			logger.Fatal("unable to start frontend service", tag.Error(err))
@@ -411,73 +460,7 @@ func (c *TemporalImpl) startFrontend() {
 	}
 
 	// Address for SDKs
-	c.frontendMembershipAddress = membership.GRPCResolverURLForTesting(clientMembershipMonitor, serviceName)
-}
-
-func (c *TemporalImpl) newMatchingClient(
-	membershipMonitor membership.Monitor,
-	logger log.Logger,
-) (resource.MatchingRawClient, error) {
-	rpcFactory, err := c.newClientRPCFactory(membershipMonitor, logger)
-	if err != nil {
-		return nil, err
-	}
-	clientFactory := c.newClientFactoryProvider(c.clusterMetadataConfig, c.mockAdminClient).NewFactory(
-		rpcFactory,
-		membershipMonitor,
-		c.GetMetricsHandler(),
-		dynamicconfig.NewCollection(c.dcClient, c.logger),
-		c.testHooks,
-		c.historyConfig.NumHistoryShards,
-		logger,
-		logger,
-	)
-	return clientFactory.NewMatchingClientWithTimeout(
-		c.namespaceIDToName,
-		matchingclient.DefaultTimeout,
-		matchingclient.DefaultLongPollTimeout,
-	)
-}
-
-func (c *TemporalImpl) newClientRPCFactory(
-	membershipMonitor membership.Monitor,
-	logger log.Logger,
-) (common.RPCFactory, error) {
-	var frontendTLSConfig *tls.Config
-	var err error
-	if c.tlsConfigProvider != nil {
-		frontendTLSConfig, err = c.tlsConfigProvider.GetFrontendClientConfig()
-		if err != nil {
-			return nil, fmt.Errorf("failed getting client TLS config: %w", err)
-		}
-	}
-
-	frontendURL := membership.GRPCResolverURLForTesting(membershipMonitor, primitives.FrontendService)
-	return rpc.NewFactory(
-		&config.Config{},
-		primitives.FrontendService,
-		logger,
-		c.GetMetricsHandler(),
-		c.tlsConfigProvider,
-		frontendURL,
-		frontendURL,
-		int(mustPortFromAddress(c.FrontendHTTPAddress())),
-		frontendTLSConfig,
-		nil,
-		resource.PerServiceDialOptionsProvider(logger),
-		membershipMonitor,
-		c.tokenProvider,
-	), nil
-}
-
-func (c *TemporalImpl) namespaceIDToName(id namespace.ID) (namespace.Name, error) {
-	resp, err := c.FrontendClient().DescribeNamespace(NewContext(), &workflowservice.DescribeNamespaceRequest{
-		Id: id.String(),
-	})
-	if err != nil {
-		return "", err
-	}
-	return namespace.Name(resp.GetNamespaceInfo().GetName()), nil
+	c.frontendMembershipAddress = grpcResolver.MakeURL(serviceName)
 }
 
 func (c *TemporalImpl) startHistory() {


### PR DESCRIPTION
## What changed?

Follow up to https://github.com/temporalio/temporal/pull/10575.

Construct a matching client from scratch instead of reaching into the onebox graph.

## Why?

In order to delete the onebox fx graph, the `matchingRawClient` has to be constructed outside of it.