### PR TITLE
Return last error from ThrottleRetryContextWithReturn on deadline break

### DIFF
--- a/common/backoff/retry.go
+++ b/common/backoff/retry.go
@@ -112,6 +112,7 @@ func ThrottleRetryContextWithReturn[T any](
 	isRetryable IsRetryable,
 ) (T, error) {
 	var zero T
+	var result T
 	var err error
 	var next time.Duration
 
@@ -125,7 +126,7 @@ func ThrottleRetryContextWithReturn[T any](
 	r := NewRetrier(policy, timeSrc)
 	t := NewRetrier(throttleRetryPolicy, timeSrc)
 	for ctx.Err() == nil {
-		result, err := fn(ctx)
+		result, err = fn(ctx)
 		if err == nil {
 			return result, nil
 		}

--- a/common/backoff/retry_test.go
+++ b/common/backoff/retry_test.go
@@ -212,6 +212,65 @@ func (s *RetrySuite) TestThrottleRetryContext() {
 	throttleRetryPolicy = originalThrottleRetryPolicy
 }
 
+// TestThrottleRetryContextWithReturnTimeout guards against a shadowing bug where a
+// retryable failure plus a deadline-triggered break returned (zero, nil): a false
+// success instead of the last error. Backoff far exceeds the deadline so the break
+// fires after the first failure.
+func (s *RetrySuite) TestThrottleRetryContextWithReturnTimeout() {
+	timeout := 200 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	start := time.Now()
+	result, err := ThrottleRetryContextWithReturn(ctx,
+		func(_ context.Context) (string, error) { return "", &someError{} },
+		NewExponentialRetryPolicy(10*time.Second), retryEverything)
+	elapsed := time.Since(start)
+	s.ErrorAs(err, new(*someError), "must return the real error, not nil, on deadline break")
+	s.Empty(result)
+	s.Less(elapsed, timeout, "should break instead of sleeping past the deadline")
+}
+
+func (s *RetrySuite) TestThrottleRetryContextWithReturnSuccess() {
+	attempt := 0
+	result, err := ThrottleRetryContextWithReturn(context.Background(),
+		func(_ context.Context) (string, error) {
+			attempt++
+			if attempt == 3 {
+				return "ok", nil
+			}
+			return "", &someError{}
+		},
+		NewExponentialRetryPolicy(1*time.Millisecond).WithMaximumAttempts(10),
+		retryEverything)
+	s.NoError(err)
+	s.Equal("ok", result)
+	s.Equal(3, attempt)
+}
+
+func (s *RetrySuite) TestThrottleRetryContextWithReturnMaxAttempts() {
+	attempt := 0
+	result, err := ThrottleRetryContextWithReturn(context.Background(),
+		func(_ context.Context) (string, error) {
+			attempt++
+			return "", &someError{}
+		},
+		NewExponentialRetryPolicy(1*time.Millisecond).WithMaximumAttempts(2),
+		retryEverything)
+	s.ErrorAs(err, new(*someError))
+	s.Empty(result)
+	s.Equal(2, attempt)
+}
+
+func (s *RetrySuite) TestThrottleRetryContextWithReturnContextCancel() {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result, err := ThrottleRetryContextWithReturn(ctx,
+		func(ctx context.Context) (string, error) { return "", ctx.Err() },
+		NewExponentialRetryPolicy(1*time.Millisecond), retryEverything)
+	s.ErrorIs(err, context.Canceled)
+	s.Empty(result)
+}
+
 var retryEverything IsRetryable = nil
 
 func (e *someError) Error() string {


### PR DESCRIPTION
## What changed?
Fixed a variable-shadowing bug in ThrottleRetryContextWithReturn. Inside the loop, result, err := fn(ctx) shadowed the outer err, so on the deadline-break path the function returned (nil, nil) instead of the last error. Switched to result, err = fn(ctx) (with result declared above the loop). Added regression tests, which this generic wrapper previously lacked.

## Why?
The bug returned a false success: nil error with an empty result. As an example, for StandaloneActivity StartActivityExecution, a short client deadline against a shard returning retryable errors produced a grpc OK with an empty 5-byte response and no run id, while nothing was persisted. The activity was silently lost with no error in metrics or logs. The fix bubbles up the real error so the client gets a retryable failure instead.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [ ] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

