### PR TITLE
Clean up schedules after tests

### DIFF
--- a/tests/callbacks_test.go
+++ b/tests/callbacks_test.go
@@ -86,7 +86,7 @@ func (s *CallbacksSuite) TestScheduledCallbackTokenMigration_LegacyWriteEnvelope
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMCallbacks, true),
 		testcore.WithDynamicConfig(callback.EncodeInternalTokenWithEnvelope, false),
 	)
-	env := testcore.NewEnv(s.T(), testOpts...)
+	env := newScheduleEnv(s.T(), testOpts...)
 
 	ctx := s.Context()
 	sid := testcore.RandomizeStr("sched-token-migration")

--- a/tests/schedule_migration_test.go
+++ b/tests/schedule_migration_test.go
@@ -1642,7 +1642,6 @@ func (s *ScheduleMigrationTestSuite) TestDeleteScheduleContextMetadata() {
 			},
 		)
 		require.NoError(t, err)
-		registerScheduleExecutionCleanup(t, env, sid)
 	}
 
 	createCHASMSentinel := func(t *testing.T, sid string) {
@@ -1927,7 +1926,6 @@ func (s *ScheduleMigrationTestSuite) TestPatchScheduleContextMetadata() {
 			},
 		)
 		s.NoError(err)
-		registerScheduleExecutionCleanup(s.T(), env, sid)
 
 		_, err = env.FrontendClient().PatchSchedule(
 			testcore.NewContext(),

--- a/tests/schedule_migration_test.go
+++ b/tests/schedule_migration_test.go
@@ -1642,6 +1642,7 @@ func (s *ScheduleMigrationTestSuite) TestDeleteScheduleContextMetadata() {
 			},
 		)
 		require.NoError(t, err)
+		registerScheduleExecutionCleanup(t, env, sid)
 	}
 
 	createCHASMSentinel := func(t *testing.T, sid string) {
@@ -1926,6 +1927,7 @@ func (s *ScheduleMigrationTestSuite) TestPatchScheduleContextMetadata() {
 			},
 		)
 		s.NoError(err)
