### PR TITLE
add chasm transaction policy and use it in close transaction handle vts

### DIFF
--- a/chasm/chasmtest/test_engine.go
+++ b/chasm/chasmtest/test_engine.go
@@ -432,7 +432,7 @@ func (e *Engine) startNew(
 	if err := exec.node.SetRootComponent(root); err != nil {
 		return chasm.StartExecutionResult{}, err
 	}
-	if _, err = exec.node.CloseTransaction(); err != nil {
+	if _, err = exec.node.CloseTransaction(chasm.TransactionPolicyActive); err != nil {
 		return chasm.StartExecutionResult{}, err
 	}
 
@@ -475,7 +475,7 @@ func (e *Engine) startAndUpdateNew(
 	if err := updateFn(mutableCtx, root); err != nil {
 		return chasm.EngineUpdateWithStartExecutionResult{}, err
 	}
-	if _, err = exec.node.CloseTransaction(); err != nil {
+	if _, err = exec.node.CloseTransaction(chasm.TransactionPolicyActive); err != nil {
 		return chasm.EngineUpdateWithStartExecutionResult{}, err
 	}
 
@@ -612,7 +612,7 @@ func (e *Engine) updateComponentInExecution(
 		return nil, err
 	}
 
-	if _, err = execution.node.CloseTransaction(); err != nil {
+	if _, err = execution.node.CloseTransaction(chasm.TransactionPolicyActive); err != nil {
 		return nil, err
 	}
 

--- a/chasm/field_test.go
+++ b/chasm/field_test.go
@@ -217,7 +217,7 @@ func (s *fieldSuite) TestDeferredPointerResolution() {
 	s.Equal(rootComponent, sc1.RootPointer.Internal.v)
 
 	// CloseTransaction should resolve the deferred pointer.
-	mutations, err := rootNode.CloseTransaction()
+	mutations, err := rootNode.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	s.NotEmpty(mutations.UpdatedNodes)
 
@@ -272,7 +272,7 @@ func (s *fieldSuite) TestMixedPointerScenario() {
 	// Transaction 1: sc11 points to root (grandparent).
 	sc11.GrandparentPointer = ComponentPointerTo(ctx, rootComponent)
 
-	_, err = rootNode.CloseTransaction()
+	_, err = rootNode.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	s.Equal(fieldTypePointer, sc11.GrandparentPointer.Internal.fieldType())
 
@@ -290,7 +290,7 @@ func (s *fieldSuite) TestMixedPointerScenario() {
 	s.Equal(fieldTypePointer, sc11.GrandparentPointer.Internal.fieldType())
 	s.Equal(fieldTypeDeferredPointer, sc1.RootPointer.Internal.fieldType())
 
-	_, err = rootNode.CloseTransaction()
+	_, err = rootNode.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	// Ensure both pointers have been resolved.
@@ -342,7 +342,7 @@ func (s *fieldSuite) TestUnresolvableDeferredPointerError() {
 	rootComponent.SubComponent11Pointer = ComponentPointerTo(ctx, orphanComponent)
 	s.Equal(fieldTypeDeferredPointer, rootComponent.SubComponent11Pointer.Internal.fieldType())
 
-	_, err = rootNode.CloseTransaction()
+	_, err = rootNode.CloseTransaction(TransactionPolicyActive)
 	s.Error(err)
 	s.Contains(err.Error(), "failed to resolve deferred pointer during transaction close")
 }
@@ -388,7 +388,7 @@ func (s *fieldSuite) TestNonAncestorComponentPointerRejected() {
 	// Root pointing to descendant sc11 should be rejected.
 	rootComponent.SubComponent11Pointer = ComponentPointerTo(ctx, sc11)
 
-	_, err = rootNode.CloseTransaction()
+	_, err = rootNode.CloseTransaction(TransactionPolicyActive)
 	s.Error(err)
 	s.Contains(err.Error(), "is not an ancestor of component")
 }
@@ -428,7 +428,7 @@ func (s *fieldSuite) TestChildComponentPointerRejected() {
 	// Root pointing to child sc1 via interface pointer should be rejected.
 	rootComponent.SubComponentInterfacePointer = ComponentPointerTo[Component](ctx, sc1)
 
-	_, err = rootNode.CloseTransaction()
+	_, err = rootNode.CloseTransaction(TransactionPolicyActive)
 	s.Error(err)
 	s.Contains(err.Error(), "is not an ancestor of component")
 }

--- a/chasm/lib/callback/tasks_test.go
+++ b/chasm/lib/callback/tasks_test.go
@@ -590,7 +590,7 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 					callback,
 				),
 			}))
-			_, err = root.CloseTransaction()
+			_, err = root.CloseTransaction(chasm.TransactionPolicyActive)
 			require.NoError(t, err)
 
 			mockEngine.EXPECT().ReadComponent(

--- a/chasm/lib/nexusoperation/operation_tasks_test.go
+++ b/chasm/lib/nexusoperation/operation_tasks_test.go
@@ -121,7 +121,7 @@ func newInvocationTaskTestEnv(
 		invocationData: invocationData,
 		Op:             chasm.NewComponentField(ctx, op),
 	}))
-	_, err = root.CloseTransaction()
+	_, err = root.CloseTransaction(chasm.TransactionPolicyActive)
 	require.NoError(t, err)
 
 	mockEngine := chasm.NewMockEngine(ctrl)

--- a/chasm/lib/nexusoperation/operation_test.go
+++ b/chasm/lib/nexusoperation/operation_test.go
@@ -372,7 +372,7 @@ func TestOperation_BuildExecutionInfo_ReturnsIsolatedSearchAttributes(t *testing
 		nil,
 	))
 	require.NoError(t, root.SetRootComponent(op))
-	_, err := root.CloseTransaction()
+	_, err := root.CloseTransaction(chasm.TransactionPolicyActive)
 	require.NoError(t, err)
 
 	ctx = chasm.NewMutableContext(context.Background(), root)

--- a/chasm/lib/scheduler/helper_test.go
+++ b/chasm/lib/scheduler/helper_test.go
@@ -240,7 +240,7 @@ func newTestEnv(t *testing.T, opts ...testEnvOption) *testEnv {
 	generator := sched.Generator.Get(ctx)
 	generator.LastProcessedTime = timestamppb.New(now)
 
-	_, err = node.CloseTransaction()
+	_, err = node.CloseTransaction(chasm.TransactionPolicyActive)
 	if err != nil {
 		t.Fatalf("failed to close initial transaction: %v", err)
 	}
@@ -276,7 +276,7 @@ func (e *testEnv) ReadContext() chasm.Context {
 
 // CloseTransaction closes the current CHASM transaction.
 func (e *testEnv) CloseTransaction() error {
-	_, err := e.Node.CloseTransaction()
+	_, err := e.Node.CloseTransaction(chasm.TransactionPolicyActive)
 	return err
 }
 
@@ -409,7 +409,7 @@ func setupSchedulerForTest(t *testing.T) (*scheduler.Scheduler, chasm.MutableCon
 	if err != nil {
 		t.Fatalf("failed to set root component: %v", err)
 	}
-	_, err = infra.node.CloseTransaction()
+	_, err = infra.node.CloseTransaction(chasm.TransactionPolicyActive)
 	if err != nil {
 		t.Fatalf("failed to close initial transaction: %v", err)
 	}
@@ -429,7 +429,7 @@ func setupSentinelForTest(t *testing.T) (*scheduler.Scheduler, chasm.MutableCont
 	if err != nil {
 		t.Fatalf("failed to set root component: %v", err)
 	}
-	_, err = infra.node.CloseTransaction()
+	_, err = infra.node.CloseTransaction(chasm.TransactionPolicyActive)
 	if err != nil {
 		t.Fatalf("failed to close initial transaction: %v", err)
 	}

--- a/chasm/lib/scheduler/scheduler_nexus_completion_test.go
+++ b/chasm/lib/scheduler/scheduler_nexus_completion_test.go
@@ -45,7 +45,7 @@ func executeNexusCompletion(t *testing.T, tc nexusCompletionTestCase) {
 	err := sched.HandleNexusCompletion(ctx, tc.completion)
 	require.NoError(t, err)
 
-	_, err = node.CloseTransaction()
+	_, err = node.CloseTransaction(chasm.TransactionPolicyActive)
 	require.NoError(t, err)
 
 	readCtx := chasm.NewContext(context.Background(), node)

--- a/chasm/lib/scheduler/scheduler_record_completed_action_test.go
+++ b/chasm/lib/scheduler/scheduler_record_completed_action_test.go
@@ -30,7 +30,7 @@ func executeRecordCompletedAction(t *testing.T, tc recordCompletedActionTestCase
 
 	sched.RecordCompletedAction(ctx, tc.completed, tc.requestID)
 
-	_, err := node.CloseTransaction()
+	_, err := node.CloseTransaction(chasm.TransactionPolicyActive)
 	require.NoError(t, err)
 
 	readCtx := chasm.NewContext(context.Background(), node)

--- a/chasm/lib/scheduler/scheduler_test.go
+++ b/chasm/lib/scheduler/scheduler_test.go
@@ -136,7 +136,7 @@ func TestCreateSchedulerFromMigration(t *testing.T) {
 	require.Equal(t, []byte("result-data"), lastResult.Success.Data)
 
 	require.NoError(t, node.SetRootComponent(sched))
-	_, err = node.CloseTransaction()
+	_, err = node.CloseTransaction(chasm.TransactionPolicyActive)
 	require.NoError(t, err)
 }
 
@@ -170,7 +170,7 @@ func TestUpdate_WithNilMemo(t *testing.T) {
 	visibility.MergeCustomMemo(ctx, map[string]*commonpb.Payload{
 		"existing": {Data: []byte("value")},
 	})
-	_, err := node.CloseTransaction()
+	_, err := node.CloseTransaction(chasm.TransactionPolicyActive)
 	require.NoError(t, err)
 
 	// Update without memo (nil) should preserve existing memo.
@@ -199,7 +199,7 @@ func TestUpdate_MemoReplaceSemantics(t *testing.T) {
 		"A": {Data: []byte("1")},
 		"B": {Data: []byte("2")},
 	})
-	_, err := node.CloseTransaction()
+	_, err := node.CloseTransaction(chasm.TransactionPolicyActive)
 	require.NoError(t, err)
 
 	// Update with only C: should fully replace memo (A and B are gone).
@@ -226,7 +226,7 @@ func TestUpdate_MemoReplaceSemantics(t *testing.T) {
 	protorequire.ProtoEqual(t, &commonpb.Payload{Data: []byte("3")}, memo["C"])
 
 	// Update with empty memo: should clear all memo fields.
-	_, err = node.CloseTransaction()
+	_, err = node.CloseTransaction(chasm.TransactionPolicyActive)
 	require.NoError(t, err)
 	ctx = chasm.NewMutableContext(context.Background(), node)
 	_, err = sched.Update(ctx, &schedulerpb.UpdateScheduleRequest{
@@ -277,7 +277,7 @@ func TestCreateSchedulerFromMigration_EmptyState(t *testing.T) {
 	require.Empty(t, invoker.BufferedStarts)
 
 	require.NoError(t, node.SetRootComponent(sched))
-	_, err = node.CloseTransaction()
+	_, err = node.CloseTransaction(chasm.TransactionPolicyActive)
 	require.NoError(t, err)
 }
 
@@ -307,7 +307,7 @@ func TestCreateSchedulerFromMigration_NoRunning(t *testing.T) {
 	sched, err := scheduler.CreateSchedulerFromMigration(ctx, req)
 	require.NoError(t, err)
 	require.NoError(t, infra.node.SetRootComponent(sched))
-	_, err = infra.node.CloseTransaction()
+	_, err = infra.node.CloseTransaction(chasm.TransactionPolicyActive)
 	require.NoError(t, err)
 
 	hasGeneratorTask := false
@@ -593,7 +593,7 @@ func TestSearchAttributes_RoundTripThroughCloseTransaction(t *testing.T) {
 	sched.IdleCloseTime = timestamppb.New(time.Now().Add(7 * 24 * time.Hour))
 
 	require.NoError(t, node.SetRootComponent(sched))
-	_, err := node.CloseTransaction()
+	_, err := node.CloseTransaction(chasm.TransactionPolicyActive)
 	require.NoError(t, err, "CloseTransaction should accept the scheduler search attributes")
 }
 

--- a/chasm/skip_persistence_test.go
+++ b/chasm/skip_persistence_test.go
@@ -23,7 +23,7 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_NewNode() {
 	rootNode := NewEmptyTree(s.registry, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
 	s.NoError(rootNode.SetRootComponent(s.minimalTestComponent()))
 
-	mutation, err := rootNode.CloseTransaction()
+	mutation, err := rootNode.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	s.Contains(mutation.UpdatedNodes, "", "brand-new node must always be persisted")
@@ -37,7 +37,7 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_LoadedUnmodified() {
 	rootNode := NewEmptyTree(s.registry, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
 	s.NoError(rootNode.SetRootComponent(s.minimalTestComponent()))
 
-	firstMutation, err := rootNode.CloseTransaction()
+	firstMutation, err := rootNode.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	s.Contains(firstMutation.UpdatedNodes, "", "new node must be in UpdatedNodes")
 
@@ -56,7 +56,7 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_LoadedUnmodified() {
 	_, err = rootNode2.Component(ctx, ComponentRef{})
 	s.NoError(err)
 
-	secondMutation, err := rootNode2.CloseTransaction()
+	secondMutation, err := rootNode2.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	s.NotContains(secondMutation.UpdatedNodes, "", "unchanged node must not be in UpdatedNodes")
@@ -74,7 +74,7 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_LoadedModified() {
 	rootNode := NewEmptyTree(s.registry, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
 	s.NoError(rootNode.SetRootComponent(s.minimalTestComponent()))
 
-	firstMutation, err := rootNode.CloseTransaction()
+	firstMutation, err := rootNode.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	persistedNodes := common.CloneProtoMap(firstMutation.UpdatedNodes)
 
@@ -90,7 +90,7 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_LoadedModified() {
 
 	component.(*TestComponent).ComponentData.RunId = "modified-run-id"
 
-	secondMutation, err := rootNode2.CloseTransaction()
+	secondMutation, err := rootNode2.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	s.Contains(secondMutation.UpdatedNodes, "", "modified node must be in UpdatedNodes")
@@ -108,7 +108,7 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_WithNewTask() {
 	rootNode := NewEmptyTree(s.registry, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
 	s.NoError(rootNode.SetRootComponent(s.minimalTestComponent()))
 
-	firstMutation, err := rootNode.CloseTransaction()
+	firstMutation, err := rootNode.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	persistedNodes := common.CloneProtoMap(firstMutation.UpdatedNodes)
 
@@ -126,7 +126,7 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_WithNewTask() {
 		Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 	ctx.AddTask(component, TaskAttributes{}, &TestSideEffectTask{Data: []byte("task-payload")})
 
-	secondMutation, err := rootNode2.CloseTransaction()
+	secondMutation, err := rootNode2.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	s.Contains(secondMutation.UpdatedNodes, "", "node with a new task must be in UpdatedNodes even if data is unchanged")
@@ -150,7 +150,7 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_DeleteUnpersistedNode() {
 	component := rootNode.value.(*TestComponent)
 	component.SubComponent1 = NewEmptyField[*TestSubComponent1]()
 
-	mutation, err := rootNode.CloseTransaction()
+	mutation, err := rootNode.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	s.Contains(mutation.UpdatedNodes, "", "root still needs initial persistence")

--- a/chasm/transaction_policy.go
+++ b/chasm/transaction_policy.go
@@ -1,0 +1,12 @@
+package chasm
+
+type TransactionPolicy int
+
+func (policy TransactionPolicy) Ptr() *TransactionPolicy {
+	return &policy
+}
+
+const (
+	TransactionPolicyActive  TransactionPolicy = 0
+	TransactionPolicyPassive TransactionPolicy = 1
+)

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -1688,7 +1688,7 @@ func (n *Node) AddTask(
 
 // CloseTransaction is used by MutableState to close the transaction and
 // track changes made in the current transaction.
-func (n *Node) CloseTransaction() (NodesMutation, error) {
+func (n *Node) CloseTransaction(transactionPolicy TransactionPolicy) (NodesMutation, error) {
 	defer n.cleanupTransaction()
 
 	if err := n.executeImmediatePureTasks(); err != nil {
@@ -1734,7 +1734,7 @@ func (n *Node) CloseTransaction() (NodesMutation, error) {
 		return NodesMutation{}, err
 	}
 
-	if err := n.closeTransactionHandleTimeSkipping(immutableContext); err != nil {
+	if err := n.closeTransactionHandleTimeSkipping(immutableContext, transactionPolicy); err != nil {
 		return NodesMutation{}, err
 	}
 
@@ -3751,7 +3751,12 @@ func encodeChasmBlob(m proto.Message) (*commonpb.DataBlob, error) {
 	return serialization.Encode(m, serialization.WithDeterministicProto3)
 }
 
-func (n *Node) closeTransactionHandleTimeSkipping(immutableContext Context) error {
+// closeTransactionHandleTimeSkipping includes all the steps needed at close transaction time
+// for time skipping of an execution in an active cluster.
+func (n *Node) closeTransactionHandleTimeSkipping(chasmContext Context, transactionPolicy TransactionPolicy) error {
+	if transactionPolicy != TransactionPolicyActive {
+		return nil
+	}
 	if n.parent != nil {
 		n.logger.Warn("time skipping handler called on non-root component is no-op")
 		return nil
@@ -3766,9 +3771,7 @@ func (n *Node) closeTransactionHandleTimeSkipping(immutableContext Context) erro
 		return nil
 	}
 
-	// todo@feiyang: how to check that the current cluster is active cluster
-	// and this closeTransaction state change logic should only happen in active cluster
-	rootComponent, err := n.Component(immutableContext, ComponentRef{})
+	rootComponent, err := n.Component(chasmContext, ComponentRef{})
 	if err != nil {
 		return err
 	}
@@ -3781,7 +3784,7 @@ func (n *Node) closeTransactionHandleTimeSkipping(immutableContext Context) erro
 	}
 
 	// runtime check
-	if !tsRoot.IsExecutionSkippable(immutableContext) {
+	if !tsRoot.IsExecutionSkippable(chasmContext) {
 		return nil
 	}
 	transition := n.defaultFindNextTargetTime()

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -318,7 +318,7 @@ func (s *nodeSuite) TestCollectionAttributes() {
 			err = rootNode.SetRootComponent(rootComponent)
 			s.NoError(err)
 
-			mutations, err := rootNode.CloseTransaction()
+			mutations, err := rootNode.CloseTransaction(TransactionPolicyActive)
 			s.NoError(err)
 			s.Len(mutations.UpdatedNodes, 4, "root, collection, and 2 collection items must be updated")
 			s.Empty(mutations.DeletedNodes)
@@ -384,7 +384,7 @@ func (s *nodeSuite) TestCollectionAttributes() {
 				rootComponent.PendingActivities = nil
 			}
 
-			mutation, err := rootNode.CloseTransaction()
+			mutation, err := rootNode.CloseTransaction(TransactionPolicyActive)
 			s.NoError(err)
 			s.Empty(mutation.UpdatedNodes, "root component data is unchanged; collection deletion is tracked by DeletedNodes")
 			s.Len(mutation.DeletedNodes, 3, "collection and 2 collection items must be deleted")
@@ -408,7 +408,7 @@ func (s *nodeSuite) TestCollectionAttributes() {
 				delete(rootComponent.PendingActivities, 1)
 			}
 
-			mutation, err := rootNode.CloseTransaction()
+			mutation, err := rootNode.CloseTransaction(TransactionPolicyActive)
 			s.NoError(err)
 			s.Empty(mutation.UpdatedNodes, "root component data is unchanged; collection item deletion is tracked by DeletedNodes")
 			s.Len(mutation.DeletedNodes, 1, "collection item 1 must be deleted")
@@ -435,7 +435,7 @@ func (s *nodeSuite) TestCollectionAttributes() {
 			}
 
 			// Now map is empty and must be deleted.
-			mutation, err := rootNode.CloseTransaction()
+			mutation, err := rootNode.CloseTransaction(TransactionPolicyActive)
 			s.NoError(err)
 			s.Empty(mutation.UpdatedNodes, "root component data is unchanged; collection deletion is tracked by DeletedNodes")
 			s.Len(mutation.DeletedNodes, 3, "collection and 2 items must be deleted")
@@ -452,7 +452,7 @@ func (s *nodeSuite) TestCollectionAttributes() {
 			err = rootNode.SetRootComponent(&TestComponent{}) // all map fields are nil
 			s.NoError(err)
 
-			mutation, err := rootNode.CloseTransaction()
+			mutation, err := rootNode.CloseTransaction(TransactionPolicyActive)
 			s.NoError(err)
 			s.Empty(mutation.DeletedNodes, "no nodes should be deleted for a map that never existed")
 		})
@@ -477,7 +477,7 @@ func (s *nodeSuite) TestCollectionAttributes() {
 			err = rootNode.SetRootComponent(&rootComponent)
 			s.NoError(err)
 
-			mutation, err := rootNode.CloseTransaction()
+			mutation, err := rootNode.CloseTransaction(TransactionPolicyActive)
 			s.NoError(err)
 			s.Empty(mutation.DeletedNodes, "no nodes should be deleted for a newly-created empty map")
 		})
@@ -494,7 +494,7 @@ func (s *nodeSuite) TestMapDeserializeNilToEmpty() {
 	err = rootNode.SetRootComponent(&TestComponent{})
 	s.NoError(err)
 
-	mutations, err := rootNode.CloseTransaction()
+	mutations, err := rootNode.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	// Only root is updated; no collection nodes because maps were nil/empty.
 	s.Len(mutations.UpdatedNodes, 1)
@@ -551,7 +551,7 @@ func (s *nodeSuite) TestPointerAttributes() {
 
 		s.Equal(fieldTypeDeferredPointer, sc11.GrandparentPointer.Internal.ft)
 
-		mutations, err := rootNode.CloseTransaction()
+		mutations, err := rootNode.CloseTransaction(TransactionPolicyActive)
 		s.NoError(err)
 		s.Len(mutations.UpdatedNodes, 5, "root, SubComponent1, SubComponent11, GrandparentPointer, and SubComponentInterfacePointer must be updated")
 		s.Empty(mutations.DeletedNodes)
@@ -610,7 +610,7 @@ func (s *nodeSuite) TestPointerAttributes() {
 
 		sc11Des.GrandparentPointer = NewEmptyField[*TestComponent]()
 
-		mutation, err := rootNode.CloseTransaction()
+		mutation, err := rootNode.CloseTransaction(TransactionPolicyActive)
 		s.NoError(err)
 		s.Empty(mutation.UpdatedNodes)
 		s.Len(mutation.DeletedNodes, 1, "GrandparentPointer must be deleted")
@@ -1125,7 +1125,7 @@ func (s *nodeSuite) TestApplyMutation_InvalidatesHydratedMapAncestors() {
 		root, err := s.newTestTree(nil)
 		s.NoError(err)
 		s.NoError(root.SetRootComponent(component))
-		mutation, err := root.CloseTransaction()
+		mutation, err := root.CloseTransaction(TransactionPolicyActive)
 		s.NoError(err)
 		s.NotEmpty(mutation.UpdatedNodes)
 		return common.CloneProtoMap(mutation.UpdatedNodes)
@@ -1142,7 +1142,7 @@ func (s *nodeSuite) TestApplyMutation_InvalidatesHydratedMapAncestors() {
 		component, err := source.Component(chasmContext, ComponentRef{})
 		s.NoError(err)
 		mutate(chasmContext, component.(*TestComponent))
-		mutation, err := source.CloseTransaction()
+		mutation, err := source.CloseTransaction(TransactionPolicyActive)
 		s.NoError(err)
 		s.NotContains(mutation.UpdatedNodes, "", "replicated mutation must not include the hydrated parent component")
 		return NodesMutation{
@@ -1544,7 +1544,7 @@ func (s *nodeSuite) TestRefreshTasks() {
 	s.True(root.IsDirty())
 	s.False(root.IsStateDirty())
 
-	mutation, err := root.CloseTransaction()
+	mutation, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	s.Len(mutation.UpdatedNodes, 2) // TaskStatus for the root node is not reset, so no need to persist it.
 	s.Equal(2, s.nodeBackend.NumTasksAdded())
@@ -2281,7 +2281,7 @@ func (s *nodeSuite) TestCloseTransaction_Success() {
 	tc.(*TestComponent).SubData1 = NewEmptyField[*protoMessageType]()
 	tc.(*TestComponent).ComponentData = &protoMessageType{CreateRequestId: primitives.NewUUID().String()}
 
-	mutations, err := node.CloseTransaction()
+	mutations, err := node.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	s.Len(mutations.UpdatedNodes, 4)
 	s.Contains(mutations.UpdatedNodes, "", "root component must be in UpdatedNodes")
@@ -2294,7 +2294,7 @@ func (s *nodeSuite) TestCloseTransaction_Success() {
 	sc1 := tc.(*TestComponent).SubComponent1.Get(chasmCtx)
 	s.NotNil(sc1)
 
-	mutations, err = node.CloseTransaction()
+	mutations, err = node.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	s.Empty(mutations.UpdatedNodes)
 	s.Empty(mutations.DeletedNodes)
@@ -2307,7 +2307,7 @@ func (s *nodeSuite) TestCloseTransaction_EmptyNode() {
 	s.NoError(err)
 	s.Nil(node.value)
 
-	mutations, err := node.CloseTransaction()
+	mutations, err := node.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	s.Empty(mutations.UpdatedNodes, "there should be no updated nodes because tree was initialized with empty serialized nodes")
 	s.Empty(mutations.DeletedNodes, "there should be no deleted nodes because tree was initialized with empty serialized nodes")
@@ -2319,7 +2319,7 @@ func (s *nodeSuite) TestCloseTransaction_LifecycleChange() {
 	chasmCtx := NewMutableContext(context.Background(), node)
 	_, err := node.Component(chasmCtx, ComponentRef{componentPath: rootPath})
 	s.NoError(err)
-	_, err = node.CloseTransaction()
+	_, err = node.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING, s.nodeBackend.LastUpdateWorkflowState())
 	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, s.nodeBackend.LastUpdateWorkflowStatus())
@@ -2328,7 +2328,7 @@ func (s *nodeSuite) TestCloseTransaction_LifecycleChange() {
 	_, err = node.Component(chasmCtx, ComponentRef{componentPath: rootPath})
 	s.NoError(err)
 	node.terminated = true
-	_, err = node.CloseTransaction()
+	_, err = node.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED, s.nodeBackend.LastUpdateWorkflowState())
 	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED, s.nodeBackend.LastUpdateWorkflowStatus())
@@ -2337,7 +2337,7 @@ func (s *nodeSuite) TestCloseTransaction_LifecycleChange() {
 	tc, err := node.Component(chasmCtx, ComponentRef{componentPath: rootPath})
 	s.NoError(err)
 	tc.(*TestComponent).Complete(chasmCtx)
-	_, err = node.CloseTransaction()
+	_, err = node.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED, s.nodeBackend.LastUpdateWorkflowState())
 	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, s.nodeBackend.LastUpdateWorkflowStatus())
@@ -2345,7 +2345,7 @@ func (s *nodeSuite) TestCloseTransaction_LifecycleChange() {
 	tc, err = node.Component(chasmCtx, ComponentRef{componentPath: rootPath})
 	s.NoError(err)
 	tc.(*TestComponent).Fail(chasmCtx)
-	_, err = node.CloseTransaction()
+	_, err = node.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED, s.nodeBackend.LastUpdateWorkflowState())
 	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_FAILED, s.nodeBackend.LastUpdateWorkflowStatus())
@@ -2367,7 +2367,7 @@ func (s *nodeSuite) TestCloseTransaction_ForceUpdateVisibility_RootLifecycleChan
 
 	// Init visiblity component
 	testComponent.(*TestComponent).Visibility = NewComponentField(chasmCtx, NewVisibility(chasmCtx))
-	mutation, err := node.CloseTransaction()
+	mutation, err := node.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	pVisibilityNode, ok := mutation.UpdatedNodes["Visibility"]
 	s.True(ok)
@@ -2386,7 +2386,7 @@ func (s *nodeSuite) TestCloseTransaction_ForceUpdateVisibility_RootLifecycleChan
 	s.nodeBackend.HandleUpdateWorkflowStateStatus = func(state enumsspb.WorkflowExecutionState, status enumspb.WorkflowExecutionStatus) (bool, error) {
 		return false, nil
 	}
-	mutation, err = node.CloseTransaction()
+	mutation, err = node.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	pVisibilityNode, ok = mutation.UpdatedNodes["Visibility"]
 	s.True(ok, "visibility should be updated when memo changes")
@@ -2401,7 +2401,7 @@ func (s *nodeSuite) TestCloseTransaction_ForceUpdateVisibility_RootLifecycleChan
 	s.nodeBackend.HandleUpdateWorkflowStateStatus = func(state enumsspb.WorkflowExecutionState, status enumspb.WorkflowExecutionStatus) (bool, error) {
 		return true, nil
 	}
-	mutation, err = node.CloseTransaction()
+	mutation, err = node.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	pVisibilityNode, ok = mutation.UpdatedNodes["Visibility"]
 	s.True(ok)
@@ -2424,7 +2424,7 @@ func (s *nodeSuite) TestCloseTransaction_ForceUpdateVisibility_RootSAMemoChanged
 	s.nodeBackend.HandleUpdateWorkflowStateStatus = func(state enumsspb.WorkflowExecutionState, status enumspb.WorkflowExecutionStatus) (bool, error) {
 		return true, nil
 	}
-	mutation, err := node.CloseTransaction()
+	mutation, err := node.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	pVisibilityNode, ok := mutation.UpdatedNodes["Visibility"]
 	s.True(ok)
@@ -2441,7 +2441,7 @@ func (s *nodeSuite) TestCloseTransaction_ForceUpdateVisibility_RootSAMemoChanged
 	s.nodeBackend.HandleUpdateWorkflowStateStatus = func(state enumsspb.WorkflowExecutionState, status enumspb.WorkflowExecutionStatus) (bool, error) {
 		return false, nil
 	}
-	mutation, err = node.CloseTransaction()
+	mutation, err = node.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	pVisibilityNode, ok = mutation.UpdatedNodes["Visibility"]
 	s.True(ok)
@@ -2519,7 +2519,7 @@ func (s *nodeSuite) TestCloseTransaction_CleanupTasksAfterInvalidTask() {
 		Return(true, nil).
 		Times(1)
 
-	mutation, err := root.CloseTransaction()
+	mutation, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	s.Equal(now.Add(1*time.Minute), s.nodeBackend.LastDeletePureTaskCall())
@@ -2630,7 +2630,7 @@ func (s *nodeSuite) TestCloseTransaction_InvalidateComponentTasks() {
 	s.testLibrary.mockPureTaskHandler.EXPECT().
 		Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil).Times(2)
 
-	mutation, err := root.CloseTransaction()
+	mutation, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	s.Equal(tasks.MaximumKey.FireTime, s.nodeBackend.LastDeletePureTaskCall())
@@ -2702,7 +2702,7 @@ func (s *nodeSuite) TestCloseTransaction_PausedStateInvalidatesTasks() {
 		// Task-specific validators must NOT be called - paused state short-circuits them.
 		// (no EXPECT calls on mock handlers)
 
-		mutation, err := root.CloseTransaction()
+		mutation, err := root.CloseTransaction(TransactionPolicyActive)
 		s.NoError(err)
 
 		componentAttr := root.serializedNode.Metadata.GetComponentAttributes()
@@ -2752,7 +2752,7 @@ func (s *nodeSuite) TestCloseTransaction_PausedStateInvalidatesTasks() {
 		s.NoError(err)
 		tc.(*TestComponent).Pause(mutableContext)
 
-		mutation, err := root.CloseTransaction()
+		mutation, err := root.CloseTransaction(TransactionPolicyActive)
 		s.NoError(err)
 
 		subAttr := root.children["SubComponent1"].serializedNode.Metadata.GetComponentAttributes()
@@ -2804,7 +2804,7 @@ func (s *nodeSuite) TestCloseTransaction_PausedStateInvalidatesTasks() {
 		s.testLibrary.mockSideEffectTaskHandler.EXPECT().
 			Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 
-		mutation, err := root.CloseTransaction()
+		mutation, err := root.CloseTransaction(TransactionPolicyActive)
 		s.NoError(err)
 
 		subAttr := root.children["SubComponent1"].serializedNode.Metadata.GetComponentAttributes()
@@ -2915,7 +2915,7 @@ func (s *nodeSuite) TestCloseTransaction_TaskValidationSubtreeDirty() {
 		// SubComponent2's validator must NOT be called - its subtree is clean.
 		// (no EXPECT on mockSideEffectTaskHandler for SubComponent2)
 
-		_, err = root.CloseTransaction()
+		_, err = root.CloseTransaction(TransactionPolicyActive)
 		s.NoError(err)
 
 		sc2Attr := root.children["SubComponent2"].serializedNode.Metadata.GetComponentAttributes()
@@ -2936,7 +2936,7 @@ func (s *nodeSuite) TestCloseTransaction_TaskValidationSubtreeDirty() {
 
 		// Both sub-components' tasks are invalidated by the paused ancestor
 		// (validateAccess short-circuits before calling task validators).
-		_, err = root.CloseTransaction()
+		_, err = root.CloseTransaction(TransactionPolicyActive)
 		s.NoError(err)
 
 		sc1Attr := root.children["SubComponent1"].serializedNode.Metadata.GetComponentAttributes()
@@ -2969,7 +2969,7 @@ func (s *nodeSuite) TestCloseTransaction_TaskValidationSubtreeDirty() {
 		s.testLibrary.mockSideEffectTaskHandler.EXPECT().
 			Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 
-		_, err = root.CloseTransaction()
+		_, err = root.CloseTransaction(TransactionPolicyActive)
 		s.NoError(err)
 	})
 
@@ -2987,7 +2987,7 @@ func (s *nodeSuite) TestCloseTransaction_TaskValidationSubtreeDirty() {
 		s.testLibrary.mockSideEffectTaskHandler.EXPECT().
 			Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 
-		_, err = root.CloseTransaction()
+		_, err = root.CloseTransaction(TransactionPolicyActive)
 		s.NoError(err)
 
 		// After CloseTransaction, subtreeIsDirty must be reset on all nodes.
@@ -3027,7 +3027,7 @@ func (s *nodeSuite) TestCloseTransaction_TaskValidationSubtreeDirty() {
 		s.False(executed)
 		s.True(root.subtreeIsDirty, "ExecutePureTask must mark subtreeIsDirty even when task is invalid")
 
-		_, err = root.CloseTransaction()
+		_, err = root.CloseTransaction(TransactionPolicyActive)
 		s.NoError(err)
 
 		componentAttr := root.serializedNode.Metadata.GetComponentAttributes()
@@ -3045,7 +3045,7 @@ func (s *nodeSuite) TestCloseTransaction_LifecycleChange_PausedRootKeepsRunning(
 	s.NoError(err)
 	rootComp.(*TestComponent).Pause(chasmCtx)
 
-	_, err = node.CloseTransaction()
+	_, err = node.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING, s.nodeBackend.LastUpdateWorkflowState())
 	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, s.nodeBackend.LastUpdateWorkflowStatus())
@@ -3150,7 +3150,7 @@ func (s *nodeSuite) TestCloseTransaction_NewComponentTasks() {
 		TestOutboundSideEffectTask{},
 	)
 
-	mutation, err := root.CloseTransaction()
+	mutation, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	s.Equal(s.timeSource.Now().UTC(), s.nodeBackend.LastDeletePureTaskCall())
@@ -3294,7 +3294,7 @@ func (s *nodeSuite) TestCloseTransaction_ApplyMutation_SideEffectTasks() {
 	s.NoError(err)
 
 	expectedCategories := []tasks.Category{tasks.CategoryTimer, tasks.CategoryOutbound, tasks.CategoryTransfer}
-	_, err = root.CloseTransaction()
+	_, err = root.CloseTransaction(TransactionPolicyActive)
 	for _, category := range expectedCategories {
 		for _, task := range s.nodeBackend.TasksByCategory[category] {
 			s.IsType(&tasks.ChasmTask{}, task)
@@ -3381,7 +3381,7 @@ func (s *nodeSuite) TestCloseTransaction_ApplyMutation_PureTasks() {
 	err = root.ApplyMutation(incomingMutation)
 	s.NoError(err)
 
-	mutation, err := root.CloseTransaction()
+	mutation, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	s.Equal(now.Add(time.Minute), s.nodeBackend.LastDeletePureTaskCall())
@@ -3400,7 +3400,7 @@ func (s *nodeSuite) TestTerminate() {
 	node := s.testComponentTree()
 
 	// First closeTransaction once to make the tree clean.
-	_, err := node.CloseTransaction()
+	_, err := node.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING, s.nodeBackend.LastUpdateWorkflowState())
@@ -3411,7 +3411,7 @@ func (s *nodeSuite) TestTerminate() {
 	s.NoError(err)
 	s.True(node.terminated)
 
-	mutations, err := node.CloseTransaction()
+	mutations, err := node.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	s.Len(mutations.UpdatedNodes, 1)
 	s.Empty(mutations.DeletedNodes)
@@ -3435,7 +3435,7 @@ func (s *nodeSuite) TestTerminate() {
 	_, err = node.Component(mutableContext, ComponentRef{})
 	s.NoError(err)
 
-	mutations, err = node.CloseTransaction()
+	mutations, err = node.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	s.Empty(mutations.UpdatedNodes)
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED, s.nodeBackend.LastUpdateWorkflowState())
@@ -3565,7 +3565,7 @@ func (s *nodeSuite) TestContextNowStableWithinContext() {
 func (s *nodeSuite) TestExecuteImmediatePureTask() {
 	root := s.testComponentTree()
 
-	mutations, err := root.CloseTransaction()
+	mutations, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	// Start a clean transaction.
@@ -3607,7 +3607,7 @@ func (s *nodeSuite) TestExecuteImmediatePureTask() {
 			gomock.Any(),
 		).Return(nil).Times(1)
 
-	mutations, err = root.CloseTransaction()
+	mutations, err = root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	s.Empty(mutations.UpdatedNodes)
 	s.Empty(mutations.DeletedNodes)
@@ -3619,7 +3619,7 @@ func (s *nodeSuite) TestExecuteImmediatePureTask() {
 func (s *nodeSuite) TestImmediatePureTaskNowStableWithinTaskOnly() {
 	root := s.testComponentTree()
 
-	_, err := root.CloseTransaction()
+	_, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	taskStartTime := time.Date(2026, 1, 1, 2, 0, 0, 0, time.UTC)
@@ -3667,7 +3667,7 @@ func (s *nodeSuite) TestImmediatePureTaskNowStableWithinTaskOnly() {
 		}).
 		Times(2)
 
-	mutations, err := root.CloseTransaction()
+	mutations, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	s.Empty(mutations.DeletedNodes)
 	s.Equal([]time.Time{taskStartTime, nextTaskTime}, observedTimes)
@@ -4426,7 +4426,7 @@ func (s *nodeSuite) TestCloseTransaction_AppliesPendingComponentMetadata() {
 	root := s.testComponentTree() // sets HandleNextTransitionCount = 1, HandleGetCurrentVersion = 1
 
 	// Initial create transaction must close cleanly before we exercise the metadata path.
-	_, err := root.CloseTransaction()
+	_, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	// Bump the transition count so we can verify LastUpdateVersionedTransition was updated.
@@ -4439,7 +4439,7 @@ func (s *nodeSuite) TestCloseTransaction_AppliesPendingComponentMetadata() {
 	s.NoError(ctx.SetRequestLinks(c, requestID, []*commonpb.Link{link}))
 	s.NoError(ctx.SetUserMetadata(c, md))
 
-	mutation, err := root.CloseTransaction()
+	mutation, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	rootSerialized, ok := mutation.UpdatedNodes[""]
@@ -4461,7 +4461,7 @@ func (s *nodeSuite) TestCloseTransaction_AppliesPendingComponentMetadata() {
 // before CloseTransaction runs.
 func (s *nodeSuite) TestSetComponentMetadata_MarksTreeDirty() {
 	root := s.testComponentTree()
-	_, err := root.CloseTransaction()
+	_, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	s.False(root.IsDirty(), "tree must be clean after the initial close")
@@ -4479,7 +4479,7 @@ func (s *nodeSuite) TestSetComponentMetadata_MarksTreeDirty() {
 	s.True(root.IsStateDirty(), "staging SetRequestLinks must mark the tree dirty")
 	s.True(root.IsDirty())
 
-	_, err = root.CloseTransaction()
+	_, err = root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	s.False(root.IsStateDirty(), "CloseTransaction must clear the dirty flag")
 
@@ -4500,7 +4500,7 @@ func (s *nodeSuite) TestSetComponentMetadata_MarksTreeDirty() {
 // are cleared afterwards.
 func (s *nodeSuite) TestCloseTransaction_DropsOrphanedComponentMetadata() {
 	root := s.testComponentTree()
-	_, err := root.CloseTransaction()
+	_, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 2 }
@@ -4517,7 +4517,7 @@ func (s *nodeSuite) TestCloseTransaction_DropsOrphanedComponentMetadata() {
 		Summary: &commonpb.Payload{Data: []byte("orphan")},
 	}))
 
-	mutation, err := root.CloseTransaction()
+	mutation, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	s.NotContains(mutation.UpdatedNodes, "", "root must not be updated by orphaned writes")
 	s.Empty(root.pendingRequestLinks)
@@ -4529,7 +4529,7 @@ func (s *nodeSuite) TestCloseTransaction_DropsOrphanedComponentMetadata() {
 // empty-string key.
 func (s *nodeSuite) TestSetComponentRequestLinks_RejectsEmptyRequestID() {
 	root := s.testComponentTree()
-	_, err := root.CloseTransaction()
+	_, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	ctx := NewMutableContext(context.Background(), root)
@@ -4554,7 +4554,7 @@ func (s *nodeSuite) TestSetComponentRequestLinks_RejectsEmptyRequestID() {
 // ChasmComponentAttributes.requests.
 func (s *nodeSuite) TestSetRequestLinks_MultipleRequestsCoexist() {
 	root := s.testComponentTree()
-	_, err := root.CloseTransaction()
+	_, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 2 }
@@ -4571,7 +4571,7 @@ func (s *nodeSuite) TestSetRequestLinks_MultipleRequestsCoexist() {
 	s.NoError(ctx.SetRequestLinks(c, "req-a", []*commonpb.Link{linkA}))
 	s.NoError(ctx.SetRequestLinks(c, "req-b", []*commonpb.Link{linkB}))
 
-	mutation, err := root.CloseTransaction()
+	mutation, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	attrs := mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes()
@@ -4585,7 +4585,7 @@ func (s *nodeSuite) TestSetRequestLinks_MultipleRequestsCoexist() {
 // transactions — leave only the second value in attrs.Requests.
 func (s *nodeSuite) TestSetRequestLinks_ReplacesEntryForSameRequestID() {
 	root := s.testComponentTree()
-	_, err := root.CloseTransaction()
+	_, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	linkA := &commonpb.Link{Variant: &commonpb.Link_WorkflowEvent_{
@@ -4604,7 +4604,7 @@ func (s *nodeSuite) TestSetRequestLinks_ReplacesEntryForSameRequestID() {
 	s.NoError(err)
 	s.NoError(ctx.SetRequestLinks(c, "req", []*commonpb.Link{linkA}))
 	s.NoError(ctx.SetRequestLinks(c, "req", []*commonpb.Link{linkB}))
-	mutation, err := root.CloseTransaction()
+	mutation, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	s.Equal([]*commonpb.Link{linkB},
 		mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes().GetRequests()["req"].GetLinks(),
@@ -4618,7 +4618,7 @@ func (s *nodeSuite) TestSetRequestLinks_ReplacesEntryForSameRequestID() {
 	c, err = root.Component(ctx, ComponentRef{})
 	s.NoError(err)
 	s.NoError(ctx.SetRequestLinks(c, "req", []*commonpb.Link{linkA}))
-	mutation, err = root.CloseTransaction()
+	mutation, err = root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	s.Equal([]*commonpb.Link{linkA},
 		mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes().GetRequests()["req"].GetLinks(),
@@ -4631,7 +4631,7 @@ func (s *nodeSuite) TestSetRequestLinks_ReplacesEntryForSameRequestID() {
 // ChasmComponentAttributes.requests.
 func (s *nodeSuite) TestSetRequestLinks_RemovesEntryWhenEmptyLinks() {
 	root := s.testComponentTree()
-	_, err := root.CloseTransaction()
+	_, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	link := &commonpb.Link{Variant: &commonpb.Link_WorkflowEvent_{
@@ -4645,7 +4645,7 @@ func (s *nodeSuite) TestSetRequestLinks_RemovesEntryWhenEmptyLinks() {
 	c, err := root.Component(ctx, ComponentRef{})
 	s.NoError(err)
 	s.NoError(ctx.SetRequestLinks(c, "req", []*commonpb.Link{link}))
-	mutation, err := root.CloseTransaction()
+	mutation, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	s.Contains(mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes().GetRequests(), "req")
 
@@ -4655,7 +4655,7 @@ func (s *nodeSuite) TestSetRequestLinks_RemovesEntryWhenEmptyLinks() {
 	c, err = root.Component(ctx, ComponentRef{})
 	s.NoError(err)
 	s.NoError(ctx.SetRequestLinks(c, "req", nil))
-	mutation, err = root.CloseTransaction()
+	mutation, err = root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	attrs := mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes()
 	s.NotContains(attrs.GetRequests(), "req", "empty links must remove the entry for requestID")
@@ -4667,7 +4667,7 @@ func (s *nodeSuite) TestSetRequestLinks_RemovesEntryWhenEmptyLinks() {
 // reading-then-writing within a single transaction never observe stale state.
 func (s *nodeSuite) TestRequestLinks_PrefersPendingOverPersisted() {
 	root := s.testComponentTree()
-	_, err := root.CloseTransaction()
+	_, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	oldLink := &commonpb.Link{Variant: &commonpb.Link_WorkflowEvent_{
@@ -4684,7 +4684,7 @@ func (s *nodeSuite) TestRequestLinks_PrefersPendingOverPersisted() {
 	c, err := root.Component(ctx, ComponentRef{})
 	s.NoError(err)
 	s.NoError(ctx.SetRequestLinks(c, "req", []*commonpb.Link{oldLink}))
-	_, err = root.CloseTransaction()
+	_, err = root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	// Open a new transaction, stage a replace with [newLink] under the same
@@ -4707,7 +4707,7 @@ func (s *nodeSuite) TestRequestLinks_PrefersPendingOverPersisted() {
 // B, read it back through the framework APIs.
 func (s *nodeSuite) TestCloseTransaction_PersistsAcrossTransactions() {
 	root := s.testComponentTree()
-	_, err := root.CloseTransaction()
+	_, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	link := &commonpb.Link{Variant: &commonpb.Link_WorkflowEvent_{
@@ -4722,7 +4722,7 @@ func (s *nodeSuite) TestCloseTransaction_PersistsAcrossTransactions() {
 	s.NoError(err)
 	s.NoError(ctx.SetRequestLinks(c, "req", []*commonpb.Link{link}))
 	s.NoError(ctx.SetUserMetadata(c, md))
-	_, err = root.CloseTransaction()
+	_, err = root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	// New transaction: framework getters must surface the persisted attrs.
@@ -4743,7 +4743,7 @@ func (s *nodeSuite) TestCloseTransaction_PersistsAcrossTransactions() {
 // component (rather than being treated as a no-op).
 func (s *nodeSuite) TestSetUserMetadata_NilClearsPersistedValue() {
 	root := s.testComponentTree()
-	_, err := root.CloseTransaction()
+	_, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	// Persist user metadata.
@@ -4755,7 +4755,7 @@ func (s *nodeSuite) TestSetUserMetadata_NilClearsPersistedValue() {
 	s.NoError(ctx.SetUserMetadata(c, &sdkpb.UserMetadata{
 		Summary: &commonpb.Payload{Data: []byte("first")},
 	}))
-	_, err = root.CloseTransaction()
+	_, err = root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 
 	// Clear with nil.
@@ -4764,7 +4764,7 @@ func (s *nodeSuite) TestSetUserMetadata_NilClearsPersistedValue() {
 	c, err = root.Component(ctx, ComponentRef{})
 	s.NoError(err)
 	s.NoError(ctx.SetUserMetadata(c, nil))
-	mutation, err := root.CloseTransaction()
+	mutation, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	s.Nil(mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes().GetUserMetadata())
 }
@@ -4798,7 +4798,7 @@ func (s *nodeSuite) TestCloseTransaction_SingletonTask_Replace_SideEffect() {
 		Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 	mutableContext.AddTask(testComponent, TaskAttributes{}, &TestSingletonReplaceSideEffectTask{Data: []byte("first")})
 
-	mutation, err := root.CloseTransaction()
+	mutation, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	rootAttr := mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes()
 	s.Len(rootAttr.SideEffectTasks, 1)
@@ -4817,7 +4817,7 @@ func (s *nodeSuite) TestCloseTransaction_SingletonTask_Replace_SideEffect() {
 		Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(2)
 	mutableContext.AddTask(testComponent, TaskAttributes{}, &TestSingletonReplaceSideEffectTask{Data: []byte("second")})
 
-	mutation, err = root.CloseTransaction()
+	mutation, err = root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	rootAttr = mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes()
 	s.Len(rootAttr.SideEffectTasks, 1, "replace mode must keep exactly one task")
@@ -4853,7 +4853,7 @@ func (s *nodeSuite) TestCloseTransaction_SingletonTask_Ignore_SideEffect() {
 		Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 	mutableContext.AddTask(testComponent, TaskAttributes{}, &TestSingletonIgnoreSideEffectTask{Data: []byte("first")})
 
-	mutation, err := root.CloseTransaction()
+	mutation, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	rootAttr := mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes()
 	s.Len(rootAttr.SideEffectTasks, 1)
@@ -4872,7 +4872,7 @@ func (s *nodeSuite) TestCloseTransaction_SingletonTask_Ignore_SideEffect() {
 		Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(2)
 	mutableContext.AddTask(testComponent, TaskAttributes{}, &TestSingletonIgnoreSideEffectTask{Data: []byte("second")})
 
-	mutation, err = root.CloseTransaction()
+	mutation, err = root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	rootAttr = mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes()
 	s.Len(rootAttr.SideEffectTasks, 1, "ignore mode must keep exactly one task")
@@ -4912,7 +4912,7 @@ func (s *nodeSuite) TestCloseTransaction_SingletonTask_Replace_Pure() {
 		Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 	mutableContext.AddTask(testComponent, TaskAttributes{ScheduledTime: t1}, &TestSingletonReplacePureTask{Data: []byte("first")})
 
-	mutation, err := root.CloseTransaction()
+	mutation, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	rootAttr := mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes()
 	s.Len(rootAttr.PureTasks, 1)
@@ -4931,7 +4931,7 @@ func (s *nodeSuite) TestCloseTransaction_SingletonTask_Replace_Pure() {
 		Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(2)
 	mutableContext.AddTask(testComponent, TaskAttributes{ScheduledTime: t2}, &TestSingletonReplacePureTask{Data: []byte("second")})
 
-	mutation, err = root.CloseTransaction()
+	mutation, err = root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	rootAttr = mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes()
 	s.Len(rootAttr.PureTasks, 1, "replace mode must keep exactly one task")
@@ -4971,7 +4971,7 @@ func (s *nodeSuite) TestCloseTransaction_SingletonTask_Ignore_Pure() {
 		Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 	mutableContext.AddTask(testComponent, TaskAttributes{ScheduledTime: t1}, &TestSingletonIgnorePureTask{Data: []byte("first")})
 
-	mutation, err := root.CloseTransaction()
+	mutation, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	rootAttr := mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes()
 	s.Len(rootAttr.PureTasks, 1)
@@ -4990,7 +4990,7 @@ func (s *nodeSuite) TestCloseTransaction_SingletonTask_Ignore_Pure() {
 		Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(2)
 	mutableContext.AddTask(testComponent, TaskAttributes{ScheduledTime: t2}, &TestSingletonIgnorePureTask{Data: []byte("second")})
 
-	mutation, err = root.CloseTransaction()
+	mutation, err = root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	rootAttr = mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes()
 	s.Len(rootAttr.PureTasks, 1, "ignore mode must keep exactly one task")
@@ -5027,7 +5027,7 @@ func (s *nodeSuite) TestCloseTransaction_SingletonTask_InvalidNewTask_DoesNotDis
 		Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 	mutableContext.AddTask(testComponent, TaskAttributes{}, &TestSingletonReplaceSideEffectTask{Data: []byte("first")})
 
-	mutation, err := root.CloseTransaction()
+	mutation, err := root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	rootAttr := mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes()
 	s.Len(rootAttr.SideEffectTasks, 1)
@@ -5049,7 +5049,7 @@ func (s *nodeSuite) TestCloseTransaction_SingletonTask_InvalidNewTask_DoesNotDis
 		Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
 	mutableContext.AddTask(testComponent, TaskAttributes{}, &TestSingletonReplaceSideEffectTask{Data: []byte("invalid-second")})
 
-	mutation, err = root.CloseTransaction()
+	mutation, err = root.CloseTransaction(TransactionPolicyActive)
 	s.NoError(err)
 	rootAttr = mutation.UpdatedNodes[""].GetMetadata().GetComponentAttributes()
 	s.Len(rootAttr.SideEffectTasks, 1, "invalid new task must not displace existing singleton")
@@ -5125,7 +5125,7 @@ func (s *nodeSuite) TestCloseTransactionHandleTimeSkipping() {
 
 		var err error
 		s.NotPanics(func() {
-			err = root.closeTransactionHandleTimeSkipping(NewContext(context.Background(), root))
+			err = root.closeTransactionHandleTimeSkipping(NewContext(context.Background(), root), TransactionPolicyActive)
 		})
 		s.NoError(err, "an execution without time-skipping info must be a safe no-op")
 	})
@@ -5163,7 +5163,7 @@ func (s *nodeSuite) TestCloseTransactionHandleTimeSkipping() {
 		// The FailOnAnyUnexpectedError logger also asserts that no error-level log is emitted.
 		var closeErr error
 		s.NotPanics(func() {
-			closeErr = child.closeTransactionHandleTimeSkipping(NewContext(context.Background(), child))
+			closeErr = child.closeTransactionHandleTimeSkipping(NewContext(context.Background(), child), TransactionPolicyActive)
 		})
 		s.NoError(closeErr)
 	})
@@ -5177,7 +5177,7 @@ func (s *nodeSuite) TestCloseTransactionHandleTimeSkipping() {
 
 		// Config disabled short-circuits before the gate check, so the missing
 		// TimeSkippingRuntimeGate on TestComponent must not surface as an error.
-		err := root.closeTransactionHandleTimeSkipping(NewContext(context.Background(), root))
+		err := root.closeTransactionHandleTimeSkipping(NewContext(context.Background(), root), TransactionPolicyActive)
 		s.NoError(err)
 	})
 
@@ -5192,7 +5192,7 @@ func (s *nodeSuite) TestCloseTransactionHandleTimeSkipping() {
 		s.Require().True(ok)
 		tl.Expect(testlogger.Error, "does not implement TimeSkippingRuntimeGate")
 
-		err := root.closeTransactionHandleTimeSkipping(NewContext(context.Background(), root))
+		err := root.closeTransactionHandleTimeSkipping(NewContext(context.Background(), root), TransactionPolicyActive)
 		s.Require().Error(err, "enabled config with no gate implementation is a misconfiguration")
 		var internalErr *serviceerror.Internal
 		s.ErrorAs(err, &internalErr, "the error must be an internal service error")
@@ -5203,7 +5203,7 @@ func (s *nodeSuite) TestCloseTransactionHandleTimeSkipping() {
 		var recorded *TimeSkippingTransition
 		s.nodeBackend.HandleRecordTimeSkippingTransition = func(tr *TimeSkippingTransition) { recorded = tr }
 
-		err := root.closeTransactionHandleTimeSkipping(NewContext(context.Background(), root))
+		err := root.closeTransactionHandleTimeSkipping(NewContext(context.Background(), root), TransactionPolicyActive)
 		s.NoError(err)
 		s.Nil(recorded, "a gate that reports not-skippable must not record a transition")
 		s.Equal(0, s.nodeBackend.NumTasksAdded(), "no timer tasks are regenerated when skipping is gated out")
@@ -5214,7 +5214,7 @@ func (s *nodeSuite) TestCloseTransactionHandleTimeSkipping() {
 		var recorded *TimeSkippingTransition
 		s.nodeBackend.HandleRecordTimeSkippingTransition = func(tr *TimeSkippingTransition) { recorded = tr }
 
-		err := root.closeTransactionHandleTimeSkipping(NewContext(context.Background(), root))
+		err := root.closeTransactionHandleTimeSkipping(NewContext(context.Background(), root), TransactionPolicyActive)
 		s.NoError(err)
 		s.Require().NotNil(recorded, "a skippable execution with a future timer must record a transition")
 		s.True(recorded.IsValid())

--- a/service/history/interfaces/chasm_tree.go
+++ b/service/history/interfaces/chasm_tree.go
@@ -16,7 +16,7 @@ var _ ChasmTree = (*chasm.Node)(nil)
 // TODO: Remove this interface and use *chasm.Node directly
 // when chasm/tree.go implementation completes.
 type ChasmTree interface {
-	CloseTransaction() (chasm.NodesMutation, error)
+	CloseTransaction(transactionPolicy chasm.TransactionPolicy) (chasm.NodesMutation, error)
 	Snapshot(*persistencespb.VersionedTransition) chasm.NodesSnapshot
 	ApplySystemMutation(chasm.NodesMutation) error
 	ApplyMutation(chasm.NodesMutation) error

--- a/service/history/interfaces/chasm_tree_mock.go
+++ b/service/history/interfaces/chasm_tree_mock.go
@@ -116,18 +116,18 @@ func (mr *MockChasmTreeMockRecorder) ArchetypeID() *gomock.Call {
 }
 
 // CloseTransaction mocks base method.
-func (m *MockChasmTree) CloseTransaction() (chasm.NodesMutation, error) {
+func (m *MockChasmTree) CloseTransaction(arg0 chasm.TransactionPolicy) (chasm.NodesMutation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CloseTransaction")
+	ret := m.ctrl.Call(m, "CloseTransaction", arg0)
 	ret0, _ := ret[0].(chasm.NodesMutation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CloseTransaction indicates an expected call of CloseTransaction.
-func (mr *MockChasmTreeMockRecorder) CloseTransaction() *gomock.Call {
+func (mr *MockChasmTreeMockRecorder) CloseTransaction(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseTransaction", reflect.TypeOf((*MockChasmTree)(nil).CloseTransaction))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseTransaction", reflect.TypeOf((*MockChasmTree)(nil).CloseTransaction), arg0)
 }
 
 // Component mocks base method.

--- a/service/history/workflow/context_test.go
+++ b/service/history/workflow/context_test.go
@@ -634,7 +634,7 @@ func (s *contextSuite) TestUpdateWorkflowExecutionWithNew_ChasmNoopSkipsPersiste
 	mockChasmTree.EXPECT().ArchetypeID().Return(chasmArchetypeID).AnyTimes()
 	mockChasmTree.EXPECT().IsStateDirty().Return(false).AnyTimes()
 	mockChasmTree.EXPECT().IsDirty().Return(false).AnyTimes()
-	mockChasmTree.EXPECT().CloseTransaction().Return(chasm.NodesMutation{}, nil).Times(1)
+	mockChasmTree.EXPECT().CloseTransaction(gomock.Any()).Return(chasm.NodesMutation{}, nil).Times(1)
 
 	s.workflowContext.archetypeID = chasmArchetypeID
 	s.workflowContext.MutableState = mutableState

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -7682,7 +7682,7 @@ func (ms *MutableStateImpl) closeTransaction(
 
 	// CloseTransaction() on chasmTree may update execution state & status,
 	// so must be called before closeTransactionUpdateTransitionHistory().
-	chasmNodesMutation, err := ms.chasmTree.CloseTransaction()
+	chasmNodesMutation, err := ms.chasmTree.CloseTransaction(toChasmTransactionPolicy(transactionPolicy))
 	if err != nil {
 		return closeTransactionResult{}, err
 	}

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -3556,7 +3556,7 @@ func (s *mutableStateSuite) TestCloseTransactionUpdateTransition() {
 				mockChasmTree.EXPECT().ArchetypeID().Return(chasm.ArchetypeID(1234)).AnyTimes()
 				gomock.InOrder(
 					mockChasmTree.EXPECT().IsStateDirty().Return(true).AnyTimes(),
-					mockChasmTree.EXPECT().CloseTransaction().Return(chasm.NodesMutation{
+					mockChasmTree.EXPECT().CloseTransaction(gomock.Any()).Return(chasm.NodesMutation{
 						UpdatedNodes: map[string]*persistencespb.ChasmNode{
 							"node-path": {
 								Metadata: &persistencespb.ChasmNodeMetadata{
@@ -5097,7 +5097,7 @@ func (s *mutableStateSuite) TestCloseTransactionTrackTombstones() {
 				mockChasmTree.EXPECT().ArchetypeID().Return(chasm.ArchetypeID(1234)).AnyTimes()
 				gomock.InOrder(
 					mockChasmTree.EXPECT().IsStateDirty().Return(true).AnyTimes(),
-					mockChasmTree.EXPECT().CloseTransaction().Return(chasm.NodesMutation{
+					mockChasmTree.EXPECT().CloseTransaction(gomock.Any()).Return(chasm.NodesMutation{
 						DeletedNodes: map[string]struct{}{deletedNodePath: {}},
 					}, nil),
 				)
@@ -5249,7 +5249,7 @@ func (s *mutableStateSuite) TestCloseTransactionAsMutation_ChasmNoopSkipsPersist
 	mockChasmTree.EXPECT().ArchetypeID().Return(chasm.WorkflowArchetypeID + 101).AnyTimes()
 	mockChasmTree.EXPECT().IsStateDirty().Return(false).AnyTimes()
 	mockChasmTree.EXPECT().IsDirty().Return(false).AnyTimes()
-	mockChasmTree.EXPECT().CloseTransaction().Return(chasm.NodesMutation{}, nil).Times(1)
+	mockChasmTree.EXPECT().CloseTransaction(gomock.Any()).Return(chasm.NodesMutation{}, nil).Times(1)
 
 	stateTransitionCount := mutableState.executionInfo.StateTransitionCount
 	var lastUpdateTime *timestamppb.Timestamp
@@ -5300,7 +5300,7 @@ func (s *mutableStateSuite) TestCloseTransactionAsMutation_WorkflowChasmNoopDoes
 	mutableState.chasmTree = mockChasmTree
 	mockChasmTree.EXPECT().ArchetypeID().Return(chasm.WorkflowArchetypeID).AnyTimes()
 	mockChasmTree.EXPECT().IsStateDirty().Return(false).AnyTimes()
-	mockChasmTree.EXPECT().CloseTransaction().Return(chasm.NodesMutation{}, nil).Times(1)
+	mockChasmTree.EXPECT().CloseTransaction(gomock.Any()).Return(chasm.NodesMutation{}, nil).Times(1)
 
 	stateTransitionCount := mutableState.executionInfo.StateTransitionCount
 
@@ -5329,7 +5329,7 @@ func (s *mutableStateSuite) TestCloseTransactionGenerateCHASMRetentionTask_Workf
 	// Is workflow, should not generate retention task
 	mockChasmTree.EXPECT().IsStateDirty().Return(true).AnyTimes()
 	mockChasmTree.EXPECT().ArchetypeID().Return(chasm.WorkflowArchetypeID).AnyTimes()
-	mockChasmTree.EXPECT().CloseTransaction().Return(chasm.NodesMutation{}, nil).AnyTimes()
+	mockChasmTree.EXPECT().CloseTransaction(gomock.Any()).Return(chasm.NodesMutation{}, nil).AnyTimes()
 	mutation, _, err := mutableState.CloseTransactionAsMutation(context.Background(), historyi.TransactionPolicyActive)
 	s.NoError(err)
 	s.Empty(mutation.Tasks[tasks.CategoryTimer])
@@ -5354,7 +5354,7 @@ func (s *mutableStateSuite) TestCloseTransactionGenerateCHASMRetentionTask_NonWo
 	mockChasmTree.EXPECT().IsStateDirty().Return(true).AnyTimes()
 	mockChasmTree.EXPECT().ArchetypeID().Return(chasm.WorkflowArchetypeID + 101).AnyTimes()
 	nonEmptyMutation := chasm.NodesMutation{UpdatedNodes: map[string]*persistencespb.ChasmNode{"": {}}}
-	mockChasmTree.EXPECT().CloseTransaction().Return(nonEmptyMutation, nil).AnyTimes()
+	mockChasmTree.EXPECT().CloseTransaction(gomock.Any()).Return(nonEmptyMutation, nil).AnyTimes()
 	_, err = mutableState.UpdateWorkflowStateStatus(
 		enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
 		enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
@@ -5393,7 +5393,7 @@ func (s *mutableStateSuite) TestCloseTransactionGenerateCHASMRetentionTask_NonWo
 	mockChasmTree.EXPECT().IsStateDirty().Return(true).AnyTimes()
 	mockChasmTree.EXPECT().ArchetypeID().Return(chasm.WorkflowArchetypeID + 101).AnyTimes()
 	nonEmptyMutation := chasm.NodesMutation{UpdatedNodes: map[string]*persistencespb.ChasmNode{"": {}}}
-	mockChasmTree.EXPECT().CloseTransaction().Return(nonEmptyMutation, nil).AnyTimes()
+	mockChasmTree.EXPECT().CloseTransaction(gomock.Any()).Return(nonEmptyMutation, nil).AnyTimes()
 	mockChasmTree.EXPECT().ApplyMutation(gomock.Any()).Return(nil).AnyTimes()
 
 	// On standby side, multiple transactions can be applied at the same time,
@@ -6515,7 +6515,7 @@ func (s *mutableStateSuite) TestCHASMNodeSize() {
 
 	mockChasmTree.EXPECT().IsStateDirty().Return(true).AnyTimes()
 	mockChasmTree.EXPECT().ArchetypeID().Return(chasm.WorkflowArchetypeID + 101).AnyTimes()
-	mockChasmTree.EXPECT().CloseTransaction().Return(chasm.NodesMutation{
+	mockChasmTree.EXPECT().CloseTransaction(gomock.Any()).Return(chasm.NodesMutation{
 		UpdatedNodes: map[string]*persistencespb.ChasmNode{
 			nodeKeyToUpdate: &updateNode,
 			newNodeKey:      &newNode,

--- a/service/history/workflow/noop_chasm_tree.go
+++ b/service/history/workflow/noop_chasm_tree.go
@@ -17,7 +17,7 @@ var NoopChasmTree = &noopChasmTree{}
 
 type noopChasmTree struct{}
 
-func (*noopChasmTree) CloseTransaction() (chasm.NodesMutation, error) {
+func (*noopChasmTree) CloseTransaction(chasm.TransactionPolicy) (chasm.NodesMutation, error) {
 	return chasm.NodesMutation{}, nil
 }
 

--- a/service/history/workflow/util.go
+++ b/service/history/workflow/util.go
@@ -11,6 +11,7 @@ import (
 	workflowpb "go.temporal.io/api/workflow/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/chasm"
 	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/effect"
@@ -316,4 +317,12 @@ func PersistenceCallbackToAPICallback(cb *persistencespb.Callback) (*commonpb.Ca
 
 func timeNotSet(ts *timestamppb.Timestamp) bool {
 	return ts == nil || ts.AsTime().IsZero()
+}
+
+func toChasmTransactionPolicy(tp historyi.TransactionPolicy) chasm.TransactionPolicy {
+	if tp == historyi.TransactionPolicyActive {
+		return chasm.TransactionPolicyActive
+	} else {
+		return chasm.TransactionPolicyPassive
+	}
 }

--- a/service/history/workflow/util_test.go
+++ b/service/history/workflow/util_test.go
@@ -1,0 +1,14 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/chasm"
+	historyi "go.temporal.io/server/service/history/interfaces"
+)
+
+func TestToChasmTransactionPolicy(t *testing.T) {
+	require.Equal(t, chasm.TransactionPolicyActive, toChasmTransactionPolicy(historyi.TransactionPolicyActive))
+	require.Equal(t, chasm.TransactionPolicyPassive, toChasmTransactionPolicy(historyi.TransactionPolicyPassive))
+}


### PR DESCRIPTION
## What changed?
1. add transaction policy to chasm close transaction
2. add task regeneration when time skipping transition is replicated to a passive cluster

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)