### PR TITLE
vts: rename time skipping propagation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
-	go.temporal.io/api v1.63.3-0.20260709034627-962203cb96b6
+	go.temporal.io/api v1.63.3-0.20260709191808-4ef18a3ef68c
 	go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee
 	go.temporal.io/sdk v1.41.1
 	go.uber.org/fx v1.24.0

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
-	go.temporal.io/api v1.63.2
+	go.temporal.io/api v1.63.3-0.20260709034627-962203cb96b6
 	go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee
 	go.temporal.io/sdk v1.41.1
 	go.uber.org/fx v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -471,8 +471,8 @@ go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0 h1:R
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0/go.mod h1:I89cynRj8y+383o7tEQVg2SVA6SRgDVIouWPUVXjx0U=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0 h1:CQvJSldHRUN6Z8jsUeYv8J0lXRvygALXIzsmAeCcZE0=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0/go.mod h1:xSQ+mEfJe/GjK1LXEyVOoSI1N9JV9ZI923X5kup43W4=
-go.temporal.io/api v1.63.2 h1:axAqAdHraBdREoK7Ufnl0LDvlmhDO0GmYJ1JTf495HA=
-go.temporal.io/api v1.63.2/go.mod h1:0k75tRljEuELWGeXjEZZO7zYqBln4+1FrG6+IMOMy7Q=
+go.temporal.io/api v1.63.3-0.20260709034627-962203cb96b6 h1:q9F8qDg9HQNZG5ng7RkTkar8/Roml44sDVhfsGvd04g=
+go.temporal.io/api v1.63.3-0.20260709034627-962203cb96b6/go.mod h1:0k75tRljEuELWGeXjEZZO7zYqBln4+1FrG6+IMOMy7Q=
 go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee h1:y6A65Iml06cR3CpxW2Zn8FQLjniPDTnN4jtr69UZxXI=
 go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee/go.mod h1:hhHijO9XRPIkAflLJJHix61M9FzbRPqk8fSydkcLkqw=
 go.temporal.io/sdk v1.41.1 h1:yOpvsHyDD1lNuwlGBv/SUodCPhjv9nDeC9lLHW/fJUA=

--- a/go.sum
+++ b/go.sum
@@ -471,8 +471,8 @@ go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0 h1:R
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0/go.mod h1:I89cynRj8y+383o7tEQVg2SVA6SRgDVIouWPUVXjx0U=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0 h1:CQvJSldHRUN6Z8jsUeYv8J0lXRvygALXIzsmAeCcZE0=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0/go.mod h1:xSQ+mEfJe/GjK1LXEyVOoSI1N9JV9ZI923X5kup43W4=
-go.temporal.io/api v1.63.3-0.20260709034627-962203cb96b6 h1:q9F8qDg9HQNZG5ng7RkTkar8/Roml44sDVhfsGvd04g=
-go.temporal.io/api v1.63.3-0.20260709034627-962203cb96b6/go.mod h1:0k75tRljEuELWGeXjEZZO7zYqBln4+1FrG6+IMOMy7Q=
+go.temporal.io/api v1.63.3-0.20260709191808-4ef18a3ef68c h1:7dgudFu0HMwar3LzTWT0/z6dMpujXgRPFe9b1TTCmOg=
+go.temporal.io/api v1.63.3-0.20260709191808-4ef18a3ef68c/go.mod h1:0k75tRljEuELWGeXjEZZO7zYqBln4+1FrG6+IMOMy7Q=
 go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee h1:y6A65Iml06cR3CpxW2Zn8FQLjniPDTnN4jtr69UZxXI=
 go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee/go.mod h1:hhHijO9XRPIkAflLJJHix61M9FzbRPqk8fSydkcLkqw=
 go.temporal.io/sdk v1.41.1 h1:yOpvsHyDD1lNuwlGBv/SUodCPhjv9nDeC9lLHW/fJUA=

--- a/service/history/workflow/timeskipping.go
+++ b/service/history/workflow/timeskipping.go
@@ -168,8 +168,8 @@ func propagateTimeSkippingToChild(
 	}
 
 	enabled := source.GetTimeSkippingInfo().GetConfig().GetEnabled()
