### PR TITLE
Don't subscribe to dynamic config until partition manager Start, fixing loser-of-load-race leak

### DIFF
--- a/service/matching/matcher_data_test.go
+++ b/service/matching/matcher_data_test.go
@@ -50,6 +50,7 @@ func (s *MatcherDataSuite) SetupTest() {
 	s.ts = clock.NewEventTimeSource().Update(time.Now())
 	s.ts.UseAsyncTimers(true)
 	rateLimitManager := newRateLimitManager(&mockUserDataManager{}, cfg, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
+	rateLimitManager.Start()
 	s.rateLimitedCount.Store(0)
 	s.md = newMatcherData(cfg, logger, s.ts, true, rateLimitManager, func() { s.rateLimitedCount.Add(1) })
 }
@@ -1095,6 +1096,7 @@ func FuzzMatcherData(f *testing.F) {
 		ts.UseAsyncTimers(true)
 		logger := log.NewNoopLogger()
 		rateLimitManager := newRateLimitManager(&mockUserDataManager{}, cfg, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
+		rateLimitManager.Start()
 		md := newMatcherData(cfg, logger, ts, true, rateLimitManager, func() {})
 
 		next := func() int {

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -528,6 +528,13 @@ func (e *matchingEngineImpl) getTaskQueuePartitionManager(
 	pm, ok = e.partitions[key]
 	if ok {
 		e.partitionsLock.Unlock()
+		// Lost the race with a concurrent load of the same partition. Release the
+		// resources newPM acquired at construction time (in particular its dynamic
+		// config subscriptions), otherwise the abandoned manager stays reachable
+		// from the dynamic config collection forever and is never garbage
+		// collected. Note that Stop cannot be used here: it blocks on the default
+		// queue future, which is only set after the manager is started.
+		newPM.closeUnstarted()
 		return pm, false, nil
 	}
 

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -528,13 +528,9 @@ func (e *matchingEngineImpl) getTaskQueuePartitionManager(
 	pm, ok = e.partitions[key]
 	if ok {
 		e.partitionsLock.Unlock()
-		// Lost the race with a concurrent load of the same partition. Release the
-		// resources newPM acquired at construction time (in particular its dynamic
-		// config subscriptions), otherwise the abandoned manager stays reachable
-		// from the dynamic config collection forever and is never garbage
-		// collected. Note that Stop cannot be used here: it blocks on the default
-		// queue future, which is only set after the manager is started.
-		newPM.closeUnstarted()
+		// Lost the race with a concurrent load of the same partition. The unstarted
+		// newPM holds no external references (subscriptions etc. are only registered
+		// in Start), so it can simply be dropped and garbage collected.
 		return pm, false, nil
 	}
 

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -1485,11 +1485,13 @@ func (s *matchingEngineSuite) TestSyncMatchActivities() {
 	dbq := newUnversionedRootQueueKey(namespaceID, tl, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
 	mgr := s.newPartitionManager(dbq.partition, s.matchingEngine.config)
 
-	// Directly override admin rate limits to simulate dynamic config at rateLimitManager.
-	mgr.GetRateLimitManager().SetAdminRateForTesting(25000.0)
-
 	s.matchingEngine.updateTaskQueue(dbq.partition, mgr)
 	mgr.Start()
+
+	// Directly override admin rate limits to simulate dynamic config at rateLimitManager.
+	// Must happen after Start, which registers the dynamic config subscriptions and
+	// initializes the admin rates from config.
+	mgr.GetRateLimitManager().SetAdminRateForTesting(25000.0)
 
 	taskQueue := &taskqueuepb.TaskQueue{
 		Name: tl,

--- a/service/matching/pri_matcher_test.go
+++ b/service/matching/pri_matcher_test.go
@@ -66,6 +66,7 @@ func (s *PriMatcherSuite) TestValidatorWorksOnRoot() {
 	})
 
 	rateLimitManager := newRateLimitManager(&mockUserDataManager{}, cfg, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
+	rateLimitManager.Start()
 
 	tm := newPriTaskMatcher(
 		ctx,
@@ -160,6 +161,7 @@ func (s *PriMatcherSuite) TestForwardPollRetriesOnResourceExhausted() {
 		require.NoError(t, err)
 
 		rateLimitManager := newRateLimitManager(&mockUserDataManager{}, cfg, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
+		rateLimitManager.Start()
 
 		tm := newPriTaskMatcher(
 			ctx,
@@ -228,6 +230,7 @@ func (s *PriMatcherSuite) TestValidatorDrop_SetsDropReason() {
 			mockValidator.EXPECT().maybeValidate(gomock.Any(), gomock.Any()).Return(false).AnyTimes()
 
 			rateLimitManager := newRateLimitManager(&mockUserDataManager{}, cfg, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
+			rateLimitManager.Start()
 			tm := newPriTaskMatcher(
 				ctx,
 				cfg,

--- a/service/matching/ratelimit_manager.go
+++ b/service/matching/ratelimit_manager.go
@@ -62,7 +62,9 @@ const (
 	defaultBurstDuration = time.Second
 )
 
-// Create a new rate limit manager for the task queue partition.
+// Create a new rate limit manager for the task queue partition. This only allocates;
+// dynamic config subscriptions are registered in Start, so an unstarted manager holds
+// no external references and can simply be garbage collected.
 func newRateLimitManager(
 	userDataManager userDataManager,
 	config *taskQueueConfig,
@@ -83,21 +85,23 @@ func newRateLimitManager(
 		r.dynamicRateBurst,
 		config.RateLimiterRefreshInterval,
 	)
+	return r
+}
 
+// Start registers dynamic config subscriptions and computes the initial rate limits.
+func (r *rateLimitManager) Start() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	// Overall system rate limit will be the min of the two configs that are partition wise times the number of partitons.
 	var cancel func()
-	r.adminNsRate, cancel = config.AdminNamespaceToPartitionRateSub(r.setAdminNsRate)
+	r.adminNsRate, cancel = r.config.AdminNamespaceToPartitionRateSub(r.setAdminNsRate)
 	r.cancels = append(r.cancels, cancel)
-	r.adminTqRate, cancel = config.AdminNamespaceTaskQueueToPartitionRateSub(r.setAdminTqRate)
+	r.adminTqRate, cancel = r.config.AdminNamespaceTaskQueueToPartitionRateSub(r.setAdminTqRate)
 	r.cancels = append(r.cancels, cancel)
-	r.numReadPartitions, cancel = config.NumReadPartitionsSub(r.setNumReadPartitions)
+	r.numReadPartitions, cancel = r.config.NumReadPartitionsSub(r.setNumReadPartitions)
 	r.cancels = append(r.cancels, cancel)
 	r.computeEffectiveRPSAndSourceLocked()
-
-	return r
 }
 
 func (r *rateLimitManager) setAdminNsRate(rps float64) {

--- a/service/matching/ratelimit_manager_test.go
+++ b/service/matching/ratelimit_manager_test.go
@@ -35,6 +35,7 @@ func (s *RateLimitManagerSuite) TestUpdatePerKeySimpleRateLimitLocked_WhenFairne
 		"test-namespace",
 	)
 	rateLimitManager := newRateLimitManager(mockUserDataManager, config, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
+	rateLimitManager.Start()
 	rateLimitManager.mu.Lock()
 	// Simulate the condition where fairnessKeyRateLimitDefault is nil
 	rateLimitManager.fairnessKeyRateLimitDefault = nil
@@ -144,6 +145,7 @@ func (s *RateLimitManagerSuite) TestFractionScaling_ApiConfigRPS() {
 		cfg, "test-ns",
 	)
 	rlm := newRateLimitManager(&mockUserDataManager{}, config, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
+	rlm.Start()
 	defer rlm.Stop()
 
 	rlm.SetAPIConfigRPSForTesting(100.0)
@@ -162,6 +164,7 @@ func (s *RateLimitManagerSuite) TestFractionScaling_WorkerRPS() {
 		cfg, "test-ns",
 	)
 	rlm := newRateLimitManager(&mockUserDataManager{}, config, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
+	rlm.Start()
 	defer rlm.Stop()
 
 	rlm.SetWorkerRPSForTesting(100.0)
@@ -197,6 +200,7 @@ func (s *RateLimitManagerSuite) TestFractionScaling_FairnessKeyRateLimitDefault(
 		},
 	}
 	rlm := newRateLimitManager(udm, config, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
+	rlm.Start()
 	defer rlm.Stop()
 
 	rlm.UserDataChanged()
@@ -218,6 +222,7 @@ func (s *RateLimitManagerSuite) TestFractionScaling_ZeroFraction() {
 		cfg, "test-ns",
 	)
 	rlm := newRateLimitManager(&mockUserDataManager{}, config, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
+	rlm.Start()
 	defer rlm.Stop()
 
 	rlm.SetAPIConfigRPSForTesting(100.0)

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -120,6 +120,10 @@ func (pm *taskQueuePartitionManagerImpl) GetCache(key any) any {
 
 var _ taskQueuePartitionManager = (*taskQueuePartitionManagerImpl)(nil)
 
+// newTaskQueuePartitionManager must only allocate: the matching engine may drop the
+// result without starting it when it loses the race with a concurrent load of the same
+// partition, so acquiring external references here (e.g. dynamic config subscriptions)
+// would leak. Anything that registers the manager elsewhere belongs in Start.
 func newTaskQueuePartitionManager(
 	e *matchingEngineImpl,
 	ns *namespace.Namespace,
@@ -291,6 +295,7 @@ func (pm *taskQueuePartitionManagerImpl) defaultQueue() physicalTaskQueueManager
 func (pm *taskQueuePartitionManagerImpl) Start() {
 	pm.loadTime = time.Now()
 	pm.engine.updateTaskQueuePartitionGauge(pm.Namespace(), pm.partition, 1)
+	pm.rateLimitManager.Start()
 	pm.userDataManager.Start()
 	for _, hook := range pm.taskHooks {
 		hook.Start()
@@ -341,19 +346,6 @@ func (pm *taskQueuePartitionManagerImpl) Stop(unloadCause unloadCause) {
 	pm.engine.updateTaskQueuePartitionGauge(pm.Namespace(), pm.partition, -1)
 
 	pm.goroGroup.Cancel()
-}
-
-// closeUnstarted releases the resources acquired when constructing a manager that
-// was never started, so that it can be garbage collected. In particular, the rate
-// limit manager registers dynamic config subscriptions at construction time, which
-// keep the whole manager graph reachable from the dynamic config collection until
-// they are cancelled. Stop cannot be used for this purpose: it blocks on
-// defaultQueueFuture, which is only set once a started manager has initialized.
-// Must not be called on a manager that has been started.
-func (pm *taskQueuePartitionManagerImpl) closeUnstarted() {
-	pm.initCancel()
-	pm.rateLimitManager.Stop()
-	pm.userDataManager.Stop()
 }
 
 func (pm *taskQueuePartitionManagerImpl) StartScaleManager(scaleState *persistencespb.PartitionScaleState) {

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -343,6 +343,19 @@ func (pm *taskQueuePartitionManagerImpl) Stop(unloadCause unloadCause) {
 	pm.goroGroup.Cancel()
 }
 
+// closeUnstarted releases the resources acquired when constructing a manager that
+// was never started, so that it can be garbage collected. In particular, the rate
+// limit manager registers dynamic config subscriptions at construction time, which
+// keep the whole manager graph reachable from the dynamic config collection until
+// they are cancelled. Stop cannot be used for this purpose: it blocks on
+// defaultQueueFuture, which is only set once a started manager has initialized.
+// Must not be called on a manager that has been started.
+func (pm *taskQueuePartitionManagerImpl) closeUnstarted() {
+	pm.initCancel()
+	pm.rateLimitManager.Stop()
+	pm.userDataManager.Stop()
+}
+
 func (pm *taskQueuePartitionManagerImpl) StartScaleManager(scaleState *persistencespb.PartitionScaleState) {
 	// Note that this must be called before defaultQueue is marked initialized!
 	// Otherwise child partitions will see empty scale info in their first ephemeral data update.

--- a/service/matching/task_queue_partition_manager_test.go
+++ b/service/matching/task_queue_partition_manager_test.go
@@ -1396,12 +1396,11 @@ func (h *capturingTaskMatchHook) getCalls() []capturedTaskMatchDetails {
 	return append([]capturedTaskMatchDetails(nil), h.calls...)
 }
 
-// closeUnstarted is used by the matching engine on the loser side of a concurrent
-// load of the same partition. It must release the dynamic config subscriptions
-// registered at construction time (otherwise the abandoned manager stays reachable
-// from the dynamic config collection forever), and it must not block even though
-// the manager was never started.
-func (s *PartitionManagerTestSuite) TestCloseUnstartedReleasesDynamicConfigSubscriptions() {
+// The matching engine drops an unstarted manager on the loser side of a concurrent
+// load of the same partition. Construction must therefore not register any dynamic
+// config subscriptions — otherwise the abandoned manager would stay reachable from
+// the dynamic config collection forever. Subscriptions are only registered in Start.
+func (s *PartitionManagerTestSuite) TestConstructionDoesNotRegisterDynamicConfigSubscriptions() {
 	f, err := tqid.NewTaskQueueFamily(namespaceID, taskQueueName)
 	s.Require().NoError(err)
 	partition := f.TaskQueue(enumspb.TASK_QUEUE_TYPE_WORKFLOW).RootPartition()
@@ -1409,18 +1408,12 @@ func (s *PartitionManagerTestSuite) TestCloseUnstartedReleasesDynamicConfigSubsc
 
 	pm, err := newTaskQueuePartitionManager(s.partitionMgr.engine, s.partitionMgr.ns, partition, tqConfig, s.partitionMgr.logger, s.partitionMgr.throttledLogger, metrics.NoopMetricsHandler, &mockUserDataManager{})
 	s.Require().NoError(err)
-	s.Require().NotEmpty(pm.rateLimitManager.cancels)
+	s.Empty(pm.rateLimitManager.cancels)
 
-	done := make(chan struct{})
-	go func() {
-		pm.closeUnstarted()
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(10 * time.Second):
-		s.FailNow("closeUnstarted blocked on an unstarted partition manager")
-	}
+	pm.rateLimitManager.Start()
+	s.NotEmpty(pm.rateLimitManager.cancels)
+
+	pm.rateLimitManager.Stop()
 	s.Empty(pm.rateLimitManager.cancels)
 }
 

--- a/service/matching/task_queue_partition_manager_test.go
+++ b/service/matching/task_queue_partition_manager_test.go
@@ -1396,6 +1396,34 @@ func (h *capturingTaskMatchHook) getCalls() []capturedTaskMatchDetails {
 	return append([]capturedTaskMatchDetails(nil), h.calls...)
 }
 
+// closeUnstarted is used by the matching engine on the loser side of a concurrent
+// load of the same partition. It must release the dynamic config subscriptions
+// registered at construction time (otherwise the abandoned manager stays reachable
+// from the dynamic config collection forever), and it must not block even though
+// the manager was never started.
+func (s *PartitionManagerTestSuite) TestCloseUnstartedReleasesDynamicConfigSubscriptions() {
+	f, err := tqid.NewTaskQueueFamily(namespaceID, taskQueueName)
+	s.Require().NoError(err)
+	partition := f.TaskQueue(enumspb.TASK_QUEUE_TYPE_WORKFLOW).RootPartition()
+	tqConfig := newTaskQueueConfig(partition.TaskQueue(), s.partitionMgr.engine.config, s.partitionMgr.ns.Name())
+
+	pm, err := newTaskQueuePartitionManager(s.partitionMgr.engine, s.partitionMgr.ns, partition, tqConfig, s.partitionMgr.logger, s.partitionMgr.throttledLogger, metrics.NoopMetricsHandler, &mockUserDataManager{})
+	s.Require().NoError(err)
+	s.Require().NotEmpty(pm.rateLimitManager.cancels)
+
+	done := make(chan struct{})
+	go func() {
+		pm.closeUnstarted()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		s.FailNow("closeUnstarted blocked on an unstarted partition manager")
+	}
+	s.Empty(pm.rateLimitManager.cancels)
+}
+
 // setupPartitionManagerWithTaskHookFactories creates a partition manager with the given task match hooks.
 func (s *PartitionManagerTestSuite) setupPartitionManagerWithTaskHookFactories(taskHookFactories []hooks.TaskHookFactory) (*taskQueuePartitionManagerImpl, func()) {
 	f, err := tqid.NewTaskQueueFamily(namespaceID, taskQueueName)


### PR DESCRIPTION
## What changed?

`newTaskQueuePartitionManager` (and `newRateLimitManager`) now only allocate: the rate limit manager's dynamic config subscriptions are registered in `Start` instead of at construction time.

With that, the loser of the double-checked race in `getTaskQueuePartitionManager` (constructed, but never started or published) holds no external references and can simply be dropped and garbage collected — no special cleanup path needed.

## Why?

Fixes #11051.

The full partition manager graph is constructed before taking the write lock. When the constructor lost the race, the abandoned manager stayed reachable from the dynamic config collection forever via the subscriptions `newRateLimitManager` registered at construction time, so it was never garbage collected.

Any repeated partition unload with user-data pollers attached triggers this: when a partition unloads, the returning `GetTaskQueueUserData` long-polls from child partitions and sticky queues race to re-create it, and every reload could strand one or more losers (~55 KB each). In the deployment where this was found, lease contention unloaded every system task queue roughly every 30s, producing unbounded matching heap growth (~50 MB/h with no workflow traffic) ending in OOM — but healthy clusters hit the same race whenever partition ownership moves (rolling deploys, scaling matching nodes). See the issue for heap profile diffs and the full root cause analysis.

## How did you test it?

- [x] built
- [x] added new unit test(s)

`TestConstructionDoesNotRegisterDynamicConfigSubscriptions` verifies that construction registers no dynamic config subscriptions, and that `Start`/`Stop` register and release them. Existing tests that construct a `rateLimitManager` directly now call `Start` on it, matching the production lifecycle. Passes in all three suite variants (Classic/Pri/Fair). The leak itself was diagnosed from production heap profile diffs (growth signature rooted at `newTaskQueuePartitionManager` under the `GetTaskQueueUserData` handler, pinned via `dynamicconfig.subscribe[...]`), matching exactly the loser path.

## Potential risks

Rate limits are now initialized in `Start` rather than at construction. The manager is only published to the partitions map immediately before `Start`, and all dispatch/poll paths gate on `defaultQueueFuture`, which is only set by `initialize` (spawned at the end of `Start`), so no path can observe the rate limit manager before its subscriptions are registered.