+		registerScheduleExecutionCleanup(s.T(), env, sid)
 
 		_, err = env.FrontendClient().PatchSchedule(
 			testcore.NewContext(),

--- a/tests/schedule_migration_test.go
+++ b/tests/schedule_migration_test.go
@@ -48,7 +48,7 @@ func TestScheduleMigrationTestSuite(t *testing.T) {
 }
 
 func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2AlreadyExists() {
-	env := testcore.NewEnv(
+	env := newScheduleEnv(
 		s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 	)
@@ -210,7 +210,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2AlreadyExists() {
 }
 
 func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1BlockedBySentinel() {
-	env := testcore.NewEnv(
+	env := newScheduleEnv(
 		s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 	)
@@ -289,7 +289,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1BlockedBySentine
 }
 
 func (s *ScheduleMigrationTestSuite) TestScheduleMigrationDynamicConfig() {
-	env := testcore.NewEnv(
+	env := newScheduleEnv(
 		s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerMigration, true),
@@ -398,7 +398,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationDynamicConfig() {
 }
 
 func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2() {
-	env := testcore.NewEnv(
+	env := newScheduleEnv(
 		s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 	)
@@ -534,7 +534,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2() {
 }
 
 func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1() {
-	env := testcore.NewEnv(
+	env := newScheduleEnv(
 		s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, false),
@@ -740,7 +740,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1() {
 }
 
 func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1Idempotent() {
-	env := testcore.NewEnv(
+	env := newScheduleEnv(
 		s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, false),
@@ -810,7 +810,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1Idempotent() {
 }
 
 func (s *ScheduleMigrationTestSuite) TestCHASMScheduleDescribeAfterDisablingCreationAndMigration() {
-	env := testcore.NewEnv(
+	env := newScheduleEnv(
 		s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, true),
@@ -911,7 +911,7 @@ func (s *ScheduleMigrationTestSuite) TestCHASMScheduleDescribeAfterDisablingCrea
 // CHASM schedule to V1, frontend operations with CHASM routing enabled fall
 // through to the V1 workflow stack when the CHASM scheduler returns ErrClosed.
 func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1RoutingFallback() {
-	env := testcore.NewEnv(
+	env := newScheduleEnv(
 		s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, true),
@@ -1046,7 +1046,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1RoutingFallback(
 }
 
 func (s *ScheduleMigrationTestSuite) TestScheduleUpdateAfterDelete() {
-	env := testcore.NewEnv(
+	env := newScheduleEnv(
 		s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, true),
@@ -1156,7 +1156,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleUpdateAfterDelete() {
 }
 
 func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2WithClosedV2() {
-	env := testcore.NewEnv(
+	env := newScheduleEnv(
 		s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 	)
@@ -1312,7 +1312,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2WithClosedV2() {
 func TestScheduleMigrationV1ToV2NoDuplicateRecentActions(t *testing.T) {
 	// Create the env without EnableChasm so that CreateSchedule does not write
 	// a CHASM sentinel (which would block the migration activity).
-	env := testcore.NewEnv(
+	env := newScheduleEnv(
 		t,
 		testcore.WithWorkerService("V1 scheduler"),
 		testcore.WithSdkWorker(),
@@ -1460,7 +1460,7 @@ func TestScheduleMigrationV1ToV2NoDuplicateRecentActions(t *testing.T) {
 func TestScheduleMigrationDeferredWithRunningWorkflow(t *testing.T) {
 	// Create the env without EnableChasm so that CreateSchedule produces a V1
 	// (workflow-backed) schedule rather than a CHASM sentinel.
-	env := testcore.NewEnv(
+	env := newScheduleEnv(
 		t,
 		testcore.WithWorkerService("V1 scheduler"),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerMigrationWithRunningWorkflows, false),
@@ -1596,7 +1596,7 @@ func TestScheduleMigrationDeferredWithRunningWorkflow(t *testing.T) {
 // any context metadata set during the handler is emitted as trailers that the
 // client can read directly.
 func (s *ScheduleMigrationTestSuite) TestDeleteScheduleContextMetadata() {
-	env := testcore.NewEnv(
+	env := newScheduleEnv(
 		s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerRouting, true),
@@ -1799,7 +1799,7 @@ func (s *ScheduleMigrationTestSuite) TestDeleteScheduleContextMetadata() {
 // TestPatchScheduleContextMetadata verifies that PatchSchedule propagates the
 // correct context metadata for CHASM and V1 schedules.
 func (s *ScheduleMigrationTestSuite) TestPatchScheduleContextMetadata() {
-	env := testcore.NewEnv(
+	env := newScheduleEnv(
 		s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerRouting, true),
@@ -1961,7 +1961,7 @@ func (s *ScheduleMigrationTestSuite) TestPatchScheduleContextMetadata() {
 // stamp Completed, and only then fire ProcessBuffer (which then sees
 // isRunning=false and does not apply SKIP).
 func TestScheduleMigration_StaleRunningDoesNotSkipPending(t *testing.T) {
-	env := testcore.NewEnv(
+	env := newScheduleEnv(
 		t,
 		testcore.WithWorkerService("scheduler operations"),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
@@ -2109,7 +2109,7 @@ func TestScheduleMigration_StaleRunningDoesNotSkipPending(t *testing.T) {
 // migrates and the other stays on V1.
 func (s *ScheduleMigrationTestSuite) TestScheduleMigrationRolloutPercent() {
 	t := s.T()
-	env := testcore.NewEnv(
+	env := newScheduleEnv(
 		t,
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerMigration, true),
@@ -2234,7 +2234,7 @@ func TestScheduleMigration_NoRunningWorkflows_GeneratorStarts(t *testing.T) {
 	tweakables := chasmscheduler.DefaultTweakables
 	tweakables.IdleTime = shortIdleTime
 
-	env := testcore.NewEnv(
+	env := newScheduleEnv(
 		t,
 		testcore.WithWorkerService("scheduler operations"),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -25,7 +25,7 @@ import (
 	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
-	adminservice "go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/api/adminservice/v1"
 	schedulespb "go.temporal.io/server/api/schedule/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/callback"

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -92,7 +92,11 @@ func newScheduleEnv(t *testing.T, opts ...testcore.TestOption) *testcore.TestEnv
 				NextPageToken:   nextPageToken,
 			})
 			if err != nil {
-				reportScheduleCleanupError(t, fmt.Errorf("list schedules: %w", err))
+				if t.Failed() {
+					t.Logf("schedule cleanup failed: list schedules: %v", err)
+				} else {
+					t.Errorf("schedule cleanup failed: list schedules: %v", err)
+				}
 				return
 			}
 			for _, schedule := range response.GetSchedules() {
@@ -116,21 +120,15 @@ func newScheduleEnv(t *testing.T, opts ...testcore.TestOption) *testcore.TestEnv
 				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete schedule %q: %w", scheduleID, err))
 			}
 		}
-		reportScheduleCleanupError(t, cleanupErr)
+		if cleanupErr != nil {
+			if t.Failed() {
+				t.Logf("schedule cleanup failed: %v", cleanupErr)
+			} else {
+				t.Errorf("schedule cleanup failed: %v", cleanupErr)
+			}
+		}
 	})
 	return env
-}
-
-func reportScheduleCleanupError(t *testing.T, err error) {
-	t.Helper()
-	if err == nil {
-		return
-	}
-	if t.Failed() {
-		t.Logf("schedule cleanup failed: %v", err)
-		return
-	}
-	t.Errorf("schedule cleanup failed: %v", err)
 }
 
 const (

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -81,51 +81,46 @@ func newScheduleEnv(t *testing.T, opts ...testcore.TestOption) *testcore.TestEnv
 	opts = append(opts, testcore.WithDynamicConfig(dynamicconfig.FrontendAllowedExperiments, []string{"*"}))
 	env := testcore.NewEnv(t, opts...)
 	t.Cleanup(func() {
-		deleteAllSchedules(t, env)
+		ctx, cancel := context.WithTimeout(chasmContextFactory(testcore.NewContext()), 30*time.Second)
+		defer cancel()
+
+		var scheduleIDs []string
+		var nextPageToken []byte
+		for {
+			response, err := env.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
+				Namespace:       env.Namespace().String(),
+				MaximumPageSize: 1000,
+				NextPageToken:   nextPageToken,
+			})
+			if err != nil {
+				reportScheduleCleanupError(t, fmt.Errorf("list schedules: %w", err))
+				return
+			}
+			for _, schedule := range response.GetSchedules() {
+				scheduleIDs = append(scheduleIDs, schedule.GetScheduleId())
+			}
+			nextPageToken = response.GetNextPageToken()
+			if len(nextPageToken) == 0 {
+				break
+			}
+		}
+
+		var cleanupErr error
+		for _, scheduleID := range scheduleIDs {
+			_, err := env.FrontendClient().DeleteSchedule(ctx, &workflowservice.DeleteScheduleRequest{
+				Namespace:  env.Namespace().String(),
+				ScheduleId: scheduleID,
+				Identity:   "test cleanup",
+			})
+			var notFoundErr *serviceerror.NotFound
+			if err != nil && !errors.As(err, &notFoundErr) {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete schedule %q: %w", scheduleID, err))
+			}
+			cleanupErr = errors.Join(cleanupErr, forceDeleteScheduleExecutions(ctx, env, scheduleID))
+		}
+		reportScheduleCleanupError(t, cleanupErr)
 	})
 	return env
-}
-
-func deleteAllSchedules(t *testing.T, env *testcore.TestEnv) {
-	t.Helper()
-	ctx, cancel := context.WithTimeout(chasmContextFactory(testcore.NewContext()), 30*time.Second)
-	defer cancel()
-
-	var scheduleIDs []string
-	var nextPageToken []byte
-	for {
-		response, err := env.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
-			Namespace:       env.Namespace().String(),
-			MaximumPageSize: 1000,
-			NextPageToken:   nextPageToken,
-		})
-		if err != nil {
-			reportScheduleCleanupError(t, fmt.Errorf("list schedules: %w", err))
-			return
-		}
-		for _, schedule := range response.GetSchedules() {
-			scheduleIDs = append(scheduleIDs, schedule.GetScheduleId())
-		}
-		nextPageToken = response.GetNextPageToken()
-		if len(nextPageToken) == 0 {
-			break
-		}
-	}
-
-	var cleanupErr error
-	for _, scheduleID := range scheduleIDs {
-		_, err := env.FrontendClient().DeleteSchedule(ctx, &workflowservice.DeleteScheduleRequest{
-			Namespace:  env.Namespace().String(),
-			ScheduleId: scheduleID,
-			Identity:   "test cleanup",
-		})
-		var notFoundErr *serviceerror.NotFound
-		if err != nil && !errors.As(err, &notFoundErr) {
-			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete schedule %q: %w", scheduleID, err))
-		}
-		cleanupErr = errors.Join(cleanupErr, forceDeleteScheduleExecutions(ctx, env, scheduleID))
-	}
-	reportScheduleCleanupError(t, cleanupErr)
 }
 
 func registerScheduleExecutionCleanup(t *testing.T, env *testcore.TestEnv, scheduleID string) {

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -77,6 +77,7 @@ func scheduleCommonOpts(t *testing.T) []testcore.TestOption {
 
 func newScheduleEnv(t *testing.T, opts ...testcore.TestOption) *testcore.TestEnv {
 	t.Helper()
+	opts = append(opts, testcore.WithDynamicConfig(dynamicconfig.FrontendAllowedExperiments, []string{"*"}))
 	env := testcore.NewEnv(t, opts...)
 	t.Cleanup(func() {
 		deleteAllSchedules(t, env)
@@ -86,7 +87,7 @@ func newScheduleEnv(t *testing.T, opts ...testcore.TestOption) *testcore.TestEnv
 
 func deleteAllSchedules(t *testing.T, env *testcore.TestEnv) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(chasmContextFactory(env.Context()), 30*time.Second)
+	ctx, cancel := context.WithTimeout(chasmContextFactory(testcore.NewContext()), 30*time.Second)
 	defer cancel()
 
 	var scheduleIDs []string

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -25,7 +25,6 @@ import (
 	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
-	"go.temporal.io/server/api/adminservice/v1"
 	schedulespb "go.temporal.io/server/api/schedule/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/callback"
@@ -116,42 +115,10 @@ func newScheduleEnv(t *testing.T, opts ...testcore.TestOption) *testcore.TestEnv
 			if err != nil && !errors.As(err, &notFoundErr) {
 				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete schedule %q: %w", scheduleID, err))
 			}
-			cleanupErr = errors.Join(cleanupErr, forceDeleteScheduleExecutions(ctx, env, scheduleID))
 		}
 		reportScheduleCleanupError(t, cleanupErr)
 	})
 	return env
-}
-
-func registerScheduleExecutionCleanup(t *testing.T, env *testcore.TestEnv, scheduleID string) {
-	t.Helper()
-	t.Cleanup(func() {
-		ctx, cancel := context.WithTimeout(chasmContextFactory(testcore.NewContext()), 30*time.Second)
-		defer cancel()
-		reportScheduleCleanupError(t, forceDeleteScheduleExecutions(ctx, env, scheduleID))
-	})
-}
-
-func forceDeleteScheduleExecutions(ctx context.Context, env *testcore.TestEnv, scheduleID string) error {
-	var cleanupErr error
-	for _, execution := range []struct {
-		workflowID string
-		archetype  chasm.Archetype
-	}{
-		{workflowID: scheduler.WorkflowIDPrefix + scheduleID},
-		{workflowID: scheduleID, archetype: chasm.SchedulerArchetype},
-	} {
-		_, err := env.AdminClient().DeleteWorkflowExecution(ctx, &adminservice.DeleteWorkflowExecutionRequest{
-			Namespace: env.Namespace().String(),
-			Execution: &commonpb.WorkflowExecution{WorkflowId: execution.workflowID},
-			Archetype: execution.archetype,
-		})
-		var notFoundErr *serviceerror.NotFound
-		if err != nil && !errors.As(err, &notFoundErr) {
-			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("force delete schedule execution %q: %w", execution.workflowID, err))
-		}
-	}
-	return cleanupErr
 }
 
 func reportScheduleCleanupError(t *testing.T, err error) {

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -75,6 +75,68 @@ func scheduleCommonOpts(t *testing.T) []testcore.TestOption {
 	return opts
 }
 
+func newScheduleEnv(t *testing.T, opts ...testcore.TestOption) *testcore.TestEnv {
+	t.Helper()
+	env := testcore.NewEnv(t, opts...)
+	t.Cleanup(func() {
+		deleteAllSchedules(t, env)
+	})
+	return env
+}
+
+func deleteAllSchedules(t *testing.T, env *testcore.TestEnv) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(chasmContextFactory(env.Context()), 30*time.Second)
+	defer cancel()
+
+	var scheduleIDs []string
+	var nextPageToken []byte
+	for {
+		response, err := env.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
+			Namespace:       env.Namespace().String(),
+			MaximumPageSize: 1000,
+			NextPageToken:   nextPageToken,
+		})
+		if err != nil {
+			reportScheduleCleanupError(t, fmt.Errorf("list schedules: %w", err))
+			return
+		}
+		for _, schedule := range response.GetSchedules() {
+			scheduleIDs = append(scheduleIDs, schedule.GetScheduleId())
+		}
+		nextPageToken = response.GetNextPageToken()
+		if len(nextPageToken) == 0 {
+			break
+		}
+	}
+
+	var cleanupErr error
+	for _, scheduleID := range scheduleIDs {
+		_, err := env.FrontendClient().DeleteSchedule(ctx, &workflowservice.DeleteScheduleRequest{
+			Namespace:  env.Namespace().String(),
+			ScheduleId: scheduleID,
+			Identity:   "test cleanup",
+		})
+		var notFoundErr *serviceerror.NotFound
+		if err != nil && !errors.As(err, &notFoundErr) {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete schedule %q: %w", scheduleID, err))
+		}
+	}
+	reportScheduleCleanupError(t, cleanupErr)
+}
+
+func reportScheduleCleanupError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		return
+	}
+	if t.Failed() {
+		t.Logf("schedule cleanup failed: %v", err)
+		return
+	}
+	t.Errorf("schedule cleanup failed: %v", err)
+}
+
 const (
 	// fastInterval is the shortest interval that reliably ticks once per second.
 	fastInterval = 1 * time.Second
@@ -107,7 +169,7 @@ func newEnvWithIdleTime(t *testing.T, idleTime time.Duration, extra ...testcore.
 	tweakables := chasmscheduler.DefaultTweakables
 	tweakables.IdleTime = idleTime
 	opts := append(scheduleCommonOpts(t), testcore.WithDynamicConfig(chasmscheduler.CurrentTweakables, tweakables))
-	return testcore.NewEnv(t, append(opts, extra...)...)
+	return newScheduleEnv(t, append(opts, extra...)...)
 }
 
 // createSchedule creates sched under sid and fails the test on error.
@@ -332,7 +394,7 @@ func runSharedScheduleTests(t *testing.T, newContext contextFactory) {
 // BUFFER_ONE keeps exactly one start in the buffer while the first workflow
 // is still running.
 func testBufferSizeReportedWhenBuffered(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-buffer-size")
 	wid := testcore.RandomizeStr("sched-buffer-size-wf")
@@ -399,7 +461,7 @@ func testBufferSizeReportedWhenBuffered(t *testing.T, newContext contextFactory)
 // from RUNNING to COMPLETED. V1's scheduler workflow does not advance its
 // memo while paused, so the listed status stays at RUNNING until unpause.
 func testRecentActionsAdvanceWhilePaused(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-recentactions-paused")
 	wid := testcore.RandomizeStr("sched-recentactions-paused-wf")
@@ -450,7 +512,7 @@ func testRecentActionsAdvanceWhilePaused(t *testing.T, newContext contextFactory
 // while paused, so its projected times would freeze at pause time and
 // eventually all sit in the past - hence this test is registered CHASM-only.
 func testFutureActionTimesAdvanceWhilePaused(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-future-actions-paused")
 	wid := testcore.RandomizeStr("sched-future-actions-paused-wf")
@@ -488,7 +550,7 @@ func testFutureActionTimesAdvanceWhilePaused(t *testing.T, newContext contextFac
 // deferred start (Attempt=-1 -> 0 in recordCompletedAction), the buffered
 // fire would be stranded.
 func testBufferOneDeferredFiresAfterCompletion(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-buffer-one-deferred")
 	wid := testcore.RandomizeStr("sched-buffer-one-deferred-wf")
@@ -551,7 +613,7 @@ func testBufferOneDeferredFiresAfterCompletion(t *testing.T, newContext contextF
 }
 
 func testDeletedScheduleOperations(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-deleted-ops"
 	wid := "sched-test-deleted-ops-wf"
@@ -607,7 +669,7 @@ func testDeletedScheduleOperations(t *testing.T, newContext contextFactory) {
 }
 
 func testBasics(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-basics"
 	wid := "sched-test-basics-wf"
@@ -1037,7 +1099,7 @@ func testBasics(t *testing.T, newContext contextFactory) {
 }
 
 func testInput(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-input"
 	wid := "sched-test-input-wf"
@@ -1101,7 +1163,7 @@ func testInput(t *testing.T, newContext contextFactory) {
 }
 
 func testLastCompletionAndError(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-last"
 	wid := "sched-test-last-wf"
@@ -1183,7 +1245,7 @@ func testScheduleContinuesAfterWorkflowRetryFailure(t *testing.T, newContext con
 	// runs created by retries). That requires the envelope token format, which is gated off by default
 	// for safe rollout, so enable it explicitly here.
 	opts := append(scheduleCommonOpts(t), testcore.WithDynamicConfig(callback.EncodeInternalTokenWithEnvelope, true))
-	s := testcore.NewEnv(t, opts...)
+	s := newScheduleEnv(t, opts...)
 
 	sid := testcore.RandomizeStr("sched-retry-fail")
 	wid := testcore.RandomizeStr("sched-retry-fail-wf")
@@ -1272,7 +1334,7 @@ func testScheduledWorkflowContinueAsNewCompletion(t *testing.T, newContext conte
 	// completion callback token, which only survives continue-as-new in the envelope token format.
 	// That format is gated off by default for safe rollout, so enable it explicitly here.
 	opts := append(scheduleCommonOpts(t), testcore.WithDynamicConfig(callback.EncodeInternalTokenWithEnvelope, true))
-	s := testcore.NewEnv(t, opts...)
+	s := newScheduleEnv(t, opts...)
 
 	sid := testcore.RandomizeStr("sched-can-completion")
 	wid := testcore.RandomizeStr("sched-can-completion-wf")
@@ -1384,7 +1446,7 @@ func testScheduledWorkflowContinueAsNewCompletion(t *testing.T, newContext conte
 }
 
 func testListSchedulesReturnsWorkflowStatus(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-list-running"
 	wid := "sched-test-list-running-wf"
@@ -1479,7 +1541,7 @@ func testListSchedulesReturnsWorkflowStatus(t *testing.T, newContext contextFact
 }
 
 func testUpdateIntervalTakesEffect(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-update-interval"
 	wid := "sched-test-update-interval-wf"
@@ -1544,7 +1606,7 @@ func testUpdateIntervalTakesEffect(t *testing.T, newContext contextFactory) {
 }
 
 func testListScheduleMatchingTimes(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-list-matching-times"
 
@@ -1593,7 +1655,7 @@ func testListScheduleMatchingTimes(t *testing.T, newContext contextFactory) {
 }
 
 func testLimitMemoSpecSize(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	expectedLimit := scheduler.CurrentTweakablePolicies.SpecFieldLengthLimit
 
@@ -1664,7 +1726,7 @@ func testLimitMemoSpecSize(t *testing.T, newContext contextFactory) {
 }
 
 func testCountSchedules(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	// Create multiple schedules with different paused states
 	sidPrefix := "sched-test-count-"
@@ -1734,7 +1796,7 @@ func testCountSchedules(t *testing.T, newContext contextFactory) {
 }
 
 func testListSchedulesPagination(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	const numSchedules = 4
 	sidPrefix := "sched-test-pagination-"
@@ -1805,7 +1867,7 @@ func testListSchedulesPagination(t *testing.T, newContext contextFactory) {
 }
 
 func testListSchedulesFilterAndEntryFields(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-list-fields"
 	wt := "sched-test-list-fields-wt"
@@ -1898,7 +1960,7 @@ func testListSchedulesFilterAndEntryFields(t *testing.T, newContext contextFacto
 }
 
 func testListSchedulesFilterByScheduleID(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid1 := "sched-filter-by-id-alpha"
 	sid2 := "sched-filter-by-id-beta"
@@ -2029,7 +2091,7 @@ func testListSchedulesFilterByScheduleID(t *testing.T, newContext contextFactory
 }
 
 func testScheduleInternalTaskQueue(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 	errorMessageKeyword := "internal per-namespace task queue"
 
 	// Test CreateSchedule with internal task queue
@@ -2121,7 +2183,7 @@ func testScheduleInternalTaskQueue(t *testing.T, newContext contextFactory) {
 }
 
 func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, enableCHASMCallbacks bool) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 	s.OverrideDynamicConfig(dynamicconfig.EnableCHASMCallbacks, enableCHASMCallbacks)
 
 	sid := "sched-test-double-reset"
@@ -2278,7 +2340,7 @@ func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, e
 }
 
 func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, enableCHASMCallbacks bool) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 	s.OverrideDynamicConfig(dynamicconfig.EnableCHASMCallbacks, enableCHASMCallbacks)
 	s.OverrideDynamicConfig(
 		callback.AllowedAddresses,
@@ -2461,7 +2523,7 @@ func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, en
 // testCreatesWorkflowSentinel tests that creating a CHASM schedule also starts a
 // dummy workflow to reserve the schedule ID in the V1 workflow ID-space.
 func testCreatesWorkflowSentinel(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sid")
 	wid := testcore.RandomizeStr("wid")
@@ -2524,7 +2586,7 @@ func testCreatesWorkflowSentinel(t *testing.T, newContext contextFactory) {
 }
 
 func testStateSizeBytesReported(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-state-size")
 	wid := testcore.RandomizeStr("sched-state-size-wf")
@@ -2569,7 +2631,7 @@ func testStateSizeBytesReported(t *testing.T, newContext contextFactory) {
 // testCreatesCHASMSentinel tests that creating a V1 schedule also creates a
 // CHASM sentinel to reserve the schedule ID in the CHASM execution space.
 func testCreatesCHASMSentinel(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sid")
 	wid := testcore.RandomizeStr("wid")
@@ -2654,7 +2716,7 @@ func testCreatesCHASMSentinel(t *testing.T, newContext contextFactory) {
 // testSkipsWorkflowSentinelWhenDisabled asserts that a CHASM CreateSchedule
 // does not start the dummy V1 workflow when EnableCHASMSchedulerSentinels is off.
 func testSkipsWorkflowSentinelWhenDisabled(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, append(scheduleCommonOpts(t),
+	s := newScheduleEnv(t, append(scheduleCommonOpts(t),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerSentinels, false),
 	)...)
 
@@ -2703,7 +2765,7 @@ func testSkipsWorkflowSentinelWhenDisabled(t *testing.T, newContext contextFacto
 // testSkipsCHASMSentinelWhenDisabled asserts that a V1 CreateSchedule does not
 // create a CHASM sentinel when EnableCHASMSchedulerSentinels is off.
 func testSkipsCHASMSentinelWhenDisabled(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, append(scheduleCommonOpts(t),
+	s := newScheduleEnv(t, append(scheduleCommonOpts(t),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerSentinels, false),
 	)...)
 
@@ -2757,7 +2819,7 @@ func testSkipsCHASMSentinelWhenDisabled(t *testing.T, newContext contextFactory)
 }
 
 func testCreateScheduleAlreadyExists(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-already-exists"
 
@@ -2808,7 +2870,7 @@ func testCreateScheduleDuplicateSdkError(t *testing.T, useCHASM bool) {
 	if useCHASM {
 		opts = append(opts, testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, true))
 	}
-	s := testcore.NewEnv(t, opts...)
+	s := newScheduleEnv(t, opts...)
 
 	sid := "sched-test-duplicate-sdk-" + uuid.NewString()[:8]
 	schedOpts := sdkclient.ScheduleOptions{
@@ -2832,7 +2894,7 @@ func testCreateScheduleDuplicateSdkError(t *testing.T, useCHASM bool) {
 }
 
 func testPatchRejectsExcessBackfillers(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 	sid := "sched-test-too-many-backfillers"
 	wt := "sched-test-too-many-backfillers-wt"
 
@@ -2910,7 +2972,7 @@ func testPatchRejectsExcessBackfillers(t *testing.T, newContext contextFactory) 
 }
 
 func testMigrationCallbackAttach(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sid")
 	wid := testcore.RandomizeStr("wid")
@@ -3040,7 +3102,7 @@ func testMigrationCallbackAttach(t *testing.T, newContext contextFactory) {
 // testCHASMCanListV1Schedules tests that a schedule created in the V1 stack
 // will also be visible in the V2 stack.
 func testCHASMCanListV1Schedules(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "schedule-created-on-v1"
 	schedule := &schedulepb.Schedule{
@@ -3111,7 +3173,7 @@ func testCHASMCanListV1Schedules(t *testing.T, newContext contextFactory) {
 
 // testRefresh applies to V1 scheduler only; V2 does not support/need manual refresh.
 func testRefresh(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-refresh"
 	wid := "sched-test-refresh-wf"
@@ -3221,7 +3283,7 @@ func testRefresh(t *testing.T, newContext contextFactory) {
 // testListBeforeRun only applies to V1, as V2 scheduler does not involve the
 // per-NS worker or workflow.
 func testListBeforeRun(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, append(scheduleCommonOpts(t),
+	s := newScheduleEnv(t, append(scheduleCommonOpts(t),
 		testcore.WithDynamicConfig(dynamicconfig.WorkerPerNamespaceWorkerCount, 0),
 	)...)
 
@@ -3269,7 +3331,7 @@ func testListBeforeRun(t *testing.T, newContext contextFactory) {
 
 // testRateLimit applies only to V1, as V2 scheduler does not impose its own rate limiting.
 func testRateLimit(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, append(scheduleCommonOpts(t),
+	s := newScheduleEnv(t, append(scheduleCommonOpts(t),
 		testcore.WithDynamicConfig(dynamicconfig.SchedulerNamespaceStartWorkflowRPS, 1.0),
 	)...)
 
@@ -3324,7 +3386,7 @@ func testRateLimit(t *testing.T, newContext contextFactory) {
 
 // testNextTimeCache only applies to V1.
 func testNextTimeCache(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-next-time-cache"
 	wid := "sched-test-next-time-cache-wf"
@@ -3481,7 +3543,7 @@ func assertRecentActionsNoDuplicateRunIDs(t *testing.T, actions []*schedulepb.Sc
 	}
 }
 func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-update-memo"
 	wid := "sched-test-update-memo-wf"
@@ -3605,7 +3667,7 @@ func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
 }
 
 func testUpdateScheduleMemoRejected(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-update-memo-rejected"
 	wid := "sched-test-update-memo-rejected-wf"
@@ -3669,7 +3731,7 @@ func testUpdateScheduleMemoOnly(t *testing.T, newContext contextFactory) {
 	// the schedule when the field is nil, similar to how memo and search_attributes are handled.
 	t.Skip("memo-only updates not yet supported: omitting the schedule field unsets the schedule")
 
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-update-memo-only"
 	wid := "sched-test-update-memo-only-wf"
@@ -3738,7 +3800,7 @@ func testUpdateScheduleMemoOnly(t *testing.T, newContext contextFactory) {
 }
 
 func testCHASMUnpauseResumesProcessing(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-unpause-resumes"
 	wid := "sched-test-unpause-resumes-wf"
@@ -3922,7 +3984,7 @@ func testPausedScheduleNeverIdles(t *testing.T, newContext contextFactory) {
 // manual-only pattern - can be created without timing out and remains
 // describable.
 func testPausedEmptySpecStaysOpen(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-paused-empty-spec")
 	wid := testcore.RandomizeStr("sched-paused-empty-spec-wf")
@@ -3971,7 +4033,7 @@ func testPausedEmptySpecStaysOpen(t *testing.T, newContext contextFactory) {
 // patch on a running schedule fires an extra action and leaves the schedule
 // active.
 func testTriggerImmediatelyOnActiveSchedule(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-trigger-on-active")
 	wid := testcore.RandomizeStr("sched-trigger-on-active-wf")
@@ -4022,7 +4084,7 @@ func testTriggerImmediatelyOnActiveSchedule(t *testing.T, newContext contextFact
 // an action even when the schedule is paused. Manual starts bypass the paused
 // gate via useScheduledAction's Manual carve-out in processBuffer.
 func testTriggerImmediatelyOnPausedSchedule(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-trigger-on-paused")
 	wid := testcore.RandomizeStr("sched-trigger-on-paused-wf")
@@ -4061,7 +4123,7 @@ func testTriggerImmediatelyOnPausedSchedule(t *testing.T, newContext contextFact
 // testTriggerImmediatelyAfterActionsExhausted verifies that TriggerImmediately
 // fires an action even on a schedule that has no LimitedActions slots left.
 func testTriggerImmediatelyAfterActionsExhausted(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-trigger-after-exhausted")
 	wid := testcore.RandomizeStr("sched-trigger-after-exhausted-wf")
@@ -4112,7 +4174,7 @@ func testBackfillWithBufferOneOverlap(t *testing.T, newContext contextFactory) {
 	//   go test ./tests/ -run 'TestScheduleCHASM/Backfill/BufferOneOverlap' -v
 	t.Skip("BUFFER_ONE backfill deferred re-enable is broken on both V1 and CHASM; see test doc")
 
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-backfill-buffer-one")
 	wid := testcore.RandomizeStr("sched-backfill-buffer-one-wf")
@@ -4156,7 +4218,7 @@ func testBackfillWithBufferOneOverlap(t *testing.T, newContext contextFactory) {
 // is narrower than the spec interval - no spec tick lands inside it, so no
 // actions fire and the backfiller still drains cleanly.
 func testBackfillRangeSmallerThanInterval(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-backfill-narrow")
 	wid := testcore.RandomizeStr("sched-backfill-narrow-wf")
@@ -4197,7 +4259,7 @@ func testBackfillRangeSmallerThanInterval(t *testing.T, newContext contextFactor
 // testBackfillWithSkipOverlap verifies that SKIP overlap correctly collapses a
 // multi-tick backfill range to a single workflow execution.
 func testBackfillWithSkipOverlap(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-backfill-skip")
 	wid := testcore.RandomizeStr("sched-backfill-skip-wf")
@@ -4226,7 +4288,7 @@ func testBackfillWithSkipOverlap(t *testing.T, newContext contextFactory) {
 }
 
 func testUpdateScheduleRequestIDTooLong(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-update-reqid-too-long"
 	wid := "sched-test-update-reqid-too-long-wf"
@@ -4258,7 +4320,7 @@ func testUpdateScheduleRequestIDTooLong(t *testing.T, newContext contextFactory)
 }
 
 func testUpdateScheduleBlobSizeLimit(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t,
+	s := newScheduleEnv(t,
 		append(scheduleCommonOpts(t),
 			testcore.WithDynamicConfig(dynamicconfig.BlobSizeLimitError, 1000),
 			testcore.WithDynamicConfig(dynamicconfig.BlobSizeLimitWarn, 500),
@@ -4331,7 +4393,7 @@ func TestScheduleCreationRolloutPercent(t *testing.T) {
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, true),
 		testcore.WithDynamicConfig(dynamicconfig.CHASMSchedulerCreationRolloutPercent, 50),
 	)
-	s := testcore.NewEnv(t, opts...)
+	s := newScheduleEnv(t, opts...)
 	ctx := s.Context()
 	nsName := s.Namespace().String()
 	nsID := s.NamespaceID().String()
@@ -4626,7 +4688,7 @@ func testBackfillBlocksIdleClose(t *testing.T, newContext contextFactory) {
 // testMultiRangeBackfillCountedExactlyOnce asserts that the `ActionCount` is
 // correctly counted when multiple backfillers are concurrently running.
 func testMultiRangeBackfillCountedExactlyOnce(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-multi-range-backfill")
 	wid := testcore.RandomizeStr("sched-multi-range-backfill-wf")
@@ -4680,7 +4742,7 @@ func testMultiRangeBackfillCountedExactlyOnce(t *testing.T, newContext contextFa
 // a backfill request to completion, even though the schedule otherwise has no
 // automated actions running.
 func testBackfillOnPausedSchedule(t *testing.T, newContext contextFactory) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-backfill-paused")
 	wid := testcore.RandomizeStr("sched-backfill-paused-wf")
@@ -4714,7 +4776,7 @@ func testBackfillOnPausedSchedule(t *testing.T, newContext contextFactory) {
 // queryable through the frontend ListSchedules API.
 func TestScheduleNextActionTimeVisibility(t *testing.T) {
 	opts := scheduleCommonOpts(t)
-	s := testcore.NewEnv(t, opts...)
+	s := newScheduleEnv(t, opts...)
 
 	v2Sid := testcore.RandomizeStr("sched-next-action-v2")
 	wid := testcore.RandomizeStr("sched-next-action-wf")
@@ -4799,7 +4861,7 @@ func TestScheduleNextActionTimeVisibility(t *testing.T) {
 // behind it. The counts aren't surfaced on the list entry, so we assert via the
 // query rather than by reading the entry's SAs.
 func TestScheduleCountsVisibility(t *testing.T) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 	newContext := chasmContextFactory
 
 	sid := testcore.RandomizeStr("sched-counts-v2")

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -25,6 +25,7 @@ import (
 	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
+	adminservice "go.temporal.io/server/api/adminservice/v1"
 	schedulespb "go.temporal.io/server/api/schedule/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/callback"
@@ -122,8 +123,40 @@ func deleteAllSchedules(t *testing.T, env *testcore.TestEnv) {
 		if err != nil && !errors.As(err, &notFoundErr) {
 			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete schedule %q: %w", scheduleID, err))
 		}
+		cleanupErr = errors.Join(cleanupErr, forceDeleteScheduleExecutions(ctx, env, scheduleID))
 	}
 	reportScheduleCleanupError(t, cleanupErr)
+}
+
+func registerScheduleExecutionCleanup(t *testing.T, env *testcore.TestEnv, scheduleID string) {
+	t.Helper()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(chasmContextFactory(testcore.NewContext()), 30*time.Second)
+		defer cancel()
+		reportScheduleCleanupError(t, forceDeleteScheduleExecutions(ctx, env, scheduleID))
+	})
+}
+
+func forceDeleteScheduleExecutions(ctx context.Context, env *testcore.TestEnv, scheduleID string) error {
+	var cleanupErr error
+	for _, execution := range []struct {
+		workflowID string
+		archetype  chasm.Archetype
+	}{
+		{workflowID: scheduler.WorkflowIDPrefix + scheduleID},
+		{workflowID: scheduleID, archetype: chasm.SchedulerArchetype},
+	} {
+		_, err := env.AdminClient().DeleteWorkflowExecution(ctx, &adminservice.DeleteWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
+			Execution: &commonpb.WorkflowExecution{WorkflowId: execution.workflowID},
+			Archetype: execution.archetype,
+		})
+		var notFoundErr *serviceerror.NotFound
+		if err != nil && !errors.As(err, &notFoundErr) {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("force delete schedule execution %q: %w", execution.workflowID, err))
+		}
+	}
+	return cleanupErr
 }
 
 func reportScheduleCleanupError(t *testing.T, err error) {

--- a/tests/schedule_workflow_pause_interaction_test.go
+++ b/tests/schedule_workflow_pause_interaction_test.go
@@ -140,7 +140,7 @@ func setupPausedScheduledWorkflow(
 	policy enumspb.ScheduleOverlapPolicy,
 	register func(s *testcore.TestEnv, wt string),
 ) *scheduledPauseFixture {
-	s := testcore.NewEnv(t, pauseInteractionOpts(t)...)
+	s := newScheduleEnv(t, pauseInteractionOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-pause-" + policy.String())
 	wid := testcore.RandomizeStr("sched-pause-wf-" + policy.String())
@@ -330,7 +330,7 @@ func setupPausedTriggeredWorkflow(
 	register func(s *testcore.TestEnv, wt string),
 	afterStart func(s *testcore.TestEnv, firstRun *commonpb.WorkflowExecution),
 ) *scheduledPauseFixture {
-	s := testcore.NewEnv(t, opts...)
+	s := newScheduleEnv(t, opts...)
 
 	sid := testcore.RandomizeStr(idPrefix)
 	wid := testcore.RandomizeStr(idPrefix + "-wf")


### PR DESCRIPTION
## Summary

- add a schedule test environment wrapper that lists and deletes schedules at test cleanup
- force-delete paired V1 and CHASM schedule executions through the admin API, including CHASM sentinels
- cover the main schedule suite, migration suite, pause-interaction tests, and scheduled callback migration test