### PR TITLE
Add intra-namespace percentage rollout for CHASM Nexus operation creation

### DIFF
--- a/chasm/lib/nexusoperation/config.go
+++ b/chasm/lib/nexusoperation/config.go
@@ -42,6 +42,29 @@ var EnableChasmWorkflowOperations = dynamicconfig.NewNamespaceBoolSetting(
 CHASM-based implementation of Nexus will be used when scheduling new Nexus Operations.`,
 )
 
+var ChasmWorkflowOperationsRolloutPercent = dynamicconfig.NewNamespaceIntSetting(
+	"nexusoperation.chasmWorkflowOperationsRolloutPercent",
+	0,
+	`Per-namespace percentage [0,100] of workflows whose new Nexus Operations are created on the CHASM-based
+implementation instead of the legacy HSM-based implementation. This setting is only consulted when
+enableChasmWorkflowOperations is true and is re-evaluated on every ScheduleNexusOperation command. Membership is
+decided by a stable hash of the namespace and workflow ID, so a given workflow consistently lands on the same
+implementation across all of its operations and dialing the percentage up is monotonic. Defaults to 0 (conservative
+dial-up model): even when enableChasmWorkflowOperations is on, no operations are routed to CHASM until the percentage
+is explicitly dialed up.`,
+)
+
+// UseChasmForWorkflow reports whether new Nexus operations for a workflow
+// should be created on CHASM. Live creation and rebuild must share this
+// predicate so reset keeps workflows in the same rollout bucket.
+func UseChasmForWorkflow(enabled bool, rolloutPercent int, namespaceName, workflowID string) bool {
+	if !enabled {
+		return false
+	}
+	key := fmt.Appendf(nil, "%s\x00%s", namespaceName, workflowID)
+	return dynamicconfig.RolloutAccepts(key, rolloutPercent)
+}
+
 var RequestTimeout = dynamicconfig.NewDestinationDurationSetting(
 	"nexusoperation.request.timeout",
 	time.Second*10,
@@ -218,33 +241,34 @@ Added for safety. Defaults to true. Likely to be removed in future server versio
 )
 
 type Config struct {
-	Enabled                             dynamicconfig.BoolPropertyFnWithNamespaceFilter
-	EnableChasm                         dynamicconfig.BoolPropertyFnWithNamespaceFilter
-	EnableChasmNexusWorkflowOperations  dynamicconfig.BoolPropertyFnWithNamespaceFilter
-	NumHistoryShards                    int32
-	LongPollBuffer                      dynamicconfig.DurationPropertyFnWithNamespaceFilter
-	LongPollTimeout                     dynamicconfig.DurationPropertyFnWithNamespaceFilter
-	RequestTimeout                      dynamicconfig.DurationPropertyFnWithDestinationFilter
-	MinRequestTimeout                   dynamicconfig.DurationPropertyFnWithNamespaceFilter
-	MaxConcurrentOperationsPerWorkflow  dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxServiceNameLength                dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxOperationNameLength              dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxOperationTokenLength             dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxOperationHeaderSize              dynamicconfig.IntPropertyFnWithNamespaceFilter
-	DisallowedOperationHeaders          dynamicconfig.TypedPropertyFn[[]string]
-	MaxOperationScheduleToCloseTimeout  dynamicconfig.DurationPropertyFnWithNamespaceFilter
-	PayloadSizeLimit                    dynamicconfig.IntPropertyFnWithNamespaceFilter
-	CallbackURLTemplate                 dynamicconfig.TypedPropertyFn[*template.Template]
-	UseSystemCallbackURL                dynamicconfig.BoolPropertyFn
-	PayloadSizeLimitWarn                dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxUserMetadataSummarySize          dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxUserMetadataDetailsSize          dynamicconfig.IntPropertyFnWithNamespaceFilter
-	UseNewFailureWireFormat             dynamicconfig.BoolPropertyFnWithNamespaceFilter
-	RecordCancelRequestCompletionEvents dynamicconfig.BoolPropertyFn
-	VisibilityMaxPageSize               dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxIDLengthLimit                    dynamicconfig.IntPropertyFn
-	MaxReasonLength                     dynamicconfig.IntPropertyFnWithNamespaceFilter
-	RetryPolicy                         func() backoff.RetryPolicy
+	Enabled                                    dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	EnableChasm                                dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	EnableChasmNexusWorkflowOperations         dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	ChasmNexusWorkflowOperationsRolloutPercent dynamicconfig.IntPropertyFnWithNamespaceFilter
+	NumHistoryShards                           int32
+	LongPollBuffer                             dynamicconfig.DurationPropertyFnWithNamespaceFilter
+	LongPollTimeout                            dynamicconfig.DurationPropertyFnWithNamespaceFilter
+	RequestTimeout                             dynamicconfig.DurationPropertyFnWithDestinationFilter
+	MinRequestTimeout                          dynamicconfig.DurationPropertyFnWithNamespaceFilter
+	MaxConcurrentOperationsPerWorkflow         dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxServiceNameLength                       dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxOperationNameLength                     dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxOperationTokenLength                    dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxOperationHeaderSize                     dynamicconfig.IntPropertyFnWithNamespaceFilter
+	DisallowedOperationHeaders                 dynamicconfig.TypedPropertyFn[[]string]
+	MaxOperationScheduleToCloseTimeout         dynamicconfig.DurationPropertyFnWithNamespaceFilter
+	PayloadSizeLimit                           dynamicconfig.IntPropertyFnWithNamespaceFilter
+	CallbackURLTemplate                        dynamicconfig.TypedPropertyFn[*template.Template]
+	UseSystemCallbackURL                       dynamicconfig.BoolPropertyFn
+	PayloadSizeLimitWarn                       dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxUserMetadataSummarySize                 dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxUserMetadataDetailsSize                 dynamicconfig.IntPropertyFnWithNamespaceFilter
+	UseNewFailureWireFormat                    dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	RecordCancelRequestCompletionEvents        dynamicconfig.BoolPropertyFn
+	VisibilityMaxPageSize                      dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxIDLengthLimit                           dynamicconfig.IntPropertyFn
+	MaxReasonLength                            dynamicconfig.IntPropertyFnWithNamespaceFilter
+	RetryPolicy                                func() backoff.RetryPolicy
 }
 
 func configProvider(dc *dynamicconfig.Collection, cfg *config.Persistence) *Config {
@@ -252,6 +276,7 @@ func configProvider(dc *dynamicconfig.Collection, cfg *config.Persistence) *Conf
 		Enabled:                            Enabled.Get(dc),
 		EnableChasm:                        dynamicconfig.EnableChasm.Get(dc),
 		EnableChasmNexusWorkflowOperations: EnableChasmWorkflowOperations.Get(dc),
+		ChasmNexusWorkflowOperationsRolloutPercent: ChasmWorkflowOperationsRolloutPercent.Get(dc),
 		NumHistoryShards:                   cfg.NumHistoryShards,
 		LongPollBuffer:                     LongPollBuffer.Get(dc),
 		LongPollTimeout:                    LongPollTimeout.Get(dc),

--- a/chasm/lib/workflow/nexus_commands.go
+++ b/chasm/lib/workflow/nexus_commands.go
@@ -35,7 +35,12 @@ func (ch *nexusCommandHandler) handleScheduleCommand(
 	ns := ctx.NamespaceEntry()
 	nsName := ns.Name().String()
 
-	if !ch.config.EnableChasmNexusWorkflowOperations(nsName) {
+	// Use the shared rollout predicate. If it rejects, let HSM create the operation.
+	if !nexusoperation.UseChasmForWorkflow(
+		ch.config.EnableChasmNexusWorkflowOperations(nsName),
+		ch.config.ChasmNexusWorkflowOperationsRolloutPercent(nsName),
+		nsName, ctx.ExecutionKey().BusinessID,
+	) {
 		return ErrCommandNotSupported
 	}
 

--- a/chasm/lib/workflow/nexus_commands_test.go
+++ b/chasm/lib/workflow/nexus_commands_test.go
@@ -54,16 +54,21 @@ func (tcx *testContext) setHasAnyBufferedEvent(value bool) {
 }
 
 var defaultConfig = &nexusoperation.Config{
-	EnableChasmNexusWorkflowOperations: dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
-	MaxServiceNameLength:               dynamicconfig.GetIntPropertyFnFilteredByNamespace(len("service")),
-	MaxOperationNameLength:             dynamicconfig.GetIntPropertyFnFilteredByNamespace(len("op")),
-	MaxConcurrentOperationsPerWorkflow: dynamicconfig.GetIntPropertyFnFilteredByNamespace(2),
-	MaxOperationHeaderSize:             dynamicconfig.GetIntPropertyFnFilteredByNamespace(20),
-	DisallowedOperationHeaders:         dynamicconfig.GetTypedPropertyFn([]string{"request-timeout"}),
-	MaxOperationScheduleToCloseTimeout: dynamicconfig.GetDurationPropertyFnFilteredByNamespace(time.Hour * 24),
+	EnableChasmNexusWorkflowOperations:         dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
+	ChasmNexusWorkflowOperationsRolloutPercent: dynamicconfig.GetIntPropertyFnFilteredByNamespace(100),
+	MaxServiceNameLength:                       dynamicconfig.GetIntPropertyFnFilteredByNamespace(len("service")),
+	MaxOperationNameLength:                     dynamicconfig.GetIntPropertyFnFilteredByNamespace(len("op")),
+	MaxConcurrentOperationsPerWorkflow:         dynamicconfig.GetIntPropertyFnFilteredByNamespace(2),
+	MaxOperationHeaderSize:                     dynamicconfig.GetIntPropertyFnFilteredByNamespace(20),
+	DisallowedOperationHeaders:                 dynamicconfig.GetTypedPropertyFn([]string{"request-timeout"}),
+	MaxOperationScheduleToCloseTimeout:         dynamicconfig.GetDurationPropertyFnFilteredByNamespace(time.Hour * 24),
 }
 
-func newTestContext(t *testing.T, cfg *nexusoperation.Config) testContext {
+func newTestContext(t *testing.T, cfg *nexusoperation.Config, workflowID ...string) testContext {
+	wfID := ""
+	if len(workflowID) > 0 {
+		wfID = workflowID[0]
+	}
 	endpointReg := nexustest.FakeEndpointRegistry{
 		OnGetByName: func(ctx context.Context, namespaceID namespace.ID, endpointName string) (*persistencespb.NexusEndpointEntry, error) {
 			if endpointName == "endpoint caller namespace unauthorized" {
@@ -113,6 +118,7 @@ func newTestContext(t *testing.T, cfg *nexusoperation.Config) testContext {
 			HandleExecutionKey: func() chasm.ExecutionKey {
 				return chasm.ExecutionKey{
 					NamespaceID: tests.GlobalNamespaceEntry.ID().String(),
+					BusinessID:  wfID,
 				}
 			},
 			GoCtx: context.WithValue(context.Background(), nexusoperation.OperationContextKey, &nexusoperation.OperationContext{MetricTagConfig: dynamicconfig.GetTypedPropertyFn(nexusoperation.NexusMetricTagConfig{})}),
@@ -143,11 +149,61 @@ func newTestContext(t *testing.T, cfg *nexusoperation.Config) testContext {
 func TestHandleScheduleCommand(t *testing.T) {
 	t.Run("chasm nexus not enabled", func(t *testing.T) {
 		tcx := newTestContext(t, &nexusoperation.Config{
-			EnableChasmNexusWorkflowOperations: dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+			EnableChasmNexusWorkflowOperations:         dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+			ChasmNexusWorkflowOperationsRolloutPercent: dynamicconfig.GetIntPropertyFnFilteredByNamespace(100),
 		})
 		err := tcx.scheduleHandler(tcx.chasmCtx, tcx.wf, commandValidator{maxPayloadSize: 1}, &commandpb.Command{}, CommandHandlerOptions{WorkflowTaskCompletedEventID: 1})
 		require.ErrorIs(t, err, ErrCommandNotSupported)
 		require.Empty(t, tcx.history.Events)
+	})
+
+	validScheduleCmd := &commandpb.Command{
+		Attributes: &commandpb.Command_ScheduleNexusOperationCommandAttributes{
+			ScheduleNexusOperationCommandAttributes: &commandpb.ScheduleNexusOperationCommandAttributes{
+				Endpoint:  "endpoint",
+				Service:   "service",
+				Operation: "op",
+			},
+		},
+	}
+
+	t.Run("rollout percent 0 routes all operations to HSM", func(t *testing.T) {
+		cfg := *defaultConfig
+		cfg.ChasmNexusWorkflowOperationsRolloutPercent = dynamicconfig.GetIntPropertyFnFilteredByNamespace(0)
+		tcx := newTestContext(t, &cfg, "any-workflow")
+		err := tcx.scheduleHandler(tcx.chasmCtx, tcx.wf, commandValidator{maxPayloadSize: 1}, validScheduleCmd, CommandHandlerOptions{WorkflowTaskCompletedEventID: 1})
+		require.ErrorIs(t, err, ErrCommandNotSupported)
+		require.Empty(t, tcx.history.Events)
+	})
+
+	t.Run("rollout percent 100 routes all operations to CHASM", func(t *testing.T) {
+		cfg := *defaultConfig
+		cfg.ChasmNexusWorkflowOperationsRolloutPercent = dynamicconfig.GetIntPropertyFnFilteredByNamespace(100)
+		tcx := newTestContext(t, &cfg, "any-workflow")
+		err := tcx.scheduleHandler(tcx.chasmCtx, tcx.wf, commandValidator{maxPayloadSize: 1}, validScheduleCmd, CommandHandlerOptions{WorkflowTaskCompletedEventID: 1})
+		require.NoError(t, err)
+		require.Len(t, tcx.history.Events, 1)
+	})
+
+	t.Run("rollout percent routes by workflow id", func(t *testing.T) {
+		nsName := tests.GlobalNamespaceEntry.Name().String()
+		const percent = 50
+		// These IDs are pinned to opposite sides of the 50% rollout for this namespace.
+		const insideID, outsideID = "wf-4", "wf-0"
+		require.True(t, dynamicconfig.RolloutAccepts(fmt.Appendf(nil, "%s\x00%s", nsName, insideID), percent))
+		require.False(t, dynamicconfig.RolloutAccepts(fmt.Appendf(nil, "%s\x00%s", nsName, outsideID), percent))
+
+		cfg := *defaultConfig
+		cfg.ChasmNexusWorkflowOperationsRolloutPercent = dynamicconfig.GetIntPropertyFnFilteredByNamespace(percent)
+
+		scheduleFor := func(workflowID string) error {
+			tcx := newTestContext(t, &cfg, workflowID)
+			return tcx.scheduleHandler(tcx.chasmCtx, tcx.wf, commandValidator{maxPayloadSize: 1}, validScheduleCmd, CommandHandlerOptions{WorkflowTaskCompletedEventID: 1})
+		}
+
+		// A workflow inside the rollout routes to CHASM; one outside falls back to HSM.
+		require.NoError(t, scheduleFor(insideID))
+		require.ErrorIs(t, scheduleFor(outsideID), ErrCommandNotSupported)
 	})
 
 	t.Run("empty attributes", func(t *testing.T) {

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -60,27 +60,28 @@ type Config struct {
 
 	// HistoryCache settings
 	// Change of these configs require shard restart
-	HistoryCacheLimitSizeBased            bool
-	HistoryHostLevelCacheMaxSize          dynamicconfig.IntPropertyFn
-	HistoryHostLevelCacheMaxSizeBytes     dynamicconfig.IntPropertyFn
-	HistoryCacheTTL                       dynamicconfig.DurationPropertyFn
-	HistoryCacheNonUserContextLockTimeout dynamicconfig.DurationPropertyFn
-	HistoryCacheBackgroundEvict           dynamicconfig.TypedPropertyFn[dynamicconfig.CacheBackgroundEvictSettings]
-	EnableWorkflowExecutionTimeoutTimer   dynamicconfig.BoolPropertyFn
-	EnableUpdateWorkflowModeIgnoreCurrent dynamicconfig.BoolPropertyFn
-	EnableTransitionHistory               dynamicconfig.BoolPropertyFnWithNamespaceFilter
-	MaxCallbacksPerWorkflow               dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxCallbacksPerExecution              dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxCallbacksPerUpdateID               dynamicconfig.IntPropertyFnWithNamespaceFilter
-	EnableChasm                           dynamicconfig.BoolPropertyFnWithNamespaceFilter
-	EnableChasmNexusWorkflowOperations    dynamicconfig.BoolPropertyFnWithNamespaceFilter
-	EnableCHASMCallbacks                  dynamicconfig.BoolPropertyFnWithNamespaceFilter
-	EnableCHASMSignalBacklinks            dynamicconfig.BoolPropertyFnWithNamespaceFilter
-	EnableWorkflowUpdateCallbacks         dynamicconfig.BoolPropertyFnWithNamespaceFilter
-	ChasmMaxInMemoryPureTasks             dynamicconfig.IntPropertyFn
-	EnableCHASMSchedulerCreation          dynamicconfig.BoolPropertyFnWithNamespaceFilter
-	EnableCHASMSchedulerMigration         dynamicconfig.BoolPropertyFnWithNamespaceFilter
-	ExternalPayloadsEnabled               dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	HistoryCacheLimitSizeBased                 bool
+	HistoryHostLevelCacheMaxSize               dynamicconfig.IntPropertyFn
+	HistoryHostLevelCacheMaxSizeBytes          dynamicconfig.IntPropertyFn
+	HistoryCacheTTL                            dynamicconfig.DurationPropertyFn
+	HistoryCacheNonUserContextLockTimeout      dynamicconfig.DurationPropertyFn
+	HistoryCacheBackgroundEvict                dynamicconfig.TypedPropertyFn[dynamicconfig.CacheBackgroundEvictSettings]
+	EnableWorkflowExecutionTimeoutTimer        dynamicconfig.BoolPropertyFn
+	EnableUpdateWorkflowModeIgnoreCurrent      dynamicconfig.BoolPropertyFn
+	EnableTransitionHistory                    dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	MaxCallbacksPerWorkflow                    dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxCallbacksPerExecution                   dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxCallbacksPerUpdateID                    dynamicconfig.IntPropertyFnWithNamespaceFilter
+	EnableChasm                                dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	EnableChasmNexusWorkflowOperations         dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	ChasmNexusWorkflowOperationsRolloutPercent dynamicconfig.IntPropertyFnWithNamespaceFilter
+	EnableCHASMCallbacks                       dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	EnableCHASMSignalBacklinks                 dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	EnableWorkflowUpdateCallbacks              dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	ChasmMaxInMemoryPureTasks                  dynamicconfig.IntPropertyFn
+	EnableCHASMSchedulerCreation               dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	EnableCHASMSchedulerMigration              dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	ExternalPayloadsEnabled                    dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
 	// EventsCache settings
 	// Change of these configs require shard restart
@@ -489,21 +490,22 @@ func NewConfig(
 		EmitShardLagLog:       dynamicconfig.EmitShardLagLog.Get(dc),
 		EnableDataLossMetrics: dynamicconfig.EnableDataLossMetrics.Get(dc),
 		// HistoryCacheLimitSizeBased should not change during runtime.
-		HistoryCacheLimitSizeBased:            dynamicconfig.HistoryCacheSizeBasedLimit.Get(dc)(),
-		HistoryHostLevelCacheMaxSize:          dynamicconfig.HistoryCacheHostLevelMaxSize.Get(dc),
-		HistoryHostLevelCacheMaxSizeBytes:     dynamicconfig.HistoryCacheHostLevelMaxSizeBytes.Get(dc),
-		HistoryCacheTTL:                       dynamicconfig.HistoryCacheTTL.Get(dc),
-		HistoryCacheNonUserContextLockTimeout: dynamicconfig.HistoryCacheNonUserContextLockTimeout.Get(dc),
-		HistoryCacheBackgroundEvict:           dynamicconfig.HistoryCacheBackgroundEvict.Get(dc),
-		EnableWorkflowExecutionTimeoutTimer:   dynamicconfig.EnableWorkflowExecutionTimeoutTimer.Get(dc),
-		EnableUpdateWorkflowModeIgnoreCurrent: dynamicconfig.EnableUpdateWorkflowModeIgnoreCurrent.Get(dc),
-		EnableTransitionHistory:               dynamicconfig.EnableTransitionHistory.Get(dc),
-		MaxCallbacksPerWorkflow:               dynamicconfig.MaxCallbacksPerWorkflow.Get(dc),
-		MaxCallbacksPerExecution:              callback.MaxPerExecution.Get(dc),
-		MaxCallbacksPerUpdateID:               dynamicconfig.MaxCallbacksPerUpdateID.Get(dc),
-		EnableChasm:                           dynamicconfig.EnableChasm.Get(dc),
-		EnableChasmNexusWorkflowOperations:    nexusoperation.EnableChasmWorkflowOperations.Get(dc),
-		ChasmMaxInMemoryPureTasks:             dynamicconfig.ChasmMaxInMemoryPureTasks.Get(dc),
+		HistoryCacheLimitSizeBased:                 dynamicconfig.HistoryCacheSizeBasedLimit.Get(dc)(),
+		HistoryHostLevelCacheMaxSize:               dynamicconfig.HistoryCacheHostLevelMaxSize.Get(dc),
+		HistoryHostLevelCacheMaxSizeBytes:          dynamicconfig.HistoryCacheHostLevelMaxSizeBytes.Get(dc),
+		HistoryCacheTTL:                            dynamicconfig.HistoryCacheTTL.Get(dc),
+		HistoryCacheNonUserContextLockTimeout:      dynamicconfig.HistoryCacheNonUserContextLockTimeout.Get(dc),
+		HistoryCacheBackgroundEvict:                dynamicconfig.HistoryCacheBackgroundEvict.Get(dc),
+		EnableWorkflowExecutionTimeoutTimer:        dynamicconfig.EnableWorkflowExecutionTimeoutTimer.Get(dc),
+		EnableUpdateWorkflowModeIgnoreCurrent:      dynamicconfig.EnableUpdateWorkflowModeIgnoreCurrent.Get(dc),
+		EnableTransitionHistory:                    dynamicconfig.EnableTransitionHistory.Get(dc),
+		MaxCallbacksPerWorkflow:                    dynamicconfig.MaxCallbacksPerWorkflow.Get(dc),
+		MaxCallbacksPerExecution:                   callback.MaxPerExecution.Get(dc),
+		MaxCallbacksPerUpdateID:                    dynamicconfig.MaxCallbacksPerUpdateID.Get(dc),
+		EnableChasm:                                dynamicconfig.EnableChasm.Get(dc),
+		EnableChasmNexusWorkflowOperations:         nexusoperation.EnableChasmWorkflowOperations.Get(dc),
+		ChasmNexusWorkflowOperationsRolloutPercent: nexusoperation.ChasmWorkflowOperationsRolloutPercent.Get(dc),
+		ChasmMaxInMemoryPureTasks:                  dynamicconfig.ChasmMaxInMemoryPureTasks.Get(dc),
 
 		EnableCHASMSchedulerCreation:  dynamicconfig.EnableCHASMSchedulerCreation.Get(dc),
 		EnableCHASMSchedulerMigration: dynamicconfig.EnableCHASMSchedulerMigration.Get(dc),

--- a/service/history/workflow/mutable_state_rebuilder.go
+++ b/service/history/workflow/mutable_state_rebuilder.go
@@ -14,6 +14,7 @@ import (
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
 	enumsspb "go.temporal.io/server/api/enums/v1"
+	"go.temporal.io/server/chasm/lib/nexusoperation"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
@@ -751,13 +752,17 @@ func (b *MutableStateRebuilderImpl) applyChasmEvent(
 	if !b.mutableState.ChasmEnabled() {
 		return false, nil
 	}
-	// Creating a Nexus operation is routed by the per-namespace nexusoperation.enableChasmWorkflowOperations
-	// flag: when off, new operations are created in the HSM tree (legacy behavior). This routing applies only
-	// to the create event; non-create events are matched against wherever the operation already lives. A reset
-	// therefore realigns an operation to whichever framework new operations are created in today.
+	// Create events use the same rollout predicate as live commands so reset does
+	// not move out-of-rollout workflows to CHASM. Non-create events apply wherever
+	// the operation already lives.
 	if event.GetEventType() == enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED {
 		nsName := b.mutableState.GetNamespaceEntry().Name().String()
-		if !b.shard.GetConfig().EnableChasmNexusWorkflowOperations(nsName) {
+		cfg := b.shard.GetConfig()
+		if !nexusoperation.UseChasmForWorkflow(
+			cfg.EnableChasmNexusWorkflowOperations(nsName),
+			cfg.ChasmNexusWorkflowOperationsRolloutPercent(nsName),
+			nsName, b.mutableState.GetExecutionInfo().WorkflowId,
+		) {
 			return false, nil
 		}
 	}

--- a/service/history/workflow/mutable_state_rebuilder_test.go
+++ b/service/history/workflow/mutable_state_rebuilder_test.go
@@ -2231,6 +2231,7 @@ func (s *stateBuilderSuite) TestApplyEvents_NexusScheduled_ChasmCreateSurfacesEr
 	// Flag ON + a CHASM registry that owns the scheduled event, so the event is routed to the CHASM
 	// tree and reaches the (failing) component lookup rather than falling back to HSM.
 	s.mockShard.GetConfig().EnableChasmNexusWorkflowOperations = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
+	s.mockShard.GetConfig().ChasmNexusWorkflowOperationsRolloutPercent = dynamicconfig.GetIntPropertyFnFilteredByNamespace(100)
 	s.mockShard.SetChasmWorkflowRegistry(newFakeChasmRegistry(&fakeChasmEventDefinition{
 		eventType: enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED,
 	}))
@@ -2343,6 +2344,7 @@ func newFakeHSMRegistry(def *fakeHSMEventDefinition) *hsm.Registry {
 type nexusRebuildCase struct {
 	chasmEnabled      bool
 	flagOn            bool
+	rolloutPercent    int
 	chasmHasDef       bool
 	hsmApplyErr       error
 	chasmApplyErr     error
@@ -2370,11 +2372,13 @@ func (s *stateBuilderSuite) runApplyStateMachineEvent(
 	}
 	s.mockShard.SetChasmWorkflowRegistry(newFakeChasmRegistry(def))
 	s.mockShard.GetConfig().EnableChasmNexusWorkflowOperations = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(tc.flagOn)
+	s.mockShard.GetConfig().ChasmNexusWorkflowOperationsRolloutPercent = dynamicconfig.GetIntPropertyFnFilteredByNamespace(tc.rolloutPercent)
 
 	ms := historyi.NewMockMutableState(s.controller)
 	ms.EXPECT().HSM().Return(nil).AnyTimes()
 	ms.EXPECT().ChasmEnabled().Return(tc.chasmEnabled).AnyTimes()
 	ms.EXPECT().GetNamespaceEntry().Return(tests.GlobalNamespaceEntry).AnyTimes()
+	ms.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{WorkflowId: "test-workflow-id"}).AnyTimes()
 	ms.EXPECT().EnsureChasmWorkflowComponent(gomock.Any()).AnyTimes()
 	ms.EXPECT().ChasmWorkflowComponent(gomock.Any()).
 		Return(&chasmworkflow.Workflow{}, nil, tc.chasmComponentErr).AnyTimes()
@@ -2407,10 +2411,17 @@ func (s *stateBuilderSuite) TestApplyStateMachineEvent() {
 	}{
 		// --- create events: routed by the per-namespace flag ---
 		{
-			name:             "nexus scheduled, flag on, creates in chasm",
+			name:             "nexus scheduled, flag on, in rollout, creates in chasm",
 			event:            nexusScheduledEvent(),
-			tc:               nexusRebuildCase{chasmEnabled: true, flagOn: true, chasmHasDef: true},
+			tc:               nexusRebuildCase{chasmEnabled: true, flagOn: true, rolloutPercent: 100, chasmHasDef: true},
 			wantChasmApplied: true,
+		},
+		{
+			// Flag on but out of rollout: create events still route to HSM.
+			name:           "nexus scheduled, flag on, out of rollout, routes to hsm",
+			event:          nexusScheduledEvent(),
+			tc:             nexusRebuildCase{chasmEnabled: true, flagOn: true, rolloutPercent: 0, chasmHasDef: true},
+			wantHSMApplied: true,
 		},
 		{
 			name:           "nexus scheduled, flag off, routes to hsm",
@@ -2428,14 +2439,14 @@ func (s *stateBuilderSuite) TestApplyStateMachineEvent() {
 			// Flag on, but CHASM has no definition for the event: fall back to creating in HSM.
 			name:           "nexus scheduled, flag on, chasm has no definition, falls back to hsm",
 			event:          nexusScheduledEvent(),
-			tc:             nexusRebuildCase{chasmEnabled: true, flagOn: true, chasmHasDef: false},
+			tc:             nexusRebuildCase{chasmEnabled: true, flagOn: true, rolloutPercent: 100, chasmHasDef: false},
 			wantHSMApplied: true,
 		},
 		{
 			// A genuine CHASM error is surfaced, never fallen back to HSM (avoids split-brain).
 			name:    "nexus scheduled, flag on, chasm error surfaced without hsm fallback",
 			event:   nexusScheduledEvent(),
-			tc:      nexusRebuildCase{chasmEnabled: true, flagOn: true, chasmHasDef: true, chasmComponentErr: chasmErr},
+			tc:      nexusRebuildCase{chasmEnabled: true, flagOn: true, rolloutPercent: 100, chasmHasDef: true, chasmComponentErr: chasmErr},
 			wantErr: chasmErr,
 		},
 		// --- non-create events: CHASM-first, HSM fallback ---

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -66,11 +66,17 @@ func TestNexusWorkflowTestSuiteCHASM(t *testing.T) {
 }
 
 func (s *NexusWorkflowTestSuite) newTestEnv(chasmEnabled bool, opts ...testcore.TestOption) *NexusTestEnv {
+	// CHASM tests need 100% rollout because the setting defaults to 0.
+	rolloutPercent := 0
+	if chasmEnabled {
+		rolloutPercent = 100
+	}
 	return newNexusTestEnv(s.T(), true, append(
 		opts,
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, chasmEnabled),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMCallbacks, chasmEnabled),
 		testcore.WithDynamicConfig(chasmnexus.EnableChasmWorkflowOperations, chasmEnabled),
+		testcore.WithDynamicConfig(chasmnexus.ChasmWorkflowOperationsRolloutPercent, rolloutPercent),
 	)...)
 }
 
@@ -3354,10 +3360,9 @@ func (s *NexusWorkflowTestSuite) mutateCompletionComponentRef(
 	s.NoError(err)
 }
 
-// TestNexusOperationSurvivesResetCrossTree verifies that when a workflow with a pending Nexus operation is
-// reset, the rebuild re-creates the operation on the tree implied by the current enableChasmWorkflowOperations flag
-// (HSM or CHASM), and the reset run replays without failing a workflow task. Rebuild deterministically picks the
-// framework by dynamic config, so flipping the flag before reset realigns the operation to the other tree.
+// TestNexusOperationSurvivesResetCrossTree verifies that reset rebuilds a pending
+// Nexus operation with the same creation predicate as live scheduling. This suite
+// pins rollout to 100%, so flipping the boolean moves creation between HSM and CHASM.
 func (s *NexusWorkflowTestSuite) TestNexusOperationSurvivesResetCrossTree(chasmEnabled bool) {
 	// This test drives the creation-policy flag itself, so run it once (not per-suite-mode).
 	if chasmEnabled {

--- a/tests/xdc/nexus_state_replication_test.go
+++ b/tests/xdc/nexus_state_replication_test.go
@@ -108,9 +108,11 @@ func (s *NexusStateReplicationSuite) SetupSuite() {
 	if s.chasmEnabled {
 		// Set EnableChasm and EnableChasmWorkflowOperations config values to true so that
 		// CHASM based Nexus operation implementation is used over the HSM one.
-		// (EnableCHASMCallbacks already default to true).
+		// (EnableCHASMCallbacks already default to true). The rollout percentage defaults to
+		// 0, so dial it up to 100 as well; otherwise the boolean flag alone routes nothing to CHASM.
 		s.dynamicConfigOverrides[dynamicconfig.EnableChasm.Key()] = true
 		s.dynamicConfigOverrides[chasmnexusoperation.EnableChasmWorkflowOperations.Key()] = true
+		s.dynamicConfigOverrides[chasmnexusoperation.ChasmWorkflowOperationsRolloutPercent.Key()] = 100
 	}
 	s.setupSuite()
 }
@@ -722,8 +724,11 @@ func (s *NexusStateReplicationSuite) TestNexusOperationChasmReplicatedWithMixedF
 	ns := s.createGlobalNamespace()
 	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
-	// Enable CHASM operation creation only on the initially-active cluster.
+	// Enable CHASM operation creation only on the initially-active cluster. The rollout percentage
+	// defaults to 0, so dial it up to 100 there as well; otherwise the boolean flag alone routes
+	// nothing to CHASM.
 	s.clusters[0].OverrideDynamicConfig(s.T(), chasmnexusoperation.EnableChasmWorkflowOperations, true)
+	s.clusters[0].OverrideDynamicConfig(s.T(), chasmnexusoperation.ChasmWorkflowOperationsRolloutPercent, 100)
 	s.clusters[1].OverrideDynamicConfig(s.T(), chasmnexusoperation.EnableChasmWorkflowOperations, false)
 
 	// Deliver the completion callback to the failover target.


### PR DESCRIPTION
## What changed?
Adds a per-namespace **percentage** control for routing new workflow-triggered Nexus operations to the CHASM implementation, on top of the existing boolean `nexusoperation.enableChasmWorkflowOperations` flag.

- New dynamic config `nexusoperation.chasmWorkflowOperationsRolloutPercent` (int, 0–100), **default 0**.
- The HSM→CHASM creation decision is centralized in one predicate, `nexusoperation.UseChasmForWorkflow(enabled, rolloutPercent, namespaceName, workflowID)`: an operation is created on the CHASM tree only when the boolean flag is on **AND** the workflow falls within the rollout percentage. Membership is decided by the shared `RolloutAccepts` helper hashing `namespace + workflowID` (same key shape as the Scheduler CHASM rollout), so a given workflow deterministically lands on the same implementation across all of its operations and dialing the percentage up is monotonic.
- **Both** framework-decision sites use the same predicate:
  - **Live creation** — the CHASM `ScheduleNexusOperation` command handler (`handleScheduleCommand`). Out-of-rollout → `ErrCommandNotSupported`, so the operation is created on the HSM tree as before.
  - **Reset / replication rebuild** — `MutableStateRebuilder.applyChasmEvent`, on the `NexusOperationScheduled` create event. Sharing the exact predicate is required: otherwise a reset could flip an out-of-rollout workflow's operations onto CHASM.
- **Cancelation is intentionally not gated** by this predicate. It is routed by the tree that already owns the operation, so an operation created while the flag/percentage was higher can still be canceled after a downgrade.

## Why?
The per-namespace boolean is too coarse for a safe migration: turning it on sends *all* of a namespace's new Nexus operations to CHASM at once. A percentage control lets us dial CHASM adoption up gradually *within* a namespace and roll back by dialing down — the de-risking control our rollout plan requires. The default of 0 makes the boolean alone a no-op until the percentage is explicitly raised, so enabling the flag can't cause an all-at-once cutover.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Low, and gated behind the default. Default 0 means behavior is unchanged for any namespace that hasn't set the percentage — enabling the boolean alone now routes nothing to CHASM until the percentage is raised. The one behavioral consequence: any test/config that enables the boolean expecting CHASM must also set the percentage (done for the tests in the repo); no production config force-enables the boolean today. 