### PR TITLE
[Scheduler] Add metric and scheduleID tag for ignored completion callbacks

### DIFF
--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -566,6 +566,7 @@ func (s *Scheduler) HandleNexusCompletion(
 	info *persistencespb.ChasmNexusCompletion,
 ) error {
 	invoker := s.Invoker.Get(ctx)
+	metricsHandler := newTaggedMetricsHandler(ctx.MetricsHandler(), s)
 
 	workflowID := invoker.runningWorkflowID(info.RequestId)
 	if workflowID == "" {
@@ -574,7 +575,10 @@ func (s *Scheduler) HandleNexusCompletion(
 		msg := "handled Nexus completion with an unrecognized request ID"
 		s.getOrCreateEventLog(ctx).LogEvent(ctx,
 			fmt.Sprintf("%s: %s", msg, info.RequestId))
-		ctx.Logger().Warn(msg, tag.RequestID(info.RequestId))
+		ctx.Logger().Warn(msg,
+			tag.RequestID(info.RequestId),
+			tag.ScheduleID(s.ScheduleId))
+		metricsHandler.Counter(metrics.ScheduleCallbackIgnored.Name()).Record(1)
 		return nil
 	}
 
@@ -583,9 +587,7 @@ func (s *Scheduler) HandleNexusCompletion(
 	// and clamp to zero in case of clock skew.
 	if closeTime := info.GetCloseTime().AsTime(); !closeTime.IsZero() {
 		latency := max(0, ctx.Now(s).Sub(closeTime))
-		newTaggedMetricsHandler(ctx.MetricsHandler(), s).
-			Timer(metrics.ScheduleCallbackLatency.Name()).
-			Record(latency)
+		metricsHandler.Timer(metrics.ScheduleCallbackLatency.Name()).Record(latency)
 	}
 
 	// Handle last completed/failed status and payloads.

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1549,6 +1549,10 @@ var (
 		"schedule_callback_latency",
 		WithDescription("Latency between a scheduled action completing and the scheduler receiving the completion callback"),
 	)
+	ScheduleCallbackIgnored = NewCounterDef(
+		"schedule_callback_ignored",
+		WithDescription("Scheduler received a completion callback unassociated with any known running actions"),
+	)
 
 	// Worker Versioning
 	WorkerDeploymentCreated                           = NewCounterDef("worker_deployment_created")


### PR DESCRIPTION
## What changed?
- Added a metric on dropped callbacks

## Why?
- ScheduleID log line will help us quicker identify schedules dropping completion callbacks
- Need to be able to alert on this, absent logscans
