### PR TITLE
SAA operator API 2: Reset/UpdateOptions fixes

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1169,7 +1169,7 @@ func (a *Activity) tryReschedule(
 	shouldRetry, retryInterval := a.shouldRetry(ctx, overridingRetryInterval)
 	resetRequested := a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED
 	// A pending reset request is always honored, regardless of the should retry result.
-	if !(shouldRetry || resetRequested) {
+	if !shouldRetry && !resetRequested {
 		return false, nil
 	}
 	event := rescheduleEvent{retryInterval: retryInterval, failure: failure}

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -297,7 +297,7 @@ func (a *Activity) GenerateRecordActivityTaskStartedResponse(
 		ActivityRunId:               key.RunID,
 		WorkflowNamespace:           namespace,
 		HeartbeatDetails:            lastHeartbeat.GetDetails(),
-		CurrentAttemptScheduledTime: a.attemptScheduleTime(attempt),
+		CurrentAttemptScheduledTime: a.dispatchTimeForAttempt(attempt),
 		ScheduledEvent: &historypb.HistoryEvent{
 			EventType: enumspb.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED,
 			EventTime: a.GetScheduleTime(),
@@ -319,10 +319,9 @@ func (a *Activity) GenerateRecordActivityTaskStartedResponse(
 	}, nil
 }
 
-// attemptScheduleTime returns when the given attempt was scheduled to run:
-// the activity's schedule time plus start delay for the first attempt, or
-// calculated from dispatchTimeForRetry on retries.
-func (a *Activity) attemptScheduleTime(attempt *activitypb.ActivityAttemptState) *timestamppb.Timestamp {
+// dispatchTimeForAttempt returns the dispatch time of the given attempt: the activity's schedule
+// time plus start delay for the first attempt, or dispatchTimeForRetry on retries.
+func (a *Activity) dispatchTimeForAttempt(attempt *activitypb.ActivityAttemptState) *timestamppb.Timestamp {
 	if attempt.GetCount() == 1 {
 		return timestamppb.New(a.firstDispatchTime())
 	}

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -661,7 +661,7 @@ func (a *Activity) UpdateActivityExecutionOptions(
 		}
 		if a.GetStatus() != activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED ||
 			!a.firstDispatchTime().After(ctx.Now(a)) {
-			return nil, serviceerror.NewInvalidArgument(
+			return nil, serviceerror.NewFailedPrecondition(
 				"cannot update start_delay: activity is no longer in its delay window")
 		}
 	}
@@ -695,16 +695,8 @@ func (a *Activity) UpdateActivityExecutionOptions(
 		attempt.CurrentRetryInterval = durationpb.New(newInterval)
 	}
 
-	// Add a new ScheduleToCloseTimeoutTask at the (possibly updated) deadline.
-	// Increment the stamp so the previous task is invalidated by the Validate check.
-	if deadline := a.scheduleToCloseDeadline(); !deadline.IsZero() {
-		a.ScheduleToCloseStamp++
-		ctx.AddTask(
-			a,
-			chasm.TaskAttributes{ScheduledTime: deadline},
-			&activitypb.ScheduleToCloseTimeoutTask{Stamp: a.GetScheduleToCloseStamp()},
-		)
-	}
+	// Recreate the ScheduleToClose task at the (possibly updated) deadline.
+	a.reissueScheduleToClose(ctx)
 
 	attempt.Stamp++
 
@@ -981,27 +973,38 @@ func (a *Activity) reset(ctx chasm.MutableContext, event resetEvent) {
 	if event.req.GetResetHeartbeat() {
 		a.clearHeartbeat(ctx)
 	}
+	dispatchTime := a.dispatchTimeRespectingStartDelay(event.resetTime)
 	if timeout := a.GetScheduleToStartTimeout().AsDuration(); timeout > 0 {
 		ctx.AddTask(
 			a,
-			chasm.TaskAttributes{ScheduledTime: event.resetTime.Add(timeout)},
+			chasm.TaskAttributes{ScheduledTime: dispatchTime.Add(timeout)},
 			&activitypb.ScheduleToStartTimeoutTask{Stamp: attempt.GetStamp()},
 		)
 	}
 	ctx.AddTask(
 		a,
-		chasm.TaskAttributes{ScheduledTime: event.resetTime},
+		chasm.TaskAttributes{ScheduledTime: dispatchTime},
 		&activitypb.ActivityDispatchTask{Stamp: attempt.GetStamp()},
 	)
 	a.emitOnResetMetrics(event.handler)
 }
 
 // handleReset handles the activity execution reset.
-// For SCHEDULED/PAUSED activities: immediately re-dispatches at attempt 1.
+//
+// For SCHEDULED and PAUSED activities (no worker running): re-dispatches at attempt 1, honoring
+// any pending start_delay or retry backoff. A PAUSED activity is unpaused first — unless
+// keepPaused is set, in which case the counter is reset to 1 but the activity stays PAUSED until
+// a later unpause.
+//
 // For STARTED activities: transitions to RESET_REQUESTED. The worker is notified via
 // ActivityReset=true on its next heartbeat response and continues to use its existing task token.
-// When the worker yields (failure or timeout with retries remaining), the activity transitions
-// back to SCHEDULED at attempt 1 via TransitionResetAttemptFailedToScheduled.
+// If the attempt fails, the activity transitions back to SCHEDULED at attempt 1 via
+// TransitionResetAttemptFailedToScheduled.
+//
+// RestoreOriginalOptions follows the same split: applied immediately for a non-running activity,
+// and deferred for a running one, so the in-flight attempt is not disturbed — every restored option
+// takes effect on the new attempt 1.
+//
 // For CANCEL_REQUESTED activities: rejected with FailedPrecondition; cancel takes precedence.
 func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetActivityExecutionRequest) (*activitypb.ResetActivityExecutionResponse, error) {
 	frontendReq := req.GetFrontendRequest()
@@ -1017,29 +1020,19 @@ func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetAc
 		resetTime = resetTime.Add(time.Duration(rand.Int63n(int64(jitter)))) //nolint:gosec
 	}
 
-	if frontendReq.GetRestoreOriginalOptions() {
-		ogOptions := a.GetOriginalOptions()
-		a.TaskQueue = common.CloneProto(ogOptions.GetTaskQueue())
-		a.ScheduleToCloseTimeout = common.CloneProto(ogOptions.GetScheduleToCloseTimeout())
-		a.ScheduleToStartTimeout = common.CloneProto(ogOptions.GetScheduleToStartTimeout())
-		a.StartToCloseTimeout = common.CloneProto(ogOptions.GetStartToCloseTimeout())
-		a.HeartbeatTimeout = common.CloneProto(ogOptions.GetHeartbeatTimeout())
-		a.RetryPolicy = common.CloneProto(ogOptions.GetRetryPolicy())
-		a.Priority = common.CloneProto(ogOptions.GetPriority())
-
-		// start_delay only governs the first dispatch. Once the first attempt has started, restoring
-		// the original value would shift ScheduleToClose without affecting dispatch timing.
-		if a.GetFirstAttemptStartedTime() == nil {
-			a.StartDelay = common.CloneProto(ogOptions.GetStartDelay())
-			resetTime = a.dispatchTimeRespectingStartDelay(resetTime)
-		}
-	}
+	restore := frontendReq.GetRestoreOriginalOptions()
 
 	switch a.Status {
 
 	case activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED:
 		return nil, serviceerror.NewFailedPrecondition("cannot reset an activity with a pending cancellation")
+	case activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED:
+		// A reset is already pending on this running attempt. For now we reject a second reset
+		// request clearly.
+		// TODO (dan): define desired behavior and implement
+		return nil, serviceerror.NewFailedPrecondition("cannot reset an activity with a pending reset")
 	case activitypb.ACTIVITY_EXECUTION_STATUS_STARTED, activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED:
+		// The worker is still executing.
 		if a.Status == activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED && !keepPaused {
 			// Unpause; the deferred reset will apply on the next retry via STARTED->SCHEDULED.
 			if err := TransitionUnpausedWhilePauseRequested.Apply(a, ctx, unpauseEvent{
@@ -1049,9 +1042,11 @@ func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetAc
 				return nil, err
 			}
 		}
-		// Worker is still executing under its existing task token. Transition to RESET_REQUESTED
-		// so heartbeat/completion calls continue to authenticate; when the worker yields the
-		// activity will land back in SCHEDULED at attempt 1.
+		// Defer mutations (option restore, heartbeat details clear, attempt-count rewind) so that
+		// the in-flight attempt is undisturbed.
+		if restore {
+			a.ResetRestoreOptions = true
+		}
 		if frontendReq.GetResetHeartbeat() {
 			a.ResetHeartbeats = true
 		}
@@ -1065,6 +1060,10 @@ func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetAc
 		return &activitypb.ResetActivityExecutionResponse{}, nil
 
 	case activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED:
+		// No worker is running; restore takes effect immediately.
+		if restore {
+			a.restoreOriginalOptions(ctx)
+		}
 		if keepPaused {
 			// Reset counts but keep the activity paused.
 			attempt := a.LastAttempt.Get(ctx)
@@ -1080,6 +1079,13 @@ func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetAc
 		fallthrough
 
 	case activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED:
+		// No worker is running: restore immediately so the re-dispatched attempt 1 uses the originals.
+		// When reached via the PAUSED fallthrough above, restoreOriginalOptions already ran (a.Status is
+		// still PAUSED at that point, since TransitionReset has not been applied), so guard against
+		// restoring twice.
+		if restore && a.Status == activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED {
+			a.restoreOriginalOptions(ctx)
+		}
 		if err := TransitionReset.Apply(a, ctx, resetEvent{
 			req:       frontendReq,
 			resetTime: resetTime,
@@ -1153,32 +1159,31 @@ func (a *Activity) recordFailedAttempt(
 }
 
 // tryReschedule attempts to reschedule the activity for retry. Returns true if rescheduled, false
-// if retry is not possible. If a reset request has been received then the retry transitions
-// through TransitionResetAttemptFailedToScheduled which applies the deferred reset (attempt count
-// goes back to 1), unless the reset was issued with keepPaused (ResetKeepPaused), in which case it
-// transitions through TransitionResetAttemptFailedToPaused and the activity stays paused.
+// if retry is not possible. It handles the cases of pause and reset requests that were received
+// while the last attempt was in progress.
 func (a *Activity) tryReschedule(
 	ctx chasm.MutableContext,
 	overridingRetryInterval time.Duration,
 	failure *failurepb.Failure,
 ) (bool, error) {
 	shouldRetry, retryInterval := a.shouldRetry(ctx, overridingRetryInterval)
-	if !shouldRetry {
+	resetRequested := a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED
+	// A pending reset request is always honored, regardless of the should retry result.
+	if !(shouldRetry || resetRequested) {
 		return false, nil
 	}
 	event := rescheduleEvent{retryInterval: retryInterval, failure: failure}
-	if a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED {
+	switch a.GetStatus() {
+	case activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED:
 		return true, TransitionAttemptFailedWhilePauseRequested.Apply(a, ctx, event)
-	}
-	if a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED {
-		// keepPaused=true on a paused activity (ResetKeepPaused) requires the yield to land in
-		// PAUSED rather than SCHEDULED so the activity stays paused until unpaused.
+	case activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED:
 		if a.ResetKeepPaused {
 			return true, TransitionResetAttemptFailedToPaused.Apply(a, ctx, event)
 		}
 		return true, TransitionResetAttemptFailedToScheduled.Apply(a, ctx, event)
+	default:
+		return true, TransitionRescheduled.Apply(a, ctx, event)
 	}
-	return true, TransitionRescheduled.Apply(a, ctx, event)
 }
 
 func (a *Activity) shouldRetry(ctx chasm.Context, overridingRetryInterval time.Duration) (bool, time.Duration) {
@@ -1291,6 +1296,47 @@ func (a *Activity) dispatchTimeRespectingStartDelay(t time.Time) time.Time {
 		return dispatchTime
 	}
 	return t
+}
+
+// reissueScheduleToClose bumps the ScheduleToCloseStamp and re-emits the ScheduleToClose timeout task
+// at the current deadline.
+func (a *Activity) reissueScheduleToClose(ctx chasm.MutableContext) {
+	if deadline := a.scheduleToCloseDeadline(); !deadline.IsZero() {
+		a.ScheduleToCloseStamp++
+		ctx.AddTask(
+			a,
+			chasm.TaskAttributes{ScheduledTime: deadline},
+			&activitypb.ScheduleToCloseTimeoutTask{Stamp: a.GetScheduleToCloseStamp()},
+		)
+	}
+}
+
+// applyDeferredOptionRestore applies a Reset(RestoreOriginalOptions) that was deferred because a
+// worker was running an attempt at reset time (see handleReset).
+func (a *Activity) applyDeferredOptionRestore(ctx chasm.MutableContext) {
+	if !a.ResetRestoreOptions {
+		return
+	}
+	a.ResetRestoreOptions = false
+	a.restoreOriginalOptions(ctx)
+}
+
+// restoreOriginalOptions resets the activity's options to the values it was originally scheduled
+// with and reissues the ScheduleToClose timer at the resulting deadline. start_delay is restored
+// only if the activity has never started.
+func (a *Activity) restoreOriginalOptions(ctx chasm.MutableContext) {
+	og := a.GetOriginalOptions()
+	a.TaskQueue = common.CloneProto(og.GetTaskQueue())
+	a.ScheduleToCloseTimeout = common.CloneProto(og.GetScheduleToCloseTimeout())
+	a.ScheduleToStartTimeout = common.CloneProto(og.GetScheduleToStartTimeout())
+	a.StartToCloseTimeout = common.CloneProto(og.GetStartToCloseTimeout())
+	a.HeartbeatTimeout = common.CloneProto(og.GetHeartbeatTimeout())
+	a.RetryPolicy = common.CloneProto(og.GetRetryPolicy())
+	a.Priority = common.CloneProto(og.GetPriority())
+	if a.GetFirstAttemptStartedTime() == nil {
+		a.StartDelay = common.CloneProto(og.GetStartDelay())
+	}
+	a.reissueScheduleToClose(ctx)
 }
 
 // scheduleToCloseDeadline returns the absolute time at which the ScheduleToClose timeout expires,

--- a/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
@@ -240,8 +240,15 @@ type ActivityState struct {
 	// retries and resets. Used as the discriminator for whether start_delay still applies on
 	// pre-dispatch rescheduling paths.
 	FirstAttemptStartedTime *timestamppb.Timestamp `protobuf:"bytes,19,opt,name=first_attempt_started_time,json=firstAttemptStartedTime,proto3" json:"first_attempt_started_time,omitempty"`
-	unknownFields           protoimpl.UnknownFields
-	sizeCache               protoimpl.SizeCache
+	// Set when a reset with restore_original_options=true is requested while a worker is running an
+	// attempt (STARTED / PAUSE_REQUESTED). The option restore is deferred so that the in-flight
+	// attempt is left undisturbed; it is applied when the worker yields and the activity transitions
+	// out of RESET_REQUESTED, so that the restored values take effect on the next attempt. For a
+	// non-running activity (SCHEDULED / PAUSED) the restore is applied immediately and this flag is
+	// not set. Reset while in CANCEL_REQUESTED or RESET_REQUESTED is rejected.
+	ResetRestoreOptions bool `protobuf:"varint,20,opt,name=reset_restore_options,json=resetRestoreOptions,proto3" json:"reset_restore_options,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *ActivityState) Reset() {
@@ -405,6 +412,13 @@ func (x *ActivityState) GetFirstAttemptStartedTime() *timestamppb.Timestamp {
 		return x.FirstAttemptStartedTime
 	}
 	return nil
+}
+
+func (x *ActivityState) GetResetRestoreOptions() bool {
+	if x != nil {
+		return x.ResetRestoreOptions
+	}
+	return false
 }
 
 type ActivityCancelState struct {
@@ -1100,7 +1114,7 @@ var File_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto protor
 
 const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawDesc = "" +
 	"\n" +
-	"@temporal/server/chasm/lib/activity/proto/v1/activity_state.proto\x12+temporal.server.chasm.lib.activity.proto.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&temporal/api/activity/v1/message.proto\x1a$temporal/api/common/v1/message.proto\x1a(temporal/api/deployment/v1/message.proto\x1a%temporal/api/failure/v1/message.proto\x1a'temporal/api/sdk/v1/user_metadata.proto\x1a'temporal/api/taskqueue/v1/message.proto\"\xbf\v\n" +
+	"@temporal/server/chasm/lib/activity/proto/v1/activity_state.proto\x12+temporal.server.chasm.lib.activity.proto.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&temporal/api/activity/v1/message.proto\x1a$temporal/api/common/v1/message.proto\x1a(temporal/api/deployment/v1/message.proto\x1a%temporal/api/failure/v1/message.proto\x1a'temporal/api/sdk/v1/user_metadata.proto\x1a'temporal/api/taskqueue/v1/message.proto\"\xf3\v\n" +
 	"\rActivityState\x12I\n" +
 	"\ractivity_type\x18\x01 \x01(\v2$.temporal.api.common.v1.ActivityTypeR\factivityType\x12C\n" +
 	"\n" +
@@ -1123,7 +1137,8 @@ const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawD
 	"\x10last_pause_state\x18\x10 \x01(\v2?.temporal.server.chasm.lib.activity.proto.v1.ActivityPauseStateR\x0elastPauseState\x12)\n" +
 	"\x10reset_heartbeats\x18\x11 \x01(\bR\x0fresetHeartbeats\x12*\n" +
 	"\x11reset_keep_paused\x18\x12 \x01(\bR\x0fresetKeepPaused\x12W\n" +
-	"\x1afirst_attempt_started_time\x18\x13 \x01(\v2\x1a.google.protobuf.TimestampR\x17firstAttemptStartedTime\"\xa7\x01\n" +
+	"\x1afirst_attempt_started_time\x18\x13 \x01(\v2\x1a.google.protobuf.TimestampR\x17firstAttemptStartedTime\x122\n" +
+	"\x15reset_restore_options\x18\x14 \x01(\bR\x13resetRestoreOptions\"\xa7\x01\n" +
 	"\x13ActivityCancelState\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x01 \x01(\tR\trequestId\x12=\n" +

--- a/chasm/lib/activity/proto/v1/activity_state.proto
+++ b/chasm/lib/activity/proto/v1/activity_state.proto
@@ -143,6 +143,14 @@ message ActivityState {
   // retries and resets. Used as the discriminator for whether start_delay still applies on
   // pre-dispatch rescheduling paths.
   google.protobuf.Timestamp first_attempt_started_time = 19;
+
+  // Set when a reset with restore_original_options=true is requested while a worker is running an
+  // attempt (STARTED / PAUSE_REQUESTED). The option restore is deferred so that the in-flight
+  // attempt is left undisturbed; it is applied when the worker yields and the activity transitions
+  // out of RESET_REQUESTED, so that the restored values take effect on the next attempt. For a
+  // non-running activity (SCHEDULED / PAUSED) the restore is applied immediately and this flag is
+  // not set. Reset while in CANCEL_REQUESTED or RESET_REQUESTED is rejected.
+  bool reset_restore_options = 20;
 }
 
 message ActivityCancelState {

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -541,6 +541,7 @@ var TransitionResetAttemptFailedToPaused = chasm.NewTransition(
 	func(a *Activity, ctx chasm.MutableContext, event rescheduleEvent) error {
 		attempt := a.LastAttempt.Get(ctx)
 		a.ResetKeepPaused = false
+		a.applyDeferredOptionRestore(ctx)
 		if a.ResetHeartbeats {
 			a.ResetHeartbeats = false
 			a.clearHeartbeat(ctx)
@@ -566,6 +567,7 @@ var TransitionResetAttemptFailedToScheduled = chasm.NewTransition(
 		currentTime := ctx.Now(a)
 
 		a.ResetKeepPaused = false
+		a.applyDeferredOptionRestore(ctx)
 		if a.ResetHeartbeats {
 			a.ResetHeartbeats = false
 			a.clearHeartbeat(ctx)

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -6384,9 +6384,9 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 			UpdateMask:      &fieldmaskpb.FieldMask{Paths: []string{"start_delay"}},
 		})
 		require.Error(t, err)
-		var invArg *serviceerror.InvalidArgument
-		require.ErrorAs(t, err, &invArg)
-		require.Contains(t, invArg.Message, "start_delay")
+		var failedPrecond *serviceerror.FailedPrecondition
+		require.ErrorAs(t, err, &failedPrecond)
+		require.Contains(t, failedPrecond.Message, "start_delay")
 	})
 
 	s.Run("UpdateNegative_Rejected", func(s *standaloneActivityTestSuite) {
@@ -7060,6 +7060,78 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 			"start_delay should not be restored when the activity has already dispatched")
 	})
 
+	s.Run("ResetRestoreOriginal_RecomputesScheduleToStartAndScheduleToClose", func(s *standaloneActivityTestSuite) {
+		// Create an activity with a long delay and a short ScheduleToClose.
+		// Update it to get rid of the delay -> pulls the ScheduleToClose in to a short deadline.
+		// Reset the delay back to the long value -> pushes the ScheduleToClose deadline out to delay + ScheduleToClose
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+		originalStartDelay := 4 * time.Second
+		scheduleToCloseTimeout := 2 * time.Second
+
+		// Create it with ScheduleToClose deadline = 2s + 4s
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			ActivityType:           env.Tv().ActivityType(),
+			Identity:               env.Tv().WorkerIdentity(),
+			Input:                  defaultInput,
+			TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
+			ScheduleToCloseTimeout: durationpb.New(scheduleToCloseTimeout),
+			StartDelay:             durationpb.New(originalStartDelay),
+		})
+		require.NoError(t, err)
+		describe := func() *workflowservice.DescribeActivityExecutionResponse {
+			resp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
+				ActivityId: activityID,
+				RunId:      startResp.RunId,
+			})
+			require.NoError(t, err)
+			return resp
+		}
+		desc := describe()
+		require.Equal(t,
+			desc.Info.ScheduleTime.AsTime().Add(originalStartDelay+scheduleToCloseTimeout),
+			desc.Info.ExpirationTime.AsTime())
+
+		// Update start_delay to 0: recreates the ScheduleToClose deadline = 0s + 2s.
+		_, err = env.FrontendClient().UpdateActivityExecutionOptions(s.Context(), &workflowservice.UpdateActivityExecutionOptionsRequest{
+			Namespace:       env.Namespace().String(),
+			ActivityId:      activityID,
+			RunId:           startResp.RunId,
+			ActivityOptions: &activitypb.ActivityOptions{StartDelay: durationpb.New(0)},
+			UpdateMask:      &fieldmaskpb.FieldMask{Paths: []string{"start_delay"}},
+		})
+		require.NoError(t, err)
+		desc = describe()
+		require.Equal(t,
+			desc.Info.ScheduleTime.AsTime().Add(0+scheduleToCloseTimeout),
+			desc.Info.ExpirationTime.AsTime())
+
+		// Reset start_delay to 4s: recreates ScheduleToClose deadline = 2s + 4s
+		_, err = env.FrontendClient().ResetActivityExecution(s.Context(), &workflowservice.ResetActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			RunId:                  startResp.RunId,
+			RestoreOriginalOptions: true,
+		})
+		require.NoError(t, err)
+		desc = describe()
+		require.Equal(t,
+			desc.Info.ScheduleTime.AsTime().Add(originalStartDelay+scheduleToCloseTimeout),
+			desc.Info.ExpirationTime.AsTime())
+
+		require.Never(t, func() bool {
+			return describe().GetInfo().GetStatus() == enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT
+		}, 3500*time.Millisecond, 200*time.Millisecond,
+			"ScheduleToStart and ScheduleToClose timeouts should have been pushed back to 6s by the start delay")
+
+	})
+
 	// The guard accepts the field mask path in either snake_case or camelCase form.
 	s.Run("UpdateCamelCaseFieldMask_Rejected", func(s *standaloneActivityTestSuite) {
 		t := s.T()
@@ -7485,6 +7557,63 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		require.False(t, actualStart.IsZero())
 		require.GreaterOrEqual(t, actualStart.Add(timerSafetyMargin).UnixNano(), expectedRequested.UnixNano(),
 			"activity dispatched before its original requested_start_time; unpause did not honor the original delay")
+	})
+
+	// Reset (without RestoreOriginalOptions) of an activity still inside its start_delay window must
+	// honor the remaining delay, as Unpause does.
+	s.Run("ResetDuringDelay_HonorsRemainingStartDelay", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+		startDelay := 5 * time.Second
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
+			Input:               defaultInput,
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			StartDelay:          durationpb.New(startDelay),
+		})
+		require.NoError(t, err)
+		descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		expectedDispatchTime := descResp.GetInfo().GetScheduleTime().AsTime().Add(startDelay)
+
+		// Reset while still in the delay window, before any worker pickup.
+		_, err = env.FrontendClient().ResetActivityExecution(s.Context(), &workflowservice.ResetActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+
+		// Poll: should not transition to STARTED until the start delay has elapsed
+		pollCtx, cancel := context.WithTimeout(s.Context(), 10*time.Second)
+		defer cancel()
+		pollResp, err := env.pollActivityTaskQueue(pollCtx, taskQueue)
+		require.NoError(t, err)
+		require.NotEmpty(t, pollResp.GetTaskToken())
+
+		// Assert that it STARTED after the expected dispatch time
+		descResp, err = env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		actualStart := descResp.GetInfo().GetActualStartTime().AsTime()
+		require.False(t, actualStart.IsZero())
+		require.GreaterOrEqual(t, actualStart.Add(timerSafetyMargin).UnixNano(), expectedDispatchTime.UnixNano(),
+			"activity dispatched before start delay end; Reset did not honor the remaining start delay")
 	})
 
 	// If the delay window has already elapsed by the time the activity is unpaused, the activity
@@ -9887,6 +10016,157 @@ func (s *standaloneActivityTestSuite) TestPauseActivityExecution() {
 		}, 10*time.Second, 200*time.Millisecond)
 	})
 
+	// CancelWhilePauseRequested: cancelling a STARTED activity that has a pending pause
+	// (PAUSE_REQUESTED) is accepted and recorded — cancel takes precedence over the pending pause.
+	// The worker is still running, so it is deferred (CANCEL_REQUESTED), not immediate.
+	t.Run("CancelWhilePauseRequested", func(t *testing.T) {
+		ctx := testcore.NewContext()
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		runID := startResp.RunId
+		env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+
+		// Pause the STARTED activity → PAUSE_REQUESTED.
+		_, err := env.FrontendClient().PauseActivityExecution(ctx, &workflowservice.PauseActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+			Identity:   "test-identity",
+			Reason:     "test-pause",
+		})
+		require.NoError(t, err)
+
+		_, err = env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+			Identity:   "test-identity",
+			Reason:     "test-cancel",
+			RequestId:  env.Tv().RequestID(),
+		})
+		require.NoError(t, err)
+
+		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+		})
+		require.NoError(t, err)
+		require.Equal(t, "test-cancel", descResp.GetInfo().GetCanceledReason(),
+			"cancel should be recorded even with a pending pause")
+	})
+
+	// CancelWhileResetRequested: cancelling a STARTED activity that has a pending reset
+	// (RESET_REQUESTED) is accepted and recorded — cancel takes precedence; deferred (CANCEL_REQUESTED).
+	t.Run("CancelWhileResetRequested", func(t *testing.T) {
+		ctx := testcore.NewContext()
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		runID := startResp.RunId
+		env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+
+		// Reset the STARTED activity → RESET_REQUESTED.
+		_, err := env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+		})
+		require.NoError(t, err)
+
+		_, err = env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+			Identity:   "test-identity",
+			Reason:     "test-cancel",
+			RequestId:  env.Tv().RequestID(),
+		})
+		require.NoError(t, err)
+
+		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+		})
+		require.NoError(t, err)
+		require.Equal(t, "test-cancel", descResp.GetInfo().GetCanceledReason(),
+			"cancel should be recorded even with a pending reset")
+	})
+
+	// PauseWhileResetRequested: pausing a STARTED activity that has a pending reset (RESET_REQUESTED)
+	// is rejected — RESET_REQUESTED is a non-pausable state.
+	t.Run("PauseWhileResetRequested", func(t *testing.T) {
+		ctx := testcore.NewContext()
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		runID := startResp.RunId
+		env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+
+		_, err := env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+		})
+		require.NoError(t, err)
+
+		_, err = env.FrontendClient().PauseActivityExecution(ctx, &workflowservice.PauseActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+			Identity:   "test-identity",
+			Reason:     "test-pause",
+		})
+		require.Error(t, err)
+		var failedPreconditionErr *serviceerror.FailedPrecondition
+		require.ErrorAs(t, err, &failedPreconditionErr)
+	})
+
+	// UpdateWhileCancelRequested: updating options on a STARTED activity that has a pending cancel
+	// (CANCEL_REQUESTED) is allowed — the worker is still running and the update applies to it.
+	t.Run("UpdateWhileCancelRequested", func(t *testing.T) {
+		ctx := testcore.NewContext()
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		runID := startResp.RunId
+		env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+
+		_, err := env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+			Identity:   "test-identity",
+			Reason:     "test-cancel",
+			RequestId:  env.Tv().RequestID(),
+		})
+		require.NoError(t, err)
+
+		_, err = env.FrontendClient().UpdateActivityExecutionOptions(ctx, &workflowservice.UpdateActivityExecutionOptionsRequest{
+			Namespace:       env.Namespace().String(),
+			ActivityId:      activityID,
+			RunId:           runID,
+			ActivityOptions: &activitypb.ActivityOptions{HeartbeatTimeout: durationpb.New(15 * time.Second)},
+			UpdateMask:      &fieldmaskpb.FieldMask{Paths: []string{"heartbeat_timeout"}},
+		})
+		require.NoError(t, err)
+
+		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+		})
+		require.NoError(t, err)
+		require.Equal(t, 15*time.Second, descResp.GetInfo().GetHeartbeatTimeout().AsDuration(),
+			"update should apply to the running attempt even with a pending cancel")
+	})
+
 	// TerminateWhilePaused: design doc says PAUSED + terminate → TERMINATED.
 	t.Run("TerminateWhilePaused", func(t *testing.T) {
 		ctx := testcore.NewContext()
@@ -11104,7 +11384,18 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		return startResp, pollResp, taskQueue
 	}
 
-	failRetryable := func(ctx context.Context, t *testing.T, taskToken []byte, nextRetryDelay time.Duration) {
+	pollActivity := func(ctx context.Context, t *testing.T, taskQueue string) *workflowservice.PollActivityTaskQueueResponse {
+		t.Helper()
+		pollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
+			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			Identity:  defaultIdentity,
+		})
+		require.NoError(t, err)
+		return pollResp
+	}
+
+	failAttemptRetryably := func(ctx context.Context, t *testing.T, taskToken []byte, nextRetryDelay time.Duration) {
 		t.Helper()
 		_, err := env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
 			Namespace: env.Namespace().String(),
@@ -11123,6 +11414,35 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.NoError(t, err)
 	}
 
+	failAttemptNonRetryably := func(ctx context.Context, t *testing.T, taskToken []byte) {
+		t.Helper()
+		_, err := env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
+			TaskToken: taskToken,
+			Failure: &failurepb.Failure{
+				Message: "non-retryable failure",
+				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+					ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+						NonRetryable: true,
+					},
+				},
+			},
+			Identity: defaultIdentity,
+		})
+		require.NoError(t, err)
+	}
+
+	completeAttempt := func(ctx context.Context, t *testing.T, taskToken []byte) {
+		t.Helper()
+		_, err := env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Result:    defaultResult,
+			Namespace: env.Namespace().String(),
+			TaskToken: taskToken,
+			Identity:  defaultIdentity,
+		})
+		require.NoError(t, err)
+	}
+
 	resetActivity := func(ctx context.Context, t *testing.T, activityID, runID string, resetHeartbeat bool) {
 		t.Helper()
 		_, err := env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
@@ -11130,6 +11450,17 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 			ActivityId:     activityID,
 			RunId:          runID,
 			ResetHeartbeat: resetHeartbeat,
+		})
+		require.NoError(t, err)
+	}
+
+	resetActivityRestoreOriginalOptions := func(ctx context.Context, t *testing.T, activityID, runID string) {
+		t.Helper()
+		_, err := env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			RunId:                  runID,
+			RestoreOriginalOptions: true,
 		})
 		require.NoError(t, err)
 	}
@@ -11155,6 +11486,17 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 			Identity:   defaultIdentity,
 		})
 		require.NoError(t, err)
+	}
+
+	describeActivity := func(ctx context.Context, t *testing.T, activityID, runID string) *workflowservice.DescribeActivityExecutionResponse {
+		t.Helper()
+		desc, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+		})
+		require.NoError(t, err)
+		return desc
 	}
 
 	waitForState := func(ctx context.Context, t *testing.T, activityID, runID string, state enumspb.PendingActivityState) {
@@ -11184,7 +11526,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		startResp, pollResp1, taskQueue := startAndPollActivity(ctx, t, activityID, retryPolicy)
 
 		// Fail attempt 1 with a short retry
-		failRetryable(ctx, t, pollResp1.TaskToken, time.Second)
+		failAttemptRetryably(ctx, t, pollResp1.TaskToken, time.Second)
 
 		// Poll attempt 2
 		pollResp2, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
@@ -11196,7 +11538,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.EqualValues(t, 2, pollResp2.Attempt)
 
 		// Fail attempt 2 with a long backoff so the activity is SCHEDULED waiting
-		failRetryable(ctx, t, pollResp2.TaskToken, 60*time.Second)
+		failAttemptRetryably(ctx, t, pollResp2.TaskToken, 60*time.Second)
 
 		// Verify activity is SCHEDULED (backing off at attempt 3)
 		await.Require(ctx, t, func(c *await.T) {
@@ -11261,7 +11603,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, desc.GetInfo().GetRunState())
 
 		// Fail the running attempt — triggers deferred reset in TransitionRescheduled
-		failRetryable(ctx, t, pollResp1.TaskToken, 0)
+		failAttemptRetryably(ctx, t, pollResp1.TaskToken, 0)
 
 		// Poll the retry — should be attempt 1
 		pollResp2, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
@@ -11347,7 +11689,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		startResp, pollResp1, taskQueue := startAndPollActivity(ctx, t, activityID, retryPolicy)
 
 		// Fail attempt 1 — now backing off for 1 minute
-		failRetryable(ctx, t, pollResp1.TaskToken, 0)
+		failAttemptRetryably(ctx, t, pollResp1.TaskToken, 0)
 
 		// Verify in SCHEDULED state
 		await.Require(ctx, t, func(c *await.T) {
@@ -11413,7 +11755,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.NotNil(t, desc.GetInfo().GetHeartbeatDetails())
 
 		// Fail the attempt with long backoff
-		failRetryable(ctx, t, pollResp1.TaskToken, 60*time.Second)
+		failAttemptRetryably(ctx, t, pollResp1.TaskToken, 60*time.Second)
 
 		// Wait for SCHEDULED state
 		await.Require(ctx, t, func(c *await.T) {
@@ -11501,7 +11843,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.NotNil(t, desc.GetInfo().GetHeartbeatDetails(), "heartbeat should still be visible before the attempt fails")
 
 		// Fail the running attempt — triggers deferred reset+heartbeat clear in TransitionRescheduled
-		failRetryable(ctx, t, pollResp1.TaskToken, 0)
+		failAttemptRetryably(ctx, t, pollResp1.TaskToken, 0)
 
 		// Poll retry — attempt=1, heartbeat details cleared
 		pollResp2, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
@@ -11583,7 +11925,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		startResp, pollResp1, taskQueue := startAndPollActivity(ctx, t, activityID, retryPolicy)
 
 		// Fail attempt 1 with a short override retry so it enters backoff
-		failRetryable(ctx, t, pollResp1.TaskToken, 0)
+		failAttemptRetryably(ctx, t, pollResp1.TaskToken, 0)
 
 		// Wait for SCHEDULED state (retry backoff)
 		await.Require(ctx, t, func(c *await.T) {
@@ -11675,7 +12017,209 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.NoError(t, err)
 	})
 
-	t.Run("RestoreOriginalOptions", func(t *testing.T) {
+	t.Run("ScheduledWithPauseStateKeepPausedFalse", func(t *testing.T) {
+		// PAUSED activity (SCHEDULED status), reset with keepPaused=false.
+		// Verify: attempt count reset to 1 and the activity dispatches (does not stay paused).
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		startResp, pollResp1, taskQueue := startAndPollActivity(ctx, t, activityID, &commonpb.RetryPolicy{
+			InitialInterval:    durationpb.New(time.Second),
+			BackoffCoefficient: 1.0,
+		})
+
+		// Fail attempt 1 → SCHEDULED backoff.
+		failAttemptRetryably(ctx, t, pollResp1.TaskToken, 0)
+		waitForState(ctx, t, activityID, startResp.GetRunId(), enumspb.PENDING_ACTIVITY_STATE_SCHEDULED)
+
+		// Pause → PAUSED.
+		pauseActivity(ctx, t, activityID, startResp.GetRunId())
+		waitForState(ctx, t, activityID, startResp.GetRunId(), enumspb.PENDING_ACTIVITY_STATE_PAUSED)
+
+		// Reset with keepPaused=false — should dispatch at attempt 1 (not stay paused).
+		_, err := env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.GetRunId(),
+			KeepPaused: false,
+		})
+		require.NoError(t, err)
+
+		pollResp2, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
+			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			Identity:  defaultIdentity,
+		})
+		require.NoError(t, err)
+		require.EqualValues(t, 1, pollResp2.Attempt, "attempt should be reset to 1")
+
+		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
+			TaskToken: pollResp2.TaskToken,
+			Result:    defaultResult,
+			Identity:  defaultIdentity,
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("StartedWithPauseStateKeepPausedFalse", func(t *testing.T) {
+		// PAUSE_REQUESTED activity (STARTED status), reset with keepPaused=false.
+		// Reset is deferred; without ResetKeepPaused the next retry dispatches instead of pausing.
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		startResp, pollResp1, taskQueue := startAndPollActivity(ctx, t, activityID, &commonpb.RetryPolicy{
+			InitialInterval:    durationpb.New(time.Second),
+			BackoffCoefficient: 1.0,
+		})
+		require.EqualValues(t, 1, pollResp1.Attempt)
+
+		// Pause while STARTED → status becomes PAUSE_REQUESTED (worker still running).
+		pauseActivity(ctx, t, activityID, startResp.GetRunId())
+		waitForState(ctx, t, activityID, startResp.GetRunId(), enumspb.PENDING_ACTIVITY_STATE_PAUSE_REQUESTED)
+
+		// Reset with keepPaused=false — deferred; ResetKeepPaused stays false so dispatch isn't blocked.
+		_, err := env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.GetRunId(),
+			KeepPaused: false,
+		})
+		require.NoError(t, err)
+
+		// Fail the running attempt — triggers TransitionRescheduled with the deferred reset.
+		failAttemptRetryably(ctx, t, pollResp1.TaskToken, 0)
+
+		// Activity should dispatch (not be stuck paused) at attempt 1.
+		pollResp2, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
+			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			Identity:  defaultIdentity,
+		})
+		require.NoError(t, err)
+		require.EqualValues(t, 1, pollResp2.Attempt, "attempt should be reset to 1 after deferred reset")
+
+		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
+			TaskToken: pollResp2.TaskToken,
+			Result:    defaultResult,
+			Identity:  defaultIdentity,
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("StartedWithPauseStateKeepPausedTrue", func(t *testing.T) {
+		// PAUSE_REQUESTED activity (STARTED status), reset with keepPaused=true.
+		// Reset is deferred; ResetKeepPaused is set so after the retry the activity stays paused.
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		startResp, pollResp1, taskQueue := startAndPollActivity(ctx, t, activityID, &commonpb.RetryPolicy{
+			InitialInterval:    durationpb.New(time.Second),
+			BackoffCoefficient: 1.0,
+		})
+		require.EqualValues(t, 1, pollResp1.Attempt)
+
+		// Pause while STARTED.
+		pauseActivity(ctx, t, activityID, startResp.GetRunId())
+		waitForState(ctx, t, activityID, startResp.GetRunId(), enumspb.PENDING_ACTIVITY_STATE_PAUSE_REQUESTED)
+
+		// Reset with keepPaused=true — deferred; ResetKeepPaused should be set.
+		_, err := env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.GetRunId(),
+			KeepPaused: true,
+		})
+		require.NoError(t, err)
+
+		// Fail the running attempt.
+		failAttemptRetryably(ctx, t, pollResp1.TaskToken, 0)
+
+		// Activity should be PAUSED at attempt 1 (deferred reset + preserved pause).
+		await.Require(ctx, t, func(c *await.T) {
+			desc, err := env.FrontendClient().DescribeActivityExecution(c.Context(), &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
+				ActivityId: activityID,
+				RunId:      startResp.GetRunId(),
+			})
+			require.NoError(c, err)
+			require.Equal(c, enumspb.PENDING_ACTIVITY_STATE_PAUSED, desc.GetInfo().GetRunState())
+			require.EqualValues(c, 1, desc.GetInfo().GetAttempt())
+		}, 5*time.Second, 100*time.Millisecond)
+
+		// Unpause and verify dispatch at attempt 1.
+		unpauseActivity(ctx, t, activityID, startResp.GetRunId())
+
+		pollResp2, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
+			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			Identity:  defaultIdentity,
+		})
+		require.NoError(t, err)
+		require.EqualValues(t, 1, pollResp2.Attempt)
+
+		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
+			TaskToken: pollResp2.TaskToken,
+			Result:    defaultResult,
+			Identity:  defaultIdentity,
+		})
+		require.NoError(t, err)
+	})
+
+	// startAttemptWithTimeouts starts a SAA with the given per-attempt timeouts and retry policy and
+	// polls it to STARTED, returning the start response, the in-flight task token, and the task queue.
+	startAttemptWithTimeouts := func(ctx context.Context, t *testing.T, activityID string, startToClose, heartbeat time.Duration) (
+		*workflowservice.StartActivityExecutionResponse, []byte,
+	) {
+		t.Helper()
+		taskQueue := testcore.RandomizeStr(t.Name())
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            defaultIdentity,
+			Input:               defaultInput,
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout: durationpb.New(startToClose),
+			HeartbeatTimeout:    durationpb.New(heartbeat),
+			RetryPolicy: &commonpb.RetryPolicy{
+				InitialInterval:    durationpb.New(10 * time.Second),
+				BackoffCoefficient: 1.0,
+				MaximumAttempts:    10,
+			},
+			RequestId: testcore.RandomizeStr(activityID),
+		})
+		require.NoError(t, err)
+		pollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
+			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			Identity:  defaultIdentity,
+		})
+		require.NoError(t, err)
+		return startResp, pollResp.GetTaskToken()
+	}
+
+	updateTimeouts := func(ctx context.Context, t *testing.T, activityID, runID string, startToClose, heartbeat time.Duration) {
+		t.Helper()
+		_, err := env.FrontendClient().UpdateActivityExecutionOptions(ctx, &workflowservice.UpdateActivityExecutionOptionsRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+			ActivityOptions: &activitypb.ActivityOptions{
+				StartToCloseTimeout: durationpb.New(startToClose),
+				HeartbeatTimeout:    durationpb.New(heartbeat),
+			},
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"start_to_close_timeout", "heartbeat_timeout"}},
+		})
+		require.NoError(t, err)
+	}
+
+	t.Run("RestoreOriginalOptions_WhileScheduled", func(t *testing.T) {
 		// Start activity with specific options, update them, then reset with
 		// RestoreOriginalOptions=true and verify the original options come back
 		// along with the attempt count being reset to 1.
@@ -11691,8 +12235,10 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		}
 		startResp, pollResp1, taskQueue := startAndPollActivity(ctx, t, activityID, retryPolicy)
 
-		// Fail attempt 1 with a long backoff so the activity is SCHEDULED backing off.
-		failRetryable(ctx, t, pollResp1.TaskToken, 60*time.Second)
+		// Fail attempt 1 with a short backoff so the activity is SCHEDULED backing off (this test
+		// covers option restoration, not backoff timing; the interval elapses before the reset so
+		// the honored re-dispatch is immediate).
+		failAttemptRetryably(ctx, t, pollResp1.TaskToken, time.Second)
 
 		await.Require(ctx, t, func(c *await.T) {
 			desc, err := env.FrontendClient().DescribeActivityExecution(c.Context(), &workflowservice.DescribeActivityExecutionRequest{
@@ -11761,129 +12307,472 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.NoError(t, err)
 	})
 
-	t.Run("ScheduledWithPauseStateKeepPausedFalse", func(t *testing.T) {
-		// PAUSED activity (SCHEDULED status), reset with keepPaused=false.
-		// Verify: attempt count reset to 1 and the activity dispatches (does not stay paused).
+	t.Run("RestoreOriginalOptions_WhileStarted_AttemptFailsRetryably", func(t *testing.T) {
+		cases := []struct {
+			name        string
+			maxAttempts int32
+		}{
+			{"RetriesRemainingWhenApplyingPendingReset", 10},
+			// The pending reset must be honored even if the "should retry" decision would otherwise be "no".
+			{"RetriesExhaustedWhenApplyingPendingReset", 2},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				activityID := testcore.RandomizeStr(t.Name())
+
+				// Start the first attempt, and then fail it so that we're on attempt 2
+				startResp, pollResp, taskQueue := startAndPollActivity(ctx, t, activityID, &commonpb.RetryPolicy{
+					InitialInterval:    durationpb.New(1 * time.Second),
+					BackoffCoefficient: 1.0,
+					MaximumAttempts:    tc.maxAttempts,
+				})
+				failAttemptRetryably(ctx, t, pollResp.TaskToken, 0)
+				desc := describeActivity(ctx, t, activityID, startResp.GetRunId())
+				require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, desc.GetInfo().GetRunState(), "expected in SCHEDULED")
+				require.EqualValues(t, 2, desc.GetInfo().GetAttempt(), "expected attempt 2")
+				originalTimeouts := []time.Duration{
+					desc.GetInfo().GetStartToCloseTimeout().AsDuration(),
+					desc.GetInfo().GetHeartbeatTimeout().AsDuration(),
+				}
+				updatedTimeouts := []time.Duration{
+					originalTimeouts[0] + 1*time.Second,
+					originalTimeouts[1] + 1*time.Second,
+				}
+				// Start the second attempt
+				pollResp = pollActivity(ctx, t, taskQueue)
+				require.EqualValues(t, 2, pollResp.Attempt)
+
+				// Update some options
+				updateTimeouts(ctx, t, activityID, startResp.GetRunId(), updatedTimeouts[0], updatedTimeouts[1])
+				desc = describeActivity(ctx, t, activityID, startResp.GetRunId())
+				require.Equal(t, updatedTimeouts[0], desc.GetInfo().GetStartToCloseTimeout().AsDuration())
+				require.Equal(t, updatedTimeouts[1], desc.GetInfo().GetHeartbeatTimeout().AsDuration())
+
+				// Reset(RestoreOriginals) -> RESET_REQUESTED
+				resetActivityRestoreOriginalOptions(ctx, t, activityID, startResp.GetRunId())
+
+				// Fail attempt retryably -> should reset
+				failAttemptRetryably(ctx, t, pollResp.TaskToken, 0)
+
+				// The reset should have been applied with the restore
+				desc = describeActivity(ctx, t, activityID, startResp.GetRunId())
+				require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, desc.GetInfo().GetRunState(), "expected in SCHEDULED")
+				require.EqualValues(t, 1, desc.GetInfo().GetAttempt(), "expected attempt 1")
+				require.Equal(t, originalTimeouts[0], desc.GetInfo().GetStartToCloseTimeout().AsDuration(),
+					"reset should have restored options")
+				require.Equal(t, originalTimeouts[1], desc.GetInfo().GetHeartbeatTimeout().AsDuration(),
+					"reset should have restored options")
+			})
+		}
+	})
+
+	t.Run("RestoreOriginalOptions_WhileStarted_AttemptFailsNonRetryably", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-
 		activityID := testcore.RandomizeStr(t.Name())
-		startResp, pollResp1, taskQueue := startAndPollActivity(ctx, t, activityID, &commonpb.RetryPolicy{
-			InitialInterval:    durationpb.New(time.Second),
-			BackoffCoefficient: 1.0,
-		})
+		originalTimeouts := []time.Duration{60 * time.Second, 50 * time.Second}
+		updatedTimeouts := []time.Duration{30 * time.Second, 20 * time.Second}
 
-		// Fail attempt 1 → SCHEDULED backoff.
-		failRetryable(ctx, t, pollResp1.TaskToken, 0)
-		waitForState(ctx, t, activityID, startResp.GetRunId(), enumspb.PENDING_ACTIVITY_STATE_SCHEDULED)
+		// Start the first attempt and then update the timeouts
+		startResp, taskToken := startAttemptWithTimeouts(ctx, t, activityID, originalTimeouts[0], originalTimeouts[1])
+		updateTimeouts(ctx, t, activityID, startResp.GetRunId(), updatedTimeouts[0], updatedTimeouts[1])
 
-		// Pause → PAUSED.
-		pauseActivity(ctx, t, activityID, startResp.GetRunId())
-		waitForState(ctx, t, activityID, startResp.GetRunId(), enumspb.PENDING_ACTIVITY_STATE_PAUSED)
-
-		// Reset with keepPaused=false — should dispatch at attempt 1 (not stay paused).
+		// Reset(RestoreOriginals) -> RESET_REQUESTED
 		_, err := env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			RunId:                  startResp.GetRunId(),
+			RestoreOriginalOptions: true,
+		})
+		require.NoError(t, err)
+
+		// Fail attempt non-retryably -> Activity terminal failure
+		failAttemptNonRetryably(ctx, t, taskToken)
+
+		// The activity should have failed and the restore changes should never have been applied
+		desc, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
 			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
 			RunId:      startResp.GetRunId(),
-			KeepPaused: false,
 		})
 		require.NoError(t, err)
-
-		pollResp2, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: env.Namespace().String(),
-			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-			Identity:  defaultIdentity,
-		})
-		require.NoError(t, err)
-		require.EqualValues(t, 1, pollResp2.Attempt, "attempt should be reset to 1")
-
-		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-			Namespace: env.Namespace().String(),
-			TaskToken: pollResp2.TaskToken,
-			Result:    defaultResult,
-			Identity:  defaultIdentity,
-		})
-		require.NoError(t, err)
+		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_FAILED, desc.GetInfo().GetStatus())
+		require.EqualValues(t, 1, desc.GetInfo().GetAttempt())
+		require.Equal(t, updatedTimeouts[0], desc.GetInfo().GetStartToCloseTimeout().AsDuration(),
+			"terminal failure with reset requested should not have restored options")
+		require.Equal(t, updatedTimeouts[1], desc.GetInfo().GetHeartbeatTimeout().AsDuration(),
+			"terminal failure with reset requested should not have restored options")
 	})
 
-	t.Run("StartedWithPauseStateKeepPausedFalse", func(t *testing.T) {
-		// PAUSE_REQUESTED activity (STARTED status), reset with keepPaused=false.
-		// Reset is deferred; without ResetKeepPaused the next retry dispatches instead of pausing.
+	t.Run("RestoreOriginalOptions_WhileStarted_AttemptSucceeds", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		activityID := testcore.RandomizeStr(t.Name())
+		originalTimeouts := []time.Duration{60 * time.Second, 50 * time.Second}
+		updatedTimeouts := []time.Duration{30 * time.Second, 20 * time.Second}
+
+		// Start the first attempt and then update the timeouts
+		startResp, taskToken := startAttemptWithTimeouts(ctx, t, activityID, originalTimeouts[0], originalTimeouts[1])
+		updateTimeouts(ctx, t, activityID, startResp.GetRunId(), updatedTimeouts[0], updatedTimeouts[1])
+
+		// Reset(RestoreOriginals) -> RESET_REQUESTED
+		_, err := env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			RunId:                  startResp.GetRunId(),
+			RestoreOriginalOptions: true,
+		})
+		require.NoError(t, err)
+
+		// Complete attempt -> Activity succeeds
+		completeAttempt(ctx, t, taskToken)
+
+		// The activity should have succeeded and the restore changes should never have been applied
+		desc, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.GetRunId(),
+		})
+		require.NoError(t, err)
+		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, desc.GetInfo().GetStatus())
+		require.EqualValues(t, 1, desc.GetInfo().GetAttempt())
+		require.Equal(t, updatedTimeouts[0], desc.GetInfo().GetStartToCloseTimeout().AsDuration(),
+			"completion with reset requested should not have restored options")
+		require.Equal(t, updatedTimeouts[1], desc.GetInfo().GetHeartbeatTimeout().AsDuration(),
+			"completion with reset requested should not have restored options")
+	})
+
+	s.Run("RestoreOriginalOptions_OnStarted_DefersScheduleToCloseRestore", func(s *standaloneActivityTestSuite) {
+		// Reset(RestoreOriginalOptions) on a STARTED attempt must NOT move the in-flight attempt's
+		// ScheduleToClose deadline. Reset means "restart at attempt 1"; every restored option — including
+		// the ScheduleToClose lifetime budget — takes effect only when the reset lands on the next
+		// attempt, never on the attempt that happens to be running when the reset is issued.
+		//
+		// Setup: create with ScheduleToClose=2s (so the restored original is short). Start it, then extend
+		// ScheduleToClose and StartToClose to 8s so the in-flight attempt is governed by 8s.
+		// Reset(RestoreOriginalOptions) restores the 2s originals. If the restore leaked onto the in-flight
+		// attempt the activity would time out at the 2s deadline; correct (deferred) behavior leaves the
+		// running attempt on its current 8s budget.
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			ActivityType:           env.Tv().ActivityType(),
+			Identity:               env.Tv().WorkerIdentity(),
+			Input:                  defaultInput,
+			TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
+			ScheduleToCloseTimeout: durationpb.New(2 * time.Second),
+		})
+		require.NoError(t, err)
+
+		// Transition to STARTED; worker never responds
+		_, err = env.FrontendClient().PollActivityTaskQueue(s.Context(), &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
+			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		})
+		require.NoError(t, err)
+
+		// Extend ScheduleToClose and StartToClose to 8s: the in-flight attempt is now governed by 8s.
+		_, err = env.FrontendClient().UpdateActivityExecutionOptions(s.Context(), &workflowservice.UpdateActivityExecutionOptionsRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+			ActivityOptions: &activitypb.ActivityOptions{
+				ScheduleToCloseTimeout: durationpb.New(8 * time.Second),
+				StartToCloseTimeout:    durationpb.New(8 * time.Second),
+			},
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"schedule_to_close_timeout", "start_to_close_timeout"}},
+		})
+		require.NoError(t, err)
+
+		// Reset(RestoreOriginalOptions): restores ScheduleToClose to 2s. The restore must be deferred to
+		// the reset landing, leaving the in-flight attempt on its current 8s deadline.
+		_, err = env.FrontendClient().ResetActivityExecution(s.Context(), &workflowservice.ResetActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			RunId:                  startResp.RunId,
+			RestoreOriginalOptions: true,
+		})
+		require.NoError(t, err)
+
+		// The in-flight attempt must not time out at the restored 2s deadline. Buggy code re-arms
+		// ScheduleToClose at 2s immediately → TIMED_OUT within ~2s; correct code leaves it at 8s.
+		require.Never(t, func() bool {
+			resp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
+				ActivityId: activityID,
+				RunId:      startResp.RunId,
+			})
+			if err != nil {
+				return false // a poll that loses the race to teardown must not fail the test
+			}
+			return resp.GetInfo().GetStatus() == enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT
+		}, 4*time.Second, 200*time.Millisecond,
+			"in-flight attempt must keep its current 8s ScheduleToClose; RestoreOriginalOptions must defer the restore of the 2s original to the reset landing")
+	})
+
+	// Reset during a running attempt is a DEFERRED reset: the activity goes to RESET_REQUESTED, the
+	// worker keeps running the in-flight attempt under its current terms, and the reset lands (attempt
+	// count -> 1, re-dispatch) only when the worker yields. RestoreOriginalOptions must leave the running
+	// attempt UNDISTURBED: EVERY restored option takes effect only when the reset lands on the next
+	// attempt — none may be applied to, or reported for, the in-flight attempt. This includes the
+	// ScheduleToClose lifetime budget (see ResetRestoreOriginal_OnStarted_DefersScheduleToCloseRestore
+	// for the timer-firing proof) as well as RetryPolicy and Priority. start_delay is already skipped for
+	// a started attempt (it only governs the first dispatch).
+	//
+	// The bug: the restore block mutates the option fields immediately, before entering RESET_REQUESTED,
+	// so the reported options diverge from the values the in-flight attempt is actually governed by. The
+	// discriminator here is the reported state during RESET_REQUESTED: it must still reflect the updated
+	// (pre-restore) values, not the restored originals.
+	s.Run("ResetRestoreOriginal_OnStarted_DefersPerAttemptOptionRestore", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		// Originals: long timeouts and a distinctive retry policy / priority, restored on the reset
+		// landing. Updated to different values below; no timer fires during the test.
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			ActivityType:           env.Tv().ActivityType(),
+			Identity:               env.Tv().WorkerIdentity(),
+			Input:                  defaultInput,
+			TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
+			ScheduleToCloseTimeout: durationpb.New(120 * time.Second),
+			StartToCloseTimeout:    durationpb.New(60 * time.Second),
+			HeartbeatTimeout:       durationpb.New(50 * time.Second),
+			RetryPolicy: &commonpb.RetryPolicy{
+				InitialInterval:    durationpb.New(10 * time.Second),
+				BackoffCoefficient: 2.0,
+				MaximumAttempts:    5,
+			},
+			Priority: &commonpb.Priority{PriorityKey: 1},
+		})
+		require.NoError(t, err)
+
+		// Transition to STARTED; the worker never responds.
+		pollResp, err := env.pollActivityTaskQueue(s.Context(), taskQueue)
+		require.NoError(t, err)
+		require.NotEmpty(t, pollResp.GetTaskToken())
+
+		// Update every option: the in-flight attempt is now governed by these (updated) values.
+		_, err = env.FrontendClient().UpdateActivityExecutionOptions(s.Context(), &workflowservice.UpdateActivityExecutionOptionsRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+			ActivityOptions: &activitypb.ActivityOptions{
+				ScheduleToCloseTimeout: durationpb.New(90 * time.Second),
+				StartToCloseTimeout:    durationpb.New(30 * time.Second),
+				HeartbeatTimeout:       durationpb.New(20 * time.Second),
+				RetryPolicy: &commonpb.RetryPolicy{
+					InitialInterval:    durationpb.New(7 * time.Second),
+					BackoffCoefficient: 3.0,
+					MaximumAttempts:    9,
+				},
+				Priority: &commonpb.Priority{PriorityKey: 4},
+			},
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{
+				"schedule_to_close_timeout", "start_to_close_timeout", "heartbeat_timeout", "retry_policy", "priority",
+			}},
+		})
+		require.NoError(t, err)
+
+		// Reset(RestoreOriginalOptions) -> RESET_REQUESTED. The in-flight attempt should be left undisturbed.
+		_, err = env.FrontendClient().ResetActivityExecution(s.Context(), &workflowservice.ResetActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			RunId:                  startResp.RunId,
+			RestoreOriginalOptions: true,
+		})
+		require.NoError(t, err)
+
+		// During RESET_REQUESTED, Describe must still report the updated (in-flight) values for every
+		// option. The restored originals must not surface until the reset lands on the next attempt.
+		descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		got := descResp.GetInfo()
+		require.Equal(t, 30*time.Second, got.GetStartToCloseTimeout().AsDuration(),
+			"running attempt must keep its current StartToClose (30s); RestoreOriginalOptions must defer the restore until the reset lands")
+		require.Equal(t, 20*time.Second, got.GetHeartbeatTimeout().AsDuration(),
+			"running attempt must keep its current Heartbeat (20s); RestoreOriginalOptions must defer the restore until the reset lands")
+		require.Equal(t, 90*time.Second, got.GetScheduleToCloseTimeout().AsDuration(),
+			"running attempt must keep its current ScheduleToClose (90s); RestoreOriginalOptions must defer the restore until the reset lands")
+		require.Equal(t, 7*time.Second, got.GetRetryPolicy().GetInitialInterval().AsDuration(),
+			"running attempt must keep its current RetryPolicy; RestoreOriginalOptions must defer the restore until the reset lands")
+		require.EqualValues(t, 9, got.GetRetryPolicy().GetMaximumAttempts(),
+			"running attempt must keep its current RetryPolicy; RestoreOriginalOptions must defer the restore until the reset lands")
+		require.EqualValues(t, 4, got.GetPriority().GetPriorityKey(),
+			"running attempt must keep its current Priority; RestoreOriginalOptions must defer the restore until the reset lands")
+	})
+
+	// Companion to the two deferral tests above: once the worker yields and the reset LANDS on the next
+	// attempt, the restored options must take effect. Deferral must not mean "dropped." (This passes both
+	// before and after the in-flight-deferral fix; it guards the landing path.)
+	s.Run("ResetRestoreOriginal_OnStarted_AppliesRestoredOptionsOnLanding", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			ActivityType:           env.Tv().ActivityType(),
+			Identity:               env.Tv().WorkerIdentity(),
+			Input:                  defaultInput,
+			TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
+			ScheduleToCloseTimeout: durationpb.New(15 * time.Minute),
+			StartToCloseTimeout:    durationpb.New(60 * time.Second),
+			HeartbeatTimeout:       durationpb.New(50 * time.Second),
+			RetryPolicy: &commonpb.RetryPolicy{
+				InitialInterval:    durationpb.New(time.Second),
+				BackoffCoefficient: 1.0,
+			},
+		})
+		require.NoError(t, err)
+
+		pollResp1, err := env.pollActivityTaskQueue(s.Context(), taskQueue)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, pollResp1.GetAttempt())
+
+		// Update the per-attempt timeouts for the in-flight attempt.
+		_, err = env.FrontendClient().UpdateActivityExecutionOptions(s.Context(), &workflowservice.UpdateActivityExecutionOptionsRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+			ActivityOptions: &activitypb.ActivityOptions{
+				StartToCloseTimeout: durationpb.New(30 * time.Second),
+				HeartbeatTimeout:    durationpb.New(20 * time.Second),
+			},
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"start_to_close_timeout", "heartbeat_timeout"}},
+		})
+		require.NoError(t, err)
+
+		// Reset(RestoreOriginalOptions) while STARTED -> RESET_REQUESTED (restore deferred).
+		_, err = env.FrontendClient().ResetActivityExecution(s.Context(), &workflowservice.ResetActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			RunId:                  startResp.RunId,
+			RestoreOriginalOptions: true,
+		})
+		require.NoError(t, err)
+
+		// Worker yields with a retryable failure -> the reset lands at attempt 1, applying the restore.
+		_, err = env.FrontendClient().RespondActivityTaskFailed(s.Context(), &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
+			TaskToken: pollResp1.GetTaskToken(),
+			Failure: &failurepb.Failure{
+				Message: "retryable failure",
+				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+					ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+						NonRetryable:   false,
+						NextRetryDelay: durationpb.New(0),
+					},
+				},
+			},
+			Identity: env.Tv().WorkerIdentity(),
+		})
+		require.NoError(t, err)
+
+		// The new attempt is dispatched at attempt 1 under the RESTORED per-attempt timeouts (60s / 50s).
+		pollResp2, err := env.pollActivityTaskQueue(s.Context(), taskQueue)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, pollResp2.GetAttempt(), "reset lands at attempt 1")
+		require.Equal(t, 60*time.Second, pollResp2.GetStartToCloseTimeout().AsDuration(),
+			"new attempt must run under the restored StartToClose (60s)")
+		require.Equal(t, 50*time.Second, pollResp2.GetHeartbeatTimeout().AsDuration(),
+			"new attempt must run under the restored Heartbeat (50s)")
+	})
+
+	// ResetRestoreOriginal_Started_AppliesDeferredRestoreOnReschedule covers the *apply* half of the
+	// deferred per-attempt option restore. ResetRestoreOriginal_OnStarted_DefersPerAttemptOptionRestore
+	// (in TestStartDelay) only checks that the restore is deferred while the attempt is in flight; this
+	// drives the attempt to fail with retries remaining so the reset lands in SCHEDULED, and checks the
+	// next attempt actually carries the restored timeouts. Without applyDeferredOptionRestore the next
+	// attempt would keep the in-flight (updated) values.
+	t.Run("ResetRestoreOriginal_Started_AppliesDeferredRestoreOnReschedule", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
 		activityID := testcore.RandomizeStr(t.Name())
-		startResp, pollResp1, taskQueue := startAndPollActivity(ctx, t, activityID, &commonpb.RetryPolicy{
-			InitialInterval:    durationpb.New(time.Second),
-			BackoffCoefficient: 1.0,
-		})
-		require.EqualValues(t, 1, pollResp1.Attempt)
+		startResp, taskToken := startAttemptWithTimeouts(ctx, t, activityID, 60*time.Second, 50*time.Second)
 
-		// Pause while STARTED → status becomes PAUSE_REQUESTED (worker still running).
+		// In-flight attempt is now governed by 30s/20s.
+		updateTimeouts(ctx, t, activityID, startResp.GetRunId(), 30*time.Second, 20*time.Second)
+
+		// Reset with RestoreOriginalOptions while running -> RESET_REQUESTED, restore deferred.
+		_, err := env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			RunId:                  startResp.GetRunId(),
+			RestoreOriginalOptions: true,
+		})
+		require.NoError(t, err)
+
+		// Worker yields with retries remaining -> reset lands in SCHEDULED at attempt 1 and the deferred
+		// restore is applied, so the next attempt carries the original 60s/50s.
+		failAttemptRetryably(ctx, t, taskToken, 0)
+
+		await.Require(ctx, t, func(c *await.T) {
+			desc, err := env.FrontendClient().DescribeActivityExecution(c.Context(), &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
+				ActivityId: activityID,
+				RunId:      startResp.GetRunId(),
+			})
+			require.NoError(c, err)
+			require.Equal(c, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, desc.GetInfo().GetRunState())
+			require.EqualValues(c, 1, desc.GetInfo().GetAttempt())
+			require.Equal(c, 60*time.Second, desc.GetInfo().GetStartToCloseTimeout().AsDuration(),
+				"next attempt must carry the restored StartToClose (60s); the deferred restore must be applied on the reset landing")
+			require.Equal(c, 50*time.Second, desc.GetInfo().GetHeartbeatTimeout().AsDuration(),
+				"next attempt must carry the restored Heartbeat (50s)")
+		}, 5*time.Second, 100*time.Millisecond)
+	})
+
+	// ResetRestoreOriginal_KeepPaused_AppliesDeferredRestoreOnPausedLanding is the same as the test
+	// above but for the PAUSED landing: reset with KeepPaused on a paused (PAUSE_REQUESTED) running
+	// attempt, then fail it. The reset lands in PAUSED via TransitionResetAttemptFailedToPaused, which
+	// must also apply the deferred restore so the paused activity carries the original timeouts.
+	t.Run("ResetRestoreOriginal_KeepPaused_AppliesDeferredRestoreOnPausedLanding", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		startResp, taskToken := startAttemptWithTimeouts(ctx, t, activityID, 60*time.Second, 50*time.Second)
+
+		updateTimeouts(ctx, t, activityID, startResp.GetRunId(), 30*time.Second, 20*time.Second)
+
+		// Pause the running attempt -> PAUSE_REQUESTED.
 		pauseActivity(ctx, t, activityID, startResp.GetRunId())
 		waitForState(ctx, t, activityID, startResp.GetRunId(), enumspb.PENDING_ACTIVITY_STATE_PAUSE_REQUESTED)
 
-		// Reset with keepPaused=false — deferred; ResetKeepPaused stays false so dispatch isn't blocked.
+		// Reset with RestoreOriginalOptions + KeepPaused -> RESET_REQUESTED, restore deferred, pause kept.
 		_, err := env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
-			Namespace:  env.Namespace().String(),
-			ActivityId: activityID,
-			RunId:      startResp.GetRunId(),
-			KeepPaused: false,
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			RunId:                  startResp.GetRunId(),
+			RestoreOriginalOptions: true,
+			KeepPaused:             true,
 		})
 		require.NoError(t, err)
 
-		// Fail the running attempt — triggers TransitionRescheduled with the deferred reset.
-		failRetryable(ctx, t, pollResp1.TaskToken, 0)
+		// Worker yields -> reset lands in PAUSED at attempt 1 and the deferred restore is applied.
+		failAttemptRetryably(ctx, t, taskToken, 0)
 
-		// Activity should dispatch (not be stuck paused) at attempt 1.
-		pollResp2, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: env.Namespace().String(),
-			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-			Identity:  defaultIdentity,
-		})
-		require.NoError(t, err)
-		require.EqualValues(t, 1, pollResp2.Attempt, "attempt should be reset to 1 after deferred reset")
-
-		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-			Namespace: env.Namespace().String(),
-			TaskToken: pollResp2.TaskToken,
-			Result:    defaultResult,
-			Identity:  defaultIdentity,
-		})
-		require.NoError(t, err)
-	})
-
-	t.Run("StartedWithPauseStateKeepPausedTrue", func(t *testing.T) {
-		// PAUSE_REQUESTED activity (STARTED status), reset with keepPaused=true.
-		// Reset is deferred; ResetKeepPaused is set so after the retry the activity stays paused.
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-
-		activityID := testcore.RandomizeStr(t.Name())
-		startResp, pollResp1, taskQueue := startAndPollActivity(ctx, t, activityID, &commonpb.RetryPolicy{
-			InitialInterval:    durationpb.New(time.Second),
-			BackoffCoefficient: 1.0,
-		})
-		require.EqualValues(t, 1, pollResp1.Attempt)
-
-		// Pause while STARTED.
-		pauseActivity(ctx, t, activityID, startResp.GetRunId())
-		waitForState(ctx, t, activityID, startResp.GetRunId(), enumspb.PENDING_ACTIVITY_STATE_PAUSE_REQUESTED)
-
-		// Reset with keepPaused=true — deferred; ResetKeepPaused should be set.
-		_, err := env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
-			Namespace:  env.Namespace().String(),
-			ActivityId: activityID,
-			RunId:      startResp.GetRunId(),
-			KeepPaused: true,
-		})
-		require.NoError(t, err)
-
-		// Fail the running attempt.
-		failRetryable(ctx, t, pollResp1.TaskToken, 0)
-
-		// Activity should be PAUSED at attempt 1 (deferred reset + preserved pause).
 		await.Require(ctx, t, func(c *await.T) {
 			desc, err := env.FrontendClient().DescribeActivityExecution(c.Context(), &workflowservice.DescribeActivityExecutionRequest{
 				Namespace:  env.Namespace().String(),
@@ -11893,26 +12782,54 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 			require.NoError(c, err)
 			require.Equal(c, enumspb.PENDING_ACTIVITY_STATE_PAUSED, desc.GetInfo().GetRunState())
 			require.EqualValues(c, 1, desc.GetInfo().GetAttempt())
+			require.Equal(c, 60*time.Second, desc.GetInfo().GetStartToCloseTimeout().AsDuration(),
+				"paused next attempt must carry the restored StartToClose (60s)")
+			require.Equal(c, 50*time.Second, desc.GetInfo().GetHeartbeatTimeout().AsDuration(),
+				"paused next attempt must carry the restored Heartbeat (50s)")
 		}, 5*time.Second, 100*time.Millisecond)
+	})
+	// ResetWhileResetRequested_Rejected: a reset issued while a reset is already pending (the
+	// activity is RESET_REQUESTED, worker still running the attempt) is rejected with a clear
+	// message and leaves the activity untouched. Accepting a second/overlapping reset is a separate
+	// semantics question deferred for now; this pins the current behavior as an explicit rejection
+	// rather than the misleading "activity execution is not running".
+	t.Run("ResetWhileResetRequested_Rejected", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
 
-		// Unpause and verify dispatch at attempt 1.
-		unpauseActivity(ctx, t, activityID, startResp.GetRunId())
+		activityID := testcore.RandomizeStr(t.Name())
+		startResp, _ := startAttemptWithTimeouts(ctx, t, activityID, 60*time.Second, 50*time.Second)
 
-		pollResp2, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: env.Namespace().String(),
-			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-			Identity:  defaultIdentity,
+		// Change a per-attempt option so a leaked restore from the rejected reset would be detectable.
+		updateTimeouts(ctx, t, activityID, startResp.GetRunId(), 30*time.Second, 20*time.Second)
+
+		// First reset -> RESET_REQUESTED (deferred reset of the running attempt). The reset handler
+		// runs synchronously, so the activity is in RESET_REQUESTED once this returns. (RESET_REQUESTED
+		// surfaces externally as runState STARTED — the worker is still running its attempt.)
+		resetActivity(ctx, t, activityID, startResp.GetRunId(), false)
+
+		// Second reset while a reset is already pending must be rejected with a clear message — the
+		// worker is still running the attempt, so "activity execution is not running" would be wrong.
+		_, err := env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			RunId:                  startResp.GetRunId(),
+			RestoreOriginalOptions: true,
+		})
+		require.ErrorAs(t, err, new(*serviceerror.FailedPrecondition))
+		require.Contains(t, err.Error(), "pending reset")
+
+		// The rejected reset must leave the activity untouched: still running its attempt
+		// (RESET_REQUESTED, surfaced as STARTED), options unchanged.
+		desc, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.GetRunId(),
 		})
 		require.NoError(t, err)
-		require.EqualValues(t, 1, pollResp2.Attempt)
-
-		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-			Namespace: env.Namespace().String(),
-			TaskToken: pollResp2.TaskToken,
-			Result:    defaultResult,
-			Identity:  defaultIdentity,
-		})
-		require.NoError(t, err)
+		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, desc.GetInfo().GetRunState())
+		require.Equal(t, 30*time.Second, desc.GetInfo().GetStartToCloseTimeout().AsDuration())
+		require.Equal(t, 20*time.Second, desc.GetInfo().GetHeartbeatTimeout().AsDuration())
 	})
 
 	// StartToCloseTimeoutWhileResetRequested: a STARTED activity with a pending reset must still
@@ -12106,8 +13023,10 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 			BackoffCoefficient: 1.0,
 		})
 
-		// Fail attempt 1 so the activity is SCHEDULED in retry backoff.
-		failRetryable(ctx, t, pollResp1.TaskToken, 60*time.Second)
+		// Fail attempt 1 so the activity is SCHEDULED in retry backoff. Use a short retry interval
+		// (policy default 1s) that elapses before the reset, so the honored re-dispatch floor is in
+		// the past and the jitter governs the dispatch time.
+		failAttemptRetryably(ctx, t, pollResp1.TaskToken, 0)
 		waitForState(ctx, t, activityID, startResp.GetRunId(), enumspb.PENDING_ACTIVITY_STATE_SCHEDULED)
 
 		jitter := 3 * time.Second


### PR DESCRIPTION
# SAA operator API: Reset / UpdateOptions fixes

## What changed?
- Reset and UpdateOptions were not recreating the ScheduleToClose timer when an option change moved the deadline.
- A plain Reset (no RestoreOriginalOptions) was not honoring the remaining start_delay.
- Reset(RestoreOriginalOptions) was mutating options immediately, which would impact a running attempt. Changed to defer all mutation to the next attempt.
- Reset while STARTED was not honoring the reset if retries were exhausted, or the failure was non-retryable.
- Return FailedPrecondition instead of InvalidArgument when UpdateOptions is rejected due to start_delay.
- Change Reset to rejected with FailedPrecondition when a cancel or another reset is already pending.

## Why?
Correctness

## How did you test it?
- [x] added new functional test(s)

## Potential risks
Could result in incorrect SAA task scheduling / timeouts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core activity scheduling, timeout re-issuance, and reset state machine behavior; incorrect timing or deferred restore could cause premature timeouts, stuck activities, or wrong options on retries.
> 
> **Overview**
> Fixes **standalone activity (SAA) operator APIs** so reset and update-options paths schedule timeouts and redispatch correctly, and so **RestoreOriginalOptions** does not disturb a worker’s in-flight attempt.
> 
> **Reset / redispatch:** Plain reset now honors remaining **start_delay** when re-issuing dispatch and schedule-to-start tasks (`dispatchTimeRespectingStartDelay` in `reset`). **UpdateOptions** and option restore share **`reissueScheduleToClose`** so the schedule-to-close timer is bumped and re-armed when deadlines move (e.g. after changing `start_delay` or restoring originals).
> 
> **RestoreOriginalOptions:** For **STARTED / PAUSE_REQUESTED**, option restore is **deferred** via new state flag **`reset_restore_options`**; **`restoreOriginalOptions`** runs on the reset landing (`applyDeferredOptionRestore` in reset-failed transitions). For **SCHEDULED / PAUSED**, restore is immediate. Pending reset is **always honored on worker yield**, even when retries are exhausted or the failure is non-retryable (`tryReschedule`).
> 
> **API errors:** Invalid **start_delay** updates outside the delay window return **FailedPrecondition** (was InvalidArgument). **Reset** is rejected with FailedPrecondition when **cancel** or another **reset** is already pending; pause while reset pending stays rejected.
> 
> Tests cover timer/deferral semantics, operator interactions (cancel/pause/update during pending reset), and expanded restore-original scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 140c9b0405694dc8c3b76f241bb391a1b37ae3a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->