### PR TITLE
fix(persistence): skip unnecessary joins in MySQL visibility count queries

### DIFF
--- a/common/persistence/visibility/store/sql/query_converter_legacy.go
+++ b/common/persistence/visibility/store/sql/query_converter_legacy.go
@@ -32,7 +32,12 @@ type (
 			token *pageTokenLegacy,
 		) (string, []any)
 
-		buildCountStmt(namespaceID namespace.ID, queryString string, groupBy []string) (string, []any)
+		buildCountStmt(
+			namespaceID namespace.ID,
+			queryString string,
+			groupBy []string,
+			usesCustomSearchAttribute bool,
+		) (string, []any)
 
 		getDatetimeFormat() string
 
@@ -48,6 +53,10 @@ type (
 		queryString   string
 
 		seenNamespaceDivision bool
+		// Set to true by convertColName when the query references a column that isn't
+		// a system search attribute, i.e. one whose values live in custom_search_attributes
+		// or chasm_search_attributes rather than directly on executions_visibility.
+		seenCustomSearchAttribute bool
 
 		chasmMapper *chasm.VisibilitySearchAttributesMapper
 		archetypeID chasm.ArchetypeID
@@ -57,6 +66,8 @@ type (
 		queryString string
 		// List of search attributes to group by (field name, not db name).
 		groupBy []string
+		// True if the query references a custom (non-system) search attribute.
+		usesCustomSearchAttribute bool
 	}
 )
 
