### PR TITLE
Add HSM<->CHASM Nexus completion conversion

### DIFF
--- a/nexusworkflowref/nexusworkflowref.go
+++ b/nexusworkflowref/nexusworkflowref.go
@@ -1,0 +1,157 @@
+// Package nexusworkflowref converts a Nexus operation completion token between its HSM and CHASM
+// forms. A rebuild (reset or conflict resolution) can re-create a workflow's Nexus operation under
+// the other framework by dynamic config after its callback token was minted, so a completion may
+// arrive addressing the framework the operation no longer lives in; converting the token lets it be
+// retried against the current framework. Only workflow-backed operations are convertible — the HSM
+// operation state machine and the CHASM workflow's Operations map are two representations of the
+// same thing, keyed by scheduled event ID.
+package nexusworkflowref
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	tokenspb "go.temporal.io/server/api/token/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/components/nexusoperations"
+)
+
+// operationsFieldName is the first segment of a workflow Nexus operation's CHASM component path (the
+// scheduled event ID, the map key, is the second). It must stay in sync with the Workflow.Operations
+// field in chasm/lib/workflow.
+const operationsFieldName = "Operations"
+
+// operationIdentity is the framework-agnostic identity of a workflow Nexus operation: the fields
+// shared by the HSM and CHASM completion refs, sufficient to address the operation in either.
+type operationIdentity struct {
+	namespaceID      string
+	workflowID       string
+	runID            string
+	scheduledEventID int64
+	requestID        string
+}
+
+// HSMRefToCHASMRef converts an HSM-format Nexus operation completion token into the equivalent
+// CHASM-format token.
+func HSMRefToCHASMRef(completion *tokenspb.NexusOperationCompletion) (*tokenspb.NexusOperationCompletion, error) {
+	id, err := identityFromHSM(completion)
+	if err != nil {
+		return nil, err
+	}
+	return chasmCompletion(id)
+}
+
+// CHASMRefToHSMRef converts a CHASM-format Nexus operation completion token into the equivalent
+// HSM-format token. It errors if the CHASM ref is not a workflow-backed operation (wrong archetype
+// or unexpected component path), since only those have an HSM equivalent.
+func CHASMRefToHSMRef(completion *tokenspb.NexusOperationCompletion) (*tokenspb.NexusOperationCompletion, error) {
+	id, err := identityFromCHASM(completion)
+	if err != nil {
+		return nil, err
+	}
+	return hsmCompletion(id), nil
+}
+
+func identityFromHSM(completion *tokenspb.NexusOperationCompletion) (operationIdentity, error) {
+	scheduledEventID, err := scheduledEventIDFromHSMRef(completion.GetRef())
+	if err != nil {
+		return operationIdentity{}, err
+	}
+	return operationIdentity{
+		namespaceID:      completion.GetNamespaceId(),
+		workflowID:       completion.GetWorkflowId(),
+		runID:            completion.GetRunId(),
+		scheduledEventID: scheduledEventID,
+		requestID:        completion.GetRequestId(),
+	}, nil
+}
+
+func identityFromCHASM(completion *tokenspb.NexusOperationCompletion) (operationIdentity, error) {
+	var ref persistencespb.ChasmComponentRef
+	if err := ref.Unmarshal(completion.GetComponentRef()); err != nil {
+		return operationIdentity{}, fmt.Errorf("failed to unmarshal component ref: %w", err)
+	}
+	// Only a workflow-backed operation has an HSM equivalent. Confirm the ref addresses one via the
+	// workflow archetype and the Operations component path before treating it as an operation.
+	if ref.GetArchetypeId() != chasm.WorkflowArchetypeID {
+		return operationIdentity{}, fmt.Errorf("component ref is not workflow-backed (archetype %d)", ref.GetArchetypeId())
+	}
+	scheduledEventID, err := scheduledEventIDFromComponentPath(ref.GetComponentPath())
+	if err != nil {
+		return operationIdentity{}, err
+	}
+	return operationIdentity{
+		namespaceID:      ref.GetNamespaceId(),
+		workflowID:       ref.GetBusinessId(),
+		runID:            ref.GetRunId(),
+		scheduledEventID: scheduledEventID,
+		requestID:        completion.GetRequestId(),
+	}, nil
+}
+
+// chasmCompletion builds a CHASM-format completion token. The ComponentRef carries no versioned
+// transitions, so identity is re-established by request ID; the consistency level chosen by the
+// resolver then selects the run (ComponentCreation keeps the ref's run, CurrentRun the current run).
+func chasmCompletion(id operationIdentity) (*tokenspb.NexusOperationCompletion, error) {
+	ref, err := (&persistencespb.ChasmComponentRef{
+		NamespaceId:   id.namespaceID,
+		BusinessId:    id.workflowID,
+		RunId:         id.runID,
+		ArchetypeId:   chasm.WorkflowArchetypeID,
+		ComponentPath: []string{operationsFieldName, strconv.FormatInt(id.scheduledEventID, 10)},
+	}).Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal component ref: %w", err)
+	}
+	return &tokenspb.NexusOperationCompletion{
+		ComponentRef: ref,
+		RequestId:    id.requestID,
+	}, nil
+}
+
+// hsmCompletion builds an HSM-format completion token. The versioned-transition fields are non-nil
+// zero values: the completion handler's reset fallback zeroes their transition counts and would
+// nil-panic if they were unset. Identity is re-established by request ID.
+func hsmCompletion(id operationIdentity) *tokenspb.NexusOperationCompletion {
+	return &tokenspb.NexusOperationCompletion{
+		NamespaceId: id.namespaceID,
+		WorkflowId:  id.workflowID,
+		RunId:       id.runID,
+		Ref: &persistencespb.StateMachineRef{
+			Path: []*persistencespb.StateMachineKey{{
+				Type: nexusoperations.OperationMachineType,
+				Id:   strconv.FormatInt(id.scheduledEventID, 10),
+			}},
+			MachineInitialVersionedTransition:    &persistencespb.VersionedTransition{},
+			MachineLastUpdateVersionedTransition: &persistencespb.VersionedTransition{},
+		},
+		RequestId: id.requestID,
+	}
+}
+
+func scheduledEventIDFromHSMRef(ref *persistencespb.StateMachineRef) (int64, error) {
+	for _, key := range ref.GetPath() {
+		if key.GetType() != nexusoperations.OperationMachineType {
+			continue
+		}
+		scheduledEventID, err := strconv.ParseInt(key.GetId(), 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid operation state machine id %q: %w", key.GetId(), err)
+		}
+		return scheduledEventID, nil
+	}
+	return 0, errors.New("completion token has no operation state machine reference")
+}
+
+func scheduledEventIDFromComponentPath(path []string) (int64, error) {
+	if len(path) != 2 || path[0] != operationsFieldName {
+		return 0, fmt.Errorf("unexpected nexus operation component path %v", path)
+	}
+	scheduledEventID, err := strconv.ParseInt(path[1], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid scheduled event id %q: %w", path[1], err)
+	}
+	return scheduledEventID, nil
+}

