### PR TITLE
[Visibility] Read Chasm Workflows

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -3110,6 +3110,13 @@ the CHASM implementation. When disabled, new update callbacks will not be regist
 but existing callbacks will still be processed and fired.`,
 	)
 
+	EnableReadChasmWorkflows = NewNamespaceBoolSetting(
+		"frontend.enableReadChasmWorkflows",
+		false,
+		`If enabled, Visibility read workflow APIS (ListWorkflowExecutions, CountWorkflowsExecutions)
+will use the CHASM API in VisibilityManager`,
+	)
+
 	VersionMembershipCacheTTL = NewGlobalDurationSetting(
 		"history.versionMembershipCacheTTL",
 		1*time.Second,

--- a/common/persistence/visibility/visibility_manager_impl.go
+++ b/common/persistence/visibility/visibility_manager_impl.go
@@ -174,6 +174,7 @@ func (p *visibilityManagerImpl) ListChasmExecutions(
 		executionInfo, err := p.convertToChasmExecutionInfo(
 			exec,
 			mapper,
+			request.ArchetypeId,
 			namespace.Name(request.Namespace),
 		)
 		if err != nil {
@@ -192,6 +193,7 @@ func (p *visibilityManagerImpl) ListChasmExecutions(
 func (p *visibilityManagerImpl) convertToChasmExecutionInfo(
 	exec *store.InternalExecutionInfo,
 	mapper *chasm.VisibilitySearchAttributesMapper,
+	archetypeID chasm.ArchetypeID,
 	namespaceName namespace.Name,
 ) (*chasmspb.VisibilityExecutionInfo, error) {
 	customSAs, chasmSAs := splitSearchAttributes(exec.SearchAttributes)
@@ -209,6 +211,48 @@ func (p *visibilityManagerImpl) convertToChasmExecutionInfo(
 	if exec.TaskQueue != "" {
 		chasmAliasedSAs.IndexedFields[sadefs.TaskQueue] = sadefs.MustEncodeValue(
 			exec.TaskQueue,
+			enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		)
+	}
+	if archetypeID == chasm.WorkflowArchetypeID {
+		if !exec.ExecutionTime.After(time.Unix(0, 0)) {
+			exec.ExecutionTime = exec.StartTime
+		}
+
+		chasmAliasedSAs.IndexedFields[sadefs.ExecutionStatus] = sadefs.MustEncodeValue(
+			exec.Status.String(),
+			enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		)
+		chasmAliasedSAs.IndexedFields[sadefs.WorkflowType] = sadefs.MustEncodeValue(
+			exec.TypeName,
+			enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		)
+		chasmAliasedSAs.IndexedFields[sadefs.ExecutionTime] = sadefs.MustEncodeValue(
+			exec.ExecutionTime,
+			enumspb.INDEXED_VALUE_TYPE_DATETIME,
+		)
+		if exec.ExecutionDuration > 0 {
+			chasmAliasedSAs.IndexedFields[sadefs.ExecutionDuration] = sadefs.MustEncodeValue(
+				exec.ExecutionDuration.Nanoseconds(),
+				enumspb.INDEXED_VALUE_TYPE_INT,
+			)
+		}
+		if exec.ParentWorkflowID != "" {
+			chasmAliasedSAs.IndexedFields[sadefs.ParentWorkflowID] = sadefs.MustEncodeValue(
+				exec.ParentWorkflowID,
+				enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			)
+			chasmAliasedSAs.IndexedFields[sadefs.ParentRunID] = sadefs.MustEncodeValue(
+				exec.ParentRunID,
+				enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			)
+		}
+		chasmAliasedSAs.IndexedFields[sadefs.RootWorkflowID] = sadefs.MustEncodeValue(
+			exec.RootWorkflowID,
+			enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		)
+		chasmAliasedSAs.IndexedFields[sadefs.RootRunID] = sadefs.MustEncodeValue(
+			exec.RootRunID,
 			enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 		)
 	}

--- a/common/searchattribute/sadefs/encode_value.go
+++ b/common/searchattribute/sadefs/encode_value.go
@@ -33,6 +33,17 @@ func MustEncodeValue(val any, t enumspb.IndexedValueType) *commonpb.Payload {
 	return valPayload
 }
 
+// MustDecodeValue decodes search attribute Payload and IndexedValueType to value.
+// Panics if it fails to decode.
+func MustDecodeValue(value *commonpb.Payload, t enumspb.IndexedValueType) any {
+	v, err := DecodeValue(value, t, false)
+	if err != nil {
+		// nolint:forbidigo
+		panic(err)
+	}
+	return v
+}
+
 // DecodeValue decodes search attribute value from Payload using (in order):
 // 1. passed type t.
 // 2. type from MetadataType field, if t is not specified.

--- a/common/searchattribute/sadefs/encode_value_test.go
+++ b/common/searchattribute/sadefs/encode_value_test.go
@@ -392,6 +392,72 @@ func Test_MustEncodeValue(t *testing.T) {
 	})
 }
 
+func Test_MustDecodeValue(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		encodedValue, err := payload.Encode("foo")
+		require.NoError(t, err)
+		decodedValue := MustDecodeValue(encodedValue, enumspb.INDEXED_VALUE_TYPE_KEYWORD)
+		require.Equal(t, "foo", decodedValue)
+	})
+
+	t.Run("success with nil value", func(t *testing.T) {
+		encodedValue, err := payload.Encode(nil)
+		require.NoError(t, err)
+		decodedValue := MustDecodeValue(encodedValue, enumspb.INDEXED_VALUE_TYPE_KEYWORD)
+		require.Nil(t, decodedValue)
+	})
+
+	t.Run("success with metadata type", func(t *testing.T) {
+		encodedValue, err := payload.Encode(int64(123))
+		require.NoError(t, err)
+		encodedValue.Metadata[MetadataType] = []byte(enumspb.INDEXED_VALUE_TYPE_INT.String())
+		decodedValue := MustDecodeValue(encodedValue, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED)
+		require.Equal(t, int64(123), decodedValue)
+	})
+
+	t.Run("panic on unspecified type without metadata", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			require.NotNil(t, r)
+			err, ok := r.(error)
+			require.True(t, ok)
+			require.ErrorIs(t, err, ErrInvalidType)
+		}()
+		encodedValue, err := payload.Encode(int64(123))
+		require.NoError(t, err)
+		_ = MustDecodeValue(encodedValue, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED)
+		require.Fail(t, "MustDecodeValue did not panic with unspecified type")
+	})
+
+	t.Run("panic on type mismatch", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			require.NotNil(t, r)
+			err, ok := r.(error)
+			require.True(t, ok)
+			require.ErrorIs(t, err, converter.ErrUnableToDecode)
+		}()
+		encodedValue, err := payload.Encode(int64(123))
+		require.NoError(t, err)
+		_ = MustDecodeValue(encodedValue, enumspb.INDEXED_VALUE_TYPE_KEYWORD)
+		require.Fail(t, "MustDecodeValue did not panic with type mismatch")
+	})
+
+	t.Run("panic on list not allowed", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			require.NotNil(t, r)
+			err, ok := r.(error)
+			require.True(t, ok)
+			require.ErrorIs(t, err, converter.ErrUnableToDecode)
+		}()
+		encodedValue, err := payload.Encode([]int64{123, 456})
+		require.NoError(t, err)
+		_ = MustDecodeValue(encodedValue, enumspb.INDEXED_VALUE_TYPE_INT)
+		require.Fail(t, "MustDecodeValue did not panic with list of values")
+	})
+}
+
 func Test_ValidateStrings(t *testing.T) {
 	_, err := validateStrings("anything here", errors.New("test error"))
 	assert.Error(t, err)

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -178,6 +178,8 @@ type Config struct {
 	// Enables ID-space collision sentinels, and must be enabled and propagated in
 	// advance of EnableCHASMSchedulerCreation.
 	EnableCHASMSchedulerSentinels dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	// Enable ListChasmExecutions to list workflows.
+	EnableReadChasmWorkflows dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
 	// Enable deployment RPCs
 	EnableDeployments dynamicconfig.BoolPropertyFnWithNamespaceFilter
@@ -363,6 +365,7 @@ func NewConfig(
 		CHASMSchedulerCreationRolloutPercent: dynamicconfig.CHASMSchedulerCreationRolloutPercent.Get(dc),
 		EnableCHASMSchedulerRouting:          dynamicconfig.EnableCHASMSchedulerRouting.Get(dc),
 		EnableCHASMSchedulerSentinels:        dynamicconfig.EnableCHASMSchedulerSentinels.Get(dc),
+		EnableReadChasmWorkflows:             dynamicconfig.EnableReadChasmWorkflows.Get(dc),
 
 		// [cleanup-wv-pre-release]
 		EnableDeployments:        dynamicconfig.EnableDeployments.Get(dc),

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -29,11 +30,13 @@ import (
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	batchspb "go.temporal.io/server/api/batch/v1"
+	chasmspb "go.temporal.io/server/api/chasm/v1"
 	deploymentspb "go.temporal.io/server/api/deployment/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
 	schedulespb "go.temporal.io/server/api/schedule/v1"
 	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
+	"go.temporal.io/server/api/visibilityservice/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/chasm/lib/callback"
@@ -90,6 +93,7 @@ import (
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -2710,8 +2714,148 @@ func (wh *WorkflowHandler) ListClosedWorkflowExecutions(ctx context.Context, req
 	}, nil
 }
 
+func convertChasmExecutionToWorkflowExecution(
+	chasmExecution *chasmspb.VisibilityExecutionInfo,
+) *workflowpb.WorkflowExecutionInfo {
+	chasmSA := chasmExecution.ChasmSearchAttributes.IndexedFields
+	//nolint:revive // Chasm execution for workflows encodes the value in VisibilityManager
+	statusStr := sadefs.MustDecodeValue(
+		chasmSA[sadefs.ExecutionStatus],
+		enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+	).(string)
+	status, err := enumspb.WorkflowExecutionStatusFromString(statusStr)
+	if err != nil {
+		// nolint:forbidigo // must never happen
+		panic(err)
+	}
+
+	//nolint:revive // Chasm execution for workflows encodes the value in VisibilityManager
+	workflowType := sadefs.MustDecodeValue(
+		chasmSA[sadefs.WorkflowType],
+		enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+	).(string)
+	//nolint:revive // Chasm execution for workflows encodes the value in VisibilityManager
+	executionTime := sadefs.MustDecodeValue(
+		chasmSA[sadefs.ExecutionTime],
+		enumspb.INDEXED_VALUE_TYPE_DATETIME,
+	).(time.Time)
+	//nolint:revive // Chasm execution for workflows encodes the value in VisibilityManager
+	taskQueue := sadefs.MustDecodeValue(
+		chasmSA[sadefs.TaskQueue],
+		enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+	).(string)
+	//nolint:revive // Chasm execution for workflows encodes the value in VisibilityManager
+	rootWorkflowID := sadefs.MustDecodeValue(
+		chasmSA[sadefs.RootWorkflowID],
+		enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+	).(string)
+	//nolint:revive // Chasm execution for workflows encodes the value in VisibilityManager
+	rootRunID := sadefs.MustDecodeValue(
+		chasmSA[sadefs.RootRunID],
+		enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+	).(string)
+
+	exec := &workflowpb.WorkflowExecutionInfo{
+		Execution: &commonpb.WorkflowExecution{
+			WorkflowId: chasmExecution.BusinessId,
+			RunId:      chasmExecution.RunId,
+		},
+		Type: &commonpb.WorkflowType{
+			Name: workflowType,
+		},
+		StartTime:        chasmExecution.StartTime,
+		ExecutionTime:    timestamppb.New(executionTime),
+		Memo:             chasmExecution.Memo,
+		SearchAttributes: chasmExecution.CustomSearchAttributes,
+		TaskQueue:        taskQueue,
+		Status:           status,
+		RootExecution: &commonpb.WorkflowExecution{
+			WorkflowId: rootWorkflowID,
+			RunId:      rootRunID,
+		},
+	}
+
+	if parentWorkflowIDPayload, ok := chasmSA[sadefs.ParentWorkflowID]; ok {
+		//nolint:revive // Chasm execution for workflows encodes the value in VisibilityManager
+		parentWorkflowID := sadefs.MustDecodeValue(
+			parentWorkflowIDPayload,
+			enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		).(string)
+		//nolint:revive // Chasm execution for workflows encodes the value in VisibilityManager
+		parentRunID := sadefs.MustDecodeValue(
+			chasmSA[sadefs.ParentRunID],
+			enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		).(string)
+
+		exec.ParentExecution = &commonpb.WorkflowExecution{
+			WorkflowId: parentWorkflowID,
+			RunId:      parentRunID,
+		}
+	}
+
+	if status != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING {
+		//nolint:revive // Chasm execution for workflows encodes the value in VisibilityManager
+		executionDuration := time.Duration(sadefs.MustDecodeValue(
+			chasmSA[sadefs.ExecutionDuration],
+			enumspb.INDEXED_VALUE_TYPE_INT,
+		).(int64))
+
+		exec.CloseTime = chasmExecution.CloseTime
+		exec.ExecutionDuration = durationpb.New(executionDuration)
+		exec.HistoryLength = chasmExecution.HistoryLength
+		exec.HistorySizeBytes = chasmExecution.HistorySizeBytes
+		exec.StateTransitionCount = chasmExecution.StateTransitionCount
+	}
+
+	return exec
+}
+
+func (wh *WorkflowHandler) listWorkflowsChasm(
+	ctx context.Context,
+	request *workflowservice.ListWorkflowExecutionsRequest,
+) (*workflowservice.ListWorkflowExecutionsResponse, error) {
+	namespaceName := namespace.Name(request.GetNamespace())
+	namespaceID, err := wh.namespaceRegistry.GetNamespaceID(namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	query, err := prepareQueryChasmWorkflows(request.Query)
+	if err != nil {
+		return nil, serviceerror.NewInvalidArgumentf("invalid query: %v", err.Error())
+	}
+
+	resp, err := wh.visibilityMgr.ListChasmExecutions(
+		ctx,
+		&visibilityservice.ListChasmExecutionsRequest{
+			ArchetypeId:   chasm.WorkflowArchetypeID,
+			NamespaceId:   namespaceID.String(),
+			Namespace:     namespaceName.String(),
+			Query:         query,
+			PageSize:      request.GetPageSize(),
+			NextPageToken: request.GetNextPageToken(),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	executions := make([]*workflowpb.WorkflowExecutionInfo, len(resp.Executions))
+	for i, chasmExec := range resp.Executions {
+		executions[i] = convertChasmExecutionToWorkflowExecution(chasmExec)
+	}
+
+	return &workflowservice.ListWorkflowExecutionsResponse{
+		Executions:    executions,
+		NextPageToken: resp.NextPageToken,
+	}, nil
+}
+
 // ListWorkflowExecutions is a visibility API to list workflow executions in a specific namespace.
-func (wh *WorkflowHandler) ListWorkflowExecutions(ctx context.Context, request *workflowservice.ListWorkflowExecutionsRequest) (_ *workflowservice.ListWorkflowExecutionsResponse, retError error) {
+func (wh *WorkflowHandler) ListWorkflowExecutions(
+	ctx context.Context,
+	request *workflowservice.ListWorkflowExecutionsRequest,
+) (_ *workflowservice.ListWorkflowExecutionsResponse, retError error) {
 	defer log.CapturePanic(wh.logger, &retError)
 
 	if request == nil {
@@ -2730,6 +2874,10 @@ func (wh *WorkflowHandler) ListWorkflowExecutions(ctx context.Context, request *
 	}
 
 	metrics.VisibilityListWorkflowsQueryLength.With(wh.metricsScope(ctx)).Record(int64(len(request.GetQuery())))
+
+	if wh.config.EnableReadChasmWorkflows(request.GetNamespace()) {
+		return wh.listWorkflowsChasm(ctx, request)
+	}
 
 	req := &manager.ListWorkflowExecutionsRequestV2{
 		NamespaceID:   namespaceID,
@@ -2847,8 +2995,56 @@ func (wh *WorkflowHandler) ScanWorkflowExecutions(ctx context.Context, request *
 	return resp, nil
 }
 
+func (wh *WorkflowHandler) countWorkflowsChasm(
+	ctx context.Context,
+	request *workflowservice.CountWorkflowExecutionsRequest,
+) (*workflowservice.CountWorkflowExecutionsResponse, error) {
+	namespaceName := namespace.Name(request.GetNamespace())
+	namespaceID, err := wh.namespaceRegistry.GetNamespaceID(namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	query, err := prepareQueryChasmWorkflows(request.Query)
+	if err != nil {
+		return nil, serviceerror.NewInvalidArgumentf("invalid query: %v", err.Error())
+	}
+
+	resp, err := wh.visibilityMgr.CountChasmExecutions(
+		ctx,
+		&visibilityservice.CountChasmExecutionsRequest{
+			ArchetypeId: chasm.WorkflowArchetypeID,
+			NamespaceId: namespaceID.String(),
+			Namespace:   namespaceName.String(),
+			Query:       query,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var groups []*workflowservice.CountWorkflowExecutionsResponse_AggregationGroup
+	if len(resp.Groups) > 0 {
+		groups = make([]*workflowservice.CountWorkflowExecutionsResponse_AggregationGroup, len(resp.Groups))
+		for i, g := range resp.Groups {
+			groups[i] = &workflowservice.CountWorkflowExecutionsResponse_AggregationGroup{
+				GroupValues: g.GroupValues,
+				Count:       g.Count,
+			}
+		}
+	}
+
+	return &workflowservice.CountWorkflowExecutionsResponse{
+		Count:  resp.Count,
+		Groups: groups,
+	}, nil
+}
+
 // CountWorkflowExecutions is a visibility API to count of workflow executions in a specific namespace.
-func (wh *WorkflowHandler) CountWorkflowExecutions(ctx context.Context, request *workflowservice.CountWorkflowExecutionsRequest) (_ *workflowservice.CountWorkflowExecutionsResponse, retError error) {
+func (wh *WorkflowHandler) CountWorkflowExecutions(
+	ctx context.Context,
+	request *workflowservice.CountWorkflowExecutionsRequest,
+) (_ *workflowservice.CountWorkflowExecutionsResponse, retError error) {
 	defer log.CapturePanic(wh.logger, &retError)
 
 	if request == nil {
@@ -2859,6 +3055,12 @@ func (wh *WorkflowHandler) CountWorkflowExecutions(ctx context.Context, request 
 	namespaceID, err := wh.namespaceRegistry.GetNamespaceID(namespaceName)
 	if err != nil {
 		return nil, err
+	}
+
+	metrics.VisibilityListWorkflowsQueryLength.With(wh.metricsScope(ctx)).Record(int64(len(request.GetQuery())))
+
+	if wh.config.EnableReadChasmWorkflows(request.GetNamespace()) {
+		return wh.countWorkflowsChasm(ctx, request)
 	}
 
 	req := &manager.CountWorkflowExecutionsRequest{
@@ -2876,6 +3078,51 @@ func (wh *WorkflowHandler) CountWorkflowExecutions(ctx context.Context, request 
 		Groups: persistenceResp.Groups,
 	}
 	return resp, nil
+}
+
+func prepareQueryChasmWorkflows(query string) (string, error) {
+	nsDivisionExpr := &sqlparser.ColName{
+		Name: sqlparser.NewColIdent(sadefs.TemporalNamespaceDivision),
+	}
+	// TemporalNamespaceDivision is null or TemporalNamespaceDivision = '<chasm workflow archetype id>'
+	baseExpr := &sqlparser.OrExpr{
+		Left: &sqlparser.IsExpr{
+			Operator: sqlparser.IsNullStr,
+			Expr:     nsDivisionExpr,
+		},
+		Right: &sqlparser.ComparisonExpr{
+			Operator: sqlparser.EqualStr,
+			Left:     nsDivisionExpr,
+			Right:    sqlparser.NewStrVal([]byte(strconv.Itoa(int(chasm.WorkflowArchetypeID)))),
+		},
+	}
+	baseQueryStr := sqlparser.String(baseExpr)
+	query = strings.TrimSpace(query)
+	if len(query) == 0 {
+		return baseQueryStr, nil
+	}
+	if len(query) >= 8 {
+		prefix := strings.ToLower(query[:8])
+		if prefix == "order by" || prefix == "group by" {
+			return baseQueryStr + " " + query, nil
+		}
+	}
+	selectPrefix := "select * from t where "
+	stmt, err := sqlparser.Parse(selectPrefix + query)
+	if err != nil {
+		return "", err
+	}
+	//nolint:revive // By construction, this is a sqlparser.Select object
+	selectExpr := stmt.(*sqlparser.Select)
+	selectExpr.Where.Expr = &sqlparser.AndExpr{
+		Left: &sqlparser.ParenExpr{
+			Expr: baseExpr,
+		},
+		Right: &sqlparser.ParenExpr{
+			Expr: selectExpr.Where.Expr,
+		},
+	}
+	return sqlparser.String(selectExpr)[len(selectPrefix):], nil
 }
 
 // GetSearchAttributes is a visibility API to get all legal keys that could be used in list APIs

--- a/service/frontend/workflow_handler_second_test.go
+++ b/service/frontend/workflow_handler_second_test.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,6 +11,7 @@ import (
 	schedulepb "go.temporal.io/api/schedule/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	schedulespb "go.temporal.io/server/api/schedule/v1"
+	"go.temporal.io/server/chasm"
 	dc "go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/payload"
@@ -153,6 +155,91 @@ func makeVisibilityManagerStub(controller *gomock.Controller) *manager.MockVisib
 	visibilityManager := manager.NewMockVisibilityManager(controller)
 	visibilityManager.EXPECT().GetIndexName().Return("index").AnyTimes()
 	return visibilityManager
+}
+
+func TestPrepareQueryChasmWorkflows(t *testing.T) {
+	t.Parallel()
+
+	baseFilter := fmt.Sprintf(
+		"TemporalNamespaceDivision is null or TemporalNamespaceDivision = '%d'",
+		chasm.WorkflowArchetypeID,
+	)
+	wrappedFilter := "(" + baseFilter + ")"
+
+	tests := []struct {
+		name     string
+		query    string
+		expected string
+	}{
+		{
+			name:     "empty query returns base filter",
+			query:    "",
+			expected: baseFilter,
+		},
+		{
+			name:     "whitespace only returns base filter",
+			query:    "   \t  ",
+			expected: baseFilter,
+		},
+		{
+			name:     "simple where clause is wrapped",
+			query:    "foo = 'bar'",
+			expected: wrappedFilter + " and (foo = 'bar')",
+		},
+		{
+			name:     "compound where clause is wrapped",
+			query:    "foo = 1 and bar = 2",
+			expected: wrappedFilter + " and (foo = 1 and bar = 2)",
+		},
+		{
+			name:     "where clause with order by",
+			query:    "foo > 1 order by bar desc",
+			expected: wrappedFilter + " and (foo > 1) order by bar desc",
+		},
+		{
+			name:     "short where clause is wrapped",
+			query:    "a = 1",
+			expected: wrappedFilter + " and (a = 1)",
+		},
+		{
+			name:     "query gets trimmed before wrapping",
+			query:    "  foo = 'bar'  ",
+			expected: wrappedFilter + " and (foo = 'bar')",
+		},
+		{
+			name:     "order by only is appended without wrapping",
+			query:    "order by foo desc",
+			expected: baseFilter + " order by foo desc",
+		},
+		{
+			name:     "group by only is appended without wrapping",
+			query:    "group by foo",
+			expected: baseFilter + " group by foo",
+		},
+		{
+			name:     "order by prefix is case-insensitive",
+			query:    "ORDER BY foo DESC",
+			expected: baseFilter + " ORDER BY foo DESC",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := prepareQueryChasmWorkflows(tc.query)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+
+	t.Run("invalid query returns parse error", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := prepareQueryChasmWorkflows("foo === bar")
+		require.Error(t, err)
+		require.Empty(t, got)
+	})
 }
 
 func makeResponseWithScheduledWorkflowAttributes(nameValueMap map[string]string) *schedulespb.DescribeResponse {

--- a/tests/advanced_visibility_test.go
+++ b/tests/advanced_visibility_test.go
@@ -55,17 +55,36 @@ type AdvancedVisibilitySuite struct {
 	parallelsuite.Suite[*AdvancedVisibilitySuite]
 }
 
+type advancedVisibilitySuiteOptions struct {
+	enableUnifiedQueryConverter bool
+	enableReadChasmWorkflows    bool
+}
+
 func TestAdvancedVisibilitySuite(t *testing.T) {
-	parallelsuite.Run(t, &AdvancedVisibilitySuite{}, true)
+	parallelsuite.Run(t, &AdvancedVisibilitySuite{}, advancedVisibilitySuiteOptions{
+		enableUnifiedQueryConverter: true,
+	})
 }
 
 func TestAdvancedVisibilitySuiteLegacy(t *testing.T) {
-	parallelsuite.Run(t, &AdvancedVisibilitySuite{}, false)
+	parallelsuite.Run(t, &AdvancedVisibilitySuite{}, advancedVisibilitySuiteOptions{
+		enableUnifiedQueryConverter: false,
+	})
+}
+
+func TestAdvancedVisibilityChasmSuite(t *testing.T) {
+	parallelsuite.Run(t, &AdvancedVisibilitySuite{}, advancedVisibilitySuiteOptions{
+		enableUnifiedQueryConverter: true,
+		enableReadChasmWorkflows:    true,
+	})
 }
 
 // newTestEnv creates a TestEnv with the dynamic config this suite needs.
 // Additional per-test options may be passed in opts.
-func (s *AdvancedVisibilitySuite) newTestEnv(enableUnifiedQueryConverter bool, opts ...testcore.TestOption) *testcore.TestEnv {
+func (s *AdvancedVisibilitySuite) newTestEnv(
+	suiteOpts advancedVisibilitySuiteOptions,
+	opts ...testcore.TestOption,
+) *testcore.TestEnv {
 	// This cluster use customized threshold for history config
 	baseOpts := []testcore.TestOption{
 		testcore.WithDynamicConfig(dynamicconfig.VisibilityDisableOrderByClause, false),
@@ -78,9 +97,10 @@ func (s *AdvancedVisibilitySuite) newTestEnv(enableUnifiedQueryConverter bool, o
 		// Allow the scavenger to remove any build ID regardless of when it was last default for a set.
 		testcore.WithDynamicConfig(dynamicconfig.RemovableBuildIdDurationSinceDefault, time.Microsecond),
 		// Enable the unified query converter
-		testcore.WithDynamicConfig(dynamicconfig.VisibilityEnableUnifiedQueryConverter, enableUnifiedQueryConverter),
+		testcore.WithDynamicConfig(dynamicconfig.VisibilityEnableUnifiedQueryConverter, suiteOpts.enableUnifiedQueryConverter),
 		// Enable external payload tracking for TestListWorkflow_ExternalPayloadSearchAttributes
 		testcore.WithDynamicConfig(dynamicconfig.ExternalPayloadsEnabled, true),
+		testcore.WithDynamicConfig(dynamicconfig.EnableReadChasmWorkflows, suiteOpts.enableReadChasmWorkflows),
 	}
 	env := testcore.NewEnv(s.T(), append(baseOpts, opts...)...)
 
@@ -94,8 +114,8 @@ func (s *AdvancedVisibilitySuite) newTestEnv(enableUnifiedQueryConverter bool, o
 	return env
 }
 
-func (s *AdvancedVisibilitySuite) TestListOpenWorkflow(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestListOpenWorkflow(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	id := "es-functional-start-workflow-test"
 	wt := "es-functional-start-workflow-test-type"
 	tl := "es-functional-start-workflow-test-taskqueue"
@@ -150,8 +170,8 @@ func (s *AdvancedVisibilitySuite) TestListOpenWorkflow(enableUnifiedQueryConvert
 	s.NotEmpty(attrType)
 }
 
-func (s *AdvancedVisibilitySuite) TestListWorkflow(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestListWorkflow(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	id := "es-functional-list-workflow-test"
 	wt := "es-functional-list-workflow-test-type"
 	tl := "es-functional-list-workflow-test-taskqueue"
@@ -164,8 +184,8 @@ func (s *AdvancedVisibilitySuite) TestListWorkflow(enableUnifiedQueryConverter b
 	s.testHelperForReadOnce(env, we.GetRunId(), query)
 }
 
-func (s *AdvancedVisibilitySuite) TestListWorkflow_ExecutionTime(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestListWorkflow_ExecutionTime(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	id := "es-functional-list-workflow-execution-time-test"
 	wt := "es-functional-list-workflow-execution-time-test-type"
 	tl := "es-functional-list-workflow-execution-time-test-taskqueue"
@@ -207,8 +227,8 @@ func (s *AdvancedVisibilitySuite) TestListWorkflow_ExecutionTime(enableUnifiedQu
 	s.testHelperForReadOnce(env, weCron.GetRunId(), cronQuery)
 }
 
-func (s *AdvancedVisibilitySuite) TestListWorkflow_SearchAttribute(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestListWorkflow_SearchAttribute(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	id := "es-functional-list-workflow-by-search-attr-test"
 	wt := "es-functional-list-workflow-by-search-attr-test-type"
 	tl := "es-functional-list-workflow-by-search-attr-test-taskqueue"
@@ -296,8 +316,8 @@ func (s *AdvancedVisibilitySuite) TestListWorkflow_SearchAttribute(enableUnified
 	}
 }
 
-func (s *AdvancedVisibilitySuite) TestListWorkflow_PageToken(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestListWorkflow_PageToken(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	id := "es-functional-list-workflow-token-test"
 	wt := "es-functional-list-workflow-token-test-type"
 	tl := "es-functional-list-workflow-token-test-taskqueue"
@@ -309,8 +329,8 @@ func (s *AdvancedVisibilitySuite) TestListWorkflow_PageToken(enableUnifiedQueryC
 	s.testListWorkflowHelper(env, numOfWorkflows, pageSize, request, id, wt)
 }
 
-func (s *AdvancedVisibilitySuite) TestListWorkflow_SearchAfter(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestListWorkflow_SearchAfter(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	id := "es-functional-list-workflow-searchAfter-test"
 	wt := "es-functional-list-workflow-searchAfter-test-type"
 	tl := "es-functional-list-workflow-searchAfter-test-taskqueue"
@@ -322,8 +342,8 @@ func (s *AdvancedVisibilitySuite) TestListWorkflow_SearchAfter(enableUnifiedQuer
 	s.testListWorkflowHelper(env, numOfWorkflows, pageSize, request, id, wt)
 }
 
-func (s *AdvancedVisibilitySuite) TestListWorkflow_OrQuery(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestListWorkflow_OrQuery(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	id := "es-functional-list-workflow-or-query-test"
 	wt := "es-functional-list-workflow-or-query-test-type"
 	tl := "es-functional-list-workflow-or-query-test-taskqueue"
@@ -434,8 +454,8 @@ func (s *AdvancedVisibilitySuite) TestListWorkflow_OrQuery(enableUnifiedQueryCon
 	s.Equal(3, searchVal)
 }
 
-func (s *AdvancedVisibilitySuite) TestListWorkflow_KeywordQuery(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestListWorkflow_KeywordQuery(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	id := "es-functional-list-workflow-keyword-query-test"
 	wt := "es-functional-list-workflow-keyword-query-test-type"
 	tl := "es-functional-list-workflow-keyword-query-test-taskqueue"
@@ -523,8 +543,8 @@ func (s *AdvancedVisibilitySuite) TestListWorkflow_KeywordQuery(enableUnifiedQue
 	s.Empty(resp.GetExecutions())
 }
 
-func (s *AdvancedVisibilitySuite) TestListWorkflow_StringQuery(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestListWorkflow_StringQuery(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	id := "es-functional-list-workflow-string-query-test"
 	wt := "es-functional-list-workflow-string-query-test-type"
 	tl := "es-functional-list-workflow-string-query-test-taskqueue"
@@ -589,8 +609,8 @@ func (s *AdvancedVisibilitySuite) TestListWorkflow_StringQuery(enableUnifiedQuer
 }
 
 // To test last page search trigger max window size error
-func (s *AdvancedVisibilitySuite) TestListWorkflow_MaxWindowSize(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestListWorkflow_MaxWindowSize(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	id := "es-functional-list-workflow-max-window-size-test"
 	wt := "es-functional-list-workflow-max-window-size-test-type"
 	tl := "es-functional-list-workflow-max-window-size-test-taskqueue"
@@ -636,8 +656,8 @@ func (s *AdvancedVisibilitySuite) TestListWorkflow_MaxWindowSize(enableUnifiedQu
 	s.Nil(resp.GetNextPageToken())
 }
 
-func (s *AdvancedVisibilitySuite) TestListWorkflow_OrderBy(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestListWorkflow_OrderBy(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	if testcore.UseSQLVisibility() {
 		s.T().Skip("This test is only for Elasticsearch")
 	}
@@ -900,8 +920,8 @@ func (s *AdvancedVisibilitySuite) testHelperForReadOnce(env *testcore.TestEnv, e
 	return openExecution
 }
 
-func (s *AdvancedVisibilitySuite) TestCountWorkflow(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestCountWorkflow(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	id := "es-functional-count-workflow-test"
 	wt := "es-functional-count-workflow-test-type"
 	tl := "es-functional-count-workflow-test-taskqueue"
@@ -940,8 +960,8 @@ func (s *AdvancedVisibilitySuite) TestCountWorkflow(enableUnifiedQueryConverter 
 	s.Equal(int64(0), resp.GetCount())
 }
 
-func (s *AdvancedVisibilitySuite) TestCountGroupByWorkflow(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestCountGroupByWorkflow(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	id := "es-functional-count-groupby-workflow-test"
 	wt := "es-functional-count-groupby-workflow-test-type"
 	tl := "es-functional-count-groupby-workflow-test-taskqueue"
@@ -1040,8 +1060,8 @@ func (s *AdvancedVisibilitySuite) createStartWorkflowExecutionRequest(env *testc
 	return request
 }
 
-func (s *AdvancedVisibilitySuite) TestUpsertWorkflowExecutionSearchAttributes(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestUpsertWorkflowExecutionSearchAttributes(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	id := "es-functional-upsert-workflow-search-attributes-test"
 	wt := "es-functional-upsert-workflow-search-attributes-test-type"
 	tl := "es-functional-upsert-workflow-search-attributes-test-taskqueue"
@@ -1320,8 +1340,8 @@ func (s *AdvancedVisibilitySuite) TestUpsertWorkflowExecutionSearchAttributes(en
 	}
 }
 
-func (s *AdvancedVisibilitySuite) TestModifyWorkflowExecutionProperties(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestModifyWorkflowExecutionProperties(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	id := "es-functional-modify-workflow-properties-test"
 	wt := "es-functional-modify-workflow-properties-test-type"
 	tl := "es-functional-modify-workflow-properties-test-taskqueue"
@@ -1584,8 +1604,8 @@ func (s *AdvancedVisibilitySuite) createSearchAttributes() *commonpb.SearchAttri
 	return searchAttributes
 }
 
-func (s *AdvancedVisibilitySuite) TestUpsertWorkflowExecution_InvalidKey(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestUpsertWorkflowExecution_InvalidKey(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	id := "es-functional-upsert-workflow-failed-test"
 	wt := "es-functional-upsert-workflow-failed-test-type"
 	tl := "es-functional-upsert-workflow-failed-test-taskqueue"
@@ -1653,8 +1673,8 @@ func (s *AdvancedVisibilitySuite) TestUpsertWorkflowExecution_InvalidKey(enableU
   5 WorkflowTaskScheduled`, env.Namespace().String()), historyEvents)
 }
 
