### PR TITLE
[Scheduler] Ensure Describe sets all defaults only on cloned proto, not on cached CHASM node

### DIFF
--- a/chasm/lib/scheduler/generator.go
+++ b/chasm/lib/scheduler/generator.go
@@ -62,14 +62,28 @@ func (g *Generator) LifecycleState(ctx chasm.Context) chasm.LifecycleState {
 }
 
 // UpdateFutureActionTimes computes and stores the next scheduled action times.
+// On spec-compile error the previously stored times are left untouched.
 func (g *Generator) UpdateFutureActionTimes(
 	ctx chasm.Context,
 	specBuilder *scheduler.SpecBuilder,
 ) {
+	futureTimes, err := g.computeFutureActionTimes(ctx, specBuilder)
+	if err != nil {
+		return
+	}
+	g.FutureActionTimes = futureTimes
+}
+
+// computeFutureActionTimes returns the next scheduled action times without mutating
+// component state, so it's safe to call from a read-only context.
+func (g *Generator) computeFutureActionTimes(
+	ctx chasm.Context,
+	specBuilder *scheduler.SpecBuilder,
+) ([]*timestamppb.Timestamp, error) {
 	sched := g.Scheduler.Get(ctx)
 	spec, err := sched.getCompiledSpec(specBuilder)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	count := recentActionCount
@@ -93,5 +107,5 @@ func (g *Generator) UpdateFutureActionTimes(
 		futureTimes = append(futureTimes, timestamppb.New(t))
 	}
 
-	g.FutureActionTimes = futureTimes
+	return futureTimes, nil
 }

