### PR TITLE
New dynamic config frontend.enableBatchActivityOperators default true

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1079,6 +1079,11 @@ so forwarding by endpoint ID will not work out of the box.`,
 		1,
 		`FrontendMaxConcurrentAdminBatchOperationPerNamespace is the max concurrent admin batch operation job count per namespace`,
 	)
+	FrontendEnableBatchActivityOperators = NewNamespaceBoolSetting(
+		"frontend.enableBatchActivityOperators",
+		true,
+		`FrontendEnableBatchActivityOperators decides whether to support batch cancel, terminate or delete on standalone activities in the frontend`,
+	)
 
 	FrontendEnableUpdateWorkflowExecution = NewNamespaceBoolSetting(
 		"frontend.enableUpdateWorkflowExecution",
@@ -3297,11 +3302,6 @@ When enabled, the scavenger will delete completed workflow execution data that a
 		`AdminBatcherGlobalRPS controls the rps of all admin batch operations across all worker hosts.
 The configured value will be divided by the number of worker hosts to get the per host rps limit. 
 0 means no global limit and each host will use AdminBatcherHostRPS.`,
-	)
-	EnableBatchActivityOperators = NewNamespaceBoolSetting(
-		"worker.enableBatchActivityOperators",
-		true,
-		`EnableBatchActivityOperators decides whether to support batch cancel, terminate or delete on standalone activities in our worker`,
 	)
 	WorkerParentCloseMaxConcurrentActivityExecutionSize = NewGlobalIntSetting(
 		"worker.ParentCloseMaxConcurrentActivityExecutionSize",

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -3299,7 +3299,7 @@ The configured value will be divided by the number of worker hosts to get the pe
 0 means no global limit and each host will use AdminBatcherHostRPS.`,
 	)
 	EnableBatchActivityOperators = NewNamespaceBoolSetting(
-		"worker.enableEnableBatchActivityOperators",
+		"worker.enableBatchActivityOperators",
 		true,
 		`EnableBatchActivityOperators decides whether to support batch cancel, terminate or delete on standalone activities in our worker`,
 	)

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -3298,6 +3298,11 @@ When enabled, the scavenger will delete completed workflow execution data that a
 The configured value will be divided by the number of worker hosts to get the per host rps limit. 
 0 means no global limit and each host will use AdminBatcherHostRPS.`,
 	)
+	EnableBatchActivityOperators = NewNamespaceBoolSetting(
+		"worker.enableEnableBatchActivityOperators",
+		true,
+		`EnableBatchActivityOperators decides whether to support batch cancel, terminate or delete on standalone activities in our worker`,
+	)
 	WorkerParentCloseMaxConcurrentActivityExecutionSize = NewGlobalIntSetting(
 		"worker.ParentCloseMaxConcurrentActivityExecutionSize",
 		1000,

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -373,7 +373,7 @@ func NewConfig(
 		MaxConcurrentBatchOperation:      dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace.Get(dc),
 		MaxExecutionCountBatchOperation:  dynamicconfig.FrontendMaxExecutionCountBatchOperationPerNamespace.Get(dc),
 		MaxConcurrentAdminBatchOperation: dynamicconfig.FrontendMaxConcurrentAdminBatchOperationPerNamespace.Get(dc),
-		EnableBatchActivityOperators:     dynamicconfig.EnableBatchActivityOperators.Get(dc),
+		EnableBatchActivityOperators:     dynamicconfig.FrontendEnableBatchActivityOperators.Get(dc),
 
 		EnableUpdateWorkflowExecution:                              dynamicconfig.FrontendEnableUpdateWorkflowExecution.Get(dc),
 		EnableUpdateWorkflowExecutionAsyncAccepted:                 dynamicconfig.FrontendEnableUpdateWorkflowExecutionAsyncAccepted.Get(dc),

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -192,6 +192,7 @@ type Config struct {
 	MaxExecutionCountBatchOperation dynamicconfig.IntPropertyFnWithNamespaceFilter
 	// Admin Batch operation dynamic config
 	MaxConcurrentAdminBatchOperation dynamicconfig.IntPropertyFnWithNamespaceFilter
+	EnableBatchActivityOperators     dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
 	EnableUpdateWorkflowExecution                              dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	EnableUpdateWorkflowExecutionAsyncAccepted                 dynamicconfig.BoolPropertyFnWithNamespaceFilter
@@ -372,6 +373,7 @@ func NewConfig(
 		MaxConcurrentBatchOperation:      dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace.Get(dc),
 		MaxExecutionCountBatchOperation:  dynamicconfig.FrontendMaxExecutionCountBatchOperationPerNamespace.Get(dc),
 		MaxConcurrentAdminBatchOperation: dynamicconfig.FrontendMaxConcurrentAdminBatchOperationPerNamespace.Get(dc),
+		EnableBatchActivityOperators:     dynamicconfig.EnableBatchActivityOperators.Get(dc),
 
 		EnableUpdateWorkflowExecution:                              dynamicconfig.FrontendEnableUpdateWorkflowExecution.Get(dc),
 		EnableUpdateWorkflowExecutionAsyncAccepted:                 dynamicconfig.FrontendEnableUpdateWorkflowExecutionAsyncAccepted.Get(dc),

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -5649,6 +5649,15 @@ func (wh *WorkflowHandler) StartBatchOperation(
 		return nil, errBatchAPINotAllowed
 	}
 
+	if !wh.config.EnableBatchActivityOperators(request.Namespace) {
+		switch op := request.Operation.(type) {
+		case *workflowservice.StartBatchOperationRequest_TerminateActivitiesOperation,
+			*workflowservice.StartBatchOperationRequest_DeleteActivitiesOperation,
+			*workflowservice.StartBatchOperationRequest_CancelActivitiesOperation:
+			return nil, serviceerror.NewInvalidArgumentf("The operation type %T is not supported for this namespace", op)
+		}
+	}
+
 	if err := batcher.ValidateBatchOperation(request); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If set to false, then batch cancel, terminate, delete on standalone activities are not allowed.
Other code changes related to memo edit are still allowed.