### PR TITLE
SAA bug fix: update start delay while paused

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -666,9 +666,11 @@ func (a *Activity) UpdateActivityExecutionOptions(
 				return nil, serviceerror.NewInvalidArgument("start_delay is not enabled for this namespace")
 			}
 		}
-		if !a.firstDispatchTime().After(ctx.Now(a)) {
+		inDelayWindow := a.firstDispatchTime().After(ctx.Now(a))
+		pausedBeforeFirstAttempt := a.GetFirstAttemptStartedTime() == nil && a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED
+		if !(inDelayWindow || pausedBeforeFirstAttempt) {
 			return nil, serviceerror.NewFailedPrecondition(
-				"cannot update start_delay: activity is no longer in its delay window")
+				"cannot update start_delay: the first activity attempt has already been dispatched")
 		}
 	}
 

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -654,7 +654,6 @@ func (a *Activity) UpdateActivityExecutionOptions(
 		updateFields = util.ParseFieldMask(mask)
 	}
 
-	// start_delay updates are only valid while the activity is still in its delay window.
 	_, hasStartDelayInMask := updateFields["startDelay"]
 	if hasStartDelayInMask {
 		newDelay := frontendReq.GetActivityOptions().GetStartDelay()
@@ -667,8 +666,7 @@ func (a *Activity) UpdateActivityExecutionOptions(
 				return nil, serviceerror.NewInvalidArgument("start_delay is not enabled for this namespace")
 			}
 		}
-		if a.GetStatus() != activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED ||
-			!a.firstDispatchTime().After(ctx.Now(a)) {
+		if !a.firstDispatchTime().After(ctx.Now(a)) {
 			return nil, serviceerror.NewFailedPrecondition(
 				"cannot update start_delay: activity is no longer in its delay window")
 		}

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -668,7 +668,7 @@ func (a *Activity) UpdateActivityExecutionOptions(
 		}
 		inDelayWindow := a.firstDispatchTime().After(ctx.Now(a))
 		pausedBeforeFirstAttempt := a.GetFirstAttemptStartedTime() == nil && a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED
-		if !(inDelayWindow || pausedBeforeFirstAttempt) {
+		if !(inDelayWindow || pausedBeforeFirstAttempt) { //nolint:staticcheck // QF1001: DeMorgan rearrangement would not be an improvement
 			return nil, serviceerror.NewFailedPrecondition(
 				"cannot update start_delay: the first activity attempt has already been dispatched")
 		}

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -7897,6 +7897,91 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		require.NoError(t, err)
 		require.NotEmpty(t, pollResp.GetTaskToken(), "expected dispatch under the updated start_delay after unpause")
 	})
