### PR TITLE
Add FirstExecutionRunID to start response

### DIFF
--- a/api/historyservice/v1/request_response.pb.go
+++ b/api/historyservice/v1/request_response.pb.go
@@ -371,8 +371,9 @@ type StartWorkflowExecutionResponse struct {
 	Started           bool                              `protobuf:"varint,4,opt,name=started,proto3" json:"started,omitempty"`
 	Status            v12.WorkflowExecutionStatus       `protobuf:"varint,5,opt,name=status,proto3,enum=temporal.api.enums.v1.WorkflowExecutionStatus" json:"status,omitempty"`
 	Link              *v14.Link                         `protobuf:"bytes,6,opt,name=link,proto3" json:"link,omitempty"`
-	// Run ID of the first execution in the chain. Equals run_id unless the current run is the result
-	// of a continue-as-new chain. May be empty when the server could not determine it.
+	// Run ID of the first execution in the chain. Equals run_id only for a first run; any
+	// continuation (continue-as-new, retry, cron, or reset) inherits the original run's ID. May be
+	// empty when the server could not determine it.
 	FirstExecutionRunId string `protobuf:"bytes,7,opt,name=first_execution_run_id,json=firstExecutionRunId,proto3" json:"first_execution_run_id,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache
@@ -3030,8 +3031,9 @@ type SignalWithStartWorkflowExecutionResponse struct {
 	RunId      string                 `protobuf:"bytes,1,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
 	Started    bool                   `protobuf:"varint,2,opt,name=started,proto3" json:"started,omitempty"`
 	SignalLink *v14.Link              `protobuf:"bytes,3,opt,name=signal_link,json=signalLink,proto3" json:"signal_link,omitempty"`
-	// Run ID of the first execution in the chain. Equals run_id unless the current run is the result
-	// of a continue-as-new chain. May be empty when the server could not determine it.
+	// Run ID of the first execution in the chain. Equals run_id only for a first run; any
+	// continuation (continue-as-new, retry, cron, or reset) inherits the original run's ID. May be
+	// empty when the server could not determine it.
 	FirstExecutionRunId string `protobuf:"bytes,4,opt,name=first_execution_run_id,json=firstExecutionRunId,proto3" json:"first_execution_run_id,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache

--- a/api/historyservice/v1/request_response.pb.go
+++ b/api/historyservice/v1/request_response.pb.go
@@ -371,8 +371,11 @@ type StartWorkflowExecutionResponse struct {
 	Started           bool                              `protobuf:"varint,4,opt,name=started,proto3" json:"started,omitempty"`
 	Status            v12.WorkflowExecutionStatus       `protobuf:"varint,5,opt,name=status,proto3,enum=temporal.api.enums.v1.WorkflowExecutionStatus" json:"status,omitempty"`
 	Link              *v14.Link                         `protobuf:"bytes,6,opt,name=link,proto3" json:"link,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// Run ID of the first execution in the chain. Equals run_id unless the current run is the result
+	// of a continue-as-new chain. May be empty when the server could not determine it.
+	FirstExecutionRunId string `protobuf:"bytes,7,opt,name=first_execution_run_id,json=firstExecutionRunId,proto3" json:"first_execution_run_id,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *StartWorkflowExecutionResponse) Reset() {
@@ -445,6 +448,13 @@ func (x *StartWorkflowExecutionResponse) GetLink() *v14.Link {
 		return x.Link
 	}
 	return nil
+}
+
+func (x *StartWorkflowExecutionResponse) GetFirstExecutionRunId() string {
+	if x != nil {
+		return x.FirstExecutionRunId
+	}
+	return ""
 }
 
 type GetMutableStateRequest struct {
@@ -10615,14 +10625,15 @@ const file_temporal_server_api_historyservice_v1_request_response_proto_rawDesc 
 	"\x18inherited_pinned_version\x18\x0f \x01(\v23.temporal.api.deployment.v1.WorkerDeploymentVersionR\x16inheritedPinnedVersion\x12s\n" +
 	"\x1binherited_auto_upgrade_info\x18\x10 \x01(\v24.temporal.api.deployment.v1.InheritedAutoUpgradeInfoR\x18inheritedAutoUpgradeInfo\x12|\n" +
 	"\x1fdeclined_target_version_upgrade\x18\x11 \x01(\v25.temporal.api.history.v1.DeclinedTargetVersionUpgradeR\x1cdeclinedTargetVersionUpgrade\x12{\n" +
-	"\x1ftime_skipping_state_propagation\x18\x13 \x01(\v24.temporal.api.common.v1.TimeSkippingStatePropagationR\x1ctimeSkippingStatePropagation:\x1f\x92\xc4\x03\x1b*\x19start_request.workflow_idJ\x04\b\x12\x10\x13\"\xfc\x02\n" +
+	"\x1ftime_skipping_state_propagation\x18\x13 \x01(\v24.temporal.api.common.v1.TimeSkippingStatePropagationR\x1ctimeSkippingStatePropagation:\x1f\x92\xc4\x03\x1b*\x19start_request.workflow_idJ\x04\b\x12\x10\x13\"\xb1\x03\n" +
 	"\x1eStartWorkflowExecutionResponse\x12\x15\n" +
 	"\x06run_id\x18\x01 \x01(\tR\x05runId\x12?\n" +
 	"\x05clock\x18\x02 \x01(\v2).temporal.server.api.clock.v1.VectorClockR\x05clock\x12n\n" +
 	"\x13eager_workflow_task\x18\x03 \x01(\v2>.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponseR\x11eagerWorkflowTask\x12\x18\n" +
 	"\astarted\x18\x04 \x01(\bR\astarted\x12F\n" +
 	"\x06status\x18\x05 \x01(\x0e2..temporal.api.enums.v1.WorkflowExecutionStatusR\x06status\x120\n" +
-	"\x04link\x18\x06 \x01(\v2\x1c.temporal.api.common.v1.LinkR\x04link\"\xda\x03\n" +
+	"\x04link\x18\x06 \x01(\v2\x1c.temporal.api.common.v1.LinkR\x04link\x123\n" +
+	"\x16first_execution_run_id\x18\a \x01(\tR\x13firstExecutionRunId\"\xda\x03\n" +
 	"\x16GetMutableStateRequest\x12!\n" +
 	"\fnamespace_id\x18\x01 \x01(\tR\vnamespaceId\x12G\n" +
 	"\texecution\x18\x02 \x01(\v2).temporal.api.common.v1.WorkflowExecutionR\texecution\x123\n" +

--- a/api/historyservice/v1/request_response.pb.go
+++ b/api/historyservice/v1/request_response.pb.go
@@ -3026,12 +3026,15 @@ func (x *SignalWithStartWorkflowExecutionRequest) GetSignalWithStartRequest() *v
 }
 
 type SignalWithStartWorkflowExecutionResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	RunId         string                 `protobuf:"bytes,1,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
-	Started       bool                   `protobuf:"varint,2,opt,name=started,proto3" json:"started,omitempty"`
-	SignalLink    *v14.Link              `protobuf:"bytes,3,opt,name=signal_link,json=signalLink,proto3" json:"signal_link,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	RunId      string                 `protobuf:"bytes,1,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
+	Started    bool                   `protobuf:"varint,2,opt,name=started,proto3" json:"started,omitempty"`
+	SignalLink *v14.Link              `protobuf:"bytes,3,opt,name=signal_link,json=signalLink,proto3" json:"signal_link,omitempty"`
+	// Run ID of the first execution in the chain. Equals run_id unless the current run is the result
+	// of a continue-as-new chain. May be empty when the server could not determine it.
+	FirstExecutionRunId string `protobuf:"bytes,4,opt,name=first_execution_run_id,json=firstExecutionRunId,proto3" json:"first_execution_run_id,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *SignalWithStartWorkflowExecutionResponse) Reset() {
@@ -3083,6 +3086,13 @@ func (x *SignalWithStartWorkflowExecutionResponse) GetSignalLink() *v14.Link {
 		return x.SignalLink
 	}
 	return nil
+}
+
+func (x *SignalWithStartWorkflowExecutionResponse) GetFirstExecutionRunId() string {
+	if x != nil {
+		return x.FirstExecutionRunId
+	}
+	return ""
 }
 
 type RemoveSignalMutableStateRequest struct {
@@ -10867,12 +10877,13 @@ const file_temporal_server_api_historyservice_v1_request_response_proto_rawDesc 
 	"\x04link\x18\x01 \x01(\v2\x1c.temporal.api.common.v1.LinkR\x04link\"\xff\x01\n" +
 	"'SignalWithStartWorkflowExecutionRequest\x12!\n" +
 	"\fnamespace_id\x18\x01 \x01(\tR\vnamespaceId\x12\x83\x01\n" +
-	"\x19signal_with_start_request\x18\x02 \x01(\v2H.temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequestR\x16signalWithStartRequest:+\x92\xc4\x03'*%signal_with_start_request.workflow_id\"\x9a\x01\n" +
+	"\x19signal_with_start_request\x18\x02 \x01(\v2H.temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequestR\x16signalWithStartRequest:+\x92\xc4\x03'*%signal_with_start_request.workflow_id\"\xcf\x01\n" +
 	"(SignalWithStartWorkflowExecutionResponse\x12\x15\n" +
 	"\x06run_id\x18\x01 \x01(\tR\x05runId\x12\x18\n" +
 	"\astarted\x18\x02 \x01(\bR\astarted\x12=\n" +
 	"\vsignal_link\x18\x03 \x01(\v2\x1c.temporal.api.common.v1.LinkR\n" +
-	"signalLink\"\xe3\x01\n" +
+	"signalLink\x123\n" +
+	"\x16first_execution_run_id\x18\x04 \x01(\tR\x13firstExecutionRunId\"\xe3\x01\n" +
 	"\x1fRemoveSignalMutableStateRequest\x12!\n" +
 	"\fnamespace_id\x18\x01 \x01(\tR\vnamespaceId\x12X\n" +
 	"\x12workflow_execution\x18\x02 \x01(\v2).temporal.api.common.v1.WorkflowExecutionR\x11workflowExecution\x12\x1d\n" +

--- a/api/persistence/v1/executions.pb.go
+++ b/api/persistence/v1/executions.pb.go
@@ -1445,9 +1445,10 @@ type WorkflowExecutionState struct {
 	// the workflow execution or request IDs that were attached to an existing running workflow
 	// execution via StartWorkflowExecutionRequest.OnConflictOptions.
 	RequestIds map[string]*RequestIDInfo `protobuf:"bytes,7,rep,name=request_ids,json=requestIds,proto3" json:"request_ids,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	// Run ID of the first execution in the chain (set on WorkflowExecutionStarted). For workflows
-	// that have not been continued-as-new this equals run_id. Empty on records written before this
-	// field was added; consumers must not assume run_id in that case.
+	// Run ID of the first execution in the chain (set on WorkflowExecutionStarted). Equals run_id
+	// only for a first run; any continuation (continue-as-new, retry, cron, or reset)
+	// inherits the original run's ID. Empty on records written before this field was added;
+	// consumers must not assume run_id in that case.
 	FirstExecutionRunId string `protobuf:"bytes,8,opt,name=first_execution_run_id,json=firstExecutionRunId,proto3" json:"first_execution_run_id,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache

--- a/api/persistence/v1/executions.pb.go
+++ b/api/persistence/v1/executions.pb.go
@@ -1443,9 +1443,13 @@ type WorkflowExecutionState struct {
 	// Request IDs that are attached to the workflow execution. It can be the request ID that started
 	// the workflow execution or request IDs that were attached to an existing running workflow
 	// execution via StartWorkflowExecutionRequest.OnConflictOptions.
-	RequestIds    map[string]*RequestIDInfo `protobuf:"bytes,7,rep,name=request_ids,json=requestIds,proto3" json:"request_ids,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	RequestIds map[string]*RequestIDInfo `protobuf:"bytes,7,rep,name=request_ids,json=requestIds,proto3" json:"request_ids,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Run ID of the first execution in the chain (set on WorkflowExecutionStarted). For workflows
+	// that have not been continued-as-new this equals run_id. Empty on records written before this
+	// field was added; consumers must not assume run_id in that case.
+	FirstExecutionRunId string `protobuf:"bytes,8,opt,name=first_execution_run_id,json=firstExecutionRunId,proto3" json:"first_execution_run_id,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *WorkflowExecutionState) Reset() {
@@ -1525,6 +1529,13 @@ func (x *WorkflowExecutionState) GetRequestIds() map[string]*RequestIDInfo {
 		return x.RequestIds
 	}
 	return nil
+}
+
+func (x *WorkflowExecutionState) GetFirstExecutionRunId() string {
+	if x != nil {
+		return x.FirstExecutionRunId
+	}
+	return ""
 }
 
 type RequestIDInfo struct {
@@ -5072,7 +5083,7 @@ const file_temporal_server_api_persistence_v1_executions_proto_rawDesc = "" +
 	"\x0eExecutionStats\x12!\n" +
 	"\fhistory_size\x18\x01 \x01(\x03R\vhistorySize\x122\n" +
 	"\x15external_payload_size\x18\x02 \x01(\x03R\x13externalPayloadSize\x124\n" +
-	"\x16external_payload_count\x18\x03 \x01(\x03R\x14externalPayloadCount\"\x8c\x05\n" +
+	"\x16external_payload_count\x18\x03 \x01(\x03R\x14externalPayloadCount\"\xc1\x05\n" +
 	"\x16WorkflowExecutionState\x12*\n" +
 	"\x11create_request_id\x18\x01 \x01(\tR\x0fcreateRequestId\x12\x15\n" +
 	"\x06run_id\x18\x02 \x01(\tR\x05runId\x12J\n" +
@@ -5082,7 +5093,8 @@ const file_temporal_server_api_persistence_v1_executions_proto_rawDesc = "" +
 	"\n" +
 	"start_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tstartTime\x12k\n" +
 	"\vrequest_ids\x18\a \x03(\v2J.temporal.server.api.persistence.v1.WorkflowExecutionState.RequestIdsEntryR\n" +
-	"requestIds\x1ap\n" +
+	"requestIds\x123\n" +
+	"\x16first_execution_run_id\x18\b \x01(\tR\x13firstExecutionRunId\x1ap\n" +
 	"\x0fRequestIdsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12G\n" +
 	"\x05value\x18\x02 \x01(\v21.temporal.server.api.persistence.v1.RequestIDInfoR\x05value:\x028\x01\"k\n" +

--- a/api/persistence/v1/executions.pb.go
+++ b/api/persistence/v1/executions.pb.go
@@ -214,9 +214,10 @@ type WorkflowExecutionInfo struct {
 	SearchAttributes                map[string]*v13.Payload `protobuf:"bytes,52,rep,name=search_attributes,json=searchAttributes,proto3" json:"search_attributes,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Memo                            map[string]*v13.Payload `protobuf:"bytes,53,rep,name=memo,proto3" json:"memo,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	VersionHistories                *v14.VersionHistories   `protobuf:"bytes,54,opt,name=version_histories,json=versionHistories,proto3" json:"version_histories,omitempty"`
-	FirstExecutionRunId             string                  `protobuf:"bytes,55,opt,name=first_execution_run_id,json=firstExecutionRunId,proto3" json:"first_execution_run_id,omitempty"`
-	ExecutionStats                  *ExecutionStats         `protobuf:"bytes,56,opt,name=execution_stats,json=executionStats,proto3" json:"execution_stats,omitempty"`
-	WorkflowRunExpirationTime       *timestamppb.Timestamp  `protobuf:"bytes,57,opt,name=workflow_run_expiration_time,json=workflowRunExpirationTime,proto3" json:"workflow_run_expiration_time,omitempty"`
+	// Deprecated. use `WorkflowExecutionState.first_execution_run_id`
+	FirstExecutionRunId       string                 `protobuf:"bytes,55,opt,name=first_execution_run_id,json=firstExecutionRunId,proto3" json:"first_execution_run_id,omitempty"`
+	ExecutionStats            *ExecutionStats        `protobuf:"bytes,56,opt,name=execution_stats,json=executionStats,proto3" json:"execution_stats,omitempty"`
+	WorkflowRunExpirationTime *timestamppb.Timestamp `protobuf:"bytes,57,opt,name=workflow_run_expiration_time,json=workflowRunExpirationTime,proto3" json:"workflow_run_expiration_time,omitempty"`
 	// Transaction Id of the first event in the last batch of events.
 	LastFirstEventTxnId  int64                  `protobuf:"varint,58,opt,name=last_first_event_txn_id,json=lastFirstEventTxnId,proto3" json:"last_first_event_txn_id,omitempty"`
 	StateTransitionCount int64                  `protobuf:"varint,59,opt,name=state_transition_count,json=stateTransitionCount,proto3" json:"state_transition_count,omitempty"`

--- a/common/persistence/cassandra/errors.go
+++ b/common/persistence/cassandra/errors.go
@@ -223,12 +223,13 @@ func extractCurrentWorkflowConflictError(
 				requestCurrentRunID,
 				actualCurrentRunID,
 			),
-			RequestIDs:       executionState.RequestIds,
-			RunID:            executionState.RunId,
-			State:            executionState.State,
-			Status:           executionState.Status,
-			LastWriteVersion: lastWriteVersion,
-			StartTime:        timestamp.TimeValuePtr(executionState.StartTime),
+			RequestIDs:          executionState.RequestIds,
+			RunID:               executionState.RunId,
+			FirstExecutionRunID: executionState.FirstExecutionRunId,
+			State:               executionState.State,
+			Status:              executionState.Status,
+			LastWriteVersion:    lastWriteVersion,
+			StartTime:           timestamp.TimeValuePtr(executionState.StartTime),
 		}
 	}
 	return nil

