### PR TITLE
Validate merged SAA retry policy updates

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"math/rand"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/nexus-rpc/sdk-go/nexus"
@@ -52,6 +51,7 @@ import (
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/common/payload"
+	"go.temporal.io/server/common/retrypolicy"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/tqid"
 	"go.temporal.io/server/common/util"
@@ -196,14 +196,14 @@ func NewStandaloneActivity(
 			Priority:               request.Priority,
 			StartDelay:             request.GetStartDelay(),
 			OriginalOptions: &apiactivitypb.ActivityOptions{
-				TaskQueue:              request.GetTaskQueue(),
-				ScheduleToCloseTimeout: request.GetScheduleToCloseTimeout(),
-				ScheduleToStartTimeout: request.GetScheduleToStartTimeout(),
-				StartToCloseTimeout:    request.GetStartToCloseTimeout(),
-				HeartbeatTimeout:       request.GetHeartbeatTimeout(),
-				RetryPolicy:            request.GetRetryPolicy(),
-				Priority:               request.GetPriority(),
-				StartDelay:             request.GetStartDelay(),
+				TaskQueue:              common.CloneProto(request.GetTaskQueue()),
+				ScheduleToCloseTimeout: common.CloneProto(request.GetScheduleToCloseTimeout()),
+				ScheduleToStartTimeout: common.CloneProto(request.GetScheduleToStartTimeout()),
+				StartToCloseTimeout:    common.CloneProto(request.GetStartToCloseTimeout()),
+				HeartbeatTimeout:       common.CloneProto(request.GetHeartbeatTimeout()),
+				RetryPolicy:            common.CloneProto(request.GetRetryPolicy()),
+				Priority:               common.CloneProto(request.GetPriority()),
+				StartDelay:             common.CloneProto(request.GetStartDelay()),
 			},
 		},
 		LastAttempt: chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{}),
