### PR TITLE
VTS: check archetypeID when handle time skipping for workflows

### DIFF
--- a/service/history/workflow/timeskipping.go
+++ b/service/history/workflow/timeskipping.go
@@ -393,6 +393,9 @@ func (ms *MutableStateImpl) closeTransactionHandleWorkflowTimeSkipping(
 	ctx context.Context,
 	transactionPolicy historyi.TransactionPolicy,
 ) (needRegenTasks bool) {
+	if !ms.IsWorkflow() {
+		return false
+	}
 	switch transactionPolicy {
 	case historyi.TransactionPolicyActive:
 		// 1. gate: only a running, time-skipping-enabled, idle workflow may skip time

--- a/service/history/workflow/timeskipping_test.go
+++ b/service/history/workflow/timeskipping_test.go
@@ -11,6 +11,7 @@ import (
 	historypb "go.temporal.io/api/history/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/components/nexusoperations"
@@ -922,28 +923,48 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 	})
 }
 
-// TestCloseTransactionHandleWorkflowTimeSkipping verifies the skippability gate is wired into the
-// active-policy path: even when a valid skip target exists (a user timer), a non-skippable workflow
-// (here, nil time-skipping config) must not skip — needRegenTasks is false and no state changes.
 func (s *mutableStateSuite) TestCloseTransactionHandleWorkflowTimeSkipping() {
 	// A valid skip target exists: a user timer one hour in the (virtual) future.
 	s.mutableState.pendingTimerInfoIDs["t1"] = &persistencespb.TimerInfo{
 		TimerId:    "t1",
 		ExpiryTime: timestamppb.New(s.mutableState.Now().Add(time.Hour)),
 	}
-	// ...but time skipping is not enabled (nil config), so the workflow is not skippable.
-	s.mutableState.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{Config: nil}
-	s.mutableState.timeSkippingInfoUpdated = false
-
-	// Make the intent explicit: the target is real, but the gate must reject the workflow.
 	s.Require().True(s.mutableState.findNextSkipTarget().IsValid(), "the user timer is a valid skip target")
-	s.Require().False(s.mutableState.isWorkflowSkippable(), "nil config means not skippable")
 
-	needRegen := s.mutableState.closeTransactionHandleWorkflowTimeSkipping(
-		context.Background(), historyi.TransactionPolicyActive)
+	s.Run("NilConfig", func() {
+		// Time skipping is not enabled (nil config), so the workflow is not skippable.
+		s.mutableState.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{Config: nil}
+		s.mutableState.timeSkippingInfoUpdated = false
+		s.Require().False(s.mutableState.isWorkflowSkippable(), "nil config means not skippable")
 
-	s.False(needRegen, "the gate must prevent skipping even though a valid target exists")
-	s.False(s.mutableState.timeSkippingInfoUpdated, "a gated-out transaction must not change state")
+		needRegen := s.mutableState.closeTransactionHandleWorkflowTimeSkipping(
+			context.Background(), historyi.TransactionPolicyActive)
+
+		s.False(needRegen, "the gate must prevent skipping even though a valid target exists")
+		s.False(s.mutableState.timeSkippingInfoUpdated, "a gated-out transaction must not change state")
+	})
+
+	s.Run("NonWorkflow", func() {
+		// Enable time skipping so the only thing rejecting the skip is the non-workflow archetype.
+		s.mutableState.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
+			Config: &commonpb.TimeSkippingConfig{Enabled: true},
+		}
+		s.mutableState.timeSkippingInfoUpdated = false
+
+		mockChasmTree := historyi.NewMockChasmTree(s.controller)
+		mockChasmTree.EXPECT().ArchetypeID().Return(activity.ArchetypeID).AnyTimes()
+		s.mutableState.chasmTree = mockChasmTree
+		s.Require().False(s.mutableState.IsWorkflow(), "a non-workflow archetype must not report as a workflow")
+
+		for _, policy := range []historyi.TransactionPolicy{
+			historyi.TransactionPolicyActive,
+			historyi.TransactionPolicyPassive,
+		} {
+			needRegen := s.mutableState.closeTransactionHandleWorkflowTimeSkipping(context.Background(), policy)
+			s.False(needRegen, "a non-workflow must never skip time (policy %v)", policy)
+			s.False(s.mutableState.timeSkippingInfoUpdated, "a non-workflow must not change state (policy %v)", policy)
+		}
+	})
 }
 
 // TestTimeSkippingTransition covers the pure timeSkippingTransition data structure:


### PR DESCRIPTION
## What changed?
add check `archetypeID` in `closeTransactionHandleWorkflowTimeSkipping`

## Why?
workflows and chasm-executions share the same mutable state and close transaction entry point, and they may impact each other 

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

