### PR TITLE
Fix CHASM schedule backfills that reuse workflow IDs

### DIFF
--- a/chasm/lib/scheduler/invoker.go
+++ b/chasm/lib/scheduler/invoker.go
@@ -366,17 +366,6 @@ func (i *Invoker) getEligibleBufferedStarts() []*schedulespb.BufferedStart {
 	})
 }
 
-// isWorkflowStarted returns true if a workflow with the given ID has already
-// been started (has a RunId set).
-func (i *Invoker) isWorkflowStarted(workflowID string) bool {
-	for _, start := range i.GetBufferedStarts() {
-		if start.GetWorkflowId() == workflowID && start.GetRunId() != "" {
-			return true
-		}
-	}
-	return false
-}
-
 // runningWorkflowExecutions returns the list of workflow executions that
 // have been started but not yet completed.
 func (i *Invoker) runningWorkflowExecutions() []*commonpb.WorkflowExecution {

--- a/chasm/lib/scheduler/invoker_execute_task_test.go
+++ b/chasm/lib/scheduler/invoker_execute_task_test.go
@@ -171,6 +171,50 @@ func TestExecuteTask_Basic(t *testing.T) {
 	})
 }
 
+func TestExecuteTask_DistinctRequestsCanReuseCompletedWorkflowID(t *testing.T) {
+	env := newInvokerExecuteTestEnv(t)
+	startTime := timestamppb.New(env.TimeSource.Now())
+	bufferedStarts := []*schedulespb.BufferedStart{
+		{
+			NominalTime: startTime,
+			ActualTime:  startTime,
+			DesiredTime: startTime,
+			RequestId:   "automatic-request",
+			WorkflowId:  "workflow-id",
+			Attempt:     1,
+			RunId:       "completed-run",
+			StartTime:   startTime,
+			Completed:   &schedulespb.CompletedResult{},
+		},
+		{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			Manual:        true,
+			RequestId:     "backfill-request",
+			WorkflowId:    "workflow-id",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL,
+			Attempt:       1,
+		},
+	}
+
+	env.mockFrontendClient.EXPECT().
+		StartWorkflowExecution(gomock.Any(), startWorkflowExecutionRequestIDMatches("backfill-request")).
+		Times(1).
+		Return(&workflowservice.StartWorkflowExecutionResponse{RunId: "backfill-run"}, nil)
+
+	runExecuteTestCase(t, env, &executeTestCase{
+		InitialBufferedStarts:    bufferedStarts,
+		ExpectedBufferedStarts:   2,
+		ExpectedRunningWorkflows: 1,
+		ExpectedActionCount:      1,
+		ValidateInvoker: func(t *testing.T, invoker *scheduler.Invoker, _ *invokerExecuteTestEnv) {
+			require.Equal(t, "completed-run", invoker.BufferedStarts[0].GetRunId())
+			require.Equal(t, "backfill-run", invoker.BufferedStarts[1].GetRunId())
+		},
+	})
+}
+
 // Execute is scheduled with an empty buffer.
 func TestExecuteTask_Empty(t *testing.T) {
 	env := newInvokerExecuteTestEnv(t)

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -358,13 +358,6 @@ func (h *InvokerExecuteTaskHandler) startWorkflows(
 			break
 		}
 
-		// Check if this start is already started. If so, we crashed after
-		// starting a workflow, but before recording the result.
-		if invoker.isWorkflowStarted(start.WorkflowId) {
-			logger.Info("skipping already-started workflow", tag.WorkflowID(start.WorkflowId))
-			continue
-		}
-
 		// Clone start before concurrent access. The clone will have RunId/StartTime
 		// set by startWorkflow, then copied back to the original in recordExecuteResult.
 		start = common.CloneProto(start)

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -4115,10 +4115,6 @@ func testBackfillReprocessesCompletedAction(
 	paused bool,
 	rangeRadius int,
 ) {
-	if strings.HasPrefix(t.Name(), "TestScheduleCHASM/") {
-		t.Skip("CHASM scheduler leaves duplicate workflow-ID backfill starts eligible indefinitely")
-	}
-
 	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-backfill-reprocess")

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -4113,7 +4113,7 @@ func testBackfillReprocessesCompletedAction(
 	t *testing.T,
 	newContext contextFactory,
 	paused bool,
-	rangeRadius int,
+	intervalsOnEachSide int,
 ) {
 	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
 
@@ -4157,14 +4157,14 @@ func testBackfillReprocessesCompletedAction(
 		patchSchedule(ctx, t, s, sid, &schedulepb.SchedulePatch{Pause: "test completed-action backfill"})
 	}
 
-	radius := time.Duration(rangeRadius) * fastInterval
+	rangeOffset := time.Duration(intervalsOnEachSide) * fastInterval
 	patchSchedule(ctx, t, s, sid, backfillPatch(
-		completedTime.Add(-radius),
-		completedTime.Add(radius),
+		completedTime.Add(-rangeOffset),
+		completedTime.Add(rangeOffset),
 		enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL,
 	))
 
-	expectedRuns := int32(2 + 2*rangeRadius)
+	expectedRuns := int32(2 + 2*intervalsOnEachSide)
 	await.RequireTruef(t, func() bool { return runs.Load() == expectedRuns }, neverWindow, pollInterval,
 		"backfill should reprocess the completed action exactly once")
 

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -312,6 +312,18 @@ func runSharedScheduleTests(t *testing.T, newContext contextFactory) {
 	})
 	t.Run("Backfill", func(t *testing.T) {
 		t.Parallel()
+		t.Run("ReprocessCompletedActionExactTimePaused", func(t *testing.T) {
+			t.Parallel()
+			testBackfillReprocessesCompletedAction(t, newContext, true, 0)
+		})
+		t.Run("ReprocessCompletedActionExactTimeActive", func(t *testing.T) {
+			t.Parallel()
+			testBackfillReprocessesCompletedAction(t, newContext, false, 0)
+		})
+		t.Run("ReprocessCompletedActionInRange", func(t *testing.T) {
+			t.Parallel()
+			testBackfillReprocessesCompletedAction(t, newContext, true, 1)
+		})
 		t.Run("SkipOverlap", func(t *testing.T) { t.Parallel(); testBackfillWithSkipOverlap(t, newContext) })
 		t.Run("BufferOneOverlap", func(t *testing.T) { t.Parallel(); testBackfillWithBufferOneOverlap(t, newContext) })
 		t.Run("MultiRangeCountedExactlyOnce", func(t *testing.T) { t.Parallel(); testMultiRangeBackfillCountedExactlyOnce(t, newContext) })
@@ -4095,6 +4107,79 @@ func testTriggerImmediatelyAfterActionsExhausted(t *testing.T, newContext contex
 	require.NotEmpty(t, desc.Info.RecentActions, "RecentActions should include the manual trigger")
 	require.Equal(t, int64(0), desc.Schedule.State.RemainingActions,
 		"manual trigger must not consume a LimitedActions slot")
+}
+
+func testBackfillReprocessesCompletedAction(
+	t *testing.T,
+	newContext contextFactory,
+	paused bool,
+	rangeRadius int,
+) {
+	if strings.HasPrefix(t.Name(), "TestScheduleCHASM/") {
+		t.Skip("CHASM scheduler leaves duplicate workflow-ID backfill starts eligible indefinitely")
+	}
+
+	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+
+	sid := testcore.RandomizeStr("sched-backfill-reprocess")
+	wid := testcore.RandomizeStr("sched-backfill-reprocess-wf")
+	wt := testcore.RandomizeStr("sched-backfill-reprocess-wt")
+
+	var runs atomic.Int32
+	registerCountingWorkflow(s, wt, &runs)
+
+	ctx := newContext(s.Context())
+	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
+		Spec: intervalSpec(fastInterval),
+		State: &schedulepb.ScheduleState{
+			LimitedActions:   true,
+			RemainingActions: 1,
+		},
+		Action: startWorkflowAction(s, wid, wt),
+	})
+
+	var completedTime time.Time
+	await.RequireTruef(t, func() bool {
+		desc, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+		})
+		if err != nil {
+			return false
+		}
+		for _, action := range desc.GetInfo().GetRecentActions() {
+			if action.GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED {
+				completedTime = action.GetScheduleTime().AsTime()
+				return true
+			}
+		}
+		return false
+	}, awaitTimeout, pollInterval, "the automatic action should complete")
+	require.Equal(t, int32(1), runs.Load())
+
+	if paused {
+		patchSchedule(ctx, t, s, sid, &schedulepb.SchedulePatch{Pause: "test completed-action backfill"})
+	}
+
+	radius := time.Duration(rangeRadius) * fastInterval
+	patchSchedule(ctx, t, s, sid, backfillPatch(
+		completedTime.Add(-radius),
+		completedTime.Add(radius),
+		enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL,
+	))
+
+	expectedRuns := int32(2 + 2*rangeRadius)
+	await.RequireTruef(t, func() bool { return runs.Load() == expectedRuns }, neverWindow, pollInterval,
+		"backfill should reprocess the completed action exactly once")
+
+	desc, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(expectedRuns), desc.GetInfo().GetActionCount())
+	require.Empty(t, desc.GetInfo().GetRunningWorkflows())
+	require.Equal(t, paused, desc.GetSchedule().GetState().GetPaused())
 }
 
 // testBackfillWithBufferOneOverlap pins the expected behavior of BUFFER_ONE


### PR DESCRIPTION
## Summary

- remove the CHASM Invoker's workflow-ID-only precheck before starting buffered actions
- allow a manual backfill to reprocess a completed nominal action
- add unit and functional regression coverage for backfills

## Problem

If there is already a start with the same workflow id in the buffer that has a runid (has been started) then the execute task would skip issuing the start workflow request. It would remain eligible indefinitely. 

## Fix

Delete the workflow-ID-only precheck and always call `StartWorkflowExecution`. History provides request-ID (backfills and auto start have different request ids)idempotency, while the scheduler selects the effective workflow ID reuse policy:

- manual/backfill starts are assigned `ALLOW_DUPLICATE`, so a completed workflow ID can start a new run
- automatic starts are assigned `REJECT_DUPLICATE`; an already-started workflow is returned as `AlreadyStarted` and handled as a non-retryable failed start
- retries of the same request remain idempotent because they use the same request ID

The schedule action's user-provided reuse-policy field does not control this distinction. Schedule validation only accepts `UNSPECIFIED` or `ALLOW_DUPLICATE`, and both V1 and CHASM choose the effective policy from whether the buffered start is manual.
