### PR TITLE
Add SAA operator APIs to DC redirection whitelist

### DIFF
--- a/common/rpc/interceptor/dc_redirection_policy.go
+++ b/common/rpc/interceptor/dc_redirection_policy.go
@@ -68,6 +68,10 @@ var selectedAPIsForwardingRedirectionPolicyWhitelistedAPIs = map[string]struct{}
 	"RequestCancelActivityExecution":   {},
 	"TerminateActivityExecution":       {},
 	"DeleteActivityExecution":          {},
+	"PauseActivityExecution":           {},
+	"UnpauseActivityExecution":         {},
+	"ResetActivityExecution":           {},
+	"UpdateActivityExecutionOptions":   {},
 }
 
 // RedirectionPolicyGenerator generate corresponding redirection policy


### PR DESCRIPTION
## What changed?
Added the standalone-activity operator APIs to the DC redirection whitelist                                                                                                          

## Why?
These four are mutating operations on standalone-activity state, which lives only on the active cluster of a global namespace. Without them in the whitelist, a request landing on a standby cluster under the SelectedAPIsForwarding policy would not be auto-forwarded to the active cluster, unlike the sibling activity  write APIs (StartActivityExecution, RequestCancelActivityExecution, TerminateActivityExecution, DeleteActivityExecution) which are already whitelisted.  

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
