### PR TITLE
Support CHASM Nexus operations in mutable state rebuild

### DIFF
--- a/service/history/workflow/mutable_state_rebuilder.go
+++ b/service/history/workflow/mutable_state_rebuilder.go
@@ -6,6 +6,7 @@ package workflow
 
 import (
 	"context"
+	"errors"
 
 	"github.com/google/uuid"
 	commonpb "go.temporal.io/api/common/v1"
@@ -682,11 +683,7 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 			}
 
 		default:
-			def, ok := b.shard.StateMachineRegistry().EventDefinition(event.GetEventType())
-			if !ok {
-				return nil, serviceerror.NewInvalidArgumentf("Unknown event type: %v", event.GetEventType())
-			}
-			if err := def.Apply(b.mutableState.HSM(), event); err != nil {
+			if err := b.applyStateMachineEvent(ctx, event); err != nil {
 				return nil, err
 			}
 		}
@@ -710,6 +707,80 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 		},
 		newRunHistory,
 	)
+}
+
+// applyStateMachineEvent applies a state-machine-backed history event (e.g. Nexus operation events)
+// during state rebuild (replication / reset).
+//
+// CHASM is tried first, then HSM. Trying CHASM first keeps the rebuilder forward-compatible: new
+// history event types are expected to be CHASM-backed, so an event type unknown to HSM should be
+// applied by CHASM rather than surfaced as an error. applyChasmEvent claims the event only when the
+// namespace routes it to CHASM and the operation lives in (for a create, is routed to) the CHASM
+// tree; otherwise it reports "not applied" and the event falls back to the HSM tree (legacy default).
+func (b *MutableStateRebuilderImpl) applyStateMachineEvent(
+	ctx context.Context,
+	event *historypb.HistoryEvent,
+) error {
+	applied, err := b.applyChasmEvent(ctx, event)
+	if err != nil {
+		return err
+	}
+	if applied {
+		return nil
+	}
+	return b.applyHSMEvent(event)
+}
+
+// applyHSMEvent applies an event to the HSM tree
+func (b *MutableStateRebuilderImpl) applyHSMEvent(event *historypb.HistoryEvent) error {
+	def, ok := b.shard.StateMachineRegistry().EventDefinition(event.GetEventType())
+	if !ok {
+		return serviceerror.NewInvalidArgumentf("Unknown event type: %v", event.GetEventType())
+	}
+	return def.Apply(b.mutableState.HSM(), event)
+}
+
+// applyChasmEvent applies an event to the CHASM workflow tree. It returns (true, nil) when CHASM
+// claimed and applied the event, (false, nil) when the event belongs to the HSM tree instead (CHASM
+// disabled for the workflow or namespace, event type unknown to CHASM, or the operation is not in the
+// CHASM tree), and (false, err) for a fatal error.
+func (b *MutableStateRebuilderImpl) applyChasmEvent(
+	ctx context.Context,
+	event *historypb.HistoryEvent,
+) (bool, error) {
+	if !b.mutableState.ChasmEnabled() {
+		return false, nil
+	}
+	// Creating a Nexus operation is routed by the per-namespace nexusoperation.enableChasmWorkflowOperations
+	// flag: when off, new operations are created in the HSM tree (legacy behavior). This routing applies only
+	// to the create event; non-create events are matched against wherever the operation already lives. A reset
+	// therefore realigns an operation to whichever framework new operations are created in today.
+	if event.GetEventType() == enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED {
+		nsName := b.mutableState.GetNamespaceEntry().Name().String()
+		if !b.shard.GetConfig().EnableChasmNexusWorkflowOperations(nsName) {
+			return false, nil
+		}
+	}
+	chasmWorkflowRegistry := b.shard.ChasmWorkflowRegistry()
+	def, ok := chasmWorkflowRegistry.EventDefinitionByEventType(event.GetEventType())
+	if !ok {
+		return false, nil
+	}
+	// Ensure the root CHASM workflow component exists before applying.
+	b.mutableState.EnsureChasmWorkflowComponent(ctx)
+	wf, chasmCtx, err := b.mutableState.ChasmWorkflowComponent(ctx)
+	if err != nil {
+		return false, err
+	}
+	if err := def.Apply(chasmCtx, wf, event); err != nil {
+		// A NotFound means the operation is not in the CHASM tree (it lives in HSM), so report "not
+		// applied" and let the caller fall back to HSM. This mirrors HSM's ErrStateMachineNotFound.
+		if errors.As(err, new(*serviceerror.NotFound)) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func (b *MutableStateRebuilderImpl) applyNewRunHistory(

--- a/service/history/workflow/mutable_state_rebuilder_test.go
+++ b/service/history/workflow/mutable_state_rebuilder_test.go
@@ -12,14 +12,18 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
+	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	historyspb "go.temporal.io/server/api/history/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/chasm"
+	chasmworkflow "go.temporal.io/server/chasm/lib/workflow"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/definition"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/payload"
@@ -2184,6 +2188,8 @@ func (s *stateBuilderSuite) TestApplyEvents_HSMRegistry() {
 	}
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 	s.mockUpdateVersion(event)
+	// CHASM disabled -> the create event is routed to the HSM tree (legacy behavior).
+	s.mockMutableState.EXPECT().ChasmEnabled().Return(false).AnyTimes()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.NoError(err)
@@ -2191,6 +2197,59 @@ func (s *stateBuilderSuite) TestApplyEvents_HSMRegistry() {
 	sm, err := nexusoperations.MachineCollection(s.mockMutableState.HSM()).Data("5")
 	s.NoError(err)
 	s.Equal(enumsspb.NEXUS_OPERATION_STATE_SCHEDULED, sm.State())
+}
+
+// TestApplyEvents_NexusScheduled_ChasmCreateSurfacesError verifies that when the creation-policy flag
+// is ON, rebuild commits to the CHASM tree and surfaces a failure to create the op there rather than
+// silently falling back to the HSM tree. Rebuild picks a framework by dynamic config; it is not an
+// error-fallback, so a CHASM failure must fail the rebuild instead of producing an HSM op.
+func (s *stateBuilderSuite) TestApplyEvents_NexusScheduled_ChasmCreateSurfacesError() {
+	version := int64(1)
+	requestID := uuid.NewString()
+	execution := &commonpb.WorkflowExecution{
+		WorkflowId: "wf-id",
+		RunId:      tests.RunID,
+	}
+	event := &historypb.HistoryEvent{
+		TaskId:    rand.Int63(),
+		Version:   version,
+		EventId:   5,
+		EventTime: timestamppb.New(time.Now().UTC()),
+		EventType: enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED,
+		Attributes: &historypb.HistoryEvent_NexusOperationScheduledEventAttributes{
+			NexusOperationScheduledEventAttributes: &historypb.NexusOperationScheduledEventAttributes{
+				EndpointId:                   "endpoint-id",
+				Endpoint:                     "endpoint",
+				Service:                      "service",
+				Operation:                    "operation",
+				WorkflowTaskCompletedEventId: 4,
+				RequestId:                    "request-id",
+			},
+		},
+	}
+
+	// Flag ON + a CHASM registry that owns the scheduled event, so the event is routed to the CHASM
+	// tree and reaches the (failing) component lookup rather than falling back to HSM.
+	s.mockShard.GetConfig().EnableChasmNexusWorkflowOperations = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
+	s.mockShard.SetChasmWorkflowRegistry(newFakeChasmRegistry(&fakeChasmEventDefinition{
+		eventType: enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED,
+	}))
+
+	// Only expect the calls that run before the state-rebuild fails; the terminal task-generation and
+	// history-builder calls (set up by mockUpdateVersion) are never reached because the op create errors.
+	s.mockMutableState.EXPECT().ClearStickyTaskQueue().AnyTimes()
+	s.mockMutableState.EXPECT().UpdateCurrentVersion(gomock.Any(), true).AnyTimes()
+	s.mockMutableState.EXPECT().ChasmEnabled().Return(true).AnyTimes()
+	s.mockMutableState.EXPECT().GetNamespaceEntry().Return(tests.GlobalNamespaceEntry).AnyTimes()
+	s.mockMutableState.EXPECT().EnsureChasmWorkflowComponent(gomock.Any()).AnyTimes()
+	s.mockMutableState.EXPECT().ChasmWorkflowComponent(gomock.Any()).
+		Return(nil, nil, serviceerror.NewInternal("chasm unavailable")).AnyTimes()
+
+	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
+	s.Error(err)
+	// The op must NOT have been created in the HSM tree (no error-fallback).
+	_, hsmErr := nexusoperations.MachineCollection(s.mockMutableState.HSM()).Data("5")
+	s.Error(hsmErr)
 }
 
 func (p *testTaskGeneratorProvider) NewTaskGenerator(
@@ -2208,4 +2267,234 @@ func (p *testTaskGeneratorProvider) NewTaskGenerator(
 		shardContext.GetArchivalMetadata(),
 		shardContext.GetLogger(),
 	)
+}
+
+// --- applyStateMachineEvent (HSM<->CHASM dispatch) coverage -------------------------------------
+//
+// These exercise the probe-and-fallback dispatch added for rebuilding Nexus operations that may live
+// in either the HSM or CHASM tree.
+
+type fakeChasmEventDefinition struct {
+	eventType enumspb.EventType
+	applyErr  error
+	applied   *bool
+}
+
+func (d *fakeChasmEventDefinition) Type() enumspb.EventType     { return d.eventType }
+func (d *fakeChasmEventDefinition) IsWorkflowTaskTrigger() bool { return false }
+func (d *fakeChasmEventDefinition) Apply(chasm.MutableContext, *chasmworkflow.Workflow, *historypb.HistoryEvent) error {
+	if d.applied != nil {
+		*d.applied = true
+	}
+	return d.applyErr
+}
+
+func (d *fakeChasmEventDefinition) CherryPick(chasm.MutableContext, *chasmworkflow.Workflow, *historypb.HistoryEvent, map[enumspb.ResetReapplyExcludeType]struct{}) error {
+	return nil
+}
+
+type fakeChasmLibrary struct {
+	defs []chasmworkflow.EventDefinition
+}
+
+func (l fakeChasmLibrary) CommandHandlers() map[enumspb.CommandType]chasmworkflow.CommandHandler {
+	return nil
+}
+
+func (l fakeChasmLibrary) EventDefinitions() []chasmworkflow.EventDefinition { return l.defs }
+
+func newFakeChasmRegistry(def *fakeChasmEventDefinition) *chasmworkflow.Registry {
+	reg := chasmworkflow.NewRegistry()
+	var defs []chasmworkflow.EventDefinition
+	if def != nil {
+		defs = append(defs, def)
+	}
+	_ = reg.Register(fakeChasmLibrary{defs: defs})
+	return reg
+}
+
+type fakeHSMEventDefinition struct {
+	eventType enumspb.EventType
+	applyErr  error
+	applied   *bool
+}
+
+func (d *fakeHSMEventDefinition) Type() enumspb.EventType     { return d.eventType }
+func (d *fakeHSMEventDefinition) IsWorkflowTaskTrigger() bool { return false }
+func (d *fakeHSMEventDefinition) Apply(*hsm.Node, *historypb.HistoryEvent) error {
+	if d.applied != nil {
+		*d.applied = true
+	}
+	return d.applyErr
+}
+
+func (d *fakeHSMEventDefinition) CherryPick(*hsm.Node, *historypb.HistoryEvent, map[enumspb.ResetReapplyExcludeType]struct{}) error {
+	return nil
+}
+
+func newFakeHSMRegistry(def *fakeHSMEventDefinition) *hsm.Registry {
+	reg := hsm.NewRegistry()
+	if def != nil {
+		_ = reg.RegisterEventDefinition(def)
+	}
+	return reg
+}
+
+type nexusRebuildCase struct {
+	chasmEnabled      bool
+	flagOn            bool
+	chasmHasDef       bool
+	hsmApplyErr       error
+	chasmApplyErr     error
+	chasmComponentErr error
+}
+
+// runApplyStateMachineEvent wires fake HSM/CHASM registries onto the shard, drives applyStateMachineEvent for the given
+// event, and reports which tree's Apply ran plus the returned error.
+func (s *stateBuilderSuite) runApplyStateMachineEvent(
+	event *historypb.HistoryEvent,
+	tc nexusRebuildCase,
+) (chasmApplied bool, hsmApplied bool, err error) {
+	s.mockShard.SetStateMachineRegistry(newFakeHSMRegistry(&fakeHSMEventDefinition{
+		eventType: event.GetEventType(),
+		applyErr:  tc.hsmApplyErr,
+		applied:   &hsmApplied,
+	}))
+	var def *fakeChasmEventDefinition
+	if tc.chasmHasDef {
+		def = &fakeChasmEventDefinition{
+			eventType: event.GetEventType(),
+			applyErr:  tc.chasmApplyErr,
+			applied:   &chasmApplied,
+		}
+	}
+	s.mockShard.SetChasmWorkflowRegistry(newFakeChasmRegistry(def))
+	s.mockShard.GetConfig().EnableChasmNexusWorkflowOperations = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(tc.flagOn)
+
+	ms := historyi.NewMockMutableState(s.controller)
+	ms.EXPECT().HSM().Return(nil).AnyTimes()
+	ms.EXPECT().ChasmEnabled().Return(tc.chasmEnabled).AnyTimes()
+	ms.EXPECT().GetNamespaceEntry().Return(tests.GlobalNamespaceEntry).AnyTimes()
+	ms.EXPECT().EnsureChasmWorkflowComponent(gomock.Any()).AnyTimes()
+	ms.EXPECT().ChasmWorkflowComponent(gomock.Any()).
+		Return(&chasmworkflow.Workflow{}, nil, tc.chasmComponentErr).AnyTimes()
+
+	rebuilder := NewMutableStateRebuilder(s.mockShard, s.logger, ms)
+	err = rebuilder.applyStateMachineEvent(context.Background(), event)
+	return chasmApplied, hsmApplied, err
+}
+
+func nexusScheduledEvent() *historypb.HistoryEvent {
+	return &historypb.HistoryEvent{EventId: 5, EventType: enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED}
+}
+
+func nexusCompletedEvent() *historypb.HistoryEvent {
+	return &historypb.HistoryEvent{EventId: 6, EventType: enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED}
+}
+
+func (s *stateBuilderSuite) TestApplyStateMachineEvent() {
+	hsmErr := serviceerror.NewInternal("hsm apply failed")
+	chasmErr := serviceerror.NewInternal("chasm unavailable")
+	notFound := serviceerror.NewNotFound("nexus operation not found for scheduled event ID")
+
+	testCases := []struct {
+		name             string
+		event            *historypb.HistoryEvent
+		tc               nexusRebuildCase
+		wantChasmApplied bool
+		wantHSMApplied   bool
+		wantErr          error
+	}{
+		// --- create events: routed by the per-namespace flag ---
+		{
+			name:             "nexus scheduled, flag on, creates in chasm",
+			event:            nexusScheduledEvent(),
+			tc:               nexusRebuildCase{chasmEnabled: true, flagOn: true, chasmHasDef: true},
+			wantChasmApplied: true,
+		},
+		{
+			name:           "nexus scheduled, flag off, routes to hsm",
+			event:          nexusScheduledEvent(),
+			tc:             nexusRebuildCase{chasmEnabled: true, flagOn: false, chasmHasDef: true},
+			wantHSMApplied: true,
+		},
+		{
+			name:           "nexus scheduled, chasm disabled, routes to hsm",
+			event:          nexusScheduledEvent(),
+			tc:             nexusRebuildCase{chasmEnabled: false, flagOn: true, chasmHasDef: true},
+			wantHSMApplied: true,
+		},
+		{
+			// Flag on, but CHASM has no definition for the event: fall back to creating in HSM.
+			name:           "nexus scheduled, flag on, chasm has no definition, falls back to hsm",
+			event:          nexusScheduledEvent(),
+			tc:             nexusRebuildCase{chasmEnabled: true, flagOn: true, chasmHasDef: false},
+			wantHSMApplied: true,
+		},
+		{
+			// A genuine CHASM error is surfaced, never fallen back to HSM (avoids split-brain).
+			name:    "nexus scheduled, flag on, chasm error surfaced without hsm fallback",
+			event:   nexusScheduledEvent(),
+			tc:      nexusRebuildCase{chasmEnabled: true, flagOn: true, chasmHasDef: true, chasmComponentErr: chasmErr},
+			wantErr: chasmErr,
+		},
+		// --- non-create events: CHASM-first, HSM fallback ---
+		{
+			name:             "non-create, chasm owns and applies",
+			event:            nexusCompletedEvent(),
+			tc:               nexusRebuildCase{chasmEnabled: true, chasmHasDef: true},
+			wantChasmApplied: true,
+		},
+		{
+			name:           "non-create, chasm disabled, routes to hsm",
+			event:          nexusCompletedEvent(),
+			tc:             nexusRebuildCase{chasmEnabled: false, chasmHasDef: true},
+			wantHSMApplied: true,
+		},
+		{
+			name:           "non-create, chasm has no definition, routes to hsm",
+			event:          nexusCompletedEvent(),
+			tc:             nexusRebuildCase{chasmEnabled: true, chasmHasDef: false},
+			wantHSMApplied: true,
+		},
+		{
+			// CHASM doesn't own the op (NotFound); the event falls back to the HSM tree.
+			name:             "non-create, chasm not found, falls back to hsm",
+			event:            nexusCompletedEvent(),
+			tc:               nexusRebuildCase{chasmEnabled: true, chasmHasDef: true, chasmApplyErr: notFound},
+			wantChasmApplied: true,
+			wantHSMApplied:   true,
+		},
+		{
+			// CHASM NotFound falls back to HSM, whose error is then surfaced as-is.
+			name:             "non-create, chasm not found, hsm error surfaced",
+			event:            nexusCompletedEvent(),
+			tc:               nexusRebuildCase{chasmEnabled: true, chasmHasDef: true, chasmApplyErr: notFound, hsmApplyErr: hsmErr},
+			wantChasmApplied: true,
+			wantHSMApplied:   true,
+			wantErr:          hsmErr,
+		},
+		{
+			// A genuine (non-NotFound) CHASM error is surfaced, not fallen back to HSM.
+			name:             "non-create, chasm error surfaced without hsm fallback",
+			event:            nexusCompletedEvent(),
+			tc:               nexusRebuildCase{chasmEnabled: true, chasmHasDef: true, chasmApplyErr: chasmErr},
+			wantChasmApplied: true,
+			wantErr:          chasmErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			chasmApplied, hsmApplied, err := s.runApplyStateMachineEvent(tc.event, tc.tc)
+			switch {
+			case tc.wantErr != nil:
+				s.ErrorIs(err, tc.wantErr)
+			default:
+				s.NoError(err)
+			}
+			s.Equal(tc.wantChasmApplied, chasmApplied)
+			s.Equal(tc.wantHSMApplied, hsmApplied)
+		})
+	}
 }

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -354,7 +354,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancellationCrossTree(chasmEn
 			s.NoError(startedHandle.Get(ctx, nil))
 
 			// Verify the operation was actually created in the tree implied by the schedule-time flag.
-			s.assertNexusOperationTree(ctx, env, run.GetID(), !tc.enableChasmAtSchedule)
+			s.assertNexusOperationTree(ctx, env, &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: run.GetRunID()}, !tc.enableChasmAtSchedule)
 
 			env.OverrideDynamicConfig(chasmnexus.EnableChasmWorkflowOperations, !tc.enableChasmAtSchedule)
 			s.NoError(env.SdkClient().SignalWorkflow(ctx, run.GetID(), run.GetRunID(), "cancel", nil))
@@ -455,7 +455,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancellationBufferedCrossTree
 	s.NoError(startedHandle.Get(ctx, nil))
 
 	// The operation was scheduled with the flag off, so it must live in the HSM tree.
-	s.assertNexusOperationTree(ctx, env, run.GetID(), true)
+	s.assertNexusOperationTree(ctx, env, &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: run.GetRunID()}, true)
 
 	s.NoError(env.SdkClient().SignalWorkflow(ctx, run.GetID(), run.GetRunID(), "cancel", nil))
 
@@ -467,17 +467,17 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancellationBufferedCrossTree
 	s.RequireNoHistoryEvent(hist, enumspb.EVENT_TYPE_WORKFLOW_TASK_FAILED)
 }
 