+
+	// Once the delay window elapses the first dispatch time is fixed in the past, so start_delay
+	// becomes immutable even while paused: an update pushing dispatch further out is rejected, and
+	// unpause dispatches immediately rather than honoring the rejected longer delay.
+	s.Run("UpdateWhilePaused_AfterWindow_Rejected", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+		// Short so the sleep below stays fast; only needs to be > 0.
+		startDelay := 1 * time.Second
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
+			Input:               defaultInput,
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			StartDelay:          durationpb.New(startDelay),
+		})
+		require.NoError(t, err)
+
+		_, err = env.FrontendClient().PauseActivityExecution(s.Context(), &workflowservice.PauseActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+			Identity:   defaultIdentity,
+			Reason:     "test-pause",
+		})
+		require.NoError(t, err)
+
+		// 2s > startDelay (1s) so firstDispatchTime is firmly in the past; pause still holds dispatch.
+		time.Sleep(2 * time.Second) //nolint:forbidigo
+
+		descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_PAUSED, descResp.GetInfo().GetRunState())
+
+		// The delay window has elapsed, so start_delay can no longer be extended even while paused.
+		_, err = env.FrontendClient().UpdateActivityExecutionOptions(s.Context(), &workflowservice.UpdateActivityExecutionOptionsRequest{
+			Namespace:       env.Namespace().String(),
+			ActivityId:      activityID,
+			RunId:           startResp.RunId,
+			ActivityOptions: &activitypb.ActivityOptions{StartDelay: durationpb.New(60 * time.Second)},
+			UpdateMask:      &fieldmaskpb.FieldMask{Paths: []string{"start_delay"}},
+		})
+		require.Error(t, err)
+		var failedPrecond *serviceerror.FailedPrecondition
+		require.ErrorAs(t, err, &failedPrecond)
+		require.Contains(t, failedPrecond.Message, "start_delay")
+
+		// Unpause dispatches immediately: the rejected update did not push dispatch out.
+		unpauseTime := time.Now()
+		_, err = env.FrontendClient().UnpauseActivityExecution(s.Context(), &workflowservice.UnpauseActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+			Identity:   defaultIdentity,
+		})
+		require.NoError(t, err)
+
+		pollCtx, cancel := context.WithTimeout(s.Context(), 5*time.Second)
+		defer cancel()
+		pollResp, err := env.pollActivityTaskQueue(pollCtx, taskQueue)
+		require.NoError(t, err)
+		require.NotEmpty(t, pollResp.GetTaskToken())
+
+		descResp, err = env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		lastStart := descResp.GetInfo().GetLastStartedTime().AsTime()
+		require.False(t, lastStart.IsZero())
+		require.WithinDuration(t, unpauseTime, lastStart, timerSafetyMargin,
+			"rejected longer start_delay must not delay dispatch; the elapsed delay dispatches on unpause")
+	})
 }
 
 func (s *standaloneActivityTestSuite) TestUpdateActivityExecutionOptions() {

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -7971,7 +7971,9 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		// update not taken effect, the elapsed original delay would dispatch immediately on unpause.
 		pollCtx, cancel := context.WithTimeout(s.Context(), 3*time.Second)
 		defer cancel()
-		pollResp, _ := env.pollActivityTaskQueue(pollCtx, taskQueue)
+		pollResp, err := env.pollActivityTaskQueue(pollCtx, taskQueue)
+		// A long-poll that gets no task within its timeout gets a non-error empty response
+		require.NoError(t, err)
 		require.Empty(t, pollResp.GetTaskToken(),
 			"activity must not dispatch within the extended start_delay after unpause")
 	})

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -7899,17 +7899,15 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 	})
 
 	// While paused before the first attempt, start_delay stays editable even after the original
-	// delay window has elapsed: pause pulls the activity out of dispatch, so extending start_delay
-	// defers the dispatch that unpause would otherwise perform immediately.
+	// delay window has elapsed: extending start_delay defers the dispatch that unpause would
+	// otherwise perform immediately.
 	s.Run("UpdateWhilePaused_AfterWindow_ExtendsDispatch", func(s *standaloneActivityTestSuite) {
 		t := s.T()
 		env := s.newTestEnv()
 
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
-		// Short so the sleep below stays fast; only needs to be > 0.
-		originalDelay := 1 * time.Second
-		// Long enough that a dispatch after unpause lands well beyond the short poll below.
+		originalDelay := 3 * time.Second
 		newDelay := 30 * time.Second
 
 		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
@@ -7933,9 +7931,6 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		})
 		require.NoError(t, err)
 
-		// 2s > originalDelay (1s) so the original delay window is firmly in the past.
-		time.Sleep(2 * time.Second) //nolint:forbidigo
-
 		descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
 			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
@@ -7943,6 +7938,9 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_PAUSED, descResp.GetInfo().GetRunState())
+
+		// wait until original delay window is in the past.
+		time.Sleep(originalDelay) //nolint:forbidigo
 
 		// The first attempt never started, so start_delay is still editable despite the elapsed window.
 		_, err = env.FrontendClient().UpdateActivityExecutionOptions(s.Context(), &workflowservice.UpdateActivityExecutionOptionsRequest{

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -7977,6 +7977,103 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		require.Empty(t, pollResp.GetTaskToken(),
 			"activity must not dispatch within the extended start_delay after unpause")
 	})
