### PR TITLE
Backlog-aware client add-task load balancing

### DIFF
--- a/client/matching/loadbalancer.go
+++ b/client/matching/loadbalancer.go
@@ -105,7 +105,49 @@ func (lb *defaultLoadBalancer) PickWritePartition(
 		partitionCount = max(1, lb.nWritePartitions(nsName.String(), taskQueue.Name(), taskQueue.TaskType()))
 	}
 
+	// Backlog-aware add-task load balancing (blueprint approach 3): if the server provided a
+	// backlog cap and per-partition counts covering all write partitions, bias new tasks toward
+	// partitions whose backlog is further below the cap (weighted random by gap to cap). Tasks
+	// concentrate on emptier partitions while every under-cap partition still gets some. Falls
+	// back to uniform when backlog data or cap is unavailable, or when every partition is at cap.
+	if backlogCap := number.DecodeCompact8(pc.BacklogCap); backlogCap > 0 &&
+		partitionCount > 0 && len(pc.BacklogCount) >= partitionCount {
+		if p, ok := pickWritePartitionByGap(pc.BacklogCount, partitionCount, backlogCap); ok {
+			return taskQueue.NormalPartition(p)
+		}
+	}
+
 	return taskQueue.NormalPartition(rand.Intn(partitionCount))
+}
+
+// pickWritePartitionByGap picks a partition with probability proportional to how far its backlog
+// is below backlogCap (blueprint approach 3: weighted random by gap between cap and current size).
+// It returns ok=false when every partition is at or above the cap, so the caller falls back to
+// uniform selection rather than starving all writes. Counts are decoded inline (rather than into
+// a slice) to avoid an allocation on the per-AddTask hot path; the caller must ensure
+// len(counts) >= partitionCount.
+func pickWritePartitionByGap(counts []number.Compact8, partitionCount int, backlogCap int64) (int, bool) {
+	var total int64
+	for i := 0; i < partitionCount; i++ {
+		if gap := backlogCap - number.DecodeCompact8(counts[i]); gap > 0 {
+			total += gap
+		}
+	}
+	if total <= 0 {
+		return 0, false
+	}
+	r := rand.Int63n(total)
+	for i := 0; i < partitionCount; i++ {
+		gap := backlogCap - number.DecodeCompact8(counts[i])
+		if gap <= 0 {
+			continue
+		}
+		if r < gap {
+			return i, true
+		}
+		r -= gap
+	}
+	return partitionCount - 1, true // unreachable in practice; guard against rounding
 }
 
 // PickReadPartition picks a partition for poller to poll task from, and keeps load balanced between partitions.

--- a/client/matching/loadbalancer.go
+++ b/client/matching/loadbalancer.go
@@ -96,11 +96,10 @@ func (lb *defaultLoadBalancer) PickWritePartition(
 		partitionCount = max(1, lb.nWritePartitions(nsName.String(), taskQueue.Name(), taskQueue.TaskType()))
 	}
 
