### PR TITLE
fix: describe only provides heartbeat/failure when opted-in

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1570,7 +1570,10 @@ func internalStatusToRunState(status activitypb.ActivityExecutionStatus) enumspb
 	}
 }
 
-func (a *Activity) buildActivityExecutionInfo(ctx chasm.Context) *apiactivitypb.ActivityExecutionInfo {
+func (a *Activity) buildActivityExecutionInfo(
+	ctx chasm.Context,
+	request *workflowservice.DescribeActivityExecutionRequest,
+) *apiactivitypb.ActivityExecutionInfo {
 	status := InternalStatusToAPIStatus(a.GetStatus())
 	runState := internalStatusToRunState(a.GetStatus())
 
@@ -1606,12 +1609,10 @@ func (a *Activity) buildActivityExecutionInfo(ctx chasm.Context) *apiactivitypb.
 		ExecutionTime:           timestamppb.New(a.firstDispatchTime()),
 		ExpirationTime:          expirationTime,
 		Header:                  requestData.GetHeader(),
-		HeartbeatDetails:        heartbeat.GetDetails(),
 		HeartbeatTimeout:        a.GetHeartbeatTimeout(),
 		Links:                   ctx.Links(a),
 		TotalHeartbeatCount:     heartbeat.GetTotalHeartbeatCount(),
 		LastAttemptCompleteTime: attempt.GetCompleteTime(),
-		LastFailure:             attempt.GetLastFailureDetails().GetFailure(),
 		LastHeartbeatTime:       heartbeat.GetRecordedTime(),
 		LastStartedTime:         attempt.GetStartedTime(),
 		LastWorkerIdentity:      attempt.GetLastWorkerIdentity(),
@@ -1634,6 +1635,12 @@ func (a *Activity) buildActivityExecutionInfo(ctx chasm.Context) *apiactivitypb.
 		TaskQueue:               a.GetTaskQueue().GetName(),
 		UserMetadata:            a.effectiveUserMetadata(ctx),
 	}
+	if request.GetIncludeHeartbeatDetails() {
+		info.HeartbeatDetails = heartbeat.GetDetails()
+	}
+	if request.GetIncludeLastFailure() {
+		info.LastFailure = attempt.GetLastFailureDetails().GetFailure()
+	}
 
 	return info
 }
@@ -1649,7 +1656,7 @@ func (a *Activity) buildDescribeActivityExecutionResponse(
 		return nil, err
 	}
 
-	info := a.buildActivityExecutionInfo(ctx)
+	info := a.buildActivityExecutionInfo(ctx, request)
 
 	var input *commonpb.Payloads
 	if request.GetIncludeInput() {

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -11655,8 +11655,9 @@ func (s *standaloneActivityTestSuite) TestUnpauseActivityExecution() {
 
 		// Heartbeat details should still be set before the unpause.
 		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  env.Namespace().String(),
-			ActivityId: activityID,
+			Namespace:               env.Namespace().String(),
+			ActivityId:              activityID,
+			IncludeHeartbeatDetails: true,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, descResp.GetInfo().GetLastHeartbeatTime(), "expected heartbeat time before unpause")
@@ -11682,8 +11683,9 @@ func (s *standaloneActivityTestSuite) TestUnpauseActivityExecution() {
 
 		// Heartbeat details must be cleared after unpause.
 		descResp, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  env.Namespace().String(),
-			ActivityId: activityID,
+			Namespace:               env.Namespace().String(),
+			ActivityId:              activityID,
+			IncludeHeartbeatDetails: true,
 		})
 		require.NoError(t, err)
 		require.Nil(t, descResp.GetInfo().GetLastHeartbeatTime(),

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -3403,11 +3403,12 @@ func (s *standaloneActivityTestSuite) TestStartToCloseTimeout() {
 
 	// Third poll: activity has timed out
 	describeResp3, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
-		Namespace:      env.Namespace().String(),
-		ActivityId:     activityID,
-		RunId:          startResp.RunId,
-		IncludeOutcome: true,
-		LongPollToken:  describeResp2.LongPollToken,
+		Namespace:          env.Namespace().String(),
+		ActivityId:         activityID,
+		RunId:              startResp.RunId,
+		IncludeOutcome:     true,
+		IncludeLastFailure: true,
+		LongPollToken:      describeResp2.LongPollToken,
 	})
 
 	require.NoError(t, err)
