### PR TITLE
Report final failures in CI notifications

### DIFF
--- a/tools/ci-notify/app.go
+++ b/tools/ci-notify/app.go
@@ -116,10 +116,8 @@ func runAlertCommand(c *cli.Context) error {
 	}
 
 	logger.Info("Built failure report",
-		zap.String("workflow", report.Workflow.Name),
-		zap.String("sha", report.Commit.ShortSHA),
-		zap.String("author", report.Commit.Author),
 		zap.Int("failed_jobs", len(report.FailedJobs)),
+		zap.Int("failed_tests", len(report.FailedTests)),
 		zap.Int("total_jobs", report.TotalJobs),
 	)
 

--- a/tools/ci-notify/app.go
+++ b/tools/ci-notify/app.go
@@ -117,7 +117,7 @@ func runAlertCommand(c *cli.Context) error {
 
 	logger.Info("Built failure report",
 		zap.Int("failed_jobs", len(report.FailedJobs)),
-		zap.Int("failed_tests", len(report.FailedTests)),
+		zap.Int("failures", len(report.Failures)),
 		zap.Int("total_jobs", report.TotalJobs),
 	)
 

--- a/tools/ci-notify/app_test.go
+++ b/tools/ci-notify/app_test.go
@@ -80,19 +80,20 @@ func TestFormatMessageForDebug(t *testing.T) {
 			HeadSHA:    "abc1234567890defghijk",
 			URL:        "https://github.com/temporalio/temporal/actions/runs/123456",
 		},
-		FailedJobs: []github.Job{{Name: "test-job-1", Conclusion: "failure"}},
-		Failures:   []string{"TestHistoryWorkflow"},
-		TotalJobs:  5,
+		FailedJobs: []github.Job{{
+			Name:       "test-job-1",
+			Conclusion: "failure",
+			URL:        "https://github.com/temporalio/temporal/actions/runs/123456/job/1",
+		}},
+		Failures:  []string{"TestHistoryWorkflow"},
+		TotalJobs: 5,
 	}
 
-	output := FormatMessageForDebug(report)
-
-	require.Contains(t, output, "CI Failed")
-	require.NotContains(t, output, "Workflow:")
-	require.NotContains(t, output, "Branch:")
-	require.NotContains(t, output, "Commit:")
-	require.Contains(t, output, "test-job-1")
-	require.Contains(t, output, "TestHistoryWorkflow")
+	expected := "🚨 CI Failed on Main Branch 🚨\n\n" +
+		"Failures (1): `TestHistoryWorkflow`\n\n" +
+		"Failed jobs (1/5): test-job-1 (https://github.com/temporalio/temporal/actions/runs/123456/job/1)\n" +
+		"\nView Run: https://github.com/temporalio/temporal/actions/runs/123456\n"
+	require.Equal(t, expected, FormatMessageForDebug(report))
 }
 
 func TestSlackMessageStructure(t *testing.T) {
@@ -109,17 +110,36 @@ func TestSlackMessageStructure(t *testing.T) {
 		TotalJobs: 3,
 	}
 
-	msg := BuildFailureMessage(report)
-
 	// Verify we have the expected number of blocks
 	// Header, Jobs List, Link = 3 blocks
-	require.Len(t, msg.Blocks, 3)
+	expected := &SlackMessage{
+		Text: "CI Failed on Main",
+		Blocks: []SlackBlock{
+			{
+				Type: "section",
+				Text: &SlackText{
+					Type: "mrkdwn",
+					Text: ":rotating_light: *CI Failed on Main Branch* :rotating_light:",
+				},
+			},
+			{
+				Type: "section",
+				Text: &SlackText{
+					Type: "mrkdwn",
+					Text: "*Failed jobs (1/3):* <http://example.com/job1|job1>",
+				},
+			},
+			{
+				Type: "section",
+				Text: &SlackText{
+					Type: "mrkdwn",
+					Text: "<https://github.com/temporalio/temporal/actions/runs/123|View Run>",
+				},
+			},
+		},
+	}
 
-	require.NotNil(t, msg.Blocks[1].Text)
-	require.Contains(t, msg.Blocks[1].Text.Text, "*Failed jobs (1/3):*")
-	require.Contains(t, msg.Blocks[1].Text.Text, "<http://example.com/job1|job1>")
-	require.NotContains(t, msg.Blocks[1].Text.Text, "•")
-	require.NotContains(t, msg.Blocks[1].Text.Text, "\n")
+	require.Equal(t, expected, BuildFailureMessage(report))
 }
 
 func TestBuildFailureMessageLimitsFailures(t *testing.T) {
@@ -144,10 +164,13 @@ func TestBuildFailureMessageLimitsFailures(t *testing.T) {
 	msg := BuildFailureMessage(report)
 
 	require.Len(t, msg.Blocks, 4)
-	require.NotNil(t, msg.Blocks[1].Text)
-	require.Contains(t, msg.Blocks[1].Text.Text, "*Failures (6):*")
-	require.Contains(t, msg.Blocks[1].Text.Text, "Test05")
-	require.NotContains(t, msg.Blocks[1].Text.Text, "Test06")
+	require.Equal(t, SlackBlock{
+		Type: "section",
+		Text: &SlackText{
+			Type: "mrkdwn",
+			Text: "*Failures (6):* `Test01`, `Test02`, `Test03`, `Test04`, `Test05`",
+		},
+	}, msg.Blocks[1])
 }
 
 func TestIsFailedJobExcludesTestStatus(t *testing.T) {
@@ -169,12 +192,11 @@ func TestFilterCompleted(t *testing.T) {
 	tests := []struct {
 		name     string
 		runs     []github.Run
-		expected int
+		expected []github.Run
 	}{
 		{
-			name:     "empty slice",
-			runs:     []github.Run{},
-			expected: 0,
+			name: "empty slice",
+			runs: []github.Run{},
 		},
 		{
 			name: "all completed",
@@ -182,7 +204,10 @@ func TestFilterCompleted(t *testing.T) {
 				{Conclusion: "success"},
 				{Conclusion: "failure"},
 			},
-			expected: 2,
+			expected: []github.Run{
+				{Conclusion: "success"},
+				{Conclusion: "failure"},
+			},
 		},
 		{
 			name: "mixed with in-progress",
@@ -191,7 +216,10 @@ func TestFilterCompleted(t *testing.T) {
 				{Conclusion: ""}, // in-progress
 				{Conclusion: "failure"},
 			},
-			expected: 2,
+			expected: []github.Run{
+				{Conclusion: "success"},
+				{Conclusion: "failure"},
+			},
 		},
 		{
 			name: "with cancelled and skipped",
@@ -201,7 +229,10 @@ func TestFilterCompleted(t *testing.T) {
 				{Conclusion: "skipped"},
 				{Conclusion: "failure"},
 			},
-			expected: 2,
+			expected: []github.Run{
+				{Conclusion: "success"},
+				{Conclusion: "failure"},
+			},
 		},
 		{
 			name: "only in-progress",
@@ -209,14 +240,12 @@ func TestFilterCompleted(t *testing.T) {
 				{Conclusion: ""},
 				{Conclusion: ""},
 			},
-			expected: 0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := filterCompleted(tt.runs)
-			require.Len(t, result, tt.expected)
+			require.Equal(t, tt.expected, filterCompleted(tt.runs))
 		})
 	}
 }
@@ -232,10 +261,9 @@ func TestSlowestRuns(t *testing.T) {
 		},
 	}
 
-	result := report.slowestRuns(3)
-
-	require.Len(t, result, 3)
-	require.Equal(t, "slowest", result[0].DisplayTitle)
-	require.Equal(t, "second slowest", result[1].DisplayTitle)
-	require.Equal(t, "medium", result[2].DisplayTitle)
+	require.Equal(t, []github.Run{
+		{DisplayTitle: "slowest", Duration: 45 * time.Minute},
+		{DisplayTitle: "second slowest", Duration: 30 * time.Minute},
+		{DisplayTitle: "medium", Duration: 20 * time.Minute},
+	}, report.slowestRuns(3))
 }

--- a/tools/ci-notify/app_test.go
+++ b/tools/ci-notify/app_test.go
@@ -108,8 +108,6 @@ func TestSlackMessageStructure(t *testing.T) {
 		TotalJobs: 3,
 	}
 
-	// Verify we have the expected number of blocks
-	// Header, Jobs List, Link = 3 blocks
 	require.Equal(t, &SlackMessage{
 		Text: "CI Failed on Main",
 		Blocks: []SlackBlock{

--- a/tools/ci-notify/app_test.go
+++ b/tools/ci-notify/app_test.go
@@ -30,8 +30,8 @@ func TestBuildFailureMessage(t *testing.T) {
 				URL:        "https://github.com/temporalio/temporal/actions/runs/123456/job/2",
 			},
 		},
-		FailedTests: []string{"TestHistoryWorkflow", "TestMatchingWorkflow"},
-		TotalJobs:   5,
+		Failures:  []string{"TestHistoryWorkflow", "TestMatchingWorkflow"},
+		TotalJobs: 5,
 	}
 
 	msg := BuildFailureMessage(report)
@@ -56,9 +56,9 @@ func TestFormatMessageForDebug(t *testing.T) {
 			HeadSHA:    "abc1234567890defghijk",
 			URL:        "https://github.com/temporalio/temporal/actions/runs/123456",
 		},
-		FailedJobs:  []github.Job{{Name: "test-job-1", Conclusion: "failure"}},
-		FailedTests: []string{"TestHistoryWorkflow"},
-		TotalJobs:   5,
+		FailedJobs: []github.Job{{Name: "test-job-1", Conclusion: "failure"}},
+		Failures:   []string{"TestHistoryWorkflow"},
+		TotalJobs:  5,
 	}
 
 	output := FormatMessageForDebug(report)
@@ -95,7 +95,7 @@ func TestSlackMessageStructure(t *testing.T) {
 	assert.Contains(t, msg.Blocks[1].Text.Text, "*Failed jobs (1/3):*")
 }
 
