### PR TITLE
docs: fix typo 'supress' -> 'suppress' in visibility manager comment

### DIFF
--- a/common/persistence/visibility/visibility_manager_impl.go
+++ b/common/persistence/visibility/visibility_manager_impl.go
@@ -379,7 +379,7 @@ func (p *visibilityManagerImpl) newInternalVisibilityRequestBase(
 	var searchAttrs *commonpb.SearchAttributes
 	if len(request.SearchAttributes.GetIndexedFields()) > 0 {
 		// Remove any system search attribute from the map.
-		// This is necessary because the validation can supress errors when trying
+		// This is necessary because the validation can suppress errors when trying
 		// to set a value on a system search attribute.
 		searchAttrs = &commonpb.SearchAttributes{
 			IndexedFields: make(map[string]*commonpb.Payload),


### PR DESCRIPTION
## What changed?
Fixed a typo in a code comment in `common/persistence/visibility/visibility_manager_impl.go`: "supress" -> "suppress".

## Why?
Corrects a misspelling so the comment reads clearly. No code or behavior change.

## How did you test it?
Documentation-only change to a comment; verified with `gofmt`. No runtime impact.

## Potential risks
None. Comment-only change with no effect on behavior.
