### PR TITLE
Document Versioning3 test flows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ Before starting the implementation of any request, you MUST REVIEW the following
 ## Testing:
 - Write tests for new functionality
 - Run tests after altering code or tests
+- Tests added to `tests/versioning_3_test.go` must include a concise numbered `Flow:` comment that accurately describes the setup, action, and assertions
 - Start with unit tests for fastest feedback
 - Prefer `require` over `assert`, avoid testify suites in unit tests (functional tests require suites for test cluster setup), use `require.Eventually` instead of `time.Sleep` (forbidden by linter)
 - For float comparisons in tests, use `InDelta` or `InEpsilon` instead of `Equal` (enforced by `testifylint`)

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -2014,18 +2014,33 @@ func (s *Versioning3Suite) testChildWorkflowInheritanceExpectInherit(crossTq boo
 
 // TestChildWorkflowExplicitPinnedOverrideTakesPrecedence verifies that a pinned
 // child override wins over inherited pinned routing on the same task queue.
+// Flow:
+// 1. Register parent v1 as current and child v2 as inactive.
+// 2. Start the parent and establish it as pinned on v1.
+// 3. Parent starts a child with an explicit pinned override to v2.
+// 4. Assert the child starts on v2 and records only the explicit override.
 func (s *Versioning3Suite) TestChildWorkflowExplicitPinnedOverrideTakesPrecedence() {
 	s.testChildWorkflowExplicitPinnedOverrideTakesPrecedence(false, vbPinned)
 }
 
 // TestChildWorkflowExplicitPinnedOverrideTakesPrecedenceCrossTaskQueue verifies
 // that an explicit target is validated against and routed on the child's task queue.
+// Flow:
+// 1. Register v1 as current on both task queues and child v2 as inactive on the child task queue.
+// 2. Verify child v2 belongs only to the child task queue, then start the parent pinned on v1.
+// 3. Parent starts a child with an explicit pinned override to child v2.
+// 4. Assert the child starts on v2 and records only the explicit override.
 func (s *Versioning3Suite) TestChildWorkflowExplicitPinnedOverrideTakesPrecedenceCrossTaskQueue() {
 	s.testChildWorkflowExplicitPinnedOverrideTakesPrecedence(true, vbPinned)
 }
 
 // TestChildWorkflowExplicitPinnedOverrideTakesPrecedenceOverAutoUpgradeParent
 // verifies that explicit child routing does not retain AutoUpgrade inheritance.
+// Flow:
+// 1. Register parent v1 as current and child v2 as inactive on the same task queue.
+// 2. Start the parent and establish AutoUpgrade behavior on v1.
+// 3. Parent starts a child with an explicit pinned override to v2.
+// 4. Assert the child starts on v2 and records no inherited AutoUpgrade metadata.
 func (s *Versioning3Suite) TestChildWorkflowExplicitPinnedOverrideTakesPrecedenceOverAutoUpgradeParent() {
 	s.testChildWorkflowExplicitPinnedOverrideTakesPrecedence(false, vbUnpinned)
 }


### PR DESCRIPTION
## What changed

- Add numbered `Flow:` comments to the three explicit pinned child override tests.
- Record the `tests/versioning_3_test.go` flow-comment convention in `AGENTS.md`.

## Why

These functional tests share setup through a helper, so documenting each scenario's setup, action, and assertions makes the individual test cases easier to review and maintain.

## Validation

- `git diff --check`
- Adversarial review accepted with no findings
- Tests not run because the change only adds comments and repository guidance

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only and contributor-guidance changes; no runtime or test logic modified.
> 
> **Overview**
> Documents how reviewers should read shared-helper Versioning3 functional tests and codifies that convention for future changes.
> 
> **`AGENTS.md`** now requires new or updated tests in `tests/versioning_3_test.go` to include a concise numbered **`Flow:`** comment covering setup, action, and assertions.
> 
> Three explicit pinned child-override scenarios gain **`Flow:`** blocks: same task queue (pinned parent), cross task queue, and explicit override over an AutoUpgrade parent—each spelling out version registration, parent start behavior, child override, and expected routing/metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbfb31fceced5820db5f8a3ada48535068308250. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->