### PR TITLE
reject unsupported and empty update_mask paths in UpdateActivityExecutionOptions

### DIFF
--- a/chasm/lib/activity/validator.go
+++ b/chasm/lib/activity/validator.go
@@ -1,6 +1,8 @@
 package activity
 
 import (
+	"strings"
+
 	"github.com/google/uuid"
 	activitypb "go.temporal.io/api/activity/v1"
 	commonpb "go.temporal.io/api/common/v1"
@@ -456,6 +458,27 @@ func validateAndNormalizeRequestCancelActivityExecutionRequest(
 	return nil
 }
 
+// supportedActivityOptionsUpdatePaths is the allowlist of update_mask paths (in camelCase JSON
+// form, as produced by util.ConvertPathToCamel) that UpdateActivityExecutionOptions supports.
+// It must stay in sync with the fields handled in MergeActivityOptions.
+var supportedActivityOptionsUpdatePaths = map[string]struct{}{
+	"taskQueue.name":                 {},
+	"scheduleToCloseTimeout":         {},
+	"scheduleToStartTimeout":         {},
+	"startToCloseTimeout":            {},
+	"heartbeatTimeout":               {},
+	"priority":                       {},
+	"priority.priorityKey":           {},
+	"priority.fairnessKey":           {},
+	"priority.fairnessWeight":        {},
+	"retryPolicy":                    {},
+	"retryPolicy.initialInterval":    {},
+	"retryPolicy.backoffCoefficient": {},
+	"retryPolicy.maximumInterval":    {},
+	"retryPolicy.maximumAttempts":    {},
+	"startDelay":                     {},
+}
+
 //nolint:revive // cyclomatic: per-field validation of a field-mask update requires explicit handling of each field
 func validateUpdateActivityExecutionOptionsRequest(
 	req *workflowservice.UpdateActivityExecutionOptionsRequest,
@@ -496,6 +519,15 @@ func validateUpdateActivityExecutionOptionsRequest(
 	}
 	if req.GetUpdateMask() == nil {
 		return serviceerror.NewInvalidArgument("UpdateMask is not provided")
+	}
+	if len(req.GetUpdateMask().GetPaths()) == 0 {
+		return serviceerror.NewInvalidArgument("UpdateMask must specify at least one path")
+	}
+	for _, path := range req.GetUpdateMask().GetPaths() {
+		jsonPath := strings.Join(util.ConvertPathToCamel(path), ".")
+		if _, ok := supportedActivityOptionsUpdatePaths[jsonPath]; !ok {
+			return serviceerror.NewInvalidArgumentf("unsupported update_mask path: %q", path)
+		}
 	}
 
 	opts := req.GetActivityOptions()

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -7846,6 +7846,52 @@ func (s *standaloneActivityTestSuite) TestUpdateActivityExecutionOptions() {
 				},
 				expectedErr: "invalid run id",
 			},
+			{
+				name: "EmptyUpdateMask",
+				req: &workflowservice.UpdateActivityExecutionOptionsRequest{
+					Namespace:       ns,
+					ActivityId:      activityID,
+					RunId:           runID,
+					ActivityOptions: validOptions,
+					UpdateMask:      &fieldmaskpb.FieldMask{Paths: []string{}},
+				},
+				expectedErr: "UpdateMask",
+			},
+			{
+				name: "UnknownPath",
+				req: &workflowservice.UpdateActivityExecutionOptionsRequest{
+					Namespace:       ns,
+					ActivityId:      activityID,
+					RunId:           runID,
+					ActivityOptions: validOptions,
+					UpdateMask:      &fieldmaskpb.FieldMask{Paths: []string{"definitely_not_an_activity_option"}},
+				},
+				expectedErr: "definitely_not_an_activity_option",
+			},
+			{
+				name: "UnsupportedRootPath",
+				req: &workflowservice.UpdateActivityExecutionOptionsRequest{
+					Namespace:  ns,
+					ActivityId: activityID,
+					RunId:      runID,
+					ActivityOptions: &activitypb.ActivityOptions{
+						TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue},
+					},
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"task_queue"}},
+				},
+				expectedErr: "task_queue",
+			},
+			{
+				name: "WildcardPath",
+				req: &workflowservice.UpdateActivityExecutionOptionsRequest{
+					Namespace:       ns,
+					ActivityId:      activityID,
+					RunId:           runID,
+					ActivityOptions: validOptions,
+					UpdateMask:      &fieldmaskpb.FieldMask{Paths: []string{"*"}},
+				},
+				expectedErr: "*",
+			},
 		}
 
 		for _, tc := range testCases {


### PR DESCRIPTION
## What changed?

`UpdateActivityExecutionOptions` validates the update_mask before applying it:
- Rejects an empty paths list unless restore_original is set
- Rejects any path not in the supported allowlist (e.g. unknown fields like `definitely_not_an_activity_option`, unsupported roots like `task_queue`, or wildcards like `*`).

## Why?

Field-mask paths were never validated against protobuf syntax or a supported-path allowlist. `ParseFieldMask` silently drops any path it doesn't recognize, so unknown/unsupported/empty masks passed validation as no-ops — yet the request still bumped the attempt stamp, recreated timers/dispatch tasks, emitted metrics, incremented state transition count, and could wake Describe long polls.

## How did you test it?

- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)

## Potential risks
Minimal, this feature is not merged yet.