### PR TITLE
Add RefConsistencyLevel CHASM transition option

### DIFF
--- a/chasm/engine.go
+++ b/chasm/engine.go
@@ -81,11 +81,39 @@ const (
 	BusinessIDConflictPolicyUseExisting
 )
 
+// RefConsistencyLevel controls how strictly a [ComponentRef] is validated when it is used to address a
+// component in UpdateComponent. Each level selects which versioned transition the execution staleness check
+// ([Node.IsStale]) keys off — i.e. how fresh the loaded mutable state must be — and, at the weakest level,
+// whether the run ID is honored. It governs only the consistency-token / run resolution of the ref;
+// archetype validation and access-intent (operation-intent) checks always apply.
+//
+// The levels form a ladder from strongest to weakest:
+//
+//   - ExecutionLastUpdate: staleness is checked against the execution's last-update versioned transition —
+//     the loaded state must be at the exact transition the ref was taken at. Strongest; the default.
+//   - ComponentCreation: staleness is checked against the target component's initial (creation) versioned
+//     transition — the loaded state need only be at least as new as when the component was created (so it
+//     is guaranteed to know about the component), tolerating a stale execution transition. The creation
+//     transition is additionally matched in [Node.Component] so the same component instance must still
+//     exist at the path.
+//   - CurrentRun: the ref is resolved by component path on the current run, dropping the run ID and every
+//     versioned transition (no staleness check). Callers relying on this level must re-establish identity
+//     in component logic (e.g. by request ID). Weakest; note this resolves the current run only and does
+//     NOT verify the ref's run and the current run are in the same chain.
+type RefConsistencyLevel int
+
+const (
+	RefConsistencyLevelExecutionLastUpdate RefConsistencyLevel = iota
+	RefConsistencyLevelComponentCreation
+	RefConsistencyLevelCurrentRun
+)
+
 type TransitionOptions struct {
-	ReusePolicy    BusinessIDReusePolicy
-	ConflictPolicy BusinessIDConflictPolicy
-	RequestID      string
-	Speculative    bool
+	ReusePolicy      BusinessIDReusePolicy
+	ConflictPolicy   BusinessIDConflictPolicy
+	ConsistencyLevel RefConsistencyLevel
+	RequestID        string
+	Speculative      bool
 }
 
 type TransitionOption func(*TransitionOptions)
@@ -169,6 +197,15 @@ func WithRequestID(
 ) TransitionOption {
 	return func(opts *TransitionOptions) {
 		opts.RequestID = requestID
+	}
+}
+
+// WithRefConsistencyLevel sets the [RefConsistencyLevel] for the transition, controlling how strictly the
+// supplied component ref is validated. Currently only UpdateComponent() honors it; it defaults to
+// [RefConsistencyLevelExecutionLastUpdate].
+func WithRefConsistencyLevel(level RefConsistencyLevel) TransitionOption {
+	return func(opts *TransitionOptions) {
+		opts.ConsistencyLevel = level
 	}
 }
 