-// assertNexusOperationTree asserts which tree the workflow's Nexus operation lives in, keyed by the operation's
-// scheduled event ID.
-func (s *NexusWorkflowTestSuite) assertNexusOperationTree(ctx context.Context, env *NexusTestEnv, workflowID string, expectHSM bool) {
+// assertNexusOperationTree asserts which tree the Nexus operation lives in for the given execution, keyed by
+// the operation's scheduled event ID. Leave the execution's RunId empty to target the current run.
+func (s *NexusWorkflowTestSuite) assertNexusOperationTree(ctx context.Context, env *NexusTestEnv, execution *commonpb.WorkflowExecution, expectHSM bool) {
 	s.T().Helper()
-	hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: workflowID})
+	hist := env.GetHistory(env.Namespace().String(), execution)
 	scheduledEvent := s.RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED)
 	opID := strconv.FormatInt(scheduledEvent.EventId, 10)
 
 	desc, err := env.AdminClient().DescribeMutableState(ctx, &adminservice.DescribeMutableStateRequest{
 		Namespace: env.Namespace().String(),
-		Execution: &commonpb.WorkflowExecution{WorkflowId: workflowID},
+		Execution: execution,
 		Archetype: chasm.WorkflowArchetype,
 	})
 	s.NoError(err)