-	disableChildPropagation := source.GetTimeSkippingInfo().GetConfig().GetDisableChildPropagation()
-	if !enabled || disableChildPropagation {
+	disablePropagation := source.GetTimeSkippingInfo().GetConfig().GetDisablePropagation()
+	if !enabled || disablePropagation {
 		return nil, stateProp
 	}
 

--- a/service/history/workflow/timeskipping_test.go
+++ b/service/history/workflow/timeskipping_test.go
@@ -172,7 +172,7 @@ func (s *mutableStateSuite) TestSnapshotTimeSkippingInfo_ForChildWorkflows() {
 
 	s.Run("child workflow propagation can be turned off", func() {
 		src := newSource()
-		src.TimeSkippingInfo.Config.DisableChildPropagation = true
+		src.TimeSkippingInfo.Config.DisablePropagation = true
 		tsc, propagatedState := propagateTimeSkippingToChild(src)
 		s.Nil(tsc)
 		s.Require().NotNil(propagatedState)
@@ -191,7 +191,7 @@ func (s *mutableStateSuite) TestSnapshotTimeSkippingInfo_ForChildWorkflows() {
 		s.Nil(propagatedState.GetFastForwardTargetTime())
 	})
 
-	s.Run("disableChildPropagation still propagates virtual time", func() {
+	s.Run("disablePropagation still propagates virtual time", func() {
 		src := newSource()
 		src.TimeSkippingInfo.Config.Enabled = false
 		tsc, propagatedState := propagateTimeSkippingToChild(src)
@@ -397,9 +397,9 @@ func (s *mutableStateSuite) TestInitTimeSkippingInfo() {
 		eventID := int64(1)
 
 		cfg := &commonpb.TimeSkippingConfig{
-			Enabled:                 true,
-			FastForward:             durationpb.New(fastForward),
-			DisableChildPropagation: true,
+			Enabled:            true,
+			FastForward:        durationpb.New(fastForward),
+			DisablePropagation: true,
 		}
 		propagation := &commonpb.TimeSkippingStatePropagation{
 			InitialSkippedDuration: durationpb.New(hasSkipped),
@@ -470,9 +470,9 @@ func (s *mutableStateSuite) TestUpdateTimeSkippingInfo() {
 
 		// new config
 		newConfig := &commonpb.TimeSkippingConfig{
-			Enabled:                 true,
-			FastForward:             durationpb.New(2 * time.Hour),
-			DisableChildPropagation: true,
+			Enabled:            true,
+			FastForward:        durationpb.New(2 * time.Hour),
+			DisablePropagation: true,
 		}
 		newEventID := int64(8)
 		s.Require().NoError(s.mutableState.updateTimeSkippingInfo(newConfig, newEventID))

--- a/tests/timeskipping_propagation_test.go
+++ b/tests/timeskipping_propagation_test.go
@@ -12,7 +12,7 @@
 // Group 2 — Child workflows.
 //
 //  1. fast-forward is not propagated to children.
-//  2. DisableChildPropagation disables propagation of the enabled flag.
+//  2. DisablePropagation disables propagation of the enabled flag.
 //  3. the child inherits the parent's accumulated skipped duration in all cases.
 //     Covered by:
 //     - TestTSPInChildWf_Basic
@@ -1080,16 +1080,16 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInReset() {
 // applyTimeSkippingConfig uses InitialSkippedDuration to seed AccumulatedSkippedDuration
 // on the new MS, so the virtual clock continues seamlessly.
 //
-// DisableChildPropagation gates child propagation only — CaN ignores it — so run 1 sets
+// DisablePropagation gates child propagation only — CaN ignores it — so run 1 sets
 // it to verify the continuation still inherits Enabled=true.
 //
 // Scenario:
-//   - Run 1 starts with TimeSkippingConfig{Enabled: true, DisableChildPropagation: true}.
+//   - Run 1 starts with TimeSkippingConfig{Enabled: true, DisablePropagation: true}.
 //   - Run 1 issues StartTimer(t1, 1h). Idle → server skips 1h.
 //     After skip: run1.AccumulatedSkippedDuration = 1h.
 //   - t1 fires. Run 1 issues ContinueAsNew (same type, same task queue).
 //   - Run 2 starts. Its WorkflowExecutionStarted event carries the current config
-//     (Enabled=true, DisableChildPropagation=true) and InitialSkippedDuration=1h. The
+//     (Enabled=true, DisablePropagation=true) and InitialSkippedDuration=1h. The
 //     applied MS has Config.Enabled=true and AccumulatedSkippedDuration=1h.
 //   - Run 2 issues StartTimer(t2, 2h). Idle → skips 2h.
 //     After skip: run2.AccumulatedSkippedDuration = 1h + 2h = 3h.
@@ -1199,7 +1199,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInCaN() {
 //
 // Retry snapshots from the previous run's live executionInfo (via
 // snapshotTimeSkippingInfoForExecutionChain), not event #1: createRequest.TimeSkippingConfig
-// carries the current config (including FastForward, ignoring DisableChildPropagation) and
+// carries the current config (including FastForward, ignoring DisablePropagation) and
 // req.InitialSkippedDuration carries the previous attempt's AccumulatedSkippedDuration at
 // retry time. initTimeSkippingInfo then seeds the retry's AccumulatedSkippedDuration from
 // it — so the previous attempt's in-flight skip IS carried forward, exactly like
@@ -1595,11 +1595,123 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInCaN_BudgetCapOverChain() {
 	})
 }
 
-// (TestTSPInChildWf_PropagationDisabled removed: DisableChildPropagation is not yet in the API)
+// TestTSPInChildWf_PropagationDisabled verifies that DisablePropagation suppresses the
+// TimeSkippingConfig from cascading into children while the parent's accumulated virtual
+// time is still inherited. The child ends up with Config.Enabled == false (it never skips
+// its own timers) but AccumulatedSkippedDuration seeded from the parent.
+//
 // Scenario:
-//   - Parent starts with TimeSkippingConfig{Enabled: true, DisableChildPropagation: true}.
+//   - Parent starts with TimeSkippingConfig{Enabled: true, DisablePropagation: true}.
 //   - Parent issues StartTimer(t1, 1h) → idle → skips 1h → parent.Accum = 1h.
-//   - t1 fires. Parent issues StartChild(child) + StartTimer(t2, 1h). The child gets no
-//     TSC but its TSI has accumulated skipped duration of 1hour.
+//   - t1 fires. Parent issues StartChild(child) + StartTimer(t2, 1h). Because propagation
+//     is disabled, the child gets no TimeSkippingConfig, but its TSI still carries the
+//     inherited InitialSkippedDuration = 1h.
+//   - Child has skipping disabled (Config nil → Enabled false), so it does not skip its own
+//     time; it completes immediately without a long timer.
+//   - Child completes → parent becomes idle on t2 → skips 1h → t2 fires → parent completes.
 //
 // End-state assertions:
+//   - parent.AccumulatedSkippedDuration == 2h (1h for t1 + 1h for t2).
+//   - child.TimeSkippingInfo.Config is nil (Enabled == false); propagation was disabled.
+//   - child.AccumulatedSkippedDuration == 1h (inherited only; the child never skips).
+//   - The parent's StartChildWorkflowExecutionInitiated event carries no TimeSkippingConfig
+//     but InitialSkippedDuration == 1h.
+func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_PropagationDisabled() {
+	env := testcore.NewEnv(s.T())
+	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
+	tv := testvars.New(s.T())
+	ctx := testcore.NewContext()
+
+	parentWFType := tv.WorkflowType()
+	childWFType := &commonpb.WorkflowType{Name: parentWFType.Name + "-child"}
+	parentWFID := tv.WorkflowID()
+	childWFID := parentWFID + "-child"
+
+	startWall := time.Now()
+
+	parentStart, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           uuid.NewString(),
+		Namespace:           env.Namespace().String(),
+		WorkflowId:          parentWFID,
+		WorkflowType:        parentWFType,
+		TaskQueue:           tv.TaskQueue(),
+		WorkflowRunTimeout:  durationpb.New(24 * time.Hour),
+		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+		// DisablePropagation keeps the enabled flag from cascading into the child; only the
+		// parent's accumulated virtual time is inherited.
+		TimeSkippingConfig: &commonpb.TimeSkippingConfig{
+			Enabled:            true,
+			DisablePropagation: true,
+		},
+	})
+	s.NoError(err)
+	parentRunID := parentStart.RunId
+
+	ns := env.Namespace().String()
+	tq := tv.TaskQueue()
+
+	parentStarted, parentKickedOff, parentDone := false, false, false
+	parentHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		fired := firedTimers(task)
+		if !parentStarted {
+			parentStarted = true
+			return cmdsResponse(timerCmd("t1", time.Hour)), nil
+		}
+		if fired["t1"] && !parentKickedOff {
+			parentKickedOff = true
+			return cmdsResponse(
+				childCmd(ns, childWFID, childWFType, tq),
+				timerCmd("t2", time.Hour),
+			), nil
+		}
+		if fired["t2"] && !parentDone {
+			parentDone = true
+			return cmdsResponse(completeCmd()), nil
+		}
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{}, nil
+	}
+
+	// The child has skipping disabled, so it must not wait on a long timer (nothing would
+	// skip it). It completes on its first workflow task.
+	childHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		return cmdsResponse(completeCmd()), nil
+	}
+
+	dispatch := typeDispatch(map[string]wftHandler{
+		parentWFType.Name: parentHandler,
+		childWFType.Name:  childHandler,
+	})
+
+	s.drivePollsUntilClosed(ctx, env, tv, dispatch, parentWFID, parentRunID, 20)
+
+	elapsed := time.Since(startWall)
+	s.Less(elapsed, 2*time.Minute, "wall-clock elapsed (%s) should be far less than 2h of virtual time", elapsed)
+
+	// ---- Parent ----
+	parentMS := s.getMutableState(env, parentWFID, parentRunID)
+	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED, parentMS.State.ExecutionState.State)
+	parentTSI := parentMS.State.ExecutionInfo.GetTimeSkippingInfo()
+	s.NotNil(parentTSI)
+	s.approxDuration(2*time.Hour, parentTSI.GetAccumulatedSkippedDuration().AsDuration(),
+		"parent should accumulate 1h (t1) + 1h (t2 after child) = 2h")
+
+	// ---- Child ----
+	childMS := s.getMutableStateByID(ctx, env, childWFID)
+	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED, childMS.State.ExecutionState.State)
+	childTSI := childMS.State.ExecutionInfo.GetTimeSkippingInfo()
+	s.NotNil(childTSI, "child still gets a TimeSkippingInfo to carry inherited virtual time")
+	s.Nil(childTSI.GetConfig(), "DisablePropagation suppresses the config; child has no TimeSkippingConfig")
+	s.False(childTSI.GetConfig().GetEnabled(), "child skipping is disabled")
+	s.approxDuration(time.Hour, childTSI.GetAccumulatedSkippedDuration().AsDuration(),
+		"child AccumulatedSkippedDuration == parent's accumulated at child-start (1h); the child never skips its own time")
+
+	// The parent's StartChildWorkflowExecutionInitiated event carries no TimeSkippingConfig
+	// (propagation disabled) but still snapshots the parent's accumulated skip so the child
+	// inherits virtual time.
+	initEvents := s.initiatedChildEvents(ctx, env, parentWFID, parentRunID)
+	s.Len(initEvents, 1)
+	initAttrs := initEvents[0].GetStartChildWorkflowExecutionInitiatedEventAttributes()
+	s.Nil(initAttrs.GetTimeSkippingConfig(), "initiated event carries no TimeSkippingConfig when propagation is disabled")
+	s.approxDuration(time.Hour, initAttrs.GetTimeSkippingStatePropagation().GetInitialSkippedDuration().AsDuration(),
+		"initiated event InitialSkippedDuration == parent's AccumulatedSkippedDuration at command time (1h)")
+}


### PR DESCRIPTION
## What changed?
the server changes for an api field rename
https://github.com/temporalio/api/pull/817

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)