@@ -3682,6 +3683,56 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution() {
 		expectedExecution := describeResp.GetInfo().GetScheduleTime().AsTime().Add(startDelay.AsDuration())
 		require.Equal(t, expectedExecution, describeResp.GetInfo().GetExecutionTime().AsTime(),
 			"execution_time should equal scheduleTime + start_delay")
+	})
+
+	s.Run("SensitiveFieldsRequireOptIn", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		startResp, err := env.startActivity(s.Context(), activityID, taskQueue)
+		require.NoError(t, err)
+
+		pollTaskResp, err := env.pollActivityTaskQueue(s.Context(), taskQueue)
+		require.NoError(t, err)
+
+		_, err = env.FrontendClient().RecordActivityTaskHeartbeat(s.Context(), &workflowservice.RecordActivityTaskHeartbeatRequest{
+			Namespace: env.Namespace().String(),
+			TaskToken: pollTaskResp.TaskToken,
+			Details:   defaultHeartbeatDetails,
+			Identity:  defaultIdentity,
+		})
+		require.NoError(t, err)
+
+		_, err = env.FrontendClient().RespondActivityTaskFailed(s.Context(), &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: env.Namespace().String(),
+			TaskToken: pollTaskResp.TaskToken,
+			Failure:   defaultFailure,
+			Identity:  defaultIdentity,
+		})
+		require.NoError(t, err)
+
+		describeResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		require.Nil(t, describeResp.GetInfo().GetHeartbeatDetails())
+		require.Nil(t, describeResp.GetInfo().GetLastFailure())
+
+		describeResp, err = env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:               env.Namespace().String(),
+			ActivityId:              activityID,
+			RunId:                   startResp.RunId,
+			IncludeHeartbeatDetails: true,
+			IncludeLastFailure:      true,
+		})
+		require.NoError(t, err)
+		protorequire.ProtoEqual(t, defaultHeartbeatDetails, describeResp.GetInfo().GetHeartbeatDetails())
+		protorequire.ProtoEqual(t, defaultFailure, describeResp.GetInfo().GetLastFailure())
 	})
 
 	s.Run("WaitAnyStateChange", func(s *standaloneActivityTestSuite) {
@@ -8959,11 +9010,13 @@ func (env *standaloneActivityEnv) validateFailure(
 	workerIdentity string,
 ) {
 	activityResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-		Namespace:      env.Namespace().String(),
-		ActivityId:     activityID,
-		RunId:          runID,
-		IncludeInput:   true,
-		IncludeOutcome: true,
+		Namespace:               env.Namespace().String(),
+		ActivityId:              activityID,
+		RunId:                   runID,
+		IncludeInput:            true,
+		IncludeOutcome:          true,
+		IncludeHeartbeatDetails: expectedHeartbeatDetails != nil,
+		IncludeLastFailure:      true,
 	})
 
 	info := activityResp.GetInfo()
@@ -8984,6 +9037,8 @@ func (env *standaloneActivityEnv) validateFailure(
 
 	if expectedHeartbeatDetails != nil {
 		protorequire.ProtoEqual(t, expectedHeartbeatDetails, info.GetHeartbeatDetails())
+	} else {
+		require.Nil(t, info.GetHeartbeatDetails())
 	}
 }
 
@@ -9924,8 +9979,9 @@ func (s *standaloneActivityTestSuite) TestPauseActivityExecution() {
 		// After fail, activity should be PAUSED (SCHEDULED + paused) at attempt=2 with a recorded failure.
 		await.Require(s.Context(), s.T(), func(c *await.T) {
 			dr, dErr := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:  env.Namespace().String(),
-				ActivityId: activityID,
+				Namespace:          env.Namespace().String(),
+				ActivityId:         activityID,
+				IncludeLastFailure: true,
 			})
 			require.NoError(c, dErr)
 			require.Equal(c, enumspb.PENDING_ACTIVITY_STATE_PAUSED, dr.GetInfo().GetRunState())
@@ -10020,8 +10076,9 @@ func (s *standaloneActivityTestSuite) TestPauseActivityExecution() {
 		// Verify attempt is now 2, activity is still paused, and LastFailure is populated.
 		await.Require(s.Context(), t, func(c *await.T) {
 			dr, dErr := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:  env.Namespace().String(),
-				ActivityId: activityID,
+				Namespace:          env.Namespace().String(),
+				ActivityId:         activityID,
+				IncludeLastFailure: true,
 			})
 			require.NoError(c, dErr)
 			require.Equal(c, enumspb.PENDING_ACTIVITY_STATE_PAUSED, dr.GetInfo().GetRunState())
@@ -12255,9 +12312,10 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 
 		// Verify heartbeat is visible in describe
 		desc, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  env.Namespace().String(),
-			ActivityId: activityID,
-			RunId:      startResp.GetRunId(),
+			Namespace:               env.Namespace().String(),
+			ActivityId:              activityID,
+			RunId:                   startResp.GetRunId(),
+			IncludeHeartbeatDetails: true,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, desc.GetInfo().GetHeartbeatDetails())
@@ -12330,9 +12388,10 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 
 		// Verify heartbeat is visible
 		desc, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  env.Namespace().String(),
-			ActivityId: activityID,
-			RunId:      startResp.GetRunId(),
+			Namespace:               env.Namespace().String(),
+			ActivityId:              activityID,
+			RunId:                   startResp.GetRunId(),
+			IncludeHeartbeatDetails: true,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, desc.GetInfo().GetHeartbeatDetails())
@@ -12342,9 +12401,10 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 
 		// Activity should still be STARTED with heartbeat still visible (reset is deferred)
 		desc, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  env.Namespace().String(),
-			ActivityId: activityID,
-			RunId:      startResp.GetRunId(),
+			Namespace:               env.Namespace().String(),
+			ActivityId:              activityID,
+			RunId:                   startResp.GetRunId(),
+			IncludeHeartbeatDetails: true,
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, desc.GetInfo().GetRunState())
@@ -12374,9 +12434,10 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 
 		// Verify new heartbeat is visible in describe
 		desc, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  env.Namespace().String(),
-			ActivityId: activityID,
-			RunId:      startResp.GetRunId(),
+			Namespace:               env.Namespace().String(),
+			ActivityId:              activityID,
+			RunId:                   startResp.GetRunId(),
+			IncludeHeartbeatDetails: true,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, desc.GetInfo().GetHeartbeatDetails(), "new heartbeat from reset attempt should be visible")


### PR DESCRIPTION
• ## What changed?
`DescribeActivityExecution` now only returns `ActivityExecutionInfo.HeartbeatDetails` and `ActivityExecutionInfo.LastFailure` when callers explicitly set `IncludeHeartbeatDetails` and `IncludeLastFailure`.

## Why?
Heartbeat details and failure payloads may contain sensitive or large application data. Returning them when callers did not opt in violates the response minimization contract for `DescribeActivityExecution`.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)

## Potential risks
Existing callers that were relying on heartbeat details or last failure being returned without setting the include flags will now need to opt in explicitly. This is the intended documented behavior.