### PR TITLE
Gate archival task executor on namespace activeness

### DIFF
--- a/service/history/archival_queue_task_executor.go
+++ b/service/history/archival_queue_task_executor.go
@@ -7,11 +7,13 @@ import (
 	"time"
 
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
 	carchiver "go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/service/history/archival"
@@ -99,6 +101,27 @@ func (e *archivalQueueTaskExecutor) processArchiveExecutionTask(ctx context.Cont
 	if err != nil {
 		return err
 	}
+	// Archival tasks are local (not replicated), so a standby cluster must retry
+	// the task rather than drop it — otherwise the archive is permanently lost.
+	// NamespaceNotActive is treated as retryable by the queue
+	// (see queues.executable isExpectedRetryableError), so returning it here
+	// re-queues the task until this cluster becomes active.
+	currentClusterName := e.shardContext.GetClusterMetadata().GetCurrentClusterName()
+	nsEntry, nsErr := e.shardContext.GetNamespaceRegistry().GetNamespaceByID(namespace.ID(task.NamespaceID))
+	if nsErr == nil {
+		activeClusterName := nsEntry.ActiveClusterName(namespace.RoutingKey{ID: task.WorkflowID})
+		if activeClusterName != currentClusterName {
+			logger.Debug("Skipping archival on standby cluster; task will retry until active.",
+				tag.WorkflowNamespaceID(task.NamespaceID),
+				tag.WorkflowID(task.WorkflowID),
+				tag.ClusterName(currentClusterName),
+				tag.TargetCluster(activeClusterName),
+			)
+			return serviceerror.NewNamespaceNotActive(task.NamespaceID, currentClusterName, activeClusterName)
+		}
+	}
+	// If the namespace lookup failed, fall through and process as active so a
+	// registry hiccup never drops archival work.
 	if len(request.Targets) > 0 {
 		_, err = e.archiver.Archive(ctx, request)
 		if err != nil {

--- a/service/history/archival_queue_task_executor_test.go
+++ b/service/history/archival_queue_task_executor_test.go
@@ -124,6 +124,44 @@ func TestArchivalQueueTaskExecutor(t *testing.T) {
 			},
 		},
 		{
+			// INV-1: a standby cluster must retry, not drop, an archival task.
+			// Archival tasks are local (not replicated), so dropping loses the
+			// archive permanently. The executor returns NamespaceNotActive, which
+			// the queue treats as retryable (queues.executable
+			// isExpectedRetryableError -> Nack -> rescheduler.Add) and re-queues.
+			// Together with the "success" case (active -> archives), this also
+			// covers failover: the same task archives once the cluster is active.
+			Name: "namespace standby in cluster",
+			Configure: func(p *params) {
+				p.NamespaceActiveClusterName = cluster.TestAlternativeClusterName
+				p.ExpectArchive = false
+				p.ExpectAddTask = false
+				p.ExpectedNamespaceNotActive = true
+			},
+		},
+		{
+			// A local (non-global) namespace is always active in every cluster
+			// (replication_resolver ActiveInCluster returns true for non-global),
+			// so the activeness gate must be a no-op and archival proceeds.
+			Name: "local namespace archives regardless of cluster",
+			Configure: func(p *params) {
+				p.NamespaceEntryOverride = namespace.NewLocalNamespaceForTest(
+					&persistencespb.NamespaceInfo{
+						Id:   tests.NamespaceID.String(),
+						Name: tests.Namespace.String(),
+					},
+					&persistencespb.NamespaceConfig{
+						Retention:               p.Retention,
+						HistoryArchivalState:    enumspb.ArchivalState(carchiver.ArchivalEnabled),
+						HistoryArchivalUri:      p.HistoryURI,
+						VisibilityArchivalState: enumspb.ArchivalState(carchiver.ArchivalEnabled),
+						VisibilityArchivalUri:   p.VisibilityURI,
+					},
+					cluster.TestCurrentClusterName,
+				)
+			},
+		},
+		{
 			Name: "get namespace internal error",
 			Configure: func(p *params) {
 				p.GetNamespaceByIDError = serviceerror.NewInternal("get namespace error")
@@ -320,6 +358,7 @@ func TestArchivalQueueTaskExecutor(t *testing.T) {
 			p.ExpectAddTask = true
 			p.MetricsHandler = metrics.NewMockHandler(p.Controller)
 			p.MutableStateExists = true
+			p.NamespaceActiveClusterName = cluster.TestCurrentClusterName
 
 			c.Configure(&p)
 			namespaceRegistry := namespace.NewMockRegistry(p.Controller)
@@ -361,13 +400,17 @@ func TestArchivalQueueTaskExecutor(t *testing.T) {
 					VisibilityArchivalUri:   p.VisibilityURI,
 				},
 				&persistencespb.NamespaceReplicationConfig{
-					ActiveClusterName: cluster.TestCurrentClusterName,
+					ActiveClusterName: p.NamespaceActiveClusterName,
 					Clusters: []string{
 						cluster.TestCurrentClusterName,
+						cluster.TestAlternativeClusterName,
 					},
 				},
 				123,
 			)
+			if p.NamespaceEntryOverride != nil {
+				namespaceEntry = p.NamespaceEntryOverride
+			}
 			namespaceRegistry.EXPECT().GetNamespaceName(namespaceEntry.ID()).
 				Return(namespaceEntry.Name(), nil).AnyTimes()
 			namespaceRegistry.EXPECT().GetNamespaceByID(namespaceEntry.ID()).
@@ -523,7 +566,15 @@ func TestArchivalQueueTaskExecutor(t *testing.T) {
 				telemetry.NoopTracer,
 			)
 			err := executable.Execute()
-			if len(p.ExpectedErrorSubstrings) > 0 {
+			if p.ExpectedNamespaceNotActive {
+				// A non-nil NamespaceNotActive error is the retry-not-drop signal:
+				// the queue treats it as retryable (queues.executable
+				// isExpectedRetryableError) and re-queues the task, so the archive
+				// is not lost while the cluster is standby.
+				require.Error(t, err)
+				var nsNotActive *serviceerror.NamespaceNotActive
+				require.ErrorAs(t, err, &nsNotActive)
+			} else if len(p.ExpectedErrorSubstrings) > 0 {
 				require.Error(t, err)
 				for _, s := range p.ExpectedErrorSubstrings {
 					assert.ErrorContains(t, err, s)
@@ -579,6 +630,17 @@ type params struct {
 	GetCloseVersionBeforeArchivalError error
 	CloseVersionAfterArchival          int64
 	GetCloseVersionAfterArchivalError  error
+	// NamespaceActiveClusterName is the active cluster for the (global) namespace
+	// under test. Defaults to the current (test) cluster so existing cases are
+	// unaffected; set to cluster.TestAlternativeClusterName to make the namespace
+	// standby in the current cluster.
+	NamespaceActiveClusterName string
+	// NamespaceEntryOverride, when non-nil, replaces the default global namespace
+	// entry built from params (used to exercise local/non-global namespaces).
+	NamespaceEntryOverride *namespace.Namespace
+	// ExpectedNamespaceNotActive, when true, asserts the executor returns a
+	// *serviceerror.NamespaceNotActive (the standby-skip, retry-not-drop signal).
+	ExpectedNamespaceNotActive bool
 }
 
 // archivalConfig represents the user configuration of archival for the cluster and namespace


### PR DESCRIPTION
## What changed and why

Closes #10888.

The archival queue task executor archived a closed workflow's history and visibility records regardless of whether the local cluster was the **active** cluster for the namespace. In a multi-cluster (global namespace) deployment, a cluster that had gone standby could continue to push archival writes for a namespace whose workflows are now owned by another cluster.

This gates archival so only the active cluster performs the archive push. When the local cluster is standby for a workflow's namespace, the executor returns `serviceerror.NamespaceNotActive` **before** archiving or emitting the deletion follow-up task, and the queue retries the task until failover makes the cluster active.

### No lost archival tasks (the key invariant)

Archival tasks are **local** (not replicated): they are generated at workflow-close time on the closing cluster and do not appear in `service/history/replication/` or `service/history/ndc/`; the archival queue is not wrapped in `queues.NewActiveStandbyExecutor`. Therefore a standby cluster must **retry**, not drop, the task — otherwise the archive is permanently lost.

`serviceerror.NamespaceNotActive` is already classified as a retryable error by the queue (`queues.executable` `isExpectedRetryableError` → `Nack` → `rescheduler.Add`), so the task is re-queued, not ACKed/deleted. The task survives until the cluster becomes active via failover, at which point archival proceeds exactly as today.

### Design choices

- **Gate location**: inside `processArchiveExecutionTask`, after `getArchiveTaskRequest` (which runs `CheckTaskVersion`) and before `e.archiver.Archive`. This keeps the gate strictly pre-effect (no partial state) and composes with — does not mask — the existing version gate (a version mismatch returns first and is dropped as before).
- **API**: `ns.ActiveClusterName(namespace.RoutingKey{ID: task.WorkflowID})`, the doc-comment-recommended per-workflow API (`common/namespace/namespace.go:256-257`), mirroring the queue infrastructure's existing activeness tagging (`queues.executable.go` `taskBaseMetricTagsWithoutArchetype`) and the canonical active/standby router (`queues.active_standby_executor.go`).
- **Registry error**: if the namespace lookup fails, the gate falls through to the active path so a registry hiccup never drops archival work (consistent with `active_standby_executor.go` / `scheduler.go`).
- **`ExecutedAsActive`** stays `true` — there is no separate standby archival executor, so the activeness-flip branch in `executable.go` is not involved; failover is handled purely by the `NamespaceNotActive` retry loop.

## Behavior change for multi-cluster deployments (intentional)

Standby clusters will stop pushing archival writes and retry the tasks until they become active. This is the behavior requested in the issue. History archival is idempotent (per-blob existence checks; visibility overwrites), and primary storage is not deleted until the active path succeeds after a successful archive, so no data is lost while a task waits on a standby cluster.

Single-cluster, local (non-global) namespace, and active-cluster behavior is unchanged.

## Out of scope

- Not wrapping archival in `NewActiveStandbyExecutor` / not authoring a standby archival executor (archival is single-path; a full active/standby split would be disproportionate scaffolding).
- Not replicating archival tasks (the retry-until-active mechanism handles failover without replication).
- Not adding a per-record visibility existence check — a separable concern that touches three archiver backends and risks the "overwrite is safe" assumption for mutable visibility records; warrants its own issue/PR.

## Test plan

- [x] New `namespace standby in cluster` case: asserts the executor returns `*serviceerror.NamespaceNotActive`, does **not** call `Archive`, and does **not** call `AddTasks` (the no-lost-task proof at the executor boundary). Mutation-confirmed: removing the gate makes this test fail.
- [x] New `local namespace archives regardless of cluster` case: local (non-global) namespaces are always active, so the gate is a no-op and archival proceeds.
- [x] Existing cases preserved: `success` (active → archives), `namespace not found` (registry error → falls through to active), `mutable state version does not match task version` (version mismatch still drops; the activeness gate runs after `CheckTaskVersion` and does not mask it).
- [x] `go test -tags test_dep ./service/history/... ./service/history/queues/...` green.
- [x] `make lint-code` — no new issues in changed files.