### PR TITLE
Move locking for task tracker to higher levels

### DIFF
--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -91,7 +91,7 @@ type (
 		deploymentRegistrationCh chan struct{}
 		pollerScalingRateLimiter quotas.RateLimiter
 
-		taskTrackerLock sync.RWMutex
+		taskTrackerLock sync.Mutex
 		tasksAdded      map[priorityKey]*taskTracker
 		tasksDispatched map[priorityKey]*taskTracker
 	}
@@ -529,7 +529,7 @@ func (c *physicalTaskQueueManagerImpl) PollTask(
 		task.backlogCountHint = c.backlogCountHint
 
 		if pollMetadata.forwardedFrom == "" { // track the task on the child, not where a poll was forwarded to
-			c.getOrCreateTaskTracker(c.tasksDispatched, priorityKey(task.getPriority().GetPriorityKey())).inc(1)
+			c.incTaskTracker(c.tasksDispatched, priorityKey(task.getPriority().GetPriorityKey()), 1)
 		}
 		return task, nil
 	}
@@ -604,7 +604,7 @@ func (c *physicalTaskQueueManagerImpl) DispatchQueryTask(
 	task *internalTask,
 ) (*matchingservice.QueryWorkflowResponse, error) {
 	if !task.isForwarded() {
-		c.getOrCreateTaskTracker(c.tasksAdded, priorityKey(task.getPriority().GetPriorityKey())).inc(1)
+		c.incTaskTracker(c.tasksAdded, priorityKey(task.getPriority().GetPriorityKey()), 1)
 	}
 	return c.matcher.OfferQuery(ctx, task)
 }
@@ -614,7 +614,7 @@ func (c *physicalTaskQueueManagerImpl) DispatchNexusTask(
 	task *internalTask,
 ) (*matchingservice.DispatchNexusTaskResponse, error) {
 	if !task.isForwarded() {
-		c.getOrCreateTaskTracker(c.tasksAdded, priorityKey(0)).inc(1) // Nexus has no priorities
+		c.incTaskTracker(c.tasksAdded, priorityKey(0), 1) // Nexus has no priorities
 	}
 	return c.matcher.OfferNexusTask(ctx, task)
 }
@@ -680,14 +680,14 @@ func (c *physicalTaskQueueManagerImpl) GetStatsByPriority(includeRates bool) map
 	}
 
 	if includeRates {
-		c.taskTrackerLock.RLock()
+		c.taskTrackerLock.Lock()
 		for pri, tt := range c.tasksAdded {
 			util.GetOrSetNew(stats, int32(pri)).TasksAddRate = tt.rate()
 		}
 		for pri, tt := range c.tasksDispatched {
 			util.GetOrSetNew(stats, int32(pri)).TasksDispatchRate = tt.rate()
 		}
-		c.taskTrackerLock.RUnlock()
+		c.taskTrackerLock.Unlock()
 	}
 
 	return stats
