### PR TITLE
Route Nexus operation cancelation by owning tree across HSM/CHASM

### DIFF
--- a/chasm/lib/workflow/nexus_commands.go
+++ b/chasm/lib/workflow/nexus_commands.go
@@ -249,9 +249,9 @@ func (ch *nexusCommandHandler) handleCancelCommand(
 	// Route by the tree that owns the operation instead of the enableChasmWorkflowOperations flag: an operation's tree
 	// is fixed when it is scheduled and does not move when the flag is later flipped. The operation belongs to the
 	// CHASM tree if it is still present, or if a terminal event for it is buffered in this workflow. Otherwise, return
-	// ErrCommandNotSupported so the dispatcher falls back to the HSM command handler.
+	// ErrCommandTargetNotFound so the dispatcher falls back to the HSM command handler.
 	if !operationFound && !hasBufferedEvent() {
-		return ErrCommandNotSupported
+		return ErrCommandTargetNotFound
 	}
 
 	// Always create the event even if there's a buffered completion to avoid breaking replay in the SDK.

--- a/chasm/lib/workflow/nexus_commands.go
+++ b/chasm/lib/workflow/nexus_commands.go
@@ -233,11 +233,6 @@ func (ch *nexusCommandHandler) handleCancelCommand(
 	cmd *commandpb.Command,
 	opts CommandHandlerOptions,
 ) error {
-	nsName := ctx.NamespaceEntry().Name().String()
-	if !ch.config.EnableChasmNexusWorkflowOperations(nsName) {
-		return ErrCommandNotSupported
-	}
-
 	attrs := cmd.GetRequestCancelNexusOperationCommandAttributes()
 	if attrs == nil {
 		return FailWorkflowTaskError{
@@ -251,11 +246,12 @@ func (ch *nexusCommandHandler) handleCancelCommand(
 		return wf.HasAnyBufferedEvent(makeNexusOperationTerminalEventFilter(attrs.ScheduledEventId))
 	}
 
+	// Route by the tree that owns the operation instead of the enableChasmWorkflowOperations flag: an operation's tree
+	// is fixed when it is scheduled and does not move when the flag is later flipped. The operation belongs to the
+	// CHASM tree if it is still present, or if a terminal event for it is buffered in this workflow. Otherwise, return
+	// ErrCommandNotSupported so the dispatcher falls back to the HSM command handler.
 	if !operationFound && !hasBufferedEvent() {
-		return FailWorkflowTaskError{
-			Cause:   enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_REQUEST_CANCEL_NEXUS_OPERATION_ATTRIBUTES,
-			Message: fmt.Sprintf("requested cancelation for a non-existing or already completed operation with scheduled event ID of %d", attrs.ScheduledEventId),
-		}
+		return ErrCommandNotSupported
 	}
 
 	// Always create the event even if there's a buffered completion to avoid breaking replay in the SDK.

--- a/chasm/lib/workflow/nexus_commands_test.go
+++ b/chasm/lib/workflow/nexus_commands_test.go
@@ -650,31 +650,19 @@ func TestHandleCancelCommand(t *testing.T) {
 	})
 
 	t.Run("operation not in chasm tree defers to hsm", func(t *testing.T) {
-		// The operation is not in the CHASM tree (it lives in HSM, or does not exist). The handler must defer to the
-		// HSM command handler via ErrCommandNotSupported rather than failing the workflow task, so cancelation follows
-		// the tree that owns the operation.
-		for _, cfg := range []struct {
-			name   string
-			config *nexusoperation.Config
-		}{
-			{name: "flag on", config: defaultConfig},
-			{name: "flag off", config: &nexusoperation.Config{
-				EnableChasmNexusWorkflowOperations: dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
-			}},
-		} {
-			t.Run(cfg.name, func(t *testing.T) {
-				tcx := newTestContext(t, cfg.config)
-				err := tcx.cancelHandler(tcx.chasmCtx, tcx.wf, commandValidator{maxPayloadSize: 1}, &commandpb.Command{
-					Attributes: &commandpb.Command_RequestCancelNexusOperationCommandAttributes{
-						RequestCancelNexusOperationCommandAttributes: &commandpb.RequestCancelNexusOperationCommandAttributes{
-							ScheduledEventId: 5,
-						},
-					},
-				}, CommandHandlerOptions{WorkflowTaskCompletedEventID: 1})
-				require.ErrorIs(t, err, ErrCommandNotSupported)
-				require.Empty(t, tcx.history.Events)
-			})
-		}
+		// The operation is not in the CHASM tree (it lives in HSM, or does not exist) and no terminal event is
+		// buffered for it. The handler must defer to the HSM command handler via ErrCommandTargetNotFound rather than
+		// failing the workflow task, so cancelation follows the tree that owns the operation.
+		tcx := newTestContext(t, defaultConfig)
+		err := tcx.cancelHandler(tcx.chasmCtx, tcx.wf, commandValidator{maxPayloadSize: 1}, &commandpb.Command{
+			Attributes: &commandpb.Command_RequestCancelNexusOperationCommandAttributes{
+				RequestCancelNexusOperationCommandAttributes: &commandpb.RequestCancelNexusOperationCommandAttributes{
+					ScheduledEventId: 5,
+				},
+			},
+		}, CommandHandlerOptions{WorkflowTaskCompletedEventID: 1})
+		require.ErrorIs(t, err, ErrCommandTargetNotFound)
+		require.Empty(t, tcx.history.Events)
 	})
 
 	t.Run("operation already completed", func(t *testing.T) {
@@ -697,7 +685,7 @@ func TestHandleCancelCommand(t *testing.T) {
 		tcx.wf.removeNexusOperation(event.EventId)
 
 		// The operation is no longer in the CHASM tree, so the handler defers to the HSM command handler
-		// via ErrCommandNotSupported.
+		// via ErrCommandTargetNotFound.
 		err = tcx.cancelHandler(tcx.chasmCtx, tcx.wf, commandValidator{maxPayloadSize: 1}, &commandpb.Command{
 			Attributes: &commandpb.Command_RequestCancelNexusOperationCommandAttributes{
 				RequestCancelNexusOperationCommandAttributes: &commandpb.RequestCancelNexusOperationCommandAttributes{
@@ -705,7 +693,7 @@ func TestHandleCancelCommand(t *testing.T) {
 				},
 			},
 		}, CommandHandlerOptions{WorkflowTaskCompletedEventID: 1})
-		require.ErrorIs(t, err, ErrCommandNotSupported)
+		require.ErrorIs(t, err, ErrCommandTargetNotFound)
 		require.Len(t, tcx.history.Events, 1) // Only scheduled event should be recorded.
 	})
 

--- a/chasm/lib/workflow/nexus_commands_test.go
+++ b/chasm/lib/workflow/nexus_commands_test.go
@@ -639,15 +639,6 @@ func TestHandleScheduleCommand(t *testing.T) {
 }
 
 func TestHandleCancelCommand(t *testing.T) {
-	t.Run("chasm nexus not enabled", func(t *testing.T) {
-		tcx := newTestContext(t, &nexusoperation.Config{
-			EnableChasmNexusWorkflowOperations: dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
-		})
-		err := tcx.cancelHandler(tcx.chasmCtx, tcx.wf, commandValidator{maxPayloadSize: 1}, &commandpb.Command{}, CommandHandlerOptions{WorkflowTaskCompletedEventID: 1})
-		require.ErrorIs(t, err, ErrCommandNotSupported)
-		require.Empty(t, tcx.history.Events)
-	})
-
 	t.Run("empty attributes", func(t *testing.T) {
 		tcx := newTestContext(t, defaultConfig)
 		err := tcx.cancelHandler(tcx.chasmCtx, tcx.wf, commandValidator{maxPayloadSize: 1}, &commandpb.Command{}, CommandHandlerOptions{WorkflowTaskCompletedEventID: 1})
@@ -658,21 +649,32 @@ func TestHandleCancelCommand(t *testing.T) {
 		require.Empty(t, tcx.history.Events)
 	})
 
-	t.Run("operation not found", func(t *testing.T) {
-		tcx := newTestContext(t, defaultConfig)
-
-		err := tcx.cancelHandler(tcx.chasmCtx, tcx.wf, commandValidator{maxPayloadSize: 1}, &commandpb.Command{
-			Attributes: &commandpb.Command_RequestCancelNexusOperationCommandAttributes{
-				RequestCancelNexusOperationCommandAttributes: &commandpb.RequestCancelNexusOperationCommandAttributes{
-					ScheduledEventId: 5,
-				},
-			},
-		}, CommandHandlerOptions{WorkflowTaskCompletedEventID: 1})
-		var failWFTErr FailWorkflowTaskError
-		require.ErrorAs(t, err, &failWFTErr)
-		require.False(t, failWFTErr.TerminateWorkflow)
-		require.Equal(t, enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_REQUEST_CANCEL_NEXUS_OPERATION_ATTRIBUTES, failWFTErr.Cause)
-		require.Empty(t, tcx.history.Events)
+	t.Run("operation not in chasm tree defers to hsm", func(t *testing.T) {
+		// The operation is not in the CHASM tree (it lives in HSM, or does not exist). The handler must defer to the
+		// HSM command handler via ErrCommandNotSupported rather than failing the workflow task, so cancelation follows
+		// the tree that owns the operation.
+		for _, cfg := range []struct {
+			name   string
+			config *nexusoperation.Config
+		}{
+			{name: "flag on", config: defaultConfig},
+			{name: "flag off", config: &nexusoperation.Config{
+				EnableChasmNexusWorkflowOperations: dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+			}},
+		} {
+			t.Run(cfg.name, func(t *testing.T) {
+				tcx := newTestContext(t, cfg.config)
+				err := tcx.cancelHandler(tcx.chasmCtx, tcx.wf, commandValidator{maxPayloadSize: 1}, &commandpb.Command{
+					Attributes: &commandpb.Command_RequestCancelNexusOperationCommandAttributes{
+						RequestCancelNexusOperationCommandAttributes: &commandpb.RequestCancelNexusOperationCommandAttributes{
+							ScheduledEventId: 5,
+						},
+					},
+				}, CommandHandlerOptions{WorkflowTaskCompletedEventID: 1})
+				require.ErrorIs(t, err, ErrCommandNotSupported)
+				require.Empty(t, tcx.history.Events)
+			})
+		}
 	})
 
 	t.Run("operation already completed", func(t *testing.T) {
@@ -694,7 +696,8 @@ func TestHandleCancelCommand(t *testing.T) {
 		// TODO: Complete the operation using CHASM equivalent of CompletedEventDefinition.
 		tcx.wf.removeNexusOperation(event.EventId)
 
-		// Try to cancel - should fail since operation is completed/deleted.
+		// The operation is no longer in the CHASM tree, so the handler defers to the HSM command handler
+		// via ErrCommandNotSupported.
 		err = tcx.cancelHandler(tcx.chasmCtx, tcx.wf, commandValidator{maxPayloadSize: 1}, &commandpb.Command{
 			Attributes: &commandpb.Command_RequestCancelNexusOperationCommandAttributes{
 				RequestCancelNexusOperationCommandAttributes: &commandpb.RequestCancelNexusOperationCommandAttributes{
@@ -702,10 +705,7 @@ func TestHandleCancelCommand(t *testing.T) {
 				},
 			},
 		}, CommandHandlerOptions{WorkflowTaskCompletedEventID: 1})
-		var failWFTErr FailWorkflowTaskError
-		require.ErrorAs(t, err, &failWFTErr)
-		require.False(t, failWFTErr.TerminateWorkflow)
-		require.Equal(t, enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_REQUEST_CANCEL_NEXUS_OPERATION_ATTRIBUTES, failWFTErr.Cause)
+		require.ErrorIs(t, err, ErrCommandNotSupported)
 		require.Len(t, tcx.history.Events, 1) // Only scheduled event should be recorded.
 	})
 

--- a/chasm/lib/workflow/registry.go
+++ b/chasm/lib/workflow/registry.go
@@ -100,6 +100,11 @@ func eventDefinitionByGoType[D EventDefinition](r *Registry) (D, bool) {
 // for example, because of a disabled feature flag.
 var ErrCommandNotSupported = errors.New("command not supported")
 
+// ErrCommandTargetNotFound is returned by a [CommandHandler] when the command type is supported but the entity it
+// targets is not owned by the CHASM tree (for example, a Nexus operation that lives in the HSM tree or no longer
+// exists). The dispatcher falls back to the HSM command handler so the command follows the tree that owns the entity.
+var ErrCommandTargetNotFound = errors.New("command target not found in chasm tree")
+
 type CommandHandlerOptions struct {
 	WorkflowTaskCompletedEventID int64
 }

--- a/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
+++ b/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
@@ -350,7 +350,11 @@ func (handler *workflowTaskCompletedHandler) handleCommand(
 					return nil, chasmErr
 				}
 				err = chasmHandler(chasmCtx, chasmWorkflow, validator, command, handlerOpts)
-				handledByCHASM = !errors.Is(err, chasmworkflow.ErrCommandNotSupported)
+				// Fall back to the HSM handler either when the command type is not supported by CHASM (disabled
+				// feature flag) or when the targeted entity is not owned by the CHASM tree (e.g. an operation
+				// scheduled in HSM before the flag was flipped on).
+				handledByCHASM = !errors.Is(err, chasmworkflow.ErrCommandNotSupported) &&
+					!errors.Is(err, chasmworkflow.ErrCommandTargetNotFound)
 			}
 		}
 		if !handledByCHASM {

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -306,83 +307,68 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancellationCrossTree(chasmEn
 			}
 			endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
 
+			// The caller schedules an async operation and waits for it to start. Once started flag is flipped and then
+			// the workflow is signaled to proceed with operation cancellation which runs against the opposite tree.
+			const awaitStartedUpdate = "await-started"
+			callerWF := func(ctx workflow.Context) error {
+				started := false
+				if err := workflow.SetUpdateHandler(ctx, awaitStartedUpdate, func(ctx workflow.Context) error {
+					return workflow.Await(ctx, func() bool { return started })
+				}); err != nil {
+					return err
+				}
+
+				c := workflow.NewNexusClient(endpointName, "service")
+				opCtx, cancelOperation := workflow.WithCancel(ctx)
+				fut := c.ExecuteOperation(opCtx, "operation", "input", workflow.NexusOperationOptions{})
+				var exec workflow.NexusOperationExecution
+				if err := fut.GetNexusOperationExecution().Get(ctx, &exec); err != nil {
+					return err
+				}
+				started = true
+
+				workflow.GetSignalChannel(ctx, "cancel").Receive(ctx, nil)
+				// cancels the operation's context, which is how the SDK emits a RequestCancelNexusOperation command.
+				cancelOperation()
+				return nil
+			}
+
+			w := worker.New(env.SdkClient(), taskQueue, worker.Options{})
+			w.RegisterWorkflow(callerWF)
+			s.NoError(w.Start())
+			defer w.Stop()
+
 			run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
-				TaskQueue:           taskQueue,
-				WorkflowTaskTimeout: time.Second,
-			}, "workflow")
+				TaskQueue: taskQueue,
+			}, callerWF)
 			s.NoError(err)
 
-			// Schedule the Nexus operation.
-			s.EventuallyWithT(func(t *assert.CollectT) {
-				pollResp, err := env.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
-					Namespace: env.Namespace().String(),
-					TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-					Identity:  "test",
-				})
-				require.NoError(t, err)
-				_, err = env.FrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
-					Identity:  "test",
-					TaskToken: pollResp.TaskToken,
-					Commands: []*commandpb.Command{
-						{
-							CommandType: enumspb.COMMAND_TYPE_SCHEDULE_NEXUS_OPERATION,
-							Attributes: &commandpb.Command_ScheduleNexusOperationCommandAttributes{
-								ScheduleNexusOperationCommandAttributes: &commandpb.ScheduleNexusOperationCommandAttributes{
-									Endpoint:  endpointName,
-									Service:   "service",
-									Operation: "operation",
-									Input:     testcore.MustToPayload(s.T(), "input"),
-								},
-							},
-						},
-					},
-				})
-				require.NoError(t, err)
-			}, time.Second*20, time.Millisecond*200)
-
-			// Wait for the operation to start, then capture its scheduled event ID.
-			pollResp, err := env.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
-				Namespace: env.Namespace().String(),
-				TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-				Identity:  "test",
+			// Block until the nexus operation has started.
+			startedHandle, err := env.SdkClient().UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
+				WorkflowID:   run.GetID(),
+				RunID:        run.GetRunID(),
+				UpdateName:   awaitStartedUpdate,
+				WaitForStage: client.WorkflowUpdateStageCompleted,
 			})
 			s.NoError(err)
-			s.RequireHistoryEvent(pollResp.History.Events, enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED)
-			scheduledEvent := s.RequireHistoryEvent(pollResp.History.Events, enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED)
+			s.NoError(startedHandle.Get(ctx, nil))
 
-			// Flip the flag before requesting cancellation.
+			// Verify the operation was actually created in the tree implied by the schedule-time flag.
+			s.assertNexusOperationTree(ctx, env, run.GetID(), !tc.enableChasmAtSchedule)
+
 			env.OverrideDynamicConfig(chasmnexus.EnableChasmWorkflowOperations, !tc.enableChasmAtSchedule)
-
-			_, err = env.FrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
-				Identity:  "test",
-				TaskToken: pollResp.TaskToken,
-				Commands: []*commandpb.Command{
-					{
-						CommandType: enumspb.COMMAND_TYPE_REQUEST_CANCEL_NEXUS_OPERATION,
-						Attributes: &commandpb.Command_RequestCancelNexusOperationCommandAttributes{
-							RequestCancelNexusOperationCommandAttributes: &commandpb.RequestCancelNexusOperationCommandAttributes{
-								ScheduledEventId: scheduledEvent.EventId,
-							},
-						},
-					},
-				},
-			})
-			s.NoError(err)
-
-			// The cancellation is recorded successfully regardless of the flag flip.
-			s.EventuallyWithT(func(t *assert.CollectT) {
-				hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{
-					WorkflowId: run.GetID(),
-					RunId:      run.GetRunID(),
-				})
-				historyrequire.New(t).RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED)
-			}, time.Second*20, time.Millisecond*200)
+			s.NoError(env.SdkClient().SignalWorkflow(ctx, run.GetID(), run.GetRunID(), "cancel", nil))
+			s.NoError(run.Get(ctx, nil))
+			hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: run.GetID()})
+			s.RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED)
+			s.RequireNoHistoryEvent(hist, enumspb.EVENT_TYPE_WORKFLOW_TASK_FAILED)
 		})
 	}
 }
 