+
+	// Symmetric to ExtendsDispatch: while paused before the first attempt, start_delay can also be
+	// retracted after the original window has elapsed, so unpause dispatches immediately.
+	s.Run("UpdateWhilePaused_AfterWindow_RetractsDispatch", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+		originalDelay := 10 * time.Second
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
+			Input:               defaultInput,
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			StartDelay:          durationpb.New(originalDelay),
+		})
+		require.NoError(t, err)
+
+		_, err = env.FrontendClient().PauseActivityExecution(s.Context(), &workflowservice.PauseActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+			Identity:   defaultIdentity,
+			Reason:     "test-pause",
+		})
+		require.NoError(t, err)
+
+		// Retract to zero while paused: the first attempt never started, so start_delay is editable.
+		_, err = env.FrontendClient().UpdateActivityExecutionOptions(s.Context(), &workflowservice.UpdateActivityExecutionOptionsRequest{
+			Namespace:       env.Namespace().String(),
+			ActivityId:      activityID,
+			RunId:           startResp.RunId,
+			ActivityOptions: &activitypb.ActivityOptions{StartDelay: durationpb.New(0)},
+			UpdateMask:      &fieldmaskpb.FieldMask{Paths: []string{"start_delay"}},
+		})
+		require.NoError(t, err)
+
+		_, err = env.FrontendClient().UnpauseActivityExecution(s.Context(), &workflowservice.UnpauseActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+			Identity:   defaultIdentity,
+		})
+		require.NoError(t, err)
+
+		// With the delay retracted, unpause dispatches immediately rather than waiting out the original 10s.
+		pollCtx, cancel := context.WithTimeout(s.Context(), 5*time.Second)
+		defer cancel()
+		pollResp, err := env.pollActivityTaskQueue(pollCtx, taskQueue)
+		require.NoError(t, err)
+		require.NotEmpty(t, pollResp.GetTaskToken(),
+			"activity must dispatch immediately after the start_delay is retracted")
+	})
+
+	// Not paused and past the delay window: the activity has been dispatched to matching (worker just
+	// hasn't polled it), so start_delay is consumed and no longer editable.
+	s.Run("UpdateAfterWindow_NotPaused_Rejected", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+		startDelay := 1 * time.Second
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
+			Input:               defaultInput,
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			StartDelay:          durationpb.New(startDelay),
+		})
+		require.NoError(t, err)
+
+		// Do not poll: the activity dispatches to matching at startDelay but no worker starts it.
+		// 2s > startDelay (1s) so firstDispatchTime is firmly in the past.
+		time.Sleep(2 * time.Second) //nolint:forbidigo
+
+		_, err = env.FrontendClient().UpdateActivityExecutionOptions(s.Context(), &workflowservice.UpdateActivityExecutionOptionsRequest{
+			Namespace:       env.Namespace().String(),
+			ActivityId:      activityID,
+			RunId:           startResp.RunId,
+			ActivityOptions: &activitypb.ActivityOptions{StartDelay: durationpb.New(60 * time.Second)},
+			UpdateMask:      &fieldmaskpb.FieldMask{Paths: []string{"start_delay"}},
+		})
+		require.Error(t, err)
+		var failedPrecond *serviceerror.FailedPrecondition
+		require.ErrorAs(t, err, &failedPrecond)
+		require.Contains(t, failedPrecond.Message, "start_delay")
+	})
 }
 
 func (s *standaloneActivityTestSuite) TestUpdateActivityExecutionOptions() {

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -7898,17 +7898,19 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		require.NotEmpty(t, pollResp.GetTaskToken(), "expected dispatch under the updated start_delay after unpause")
 	})
 
