### PR TITLE
Fix workflow reset to original execution when current execution is deleted

### DIFF
--- a/service/history/api/resetworkflow/api.go
+++ b/service/history/api/resetworkflow/api.go
@@ -2,6 +2,7 @@ package resetworkflow
 
 import (
 	"context"
+	"errors"
 
 	"github.com/google/uuid"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -89,6 +90,7 @@ func Invoke(
 		request.WorkflowExecution.GetWorkflowId(),
 		locks.PriorityHigh,
 	)
+	currentExecutionMissing, err := shouldTolerateMissingCurrentExecution(err, baseRunID)
 	if err != nil {
 		return nil, err
 	}
@@ -97,9 +99,12 @@ func Invoke(
 	}
 
 	var currentWorkflowLease api.WorkflowLease
-	if currentRunID == baseRunID {
+	switch {
+	case currentExecutionMissing:
+		// no current run to lease; leave the lease nil.
+	case currentRunID == baseRunID:
 		currentWorkflowLease = baseWorkflowLease
-	} else {
+	default:
 		currentWorkflowLease, err = workflowConsistencyChecker.GetWorkflowLease(
 			ctx,
 			nil,
@@ -117,7 +122,8 @@ func Invoke(
 	}
 
 	// dedup by requestID
-	if currentWorkflowLease.GetMutableState().GetExecutionState().CreateRequestId == request.GetRequestId() {
+	if currentWorkflowLease != nil &&
+		currentWorkflowLease.GetMutableState().GetExecutionState().CreateRequestId == request.GetRequestId() {
 		shardContext.GetLogger().Info("Duplicated reset request",
 			tag.WorkflowID(workflowID),
 			tag.WorkflowRunID(currentRunID),
@@ -160,6 +166,16 @@ func Invoke(
 		),
 	).Record(1)
 
+	var currentWorkflow ndc.Workflow
+	if currentWorkflowLease != nil {
+		currentWorkflow = ndc.NewWorkflow(
+			shardContext.GetClusterMetadata(),
+			currentWorkflowLease.GetContext(),
+			currentWorkflowLease.GetMutableState(),
+			currentWorkflowLease.GetReleaseFn(),
+		)
+	}
+
 	allowResetWithPendingChildren := shardContext.GetConfig().AllowResetWithPendingChildren(namespaceEntry.Name().String())
 	if err := ndc.NewWorkflowResetter(
 		shardContext,
@@ -176,12 +192,7 @@ func Invoke(
 		baseNextEventID,
 		resetRunID,
 		baseWorkflow,
-		ndc.NewWorkflow(
-			shardContext.GetClusterMetadata(),
-			currentWorkflowLease.GetContext(),
-			currentWorkflowLease.GetMutableState(),
-			currentWorkflowLease.GetReleaseFn(),
-		),
+		currentWorkflow,
 		request.GetReason(),
 		nil,
 		GetResetReapplyExcludeTypes(request.GetResetReapplyExcludeTypes(), request.GetResetReapplyType()),
@@ -202,6 +213,21 @@ func Invoke(
 	return &historyservice.ResetWorkflowExecutionResponse{
 		RunId: resetRunID,
 	}, nil
+}
+
+// shouldTolerateMissingCurrentExecution reports whether a failure to resolve the current execution
+// should be tolerated (reset proceeds with no current run). A NotFound is tolerated only when an
+// explicit base runId was provided; without one there is nothing to reset from. Any other error is
+// returned unchanged.
+func shouldTolerateMissingCurrentExecution(currentErr error, baseRunID string) (currentExecutionMissing bool, err error) {
+	if currentErr == nil {
+		return false, nil
+	}
+	var notFound *serviceerror.NotFound
+	if errors.As(currentErr, &notFound) && baseRunID != "" {
+		return true, nil
+	}
+	return false, currentErr
 }
 
 // GetResetReapplyExcludeTypes computes the set of requested exclude types. It

--- a/service/history/api/resetworkflow/api_test.go
+++ b/service/history/api/resetworkflow/api_test.go
@@ -23,25 +23,25 @@ func (s *resetWorkflowSuite) TestShouldTolerateMissingCurrentExecution() {
 	// No error resolving the current execution => not missing, no error.
 	missing, err := shouldTolerateMissingCurrentExecution(nil, "base-run-id")
 	s.False(missing)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	notFound := serviceerror.NewNotFound("current execution not found")
 
 	// NotFound with an explicit base runId => tolerate (proceed with no current), no error.
 	missing, err = shouldTolerateMissingCurrentExecution(notFound, "base-run-id")
 	s.True(missing)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	// NotFound with an empty base runId => not tolerated (nothing to reset from), error returned.
 	missing, err = shouldTolerateMissingCurrentExecution(notFound, "")
 	s.False(missing)
-	s.ErrorIs(err, notFound)
+	s.Require().ErrorIs(err, notFound)
 
 	// A non-NotFound error => not tolerated regardless of base runId, error returned unchanged.
 	other := serviceerror.NewUnavailable("persistence unavailable")
 	missing, err = shouldTolerateMissingCurrentExecution(other, "base-run-id")
 	s.False(missing)
-	s.ErrorIs(err, other)
+	s.Require().ErrorIs(err, other)
 }
 
 func (s *resetWorkflowSuite) TestGetResetReapplyExcludeTypes() {

--- a/service/history/api/resetworkflow/api_test.go
+++ b/service/history/api/resetworkflow/api_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
 )
 
 type (
@@ -16,6 +17,31 @@ type (
 func TestResetWorkflowSuite(t *testing.T) {
 	s := new(resetWorkflowSuite)
 	suite.Run(t, s)
+}
+
+func (s *resetWorkflowSuite) TestShouldTolerateMissingCurrentExecution() {
+	// No error resolving the current execution => not missing, no error.
+	missing, err := shouldTolerateMissingCurrentExecution(nil, "base-run-id")
+	s.False(missing)
+	s.NoError(err)
+
+	notFound := serviceerror.NewNotFound("current execution not found")
+
+	// NotFound with an explicit base runId => tolerate (proceed with no current), no error.
+	missing, err = shouldTolerateMissingCurrentExecution(notFound, "base-run-id")
+	s.True(missing)
+	s.NoError(err)
+
+	// NotFound with an empty base runId => not tolerated (nothing to reset from), error returned.
+	missing, err = shouldTolerateMissingCurrentExecution(notFound, "")
+	s.False(missing)
+	s.ErrorIs(err, notFound)
+
+	// A non-NotFound error => not tolerated regardless of base runId, error returned unchanged.
+	other := serviceerror.NewUnavailable("persistence unavailable")
+	missing, err = shouldTolerateMissingCurrentExecution(other, "base-run-id")
+	s.False(missing)
+	s.ErrorIs(err, other)
 }
 
 func (s *resetWorkflowSuite) TestGetResetReapplyExcludeTypes() {

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -376,10 +376,33 @@ func (r *workflowResetterImpl) persistToDB(
 
 	currentExecutionMissing := currentWorkflow == nil
 	if currentExecutionMissing {
-		// Create the reset run as the new current execution. CreateWorkflowModeBrandNew succeeds
-		// precisely because there is no current_executions row to conflict with.
-		// NOTE: the base run is not persisted in this branch, so the base->reset ResetRunID link
-		// set by UpdateResetRunID is not saved here.
+		// There is no current_executions row (the current run was deleted), so the base->reset link
+		// and the new current run cannot be committed atomically: re-establishing a missing current
+		// requires a brand-new insert, while the base run needs a bypass-current update, and no
+		// single Transaction method does both. Write base-first so retries are safe: if the create
+		// fails, a retry rewrites the base link and the brand-new insert still succeeds. Creating
+		// first would leave the reset run as current and permanently conflict with the create.
+		baseWorkflowMutation, baseWorkflowEventsSeq, err := baseWorkflow.GetMutableState().CloseTransactionAsMutation(
+			ctx,
+			historyi.TransactionPolicyActive,
+		)
+		if err != nil {
+			return err
+		}
+		if _, _, err := r.transaction.UpdateWorkflowExecution(
+			ctx,
+			persistence.UpdateWorkflowModeBypassCurrent,
+			chasm.WorkflowArchetypeID,
+			baseWorkflow.GetMutableState().GetCurrentVersion(),
+			baseWorkflowMutation,
+			baseWorkflowEventsSeq,
+			nil,
+			nil,
+			nil,
+			baseWorkflow.GetMutableState().IsWorkflow(),
+		); err != nil {
+			return err
+		}
 		if _, err := r.transaction.CreateWorkflowExecution(
 			ctx,
 			persistence.CreateWorkflowModeBrandNew,

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -141,18 +141,20 @@ func (r *workflowResetterImpl) ResetWorkflow(
 	// user-facing reset API path; all other callers pass a concrete current run.
 	currentExecutionMissing := currentWorkflow == nil
 	if currentExecutionMissing {
-		// Nothing to terminate. Reapply only the base run's own post-reset events; do NOT follow
-		// the continue-as-new chain, since the runs it points to may have been deleted.
+		// No current run to terminate. Reapply along the continue-as-new chain as far as it survives.
 		reapplyEventsFn = func(ctx context.Context, resetMutableState historyi.MutableState) error {
-			_, err := r.reapplyEventsFromBranch(
+			_, err := r.reapplyContinueAsNewWorkflowEvents(
 				ctx,
 				resetMutableState,
+				nil,
+				namespaceID,
+				workflowID,
+				baseRunID,
+				baseBranchToken,
 				baseRebuildLastEventID+1,
 				baseNextEventID,
-				baseBranchToken,
 				resetReapplyExcludeTypes,
 				allowResetWithPendingChildren,
-				make(map[string]*persistencespb.ResetChildInfo),
 			)
 			return err
 		}
@@ -760,7 +762,8 @@ func (r *workflowResetterImpl) reapplyContinueAsNewWorkflowEvents(
 		var wfCtx historyi.WorkflowContext
 		var err error
 
-		if runID == currentWorkflow.GetMutableState().GetWorkflowKey().RunID {
+		// currentWorkflow is nil when resetting a workflow with no current run; load every run from the cache.
+		if currentWorkflow != nil && runID == currentWorkflow.GetMutableState().GetWorkflowKey().RunID {
 			wfCtx = currentWorkflow.GetContext()
 		} else {
 			var release historyi.ReleaseWorkflowContextFunc
@@ -796,11 +799,17 @@ func (r *workflowResetterImpl) reapplyContinueAsNewWorkflowEvents(
 
 	// Second, for remaining continue as new workflow, reapply eligible events
 	for len(nextRunID) != 0 {
-		lastVisitedRunID = nextRunID
 		nextWorkflowNextEventID, nextWorkflowBranchToken, err := getNextEventIDBranchToken(nextRunID)
 		if err != nil {
+			// A deleted run truncates the chain; other errors must fail the reset so a retry
+			// can reapply the full surviving chain, since reset is one-shot.
+			var notFound *serviceerror.NotFound
+			if errors.As(err, &notFound) {
+				break
+			}
 			return "", err
 		}
+		lastVisitedRunID = nextRunID
 
 		nextRunID, err = r.reapplyEventsFromBranch(
 			ctx,

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -136,8 +136,27 @@ func (r *workflowResetterImpl) ResetWorkflow(
 	var currentWorkflowMutation *persistence.WorkflowMutation
 	var currentWorkflowEventsSeq []*persistence.WorkflowEvents
 	var reapplyEventsFn workflowResetReapplyEventsFn
-	currentMutableState := currentWorkflow.GetMutableState()
-	if currentMutableState.IsWorkflowExecutionRunning() {
+	// currentWorkflow is nil only for a reset by explicit runId whose workflow has no current
+	// execution (the current run was deleted while older runs survive). This is exclusive to the
+	// user-facing reset API path; all other callers pass a concrete current run.
+	currentExecutionMissing := currentWorkflow == nil
+	if currentExecutionMissing {
+		// Nothing to terminate. Reapply only the base run's own post-reset events; do NOT follow
+		// the continue-as-new chain, since the runs it points to may have been deleted.
+		reapplyEventsFn = func(ctx context.Context, resetMutableState historyi.MutableState) error {
+			_, err := r.reapplyEventsFromBranch(
+				ctx,
+				resetMutableState,
+				baseRebuildLastEventID+1,
+				baseNextEventID,
+				baseBranchToken,
+				resetReapplyExcludeTypes,
+				allowResetWithPendingChildren,
+				make(map[string]*persistencespb.ResetChildInfo),
+			)
+			return err
+		}
+	} else if currentMutableState := currentWorkflow.GetMutableState(); currentMutableState.IsWorkflowExecutionRunning() {
 		currentMutableState.GetExecutionInfo().WorkflowWasReset = true
 		if err := r.terminateWorkflow(
 			currentMutableState,
@@ -255,7 +274,9 @@ func (r *workflowResetterImpl) ResetWorkflow(
 		return err
 	}
 
-	currentWorkflow.GetContext().UpdateRegistry(ctx).Abort(update.AbortReasonWorkflowCompleted)
+	if !currentExecutionMissing {
+		currentWorkflow.GetContext().UpdateRegistry(ctx).Abort(update.AbortReasonWorkflowCompleted)
+	}
 
 	return nil
 }
@@ -345,8 +366,6 @@ func (r *workflowResetterImpl) persistToDB(
 	currentWorkflowEventsSeq []*persistence.WorkflowEvents,
 	resetWorkflow Workflow,
 ) error {
-	currentRunID := currentWorkflow.GetMutableState().GetExecutionState().GetRunId()
-	baseRunID := baseWorkflow.GetMutableState().GetExecutionState().GetRunId()
 	resetWorkflowSnapshot, resetWorkflowEventsSeq, err := resetWorkflow.GetMutableState().CloseTransactionAsSnapshot(
 		ctx,
 		historyi.TransactionPolicyActive,
@@ -354,6 +373,29 @@ func (r *workflowResetterImpl) persistToDB(
 	if err != nil {
 		return err
 	}
+
+	currentExecutionMissing := currentWorkflow == nil
+	if currentExecutionMissing {
+		// Create the reset run as the new current execution. CreateWorkflowModeBrandNew succeeds
+		// precisely because there is no current_executions row to conflict with.
+		// NOTE: the base run is not persisted in this branch, so the base->reset ResetRunID link
+		// set by UpdateResetRunID is not saved here.
+		if _, err := r.transaction.CreateWorkflowExecution(
+			ctx,
+			persistence.CreateWorkflowModeBrandNew,
+			chasm.WorkflowArchetypeID,
+			resetWorkflow.GetMutableState().GetCurrentVersion(),
+			resetWorkflowSnapshot,
+			resetWorkflowEventsSeq,
+			resetWorkflow.GetMutableState().IsWorkflow(),
+		); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	currentRunID := currentWorkflow.GetMutableState().GetExecutionState().GetRunId()
+	baseRunID := baseWorkflow.GetMutableState().GetExecutionState().GetRunId()
 
 	if currentRunID == baseRunID {
 		// There are just 2 runs to update - base & new run.

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -282,6 +282,61 @@ func (s *workflowResetterSuite) TestPersistToDB_CurrentNotTerminated() {
 	s.False(resetReleaseCalled)
 }
 
+func (s *workflowResetterSuite) TestPersistToDB_CurrentExecutionMissing() {
+	// No current execution exists (e.g. the current run was deleted while older runs survive).
+	// persistToDB must create the reset run as the new current via CreateWorkflowModeBrandNew,
+	// and must not touch the (nil) current or the base run.
+	baseWorkflow := NewMockWorkflow(s.controller) // must not be used in this path
+
+	resetWorkflow := NewMockWorkflow(s.controller)
+	resetReleaseCalled := false
+	resetContext := historyi.NewMockWorkflowContext(s.controller)
+	resetMutableState := historyi.NewMockMutableState(s.controller)
+	var resetReleaseFn historyi.ReleaseWorkflowContextFunc = func(error) { resetReleaseCalled = true }
+	resetWorkflow.EXPECT().GetContext().Return(resetContext).AnyTimes()
+	resetWorkflow.EXPECT().GetMutableState().Return(resetMutableState).AnyTimes()
+	resetWorkflow.EXPECT().GetReleaseFn().Return(resetReleaseFn).AnyTimes()
+
+	resetMutableState.EXPECT().GetCurrentVersion().Return(int64(0)).AnyTimes()
+	resetMutableState.EXPECT().IsWorkflow().Return(true).AnyTimes()
+
+	resetSnapshot := &persistence.WorkflowSnapshot{
+		ExecutionInfo: &persistencespb.WorkflowExecutionInfo{},
+	}
+	resetEventsSeq := []*persistence.WorkflowEvents{{
+		NamespaceID: s.namespaceID.String(),
+		WorkflowID:  s.workflowID,
+		RunID:       s.resetRunID,
+		BranchToken: []byte("some random reset branch token"),
+		Events: []*historypb.HistoryEvent{{
+			EventId: 123,
+		}},
+	}}
+	resetMutableState.EXPECT().CloseTransactionAsSnapshot(
+		context.Background(),
+		historyi.TransactionPolicyActive,
+	).Return(resetSnapshot, resetEventsSeq, nil)
+
+	resetNewEventsSize := int64(4321)
+	// The key assertion: reset run is created as the new current with BrandNew mode,
+	// not an Update/ConflictResolve mode (both of which assume an existing current row).
+	s.mockTransaction.EXPECT().CreateWorkflowExecution(
+		gomock.Any(),
+		persistence.CreateWorkflowModeBrandNew,
+		chasm.WorkflowArchetypeID,
+		int64(0),
+		resetSnapshot,
+		resetEventsSeq,
+		true, // isWorkflow
+	).Return(resetNewEventsSize, nil)
+
+	// nil current workflow, and nil current mutation/events.
+	err := s.workflowResetter.persistToDB(context.Background(), baseWorkflow, nil, nil, nil, resetWorkflow)
+	s.NoError(err)
+	// persistToDB function is not charged of releasing locks
+	s.False(resetReleaseCalled)
+}
+
 func (s *workflowResetterSuite) TestReplayResetWorkflow() {
 	ctx := context.Background()
 	baseBranchToken := []byte("some random base branch token")

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -14,6 +14,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
 	historypb "go.temporal.io/api/history/v1"
+	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	updatepb "go.temporal.io/api/update/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
@@ -848,6 +849,154 @@ func (s *workflowResetterSuite) TestReapplyContinueAsNewWorkflowEvents_WithConti
 	)
 	s.NoError(err)
 	s.Equal(newRunID, lastVisitedRunID)
+}
+
+// cacheWorkflowContext registers a mock context for runID so getNextEventIDBranchToken loads it from the cache.
+func (s *workflowResetterSuite) cacheWorkflowContext(runID string, ctx historyi.WorkflowContext) {
+	key := wcache.Key{
+		WorkflowKey: definition.NewWorkflowKey(s.namespaceID.String(), s.workflowID, runID),
+		ArchetypeID: chasm.WorkflowArchetypeID,
+		ShardUUID:   s.mockShard.GetOwner(),
+	}
+	s.NoError(wcache.PutContextIfNotExist(s.workflowResetter.workflowCache, key, ctx))
+}
+
+// TestReapplyContinueAsNewWorkflowEvents_MissingCurrent_ChainTruncatedOnDeletedRun asserts that with no current
+// run the chain is followed past base into surviving runs and stops cleanly at the first run that no longer loads.
+func (s *workflowResetterSuite) TestReapplyContinueAsNewWorkflowEvents_MissingCurrent_ChainTruncatedOnDeletedRun() {
+	ctx := context.Background()
+	baseFirstEventID := int64(124)
+	baseNextEventID := int64(456)
+	baseBranchToken := []byte("base branch token")
+
+	runBID := uuid.NewString()
+	runBBranchToken := []byte("runB branch token")
+	runBNextEventID := int64(6)
+	runCID := uuid.NewString()
+
+	baseEvents := []*historypb.HistoryEvent{
+		{EventId: 124, EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED, Attributes: &historypb.HistoryEvent_WorkflowTaskCompletedEventAttributes{WorkflowTaskCompletedEventAttributes: &historypb.WorkflowTaskCompletedEventAttributes{}}},
+		{EventId: 125, EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW, Attributes: &historypb.HistoryEvent_WorkflowExecutionContinuedAsNewEventAttributes{WorkflowExecutionContinuedAsNewEventAttributes: &historypb.WorkflowExecutionContinuedAsNewEventAttributes{NewExecutionRunId: runBID}}},
+	}
+	runBEvents := []*historypb.HistoryEvent{
+		{EventId: 1, EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED, Attributes: &historypb.HistoryEvent_WorkflowExecutionStartedEventAttributes{WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{}}},
+		{EventId: 5, EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW, Attributes: &historypb.HistoryEvent_WorkflowExecutionContinuedAsNewEventAttributes{WorkflowExecutionContinuedAsNewEventAttributes: &historypb.WorkflowExecutionContinuedAsNewEventAttributes{NewExecutionRunId: runCID}}},
+	}
+
+	shardID := s.mockShard.GetShardID()
+	s.mockExecutionMgr.EXPECT().ReadHistoryBranchByBatch(gomock.Any(), &persistence.ReadHistoryBranchRequest{
+		BranchToken:   baseBranchToken,
+		MinEventID:    baseFirstEventID,
+		MaxEventID:    baseNextEventID,
+		PageSize:      defaultPageSize,
+		NextPageToken: nil,
+		ShardID:       shardID,
+	}).Return(&persistence.ReadHistoryBranchByBatchResponse{History: []*historypb.History{{Events: baseEvents}}}, nil)
+	s.mockExecutionMgr.EXPECT().ReadHistoryBranchByBatch(gomock.Any(), &persistence.ReadHistoryBranchRequest{
+		BranchToken:   runBBranchToken,
+		MinEventID:    common.FirstEventID,
+		MaxEventID:    runBNextEventID,
+		PageSize:      defaultPageSize,
+		NextPageToken: nil,
+		ShardID:       shardID,
+	}).Return(&persistence.ReadHistoryBranchByBatchResponse{History: []*historypb.History{{Events: runBEvents}}}, nil)
+
+	// runB survives and loads.
+	runBContext := historyi.NewMockWorkflowContext(s.controller)
+	runBContext.EXPECT().Lock(gomock.Any(), locks.PriorityHigh).Return(nil)
+	runBContext.EXPECT().Unlock()
+	runBContext.EXPECT().IsDirty().Return(false).AnyTimes()
+	runBMutableState := historyi.NewMockMutableState(s.controller)
+	runBContext.EXPECT().LoadMutableState(gomock.Any(), s.mockShard).Return(runBMutableState, nil)
+	runBMutableState.EXPECT().GetNextEventID().Return(runBNextEventID).AnyTimes()
+	runBMutableState.EXPECT().GetCurrentBranchToken().Return(runBBranchToken, nil).AnyTimes()
+	s.cacheWorkflowContext(runBID, runBContext)
+
+	// runC was deleted; loading it truncates the chain.
+	runCContext := historyi.NewMockWorkflowContext(s.controller)
+	runCContext.EXPECT().Lock(gomock.Any(), locks.PriorityHigh).Return(nil)
+	runCContext.EXPECT().Unlock()
+	runCContext.EXPECT().IsDirty().Return(false).AnyTimes()
+	runCContext.EXPECT().Clear().AnyTimes()
+	runCContext.EXPECT().LoadMutableState(gomock.Any(), s.mockShard).Return(nil, serviceerror.NewNotFound("workflow execution not found"))
+	s.cacheWorkflowContext(runCID, runCContext)
+
+	resetMutableState := historyi.NewMockMutableState(s.controller)
+	smReg := hsm.NewRegistry()
+	s.NoError(workflow.RegisterStateMachine(smReg))
+	root, err := hsm.NewRoot(smReg, workflow.StateMachineType, nil, make(map[string]*persistencespb.StateMachineMap), nil)
+	s.NoError(err)
+	resetMutableState.EXPECT().HSM().Return(root).AnyTimes()
+
+	lastVisitedRunID, err := s.workflowResetter.reapplyContinueAsNewWorkflowEvents(
+		ctx,
+		resetMutableState,
+		nil, // no current run
+		s.namespaceID,
+		s.workflowID,
+		s.baseRunID,
+		baseBranchToken,
+		baseFirstEventID,
+		baseNextEventID,
+		nil,
+		false, // allowResetWithPendingChildren
+	)
+	s.NoError(err)
+	s.Equal(runBID, lastVisitedRunID)
+}
+
+// TestReapplyContinueAsNewWorkflowEvents_MissingCurrent_TransientLoadErrorFailsReset asserts that a non-NotFound
+// error while loading the next run fails the reset rather than silently truncating the chain.
+func (s *workflowResetterSuite) TestReapplyContinueAsNewWorkflowEvents_MissingCurrent_TransientLoadErrorFailsReset() {
+	ctx := context.Background()
+	baseFirstEventID := int64(124)
+	baseNextEventID := int64(456)
+	baseBranchToken := []byte("base branch token")
+	runBID := uuid.NewString()
+
+	baseEvents := []*historypb.HistoryEvent{
+		{EventId: 124, EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED, Attributes: &historypb.HistoryEvent_WorkflowTaskCompletedEventAttributes{WorkflowTaskCompletedEventAttributes: &historypb.WorkflowTaskCompletedEventAttributes{}}},
+		{EventId: 125, EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW, Attributes: &historypb.HistoryEvent_WorkflowExecutionContinuedAsNewEventAttributes{WorkflowExecutionContinuedAsNewEventAttributes: &historypb.WorkflowExecutionContinuedAsNewEventAttributes{NewExecutionRunId: runBID}}},
+	}
+	s.mockExecutionMgr.EXPECT().ReadHistoryBranchByBatch(gomock.Any(), &persistence.ReadHistoryBranchRequest{
+		BranchToken:   baseBranchToken,
+		MinEventID:    baseFirstEventID,
+		MaxEventID:    baseNextEventID,
+		PageSize:      defaultPageSize,
+		NextPageToken: nil,
+		ShardID:       s.mockShard.GetShardID(),
+	}).Return(&persistence.ReadHistoryBranchByBatchResponse{History: []*historypb.History{{Events: baseEvents}}}, nil)
+
+	runBContext := historyi.NewMockWorkflowContext(s.controller)
+	runBContext.EXPECT().Lock(gomock.Any(), locks.PriorityHigh).Return(nil)
+	runBContext.EXPECT().Unlock()
+	runBContext.EXPECT().IsDirty().Return(false).AnyTimes()
+	runBContext.EXPECT().Clear().AnyTimes()
+	runBContext.EXPECT().LoadMutableState(gomock.Any(), s.mockShard).Return(nil, serviceerror.NewUnavailable("db unavailable"))
+	s.cacheWorkflowContext(runBID, runBContext)
+
+	resetMutableState := historyi.NewMockMutableState(s.controller)
+	smReg := hsm.NewRegistry()
+	s.NoError(workflow.RegisterStateMachine(smReg))
+	root, err := hsm.NewRoot(smReg, workflow.StateMachineType, nil, make(map[string]*persistencespb.StateMachineMap), nil)
+	s.NoError(err)
+	resetMutableState.EXPECT().HSM().Return(root).AnyTimes()
+
+	_, err = s.workflowResetter.reapplyContinueAsNewWorkflowEvents(
+		ctx,
+		resetMutableState,
+		nil, // no current run
+		s.namespaceID,
+		s.workflowID,
+		s.baseRunID,
+		baseBranchToken,
+		baseFirstEventID,
+		baseNextEventID,
+		nil,
+		false, // allowResetWithPendingChildren
+	)
+	var unavailable *serviceerror.Unavailable
+	s.ErrorAs(err, &unavailable)
 }
 
 func (s *workflowResetterSuite) TestReapplyWorkflowEvents() {

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -284,9 +284,14 @@ func (s *workflowResetterSuite) TestPersistToDB_CurrentNotTerminated() {
 
 func (s *workflowResetterSuite) TestPersistToDB_CurrentExecutionMissing() {
 	// No current execution exists (e.g. the current run was deleted while older runs survive).
-	// persistToDB must create the reset run as the new current via CreateWorkflowModeBrandNew,
-	// and must not touch the (nil) current or the base run.
-	baseWorkflow := NewMockWorkflow(s.controller) // must not be used in this path
+	// persistToDB must persist the base run (bypassing the missing current record) so its
+	// ResetRunID link reaches the DB, then create the reset run as the new current via
+	// CreateWorkflowModeBrandNew. The nil current must not be touched.
+	baseWorkflow := NewMockWorkflow(s.controller)
+	baseMutableState := historyi.NewMockMutableState(s.controller)
+	baseWorkflow.EXPECT().GetMutableState().Return(baseMutableState).AnyTimes()
+	baseMutableState.EXPECT().GetCurrentVersion().Return(int64(0)).AnyTimes()
+	baseMutableState.EXPECT().IsWorkflow().Return(true).AnyTimes()
 
 	resetWorkflow := NewMockWorkflow(s.controller)
 	resetReleaseCalled := false
@@ -317,6 +322,32 @@ func (s *workflowResetterSuite) TestPersistToDB_CurrentExecutionMissing() {
 		historyi.TransactionPolicyActive,
 	).Return(resetSnapshot, resetEventsSeq, nil)
 
+	// The base run is closed as a mutation carrying the ResetRunID set by UpdateResetRunID.
+	baseMutation := &persistence.WorkflowMutation{
+		ExecutionInfo: &persistencespb.WorkflowExecutionInfo{ResetRunId: s.resetRunID},
+	}
+	baseEventsSeq := []*persistence.WorkflowEvents{}
+	baseMutableState.EXPECT().CloseTransactionAsMutation(
+		context.Background(),
+		historyi.TransactionPolicyActive,
+	).Return(baseMutation, baseEventsSeq, nil)
+
+	// Base-first: the base run is persisted with BypassCurrent (tolerating the missing current
+	// record) before the reset run is created as the new current.
+	baseUpdateEventsSize := int64(1234)
+	baseUpdateCurrent := s.mockTransaction.EXPECT().UpdateWorkflowExecution(
+		gomock.Any(),
+		persistence.UpdateWorkflowModeBypassCurrent,
+		chasm.WorkflowArchetypeID,
+		int64(0),
+		baseMutation,
+		baseEventsSeq,
+		(*int64)(nil),
+		(*persistence.WorkflowSnapshot)(nil),
+		([]*persistence.WorkflowEvents)(nil),
+		true, // isWorkflow
+	).Return(baseUpdateEventsSize, int64(0), nil)
+
 	resetNewEventsSize := int64(4321)
 	// The key assertion: reset run is created as the new current with BrandNew mode,
 	// not an Update/ConflictResolve mode (both of which assume an existing current row).
@@ -328,7 +359,7 @@ func (s *workflowResetterSuite) TestPersistToDB_CurrentExecutionMissing() {
 		resetSnapshot,
 		resetEventsSeq,
 		true, // isWorkflow
-	).Return(resetNewEventsSize, nil)
+	).Return(resetNewEventsSize, nil).After(baseUpdateCurrent)
 
 	// nil current workflow, and nil current mutation/events.
 	err := s.workflowResetter.persistToDB(context.Background(), baseWorkflow, nil, nil, nil, resetWorkflow)

--- a/tests/reset_workflow_test.go
+++ b/tests/reset_workflow_test.go
@@ -1029,13 +1029,13 @@ func (s *ResetWorkflowTestSuite) TestResetWorkflowByRunID_CurrentExecutionMissin
 
 	// Wait for the original run to continue-as-new and the chain to stop running, so run A is
 	// closed (ContinuedAsNew) and run B is the current (closed) execution.
-	s.Eventually(func() bool {
+	s.Await(func(s *ResetWorkflowTestSuite) {
 		resp, err := env.FrontendClient().CountWorkflowExecutions(s.Context(), &workflowservice.CountWorkflowExecutionsRequest{
 			Namespace: env.Namespace().String(),
 			Query:     fmt.Sprintf("WorkflowId = \"%s\" AND ExecutionStatus != \"Running\"", run.GetID()),
 		})
 		s.NoError(err)
-		return resp.GetCount() >= 2
+		s.GreaterOrEqual(resp.GetCount(), int64(2))
 	}, 30*time.Second, time.Second)
 
 	baseRunID := run.GetRunID() // run A
@@ -1054,6 +1054,8 @@ func (s *ResetWorkflowTestSuite) TestResetWorkflowByRunID_CurrentExecutionMissin
 			lastWorkflowTask = event
 		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW:
 			currentRunID = event.GetWorkflowExecutionContinuedAsNewEventAttributes().GetNewExecutionRunId()
+		default:
+			// other event types are not relevant here
 		}
 	}
 	s.NotEmpty(currentRunID)
@@ -1071,7 +1073,7 @@ func (s *ResetWorkflowTestSuite) TestResetWorkflowByRunID_CurrentExecutionMissin
 	s.NoError(err)
 
 	// Wait until there is no current execution: resolving by workflowId only now returns NotFound.
-	s.Eventually(func() bool {
+	s.AwaitTrue(func() bool {
 		_, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
 			Namespace: env.Namespace().String(),
 			Execution: &commonpb.WorkflowExecution{WorkflowId: run.GetID()},

--- a/tests/reset_workflow_test.go
+++ b/tests/reset_workflow_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"strconv"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	filterpb "go.temporal.io/api/filter/v1"
 	historypb "go.temporal.io/api/history/v1"
 	protocolpb "go.temporal.io/api/protocol/v1"
+	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	updatepb "go.temporal.io/api/update/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
@@ -1007,6 +1009,115 @@ func (s *ResetWorkflowTestSuite) TestResetWorkflow_ResetAfterContinueAsNew() {
 		WorkflowExecution:         wfExec,
 		WorkflowTaskFinishEventId: lastWorkflowTask.GetEventId(),
 		RequestId:                 uuid.NewString(),
+	})
+	s.NoError(err)
+}
+
+func (s *ResetWorkflowTestSuite) TestResetWorkflowByRunID_CurrentExecutionMissing() {
+	// Speed up the transfer/visibility queues so the DeleteExecutionTask for the closed current
+	// run is processed promptly (deleting a closed workflow is async). Mirrors the delete-execution
+	// suite (tests/workflow_delete_execution_test.go).
+	env := testcore.NewEnv(s.T(),
+		testcore.WithDynamicConfig(dynamicconfig.TransferProcessorUpdateAckInterval, 1*time.Second),
+		testcore.WithDynamicConfig(dynamicconfig.VisibilityProcessorUpdateAckInterval, 1*time.Second),
+	)
+
+	// Run a workflow that continues-as-new exactly once: run A (closed, ContinuedAsNew) -> run B.
+	env.SdkWorker().RegisterWorkflow(CaNOnceWorkflow)
+	run, err := env.SdkClient().ExecuteWorkflow(s.Context(), sdkclient.StartWorkflowOptions{TaskQueue: env.WorkerTaskQueue()}, CaNOnceWorkflow, "")
+	s.NoError(err)
+
+	// Wait for the original run to continue-as-new and the chain to stop running, so run A is
+	// closed (ContinuedAsNew) and run B is the current (closed) execution.
+	s.Eventually(func() bool {
+		resp, err := env.FrontendClient().CountWorkflowExecutions(s.Context(), &workflowservice.CountWorkflowExecutionsRequest{
+			Namespace: env.Namespace().String(),
+			Query:     fmt.Sprintf("WorkflowId = \"%s\" AND ExecutionStatus != \"Running\"", run.GetID()),
+		})
+		s.NoError(err)
+		return resp.GetCount() >= 2
+	}, 30*time.Second, time.Second)
+
+	baseRunID := run.GetRunID() // run A
+
+	// From run A's history, find the current run (B) via its ContinuedAsNew event and run A's
+	// reset point (its last completed workflow task).
+	runAEvents := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{
+		WorkflowId: run.GetID(),
+		RunId:      baseRunID,
+	})
+	var currentRunID string
+	var lastWorkflowTask *historypb.HistoryEvent
+	for _, event := range runAEvents {
+		switch event.GetEventType() {
+		case enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED:
+			lastWorkflowTask = event
+		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW:
+			currentRunID = event.GetWorkflowExecutionContinuedAsNewEventAttributes().GetNewExecutionRunId()
+		}
+	}
+	s.NotEmpty(currentRunID)
+	s.NotNil(lastWorkflowTask)
+
+	// Delete the current run (B). This clears the current_executions record while run A survives —
+	// the "no current execution, older run exists" condition.
+	_, err = env.FrontendClient().DeleteWorkflowExecution(s.Context(), &workflowservice.DeleteWorkflowExecutionRequest{
+		Namespace: env.Namespace().String(),
+		WorkflowExecution: &commonpb.WorkflowExecution{
+			WorkflowId: run.GetID(),
+			RunId:      currentRunID,
+		},
+	})
+	s.NoError(err)
+
+	// Wait until there is no current execution: resolving by workflowId only now returns NotFound.
+	s.Eventually(func() bool {
+		_, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
+			Execution: &commonpb.WorkflowExecution{WorkflowId: run.GetID()},
+		})
+		var notFound *serviceerror.NotFound
+		return errors.As(err, &notFound)
+	}, 30*time.Second, 100*time.Millisecond)
+
+	// Sanity: run A still exists and is addressable by its runId.
+	_, err = env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: baseRunID},
+	})
+	s.NoError(err)
+
+	// Reset by run A's explicit runId. Before the fix this fails with NotFound (current missing);
+	// after the fix it must succeed and create a new current execution from run A.
+	resetResp, err := env.FrontendClient().ResetWorkflowExecution(s.Context(), &workflowservice.ResetWorkflowExecutionRequest{
+		Namespace: env.Namespace().String(),
+		WorkflowExecution: &commonpb.WorkflowExecution{
+			WorkflowId: run.GetID(),
+			RunId:      baseRunID,
+		},
+		Reason:                    "reset by runId with current execution missing",
+		WorkflowTaskFinishEventId: lastWorkflowTask.GetEventId(),
+		RequestId:                 uuid.NewString(),
+	})
+	s.NoError(err)
+	s.NotEmpty(resetResp.GetRunId())
+	s.NotEqual(baseRunID, resetResp.GetRunId())
+
+	// The reset run exists and is derived from run A.
+	descResp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{
+			WorkflowId: run.GetID(),
+			RunId:      resetResp.GetRunId(),
+		},
+	})
+	s.NoError(err)
+	s.Equal(baseRunID, descResp.WorkflowExecutionInfo.GetFirstRunId())
+
+	// The workflow again has a current execution: resolving by workflowId only now succeeds.
+	_, err = env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: run.GetID()},
 	})
 	s.NoError(err)
 }

--- a/tests/reset_workflow_test.go
+++ b/tests/reset_workflow_test.go
@@ -972,23 +972,6 @@ func CaNOnceWorkflow(ctx workflow.Context, input string) (string, error) {
 	return input, nil
 }
 
-// CaNChainSignalWorkflow builds a three-run continue-as-new chain: run A (count 0) continues-as-new
-// immediately, run B (count 1) waits for a "reapply-me" signal before continuing-as-new, and run C
-// (count 2) completes. The signal recorded on the surviving intermediate run B is what a reset of
-// run A must reapply once the current run has been deleted.
-func CaNChainSignalWorkflow(ctx workflow.Context, count int) (string, error) {
-	switch count {
-	case 0:
-		return "", workflow.NewContinueAsNewError(ctx, CaNChainSignalWorkflow, 1)
-	case 1:
-		var val string
-		workflow.GetSignalChannel(ctx, "reapply-me").Receive(ctx, &val)
-		return "", workflow.NewContinueAsNewError(ctx, CaNChainSignalWorkflow, 2)
-	default:
-		return "done", nil
-	}
-}
-
 func (s *ResetWorkflowTestSuite) TestResetWorkflow_ResetAfterContinueAsNew() {
 	env := testcore.NewEnv(s.T())
 
@@ -1028,6 +1011,23 @@ func (s *ResetWorkflowTestSuite) TestResetWorkflow_ResetAfterContinueAsNew() {
 		RequestId:                 uuid.NewString(),
 	})
 	s.NoError(err)
+}
+
+// CaNChainSignalWorkflow builds a three-run continue-as-new chain: run A (count 0) continues-as-new
+// immediately, run B (count 1) waits for a "reapply-me" signal before continuing-as-new, and run C
+// (count 2) completes. The signal recorded on the surviving intermediate run B is what a reset of
+// run A must reapply once the current run has been deleted.
+func CaNChainSignalWorkflow(ctx workflow.Context, count int) (string, error) {
+	switch count {
+	case 0:
+		return "", workflow.NewContinueAsNewError(ctx, CaNChainSignalWorkflow, 1)
+	case 1:
+		var val string
+		workflow.GetSignalChannel(ctx, "reapply-me").Receive(ctx, &val)
+		return "", workflow.NewContinueAsNewError(ctx, CaNChainSignalWorkflow, 2)
+	default:
+		return "done", nil
+	}
 }
 
 // TestResetWorkflowByRunID_CurrentExecutionMissing resets by an explicit runId when the workflow has

--- a/tests/reset_workflow_test.go
+++ b/tests/reset_workflow_test.go
@@ -972,6 +972,23 @@ func CaNOnceWorkflow(ctx workflow.Context, input string) (string, error) {
 	return input, nil
 }
 
+// CaNChainSignalWorkflow builds a three-run continue-as-new chain: run A (count 0) continues-as-new
+// immediately, run B (count 1) waits for a "reapply-me" signal before continuing-as-new, and run C
+// (count 2) completes. The signal recorded on the surviving intermediate run B is what a reset of
+// run A must reapply once the current run has been deleted.
+func CaNChainSignalWorkflow(ctx workflow.Context, count int) (string, error) {
+	switch count {
+	case 0:
+		return "", workflow.NewContinueAsNewError(ctx, CaNChainSignalWorkflow, 1)
+	case 1:
+		var val string
+		workflow.GetSignalChannel(ctx, "reapply-me").Receive(ctx, &val)
+		return "", workflow.NewContinueAsNewError(ctx, CaNChainSignalWorkflow, 2)
+	default:
+		return "done", nil
+	}
+}
+
 func (s *ResetWorkflowTestSuite) TestResetWorkflow_ResetAfterContinueAsNew() {
 	env := testcore.NewEnv(s.T())
 
@@ -1013,62 +1030,61 @@ func (s *ResetWorkflowTestSuite) TestResetWorkflow_ResetAfterContinueAsNew() {
 	s.NoError(err)
 }
 
+// TestResetWorkflowByRunID_CurrentExecutionMissing resets by an explicit runId when the workflow has
+// no current execution (the current run was deleted while older runs survive). It uses a three-run
+// chain A -> B (waits for a signal) -> C, deletes the current run C, then resets by run A. This covers
+// both the base->reset persistence when the current is missing and the reapply walking the surviving
+// chain past the base: the signal recorded on the surviving intermediate run B must land on the reset
+// run, and the walk must stop cleanly at the deleted run C.
 func (s *ResetWorkflowTestSuite) TestResetWorkflowByRunID_CurrentExecutionMissing() {
-	// Speed up the transfer/visibility queues so the DeleteExecutionTask for the closed current
-	// run is processed promptly (deleting a closed workflow is async). Mirrors the delete-execution
-	// suite (tests/workflow_delete_execution_test.go).
+	// Speed up the transfer/visibility queues so the async DeleteExecutionTask for the closed current
+	// run is processed promptly. Mirrors the delete-execution suite (tests/workflow_delete_execution_test.go).
 	env := testcore.NewEnv(s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.TransferProcessorUpdateAckInterval, 1*time.Second),
 		testcore.WithDynamicConfig(dynamicconfig.VisibilityProcessorUpdateAckInterval, 1*time.Second),
 	)
 
-	// Run a workflow that continues-as-new exactly once: run A (closed, ContinuedAsNew) -> run B.
-	env.SdkWorker().RegisterWorkflow(CaNOnceWorkflow)
-	run, err := env.SdkClient().ExecuteWorkflow(s.Context(), sdkclient.StartWorkflowOptions{TaskQueue: env.WorkerTaskQueue()}, CaNOnceWorkflow, "")
+	// Run A -> run B (waits for signal) -> run C. Run A is the reset target; run C becomes current.
+	env.SdkWorker().RegisterWorkflow(CaNChainSignalWorkflow)
+	run, err := env.SdkClient().ExecuteWorkflow(s.Context(), sdkclient.StartWorkflowOptions{TaskQueue: env.WorkerTaskQueue()}, CaNChainSignalWorkflow, 0)
 	s.NoError(err)
+	baseRunID := run.GetRunID() // run A
 
-	// Wait for the original run to continue-as-new and the chain to stop running, so run A is
-	// closed (ContinuedAsNew) and run B is the current (closed) execution.
-	s.Await(func(s *ResetWorkflowTestSuite) {
+	// Wait until run B is the running current execution, then signal it so the signal lands in B's history.
+	s.AwaitTrue(func() bool {
+		desc, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
+			Execution: &commonpb.WorkflowExecution{WorkflowId: run.GetID()},
+		})
+		if err != nil {
+			return false
+		}
+		info := desc.GetWorkflowExecutionInfo()
+		return info.GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING && info.GetExecution().GetRunId() != baseRunID
+	}, 30*time.Second, 100*time.Millisecond)
+	s.NoError(env.SdkClient().SignalWorkflow(s.Context(), run.GetID(), "", "reapply-me", "payload"))
+
+	// Wait for the whole chain (A, B, C) to stop running.
+	s.AwaitTrue(func() bool {
 		resp, err := env.FrontendClient().CountWorkflowExecutions(s.Context(), &workflowservice.CountWorkflowExecutionsRequest{
 			Namespace: env.Namespace().String(),
 			Query:     fmt.Sprintf("WorkflowId = \"%s\" AND ExecutionStatus != \"Running\"", run.GetID()),
 		})
-		s.NoError(err)
-		s.GreaterOrEqual(resp.GetCount(), int64(2))
+		return err == nil && resp.GetCount() >= 3
 	}, 30*time.Second, time.Second)
 
-	baseRunID := run.GetRunID() // run A
-
-	// From run A's history, find the current run (B) via its ContinuedAsNew event and run A's
-	// reset point (its last completed workflow task).
-	runAEvents := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{
-		WorkflowId: run.GetID(),
-		RunId:      baseRunID,
-	})
-	var currentRunID string
-	var lastWorkflowTask *historypb.HistoryEvent
-	for _, event := range runAEvents {
-		switch event.GetEventType() {
-		case enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED:
-			lastWorkflowTask = event
-		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW:
-			currentRunID = event.GetWorkflowExecutionContinuedAsNewEventAttributes().GetNewExecutionRunId()
-		default:
-			// other event types are not relevant here
-		}
-	}
-	s.NotEmpty(currentRunID)
-	s.NotNil(lastWorkflowTask)
-
-	// Delete the current run (B). This clears the current_executions record while run A survives —
-	// the "no current execution, older run exists" condition.
-	_, err = env.FrontendClient().DeleteWorkflowExecution(s.Context(), &workflowservice.DeleteWorkflowExecutionRequest{
+	// Delete the current run (C). This clears the current_executions record while run A and run B
+	// survive — the "no current execution, older run exists" condition.
+	desc, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
 		Namespace: env.Namespace().String(),
-		WorkflowExecution: &commonpb.WorkflowExecution{
-			WorkflowId: run.GetID(),
-			RunId:      currentRunID,
-		},
+		Execution: &commonpb.WorkflowExecution{WorkflowId: run.GetID()},
+	})
+	s.NoError(err)
+	currentRunID := desc.GetWorkflowExecutionInfo().GetExecution().GetRunId()
+	s.NotEqual(baseRunID, currentRunID)
+	_, err = env.FrontendClient().DeleteWorkflowExecution(s.Context(), &workflowservice.DeleteWorkflowExecutionRequest{
+		Namespace:         env.Namespace().String(),
+		WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: currentRunID},
 	})
 	s.NoError(err)
 
@@ -1082,21 +1098,22 @@ func (s *ResetWorkflowTestSuite) TestResetWorkflowByRunID_CurrentExecutionMissin
 		return errors.As(err, &notFound)
 	}, 30*time.Second, 100*time.Millisecond)
 
-	// Sanity: run A still exists and is addressable by its runId.
-	_, err = env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
-		Namespace: env.Namespace().String(),
-		Execution: &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: baseRunID},
-	})
-	s.NoError(err)
+	// Sanity: run A still exists and is addressable by its runId. Find its reset point (last completed
+	// workflow task) while we are here.
+	runAEvents := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: baseRunID})
+	var lastWorkflowTask *historypb.HistoryEvent
+	for _, event := range runAEvents {
+		if event.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED {
+			lastWorkflowTask = event
+		}
+	}
+	s.NotNil(lastWorkflowTask)
 
 	// Reset by run A's explicit runId. Before the fix this fails with NotFound (current missing);
 	// after the fix it must succeed and create a new current execution from run A.
 	resetResp, err := env.FrontendClient().ResetWorkflowExecution(s.Context(), &workflowservice.ResetWorkflowExecutionRequest{
-		Namespace: env.Namespace().String(),
-		WorkflowExecution: &commonpb.WorkflowExecution{
-			WorkflowId: run.GetID(),
-			RunId:      baseRunID,
-		},
+		Namespace:                 env.Namespace().String(),
+		WorkflowExecution:         &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: baseRunID},
 		Reason:                    "reset by runId with current execution missing",
 		WorkflowTaskFinishEventId: lastWorkflowTask.GetEventId(),
 		RequestId:                 uuid.NewString(),
@@ -1108,10 +1125,7 @@ func (s *ResetWorkflowTestSuite) TestResetWorkflowByRunID_CurrentExecutionMissin
 	// The reset run exists and is derived from run A.
 	descResp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
 		Namespace: env.Namespace().String(),
-		Execution: &commonpb.WorkflowExecution{
-			WorkflowId: run.GetID(),
-			RunId:      resetResp.GetRunId(),
-		},
+		Execution: &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: resetResp.GetRunId()},
 	})
 	s.NoError(err)
 	s.Equal(baseRunID, descResp.WorkflowExecutionInfo.GetFirstRunId())
@@ -1132,6 +1146,18 @@ func (s *ResetWorkflowTestSuite) TestResetWorkflowByRunID_CurrentExecutionMissin
 		Execution: &commonpb.WorkflowExecution{WorkflowId: run.GetID()},
 	})
 	s.NoError(err)
+
+	// The signal recorded on the surviving intermediate run B must be reapplied onto the reset run.
+	// Reapplying only run A's own events (the previous behavior) would drop it.
+	resetEvents := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: resetResp.GetRunId()})
+	signalReapplied := false
+	for _, event := range resetEvents {
+		if event.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED &&
+			event.GetWorkflowExecutionSignaledEventAttributes().GetSignalName() == "reapply-me" {
+			signalReapplied = true
+		}
+	}
+	s.True(signalReapplied, "signal from surviving intermediate run should be reapplied to the reset run")
 }
 
 func (s *ResetWorkflowTestSuite) TestResetWorkflowWithExternalPayloads() {

--- a/tests/reset_workflow_test.go
+++ b/tests/reset_workflow_test.go
@@ -1116,6 +1116,16 @@ func (s *ResetWorkflowTestSuite) TestResetWorkflowByRunID_CurrentExecutionMissin
 	s.NoError(err)
 	s.Equal(baseRunID, descResp.WorkflowExecutionInfo.GetFirstRunId())
 
+	// The base run (A) records the base->reset link, so lineage navigation and child-completion
+	// redirect can follow run A to the reset run. This is persisted even though A is not the
+	// current execution (bypass-current write of the base run).
+	baseDescResp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: baseRunID},
+	})
+	s.NoError(err)
+	s.Equal(resetResp.GetRunId(), baseDescResp.GetWorkflowExtendedInfo().GetResetRunId())
+
 	// The workflow again has a current execution: resolving by workflowId only now succeeds.
 	_, err = env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
 		Namespace: env.Namespace().String(),


### PR DESCRIPTION
## What changed?
Reset now tolerates a missing current execution when an explicit `runId` is provided. In
`resetworkflow`, a `NotFound` from resolving the current run is treated as "no current" — but only
when a base `runId` was given (with no base run there is still nothing to reset from, so it keeps
erroring). The resetter then handles a nil current: it skips termination and persists the reset run
**as the new current execution** via `CreateWorkflowModeBrandNew`, instead of the update /
conflict-resolve modes that assume an existing `current_executions` row. It then reapplies
from the base run as far through the continue-as-new chain as it can until it encounters a later run
that has been deleted.

## Why?
Resetting a workflow by an explicit `runId` returned `workflow not found` whenever the workflow had
no current execution — e.g. the current run was deleted while older runs still existed. Reset
resolved the current execution unconditionally, so the `NotFound` from the missing
`current_executions` record surfaced even though the run named by `runId` was present and resettable.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests — the existing `ResetWorkflowTestSuite` and `workflowResetterSuite`
  stay green (the shared reset / `persistToDB` paths were restructured).
- [x] added new unit test(s) — `TestShouldTolerateMissingCurrentExecution` (the NotFound-tolerance
  boundary) and `TestPersistToDB_CurrentExecutionMissing` (asserts `CreateWorkflowModeBrandNew`, no
  termination).
- [x] added new functional test(s) — `TestResetWorkflowByRunID_CurrentExecutionMissing`: builds the
  run chain, deletes the current run, resets by the older runId, and asserts success + new current.

Manual reproduction against a file-backed dev server (`make start-sqlite-file`), with a worker whose
workflow continues-as-new once (run A closes `ContinuedAsNew`, run B is current/Running):
```bash
# Create the orphaned state: delete the current run, leaving the older run.
temporal workflow terminate -w reset-repro-wf -r "$RUN_B" --reason repro
temporal workflow delete    -w reset-repro-wf -r "$RUN_B"     # async; clears current_executions
temporal workflow describe  -w reset-repro-wf                 # -> NotFound (no current)

# Reset by the surviving older run:
temporal workflow reset -w reset-repro-wf -r "$RUN_A" --type FirstWorkflowTask --reason repro
#   before: FAILS "workflow not found"   |   after: SUCCEEDS, and:
temporal workflow describe -w reset-repro-wf                  # -> resolves the reset run (current restored)
```
(The failed reset writes nothing, so run A is reusable; a successful reset repopulates
`current_executions`, so re-orphan to repeat.)

## Potential risks
- New create-as-current persistence path, reachable only from the user-facing reset API when the
  current is missing; the other `ResetWorkflow` callers always pass a concrete current and are
  unaffected.

## Fixes
#10690 