### PR TITLE
add time skipping runtime to chasm framework (2)

### DIFF
--- a/chasm/node_backend_mock.go
+++ b/chasm/node_backend_mock.go
@@ -23,25 +23,26 @@ var _ NodeBackend = (*MockNodeBackend)(nil)
 // fields (thread-safe).
 type MockNodeBackend struct {
 	// Optional function overrides. If nil, methods return zero-values.
-	HandleGetExecutionState           func() *persistencespb.WorkflowExecutionState
-	HandleGetExecutionInfo            func() *persistencespb.WorkflowExecutionInfo
-	HandleGetCurrentVersion           func() int64
-	HandleNextTransitionCount         func() int64
-	HandleGetApproximatePersistedSize func() int
-	HandleCurrentVersionedTransition  func() *persistencespb.VersionedTransition
-	HandleGetWorkflowKey              func() definition.WorkflowKey
-	HandleUpdateWorkflowStateStatus   func(state enumsspb.WorkflowExecutionState, status enumspb.WorkflowExecutionStatus) (bool, error)
-	HandleIsWorkflow                  func() bool
-	HandleGetNexusCompletion          func(ctx context.Context, requestID string) (nexusrpc.CompleteOperationOptions, error)
-	HandleGetNexusUpdateCompletion    func(ctx context.Context, updateID string, requestID string) (nexusrpc.CompleteOperationOptions, error)
-	HandleAddHistoryEvent             func(t enumspb.EventType, setAttributes func(*historypb.HistoryEvent)) *historypb.HistoryEvent
-	HandleLoadHistoryEvent            func(ctx context.Context, token []byte) (*historypb.HistoryEvent, error)
-	HandleGenerateEventLoadToken      func(event *historypb.HistoryEvent) ([]byte, error)
-	HandleHasAnyBufferedEvent         func(filter func(*historypb.HistoryEvent) bool) bool
-	HandleGetNamespaceEntry           func() *namespace.Namespace
-	HandleEndpointRegistry            func() EndpointRegistry
-	HandleSetTimeSkippingConfig       func(config *commonpb.TimeSkippingConfig)
-	HandleNow                         func() time.Time
+	HandleGetExecutionState            func() *persistencespb.WorkflowExecutionState
+	HandleGetExecutionInfo             func() *persistencespb.WorkflowExecutionInfo
+	HandleGetCurrentVersion            func() int64
+	HandleNextTransitionCount          func() int64
+	HandleGetApproximatePersistedSize  func() int
+	HandleCurrentVersionedTransition   func() *persistencespb.VersionedTransition
+	HandleGetWorkflowKey               func() definition.WorkflowKey
+	HandleUpdateWorkflowStateStatus    func(state enumsspb.WorkflowExecutionState, status enumspb.WorkflowExecutionStatus) (bool, error)
+	HandleIsWorkflow                   func() bool
+	HandleGetNexusCompletion           func(ctx context.Context, requestID string) (nexusrpc.CompleteOperationOptions, error)
+	HandleGetNexusUpdateCompletion     func(ctx context.Context, updateID string, requestID string) (nexusrpc.CompleteOperationOptions, error)
+	HandleAddHistoryEvent              func(t enumspb.EventType, setAttributes func(*historypb.HistoryEvent)) *historypb.HistoryEvent
+	HandleLoadHistoryEvent             func(ctx context.Context, token []byte) (*historypb.HistoryEvent, error)
+	HandleGenerateEventLoadToken       func(event *historypb.HistoryEvent) ([]byte, error)
+	HandleHasAnyBufferedEvent          func(filter func(*historypb.HistoryEvent) bool) bool
+	HandleGetNamespaceEntry            func() *namespace.Namespace
+	HandleEndpointRegistry             func() EndpointRegistry
+	HandleSetTimeSkippingConfig        func(config *commonpb.TimeSkippingConfig)
+	HandleNow                          func() time.Time
+	HandleRecordTimeSkippingTransition func(transition *TimeSkippingTransition)
 
 	// Recorded calls (protected by mu).
 	mu                  sync.Mutex
@@ -271,4 +272,12 @@ func (m *MockNodeBackend) Now() time.Time {
 		return m.HandleNow()
 	}
 	return time.Now()
+}
+
+func (m *MockNodeBackend) RecordTimeSkippingTransition(transition *TimeSkippingTransition) {
+	if m.HandleRecordTimeSkippingTransition != nil {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		m.HandleRecordTimeSkippingTransition(transition)
+	}
 }

--- a/chasm/test_component_test.go
+++ b/chasm/test_component_test.go
@@ -64,6 +64,13 @@ type (
 		SubComponent2Data *protoMessageType
 	}
 
+	TestTimeSkippingImplComponent struct {
+		UnimplementedComponent
+
+		ComponentData        *protoMessageType
+		isExecutionSkippable bool
+	}
+
 	TestSubComponent interface {
 		GetData() string
 	}