-// TestNexusOperationCancellationBufferedCrossTree tests using an operation that lives in the HSM tree reaches a
-// terminal state whose completion event is buffered while a workflow task in flight requests cancellation.
+// TestNexusOperationCancellationBufferedCrossTree verifies that when an operation living in the HSM tree reaches a
+// terminal state whose completion event is buffered while a workflow task requesting cancellation is in flight, the
+// CHASM cancel handler records a no-op CancelRequested rather than failing the workflow task.
 func (s *NexusWorkflowTestSuite) TestNexusOperationCancellationBufferedCrossTree(chasmEnabled bool) {
 	// This test drives the creation-policy flag itself, so run it once (not per-suite-mode).
 	if chasmEnabled {
@@ -392,6 +378,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancellationBufferedCrossTree
 	env := s.newTestEnv(true)
 	ctx := env.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
+	// Schedule the operation in the HSM tree.
 	env.OverrideDynamicConfig(chasmnexus.EnableChasmWorkflowOperations, false)
 
 	var callbackToken, publicCallbackURL string
@@ -404,101 +391,107 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancellationBufferedCrossTree
 	}
 	endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
 
-	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
-		TaskQueue:           taskQueue,
-		WorkflowTaskTimeout: 20 * time.Second,
-	}, "workflow")
-	s.NoError(err)
-
-	// Schedule the Nexus operation (lands in the HSM tree).
-	s.EventuallyWithT(func(t *assert.CollectT) {
-		pollResp, err := env.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
-			Namespace: env.Namespace().String(),
-			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-			Identity:  "test",
+	// deliverCompletion is a local activity that delivers the async completion. Running it inside the cancellation
+	// workflow task keeps that task in flight while the completion is delivered, so the terminal event is buffered and
+	// not yet applied when the cancel command is processed.
+	deliverCompletion := func(ctx context.Context) error {
+		return s.sendNexusCompletionRequest(ctx, publicCallbackURL, nexusrpc.CompleteOperationOptions{
+			Result: testcore.MustToPayload(s.T(), "result"),
+			Header: nexus.Header{commonnexus.CallbackTokenHeader: callbackToken},
 		})
-		require.NoError(t, err)
-		_, err = env.FrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
-			Identity:  "test",
-			TaskToken: pollResp.TaskToken,
-			Commands: []*commandpb.Command{
-				{
-					CommandType: enumspb.COMMAND_TYPE_SCHEDULE_NEXUS_OPERATION,
-					Attributes: &commandpb.Command_ScheduleNexusOperationCommandAttributes{
-						ScheduleNexusOperationCommandAttributes: &commandpb.ScheduleNexusOperationCommandAttributes{
-							Endpoint:  endpointName,
-							Service:   "service",
-							Operation: "operation",
-							Input:     testcore.MustToPayload(s.T(), "input"),
-						},
-					},
-				},
-			},
-		})
-		require.NoError(t, err)
-	}, time.Second*20, time.Millisecond*200)
-
-	// Wait for the operation to start (async). The started event schedules the next workflow task.
-	s.EventuallyWithT(func(t *assert.CollectT) {
-		hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: run.GetID()})
-		historyrequire.New(t).RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED)
-	}, time.Second*20, time.Millisecond*200)
-
-	// Poll and hold the started-triggered workflow task without responding, so a workflow task is in flight.
-	pollResp, err := env.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
-		Namespace: env.Namespace().String(),
-		TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-		Identity:  "test",
-	})
-	s.NoError(err)
-	scheduledEvent := s.RequireHistoryEvent(pollResp.History.Events, enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED)
-
-	// Deliver the async completion while the workflow task is in flight, so the terminal event is buffered and is
-	// not yet applied when the cancellation command is processed.
-	completion := nexusrpc.CompleteOperationOptions{
-		Result: testcore.MustToPayload(s.T(), "result"),
-		Header: nexus.Header{commonnexus.CallbackTokenHeader: callbackToken},
 	}
