### PR TITLE
Move archival setup into archival suite

### DIFF
--- a/tests/archival_test.go
+++ b/tests/archival_test.go
@@ -22,10 +22,14 @@ import (
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/archiver"
+	"go.temporal.io/server/common/archiver/filestore"
 	"go.temporal.io/server/common/archiver/provider"
+	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/convert"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/persistence"
@@ -49,7 +53,6 @@ type (
 
 	archivalTestEnv struct {
 		*testcore.TestEnv
-
 		archivalNamespace   namespace.Name
 		archivalNamespaceID namespace.ID
 
@@ -60,6 +63,10 @@ type (
 		// Counters to verify custom archivers are being called
 		customHistoryArchiveCalled    atomic.Int32
 		customVisibilityArchiveCalled atomic.Int32
+
+		archiverProvider provider.ArchiverProvider
+		historyURI       string
+		visibilityURI    string
 	}
 
 	archivalWorkflowInfo struct {
@@ -111,7 +118,13 @@ func TestArchivalSuite(t *testing.T) {
 }
 
 func (s *ArchivalSuite) newTestEnv() *archivalTestEnv {
-	ae := &archivalTestEnv{}
+	cfg := &config.FilestoreArchiver{FileMode: "0666", DirMode: "0766"}
+	historyProvider := &config.HistoryArchiverProvider{Filestore: cfg}
+	visibilityProvider := &config.VisibilityArchiverProvider{Filestore: cfg}
+	ae := &archivalTestEnv{
+		historyURI:    filestore.URIScheme + "://" + s.T().TempDir(),
+		visibilityURI: filestore.URIScheme + "://" + s.T().TempDir(),
+	}
 
 	// Create custom history archiver factory for custom scheme
 	customHistoryArchiverFactory := provider.CustomHistoryArchiverFactoryFunc(
@@ -146,6 +159,15 @@ func (s *ArchivalSuite) newTestEnv() *archivalTestEnv {
 		testcore.WithArchival(),
 		testcore.WithCustomArchivers(customHistoryArchiverFactory, customVisibilityArchiverFactory),
 	)
+	ae.archiverProvider = provider.NewArchiverProvider(
+		historyProvider,
+		visibilityProvider,
+		customHistoryArchiverFactory,
+		customVisibilityArchiverFactory,
+		ae.GetTestCluster().ExecutionManager(),
+		log.NewNoopLogger(),
+		metrics.NoopMetricsHandler,
+	)
 
 	var err error
 
@@ -155,8 +177,8 @@ func (s *ArchivalSuite) newTestEnv() *archivalTestEnv {
 		ae.archivalNamespace,
 		0, // Archive right away.
 		enumspb.ARCHIVAL_STATE_ENABLED,
-		ae.GetTestCluster().ArchiverBase().HistoryURI(),
-		ae.GetTestCluster().ArchiverBase().VisibilityURI(),
+		ae.historyURI,
+		ae.visibilityURI,
 	)
 	s.NoError(err)
 
@@ -178,7 +200,6 @@ func (s *ArchivalSuite) newTestEnv() *archivalTestEnv {
 
 func (s *ArchivalSuite) TestArchival_TimerQueueProcessor() {
 	env := s.newTestEnv()
-	s.True(env.GetTestCluster().ArchiverBase().Metadata().GetHistoryConfig().ClusterConfiguredForArchival())
 
 	workflowID := "archival-timer-queue-processor-workflow-id"
 	workflowType := "archival-timer-queue-processor-type"
@@ -194,7 +215,6 @@ func (s *ArchivalSuite) TestArchival_TimerQueueProcessor() {
 
 func (s *ArchivalSuite) TestArchival_ContinueAsNew() {
 	env := s.newTestEnv()
-	s.True(env.GetTestCluster().ArchiverBase().Metadata().GetHistoryConfig().ClusterConfiguredForArchival())
 
 	workflowID := "archival-continueAsNew-workflow-id"
 	workflowType := "archival-continueAsNew-workflow-type"
@@ -214,7 +234,6 @@ func (s *ArchivalSuite) TestArchival_ArchiverWorker() {
 	// s.T().SkipNow() // flaky test, skip for now, will reimplement archival feature.
 
 	env := s.newTestEnv()
-	s.True(env.GetTestCluster().ArchiverBase().Metadata().GetHistoryConfig().ClusterConfiguredForArchival())
 
 	workflowID := "archival-archiver-worker-workflow-id"
 	workflowType := "archival-archiver-worker-workflow-type"
@@ -229,7 +248,6 @@ func (s *ArchivalSuite) TestArchival_ArchiverWorker() {
 
 func (s *ArchivalSuite) TestVisibilityArchival() {
 	env := s.newTestEnv()
-	s.True(env.GetTestCluster().ArchiverBase().Metadata().GetVisibilityConfig().ClusterConfiguredForArchival())
 
 	workflowID := "archival-visibility-workflow-id"
 	workflowType := "archival-visibility-workflow-type"
@@ -278,7 +296,6 @@ func (s *ArchivalSuite) TestVisibilityArchival() {
 
 func (s *ArchivalSuite) TestCustomArchiver() {
 	env := s.newTestEnv()
-	s.True(env.GetTestCluster().ArchiverBase().Metadata().GetHistoryConfig().ClusterConfiguredForArchival())
 
 	workflowID := "custom-history-archiver-workflow-id"
 	workflowType := "custom-history-archiver-type"
@@ -306,16 +323,16 @@ func (s *ArchivalSuite) TestCustomArchiver() {
 
 // workflowIsArchived asserts that both the workflow history and workflow visibility are archived.
 func (s *ArchivalSuite) workflowIsArchived(env *archivalTestEnv, namespaceID namespace.ID, execution *commonpb.WorkflowExecution) {
-	historyURI, err := archiver.NewURI(env.GetTestCluster().ArchiverBase().HistoryURI())
+	historyURI, err := archiver.NewURI(env.historyURI)
 	s.NoError(err)
-	historyArchiver, err := env.GetTestCluster().ArchiverBase().Provider().GetHistoryArchiver(
+	historyArchiver, err := env.archiverProvider.GetHistoryArchiver(
 		historyURI.Scheme(),
 	)
 	s.NoError(err)
 
-	visibilityURI, err := archiver.NewURI(env.GetTestCluster().ArchiverBase().VisibilityURI())
+	visibilityURI, err := archiver.NewURI(env.visibilityURI)
 	s.NoError(err)
-	visibilityArchiver, err := env.GetTestCluster().ArchiverBase().Provider().GetVisibilityArchiver(
+	visibilityArchiver, err := env.archiverProvider.GetVisibilityArchiver(
 		visibilityURI.Scheme(),
 	)
 	s.NoError(err)

--- a/tests/leakcheck/leak_test.go
+++ b/tests/leakcheck/leak_test.go
@@ -53,7 +53,6 @@ var objectLeakOpts = []objectleak.Option{
 	objectleak.WithExpected("FunctionalTestBase"),
 	objectleak.WithExpected("FunctionalTestBase.Logger*"),
 	objectleak.WithExpected("FunctionalTestBase.Suite*"),
-	objectleak.WithExpected("FunctionalTestBase.testCluster.archiverBase*"),
 	objectleak.WithExpected("FunctionalTestBase.testCluster.host*"),
 	objectleak.WithExpected("FunctionalTestBase.testCluster.testBase*"),
 	objectleak.WithExpected("FunctionalTestBase.testClusterConfig"),

--- a/tests/testcore/test_cluster.go
+++ b/tests/testcore/test_cluster.go
@@ -22,7 +22,6 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common/archiver"
-	"go.temporal.io/server/common/archiver/filestore"
 	"go.temporal.io/server/common/archiver/provider"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/cluster"
@@ -59,19 +58,8 @@ type (
 
 	// TestCluster is a testcore struct for functional tests
 	TestCluster struct {
-		testBase     *persistencetests.TestBase
-		archiverBase *ArchiverBase
-		host         *TemporalImpl
-	}
-
-	// ArchiverBase is a testcore struct for archiver provider being used in functional tests
-	ArchiverBase struct {
-		metadata                 archiver.ArchivalMetadata
-		provider                 provider.ArchiverProvider
-		historyStoreDirectory    string
-		visibilityStoreDirectory string
-		historyURI               string
-		visibilityURI            string
+		testBase *persistencetests.TestBase
+		host     *TemporalImpl
 	}
 
 	// TestClusterConfig are config for a test cluster
@@ -114,22 +102,6 @@ const (
 	httpProtocol transferProtocol = "http"
 	grpcProtocol transferProtocol = "grpc"
 )
-
-func (a *ArchiverBase) Metadata() archiver.ArchivalMetadata {
-	return a.metadata
-}
-
-func (a *ArchiverBase) Provider() provider.ArchiverProvider {
-	return a.provider
-}
-
-func (a *ArchiverBase) HistoryURI() string {
-	return a.historyURI
-}
-
-func (a *ArchiverBase) VisibilityURI() string {
-	return a.visibilityURI
-}
 
 func (f *defaultTestClusterFactory) NewCluster(t *testing.T, clusterConfig *TestClusterConfig, logger log.Logger) (*TestCluster, error) {
 	return newClusterWithPersistenceTestBaseFactory(t, clusterConfig, logger, f.tbFactory)
@@ -228,7 +200,7 @@ func newClusterWithPersistenceTestBaseFactory(
 	testBase := tbFactory.NewTestBase(&clusterConfig.Persistence)
 
 	testBase.Setup(clusterMetadataConfig)
-	archiverBase := newArchiverBase(
+	archiverMetadata, archiverProvider := newArchivalMetadataAndProvider(
 		clusterConfig.EnableArchival,
 		clusterConfig.CustomHistoryArchiverFactory,
 		clusterConfig.CustomVisibilityArchiverFactory,
@@ -340,8 +312,8 @@ func newClusterWithPersistenceTestBaseFactory(
 		Logger:                           logger,
 		ESConfig:                         clusterConfig.ESConfig,
 		ESClient:                         esClient,
-		ArchiverMetadata:                 archiverBase.metadata,
-		ArchiverProvider:                 archiverBase.provider,
+		ArchiverMetadata:                 archiverMetadata,
+		ArchiverProvider:                 archiverProvider,
 		FrontendConfig:                   clusterConfig.FrontendConfig,
 		HistoryConfig:                    clusterConfig.HistoryConfig,
 		MatchingConfig:                   clusterConfig.MatchingConfig,
@@ -352,7 +324,7 @@ func newClusterWithPersistenceTestBaseFactory(
 		DynamicConfigOverrides:           clusterConfig.DynamicConfigOverrides,
 		TLSConfigProvider:                tlsConfigProvider,
 		ServiceFxOptions:                 clusterConfig.ServiceFxOptions,
-		TaskCategoryRegistry:             temporal.TaskCategoryRegistryProvider(archiverBase.metadata),
+		TaskCategoryRegistry:             temporal.TaskCategoryRegistryProvider(archiverMetadata),
 		HostsByProtocolByService:         hostsByProtocolByService,
 		SpanExporters:                    clusterConfig.SpanExporters,
 		TokenProvider:                    clusterConfig.TokenProvider,
@@ -373,7 +345,7 @@ func newClusterWithPersistenceTestBaseFactory(
 		return nil, err
 	}
 
-	return &TestCluster{testBase: testBase, archiverBase: archiverBase, host: cluster}, nil
+	return &TestCluster{testBase: testBase, host: cluster}, nil
 }
 
 func setupIndex(esConfig *esclient.Config, logger log.Logger) error {
@@ -488,34 +460,25 @@ func newPProfInitializerImpl(logger log.Logger, port int) *pprof.PProfInitialize
 	}
 }
 
-func newArchiverBase(
+// TODO: remove when onebox uses temporal.NewServerFx and archival wiring comes from production config.
+func newArchivalMetadataAndProvider(
 	enabled bool,
 	customHistoryArchiverFactory provider.CustomHistoryArchiverFactory,
 	customVisibilityArchiverFactory provider.CustomVisibilityArchiverFactory,
 	executionManager persistence.ExecutionManager,
 	logger log.Logger,
-) *ArchiverBase {
+) (archiver.ArchivalMetadata, provider.ArchiverProvider) {
 	dcCollection := dynamicconfig.NewNoopCollection()
 	if !enabled {
-		return &ArchiverBase{
-			metadata: archiver.NewArchivalMetadata(dcCollection, "", false, "", false, &config.ArchivalNamespaceDefaults{}),
-			provider: provider.NewArchiverProvider(nil, nil, nil, nil, nil, logger, metrics.NoopMetricsHandler),
-		}
+		return archiver.NewArchivalMetadata(dcCollection, "", false, "", false, &config.ArchivalNamespaceDefaults{}),
+			provider.NewArchiverProvider(nil, nil, nil, nil, nil, logger, metrics.NoopMetricsHandler)
 	}
 
-	historyStoreDirectory, err := os.MkdirTemp("", "test-history-archival")
-	if err != nil {
-		logger.Fatal("Failed to create temp dir for history archival", tag.Error(err))
-	}
-	visibilityStoreDirectory, err := os.MkdirTemp("", "test-visibility-archival")
-	if err != nil {
-		logger.Fatal("Failed to create temp dir for visibility archival", tag.Error(err))
-	}
 	cfg := &config.FilestoreArchiver{
 		FileMode: "0666",
 		DirMode:  "0766",
 	}
-	provider := provider.NewArchiverProvider(
+	archiverProvider := provider.NewArchiverProvider(
 		&config.HistoryArchiverProvider{
 			Filestore: cfg,
 		},
@@ -528,23 +491,16 @@ func newArchiverBase(
 		logger,
 		metrics.NoopMetricsHandler,
 	)
-	return &ArchiverBase{
-		metadata: archiver.NewArchivalMetadata(dcCollection, "enabled", true, "enabled", true, &config.ArchivalNamespaceDefaults{
-			History: config.HistoryArchivalNamespaceDefaults{
-				State: "enabled",
-				URI:   "testScheme://test/history/archive/path",
-			},
-			Visibility: config.VisibilityArchivalNamespaceDefaults{
-				State: "enabled",
-				URI:   "testScheme://test/visibility/archive/path",
-			},
-		}),
-		provider:                 provider,
-		historyStoreDirectory:    historyStoreDirectory,
-		visibilityStoreDirectory: visibilityStoreDirectory,
-		historyURI:               filestore.URIScheme + "://" + historyStoreDirectory,
-		visibilityURI:            filestore.URIScheme + "://" + visibilityStoreDirectory,
-	}
+	return archiver.NewArchivalMetadata(dcCollection, "enabled", true, "enabled", true, &config.ArchivalNamespaceDefaults{
+		History: config.HistoryArchivalNamespaceDefaults{
+			State: "enabled",
+			URI:   "testScheme://test/history/archive/path",
+		},
+		Visibility: config.VisibilityArchivalNamespaceDefaults{
+			State: "enabled",
+			URI:   "testScheme://test/visibility/archive/path",
+		},
+	}), archiverProvider
 }
 
 // TearDownCluster tears down the test cluster
@@ -556,22 +512,12 @@ func (tc *TestCluster) TearDownCluster() error {
 			errs = multierr.Combine(errs, err)
 		}
 	}
-	if err := os.RemoveAll(tc.archiverBase.historyStoreDirectory); err != nil {
-		errs = multierr.Combine(errs, err)
-	}
-	if err := os.RemoveAll(tc.archiverBase.visibilityStoreDirectory); err != nil {
-		errs = multierr.Combine(errs, err)
-	}
 	return errs
 }
 
 // TODO (alex): remove this method. Replace usages with concrete methods.
 func (tc *TestCluster) TestBase() *persistencetests.TestBase {
 	return tc.testBase
-}
-
-func (tc *TestCluster) ArchiverBase() *ArchiverBase {
-	return tc.archiverBase
 }
 
 func (tc *TestCluster) FrontendClient() workflowservice.WorkflowServiceClient {


### PR DESCRIPTION
## What changed?

Moved archival-specific cluster setup into `tests/archival_test.go` so the suite owns it.

## Why?

This keeps archival-only test plumbing out of the shared testcore cluster setup. Making changes to onebox easier.
