### PR TITLE
Add activity start-delay metadata for COGS tracking

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1010,7 +1010,7 @@ func (a *Activity) unpause(
 	ctx.AddTask(
 		a,
 		chasm.TaskAttributes{ScheduledTime: dispatchTime},
-		&activitypb.ActivityDispatchTask{Stamp: attempt.GetStamp()})
+		a.newActivityDispatchTask(ctx))
 }
 
 // unpauseDispatchTime computes when an unpaused attempt should be dispatched
@@ -1069,7 +1069,7 @@ func (a *Activity) reset(ctx chasm.MutableContext, event resetEvent) {
 	ctx.AddTask(
 		a,
 		chasm.TaskAttributes{ScheduledTime: dispatchTime},
-		&activitypb.ActivityDispatchTask{Stamp: attempt.GetStamp()},
+		a.newActivityDispatchTask(ctx),
 	)
 	a.emitOnResetMetrics(event.handler)
 }
@@ -1337,6 +1337,44 @@ func (a *Activity) firstDispatchTime() time.Time {
 	return a.ScheduleTime.AsTime().Add(a.GetStartDelay().AsDuration())
 }
 
+func (a *Activity) newActivityDispatchTask(ctx chasm.Context) *activitypb.ActivityDispatchTask {
+	dispatchReason := activitypb.ActivityDispatchTask_DISPATCH_REASON_IMMEDIATE
+	if a.GetFirstAttemptStartedTime() != nil {
+		dispatchReason = activitypb.ActivityDispatchTask_DISPATCH_REASON_RETRY
+	} else if a.GetStartDelay().AsDuration() > 0 {
+		dispatchReason = activitypb.ActivityDispatchTask_DISPATCH_REASON_START_DELAY
+	}
+
+	return &activitypb.ActivityDispatchTask{
+		Stamp:            a.LastAttempt.Get(ctx).GetStamp(),
+		DispatchReason:   dispatchReason,
+		StartDelayBucket: startDelayBucket(a.GetStartDelay().AsDuration()),
+	}
+}
+
+func startDelayBucket(delay time.Duration) activitypb.ActivityDispatchTask_StartDelayBucket {
+	switch {
+	case delay <= 0:
+		return activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE
+	case delay < time.Minute:
+		return activitypb.ActivityDispatchTask_START_DELAY_BUCKET_LT_1M
+	case delay < 10*time.Minute:
+		return activitypb.ActivityDispatchTask_START_DELAY_BUCKET_1M_10M
+	case delay < time.Hour:
+		return activitypb.ActivityDispatchTask_START_DELAY_BUCKET_10M_1H
+	case delay < 6*time.Hour:
+		return activitypb.ActivityDispatchTask_START_DELAY_BUCKET_1H_6H
+	case delay < 24*time.Hour:
+		return activitypb.ActivityDispatchTask_START_DELAY_BUCKET_6H_1D
+	case delay < 7*24*time.Hour:
+		return activitypb.ActivityDispatchTask_START_DELAY_BUCKET_1D_7D
+	case delay <= 30*24*time.Hour:
+		return activitypb.ActivityDispatchTask_START_DELAY_BUCKET_7D_30D
+	default:
+		return activitypb.ActivityDispatchTask_START_DELAY_BUCKET_GT_30D
+	}
+}
+
 // reissueDispatchAndScheduleToStart re-emits the ActivityDispatchTask and ScheduleToStart timeout task for
 // a SCHEDULED activity. Retries fire at the retry time; first attempts dispatch now, lifted to
 // honor any pending start_delay.
