### PR TITLE
Preserve pending activity next retry delay

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -668,7 +668,6 @@ func (a *Activity) UpdateActivityExecutionOptions(
 	}
 
 	attempt := a.LastAttempt.Get(ctx)
-	policyRetryIntervalBeforeUpdate := backoff.CalculateExponentialRetryInterval(a.RetryPolicy, attempt.GetCount()-1)
 
 	if frontendReq.GetRestoreOriginal() {
 		ogOptions := a.GetOriginalOptions()
@@ -692,16 +691,9 @@ func (a *Activity) UpdateActivityExecutionOptions(
 
 	// Recalculate policy-derived retry intervals based on the (possibly updated) retry policy.
 	// Worker-provided NextRetryDelay values are preserved for their already-scheduled retry.
-	if a.shouldRecalculateCurrentRetryInterval(
-		attempt,
-		frontendReq.GetRestoreOriginal(),
-		updateFields,
-		policyRetryIntervalBeforeUpdate,
-	) {
+	if a.shouldRecalculateCurrentRetryInterval(attempt, frontendReq.GetRestoreOriginal(), updateFields) {
 		newInterval := backoff.CalculateExponentialRetryInterval(a.RetryPolicy, attempt.GetCount()-1)
-		if newInterval < attempt.GetCurrentRetryInterval().AsDuration() {
-			attempt.CurrentRetryInterval = durationpb.New(newInterval)
-		}
+		attempt.CurrentRetryInterval = durationpb.New(newInterval)
 	}
 
 	// Recreate the ScheduleToClose task at the (possibly updated) deadline.
@@ -744,13 +736,12 @@ func (a *Activity) UpdateActivityExecutionOptions(
 //   - a retry is actually pending (CurrentRetryInterval is set);
 //   - the update touches the retry policy: either RestoreOriginal (which replaces the whole policy),
 //     or the update mask includes "retryPolicy" or one of its subfields;
-//   - the pending interval is still policy-derived, i.e. it equals the pre-update policy value.
-//     A mismatch means the interval is a worker-provided NextRetryDelay override, which we preserve.
+//   - the pending interval is still policy-derived (CurrentRetryIntervalSource is RETRY_POLICY).
+//     A worker-provided NextRetryDelay override is preserved regardless of its value.
 func (a *Activity) shouldRecalculateCurrentRetryInterval(
 	attempt *activitypb.ActivityAttemptState,
 	restoreOriginal bool,
 	updateFields map[string]struct{},
-	policyRetryIntervalBeforeUpdate time.Duration,
 ) bool {
 	status := a.GetStatus()
 	if status != activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED &&
@@ -758,8 +749,7 @@ func (a *Activity) shouldRecalculateCurrentRetryInterval(
 		return false
 	}
 
-	currentRetryInterval := attempt.GetCurrentRetryInterval()
-	if currentRetryInterval == nil {
+	if attempt.GetCurrentRetryInterval() == nil {
 		return false
 	}
 
@@ -769,10 +759,7 @@ func (a *Activity) shouldRecalculateCurrentRetryInterval(
 		}
 	}
 
-	// CurrentRetryInterval stores either policy-derived backoff or worker-provided NextRetryDelay overrides.
-	// Only recalculate intervals that match the old policy value; different values are treated as explicit
-	// worker overrides.
-	return currentRetryInterval.AsDuration() == policyRetryIntervalBeforeUpdate
+	return attempt.GetCurrentRetryIntervalSource() == activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_RETRY_POLICY
 }
 
 // mergeActivityOptions applies the field mask from the request to the activity state.
@@ -984,6 +971,7 @@ func (a *Activity) unpause(
 	if event.req.GetResetAttempts() {
 		attempt.Count = 1
 		attempt.CurrentRetryInterval = nil
+		attempt.CurrentRetryIntervalSource = activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED
 	}
 	if event.req.GetResetHeartbeat() {
 		a.LastHeartbeat = chasm.NewDataField(ctx, &activitypb.ActivityHeartbeatState{})
@@ -1043,6 +1031,7 @@ func (a *Activity) reset(ctx chasm.MutableContext, event resetEvent) {
 	attempt.Count = 1
 	attempt.Stamp++
 	attempt.CurrentRetryInterval = nil
+	attempt.CurrentRetryIntervalSource = activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED
 	if event.req.GetResetHeartbeat() {
 		a.clearHeartbeat(ctx)
 	}
@@ -1163,6 +1152,7 @@ func (a *Activity) resetKeepPaused(
 	attempt.Count = 1
 	attempt.Stamp++
 	attempt.CurrentRetryInterval = nil
+	attempt.CurrentRetryIntervalSource = activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED
 	attempt.DispatchTime = nil
 	if frontendReq.GetResetHeartbeat() {
 		a.clearHeartbeat(ctx)
@@ -1222,7 +1212,7 @@ func (a *Activity) applyFailedAttempt(ctx chasm.MutableContext, event reschedule
 	attempt := a.LastAttempt.Get(ctx)
 	attempt.Count++
 	attempt.Stamp++
-	return a.recordFailedAttempt(ctx, event.retryInterval, event.failure, ctx.Now(a), false)
+	return a.recordFailedAttempt(ctx, event.retryInterval, event.retryIntervalSource, event.failure, ctx.Now(a), false)
 }
 
 // recordFailedAttempt records any failures resulting from a tried attempt, including worker application failures and
@@ -1231,6 +1221,7 @@ func (a *Activity) applyFailedAttempt(ctx chasm.MutableContext, event reschedule
 func (a *Activity) recordFailedAttempt(
 	ctx chasm.MutableContext,
 	retryInterval time.Duration,
+	retryIntervalSource activitypb.ActivityRetryIntervalSource,
 	failure *failurepb.Failure,
 	currentTime time.Time,
 	noRetriesLeft bool,
@@ -1245,8 +1236,10 @@ func (a *Activity) recordFailedAttempt(
 
 	if noRetriesLeft {
 		attempt.CurrentRetryInterval = nil
+		attempt.CurrentRetryIntervalSource = activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED
 	} else {
 		attempt.CurrentRetryInterval = durationpb.New(retryInterval)
+		attempt.CurrentRetryIntervalSource = retryIntervalSource
 	}
 	return nil
 }
@@ -1267,7 +1260,11 @@ func (a *Activity) tryReschedule(
 	if !resetRequested && !(failureRetryable && shouldRetry) { //nolint:staticcheck // QF1001: DeMorgan rearrangement would not be an improvement
 		return false, nil
 	}
-	event := rescheduleEvent{retryInterval: retryInterval, failure: failure}
+	retryIntervalSource := activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_RETRY_POLICY
+	if overridingRetryInterval > 0 {
+		retryIntervalSource = activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_WORKER_OVERRIDE
+	}
+	event := rescheduleEvent{retryInterval: retryInterval, retryIntervalSource: retryIntervalSource, failure: failure}
 	switch a.GetStatus() {
 	case activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED:
 		return true, TransitionAttemptFailedWhilePauseRequested.Apply(a, ctx, event)

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -737,7 +737,10 @@ func (a *Activity) UpdateActivityExecutionOptions(
 //   - the update touches the retry policy: either RestoreOriginal (which replaces the whole policy),
 //     or the update mask includes "retryPolicy" or one of its subfields;
 //   - the pending interval is still policy-derived (CurrentRetryIntervalSource is RETRY_POLICY).
-//     A worker-provided NextRetryDelay override is preserved regardless of its value.
+//     A worker-provided NextRetryDelay override is preserved regardless of its value. An
+//     UNSPECIFIED source (attempt state persisted before this field existed) is treated the same
+//     as an override, since we can no longer tell whether it was policy-derived or a worker
+//     override, and preserving it is the safer default.
 func (a *Activity) shouldRecalculateCurrentRetryInterval(
 	attempt *activitypb.ActivityAttemptState,
 	restoreOriginal bool,

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -699,7 +699,9 @@ func (a *Activity) UpdateActivityExecutionOptions(
 		policyRetryIntervalBeforeUpdate,
 	) {
 		newInterval := backoff.CalculateExponentialRetryInterval(a.RetryPolicy, attempt.GetCount()-1)
-		attempt.CurrentRetryInterval = durationpb.New(newInterval)
+		if newInterval < attempt.GetCurrentRetryInterval().AsDuration() {
+			attempt.CurrentRetryInterval = durationpb.New(newInterval)
+		}
 	}
 
 	// Recreate the ScheduleToClose task at the (possibly updated) deadline.

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -728,7 +728,7 @@ func TestEffectiveUserMetadata_FallsBackToLegacy(t *testing.T) {
 }
 
 func TestShouldRecalculateCurrentRetryInterval(t *testing.T) {
-	policyRetryInterval := 2 * time.Second
+	retryInterval := 2 * time.Second
 
 	testCases := []struct {
 		name                 string
@@ -736,46 +736,53 @@ func TestShouldRecalculateCurrentRetryInterval(t *testing.T) {
 		restoreOriginal      bool
 		updateFields         map[string]struct{}
 		currentRetryInterval *durationpb.Duration
+		retryIntervalSource  activitypb.ActivityRetryIntervalSource
 		expectRecalculate    bool
 	}{
 		{
 			name:                 "retry policy subfield update with policy-derived interval",
 			status:               activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
 			updateFields:         map[string]struct{}{"retryPolicy.initialInterval": {}},
-			currentRetryInterval: durationpb.New(policyRetryInterval),
+			currentRetryInterval: durationpb.New(retryInterval),
+			retryIntervalSource:  activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_RETRY_POLICY,
 			expectRecalculate:    true,
 		},
 		{
 			name:                 "retry policy replacement with policy-derived interval",
 			status:               activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
 			updateFields:         map[string]struct{}{"retryPolicy": {}},
-			currentRetryInterval: durationpb.New(policyRetryInterval),
+			currentRetryInterval: durationpb.New(retryInterval),
+			retryIntervalSource:  activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_RETRY_POLICY,
 			expectRecalculate:    true,
 		},
 		{
 			name:                 "restore original with policy-derived interval",
 			status:               activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED,
 			restoreOriginal:      true,
-			currentRetryInterval: durationpb.New(policyRetryInterval),
+			currentRetryInterval: durationpb.New(retryInterval),
+			retryIntervalSource:  activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_RETRY_POLICY,
 			expectRecalculate:    true,
 		},
 		{
 			name:                 "unrelated update preserves retry interval",
 			status:               activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
 			updateFields:         map[string]struct{}{"heartbeatTimeout": {}},
-			currentRetryInterval: durationpb.New(policyRetryInterval),
+			currentRetryInterval: durationpb.New(retryInterval),
+			retryIntervalSource:  activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_RETRY_POLICY,
 		},
 		{
-			name:                 "worker override differs from policy interval",
+			name:                 "worker override is preserved regardless of value",
 			status:               activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
 			updateFields:         map[string]struct{}{"retryPolicy.initialInterval": {}},
-			currentRetryInterval: durationpb.New(policyRetryInterval + time.Second),
+			currentRetryInterval: durationpb.New(retryInterval),
+			retryIntervalSource:  activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_WORKER_OVERRIDE,
 		},
 		{
 			name:                 "started activity is not in retry backoff",
 			status:               activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
 			updateFields:         map[string]struct{}{"retryPolicy.initialInterval": {}},
-			currentRetryInterval: durationpb.New(policyRetryInterval),
+			currentRetryInterval: durationpb.New(retryInterval),
+			retryIntervalSource:  activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_RETRY_POLICY,
 		},
 		{
 			name:         "missing retry interval",
@@ -792,14 +799,14 @@ func TestShouldRecalculateCurrentRetryInterval(t *testing.T) {
 				},
 			}
 			attempt := &activitypb.ActivityAttemptState{
-				CurrentRetryInterval: tc.currentRetryInterval,
+				CurrentRetryInterval:       tc.currentRetryInterval,
+				CurrentRetryIntervalSource: tc.retryIntervalSource,
 			}
 
 			got := activity.shouldRecalculateCurrentRetryInterval(
 				attempt,
 				tc.restoreOriginal,
 				tc.updateFields,
-				policyRetryInterval,
 			)
 
 			require.Equal(t, tc.expectRecalculate, got)

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -778,6 +778,13 @@ func TestShouldRecalculateCurrentRetryInterval(t *testing.T) {
 			retryIntervalSource:  activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_WORKER_OVERRIDE,
 		},
 		{
+			name:                 "unspecified source (pre-existing attempt state) is preserved",
+			status:               activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+			updateFields:         map[string]struct{}{"retryPolicy.initialInterval": {}},
+			currentRetryInterval: durationpb.New(retryInterval),
+			retryIntervalSource:  activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED,
+		},
+		{
 			name:                 "started activity is not in retry backoff",
 			status:               activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
 			updateFields:         map[string]struct{}{"retryPolicy.initialInterval": {}},

--- a/chasm/lib/activity/gen/activitypb/v1/activity_state.go-helpers.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/activity_state.go-helpers.pb.go
@@ -330,3 +330,22 @@ func ActivityExecutionStatusFromString(s string) (ActivityExecutionStatus, error
 	}
 	return ActivityExecutionStatus(0), fmt.Errorf("%s is not a valid ActivityExecutionStatus", s)
 }
+
+var (
+	ActivityRetryIntervalSource_shorthandValue = map[string]int32{
+		"Unspecified":    0,
+		"RetryPolicy":    1,
+		"WorkerOverride": 2,
+	}
+)
+
+// ActivityRetryIntervalSourceFromString parses a ActivityRetryIntervalSource value from  either the protojson
+// canonical SCREAMING_CASE enum or the traditional temporal PascalCase enum to ActivityRetryIntervalSource
+func ActivityRetryIntervalSourceFromString(s string) (ActivityRetryIntervalSource, error) {
+	if v, ok := ActivityRetryIntervalSource_value[s]; ok {
+		return ActivityRetryIntervalSource(v), nil
+	} else if v, ok := ActivityRetryIntervalSource_shorthandValue[s]; ok {
+		return ActivityRetryIntervalSource(v), nil
+	}
+	return ActivityRetryIntervalSource(0), fmt.Errorf("%s is not a valid ActivityRetryIntervalSource", s)
+}

--- a/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
@@ -167,6 +167,71 @@ func (ActivityExecutionStatus) EnumDescriptor() ([]byte, []int) {
 	return file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawDescGZIP(), []int{0}
 }
 
+// ActivityRetryIntervalSource distinguishes how ActivityAttemptState.current_retry_interval was
+// derived, so that retry policy updates only recompute intervals that are still policy-derived and
+// never clobber a worker-provided override.
+type ActivityRetryIntervalSource int32
+
+const (
+	ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED ActivityRetryIntervalSource = 0
+	// current_retry_interval was computed from the activity's retry policy.
+	ACTIVITY_RETRY_INTERVAL_SOURCE_RETRY_POLICY ActivityRetryIntervalSource = 1
+	// current_retry_interval was set from a worker-provided NextRetryDelay override on a retryable
+	// application failure, overriding the retry-policy-derived backoff for this attempt only.
+	ACTIVITY_RETRY_INTERVAL_SOURCE_WORKER_OVERRIDE ActivityRetryIntervalSource = 2
+)
+
+// Enum value maps for ActivityRetryIntervalSource.
+var (
+	ActivityRetryIntervalSource_name = map[int32]string{
+		0: "ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED",
+		1: "ACTIVITY_RETRY_INTERVAL_SOURCE_RETRY_POLICY",
+		2: "ACTIVITY_RETRY_INTERVAL_SOURCE_WORKER_OVERRIDE",
+	}
+	ActivityRetryIntervalSource_value = map[string]int32{
+		"ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED":     0,
+		"ACTIVITY_RETRY_INTERVAL_SOURCE_RETRY_POLICY":    1,
+		"ACTIVITY_RETRY_INTERVAL_SOURCE_WORKER_OVERRIDE": 2,
+	}
+)
+
+func (x ActivityRetryIntervalSource) Enum() *ActivityRetryIntervalSource {
+	p := new(ActivityRetryIntervalSource)
+	*p = x
+	return p
+}
+
+func (x ActivityRetryIntervalSource) String() string {
+	switch x {
+	case ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED:
+		return "Unspecified"
+	case ACTIVITY_RETRY_INTERVAL_SOURCE_RETRY_POLICY:
+		return "RetryPolicy"
+	case ACTIVITY_RETRY_INTERVAL_SOURCE_WORKER_OVERRIDE:
+		return "WorkerOverride"
+	default:
+		return strconv.Itoa(int(x))
+	}
+
+}
+
+func (ActivityRetryIntervalSource) Descriptor() protoreflect.EnumDescriptor {
+	return file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_enumTypes[1].Descriptor()
+}
+
+func (ActivityRetryIntervalSource) Type() protoreflect.EnumType {
+	return &file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_enumTypes[1]
+}
+
+func (x ActivityRetryIntervalSource) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ActivityRetryIntervalSource.Descriptor instead.
+func (ActivityRetryIntervalSource) EnumDescriptor() ([]byte, []int) {
+	return file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawDescGZIP(), []int{1}
+}
+
 type ActivityState struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The type of the activity, a string that maps to a registered activity on a worker.
@@ -644,9 +709,13 @@ type ActivityAttemptState struct {
 	// `client-version` header on PollActivityTaskQueue). Same overwrite semantics as sdk_name.
 	SdkVersion string `protobuf:"bytes,11,opt,name=sdk_version,json=sdkVersion,proto3" json:"sdk_version,omitempty"`
 	// Time the current activity attempt is scheduled to dispatch.
-	DispatchTime  *timestamppb.Timestamp `protobuf:"bytes,12,opt,name=dispatch_time,json=dispatchTime,proto3" json:"dispatch_time,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	DispatchTime *timestamppb.Timestamp `protobuf:"bytes,12,opt,name=dispatch_time,json=dispatchTime,proto3" json:"dispatch_time,omitempty"`
+	// Source of current_retry_interval, distinguishing a retry-policy-derived backoff from a
+	// worker-provided NextRetryDelay override. Retry policy updates only recompute
+	// current_retry_interval when this is ACTIVITY_RETRY_INTERVAL_SOURCE_RETRY_POLICY.
+	CurrentRetryIntervalSource ActivityRetryIntervalSource `protobuf:"varint,13,opt,name=current_retry_interval_source,json=currentRetryIntervalSource,proto3,enum=temporal.server.chasm.lib.activity.proto.v1.ActivityRetryIntervalSource" json:"current_retry_interval_source,omitempty"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *ActivityAttemptState) Reset() {
@@ -761,6 +830,13 @@ func (x *ActivityAttemptState) GetDispatchTime() *timestamppb.Timestamp {
 		return x.DispatchTime
 	}
 	return nil
+}
+
+func (x *ActivityAttemptState) GetCurrentRetryIntervalSource() ActivityRetryIntervalSource {
+	if x != nil {
+		return x.CurrentRetryIntervalSource
+	}
+	return ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED
 }
 
 type ActivityHeartbeatState struct {
@@ -1163,7 +1239,7 @@ const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawD
 	"\bidentity\x18\x02 \x01(\tR\bidentity\x12\x16\n" +
 	"\x06reason\x18\x03 \x01(\tR\x06reason\x12\x1d\n" +
 	"\n" +
-	"request_id\x18\x04 \x01(\tR\trequestId\"\xe5\x06\n" +
+	"request_id\x18\x04 \x01(\tR\trequestId\"\xf3\a\n" +
 	"\x14ActivityAttemptState\x12\x14\n" +
 	"\x05count\x18\x01 \x01(\x05R\x05count\x12O\n" +
 	"\x16current_retry_interval\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\x14currentRetryInterval\x12=\n" +
@@ -1178,7 +1254,8 @@ const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawD
 	" \x01(\tR\asdkName\x12\x1f\n" +
 	"\vsdk_version\x18\v \x01(\tR\n" +
 	"sdkVersion\x12?\n" +
-	"\rdispatch_time\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\fdispatchTime\x1a\x80\x01\n" +
+	"\rdispatch_time\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\fdispatchTime\x12\x8b\x01\n" +
+	"\x1dcurrent_retry_interval_source\x18\r \x01(\x0e2H.temporal.server.chasm.lib.activity.proto.v1.ActivityRetryIntervalSourceR\x1acurrentRetryIntervalSource\x1a\x80\x01\n" +
 	"\x12LastFailureDetails\x12.\n" +
 	"\x04time\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x04time\x12:\n" +
 	"\afailure\x18\x02 \x01(\v2 .temporal.api.failure.v1.FailureR\afailure\"\xc9\x01\n" +
@@ -1214,7 +1291,11 @@ const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawD
 	" ACTIVITY_EXECUTION_STATUS_PAUSED\x10\t\x12-\n" +
 	")ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED\x10\n" +
 	"\x12-\n" +
-	")ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED\x10\vBDZBgo.temporal.io/server/chasm/lib/activity/gen/activitypb;activitypbb\x06proto3"
+	")ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED\x10\v*\xb2\x01\n" +
+	"\x1bActivityRetryIntervalSource\x12.\n" +
+	"*ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED\x10\x00\x12/\n" +
+	"+ACTIVITY_RETRY_INTERVAL_SOURCE_RETRY_POLICY\x10\x01\x122\n" +
+	".ACTIVITY_RETRY_INTERVAL_SOURCE_WORKER_OVERRIDE\x10\x02BDZBgo.temporal.io/server/chasm/lib/activity/gen/activitypb;activitypbb\x06proto3"
 
 var (
 	file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawDescOnce sync.Once
@@ -1228,75 +1309,77 @@ func file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawDe
 	return file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawDescData
 }
 
-var file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_goTypes = []any{
 	(ActivityExecutionStatus)(0),                    // 0: temporal.server.chasm.lib.activity.proto.v1.ActivityExecutionStatus
-	(*ActivityState)(nil),                           // 1: temporal.server.chasm.lib.activity.proto.v1.ActivityState
-	(*ActivityCancelState)(nil),                     // 2: temporal.server.chasm.lib.activity.proto.v1.ActivityCancelState
-	(*ActivityTerminateState)(nil),                  // 3: temporal.server.chasm.lib.activity.proto.v1.ActivityTerminateState
-	(*ActivityPauseState)(nil),                      // 4: temporal.server.chasm.lib.activity.proto.v1.ActivityPauseState
-	(*ActivityAttemptState)(nil),                    // 5: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState
-	(*ActivityHeartbeatState)(nil),                  // 6: temporal.server.chasm.lib.activity.proto.v1.ActivityHeartbeatState
-	(*ActivityRequestData)(nil),                     // 7: temporal.server.chasm.lib.activity.proto.v1.ActivityRequestData
-	(*ActivityOutcome)(nil),                         // 8: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome
-	(*ActivityAttemptState_LastFailureDetails)(nil), // 9: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.LastFailureDetails
-	(*ActivityOutcome_Successful)(nil),              // 10: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Successful
-	(*ActivityOutcome_Failed)(nil),                  // 11: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Failed
-	(*v1.ActivityType)(nil),                         // 12: temporal.api.common.v1.ActivityType
-	(*v11.TaskQueue)(nil),                           // 13: temporal.api.taskqueue.v1.TaskQueue
-	(*durationpb.Duration)(nil),                     // 14: google.protobuf.Duration
-	(*v1.RetryPolicy)(nil),                          // 15: temporal.api.common.v1.RetryPolicy
-	(*timestamppb.Timestamp)(nil),                   // 16: google.protobuf.Timestamp
-	(*v1.Priority)(nil),                             // 17: temporal.api.common.v1.Priority
-	(*v12.ActivityOptions)(nil),                     // 18: temporal.api.activity.v1.ActivityOptions
-	(*v13.WorkerDeploymentVersion)(nil),             // 19: temporal.api.deployment.v1.WorkerDeploymentVersion
-	(*v1.Payloads)(nil),                             // 20: temporal.api.common.v1.Payloads
-	(*v1.Header)(nil),                               // 21: temporal.api.common.v1.Header
-	(*v14.UserMetadata)(nil),                        // 22: temporal.api.sdk.v1.UserMetadata
-	(*v15.Failure)(nil),                             // 23: temporal.api.failure.v1.Failure
+	(ActivityRetryIntervalSource)(0),                // 1: temporal.server.chasm.lib.activity.proto.v1.ActivityRetryIntervalSource
+	(*ActivityState)(nil),                           // 2: temporal.server.chasm.lib.activity.proto.v1.ActivityState
+	(*ActivityCancelState)(nil),                     // 3: temporal.server.chasm.lib.activity.proto.v1.ActivityCancelState
+	(*ActivityTerminateState)(nil),                  // 4: temporal.server.chasm.lib.activity.proto.v1.ActivityTerminateState
+	(*ActivityPauseState)(nil),                      // 5: temporal.server.chasm.lib.activity.proto.v1.ActivityPauseState
+	(*ActivityAttemptState)(nil),                    // 6: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState
+	(*ActivityHeartbeatState)(nil),                  // 7: temporal.server.chasm.lib.activity.proto.v1.ActivityHeartbeatState
+	(*ActivityRequestData)(nil),                     // 8: temporal.server.chasm.lib.activity.proto.v1.ActivityRequestData
+	(*ActivityOutcome)(nil),                         // 9: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome
+	(*ActivityAttemptState_LastFailureDetails)(nil), // 10: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.LastFailureDetails
+	(*ActivityOutcome_Successful)(nil),              // 11: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Successful
+	(*ActivityOutcome_Failed)(nil),                  // 12: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Failed
+	(*v1.ActivityType)(nil),                         // 13: temporal.api.common.v1.ActivityType
+	(*v11.TaskQueue)(nil),                           // 14: temporal.api.taskqueue.v1.TaskQueue
+	(*durationpb.Duration)(nil),                     // 15: google.protobuf.Duration
+	(*v1.RetryPolicy)(nil),                          // 16: temporal.api.common.v1.RetryPolicy
+	(*timestamppb.Timestamp)(nil),                   // 17: google.protobuf.Timestamp
+	(*v1.Priority)(nil),                             // 18: temporal.api.common.v1.Priority
+	(*v12.ActivityOptions)(nil),                     // 19: temporal.api.activity.v1.ActivityOptions
+	(*v13.WorkerDeploymentVersion)(nil),             // 20: temporal.api.deployment.v1.WorkerDeploymentVersion
+	(*v1.Payloads)(nil),                             // 21: temporal.api.common.v1.Payloads
+	(*v1.Header)(nil),                               // 22: temporal.api.common.v1.Header
+	(*v14.UserMetadata)(nil),                        // 23: temporal.api.sdk.v1.UserMetadata
+	(*v15.Failure)(nil),                             // 24: temporal.api.failure.v1.Failure
 }
 var file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_depIdxs = []int32{
-	12, // 0: temporal.server.chasm.lib.activity.proto.v1.ActivityState.activity_type:type_name -> temporal.api.common.v1.ActivityType
-	13, // 1: temporal.server.chasm.lib.activity.proto.v1.ActivityState.task_queue:type_name -> temporal.api.taskqueue.v1.TaskQueue
-	14, // 2: temporal.server.chasm.lib.activity.proto.v1.ActivityState.schedule_to_close_timeout:type_name -> google.protobuf.Duration
-	14, // 3: temporal.server.chasm.lib.activity.proto.v1.ActivityState.schedule_to_start_timeout:type_name -> google.protobuf.Duration
-	14, // 4: temporal.server.chasm.lib.activity.proto.v1.ActivityState.start_to_close_timeout:type_name -> google.protobuf.Duration
-	14, // 5: temporal.server.chasm.lib.activity.proto.v1.ActivityState.heartbeat_timeout:type_name -> google.protobuf.Duration
-	15, // 6: temporal.server.chasm.lib.activity.proto.v1.ActivityState.retry_policy:type_name -> temporal.api.common.v1.RetryPolicy
+	13, // 0: temporal.server.chasm.lib.activity.proto.v1.ActivityState.activity_type:type_name -> temporal.api.common.v1.ActivityType
+	14, // 1: temporal.server.chasm.lib.activity.proto.v1.ActivityState.task_queue:type_name -> temporal.api.taskqueue.v1.TaskQueue
+	15, // 2: temporal.server.chasm.lib.activity.proto.v1.ActivityState.schedule_to_close_timeout:type_name -> google.protobuf.Duration
+	15, // 3: temporal.server.chasm.lib.activity.proto.v1.ActivityState.schedule_to_start_timeout:type_name -> google.protobuf.Duration
+	15, // 4: temporal.server.chasm.lib.activity.proto.v1.ActivityState.start_to_close_timeout:type_name -> google.protobuf.Duration
+	15, // 5: temporal.server.chasm.lib.activity.proto.v1.ActivityState.heartbeat_timeout:type_name -> google.protobuf.Duration
+	16, // 6: temporal.server.chasm.lib.activity.proto.v1.ActivityState.retry_policy:type_name -> temporal.api.common.v1.RetryPolicy
 	0,  // 7: temporal.server.chasm.lib.activity.proto.v1.ActivityState.status:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityExecutionStatus
-	16, // 8: temporal.server.chasm.lib.activity.proto.v1.ActivityState.schedule_time:type_name -> google.protobuf.Timestamp
-	17, // 9: temporal.server.chasm.lib.activity.proto.v1.ActivityState.priority:type_name -> temporal.api.common.v1.Priority
-	2,  // 10: temporal.server.chasm.lib.activity.proto.v1.ActivityState.cancel_state:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityCancelState
-	3,  // 11: temporal.server.chasm.lib.activity.proto.v1.ActivityState.terminate_state:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityTerminateState
-	14, // 12: temporal.server.chasm.lib.activity.proto.v1.ActivityState.start_delay:type_name -> google.protobuf.Duration
-	18, // 13: temporal.server.chasm.lib.activity.proto.v1.ActivityState.original_options:type_name -> temporal.api.activity.v1.ActivityOptions
-	4,  // 14: temporal.server.chasm.lib.activity.proto.v1.ActivityState.last_pause_state:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityPauseState
-	16, // 15: temporal.server.chasm.lib.activity.proto.v1.ActivityState.first_attempt_started_time:type_name -> google.protobuf.Timestamp
-	16, // 16: temporal.server.chasm.lib.activity.proto.v1.ActivityCancelState.request_time:type_name -> google.protobuf.Timestamp
-	16, // 17: temporal.server.chasm.lib.activity.proto.v1.ActivityPauseState.pause_time:type_name -> google.protobuf.Timestamp
-	14, // 18: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.current_retry_interval:type_name -> google.protobuf.Duration
-	16, // 19: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.started_time:type_name -> google.protobuf.Timestamp
-	16, // 20: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.complete_time:type_name -> google.protobuf.Timestamp
-	9,  // 21: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.last_failure_details:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.LastFailureDetails
-	19, // 22: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.last_deployment_version:type_name -> temporal.api.deployment.v1.WorkerDeploymentVersion
-	16, // 23: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.dispatch_time:type_name -> google.protobuf.Timestamp
-	20, // 24: temporal.server.chasm.lib.activity.proto.v1.ActivityHeartbeatState.details:type_name -> temporal.api.common.v1.Payloads
-	16, // 25: temporal.server.chasm.lib.activity.proto.v1.ActivityHeartbeatState.recorded_time:type_name -> google.protobuf.Timestamp
-	20, // 26: temporal.server.chasm.lib.activity.proto.v1.ActivityRequestData.input:type_name -> temporal.api.common.v1.Payloads
-	21, // 27: temporal.server.chasm.lib.activity.proto.v1.ActivityRequestData.header:type_name -> temporal.api.common.v1.Header
-	22, // 28: temporal.server.chasm.lib.activity.proto.v1.ActivityRequestData.user_metadata:type_name -> temporal.api.sdk.v1.UserMetadata
-	10, // 29: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.successful:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Successful
-	11, // 30: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.failed:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Failed
-	16, // 31: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.LastFailureDetails.time:type_name -> google.protobuf.Timestamp
-	23, // 32: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.LastFailureDetails.failure:type_name -> temporal.api.failure.v1.Failure
-	20, // 33: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Successful.output:type_name -> temporal.api.common.v1.Payloads
-	23, // 34: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Failed.failure:type_name -> temporal.api.failure.v1.Failure
-	35, // [35:35] is the sub-list for method output_type
-	35, // [35:35] is the sub-list for method input_type
-	35, // [35:35] is the sub-list for extension type_name
-	35, // [35:35] is the sub-list for extension extendee
-	0,  // [0:35] is the sub-list for field type_name
+	17, // 8: temporal.server.chasm.lib.activity.proto.v1.ActivityState.schedule_time:type_name -> google.protobuf.Timestamp
+	18, // 9: temporal.server.chasm.lib.activity.proto.v1.ActivityState.priority:type_name -> temporal.api.common.v1.Priority
+	3,  // 10: temporal.server.chasm.lib.activity.proto.v1.ActivityState.cancel_state:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityCancelState
+	4,  // 11: temporal.server.chasm.lib.activity.proto.v1.ActivityState.terminate_state:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityTerminateState
+	15, // 12: temporal.server.chasm.lib.activity.proto.v1.ActivityState.start_delay:type_name -> google.protobuf.Duration
+	19, // 13: temporal.server.chasm.lib.activity.proto.v1.ActivityState.original_options:type_name -> temporal.api.activity.v1.ActivityOptions
+	5,  // 14: temporal.server.chasm.lib.activity.proto.v1.ActivityState.last_pause_state:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityPauseState
+	17, // 15: temporal.server.chasm.lib.activity.proto.v1.ActivityState.first_attempt_started_time:type_name -> google.protobuf.Timestamp
+	17, // 16: temporal.server.chasm.lib.activity.proto.v1.ActivityCancelState.request_time:type_name -> google.protobuf.Timestamp
+	17, // 17: temporal.server.chasm.lib.activity.proto.v1.ActivityPauseState.pause_time:type_name -> google.protobuf.Timestamp
+	15, // 18: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.current_retry_interval:type_name -> google.protobuf.Duration
+	17, // 19: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.started_time:type_name -> google.protobuf.Timestamp
+	17, // 20: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.complete_time:type_name -> google.protobuf.Timestamp
+	10, // 21: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.last_failure_details:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.LastFailureDetails
+	20, // 22: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.last_deployment_version:type_name -> temporal.api.deployment.v1.WorkerDeploymentVersion
+	17, // 23: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.dispatch_time:type_name -> google.protobuf.Timestamp
+	1,  // 24: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.current_retry_interval_source:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityRetryIntervalSource
+	21, // 25: temporal.server.chasm.lib.activity.proto.v1.ActivityHeartbeatState.details:type_name -> temporal.api.common.v1.Payloads
+	17, // 26: temporal.server.chasm.lib.activity.proto.v1.ActivityHeartbeatState.recorded_time:type_name -> google.protobuf.Timestamp
+	21, // 27: temporal.server.chasm.lib.activity.proto.v1.ActivityRequestData.input:type_name -> temporal.api.common.v1.Payloads
+	22, // 28: temporal.server.chasm.lib.activity.proto.v1.ActivityRequestData.header:type_name -> temporal.api.common.v1.Header
+	23, // 29: temporal.server.chasm.lib.activity.proto.v1.ActivityRequestData.user_metadata:type_name -> temporal.api.sdk.v1.UserMetadata
+	11, // 30: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.successful:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Successful
+	12, // 31: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.failed:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Failed
+	17, // 32: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.LastFailureDetails.time:type_name -> google.protobuf.Timestamp
+	24, // 33: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.LastFailureDetails.failure:type_name -> temporal.api.failure.v1.Failure
+	21, // 34: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Successful.output:type_name -> temporal.api.common.v1.Payloads
+	24, // 35: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Failed.failure:type_name -> temporal.api.failure.v1.Failure
+	36, // [36:36] is the sub-list for method output_type
+	36, // [36:36] is the sub-list for method input_type
+	36, // [36:36] is the sub-list for extension type_name
+	36, // [36:36] is the sub-list for extension extendee
+	0,  // [0:36] is the sub-list for field type_name
 }
 
 func init() { file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_init() }
@@ -1313,7 +1396,7 @@ func file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_init(
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawDesc), len(file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawDesc)),
-			NumEnums:      1,
+			NumEnums:      2,
 			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/chasm/lib/activity/proto/v1/activity_state.proto
+++ b/chasm/lib/activity/proto/v1/activity_state.proto
@@ -171,6 +171,18 @@ message ActivityPauseState {
   string request_id = 4;
 }
 
+// ActivityRetryIntervalSource distinguishes how ActivityAttemptState.current_retry_interval was
+// derived, so that retry policy updates only recompute intervals that are still policy-derived and
+// never clobber a worker-provided override.
+enum ActivityRetryIntervalSource {
+  ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED = 0;
+  // current_retry_interval was computed from the activity's retry policy.
+  ACTIVITY_RETRY_INTERVAL_SOURCE_RETRY_POLICY = 1;
+  // current_retry_interval was set from a worker-provided NextRetryDelay override on a retryable
+  // application failure, overriding the retry-policy-derived backoff for this attempt only.
+  ACTIVITY_RETRY_INTERVAL_SOURCE_WORKER_OVERRIDE = 2;
+}
+
 message ActivityAttemptState {
   // The attempt this activity is currently on.
   // Incremented each time a new attempt is scheduled. A newly created activity will immediately be scheduled, and
@@ -233,6 +245,11 @@ message ActivityAttemptState {
 
   // Time the current activity attempt is scheduled to dispatch.
   google.protobuf.Timestamp dispatch_time = 12;
+
+  // Source of current_retry_interval, distinguishing a retry-policy-derived backoff from a
+  // worker-provided NextRetryDelay override. Retry policy updates only recompute
+  // current_retry_interval when this is ACTIVITY_RETRY_INTERVAL_SOURCE_RETRY_POLICY.
+  ActivityRetryIntervalSource current_retry_interval_source = 13;
 }
 
 message ActivityHeartbeatState {

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -88,9 +88,10 @@ var TransitionScheduled = chasm.NewTransition(
 )
 
 type rescheduleEvent struct {
-	retryInterval time.Duration
-	failure       *failurepb.Failure
-	timeoutType   enumspb.TimeoutType
+	retryInterval       time.Duration
+	retryIntervalSource activitypb.ActivityRetryIntervalSource
+	failure             *failurepb.Failure
+	timeoutType         enumspb.TimeoutType
 }
 
 // TransitionRescheduled transitions to Scheduled from Started, which happens on retries. The event
@@ -245,7 +246,7 @@ var TransitionFailed = chasm.NewTransition(
 			attempt := a.LastAttempt.Get(ctx)
 			attempt.LastWorkerIdentity = req.GetIdentity()
 
-			if err := a.recordFailedAttempt(ctx, 0, req.GetFailure(), ctx.Now(a), true); err != nil {
+			if err := a.recordFailedAttempt(ctx, 0, activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED, req.GetFailure(), ctx.Now(a), true); err != nil {
 				return err
 			}
 
@@ -390,10 +391,10 @@ var TransitionTimedOut = chasm.NewTransition(
 				err = a.recordScheduleToStartOrCloseTimeoutFailure(ctx, timeoutType)
 			case enumspb.TIMEOUT_TYPE_START_TO_CLOSE:
 				failure := createStartToCloseTimeoutFailure()
-				err = a.recordFailedAttempt(ctx, 0, failure, ctx.Now(a), true)
+				err = a.recordFailedAttempt(ctx, 0, activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED, failure, ctx.Now(a), true)
 			case enumspb.TIMEOUT_TYPE_HEARTBEAT:
 				failure := createHeartbeatTimeoutFailure()
-				err = a.recordFailedAttempt(ctx, 0, failure, ctx.Now(a), true)
+				err = a.recordFailedAttempt(ctx, 0, activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED, failure, ctx.Now(a), true)
 			default:
 				err = fmt.Errorf("unhandled activity timeout: %v", timeoutType)
 			}
@@ -550,11 +551,12 @@ var TransitionResetAttemptFailedToPaused = chasm.NewTransition(
 		}
 		attempt.Count = 1
 		attempt.Stamp++
-		if err := a.recordFailedAttempt(ctx, event.retryInterval, event.failure, ctx.Now(a), false); err != nil {
+		if err := a.recordFailedAttempt(ctx, event.retryInterval, event.retryIntervalSource, event.failure, ctx.Now(a), false); err != nil {
 			return err
 		}
 		// Reset discards the retry backoff
 		attempt.CurrentRetryInterval = nil
+		attempt.CurrentRetryIntervalSource = activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED
 		attempt.DispatchTime = nil
 		return nil
 	},
@@ -583,11 +585,12 @@ var TransitionResetAttemptFailedToScheduled = chasm.NewTransition(
 		attempt.Count = 1
 		attempt.Stamp++
 
-		if err := a.recordFailedAttempt(ctx, event.retryInterval, event.failure, currentTime, false); err != nil {
+		if err := a.recordFailedAttempt(ctx, event.retryInterval, event.retryIntervalSource, event.failure, currentTime, false); err != nil {
 			return err
 		}
 		// Reset discards the retry backoff
 		attempt.CurrentRetryInterval = nil
+		attempt.CurrentRetryIntervalSource = activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED
 
 		dispatchTime := a.dispatchTimeRespectingStartDelay(currentTime)
 		attempt.DispatchTime = timestamppb.New(dispatchTime)

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -8072,6 +8072,89 @@ func (s *standaloneActivityTestSuite) TestUpdateActivityExecutionOptions() {
 		require.EqualValues(t, 2, pollResp2.Attempt)
 	})
 
+	t.Run("UpdateRetryPolicy_PreservesEqualNextRetryDelay", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+		workerNextRetryDelay := 2 * time.Minute
+		updatedPolicyInterval := 10 * time.Minute
+
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        &commonpb.ActivityType{Name: "test-activity"},
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout: durationpb.New(30 * time.Minute),
+			RetryPolicy: &commonpb.RetryPolicy{
+				InitialInterval: durationpb.New(workerNextRetryDelay),
+				MaximumAttempts: 5,
+			},
+		})
+		require.NoError(t, err)
+
+		pollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
+			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		})
+		require.NoError(t, err)
+		require.EqualValues(t, 1, pollResp.Attempt)
+
+		_, err = env.FrontendClient().RespondActivityTaskFailed(ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
+			TaskToken: pollResp.TaskToken,
+			Failure: &failurepb.Failure{
+				Message: "retryable failure",
+				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+					ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+						NonRetryable:   false,
+						NextRetryDelay: durationpb.New(workerNextRetryDelay),
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		describeBeforeUpdate, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, describeBeforeUpdate.GetInfo().GetCurrentRetryInterval())
+		require.Equal(t, workerNextRetryDelay, describeBeforeUpdate.GetInfo().GetCurrentRetryInterval().AsDuration())
+		require.NotNil(t, describeBeforeUpdate.GetInfo().GetNextAttemptScheduleTime())
+		nextAttemptScheduleTime := describeBeforeUpdate.GetInfo().GetNextAttemptScheduleTime().AsTime()
+
+		updateResp, err := env.FrontendClient().UpdateActivityExecutionOptions(ctx, &workflowservice.UpdateActivityExecutionOptionsRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+			ActivityOptions: &activitypb.ActivityOptions{
+				RetryPolicy: &commonpb.RetryPolicy{
+					InitialInterval: durationpb.New(updatedPolicyInterval),
+				},
+			},
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"retry_policy.initial_interval"}},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, updateResp)
+		require.Equal(t, updatedPolicyInterval, updateResp.GetActivityOptions().GetRetryPolicy().GetInitialInterval().AsDuration())
+
+		describeAfterUpdate, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		require.Equal(t, updatedPolicyInterval, describeAfterUpdate.GetInfo().GetRetryPolicy().GetInitialInterval().AsDuration())
+		require.NotNil(t, describeAfterUpdate.GetInfo().GetCurrentRetryInterval())
+		require.Equal(t, workerNextRetryDelay, describeAfterUpdate.GetInfo().GetCurrentRetryInterval().AsDuration())
+		require.NotNil(t, describeAfterUpdate.GetInfo().GetNextAttemptScheduleTime())
+		require.Equal(t, nextAttemptScheduleTime, describeAfterUpdate.GetInfo().GetNextAttemptScheduleTime().AsTime())
+	})
+
 	t.Run("ChangeRetryInterval_WhileStarted", func(t *testing.T) {
 		// Update retry_policy.initial_interval while the activity is STARTED (running).
 		// In this state CurrentRetryInterval is not recalculated at update time — the new


### PR DESCRIPTION
 ## What changed?
Fixed standalone activity option updates so a pending retry is not delayed when the worker-provided `NextRetryDelay` happens to equal the old retry-policy interval.

When recalculating `CurrentRetryInterval` after `UpdateActivityExecutionOptions`, the activity now only applies the newly computed policy interval if it shortens the already scheduled retry delay. This preserves the existing retry schedule when a retry-policy update would otherwise move the next attempt later.

Added a regression test for the case where:
  - attempt 1 fails with `NextRetryDelay=2m`
  - the current retry policy also had `InitialInterval=2m`
  - the retry policy is updated to `InitialInterval=10m`
  - the pending retry must remain scheduled at 2m, not move to 10m

## Why?

#10920 preserved worker-provided `NextRetryDelay` when it differed from the policy-derived interval, but missed the edge case where the worker delay and old policy interval were equal. In that case, the update path treated the pending retry as policy-derived and recalculated it from the new policy, incorrectly extending the already scheduled retry from 2m to 10m. A retry-policy update should not delay an existing worker-controlled retry.

## How did you test it?
  - [ ] built
  - [ ] run locally and tested manually
  - [x] covered by existing tests
  - [ ] added new unit test(s)
  - [x] added new functional test(s)


## Potential risks
Minimal, this is still part of our testing push and not released to production.