### PR TITLE
[Scheduler] Implement Terminate to handle system-oringated terminations

### DIFF
--- a/chasm/lib/scheduler/export_test.go
+++ b/chasm/lib/scheduler/export_test.go
@@ -13,6 +13,12 @@ import (
 
 // Export unexported methods for testing.
 
+// ExecutionStatus search-attribute values, exported for tests.
+var (
+	ExecutionStatusRunning   = executionStatusRunning
+	ExecutionStatusCompleted = executionStatusCompleted
+)
+
 func NewTestHandler(logger log.Logger) *handler {
 	return newHandler(logger, legacyscheduler.NewSpecBuilder())
 }

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -337,7 +337,13 @@ func (s *Scheduler) Terminate(
 	_ chasm.MutableContext,
 	_ chasm.TerminateComponentRequest,
 ) (chasm.TerminateComponentResponse, error) {
-	// TODO: Implement terminate logic.
+	if s.Closed {
+		return chasm.TerminateComponentResponse{}, ErrClosed
+	}
+
+	// Needed so that the CHASM-level search attribute reads closed as well as the
+	// MS-level/legacy ExecutionStatus.
+	s.Closed = true
 	return chasm.TerminateComponentResponse{}, nil
 }
 

--- a/chasm/lib/scheduler/scheduler_test.go
+++ b/chasm/lib/scheduler/scheduler_test.go
@@ -17,6 +17,7 @@ import (
 	"go.temporal.io/server/chasm/lib/scheduler"
 	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common/payload"
+	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/service/history/tasks"
@@ -564,6 +565,57 @@ func TestSearchAttributes_BufferedStartsCount(t *testing.T) {
 		sas := sentinel.SearchAttributes(ctx)
 		_, ok := findSearchAttribute(t, sas, scheduler.ScheduleBufferedStartsCountName)
 		require.False(t, ok)
+	})
+}
+
+// TestTerminate verifies that terminating a schedule flips its published
+// ExecutionStatus search attribute closed, so it leaves the CHASM ListSchedules
+// query (service/worker/scheduler.VisibilityListQueryChasm).
+func TestTerminate(t *testing.T) {
+	t.Run("closes the schedule and flips ExecutionStatus to Completed", func(t *testing.T) {
+		sched, ctx, _ := setupSchedulerForTest(t)
+
+		require.False(t, sched.Closed)
+		require.Equal(t, chasm.LifecycleStateRunning, sched.LifecycleState(ctx))
+		status, ok := findSearchAttribute(t, sched.SearchAttributes(ctx), sadefs.ExecutionStatus)
+		require.True(t, ok)
+		require.Equal(t, scheduler.ExecutionStatusRunning, status)
+
+		_, err := sched.Terminate(ctx, chasm.TerminateComponentRequest{})
+		require.NoError(t, err)
+
+		// Closed at both altitudes: lifecycle state (MS-level status) and the SA.
+		require.True(t, sched.Closed)
+		require.Equal(t, chasm.LifecycleStateCompleted, sched.LifecycleState(ctx))
+		status, ok = findSearchAttribute(t, sched.SearchAttributes(ctx), sadefs.ExecutionStatus)
+		require.True(t, ok)
+		require.Equal(t, scheduler.ExecutionStatusCompleted, status)
+	})
+
+	t.Run("returns ErrClosed when already closed", func(t *testing.T) {
+		sched, ctx, _ := setupSchedulerForTest(t)
+
+		_, err := sched.Terminate(ctx, chasm.TerminateComponentRequest{})
+		require.NoError(t, err)
+
+		_, err = sched.Terminate(ctx, chasm.TerminateComponentRequest{})
+		require.ErrorIs(t, err, scheduler.ErrClosed)
+	})
+
+	t.Run("closing after terminate enqueues a visibility task", func(t *testing.T) {
+		env := newTestEnv(t)
+		sched := env.Scheduler
+
+		_, err := sched.Terminate(env.MutableContext(), chasm.TerminateComponentRequest{})
+		require.NoError(t, err)
+
+		// Discard setup tasks; assert only on what closing the terminated schedule emits.
+		env.NodeBackend.TasksByCategory = nil
+		require.NoError(t, env.Node.SetRootComponent(sched))
+		require.NoError(t, env.CloseTransaction())
+
+		require.NotEmpty(t, env.NodeBackend.TasksByCategory[tasks.CategoryVisibility],
+			"terminate must enqueue a visibility task so the closed status reaches ListSchedules")
 	})
 }
 


### PR DESCRIPTION
## What changed?
- Scheduler.Terminate now sets Scheduler.Closed = true

## Why?
- Although the MS-levell ExecutionStatus SA is updated when the termination is processed, the CHASM-level execution status SA (which ListSchedules `OR's` against) is still driven by each component's `SearchAttributes()` provider.
- A functional test was not possible for this, as there's no "natural" (black-box reachable scenario) in which a scheduler component will terminate; it only arises in the event of another bug that triggers framework-level termination for mutable state size exceeding limit. 

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
