### PR TITLE
Add configurable latency thresholds for history health

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -260,6 +260,11 @@ response to a StartWorkflowExecution request and skipping the trip through match
 		5*time.Second,
 		`historyHealthSignalLatencyWindowSize is the time window size in seconds for aggregating latencies`,
 	)
+	HistoryHealthSignalPercentileLatencySettings = NewGlobalTypedSetting(
+		"system.historyHealthSignalPercentileLatencySettings",
+		LatencyHealthChecksPerPercentile{},
+		"historyHealthSignalPercentileLatencySettings controls what latency health checks are enabled and enforced for the history system",
+	)
 	// TODO: This should be removed once percentiles are the default.
 	HistoryHealthSignalUsePercentiles = NewGlobalBoolSetting(
 		"system.historyHealthSignalUsePercentiles",

--- a/common/dynamicconfig/shared_constants.go
+++ b/common/dynamicconfig/shared_constants.go
@@ -228,3 +228,19 @@ type SimplePartitionScalerThreshold struct {
 	Window     time.Duration // window to measure add rate over
 	TargetRate int           // target tasks/second per partition
 }
+
+type LatencyHealthCheckSettings struct {
+	// Percentile is a number from 0.00 to 1.00 which represents how far into the distribution we should look, eg 0.99 is p99.
+	Percentile float64
+
+	// Threshold is the amount of time this percentiles reading must exceed to trigger an unhealthy response (if enforced).
+	Threshold time.Duration
+
+	// Enforced allows this health check to return unhealthy responses, when false this health check will always report healthy.
+	Enforced bool
+}
+
+type LatencyHealthChecksPerPercentile struct {
+	// PercentileSettings stores settings for the health check of each percentile.
+	PercentileSettings []LatencyHealthCheckSettings
+}

--- a/common/rpc/interceptor/health_check.go
+++ b/common/rpc/interceptor/health_check.go
@@ -219,7 +219,7 @@ func (s *healthSignalAggregatorImpl) Record(latency time.Duration, err error) {
 }
 
 func (s *healthSignalAggregatorImpl) AverageLatency() float64 {
-	if !s.aggregatorEnabled() || s.percentilesEnabled() {
+	if !s.aggregatorEnabled() {
 		s.logger.Debug("health signal average aggregator is disabled")
 		return 0
 	}
@@ -227,7 +227,7 @@ func (s *healthSignalAggregatorImpl) AverageLatency() float64 {
 }
 
 func (s *healthSignalAggregatorImpl) LatencyQuantile(quantile float64) float64 {
-	if !s.aggregatorEnabled() || !s.percentilesEnabled() {
+	if !s.aggregatorEnabled() {
 		s.logger.Debug("health signal percentile aggregator is disabled")
 		return 0
 	}

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -415,6 +415,7 @@ type Config struct {
 	HealthPersistenceLatencyFailure dynamicconfig.FloatPropertyFn
 	HealthPersistenceErrorRatio     dynamicconfig.FloatPropertyFn
 	HealthRPCLatencyFailure         dynamicconfig.FloatPropertyFn
+	HealthRPCLatencyPercentiles     dynamicconfig.TypedPropertyFn[dynamicconfig.LatencyHealthChecksPerPercentile]
 	HealthRPCErrorRatio             dynamicconfig.FloatPropertyFn
 	HealthHistoryInitializationTime dynamicconfig.DurationPropertyFn
 	BreakdownMetricsByTaskQueue     dynamicconfig.BoolPropertyFnWithTaskQueueFilter
@@ -803,6 +804,7 @@ func NewConfig(
 		HealthPersistenceLatencyFailure: dynamicconfig.HealthPersistenceLatencyFailure.Get(dc),
 		HealthPersistenceErrorRatio:     dynamicconfig.HealthPersistenceErrorRatio.Get(dc),
 		HealthRPCLatencyFailure:         dynamicconfig.HealthRPCLatencyFailure.Get(dc),
+		HealthRPCLatencyPercentiles:     dynamicconfig.HistoryHealthSignalPercentileLatencySettings.Get(dc),
 		HealthRPCErrorRatio:             dynamicconfig.HealthRPCErrorRatio.Get(dc),
 		HealthHistoryInitializationTime: dynamicconfig.HealthHistoryInitializationTime.Get(dc),
 

--- a/service/history/deep_health_check.go
+++ b/service/history/deep_health_check.go
@@ -53,22 +53,32 @@ func (h *deepHealthCheckHandler) DeepHealthCheck(
 		Message: fmt.Sprintf("historyservice gRPC health check: %s", status.Status.String()),
 	})
 
-	// TODO: Remove AverageLatency check once Latency is used by default. It is fine to combine both for now since only one returns a non-zero value.
+	// TODO: Remove AverageLatency check once Latency is used by default.
 	checks = append(checks, errorIfOverThreshold(healthcheck.CheckTypeRPCLatency,
-		h.historyHealthSignal.AverageLatency()+h.historyHealthSignal.LatencyQuantile(0.99), h.config.HealthRPCLatencyFailure(),
-		"historyservice latency"))
+		h.historyHealthSignal.AverageLatency(), h.config.HealthRPCLatencyFailure(),
+		"historyservice latency", true))
+
+	for _, settings := range h.config.HealthRPCLatencyPercentiles().PercentileSettings {
+		checks = append(checks, errorIfOverThreshold(
+			healthcheck.CheckTypeRPCLatency+fmt.Sprintf("_P%0.2f", 100.0*settings.Percentile),
+			h.historyHealthSignal.LatencyQuantile(settings.Percentile),
+			float64(settings.Threshold.Milliseconds()),
+			fmt.Sprintf("historyservice percentile latency (P%0.2f < %d, enforced: %t)", 100.0*settings.Percentile, settings.Threshold.Milliseconds(), settings.Enforced),
+			settings.Enforced,
+		))
+	}
 
 	checks = append(checks, errorIfOverThreshold(healthcheck.CheckTypeRPCErrorRatio,
 		h.historyHealthSignal.ErrorRatio(), h.config.HealthRPCErrorRatio(),
-		"historyservice error ratio"))
+		"historyservice error ratio", true))
 
 	checks = append(checks, errorIfOverThreshold(healthcheck.CheckTypePersistenceLatency,
 		h.persistenceHealthSignal.AverageLatency(), h.config.HealthPersistenceLatencyFailure(),
-		"persistenceservice latency"))
+		"persistenceservice latency", true))
 
 	checks = append(checks, errorIfOverThreshold(healthcheck.CheckTypePersistenceErrRatio,
 		h.persistenceHealthSignal.ErrorRatio(), h.config.HealthPersistenceErrorRatio(),
-		"persistenceservice error ratio"))
+		"persistenceservice error ratio", true))
 
 	overallState := enumsspb.HEALTH_STATE_SERVING
 
