### PR TITLE
wire in time-skipping config implementation for chasm (1)

### DIFF
--- a/chasm/context.go
+++ b/chasm/context.go
@@ -283,6 +283,10 @@ func (c *mutableCtx) withValue(key any, value any) Context {
 	}
 }
 
+func (c *mutableCtx) SetTimeSkippingConfig(config *commonpb.TimeSkippingConfig) {
+	c.root.backend.SetTimeSkippingConfig(config)
+}
+
 // ContextWithValue returns a new Context with the given key-value pair added.
 // Added key-value pairs will be accessible via the Value() method on the returned Context,
 // and the behavior of the key-value pair is the same as context.Context.WithValue().

--- a/chasm/context_mock.go
+++ b/chasm/context_mock.go
@@ -187,6 +187,7 @@ type MockMutableContext struct {
 	Tasks                   []MockTask
 	LinksByRequest          map[Component]map[string][]*commonpb.Link
 	UserMetadataByComponent map[Component]*sdkpb.UserMetadata
+	TimeSkippingConfig      *commonpb.TimeSkippingConfig
 }
 
 func (c *MockMutableContext) AddTask(component Component, attributes TaskAttributes, payload any) {
@@ -229,6 +230,12 @@ func (c *MockMutableContext) withValue(key any, value any) Context {
 		MockContext: *ContextWithValue(&c.MockContext, key, value),
 		Tasks:       slices.Clone(c.Tasks),
 	}
+}
+
+func (c *MockMutableContext) SetTimeSkippingConfig(config *commonpb.TimeSkippingConfig) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.TimeSkippingConfig = config
 }
 
 type MockTask struct {

--- a/chasm/node_backend_mock.go
+++ b/chasm/node_backend_mock.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -39,6 +40,7 @@ type MockNodeBackend struct {
 	HandleHasAnyBufferedEvent         func(filter func(*historypb.HistoryEvent) bool) bool
 	HandleGetNamespaceEntry           func() *namespace.Namespace
 	HandleEndpointRegistry            func() EndpointRegistry
+	HandleSetTimeSkippingConfig       func(config *commonpb.TimeSkippingConfig)
 
 	// Recorded calls (protected by mu).
 	mu                  sync.Mutex
@@ -251,4 +253,10 @@ func (m *MockNodeBackend) NumTasksAdded() int {
 		count += len(ts)
 	}
 	return count
+}
+
+func (m *MockNodeBackend) SetTimeSkippingConfig(config *commonpb.TimeSkippingConfig) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.HandleSetTimeSkippingConfig(config)
 }

--- a/chasm/timeskipping.go
+++ b/chasm/timeskipping.go
@@ -41,10 +41,7 @@ type TimeSkippingRuntimeGate interface {
 // =============================================================================
 // Time Skipping Data Structure
 // =============================================================================
-<<<<<<< HEAD
 
-=======
->>>>>>> ecc8e5e32 (add time skipping to chasm framework)
 type TimeSkippingTransition struct {
 	CurrentTime              time.Time
 	TargetTime               time.Time

--- a/chasm/timeskipping.go
+++ b/chasm/timeskipping.go
@@ -41,7 +41,10 @@ type TimeSkippingRuntimeGate interface {
 // =============================================================================
 // Time Skipping Data Structure
 // =============================================================================
+<<<<<<< HEAD
 
+=======
+>>>>>>> ecc8e5e32 (add time skipping to chasm framework)
 type TimeSkippingTransition struct {
 	CurrentTime              time.Time
 	TargetTime               time.Time

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -234,6 +234,7 @@ type (
 			requestID string,
 		) (nexusrpc.CompleteOperationOptions, error)
 		EndpointRegistry() EndpointRegistry
+		SetTimeSkippingConfig(config *commonpb.TimeSkippingConfig)
 	}
 
 	// NodePathEncoder is an interface for encoding and decoding node paths.

--- a/service/history/workflow/timeskipping.go
+++ b/service/history/workflow/timeskipping.go
@@ -62,6 +62,16 @@ func (ms *MutableStateImpl) updateTimeSkippingInfo(
 	return nil
 }
 
+func (ms *MutableStateImpl) SetTimeSkippingConfig(config *commonpb.TimeSkippingConfig) {
+	if ms.executionInfo.GetTimeSkippingInfo() == nil {
+		// init/update only return an error when their init-or-not precondition is violated,
+		// which the dispatch below already guarantees; the error is redundant here.
+		_ = ms.initTimeSkippingInfo(config, nil, 0)
+	} else {
+		_ = ms.updateTimeSkippingInfo(config, 0)
+	}
+}
+
 // applyFastForward (re)computes the FastForwardInfo using the new TimeSkippingConfig (TSC) and propagated time-skippingstates.
 // This method should be called whenever the TimeSkippingConfig is initialized or updated.
 // An invariant of the FastForwardInfo is that after this method is called, if the current TSC has a FastForward value,

--- a/service/history/workflow/timeskipping_test.go
+++ b/service/history/workflow/timeskipping_test.go
@@ -532,6 +532,43 @@ func (s *mutableStateSuite) TestUpdateTimeSkippingInfo() {
 	})
 }
 
+// TestSetTimeSkippingConfig verifies the dispatcher: a nil TimeSkippingInfo routes to the
+// init path (creating it), while an existing TimeSkippingInfo routes to the update path.
+func (s *mutableStateSuite) TestSetTimeSkippingConfig() {
+	s.Run("InitsWhenTimeSkippingInfoNil", func() {
+		s.mutableState.timeSource = clock.NewEventTimeSource()
+		s.mutableState.executionInfo.TimeSkippingInfo = nil
+		s.mutableState.timeSkippingInfoUpdated = false
+
+		cfg := &commonpb.TimeSkippingConfig{Enabled: true}
+		s.mutableState.SetTimeSkippingConfig(cfg)
+
+		tsi := s.mutableState.executionInfo.GetTimeSkippingInfo()
+		s.Require().NotNil(tsi, "nil TimeSkippingInfo must be initialized")
+		s.True(proto.Equal(cfg, tsi.GetConfig()))
+		s.True(s.mutableState.timeSkippingInfoUpdated)
+	})
+
+	s.Run("UpdatesWhenTimeSkippingInfoExists", func() {
+		s.mutableState.timeSource = clock.NewEventTimeSource()
+		s.mutableState.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
+			Config:                     &commonpb.TimeSkippingConfig{Enabled: false},
+			AccumulatedSkippedDuration: durationpb.New(time.Hour),
+		}
+		s.mutableState.timeSkippingInfoUpdated = false
+
+		newCfg := &commonpb.TimeSkippingConfig{Enabled: true}
+		s.mutableState.SetTimeSkippingConfig(newCfg)
+
+		tsi := s.mutableState.executionInfo.GetTimeSkippingInfo()
+		s.Require().NotNil(tsi)
+		s.True(proto.Equal(newCfg, tsi.GetConfig()), "config must be replaced in place")
+		s.Equal(time.Hour, tsi.GetAccumulatedSkippedDuration().AsDuration(),
+			"update must preserve accumulated skipped duration")
+		s.True(s.mutableState.timeSkippingInfoUpdated)
+	})
+}
+
 // TestWrapExecutionTimes covers the three invariants of wrapExecutionTimes:
 // a nil/zero skipped duration is a no-op; a non-zero duration shifts every *set*
 // execution timestamp forward by exactly that duration; unset timestamps stay unset.


### PR DESCRIPTION
## What changed?
wire in time-skipping config implementation

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