-	// Once the delay window elapses the first dispatch time is fixed in the past, so start_delay
-	// becomes immutable even while paused: an update pushing dispatch further out is rejected, and
-	// unpause dispatches immediately rather than honoring the rejected longer delay.
-	s.Run("UpdateWhilePaused_AfterWindow_Rejected", func(s *standaloneActivityTestSuite) {
+	// While paused before the first attempt, start_delay stays editable even after the original
+	// delay window has elapsed: pause pulls the activity out of dispatch, so extending start_delay
+	// defers the dispatch that unpause would otherwise perform immediately.
+	s.Run("UpdateWhilePaused_AfterWindow_ExtendsDispatch", func(s *standaloneActivityTestSuite) {
 		t := s.T()
 		env := s.newTestEnv()
 
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 		// Short so the sleep below stays fast; only needs to be > 0.
-		startDelay := 1 * time.Second
+		originalDelay := 1 * time.Second
+		// Long enough that a dispatch after unpause lands well beyond the short poll below.
+		newDelay := 30 * time.Second
 
 		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
 			Namespace:           env.Namespace().String(),
@@ -7918,7 +7920,7 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 			Input:               defaultInput,
 			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
 			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
-			StartDelay:          durationpb.New(startDelay),
+			StartDelay:          durationpb.New(originalDelay),
 		})
 		require.NoError(t, err)
 
@@ -7931,7 +7933,7 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		})
 		require.NoError(t, err)
 
-		// 2s > startDelay (1s) so firstDispatchTime is firmly in the past; pause still holds dispatch.
+		// 2s > originalDelay (1s) so the original delay window is firmly in the past.
 		time.Sleep(2 * time.Second) //nolint:forbidigo
 
 		descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
@@ -7942,21 +7944,23 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		require.NoError(t, err)
 		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_PAUSED, descResp.GetInfo().GetRunState())
 
-		// The delay window has elapsed, so start_delay can no longer be extended even while paused.
+		// The first attempt never started, so start_delay is still editable despite the elapsed window.
 		_, err = env.FrontendClient().UpdateActivityExecutionOptions(s.Context(), &workflowservice.UpdateActivityExecutionOptionsRequest{
 			Namespace:       env.Namespace().String(),
 			ActivityId:      activityID,
 			RunId:           startResp.RunId,
-			ActivityOptions: &activitypb.ActivityOptions{StartDelay: durationpb.New(60 * time.Second)},
+			ActivityOptions: &activitypb.ActivityOptions{StartDelay: durationpb.New(newDelay)},
 			UpdateMask:      &fieldmaskpb.FieldMask{Paths: []string{"start_delay"}},
 		})
-		require.Error(t, err)
-		var failedPrecond *serviceerror.FailedPrecondition
-		require.ErrorAs(t, err, &failedPrecond)
-		require.Contains(t, failedPrecond.Message, "start_delay")
+		require.NoError(t, err)
+		descResp, err = env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		require.Equal(t, newDelay, descResp.GetInfo().GetStartDelay().AsDuration())
 
-		// Unpause dispatches immediately: the rejected update did not push dispatch out.
-		unpauseTime := time.Now()
 		_, err = env.FrontendClient().UnpauseActivityExecution(s.Context(), &workflowservice.UnpauseActivityExecutionRequest{
 			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
@@ -7965,22 +7969,13 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		})
 		require.NoError(t, err)
 
-		pollCtx, cancel := context.WithTimeout(s.Context(), 5*time.Second)
+		// Dispatch now honors the extended delay (~30s out), so a short poll must find no task; had the
+		// update not taken effect, the elapsed original delay would dispatch immediately on unpause.
+		pollCtx, cancel := context.WithTimeout(s.Context(), 3*time.Second)
 		defer cancel()
-		pollResp, err := env.pollActivityTaskQueue(pollCtx, taskQueue)
-		require.NoError(t, err)
-		require.NotEmpty(t, pollResp.GetTaskToken())
-
-		descResp, err = env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  env.Namespace().String(),
-			ActivityId: activityID,
-			RunId:      startResp.RunId,
-		})
-		require.NoError(t, err)
-		lastStart := descResp.GetInfo().GetLastStartedTime().AsTime()
-		require.False(t, lastStart.IsZero())
-		require.WithinDuration(t, unpauseTime, lastStart, timerSafetyMargin,
-			"rejected longer start_delay must not delay dispatch; the elapsed delay dispatches on unpause")
+		pollResp, _ := env.pollActivityTaskQueue(pollCtx, taskQueue)
+		require.Empty(t, pollResp.GetTaskToken(),
+			"activity must not dispatch within the extended start_delay after unpause")
 	})
 }
 

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -7820,6 +7820,83 @@ func (s *standaloneActivityTestSuite) TestStartDelay() {
 		require.GreaterOrEqual(t, lastStart.Add(timerSafetyMargin).UnixNano(), expectedExecution.UnixNano(),
 			"activity dispatched before its original execution_time; multiple pause cycles let the target drift")
 	})
