### PR TITLE
Add `partition_scale_target` metric next to existing _read and _write gauges

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1281,6 +1281,7 @@ var (
 	PartitionScaleEvents = NewCounterDef("partition_scale_events")
 	PartitionScaleRead   = NewGaugeDef("partition_scale_read")
 	PartitionScaleWrite  = NewGaugeDef("partition_scale_write")
+	PartitionScaleTarget = NewGaugeDef("partition_scale_target")
 
 	// ----------------------------------------------------------------------------------------------------------------
 	// Matching service: Metrics to track the health of worker registry.

--- a/service/matching/scale_manager.go
+++ b/service/matching/scale_manager.go
@@ -102,6 +102,7 @@ func (sm *scaleManager) Stop() {
 		// this is unfortunate but at least allows max() across pods to get the right value
 		metrics.PartitionScaleRead.With(sm.metricsHandler).Record(float64(-1))
 		metrics.PartitionScaleWrite.With(sm.metricsHandler).Record(float64(-1))
+		metrics.PartitionScaleTarget.With(sm.metricsHandler).Record(float64(-1))
 	}
 }
 
@@ -298,6 +299,7 @@ func (sm *scaleManager) setState(newState *persistencespb.PartitionScaleState, s
 	if sm.emitGaugeMetrics() {
 		metrics.PartitionScaleRead.With(sm.metricsHandler).Record(float64(newInfo.Read))
 		metrics.PartitionScaleWrite.With(sm.metricsHandler).Record(float64(newInfo.Write))
+		metrics.PartitionScaleTarget.With(sm.metricsHandler).Record(float64(sm.scaleState.GetTarget()))
 	}
 }
 

--- a/service/matching/scale_manager_test.go
+++ b/service/matching/scale_manager_test.go
@@ -18,6 +18,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/common/testing/protoutils"
@@ -41,6 +42,12 @@ type ScaleManagerSuite struct {
 	sm       *scaleManager
 	settings dynamicconfig.PartitionScaleManagerSettings
 
+	// metricsHandler and emitGauges control the gauge metrics wired into the
+	// manager. Tests that assert on emitted gauges swap in a capture handler and
+	// enable emission before calling startManager.
+	metricsHandler metrics.Handler
+	emitGauges     bool
+
 	// newTarget counts "new target" logs, which are also used for test synchronization
 	newTarget *testlogger.Expectation
 }
@@ -57,6 +64,8 @@ func (s *ScaleManagerSuite) SetupTest() {
 	s.userData = NewMockuserDataManager(s.controller)
 	s.matching = matchingservicemock.NewMockMatchingServiceClient(s.controller)
 	s.timeSource = clock.NewEventTimeSource()
+	s.metricsHandler = metrics.NoopMetricsHandler
+	s.emitGauges = false
 
 	// scaler.Stop is called from sm.Stop in TearDownTest, but only if the test
 	// actually started the manager.
@@ -100,14 +109,14 @@ func (s *ScaleManagerSuite) startManagerWithLogger(
 		context.Background(),
 		tqid.MustNormalPartitionFromRpcName("tq", "ns-id", enumspb.TASK_QUEUE_TYPE_WORKFLOW),
 		logger,
-		metrics.NoopMetricsHandler,
+		s.metricsHandler,
 		s.userData,
 		s.matching,
 		s.scaler,
 		s.timeSource,
 		dynamicconfig.GetTypedPropertyFn(s.settings),
 		dynamicconfig.GetIntPropertyFn(writePartitions),
-		dynamicconfig.GetBoolPropertyFn(false),
+		dynamicconfig.GetBoolPropertyFn(s.emitGauges),
 	)
 	s.sm.Start(initial, s.scaleDB)
 }