@@ -153,7 +164,7 @@ func (c *QueryConverterLegacy) BuildCountStmt() (*sqlplugin.VisibilitySelectFilt
 	for i, fieldName := range qp.groupBy {
 		groupByDbNames[i] = sadefs.GetSqlDbColName(fieldName)
 	}
-	queryString, queryArgs := c.buildCountStmt(c.namespaceID, qp.queryString, groupByDbNames)
+	queryString, queryArgs := c.buildCountStmt(c.namespaceID, qp.queryString, groupByDbNames, qp.usesCustomSearchAttribute)
 	return &sqlplugin.VisibilitySelectFilter{
 		Query:     queryString,
 		QueryArgs: queryArgs,
@@ -182,7 +193,7 @@ func (c *QueryConverterLegacy) convertWhereString(queryString string) (*queryPar
 		return nil, err
 	}
 
-	res := &queryParamsLegacy{}
+	res := &queryParamsLegacy{usesCustomSearchAttribute: c.seenCustomSearchAttribute}
 	if selectStmt.Where != nil {
 		res.queryString = sqlparser.String(selectStmt.Where.Expr)
 	}
@@ -460,6 +471,9 @@ func (c *QueryConverterLegacy) convertColName(exprRef *sqlparser.Expr) (*saColNa
 	}
 	if saFieldName == sadefs.TemporalNamespaceDivision {
 		c.seenNamespaceDivision = true
+	}
+	if sadefs.IsPreallocatedCSAFieldName(saFieldName, saType) || sadefs.IsChasmSearchAttribute(saFieldName) {
+		c.seenCustomSearchAttribute = true
 	}
 	if saAlias == sadefs.CloseTime {
 		*exprRef = c.getCoalesceCloseTimeExpr()

--- a/common/persistence/visibility/store/sql/query_converter_legacy.go
+++ b/common/persistence/visibility/store/sql/query_converter_legacy.go
@@ -32,7 +32,12 @@ type (
 			token *pageTokenLegacy,
 		) (string, []any)
 
-		buildCountStmt(namespaceID namespace.ID, queryString string, groupBy []string) (string, []any)
+		buildCountStmt(
+			namespaceID namespace.ID,
+			queryString string,
+			groupBy []string,
+			usesCustomSearchAttribute bool,
+		) (string, []any)
 
 		getDatetimeFormat() string
 
@@ -48,6 +53,10 @@ type (
 		queryString   string
 
 		seenNamespaceDivision bool
+		// Set to true by convertColName when the query references a column that isn't
+		// a system search attribute, i.e. one whose values live in custom_search_attributes
+		// or chasm_search_attributes rather than directly on executions_visibility.
+		seenCustomSearchAttribute bool
 
 		chasmMapper *chasm.VisibilitySearchAttributesMapper
 		archetypeID chasm.ArchetypeID
@@ -57,6 +66,8 @@ type (
 		queryString string
 		// List of search attributes to group by (field name, not db name).
 		groupBy []string
+		// True if the query references a custom (non-system) search attribute.
+		usesCustomSearchAttribute bool
 	}
 )
 
@@ -153,7 +164,7 @@ func (c *QueryConverterLegacy) BuildCountStmt() (*sqlplugin.VisibilitySelectFilt
 	for i, fieldName := range qp.groupBy {
 		groupByDbNames[i] = sadefs.GetSqlDbColName(fieldName)
 	}
-	queryString, queryArgs := c.buildCountStmt(c.namespaceID, qp.queryString, groupByDbNames)
+	queryString, queryArgs := c.buildCountStmt(c.namespaceID, qp.queryString, groupByDbNames, qp.usesCustomSearchAttribute)
 	return &sqlplugin.VisibilitySelectFilter{
 		Query:     queryString,
 		QueryArgs: queryArgs,
@@ -182,7 +193,7 @@ func (c *QueryConverterLegacy) convertWhereString(queryString string) (*queryPar
 		return nil, err
 	}
 
-	res := &queryParamsLegacy{}
+	res := &queryParamsLegacy{usesCustomSearchAttribute: c.seenCustomSearchAttribute}
 	if selectStmt.Where != nil && selectStmt.Where.Expr != nil {
 		res.queryString = sqlparser.String(selectStmt.Where.Expr)
 	}
@@ -466,6 +477,9 @@ func (c *QueryConverterLegacy) convertColName(exprRef *sqlparser.Expr) (*saColNa
 	}
 	if saFieldName == sadefs.TemporalNamespaceDivision {
 		c.seenNamespaceDivision = true
+	}
+	if sadefs.IsPreallocatedCSAFieldName(saFieldName, saType) || sadefs.IsChasmSearchAttribute(saFieldName) {
+		c.seenCustomSearchAttribute = true
 	}
 	if saAlias == sadefs.CloseTime {
 		*exprRef = c.getCoalesceCloseTimeExpr()

--- a/common/persistence/visibility/store/sql/query_converter_legacy_mysql.go
+++ b/common/persistence/visibility/store/sql/query_converter_legacy_mysql.go
@@ -260,6 +260,7 @@ func (c *mysqlQueryConverter) buildCountStmt(
 	namespaceID namespace.ID,
 	queryString string,
 	groupBy []string,
+	usesCustomSearchAttribute bool,
 ) (string, []any) {
 	var whereClauses []string
 	var queryArgs []any
@@ -279,18 +280,30 @@ func (c *mysqlQueryConverter) buildCountStmt(
 		groupByClause = fmt.Sprintf("GROUP BY %s", strings.Join(groupBy, ", "))
 	}
 
+	// GROUP BY is only ever allowed on ExecutionStatus (a column on executions_visibility
+	// itself), so the joins are only needed when the WHERE clause references a custom or
+	// CHASM search attribute. Skipping them when it doesn't avoids an expensive join against
+	// custom_search_attributes/chasm_search_attributes that the query never uses.
+	joinClause := ""
+	if usesCustomSearchAttribute {
+		joinClause = fmt.Sprintf(
+			`LEFT JOIN custom_search_attributes USING (%s, %s)
+		LEFT JOIN chasm_search_attributes USING (%s, %s)`,
+			sadefs.GetSqlDbColName(sadefs.NamespaceID),
+			sadefs.GetSqlDbColName(sadefs.RunID),
+			sadefs.GetSqlDbColName(sadefs.NamespaceID),
+			sadefs.GetSqlDbColName(sadefs.RunID),
+		)
+	}
+
 	return fmt.Sprintf(
 		`SELECT %s
 		FROM executions_visibility ev
-		LEFT JOIN custom_search_attributes USING (%s, %s)
-		LEFT JOIN chasm_search_attributes USING (%s, %s)
+		%s
 		WHERE %s
 		%s`,
 		strings.Join(append(groupBy, "COUNT(*)"), ", "),
-		sadefs.GetSqlDbColName(sadefs.NamespaceID),
-		sadefs.GetSqlDbColName(sadefs.RunID),
-		sadefs.GetSqlDbColName(sadefs.NamespaceID),
-		sadefs.GetSqlDbColName(sadefs.RunID),
+		joinClause,
 		strings.Join(whereClauses, " AND "),
 		groupByClause,
 	), queryArgs

--- a/common/persistence/visibility/store/sql/query_converter_legacy_mysql_test.go
+++ b/common/persistence/visibility/store/sql/query_converter_legacy_mysql_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	"github.com/temporalio/sqlparser"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
 )
 
@@ -22,6 +23,33 @@ func TestMySQLQueryConverterSuite(t *testing.T) {
 		},
 	}
 	suite.Run(t, s)
+}
+
+func (s *mysqlQueryConverterSuite) TestBuildCountStmtSkipsJoinsWithoutCustomSearchAttribute() {
+	// GROUP BY ExecutionStatus with no filter only references a column on
+	// executions_visibility itself, so the count query shouldn't join against
+	// custom_search_attributes/chasm_search_attributes at all.
+	sqlStr, _ := s.queryConverter.buildCountStmt(
+		namespace.ID("test-namespace-id"),
+		"",
+		[]string{"status"},
+		false,
+	)
+	s.NotContains(sqlStr, "custom_search_attributes")
+	s.NotContains(sqlStr, "chasm_search_attributes")
+}
+
+func (s *mysqlQueryConverterSuite) TestBuildCountStmtJoinsWithCustomSearchAttribute() {
+	// A query filtering on a custom search attribute column still needs both joins
+	// to resolve it, so correctness must be preserved when usesCustomSearchAttribute is true.
+	sqlStr, _ := s.queryConverter.buildCountStmt(
+		namespace.ID("test-namespace-id"),
+		"(Int01 = 1)",
+		nil,
+		true,
+	)
+	s.Contains(sqlStr, "LEFT JOIN custom_search_attributes")
+	s.Contains(sqlStr, "LEFT JOIN chasm_search_attributes")
 }
 
 func (s *mysqlQueryConverterSuite) TestGetCoalesceCloseTimeExpr() {

--- a/common/persistence/visibility/store/sql/query_converter_legacy_postgresql.go
+++ b/common/persistence/visibility/store/sql/query_converter_legacy_postgresql.go
@@ -261,6 +261,7 @@ func (c *pgQueryConverter) buildCountStmt(
 	namespaceID namespace.ID,
 	queryString string,
 	groupBy []string,
+	_ bool, // usesCustomSearchAttribute: unused, Postgres never joins for count queries
 ) (string, []any) {
 	var whereClauses []string
 	var queryArgs []any

--- a/common/persistence/visibility/store/sql/query_converter_legacy_sqlite.go
+++ b/common/persistence/visibility/store/sql/query_converter_legacy_sqlite.go
@@ -301,6 +301,7 @@ func (c *sqliteQueryConverter) buildCountStmt(
 	namespaceID namespace.ID,
 	queryString string,
 	groupBy []string,
+	_ bool, // usesCustomSearchAttribute: unused, SQLite never joins for count queries
 ) (string, []any) {
 	var whereClauses []string
 	var queryArgs []any

--- a/common/persistence/visibility/store/sql/query_converter_legacy_test.go
+++ b/common/persistence/visibility/store/sql/query_converter_legacy_test.go
@@ -68,34 +68,49 @@ func (s *queryConverterSuite) TestConvertWhereString() {
 			err:    nil,
 		},
 		{
-			name:   "single condition int",
-			input:  "AliasForInt01 = 1",
-			output: &queryParamsLegacy{queryString: "(Int01 = 1) and TemporalNamespaceDivision is null"},
-			err:    nil,
+			name:  "single condition int",
+			input: "AliasForInt01 = 1",
+			output: &queryParamsLegacy{
+				queryString:               "(Int01 = 1) and TemporalNamespaceDivision is null",
+				usesCustomSearchAttribute: true,
+			},
+			err: nil,
 		},
 		{
-			name:   "single condition keyword",
-			input:  "AliasForKeyword01 = 1",
-			output: &queryParamsLegacy{queryString: "(Keyword01 = 1) and TemporalNamespaceDivision is null"},
-			err:    nil,
+			name:  "single condition keyword",
+			input: "AliasForKeyword01 = 1",
+			output: &queryParamsLegacy{
+				queryString:               "(Keyword01 = 1) and TemporalNamespaceDivision is null",
+				usesCustomSearchAttribute: true,
+			},
+			err: nil,
 		},
 		{
-			name:   "or condition keyword",
-			input:  "AliasForInt01 = 1 OR AliasForKeyword01 = 1",
-			output: &queryParamsLegacy{queryString: "(Int01 = 1 or Keyword01 = 1) and TemporalNamespaceDivision is null"},
-			err:    nil,
+			name:  "or condition keyword",
+			input: "AliasForInt01 = 1 OR AliasForKeyword01 = 1",
+			output: &queryParamsLegacy{
+				queryString:               "(Int01 = 1 or Keyword01 = 1) and TemporalNamespaceDivision is null",
+				usesCustomSearchAttribute: true,
+			},
+			err: nil,
 		},
 		{
-			name:   "no double parenthesis",
-			input:  "(AliasForInt01 = 1 OR AliasForKeyword01 = 1)",
-			output: &queryParamsLegacy{queryString: "(Int01 = 1 or Keyword01 = 1) and TemporalNamespaceDivision is null"},
-			err:    nil,
+			name:  "no double parenthesis",
+			input: "(AliasForInt01 = 1 OR AliasForKeyword01 = 1)",
+			output: &queryParamsLegacy{
+				queryString:               "(Int01 = 1 or Keyword01 = 1) and TemporalNamespaceDivision is null",
+				usesCustomSearchAttribute: true,
+			},
+			err: nil,
 		},
 		{
-			name:   "has namespace division",
-			input:  "(AliasForInt01 = 1 OR AliasForKeyword01 = 1) AND TemporalNamespaceDivision = 'foo'",
-			output: &queryParamsLegacy{queryString: "((Int01 = 1 or Keyword01 = 1) and TemporalNamespaceDivision = 'foo')"},
-			err:    nil,
+			name:  "has namespace division",
+			input: "(AliasForInt01 = 1 OR AliasForKeyword01 = 1) AND TemporalNamespaceDivision = 'foo'",
+			output: &queryParamsLegacy{
+				queryString:               "((Int01 = 1 or Keyword01 = 1) and TemporalNamespaceDivision = 'foo')",
+				usesCustomSearchAttribute: true,
+			},
+			err: nil,
 		},
 		{
 			name:  "group by one field",
@@ -1198,22 +1213,25 @@ func (s *queryConverterSuite) TestConvertWhereString_WithChasmMapper() {
 	)
 
 	testCases := []struct {
-		name     string
-		input    string
-		expected string
-		err      error
+		name                              string
+		input                             string
+		expected                          string
+		expectedUsesCustomSearchAttribute bool
+		err                               error
 	}{
 		{
-			name:     "CHASM search attribute",
-			input:    "ChasmStatus = 'active'",
-			expected: "(TemporalKeyword01 = 'active') and TemporalNamespaceDivision is null",
-			err:      nil,
+			name:                              "CHASM search attribute",
+			input:                             "ChasmStatus = 'active'",
+			expected:                          "(TemporalKeyword01 = 'active') and TemporalNamespaceDivision is null",
+			expectedUsesCustomSearchAttribute: true,
+			err:                               nil,
 		},
 		{
-			name:     "CHASM search attribute with namespace division",
-			input:    "ChasmStatus = 'active' AND TemporalNamespaceDivision = '123'",
-			expected: "(TemporalKeyword01 = 'active' and TemporalNamespaceDivision = '123')",
-			err:      nil,
+			name:                              "CHASM search attribute with namespace division",
+			input:                             "ChasmStatus = 'active' AND TemporalNamespaceDivision = '123'",
+			expected:                          "(TemporalKeyword01 = 'active' and TemporalNamespaceDivision = '123')",
+			expectedUsesCustomSearchAttribute: true,
+			err:                               nil,
 		},
 	}
 
@@ -1223,6 +1241,7 @@ func (s *queryConverterSuite) TestConvertWhereString_WithChasmMapper() {
 			if tc.err == nil {
 				s.NoError(err)
 				s.Equal(tc.expected, qp.queryString)
+				s.Equal(tc.expectedUsesCustomSearchAttribute, qp.usesCustomSearchAttribute)
 			} else {
 				s.Error(err)
 				s.Equal(tc.err, err)

--- a/common/persistence/visibility/store/sql/query_converter_legacy_test.go
+++ b/common/persistence/visibility/store/sql/query_converter_legacy_test.go
@@ -68,34 +68,49 @@ func (s *queryConverterSuite) TestConvertWhereString() {
 			err:    nil,
 		},
 		{
-			name:   "single condition int",
-			input:  "AliasForInt01 = 1",
-			output: &queryParamsLegacy{queryString: "(Int01 = 1) and TemporalNamespaceDivision is null"},
-			err:    nil,
+			name:  "single condition int",
+			input: "AliasForInt01 = 1",
+			output: &queryParamsLegacy{
+				queryString:               "(Int01 = 1) and TemporalNamespaceDivision is null",
+				usesCustomSearchAttribute: true,
+			},
+			err: nil,
 		},
 		{
-			name:   "single condition keyword",
-			input:  "AliasForKeyword01 = 1",
-			output: &queryParamsLegacy{queryString: "(Keyword01 = 1) and TemporalNamespaceDivision is null"},
-			err:    nil,
+			name:  "single condition keyword",
+			input: "AliasForKeyword01 = 1",
+			output: &queryParamsLegacy{
+				queryString:               "(Keyword01 = 1) and TemporalNamespaceDivision is null",
+				usesCustomSearchAttribute: true,
+			},
+			err: nil,
 		},
 		{
-			name:   "or condition keyword",
-			input:  "AliasForInt01 = 1 OR AliasForKeyword01 = 1",
-			output: &queryParamsLegacy{queryString: "(Int01 = 1 or Keyword01 = 1) and TemporalNamespaceDivision is null"},
-			err:    nil,
+			name:  "or condition keyword",
+			input: "AliasForInt01 = 1 OR AliasForKeyword01 = 1",
+			output: &queryParamsLegacy{
+				queryString:               "(Int01 = 1 or Keyword01 = 1) and TemporalNamespaceDivision is null",
+				usesCustomSearchAttribute: true,
+			},
+			err: nil,
 		},
 		{
-			name:   "no double parenthesis",
-			input:  "(AliasForInt01 = 1 OR AliasForKeyword01 = 1)",
-			output: &queryParamsLegacy{queryString: "(Int01 = 1 or Keyword01 = 1) and TemporalNamespaceDivision is null"},
-			err:    nil,
+			name:  "no double parenthesis",
+			input: "(AliasForInt01 = 1 OR AliasForKeyword01 = 1)",
+			output: &queryParamsLegacy{
+				queryString:               "(Int01 = 1 or Keyword01 = 1) and TemporalNamespaceDivision is null",
+				usesCustomSearchAttribute: true,
+			},
+			err: nil,
 		},
 		{
-			name:   "has namespace division",
-			input:  "(AliasForInt01 = 1 OR AliasForKeyword01 = 1) AND TemporalNamespaceDivision = 'foo'",
-			output: &queryParamsLegacy{queryString: "((Int01 = 1 or Keyword01 = 1) and TemporalNamespaceDivision = 'foo')"},
-			err:    nil,
+			name:  "has namespace division",
+			input: "(AliasForInt01 = 1 OR AliasForKeyword01 = 1) AND TemporalNamespaceDivision = 'foo'",
+			output: &queryParamsLegacy{
+				queryString:               "((Int01 = 1 or Keyword01 = 1) and TemporalNamespaceDivision = 'foo')",
+				usesCustomSearchAttribute: true,
+			},
+			err: nil,
 		},
 		{
 			name:  "group by one field",
@@ -1211,22 +1226,25 @@ func (s *queryConverterSuite) TestConvertWhereString_WithChasmMapper() {
 	)
 
 	testCases := []struct {
-		name     string
-		input    string
-		expected string
-		err      error
+		name                              string
+		input                             string
+		expected                          string
+		expectedUsesCustomSearchAttribute bool
+		err                               error
 	}{
 		{
-			name:     "CHASM search attribute",
-			input:    "ChasmStatus = 'active'",
-			expected: "(TemporalKeyword01 = 'active') and TemporalNamespaceDivision is null",
-			err:      nil,
+			name:                              "CHASM search attribute",
+			input:                             "ChasmStatus = 'active'",
+			expected:                          "(TemporalKeyword01 = 'active') and TemporalNamespaceDivision is null",
+			expectedUsesCustomSearchAttribute: true,
+			err:                               nil,
 		},
 		{
-			name:     "CHASM search attribute with namespace division",
-			input:    "ChasmStatus = 'active' AND TemporalNamespaceDivision = '123'",
-			expected: "(TemporalKeyword01 = 'active' and TemporalNamespaceDivision = '123')",
-			err:      nil,
+			name:                              "CHASM search attribute with namespace division",
+			input:                             "ChasmStatus = 'active' AND TemporalNamespaceDivision = '123'",
+			expected:                          "(TemporalKeyword01 = 'active' and TemporalNamespaceDivision = '123')",
+			expectedUsesCustomSearchAttribute: true,
+			err:                               nil,
 		},
 	}
 
@@ -1236,6 +1254,7 @@ func (s *queryConverterSuite) TestConvertWhereString_WithChasmMapper() {
 			if tc.err == nil {
 				s.NoError(err)
 				s.Equal(tc.expected, qp.queryString)
+				s.Equal(tc.expectedUsesCustomSearchAttribute, qp.usesCustomSearchAttribute)
 			} else {
 				s.Error(err)
 				s.Equal(tc.err, err)


### PR DESCRIPTION
## Summary

Fixes #10991 — `CountWorkflowExecutions` with `GROUP BY ExecutionStatus` was 8-16x slower than necessary on MySQL because `mysqlQueryConverter.buildCountStmt` unconditionally `LEFT JOIN`s `custom_search_attributes` and `chasm_search_attributes`, even when the query never references a column from either table.

### Root cause

`GROUP BY` is only ever allowed on `ExecutionStatus` (enforced by `query.IsGroupByFieldAllowed`, checked in `convertSelectStmt`), which lives directly on `executions_visibility` — it never needs the joined tables. The joins are only actually needed when the `WHERE` clause filters on a genuine custom or CHASM search attribute column (the ones physically stored in `custom_search_attributes`/`chasm_search_attributes` per the schema, e.g. `Keyword01`, `TemporalInt01`). For the reported case (`GROUP BY ExecutionStatus`, no filter), neither table contributes anything to the result, so the joins are pure overhead — MySQL still has to do a nested-loop join against every row.

Note: I checked and, contrary to the issue's claim, PostgreSQL's and SQLite's `buildCountStmt` (`query_converter_legacy_postgresql.go`, `query_converter_legacy_sqlite.go`) never had this join at all — only the MySQL variant does. So this fix is scoped to MySQL; the other two dialects just accept and ignore the new parameter to keep the shared interface consistent.

### Fix

- Added `seenCustomSearchAttribute` tracking to `QueryConverterLegacy` (mirroring the existing `seenNamespaceDivision` pattern), set in `convertColName` — the single choke point where every column reference in the query is resolved — using `sadefs.IsPreallocatedCSAFieldName`/`sadefs.IsChasmSearchAttribute` to check whether the resolved field name is one of the physically-joined-table columns (not `sadefs.IsSystem`, which would incorrectly flag predefined-but-still-`executions_visibility`-resident attributes like `TemporalNamespaceDivision` as needing a join).
- Threaded this through `queryParamsLegacy` → `BuildCountStmt` → the `buildCountStmt` interface method (now takes a `usesCustomSearchAttribute bool`) → `mysqlQueryConverter.buildCountStmt`, which now only emits the two `LEFT JOIN`s when that's true.

### Test plan

- Added `TestBuildCountStmtSkipsJoinsWithoutCustomSearchAttribute` / `TestBuildCountStmtJoinsWithCustomSearchAttribute` in `query_converter_legacy_mysql_test.go`, asserting the generated SQL string does/doesn't contain the join clauses.
- Verified the "skips joins" test fails (by temporarily hardcoding the join condition to always-true) and passes with the fix — confirms it actually catches the regression.
- Updated existing `TestConvertWhereString`/`TestConvertWhereString_WithChasmMapper` table-driven tests in `query_converter_legacy_test.go` (shared across all 3 dialects) with the new `usesCustomSearchAttribute` field on `queryParamsLegacy`, since several existing cases (`AliasForInt01 = 1`, CHASM `ChasmStatus`) now correctly assert `true`.
- `go test ./common/persistence/visibility/store/sql/...` — all pass (unit-testable, no live DB/cluster needed, as these are pure SQL-string-generation functions).
- `go build ./...` — full repo builds clean.
- `golangci-lint run --config=.github/.golangci.yml ./common/persistence/visibility/store/sql/...` — no new findings introduced by this change (one unrelated pre-existing `staticcheck` naming finding in `query_converter_legacy_postgresql.go` predates this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code). I've reviewed and tested every change in this PR.

Note: per CONTRIBUTING.md this repo requires the Temporal CLA before merge — I understand the bot will prompt for that.