@@ -82,6 +89,8 @@ var (
 	_ VisibilitySearchAttributesProvider = (*TestComponent)(nil)
 	_ VisibilityMemoProvider             = (*TestComponent)(nil)
 	_ RootComponent                      = (*TestComponent)(nil)
+	_ RootComponent                      = (*TestTimeSkippingImplComponent)(nil)
+	_ TimeSkippingRuntimeGate            = (*TestTimeSkippingImplComponent)(nil)
 )
 
 func (tc *TestComponent) LifecycleState(_ Context) LifecycleState {
@@ -180,6 +189,26 @@ func (tsc11 *TestSubComponent11) LifecycleState(_ Context) LifecycleState {
 
 func (tsc2 *TestSubComponent2) LifecycleState(_ Context) LifecycleState {
 	return LifecycleStateRunning
+}
+
+func (gc *TestTimeSkippingImplComponent) LifecycleState(_ Context) LifecycleState {
+	return LifecycleStateRunning
+}
+
+func (gc *TestTimeSkippingImplComponent) ContextMetadata(_ Context) map[string]string {
+	return nil
+}
+
+func (gc *TestTimeSkippingImplComponent) Terminate(
+	_ MutableContext,
+	_ TerminateComponentRequest,
+) (TerminateComponentResponse, error) {
+	return TerminateComponentResponse{}, nil
+}
+
+// IsExecutionSkippable implements the TimeSkippingRuntimeGate interface.
+func (gc *TestTimeSkippingImplComponent) IsExecutionSkippable(_ Context) bool {
+	return gc.isExecutionSkippable
 }
 
 func setTestComponentFields(c *TestComponent, backend *MockNodeBackend) {

--- a/chasm/test_library_test.go
+++ b/chasm/test_library_test.go
@@ -40,6 +40,7 @@ func (l *TestLibrary) Components() []*RegistrableComponent {
 			WithBusinessIDAlias("TestBusinessId"),
 			WithSearchAttributes(TestComponentStartTimeSearchAttribute),
 		),
+		NewRegistrableComponent[*TestTimeSkippingImplComponent](testTimeSkippingComponentName),
 		NewRegistrableComponent[*TestSubComponent1](testSubComponent1Name),
 		NewRegistrableComponent[*TestSubComponent11](testSubComponent11Name),
 		NewRegistrableComponent[*TestSubComponent2](testSubComponent2Name),

--- a/chasm/test_var_test.go
+++ b/chasm/test_var_test.go
@@ -1,11 +1,12 @@
 package chasm
 
 const (
-	testLibraryName        = "TestLibrary"
-	testComponentName      = "test_component"
-	testSubComponent1Name  = "test_sub_component_1"
-	testSubComponent11Name = "test_sub_component_11"
-	testSubComponent2Name  = "test_sub_component_2"
+	testLibraryName               = "TestLibrary"
+	testComponentName             = "test_component"
+	testTimeSkippingComponentName = "test_timeskipping_component"
+	testSubComponent1Name         = "test_sub_component_1"
+	testSubComponent11Name        = "test_sub_component_11"
+	testSubComponent2Name         = "test_sub_component_2"
 
 	testSideEffectTaskName            = "test_side_effect_task"
 	testDiscardableSideEffectTaskName = "test_discardable_side_effect_task"

--- a/chasm/timeskipping.go
+++ b/chasm/timeskipping.go
@@ -41,10 +41,7 @@ type TimeSkippingRuntimeGate interface {
 // =============================================================================
 // Time Skipping Data Structure
 // =============================================================================
-<<<<<<< HEAD
 
-=======
->>>>>>> ecc8e5e32 (add time skipping to chasm framework)
 type TimeSkippingTransition struct {
 	CurrentTime              time.Time
 	TargetTime               time.Time

--- a/chasm/timeskipping.go
+++ b/chasm/timeskipping.go
@@ -41,7 +41,10 @@ type TimeSkippingRuntimeGate interface {
 // =============================================================================
 // Time Skipping Data Structure
 // =============================================================================
+<<<<<<< HEAD
 
+=======
+>>>>>>> ecc8e5e32 (add time skipping to chasm framework)
 type TimeSkippingTransition struct {
 	CurrentTime              time.Time
 	TargetTime               time.Time

--- a/chasm/timeskipping.go
+++ b/chasm/timeskipping.go
@@ -43,8 +43,11 @@ type TimeSkippingRuntimeGate interface {
 // =============================================================================
 
 type TimeSkippingTransition struct {
-	CurrentTime              time.Time
-	TargetTime               time.Time
+	CurrentTime time.Time
+	// targetTime is intentionally private: it may only be written through TrackEarliestFutureTime
+	// and GateByFastForward, both of which reject any candidate before CurrentTime. That guarantee
+	// is what keeps GetSkippedDuration from ever going negative. Read it via GetTargetTime.
+	targetTime               time.Time
 	DisabledAfterFastForward bool
 }
 
@@ -60,15 +63,25 @@ func NewTimeSkippingTransition(currentTime time.Time) *TimeSkippingTransition {
 // signal. Nil-safe. A transition without a current time is never valid — every meaningful field is
 // derived relative to the current time, so without it there is nothing to apply.
 func (t *TimeSkippingTransition) IsValid() bool {
-	return t != nil && !t.CurrentTime.IsZero() && (!t.TargetTime.IsZero() || t.DisabledAfterFastForward)
+	return t != nil && !t.CurrentTime.IsZero() && (!t.targetTime.IsZero() || t.DisabledAfterFastForward)
+}
+
+// GetTargetTime returns the earliest tracked skip target, or the zero time when none has been set.
+// Nil-safe. This is the only way to read the target: it is written exclusively through
+// TrackEarliestFutureTime and GateByFastForward, which never accept a time before CurrentTime.
+func (t *TimeSkippingTransition) GetTargetTime() time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	return t.targetTime
 }
 
 func (t *TimeSkippingTransition) TrackEarliestFutureTime(candidate time.Time) {
 	if t == nil || t.CurrentTime.IsZero() || candidate.IsZero() || candidate.Before(t.CurrentTime) {
 		return
 	}
-	if t.TargetTime.IsZero() || candidate.Before(t.TargetTime) {
-		t.TargetTime = candidate
+	if t.targetTime.IsZero() || candidate.Before(t.targetTime) {
+		t.targetTime = candidate
 	}
 }
 
@@ -83,7 +96,7 @@ func (t *TimeSkippingTransition) GateByFastForward(ff *persistencespb.FastForwar
 	ffTargetTime := ff.GetTargetTime().AsTime()
 	// If a real candidate is scheduled strictly before the fast-forward target, we skip to
 	// that and the fast-forward budget is not yet exhausted — leave time skipping enabled.
-	if !t.TargetTime.IsZero() && t.TargetTime.Before(ffTargetTime) {
+	if !t.targetTime.IsZero() && t.targetTime.Before(ffTargetTime) {
 		return
 	}
 	// Otherwise the fast-forward target is the earliest target: skip to it (clamped to the
@@ -95,8 +108,8 @@ func (t *TimeSkippingTransition) GateByFastForward(ff *persistencespb.FastForwar
 }
 
 func (t *TimeSkippingTransition) GetSkippedDuration() time.Duration {
-	if t == nil || t.CurrentTime.IsZero() || t.TargetTime.IsZero() {
+	if t == nil || t.CurrentTime.IsZero() || t.targetTime.IsZero() {
 		return 0
 	}
-	return t.TargetTime.Sub(t.CurrentTime)
+	return t.targetTime.Sub(t.CurrentTime)
 }

--- a/chasm/timeskipping.go
+++ b/chasm/timeskipping.go
@@ -93,3 +93,10 @@ func (t *TimeSkippingTransition) GateByFastForward(ff *persistencespb.FastForwar
 	t.TrackEarliestFutureTime(ffTargetTime)
 	t.DisabledAfterFastForward = true
 }
+
+func (t *TimeSkippingTransition) GetSkippedDuration() time.Duration {
+	if t == nil || t.CurrentTime.IsZero() || t.TargetTime.IsZero() {
+		return 0
+	}
+	return t.TargetTime.Sub(t.CurrentTime)
+}

--- a/chasm/timeskipping_test.go
+++ b/chasm/timeskipping_test.go
@@ -19,7 +19,7 @@ func TestTimeSkippingTransition(t *testing.T) {
 	t.Run("New sets only the current time", func(t *testing.T) {
 		tr := NewTimeSkippingTransition(base)
 		require.Equal(t, base, tr.CurrentTime)
-		require.True(t, tr.TargetTime.IsZero())
+		require.True(t, tr.GetTargetTime().IsZero())
 		require.False(t, tr.DisabledAfterFastForward)
 		require.False(t, tr.IsValid(), "a transition with no target and no disable signal is invalid")
 	})
@@ -39,11 +39,11 @@ func TestTimeSkippingTransition(t *testing.T) {
 		tr := NewTimeSkippingTransition(base)
 		require.NotPanics(t, func() { tr.GateByFastForward(nil) })
 		tr.GateByFastForward(nil)
-		require.True(t, tr.TargetTime.IsZero())
+		require.True(t, tr.GetTargetTime().IsZero())
 		require.False(t, tr.DisabledAfterFastForward)
 
 		tr.GateByFastForward(&persistencespb.FastForwardInfo{}) // non-nil ff, nil target time
-		require.True(t, tr.TargetTime.IsZero())
+		require.True(t, tr.GetTargetTime().IsZero())
 		require.False(t, tr.DisabledAfterFastForward)
 		require.False(t, tr.IsValid())
 	})
@@ -55,25 +55,25 @@ func TestTimeSkippingTransition(t *testing.T) {
 			tr := NewTimeSkippingTransition(base)
 			tr.TrackEarliestFutureTime(time.Time{})          // zero candidate
 			tr.TrackEarliestFutureTime(base.Add(-time.Hour)) // past candidate
-			require.True(t, tr.TargetTime.IsZero())
+			require.True(t, tr.GetTargetTime().IsZero())
 		})
 
 		t.Run("keeps the earliest of several future candidates", func(t *testing.T) {
 			tr := NewTimeSkippingTransition(base)
 			tr.TrackEarliestFutureTime(base.Add(3 * time.Hour))
-			require.Equal(t, base.Add(3*time.Hour), tr.TargetTime)
+			require.Equal(t, base.Add(3*time.Hour), tr.GetTargetTime())
 
 			tr.TrackEarliestFutureTime(base.Add(time.Hour)) // earlier wins
-			require.Equal(t, base.Add(time.Hour), tr.TargetTime)
+			require.Equal(t, base.Add(time.Hour), tr.GetTargetTime())
 
 			tr.TrackEarliestFutureTime(base.Add(2 * time.Hour)) // later is ignored
-			require.Equal(t, base.Add(time.Hour), tr.TargetTime)
+			require.Equal(t, base.Add(time.Hour), tr.GetTargetTime())
 		})
 
 		t.Run("accepts a candidate equal to the current time", func(t *testing.T) {
 			tr := NewTimeSkippingTransition(base)
 			tr.TrackEarliestFutureTime(base)
-			require.Equal(t, base, tr.TargetTime)
+			require.Equal(t, base, tr.GetTargetTime())
 		})
 	})
 
@@ -85,7 +85,7 @@ func TestTimeSkippingTransition(t *testing.T) {
 		t.Run("taken as the target and disables when nothing earlier exists", func(t *testing.T) {
 			tr := NewTimeSkippingTransition(base)
 			tr.GateByFastForward(&persistencespb.FastForwardInfo{TargetTime: timestamppb.New(base.Add(time.Hour))})
-			require.True(t, base.Add(time.Hour).Equal(tr.TargetTime))
+			require.True(t, base.Add(time.Hour).Equal(tr.GetTargetTime()))
 			require.True(t, tr.DisabledAfterFastForward)
 			require.True(t, tr.IsValid())
 		})
@@ -94,7 +94,7 @@ func TestTimeSkippingTransition(t *testing.T) {
 			tr := NewTimeSkippingTransition(base)
 			tr.TrackEarliestFutureTime(base.Add(time.Hour))
 			tr.GateByFastForward(&persistencespb.FastForwardInfo{TargetTime: timestamppb.New(base.Add(3 * time.Hour))})
-			require.Equal(t, base.Add(time.Hour), tr.TargetTime)
+			require.Equal(t, base.Add(time.Hour), tr.GetTargetTime())
 			require.False(t, tr.DisabledAfterFastForward)
 		})
 
@@ -102,7 +102,7 @@ func TestTimeSkippingTransition(t *testing.T) {
 			tr := NewTimeSkippingTransition(base)
 			tr.TrackEarliestFutureTime(base.Add(3 * time.Hour))
 			tr.GateByFastForward(&persistencespb.FastForwardInfo{TargetTime: timestamppb.New(base.Add(time.Hour))})
-			require.True(t, base.Add(time.Hour).Equal(tr.TargetTime))
+			require.True(t, base.Add(time.Hour).Equal(tr.GetTargetTime()))
 			require.True(t, tr.DisabledAfterFastForward)
 		})
 
@@ -112,21 +112,21 @@ func TestTimeSkippingTransition(t *testing.T) {
 				HasReached: true,
 				TargetTime: timestamppb.New(base.Add(time.Hour)),
 			})
-			require.True(t, tr.TargetTime.IsZero())
+			require.True(t, tr.GetTargetTime().IsZero())
 			require.False(t, tr.DisabledAfterFastForward)
 		})
 
 		t.Run("ignores a zero-valued target time", func(t *testing.T) {
 			tr := NewTimeSkippingTransition(base)
 			tr.GateByFastForward(&persistencespb.FastForwardInfo{TargetTime: timestamppb.New(time.Time{})})
-			require.True(t, tr.TargetTime.IsZero())
+			require.True(t, tr.GetTargetTime().IsZero())
 			require.False(t, tr.DisabledAfterFastForward)
 		})
 
 		t.Run("target equal to current disables and sets the target", func(t *testing.T) {
 			tr := NewTimeSkippingTransition(base)
 			tr.GateByFastForward(&persistencespb.FastForwardInfo{TargetTime: timestamppb.New(base)})
-			require.True(t, base.Equal(tr.TargetTime))
+			require.True(t, base.Equal(tr.GetTargetTime()))
 			require.True(t, tr.DisabledAfterFastForward)
 			require.True(t, tr.IsValid())
 		})
@@ -134,7 +134,7 @@ func TestTimeSkippingTransition(t *testing.T) {
 		t.Run("past target disables as a bare signal", func(t *testing.T) {
 			tr := NewTimeSkippingTransition(base)
 			tr.GateByFastForward(&persistencespb.FastForwardInfo{TargetTime: timestamppb.New(base.Add(-time.Hour))})
-			require.True(t, tr.TargetTime.IsZero(), "a past target is not a future skip target")
+			require.True(t, tr.GetTargetTime().IsZero(), "a past target is not a future skip target")
 			require.True(t, tr.DisabledAfterFastForward)
 			require.True(t, tr.IsValid())
 		})
@@ -144,7 +144,7 @@ func TestTimeSkippingTransition(t *testing.T) {
 	// make it valid — every field is relative to the current time.
 	t.Run("no current time always invalid", func(t *testing.T) {
 		t.Run("a directly-set target is still invalid", func(t *testing.T) {
-			tr := &TimeSkippingTransition{TargetTime: base.Add(time.Hour)}
+			tr := &TimeSkippingTransition{targetTime: base.Add(time.Hour)}
 			require.False(t, tr.IsValid())
 		})
 
@@ -157,9 +157,49 @@ func TestTimeSkippingTransition(t *testing.T) {
 			tr := &TimeSkippingTransition{}
 			tr.TrackEarliestFutureTime(base)
 			tr.GateByFastForward(&persistencespb.FastForwardInfo{TargetTime: timestamppb.New(base.Add(time.Hour))})
-			require.True(t, tr.TargetTime.IsZero())
+			require.True(t, tr.GetTargetTime().IsZero())
 			require.False(t, tr.DisabledAfterFastForward)
 			require.False(t, tr.IsValid())
+		})
+	})
+
+	// Invariant 5: GetSkippedDuration is the gap from current to target time, and is zero whenever
+	// there is nothing to skip — a nil receiver, no current time, or no target time.
+	t.Run("skipped duration", func(t *testing.T) {
+		t.Run("nil receiver is zero", func(t *testing.T) {
+			var nilTr *TimeSkippingTransition
+			require.Zero(t, nilTr.GetSkippedDuration())
+		})
+
+		t.Run("no current time is zero", func(t *testing.T) {
+			tr := &TimeSkippingTransition{targetTime: base.Add(time.Hour)}
+			require.Zero(t, tr.GetSkippedDuration())
+		})
+
+		t.Run("no target time is zero", func(t *testing.T) {
+			tr := NewTimeSkippingTransition(base)
+			require.Zero(t, tr.GetSkippedDuration())
+		})
+
+		t.Run("target after current is the gap", func(t *testing.T) {
+			tr := NewTimeSkippingTransition(base)
+			tr.TrackEarliestFutureTime(base.Add(90 * time.Minute))
+			require.Equal(t, 90*time.Minute, tr.GetSkippedDuration())
+		})
+
+		t.Run("target equal to current is zero", func(t *testing.T) {
+			tr := NewTimeSkippingTransition(base)
+			tr.TrackEarliestFutureTime(base)
+			require.Zero(t, tr.GetSkippedDuration())
+		})
+
+		t.Run("a past candidate leaves no target and is zero", func(t *testing.T) {
+			// TrackEarliestFutureTime rejects a past candidate, so the target stays unset and
+			// there is nothing to skip — the duration is zero, never negative.
+			tr := NewTimeSkippingTransition(base)
+			tr.TrackEarliestFutureTime(base.Add(-time.Hour))
+			require.True(t, tr.GetTargetTime().IsZero())
+			require.Zero(t, tr.GetSkippedDuration())
 		})
 	})
 }

--- a/chasm/timeskipping_test.go
+++ b/chasm/timeskipping_test.go
@@ -23,7 +23,6 @@ func TestTimeSkippingTransition(t *testing.T) {
 		require.False(t, tr.DisabledAfterFastForward)
 		require.False(t, tr.IsValid(), "a transition with no target and no disable signal is invalid")
 	})
-
 	// Invariant 1: every method is nil-safe — on a nil receiver, and (for GateByFastForward)
 	// on a nil/absent fast-forward argument.
 	t.Run("nil safe", func(t *testing.T) {

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -3690,7 +3690,8 @@ func encodeChasmBlob(m proto.Message) (*commonpb.DataBlob, error) {
 }
 
 func (n *Node) closeTransactionHandleTimeSkipping(immutableContext Context) error {
-	if !softassert.That(n.logger, n.parent == nil, "closeTransactionHandleTimeSkipping must run on the root node") {
+	if n.parent != nil {
+		n.logger.Warn("time skipping handler called on non-root component is no-op")
 		return nil
 	}
 	if n.ArchetypeID() == WorkflowArchetypeID {
@@ -3765,8 +3766,8 @@ func (n *Node) regenerateTimerTasksForTimeSkipping() error {
 }
 
 // defaultFindNextTargetTime finds the earliest timer task from both pure tasks and side-effect tasks
-// as the target time for time skipping, and conditionally adjust the target time with the fast-forward time if set
-// this method doesn't validate tasks and assumes to be called after invalidate tasks are deleted
+// as the target time for time skipping, and conditionally adjusts the target time with the fast-forward time if set.
+// this method doesn't validate tasks and is assumed to be called after invalidate tasks are deleted
 func (n *Node) defaultFindNextTargetTime() *TimeSkippingTransition {
 	transition := NewTimeSkippingTransition(n.Now(nil))
 	now := transition.CurrentTime

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -3751,16 +3751,26 @@ func (n *Node) regenerateTimerTasksForTimeSkipping() error {
 			node.closeTransactionGeneratePhysicalSideEffectTask(sideEffectTask, nodePath, archetypeID)
 		}
 
-		for _, pureTask := range componentAttr.GetPureTasks() {
-			// Pure tasks are represented by a single physical task, so we only need to
-			// regenerate that one. Time conversion for task regeneration is handled by
-			// backend.AddTask, so no time changes are needed here.
-			pureTask.PhysicalTaskStatus = physicalTaskStatusNone
-			if firstPureTask == nil || comparePureTasks(pureTask, firstPureTask) < 0 {
-				firstPureTask = pureTask
-				firstPureTaskNode = node
-			}
+		// Find the earliest pure task in the entire tree. Pure tasks are sorted
+		// by scheduled time, so pureTasks[0] is the earliest for this component.
+		pureTasks := componentAttr.GetPureTasks()
+		if len(pureTasks) == 0 {
+			continue
 		}
+
+		if firstPureTask == nil || comparePureTasks(pureTasks[0], firstPureTask) < 0 {
+			firstPureTask = pureTasks[0]
+			firstPureTaskNode = node
+		}
+	}
+
+	if firstPureTask != nil {
+		// Pure tasks are represented by a single physical task, so we only need to
+		// regenerate that one. The earliest pure task is already
+		// physicalTaskStatusCreated from a prior transaction, and
+		// closeTransactionGeneratePhysicalPureTask short-circuits on that status.
+		// Reset it so backend.AddTask re-converts the fire time for the skipped time.
+		firstPureTask.PhysicalTaskStatus = physicalTaskStatusNone
 	}
 	return n.closeTransactionGeneratePhysicalPureTask(firstPureTask, firstPureTaskNode, archetypeID)
 }

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -232,8 +232,9 @@ type (
 			requestID string,
 		) (nexusrpc.CompleteOperationOptions, error)
 		EndpointRegistry() EndpointRegistry
-		SetTimeSkippingConfig(config *commonpb.TimeSkippingConfig)
 		Now() time.Time
+		SetTimeSkippingConfig(config *commonpb.TimeSkippingConfig)
+		RecordTimeSkippingTransition(transition *TimeSkippingTransition)
 	}
 
 	// NodePathEncoder is an interface for encoding and decoding node paths.
@@ -1709,6 +1710,10 @@ func (n *Node) CloseTransaction() (NodesMutation, error) {
 	}
 
 	if err := n.closeTransactionApplyPendingComponentMetadata(); err != nil {
+		return NodesMutation{}, err
+	}
+
+	if err := n.closeTransactionHandleTimeSkipping(immutableContext); err != nil {
 		return NodesMutation{}, err
 	}
 
@@ -3682,4 +3687,114 @@ func makeValidationFn(
 // serializer while preserving deterministic proto3 bytes for byte comparisons.
 func encodeChasmBlob(m proto.Message) (*commonpb.DataBlob, error) {
 	return serialization.Encode(m, serialization.WithDeterministicProto3)
+}
+
+func (n *Node) closeTransactionHandleTimeSkipping(immutableContext Context) error {
+	if !softassert.That(n.logger, n.parent == nil, "closeTransactionHandleTimeSkipping must run on the root node") {
+		return nil
+	}
+	if n.ArchetypeID() == WorkflowArchetypeID {
+		return nil
+	}
+
+	// conf check
+	tsi := n.backend.GetExecutionInfo().GetTimeSkippingInfo()
+	if !tsi.GetConfig().GetEnabled() {
+		return nil
+	}
+
+	// todo@feiyang: how to check that the current cluster is active cluster
+	// and this closeTransaction state change logic should only happen in active cluster
+	rootComponent, err := n.Component(immutableContext, ComponentRef{})
+	if err != nil {
+		return err
+	}
+	tsRoot, ok := rootComponent.(TimeSkippingRuntimeGate)
+	if !ok {
+		n.logger.Error(
+			"root component does not implement TimeSkippingRuntimeGate when executions have turned on time skipping",
+			tag.Error(fmt.Errorf("type: %s", reflect.TypeOf(rootComponent).Name())))
+		return serviceerror.NewInternal("time skipping is not enabled for current execution type")
+	}
+
+	// runtime check
+	if !tsRoot.IsExecutionSkippable(immutableContext) {
+		return nil
+	}
+	transition := n.defaultFindNextTargetTime()
+	if !transition.IsValid() {
+		return nil
+	}
+
+	// state change
+	n.backend.RecordTimeSkippingTransition(transition)
+	return n.regenerateTimerTasksForTimeSkipping()
+}
+
+func (n *Node) regenerateTimerTasksForTimeSkipping() error {
+	archetypeID := n.ArchetypeID()
+	var firstPureTask *persistencespb.ChasmComponentAttributes_Task
+	var firstPureTaskNode *Node
+
+	for nodePath, node := range n.andAllChildren() {
+		componentAttr := node.serializedNode.GetMetadata().GetComponentAttributes()
+		if componentAttr == nil {
+			continue
+		}
+
+		for _, sideEffectTask := range componentAttr.GetSideEffectTasks() {
+			if taskCategory(sideEffectTask) != tasks.CategoryTimer {
+				continue
+			}
+			sideEffectTask.PhysicalTaskStatus = physicalTaskStatusNone
+			node.closeTransactionGeneratePhysicalSideEffectTask(sideEffectTask, nodePath, archetypeID)
+		}
+
+		for _, pureTask := range componentAttr.GetPureTasks() {
+			// Pure tasks are represented by a single physical task, so we only need to
+			// regenerate that one. Time conversion for task regeneration is handled by
+			// backend.AddTask, so no time changes are needed here.
+			pureTask.PhysicalTaskStatus = physicalTaskStatusNone
+			if firstPureTask == nil || comparePureTasks(pureTask, firstPureTask) < 0 {
+				firstPureTask = pureTask
+				firstPureTaskNode = node
+			}
+		}
+	}
+	return n.closeTransactionGeneratePhysicalPureTask(firstPureTask, firstPureTaskNode, archetypeID)
+}
+
+// defaultFindNextTargetTime finds the earliest timer task from both pure tasks and side-effect tasks
+// as the target time for time skipping, and conditionally adjust the target time with the fast-forward time if set
+// this method doesn't validate tasks and assumes to be called after invalidate tasks are deleted
+func (n *Node) defaultFindNextTargetTime() *TimeSkippingTransition {
+	transition := NewTimeSkippingTransition(n.Now(nil))
+	now := transition.CurrentTime
+	for _, node := range n.andAllChildren() {
+		componentAttr := node.serializedNode.GetMetadata().GetComponentAttributes()
+		if componentAttr == nil {
+			continue
+		}
+		for _, taskList := range [][]*persistencespb.ChasmComponentAttributes_Task{
+			componentAttr.GetPureTasks(),
+			componentAttr.GetSideEffectTasks(),
+		} {
+			for _, task := range taskList {
+				if taskCategory(task) != tasks.CategoryTimer {
+					continue
+				}
+				scheduledTime := task.GetScheduledTime().AsTime()
+				if !scheduledTime.After(now) {
+					continue
+				}
+				transition.TrackEarliestFutureTime(scheduledTime)
+			}
+		}
+	}
+	tsi := n.backend.GetExecutionInfo().GetTimeSkippingInfo()
+	ff := tsi.GetFastForwardInfo()
+	if ff != nil && !ff.HasReached {
+		transition.GateByFastForward(ff)
+	}
+	return transition
 }

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -4600,6 +4600,7 @@ func (s *nodeSuite) TestCloseTransactionHandleTimeSkipping() {
 	// preserves the unmanaged skippable flag so IsExecutionSkippable is deterministic.
 	gateRoot := func(skippable bool) *Node {
 		s.nodeBackend = &MockNodeBackend{}
+		s.nodeBackend.HandleNow = s.timeSource.Now
 		s.nodeBackend.HandleNextTransitionCount = func() int64 { return 1 }
 		s.nodeBackend.HandleGetCurrentVersion = func() int64 { return 1 }
 		s.timeSource.Update(baseTime)
@@ -4643,6 +4644,7 @@ func (s *nodeSuite) TestCloseTransactionHandleTimeSkipping() {
 
 	s.Run("NonRootNodeIsNoOp", func() {
 		s.nodeBackend = &MockNodeBackend{}
+		s.nodeBackend.HandleNow = s.timeSource.Now
 		s.timeSource.Update(time.Date(2027, 1, 1, 12, 0, 0, 0, time.UTC))
 		root, err := s.newTestTree(map[string]*persistencespb.ChasmNode{
 			"": {
@@ -4764,6 +4766,7 @@ func (s *nodeSuite) TestDefaultFindNextTargetTime() {
 	// fresh backend with the clock pinned to baseTime.
 	buildRoot := func(sideEffect, pure []*persistencespb.ChasmComponentAttributes_Task) *Node {
 		s.nodeBackend = &MockNodeBackend{}
+		s.nodeBackend.HandleNow = s.timeSource.Now
 		s.timeSource.Update(baseTime)
 		root, err := s.newTestTree(map[string]*persistencespb.ChasmNode{
 			"": {
@@ -4845,6 +4848,7 @@ func (s *nodeSuite) TestRegenerateTimerTasksForTimeSkipping() {
 
 	s.Run("RegeneratesSideEffectTimersAndEarliestPureTask", func() {
 		s.nodeBackend = &MockNodeBackend{}
+		s.nodeBackend.HandleNow = s.timeSource.Now
 		s.timeSource.Update(baseTime)
 
 		root, err := s.newTestTree(map[string]*persistencespb.ChasmNode{
@@ -4928,6 +4932,7 @@ func (s *nodeSuite) TestRegenerateTimerTasksForTimeSkipping() {
 
 	s.Run("NoPureTasksDeletesWithMaximumKey", func() {
 		s.nodeBackend = &MockNodeBackend{}
+		s.nodeBackend.HandleNow = s.timeSource.Now
 		s.timeSource.Update(baseTime)
 
 		root, err := s.newTestTree(map[string]*persistencespb.ChasmNode{
@@ -4966,6 +4971,7 @@ func (s *nodeSuite) TestRegenerateTimerTasksForTimeSkipping() {
 		// transaction. Regeneration must reset it so closeTransactionGeneratePhysicalPureTask
 		// does not short-circuit and instead re-adds the physical task at the skipped time.
 		s.nodeBackend = &MockNodeBackend{}
+		s.nodeBackend.HandleNow = s.timeSource.Now
 		s.timeSource.Update(baseTime)
 
 		root, err := s.newTestTree(map[string]*persistencespb.ChasmNode{

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -4918,8 +4918,8 @@ func (s *nodeSuite) TestRegenerateTimerTasksForTimeSkipping() {
 			"the timer side-effect task must be regenerated")
 		s.Equal(physicalTaskStatusCreated, rootAttrs.SideEffectTasks[1].PhysicalTaskStatus,
 			"the non-timer side-effect task is untouched and keeps its created status")
-		s.Equal(physicalTaskStatusNone, rootAttrs.PureTasks[0].PhysicalTaskStatus,
-			"a non-earliest pure task is reset but not regenerated")
+		s.Equal(physicalTaskStatusCreated, rootAttrs.PureTasks[0].PhysicalTaskStatus,
+			"a non-earliest pure task is left untouched and not regenerated")
 
 		childAttrs := root.children["SubComponent1"].serializedNode.Metadata.GetComponentAttributes()
 		s.Equal(physicalTaskStatusCreated, childAttrs.PureTasks[0].PhysicalTaskStatus,
@@ -4959,5 +4959,48 @@ func (s *nodeSuite) TestRegenerateTimerTasksForTimeSkipping() {
 		s.Equal(1, s.nodeBackend.NumTasksAdded(), "only the side-effect timer task is regenerated")
 		s.Equal(tasks.MaximumKey.FireTime, s.nodeBackend.LastDeletePureTaskCall(),
 			"with no pure tasks, deletion sweeps up to the maximum key")
+	})
+
+	s.Run("RegeneratesAlreadyCreatedEarliestPureTask", func() {
+		// The earliest pure task already carries physicalTaskStatusCreated from a prior
+		// transaction. Regeneration must reset it so closeTransactionGeneratePhysicalPureTask
+		// does not short-circuit and instead re-adds the physical task at the skipped time.
+		s.nodeBackend = &MockNodeBackend{}
+		s.timeSource.Update(baseTime)
+
+		root, err := s.newTestTree(map[string]*persistencespb.ChasmNode{
+			"": {
+				Metadata: &persistencespb.ChasmNodeMetadata{
+					InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+					LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+					Attributes: &persistencespb.ChasmNodeMetadata_ComponentAttributes{
+						ComponentAttributes: &persistencespb.ChasmComponentAttributes{
+							TypeId: testComponentTypeID,
+							PureTasks: []*persistencespb.ChasmComponentAttributes_Task{
+								{
+									TypeId:                    testPureTaskTypeID,
+									ScheduledTime:             timestamppb.New(baseTime.Add(time.Hour)),
+									VersionedTransition:       &persistencespb.VersionedTransition{TransitionCount: 1},
+									VersionedTransitionOffset: 1,
+									PhysicalTaskStatus:        physicalTaskStatusCreated,
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+		s.NoError(err)
+
+		s.NoError(root.regenerateTimerTasksForTimeSkipping())
+
+		s.Equal(1, s.nodeBackend.NumTasksAdded(),
+			"the already-created earliest pure task is reset and regenerated, not short-circuited")
+		s.Equal(baseTime.Add(time.Hour).UTC(), s.nodeBackend.LastDeletePureTaskCall(),
+			"pure-task deletion is anchored at the earliest pure scheduled time")
+
+		rootAttrs := root.serializedNode.Metadata.GetComponentAttributes()
+		s.Equal(physicalTaskStatusCreated, rootAttrs.PureTasks[0].PhysicalTaskStatus,
+			"the regenerated earliest pure task ends up created again")
 	})
 }

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -4568,3 +4568,344 @@ func (s *nodeSuite) TestSetUserMetadata_NilClearsPersistedValue() {
 	s.NoError(err)
 	s.Nil(mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes().GetUserMetadata())
 }
+
+// TestCloseTransactionHandleTimeSkipping covers the framework-level guard rails of the root-only
+// close-transaction hook: it must be panic-safe and non-erroring for executions without time
+// skipping, a no-op on non-root nodes, and it must surface an internal error only when the config
+// says time skipping is on but the root component does not implement TimeSkippingRuntimeGate.
+func (s *nodeSuite) TestCloseTransactionHandleTimeSkipping() {
+	// executionInfo installs a GetExecutionInfo stub returning the given time-skipping info.
+	executionInfo := func(tsi *persistencespb.TimeSkippingInfo) {
+		s.nodeBackend.HandleGetExecutionInfo = func() *persistencespb.WorkflowExecutionInfo {
+			return &persistencespb.WorkflowExecutionInfo{TimeSkippingInfo: tsi}
+		}
+	}
+
+	// TestComponent (the root of testComponentTree) does not implement TimeSkippingRuntimeGate,
+	// which is exactly what the "gate not implemented" cases below rely on.
+
+	s.Run("NilTimeSkippingInfoIsSafeNoOp", func() {
+		s.nodeBackend = &MockNodeBackend{}
+		// default GetExecutionInfo returns an empty WorkflowExecutionInfo => nil TimeSkippingInfo
+		root := s.testComponentTree()
+
+		var err error
+		s.NotPanics(func() {
+			err = root.closeTransactionHandleTimeSkipping(NewContext(context.Background(), root))
+		})
+		s.NoError(err, "an execution without time-skipping info must be a safe no-op")
+	})
+
+	s.Run("NonRootNodeIsSafeNoOp", func() {
+		s.nodeBackend = &MockNodeBackend{}
+		s.timeSource.Update(time.Date(2027, 1, 1, 12, 0, 0, 0, time.UTC))
+		root, err := s.newTestTree(map[string]*persistencespb.ChasmNode{
+			"": {
+				Metadata: &persistencespb.ChasmNodeMetadata{
+					InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+					LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+					Attributes: &persistencespb.ChasmNodeMetadata_ComponentAttributes{
+						ComponentAttributes: &persistencespb.ChasmComponentAttributes{TypeId: testComponentTypeID},
+					},
+				},
+			},
+			"SubComponent1": {
+				Metadata: &persistencespb.ChasmNodeMetadata{
+					InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+					LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+					Attributes: &persistencespb.ChasmNodeMetadata_ComponentAttributes{
+						ComponentAttributes: &persistencespb.ChasmComponentAttributes{TypeId: testSubComponent1TypeID},
+					},
+				},
+			},
+		})
+		s.NoError(err)
+		child := root.children["SubComponent1"]
+		s.Require().NotNil(child)
+		s.Require().NotNil(child.parent, "must exercise a genuinely non-root node")
+
+		// The root-only guard is a soft assertion, which logs an error before returning nil.
+		tl, ok := s.logger.(*testlogger.TestLogger)
+		s.Require().True(ok)
+		tl.Expect(testlogger.Error, "must run on the root node")
+
+		var closeErr error
+		s.NotPanics(func() {
+			closeErr = child.closeTransactionHandleTimeSkipping(NewContext(context.Background(), child))
+		})
+		s.NoError(closeErr, "a non-root node must be a safe no-op, not an error")
+	})
+
+	s.Run("ConfigDisabledAndGateNotImplemented_NoError", func() {
+		s.nodeBackend = &MockNodeBackend{}
+		executionInfo(&persistencespb.TimeSkippingInfo{
+			Config: &commonpb.TimeSkippingConfig{Enabled: false},
+		})
+		root := s.testComponentTree()
+
+		// Config disabled short-circuits before the gate check, so the missing
+		// TimeSkippingRuntimeGate on TestComponent must not surface as an error.
+		err := root.closeTransactionHandleTimeSkipping(NewContext(context.Background(), root))
+		s.NoError(err)
+	})
+
+	s.Run("ConfigEnabledAndGateNotImplemented_InternalError", func() {
+		s.nodeBackend = &MockNodeBackend{}
+		executionInfo(&persistencespb.TimeSkippingInfo{
+			Config: &commonpb.TimeSkippingConfig{Enabled: true},
+		})
+		root := s.testComponentTree()
+
+		tl, ok := s.logger.(*testlogger.TestLogger)
+		s.Require().True(ok)
+		tl.Expect(testlogger.Error, "does not implement TimeSkippingRuntimeGate")
+
+		err := root.closeTransactionHandleTimeSkipping(NewContext(context.Background(), root))
+		s.Require().Error(err, "enabled config with no gate implementation is a misconfiguration")
+		var internalErr *serviceerror.Internal
+		s.ErrorAs(err, &internalErr, "the error must be an internal service error")
+	})
+}
+
+// TestDefaultFindNextTargetTime covers the earliest-future-timer selection across the whole tree:
+// non-timer and past tasks are ignored, the earliest future timer wins, and an active fast-forward
+// caps (and disables) the skip when it is the earliest target.
+func (s *nodeSuite) TestDefaultFindNextTargetTime() {
+	baseTime := time.Date(2027, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	// timerTask builds a timer-category task (non-visibility type, no destination, future
+	// scheduled time). transferTask builds an immediate/transfer task (no scheduled time) that
+	// must never be treated as a skip target.
+	timerTask := func(offset time.Duration) *persistencespb.ChasmComponentAttributes_Task {
+		return &persistencespb.ChasmComponentAttributes_Task{
+			TypeId:              testSideEffectTaskTypeID,
+			ScheduledTime:       timestamppb.New(baseTime.Add(offset)),
+			VersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+		}
+	}
+	transferTask := func() *persistencespb.ChasmComponentAttributes_Task {
+		return &persistencespb.ChasmComponentAttributes_Task{
+			TypeId:              testSideEffectTaskTypeID,
+			VersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+		}
+	}
+
+	// buildRoot builds a single-root tree carrying the given side-effect and pure tasks, on a
+	// fresh backend with the clock pinned to baseTime.
+	buildRoot := func(sideEffect, pure []*persistencespb.ChasmComponentAttributes_Task) *Node {
+		s.nodeBackend = &MockNodeBackend{}
+		s.timeSource.Update(baseTime)
+		root, err := s.newTestTree(map[string]*persistencespb.ChasmNode{
+			"": {
+				Metadata: &persistencespb.ChasmNodeMetadata{
+					InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+					LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+					Attributes: &persistencespb.ChasmNodeMetadata_ComponentAttributes{
+						ComponentAttributes: &persistencespb.ChasmComponentAttributes{
+							TypeId:          testComponentTypeID,
+							SideEffectTasks: sideEffect,
+							PureTasks:       pure,
+						},
+					},
+				},
+			},
+		})
+		s.NoError(err)
+		return root
+	}
+
+	s.Run("NoTasksInvalidTransition", func() {
+		root := buildRoot(nil, nil)
+		tr := root.defaultFindNextTargetTime()
+		s.Require().NotNil(tr)
+		s.Equal(baseTime, tr.CurrentTime)
+		s.True(tr.TargetTime.IsZero())
+		s.False(tr.IsValid())
+	})
+
+	s.Run("EarliestFutureTaskWins", func() {
+		root := buildRoot(
+			[]*persistencespb.ChasmComponentAttributes_Task{timerTask(2 * time.Hour)},
+			[]*persistencespb.ChasmComponentAttributes_Task{timerTask(time.Hour)},
+		)
+		tr := root.defaultFindNextTargetTime()
+		s.Require().NotNil(tr)
+		s.True(tr.IsValid())
+		s.Equal(baseTime.Add(time.Hour), tr.TargetTime, "the earliest future timer across all task lists wins")
+		s.False(tr.DisabledAfterFastForward)
+	})
+
+	s.Run("PastAndNonTimerTasksIgnored", func() {
+		root := buildRoot(
+			[]*persistencespb.ChasmComponentAttributes_Task{timerTask(-time.Hour), transferTask()},
+			[]*persistencespb.ChasmComponentAttributes_Task{timerTask(3 * time.Hour)},
+		)
+		tr := root.defaultFindNextTargetTime()
+		s.Require().NotNil(tr)
+		s.Equal(baseTime.Add(3*time.Hour), tr.TargetTime,
+			"past timers and non-timer (transfer) tasks must not be skip targets")
+	})
+
+	s.Run("EarlierFastForwardCapsAndDisables", func() {
+		root := buildRoot(nil, []*persistencespb.ChasmComponentAttributes_Task{timerTask(3 * time.Hour)})
+		s.nodeBackend.HandleGetExecutionInfo = func() *persistencespb.WorkflowExecutionInfo {
+			return &persistencespb.WorkflowExecutionInfo{
+				TimeSkippingInfo: &persistencespb.TimeSkippingInfo{
+					FastForwardInfo: &persistencespb.FastForwardInfo{
+						TargetTime: timestamppb.New(baseTime.Add(time.Hour)),
+						HasReached: false,
+					},
+				},
+			}
+		}
+		tr := root.defaultFindNextTargetTime()
+		s.Require().NotNil(tr)
+		s.True(baseTime.Add(time.Hour).Equal(tr.TargetTime),
+			"an earlier fast-forward caps the skip below the later timer")
+		s.True(tr.DisabledAfterFastForward, "reaching the fast-forward target disables time skipping")
+	})
+
+	s.Run("ReachedFastForwardIsIgnored", func() {
+		root := buildRoot(nil, []*persistencespb.ChasmComponentAttributes_Task{timerTask(3 * time.Hour)})
+		s.nodeBackend.HandleGetExecutionInfo = func() *persistencespb.WorkflowExecutionInfo {
+			return &persistencespb.WorkflowExecutionInfo{
+				TimeSkippingInfo: &persistencespb.TimeSkippingInfo{
+					FastForwardInfo: &persistencespb.FastForwardInfo{
+						TargetTime: timestamppb.New(baseTime.Add(time.Hour)),
+						HasReached: true,
+					},
+				},
+			}
+		}
+		tr := root.defaultFindNextTargetTime()
+		s.Require().NotNil(tr)
+		s.Equal(baseTime.Add(3*time.Hour), tr.TargetTime, "an already-reached fast-forward must not gate the skip")
+		s.False(tr.DisabledAfterFastForward)
+	})
+}
+
+// TestRegenerateTimerTasksForTimeSkipping verifies task regeneration: every timer side-effect task
+// is re-created (non-timer ones are skipped), only the single earliest pure task across the tree
+// gets a physical pure task, and pure-task deletion is anchored at the earliest scheduled time (or
+// the maximum key when there are no pure tasks).
+func (s *nodeSuite) TestRegenerateTimerTasksForTimeSkipping() {
+	baseTime := time.Date(2027, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	s.Run("RegeneratesSideEffectTimersAndEarliestPureTask", func() {
+		s.nodeBackend = &MockNodeBackend{}
+		s.timeSource.Update(baseTime)
+
+		root, err := s.newTestTree(map[string]*persistencespb.ChasmNode{
+			"": {
+				Metadata: &persistencespb.ChasmNodeMetadata{
+					InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+					LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+					Attributes: &persistencespb.ChasmNodeMetadata_ComponentAttributes{
+						ComponentAttributes: &persistencespb.ChasmComponentAttributes{
+							TypeId: testComponentTypeID,
+							SideEffectTasks: []*persistencespb.ChasmComponentAttributes_Task{
+								{ // timer side-effect task, already-created status must be reset & regenerated
+									TypeId:                    testSideEffectTaskTypeID,
+									ScheduledTime:             timestamppb.New(baseTime.Add(2 * time.Hour)),
+									VersionedTransition:       &persistencespb.VersionedTransition{TransitionCount: 1},
+									VersionedTransitionOffset: 1,
+									PhysicalTaskStatus:        physicalTaskStatusCreated,
+								},
+								{ // transfer (no scheduled time) task: not a timer, must be skipped
+									TypeId:                    testSideEffectTaskTypeID,
+									VersionedTransition:       &persistencespb.VersionedTransition{TransitionCount: 1},
+									VersionedTransitionOffset: 2,
+									PhysicalTaskStatus:        physicalTaskStatusCreated,
+								},
+							},
+							PureTasks: []*persistencespb.ChasmComponentAttributes_Task{
+								{ // later pure task on the root
+									TypeId:                    testPureTaskTypeID,
+									ScheduledTime:             timestamppb.New(baseTime.Add(2 * time.Hour)),
+									VersionedTransition:       &persistencespb.VersionedTransition{TransitionCount: 1},
+									VersionedTransitionOffset: 3,
+									PhysicalTaskStatus:        physicalTaskStatusCreated,
+								},
+							},
+						},
+					},
+				},
+			},
+			"SubComponent1": {
+				Metadata: &persistencespb.ChasmNodeMetadata{
+					InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+					LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+					Attributes: &persistencespb.ChasmNodeMetadata_ComponentAttributes{
+						ComponentAttributes: &persistencespb.ChasmComponentAttributes{
+							TypeId: testSubComponent1TypeID,
+							PureTasks: []*persistencespb.ChasmComponentAttributes_Task{
+								{ // earliest pure task across the tree
+									TypeId:                    testPureTaskTypeID,
+									ScheduledTime:             timestamppb.New(baseTime.Add(time.Hour)),
+									VersionedTransition:       &persistencespb.VersionedTransition{TransitionCount: 1},
+									VersionedTransitionOffset: 1,
+									PhysicalTaskStatus:        physicalTaskStatusNone,
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+		s.NoError(err)
+
+		s.NoError(root.regenerateTimerTasksForTimeSkipping())
+
+		// One physical task for the timer side-effect task + one for the single earliest pure task.
+		s.Equal(2, s.nodeBackend.NumTasksAdded())
+		s.Equal(baseTime.Add(time.Hour).UTC(), s.nodeBackend.LastDeletePureTaskCall(),
+			"pure-task deletion is anchored at the earliest pure scheduled time")
+
+		rootAttrs := root.serializedNode.Metadata.GetComponentAttributes()
+		s.Equal(physicalTaskStatusCreated, rootAttrs.SideEffectTasks[0].PhysicalTaskStatus,
+			"the timer side-effect task must be regenerated")
+		s.Equal(physicalTaskStatusCreated, rootAttrs.SideEffectTasks[1].PhysicalTaskStatus,
+			"the non-timer side-effect task is untouched and keeps its created status")
+		s.Equal(physicalTaskStatusNone, rootAttrs.PureTasks[0].PhysicalTaskStatus,
+			"a non-earliest pure task is reset but not regenerated")
+
+		childAttrs := root.children["SubComponent1"].serializedNode.Metadata.GetComponentAttributes()
+		s.Equal(physicalTaskStatusCreated, childAttrs.PureTasks[0].PhysicalTaskStatus,
+			"the earliest pure task gets a physical task")
+	})
+
+	s.Run("NoPureTasksDeletesWithMaximumKey", func() {
+		s.nodeBackend = &MockNodeBackend{}
+		s.timeSource.Update(baseTime)
+
+		root, err := s.newTestTree(map[string]*persistencespb.ChasmNode{
+			"": {
+				Metadata: &persistencespb.ChasmNodeMetadata{
+					InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+					LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+					Attributes: &persistencespb.ChasmNodeMetadata_ComponentAttributes{
+						ComponentAttributes: &persistencespb.ChasmComponentAttributes{
+							TypeId: testComponentTypeID,
+							SideEffectTasks: []*persistencespb.ChasmComponentAttributes_Task{
+								{
+									TypeId:                    testSideEffectTaskTypeID,
+									ScheduledTime:             timestamppb.New(baseTime.Add(time.Hour)),
+									VersionedTransition:       &persistencespb.VersionedTransition{TransitionCount: 1},
+									VersionedTransitionOffset: 1,
+									PhysicalTaskStatus:        physicalTaskStatusNone,
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+		s.NoError(err)
+
+		s.NoError(root.regenerateTimerTasksForTimeSkipping())
+
+		s.Equal(1, s.nodeBackend.NumTasksAdded(), "only the side-effect timer task is regenerated")
+		s.Equal(tasks.MaximumKey.FireTime, s.nodeBackend.LastDeletePureTaskCall(),
+			"with no pure tasks, deletion sweeps up to the maximum key")
+	})
+}

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -4719,7 +4719,7 @@ func (s *nodeSuite) TestDefaultFindNextTargetTime() {
 		tr := root.defaultFindNextTargetTime()
 		s.Require().NotNil(tr)
 		s.Equal(baseTime, tr.CurrentTime)
-		s.True(tr.TargetTime.IsZero())
+		s.True(tr.GetTargetTime().IsZero())
 		s.False(tr.IsValid())
 	})
 
@@ -4731,7 +4731,7 @@ func (s *nodeSuite) TestDefaultFindNextTargetTime() {
 		tr := root.defaultFindNextTargetTime()
 		s.Require().NotNil(tr)
 		s.True(tr.IsValid())
-		s.Equal(baseTime.Add(time.Hour), tr.TargetTime, "the earliest future timer across all task lists wins")
+		s.Equal(baseTime.Add(time.Hour), tr.GetTargetTime(), "the earliest future timer across all task lists wins")
 		s.False(tr.DisabledAfterFastForward)
 	})
 
@@ -4742,7 +4742,7 @@ func (s *nodeSuite) TestDefaultFindNextTargetTime() {
 		)
 		tr := root.defaultFindNextTargetTime()
 		s.Require().NotNil(tr)
-		s.Equal(baseTime.Add(3*time.Hour), tr.TargetTime,
+		s.Equal(baseTime.Add(3*time.Hour), tr.GetTargetTime(),
 			"past timers and non-timer (transfer) tasks must not be skip targets")
 	})
 
@@ -4760,7 +4760,7 @@ func (s *nodeSuite) TestDefaultFindNextTargetTime() {
 		}
 		tr := root.defaultFindNextTargetTime()
 		s.Require().NotNil(tr)
-		s.True(baseTime.Add(time.Hour).Equal(tr.TargetTime),
+		s.True(baseTime.Add(time.Hour).Equal(tr.GetTargetTime()),
 			"an earlier fast-forward caps the skip below the later timer")
 		s.True(tr.DisabledAfterFastForward, "reaching the fast-forward target disables time skipping")
 	})
@@ -4779,7 +4779,7 @@ func (s *nodeSuite) TestDefaultFindNextTargetTime() {
 		}
 		tr := root.defaultFindNextTargetTime()
 		s.Require().NotNil(tr)
-		s.Equal(baseTime.Add(3*time.Hour), tr.TargetTime, "an already-reached fast-forward must not gate the skip")
+		s.Equal(baseTime.Add(3*time.Hour), tr.GetTargetTime(), "an already-reached fast-forward must not gate the skip")
 		s.False(tr.DisabledAfterFastForward)
 	})
 }

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -4574,11 +4574,56 @@ func (s *nodeSuite) TestSetUserMetadata_NilClearsPersistedValue() {
 // skipping, a no-op on non-root nodes, and it must surface an internal error only when the config
 // says time skipping is on but the root component does not implement TimeSkippingRuntimeGate.
 func (s *nodeSuite) TestCloseTransactionHandleTimeSkipping() {
+	baseTime := time.Date(2027, 1, 1, 12, 0, 0, 0, time.UTC)
+
 	// executionInfo installs a GetExecutionInfo stub returning the given time-skipping info.
 	executionInfo := func(tsi *persistencespb.TimeSkippingInfo) {
 		s.nodeBackend.HandleGetExecutionInfo = func() *persistencespb.WorkflowExecutionInfo {
 			return &persistencespb.WorkflowExecutionInfo{TimeSkippingInfo: tsi}
 		}
+	}
+
+	// timerTask builds a future timer-category task scheduled at baseTime+offset.
+	timerTask := func(offset time.Duration, typeID uint32, tvOffset int64) *persistencespb.ChasmComponentAttributes_Task {
+		return &persistencespb.ChasmComponentAttributes_Task{
+			TypeId:                    typeID,
+			ScheduledTime:             timestamppb.New(baseTime.Add(offset)),
+			VersionedTransition:       &persistencespb.VersionedTransition{TransitionCount: 1},
+			VersionedTransitionOffset: tvOffset,
+			PhysicalTaskStatus:        physicalTaskStatusNone,
+		}
+	}
+
+	// gateRoot builds a root whose component implements TimeSkippingRuntimeGate (returning the
+	// given skippable value), carries two side-effect and three pure future timer tasks as skip
+	// targets, and has time skipping enabled in its config. The in-memory SetRootComponent path
+	// preserves the unmanaged skippable flag so IsExecutionSkippable is deterministic.
+	gateRoot := func(skippable bool) *Node {
+		s.nodeBackend = &MockNodeBackend{}
+		s.nodeBackend.HandleNextTransitionCount = func() int64 { return 1 }
+		s.nodeBackend.HandleGetCurrentVersion = func() int64 { return 1 }
+		s.timeSource.Update(baseTime)
+
+		var nilSerializedNodes map[string]*persistencespb.ChasmNode
+		root, err := s.newTestTree(nilSerializedNodes)
+		s.NoError(err)
+		s.NoError(root.SetRootComponent(&TestTimeSkippingImplComponent{
+			ComponentData:        &protoMessageType{CreateRequestId: "gate"},
+			isExecutionSkippable: skippable,
+		}))
+
+		attrs := root.serializedNode.Metadata.GetComponentAttributes()
+		attrs.SideEffectTasks = []*persistencespb.ChasmComponentAttributes_Task{
+			timerTask(2*time.Hour, testSideEffectTaskTypeID, 1),
+			timerTask(4*time.Hour, testSideEffectTaskTypeID, 2),
+		}
+		attrs.PureTasks = []*persistencespb.ChasmComponentAttributes_Task{
+			timerTask(time.Hour, testPureTaskTypeID, 3), // earliest overall
+			timerTask(3*time.Hour, testPureTaskTypeID, 4),
+			timerTask(5*time.Hour, testPureTaskTypeID, 5),
+		}
+		executionInfo(&persistencespb.TimeSkippingInfo{Config: &commonpb.TimeSkippingConfig{Enabled: true}})
+		return root
 	}
 
 	// TestComponent (the root of testComponentTree) does not implement TimeSkippingRuntimeGate,
@@ -4596,7 +4641,7 @@ func (s *nodeSuite) TestCloseTransactionHandleTimeSkipping() {
 		s.NoError(err, "an execution without time-skipping info must be a safe no-op")
 	})
 
-	s.Run("NonRootNodeIsSafeNoOp", func() {
+	s.Run("NonRootNodeIsNoOp", func() {
 		s.nodeBackend = &MockNodeBackend{}
 		s.timeSource.Update(time.Date(2027, 1, 1, 12, 0, 0, 0, time.UTC))
 		root, err := s.newTestTree(map[string]*persistencespb.ChasmNode{
@@ -4624,16 +4669,13 @@ func (s *nodeSuite) TestCloseTransactionHandleTimeSkipping() {
 		s.Require().NotNil(child)
 		s.Require().NotNil(child.parent, "must exercise a genuinely non-root node")
 
-		// The root-only guard is a soft assertion, which logs an error before returning nil.
-		tl, ok := s.logger.(*testlogger.TestLogger)
-		s.Require().True(ok)
-		tl.Expect(testlogger.Error, "must run on the root node")
-
+		// A non-root node is a benign no-op: it logs a warning (not an error) and returns nil.
+		// The FailOnAnyUnexpectedError logger also asserts that no error-level log is emitted.
 		var closeErr error
 		s.NotPanics(func() {
 			closeErr = child.closeTransactionHandleTimeSkipping(NewContext(context.Background(), child))
 		})
-		s.NoError(closeErr, "a non-root node must be a safe no-op, not an error")
+		s.NoError(closeErr)
 	})
 
 	s.Run("ConfigDisabledAndGateNotImplemented_NoError", func() {
@@ -4664,6 +4706,34 @@ func (s *nodeSuite) TestCloseTransactionHandleTimeSkipping() {
 		s.Require().Error(err, "enabled config with no gate implementation is a misconfiguration")
 		var internalErr *serviceerror.Internal
 		s.ErrorAs(err, &internalErr, "the error must be an internal service error")
+	})
+
+	s.Run("GateNotSkippable_NoStateChange", func() {
+		root := gateRoot(false)
+		var recorded *TimeSkippingTransition
+		s.nodeBackend.HandleRecordTimeSkippingTransition = func(tr *TimeSkippingTransition) { recorded = tr }
+
+		err := root.closeTransactionHandleTimeSkipping(NewContext(context.Background(), root))
+		s.NoError(err)
+		s.Nil(recorded, "a gate that reports not-skippable must not record a transition")
+		s.Equal(0, s.nodeBackend.NumTasksAdded(), "no timer tasks are regenerated when skipping is gated out")
+	})
+
+	s.Run("GateSkippable_RecordsTransitionAndRegeneratesTasks", func() {
+		root := gateRoot(true)
+		var recorded *TimeSkippingTransition
+		s.nodeBackend.HandleRecordTimeSkippingTransition = func(tr *TimeSkippingTransition) { recorded = tr }
+
+		err := root.closeTransactionHandleTimeSkipping(NewContext(context.Background(), root))
+		s.NoError(err)
+		s.Require().NotNil(recorded, "a skippable execution with a future timer must record a transition")
+		s.True(recorded.IsValid())
+		s.True(baseTime.Add(time.Hour).Equal(recorded.GetTargetTime()), "skips to the earliest future timer task")
+		// Two side-effect timer tasks are each regenerated, plus the single earliest pure task
+		// (only one physical pure task is generated regardless of pure-task count) => 3 total.
+		s.Equal(3, s.nodeBackend.NumTasksAdded(), "two side-effect tasks and the earliest pure task are regenerated")
+		s.Equal(baseTime.Add(time.Hour).UTC(), s.nodeBackend.LastDeletePureTaskCall(),
+			"pure-task deletion is anchored at the earliest pure scheduled time")
 	})
 }
 
@@ -4726,7 +4796,7 @@ func (s *nodeSuite) TestDefaultFindNextTargetTime() {
 	s.Run("EarliestFutureTaskWins", func() {
 		root := buildRoot(
 			[]*persistencespb.ChasmComponentAttributes_Task{timerTask(2 * time.Hour)},
-			[]*persistencespb.ChasmComponentAttributes_Task{timerTask(time.Hour)},
+			[]*persistencespb.ChasmComponentAttributes_Task{timerTask(time.Hour), transferTask()},
 		)
 		tr := root.defaultFindNextTargetTime()
 		s.Require().NotNil(tr)
@@ -4747,7 +4817,7 @@ func (s *nodeSuite) TestDefaultFindNextTargetTime() {
 	})
 
 	s.Run("EarlierFastForwardCapsAndDisables", func() {
-		root := buildRoot(nil, []*persistencespb.ChasmComponentAttributes_Task{timerTask(3 * time.Hour)})
+		root := buildRoot(nil, []*persistencespb.ChasmComponentAttributes_Task{timerTask(3 * time.Hour), transferTask()})
 		s.nodeBackend.HandleGetExecutionInfo = func() *persistencespb.WorkflowExecutionInfo {
 			return &persistencespb.WorkflowExecutionInfo{
 				TimeSkippingInfo: &persistencespb.TimeSkippingInfo{
@@ -4763,24 +4833,6 @@ func (s *nodeSuite) TestDefaultFindNextTargetTime() {
 		s.True(baseTime.Add(time.Hour).Equal(tr.GetTargetTime()),
 			"an earlier fast-forward caps the skip below the later timer")
 		s.True(tr.DisabledAfterFastForward, "reaching the fast-forward target disables time skipping")
-	})
-
-	s.Run("ReachedFastForwardIsIgnored", func() {
-		root := buildRoot(nil, []*persistencespb.ChasmComponentAttributes_Task{timerTask(3 * time.Hour)})
-		s.nodeBackend.HandleGetExecutionInfo = func() *persistencespb.WorkflowExecutionInfo {
-			return &persistencespb.WorkflowExecutionInfo{
-				TimeSkippingInfo: &persistencespb.TimeSkippingInfo{
-					FastForwardInfo: &persistencespb.FastForwardInfo{
-						TargetTime: timestamppb.New(baseTime.Add(time.Hour)),
-						HasReached: true,
-					},
-				},
-			}
-		}
-		tr := root.defaultFindNextTargetTime()
-		s.Require().NotNil(tr)
-		s.Equal(baseTime.Add(3*time.Hour), tr.GetTargetTime(), "an already-reached fast-forward must not gate the skip")
-		s.False(tr.DisabledAfterFastForward)
 	})
 }
 

--- a/service/history/workflow/timeskipping.go
+++ b/service/history/workflow/timeskipping.go
@@ -434,3 +434,28 @@ func (ms *MutableStateImpl) closeTransactionRegenTimerTasksForWorkflowTimeSkippi
 		return serviceerror.NewInternalf("unknown transaction policy: %v", transactionPolicy)
 	}
 }
+
+func (ms *MutableStateImpl) RecordTimeSkippingTransition(transition *chasm.TimeSkippingTransition) {
+	if ms.IsWorkflow() {
+		// CHASM-based executions only, and workflows use events
+		return
+	}
+	if !transition.IsValid() {
+		return
+	}
+	ms.applyTransitionToTimeSkippingInfo(transition)
+	// todo@timeskipping: delete time skipping timer or add regeneration for chasm
+}
+
+func (ms *MutableStateImpl) applyTransitionToTimeSkippingInfo(transition *chasm.TimeSkippingTransition) {
+	tsi := ms.executionInfo.GetTimeSkippingInfo()
+	tsi.AccumulatedSkippedDuration = durationpb.New(
+		tsi.GetAccumulatedSkippedDuration().AsDuration() + transition.GetSkippedDuration())
+
+	if transition.DisabledAfterFastForward {
+		tsi.Config.Enabled = false
+		tsi.FastForwardInfo.HasReached = true
+	}
+	// update flag
+	ms.timeSkippingInfoUpdated = true
+}

--- a/service/history/workflow/timeskipping.go
+++ b/service/history/workflow/timeskipping.go
@@ -362,7 +362,7 @@ func (ms *MutableStateImpl) closeTransactionHandleWorkflowTimeSkipping(
 		}
 		// 3. state change
 		_, err := ms.AddWorkflowExecutionTimeSkippingTransitionedEvent(
-			ctx, transition.TargetTime, transition.DisabledAfterFastForward)
+			ctx, transition.GetTargetTime(), transition.DisabledAfterFastForward)
 		if err != nil {
 			ms.logger.Error("failed to add workflow execution time skipping transitioned event", tag.Error(err))
 			return false

--- a/service/history/workflow/timeskipping_test.go
+++ b/service/history/workflow/timeskipping_test.go
@@ -737,7 +737,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(t1, tr.TargetTime)
+		s.Equal(t1, tr.GetTargetTime())
 		s.False(tr.DisabledAfterFastForward)
 	})
 
@@ -748,7 +748,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(baseTime.Add(2*time.Hour), tr.TargetTime)
+		s.Equal(baseTime.Add(2*time.Hour), tr.GetTargetTime())
 	})
 
 	s.Run("UserTimer_PlusEarlierFastForward_TargetIsFastForward", func() {
@@ -759,7 +759,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(fastForwardTarget, tr.TargetTime)
+		s.Equal(fastForwardTarget, tr.GetTargetTime())
 		// The fast-forward is the earliest target (earlier than the timer), so skipping to it
 		// consumes the budget and disables time skipping on this transition.
 		s.True(tr.DisabledAfterFastForward)
@@ -776,7 +776,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(execTime, tr.TargetTime)
+		s.Equal(execTime, tr.GetTargetTime())
 		s.False(tr.DisabledAfterFastForward)
 	})
 
@@ -819,7 +819,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(schedTime, tr.TargetTime)
+		s.Equal(schedTime, tr.GetTargetTime())
 		s.False(tr.DisabledAfterFastForward)
 	})
 
@@ -838,7 +838,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(early, tr.TargetTime)
+		s.Equal(early, tr.GetTargetTime())
 	})
 
 	s.Run("ActivityBackoff_PlusEarlierTimer_TargetIsTimer", func() {
@@ -852,7 +852,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(timerTime, tr.TargetTime)
+		s.Equal(timerTime, tr.GetTargetTime())
 	})
 
 	s.Run("RunTimeoutIsATarget", func() {
@@ -862,7 +862,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(runTimeout, tr.TargetTime)
+		s.Equal(runTimeout, tr.GetTargetTime())
 	})
 
 	s.Run("ExecutionTimeoutIsATarget", func() {
@@ -872,7 +872,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(execTimeout, tr.TargetTime)
+		s.Equal(execTimeout, tr.GetTargetTime())
 	})
 
 	s.Run("EarliestOfRunAndExecutionTimeoutWins", func() {
@@ -883,7 +883,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(runTimeout, tr.TargetTime, "the earlier run timeout must win")
+		s.Equal(runTimeout, tr.GetTargetTime(), "the earlier run timeout must win")
 	})
 
 	s.Run("ExpiredTimeoutsAreNotTargets", func() {
@@ -902,7 +902,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(runTimeout, tr.TargetTime, "skip is bounded by the earlier run timeout")
+		s.Equal(runTimeout, tr.GetTargetTime(), "skip is bounded by the earlier run timeout")
 		s.False(tr.DisabledAfterFastForward, "fast-forward not reached: it was not the chosen target")
 	})
 
@@ -914,7 +914,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(fastForwardTarget, tr.TargetTime)
+		s.Equal(fastForwardTarget, tr.GetTargetTime())
 		s.True(tr.DisabledAfterFastForward, "fast-forward is the earliest target: skipping to it disables time skipping")
 	})
 
@@ -926,7 +926,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(execTimeout, tr.TargetTime, "skip is bounded by the earlier execution timeout")
+		s.Equal(execTimeout, tr.GetTargetTime(), "skip is bounded by the earlier execution timeout")
 		s.False(tr.DisabledAfterFastForward)
 	})
 
@@ -940,7 +940,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(fastForwardTarget, tr.TargetTime, "a zero-valued timeout must not cap the skip")
+		s.Equal(fastForwardTarget, tr.GetTargetTime(), "a zero-valued timeout must not cap the skip")
 		// The fast-forward is the only (and therefore earliest) target, so it is reached and
 		// time skipping is disabled.
 		s.True(tr.DisabledAfterFastForward)
@@ -954,7 +954,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(baseTime, tr.TargetTime)
+		s.Equal(baseTime, tr.GetTargetTime())
 		s.True(tr.DisabledAfterFastForward)
 	})
 }

--- a/service/history/workflow/timeskipping_test.go
+++ b/service/history/workflow/timeskipping_test.go
@@ -1214,3 +1214,104 @@ func (s *mutableStateSuite) TestChasmContextNowReflectsAccumulatedSkippedDuratio
 	s.Equal(baseTime.Add(accumulatedSkip), ctx.Now(nil),
 		"CHASM Context.Now must reflect the mutable state's virtual time")
 }
+
+// TestRecordTimeSkippingTransition covers the CHASM-execution entry point for applying a
+// time-skipping transition: it is a no-op for workflow-based executions (which use events) and for
+// invalid transitions, accumulates the skipped duration for a valid transition, and disables the
+// config while marking the fast-forward reached when the transition is a fast-forward completion.
+func (s *mutableStateSuite) TestRecordTimeSkippingTransition() {
+	baseTime := time.Date(2027, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	// asChasmExecution swaps in a chasm tree whose archetype is not a workflow, so IsWorkflow()
+	// is false and the transition is applied. asWorkflowExecution keeps IsWorkflow() true.
+	asChasmExecution := func() {
+		mockChasmTree := historyi.NewMockChasmTree(s.controller)
+		mockChasmTree.EXPECT().ArchetypeID().Return(chasm.ArchetypeID(1234)).AnyTimes()
+		s.mutableState.chasmTree = mockChasmTree
+	}
+	asWorkflowExecution := func() {
+		mockChasmTree := historyi.NewMockChasmTree(s.controller)
+		mockChasmTree.EXPECT().ArchetypeID().Return(chasm.WorkflowArchetypeID).AnyTimes()
+		s.mutableState.chasmTree = mockChasmTree
+	}
+
+	s.Run("WorkflowExecutionIsNoOp", func() {
+		asWorkflowExecution()
+		s.mutableState.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
+			Config:                     &commonpb.TimeSkippingConfig{Enabled: true},
+			AccumulatedSkippedDuration: durationpb.New(time.Hour),
+		}
+		s.mutableState.timeSkippingInfoUpdated = false
+
+		tr := chasm.NewTimeSkippingTransition(baseTime)
+		tr.TrackEarliestFutureTime(baseTime.Add(2 * time.Hour))
+		s.Require().True(tr.IsValid(), "the transition itself is valid; the workflow gate is what suppresses it")
+
+		s.mutableState.RecordTimeSkippingTransition(tr)
+
+		tsi := s.mutableState.executionInfo.GetTimeSkippingInfo()
+		s.Equal(time.Hour, tsi.GetAccumulatedSkippedDuration().AsDuration(), "workflow executions use events, not this path")
+		s.False(s.mutableState.timeSkippingInfoUpdated)
+	})
+
+	s.Run("InvalidTransitionIsNoOp", func() {
+		asChasmExecution()
+		s.mutableState.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
+			Config:                     &commonpb.TimeSkippingConfig{Enabled: true},
+			AccumulatedSkippedDuration: durationpb.New(time.Hour),
+		}
+		s.mutableState.timeSkippingInfoUpdated = false
+
+		// A nil transition and a transition with no target are both invalid and must not mutate state.
+		s.mutableState.RecordTimeSkippingTransition(nil)
+		s.mutableState.RecordTimeSkippingTransition(chasm.NewTimeSkippingTransition(baseTime))
+
+		tsi := s.mutableState.executionInfo.GetTimeSkippingInfo()
+		s.Equal(time.Hour, tsi.GetAccumulatedSkippedDuration().AsDuration())
+		s.False(s.mutableState.timeSkippingInfoUpdated)
+	})
+
+	s.Run("ValidTransitionAccumulatesDuration", func() {
+		asChasmExecution()
+		s.mutableState.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
+			Config:                     &commonpb.TimeSkippingConfig{Enabled: true},
+			AccumulatedSkippedDuration: durationpb.New(time.Hour),
+		}
+		s.mutableState.timeSkippingInfoUpdated = false
+
+		tr := chasm.NewTimeSkippingTransition(baseTime)
+		tr.TrackEarliestFutureTime(baseTime.Add(2 * time.Hour)) // skips 2h
+
+		s.mutableState.RecordTimeSkippingTransition(tr)
+
+		tsi := s.mutableState.executionInfo.GetTimeSkippingInfo()
+		s.Equal(3*time.Hour, tsi.GetAccumulatedSkippedDuration().AsDuration(), "1h pre-existing + 2h skipped")
+		s.True(tsi.GetConfig().GetEnabled(), "a plain skip must leave time skipping enabled")
+		s.True(s.mutableState.timeSkippingInfoUpdated)
+	})
+
+	s.Run("DisabledAfterFastForwardDisablesConfigAndMarksReached", func() {
+		asChasmExecution()
+		s.mutableState.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
+			Config:                     &commonpb.TimeSkippingConfig{Enabled: true},
+			AccumulatedSkippedDuration: durationpb.New(time.Hour),
+			FastForwardInfo: &persistencespb.FastForwardInfo{
+				TargetTime: timestamppb.New(baseTime.Add(time.Hour)),
+				HasReached: false,
+			},
+		}
+		s.mutableState.timeSkippingInfoUpdated = false
+
+		tr := chasm.NewTimeSkippingTransition(baseTime)
+		tr.GateByFastForward(&persistencespb.FastForwardInfo{TargetTime: timestamppb.New(baseTime.Add(time.Hour))})
+		s.Require().True(tr.DisabledAfterFastForward)
+
+		s.mutableState.RecordTimeSkippingTransition(tr)
+
+		tsi := s.mutableState.executionInfo.GetTimeSkippingInfo()
+		s.Equal(2*time.Hour, tsi.GetAccumulatedSkippedDuration().AsDuration(), "1h pre-existing + 1h skipped to the fast-forward")
+		s.False(tsi.GetConfig().GetEnabled(), "reaching the fast-forward disables time skipping")
+		s.True(tsi.GetFastForwardInfo().GetHasReached(), "the fast-forward must be marked reached")
+		s.True(s.mutableState.timeSkippingInfoUpdated)
+	})
+}


### PR DESCRIPTION
## What changed?
wire in runtime of time skipping for chasm framework

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