@@ -247,6 +256,55 @@ func (s *ScaleManagerSuite) TestDecisionPersistsAndUpdatesEphemeralData() {
 	info := waitRecv(s, scaleInfos, "no ephemeral data update")
 	s.Equal(int32(4), info.Read)
 	s.Equal(int32(2), info.Write)
+}
+
+// TestEmitsGaugeMetrics verifies that when gauge emission is enabled, a scale
+// decision records the read, write, and target gauges with the expected values.
+func (s *ScaleManagerSuite) TestEmitsGaugeMetrics() {
+	capture := metricstest.NewCaptureHandler()
+	cap := capture.StartCapture()
+	defer capture.StopCapture(cap)
+	s.metricsHandler = capture
+	s.emitGauges = true
+
+	s.scaler.EXPECT().OnTasks(gomock.Any()).
+		Return(PartitionScalerDecision{NewTarget: 2})
+
+	dbWrites := make(chan *persistencespb.PartitionScaleState, 1)
+	s.scaleDB.EXPECT().UpdateScaleState(gomock.Any(), gomock.Any()).
+		Do(func(state *persistencespb.PartitionScaleState, _ bool) {
+			dbWrites <- common.CloneProto(state)
+		}).
+		Return(nil)
+
+	s.userData.EXPECT().SetPartitionScale(gomock.Any()).AnyTimes()
+
+	s.startManager(4, nil) // 4 write partitions in dynamic config
+
+	s.sm.AddedTasks(1)
+	waitRecv(s, dbWrites, "no db write")
+
+	// setState records the gauges after the ephemeral push, so poll the snapshot
+	// until the decision's values land: Read=4 (dynamic config), Write=Target=2.
+	lastValue := func(name string) (float64, bool) {
+		recs := cap.Snapshot()[name]
+		if len(recs) == 0 {
+			return 0, false
+		}
+		v, ok := recs[len(recs)-1].Value.(float64)
+		return v, ok
+	}
+	await.RequireTruef(s.T(), func() bool {
+		v, ok := lastValue(metrics.PartitionScaleTarget.Name())
+		return ok && v == 2
+	}, time.Second, time.Millisecond, "target gauge never reached 2")
+
+	read, _ := lastValue(metrics.PartitionScaleRead.Name())
+	write, _ := lastValue(metrics.PartitionScaleWrite.Name())
+	target, _ := lastValue(metrics.PartitionScaleTarget.Name())
+	s.Equal(float64(4), read, "read gauge")
+	s.Equal(float64(2), write, "write gauge")
+	s.Equal(float64(2), target, "target gauge")
 }
 
 // TestNonPositiveShadowLogIntervalDisabled verifies that ShadowModeLogInterval