-	s.NoError(s.sendNexusCompletionRequest(ctx, publicCallbackURL, completion))
 
-	// Complete the held workflow task with a cancel nexus operation command. The CHASM handler runs, the op is not in
-	// the CHASM tree but a terminal event is buffered, so it records a no-op CancelRequested rather than a failure.
-	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
-		Identity:  "test",
-		TaskToken: pollResp.TaskToken,
-		Commands: []*commandpb.Command{
-			{
-				CommandType: enumspb.COMMAND_TYPE_REQUEST_CANCEL_NEXUS_OPERATION,
-				Attributes: &commandpb.Command_RequestCancelNexusOperationCommandAttributes{
-					RequestCancelNexusOperationCommandAttributes: &commandpb.RequestCancelNexusOperationCommandAttributes{
-						ScheduledEventId: scheduledEvent.EventId,
-					},
-				},
-			},
-		},
-	})
+	// The caller starts an async operation and waits for it to start. When signaled, it buffers the operation's
+	//	completion and requests cancellation within the same workflow task.
+	const awaitStartedUpdate = "await-started"
+	callerWF := func(ctx workflow.Context) error {
+		started := false
+		if err := workflow.SetUpdateHandler(ctx, awaitStartedUpdate, func(ctx workflow.Context) error {
+			return workflow.Await(ctx, func() bool { return started })
+		}); err != nil {
+			return err
+		}
+
+		c := workflow.NewNexusClient(endpointName, "service")
+		opCtx, cancelOperation := workflow.WithCancel(ctx)
+		fut := c.ExecuteOperation(opCtx, "operation", "input", workflow.NexusOperationOptions{})
+		var exec workflow.NexusOperationExecution
+		if err := fut.GetNexusOperationExecution().Get(ctx, &exec); err != nil {
+			return err
+		}
+		started = true
+
+		workflow.GetSignalChannel(ctx, "cancel").Receive(ctx, nil)
+
+		laCtx := workflow.WithLocalActivityOptions(ctx, workflow.LocalActivityOptions{ScheduleToCloseTimeout: 10 * time.Second})
+		if err := workflow.ExecuteLocalActivity(laCtx, deliverCompletion).Get(ctx, nil); err != nil {
+			return err
+		}
+		cancelOperation()
+
+		_ = fut.Get(ctx, nil)
+		return nil
+	}
+
+	w := worker.New(env.SdkClient(), taskQueue, worker.Options{})
+	w.RegisterWorkflow(callerWF)
+	w.RegisterActivity(deliverCompletion)
+	s.NoError(w.Start())
+	defer w.Stop()
+
+	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		TaskQueue: taskQueue,
+	}, callerWF)
 	s.NoError(err)
 
