### PR TITLE
wf-pause: allow pausing a workflow before the first workflow task is dispatched

### DIFF
--- a/common/persistence/workflow_state_status_validator.go
+++ b/common/persistence/workflow_state_status_validator.go
@@ -68,12 +68,8 @@ func ValidateUpdateWorkflowStateStatus(
 
 	// validate workflow state & status
 	switch state {
-	case enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING, enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE:
+	case enumsspb.WORKFLOW_EXECUTION_STATE_CREATED, enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING, enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE:
 		if status != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING && status != enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED {
-			return serviceerror.NewInternalf("Update workflow with invalid state: %v or status: %v", state, status)
-		}
-	case enumsspb.WORKFLOW_EXECUTION_STATE_CREATED:
-		if status != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING {
 			return serviceerror.NewInternalf("Update workflow with invalid state: %v or status: %v", state, status)
 		}
 	default:

--- a/common/persistence/workflow_state_status_validator_test.go
+++ b/common/persistence/workflow_state_status_validator_test.go
@@ -118,11 +118,13 @@ func (s *workflowStateStatusSuite) TestUpdateWorkflowStateStatus_WorkflowStateCr
 		enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED,
 		enumspb.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW,
 		enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT,
-		enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED,
 	}
 
-	// Updating workflow to State: CREATED and status: RUNNING is allowed
+	// Updating workflow to State: CREATED and status: {RUNNING, PAUSED} is
+	// allowed: a workflow can be paused before its first workflow task has ever
+	// run (e.g. while waiting out start_delay/cron/retry backoff).
 	s.NoError(ValidateUpdateWorkflowStateStatus(enumsspb.WORKFLOW_EXECUTION_STATE_CREATED, enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING))
+	s.NoError(ValidateUpdateWorkflowStateStatus(enumsspb.WORKFLOW_EXECUTION_STATE_CREATED, enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED))
 
 	for _, status := range disallowedStatuses {
 		s.Error(ValidateUpdateWorkflowStateStatus(enumsspb.WORKFLOW_EXECUTION_STATE_CREATED, status))

--- a/service/history/api/unpauseworkflow/api.go
+++ b/service/history/api/unpauseworkflow/api.go
@@ -71,9 +71,23 @@ func Invoke(
 				return nil, err
 			}
 
+			// If the workflow is still in start_delay/cron/retry backoff, the original
+			// WorkflowBackoffTimerTask is untouched by pause and will fire on its own once the
+			// workflow is running again. Forcing a workflow task now would skip
+			// the remaining delay, so only force one immediately if that target
+			// has already elapsed (in which case the backoff timer already fired,
+			// found the workflow paused, and did nothing).
+			createWorkflowTask := true
+			if !mutableState.HadOrHasWorkflowTask() {
+				executionTime := mutableState.GetExecutionInfo().GetExecutionTime().AsTime()
+				if shard.GetTimeSource().Now().Before(executionTime) {
+					createWorkflowTask = false
+				}
+			}
+
 			return &api.UpdateWorkflowAction{
 				Noop:               false,
-				CreateWorkflowTask: true, // Create workflow task when unpausing
+				CreateWorkflowTask: createWorkflowTask,
 			}, nil
 		},
 		nil,

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -1705,11 +1705,14 @@ func (s *mutableStateSuite) TestUpdateWorkflowStateStatus_Table() {
 			wantErr:      false,
 		},
 		{
+			// A workflow can be paused before its first workflow task has ever
+			// run (e.g. while waiting out start_delay/cron/retry backoff), in
+			// which case the run-state stays CREATED.
 			name:         "created-> {created, paused}",
 			currentState: enumsspb.WORKFLOW_EXECUTION_STATE_CREATED,
 			toState:      enumsspb.WORKFLOW_EXECUTION_STATE_CREATED,
 			toStatus:     enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED,
-			wantErr:      true,
+			wantErr:      false,
 		},
 		{
 			name:         "created-> {created, completed} (invalid)",
@@ -2158,6 +2161,51 @@ func (s *mutableStateSuite) TestPauseWorkflowExecution_FailStateValidation() {
 	// Status should remain unchanged and PauseInfo should not be set when validation fails.
 	s.Equal(prevStatus, s.mutableState.executionState.Status)
 	s.Nil(s.mutableState.executionInfo.PauseInfo)
+}
+
+// TestPauseUnpause_BeforeFirstWorkflowTask_RunStateStaysCreated verifies that
+// pausing and unpausing a workflow that has never run a workflow task (e.g.
+// while waiting out start_delay/cron/retry backoff) only ever changes Status;
+// the run-state stays CREATED throughout and does not get promoted to
+// RUNNING by pause/unpause themselves. The run-state is only ever supposed to
+// transition to RUNNING when the first WorkflowTaskScheduled event is applied
+// (see ApplyWorkflowTaskScheduledEvent), which does not happen here.
+func (s *mutableStateSuite) TestPauseUnpause_BeforeFirstWorkflowTask_RunStateStaysCreated() {
+	s.SetupSubTest()
+	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
+
+	_, err := s.mutableState.AddWorkflowExecutionStartedEvent(
+		&commonpb.WorkflowExecution{WorkflowId: tests.WorkflowID, RunId: tests.RunID},
+		&historyservice.StartWorkflowExecutionRequest{
+			NamespaceId: tests.NamespaceID.String(),
+			StartRequest: &workflowservice.StartWorkflowExecutionRequest{
+				WorkflowType: &commonpb.WorkflowType{Name: "test-workflow"},
+				TaskQueue:    &taskqueuepb.TaskQueue{Name: "test-queue"},
+			},
+			FirstWorkflowTaskBackoff: durationpb.New(time.Minute),
+		},
+	)
+	s.NoError(err)
+
+	// A fresh mutable state starts as (CREATED, RUNNING); adding the started
+	// event with a start_delay does not schedule a workflow task, so it stays
+	// (CREATED, RUNNING) and HadOrHasWorkflowTask() is false.
+	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_CREATED, s.mutableState.executionState.State)
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, s.mutableState.executionState.Status)
+	s.False(s.mutableState.HadOrHasWorkflowTask())
+
+	_, err = s.mutableState.AddWorkflowExecutionPausedEvent("tester", "test_reason", uuid.NewString())
+	s.NoError(err)
+	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_CREATED, s.mutableState.executionState.State)
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED, s.mutableState.executionState.Status)
+
+	_, err = s.mutableState.AddWorkflowExecutionUnpausedEvent("tester", "test_reason", uuid.NewString())
+	s.NoError(err)
+	// Unpause must restore (CREATED, RUNNING), not (RUNNING, RUNNING): the
+	// run-state is untouched by pause/unpause, only Status is.
+	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_CREATED, s.mutableState.executionState.State)
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, s.mutableState.executionState.Status)
+	s.False(s.mutableState.HadOrHasWorkflowTask(), "unpause must not itself schedule a workflow task")
 }
 
 func (s *mutableStateSuite) TestContinueAsNewMinBackoff() {

--- a/service/history/workflow/mutable_state_state_status.go
+++ b/service/history/workflow/mutable_state_state_status.go
@@ -23,12 +23,11 @@ func setStateStatus(
 		// no validation
 	case enumsspb.WORKFLOW_EXECUTION_STATE_CREATED:
 		switch state {
-		case enumsspb.WORKFLOW_EXECUTION_STATE_CREATED:
-			if status != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING {
-				return invalidStateTransitionErr(e.GetState(), state, status)
-			}
-
-		case enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING:
+		case enumsspb.WORKFLOW_EXECUTION_STATE_CREATED, enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING:
+			// PAUSED is allowed while staying CREATED: a workflow may be paused
+			// before its first workflow task has ever run (e.g. while waiting
+			// out start_delay, cron, or retry backoff), in which case the
+			// run-state stays CREATED rather than advancing to RUNNING.
 			if status != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING && status != enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED {
 				return invalidStateTransitionErr(e.GetState(), state, status)
 			}

--- a/tests/pause_workflow_execution_test.go
+++ b/tests/pause_workflow_execution_test.go
@@ -2121,6 +2121,163 @@ func (s *PauseWorkflowExecutionSuite) TestResetWhilePaused() {
 	})
 }
 
+// TestStartDelayPaused_UnpauseBeforeDelayElapses_HonorsRemainingDelay asserts
+// that pausing a workflow before it has ever run a workflow task (i.e. while it
+// is still sitting in its start_delay window) and then unpausing well before
+// that delay elapses does not skip the remaining delay: the first workflow task
+// is not scheduled until the original wall-clock target (StartTime+StartDelay)
+// is reached, mirroring how standalone activities honor start_delay across
+// pause/unpause (see chasm/lib/activity's dispatchTimeRespectingStartDelay).
+func (s *PauseWorkflowExecutionSuite) TestStartDelayPaused_UnpauseBeforeDelayElapses_HonorsRemainingDelay() {
+	env := s.newTestEnv()
+
+	const startDelay = 6 * time.Second
+	workflowOptions := sdkclient.StartWorkflowOptions{
+		ID:         testcore.RandomizeStr("pause-start-delay-wf-" + s.T().Name()),
+		TaskQueue:  env.WorkerTaskQueue(),
+		StartDelay: startDelay,
+	}
+	workflowRun, err := env.SdkClient().ExecuteWorkflow(s.Context(), workflowOptions, env.workflowFn)
+	s.NoError(err)
+	workflowID := workflowRun.GetID()
+	runID := workflowRun.GetRunID()
+
+	descBeforePause, err := env.SdkClient().DescribeWorkflowExecution(s.Context(), workflowID, runID)
+	s.NoError(err)
+	delayTarget := descBeforePause.GetWorkflowExecutionInfo().GetStartTime().AsTime().Add(startDelay)
+
+	// Pause immediately, well before the start_delay elapses. The workflow has
+	// not run a workflow task yet, so this must succeed even though the
+	// underlying run is still in the CREATED run-state.
+	_, err = env.FrontendClient().PauseWorkflowExecution(s.Context(), &workflowservice.PauseWorkflowExecutionRequest{
+		Namespace:  env.Namespace().String(),
+		WorkflowId: workflowID,
+		RunId:      runID,
+		Identity:   env.pauseIdentity,
+		Reason:     env.pauseReason,
+		RequestId:  uuid.NewString(),
+	})
+	s.NoError(err)
+	s.Await(func(s *PauseWorkflowExecutionSuite) {
+		s.assertWorkflowIsPaused(env, workflowID, runID)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	s.Greater(time.Until(delayTarget), 2*time.Second, "test setup too slow relative to startDelay; increase startDelay")
+
+	_, err = env.FrontendClient().UnpauseWorkflowExecution(s.Context(), &workflowservice.UnpauseWorkflowExecutionRequest{
+		Namespace:  env.Namespace().String(),
+		WorkflowId: workflowID,
+		RunId:      runID,
+		Identity:   env.pauseIdentity,
+		Reason:     env.pauseReason,
+		RequestId:  uuid.NewString(),
+	})
+	s.NoError(err)
+	s.Await(func(s *PauseWorkflowExecutionSuite) {
+		desc, err := env.SdkClient().DescribeWorkflowExecution(s.Context(), workflowID, runID)
+		s.NoError(err)
+		s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, desc.GetWorkflowExecutionInfo().GetStatus())
+	}, 5*time.Second, 100*time.Millisecond)
+
+	// Sleep until shortly before the original wall-clock target. The remaining
+	// start_delay must still be honored even though the workflow is unpaused:
+	// no workflow task should be scheduled yet.
+	remaining := time.Until(delayTarget)
+	s.NoError(util.InterruptibleSleep(s.Context(), remaining-time.Second))
+
+	descBeforeTarget, err := env.SdkClient().DescribeWorkflowExecution(s.Context(), workflowID, runID)
+	s.NoError(err)
+	s.Empty(descBeforeTarget.PendingActivities, "activity must not be scheduled before the honored start_delay target")
+	// History must contain exactly start/pause/unpause: no workflow task (or
+	// anything else) has been scheduled yet.
+	s.EqualHistoryEvents(`
+  1 WorkflowExecutionStarted
+  2 WorkflowExecutionPaused
+  3 WorkflowExecutionUnpaused`, env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{
+		WorkflowId: workflowID,
+		RunId:      runID,
+	}))
+
+	// Once the original target passes, the first workflow task fires normally.
+	s.Await(func(s *PauseWorkflowExecutionSuite) {
+		desc, err := env.SdkClient().DescribeWorkflowExecution(s.Context(), workflowID, runID)
+		s.NoError(err)
+		s.NotEmpty(desc.PendingActivities, "activity should be scheduled once the honored start_delay elapses")
+	}, 5*time.Second, 100*time.Millisecond)
+
+	// Let the workflow complete.
+	env.SendToChannel(env.activityCompletedCh)
+	err = env.SdkClient().SignalWorkflow(s.Context(), workflowID, runID, env.testEndSignal, "done")
+	s.NoError(err)
+	s.Await(func(s *PauseWorkflowExecutionSuite) {
+		desc, err := env.SdkClient().DescribeWorkflowExecution(s.Context(), workflowID, runID)
+		s.NoError(err)
+		s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, desc.GetWorkflowExecutionInfo().GetStatus())
+	}, 10*time.Second, 200*time.Millisecond)
+}
+
+// TestStartDelayPaused_UnpauseAfterDelayElapses_DispatchesImmediately asserts
+// that if a paused, not-yet-started workflow's start_delay window fully elapses
+// while it is still paused, unpausing dispatches the first workflow task
+// immediately rather than replaying the (already-expired) delay. This mirrors
+// standalone activity behavior in the same situation.
+func (s *PauseWorkflowExecutionSuite) TestStartDelayPaused_UnpauseAfterDelayElapses_DispatchesImmediately() {
+	env := s.newTestEnv()
+
+	const startDelay = 3 * time.Second
+	workflowOptions := sdkclient.StartWorkflowOptions{
+		ID:         testcore.RandomizeStr("pause-start-delay-elapsed-wf-" + s.T().Name()),
+		TaskQueue:  env.WorkerTaskQueue(),
+		StartDelay: startDelay,
+	}
+	workflowRun, err := env.SdkClient().ExecuteWorkflow(s.Context(), workflowOptions, env.workflowFn)
+	s.NoError(err)
+	workflowID := workflowRun.GetID()
+	runID := workflowRun.GetRunID()
+
+	_, err = env.FrontendClient().PauseWorkflowExecution(s.Context(), &workflowservice.PauseWorkflowExecutionRequest{
+		Namespace:  env.Namespace().String(),
+		WorkflowId: workflowID,
+		RunId:      runID,
+		Identity:   env.pauseIdentity,
+		Reason:     env.pauseReason,
+		RequestId:  uuid.NewString(),
+	})
+	s.NoError(err)
+	s.Await(func(s *PauseWorkflowExecutionSuite) {
+		s.assertWorkflowIsPaused(env, workflowID, runID)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	// Stay paused past the original start_delay window.
+	s.NoError(util.InterruptibleSleep(s.Context(), startDelay+time.Second))
+
+	_, err = env.FrontendClient().UnpauseWorkflowExecution(s.Context(), &workflowservice.UnpauseWorkflowExecutionRequest{
+		Namespace:  env.Namespace().String(),
+		WorkflowId: workflowID,
+		RunId:      runID,
+		Identity:   env.pauseIdentity,
+		Reason:     env.pauseReason,
+		RequestId:  uuid.NewString(),
+	})
+	s.NoError(err)
+
+	// The delay expired while paused,  the first workflow task dispatches immediately
+	s.Await(func(s *PauseWorkflowExecutionSuite) {
+		desc, err := env.SdkClient().DescribeWorkflowExecution(s.Context(), workflowID, runID)
+		s.NoError(err)
+		s.NotEmpty(desc.PendingActivities, "activity should be scheduled immediately since start_delay already elapsed while paused")
+	}, 3*time.Second, 100*time.Millisecond)
+
+	env.SendToChannel(env.activityCompletedCh)
+	err = env.SdkClient().SignalWorkflow(s.Context(), workflowID, runID, env.testEndSignal, "done")
+	s.NoError(err)
+	s.Await(func(s *PauseWorkflowExecutionSuite) {
+		desc, err := env.SdkClient().DescribeWorkflowExecution(s.Context(), workflowID, runID)
+		s.NoError(err)
+		s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, desc.GetWorkflowExecutionInfo().GetStatus())
+	}, 10*time.Second, 200*time.Millisecond)
+}
+
 // TestActivityRetryDeferredWhilePaused validates that pausing a workflow while
 // one of its activities is retrying defers the activity's retries: the pending
 // activity's attempt count stops increasing for the duration of the pause and


### PR DESCRIPTION
## What changed?
* Workflow pause supports pausing a workflow that has not run its first workflow task yet, ie when in the `start_delay`.
* Unpause will foce-schedule a workflow task if the workflow had/has a workflow task OR the `MutableState.ExecutionInfo.ExecutionTime` is in the past.

## Why?
Standalone activities (wip on feature/saa-operator-cmds) supports pausing during its equivalent pre-dispatch `start_delay` window and honors the remaining delay on unpause.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [X] added new functional test(s)

## Potential risks
There is a risk that code checking the state-matrix change will have an unexpected change but it is minimal because workflow pause is still gated behind a default off dynamic config.
