### PR TITLE
Sync WCI compute status to worker deployment version state

### DIFF
--- a/service/worker/workerdeployment/version_activities.go
+++ b/service/worker/workerdeployment/version_activities.go
@@ -19,6 +19,7 @@ import (
 	"go.temporal.io/sdk/temporal"
 	deploymentspb "go.temporal.io/server/api/deployment/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/worker_versioning"
@@ -197,6 +198,19 @@ func (a *VersionActivities) GetVersionDrainageStatus(ctx context.Context, versio
 		LastChangedTime: nil, // ignored; whether Status changed will be evaluated by the receiver
 		LastCheckedTime: timestamppb.Now(),
 	}, nil
+}
+
+func (a *VersionActivities) DescribeWorkerControllerInstanceStatus(ctx context.Context, version *deploymentspb.WorkerDeploymentVersion) (*deploymentpb.ComputeStatus, error) {
+	resp, _, err := a.WorkerControllerInstanceClient.DescribeWorkerControllerInstance(ctx, a.namespace, &deploymentpb.WorkerDeploymentVersion{DeploymentName: version.GetDeploymentName(), BuildId: version.GetBuildId()})
+	if err != nil {
+		if common.IsNotFoundError(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	return wciValidationStatusToComputeStatus(resp.ValidationStatus), nil
 }
 
 func (a *VersionActivities) UpdateWorkerControllerInstance(ctx context.Context, input *deploymentspb.UpdateWorkerControllerInstanceInput) (*computepb.ComputeConfigSummary, error) {

--- a/service/worker/workerdeployment/version_workflow.go
+++ b/service/worker/workerdeployment/version_workflow.go
@@ -345,6 +345,12 @@ func (d *VersionWorkflowRunner) run(ctx workflow.Context) error {
 		}
 	}
 
+	// When creating a compute provider and version together, there is a race condition between the two coming up. Making sure to have pulled
+	// the latest state from the compute provider if this happens to be the slower one.
+	if err := d.syncVersionDataToComputeStatus(ctx); err != nil {
+		return err
+	}
+
 	// Listen to signals in a different goroutine to make business logic clearer
 	workflow.Go(ctx, d.listenToSignals)
 
@@ -1242,6 +1248,30 @@ func (d *VersionWorkflowRunner) syncVersionStatusAfterDrainageStatusChange(ctx w
 	}
 
 	return d.syncVersionDataToTaskQueues(ctx, versionData)
+}
+
+// syncVersionDataToComputeStatus is a helper that syncs the compute status from WCI to the worker deployment version
+func (d *VersionWorkflowRunner) syncVersionDataToComputeStatus(ctx workflow.Context) error {
+	if workflow.GetVersion(ctx, "sync-compute-validation-status", workflow.DefaultVersion, 0) == workflow.DefaultVersion {
+		return nil
+	}
+
+	state := d.GetVersionState()
+
+	if state.ComputeStatus == nil && state.ComputeConfig != nil {
+		workflow.Go(ctx, func(ctx workflow.Context) {
+			logger := workflow.GetLogger(ctx)
+
+			var result deploymentpb.ComputeStatus
+			resp := workflow.ExecuteActivity(workflow.WithActivityOptions(ctx, defaultActivityOptions), d.a.DescribeWorkerControllerInstanceStatus, state.GetVersion())
+			if err := resp.Get(ctx, &result); err != nil {
+				logger.Error("failed to sync compute status", "error", err)
+			} else if result.ProviderValidation != nil {
+				state.ComputeStatus = &result
+			}
+		})
+	}
+	return nil
 }
 
 // syncVersionDataToTaskQueues is a helper that syncs the provided version data to all task queues.

--- a/service/worker/workerdeployment/version_workflow_test.go
+++ b/service/worker/workerdeployment/version_workflow_test.go
@@ -54,6 +54,11 @@ func (s *VersionWorkflowSuite) SetupTest() {
 	}
 	s.env.RegisterWorkflowWithOptions(versionWorkflow, workflow.RegisterOptions{Name: WorkerDeploymentVersionWorkflowType})
 
+	var a *VersionActivities
+	s.env.OnActivity(a.DescribeWorkerControllerInstanceStatus, mock.Anything, mock.Anything).
+		Return(&deploymentpb.ComputeStatus{}, nil).
+		Maybe()
+
 	// Initialize an empty ClientImpl to use its helper methods
 	s.workerDeploymentClient = &ClientImpl{}
 }


### PR DESCRIPTION
## What changed?
Add DescribeWorkerControllerInstanceStatus activity to fetch the WCI validation status and map it to a ComputeStatus. During handleSyncState, invoke syncVersionDataToComputeStatus to update the version state's ComputeStatus with the provider validation result. The sync is gated behind the "sync-compute-validation-status" workflow version for backward compatibility.

## Why?
During creation of a new version there is a risk of the compute provider validation finishing before the version is created, and thereby the sync signal for the compute status being missed. This highlighted that there is no backstop for the status sync in this and other cases of missing the signal so adding one.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
