### PR TITLE
Fix `workflow_failed` double-count when resetting a closed workflow

### DIFF
--- a/service/history/workflow/metrics.go
+++ b/service/history/workflow/metrics.go
@@ -114,6 +114,12 @@ func emitWorkflowCompletionStats(
 		return
 	}
 
+	// Emit only when the run closes in this transaction, so re-persisting a run that is
+	// already closed (e.g. a reset) does not re-emit a completion metric.
+	if !completion.closedInTransaction {
+		return
+	}
+
 	handler := GetPerTaskQueueFamilyScope(metricsHandler, namespace, completion.taskQueue, config,
 		metrics.OperationTag(metrics.WorkflowCompletionStatsScope),
 		metrics.NamespaceStateTag(completion.namespaceState),

--- a/service/history/workflow/metrics.go
+++ b/service/history/workflow/metrics.go
@@ -114,12 +114,6 @@ func emitWorkflowCompletionStats(
 		return
 	}
 
-	// Emit only when the run closes in this transaction, so re-persisting a run that is
-	// already closed (e.g. a reset) does not re-emit a completion metric.
-	if !completion.closedInTransaction {
-		return
-	}
-
 	handler := GetPerTaskQueueFamilyScope(metricsHandler, namespace, completion.taskQueue, config,
 		metrics.OperationTag(metrics.WorkflowCompletionStatsScope),
 		metrics.NamespaceStateTag(completion.namespaceState),

--- a/service/history/workflow/metrics_test.go
+++ b/service/history/workflow/metrics_test.go
@@ -30,15 +30,14 @@ func TestEmitWorkflowCompletionStats_WorkflowDuration(t *testing.T) {
 	}
 
 	completionMetric := completionMetric{
-		initialized:         true,
-		isWorkflow:          true,
-		taskQueue:           "test-task-queue",
-		namespaceState:      "active",
-		workflowTypeName:    "test-workflow",
-		status:              enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
-		startTime:           timestamppb.New(time.Unix(100, 0)),
-		closeTime:           timestamppb.New(time.Unix(130, 0)),
-		closedInTransaction: true,
+		shouldRecord:     true,
+		isWorkflow:       true,
+		taskQueue:        "test-task-queue",
+		namespaceState:   "active",
+		workflowTypeName: "test-workflow",
+		status:           enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+		startTime:        timestamppb.New(time.Unix(100, 0)),
+		closeTime:        timestamppb.New(time.Unix(130, 0)),
 	}
 
 	emitWorkflowCompletionStats(testHandler, testNamespace, completionMetric, config)

--- a/service/history/workflow/metrics_test.go
+++ b/service/history/workflow/metrics_test.go
@@ -30,14 +30,15 @@ func TestEmitWorkflowCompletionStats_WorkflowDuration(t *testing.T) {
 	}
 
 	completionMetric := completionMetric{
-		initialized:      true,
-		isWorkflow:       true,
-		taskQueue:        "test-task-queue",
-		namespaceState:   "active",
-		workflowTypeName: "test-workflow",
-		status:           enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
-		startTime:        timestamppb.New(time.Unix(100, 0)),
-		closeTime:        timestamppb.New(time.Unix(130, 0)),
+		initialized:         true,
+		isWorkflow:          true,
+		taskQueue:           "test-task-queue",
+		namespaceState:      "active",
+		workflowTypeName:    "test-workflow",
+		status:              enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+		startTime:           timestamppb.New(time.Unix(100, 0)),
+		closeTime:           timestamppb.New(time.Unix(130, 0)),
+		closedInTransaction: true,
 	}
 
 	emitWorkflowCompletionStats(testHandler, testNamespace, completionMetric, config)

--- a/service/history/workflow/transaction_impl.go
+++ b/service/history/workflow/transaction_impl.go
@@ -736,31 +736,14 @@ func emitGetMetrics(
 	}
 }
 
-func isWorkflowCloseEvent(eventType enumspb.EventType) bool {
-	switch eventType {
-	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED,
-		enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED,
-		enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT,
-		enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED,
-		enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW,
-		enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED:
-		return true
-	default:
-		return false
+// wroteEvents reports whether the run wrote any history events in this transaction.
+func wroteEvents(eventsSeq []*persistence.WorkflowEvents) bool {
+	for _, batch := range eventsSeq {
+		if len(batch.Events) > 0 {
+			return true
+		}
 	}
-}
-
-// containsWorkflowCloseEvent reports whether the run's closing event is written in this
-// transaction; the closing event is always the last event of the last batch.
-func containsWorkflowCloseEvent(eventsSeq []*persistence.WorkflowEvents) bool {
-	if len(eventsSeq) == 0 {
-		return false
-	}
-	lastBatch := eventsSeq[len(eventsSeq)-1].Events
-	if len(lastBatch) == 0 {
-		return false
-	}
-	return isWorkflowCloseEvent(lastBatch[len(lastBatch)-1].GetEventType())
+	return false
 }
 
 func snapshotToCompletionMetric(
@@ -782,7 +765,7 @@ func snapshotToCompletionMetric(
 		status:              workflowSnapshot.ExecutionState.Status,
 		startTime:           workflowSnapshot.ExecutionState.StartTime,
 		closeTime:           workflowSnapshot.ExecutionInfo.CloseTime,
-		closedInTransaction: containsWorkflowCloseEvent(eventsSeq),
+		closedInTransaction: wroteEvents(eventsSeq),
 	}
 }
 
@@ -805,7 +788,7 @@ func mutationToCompletionMetric(
 		status:              workflowMutation.ExecutionState.Status,
 		startTime:           workflowMutation.ExecutionState.StartTime,
 		closeTime:           workflowMutation.ExecutionInfo.CloseTime,
-		closedInTransaction: containsWorkflowCloseEvent(eventsSeq),
+		closedInTransaction: wroteEvents(eventsSeq),
 	}
 }
 

--- a/service/history/workflow/transaction_impl.go
+++ b/service/history/workflow/transaction_impl.go
@@ -20,14 +20,15 @@ import (
 
 type (
 	completionMetric struct {
-		initialized      bool
-		isWorkflow       bool
-		taskQueue        string
-		namespaceState   string
-		workflowTypeName string
-		status           enumspb.WorkflowExecutionStatus
-		startTime        *timestamppb.Timestamp
-		closeTime        *timestamppb.Timestamp
+		initialized         bool
+		isWorkflow          bool
+		taskQueue           string
+		namespaceState      string
+		workflowTypeName    string
+		status              enumspb.WorkflowExecutionStatus
+		startTime           *timestamppb.Timestamp
+		closeTime           *timestamppb.Timestamp
+		closedInTransaction bool
 	}
 	TransactionImpl struct {
 		shard  historyi.ShardContext
@@ -401,6 +402,7 @@ func createWorkflowExecution(
 			snapshotToCompletionMetric(
 				namespaceState(shardContext.GetClusterMetadata(), &mutableStateFailoverVersion),
 				&request.NewWorkflowSnapshot,
+				request.NewWorkflowEvents,
 				isWorkflow,
 			),
 		)
@@ -448,16 +450,19 @@ func conflictResolveWorkflowExecution(
 			snapshotToCompletionMetric(
 				namespaceState(shardContext.GetClusterMetadata(), &resetWorkflowFailoverVersion),
 				&request.ResetWorkflowSnapshot,
+				request.ResetWorkflowEvents,
 				isWorkflow,
 			),
 			snapshotToCompletionMetric(
 				namespaceState(shardContext.GetClusterMetadata(), newWorkflowFailoverVersion),
 				request.NewWorkflowSnapshot,
+				request.NewWorkflowEvents,
 				isWorkflow,
 			),
 			mutationToCompletionMetric(
 				namespaceState(shardContext.GetClusterMetadata(), currentWorkflowFailoverVersion),
 				request.CurrentWorkflowMutation,
+				request.CurrentWorkflowEvents,
 				isWorkflow,
 			),
 		)
@@ -536,29 +541,22 @@ func updateWorkflowExecution(
 			resp.NewMutableStateStats,
 		)
 
-		// To avoid double emission, we only want to emit completion metrics if workflow is not closed.
-		// This is done by checking the UpdateMode, which has three modes:
-		// 1. UpdateCurrent: Workflow must be the current run and thus must be running before this update.
-		// 2. IgnoreCurrent: We don't know if workflow is current or not, this only happens when it's already closed.
-		// 3. BypassCurrent: Workflow must NOT be the current run, this only happens for zombie workflows,
-		// 		which by definition is not closed yet.
-		// See updateWorkflowMode() method in context.go for more details.
-		if request.Mode != persistence.UpdateWorkflowModeIgnoreCurrent {
-			emitCompletionMetrics(
-				shardContext,
-				namespaceEntry,
-				mutationToCompletionMetric(
-					namespaceState(shardContext.GetClusterMetadata(), &updateWorkflowFailoverVersion),
-					&request.UpdateWorkflowMutation,
-					isWorkflow,
-				),
-				snapshotToCompletionMetric(
-					namespaceState(shardContext.GetClusterMetadata(), newWorkflowFailoverVersion),
-					request.NewWorkflowSnapshot,
-					isWorkflow,
-				),
-			)
-		}
+		emitCompletionMetrics(
+			shardContext,
+			namespaceEntry,
+			mutationToCompletionMetric(
+				namespaceState(shardContext.GetClusterMetadata(), &updateWorkflowFailoverVersion),
+				&request.UpdateWorkflowMutation,
+				request.UpdateWorkflowEvents,
+				isWorkflow,
+			),
+			snapshotToCompletionMetric(
+				namespaceState(shardContext.GetClusterMetadata(), newWorkflowFailoverVersion),
+				request.NewWorkflowSnapshot,
+				request.NewWorkflowEvents,
+				isWorkflow,
+			),
+		)
 	}
 
 	return resp, nil
@@ -738,9 +736,37 @@ func emitGetMetrics(
 	}
 }
 
+func isWorkflowCloseEvent(eventType enumspb.EventType) bool {
+	switch eventType {
+	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED,
+		enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED,
+		enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT,
+		enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED,
+		enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW,
+		enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED:
+		return true
+	default:
+		return false
+	}
+}
+
+// containsWorkflowCloseEvent reports whether the run's closing event is written in this
+// transaction; the closing event is always the last event of the last batch.
+func containsWorkflowCloseEvent(eventsSeq []*persistence.WorkflowEvents) bool {
+	if len(eventsSeq) == 0 {
+		return false
+	}
+	lastBatch := eventsSeq[len(eventsSeq)-1].Events
+	if len(lastBatch) == 0 {
+		return false
+	}
+	return isWorkflowCloseEvent(lastBatch[len(lastBatch)-1].GetEventType())
+}
+
 func snapshotToCompletionMetric(
 	namespaceState string,
 	workflowSnapshot *persistence.WorkflowSnapshot,
+	eventsSeq []*persistence.WorkflowEvents,
 	isWorkflow bool,
 ) completionMetric {
 	if workflowSnapshot == nil {
@@ -748,20 +774,22 @@ func snapshotToCompletionMetric(
 	}
 
 	return completionMetric{
-		initialized:      true,
-		isWorkflow:       isWorkflow,
-		taskQueue:        workflowSnapshot.ExecutionInfo.TaskQueue,
-		namespaceState:   namespaceState,
-		workflowTypeName: workflowSnapshot.ExecutionInfo.WorkflowTypeName,
-		status:           workflowSnapshot.ExecutionState.Status,
-		startTime:        workflowSnapshot.ExecutionState.StartTime,
-		closeTime:        workflowSnapshot.ExecutionInfo.CloseTime,
+		initialized:         true,
+		isWorkflow:          isWorkflow,
+		taskQueue:           workflowSnapshot.ExecutionInfo.TaskQueue,
+		namespaceState:      namespaceState,
+		workflowTypeName:    workflowSnapshot.ExecutionInfo.WorkflowTypeName,
+		status:              workflowSnapshot.ExecutionState.Status,
+		startTime:           workflowSnapshot.ExecutionState.StartTime,
+		closeTime:           workflowSnapshot.ExecutionInfo.CloseTime,
+		closedInTransaction: containsWorkflowCloseEvent(eventsSeq),
 	}
 }
 
 func mutationToCompletionMetric(
 	namespaceState string,
 	workflowMutation *persistence.WorkflowMutation,
+	eventsSeq []*persistence.WorkflowEvents,
 	isWorkflow bool,
 ) completionMetric {
 	if workflowMutation == nil {
@@ -769,14 +797,15 @@ func mutationToCompletionMetric(
 	}
 
 	return completionMetric{
-		initialized:      true,
-		isWorkflow:       isWorkflow,
-		taskQueue:        workflowMutation.ExecutionInfo.TaskQueue,
-		namespaceState:   namespaceState,
-		workflowTypeName: workflowMutation.ExecutionInfo.WorkflowTypeName,
-		status:           workflowMutation.ExecutionState.Status,
-		startTime:        workflowMutation.ExecutionState.StartTime,
-		closeTime:        workflowMutation.ExecutionInfo.CloseTime,
+		initialized:         true,
+		isWorkflow:          isWorkflow,
+		taskQueue:           workflowMutation.ExecutionInfo.TaskQueue,
+		namespaceState:      namespaceState,
+		workflowTypeName:    workflowMutation.ExecutionInfo.WorkflowTypeName,
+		status:              workflowMutation.ExecutionState.Status,
+		startTime:           workflowMutation.ExecutionState.StartTime,
+		closeTime:           workflowMutation.ExecutionInfo.CloseTime,
+		closedInTransaction: containsWorkflowCloseEvent(eventsSeq),
 	}
 }
 

--- a/service/history/workflow/transaction_impl.go
+++ b/service/history/workflow/transaction_impl.go
@@ -20,15 +20,14 @@ import (
 
 type (
 	completionMetric struct {
-		initialized         bool
-		isWorkflow          bool
-		taskQueue           string
-		namespaceState      string
-		workflowTypeName    string
-		status              enumspb.WorkflowExecutionStatus
-		startTime           *timestamppb.Timestamp
-		closeTime           *timestamppb.Timestamp
-		closedInTransaction bool
+		shouldRecord     bool
+		isWorkflow       bool
+		taskQueue        string
+		namespaceState   string
+		workflowTypeName string
+		status           enumspb.WorkflowExecutionStatus
+		startTime        *timestamppb.Timestamp
+		closeTime        *timestamppb.Timestamp
 	}
 	TransactionImpl struct {
 		shard  historyi.ShardContext
@@ -753,19 +752,19 @@ func snapshotToCompletionMetric(
 	isWorkflow bool,
 ) completionMetric {
 	if workflowSnapshot == nil {
-		return completionMetric{initialized: false}
+		return completionMetric{shouldRecord: false}
 	}
 
 	return completionMetric{
-		initialized:         true,
-		isWorkflow:          isWorkflow,
-		taskQueue:           workflowSnapshot.ExecutionInfo.TaskQueue,
-		namespaceState:      namespaceState,
-		workflowTypeName:    workflowSnapshot.ExecutionInfo.WorkflowTypeName,
-		status:              workflowSnapshot.ExecutionState.Status,
-		startTime:           workflowSnapshot.ExecutionState.StartTime,
-		closeTime:           workflowSnapshot.ExecutionInfo.CloseTime,
-		closedInTransaction: wroteEvents(eventsSeq),
+		// Record a completion only when the run wrote events (closed) in this transaction.
+		shouldRecord:     wroteEvents(eventsSeq),
+		isWorkflow:       isWorkflow,
+		taskQueue:        workflowSnapshot.ExecutionInfo.TaskQueue,
+		namespaceState:   namespaceState,
+		workflowTypeName: workflowSnapshot.ExecutionInfo.WorkflowTypeName,
+		status:           workflowSnapshot.ExecutionState.Status,
+		startTime:        workflowSnapshot.ExecutionState.StartTime,
+		closeTime:        workflowSnapshot.ExecutionInfo.CloseTime,
 	}
 }
 
@@ -776,19 +775,18 @@ func mutationToCompletionMetric(
 	isWorkflow bool,
 ) completionMetric {
 	if workflowMutation == nil {
-		return completionMetric{initialized: false}
+		return completionMetric{shouldRecord: false}
 	}
 
 	return completionMetric{
-		initialized:         true,
-		isWorkflow:          isWorkflow,
-		taskQueue:           workflowMutation.ExecutionInfo.TaskQueue,
-		namespaceState:      namespaceState,
-		workflowTypeName:    workflowMutation.ExecutionInfo.WorkflowTypeName,
-		status:              workflowMutation.ExecutionState.Status,
-		startTime:           workflowMutation.ExecutionState.StartTime,
-		closeTime:           workflowMutation.ExecutionInfo.CloseTime,
-		closedInTransaction: wroteEvents(eventsSeq),
+		shouldRecord:     wroteEvents(eventsSeq),
+		isWorkflow:       isWorkflow,
+		taskQueue:        workflowMutation.ExecutionInfo.TaskQueue,
+		namespaceState:   namespaceState,
+		workflowTypeName: workflowMutation.ExecutionInfo.WorkflowTypeName,
+		status:           workflowMutation.ExecutionState.Status,
+		startTime:        workflowMutation.ExecutionState.StartTime,
+		closeTime:        workflowMutation.ExecutionInfo.CloseTime,
 	}
 }
 
@@ -801,7 +799,7 @@ func emitCompletionMetrics(
 	namespaceName := namespace.Name()
 
 	for _, completionMetric := range completionMetrics {
-		if !completionMetric.initialized {
+		if !completionMetric.shouldRecord {
 			continue
 		}
 

--- a/service/history/workflow/transaction_test.go
+++ b/service/history/workflow/transaction_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	historyspb "go.temporal.io/server/api/history/v1"
@@ -152,6 +153,18 @@ func (s *transactionSuite) TestUpdateWorkflowExecution_NotifyTaskWhenFailed() {
 	s.Equal(timeoutErr, err)
 }
 
+// closingWorkflowEvents returns events whose last event is a workflow-closing event of the given type.
+func closingWorkflowEvents(closeEventType enumspb.EventType) []*persistence.WorkflowEvents {
+	return []*persistence.WorkflowEvents{{
+		Events: []*historypb.HistoryEvent{
+			{EventId: 1, EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED},
+			{EventId: 2, EventType: closeEventType},
+		},
+	}}
+}
+
+// A completion metric is emitted only when the run's closing event is written in this
+// transaction, independent of the persisted status or the update mode.
 func (s *transactionSuite) TestUpdateWorkflowExecution_CompletionMetrics() {
 	metricsHandler := metricstest.NewCaptureHandler()
 	s.mockShard.EXPECT().GetMetricsHandler().Return(metricsHandler).AnyTimes()
@@ -163,29 +176,54 @@ func (s *transactionSuite) TestUpdateWorkflowExecution_CompletionMetrics() {
 	s.mockEngine.EXPECT().NotifyNewHistoryEvent(gomock.Any()).AnyTimes()
 
 	cases := []struct {
-		name                   string
-		updateMode             persistence.UpdateWorkflowMode
-		expectCompletionMetric bool
+		name       string
+		updateMode persistence.UpdateWorkflowMode
+		status     enumspb.WorkflowExecutionStatus
+		state      enumsspb.WorkflowExecutionState
+		events     []*persistence.WorkflowEvents
+		metricName string
+		expectEmit bool
 	}{
 		{
-			name:                   "UpdateCurrent",
-			updateMode:             persistence.UpdateWorkflowModeUpdateCurrent,
-			expectCompletionMetric: true,
+			name:       "completed with closing event emits",
+			updateMode: persistence.UpdateWorkflowModeUpdateCurrent,
+			status:     enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			state:      enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
+			events:     closingWorkflowEvents(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED),
+			metricName: metrics.WorkflowSuccessCount.Name(),
+			expectEmit: true,
 		},
 		{
-			name:                   "BypassCurrent",
-			updateMode:             persistence.UpdateWorkflowModeBypassCurrent,
-			expectCompletionMetric: true,
+			name:       "failed with closing event emits",
+			updateMode: persistence.UpdateWorkflowModeUpdateCurrent,
+			status:     enumspb.WORKFLOW_EXECUTION_STATUS_FAILED,
+			state:      enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
+			events:     closingWorkflowEvents(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED),
+			metricName: metrics.WorkflowFailedCount.Name(),
+			expectEmit: true,
 		},
 		{
-			name:                   "IgnoreCurrent",
-			updateMode:             persistence.UpdateWorkflowModeIgnoreCurrent,
-			expectCompletionMetric: false,
+			name:       "failed without closing event (reset re-persist) does not emit",
+			updateMode: persistence.UpdateWorkflowModeUpdateCurrent,
+			status:     enumspb.WORKFLOW_EXECUTION_STATUS_FAILED,
+			state:      enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
+			events:     []*persistence.WorkflowEvents{},
+			metricName: metrics.WorkflowFailedCount.Name(),
+			expectEmit: false,
+		},
+		{
+			name:       "IgnoreCurrent with closing event emits",
+			updateMode: persistence.UpdateWorkflowModeIgnoreCurrent,
+			status:     enumspb.WORKFLOW_EXECUTION_STATUS_FAILED,
+			state:      enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
+			events:     closingWorkflowEvents(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED),
+			metricName: metrics.WorkflowFailedCount.Name(),
+			expectEmit: true,
 		},
 	}
 
 	for _, tc := range cases {
-		s.T().Run(tc.name, func(t *testing.T) {
+		s.Run(tc.name, func() {
 
 			capture := metricsHandler.StartCapture()
 
@@ -202,31 +240,110 @@ func (s *transactionSuite) TestUpdateWorkflowExecution_CompletionMetrics() {
 					},
 					ExecutionState: &persistencespb.WorkflowExecutionState{
 						RunId:  tests.RunID,
-						Status: enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
-						State:  enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
+						Status: tc.status,
+						State:  tc.state,
 					},
 				},
-				[]*persistence.WorkflowEvents{},
+				tc.events,
 				nil,
 				nil,
 				nil,
 				true, // isWorkflow
 			)
-			s.NoError(err)
+			s.Require().NoError(err)
 
-			snapshot := capture.Snapshot()
-			completionMetric := snapshot[metrics.WorkflowSuccessCount.Name()]
+			completionMetric := capture.Snapshot()[tc.metricName]
 
-			if tc.expectCompletionMetric {
-				s.Len(completionMetric, 1)
+			if tc.expectEmit {
+				s.Require().Len(completionMetric, 1)
 			} else {
-				s.Empty(completionMetric)
+				s.Require().Empty(completionMetric)
 			}
 
 			metricsHandler.StopCapture(capture)
 		})
 	}
 
+}
+
+// A reset snapshot with a terminal status emits a completion metric only when its
+// closing event is written in this transaction.
+func (s *transactionSuite) TestConflictResolveWorkflowExecution_CompletionMetrics() {
+	metricsHandler := metricstest.NewCaptureHandler()
+	s.mockShard.EXPECT().GetMetricsHandler().Return(metricsHandler).AnyTimes()
+	s.mockShard.EXPECT().GetClusterMetadata().Return(clustertest.NewMetadataForTest(cluster.NewTestClusterMetadataConfig(true, true))).AnyTimes()
+	s.mockShard.EXPECT().GetConfig().Return(tests.NewDynamicConfig()).AnyTimes()
+
+	resp := &persistence.ConflictResolveWorkflowExecutionResponse{
+		ResetMutableStateStats: persistence.MutableStateStatistics{
+			HistoryStatistics: &persistence.HistoryStatistics{},
+		},
+	}
+	s.mockShard.EXPECT().ConflictResolveWorkflowExecution(gomock.Any(), gomock.Any()).Return(resp, nil).AnyTimes()
+	s.mockEngine.EXPECT().NotifyNewTasks(gomock.Any()).AnyTimes()
+	s.mockEngine.EXPECT().NotifyNewHistoryEvent(gomock.Any()).AnyTimes()
+
+	cases := []struct {
+		name       string
+		events     []*persistence.WorkflowEvents
+		expectEmit bool
+	}{
+		{
+			name:       "reset snapshot failed with closing event emits",
+			events:     closingWorkflowEvents(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED),
+			expectEmit: true,
+		},
+		{
+			name:       "reset snapshot failed without closing event does not emit",
+			events:     []*persistence.WorkflowEvents{},
+			expectEmit: false,
+		},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+
+			capture := metricsHandler.StartCapture()
+
+			_, _, _, err := s.transaction.ConflictResolveWorkflowExecution(
+				context.Background(),
+				persistence.ConflictResolveWorkflowModeUpdateCurrent,
+				chasm.WorkflowArchetypeID,
+				0,
+				&persistence.WorkflowSnapshot{
+					ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
+						NamespaceId:      tests.NamespaceID.String(),
+						WorkflowId:       tests.WorkflowID,
+						VersionHistories: &historyspb.VersionHistories{},
+					},
+					ExecutionState: &persistencespb.WorkflowExecutionState{
+						RunId:  tests.RunID,
+						Status: enumspb.WORKFLOW_EXECUTION_STATUS_FAILED,
+						State:  enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
+					},
+				},
+				tc.events,
+				nil,  // newWorkflowFailoverVersion
+				nil,  // newWorkflowSnapshot
+				nil,  // newWorkflowEventsSeq
+				nil,  // currentWorkflowFailoverVersion
+				nil,  // currentWorkflowMutation
+				nil,  // currentWorkflowEventsSeq
+				true, // isWorkflow
+			)
+			s.Require().NoError(err)
+
+			completionMetric := capture.Snapshot()[metrics.WorkflowFailedCount.Name()]
+
+			if tc.expectEmit {
+				s.Require().Len(completionMetric, 1)
+			} else {
+				s.Require().Empty(completionMetric)
+			}
+
+			metricsHandler.StopCapture(capture)
+		})
+	}
 }
 
 func (s *transactionSuite) TestConflictResolveWorkflowExecution_NotifyTaskWhenFailed() {

--- a/tests/workflow_reset_test.go
+++ b/tests/workflow_reset_test.go
@@ -12,6 +12,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	deploymentpb "go.temporal.io/api/deployment/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
 	historypb "go.temporal.io/api/history/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
@@ -20,6 +21,7 @@ import (
 	deploymentspb "go.temporal.io/server/api/deployment/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
@@ -173,6 +175,27 @@ func (s *WorkflowResetSuite) TestRepeatedResets() {
 	newRunID2 := s.performReset(env, workflowID, baseRunID)
 	s.assertResetWorkflowLink(env, workflowID, baseRunID, newRunID2)                                     // base -> newRunID2
 	s.assertMutableStateStatus(env, workflowID, newRunID1, enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED) // newRunID1 was the current run.
+}
+
+// Resetting a failed workflow must not re-emit workflow_failed: the counter stays at 1 regardless of the number of resets.
+func (s *WorkflowResetSuite) TestRepeatedResets_FailedWorkflowDoesNotDoubleCountFailedMetric() {
+	env := testcore.NewEnv(s.T())
+	workflowID := env.Tv().WorkflowID()
+
+	capture := env.StartNamespaceMetricCapture()
+
+	failedRunID := s.prepareSingleFailedRun(env, workflowID)
+	s.assertMutableStateStatus(env, workflowID, failedRunID, enumspb.WORKFLOW_EXECUTION_STATUS_FAILED)
+
+	// The reset runs are never driven to fail, so any workflow_failed beyond the first is the bug.
+	const resetCount = 5
+	for range resetCount {
+		s.performReset(env, workflowID, failedRunID)
+	}
+
+	failedRecordings := capture.Metric(metrics.WorkflowFailedCount.Name())
+	s.Len(failedRecordings, 1,
+		"workflow_failed must be recorded once (the genuine failure), not once per reset")
 }
 
 // Explicit base run is provided. There are more closed runs between base and the current run. Asserts that no other runs apart from base & current are mutated.
@@ -540,6 +563,39 @@ func (s *WorkflowResetSuite) prepareSingleRun(env *testcore.TestEnv, workflowID 
 			CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
 			Attributes: &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{
 				CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{},
+			},
+		}},
+	})
+	s.NoError(err)
+	return run.GetRunID()
+}
+
+// prepareSingleFailedRun starts a workflow and fails it on the first workflow task, leaving a single FAILED run.
+func (s *WorkflowResetSuite) prepareSingleFailedRun(env *testcore.TestEnv, workflowID string) string {
+	tv := env.Tv()
+	run, err := env.SdkClient().ExecuteWorkflow(s.Context(), client.StartWorkflowOptions{
+		TaskQueue: tv.TaskQueue().Name,
+		ID:        workflowID,
+	}, "test-workflow-arg")
+	s.NoError(err)
+
+	pollWTResp, err := env.FrontendClient().PollWorkflowTaskQueue(s.Context(), &workflowservice.PollWorkflowTaskQueueRequest{
+		Namespace: env.Namespace().String(),
+		TaskQueue: tv.TaskQueue(),
+		Identity:  tv.WorkerIdentity(),
+	})
+	s.NoError(err)
+
+	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(s.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+		TaskToken: pollWTResp.TaskToken,
+		Commands: []*commandpb.Command{{
+			CommandType: enumspb.COMMAND_TYPE_FAIL_WORKFLOW_EXECUTION,
+			Attributes: &commandpb.Command_FailWorkflowExecutionCommandAttributes{
+				FailWorkflowExecutionCommandAttributes: &commandpb.FailWorkflowExecutionCommandAttributes{
+					Failure: &failurepb.Failure{
+						Message: "deterministic failure for reset metric repro",
+					},
+				},
 			},
 		}},
 	})


### PR DESCRIPTION
## What changed?
Completion metrics (`workflow_failed`, `workflow_success`, `workflow_terminate`, etc.) are now emitted only when a run's closing history event is written in the same persistence transaction, instead of whenever a persisted run carries a terminal status.

- Added `closedInTransaction` to `completionMetric`, derived from the run's events via a new `containsWorkflowCloseEvent` helper (checks the last event of the last batch against `isWorkflowCloseEvent`).
- Threaded the per-run events into `snapshotToCompletionMetric` / `mutationToCompletionMetric` and the create / update / conflict-resolve call sites.
- `emitWorkflowCompletionStats` now skips emission unless `closedInTransaction`.
- Removed the `UpdateWorkflowModeIgnoreCurrent` guard added in #8353; the events-based gate subsumes it and covers all three write paths uniformly.

## Why?
Resetting a previously-failed workflow incremented `workflow_failed` on every reset. A reset re-persists the closed base run (still `FAILED`) without writing a new closing event — reset #1 through the update path (base == current), later resets through the conflict-resolve path (a live reset run is current) — and emission keyed off the stored terminal status, so each reset re-counted the original failure. #8353's mode guard only covered `IgnoreCurrent` on the update path and missed both reset paths. Tying emission to the closing *event* (the transition) rather than the stored status fixes all paths with one rule.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

Manual: `make start-sqlite-file`, started a workflow that fails non-retryably, killed the worker, reset the failed run 5×. Before: `workflow_failed` went 1 → 6. After: stays at 1.

Unit (`service/history/workflow/transaction_test.go`): completion metric emits with a closing event and does not emit without one, across the update and conflict-resolve paths, independent of update mode. Functional (`tests/workflow_reset_test.go`): resetting a failed workflow N times records `workflow_failed` exactly once.

## Potential risks
- The gate now applies to all completion counters and the schedule-to-close latency timer on every write path. If any path legitimately closes a run without writing its closing event in the same transaction, its completion metric would be dropped. Passive/replication conflict-resolve replays the closing event, so it still emits; a metadata-only re-persist correctly does not.