-	// The cancellation is recorded and the operation completes via its buffered HSM completion.
-	s.EventuallyWithT(func(t *assert.CollectT) {
-		hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{
-			WorkflowId: run.GetID(),
-			RunId:      run.GetRunID(),
-		})
-		hr := historyrequire.New(t)
-		hr.RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED)
-		hr.RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED)
-	}, time.Second*20, time.Millisecond*200)
-
-	// The no-op cross-tree cancellation did not fail the workflow task.
-	hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{
-		WorkflowId: run.GetID(),
-		RunId:      run.GetRunID(),
+	// Block until the nexus operation has started.
+	startedHandle, err := env.SdkClient().UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
+		WorkflowID:   run.GetID(),
+		RunID:        run.GetRunID(),
+		UpdateName:   awaitStartedUpdate,
+		WaitForStage: client.WorkflowUpdateStageCompleted,
 	})
-	s.RequireNoHistoryEvent(hist, enumspb.EVENT_TYPE_WORKFLOW_TASK_FAILED)
+	s.NoError(err)
+	s.NoError(startedHandle.Get(ctx, nil))
 
-	// Terminate the manually driven workflow.
-	s.NoError(env.SdkClient().TerminateWorkflow(ctx, run.GetID(), run.GetRunID(), "test"))
+	// The operation was scheduled with the flag off, so it must live in the HSM tree.
+	s.assertNexusOperationTree(ctx, env, run.GetID(), true)
+
+	s.NoError(env.SdkClient().SignalWorkflow(ctx, run.GetID(), run.GetRunID(), "cancel", nil))
+
+	s.NoError(run.Get(ctx, nil))
+	hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: run.GetID()})
+	s.RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED)
+	s.RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED)
+	// The no-op cross-tree cancellation did not fail the workflow task.
+	s.RequireNoHistoryEvent(hist, enumspb.EVENT_TYPE_WORKFLOW_TASK_FAILED)
+}
+
+// assertNexusOperationTree asserts which tree the workflow's Nexus operation lives in, keyed by the operation's
+// scheduled event ID.
+func (s *NexusWorkflowTestSuite) assertNexusOperationTree(ctx context.Context, env *NexusTestEnv, workflowID string, expectHSM bool) {
+	s.T().Helper()
+	hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: workflowID})
+	scheduledEvent := s.RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED)
+	opID := strconv.FormatInt(scheduledEvent.EventId, 10)
+
+	desc, err := env.AdminClient().DescribeMutableState(ctx, &adminservice.DescribeMutableStateRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: workflowID},
+		Archetype: chasm.WorkflowArchetype,
+	})
+	s.NoError(err)
+	_, inHSM := desc.DatabaseMutableState.GetExecutionInfo().
+		GetSubStateMachinesByType()[nexusoperations.OperationMachineType].GetMachinesById()[opID]
+	_, inCHASM := desc.DatabaseMutableState.GetChasmNodes()["Operations#"+opID]
+
+	if expectHSM {
+		s.True(inHSM, "operation %s scheduled with the flag off should be an HSM sub-state-machine", opID)
+		s.False(inCHASM, "operation %s scheduled with the flag off should not be a CHASM node", opID)
+	} else {
+		s.True(inCHASM, "operation %s scheduled with the flag on should be a CHASM node", opID)
+		s.False(inHSM, "operation %s scheduled with the flag on should not be an HSM sub-state-machine", opID)
+	}
 }
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion(chasmEnabled bool) {

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -267,6 +267,240 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelation(chasmEnabled bool
 	s.RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_COMPLETED)
 }
 
