### PR TITLE
Persist on-demand compute config validation to ComputeStatus

### DIFF
--- a/service/worker/workerdeployment/client.go
+++ b/service/worker/workerdeployment/client.go
@@ -21,6 +21,7 @@ import (
 	updatepb "go.temporal.io/api/update/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	wciclient "go.temporal.io/auto-scaled-workers/wci/client"
+	wciiface "go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 	"go.temporal.io/sdk/temporal"
 	deploymentspb "go.temporal.io/server/api/deployment/v1"
 	"go.temporal.io/server/api/historyservice/v1"
@@ -2110,10 +2111,57 @@ func (d *ClientImpl) ValidateComputeConfig(
 	identity string,
 ) error {
 	upserts := scalingGroupUpdatesToWCI(upsertScalingGroups)
-	if err := d.workerControllerInstanceClient.ValidateWorkerControllerInstanceSpec(ctx, namespaceEntry, version, identity, upserts, removeScalingGroups); err != nil {
-		return serviceerror.NewInvalidArgument(err.Error())
+	validationErr := d.workerControllerInstanceClient.ValidateWorkerControllerInstanceSpec(ctx, namespaceEntry, version, identity, upserts, removeScalingGroups)
+
+	// Persist the on-demand validation outcome to the version workflow's ComputeStatus so the
+	// result is reflected immediately, instead of waiting for the next periodic check. This reuses
+	// the SignalSyncValidationStatus receiver that the periodic check delivers to. Best-effort:
+	// a failure to sync must not change the validation result returned to the caller.
+	now := time.Now()
+	status := wciiface.NewValidationStatusSuccess(now)
+	if validationErr != nil {
+		status = wciiface.NewValidationStatusFailed(now, validationErr.Error())
+	}
+	if syncErr := d.syncValidationStatus(ctx, namespaceEntry, version, status, identity); syncErr != nil {
+		d.logger.Error("failed to sync compute validation status to version workflow",
+			tag.WorkflowNamespace(namespaceEntry.Name().String()),
+			tag.Error(syncErr))
+	}
+
+	if validationErr != nil {
+		return serviceerror.NewInvalidArgument(validationErr.Error())
 	}
 	return nil
+}
+
+// syncValidationStatus signals the version workflow with the outcome of a compute-config
+// validation so it can persist the result into ComputeStatus (see the SignalSyncValidationStatus
+// receiver in version_workflow.go).
+func (d *ClientImpl) syncValidationStatus(
+	ctx context.Context,
+	namespaceEntry *namespace.Namespace,
+	version *deploymentpb.WorkerDeploymentVersion,
+	status *wciiface.ValidationStatus,
+	identity string,
+) error {
+	input, err := sdk.PreferProtoDataConverter.ToPayloads(status)
+	if err != nil {
+		return err
+	}
+	_, err = d.historyClient.SignalWorkflowExecution(ctx, &historyservice.SignalWorkflowExecutionRequest{
+		NamespaceId: namespaceEntry.ID().String(),
+		SignalRequest: &workflowservice.SignalWorkflowExecutionRequest{
+			Namespace: namespaceEntry.Name().String(),
+			WorkflowExecution: &commonpb.WorkflowExecution{
+				WorkflowId: GenerateVersionWorkflowID(version.GetDeploymentName(), version.GetBuildId()),
+			},
+			SignalName: worker_versioning.SignalSyncValidationStatus,
+			Input:      input,
+			Identity:   identity,
+			RequestId:  uuid.NewString(),
+		},
+	})
+	return err
 }
 
 // queryVersionState queries the version workflow for its current state.


### PR DESCRIPTION
## What changed?

`ValidateWorkerDeploymentVersionComputeConfig` (frontend RPC → `ClientImpl.ValidateComputeConfig`) runs a WCI connectivity check but returns without persisting the outcome. The only writer of `compute_status.provider_validation` is the periodic check in `version_workflow.go` (via the `SignalSyncValidationStatus` receiver). So a version's `compute_status` only updates on that periodic cadence, not when a user runs an on-demand validation.

This makes `ValidateComputeConfig` also persist its result: it builds a `wciiface.ValidationStatus` (success/failure) and signals the version workflow with the existing `SignalSyncValidationStatus`, which the workflow already converts and stores into `ComputeStatus`. The sync is best-effort and does not change the validation result returned to the caller.

## Why?

Surfaced while building the UI for connectivity health (temporalio/ui — DT-4174). The UI connection badge reads `compute_status.provider_validation`. Verified locally against a serverless (Lambda) worker deployment: the worker connected and ran a workflow to completion, on-demand **Validate Connection** succeeded, yet `compute_status` stayed `null` (badge stuck on "Pending") because nothing persisted the manual check. A user who explicitly validates a connection reasonably expects the status to reflect it immediately rather than up to ~6h later.

## Notes / open questions for reviewers

This is a **starting point** — I'm a UI engineer and would appreciate a gut check on the mechanism:

1. **Best-effort sync**: a failed signal is logged and swallowed so it can't change the validation result. Should a persistence failure instead surface to the caller?
2. **Version workflow must exist**: if validate is called for a version with no running workflow (e.g. a pre-create/edit validation), the signal fails and is logged. Is on-demand validate ever called before the version workflow exists? If so, is silently skipping the right behavior?
3. **Signal payload encoding**: `ValidationStatus` is a plain (non-proto) struct; I encode it with `sdk.PreferProtoDataConverter.ToPayloads`, matching the existing arg-encoding pattern in this file and the `c.Receive(ctx, &vs)` receiver. Please confirm this is the intended converter for this signal.
4. **RequestId**: uses a fresh UUID per call (each manual validate should deliver). The receiver doesn't appear to dedup on it.
5. Alternatively, if persisting on-demand results isn't desired, the UI side can drop the "or use Validate Connection to check now" hint from its Pending tooltip instead.

Builds clean (`go build ./service/worker/workerdeployment/... ./service/frontend/...`, `go vet`). Not yet covered by a test — happy to add one with guidance on the preferred harness for signalling the version workflow.
