### PR TITLE
replication: add source_task_id to sent replication lifecycle events

### DIFF
--- a/common/wideevents/replication_events.go
+++ b/common/wideevents/replication_events.go
@@ -42,7 +42,10 @@ type ReplicationLifecyclePayload struct {
 	ParentInitiatedID int64
 	Details           map[string]any
 	// sent-only
-	NewRunID     string
+	NewRunID string
+	// SourceTaskID is the sender's replication-queue task id for this event, recorded so a "sent"
+	// event can be correlated with the source cluster's replication queue.
+	SourceTaskID int64
 	IsFirstSync  bool
 	FirstEventID int64
 	NextEventID  int64
@@ -133,6 +136,9 @@ func (p ReplicationLifecyclePayload) Attributes() []log.KeyValue {
 func (p ReplicationLifecyclePayload) appendSent(attrs []log.KeyValue) []log.KeyValue {
 	if p.NewRunID != "" {
 		attrs = append(attrs, log.String("new_run_id", p.NewRunID))
+	}
+	if p.SourceTaskID != 0 {
+		attrs = append(attrs, log.Int64("source_task_id", p.SourceTaskID))
 	}
 	attrs = append(attrs, log.Bool("is_first_sync", p.IsFirstSync))
 	if p.FirstEventID != 0 {

--- a/common/wideevents/replication_events_test.go
+++ b/common/wideevents/replication_events_test.go
@@ -154,6 +154,7 @@ func fullyPopulatedReplication(phase ReplicationPhase) ReplicationLifecyclePaylo
 		ParentInitiatedID:   3,
 		Details:             map[string]any{"k": "v"},
 		NewRunID:            "new-run",
+		SourceTaskID:        42,
 		IsFirstSync:         true,
 		FirstEventID:        1,
 		NextEventID:         8,
@@ -206,6 +207,7 @@ func TestReplicationLifecycleFieldSetLocked(t *testing.T) {
 		ReplicationSent: mergeFields(base, map[string]any{
 			"phase":          "sent",
 			"new_run_id":     "new-run",
+			"source_task_id": int64(42),
 			"is_first_sync":  true,
 			"first_event_id": int64(1),
 			"next_event_id":  int64(8),

--- a/service/history/replication/replication_events.go
+++ b/service/history/replication/replication_events.go
@@ -96,13 +96,14 @@ func (s *StreamSenderImpl) emitReplicationSent(
 	}
 
 	payload := wideevents.ReplicationLifecyclePayload{
-		Phase:       wideevents.ReplicationSent,
-		TaskType:    taskType,
-		Shard:       s.serverShardKey.ShardID,
-		Namespace:   nsName.String(),
-		NamespaceID: nsID,
-		WorkflowID:  item.GetWorkflowID(),
-		RunID:       item.GetRunID(),
+		Phase:        wideevents.ReplicationSent,
+		TaskType:     taskType,
+		Shard:        s.serverShardKey.ShardID,
+		Namespace:    nsName.String(),
+		NamespaceID:  nsID,
+		WorkflowID:   item.GetWorkflowID(),
+		RunID:        item.GetRunID(),
+		SourceTaskID: item.GetTaskID(),
 	}
 	if vt := task.GetVersionedTransition(); vt != nil {
 		payload.FailoverVersion = vt.GetNamespaceFailoverVersion()


### PR DESCRIPTION
## What

Adds a `source_task_id` field to the **sent**-phase `replication_lifecycle` wide event, populated from the source shard's replication-queue task id (`item.GetTaskID()`).

## Why

The `replication_lifecycle` event traces a task through `sent → executing → applied`, but there was no stable identifier tying a `sent` event on the active cluster back to the source cluster's replication queue. `source_task_id` lets a reader correlate a sent event with the source replication queue and join it to the matching apply on the passive side.

## Details

- `common/wideevents/replication_events.go`: new `SourceTaskID int64` field in the sent-only group; emitted as `source_task_id` from `appendSent`, only when non-zero (inert otherwise).
- `service/history/replication/replication_events.go`: `emitReplicationSent` sets `SourceTaskID: item.GetTaskID()`.
- `common/wideevents/replication_events_test.go`: field-set lock test updated to assert `source_task_id` on the sent phase.

Scoped intentionally small; no behavior change beyond the added field.

## Test

`go test ./common/wideevents/` passes (the field-set-locked test covers the new field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)