### PR TITLE
Add shared registry with nil libraries for tdbg

### DIFF
--- a/chasm/lib/activity/library.go
+++ b/chasm/lib/activity/library.go
@@ -75,7 +75,7 @@ func (l *componentOnlyLibrary) Components() []*chasm.RegistrableComponent {
 }
 
 // NewNilLibrary creates a Library with all nil handlers. Useful for
-// registration-only contexts like tdbg where no task execution is needed.
+// decoding contexts like tdbg where no task execution is needed.
 func NewNilLibrary() chasm.Library {
 	return &library{
 		componentOnlyLibrary: *newComponentOnlyLibrary(nil, nil),

--- a/chasm/lib/all/all.go
+++ b/chasm/lib/all/all.go
@@ -1,0 +1,31 @@
+// Package all provides the canonical list of all CHASM libraries for decoding contexts.
+// When adding a new library to chasm/lib, add its NewNilLibrary() call here and run
+// the unit tests — TestAllLibrariesRegistered will fail if a library is missing.
+package all
+
+import (
+	"go.temporal.io/server/chasm"
+	activitylib "go.temporal.io/server/chasm/lib/activity"
+	callbacklib "go.temporal.io/server/chasm/lib/callback"
+	chasmnexus "go.temporal.io/server/chasm/lib/nexusoperation"
+	chasmscheduler "go.temporal.io/server/chasm/lib/scheduler"
+	chasmworkflow "go.temporal.io/server/chasm/lib/workflow"
+)
+
+// RegisterAll registers all CHASM libraries in their decoding (nil handler) mode into registry.
+func RegisterAll(registry *chasm.Registry) error {
+	libs := []chasm.Library{
+		&chasm.CoreLibrary{},
+		chasmworkflow.NewNilLibrary(),
+		activitylib.NewNilLibrary(),
+		chasmscheduler.NewNilLibrary(),
+		callbacklib.NewNilLibrary(),
+		chasmnexus.NewNilLibrary(),
+	}
+	for _, lib := range libs {
+		if err := registry.Register(lib); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/chasm/lib/all/all_test.go
+++ b/chasm/lib/all/all_test.go
@@ -1,0 +1,49 @@
+package all_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/all"
+	"go.temporal.io/server/common/log"
+)
+
+// excludedLibDirs are subdirectories of chasm/lib that are intentionally absent
+// from RegisterAll. Add a new entry here only when the library is genuinely
+// unsuitable for decoding contexts (e.g. test-only libraries).
+var excludedLibDirs = map[string]bool{
+	"all":   true, // this package itself
+	"tests": true, // test-only library
+}
+
+// TestAllLibrariesRegistered scans the chasm/lib directory and asserts that every
+// library subdirectory is represented in the registry built by RegisterAll.
+// If this test fails after adding a new library, add its NewNilLibrary() call to
+// chasm/lib/all/all.go.
+func TestAllLibrariesRegistered(t *testing.T) {
+	registry := chasm.NewRegistry(log.NewNoopLogger())
+	require.NoError(t, all.RegisterAll(registry))
+
+	registeredNames := make(map[string]bool)
+	for _, name := range registry.LibraryNames() {
+		registeredNames[name] = true
+	}
+
+	// chasm/lib is the parent of this package's directory.
+	entries, err := os.ReadDir("..")
+	require.NoError(t, err)
+
+	for _, entry := range entries {
+		if !entry.IsDir() || excludedLibDirs[entry.Name()] {
+			continue
+		}
+		require.True(t,
+			registeredNames[entry.Name()],
+			"library directory %q exists in chasm/lib but is not registered in RegisterAll; "+
+				"add its NewNilLibrary() call to chasm/lib/all/all.go",
+			entry.Name(),
+		)
+	}
+}

--- a/chasm/lib/callback/library.go
+++ b/chasm/lib/callback/library.go
@@ -15,7 +15,7 @@ type (
 )
 
 // NewNilLibrary creates a Library with all nil handlers. Useful for
-// registration-only contexts like tdbg where no task execution is needed.
+// decoding contexts like tdbg where no task execution is needed.
 func NewNilLibrary() *Library {
 	return &Library{}
 }

--- a/chasm/lib/nexusoperation/library.go
+++ b/chasm/lib/nexusoperation/library.go
@@ -41,6 +41,12 @@ func newComponentOnlyLibrary(dc *dynamicconfig.Collection) *componentOnlyLibrary
 	}
 }
 
+// NewNilLibrary creates a Library with nil handlers and nil config.
+// Useful for decoding contexts like tdbg where no task execution is needed.
+func NewNilLibrary() *Library {
+	return &Library{}
+}
+
 func (l *componentOnlyLibrary) Name() string {
 	return libraryName
 }

--- a/chasm/lib/scheduler/eventlog_test.go
+++ b/chasm/lib/scheduler/eventlog_test.go
@@ -69,7 +69,7 @@ func TestEventLog_DropsEarliestWhenFull(t *testing.T) {
 
 // TestEventLog_NoConfigFallsBackToDefaults checks that LogEvent applies the
 // default retention limits instead of panicking when no config is reachable via
-// the context, as in tdbg's registration-only setup.
+// the context, as in tdbg's decoding setup.
 func TestEventLog_NoConfigFallsBackToDefaults(t *testing.T) {
 	ctx := &chasm.MockMutableContext{}
 	eventLog := scheduler.NewEventLog(ctx)

--- a/chasm/lib/scheduler/library.go
+++ b/chasm/lib/scheduler/library.go
@@ -24,7 +24,7 @@ type (
 )
 
 // NewNilLibrary creates a Library with all nil handlers. Useful for
-// registration-only contexts like tdbg where no task execution is needed.
+// decoding contexts like tdbg where no task execution is needed.
 func NewNilLibrary() *Library {
 	return &Library{}
 }

--- a/chasm/lib/workflow/library.go
+++ b/chasm/lib/workflow/library.go
@@ -42,6 +42,12 @@ func NewLibrary(registry *Registry) chasm.Library {
 	return &library{registry: registry}
 }
 
+// NewNilLibrary creates a Library with nil handlers. Useful for
+// decoding contexts like tdbg where no task execution is needed.
+func NewNilLibrary() chasm.Library {
+	return &library{registry: NewRegistry()}
+}
+
 func (l *library) Name() string {
 	return chasm.WorkflowLibraryName
 }

--- a/chasm/registry.go
+++ b/chasm/registry.go
@@ -373,6 +373,15 @@ func (r *Registry) registerNexusService(svc *nexus.Service) error {
 	return nil
 }
 
+// LibraryNames returns the names of all registered libraries.
+func (r *Registry) LibraryNames() []string {
+	names := make([]string, 0, len(r.libraries))
+	for name := range r.libraries {
+		names = append(names, name)
+	}
+	return names
+}
+
 // NexusServices returns all registered Nexus services.
 func (r *Registry) NexusServices() map[string]*nexus.Service {
 	// Return a copy to prevent external modification

--- a/tools/tdbg/chasm_registry.go
+++ b/tools/tdbg/chasm_registry.go
@@ -2,40 +2,14 @@ package tdbg
 
 import (
 	"go.temporal.io/server/chasm"
-	activitylib "go.temporal.io/server/chasm/lib/activity"
-	callbacklib "go.temporal.io/server/chasm/lib/callback"
-	chasmscheduler "go.temporal.io/server/chasm/lib/scheduler"
-	chasmtests "go.temporal.io/server/chasm/lib/tests"
-	chasmworkflow "go.temporal.io/server/chasm/lib/workflow"
+	"go.temporal.io/server/chasm/lib/all"
 	"go.temporal.io/server/common/log"
 )
 
 func newChasmRegistry(logger log.Logger) (*chasm.Registry, error) {
 	registry := chasm.NewRegistry(logger)
-
-	if err := registry.Register(&chasm.CoreLibrary{}); err != nil {
+	if err := all.RegisterAll(registry); err != nil {
 		return nil, err
 	}
-
-	if err := registry.Register(chasmworkflow.NewLibrary(chasmworkflow.NewRegistry())); err != nil {
-		return nil, err
-	}
-
-	if err := registry.Register(activitylib.NewNilLibrary()); err != nil {
-		return nil, err
-	}
-
-	if err := registry.Register(chasmscheduler.NewNilLibrary()); err != nil {
-		return nil, err
-	}
-
-	if err := registry.Register(chasmtests.Library); err != nil {
-		return nil, err
-	}
-
-	if err := registry.Register(callbacklib.NewNilLibrary()); err != nil {
-		return nil, err
-	}
-
 	return registry, nil
 }


### PR DESCRIPTION
## What changed?
Add shared registry with nil libraries for tdbg

## Why?
Create a single registry with nil library components. This can be used by any service that needs ability to decode CHASM serialized nodes.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)