### PR TITLE
Add default page size for archived visibility queries

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -864,6 +864,11 @@ This config is EXPERIMENTAL and may be changed or removed in a later release.`,
 		10000,
 		`VisibilityArchivalQueryMaxPageSize is the maximum page size for a visibility archival query`,
 	)
+	VisibilityArchivalQueryDefaultPageSize = NewGlobalIntSetting(
+		"frontend.visibilityArchivalQueryDefaultPageSize",
+		1000,
+		`VisibilityArchivalQueryDefaultPageSize is the default page size for a visibility archival query when the caller omits PageSize. Should not exceed frontend.visibilityArchivalQueryMaxPageSize.`,
+	)
 	EnableServerVersionCheck = NewGlobalBoolSetting(
 		"frontend.enableServerVersionCheck",
 		os.Getenv("TEMPORAL_VERSION_CHECK_DISABLED") == "",

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -111,7 +111,8 @@ type Config struct {
 	DefaultWorkflowRetryPolicy dynamicconfig.TypedPropertyFnWithNamespaceFilter[retrypolicy.DefaultRetrySettings]
 
 	// VisibilityArchival system protection
-	VisibilityArchivalQueryMaxPageSize dynamicconfig.IntPropertyFn
+	VisibilityArchivalQueryMaxPageSize     dynamicconfig.IntPropertyFn
+	VisibilityArchivalQueryDefaultPageSize dynamicconfig.IntPropertyFn
 
 	// DEPRECATED
 	SendRawWorkflowHistory dynamicconfig.BoolPropertyFnWithNamespaceFilter
@@ -334,6 +335,7 @@ func NewConfig(
 		SearchAttributesSizeOfValueLimit:         dynamicconfig.SearchAttributesSizeOfValueLimit.Get(dc),
 		SearchAttributesTotalSizeLimit:           dynamicconfig.SearchAttributesTotalSizeLimit.Get(dc),
 		VisibilityArchivalQueryMaxPageSize:       dynamicconfig.VisibilityArchivalQueryMaxPageSize.Get(dc),
+		VisibilityArchivalQueryDefaultPageSize:   dynamicconfig.VisibilityArchivalQueryDefaultPageSize.Get(dc),
 		DisallowQuery:                            dynamicconfig.DisallowQuery.Get(dc),
 		SendRawWorkflowHistory:                   dynamicconfig.SendRawWorkflowHistory.Get(dc),
 		DefaultWorkflowRetryPolicy:               dynamicconfig.DefaultWorkflowRetryPolicy.Get(dc),

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -2758,8 +2758,9 @@ func (wh *WorkflowHandler) ListArchivedWorkflowExecutions(ctx context.Context, r
 	}
 
 	maxPageSize := int32(wh.config.VisibilityArchivalQueryMaxPageSize())
+	defaultPageSize := int32(wh.config.VisibilityArchivalQueryDefaultPageSize())
 	if request.GetPageSize() <= 0 {
-		request.PageSize = maxPageSize
+		request.PageSize = defaultPageSize
 	} else if request.GetPageSize() > maxPageSize {
 		return nil, serviceerror.NewInvalidArgumentf(errPageSizeTooBigMessage, maxPageSize)
 	}

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -2228,6 +2228,94 @@ func (s *WorkflowHandlerSuite) TestListArchivedVisibility_Success() {
 	s.NoError(err)
 }
 
+// expectArchivalPageSizeQuery sets up the mocks shared by the archived-visibility
+// page-size tests (namespace enabled for archival + archiver provider) and stubs the
+// visibility archiver's Query to assert the caller-supplied PageSize propagated correctly.
+// It returns a function to build the handler from a config so each test can override config.
+func (s *WorkflowHandlerSuite) expectArchivalPageSizeQuery(expectedPageSize int) {
+	s.mockNamespaceCache.EXPECT().GetNamespace(gomock.Any()).Return(namespace.NewLocalNamespaceForTest(
+		&persistencespb.NamespaceInfo{Name: "test-namespace"},
+		&persistencespb.NamespaceConfig{
+			VisibilityArchivalState: enumspb.ARCHIVAL_STATE_ENABLED,
+			VisibilityArchivalUri:   testVisibilityArchivalURI,
+		},
+		"",
+	), nil).AnyTimes()
+	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "random URI")).Times(2)
+	s.mockVisibilityArchiver.EXPECT().Query(gomock.Any(), gomock.Any(), gomock.Cond(func(req *archiver.QueryVisibilityRequest) bool {
+		return req.PageSize == expectedPageSize
+	}), gomock.Any()).Return(&archiver.QueryVisibilityResponse{}, nil)
+	s.mockArchiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any()).Return(s.mockVisibilityArchiver, nil)
+	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes("", false)
+}
+
+func (s *WorkflowHandlerSuite) archivedListRequestWithPageSize(pageSize int32) *workflowservice.ListArchivedWorkflowExecutionsRequest {
+	return &workflowservice.ListArchivedWorkflowExecutionsRequest{
+		Namespace: "some random namespace name",
+		PageSize:  pageSize,
+		Query:     "some random query string",
+	}
+}
+
+func (s *WorkflowHandlerSuite) TestListArchivedVisibility_DefaultPageSizeWhenOmitted() {
+	s.expectArchivalPageSizeQuery(1000)
+	wh := s.getWorkflowHandler(s.newConfig())
+
+	resp, err := wh.ListArchivedWorkflowExecutions(context.Background(), s.archivedListRequestWithPageSize(0))
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+}
+
+func (s *WorkflowHandlerSuite) TestListArchivedVisibility_UsesExplicitPageSize() {
+	s.expectArchivalPageSizeQuery(500)
+	wh := s.getWorkflowHandler(s.newConfig())
+
+	resp, err := wh.ListArchivedWorkflowExecutions(context.Background(), s.archivedListRequestWithPageSize(500))
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+}
+
+func (s *WorkflowHandlerSuite) TestListArchivedVisibility_RejectsPageSizeOverMax() {
+	// The page-size validation runs before the cluster-archival check, so the
+	// handler returns InvalidArgument without ever consulting archival metadata.
+	wh := s.getWorkflowHandler(s.newConfig())
+
+	resp, err := wh.ListArchivedWorkflowExecutions(context.Background(), s.archivedListRequestWithPageSize(100000))
+	s.Require().Nil(resp)
+	s.Require().Error(err)
+	var invalidArgErr *serviceerror.InvalidArgument
+	s.Require().ErrorAs(err, &invalidArgErr)
+}
+
+func (s *WorkflowHandlerSuite) TestListArchivedVisibility_PageSizeAtMaxAllowed() {
+	s.expectArchivalPageSizeQuery(10000)
+	wh := s.getWorkflowHandler(s.newConfig())
+
+	resp, err := wh.ListArchivedWorkflowExecutions(context.Background(), s.archivedListRequestWithPageSize(10000))
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+}
+
+func (s *WorkflowHandlerSuite) TestListArchivedVisibility_DefaultPageSizeDynamicConfigOverridable() {
+	config := s.newConfig()
+	config.VisibilityArchivalQueryDefaultPageSize = dc.GetIntPropertyFn(250)
+	s.expectArchivalPageSizeQuery(250)
+	wh := s.getWorkflowHandler(config)
+
+	resp, err := wh.ListArchivedWorkflowExecutions(context.Background(), s.archivedListRequestWithPageSize(0))
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+}
+
+func (s *WorkflowHandlerSuite) TestListArchivedVisibility_NegativePageSizeUsesDefault() {
+	s.expectArchivalPageSizeQuery(1000)
+	wh := s.getWorkflowHandler(s.newConfig())
+
+	resp, err := wh.ListArchivedWorkflowExecutions(context.Background(), s.archivedListRequestWithPageSize(-1))
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+}
+
 func (s *WorkflowHandlerSuite) TestGetSearchAttributes() {
 	wh := s.getWorkflowHandler(s.newConfig())
 


### PR DESCRIPTION
## Summary

`ListArchivedWorkflowExecutions` previously substituted the **max** page size (`10000`) when the caller omitted `PageSize`, causing large archival reads that time out UI/CLI listings (closes #9258).

This introduces an additive dynamic-config key `frontend.visibilityArchivalQueryDefaultPageSize` (default `1000`) that the handler consults **only when the caller omits `PageSize`**. The existing max (`frontend.visibilityArchivalQueryMaxPageSize`, `10000`) is unchanged and still rejects over-large explicit requests with `InvalidArgument`.

This implements the maintainer's additive direction (@yycptt, https://github.com/temporalio/temporal/issues/9258) rather than the issue's literal "reduce the max" ask, which would break callers that intentionally request large pages and remove the system-protection ceiling with no per-deployment escape hatch.

## Changes

- `common/dynamicconfig/constants.go` — new Global Int key `frontend.visibilityArchivalQueryDefaultPageSize`, default `1000`, placed directly below the existing max key.
- `service/frontend/service.go` — new `Config` field + wiring, mirroring the existing max.
- `service/frontend/workflow_handler.go` — the `PageSize <= 0` (omitted) branch now substitutes the new **default** (`1000`) instead of the **max** (`10000`). The `> maxPageSize` branch still returns `InvalidArgument`.
- `service/frontend/workflow_handler_test.go` — 6 new tests covering the default-vs-explicit-vs-overflow-vs-overridable matrix.

## Behavior change (please note on upgrade)

When `PageSize` is omitted, the effective page size for `ListArchivedWorkflowExecutions` changes from `10000` to `1000`. Callers that always set `PageSize` see **no change**. The max stays `10000`; callers needing large pages can still request them explicitly.

Operators can restore the prior effective behavior per-deployment (no restart) by setting:

```
frontend.visibilityArchivalQueryDefaultPageSize = 10000
```

No DB migration, no proto change, no rolling-upgrade coordination. Purely additive.

### Default-vs-max note

If an operator sets `DefaultPageSize > MaxPageSize` via dynamic config, an omitted `PageSize` would flow through above the max (the over-max check only runs for caller-specified values). The new key's doc string carries a "Should not exceed `frontend.visibilityArchivalQueryMaxPageSize`" caveat; this matches the existing `NexusEndpointListDefaultPageSize`/`MaxPageSize` precedent.

## Test plan

- [x] `go build ./common/dynamicconfig/... ./service/frontend/...`
- [x] `make lint-code` (0 issues)
- [x] `go test -tags test_dep ./service/frontend/ ./common/dynamicconfig/`
- New tests: omitted→1000, explicit passthrough (500), over-max rejected (`InvalidArgument`), at-max boundary (10000 allowed), dynamic-config override (250), negative→default.

Closes #9258