### PR TITLE
Bring in latest manual docker build action to v1.30.x

### DIFF
--- a/.github/actions/build-binaries/action.yml
+++ b/.github/actions/build-binaries/action.yml
@@ -19,14 +19,14 @@ runs:
   using: composite
   steps:
     - name: Setup Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: "go.mod"
         cache: true
 
     - name: Run GoReleaser (release)
       if: inputs.release == 'true'
-      uses: goreleaser/goreleaser-action@v6
+      uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
       with:
         distribution: goreleaser
         version: v2.13.1
@@ -36,7 +36,7 @@ runs:
 
     - name: Run GoReleaser (build - all architectures)
       if: inputs.release != 'true' && inputs.single-arch == ''
-      uses: goreleaser/goreleaser-action@v6
+      uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
       with:
         distribution: goreleaser
         version: v2.13.1
@@ -46,7 +46,7 @@ runs:
 
     - name: Run GoReleaser (build - single architecture)
       if: inputs.release != 'true' && inputs.single-arch != ''
-      uses: goreleaser/goreleaser-action@v6
+      uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
       with:
         distribution: goreleaser
         version: v2.13.1

--- a/.github/actions/build-docker-images/action.yml
+++ b/.github/actions/build-docker-images/action.yml
@@ -29,7 +29,7 @@ inputs:
   alpine-tag:
     description: "Alpine base image tag"
     required: false
-    default: "3.23.5"
+    default: ""
   dockerhub-username:
     description: "Docker Hub username"
     required: false
@@ -44,6 +44,9 @@ outputs:
   sha-tag:
     description: "Docker SHA tag (e.g., sha-abc1234)"
     value: ${{ steps.image-tags.outputs.sha }}
+  sha-full-tag:
+    description: "Docker full SHA tag (e.g., sha-abcdef123456...)"
+    value: ${{ steps.image-tags.outputs.sha-full }}
 
 runs:
   using: composite
@@ -93,14 +96,14 @@ runs:
         .github/actions/build-docker-images/scripts/docker-build-helper extract-binary-version temporal-server server-version
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
     - name: Log in to Docker Hub
       if: inputs.push == 'true'
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
       with:
         username: ${{ inputs.dockerhub-username }}
         password: ${{ inputs.dockerhub-token }}
@@ -111,23 +114,30 @@ runs:
       working-directory: ${{ github.workspace }}
       env:
         IMAGE_REPO: temporaliotest
-        IMAGE_SHA_TAG: ${{ steps.image-tags.outputs.sha }}
+        IMAGE_SHA_SHORT_TAG: ${{ steps.image-tags.outputs.sha }}
+        IMAGE_SHA_FULL_TAG: ${{ steps.image-tags.outputs.sha-full }}
         IMAGE_BRANCH_TAG: ${{ steps.image-tags.outputs.tag }}
         TEMPORAL_SHA: ${{ steps.image-tags.outputs.git-sha }}
         TAG_LATEST: ${{ inputs.tag-latest }}
         ALPINE_TAG: ${{ inputs.alpine-tag }}
+        PLATFORM: ${{ inputs.platform }}
+        LOAD: ${{ inputs.load }}
         SERVER_VERSION: ${{ steps.extract-version.outputs.server-version }}
         CLI_VERSION: ${{ steps.extract-cli-version.outputs.cli-version }}
       run: |
-        if [ -n "${{ inputs.platform }}" ]; then
+        if [ -z "${ALPINE_TAG}" ]; then
+          unset ALPINE_TAG
+        fi
+
+        if [ -n "${PLATFORM}" ]; then
           docker buildx bake \
-            --set "*.platform=${{ inputs.platform }}" \
-            ${{ inputs.load == 'true' && '--load' || '' }} \
+            --set "*.platform=${PLATFORM}" \
+            $( [ "${LOAD}" = "true" ] && echo --load ) \
             -f docker/docker-bake.hcl \
             server admin-tools
         else
           docker buildx bake \
-            ${{ inputs.load == 'true' && '--load' || '' }} \
+            $( [ "${LOAD}" = "true" ] && echo --load ) \
             -f docker/docker-bake.hcl \
             server admin-tools
         fi
@@ -138,7 +148,8 @@ runs:
       working-directory: ${{ github.workspace }}
       env:
         IMAGE_REPO: temporaliotest
