### PR TITLE
feat: Added status command for scheduler migration

### DIFF
--- a/tools/tdbg/commands.go
+++ b/tools/tdbg/commands.go
@@ -936,6 +936,59 @@ func parseMigrateTarget(c *cli.Context) (adminservice.MigrateScheduleRequest_Sch
 	}
 }
 
+// v1ScheduleVisibilityQuery returns the visibility query selecting running V1 (workflow-backed)
+// schedules.
+func v1ScheduleVisibilityQuery() string {
+	return fmt.Sprintf("TemporalNamespaceDivision = '%s' AND ExecutionStatus = 'Running'", scheduler.NamespaceDivision)
+}
+
+// v2ScheduleVisibilityQuery returns the visibility query selecting running V2 (CHASM) schedules.
+// The explicit TemporalNamespaceDivision filter is required, otherwise the visibility query
+// converter appends "TemporalNamespaceDivision IS NULL" and excludes CHASM executions.
+func v2ScheduleVisibilityQuery() string {
+	return fmt.Sprintf("TemporalNamespaceDivision = '%d' AND ExecutionStatus = 'Running'", chasm.SchedulerArchetypeID)
+}
+
+// AdminScheduleStatus reports how many schedules in --namespace are currently V1
+// (workflow-backed) vs V2 (CHASM), using the same default visibility queries as
+// `schedule migrate --from-visibility`.
+func AdminScheduleStatus(c *cli.Context, clientFactory ClientFactory) error {
+	ns, err := getRequiredOption(c, FlagNamespace)
+	if err != nil {
+		return err
+	}
+
+	wfClient := clientFactory.WorkflowClient(c)
+
+	v1Count, err := countScheduleVisibility(c, wfClient, ns, v1ScheduleVisibilityQuery())
+	if err != nil {
+		return fmt.Errorf("unable to count V1 schedules: %w", err)
+	}
+	v2Count, err := countScheduleVisibility(c, wfClient, ns, v2ScheduleVisibilityQuery())
+	if err != nil {
+		return fmt.Errorf("unable to count V2 schedules: %w", err)
+	}
+
+	_, _ = fmt.Fprintf(c.App.Writer, "Namespace: %s\n", ns)
+	_, _ = fmt.Fprintf(c.App.Writer, "V1 (workflow-backed): %d\n", v1Count)
+	_, _ = fmt.Fprintf(c.App.Writer, "V2 (CHASM):           %d\n", v2Count)
+	_, _ = fmt.Fprintf(c.App.Writer, "Total:                %d\n", v1Count+v2Count)
+	return nil
+}
+
+func countScheduleVisibility(c *cli.Context, wfClient workflowservice.WorkflowServiceClient, ns, query string) (int64, error) {
+	ctx, cancel := newContext(c)
+	defer cancel()
+	resp, err := wfClient.CountWorkflowExecutions(ctx, &workflowservice.CountWorkflowExecutionsRequest{
+		Namespace: ns,
+		Query:     query,
+	})
+	if err != nil {
+		return 0, err
+	}
+	return resp.GetCount(), nil
+}
+
 // migrateSingleSchedule migrates one schedule and performs the migration immediately.
 func migrateSingleSchedule(
 	c *cli.Context,
@@ -981,12 +1034,10 @@ func migrateSchedulesFromVisibility(
 	if query == "" {
 		if target == adminservice.MigrateScheduleRequest_SCHEDULER_TARGET_CHASM {
 			// Forward migration V1 -> V2: all running V1 (workflow-backed) schedules.
-			query = fmt.Sprintf("TemporalNamespaceDivision = '%s' AND ExecutionStatus = 'Running'", scheduler.NamespaceDivision)
+			query = v1ScheduleVisibilityQuery()
 		} else {
-			// Rollback V2 -> V1: all running V2 (CHASM) schedules. The explicit
-			// TemporalNamespaceDivision filter is required, otherwise the visibility query
-			// converter appends "TemporalNamespaceDivision IS NULL" and excludes CHASM executions.
-			query = fmt.Sprintf("TemporalNamespaceDivision = '%d' AND ExecutionStatus = 'Running'", chasm.SchedulerArchetypeID)
+			// Rollback V2 -> V1: all running V2 (CHASM) schedules.
+			query = v2ScheduleVisibilityQuery()
 		}
 	}
 

--- a/tools/tdbg/schedule_status_test.go
+++ b/tools/tdbg/schedule_status_test.go
@@ -1,0 +1,97 @@
+package tdbg_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/service/worker/scheduler"
+	"go.temporal.io/server/tools/tdbg"
+	"go.temporal.io/server/tools/tdbg/tdbgtest"
+	"google.golang.org/grpc"
+)
+
+type statusWorkflowClient struct {
+	workflowservice.WorkflowServiceClient
+	counts map[string]int64 // query -> count
+	err    error
+
+	requests []*workflowservice.CountWorkflowExecutionsRequest
+}
+
+func (c *statusWorkflowClient) CountWorkflowExecutions(
+	_ context.Context,
+	req *workflowservice.CountWorkflowExecutionsRequest,
+	_ ...grpc.CallOption,
+) (*workflowservice.CountWorkflowExecutionsResponse, error) {
+	c.requests = append(c.requests, req)
+	if c.err != nil {
+		return nil, c.err
+	}
+	return &workflowservice.CountWorkflowExecutionsResponse{Count: c.counts[req.Query]}, nil
+}
+
+func runScheduleStatus(t *testing.T, wf workflowservice.WorkflowServiceClient, args ...string) (stdoutStr, stderrStr string, err error) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	factory := migrateClientFactory{admin: &migrateAdminClient{}, workflow: wf}
+	app := tdbgtest.NewCliApp(func(params *tdbg.Params) {
+		params.ClientFactory = factory
+		params.Writer = &stdout
+		params.ErrWriter = &stderr
+	})
+	runArgs := append([]string{"tdbg"}, args...)
+	err = app.Run(runArgs)
+	return stdout.String(), stderr.String(), err
+}
+
+func TestScheduleStatus_Basic(t *testing.T) {
+	v1Query := fmt.Sprintf("TemporalNamespaceDivision = '%s' AND ExecutionStatus = 'Running'", scheduler.NamespaceDivision)
+	v2Query := fmt.Sprintf("TemporalNamespaceDivision = '%d' AND ExecutionStatus = 'Running'", chasm.SchedulerArchetypeID)
+	wf := &statusWorkflowClient{counts: map[string]int64{
+		v1Query: 42,
+		v2Query: 7,
+	}}
+
+	stdout, _, err := runScheduleStatus(t, wf, "-n", "my-ns", "schedule", "migrate", "status")
+	require.NoError(t, err)
+
+	require.Len(t, wf.requests, 2)
+	for _, req := range wf.requests {
+		require.Equal(t, "my-ns", req.Namespace)
+	}
+	gotQueries := []string{wf.requests[0].Query, wf.requests[1].Query}
+	require.ElementsMatch(t, []string{v1Query, v2Query}, gotQueries)
+
+	require.Contains(t, stdout, "Namespace: my-ns")
+	require.Contains(t, stdout, "V1 (workflow-backed): 42")
+	require.Contains(t, stdout, "V2 (CHASM):           7")
+	require.Contains(t, stdout, "Total:                49")
+}
+
+func TestScheduleStatus_DefaultsToDefaultNamespace(t *testing.T) {
+	// --namespace/-n defaults to "default" (a global flag), mirroring `schedule migrate`'s
+	// behavior of never requiring it explicitly.
+	wf := &statusWorkflowClient{counts: map[string]int64{}}
+	stdout, _, err := runScheduleStatus(t, wf, "schedule", "migrate", "status")
+	require.NoError(t, err)
+
+	require.Len(t, wf.requests, 2)
+	for _, req := range wf.requests {
+		require.Equal(t, "default", req.Namespace)
+	}
+	require.Contains(t, stdout, "Namespace: default")
+}
+
+func TestScheduleStatus_CountError(t *testing.T) {
+	wf := &statusWorkflowClient{err: errors.New("boom")}
+	_, _, err := runScheduleStatus(t, wf, "-n", "my-ns", "schedule", "migrate", "status")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unable to count")
+	require.Contains(t, err.Error(), "boom")
+}

