### PR TITLE
Return last error from ThrottleRetryContextWithReturn on deadline break (#10973)

### DIFF
--- a/common/backoff/retry.go
+++ b/common/backoff/retry.go
@@ -112,6 +112,7 @@ func ThrottleRetryContextWithReturn[T any](
 	isRetryable IsRetryable,
 ) (T, error) {
 	var zero T
+	var result T
 	var err error
 	var next time.Duration
 
@@ -125,7 +126,7 @@ func ThrottleRetryContextWithReturn[T any](
 	r := NewRetrier(policy, timeSrc)
 	t := NewRetrier(throttleRetryPolicy, timeSrc)
 	for ctx.Err() == nil {
-		result, err := fn(ctx)
+		result, err = fn(ctx)
 		if err == nil {
 			return result, nil
 		}

--- a/common/backoff/retry_test.go
+++ b/common/backoff/retry_test.go
@@ -212,6 +212,65 @@ func (s *RetrySuite) TestThrottleRetryContext() {
 	throttleRetryPolicy = originalThrottleRetryPolicy
 }
 
+// TestThrottleRetryContextWithReturnTimeout guards against a shadowing bug where a
+// retryable failure plus a deadline-triggered break returned (zero, nil): a false
+// success instead of the last error. Backoff far exceeds the deadline so the break
+// fires after the first failure.
+func (s *RetrySuite) TestThrottleRetryContextWithReturnTimeout() {
+	timeout := 200 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	start := time.Now()
+	result, err := ThrottleRetryContextWithReturn(ctx,
+		func(_ context.Context) (string, error) { return "", &someError{} },
+		NewExponentialRetryPolicy(10*time.Second), retryEverything)
+	elapsed := time.Since(start)
+	s.ErrorAs(err, new(*someError), "must return the real error, not nil, on deadline break")
+	s.Empty(result)
+	s.Less(elapsed, timeout, "should break instead of sleeping past the deadline")
+}
+
+func (s *RetrySuite) TestThrottleRetryContextWithReturnSuccess() {
+	attempt := 0
+	result, err := ThrottleRetryContextWithReturn(context.Background(),
+		func(_ context.Context) (string, error) {
+			attempt++
+			if attempt == 3 {
+				return "ok", nil
+			}
+			return "", &someError{}
+		},
+		NewExponentialRetryPolicy(1*time.Millisecond).WithMaximumAttempts(10),
+		retryEverything)
+	s.NoError(err)
+	s.Equal("ok", result)
+	s.Equal(3, attempt)
+}
+
+func (s *RetrySuite) TestThrottleRetryContextWithReturnMaxAttempts() {
+	attempt := 0
+	result, err := ThrottleRetryContextWithReturn(context.Background(),
+		func(_ context.Context) (string, error) {
+			attempt++
+			return "", &someError{}
+		},
+		NewExponentialRetryPolicy(1*time.Millisecond).WithMaximumAttempts(2),
+		retryEverything)
+	s.ErrorAs(err, new(*someError))
+	s.Empty(result)
+	s.Equal(2, attempt)
+}
+
+func (s *RetrySuite) TestThrottleRetryContextWithReturnContextCancel() {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result, err := ThrottleRetryContextWithReturn(ctx,
+		func(ctx context.Context) (string, error) { return "", ctx.Err() },
+		NewExponentialRetryPolicy(1*time.Millisecond), retryEverything)
+	s.ErrorIs(err, context.Canceled)
+	s.Empty(result)
+}
+
 var retryEverything IsRetryable = nil
 
 func (e *someError) Error() string {


### PR DESCRIPTION
## What changed?
Fixes a variable-shadowing bug in ThrottleRetryContextWithReturn (common/backoff/retry.go). result, err := fn(ctx) inside the retry loop  shadowed the outer err, so a deadline-triggered break returned (zero, nil): a false success that swallowed the last real error. The fix moves  result to the outer scope and uses result, err = fn(ctx) so the last error survives the loop and callers get a retryble failure instead of a  silent success. Adds regression tests in retry_test.go.

### Original PRs
https://github.com/temporalio/temporal/pull/10973

## Why is this necessary as a patch?
Customer escalation. StandaloneActivity StartActivityExecution silently dropped activities: grpc OK with an empty response, no run id, nothing persisted, and no error in metrics or logs. The loss is invisible and undetectable without deep tracing, so it will keep recurring for any affected customer and continue eroding trust in the API's durability contract. It should not wait for the next release

## What testing or retesting is appropriate for this patch after merge?
Unit tests in common/backoff/retry_test.go cover the deadline-break case plus success, max-attempts, and context-cancel paths; the suite passes on this branch. The change is isolated to a single retry helper, so no VCR or OSS Longhaul rerun is needed.
