### PR TITLE
[Scheduler] Skip recomputing FutureActionTimes after handling completion events

### DIFF
--- a/chasm/lib/scheduler/gen/schedulerpb/v1/tasks.pb.go
+++ b/chasm/lib/scheduler/gen/schedulerpb/v1/tasks.pb.go
@@ -112,9 +112,11 @@ func (*SchedulerCallbacksTask) Descriptor() ([]byte, []int) {
 
 // Buffers actions based on the schedule's specification.
 type GeneratorTask struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// When set, skip recomputing FutureActionTimes to avoid oscillating visbility.
+	SkipFutureActionTimes bool `protobuf:"varint,1,opt,name=skip_future_action_times,json=skipFutureActionTimes,proto3" json:"skip_future_action_times,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *GeneratorTask) Reset() {
@@ -145,6 +147,13 @@ func (x *GeneratorTask) ProtoReflect() protoreflect.Message {
 // Deprecated: Use GeneratorTask.ProtoReflect.Descriptor instead.
 func (*GeneratorTask) Descriptor() ([]byte, []int) {
 	return file_temporal_server_chasm_lib_scheduler_proto_v1_tasks_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *GeneratorTask) GetSkipFutureActionTimes() bool {
+	if x != nil {
+		return x.SkipFutureActionTimes
+	}
+	return false
 }
 
 // Processes buffered actions, deciding whether to execute, delay, or discard.
@@ -303,8 +312,9 @@ const file_temporal_server_chasm_lib_scheduler_proto_v1_tasks_proto_rawDesc = ""
 	"8temporal/server/chasm/lib/scheduler/proto/v1/tasks.proto\x12,temporal.server.chasm.lib.scheduler.proto.v1\x1a\x1egoogle/protobuf/duration.proto\"V\n" +
 	"\x11SchedulerIdleTask\x12A\n" +
 	"\x0fidle_time_total\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\ridleTimeTotal\"\x18\n" +
-	"\x16SchedulerCallbacksTask\"\x0f\n" +
-	"\rGeneratorTask\"\x1a\n" +
+	"\x16SchedulerCallbacksTask\"H\n" +
+	"\rGeneratorTask\x127\n" +
+	"\x18skip_future_action_times\x18\x01 \x01(\bR\x15skipFutureActionTimes\"\x1a\n" +
 	"\x18InvokerProcessBufferTask\"\x14\n" +
 	"\x12InvokerExecuteTask\"\x10\n" +
 	"\x0eBackfillerTask\" \n" +

--- a/chasm/lib/scheduler/generator.go
+++ b/chasm/lib/scheduler/generator.go
@@ -45,16 +45,26 @@ func newGeneratorWithState(ctx chasm.MutableContext, state *schedulerpb.Generato
 // Generate immediately kicks off a new GeneratorTask. Used after updating the
 // schedule specification.
 func (g *Generator) Generate(ctx chasm.MutableContext) {
-	g.scheduleTask(ctx, chasm.TaskScheduledTimeImmediate)
+	g.scheduleTask(ctx, chasm.TaskScheduledTimeImmediate, false)
+}
+
+// GenerateSkippingFutureActionTimes immediately kicks off a GeneratorTask that
+// re-arms idle handling but leaves FutureActionTimes untouched. Used to
+// avoid oscillating visibility after a completion, where the completion's
+// GeneratorTask runs in advance of the regular interval's GeneratorTask.
+func (g *Generator) GenerateSkippingFutureActionTimes(ctx chasm.MutableContext) {
+	g.scheduleTask(ctx, chasm.TaskScheduledTimeImmediate, true)
 }
 
 // scheduleTask schedules a GeneratorTask at the given time.
-func (g *Generator) scheduleTask(ctx chasm.MutableContext, scheduledTime time.Time) {
+func (g *Generator) scheduleTask(ctx chasm.MutableContext, scheduledTime time.Time, skipFutureActionTimes bool) {
 	g.getOrCreateEventLog(ctx).LogEvent(ctx,
 		fmt.Sprintf("scheduled generatorTask for %s", scheduledTime.Format(time.RFC3339)))
 	ctx.AddTask(g, chasm.TaskAttributes{
 		ScheduledTime: scheduledTime,
-	}, &schedulerpb.GeneratorTask{})
+	}, &schedulerpb.GeneratorTask{
+		SkipFutureActionTimes: skipFutureActionTimes,
+	})
 }
 
 func (g *Generator) LifecycleState(ctx chasm.Context) chasm.LifecycleState {

--- a/chasm/lib/scheduler/generator_tasks.go
+++ b/chasm/lib/scheduler/generator_tasks.go
@@ -51,7 +51,7 @@ func (g *GeneratorTaskHandler) Execute(
 	ctx chasm.MutableContext,
 	generator *Generator,
 	_ chasm.TaskAttributes,
-	_ *schedulerpb.GeneratorTask,
+	task *schedulerpb.GeneratorTask,
 ) error {
 	scheduler := generator.Scheduler.Get(ctx)
 	logger := newTaggedLogger(g.baseLogger, scheduler)
@@ -129,7 +129,9 @@ func (g *GeneratorTaskHandler) Execute(
 
 	// Write the new high water mark and future action times.
 	generator.LastProcessedTime = timestamppb.New(result.LastActionTime)
-	generator.UpdateFutureActionTimes(ctx, g.specBuilder)
+	if !task.GetSkipFutureActionTimes() {
+		generator.UpdateFutureActionTimes(ctx, g.specBuilder)
+	}
 
 	// Schedule the next timer task. Three outcomes are possible:
 	// - isIdle: the schedule is done; arm the idle task to close it.
@@ -169,7 +171,7 @@ func (g *GeneratorTaskHandler) Execute(
 		// Keep the generator task perpetually scheduled. When paused, the next
 		// fire will simply advance the HWM without appending actions (handled in
 		// ProcessTimeRange).
-		generator.scheduleTask(ctx, result.NextWakeupTime)
+		generator.scheduleTask(ctx, result.NextWakeupTime, false)
 	} else {
 		// Hold open without a task: see the comment block above.
 		metricsHandler.Counter(metrics.SchedulerGeneratorLoopCompleted.Name()).Record(1)

--- a/chasm/lib/scheduler/generator_tasks_test.go
+++ b/chasm/lib/scheduler/generator_tasks_test.go
@@ -134,6 +134,34 @@ func TestGeneratorTask_UpdateFutureActionTimes_LimitedActions(t *testing.T) {
 	require.Len(t, generator.FutureActionTimes, 2)
 }
 
+func TestGeneratorTask_SkipFutureActionTimes(t *testing.T) {
+	env := newTestEnv(t)
+	handler := newGeneratorHandler(env)
+
+	ctx := env.MutableContext()
+	sched := env.Scheduler
+	generator := sched.Generator.Get(ctx)
+
+	sched.Schedule.State.LimitedActions = true
+	sched.Schedule.State.RemainingActions = 2
+
+	// Seed the window with a normal run.
+	require.NoError(t, handler.Execute(ctx, generator, chasm.TaskAttributes{}, &schedulerpb.GeneratorTask{}))
+	require.Len(t, generator.FutureActionTimes, 2)
+
+	// A skip run leaves the window untouched even though the count input changed,
+	// mirroring a completion-triggered run firing after RemainingActions dropped.
+	sched.Schedule.State.RemainingActions = 1
+	require.NoError(t, handler.Execute(ctx, generator, chasm.TaskAttributes{}, &schedulerpb.GeneratorTask{
+		SkipFutureActionTimes: true,
+	}))
+	require.Len(t, generator.FutureActionTimes, 2)
+
+	// A normal run picks up the new count.
+	require.NoError(t, handler.Execute(ctx, generator, chasm.TaskAttributes{}, &schedulerpb.GeneratorTask{}))
+	require.Len(t, generator.FutureActionTimes, 1)
+}
+
 func TestGeneratorTask_Idle_SetsIdleCloseTime(t *testing.T) {
 	env := newTestEnv(t)
 	handler := newGeneratorHandler(env)

--- a/chasm/lib/scheduler/proto/v1/tasks.proto
+++ b/chasm/lib/scheduler/proto/v1/tasks.proto
@@ -20,7 +20,10 @@ message SchedulerIdleTask {
 message SchedulerCallbacksTask {}
 
 // Buffers actions based on the schedule's specification.
-message GeneratorTask {}
+message GeneratorTask {
+  // When set, skip recomputing FutureActionTimes to avoid oscillating visbility.
+  bool skip_future_action_times = 1;
+}
 
 // Processes buffered actions, deciding whether to execute, delay, or discard.
 message InvokerProcessBufferTask {}

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -627,10 +627,11 @@ func (s *Scheduler) HandleNexusCompletion(
 	}
 	invoker.recordCompletedAction(ctx, completed, info.RequestId)
 
-	// Generate immediately after recording completions, so that an idle task
-	// can be scheduled if no more actions are remaining. Necessary as
-	// additional events invalidate in-flight idle tasks.
-	s.Generator.Get(ctx).Generate(ctx)
+	// Generate immediately after recording completions, so that an idle task can
+	// be scheduled if no more actions are remaining. Necessary as additional events
+	// invalidate in-flight idle tasks. Skip recomputing FutureActionTimes, as it is
+	// maintained by the looping GeneratorTask that runs on the schedule's interval.
+	s.Generator.Get(ctx).GenerateSkippingFutureActionTimes(ctx)
 
 	return nil
 }


### PR DESCRIPTION
**Pending a functional test to show observed visibility write count**

## What changed?
We skip computing `FutureActionTimes` in `GeneratorTask` as a result of handling completion callbacks. 

## Why?
The completion handler runs a `GeneratorTask` to drive the idle timer, which is reset on external events (including completions). Whenever a task runs, CHASM framework calls `Memo` to determine if it should make a visibility upsert. Prior to the change, we'd observe a `Memo` write from the completion handler `GeneratorTask` *removing* an entry (because `RemainingActions` decrements, for example). Then, when the looping `GeneratorTask` that drives automated actions ran, it caused an oscillation from *adding* another entry (because now the high water mark has advanced past the start interval).

The write that merely *removes* an entry before the high water mark moves past the scheduled interval isn't particularly useful to anyone, so it's wasted load on visi. This change removes the potential for a completion callback to trigger a visibility memo write. 

Oh, note: I did also experiment with trying to get fancy within `GeneratorTask`, in deciding if it should update FutureActionTimes automatically, but I couldn't come up with a clean, pure condition that didn't also regress some weird edge case test. 

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- Biggest risk is that we somehow don't update visibility's `FutureActionTimes` field when we expected to. However, this is mitigated given that the regularly-scheduled `GeneratorTask` *always* recomputes future action times, so in a scenario where I've missed a valid case for updating visi as a result of a completion, the worst case is visi updates only after the next interval elapses.