--- a/common/persistence/data_interfaces.go
+++ b/common/persistence/data_interfaces.go
@@ -116,12 +116,16 @@ type (
 		// RequestIDs contains all request IDs associated with the workflow execution, ie., contain the
 		// request ID that started the workflow execution as well as the request IDs that were attached
 		// to the workflow execution when it was running.
-		RequestIDs       map[string]*persistencespb.RequestIDInfo
-		RunID            string
-		State            enumsspb.WorkflowExecutionState
-		Status           enumspb.WorkflowExecutionStatus
-		LastWriteVersion int64
-		StartTime        *time.Time
+		RequestIDs map[string]*persistencespb.RequestIDInfo
+		RunID      string
+		// FirstExecutionRunID is the run ID of the first execution in the continue-as-new chain.
+		// May be empty on records written before this field was added to WorkflowExecutionState;
+		// callers must not assume RunID in that case.
+		FirstExecutionRunID string
+		State               enumsspb.WorkflowExecutionState
+		Status              enumspb.WorkflowExecutionStatus
+		LastWriteVersion    int64
+		StartTime           *time.Time
 	}
 
 	// WorkflowConditionFailedError represents a failed conditional update for workflow record

--- a/common/persistence/sql/errors.go
+++ b/common/persistence/sql/errors.go
@@ -29,12 +29,13 @@ func (m *sqlExecutionStore) extractCurrentWorkflowConflictError(
 	}
 
 	return &p.CurrentWorkflowConditionFailedError{
-		Msg:              message,
-		RequestIDs:       executionState.RequestIds,
-		RunID:            currentRow.RunID.String(),
-		State:            currentRow.State,
-		Status:           currentRow.Status,
-		LastWriteVersion: currentRow.LastWriteVersion,
-		StartTime:        currentRow.StartTime,
+		Msg:                 message,
+		RequestIDs:          executionState.RequestIds,
+		RunID:               currentRow.RunID.String(),
+		FirstExecutionRunID: executionState.FirstExecutionRunId,
+		State:               currentRow.State,
+		Status:              currentRow.Status,
+		LastWriteVersion:    currentRow.LastWriteVersion,
+		StartTime:           currentRow.StartTime,
 	}
 }

--- a/common/persistence/sql/execution_util.go
+++ b/common/persistence/sql/execution_util.go
@@ -984,12 +984,13 @@ func assertRunIDAndUpdateCurrentExecution(
 					currentRow.RunID,
 					previousRunID,
 				),
-				RequestIDs:       executionState.RequestIds,
-				RunID:            currentRow.RunID.String(),
-				State:            currentRow.State,
-				Status:           currentRow.Status,
-				LastWriteVersion: currentRow.LastWriteVersion,
-				StartTime:        currentRow.StartTime,
+				RequestIDs:          executionState.RequestIds,
+				RunID:               currentRow.RunID.String(),
+				FirstExecutionRunID: executionState.FirstExecutionRunId,
+				State:               currentRow.State,
+				Status:              currentRow.Status,
+				LastWriteVersion:    currentRow.LastWriteVersion,
+				StartTime:           currentRow.StartTime,
 			}
 		}
 		return nil
@@ -1046,12 +1047,13 @@ func assertRunIDMismatch(requestRunID primitives.UUID, currentRow *sqlplugin.Cur
 				requestRunID,
 				currentRow.RunID.String(),
 			),
-			RequestIDs:       executionState.RequestIds,
-			RunID:            currentRow.RunID.String(),
-			State:            currentRow.State,
-			Status:           currentRow.Status,
-			LastWriteVersion: currentRow.LastWriteVersion,
-			StartTime:        currentRow.StartTime,
+			RequestIDs:          executionState.RequestIds,
+			RunID:               currentRow.RunID.String(),
+			FirstExecutionRunID: executionState.FirstExecutionRunId,
+			State:               currentRow.State,
+			Status:              currentRow.Status,
+			LastWriteVersion:    currentRow.LastWriteVersion,
+			StartTime:           currentRow.StartTime,
 		}
 	}
 	return nil

--- a/proto/internal/temporal/server/api/historyservice/v1/request_response.proto
+++ b/proto/internal/temporal/server/api/historyservice/v1/request_response.proto
@@ -116,8 +116,9 @@ message StartWorkflowExecutionResponse {
   bool started = 4;
   temporal.api.enums.v1.WorkflowExecutionStatus status = 5;
   temporal.api.common.v1.Link link = 6;
-  // Run ID of the first execution in the chain. Equals run_id unless the current run is the result
-  // of a continue-as-new chain. May be empty when the server could not determine it.
+  // Run ID of the first execution in the chain. Equals run_id only for a first run; any
+  // continuation (continue-as-new, retry, cron, or reset) inherits the original run's ID. May be
+  // empty when the server could not determine it.
   string first_execution_run_id = 7;
 }
 
@@ -513,8 +514,9 @@ message SignalWithStartWorkflowExecutionResponse {
   string run_id = 1;
   bool started = 2;
   temporal.api.common.v1.Link signal_link = 3;
-  // Run ID of the first execution in the chain. Equals run_id unless the current run is the result
-  // of a continue-as-new chain. May be empty when the server could not determine it.
+  // Run ID of the first execution in the chain. Equals run_id only for a first run; any
+  // continuation (continue-as-new, retry, cron, or reset) inherits the original run's ID. May be
+  // empty when the server could not determine it.
   string first_execution_run_id = 4;
 }
 