+
+	// start_delay is mutable while the first dispatch is still pending, which includes while the
+	// activity is paused in the delay window: UpdateActivityOptions can change anything while
+	// paused, including the start delay.
+	s.Run("UpdateWhilePaused_ShortensDispatch", func(s *standaloneActivityTestSuite) {
+		t := s.T()
+		env := s.newTestEnv()
+
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+		// If the paused update didn't take effect, the poll would time out.
+		originalDelay := 60 * time.Second
+		// The poll returns quickly under the updated delay.
+		newDelay := 2 * time.Second
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        env.Tv().ActivityType(),
+			Identity:            env.Tv().WorkerIdentity(),
+			Input:               defaultInput,
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			StartDelay:          durationpb.New(originalDelay),
+		})
+		require.NoError(t, err)
+
+		// Pause while inside the delay window -> PAUSED
+		_, err = env.FrontendClient().PauseActivityExecution(s.Context(), &workflowservice.PauseActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+			Identity:   defaultIdentity,
+			Reason:     "test-pause",
+		})
+		require.NoError(t, err)
+		descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_PAUSED, descResp.GetInfo().GetRunState())
+
+		// Update start_delay while paused
+		_, err = env.FrontendClient().UpdateActivityExecutionOptions(s.Context(), &workflowservice.UpdateActivityExecutionOptionsRequest{
+			Namespace:       env.Namespace().String(),
+			ActivityId:      activityID,
+			RunId:           startResp.RunId,
+			ActivityOptions: &activitypb.ActivityOptions{StartDelay: durationpb.New(newDelay)},
+			UpdateMask:      &fieldmaskpb.FieldMask{Paths: []string{"start_delay"}},
+		})
+		require.NoError(t, err)
+		descResp, err = env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		require.Equal(t, newDelay, descResp.GetInfo().GetStartDelay().AsDuration())
+
+		// Unpause; dispatch honors the updated (shorter) delay, so the poll succeeds well within the 10s
+		// context and long before the original 60s delay would have elapsed.
+		_, err = env.FrontendClient().UnpauseActivityExecution(s.Context(), &workflowservice.UnpauseActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+			Identity:   defaultIdentity,
+		})
+		require.NoError(t, err)
+
+		pollCtx, cancel := context.WithTimeout(s.Context(), 10*time.Second)
+		defer cancel()
+		pollResp, err := env.pollActivityTaskQueue(pollCtx, taskQueue)
+		require.NoError(t, err)
+		require.NotEmpty(t, pollResp.GetTaskToken(), "expected dispatch under the updated start_delay after unpause")
+	})
 }
 
 func (s *standaloneActivityTestSuite) TestUpdateActivityExecutionOptions() {


### PR DESCRIPTION
## What changed?
Change the `UpdateActivityOptions` handler so that it allows start delay to be updated during the delay period, regardless of status. 

## Why?
It should be possible to update start delay while paused, but was not.

## How did you test it?
- [x] added new functional test(s)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dispatch-timing validation for a user-facing API; incorrect logic could allow late start_delay edits or block valid paused updates, but scope is narrow and covered by new functional tests.
> 
> **Overview**
> **`UpdateActivityExecutionOptions`** no longer requires `SCHEDULED` status to change **`start_delay`**. Updates are allowed while the first attempt is still undispatched: either the activity is still before its first dispatch time, or it is **`PAUSED`** with no **`FirstAttemptStartedTime`**. After the first dispatch has been sent (including when still scheduled on matching but not paused), **`start_delay`** updates are rejected with a clearer failed-precondition message.
> 
> Standalone functional tests cover shortening/extending/zeroing delay while paused (including after the original delay window has passed) and rejecting updates once the delay window has elapsed without pause.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d647bde7eee997a8b3192c709da73f0e83bd128. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->