--- a/tools/tdbg/tdbg_commands.go
+++ b/tools/tdbg/tdbg_commands.go
@@ -343,6 +343,13 @@ func newAdminScheduleCommands(clientFactory ClientFactory) []*cli.Command {
 				return AdminMigrateSchedule(c, clientFactory)
 			},
 		},
+		{
+			Name:  "status",
+			Usage: "Show counts of V1 (workflow-backed) and V2 (CHASM) schedules in --namespace, from visibility",
+			Action: func(c *cli.Context) error {
+				return AdminScheduleStatus(c, clientFactory)
+			},
+		},
 	}
 }
 

--- a/tools/tdbg/tdbg_commands.go
+++ b/tools/tdbg/tdbg_commands.go
@@ -309,9 +309,12 @@ func newAdminScheduleCommands(clientFactory ClientFactory) []*cli.Command {
 					Usage:   "Schedule ID (single-schedule mode)",
 				},
 				&cli.StringFlag{
-					Name:     FlagTarget,
-					Usage:    "Target scheduler implementation: chasm, workflow",
-					Required: true,
+					Name: FlagTarget,
+					// Not marked Required here: it is validated (and required) by
+					// parseMigrateTarget when the migrate action itself runs. Marking it
+					// Required at the CLI level would also apply to the "status" subcommand
+					// below, which has no use for --target.
+					Usage: "Target scheduler implementation: chasm, workflow",
 				},
 				&cli.BoolFlag{
 					Name: FlagFromVisibility,
@@ -342,12 +345,14 @@ func newAdminScheduleCommands(clientFactory ClientFactory) []*cli.Command {
 			Action: func(c *cli.Context) error {
 				return AdminMigrateSchedule(c, clientFactory)
 			},
-		},
-		{
-			Name:  "status",
-			Usage: "Show counts of V1 (workflow-backed) and V2 (CHASM) schedules in --namespace, from visibility",
-			Action: func(c *cli.Context) error {
-				return AdminScheduleStatus(c, clientFactory)
+			Subcommands: []*cli.Command{
+				{
+					Name:  "status",
+					Usage: "Show counts of V1 (workflow-backed) and V2 (CHASM) schedules in --namespace, from visibility",
+					Action: func(c *cli.Context) error {
+						return AdminScheduleStatus(c, clientFactory)
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## What changed?
Adds a status command for migrations

```
./tdbg -n default schedule migrate status
Namespace: default
V1 (workflow-backed): 1
V2 (CHASM):           0
Total:                1
```
## Why?

to make it easier to understand what is going on during migrations via a visibility count

## How did you test it?
- [ ] built
- [X] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

Very low risk, cli change only.