### PR TITLE
Treat zero schedule catchup window as unset

### DIFF
--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -658,7 +658,8 @@ func (s *Scheduler) Describe(
 	if s.Schedule.GetPolicies().GetOverlapPolicy() == enumspb.SCHEDULE_OVERLAP_POLICY_UNSPECIFIED {
 		s.Schedule.Policies.OverlapPolicy = s.overlapPolicy()
 	}
-	if !s.Schedule.GetPolicies().GetCatchupWindow().IsValid() {
+	catchupWindow := s.Schedule.GetPolicies().GetCatchupWindow()
+	if !catchupWindow.IsValid() || catchupWindow.AsDuration() == 0 {
 		// TODO - this should be set from Tweakables.DefaultCatchupWindow.
 		s.Schedule.Policies.CatchupWindow = durationpb.New(365 * 24 * time.Hour)
 	}

--- a/chasm/lib/scheduler/scheduler_test.go
+++ b/chasm/lib/scheduler/scheduler_test.go
@@ -22,6 +22,7 @@ import (
 	"go.temporal.io/server/service/history/tasks"
 	legacyscheduler "go.temporal.io/server/service/worker/scheduler"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -637,4 +638,23 @@ func TestScheduler_Describe_ReturnsIsolatedVisibilityMaps(t *testing.T) {
 		"DescribeSchedule response Memo must be a copy, not the live Visibility map")
 	require.NotContains(t, vis.CustomSearchAttributes(ctx), "injectedSA",
 		"DescribeSchedule response SearchAttributes must be a copy, not the live Visibility map")
+}
+
+func TestScheduler_Describe_ZeroCatchupWindowUsesDefault(t *testing.T) {
+	sched, ctx, _ := setupSchedulerForTest(t)
+	sched.Schedule.Policies.CatchupWindow = durationpb.New(0)
+
+	resp, err := sched.Describe(ctx, &schedulerpb.DescribeScheduleRequest{
+		NamespaceId: namespaceID,
+		FrontendRequest: &workflowservice.DescribeScheduleRequest{
+			Namespace:  namespace,
+			ScheduleId: scheduleID,
+		},
+	}, legacyscheduler.NewSpecBuilder())
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		365*24*time.Hour,
+		resp.GetFrontendResponse().GetSchedule().GetPolicies().GetCatchupWindow().AsDuration(),
+	)
 }

--- a/chasm/lib/scheduler/spec_processor.go
+++ b/chasm/lib/scheduler/spec_processor.go
@@ -195,7 +195,7 @@ func (s *SpecProcessorImpl) ProcessTimeRange(
 
 func catchupWindow(s *Scheduler, tweakables Tweakables) time.Duration {
 	cw := s.Schedule.GetPolicies().GetCatchupWindow()
-	if cw == nil {
+	if cw == nil || cw.AsDuration() == 0 {
 		return tweakables.DefaultCatchupWindow
 	}
 

--- a/chasm/lib/scheduler/spec_processor_test.go
+++ b/chasm/lib/scheduler/spec_processor_test.go
@@ -155,6 +155,13 @@ func TestProcessTimeRange_CatchupWindow(t *testing.T) {
 	res, err := processor.ProcessTimeRange(sched, start, end, enumspb.SCHEDULE_OVERLAP_POLICY_UNSPECIFIED, sched.WorkflowID(), "", false, nil)
 	require.NoError(t, err)
 	require.Len(t, res.BufferedStarts, 5)
+
+	// Zero means unspecified, so it uses the default rather than the minimum.
+	sched.Schedule.Policies.CatchupWindow = durationpb.New(0)
+	start = end.Add(-defaultInterval * 5)
+	res, err = processor.ProcessTimeRange(sched, start, end, enumspb.SCHEDULE_OVERLAP_POLICY_UNSPECIFIED, sched.WorkflowID(), "", false, nil)
+	require.NoError(t, err)
+	require.Len(t, res.BufferedStarts, 5)
 }
 
 func TestProcessTimeRange_Limit(t *testing.T) {

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -1304,7 +1304,7 @@ func (s *scheduler) updateTweakables() {
 
 func (s *scheduler) getCatchupWindow() time.Duration {
 	cw := s.Schedule.Policies.CatchupWindow
-	if cw == nil {
+	if cw == nil || cw.AsDuration() == 0 {
 		return s.tweakables.DefaultCatchupWindow
 	} else if cw.AsDuration() < s.tweakables.MinCatchupWindow {
 		return s.tweakables.MinCatchupWindow

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -452,6 +453,22 @@ func (s *workflowSuite) TestCatchupWindow() {
 	})
 	s.True(s.env.IsWorkflowCompleted())
 	s.True(workflow.IsContinueAsNewError(s.env.GetWorkflowError()))
+}
+
+func TestGetCatchupWindowZeroUsesDefault(t *testing.T) {
+	s := &scheduler{
+		StartScheduleArgs: &schedulespb.StartScheduleArgs{
+			Schedule: &schedulepb.Schedule{
+				Policies: &schedulepb.SchedulePolicies{CatchupWindow: durationpb.New(0)},
+			},
+		},
+		tweakables: TweakablePolicies{
+			DefaultCatchupWindow: 365 * 24 * time.Hour,
+			MinCatchupWindow:     10 * time.Second,
+		},
+	}
+
+	require.Equal(t, 365*24*time.Hour, s.getCatchupWindow())
 }
 
 func (s *workflowSuite) TestCatchupWindowWhilePaused() {


### PR DESCRIPTION
## What changed
- Treat a zero catch-up-window duration as unspecified in both legacy and CHASM schedulers.
- Resolve zero to the configured default rather than the minimum.
- Normalize CHASM describe responses to the one-year default.
- Add focused coverage for scheduling and describe behavior.

## Why
Nil and zero represent an unspecified SDK value. Zero previously fell through to the 10-second minimum, producing different behavior depending on protobuf presence.

Positive non-zero values below the supported minimum continue to resolve to the minimum.

## Validation
- Legacy scheduler focused test
- CHASM processor and describe tests
- Full `make lint-code`

## Breaking changes
An explicitly encoded zero duration now selects the default instead of the 10-second minimum.