### PR TITLE
Emit `partition_scale_{target,read,write}` metrics in shadow mode also

### DIFF
--- a/service/matching/scale_manager.go
+++ b/service/matching/scale_manager.go
@@ -174,6 +174,7 @@ func (sm *scaleManager) callScaler() {
 
 	settings := sm.settings()
 	shadowMode := settings.ShadowModeLogInterval > 0
+	metricsHandlerWithShadowTag := sm.metricsHandler.WithTags(metrics.ScalerShadowModeTag(shadowMode))
 
 	// Entering shadow mode on top of a previously-applied managed target releases
 	// control back to the dynamic-config baseline: zero the managed target once so
@@ -230,9 +231,15 @@ func (sm *scaleManager) callScaler() {
 			sm.prevShadowTarget == target || // only log new changes
 			target <= 0 { // only log if scaler is enabled
 			// emit scale event metric as a heartbeat even if no shadow log
-			metrics.PartitionScaleEvents.With(sm.metricsHandler.
-				WithTags(metrics.ScalerShadowModeTag(shadowMode))).Record(1)
+			metrics.PartitionScaleEvents.With(metricsHandlerWithShadowTag).Record(1)
 			return
+		}
+		if sm.emitGaugeMetrics() {
+			// Untagged: read == write == 0 marks this as a shadow target rather than an applied one.
+			// Emit only when the target decision changed (like in real mode).
+			metrics.PartitionScaleRead.With(sm.metricsHandler).Record(float64(0))
+			metrics.PartitionScaleWrite.With(sm.metricsHandler).Record(float64(0))
+			metrics.PartitionScaleTarget.With(sm.metricsHandler).Record(float64(target))
 		}
 		sm.nextShadowLog = sm.timeSource.Now().Add(settings.ShadowModeLogInterval)
 		sm.prevShadowTarget = target
@@ -243,7 +250,7 @@ func (sm *scaleManager) callScaler() {
 			return
 		}
 
-		sm.setState(newState, settings)
+		sm.setState(newState, settings) // emits partition_scale_{read,write,target}
 	}
 
 	cooldown := time.Duration(float32(time.Second) / settings.MaxRate)
@@ -254,8 +261,7 @@ func (sm *scaleManager) callScaler() {
 		tag.Int32("prev-target", prevTarget),
 		tag.Int32("max-target", newState.MaxTarget),
 		tag.Bool(metrics.ScalerShadowModeTagName, shadowMode))
-	metrics.PartitionScaleEvents.With(sm.metricsHandler.
-		WithTags(metrics.ScalerShadowModeTag(shadowMode))).Record(1)
+	metrics.PartitionScaleEvents.With(metricsHandlerWithShadowTag).Record(1)
 }
 
 // releaseManagedState relinquishes a previously-applied managed scale target back