+// TestNexusOperationCancellationCrossTree verifies that a RequestCancelNexusOperation command is routed to the tree
+// that actually holds the operation, not to the tree implied by the current enableChasmWorkflowOperations flag.
+// An operation's tree is fixed when it is scheduled, so flipping the flag (a downgrade or an upgrade) must not cause
+// the cancellation to fail the workflow task.
+func (s *NexusWorkflowTestSuite) TestNexusOperationCancellationCrossTree(chasmEnabled bool) {
+	// This test drives the creation-policy flag itself, so run it once (not per-suite-mode).
+	if chasmEnabled {
+		s.T().Skip("cross-tree cancel test controls the flag explicitly; run once via the HSM suite")
+	}
+
+	testCases := []struct {
+		name string
+		// enableChasmWorkflowOperations value at schedule time, which selects the tree the op is created in
+		// (true -> CHASM, false -> HSM). The flag is flipped to the opposite value to simulate a cancellation after a
+		// downgrade or an upgrade.
+		enableChasmAtSchedule bool
+	}{
+		{name: "ChasmOpCanceledAfterDowngrade", enableChasmAtSchedule: true},
+		{name: "HsmOpCanceledAfterUpgrade", enableChasmAtSchedule: false},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func(s *NexusWorkflowTestSuite) {
+			env := s.newTestEnv(true)
+			ctx := env.Context()
+			taskQueue := testcore.RandomizeStr(s.T().Name())
+
+			env.OverrideDynamicConfig(chasmnexus.EnableChasmWorkflowOperations, tc.enableChasmAtSchedule)
+
+			h := nexustest.Handler{
+				OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
+					return &nexus.HandlerStartOperationResultAsync{OperationToken: "test"}, nil
+				},
+				OnCancelOperation: func(ctx context.Context, service, operation, token string, options nexus.CancelOperationOptions) error {
+					return nil
+				},
+			}
+			endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
+
+			run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+				TaskQueue:           taskQueue,
+				WorkflowTaskTimeout: time.Second,
+			}, "workflow")
+			s.NoError(err)
+
+			// Schedule the Nexus operation.
+			s.EventuallyWithT(func(t *assert.CollectT) {
+				pollResp, err := env.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+					Namespace: env.Namespace().String(),
+					TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					Identity:  "test",
+				})
+				require.NoError(t, err)
+				_, err = env.FrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+					Identity:  "test",
+					TaskToken: pollResp.TaskToken,
+					Commands: []*commandpb.Command{
+						{
+							CommandType: enumspb.COMMAND_TYPE_SCHEDULE_NEXUS_OPERATION,
+							Attributes: &commandpb.Command_ScheduleNexusOperationCommandAttributes{
+								ScheduleNexusOperationCommandAttributes: &commandpb.ScheduleNexusOperationCommandAttributes{
+									Endpoint:  endpointName,
+									Service:   "service",
+									Operation: "operation",
+									Input:     testcore.MustToPayload(s.T(), "input"),
+								},
+							},
+						},
+					},
+				})
+				require.NoError(t, err)
+			}, time.Second*20, time.Millisecond*200)
+
+			// Wait for the operation to start, then capture its scheduled event ID.
+			pollResp, err := env.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+				Namespace: env.Namespace().String(),
+				TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				Identity:  "test",
+			})
+			s.NoError(err)
+			s.RequireHistoryEvent(pollResp.History.Events, enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED)
+			scheduledEvent := s.RequireHistoryEvent(pollResp.History.Events, enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED)
+
+			// Flip the flag before requesting cancellation.
+			env.OverrideDynamicConfig(chasmnexus.EnableChasmWorkflowOperations, !tc.enableChasmAtSchedule)
+
+			_, err = env.FrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+				Identity:  "test",
+				TaskToken: pollResp.TaskToken,
+				Commands: []*commandpb.Command{
+					{
+						CommandType: enumspb.COMMAND_TYPE_REQUEST_CANCEL_NEXUS_OPERATION,
+						Attributes: &commandpb.Command_RequestCancelNexusOperationCommandAttributes{
+							RequestCancelNexusOperationCommandAttributes: &commandpb.RequestCancelNexusOperationCommandAttributes{
+								ScheduledEventId: scheduledEvent.EventId,
+							},
+						},
+					},
+				},
+			})
+			s.NoError(err)
+
+			// The cancellation is recorded successfully regardless of the flag flip.
+			s.EventuallyWithT(func(t *assert.CollectT) {
+				hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{
+					WorkflowId: run.GetID(),
+					RunId:      run.GetRunID(),
+				})
+				historyrequire.New(t).RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED)
+			}, time.Second*20, time.Millisecond*200)
+		})
+	}
+}
+
+// TestNexusOperationCancellationBufferedCrossTree tests using an operation that lives in the HSM tree reaches a
+// terminal state whose completion event is buffered while a workflow task in flight requests cancellation.
+func (s *NexusWorkflowTestSuite) TestNexusOperationCancellationBufferedCrossTree(chasmEnabled bool) {
+	// This test drives the creation-policy flag itself, so run it once (not per-suite-mode).
+	if chasmEnabled {
+		s.T().Skip("cross-tree cancel test controls the flag explicitly; run once via the HSM suite")
+	}
+
+	env := s.newTestEnv(true)
+	ctx := env.Context()
+	taskQueue := testcore.RandomizeStr(s.T().Name())
+	env.OverrideDynamicConfig(chasmnexus.EnableChasmWorkflowOperations, false)
+
+	var callbackToken, publicCallbackURL string
+	h := nexustest.Handler{
+		OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
+			callbackToken = options.CallbackHeader.Get(commonnexus.CallbackTokenHeader)
+			publicCallbackURL = options.CallbackURL
+			return &nexus.HandlerStartOperationResultAsync{OperationToken: "test"}, nil
+		},
+	}
+	endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
+
+	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		TaskQueue:           taskQueue,
+		WorkflowTaskTimeout: 20 * time.Second,
+	}, "workflow")
+	s.NoError(err)
+
+	// Schedule the Nexus operation (lands in the HSM tree).
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		pollResp, err := env.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+			Namespace: env.Namespace().String(),
+			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			Identity:  "test",
+		})
+		require.NoError(t, err)
+		_, err = env.FrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+			Identity:  "test",
+			TaskToken: pollResp.TaskToken,
+			Commands: []*commandpb.Command{
+				{
+					CommandType: enumspb.COMMAND_TYPE_SCHEDULE_NEXUS_OPERATION,
+					Attributes: &commandpb.Command_ScheduleNexusOperationCommandAttributes{
+						ScheduleNexusOperationCommandAttributes: &commandpb.ScheduleNexusOperationCommandAttributes{
+							Endpoint:  endpointName,
+							Service:   "service",
+							Operation: "operation",
+							Input:     testcore.MustToPayload(s.T(), "input"),
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+	}, time.Second*20, time.Millisecond*200)
+
+	// Wait for the operation to start (async). The started event schedules the next workflow task.
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: run.GetID()})
+		historyrequire.New(t).RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED)
+	}, time.Second*20, time.Millisecond*200)
+
+	// Poll and hold the started-triggered workflow task without responding, so a workflow task is in flight.
+	pollResp, err := env.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+		Namespace: env.Namespace().String(),
+		TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		Identity:  "test",
+	})
+	s.NoError(err)
+	scheduledEvent := s.RequireHistoryEvent(pollResp.History.Events, enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED)
+
+	// Deliver the async completion while the workflow task is in flight, so the terminal event is buffered and is
+	// not yet applied when the cancellation command is processed.
+	completion := nexusrpc.CompleteOperationOptions{
+		Result: testcore.MustToPayload(s.T(), "result"),
+		Header: nexus.Header{commonnexus.CallbackTokenHeader: callbackToken},
+	}
+	s.NoError(s.sendNexusCompletionRequest(ctx, publicCallbackURL, completion))
+
+	// Complete the held workflow task with a cancel nexus operation command. The CHASM handler runs, the op is not in
+	// the CHASM tree but a terminal event is buffered, so it records a no-op CancelRequested rather than a failure.
+	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+		Identity:  "test",
+		TaskToken: pollResp.TaskToken,
+		Commands: []*commandpb.Command{
+			{
+				CommandType: enumspb.COMMAND_TYPE_REQUEST_CANCEL_NEXUS_OPERATION,
+				Attributes: &commandpb.Command_RequestCancelNexusOperationCommandAttributes{
+					RequestCancelNexusOperationCommandAttributes: &commandpb.RequestCancelNexusOperationCommandAttributes{
+						ScheduledEventId: scheduledEvent.EventId,
+					},
+				},
+			},
+		},
+	})
+	s.NoError(err)
+
+	// The cancellation is recorded and the operation completes via its buffered HSM completion.
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{
+			WorkflowId: run.GetID(),
+			RunId:      run.GetRunID(),
+		})
+		hr := historyrequire.New(t)
+		hr.RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED)
+		hr.RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED)
+	}, time.Second*20, time.Millisecond*200)
+
+	// The no-op cross-tree cancellation did not fail the workflow task.
+	hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{
+		WorkflowId: run.GetID(),
+		RunId:      run.GetRunID(),
+	})
+	s.RequireNoHistoryEvent(hist, enumspb.EVENT_TYPE_WORKFLOW_TASK_FAILED)
+
+	// Terminate the manually driven workflow.
+	s.NoError(env.SdkClient().TerminateWorkflow(ctx, run.GetID(), run.GetRunID(), "test"))
+}
+
 func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion(chasmEnabled bool) {
 	env := s.newTestEnv(chasmEnabled)
 	ctx := env.Context()


### PR DESCRIPTION
## What changed?
A Nexus operation's tree (HSM or CHASM) is fixed when it is scheduled and never moves. The CHASM `RequestCancelNexusOperation` command handler, however, chose its tree from the current `enableChasmWorkflowOperations` flag — so after a flag flip the two could disagree and the cancelation would fail the workflow task. This changes the cancel path to route by the tree that actually **owns** the operation and supporting both directions of mixed state: a **downgrade** (op created in CHASM, flag later off) and an op still in **HSM** after an upgrade.

## Why?
Cancelation must follow the operation's tree, not a flag that can change between scheduling and canceling. Without this, flipping `enableChasmWorkflowOperations` (rollout, downgrade) breaks cancelation of in-flight operations.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

## Potential risks
Low. The HSM handler and schedule path are unchanged; the dispatcher fallback is pre-existing. The only behaviour change is on the cancel path. 