### PR TITLE
Update Alpine to 3.23.5

### DIFF
--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -38,7 +38,7 @@ variable "TAG_LATEST" {
 # NOTE: We use just the tag without a digest pin because digest-pinned manifest lists
 # cause platform resolution issues in multi-arch buildx builds (InvalidBaseImagePlatform warnings).
 variable "ALPINE_TAG" {
-  default = "3.23.4"
+  default = "3.23.5"
 }
 
 target "admin-tools" {


### PR DESCRIPTION
Title, bumped Alpine to newest 3.23.x. Grepped for other 3.23 references and found none.
