### PR TITLE
test(mixedbrain): add scheduler_stress scenario and server log scanning

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -506,7 +506,7 @@ jobs:
 
       - name: Print Omes logs
         if: always()
-        run: cat .testoutput/mixedbrain_omes.log || true
+        run: cat .testoutput/mixedbrain_omes_*.log || true
 
       - name: Stop containerized dependencies
         if: always()

--- a/tests/mixedbrain/log_scan_util.go
+++ b/tests/mixedbrain/log_scan_util.go
@@ -1,0 +1,107 @@
+package mixedbrain
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// logLineValidator inspects a single server log line and returns a non-nil
+// error if the line indicates a problem. Validators are run against every line
+// of each server log file after the servers stop. To add a new scan, implement
+// this interface (or use substringValidator / validatorFunc) and append it to
+// serverLogValidators.
+type logLineValidator interface {
+	Validate(line string) error
+}
+
+// validatorFunc adapts a plain function into a logLineValidator, for ad-hoc
+// checks that don't fit the substring model (regex, JSON field parsing, etc.).
+type validatorFunc func(line string) error
+
+func (f validatorFunc) Validate(line string) error { return f(line) }
+
+// substringValidator fails a line that contains `include` unless the line also
+// contains one of `exclude` (known-good lines to skip). This mirrors the
+// |= / != operators in saas-cicd oss-cicd/e2e/workflows/generic/activities/check_logs.go;
+// keep the two in sync when adjusting the exclude lists.
+type substringValidator struct {
+	name    string
+	include string
+	exclude []string
+}
+
+func (v substringValidator) Validate(line string) error {
+	if !strings.Contains(line, v.include) {
+		return nil
+	}
+	for _, e := range v.exclude {
+		if strings.Contains(line, e) {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s: %s", v.name, truncate(line, 500))
+}
+
+// serverLogValidators is the registry of checks applied to server logs.
+// Append an entry to add a new scan.
+var serverLogValidators = []logLineValidator{
+	substringValidator{
+		name:    "soft assertion",
+		include: "failed assertion:",
+		// per saas-cicd check_logs.go assertionQueryTemplate
+		exclude: []string{"found otherHasTasks in classic metadata"},
+	},
+	substringValidator{
+		name:    "panic",
+		include: "panic",
+		exclude: []string{
+			"Potential deadlock detected", // expected under resource-constrained load
+			"[TMPRL1100]",                 // invalid state transition, sdk-side (per saas-cicd)
+		},
+	},
+	substringValidator{
+		name:    "inconsistent metric descriptor",
+		include: "a previously registered descriptor with the same fully-qualified name as",
+	},
+}
+
+// scanServerLogs runs every validator against every line of each log file and
+// fails the test (without stopping at the first hit) on any validation error.
+func scanServerLogs(t testing.TB, validators []logLineValidator, logPaths ...string) {
+	t.Helper()
+	for _, path := range logPaths {
+		scanLogFile(t, validators, path)
+	}
+}
+
+func scanLogFile(t testing.TB, validators []logLineValidator, path string) {
+	t.Helper()
+	f, err := os.Open(path)
+	require.NoError(t, err, "open server log %s", path)
+	defer func() { _ = f.Close() }()
+
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024) // server JSON lines can be long
+	for n := 1; sc.Scan(); n++ {
+		line := sc.Text()
+		for _, v := range validators {
+			if err := v.Validate(line); err != nil {
+				t.Errorf("%s:%d %v", filepath.Base(path), n, err)
+			}
+		}
+	}
+	require.NoError(t, sc.Err(), "read server log %s", path)
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}

--- a/tests/mixedbrain/log_scan_util.go
+++ b/tests/mixedbrain/log_scan_util.go
@@ -6,25 +6,17 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"testing"
 
-	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/util"
 )
 
 // logLineValidator inspects a single server log line and returns a non-nil
 // error if the line indicates a problem. Validators are run against every line
 // of each server log file after the servers stop. To add a new scan, implement
-// this interface (or use substringValidator / validatorFunc) and append it to
-// serverLogValidators.
+// this interface (or use substringValidator) and append it to serverLogValidators.
 type logLineValidator interface {
 	Validate(line string) error
 }
