### PR TITLE
Add xdc-redirection-source-cell header on redirected RPCs

### DIFF
--- a/chasm/lib/nexusoperation/config.go
+++ b/chasm/lib/nexusoperation/config.go
@@ -115,7 +115,8 @@ var DisallowedOperationHeaders = dynamicconfig.NewGlobalTypedSettingWithConverte
 	},
 	[]string{
 		"request-timeout",
-		interceptor.DCRedirectionApiHeaderName,
+		interceptor.DCRedirectionAPIHeaderName,
+		interceptor.DCRedirectionSourceCellHeaderName,
 		interceptor.DCRedirectionContextHeaderName,
 		headers.CallerNameHeaderName,
 		headers.CallerTypeHeaderName,

--- a/common/rpc/interceptor/redirection.go
+++ b/common/rpc/interceptor/redirection.go
@@ -24,9 +24,10 @@ import (
 // Note the nexusoperations component references these headers and adds them to a list of disallowed headers for users to set.
 // If any other headers are added for internal use, they should be added to the disallowed headers list.
 const (
-	DCRedirectionContextHeaderName = "xdc-redirection"
-	DCRedirectionApiHeaderName     = "xdc-redirection-api"
-	dcRedirectionMetricsPrefix     = "DCRedirection"
+	DCRedirectionContextHeaderName    = "xdc-redirection"
+	DCRedirectionAPIHeaderName        = "xdc-redirection-api"
+	DCRedirectionSourceCellHeaderName = "xdc-redirection-source-cell"
+	dcRedirectionMetricsPrefix        = "DCRedirection"
 )
 
 var (
@@ -290,7 +291,8 @@ func (i *Redirection) handleRedirectAPIInvocation(
 				return err
 			}
 			resp = respCtorFn()
-			ctx = metadata.AppendToOutgoingContext(ctx, DCRedirectionApiHeaderName, "true")
+			ctx = metadata.AppendToOutgoingContext(ctx, DCRedirectionAPIHeaderName, "true")
+			ctx = metadata.AppendToOutgoingContext(ctx, DCRedirectionSourceCellHeaderName, i.currentClusterName)
 			err = remoteClient.Invoke(ctx, info.FullMethod, req, resp)
 			if err != nil {
 				return err

--- a/components/nexusoperations/config.go
+++ b/components/nexusoperations/config.go
@@ -102,7 +102,8 @@ var DisallowedOperationHeaders = dynamicconfig.NewGlobalTypedSettingWithConverte
 	},
 	[]string{
 		"request-timeout",
-		interceptor.DCRedirectionApiHeaderName,
+		interceptor.DCRedirectionAPIHeaderName,
+		interceptor.DCRedirectionSourceCellHeaderName,
 		interceptor.DCRedirectionContextHeaderName,
 		headers.CallerNameHeaderName,
 		headers.CallerTypeHeaderName,

--- a/service/frontend/nexus_completion_http_handler.go
+++ b/service/frontend/nexus_completion_http_handler.go
@@ -381,7 +381,8 @@ func (h *nexusCompletionHandler) forwardCompleteOperation(ctx context.Context, r
 		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid operation state: %q", r.State)
 	}
 
-	rCtx.originalHeaders.Set(interceptor.DCRedirectionApiHeaderName, "true")
+	rCtx.originalHeaders.Set(interceptor.DCRedirectionAPIHeaderName, "true")
+	rCtx.originalHeaders.Set(interceptor.DCRedirectionSourceCellHeaderName, h.ClusterMetadata.GetCurrentClusterName())
 	cc := nexusrpc.NewCompletionHTTPClient(nexusrpc.CompletionHTTPClientOptions{
 		HTTPCaller: (&forwardingHTTPHeaderWrapper{
 			client:                 client,

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -592,7 +592,8 @@ func (h *nexusHandler) forwardStartOperation(
 	options nexus.StartOperationOptions,
 	oc *operationContext,
 ) (nexus.HandlerStartOperationResult[any], error) {
-	options.Header[interceptor.DCRedirectionApiHeaderName] = "true"
+	options.Header[interceptor.DCRedirectionAPIHeaderName] = "true"
+	options.Header[interceptor.DCRedirectionSourceCellHeaderName] = h.clusterMetadata.GetCurrentClusterName()
 
 	client, err := h.nexusClientForActiveCluster(oc, service)
 	if err != nil {
@@ -722,7 +723,8 @@ func (h *nexusHandler) forwardCancelOperation(
 	options nexus.CancelOperationOptions,
 	oc *operationContext,
 ) error {
-	options.Header[interceptor.DCRedirectionApiHeaderName] = "true"
+	options.Header[interceptor.DCRedirectionAPIHeaderName] = "true"
+	options.Header[interceptor.DCRedirectionSourceCellHeaderName] = h.clusterMetadata.GetCurrentClusterName()
 
 	client, err := h.nexusClientForActiveCluster(oc, service)
 	if err != nil {


### PR DESCRIPTION
## What changed

Adds a new gRPC metadata header, `xdc-redirection-source-cell`, that is stamped onto redirected API invocations in `common/rpc/interceptor/redirection.go`.

- New exported constant `DCRedirectionSourceCellHeaderName = "xdc-redirection-source-cell"` (in the shared header const block).
- In `handleRedirectAPIInvocation`, the forwarding cell appends its own cluster name (`i.currentClusterName`) to the outgoing context alongside the existing `xdc-redirection` / `xdc-redirection-api` headers, immediately before invoking the remote client.

Also renames the pre-existing `DCRedirectionApiHeaderName` → `DCRedirectionAPIHeaderName` (and its 5 references) to satisfy staticcheck ST1003 (Go initialisms), since adding the new const re-aligns the shared block and brings that line into scope.

## Why

The receiving (target) cell can read this header from incoming metadata to log where a redirected RPC originated, aiding cross-cell request tracing.

## Scope / risk

Additive observability plumbing plus a mechanical const rename. No routing behavior changes; the header is set but nothing in this change reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)