@@ -288,7 +325,9 @@ func UpdateWithStartExecution[C RootComponent, I any, O any](
 //     comment of the NewRef method in MutableContext.
 //
 // UpdateComponent applies updateFn to the component identified by the supplied component reference.
-// opts are currently ignored.
+//
+// The only opts currently honored is [WithRefConsistencyLevel]; it selects the [RefConsistencyLevel] used to
+// resolve and validate the ref (see that type for the ladder of levels). Other options are ignored.
 //
 // It returns the result, along with the new component reference. The returned reference may be
 // nil when updateFn deletes the component in the same transaction and the component is not the
@@ -303,6 +342,15 @@ func UpdateComponent[C any, R []byte | ComponentRef, I any, O any](
 	var output O
 
 	ref, err := convertComponentRef(r)
+	if err != nil {
+		return output, nil, err
+	}
+
+	var options TransitionOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+	ref, err = ref.forConsistencyLevel(options.ConsistencyLevel)
 	if err != nil {
 		return output, nil, err
 	}

--- a/chasm/ref.go
+++ b/chasm/ref.go
@@ -80,6 +80,37 @@ func NewComponentRefByArchetypeID(
 	}
 }
 
+// forConsistencyLevel returns a copy of the ref adjusted for the requested [RefConsistencyLevel] by
+// dropping the consistency tokens (and, at the weakest level, the run ID) that the level does not enforce.
+// See [RefConsistencyLevel] for the ladder.
+func (r *ComponentRef) forConsistencyLevel(level RefConsistencyLevel) (ComponentRef, error) {
+	ref := *r
+	switch level {
+	case RefConsistencyLevelExecutionLastUpdate:
+		// Strongest (default): enforce the execution-level token; nothing relaxed.
+		return ref, nil
+	case RefConsistencyLevelComponentCreation:
+		// Tolerate a stale execution transition without losing the staleness guarantee: run the
+		// execution staleness check ([Node.IsStale]) against the component's creation transition
+		// instead of the execution's last update. This still reloads a mutable state that predates
+		// the component (so the handler never operates on a state that doesn't yet know about the
+		// component), while no longer requiring the ref to match the latest execution transition.
+		// The creation transition is also matched in [Node.Component]; identity is otherwise the
+		// caller's responsibility (e.g. request ID).
+		ref.executionLastUpdateVT = ref.componentInitialVT
+		return ref, nil
+	case RefConsistencyLevelCurrentRun:
+		// Weakest: resolve by component path on the current run. Drop the run ID and every versioned
+		// transition; identity must be re-established by caller logic (e.g. request ID).
+		ref.executionLastUpdateVT = nil
+		ref.componentInitialVT = nil
+		ref.RunID = ""
+		return ref, nil
+	default:
+		return ref, serviceerror.NewInternalf("unknown ref consistency level: %d", level)
+	}
+}
+
 func (r *ComponentRef) ArchetypeID(
 	registry *Registry,
 ) (ArchetypeID, error) {

--- a/chasm/ref_test.go
+++ b/chasm/ref_test.go
@@ -114,3 +114,82 @@ func (s *componentRefSuite) TestSerializeDeserialize() {
 	s.Equal(ref.ExecutionKey, deserializedRef.ExecutionKey)
 	s.Equal(ref.componentPath, deserializedRef.componentPath)
 }
+
+func (s *componentRefSuite) TestForConsistencyLevel() {
+	newRef := func() ComponentRef {
+		return ComponentRef{
+			ExecutionKey: ExecutionKey{
+				NamespaceID: primitives.NewUUID().String(),
+				BusinessID:  primitives.NewUUID().String(),
+				RunID:       primitives.NewUUID().String(),
+			},
+			archetypeID:     WorkflowArchetypeID,
+			executionGoType: reflect.TypeFor[*TestComponent](),
+			executionLastUpdateVT: &persistencespb.VersionedTransition{
+				NamespaceFailoverVersion: rand.Int63(),
+				TransitionCount:          rand.Int63(),
+			},
+			componentPath: []string{primitives.NewUUID().String()},
+			componentInitialVT: &persistencespb.VersionedTransition{
+				NamespaceFailoverVersion: rand.Int63(),
+				TransitionCount:          rand.Int63(),
+			},
+		}
+	}
+
+	testCases := []struct {
+		name  string
+		level RefConsistencyLevel
+		// verify asserts the level-specific expectations on the original (orig) and adjusted refs.
+		verify func(orig, adjusted ComponentRef)
+	}{
+		{
+			name:  "ExecutionLastUpdate keeps everything",
+			level: RefConsistencyLevelExecutionLastUpdate,
+			verify: func(orig, adjusted ComponentRef) {
+				// Staleness keyed off the execution's last-update transition; nothing relaxed.
+				s.ProtoEqual(orig.executionLastUpdateVT, adjusted.executionLastUpdateVT)
+				s.ProtoEqual(orig.componentInitialVT, adjusted.componentInitialVT)
+				s.Equal(orig.RunID, adjusted.RunID)
+			},
+		},
+		{
+			name:  "ComponentCreation keys staleness off the component creation VT",
+			level: RefConsistencyLevelComponentCreation,
+			verify: func(orig, adjusted ComponentRef) {
+				// The staleness check (Node.IsStale keys off executionLastUpdateVT) now uses the
+				// component's creation transition, so a behind mutable state is still reloaded.
+				s.ProtoEqual(orig.componentInitialVT, adjusted.executionLastUpdateVT)
+				// The creation transition is preserved for the component-identity check, run ID kept.
+				s.ProtoEqual(orig.componentInitialVT, adjusted.componentInitialVT)
+				s.Equal(orig.RunID, adjusted.RunID)
+			},
+		},
+		{
+			name:  "CurrentRun drops both VTs and the run ID",
+			level: RefConsistencyLevelCurrentRun,
+			verify: func(orig, adjusted ComponentRef) {
+				s.Nil(adjusted.executionLastUpdateVT)
+				s.Nil(adjusted.componentInitialVT)
+				s.Empty(adjusted.RunID)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			ref := newRef()
+			adjusted, err := ref.forConsistencyLevel(tc.level)
+			s.NoError(err)
+			tc.verify(ref, adjusted)
+
+			// Invariants for every level: path/archetype identity is preserved, and the receiver
+			// is never mutated (value semantics).
+			s.Equal(ref.componentPath, adjusted.componentPath)
+			s.Equal(ref.archetypeID, adjusted.archetypeID)
+			s.NotNil(ref.executionLastUpdateVT)
+			s.NotNil(ref.componentInitialVT)
+			s.NotEmpty(ref.RunID)
+		})
+	}
+}


### PR DESCRIPTION
## What changed?
Adds a `RefConsistencyLevel` CHASM `TransitionOption` on `UpdateComponent`. Each level selects which versioned transition the execution staleness check (`Node.IsStale`) keys off — i.e. how fresh the loaded mutable state must be — and, at the weakest level, whether the run ID is honored. Levels, strongest → weakest:

- `RefConsistencyLevelExecutionLastUpdate` (default) — staleness checked against the execution's last-update versioned transition; the loaded state must be at the exact transition the ref was taken at.
- `RefConsistencyLevelComponentCreation` — staleness checked against the target component's initial (creation) versioned transition; the loaded state need only be at least as new as when the component was created (so it is guaranteed to know about the component), tolerating a stale execution transition. The creation transition is additionally matched in `Node.Component` so the same component instance must still exist at the path.
- `RefConsistencyLevelCurrentRun` — resolve by component path on the current run, dropping the run ID and every versioned transition (no staleness check); identity is re-established by caller logic (e.g. request ID). Resolves the current run only — it does **not** verify the ref's run and the current run are in the same chain (future work).

`ComponentRef.forConsistencyLevel` applies the per-level relaxation. Only `UpdateComponent` honors the option today (`ReadComponent` / `PollComponent` can be extended later).

## Why?
The Nexus async-completion path needs a ref-consistency level weaker than the strict default: a completion can arrive with a ref whose execution transition is no longer consistent with the current transition history after a history-rewriting event (replication conflict resolution / forced failover), which the strict level would wrongly reject. 

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- None to existing behavior. This only adds a framework option; the option defaults to `RefConsistencyLevelExecutionLastUpdate`, which is identical to the prior strict validation, so every existing `UpdateComponent` caller is unaffected. No consumer opts into a weaker level in this PR.