-func (s *AdvancedVisibilitySuite) TestChildWorkflow_ParentWorkflow(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestChildWorkflow_ParentWorkflow(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	var (
 		wfID        = testcore.RandomizeStr(s.T().Name())
 		childWfID   = testcore.RandomizeStr(s.T().Name())
@@ -1735,8 +1755,8 @@ func (s *AdvancedVisibilitySuite) TestChildWorkflow_ParentWorkflow(enableUnified
 	)
 }
 
-func (s *AdvancedVisibilitySuite) Test_LongWorkflowID(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) Test_LongWorkflowID(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	if env.GetTestClusterConfig().Persistence.StoreType == config.StoreTypeSQL {
 		// TODO: remove this when workflow_id field size is increased from varchar(255) in SQL schema.
 		return
@@ -1754,8 +1774,8 @@ func (s *AdvancedVisibilitySuite) Test_LongWorkflowID(enableUnifiedQueryConverte
 	s.testHelperForReadOnce(env, we.GetRunId(), query)
 }
 
-func (s *AdvancedVisibilitySuite) Test_BuildIdIndexedOnCompletion_UnversionedWorker(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) Test_BuildIdIndexedOnCompletion_UnversionedWorker(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	id := testcore.RandomizeStr(s.T().Name())
 	workflowType := "functional-build-id"
 	taskQueue := testcore.RandomizeStr(s.T().Name())
@@ -1850,9 +1870,10 @@ func (s *AdvancedVisibilitySuite) Test_BuildIdIndexedOnCompletion_UnversionedWor
 	}
 }
 
-func (s *AdvancedVisibilitySuite) Test_BuildIdIndexedOnCompletion_VersionedWorker(enableUnifiedQueryConverter bool) {
+func (s *AdvancedVisibilitySuite) Test_BuildIdIndexedOnCompletion_VersionedWorker(suiteOpts advancedVisibilitySuiteOptions) {
 	// Use only one partition to avoid having to wait for user data propagation later
-	env := s.newTestEnv(enableUnifiedQueryConverter,
+	env := s.newTestEnv(
+		suiteOpts,
 		testcore.WithDynamicConfig(dynamicconfig.MatchingNumTaskqueueReadPartitions, 1),
 		testcore.WithDynamicConfig(dynamicconfig.MatchingNumTaskqueueWritePartitions, 1),
 	)
@@ -2007,9 +2028,10 @@ func (s *AdvancedVisibilitySuite) Test_BuildIdIndexedOnCompletion_VersionedWorke
 	}, 10*time.Second, 100*time.Millisecond)
 }
 
-func (s *AdvancedVisibilitySuite) Test_BuildIdIndexedOnReset(enableUnifiedQueryConverter bool) {
+func (s *AdvancedVisibilitySuite) Test_BuildIdIndexedOnReset(suiteOpts advancedVisibilitySuiteOptions) {
 	// Use only one partition to avoid having to wait for user data propagation later
-	env := s.newTestEnv(enableUnifiedQueryConverter,
+	env := s.newTestEnv(
+		suiteOpts,
 		testcore.WithDynamicConfig(dynamicconfig.MatchingNumTaskqueueReadPartitions, 1),
 		testcore.WithDynamicConfig(dynamicconfig.MatchingNumTaskqueueWritePartitions, 1),
 	)
@@ -2087,9 +2109,10 @@ func (s *AdvancedVisibilitySuite) Test_BuildIdIndexedOnReset(enableUnifiedQueryC
 	}, 10*time.Second, 100*time.Millisecond)
 }
 
-func (s *AdvancedVisibilitySuite) Test_BuildIdIndexedOnRetry(enableUnifiedQueryConverter bool) {
+func (s *AdvancedVisibilitySuite) Test_BuildIdIndexedOnRetry(suiteOpts advancedVisibilitySuiteOptions) {
 	// Use only one partition to avoid having to wait for user data propagation later
-	env := s.newTestEnv(enableUnifiedQueryConverter,
+	env := s.newTestEnv(
+		suiteOpts,
 		testcore.WithDynamicConfig(dynamicconfig.MatchingNumTaskqueueReadPartitions, 1),
 		testcore.WithDynamicConfig(dynamicconfig.MatchingNumTaskqueueWritePartitions, 1),
 	)
@@ -2151,8 +2174,8 @@ func (s *AdvancedVisibilitySuite) Test_BuildIdIndexedOnRetry(enableUnifiedQueryC
 	}, 10*time.Second, 100*time.Millisecond)
 }
 
-func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_ByBuildId(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_ByBuildId(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	tq1 := s.T().Name()
 	tq2 := s.T().Name() + "-2"
 	tq3 := s.T().Name() + "-3"
@@ -2273,8 +2296,8 @@ func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_ByBuildId(enableUni
 
 }
 
-func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_ByBuildId_NotInNamespace(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_ByBuildId_NotInNamespace(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	buildId := s.T().Name() + "v0"
 
 	reachabilityResponse, err := env.FrontendClient().GetWorkerTaskReachability(s.Context(), &workflowservice.GetWorkerTaskReachabilityRequest{
@@ -2289,8 +2312,8 @@ func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_ByBuildId_NotInName
 	}}, reachabilityResponse.BuildIdReachability)
 }
 
-func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_ByBuildId_NotInTaskQueue(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_ByBuildId_NotInTaskQueue(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	tq := s.T().Name()
 	v0 := s.T().Name() + "v0"
 	v01 := s.T().Name() + "v0.1"
@@ -2323,8 +2346,8 @@ func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_ByBuildId_NotInTask
 	checkReachability()
 }
 
-func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_EmptyBuildIds(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_EmptyBuildIds(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 
 	_, err := env.FrontendClient().GetWorkerTaskReachability(s.Context(), &workflowservice.GetWorkerTaskReachabilityRequest{
 		Namespace: env.Namespace().String(),
@@ -2333,8 +2356,8 @@ func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_EmptyBuildIds(enabl
 	s.ErrorAs(err, &invalidArgument)
 }
 
-func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_TooManyBuildIds(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_TooManyBuildIds(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 
 	_, err := env.FrontendClient().GetWorkerTaskReachability(s.Context(), &workflowservice.GetWorkerTaskReachabilityRequest{
 		Namespace: env.Namespace().String(),
@@ -2344,8 +2367,8 @@ func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_TooManyBuildIds(ena
 	s.ErrorAs(err, &invalidArgument)
 }
 
-func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_Unversioned_InNamespace(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_Unversioned_InNamespace(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 
 	_, err := env.FrontendClient().GetWorkerTaskReachability(s.Context(), &workflowservice.GetWorkerTaskReachabilityRequest{
 		Namespace: env.Namespace().String(),
@@ -2355,8 +2378,8 @@ func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_Unversioned_InNames
 	s.ErrorAs(err, &invalidArgument)
 }
 
-func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_Unversioned_InTaskQueue(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_Unversioned_InTaskQueue(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	tq := s.T().Name()
 
 	_, err := env.FrontendClient().StartWorkflowExecution(s.Context(), &workflowservice.StartWorkflowExecutionRequest{
@@ -2410,8 +2433,8 @@ func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_Unversioned_InTaskQ
 	s.checkReachability(env, tq, "", enumspb.TASK_REACHABILITY_CLOSED_WORKFLOWS)
 }
 
-func (s *AdvancedVisibilitySuite) TestBuildIdScavenger_DeletesUnusedBuildId(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter, testcore.WithWorkerService("build id scavenger workflow"))
+func (s *AdvancedVisibilitySuite) TestBuildIdScavenger_DeletesUnusedBuildId(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts, testcore.WithWorkerService("build id scavenger workflow"))
 	tq := s.T().Name()
 	buildIdv0 := s.T().Name() + "-v0"
 	buildIdv1 := s.T().Name() + "-v1"
@@ -2468,8 +2491,8 @@ func (s *AdvancedVisibilitySuite) TestBuildIdScavenger_DeletesUnusedBuildId(enab
 	s.Empty(res.BuildIdReachability[0].TaskQueueReachability)
 }
 
-func (s *AdvancedVisibilitySuite) TestListWorkflow_ExternalPayloadSearchAttributes(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestListWorkflow_ExternalPayloadSearchAttributes(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 	id := "es-functional-external-payload-test"
 	wt := "es-functional-external-payload-test-type"
 	tl := "es-functional-external-payload-test-taskqueue"
@@ -2525,8 +2548,8 @@ func (s *AdvancedVisibilitySuite) TestListWorkflow_ExternalPayloadSearchAttribut
 	s.testHelperForReadOnce(env, we.GetRunId(), query)
 }
 
-func (s *AdvancedVisibilitySuite) TestScheduleListingWithSearchAttributes(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter)
+func (s *AdvancedVisibilitySuite) TestScheduleListingWithSearchAttributes(suiteOpts advancedVisibilitySuiteOptions) {
+	env := s.newTestEnv(suiteOpts)
 
 	// Test 1: List schedule with "scheduleId" query
 	scheduleID := "test-schedule-" + uuid.NewString()


### PR DESCRIPTION
## What changed?
Updated List/CountWorkflowExecutions to support Chasm Workflows.
The change is gated under dynamic config `frontend.enableReadChasmWorkflows`.

## Why?
Support reading Chasm Workflows

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)

## Potential risks

