### PR TITLE
Fix review workflow 

### DIFF
--- a/.github/workflows/claude-review-teams.yml
+++ b/.github/workflows/claude-review-teams.yml
@@ -147,6 +147,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -157,4 +158,3 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          mode: review

--- a/.github/workflows/claude-review-teams.yml
+++ b/.github/workflows/claude-review-teams.yml
@@ -163,6 +163,9 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ needs.check-review-eligibility.outputs.pr_number }}
 
+            Before reviewing, read `.claude/skills/review/SKILL.md` and apply it as the review skill.
+            Follow any referenced project instructions from that skill, including `.github/copilot-instructions.md`.
+
             Please review this pull request with a focus on:
             - Code quality and best practices
             - Potential bugs or issues
@@ -174,4 +177,4 @@ jobs:
             Use `mcp__github_inline_comment__create_inline_comment` with `confirmed: true` to highlight specific code issues.
             Only post GitHub comments - don't submit review text as messages.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-review-teams.yml
+++ b/.github/workflows/claude-review-teams.yml
@@ -40,8 +40,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
-          private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
+          app-id: ${{ secrets.TEMPORAL_CLAUDE_REVIEW_APP_ID }}
+          private-key: ${{ secrets.TEMPORAL_CLAUDE_REVIEW_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           # Least-privilege: members:read for team-membership lookups,
           # pull-requests:read for the workflow_dispatch PR lookup, and

--- a/.github/workflows/claude-review-teams.yml
+++ b/.github/workflows/claude-review-teams.yml
@@ -159,6 +159,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ needs.check-review-eligibility.outputs.pr_number }}

--- a/.github/workflows/claude-review-teams.yml
+++ b/.github/workflows/claude-review-teams.yml
@@ -161,19 +161,9 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ needs.check-review-eligibility.outputs.pr_number }}
-
-            Before reviewing, read `.claude/skills/review/SKILL.md` and apply it as the review skill.
-            Follow any referenced project instructions from that skill, including `.github/copilot-instructions.md`.
-
-            Please review this pull request with a focus on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Security implications
-            - Performance considerations
-
-            Note: The PR branch is already checked out in the current working directory.
+            Use `.claude/skills/review/SKILL.md` and apply it as the review skill.
+            Please review this pull request.
+            The PR branch is already checked out in the current working directory.
             Use `gh pr comment` for top-level feedback.
             Use `mcp__github_inline_comment__create_inline_comment` with `confirmed: true` to highlight specific code issues.
             Only post GitHub comments - don't submit review text as messages.

--- a/.github/workflows/claude-review-teams.yml
+++ b/.github/workflows/claude-review-teams.yml
@@ -35,6 +35,7 @@ jobs:
     outputs:
       should_review: ${{ steps.decision.outputs.should_review }}
       head_sha: ${{ steps.resolve.outputs.head_sha }}
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
     steps:
       - name: Generate app token
         id: generate_token
@@ -158,3 +159,19 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ needs.check-review-eligibility.outputs.pr_number }}
+
+            Please review this pull request with a focus on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Security implications
+            - Performance considerations
+
+            Note: The PR branch is already checked out in the current working directory.
+            Use `gh pr comment` for top-level feedback.
+            Use `mcp__github_inline_comment__create_inline_comment` with `confirmed: true` to highlight specific code issues.
+            Only post GitHub comments - don't submit review text as messages.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-review-teams.yml
+++ b/.github/workflows/claude-review-teams.yml
@@ -40,8 +40,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.TEMPORAL_CLAUDE_REVIEW_APP_ID }}
-          private-key: ${{ secrets.TEMPORAL_CLAUDE_REVIEW_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.TEMPORAL_AI_REVIEW_APP_ID }}
+          private-key: ${{ secrets.TEMPORAL_AI_REVIEW_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           # Least-privilege: members:read for team-membership lookups,
           # pull-requests:read for the workflow_dispatch PR lookup, and


### PR DESCRIPTION
WISOTT

Cannot be tested without merging as Claude GHA refuses to run:
```
Skipping action due to workflow validation: Workflow validation failed.
  The workflow file must exist and have identical content to the version on the
  repository's default branch.
```

Example: https://github.com/temporalio/temporal/actions/runs/28825475195/job/85487455156