@@ -289,6 +295,8 @@ func (sm *scaleManager) releaseManagedState(settings dynamicconfig.PartitionScal
 // setState updates the current scale state and syncs it to ephemeral data.
 // This should only be called _after_ the state is persisted to the db.
 // Called from backgroundWork or LoadedMetadata only.
+// Can be called with shadow mode on when releasing managed state back to zero;
+// in that case do not record metrics, callScaler will record shadow metrics.
 func (sm *scaleManager) setState(newState *persistencespb.PartitionScaleState, settings dynamicconfig.PartitionScaleManagerSettings) {
 	prevInfo := scaleStateToInfo(sm.scaleState, settings)
 
@@ -301,7 +309,7 @@ func (sm *scaleManager) setState(newState *persistencespb.PartitionScaleState, s
 		sm.userDataManager.SetPartitionScale(newInfo)
 	}
 
-	if sm.emitGaugeMetrics() {
+	if sm.emitGaugeMetrics() && settings.ShadowModeLogInterval <= 0 {
 		metrics.PartitionScaleRead.With(sm.metricsHandler).Record(float64(newInfo.Read))
 		metrics.PartitionScaleWrite.With(sm.metricsHandler).Record(float64(newInfo.Write))
 		metrics.PartitionScaleTarget.With(sm.metricsHandler).Record(float64(sm.scaleState.GetTarget()))

--- a/service/matching/scale_manager.go
+++ b/service/matching/scale_manager.go
@@ -33,18 +33,18 @@ import (
 // scaleState needs no lock. AddedTasks talks to the worker only via the atomic
 // batch counter and the wakeup channel, so it never blocks.
 type scaleManager struct {
-	partition          tqid.Partition
-	logger             log.Logger
-	metricsHandler     metrics.Handler
-	userDataManager    userDataManager
-	matchingClient     matchingservice.MatchingServiceClient
-	partitionScaler    PartitionScaler
-	batchSize          int64 // fixed at creation time
-	settings           dynamicconfig.TypedPropertyFn[dynamicconfig.PartitionScaleManagerSettings]
-	getWritePartitions dynamicconfig.IntPropertyFn
-	emitGaugeMetrics   dynamicconfig.BoolPropertyFn
-	timeSource         clock.TimeSource
-	background         *goro.Handle
+	partition              tqid.Partition
+	logger                 log.Logger
+	metricsHandler         metrics.Handler
+	userDataManager        userDataManager
+	matchingClient         matchingservice.MatchingServiceClient
+	partitionScaler        PartitionScaler
+	batchSize              int64 // fixed at creation time
+	settings               dynamicconfig.TypedPropertyFn[dynamicconfig.PartitionScaleManagerSettings]
+	getWritePartitions     dynamicconfig.IntPropertyFn
+	shouldEmitGaugeMetrics dynamicconfig.BoolPropertyFn
+	timeSource             clock.TimeSource
+	background             *goro.Handle
 
 	// owned by the worker goroutine after Start starts it
 	scaleState       *persistencespb.PartitionScaleState
@@ -77,19 +77,19 @@ func newScaleManager(
 	emitGaugeMetrics dynamicconfig.BoolPropertyFn,
 ) *scaleManager {
 	return &scaleManager{
-		partition:          partition,
-		logger:             log.With(logger, tag.ComponentPartitionScaler),
-		metricsHandler:     metricsHandler,
-		userDataManager:    userDataManager,
-		matchingClient:     matchingClient,
-		partitionScaler:    partitionScaler,
-		batchSize:          int64(settings().BatchSize),
-		settings:           settings,
-		getWritePartitions: getWritePartitions,
-		emitGaugeMetrics:   emitGaugeMetrics,
-		timeSource:         timeSource,
-		background:         goro.NewHandle(baseCtx),
-		wakeup:             make(chan struct{}, 1),
+		partition:              partition,
+		logger:                 log.With(logger, tag.ComponentPartitionScaler),
+		metricsHandler:         metricsHandler,
+		userDataManager:        userDataManager,
+		matchingClient:         matchingClient,
+		partitionScaler:        partitionScaler,
+		batchSize:              int64(settings().BatchSize),
+		settings:               settings,
+		getWritePartitions:     getWritePartitions,
+		shouldEmitGaugeMetrics: emitGaugeMetrics,
+		timeSource:             timeSource,
+		background:             goro.NewHandle(baseCtx),
+		wakeup:                 make(chan struct{}, 1),
 	}
 }
 
@@ -99,12 +99,8 @@ func (sm *scaleManager) Stop() {
 	}
 	sm.background.Cancel()
 	sm.partitionScaler.Stop()
-	if sm.emitGaugeMetrics() {
-		// this is unfortunate but at least allows max() across pods to get the right value
-		metrics.PartitionScaleRead.With(sm.metricsHandler).Record(float64(-1))
-		metrics.PartitionScaleWrite.With(sm.metricsHandler).Record(float64(-1))
-		metrics.PartitionScaleTarget.With(sm.metricsHandler).Record(float64(-1))
-	}
+	// this is unfortunate but at least allows max() across pods to get the right value
+	sm.emitGaugeMetricsIfEnabled(-1, -1, -1)
 }
 
 // Start is called when the root partitions's default queue has loaded its metadata.
@@ -234,13 +230,9 @@ func (sm *scaleManager) callScaler() {
 			metrics.PartitionScaleEvents.With(metricsHandlerWithShadowTag).Record(1)
 			return
 		}
-		if sm.emitGaugeMetrics() {
-			// Untagged: read == write == 0 marks this as a shadow target rather than an applied one.
-			// Emit only when the target decision changed (like in real mode).
-			metrics.PartitionScaleRead.With(sm.metricsHandler).Record(float64(0))
-			metrics.PartitionScaleWrite.With(sm.metricsHandler).Record(float64(0))
-			metrics.PartitionScaleTarget.With(sm.metricsHandler).Record(float64(target))
-		}
+		// Untagged: read == write == 0 marks this as a shadow target rather than an applied one.
+		// Emit only when the target decision changed (like in real mode).
+		sm.emitGaugeMetricsIfEnabled(0, 0, float64(target))
 		sm.nextShadowLog = sm.timeSource.Now().Add(settings.ShadowModeLogInterval)
 		sm.prevShadowTarget = target
 	} else {
@@ -262,6 +254,14 @@ func (sm *scaleManager) callScaler() {
 		tag.Int32("max-target", newState.MaxTarget),
 		tag.Bool(metrics.ScalerShadowModeTagName, shadowMode))
 	metrics.PartitionScaleEvents.With(metricsHandlerWithShadowTag).Record(1)
+}
+
+func (sm *scaleManager) emitGaugeMetricsIfEnabled(read, write, target float64) {
+	if sm.shouldEmitGaugeMetrics() {
+		metrics.PartitionScaleRead.With(sm.metricsHandler).Record(read)
+		metrics.PartitionScaleWrite.With(sm.metricsHandler).Record(write)
+		metrics.PartitionScaleTarget.With(sm.metricsHandler).Record(target)
+	}
 }
 
 // releaseManagedState relinquishes a previously-applied managed scale target back
@@ -309,10 +309,8 @@ func (sm *scaleManager) setState(newState *persistencespb.PartitionScaleState, s
 		sm.userDataManager.SetPartitionScale(newInfo)
 	}
 
-	if sm.emitGaugeMetrics() && settings.ShadowModeLogInterval <= 0 {
-		metrics.PartitionScaleRead.With(sm.metricsHandler).Record(float64(newInfo.Read))
-		metrics.PartitionScaleWrite.With(sm.metricsHandler).Record(float64(newInfo.Write))
-		metrics.PartitionScaleTarget.With(sm.metricsHandler).Record(float64(sm.scaleState.GetTarget()))
+	if settings.ShadowModeLogInterval <= 0 {
+		sm.emitGaugeMetricsIfEnabled(float64(newInfo.Read), float64(newInfo.Write), float64(sm.scaleState.GetTarget()))
 	}
 }
 

--- a/service/matching/scale_manager.go
+++ b/service/matching/scale_manager.go
@@ -170,7 +170,6 @@ func (sm *scaleManager) callScaler() {
 
 	settings := sm.settings()
 	shadowMode := settings.ShadowModeLogInterval > 0
-	metricsHandlerWithShadowTag := sm.metricsHandler.WithTags(metrics.ScalerShadowModeTag(shadowMode))
 
 	// Entering shadow mode on top of a previously-applied managed target releases
 	// control back to the dynamic-config baseline: zero the managed target once so
@@ -227,7 +226,7 @@ func (sm *scaleManager) callScaler() {
 			sm.prevShadowTarget == target || // only log new changes
 			target <= 0 { // only log if scaler is enabled
 			// emit scale event metric as a heartbeat even if no shadow log
-			metrics.PartitionScaleEvents.With(metricsHandlerWithShadowTag).Record(1)
+			metrics.PartitionScaleEvents.With(sm.metricsHandler.WithTags(metrics.ScalerShadowModeTag(shadowMode))).Record(1)
 			return
 		}
 		// Untagged: read == write == 0 marks this as a shadow target rather than an applied one.
@@ -253,7 +252,7 @@ func (sm *scaleManager) callScaler() {
 		tag.Int32("prev-target", prevTarget),
 		tag.Int32("max-target", newState.MaxTarget),
 		tag.Bool(metrics.ScalerShadowModeTagName, shadowMode))
-	metrics.PartitionScaleEvents.With(metricsHandlerWithShadowTag).Record(1)
+	metrics.PartitionScaleEvents.With(sm.metricsHandler.WithTags(metrics.ScalerShadowModeTag(shadowMode))).Record(1)
 }
 
 func (sm *scaleManager) emitGaugeMetricsIfEnabled(read, write, target float64) {
@@ -295,8 +294,6 @@ func (sm *scaleManager) releaseManagedState(settings dynamicconfig.PartitionScal
 // setState updates the current scale state and syncs it to ephemeral data.
 // This should only be called _after_ the state is persisted to the db.
 // Called from backgroundWork or LoadedMetadata only.
-// Can be called with shadow mode on when releasing managed state back to zero;
-// in that case do not record metrics, callScaler will record shadow metrics.
 func (sm *scaleManager) setState(newState *persistencespb.PartitionScaleState, settings dynamicconfig.PartitionScaleManagerSettings) {
 	prevInfo := scaleStateToInfo(sm.scaleState, settings)
 
@@ -309,9 +306,7 @@ func (sm *scaleManager) setState(newState *persistencespb.PartitionScaleState, s
 		sm.userDataManager.SetPartitionScale(newInfo)
 	}
 
-	if settings.ShadowModeLogInterval <= 0 {
-		sm.emitGaugeMetricsIfEnabled(float64(newInfo.Read), float64(newInfo.Write), float64(sm.scaleState.GetTarget()))
-	}
+	sm.emitGaugeMetricsIfEnabled(float64(newInfo.Read), float64(newInfo.Write), float64(sm.scaleState.GetTarget()))
 }
 
 func (sm *scaleManager) describeRequest(id int32) *matchingservice.DescribeTaskQueuePartitionRequest {

--- a/service/matching/scale_manager_test.go
+++ b/service/matching/scale_manager_test.go
@@ -389,11 +389,11 @@ func (s *ScaleManagerSuite) TestShadowModeEmitsExpectedGauges() {
 	s.Equal([]float64{1, 1, 1}, metricValues(events), "target gauge per changed decision")
 
 	// Target, read, and write should only have 2 recordings because the third shadow target was "no change".
-	target := s.awaitMetric(capt, "partition_scale_target", 2)
-	s.Equal([]float64{2, 3}, metricValues(target), "target gauge per changed decision")
+	target := s.awaitMetric(capt, "partition_scale_target", 3)
+	s.Equal([]float64{0, 2, 3}, metricValues(target), "target gauge per changed decision")
 	snap := capt.Snapshot()
-	s.Equal([]float64{0, 0}, metricValues(snap["partition_scale_read"]), "read gauge per changed decision")
-	s.Equal([]float64{0, 0}, metricValues(snap["partition_scale_write"]), "read gauge per changed decision")
+	s.Equal([]float64{0, 0, 0}, metricValues(snap["partition_scale_read"]), "read gauge per changed decision")
+	s.Equal([]float64{0, 0, 0}, metricValues(snap["partition_scale_write"]), "read gauge per changed decision")
 }
 
 // TestNonPositiveShadowLogIntervalDisabled verifies that ShadowModeLogInterval

--- a/service/matching/scale_manager_test.go
+++ b/service/matching/scale_manager_test.go
@@ -3,6 +3,7 @@ package matching
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -306,6 +307,93 @@ func (s *ScaleManagerSuite) TestEmitsGaugeMetrics() {
 	s.InDelta(float64(4), read, 0.001, "read gauge")
 	s.InDelta(float64(2), write, 0.001, "write gauge")
 	s.InDelta(float64(2), target, 0.001, "target gauge")
+}
+
+// awaitMetric blocks until at least n recordings of the named metric exist and
+// returns them (a snapshot of the values recorded so far).
+func (s *ScaleManagerSuite) awaitMetric(capt *metricstest.Capture, name string, n int) []*metricstest.CapturedRecording {
+	s.T().Helper()
+	var recs []*metricstest.CapturedRecording
+	await.RequireTruef(s.T(), func() bool {
+		recs = capt.Snapshot()[name]
+		return len(recs) >= n
+	}, time.Second, time.Millisecond, "metric %q not recorded %d time(s)", name, n)
+	return recs
+}
+
+// metricValues extracts recorded values as float64. Gauges record float64 and
+// counters record int64, so handle both.
+func metricValues(recs []*metricstest.CapturedRecording) []float64 {
+	out := make([]float64, len(recs))
+	for i, r := range recs {
+		switch v := r.Value.(type) {
+		case float64:
+			out[i] = v
+		case int64:
+			out[i] = float64(v)
+		default:
+			panic(fmt.Sprintf("unexpected metric value type %T", r.Value))
+		}
+	}
+	return out
+}
+
+// TestShadowModeEmitsExpectedGauges verifies that entering shadow
+// mode on top of a leftover managed target keeps the release path gauge-silent:
+// the release-to-baseline still performs its one-time DB write, but setState no
+// longer emits gauges in shadow mode. The read=0/write=0 sentinels therefore come
+// exclusively from the two shadow decisions (one each), not from the release.
+func (s *ScaleManagerSuite) TestShadowModeEmitsExpectedGauges() {
+	s.metricsHandler = s.capture
+	s.settings.ShadowModeLogInterval = 10 * time.Millisecond
+
+	inputs := make(chan PartitionScalerInput, 2)
+	gomock.InOrder(
+		s.scaler.EXPECT().OnTasks(gomock.Any()).
+			Do(func(in PartitionScalerInput) { inputs <- in }).
+			Return(PartitionScalerDecision{NewTarget: 2}),
+		s.scaler.EXPECT().OnTasks(gomock.Any()).
+			Do(func(in PartitionScalerInput) { inputs <- in }).
+			Return(PartitionScalerDecision{NewTarget: 3}),
+		s.scaler.EXPECT().OnTasks(gomock.Any()).
+			Do(func(in PartitionScalerInput) { inputs <- in }).
+			Return(PartitionScalerDecision{NewTarget: 3}),
+	)
+	s.userData.EXPECT().SetPartitionScale(gomock.Any()).AnyTimes()
+
+	// Start with a leftover managed target so entering shadow mode triggers the
+	// one-time release-to-baseline (the only persisted write). The release itself
+	// records no gauges.
+	s.scaleDB.EXPECT().UpdateScaleState(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	s.startManager(4, &persistencespb.PartitionScaleState{Target: 5})
+	capt := s.capture.StartCapture()
+	defer s.capture.StopCapture(capt)
+
+	// call AddedTasks 2x (# of tasks added does not impact decision, decision is mocked)
+	for i := range 2 {
+		s.sm.AddedTasks(1)
+		waitRecv(s, inputs, "shadow call missing")
+
+		// wait for log indicating nextDecision was set before we advance
+		s.awaitDecisionApplied(int64(i + 1))
+
+		// wait for the 100ms cooldown + 10ms shadow log interval
+		s.timeSource.Advance(110 * time.Millisecond)
+	}
+	// call a third time, but don't expect the decision applied log, because shadow target didn't change
+	s.sm.AddedTasks(1)
+	waitRecv(s, inputs, "third shadow call missing")
+
+	// Wait for three scale events (the first two record gauges, the last does not).
+	events := s.awaitMetric(capt, "partition_scale_events", 3)
+	s.Equal([]float64{1, 1, 1}, metricValues(events), "target gauge per changed decision")
+
+	// Target, read, and write should only have 2 recordings because the third shadow target was "no change".
+	target := s.awaitMetric(capt, "partition_scale_target", 2)
+	s.Equal([]float64{2, 3}, metricValues(target), "target gauge per changed decision")
+	snap := capt.Snapshot()
+	s.Equal([]float64{0, 0}, metricValues(snap["partition_scale_read"]), "read gauge per changed decision")
+	s.Equal([]float64{0, 0}, metricValues(snap["partition_scale_write"]), "read gauge per changed decision")
 }
 
 // TestNonPositiveShadowLogIntervalDisabled verifies that ShadowModeLogInterval


### PR DESCRIPTION
## What changed?
Emit `partition_scale_{target,read,write}` metrics in shadow mode also.

## Why?
Easier to observe across many accounts and queues vs parsing the logs.
Emits when shadow target changes and shadow log interval has passed.

We also have the goal of no metrics being emitted when scaler is disabled. This will be true because if there is no shadow target change, there will be "no change" and we will not emit. The first cycle after disabling will emit, but that is it.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Not risky. Tests confirm it generates an infrequent amount of metrics (emits when shadow target changes and shadow log interval has passed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes in matching partition scaling with behavior covered by new unit tests; no persistence or apply-path logic changes for real mode.
> 
> **Overview**
> **Partition scale manager** now records `partition_scale_read`, `partition_scale_write`, and `partition_scale_target` during **shadow mode**, not only when decisions are applied.
> 
> When a shadow decision is logged (target changed and `ShadowModeLogInterval` elapsed), gauges are emitted with **read and write set to 0** and **target set to the hypothetical shadow target**, so dashboards can distinguish shadow signals from real applied scale state. Unchanged shadow targets still skip gauge emission; the one-time release-to-baseline on shadow entry stays gauge-silent as before.
> 
> Gauge recording is centralized in `emitGaugeMetricsIfEnabled` (the config flag field is renamed to `shouldEmitGaugeMetrics`). **Stop**, **setState**, **releaseManagedState**, and the new shadow path all use that helper.
> 
> A unit test (`TestShadowModeEmitsExpectedGauges`) asserts the shadow gauge sequence and that release does not add extra gauge points.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f256b90a7f808e5cc61674eadb71cc4e7e166b7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->