### PR TITLE
fix: reject restore_original when a standalone activity has no original options snapshot

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -642,6 +642,13 @@ func (a *Activity) UpdateActivityExecutionOptions(
 	}
 
 	frontendReq := req.GetFrontendRequest()
+
+	if frontendReq.GetRestoreOriginal() {
+		if err := validateOriginalOptionsRestorable(a.GetOriginalOptions()); err != nil {
+			return nil, err
+		}
+	}
+
 	updateFields := map[string]struct{}{}
 	if mask := frontendReq.GetUpdateMask(); mask != nil {
 		updateFields = util.ParseFieldMask(mask)
@@ -1081,6 +1088,12 @@ func (a *Activity) reset(ctx chasm.MutableContext, event resetEvent) {
 // For CANCEL_REQUESTED activities: rejected with FailedPrecondition; cancel takes precedence.
 func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetActivityExecutionRequest) (*activitypb.ResetActivityExecutionResponse, error) {
 	frontendReq := req.GetFrontendRequest()
+
+	if frontendReq.GetRestoreOriginalOptions() {
+		if err := validateOriginalOptionsRestorable(a.GetOriginalOptions()); err != nil {
+			return nil, err
+		}
+	}
 
 	metricsHandler, err := a.enrichMetricsHandler(ctx, metrics.ActivityResetScope)
 	if err != nil {

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -806,3 +806,72 @@ func TestShouldRecalculateCurrentRetryInterval(t *testing.T) {
 		})
 	}
 }
+
+// TestUpdateActivityExecutionOptions_RestoreOriginal_RejectsMissingOriginalOptions mimics an
+// activity persisted before original_options existed (e.g. created by a binary predating this
+// field's introduction). Restoring such an activity's options has nothing valid to fall back to
+// and must be rejected rather than silently wiping TaskQueue and both close/start timeouts.
+func TestUpdateActivityExecutionOptions_RestoreOriginal_RejectsMissingOriginalOptions(t *testing.T) {
+	ctx := &chasm.MockMutableContext{
+		MockContext: chasm.MockContext{
+			HandleNow: func(chasm.Component) time.Time { return time.Unix(0, 0) },
+		},
+	}
+
+	activity := &Activity{
+		ActivityState: &activitypb.ActivityState{
+			Status:                 activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+			ActivityType:           &commonpb.ActivityType{Name: "T"},
+			TaskQueue:              &taskqueuepb.TaskQueue{Name: "current-task-queue"},
+			ScheduleToCloseTimeout: durationpb.New(30 * time.Second),
+			StartToCloseTimeout:    durationpb.New(10 * time.Second),
+			OriginalOptions:        nil,
+		},
+		LastAttempt: chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{}),
+	}
+
+	_, err := activity.UpdateActivityExecutionOptions(ctx, &activitypb.UpdateActivityExecutionOptionsRequest{
+		FrontendRequest: &workflowservice.UpdateActivityExecutionOptionsRequest{
+			ActivityId:      "act",
+			RestoreOriginal: true,
+		},
+	})
+
+	require.Error(t, err)
+	require.Equal(t, "current-task-queue", activity.GetTaskQueue().GetName())
+	require.Equal(t, 30*time.Second, activity.GetScheduleToCloseTimeout().AsDuration())
+	require.Equal(t, 10*time.Second, activity.GetStartToCloseTimeout().AsDuration())
+}
+
+// TestHandleReset_RestoreOriginalOptions_RejectsMissingOriginalOptions covers the equivalent gap
+// on the Reset(RestoreOriginalOptions=true) path, for an activity with no original_options
+// snapshot (see the Update test above for the scenario this mimics).
+func TestHandleReset_RestoreOriginalOptions_RejectsMissingOriginalOptions(t *testing.T) {
+	ctx := &chasm.MockMutableContext{
+		MockContext: chasm.MockContext{
+			HandleNow: func(chasm.Component) time.Time { return time.Unix(0, 0) },
+		},
+	}
+
+	activity := &Activity{
+		ActivityState: &activitypb.ActivityState{
+			Status:                 activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+			ActivityType:           &commonpb.ActivityType{Name: "T"},
+			TaskQueue:              &taskqueuepb.TaskQueue{Name: "current-task-queue"},
+			ScheduleToCloseTimeout: durationpb.New(30 * time.Second),
+			StartToCloseTimeout:    durationpb.New(10 * time.Second),
+			OriginalOptions:        nil,
+		},
+		LastAttempt: chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{}),
+	}
+
+	_, err := activity.handleReset(ctx, &activitypb.ResetActivityExecutionRequest{
+		FrontendRequest: &workflowservice.ResetActivityExecutionRequest{
+			ActivityId:             "act",
+			RestoreOriginalOptions: true,
+		},
+	})
+
+	require.Error(t, err)
+	require.Equal(t, "current-task-queue", activity.GetTaskQueue().GetName())
+}

--- a/chasm/lib/activity/validator.go
+++ b/chasm/lib/activity/validator.go
@@ -214,6 +214,20 @@ func validateAndNormalizeTimeouts(
 	return nil
 }
 
+// validateOriginalOptionsRestorable checks that a captured "original options" snapshot has enough
+// information to safely restore. An activity persisted before original_options existed (or
+// otherwise missing a snapshot) has original == nil; restoring it would silently wipe TaskQueue and
+// both close/start timeouts, leaving an invalid activity configuration, so reject the request instead.
+func validateOriginalOptionsRestorable(original *activitypb.ActivityOptions) error {
+	if original.GetTaskQueue().GetName() == "" {
+		return serviceerror.NewInvalidArgument("cannot restore original options: no original task queue was recorded for this activity")
+	}
+	if original.GetScheduleToCloseTimeout().AsDuration() <= 0 && original.GetStartToCloseTimeout().AsDuration() <= 0 {
+		return serviceerror.NewInvalidArgument("cannot restore original options: no original schedule-to-close or start-to-close timeout was recorded for this activity")
+	}
+	return nil
+}
+
 func validateAndNormalizeIDPolicy(req *workflowservice.StartActivityExecutionRequest) error {
 	if req.GetIdReusePolicy() == enumspb.ACTIVITY_ID_REUSE_POLICY_UNSPECIFIED {
 		req.IdReusePolicy = enumspb.ACTIVITY_ID_REUSE_POLICY_ALLOW_DUPLICATE


### PR DESCRIPTION
## What changed?

Added a guard that rejects UpdateOptions(restore_original=true) requests on a standalone activity when its OriginalOptions snapshot is missing.

## Why?

A standalone activity started before OriginalOptions existed deserializes with `OriginalOptions == nil`. Restoring such an activity previously succeeded silently, wiping TaskQueue and both close/start timeouts, leaving the activity in an invalid configuration. 

## How did you test it?

- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

None, this feature has not been rolled out.