-        IMAGE_SHA_TAG: ${{ steps.image-tags.outputs.sha }}
+        IMAGE_SHA_SHORT_TAG: ${{ steps.image-tags.outputs.sha }}
+        IMAGE_SHA_FULL_TAG: ${{ steps.image-tags.outputs.sha-full }}
         IMAGE_BRANCH_TAG: ${{ steps.image-tags.outputs.tag }}
         TEMPORAL_SHA: ${{ steps.image-tags.outputs.git-sha }}
         TAG_LATEST: ${{ inputs.tag-latest }}
@@ -146,7 +157,21 @@ runs:
         SERVER_VERSION: ${{ steps.extract-version.outputs.server-version }}
         CLI_VERSION: ${{ steps.extract-cli-version.outputs.cli-version }}
       run: |
-        docker buildx bake \
-          --push \
-          -f docker/docker-bake.hcl \
-          server admin-tools
+        if [ -z "${ALPINE_TAG}" ]; then
+          unset ALPINE_TAG
+        fi
+
+        for attempt in 1 2 3; do
+          echo "Docker build/push attempt $attempt/3"
+          if timeout 1200 docker buildx bake \
+              --push \
+              -f docker/docker-bake.hcl \
+              server admin-tools; then
+            exit 0
+          fi
+          if [ "$attempt" -lt 3 ]; then
+            echo "Attempt $attempt failed, retrying in 30s..."
+            sleep 30
+          fi
+        done
+        exit 1

