### PR TITLE
Distinguish per-key from whole-queue rate limiting in matching hook

### DIFF
--- a/service/matching/hooks/task_lifecycle_hooks.go
+++ b/service/matching/hooks/task_lifecycle_hooks.go
@@ -19,8 +19,10 @@ const (
 	SyncMatchOutcomeNotMatched
 	// The task was sync-matched successfully.
 	SyncMatchOutcomeSuccess
-	// A poller was available but rate limiting blocked the match.
+	// A poller was available but whole-queue rate limiting blocked the match.
 	SyncMatchOutcomeRateLimited
+	// A poller was available but per-fairness-key rate limiting blocked the match.
+	SyncMatchOutcomeFairnessKeyRateLimited
 )
 
 type (

--- a/service/matching/matcher_data.go
+++ b/service/matching/matcher_data.go
@@ -52,9 +52,9 @@ const (
 type rateLimitKind int
 
 const (
-	rateLimitNone         rateLimitKind = iota
-	rateLimitWholeQueue                         // whole-queue rate limit is blocking
-	rateLimitFairnessKey                        // per-fairness-key rate limit is blocking
+	rateLimitNone        rateLimitKind = iota
+	rateLimitWholeQueue                // whole-queue rate limit is blocking
+	rateLimitFairnessKey               // per-fairness-key rate limit is blocking
 )
 
 type taskForwarderType int32

--- a/service/matching/matcher_data.go
+++ b/service/matching/matcher_data.go
@@ -45,9 +45,16 @@ const (
 	// A poller was available but whole-queue rate limiting blocked the match.
 	syncMatchRateLimited
 	// A poller was available but per-fairness-key rate limiting blocked the match.
-	// This is distinct from syncMatchRateLimited because WCI should still scale
-	// up workers when only per-key limits are hit.
-	syncMatchPerKeyRateLimited
+	syncMatchFairnessKeyRateLimited
+)
+
+// rateLimitKind distinguishes which rate limiter blocked a match in findMatch.
+type rateLimitKind int
+
+const (
+	rateLimitNone         rateLimitKind = iota
+	rateLimitWholeQueue                         // whole-queue rate limit is blocking
+	rateLimitFairnessKey                        // per-fairness-key rate limit is blocking
 )
 
 type taskForwarderType int32
@@ -369,10 +376,12 @@ func (d *matcherData) MatchTaskImmediately(task *internalTask) syncMatchOutcome 
 		return syncMatchSuccess
 	}
 	d.tasks.Remove(task)
-	if outcome == syncMatchRateLimited || outcome == syncMatchPerKeyRateLimited {
+	switch outcome {
+	case syncMatchRateLimited, syncMatchFairnessKeyRateLimited:
 		return outcome
+	default:
+		return syncMatchNoPoller
 	}
-	return syncMatchNoPoller
 }
 
 func (d *matcherData) MatchPollerImmediately(poller *waitingPoller) *matchResult {
@@ -412,7 +421,7 @@ func (d *matcherData) ReprocessTasks(pred func(*internalTask) bool) []*internalT
 // minimum wait until any rate-limited task (that has a compatible poller) becomes ready.
 // call with lock held
 // nolint:revive // will improve later
-func (d *matcherData) findMatch(allowForwarding bool, now int64) (matchedTask *internalTask, matchedPoller *waitingPoller, minDelay time.Duration, wholeQueueLimited bool) {
+func (d *matcherData) findMatch(allowForwarding bool, now int64) (matchedTask *internalTask, matchedPoller *waitingPoller, minDelay time.Duration, rateLimitedBy rateLimitKind) {
 	// TODO(pri): optimize so it's not O(d*n) worst case
 	// Scan keeps its callback on the stack, so this walk does not allocate; the equivalent
 	// tree.Iter() cursor escapes to the heap.
@@ -426,7 +435,7 @@ func (d *matcherData) findMatch(allowForwarding bool, now int64) (matchedTask *i
 	wholeQueueReady, perKeyLimited := d.rateLimitManager.rateLimitState()
 	if !perKeyLimited && d.tasks.Len() > 0 && d.pollers.Len() > 0 {
 		if delay := wholeQueueReady.delay(now); delay > 0 {
-			return nil, nil, delay, true
+			return nil, nil, delay, rateLimitWholeQueue
 		}
 	}
 
@@ -474,6 +483,7 @@ func (d *matcherData) findMatch(allowForwarding bool, now int64) (matchedTask *i
 				if minDelay == 0 || delay < minDelay {
 					minDelay = delay
 				}
+				rateLimitedBy = rateLimitFairnessKey
 				return true
 			}
 		}
@@ -525,14 +535,18 @@ func (d *matcherData) findAndWakeMatches() (outcome syncMatchOutcome) {
 
 	for {
 		// search for highest-priority ready match; skip per-key rate-limited tasks
-		task, poller, minDelay, wholeQueueLimited := d.findMatch(allowForwarding, now)
+		task, poller, minDelay, rateLimitedBy := d.findMatch(allowForwarding, now)
 		if task == nil || poller == nil {
 			if minDelay > 0 {
 				d.rateLimitTimer.set(d.timeSource, d.rematchAfterTimer, minDelay)
-				if wholeQueueLimited {
+				switch rateLimitedBy {
+				case rateLimitWholeQueue:
 					return syncMatchRateLimited
+				case rateLimitFairnessKey:
+					return syncMatchFairnessKeyRateLimited
+				default:
+					return syncMatchUnspecified
 				}
-				return syncMatchPerKeyRateLimited
 			}
 			// no more current matches, stop rate limit timer if was running
 			d.rateLimitTimer.unset()

--- a/service/matching/matcher_data.go
+++ b/service/matching/matcher_data.go
@@ -42,8 +42,12 @@ const (
 	syncMatchBacklogPresent
 	// Sync match was attempted but no poller was available.
 	syncMatchNoPoller
-	// A poller was available but rate limiting blocked the match.
+	// A poller was available but whole-queue rate limiting blocked the match.
 	syncMatchRateLimited
+	// A poller was available but per-fairness-key rate limiting blocked the match.
+	// This is distinct from syncMatchRateLimited because WCI should still scale
+	// up workers when only per-key limits are hit.
+	syncMatchPerKeyRateLimited
 )
 
 type taskForwarderType int32
@@ -359,14 +363,14 @@ func (d *matcherData) MatchTaskImmediately(task *internalTask) syncMatchOutcome 
 
 	task.initMatch(d)
 	d.tasks.Add(task)
-	rateLimited := d.findAndWakeMatches()
+	outcome := d.findAndWakeMatches()
 	// don't wait, check if match() picked this one already
 	if task.matchResult != nil {
 		return syncMatchSuccess
 	}
 	d.tasks.Remove(task)
-	if rateLimited {
-		return syncMatchRateLimited
+	if outcome == syncMatchRateLimited || outcome == syncMatchPerKeyRateLimited {
+		return outcome
 	}
 	return syncMatchNoPoller
 }
@@ -408,7 +412,7 @@ func (d *matcherData) ReprocessTasks(pred func(*internalTask) bool) []*internalT
 // minimum wait until any rate-limited task (that has a compatible poller) becomes ready.
 // call with lock held
 // nolint:revive // will improve later
-func (d *matcherData) findMatch(allowForwarding bool, now int64) (matchedTask *internalTask, matchedPoller *waitingPoller, minDelay time.Duration) {
+func (d *matcherData) findMatch(allowForwarding bool, now int64) (matchedTask *internalTask, matchedPoller *waitingPoller, minDelay time.Duration, wholeQueueLimited bool) {
 	// TODO(pri): optimize so it's not O(d*n) worst case
 	// Scan keeps its callback on the stack, so this walk does not allocate; the equivalent
 	// tree.Iter() cursor escapes to the heap.
@@ -422,7 +426,7 @@ func (d *matcherData) findMatch(allowForwarding bool, now int64) (matchedTask *i
 	wholeQueueReady, perKeyLimited := d.rateLimitManager.rateLimitState()
 	if !perKeyLimited && d.tasks.Len() > 0 && d.pollers.Len() > 0 {
 		if delay := wholeQueueReady.delay(now); delay > 0 {
-			return nil, nil, delay
+			return nil, nil, delay, true
 		}
 	}
 
@@ -513,23 +517,26 @@ func (d *matcherData) allowForwarding() (allowForwarding bool) {
 	return delayToForwardingAllowed <= 0
 }
 
-// call with lock held. Returns true if a match was found but blocked by rate limiting.
-func (d *matcherData) findAndWakeMatches() (rateLimited bool) {
+// call with lock held. Returns the rate limit outcome if a match was blocked.
+func (d *matcherData) findAndWakeMatches() (outcome syncMatchOutcome) {
 	allowForwarding := d.canForward && d.allowForwarding()
 
 	now := d.timeSource.Now().UnixNano()
 
 	for {
 		// search for highest-priority ready match; skip per-key rate-limited tasks
-		task, poller, minDelay := d.findMatch(allowForwarding, now)
+		task, poller, minDelay, wholeQueueLimited := d.findMatch(allowForwarding, now)
 		if task == nil || poller == nil {
 			if minDelay > 0 {
 				d.rateLimitTimer.set(d.timeSource, d.rematchAfterTimer, minDelay)
-				return true
+				if wholeQueueLimited {
+					return syncMatchRateLimited
+				}
+				return syncMatchPerKeyRateLimited
 			}
 			// no more current matches, stop rate limit timer if was running
 			d.rateLimitTimer.unset()
-			return false
+			return syncMatchUnspecified
 		}
 
 		// ready to signal match

--- a/service/matching/matcher_data_test.go
+++ b/service/matching/matcher_data_test.go
@@ -227,7 +227,7 @@ func (s *MatcherDataSuite) TestMatchTaskImmediatelyRateLimited() {
 	s.Equal(syncMatchRateLimited, s.md.MatchTaskImmediately(t))
 }
 
-func (s *MatcherDataSuite) TestMatchTaskImmediatelyPerKeyRateLimited() {
+func (s *MatcherDataSuite) TestMatchTaskImmediatelyFairnessKeyRateLimited() {
 	// Set per-key rate limit with a low RPS and zero burst so consuming one token
 	// puts the key well into the future.
 	s.md.rateLimitManager.SetFairnessKeyRateLimitDefaultForTesting(1.0, enumspb.RATE_LIMIT_SOURCE_API)
@@ -252,7 +252,7 @@ func (s *MatcherDataSuite) TestMatchTaskImmediatelyPerKeyRateLimited() {
 		CreateTime: timestamppb.New(s.now()),
 		Priority:   &commonpb.Priority{FairnessKey: "key1"},
 	}, nil, 0, nil)
-	s.Equal(syncMatchPerKeyRateLimited, s.md.MatchTaskImmediately(syncTask))
+	s.Equal(syncMatchFairnessKeyRateLimited, s.md.MatchTaskImmediately(syncTask))
 }
 
 func (s *MatcherDataSuite) TestMatchTaskImmediatelyDisabledBacklog() {

--- a/service/matching/matcher_data_test.go
+++ b/service/matching/matcher_data_test.go
@@ -227,6 +227,34 @@ func (s *MatcherDataSuite) TestMatchTaskImmediatelyRateLimited() {
 	s.Equal(syncMatchRateLimited, s.md.MatchTaskImmediately(t))
 }
 
+func (s *MatcherDataSuite) TestMatchTaskImmediatelyPerKeyRateLimited() {
+	// Set per-key rate limit with a low RPS and zero burst so consuming one token
+	// puts the key well into the future.
+	s.md.rateLimitManager.SetFairnessKeyRateLimitDefaultForTesting(1.0, enumspb.RATE_LIMIT_SOURCE_API)
+	s.md.rateLimitManager.UpdatePerKeySimpleRateLimitWithBurstForTesting(0)
+
+	// Add a waiting poller.
+	go func() {
+		poller := &waitingPoller{startTime: s.now()}
+		s.md.EnqueuePollerAndWait(nil, poller)
+	}()
+	s.waitForPollers(1)
+
+	// Consume one token for "key1" by directly consuming via the rate limit manager.
+	dummyTask := newInternalTaskForSyncMatch(&persistencespb.TaskInfo{
+		CreateTime: timestamppb.New(s.now()),
+		Priority:   &commonpb.Priority{FairnessKey: "key1"},
+	}, nil, 0, nil)
+	s.md.rateLimitManager.consumeTokens(s.now().UnixNano(), dummyTask, 1)
+
+	// Now sync-match another key1 task. Should return per-key rate limited, not whole-queue.
+	syncTask := newInternalTaskForSyncMatch(&persistencespb.TaskInfo{
+		CreateTime: timestamppb.New(s.now()),
+		Priority:   &commonpb.Priority{FairnessKey: "key1"},
+	}, nil, 0, nil)
+	s.Equal(syncMatchPerKeyRateLimited, s.md.MatchTaskImmediately(syncTask))
+}
+
 func (s *MatcherDataSuite) TestMatchTaskImmediatelyDisabledBacklog() {
 	// register some backlog with old tasks
 	s.md.EnqueueTaskNoWait(s.newBacklogTask(123, 10*time.Minute, nil))
@@ -888,7 +916,7 @@ func (s *MatcherDataSuite) TestFindMatch() {
 			// Call findMatch
 			s.md.lock.Lock()
 			now := s.ts.Now().UnixNano()
-			foundTask, foundPoller, _ := s.md.findMatch(tc.allowForwarding, now)
+			foundTask, foundPoller, _, _ := s.md.findMatch(tc.allowForwarding, now)
 			s.md.lock.Unlock()
 
 			if tc.shouldMatch {

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -676,6 +676,9 @@ func syncMatchOutcomeToHook(outcome syncMatchOutcome) hooks.SyncMatchOutcome {
 	case syncMatchUnspecified:
 		return hooks.SyncMatchOutcomeUnspecified
 	default:
+		// syncMatchPerKeyRateLimited, syncMatchNoPoller, syncMatchBacklogPresent
+		// all map to NotMatched. Per-key rate limiting should not suppress WCI
+		// scaling because other fairness keys may still need workers.
 		return hooks.SyncMatchOutcomeNotMatched
 	}
 }

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -673,12 +673,11 @@ func syncMatchOutcomeToHook(outcome syncMatchOutcome) hooks.SyncMatchOutcome {
 		return hooks.SyncMatchOutcomeSuccess
 	case syncMatchRateLimited:
 		return hooks.SyncMatchOutcomeRateLimited
+	case syncMatchFairnessKeyRateLimited:
+		return hooks.SyncMatchOutcomeFairnessKeyRateLimited
 	case syncMatchUnspecified:
 		return hooks.SyncMatchOutcomeUnspecified
 	default:
-		// syncMatchPerKeyRateLimited, syncMatchNoPoller, syncMatchBacklogPresent
-		// all map to NotMatched. Per-key rate limiting should not suppress WCI
-		// scaling because other fairness keys may still need workers.
 		return hooks.SyncMatchOutcomeNotMatched
 	}
 }


### PR DESCRIPTION
## What

Distinguishes per-fairness-key rate limiting from whole-queue rate limiting by introducing a new enum constant called `SyncMatchOutcomeFairnessKeyRateLimited`. This is now propagated to the matching hook API.

## Why

PR #10045 added `SyncMatchOutcomeRateLimited` but didn't distinguish whole-queue from per-key rate limits. These have different scaling implications: whole-queue limits mean more workers can't help, but per-key limits doesn't mean you cannot scale up.

## How did you test it?

Unit tests: `TestMatchTaskImmediatelyFairnessKeyRateLimited` verifies per-key rate limiting returns the distinct outcome; existing `TestMatchTaskImmediatelyRateLimited` covers the whole-queue case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)