### PR TITLE
SAA operator API 4: Honor Reset request even if attempt fails non-retryably

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1188,8 +1188,7 @@ func (a *Activity) tryReschedule(
 	shouldRetry, retryInterval := a.shouldRetry(ctx, overridingRetryInterval)
 	resetRequested := a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED
 	// A pending reset request is always honored, regardless of retryability or the should retry result.
-	//nolint:forbidigo // DeMorgan rearrangement would not be an improvement
-	if !resetRequested && !(failureRetryable && shouldRetry) {
+	if !resetRequested && !(failureRetryable && shouldRetry) { //nolint:staticcheck // QF1001: DeMorgan rearrangement would not be an improvement
 		return false, nil
 	}
 	event := rescheduleEvent{retryInterval: retryInterval, failure: failure}

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -549,7 +549,10 @@ func (a *Activity) HandleFailed(
 		!appFailure.GetNonRetryable() &&
 		!slices.Contains(a.GetRetryPolicy().GetNonRetryableErrorTypes(), appFailure.GetType())
 
-	if isRetryable {
+	// A pending reset is honored even for a non-retryable failure: the reset discards the failed
+	// attempt and re-dispatches attempt 1. tryReschedule honors the reset regardless of shouldRetry.
+	resetRequested := a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED
+	if isRetryable || resetRequested {
 		rescheduled, err := a.tryReschedule(ctx, appFailure.GetNextRetryDelay().AsDuration(), failure)
 		if err != nil {
 			return nil, err

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1188,6 +1188,7 @@ func (a *Activity) tryReschedule(
 	shouldRetry, retryInterval := a.shouldRetry(ctx, overridingRetryInterval)
 	resetRequested := a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED
 	// A pending reset request is always honored, regardless of retryability or the should retry result.
+	//staticcheck:ignore QF1001 (DeMorgan rearrangement would not be an improvement)
 	if !resetRequested && !(failureRetryable && shouldRetry) {
 		return false, nil
 	}

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -549,19 +549,14 @@ func (a *Activity) HandleFailed(
 		!appFailure.GetNonRetryable() &&
 		!slices.Contains(a.GetRetryPolicy().GetNonRetryableErrorTypes(), appFailure.GetType())
 
-	// A pending reset is honored even for a non-retryable failure: the reset discards the failed
-	// attempt and re-dispatches attempt 1. tryReschedule honors the reset regardless of shouldRetry.
-	resetRequested := a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED
-	if isRetryable || resetRequested {
-		rescheduled, err := a.tryReschedule(ctx, appFailure.GetNextRetryDelay().AsDuration(), failure)
-		if err != nil {
-			return nil, err
-		}
-		if rescheduled {
-			a.emitOnAttemptFailedMetrics(ctx, metricsHandler)
+	rescheduled, err := a.tryReschedule(ctx, isRetryable, appFailure.GetNextRetryDelay().AsDuration(), failure)
+	if err != nil {
+		return nil, err
+	}
+	if rescheduled {
+		a.emitOnAttemptFailedMetrics(ctx, metricsHandler)
 
-			return &historyservice.RespondActivityTaskFailedResponse{}, nil
-		}
+		return &historyservice.RespondActivityTaskFailedResponse{}, nil
 	}
 
 	if err := TransitionFailed.Apply(a, ctx, failedEvent{
@@ -1182,16 +1177,18 @@ func (a *Activity) recordFailedAttempt(
 
 // tryReschedule attempts to reschedule the activity for retry. Returns true if rescheduled, false
 // if retry is not possible. It handles the cases of pause and reset requests that were received
-// while the last attempt was in progress.
+// while the last attempt was in progress. failureRetryable reports whether the failure itself
+// permits a retry (timeouts always do; RespondActivityTaskFailed depends on the failure).
 func (a *Activity) tryReschedule(
 	ctx chasm.MutableContext,
+	failureRetryable bool,
 	overridingRetryInterval time.Duration,
 	failure *failurepb.Failure,
 ) (bool, error) {
 	shouldRetry, retryInterval := a.shouldRetry(ctx, overridingRetryInterval)
 	resetRequested := a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED
-	// A pending reset request is always honored, regardless of the should retry result.
-	if !shouldRetry && !resetRequested {
+	// A pending reset request is always honored, regardless of retryability or the should retry result.
+	if !resetRequested && !(failureRetryable && shouldRetry) {
 		return false, nil
 	}
 	event := rescheduleEvent{retryInterval: retryInterval, failure: failure}

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -687,9 +687,13 @@ func (a *Activity) UpdateActivityExecutionOptions(
 
 	attempt := a.LastAttempt.Get(ctx)
 
-	// Recalculate the current retry interval based on the (possibly updated) retry policy.
+	// Recalculate the retry interval based on the (possibly updated) retry policy.
 	// This ensures a shortened retry interval takes effect immediately on re-dispatch.
-	if a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED && attempt.GetCurrentRetryInterval() != nil {
+	status := a.GetStatus()
+	if (status == activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED ||
+		status == activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED) &&
+		attempt.GetCurrentRetryInterval() != nil {
+
 		newInterval := backoff.CalculateExponentialRetryInterval(a.RetryPolicy, attempt.GetCount()-1)
 		attempt.CurrentRetryInterval = durationpb.New(newInterval)
 	}
@@ -919,6 +923,9 @@ func (a *Activity) unpause(
 	event unpauseEvent,
 ) {
 	attempt := a.LastAttempt.Get(ctx)
+	// Compute the dispatch time while the pending retry state is still intact; it is cleared below.
+	dispatchTime := a.unpauseDispatchTime(ctx, event)
+
 	if event.req.GetResetAttempts() {
 		attempt.Count = 1
 	}
@@ -927,11 +934,6 @@ func (a *Activity) unpause(
 	}
 	attempt.Stamp++
 	attempt.CurrentRetryInterval = nil
-	unpauseTime := ctx.Now(a)
-	if jitter := event.req.GetJitter().AsDuration(); jitter > 0 {
-		unpauseTime = unpauseTime.Add(time.Duration(rand.Int63n(int64(jitter)))) //nolint:gosec
-	}
-	dispatchTime := a.dispatchTimeRespectingStartDelay(unpauseTime)
 	if timeout := a.GetScheduleToStartTimeout().AsDuration(); timeout > 0 {
 		ctx.AddTask(
 			a,
@@ -942,6 +944,23 @@ func (a *Activity) unpause(
 		a,
 		chasm.TaskAttributes{ScheduledTime: dispatchTime},
 		&activitypb.ActivityDispatchTask{Stamp: attempt.GetStamp()})
+}
+
+// unpauseDispatchTime computes when an unpaused attempt should be dispatched
+func (a *Activity) unpauseDispatchTime(ctx chasm.MutableContext, event unpauseEvent) time.Time {
+	unpauseTime := ctx.Now(a)
+	if jitter := event.req.GetJitter().AsDuration(); jitter > 0 {
+		unpauseTime = unpauseTime.Add(time.Duration(rand.Int63n(int64(jitter)))) //nolint:gosec
+	}
+	dispatchTime := a.dispatchTimeRespectingStartDelay(unpauseTime)
+	var retryDispatchTime *timestamppb.Timestamp
+	if !event.req.GetResetAttempts() {
+		retryDispatchTime = dispatchTimeForRetry(a.LastAttempt.Get(ctx))
+	}
+	if retryDispatchTime != nil && retryDispatchTime.AsTime().After(dispatchTime) {
+		return retryDispatchTime.AsTime()
+	}
+	return dispatchTime
 }
 
 func (a *Activity) recordPauseState(
@@ -990,10 +1009,11 @@ func (a *Activity) reset(ctx chasm.MutableContext, event resetEvent) {
 
 // handleReset handles the activity execution reset.
 //
-// For SCHEDULED and PAUSED activities (no worker running): re-dispatches at attempt 1, honoring
-// any pending start_delay or retry backoff. A PAUSED activity is unpaused first — unless
-// keepPaused is set, in which case the counter is reset to 1 but the activity stays PAUSED until
-// a later unpause.
+// For SCHEDULED and PAUSED activities (no worker running): re-dispatches at attempt 1. Any pending
+// retry backoff is discarded (reset clears CurrentRetryInterval), but a pending start_delay is
+// honored so the re-dispatched attempt 1 does not fire before its original requested start time. A
+// PAUSED activity is unpaused first — unless keepPaused is set, in which case the counter is reset
+// to 1 but the activity stays PAUSED until a later unpause.
 //
 // For STARTED activities: transitions to RESET_REQUESTED. The worker is notified via
 // ActivityReset=true on its next heartbeat response and continues to use its existing task token.

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1188,7 +1188,7 @@ func (a *Activity) tryReschedule(
 	shouldRetry, retryInterval := a.shouldRetry(ctx, overridingRetryInterval)
 	resetRequested := a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED
 	// A pending reset request is always honored, regardless of retryability or the should retry result.
-	//staticcheck:ignore QF1001 (DeMorgan rearrangement would not be an improvement)
+	//nolint:forbidigo // DeMorgan rearrangement would not be an improvement
 	if !resetRequested && !(failureRetryable && shouldRetry) {
 		return false, nil
 	}

--- a/chasm/lib/activity/activity_tasks.go
+++ b/chasm/lib/activity/activity_tasks.go
@@ -191,7 +191,7 @@ func (h *startToCloseTimeoutTaskHandler) Execute(
 	_ chasm.TaskAttributes,
 	_ *activitypb.StartToCloseTimeoutTask,
 ) error {
-	rescheduled, err := activity.tryReschedule(ctx, 0, createStartToCloseTimeoutFailure())
+	rescheduled, err := activity.tryReschedule(ctx, true, 0, createStartToCloseTimeoutFailure())
 	if err != nil {
 		return err
 	}
@@ -272,7 +272,7 @@ func (h *heartbeatTimeoutTaskHandler) Execute(
 	_ chasm.TaskAttributes,
 	_ *activitypb.HeartbeatTimeoutTask,
 ) error {
-	rescheduled, err := activity.tryReschedule(ctx, 0, createHeartbeatTimeoutFailure())
+	rescheduled, err := activity.tryReschedule(ctx, true, 0, createHeartbeatTimeoutFailure())
 	if err != nil {
 		return err
 	}

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -548,15 +548,19 @@ var TransitionResetAttemptFailedToPaused = chasm.NewTransition(
 		}
 		attempt.Count = 1
 		attempt.Stamp++
-		return a.recordFailedAttempt(ctx, event.retryInterval, event.failure, ctx.Now(a), false)
+		if err := a.recordFailedAttempt(ctx, event.retryInterval, event.failure, ctx.Now(a), false); err != nil {
+			return err
+		}
+		// Reset discards the retry backoff
+		attempt.CurrentRetryInterval = nil
+		return nil
 	},
 )
 
 // TransitionResetAttemptFailedToScheduled transitions RESET_REQUESTED → SCHEDULED. It is performed
 // instead of TransitionRescheduled when the activity is in RESET_REQUESTED and the worker yields
-// (failure or timeout) with retries remaining. The failed attempt is recorded, the count is reset
-// to 0 and then incremented to 1 (so the next attempt is "attempt 1"), and a fresh dispatch task
-// is emitted at the next retry time.
+// (failure or timeout) with retries remaining. The failed attempt is recorded and the count is
+// reset to 1 (so the next attempt is "attempt 1").
 var TransitionResetAttemptFailedToScheduled = chasm.NewTransition(
 	[]activitypb.ActivityExecutionStatus{
 		activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
@@ -579,13 +583,15 @@ var TransitionResetAttemptFailedToScheduled = chasm.NewTransition(
 		if err := a.recordFailedAttempt(ctx, event.retryInterval, event.failure, currentTime, false); err != nil {
 			return err
 		}
+		// Reset discards the retry backoff
+		attempt.CurrentRetryInterval = nil
 
-		retryScheduledTime := dispatchTimeForRetry(attempt).AsTime()
+		dispatchTime := a.dispatchTimeRespectingStartDelay(currentTime)
 		if timeout := a.GetScheduleToStartTimeout().AsDuration(); timeout > 0 {
 			ctx.AddTask(
 				a,
 				chasm.TaskAttributes{
-					ScheduledTime: retryScheduledTime.Add(timeout),
+					ScheduledTime: dispatchTime.Add(timeout),
 				},
 				&activitypb.ScheduleToStartTimeoutTask{
 					Stamp: attempt.GetStamp(),
@@ -594,7 +600,7 @@ var TransitionResetAttemptFailedToScheduled = chasm.NewTransition(
 		ctx.AddTask(
 			a,
 			chasm.TaskAttributes{
-				ScheduledTime: retryScheduledTime,
+				ScheduledTime: dispatchTime,
 			},
 			&activitypb.ActivityDispatchTask{
 				Stamp: attempt.GetStamp(),

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -12399,6 +12399,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.NoError(t, err)
 	})
 
+	// A Reset request when STARTED should be honored even if the attempt fails retryably.
 	t.Run("RestoreOriginalOptions_WhileStarted_AttemptFailsRetryably", func(t *testing.T) {
 		cases := []struct {
 			name        string
@@ -12460,6 +12461,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		}
 	})
 
+	// A Reset request when STARTED should be honored even if the attempt fails non-retryably.
 	t.Run("RestoreOriginalOptions_WhileStarted_AttemptFailsNonRetryably", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
@@ -12480,22 +12482,17 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		})
 		require.NoError(t, err)
 
-		// Fail attempt non-retryably -> Activity terminal failure
+		// Fail attempt non-retryably -> should still reset
 		failAttemptNonRetryably(ctx, t, taskToken)
 
-		// The activity should have failed and the restore changes should never have been applied
-		desc, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  env.Namespace().String(),
-			ActivityId: activityID,
-			RunId:      startResp.GetRunId(),
-		})
-		require.NoError(t, err)
-		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_FAILED, desc.GetInfo().GetStatus())
-		require.EqualValues(t, 1, desc.GetInfo().GetAttempt())
-		require.Equal(t, updatedTimeouts[0], desc.GetInfo().GetStartToCloseTimeout().AsDuration(),
-			"terminal failure with reset requested should not have restored options")
-		require.Equal(t, updatedTimeouts[1], desc.GetInfo().GetHeartbeatTimeout().AsDuration(),
-			"terminal failure with reset requested should not have restored options")
+		// The reset should have been applied with the restore
+		desc := describeActivity(ctx, t, activityID, startResp.GetRunId())
+		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, desc.GetInfo().GetRunState(), "expected in SCHEDULED")
+		require.EqualValues(t, 1, desc.GetInfo().GetAttempt(), "expected attempt 1")
+		require.Equal(t, originalTimeouts[0], desc.GetInfo().GetStartToCloseTimeout().AsDuration(),
+			"reset should have restored options")
+		require.Equal(t, originalTimeouts[1], desc.GetInfo().GetHeartbeatTimeout().AsDuration(),
+			"reset should have restored options")
 	})
 
 	t.Run("RestoreOriginalOptions_WhileStarted_AttemptSucceeds", func(t *testing.T) {

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -9854,9 +9854,11 @@ func (s *standaloneActivityTestSuite) TestPauseActivityExecution() {
 		require.EqualValues(t, 2, poll2Resp.Attempt)
 	})
 
-	// PauseWhileRetryNoWait: pause an activity during a long retry backoff (30s), then immediately
-	// unpause. The activity should be dispatched quickly — well before the 30s retry interval elapses.
-	t.Run("PauseWhileRetryNoWait", func(t *testing.T) {
+	// PauseWhileRetryHonorsBackoff: pausing an activity mid retry-backoff and immediately unpausing
+	// must not shortcut the remaining backoff. Unpause honors the pending retry's dispatch time
+	// (complete_time + retry_interval), just as it honors a pending start_delay, so the activity
+	// stays SCHEDULED until the original backoff would have elapsed rather than dispatching at once.
+	t.Run("PauseWhileRetryHonorsBackoff", func(t *testing.T) {
 		ctx := testcore.NewContext()
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
@@ -9900,7 +9902,7 @@ func (s *standaloneActivityTestSuite) TestPauseActivityExecution() {
 		})
 		require.NoError(t, err)
 
-		// Wait for activity to be rescheduled at attempt=2.
+		// Wait for activity to be rescheduled at attempt=2 (in retry backoff).
 		await.Require(ctx, t, func(c *await.T) {
 			dr, dErr := env.FrontendClient().DescribeActivityExecution(c.Context(), &workflowservice.DescribeActivityExecutionRequest{
 				Namespace:  env.Namespace().String(),
@@ -9910,7 +9912,7 @@ func (s *standaloneActivityTestSuite) TestPauseActivityExecution() {
 			require.EqualValues(c, 2, dr.GetInfo().GetAttempt())
 		}, 10*time.Second, 200*time.Millisecond)
 
-		// Pause, then immediately unpause – this should skip the remaining 30s backoff.
+		// Pause, then immediately unpause.
 		_, err = env.FrontendClient().PauseActivityExecution(ctx, &workflowservice.PauseActivityExecutionRequest{
 			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
@@ -9925,15 +9927,15 @@ func (s *standaloneActivityTestSuite) TestPauseActivityExecution() {
 		})
 		require.NoError(t, err)
 
-		// Activity should be dispatched quickly (well within the 30s retry backoff window).
-		poll2Resp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: env.Namespace().String(),
-			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-			Identity:  env.Tv().WorkerIdentity(),
-		})
-		require.NoError(t, err)
-		require.Equal(t, activityID, poll2Resp.GetActivityId())
-		require.EqualValues(t, 2, poll2Resp.Attempt)
+		// Honor backoff: the activity must stay SCHEDULED well past the unpause
+		require.Never(t, func() bool {
+			dr, dErr := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:  env.Namespace().String(),
+				ActivityId: activityID,
+			})
+			return dErr != nil || dr.GetInfo().GetRunState() != enumspb.PENDING_ACTIVITY_STATE_SCHEDULED
+		}, 5*time.Second, 100*time.Millisecond,
+			"unpause must honor the remaining retry backoff; activity should remain SCHEDULED")
 	})
 
 	// PauseWhileCancelRequested: pausing a CANCEL_REQUESTED activity must be rejected with
@@ -11622,6 +11624,96 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 			Identity:  defaultIdentity,
 		})
 		require.NoError(t, err)
+	})
+
+	// Resetting a STARTED activity that is on attempt > 1 must re-dispatch the fresh attempt 1
+	// promptly: reset honors start_delay (here 0, so immediate) but must NOT honor the retry
+	// backoff of the attempt that was in flight.
+	t.Run("WhileRunningOnLaterAttemptDropsRetryBackoff", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		retryPolicy := &commonpb.RetryPolicy{
+			InitialInterval:    durationpb.New(time.Second),
+			BackoffCoefficient: 10.0,
+		}
+		startResp, pollResp1, taskQueue := startAndPollActivity(ctx, t, activityID, retryPolicy)
+		require.EqualValues(t, 1, pollResp1.Attempt)
+
+		// Fail attempt 1 -> ~1s backoff, then attempt 2 is dispatched and picked up by a worker.
+		failAttemptRetryably(ctx, t, pollResp1.TaskToken, 0)
+		pollResp2 := pollActivity(ctx, t, taskQueue)
+		require.EqualValues(t, 2, pollResp2.Attempt)
+
+		// Reset while attempt 2 is STARTED (deferred), then fail attempt 2 to trigger the reset.
+		resetActivity(ctx, t, activityID, startResp.GetRunId(), false)
+		failAttemptRetryably(ctx, t, pollResp2.TaskToken, 0)
+
+		// The reset attempt (attempt 1) must dispatch promptly.
+		pollCtx, pollCancel := context.WithTimeout(ctx, 5*time.Second)
+		defer pollCancel()
+		pollResp3, err := env.FrontendClient().PollActivityTaskQueue(pollCtx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
+			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			Identity:  defaultIdentity,
+		})
+		require.NoError(t, err, "reset attempt should dispatch promptly, not after the in-flight attempt's retry backoff")
+		require.NotEmpty(t, pollResp3.GetTaskToken(), "reset attempt should dispatch promptly, not after the in-flight attempt's retry backoff")
+		require.EqualValues(t, 1, pollResp3.Attempt, "attempt should be reset to 1")
+
+		completeAttempt(ctx, t, pollResp3.TaskToken)
+	})
+
+	// Reset(keepPaused=true) of a STARTED activity on attempt > 1 lands it back in PAUSED via
+	// TransitionResetAttemptFailedToPaused.
+	t.Run("KeepPausedWhileRunningOnLaterAttemptDropsRetryBackoff", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		retryPolicy := &commonpb.RetryPolicy{
+			InitialInterval:    durationpb.New(time.Second),
+			BackoffCoefficient: 10.0,
+		}
+		startResp, pollResp1, taskQueue := startAndPollActivity(ctx, t, activityID, retryPolicy)
+		require.EqualValues(t, 1, pollResp1.Attempt)
+
+		// Fail attempt 1 -> ~1s backoff, then attempt 2 is dispatched and picked up by a worker.
+		failAttemptRetryably(ctx, t, pollResp1.TaskToken, 0)
+		pollResp2 := pollActivity(ctx, t, taskQueue)
+		require.EqualValues(t, 2, pollResp2.Attempt)
+
+		// Pause the running attempt (-> PAUSE_REQUESTED), then reset with keepPaused so the activity
+		// lands back in PAUSED (not SCHEDULED) when the attempt yields.
+		pauseActivity(ctx, t, activityID, startResp.GetRunId())
+		_, err := env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.GetRunId(),
+			KeepPaused: true,
+		})
+		require.NoError(t, err)
+
+		// Fail attempt 2 -> deferred keep-paused reset -> PAUSED at attempt 1.
+		failAttemptRetryably(ctx, t, pollResp2.TaskToken, 0)
+		waitForState(ctx, t, activityID, startResp.GetRunId(), enumspb.PENDING_ACTIVITY_STATE_PAUSED)
+
+		// Unpause: attempt 1 must dispatch promptly, not after attempt 2's 10s backoff.
+		unpauseActivity(ctx, t, activityID, startResp.GetRunId())
+
+		pollCtx, pollCancel := context.WithTimeout(ctx, 5*time.Second)
+		defer pollCancel()
+		pollResp3, err := env.FrontendClient().PollActivityTaskQueue(pollCtx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
+			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			Identity:  defaultIdentity,
+		})
+		require.NoError(t, err, "unpaused reset attempt should dispatch promptly, not after the in-flight attempt's retry backoff")
+		require.NotEmpty(t, pollResp3.GetTaskToken(), "unpaused reset attempt should dispatch promptly, not after the in-flight attempt's retry backoff")
+		require.EqualValues(t, 1, pollResp3.Attempt, "attempt should be reset to 1")
+
+		completeAttempt(ctx, t, pollResp3.TaskToken)
 	})
 
 	t.Run("WhileCancelRequestedReturnsFailedPrecondition", func(t *testing.T) {


### PR DESCRIPTION
## What changed?
Honor Reset request even if attempt fails non-retryably

## Why?
Agreed product spec.

## How did you test it?
- [x] added new functional test(s)

## Potential risks
Could break SAA reset behavior if wrong

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core activity failure/reschedule paths for standalone reset; wrong logic could break reset, retry, or terminal-failure behavior.
> 
> **Overview**
> **Pending reset on a running standalone activity is now applied when the worker reports a non-retryable failure**, instead of failing the execution and leaving deferred `RestoreOriginalOptions` unapplied.
> 
> `HandleFailed` always routes through `tryReschedule` (not only when the application failure is retryable). `tryReschedule` takes a new `failureRetryable` flag: normal retries still require retryability plus `shouldRetry`, but **`RESET_REQUESTED` is honored regardless**. Timeout handlers pass `failureRetryable: true` so behavior stays the same for start-to-close and heartbeat timeouts.
> 
> Functional tests now expect **SCHEDULED at attempt 1 with original timeouts restored** after reset + non-retryable fail while started.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c0b8207b4cb1619c0dfe3137c928e11cdbd93b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->