### PR TITLE
Include config file name in legacy config loader parse errors

### DIFF
--- a/common/config/loader.go
+++ b/common/config/loader.go
@@ -201,12 +201,12 @@ func (opts *loadOptions) loadLegacy(config any) error {
 
 		processedData, err := processConfigFile(data, filepath.Base(f))
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to process config file %s: %w", f, err)
 		}
 
 		err = yaml.Unmarshal(processedData, config)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to unmarshal config file %s: %w", f, err)
 		}
 	}
 

--- a/common/config/loader_test.go
+++ b/common/config/loader_test.go
@@ -108,6 +108,19 @@ services:
 			errorContains: "yaml",
 		},
 		{
+			// Regression test: the error must identify which config file failed to
+			// parse, since the underlying yaml error (e.g. "did not find expected key")
+			// has no file context of its own and is otherwise impossible to act on
+			// when multiple config files are loaded (base.yaml, env.yaml, env_zone.yaml).
+			name:          "invalid yaml error identifies the offending file",
+			configContent: invalidYaml,
+			loadOptions: func(configPath string) []loadOption {
+				return []loadOption{WithConfigDir(filepath.Dir(configPath))}
+			},
+			expectError:   true,
+			errorContains: "base.yaml",
+		},
+		{
 			name:          "non-existent directory returns error",
 			configContent: "",
 			loadOptions: func(configPath string) []loadOption {


### PR DESCRIPTION
## What changed?
Errors from `processConfigFile` and `yaml.Unmarshal` in the legacy hierarchical config loader (`base.yaml`, `env.yaml`, `env_zone.yaml`) are now wrapped with the path of the offending file, matching the behavior already used by the newer `WithConfigFile`/`WithEmbedded` loading paths.

## Why?
Previously these errors were returned bare, so a failure like "did not find expected key" gave no indication of which loaded file caused it — as reported in #455, where a customer's service failed to start with a config error that named a line number but not a file, making the issue difficult to diagnose.

Fixes #455

## How did you test it?
- [x] built
- [x] covered by existing tests
- [x] added new unit test(s)

## Potential risks
None - this only adds file-path context to existing error paths; the underlying error types and control flow are unchanged.