--- a/proto/internal/temporal/server/api/historyservice/v1/request_response.proto
+++ b/proto/internal/temporal/server/api/historyservice/v1/request_response.proto
@@ -513,6 +513,9 @@ message SignalWithStartWorkflowExecutionResponse {
   string run_id = 1;
   bool started = 2;
   temporal.api.common.v1.Link signal_link = 3;
+  // Run ID of the first execution in the chain. Equals run_id unless the current run is the result
+  // of a continue-as-new chain. May be empty when the server could not determine it.
+  string first_execution_run_id = 4;
 }
 
 message RemoveSignalMutableStateRequest {

--- a/proto/internal/temporal/server/api/historyservice/v1/request_response.proto
+++ b/proto/internal/temporal/server/api/historyservice/v1/request_response.proto
@@ -116,6 +116,9 @@ message StartWorkflowExecutionResponse {
   bool started = 4;
   temporal.api.enums.v1.WorkflowExecutionStatus status = 5;
   temporal.api.common.v1.Link link = 6;
+  // Run ID of the first execution in the chain. Equals run_id unless the current run is the result
+  // of a continue-as-new chain. May be empty when the server could not determine it.
+  string first_execution_run_id = 7;
 }
 
 message GetMutableStateRequest {

--- a/proto/internal/temporal/server/api/persistence/v1/executions.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/executions.proto
@@ -391,9 +391,10 @@ message WorkflowExecutionState {
   // the workflow execution or request IDs that were attached to an existing running workflow
   // execution via StartWorkflowExecutionRequest.OnConflictOptions.
   map<string, RequestIDInfo> request_ids = 7;
-  // Run ID of the first execution in the chain (set on WorkflowExecutionStarted). For workflows
-  // that have not been continued-as-new this equals run_id. Empty on records written before this
-  // field was added; consumers must not assume run_id in that case.
+  // Run ID of the first execution in the chain (set on WorkflowExecutionStarted). Equals run_id
+  // only for a first run; any continuation (continue-as-new, retry, cron, or reset)
+  // inherits the original run's ID. Empty on records written before this field was added;
+  // consumers must not assume run_id in that case.
   string first_execution_run_id = 8;
 }
 

--- a/proto/internal/temporal/server/api/persistence/v1/executions.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/executions.proto
@@ -145,6 +145,7 @@ message WorkflowExecutionInfo {
   map<string, temporal.api.common.v1.Payload> search_attributes = 52;
   map<string, temporal.api.common.v1.Payload> memo = 53;
   temporal.server.api.history.v1.VersionHistories version_histories = 54;
+  // Deprecated. use `WorkflowExecutionState.first_execution_run_id`
   string first_execution_run_id = 55;
   ExecutionStats execution_stats = 56;
   google.protobuf.Timestamp workflow_run_expiration_time = 57;

--- a/proto/internal/temporal/server/api/persistence/v1/executions.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/executions.proto
@@ -390,6 +390,10 @@ message WorkflowExecutionState {
   // the workflow execution or request IDs that were attached to an existing running workflow
   // execution via StartWorkflowExecutionRequest.OnConflictOptions.
   map<string, RequestIDInfo> request_ids = 7;
+  // Run ID of the first execution in the chain (set on WorkflowExecutionStarted). For workflows
+  // that have not been continued-as-new this equals run_id. Empty on records written before this
+  // field was added; consumers must not assume run_id in that case.
+  string first_execution_run_id = 8;
 }
 
 message RequestIDInfo {

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -590,11 +590,12 @@ func (wh *WorkflowHandler) convertToStartWorkflowExecutionResponse(
 	}
 
 	return &workflowservice.StartWorkflowExecutionResponse{
-		RunId:             resp.GetRunId(),
-		Started:           resp.Started,
-		EagerWorkflowTask: resp.GetEagerWorkflowTask(),
-		Link:              resp.GetLink(),
-		Status:            resp.GetStatus(),
+		RunId:               resp.GetRunId(),
+		FirstExecutionRunId: resp.GetFirstExecutionRunId(),
+		Started:             resp.Started,
+		EagerWorkflowTask:   resp.GetEagerWorkflowTask(),
+		Link:                resp.GetLink(),
+		Status:              resp.GetStatus(),
 	}, nil
 }
 

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -2367,9 +2367,10 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 	}
 
 	return &workflowservice.SignalWithStartWorkflowExecutionResponse{
-		RunId:      resp.GetRunId(),
-		Started:    resp.Started,
-		SignalLink: resp.GetSignalLink(),
+		RunId:               resp.GetRunId(),
+		FirstExecutionRunId: resp.GetFirstExecutionRunId(),
+		Started:             resp.Started,
+		SignalLink:          resp.GetSignalLink(),
 	}, nil
 }
 

--- a/service/history/api/signalwithstartworkflow/api.go
+++ b/service/history/api/signalwithstartworkflow/api.go
@@ -75,7 +75,7 @@ func Invoke(
 		return nil, err
 	}
 
-	runID, firstExecutionRunID, started, err := SignalWithStartWorkflow(
+	outcome, err := SignalWithStartWorkflow(
 		ctx,
 		shard,
 		namespaceEntry,
@@ -88,19 +88,19 @@ func Invoke(
 	}
 
 	// Notify version workflow if we're starting a new workflow pinned to a potentially drained version
-	if started {
+	if outcome.started {
 		api.ReactivateVersionWorkflowIfPinned(ctx, namespaceEntry, request.GetVersioningOverride(), reactivationSignaler, shard.GetConfig().EnableVersionReactivationSignals(), shouldSkipReactivation, revisionNumber)
 	}
 
 	swr := signalWithStartRequest.SignalWithStartRequest
 	return &historyservice.SignalWithStartWorkflowExecutionResponse{
-		RunId:               runID,
-		FirstExecutionRunId: firstExecutionRunID,
-		Started:             started,
+		RunId:               outcome.runID,
+		FirstExecutionRunId: outcome.firstExecutionRunID,
+		Started:             outcome.started,
 		SignalLink: api.GenerateRequestIDRefLink(
 			swr.GetNamespace(),
 			swr.GetWorkflowId(),
-			runID,
+			outcome.runID,
 			swr.GetRequestId(),
 			enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED,
 		),

--- a/service/history/api/signalwithstartworkflow/api.go
+++ b/service/history/api/signalwithstartworkflow/api.go
@@ -106,4 +106,3 @@ func Invoke(
 		),
 	}, nil
 }
-

--- a/service/history/api/signalwithstartworkflow/api.go
+++ b/service/history/api/signalwithstartworkflow/api.go
@@ -75,7 +75,7 @@ func Invoke(
 		return nil, err
 	}
 
-	runID, started, err := SignalWithStartWorkflow(
+	runID, firstExecutionRunID, started, err := SignalWithStartWorkflow(
 		ctx,
 		shard,
 		namespaceEntry,
@@ -94,8 +94,9 @@ func Invoke(
 
 	swr := signalWithStartRequest.SignalWithStartRequest
 	return &historyservice.SignalWithStartWorkflowExecutionResponse{
-		RunId:   runID,
-		Started: started,
+		RunId:               runID,
+		FirstExecutionRunId: firstExecutionRunID,
+		Started:             started,
 		SignalLink: api.GenerateRequestIDRefLink(
 			swr.GetNamespace(),
 			swr.GetWorkflowId(),

--- a/service/history/api/signalwithstartworkflow/api.go
+++ b/service/history/api/signalwithstartworkflow/api.go
@@ -3,6 +3,7 @@ package signalwithstartworkflow
 import (
 	"context"
 
+	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/api/historyservice/v1"
@@ -87,6 +88,16 @@ func Invoke(
 		return nil, err
 	}
 
+	// CurrentWorkflowConditionFailedError carries the persisted WorkflowExecutionState blob, which
+	// may not have first_execution_run_id populated on records written before that field existed.
+	// Load mutable state once to recover the canonical head-of-chain run id in that case (mirrors
+	// StartWorkflowExecution's behavior).
+	if firstExecutionRunID == "" && runID != "" {
+		if id, derr := getFirstExecutionRunID(ctx, shard, workflowConsistencyChecker, namespaceID, signalWithStartRequest.SignalWithStartRequest.GetWorkflowId(), runID); derr == nil {
+			firstExecutionRunID = id
+		}
+	}
+
 	// Notify version workflow if we're starting a new workflow pinned to a potentially drained version
 	if started {
 		api.ReactivateVersionWorkflowIfPinned(ctx, namespaceEntry, request.GetVersioningOverride(), reactivationSignaler, shard.GetConfig().EnableVersionReactivationSignals(), shouldSkipReactivation, revisionNumber)
@@ -105,4 +116,35 @@ func Invoke(
 			enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED,
 		),
 	}, nil
+}
+
+// getFirstExecutionRunID loads mutable state for the given run and resolves the head-of-chain run id
+// via MutableState.GetFirstRunID() (which checks ExecutionState, then the deprecated ExecutionInfo
+// field, then falls back to reading the WorkflowExecutionStarted event). Used to recover the value
+// for legacy workflows whose persisted WorkflowExecutionState predates first_execution_run_id.
+func getFirstExecutionRunID(
+	ctx context.Context,
+	shard historyi.ShardContext,
+	workflowConsistencyChecker api.WorkflowConsistencyChecker,
+	namespaceID namespace.ID,
+	workflowID string,
+	runID string,
+) (_ string, retErr error) {
+	workflowContext, releaseFn, err := workflowConsistencyChecker.GetWorkflowCache().GetOrCreateWorkflowExecution(
+		ctx,
+		shard,
+		namespaceID,
+		&commonpb.WorkflowExecution{WorkflowId: workflowID, RunId: runID},
+		locks.PriorityHigh,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer func() { releaseFn(retErr) }()
+
+	ms, err := workflowContext.LoadMutableState(ctx, shard)
+	if err != nil {
+		return "", err
+	}
+	return ms.GetFirstRunID(ctx)
 }

--- a/service/history/api/signalwithstartworkflow/api.go
+++ b/service/history/api/signalwithstartworkflow/api.go
@@ -3,7 +3,6 @@ package signalwithstartworkflow
 import (
 	"context"
 
-	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/api/historyservice/v1"
@@ -88,16 +87,6 @@ func Invoke(
 		return nil, err
 	}
 
-	// CurrentWorkflowConditionFailedError carries the persisted WorkflowExecutionState blob, which
-	// may not have first_execution_run_id populated on records written before that field existed.
-	// Load mutable state once to recover the canonical head-of-chain run id in that case (mirrors
-	// StartWorkflowExecution's behavior).
-	if firstExecutionRunID == "" && runID != "" {
-		if id, derr := getFirstExecutionRunID(ctx, shard, workflowConsistencyChecker, namespaceID, signalWithStartRequest.SignalWithStartRequest.GetWorkflowId(), runID); derr == nil {
-			firstExecutionRunID = id
-		}
-	}
-
 	// Notify version workflow if we're starting a new workflow pinned to a potentially drained version
 	if started {
 		api.ReactivateVersionWorkflowIfPinned(ctx, namespaceEntry, request.GetVersioningOverride(), reactivationSignaler, shard.GetConfig().EnableVersionReactivationSignals(), shouldSkipReactivation, revisionNumber)
@@ -118,33 +107,3 @@ func Invoke(
 	}, nil
 }
 
-// getFirstExecutionRunID loads mutable state for the given run and resolves the head-of-chain run id
-// via MutableState.GetFirstRunID() (which checks ExecutionState, then the deprecated ExecutionInfo
-// field, then falls back to reading the WorkflowExecutionStarted event). Used to recover the value
-// for legacy workflows whose persisted WorkflowExecutionState predates first_execution_run_id.
-func getFirstExecutionRunID(
-	ctx context.Context,
-	shard historyi.ShardContext,
-	workflowConsistencyChecker api.WorkflowConsistencyChecker,
-	namespaceID namespace.ID,
-	workflowID string,
-	runID string,
-) (_ string, retErr error) {
-	workflowContext, releaseFn, err := workflowConsistencyChecker.GetWorkflowCache().GetOrCreateWorkflowExecution(
-		ctx,
-		shard,
-		namespaceID,
-		&commonpb.WorkflowExecution{WorkflowId: workflowID, RunId: runID},
-		locks.PriorityHigh,
-	)
-	if err != nil {
-		return "", err
-	}
-	defer func() { releaseFn(retErr) }()
-
-	ms, err := workflowContext.LoadMutableState(ctx, shard)
-	if err != nil {
-		return "", err
-	}
-	return ms.GetFirstRunID(ctx)
-}

--- a/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
+++ b/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
@@ -19,6 +19,9 @@ import (
 	historyi "go.temporal.io/server/service/history/interfaces"
 )
 
+// SignalWithStartWorkflow returns the run id and first-execution run id of the workflow that
+// received the signal (or was started). firstExecutionRunID may be empty when reading from a
+// pre-existing record whose ExecutionState has not been backfilled yet.
 func SignalWithStartWorkflow(
 	ctx context.Context,
 	shard historyi.ShardContext,
@@ -26,7 +29,7 @@ func SignalWithStartWorkflow(
 	currentWorkflowLease api.WorkflowLease,
 	startRequest *historyservice.StartWorkflowExecutionRequest,
 	signalWithStartRequest *workflowservice.SignalWithStartWorkflowExecutionRequest,
-) (string, bool, error) {
+) (runID string, firstExecutionRunID string, started bool, err error) {
 	// workflow is running and restart was not requested, and conflict policy is to use existing
 	if currentWorkflowLease != nil &&
 		currentWorkflowLease.GetMutableState().IsWorkflowExecutionRunning() &&
@@ -40,9 +43,12 @@ func SignalWithStartWorkflow(
 			currentWorkflowLease,
 			signalWithStartRequest,
 		); err != nil {
-			return "", false, err
+			return "", "", false, err
 		}
-		return currentWorkflowLease.GetContext().GetWorkflowKey().RunID, false, nil
+		return currentWorkflowLease.GetContext().GetWorkflowKey().RunID,
+			currentWorkflowLease.GetMutableState().GetExecutionState().FirstExecutionRunId,
+			false,
+			nil
 	}
 	// else, either workflow is not running or restart requested
 	return startAndSignalWorkflow(
@@ -62,7 +68,7 @@ func startAndSignalWorkflow(
 	currentWorkflowLease api.WorkflowLease,
 	startRequest *historyservice.StartWorkflowExecutionRequest,
 	signalWithStartRequest *workflowservice.SignalWithStartWorkflowExecutionRequest,
-) (string, bool, error) {
+) (string, string, bool, error) {
 	workflowID := signalWithStartRequest.GetWorkflowId()
 	runID := uuid.New().String()
 	// TODO(bergundy): Support eager workflow task
@@ -75,12 +81,12 @@ func startAndSignalWorkflow(
 		signalWithStartRequest,
 	)
 	if err != nil {
-		return "", false, err
+		return "", "", false, err
 	}
 
 	newWorkflowLease, err := api.NewWorkflowLeaseAndContext(nil, shard, newMutableState)
 	if err != nil {
-		return "", false, err
+		return "", "", false, err
 	}
 
 	if err = api.ValidateSignal(
@@ -91,7 +97,7 @@ func startAndSignalWorkflow(
 		signalWithStartRequest.GetHeader().Size(),
 		"SignalWithStartWorkflowExecution",
 	); err != nil {
-		return "", false, err
+		return "", "", false, err
 	}
 
 	workflowMutationFn, err := createWorkflowMutationFunction(
@@ -103,7 +109,7 @@ func startAndSignalWorkflow(
 		signalWithStartRequest.GetWorkflowIdConflictPolicy(),
 	)
 	if err != nil {
-		return "", false, err
+		return "", "", false, err
 	}
 	if workflowMutationFn != nil {
 		if err = startAndSignalWithCurrentWorkflow(
@@ -113,13 +119,14 @@ func startAndSignalWorkflow(
 			workflowMutationFn,
 			newWorkflowLease,
 		); err != nil {
-			return "", false, err
+			return "", "", false, err
 		}
-		return runID, true, nil
+		// Started a fresh run after terminating the existing one: this run is the head of the chain.
+		return runID, runID, true, nil
 	}
 	vrid, err := createVersionedRunID(currentWorkflowLease)
 	if err != nil {
-		return "", false, err
+		return "", "", false, err
 	}
 	return startAndSignalWithoutCurrentWorkflow(
 		ctx,
@@ -221,16 +228,16 @@ func startAndSignalWithoutCurrentWorkflow(
 	vrid *api.VersionedRunID,
 	newWorkflowLease api.WorkflowLease,
 	requestID string,
-) (string, bool, error) {
+) (string, string, bool, error) {
 	newWorkflow, newWorkflowEventsSeq, err := newWorkflowLease.GetMutableState().CloseTransactionAsSnapshot(
 		ctx,
 		historyi.TransactionPolicyActive,
 	)
 	if err != nil {
-		return "", false, err
+		return "", "", false, err
 	}
 	if len(newWorkflowEventsSeq) != 1 {
-		return "", false, serviceerror.NewInternal("unable to create 1st event batch")
+		return "", "", false, serviceerror.NewInternal("unable to create 1st event batch")
 	}
 
 	createMode := persistence.CreateWorkflowModeBrandNew
@@ -246,7 +253,7 @@ func startAndSignalWithoutCurrentWorkflow(
 			newWorkflowLease.GetMutableState(),
 		)
 		if err != nil {
-			return "", false, err
+			return "", "", false, err
 		}
 	}
 	err = newWorkflowLease.GetContext().CreateWorkflowExecution(
@@ -262,14 +269,16 @@ func startAndSignalWithoutCurrentWorkflow(
 	)
 	switch failedErr := err.(type) {
 	case nil:
-		return newWorkflowLease.GetContext().GetWorkflowKey().RunID, true, nil
+		// Brand-new run: head of the chain == this run id.
+		runID := newWorkflowLease.GetContext().GetWorkflowKey().RunID
+		return runID, runID, true, nil
 	case *persistence.CurrentWorkflowConditionFailedError:
 		if _, ok := failedErr.RequestIDs[requestID]; ok {
-			return failedErr.RunID, false, nil
+			return failedErr.RunID, failedErr.FirstExecutionRunID, false, nil
 		}
-		return "", false, err
+		return "", "", false, err
 	default:
-		return "", false, err
+		return "", "", false, err
 	}
 }
 

--- a/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
+++ b/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
@@ -68,9 +68,9 @@ func startAndSignalWorkflow(
 	currentWorkflowLease api.WorkflowLease,
 	startRequest *historyservice.StartWorkflowExecutionRequest,
 	signalWithStartRequest *workflowservice.SignalWithStartWorkflowExecutionRequest,
-) (string, string, bool, error) {
+) (runID string, firstExecutionRunID string, started bool, err error) {
 	workflowID := signalWithStartRequest.GetWorkflowId()
-	runID := uuid.New().String()
+	runID = uuid.New().String()
 	// TODO(bergundy): Support eager workflow task
 	newMutableState, err := api.NewWorkflowWithSignal(
 		shard,
@@ -228,7 +228,7 @@ func startAndSignalWithoutCurrentWorkflow(
 	vrid *api.VersionedRunID,
 	newWorkflowLease api.WorkflowLease,
 	requestID string,
-) (string, string, bool, error) {
+) (runID string, firstExecutionRunID string, started bool, err error) {
 	newWorkflow, newWorkflowEventsSeq, err := newWorkflowLease.GetMutableState().CloseTransactionAsSnapshot(
 		ctx,
 		historyi.TransactionPolicyActive,
@@ -270,7 +270,7 @@ func startAndSignalWithoutCurrentWorkflow(
 	switch failedErr := err.(type) {
 	case nil:
 		// Brand-new run: head of the chain == this run id.
-		runID := newWorkflowLease.GetContext().GetWorkflowKey().RunID
+		runID = newWorkflowLease.GetContext().GetWorkflowKey().RunID
 		return runID, runID, true, nil
 	case *persistence.CurrentWorkflowConditionFailedError:
 		if _, ok := failedErr.RequestIDs[requestID]; ok {

--- a/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
+++ b/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
@@ -133,6 +133,7 @@ func startAndSignalWorkflow(
 		shard,
 		vrid,
 		newWorkflowLease,
+		currentWorkflowLease,
 		signalWithStartRequest.RequestId,
 	)
 }
@@ -227,6 +228,7 @@ func startAndSignalWithoutCurrentWorkflow(
 	shardContext historyi.ShardContext,
 	vrid *api.VersionedRunID,
 	newWorkflowLease api.WorkflowLease,
+	currentWorkflowLease api.WorkflowLease,
 	requestID string,
 ) (runID string, firstExecutionRunID string, started bool, err error) {
 	newWorkflow, newWorkflowEventsSeq, err := newWorkflowLease.GetMutableState().CloseTransactionAsSnapshot(
@@ -274,7 +276,18 @@ func startAndSignalWithoutCurrentWorkflow(
 		return runID, runID, true, nil
 	case *persistence.CurrentWorkflowConditionFailedError:
 		if _, ok := failedErr.RequestIDs[requestID]; ok {
-			return failedErr.RunID, failedErr.FirstExecutionRunID, false, nil
+			// CurrentWorkflowConditionFailedError carries the persisted WorkflowExecutionState blob,
+			// which may not have first_execution_run_id populated on records written before that
+			// field existed. Fall back to the mutable state we already have loaded to recover the
+			// canonical head-of-chain run id (mirrors StartWorkflowExecution's behavior).
+			firstRunID := failedErr.FirstExecutionRunID
+			if firstRunID == "" && currentWorkflowLease != nil &&
+				currentWorkflowLease.GetContext().GetWorkflowKey().RunID == failedErr.RunID {
+				if id, ferr := currentWorkflowLease.GetMutableState().GetFirstRunID(ctx); ferr == nil {
+					firstRunID = id
+				}
+			}
+			return failedErr.RunID, firstRunID, false, nil
 		}
 		return "", "", false, err
 	default:

--- a/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
+++ b/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
@@ -53,9 +53,14 @@ func SignalWithStartWorkflow(
 		); err != nil {
 			return startOutcome{}, err
 		}
+
+		firstExecutionRunID, err := currentWorkflowLease.GetMutableState().GetFirstRunID(ctx)
+		if err != nil {
+			return startOutcome{}, err
+		}
 		return startOutcome{
 			runID:               currentWorkflowLease.GetContext().GetWorkflowKey().RunID,
-			firstExecutionRunID: currentWorkflowLease.GetMutableState().GetExecutionState().FirstExecutionRunId,
+			firstExecutionRunID: firstExecutionRunID,
 			started:             false,
 		}, nil
 	}

--- a/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
+++ b/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
@@ -19,9 +19,17 @@ import (
 	historyi "go.temporal.io/server/service/history/interfaces"
 )
 
-// SignalWithStartWorkflow returns the run id and first-execution run id of the workflow that
-// received the signal (or was started). firstExecutionRunID may be empty when reading from a
-// pre-existing record whose ExecutionState has not been backfilled yet.
+// startOutcome describes the run that received the signal (or was started).
+type startOutcome struct {
+	// runID is the run that received the signal or was started.
+	runID string
+	// firstExecutionRunID is the head-of-chain run id. May be empty when reading from a pre-existing
+	// record whose ExecutionState has not been backfilled yet.
+	firstExecutionRunID string
+	// started is true when a new run was created rather than signaling an existing one.
+	started bool
+}
+
 func SignalWithStartWorkflow(
 	ctx context.Context,
 	shard historyi.ShardContext,
@@ -29,7 +37,7 @@ func SignalWithStartWorkflow(
 	currentWorkflowLease api.WorkflowLease,
 	startRequest *historyservice.StartWorkflowExecutionRequest,
 	signalWithStartRequest *workflowservice.SignalWithStartWorkflowExecutionRequest,
-) (runID string, firstExecutionRunID string, started bool, err error) {
+) (startOutcome, error) {
 	// workflow is running and restart was not requested, and conflict policy is to use existing
 	if currentWorkflowLease != nil &&
 		currentWorkflowLease.GetMutableState().IsWorkflowExecutionRunning() &&
@@ -43,12 +51,13 @@ func SignalWithStartWorkflow(
 			currentWorkflowLease,
 			signalWithStartRequest,
 		); err != nil {
-			return "", "", false, err
+			return startOutcome{}, err
 		}
-		return currentWorkflowLease.GetContext().GetWorkflowKey().RunID,
-			currentWorkflowLease.GetMutableState().GetExecutionState().FirstExecutionRunId,
-			false,
-			nil
+		return startOutcome{
+			runID:               currentWorkflowLease.GetContext().GetWorkflowKey().RunID,
+			firstExecutionRunID: currentWorkflowLease.GetMutableState().GetExecutionState().FirstExecutionRunId,
+			started:             false,
+		}, nil
 	}
 	// else, either workflow is not running or restart requested
 	return startAndSignalWorkflow(
@@ -68,9 +77,9 @@ func startAndSignalWorkflow(
 	currentWorkflowLease api.WorkflowLease,
 	startRequest *historyservice.StartWorkflowExecutionRequest,
 	signalWithStartRequest *workflowservice.SignalWithStartWorkflowExecutionRequest,
-) (runID string, firstExecutionRunID string, started bool, err error) {
+) (startOutcome, error) {
 	workflowID := signalWithStartRequest.GetWorkflowId()
-	runID = uuid.New().String()
+	runID := uuid.New().String()
 	// TODO(bergundy): Support eager workflow task
 	newMutableState, err := api.NewWorkflowWithSignal(
 		shard,
@@ -81,12 +90,12 @@ func startAndSignalWorkflow(
 		signalWithStartRequest,
 	)
 	if err != nil {
-		return "", "", false, err
+		return startOutcome{}, err
 	}
 
 	newWorkflowLease, err := api.NewWorkflowLeaseAndContext(nil, shard, newMutableState)
 	if err != nil {
-		return "", "", false, err
+		return startOutcome{}, err
 	}
 
 	if err = api.ValidateSignal(
@@ -97,7 +106,7 @@ func startAndSignalWorkflow(
 		signalWithStartRequest.GetHeader().Size(),
 		"SignalWithStartWorkflowExecution",
 	); err != nil {
-		return "", "", false, err
+		return startOutcome{}, err
 	}
 
 	workflowMutationFn, err := createWorkflowMutationFunction(
@@ -109,7 +118,7 @@ func startAndSignalWorkflow(
 		signalWithStartRequest.GetWorkflowIdConflictPolicy(),
 	)
 	if err != nil {
-		return "", "", false, err
+		return startOutcome{}, err
 	}
 	if workflowMutationFn != nil {
 		if err = startAndSignalWithCurrentWorkflow(
@@ -119,14 +128,14 @@ func startAndSignalWorkflow(
 			workflowMutationFn,
 			newWorkflowLease,
 		); err != nil {
-			return "", "", false, err
+			return startOutcome{}, err
 		}
 		// Started a fresh run after terminating the existing one: this run is the head of the chain.
-		return runID, runID, true, nil
+		return startOutcome{runID: runID, firstExecutionRunID: runID, started: true}, nil
 	}
 	vrid, err := createVersionedRunID(currentWorkflowLease)
 	if err != nil {
-		return "", "", false, err
+		return startOutcome{}, err
 	}
 	return startAndSignalWithoutCurrentWorkflow(
 		ctx,
@@ -230,16 +239,16 @@ func startAndSignalWithoutCurrentWorkflow(
 	newWorkflowLease api.WorkflowLease,
 	currentWorkflowLease api.WorkflowLease,
 	requestID string,
-) (runID string, firstExecutionRunID string, started bool, err error) {
+) (startOutcome, error) {
 	newWorkflow, newWorkflowEventsSeq, err := newWorkflowLease.GetMutableState().CloseTransactionAsSnapshot(
 		ctx,
 		historyi.TransactionPolicyActive,
 	)
 	if err != nil {
-		return "", "", false, err
+		return startOutcome{}, err
 	}
 	if len(newWorkflowEventsSeq) != 1 {
-		return "", "", false, serviceerror.NewInternal("unable to create 1st event batch")
+		return startOutcome{}, serviceerror.NewInternal("unable to create 1st event batch")
 	}
 
 	createMode := persistence.CreateWorkflowModeBrandNew
@@ -255,7 +264,7 @@ func startAndSignalWithoutCurrentWorkflow(
 			newWorkflowLease.GetMutableState(),
 		)
 		if err != nil {
-			return "", "", false, err
+			return startOutcome{}, err
 		}
 	}
 	err = newWorkflowLease.GetContext().CreateWorkflowExecution(
@@ -272,8 +281,8 @@ func startAndSignalWithoutCurrentWorkflow(
 	switch failedErr := err.(type) {
 	case nil:
 		// Brand-new run: head of the chain == this run id.
-		runID = newWorkflowLease.GetContext().GetWorkflowKey().RunID
-		return runID, runID, true, nil
+		runID := newWorkflowLease.GetContext().GetWorkflowKey().RunID
+		return startOutcome{runID: runID, firstExecutionRunID: runID, started: true}, nil
 	case *persistence.CurrentWorkflowConditionFailedError:
 		if _, ok := failedErr.RequestIDs[requestID]; ok {
 			// CurrentWorkflowConditionFailedError carries the persisted WorkflowExecutionState blob,
@@ -287,11 +296,11 @@ func startAndSignalWithoutCurrentWorkflow(
 					firstRunID = id
 				}
 			}
-			return failedErr.RunID, firstRunID, false, nil
+			return startOutcome{runID: failedErr.RunID, firstExecutionRunID: firstRunID, started: false}, nil
 		}
-		return "", "", false, err
+		return startOutcome{}, err
 	default:
-		return "", "", false, err
+		return startOutcome{}, err
 	}
 }
 

--- a/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
+++ b/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
@@ -164,6 +164,7 @@ func createWorkflowMutationFunction(
 		currentExecutionState.State,
 		currentExecutionState.Status,
 		currentExecutionState.RequestIds,
+		currentExecutionState.FirstExecutionRunId,
 		workflowIDReusePolicy,
 		workflowIDConflictPolicy,
 		currentWorkflowStartTime,

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -75,11 +75,13 @@ type creationParams struct {
 }
 
 // mutableStateInfo is a container for the relevant mutable state information to generate a start response with an eager
-// workflow task.
+// workflow task and to recover head-of-chain identity for legacy workflows missing
+// WorkflowExecutionState.first_execution_run_id.
 type mutableStateInfo struct {
-	branchToken  []byte
-	lastEventID  int64
-	workflowTask *historyi.WorkflowTaskInfo
+	branchToken         []byte
+	lastEventID         int64
+	workflowTask        *historyi.WorkflowTaskInfo
+	firstExecutionRunID string
 }
 
 // NewStarter creates a new starter, fails if getting the active namespace fails.
@@ -324,6 +326,15 @@ func (s *Starter) handleConflict(
 	creationParams *creationParams,
 	currentWorkflowConditionFailed *persistence.CurrentWorkflowConditionFailedError,
 ) (*historyservice.StartWorkflowExecutionResponse, StartOutcome, error) {
+	// CurrentWorkflowConditionFailedError is built from the persisted WorkflowExecutionState blob,
+	// which may not yet carry first_execution_run_id on workflows persisted before that field
+	// existed. In that case, load mutable state once to recover the canonical head-of-chain run id
+	// (which checks ExecutionState, then ExecutionInfo, then the WorkflowExecutionStarted event).
+	if currentWorkflowConditionFailed.FirstExecutionRunID == "" && currentWorkflowConditionFailed.RunID != "" {
+		if info, err := s.getMutableStateInfo(ctx, currentWorkflowConditionFailed.RunID); err == nil {
+			currentWorkflowConditionFailed.FirstExecutionRunID = info.firstExecutionRunID
+		}
+	}
 	request := s.request.StartRequest
 	currentWorkflowRequestIDs := currentWorkflowConditionFailed.RequestIDs
 	if requestIDInfo, ok := currentWorkflowRequestIDs[request.GetRequestId()]; ok {
@@ -495,7 +506,7 @@ func (s *Starter) resolveDuplicateWorkflowID(
 
 			// extract information from MutableState in case this is an eager start
 			mutableState := workflowLease.GetMutableState()
-			mutableStateInfo, err = extractMutableStateInfo(mutableState)
+			mutableStateInfo, err = extractMutableStateInfo(ctx, mutableState)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -605,11 +616,13 @@ func (s *Starter) getMutableStateInfo(ctx context.Context, runID string) (_ *mut
 		return nil, err
 	}
 
-	return extractMutableStateInfo(ms)
+	return extractMutableStateInfo(ctx, ms)
 }
 
-// extractMutableStateInfo extracts the relevant information to generate a start response with an eager workflow task.
-func extractMutableStateInfo(mutableState historyi.MutableState) (*mutableStateInfo, error) {
+// extractMutableStateInfo extracts the relevant information to generate a start response with an eager workflow task
+// and recovers the head-of-chain run id (used by the dedup / conflict path for legacy workflows whose
+// persisted WorkflowExecutionState predates first_execution_run_id).
+func extractMutableStateInfo(ctx context.Context, mutableState historyi.MutableState) (*mutableStateInfo, error) {
 	branchToken, err := mutableState.GetCurrentBranchToken()
 	if err != nil {
 		return nil, err
@@ -624,10 +637,16 @@ func extractMutableStateInfo(mutableState historyi.MutableState) (*mutableStateI
 		workflowTask = *workflowTaskSource
 	}
 
+	firstRunID, err := mutableState.GetFirstRunID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	return &mutableStateInfo{
-		branchToken:  branchToken,
-		lastEventID:  mutableState.GetNextEventID() - 1,
-		workflowTask: &workflowTask,
+		branchToken:         branchToken,
+		lastEventID:         mutableState.GetNextEventID() - 1,
+		workflowTask:        &workflowTask,
+		firstExecutionRunID: firstRunID,
 	}, nil
 }
 

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -223,6 +223,7 @@ func (s *Starter) Invoke(
 
 	resp, err = s.generateResponse(
 		creationParams.runID,
+		creationParams.runID, // brand-new chain: first == current run
 		creationParams.workflowTaskInfo,
 		extractHistoryEvents(creationParams.workflowEventBatches),
 	)
@@ -329,7 +330,7 @@ func (s *Starter) handleConflict(
 		metrics.StartWorkflowRequestDeduped.With(s.getMetricsHandler()).Record(1)
 
 		if requestIDInfo.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED {
-			resp, err := s.respondToRetriedRequest(ctx, currentWorkflowConditionFailed.RunID)
+			resp, err := s.respondToRetriedRequest(ctx, currentWorkflowConditionFailed.RunID, currentWorkflowConditionFailed.FirstExecutionRunID)
 			if resp != nil {
 				resp.Status = currentWorkflowConditionFailed.Status
 			}
@@ -337,10 +338,11 @@ func (s *Starter) handleConflict(
 		}
 
 		resp := &historyservice.StartWorkflowExecutionResponse{
-			RunId:   currentWorkflowConditionFailed.RunID,
-			Started: false,
-			Status:  currentWorkflowConditionFailed.Status,
-			Link:    s.generateRequestIdRefLink(currentWorkflowConditionFailed.RunID),
+			RunId:               currentWorkflowConditionFailed.RunID,
+			FirstExecutionRunId: currentWorkflowConditionFailed.FirstExecutionRunID,
+			Started:             false,
+			Status:              currentWorkflowConditionFailed.Status,
+			Link:                s.generateRequestIdRefLink(currentWorkflowConditionFailed.RunID),
 		}
 		return resp, StartDeduped, nil
 	}
@@ -361,6 +363,7 @@ func (s *Starter) handleConflict(
 	}
 	resp, err := s.generateResponse(
 		creationParams.runID,
+		creationParams.runID, // brand-new chain after replacing current
 		creationParams.workflowTaskInfo,
 		extractHistoryEvents(creationParams.workflowEventBatches),
 	)
@@ -440,6 +443,7 @@ func (s *Starter) resolveDuplicateWorkflowID(
 		currentWorkflowConditionFailed.State,
 		currentWorkflowConditionFailed.Status,
 		currentWorkflowConditionFailed.RequestIDs,
+		currentWorkflowConditionFailed.FirstExecutionRunID,
 		s.request.StartRequest.GetWorkflowIdReusePolicy(),
 		s.request.StartRequest.GetWorkflowIdConflictPolicy(),
 		currentWorkflowStartTime,
@@ -509,17 +513,18 @@ func (s *Starter) resolveDuplicateWorkflowID(
 	case nil:
 		if !s.requestEagerStart() {
 			return &historyservice.StartWorkflowExecutionResponse{
-				RunId:   newRunID,
-				Started: true,
-				Status:  enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-				Link:    s.generateStartedEventRefLink(newRunID),
+				RunId:               newRunID,
+				FirstExecutionRunId: newRunID,
+				Started:             true,
+				Status:              enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+				Link:                s.generateStartedEventRefLink(newRunID),
 			}, StartNew, nil
 		}
 		events, err := s.getWorkflowHistory(ctx, mutableStateInfo)
 		if err != nil {
 			return nil, StartErr, err
 		}
-		resp, err := s.generateResponse(newRunID, mutableStateInfo.workflowTask, events)
+		resp, err := s.generateResponse(newRunID, newRunID, mutableStateInfo.workflowTask, events)
 		return resp, StartNew, err
 	case consts.ErrWorkflowCompleted:
 		// Exit and retry again from the top.
@@ -538,11 +543,13 @@ func (s *Starter) resolveDuplicateWorkflowID(
 func (s *Starter) respondToRetriedRequest(
 	ctx context.Context,
 	runID string,
+	firstExecutionRunID string,
 ) (*historyservice.StartWorkflowExecutionResponse, error) {
 	if !s.requestEagerStart() {
 		return &historyservice.StartWorkflowExecutionResponse{
-			RunId:   runID,
-			Started: true,
+			RunId:               runID,
+			FirstExecutionRunId: firstExecutionRunID,
+			Started:             true,
 			// Status is set by caller
 			Link: s.generateStartedEventRefLink(runID),
 		}, nil
@@ -561,8 +568,9 @@ func (s *Starter) respondToRetriedRequest(
 			Record(1, metrics.ReasonTag(eagerStartDeniedReasonTaskAlreadyDispatched))
 
 		return &historyservice.StartWorkflowExecutionResponse{
-			RunId:   runID,
-			Started: true,
+			RunId:               runID,
+			FirstExecutionRunId: firstExecutionRunID,
+			Started:             true,
 			// Status is set by caller
 			Link: s.generateStartedEventRefLink(runID),
 		}, nil
@@ -573,7 +581,7 @@ func (s *Starter) respondToRetriedRequest(
 		return nil, err
 	}
 
-	return s.generateResponse(runID, mutableStateInfo.workflowTask, events)
+	return s.generateResponse(runID, firstExecutionRunID, mutableStateInfo.workflowTask, events)
 }
 
 // getMutableStateInfo gets the relevant mutable state information while getting the state for the given run from the
@@ -707,10 +715,11 @@ func (s *Starter) handleUseExistingWorkflowOnConflictOptions(
 	switch err {
 	case nil:
 		resp := &historyservice.StartWorkflowExecutionResponse{
-			RunId:   workflowKey.RunID,
-			Started: false, // set explicitly for emphasis
-			Status:  enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-			Link:    responseLink,
+			RunId:               workflowKey.RunID,
+			FirstExecutionRunId: currentWorkflowConditionFailed.FirstExecutionRunID,
+			Started:             false, // set explicitly for emphasis
+			Status:              enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			Link:                responseLink,
 		}
 		return resp, StartReused, nil
 	case consts.ErrWorkflowCompleted:
@@ -723,6 +732,7 @@ func (s *Starter) handleUseExistingWorkflowOnConflictOptions(
 			s.namespace,
 			currentWorkflowConditionFailed.Status,
 			currentWorkflowConditionFailed.RequestIDs,
+			currentWorkflowConditionFailed.FirstExecutionRunID,
 			s.request.StartRequest.GetWorkflowIdReusePolicy(),
 			currentWorkflowStartTime,
 		)
@@ -751,9 +761,12 @@ func extractHistoryEvents(persistenceEvents []*persistence.WorkflowEvents) []*hi
 }
 
 // generateResponse is a helper for generating StartWorkflowExecutionResponse for eager and non-eager workflow start
-// requests.
+// requests. firstExecutionRunID should be the run id of the first execution in the chain (equals
+// runID for brand-new starts). Empty when the server could not determine it from persistence; do
+// not assume RunId in that case.
 func (s *Starter) generateResponse(
 	runID string,
+	firstExecutionRunID string,
 	workflowTaskInfo *historyi.WorkflowTaskInfo,
 	historyEvents []*historypb.HistoryEvent,
 ) (*historyservice.StartWorkflowExecutionResponse, error) {
@@ -764,10 +777,11 @@ func (s *Starter) generateResponse(
 
 	if !s.requestEagerStart() {
 		return &historyservice.StartWorkflowExecutionResponse{
-			RunId:   runID,
-			Started: true,
-			Status:  enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-			Link:    s.generateStartedEventRefLink(runID),
+			RunId:               runID,
+			FirstExecutionRunId: firstExecutionRunID,
+			Started:             true,
+			Status:              enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			Link:                s.generateStartedEventRefLink(runID),
 		}, nil
 	}
 
@@ -792,11 +806,12 @@ func (s *Starter) generateResponse(
 		return nil, err
 	}
 	return &historyservice.StartWorkflowExecutionResponse{
-		RunId:   runID,
-		Clock:   clock,
-		Started: true,
-		Status:  enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		Link:    s.generateStartedEventRefLink(runID),
+		RunId:               runID,
+		FirstExecutionRunId: firstExecutionRunID,
+		Clock:               clock,
+		Started:             true,
+		Status:              enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+		Link:                s.generateStartedEventRefLink(runID),
 		EagerWorkflowTask: &workflowservice.PollWorkflowTaskQueueResponse{
 			TaskToken:         serializedToken,
 			WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: workflowID, RunId: runID},

--- a/service/history/api/workflow_id_dedup.go
+++ b/service/history/api/workflow_id_dedup.go
@@ -37,6 +37,7 @@ func ResolveDuplicateWorkflowID(
 	currentState enumsspb.WorkflowExecutionState,
 	currentStatus enumspb.WorkflowExecutionStatus,
 	currentRequestIDs map[string]*persistencespb.RequestIDInfo,
+	currentFirstExecutionRunID string,
 	wfIDReusePolicy enumspb.WorkflowIdReusePolicy,
 	wfIDConflictPolicy enumspb.WorkflowIdConflictPolicy,
 	currentWorkflowStartTime time.Time,
@@ -53,6 +54,7 @@ func ResolveDuplicateWorkflowID(
 			namespaceEntry,
 			newRunID,
 			currentRequestIDs,
+			currentFirstExecutionRunID,
 			wfIDConflictPolicy,
 			currentWorkflowStartTime,
 			parentExecutionInfo,
@@ -68,6 +70,7 @@ func ResolveDuplicateWorkflowID(
 			namespaceEntry,
 			currentStatus,
 			currentRequestIDs,
+			currentFirstExecutionRunID,
 			wfIDReusePolicy,
 			currentWorkflowStartTime,
 		)
@@ -86,6 +89,7 @@ func ResolveWorkflowIDConflictPolicy(
 	namespaceEntry *namespace.Namespace,
 	newRunID string,
 	currentRequestIDs map[string]*persistencespb.RequestIDInfo,
+	currentFirstExecutionRunID string,
 	wfIDConflictPolicy enumspb.WorkflowIdConflictPolicy,
 	currentWorkflowStartTime time.Time,
 	parentExecutionInfo *workflowspb.ParentExecutionInfo,
@@ -94,7 +98,7 @@ func ResolveWorkflowIDConflictPolicy(
 	switch wfIDConflictPolicy { //nolint:exhaustive
 	case enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL:
 		msg := "Workflow execution is already running. WorkflowId: %v, RunId: %v."
-		return nil, generateWorkflowAlreadyStartedError(msg, currentRequestIDs, workflowKey)
+		return nil, generateWorkflowAlreadyStartedError(msg, currentRequestIDs, workflowKey, currentFirstExecutionRunID)
 	case enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING:
 		return nil, ErrUseCurrentExecution
 	case enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING:
@@ -112,6 +116,7 @@ func ResolveWorkflowIDReusePolicy(
 	namespaceEntry *namespace.Namespace,
 	currentStatus enumspb.WorkflowExecutionStatus,
 	currentRequestIDs map[string]*persistencespb.RequestIDInfo,
+	currentFirstExecutionRunID string,
 	wfIDReusePolicy enumspb.WorkflowIdReusePolicy,
 	currentWorkflowStartTime time.Time,
 ) error {
@@ -121,11 +126,11 @@ func ResolveWorkflowIDReusePolicy(
 	case enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY:
 		if _, ok := consts.FailedWorkflowStatuses[currentStatus]; !ok {
 			msg := "Workflow execution already finished successfully. WorkflowId: %v, RunId: %v. Workflow Id reuse policy: allow duplicate workflow Id if last run failed."
-			return generateWorkflowAlreadyStartedError(msg, currentRequestIDs, workflowKey)
+			return generateWorkflowAlreadyStartedError(msg, currentRequestIDs, workflowKey, currentFirstExecutionRunID)
 		}
 	case enumspb.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE:
 		msg := "Workflow execution already finished. WorkflowId: %v, RunId: %v. Workflow Id reuse policy: reject duplicate workflow Id."
-		return generateWorkflowAlreadyStartedError(msg, currentRequestIDs, workflowKey)
+		return generateWorkflowAlreadyStartedError(msg, currentRequestIDs, workflowKey, currentFirstExecutionRunID)
 	default:
 		return serviceerror.NewInternal(
 			fmt.Sprintf("Failed to process start workflow id reuse policy: %v.", wfIDReusePolicy),
@@ -234,6 +239,7 @@ func generateWorkflowAlreadyStartedError(
 	errMsg string,
 	requestIDs map[string]*persistencespb.RequestIDInfo,
 	workflowKey definition.WorkflowKey,
+	firstExecutionRunID string,
 ) error {
 	createRequestID := ""
 	for requestID, info := range requestIDs {
@@ -241,10 +247,13 @@ func generateWorkflowAlreadyStartedError(
 			createRequestID = requestID
 		}
 	}
-	return serviceerror.NewWorkflowExecutionAlreadyStarted(
+	// firstExecutionRunID may be empty for records written before WorkflowExecutionState.first_execution_run_id
+	// existed. In that case return empty rather than guessing — callers must not assume RunId.
+	return serviceerror.NewWorkflowExecutionAlreadyStartedWithFirstExecutionRunId(
 		fmt.Sprintf(errMsg, workflowKey.WorkflowID, workflowKey.RunID),
 		createRequestID,
 		workflowKey.RunID,
+		firstExecutionRunID,
 	)
 }
 

--- a/service/history/history_engine2_test.go
+++ b/service/history/history_engine2_test.go
@@ -1575,11 +1575,12 @@ func makeCurrentWorkflowConditionFailedError(
 				EventId:   common.BufferedEventID,
 			},
 		},
-		RunID:            tv.RunID(),
-		State:            enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING,
-		Status:           enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		LastWriteVersion: lastWriteVersion,
-		StartTime:        timestamp.TimeValuePtr(startTime),
+		RunID:               tv.RunID(),
+		FirstExecutionRunID: tv.RunID(),
+		State:               enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING,
+		Status:              enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+		LastWriteVersion:    lastWriteVersion,
+		StartTime:           timestamp.TimeValuePtr(startTime),
 	}
 }
 
@@ -1785,11 +1786,12 @@ func (s *engine2Suite) TestStartWorkflowExecution_Dedup() {
 						EventId:   common.FirstEventID,
 					},
 				},
-				RunID:            prevRunID,
-				State:            enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
-				Status:           enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
-				LastWriteVersion: lastWriteVersion,
-				StartTime:        nil,
+				RunID:               prevRunID,
+				FirstExecutionRunID: prevRunID,
+				State:               enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
+				Status:              enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+				LastWriteVersion:    lastWriteVersion,
+				StartTime:           nil,
 			}
 		}
 
@@ -1891,11 +1893,12 @@ func (s *engine2Suite) TestStartWorkflowExecution_Dedup() {
 								EventId:   common.FirstEventID,
 							},
 						},
-						RunID:            prevRunID,
-						State:            enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
-						Status:           status,
-						LastWriteVersion: lastWriteVersion,
-						StartTime:        nil,
+						RunID:               prevRunID,
+						FirstExecutionRunID: prevRunID,
+						State:               enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
+						Status:              status,
+						LastWriteVersion:    lastWriteVersion,
+						StartTime:           nil,
 					}
 				}
 

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -515,17 +515,17 @@ func NewMutableStateFromDB(
 		mutableState.totalTombstones += len(tombstoneBatch.StateMachineTombstones)
 	}
 
+	// FirstExecutionRunId was duplicated from ExecutionInfo onto ExecutionState so the dedup /
+	// conflict path can surface it without loading ExecutionInfo. Backfill in memory for records
+	// written before that change so the next persist writes it through.
+	if dbRecord.ExecutionState.FirstExecutionRunId == "" && dbRecord.ExecutionInfo.FirstExecutionRunId != "" {
+		dbRecord.ExecutionState.FirstExecutionRunId = dbRecord.ExecutionInfo.FirstExecutionRunId
+	}
+
 	mutableState.approximateSize += dbRecord.ExecutionState.Size() - mutableState.executionState.Size()
 	mutableState.executionState = dbRecord.ExecutionState
 	mutableState.approximateSize += dbRecord.ExecutionInfo.Size() - mutableState.executionInfo.Size()
 	mutableState.executionInfo = dbRecord.ExecutionInfo
-
-	// FirstExecutionRunId was duplicated from ExecutionInfo onto ExecutionState so the dedup /
-	// conflict path can surface it without loading ExecutionInfo. Backfill in memory for records
-	// written before that change so the next persist writes it through.
-	if mutableState.executionState.FirstExecutionRunId == "" && mutableState.executionInfo.FirstExecutionRunId != "" {
-		mutableState.executionState.FirstExecutionRunId = mutableState.executionInfo.FirstExecutionRunId
-	}
 
 	// StartTime was moved from ExecutionInfo to executionState
 	if mutableState.executionState.StartTime == nil && dbRecord.ExecutionInfo.StartTime != nil {

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -520,6 +520,13 @@ func NewMutableStateFromDB(
 	mutableState.approximateSize += dbRecord.ExecutionInfo.Size() - mutableState.executionInfo.Size()
 	mutableState.executionInfo = dbRecord.ExecutionInfo
 
+	// FirstExecutionRunId was duplicated from ExecutionInfo onto ExecutionState so the dedup /
+	// conflict path can surface it without loading ExecutionInfo. Backfill in memory for records
+	// written before that change so the next persist writes it through.
+	if mutableState.executionState.FirstExecutionRunId == "" && mutableState.executionInfo.FirstExecutionRunId != "" {
+		mutableState.executionState.FirstExecutionRunId = mutableState.executionInfo.FirstExecutionRunId
+	}
+
 	// StartTime was moved from ExecutionInfo to executionState
 	if mutableState.executionState.StartTime == nil && dbRecord.ExecutionInfo.StartTime != nil {
 		mutableState.executionState.StartTime = dbRecord.ExecutionInfo.StartTime

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -1990,10 +1990,10 @@ func (ms *MutableStateImpl) GetFirstRunID(
 	// Prefer the canonical source on ExecutionState; the equivalent field on ExecutionInfo is
 	// deprecated. NewMutableStateFromDB backfills ExecutionState from ExecutionInfo on load, so
 	// records that pre-date the ExecutionState field also resolve here.
-	if firstRunID := ms.executionState.FirstExecutionRunId; len(firstRunID) != 0 {
+	if firstRunID := ms.executionState.FirstExecutionRunId; firstRunID != "" {
 		return firstRunID, nil
 	}
-	if firstRunID := ms.executionInfo.FirstExecutionRunId; len(firstRunID) != 0 {
+	if firstRunID := ms.executionInfo.FirstExecutionRunId; firstRunID != "" {
 		return firstRunID, nil
 	}
 	// Workflows created with Temporal release v0.28.0 or earlier don't have FirstExecutionRunID

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -2984,6 +2984,7 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionStartedEvent(
 	ms.executionInfo.OriginalExecutionRunId = event.GetOriginalExecutionRunId()
 
 	ms.approximateSize -= ms.executionState.Size()
+	ms.executionState.FirstExecutionRunId = event.GetFirstExecutionRunId()
 	if err := ms.addCompletionCallbacks(
 		startEvent,
 		requestID,

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -1987,13 +1987,17 @@ func (ms *MutableStateImpl) GetStartEvent(
 func (ms *MutableStateImpl) GetFirstRunID(
 	ctx context.Context,
 ) (string, error) {
-	firstRunID := ms.executionInfo.FirstExecutionRunId
-	// This is needed for backwards compatibility.  Workflow execution create with Temporal release v0.28.0 or earlier
-	// does not have FirstExecutionRunID stored as part of mutable state.  If this is not set then load it from
-	// workflow execution started event.
-	if len(firstRunID) != 0 {
+	// Prefer the canonical source on ExecutionState; the equivalent field on ExecutionInfo is
+	// deprecated. NewMutableStateFromDB backfills ExecutionState from ExecutionInfo on load, so
+	// records that pre-date the ExecutionState field also resolve here.
+	if firstRunID := ms.executionState.FirstExecutionRunId; len(firstRunID) != 0 {
 		return firstRunID, nil
 	}
+	if firstRunID := ms.executionInfo.FirstExecutionRunId; len(firstRunID) != 0 {
+		return firstRunID, nil
+	}
+	// Workflows created with Temporal release v0.28.0 or earlier don't have FirstExecutionRunID
+	// stored as part of mutable state — load it from the WorkflowExecutionStarted event.
 	currentStartEvent, err := ms.GetStartEvent(ctx)
 	if err != nil {
 		return "", err

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -5861,10 +5861,11 @@ func (s *mutableStateSuite) buildSnapshot(state *MutableStateImpl) *persistences
 			WorkflowTaskLastUpdateVersionedTransition:     state.executionInfo.WorkflowTaskLastUpdateVersionedTransition,
 		},
 		ExecutionState: &persistencespb.WorkflowExecutionState{
-			RunId:     state.executionState.RunId,
-			State:     enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING,
-			Status:    enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-			StartTime: state.executionState.StartTime,
+			RunId:               state.executionState.RunId,
+			State:               enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING,
+			Status:              enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			StartTime:           state.executionState.StartTime,
+			FirstExecutionRunId: state.executionState.FirstExecutionRunId,
 		},
 		NextEventId: 103,
 	}

--- a/tests/continue_as_new_test.go
+++ b/tests/continue_as_new_test.go
@@ -26,6 +26,7 @@ import (
 	"go.temporal.io/server/common/testing/taskpoller"
 	"go.temporal.io/server/common/testing/testvars"
 	"go.temporal.io/server/tests/testcore"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
@@ -1106,11 +1107,11 @@ func (s *ContinueAsNewTestSuite) TestStartAfterContinueAsNew_FirstExecutionRunId
 
 	// Drive exactly one CAN. After the WT completes, the second run is RUNNING with no further
 	// pollers, so the subsequent StartWorkflowExecution calls below land on a live workflow.
-	didCAN := false
-	wtHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
-		if !didCAN {
-			didCAN = true
-			return []*commandpb.Command{{
+	tv := testvars.New(s.T()).WithTaskQueue(tl)
+	poller := taskpoller.New(s.T(), env.FrontendClient(), env.Namespace().String())
+	_, err = poller.PollAndHandleWorkflowTask(tv, func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{
+			Commands: []*commandpb.Command{{
 				CommandType: enumspb.COMMAND_TYPE_CONTINUE_AS_NEW_WORKFLOW_EXECUTION,
 				Attributes: &commandpb.Command_ContinueAsNewWorkflowExecutionCommandAttributes{
 					ContinueAsNewWorkflowExecutionCommandAttributes: &commandpb.ContinueAsNewWorkflowExecutionCommandAttributes{
@@ -1120,27 +1121,9 @@ func (s *ContinueAsNewTestSuite) TestStartAfterContinueAsNew_FirstExecutionRunId
 						WorkflowTaskTimeout: durationpb.New(10 * time.Second),
 					},
 				},
-			}}, nil
-		}
-		return []*commandpb.Command{{
-			CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
-			Attributes: &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{
-				CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{
-					Result: payloads.EncodeString("done"),
-				},
-			},
-		}}, nil
-	}
-	poller := &testcore.TaskPoller{
-		Client:              env.FrontendClient(),
-		Namespace:           env.Namespace().String(),
-		TaskQueue:           taskQueue,
-		Identity:            identity,
-		WorkflowTaskHandler: wtHandler,
-		Logger:              env.Logger,
-		T:                   s.T(),
-	}
-	_, err = poller.PollAndProcessWorkflowTask()
+			}},
+		}, nil
+	})
 	s.NoError(err)
 
 	// Confirm the post-CAN run is current and distinct from the original.
@@ -1154,20 +1137,20 @@ func (s *ContinueAsNewTestSuite) TestStartAfterContinueAsNew_FirstExecutionRunId
 	s.Equal(we0.RunId, descResp.WorkflowExecutionInfo.GetFirstRunId())
 
 	// FAIL conflict policy: error should expose the original run id as the first execution run id.
-	failReq := *startReq
+	failReq := proto.Clone(startReq).(*workflowservice.StartWorkflowExecutionRequest)
 	failReq.RequestId = uuid.NewString()
 	failReq.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL
-	_, err = env.FrontendClient().StartWorkflowExecution(s.Context(), &failReq)
+	_, err = env.FrontendClient().StartWorkflowExecution(s.Context(), failReq)
 	var already *serviceerror.WorkflowExecutionAlreadyStarted
 	s.ErrorAs(err, &already)
 	s.Equal(currentRunID, already.RunId, "AlreadyStarted error should reference the current run")
 	s.Equal(we0.RunId, already.FirstExecutionRunId, "AlreadyStarted error should expose head-of-chain run id")
 
 	// USE_EXISTING dedup: response carries the original run id as first_execution_run_id.
-	useExistingReq := *startReq
+	useExistingReq := proto.Clone(startReq).(*workflowservice.StartWorkflowExecutionRequest)
 	useExistingReq.RequestId = uuid.NewString()
 	useExistingReq.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING
-	we2, err := env.FrontendClient().StartWorkflowExecution(s.Context(), &useExistingReq)
+	we2, err := env.FrontendClient().StartWorkflowExecution(s.Context(), useExistingReq)
 	s.NoError(err)
 	s.False(we2.Started)
 	s.Equal(currentRunID, we2.RunId)

--- a/tests/continue_as_new_test.go
+++ b/tests/continue_as_new_test.go
@@ -1072,3 +1072,104 @@ func (s *ContinueAsNewTestSuite) TestContinueAsNewWithInternalTaskQueue_Blocked(
 	}
 	s.True(foundTaskFailed, "WorkflowTaskFailed event should be recorded")
 }
+
+// TestStartAfterContinueAsNew_FirstExecutionRunId verifies that once a workflow has been continued
+// as new, subsequent StartWorkflowExecution calls (both the USE_EXISTING response and the FAIL
+// WorkflowExecutionAlreadyStarted error) report the original (head-of-chain) run id in
+// first_execution_run_id, even though the current run id is the post-CAN run.
+func (s *ContinueAsNewTestSuite) TestStartAfterContinueAsNew_FirstExecutionRunId() {
+	env := testcore.NewEnv(s.T())
+	env.OverrideDynamicConfig(dynamicconfig.WorkflowIdReuseMinimalInterval, time.Duration(0))
+
+	id := "functional-start-after-can-first-run-test"
+	wt := "functional-start-after-can-first-run-test-type"
+	tl := "functional-start-after-can-first-run-test-taskqueue"
+	identity := "worker1"
+
+	workflowType := &commonpb.WorkflowType{Name: wt}
+	taskQueue := &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
+
+	startReq := &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           uuid.NewString(),
+		Namespace:           env.Namespace().String(),
+		WorkflowId:          id,
+		WorkflowType:        workflowType,
+		TaskQueue:           taskQueue,
+		WorkflowRunTimeout:  durationpb.New(100 * time.Second),
+		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+		Identity:            identity,
+	}
+
+	we0, err := env.FrontendClient().StartWorkflowExecution(s.Context(), startReq)
+	s.NoError(err)
+	s.Equal(we0.RunId, we0.FirstExecutionRunId, "brand-new start should set FirstExecutionRunId to RunId")
+
+	// Drive exactly one CAN. After the WT completes, the second run is RUNNING with no further
+	// pollers, so the subsequent StartWorkflowExecution calls below land on a live workflow.
+	didCAN := false
+	wtHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
+		if !didCAN {
+			didCAN = true
+			return []*commandpb.Command{{
+				CommandType: enumspb.COMMAND_TYPE_CONTINUE_AS_NEW_WORKFLOW_EXECUTION,
+				Attributes: &commandpb.Command_ContinueAsNewWorkflowExecutionCommandAttributes{
+					ContinueAsNewWorkflowExecutionCommandAttributes: &commandpb.ContinueAsNewWorkflowExecutionCommandAttributes{
+						WorkflowType:        workflowType,
+						TaskQueue:           taskQueue,
+						WorkflowRunTimeout:  durationpb.New(100 * time.Second),
+						WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+					},
+				},
+			}}, nil
+		}
+		return []*commandpb.Command{{
+			CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
+			Attributes: &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{
+				CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{
+					Result: payloads.EncodeString("done"),
+				},
+			},
+		}}, nil
+	}
+	poller := &testcore.TaskPoller{
+		Client:              env.FrontendClient(),
+		Namespace:           env.Namespace().String(),
+		TaskQueue:           taskQueue,
+		Identity:            identity,
+		WorkflowTaskHandler: wtHandler,
+		Logger:              env.Logger,
+		T:                   s.T(),
+	}
+	_, err = poller.PollAndProcessWorkflowTask()
+	s.NoError(err)
+
+	// Confirm the post-CAN run is current and distinct from the original.
+	descResp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: id},
+	})
+	s.NoError(err)
+	currentRunID := descResp.WorkflowExecutionInfo.Execution.GetRunId()
+	s.NotEqual(we0.RunId, currentRunID, "post-CAN run id should differ from original")
+	s.Equal(we0.RunId, descResp.WorkflowExecutionInfo.GetFirstRunId())
+
+	// FAIL conflict policy: error should expose the original run id as the first execution run id.
+	failReq := *startReq
+	failReq.RequestId = uuid.NewString()
+	failReq.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL
+	_, err = env.FrontendClient().StartWorkflowExecution(s.Context(), &failReq)
+	var already *serviceerror.WorkflowExecutionAlreadyStarted
+	s.ErrorAs(err, &already)
+	s.Equal(currentRunID, already.RunId, "AlreadyStarted error should reference the current run")
+	s.Equal(we0.RunId, already.FirstExecutionRunId, "AlreadyStarted error should expose head-of-chain run id")
+
+	// USE_EXISTING dedup: response carries the original run id as first_execution_run_id.
+	useExistingReq := *startReq
+	useExistingReq.RequestId = uuid.NewString()
+	useExistingReq.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING
+	we2, err := env.FrontendClient().StartWorkflowExecution(s.Context(), &useExistingReq)
+	s.NoError(err)
+	s.False(we2.Started)
+	s.Equal(currentRunID, we2.RunId)
+	s.Equal(we0.RunId, we2.FirstExecutionRunId)
+}

--- a/tests/continue_as_new_test.go
+++ b/tests/continue_as_new_test.go
@@ -1156,3 +1156,209 @@ func (s *ContinueAsNewTestSuite) TestStartAfterContinueAsNew_FirstExecutionRunId
 	s.Equal(currentRunID, we2.RunId)
 	s.Equal(we0.RunId, we2.FirstExecutionRunId)
 }
+
+// TestResetOfNonCurrentRunFromDifferentChain_FirstExecutionRunId covers the interesting case where
+// the workflow has two distinct chains (chain 1: original run A; chain 2: a fresh start B after A
+// terminated), and the caller resets A — a non-current run from a *different* chain than the
+// currently-current B. The reset run D inherits its first_execution_run_id from A's chain (A),
+// not from B. After the reset, dedup responses against the workflow id should report A as the
+// FirstExecutionRunId, even though the workflow's most recent prior chain head was B.
+func (s *ContinueAsNewTestSuite) TestResetOfNonCurrentRunFromDifferentChain_FirstExecutionRunId() {
+	env := testcore.NewEnv(s.T())
+	env.OverrideDynamicConfig(dynamicconfig.WorkflowIdReuseMinimalInterval, time.Duration(0))
+
+	id := "functional-reset-non-current-different-chain-test"
+	wt := "functional-reset-non-current-different-chain-test-type"
+	tl := "functional-reset-non-current-different-chain-test-taskqueue"
+	identity := "worker1"
+
+	workflowType := &commonpb.WorkflowType{Name: wt}
+	taskQueue := &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
+
+	// Chain 1: start run A and complete it.
+	chain1Req := &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           uuid.NewString(),
+		Namespace:           env.Namespace().String(),
+		WorkflowId:          id,
+		WorkflowType:        workflowType,
+		TaskQueue:           taskQueue,
+		WorkflowRunTimeout:  durationpb.New(100 * time.Second),
+		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+		Identity:            identity,
+	}
+	we0, err := env.FrontendClient().StartWorkflowExecution(s.Context(), chain1Req)
+	s.NoError(err)
+	chain1RunID := we0.RunId
+
+	tv := testvars.New(s.T()).WithTaskQueue(tl)
+	poller := taskpoller.New(s.T(), env.FrontendClient(), env.Namespace().String())
+	_, err = poller.PollAndHandleWorkflowTask(tv, func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{
+			Commands: []*commandpb.Command{{
+				CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
+				Attributes: &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{
+					CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{
+						Result: payloads.EncodeString("chain1-done"),
+					},
+				},
+			}},
+		}, nil
+	})
+	s.NoError(err)
+
+	// Chain 2: start run B as a brand-new chain (chain1's run is already completed, so this is a
+	// new chain with B as its head).
+	chain2Req := proto.Clone(chain1Req).(*workflowservice.StartWorkflowExecutionRequest)
+	chain2Req.RequestId = uuid.NewString()
+	we1, err := env.FrontendClient().StartWorkflowExecution(s.Context(), chain2Req)
+	s.NoError(err)
+	chain2RunID := we1.RunId
+	s.NotEqual(chain1RunID, chain2RunID)
+	s.Equal(chain2RunID, we1.FirstExecutionRunId, "chain 2 run B should be its own chain head")
+
+	// Sanity: workflow's current chain head is B.
+	desc, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: id},
+	})
+	s.NoError(err)
+	s.Equal(chain2RunID, desc.WorkflowExecutionInfo.Execution.GetRunId())
+	s.Equal(chain2RunID, desc.WorkflowExecutionInfo.GetFirstRunId())
+
+	// Locate the WorkflowTaskCompleted event in chain1's history to use as reset point.
+	chain1Events := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: id, RunId: chain1RunID})
+	var wtCompletedEventID int64
+	for _, ev := range chain1Events {
+		if ev.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED {
+			wtCompletedEventID = ev.GetEventId()
+		}
+	}
+	s.NotZero(wtCompletedEventID)
+
+	// Reset chain1's non-current run A → produces a new run D that inherits A's chain head.
+	resetResp, err := env.FrontendClient().ResetWorkflowExecution(s.Context(), &workflowservice.ResetWorkflowExecutionRequest{
+		Namespace:                 env.Namespace().String(),
+		WorkflowExecution:         &commonpb.WorkflowExecution{WorkflowId: id, RunId: chain1RunID},
+		Reason:                    "reset non-current run from different chain",
+		WorkflowTaskFinishEventId: wtCompletedEventID,
+		RequestId:                 uuid.NewString(),
+	})
+	s.NoError(err)
+	resetRunID := resetResp.RunId
+	s.NotEqual(chain1RunID, resetRunID)
+	s.NotEqual(chain2RunID, resetRunID)
+
+	// After reset, workflow's chain head switches from chain 2's head (B) back to chain 1's head (A).
+	desc, err = env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: id},
+	})
+	s.NoError(err)
+	s.Equal(resetRunID, desc.WorkflowExecutionInfo.Execution.GetRunId())
+	s.Equal(chain1RunID, desc.WorkflowExecutionInfo.GetFirstRunId(), "reset run should inherit chain1's head, not chain2's")
+
+	// USE_EXISTING dedup against the reset run: FirstExecutionRunId tracks the reset's chain (A),
+	// not the prior chain (B).
+	useExistingReq := proto.Clone(chain1Req).(*workflowservice.StartWorkflowExecutionRequest)
+	useExistingReq.RequestId = uuid.NewString()
+	useExistingReq.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING
+	we2, err := env.FrontendClient().StartWorkflowExecution(s.Context(), useExistingReq)
+	s.NoError(err)
+	s.False(we2.Started)
+	s.Equal(resetRunID, we2.RunId)
+	s.Equal(chain1RunID, we2.FirstExecutionRunId)
+	s.NotEqual(chain2RunID, we2.FirstExecutionRunId, "chain switched back to chain1 after reset")
+}
+
+// TestResetOfNonCurrentRunAfterContinueAsNew_FirstExecutionRunId covers the case where the workflow
+// has continued-as-new (so a different run is current) and the caller resets the *original*
+// (non-current) run. The resulting reset run becomes current; its first_execution_run_id should
+// still report the head of the chain (the original run id), and so should subsequent
+// Start/dedup interactions against the resulting workflow.
+func (s *ContinueAsNewTestSuite) TestResetOfNonCurrentRunAfterContinueAsNew_FirstExecutionRunId() {
+	env := testcore.NewEnv(s.T())
+	env.OverrideDynamicConfig(dynamicconfig.WorkflowIdReuseMinimalInterval, time.Duration(0))
+
+	id := "functional-reset-non-current-after-can-test"
+	wt := "functional-reset-non-current-after-can-test-type"
+	tl := "functional-reset-non-current-after-can-test-taskqueue"
+	identity := "worker1"
+
+	workflowType := &commonpb.WorkflowType{Name: wt}
+	taskQueue := &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
+
+	startReq := &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           uuid.NewString(),
+		Namespace:           env.Namespace().String(),
+		WorkflowId:          id,
+		WorkflowType:        workflowType,
+		TaskQueue:           taskQueue,
+		WorkflowRunTimeout:  durationpb.New(100 * time.Second),
+		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+		Identity:            identity,
+	}
+	we0, err := env.FrontendClient().StartWorkflowExecution(s.Context(), startReq)
+	s.NoError(err)
+	originalRunID := we0.RunId
+
+	// Drive one CAN so the original run becomes non-current.
+	tv := testvars.New(s.T()).WithTaskQueue(tl)
+	poller := taskpoller.New(s.T(), env.FrontendClient(), env.Namespace().String())
+	_, err = poller.PollAndHandleWorkflowTask(tv, func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{
+			Commands: []*commandpb.Command{{
+				CommandType: enumspb.COMMAND_TYPE_CONTINUE_AS_NEW_WORKFLOW_EXECUTION,
+				Attributes: &commandpb.Command_ContinueAsNewWorkflowExecutionCommandAttributes{
+					ContinueAsNewWorkflowExecutionCommandAttributes: &commandpb.ContinueAsNewWorkflowExecutionCommandAttributes{
+						WorkflowType:        workflowType,
+						TaskQueue:           taskQueue,
+						WorkflowRunTimeout:  durationpb.New(100 * time.Second),
+						WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+					},
+				},
+			}},
+		}, nil
+	})
+	s.NoError(err)
+
+	// Locate the WorkflowTaskCompleted event in the original (non-current) run to use as reset point.
+	originalEvents := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: id, RunId: originalRunID})
+	var wtCompletedEventID int64
+	for _, ev := range originalEvents {
+		if ev.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED {
+			wtCompletedEventID = ev.GetEventId()
+		}
+	}
+	s.NotZero(wtCompletedEventID)
+
+	// Reset the *non-current* original run.
+	resetResp, err := env.FrontendClient().ResetWorkflowExecution(s.Context(), &workflowservice.ResetWorkflowExecutionRequest{
+		Namespace:                 env.Namespace().String(),
+		WorkflowExecution:         &commonpb.WorkflowExecution{WorkflowId: id, RunId: originalRunID},
+		Reason:                    "reset non-current run after CAN",
+		WorkflowTaskFinishEventId: wtCompletedEventID,
+		RequestId:                 uuid.NewString(),
+	})
+	s.NoError(err)
+	resetRunID := resetResp.RunId
+	s.NotEqual(originalRunID, resetRunID)
+
+	// The reset run is now current. The chain head must still be the original run id.
+	desc, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: id},
+	})
+	s.NoError(err)
+	s.Equal(resetRunID, desc.WorkflowExecutionInfo.Execution.GetRunId())
+	s.Equal(originalRunID, desc.WorkflowExecutionInfo.GetFirstRunId(), "reset of non-current run should preserve chain head")
+
+	// USE_EXISTING: response references the reset run id, FirstExecutionRunId == original head.
+	useExistingReq := proto.Clone(startReq).(*workflowservice.StartWorkflowExecutionRequest)
+	useExistingReq.RequestId = uuid.NewString()
+	useExistingReq.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING
+	we2, err := env.FrontendClient().StartWorkflowExecution(s.Context(), useExistingReq)
+	s.NoError(err)
+	s.False(we2.Started)
+	s.Equal(resetRunID, we2.RunId)
+	s.Equal(originalRunID, we2.FirstExecutionRunId)
+}

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -1919,6 +1919,100 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_InternalTaskQueue() {
 
 }
 
+// TestStartWorkflowExecution_FirstExecutionRunId covers the contract that StartWorkflowExecution
+// (both the response and the WorkflowExecutionAlreadyStarted error) carries first_execution_run_id
+// pointing at the head of the continue-as-new chain. For workflows that have never been continued
+// as new, this should equal the current run id; the chained case is covered in continue_as_new_test.go.
+func (s *WorkflowTestSuite) TestStartWorkflowExecution_FirstExecutionRunId() {
+	s.Run("brand new start", func(s *WorkflowTestSuite) {
+		env := testcore.NewEnv(s.T())
+		tv := testvars.New(s.T())
+		req := &workflowservice.StartWorkflowExecutionRequest{
+			RequestId:          uuid.NewString(),
+			Namespace:          env.Namespace().String(),
+			WorkflowId:         testcore.RandomizeStr(s.T().Name()),
+			WorkflowType:       tv.WorkflowType(),
+			TaskQueue:          tv.TaskQueue(),
+			WorkflowRunTimeout: durationpb.New(100 * time.Second),
+			Identity:           tv.WorkerIdentity(),
+		}
+		we, err := env.FrontendClient().StartWorkflowExecution(s.Context(), req)
+		s.NoError(err)
+		requireStartedAndRunning(s.T(), we)
+		s.Equal(we.RunId, we.FirstExecutionRunId)
+	})
+
+	s.Run("use existing dedup", func(s *WorkflowTestSuite) {
+		env := testcore.NewEnv(s.T())
+		tv := testvars.New(s.T())
+		req := &workflowservice.StartWorkflowExecutionRequest{
+			RequestId:          uuid.NewString(),
+			Namespace:          env.Namespace().String(),
+			WorkflowId:         testcore.RandomizeStr(s.T().Name()),
+			WorkflowType:       tv.WorkflowType(),
+			TaskQueue:          tv.TaskQueue(),
+			WorkflowRunTimeout: durationpb.New(100 * time.Second),
+			Identity:           tv.WorkerIdentity(),
+		}
+		we0, err := env.FrontendClient().StartWorkflowExecution(s.Context(), req)
+		s.NoError(err)
+
+		req.RequestId = uuid.NewString()
+		req.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING
+		we1, err := env.FrontendClient().StartWorkflowExecution(s.Context(), req)
+		s.NoError(err)
+		requireNotStartedButRunning(s.T(), we1)
+		s.Equal(we0.RunId, we1.RunId)
+		s.Equal(we0.RunId, we1.FirstExecutionRunId)
+	})
+
+	s.Run("fail policy error carries first execution run id", func(s *WorkflowTestSuite) {
+		env := testcore.NewEnv(s.T())
+		tv := testvars.New(s.T())
+		req := &workflowservice.StartWorkflowExecutionRequest{
+			RequestId:          uuid.NewString(),
+			Namespace:          env.Namespace().String(),
+			WorkflowId:         testcore.RandomizeStr(s.T().Name()),
+			WorkflowType:       tv.WorkflowType(),
+			TaskQueue:          tv.TaskQueue(),
+			WorkflowRunTimeout: durationpb.New(100 * time.Second),
+			Identity:           tv.WorkerIdentity(),
+		}
+		we0, err := env.FrontendClient().StartWorkflowExecution(s.Context(), req)
+		s.NoError(err)
+
+		req.RequestId = uuid.NewString()
+		// Default conflict policy is FAIL.
+		_, err = env.FrontendClient().StartWorkflowExecution(s.Context(), req)
+		var already *serviceerror.WorkflowExecutionAlreadyStarted
+		s.ErrorAs(err, &already)
+		s.Equal(we0.RunId, already.RunId)
+		s.Equal(we0.RunId, already.FirstExecutionRunId)
+	})
+
+	s.Run("retried request dedup", func(s *WorkflowTestSuite) {
+		env := testcore.NewEnv(s.T())
+		tv := testvars.New(s.T())
+		req := &workflowservice.StartWorkflowExecutionRequest{
+			RequestId:          uuid.NewString(),
+			Namespace:          env.Namespace().String(),
+			WorkflowId:         testcore.RandomizeStr(s.T().Name()),
+			WorkflowType:       tv.WorkflowType(),
+			TaskQueue:          tv.TaskQueue(),
+			WorkflowRunTimeout: durationpb.New(100 * time.Second),
+			Identity:           tv.WorkerIdentity(),
+		}
+		we0, err := env.FrontendClient().StartWorkflowExecution(s.Context(), req)
+		s.NoError(err)
+
+		// Re-issue with same RequestId: server dedupes against the started request.
+		we1, err := env.FrontendClient().StartWorkflowExecution(s.Context(), req)
+		s.NoError(err)
+		s.Equal(we0.RunId, we1.RunId)
+		s.Equal(we0.RunId, we1.FirstExecutionRunId)
+	})
+}
+
 func requireNotStartedButRunning(t *testing.T, resp *workflowservice.StartWorkflowExecutionResponse) {
 	t.Helper()
 	require.False(t, resp.Started)

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -30,8 +30,10 @@ import (
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/testing/parallelsuite"
+	"go.temporal.io/server/common/testing/taskpoller"
 	"go.temporal.io/server/common/testing/testvars"
 	"go.temporal.io/server/tests/testcore"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
@@ -2010,6 +2012,268 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_FirstExecutionRunId() {
 		s.NoError(err)
 		s.Equal(we0.RunId, we1.RunId)
 		s.Equal(we0.RunId, we1.FirstExecutionRunId)
+	})
+}
+
+// TestStartWorkflowExecution_FirstExecutionRunId_AfterRetry verifies that when a workflow has been
+// retried (creating a new run with the same workflow id), a subsequent StartWorkflowExecution with
+// the FAIL conflict policy fails with WorkflowExecutionAlreadyStarted, and that error reports the
+// original (first attempt) run id in FirstExecutionRunId — not the retry's run id.
+func (s *WorkflowTestSuite) TestStartWorkflowExecution_FirstExecutionRunId_AfterRetry() {
+	env := testcore.NewEnv(s.T())
+	tv := testvars.New(s.T())
+	workflowID := testcore.RandomizeStr(s.T().Name())
+
+	startReq := &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           uuid.NewString(),
+		Namespace:           env.Namespace().String(),
+		WorkflowId:          workflowID,
+		WorkflowType:        tv.WorkflowType(),
+		TaskQueue:           tv.TaskQueue(),
+		WorkflowRunTimeout:  durationpb.New(100 * time.Second),
+		WorkflowTaskTimeout: durationpb.New(1 * time.Second),
+		Identity:            tv.WorkerIdentity(),
+		RetryPolicy: &commonpb.RetryPolicy{
+			InitialInterval:    durationpb.New(1 * time.Second),
+			MaximumInterval:    durationpb.New(1 * time.Second),
+			MaximumAttempts:    3,
+			BackoffCoefficient: 1.0,
+		},
+	}
+	we0, err := env.FrontendClient().StartWorkflowExecution(s.Context(), startReq)
+	s.NoError(err)
+	originalRunID := we0.RunId
+	s.Equal(originalRunID, we0.FirstExecutionRunId)
+
+	// Fail the first attempt so the server creates a retry run.
+	poller := taskpoller.New(s.T(), env.FrontendClient(), env.Namespace().String())
+	_, err = poller.PollAndHandleWorkflowTask(tv, func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{
+			Commands: []*commandpb.Command{{
+				CommandType: enumspb.COMMAND_TYPE_FAIL_WORKFLOW_EXECUTION,
+				Attributes: &commandpb.Command_FailWorkflowExecutionCommandAttributes{
+					FailWorkflowExecutionCommandAttributes: &commandpb.FailWorkflowExecutionCommandAttributes{
+						Failure: failure.NewServerFailure("retryable", false),
+					},
+				},
+			}},
+		}, nil
+	})
+	s.NoError(err)
+
+	// Wait for the retry run to be current and confirm it differs from the original.
+	var retryRunID string
+	s.Eventually(func() bool {
+		desc, derr := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
+			Execution: &commonpb.WorkflowExecution{WorkflowId: workflowID},
+		})
+		if derr != nil {
+			return false
+		}
+		retryRunID = desc.WorkflowExecutionInfo.Execution.GetRunId()
+		return retryRunID != "" && retryRunID != originalRunID
+	}, 10*time.Second, 100*time.Millisecond)
+	s.NotEmpty(retryRunID)
+	s.NotEqual(originalRunID, retryRunID)
+
+	// FAIL policy: error must surface the original run id as the first execution run id.
+	failReq := proto.Clone(startReq).(*workflowservice.StartWorkflowExecutionRequest)
+	failReq.RequestId = uuid.NewString()
+	failReq.RetryPolicy = nil
+	failReq.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL
+	_, err = env.FrontendClient().StartWorkflowExecution(s.Context(), failReq)
+	var already *serviceerror.WorkflowExecutionAlreadyStarted
+	s.ErrorAs(err, &already)
+	s.Equal(retryRunID, already.RunId)
+	s.Equal(originalRunID, already.FirstExecutionRunId)
+}
+
+// TestStartWorkflowExecution_FirstExecutionRunId_AfterReset verifies that after a workflow is
+// reset, a StartWorkflowExecution against the reset workflow (with FAIL or USE_EXISTING) reports
+// the original run id as FirstExecutionRunId — not the reset's new run id.
+func (s *WorkflowTestSuite) TestStartWorkflowExecution_FirstExecutionRunId_AfterReset() {
+	env := testcore.NewEnv(s.T())
+	tv := testvars.New(s.T())
+	workflowID := testcore.RandomizeStr(s.T().Name())
+
+	startReq := &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           uuid.NewString(),
+		Namespace:           env.Namespace().String(),
+		WorkflowId:          workflowID,
+		WorkflowType:        tv.WorkflowType(),
+		TaskQueue:           tv.TaskQueue(),
+		WorkflowRunTimeout:  durationpb.New(100 * time.Second),
+		WorkflowTaskTimeout: durationpb.New(1 * time.Second),
+		Identity:            tv.WorkerIdentity(),
+	}
+	we0, err := env.FrontendClient().StartWorkflowExecution(s.Context(), startReq)
+	s.NoError(err)
+	originalRunID := we0.RunId
+
+	// Drive one workflow task so there is a WorkflowTaskCompleted to reset to. Don't complete the
+	// workflow — we need it to be resetable to a non-trivial point.
+	var firstWTCompletedEventID int64
+	poller := taskpoller.New(s.T(), env.FrontendClient(), env.Namespace().String())
+	_, err = poller.PollAndHandleWorkflowTask(tv, func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{
+			Commands: []*commandpb.Command{{
+				CommandType: enumspb.COMMAND_TYPE_START_TIMER,
+				Attributes: &commandpb.Command_StartTimerCommandAttributes{
+					StartTimerCommandAttributes: &commandpb.StartTimerCommandAttributes{
+						TimerId:            "t1",
+						StartToFireTimeout: durationpb.New(time.Hour),
+					},
+				},
+			}},
+		}, nil
+	})
+	s.NoError(err)
+
+	events := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: workflowID, RunId: originalRunID})
+	for _, ev := range events {
+		if ev.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED {
+			firstWTCompletedEventID = ev.GetEventId()
+		}
+	}
+	s.NotZero(firstWTCompletedEventID)
+
+	resetResp, err := env.FrontendClient().ResetWorkflowExecution(s.Context(), &workflowservice.ResetWorkflowExecutionRequest{
+		Namespace:                 env.Namespace().String(),
+		WorkflowExecution:         &commonpb.WorkflowExecution{WorkflowId: workflowID, RunId: originalRunID},
+		Reason:                    "test reset preserves FirstExecutionRunId",
+		WorkflowTaskFinishEventId: firstWTCompletedEventID,
+		RequestId:                 uuid.NewString(),
+	})
+	s.NoError(err)
+	resetRunID := resetResp.RunId
+	s.NotEqual(originalRunID, resetRunID)
+
+	// FAIL policy: error references the reset (current) run, but first-execution stays at the head.
+	failReq := proto.Clone(startReq).(*workflowservice.StartWorkflowExecutionRequest)
+	failReq.RequestId = uuid.NewString()
+	failReq.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL
+	_, err = env.FrontendClient().StartWorkflowExecution(s.Context(), failReq)
+	var already *serviceerror.WorkflowExecutionAlreadyStarted
+	s.ErrorAs(err, &already)
+	s.Equal(resetRunID, already.RunId)
+	s.Equal(originalRunID, already.FirstExecutionRunId)
+
+	// USE_EXISTING: response references the reset run id, FirstExecutionRunId == head.
+	useExisting := proto.Clone(startReq).(*workflowservice.StartWorkflowExecutionRequest)
+	useExisting.RequestId = uuid.NewString()
+	useExisting.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING
+	we2, err := env.FrontendClient().StartWorkflowExecution(s.Context(), useExisting)
+	s.NoError(err)
+	s.False(we2.Started)
+	s.Equal(resetRunID, we2.RunId)
+	s.Equal(originalRunID, we2.FirstExecutionRunId)
+}
+
+// TestSignalWithStartWorkflowExecution_FirstExecutionRunId verifies that the
+// SignalWithStartWorkflowExecution response and (under FAIL conflict policy) error both carry
+// FirstExecutionRunId of the head-of-chain run, matching the contract from StartWorkflowExecution.
+func (s *WorkflowTestSuite) TestSignalWithStartWorkflowExecution_FirstExecutionRunId() {
+	s.Run("brand new start via SignalWithStart", func(s *WorkflowTestSuite) {
+		env := testcore.NewEnv(s.T())
+		tv := testvars.New(s.T())
+		req := &workflowservice.SignalWithStartWorkflowExecutionRequest{
+			RequestId:          uuid.NewString(),
+			Namespace:          env.Namespace().String(),
+			WorkflowId:         testcore.RandomizeStr(s.T().Name()),
+			WorkflowType:       tv.WorkflowType(),
+			TaskQueue:          tv.TaskQueue(),
+			WorkflowRunTimeout: durationpb.New(100 * time.Second),
+			SignalName:         "sig",
+			SignalInput:        payloads.EncodeString("x"),
+			Identity:           tv.WorkerIdentity(),
+		}
+		resp, err := env.FrontendClient().SignalWithStartWorkflowExecution(s.Context(), req)
+		s.NoError(err)
+		s.True(resp.Started)
+		s.Equal(resp.RunId, resp.FirstExecutionRunId)
+	})
+
+	s.Run("signal existing workflow returns first execution run id", func(s *WorkflowTestSuite) {
+		env := testcore.NewEnv(s.T())
+		tv := testvars.New(s.T())
+		workflowID := testcore.RandomizeStr(s.T().Name())
+
+		startReq := &workflowservice.StartWorkflowExecutionRequest{
+			RequestId:          uuid.NewString(),
+			Namespace:          env.Namespace().String(),
+			WorkflowId:         workflowID,
+			WorkflowType:       tv.WorkflowType(),
+			TaskQueue:          tv.TaskQueue(),
+			WorkflowRunTimeout: durationpb.New(100 * time.Second),
+			Identity:           tv.WorkerIdentity(),
+		}
+		we0, err := env.FrontendClient().StartWorkflowExecution(s.Context(), startReq)
+		s.NoError(err)
+
+		swsReq := &workflowservice.SignalWithStartWorkflowExecutionRequest{
+			RequestId:          uuid.NewString(),
+			Namespace:          env.Namespace().String(),
+			WorkflowId:         workflowID,
+			WorkflowType:       tv.WorkflowType(),
+			TaskQueue:          tv.TaskQueue(),
+			WorkflowRunTimeout: durationpb.New(100 * time.Second),
+			SignalName:         "sig",
+			SignalInput:        payloads.EncodeString("x"),
+			Identity:           tv.WorkerIdentity(),
+		}
+		resp, err := env.FrontendClient().SignalWithStartWorkflowExecution(s.Context(), swsReq)
+		s.NoError(err)
+		s.False(resp.Started)
+		s.Equal(we0.RunId, resp.RunId)
+		s.Equal(we0.RunId, resp.FirstExecutionRunId)
+	})
+
+	s.Run("reject duplicate on completed workflow carries first execution run id", func(s *WorkflowTestSuite) {
+		// SignalWithStart does not accept WORKFLOW_ID_CONFLICT_POLICY_FAIL, so the AlreadyStarted
+		// error path is reached via WorkflowIdReusePolicy REJECT_DUPLICATE against a completed run.
+		env := testcore.NewEnv(s.T())
+		tv := testvars.New(s.T())
+		workflowID := testcore.RandomizeStr(s.T().Name())
+
+		startReq := &workflowservice.StartWorkflowExecutionRequest{
+			RequestId:          uuid.NewString(),
+			Namespace:          env.Namespace().String(),
+			WorkflowId:         workflowID,
+			WorkflowType:       tv.WorkflowType(),
+			TaskQueue:          tv.TaskQueue(),
+			WorkflowRunTimeout: durationpb.New(100 * time.Second),
+			Identity:           tv.WorkerIdentity(),
+		}
+		we0, err := env.FrontendClient().StartWorkflowExecution(s.Context(), startReq)
+		s.NoError(err)
+
+		// Terminate the workflow so it's completed (FAILED/TERMINATED) — this triggers the reuse-policy branch on the next start.
+		_, err = env.FrontendClient().TerminateWorkflowExecution(s.Context(), &workflowservice.TerminateWorkflowExecutionRequest{
+			Namespace:         env.Namespace().String(),
+			WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: workflowID},
+			Reason:            "test",
+			Identity:          tv.WorkerIdentity(),
+		})
+		s.NoError(err)
+
+		swsReq := &workflowservice.SignalWithStartWorkflowExecutionRequest{
+			RequestId:             uuid.NewString(),
+			Namespace:             env.Namespace().String(),
+			WorkflowId:            workflowID,
+			WorkflowType:          tv.WorkflowType(),
+			TaskQueue:             tv.TaskQueue(),
+			WorkflowRunTimeout:    durationpb.New(100 * time.Second),
+			SignalName:            "sig",
+			SignalInput:           payloads.EncodeString("x"),
+			Identity:              tv.WorkerIdentity(),
+			WorkflowIdReusePolicy: enumspb.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
+		}
+		_, err = env.FrontendClient().SignalWithStartWorkflowExecution(s.Context(), swsReq)
+		var already *serviceerror.WorkflowExecutionAlreadyStarted
+		s.ErrorAs(err, &already)
+		s.Equal(we0.RunId, already.RunId)
+		s.Equal(we0.RunId, already.FirstExecutionRunId)
 	})
 }
 

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -2063,19 +2063,16 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_FirstExecutionRunId_After
 
 	// Wait for the retry run to be current and confirm it differs from the original.
 	var retryRunID string
-	s.Eventually(func() bool {
+	s.Await(func(s *WorkflowTestSuite) {
 		desc, derr := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
 			Namespace: env.Namespace().String(),
 			Execution: &commonpb.WorkflowExecution{WorkflowId: workflowID},
 		})
-		if derr != nil {
-			return false
-		}
+		s.NoError(derr)
 		retryRunID = desc.WorkflowExecutionInfo.Execution.GetRunId()
-		return retryRunID != "" && retryRunID != originalRunID
+		s.NotEqual(originalRunID, retryRunID)
+		s.NotEmpty(retryRunID)
 	}, 10*time.Second, 100*time.Millisecond)
-	s.NotEmpty(retryRunID)
-	s.NotEqual(originalRunID, retryRunID)
 
 	// FAIL policy: error must surface the original run id as the first execution run id.
 	failReq := proto.Clone(startReq).(*workflowservice.StartWorkflowExecutionRequest)


### PR DESCRIPTION
## What changed?

Add FirstExecutionRunID to start response

## Why?

closes https://github.com/temporalio/temporal/issues/8537

>Today, when SDK gets StartWorkflowExecutionResponse with started as false or WorkflowExecutionAlreadyStartedFailure, it doesn't include the first execution run ID that we can bind successive calls to. It only provides the run ID. If you start a workflow today successfully, SDK uses the run ID as the first execution run ID on successive calls like cancel and signal and such. But if you start a workflow today w/ conflict policy of use existing and it doesn't start, that run ID is not acceptable for first execution run ID.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workflow start/dedup/conflict handling and persistence shape for current-execution records; behavior is additive but clients may rely on the new field for signals/cancel after USE_EXISTING starts.
> 
> **Overview**
> Adds **`first_execution_run_id`** to **Start** and **SignalWithStart** responses (history → frontend) so clients get the head-of-chain run ID when `started` is false, on request dedup, and on **`WorkflowExecutionAlreadyStarted`** — not only the current `run_id`.
> 
> **Persistence:** canonical value moves to **`WorkflowExecutionState.first_execution_run_id`** (with **`ExecutionInfo`** field deprecated); it is set on workflow start, backfilled on load from legacy **`ExecutionInfo`**, and included on **`CurrentWorkflowConditionFailedError`** from SQL/Cassandra. Start/signal-with-start paths resolve it via **`GetFirstRunID`** when persisted state is missing it.
> 
> **Behavior:** new runs set first == current; continue-as-new, retry, reset, and similar continuations inherit the original chain head. Empty is allowed when the server cannot determine it (old records).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4091515dd6d3490c0278877fd22ce86b1a77a487. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->