### PR TITLE
Fix nil-map panic in simplePartitionScaler

### DIFF
--- a/service/matching/simple_partition_scaler.go
+++ b/service/matching/simple_partition_scaler.go
@@ -42,8 +42,9 @@ type simplePartitionScaler struct {
 
 func newSimplePartitionScaler(cfg scalerCfg, ts clock.TimeSource) *simplePartitionScaler {
 	return &simplePartitionScaler{
-		cfg: cfg,
-		ts:  ts,
+		cfg:      cfg,
+		ts:       ts,
+		trackers: make(map[time.Duration]*taskTracker),
 	}
 }
 

--- a/service/matching/simple_partition_scaler_test.go
+++ b/service/matching/simple_partition_scaler_test.go
@@ -1,0 +1,40 @@
+package matching
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/dynamicconfig"
+)
+
+// TestSimplePartitionScalerEnabledDoesNotPanic is the regression test for the
+// nil-map panic in getTracker: when the scaler is enabled with any Up/Down
+// window, OnTasks lazily creates trackers by writing to the trackers map. If
+// that map is never initialized in the constructor, this write panics with
+// "assignment to entry in nil map" and crash-loops the matching service.
+//
+// The existing scale_manager_test.go only drives a MockPartitionScaler, so it
+// never exercised this real code path.
+func TestSimplePartitionScalerEnabledDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	scaler := newSimplePartitionScaler(
+		dynamicconfig.GetTypedPropertyFn(dynamicconfig.SimplePartitionScalerSettings{
+			Enabled: true,
+			Ups: []dynamicconfig.SimplePartitionScalerThreshold{
+				{Window: time.Second, TargetRate: 100},
+			},
+		}),
+		clock.NewEventTimeSource(),
+	)
+
+	// The first call reaches getTracker (the map write that used to panic) and,
+	// because no full window has elapsed yet, must report no change.
+	var dec PartitionScalerDecision
+	require.NotPanics(t, func() {
+		dec = scaler.OnTasks(PartitionScalerInput{NumTasks: 1, CurrentTarget: 1})
+	})
+	require.True(t, dec.NoChange, "first call before a full window should not change the target")
+}

--- a/service/matching/simple_partition_scaler_test.go
+++ b/service/matching/simple_partition_scaler_test.go
@@ -9,14 +9,10 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 )
 
-// TestSimplePartitionScalerEnabledDoesNotPanic is the regression test for the
-// nil-map panic in getTracker: when the scaler is enabled with any Up/Down
-// window, OnTasks lazily creates trackers by writing to the trackers map. If
-// that map is never initialized in the constructor, this write panics with
-// "assignment to entry in nil map" and crash-loops the matching service.
-//
-// The existing scale_manager_test.go only drives a MockPartitionScaler, so it
-// never exercised this real code path.
+// TestSimplePartitionScalerEnabledDoesNotPanic when the scaler is enabled with any
+// Up/Down window, OnTasks lazily creates trackers by writing to the trackers map.
+// Confirm that when SimplePartitionScaler is enabled with non-empty Ups and Downs,
+// there is no nil-map panic.
 func TestSimplePartitionScalerEnabledDoesNotPanic(t *testing.T) {
 	t.Parallel()
 
@@ -26,12 +22,15 @@ func TestSimplePartitionScalerEnabledDoesNotPanic(t *testing.T) {
 			Ups: []dynamicconfig.SimplePartitionScalerThreshold{
 				{Window: time.Second, TargetRate: 100},
 			},
+			Downs: []dynamicconfig.SimplePartitionScalerThreshold{
+				{Window: time.Second, TargetRate: 100},
+			},
 		}),
 		clock.NewEventTimeSource(),
 	)
 
-	// The first call reaches getTracker (the map write that used to panic) and,
-	// because no full window has elapsed yet, must report no change.
+	// The first call reaches getTracker. Must report no change because no full
+	// window has elapsed yet.
 	var dec PartitionScalerDecision
 	require.NotPanics(t, func() {
 		dec = scaler.OnTasks(PartitionScalerInput{NumTasks: 1, CurrentTarget: 1})


### PR DESCRIPTION
## What

Initialize the `trackers` map in `newSimplePartitionScaler`, and add a regression test.

## Why

`newSimplePartitionScaler` never initialized `trackers`, leaving it `nil`. The first time `OnTasks` ran with the scaler **enabled** and an Up/Down window configured, `getTracker` wrote to that nil map -> matching panic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line constructor fix with a focused regression test; no change to scaling logic beyond preventing the panic.
> 
> **Overview**
> Fixes a **matching service panic** when the simple partition scaler is enabled with configured Up/Down windows: `newSimplePartitionScaler` now initializes the `trackers` map so the first `OnTasks` → `getTracker` write is not an assignment to a nil map.
> 
> Adds **`simple_partition_scaler_test.go`** with a regression test that builds the real scaler (not the mock used elsewhere), enables it with Ups/Downs, and asserts `OnTasks` does not panic and returns `NoChange` before a full rate window elapses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 945c5efc4e4b83c1f64b36a65670f463dd01567f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->