### PR TITLE
Fix nil-map panic in simplePartitionScaler (#11054)

### DIFF
--- a/service/matching/simple_partition_scaler.go
+++ b/service/matching/simple_partition_scaler.go
@@ -42,8 +42,9 @@ type simplePartitionScaler struct {
 
 func newSimplePartitionScaler(cfg scalerCfg, ts clock.TimeSource) *simplePartitionScaler {
 	return &simplePartitionScaler{
-		cfg: cfg,
-		ts:  ts,
+		cfg:      cfg,
+		ts:       ts,
+		trackers: make(map[time.Duration]*taskTracker),
 	}
 }
 

--- a/service/matching/simple_partition_scaler_test.go
+++ b/service/matching/simple_partition_scaler_test.go
@@ -1,0 +1,39 @@
+package matching
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/dynamicconfig"
+)
+
+// TestSimplePartitionScalerEnabledDoesNotPanic when the scaler is enabled with any
+// Up/Down window, OnTasks lazily creates trackers by writing to the trackers map.
+// Confirm that when SimplePartitionScaler is enabled with non-empty Ups and Downs,
+// there is no nil-map panic.
+func TestSimplePartitionScalerEnabledDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	scaler := newSimplePartitionScaler(
+		dynamicconfig.GetTypedPropertyFn(dynamicconfig.SimplePartitionScalerSettings{
+			Enabled: true,
+			Ups: []dynamicconfig.SimplePartitionScalerThreshold{
+				{Window: time.Second, TargetRate: 100},
+			},
+			Downs: []dynamicconfig.SimplePartitionScalerThreshold{
+				{Window: time.Second, TargetRate: 100},
+			},
+		}),
+		clock.NewEventTimeSource(),
+	)
+
+	// The first call reaches getTracker. Must report no change because no full
+	// window has elapsed yet.
+	var dec PartitionScalerDecision
+	require.NotPanics(t, func() {
+		dec = scaler.OnTasks(PartitionScalerInput{NumTasks: 1, CurrentTarget: 1})
+	})
+	require.True(t, dec.NoChange, "first call before a full window should not change the target")
+}


### PR DESCRIPTION
## What

Initialize the `trackers` map in `newSimplePartitionScaler`, and add a regression test.

## Why

`newSimplePartitionScaler` never initialized `trackers`, leaving it `nil`. The first time `OnTasks` ran with the scaler **enabled** and an Up/Down window configured, `getTracker` wrote to that nil map -> matching panic.