@@ -1351,7 +1389,7 @@ func (a *Activity) reissueDispatchAndScheduleToStart(ctx chasm.MutableContext, a
 	ctx.AddTask(
 		a,
 		chasm.TaskAttributes{ScheduledTime: dispatchTime},
-		&activitypb.ActivityDispatchTask{Stamp: attempt.GetStamp()},
+		a.newActivityDispatchTask(ctx),
 	)
 	if timeout := a.GetScheduleToStartTimeout().AsDuration(); timeout > 0 {
 		ctx.AddTask(

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1338,11 +1338,11 @@ func (a *Activity) firstDispatchTime() time.Time {
 }
 
 func (a *Activity) newActivityDispatchTask(ctx chasm.Context) *activitypb.ActivityDispatchTask {
-	dispatchReason := activitypb.ActivityDispatchTask_DISPATCH_REASON_IMMEDIATE
+	dispatchReason := activitypb.DISPATCH_REASON_IMMEDIATE
 	if a.GetFirstAttemptStartedTime() != nil {
-		dispatchReason = activitypb.ActivityDispatchTask_DISPATCH_REASON_RETRY
+		dispatchReason = activitypb.DISPATCH_REASON_RETRY
 	} else if a.GetStartDelay().AsDuration() > 0 {
-		dispatchReason = activitypb.ActivityDispatchTask_DISPATCH_REASON_START_DELAY
+		dispatchReason = activitypb.DISPATCH_REASON_START_DELAY
 	}
 
 	return &activitypb.ActivityDispatchTask{
@@ -1352,26 +1352,26 @@ func (a *Activity) newActivityDispatchTask(ctx chasm.Context) *activitypb.Activi
 	}
 }
 
-func startDelayBucket(delay time.Duration) activitypb.ActivityDispatchTask_StartDelayBucket {
+func startDelayBucket(delay time.Duration) activitypb.StartDelayBucket {
 	switch {
 	case delay <= 0:
-		return activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE
+		return activitypb.START_DELAY_BUCKET_NONE
 	case delay < time.Minute:
-		return activitypb.ActivityDispatchTask_START_DELAY_BUCKET_LT_1M
+		return activitypb.START_DELAY_BUCKET_LT_1M
 	case delay < 10*time.Minute:
-		return activitypb.ActivityDispatchTask_START_DELAY_BUCKET_1M_10M
+		return activitypb.START_DELAY_BUCKET_1M_10M
 	case delay < time.Hour:
-		return activitypb.ActivityDispatchTask_START_DELAY_BUCKET_10M_1H
+		return activitypb.START_DELAY_BUCKET_10M_1H
 	case delay < 6*time.Hour:
-		return activitypb.ActivityDispatchTask_START_DELAY_BUCKET_1H_6H
+		return activitypb.START_DELAY_BUCKET_1H_6H
 	case delay < 24*time.Hour:
-		return activitypb.ActivityDispatchTask_START_DELAY_BUCKET_6H_1D
+		return activitypb.START_DELAY_BUCKET_6H_1D
 	case delay < 7*24*time.Hour:
-		return activitypb.ActivityDispatchTask_START_DELAY_BUCKET_1D_7D
+		return activitypb.START_DELAY_BUCKET_1D_7D
 	case delay <= 30*24*time.Hour:
-		return activitypb.ActivityDispatchTask_START_DELAY_BUCKET_7D_30D
+		return activitypb.START_DELAY_BUCKET_7D_30D
 	default:
-		return activitypb.ActivityDispatchTask_START_DELAY_BUCKET_GT_30D
+		return activitypb.START_DELAY_BUCKET_GT_30D
 	}
 }
 

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -72,6 +72,85 @@ func TestSearchAttributesIncludesExecutionTime(t *testing.T) {
 	}
 }
 
+func TestStartDelayBucket(t *testing.T) {
+	testCases := []struct {
+		name     string
+		delay    time.Duration
+		expected activitypb.ActivityDispatchTask_StartDelayBucket
+	}{
+		{name: "negative", delay: -time.Second, expected: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE},
+		{name: "zero", delay: 0, expected: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE},
+		{name: "less than one minute", delay: time.Minute - time.Nanosecond, expected: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_LT_1M},
+		{name: "one minute", delay: time.Minute, expected: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_1M_10M},
+		{name: "ten minutes", delay: 10 * time.Minute, expected: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_10M_1H},
+		{name: "one hour", delay: time.Hour, expected: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_1H_6H},
+		{name: "six hours", delay: 6 * time.Hour, expected: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_6H_1D},
+		{name: "one day", delay: 24 * time.Hour, expected: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_1D_7D},
+		{name: "seven days", delay: 7 * 24 * time.Hour, expected: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_7D_30D},
+		{name: "thirty days", delay: 30 * 24 * time.Hour, expected: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_7D_30D},
+		{name: "more than thirty days", delay: 30*24*time.Hour + time.Nanosecond, expected: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_GT_30D},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, startDelayBucket(tc.delay))
+		})
+	}
+}
+
+func TestNewActivityDispatchTask(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		startDelay              time.Duration
+		firstAttemptStartedTime *timestamppb.Timestamp
+		expectedReason          activitypb.ActivityDispatchTask_DispatchReason
+		expectedBucket          activitypb.ActivityDispatchTask_StartDelayBucket
+	}{
+		{
+			name:           "immediate",
+			expectedReason: activitypb.ActivityDispatchTask_DISPATCH_REASON_IMMEDIATE,
+			expectedBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE,
+		},
+		{
+			name:           "start delay",
+			startDelay:     time.Hour,
+			expectedReason: activitypb.ActivityDispatchTask_DISPATCH_REASON_START_DELAY,
+			expectedBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_1H_6H,
+		},
+		{
+			name:                    "retry without configured start delay",
+			firstAttemptStartedTime: timestamppb.Now(),
+			expectedReason:          activitypb.ActivityDispatchTask_DISPATCH_REASON_RETRY,
+			expectedBucket:          activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE,
+		},
+		{
+			name:                    "retry preserves configured start delay bucket",
+			startDelay:              time.Hour,
+			firstAttemptStartedTime: timestamppb.Now(),
+			expectedReason:          activitypb.ActivityDispatchTask_DISPATCH_REASON_RETRY,
+			expectedBucket:          activitypb.ActivityDispatchTask_START_DELAY_BUCKET_1H_6H,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := &chasm.MockMutableContext{}
+			activity := &Activity{
+				ActivityState: &activitypb.ActivityState{
+					StartDelay:              durationpb.New(tc.startDelay),
+					FirstAttemptStartedTime: tc.firstAttemptStartedTime,
+				},
+				LastAttempt: chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{Stamp: 1}),
+			}
+
+			task := activity.newActivityDispatchTask(ctx)
+			require.Equal(t, int32(1), task.GetStamp())
+			require.Equal(t, tc.expectedReason, task.GetDispatchReason())
+			require.Equal(t, tc.expectedBucket, task.GetStartDelayBucket())
+		})
+	}
+}
+
 func TestHandleStarted(t *testing.T) {
 	testTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 	testRequestID := "test-request-id"

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -76,19 +76,19 @@ func TestStartDelayBucket(t *testing.T) {
 	testCases := []struct {
 		name     string
 		delay    time.Duration
-		expected activitypb.ActivityDispatchTask_StartDelayBucket
+		expected activitypb.StartDelayBucket
 	}{
-		{name: "negative", delay: -time.Second, expected: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE},
-		{name: "zero", delay: 0, expected: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE},
-		{name: "less than one minute", delay: time.Minute - time.Nanosecond, expected: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_LT_1M},
-		{name: "one minute", delay: time.Minute, expected: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_1M_10M},
-		{name: "ten minutes", delay: 10 * time.Minute, expected: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_10M_1H},
-		{name: "one hour", delay: time.Hour, expected: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_1H_6H},
-		{name: "six hours", delay: 6 * time.Hour, expected: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_6H_1D},
-		{name: "one day", delay: 24 * time.Hour, expected: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_1D_7D},
-		{name: "seven days", delay: 7 * 24 * time.Hour, expected: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_7D_30D},
-		{name: "thirty days", delay: 30 * 24 * time.Hour, expected: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_7D_30D},
-		{name: "more than thirty days", delay: 30*24*time.Hour + time.Nanosecond, expected: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_GT_30D},
+		{name: "negative", delay: -time.Second, expected: activitypb.START_DELAY_BUCKET_NONE},
+		{name: "zero", delay: 0, expected: activitypb.START_DELAY_BUCKET_NONE},
+		{name: "less than one minute", delay: time.Minute - time.Nanosecond, expected: activitypb.START_DELAY_BUCKET_LT_1M},
+		{name: "one minute", delay: time.Minute, expected: activitypb.START_DELAY_BUCKET_1M_10M},
+		{name: "ten minutes", delay: 10 * time.Minute, expected: activitypb.START_DELAY_BUCKET_10M_1H},
+		{name: "one hour", delay: time.Hour, expected: activitypb.START_DELAY_BUCKET_1H_6H},
+		{name: "six hours", delay: 6 * time.Hour, expected: activitypb.START_DELAY_BUCKET_6H_1D},
+		{name: "one day", delay: 24 * time.Hour, expected: activitypb.START_DELAY_BUCKET_1D_7D},
+		{name: "seven days", delay: 7 * 24 * time.Hour, expected: activitypb.START_DELAY_BUCKET_7D_30D},
+		{name: "thirty days", delay: 30 * 24 * time.Hour, expected: activitypb.START_DELAY_BUCKET_7D_30D},
+		{name: "more than thirty days", delay: 30*24*time.Hour + time.Nanosecond, expected: activitypb.START_DELAY_BUCKET_GT_30D},
 	}
 
 	for _, tc := range testCases {
@@ -103,32 +103,32 @@ func TestNewActivityDispatchTask(t *testing.T) {
 		name                    string
 		startDelay              time.Duration
 		firstAttemptStartedTime *timestamppb.Timestamp
-		expectedReason          activitypb.ActivityDispatchTask_DispatchReason
-		expectedBucket          activitypb.ActivityDispatchTask_StartDelayBucket
+		expectedReason          activitypb.DispatchReason
+		expectedBucket          activitypb.StartDelayBucket
 	}{
 		{
 			name:           "immediate",
-			expectedReason: activitypb.ActivityDispatchTask_DISPATCH_REASON_IMMEDIATE,
-			expectedBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE,
+			expectedReason: activitypb.DISPATCH_REASON_IMMEDIATE,
+			expectedBucket: activitypb.START_DELAY_BUCKET_NONE,
 		},
 		{
 			name:           "start delay",
 			startDelay:     time.Hour,
-			expectedReason: activitypb.ActivityDispatchTask_DISPATCH_REASON_START_DELAY,
-			expectedBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_1H_6H,
+			expectedReason: activitypb.DISPATCH_REASON_START_DELAY,
+			expectedBucket: activitypb.START_DELAY_BUCKET_1H_6H,
 		},
 		{
 			name:                    "retry without configured start delay",
 			firstAttemptStartedTime: timestamppb.Now(),
-			expectedReason:          activitypb.ActivityDispatchTask_DISPATCH_REASON_RETRY,
-			expectedBucket:          activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE,
+			expectedReason:          activitypb.DISPATCH_REASON_RETRY,
+			expectedBucket:          activitypb.START_DELAY_BUCKET_NONE,
 		},
 		{
 			name:                    "retry preserves configured start delay bucket",
 			startDelay:              time.Hour,
 			firstAttemptStartedTime: timestamppb.Now(),
-			expectedReason:          activitypb.ActivityDispatchTask_DISPATCH_REASON_RETRY,
-			expectedBucket:          activitypb.ActivityDispatchTask_START_DELAY_BUCKET_1H_6H,
+			expectedReason:          activitypb.DISPATCH_REASON_RETRY,
+			expectedBucket:          activitypb.START_DELAY_BUCKET_1H_6H,
 		},
 	}
 

--- a/chasm/lib/activity/gen/activitypb/v1/tasks.go-helpers.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/tasks.go-helpers.pb.go
@@ -2,6 +2,8 @@
 package activitypb
 
 import (
+	"fmt"
+
 	"google.golang.org/protobuf/proto"
 )
 
@@ -188,4 +190,50 @@ func (this *HeartbeatTimeoutTask) Equal(that interface{}) bool {
 	}
 
 	return proto.Equal(this, that1)
+}
+
+var (
+	DispatchReason_shorthandValue = map[string]int32{
+		"Unspecified": 0,
+		"Immediate":   1,
+		"StartDelay":  2,
+		"Retry":       3,
+	}
+)
+
+// DispatchReasonFromString parses a DispatchReason value from  either the protojson
+// canonical SCREAMING_CASE enum or the traditional temporal PascalCase enum to DispatchReason
+func DispatchReasonFromString(s string) (DispatchReason, error) {
+	if v, ok := DispatchReason_value[s]; ok {
+		return DispatchReason(v), nil
+	} else if v, ok := DispatchReason_shorthandValue[s]; ok {
+		return DispatchReason(v), nil
+	}
+	return DispatchReason(0), fmt.Errorf("%s is not a valid DispatchReason", s)
+}
+
+var (
+	StartDelayBucket_shorthandValue = map[string]int32{
+		"Unspecified": 0,
+		"None":        1,
+		"Lt1M":        2,
+		"1M10M":       3,
+		"10M1H":       4,
+		"1H6H":        5,
+		"6H1D":        6,
+		"1D7D":        7,
+		"7D30D":       8,
+		"Gt30D":       9,
+	}
+)
+
+// StartDelayBucketFromString parses a StartDelayBucket value from  either the protojson
+// canonical SCREAMING_CASE enum or the traditional temporal PascalCase enum to StartDelayBucket
+func StartDelayBucketFromString(s string) (StartDelayBucket, error) {
+	if v, ok := StartDelayBucket_value[s]; ok {
+		return StartDelayBucket(v), nil
+	} else if v, ok := StartDelayBucket_shorthandValue[s]; ok {
+		return StartDelayBucket(v), nil
+	}
+	return StartDelayBucket(0), fmt.Errorf("%s is not a valid StartDelayBucket", s)
 }

--- a/chasm/lib/activity/gen/activitypb/v1/tasks.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/tasks.pb.go
@@ -8,6 +8,7 @@ package activitypb
 
 import (
 	reflect "reflect"
+	"strconv"
 	sync "sync"
 	unsafe "unsafe"
 
@@ -22,12 +23,177 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type ActivityDispatchTask_DispatchReason int32
+
+const (
+	ActivityDispatchTask_DISPATCH_REASON_UNSPECIFIED ActivityDispatchTask_DispatchReason = 0
+	ActivityDispatchTask_DISPATCH_REASON_IMMEDIATE   ActivityDispatchTask_DispatchReason = 1
+	ActivityDispatchTask_DISPATCH_REASON_START_DELAY ActivityDispatchTask_DispatchReason = 2
+	ActivityDispatchTask_DISPATCH_REASON_RETRY       ActivityDispatchTask_DispatchReason = 3
+)
+
+// Enum value maps for ActivityDispatchTask_DispatchReason.
+var (
+	ActivityDispatchTask_DispatchReason_name = map[int32]string{
+		0: "DISPATCH_REASON_UNSPECIFIED",
+		1: "DISPATCH_REASON_IMMEDIATE",
+		2: "DISPATCH_REASON_START_DELAY",
+		3: "DISPATCH_REASON_RETRY",
+	}
+	ActivityDispatchTask_DispatchReason_value = map[string]int32{
+		"DISPATCH_REASON_UNSPECIFIED": 0,
+		"DISPATCH_REASON_IMMEDIATE":   1,
+		"DISPATCH_REASON_START_DELAY": 2,
+		"DISPATCH_REASON_RETRY":       3,
+	}
+)
+
+func (x ActivityDispatchTask_DispatchReason) Enum() *ActivityDispatchTask_DispatchReason {
+	p := new(ActivityDispatchTask_DispatchReason)
+	*p = x
+	return p
+}
+
+func (x ActivityDispatchTask_DispatchReason) String() string {
+	switch x {
+	case ActivityDispatchTask_DISPATCH_REASON_UNSPECIFIED:
+		return "ActivityDispatchTaskDispatchReasonUnspecified"
+	case ActivityDispatchTask_DISPATCH_REASON_IMMEDIATE:
+		return "ActivityDispatchTaskDispatchReasonImmediate"
+	case ActivityDispatchTask_DISPATCH_REASON_START_DELAY:
+		return "ActivityDispatchTaskDispatchReasonStartDelay"
+	case ActivityDispatchTask_DISPATCH_REASON_RETRY:
+		return "ActivityDispatchTaskDispatchReasonRetry"
+	default:
+		return strconv.Itoa(int(x))
+	}
+
+}
+
+func (ActivityDispatchTask_DispatchReason) Descriptor() protoreflect.EnumDescriptor {
+	return file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_enumTypes[0].Descriptor()
+}
+
+func (ActivityDispatchTask_DispatchReason) Type() protoreflect.EnumType {
+	return &file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_enumTypes[0]
+}
+
+func (x ActivityDispatchTask_DispatchReason) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ActivityDispatchTask_DispatchReason.Descriptor instead.
+func (ActivityDispatchTask_DispatchReason) EnumDescriptor() ([]byte, []int) {
+	return file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_rawDescGZIP(), []int{0, 0}
+}
+
+type ActivityDispatchTask_StartDelayBucket int32
+
+const (
+	ActivityDispatchTask_START_DELAY_BUCKET_UNSPECIFIED ActivityDispatchTask_StartDelayBucket = 0
+	ActivityDispatchTask_START_DELAY_BUCKET_NONE        ActivityDispatchTask_StartDelayBucket = 1
+	ActivityDispatchTask_START_DELAY_BUCKET_LT_1M       ActivityDispatchTask_StartDelayBucket = 2
+	ActivityDispatchTask_START_DELAY_BUCKET_1M_10M      ActivityDispatchTask_StartDelayBucket = 3
+	ActivityDispatchTask_START_DELAY_BUCKET_10M_1H      ActivityDispatchTask_StartDelayBucket = 4
+	ActivityDispatchTask_START_DELAY_BUCKET_1H_6H       ActivityDispatchTask_StartDelayBucket = 5
+	ActivityDispatchTask_START_DELAY_BUCKET_6H_1D       ActivityDispatchTask_StartDelayBucket = 6
+	ActivityDispatchTask_START_DELAY_BUCKET_1D_7D       ActivityDispatchTask_StartDelayBucket = 7
+	ActivityDispatchTask_START_DELAY_BUCKET_7D_30D      ActivityDispatchTask_StartDelayBucket = 8
+	ActivityDispatchTask_START_DELAY_BUCKET_GT_30D      ActivityDispatchTask_StartDelayBucket = 9
+)
+
+// Enum value maps for ActivityDispatchTask_StartDelayBucket.
+var (
+	ActivityDispatchTask_StartDelayBucket_name = map[int32]string{
+		0: "START_DELAY_BUCKET_UNSPECIFIED",
+		1: "START_DELAY_BUCKET_NONE",
+		2: "START_DELAY_BUCKET_LT_1M",
+		3: "START_DELAY_BUCKET_1M_10M",
+		4: "START_DELAY_BUCKET_10M_1H",
+		5: "START_DELAY_BUCKET_1H_6H",
+		6: "START_DELAY_BUCKET_6H_1D",
+		7: "START_DELAY_BUCKET_1D_7D",
+		8: "START_DELAY_BUCKET_7D_30D",
+		9: "START_DELAY_BUCKET_GT_30D",
+	}
+	ActivityDispatchTask_StartDelayBucket_value = map[string]int32{
+		"START_DELAY_BUCKET_UNSPECIFIED": 0,
+		"START_DELAY_BUCKET_NONE":        1,
+		"START_DELAY_BUCKET_LT_1M":       2,
+		"START_DELAY_BUCKET_1M_10M":      3,
+		"START_DELAY_BUCKET_10M_1H":      4,
+		"START_DELAY_BUCKET_1H_6H":       5,
+		"START_DELAY_BUCKET_6H_1D":       6,
+		"START_DELAY_BUCKET_1D_7D":       7,
+		"START_DELAY_BUCKET_7D_30D":      8,
+		"START_DELAY_BUCKET_GT_30D":      9,
+	}
+)
+
+func (x ActivityDispatchTask_StartDelayBucket) Enum() *ActivityDispatchTask_StartDelayBucket {
+	p := new(ActivityDispatchTask_StartDelayBucket)
+	*p = x
+	return p
+}
+
+func (x ActivityDispatchTask_StartDelayBucket) String() string {
+	switch x {
+	case ActivityDispatchTask_START_DELAY_BUCKET_UNSPECIFIED:
+		return "ActivityDispatchTaskStartDelayBucketUnspecified"
+	case ActivityDispatchTask_START_DELAY_BUCKET_NONE:
+		return "ActivityDispatchTaskStartDelayBucketNone"
+	case ActivityDispatchTask_START_DELAY_BUCKET_LT_1M:
+		return "ActivityDispatchTaskStartDelayBucketLt1M"
+	case ActivityDispatchTask_START_DELAY_BUCKET_1M_10M:
+		return "ActivityDispatchTaskStartDelayBucket1M10M"
+	case ActivityDispatchTask_START_DELAY_BUCKET_10M_1H:
+		return "ActivityDispatchTaskStartDelayBucket10M1H"
+	case ActivityDispatchTask_START_DELAY_BUCKET_1H_6H:
+
+		// Deprecated: Use ActivityDispatchTask_StartDelayBucket.Descriptor instead.
+		return "ActivityDispatchTaskStartDelayBucket1H6H"
+	case ActivityDispatchTask_START_DELAY_BUCKET_6H_1D:
+		return "ActivityDispatchTaskStartDelayBucket6H1D"
+	case ActivityDispatchTask_START_DELAY_BUCKET_1D_7D:
+		return "ActivityDispatchTaskStartDelayBucket1D7D"
+	case ActivityDispatchTask_START_DELAY_BUCKET_7D_30D:
+		return "ActivityDispatchTaskStartDelayBucket7D30D"
+
+		// The current stamp for this activity execution. Used for task validation. See also [ActivityAttemptState].
+	case ActivityDispatchTask_START_DELAY_BUCKET_GT_30D:
+		return "ActivityDispatchTaskStartDelayBucketGt30D"
+	default:
+		return strconv.Itoa(int(x))
+	}
+
+}
+
+func (ActivityDispatchTask_StartDelayBucket) Descriptor() protoreflect.EnumDescriptor {
+	return file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_enumTypes[1].Descriptor()
+}
+
+func (ActivityDispatchTask_StartDelayBucket) Type() protoreflect.EnumType {
+	return &file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_enumTypes[1]
+}
+
+func (x ActivityDispatchTask_StartDelayBucket) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+func (ActivityDispatchTask_StartDelayBucket) EnumDescriptor() ([]byte, []int) {
+	return file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_rawDescGZIP(), []int{0, 1}
+}
+
 type ActivityDispatchTask struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// The current stamp for this activity execution. Used for task validation. See also [ActivityAttemptState].
-	Stamp         int32 `protobuf:"varint,1,opt,name=stamp,proto3" json:"stamp,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+
+	Stamp int32 `protobuf:"varint,1,opt,name=stamp,proto3" json:"stamp,omitempty"`
+	// Dispatch category based on attempt history and the configured start delay.
+	DispatchReason ActivityDispatchTask_DispatchReason `protobuf:"varint,2,opt,name=dispatch_reason,json=dispatchReason,proto3,enum=temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask_DispatchReason" json:"dispatch_reason,omitempty"`
+	// Bucket for the configured start delay, independent of actual dispatch time.
+	StartDelayBucket ActivityDispatchTask_StartDelayBucket `protobuf:"varint,3,opt,name=start_delay_bucket,json=startDelayBucket,proto3,enum=temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask_StartDelayBucket" json:"start_delay_bucket,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *ActivityDispatchTask) Reset() {
@@ -65,6 +231,20 @@ func (x *ActivityDispatchTask) GetStamp() int32 {
 		return x.Stamp
 	}
 	return 0
+}
+
+func (x *ActivityDispatchTask) GetDispatchReason() ActivityDispatchTask_DispatchReason {
+	if x != nil {
+		return x.DispatchReason
+	}
+	return ActivityDispatchTask_DISPATCH_REASON_UNSPECIFIED
+}
+
+func (x *ActivityDispatchTask) GetStartDelayBucket() ActivityDispatchTask_StartDelayBucket {
+	if x != nil {
+		return x.StartDelayBucket
+	}
+	return ActivityDispatchTask_START_DELAY_BUCKET_UNSPECIFIED
 }
 
 type ScheduleToStartTimeoutTask struct {
@@ -254,9 +434,27 @@ var File_temporal_server_chasm_lib_activity_proto_v1_tasks_proto protoreflect.Fi
 
 const file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_rawDesc = "" +
 	"\n" +
-	"7temporal/server/chasm/lib/activity/proto/v1/tasks.proto\x12+temporal.server.chasm.lib.activity.proto.v1\",\n" +
+	"7temporal/server/chasm/lib/activity/proto/v1/tasks.proto\x12+temporal.server.chasm.lib.activity.proto.v1\"\x83\x06\n" +
 	"\x14ActivityDispatchTask\x12\x14\n" +
-	"\x05stamp\x18\x01 \x01(\x05R\x05stamp\"2\n" +
+	"\x05stamp\x18\x01 \x01(\x05R\x05stamp\x12y\n" +
+	"\x0fdispatch_reason\x18\x02 \x01(\x0e2P.temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask.DispatchReasonR\x0edispatchReason\x12\x80\x01\n" +
+	"\x12start_delay_bucket\x18\x03 \x01(\x0e2R.temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask.StartDelayBucketR\x10startDelayBucket\"\x8c\x01\n" +
+	"\x0eDispatchReason\x12\x1f\n" +
+	"\x1bDISPATCH_REASON_UNSPECIFIED\x10\x00\x12\x1d\n" +
+	"\x19DISPATCH_REASON_IMMEDIATE\x10\x01\x12\x1f\n" +
+	"\x1bDISPATCH_REASON_START_DELAY\x10\x02\x12\x19\n" +
+	"\x15DISPATCH_REASON_RETRY\x10\x03\"\xc7\x02\n" +
+	"\x10StartDelayBucket\x12\"\n" +
+	"\x1eSTART_DELAY_BUCKET_UNSPECIFIED\x10\x00\x12\x1b\n" +
+	"\x17START_DELAY_BUCKET_NONE\x10\x01\x12\x1c\n" +
+	"\x18START_DELAY_BUCKET_LT_1M\x10\x02\x12\x1d\n" +
+	"\x19START_DELAY_BUCKET_1M_10M\x10\x03\x12\x1d\n" +
+	"\x19START_DELAY_BUCKET_10M_1H\x10\x04\x12\x1c\n" +
+	"\x18START_DELAY_BUCKET_1H_6H\x10\x05\x12\x1c\n" +
+	"\x18START_DELAY_BUCKET_6H_1D\x10\x06\x12\x1c\n" +
+	"\x18START_DELAY_BUCKET_1D_7D\x10\a\x12\x1d\n" +
+	"\x19START_DELAY_BUCKET_7D_30D\x10\b\x12\x1d\n" +
+	"\x19START_DELAY_BUCKET_GT_30D\x10\t\"2\n" +
 	"\x1aScheduleToStartTimeoutTask\x12\x14\n" +
 	"\x05stamp\x18\x01 \x01(\x05R\x05stamp\"2\n" +
 	"\x1aScheduleToCloseTimeoutTask\x12\x14\n" +
@@ -278,20 +476,25 @@ func file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_rawDescGZIP() 
 	return file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_rawDescData
 }
 
+var file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_goTypes = []any{
-	(*ActivityDispatchTask)(nil),       // 0: temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask
-	(*ScheduleToStartTimeoutTask)(nil), // 1: temporal.server.chasm.lib.activity.proto.v1.ScheduleToStartTimeoutTask
-	(*ScheduleToCloseTimeoutTask)(nil), // 2: temporal.server.chasm.lib.activity.proto.v1.ScheduleToCloseTimeoutTask
-	(*StartToCloseTimeoutTask)(nil),    // 3: temporal.server.chasm.lib.activity.proto.v1.StartToCloseTimeoutTask
-	(*HeartbeatTimeoutTask)(nil),       // 4: temporal.server.chasm.lib.activity.proto.v1.HeartbeatTimeoutTask
+	(ActivityDispatchTask_DispatchReason)(0),   // 0: temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask.DispatchReason
+	(ActivityDispatchTask_StartDelayBucket)(0), // 1: temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask.StartDelayBucket
+	(*ActivityDispatchTask)(nil),               // 2: temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask
+	(*ScheduleToStartTimeoutTask)(nil),         // 3: temporal.server.chasm.lib.activity.proto.v1.ScheduleToStartTimeoutTask
+	(*ScheduleToCloseTimeoutTask)(nil),         // 4: temporal.server.chasm.lib.activity.proto.v1.ScheduleToCloseTimeoutTask
+	(*StartToCloseTimeoutTask)(nil),            // 5: temporal.server.chasm.lib.activity.proto.v1.StartToCloseTimeoutTask
+	(*HeartbeatTimeoutTask)(nil),               // 6: temporal.server.chasm.lib.activity.proto.v1.HeartbeatTimeoutTask
 }
 var file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_depIdxs = []int32{
-	0, // [0:0] is the sub-list for method output_type
-	0, // [0:0] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	0, // 0: temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask.dispatch_reason:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask.DispatchReason
+	1, // 1: temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask.start_delay_bucket:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask.StartDelayBucket
+	2, // [2:2] is the sub-list for method output_type
+	2, // [2:2] is the sub-list for method input_type
+	2, // [2:2] is the sub-list for extension type_name
+	2, // [2:2] is the sub-list for extension extendee
+	0, // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_init() }
@@ -304,13 +507,14 @@ func file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_rawDesc), len(file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_rawDesc)),
-			NumEnums:      0,
+			NumEnums:      2,
 			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
 		GoTypes:           file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_goTypes,
 		DependencyIndexes: file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_depIdxs,
+		EnumInfos:         file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_enumTypes,
 		MessageInfos:      file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_msgTypes,
 	}.Build()
 	File_temporal_server_chasm_lib_activity_proto_v1_tasks_proto = out.File

