### PR TITLE
fix: de-duplicate pause even if activity is unpaused

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -893,12 +893,15 @@ func (a *Activity) handlePauseRequested(ctx chasm.MutableContext, req *activityp
 	if a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED {
 		return nil, serviceerror.NewFailedPrecondition("cannot pause an activity with a pending cancellation")
 	}
+	// Deduplicate a replay of a request that already paused this activity, even if the
+	// activity has since been unpaused. Without this check, a delayed replay of an old
+	// Pause request would silently re-pause an activity that a later Unpause resumed.
+	newReqID := req.GetFrontendRequest().GetRequestId()
+	if newReqID != "" && a.LastPauseState.GetRequestId() == newReqID {
+		return &activitypb.PauseActivityExecutionResponse{}, nil
+	}
+
 	if a.isPaused() {
-		newReqID := req.GetFrontendRequest().GetRequestId()
-		existingReqID := a.LastPauseState.GetRequestId()
-		if newReqID != "" && existingReqID == newReqID {
-			return &activitypb.PauseActivityExecutionResponse{}, nil
-		}
 		return nil, serviceerror.NewFailedPrecondition("activity is already paused")
 	}
 

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -9736,6 +9736,75 @@ func (s *standaloneActivityTestSuite) TestPauseActivityExecution() {
 		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_PAUSED, resp.GetInfo().GetRunState())
 	})
 
+	t.Run("PauseReplayAfterUnpause_IsDeduplicated", func(t *testing.T) {
+		ctx := testcore.NewContext()
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		runID := startResp.RunId
+
+		const replayedRequestID = "at-008-replayed-request-id"
+
+		// Original pause.
+		_, err := env.FrontendClient().PauseActivityExecution(ctx, &workflowservice.PauseActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+			Identity:   "test-identity",
+			Reason:     "test-pause",
+			RequestId:  replayedRequestID,
+		})
+		require.NoError(t, err)
+
+		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+		})
+		require.NoError(t, err)
+		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_PAUSED, descResp.GetInfo().GetRunState())
+
+		// Unpause. The activity resumes and is no longer paused.
+		_, err = env.FrontendClient().UnpauseActivityExecution(ctx, &workflowservice.UnpauseActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+			Identity:   "test-identity",
+		})
+		require.NoError(t, err)
+
+		descResp, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+		})
+		require.NoError(t, err)
+		require.NotEqual(t, enumspb.PENDING_ACTIVITY_STATE_PAUSED, descResp.GetInfo().GetRunState())
+
+		// Delayed replay of the ORIGINAL pause request (same request ID), arriving after the
+		// Unpause has already been applied. It must be deduplicated as a no-op, not re-pause
+		// the activity.
+		_, err = env.FrontendClient().PauseActivityExecution(ctx, &workflowservice.PauseActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+			Identity:   "test-identity",
+			Reason:     "test-pause",
+			RequestId:  replayedRequestID,
+		})
+		require.NoError(t, err)
+
+		descResp, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+		})
+		require.NoError(t, err)
+		require.NotEqual(t, enumspb.PENDING_ACTIVITY_STATE_PAUSED, descResp.GetInfo().GetRunState(),
+			"replayed pause request with an already-consumed request ID must not re-pause the activity")
+	})
+
 	t.Run("PauseNotFound", func(t *testing.T) {
 		ctx := testcore.NewContext()
 


### PR DESCRIPTION
## What changed?
Deduplicate PauseActivityExecution by request ID unconditionally, instead of only when paused. Previously, if an unpause was received between the duplicated request the request would transition back to paused and not be correctly de-duped.

## Why?
Correcting de-duplication semantics.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [X] added new functional test(s)

## Potential risks
No
