### PR TITLE
Add latency metric for backfilling replication history events

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1096,6 +1096,9 @@ var (
 	// ReplicationOrphanedHistoryBranch tracks cases where history branch cleanup was skipped on error
 	// to avoid deleting successfully written history. These orphaned branches will be cleaned up by GC.
 	ReplicationOrphanedHistoryBranch = NewCounterDef("replication_orphaned_history_branch")
+	// ReplicationBackfillEventsLatency measures the latency of bringing local events up to the
+	// source cluster's current branch (backfilling history events) during workflow state replication.
+	ReplicationBackfillEventsLatency = NewTimerDef("replication_backfill_events_latency")
 	// ReplicationTasksLag is a heuristic for how far behind the remote DC is for a given cluster. It measures the
 	// difference between task IDs so its unit should be "tasks".
 	ReplicationTasksLag                             = NewDimensionlessHistogramDef("replication_tasks_lag")

--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -1122,14 +1122,11 @@ func (r *WorkflowStateReplicatorImpl) bringLocalEventsUpToSourceCurrentBranch(
 	eventBlobs []*commonpb.DataBlob,
 	isNewMutableState bool,
 ) ([]byte, error) {
-	ns, err := r.namespaceRegistry.GetNamespaceByID(namespaceID)
-	if err != nil {
-		return nil, err
-	}
 	startTime := time.Now().UTC()
+	nsName := namespace.EmptyName.String()
 	defer func() {
 		metrics.ReplicationBackfillEventsLatency.With(r.shardContext.GetMetricsHandler()).
-			Record(time.Since(startTime), metrics.NamespaceTag(ns.Name().String()))
+			Record(time.Since(startTime), metrics.NamespaceTag(nsName))
 	}()
 
 	sourceVersionHistory, err := versionhistory.GetCurrentVersionHistory(sourceVersionHistories)
@@ -1221,6 +1218,11 @@ func (r *WorkflowStateReplicatorImpl) bringLocalEventsUpToSourceCurrentBranch(
 		historyEvents = append(historyEvents, events)
 	}
 
+	ns, err := r.namespaceRegistry.GetNamespaceByID(namespaceID)
+	if err != nil {
+		return newBranchToken, err
+	}
+	nsName = ns.Name().String()
 	// In standby cluster, use a background low priority which is higher than the standby task processing
 	callerType := headers.CallerTypeBackgroundLow
 	if ns.ActiveClusterName(namespace.RoutingKey{ID: workflowID}) == r.clusterMetadata.GetCurrentClusterName() {

--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -1232,7 +1232,7 @@ func (r *WorkflowStateReplicatorImpl) bringLocalEventsUpToSourceCurrentBranch(
 	quotaRequest := quotas.NewRequest(
 		"AppendRawHistoryNodes",
 		1,
-		ns.Name().String(),
+		nsName,
 		callerType,
 		0,
 		"",
@@ -1277,7 +1277,7 @@ func (r *WorkflowStateReplicatorImpl) bringLocalEventsUpToSourceCurrentBranch(
 				localMutableState.AddReapplyCandidateEvent(event)
 				r.addEventToCache(localMutableState.GetWorkflowKey(), event)
 			}
-			if r.enablePersistenceRateLimiter(ns.Name().String()) {
+			if r.enablePersistenceRateLimiter(nsName) {
 				if err := r.persistenceRateLimiter.Wait(ctx, quotaRequest); err != nil {
 					return err
 				}
@@ -1304,7 +1304,7 @@ func (r *WorkflowStateReplicatorImpl) bringLocalEventsUpToSourceCurrentBranch(
 			isNewBranch = false
 
 			localMutableState.GetExecutionInfo().ExecutionStats.HistorySize += int64(len(historyBlob.rawHistory.Data))
-			if r.shardContext.GetConfig().ExternalPayloadsEnabled(ns.Name().String()) {
+			if r.shardContext.GetConfig().ExternalPayloadsEnabled(nsName) {
 				externalPayloadSize, externalPayloadCount, err := workflow.CalculateExternalPayloadSize(
 					events,
 					metrics.NoopMetricsHandler, // don't record metrics since those are not new uploads
@@ -1348,7 +1348,7 @@ func (r *WorkflowStateReplicatorImpl) bringLocalEventsUpToSourceCurrentBranch(
 			localMutableState.AddReapplyCandidateEvent(event)
 			r.addEventToCache(localMutableState.GetWorkflowKey(), event)
 		}
-		if r.enablePersistenceRateLimiter(ns.Name().String()) {
+		if r.enablePersistenceRateLimiter(nsName) {
 			if err := r.persistenceRateLimiter.Wait(ctx, quotaRequest); err != nil {
 				return newBranchToken, err
 			}

--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -1122,14 +1122,14 @@ func (r *WorkflowStateReplicatorImpl) bringLocalEventsUpToSourceCurrentBranch(
 	eventBlobs []*commonpb.DataBlob,
 	isNewMutableState bool,
 ) ([]byte, error) {
-	nsName := namespace.EmptyName.String()
-	if ns, err := r.namespaceRegistry.GetNamespaceByID(namespaceID); err == nil && ns != nil {
-		nsName = ns.Name().String()
+	ns, err := r.namespaceRegistry.GetNamespaceByID(namespaceID)
+	if err != nil {
+		return nil, err
 	}
 	startTime := time.Now().UTC()
 	defer func() {
 		metrics.ReplicationBackfillEventsLatency.With(r.shardContext.GetMetricsHandler()).
-			Record(time.Since(startTime), metrics.NamespaceTag(nsName))
+			Record(time.Since(startTime), metrics.NamespaceTag(ns.Name().String()))
 	}()
 
 	sourceVersionHistory, err := versionhistory.GetCurrentVersionHistory(sourceVersionHistories)
@@ -1221,10 +1221,6 @@ func (r *WorkflowStateReplicatorImpl) bringLocalEventsUpToSourceCurrentBranch(
 		historyEvents = append(historyEvents, events)
 	}
 
-	ns, err := r.namespaceRegistry.GetNamespaceByID(namespaceID)
-	if err == nil && ns != nil {
-		nsName = ns.Name().String()
-	}
 	// In standby cluster, use a background low priority which is higher than the standby task processing
 	callerType := headers.CallerTypeBackgroundLow
 	if ns.ActiveClusterName(namespace.RoutingKey{ID: workflowID}) == r.clusterMetadata.GetCurrentClusterName() {
@@ -1234,7 +1230,7 @@ func (r *WorkflowStateReplicatorImpl) bringLocalEventsUpToSourceCurrentBranch(
 	quotaRequest := quotas.NewRequest(
 		"AppendRawHistoryNodes",
 		1,
-		nsName,
+		ns.Name().String(),
 		callerType,
 		0,
 		"",
@@ -1279,7 +1275,7 @@ func (r *WorkflowStateReplicatorImpl) bringLocalEventsUpToSourceCurrentBranch(
 				localMutableState.AddReapplyCandidateEvent(event)
 				r.addEventToCache(localMutableState.GetWorkflowKey(), event)
 			}
-			if r.enablePersistenceRateLimiter(nsName) {
+			if r.enablePersistenceRateLimiter(ns.Name().String()) {
 				if err := r.persistenceRateLimiter.Wait(ctx, quotaRequest); err != nil {
 					return err
 				}
@@ -1306,7 +1302,7 @@ func (r *WorkflowStateReplicatorImpl) bringLocalEventsUpToSourceCurrentBranch(
 			isNewBranch = false
 
 			localMutableState.GetExecutionInfo().ExecutionStats.HistorySize += int64(len(historyBlob.rawHistory.Data))
-			if r.shardContext.GetConfig().ExternalPayloadsEnabled(nsName) {
+			if r.shardContext.GetConfig().ExternalPayloadsEnabled(ns.Name().String()) {
 				externalPayloadSize, externalPayloadCount, err := workflow.CalculateExternalPayloadSize(
 					events,
 					metrics.NoopMetricsHandler, // don't record metrics since those are not new uploads
@@ -1350,7 +1346,7 @@ func (r *WorkflowStateReplicatorImpl) bringLocalEventsUpToSourceCurrentBranch(
 			localMutableState.AddReapplyCandidateEvent(event)
 			r.addEventToCache(localMutableState.GetWorkflowKey(), event)
 		}
-		if r.enablePersistenceRateLimiter(nsName) {
+		if r.enablePersistenceRateLimiter(ns.Name().String()) {
 			if err := r.persistenceRateLimiter.Wait(ctx, quotaRequest); err != nil {
 				return newBranchToken, err
 			}

--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -1122,6 +1122,16 @@ func (r *WorkflowStateReplicatorImpl) bringLocalEventsUpToSourceCurrentBranch(
 	eventBlobs []*commonpb.DataBlob,
 	isNewMutableState bool,
 ) ([]byte, error) {
+	nsName := namespace.EmptyName.String()
+	if ns, err := r.namespaceRegistry.GetNamespaceByID(namespaceID); err == nil && ns != nil {
+		nsName = ns.Name().String()
+	}
+	startTime := time.Now().UTC()
+	defer func() {
+		metrics.ReplicationBackfillEventsLatency.With(r.shardContext.GetMetricsHandler()).
+			Record(time.Since(startTime), metrics.NamespaceTag(nsName))
+	}()
+
 	sourceVersionHistory, err := versionhistory.GetCurrentVersionHistory(sourceVersionHistories)
 	if err != nil {
 		return nil, err
@@ -1211,7 +1221,6 @@ func (r *WorkflowStateReplicatorImpl) bringLocalEventsUpToSourceCurrentBranch(
 		historyEvents = append(historyEvents, events)
 	}
 
-	nsName := namespace.EmptyName.String()
 	ns, err := r.namespaceRegistry.GetNamespaceByID(namespaceID)
 	if err == nil && ns != nil {
 		nsName = ns.Name().String()

--- a/service/history/ndc/workflow_state_replicator_test.go
+++ b/service/history/ndc/workflow_state_replicator_test.go
@@ -1155,6 +1155,7 @@ func (s *workflowReplicatorSuite) Test_bringLocalEventsUpToSourceCurrentBranch_W
 	mockShard.EXPECT().GenerateTaskID().Return(taskId3, nil).Times(1)
 	mockShard.EXPECT().GetRemoteAdminClient(sourceClusterName).Return(s.mockRemoteAdminClient, nil).AnyTimes()
 	mockShard.EXPECT().GetShardID().Return(int32(0)).AnyTimes()
+	mockShard.EXPECT().GetMetricsHandler().Return(s.mockShard.GetMetricsHandler()).AnyTimes()
 	mockShard.EXPECT().GetConfig().Return(s.mockShard.GetConfig()).AnyTimes()
 	s.workflowStateReplicator.shardContext = mockShard
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(namespace.ID(namespaceID)).Return(namespace.NewNamespaceForTest(
@@ -1318,6 +1319,7 @@ func (s *workflowReplicatorSuite) Test_bringLocalEventsUpToSourceCurrentBranch_W
 	mockShard.EXPECT().GenerateTaskID().Return(taskId3, nil).Times(1)
 	mockShard.EXPECT().GetRemoteAdminClient(sourceClusterName).Return(s.mockRemoteAdminClient, nil).AnyTimes()
 	mockShard.EXPECT().GetShardID().Return(int32(0)).AnyTimes()
+	mockShard.EXPECT().GetMetricsHandler().Return(s.mockShard.GetMetricsHandler()).AnyTimes()
 	mockShard.EXPECT().GetConfig().Return(s.mockShard.GetConfig()).AnyTimes()
 	s.workflowStateReplicator.shardContext = mockShard
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(namespace.ID(namespaceID)).Return(namespace.NewNamespaceForTest(
@@ -1506,6 +1508,7 @@ func (s *workflowReplicatorSuite) Test_bringLocalEventsUpToSourceCurrentBranch_W
 	mockShard.EXPECT().GenerateTaskID().Return(taskId3, nil).Times(1)
 	mockShard.EXPECT().GetRemoteAdminClient(sourceClusterName).Return(s.mockRemoteAdminClient, nil).AnyTimes()
 	mockShard.EXPECT().GetShardID().Return(int32(0)).AnyTimes()
+	mockShard.EXPECT().GetMetricsHandler().Return(s.mockShard.GetMetricsHandler()).AnyTimes()
 	mockShard.EXPECT().GetConfig().Return(s.mockShard.GetConfig()).AnyTimes()
 	s.workflowStateReplicator.shardContext = mockShard
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(namespace.ID(namespaceID)).Return(namespace.NewNamespaceForTest(
@@ -2030,6 +2033,7 @@ func (s *workflowReplicatorSuite) Test_bringLocalEventsUpToSourceCurrentBranch_E
 	mockShard.EXPECT().GenerateTaskID().Return(taskID, nil).Times(1)
 	mockShard.EXPECT().GetRemoteAdminClient(sourceClusterName).Return(s.mockRemoteAdminClient, nil).AnyTimes()
 	mockShard.EXPECT().GetShardID().Return(int32(0)).AnyTimes()
+	mockShard.EXPECT().GetMetricsHandler().Return(s.mockShard.GetMetricsHandler()).AnyTimes()
 	mockShard.EXPECT().GetConfig().Return(s.mockShard.GetConfig()).AnyTimes()
 	mockEventsCache := events.NewMockCache(s.controller)
 	mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()


### PR DESCRIPTION
## What

Adds a timer metric `replication_backfill_events_latency` that measures how long `bringLocalEventsUpToSourceCurrentBranch` takes to execute during workflow state replication (backfilling history events).

The metric is recorded via a `defer` so it captures every return path (including early returns and errors) and is tagged with the namespace name.

## Why

We currently have no visibility into how long backfilling replication history events takes. This metric surfaces that latency per-namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)