--- a/chasm/lib/scheduler/generator.go
+++ b/chasm/lib/scheduler/generator.go
@@ -6,6 +6,7 @@ import (
 
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/service/worker/scheduler"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -64,11 +65,14 @@ func (g *Generator) LifecycleState(ctx chasm.Context) chasm.LifecycleState {
 // UpdateFutureActionTimes computes and stores the next scheduled action times.
 // On spec-compile error the previously stored times are left untouched.
 func (g *Generator) UpdateFutureActionTimes(
-	ctx chasm.Context,
+	ctx chasm.MutableContext,
 	specBuilder *scheduler.SpecBuilder,
 ) {
 	futureTimes, err := g.computeFutureActionTimes(ctx, specBuilder)
 	if err != nil {
+		g.getOrCreateEventLog(ctx).LogEvent(ctx,
+			fmt.Sprintf("failed to update future action times: %v", err.Error()))
+		ctx.Logger().Warn("failed to update future action times", tag.Error(err))
 		return
 	}
 	g.FutureActionTimes = futureTimes

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -657,27 +657,30 @@ func (s *Scheduler) Describe(
 	}
 
 	visibility := s.Visibility.Get(ctx)
-	// CustomMemo/CustomSearchAttributes return the component's live maps by reference.
+	// CustomMemo returns a shallow copy, so deleting a key here is safe.
 	memo := visibility.CustomMemo(ctx)
-	delete(memo, visibilityMemoFieldInfo) // We don't need to return a redundant info block.
+	delete(memo, visibilityMemoFieldInfo) // ScheduleInfo is returned separately via Info below.
 
-	if s.Schedule.GetPolicies().GetOverlapPolicy() == enumspb.SCHEDULE_OVERLAP_POLICY_UNSPECIFIED {
-		s.Schedule.Policies.OverlapPolicy = s.overlapPolicy()
-	}
-	if !s.Schedule.GetPolicies().GetCatchupWindow().IsValid() {
-		// TODO - this should be set from Tweakables.DefaultCatchupWindow.
-		s.Schedule.Policies.CatchupWindow = durationpb.New(365 * 24 * time.Hour)
-	}
-
+	// Describe must not mutate the cached component: default on a clone, not s.Schedule.
 	schedule := common.CloneProto(s.Schedule)
+	if schedule.GetPolicies().GetOverlapPolicy() == enumspb.SCHEDULE_OVERLAP_POLICY_UNSPECIFIED {
+		schedule.Policies.OverlapPolicy = s.overlapPolicy()
+	}
+	if !schedule.GetPolicies().GetCatchupWindow().IsValid() {
+		// TODO - this should be set from Tweakables.DefaultCatchupWindow.
+		schedule.Policies.CatchupWindow = durationpb.New(365 * 24 * time.Hour)
+	}
 	cleanSpec(schedule.Spec)
 
 	generator := s.Generator.Get(ctx)
-	if generator.GetFutureActionTimes() == nil {
-		// FutureActionTimes is populated asynchronously by the GeneratorTask. If a
-		// newly-created schedule is described before the task executes, this field may be
-		// nil. In that case, compute it on-demand.
-		generator.UpdateFutureActionTimes(ctx, specBuilder)
+	futureActionTimes := generator.GetFutureActionTimes()
+	if futureActionTimes == nil {
+		// Populated asynchronously by the GeneratorTask; may be nil before it first runs.
+		// Compute here without storing back, since Describe must stay read-only.
+		var err error
+		if futureActionTimes, err = generator.computeFutureActionTimes(ctx, specBuilder); err != nil {
+			ctx.Logger().Warn("failed to compute future action times for DescribeSchedule", tag.Error(err))
+		}
 	}
 
 	// Populate computed views from Invoker's BufferedStarts.
@@ -685,7 +688,7 @@ func (s *Scheduler) Describe(
 	info := common.CloneProto(s.Info)
 	info.RunningWorkflows = invoker.runningWorkflowExecutions()
 	info.RecentActions = invoker.recentActions()
-	info.FutureActionTimes = generator.GetFutureActionTimes()
+	info.FutureActionTimes = futureActionTimes
 	// BufferedStarts holds waiting, running, and recently-completed entries; only the
 	// waiting portion (those not yet surfaced via RecentActions) counts as buffered.
 	info.BufferSize = int64(len(invoker.GetBufferedStarts()) - len(info.RecentActions))

--- a/chasm/lib/scheduler/scheduler_test.go
+++ b/chasm/lib/scheduler/scheduler_test.go
@@ -689,3 +689,39 @@ func TestScheduler_Describe_ReturnsIsolatedVisibilityMaps(t *testing.T) {
 	require.NotContains(t, vis.CustomSearchAttributes(ctx), "injectedSA",
 		"DescribeSchedule response SearchAttributes must be a copy, not the live Visibility map")
 }
+
+// TestScheduler_Describe_DoesNotMutateCachedComponent proves Describe defaults and
+// computes for the response only.
+func TestScheduler_Describe_DoesNotMutateCachedComponent(t *testing.T) {
+	sched, ctx, _ := setupSchedulerForTest(t)
+	specBuilder := newLegacySpecBuilder(0, 0)
+
+	// Set state on the cached CHASM component directly.
+	sched.Schedule.Policies.OverlapPolicy = enumspb.SCHEDULE_OVERLAP_POLICY_UNSPECIFIED
+	sched.Schedule.Policies.CatchupWindow = nil
+	generator := sched.Generator.Get(ctx)
+	generator.FutureActionTimes = nil
+
+	// Call Describe, which shouldn't mutate any cached fields.
+	resp, err := sched.Describe(ctx, &schedulerpb.DescribeScheduleRequest{
+		NamespaceId: namespaceID,
+		FrontendRequest: &workflowservice.DescribeScheduleRequest{
+			Namespace:  namespace,
+			ScheduleId: scheduleID,
+		},
+	}, specBuilder)
+	require.NoError(t, err)
+
+	fr := resp.GetFrontendResponse()
+	require.Equal(t, enumspb.SCHEDULE_OVERLAP_POLICY_SKIP, fr.GetSchedule().GetPolicies().GetOverlapPolicy())
+	require.Equal(t, 365*24*time.Hour, fr.GetSchedule().GetPolicies().GetCatchupWindow().AsDuration())
+	require.NotEmpty(t, fr.GetInfo().GetFutureActionTimes(), "Describe should compute future action times on-demand")
+
+	// Assert cached component state wasn't touched.
+	require.Equal(t, enumspb.SCHEDULE_OVERLAP_POLICY_UNSPECIFIED, sched.Schedule.GetPolicies().GetOverlapPolicy(),
+		"Describe must not write the default overlap policy back onto the cached component")
+	require.Nil(t, sched.Schedule.GetPolicies().GetCatchupWindow(),
+		"Describe must not write the default catch-up window back onto the cached component")
+	require.Nil(t, generator.GetFutureActionTimes(),
+		"Describe must not store computed FutureActionTimes back onto the Generator")
+}


### PR DESCRIPTION
## What changed?
- CHASM Scheduler's `DescribeSchedule` now clones before setting any default values, as these could leak back into the cached CHASM node.
- The actual impact would be net-zero, given that upon evaluation elsewhere through the scheduler code, those some nils would use the (errantly cached) defaults anyways.

## Why?
- Cleanliness.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
