### PR TITLE
Add run fallback to CHASM Nexus operation completion

### DIFF
--- a/chasm/component.go
+++ b/chasm/component.go
@@ -100,12 +100,20 @@ func (s LifecycleState) String() string {
 	}
 }
 
+// OperationIntent declares how a caller intends to access a component.
+// Set it with NewContextWithOperationIntent.
 type OperationIntent int
 
 const (
+	// OperationIntentProgress means the caller intends to modify the component.
+	// Rejected for closed executions.
 	OperationIntentProgress OperationIntent = 1 << iota
+
+	// OperationIntentObserve means the caller only intends to read the component.
+	// Allowed for closed executions.
 	OperationIntentObserve
 
+	// OperationIntentUnspecified is the zero value and is treated like observe.
 	OperationIntentUnspecified = OperationIntent(0)
 )
 
@@ -118,11 +126,8 @@ type operationIntentCtxKeyType struct{}
 
 var operationIntentCtxKey = operationIntentCtxKeyType{}
 
-// NewContextWithOperationIntent returns a child context carrying the given OperationIntent, which
-// validateAccess reads back from the context (see operationIntentFromContext). Callers request
-// OperationIntentProgress so that a write targeting a component whose ancestor is closed (or whose
-// root execution has completed) is rejected with errAccessCheckFailed — a NotFound — instead of
-// silently mutating a closed tree. See the "closed" cases in tree_test.go's validateAccess tests.
+// NewContextWithOperationIntent returns a child context carrying the given OperationIntent.
+// See OperationIntent for the access semantics.
 func NewContextWithOperationIntent(
 	ctx context.Context,
 	intent OperationIntent,

--- a/chasm/component.go
+++ b/chasm/component.go
@@ -118,9 +118,11 @@ type operationIntentCtxKeyType struct{}
 
 var operationIntentCtxKey = operationIntentCtxKeyType{}
 
-// NewContextWithOperationIntent returns a child context carrying the given OperationIntent.
-// Callers use this to request OperationIntentProgress so that access to a component under a
-// closed ancestor is blocked and surfaces as a NotFound.
+// NewContextWithOperationIntent returns a child context carrying the given OperationIntent, which
+// validateAccess reads back from the context (see operationIntentFromContext). Callers request
+// OperationIntentProgress so that a write targeting a component whose ancestor is closed (or whose
+// root execution has completed) is rejected with errAccessCheckFailed — a NotFound — instead of
+// silently mutating a closed tree. See the "closed" cases in tree_test.go's validateAccess tests.
 func NewContextWithOperationIntent(
 	ctx context.Context,
 	intent OperationIntent,

--- a/chasm/component.go
+++ b/chasm/component.go
@@ -118,13 +118,6 @@ type operationIntentCtxKeyType struct{}
 
 var operationIntentCtxKey = operationIntentCtxKeyType{}
 
-func newContextWithOperationIntent(
-	ctx context.Context,
-	intent OperationIntent,
-) context.Context {
-	return context.WithValue(ctx, operationIntentCtxKey, intent)
-}
-
 // NewContextWithOperationIntent returns a child context carrying the given OperationIntent.
 // Callers use this to request OperationIntentProgress so that access to a component under a
 // closed ancestor is blocked and surfaces as a NotFound.
@@ -132,7 +125,7 @@ func NewContextWithOperationIntent(
 	ctx context.Context,
 	intent OperationIntent,
 ) context.Context {
-	return newContextWithOperationIntent(ctx, intent)
+	return context.WithValue(ctx, operationIntentCtxKey, intent)
 }
 
 func operationIntentFromContext(

--- a/chasm/component.go
+++ b/chasm/component.go
@@ -125,6 +125,16 @@ func newContextWithOperationIntent(
 	return context.WithValue(ctx, operationIntentCtxKey, intent)
 }
 
+// NewContextWithOperationIntent returns a child context carrying the given OperationIntent.
+// Callers use this to request OperationIntentProgress so that access to a component under a
+// closed ancestor is blocked and surfaces as a NotFound.
+func NewContextWithOperationIntent(
+	ctx context.Context,
+	intent OperationIntent,
+) context.Context {
+	return newContextWithOperationIntent(ctx, intent)
+}
+
 func operationIntentFromContext(
 	ctx context.Context,
 ) OperationIntent {

--- a/chasm/component_test.go
+++ b/chasm/component_test.go
@@ -10,11 +10,18 @@ import (
 func TestNewContextWithOperationIntent(t *testing.T) {
 	t.Parallel()
 
-	// A bare context carries no intent.
-	require.Equal(t, OperationIntentUnspecified, operationIntentFromContext(context.Background()))
+	t.Run("bare context carries no intent", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, OperationIntentUnspecified, operationIntentFromContext(context.Background()))
+	})
 
-	// The exported helper sets the intent that validateAccess reads back from the context,
-	// which is how the completion RPC handler requests OperationIntentProgress.
-	ctx := NewContextWithOperationIntent(context.Background(), OperationIntentProgress)
-	require.Equal(t, OperationIntentProgress, operationIntentFromContext(ctx))
+	t.Run("round-trips the intent read back by validateAccess", func(t *testing.T) {
+		t.Parallel()
+		// This is how the completion RPC handler requests OperationIntentProgress; validateAccess
+		// reads it back via operationIntentFromContext. The downstream effect — a progress write to a
+		// closed tree failing with errAccessCheckFailed (NotFound) — is covered by the "closed" cases
+		// in tree_test.go's validateAccess tests.
+		ctx := NewContextWithOperationIntent(context.Background(), OperationIntentProgress)
+		require.Equal(t, OperationIntentProgress, operationIntentFromContext(ctx))
+	})
 }

--- a/chasm/component_test.go
+++ b/chasm/component_test.go
@@ -15,12 +15,8 @@ func TestNewContextWithOperationIntent(t *testing.T) {
 		require.Equal(t, OperationIntentUnspecified, operationIntentFromContext(context.Background()))
 	})
 
-	t.Run("round-trips the intent read back by validateAccess", func(t *testing.T) {
+	t.Run("round-trips the set intent", func(t *testing.T) {
 		t.Parallel()
-		// This is how the completion RPC handler requests OperationIntentProgress; validateAccess
-		// reads it back via operationIntentFromContext. The downstream effect — a progress write to a
-		// closed tree failing with errAccessCheckFailed (NotFound) — is covered by the "closed" cases
-		// in tree_test.go's validateAccess tests.
 		ctx := NewContextWithOperationIntent(context.Background(), OperationIntentProgress)
 		require.Equal(t, OperationIntentProgress, operationIntentFromContext(ctx))
 	})

--- a/chasm/component_test.go
+++ b/chasm/component_test.go
@@ -1,0 +1,20 @@
+package chasm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewContextWithOperationIntent(t *testing.T) {
+	t.Parallel()
+
+	// A bare context carries no intent.
+	require.Equal(t, OperationIntentUnspecified, operationIntentFromContext(context.Background()))
+
+	// The exported helper sets the intent that validateAccess reads back from the context,
+	// which is how the completion RPC handler requests OperationIntentProgress.
+	ctx := NewContextWithOperationIntent(context.Background(), OperationIntentProgress)
+	require.Equal(t, OperationIntentProgress, operationIntentFromContext(ctx))
+}

--- a/chasm/ref.go
+++ b/chasm/ref.go
@@ -13,6 +13,9 @@ var ErrMalformedComponentRef = serviceerror.NewInvalidArgument("malformed compon
 // ErrInvalidComponentRef is returned when component ref bytes deserialize to an invalid component ref.
 var ErrInvalidComponentRef = serviceerror.NewInvalidArgument("invalid component ref")
 
+// ErrInvalidRefConsistencyLevel is returned when a component ref cannot be used at the requested RefConsistencyLevel.
+var ErrInvalidRefConsistencyLevel = serviceerror.NewInvalidArgument("invalid consistency level for component ref")
+
 // ExecutionKey uniquely identifies a CHASM execution in the system.
 type ExecutionKey struct {
 	NamespaceID string
@@ -100,6 +103,11 @@ func (r *ComponentRef) forConsistencyLevel(level RefConsistencyLevel) (Component
 		ref.executionLastUpdateVT = ref.componentInitialVT
 		return ref, nil
 	case RefConsistencyLevelCurrentRun:
+		// Only workflow executions have a run chain to resolve a "current run" against, so this level
+		// is invalid for other archetypes (see ErrInvalidRefConsistencyLevel).
+		if r.archetypeID != WorkflowArchetypeID {
+			return ComponentRef{}, ErrInvalidRefConsistencyLevel
+		}
 		// Weakest: resolve by component path on the current run. Drop the run ID and every versioned
 		// transition; identity must be re-established by caller logic (e.g. request ID).
 		ref.executionLastUpdateVT = nil

--- a/chasm/ref_test.go
+++ b/chasm/ref_test.go
@@ -140,6 +140,10 @@ func (s *componentRefSuite) TestForConsistencyLevel() {
 	testCases := []struct {
 		name  string
 		level RefConsistencyLevel
+		// archetypeID overrides the ref's archetype; the zero value keeps newRef's WorkflowArchetypeID.
+		archetypeID ArchetypeID
+		// wantErr, when set, is the error forConsistencyLevel must return (verify is then skipped).
+		wantErr error
 		// verify asserts the level-specific expectations on the original (orig) and adjusted refs.
 		verify func(orig, adjusted ComponentRef)
 	}{
@@ -174,12 +178,27 @@ func (s *componentRefSuite) TestForConsistencyLevel() {
 				s.Empty(adjusted.RunID)
 			},
 		},
+		{
+			// CurrentRun only makes sense for workflow executions (they have a run chain), so it is
+			// rejected for other archetypes.
+			name:        "CurrentRun is rejected for a non-workflow archetype",
+			level:       RefConsistencyLevelCurrentRun,
+			archetypeID: WorkflowArchetypeID + 1,
+			wantErr:     ErrInvalidRefConsistencyLevel,
+		},
 	}
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
 			ref := newRef()
+			if tc.archetypeID != UnspecifiedArchetypeID {
+				ref.archetypeID = tc.archetypeID
+			}
 			adjusted, err := ref.forConsistencyLevel(tc.level)
+			if tc.wantErr != nil {
+				s.ErrorIs(err, tc.wantErr)
+				return
+			}
 			s.NoError(err)
 			tc.verify(ref, adjusted)
 

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -1998,7 +1998,7 @@ func (n *Node) closeTransactionUpdateComponentTasks(
 	nextVersionedTransition *persistencespb.VersionedTransition,
 ) error {
 	taskOffset := int64(1)
-	taskValidationContext := NewContext(newContextWithOperationIntent(context.Background(), OperationIntentProgress), n)
+	taskValidationContext := NewContext(NewContextWithOperationIntent(context.Background(), OperationIntentProgress), n)
 
 	archetypeID := n.ArchetypeID()
 
@@ -3506,7 +3506,7 @@ func (n *Node) ExecutePureTask(
 		return false, fmt.Errorf("ExecutePureTask called on a SideEffect task '%s'", registrableTask.fqType())
 	}
 
-	progressIntentCtx := newContextWithOperationIntent(baseCtx, OperationIntentProgress)
+	progressIntentCtx := NewContextWithOperationIntent(baseCtx, OperationIntentProgress)
 	validationContext := NewContext(progressIntentCtx, n)
 
 	// Ensure this node's component value is hydrated before execution.
@@ -3640,7 +3640,7 @@ func (n *Node) ValidateSideEffectTask(
 	// All structural checks passed — the task exists in the tree.
 
 	// Component must be hydrated before the task's validator is called.
-	validateCtx := NewContext(newContextWithOperationIntent(ctx, OperationIntentProgress), n)
+	validateCtx := NewContext(NewContextWithOperationIntent(ctx, OperationIntentProgress), n)
 	if err := node.prepareComponentValue(validateCtx); err != nil {
 		return false, false, err
 	}
@@ -3795,7 +3795,7 @@ func (n *Node) invokeSideEffectTaskFn(
 		validationFn: makeValidationFn(registrableTask, validate, chasmTask.Attempt, taskAttributes, taskValue),
 	}
 
-	ctx = newContextWithOperationIntent(ctx, OperationIntentProgress)
+	ctx = NewContextWithOperationIntent(ctx, OperationIntentProgress)
 
 	defer log.CapturePanic(n.logger, &retErr)
 

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -2085,7 +2085,7 @@ func (s *nodeSuite) TestValidateAccess() {
 			s.NoError(err)
 
 			ctx := NewContext(
-				newContextWithOperationIntent(context.Background(), tc.intent),
+				NewContextWithOperationIntent(context.Background(), tc.intent),
 				root,
 			)
 
@@ -2142,7 +2142,7 @@ func (s *nodeSuite) TestGetComponent_DetachedNodeBypassesParentValidation() {
 
 	// Close the root node (set lifecycle to COMPLETED).
 	ctx := NewMutableContext(
-		newContextWithOperationIntent(context.Background(), OperationIntentProgress),
+		NewContextWithOperationIntent(context.Background(), OperationIntentProgress),
 		root,
 	)
 	err = root.prepareComponentValue(ctx)
@@ -2171,7 +2171,7 @@ func (s *nodeSuite) TestGetComponent_ClosedTargetSucceeds() {
 	s.True(ok)
 
 	ctx := NewMutableContext(
-		newContextWithOperationIntent(context.Background(), OperationIntentProgress),
+		NewContextWithOperationIntent(context.Background(), OperationIntentProgress),
 		root,
 	)
 
@@ -3038,7 +3038,7 @@ func (s *nodeSuite) TestCloseTransaction_PausedStateInvalidatesTasks() {
 		s.NoError(err)
 
 		ctx := NewContext(
-			newContextWithOperationIntent(context.Background(), OperationIntentProgress),
+			NewContextWithOperationIntent(context.Background(), OperationIntentProgress),
 			root,
 		)
 

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -2174,24 +2174,13 @@ func (h *Handler) CompleteNexusOperationChasm(
 	ctx context.Context,
 	request *historyservice.CompleteNexusOperationChasmRequest,
 ) (*historyservice.CompleteNexusOperationChasmResponse, error) {
-	componentRef := request.GetCompletion().GetComponentRef()
-	if len(componentRef) == 0 {
+	componentRefBytes := request.GetCompletion().GetComponentRef()
+	if len(componentRefBytes) == 0 {
 		return nil, serviceerror.NewInvalidArgument("invalid component ref")
 	}
-
-	// Ignore transition-history fields when applying completion,
-	// use Request ID to accept or reject the completion instead.
-	// TODO(stephan): This should be a CHASM transition option.
-	ref := &persistencespb.ChasmComponentRef{}
-	if err := ref.Unmarshal(componentRef); err != nil {
-		return nil, serviceerror.NewInvalidArgument("invalid component ref")
-	}
-	ref.ExecutionVersionedTransition = nil
-	ref.ComponentInitialVersionedTransition = nil
-	var err error
-	componentRef, err = ref.Marshal()
+	ref, err := chasm.DeserializeComponentRef(componentRefBytes)
 	if err != nil {
-		return nil, serviceerror.NewInvalidArgument("invalid component ref")
+		return nil, h.convertError(err)
 	}
 
 	completion := &persistencespb.ChasmNexusCompletion{
@@ -2214,22 +2203,53 @@ func (h *Handler) CompleteNexusOperationChasm(
 		return nil, serviceerror.NewUnimplemented("unhandled Nexus operation outcome")
 	}
 
-	// Attempt to access the component and call its invocation method. We execute
-	// this similarly as we would a pure task (holding an exclusive lock), as the
-	// assumption is that the accessed component will be recording (or generating a
-	// task) based on this result.
-	_, _, err = chasm.UpdateComponent(
-		ctx,
-		componentRef,
-		func(c chasm.NexusCompletionHandler, ctx chasm.MutableContext, completion *persistencespb.ChasmNexusCompletion) (chasm.NoValue, error) {
-			return nil, c.HandleNexusCompletion(ctx, completion)
-		},
-		completion)
+	// Access the component with progress intent so that the framework blocks access to a
+	// completion targeting an operation under a closed workflow and surfaces it as a
+	// NotFound. That NotFound is the signal to fall back to the current run below.
+	ctx = chasm.NewContextWithOperationIntent(ctx, chasm.OperationIntentProgress)
+
+	// First attempt: resolve the run carried by the ref. ComponentCreation tolerates a stale execution transition
+	// (a completion may carry a ref from before a reset/rebuild rewrote transition history) while still guaranteeing
+	// the loaded state knows about the operation; identity is enforced by request ID in the handler.
+	handlerInvoked, err := h.applyChasmNexusCompletion(ctx, ref, completion, chasm.RefConsistencyLevelComponentCreation)
+	// A workflow reset creates a new run that carries the same scheduled operation (and request ID). When the ref's
+	// run can no longer be resolved, retry once on the current run at CurrentRun, which drops the run ID and every
+	// versioned transition. Only retry when the completion handler was not invoked; a completion that reached the
+	// operation and was rejected there (e.g. a request-ID mismatch or an already-terminal operation) is definitive.
+	_, isNotFound := errors.AsType[*serviceerror.NotFound](err)
+	if !handlerInvoked &&
+		isNotFound &&
+		completion.GetRequestId() != "" &&
+		ref.RunID != "" {
+		_, err = h.applyChasmNexusCompletion(ctx, ref, completion, chasm.RefConsistencyLevelCurrentRun)
+	}
 	if err != nil {
 		return nil, h.convertError(err)
 	}
 
 	return &historyservice.CompleteNexusOperationChasmResponse{}, nil
+}
+
+// applyChasmNexusCompletion applies an async Nexus operation completion to the component addressed by ref
+// at the given consistency level. It reports whether the operation's HandleNexusCompletion ran: handlerInvoked
+// is true only when the ref resolved and the framework access checks passed, and false when the failure came
+// from run lookup or the closed-ancestor access check.
+func (h *Handler) applyChasmNexusCompletion(
+	ctx context.Context,
+	ref chasm.ComponentRef,
+	completion *persistencespb.ChasmNexusCompletion,
+	level chasm.RefConsistencyLevel,
+) (handlerInvoked bool, err error) {
+	_, _, err = chasm.UpdateComponent(
+		ctx,
+		ref,
+		func(c chasm.NexusCompletionHandler, ctx chasm.MutableContext, completion *persistencespb.ChasmNexusCompletion) (chasm.NoValue, error) {
+			handlerInvoked = true
+			return nil, c.HandleNexusCompletion(ctx, completion)
+		},
+		completion,
+		chasm.WithRefConsistencyLevel(level))
+	return handlerInvoked, err
 }
 
 // convertError is a helper method to convert ShardOwnershipLostError from persistence layer returned by various

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -2203,9 +2203,8 @@ func (h *Handler) CompleteNexusOperationChasm(
 		return nil, serviceerror.NewUnimplemented("unhandled Nexus operation outcome")
 	}
 
-	// The current-run fallback below only applies to workflow-backed operations: only workflows are reset
-	// onto a new run (at least until CHASM executions get conflict resolution), so a standalone archetype
-	// has no other run to fall back to.
+	// Resolve the archetype up front; the current-run fallback below is gated on it
+	// (see shouldFallBackToCurrentRun).
 	archetypeID, err := ref.ArchetypeID(h.chasmRegistry)
 	if err != nil {
 		return nil, h.convertError(err)
@@ -2220,16 +2219,7 @@ func (h *Handler) CompleteNexusOperationChasm(
 	// (a completion may carry a ref from before a reset/rebuild rewrote transition history) while still guaranteeing
 	// the loaded state knows about the operation; identity is enforced by request ID in the handler.
 	handlerInvoked, err := h.applyChasmNexusCompletion(ctx, ref, completion, chasm.RefConsistencyLevelComponentCreation)
-	// A workflow reset creates a new run that carries the same scheduled operation (and request ID). When the ref's
-	// run can no longer be resolved, retry once on the current run at CurrentRun, which drops the run ID and every
-	// versioned transition. Only retry when the completion handler was not invoked; a completion that reached the
-	// operation and was rejected there (e.g. a request-ID mismatch or an already-terminal operation) is definitive.
-	_, isNotFound := errors.AsType[*serviceerror.NotFound](err)
-	if !handlerInvoked &&
-		isNotFound &&
-		completion.GetRequestId() != "" &&
-		ref.RunID != "" &&
-		archetypeID == chasm.WorkflowArchetypeID {
+	if shouldFallBackToCurrentRun(handlerInvoked, err, completion, ref, archetypeID) {
 		_, err = h.applyChasmNexusCompletion(ctx, ref, completion, chasm.RefConsistencyLevelCurrentRun)
 	}
 	if err != nil {
@@ -2237,6 +2227,36 @@ func (h *Handler) CompleteNexusOperationChasm(
 	}
 
 	return &historyservice.CompleteNexusOperationChasmResponse{}, nil
+}
+
+// shouldFallBackToCurrentRun reports whether a failed first completion attempt should be retried
+// against the current run at RefConsistencyLevelCurrentRun. A workflow reset creates a new run that
+// carries the same scheduled operation (and request ID), so a completion whose ref names the reset
+// (old) run must be re-resolved to the current run. All of the following must hold:
+//
+//   - handlerInvoked is false: the failure came from run lookup or the closed-ancestor access check,
+//     not from the operation itself. A completion that reached the operation and was rejected there
+//     (e.g. a request-ID mismatch or an already-terminal operation) is definitive — never retry it.
+//   - err is a NotFound: only an unresolvable run/component is worth re-resolving.
+//   - the completion carries a request ID: CurrentRun drops the run ID and every versioned transition,
+//     so the handler re-establishes identity by request ID; without one we can't safely match a run.
+//   - the ref names a run: if it doesn't, the first attempt already targeted the current run, so a
+//     CurrentRun retry would be identical.
+//   - the ref addresses a workflow: only workflows are reset onto a new run (until CHASM executions
+//     get conflict resolution), so a standalone archetype has no other run to fall back to.
+func shouldFallBackToCurrentRun(
+	handlerInvoked bool,
+	err error,
+	completion *persistencespb.ChasmNexusCompletion,
+	ref chasm.ComponentRef,
+	archetypeID chasm.ArchetypeID,
+) bool {
+	_, isNotFound := errors.AsType[*serviceerror.NotFound](err)
+	return !handlerInvoked &&
+		isNotFound &&
+		completion.GetRequestId() != "" &&
+		ref.RunID != "" &&
+		archetypeID == chasm.WorkflowArchetypeID
 }
 
 // applyChasmNexusCompletion applies an async Nexus operation completion to the component addressed by ref

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -2178,10 +2178,6 @@ func (h *Handler) CompleteNexusOperationChasm(
 	if len(componentRefBytes) == 0 {
 		return nil, serviceerror.NewInvalidArgument("invalid component ref")
 	}
-	ref, err := chasm.DeserializeComponentRef(componentRefBytes)
-	if err != nil {
-		return nil, h.convertError(err)
-	}
 
 	completion := &persistencespb.ChasmNexusCompletion{
 		StartTime:      request.StartTime,
@@ -2203,24 +2199,20 @@ func (h *Handler) CompleteNexusOperationChasm(
 		return nil, serviceerror.NewUnimplemented("unhandled Nexus operation outcome")
 	}
 
-	// Resolve the archetype up front; the current-run fallback below is gated on it
-	// (see shouldFallBackToCurrentRun).
-	archetypeID, err := ref.ArchetypeID(h.chasmRegistry)
-	if err != nil {
-		return nil, h.convertError(err)
-	}
-
 	// Access the component with progress intent so that the framework blocks access to a
 	// completion targeting an operation under a closed workflow and surfaces it as a
 	// NotFound. That NotFound is the signal to fall back to the current run below.
 	ctx = chasm.NewContextWithOperationIntent(ctx, chasm.OperationIntentProgress)
 
-	// First attempt: resolve the run carried by the ref. ComponentCreation tolerates a stale execution transition
-	// (a completion may carry a ref from before a reset/rebuild rewrote transition history) while still guaranteeing
-	// the loaded state knows about the operation; identity is enforced by request ID in the handler.
-	handlerInvoked, err := h.applyChasmNexusCompletion(ctx, ref, completion, chasm.RefConsistencyLevelComponentCreation)
-	if shouldFallBackToCurrentRun(handlerInvoked, err, completion, ref, archetypeID) {
-		_, err = h.applyChasmNexusCompletion(ctx, ref, completion, chasm.RefConsistencyLevelCurrentRun)
+	// First try the component as of its creation transition. This tolerates refs
+	// from before a reset while still ensuring the loaded state has the operation.
+	handlerInvoked, err := h.applyChasmNexusCompletion(ctx, componentRefBytes, completion, chasm.RefConsistencyLevelComponentCreation)
+	if shouldFallBackToCurrentRun(handlerInvoked, err, completion) {
+		// If reset moved the operation to the current run, retry without the ref's
+		// run ID or transition tokens. Non-workflow refs cannot use this lookup.
+		if _, fbErr := h.applyChasmNexusCompletion(ctx, componentRefBytes, completion, chasm.RefConsistencyLevelCurrentRun); !errors.Is(fbErr, chasm.ErrInvalidRefConsistencyLevel) {
+			err = fbErr
+		}
 	}
 	if err != nil {
 		return nil, h.convertError(err)
@@ -2229,49 +2221,34 @@ func (h *Handler) CompleteNexusOperationChasm(
 	return &historyservice.CompleteNexusOperationChasmResponse{}, nil
 }
 
-// shouldFallBackToCurrentRun reports whether a failed first completion attempt should be retried
-// against the current run at RefConsistencyLevelCurrentRun. A workflow reset creates a new run that
-// carries the same scheduled operation (and request ID), so a completion whose ref names the reset
-// (old) run must be re-resolved to the current run. All of the following must hold:
+// shouldFallBackToCurrentRun reports whether a pre-handler NotFound can be
+// retried against the current workflow run.
 //
-//   - handlerInvoked is false: the failure came from run lookup or the closed-ancestor access check,
-//     not from the operation itself. A completion that reached the operation and was rejected there
-//     (e.g. a request-ID mismatch or an already-terminal operation) is definitive — never retry it.
-//   - err is a NotFound: only an unresolvable run/component is worth re-resolving.
-//   - the completion carries a request ID: CurrentRun drops the run ID and every versioned transition,
-//     so the handler re-establishes identity by request ID; without one we can't safely match a run.
-//   - the ref names a run: if it doesn't, the first attempt already targeted the current run, so a
-//     CurrentRun retry would be identical.
-//   - the ref addresses a workflow: only workflows are reset onto a new run (until CHASM executions
-//     get conflict resolution), so a standalone archetype has no other run to fall back to.
+// CurrentRun drops the run ID and transition tokens, so the completion must have
+// a request ID for the handler to re-establish operation identity.
 func shouldFallBackToCurrentRun(
 	handlerInvoked bool,
 	err error,
 	completion *persistencespb.ChasmNexusCompletion,
-	ref chasm.ComponentRef,
-	archetypeID chasm.ArchetypeID,
 ) bool {
 	_, isNotFound := errors.AsType[*serviceerror.NotFound](err)
 	return !handlerInvoked &&
 		isNotFound &&
-		completion.GetRequestId() != "" &&
-		ref.RunID != "" &&
-		archetypeID == chasm.WorkflowArchetypeID
+		completion.GetRequestId() != ""
 }
 
-// applyChasmNexusCompletion applies an async Nexus operation completion to the component addressed by ref
-// at the given consistency level. It reports whether the operation's HandleNexusCompletion ran: handlerInvoked
-// is true only when the ref resolved and the framework access checks passed, and false when the failure came
-// from run lookup or the closed-ancestor access check.
+// applyChasmNexusCompletion applies a Nexus completion using the requested ref
+// consistency level. handlerInvoked is true only if the ref resolved and access
+// checks passed before calling HandleNexusCompletion.
 func (h *Handler) applyChasmNexusCompletion(
 	ctx context.Context,
-	ref chasm.ComponentRef,
+	componentRefBytes []byte,
 	completion *persistencespb.ChasmNexusCompletion,
 	level chasm.RefConsistencyLevel,
 ) (handlerInvoked bool, err error) {
 	_, _, err = chasm.UpdateComponent(
 		ctx,
-		ref,
+		componentRefBytes,
 		func(c chasm.NexusCompletionHandler, ctx chasm.MutableContext, completion *persistencespb.ChasmNexusCompletion) (chasm.NoValue, error) {
 			handlerInvoked = true
 			return nil, c.HandleNexusCompletion(ctx, completion)

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -2203,6 +2203,14 @@ func (h *Handler) CompleteNexusOperationChasm(
 		return nil, serviceerror.NewUnimplemented("unhandled Nexus operation outcome")
 	}
 
+	// The current-run fallback below only applies to workflow-backed operations: only workflows are reset
+	// onto a new run (at least until CHASM executions get conflict resolution), so a standalone archetype
+	// has no other run to fall back to.
+	archetypeID, err := ref.ArchetypeID(h.chasmRegistry)
+	if err != nil {
+		return nil, h.convertError(err)
+	}
+
 	// Access the component with progress intent so that the framework blocks access to a
 	// completion targeting an operation under a closed workflow and surfaces it as a
 	// NotFound. That NotFound is the signal to fall back to the current run below.
@@ -2220,7 +2228,8 @@ func (h *Handler) CompleteNexusOperationChasm(
 	if !handlerInvoked &&
 		isNotFound &&
 		completion.GetRequestId() != "" &&
-		ref.RunID != "" {
+		ref.RunID != "" &&
+		archetypeID == chasm.WorkflowArchetypeID {
 		_, err = h.applyChasmNexusCompletion(ctx, ref, completion, chasm.RefConsistencyLevelCurrentRun)
 	}
 	if err != nil {

--- a/service/history/handler_test.go
+++ b/service/history/handler_test.go
@@ -91,12 +91,13 @@ func (f fakeNexusCompletionHandler) HandleNexusCompletion(chasm.MutableContext, 
 	return f.err
 }
 
-func newCompleteNexusOperationChasmRequest(t *testing.T, runID, requestID string) *historyservice.CompleteNexusOperationChasmRequest {
+func newCompleteNexusOperationChasmRequest(t *testing.T, archetypeID chasm.ArchetypeID, runID, requestID string) *historyservice.CompleteNexusOperationChasmRequest {
 	t.Helper()
 	pRef := &persistencespb.ChasmComponentRef{
 		NamespaceId: "test-namespace-id",
 		BusinessId:  "test-workflow-id",
 		RunId:       runID,
+		ArchetypeId: archetypeID,
 	}
 	refBytes, err := pRef.Marshal()
 	require.NoError(t, err)
@@ -124,19 +125,25 @@ func TestCompleteNexusOperationChasm_RunFallback(t *testing.T) {
 	notFound := serviceerror.NewNotFound("operation not found")
 	internalErr := serviceerror.NewInternal("boom")
 
+	// A non-workflow archetype stands in for a standalone CHASM operation, which is never reset and
+	// so must not trigger the current-run fallback.
+	nonWorkflowArchetypeID := chasm.WorkflowArchetypeID + 1
+
 	testCases := []struct {
 		name string
-		// runID / requestID populate the incoming ref and completion.
-		runID     string
-		requestID string
+		// archetypeID / runID / requestID populate the incoming ref and completion.
+		archetypeID chasm.ArchetypeID
+		runID       string
+		requestID   string
 		// setupEngine wires the mock's UpdateComponent behavior and asserts call count.
 		setupEngine func(engine *chasm.MockEngine)
 		wantErr     bool
 	}{
 		{
-			name:      "falls back to current run on NotFound",
-			runID:     refRunID,
-			requestID: requestID,
+			name:        "falls back to current run on NotFound",
+			archetypeID: chasm.WorkflowArchetypeID,
+			runID:       refRunID,
+			requestID:   requestID,
 			setupEngine: func(engine *chasm.MockEngine) {
 				gomock.InOrder(
 					// First lookup uses the ref's run ID and misses (run was reset).
@@ -150,9 +157,23 @@ func TestCompleteNexusOperationChasm_RunFallback(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:      "no fallback once the completion handler was invoked",
-			runID:     refRunID,
-			requestID: requestID,
+			name:        "no fallback for non-workflow archetype",
+			archetypeID: nonWorkflowArchetypeID,
+			runID:       refRunID,
+			requestID:   requestID,
+			setupEngine: func(engine *chasm.MockEngine) {
+				// A standalone archetype is never reset, so the NotFound is definitive: only the
+				// first lookup runs, with no current-run fallback.
+				engine.EXPECT().UpdateComponent(gomock.Any(), matchRunID(refRunID), gomock.Any(), gomock.Any()).
+					Return(nil, notFound)
+			},
+			wantErr: true,
+		},
+		{
+			name:        "no fallback once the completion handler was invoked",
+			archetypeID: chasm.WorkflowArchetypeID,
+			runID:       refRunID,
+			requestID:   requestID,
 			setupEngine: func(engine *chasm.MockEngine) {
 				// The ref resolved and access passed; the handler ran and rejected the
 				// completion (e.g. request-ID mismatch) causes no retry.
@@ -165,9 +186,10 @@ func TestCompleteNexusOperationChasm_RunFallback(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:      "no fallback on non-NotFound error",
-			runID:     refRunID,
-			requestID: requestID,
+			name:        "no fallback on non-NotFound error",
+			archetypeID: chasm.WorkflowArchetypeID,
+			runID:       refRunID,
+			requestID:   requestID,
 			setupEngine: func(engine *chasm.MockEngine) {
 				engine.EXPECT().UpdateComponent(gomock.Any(), matchRunID(refRunID), gomock.Any(), gomock.Any()).
 					Return(nil, internalErr)
@@ -175,9 +197,10 @@ func TestCompleteNexusOperationChasm_RunFallback(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:      "no fallback when the ref carries no run ID",
-			runID:     "",
-			requestID: requestID,
+			name:        "no fallback when the ref carries no run ID",
+			archetypeID: chasm.WorkflowArchetypeID,
+			runID:       "",
+			requestID:   requestID,
 			setupEngine: func(engine *chasm.MockEngine) {
 				engine.EXPECT().UpdateComponent(gomock.Any(), matchRunID(""), gomock.Any(), gomock.Any()).
 					Return(nil, notFound)
@@ -185,9 +208,10 @@ func TestCompleteNexusOperationChasm_RunFallback(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:      "no fallback when the completion has no request ID",
-			runID:     refRunID,
-			requestID: "",
+			name:        "no fallback when the completion has no request ID",
+			archetypeID: chasm.WorkflowArchetypeID,
+			runID:       refRunID,
+			requestID:   "",
 			setupEngine: func(engine *chasm.MockEngine) {
 				engine.EXPECT().UpdateComponent(gomock.Any(), matchRunID(refRunID), gomock.Any(), gomock.Any()).
 					Return(nil, notFound)
@@ -208,7 +232,7 @@ func TestCompleteNexusOperationChasm_RunFallback(t *testing.T) {
 			}
 			ctx := chasm.NewEngineContext(context.Background(), engine)
 
-			_, err := h.CompleteNexusOperationChasm(ctx, newCompleteNexusOperationChasmRequest(t, tc.runID, tc.requestID))
+			_, err := h.CompleteNexusOperationChasm(ctx, newCompleteNexusOperationChasmRequest(t, tc.archetypeID, tc.runID, tc.requestID))
 			if tc.wantErr {
 				require.Error(t, err)
 			} else {

--- a/service/history/handler_test.go
+++ b/service/history/handler_test.go
@@ -137,7 +137,8 @@ func TestCompleteNexusOperationChasm_RunFallback(t *testing.T) {
 		requestID   string
 		// setupEngine wires the mock's UpdateComponent behavior and asserts call count.
 		setupEngine func(engine *chasm.MockEngine)
-		wantErr     bool
+		// wantErrContains is the substring the returned error must contain; empty means no error.
+		wantErrContains string
 	}{
 		{
 			name:        "falls back to current run on NotFound",
@@ -154,7 +155,7 @@ func TestCompleteNexusOperationChasm_RunFallback(t *testing.T) {
 						Return(nil, nil),
 				)
 			},
-			wantErr: false,
+			wantErrContains: "",
 		},
 		{
 			name:        "no fallback for non-workflow archetype",
@@ -167,7 +168,7 @@ func TestCompleteNexusOperationChasm_RunFallback(t *testing.T) {
 				engine.EXPECT().UpdateComponent(gomock.Any(), matchRunID(refRunID), gomock.Any(), gomock.Any()).
 					Return(nil, notFound)
 			},
-			wantErr: true,
+			wantErrContains: "operation not found",
 		},
 		{
 			name:        "no fallback once the completion handler was invoked",
@@ -183,7 +184,7 @@ func TestCompleteNexusOperationChasm_RunFallback(t *testing.T) {
 						return nil, err
 					})
 			},
-			wantErr: true,
+			wantErrContains: "operation not found",
 		},
 		{
 			name:        "no fallback on non-NotFound error",
@@ -194,18 +195,7 @@ func TestCompleteNexusOperationChasm_RunFallback(t *testing.T) {
 				engine.EXPECT().UpdateComponent(gomock.Any(), matchRunID(refRunID), gomock.Any(), gomock.Any()).
 					Return(nil, internalErr)
 			},
-			wantErr: true,
-		},
-		{
-			name:        "no fallback when the ref carries no run ID",
-			archetypeID: chasm.WorkflowArchetypeID,
-			runID:       "",
-			requestID:   requestID,
-			setupEngine: func(engine *chasm.MockEngine) {
-				engine.EXPECT().UpdateComponent(gomock.Any(), matchRunID(""), gomock.Any(), gomock.Any()).
-					Return(nil, notFound)
-			},
-			wantErr: true,
+			wantErrContains: "boom",
 		},
 		{
 			name:        "no fallback when the completion has no request ID",
@@ -216,12 +206,13 @@ func TestCompleteNexusOperationChasm_RunFallback(t *testing.T) {
 				engine.EXPECT().UpdateComponent(gomock.Any(), matchRunID(refRunID), gomock.Any(), gomock.Any()).
 					Return(nil, notFound)
 			},
-			wantErr: true,
+			wantErrContains: "operation not found",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ctrl := gomock.NewController(t)
 			engine := chasm.NewMockEngine(ctrl)
 			tc.setupEngine(engine)
@@ -233,10 +224,10 @@ func TestCompleteNexusOperationChasm_RunFallback(t *testing.T) {
 			ctx := chasm.NewEngineContext(context.Background(), engine)
 
 			_, err := h.CompleteNexusOperationChasm(ctx, newCompleteNexusOperationChasmRequest(t, tc.archetypeID, tc.runID, tc.requestID))
-			if tc.wantErr {
-				require.Error(t, err)
-			} else {
+			if tc.wantErrContains == "" {
 				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.wantErrContains)
 			}
 		})
 	}

--- a/service/history/handler_test.go
+++ b/service/history/handler_test.go
@@ -6,13 +6,18 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/api/historyservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	tokenspb "go.temporal.io/server/api/token/v1"
+	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/membership"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
-	"go.temporal.io/server/common/serviceerror"
+	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tests"
@@ -44,13 +49,13 @@ func TestDescribeHistoryHost(t *testing.T) {
 		},
 		tests.NewDynamicConfig(),
 	)
-	controller.EXPECT().GetShardByID(int32(1)).Return(mockShard1, serviceerror.NewShardOwnershipLost("", ""))
+	controller.EXPECT().GetShardByID(int32(1)).Return(mockShard1, serviceerrors.NewShardOwnershipLost("", ""))
 
 	_, err := h.DescribeHistoryHost(context.Background(), &historyservice.DescribeHistoryHostRequest{
 		ShardId: 1,
 	})
 	assert.Error(t, err)
-	var sol *serviceerror.ShardOwnershipLost
+	var sol *serviceerrors.ShardOwnershipLost
 	assert.True(t, errors.As(err, &sol))
 
 	mockShard2 := shard.NewTestContext(
@@ -69,4 +74,154 @@ func TestDescribeHistoryHost(t *testing.T) {
 		ShardId: 2,
 	})
 	assert.NoError(t, err)
+}
+
+// fakeNexusCompletionHandler is a CHASM component that records whether its completion
+// handler ran and returns a canned error, used to drive the handler's run-fallback logic.
+type fakeNexusCompletionHandler struct {
+	chasm.UnimplementedComponent
+	err error
+}
+
+func (fakeNexusCompletionHandler) LifecycleState(chasm.Context) chasm.LifecycleState {
+	return chasm.LifecycleStateRunning
+}
+
+func (f fakeNexusCompletionHandler) HandleNexusCompletion(chasm.MutableContext, *persistencespb.ChasmNexusCompletion) error {
+	return f.err
+}
+
+func newCompleteNexusOperationChasmRequest(t *testing.T, runID, requestID string) *historyservice.CompleteNexusOperationChasmRequest {
+	t.Helper()
+	pRef := &persistencespb.ChasmComponentRef{
+		NamespaceId: "test-namespace-id",
+		BusinessId:  "test-workflow-id",
+		RunId:       runID,
+	}
+	refBytes, err := pRef.Marshal()
+	require.NoError(t, err)
+	return &historyservice.CompleteNexusOperationChasmRequest{
+		Completion: &tokenspb.NexusOperationCompletion{
+			RequestId:    requestID,
+			ComponentRef: refBytes,
+		},
+		Outcome: &historyservice.CompleteNexusOperationChasmRequest_Success{
+			Success: &commonpb.Payload{},
+		},
+	}
+}
+
+func TestCompleteNexusOperationChasm_RunFallback(t *testing.T) {
+	t.Parallel()
+
+	const (
+		refRunID  = "original-run-id"
+		requestID = "request-id"
+	)
+
+	// notFound is returned by run lookup / the closed-ancestor access check without ever
+	// entering the completion handler; internalErr stands in for a non-NotFound failure.
+	notFound := serviceerror.NewNotFound("operation not found")
+	internalErr := serviceerror.NewInternal("boom")
+
+	testCases := []struct {
+		name string
+		// runID / requestID populate the incoming ref and completion.
+		runID     string
+		requestID string
+		// setupEngine wires the mock's UpdateComponent behavior and asserts call count.
+		setupEngine func(engine *chasm.MockEngine)
+		wantErr     bool
+	}{
+		{
+			name:      "falls back to current run on NotFound",
+			runID:     refRunID,
+			requestID: requestID,
+			setupEngine: func(engine *chasm.MockEngine) {
+				gomock.InOrder(
+					// First lookup uses the ref's run ID and misses (run was reset).
+					engine.EXPECT().UpdateComponent(gomock.Any(), matchRunID(refRunID), gomock.Any(), gomock.Any()).
+						Return(nil, notFound),
+					// Fallback drops the run ID and hits the current run.
+					engine.EXPECT().UpdateComponent(gomock.Any(), matchRunID(""), gomock.Any(), gomock.Any()).
+						Return(nil, nil),
+				)
+			},
+			wantErr: false,
+		},
+		{
+			name:      "no fallback once the completion handler was invoked",
+			runID:     refRunID,
+			requestID: requestID,
+			setupEngine: func(engine *chasm.MockEngine) {
+				// The ref resolved and access passed; the handler ran and rejected the
+				// completion (e.g. request-ID mismatch) causes no retry.
+				engine.EXPECT().UpdateComponent(gomock.Any(), matchRunID(refRunID), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ chasm.ComponentRef, fn func(chasm.MutableContext, chasm.Component) error, _ ...chasm.TransitionOption) ([]byte, error) {
+						err := fn(&chasm.MockMutableContext{}, fakeNexusCompletionHandler{err: notFound})
+						return nil, err
+					})
+			},
+			wantErr: true,
+		},
+		{
+			name:      "no fallback on non-NotFound error",
+			runID:     refRunID,
+			requestID: requestID,
+			setupEngine: func(engine *chasm.MockEngine) {
+				engine.EXPECT().UpdateComponent(gomock.Any(), matchRunID(refRunID), gomock.Any(), gomock.Any()).
+					Return(nil, internalErr)
+			},
+			wantErr: true,
+		},
+		{
+			name:      "no fallback when the ref carries no run ID",
+			runID:     "",
+			requestID: requestID,
+			setupEngine: func(engine *chasm.MockEngine) {
+				engine.EXPECT().UpdateComponent(gomock.Any(), matchRunID(""), gomock.Any(), gomock.Any()).
+					Return(nil, notFound)
+			},
+			wantErr: true,
+		},
+		{
+			name:      "no fallback when the completion has no request ID",
+			runID:     refRunID,
+			requestID: "",
+			setupEngine: func(engine *chasm.MockEngine) {
+				engine.EXPECT().UpdateComponent(gomock.Any(), matchRunID(refRunID), gomock.Any(), gomock.Any()).
+					Return(nil, notFound)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			engine := chasm.NewMockEngine(ctrl)
+			tc.setupEngine(engine)
+
+			h := &Handler{
+				logger:         log.NewNoopLogger(),
+				metricsHandler: metrics.NoopMetricsHandler,
+			}
+			ctx := chasm.NewEngineContext(context.Background(), engine)
+
+			_, err := h.CompleteNexusOperationChasm(ctx, newCompleteNexusOperationChasmRequest(t, tc.runID, tc.requestID))
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// matchRunID matches a chasm.ComponentRef argument by its RunID.
+func matchRunID(runID string) gomock.Matcher {
+	return gomock.Cond(func(x any) bool {
+		ref, ok := x.(chasm.ComponentRef)
+		return ok && ref.RunID == runID
+	})
 }

--- a/tests/nexus_standalone_test.go
+++ b/tests/nexus_standalone_test.go
@@ -2167,7 +2167,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationPoll() {
 	})
 }
 
-func (s *NexusStandaloneTestSuite) TestAsyncCompletionIgnoresTransitionFieldsInCallbackToken() {
+func (s *NexusStandaloneTestSuite) TestAsyncCompletionIgnoresExecutionTransitionInCallbackToken() {
 	env := s.newTestEnv()
 	handlerLink := &commonpb.Link_WorkflowEvent{
 		Namespace:  env.Namespace().String(),
@@ -2226,8 +2226,11 @@ func (s *NexusStandaloneTestSuite) TestAsyncCompletionIgnoresTransitionFieldsInC
 	completionToken, err := gen.DecodeCompletion(decodedToken)
 	s.NoError(err)
 
-	// Deliberately corrupt transition fields in the callback token. Completion should
-	// still succeed because the handler strips these fields before validation.
+	// Deliberately corrupt the execution transition in the callback token. Completion should still
+	// succeed: it resolves at RefConsistencyLevelComponentCreation, which ignores the execution
+	// transition (staleness is checked against the component's creation transition instead) and
+	// re-establishes identity by request ID. The creation transition is left valid, as the framework
+	// legitimately relies on it to guarantee the loaded state knows about the operation.
 	ref := &persistencespb.ChasmComponentRef{}
 	s.NoError(ref.Unmarshal(completionToken.GetComponentRef()))
 	s.NotNil(ref.ExecutionVersionedTransition)
@@ -2235,10 +2238,6 @@ func (s *NexusStandaloneTestSuite) TestAsyncCompletionIgnoresTransitionFieldsInC
 	ref.ExecutionVersionedTransition = &persistencespb.VersionedTransition{
 		NamespaceFailoverVersion: ref.ExecutionVersionedTransition.NamespaceFailoverVersion + 1000,
 		TransitionCount:          ref.ExecutionVersionedTransition.TransitionCount + 1000,
-	}
-	ref.ComponentInitialVersionedTransition = &persistencespb.VersionedTransition{
-		NamespaceFailoverVersion: ref.ComponentInitialVersionedTransition.NamespaceFailoverVersion + 1000,
-		TransitionCount:          ref.ComponentInitialVersionedTransition.TransitionCount + 1000,
 	}
 	completionToken.ComponentRef, err = ref.Marshal()
 	s.NoError(err)

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -1131,16 +1131,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletion(chasmEnabled 
 			nexus.HandlerErrorTypeNotFound,
 		)
 		assertInvalidCompletionTokenRejected(
-			"missing run",
-			func(token *tokenspb.NexusOperationCompletion) *tokenspb.NexusOperationCompletion {
-				s.mutateCompletionComponentRef(token, func(ref *persistencespb.ChasmComponentRef) {
-					ref.RunId = uuid.NewString()
-				})
-				return token
-			},
-			nexus.HandlerErrorTypeNotFound,
-		)
-		assertInvalidCompletionTokenRejected(
 			"wrong archetype",
 			func(token *tokenspb.NexusOperationCompletion) *tokenspb.NexusOperationCompletion {
 				s.mutateCompletionComponentRef(token, func(ref *persistencespb.ChasmComponentRef) {
@@ -1986,9 +1976,6 @@ NexusOperationStarted`, hist)
 }
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAfterReset(chasmEnabled bool) {
-	if chasmEnabled {
-		s.T().Skip("Blocked on CHASM Nexus async completion after reset support")
-	}
 	env := s.newTestEnv(chasmEnabled)
 	ctx := s.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())


### PR DESCRIPTION
## What changed?
Brings CHASM async Nexus operation completion to parity with the HSM completion handler by resolving completions across runs after a workflow reset.

`CompleteNexusOperationChasm` now performs a two-lookup run fallback:
- **1st lookup** at `RefConsistencyLevelComponentCreation` — tolerates a stale execution transition (a completion may carry a ref from before a reset/rebuild rewrote transition history) while still guaranteeing the loaded state knows about the operation.
- On a `NotFound` that never reached the operation, **retry** at `RefConsistencyLevelCurrentRun` — the framework drops the run ID and every versioned transition and resolves the current run.

Identity is enforced by request ID in `HandleNexusCompletion`, so a completion carrying a stale/wrong run ID falls back to the current run rather than being rejected (mirrors the HSM handler). Completions are accessed with `OperationIntentProgress` so the framework blocks access to an operation under a closed workflow and surfaces it as a `NotFound`, which drives the fallback. The retry only fires when the completion handler was never reached, a completion that reached the operation and was rejected there is definitive.

The fallback is gated to workflow-backed operations (`WorkflowArchetypeID`): only workflows are reset onto a new run, so a standalone Nexus operation has no other run to fall back to.

## Why?
The HSM handler already resolves completions on the current run after a reset — a reset creates a new run that inherits the scheduled operation and its request ID. The CHASM path previously did a single lookup pinned to the ref's run ID, so a completion arriving after a reset was lost. This closes that gap.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
The reset reapply/rebuild PRs it builds on (#10986, #10983) have merged; this is rebased on latest `main`.