### PR TITLE
[testcore] Use a single shared cluster for everything

### DIFF
--- a/tests/activity_api_batch_unpause_test.go
+++ b/tests/activity_api_batch_unpause_test.go
@@ -31,8 +31,7 @@ type ActivityApiBatchUnpauseClientTestSuite struct {
 }
 
 func TestActivityApiBatchUnpauseClientTestSuite(t *testing.T) {
-	testcore.UseSuiteScopedCluster(t)                                               //nolint:staticcheck // SA1019: suite reuses one worker-service cluster to avoid per-test cluster churn.
-	parallelsuite.RunLegacySequential(t, &ActivityApiBatchUnpauseClientTestSuite{}) //nolint:staticcheck // SA1019: suite reuses one worker-service cluster to avoid per-test cluster churn.
+	parallelsuite.Run(t, &ActivityApiBatchUnpauseClientTestSuite{})
 }
 
 type internalTestWorkflow struct {
@@ -93,7 +92,7 @@ func (s *ActivityApiBatchUnpauseClientTestSuite) createWorkflow(env *testcore.Te
 }
 
 func (s *ActivityApiBatchUnpauseClientTestSuite) TestActivityBatchUnpause_Success() {
-	env := testcore.NewEnv(s.T())
+	env := testcore.NewEnv(s.T(), testcore.WithWorkerService("batch unpause activity operations require system worker batcher"))
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -303,7 +302,7 @@ func (s *ActivityApiBatchUnpauseClientTestSuite) TestActivityBatchUnpause_MatchA
 }
 
 func (s *ActivityApiBatchUnpauseClientTestSuite) TestActivityBatchUnpause_Failed() {
-	env := testcore.NewEnv(s.T())
+	env := testcore.NewEnv(s.T(), testcore.WithWorkerService("batch unpause activity operations require system worker batcher"))
 
 	// neither activity type not "match all" is provided
 	_, err := env.SdkClient().WorkflowService().StartBatchOperation(context.Background(), &workflowservice.StartBatchOperationRequest{
@@ -341,7 +340,7 @@ func (s *ActivityApiBatchUnpauseClientTestSuite) TestActivityBatchUnpause_Failed
 // This is an end-to-end complement to the unit-level checkNamespace tests: it
 // exercises the full path from StartBatchOperation through the batcher worker.
 func (s *ActivityApiBatchUnpauseClientTestSuite) TestBatchTerminate_NamespaceIsolation() {
-	env := testcore.NewEnv(s.T())
+	env := testcore.NewEnv(s.T(), testcore.WithWorkerService("batch terminate namespace isolation test uses system worker batcher"))
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 

--- a/tests/leakcheck/leak_test.go
+++ b/tests/leakcheck/leak_test.go
@@ -158,7 +158,12 @@ func buildRunTeardownCluster(t *testing.T, leakCheck *objectleak.ObjectLeakCheck
 	t.Run("cluster", func(t *testing.T) {
 		env := testcore.NewEnv(t,
 			testcore.WithDedicatedCluster(),
-			testcore.WithWorkerService("leak regression test"))
+			testcore.WithWorkerService("leak checker needs worker service to exercise full server path"),
+		)
+
+		// Doing a no-op global metric capture to satisfy the dedicated cluster guard, otherwise
+		// we'll trigger a cluster misuse fatal.
+		env.StartGlobalMetricCapture()
 
 		env.SdkWorker().RegisterWorkflow(smokeWorkflow)
 		run, err := env.SdkClient().ExecuteWorkflow(

--- a/tests/namespace_test.go
+++ b/tests/namespace_test.go
@@ -31,7 +31,7 @@ type (
 )
 
 func TestNamespaceSuite(t *testing.T) {
-	parallelsuite.RunLegacySequential(t, &namespaceTestSuite{}) //nolint:staticcheck // SA1019: namespace deletion tests use dedicated worker-service clusters.
+	parallelsuite.Run(t, &namespaceTestSuite{})
 }
 
 func (s *namespaceTestSuite) newTestEnv(opts ...testcore.TestOption) *testcore.TestEnv {

--- a/tests/poller_scaling_test.go
+++ b/tests/poller_scaling_test.go
@@ -31,12 +31,13 @@ type PollerScalingIntegSuite struct {
 }
 
 func TestPollerScalingFunctionalSuite(t *testing.T) {
-	testcore.UseSuiteScopedCluster(t)                                //nolint:staticcheck // SA1019: suite reuses one worker-service cluster to avoid per-test cluster churn.
-	parallelsuite.RunLegacySequential(t, &PollerScalingIntegSuite{}) //nolint:staticcheck // SA1019: suite reuses one worker-service cluster to avoid per-test cluster churn.
+	parallelsuite.Run(t, &PollerScalingIntegSuite{})
 }
 
 func (s *PollerScalingIntegSuite) setupEnv(opts ...testcore.TestOption) *testcore.TestEnv {
 	opts = append([]testcore.TestOption{
+		testcore.WithWorkerService("poller scaling test uses worker deployment system workflows"),
+
 		// Force one partition so we can reliably see the backlog
 		testcore.WithDynamicConfig(dynamicconfig.MatchingNumTaskqueueReadPartitions, 1),
 		testcore.WithDynamicConfig(dynamicconfig.MatchingNumTaskqueueWritePartitions, 1),

--- a/tests/schedule_migration_test.go
+++ b/tests/schedule_migration_test.go
@@ -43,13 +43,13 @@ type ScheduleMigrationTestSuite struct {
 }
 
 func TestScheduleMigrationTestSuite(t *testing.T) {
-	testcore.UseSuiteScopedCluster(t)                                   //nolint:staticcheck // SA1019: suite reuses one worker-service cluster to avoid per-test cluster churn.
-	parallelsuite.RunLegacySequential(t, &ScheduleMigrationTestSuite{}) //nolint:staticcheck // SA1019: suite reuses one worker-service cluster to avoid per-test cluster churn.
+	parallelsuite.Run(t, &ScheduleMigrationTestSuite{})
 }
 
 func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2AlreadyExists() {
 	env := newScheduleEnv(
 		s.T(),
+		testcore.WithWorkerService("schedule migration tests require system worker for v1 schedule management"),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 	)
 
@@ -291,6 +291,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1BlockedBySentine
 func (s *ScheduleMigrationTestSuite) TestScheduleMigrationDynamicConfig() {
 	env := newScheduleEnv(
 		s.T(),
+		testcore.WithWorkerService("schedule migration tests require system worker for v1 schedule management"),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerMigration, true),
 	)
@@ -400,6 +401,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationDynamicConfig() {
 func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2() {
 	env := newScheduleEnv(
 		s.T(),
+		testcore.WithWorkerService("schedule migration tests require system worker for v1 schedule management"),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 	)
 
@@ -536,6 +538,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2() {
 func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1() {
 	env := newScheduleEnv(
 		s.T(),
+		testcore.WithWorkerService("schedule migration tests require system worker for v1 schedule management"),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, false),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerRouting, false),
@@ -742,6 +745,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1() {
 func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1Idempotent() {
 	env := newScheduleEnv(
 		s.T(),
+		testcore.WithWorkerService("schedule migration tests require system worker for v1 schedule management"),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, false),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerRouting, false),
@@ -812,6 +816,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1Idempotent() {
 func (s *ScheduleMigrationTestSuite) TestCHASMScheduleDescribeAfterDisablingCreationAndMigration() {
 	env := newScheduleEnv(
 		s.T(),
+		testcore.WithWorkerService("schedule migration tests require system worker for v1 schedule management"),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerMigration, true),
@@ -913,6 +918,7 @@ func (s *ScheduleMigrationTestSuite) TestCHASMScheduleDescribeAfterDisablingCrea
 func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1RoutingFallback() {
 	env := newScheduleEnv(
 		s.T(),
+		testcore.WithWorkerService("schedule migration tests require system worker for v1 schedule management"),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerRouting, true),
@@ -1048,6 +1054,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1RoutingFallback(
 func (s *ScheduleMigrationTestSuite) TestScheduleUpdateAfterDelete() {
 	env := newScheduleEnv(
 		s.T(),
+		testcore.WithWorkerService("schedule migration tests require system worker for v1 schedule management"),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerRouting, true),
@@ -1158,6 +1165,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleUpdateAfterDelete() {
 func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2WithClosedV2() {
 	env := newScheduleEnv(
 		s.T(),
+		testcore.WithWorkerService("schedule migration tests require system worker for v1 schedule management"),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 	)
 
@@ -1598,6 +1606,7 @@ func TestScheduleMigrationDeferredWithRunningWorkflow(t *testing.T) {
 func (s *ScheduleMigrationTestSuite) TestDeleteScheduleContextMetadata() {
 	env := newScheduleEnv(
 		s.T(),
+		testcore.WithWorkerService("schedule migration tests require system worker for v1 schedule management"),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerRouting, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerSentinels, true),
@@ -1801,6 +1810,7 @@ func (s *ScheduleMigrationTestSuite) TestDeleteScheduleContextMetadata() {
 func (s *ScheduleMigrationTestSuite) TestPatchScheduleContextMetadata() {
 	env := newScheduleEnv(
 		s.T(),
+		testcore.WithWorkerService("schedule migration tests require system worker for v1 schedule management"),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerRouting, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerSentinels, true),
@@ -2111,6 +2121,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationRolloutPercent() {
 	t := s.T()
 	env := newScheduleEnv(
 		t,
+		testcore.WithWorkerService("schedule migration tests require system worker for v1 schedule management"),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerMigration, true),
 		testcore.WithDynamicConfig(dynamicconfig.CHASMSchedulerMigrationRolloutPercent, 50),

--- a/tests/task_queue_stats_test.go
+++ b/tests/task_queue_stats_test.go
@@ -67,6 +67,7 @@ func newTaskQueueStatsContext(
 	extraOpts ...testcore.TestOption,
 ) *taskQueueStatsContext {
 	opts := []testcore.TestOption{
+		testcore.WithWorkerService("task queue stats tests use worker deployment system workflows"),
 		testcore.WithDynamicConfig(dynamicconfig.EnableDeploymentVersions, true),
 		testcore.WithDynamicConfig(dynamicconfig.FrontendEnableWorkerVersioningWorkflowAPIs, true),
 		testcore.WithDynamicConfig(dynamicconfig.MatchingUseNewMatcher, usePriMatcher),
@@ -94,8 +95,7 @@ type TaskQueueStatsSuite struct {
 }
 
 func TestTaskQueueStats_Pri_Suite(t *testing.T) {
-	testcore.UseSuiteScopedCluster(t)                                  //nolint:staticcheck // SA1019: suite reuses one worker-service cluster to avoid per-test cluster churn.
-	parallelsuite.RunLegacySequential(t, &TaskQueueStatsSuite{}, true) //nolint:staticcheck // SA1019: suite reuses one worker-service cluster to avoid per-test cluster churn.
+	parallelsuite.Run(t, &TaskQueueStatsSuite{}, true)
 }
 
 func (s *TaskQueueStatsSuite) newTaskQueueStatsContext(
@@ -189,7 +189,7 @@ func (s *TaskQueueStatsSuite) TestAddMultipleTasks_ValidateStats_Cached(usePriMa
 func (s *TaskQueueStatsSuite) TestVersioningSuite(usePriMatcher bool) {
 	for _, behavior := range testcore.AllMatchingBehaviors() {
 		s.T().Run(behavior.Name()+"Suite", func(t *testing.T) { //nolint:testifylint // nested parallelsuite.Run needs raw *testing.T
-			parallelsuite.RunLegacySequential(t, &TaskQueueStatsVersionSuite{}, usePriMatcher, behavior) //nolint:staticcheck // SA1019: suite reuses one worker-service cluster to avoid per-test cluster churn.
+			parallelsuite.Run(t, &TaskQueueStatsVersionSuite{}, usePriMatcher, behavior)
 		})
 	}
 }

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -607,6 +607,20 @@ func (s *FunctionalTestBase) MarkNamespaceAsDeleted(
 	return err
 }
 
+// DeleteNamespaceRecord physically removes nsName's row from persistence, bypassing
+// DeleteNamespaceWorkflow/ReclaimResourcesWorkflow entirely - mirroring the same
+// direct-persistence bypass RegisterNamespace already uses for creation. Those workflows exist
+// to safely paginate through and delete potentially large amounts of *production* execution
+// data before removing the namespace record; test namespaces are backed by an ephemeral
+// per-run persistence store and typically own zero or a handful of executions, so that
+// machinery (and its cost of routing every cleanup through the shared cluster's one system
+// worker) isn't needed here.
+func (s *FunctionalTestBase) DeleteNamespaceRecord(nsName namespace.Name) error {
+	return s.testCluster.testBase.MetadataManager.DeleteNamespaceByName(context.Background(), &persistence.DeleteNamespaceByNameRequest{
+		Name: nsName.String(),
+	})
+}
+
 func (s *FunctionalTestBase) GetHistoryFunc(namespace string, execution *commonpb.WorkflowExecution) func() []*historypb.HistoryEvent {
 	return func() []*historypb.HistoryEvent {
 		historyResponse, err := s.FrontendClient().GetWorkflowExecutionHistory(NewContext(), &workflowservice.GetWorkflowExecutionHistoryRequest{

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -16,7 +16,7 @@ import (
 var testClusterRouter *clusterRouter
 
 func init() {
-	sharedSize := max(1, runtime.GOMAXPROCS(0)/2)
+	sharedSize := 1
 	if v := os.Getenv("TEMPORAL_TEST_SHARED_CLUSTERS"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil || n <= 0 {
@@ -235,9 +235,11 @@ type clusterRequest struct {
 }
 
 // mustBeFresh reports whether the request requires a brand-new cluster that
-// cannot be reused.
+// cannot be reused. needWorkerService deliberately does not force this: shared
+// (and suite-scoped) clusters run the worker service by default, so a test that
+// needs it can reuse the shared cluster instead of requiring a fresh one.
 func (r clusterRequest) mustBeFresh() bool {
-	return r.needWorkerService || len(r.dynamicConfig) > 0 || len(r.clusterOpts) > 0
+	return len(r.dynamicConfig) > 0 || len(r.clusterOpts) > 0
 }
 
 // needsDedicated reports whether the request must be served by a dedicated
@@ -337,8 +339,11 @@ func (p *clusterRouter) getSuiteScoped(t *testing.T) *FunctionalTestBase {
 
 func (p *clusterRouter) getDedicated(t *testing.T, req clusterRequest) *FunctionalTestBase {
 	req.kind = clusterKindDedicated
-	if req.mustBeFresh() {
-		// Custom config or fx options require a fresh cluster (can't reuse).
+	if req.mustBeFresh() || req.needWorkerService {
+		// Always create a new cluster in the following cases:
+		// - custom configs are set, since they can't be shared across tests
+		// - worker service is needed, since goroutines (system workers, matching partition managers) don't clean up between
+		//   tests and would accumulate in a long-lived pooled cluster.
 		p.dedicated.reserveSlot(t)
 		cluster := p.createCluster(t, req)
 
@@ -352,7 +357,7 @@ func (p *clusterRouter) getDedicated(t *testing.T, req clusterRequest) *Function
 		return cluster
 	}
 
-	// If no custom config is provided, reuse an existing cluster.
+	// If no custom config or worker service is needed, reuse an existing cluster.
 	return p.dedicated.get(t, func() *FunctionalTestBase {
 		return p.createCluster(t, req)
 	})
@@ -362,8 +367,11 @@ func (p *clusterRouter) createCluster(t *testing.T, req clusterRequest) *Functio
 	tbase := &FunctionalTestBase{}
 	tbase.SetT(t)
 
-	// The worker service is off unless the request explicitly needs it.
-	opts := []TestClusterOption{withWorkerService(req.needWorkerService)}
+	// Keep the worker service off unless explicitly enabled via WithWorkerService.
+	// Shared (and suite-scoped) clusters always run it, though, so tests that need
+	// it can reuse the shared cluster instead of requiring a dedicated one.
+	needWorkerService := req.needWorkerService || req.kind != clusterKindDedicated
+	opts := []TestClusterOption{withWorkerService(needWorkerService)}
 	if req.kind != clusterKindDedicated {
 		opts = append(opts, WithSharedCluster())
 	}

--- a/tests/testcore/test_cluster_pool_test.go
+++ b/tests/testcore/test_cluster_pool_test.go
@@ -1,7 +1,12 @@
 package testcore
 
 import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -103,4 +108,67 @@ func TestClusterPool_PoisonedActiveClusterSwapsWithoutRecycling(t *testing.T) {
 	// The old poisoned lease remains active, while leaseCount restarts on the replacement.
 	require.Equal(t, 2, slot.activeLeases)
 	require.Equal(t, 1, slot.leaseCount)
+}
+
+// TestClusterPool_SharedClusterConcurrency spins up multiple subtests in parallel and acquire
+// a singular shared cluster. This test ensures that concurrent access to this cluster is allowed
+// by the pool, and parallel tests are not blocked waiting.
+func TestClusterPool_SharedClusterConcurrency(t *testing.T) {
+	// Mirrors the real shared pool: a single slot, non-exclusive access.
+	p := newClusterPool(1, false, 0)
+	singleSharedClusterSlot := p.allSlots[0]
+
+	var clustersCreated atomic.Int32
+	createCluster := func() *FunctionalTestBase {
+		clustersCreated.Add(1)
+		return &FunctionalTestBase{}
+	}
+
+	const numSubtests = 5
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	// Each subtest will simply request a shared cluster, and append it
+	// to `clusters` slice, in parallel.
+	var mu sync.Mutex
+	clusters := make([]*FunctionalTestBase, 0, numSubtests)
+
+	// Use a channel + atomic var to block on all subtests until all of them
+	// have acquired the shared cluster.
+	var arrived atomic.Int32
+	release := make(chan struct{})
+
+	for i := range numSubtests {
+		t.Run(fmt.Sprintf("subtest-%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			cluster := p.get(t, createCluster)
+
+			mu.Lock()
+			clusters = append(clusters, cluster)
+			mu.Unlock()
+
+			// Unblock the `release` chan iff all subtests finished acquiring the shared cluster.
+			// I.e., if `p.get(...)` blocks, we'd fail the subtest(s) via hitting the ctx timeout.
+			if arrived.Add(1) == numSubtests {
+				close(release)
+			}
+			select {
+			case <-release:
+			case <-ctx.Done():
+				t.Fatal("timed out waiting for sibling subtests to acquire the shared cluster")
+			}
+		})
+	}
+
+	// Need to put assertions in t.Cleanup(...) so it runs after the top-level test function returns
+	// AND all parallel subtests above complete.
+	t.Cleanup(func() {
+		require.Equal(t, int32(1), clustersCreated.Load())
+		require.Len(t, clusters, numSubtests)
+		for _, c := range clusters {
+			require.Same(t, singleSharedClusterSlot.cluster, c)
+		}
+	})
 }

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -141,12 +141,14 @@ func WithTestVars(fn func(*testvars.TestVars) *testvars.TestVars) TestOption {
 }
 
 // WithWorkerService enables the system worker service. The service is off by
-// default to avoid the worker overhead. This implies a dedicated cluster.
-func WithWorkerService(reason string) TestOption {
+// default to avoid the worker overhead.
+// If this is not coupled with any option that requires a dedicated cluster,
+// we will create a cluster that will be recycled by other tests that also
+// need the system worker service.
+// The string parameter serves as documentation regarding the usage of the worker service.
+func WithWorkerService(_ string) TestOption {
 	return func(o *testOptions) {
-		o.dedicatedCluster = true
 		o.needWorkerService = true
-		o.dedicatedReason = "worker service required: " + reason
 	}
 }
 
@@ -288,6 +290,33 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 	)
 	if err != nil {
 		t.Fatalf("Failed to register namespace: %v", err)
+	}
+	if !options.dedicatedCluster {
+		// EXPERIMENT: shared clusters live for the whole test binary, so namespaces
+		// registered by each test otherwise accumulate for the process lifetime.
+		// Delete the persistence record directly rather than going through
+		// DeleteNamespaceWorkflow/ReclaimResourcesWorkflow: routing every test's
+		// cleanup through the shared cluster's one system worker caused an OOM
+		// (async, unbounded backlog) and then a suite-wide timeout (sync, worker
+		// throughput bottleneck) in earlier attempts. See DeleteNamespaceRecord.
+		//
+		// Deliberately NOT delayed: an earlier version soft-marked the namespace
+		// synchronously and scheduled the physical delete via time.AfterFunc after
+		// a grace period, to avoid racing detached goroutines some test helpers
+		// (e.g. sendUpdateInternal) spawn without guaranteeing they finish before
+		// the test returns. That delayed callback held a direct reference to the
+		// shared cluster's *FunctionalTestBase across the delay, and the shared
+		// pool can poison-and-recycle that same object at any time (tearing down
+		// and nilling its testCluster field) if any test taints it - so once any
+		// test poisoned the shared cluster, every other still-pending delayed
+		// delete would nil-pointer-panic in an unrecovered goroutine, crashing the
+		// whole process. That crash was worse than the race it was meant to fix,
+		// so deleting immediately here is the safer tradeoff for now.
+		t.Cleanup(func() {
+			if err := base.DeleteNamespaceRecord(ns); err != nil {
+				t.Logf("namespace cleanup failed for %s: %v", ns, err)
+			}
+		})
 	}
 
 	tv := testvars.New(t)

--- a/tests/update_workflow_utils.go
+++ b/tests/update_workflow_utils.go
@@ -87,13 +87,30 @@ func sendUpdateInternal(
 ) <-chan updateResponseErr {
 	s.T().Helper()
 
-	updateResultCh := make(chan updateResponseErr)
+	// updateResultCh is buffered so the goroutine below never blocks on sending to it,
+	// regardless of whether (or when) the caller reads it.
+	updateResultCh := make(chan updateResponseErr, 1)
+	done := make(chan struct{})
+	// Block this test's cleanup phase until the goroutine below has finished, so its
+	// s.T().Errorf call (if any) always happens while the test is still active. Without this,
+	// a slow UpdateWorkflowExecution call can still be in flight when the test itself returns,
+	// and failing from a goroutine after the test has completed panics the whole process -
+	// this used to be masked by how long namespace deletion took to become fully effective,
+	// but isn't safe to rely on.
+	s.T().Cleanup(func() { //nolint:staticcheck // SA1019: s is a generic testcore.Env here, not a suite, so T() is the only way to get *testing.T.
+		select {
+		case <-done:
+		case <-time.After(30 * time.Second):
+			s.T().Logf("sendUpdateInternal: background UpdateWorkflowExecution for update %s did not finish before cleanup timeout", tv.UpdateID()) //nolint:staticcheck // SA1019: same as above.
+		}
+	})
 	go func() {
 		updateResp, updateErr := s.FrontendClient().UpdateWorkflowExecution(ctx, updateWorkflowRequest(s, tv, waitPolicy))
 		if requireNoError && updateErr != nil {
 			s.T().Errorf("Update failed: %v", updateErr)
 		}
 		updateResultCh <- updateResponseErr{response: updateResp, err: updateErr}
+		close(done)
 	}()
 	waitUpdateAdmitted(s, tv)
 	return updateResultCh

--- a/tests/worker_registry_test.go
+++ b/tests/worker_registry_test.go
@@ -22,12 +22,12 @@ type WorkerRegistryTestSuite struct {
 }
 
 func TestWorkerRegistryTestSuite(t *testing.T) {
-	testcore.UseSuiteScopedCluster(t)                                //nolint:staticcheck // SA1019: suite reuses one worker-service cluster to avoid per-test cluster churn.
-	parallelsuite.RunLegacySequential(t, &WorkerRegistryTestSuite{}) //nolint:staticcheck // SA1019: suite reuses one worker-service cluster to avoid per-test cluster churn.
+	parallelsuite.Run(t, &WorkerRegistryTestSuite{})
 }
 
 func (s *WorkerRegistryTestSuite) newTestEnv(opts ...testcore.TestOption) *testcore.TestEnv {
 	baseOpts := []testcore.TestOption{
+		testcore.WithWorkerService("worker registry tests use system worker for heartbeat processing"),
 		testcore.WithDynamicConfig(dynamicconfig.WorkerHeartbeatsEnabled, true),
 	}
 	return testcore.NewEnv(s.T(), append(baseOpts, opts...)...)

--- a/tests/workflow_alias_search_attribute_test.go
+++ b/tests/workflow_alias_search_attribute_test.go
@@ -27,12 +27,13 @@ type WorkflowAliasSearchAttributeTestSuite struct {
 }
 
 func TestWorkflowAliasSearchAttributeTestSuite(t *testing.T) {
-	testcore.UseSuiteScopedCluster(t)                                              //nolint:staticcheck // SA1019: suite reuses one worker-service cluster to avoid per-test cluster churn.
-	parallelsuite.RunLegacySequential(t, &WorkflowAliasSearchAttributeTestSuite{}) //nolint:staticcheck // SA1019: suite reuses one worker-service cluster to avoid per-test cluster churn.
+	parallelsuite.Run(t, &WorkflowAliasSearchAttributeTestSuite{})
 }
 
 func (s *WorkflowAliasSearchAttributeTestSuite) newTestEnv(opts ...testcore.TestOption) *testcore.TestEnv {
 	opts = append([]testcore.TestOption{
+		testcore.WithWorkerService("workflow alias search attribute tests use worker deployment system workflows"),
+
 		// Keep deployment versions short because worker-deployment system workflow IDs must fit into 255 characters.
 		testcore.WithTestVars(func(tv *testvars.TestVars) *testvars.TestVars {
 			return tv.WithDeploymentSeries("alias-sa").WithBuildID("v1")


### PR DESCRIPTION
## What changed?

Experiment to try and see if we can reuse a single shared cluster for all tests that request a shared cluster.

## Why?

Reduce memory usage of tests.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

Need to watch out if it increases flakes.