### PR TITLE
delete and delegate time source of chasm node to backend (3)

### DIFF
--- a/chasm/chasmtest/test_engine.go
+++ b/chasm/chasmtest/test_engine.go
@@ -23,18 +23,15 @@ import (
 )
 
 type (
-	EngineOption func(*Engine)
-
 	// Engine is a lightweight in memory CHASM engine for unit tests. It implements
 	// [chasm.Engine] and supports the full set of conflict and reuse policies, as
 	// well as blocking [PollComponent] with [NotifyExecution], matching the behavior
 	// of the production engine as closely as possible without persistence or shard logic.
 	Engine struct {
-		t          *testing.T
-		registry   *chasm.Registry
-		logger     log.Logger
-		metrics    metrics.Handler
-		timeSource clock.TimeSource
+		t        *testing.T
+		registry *chasm.Registry
+		logger   log.Logger
+		metrics  metrics.Handler
 		// currentExecutions maps (namespaceID, businessID) to the latest run (running or closed).
 		currentExecutions map[businessKey]*execution
 		// allExecutions maps (namespaceID, businessID, runID) to any run, for lookups by specific RunID.
@@ -48,6 +45,11 @@ type (
 		backend   *chasm.MockNodeBackend
 		root      chasm.RootComponent
 		requestID string
+		// timeSource is this execution's clock, owned by its mutable-state stand-in
+		// (backend). Context.Now routes through backend.Now, so each execution reads
+		// its own time — mirroring production, where every MutableState owns its
+		// (time-skipping-aware) time source rather than sharing an engine-wide clock.
+		timeSource *clock.EventTimeSource
 	}
 
 	businessKey struct {
@@ -62,17 +64,6 @@ type (
 	}
 )
 
-// WithTimeSource overrides the engine's default time source.
-// The default is a [clock.EventTimeSource] initialized to [time.Now] at engine creation,
-// which gives deterministic, frozen time suitable for most unit tests.
-// Pass a *clock.EventTimeSource when tests need to advance time explicitly;
-// the caller holds the reference and calls ts.Update(...) directly.
-func WithTimeSource(ts clock.TimeSource) EngineOption {
-	return func(e *Engine) {
-		e.timeSource = ts
-	}
-}
-
 var defaultTransitionOptions = chasm.TransitionOptions{
 	ReusePolicy:    chasm.BusinessIDReusePolicyAllowDuplicate,
 	ConflictPolicy: chasm.BusinessIDConflictPolicyFail,
@@ -83,28 +74,18 @@ var _ chasm.Engine = (*Engine)(nil)
 func NewEngine(
 	t *testing.T,
 	registry *chasm.Registry,
-	opts ...EngineOption,
 ) *Engine {
 	t.Helper()
 
-	ts := clock.NewEventTimeSource()
-	ts.Update(time.Now())
-	e := &Engine{
+	return &Engine{
 		t:                 t,
 		registry:          registry,
 		logger:            testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly),
 		metrics:           metrics.NoopMetricsHandler,
-		timeSource:        ts,
 		currentExecutions: make(map[businessKey]*execution),
 		allExecutions:     make(map[runKey]*execution),
 		notifier:          newExecutionNotifier(),
 	}
-
-	for _, opt := range opts {
-		opt(e)
-	}
-
-	return e
 }
 
 // Tasks returns all physical tasks scheduled for the execution identified by ref, grouped by category.
@@ -120,6 +101,18 @@ func (e *Engine) Tasks(ref chasm.ComponentRef) (map[tasks.Category][]tasks.Task,
 	result := make(map[tasks.Category][]tasks.Task, len(exec.backend.TasksByCategory))
 	maps.Copy(result, exec.backend.TasksByCategory)
 	return result, nil
+}
+
+// TimeSource returns the clock for the execution identified by ref. Each execution's
+// mutable-state stand-in (backend) owns its clock and Context.Now routes through it,
+// so tests advance a specific execution's time via ts.Update(...). Defaults to a
+// frozen time.Now captured when the execution was created.
+func (e *Engine) TimeSource(ref chasm.ComponentRef) (*clock.EventTimeSource, error) {
+	exec, err := e.executionForRef(ref)
+	if err != nil {
+		return nil, err
+	}
+	return exec.timeSource, nil
 }
 
 func (e *Engine) StartExecution(
@@ -514,7 +507,16 @@ func (e *Engine) newExecution(key chasm.ExecutionKey) *execution {
 		}
 	)
 
+	// Each execution owns its clock, as its mutable-state stand-in (backend). Defaults
+	// to a frozen time.Now; a test can advance it via the execution's timeSource.
+	timeSource := clock.NewEventTimeSource()
+	timeSource.Update(time.Now())
+
 	backend := &chasm.MockNodeBackend{
+		// Now sources the framework clock from this execution's time source, so that
+		// Context.Now (which routes through the backend) reflects the execution's own
+		// clock rather than a shared engine-wide one.
+		HandleNow: timeSource.Now,
 		// NextTransitionCount increments on every CloseTransaction call, matching
 		// the real engine's per transition monotonic counter.
 		HandleNextTransitionCount: func() int64 {
@@ -559,11 +561,11 @@ func (e *Engine) newExecution(key chasm.ExecutionKey) *execution {
 		},
 	}
 	return &execution{
-		key:     key,
-		backend: backend,
+		key:        key,
+		backend:    backend,
+		timeSource: timeSource,
 		node: chasm.NewEmptyTree(
 			e.registry,
-			e.timeSource,
 			backend,
 			chasm.DefaultPathEncoder,
 			e.logger,

--- a/chasm/field_test.go
+++ b/chasm/field_test.go
@@ -143,7 +143,6 @@ func (s *fieldSuite) newTestTree(
 	if len(serializedNodes) == 0 {
 		return NewEmptyTree(
 			s.registry,
-			s.timeSource,
 			s.nodeBackend,
 			s.nodePathEncoder,
 			s.logger,
@@ -153,7 +152,6 @@ func (s *fieldSuite) newTestTree(
 	return NewTreeFromDB(
 		serializedNodes,
 		s.registry,
-		s.timeSource,
 		s.nodeBackend,
 		s.nodePathEncoder,
 		s.logger,
@@ -165,7 +163,6 @@ func (s *fieldSuite) newTestTree(
 func (s *fieldSuite) setupComponentWithTree(rootComponent *TestComponent) (*Node, MutableContext, error) {
 	rootNode := NewEmptyTree(
 		s.registry,
-		s.timeSource,
 		s.nodeBackend,
 		s.nodePathEncoder,
 		s.logger,

--- a/chasm/lib/callback/tasks_test.go
+++ b/chasm/lib/callback/tasks_test.go
@@ -555,7 +555,7 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 			require.NoError(t, err)
 
 			nodeBackend := &chasm.MockNodeBackend{}
-			root := chasm.NewEmptyTree(chasmRegistry, timeSource, nodeBackend, chasm.DefaultPathEncoder, logger, metricsHandler)
+			root := chasm.NewEmptyTree(chasmRegistry, nodeBackend, chasm.DefaultPathEncoder, logger, metricsHandler)
 
 			// Create headers
 			headers := nexus.Header{}

--- a/chasm/lib/nexusoperation/operation_tasks_test.go
+++ b/chasm/lib/nexusoperation/operation_tasks_test.go
@@ -115,7 +115,7 @@ func newInvocationTaskTestEnv(
 		},
 	}
 
-	root := chasm.NewEmptyTree(registry, timeSource, nodeBackend, chasm.DefaultPathEncoder, logger, metrics.NoopMetricsHandler)
+	root := chasm.NewEmptyTree(registry, nodeBackend, chasm.DefaultPathEncoder, logger, metrics.NoopMetricsHandler)
 	ctx := chasm.NewMutableContext(context.Background(), root)
 	require.NoError(t, root.SetRootComponent(&mockStoreComponent{
 		invocationData: invocationData,

--- a/chasm/lib/nexusoperation/operation_test.go
+++ b/chasm/lib/nexusoperation/operation_test.go
@@ -361,7 +361,7 @@ func TestOperation_BuildExecutionInfo_ReturnsIsolatedSearchAttributes(t *testing
 			return &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 1}
 		},
 	}
-	root := chasm.NewEmptyTree(registry, timeSource, nodeBackend, chasm.DefaultPathEncoder, logger, metrics.NoopMetricsHandler)
+	root := chasm.NewEmptyTree(registry, nodeBackend, chasm.DefaultPathEncoder, logger, metrics.NoopMetricsHandler)
 	ctx := chasm.NewMutableContext(context.Background(), root)
 
 	op := NewOperation(&nexusoperationpb.OperationState{Status: nexusoperationpb.OPERATION_STATUS_STARTED})

--- a/chasm/lib/scheduler/helper_test.go
+++ b/chasm/lib/scheduler/helper_test.go
@@ -212,6 +212,7 @@ func newTestEnv(t *testing.T, opts ...testEnvOption) *testEnv {
 
 	tv := testvars.New(t)
 	nodeBackend := &chasm.MockNodeBackend{
+		HandleNow:                 timeSource.Now,
 		HandleNextTransitionCount: func() int64 { return 2 },
 		HandleGetCurrentVersion:   func() int64 { return 1 },
 		HandleGetWorkflowKey:      tv.Any().WorkflowKey,
@@ -225,7 +226,7 @@ func newTestEnv(t *testing.T, opts ...testEnvOption) *testEnv {
 		},
 	}
 
-	node := chasm.NewEmptyTree(registry, timeSource, nodeBackend, nodePathEncoder, logger, metrics.NoopMetricsHandler)
+	node := chasm.NewEmptyTree(registry, nodeBackend, nodePathEncoder, logger, metrics.NoopMetricsHandler)
 	ctx := chasm.NewMutableContext(context.Background(), node)
 	sched, err := scheduler.NewScheduler(ctx, namespace, namespaceID, scheduleID, defaultSchedule(), nil)
 	if err != nil {
@@ -363,6 +364,7 @@ func setupTestInfra(t *testing.T, specProcessor scheduler.SpecProcessor) *testIn
 	timeSource.Update(time.Now())
 
 	tv := testvars.New(t)
+	nodeBackend.HandleNow = timeSource.Now
 	nodeBackend.HandleNextTransitionCount = func() int64 { return 2 }
 	nodeBackend.HandleGetCurrentVersion = func() int64 { return 1 }
 	nodeBackend.HandleGetWorkflowKey = tv.Any().WorkflowKey
@@ -375,7 +377,7 @@ func setupTestInfra(t *testing.T, specProcessor scheduler.SpecProcessor) *testIn
 		}
 	}
 
-	node := chasm.NewEmptyTree(registry, timeSource, nodeBackend, nodePathEncoder, logger, metrics.NoopMetricsHandler)
+	node := chasm.NewEmptyTree(registry, nodeBackend, nodePathEncoder, logger, metrics.NoopMetricsHandler)
 	return &testInfra{
 		node:        node,
 		nodeBackend: nodeBackend,

--- a/chasm/node_backend_mock.go
+++ b/chasm/node_backend_mock.go
@@ -41,6 +41,7 @@ type MockNodeBackend struct {
 	HandleGetNamespaceEntry           func() *namespace.Namespace
 	HandleEndpointRegistry            func() EndpointRegistry
 	HandleSetTimeSkippingConfig       func(config *commonpb.TimeSkippingConfig)
+	HandleNow                         func() time.Time
 
 	// Recorded calls (protected by mu).
 	mu                  sync.Mutex
@@ -256,7 +257,18 @@ func (m *MockNodeBackend) NumTasksAdded() int {
 }
 
 func (m *MockNodeBackend) SetTimeSkippingConfig(config *commonpb.TimeSkippingConfig) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.HandleSetTimeSkippingConfig(config)
+	if m.HandleSetTimeSkippingConfig != nil {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		m.HandleSetTimeSkippingConfig(config)
+	}
+}
+
+func (m *MockNodeBackend) Now() time.Time {
+	if m.HandleNow != nil {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		return m.HandleNow()
+	}
+	return time.Now()
 }

--- a/chasm/skip_persistence_test.go
+++ b/chasm/skip_persistence_test.go
@@ -20,7 +20,7 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_NewNode() {
 	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 1 }
 	s.nodeBackend.HandleGetCurrentVersion = func() int64 { return 1 }
 
-	rootNode := NewEmptyTree(s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
+	rootNode := NewEmptyTree(s.registry, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
 	s.NoError(rootNode.SetRootComponent(s.minimalTestComponent()))
 
 	mutation, err := rootNode.CloseTransaction()
@@ -34,7 +34,7 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_LoadedUnmodified() {
 	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 1 }
 	s.nodeBackend.HandleGetCurrentVersion = func() int64 { return 1 }
 
-	rootNode := NewEmptyTree(s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
+	rootNode := NewEmptyTree(s.registry, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
 	s.NoError(rootNode.SetRootComponent(s.minimalTestComponent()))
 
 	firstMutation, err := rootNode.CloseTransaction()
@@ -49,7 +49,7 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_LoadedUnmodified() {
 	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 2 }
 	s.nodeBackend.HandleGetCurrentVersion = func() int64 { return 1 }
 
-	rootNode2, err := NewTreeFromDB(persistedNodes, s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
+	rootNode2, err := NewTreeFromDB(persistedNodes, s.registry, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
 	s.NoError(err)
 
 	ctx := NewMutableContext(context.Background(), rootNode2)
@@ -71,7 +71,7 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_LoadedModified() {
 	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 1 }
 	s.nodeBackend.HandleGetCurrentVersion = func() int64 { return 1 }
 
-	rootNode := NewEmptyTree(s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
+	rootNode := NewEmptyTree(s.registry, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
 	s.NoError(rootNode.SetRootComponent(s.minimalTestComponent()))
 
 	firstMutation, err := rootNode.CloseTransaction()
@@ -81,7 +81,7 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_LoadedModified() {
 	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 2 }
 	s.nodeBackend.HandleGetCurrentVersion = func() int64 { return 1 }
 
-	rootNode2, err := NewTreeFromDB(persistedNodes, s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
+	rootNode2, err := NewTreeFromDB(persistedNodes, s.registry, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
 	s.NoError(err)
 
 	ctx := NewMutableContext(context.Background(), rootNode2)
@@ -105,7 +105,7 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_WithNewTask() {
 	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 1 }
 	s.nodeBackend.HandleGetCurrentVersion = func() int64 { return 1 }
 
-	rootNode := NewEmptyTree(s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
+	rootNode := NewEmptyTree(s.registry, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
 	s.NoError(rootNode.SetRootComponent(s.minimalTestComponent()))
 
 	firstMutation, err := rootNode.CloseTransaction()
@@ -115,7 +115,7 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_WithNewTask() {
 	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 2 }
 	s.nodeBackend.HandleGetCurrentVersion = func() int64 { return 1 }
 
-	rootNode2, err := NewTreeFromDB(persistedNodes, s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
+	rootNode2, err := NewTreeFromDB(persistedNodes, s.registry, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
 	s.NoError(err)
 
 	ctx := NewMutableContext(context.Background(), rootNode2)
@@ -138,7 +138,7 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_DeleteUnpersistedNode() {
 	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 1 }
 	s.nodeBackend.HandleGetCurrentVersion = func() int64 { return 1 }
 
-	rootNode := NewEmptyTree(s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
+	rootNode := NewEmptyTree(s.registry, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
 	s.NoError(rootNode.SetRootComponent(&TestComponent{
 		ComponentData: &persistencespb.WorkflowExecutionState{RunId: "root"},
 		SubComponent1: NewComponentField(nil, &TestSubComponent1{

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -235,6 +235,7 @@ type (
 		) (nexusrpc.CompleteOperationOptions, error)
 		EndpointRegistry() EndpointRegistry
 		SetTimeSkippingConfig(config *commonpb.TimeSkippingConfig)
+		Now() time.Time
 	}
 
 	// NodePathEncoder is an interface for encoding and decoding node paths.
@@ -1644,7 +1645,7 @@ func (n *Node) Now(
 	_ Component,
 ) time.Time {
 	// TODO: Now() could be different for components after we support Pause for CHASM components.
-	return n.timeSource.Now()
+	return n.backend.Now()
 }
 
 // AddTask implements the CHASM MutableContext interface

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -20,7 +20,6 @@ import (
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
-	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -132,7 +131,6 @@ type (
 	// nodeBase is a set of dependencies and states shared by all nodes in a CHASM tree.
 	nodeBase struct {
 		registry       *Registry
-		timeSource     clock.TimeSource
 		backend        NodeBackend
 		pathEncoder    NodePathEncoder
 		logger         log.Logger
@@ -261,20 +259,19 @@ type (
 func NewTreeFromDB(
 	serializedNodes map[string]*persistencespb.ChasmNode, // This is coming from MS map[nodePath]ChasmNode.
 	registry *Registry,
-	timeSource clock.TimeSource,
 	backend NodeBackend,
 	pathEncoder NodePathEncoder,
 	logger log.Logger,
 	metricsHandler metrics.Handler,
 ) (*Node, error) {
 	if len(serializedNodes) == 0 {
-		root := NewEmptyTree(registry, timeSource, backend, pathEncoder, logger, metricsHandler)
+		root := NewEmptyTree(registry, backend, pathEncoder, logger, metricsHandler)
 		// NewEmptyTree initializes the serializedNode to an empty component node,
 		root.serializedNode.Metadata.GetComponentAttributes().TypeId = WorkflowArchetypeID
 		return root, nil
 	}
 
-	root := newTreeHelper(registry, timeSource, backend, pathEncoder, logger, metricsHandler)
+	root := newTreeHelper(registry, backend, pathEncoder, logger, metricsHandler)
 	for encodedPath, serializedNode := range serializedNodes {
 		nodePath, err := pathEncoder.Decode(encodedPath)
 		if err != nil {
@@ -292,13 +289,12 @@ func NewTreeFromDB(
 // NewEmptyTree creates a new empty in-memory CHASM tree.
 func NewEmptyTree(
 	registry *Registry,
-	timeSource clock.TimeSource,
 	backend NodeBackend,
 	pathEncoder NodePathEncoder,
 	logger log.Logger,
 	metricsHandler metrics.Handler,
 ) *Node {
-	root := newTreeHelper(registry, timeSource, backend, pathEncoder, logger, metricsHandler)
+	root := newTreeHelper(registry, backend, pathEncoder, logger, metricsHandler)
 
 	// If serializedNodes is empty, it means that this new tree.
 	// Initialize empty serializedNode.
@@ -314,7 +310,6 @@ func NewEmptyTree(
 
 func newTreeHelper(
 	registry *Registry,
-	timeSource clock.TimeSource,
 	backend NodeBackend,
 	pathEncoder NodePathEncoder,
 	logger log.Logger,
@@ -322,7 +317,6 @@ func newTreeHelper(
 ) *Node {
 	base := &nodeBase{
 		registry:       registry,
-		timeSource:     timeSource,
 		backend:        backend,
 		pathEncoder:    pathEncoder,
 		logger:         logger,

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -72,6 +72,7 @@ func (s *nodeSuite) SetupTest() {
 	s.NoError(err)
 
 	s.timeSource = clock.NewEventTimeSource()
+	s.nodeBackend.HandleNow = s.timeSource.Now
 	s.nodePathEncoder = &testNodePathEncoder{}
 }
 
@@ -223,7 +224,7 @@ func (s *nodeSuite) TestSerializeNode_ClearSubDataField() {
 }
 
 func (s *nodeSuite) TestSetRootComponent_SetsArchetypeID() {
-	rootNode := NewEmptyTree(s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
+	rootNode := NewEmptyTree(s.registry, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
 	s.Equal(WorkflowArchetypeID, rootNode.ArchetypeID())
 	rootComponent := &TestComponent{
 		MSPointer: NewMSPointer(s.nodeBackend),
@@ -3286,7 +3287,6 @@ func (e *testNodePathEncoder) Decode(
 func (s *nodeSuite) nodeBase() *nodeBase {
 	return &nodeBase{
 		registry:    s.registry,
-		timeSource:  s.timeSource,
 		backend:     s.nodeBackend,
 		pathEncoder: s.nodePathEncoder,
 
@@ -4181,9 +4181,9 @@ func (s *nodeSuite) newTestTree(
 	serializedNodes map[string]*persistencespb.ChasmNode,
 ) (*Node, error) {
 	if len(serializedNodes) == 0 {
-		return NewEmptyTree(s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler), nil
+		return NewEmptyTree(s.registry, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler), nil
 	}
-	return NewTreeFromDB(serializedNodes, s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
+	return NewTreeFromDB(serializedNodes, s.registry, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
 }
 
 func (s *nodeSuite) emptyDataBlob() *commonpb.DataBlob {

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -424,7 +424,6 @@ func NewMutableState(
 	if s.config.EnableChasm(namespaceName) {
 		s.chasmTree = chasm.NewEmptyTree(
 			shard.ChasmRegistry(),
-			shard.GetTimeSource(),
 			s,
 			chasm.DefaultPathEncoder,
 			logger,
@@ -576,7 +575,6 @@ func NewMutableStateFromDB(
 		mutableState.chasmTree, err = chasm.NewTreeFromDB(
 			dbRecord.ChasmNodes,
 			shard.ChasmRegistry(),
-			shard.GetTimeSource(),
 			mutableState,
 			chasm.DefaultPathEncoder,
 			mutableState.logger, // this logger is tagged with execution key.

--- a/service/history/workflow/timeskipping_test.go
+++ b/service/history/workflow/timeskipping_test.go
@@ -9,8 +9,10 @@ import (
 	historypb "go.temporal.io/api/history/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/components/nexusoperations"
 	historyi "go.temporal.io/server/service/history/interfaces"
 	"google.golang.org/protobuf/proto"
@@ -1176,4 +1178,39 @@ func (s *mutableStateSuite) TestWrapTimeSourceWithTimeSkipping() {
 		)
 		s.Equal(fixedBase.Add(skipped), event.GetEventTime().AsTime())
 	})
+}
+
+// TestChasmContextNowReflectsAccumulatedSkippedDuration verifies the end-to-end delegation with a
+// real mutable state: once it has accumulated skipped duration its Now() returns virtual time, and
+// a CHASM Context built over that mutable state (as its NodeBackend) reflects the same virtual time
+// via Context.Now -> Node.Now -> backend.Now.
+func (s *mutableStateSuite) TestChasmContextNowReflectsAccumulatedSkippedDuration() {
+	const accumulatedSkip = 3 * time.Hour
+	baseTime := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	ts := clock.NewEventTimeSource()
+	ts.Update(baseTime)
+	s.mutableState.timeSource = ts
+	s.mutableState.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
+		Config:                     &commonpb.TimeSkippingConfig{Enabled: true},
+		AccumulatedSkippedDuration: durationpb.New(accumulatedSkip),
+	}
+	s.mutableState.wrapTimeSourceWithTimeSkipping()
+
+	s.Require().Equal(baseTime.Add(accumulatedSkip), s.mutableState.Now(),
+		"sanity: the real mutable state reports virtual time")
+
+	// Build a CHASM tree backed by the real mutable state, then a CHASM context over it.
+	// Context.Now delegates through Node.Now -> backend.Now (== mutableState.Now).
+	node := chasm.NewEmptyTree(
+		chasm.NewRegistry(s.logger),
+		s.mutableState,
+		chasm.DefaultPathEncoder,
+		s.logger,
+		metrics.NoopMetricsHandler,
+	)
+	ctx := chasm.NewMutableContext(context.Background(), node)
+
+	s.Equal(baseTime.Add(accumulatedSkip), ctx.Now(nil),
+		"CHASM Context.Now must reflect the mutable state's virtual time")
 }


### PR DESCRIPTION
## What changed?
* Delegate time-related functions (currently only `Now()`) to the backend.
* Remove the time source from the Chasm node, as it is only used by `Now()`. Additionally, this time source is not wrapped by the time-skipping mechanism.


## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