--- a/.github/actions/build-docker-images/scripts/main.go
+++ b/.github/actions/build-docker-images/scripts/main.go
@@ -14,7 +14,7 @@ import (
 var validArchs = []string{"amd64", "arm64"}
 
 // defaultCliVersion should be updated to the latest cli version
-const defaultCliVersion = "1.7.2"
+const defaultCliVersion = "1.6.1"
 
 func main() {
 	if len(os.Args) < 2 {
@@ -124,16 +124,19 @@ func setImageTags() error {
 		return fmt.Errorf("failed to generate valid Docker tag from branch name")
 	}
 
-	// Generate short SHA tag (first 7 characters with "sha-" prefix)
+	// Generate SHA tags. Keep the short tag for compatibility and add the full
+	// SHA tag to avoid collisions for automation.
 	shortSha := sha
 	if len(shortSha) > 7 {
 		shortSha = shortSha[:7]
 	}
 	shaTag := fmt.Sprintf("sha-%s", shortSha)
+	fullShaTag := fmt.Sprintf("sha-%s", sha)
 
 	fmt.Printf("Original: %s\n", ref)
 	fmt.Printf("Sanitized: %s\n", safeTag)
-	fmt.Printf("SHA tag: %s\n", shaTag)
+	fmt.Printf("Short SHA tag: %s\n", shaTag)
+	fmt.Printf("Full SHA tag: %s\n", fullShaTag)
 
 	// Set outputs for GitHub Actions
 	if err := setOutput("tag", safeTag); err != nil {
@@ -141,6 +144,9 @@ func setImageTags() error {
 	}
 	if err := setOutput("sha", shaTag); err != nil {
 		return fmt.Errorf("failed to set sha output: %w", err)
+	}
+	if err := setOutput("sha-full", fullShaTag); err != nil {
+		return fmt.Errorf("failed to set sha-full output: %w", err)
 	}
 	if err := setOutput("git-sha", sha); err != nil {
 		return fmt.Errorf("failed to set git-sha output: %w", err)

--- a/.github/workflows/docker-build-manual.yml
+++ b/.github/workflows/docker-build-manual.yml
@@ -4,12 +4,14 @@ name: Manual Docker Build
 on:
   workflow_dispatch:
     inputs:
+      cli-version:
+        description: "Optional Temporal CLI version override (leave empty to use default)"
+        default: ""
       alpine-tag:
-        description: "Alpine base image tag (e.g., 3.23.5)"
-        required: true
-        default: "3.23.5"
+        description: "Optional Alpine base image tag override (leave empty to use default from docker-bake.hcl)"
+        default: ""
       push:
-        description: "Push images to Docker Hub"
+        description: "Push images to Docker Hub (temporaliotest/server and temporaliotest/admin-tools)"
         required: true
         type: boolean
         default: false
@@ -18,44 +20,57 @@ on:
         required: true
         type: boolean
         default: false
-      platform:
-        description: "Platform to build (leave empty for multi-arch, or specify linux/amd64 or linux/arm64)"
-        required: false
-        default: ""
-      snapshot:
-        description: "Build in snapshot mode (for non-release builds)"
-        required: true
-        type: boolean
-        default: true
 
 permissions:
   contents: read
 
 jobs:
-  build-docker:
+  build-binaries:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
-
-      - name: Determine single-arch parameter
-        id: arch-param
-        run: |
-          if [ -n "${{ inputs.platform }}" ]; then
-            # Extract arch from platform (e.g., linux/amd64 -> amd64)
-            ARCH=$(echo "${{ inputs.platform }}" | cut -d'/' -f2)
-            echo "single-arch=${ARCH}" >> "$GITHUB_OUTPUT"
-          else
-            echo "single-arch=" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Build binaries
         uses: ./.github/actions/build-binaries
         with:
-          snapshot: ${{ inputs.snapshot }}
-          single-arch: ${{ steps.arch-param.outputs.single-arch }}
+          single-arch: ${{ matrix.arch }}
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: binaries-${{ matrix.arch }}
+          path: dist/*_linux_*
+          if-no-files-found: error
+          retention-days: 1
+
+  build-docker:
+    needs: build-binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Download binaries
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          pattern: binaries-*
+          merge-multiple: true
+          path: dist
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "go.mod"
+          cache: true
 
       - name: Build Docker images
         id: build-docker
@@ -64,9 +79,8 @@ jobs:
         with:
           push: false
           tag-latest: ${{ inputs.tag-latest }}
-          platform: ${{ inputs.platform }}
           alpine-tag: ${{ inputs.alpine-tag }}
-          load: ${{ inputs.platform == 'linux/amd64' || inputs.platform == '' }}
+          cli-version: ${{ inputs.cli-version }}
 
       - name: Build and push Docker images
         id: push-docker
@@ -75,29 +89,35 @@ jobs:
         with:
           push: true
           tag-latest: ${{ inputs.tag-latest }}
-          platform: ${{ inputs.platform }}
           alpine-tag: ${{ inputs.alpine-tag }}
+          cli-version: ${{ inputs.cli-version }}
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Output image tags
         env:
           SHA_TAG: ${{ steps.build-docker.outputs.sha-tag || steps.push-docker.outputs.sha-tag }}
+          SHA_FULL_TAG: ${{ steps.build-docker.outputs.sha-full-tag || steps.push-docker.outputs.sha-full-tag }}
           BRANCH_TAG: ${{ steps.build-docker.outputs.branch-tag || steps.push-docker.outputs.branch-tag }}
+          PUSHED: ${{ inputs.push }}
+          TAG_LATEST: ${{ inputs.tag-latest }}
         run: |
           {
             echo "### Docker Images Built"
             echo ""
-            echo "**Branch:** ${{ github.ref_name }}"
-            echo "**SHA Tag:** ${SHA_TAG}"
+            echo "**Branch:** ${GITHUB_REF_NAME}"
+            echo "**Short SHA Tag:** ${SHA_TAG}"
+            echo "**Full SHA Tag:** ${SHA_FULL_TAG}"
             echo "**Branch Tag:** ${BRANCH_TAG}"
-            echo "**Platform:** ${{ inputs.platform || 'linux/amd64,linux/arm64' }}"
-            echo "**Pushed to Docker Hub:** ${{ inputs.push }}"
-            echo "**Tagged as latest:** ${{ inputs.tag-latest }}"
+            echo "**Platform:** linux/amd64,linux/arm64"
+            echo "**Pushed to Docker Hub:** ${PUSHED}"
+            echo "**Tagged as latest:** ${TAG_LATEST}"
             echo ""
             echo "**Image Tags:**"
             echo "- temporaliotest/server:${SHA_TAG}"
             echo "- temporaliotest/admin-tools:${SHA_TAG}"
+            echo "- temporaliotest/server:${SHA_FULL_TAG}"
+            echo "- temporaliotest/admin-tools:${SHA_FULL_TAG}"
             echo "- temporaliotest/server:${BRANCH_TAG}"
             echo "- temporaliotest/admin-tools:${BRANCH_TAG}"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What changed?
- Manual docker build is failing on this older branch, bringing the GHA up to date

## Why?
https://github.com/temporalio/temporal/actions/runs/28972378000/job/85971046328

Unblocking security release.
