### PR TITLE
Move max-attempt check from Dispatcher to caller

### DIFF
--- a/common/workercommands/dispatcher.go
+++ b/common/workercommands/dispatcher.go
@@ -51,9 +51,9 @@ const (
 //     *temporal.CanceledError. Permanent — the worker contract requires success for all
 //     defined commands, so this indicates a bug or version incompatibility.
 //
-// Retryable errors are capped at MaxTaskAttempts attempts (in-memory). These
-// commands are best-effort — the activity will eventually time out anyway — so excessive
-// retries waste resources. The counter resets on shard movement, which is acceptable.
+// Callers are responsible for enforcing retry limits (see MaxTaskAttempts).
+// These commands are best-effort — the activity will eventually time out anyway —
+// so excessive retries waste resources.
 type Dispatcher struct {
 	matchingClient resource.MatchingClient
 	config         *configs.Config
@@ -78,20 +78,8 @@ func NewDispatcher(
 func (d *Dispatcher) Execute(
 	ctx context.Context,
 	task *tasks.WorkerCommandsTask,
-	attempt int,
 	namespaceName string,
 ) error {
-	if attempt > MaxTaskAttempts {
-		d.logger.Info("Worker commands task exceeded max attempts, dropping",
-			tag.WorkflowID(task.WorkflowID),
-			tag.WorkflowRunID(task.RunID),
-			tag.NewStringTag("control_queue", task.Destination),
-			tag.Attempt(int32(attempt)),
-		)
-		d.recordCommandMetrics(task.Commands, namespaceName, "max_attempts_exceeded")
-		return nil
-	}
-
 	if !d.config.EnableCancelActivityWorkerCommand(namespaceName) {
 		d.logger.Info("Worker commands feature disabled, dropping task",
 			tag.WorkflowNamespace(namespaceName),
@@ -212,8 +200,13 @@ func (d *Dispatcher) handleError(nexusErr error, task *tasks.WorkerCommandsTask,
 }
 
 func (d *Dispatcher) recordCommandMetrics(commands []*workerpb.WorkerCommand, namespaceName string, outcome string) {
+	RecordCommandMetrics(commands, d.metricsHandler, namespaceName, outcome)
+}
+
+// RecordCommandMetrics records per-command metrics with the given outcome.
+func RecordCommandMetrics(commands []*workerpb.WorkerCommand, metricsHandler metrics.Handler, namespaceName string, outcome string) {
 	for _, cmd := range commands {
-		metrics.WorkerCommandsSent.With(d.metricsHandler).Record(
+		metrics.WorkerCommandsSent.With(metricsHandler).Record(
 			1,
 			metrics.NamespaceTag(namespaceName),
 			metrics.OutcomeTag(outcome),

--- a/common/workercommands/dispatcher_test.go
+++ b/common/workercommands/dispatcher_test.go
@@ -52,7 +52,7 @@ func TestExecute_FeatureFlagOff_DropsTask(t *testing.T) {
 	}
 
 	task := testWorkerCommandsTask()
-	err := d.Execute(context.Background(), task, 1 /* attempt */, "test-namespace")
+	err := d.Execute(context.Background(), task, "test-namespace")
 	require.NoError(t, err, "task should be silently dropped when feature flag is off")
 }
 
@@ -66,66 +66,8 @@ func TestExecute_EmptyCommands_DropsTask(t *testing.T) {
 
 	task := testWorkerCommandsTask()
 	task.Commands = nil
-	err := d.Execute(context.Background(), task, 1 /* attempt */, "test-namespace")
+	err := d.Execute(context.Background(), task, "test-namespace")
 	require.NoError(t, err, "task with no commands should be dropped")
-}
-
-func TestExecute_ExceedsMaxAttempts_DropsTask(t *testing.T) {
-	metricsHandler := metricstest.NewCaptureHandler()
-	capture := metricsHandler.StartCapture()
-	defer metricsHandler.StopCapture(capture)
-
-	d := &Dispatcher{
-		config: &configs.Config{
-			EnableCancelActivityWorkerCommand: func(string) bool { return true },
-		},
-		metricsHandler: metricsHandler,
-		logger:         log.NewNoopLogger(),
-	}
-
-	task := testWorkerCommandsTask()
-	err := d.Execute(context.Background(), task, MaxTaskAttempts+1, "test-namespace")
-	require.NoError(t, err, "task should be dropped when max attempts exceeded")
-
-	requireMetricValue(t, capture.Snapshot(), "max_attempts_exceeded")
-}
-
-func TestExecute_AtMaxAttempt_StillExecutes(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	mockClient := matchingservicemock.NewMockMatchingServiceClient(ctrl)
-	metricsHandler := metricstest.NewCaptureHandler()
-	capture := metricsHandler.StartCapture()
-	defer metricsHandler.StopCapture(capture)
-
-	d := &Dispatcher{
-		matchingClient: mockClient,
-		config: &configs.Config{
-			EnableCancelActivityWorkerCommand: func(string) bool { return true },
-		},
-		metricsHandler: metricsHandler,
-		logger:         log.NewNoopLogger(),
-	}
-
-	mockClient.EXPECT().DispatchNexusTask(gomock.Any(), gomock.Any()).Return(
-		&matchingservice.DispatchNexusTaskResponse{
-			Outcome: &matchingservice.DispatchNexusTaskResponse_Response{
-				Response: &nexuspb.Response{
-					Variant: &nexuspb.Response_StartOperation{
-						StartOperation: &nexuspb.StartOperationResponse{
-							Variant: &nexuspb.StartOperationResponse_SyncSuccess{
-								SyncSuccess: &nexuspb.StartOperationResponse_Sync{},
-							},
-						},
-					},
-				},
-			},
-		}, nil)
-
-	task := testWorkerCommandsTask()
-	err := d.Execute(context.Background(), task, MaxTaskAttempts, "test-namespace")
-	require.NoError(t, err, "task at exactly max attempt should still execute")
-
-	requireMetricValue(t, capture.Snapshot(), "success")
 }
 
 func TestExecute_DispatchSuccess(t *testing.T) {
@@ -164,7 +106,7 @@ func TestExecute_DispatchSuccess(t *testing.T) {
 		})
 
 	task := testWorkerCommandsTask()
-	err := d.Execute(context.Background(), task, 1 /* attempt */, "test-namespace")
+	err := d.Execute(context.Background(), task, "test-namespace")
 	require.NoError(t, err)
 
 	require.NotNil(t, capturedReq)
@@ -195,7 +137,7 @@ func TestExecute_DispatchRPCError(t *testing.T) {
 		nil, errors.New("connection refused"))
 
 	task := testWorkerCommandsTask()
-	err := d.Execute(context.Background(), task, 1 /* attempt */, "test-namespace")
+	err := d.Execute(context.Background(), task, "test-namespace")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "connection refused")
 
@@ -226,7 +168,7 @@ func TestExecute_UpstreamTimeout(t *testing.T) {
 		}, nil)
 
 	task := testWorkerCommandsTask()
-	err := d.Execute(context.Background(), task, 1 /* attempt */, "test-namespace")
+	err := d.Execute(context.Background(), task, "test-namespace")
 	require.Error(t, err)
 
 	var he *nexus.HandlerError

--- a/service/history/outbound_queue_active_task_executor.go
+++ b/service/history/outbound_queue_active_task_executor.go
@@ -9,6 +9,7 @@ import (
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/common/workercommands"
@@ -106,7 +107,17 @@ func (e *outboundQueueActiveTaskExecutor) Execute(
 		task.Attempt = executable.Attempt()
 		return respond(e.executeChasmSideEffectTask(ctx, task))
 	case *tasks.WorkerCommandsTask:
-		return respond(e.workerCommandsDispatcher.Execute(ctx, task, executable.Attempt(), namespaceTag.Value))
+		if executable.Attempt() > workercommands.MaxTaskAttempts {
+			e.logger.Info("Worker commands task exceeded max attempts, dropping",
+				tag.WorkflowID(task.WorkflowID),
+				tag.WorkflowRunID(task.RunID),
+				tag.NewStringTag("control_queue", task.Destination),
+				tag.Attempt(int32(executable.Attempt())),
+			)
+			workercommands.RecordCommandMetrics(task.Commands, e.metricsHandler, namespaceTag.Value, "max_attempts_exceeded")
+			return respond(nil)
+		}
+		return respond(e.workerCommandsDispatcher.Execute(ctx, task, namespaceTag.Value))
 	}
 
 	return respond(queueserrors.NewUnprocessableTaskError(fmt.Sprintf("unknown task type '%T'", task)))

--- a/service/history/outbound_queue_active_task_executor_test.go
+++ b/service/history/outbound_queue_active_task_executor_test.go
@@ -8,12 +8,15 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	workerpb "go.temporal.io/api/worker/v1"
+	"go.temporal.io/server/api/matchingservicemock/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/testing/testvars"
+	"go.temporal.io/server/common/workercommands"
 	"go.temporal.io/server/service/history/hsm"
 	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/queues"
@@ -264,6 +267,39 @@ func (s *outboundQueueActiveTaskExecutorSuite) TestExecute_PreValidationFails() 
 			s.NotEmpty(result.ExecutionMetricTags)
 		})
 	}
+}
+
+func (s *outboundQueueActiveTaskExecutorSuite) TestExecute_WorkerCommandsTask_ExceedsMaxAttempts() {
+	ctx := context.Background()
+
+	mockClient := matchingservicemock.NewMockMatchingServiceClient(s.controller)
+	mockClient.EXPECT().DispatchNexusTask(gomock.Any(), gomock.Any()).Times(0)
+	s.executor.workerCommandsDispatcher = workercommands.NewDispatcher(
+		mockClient,
+		s.mockShard.GetConfig(),
+		s.metricsHandler,
+		s.logger,
+	)
+
+	task := &tasks.WorkerCommandsTask{
+		WorkflowKey: tests.WorkflowKey,
+		TaskID:      s.mustGenerateTaskID(),
+		Destination: "test-control-queue",
+		Commands: []*workerpb.WorkerCommand{
+			{Type: &workerpb.WorkerCommand_CancelActivity{
+				CancelActivity: &workerpb.CancelActivityCommand{TaskToken: []byte("token")},
+			}},
+		},
+	}
+
+	s.mockExecutable.EXPECT().GetTask().Return(task).AnyTimes()
+	s.mockExecutable.EXPECT().Attempt().Return(workercommands.MaxTaskAttempts + 1).AnyTimes()
+	s.mockExecutable.EXPECT().GetWorkflowID().Return("").AnyTimes()
+
+	result := s.executor.Execute(ctx, s.mockExecutable)
+
+	s.NoError(result.ExecutionErr)
+	s.True(result.ExecutedAsActive)
 }
 
 func (s *outboundQueueActiveTaskExecutorSuite) mustGenerateTaskID() int64 {


### PR DESCRIPTION
## What

Remove the `attempt` parameter from `Dispatcher.Execute` and move the max-attempt guard to the caller (`outboundQueueActiveTaskExecutor`). Export `RecordCommandMetrics` so callers can record the same metrics.

## Why

For standalone activities, the attempt check happens upstream (in CHASM task `Validate`), so the Dispatcher doesn't need it. Keeping the API surface clean by having callers handle this.

## How did you test it?

- **Unit tests**: updated dispatcher tests to remove attempt parameter; removed max-attempt test from dispatcher (now caller responsibility)
- Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)