### PR TITLE
Fix standalone activity heartbeat flag precedence

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1500,11 +1500,16 @@ func (a *Activity) RecordHeartbeat(
 			},
 		)
 	}
-	return &historyservice.RecordActivityTaskHeartbeatResponse{
-		CancelRequested: a.Status == activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
-		ActivityPaused:  a.Status == activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED || (a.Status == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED && a.ResetKeepPaused),
-		ActivityReset:   a.Status == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
-	}, nil
+	response := &historyservice.RecordActivityTaskHeartbeatResponse{}
+	switch a.Status {
+	case activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED:
+		response.CancelRequested = true
+	case activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED:
+		response.ActivityReset = true
+	case activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED:
+		response.ActivityPaused = true
+	}
+	return response, nil
 }
 
 // InternalStatusToAPIStatus converts internal activity execution status to API status.

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1508,6 +1508,8 @@ func (a *Activity) RecordHeartbeat(
 		response.ActivityReset = true
 	case activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED:
 		response.ActivityPaused = true
+	default:
+		// no-op
 	}
 	return response, nil
 }

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -299,12 +299,9 @@ func TestRecordHeartbeatPauseResetCancelFlags(t *testing.T) {
 			wantPaused: true,
 		},
 		{
-			// A reset issued with keepPaused on a paused activity sets ResetKeepPaused; the worker
-			// must be told it is both paused and being reset.
-			name:            "reset with keep-paused propagates both paused and reset",
+			name:            "reset with keep-paused propagates only reset",
 			status:          activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
 			resetKeepPaused: true,
-			wantPaused:      true,
 			wantReset:       true,
 		},
 		{


### PR DESCRIPTION
## What changed?
Updated standalone activity heartbeat responses to return only the highest-precedence requested action: cancel, reset, then pause.

## Why?
A reset with keep-paused previously returned both reset and pause flags. Workers must receive only one action per heartbeat response.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
None, into a feature branch.