--- a/nexusworkflowref/nexusworkflowref_test.go
+++ b/nexusworkflowref/nexusworkflowref_test.go
@@ -1,0 +1,125 @@
+package nexusworkflowref
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	tokenspb "go.temporal.io/server/api/token/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/components/nexusoperations"
+)
+
+const (
+	testNamespaceID      = "namespace-id"
+	testWorkflowID       = "workflow-id"
+	testRunID            = "run-id"
+	testScheduledEventID = int64(42)
+	testRequestID        = "request-id"
+)
+
+func hsmToken() *tokenspb.NexusOperationCompletion {
+	return &tokenspb.NexusOperationCompletion{
+		NamespaceId: testNamespaceID,
+		WorkflowId:  testWorkflowID,
+		RunId:       testRunID,
+		Ref: &persistencespb.StateMachineRef{
+			Path: []*persistencespb.StateMachineKey{{
+				Type: nexusoperations.OperationMachineType,
+				Id:   strconv.FormatInt(testScheduledEventID, 10),
+			}},
+		},
+		RequestId: testRequestID,
+	}
+}
+
+func chasmToken(t *testing.T, archetypeID uint32, path []string) *tokenspb.NexusOperationCompletion {
+	t.Helper()
+	ref, err := (&persistencespb.ChasmComponentRef{
+		NamespaceId:   testNamespaceID,
+		BusinessId:    testWorkflowID,
+		RunId:         testRunID,
+		ArchetypeId:   archetypeID,
+		ComponentPath: path,
+	}).Marshal()
+	require.NoError(t, err)
+	return &tokenspb.NexusOperationCompletion{ComponentRef: ref, RequestId: testRequestID}
+}
+
+func TestHSMRefToCHASMRef(t *testing.T) {
+	t.Parallel()
+
+	chasmCompletion, err := HSMRefToCHASMRef(hsmToken())
+	require.NoError(t, err)
+	require.NotEmpty(t, chasmCompletion.GetComponentRef())
+	require.Nil(t, chasmCompletion.GetRef())
+	require.Equal(t, testRequestID, chasmCompletion.GetRequestId())
+
+	var ref persistencespb.ChasmComponentRef
+	require.NoError(t, ref.Unmarshal(chasmCompletion.GetComponentRef()))
+	require.Equal(t, testNamespaceID, ref.GetNamespaceId())
+	require.Equal(t, testWorkflowID, ref.GetBusinessId())
+	require.Equal(t, testRunID, ref.GetRunId())
+	require.Equal(t, chasm.WorkflowArchetypeID, ref.GetArchetypeId())
+	require.Equal(t, []string{operationsFieldName, strconv.FormatInt(testScheduledEventID, 10)}, ref.GetComponentPath())
+}
+
+func TestHSMRefToCHASMRef_NoOperationRef(t *testing.T) {
+	t.Parallel()
+
+	_, err := HSMRefToCHASMRef(&tokenspb.NexusOperationCompletion{RequestId: testRequestID})
+	require.Error(t, err)
+}
+
+func TestCHASMRefToHSMRef(t *testing.T) {
+	t.Parallel()
+
+	token := chasmToken(t, chasm.WorkflowArchetypeID, []string{operationsFieldName, strconv.FormatInt(testScheduledEventID, 10)})
+	hsmCompletion, err := CHASMRefToHSMRef(token)
+	require.NoError(t, err)
+	require.Empty(t, hsmCompletion.GetComponentRef())
+	require.Equal(t, testNamespaceID, hsmCompletion.GetNamespaceId())
+	require.Equal(t, testWorkflowID, hsmCompletion.GetWorkflowId())
+	require.Equal(t, testRunID, hsmCompletion.GetRunId())
+	require.Equal(t, testRequestID, hsmCompletion.GetRequestId())
+
+	path := hsmCompletion.GetRef().GetPath()
+	require.Len(t, path, 1)
+	require.Equal(t, nexusoperations.OperationMachineType, path[0].GetType())
+	require.Equal(t, strconv.FormatInt(testScheduledEventID, 10), path[0].GetId())
+	// Non-nil versioned transitions so the HSM completion handler's reset fallback does not nil-panic.
+	require.NotNil(t, hsmCompletion.GetRef().GetMachineInitialVersionedTransition())
+	require.NotNil(t, hsmCompletion.GetRef().GetMachineLastUpdateVersionedTransition())
+}
+
+func TestCHASMRefToHSMRef_RejectsNonWorkflowArchetype(t *testing.T) {
+	t.Parallel()
+
+	token := chasmToken(t, chasm.WorkflowArchetypeID+1, []string{operationsFieldName, strconv.FormatInt(testScheduledEventID, 10)})
+	_, err := CHASMRefToHSMRef(token)
+	require.ErrorContains(t, err, "not workflow-backed")
+}
+
+func TestCHASMRefToHSMRef_RejectsUnexpectedPath(t *testing.T) {
+	t.Parallel()
+
+	token := chasmToken(t, chasm.WorkflowArchetypeID, []string{"NotOperations", "42"})
+	_, err := CHASMRefToHSMRef(token)
+	require.ErrorContains(t, err, "unexpected nexus operation component path")
+}
+
+func TestRoundTripHSMToCHASMToHSM(t *testing.T) {
+	t.Parallel()
+
+	chasmCompletion, err := HSMRefToCHASMRef(hsmToken())
+	require.NoError(t, err)
+	hsmCompletion, err := CHASMRefToHSMRef(chasmCompletion)
+	require.NoError(t, err)
+
+	require.Equal(t, testNamespaceID, hsmCompletion.GetNamespaceId())
+	require.Equal(t, testWorkflowID, hsmCompletion.GetWorkflowId())
+	require.Equal(t, testRunID, hsmCompletion.GetRunId())
+	require.Equal(t, testRequestID, hsmCompletion.GetRequestId())
+	require.Equal(t, strconv.FormatInt(testScheduledEventID, 10), hsmCompletion.GetRef().GetPath()[0].GetId())
+}


### PR DESCRIPTION
## What changed?
Adds a top-level `nexusworkflowref` package exposing two functions that convert a Nexus operation completion token between its HSM and CHASM forms:
- `HSMRefToCHASMRef` — HSM `StateMachineRef` token → CHASM `ChasmComponentRef` token
- `CHASMRefToHSMRef` — the reverse

Both directions rebuild the target framework's ref from the fields shared by the two representations (namespace, workflow, run, scheduled event ID, request ID). `CHASMRefToHSMRef` only accepts workflow-backed operations: it verifies the ref's `WorkflowArchetypeID` and its `["Operations", "<scheduledEventID>"]` component path before converting.

## Why?
Preparation for the cross-framework Nexus completion fallback (#11035), where a completion whose token targets one framework must be retried against the other after a rebuild (reset or conflict resolution) flips the operation's framework. 

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Low — additive, and only invoked by #11035. The one coupling to watch: the converter encodes the CHASM `Operations` map field name and `WorkflowArchetypeID`; a change to the workflow component's layout must be reflected here.