### PR TITLE
Capture test-cluster creation events

### DIFF
--- a/.github/actions/post-test-reporting/action.yml
+++ b/.github/actions/post-test-reporting/action.yml
@@ -121,4 +121,4 @@ runs:
         name: test-cluster-events--${{ github.run_id }}--${{ steps.get_job_id.outputs.job_id }}--${{ github.run_attempt }}--${{ inputs.artifact_name_suffix }}
         path: ./.testoutput/test-cluster-events.jsonl
         if-no-files-found: ignore
-        retention-days: 28
+        retention-days: 14

--- a/.github/actions/post-test-reporting/action.yml
+++ b/.github/actions/post-test-reporting/action.yml
@@ -113,3 +113,12 @@ runs:
         path: ${{ inputs.debug_log_path }}
         if-no-files-found: ignore
         retention-days: 14
+
+    - name: Upload cluster events
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      if: ${{ !cancelled() }}
+      with:
+        name: test-cluster-events--${{ github.run_id }}--${{ steps.get_job_id.outputs.job_id }}--${{ github.run_attempt }}--${{ inputs.artifact_name_suffix }}
+        path: ./.testoutput/test-cluster-events.jsonl
+        if-no-files-found: ignore
+        retention-days: 28

--- a/.github/actions/post-test-reporting/action.yml
+++ b/.github/actions/post-test-reporting/action.yml
@@ -114,7 +114,7 @@ runs:
         if-no-files-found: ignore
         retention-days: 14
 
-    - name: Upload cluster events
+    - name: Upload test cluster events
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       if: ${{ !cancelled() }}
       with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -439,6 +439,7 @@ jobs:
           TEST_ARGS: "${{ matrix.test_args }}"
           TEMPORAL_TEST_LOG_FILE: ${{ github.workspace }}/.testoutput/debug.log
           TEMPORAL_TEST_LOG_LEVEL: info
+          TEMPORAL_TEST_CLUSTER_EVENTS_FILE: ${{ github.workspace }}/.testoutput/test-cluster-events.jsonl
 
       - name: Dump container logs
         if: ${{ failure() && toJson(matrix.containers) != '[]' }}

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -271,6 +271,11 @@ func (s *FunctionalTestBase) SetupSuiteWithCluster(options ...TestClusterOption)
 	// Reserve a slot from the dedicated test cluster pool.
 	testClusterRouter.dedicated.reserveSlot(s.T())
 	s.setupCluster(options...)
