### PR TITLE
Gate archival task executor on active cluster

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2437,6 +2437,13 @@ archivalQueueProcessor`,
 		2,
 		`ArchivalQueueMaxReaderCount is the max number of readers in one multi-cursor archival queue`,
 	)
+	ArchivalQueueArchiveOnlyOnActiveCluster = NewNamespaceBoolSetting(
+		"history.archivalQueueArchiveOnlyOnActiveCluster",
+		true,
+		`ArchivalQueueArchiveOnlyOnActiveCluster controls whether the archival queue skips the archive push when the
+current cluster is not active for the workflow's namespace. Set to false to restore the previous behavior of
+archiving from every cluster that replicates the namespace.`,
+	)
 
 	WorkflowExecutionMaxInFlightUpdates = NewNamespaceIntSetting(
 		"history.maxInFlightUpdates",

--- a/service/history/archival_queue_task_executor.go
+++ b/service/history/archival_queue_task_executor.go
@@ -12,6 +12,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/service/history/archival"
@@ -147,9 +148,34 @@ func (e *archivalQueueTaskExecutor) getArchiveTaskRequest(
 		return nil, err
 	}
 
+	// A standby cluster generates its own archival task when it applies the replicated close event,
+	// so the active cluster's task already covers the archive. Skipping the push here drops the
+	// duplicate write, which visibility archival does not dedup. Targets are left empty rather than
+	// returning early so that addDeletionTask still runs: with archival enabled it is the only
+	// producer of the retention DeleteHistoryEventTask, and each cluster must delete its own copy.
+	//
+	// Only global namespaces are gated. ActiveClusterName reports the recorded active cluster
+	// without regard to whether the namespace is replicated, so a local namespace must be treated
+	// as active here rather than compared against the current cluster.
+	isActive := true
+	if namespaceEntry.IsGlobalNamespace() &&
+		e.shardContext.GetConfig().ArchivalQueueArchiveOnlyOnActiveCluster(namespaceName.String()) {
+		currentCluster := e.shardContext.GetClusterMetadata().GetCurrentClusterName()
+		activeCluster := namespaceEntry.ActiveClusterName(namespace.RoutingKey{ID: task.WorkflowID})
+		isActive = activeCluster == currentCluster
+		if !isActive {
+			logger.Debug(
+				"Skipping archival on standby cluster.",
+				tag.ClusterName(currentCluster),
+				tag.TargetCluster(activeCluster),
+			)
+		}
+	}
+
 	var historyURI, visibilityURI carchiver.URI
 	var targets []archival.Target
-	if e.shardContext.GetArchivalMetadata().GetVisibilityConfig().ClusterConfiguredForArchival() &&
+	if isActive &&
+		e.shardContext.GetArchivalMetadata().GetVisibilityConfig().ClusterConfiguredForArchival() &&
 		namespaceEntry.VisibilityArchivalState().State == enumspb.ARCHIVAL_STATE_ENABLED {
 		targets = append(targets, archival.TargetVisibility)
 		visibilityURIString := namespaceEntry.VisibilityArchivalState().URI
@@ -168,7 +194,8 @@ func (e *archivalQueueTaskExecutor) getArchiveTaskRequest(
 			return nil, fmt.Errorf("failed to parse visibility URI for archival task: %w", err)
 		}
 	}
-	if e.shardContext.GetArchivalMetadata().GetHistoryConfig().ClusterConfiguredForArchival() &&
+	if isActive &&
+		e.shardContext.GetArchivalMetadata().GetHistoryConfig().ClusterConfiguredForArchival() &&
 		namespaceEntry.HistoryArchivalState().State == enumspb.ARCHIVAL_STATE_ENABLED {
 		historyURIString := namespaceEntry.HistoryArchivalState().URI
 		historyURI, err = carchiver.NewURI(historyURIString)

--- a/service/history/archival_queue_task_executor_test.go
+++ b/service/history/archival_queue_task_executor_test.go
@@ -17,6 +17,7 @@ import (
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/definition"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
@@ -41,6 +42,34 @@ func TestArchivalQueueTaskExecutor(t *testing.T) {
 		{
 			Name: "success",
 			Configure: func(p *params) {
+			},
+		},
+		{
+			// The active cluster archives this workflow, so pushing again from here would be a
+			// duplicate write that visibility archival does not dedup. The deletion task must
+			// still be scheduled: with archival enabled, addDeletionTask is the only producer of
+			// the retention DeleteHistoryEventTask, and this cluster still holds its own copy.
+			Name: "standby cluster skips archival but still schedules deletion",
+			Configure: func(p *params) {
+				p.NamespaceActiveClusterName = cluster.TestAlternativeClusterName
+				p.ExpectArchive = false
+				p.ExpectedTargets = nil
+				p.ExpectAddTask = true
+			},
+		},
+		{
+			Name: "standby cluster archives when active cluster gate is disabled",
+			Configure: func(p *params) {
+				p.NamespaceActiveClusterName = cluster.TestAlternativeClusterName
+				p.DisableActiveClusterGate = true
+			},
+		},
+		{
+			// A local namespace is active wherever it lives, so it must archive even though its
+			// recorded active cluster name differs from the current cluster.
+			Name: "local namespace archives regardless of active cluster name",
+			Configure: func(p *params) {
+				p.LocalNamespace = true
 			},
 		},
 		{
@@ -320,6 +349,7 @@ func TestArchivalQueueTaskExecutor(t *testing.T) {
 			p.ExpectAddTask = true
 			p.MetricsHandler = metrics.NewMockHandler(p.Controller)
 			p.MutableStateExists = true
+			p.NamespaceActiveClusterName = cluster.TestCurrentClusterName
 
 			c.Configure(&p)
 			namespaceRegistry := namespace.NewMockRegistry(p.Controller)
@@ -337,6 +367,9 @@ func TestArchivalQueueTaskExecutor(t *testing.T) {
 			cfg.RetentionTimerJitterDuration = func() time.Duration {
 				return 0
 			}
+			if p.DisableActiveClusterGate {
+				cfg.ArchivalQueueArchiveOnlyOnActiveCluster = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false)
+			}
 			shardContext.EXPECT().GetConfig().Return(cfg).AnyTimes()
 			mockMetadata := cluster.NewMockMetadata(p.Controller)
 			mockMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(true).AnyTimes()
@@ -348,26 +381,40 @@ func TestArchivalQueueTaskExecutor(t *testing.T) {
 			historyArchivalState := p.HistoryConfig.NamespaceArchivalState
 			visibilityArchivalState := p.VisibilityConfig.NamespaceArchivalState
 
-			namespaceEntry := namespace.NewGlobalNamespaceForTest(
-				&persistencespb.NamespaceInfo{
-					Id:   tests.NamespaceID.String(),
-					Name: tests.Namespace.String(),
-				},
-				&persistencespb.NamespaceConfig{
-					Retention:               p.Retention,
-					HistoryArchivalState:    enumspb.ArchivalState(historyArchivalState),
-					HistoryArchivalUri:      p.HistoryURI,
-					VisibilityArchivalState: enumspb.ArchivalState(visibilityArchivalState),
-					VisibilityArchivalUri:   p.VisibilityURI,
-				},
-				&persistencespb.NamespaceReplicationConfig{
-					ActiveClusterName: cluster.TestCurrentClusterName,
-					Clusters: []string{
-						cluster.TestCurrentClusterName,
+			namespaceInfo := &persistencespb.NamespaceInfo{
+				Id:   tests.NamespaceID.String(),
+				Name: tests.Namespace.String(),
+			}
+			namespaceConfig := &persistencespb.NamespaceConfig{
+				Retention:               p.Retention,
+				HistoryArchivalState:    enumspb.ArchivalState(historyArchivalState),
+				HistoryArchivalUri:      p.HistoryURI,
+				VisibilityArchivalState: enumspb.ArchivalState(visibilityArchivalState),
+				VisibilityArchivalUri:   p.VisibilityURI,
+			}
+			var namespaceEntry *namespace.Namespace
+			if p.LocalNamespace {
+				// The target cluster deliberately differs from the current cluster: a local
+				// namespace is active wherever it lives, so the gate must not consult it.
+				namespaceEntry = namespace.NewLocalNamespaceForTest(
+					namespaceInfo,
+					namespaceConfig,
+					cluster.TestAlternativeClusterName,
+				)
+			} else {
+				namespaceEntry = namespace.NewGlobalNamespaceForTest(
+					namespaceInfo,
+					namespaceConfig,
+					&persistencespb.NamespaceReplicationConfig{
+						ActiveClusterName: p.NamespaceActiveClusterName,
+						Clusters: []string{
+							cluster.TestCurrentClusterName,
+							cluster.TestAlternativeClusterName,
+						},
 					},
-				},
-				123,
-			)
+					123,
+				)
+			}
 			namespaceRegistry.EXPECT().GetNamespaceName(namespaceEntry.ID()).
 				Return(namespaceEntry.Name(), nil).AnyTimes()
 			namespaceRegistry.EXPECT().GetNamespaceByID(namespaceEntry.ID()).
@@ -579,6 +626,14 @@ type params struct {
 	GetCloseVersionBeforeArchivalError error
 	CloseVersionAfterArchival          int64
 	GetCloseVersionAfterArchivalError  error
+	// NamespaceActiveClusterName is the active cluster of the global namespace under test. It
+	// defaults to the current cluster; set it to cluster.TestAlternativeClusterName to make the
+	// current cluster standby for the namespace.
+	NamespaceActiveClusterName string
+	// LocalNamespace builds a local (non-global) namespace instead of a global one.
+	LocalNamespace bool
+	// DisableActiveClusterGate turns off history.archivalQueueArchiveOnlyOnActiveCluster.
+	DisableActiveClusterGate bool
 }
 
 // archivalConfig represents the user configuration of archival for the cluster and namespace

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -390,6 +390,7 @@ type Config struct {
 	ArchivalProcessorArchiveDelay                       dynamicconfig.DurationPropertyFn
 	ArchivalBackendMaxRPS                               dynamicconfig.FloatPropertyFn
 	ArchivalQueueMaxReaderCount                         dynamicconfig.IntPropertyFn
+	ArchivalQueueArchiveOnlyOnActiveCluster             dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
 	WorkflowExecutionMaxInFlightUpdates                           dynamicconfig.IntPropertyFnWithNamespaceFilter
 	WorkflowExecutionMaxInFlightUpdatePayloads                    dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -777,6 +778,7 @@ func NewConfig(
 		ArchivalProcessorArchiveDelay:                       dynamicconfig.ArchivalProcessorArchiveDelay.Get(dc),
 		ArchivalBackendMaxRPS:                               dynamicconfig.ArchivalBackendMaxRPS.Get(dc),
 		ArchivalQueueMaxReaderCount:                         dynamicconfig.ArchivalQueueMaxReaderCount.Get(dc),
+		ArchivalQueueArchiveOnlyOnActiveCluster:             dynamicconfig.ArchivalQueueArchiveOnlyOnActiveCluster.Get(dc),
 
 		// workflow update related
 		WorkflowExecutionMaxInFlightUpdates:                           dynamicconfig.WorkflowExecutionMaxInFlightUpdates.Get(dc),


### PR DESCRIPTION
What changed?

Gates the archival queue task executor so that, for a global (replicated) namespace, only the active cluster pushes to the archival store. When the current cluster is not active for the workflow's namespace, getArchiveTaskRequest skips the history and visibility target blocks, leaving request.Targets empty; processArchiveExecutionTask already skips archiver.Archive for empty targets, so the archive push is dropped while the rest of the path is unchanged.

- Uses namespaceEntry.ActiveClusterName(namespace.RoutingKey{ID: task.WorkflowID}) — the per-workflow activeness API used elsewhere in the queue (queues/executable.go), which the forbidigo rule prefers over ActiveInCluster for workflow-scoped decisions and which handles active-active namespaces.
- Guarded by IsGlobalNamespace(): ActiveClusterName reports the recorded active cluster regardless of whether the namespace is replicated, so local namespaces are treated as active and always archive.
- Added namespace dynamic config history.archivalQueueArchiveOnlyOnActiveCluster (default true) as a kill switch.

Deletion is deliberately untouched. With archival enabled, the retention DeleteHistoryEventTask is not generated at close time (workflow/task_generator.go takes the archival branch) — addDeletionTask in this executor is its only producer. Because the change skips the targets rather than returning early, addDeletionTask still runs and the task acks, so retention and task acking are unchanged on every cluster.

Closes #10888.

Why?

With replication, both active and standby clusters run the archival queue andr a global namespace. History archival dedups via a per-blob existence check,but visibility archival has none (service/history/archival/archiver.go archiveVisibility always writes), so standby clusters double-write visibility records and add avoidable load on
the archival store.

Skipping the push on standby is safe: a standby cluster generates its own arce replicated close event (workflow/mutable_state_rebuilder.go →GenerateWorkflowCloseTasks), so the active cluster's task already covers the archive — nothing is lost by not pushing from standby.

How did you test it?

- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

New cases in service/history/archival_queue_task_executor_test.go:
- standby cluster skips archival but still schedules deletion — namespace acthive call, empty targets, and that the retention DeleteHistoryEventTask isstill scheduled and the task acks with no error.                                                                                                                                         - standby cluster archives when active cluster gate is disabled — verifies thbehavior.
- local namespace archives regardless of active cluster name — verifies the IsGlobalNamespace() guard.                                                                                   
go test -tags test_dep ./service/history/ -run TestArchivalQueueTaskExecutor passes; make lint-code is clean.                                                                            
Potential risks                                                                                                                                                                          
- If the activeness check returns a false negative on the true active cluster, archival would be skipped there. The history.archivalQueueArchiveOnlyOnActiveCluster kill switch (default on) lets operators revert to archive-on-every-cluster without a deploy. Deletruns on a separate per-cluster path.
- Execute still reports ExecutedAsActive: true; standby-processed archival tasks remain tagged active in metrics. Left as-is to keep the change focused.