@@ -3268,4 +3268,146 @@ func (s *NexusWorkflowTestSuite) mutateCompletionComponentRef(
 	var err error
 	token.ComponentRef, err = ref.Marshal()
 	s.NoError(err)
+}
+
+// TestNexusOperationSurvivesResetCrossTree verifies that when a workflow with a pending Nexus operation is
+// reset, the rebuild re-creates the operation on the tree implied by the current enableChasmWorkflowOperations flag
+// (HSM or CHASM), and the reset run replays without failing a workflow task. Rebuild deterministically picks the
+// framework by dynamic config, so flipping the flag before reset realigns the operation to the other tree.
+func (s *NexusWorkflowTestSuite) TestNexusOperationSurvivesResetCrossTree(chasmEnabled bool) {
+	// This test drives the creation-policy flag itself, so run it once (not per-suite-mode).
+	if chasmEnabled {
+		s.T().Skip("reset-reapply test controls the flag explicitly; run once via the HSM suite")
+	}
+
+	testCases := []struct {
+		name string
+		// enableChasmWorkflowOperations value at schedule time (true -> CHASM, false -> HSM).
+		enableChasmAtSchedule bool
+		// flip the flag before reset to exercise the realign-by-config behavior.
+		flipFlagBeforeReset bool
+	}{
+		{name: "ChasmOpStaysChasm", enableChasmAtSchedule: true, flipFlagBeforeReset: false},
+		{name: "HsmOpStaysHsm", enableChasmAtSchedule: false, flipFlagBeforeReset: false},
+		{name: "ChasmOpRealignsToHsmAfterDowngrade", enableChasmAtSchedule: true, flipFlagBeforeReset: true},
+		{name: "HsmOpRealignsToChasmAfterUpgrade", enableChasmAtSchedule: false, flipFlagBeforeReset: true},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func(s *NexusWorkflowTestSuite) {
+			env := s.newTestEnv(true)
+			ctx := s.Context()
+			taskQueue := testcore.RandomizeStr(s.T().Name())
+			env.OverrideDynamicConfig(chasmnexus.EnableChasmWorkflowOperations, tc.enableChasmAtSchedule)
+
+			h := nexustest.Handler{
+				OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
+					return &nexus.HandlerStartOperationResultAsync{OperationToken: "test"}, nil
+				},
+				OnCancelOperation: func(ctx context.Context, service, operation, token string, options nexus.CancelOperationOptions) error {
+					return nil
+				},
+			}
+			endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
+
+			const awaitStartedUpdate = "await-started"
+			callerWF := func(ctx workflow.Context) error {
+				started := false
+				if err := workflow.SetUpdateHandler(ctx, awaitStartedUpdate, func(ctx workflow.Context) error {
+					return workflow.Await(ctx, func() bool { return started })
+				}); err != nil {
+					return err
+				}
+				c := workflow.NewNexusClient(endpointName, "service")
+				fut := c.ExecuteOperation(ctx, "operation", "input", workflow.NexusOperationOptions{})
+				var exec workflow.NexusOperationExecution
+				if err := fut.GetNexusOperationExecution().Get(ctx, &exec); err != nil {
+					return err
+				}
+				started = true
+				workflow.GetSignalChannel(ctx, "done").Receive(ctx, nil)
+				return nil
+			}
+
+			w := worker.New(env.SdkClient(), taskQueue, worker.Options{})
+			w.RegisterWorkflow(callerWF)
+			s.NoError(w.Start())
+			defer w.Stop()
+
+			run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{TaskQueue: taskQueue}, callerWF)
+			s.NoError(err)
+
+			// Block until the Nexus operation has started.
+			startedHandle, err := env.SdkClient().UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
+				WorkflowID:   run.GetID(),
+				RunID:        run.GetRunID(),
+				UpdateName:   awaitStartedUpdate,
+				WaitForStage: client.WorkflowUpdateStageCompleted,
+			})
+			s.NoError(err)
+			s.NoError(startedHandle.Get(ctx, nil))
+
+			// The operation is created in the tree implied by the schedule-time flag, in the original run.
+			s.assertNexusOperationTree(ctx, env, &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: run.GetRunID()}, !tc.enableChasmAtSchedule)
+
+			expectHSMAfterReset := !tc.enableChasmAtSchedule
+			if tc.flipFlagBeforeReset {
+				env.OverrideDynamicConfig(chasmnexus.EnableChasmWorkflowOperations, !tc.enableChasmAtSchedule)
+				expectHSMAfterReset = tc.enableChasmAtSchedule
+			}
+
+			// Reset to the last completed workflow task; this rebuilds mutable state (including the Nexus op).
+			hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: run.GetRunID()})
+			var lastWFT *historypb.HistoryEvent
+			for _, e := range hist {
+				if e.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED {
+					lastWFT = e
+				}
+			}
+			s.NotNil(lastWFT)
+			resetResp, err := env.FrontendClient().ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
+				Namespace:                 env.Namespace().String(),
+				WorkflowExecution:         &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: run.GetRunID()},
+				Reason:                    "reset-reapply nexus operation test",
+				WorkflowTaskFinishEventId: lastWFT.GetEventId(),
+				RequestId:                 uuid.NewString(),
+			})
+			s.NoError(err)
+			newRunID := resetResp.GetRunId()
+
+			// After the rebuild the operation lives on the tree implied by the current flag, verified on the
+			// specific post-reset run.
+			s.assertNexusOperationTree(ctx, env, &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: newRunID}, expectHSMAfterReset)
+
+			// Drive the reset run to completion, then assert on its final history.
+			s.NoError(env.SdkClient().SignalWorkflow(ctx, run.GetID(), newRunID, "done", nil))
+			s.NoError(env.SdkClient().GetWorkflow(ctx, run.GetID(), newRunID).Get(ctx, nil))
+
+			// The reset run's full history is identical regardless of which tree holds the operation: the
+			// operation is reapplied (events 6-7, NexusOperationScheduled/Started) onto the rebuilt tree, the
+			// reset boundary is the synthetic WorkflowTaskFailed (event 10, Cause 20 = RESET_WORKFLOW), and the
+			// run then replays and completes cleanly.
+			newHist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: newRunID})
+			s.EqualHistoryEvents(`
+  1 WorkflowExecutionStarted
+  2 WorkflowTaskScheduled
+  3 WorkflowTaskStarted
+  4 WorkflowTaskCompleted
+  5 WorkflowExecutionUpdateAccepted
+  6 NexusOperationScheduled
+  7 NexusOperationStarted
+  8 WorkflowTaskScheduled
+  9 WorkflowTaskStarted
+ 10 WorkflowTaskFailed {"Cause":20}
+ 11 WorkflowTaskScheduled
+ 12 WorkflowTaskStarted
+ 13 WorkflowTaskCompleted
+ 14 WorkflowExecutionUpdateCompleted
+ 15 WorkflowExecutionSignaled
+ 16 WorkflowTaskScheduled
+ 17 WorkflowTaskStarted
+ 18 WorkflowTaskCompleted
+ 19 WorkflowExecutionCompleted`, newHist)
+		})
+	}
 }


