### PR TITLE
Don't count backlog for persistence rate limited errors

### DIFF
--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -399,11 +399,11 @@ func (s *BacklogManagerTestSuite) TestApproximateBacklogCount_NotIncrementedBySp
 
 	s.blm.Start()
 	defer s.blm.Stop()
-	s.NoError(s.blm.WaitUntilInitialized(context.Background()))
+	s.Require().NoError(s.blm.WaitUntilInitialized(context.Background()))
 
 	s.ptqMgr.EXPECT().AddSpooledTask(gomock.Any()).Return(nil).AnyTimes()
 	for range 10 {
-		s.Error(s.blm.SpoolTask(&persistencespb.TaskInfo{
+		s.Require().Error(s.blm.SpoolTask(&persistencespb.TaskInfo{
 			ExpiryTime: timestamp.TimeNowPtrUtcAddSeconds(3000),
 			CreateTime: timestamp.TimeNowPtrUtc(),
 		}))
@@ -421,11 +421,11 @@ func (s *BacklogManagerTestSuite) TestApproximateBacklogCount_NotIncrementedBySp
 
 	s.blm.Start()
 	defer s.blm.Stop()
-	s.NoError(s.blm.WaitUntilInitialized(context.Background()))
+	s.Require().NoError(s.blm.WaitUntilInitialized(context.Background()))
 
 	s.ptqMgr.EXPECT().AddSpooledTask(gomock.Any()).Return(nil).AnyTimes()
 	for range 10 {
-		s.Error(s.blm.SpoolTask(&persistencespb.TaskInfo{
+		s.Require().Error(s.blm.SpoolTask(&persistencespb.TaskInfo{
 			ExpiryTime: timestamp.TimeNowPtrUtcAddSeconds(3000),
 			CreateTime: timestamp.TimeNowPtrUtc(),
 		}))

--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -391,6 +391,50 @@ func (s *BacklogManagerTestSuite) TestApproximateBacklogCount_NotIncrementedBySp
 		"backlog count should not be incremented")
 }
 
+func (s *BacklogManagerTestSuite) TestApproximateBacklogCount_NotIncrementedBySpoolTask_PersistenceLimit() {
+	// A write dropped by the persistence rate limiter definitely didn't reach the database,
+	// so it should not count towards the backlog.
+	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
+	s.taskMgr.addFault("CreateTasks", "PersistenceLimit", 1.0)
+
+	s.blm.Start()
+	defer s.blm.Stop()
+	s.NoError(s.blm.WaitUntilInitialized(context.Background()))
+
+	s.ptqMgr.EXPECT().AddSpooledTask(gomock.Any()).Return(nil).AnyTimes()
+	for range 10 {
+		s.Error(s.blm.SpoolTask(&persistencespb.TaskInfo{
+			ExpiryTime: timestamp.TimeNowPtrUtcAddSeconds(3000),
+			CreateTime: timestamp.TimeNowPtrUtc(),
+		}))
+	}
+
+	s.Equal(int64(0), totalApproximateBacklogCount(s.blm),
+		"backlog count should not be incremented for rate-limited writes")
+}
+
+func (s *BacklogManagerTestSuite) TestApproximateBacklogCount_NotIncrementedBySpoolTask_ConcurrentLimit() {
+	// A write rejected by the ConcurrentRequestLimiter interceptor definitely didn't reach the
+	// database, so it should not count towards the backlog.
+	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
+	s.taskMgr.addFault("CreateTasks", "ConcurrentLimit", 1.0)
+
+	s.blm.Start()
+	defer s.blm.Stop()
+	s.NoError(s.blm.WaitUntilInitialized(context.Background()))
+
+	s.ptqMgr.EXPECT().AddSpooledTask(gomock.Any()).Return(nil).AnyTimes()
+	for range 10 {
+		s.Error(s.blm.SpoolTask(&persistencespb.TaskInfo{
+			ExpiryTime: timestamp.TimeNowPtrUtcAddSeconds(3000),
+			CreateTime: timestamp.TimeNowPtrUtc(),
+		}))
+	}
+
+	s.Equal(int64(0), totalApproximateBacklogCount(s.blm),
+		"backlog count should not be incremented for concurrency-limited writes")
+}
+
 func (s *BacklogManagerTestSuite) TestApproximateBacklogCount_ResetOnDrained() {
 	if !s.newMatcher || s.fairness {
 		s.T().Skip("only for priority backlog manager")

--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -3,12 +3,14 @@ package matching
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"slices"
 	"sync"
 	"time"
 
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/log"
@@ -580,7 +582,7 @@ func (db *taskQueueDB) CreateTasks(
 		} else {
 			db.lastChange = time.Now()
 		}
-	} else if _, ok := err.(*persistence.ConditionFailedError); ok {
+	} else if writeDefinitelyFailed(err) {
 		// tasks definitely were not created, restore the counter. For other errors tasks may or may not be created.
 		// In those cases we keep the count incremented, hence it may be an overestimate.
 		for i, update := range updates {
@@ -656,7 +658,7 @@ func (db *taskQueueDB) CreateFairTasks(
 		} else {
 			db.lastChange = time.Now()
 		}
-	} else if _, ok := err.(*persistence.ConditionFailedError); ok {
+	} else if writeDefinitelyFailed(err) {
 		// Tasks definitely were not created, restore the counter. For other errors tasks may or may not be created.
 		// In those cases we keep the count incremented, hence it may be an overestimate.
 		// Don't bother restoring MaxReadLevel, it's okay if that's too high.
@@ -665,6 +667,28 @@ func (db *taskQueueDB) CreateFairTasks(
 		}
 	}
 	return newTasks, err
+}
+
+// writeDefinitelyFailed returns whether an error from a CreateTasks call indicates the tasks
+// were definitely not persisted, so that we can safely un-increment ApproximateBacklogCount.
+// We have to be conservative: for most errors (e.g. Unavailable) the write may or may not have
+// reached the database, so we leave the count incremented and accept a possible overestimate.
+// Only errors that reject the write before it reaches the database qualify:
+//   - ConditionFailedError: the range ID LWT failed, so the batch was rejected.
+//   - ResourceExhausted with a persistence rate-limit or concurrent-limit cause: dropped by
+//     the persistence rate limiter (see persistence.ErrPersistence*LimitExceeded).
+func writeDefinitelyFailed(err error) bool {
+	if _, ok := err.(*persistence.ConditionFailedError); ok {
+		return true
+	}
+	if re, ok := errors.AsType[*serviceerror.ResourceExhausted](err); ok {
+		switch re.Cause {
+		case enumspb.RESOURCE_EXHAUSTED_CAUSE_PERSISTENCE_LIMIT,
+			enumspb.RESOURCE_EXHAUSTED_CAUSE_CONCURRENT_LIMIT:
+			return true
+		}
+	}
+	return false
 }
 
 // GetTasks returns a batch of tasks between the given range

--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -682,7 +682,7 @@ func writeDefinitelyFailed(err error) bool {
 		return true
 	}
 	if re, ok := errors.AsType[*serviceerror.ResourceExhausted](err); ok {
-		switch re.Cause {
+		switch re.Cause { // nolint:exhaustive
 		case enumspb.RESOURCE_EXHAUSTED_CAUSE_PERSISTENCE_LIMIT,
 			enumspb.RESOURCE_EXHAUSTED_CAUSE_CONCURRENT_LIMIT:
 			return true

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -5414,6 +5414,14 @@ func (m *testTaskManager) CreateTasks(
 		return nil, &persistence.ConditionFailedError{Msg: "Fake ConditionFailedError"}
 	} else if m.fault("CreateTasks", "Unavailable") {
 		return nil, serviceerror.NewUnavailable("Fake Unavailable")
+	} else if m.fault("CreateTasks", "PersistenceLimit") {
+		return nil, persistence.ErrPersistenceNamespaceShardLimitExceeded
+	} else if m.fault("CreateTasks", "ConcurrentLimit") {
+		return nil, &serviceerror.ResourceExhausted{
+			Cause:   enumspb.RESOURCE_EXHAUSTED_CAUSE_CONCURRENT_LIMIT,
+			Scope:   enumspb.RESOURCE_EXHAUSTED_SCOPE_SYSTEM,
+			Message: "Fake concurrent request limit exceeded",
+		}
 	}
 
 	tlm := m.getQueueData(taskQueue, namespaceID, taskType)


### PR DESCRIPTION
## What changed?
If persistence returns a rate limited or concurrency limited error, we know that
the write couldn't have succeeded, so we should not leave backlog count
incremented.

## Why?
More accurate backlog count.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
