### PR TITLE
Convert Nexus completion tokens across HSM and CHASM

### DIFF
--- a/service/frontend/nexus_completion_http_handler.go
+++ b/service/frontend/nexus_completion_http_handler.go
@@ -33,6 +33,7 @@ import (
 	"go.temporal.io/server/common/rpc/interceptor"
 	"go.temporal.io/server/nexusworkflowref"
 	"go.temporal.io/server/service/frontend/configs"
+	"go.temporal.io/server/service/history/consts"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -255,6 +256,10 @@ func (h *nexusCompletionHandler) CompleteOperation(ctx context.Context, r *nexus
 // original framework, the token is converted to the other framework and tried once more. Identity
 // is re-established by request ID, so the fallback only runs when the token carries one.
 //
+// The fallback is also skipped when the error is terminal (the workflow already completed or does
+// not exist): the operation can't be applied in either framework, so converting the token and
+// retrying would be a wasted round-trip.
+//
 // chasmEnabled gates the HSM->CHASM direction: a workflow in a CHASM-disabled namespace has no
 // CHASM tree, so converting to CHASM would be futile (and the CHASM engine would flag it).
 func (h *nexusCompletionHandler) completeOperation(
@@ -276,6 +281,11 @@ func (h *nexusCompletionHandler) completeOperation(
 	if _, notFound := errors.AsType[*serviceerror.NotFound](err); !notFound || completion.GetRequestId() == "" {
 		return err
 	}
+	// A terminal error means the workflow itself is gone, so the operation can't be completed in the
+	// other framework either; don't waste a round-trip converting the token and retrying.
+	if isTerminalCompletionError(err) {
+		return err
+	}
 	// Converting HSM -> CHASM is only meaningful when the namespace has CHASM enabled (and thus a
 	// CHASM tree); CHASM -> HSM is always safe since HSM is the legacy default.
 	if !isChasm && !chasmEnabled {
@@ -290,6 +300,21 @@ func (h *nexusCompletionHandler) completeOperation(
 		return h.completeHSMOperation(ctx, converted, successPayload, req, links)
 	}
 	return h.completeChasmOperation(ctx, logger, converted, successPayload, req, links)
+}
+
+// isTerminalCompletionError reports whether err indicates the target workflow is gone — already
+// completed or nonexistent — so an async operation completion can never be applied in either
+// framework and there is no point retrying after a token conversion. Both cases arrive as a plain
+// serviceerror.NotFound over the history gRPC boundary (which does not preserve error identity), so
+// they are matched by message. A reset/rebuild that merely moved the operation to the other
+// framework surfaces a different NotFound (stale reference / component not found), which is retried.
+func isTerminalCompletionError(err error) bool {
+	var nfe *serviceerror.NotFound
+	if !errors.As(err, &nfe) {
+		return false
+	}
+	msg := nfe.Error()
+	return msg == consts.ErrWorkflowCompleted.Error() || msg == consts.ErrWorkflowExecutionNotFound.Error()
 }
 
 // convertCompletionToOtherFramework re-addresses a Nexus operation completion token to the

--- a/service/frontend/nexus_completion_http_handler.go
+++ b/service/frontend/nexus_completion_http_handler.go
@@ -249,19 +249,9 @@ func (h *nexusCompletionHandler) CompleteOperation(ctx context.Context, r *nexus
 	return commonnexus.ConvertGRPCError(err, false)
 }
 
-// completeOperation dispatches the completion to the framework its token targets (CHASM when a
-// ComponentRef is present, otherwise HSM). A rebuild (reset or conflict resolution) can flip an
-// operation between HSM and CHASM by dynamic config after the callback token was minted, so the
-// token's framework may no longer match the operation. If the operation was not found in its
-// original framework, the token is converted to the other framework and tried once more. Identity
-// is re-established by request ID, so the fallback only runs when the token carries one.
-//
-// The fallback is also skipped when the error is terminal (the workflow already completed or does
-// not exist): the operation can't be applied in either framework, so converting the token and
-// retrying would be a wasted round-trip.
-//
-// chasmEnabled gates the HSM->CHASM direction: a workflow in a CHASM-disabled namespace has no
-// CHASM tree, so converting to CHASM would be futile (and the CHASM engine would flag it).
+// completeOperation dispatches the completion to the framework named by its
+// token. If that framework no longer has the operation, the token is converted
+// to the other framework and retried once.
 func (h *nexusCompletionHandler) completeOperation(
 	ctx context.Context,
 	logger log.Logger,
@@ -281,13 +271,11 @@ func (h *nexusCompletionHandler) completeOperation(
 	if _, notFound := errors.AsType[*serviceerror.NotFound](err); !notFound || completion.GetRequestId() == "" {
 		return err
 	}
-	// A terminal error means the workflow itself is gone, so the operation can't be completed in the
-	// other framework either; don't waste a round-trip converting the token and retrying.
+	// If the workflow itself is gone, the operation cannot exist in either framework.
 	if isTerminalCompletionError(err) {
 		return err
 	}
-	// Converting HSM -> CHASM is only meaningful when the namespace has CHASM enabled (and thus a
-	// CHASM tree); CHASM -> HSM is always safe since HSM is the legacy default.
+	// Only try HSM -> CHASM when this namespace can have CHASM workflow state.
 	if !isChasm && !chasmEnabled {
 		return err
 	}
@@ -302,12 +290,8 @@ func (h *nexusCompletionHandler) completeOperation(
 	return h.completeChasmOperation(ctx, logger, converted, successPayload, req, links)
 }
 
-// isTerminalCompletionError reports whether err indicates the target workflow is gone — already
-// completed or nonexistent — so an async operation completion can never be applied in either
-// framework and there is no point retrying after a token conversion. Both cases arrive as a plain
-// serviceerror.NotFound over the history gRPC boundary (which does not preserve error identity), so
-// they are matched by message. A reset/rebuild that merely moved the operation to the other
-// framework surfaces a different NotFound (stale reference / component not found), which is retried.
+// isTerminalCompletionError reports whether err means the workflow is already
+// completed or does not exist. These arrive as NotFound errors from history.
 func isTerminalCompletionError(err error) bool {
 	var nfe *serviceerror.NotFound
 	if !errors.As(err, &nfe) {
@@ -317,13 +301,8 @@ func isTerminalCompletionError(err error) bool {
 	return msg == consts.ErrWorkflowCompleted.Error() || msg == consts.ErrWorkflowExecutionNotFound.Error()
 }
 
-// convertCompletionToOtherFramework re-addresses a Nexus operation completion token to the
-// framework opposite the one it currently targets (HSM <-> CHASM).
-//
-// A rebuild (reset or conflict resolution) can re-create an operation under the other framework by
-// dynamic config after its callback token was minted — the intentional escape hatch to roll
-// operations back to HSM or forward to CHASM. The token then addresses the framework the operation
-// no longer lives in; converting it lets the completion be retried against the current one.
+// convertCompletionToOtherFramework converts a workflow Nexus completion token
+// between HSM and CHASM forms.
 func convertCompletionToOtherFramework(completion *tokenspb.NexusOperationCompletion) (*tokenspb.NexusOperationCompletion, error) {
 	if len(completion.GetComponentRef()) > 0 {
 		return nexusworkflowref.CHASMRefToHSMRef(completion)

--- a/service/frontend/nexus_completion_http_handler.go
+++ b/service/frontend/nexus_completion_http_handler.go
@@ -31,6 +31,7 @@ import (
 	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/common/rpc"
 	"go.temporal.io/server/common/rpc/interceptor"
+	"go.temporal.io/server/nexusworkflowref"
 	"go.temporal.io/server/service/frontend/configs"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
@@ -231,11 +232,7 @@ func (h *nexusCompletionHandler) CompleteOperation(ctx context.Context, r *nexus
 		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid completion state")
 	}
 
-	if len(completion.GetComponentRef()) > 0 {
-		err = h.completeChasmOperation(ctx, logger, completion, successPayload, r, links)
-	} else {
-		err = h.completeHSMOperation(ctx, completion, successPayload, r, links)
-	}
+	err = h.completeOperation(ctx, logger, completion, successPayload, r, links, h.Config.EnableChasm(ns.Name().String()))
 	if err == nil {
 		return nil
 	}
@@ -249,6 +246,64 @@ func (h *nexusCompletionHandler) CompleteOperation(ctx context.Context, r *nexus
 		return commonnexus.ConvertGRPCError(err, true)
 	}
 	return commonnexus.ConvertGRPCError(err, false)
+}
+
+// completeOperation dispatches the completion to the framework its token targets (CHASM when a
+// ComponentRef is present, otherwise HSM). A rebuild (reset or conflict resolution) can flip an
+// operation between HSM and CHASM by dynamic config after the callback token was minted, so the
+// token's framework may no longer match the operation. If the operation was not found in its
+// original framework, the token is converted to the other framework and tried once more. Identity
+// is re-established by request ID, so the fallback only runs when the token carries one.
+//
+// chasmEnabled gates the HSM->CHASM direction: a workflow in a CHASM-disabled namespace has no
+// CHASM tree, so converting to CHASM would be futile (and the CHASM engine would flag it).
+func (h *nexusCompletionHandler) completeOperation(
+	ctx context.Context,
+	logger log.Logger,
+	completion *tokenspb.NexusOperationCompletion,
+	successPayload *commonpb.Payload,
+	req *nexusrpc.CompletionRequest,
+	links []*commonpb.Link,
+	chasmEnabled bool,
+) error {
+	isChasm := len(completion.GetComponentRef()) > 0
+	var err error
+	if isChasm {
+		err = h.completeChasmOperation(ctx, logger, completion, successPayload, req, links)
+	} else {
+		err = h.completeHSMOperation(ctx, completion, successPayload, req, links)
+	}
+	if _, notFound := errors.AsType[*serviceerror.NotFound](err); !notFound || completion.GetRequestId() == "" {
+		return err
+	}
+	// Converting HSM -> CHASM is only meaningful when the namespace has CHASM enabled (and thus a
+	// CHASM tree); CHASM -> HSM is always safe since HSM is the legacy default.
+	if !isChasm && !chasmEnabled {
+		return err
+	}
+	converted, convErr := convertCompletionToOtherFramework(completion)
+	if convErr != nil {
+		logger.Warn("failed to convert nexus completion token to the other framework", tag.Error(convErr))
+		return err
+	}
+	if isChasm {
+		return h.completeHSMOperation(ctx, converted, successPayload, req, links)
+	}
+	return h.completeChasmOperation(ctx, logger, converted, successPayload, req, links)
+}
+
+// convertCompletionToOtherFramework re-addresses a Nexus operation completion token to the
+// framework opposite the one it currently targets (HSM <-> CHASM).
+//
+// A rebuild (reset or conflict resolution) can re-create an operation under the other framework by
+// dynamic config after its callback token was minted — the intentional escape hatch to roll
+// operations back to HSM or forward to CHASM. The token then addresses the framework the operation
+// no longer lives in; converting it lets the completion be retried against the current one.
+func convertCompletionToOtherFramework(completion *tokenspb.NexusOperationCompletion) (*tokenspb.NexusOperationCompletion, error) {
+	if len(completion.GetComponentRef()) > 0 {
+		return nexusworkflowref.CHASMRefToHSMRef(completion)
+	}
+	return nexusworkflowref.HSMRefToCHASMRef(completion)
 }
 
 func (h *nexusCompletionHandler) completeHSMOperation(

--- a/service/frontend/nexus_completion_http_handler_test.go
+++ b/service/frontend/nexus_completion_http_handler_test.go
@@ -1,0 +1,179 @@
+package frontend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/api/historyservice/v1"
+	"go.temporal.io/server/api/historyservicemock/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	tokenspb "go.temporal.io/server/api/token/v1"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/nexus/nexusrpc"
+	"go.temporal.io/server/components/nexusoperations"
+	"go.temporal.io/server/nexusworkflowref"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc"
+)
+
+const convTestRequestID = "request-id"
+
+// hsmCompletionToken builds a minimal HSM-shaped token; chasmCompletionToken derives the CHASM-shaped
+// token from it via nexusworkflowref, so only the HSM ref layout is spelled out here.
+func hsmCompletionToken() *tokenspb.NexusOperationCompletion {
+	return &tokenspb.NexusOperationCompletion{
+		NamespaceId: "namespace-id",
+		WorkflowId:  "workflow-id",
+		RunId:       "run-id",
+		Ref: &persistencespb.StateMachineRef{
+			Path: []*persistencespb.StateMachineKey{{
+				Type: nexusoperations.OperationMachineType,
+				Id:   "42",
+			}},
+		},
+		RequestId: convTestRequestID,
+	}
+}
+
+func chasmCompletionToken(t *testing.T) *tokenspb.NexusOperationCompletion {
+	t.Helper()
+	completion, err := nexusworkflowref.HSMRefToCHASMRef(hsmCompletionToken())
+	require.NoError(t, err)
+	return completion
+}
+
+func TestConvertCompletionToOtherFramework(t *testing.T) {
+	t.Parallel()
+
+	// HSM token converts to a CHASM-shaped token (ComponentRef, no HSM ref).
+	toChasm, err := convertCompletionToOtherFramework(hsmCompletionToken())
+	require.NoError(t, err)
+	require.NotEmpty(t, toChasm.GetComponentRef())
+	require.Nil(t, toChasm.GetRef())
+	require.Equal(t, convTestRequestID, toChasm.GetRequestId())
+
+	// CHASM token converts to an HSM-shaped token (ref, no ComponentRef).
+	toHSM, err := convertCompletionToOtherFramework(chasmCompletionToken(t))
+	require.NoError(t, err)
+	require.NotNil(t, toHSM.GetRef())
+	require.Empty(t, toHSM.GetComponentRef())
+	require.Equal(t, convTestRequestID, toHSM.GetRequestId())
+}
+
+func TestCompleteOperation_FrameworkFallback(t *testing.T) {
+	t.Parallel()
+
+	notFound := serviceerror.NewNotFound("operation not found")
+	internalErr := serviceerror.NewInternal("boom")
+
+	testCases := []struct {
+		name string
+		// chasmDisabled models a CHASM-disabled namespace; it suppresses the HSM->CHASM fallback.
+		chasmDisabled bool
+		token         func(t *testing.T) *tokenspb.NexusOperationCompletion
+		setupClient   func(t *testing.T, client *historyservicemock.MockHistoryServiceClient)
+		wantErr       bool
+	}{
+		{
+			name:  "HSM primary succeeds, no fallback",
+			token: func(*testing.T) *tokenspb.NexusOperationCompletion { return hsmCompletionToken() },
+			setupClient: func(t *testing.T, client *historyservicemock.MockHistoryServiceClient) {
+				client.EXPECT().CompleteNexusOperation(gomock.Any(), gomock.Any()).
+					Return(&historyservice.CompleteNexusOperationResponse{}, nil)
+			},
+		},
+		{
+			name:  "HSM primary NotFound converts to CHASM and succeeds",
+			token: func(*testing.T) *tokenspb.NexusOperationCompletion { return hsmCompletionToken() },
+			setupClient: func(t *testing.T, client *historyservicemock.MockHistoryServiceClient) {
+				gomock.InOrder(
+					client.EXPECT().CompleteNexusOperation(gomock.Any(), gomock.Any()).
+						Return(nil, notFound),
+					client.EXPECT().CompleteNexusOperationChasm(gomock.Any(), gomock.Any()).
+						DoAndReturn(func(_ context.Context, req *historyservice.CompleteNexusOperationChasmRequest, _ ...grpc.CallOption) (*historyservice.CompleteNexusOperationChasmResponse, error) {
+							require.NotEmpty(t, req.GetCompletion().GetComponentRef())
+							require.Equal(t, convTestRequestID, req.GetCompletion().GetRequestId())
+							return &historyservice.CompleteNexusOperationChasmResponse{}, nil
+						}),
+				)
+			},
+		},
+		{
+			name:  "CHASM primary NotFound converts to HSM and succeeds",
+			token: chasmCompletionToken,
+			setupClient: func(t *testing.T, client *historyservicemock.MockHistoryServiceClient) {
+				gomock.InOrder(
+					client.EXPECT().CompleteNexusOperationChasm(gomock.Any(), gomock.Any()).
+						Return(nil, notFound),
+					client.EXPECT().CompleteNexusOperation(gomock.Any(), gomock.Any()).
+						DoAndReturn(func(_ context.Context, req *historyservice.CompleteNexusOperationRequest, _ ...grpc.CallOption) (*historyservice.CompleteNexusOperationResponse, error) {
+							require.NotNil(t, req.GetCompletion().GetRef())
+							return &historyservice.CompleteNexusOperationResponse{}, nil
+						}),
+				)
+			},
+		},
+		{
+			name:          "no HSM to CHASM fallback when chasm disabled for namespace",
+			chasmDisabled: true,
+			token:         func(*testing.T) *tokenspb.NexusOperationCompletion { return hsmCompletionToken() },
+			setupClient: func(t *testing.T, client *historyservicemock.MockHistoryServiceClient) {
+				client.EXPECT().CompleteNexusOperation(gomock.Any(), gomock.Any()).Return(nil, notFound)
+			},
+			wantErr: true,
+		},
+		{
+			name: "no fallback when token has no request ID",
+			token: func(*testing.T) *tokenspb.NexusOperationCompletion {
+				token := hsmCompletionToken()
+				token.RequestId = ""
+				return token
+			},
+			setupClient: func(t *testing.T, client *historyservicemock.MockHistoryServiceClient) {
+				client.EXPECT().CompleteNexusOperation(gomock.Any(), gomock.Any()).Return(nil, notFound)
+			},
+			wantErr: true,
+		},
+		{
+			name:  "no fallback on non-NotFound error",
+			token: func(*testing.T) *tokenspb.NexusOperationCompletion { return hsmCompletionToken() },
+			setupClient: func(t *testing.T, client *historyservicemock.MockHistoryServiceClient) {
+				client.EXPECT().CompleteNexusOperation(gomock.Any(), gomock.Any()).Return(nil, internalErr)
+			},
+			wantErr: true,
+		},
+		{
+			name:  "both frameworks NotFound returns NotFound",
+			token: func(*testing.T) *tokenspb.NexusOperationCompletion { return hsmCompletionToken() },
+			setupClient: func(t *testing.T, client *historyservicemock.MockHistoryServiceClient) {
+				gomock.InOrder(
+					client.EXPECT().CompleteNexusOperation(gomock.Any(), gomock.Any()).Return(nil, notFound),
+					client.EXPECT().CompleteNexusOperationChasm(gomock.Any(), gomock.Any()).Return(nil, notFound),
+				)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			client := historyservicemock.NewMockHistoryServiceClient(ctrl)
+			tc.setupClient(t, client)
+
+			h := &nexusCompletionHandler{HistoryClient: client}
+			req := &nexusrpc.CompletionRequest{State: nexus.OperationStateSucceeded, OperationToken: "operation-token"}
+
+			err := h.completeOperation(context.Background(), log.NewNoopLogger(), tc.token(t), &commonpb.Payload{}, req, nil, !tc.chasmDisabled)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/service/frontend/nexus_completion_http_handler_test.go
+++ b/service/frontend/nexus_completion_http_handler_test.go
@@ -22,8 +22,7 @@ import (
 
 const convTestRequestID = "request-id"
 
-// hsmCompletionToken builds a minimal HSM-shaped token; chasmCompletionToken derives the CHASM-shaped
-// token from it via nexusworkflowref, so only the HSM ref layout is spelled out here.
+// hsmCompletionToken builds the HSM token used by these conversion tests.
 func hsmCompletionToken() *tokenspb.NexusOperationCompletion {
 	return &tokenspb.NexusOperationCompletion{
 		NamespaceId: "namespace-id",
@@ -49,14 +48,14 @@ func chasmCompletionToken(t *testing.T) *tokenspb.NexusOperationCompletion {
 func TestConvertCompletionToOtherFramework(t *testing.T) {
 	t.Parallel()
 
-	// HSM token converts to a CHASM-shaped token (ComponentRef, no HSM ref).
+	// HSM -> CHASM.
 	toChasm, err := convertCompletionToOtherFramework(hsmCompletionToken())
 	require.NoError(t, err)
 	require.NotEmpty(t, toChasm.GetComponentRef())
 	require.Nil(t, toChasm.GetRef())
 	require.Equal(t, convTestRequestID, toChasm.GetRequestId())
 
-	// CHASM token converts to an HSM-shaped token (ref, no ComponentRef).
+	// CHASM -> HSM.
 	toHSM, err := convertCompletionToOtherFramework(chasmCompletionToken(t))
 	require.NoError(t, err)
 	require.NotNil(t, toHSM.GetRef())
@@ -72,7 +71,7 @@ func TestCompleteOperation_FrameworkFallback(t *testing.T) {
 
 	testCases := []struct {
 		name string
-		// chasmDisabled models a CHASM-disabled namespace; it suppresses the HSM->CHASM fallback.
+		// chasmDisabled suppresses the HSM -> CHASM fallback.
 		chasmDisabled bool
 		token         func(t *testing.T) *tokenspb.NexusOperationCompletion
 		setupClient   func(t *testing.T, client *historyservicemock.MockHistoryServiceClient)

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -2060,6 +2060,118 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAfterReset(cha
 	s.RequireHistoryEvent(resetHist, enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED)
 }
 
+// TestNexusOperationAsyncCompletionAfterFrameworkFlip asserts that an async completion whose
+// callback token was minted for one framework (HSM or CHASM) still completes the operation after a
+// rebuild re-created it in the other framework.
+//
+// A rebuild picks the framework by the nexusoperation.enableChasmWorkflowOperations flag at rebuild
+// time (an intentional escape hatch to roll operations back to HSM or forward to CHASM). The
+// callback token, minted at schedule time, then addresses the wrong framework: the completion
+// dispatcher tries the token's framework, gets NotFound, converts the token to the other framework,
+// and completes there. If the conversion did not happen the operation would never complete and the
+// reset run would hang — so the NexusOperationCompleted assertion is load-bearing.
+//
+// This exercises the reset rebuild's cross-tree routing, so like TestNexusOperationSurvivesResetCrossTree
+// it drives the flag explicitly and runs once via the HSM suite.
+func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAfterFrameworkFlip(chasmEnabled bool) {
+	if chasmEnabled {
+		s.T().Skip("framework-flip test controls the flag explicitly; run once via the HSM suite")
+	}
+
+	testCases := []struct {
+		name string
+		// enableChasmWorkflowOperations value at schedule time (true -> operation minted under CHASM,
+		// false -> under HSM). The flag is flipped before the reset so the rebuild re-creates the
+		// operation in the other framework, leaving the callback token addressing the original one.
+		enableChasmAtSchedule bool
+	}{
+		{name: "ChasmTokenCompletesHsmOpAfterDowngrade", enableChasmAtSchedule: true},
+		{name: "HsmTokenCompletesChasmOpAfterUpgrade", enableChasmAtSchedule: false},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func(s *NexusWorkflowTestSuite) {
+			env := s.newTestEnv(true)
+			ctx := s.Context()
+			taskQueue := testcore.RandomizeStr(s.T().Name())
+			env.OverrideDynamicConfig(chasmnexus.EnableChasmWorkflowOperations, tc.enableChasmAtSchedule)
+
+			var callbackToken, publicCallbackURL string
+			h := nexustest.Handler{
+				OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
+					callbackToken = options.CallbackHeader.Get(commonnexus.CallbackTokenHeader)
+					publicCallbackURL = options.CallbackURL
+					return &nexus.HandlerStartOperationResultAsync{OperationToken: "test"}, nil
+				},
+			}
+			endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
+
+			callerWF := func(ctx workflow.Context) (string, error) {
+				c := workflow.NewNexusClient(endpointName, "service")
+				fut := c.ExecuteOperation(ctx, "operation", "input", workflow.NexusOperationOptions{})
+				var result string
+				return result, fut.Get(ctx, &result)
+			}
+
+			w := worker.New(env.SdkClient(), taskQueue, worker.Options{})
+			w.RegisterWorkflow(callerWF)
+			s.NoError(w.Start())
+			defer w.Stop()
+
+			run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{TaskQueue: taskQueue}, callerWF)
+			s.NoError(err)
+			wfExec := &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: run.GetRunID()}
+
+			// Wait for the NexusOperationStarted event (captures the callback token) and find the WFT
+			// completed after it to use as the reset point.
+			var wftCompletedEventID int64
+			s.EventuallyWithT(func(t *assert.CollectT) {
+				hr := historyrequire.New(t)
+				hist := env.GetHistory(env.Namespace().String(), wfExec)
+				opStartedEvent := hr.RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED)
+				if opStartedEvent == nil {
+					return
+				}
+				wftCompletedIdx := slices.IndexFunc(hist, func(e *historypb.HistoryEvent) bool {
+					return e.EventType == enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED && e.EventId > opStartedEvent.EventId
+				})
+				require.Positive(t, wftCompletedIdx, "expected WorkflowTaskCompleted after NexusOperationStarted")
+				wftCompletedEventID = hist[wftCompletedIdx].EventId
+			}, time.Second*10, time.Millisecond*200)
+
+			// Flip the framework flag, then reset: the rebuild re-creates the operation in the other
+			// framework, so the callback token captured above now addresses the wrong one.
+			env.OverrideDynamicConfig(chasmnexus.EnableChasmWorkflowOperations, !tc.enableChasmAtSchedule)
+
+			resetResp, err := env.FrontendClient().ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
+				Namespace:                 env.Namespace().String(),
+				WorkflowExecution:         wfExec,
+				Reason:                    "test",
+				RequestId:                 uuid.NewString(),
+				WorkflowTaskFinishEventId: wftCompletedEventID,
+			})
+			s.NoError(err)
+
+			resetExec := &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: resetResp.RunId}
+			s.RequireHistoryEvent(env.GetHistory(env.Namespace().String(), resetExec), enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED)
+
+			// Deliver the stale completion. The dispatcher tries the token's original framework, gets
+			// NotFound (the operation now lives in the other framework), converts the token, and completes.
+			completion := nexusrpc.CompleteOperationOptions{
+				Result: testcore.MustToPayload(s.T(), "result"),
+				Header: nexus.Header{commonnexus.CallbackTokenHeader: callbackToken},
+			}
+			s.NoError(s.sendNexusCompletionRequest(ctx, publicCallbackURL, completion))
+
+			var result string
+			resetRun := env.SdkClient().GetWorkflow(ctx, run.GetID(), resetResp.RunId)
+			s.NoError(resetRun.Get(ctx, &result))
+			s.Equal("result", result)
+			s.RequireHistoryEvent(env.GetHistory(env.Namespace().String(), resetExec), enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED)
+		})
+	}
+}
+
 func (s *NexusWorkflowTestSuite) TestNexusAsyncOperationWithNilIO(chasmEnabled bool) {
 	if chasmEnabled {
 		s.T().Skip("Blocked on CHASM Nexus async completion with nil IO support")

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -2060,19 +2060,9 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAfterReset(cha
 	s.RequireHistoryEvent(resetHist, enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED)
 }
 
-// TestNexusOperationAsyncCompletionAfterFrameworkFlip asserts that an async completion whose
-// callback token was minted for one framework (HSM or CHASM) still completes the operation after a
-// rebuild re-created it in the other framework.
-//
-// A rebuild picks the framework by the nexusoperation.enableChasmWorkflowOperations flag at rebuild
-// time (an intentional escape hatch to roll operations back to HSM or forward to CHASM). The
-// callback token, minted at schedule time, then addresses the wrong framework: the completion
-// dispatcher tries the token's framework, gets NotFound, converts the token to the other framework,
-// and completes there. If the conversion did not happen the operation would never complete and the
-// reset run would hang — so the NexusOperationCompleted assertion is load-bearing.
-//
-// This exercises the reset rebuild's cross-tree routing, so like TestNexusOperationSurvivesResetCrossTree
-// it drives the flag explicitly and runs once via the HSM suite.
+// TestNexusOperationAsyncCompletionAfterFrameworkFlip verifies that a stale
+// callback token still completes after reset rebuilds the operation in the
+// other framework.
 func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAfterFrameworkFlip(chasmEnabled bool) {
 	if chasmEnabled {
 		s.T().Skip("framework-flip test controls the flag explicitly; run once via the HSM suite")
@@ -2080,9 +2070,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAfterFramework
 
 	testCases := []struct {
 		name string
-		// enableChasmWorkflowOperations value at schedule time (true -> operation minted under CHASM,
-		// false -> under HSM). The flag is flipped before the reset so the rebuild re-creates the
-		// operation in the other framework, leaving the callback token addressing the original one.
+		// enableChasmAtSchedule selects the framework used when the callback token is minted.
 		enableChasmAtSchedule bool
 	}{
 		{name: "ChasmTokenCompletesHsmOpAfterDowngrade", enableChasmAtSchedule: true},
@@ -2122,8 +2110,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAfterFramework
 			s.NoError(err)
 			wfExec := &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: run.GetRunID()}
 
-			// Wait for the NexusOperationStarted event (captures the callback token) and find the WFT
-			// completed after it to use as the reset point.
+			// Use the WFT after NexusOperationStarted as the reset point.
 			var wftCompletedEventID int64
 			s.EventuallyWithT(func(t *assert.CollectT) {
 				hr := historyrequire.New(t)
@@ -2139,8 +2126,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAfterFramework
 				wftCompletedEventID = hist[wftCompletedIdx].EventId
 			}, time.Second*10, time.Millisecond*200)
 
-			// Flip the framework flag, then reset: the rebuild re-creates the operation in the other
-			// framework, so the callback token captured above now addresses the wrong one.
+			// Flip the framework before reset so rebuild moves the operation.
 			env.OverrideDynamicConfig(chasmnexus.EnableChasmWorkflowOperations, !tc.enableChasmAtSchedule)
 
 			resetResp, err := env.FrontendClient().ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
@@ -2155,8 +2141,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAfterFramework
 			resetExec := &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: resetResp.RunId}
 			s.RequireHistoryEvent(env.GetHistory(env.Namespace().String(), resetExec), enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED)
 
-			// Deliver the stale completion. The dispatcher tries the token's original framework, gets
-			// NotFound (the operation now lives in the other framework), converts the token, and completes.
+			// Deliver the stale completion and expect the dispatcher to convert it.
 			completion := nexusrpc.CompleteOperationOptions{
 				Result: testcore.MustToPayload(s.T(), "result"),
 				Header: nexus.Header{commonnexus.CallbackTokenHeader: callbackToken},


### PR DESCRIPTION
## What changed?
On a `NotFound` from the framework a Nexus completion token targets, the frontend dispatcher converts the token to the other framework (HSM ↔ CHASM) and retries once. A reset/rebuild can re-create an operation under the other framework (by dynamic config) after its callback token was minted, leaving the token addressing the framework the operation no longer lives in.

Conversion goes through the `nexusworkflowref` package (#11050); identity is re-established by request ID, not versioned transitions. HSM→CHASM is only attempted when the namespace has CHASM enabled; CHASM→HSM is always attempted. Terminal errors (the workflow already completed or no longer exists) skip the retry, since the operation can't be applied in either framework.

## Why?
Extends the reset reapply's cross-tree routing (#10986) to the live-completion path. Without it, an async completion for an operation whose framework was flipped by a rebuild never lands.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

## Potential risks
Low. Confined to the frontend completion dispatcher, CHASM is only attempted when it is enabled for the namespace.