+	clusterRequest{
+		kind:              clusterKindDedicated,
+		dedicatedReason:   "legacy-suite",
+		needWorkerService: ApplyTestClusterOptions(options).EnableWorkerService,
+	}.recordCreation(s.T())
 }
 
 func (s *FunctionalTestBase) setupCluster(options ...TestClusterOption) {

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -1,6 +1,7 @@
 package testcore
 
 import (
+	"encoding/json"
 	"log"
 	"os"
 	"runtime"
@@ -33,13 +34,20 @@ func init() {
 		dedicatedSize = n
 	}
 
-	testClusterRouter = &clusterRouter{
-		shared:    newClusterPool(sharedSize, false, 0),
-		dedicated: newClusterPool(dedicatedSize, true, 0),
+	var eventsFile *os.File
+	if path := os.Getenv("TEMPORAL_TEST_CLUSTER_EVENTS_FILE"); path != "" {
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if err != nil {
+			log.Printf("cluster events disabled: cannot open %q: %v", path, err)
+		}
+		eventsFile = f
 	}
 
-	log.Printf("CLUSTERPOOL config: GOMAXPROCS=%d sharedSize=%d dedicatedSize=%d",
-		runtime.GOMAXPROCS(0), sharedSize, dedicatedSize)
+	testClusterRouter = &clusterRouter{
+		shared:     newClusterPool(sharedSize, false, 0),
+		dedicated:  newClusterPool(dedicatedSize, true, 0),
+		eventsFile: eventsFile,
+	}
 }
 
 // clusterPool manages a fixed number of test [clusterPoolSlot]s.
@@ -165,6 +173,11 @@ type clusterRouter struct {
 	shared      *clusterPool
 	dedicated   *clusterPool
 	suiteScoped sync.Map
+
+	// eventsMu guards appends to eventsFile, the JSON Lines sink for cluster
+	// creation events. A nil eventsFile means events fall back to the test log.
+	eventsMu   sync.Mutex
+	eventsFile *os.File
 }
 
 // suiteScopedCluster owns one lazily created legacy suite cluster.
@@ -211,8 +224,8 @@ const (
 type clusterRequest struct {
 	kind              string // set by the router: shared, dedicated, or suite-scoped
 	dedicated         bool
-	needWorkerService bool
 	dedicatedReason   string
+	needWorkerService bool
 	dynamicConfig     map[dynamicconfig.Key]any
 	clusterOpts       []TestClusterOption
 }
@@ -248,13 +261,31 @@ func (r clusterRequest) reason() string {
 	}
 }
 
-// recordCreation logs one line per test-cluster creation (prefixed with
-// CLUSTEREVENT) so a CI run can be grepped for which suite created how many
-// clusters of each kind, and why.
+// recordCreation appends one JSON Lines event per test-cluster creation so a CI
+// run can be queried for which suite created how many clusters of each kind, and
+// why. The append is flushed per line so it survives a hard process kill (e.g.
+// an OOM); events fall back to the test log when no events file is configured.
 func (r clusterRequest) recordCreation(t *testing.T) {
 	suite, _, _ := strings.Cut(t.Name(), "/")
-	log.Printf("CLUSTEREVENT suite=%q test=%q kind=%s worker=%v reason=%q",
-		suite, t.Name(), r.kind, r.needWorkerService, r.reason())
+	line, err := json.Marshal(map[string]any{
+		"suite":  suite,
+		"test":   t.Name(),
+		"kind":   r.kind,
+		"reason": r.reason(),
+		"worker": r.needWorkerService,
+	})
+	if err != nil {
+		return
+	}
+
+	if testClusterRouter.eventsFile == nil {
+		log.Printf("CLUSTEREVENT %s", line)
+		return
+	}
+	// A sub-page append is atomic, so concurrent tests interleave cleanly.
+	testClusterRouter.eventsMu.Lock()
+	defer testClusterRouter.eventsMu.Unlock()
+	_, _ = testClusterRouter.eventsFile.Write(append(line, '\n'))
 }
 
 func (p *clusterRouter) get(t *testing.T, req clusterRequest) (tb *FunctionalTestBase) {

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -218,9 +218,9 @@ type clusterRequest struct {
 }
 
 // mustBeFresh reports whether the request requires a brand-new cluster that
-// cannot be reused, because it carries custom dynamic config or fx options.
+// cannot be reused.
 func (r clusterRequest) mustBeFresh() bool {
-	return len(r.dynamicConfig) > 0 || len(r.clusterOpts) > 0
+	return r.needWorkerService || len(r.dynamicConfig) > 0 || len(r.clusterOpts) > 0
 }
 
 // needsDedicated reports whether the request must be served by a dedicated

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -1,6 +1,7 @@
 package testcore
 
 import (
+	"log"
 	"os"
 	"runtime"
 	"strconv"
@@ -36,6 +37,9 @@ func init() {
 		shared:    newClusterPool(sharedSize, false, 0),
 		dedicated: newClusterPool(dedicatedSize, true, 0),
 	}
+
+	log.Printf("CLUSTERPOOL config: GOMAXPROCS=%d sharedSize=%d dedicatedSize=%d",
+		runtime.GOMAXPROCS(0), sharedSize, dedicatedSize)
 }
 
 // clusterPool manages a fixed number of test [clusterPoolSlot]s.
@@ -196,14 +200,71 @@ func UseSuiteScopedCluster(t *testing.T) {
 	})
 }
 
-func (p *clusterRouter) get(t *testing.T, dedicated bool, dynamicConfig map[dynamicconfig.Key]any, clusterOpts []TestClusterOption) (tb *FunctionalTestBase) {
+// Cluster kinds recorded in creation events.
+const (
+	clusterKindShared      = "shared"
+	clusterKindDedicated   = "dedicated"
+	clusterKindSuiteScoped = "suite-scoped"
+)
+
+// clusterRequest describes what a test needs from the cluster router.
+type clusterRequest struct {
+	kind              string // set by the router: shared, dedicated, or suite-scoped
+	dedicated         bool
+	needWorkerService bool
+	dedicatedReason   string
+	dynamicConfig     map[dynamicconfig.Key]any
+	clusterOpts       []TestClusterOption
+}
+
+// mustBeFresh reports whether the request requires a brand-new cluster that
+// cannot be reused, because it carries custom dynamic config or fx options.
+func (r clusterRequest) mustBeFresh() bool {
+	return len(r.dynamicConfig) > 0 || len(r.clusterOpts) > 0
+}
+
+// needsDedicated reports whether the request must be served by a dedicated
+// cluster rather than the shared pool.
+func (r clusterRequest) needsDedicated() bool {
+	return r.dedicated || r.mustBeFresh()
+}
+
+// reason explains why the cluster was created, for analytics. It falls back to a
+// generic reason when the caller did not provide one.
+func (r clusterRequest) reason() string {
+	switch r.kind {
+	case clusterKindShared:
+		return "shared pool"
+	case clusterKindSuiteScoped:
+		return "suite-scoped"
+	}
+	switch {
+	case r.dedicatedReason != "":
+		return r.dedicatedReason
+	case r.mustBeFresh():
+		return "custom config"
+	default:
+		return "dedicated (pooled)"
+	}
+}
+
+// recordCreation logs one line per test-cluster creation (prefixed with
+// CLUSTEREVENT) so a CI run can be grepped for which suite created how many
+// clusters of each kind, and why.
+func (r clusterRequest) recordCreation(t *testing.T) {
+	suite, _, _ := strings.Cut(t.Name(), "/")
+	log.Printf("CLUSTEREVENT suite=%q test=%q kind=%s worker=%v reason=%q",
+		suite, t.Name(), r.kind, r.needWorkerService, r.reason())
+}
+
+func (p *clusterRouter) get(t *testing.T, req clusterRequest) (tb *FunctionalTestBase) {
 	defer func() {
 		if tb != nil {
 			tb.RegisterTest(t)
 		}
 	}()
-	if dedicated || len(dynamicConfig) > 0 || len(clusterOpts) > 0 {
-		return p.getDedicated(t, dynamicConfig, clusterOpts)
+	if req.needsDedicated() {
+		return p.getDedicated(t, req)
 	}
 	if cluster := p.getSuiteScoped(t); cluster != nil {
 		return cluster
@@ -213,7 +274,7 @@ func (p *clusterRouter) get(t *testing.T, dedicated bool, dynamicConfig map[dyna
 
 func (p *clusterRouter) getShared(t *testing.T) *FunctionalTestBase {
 	return p.shared.get(t, func() *FunctionalTestBase {
-		return p.createCluster(t, nil, true, nil)
+		return p.createCluster(t, clusterRequest{kind: clusterKindShared})
 	})
 }
 
@@ -235,17 +296,18 @@ func (p *clusterRouter) getSuiteScoped(t *testing.T) *FunctionalTestBase {
 		// TODO(stephan, #10580): remove this workaround once the proper cluster-pool fix lands.
 		// Enable the worker service on suite-scoped clusters. The only current user (Versioning3) needs the system
 		// worker for worker-deployment APIs.
-		suiteCluster.cluster = p.createCluster(t, nil, true, []TestClusterOption{withWorkerService(true)})
+		suiteCluster.cluster = p.createCluster(t, clusterRequest{kind: clusterKindSuiteScoped, needWorkerService: true})
 	})
 	suiteCluster.cluster.SetT(t)
 	return suiteCluster.cluster
 }
 
-func (p *clusterRouter) getDedicated(t *testing.T, dynamicConfig map[dynamicconfig.Key]any, clusterOpts []TestClusterOption) *FunctionalTestBase {
-	if len(dynamicConfig) > 0 || len(clusterOpts) > 0 {
+func (p *clusterRouter) getDedicated(t *testing.T, req clusterRequest) *FunctionalTestBase {
+	req.kind = clusterKindDedicated
+	if req.mustBeFresh() {
 		// Custom config or fx options require a fresh cluster (can't reuse).
 		p.dedicated.reserveSlot(t)
-		cluster := p.createCluster(t, dynamicConfig, false, clusterOpts)
+		cluster := p.createCluster(t, req)
 
 		// Register cleanup to tear down the cluster when the test completes.
 		t.Cleanup(func() {
@@ -259,25 +321,26 @@ func (p *clusterRouter) getDedicated(t *testing.T, dynamicConfig map[dynamicconf
 
 	// If no custom config is provided, reuse an existing cluster.
 	return p.dedicated.get(t, func() *FunctionalTestBase {
-		return p.createCluster(t, nil, false, nil)
+		return p.createCluster(t, req)
 	})
 }
 
-func (p *clusterRouter) createCluster(t *testing.T, dynamicConfig map[dynamicconfig.Key]any, shared bool, clusterOpts []TestClusterOption) *FunctionalTestBase {
+func (p *clusterRouter) createCluster(t *testing.T, req clusterRequest) *FunctionalTestBase {
 	tbase := &FunctionalTestBase{}
 	tbase.SetT(t)
 
-	// Keep the worker service off unless explicitly enabled via WithWorkerService.
-	opts := []TestClusterOption{withWorkerService(false)}
-	if shared {
+	// The worker service is off unless the request explicitly needs it.
+	opts := []TestClusterOption{withWorkerService(req.needWorkerService)}
+	if req.kind != clusterKindDedicated {
 		opts = append(opts, WithSharedCluster())
 	}
-	if len(dynamicConfig) > 0 {
-		opts = append(opts, WithDynamicConfigOverrides(dynamicConfig))
+	if len(req.dynamicConfig) > 0 {
+		opts = append(opts, WithDynamicConfigOverrides(req.dynamicConfig))
 	}
-	opts = append(opts, clusterOpts...)
+	opts = append(opts, req.clusterOpts...)
 
 	tbase.setupCluster(opts...)
+	req.recordCreation(t)
 
 	return tbase
 }

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -174,9 +174,9 @@ type clusterRouter struct {
 	dedicated   *clusterPool
 	suiteScoped sync.Map
 
-	// eventsMu guards appends to eventsFile, the JSON Lines sink for cluster
+	// eventsLock guards appends to eventsFile, the JSON Lines sink for cluster
 	// creation events. A nil eventsFile means events fall back to the test log.
-	eventsMu   sync.Mutex
+	eventsLock sync.Mutex
 	eventsFile *os.File
 }
 
@@ -283,8 +283,8 @@ func (r clusterRequest) recordCreation(t *testing.T) {
 		return
 	}
 	// A sub-page append is atomic, so concurrent tests interleave cleanly.
-	testClusterRouter.eventsMu.Lock()
-	defer testClusterRouter.eventsMu.Unlock()
+	testClusterRouter.eventsLock.Lock()
+	defer testClusterRouter.eventsLock.Unlock()
 	_, _ = testClusterRouter.eventsFile.Write(append(line, '\n'))
 }
 

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -174,9 +174,6 @@ type clusterRouter struct {
 	dedicated   *clusterPool
 	suiteScoped sync.Map
 
-	// eventsLock guards appends to eventsFile, the JSON Lines sink for cluster
-	// creation events. A nil eventsFile means events fall back to the test log.
-	eventsLock sync.Mutex
 	eventsFile *os.File
 }
 
@@ -282,9 +279,8 @@ func (r clusterRequest) recordCreation(t *testing.T) {
 		log.Printf("CLUSTEREVENT %s", line)
 		return
 	}
-	// A sub-page append is atomic, so concurrent tests interleave cleanly.
-	testClusterRouter.eventsLock.Lock()
-	defer testClusterRouter.eventsLock.Unlock()
+	// O_APPEND makes each write land atomically at EOF and os.File serializes
+	// concurrent writes, so lines from parallel tests don't interleave.
 	_, _ = testClusterRouter.eventsFile.Write(append(line, '\n'))
 }
 

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -260,8 +260,7 @@ func (r clusterRequest) reason() string {
 
 // recordCreation appends one JSON Lines event per test-cluster creation so a CI
 // run can be queried for which suite created how many clusters of each kind, and
-// why. The append is flushed per line so it survives a hard process kill (e.g.
-// an OOM); events fall back to the test log when no events file is configured.
+// why. Events fall back to the test log when no events file is configured.
 func (r clusterRequest) recordCreation(t *testing.T) {
 	suite, _, _ := strings.Cut(t.Name(), "/")
 	line, err := json.Marshal(map[string]any{

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -88,6 +88,7 @@ type TestOption func(*testOptions)
 
 type testOptions struct {
 	dedicatedCluster         bool
+	needWorkerService        bool
 	dedicatedReason          string
 	disableTestloggerFailure bool
 	dynamicConfigSettings    []dynamicConfigOverride
@@ -143,7 +144,7 @@ func WithTestVars(fn func(*testvars.TestVars) *testvars.TestVars) TestOption {
 func WithWorkerService(reason string) TestOption {
 	return func(o *testOptions) {
 		o.dedicatedCluster = true
-		o.clusterOptions = append(o.clusterOptions, withWorkerService(true))
+		o.needWorkerService = true
 		o.dedicatedReason = "worker service required: " + reason
 	}
 }
@@ -265,7 +266,13 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 	}
 
 	// Obtain the test cluster from the router.
-	base := testClusterRouter.get(t, options.dedicatedCluster, startupConfig, options.clusterOptions)
+	base := testClusterRouter.get(t, clusterRequest{
+		dedicated:         options.dedicatedCluster,
+		needWorkerService: options.needWorkerService,
+		dedicatedReason:   options.dedicatedReason,
+		dynamicConfig:     startupConfig,
+		clusterOpts:       options.clusterOptions,
+	})
 	cluster := base.GetTestCluster()
 
 	// Create a dedicated namespace for the test to help with test isolation.


### PR DESCRIPTION
## What changed?

Emit a JSON file with test cluster events.

Example
```
{"kind":"shared","reason":"shared pool","suite":"TestActivityTestSuite","test":"TestActivityTestSuite/TestActivityRetry","worker":false}
{"kind":"shared","reason":"shared pool","suite":"TestActivityTestSuite","test":"TestActivityTestSuite/TestActivityCancellationNotStarted","worker":false}
{"kind":"shared","reason":"shared pool","suite":"TestActivityTestSuite","test":"TestActivityTestSuite/TestActivityHeartBeatWorkflow_Success","worker":false}
{"kind":"shared","reason":"shared pool","suite":"TestActivityTestSuite","test":"TestActivityTestSuite/TestActivityHeartBeat_RecordIdentity","worker":false}
{"kind":"dedicated","reason":"custom config","suite":"TestSignalWorkflowTestSuiteChasm","test":"TestSignalWorkflowTestSuiteChasm/TestSignalExternalWorkflowCommand","worker":false}
{"kind":"dedicated","reason":"custom config","suite":"TestSignalWorkflowTestSuiteChasm","test":"TestSignalWorkflowTestSuiteChasm/TestSignalExternalWorkflowCommand_UnKnownTarget","worker":false}
{"kind":"dedicated","reason":"custom config","suite":"TestSignalWorkflowTestSuiteChasm","test":"TestSignalWorkflowTestSuiteChasm/TestSignalExternalWorkflowCommand_WithoutRunID","worker":false}
{"kind":"dedicated","reason":"custom config","suite":"TestSignalWorkflowTestSuiteLegacy","test":"TestSignalWorkflowTestSuiteLegacy/TestSignalExternalWorkflowCommand","worker":false}
{"kind":"dedicated","reason":"custom config","suite":"TestSignalWorkflowTestSuiteLegacy","test":"TestSignalWorkflowTestSuiteLegacy/TestSignalExternalWorkflowCommand_UnKnownTarget","worker":false}
{"kind":"dedicated","reason":"custom config","suite":"TestSignalWorkflowTestSuiteLegacy","test":"TestSignalWorkflowTestSuiteLegacy/TestSignalExternalWorkflowCommand_WithoutRunID","worker":false}
```

## Why?

Gain better insights into test cluster usage.