### PR TITLE
[testcore] Run testcore unit tests in CI and fix unit test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,12 @@ MIXED_BRAIN_TEST_ROOT         := ./tests/mixedbrain
 DB_INTEGRATION_TEST_ROOT      := ./common/persistence/tests
 DB_TOOL_INTEGRATION_TEST_ROOT := ./tools/tests
 INTEGRATION_TEST_DIRS := $(DB_INTEGRATION_TEST_ROOT) $(DB_TOOL_INTEGRATION_TEST_ROOT) ./temporaltest
+TESTCORE_UNITTESTS := ./tests/testcore
 ifeq ($(UNIT_TEST_DIRS),)
 UNIT_TEST_DIRS := $(filter-out $(FUNCTIONAL_TEST_ROOT)% $(FUNCTIONAL_TEST_XDC_ROOT)% $(FUNCTIONAL_TEST_NDC_ROOT)% $(MIXED_BRAIN_TEST_ROOT)% $(DB_INTEGRATION_TEST_ROOT)% $(DB_TOOL_INTEGRATION_TEST_ROOT)% ./temporaltest%,$(TEST_DIRS))
+
+# Testcore unit tests are filtered out by the FUNCTIONAL_TEST_ROOT pattern, need to add them back manually.
+UNIT_TEST_DIRS += $(TESTCORE_UNITTESTS)
 endif
 SYSTEM_WORKFLOWS_ROOT := ./service/worker
 

--- a/tests/testcore/test_cluster_pool_test.go
+++ b/tests/testcore/test_cluster_pool_test.go
@@ -4,23 +4,23 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/dynamicconfig"
 )
 
-func TestGlobalOverridesSurviveTestCleanup(t *testing.T) {
-	var dcClient *dynamicconfig.MemoryClient
+func TestClusterPool_GlobalOverridesSurviveTestCleanup(t *testing.T) {
+	dc := dynamicconfig.NewMemoryClient()
 
-	t.Run("create", func(t *testing.T) {
-		impl := newTemporal(t, &TemporalParams{
-			ClusterMetadataConfig: &cluster.Config{},
-		})
-		dcClient = impl.dcClient
+	t.Run("apply", func(t *testing.T) {
+		// Apply global defaults the same way newTemporal does: via PartialOverrideValue
+		// without registering a t.Cleanup, so they persist beyond the test's lifetime.
+		for k, v := range defaultDynamicConfigOverrides {
+			dc.PartialOverrideValue(k, v)
+		}
 	})
-	// "create" subtest finished — its t.Cleanup has run
-	// but we expect global dynamic config overrides to still be in place.
+	// "apply" subtest finished - its t.Cleanup has run.
+	// Global overrides must still be in place.
 	for k, v := range defaultDynamicConfigOverrides {
-		got := dcClient.GetValue(k)
+		got := dc.GetValue(k)
 		require.NotEmpty(t, got, "key %s missing after cleanup", k)
 		require.Equal(t, v, got[0].Value, "key %s wrong after cleanup", k)
 	}


### PR DESCRIPTION
## What changed?

Testcore contains functional testing's common utils, for example cluster pools, metric captures, etc... Right now these are under `test/testcore/...`. At the moment, their unit tests don't run because we filter out the entire `./test` dir which contains functional tests.

I considered moving these to a different location, but that seems like a slightly more painful codemod, and the current location seems to make sense (these are used for functional tests).

A side effect of running these in CI is figuring out that the `tests/testcore/test_cluster_pool_test.go` would be failing, because we were trying to stand up a onebox temporal cluster without any services, causing Nexus callback URL set call to fail (it needs frontend address). Also fixed that unit test in this PR.

## Why?

Run all tests in CI/CD.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)