-	// Backlog-aware add-task load balancing (blueprint approach 3): if the server provided a
-	// backlog cap and per-partition counts covering all write partitions, bias new tasks toward
-	// partitions whose backlog is further below the cap (weighted random by gap to cap). Tasks
-	// concentrate on emptier partitions while every under-cap partition still gets some. Falls
-	// back to uniform when backlog data or cap is unavailable, or when every partition is at cap.
+	// Backlog-aware add-task load balancing:
+	// If the server provided a backlog cap and per-partition counts covering all write partitions, bias
+	// new tasks toward partitions whose backlog is further below the cap (weighted random by gap to cap).
+	// Falls back to uniform when backlog data or cap is unavailable, or when every partition is at cap.
 	if backlogCap := number.DecodeCompact8(pc.BacklogCap); backlogCap > 0 &&
 		partitionCount > 0 && len(pc.BacklogCount) >= partitionCount {
 		if p, ok := pickWritePartitionByGap(pc.BacklogCount, partitionCount, backlogCap); ok {
@@ -112,33 +111,29 @@ func (lb *defaultLoadBalancer) PickWritePartition(
 }
 
 // pickWritePartitionByGap picks a partition with probability proportional to how far its backlog
-// is below backlogCap (blueprint approach 3: weighted random by gap between cap and current size).
-// It returns ok=false when every partition is at or above the cap, so the caller falls back to
-// uniform selection rather than starving all writes. Counts are decoded inline (rather than into
-// a slice) to avoid an allocation on the per-AddTask hot path; the caller must ensure
-// len(counts) >= partitionCount.
+// is below backlogCap. Returns ok=false when every partition is at or above the cap.
 func pickWritePartitionByGap(counts []number.Compact8, partitionCount int, backlogCap int64) (int, bool) {
 	var total int64
-	for i := 0; i < partitionCount; i++ {
+	for i := range partitionCount {
 		if gap := backlogCap - number.DecodeCompact8(counts[i]); gap > 0 {
 			total += gap
 		}
 	}
-	if total <= 0 {
+	if total <= 0 { // all partitions are at or above cap
 		return 0, false
 	}
 	r := rand.Int63n(total)
-	for i := 0; i < partitionCount; i++ {
+	for i := range partitionCount {
 		gap := backlogCap - number.DecodeCompact8(counts[i])
-		if gap <= 0 {
+		if gap <= 0 { // this partition is at or above cap
 			continue
 		}
-		if r < gap {
+		if r < gap { // more likely to be true the bigger this partition's gap is
 			return i, true
 		}
 		r -= gap
 	}
-	return partitionCount - 1, true // unreachable in practice; guard against rounding
+	return partitionCount - 1, true // unreachable in practice; guard against compact8 rounding
 }
 
 // PickReadPartition picks a partition for poller to poll task from, and keeps load balanced between partitions.

--- a/client/matching/loadbalancer.go
+++ b/client/matching/loadbalancer.go
@@ -96,23 +96,24 @@ func (lb *defaultLoadBalancer) PickWritePartition(
 		partitionCount = max(1, lb.nWritePartitions(nsName.String(), taskQueue.Name(), taskQueue.TaskType()))
 	}
 
-	// Backlog-aware add-task load balancing:
-	// If the server provided a backlog cap and per-partition counts covering all write partitions, bias
-	// new tasks toward partitions whose backlog is further below the cap (weighted random by gap to cap).
-	// Falls back to uniform when backlog data or cap is unavailable, or when every partition is at cap.
-	if backlogCap := number.DecodeCompact8(pc.BacklogCap); backlogCap > 0 &&
-		partitionCount > 0 && len(pc.BacklogCount) >= partitionCount {
-		if p, ok := pickWritePartitionByGap(pc.BacklogCount, partitionCount, backlogCap); ok {
-			return taskQueue.NormalPartition(p)
-		}
-	}
-
-	return taskQueue.NormalPartition(rand.Intn(partitionCount))
+	return taskQueue.NormalPartition(pickWritePartitionByGap(
+		pc.BacklogCount,
+		partitionCount,
+		number.DecodeCompact8(pc.BacklogCap),
+	))
 }
 
 // pickWritePartitionByGap picks a partition with probability proportional to how far its backlog
-// is below backlogCap. Returns ok=false when every partition is at or above the cap.
-func pickWritePartitionByGap(counts []number.Compact8, partitionCount int, backlogCap int64) (int, bool) {
+// is below backlogCap. Falls back to uniform random if any of these are true:
+//   - every partition is at or above the backlogCap
+//   - backlogCap is 0
+//   - when backlog data is not available for all write partitions
+func pickWritePartitionByGap(counts []number.Compact8, partitionCount int, backlogCap int64) int {
+	if backlogCap == 0 ||
+		len(counts) < partitionCount {
+		return rand.Intn(partitionCount)
+	}
+
 	var total int64
 	for i := range partitionCount {
 		if gap := backlogCap - number.DecodeCompact8(counts[i]); gap > 0 {
@@ -120,7 +121,7 @@ func pickWritePartitionByGap(counts []number.Compact8, partitionCount int, backl
 		}
 	}
 	if total <= 0 { // all partitions are at or above cap
-		return 0, false
+		return rand.Intn(partitionCount)
 	}
 	r := rand.Int63n(total)
 	for i := range partitionCount {
@@ -129,11 +130,11 @@ func pickWritePartitionByGap(counts []number.Compact8, partitionCount int, backl
 			continue
 		}
 		if r < gap { // more likely to be true the bigger this partition's gap is
-			return i, true
+			return i
 		}
 		r -= gap
 	}
-	return partitionCount - 1, true // unreachable in practice; guard against compact8 rounding
+	return partitionCount - 1 // unreachable in practice; guard against compact8 rounding
 }
 
 // PickReadPartition picks a partition for poller to poll task from, and keeps load balanced between partitions.

--- a/client/matching/loadbalancer_test.go
+++ b/client/matching/loadbalancer_test.go
@@ -252,32 +252,6 @@ func TestPickReadPartition_IncompleteBacklogFallsBack(t *testing.T) {
 	}
 }
 
-func TestPickWritePartitionByGap(t *testing.T) {
-	// compact8: byte 0 -> 0, byte 192 -> ~12.6M (see common/number/compact8_test.go).
-	// cap ~21M: partition 0 is empty (gap ~21M), partition 1 is partly full (gap ~8.4M).
-	counts := []number.Compact8{0, 192}
-	backlogCap := number.DecodeCompact8(200)
-	partitionCount := 2
-
-	picks := make([]int, partitionCount)
-	const n = 3000
-	for range n {
-		p, ok := pickWritePartitionByGap(counts, partitionCount, backlogCap)
-		assert.True(t, ok)
-		picks[p]++
-	}
-	// partition 0 gets the larger share (bigger gap), but partition 1 still gets some.
-	assert.Greater(t, picks[0], picks[1])
-	assert.Greater(t, picks[1], 0, "the below-cap partition still gets some tasks")
-	gap0 := backlogCap - number.DecodeCompact8(0)
-	gap1 := backlogCap - number.DecodeCompact8(192)
-	assert.InDelta(t, float64(n)*float64(gap0)/float64(gap0+gap1), picks[0], float64(n)*0.05)
-
-	// every partition at/above cap -> ok=false so caller falls back to uniform.
-	_, ok := pickWritePartitionByGap([]number.Compact8{200, 200}, 2, backlogCap)
-	assert.False(t, ok)
-}
-
 func TestPickWritePartition_BacklogAware(t *testing.T) {
 	f, err := tqid.NewTaskQueueFamily("fake-namespace-id", "fake-taskqueue")
 	assert.NoError(t, err)
@@ -288,10 +262,13 @@ func TestPickWritePartition_BacklogAware(t *testing.T) {
 		taskQueueLBs:      make(map[tqid.TaskQueue]*tqLoadBalancer),
 	}
 
-	// cap (byte 200) decodes to ~21M. Both partitions are below the cap: partition 0 is empty
-	// (gap ~21M) and partition 1 is partially full (byte 192 ~12.6M, gap ~8.4M). Writes should
-	// favor the emptier partition 0 while partition 1 still receives a meaningful share. This
-	// exercises the weighting gradient through the full path, not just at-cap exclusion.
+	// compact8: byte 0 -> 0, byte 192 -> ~12.6M, byte 200 (cap) -> ~21M
+	// (see common/number/compact8_test.go).
+	backlogCap := number.DecodeCompact8(200)
+
+	// Both partitions are below the cap: partition 0 is empty (gap ~21M) and partition 1 is
+	// partially full (byte 192 ~12.6M, gap ~8.4M). Writes should favor the emptier partition 0
+	// in proportion to the gaps, while partition 1 still receives a meaningful share.
 	pc := PartitionCounts{
 		Read:         2,
 		Write:        2,
@@ -299,13 +276,34 @@ func TestPickWritePartition_BacklogAware(t *testing.T) {
 		BacklogCount: []number.Compact8{0, 192},
 	}
 	counts := make([]int, 2)
-	const n = 1000
+	const n = 3000
 	for range n {
 		p := lb.PickWritePartition(taskQueue, pc)
 		counts[p.PartitionId()]++
 	}
 	assert.Greater(t, counts[0], counts[1], "emptier partition should receive more writes")
 	assert.Greater(t, counts[1], 0, "the below-cap partition should still receive some writes")
+	gap0 := backlogCap - number.DecodeCompact8(0)
+	gap1 := backlogCap - number.DecodeCompact8(192)
+	assert.InDelta(t, float64(n)*float64(gap0)/float64(gap0+gap1), counts[0], float64(n)*0.05,
+		"writes split in proportion to each partition's gap to cap")
+
+	// Now, every partition at/above cap -> no gap to weight by, so the picker declines and the caller
+	// falls back to uniform random.
+	pcAtCap := PartitionCounts{
+		Read:         2,
+		Write:        2,
+		BacklogCap:   200,
+		BacklogCount: []number.Compact8{200, 200},
+	}
+	atCap := make([]int, 2)
+	for range n {
+		p := lb.PickWritePartition(taskQueue, pcAtCap)
+		atCap[p.PartitionId()]++
+	}
+	for i := range atCap {
+		assert.InDelta(t, n/2, atCap[i], float64(n)*0.1, "at-cap partition %d roughly uniform", i)
+	}
 }
 
 func TestPickWritePartition_NoBacklogUniform(t *testing.T) {

--- a/client/matching/loadbalancer_test.go
+++ b/client/matching/loadbalancer_test.go
@@ -317,6 +317,85 @@ func TestPickReadPartition_ShortBacklogFallsBack(t *testing.T) {
 	}
 }
 
+func TestPickWritePartitionByGap(t *testing.T) {
+	// compact8: byte 0 -> 0, byte 192 -> ~12.6M (see common/number/compact8_test.go).
+	// cap ~21M: partition 0 is empty (gap ~21M), partition 1 is partly full (gap ~8.4M).
+	counts := []number.Compact8{0, 192}
+	backlogCap := number.DecodeCompact8(200)
+	partitionCount := 2
+
+	picks := make([]int, partitionCount)
+	const n = 3000
+	for range n {
+		p, ok := pickWritePartitionByGap(counts, partitionCount, backlogCap)
+		assert.True(t, ok)
+		picks[p]++
+	}
+	// partition 0 gets the larger share (bigger gap), but partition 1 still gets some.
+	assert.Greater(t, picks[0], picks[1])
+	assert.Greater(t, picks[1], 0, "the below-cap partition still gets some tasks")
+	gap0 := backlogCap - number.DecodeCompact8(0)
+	gap1 := backlogCap - number.DecodeCompact8(192)
+	assert.InDelta(t, float64(n)*float64(gap0)/float64(gap0+gap1), picks[0], float64(n)*0.05)
+
+	// every partition at/above cap -> ok=false so caller falls back to uniform.
+	_, ok := pickWritePartitionByGap([]number.Compact8{200, 200}, 2, backlogCap)
+	assert.False(t, ok)
+}
+
+func TestPickWritePartition_BacklogAware(t *testing.T) {
+	f, err := tqid.NewTaskQueueFamily("fake-namespace-id", "fake-taskqueue")
+	assert.NoError(t, err)
+	taskQueue := f.TaskQueue(enumspb.TASK_QUEUE_TYPE_ACTIVITY)
+
+	lb := &defaultLoadBalancer{
+		namespaceIDToName: func(namespace.ID) (namespace.Name, error) { return "fake-namespace", nil },
+		taskQueueLBs:      make(map[tqid.TaskQueue]*tqLoadBalancer),
+	}
+
+	// cap (byte 200) decodes to ~21M. Both partitions are below the cap: partition 0 is empty
+	// (gap ~21M) and partition 1 is partially full (byte 192 ~12.6M, gap ~8.4M). Writes should
+	// favor the emptier partition 0 while partition 1 still receives a meaningful share. This
+	// exercises the weighting gradient through the full path, not just at-cap exclusion.
+	pc := PartitionCounts{
+		Read:         2,
+		Write:        2,
+		BacklogCap:   200,
+		BacklogCount: []number.Compact8{0, 192},
+	}
+	counts := make([]int, 2)
+	const n = 1000
+	for range n {
+		p := lb.PickWritePartition(taskQueue, pc)
+		counts[p.PartitionId()]++
+	}
+	assert.Greater(t, counts[0], counts[1], "emptier partition should receive more writes")
+	assert.Greater(t, counts[1], 0, "the below-cap partition should still receive some writes")
+}
+
+func TestPickWritePartition_NoBacklogUniform(t *testing.T) {
+	f, err := tqid.NewTaskQueueFamily("fake-namespace-id", "fake-taskqueue")
+	assert.NoError(t, err)
+	taskQueue := f.TaskQueue(enumspb.TASK_QUEUE_TYPE_ACTIVITY)
+
+	lb := &defaultLoadBalancer{
+		namespaceIDToName: func(namespace.ID) (namespace.Name, error) { return "fake-namespace", nil },
+		taskQueueLBs:      make(map[tqid.TaskQueue]*tqLoadBalancer),
+	}
+
+	// no backlog cap -> uniform random across the 4 write partitions.
+	pc := PartitionCounts{Read: 4, Write: 4}
+	counts := make([]int, 4)
+	const n = 4000
+	for range n {
+		p := lb.PickWritePartition(taskQueue, pc)
+		counts[p.PartitionId()]++
+	}
+	for i := range counts {
+		assert.InDelta(t, n/4, counts[i], float64(n)*0.1, "partition %d roughly uniform", i)
+	}
+}
+
 func maxPollerCount(tqlb *tqLoadBalancer) int {
 	res := -1
 	for _, c := range tqlb.pollerCounts {

--- a/client/matching/loadbalancer_test.go
+++ b/client/matching/loadbalancer_test.go
@@ -263,16 +263,16 @@ func TestPickWritePartition_BacklogAware(t *testing.T) {
 		taskQueueLBs:      make(map[tqid.TaskQueue]*tqLoadBalancer),
 	}
 
-	backlogCap := number.DecodeCompact8(number.EncodeCompact8(21000000))
+	backlogCap := number.DecodeCompact8(number.EncodeCompact8(21_000_000))
 
 	// Both partitions are below the cap: partition 0 is empty (gap ~21M) and partition 1 is
-	// partially full (byte 192 ~12.6M, gap ~8.4M). Writes should favor the emptier partition 0
+	// partially full (~12.6M, gap ~8.4M). Writes should favor the emptier partition 0
 	// in proportion to the gaps, while partition 1 still receives a meaningful share.
 	pc := PartitionCounts{
 		Read:         2,
 		Write:        2,
 		BacklogCap:   200,
-		BacklogCount: []number.Compact8{0, 192},
+		BacklogCount: []number.Compact8{0, number.EncodeCompact8(13_000_000)},
 	}
 	counts := make([]int, 2)
 	const n = 3000
@@ -283,7 +283,7 @@ func TestPickWritePartition_BacklogAware(t *testing.T) {
 	require.Greater(t, counts[0], counts[1], "emptier partition should receive more writes")
 	require.Positive(t, counts[1], "the below-cap partition should still receive some writes")
 	gap0 := backlogCap - number.DecodeCompact8(0)
-	gap1 := backlogCap - number.DecodeCompact8(192)
+	gap1 := backlogCap - number.DecodeCompact8(number.EncodeCompact8(13_000_000))
 	require.InDelta(t, float64(n)*float64(gap0)/float64(gap0+gap1), counts[0], float64(n)*0.05,
 		"writes split in proportion to each partition's gap to cap")
 

--- a/client/matching/loadbalancer_test.go
+++ b/client/matching/loadbalancer_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/number"
@@ -172,12 +173,12 @@ func TestTQLoadBalancerWeighted_FillsEachBeforeFocussingOnBacklog(t *testing.T) 
 	// During the first Read picks, no partition should ever exceed one poller.
 	for range 4 {
 		lb.PickReadPartition(tq, pc)
-		assert.LessOrEqual(t, maxPollerCount(tqlb), 1,
+		require.LessOrEqual(t, maxPollerCount(tqlb), 1,
 			"no partition should get a 2nd poller until every partition has 1")
 	}
 	// After exactly Read picks, every partition has exactly one poller.
 	for i, c := range tqlb.pollerCounts {
-		assert.Equalf(t, 1, c, "partition %d should have exactly one poller after the first round", i)
+		require.Equalf(t, 1, c, "partition %d should have exactly one poller after the first round", i)
 	}
 
 	// Do a lot more rounds of picking
@@ -186,8 +187,8 @@ func TestTQLoadBalancerWeighted_FillsEachBeforeFocussingOnBacklog(t *testing.T) 
 	}
 
 	// The high-backlog partition gets the most pollers; empty partitions still get some.
-	assert.Greater(t, tqlb.pollerCounts[3], tqlb.pollerCounts[0])
-	assert.Greater(t, tqlb.pollerCounts[0], 0)
+	require.Greater(t, tqlb.pollerCounts[3], tqlb.pollerCounts[0])
+	require.Positive(t, tqlb.pollerCounts[0])
 }
 
 func TestTQLoadBalancerWeighted_EqualWeightsBalances(t *testing.T) {
@@ -205,13 +206,13 @@ func TestTQLoadBalancerWeighted_EqualWeightsBalances(t *testing.T) {
 		lb.PickReadPartition(tq, pc)
 	}
 	for _, c := range lb.getTaskQueueLoadBalancer(tq).pollerCounts {
-		assert.Equal(t, 2, c)
+		require.Equal(t, 2, c)
 	}
 }
 
 func TestPickReadPartition_NoBacklogFallsBack(t *testing.T) {
 	f, err := tqid.NewTaskQueueFamily("fake-namespace-id", "fake-taskqueue")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tq := f.TaskQueue(enumspb.TASK_QUEUE_TYPE_ACTIVITY)
 
 	lb := &defaultLoadBalancer{
@@ -226,13 +227,13 @@ func TestPickReadPartition_NoBacklogFallsBack(t *testing.T) {
 	}
 	tqlb := lb.getTaskQueueLoadBalancer(tq)
 	for _, c := range tqlb.pollerCounts {
-		assert.Equal(t, 2, c)
+		require.Equal(t, 2, c)
 	}
 }
 
 func TestPickReadPartition_IncompleteBacklogFallsBack(t *testing.T) {
 	f, err := tqid.NewTaskQueueFamily("fake-namespace-id", "fake-taskqueue")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tq := f.TaskQueue(enumspb.TASK_QUEUE_TYPE_ACTIVITY)
 
 	lb := &defaultLoadBalancer{
@@ -248,13 +249,13 @@ func TestPickReadPartition_IncompleteBacklogFallsBack(t *testing.T) {
 	}
 	tqlb := lb.getTaskQueueLoadBalancer(tq)
 	for _, c := range tqlb.pollerCounts {
-		assert.Equal(t, 2, c)
+		require.Equal(t, 2, c)
 	}
 }
 
 func TestPickWritePartition_BacklogAware(t *testing.T) {
 	f, err := tqid.NewTaskQueueFamily("fake-namespace-id", "fake-taskqueue")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	taskQueue := f.TaskQueue(enumspb.TASK_QUEUE_TYPE_ACTIVITY)
 
 	lb := &defaultLoadBalancer{
@@ -279,11 +280,11 @@ func TestPickWritePartition_BacklogAware(t *testing.T) {
 		p := lb.PickWritePartition(taskQueue, pc)
 		counts[p.PartitionId()]++
 	}
-	assert.Greater(t, counts[0], counts[1], "emptier partition should receive more writes")
-	assert.Greater(t, counts[1], 0, "the below-cap partition should still receive some writes")
+	require.Greater(t, counts[0], counts[1], "emptier partition should receive more writes")
+	require.Positive(t, counts[1], "the below-cap partition should still receive some writes")
 	gap0 := backlogCap - number.DecodeCompact8(0)
 	gap1 := backlogCap - number.DecodeCompact8(192)
-	assert.InDelta(t, float64(n)*float64(gap0)/float64(gap0+gap1), counts[0], float64(n)*0.05,
+	require.InDelta(t, float64(n)*float64(gap0)/float64(gap0+gap1), counts[0], float64(n)*0.05,
 		"writes split in proportion to each partition's gap to cap")
 
 	// Now, every partition at/above cap -> no gap to weight by, so the picker declines and the caller
@@ -300,13 +301,13 @@ func TestPickWritePartition_BacklogAware(t *testing.T) {
 		atCap[p.PartitionId()]++
 	}
 	for i := range atCap {
-		assert.InDelta(t, n/2, atCap[i], float64(n)*0.1, "at-cap partition %d roughly uniform", i)
+		require.InDelta(t, n/2, atCap[i], float64(n)*0.1, "at-cap partition %d roughly uniform", i)
 	}
 }
 
 func TestPickWritePartition_NoBacklogUniform(t *testing.T) {
 	f, err := tqid.NewTaskQueueFamily("fake-namespace-id", "fake-taskqueue")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	taskQueue := f.TaskQueue(enumspb.TASK_QUEUE_TYPE_ACTIVITY)
 
 	lb := &defaultLoadBalancer{
@@ -323,7 +324,7 @@ func TestPickWritePartition_NoBacklogUniform(t *testing.T) {
 		counts[p.PartitionId()]++
 	}
 	for i := range counts {
-		assert.InDelta(t, n/4, counts[i], float64(n)*0.1, "partition %d roughly uniform", i)
+		require.InDelta(t, n/4, counts[i], float64(n)*0.1, "partition %d roughly uniform", i)
 	}
 }
 

--- a/client/matching/loadbalancer_test.go
+++ b/client/matching/loadbalancer_test.go
@@ -262,9 +262,7 @@ func TestPickWritePartition_BacklogAware(t *testing.T) {
 		taskQueueLBs:      make(map[tqid.TaskQueue]*tqLoadBalancer),
 	}
 
-	// compact8: byte 0 -> 0, byte 192 -> ~12.6M, byte 200 (cap) -> ~21M
-	// (see common/number/compact8_test.go).
-	backlogCap := number.DecodeCompact8(200)
+	backlogCap := number.DecodeCompact8(number.EncodeCompact8(21000000))
 
 	// Both partitions are below the cap: partition 0 is empty (gap ~21M) and partition 1 is
 	// partially full (byte 192 ~12.6M, gap ~8.4M). Writes should favor the emptier partition 0


### PR DESCRIPTION
## What changed
Backlog-aware add-task load balancing on the client. When the server provides a backlog cap and per-partition counts covering the write partitions, `PickWritePartition` biases new tasks toward partitions whose backlog is further below the cap, weighted-random by gap to cap. Tasks concentrate on emptier partitions while every under-cap partition still gets some.

Falls back to the existing uniform random selection when:
- there's no backlog cap or counts (dynamic partitioning off / backlog LB not configured),
- the counts are shorter than the write count (e.g. lagging a scale-up), or
- every partition is already at/above the cap.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task routing for all add-task calls when backlog metadata is present; mis-weighting or stale counts could skew load across partitions, though fallbacks preserve prior random behavior.
> 
> **Overview**
> **`PickWritePartition`** no longer picks a write partition with uniform random. When the server supplies **`BacklogCap`** and per-partition **`BacklogCount`** for every write partition, new tasks go to partitions with probability proportional to how far each backlog is below the cap (gap-weighted random via **`pickWritePartitionByGap`**).
> 
> Behavior matches the existing read-side backlog weighting pattern: emptier partitions get more adds, but under-cap partitions still receive traffic. If the cap is zero, counts are incomplete (e.g. scale-up lag), or every partition is at/above cap, selection falls back to the previous uniform **`rand.Intn`** behavior.
> 
> Tests cover proportional splitting, at-cap uniform fallback, and no-cap uniform fallback; several read-path tests switch **`assert`** to **`require`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f91bcdcb948275bcfbf80f3db4415e8db95e9fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->