### PR TITLE
Fix SAA reset attempt dispatch time reporting

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -320,9 +320,11 @@ func (a *Activity) GenerateRecordActivityTaskStartedResponse(
 	}, nil
 }
 
-// dispatchTimeForAttempt returns the dispatch time of the given attempt: the activity's schedule
-// time plus start delay for the first attempt, or dispatchTimeForRetry on retries.
+// dispatchTimeForAttempt returns the dispatch time of the given attempt.
 func (a *Activity) dispatchTimeForAttempt(attempt *activitypb.ActivityAttemptState) *timestamppb.Timestamp {
+	if dispatchTime := attempt.GetDispatchTime(); dispatchTime != nil {
+		return dispatchTime
+	}
 	if attempt.GetCount() == 1 {
 		return timestamppb.New(a.firstDispatchTime())
 	}
@@ -975,6 +977,7 @@ func (a *Activity) unpause(
 ) {
 	attempt := a.LastAttempt.Get(ctx)
 	dispatchTime := a.unpauseDispatchTime(ctx, event)
+	attempt.DispatchTime = timestamppb.New(dispatchTime)
 
 	if event.req.GetResetAttempts() {
 		attempt.Count = 1
@@ -1042,6 +1045,7 @@ func (a *Activity) reset(ctx chasm.MutableContext, event resetEvent) {
 		a.clearHeartbeat(ctx)
 	}
 	dispatchTime := a.dispatchTimeRespectingStartDelay(event.resetTime)
+	attempt.DispatchTime = timestamppb.New(dispatchTime)
 	if timeout := a.GetScheduleToStartTimeout().AsDuration(); timeout > 0 {
 		ctx.AddTask(
 			a,
@@ -1157,6 +1161,7 @@ func (a *Activity) resetKeepPaused(
 	attempt.Count = 1
 	attempt.Stamp++
 	attempt.CurrentRetryInterval = nil
+	attempt.DispatchTime = nil
 	if frontendReq.GetResetHeartbeat() {
 		a.clearHeartbeat(ctx)
 	}
@@ -1323,6 +1328,7 @@ func (a *Activity) reissueDispatchAndScheduleToStart(ctx chasm.MutableContext, a
 	} else {
 		dispatchTime = a.dispatchTimeRespectingStartDelay(ctx.Now(a))
 	}
+	attempt.DispatchTime = timestamppb.New(dispatchTime)
 	ctx.AddTask(
 		a,
 		chasm.TaskAttributes{ScheduledTime: dispatchTime},

--- a/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
@@ -642,7 +642,9 @@ type ActivityAttemptState struct {
 	SdkName string `protobuf:"bytes,10,opt,name=sdk_name,json=sdkName,proto3" json:"sdk_name,omitempty"`
 	// The version of the SDK of the worker that most recently picked up an attempt of this activity (from the gRPC
 	// `client-version` header on PollActivityTaskQueue). Same overwrite semantics as sdk_name.
-	SdkVersion    string `protobuf:"bytes,11,opt,name=sdk_version,json=sdkVersion,proto3" json:"sdk_version,omitempty"`
+	SdkVersion string `protobuf:"bytes,11,opt,name=sdk_version,json=sdkVersion,proto3" json:"sdk_version,omitempty"`
+	// Time the current activity attempt is scheduled to dispatch.
+	DispatchTime  *timestamppb.Timestamp `protobuf:"bytes,12,opt,name=dispatch_time,json=dispatchTime,proto3" json:"dispatch_time,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -752,6 +754,13 @@ func (x *ActivityAttemptState) GetSdkVersion() string {
 		return x.SdkVersion
 	}
 	return ""
+}
+
+func (x *ActivityAttemptState) GetDispatchTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.DispatchTime
+	}
+	return nil
 }
 
 type ActivityHeartbeatState struct {
@@ -1154,7 +1163,7 @@ const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawD
 	"\bidentity\x18\x02 \x01(\tR\bidentity\x12\x16\n" +
 	"\x06reason\x18\x03 \x01(\tR\x06reason\x12\x1d\n" +
 	"\n" +
-	"request_id\x18\x04 \x01(\tR\trequestId\"\xa4\x06\n" +
+	"request_id\x18\x04 \x01(\tR\trequestId\"\xe5\x06\n" +
 	"\x14ActivityAttemptState\x12\x14\n" +
 	"\x05count\x18\x01 \x01(\x05R\x05count\x12O\n" +
 	"\x16current_retry_interval\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\x14currentRetryInterval\x12=\n" +
@@ -1168,7 +1177,8 @@ const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawD
 	"\bsdk_name\x18\n" +
 	" \x01(\tR\asdkName\x12\x1f\n" +
 	"\vsdk_version\x18\v \x01(\tR\n" +
-	"sdkVersion\x1a\x80\x01\n" +
+	"sdkVersion\x12?\n" +
+	"\rdispatch_time\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\fdispatchTime\x1a\x80\x01\n" +
 	"\x12LastFailureDetails\x12.\n" +
 	"\x04time\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x04time\x12:\n" +
 	"\afailure\x18\x02 \x01(\v2 .temporal.api.failure.v1.FailureR\afailure\"\xc9\x01\n" +
@@ -1270,22 +1280,23 @@ var file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_depIdx
 	16, // 20: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.complete_time:type_name -> google.protobuf.Timestamp
 	9,  // 21: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.last_failure_details:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.LastFailureDetails
 	19, // 22: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.last_deployment_version:type_name -> temporal.api.deployment.v1.WorkerDeploymentVersion
-	20, // 23: temporal.server.chasm.lib.activity.proto.v1.ActivityHeartbeatState.details:type_name -> temporal.api.common.v1.Payloads
-	16, // 24: temporal.server.chasm.lib.activity.proto.v1.ActivityHeartbeatState.recorded_time:type_name -> google.protobuf.Timestamp
-	20, // 25: temporal.server.chasm.lib.activity.proto.v1.ActivityRequestData.input:type_name -> temporal.api.common.v1.Payloads
-	21, // 26: temporal.server.chasm.lib.activity.proto.v1.ActivityRequestData.header:type_name -> temporal.api.common.v1.Header
-	22, // 27: temporal.server.chasm.lib.activity.proto.v1.ActivityRequestData.user_metadata:type_name -> temporal.api.sdk.v1.UserMetadata
-	10, // 28: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.successful:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Successful
-	11, // 29: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.failed:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Failed
-	16, // 30: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.LastFailureDetails.time:type_name -> google.protobuf.Timestamp
-	23, // 31: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.LastFailureDetails.failure:type_name -> temporal.api.failure.v1.Failure
-	20, // 32: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Successful.output:type_name -> temporal.api.common.v1.Payloads
-	23, // 33: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Failed.failure:type_name -> temporal.api.failure.v1.Failure
-	34, // [34:34] is the sub-list for method output_type
-	34, // [34:34] is the sub-list for method input_type
-	34, // [34:34] is the sub-list for extension type_name
-	34, // [34:34] is the sub-list for extension extendee
-	0,  // [0:34] is the sub-list for field type_name
+	16, // 23: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.dispatch_time:type_name -> google.protobuf.Timestamp
+	20, // 24: temporal.server.chasm.lib.activity.proto.v1.ActivityHeartbeatState.details:type_name -> temporal.api.common.v1.Payloads
+	16, // 25: temporal.server.chasm.lib.activity.proto.v1.ActivityHeartbeatState.recorded_time:type_name -> google.protobuf.Timestamp
+	20, // 26: temporal.server.chasm.lib.activity.proto.v1.ActivityRequestData.input:type_name -> temporal.api.common.v1.Payloads
+	21, // 27: temporal.server.chasm.lib.activity.proto.v1.ActivityRequestData.header:type_name -> temporal.api.common.v1.Header
+	22, // 28: temporal.server.chasm.lib.activity.proto.v1.ActivityRequestData.user_metadata:type_name -> temporal.api.sdk.v1.UserMetadata
+	10, // 29: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.successful:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Successful
+	11, // 30: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.failed:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Failed
+	16, // 31: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.LastFailureDetails.time:type_name -> google.protobuf.Timestamp
+	23, // 32: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.LastFailureDetails.failure:type_name -> temporal.api.failure.v1.Failure
+	20, // 33: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Successful.output:type_name -> temporal.api.common.v1.Payloads
+	23, // 34: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Failed.failure:type_name -> temporal.api.failure.v1.Failure
+	35, // [35:35] is the sub-list for method output_type
+	35, // [35:35] is the sub-list for method input_type
+	35, // [35:35] is the sub-list for extension type_name
+	35, // [35:35] is the sub-list for extension extendee
+	0,  // [0:35] is the sub-list for field type_name
 }
 
 func init() { file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_init() }

--- a/chasm/lib/activity/proto/v1/activity_state.proto
+++ b/chasm/lib/activity/proto/v1/activity_state.proto
@@ -230,6 +230,9 @@ message ActivityAttemptState {
   // The version of the SDK of the worker that most recently picked up an attempt of this activity (from the gRPC
   // `client-version` header on PollActivityTaskQueue). Same overwrite semantics as sdk_name.
   string sdk_version = 11;
+
+  // Time the current activity attempt is scheduled to dispatch.
+  google.protobuf.Timestamp dispatch_time = 12;
 }
 
 message ActivityHeartbeatState {

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -49,6 +49,7 @@ var TransitionScheduled = chasm.NewTransition(
 		// Start delay defers the dispatch and extends ScheduleToClose and ScheduleToStart timeouts. StartToClose and
 		// Heartbeat timeouts are unaffected as they only start when a worker picks up the task.
 		dispatchTime := a.firstDispatchTime()
+		attempt.DispatchTime = timestamppb.New(dispatchTime)
 
 		if timeout := a.GetScheduleToStartTimeout().AsDuration(); timeout > 0 {
 			ctx.AddTask(
@@ -106,6 +107,7 @@ var TransitionRescheduled = chasm.NewTransition(
 
 		attempt := a.LastAttempt.Get(ctx)
 		retryScheduledTime := dispatchTimeForRetry(attempt).AsTime()
+		attempt.DispatchTime = timestamppb.New(retryScheduledTime)
 
 		if timeout := a.GetScheduleToStartTimeout().AsDuration(); timeout > 0 {
 			ctx.AddTask(
@@ -553,6 +555,7 @@ var TransitionResetAttemptFailedToPaused = chasm.NewTransition(
 		}
 		// Reset discards the retry backoff
 		attempt.CurrentRetryInterval = nil
+		attempt.DispatchTime = nil
 		return nil
 	},
 )
@@ -587,6 +590,7 @@ var TransitionResetAttemptFailedToScheduled = chasm.NewTransition(
 		attempt.CurrentRetryInterval = nil
 
 		dispatchTime := a.dispatchTimeRespectingStartDelay(currentTime)
+		attempt.DispatchTime = timestamppb.New(dispatchTime)
 		if timeout := a.GetScheduleToStartTimeout().AsDuration(); timeout > 0 {
 			ctx.AddTask(
 				a,

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -7419,6 +7419,78 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 			"activity dispatched before start delay end; Reset did not honor the remaining start delay")
 	})
 
+	s.Run("ResetAfterFirstStart_ReportsResetDispatchTime", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+		startDelay := 1 * time.Second
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
+			Input:               defaultInput,
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			RetryPolicy:         defaultRetryPolicy,
+			StartDelay:          durationpb.New(startDelay),
+		})
+		require.NoError(t, err)
+
+		pollResp1, err := env.pollActivityTaskQueue(s.Context(), taskQueue)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, pollResp1.GetAttempt())
+		firstAttemptDispatchTime := pollResp1.GetCurrentAttemptScheduledTime().AsTime()
+
+		_, err = env.FrontendClient().RespondActivityTaskFailed(s.Context(), &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
+			TaskToken: pollResp1.GetTaskToken(),
+			Failure: &failurepb.Failure{
+				Message: "retryable failure",
+				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+					ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+						NonRetryable:   false,
+						NextRetryDelay: durationpb.New(time.Hour),
+					},
+				},
+			},
+			Identity: defaultIdentity,
+		})
+		require.NoError(t, err)
+
+		descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.GetRunId(),
+		})
+		require.NoError(t, err)
+		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, descResp.GetInfo().GetRunState())
+
+		// After the first worker pickup, reset rewinds the attempt count to 1 but must report
+		// the reset attempt's dispatch time, not the original first dispatch time.
+		resetTime := time.Now()
+		_, err = env.FrontendClient().ResetActivityExecution(s.Context(), &workflowservice.ResetActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.GetRunId(),
+		})
+		require.NoError(t, err)
+
+		pollCtx, cancel := context.WithTimeout(s.Context(), 10*time.Second)
+		defer cancel()
+		pollResp2, err := env.pollActivityTaskQueue(pollCtx, taskQueue)
+		require.NoError(t, err)
+		pollTime := time.Now()
+		require.EqualValues(t, 1, pollResp2.GetAttempt())
+		resetAttemptDispatchTime := pollResp2.GetCurrentAttemptScheduledTime().AsTime()
+		require.NotEqual(t, firstAttemptDispatchTime, resetAttemptDispatchTime)
+		require.GreaterOrEqual(t, resetAttemptDispatchTime.Add(timerSafetyMargin).UnixNano(), resetTime.UnixNano())
+		require.LessOrEqual(t, resetAttemptDispatchTime.UnixNano(), pollTime.Add(timerSafetyMargin).UnixNano())
+	})
+
 	// If the delay window has already elapsed by the time the activity is unpaused, the activity
 	// should dispatch immediately (no leftover delay to honor).
 	s.Run("PauseDuringDelay_UnpauseAfterDelay_DispatchesImmediately", func(s *standaloneActivityTestSuite) {


### PR DESCRIPTION
## What changed?
Persist the current SAA attempt dispatch time in `ActivityAttemptState.dispatch_time` and use it when reporting `CurrentAttemptScheduledTime`.

## Why?
Reset rewinds the attempt count to `1` and re-dispatches the activity. Deriving dispatch time from `attempt == 1` incorrectly reports the original first dispatch time instead of the reset attempt’s dispatch time.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [X] added new functional test(s)