-
-// validatorFunc adapts a plain function into a logLineValidator, for ad-hoc
-// checks that don't fit the substring model (regex, JSON field parsing, etc.).
-type validatorFunc func(line string) error
-
-func (f validatorFunc) Validate(line string) error { return f(line) }
 
 // substringValidator fails a line that contains `include` unless the line also
 // contains one of `exclude` (known-good lines to skip). This mirrors the
@@ -45,7 +37,7 @@ func (v substringValidator) Validate(line string) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("%s: %s", v.name, truncate(line, 500))
+	return fmt.Errorf("%s: %s", v.name, util.TruncateUTF8(line, 500))
 }
 
 // serverLogValidators is the registry of checks applied to server logs.
@@ -65,43 +57,33 @@ var serverLogValidators = []logLineValidator{
 			"[TMPRL1100]",                 // invalid state transition, sdk-side (per saas-cicd)
 		},
 	},
-	substringValidator{
-		name:    "inconsistent metric descriptor",
-		include: "a previously registered descriptor with the same fully-qualified name as",
-	},
 }
 
 // scanServerLogs runs every validator against every line of each log file and
-// fails the test (without stopping at the first hit) on any validation error.
-func scanServerLogs(t testing.TB, validators []logLineValidator, logPaths ...string) {
-	t.Helper()
+// returns a message for each validation failure (it does not stop at the first).
+func scanServerLogs(validators []logLineValidator, logPaths ...string) ([]string, error) {
+	var problems []string
 	for _, path := range logPaths {
-		scanLogFile(t, validators, path)
-	}
-}
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, fmt.Errorf("open server log %s: %w", path, err)
+		}
 
-func scanLogFile(t testing.TB, validators []logLineValidator, path string) {
-	t.Helper()
-	f, err := os.Open(path)
-	require.NoError(t, err, "open server log %s", path)
-	defer func() { _ = f.Close() }()
-
-	sc := bufio.NewScanner(f)
-	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024) // server JSON lines can be long
-	for n := 1; sc.Scan(); n++ {
-		line := sc.Text()
-		for _, v := range validators {
-			if err := v.Validate(line); err != nil {
-				t.Errorf("%s:%d %v", filepath.Base(path), n, err)
+		sc := bufio.NewScanner(f)
+		sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024) // server JSON lines can be long
+		for n := 1; sc.Scan(); n++ {
+			line := sc.Text()
+			for _, v := range validators {
+				if err := v.Validate(line); err != nil {
+					problems = append(problems, fmt.Sprintf("%s:%d %v", filepath.Base(path), n, err))
+				}
 			}
 		}
+		err = sc.Err()
+		_ = f.Close()
+		if err != nil {
+			return nil, fmt.Errorf("read server log %s: %w", path, err)
+		}
 	}
-	require.NoError(t, sc.Err(), "read server log %s", path)
-}
-
-func truncate(s string, max int) string {
-	if len(s) <= max {
-		return s
-	}
-	return s[:max] + "..."
+	return problems, nil
 }

--- a/tests/mixedbrain/log_scan_util.go
+++ b/tests/mixedbrain/log_scan_util.go
@@ -19,9 +19,7 @@ type logLineValidator interface {
 }
 
 // substringValidator fails a line that contains `include` unless the line also
