### PR TITLE
Fix Claude review label testing

### DIFF
--- a/.github/workflows/claude-review-teams.yml
+++ b/.github/workflows/claude-review-teams.yml
@@ -20,7 +20,18 @@ env:
 
 jobs:
   check-review-eligibility:
-    if: github.event.pull_request.draft == false
+    if: >-
+      (
+        github.event.action != 'labeled' &&
+        github.event.pull_request.draft == false
+      ) ||
+      (
+        github.event.action == 'labeled' &&
+        (
+          github.event.label.name == 'request-claude-review' ||
+          github.event.label.name == 'skip-claude-review'
+        )
+      )
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 2
     permissions: {} # uses the Temporal CI/CD Bot app token, not GITHUB_TOKEN
@@ -31,7 +42,7 @@ jobs:
     steps:
       - name: Generate app token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ secrets.TEMPORAL_AI_REVIEW_APP_ID }}
           private-key: ${{ secrets.TEMPORAL_AI_REVIEW_APP_PRIVATE_KEY }}
@@ -212,11 +223,18 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      pull-requests: write
-      issues: write
-      id-token: write
     steps:
       - uses: actions/checkout@v4
+      - name: Generate review app token
+        id: generate_review_token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.TEMPORAL_AI_REVIEW_APP_ID }}
+          private-key: ${{ secrets.TEMPORAL_AI_REVIEW_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: read
+          permission-pull-requests: write
+          permission-issues: write
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.check-review-eligibility.outputs.head_sha }}
@@ -224,6 +242,7 @@ jobs:
       - name: Claude PR review
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ steps.generate_review_token.outputs.token }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: ${{ github.event.action != 'labeled' }}
           prompt: |


### PR DESCRIPTION

Passes the Temporal AI Review app token to claude-code-action so it skips the failing Anthropic OIDC GitHub token exchange.