--- a/service/matching/scale_manager_test.go
+++ b/service/matching/scale_manager_test.go
@@ -42,10 +42,10 @@ type ScaleManagerSuite struct {
 	sm       *scaleManager
 	settings dynamicconfig.PartitionScaleManagerSettings
 
-	// metricsHandler is wired into the manager. It defaults to capture (so any
-	// test can assert on emitted gauges via s.capture), and gauge emission is
-	// enabled whenever the handler isn't the Noop handler. A test can opt out by
-	// setting s.metricsHandler = metrics.NoopMetricsHandler before startManager.
+	// metricsHandler is wired into the manager. It defaults to Noop (gauge
+	// emission is enabled whenever the handler isn't the Noop handler, so gauges
+	// are off by default). A test that asserts on emitted gauges sets
+	// s.metricsHandler = s.capture before startManager.
 	metricsHandler metrics.Handler
 	capture        *metricstest.CaptureHandler
 
@@ -66,7 +66,7 @@ func (s *ScaleManagerSuite) SetupTest() {
 	s.matching = matchingservicemock.NewMockMatchingServiceClient(s.controller)
 	s.timeSource = clock.NewEventTimeSource()
 	s.capture = metricstest.NewCaptureHandler()
-	s.metricsHandler = s.capture
+	s.metricsHandler = metrics.NoopMetricsHandler
 
 	// scaler.Stop is called from sm.Stop in TearDownTest, but only if the test
 	// actually started the manager.
@@ -262,6 +262,7 @@ func (s *ScaleManagerSuite) TestDecisionPersistsAndUpdatesEphemeralData() {
 // TestEmitsGaugeMetrics verifies that when gauge emission is enabled, a scale
 // decision records the read, write, and target gauges with the expected values.
 func (s *ScaleManagerSuite) TestEmitsGaugeMetrics() {
+	s.metricsHandler = s.capture
 	capture := s.capture.StartCapture()
 	defer s.capture.StopCapture(capture)
 

--- a/service/matching/scale_manager_test.go
+++ b/service/matching/scale_manager_test.go
@@ -42,11 +42,12 @@ type ScaleManagerSuite struct {
 	sm       *scaleManager
 	settings dynamicconfig.PartitionScaleManagerSettings
 
-	// metricsHandler and emitGauges control the gauge metrics wired into the
-	// manager. Tests that assert on emitted gauges swap in a capture handler and
-	// enable emission before calling startManager.
+	// metricsHandler is wired into the manager. It defaults to capture (so any
+	// test can assert on emitted gauges via s.capture), and gauge emission is
+	// enabled whenever the handler isn't the Noop handler. A test can opt out by
+	// setting s.metricsHandler = metrics.NoopMetricsHandler before startManager.
 	metricsHandler metrics.Handler
-	emitGauges     bool
+	capture        *metricstest.CaptureHandler
 
 	// newTarget counts "new target" logs, which are also used for test synchronization
 	newTarget *testlogger.Expectation
@@ -64,8 +65,8 @@ func (s *ScaleManagerSuite) SetupTest() {
 	s.userData = NewMockuserDataManager(s.controller)
 	s.matching = matchingservicemock.NewMockMatchingServiceClient(s.controller)
 	s.timeSource = clock.NewEventTimeSource()
-	s.metricsHandler = metrics.NoopMetricsHandler
-	s.emitGauges = false
+	s.capture = metricstest.NewCaptureHandler()
+	s.metricsHandler = s.capture
 
 	// scaler.Stop is called from sm.Stop in TearDownTest, but only if the test
 	// actually started the manager.
@@ -116,7 +117,7 @@ func (s *ScaleManagerSuite) startManagerWithLogger(
 		s.timeSource,
 		dynamicconfig.GetTypedPropertyFn(s.settings),
 		dynamicconfig.GetIntPropertyFn(writePartitions),
-		dynamicconfig.GetBoolPropertyFn(s.emitGauges),
+		func() bool { return s.metricsHandler != metrics.NoopMetricsHandler },
 	)
 	s.sm.Start(initial, s.scaleDB)
 }
@@ -261,11 +262,8 @@ func (s *ScaleManagerSuite) TestDecisionPersistsAndUpdatesEphemeralData() {
 // TestEmitsGaugeMetrics verifies that when gauge emission is enabled, a scale
 // decision records the read, write, and target gauges with the expected values.
 func (s *ScaleManagerSuite) TestEmitsGaugeMetrics() {
-	capture := metricstest.NewCaptureHandler()
-	cap := capture.StartCapture()
-	defer capture.StopCapture(cap)
-	s.metricsHandler = capture
-	s.emitGauges = true
+	cap := s.capture.StartCapture()
+	defer s.capture.StopCapture(cap)
 
 	s.scaler.EXPECT().OnTasks(gomock.Any()).
 		Return(PartitionScalerDecision{NewTarget: 2})

--- a/service/matching/scale_manager_test.go
+++ b/service/matching/scale_manager_test.go
@@ -262,8 +262,8 @@ func (s *ScaleManagerSuite) TestDecisionPersistsAndUpdatesEphemeralData() {
 // TestEmitsGaugeMetrics verifies that when gauge emission is enabled, a scale
 // decision records the read, write, and target gauges with the expected values.
 func (s *ScaleManagerSuite) TestEmitsGaugeMetrics() {
-	cap := s.capture.StartCapture()
-	defer s.capture.StopCapture(cap)
+	capture := s.capture.StartCapture()
+	defer s.capture.StopCapture(capture)
 
 	s.scaler.EXPECT().OnTasks(gomock.Any()).
 		Return(PartitionScalerDecision{NewTarget: 2})
@@ -285,7 +285,7 @@ func (s *ScaleManagerSuite) TestEmitsGaugeMetrics() {
 	// setState records the gauges after the ephemeral push, so poll the snapshot
 	// until the decision's values land: Read=4 (dynamic config), Write=Target=2.
 	lastValue := func(name string) (float64, bool) {
-		recs := cap.Snapshot()[name]
+		recs := capture.Snapshot()[name]
 		if len(recs) == 0 {
 			return 0, false
 		}
@@ -300,9 +300,9 @@ func (s *ScaleManagerSuite) TestEmitsGaugeMetrics() {
 	read, _ := lastValue(metrics.PartitionScaleRead.Name())
 	write, _ := lastValue(metrics.PartitionScaleWrite.Name())
 	target, _ := lastValue(metrics.PartitionScaleTarget.Name())
-	s.Equal(float64(4), read, "read gauge")
-	s.Equal(float64(2), write, "write gauge")
-	s.Equal(float64(2), target, "target gauge")
+	s.InDelta(float64(4), read, 0.001, "read gauge")
+	s.InDelta(float64(2), write, 0.001, "write gauge")
+	s.InDelta(float64(2), target, 0.001, "target gauge")
 }
 
 // TestNonPositiveShadowLogIntervalDisabled verifies that ShadowModeLogInterval


### PR DESCRIPTION
## What changed?
Emit target separately from write count

## Why?
Target can be different from Write now that we limit how fast write can shrink below read.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
None


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change to matching partition scale metrics and tests; no scaling or persistence behavior changes.
> 
> **Overview**
> Adds a **`partition_scale_target`** gauge so operators can see the scaler’s desired partition count separately from **`partition_scale_write`**, which can lag **target** while write partitions shrink slowly during drain.
> 
> **`scaleManager`** now records `scaleState.GetTarget()` whenever it emits the existing read/write gauges, and clears the target gauge to **-1** on stop (same pattern as the other partition scale gauges).
> 
> Unit coverage includes **`TestEmitsGaugeMetrics`**, which enables gauge emission via **`metricstest.CaptureHandler`** and asserts read, write, and target values after a scale-up decision.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25c56d2e33cd6ce77a93153e70ced21eb5f10bd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->