-// contains one of `exclude` (known-good lines to skip). This mirrors the
-// |= / != operators in saas-cicd oss-cicd/e2e/workflows/generic/activities/check_logs.go;
-// keep the two in sync when adjusting the exclude lists.
+// contains one of `exclude` (known-good lines to skip).
 type substringValidator struct {
 	name    string
 	include string
@@ -46,7 +44,6 @@ var serverLogValidators = []logLineValidator{
 	substringValidator{
 		name:    "soft assertion",
 		include: "failed assertion:",
-		// per saas-cicd check_logs.go assertionQueryTemplate
 		exclude: []string{"found otherHasTasks in classic metadata"},
 	},
 	substringValidator{
@@ -54,7 +51,7 @@ var serverLogValidators = []logLineValidator{
 		include: "panic",
 		exclude: []string{
 			"Potential deadlock detected", // expected under resource-constrained load
-			"[TMPRL1100]",                 // invalid state transition, sdk-side (per saas-cicd)
+			"[TMPRL1100]",                 // invalid state transition, sdk-side
 		},
 	},
 }

--- a/tests/mixedbrain/log_scan_util.go
+++ b/tests/mixedbrain/log_scan_util.go
@@ -48,7 +48,7 @@ var serverLogValidators = []logLineValidator{
 	},
 	substringValidator{
 		name:    "panic",
-		include: "panic",
+		include: "panic:",
 		exclude: []string{
 			"Potential deadlock detected", // expected under resource-constrained load
 			"[TMPRL1100]",                 // invalid state transition, sdk-side

--- a/tests/mixedbrain/log_scan_util_test.go
+++ b/tests/mixedbrain/log_scan_util_test.go
@@ -31,17 +31,8 @@ func TestScanServerLogs(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
 
 	// Only the un-excluded soft assertion on line 2 should be reported.
-	mock := &mockT{}
-	scanLogFile(mock, serverLogValidators, path)
-	require.Equal(t, 1, mock.errors, "expected exactly one flagged line")
+	problems, err := scanServerLogs(serverLogValidators, path)
+	require.NoError(t, err)
+	require.Len(t, problems, 1)
+	require.Contains(t, problems[0], "server.log:2")
 }
-
-// mockT captures Errorf calls so we can assert on validation hits without
-// failing the real test.
-type mockT struct {
-	testing.TB
-	errors int
-}
-
-func (m *mockT) Errorf(string, ...any) { m.errors++ }
-func (m *mockT) Helper()               {}

--- a/tests/mixedbrain/log_scan_util_test.go
+++ b/tests/mixedbrain/log_scan_util_test.go
@@ -1,0 +1,47 @@
+package mixedbrain
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubstringValidator(t *testing.T) {
+	v := substringValidator{
+		name:    "panic",
+		include: "panic",
+		exclude: []string{"Potential deadlock detected"},
+	}
+
+	require.NoError(t, v.Validate(`{"msg":"all good"}`), "no include match")
+	require.NoError(t, v.Validate(`{"msg":"panic: Potential deadlock detected"}`), "excluded")
+	require.Error(t, v.Validate(`{"msg":"panic: nil map write"}`), "included, not excluded")
+}
+
+func TestScanServerLogs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "server.log")
+	content := `{"level":"info","msg":"starting"}
+{"level":"error","msg":"failed assertion: shard closed","failed-assertion":true}
+{"level":"error","msg":"failed assertion: found otherHasTasks in classic metadata","failed-assertion":true}
+{"level":"info","msg":"panic recovered: Potential deadlock detected"}
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+	// Only the un-excluded soft assertion on line 2 should be reported.
+	mock := &mockT{}
+	scanLogFile(mock, serverLogValidators, path)
+	require.Equal(t, 1, mock.errors, "expected exactly one flagged line")
+}
+
+// mockT captures Errorf calls so we can assert on validation hits without
+// failing the real test.
+type mockT struct {
+	testing.TB
+	errors int
+}
+
+func (m *mockT) Errorf(string, ...any) { m.errors++ }
+func (m *mockT) Helper()               {}

--- a/tests/mixedbrain/log_scan_util_test.go
+++ b/tests/mixedbrain/log_scan_util_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestSubstringValidator(t *testing.T) {
+	t.Parallel()
 	v := substringValidator{
 		name:    "panic",
 		include: "panic",
@@ -21,6 +22,7 @@ func TestSubstringValidator(t *testing.T) {
 }
 
 func TestScanServerLogs(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "server.log")
 	content := `{"level":"info","msg":"starting"}

--- a/tests/mixedbrain/mixed_brain_test.go
+++ b/tests/mixedbrain/mixed_brain_test.go
@@ -39,8 +39,9 @@ func logDir(t *testing.T) string {
 }
 
 // TestMixedBrain starts two servers in parallel, one using the current branch's binary
-// and the other using the latest release binary. It then runs Omes throughput_stress
-// to ensure that the mixed brain works correctly.
+// and the other using the latest release binary. It then runs the Omes
+// throughput_stress and scheduler_stress scenarios to ensure that the mixed
+// brain works correctly.
 // Uses SQLite locally; and a dedicated database in CI for better concurrency.
 func TestMixedBrain(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -49,6 +50,9 @@ func TestMixedBrain(t *testing.T) {
 	currentBinary := filepath.Join(tmpDir, "temporal-server-current")
 	releaseBinary := filepath.Join(tmpDir, "temporal-server-release")
 	omesBinary := filepath.Join(tmpDir, "omes-bin")
+
+	currentLog := filepath.Join(logRoot, "mixedbrain_process-current.log")
+	releaseLog := filepath.Join(logRoot, "mixedbrain_process-release.log")
 
 	t.Run("setup", func(t *testing.T) {
 		t.Run("build current server", func(t *testing.T) {
@@ -86,16 +90,24 @@ func TestMixedBrain(t *testing.T) {
 	runID := fmt.Sprintf("mixed-brain-%d", time.Now().Unix())
 	nexusEndpoint := "mixed-brain-nexus"
 
+	// Each scenario runs in its own namespace so the concurrent scenarios stay
+	// isolated. The Nexus endpoint lives in the throughput_stress namespace.
+	const throughputNamespace = "throughput-stress"
+	const schedulerNamespace = "scheduler-stress"
+
 	t.Run("start current server", func(st *testing.T) {
 		// Server processes use the parent t so their context survives this sub-test.
-		procCurrent = startServerProcess(t, "current", currentBinary, configCurrent, filepath.Join(logRoot, "mixedbrain_process-current.log"))
+		procCurrent = startServerProcess(t, "current", currentBinary, configCurrent, currentLog)
 
 		var err error
 		conn, err = grpc.NewClient(portsCurrent.frontendAddr(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 		require.NoError(st, err)
 
 		// This ensures the current server is fully booted before starting the release server.
-		registerDefaultNamespace(st, conn)
+		// Both namespaces are registered here so they have the full cluster-formation
+		// window to propagate to all services before Omes connects.
+		registerNamespace(st, conn, throughputNamespace)
+		registerNamespace(st, conn, schedulerNamespace)
 	})
 	if t.Failed() {
 		return
@@ -104,7 +116,7 @@ func TestMixedBrain(t *testing.T) {
 	defer func() { _ = conn.Close() }()
 
 	t.Run("start release server", func(_ *testing.T) {
-		procRelease = startServerProcess(t, "release", releaseBinary, configRelease, filepath.Join(logRoot, "mixedbrain_process-release.log"))
+		procRelease = startServerProcess(t, "release", releaseBinary, configRelease, releaseLog)
 	})
 	if t.Failed() {
 		return
@@ -119,11 +131,38 @@ func TestMixedBrain(t *testing.T) {
 	}
 
 	t.Run("run omes", func(st *testing.T) {
-		createNexusEndpoint(st, conn, nexusEndpoint, "default", "omes-"+runID)
+		createNexusEndpoint(st, conn, nexusEndpoint, throughputNamespace, "omes-"+runID)
 
 		proxy = startFrontendProxy(st, portsCurrent.frontendAddr(), portsRelease.frontendAddr())
 
-		runOmes(st, omesBinary, proxy.addr(), filepath.Join(logRoot, "mixedbrain_omes.log"), testDuration(), runID, nexusEndpoint)
+		// Both scenarios run concurrently against the same proxy for the full test
+		// duration, each in its own namespace (and with a distinct run ID / task
+		// queue) so their load stays isolated while both exercise the mixed cluster.
+		scenarios := []omesScenario{
+			{
+				name:      "throughput_stress",
+				namespace: throughputNamespace,
+				runID:     runID,
+				options: []string{
+					"internal-iterations=10",
+					"nexus-endpoint=" + nexusEndpoint,
+				},
+			},
+			{
+				// scheduler_stress needs no Nexus endpoint or search attributes; the
+				// chasm-scheduler experiment is left at its scenario default (on).
+				name:      "scheduler_stress",
+				namespace: schedulerNamespace,
+				runID:     runID + "-scheduler",
+			},
+		}
+		for _, scenario := range scenarios {
+			st.Run(scenario.name, func(sst *testing.T) {
+				sst.Parallel()
+				logPath := filepath.Join(logRoot, "mixedbrain_omes_"+scenario.name+".log")
+				runOmes(sst, omesBinary, proxy.addr(), logPath, testDuration(), scenario)
+			})
+		}
 	})
 	if t.Failed() {
 		return
@@ -140,14 +179,34 @@ func TestMixedBrain(t *testing.T) {
 			require.Positive(st, count, "expected proxy to route traffic to %s server", backend)
 		}
 	})
+
+	// Stop the servers so their logs are fully flushed, then scan them for
+	// panics, soft-assertion failures, and other problems that don't surface as
+	// a process exit. Runs regardless of whether "verify" failed, since a crashed
+	// server's log is exactly what we want to inspect.
+	procCurrent.stop()
+	procRelease.stop()
+
+	t.Run("scan server logs", func(st *testing.T) {
+		scanServerLogs(st, serverLogValidators, currentLog, releaseLog)
+	})
 }
 
-// runOmes runs Omes throughput stress scenario.
+// omesScenario describes a single Omes scenario invocation for the mixed brain test.
+type omesScenario struct {
+	name      string
+	namespace string
+	runID     string
+	// options are extra "key=value" pairs passed as --option flags.
+	options []string
+}
+
+// runOmes runs the given Omes scenario against serverAddr.
 // Retries if Omes fails due to search attribute not being ready yet.
 // Deducts elapsed time from duration on retry so total wall time stays bounded.
-func runOmes(t *testing.T, binary, serverAddr, logPath string, duration time.Duration, runID, nexusEndpoint string) {
+func runOmes(t *testing.T, binary, serverAddr, logPath string, duration time.Duration, scenario omesScenario) {
 	t.Helper()
-	t.Logf("Running Omes throughput_stress for %v against %s", duration, serverAddr)
+	t.Logf("Running Omes %s for %v against %s", scenario.name, duration, serverAddr)
 
 	started := time.Now()
 	for {
@@ -157,19 +216,23 @@ func runOmes(t *testing.T, binary, serverAddr, logPath string, duration time.Dur
 		logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 		require.NoError(t, err)
 
-		var buf bytes.Buffer
-		cmd := exec.CommandContext(t.Context(), binary,
+		args := []string{
 			"run-scenario-with-worker",
-			"--scenario", "throughput_stress",
+			"--scenario", scenario.name,
 			"--language", "go",
 			"--server-address", serverAddr,
+			"--namespace", scenario.namespace,
 			"--duration", remaining.String(),
 			"--timeout", (remaining + 2*time.Minute).String(), // with grace period to complete
-			"--run-id", runID,
+			"--run-id", scenario.runID,
 			"--max-concurrent", "5",
-			"--option", "internal-iterations=10",
-			"--option", "nexus-endpoint="+nexusEndpoint,
-		)
+		}
+		for _, opt := range scenario.options {
+			args = append(args, "--option", opt)
+		}
+
+		var buf bytes.Buffer
+		cmd := exec.CommandContext(t.Context(), binary, args...)
 		cmd.Stdout = logFile
 		cmd.Stderr = io.MultiWriter(logFile, &buf)
 		cmd.Cancel = func() error { return cmd.Process.Signal(syscall.SIGTERM) }

--- a/tests/mixedbrain/mixed_brain_test.go
+++ b/tests/mixedbrain/mixed_brain_test.go
@@ -188,7 +188,11 @@ func TestMixedBrain(t *testing.T) {
 	procRelease.stop()
 
 	t.Run("scan server logs", func(st *testing.T) {
-		scanServerLogs(st, serverLogValidators, currentLog, releaseLog)
+		problems, err := scanServerLogs(serverLogValidators, currentLog, releaseLog)
+		require.NoError(st, err)
+		for _, p := range problems {
+			st.Error(p)
+		}
 	})
 }
 

--- a/tests/mixedbrain/mixed_brain_test.go
+++ b/tests/mixedbrain/mixed_brain_test.go
@@ -38,6 +38,37 @@ func logDir(t *testing.T) string {
 	return dir
 }
 
+// nexusEndpoint is created in the throughput_stress namespace before Omes runs.
+const nexusEndpoint = "mixed-brain-nexus"
+
+// omesScenario describes a single Omes scenario invocation for the mixed brain test.
+type omesScenario struct {
+	name      string
+	namespace string
+	// options are extra "key=value" pairs passed as --option flags.
+	options []string
+}
+
+// scenarios are the Omes scenarios run concurrently against the mixed cluster,
+// each in its own namespace (and, at runtime, its own run ID / task queue) so
+// their load stays isolated while both exercise the mixed-version cluster.
+var scenarios = []omesScenario{
+	{
+		name:      "throughput_stress",
+		namespace: "throughput-stress",
+		options: []string{
+			"internal-iterations=10",
+			"nexus-endpoint=" + nexusEndpoint,
+		},
+	},
+	{
+		// scheduler_stress needs no Nexus endpoint or search attributes;
+		// chasm-scheduler is left at its scenario default (on).
+		name:      "scheduler_stress",
+		namespace: "scheduler-stress",
+	},
+}
+
 // TestMixedBrain starts two servers in parallel, one using the current branch's binary
 // and the other using the latest release binary. It then runs the Omes
 // throughput_stress and scheduler_stress scenarios to ensure that the mixed
@@ -88,12 +119,6 @@ func TestMixedBrain(t *testing.T) {
 	var conn *grpc.ClientConn
 	var proxy *frontendProxy
 	runID := fmt.Sprintf("mixed-brain-%d", time.Now().Unix())
-	nexusEndpoint := "mixed-brain-nexus"
-
-	// Each scenario runs in its own namespace so the concurrent scenarios stay
-	// isolated. The Nexus endpoint lives in the throughput_stress namespace.
-	const throughputNamespace = "throughput-stress"
-	const schedulerNamespace = "scheduler-stress"
 
 	t.Run("start current server", func(st *testing.T) {
 		// Server processes use the parent t so their context survives this sub-test.
@@ -103,11 +128,12 @@ func TestMixedBrain(t *testing.T) {
 		conn, err = grpc.NewClient(portsCurrent.frontendAddr(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 		require.NoError(st, err)
 
-		// This ensures the current server is fully booted before starting the release server.
-		// Both namespaces are registered here so they have the full cluster-formation
-		// window to propagate to all services before Omes connects.
-		registerNamespace(st, conn, throughputNamespace)
-		registerNamespace(st, conn, schedulerNamespace)
+		// This ensures the current server is fully booted before starting the release
+		// server. Registering every scenario's namespace here gives them the full
+		// cluster-formation window to propagate to all services before Omes connects.
+		for _, s := range scenarios {
+			registerNamespace(st, conn, s.namespace)
+		}
 	})
 	if t.Failed() {
 		return
@@ -131,36 +157,18 @@ func TestMixedBrain(t *testing.T) {
 	}
 
 	t.Run("run omes", func(st *testing.T) {
-		createNexusEndpoint(st, conn, nexusEndpoint, throughputNamespace, "omes-"+runID)
+		// The scenario's run ID determines its task queue (omes-<run ID>).
+		// throughput_stress owns the Nexus endpoint, so target its task queue.
+		throughput := scenarios[0]
+		createNexusEndpoint(st, conn, nexusEndpoint, throughput.namespace, "omes-"+runID+"-"+throughput.name)
 
 		proxy = startFrontendProxy(st, portsCurrent.frontendAddr(), portsRelease.frontendAddr())
 
-		// Both scenarios run concurrently against the same proxy for the full test
-		// duration, each in its own namespace (and with a distinct run ID / task
-		// queue) so their load stays isolated while both exercise the mixed cluster.
-		scenarios := []omesScenario{
-			{
-				name:      "throughput_stress",
-				namespace: throughputNamespace,
-				runID:     runID,
-				options: []string{
-					"internal-iterations=10",
-					"nexus-endpoint=" + nexusEndpoint,
-				},
-			},
-			{
-				// scheduler_stress needs no Nexus endpoint or search attributes; the
-				// chasm-scheduler experiment is left at its scenario default (on).
-				name:      "scheduler_stress",
-				namespace: schedulerNamespace,
-				runID:     runID + "-scheduler",
-			},
-		}
 		for _, scenario := range scenarios {
 			st.Run(scenario.name, func(sst *testing.T) {
 				sst.Parallel()
 				logPath := filepath.Join(logRoot, "mixedbrain_omes_"+scenario.name+".log")
-				runOmes(sst, omesBinary, proxy.addr(), logPath, testDuration(), scenario)
+				runOmes(sst, omesBinary, proxy.addr(), logPath, testDuration(), scenario, runID+"-"+scenario.name)
 			})
 		}
 	})
@@ -196,19 +204,10 @@ func TestMixedBrain(t *testing.T) {
 	})
 }
 
-// omesScenario describes a single Omes scenario invocation for the mixed brain test.
-type omesScenario struct {
-	name      string
-	namespace string
-	runID     string
-	// options are extra "key=value" pairs passed as --option flags.
-	options []string
-}
-
-// runOmes runs the given Omes scenario against serverAddr.
+// runOmes runs the given Omes scenario against serverAddr under the given run ID.
 // Retries if Omes fails due to search attribute not being ready yet.
 // Deducts elapsed time from duration on retry so total wall time stays bounded.
-func runOmes(t *testing.T, binary, serverAddr, logPath string, duration time.Duration, scenario omesScenario) {
+func runOmes(t *testing.T, binary, serverAddr, logPath string, duration time.Duration, scenario omesScenario, runID string) {
 	t.Helper()
 	t.Logf("Running Omes %s for %v against %s", scenario.name, duration, serverAddr)
 
@@ -228,7 +227,7 @@ func runOmes(t *testing.T, binary, serverAddr, logPath string, duration time.Dur
 			"--namespace", scenario.namespace,
 			"--duration", remaining.String(),
 			"--timeout", (remaining + 2*time.Minute).String(), // with grace period to complete
-			"--run-id", scenario.runID,
+			"--run-id", runID,
 			"--max-concurrent", "5",
 		}
 		for _, opt := range scenario.options {

--- a/tests/mixedbrain/server_util.go
+++ b/tests/mixedbrain/server_util.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -22,12 +23,13 @@ import (
 )
 
 type serverProcess struct {
-	name    string
-	cmd     *exec.Cmd
-	cancel  context.CancelFunc
-	logFile *os.File
-	logPath string
-	done    chan error
+	name     string
+	cmd      *exec.Cmd
+	cancel   context.CancelFunc
+	logFile  *os.File
+	logPath  string
+	done     chan error
+	stopOnce sync.Once
 }
 
 func startServerProcess(t *testing.T, name, binary, configDir, logPath string) *serverProcess {
@@ -65,10 +67,13 @@ func startServerProcess(t *testing.T, name, binary, configDir, logPath string) *
 	}
 }
 
+// stop is idempotent: it may be called explicitly and again via t.Cleanup.
 func (p *serverProcess) stop() {
-	p.cancel()
-	<-p.done
-	_ = p.logFile.Close()
+	p.stopOnce.Do(func() {
+		p.cancel()
+		<-p.done
+		_ = p.logFile.Close()
+	})
 }
 
 func (p *serverProcess) requireAlive(t *testing.T) {
@@ -81,14 +86,14 @@ func (p *serverProcess) requireAlive(t *testing.T) {
 	}
 }
 
-func registerDefaultNamespace(t *testing.T, conn *grpc.ClientConn) {
+func registerNamespace(t *testing.T, conn *grpc.ClientConn, namespace string) {
 	t.Helper()
 
 	client := workflowservice.NewWorkflowServiceClient(conn)
 
 	require.Eventually(t, func() bool {
 		_, err := client.RegisterNamespace(t.Context(), &workflowservice.RegisterNamespaceRequest{
-			Namespace:                        "default",
+			Namespace:                        namespace,
 			WorkflowExecutionRetentionPeriod: durationpb.New(24 * time.Hour),
 		})
 		if err == nil {
@@ -96,7 +101,7 @@ func registerDefaultNamespace(t *testing.T, conn *grpc.ClientConn) {
 		}
 		st, ok := status.FromError(err)
 		return ok && st.Code() == codes.AlreadyExists
-	}, retryTimeout, time.Second, "failed to register default namespace")
+	}, retryTimeout, time.Second, "failed to register namespace %s", namespace)
 }
 
 func createNexusEndpoint(t *testing.T, conn *grpc.ClientConn, endpointName, namespace, taskQueue string) {


### PR DESCRIPTION
Adds the `scheduler_stress` Omes scenario to the mixed brain test, and scans both server logs for panics and soft-assertion failures after the run.

Worth calling out (not obvious from the diff):
- Both scenarios run **concurrently**, each in its own namespace, through the shared proxy. Roughly doubles peak cluster load - watch the memory snapshot on the arm runner.
- `enable-chasm-scheduler` is left at its default (on).
- The log scan is the main pass/fail signal for `scheduler_stress`, which swallows its own operation errors. The panic/assertion exclude lists are a starting point and may need tuning after a real CI run.