-func TestBuildFailureMessageLimitsFinalFailedTests(t *testing.T) {
+func TestBuildFailureMessageLimitsFailures(t *testing.T) {
 	report := &FailureReport{
 		Run: github.Run{
 			URL: "https://github.com/temporalio/temporal/actions/runs/123",
@@ -103,7 +103,7 @@ func TestBuildFailureMessageLimitsFinalFailedTests(t *testing.T) {
 		FailedJobs: []github.Job{
 			{Name: "job1", URL: "http://example.com/job1"},
 		},
-		FailedTests: []string{
+		Failures: []string{
 			"Test01",
 			"Test02",
 			"Test03",
@@ -118,7 +118,7 @@ func TestBuildFailureMessageLimitsFinalFailedTests(t *testing.T) {
 
 	require.Len(t, msg.Blocks, 4)
 	require.NotNil(t, msg.Blocks[1].Text)
-	assert.Contains(t, msg.Blocks[1].Text.Text, "*Final failed tests (6):*")
+	assert.Contains(t, msg.Blocks[1].Text.Text, "*Final failures (6):*")
 	assert.Contains(t, msg.Blocks[1].Text.Text, "Test05")
 	assert.NotContains(t, msg.Blocks[1].Text.Text, "Test06")
 }

--- a/tools/ci-notify/app_test.go
+++ b/tools/ci-notify/app_test.go
@@ -46,6 +46,8 @@ func TestBuildFailureMessage(t *testing.T) {
 	require.NotNil(t, msg.Blocks[1].Text)
 	assert.Contains(t, msg.Blocks[1].Text.Text, "TestHistoryWorkflow")
 	assert.Contains(t, msg.Blocks[1].Text.Text, "TestMatchingWorkflow")
+	assert.NotContains(t, msg.Blocks[1].Text.Text, "•")
+	assert.NotContains(t, msg.Blocks[1].Text.Text, "`")
 }
 
 func TestFormatMessageForDebug(t *testing.T) {
@@ -93,6 +95,8 @@ func TestSlackMessageStructure(t *testing.T) {
 
 	require.NotNil(t, msg.Blocks[1].Text)
 	assert.Contains(t, msg.Blocks[1].Text.Text, "*Failed jobs (1/3):*")
+	assert.Contains(t, msg.Blocks[1].Text.Text, "<http://example.com/job1|job1>")
+	assert.NotContains(t, msg.Blocks[1].Text.Text, "•")
 }
 
 func TestBuildFailureMessageLimitsFailures(t *testing.T) {

--- a/tools/ci-notify/app_test.go
+++ b/tools/ci-notify/app_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/server/tools/common/github"
 )
@@ -37,18 +36,18 @@ func TestBuildFailureMessage(t *testing.T) {
 	msg := BuildFailureMessage(report)
 
 	require.NotNil(t, msg, "BuildFailureMessage returned nil")
-	assert.Contains(t, msg.Text, "CI Failed")
-	assert.NotEmpty(t, msg.Blocks, "Message should have at least one block")
+	require.Contains(t, msg.Text, "CI Failed")
+	require.NotEmpty(t, msg.Blocks, "Message should have at least one block")
 
 	// Check that the first block contains the header
 	require.NotNil(t, msg.Blocks[0].Text)
-	assert.Contains(t, msg.Blocks[0].Text.Text, "CI Failed")
+	require.Contains(t, msg.Blocks[0].Text.Text, "CI Failed")
 	require.NotNil(t, msg.Blocks[1].Text)
-	assert.Contains(t, msg.Blocks[1].Text.Text, "TestHistoryWorkflow")
-	assert.Contains(t, msg.Blocks[1].Text.Text, "TestMatchingWorkflow")
-	assert.Contains(t, msg.Blocks[1].Text.Text, "`TestHistoryWorkflow`, `TestMatchingWorkflow`")
-	assert.NotContains(t, msg.Blocks[1].Text.Text, "•")
-	assert.NotContains(t, msg.Blocks[1].Text.Text, "\n")
+	require.Contains(t, msg.Blocks[1].Text.Text, "TestHistoryWorkflow")
+	require.Contains(t, msg.Blocks[1].Text.Text, "TestMatchingWorkflow")
+	require.Contains(t, msg.Blocks[1].Text.Text, "`TestHistoryWorkflow`, `TestMatchingWorkflow`")
+	require.NotContains(t, msg.Blocks[1].Text.Text, "•")
+	require.NotContains(t, msg.Blocks[1].Text.Text, "\n")
 }
 
 func TestFormatMessageForDebug(t *testing.T) {
@@ -66,12 +65,12 @@ func TestFormatMessageForDebug(t *testing.T) {
 
 	output := FormatMessageForDebug(report)
 
-	assert.Contains(t, output, "CI Failed")
-	assert.NotContains(t, output, "Workflow:")
-	assert.NotContains(t, output, "Branch:")
-	assert.NotContains(t, output, "Commit:")
-	assert.Contains(t, output, "test-job-1")
-	assert.Contains(t, output, "TestHistoryWorkflow")
+	require.Contains(t, output, "CI Failed")
+	require.NotContains(t, output, "Workflow:")
+	require.NotContains(t, output, "Branch:")
+	require.NotContains(t, output, "Commit:")
+	require.Contains(t, output, "test-job-1")
+	require.Contains(t, output, "TestHistoryWorkflow")
 }
 
 func TestSlackMessageStructure(t *testing.T) {
@@ -92,13 +91,13 @@ func TestSlackMessageStructure(t *testing.T) {
 
 	// Verify we have the expected number of blocks
 	// Header, Jobs List, Link = 3 blocks
-	assert.Len(t, msg.Blocks, 3)
+	require.Len(t, msg.Blocks, 3)
 
 	require.NotNil(t, msg.Blocks[1].Text)
-	assert.Contains(t, msg.Blocks[1].Text.Text, "*Failed jobs (1/3):*")
-	assert.Contains(t, msg.Blocks[1].Text.Text, "<http://example.com/job1|job1>")
-	assert.NotContains(t, msg.Blocks[1].Text.Text, "•")
-	assert.NotContains(t, msg.Blocks[1].Text.Text, "\n")
+	require.Contains(t, msg.Blocks[1].Text.Text, "*Failed jobs (1/3):*")
+	require.Contains(t, msg.Blocks[1].Text.Text, "<http://example.com/job1|job1>")
+	require.NotContains(t, msg.Blocks[1].Text.Text, "•")
+	require.NotContains(t, msg.Blocks[1].Text.Text, "\n")
 }
 
 func TestBuildFailureMessageLimitsFailures(t *testing.T) {
@@ -124,9 +123,9 @@ func TestBuildFailureMessageLimitsFailures(t *testing.T) {
 
 	require.Len(t, msg.Blocks, 4)
 	require.NotNil(t, msg.Blocks[1].Text)
-	assert.Contains(t, msg.Blocks[1].Text.Text, "*Failures (6):*")
-	assert.Contains(t, msg.Blocks[1].Text.Text, "Test05")
-	assert.NotContains(t, msg.Blocks[1].Text.Text, "Test06")
+	require.Contains(t, msg.Blocks[1].Text.Text, "*Failures (6):*")
+	require.Contains(t, msg.Blocks[1].Text.Text, "Test05")
+	require.NotContains(t, msg.Blocks[1].Text.Text, "Test06")
 }
 
 func TestIsFailedJobExcludesTestStatus(t *testing.T) {
@@ -195,7 +194,7 @@ func TestFilterCompleted(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := filterCompleted(tt.runs)
-			assert.Len(t, result, tt.expected)
+			require.Len(t, result, tt.expected)
 		})
 	}
 }

--- a/tools/ci-notify/app_test.go
+++ b/tools/ci-notify/app_test.go
@@ -118,7 +118,7 @@ func TestBuildFailureMessageLimitsFailures(t *testing.T) {
 
 	require.Len(t, msg.Blocks, 4)
 	require.NotNil(t, msg.Blocks[1].Text)
-	assert.Contains(t, msg.Blocks[1].Text.Text, "*Final failures (6):*")
+	assert.Contains(t, msg.Blocks[1].Text.Text, "*Failures (6):*")
 	assert.Contains(t, msg.Blocks[1].Text.Text, "Test05")
 	assert.NotContains(t, msg.Blocks[1].Text.Text, "Test06")
 }

--- a/tools/ci-notify/app_test.go
+++ b/tools/ci-notify/app_test.go
@@ -123,6 +123,21 @@ func TestBuildFailureMessageLimitsFailures(t *testing.T) {
 	assert.NotContains(t, msg.Blocks[1].Text.Text, "Test06")
 }
 
+func TestIsFailedJobExcludesTestStatus(t *testing.T) {
+	require.True(t, isFailedJob(github.Job{
+		Name:       "Functional test (sqlite, shard1)",
+		Conclusion: github.ConclusionFailure,
+	}))
+	require.False(t, isFailedJob(github.Job{
+		Name:       testStatusJobName,
+		Conclusion: github.ConclusionFailure,
+	}))
+	require.False(t, isFailedJob(github.Job{
+		Name:       "Functional test (sqlite, shard1)",
+		Conclusion: github.ConclusionSuccess,
+	}))
+}
+
 func TestFilterCompleted(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/tools/ci-notify/app_test.go
+++ b/tools/ci-notify/app_test.go
@@ -33,7 +33,7 @@ func TestBuildFailureMessage(t *testing.T) {
 		TotalJobs: 5,
 	}
 
-	expected := &SlackMessage{
+	require.Equal(t, &SlackMessage{
 		Text: "CI Failed on Main",
 		Blocks: []SlackBlock{
 			{
@@ -67,9 +67,7 @@ func TestBuildFailureMessage(t *testing.T) {
 				},
 			},
 		},
-	}
-
-	require.Equal(t, expected, BuildFailureMessage(report))
+	}, BuildFailureMessage(report))
 }
 
 func TestFormatMessageForDebug(t *testing.T) {
@@ -89,11 +87,11 @@ func TestFormatMessageForDebug(t *testing.T) {
 		TotalJobs: 5,
 	}
 
-	expected := "🚨 CI Failed on Main Branch 🚨\n\n" +
-		"Failures (1): `TestHistoryWorkflow`\n\n" +
-		"Failed jobs (1/5): test-job-1 (https://github.com/temporalio/temporal/actions/runs/123456/job/1)\n" +
-		"\nView Run: https://github.com/temporalio/temporal/actions/runs/123456\n"
-	require.Equal(t, expected, FormatMessageForDebug(report))
+	require.Equal(t, "🚨 CI Failed on Main Branch 🚨\n\n"+
+		"Failures (1): `TestHistoryWorkflow`\n\n"+
+		"Failed jobs (1/5): test-job-1 (https://github.com/temporalio/temporal/actions/runs/123456/job/1)\n"+
+		"\nView Run: https://github.com/temporalio/temporal/actions/runs/123456\n",
+		FormatMessageForDebug(report))
 }
 
 func TestSlackMessageStructure(t *testing.T) {
@@ -112,7 +110,7 @@ func TestSlackMessageStructure(t *testing.T) {
 
 	// Verify we have the expected number of blocks
 	// Header, Jobs List, Link = 3 blocks
-	expected := &SlackMessage{
+	require.Equal(t, &SlackMessage{
 		Text: "CI Failed on Main",
 		Blocks: []SlackBlock{
 			{
@@ -137,9 +135,7 @@ func TestSlackMessageStructure(t *testing.T) {
 				},
 			},
 		},
-	}
-
-	require.Equal(t, expected, BuildFailureMessage(report))
+	}, BuildFailureMessage(report))
 }
 
 func TestBuildFailureMessageLimitsFailures(t *testing.T) {

--- a/tools/ci-notify/app_test.go
+++ b/tools/ci-notify/app_test.go
@@ -33,21 +33,43 @@ func TestBuildFailureMessage(t *testing.T) {
 		TotalJobs: 5,
 	}
 
-	msg := BuildFailureMessage(report)
+	expected := &SlackMessage{
+		Text: "CI Failed on Main",
+		Blocks: []SlackBlock{
+			{
+				Type: "section",
+				Text: &SlackText{
+					Type: "mrkdwn",
+					Text: ":rotating_light: *CI Failed on Main Branch* :rotating_light:",
+				},
+			},
+			{
+				Type: "section",
+				Text: &SlackText{
+					Type: "mrkdwn",
+					Text: "*Failures (2):* `TestHistoryWorkflow`, `TestMatchingWorkflow`",
+				},
+			},
+			{
+				Type: "section",
+				Text: &SlackText{
+					Type: "mrkdwn",
+					Text: "*Failed jobs (2/5):* " +
+						"<https://github.com/temporalio/temporal/actions/runs/123456/job/1|test-job-1>, " +
+						"<https://github.com/temporalio/temporal/actions/runs/123456/job/2|test-job-2>",
+				},
+			},
+			{
+				Type: "section",
+				Text: &SlackText{
+					Type: "mrkdwn",
+					Text: "<https://github.com/temporalio/temporal/actions/runs/123456|View Run>",
+				},
+			},
+		},
+	}
 
-	require.NotNil(t, msg, "BuildFailureMessage returned nil")
-	require.Contains(t, msg.Text, "CI Failed")
-	require.NotEmpty(t, msg.Blocks, "Message should have at least one block")
-
-	// Check that the first block contains the header
-	require.NotNil(t, msg.Blocks[0].Text)
-	require.Contains(t, msg.Blocks[0].Text.Text, "CI Failed")
-	require.NotNil(t, msg.Blocks[1].Text)
-	require.Contains(t, msg.Blocks[1].Text.Text, "TestHistoryWorkflow")
-	require.Contains(t, msg.Blocks[1].Text.Text, "TestMatchingWorkflow")
-	require.Contains(t, msg.Blocks[1].Text.Text, "`TestHistoryWorkflow`, `TestMatchingWorkflow`")
-	require.NotContains(t, msg.Blocks[1].Text.Text, "•")
-	require.NotContains(t, msg.Blocks[1].Text.Text, "\n")
+	require.Equal(t, expected, BuildFailureMessage(report))
 }
 
 func TestFormatMessageForDebug(t *testing.T) {

--- a/tools/ci-notify/app_test.go
+++ b/tools/ci-notify/app_test.go
@@ -46,8 +46,9 @@ func TestBuildFailureMessage(t *testing.T) {
 	require.NotNil(t, msg.Blocks[1].Text)
 	assert.Contains(t, msg.Blocks[1].Text.Text, "TestHistoryWorkflow")
 	assert.Contains(t, msg.Blocks[1].Text.Text, "TestMatchingWorkflow")
+	assert.Contains(t, msg.Blocks[1].Text.Text, "`TestHistoryWorkflow`, `TestMatchingWorkflow`")
 	assert.NotContains(t, msg.Blocks[1].Text.Text, "•")
-	assert.NotContains(t, msg.Blocks[1].Text.Text, "`")
+	assert.NotContains(t, msg.Blocks[1].Text.Text, "\n")
 }
 
 func TestFormatMessageForDebug(t *testing.T) {
@@ -97,6 +98,7 @@ func TestSlackMessageStructure(t *testing.T) {
 	assert.Contains(t, msg.Blocks[1].Text.Text, "*Failed jobs (1/3):*")
 	assert.Contains(t, msg.Blocks[1].Text.Text, "<http://example.com/job1|job1>")
 	assert.NotContains(t, msg.Blocks[1].Text.Text, "•")
+	assert.NotContains(t, msg.Blocks[1].Text.Text, "\n")
 }
 
 func TestBuildFailureMessageLimitsFailures(t *testing.T) {

--- a/tools/ci-notify/app_test.go
+++ b/tools/ci-notify/app_test.go
@@ -11,18 +11,12 @@ import (
 
 func TestBuildFailureMessage(t *testing.T) {
 	report := &FailureReport{
-		Workflow: github.Run{
+		Run: github.Run{
 			Name:       "All Tests",
 			HeadBranch: "main",
 			HeadSHA:    "abc1234567890defghijk",
 			URL:        "https://github.com/temporalio/temporal/actions/runs/123456",
 			CreatedAt:  time.Now(),
-		},
-		Commit: CommitInfo{
-			SHA:      "abc1234567890defghijk",
-			ShortSHA: "abc1234",
-			Author:   "Test Author",
-			Message:  "Test commit message",
 		},
 		FailedJobs: []github.Job{
 			{
@@ -36,7 +30,8 @@ func TestBuildFailureMessage(t *testing.T) {
 				URL:        "https://github.com/temporalio/temporal/actions/runs/123456/job/2",
 			},
 		},
-		TotalJobs: 5,
+		FailedTests: []string{"TestHistoryWorkflow", "TestMatchingWorkflow"},
+		TotalJobs:   5,
 	}
 
 	msg := BuildFailureMessage(report)
@@ -48,48 +43,41 @@ func TestBuildFailureMessage(t *testing.T) {
 	// Check that the first block contains the header
 	require.NotNil(t, msg.Blocks[0].Text)
 	assert.Contains(t, msg.Blocks[0].Text.Text, "CI Failed")
+	require.NotNil(t, msg.Blocks[1].Text)
+	assert.Contains(t, msg.Blocks[1].Text.Text, "TestHistoryWorkflow")
+	assert.Contains(t, msg.Blocks[1].Text.Text, "TestMatchingWorkflow")
 }
 
 func TestFormatMessageForDebug(t *testing.T) {
 	report := &FailureReport{
-		Workflow: github.Run{
+		Run: github.Run{
 			Name:       "All Tests",
 			HeadBranch: "main",
 			HeadSHA:    "abc1234567890defghijk",
 			URL:        "https://github.com/temporalio/temporal/actions/runs/123456",
 		},
-		Commit: CommitInfo{
-			SHA:      "abc1234567890defghijk",
-			ShortSHA: "abc1234",
-			Author:   "Test Author",
-		},
-		FailedJobs: []github.Job{
-			{Name: "test-job-1", Conclusion: "failure"},
-		},
-		TotalJobs: 5,
+		FailedJobs:  []github.Job{{Name: "test-job-1", Conclusion: "failure"}},
+		FailedTests: []string{"TestHistoryWorkflow"},
+		TotalJobs:   5,
 	}
 
 	output := FormatMessageForDebug(report)
 
 	assert.Contains(t, output, "CI Failed")
-	assert.Contains(t, output, "All Tests")
-	assert.Contains(t, output, "abc1234")
-	assert.Contains(t, output, "Test Author")
+	assert.NotContains(t, output, "Workflow:")
+	assert.NotContains(t, output, "Branch:")
+	assert.NotContains(t, output, "Commit:")
 	assert.Contains(t, output, "test-job-1")
+	assert.Contains(t, output, "TestHistoryWorkflow")
 }
 
 func TestSlackMessageStructure(t *testing.T) {
 	report := &FailureReport{
-		Workflow: github.Run{
+		Run: github.Run{
 			Name:       "All Tests",
 			HeadBranch: "main",
 			HeadSHA:    "abc1234567890",
 			URL:        "https://github.com/temporalio/temporal/actions/runs/123",
-		},
-		Commit: CommitInfo{
-			SHA:      "abc1234567890",
-			ShortSHA: "abc1234",
-			Author:   "Test",
 		},
 		FailedJobs: []github.Job{
 			{Name: "job1", URL: "http://example.com/job1"},
@@ -100,12 +88,39 @@ func TestSlackMessageStructure(t *testing.T) {
 	msg := BuildFailureMessage(report)
 
 	// Verify we have the expected number of blocks
-	// Header, Info, Summary, Jobs List, Link = 5 blocks
-	assert.Len(t, msg.Blocks, 5)
+	// Header, Jobs List, Link = 3 blocks
+	assert.Len(t, msg.Blocks, 3)
 
-	// Verify the info block has 4 fields
-	infoBlock := msg.Blocks[1]
-	assert.Len(t, infoBlock.Fields, 4)
+	require.NotNil(t, msg.Blocks[1].Text)
+	assert.Contains(t, msg.Blocks[1].Text.Text, "*Failed jobs (1/3):*")
+}
+
+func TestBuildFailureMessageLimitsFinalFailedTests(t *testing.T) {
+	report := &FailureReport{
+		Run: github.Run{
+			URL: "https://github.com/temporalio/temporal/actions/runs/123",
+		},
+		FailedJobs: []github.Job{
+			{Name: "job1", URL: "http://example.com/job1"},
+		},
+		FailedTests: []string{
+			"Test01",
+			"Test02",
+			"Test03",
+			"Test04",
+			"Test05",
+			"Test06",
+		},
+		TotalJobs: 3,
+	}
+
+	msg := BuildFailureMessage(report)
+
+	require.Len(t, msg.Blocks, 4)
+	require.NotNil(t, msg.Blocks[1].Text)
+	assert.Contains(t, msg.Blocks[1].Text.Text, "*Final failed tests (6):*")
+	assert.Contains(t, msg.Blocks[1].Text.Text, "Test05")
+	assert.NotContains(t, msg.Blocks[1].Text.Text, "Test06")
 }
 
 func TestFilterCompleted(t *testing.T) {

--- a/tools/ci-notify/artifacts.go
+++ b/tools/ci-notify/artifacts.go
@@ -5,11 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"regexp"
-	"sort"
-	"strconv"
+	"slices"
 	"strings"
 	"time"
 
@@ -27,19 +25,14 @@ type testSummary struct {
 type summaryRow struct {
 	Kind  string `json:"kind"`
 	Name  string `json:"name"`
-	Final bool   `json:"final,omitempty"`
+	Final bool   `json:"final"`
 }
 
-func getFailures(ctx context.Context, run github.Run, runID string) ([]string, error) {
-	artifactRunID, err := artifactRunID(run, runID)
-	if err != nil {
-		return nil, err
-	}
-
+func getFailures(ctx context.Context, runID int64) ([]string, error) {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	artifacts, err := github.ListRunArtifacts(ctx, "temporalio/temporal", artifactRunID)
+	artifacts, err := github.ListRunArtifacts(ctx, "temporalio/temporal", runID)
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +45,7 @@ func getFailures(ctx context.Context, run github.Run, runID string) ([]string, e
 
 	var failures []string
 	for _, artifact := range artifacts {
-		if artifact.Expired || !isSummaryArtifact(artifact.Name) {
+		if artifact.Expired || !strings.HasPrefix(artifact.Name, "test-summary-json--") {
 			continue
 		}
 
@@ -69,21 +62,6 @@ func getFailures(ctx context.Context, run github.Run, runID string) ([]string, e
 	}
 
 	return uniqueSorted(failures), nil
-}
-
-func artifactRunID(run github.Run, runID string) (int64, error) {
-	if run.DatabaseID != 0 {
-		return run.DatabaseID, nil
-	}
-	id, err := strconv.ParseInt(runID, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("invalid workflow run ID %q: %w", runID, err)
-	}
-	return id, nil
-}
-
-func isSummaryArtifact(name string) bool {
-	return strings.HasPrefix(name, "test-summary-json--")
 }
 
 func failuresFromZip(zipPath string) ([]string, error) {
@@ -115,13 +93,8 @@ func failuresFromZipFile(file *zip.File) ([]string, error) {
 	}
 	defer func() { _ = rc.Close() }()
 
-	data, err := io.ReadAll(rc)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read %s in artifact zip: %w", file.Name, err)
-	}
-
 	var summary testSummary
-	if err := json.Unmarshal(data, &summary); err != nil {
+	if err := json.NewDecoder(rc).Decode(&summary); err != nil {
 		return nil, fmt.Errorf("failed to parse %s in artifact zip: %w", file.Name, err)
 	}
 	return reportableFailures(summary.Rows), nil
@@ -130,23 +103,16 @@ func failuresFromZipFile(file *zip.File) ([]string, error) {
 func reportableFailures(rows []summaryRow) []string {
 	var failures []string
 	for _, row := range rows {
-		if !isReportableFailure(row) {
+		if !row.Final && row.Kind != summaryKindOOM {
 			continue
 		}
-		failures = append(failures, failureName(row))
+		if row.Kind == summaryKindOOM {
+			failures = append(failures, summaryKindOOM)
+			continue
+		}
+		failures = append(failures, normalizeFailureName(row.Name))
 	}
 	return failures
-}
-
-func isReportableFailure(row summaryRow) bool {
-	return row.Final || row.Kind == summaryKindOOM
-}
-
-func failureName(row summaryRow) string {
-	if row.Kind == summaryKindOOM {
-		return summaryKindOOM
-	}
-	return normalizeFailureName(row.Name)
 }
 
 func normalizeFailureName(name string) string {
@@ -160,15 +126,7 @@ func normalizeFailureName(name string) string {
 }
 
 func uniqueSorted(values []string) []string {
-	seen := make(map[string]struct{}, len(values))
-	var unique []string
-	for _, value := range values {
-		if _, ok := seen[value]; ok {
-			continue
-		}
-		seen[value] = struct{}{}
-		unique = append(unique, value)
-	}
-	sort.Strings(unique)
-	return unique
+	values = slices.Clone(values)
+	slices.Sort(values)
+	return slices.Compact(values)
 }

--- a/tools/ci-notify/artifacts.go
+++ b/tools/ci-notify/artifacts.go
@@ -150,16 +150,16 @@ func isReportableFailure(suite junit.Testsuite, testcase junit.Testcase) bool {
 }
 
 func isDataRaceFailure(suite junit.Testsuite, testcase junit.Testcase) bool {
-	fields := []string{
-		suite.Name,
-		testcase.Name,
-		testcase.Classname,
+	if dataRaceRegex.MatchString(suite.Name) ||
+		dataRaceRegex.MatchString(testcase.Name) ||
+		dataRaceRegex.MatchString(testcase.Classname) {
+		return true
 	}
+
 	if testcase.Failure != nil {
-		fields = append(fields, testcase.Failure.Message, testcase.Failure.Type, testcase.Failure.Data)
-	}
-	for _, field := range fields {
-		if dataRaceRegex.MatchString(field) {
+		if dataRaceRegex.MatchString(testcase.Failure.Message) ||
+			dataRaceRegex.MatchString(testcase.Failure.Type) ||
+			dataRaceRegex.MatchString(testcase.Failure.Data) {
 			return true
 		}
 	}

--- a/tools/ci-notify/artifacts.go
+++ b/tools/ci-notify/artifacts.go
@@ -2,9 +2,8 @@ package cinotify
 
 import (
 	"archive/zip"
-	"bytes"
 	"context"
-	"encoding/xml"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -14,13 +13,19 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jstemmer/go-junit-report/v2/junit"
 	"go.temporal.io/server/tools/common/github"
 )
 
-var finalTestRegex = regexp.MustCompile(`\s*\(final\)$`)
-var trailingTestSuffixRegex = regexp.MustCompile(`\s*\([^)]+\)$`)
-var dataRaceRegex = regexp.MustCompile(`(^|\n)DATA RACE: `)
+var trailingFailureSuffixRegex = regexp.MustCompile(`\s*\([^)]+\)$`)
+
+type testSummary struct {
+	Rows []summaryRow `json:"rows"`
+}
+
+type summaryRow struct {
+	Name  string `json:"name"`
+	Final bool   `json:"final,omitempty"`
+}
 
 func getFailures(ctx context.Context, run github.Run, runID string) ([]string, error) {
 	artifactRunID, err := artifactRunID(run, runID)
@@ -44,7 +49,7 @@ func getFailures(ctx context.Context, run github.Run, runID string) ([]string, e
 
 	var failures []string
 	for _, artifact := range artifacts {
-		if artifact.Expired || !isJUnitArtifact(artifact.Name) {
+		if artifact.Expired || !isSummaryArtifact(artifact.Name) {
 			continue
 		}
 
@@ -74,8 +79,8 @@ func artifactRunID(run github.Run, runID string) (int64, error) {
 	return id, nil
 }
 
-func isJUnitArtifact(name string) bool {
-	return strings.Contains(strings.ToLower(name), "junit")
+func isSummaryArtifact(name string) bool {
+	return strings.HasPrefix(name, "test-summary-json--")
 }
 
 func failuresFromZip(zipPath string) ([]string, error) {
@@ -87,7 +92,7 @@ func failuresFromZip(zipPath string) ([]string, error) {
 
 	var failures []string
 	for _, file := range reader.File {
-		if file.FileInfo().IsDir() || !strings.HasSuffix(strings.ToLower(file.Name), ".xml") {
+		if file.FileInfo().IsDir() || !strings.HasSuffix(file.Name, "test-summary.json") {
 			continue
 		}
 
@@ -112,50 +117,27 @@ func failuresFromZipFile(file *zip.File) ([]string, error) {
 		return nil, fmt.Errorf("failed to read %s in artifact zip: %w", file.Name, err)
 	}
 
-	suites, err := parseJUnit(data)
-	if err != nil {
+	var summary testSummary
+	if err := json.Unmarshal(data, &summary); err != nil {
 		return nil, fmt.Errorf("failed to parse %s in artifact zip: %w", file.Name, err)
 	}
-	return failures(suites), nil
+	return finalFailures(summary.Rows), nil
 }
 
-func parseJUnit(data []byte) (*junit.Testsuites, error) {
-	var suites junit.Testsuites
-	if err := xml.NewDecoder(bytes.NewReader(data)).Decode(&suites); err == nil {
-		return &suites, nil
-	}
-
-	var suite junit.Testsuite
-	if err := xml.NewDecoder(bytes.NewReader(data)).Decode(&suite); err != nil {
-		return nil, err
-	}
-	return &junit.Testsuites{Suites: []junit.Testsuite{suite}}, nil
-}
-
-func failures(suites *junit.Testsuites) []string {
+func finalFailures(rows []summaryRow) []string {
 	var failures []string
-	for _, suite := range suites.Suites {
-		for _, testcase := range suite.Testcases {
-			if testcase.Failure == nil || testcase.Skipped != nil || !isReportableFailure(testcase) {
-				continue
-			}
-			failures = append(failures, normalizeTestName(testcase.Name))
+	for _, row := range rows {
+		if !row.Final {
+			continue
 		}
+		failures = append(failures, normalizeFailureName(row.Name))
 	}
 	return failures
 }
 
-func isReportableFailure(testcase junit.Testcase) bool {
-	return finalTestRegex.MatchString(testcase.Name) || isDataRaceFailure(testcase)
-}
-
-func isDataRaceFailure(testcase junit.Testcase) bool {
-	return dataRaceRegex.MatchString(testcase.Name)
-}
-
-func normalizeTestName(name string) string {
+func normalizeFailureName(name string) string {
 	for {
-		stripped := trailingTestSuffixRegex.ReplaceAllString(name, "")
+		stripped := trailingFailureSuffixRegex.ReplaceAllString(name, "")
 		if stripped == name {
 			return name
 		}

--- a/tools/ci-notify/artifacts.go
+++ b/tools/ci-notify/artifacts.go
@@ -14,9 +14,14 @@ import (
 	"go.temporal.io/server/tools/common/github"
 )
 
-var trailingFailureSuffixRegex = regexp.MustCompile(`\s*\([^)]+\)$`)
+const (
+	temporalRepository    = "temporalio/temporal"
+	summaryArtifactPrefix = "test-summary-json--"
+	summaryFileSuffix     = "test-summary.json"
+	summaryKindOOM        = "OOM"
+)
 
-const summaryKindOOM = "OOM"
+var trailingFailureSuffixRegex = regexp.MustCompile(`\s*\([^)]+\)$`)
 
 type testSummary struct {
 	Rows []summaryRow `json:"rows"`
@@ -32,7 +37,7 @@ func getFailures(ctx context.Context, runID int64) ([]string, error) {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	artifacts, err := github.ListRunArtifacts(ctx, "temporalio/temporal", runID)
+	artifacts, err := github.ListRunArtifacts(ctx, temporalRepository, runID)
 	if err != nil {
 		return nil, err
 	}
@@ -45,11 +50,11 @@ func getFailures(ctx context.Context, runID int64) ([]string, error) {
 
 	var failures []string
 	for _, artifact := range artifacts {
-		if artifact.Expired || !strings.HasPrefix(artifact.Name, "test-summary-json--") {
+		if artifact.Expired || !strings.HasPrefix(artifact.Name, summaryArtifactPrefix) {
 			continue
 		}
 
-		zipPath, err := github.DownloadArtifact(ctx, "temporalio/temporal", artifact.ID, tempDir)
+		zipPath, err := github.DownloadArtifact(ctx, temporalRepository, artifact.ID, tempDir)
 		if err != nil {
 			continue
 		}
@@ -73,7 +78,7 @@ func failuresFromZip(zipPath string) ([]string, error) {
 
 	var failures []string
 	for _, file := range reader.File {
-		if file.FileInfo().IsDir() || !strings.HasSuffix(file.Name, "test-summary.json") {
+		if file.FileInfo().IsDir() || !strings.HasSuffix(file.Name, summaryFileSuffix) {
 			continue
 		}
 

--- a/tools/ci-notify/artifacts.go
+++ b/tools/ci-notify/artifacts.go
@@ -18,11 +18,14 @@ import (
 
 var trailingFailureSuffixRegex = regexp.MustCompile(`\s*\([^)]+\)$`)
 
+const summaryKindOOM = "OOM"
+
 type testSummary struct {
 	Rows []summaryRow `json:"rows"`
 }
 
 type summaryRow struct {
+	Kind  string `json:"kind"`
 	Name  string `json:"name"`
 	Final bool   `json:"final,omitempty"`
 }
@@ -121,18 +124,29 @@ func failuresFromZipFile(file *zip.File) ([]string, error) {
 	if err := json.Unmarshal(data, &summary); err != nil {
 		return nil, fmt.Errorf("failed to parse %s in artifact zip: %w", file.Name, err)
 	}
-	return finalFailures(summary.Rows), nil
+	return reportableFailures(summary.Rows), nil
 }
 
-func finalFailures(rows []summaryRow) []string {
+func reportableFailures(rows []summaryRow) []string {
 	var failures []string
 	for _, row := range rows {
-		if !row.Final {
+		if !isReportableFailure(row) {
 			continue
 		}
-		failures = append(failures, normalizeFailureName(row.Name))
+		failures = append(failures, failureName(row))
 	}
 	return failures
+}
+
+func isReportableFailure(row summaryRow) bool {
+	return row.Final || row.Kind == summaryKindOOM
+}
+
+func failureName(row summaryRow) string {
+	if row.Kind == summaryKindOOM {
+		return summaryKindOOM
+	}
+	return normalizeFailureName(row.Name)
 }
 
 func normalizeFailureName(name string) string {

--- a/tools/ci-notify/artifacts.go
+++ b/tools/ci-notify/artifacts.go
@@ -21,7 +21,7 @@ import (
 var finalTestRegex = regexp.MustCompile(`\s*\(final\)$`)
 var trailingTestSuffixRegex = regexp.MustCompile(`\s*\([^)]+\)$`)
 
-func getFinalFailures(ctx context.Context, run github.Run, runID string) ([]string, error) {
+func getFailures(ctx context.Context, run github.Run, runID string) ([]string, error) {
 	artifactRunID, err := artifactRunID(run, runID)
 	if err != nil {
 		return nil, err
@@ -52,7 +52,7 @@ func getFinalFailures(ctx context.Context, run github.Run, runID string) ([]stri
 			continue
 		}
 
-		artifactFailures, err := finalFailuresFromZip(zipPath)
+		artifactFailures, err := failuresFromZip(zipPath)
 		if err != nil {
 			continue
 		}
@@ -77,7 +77,7 @@ func isJUnitArtifact(name string) bool {
 	return strings.Contains(strings.ToLower(name), "junit")
 }
 
-func finalFailuresFromZip(zipPath string) ([]string, error) {
+func failuresFromZip(zipPath string) ([]string, error) {
 	reader, err := zip.OpenReader(zipPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open artifact zip %s: %w", zipPath, err)
@@ -90,7 +90,7 @@ func finalFailuresFromZip(zipPath string) ([]string, error) {
 			continue
 		}
 
-		fileFailures, err := finalFailuresFromZipFile(file)
+		fileFailures, err := failuresFromZipFile(file)
 		if err != nil {
 			continue
 		}
@@ -99,7 +99,7 @@ func finalFailuresFromZip(zipPath string) ([]string, error) {
 	return failures, nil
 }
 
-func finalFailuresFromZipFile(file *zip.File) ([]string, error) {
+func failuresFromZipFile(file *zip.File) ([]string, error) {
 	rc, err := file.Open()
 	if err != nil {
 		return nil, fmt.Errorf("failed to open %s in artifact zip: %w", file.Name, err)
@@ -115,7 +115,7 @@ func finalFailuresFromZipFile(file *zip.File) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse %s in artifact zip: %w", file.Name, err)
 	}
-	return finalFailures(suites), nil
+	return failures(suites), nil
 }
 
 func parseJUnit(data []byte) (*junit.Testsuites, error) {
@@ -131,17 +131,38 @@ func parseJUnit(data []byte) (*junit.Testsuites, error) {
 	return &junit.Testsuites{Suites: []junit.Testsuite{suite}}, nil
 }
 
-func finalFailures(suites *junit.Testsuites) []string {
+func failures(suites *junit.Testsuites) []string {
 	var failures []string
 	for _, suite := range suites.Suites {
 		for _, testcase := range suite.Testcases {
-			if testcase.Failure == nil || testcase.Skipped != nil || !finalTestRegex.MatchString(testcase.Name) {
+			if testcase.Failure == nil || testcase.Skipped != nil || !isReportableFailure(suite, testcase) {
 				continue
 			}
 			failures = append(failures, normalizeTestName(testcase.Name))
 		}
 	}
 	return failures
+}
+
+func isReportableFailure(suite junit.Testsuite, testcase junit.Testcase) bool {
+	return finalTestRegex.MatchString(testcase.Name) || isDataRaceFailure(suite, testcase)
+}
+
+func isDataRaceFailure(suite junit.Testsuite, testcase junit.Testcase) bool {
+	fields := []string{
+		suite.Name,
+		testcase.Name,
+		testcase.Classname,
+	}
+	if testcase.Failure != nil {
+		fields = append(fields, testcase.Failure.Message, testcase.Failure.Type, testcase.Failure.Data)
+	}
+	for _, field := range fields {
+		if strings.Contains(strings.ToLower(field), "data race") {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeTestName(name string) string {

--- a/tools/ci-notify/artifacts.go
+++ b/tools/ci-notify/artifacts.go
@@ -136,7 +136,7 @@ func failures(suites *junit.Testsuites) []string {
 	var failures []string
 	for _, suite := range suites.Suites {
 		for _, testcase := range suite.Testcases {
-			if testcase.Failure == nil || testcase.Skipped != nil || !isReportableFailure(suite, testcase) {
+			if testcase.Failure == nil || testcase.Skipped != nil || !isReportableFailure(testcase) {
 				continue
 			}
 			failures = append(failures, normalizeTestName(testcase.Name))
@@ -145,25 +145,12 @@ func failures(suites *junit.Testsuites) []string {
 	return failures
 }
 
-func isReportableFailure(suite junit.Testsuite, testcase junit.Testcase) bool {
-	return finalTestRegex.MatchString(testcase.Name) || isDataRaceFailure(suite, testcase)
+func isReportableFailure(testcase junit.Testcase) bool {
+	return finalTestRegex.MatchString(testcase.Name) || isDataRaceFailure(testcase)
 }
 
-func isDataRaceFailure(suite junit.Testsuite, testcase junit.Testcase) bool {
-	if dataRaceRegex.MatchString(suite.Name) ||
-		dataRaceRegex.MatchString(testcase.Name) ||
-		dataRaceRegex.MatchString(testcase.Classname) {
-		return true
-	}
-
-	if testcase.Failure != nil {
-		if dataRaceRegex.MatchString(testcase.Failure.Message) ||
-			dataRaceRegex.MatchString(testcase.Failure.Type) ||
-			dataRaceRegex.MatchString(testcase.Failure.Data) {
-			return true
-		}
-	}
-	return false
+func isDataRaceFailure(testcase junit.Testcase) bool {
+	return dataRaceRegex.MatchString(testcase.Name)
 }
 
 func normalizeTestName(name string) string {

--- a/tools/ci-notify/artifacts.go
+++ b/tools/ci-notify/artifacts.go
@@ -1,0 +1,169 @@
+package cinotify
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jstemmer/go-junit-report/v2/junit"
+	"go.temporal.io/server/tools/common/github"
+)
+
+var finalTestRegex = regexp.MustCompile(`\s*\(final\)$`)
+var trailingTestSuffixRegex = regexp.MustCompile(`\s*\([^)]+\)$`)
+
+func getFinalFailedTests(ctx context.Context, run github.Run, runID string) ([]string, error) {
+	artifactRunID, err := artifactRunID(run, runID)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	artifacts, err := github.ListRunArtifacts(ctx, "temporalio/temporal", artifactRunID)
+	if err != nil {
+		return nil, err
+	}
+
+	tempDir, err := os.MkdirTemp("", "ci-notify-artifacts-*")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	var tests []string
+	for _, artifact := range artifacts {
+		if artifact.Expired || !isJUnitArtifact(artifact.Name) {
+			continue
+		}
+
+		zipPath, err := github.DownloadArtifact(ctx, "temporalio/temporal", artifact.ID, tempDir)
+		if err != nil {
+			continue
+		}
+
+		artifactTests, err := finalFailedTestsFromZip(zipPath)
+		if err != nil {
+			continue
+		}
+		tests = append(tests, artifactTests...)
+	}
+
+	return uniqueSorted(tests), nil
+}
+
+func artifactRunID(run github.Run, runID string) (int64, error) {
+	if run.DatabaseID != 0 {
+		return run.DatabaseID, nil
+	}
+	id, err := strconv.ParseInt(runID, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid workflow run ID %q: %w", runID, err)
+	}
+	return id, nil
+}
+
+func isJUnitArtifact(name string) bool {
+	return strings.Contains(strings.ToLower(name), "junit")
+}
+
+func finalFailedTestsFromZip(zipPath string) ([]string, error) {
+	reader, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open artifact zip %s: %w", zipPath, err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	var tests []string
+	for _, file := range reader.File {
+		if file.FileInfo().IsDir() || !strings.HasSuffix(strings.ToLower(file.Name), ".xml") {
+			continue
+		}
+
+		fileTests, err := finalFailedTestsFromZipFile(file)
+		if err != nil {
+			continue
+		}
+		tests = append(tests, fileTests...)
+	}
+	return tests, nil
+}
+
+func finalFailedTestsFromZipFile(file *zip.File) ([]string, error) {
+	rc, err := file.Open()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open %s in artifact zip: %w", file.Name, err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s in artifact zip: %w", file.Name, err)
+	}
+
+	suites, err := parseJUnit(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse %s in artifact zip: %w", file.Name, err)
+	}
+	return finalFailedTests(suites), nil
+}
+
+func parseJUnit(data []byte) (*junit.Testsuites, error) {
+	var suites junit.Testsuites
+	if err := xml.NewDecoder(bytes.NewReader(data)).Decode(&suites); err == nil {
+		return &suites, nil
+	}
+
+	var suite junit.Testsuite
+	if err := xml.NewDecoder(bytes.NewReader(data)).Decode(&suite); err != nil {
+		return nil, err
+	}
+	return &junit.Testsuites{Suites: []junit.Testsuite{suite}}, nil
+}
+
+func finalFailedTests(suites *junit.Testsuites) []string {
+	var tests []string
+	for _, suite := range suites.Suites {
+		for _, testcase := range suite.Testcases {
+			if testcase.Failure == nil || testcase.Skipped != nil || !finalTestRegex.MatchString(testcase.Name) {
+				continue
+			}
+			tests = append(tests, normalizeTestName(testcase.Name))
+		}
+	}
+	return tests
+}
+
+func normalizeTestName(name string) string {
+	for {
+		stripped := trailingTestSuffixRegex.ReplaceAllString(name, "")
+		if stripped == name {
+			return name
+		}
+		name = stripped
+	}
+}
+
+func uniqueSorted(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	var unique []string
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		unique = append(unique, value)
+	}
+	sort.Strings(unique)
+	return unique
+}

--- a/tools/ci-notify/artifacts.go
+++ b/tools/ci-notify/artifacts.go
@@ -21,7 +21,7 @@ import (
 var finalTestRegex = regexp.MustCompile(`\s*\(final\)$`)
 var trailingTestSuffixRegex = regexp.MustCompile(`\s*\([^)]+\)$`)
 
-func getFinalFailedTests(ctx context.Context, run github.Run, runID string) ([]string, error) {
+func getFinalFailures(ctx context.Context, run github.Run, runID string) ([]string, error) {
 	artifactRunID, err := artifactRunID(run, runID)
 	if err != nil {
 		return nil, err
@@ -41,7 +41,7 @@ func getFinalFailedTests(ctx context.Context, run github.Run, runID string) ([]s
 	}
 	defer func() { _ = os.RemoveAll(tempDir) }()
 
-	var tests []string
+	var failures []string
 	for _, artifact := range artifacts {
 		if artifact.Expired || !isJUnitArtifact(artifact.Name) {
 			continue
@@ -52,14 +52,14 @@ func getFinalFailedTests(ctx context.Context, run github.Run, runID string) ([]s
 			continue
 		}
 
-		artifactTests, err := finalFailedTestsFromZip(zipPath)
+		artifactFailures, err := finalFailuresFromZip(zipPath)
 		if err != nil {
 			continue
 		}
-		tests = append(tests, artifactTests...)
+		failures = append(failures, artifactFailures...)
 	}
 
-	return uniqueSorted(tests), nil
+	return uniqueSorted(failures), nil
 }
 
 func artifactRunID(run github.Run, runID string) (int64, error) {
@@ -77,29 +77,29 @@ func isJUnitArtifact(name string) bool {
 	return strings.Contains(strings.ToLower(name), "junit")
 }
 
-func finalFailedTestsFromZip(zipPath string) ([]string, error) {
+func finalFailuresFromZip(zipPath string) ([]string, error) {
 	reader, err := zip.OpenReader(zipPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open artifact zip %s: %w", zipPath, err)
 	}
 	defer func() { _ = reader.Close() }()
 
-	var tests []string
+	var failures []string
 	for _, file := range reader.File {
 		if file.FileInfo().IsDir() || !strings.HasSuffix(strings.ToLower(file.Name), ".xml") {
 			continue
 		}
 
-		fileTests, err := finalFailedTestsFromZipFile(file)
+		fileFailures, err := finalFailuresFromZipFile(file)
 		if err != nil {
 			continue
 		}
-		tests = append(tests, fileTests...)
+		failures = append(failures, fileFailures...)
 	}
-	return tests, nil
+	return failures, nil
 }
 
-func finalFailedTestsFromZipFile(file *zip.File) ([]string, error) {
+func finalFailuresFromZipFile(file *zip.File) ([]string, error) {
 	rc, err := file.Open()
 	if err != nil {
 		return nil, fmt.Errorf("failed to open %s in artifact zip: %w", file.Name, err)
@@ -115,7 +115,7 @@ func finalFailedTestsFromZipFile(file *zip.File) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse %s in artifact zip: %w", file.Name, err)
 	}
-	return finalFailedTests(suites), nil
+	return finalFailures(suites), nil
 }
 
 func parseJUnit(data []byte) (*junit.Testsuites, error) {
@@ -131,17 +131,17 @@ func parseJUnit(data []byte) (*junit.Testsuites, error) {
 	return &junit.Testsuites{Suites: []junit.Testsuite{suite}}, nil
 }
 
-func finalFailedTests(suites *junit.Testsuites) []string {
-	var tests []string
+func finalFailures(suites *junit.Testsuites) []string {
+	var failures []string
 	for _, suite := range suites.Suites {
 		for _, testcase := range suite.Testcases {
 			if testcase.Failure == nil || testcase.Skipped != nil || !finalTestRegex.MatchString(testcase.Name) {
 				continue
 			}
-			tests = append(tests, normalizeTestName(testcase.Name))
+			failures = append(failures, normalizeTestName(testcase.Name))
 		}
 	}
-	return tests
+	return failures
 }
 
 func normalizeTestName(name string) string {

--- a/tools/ci-notify/artifacts.go
+++ b/tools/ci-notify/artifacts.go
@@ -20,6 +20,7 @@ import (
 
 var finalTestRegex = regexp.MustCompile(`\s*\(final\)$`)
 var trailingTestSuffixRegex = regexp.MustCompile(`\s*\([^)]+\)$`)
+var dataRaceRegex = regexp.MustCompile(`(^|\n)DATA RACE: `)
 
 func getFailures(ctx context.Context, run github.Run, runID string) ([]string, error) {
 	artifactRunID, err := artifactRunID(run, runID)
@@ -158,7 +159,7 @@ func isDataRaceFailure(suite junit.Testsuite, testcase junit.Testcase) bool {
 		fields = append(fields, testcase.Failure.Message, testcase.Failure.Type, testcase.Failure.Data)
 	}
 	for _, field := range fields {
-		if strings.Contains(strings.ToLower(field), "data race") {
+		if dataRaceRegex.MatchString(field) {
 			return true
 		}
 	}

--- a/tools/ci-notify/artifacts_test.go
+++ b/tools/ci-notify/artifacts_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFinalFailedTests(t *testing.T) {
+func TestFinalFailures(t *testing.T) {
 	suites, err := parseJUnit([]byte(`<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
   <testsuite name="suite">
@@ -25,7 +25,7 @@ func TestFinalFailedTests(t *testing.T) {
 </testsuites>`))
 	require.NoError(t, err)
 
-	require.Equal(t, []string{"TestHistoryWorkflow"}, finalFailedTests(suites))
+	require.Equal(t, []string{"TestHistoryWorkflow"}, finalFailures(suites))
 }
 
 func TestParseJUnitSingleTestsuite(t *testing.T) {
@@ -37,5 +37,5 @@ func TestParseJUnitSingleTestsuite(t *testing.T) {
 </testsuite>`))
 	require.NoError(t, err)
 
-	require.Equal(t, []string{"TestMatchingWorkflow"}, finalFailedTests(suites))
+	require.Equal(t, []string{"TestMatchingWorkflow"}, finalFailures(suites))
 }

--- a/tools/ci-notify/artifacts_test.go
+++ b/tools/ci-notify/artifacts_test.go
@@ -1,61 +1,51 @@
 package cinotify
 
 import (
+	"archive/zip"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestFailures(t *testing.T) {
-	suites, err := parseJUnit([]byte(`<?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
-  <testsuite name="suite">
-    <testcase classname="history" name="TestHistoryWorkflow (retry 1) (final)">
-      <failure message="failed">failed</failure>
-    </testcase>
-    <testcase classname="history" name="TestRetryFailure (retry 1)">
-      <failure message="failed">failed</failure>
-    </testcase>
-    <testcase classname="history" name="TestSkippedFinal (final)">
-      <skipped message="skipped"/>
-      <failure message="failed">failed</failure>
-    </testcase>
-    <testcase classname="history" name="TestPassedFinal (final)"/>
-  </testsuite>
-  <testsuite name="DATA RACE">
-    <testcase classname="race" name="DATA RACE: detected">
-      <failure message="WARNING: DATA RACE">race details</failure>
-    </testcase>
-  </testsuite>
-</testsuites>`))
-	require.NoError(t, err)
+func TestFinalFailures(t *testing.T) {
+	rows := []summaryRow{
+		{Name: "TestHistoryWorkflow (retry 1) (final)", Final: true},
+		{Name: "TestRetryFailure (retry 1)"},
+		{Name: "DATA RACE: detected"},
+	}
 
-	require.Equal(t, []string{"TestHistoryWorkflow", "DATA RACE: detected"}, failures(suites))
+	require.Equal(t, []string{"TestHistoryWorkflow"}, finalFailures(rows))
 }
 
-func TestParseJUnitSingleTestsuite(t *testing.T) {
-	suites, err := parseJUnit([]byte(`<?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="suite">
-  <testcase classname="matching" name="TestMatchingWorkflow (final)">
-    <failure message="failed">failed</failure>
-  </testcase>
-</testsuite>`))
+func TestFailuresFromZip(t *testing.T) {
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "artifact.zip")
+	file, err := os.Create(zipPath)
 	require.NoError(t, err)
 
-	require.Equal(t, []string{"TestMatchingWorkflow"}, failures(suites))
-}
-
-func TestFailuresIncludesDataRace(t *testing.T) {
-	suites, err := parseJUnit([]byte(`<?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="suite">
-  <testcase classname="race" name="DATA RACE: detected">
-    <failure message="WARNING: DATA RACE">race details</failure>
-  </testcase>
-  <testcase classname="race" name="NotADataRace">
-    <failure message="data race">lowercase marker should not match</failure>
-  </testcase>
-</testsuite>`))
+	writer := zip.NewWriter(file)
+	summaryFile, err := writer.Create("test-summary.json")
 	require.NoError(t, err)
+	_, err = summaryFile.Write([]byte(`{
+  "rows": [
+    {
+      "kind": "Failed",
+      "name": "TestMatchingWorkflow (final)",
+      "final": true
+    },
+    {
+      "kind": "DATA RACE",
+      "name": "DATA RACE: detected"
+    }
+  ]
+}`))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	require.NoError(t, file.Close())
 
-	require.Equal(t, []string{"DATA RACE: detected"}, failures(suites))
+	failures, err := failuresFromZip(zipPath)
+	require.NoError(t, err)
+	require.Equal(t, []string{"TestMatchingWorkflow"}, failures)
 }

--- a/tools/ci-notify/artifacts_test.go
+++ b/tools/ci-notify/artifacts_test.go
@@ -16,7 +16,10 @@ func TestReportableFailures(t *testing.T) {
 		{Kind: summaryKindOOM, Name: "OOM prevention"},
 	}
 
-	require.Equal(t, []string{"TestHistoryWorkflow", "OOM"}, reportableFailures(rows))
+	require.Equal(t, []string{
+		"TestHistoryWorkflow",
+		"OOM",
+	}, reportableFailures(rows))
 }
 
 func TestFailuresFromZip(t *testing.T) {

--- a/tools/ci-notify/artifacts_test.go
+++ b/tools/ci-notify/artifacts_test.go
@@ -44,3 +44,18 @@ func TestParseJUnitSingleTestsuite(t *testing.T) {
 
 	require.Equal(t, []string{"TestMatchingWorkflow"}, failures(suites))
 }
+
+func TestFailuresIncludesDataRace(t *testing.T) {
+	suites, err := parseJUnit([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="suite">
+  <testcase classname="race" name="DATA RACE: detected">
+    <failure message="WARNING: DATA RACE">race details</failure>
+  </testcase>
+  <testcase classname="race" name="NotADataRace">
+    <failure message="data race">lowercase marker should not match</failure>
+  </testcase>
+</testsuite>`))
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"DATA RACE: detected"}, failures(suites))
+}

--- a/tools/ci-notify/artifacts_test.go
+++ b/tools/ci-notify/artifacts_test.go
@@ -1,0 +1,41 @@
+package cinotify
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFinalFailedTests(t *testing.T) {
+	suites, err := parseJUnit([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="suite">
+    <testcase classname="history" name="TestHistoryWorkflow (retry 1) (final)">
+      <failure message="failed">failed</failure>
+    </testcase>
+    <testcase classname="history" name="TestRetryFailure (retry 1)">
+      <failure message="failed">failed</failure>
+    </testcase>
+    <testcase classname="history" name="TestSkippedFinal (final)">
+      <skipped message="skipped"/>
+      <failure message="failed">failed</failure>
+    </testcase>
+    <testcase classname="history" name="TestPassedFinal (final)"/>
+  </testsuite>
+</testsuites>`))
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"TestHistoryWorkflow"}, finalFailedTests(suites))
+}
+
+func TestParseJUnitSingleTestsuite(t *testing.T) {
+	suites, err := parseJUnit([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="suite">
+  <testcase classname="matching" name="TestMatchingWorkflow (final)">
+    <failure message="failed">failed</failure>
+  </testcase>
+</testsuite>`))
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"TestMatchingWorkflow"}, finalFailedTests(suites))
+}

--- a/tools/ci-notify/artifacts_test.go
+++ b/tools/ci-notify/artifacts_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFinalFailures(t *testing.T) {
+func TestFailures(t *testing.T) {
 	suites, err := parseJUnit([]byte(`<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
   <testsuite name="suite">
@@ -22,10 +22,15 @@ func TestFinalFailures(t *testing.T) {
     </testcase>
     <testcase classname="history" name="TestPassedFinal (final)"/>
   </testsuite>
+  <testsuite name="DATA RACE">
+    <testcase classname="race" name="DATA RACE: detected">
+      <failure message="WARNING: DATA RACE">race details</failure>
+    </testcase>
+  </testsuite>
 </testsuites>`))
 	require.NoError(t, err)
 
-	require.Equal(t, []string{"TestHistoryWorkflow"}, finalFailures(suites))
+	require.Equal(t, []string{"TestHistoryWorkflow", "DATA RACE: detected"}, failures(suites))
 }
 
 func TestParseJUnitSingleTestsuite(t *testing.T) {
@@ -37,5 +42,5 @@ func TestParseJUnitSingleTestsuite(t *testing.T) {
 </testsuite>`))
 	require.NoError(t, err)
 
-	require.Equal(t, []string{"TestMatchingWorkflow"}, finalFailures(suites))
+	require.Equal(t, []string{"TestMatchingWorkflow"}, failures(suites))
 }

--- a/tools/ci-notify/artifacts_test.go
+++ b/tools/ci-notify/artifacts_test.go
@@ -9,13 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFinalFailures(t *testing.T) {
+func TestReportableFailures(t *testing.T) {
 	rows := []summaryRow{
-		{Name: "TestHistoryWorkflow (retry 1) (final)", Final: true},
-		{Name: "TestRetryFailure (retry 1)"},
+		{Kind: "Failed", Name: "TestHistoryWorkflow (retry 1) (final)", Final: true},
+		{Kind: "Failed", Name: "TestRetryFailure (retry 1)"},
+		{Kind: summaryKindOOM, Name: "OOM prevention"},
 	}
 
-	require.Equal(t, []string{"TestHistoryWorkflow"}, finalFailures(rows))
+	require.Equal(t, []string{"TestHistoryWorkflow", "OOM"}, reportableFailures(rows))
 }
 
 func TestFailuresFromZip(t *testing.T) {
@@ -29,18 +30,22 @@ func TestFailuresFromZip(t *testing.T) {
 	require.NoError(t, err)
 	_, err = summaryFile.Write([]byte(`{
   "rows": [
-	    {
-	      "kind": "Failed",
-	      "name": "TestMatchingWorkflow (final)",
-	      "final": true
-	    }
-	  ]
-	}`))
+    {
+      "kind": "Failed",
+      "name": "TestMatchingWorkflow (final)",
+      "final": true
+    },
+    {
+      "kind": "OOM",
+      "name": "OOM prevention"
+    }
+  ]
+}`))
 	require.NoError(t, err)
 	require.NoError(t, writer.Close())
 	require.NoError(t, file.Close())
 
 	failures, err := failuresFromZip(zipPath)
 	require.NoError(t, err)
-	require.Equal(t, []string{"TestMatchingWorkflow"}, failures)
+	require.Equal(t, []string{"TestMatchingWorkflow", "OOM"}, failures)
 }

--- a/tools/ci-notify/artifacts_test.go
+++ b/tools/ci-notify/artifacts_test.go
@@ -9,19 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestReportableFailures(t *testing.T) {
-	rows := []summaryRow{
-		{Kind: "Failed", Name: "TestHistoryWorkflow (retry 1) (final)", Final: true},
-		{Kind: "Failed", Name: "TestRetryFailure (retry 1)"},
-		{Kind: summaryKindOOM, Name: "OOM prevention"},
-	}
-
-	require.Equal(t, []string{
-		"TestHistoryWorkflow",
-		"OOM",
-	}, reportableFailures(rows))
-}
-
 func TestFailuresFromZip(t *testing.T) {
 	dir := t.TempDir()
 	zipPath := filepath.Join(dir, "artifact.zip")
@@ -35,8 +22,12 @@ func TestFailuresFromZip(t *testing.T) {
   "rows": [
     {
       "kind": "Failed",
-      "name": "TestMatchingWorkflow (final)",
+      "name": "TestMatchingWorkflow (retry 1) (final)",
       "final": true
+    },
+    {
+      "kind": "Failed",
+      "name": "TestRetryFailure (retry 1)"
     },
     {
       "kind": "OOM",

--- a/tools/ci-notify/artifacts_test.go
+++ b/tools/ci-notify/artifacts_test.go
@@ -13,7 +13,6 @@ func TestFinalFailures(t *testing.T) {
 	rows := []summaryRow{
 		{Name: "TestHistoryWorkflow (retry 1) (final)", Final: true},
 		{Name: "TestRetryFailure (retry 1)"},
-		{Name: "DATA RACE: detected"},
 	}
 
 	require.Equal(t, []string{"TestHistoryWorkflow"}, finalFailures(rows))
@@ -30,17 +29,13 @@ func TestFailuresFromZip(t *testing.T) {
 	require.NoError(t, err)
 	_, err = summaryFile.Write([]byte(`{
   "rows": [
-    {
-      "kind": "Failed",
-      "name": "TestMatchingWorkflow (final)",
-      "final": true
-    },
-    {
-      "kind": "DATA RACE",
-      "name": "DATA RACE: detected"
-    }
-  ]
-}`))
+	    {
+	      "kind": "Failed",
+	      "name": "TestMatchingWorkflow (final)",
+	      "final": true
+	    }
+	  ]
+	}`))
 	require.NoError(t, err)
 	require.NoError(t, writer.Close())
 	require.NoError(t, file.Close())

--- a/tools/ci-notify/failure_report.go
+++ b/tools/ci-notify/failure_report.go
@@ -28,22 +28,6 @@ func BuildFailureReport(runID string) (*FailureReport, error) {
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	commitMeta, err := github.GetCommit(ctx, "temporalio/temporal", run.HeadSHA)
-	author := commitMeta.Commit.Author.Name
-	if err != nil {
-		// Non-fatal: use unknown if we can't get author
-		author = "Unknown"
-	}
-
-	commit := CommitInfo{
-		SHA:      run.HeadSHA,
-		ShortSHA: run.ShortSHA(),
-		Author:   author,
-		Message:  run.DisplayTitle,
-	}
-
 	// Identify failed jobs
 	var failedJobs []github.Job
 	for _, job := range run.Jobs {
@@ -52,10 +36,15 @@ func BuildFailureReport(runID string) (*FailureReport, error) {
 		}
 	}
 
+	failedTests, err := getFinalFailedTests(context.Background(), *run, runID)
+	if err != nil {
+		failedTests = nil
+	}
+
 	return &FailureReport{
-		Workflow:   *run,
-		Commit:     commit,
-		FailedJobs: failedJobs,
-		TotalJobs:  len(run.Jobs),
+		Run:         *run,
+		FailedJobs:  failedJobs,
+		FailedTests: failedTests,
+		TotalJobs:   len(run.Jobs),
 	}, nil
 }

--- a/tools/ci-notify/failure_report.go
+++ b/tools/ci-notify/failure_report.go
@@ -38,7 +38,7 @@ func BuildFailureReport(runID string) (*FailureReport, error) {
 		}
 	}
 
-	failures, err := getFailures(context.Background(), *run, runID)
+	failures, err := getFailures(context.Background(), run.DatabaseID)
 	if err != nil {
 		failures = nil
 	}

--- a/tools/ci-notify/failure_report.go
+++ b/tools/ci-notify/failure_report.go
@@ -36,15 +36,15 @@ func BuildFailureReport(runID string) (*FailureReport, error) {
 		}
 	}
 
-	failedTests, err := getFinalFailedTests(context.Background(), *run, runID)
+	failures, err := getFinalFailures(context.Background(), *run, runID)
 	if err != nil {
-		failedTests = nil
+		failures = nil
 	}
 
 	return &FailureReport{
-		Run:         *run,
-		FailedJobs:  failedJobs,
-		FailedTests: failedTests,
-		TotalJobs:   len(run.Jobs),
+		Run:        *run,
+		FailedJobs: failedJobs,
+		Failures:   failures,
+		TotalJobs:  len(run.Jobs),
 	}, nil
 }

--- a/tools/ci-notify/failure_report.go
+++ b/tools/ci-notify/failure_report.go
@@ -8,6 +8,8 @@ import (
 	"go.temporal.io/server/tools/common/github"
 )
 
+const testStatusJobName = "Test Status"
+
 // getWorkflowRun fetches workflow run details for failure notifications.
 func getWorkflowRun(runID string) (*github.Run, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -31,7 +33,7 @@ func BuildFailureReport(runID string) (*FailureReport, error) {
 	// Identify failed jobs
 	var failedJobs []github.Job
 	for _, job := range run.Jobs {
-		if job.Conclusion == github.ConclusionFailure {
+		if isFailedJob(job) {
 			failedJobs = append(failedJobs, job)
 		}
 	}
@@ -47,4 +49,8 @@ func BuildFailureReport(runID string) (*FailureReport, error) {
 		Failures:   failures,
 		TotalJobs:  len(run.Jobs),
 	}, nil
+}
+
+func isFailedJob(job github.Job) bool {
+	return job.Conclusion == github.ConclusionFailure && job.Name != testStatusJobName
 }

--- a/tools/ci-notify/failure_report.go
+++ b/tools/ci-notify/failure_report.go
@@ -36,7 +36,7 @@ func BuildFailureReport(runID string) (*FailureReport, error) {
 		}
 	}
 
-	failures, err := getFinalFailures(context.Background(), *run, runID)
+	failures, err := getFailures(context.Background(), *run, runID)
 	if err != nil {
 		failures = nil
 	}

--- a/tools/ci-notify/slack.go
+++ b/tools/ci-notify/slack.go
@@ -7,9 +7,9 @@ import (
 	"net/http"
 	"strings"
 	"time"
-
-	"go.temporal.io/server/tools/common/github"
 )
+
+const maxFailedTests = 5
 
 // SlackMessage represents a Slack Block Kit message
 type SlackMessage struct {
@@ -41,40 +41,6 @@ func BuildFailureMessage(report *FailureReport) *SlackMessage {
 		},
 	}
 
-	// Workflow and commit info
-	commitURL := github.CommitURL("temporalio/temporal", report.Commit.SHA)
-	infoBlock := SlackBlock{
-		Type: "section",
-		Fields: []SlackText{
-			{
-				Type: "mrkdwn",
-				Text: fmt.Sprintf("*Workflow:*\n%s", report.Workflow.Name),
-			},
-			{
-				Type: "mrkdwn",
-				Text: fmt.Sprintf("*Branch:*\n`%s`", report.Workflow.HeadBranch),
-			},
-			{
-				Type: "mrkdwn",
-				Text: fmt.Sprintf("*Commit:*\n<%s|%s>", commitURL, report.Commit.ShortSHA),
-			},
-			{
-				Type: "mrkdwn",
-				Text: fmt.Sprintf("*Author:*\n%s", report.Commit.Author),
-			},
-		},
-	}
-
-	// Failure summary
-	summaryBlock := SlackBlock{
-		Type: "section",
-		Text: &SlackText{
-			Type: "mrkdwn",
-			Text: fmt.Sprintf("*Failed Jobs:* %d of %d total jobs",
-				len(report.FailedJobs), report.TotalJobs),
-		},
-	}
-
 	// List of failed jobs
 	var failedJobNames []string
 	for _, job := range report.FailedJobs {
@@ -86,29 +52,49 @@ func BuildFailureMessage(report *FailureReport) *SlackMessage {
 		Type: "section",
 		Text: &SlackText{
 			Type: "mrkdwn",
-			Text: fmt.Sprintf("*Failed Jobs:*\n%s",
+			Text: fmt.Sprintf("*Failed jobs (%d/%d):*\n%s",
+				len(report.FailedJobs),
+				report.TotalJobs,
 				strings.Join(failedJobNames, "\n")),
 		},
 	}
 
-	// Link to workflow run
+	blocks := []SlackBlock{headerBlock}
+	if len(report.FailedTests) > 0 {
+		tests := report.FailedTests
+		if len(tests) > maxFailedTests {
+			tests = tests[:maxFailedTests]
+		}
+
+		var failedTests []string
+		for _, test := range tests {
+			failedTests = append(failedTests, fmt.Sprintf("• `%s`", test))
+		}
+		blocks = append(blocks, SlackBlock{
+			Type: "section",
+			Text: &SlackText{
+				Type: "mrkdwn",
+				Text: fmt.Sprintf("*Final failed tests (%d):*\n%s",
+					len(report.FailedTests),
+					strings.Join(failedTests, "\n")),
+			},
+		})
+	}
+	blocks = append(blocks, jobsBlock)
+
+	// Link to run
 	linkBlock := SlackBlock{
 		Type: "section",
 		Text: &SlackText{
 			Type: "mrkdwn",
-			Text: fmt.Sprintf("<%s|View Full Workflow Run>", report.Workflow.URL),
+			Text: fmt.Sprintf("<%s|View Run>", report.Run.URL),
 		},
 	}
+	blocks = append(blocks, linkBlock)
 
 	return &SlackMessage{
-		Text: fmt.Sprintf("CI Failed on Main: %s", report.Workflow.Name),
-		Blocks: []SlackBlock{
-			headerBlock,
-			infoBlock,
-			summaryBlock,
-			jobsBlock,
-			linkBlock,
-		},
+		Text:   "CI Failed on Main",
+		Blocks: blocks,
 	}
 }
 
@@ -116,15 +102,19 @@ func BuildFailureMessage(report *FailureReport) *SlackMessage {
 func FormatMessageForDebug(report *FailureReport) string {
 	var sb strings.Builder
 	fmt.Fprint(&sb, "🚨 CI Failed on Main Branch 🚨\n\n")
-	fmt.Fprintf(&sb, "Workflow: %s\n", report.Workflow.Name)
-	fmt.Fprintf(&sb, "Branch: %s\n", report.Workflow.HeadBranch)
-	fmt.Fprintf(&sb, "Commit: %s (%s)\n", report.Commit.ShortSHA, report.Commit.Author)
-	fmt.Fprintf(&sb, "Failed Jobs: %d of %d total jobs\n\n", len(report.FailedJobs), report.TotalJobs)
-	fmt.Fprintln(&sb, "Failed Jobs:")
+	if len(report.FailedTests) > 0 {
+		fmt.Fprintf(&sb, "Final failed tests (%d):\n", len(report.FailedTests))
+		for _, test := range report.FailedTests[:min(len(report.FailedTests), maxFailedTests)] {
+			fmt.Fprintf(&sb, "  • %s\n", test)
+		}
+		fmt.Fprintln(&sb)
+	}
+
+	fmt.Fprintf(&sb, "Failed jobs (%d/%d):\n", len(report.FailedJobs), report.TotalJobs)
 	for _, job := range report.FailedJobs {
 		fmt.Fprintf(&sb, "  • %s\n    %s\n", job.Name, job.URL)
 	}
-	fmt.Fprintf(&sb, "\nView Full Workflow Run: %s\n", report.Workflow.URL)
+	fmt.Fprintf(&sb, "\nView Run: %s\n", report.Run.URL)
 	return sb.String()
 }
 

--- a/tools/ci-notify/slack.go
+++ b/tools/ci-notify/slack.go
@@ -74,7 +74,7 @@ func BuildFailureMessage(report *FailureReport) *SlackMessage {
 			Type: "section",
 			Text: &SlackText{
 				Type: "mrkdwn",
-				Text: fmt.Sprintf("*Final failures (%d):*\n%s",
+				Text: fmt.Sprintf("*Failures (%d):*\n%s",
 					len(report.Failures),
 					strings.Join(failureLines, "\n")),
 			},
@@ -103,7 +103,7 @@ func FormatMessageForDebug(report *FailureReport) string {
 	var sb strings.Builder
 	fmt.Fprint(&sb, "🚨 CI Failed on Main Branch 🚨\n\n")
 	if len(report.Failures) > 0 {
-		fmt.Fprintf(&sb, "Final failures (%d):\n", len(report.Failures))
+		fmt.Fprintf(&sb, "Failures (%d):\n", len(report.Failures))
 		for _, failure := range report.Failures[:min(len(report.Failures), maxFailures)] {
 			fmt.Fprintf(&sb, "  • %s\n", failure)
 		}

--- a/tools/ci-notify/slack.go
+++ b/tools/ci-notify/slack.go
@@ -66,10 +66,10 @@ func BuildFailureMessage(report *FailureReport) *SlackMessage {
 			failures = failures[:maxFailures]
 		}
 
-			var failureLines []string
-			for _, failure := range failures {
-				failureLines = append(failureLines, fmt.Sprintf("`%s`", failure))
-			}
+		var failureLines []string
+		for _, failure := range failures {
+			failureLines = append(failureLines, failure)
+		}
 		blocks = append(blocks, SlackBlock{
 			Type: "section",
 			Text: &SlackText{

--- a/tools/ci-notify/slack.go
+++ b/tools/ci-notify/slack.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-const maxFailedTests = 5
+const maxFailures = 5
 
 // SlackMessage represents a Slack Block Kit message
 type SlackMessage struct {
@@ -60,23 +60,23 @@ func BuildFailureMessage(report *FailureReport) *SlackMessage {
 	}
 
 	blocks := []SlackBlock{headerBlock}
-	if len(report.FailedTests) > 0 {
-		tests := report.FailedTests
-		if len(tests) > maxFailedTests {
-			tests = tests[:maxFailedTests]
+	if len(report.Failures) > 0 {
+		failures := report.Failures
+		if len(failures) > maxFailures {
+			failures = failures[:maxFailures]
 		}
 
-		var failedTests []string
-		for _, test := range tests {
-			failedTests = append(failedTests, fmt.Sprintf("• `%s`", test))
+		var failureLines []string
+		for _, failure := range failures {
+			failureLines = append(failureLines, fmt.Sprintf("• `%s`", failure))
 		}
 		blocks = append(blocks, SlackBlock{
 			Type: "section",
 			Text: &SlackText{
 				Type: "mrkdwn",
-				Text: fmt.Sprintf("*Final failed tests (%d):*\n%s",
-					len(report.FailedTests),
-					strings.Join(failedTests, "\n")),
+				Text: fmt.Sprintf("*Final failures (%d):*\n%s",
+					len(report.Failures),
+					strings.Join(failureLines, "\n")),
 			},
 		})
 	}
@@ -102,10 +102,10 @@ func BuildFailureMessage(report *FailureReport) *SlackMessage {
 func FormatMessageForDebug(report *FailureReport) string {
 	var sb strings.Builder
 	fmt.Fprint(&sb, "🚨 CI Failed on Main Branch 🚨\n\n")
-	if len(report.FailedTests) > 0 {
-		fmt.Fprintf(&sb, "Final failed tests (%d):\n", len(report.FailedTests))
-		for _, test := range report.FailedTests[:min(len(report.FailedTests), maxFailedTests)] {
-			fmt.Fprintf(&sb, "  • %s\n", test)
+	if len(report.Failures) > 0 {
+		fmt.Fprintf(&sb, "Final failures (%d):\n", len(report.Failures))
+		for _, failure := range report.Failures[:min(len(report.Failures), maxFailures)] {
+			fmt.Fprintf(&sb, "  • %s\n", failure)
 		}
 		fmt.Fprintln(&sb)
 	}

--- a/tools/ci-notify/slack.go
+++ b/tools/ci-notify/slack.go
@@ -52,10 +52,10 @@ func BuildFailureMessage(report *FailureReport) *SlackMessage {
 		Type: "section",
 		Text: &SlackText{
 			Type: "mrkdwn",
-			Text: fmt.Sprintf("*Failed jobs (%d/%d):*\n%s",
+			Text: fmt.Sprintf("*Failed jobs (%d/%d):* %s",
 				len(report.FailedJobs),
 				report.TotalJobs,
-				strings.Join(failedJobNames, "\n")),
+				strings.Join(failedJobNames, ", ")),
 		},
 	}
 
@@ -68,15 +68,15 @@ func BuildFailureMessage(report *FailureReport) *SlackMessage {
 
 		var failureLines []string
 		for _, failure := range failures {
-			failureLines = append(failureLines, failure)
+			failureLines = append(failureLines, fmt.Sprintf("`%s`", failure))
 		}
 		blocks = append(blocks, SlackBlock{
 			Type: "section",
 			Text: &SlackText{
 				Type: "mrkdwn",
-				Text: fmt.Sprintf("*Failures (%d):*\n%s",
+				Text: fmt.Sprintf("*Failures (%d):* %s",
 					len(report.Failures),
-					strings.Join(failureLines, "\n")),
+					strings.Join(failureLines, ", ")),
 			},
 		})
 	}
@@ -103,17 +103,19 @@ func FormatMessageForDebug(report *FailureReport) string {
 	var sb strings.Builder
 	fmt.Fprint(&sb, "🚨 CI Failed on Main Branch 🚨\n\n")
 	if len(report.Failures) > 0 {
-		fmt.Fprintf(&sb, "Failures (%d):\n", len(report.Failures))
+		var failures []string
 		for _, failure := range report.Failures[:min(len(report.Failures), maxFailures)] {
-			fmt.Fprintf(&sb, "  %s\n", failure)
+			failures = append(failures, fmt.Sprintf("`%s`", failure))
 		}
+		fmt.Fprintf(&sb, "Failures (%d): %s\n", len(report.Failures), strings.Join(failures, ", "))
 		fmt.Fprintln(&sb)
 	}
 
-	fmt.Fprintf(&sb, "Failed jobs (%d/%d):\n", len(report.FailedJobs), report.TotalJobs)
+	var failedJobNames []string
 	for _, job := range report.FailedJobs {
-		fmt.Fprintf(&sb, "  %s\n    %s\n", job.Name, job.URL)
+		failedJobNames = append(failedJobNames, fmt.Sprintf("%s (%s)", job.Name, job.URL))
 	}
+	fmt.Fprintf(&sb, "Failed jobs (%d/%d): %s\n", len(report.FailedJobs), report.TotalJobs, strings.Join(failedJobNames, ", "))
 	fmt.Fprintf(&sb, "\nView Run: %s\n", report.Run.URL)
 	return sb.String()
 }

--- a/tools/ci-notify/slack.go
+++ b/tools/ci-notify/slack.go
@@ -45,7 +45,7 @@ func BuildFailureMessage(report *FailureReport) *SlackMessage {
 	var failedJobNames []string
 	for _, job := range report.FailedJobs {
 		failedJobNames = append(failedJobNames,
-			fmt.Sprintf("• <%s|%s>", job.URL, job.Name))
+			fmt.Sprintf("<%s|%s>", job.URL, job.Name))
 	}
 
 	jobsBlock := SlackBlock{
@@ -66,10 +66,10 @@ func BuildFailureMessage(report *FailureReport) *SlackMessage {
 			failures = failures[:maxFailures]
 		}
 
-		var failureLines []string
-		for _, failure := range failures {
-			failureLines = append(failureLines, fmt.Sprintf("• `%s`", failure))
-		}
+			var failureLines []string
+			for _, failure := range failures {
+				failureLines = append(failureLines, fmt.Sprintf("`%s`", failure))
+			}
 		blocks = append(blocks, SlackBlock{
 			Type: "section",
 			Text: &SlackText{
@@ -105,14 +105,14 @@ func FormatMessageForDebug(report *FailureReport) string {
 	if len(report.Failures) > 0 {
 		fmt.Fprintf(&sb, "Failures (%d):\n", len(report.Failures))
 		for _, failure := range report.Failures[:min(len(report.Failures), maxFailures)] {
-			fmt.Fprintf(&sb, "  • %s\n", failure)
+			fmt.Fprintf(&sb, "  %s\n", failure)
 		}
 		fmt.Fprintln(&sb)
 	}
 
 	fmt.Fprintf(&sb, "Failed jobs (%d/%d):\n", len(report.FailedJobs), report.TotalJobs)
 	for _, job := range report.FailedJobs {
-		fmt.Fprintf(&sb, "  • %s\n    %s\n", job.Name, job.URL)
+		fmt.Fprintf(&sb, "  %s\n    %s\n", job.Name, job.URL)
 	}
 	fmt.Fprintf(&sb, "\nView Run: %s\n", report.Run.URL)
 	return sb.String()

--- a/tools/ci-notify/types.go
+++ b/tools/ci-notify/types.go
@@ -9,10 +9,10 @@ import (
 
 // FailureReport aggregates all failure information
 type FailureReport struct {
-	Run         github.Run
-	FailedJobs  []github.Job
-	FailedTests []string
-	TotalJobs   int
+	Run        github.Run
+	FailedJobs []github.Job
+	Failures   []string
+	TotalJobs  int
 }
 
 // DigestReport aggregates success metrics for a time period

--- a/tools/ci-notify/types.go
+++ b/tools/ci-notify/types.go
@@ -7,20 +7,12 @@ import (
 	"go.temporal.io/server/tools/common/github"
 )
 
-// CommitInfo represents commit metadata
-type CommitInfo struct {
-	SHA      string
-	ShortSHA string // First 7 chars
-	Author   string
-	Message  string
-}
-
 // FailureReport aggregates all failure information
 type FailureReport struct {
-	Workflow   github.Run
-	Commit     CommitInfo
-	FailedJobs []github.Job
-	TotalJobs  int
+	Run         github.Run
+	FailedJobs  []github.Job
+	FailedTests []string
+	TotalJobs   int
 }
 
 // DigestReport aggregates success metrics for a time period


### PR DESCRIPTION
## What changed?

`ci-notify` reports failure details.

<details><summary>Example</summary>
<p>

```
ci-notify dry run for latest origin/main
generated_at: 2026-07-10T23:18:44Z
commit: 2837ed9ac636bdc3741733cceb54c7c379177bc4
run_id: 29120528353
run_metadata: {"conclusion":"failure","createdAt":"2026-07-10T20:11:10Z","databaseId":29120528353,"displayTitle":"Update to API v1.63.3 (#11011)","headSha":"2837ed9ac636bdc3741733cceb54c7c379177bc4","status":"completed","url":"https://github.com/temporalio/temporal/actions/runs/29120528353"}

command:
go run ./cmd/tools/ci-notify alert --run-id 29120528353 --dry-run

output:
{"level":"info","ts":1783725525.7342331,"caller":"ci-notify/app.go:105","msg":"Starting `ci-notify alert`","run_id":"29120528353","dry_run":true}
{"level":"info","ts":1783725545.294624,"caller":"ci-notify/app.go:118","msg":"Built failure report","failed_jobs":2,"failures":2,"total_jobs":49}
{"level":"info","ts":1783725545.294701,"caller":"ci-notify/app.go:126","msg":"Dry-run mode: printing message to stdout"}
🚨 CI Failed on Main Branch 🚨

Failures (2): `TestDeploymentVersionSuite/TestDeleteVersion_ThenRecreateByPolling`, `TestPartitionScaling_Down`

Failed jobs (2/49): Functional test (sqlite, shard1) (https://github.com/temporalio/temporal/actions/runs/29120528353/job/86454851776), Functional test (postgres12_pgx, shard2) (https://github.com/temporalio/temporal/actions/runs/29120528353/job/86454851972)

View Run: https://github.com/temporalio/temporal/actions/runs/29120528353


--- Slack JSON Payload ---
{
  "text": "CI Failed on Main",
  "blocks": [
    {
      "type": "section",
      "text": {
        "type": "mrkdwn",
        "text": ":rotating_light: *CI Failed on Main Branch* :rotating_light:"
      }
    },
    {
      "type": "section",
      "text": {
        "type": "mrkdwn",
        "text": "*Failures (2):* `TestDeploymentVersionSuite/TestDeleteVersion_ThenRecreateByPolling`, `TestPartitionScaling_Down`"
      }
    },
    {
      "type": "section",
      "text": {
        "type": "mrkdwn",
        "text": "*Failed jobs (2/49):* \u003chttps://github.com/temporalio/temporal/actions/runs/29120528353/job/86454851776|Functional test (sqlite, shard1)\u003e, \u003chttps://github.com/temporalio/temporal/actions/runs/29120528353/job/86454851972|Functional test (postgres12_pgx, shard2)\u003e"
      }
    },
    {
      "type": "section",
      "text": {
        "type": "mrkdwn",
        "text": "\u003chttps://github.com/temporalio/temporal/actions/runs/29120528353|View Run\u003e"
      }
    }
  ]
}


```


</p>
</details> 

## Why?

Make it actionable to see what failed.