@@ -96,9 +106,9 @@ func suppressStartupErrors(status grpchealthspb.HealthCheckResponse_ServingStatu
 	return toLocalHealthProto(status)
 }
 
-func errorIfOverThreshold(checkType string, value float64, threshold float64, message string) *healthspb.HealthCheck {
+func errorIfOverThreshold(checkType string, value float64, threshold float64, message string, enforced bool) *healthspb.HealthCheck {
 	state := enumsspb.HEALTH_STATE_SERVING
-	if value > threshold {
+	if value > threshold && enforced {
 		state = enumsspb.HEALTH_STATE_NOT_SERVING
 	}
 	return &healthspb.HealthCheck{

--- a/service/history/deep_health_check_test.go
+++ b/service/history/deep_health_check_test.go
@@ -9,6 +9,7 @@ import (
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	healthspb "go.temporal.io/server/api/health/v1"
 	"go.temporal.io/server/api/historyservice/v1"
+	"go.temporal.io/server/common/dynamicconfig"
 	health2 "go.temporal.io/server/common/health"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
@@ -26,14 +27,15 @@ func TestDeepHealthCheck(t *testing.T) {
 	}
 
 	testCases := []struct {
-		desc             string
-		timeSinceStartup time.Duration
-		grpcHealthStatus healthpb.HealthCheckResponse_ServingStatus
-		historyRecords   []record
-		persistRecords   []record
-		expected         *historyservice.DeepHealthCheckResponse
-		shouldError      bool
-		expectedError    string
+		desc                string
+		timeSinceStartup    time.Duration
+		percentilesEnforced bool
+		grpcHealthStatus    healthpb.HealthCheckResponse_ServingStatus
+		historyRecords      []record
+		persistRecords      []record
+		expected            *historyservice.DeepHealthCheckResponse
+		shouldError         bool
+		expectedError       string
 	}{
 		{
 			desc:             "all checks healthy",
@@ -61,6 +63,27 @@ func TestDeepHealthCheck(t *testing.T) {
 						Value:     100,
 						Threshold: 1000,
 						Message:   "historyservice latency",
+					},
+					{
+						CheckType: health2.CheckTypeRPCLatency + "_P99.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     100,
+						Threshold: 2000,
+						Message:   "historyservice percentile latency (P99.00 < 2000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypeRPCLatency + "_P90.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     100,
+						Threshold: 1000,
+						Message:   "historyservice percentile latency (P90.00 < 1000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypeRPCLatency + "_P50.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     100,
+						Threshold: 500,
+						Message:   "historyservice percentile latency (P50.00 < 500, enforced: false)",
 					},
 					{
 						CheckType: health2.CheckTypeRPCErrorRatio,
@@ -114,6 +137,27 @@ func TestDeepHealthCheck(t *testing.T) {
 						Message:   "historyservice latency",
 					},
 					{
+						CheckType: health2.CheckTypeRPCLatency + "_P99.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     100,
+						Threshold: 2000,
+						Message:   "historyservice percentile latency (P99.00 < 2000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypeRPCLatency + "_P90.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     100,
+						Threshold: 1000,
+						Message:   "historyservice percentile latency (P90.00 < 1000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypeRPCLatency + "_P50.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     100,
+						Threshold: 500,
+						Message:   "historyservice percentile latency (P50.00 < 500, enforced: false)",
+					},
+					{
 						CheckType: health2.CheckTypeRPCErrorRatio,
 						State:     enumsspb.HEALTH_STATE_SERVING,
 						Value:     0,
@@ -142,8 +186,8 @@ func TestDeepHealthCheck(t *testing.T) {
 			timeSinceStartup: 5 * time.Minute,
 			grpcHealthStatus: healthpb.HealthCheckResponse_SERVING,
 			historyRecords: []record{
-				{2 * time.Second, nil},
-				{2 * time.Second, nil},
+				{1500 * time.Millisecond, nil},
+				{1500 * time.Millisecond, nil},
 			},
 			persistRecords: []record{
 				{100 * time.Millisecond, context.DeadlineExceeded},
@@ -160,9 +204,103 @@ func TestDeepHealthCheck(t *testing.T) {
 					{
 						CheckType: health2.CheckTypeRPCLatency,
 						State:     enumsspb.HEALTH_STATE_NOT_SERVING,
-						Value:     2000,
+						Value:     1500,
 						Threshold: 1000,
 						Message:   "historyservice latency",
+					},
+					{
+						CheckType: health2.CheckTypeRPCLatency + "_P99.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     1500,
+						Threshold: 2000,
+						Message:   "historyservice percentile latency (P99.00 < 2000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypeRPCLatency + "_P90.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     1500,
+						Threshold: 1000,
+						Message:   "historyservice percentile latency (P90.00 < 1000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypeRPCLatency + "_P50.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     1500,
+						Threshold: 500,
+						Message:   "historyservice percentile latency (P50.00 < 500, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypeRPCErrorRatio,
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     0,
+						Threshold: 0.1,
+						Message:   "historyservice error ratio",
+					},
+					{
+						CheckType: health2.CheckTypePersistenceLatency,
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     100,
+						Threshold: 1000,
+						Message:   "persistenceservice latency",
+					},
+					{
+						CheckType: health2.CheckTypePersistenceErrRatio,
+						State:     enumsspb.HEALTH_STATE_NOT_SERVING,
+						Value:     1,
+						Threshold: 0.1,
+						Message:   "persistenceservice error ratio",
+					},
+				},
+			},
+		},
+		{
+			desc:                "rpc latency and persistence error ratio over thresholds, percentiles enforced",
+			timeSinceStartup:    5 * time.Minute,
+			percentilesEnforced: true,
+			grpcHealthStatus:    healthpb.HealthCheckResponse_SERVING,
+			historyRecords: []record{
+				{1500 * time.Millisecond, nil},
+				{1500 * time.Millisecond, nil},
+			},
+			persistRecords: []record{
+				{100 * time.Millisecond, context.DeadlineExceeded},
+				{100 * time.Millisecond, context.DeadlineExceeded},
+			},
+			expected: &historyservice.DeepHealthCheckResponse{
+				State: enumsspb.HEALTH_STATE_NOT_SERVING,
+				Checks: []*healthspb.HealthCheck{
+					{
+						CheckType: health2.CheckTypeGRPCHealth,
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Message:   "historyservice gRPC health check: SERVING",
+					},
+					{
+						CheckType: health2.CheckTypeRPCLatency,
+						State:     enumsspb.HEALTH_STATE_NOT_SERVING,
+						Value:     1500,
+						Threshold: 1000,
+						Message:   "historyservice latency",
+					},
+					{
+						CheckType: health2.CheckTypeRPCLatency + "_P99.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     1500,
+						Threshold: 2000,
+						Message:   "historyservice percentile latency (P99.00 < 2000, enforced: true)",
+					},
+					{
+						CheckType: health2.CheckTypeRPCLatency + "_P90.00",
+						State:     enumsspb.HEALTH_STATE_NOT_SERVING,
+						Value:     1500,
+						Threshold: 1000,
+						Message:   "historyservice percentile latency (P90.00 < 1000, enforced: true)",
+					},
+					{
+						CheckType: health2.CheckTypeRPCLatency + "_P50.00",
+						State:     enumsspb.HEALTH_STATE_NOT_SERVING,
+						Value:     1500,
+						Threshold: 500,
+						Message:   "historyservice percentile latency (P50.00 < 500, enforced: true)",
 					},
 					{
 						CheckType: health2.CheckTypeRPCErrorRatio,
@@ -216,6 +354,27 @@ func TestDeepHealthCheck(t *testing.T) {
 						Message:   "historyservice latency",
 					},
 					{
+						CheckType: health2.CheckTypeRPCLatency + "_P99.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     100,
+						Threshold: 2000,
+						Message:   "historyservice percentile latency (P99.00 < 2000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypeRPCLatency + "_P90.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     100,
+						Threshold: 1000,
+						Message:   "historyservice percentile latency (P90.00 < 1000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypeRPCLatency + "_P50.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     100,
+						Threshold: 500,
+						Message:   "historyservice percentile latency (P50.00 < 500, enforced: false)",
+					},
+					{
 						CheckType: health2.CheckTypeRPCErrorRatio,
 						State:     enumsspb.HEALTH_STATE_SERVING,
 						Value:     0,
@@ -267,6 +426,27 @@ func TestDeepHealthCheck(t *testing.T) {
 						Message:   "historyservice latency",
 					},
 					{
+						CheckType: health2.CheckTypeRPCLatency + "_P99.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     2000,
+						Threshold: 2000,
+						Message:   "historyservice percentile latency (P99.00 < 2000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypeRPCLatency + "_P90.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     2000,
+						Threshold: 1000,
+						Message:   "historyservice percentile latency (P90.00 < 1000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypeRPCLatency + "_P50.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     2000,
+						Threshold: 500,
+						Message:   "historyservice percentile latency (P50.00 < 500, enforced: false)",
+					},
+					{
 						CheckType: health2.CheckTypeRPCErrorRatio,
 						State:     enumsspb.HEALTH_STATE_SERVING,
 						Value:     0,
@@ -312,6 +492,27 @@ func TestDeepHealthCheck(t *testing.T) {
 						Message:   "historyservice latency",
 					},
 					{
+						CheckType: health2.CheckTypeRPCLatency + "_P99.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     0,
+						Threshold: 2000,
+						Message:   "historyservice percentile latency (P99.00 < 2000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypeRPCLatency + "_P90.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     0,
+						Threshold: 1000,
+						Message:   "historyservice percentile latency (P90.00 < 1000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypeRPCLatency + "_P50.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     0,
+						Threshold: 500,
+						Message:   "historyservice percentile latency (P50.00 < 500, enforced: false)",
+					},
+					{
 						CheckType: health2.CheckTypeRPCErrorRatio,
 						State:     enumsspb.HEALTH_STATE_SERVING,
 						Value:     0,
@@ -350,6 +551,27 @@ func TestDeepHealthCheck(t *testing.T) {
 					HealthPersistenceErrorRatio:     func() float64 { return 0.1 },
 					HealthRPCErrorRatio:             func() float64 { return 0.1 },
 					HealthHistoryInitializationTime: func() time.Duration { return time.Minute },
+					HealthRPCLatencyPercentiles: func() dynamicconfig.LatencyHealthChecksPerPercentile {
+						return dynamicconfig.LatencyHealthChecksPerPercentile{
+							PercentileSettings: []dynamicconfig.LatencyHealthCheckSettings{
+								{
+									Percentile: 0.99,
+									Threshold:  2 * time.Second,
+									Enforced:   tc.percentilesEnforced,
+								},
+								{
+									Percentile: 0.90,
+									Threshold:  1 * time.Second,
+									Enforced:   tc.percentilesEnforced,
+								},
+								{
+									Percentile: 0.50,
+									Threshold:  500 * time.Millisecond,
+									Enforced:   tc.percentilesEnforced,
+								},
+							},
+						}
+					},
 				},
 				historyHealthSignal:     interceptor.NewHealthSignalAggregator(testLogger, func() bool { return true }, func() bool { return true }, time.Second, 10, time.Second, 10),
 				persistenceHealthSignal: persistence.NewHealthSignalAggregator(true, time.Second, 100, metrics.NoopMetricsHandler, testLogger),


### PR DESCRIPTION
## What changed?
This adds configurable latency thresholds for history health checks so that we can dynamically change what percentiles we want to look at, as well as what values we want to alert on.

This also adds enforceability as a concept to the health checks so that we can have them reported in a safer way when testing.

## Why?
So we can test out different percentile settings and evaluate good defaults.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Changing health checks is always risky, but this adds a softer version of them so it should make things safer ultimately.
