### PR TITLE
Add configurable latency thresholds for persistence health

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -276,6 +276,26 @@ response to a StartWorkflowExecution request and skipping the trip through match
 		true,
 		`PersistenceHealthSignalAggregationEnabled determines whether persistence latency and error averages are tracked`,
 	)
+	PersistenceHealthSignalPercentilesEnabled = NewGlobalBoolSetting(
+		"system.persistenceHealthSignalPercentilesEnabled",
+		false,
+		`PersistenceHealthSignalPercentilesEnabled determines whether persistence latency is tracked using distribution objects`,
+	)
+	PersistenceHealthSignalLatencyWindowCount = NewGlobalIntSetting(
+		"system.persistenceHealthSignalLatencyWindowCount",
+		10,
+		`PersistenceHealthSignalLatencyWindowCount is the number of signal windows to compute latencies over`,
+	)
+	PersistenceHealthSignalLatencyWindowSize = NewGlobalDurationSetting(
+		"system.persistenceHealthSignalLatencyWindowSize",
+		5*time.Second,
+		`PersistenceHealthSignalLatencyWindowSize is the time window size in seconds for aggregating latencies`,
+	)
+	PersistenceHealthSignalPercentileLatencySettings = NewGlobalTypedSetting(
+		"system.persistenceHealthSignalPercentileLatencySettings",
+		LatencyHealthChecksPerPercentile{},
+		"persistenceHealthSignalPercentileLatencySettings controls what latency health checks are enabled and enforced for the persistence system",
+	)
 	PersistenceHealthSignalWindowSize = NewGlobalDurationSetting(
 		"system.persistenceHealthSignalWindowSize",
 		10*time.Second,

--- a/common/persistence/client/fx.go
+++ b/common/persistence/client/fx.go
@@ -169,10 +169,13 @@ func HealthSignalAggregatorProvider(
 	if dynamicconfig.PersistenceHealthSignalMetricsEnabled.Get(dynamicCollection)() {
 		aggregator := persistence.NewHealthSignalAggregator(
 			dynamicconfig.PersistenceHealthSignalAggregationEnabled.Get(dynamicCollection)(),
+			dynamicconfig.PersistenceHealthSignalPercentilesEnabled.Get(dynamicCollection),
 			dynamicconfig.PersistenceHealthSignalWindowSize.Get(dynamicCollection)(),
 			dynamicconfig.PersistenceHealthSignalBufferSize.Get(dynamicCollection)(),
 			metricsHandler,
 			logger,
+			dynamicconfig.PersistenceHealthSignalLatencyWindowSize.Get(dynamicCollection)(),
+			dynamicconfig.PersistenceHealthSignalLatencyWindowCount.Get(dynamicCollection)(),
 		)
 		lc.Append(fx.StopHook(aggregator.Stop))
 		return aggregator

--- a/common/persistence/health_signal_aggregator.go
+++ b/common/persistence/health_signal_aggregator.go
@@ -7,8 +7,11 @@ import (
 
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/aggregate"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/stats"
 )
 
 const (
@@ -19,6 +22,7 @@ type (
 	HealthSignalAggregator interface {
 		Record(callerSegment int32, latency time.Duration, err error)
 		AverageLatency() float64
+		LatencyQuantile(quantile float64) float64
 		ErrorRatio() float64
 		Start()
 		Stop()
@@ -33,8 +37,11 @@ type (
 		requestsLock  sync.Mutex
 
 		aggregationEnabled bool
-		latencyAverage     aggregate.MovingWindowAverage
-		errorRatio         aggregate.MovingWindowAverage
+		percentilesEnabled dynamicconfig.BoolPropertyFn
+
+		latencyAverage      aggregate.MovingWindowAverage
+		latencyDistribution stats.TimeWindowedStats
+		errorRatio          aggregate.MovingWindowAverage
 
 		metricsHandler   metrics.Handler
 		emitMetricsTimer *time.Ticker
@@ -45,19 +52,39 @@ type (
 
 func NewHealthSignalAggregator(
 	aggregationEnabled bool,
+	percentilesEnabled dynamicconfig.BoolPropertyFn,
 	windowSize time.Duration,
 	maxBufferSize int,
 	metricsHandler metrics.Handler,
 	logger log.Logger,
+	latencyWindowSize time.Duration,
+	latencyWindowCount int,
 ) *healthSignalAggregatorImpl {
+	latencyDistribution, err := stats.NewWindowedTDigest(stats.WindowConfig{
+		WindowSize:  latencyWindowSize,
+		WindowCount: latencyWindowCount,
+	})
+	if err != nil {
+		logger.Error("failed to create latency distribution helper, falling back to default config", tag.Error(err))
+		latencyDistribution, err = stats.NewWindowedTDigest(stats.WindowConfig{
+			WindowSize:  5 * time.Second,
+			WindowCount: 10,
+		})
+		if err != nil {
+			logger.Error("failed to create fallback latency distribution helper", tag.Error(err))
+		}
+	}
+
 	ret := &healthSignalAggregatorImpl{
-		status:             common.DaemonStatusInitialized,
-		shutdownCh:         make(chan struct{}),
-		requestCounts:      make(map[int32]int64),
-		metricsHandler:     metricsHandler,
-		emitMetricsTimer:   time.NewTicker(emitMetricsInterval),
-		logger:             logger,
-		aggregationEnabled: aggregationEnabled,
+		status:              common.DaemonStatusInitialized,
+		shutdownCh:          make(chan struct{}),
+		requestCounts:       make(map[int32]int64),
+		metricsHandler:      metricsHandler,
+		emitMetricsTimer:    time.NewTicker(emitMetricsInterval),
+		logger:              logger,
+		aggregationEnabled:  aggregationEnabled,
+		percentilesEnabled:  percentilesEnabled,
+		latencyDistribution: latencyDistribution,
 	}
 
 	if aggregationEnabled {
@@ -90,6 +117,10 @@ func (s *healthSignalAggregatorImpl) Record(callerSegment int32, latency time.Du
 	if s.aggregationEnabled {
 		s.latencyAverage.Record(latency.Milliseconds())
 
+		if s.percentilesEnabled() && s.latencyDistribution != nil {
+			s.latencyDistribution.RecordToLatestWindow(float64(latency.Milliseconds()))
+		}
+
 		if isUnhealthyError(err) {
 			s.errorRatio.Record(1)
 		} else {
@@ -104,6 +135,18 @@ func (s *healthSignalAggregatorImpl) Record(callerSegment int32, latency time.Du
 
 func (s *healthSignalAggregatorImpl) AverageLatency() float64 {
 	return s.latencyAverage.Average()
+}
+
+func (s *healthSignalAggregatorImpl) LatencyQuantile(quantile float64) float64 {
+	if !s.percentilesEnabled() {
+		s.logger.Debug("health signal percentile aggregator is disabled")
+		return 0
+	}
+	if s.latencyDistribution == nil {
+		return 0
+	}
+
+	return s.latencyDistribution.Quantile(quantile)
 }
 
 func (s *healthSignalAggregatorImpl) ErrorRatio() float64 {

--- a/common/persistence/noop_health_signal_aggregator.go
+++ b/common/persistence/noop_health_signal_aggregator.go
@@ -22,6 +22,10 @@ func (a *noopSignalAggregator) AverageLatency() float64 {
 	return 0
 }
 
+func (a *noopSignalAggregator) LatencyQuantile(quantile float64) float64 {
+	return 0
+}
+
 func (*noopSignalAggregator) ErrorRatio() float64 {
 	return 0
 }

--- a/common/rpc/interceptor/health_check.go
+++ b/common/rpc/interceptor/health_check.go
@@ -227,7 +227,7 @@ func (s *healthSignalAggregatorImpl) AverageLatency() float64 {
 }
 
 func (s *healthSignalAggregatorImpl) LatencyQuantile(quantile float64) float64 {
-	if !s.aggregatorEnabled() {
+	if !s.percentilesEnabled() {
 		s.logger.Debug("health signal percentile aggregator is disabled")
 		return 0
 	}

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -414,13 +414,14 @@ type Config struct {
 	BusinessIDReuseLimiterCacheSize          dynamicconfig.IntPropertyFn
 	BusinessIDReuseLimiterCacheTTL           dynamicconfig.DurationPropertyFn
 
-	HealthPersistenceLatencyFailure dynamicconfig.FloatPropertyFn
-	HealthPersistenceErrorRatio     dynamicconfig.FloatPropertyFn
-	HealthRPCLatencyFailure         dynamicconfig.FloatPropertyFn
-	HealthRPCLatencyPercentiles     dynamicconfig.TypedPropertyFn[dynamicconfig.LatencyHealthChecksPerPercentile]
-	HealthRPCErrorRatio             dynamicconfig.FloatPropertyFn
-	HealthHistoryInitializationTime dynamicconfig.DurationPropertyFn
-	BreakdownMetricsByTaskQueue     dynamicconfig.BoolPropertyFnWithTaskQueueFilter
+	HealthPersistenceLatencyFailure     dynamicconfig.FloatPropertyFn
+	HealthPersistenceLatencyPercentiles dynamicconfig.TypedPropertyFn[dynamicconfig.LatencyHealthChecksPerPercentile]
+	HealthPersistenceErrorRatio         dynamicconfig.FloatPropertyFn
+	HealthRPCLatencyFailure             dynamicconfig.FloatPropertyFn
+	HealthRPCLatencyPercentiles         dynamicconfig.TypedPropertyFn[dynamicconfig.LatencyHealthChecksPerPercentile]
+	HealthRPCErrorRatio                 dynamicconfig.FloatPropertyFn
+	HealthHistoryInitializationTime     dynamicconfig.DurationPropertyFn
+	BreakdownMetricsByTaskQueue         dynamicconfig.BoolPropertyFnWithTaskQueueFilter
 
 	LogAllReqErrors dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
@@ -804,12 +805,13 @@ func NewConfig(
 		BusinessIDReuseLimiterCacheSize:          dynamicconfig.BusinessIDReuseLimiterCacheSize.Get(dc),
 		BusinessIDReuseLimiterCacheTTL:           dynamicconfig.BusinessIDReuseLimiterCacheTTL.Get(dc),
 
-		HealthPersistenceLatencyFailure: dynamicconfig.HealthPersistenceLatencyFailure.Get(dc),
-		HealthPersistenceErrorRatio:     dynamicconfig.HealthPersistenceErrorRatio.Get(dc),
-		HealthRPCLatencyFailure:         dynamicconfig.HealthRPCLatencyFailure.Get(dc),
-		HealthRPCLatencyPercentiles:     dynamicconfig.HistoryHealthSignalPercentileLatencySettings.Get(dc),
-		HealthRPCErrorRatio:             dynamicconfig.HealthRPCErrorRatio.Get(dc),
-		HealthHistoryInitializationTime: dynamicconfig.HealthHistoryInitializationTime.Get(dc),
+		HealthPersistenceLatencyFailure:     dynamicconfig.HealthPersistenceLatencyFailure.Get(dc),
+		HealthPersistenceLatencyPercentiles: dynamicconfig.PersistenceHealthSignalPercentileLatencySettings.Get(dc),
+		HealthPersistenceErrorRatio:         dynamicconfig.HealthPersistenceErrorRatio.Get(dc),
+		HealthRPCLatencyFailure:             dynamicconfig.HealthRPCLatencyFailure.Get(dc),
+		HealthRPCLatencyPercentiles:         dynamicconfig.HistoryHealthSignalPercentileLatencySettings.Get(dc),
+		HealthRPCErrorRatio:                 dynamicconfig.HealthRPCErrorRatio.Get(dc),
+		HealthHistoryInitializationTime:     dynamicconfig.HealthHistoryInitializationTime.Get(dc),
 
 		BreakdownMetricsByTaskQueue: dynamicconfig.MetricsBreakdownByTaskQueue.Get(dc),
 

--- a/service/history/deep_health_check.go
+++ b/service/history/deep_health_check.go
@@ -72,9 +72,20 @@ func (h *deepHealthCheckHandler) DeepHealthCheck(
 		h.historyHealthSignal.ErrorRatio(), h.config.HealthRPCErrorRatio(),
 		"historyservice error ratio", true))
 
+	// TODO: Remove AverageLatency check once Latency is used by default.
 	checks = append(checks, errorIfOverThreshold(healthcheck.CheckTypePersistenceLatency,
 		h.persistenceHealthSignal.AverageLatency(), h.config.HealthPersistenceLatencyFailure(),
 		"persistenceservice latency", true))
+
+	for _, settings := range h.config.HealthPersistenceLatencyPercentiles().PercentileSettings {
+		checks = append(checks, errorIfOverThreshold(
+			healthcheck.CheckTypePersistenceLatency+fmt.Sprintf("_P%0.2f", 100.0*settings.Percentile),
+			h.persistenceHealthSignal.LatencyQuantile(settings.Percentile),
+			float64(settings.Threshold.Milliseconds()),
+			fmt.Sprintf("persistenceservice percentile latency (P%0.2f < %d, enforced: %t)", 100.0*settings.Percentile, settings.Threshold.Milliseconds(), settings.Enforced),
+			settings.Enforced,
+		))
+	}
 
 	checks = append(checks, errorIfOverThreshold(healthcheck.CheckTypePersistenceErrRatio,
 		h.persistenceHealthSignal.ErrorRatio(), h.config.HealthPersistenceErrorRatio(),

--- a/service/history/deep_health_check_test.go
+++ b/service/history/deep_health_check_test.go
@@ -100,6 +100,27 @@ func TestDeepHealthCheck(t *testing.T) {
 						Message:   "persistenceservice latency",
 					},
 					{
+						CheckType: health2.CheckTypePersistenceLatency + "_P99.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     100,
+						Threshold: 2000,
+						Message:   "persistenceservice percentile latency (P99.00 < 2000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypePersistenceLatency + "_P90.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     100,
+						Threshold: 1000,
+						Message:   "persistenceservice percentile latency (P90.00 < 1000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypePersistenceLatency + "_P50.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     100,
+						Threshold: 500,
+						Message:   "persistenceservice percentile latency (P50.00 < 500, enforced: false)",
+					},
+					{
 						CheckType: health2.CheckTypePersistenceErrRatio,
 						State:     enumsspb.HEALTH_STATE_SERVING,
 						Value:     0,
@@ -172,6 +193,27 @@ func TestDeepHealthCheck(t *testing.T) {
 						Message:   "persistenceservice latency",
 					},
 					{
+						CheckType: health2.CheckTypePersistenceLatency + "_P99.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     100,
+						Threshold: 2000,
+						Message:   "persistenceservice percentile latency (P99.00 < 2000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypePersistenceLatency + "_P90.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     100,
+						Threshold: 1000,
+						Message:   "persistenceservice percentile latency (P90.00 < 1000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypePersistenceLatency + "_P50.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     100,
+						Threshold: 500,
+						Message:   "persistenceservice percentile latency (P50.00 < 500, enforced: false)",
+					},
+					{
 						CheckType: health2.CheckTypePersistenceErrRatio,
 						State:     enumsspb.HEALTH_STATE_SERVING,
 						Value:     0,
@@ -190,8 +232,8 @@ func TestDeepHealthCheck(t *testing.T) {
 				{1500 * time.Millisecond, nil},
 			},
 			persistRecords: []record{
-				{100 * time.Millisecond, context.DeadlineExceeded},
-				{100 * time.Millisecond, context.DeadlineExceeded},
+				{800 * time.Millisecond, context.DeadlineExceeded},
+				{800 * time.Millisecond, context.DeadlineExceeded},
 			},
 			expected: &historyservice.DeepHealthCheckResponse{
 				State: enumsspb.HEALTH_STATE_NOT_SERVING,
@@ -239,9 +281,30 @@ func TestDeepHealthCheck(t *testing.T) {
 					{
 						CheckType: health2.CheckTypePersistenceLatency,
 						State:     enumsspb.HEALTH_STATE_SERVING,
-						Value:     100,
+						Value:     800,
 						Threshold: 1000,
 						Message:   "persistenceservice latency",
+					},
+					{
+						CheckType: health2.CheckTypePersistenceLatency + "_P99.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     800,
+						Threshold: 2000,
+						Message:   "persistenceservice percentile latency (P99.00 < 2000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypePersistenceLatency + "_P90.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     800,
+						Threshold: 1000,
+						Message:   "persistenceservice percentile latency (P90.00 < 1000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypePersistenceLatency + "_P50.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     800,
+						Threshold: 500,
+						Message:   "persistenceservice percentile latency (P50.00 < 500, enforced: false)",
 					},
 					{
 						CheckType: health2.CheckTypePersistenceErrRatio,
@@ -263,8 +326,8 @@ func TestDeepHealthCheck(t *testing.T) {
 				{1500 * time.Millisecond, nil},
 			},
 			persistRecords: []record{
-				{100 * time.Millisecond, context.DeadlineExceeded},
-				{100 * time.Millisecond, context.DeadlineExceeded},
+				{800 * time.Millisecond, context.DeadlineExceeded},
+				{800 * time.Millisecond, context.DeadlineExceeded},
 			},
 			expected: &historyservice.DeepHealthCheckResponse{
 				State: enumsspb.HEALTH_STATE_NOT_SERVING,
@@ -312,9 +375,30 @@ func TestDeepHealthCheck(t *testing.T) {
 					{
 						CheckType: health2.CheckTypePersistenceLatency,
 						State:     enumsspb.HEALTH_STATE_SERVING,
-						Value:     100,
+						Value:     800,
 						Threshold: 1000,
 						Message:   "persistenceservice latency",
+					},
+					{
+						CheckType: health2.CheckTypePersistenceLatency + "_P99.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     800,
+						Threshold: 2000,
+						Message:   "persistenceservice percentile latency (P99.00 < 2000, enforced: true)",
+					},
+					{
+						CheckType: health2.CheckTypePersistenceLatency + "_P90.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     800,
+						Threshold: 1000,
+						Message:   "persistenceservice percentile latency (P90.00 < 1000, enforced: true)",
+					},
+					{
+						CheckType: health2.CheckTypePersistenceLatency + "_P50.00",
+						State:     enumsspb.HEALTH_STATE_NOT_SERVING,
+						Value:     800,
+						Threshold: 500,
+						Message:   "persistenceservice percentile latency (P50.00 < 500, enforced: true)",
 					},
 					{
 						CheckType: health2.CheckTypePersistenceErrRatio,
@@ -389,6 +473,27 @@ func TestDeepHealthCheck(t *testing.T) {
 						Message:   "persistenceservice latency",
 					},
 					{
+						CheckType: health2.CheckTypePersistenceLatency + "_P99.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     100,
+						Threshold: 2000,
+						Message:   "persistenceservice percentile latency (P99.00 < 2000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypePersistenceLatency + "_P90.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     100,
+						Threshold: 1000,
+						Message:   "persistenceservice percentile latency (P90.00 < 1000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypePersistenceLatency + "_P50.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     100,
+						Threshold: 500,
+						Message:   "persistenceservice percentile latency (P50.00 < 500, enforced: false)",
+					},
+					{
 						CheckType: health2.CheckTypePersistenceErrRatio,
 						State:     enumsspb.HEALTH_STATE_SERVING,
 						Value:     0,
@@ -461,6 +566,27 @@ func TestDeepHealthCheck(t *testing.T) {
 						Message:   "persistenceservice latency",
 					},
 					{
+						CheckType: health2.CheckTypePersistenceLatency + "_P99.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     100,
+						Threshold: 2000,
+						Message:   "persistenceservice percentile latency (P99.00 < 2000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypePersistenceLatency + "_P90.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     100,
+						Threshold: 1000,
+						Message:   "persistenceservice percentile latency (P90.00 < 1000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypePersistenceLatency + "_P50.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     100,
+						Threshold: 500,
+						Message:   "persistenceservice percentile latency (P50.00 < 500, enforced: false)",
+					},
+					{
 						CheckType: health2.CheckTypePersistenceErrRatio,
 						State:     enumsspb.HEALTH_STATE_SERVING,
 						Value:     0,
@@ -527,6 +653,27 @@ func TestDeepHealthCheck(t *testing.T) {
 						Message:   "persistenceservice latency",
 					},
 					{
+						CheckType: health2.CheckTypePersistenceLatency + "_P99.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     0,
+						Threshold: 2000,
+						Message:   "persistenceservice percentile latency (P99.00 < 2000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypePersistenceLatency + "_P90.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     0,
+						Threshold: 1000,
+						Message:   "persistenceservice percentile latency (P90.00 < 1000, enforced: false)",
+					},
+					{
+						CheckType: health2.CheckTypePersistenceLatency + "_P50.00",
+						State:     enumsspb.HEALTH_STATE_SERVING,
+						Value:     0,
+						Threshold: 500,
+						Message:   "persistenceservice percentile latency (P50.00 < 500, enforced: false)",
+					},
+					{
 						CheckType: health2.CheckTypePersistenceErrRatio,
 						State:     enumsspb.HEALTH_STATE_SERVING,
 						Value:     0,
@@ -572,9 +719,30 @@ func TestDeepHealthCheck(t *testing.T) {
 							},
 						}
 					},
+					HealthPersistenceLatencyPercentiles: func() dynamicconfig.LatencyHealthChecksPerPercentile {
+						return dynamicconfig.LatencyHealthChecksPerPercentile{
+							PercentileSettings: []dynamicconfig.LatencyHealthCheckSettings{
+								{
+									Percentile: 0.99,
+									Threshold:  2 * time.Second,
+									Enforced:   tc.percentilesEnforced,
+								},
+								{
+									Percentile: 0.90,
+									Threshold:  1 * time.Second,
+									Enforced:   tc.percentilesEnforced,
+								},
+								{
+									Percentile: 0.50,
+									Threshold:  500 * time.Millisecond,
+									Enforced:   tc.percentilesEnforced,
+								},
+							},
+						}
+					},
 				},
 				historyHealthSignal:     interceptor.NewHealthSignalAggregator(testLogger, func() bool { return true }, func() bool { return true }, time.Second, 10, time.Second, 10),
-				persistenceHealthSignal: persistence.NewHealthSignalAggregator(true, time.Second, 100, metrics.NoopMetricsHandler, testLogger),
+				persistenceHealthSignal: persistence.NewHealthSignalAggregator(true, func() bool { return true }, time.Second, 100, metrics.NoopMetricsHandler, testLogger, time.Second, 10),
 				startupTime:             startupTime,
 			}
 


### PR DESCRIPTION
## What changed?
This adds configurable latency thresholds for persistence health checks so that we can dynamically change what percentiles we want to look at, as well as what values we want to alert on.

This also adds enforceability as a concept to the health checks so that we can have them reported in a safer way when testing.

These latencies are computed using the same tdigest based library we use in history health checks, which will allow us to get much more useful percentile values than the current average only reporting.

## Why?
So we can test out different percentile settings and evaluate good defaults.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Changing health checks is always risky, but this adds a softer version of them so it should make things safer ultimately.