@@ -709,7 +709,7 @@ func (c *physicalTaskQueueManagerImpl) TrySyncMatch(ctx context.Context, task *i
 	if !task.isForwarded() {
 		// request sent by history service
 		c.liveness.markAlive()
-		c.getOrCreateTaskTracker(c.tasksAdded, priorityKey(task.getPriority().GetPriorityKey())).inc(1)
+		c.incTaskTracker(c.tasksAdded, priorityKey(task.getPriority().GetPriorityKey()), 1)
 		if disable, _ := testhooks.Get(c.partitionMgr.engine.testHooks, testhooks.MatchingDisableSyncMatch, c.partitionMgr.ns.ID()); disable {
 			return syncMatchNoPoller, nil
 		}
@@ -930,10 +930,11 @@ func (c *physicalTaskQueueManagerImpl) UpdateRemotePriorityBacklogs(backlogs rem
 	}
 }
 
-func (c *physicalTaskQueueManagerImpl) getOrCreateTaskTracker(
+func (c *physicalTaskQueueManagerImpl) incTaskTracker(
 	intervals map[priorityKey]*taskTracker,
 	priorityKey priorityKey,
-) *taskTracker {
+	n int,
+) {
 	// priorityKey could be zero here if we're tracking dispatched tasks (i.e. called from PollTask)
 	// and the poll was forwarded so we have a "started" task. We don't return the priority with the
 	// started task info so it's not available here. Use the default priority to avoid confusion
@@ -944,26 +945,17 @@ func (c *physicalTaskQueueManagerImpl) getOrCreateTaskTracker(
 		priorityKey = c.config.DefaultPriorityKey
 	}
 
-	// First try with read lock for the common case where tracker already exists.
-	c.taskTrackerLock.RLock()
-	if tracker, ok := intervals[priorityKey]; ok {
-		c.taskTrackerLock.RUnlock()
-		return tracker
-	}
-	c.taskTrackerLock.RUnlock()
-
-	// Otherwise, we need to maybe create a new tracker with the write lock.
 	c.taskTrackerLock.Lock()
 	defer c.taskTrackerLock.Unlock()
-	if tracker, ok := intervals[priorityKey]; ok {
-		return tracker // tracker was created while we were waiting for the lock
+
+	tracker, ok := intervals[priorityKey]
+	if !ok {
+		// Initialize all task trackers together; or the timeframes won't line up.
+		c.tasksAdded[priorityKey] = c.partitionMgr.engine.newTaskTracker()
+		c.tasksDispatched[priorityKey] = c.partitionMgr.engine.newTaskTracker()
+		tracker = intervals[priorityKey]
 	}
-
-	// Initalize all task trackers together; or the timeframes won't line up.
-	c.tasksAdded[priorityKey] = c.partitionMgr.engine.newTaskTracker()
-	c.tasksDispatched[priorityKey] = c.partitionMgr.engine.newTaskTracker()
-
-	return intervals[priorityKey]
+	tracker.inc(n)
 }
 
 func aggregateStats(stats map[int32]*taskqueuepb.TaskQueueStats) *taskqueuepb.TaskQueueStats {

--- a/service/matching/task_tracker.go
+++ b/service/matching/task_tracker.go
@@ -1,7 +1,6 @@
 package matching
 
 import (
-	"sync"
 	"time"
 
 	"go.temporal.io/server/common/clock"
@@ -37,8 +36,9 @@ func (cb *circularTaskBuffer) totalTasks() int {
 	return totalTasks
 }
 
+// taskTracker is not safe for concurrent use; callers must provide their own
+// synchronization.
 type taskTracker struct {
-	lock            sync.Mutex
 	clock           clock.TimeSource
 	startTime       time.Time     // time when taskTracker was initialized
 	bucketStartTime time.Time     // the starting time of a bucket in the buffer
@@ -66,9 +66,8 @@ func newTaskTracker(
 	}
 }
 
-// advanceAndResetLocked advances the trackers position and clears out any expired intervals
-// This method must be called with taskTracker's lock held.
-func (s *taskTracker) advanceAndResetLocked(elapsed time.Duration) {
+// advanceAndReset advances the trackers position and clears out any expired intervals.
+func (s *taskTracker) advanceAndReset(elapsed time.Duration) {
 	// Calculate the number of intervals elapsed since the start interval time
 	intervalsElapsed := int(elapsed / s.bucketSize)
 
@@ -80,38 +79,28 @@ func (s *taskTracker) advanceAndResetLocked(elapsed time.Duration) {
 
 // inc increments the count of tasks by n at the current time
 func (s *taskTracker) inc(n int) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
 	currentTime := s.clock.Now()
 
 	// Calculate elapsed time from the latest start interval time
 	elapsed := currentTime.Sub(s.bucketStartTime)
-	s.advanceAndResetLocked(elapsed)
+	s.advanceAndReset(elapsed)
 	s.tasks.inc(n)
 }
 
 // rate returns the rate of increments in a given interval
 func (s *taskTracker) rate() float32 {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-	rate, _ := s.rateAndFullLocked()
+	rate, _ := s.rateAndFull()
 	return rate
 }
 
-// rateLocked returns the rate of increments in a given interval, plus whether the full
+// rateAndFull returns the rate of increments in a given interval, plus whether the full
 // interval has elapsed.
 func (s *taskTracker) rateAndFull() (float32, bool) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-	return s.rateAndFullLocked()
-}
-
-func (s *taskTracker) rateAndFullLocked() (float32, bool) {
 	currentTime := s.clock.Now()
 
 	// Calculate elapsed time from the latest start interval time
 	elapsed := currentTime.Sub(s.bucketStartTime)
-	s.advanceAndResetLocked(elapsed)
+	s.advanceAndReset(elapsed)
 	totalTasks := s.tasks.totalTasks()
 
 	elapsedTime := min(


### PR DESCRIPTION
## What changed?
Remove lock from `taskTracker` and use existing lock in `physicalTaskQueueManagerImpl`.

## Why?
Reduce excessive locking overhead.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