--- a/chasm/lib/activity/gen/activitypb/v1/tasks.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/tasks.pb.go
@@ -23,24 +23,24 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-type ActivityDispatchTask_DispatchReason int32
+type DispatchReason int32
 
 const (
-	ActivityDispatchTask_DISPATCH_REASON_UNSPECIFIED ActivityDispatchTask_DispatchReason = 0
-	ActivityDispatchTask_DISPATCH_REASON_IMMEDIATE   ActivityDispatchTask_DispatchReason = 1
-	ActivityDispatchTask_DISPATCH_REASON_START_DELAY ActivityDispatchTask_DispatchReason = 2
-	ActivityDispatchTask_DISPATCH_REASON_RETRY       ActivityDispatchTask_DispatchReason = 3
+	DISPATCH_REASON_UNSPECIFIED DispatchReason = 0
+	DISPATCH_REASON_IMMEDIATE   DispatchReason = 1
+	DISPATCH_REASON_START_DELAY DispatchReason = 2
+	DISPATCH_REASON_RETRY       DispatchReason = 3
 )
 
-// Enum value maps for ActivityDispatchTask_DispatchReason.
+// Enum value maps for DispatchReason.
 var (
-	ActivityDispatchTask_DispatchReason_name = map[int32]string{
+	DispatchReason_name = map[int32]string{
 		0: "DISPATCH_REASON_UNSPECIFIED",
 		1: "DISPATCH_REASON_IMMEDIATE",
 		2: "DISPATCH_REASON_START_DELAY",
 		3: "DISPATCH_REASON_RETRY",
 	}
-	ActivityDispatchTask_DispatchReason_value = map[string]int32{
+	DispatchReason_value = map[string]int32{
 		"DISPATCH_REASON_UNSPECIFIED": 0,
 		"DISPATCH_REASON_IMMEDIATE":   1,
 		"DISPATCH_REASON_START_DELAY": 2,
@@ -48,63 +48,63 @@ var (
 	}
 )
 
-func (x ActivityDispatchTask_DispatchReason) Enum() *ActivityDispatchTask_DispatchReason {
-	p := new(ActivityDispatchTask_DispatchReason)
+func (x DispatchReason) Enum() *DispatchReason {
+	p := new(DispatchReason)
 	*p = x
 	return p
 }
 
-func (x ActivityDispatchTask_DispatchReason) String() string {
+func (x DispatchReason) String() string {
 	switch x {
-	case ActivityDispatchTask_DISPATCH_REASON_UNSPECIFIED:
-		return "ActivityDispatchTaskDispatchReasonUnspecified"
-	case ActivityDispatchTask_DISPATCH_REASON_IMMEDIATE:
-		return "ActivityDispatchTaskDispatchReasonImmediate"
-	case ActivityDispatchTask_DISPATCH_REASON_START_DELAY:
-		return "ActivityDispatchTaskDispatchReasonStartDelay"
-	case ActivityDispatchTask_DISPATCH_REASON_RETRY:
-		return "ActivityDispatchTaskDispatchReasonRetry"
+	case DISPATCH_REASON_UNSPECIFIED:
+		return "Unspecified"
+	case DISPATCH_REASON_IMMEDIATE:
+		return "Immediate"
+	case DISPATCH_REASON_START_DELAY:
+		return "StartDelay"
+	case DISPATCH_REASON_RETRY:
+		return "Retry"
 	default:
 		return strconv.Itoa(int(x))
 	}
 
 }
 
-func (ActivityDispatchTask_DispatchReason) Descriptor() protoreflect.EnumDescriptor {
+func (DispatchReason) Descriptor() protoreflect.EnumDescriptor {
 	return file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_enumTypes[0].Descriptor()
 }
 
-func (ActivityDispatchTask_DispatchReason) Type() protoreflect.EnumType {
+func (DispatchReason) Type() protoreflect.EnumType {
 	return &file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_enumTypes[0]
 }
 
-func (x ActivityDispatchTask_DispatchReason) Number() protoreflect.EnumNumber {
+func (x DispatchReason) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use ActivityDispatchTask_DispatchReason.Descriptor instead.
-func (ActivityDispatchTask_DispatchReason) EnumDescriptor() ([]byte, []int) {
-	return file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_rawDescGZIP(), []int{0, 0}
+// Deprecated: Use DispatchReason.Descriptor instead.
+func (DispatchReason) EnumDescriptor() ([]byte, []int) {
+	return file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_rawDescGZIP(), []int{0}
 }
 
-type ActivityDispatchTask_StartDelayBucket int32
+type StartDelayBucket int32
 
 const (
-	ActivityDispatchTask_START_DELAY_BUCKET_UNSPECIFIED ActivityDispatchTask_StartDelayBucket = 0
-	ActivityDispatchTask_START_DELAY_BUCKET_NONE        ActivityDispatchTask_StartDelayBucket = 1
-	ActivityDispatchTask_START_DELAY_BUCKET_LT_1M       ActivityDispatchTask_StartDelayBucket = 2
-	ActivityDispatchTask_START_DELAY_BUCKET_1M_10M      ActivityDispatchTask_StartDelayBucket = 3
-	ActivityDispatchTask_START_DELAY_BUCKET_10M_1H      ActivityDispatchTask_StartDelayBucket = 4
-	ActivityDispatchTask_START_DELAY_BUCKET_1H_6H       ActivityDispatchTask_StartDelayBucket = 5
-	ActivityDispatchTask_START_DELAY_BUCKET_6H_1D       ActivityDispatchTask_StartDelayBucket = 6
-	ActivityDispatchTask_START_DELAY_BUCKET_1D_7D       ActivityDispatchTask_StartDelayBucket = 7
-	ActivityDispatchTask_START_DELAY_BUCKET_7D_30D      ActivityDispatchTask_StartDelayBucket = 8
-	ActivityDispatchTask_START_DELAY_BUCKET_GT_30D      ActivityDispatchTask_StartDelayBucket = 9
+	START_DELAY_BUCKET_UNSPECIFIED StartDelayBucket = 0
+	START_DELAY_BUCKET_NONE        StartDelayBucket = 1
+	START_DELAY_BUCKET_LT_1M       StartDelayBucket = 2
+	START_DELAY_BUCKET_1M_10M      StartDelayBucket = 3
+	START_DELAY_BUCKET_10M_1H      StartDelayBucket = 4
+	START_DELAY_BUCKET_1H_6H       StartDelayBucket = 5
+	START_DELAY_BUCKET_6H_1D       StartDelayBucket = 6
+	START_DELAY_BUCKET_1D_7D       StartDelayBucket = 7
+	START_DELAY_BUCKET_7D_30D      StartDelayBucket = 8
+	START_DELAY_BUCKET_GT_30D      StartDelayBucket = 9
 )
 
-// Enum value maps for ActivityDispatchTask_StartDelayBucket.
+// Enum value maps for StartDelayBucket.
 var (
-	ActivityDispatchTask_StartDelayBucket_name = map[int32]string{
+	StartDelayBucket_name = map[int32]string{
 		0: "START_DELAY_BUCKET_UNSPECIFIED",
 		1: "START_DELAY_BUCKET_NONE",
 		2: "START_DELAY_BUCKET_LT_1M",
@@ -116,7 +116,7 @@ var (
 		8: "START_DELAY_BUCKET_7D_30D",
 		9: "START_DELAY_BUCKET_GT_30D",
 	}
-	ActivityDispatchTask_StartDelayBucket_value = map[string]int32{
+	StartDelayBucket_value = map[string]int32{
 		"START_DELAY_BUCKET_UNSPECIFIED": 0,
 		"START_DELAY_BUCKET_NONE":        1,
 		"START_DELAY_BUCKET_LT_1M":       2,
@@ -130,68 +130,65 @@ var (
 	}
 )
 
-func (x ActivityDispatchTask_StartDelayBucket) Enum() *ActivityDispatchTask_StartDelayBucket {
-	p := new(ActivityDispatchTask_StartDelayBucket)
+func (x StartDelayBucket) Enum() *StartDelayBucket {
+	p := new(StartDelayBucket)
 	*p = x
 	return p
 }
 
-func (x ActivityDispatchTask_StartDelayBucket) String() string {
+func (x StartDelayBucket) String() string {
 	switch x {
-	case ActivityDispatchTask_START_DELAY_BUCKET_UNSPECIFIED:
-		return "ActivityDispatchTaskStartDelayBucketUnspecified"
-	case ActivityDispatchTask_START_DELAY_BUCKET_NONE:
-		return "ActivityDispatchTaskStartDelayBucketNone"
-	case ActivityDispatchTask_START_DELAY_BUCKET_LT_1M:
-		return "ActivityDispatchTaskStartDelayBucketLt1M"
-	case ActivityDispatchTask_START_DELAY_BUCKET_1M_10M:
-		return "ActivityDispatchTaskStartDelayBucket1M10M"
-	case ActivityDispatchTask_START_DELAY_BUCKET_10M_1H:
-		return "ActivityDispatchTaskStartDelayBucket10M1H"
-	case ActivityDispatchTask_START_DELAY_BUCKET_1H_6H:
-
-		// Deprecated: Use ActivityDispatchTask_StartDelayBucket.Descriptor instead.
-		return "ActivityDispatchTaskStartDelayBucket1H6H"
-	case ActivityDispatchTask_START_DELAY_BUCKET_6H_1D:
-		return "ActivityDispatchTaskStartDelayBucket6H1D"
-	case ActivityDispatchTask_START_DELAY_BUCKET_1D_7D:
-		return "ActivityDispatchTaskStartDelayBucket1D7D"
-	case ActivityDispatchTask_START_DELAY_BUCKET_7D_30D:
-		return "ActivityDispatchTaskStartDelayBucket7D30D"
-
-		// The current stamp for this activity execution. Used for task validation. See also [ActivityAttemptState].
-	case ActivityDispatchTask_START_DELAY_BUCKET_GT_30D:
-		return "ActivityDispatchTaskStartDelayBucketGt30D"
+	case START_DELAY_BUCKET_UNSPECIFIED:
+		return "Unspecified"
+	case START_DELAY_BUCKET_NONE:
+		return "None"
+	case START_DELAY_BUCKET_LT_1M:
+		return "Lt1M"
+	case START_DELAY_BUCKET_1M_10M:
+		return "1M10M"
+	case START_DELAY_BUCKET_10M_1H:
+		return "10M1H"
+	case START_DELAY_BUCKET_1H_6H:
+		return "1H6H"
+	case START_DELAY_BUCKET_6H_1D:
+		return "6H1D"
+	case START_DELAY_BUCKET_1D_7D:
+		return "1D7D"
+	case START_DELAY_BUCKET_7D_30D:
+		return "7D30D"
+	case START_DELAY_BUCKET_GT_30D:
+		return "Gt30D"
 	default:
 		return strconv.Itoa(int(x))
 	}
 
 }
 
-func (ActivityDispatchTask_StartDelayBucket) Descriptor() protoreflect.EnumDescriptor {
+func (StartDelayBucket) Descriptor() protoreflect.EnumDescriptor {
 	return file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_enumTypes[1].Descriptor()
 }
 
-func (ActivityDispatchTask_StartDelayBucket) Type() protoreflect.EnumType {
+func (StartDelayBucket) Type() protoreflect.EnumType {
 	return &file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_enumTypes[1]
 }
 
-func (x ActivityDispatchTask_StartDelayBucket) Number() protoreflect.EnumNumber {
+func (x StartDelayBucket) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-func (ActivityDispatchTask_StartDelayBucket) EnumDescriptor() ([]byte, []int) {
-	return file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_rawDescGZIP(), []int{0, 1}
+// Deprecated: Use StartDelayBucket.Descriptor instead.
+func (StartDelayBucket) EnumDescriptor() ([]byte, []int) {
+	return file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_rawDescGZIP(), []int{1}
 }
 
 type ActivityDispatchTask struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-
+	// The current stamp for this activity execution. Used for task validation. See also [ActivityAttemptState].
 	Stamp int32 `protobuf:"varint,1,opt,name=stamp,proto3" json:"stamp,omitempty"`
 	// Dispatch category based on attempt history and the configured start delay.
-	DispatchReason ActivityDispatchTask_DispatchReason `protobuf:"varint,2,opt,name=dispatch_reason,json=dispatchReason,proto3,enum=temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask_DispatchReason" json:"dispatch_reason,omitempty"`
+	DispatchReason DispatchReason `protobuf:"varint,2,opt,name=dispatch_reason,json=dispatchReason,proto3,enum=temporal.server.chasm.lib.activity.proto.v1.DispatchReason" json:"dispatch_reason,omitempty"`
 	// Bucket for the configured start delay, independent of actual dispatch time.
-	StartDelayBucket ActivityDispatchTask_StartDelayBucket `protobuf:"varint,3,opt,name=start_delay_bucket,json=startDelayBucket,proto3,enum=temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask_StartDelayBucket" json:"start_delay_bucket,omitempty"`
+	StartDelayBucket StartDelayBucket `protobuf:"varint,3,opt,name=start_delay_bucket,json=startDelayBucket,proto3,enum=temporal.server.chasm.lib.activity.proto.v1.StartDelayBucket" json:"start_delay_bucket,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -233,18 +230,18 @@ func (x *ActivityDispatchTask) GetStamp() int32 {
 	return 0
 }
 
-func (x *ActivityDispatchTask) GetDispatchReason() ActivityDispatchTask_DispatchReason {
+func (x *ActivityDispatchTask) GetDispatchReason() DispatchReason {
 	if x != nil {
 		return x.DispatchReason
 	}
-	return ActivityDispatchTask_DISPATCH_REASON_UNSPECIFIED
+	return DISPATCH_REASON_UNSPECIFIED
 }
 
-func (x *ActivityDispatchTask) GetStartDelayBucket() ActivityDispatchTask_StartDelayBucket {
+func (x *ActivityDispatchTask) GetStartDelayBucket() StartDelayBucket {
 	if x != nil {
 		return x.StartDelayBucket
 	}
-	return ActivityDispatchTask_START_DELAY_BUCKET_UNSPECIFIED
+	return START_DELAY_BUCKET_UNSPECIFIED
 }
 
 type ScheduleToStartTimeoutTask struct {
@@ -434,16 +431,24 @@ var File_temporal_server_chasm_lib_activity_proto_v1_tasks_proto protoreflect.Fi
 
 const file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_rawDesc = "" +
 	"\n" +
-	"7temporal/server/chasm/lib/activity/proto/v1/tasks.proto\x12+temporal.server.chasm.lib.activity.proto.v1\"\x83\x06\n" +
+	"7temporal/server/chasm/lib/activity/proto/v1/tasks.proto\x12+temporal.server.chasm.lib.activity.proto.v1\"\xff\x01\n" +
 	"\x14ActivityDispatchTask\x12\x14\n" +
-	"\x05stamp\x18\x01 \x01(\x05R\x05stamp\x12y\n" +
-	"\x0fdispatch_reason\x18\x02 \x01(\x0e2P.temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask.DispatchReasonR\x0edispatchReason\x12\x80\x01\n" +
-	"\x12start_delay_bucket\x18\x03 \x01(\x0e2R.temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask.StartDelayBucketR\x10startDelayBucket\"\x8c\x01\n" +
+	"\x05stamp\x18\x01 \x01(\x05R\x05stamp\x12d\n" +
+	"\x0fdispatch_reason\x18\x02 \x01(\x0e2;.temporal.server.chasm.lib.activity.proto.v1.DispatchReasonR\x0edispatchReason\x12k\n" +
+	"\x12start_delay_bucket\x18\x03 \x01(\x0e2=.temporal.server.chasm.lib.activity.proto.v1.StartDelayBucketR\x10startDelayBucket\"2\n" +
+	"\x1aScheduleToStartTimeoutTask\x12\x14\n" +
+	"\x05stamp\x18\x01 \x01(\x05R\x05stamp\"2\n" +
+	"\x1aScheduleToCloseTimeoutTask\x12\x14\n" +
+	"\x05stamp\x18\x01 \x01(\x05R\x05stamp\"/\n" +
+	"\x17StartToCloseTimeoutTask\x12\x14\n" +
+	"\x05stamp\x18\x01 \x01(\x05R\x05stamp\",\n" +
+	"\x14HeartbeatTimeoutTask\x12\x14\n" +
+	"\x05stamp\x18\x01 \x01(\x05R\x05stamp*\x8c\x01\n" +
 	"\x0eDispatchReason\x12\x1f\n" +
 	"\x1bDISPATCH_REASON_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19DISPATCH_REASON_IMMEDIATE\x10\x01\x12\x1f\n" +
 	"\x1bDISPATCH_REASON_START_DELAY\x10\x02\x12\x19\n" +
-	"\x15DISPATCH_REASON_RETRY\x10\x03\"\xc7\x02\n" +
+	"\x15DISPATCH_REASON_RETRY\x10\x03*\xc7\x02\n" +
 	"\x10StartDelayBucket\x12\"\n" +
 	"\x1eSTART_DELAY_BUCKET_UNSPECIFIED\x10\x00\x12\x1b\n" +
 	"\x17START_DELAY_BUCKET_NONE\x10\x01\x12\x1c\n" +
@@ -454,15 +459,7 @@ const file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_rawDesc = "" 
 	"\x18START_DELAY_BUCKET_6H_1D\x10\x06\x12\x1c\n" +
 	"\x18START_DELAY_BUCKET_1D_7D\x10\a\x12\x1d\n" +
 	"\x19START_DELAY_BUCKET_7D_30D\x10\b\x12\x1d\n" +
-	"\x19START_DELAY_BUCKET_GT_30D\x10\t\"2\n" +
-	"\x1aScheduleToStartTimeoutTask\x12\x14\n" +
-	"\x05stamp\x18\x01 \x01(\x05R\x05stamp\"2\n" +
-	"\x1aScheduleToCloseTimeoutTask\x12\x14\n" +
-	"\x05stamp\x18\x01 \x01(\x05R\x05stamp\"/\n" +
-	"\x17StartToCloseTimeoutTask\x12\x14\n" +
-	"\x05stamp\x18\x01 \x01(\x05R\x05stamp\",\n" +
-	"\x14HeartbeatTimeoutTask\x12\x14\n" +
-	"\x05stamp\x18\x01 \x01(\x05R\x05stampBDZBgo.temporal.io/server/chasm/lib/activity/gen/activitypb;activitypbb\x06proto3"
+	"\x19START_DELAY_BUCKET_GT_30D\x10\tBDZBgo.temporal.io/server/chasm/lib/activity/gen/activitypb;activitypbb\x06proto3"
 
 var (
 	file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_rawDescOnce sync.Once
@@ -479,17 +476,17 @@ func file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_rawDescGZIP() 
 var file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_goTypes = []any{
-	(ActivityDispatchTask_DispatchReason)(0),   // 0: temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask.DispatchReason
-	(ActivityDispatchTask_StartDelayBucket)(0), // 1: temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask.StartDelayBucket
-	(*ActivityDispatchTask)(nil),               // 2: temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask
-	(*ScheduleToStartTimeoutTask)(nil),         // 3: temporal.server.chasm.lib.activity.proto.v1.ScheduleToStartTimeoutTask
-	(*ScheduleToCloseTimeoutTask)(nil),         // 4: temporal.server.chasm.lib.activity.proto.v1.ScheduleToCloseTimeoutTask
-	(*StartToCloseTimeoutTask)(nil),            // 5: temporal.server.chasm.lib.activity.proto.v1.StartToCloseTimeoutTask
-	(*HeartbeatTimeoutTask)(nil),               // 6: temporal.server.chasm.lib.activity.proto.v1.HeartbeatTimeoutTask
+	(DispatchReason)(0),                // 0: temporal.server.chasm.lib.activity.proto.v1.DispatchReason
+	(StartDelayBucket)(0),              // 1: temporal.server.chasm.lib.activity.proto.v1.StartDelayBucket
+	(*ActivityDispatchTask)(nil),       // 2: temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask
+	(*ScheduleToStartTimeoutTask)(nil), // 3: temporal.server.chasm.lib.activity.proto.v1.ScheduleToStartTimeoutTask
+	(*ScheduleToCloseTimeoutTask)(nil), // 4: temporal.server.chasm.lib.activity.proto.v1.ScheduleToCloseTimeoutTask
+	(*StartToCloseTimeoutTask)(nil),    // 5: temporal.server.chasm.lib.activity.proto.v1.StartToCloseTimeoutTask
+	(*HeartbeatTimeoutTask)(nil),       // 6: temporal.server.chasm.lib.activity.proto.v1.HeartbeatTimeoutTask
 }
 var file_temporal_server_chasm_lib_activity_proto_v1_tasks_proto_depIdxs = []int32{
-	0, // 0: temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask.dispatch_reason:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask.DispatchReason
-	1, // 1: temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask.start_delay_bucket:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask.StartDelayBucket
+	0, // 0: temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask.dispatch_reason:type_name -> temporal.server.chasm.lib.activity.proto.v1.DispatchReason
+	1, // 1: temporal.server.chasm.lib.activity.proto.v1.ActivityDispatchTask.start_delay_bucket:type_name -> temporal.server.chasm.lib.activity.proto.v1.StartDelayBucket
 	2, // [2:2] is the sub-list for method output_type
 	2, // [2:2] is the sub-list for method input_type
 	2, // [2:2] is the sub-list for extension type_name

--- a/chasm/lib/activity/proto/v1/tasks.proto
+++ b/chasm/lib/activity/proto/v1/tasks.proto
@@ -4,27 +4,27 @@ package temporal.server.chasm.lib.activity.proto.v1;
 
 option go_package = "go.temporal.io/server/chasm/lib/activity/gen/activitypb;activitypb";
 
+enum DispatchReason {
+  DISPATCH_REASON_UNSPECIFIED = 0;
+  DISPATCH_REASON_IMMEDIATE = 1;
+  DISPATCH_REASON_START_DELAY = 2;
+  DISPATCH_REASON_RETRY = 3;
+}
+
+enum StartDelayBucket {
+  START_DELAY_BUCKET_UNSPECIFIED = 0;
+  START_DELAY_BUCKET_NONE = 1;
+  START_DELAY_BUCKET_LT_1M = 2;
+  START_DELAY_BUCKET_1M_10M = 3;
+  START_DELAY_BUCKET_10M_1H = 4;
+  START_DELAY_BUCKET_1H_6H = 5;
+  START_DELAY_BUCKET_6H_1D = 6;
+  START_DELAY_BUCKET_1D_7D = 7;
+  START_DELAY_BUCKET_7D_30D = 8;
+  START_DELAY_BUCKET_GT_30D = 9;
+}
+
 message ActivityDispatchTask {
-  enum DispatchReason {
-    DISPATCH_REASON_UNSPECIFIED = 0;
-    DISPATCH_REASON_IMMEDIATE = 1;
-    DISPATCH_REASON_START_DELAY = 2;
-    DISPATCH_REASON_RETRY = 3;
-  }
-
-  enum StartDelayBucket {
-    START_DELAY_BUCKET_UNSPECIFIED = 0;
-    START_DELAY_BUCKET_NONE = 1;
-    START_DELAY_BUCKET_LT_1M = 2;
-    START_DELAY_BUCKET_1M_10M = 3;
-    START_DELAY_BUCKET_10M_1H = 4;
-    START_DELAY_BUCKET_1H_6H = 5;
-    START_DELAY_BUCKET_6H_1D = 6;
-    START_DELAY_BUCKET_1D_7D = 7;
-    START_DELAY_BUCKET_7D_30D = 8;
-    START_DELAY_BUCKET_GT_30D = 9;
-  }
-
   // The current stamp for this activity execution. Used for task validation. See also [ActivityAttemptState].
   int32 stamp = 1;
 

--- a/chasm/lib/activity/proto/v1/tasks.proto
+++ b/chasm/lib/activity/proto/v1/tasks.proto
@@ -5,8 +5,34 @@ package temporal.server.chasm.lib.activity.proto.v1;
 option go_package = "go.temporal.io/server/chasm/lib/activity/gen/activitypb;activitypb";
 
 message ActivityDispatchTask {
+  enum DispatchReason {
+    DISPATCH_REASON_UNSPECIFIED = 0;
+    DISPATCH_REASON_IMMEDIATE = 1;
+    DISPATCH_REASON_START_DELAY = 2;
+    DISPATCH_REASON_RETRY = 3;
+  }
+
+  enum StartDelayBucket {
+    START_DELAY_BUCKET_UNSPECIFIED = 0;
+    START_DELAY_BUCKET_NONE = 1;
+    START_DELAY_BUCKET_LT_1M = 2;
+    START_DELAY_BUCKET_1M_10M = 3;
+    START_DELAY_BUCKET_10M_1H = 4;
+    START_DELAY_BUCKET_1H_6H = 5;
+    START_DELAY_BUCKET_6H_1D = 6;
+    START_DELAY_BUCKET_1D_7D = 7;
+    START_DELAY_BUCKET_7D_30D = 8;
+    START_DELAY_BUCKET_GT_30D = 9;
+  }
+
   // The current stamp for this activity execution. Used for task validation. See also [ActivityAttemptState].
   int32 stamp = 1;
+
+  // Dispatch category based on attempt history and the configured start delay.
+  DispatchReason dispatch_reason = 2;
+
+  // Bucket for the configured start delay, independent of actual dispatch time.
+  StartDelayBucket start_delay_bucket = 3;
 }
 
 message ScheduleToStartTimeoutTask {

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -79,9 +79,7 @@ var TransitionScheduled = chasm.NewTransition(
 		ctx.AddTask(
 			a,
 			dispatchAttrs,
-			&activitypb.ActivityDispatchTask{
-				Stamp: attempt.GetStamp(),
-			})
+			a.newActivityDispatchTask(ctx))
 
 		return nil
 	},
@@ -126,9 +124,7 @@ var TransitionRescheduled = chasm.NewTransition(
 			chasm.TaskAttributes{
 				ScheduledTime: retryScheduledTime,
 			},
-			&activitypb.ActivityDispatchTask{
-				Stamp: attempt.GetStamp(),
-			})
+			a.newActivityDispatchTask(ctx))
 
 		return nil
 	},
@@ -598,9 +594,7 @@ var TransitionResetAttemptFailedToScheduled = chasm.NewTransition(
 			chasm.TaskAttributes{
 				ScheduledTime: dispatchTime,
 			},
-			&activitypb.ActivityDispatchTask{
-				Stamp: attempt.GetStamp(),
-			})
+			a.newActivityDispatchTask(ctx))
 
 		return nil
 	},

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -45,8 +45,8 @@ func TestTransitionScheduled(t *testing.T) {
 		startDelay               time.Duration
 		scheduleToStartTimeout   time.Duration
 		scheduleToCloseTimeout   time.Duration
-		expectedDispatchReason   activitypb.ActivityDispatchTask_DispatchReason
-		expectedStartDelayBucket activitypb.ActivityDispatchTask_StartDelayBucket
+		expectedDispatchReason   activitypb.DispatchReason
+		expectedStartDelayBucket activitypb.StartDelayBucket
 	}{
 		{
 			name:                 "all timeouts set",
@@ -58,8 +58,8 @@ func TestTransitionScheduled(t *testing.T) {
 			},
 			scheduleToStartTimeout:   defaultScheduleToStartTimeout,
 			scheduleToCloseTimeout:   defaultScheduleToCloseTimeout,
-			expectedDispatchReason:   activitypb.ActivityDispatchTask_DISPATCH_REASON_IMMEDIATE,
-			expectedStartDelayBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE,
+			expectedDispatchReason:   activitypb.DISPATCH_REASON_IMMEDIATE,
+			expectedStartDelayBucket: activitypb.START_DELAY_BUCKET_NONE,
 		},
 		{
 			name:                 "schedule to start timeout not set",
@@ -70,8 +70,8 @@ func TestTransitionScheduled(t *testing.T) {
 			},
 			scheduleToStartTimeout:   0,
 			scheduleToCloseTimeout:   defaultScheduleToCloseTimeout,
-			expectedDispatchReason:   activitypb.ActivityDispatchTask_DISPATCH_REASON_IMMEDIATE,
-			expectedStartDelayBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE,
+			expectedDispatchReason:   activitypb.DISPATCH_REASON_IMMEDIATE,
+			expectedStartDelayBucket: activitypb.START_DELAY_BUCKET_NONE,
 		},
 		{
 			name:                 "schedule to close timeout not set",
@@ -82,8 +82,8 @@ func TestTransitionScheduled(t *testing.T) {
 			},
 			scheduleToStartTimeout:   defaultScheduleToStartTimeout,
 			scheduleToCloseTimeout:   0,
-			expectedDispatchReason:   activitypb.ActivityDispatchTask_DISPATCH_REASON_IMMEDIATE,
-			expectedStartDelayBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE,
+			expectedDispatchReason:   activitypb.DISPATCH_REASON_IMMEDIATE,
+			expectedStartDelayBucket: activitypb.START_DELAY_BUCKET_NONE,
 		},
 		{
 			name:                 "start delay",
@@ -96,8 +96,8 @@ func TestTransitionScheduled(t *testing.T) {
 			startDelay:               5 * time.Minute,
 			scheduleToStartTimeout:   defaultScheduleToStartTimeout,
 			scheduleToCloseTimeout:   defaultScheduleToCloseTimeout,
-			expectedDispatchReason:   activitypb.ActivityDispatchTask_DISPATCH_REASON_START_DELAY,
-			expectedStartDelayBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_1M_10M,
+			expectedDispatchReason:   activitypb.DISPATCH_REASON_START_DELAY,
+			expectedStartDelayBucket: activitypb.START_DELAY_BUCKET_1M_10M,
 		},
 	}
 
@@ -174,7 +174,7 @@ func TestTransitionRescheduled(t *testing.T) {
 		expectedTasks            []chasm.MockTask
 		expectedRetryInterval    time.Duration
 		startDelay               time.Duration
-		expectedStartDelayBucket activitypb.ActivityDispatchTask_StartDelayBucket
+		expectedStartDelayBucket activitypb.StartDelayBucket
 		retryPolicy              *commonpb.RetryPolicy
 		scheduleToStartTimeout   time.Duration
 		operationTag             string
@@ -189,7 +189,7 @@ func TestTransitionRescheduled(t *testing.T) {
 				{Payload: &activitypb.ActivityDispatchTask{}},
 			},
 			expectedRetryInterval:    2 * time.Second,
-			expectedStartDelayBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE,
+			expectedStartDelayBucket: activitypb.START_DELAY_BUCKET_NONE,
 			retryPolicy:              defaultRetryPolicy,
 			scheduleToStartTimeout:   defaultScheduleToStartTimeout,
 			operationTag:             metrics.TimerActiveTaskActivityTimeoutScope,
@@ -204,7 +204,7 @@ func TestTransitionRescheduled(t *testing.T) {
 				{Payload: &activitypb.ActivityDispatchTask{}},
 			},
 			expectedRetryInterval:    4 * time.Second,
-			expectedStartDelayBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE,
+			expectedStartDelayBucket: activitypb.START_DELAY_BUCKET_NONE,
 			retryPolicy:              defaultRetryPolicy,
 			scheduleToStartTimeout:   defaultScheduleToStartTimeout,
 			operationTag:             metrics.TimerActiveTaskActivityTimeoutScope,
@@ -218,7 +218,7 @@ func TestTransitionRescheduled(t *testing.T) {
 				{Payload: &activitypb.ActivityDispatchTask{}},
 			},
 			expectedRetryInterval:    2 * time.Second,
-			expectedStartDelayBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE,
+			expectedStartDelayBucket: activitypb.START_DELAY_BUCKET_NONE,
 			retryPolicy:              defaultRetryPolicy,
 			scheduleToStartTimeout:   0,
 			operationTag:             metrics.TimerActiveTaskActivityTimeoutScope,
@@ -233,7 +233,7 @@ func TestTransitionRescheduled(t *testing.T) {
 				{Payload: &activitypb.ActivityDispatchTask{}},
 			},
 			expectedRetryInterval:    2 * time.Second,
-			expectedStartDelayBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE,
+			expectedStartDelayBucket: activitypb.START_DELAY_BUCKET_NONE,
 			retryPolicy:              defaultRetryPolicy,
 			scheduleToStartTimeout:   defaultScheduleToStartTimeout,
 			operationTag:             metrics.TimerActiveTaskActivityTimeoutScope,
@@ -249,7 +249,7 @@ func TestTransitionRescheduled(t *testing.T) {
 				{Payload: &activitypb.ActivityDispatchTask{}},
 			},
 			expectedRetryInterval:    2 * time.Second,
-			expectedStartDelayBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE,
+			expectedStartDelayBucket: activitypb.START_DELAY_BUCKET_NONE,
 			retryPolicy:              defaultRetryPolicy,
 			scheduleToStartTimeout:   defaultScheduleToStartTimeout,
 			operationTag:             metrics.HistoryRespondActivityTaskFailedScope,
@@ -264,7 +264,7 @@ func TestTransitionRescheduled(t *testing.T) {
 			},
 			expectedRetryInterval:    2 * time.Second,
 			startDelay:               5 * time.Minute,
-			expectedStartDelayBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_1M_10M,
+			expectedStartDelayBucket: activitypb.START_DELAY_BUCKET_1M_10M,
 			retryPolicy:              defaultRetryPolicy,
 			scheduleToStartTimeout:   defaultScheduleToStartTimeout,
 			operationTag:             metrics.HistoryRespondActivityTaskFailedScope,
@@ -324,7 +324,7 @@ func TestTransitionRescheduled(t *testing.T) {
 					dispatchTask, ok := actualTask.Payload.(*activitypb.ActivityDispatchTask)
 					require.True(t, ok, "expected ActivityDispatchTask at index %d", i)
 					require.Equal(t, defaultTime.Add(tc.expectedRetryInterval), actualTask.Attributes.ScheduledTime)
-					require.Equal(t, activitypb.ActivityDispatchTask_DISPATCH_REASON_RETRY, dispatchTask.GetDispatchReason())
+					require.Equal(t, activitypb.DISPATCH_REASON_RETRY, dispatchTask.GetDispatchReason())
 					require.Equal(t, tc.expectedStartDelayBucket, dispatchTask.GetStartDelayBucket())
 				case *activitypb.ScheduleToStartTimeoutTask:
 					_, ok := actualTask.Payload.(*activitypb.ScheduleToStartTimeoutTask)

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -39,11 +39,14 @@ var (
 
 func TestTransitionScheduled(t *testing.T) {
 	testCases := []struct {
-		name                   string
-		startingAttemptCount   int32
-		expectedTasks          []chasm.MockTask
-		scheduleToStartTimeout time.Duration
-		scheduleToCloseTimeout time.Duration
+		name                     string
+		startingAttemptCount     int32
+		expectedTasks            []chasm.MockTask
+		startDelay               time.Duration
+		scheduleToStartTimeout   time.Duration
+		scheduleToCloseTimeout   time.Duration
+		expectedDispatchReason   activitypb.ActivityDispatchTask_DispatchReason
+		expectedStartDelayBucket activitypb.ActivityDispatchTask_StartDelayBucket
 	}{
 		{
 			name:                 "all timeouts set",
@@ -53,8 +56,10 @@ func TestTransitionScheduled(t *testing.T) {
 				{Payload: &activitypb.ScheduleToCloseTimeoutTask{}},
 				{Payload: &activitypb.ActivityDispatchTask{}},
 			},
-			scheduleToStartTimeout: defaultScheduleToStartTimeout,
-			scheduleToCloseTimeout: defaultScheduleToCloseTimeout,
+			scheduleToStartTimeout:   defaultScheduleToStartTimeout,
+			scheduleToCloseTimeout:   defaultScheduleToCloseTimeout,
+			expectedDispatchReason:   activitypb.ActivityDispatchTask_DISPATCH_REASON_IMMEDIATE,
+			expectedStartDelayBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE,
 		},
 		{
 			name:                 "schedule to start timeout not set",
@@ -63,8 +68,10 @@ func TestTransitionScheduled(t *testing.T) {
 				{Payload: &activitypb.ScheduleToCloseTimeoutTask{}},
 				{Payload: &activitypb.ActivityDispatchTask{}},
 			},
-			scheduleToStartTimeout: 0,
-			scheduleToCloseTimeout: defaultScheduleToCloseTimeout,
+			scheduleToStartTimeout:   0,
+			scheduleToCloseTimeout:   defaultScheduleToCloseTimeout,
+			expectedDispatchReason:   activitypb.ActivityDispatchTask_DISPATCH_REASON_IMMEDIATE,
+			expectedStartDelayBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE,
 		},
 		{
 			name:                 "schedule to close timeout not set",
@@ -73,8 +80,24 @@ func TestTransitionScheduled(t *testing.T) {
 				{Payload: &activitypb.ScheduleToStartTimeoutTask{}},
 				{Payload: &activitypb.ActivityDispatchTask{}},
 			},
-			scheduleToStartTimeout: defaultScheduleToStartTimeout,
-			scheduleToCloseTimeout: 0,
+			scheduleToStartTimeout:   defaultScheduleToStartTimeout,
+			scheduleToCloseTimeout:   0,
+			expectedDispatchReason:   activitypb.ActivityDispatchTask_DISPATCH_REASON_IMMEDIATE,
+			expectedStartDelayBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE,
+		},
+		{
+			name:                 "start delay",
+			startingAttemptCount: 0,
+			expectedTasks: []chasm.MockTask{
+				{Payload: &activitypb.ScheduleToStartTimeoutTask{}},
+				{Payload: &activitypb.ScheduleToCloseTimeoutTask{}},
+				{Payload: &activitypb.ActivityDispatchTask{}},
+			},
+			startDelay:               5 * time.Minute,
+			scheduleToStartTimeout:   defaultScheduleToStartTimeout,
+			scheduleToCloseTimeout:   defaultScheduleToCloseTimeout,
+			expectedDispatchReason:   activitypb.ActivityDispatchTask_DISPATCH_REASON_START_DELAY,
+			expectedStartDelayBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_1M_10M,
 		},
 	}
 
@@ -94,6 +117,7 @@ func TestTransitionScheduled(t *testing.T) {
 					ActivityType:           &commonpb.ActivityType{Name: "test-activity-type"},
 					RetryPolicy:            defaultRetryPolicy,
 					ScheduleTime:           timestamppb.New(defaultTime),
+					StartDelay:             durationpb.New(tc.startDelay),
 					ScheduleToCloseTimeout: durationpb.New(tc.scheduleToCloseTimeout),
 					ScheduleToStartTimeout: durationpb.New(tc.scheduleToStartTimeout),
 					StartToCloseTimeout:    durationpb.New(defaultStartToCloseTimeout),
@@ -122,11 +146,18 @@ func TestTransitionScheduled(t *testing.T) {
 
 				switch expectedTask.Payload.(type) {
 				case *activitypb.ActivityDispatchTask:
-					require.Empty(t, actualTask.Attributes.ScheduledTime)
+					dispatchTask := actualTask.Payload.(*activitypb.ActivityDispatchTask)
+					if tc.startDelay == 0 {
+						require.Empty(t, actualTask.Attributes.ScheduledTime)
+					} else {
+						require.Equal(t, defaultTime.Add(tc.startDelay), actualTask.Attributes.ScheduledTime)
+					}
+					require.Equal(t, tc.expectedDispatchReason, dispatchTask.GetDispatchReason())
+					require.Equal(t, tc.expectedStartDelayBucket, dispatchTask.GetStartDelayBucket())
 				case *activitypb.ScheduleToStartTimeoutTask:
-					require.Equal(t, defaultTime.Add(tc.scheduleToStartTimeout), actualTask.Attributes.ScheduledTime)
+					require.Equal(t, defaultTime.Add(tc.startDelay).Add(tc.scheduleToStartTimeout), actualTask.Attributes.ScheduledTime)
 				case *activitypb.ScheduleToCloseTimeoutTask:
-					require.Equal(t, defaultTime.Add(tc.scheduleToCloseTimeout), actualTask.Attributes.ScheduledTime)
+					require.Equal(t, defaultTime.Add(tc.startDelay).Add(tc.scheduleToCloseTimeout), actualTask.Attributes.ScheduledTime)
 				default:
 					t.Fatalf("unexpected task payload type at index %d: %T", i, actualTask.Payload)
 				}
@@ -138,15 +169,17 @@ func TestTransitionScheduled(t *testing.T) {
 
 func TestTransitionRescheduled(t *testing.T) {
 	testCases := []struct {
-		name                   string
-		startingAttemptCount   int32
-		expectedTasks          []chasm.MockTask
-		expectedRetryInterval  time.Duration
-		retryPolicy            *commonpb.RetryPolicy
-		scheduleToStartTimeout time.Duration
-		operationTag           string
-		counterMetric          string
-		timeoutType            enumspb.TimeoutType
+		name                     string
+		startingAttemptCount     int32
+		expectedTasks            []chasm.MockTask
+		expectedRetryInterval    time.Duration
+		startDelay               time.Duration
+		expectedStartDelayBucket activitypb.ActivityDispatchTask_StartDelayBucket
+		retryPolicy              *commonpb.RetryPolicy
+		scheduleToStartTimeout   time.Duration
+		operationTag             string
+		counterMetric            string
+		timeoutType              enumspb.TimeoutType
 	}{
 		{
 			name:                 "second attempt - timeout recorded",
@@ -155,12 +188,13 @@ func TestTransitionRescheduled(t *testing.T) {
 				{Payload: &activitypb.ScheduleToStartTimeoutTask{}},
 				{Payload: &activitypb.ActivityDispatchTask{}},
 			},
-			expectedRetryInterval:  2 * time.Second,
-			retryPolicy:            defaultRetryPolicy,
-			scheduleToStartTimeout: defaultScheduleToStartTimeout,
-			operationTag:           metrics.TimerActiveTaskActivityTimeoutScope,
-			counterMetric:          metrics.ActivityTaskTimeout.Name(),
-			timeoutType:            enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
+			expectedRetryInterval:    2 * time.Second,
+			expectedStartDelayBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE,
+			retryPolicy:              defaultRetryPolicy,
+			scheduleToStartTimeout:   defaultScheduleToStartTimeout,
+			operationTag:             metrics.TimerActiveTaskActivityTimeoutScope,
+			counterMetric:            metrics.ActivityTaskTimeout.Name(),
+			timeoutType:              enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
 		},
 		{
 			name:                 "third attempt - timeout recorded",
@@ -169,12 +203,13 @@ func TestTransitionRescheduled(t *testing.T) {
 				{Payload: &activitypb.ScheduleToStartTimeoutTask{}},
 				{Payload: &activitypb.ActivityDispatchTask{}},
 			},
-			expectedRetryInterval:  4 * time.Second,
-			retryPolicy:            defaultRetryPolicy,
-			scheduleToStartTimeout: defaultScheduleToStartTimeout,
-			operationTag:           metrics.TimerActiveTaskActivityTimeoutScope,
-			counterMetric:          metrics.ActivityTaskTimeout.Name(),
-			timeoutType:            enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
+			expectedRetryInterval:    4 * time.Second,
+			expectedStartDelayBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE,
+			retryPolicy:              defaultRetryPolicy,
+			scheduleToStartTimeout:   defaultScheduleToStartTimeout,
+			operationTag:             metrics.TimerActiveTaskActivityTimeoutScope,
+			counterMetric:            metrics.ActivityTaskTimeout.Name(),
+			timeoutType:              enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
 		},
 		{
 			name:                 "no schedule to start timeout",
@@ -182,12 +217,13 @@ func TestTransitionRescheduled(t *testing.T) {
 			expectedTasks: []chasm.MockTask{
 				{Payload: &activitypb.ActivityDispatchTask{}},
 			},
-			expectedRetryInterval:  2 * time.Second,
-			retryPolicy:            defaultRetryPolicy,
-			scheduleToStartTimeout: 0,
-			operationTag:           metrics.TimerActiveTaskActivityTimeoutScope,
-			counterMetric:          metrics.ActivityTaskTimeout.Name(),
-			timeoutType:            enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
+			expectedRetryInterval:    2 * time.Second,
+			expectedStartDelayBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE,
+			retryPolicy:              defaultRetryPolicy,
+			scheduleToStartTimeout:   0,
+			operationTag:             metrics.TimerActiveTaskActivityTimeoutScope,
+			counterMetric:            metrics.ActivityTaskTimeout.Name(),
+			timeoutType:              enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
 		},
 		{
 			name:                 "heartbeat timeout - timeout recorded",
@@ -196,12 +232,13 @@ func TestTransitionRescheduled(t *testing.T) {
 				{Payload: &activitypb.ScheduleToStartTimeoutTask{}},
 				{Payload: &activitypb.ActivityDispatchTask{}},
 			},
-			expectedRetryInterval:  2 * time.Second,
-			retryPolicy:            defaultRetryPolicy,
-			scheduleToStartTimeout: defaultScheduleToStartTimeout,
-			operationTag:           metrics.TimerActiveTaskActivityTimeoutScope,
-			counterMetric:          metrics.ActivityTaskTimeout.Name(),
-			timeoutType:            enumspb.TIMEOUT_TYPE_HEARTBEAT,
+			expectedRetryInterval:    2 * time.Second,
+			expectedStartDelayBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE,
+			retryPolicy:              defaultRetryPolicy,
+			scheduleToStartTimeout:   defaultScheduleToStartTimeout,
+			operationTag:             metrics.TimerActiveTaskActivityTimeoutScope,
+			counterMetric:            metrics.ActivityTaskTimeout.Name(),
+			timeoutType:              enumspb.TIMEOUT_TYPE_HEARTBEAT,
 		},
 
 		{
@@ -211,11 +248,27 @@ func TestTransitionRescheduled(t *testing.T) {
 				{Payload: &activitypb.ScheduleToStartTimeoutTask{}},
 				{Payload: &activitypb.ActivityDispatchTask{}},
 			},
-			expectedRetryInterval:  2 * time.Second,
-			retryPolicy:            defaultRetryPolicy,
-			scheduleToStartTimeout: defaultScheduleToStartTimeout,
-			operationTag:           metrics.HistoryRespondActivityTaskFailedScope,
-			counterMetric:          metrics.ActivityTaskFail.Name(),
+			expectedRetryInterval:    2 * time.Second,
+			expectedStartDelayBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_NONE,
+			retryPolicy:              defaultRetryPolicy,
+			scheduleToStartTimeout:   defaultScheduleToStartTimeout,
+			operationTag:             metrics.HistoryRespondActivityTaskFailedScope,
+			counterMetric:            metrics.ActivityTaskFail.Name(),
+		},
+		{
+			name:                 "retry preserves configured start delay bucket",
+			startingAttemptCount: 1,
+			expectedTasks: []chasm.MockTask{
+				{Payload: &activitypb.ScheduleToStartTimeoutTask{}},
+				{Payload: &activitypb.ActivityDispatchTask{}},
+			},
+			expectedRetryInterval:    2 * time.Second,
+			startDelay:               5 * time.Minute,
+			expectedStartDelayBucket: activitypb.ActivityDispatchTask_START_DELAY_BUCKET_1M_10M,
+			retryPolicy:              defaultRetryPolicy,
+			scheduleToStartTimeout:   defaultScheduleToStartTimeout,
+			operationTag:             metrics.HistoryRespondActivityTaskFailedScope,
+			counterMetric:            metrics.ActivityTaskFail.Name(),
 		},
 	}
 
@@ -228,13 +281,15 @@ func TestTransitionRescheduled(t *testing.T) {
 
 			activity := &Activity{
 				ActivityState: &activitypb.ActivityState{
-					ActivityType:           &commonpb.ActivityType{Name: "test-activity-type"},
-					RetryPolicy:            defaultRetryPolicy,
-					ScheduleToCloseTimeout: durationpb.New(defaultScheduleToCloseTimeout),
-					ScheduleToStartTimeout: durationpb.New(tc.scheduleToStartTimeout),
-					StartToCloseTimeout:    durationpb.New(defaultStartToCloseTimeout),
-					Status:                 activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
-					TaskQueue:              &taskqueuepb.TaskQueue{Name: "test-task-queue"},
+					ActivityType:            &commonpb.ActivityType{Name: "test-activity-type"},
+					RetryPolicy:             defaultRetryPolicy,
+					ScheduleToCloseTimeout:  durationpb.New(defaultScheduleToCloseTimeout),
+					ScheduleToStartTimeout:  durationpb.New(tc.scheduleToStartTimeout),
+					StartDelay:              durationpb.New(tc.startDelay),
+					StartToCloseTimeout:     durationpb.New(defaultStartToCloseTimeout),
+					Status:                  activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
+					TaskQueue:               &taskqueuepb.TaskQueue{Name: "test-task-queue"},
+					FirstAttemptStartedTime: timestamppb.New(defaultTime),
 				},
 				LastAttempt: chasm.NewDataField(ctx, attemptState),
 				Outcome:     chasm.NewDataField(ctx, outcome),
@@ -266,9 +321,11 @@ func TestTransitionRescheduled(t *testing.T) {
 
 				switch expectedTask.Payload.(type) {
 				case *activitypb.ActivityDispatchTask:
-					_, ok := actualTask.Payload.(*activitypb.ActivityDispatchTask)
+					dispatchTask, ok := actualTask.Payload.(*activitypb.ActivityDispatchTask)
 					require.True(t, ok, "expected ActivityDispatchTask at index %d", i)
 					require.Equal(t, defaultTime.Add(tc.expectedRetryInterval), actualTask.Attributes.ScheduledTime)
+					require.Equal(t, activitypb.ActivityDispatchTask_DISPATCH_REASON_RETRY, dispatchTask.GetDispatchReason())
+					require.Equal(t, tc.expectedStartDelayBucket, dispatchTask.GetStartDelayBucket())
 				case *activitypb.ScheduleToStartTimeoutTask:
 					_, ok := actualTask.Payload.(*activitypb.ScheduleToStartTimeoutTask)
 					require.True(t, ok, "expected ScheduleToStartTimeoutTask at index %d", i)


### PR DESCRIPTION
## What changed?
Added dispatch-reason and configured start-delay-bucket metadata to standalone activity dispatch tasks. All task creation paths now populate this metadata consistently, with coverage for immediate, delayed, and retry dispatches.

## Why?
Persistence layer needs this metadata to measure how often activity dispatch tasks are persisted to the task database and quantify the write amplification associated with configured start delay.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)
