### PR TITLE
remove reset_heartbeats field in ResetActivityExecutionRequest

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1032,7 +1032,7 @@ func (a *Activity) recordPauseState(
 	a.emitOnPausedMetrics(event.metricsHandler)
 }
 
-func (a *Activity) clearHeartbeat(ctx chasm.MutableContext) {
+func (a *Activity) clearHeartbeatDetails(ctx chasm.MutableContext) {
 	if hb, ok := a.LastHeartbeat.TryGet(ctx); ok {
 		hb.Details = nil
 		hb.RecordedTime = nil
@@ -1045,7 +1045,7 @@ func (a *Activity) reset(ctx chasm.MutableContext, event resetEvent) {
 	attempt.Stamp++
 	attempt.CurrentRetryInterval = nil
 	attempt.CurrentRetryIntervalSource = activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED
-	a.clearHeartbeat(ctx)
+	a.clearHeartbeatDetails(ctx)
 	dispatchTime := a.dispatchTimeRespectingStartDelay(event.resetTime)
 	attempt.DispatchTime = timestamppb.New(dispatchTime)
 	if timeout := a.GetScheduleToStartTimeout().AsDuration(); timeout > 0 {
@@ -1167,7 +1167,7 @@ func (a *Activity) resetKeepPaused(
 	attempt.CurrentRetryInterval = nil
 	attempt.CurrentRetryIntervalSource = activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED
 	attempt.DispatchTime = nil
-	a.clearHeartbeat(ctx)
+	a.clearHeartbeatDetails(ctx)
 	a.emitOnResetMetrics(metricsHandler)
 	return &activitypb.ResetActivityExecutionResponse{}, nil
 }

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1045,9 +1045,7 @@ func (a *Activity) reset(ctx chasm.MutableContext, event resetEvent) {
 	attempt.Stamp++
 	attempt.CurrentRetryInterval = nil
 	attempt.CurrentRetryIntervalSource = activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED
-	if event.req.GetResetHeartbeat() {
-		a.clearHeartbeat(ctx)
-	}
+	a.clearHeartbeat(ctx)
 	dispatchTime := a.dispatchTimeRespectingStartDelay(event.resetTime)
 	attempt.DispatchTime = timestamppb.New(dispatchTime)
 	if timeout := a.GetScheduleToStartTimeout().AsDuration(); timeout > 0 {
@@ -1113,7 +1111,7 @@ func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetAc
 			a.restoreOriginalOptions(ctx)
 		}
 		if frontendReq.GetKeepPaused() {
-			return a.resetKeepPaused(ctx, frontendReq, metricsHandler)
+			return a.resetKeepPaused(ctx, metricsHandler)
 		}
 		// No keepPaused: perform an immediate reset. restoreOriginalOptions (if requested) already
 		// ran above, so skip it in resetImmediately to avoid restoring twice.
@@ -1128,7 +1126,7 @@ func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetAc
 
 // deferResetWhileRunning defers reset mutations (option restore, heartbeat details clear,
 // attempt-count rewind) while a worker is still executing (STARTED or PAUSE_REQUESTED), so that the
-// in-flight attempt is undisturbed. The deferred reset applies on the next retry via STARTED->SCHEDULED.
+// in-flight attempt is undisturbed. The deferred reset applies when the worker yields.
 func (a *Activity) deferResetWhileRunning(
 	ctx chasm.MutableContext,
 	frontendReq *workflowservice.ResetActivityExecutionRequest,
@@ -1149,9 +1147,6 @@ func (a *Activity) deferResetWhileRunning(
 	if frontendReq.GetRestoreOriginalOptions() {
 		a.ResetRestoreOptions = true
 	}
-	if frontendReq.GetResetHeartbeat() {
-		a.ResetHeartbeats = true
-	}
 	// keepPaused on a paused (PAUSE_REQUESTED) activity preserves the pause: when the worker
 	// yields the activity lands back in PAUSED rather than SCHEDULED.
 	a.ResetKeepPaused = keepPaused && pauseRequested
@@ -1164,7 +1159,6 @@ func (a *Activity) deferResetWhileRunning(
 
 func (a *Activity) resetKeepPaused(
 	ctx chasm.MutableContext,
-	frontendReq *workflowservice.ResetActivityExecutionRequest,
 	metricsHandler metrics.Handler,
 ) (*activitypb.ResetActivityExecutionResponse, error) {
 	attempt := a.LastAttempt.Get(ctx)
@@ -1173,9 +1167,7 @@ func (a *Activity) resetKeepPaused(
 	attempt.CurrentRetryInterval = nil
 	attempt.CurrentRetryIntervalSource = activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED
 	attempt.DispatchTime = nil
-	if frontendReq.GetResetHeartbeat() {
-		a.clearHeartbeat(ctx)
-	}
+	a.clearHeartbeat(ctx)
 	a.emitOnResetMetrics(metricsHandler)
 	return &activitypb.ResetActivityExecutionResponse{}, nil
 }
@@ -1194,7 +1186,6 @@ func (a *Activity) resetImmediately(
 		resetTime = resetTime.Add(time.Duration(rand.Int63n(int64(jitter)))) //nolint:gosec
 	}
 	if err := TransitionReset.Apply(a, ctx, resetEvent{
-		req:       frontendReq,
 		resetTime: resetTime,
 		handler:   metricsHandler,
 	}); err != nil {

--- a/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
@@ -292,10 +292,6 @@ type ActivityState struct {
 	// since been unpaused), hence the "last" prefix. No logic gates on this field — it is descriptive
 	// metadata only.
 	LastPauseState *ActivityPauseState `protobuf:"bytes,16,opt,name=last_pause_state,json=lastPauseState,proto3" json:"last_pause_state,omitempty"`
-	// Set when reset was requested while the activity was STARTED and the operator asked for
-	// heartbeat details to be cleared on the next retry. Consumed when the worker yields and the
-	// activity transitions out of RESET_REQUESTED.
-	ResetHeartbeats bool `protobuf:"varint,17,opt,name=reset_heartbeats,json=resetHeartbeats,proto3" json:"reset_heartbeats,omitempty"`
 	// Set when a reset is requested with keep_paused=true on a paused (PAUSE_REQUESTED) activity, so
 	// that when the worker yields the activity lands back in PAUSED rather than SCHEDULED. Consumed
 	// when the activity transitions out of RESET_REQUESTED.
@@ -456,13 +452,6 @@ func (x *ActivityState) GetLastPauseState() *ActivityPauseState {
 		return x.LastPauseState
 	}
 	return nil
-}
-
-func (x *ActivityState) GetResetHeartbeats() bool {
-	if x != nil {
-		return x.ResetHeartbeats
-	}
-	return false
 }
 
 func (x *ActivityState) GetResetKeepPaused() bool {
@@ -1199,7 +1188,7 @@ var File_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto protor
 
 const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawDesc = "" +
 	"\n" +
-	"@temporal/server/chasm/lib/activity/proto/v1/activity_state.proto\x12+temporal.server.chasm.lib.activity.proto.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&temporal/api/activity/v1/message.proto\x1a$temporal/api/common/v1/message.proto\x1a(temporal/api/deployment/v1/message.proto\x1a%temporal/api/failure/v1/message.proto\x1a'temporal/api/sdk/v1/user_metadata.proto\x1a'temporal/api/taskqueue/v1/message.proto\"\xf3\v\n" +
+	"@temporal/server/chasm/lib/activity/proto/v1/activity_state.proto\x12+temporal.server.chasm.lib.activity.proto.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&temporal/api/activity/v1/message.proto\x1a$temporal/api/common/v1/message.proto\x1a(temporal/api/deployment/v1/message.proto\x1a%temporal/api/failure/v1/message.proto\x1a'temporal/api/sdk/v1/user_metadata.proto\x1a'temporal/api/taskqueue/v1/message.proto\"\xe0\v\n" +
 	"\rActivityState\x12I\n" +
 	"\ractivity_type\x18\x01 \x01(\v2$.temporal.api.common.v1.ActivityTypeR\factivityType\x12C\n" +
 	"\n" +
@@ -1219,11 +1208,10 @@ const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawD
 	"startDelay\x12T\n" +
 	"\x10original_options\x18\x0e \x01(\v2).temporal.api.activity.v1.ActivityOptionsR\x0foriginalOptions\x125\n" +
 	"\x17schedule_to_close_stamp\x18\x0f \x01(\x05R\x14scheduleToCloseStamp\x12i\n" +
-	"\x10last_pause_state\x18\x10 \x01(\v2?.temporal.server.chasm.lib.activity.proto.v1.ActivityPauseStateR\x0elastPauseState\x12)\n" +
-	"\x10reset_heartbeats\x18\x11 \x01(\bR\x0fresetHeartbeats\x12*\n" +
+	"\x10last_pause_state\x18\x10 \x01(\v2?.temporal.server.chasm.lib.activity.proto.v1.ActivityPauseStateR\x0elastPauseState\x12*\n" +
 	"\x11reset_keep_paused\x18\x12 \x01(\bR\x0fresetKeepPaused\x12W\n" +
 	"\x1afirst_attempt_started_time\x18\x13 \x01(\v2\x1a.google.protobuf.TimestampR\x17firstAttemptStartedTime\x122\n" +
-	"\x15reset_restore_options\x18\x14 \x01(\bR\x13resetRestoreOptions\"\xa7\x01\n" +
+	"\x15reset_restore_options\x18\x14 \x01(\bR\x13resetRestoreOptionsJ\x04\b\x11\x10\x12R\x10reset_heartbeats\"\xa7\x01\n" +
 	"\x13ActivityCancelState\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x01 \x01(\tR\trequestId\x12=\n" +

--- a/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
@@ -1188,7 +1188,7 @@ var File_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto protor
 
 const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawDesc = "" +
 	"\n" +
-	"@temporal/server/chasm/lib/activity/proto/v1/activity_state.proto\x12+temporal.server.chasm.lib.activity.proto.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&temporal/api/activity/v1/message.proto\x1a$temporal/api/common/v1/message.proto\x1a(temporal/api/deployment/v1/message.proto\x1a%temporal/api/failure/v1/message.proto\x1a'temporal/api/sdk/v1/user_metadata.proto\x1a'temporal/api/taskqueue/v1/message.proto\"\xe0\v\n" +
+	"@temporal/server/chasm/lib/activity/proto/v1/activity_state.proto\x12+temporal.server.chasm.lib.activity.proto.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&temporal/api/activity/v1/message.proto\x1a$temporal/api/common/v1/message.proto\x1a(temporal/api/deployment/v1/message.proto\x1a%temporal/api/failure/v1/message.proto\x1a'temporal/api/sdk/v1/user_metadata.proto\x1a'temporal/api/taskqueue/v1/message.proto\"\xc8\v\n" +
 	"\rActivityState\x12I\n" +
 	"\ractivity_type\x18\x01 \x01(\v2$.temporal.api.common.v1.ActivityTypeR\factivityType\x12C\n" +
 	"\n" +
@@ -1211,7 +1211,7 @@ const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawD
 	"\x10last_pause_state\x18\x10 \x01(\v2?.temporal.server.chasm.lib.activity.proto.v1.ActivityPauseStateR\x0elastPauseState\x12*\n" +
 	"\x11reset_keep_paused\x18\x12 \x01(\bR\x0fresetKeepPaused\x12W\n" +
 	"\x1afirst_attempt_started_time\x18\x13 \x01(\v2\x1a.google.protobuf.TimestampR\x17firstAttemptStartedTime\x122\n" +
-	"\x15reset_restore_options\x18\x14 \x01(\bR\x13resetRestoreOptionsJ\x04\b\x11\x10\x12R\x10reset_heartbeats\"\xa7\x01\n" +
+	"\x15reset_restore_options\x18\x14 \x01(\bR\x13resetRestoreOptions\"\xa7\x01\n" +
 	"\x13ActivityCancelState\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x01 \x01(\tR\trequestId\x12=\n" +

--- a/chasm/lib/activity/handler.go
+++ b/chasm/lib/activity/handler.go
@@ -449,7 +449,7 @@ func (h *handler) ResetActivityExecution(ctx context.Context, req *activitypb.Re
 					RunId:      frontendReq.GetRunId(),
 				},
 				Activity:               &workflowservice.ResetActivityRequest_Id{Id: frontendReq.GetActivityId()},
-				ResetHeartbeat:         frontendReq.GetResetHeartbeat(),
+				ResetHeartbeat:         true,
 				RestoreOriginalOptions: frontendReq.GetRestoreOriginalOptions(),
 				KeepPaused:             frontendReq.GetKeepPaused(),
 				Jitter:                 frontendReq.GetJitter(),

--- a/chasm/lib/activity/proto/v1/activity_state.proto
+++ b/chasm/lib/activity/proto/v1/activity_state.proto
@@ -128,11 +128,6 @@ message ActivityState {
   // metadata only.
   ActivityPauseState last_pause_state = 16;
 
-  // Set when reset was requested while the activity was STARTED and the operator asked for
-  // heartbeat details to be cleared on the next retry. Consumed when the worker yields and the
-  // activity transitions out of RESET_REQUESTED.
-  bool reset_heartbeats = 17;
-
   // Set when a reset is requested with keep_paused=true on a paused (PAUSE_REQUESTED) activity, so
   // that when the worker yields the activity lands back in PAUSED rather than SCHEDULED. Consumed
   // when the activity transitions out of RESET_REQUESTED.

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -537,7 +537,7 @@ var TransitionResetAttemptFailedToPaused = chasm.NewTransition(
 		attempt := a.LastAttempt.Get(ctx)
 		a.ResetKeepPaused = false
 		a.applyDeferredOptionRestore(ctx)
-		a.clearHeartbeat(ctx)
+		a.clearHeartbeatDetails(ctx)
 		attempt.Count = 1
 		attempt.Stamp++
 		if err := a.recordFailedAttempt(ctx, event.retryInterval, event.retryIntervalSource, event.failure, ctx.Now(a), false); err != nil {
@@ -566,7 +566,7 @@ var TransitionResetAttemptFailedToScheduled = chasm.NewTransition(
 
 		a.ResetKeepPaused = false
 		a.applyDeferredOptionRestore(ctx)
-		a.clearHeartbeat(ctx)
+		a.clearHeartbeatDetails(ctx)
 
 		attempt.Count = 1
 		attempt.Stamp++

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -198,8 +198,6 @@ var TransitionCompleted = chasm.NewTransition(
 	activitypb.ACTIVITY_EXECUTION_STATUS_COMPLETED,
 	func(a *Activity, ctx chasm.MutableContext, event completeEvent) error {
 		return a.StoreOrSelf(ctx).RecordCompleted(ctx, func(ctx chasm.MutableContext) error {
-			a.ResetHeartbeats = false
-
 			req := event.req.GetCompleteRequest()
 
 			attempt := a.LastAttempt.Get(ctx)
@@ -236,7 +234,6 @@ var TransitionFailed = chasm.NewTransition(
 	func(a *Activity, ctx chasm.MutableContext, event failedEvent) error {
 		return a.StoreOrSelf(ctx).RecordCompleted(ctx, func(ctx chasm.MutableContext) error {
 			req := event.req.GetFailedRequest()
-			a.ResetHeartbeats = false
 
 			if details := req.GetLastHeartbeatDetails(); details != nil {
 				heartbeat := a.getOrCreateLastHeartbeat(ctx)
@@ -279,7 +276,6 @@ var TransitionTerminated = chasm.NewTransition(
 			a.TerminateState = &activitypb.ActivityTerminateState{
 				RequestId: event.request.RequestID,
 			}
-			a.ResetHeartbeats = false
 			outcome := a.Outcome.Get(ctx)
 			failure := &failurepb.Failure{
 				Message: event.request.Reason,
@@ -354,7 +350,6 @@ var TransitionCanceled = chasm.NewTransition(
 					Failure: failure,
 				},
 			}
-			a.ResetHeartbeats = false
 
 			a.emitOnCanceledMetrics(ctx, event.handler, event.fromStatus)
 
@@ -401,8 +396,6 @@ var TransitionTimedOut = chasm.NewTransition(
 			if err != nil {
 				return err
 			}
-
-			a.ResetHeartbeats = false
 
 			a.emitOnTimedOutMetrics(ctx, event.metricsHandler, timeoutType, event.fromStatus)
 
@@ -491,7 +484,6 @@ var TransitionAttemptFailedWhilePauseRequested = chasm.NewTransition(
 )
 
 type resetEvent struct {
-	req       *workflowservice.ResetActivityExecutionRequest
 	resetTime time.Time
 	handler   metrics.Handler
 }
@@ -545,10 +537,7 @@ var TransitionResetAttemptFailedToPaused = chasm.NewTransition(
 		attempt := a.LastAttempt.Get(ctx)
 		a.ResetKeepPaused = false
 		a.applyDeferredOptionRestore(ctx)
-		if a.ResetHeartbeats {
-			a.ResetHeartbeats = false
-			a.clearHeartbeat(ctx)
-		}
+		a.clearHeartbeat(ctx)
 		attempt.Count = 1
 		attempt.Stamp++
 		if err := a.recordFailedAttempt(ctx, event.retryInterval, event.retryIntervalSource, event.failure, ctx.Now(a), false); err != nil {
@@ -577,10 +566,7 @@ var TransitionResetAttemptFailedToScheduled = chasm.NewTransition(
 
 		a.ResetKeepPaused = false
 		a.applyDeferredOptionRestore(ctx)
-		if a.ResetHeartbeats {
-			a.ResetHeartbeats = false
-			a.clearHeartbeat(ctx)
-		}
+		a.clearHeartbeat(ctx)
 
 		attempt.Count = 1
 		attempt.Stamp++

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -723,167 +723,100 @@ func TestTransitionCanceled(t *testing.T) {
 	protorequire.ProtoEqual(t, expectedFailure, outcome.GetFailed().GetFailure())
 }
 
-// TestTerminalTransitionsClearResetFlags verifies that ResetHeartbeats is cleared by every
-// terminal transition and that terminals are reachable from RESET_REQUESTED so a reset-in-flight
-// activity does not get stuck.
-func TestTerminalTransitionsClearResetFlags(t *testing.T) {
-	makeActivity := func(ctx *chasm.MockMutableContext, status activitypb.ActivityExecutionStatus) *Activity {
-		return &Activity{
-			ActivityState: &activitypb.ActivityState{
-				ActivityType:           &commonpb.ActivityType{Name: "test-activity-type"},
-				RetryPolicy:            defaultRetryPolicy,
-				ScheduleToCloseTimeout: durationpb.New(defaultScheduleToCloseTimeout),
-				ScheduleToStartTimeout: durationpb.New(defaultScheduleToStartTimeout),
-				StartToCloseTimeout:    durationpb.New(defaultStartToCloseTimeout),
-				Status:                 status,
-				TaskQueue:              &taskqueuepb.TaskQueue{Name: "test-task-queue"},
-				ResetHeartbeats:        true,
-			},
-			LastAttempt:   chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{Count: 2}),
-			LastHeartbeat: chasm.NewDataField(ctx, &activitypb.ActivityHeartbeatState{}),
-			Outcome:       chasm.NewDataField(ctx, &activitypb.ActivityOutcome{}),
-		}
+func TestTransitionResetClearsHeartbeat(t *testing.T) {
+	ctx := &chasm.MockMutableContext{}
+	ctx.HandleNow = func(chasm.Component) time.Time { return defaultTime }
+	attemptState := &activitypb.ActivityAttemptState{Count: 2}
+	heartbeatState := &activitypb.ActivityHeartbeatState{
+		Details:      payloads.EncodeString("heartbeat-details"),
+		RecordedTime: timestamppb.New(defaultTime),
 	}
 
-	newCtx := func() *chasm.MockMutableContext {
-		ctx := &chasm.MockMutableContext{}
-		ctx.HandleNow = func(chasm.Component) time.Time { return defaultTime }
-		return ctx
+	act := &Activity{
+		ActivityState: &activitypb.ActivityState{
+			ActivityType:           &commonpb.ActivityType{Name: "test-activity-type"},
+			RetryPolicy:            defaultRetryPolicy,
+			ScheduleToCloseTimeout: durationpb.New(defaultScheduleToCloseTimeout),
+			ScheduleToStartTimeout: durationpb.New(defaultScheduleToStartTimeout),
+			StartToCloseTimeout:    durationpb.New(defaultStartToCloseTimeout),
+			Status:                 activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+			ScheduleTime:           timestamppb.New(defaultTime),
+			TaskQueue:              &taskqueuepb.TaskQueue{Name: "test-task-queue"},
+		},
+		LastAttempt:   chasm.NewDataField(ctx, attemptState),
+		LastHeartbeat: chasm.NewDataField(ctx, heartbeatState),
+		Outcome:       chasm.NewDataField(ctx, &activitypb.ActivityOutcome{}),
 	}
 
-	t.Run("TransitionCompleted", func(t *testing.T) {
-		ctx := newCtx()
-		act := makeActivity(ctx, activitypb.ACTIVITY_EXECUTION_STATUS_STARTED)
+	err := TransitionReset.Apply(act, ctx, resetEvent{resetTime: defaultTime, handler: metrics.NoopMetricsHandler})
+	require.NoError(t, err)
+	require.Nil(t, heartbeatState.GetDetails())
+	require.Nil(t, heartbeatState.GetRecordedTime())
+}
 
-		ctrl := gomock.NewController(t)
-		mh := metrics.NewMockHandler(ctrl)
-		s2c := metrics.NewMockTimerIface(ctrl)
-		s2c.EXPECT().Record(gomock.Any())
-		mh.EXPECT().Timer(metrics.ActivityStartToCloseLatency.Name()).Return(s2c)
-		sch2c := metrics.NewMockTimerIface(ctrl)
-		sch2c.EXPECT().Record(gomock.Any())
-		mh.EXPECT().Timer(metrics.ActivityScheduleToCloseLatency.Name()).Return(sch2c)
-		ctr := metrics.NewMockCounterIface(ctrl)
-		ctr.EXPECT().Record(int64(1))
-		mh.EXPECT().Counter(metrics.ActivitySuccess.Name()).Return(ctr)
+func TestDeferredResetClearsHeartbeat(t *testing.T) {
+	testCases := []struct {
+		name              string
+		transition        chasm.Transition[activitypb.ActivityExecutionStatus, *Activity, rescheduleEvent]
+		resetKeepPaused   bool
+		expectedStatus    activitypb.ActivityExecutionStatus
+		expectedTaskCount int
+	}{
+		{
+			name:              "scheduled",
+			transition:        TransitionResetAttemptFailedToScheduled,
+			expectedStatus:    activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+			expectedTaskCount: 1,
+		},
+		{
+			name:            "paused",
+			transition:      TransitionResetAttemptFailedToPaused,
+			resetKeepPaused: true,
+			expectedStatus:  activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED,
+		},
+	}
 
-		err := TransitionCompleted.Apply(act, ctx, completeEvent{
-			req: &historyservice.RespondActivityTaskCompletedRequest{
-				CompleteRequest: &workflowservice.RespondActivityTaskCompletedRequest{Identity: "worker"},
-			},
-			metricsHandler: mh,
-		})
-		require.NoError(t, err)
-		require.False(t, act.ResetHeartbeats, "ResetHeartbeats should be cleared by TransitionCompleted")
-	})
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := &chasm.MockMutableContext{}
+			ctx.HandleNow = func(chasm.Component) time.Time { return defaultTime }
+			attemptState := &activitypb.ActivityAttemptState{
+				Count:       3,
+				StartedTime: timestamppb.New(defaultTime),
+			}
+			heartbeatState := &activitypb.ActivityHeartbeatState{
+				Details:      payloads.EncodeString("heartbeat-details"),
+				RecordedTime: timestamppb.New(defaultTime),
+			}
 
-	t.Run("TransitionFailed", func(t *testing.T) {
-		ctx := newCtx()
-		act := makeActivity(ctx, activitypb.ACTIVITY_EXECUTION_STATUS_STARTED)
-
-		ctrl := gomock.NewController(t)
-		mh := metrics.NewMockHandler(ctrl)
-		s2c := metrics.NewMockTimerIface(ctrl)
-		s2c.EXPECT().Record(gomock.Any())
-		mh.EXPECT().Timer(metrics.ActivityStartToCloseLatency.Name()).Return(s2c)
-		sch2c := metrics.NewMockTimerIface(ctrl)
-		sch2c.EXPECT().Record(gomock.Any())
-		mh.EXPECT().Timer(metrics.ActivityScheduleToCloseLatency.Name()).Return(sch2c)
-		cFail := metrics.NewMockCounterIface(ctrl)
-		cFail.EXPECT().Record(int64(1))
-		mh.EXPECT().Counter(metrics.ActivityFail.Name()).Return(cFail)
-		cTaskFail := metrics.NewMockCounterIface(ctrl)
-		cTaskFail.EXPECT().Record(int64(1))
-		mh.EXPECT().Counter(metrics.ActivityTaskFail.Name()).Return(cTaskFail)
-
-		err := TransitionFailed.Apply(act, ctx, failedEvent{
-			req: &historyservice.RespondActivityTaskFailedRequest{
-				FailedRequest: &workflowservice.RespondActivityTaskFailedRequest{
-					Failure: &failurepb.Failure{
-						Message: "non-retryable",
-						FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
-							ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{NonRetryable: true},
-						},
-					},
+			act := &Activity{
+				ActivityState: &activitypb.ActivityState{
+					ActivityType:            &commonpb.ActivityType{Name: "test-activity-type"},
+					RetryPolicy:             defaultRetryPolicy,
+					ScheduleToCloseTimeout:  durationpb.New(defaultScheduleToCloseTimeout),
+					ScheduleToStartTimeout:  durationpb.New(0),
+					StartToCloseTimeout:     durationpb.New(defaultStartToCloseTimeout),
+					Status:                  activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
+					ScheduleTime:            timestamppb.New(defaultTime),
+					FirstAttemptStartedTime: timestamppb.New(defaultTime),
+					TaskQueue:               &taskqueuepb.TaskQueue{Name: "test-task-queue"},
+					ResetKeepPaused:         tc.resetKeepPaused,
 				},
-			},
-			metricsHandler: mh,
+				LastAttempt:   chasm.NewDataField(ctx, attemptState),
+				LastHeartbeat: chasm.NewDataField(ctx, heartbeatState),
+				Outcome:       chasm.NewDataField(ctx, &activitypb.ActivityOutcome{}),
+			}
+
+			err := tc.transition.Apply(act, ctx, rescheduleEvent{})
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedStatus, act.Status)
+			require.Equal(t, int32(1), attemptState.Count)
+			require.Nil(t, attemptState.GetCurrentRetryInterval())
+			require.Nil(t, heartbeatState.GetDetails())
+			require.Nil(t, heartbeatState.GetRecordedTime())
+			require.Len(t, ctx.Tasks, tc.expectedTaskCount)
 		})
-		require.NoError(t, err)
-		require.False(t, act.ResetHeartbeats, "ResetHeartbeats should be cleared by TransitionFailed")
-	})
-
-	t.Run("TransitionTerminated", func(t *testing.T) {
-		ctx := newCtx()
-		act := makeActivity(ctx, activitypb.ACTIVITY_EXECUTION_STATUS_STARTED)
-
-		ctrl := gomock.NewController(t)
-		mh := metrics.NewMockHandler(ctrl)
-		ctr := metrics.NewMockCounterIface(ctrl)
-		ctr.EXPECT().Record(int64(1))
-		mh.EXPECT().Counter(metrics.ActivityTerminate.Name()).Return(ctr)
-
-		err := TransitionTerminated.Apply(act, ctx, terminateEvent{
-			request:        chasm.TerminateComponentRequest{Reason: "test"},
-			metricsHandler: mh,
-			fromStatus:     activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
-		})
-		require.NoError(t, err)
-		require.False(t, act.ResetHeartbeats, "ResetHeartbeats should be cleared by TransitionTerminated")
-	})
-
-	t.Run("TransitionCanceled", func(t *testing.T) {
-		ctx := newCtx()
-		act := makeActivity(ctx, activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED)
-
-		ctrl := gomock.NewController(t)
-		mh := metrics.NewMockHandler(ctrl)
-		s2c := metrics.NewMockTimerIface(ctrl)
-		s2c.EXPECT().Record(gomock.Any())
-		mh.EXPECT().Timer(metrics.ActivityStartToCloseLatency.Name()).Return(s2c)
-		sch2c := metrics.NewMockTimerIface(ctrl)
-		sch2c.EXPECT().Record(gomock.Any())
-		mh.EXPECT().Timer(metrics.ActivityScheduleToCloseLatency.Name()).Return(sch2c)
-		ctr := metrics.NewMockCounterIface(ctrl)
-		ctr.EXPECT().Record(int64(1))
-		mh.EXPECT().Counter(metrics.ActivityCancel.Name()).Return(ctr)
-
-		err := TransitionCanceled.Apply(act, ctx, cancelEvent{
-			handler:    mh,
-			fromStatus: activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
-		})
-		require.NoError(t, err)
-		require.False(t, act.ResetHeartbeats, "ResetHeartbeats should be cleared by TransitionCanceled")
-	})
-
-	t.Run("TransitionTimedOut", func(t *testing.T) {
-		ctx := newCtx()
-		act := makeActivity(ctx, activitypb.ACTIVITY_EXECUTION_STATUS_STARTED)
-
-		ctrl := gomock.NewController(t)
-		mh := metrics.NewMockHandler(ctrl)
-		s2c := metrics.NewMockTimerIface(ctrl)
-		s2c.EXPECT().Record(gomock.Any())
-		mh.EXPECT().Timer(metrics.ActivityStartToCloseLatency.Name()).Return(s2c)
-		sch2c := metrics.NewMockTimerIface(ctrl)
-		sch2c.EXPECT().Record(gomock.Any())
-		mh.EXPECT().Timer(metrics.ActivityScheduleToCloseLatency.Name()).Return(sch2c)
-		timeoutTag := metrics.StringTag("timeout_type", enumspb.TIMEOUT_TYPE_START_TO_CLOSE.String())
-		cTimeout := metrics.NewMockCounterIface(ctrl)
-		cTimeout.EXPECT().Record(int64(1), timeoutTag)
-		mh.EXPECT().Counter(metrics.ActivityTimeout.Name()).Return(cTimeout)
-		cTaskTimeout := metrics.NewMockCounterIface(ctrl)
-		cTaskTimeout.EXPECT().Record(int64(1), timeoutTag)
-		mh.EXPECT().Counter(metrics.ActivityTaskTimeout.Name()).Return(cTaskTimeout)
-
-		err := TransitionTimedOut.Apply(act, ctx, timeoutEvent{
-			timeoutType:    enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
-			metricsHandler: mh,
-			fromStatus:     activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
-		})
-		require.NoError(t, err)
-		require.False(t, act.ResetHeartbeats, "ResetHeartbeats should be cleared by TransitionTimedOut")
-	})
+	}
 }
 
 // TestTransitionResetFromPaused verifies that TransitionReset applied to a PAUSED activity

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -750,8 +750,8 @@ func TestTransitionResetClearsHeartbeat(t *testing.T) {
 
 	err := TransitionReset.Apply(act, ctx, resetEvent{resetTime: defaultTime, handler: metrics.NoopMetricsHandler})
 	require.NoError(t, err)
-	require.Nil(t, heartbeatState.GetDetails())
-	require.Nil(t, heartbeatState.GetRecordedTime())
+	require.Nil(t, act.LastHeartbeat.Get(ctx).GetDetails())
+	require.Nil(t, act.LastHeartbeat.Get(ctx).GetRecordedTime())
 }
 
 func TestDeferredResetClearsHeartbeat(t *testing.T) {
@@ -765,14 +765,16 @@ func TestDeferredResetClearsHeartbeat(t *testing.T) {
 		{
 			name:              "scheduled",
 			transition:        TransitionResetAttemptFailedToScheduled,
+			resetKeepPaused:   false,
 			expectedStatus:    activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
 			expectedTaskCount: 1,
 		},
 		{
-			name:            "paused",
-			transition:      TransitionResetAttemptFailedToPaused,
-			resetKeepPaused: true,
-			expectedStatus:  activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED,
+			name:              "paused",
+			transition:        TransitionResetAttemptFailedToPaused,
+			resetKeepPaused:   true,
+			expectedStatus:    activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED,
+			expectedTaskCount: 0,
 		},
 	}
 
@@ -812,8 +814,8 @@ func TestDeferredResetClearsHeartbeat(t *testing.T) {
 			require.Equal(t, tc.expectedStatus, act.Status)
 			require.Equal(t, int32(1), attemptState.Count)
 			require.Nil(t, attemptState.GetCurrentRetryInterval())
-			require.Nil(t, heartbeatState.GetDetails())
-			require.Nil(t, heartbeatState.GetRecordedTime())
+			require.Nil(t, act.LastHeartbeat.Get(ctx).GetDetails())
+			require.Nil(t, act.LastHeartbeat.Get(ctx).GetRecordedTime())
 			require.Len(t, ctx.Tasks, tc.expectedTaskCount)
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
-	go.temporal.io/api v1.63.3-0.20260709191808-4ef18a3ef68c
+	go.temporal.io/api v1.63.4-0.20260714230652-9624eed0ed99
 	go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee
 	go.temporal.io/sdk v1.41.1
 	go.uber.org/fx v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -471,8 +471,8 @@ go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0 h1:R
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0/go.mod h1:I89cynRj8y+383o7tEQVg2SVA6SRgDVIouWPUVXjx0U=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0 h1:CQvJSldHRUN6Z8jsUeYv8J0lXRvygALXIzsmAeCcZE0=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0/go.mod h1:xSQ+mEfJe/GjK1LXEyVOoSI1N9JV9ZI923X5kup43W4=
-go.temporal.io/api v1.63.3-0.20260709191808-4ef18a3ef68c h1:7dgudFu0HMwar3LzTWT0/z6dMpujXgRPFe9b1TTCmOg=
-go.temporal.io/api v1.63.3-0.20260709191808-4ef18a3ef68c/go.mod h1:0k75tRljEuELWGeXjEZZO7zYqBln4+1FrG6+IMOMy7Q=
+go.temporal.io/api v1.63.4-0.20260714230652-9624eed0ed99 h1:NaqvrLzEHe3amhPcl0Y+KQtFC35mWb4D56ml4T+K6lg=
+go.temporal.io/api v1.63.4-0.20260714230652-9624eed0ed99/go.mod h1:0k75tRljEuELWGeXjEZZO7zYqBln4+1FrG6+IMOMy7Q=
 go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee h1:y6A65Iml06cR3CpxW2Zn8FQLjniPDTnN4jtr69UZxXI=
 go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee/go.mod h1:hhHijO9XRPIkAflLJJHix61M9FzbRPqk8fSydkcLkqw=
 go.temporal.io/sdk v1.41.1 h1:yOpvsHyDD1lNuwlGBv/SUodCPhjv9nDeC9lLHW/fJUA=

--- a/tests/activity_api_reset_test.go
+++ b/tests/activity_api_reset_test.go
@@ -91,10 +91,10 @@ func (s *ActivityApiResetClientTestSuite) SetupTest() {
 	if s.apiName == "execution-api" {
 		s.resetFn = func(ctx context.Context, wfID, actID string, resetHeartbeat, keepPaused bool) error {
 			_, err := s.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
-				Namespace:      s.Namespace().String(),
-				WorkflowId:     wfID,
-				ActivityId:     actID,
-				KeepPaused:     keepPaused,
+				Namespace:  s.Namespace().String(),
+				WorkflowId: wfID,
+				ActivityId: actID,
+				KeepPaused: keepPaused,
 			})
 			return err
 		}

--- a/tests/activity_api_reset_test.go
+++ b/tests/activity_api_reset_test.go
@@ -94,7 +94,6 @@ func (s *ActivityApiResetClientTestSuite) SetupTest() {
 				Namespace:      s.Namespace().String(),
 				WorkflowId:     wfID,
 				ActivityId:     actID,
-				ResetHeartbeat: resetHeartbeat,
 				KeepPaused:     keepPaused,
 			})
 			return err

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -12419,7 +12419,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.NoError(t, err)
 	})
 
-	t.Run("ResetClearsHeartbeat", func(t *testing.T) {
+	t.Run("ResetClearsHeartbeatDetails", func(t *testing.T) {
 		// Activity records heartbeats. Reset clears them.
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
@@ -12492,7 +12492,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.NoError(t, err)
 	})
 
-	t.Run("ResetWhileRunningClearsHeartbeat", func(t *testing.T) {
+	t.Run("ResetClearsHeartbeatState", func(t *testing.T) {
 		// Reset while the activity is STARTED.
 		// The heartbeat clear is deferred — it only takes effect on the next retry,
 		// matching the behavior of the workflow activity HeartbeatDetails reset test.

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -12049,13 +12049,12 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.NoError(t, err)
 	}
 
-	resetActivity := func(ctx context.Context, t *testing.T, activityID, runID string, resetHeartbeat bool) {
+	resetActivity := func(ctx context.Context, t *testing.T, activityID, runID string) {
 		t.Helper()
 		_, err := env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
-			Namespace:      env.Namespace().String(),
-			ActivityId:     activityID,
-			RunId:          runID,
-			ResetHeartbeat: resetHeartbeat,
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
 		})
 		require.NoError(t, err)
 	}
@@ -12161,7 +12160,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		}, 5*time.Second, 200*time.Millisecond)
 
 		// Reset while SCHEDULED — should re-dispatch immediately at attempt 1
-		resetActivity(ctx, t, activityID, startResp.GetRunId(), false)
+		resetActivity(ctx, t, activityID, startResp.GetRunId())
 
 		// Poll — should be attempt 1
 		pollResp3, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
@@ -12197,7 +12196,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.EqualValues(t, 1, pollResp1.Attempt)
 
 		// Reset while running
-		resetActivity(ctx, t, activityID, startResp.GetRunId(), false)
+		resetActivity(ctx, t, activityID, startResp.GetRunId())
 
 		// Verify activity still appears as STARTED (reset is deferred)
 		desc, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
@@ -12251,7 +12250,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.EqualValues(t, 2, pollResp2.Attempt)
 
 		// Reset while attempt 2 is STARTED (deferred), then fail attempt 2 to trigger the reset.
-		resetActivity(ctx, t, activityID, startResp.GetRunId(), false)
+		resetActivity(ctx, t, activityID, startResp.GetRunId())
 		failAttemptRetryably(ctx, t, pollResp2.TaskToken, 0)
 
 		// The reset attempt (attempt 1) must dispatch promptly.
@@ -12399,7 +12398,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		}, 5*time.Second, 200*time.Millisecond)
 
 		// Reset — should bypass the 1-minute wait and dispatch immediately
-		resetActivity(ctx, t, activityID, startResp.GetRunId(), false)
+		resetActivity(ctx, t, activityID, startResp.GetRunId())
 
 		// Poll — task should be available immediately after reset (no long backoff)
 		pollResp2, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
@@ -12420,8 +12419,8 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.NoError(t, err)
 	})
 
-	t.Run("HeartbeatReset", func(t *testing.T) {
-		// Activity records heartbeats. Reset with resetHeartbeat=true clears them.
+	t.Run("ResetClearsHeartbeat", func(t *testing.T) {
+		// Activity records heartbeats. Reset clears them.
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
@@ -12465,12 +12464,11 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 			require.Equal(c, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, d.GetInfo().GetRunState())
 		}, 5*time.Second, 200*time.Millisecond)
 
-		// Reset with heartbeat reset
+		// Reset clears recorded heartbeat state.
 		_, err = env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
-			Namespace:      env.Namespace().String(),
-			ActivityId:     activityID,
-			RunId:          startResp.GetRunId(),
-			ResetHeartbeat: true,
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.GetRunId(),
 		})
 		require.NoError(t, err)
 
@@ -12494,8 +12492,8 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.NoError(t, err)
 	})
 
-	t.Run("HeartbeatResetWhileRunning", func(t *testing.T) {
-		// Reset with resetHeartbeat=true while the activity is STARTED.
+	t.Run("ResetWhileRunningClearsHeartbeat", func(t *testing.T) {
+		// Reset while the activity is STARTED.
 		// The heartbeat clear is deferred — it only takes effect on the next retry,
 		// matching the behavior of the workflow activity HeartbeatDetails reset test.
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -12527,8 +12525,8 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.NoError(t, err)
 		require.NotNil(t, desc.GetInfo().GetHeartbeatDetails())
 
-		// Reset with heartbeat reset while STARTED — deferred
-		resetActivity(ctx, t, activityID, startResp.GetRunId(), true)
+		// Reset while STARTED — heartbeat clearing is deferred.
+		resetActivity(ctx, t, activityID, startResp.GetRunId())
 
 		// Activity should still be STARTED with heartbeat still visible (reset is deferred)
 		desc, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
@@ -13555,7 +13553,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		// First reset -> RESET_REQUESTED (deferred reset of the running attempt). The reset handler
 		// runs synchronously, so the activity is in RESET_REQUESTED once this returns. (RESET_REQUESTED
 		// surfaces externally as runState STARTED — the worker is still running its attempt.)
-		resetActivity(ctx, t, activityID, startResp.GetRunId(), false)
+		resetActivity(ctx, t, activityID, startResp.GetRunId())
 
 		// Second reset while a reset is already pending must be rejected with a clear message — the
 		// worker is still running the attempt, so "activity execution is not running" would be wrong.


### PR DESCRIPTION
## What changed?
Resetting an activity execution now always clears heartbeat details. 

https://github.com/temporalio/api/pull/820 Removes the `reset_heartbeat` field from the Request message.

## Why?
This change simplifies the API surface and we (the engineering/product team) do not see a good use case for resetting an activity and keeping heartbeat data. If this is needed or there is a big customer ask for it we can add this back in the future.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [X] added new functional test(s)

## Potential risks
Minimal, PR is into a feature branch