### PR DESCRIPTION
## What changed?
During mutable-state **rebuild** (workflow reset, replication, conflict resolution), Nexus events were dispatched only through the HSM framework, so CHASM-backed operations were dropped on rebuild. This routes state rebuild to either tree, keyed on the cross-tree-stable `ScheduledEventId`.

- `workflow/mutable_state_rebuilder.go` — `applyStateMachineEvent` is now a generic **CHASM-first, HSM-fallback** dispatch: it tries CHASM and falls back to HSM when CHASM does not own the event (CHASM disabled, event type unknown to CHASM, or the operation is not in the CHASM tree — surfaced as a `NotFound`). Trying CHASM first keeps the rebuilder forward-compatible, since new event types are expected to be CHASM-backed. The create event (`NexusOperationScheduled`) is routed inside the CHASM path by the per-namespace `enableChasmWorkflowOperations` flag (on → create in CHASM, off → fall back to HSM). A genuine CHASM apply error is surfaced, never fallen back to HSM, to avoid split-brain state.
- Functional test (`tests/nexus_workflow_test.go`): resets a workflow with a pending Nexus operation and asserts it is rebuilt on the tree implied by the current flag (stays, or realigns when the flag is flipped), verified on the original and post-reset runs plus the full reset-run history.

## Why?
Without this, resetting or replicating a workflow with a CHASM-backed Nexus operation drops the operation on rebuild. Depends on #10986 for the `ShardContext.ChasmWorkflowRegistry()` accessor and CHASM-aware event reapply — the latter is required for async completion to remain correct once operations are routed to CHASM on rebuild (they are runtime-coupled, hence the stacking).

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

## Potential risks
- Rebuild mirrors the live creation policy (the `enableChasmWorkflowOperations` config) which is in disabled state so risk is minimal.