### PR TITLE
Allow sticky queues to make poller scaling decisions

### DIFF
--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -907,7 +907,8 @@ func (c *physicalTaskQueueManagerImpl) makePollerScalingDecisionImpl(
 		delta = 1
 	} else if c.queue.Partition().Kind() != enumspb.TASK_QUEUE_KIND_STICKY && !c.queue.Partition().IsRoot() {
 		// Non-root partitions don't have an appropriate view of the data to make decisions beyond backlog.
-		// Sticky queues are exempt: they aren't considered root but do have a complete view of their data.
+		// Sticky queues are exempt: they aren't considered root but do have a complete view of their data,
+		// as they have only 1 partition.
 		return nil
 	} else {
 		if (stats.GetTasksAddRate() / stats.GetTasksDispatchRate()) > 1.2 {

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -905,8 +905,9 @@ func (c *physicalTaskQueueManagerImpl) makePollerScalingDecisionImpl(
 		// Always increase when there is a backlog, even if we're a partition. It's also important to increase for
 		// sticky queues.
 		delta = 1
-	} else if !c.queue.Partition().IsRoot() {
+	} else if c.queue.Partition().Kind() != enumspb.TASK_QUEUE_KIND_STICKY && !c.queue.Partition().IsRoot() {
 		// Non-root partitions don't have an appropriate view of the data to make decisions beyond backlog.
+		// Sticky queues are exempt: they aren't considered root but do have a complete view of their data.
 		return nil
 	} else {
 		if (stats.GetTasksAddRate() / stats.GetTasksDispatchRate()) > 1.2 {

--- a/service/matching/physical_task_queue_manager_test.go
+++ b/service/matching/physical_task_queue_manager_test.go
@@ -480,6 +480,30 @@ func (s *PhysicalTaskQueueManagerTestSuite) TestPollScalingNonRootPartition() {
 	s.Nil(decision)
 }
 
+func (s *PhysicalTaskQueueManagerTestSuite) TestPollScalingStickyQueue() {
+	// Sticky queues aren't considered root, but unlike non-root normal partitions they have a
+	// complete view of their data, so they should still emit scaling decisions beyond backlog.
+	f, err := tqid.NewTaskQueueFamily(namespaceID, taskQueueName)
+	s.Require().NoError(err)
+	stickyPartition := f.TaskQueue(enumspb.TASK_QUEUE_TYPE_WORKFLOW).StickyPartition("sticky-name")
+	s.False(stickyPartition.IsRoot())
+	s.tqMgr.queue = UnversionedQueueKey(stickyPartition)
+	// Disable rate limit to ensure that's not why a decision is returned here.
+	rl := quotas.NewMockRateLimiter(s.controller)
+	rl.EXPECT().AllowN(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+	s.tqMgr.pollerScalingRateLimiter = rl
+
+	// No backlog, but add rate exceeds dispatch rate: a non-root normal partition would return nil
+	// here, but a sticky queue should still suggest a scale-up.
+	fakeStats := &taskqueuepb.TaskQueueStats{
+		TasksAddRate:      100,
+		TasksDispatchRate: 10,
+	}
+	decision := s.tqMgr.makePollerScalingDecisionImpl(time.Now(), func() *taskqueuepb.TaskQueueStats { return fakeStats })
+	s.NotNil(decision)
+	s.GreaterOrEqual(decision.PollRequestDeltaSuggestion, int32(1))
+}
+
 func (s *PhysicalTaskQueueManagerTestSuite) TestPollScalingDownOnLongSyncMatch() {
 	fakeStats := &taskqueuepb.TaskQueueStats{
 		ApproximateBacklogCount: 0,


### PR DESCRIPTION
## What changed

In `makePollerScalingDecisionImpl`, sticky queues were hitting the non-root partition early-return and could therefore only emit scaling decisions when there was a backlog. Sticky queues report `IsRoot() == false` (per the `Partition` interface contract), so they fell into the same branch as non-root normal partitions.

Unlike non-root normal partitions, sticky queues *do* have a complete view of their data, so they should be allowed to make scaling decisions based on add/dispatch rate as well.

This PR excludes sticky queues from that early-return. The sticky check is placed first so it short-circuits before `IsRoot()`.

## Testing

- Added `TestPollScalingStickyQueue`, which verifies a sticky queue (non-root) still emits a scale-up decision when add-rate exceeds dispatch-rate with no backlog — a case where a non-root normal partition returns nil.
- Existing poller-scaling tests still pass across the Classic, Pri, and Fair suites.
- `go vet` and `golangci-lint` are clean on the change.