@@ -760,14 +760,7 @@ func (a *Activity) shouldRecalculateCurrentRetryInterval(
 	}
 
 	if !restoreOriginal {
-		hasRetryPolicyInMask := false
-		for field := range updateFields {
-			if field == "retryPolicy" || strings.HasPrefix(field, "retryPolicy.") {
-				hasRetryPolicyInMask = true
-				break
-			}
-		}
-		if !hasRetryPolicyInMask {
+		if !util.FieldMaskHasPathOrSubPath(updateFields, "retryPolicy") {
 			return false
 		}
 	}
@@ -787,18 +780,24 @@ func (a *Activity) mergeActivityOptions(
 
 	// Build an ActivityOptions view of the current Activity state so we can use the shared merge function.
 	ao := &apiactivitypb.ActivityOptions{
-		TaskQueue:              a.TaskQueue,
-		ScheduleToCloseTimeout: a.ScheduleToCloseTimeout,
-		ScheduleToStartTimeout: a.ScheduleToStartTimeout,
-		StartToCloseTimeout:    a.StartToCloseTimeout,
-		HeartbeatTimeout:       a.HeartbeatTimeout,
-		Priority:               a.Priority,
-		RetryPolicy:            a.RetryPolicy,
-		StartDelay:             a.StartDelay,
+		TaskQueue:              common.CloneProto(a.TaskQueue),
+		ScheduleToCloseTimeout: common.CloneProto(a.ScheduleToCloseTimeout),
+		ScheduleToStartTimeout: common.CloneProto(a.ScheduleToStartTimeout),
+		StartToCloseTimeout:    common.CloneProto(a.StartToCloseTimeout),
+		HeartbeatTimeout:       common.CloneProto(a.HeartbeatTimeout),
+		Priority:               common.CloneProto(a.Priority),
+		RetryPolicy:            common.CloneProto(a.RetryPolicy),
+		StartDelay:             common.CloneProto(a.StartDelay),
 	}
 
-	if err := activityoptions.MergeActivityOptions(ao, req.GetActivityOptions(), updateFields); err != nil {
+	if err := activityoptions.MergeActivityOptions(ao, common.CloneProto(req.GetActivityOptions()), updateFields); err != nil {
 		return err
+	}
+
+	if util.FieldMaskHasSubPath(updateFields, "retryPolicy") {
+		if err := retrypolicy.Validate(ao.GetRetryPolicy()); err != nil {
+			return err
+		}
 	}
 
 	// Re-normalize timeouts after the update so that relationships like

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	apiactivitypb "go.temporal.io/api/activity/v1" //nolint:importas
 	commonpb "go.temporal.io/api/common/v1"
 	sdkpb "go.temporal.io/api/sdk/v1"
 	"go.temporal.io/api/serviceerror"
@@ -21,6 +22,7 @@ import (
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -455,6 +457,87 @@ func TestNewStandaloneActivity_UserMetadataDualWrite(t *testing.T) {
 	// Legacy location: ActivityRequestData also carries it so rolled-back code
 	// can still surface user metadata via the old field.
 	require.Same(t, md, activity.RequestData.Get(ctx).GetUserMetadata()) //nolint:staticcheck // exercising legacy field
+}
+
+func TestNewStandaloneActivity_OriginalOptionsUnaffectedBySubfieldUpdate(t *testing.T) {
+	ctx := &chasm.MockMutableContext{
+		MockContext: chasm.MockContext{
+			HandleNow: func(chasm.Component) time.Time { return time.Unix(0, 0) },
+		},
+	}
+
+	activity, err := NewStandaloneActivity(ctx, &workflowservice.StartActivityExecutionRequest{
+		Namespace:              "ns",
+		ActivityId:             "act",
+		ActivityType:           &commonpb.ActivityType{Name: "T"},
+		TaskQueue:              &taskqueuepb.TaskQueue{Name: "original-task-queue"},
+		ScheduleToCloseTimeout: durationpb.New(30 * time.Second),
+		ScheduleToStartTimeout: durationpb.New(20 * time.Second),
+		StartToCloseTimeout:    durationpb.New(10 * time.Second),
+		RetryPolicy: &commonpb.RetryPolicy{
+			InitialInterval:    durationpb.New(10 * time.Second),
+			BackoffCoefficient: 2,
+			MaximumInterval:    durationpb.New(100 * time.Second),
+			MaximumAttempts:    5,
+		},
+		Priority: &commonpb.Priority{
+			FairnessKey: "original-fairness-key",
+		},
+	})
+	require.NoError(t, err)
+
+	err = activity.mergeActivityOptions(&workflowservice.UpdateActivityExecutionOptionsRequest{
+		ActivityId: "act",
+		ActivityOptions: &apiactivitypb.ActivityOptions{
+			TaskQueue: &taskqueuepb.TaskQueue{Name: "updated-task-queue"},
+			RetryPolicy: &commonpb.RetryPolicy{
+				InitialInterval: durationpb.New(time.Second),
+			},
+			Priority: &commonpb.Priority{
+				FairnessKey: "updated-fairness-key",
+			},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{
+			"task_queue.name",
+			"retry_policy.initial_interval",
+			"priority.fairness_key",
+		}},
+	})
+	require.NoError(t, err)
+
+	originalOptions := activity.GetOriginalOptions()
+	require.Equal(t, "original-task-queue", originalOptions.GetTaskQueue().GetName())
+	require.Equal(t, 10*time.Second, originalOptions.GetRetryPolicy().GetInitialInterval().AsDuration())
+	require.Equal(t, "original-fairness-key", originalOptions.GetPriority().GetFairnessKey())
+}
+
+func TestMergeActivityOptionsRejectsInvalidMergedRetryPolicy(t *testing.T) {
+	activity := &Activity{
+		ActivityState: &activitypb.ActivityState{
+			ActivityType:           &commonpb.ActivityType{Name: "T"},
+			TaskQueue:              &taskqueuepb.TaskQueue{Name: "Q"},
+			ScheduleToCloseTimeout: durationpb.New(30 * time.Second),
+			ScheduleToStartTimeout: durationpb.New(20 * time.Second),
+			StartToCloseTimeout:    durationpb.New(10 * time.Second),
+			RetryPolicy: &commonpb.RetryPolicy{
+				InitialInterval:    durationpb.New(10 * time.Second),
+				BackoffCoefficient: 2,
+				MaximumInterval:    durationpb.New(30 * time.Second),
+				MaximumAttempts:    5,
+			},
+		},
+	}
+
+	err := activity.mergeActivityOptions(&workflowservice.UpdateActivityExecutionOptionsRequest{
+		ActivityId: "act",
+		ActivityOptions: &apiactivitypb.ActivityOptions{
+			RetryPolicy: &commonpb.RetryPolicy{
+				InitialInterval: durationpb.New(60 * time.Second),
+			},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"retry_policy.initial_interval"}},
+	})
+	require.ErrorContains(t, err, "MaximumInterval cannot be less than InitialInterval")
 }
 
 // TestEffectiveUserMetadata_PrefersFrameworkLocation ensures the helper used by

--- a/common/activityoptions/merge.go
+++ b/common/activityoptions/merge.go
@@ -75,6 +75,9 @@ func MergeActivityOptions(mergeInto, mergeFrom *activitypb.ActivityOptions, upda
 	}
 
 	if _, ok := updateFields["retryPolicy"]; ok {
+		if mergeFrom.GetRetryPolicy() == nil {
+			return serviceerror.NewInvalidArgument("RetryPolicy is not provided")
+		}
 		mergeInto.RetryPolicy = mergeFrom.GetRetryPolicy()
 	}
 

--- a/common/activityoptions/merge_test.go
+++ b/common/activityoptions/merge_test.go
@@ -165,6 +165,9 @@ func TestMergeActivityOptionsErrors(t *testing.T) {
 	err = MergeActivityOptions(&activitypb.ActivityOptions{}, emptyOpts, makeReq("retry_policy.initial_interval"))
 	require.ErrorContains(t, err, "RetryPolicy is not provided")
 
+	err = MergeActivityOptions(&activitypb.ActivityOptions{}, emptyOpts, makeReq("retry_policy"))
+	require.ErrorContains(t, err, "RetryPolicy is not provided")
+
 	err = MergeActivityOptions(&activitypb.ActivityOptions{}, emptyOpts, makeReq("taskQueue.name"))
 	require.ErrorContains(t, err, "TaskQueue is not provided")
 

--- a/common/util/proto.go
+++ b/common/util/proto.go
@@ -36,13 +36,30 @@ func ConvertPathToCamel(input string) []string {
 }
 
 func ParseFieldMask(mask *fieldmaskpb.FieldMask) map[string]struct{} {
-	updateFields := make(map[string]struct{})
+	fieldMaskPaths := make(map[string]struct{})
 
 	for _, path := range mask.Paths {
 		pathParts := ConvertPathToCamel(path)
 		jsonPath := strings.Join(pathParts, ".")
-		updateFields[jsonPath] = struct{}{}
+		fieldMaskPaths[jsonPath] = struct{}{}
 	}
 
-	return updateFields
+	return fieldMaskPaths
+}
+
+func FieldMaskHasSubPath(fieldMaskPaths map[string]struct{}, path string) bool {
+	prefix := path + "."
+	for field := range fieldMaskPaths {
+		if strings.HasPrefix(field, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func FieldMaskHasPathOrSubPath(fieldMaskPaths map[string]struct{}, path string) bool {
+	if _, ok := fieldMaskPaths[path]; ok {
+		return true
+	}
+	return FieldMaskHasSubPath(fieldMaskPaths, path)
 }

--- a/common/util/proto.go
+++ b/common/util/proto.go
@@ -48,7 +48,7 @@ func ParseFieldMask(mask *fieldmaskpb.FieldMask) map[string]struct{} {
 }
 
 func FieldMaskHasSubPath(fieldMaskPaths map[string]struct{}, path string) bool {
-	prefix := path + "."
+	prefix := strings.TrimSuffix(path, ".") + "."
 	for field := range fieldMaskPaths {
 		if strings.HasPrefix(field, prefix) {
 			return true

--- a/common/util/proto_test.go
+++ b/common/util/proto_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConvertPathToCamel(t *testing.T) {
@@ -51,4 +52,30 @@ func TestConvertPathToCamel(t *testing.T) {
 			assert.Equal(t, tc.expectedOutput, actualOutput)
 		})
 	}
+}
+
+func TestFieldMaskHasSubPath(t *testing.T) {
+	fieldMaskPaths := map[string]struct{}{
+		"retryPolicy":                 {},
+		"retryPolicy.initialInterval": {},
+		"retryPolicy.maximumAttempts": {},
+		"retryPolicyExtra.field":      {},
+	}
+
+	require.True(t, FieldMaskHasSubPath(fieldMaskPaths, "retryPolicy"))
+	require.False(t, FieldMaskHasSubPath(map[string]struct{}{"retryPolicy": {}}, "retryPolicy"))
+	require.False(t, FieldMaskHasSubPath(fieldMaskPaths, "retryPolicy.initialInterval"))
+	require.False(t, FieldMaskHasSubPath(map[string]struct{}{"retryPolicyExtra.field": {}}, "retryPolicy"))
+}
+
+func TestFieldMaskHasPathOrSubPath(t *testing.T) {
+	fieldMaskPaths := map[string]struct{}{
+		"retryPolicy":          {},
+		"priority.fairnessKey": {},
+		"taskQueue.name":       {},
+	}
+
+	require.True(t, FieldMaskHasPathOrSubPath(fieldMaskPaths, "retryPolicy"))
+	require.True(t, FieldMaskHasPathOrSubPath(fieldMaskPaths, "priority"))
+	require.False(t, FieldMaskHasPathOrSubPath(fieldMaskPaths, "retryPolicy.initialInterval"))
 }

--- a/service/history/api/updateactivityoptions/api.go
+++ b/service/history/api/updateactivityoptions/api.go
@@ -20,6 +20,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/retrypolicy"
 	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/service/history/api"
 	"go.temporal.io/server/service/history/consts"
@@ -197,6 +198,12 @@ func processActivityOptionsUpdate(
 	// update activity options
 	if err := activityoptions.MergeActivityOptions(mergeInto, mergeFrom, updateFields); err != nil {
 		return nil, err
+	}
+
+	if util.FieldMaskHasSubPath(updateFields, "retryPolicy") {
+		if err := retrypolicy.Validate(mergeInto.GetRetryPolicy()); err != nil {
+			return nil, err
+		}
 	}
 
 	// validate the updated options

--- a/service/history/api/updateactivityoptions/api_test.go
+++ b/service/history/api/updateactivityoptions/api_test.go
@@ -284,6 +284,43 @@ func (s *activityOptionsSuite) Test_updateActivityOptionsAcceptance() {
 	s.NotNil(response)
 }
 
+func (s *activityOptionsSuite) Test_updateActivityOptionsRejectsInvalidMergedRetryPolicy() {
+	activityInfo := &persistencespb.ActivityInfo{
+		TaskQueue:               "task_queue_name",
+		ScheduleToCloseTimeout:  durationpb.New(30 * time.Second),
+		ScheduleToStartTimeout:  durationpb.New(20 * time.Second),
+		StartToCloseTimeout:     durationpb.New(10 * time.Second),
+		RetryBackoffCoefficient: 2,
+		RetryInitialInterval:    durationpb.New(10 * time.Second),
+		RetryMaximumInterval:    durationpb.New(30 * time.Second),
+		RetryMaximumAttempts:    5,
+		HasRetryPolicy:          true,
+		ActivityId:              "activity_id",
+		ActivityType:            &commonpb.ActivityType{Name: "activity_type"},
+	}
+
+	request := &historyservice.UpdateActivityOptionsRequest{
+		UpdateRequest: &workflowservice.UpdateActivityOptionsRequest{
+			ActivityOptions: &activitypb.ActivityOptions{
+				RetryPolicy: &commonpb.RetryPolicy{
+					InitialInterval: durationpb.New(60 * time.Second),
+				},
+			},
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{"retry_policy.initial_interval"},
+			},
+			Activity: &workflowservice.UpdateActivityOptionsRequest_Id{Id: "activity_id"},
+		},
+	}
+
+	s.mockMutableState.EXPECT().IsWorkflowExecutionRunning().Return(true)
+	s.mockMutableState.EXPECT().GetActivityByActivityID("activity_id").Return(activityInfo, true)
+
+	_, err := processActivityOptionsRequest(
+		s.validator, s.mockMutableState, request.GetUpdateRequest(), request.GetNamespaceId())
+	s.ErrorContains(err, "MaximumInterval cannot be less than InitialInterval")
+}
+
 func (s *activityOptionsSuite) Test_updateActivityOptions_RestoreDefaultFail() {
 	updateMask := &fieldmaskpb.FieldMask{
 		Paths: []string{

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -8549,6 +8549,99 @@ func (s *standaloneActivityTestSuite) TestUpdateActivityExecutionOptions() {
 			pollOutcome.GetOutcome().GetFailure().GetTimeoutFailureInfo().GetTimeoutType(),
 		)
 	})
+
+	t.Run("RejectInvalidMergedRetryPolicy", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		// Start with a valid retry policy. The subfield updates below are validated against
+		// the merged result, not just the incoming delta.
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        &commonpb.ActivityType{Name: "test-activity"},
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout: durationpb.New(30 * time.Minute),
+			RetryPolicy: &commonpb.RetryPolicy{
+				InitialInterval: durationpb.New(10 * time.Second),
+				MaximumAttempts: 5,
+			},
+		})
+		require.NoError(t, err)
+
+		testCases := []struct {
+			name        string
+			options     *activitypb.ActivityOptions
+			mask        []string
+			expectedErr string
+		}{
+			{
+				// 1s is a valid duration on its own; it is invalid only because the merged
+				// policy would have MaximumInterval (1s) < the existing InitialInterval (10s).
+				name:        "MaximumIntervalBelowInitialInterval",
+				options:     &activitypb.ActivityOptions{RetryPolicy: &commonpb.RetryPolicy{MaximumInterval: durationpb.New(1 * time.Second)}},
+				mask:        []string{"retry_policy.maximum_interval"},
+				expectedErr: "MaximumInterval cannot be less than InitialInterval",
+			},
+			{
+				name:        "BackoffCoefficientBelowOne",
+				options:     &activitypb.ActivityOptions{RetryPolicy: &commonpb.RetryPolicy{BackoffCoefficient: 0.5}},
+				mask:        []string{"retry_policy.backoff_coefficient"},
+				expectedErr: "BackoffCoefficient cannot be less than 1",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := env.FrontendClient().UpdateActivityExecutionOptions(ctx, &workflowservice.UpdateActivityExecutionOptionsRequest{
+					Namespace:       env.Namespace().String(),
+					ActivityId:      activityID,
+					RunId:           startResp.RunId,
+					ActivityOptions: tc.options,
+					UpdateMask:      &fieldmaskpb.FieldMask{Paths: tc.mask},
+				})
+				var invalidArgErr *serviceerror.InvalidArgument
+				require.ErrorAs(t, err, &invalidArgErr)
+				require.Contains(t, invalidArgErr.Message, tc.expectedErr)
+			})
+		}
+	})
+
+	t.Run("RejectNilRetryPolicyReplacement", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        &commonpb.ActivityType{Name: "test-activity"},
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout: durationpb.New(30 * time.Minute),
+			RetryPolicy: &commonpb.RetryPolicy{
+				InitialInterval: durationpb.New(10 * time.Second),
+				MaximumAttempts: 5,
+			},
+		})
+		require.NoError(t, err)
+
+		// A full retry_policy replacement (top-level mask path) with no policy provided must be rejected.
+		_, err = env.FrontendClient().UpdateActivityExecutionOptions(ctx, &workflowservice.UpdateActivityExecutionOptionsRequest{
+			Namespace:       env.Namespace().String(),
+			ActivityId:      activityID,
+			RunId:           startResp.RunId,
+			ActivityOptions: &activitypb.ActivityOptions{},
+			UpdateMask:      &fieldmaskpb.FieldMask{Paths: []string{"retry_policy"}},
+		})
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Contains(t, invalidArgErr.Message, "RetryPolicy is not provided")
+	})
 }
 
 // Verifies update-options invalidates a legacy ScheduleToClose timer whose stamp is 0.


### PR DESCRIPTION
## What changed?
Fixed SAA update-options handling to clone proto option state before merging updates, reject nil top-level retry policy replacements, and validate retry policy subfield updates after merging with existing state. Added shared field-mask helpers.

## Why?
A subfield update could previously mutate aliased original options or produce an invalid merged retry policy, such as initial_interval > maximum_interval. A top-level retry_policy update with no policy could also slip through validation as nil, leading to inconsistent retry behavior or nil-deref risk.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [ ] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)
