### PR TITLE
Use suite contexts in functional tests

### DIFF
--- a/tests/activity_api_batch_reset_test.go
+++ b/tests/activity_api_batch_reset_test.go
@@ -47,7 +47,7 @@ func (s *ActivityAPIBatchResetClientTestSuite) createBatchResetWorkflow(env *tes
 		ID:        testcore.RandomizeStr("wf_id"),
 		TaskQueue: env.WorkerTaskQueue(),
 	}
-	workflowRun, err := env.SdkClient().ExecuteWorkflow(env.Context(), workflowOptions, workflowFn)
+	workflowRun, err := env.SdkClient().ExecuteWorkflow(s.Context(), workflowOptions, workflowFn)
 	s.NoError(err)
 	s.NotNil(workflowRun)
 
@@ -67,12 +67,12 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_Success() 
 
 	// wait for activity to start in both workflows
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		description, err := env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
+		description, err := env.SdkClient().DescribeWorkflowExecution(s.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.GetPendingActivities(), 1)
 		require.Positive(t, internalWorkflow.startedActivityCount.Load())
 
-		description, err = env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun2.GetID(), workflowRun2.GetRunID())
+		description, err = env.SdkClient().DescribeWorkflowExecution(s.Context(), workflowRun2.GetID(), workflowRun2.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.GetPendingActivities(), 1)
 		require.Positive(t, internalWorkflow.startedActivityCount.Load())
@@ -86,18 +86,18 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_Success() 
 	}
 
 	pauseRequest.Execution.WorkflowId = workflowRun1.GetID()
-	resp, err := env.FrontendClient().PauseActivity(env.Context(), pauseRequest)
+	resp, err := env.FrontendClient().PauseActivity(s.Context(), pauseRequest)
 	s.NoError(err)
 	s.NotNil(resp)
 
 	pauseRequest.Execution.WorkflowId = workflowRun2.GetID()
-	resp, err = env.FrontendClient().PauseActivity(env.Context(), pauseRequest)
+	resp, err = env.FrontendClient().PauseActivity(s.Context(), pauseRequest)
 	s.NoError(err)
 	s.NotNil(resp)
 
 	// wait for activities to be paused
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		description, err := env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
+		description, err := env.SdkClient().DescribeWorkflowExecution(s.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.GetPendingActivities(), 1)
 		require.True(t, description.PendingActivities[0].Paused)
@@ -114,7 +114,7 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_Success() 
 	query := fmt.Sprintf("(WorkflowType='%s' AND %s)", workflowTypeName, resetCause)
 
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		listResp, err = env.FrontendClient().ListWorkflowExecutions(env.Context(), &workflowservice.ListWorkflowExecutionsRequest{
+		listResp, err = env.FrontendClient().ListWorkflowExecutions(s.Context(), &workflowservice.ListWorkflowExecutionsRequest{
 			Namespace: env.Namespace().String(),
 			PageSize:  10,
 			Query:     query,
@@ -126,7 +126,7 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_Success() 
 	}, 5*time.Second, 500*time.Millisecond)
 
 	// reset the activities in both workflows with batch reset
-	_, err = env.SdkClient().WorkflowService().StartBatchOperation(env.Context(), &workflowservice.StartBatchOperationRequest{
+	_, err = env.SdkClient().WorkflowService().StartBatchOperation(s.Context(), &workflowservice.StartBatchOperationRequest{
 		Namespace: env.Namespace().String(),
 		Operation: &workflowservice.StartBatchOperationRequest_ResetActivitiesOperation{
 			ResetActivitiesOperation: &batchpb.BatchOperationResetActivities{
@@ -142,13 +142,13 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_Success() 
 
 	// make sure activities are restarted and still paused
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		description, err := env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
+		description, err := env.SdkClient().DescribeWorkflowExecution(s.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.PendingActivities, 1)
 		require.True(t, description.PendingActivities[0].Paused)
 		require.Equal(t, int32(1), description.PendingActivities[0].Attempt)
 
-		description, err = env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun2.GetID(), workflowRun2.GetRunID())
+		description, err = env.SdkClient().DescribeWorkflowExecution(s.Context(), workflowRun2.GetID(), workflowRun2.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.PendingActivities, 1)
 		require.True(t, description.PendingActivities[0].Paused)
@@ -159,7 +159,7 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_Success() 
 	internalWorkflow.letActivitySucceed.Store(true)
 
 	// reset the activities in both workflows with batch reset
-	_, err = env.SdkClient().WorkflowService().StartBatchOperation(env.Context(), &workflowservice.StartBatchOperationRequest{
+	_, err = env.SdkClient().WorkflowService().StartBatchOperation(s.Context(), &workflowservice.StartBatchOperationRequest{
 		Namespace: env.Namespace().String(),
 		Operation: &workflowservice.StartBatchOperationRequest_ResetActivitiesOperation{
 			ResetActivitiesOperation: &batchpb.BatchOperationResetActivities{
@@ -174,10 +174,10 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_Success() 
 	s.NoError(err)
 
 	var out string
-	err = workflowRun1.Get(env.Context(), &out)
+	err = workflowRun1.Get(s.Context(), &out)
 	s.NoError(err)
 
-	err = workflowRun2.Get(env.Context(), &out)
+	err = workflowRun2.Get(s.Context(), &out)
 	s.NoError(err)
 }
 
@@ -194,12 +194,12 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_Success_Pr
 
 	// wait for activity to start in both workflows
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		description, err := env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
+		description, err := env.SdkClient().DescribeWorkflowExecution(s.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.GetPendingActivities(), 1)
 		require.Positive(t, internalWorkflow.startedActivityCount.Load())
 
-		description, err = env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun2.GetID(), workflowRun2.GetRunID())
+		description, err = env.SdkClient().DescribeWorkflowExecution(s.Context(), workflowRun2.GetID(), workflowRun2.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.GetPendingActivities(), 1)
 		require.Positive(t, internalWorkflow.startedActivityCount.Load())
@@ -213,18 +213,18 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_Success_Pr
 	}
 
 	pauseRequest.Execution.WorkflowId = workflowRun1.GetID()
-	resp, err := env.FrontendClient().PauseActivity(env.Context(), pauseRequest)
+	resp, err := env.FrontendClient().PauseActivity(s.Context(), pauseRequest)
 	s.NoError(err)
 	s.NotNil(resp)
 
 	pauseRequest.Execution.WorkflowId = workflowRun2.GetID()
-	resp, err = env.FrontendClient().PauseActivity(env.Context(), pauseRequest)
+	resp, err = env.FrontendClient().PauseActivity(s.Context(), pauseRequest)
 	s.NoError(err)
 	s.NotNil(resp)
 
 	// wait for activities to be paused
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		description, err := env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
+		description, err := env.SdkClient().DescribeWorkflowExecution(s.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.GetPendingActivities(), 1)
 		require.True(t, description.PendingActivities[0].Paused)
@@ -241,7 +241,7 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_Success_Pr
 	query := fmt.Sprintf("(WorkflowType='%s' AND %s)", workflowTypeName, resetCause)
 
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		listResp, err = env.FrontendClient().ListWorkflowExecutions(env.Context(), &workflowservice.ListWorkflowExecutionsRequest{
+		listResp, err = env.FrontendClient().ListWorkflowExecutions(s.Context(), &workflowservice.ListWorkflowExecutionsRequest{
 			Namespace: env.Namespace().String(),
 			PageSize:  10,
 			Query:     query,
@@ -253,7 +253,7 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_Success_Pr
 	}, 5*time.Second, 500*time.Millisecond)
 
 	// reset the activities in both workflows with batch reset
-	_, err = env.SdkClient().WorkflowService().StartBatchOperation(env.Context(), &workflowservice.StartBatchOperationRequest{
+	_, err = env.SdkClient().WorkflowService().StartBatchOperation(s.Context(), &workflowservice.StartBatchOperationRequest{
 		Namespace: env.Namespace().String(),
 		Operation: &workflowservice.StartBatchOperationRequest_ResetActivitiesOperation{
 			ResetActivitiesOperation: &batchpb.BatchOperationResetActivities{
@@ -269,13 +269,13 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_Success_Pr
 
 	// make sure activities are restarted and still paused
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		description, err := env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
+		description, err := env.SdkClient().DescribeWorkflowExecution(s.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.PendingActivities, 1)
 		require.True(t, description.PendingActivities[0].Paused)
 		require.Equal(t, int32(1), description.PendingActivities[0].Attempt)
 
-		description, err = env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun2.GetID(), workflowRun2.GetRunID())
+		description, err = env.SdkClient().DescribeWorkflowExecution(s.Context(), workflowRun2.GetID(), workflowRun2.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.PendingActivities, 1)
 		require.True(t, description.PendingActivities[0].Paused)
@@ -286,7 +286,7 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_Success_Pr
 	internalWorkflow.letActivitySucceed.Store(true)
 
 	// reset the activities in both workflows with batch reset
-	_, err = env.SdkClient().WorkflowService().StartBatchOperation(env.Context(), &workflowservice.StartBatchOperationRequest{
+	_, err = env.SdkClient().WorkflowService().StartBatchOperation(s.Context(), &workflowservice.StartBatchOperationRequest{
 		Namespace: env.Namespace().String(),
 		Operation: &workflowservice.StartBatchOperationRequest_ResetActivitiesOperation{
 			ResetActivitiesOperation: &batchpb.BatchOperationResetActivities{
@@ -301,16 +301,16 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_Success_Pr
 	s.NoError(err)
 
 	var out string
-	err = workflowRun1.Get(env.Context(), &out)
+	err = workflowRun1.Get(s.Context(), &out)
 	s.NoError(err)
 
-	err = workflowRun2.Get(env.Context(), &out)
+	err = workflowRun2.Get(s.Context(), &out)
 	s.NoError(err)
 }
 
 func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_RunningWorkflowsResetAttempts() {
 	env := newBatchResetEnv(s.T())
-	ctx := env.Context()
+	ctx := s.Context()
 
 	const workflowCount = 10
 	workflowTypeName := testcore.RandomizeStr("activity-batch-reset-running-workflow")
@@ -415,12 +415,12 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_DontResetA
 
 	// wait for activity to start in both workflows
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		description, err := env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
+		description, err := env.SdkClient().DescribeWorkflowExecution(s.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.GetPendingActivities(), 1)
 		require.Positive(t, internalWorkflow.startedActivityCount.Load())
 
-		description, err = env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun2.GetID(), workflowRun2.GetRunID())
+		description, err = env.SdkClient().DescribeWorkflowExecution(s.Context(), workflowRun2.GetID(), workflowRun2.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.GetPendingActivities(), 1)
 		require.Positive(t, internalWorkflow.startedActivityCount.Load())
@@ -434,18 +434,18 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_DontResetA
 	}
 
 	pauseRequest.Execution.WorkflowId = workflowRun1.GetID()
-	resp, err := env.FrontendClient().PauseActivity(env.Context(), pauseRequest)
+	resp, err := env.FrontendClient().PauseActivity(s.Context(), pauseRequest)
 	s.NoError(err)
 	s.NotNil(resp)
 
 	pauseRequest.Execution.WorkflowId = workflowRun2.GetID()
-	resp, err = env.FrontendClient().PauseActivity(env.Context(), pauseRequest)
+	resp, err = env.FrontendClient().PauseActivity(s.Context(), pauseRequest)
 	s.NoError(err)
 	s.NotNil(resp)
 
 	// wait for activities to be paused
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		description, err := env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
+		description, err := env.SdkClient().DescribeWorkflowExecution(s.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.GetPendingActivities(), 1)
 		require.True(t, description.PendingActivities[0].Paused)
@@ -462,7 +462,7 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_DontResetA
 	query := fmt.Sprintf("(WorkflowType='%s' AND %s)", workflowTypeName, resetCause)
 
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		listResp, err = env.FrontendClient().ListWorkflowExecutions(env.Context(), &workflowservice.ListWorkflowExecutionsRequest{
+		listResp, err = env.FrontendClient().ListWorkflowExecutions(s.Context(), &workflowservice.ListWorkflowExecutionsRequest{
 			Namespace: env.Namespace().String(),
 			PageSize:  10,
 			Query:     query,
@@ -474,7 +474,7 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_DontResetA
 	}, 5*time.Second, 500*time.Millisecond)
 
 	// reset the activities in both workflows with batch reset
-	_, err = env.SdkClient().WorkflowService().StartBatchOperation(env.Context(), &workflowservice.StartBatchOperationRequest{
+	_, err = env.SdkClient().WorkflowService().StartBatchOperation(s.Context(), &workflowservice.StartBatchOperationRequest{
 		Namespace: env.Namespace().String(),
 		Operation: &workflowservice.StartBatchOperationRequest_ResetActivitiesOperation{
 			ResetActivitiesOperation: &batchpb.BatchOperationResetActivities{
@@ -491,12 +491,12 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_DontResetA
 
 	// make sure activities are restarted and still paused
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		description, err := env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
+		description, err := env.SdkClient().DescribeWorkflowExecution(s.Context(), workflowRun1.GetID(), workflowRun1.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.PendingActivities, 1)
 		require.NotEqual(t, int32(1), description.PendingActivities[0].Attempt)
 
-		description, err = env.SdkClient().DescribeWorkflowExecution(env.Context(), workflowRun2.GetID(), workflowRun2.GetRunID())
+		description, err = env.SdkClient().DescribeWorkflowExecution(s.Context(), workflowRun2.GetID(), workflowRun2.GetRunID())
 		require.NoError(t, err)
 		require.Len(t, description.PendingActivities, 1)
 		require.NotEqual(t, int32(1), description.PendingActivities[0].Attempt)
@@ -506,7 +506,7 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_DontResetA
 	internalWorkflow.letActivitySucceed.Store(true)
 
 	// reset the activities in both workflows with batch reset
-	_, err = env.SdkClient().WorkflowService().StartBatchOperation(env.Context(), &workflowservice.StartBatchOperationRequest{
+	_, err = env.SdkClient().WorkflowService().StartBatchOperation(s.Context(), &workflowservice.StartBatchOperationRequest{
 		Namespace: env.Namespace().String(),
 		Operation: &workflowservice.StartBatchOperationRequest_ResetActivitiesOperation{
 			ResetActivitiesOperation: &batchpb.BatchOperationResetActivities{
@@ -521,10 +521,10 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_DontResetA
 	s.NoError(err)
 
 	var out string
-	err = workflowRun1.Get(env.Context(), &out)
+	err = workflowRun1.Get(s.Context(), &out)
 	s.NoError(err)
 
-	err = workflowRun2.Get(env.Context(), &out)
+	err = workflowRun2.Get(s.Context(), &out)
 	s.NoError(err)
 }
 
@@ -532,7 +532,7 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_Failed() {
 	env := newBatchResetEnv(s.T())
 
 	// neither activity type not "match all" is provided
-	_, err := env.SdkClient().WorkflowService().StartBatchOperation(env.Context(), &workflowservice.StartBatchOperationRequest{
+	_, err := env.SdkClient().WorkflowService().StartBatchOperation(s.Context(), &workflowservice.StartBatchOperationRequest{
 		Namespace: env.Namespace().String(),
 		Operation: &workflowservice.StartBatchOperationRequest_ResetActivitiesOperation{
 			ResetActivitiesOperation: &batchpb.BatchOperationResetActivities{},
@@ -546,7 +546,7 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_Failed() {
 	s.ErrorAs(err, new(*serviceerror.InvalidArgument))
 
 	// neither activity type not "match all" is provided
-	_, err = env.SdkClient().WorkflowService().StartBatchOperation(env.Context(), &workflowservice.StartBatchOperationRequest{
+	_, err = env.SdkClient().WorkflowService().StartBatchOperation(s.Context(), &workflowservice.StartBatchOperationRequest{
 		Namespace: env.Namespace().String(),
 		Operation: &workflowservice.StartBatchOperationRequest_ResetActivitiesOperation{
 			ResetActivitiesOperation: &batchpb.BatchOperationResetActivities{
@@ -562,7 +562,7 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_Failed() {
 	s.ErrorAs(err, new(*serviceerror.InvalidArgument))
 
 	// malformed visibility query should be rejected before the batch workflow starts
-	_, err = env.SdkClient().WorkflowService().StartBatchOperation(env.Context(), &workflowservice.StartBatchOperationRequest{
+	_, err = env.SdkClient().WorkflowService().StartBatchOperation(s.Context(), &workflowservice.StartBatchOperationRequest{
 		Namespace: env.Namespace().String(),
 		Operation: &workflowservice.StartBatchOperationRequest_DeletionOperation{
 			DeletionOperation: &batchpb.BatchOperationDeletion{},

--- a/tests/activity_api_batch_unpause_test.go
+++ b/tests/activity_api_batch_unpause_test.go
@@ -85,7 +85,7 @@ func (s *ActivityApiBatchUnpauseClientTestSuite) createWorkflow(env *testcore.Te
 		ID:        testcore.RandomizeStr("wf_id-" + s.T().Name()),
 		TaskQueue: env.WorkerTaskQueue(),
 	}
-	workflowRun, err := env.SdkClient().ExecuteWorkflow(env.Context(), workflowOptions, workflowFn)
+	workflowRun, err := env.SdkClient().ExecuteWorkflow(s.Context(), workflowOptions, workflowFn)
 	s.NoError(err)
 	s.NotNil(workflowRun)
 
@@ -201,7 +201,7 @@ func (s *ActivityApiBatchUnpauseClientTestSuite) TestActivityBatchUnpause_Succes
 
 func (s *ActivityApiBatchUnpauseClientTestSuite) TestActivityBatchUnpause_MatchAll() {
 	env := testcore.NewEnv(s.T(), testcore.WithWorkerService("batch operations"))
-	ctx := env.Context()
+	ctx := s.Context()
 
 	const workflowCount = 10
 	workflowTypeName := testcore.RandomizeStr("activity-batch-unpause-match-all-workflow")

--- a/tests/activity_api_batch_update_options_test.go
+++ b/tests/activity_api_batch_update_options_test.go
@@ -39,7 +39,7 @@ func (s *ActivityAPIBatchUpdateOptionsSuite) createBatchUpdateOptionsWorkflow(en
 		ID:        testcore.RandomizeStr("wf_id-" + s.T().Name()),
 		TaskQueue: env.WorkerTaskQueue(),
 	}
-	workflowRun, err := env.SdkClient().ExecuteWorkflow(env.Context(), workflowOptions, workflowFn)
+	workflowRun, err := env.SdkClient().ExecuteWorkflow(s.Context(), workflowOptions, workflowFn)
 	s.NoError(err)
 	s.NotNil(workflowRun)
 
@@ -52,7 +52,7 @@ func (s *ActivityAPIBatchUpdateOptionsSuite) TestActivityBatchUpdateOptionsSucce
 		testcore.WithDynamicConfig(dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace, testcore.ClientSuiteLimit),
 	)
 
-	ctx := env.Context()
+	ctx := s.Context()
 
 	internalWorkflow := newInternalWorkflow()
 
@@ -120,7 +120,7 @@ func (s *ActivityAPIBatchUpdateOptionsSuite) TestActivityBatchUpdateOptionsSucce
 	}, 5*time.Second, 500*time.Millisecond)
 
 	// unpause the activities in both workflows with batch unpause
-	_, err = env.SdkClient().WorkflowService().StartBatchOperation(env.Context(), &workflowservice.StartBatchOperationRequest{
+	_, err = env.SdkClient().WorkflowService().StartBatchOperation(s.Context(), &workflowservice.StartBatchOperationRequest{
 		Namespace: env.Namespace().String(),
 		Operation: &workflowservice.StartBatchOperationRequest_UpdateActivityOptionsOperation{
 			UpdateActivityOptionsOperation: &batchpb.BatchOperationUpdateActivityOptions{
@@ -155,7 +155,7 @@ func (s *ActivityAPIBatchUpdateOptionsSuite) TestActivityBatchUpdateOptionsSucce
 	}, 5*time.Second, 100*time.Millisecond)
 
 	// unpause the activities in both workflows with batch unpause
-	_, err = env.SdkClient().WorkflowService().StartBatchOperation(env.Context(), &workflowservice.StartBatchOperationRequest{
+	_, err = env.SdkClient().WorkflowService().StartBatchOperation(s.Context(), &workflowservice.StartBatchOperationRequest{
 		Namespace: env.Namespace().String(),
 		Operation: &workflowservice.StartBatchOperationRequest_UnpauseActivitiesOperation{
 			UnpauseActivitiesOperation: &batchpb.BatchOperationUnpauseActivities{
@@ -200,7 +200,7 @@ func (s *ActivityAPIBatchUpdateOptionsSuite) TestActivityBatchUpdateOptionsMatch
 		testcore.WithDynamicConfig(dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace, testcore.ClientSuiteLimit),
 	)
 
-	ctx := env.Context()
+	ctx := s.Context()
 	const workflowCount = 10
 	workflowTypeName := testcore.RandomizeStr("activity-batch-update-options-match-all-workflow")
 	updatedScheduleToClose := 10 * time.Second
@@ -293,7 +293,7 @@ func (s *ActivityAPIBatchUpdateOptionsSuite) TestActivityBatchUpdateOptionsFaile
 	)
 
 	// neither activity type nor "match all" is provided
-	_, err := env.SdkClient().WorkflowService().StartBatchOperation(env.Context(), &workflowservice.StartBatchOperationRequest{
+	_, err := env.SdkClient().WorkflowService().StartBatchOperation(s.Context(), &workflowservice.StartBatchOperationRequest{
 		Namespace: env.Namespace().String(),
 		Operation: &workflowservice.StartBatchOperationRequest_UpdateActivityOptionsOperation{
 			UpdateActivityOptionsOperation: &batchpb.BatchOperationUpdateActivityOptions{},
@@ -307,7 +307,7 @@ func (s *ActivityAPIBatchUpdateOptionsSuite) TestActivityBatchUpdateOptionsFaile
 	env.ErrorAs(err, new(*serviceerror.InvalidArgument))
 
 	// neither activity type nor "match all" is provided
-	_, err = env.SdkClient().WorkflowService().StartBatchOperation(env.Context(), &workflowservice.StartBatchOperationRequest{
+	_, err = env.SdkClient().WorkflowService().StartBatchOperation(s.Context(), &workflowservice.StartBatchOperationRequest{
 		Namespace: env.Namespace().String(),
 		Operation: &workflowservice.StartBatchOperationRequest_UpdateActivityOptionsOperation{
 			UpdateActivityOptionsOperation: &batchpb.BatchOperationUpdateActivityOptions{
@@ -323,7 +323,7 @@ func (s *ActivityAPIBatchUpdateOptionsSuite) TestActivityBatchUpdateOptionsFaile
 	env.ErrorAs(err, new(*serviceerror.InvalidArgument))
 
 	// cannot set activity options and restore original
-	_, err = env.SdkClient().WorkflowService().StartBatchOperation(env.Context(), &workflowservice.StartBatchOperationRequest{
+	_, err = env.SdkClient().WorkflowService().StartBatchOperation(s.Context(), &workflowservice.StartBatchOperationRequest{
 		Namespace: env.Namespace().String(),
 		Operation: &workflowservice.StartBatchOperationRequest_UpdateActivityOptionsOperation{
 			UpdateActivityOptionsOperation: &batchpb.BatchOperationUpdateActivityOptions{

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -4080,7 +4080,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution() {
 	s.Run("DeadlineExceeded", func(s *standaloneActivityTestSuite) {
 		env := s.newTestEnv()
 		t := s.T()
-		ctx := testcore.NewContext()
+		ctx := s.Context()
 
 		// Start an activity and get initial long-poll state token
 		activityID := env.Tv().ActivityID()
@@ -4157,7 +4157,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution() {
 	s.Run("NotFound", func(s *standaloneActivityTestSuite) {
 		env := s.newTestEnv()
 		t := s.T()
-		ctx := testcore.NewContext()
+		ctx := s.Context()
 
 		existingActivityID := env.Tv().ActivityID()
 		tq := env.Tv().TaskQueue()
@@ -4241,7 +4241,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution() {
 	s.Run("InvalidArgument", func(s *standaloneActivityTestSuite) {
 		env := s.newTestEnv()
 		t := s.T()
-		ctx := testcore.NewContext()
+		ctx := s.Context()
 
 		existingActivityID := env.Tv().ActivityID()
 		tq := env.Tv().TaskQueue()
@@ -4550,7 +4550,7 @@ func (s *standaloneActivityTestSuite) TestPollActivityExecution_EmptyRunID() {
 func (s *standaloneActivityTestSuite) TestPollActivityExecution_NotFound() {
 	env := s.newTestEnv()
 	t := s.T()
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 
 	existingActivityID := env.Tv().ActivityID()
 	tq := env.Tv().TaskQueue()
@@ -4613,7 +4613,7 @@ func (s *standaloneActivityTestSuite) TestPollActivityExecution_NotFound() {
 func (s *standaloneActivityTestSuite) TestPollActivityExecution_InvalidArgument() {
 	env := s.newTestEnv()
 	t := s.T()
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 
 	existingNamespace := env.Namespace().String()
 	validRunID := "11111111-2222-3333-4444-555555555555"
@@ -5049,7 +5049,7 @@ func (s *standaloneActivityTestSuite) TestCountActivityExecutions() {
 func (s *standaloneActivityTestSuite) TestHeartbeat() {
 	env := s.newTestEnv()
 	t := s.T()
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	heartbeatDetails := payloads.EncodeString("Heartbeat Details")
 
 	t.Run("InvalidArgument", func(t *testing.T) {

--- a/tests/admin_test.go
+++ b/tests/admin_test.go
@@ -66,10 +66,10 @@ func (s *AdminTestSuite) TestAdminRebuildMutableState(testWithChasm bool) {
 		TaskQueue:          env.WorkerTaskQueue(),
 		WorkflowRunTimeout: 20 * time.Second,
 	}
-	ctx, cancel := context.WithTimeout(env.Context(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(s.Context(), 30*time.Second)
 	defer cancel()
 
-	workflowRun, err := env.SdkClient().ExecuteWorkflow(env.Context(), workflowOptions, workflowFn)
+	workflowRun, err := env.SdkClient().ExecuteWorkflow(s.Context(), workflowOptions, workflowFn)
 	s.NoError(err)
 	runID := workflowRun.GetRunID()
 

--- a/tests/chasm_test.go
+++ b/tests/chasm_test.go
@@ -55,7 +55,7 @@ type chasmTestEnv struct {
 
 // newChasmTestEnv creates a chasmTestEnv backed by a dedicated cluster with
 // EnableChasm and VisibilityEnableUnifiedQueryConverter overridden for the test.
-func newChasmTestEnv(t *testing.T, unified bool) chasmTestEnv {
+func newChasmTestEnv(suiteContext func() context.Context, t *testing.T, unified bool) chasmTestEnv {
 	t.Helper()
 
 	// WithDedicatedCluster acquires an exclusive pooled slot — no fresh cluster
@@ -69,7 +69,7 @@ func newChasmTestEnv(t *testing.T, unified bool) chasmTestEnv {
 		testcore.WithDynamicConfig(dynamicconfig.DeleteNamespaceUseChasmDeleteExecution, true),
 	)
 
-	chasmCtx, err := env.GetTestCluster().Host().ChasmContext(env.Context())
+	chasmCtx, err := env.GetTestCluster().Host().ChasmContext(suiteContext())
 	require.NoError(t, err)
 
 	return chasmTestEnv{TestEnv: env, chasmCtx: chasmCtx}
@@ -81,7 +81,8 @@ func newChasmTestEnv(t *testing.T, unified bool) chasmTestEnv {
 func (s *ChasmSuite) forBothConverters(fn func(*ChasmSuite, chasmTestEnv)) {
 	for _, unified := range []bool{false, true} {
 		s.Run(fmt.Sprintf("unified=%v", unified), func(ss *ChasmSuite) {
-			fn(ss, newChasmTestEnv(ss.T(), unified))
+			// Resolve the suite context after NewEnv attaches its RPC header decorator.
+			fn(ss, newChasmTestEnv(ss.Context, ss.T(), unified))
 		})
 	}
 }
@@ -498,7 +499,7 @@ func (s *ChasmSuite) TestListWorkflowExecutions() {
 		var execInfo *workflowpb.WorkflowExecutionInfo
 		ss.AwaitTrue(
 			func() bool {
-				listResp, err := cenv.FrontendClient().ListWorkflowExecutions(cenv.Context(), &workflowservice.ListWorkflowExecutionsRequest{
+				listResp, err := cenv.FrontendClient().ListWorkflowExecutions(ss.Context(), &workflowservice.ListWorkflowExecutionsRequest{
 					Namespace: cenv.Namespace().String(),
 					PageSize:  10,
 					Query:     visQuery,
@@ -551,7 +552,7 @@ func (s *ChasmSuite) TestPayloadStoreForceDelete() {
 		var executionInfo *workflowpb.WorkflowExecutionInfo
 		ss.AwaitTrue(
 			func() bool {
-				resp, err := cenv.FrontendClient().ListWorkflowExecutions(cenv.Context(), &workflowservice.ListWorkflowExecutionsRequest{
+				resp, err := cenv.FrontendClient().ListWorkflowExecutions(ss.Context(), &workflowservice.ListWorkflowExecutionsRequest{
 					Namespace: cenv.Namespace().String(),
 					PageSize:  10,
 					Query:     visQuery,
@@ -573,7 +574,7 @@ func (s *ChasmSuite) TestPayloadStoreForceDelete() {
 		ss.NoError(err)
 		ss.Equal(tests.ArchetypeID, chasm.ArchetypeID(parsedArchetypeID))
 
-		_, err = cenv.AdminClient().DeleteWorkflowExecution(cenv.Context(), &adminservice.DeleteWorkflowExecutionRequest{
+		_, err = cenv.AdminClient().DeleteWorkflowExecution(ss.Context(), &adminservice.DeleteWorkflowExecutionRequest{
 			Namespace: cenv.Namespace().String(),
 			Execution: &commonpb.WorkflowExecution{
 				WorkflowId: storeID,
@@ -584,7 +585,7 @@ func (s *ChasmSuite) TestPayloadStoreForceDelete() {
 		ss.NoError(err)
 
 		// Validate mutable state is deleted.
-		_, err = cenv.AdminClient().DescribeMutableState(cenv.Context(), &adminservice.DescribeMutableStateRequest{
+		_, err = cenv.AdminClient().DescribeMutableState(ss.Context(), &adminservice.DescribeMutableStateRequest{
 			Namespace: cenv.Namespace().String(),
 			Execution: &commonpb.WorkflowExecution{
 				WorkflowId: storeID,
@@ -842,7 +843,7 @@ func (s *ChasmSuite) TestMutableStateRebuilder() {
 		// payloadStore archetype is not the workflow archetype, should fail the rebuild.
 		ss.NotEqual(tests.Archetype, chasm.WorkflowArchetype, "Archetype should not be the workflow archetype")
 
-		_, err = cenv.AdminClient().RebuildMutableState(cenv.Context(), &adminservice.RebuildMutableStateRequest{
+		_, err = cenv.AdminClient().RebuildMutableState(ss.Context(), &adminservice.RebuildMutableStateRequest{
 			Namespace: cenv.Namespace().String(),
 			Execution: &commonpb.WorkflowExecution{
 				WorkflowId: storeID,
@@ -1035,7 +1036,7 @@ func (s *ChasmSuite) TestPayloadStore_ApproximateExecutionSize() {
 		sizeDelta := float64(100) // Allow 100 bytes of variance due to overhead, encoding, etc.
 		ss.InDelta(payloadSize, currentApproxSize-initialApproxSize, sizeDelta)
 
-		adminDescResp, err := cenv.AdminClient().DescribeMutableState(cenv.Context(), &adminservice.DescribeMutableStateRequest{
+		adminDescResp, err := cenv.AdminClient().DescribeMutableState(ss.Context(), &adminservice.DescribeMutableStateRequest{
 			Namespace: cenv.Namespace().String(),
 			Execution: &commonpb.WorkflowExecution{
 				WorkflowId: storeID,
@@ -1058,7 +1059,7 @@ func (s *ChasmSuite) TestNamespaceDelete_WithChasmExecutions() {
 		_, err := rand.Read(namespaceSuffix[:])
 		ss.NoError(err)
 		namespaceName := fmt.Sprintf("ns-chasm-delete-%x", namespaceSuffix)
-		_, err = cenv.FrontendClient().RegisterNamespace(cenv.Context(), &workflowservice.RegisterNamespaceRequest{
+		_, err = cenv.FrontendClient().RegisterNamespace(ss.Context(), &workflowservice.RegisterNamespaceRequest{
 			Namespace:                        namespaceName,
 			WorkflowExecutionRetentionPeriod: durationpb.New(24 * time.Hour),
 			HistoryArchivalState:             enumspb.ARCHIVAL_STATE_DISABLED,
@@ -1066,7 +1067,7 @@ func (s *ChasmSuite) TestNamespaceDelete_WithChasmExecutions() {
 		})
 		ss.NoError(err)
 
-		descResp, err := cenv.FrontendClient().DescribeNamespace(cenv.Context(), &workflowservice.DescribeNamespaceRequest{
+		descResp, err := cenv.FrontendClient().DescribeNamespace(ss.Context(), &workflowservice.DescribeNamespaceRequest{
 			Namespace: namespaceName,
 		})
 		ss.NoError(err)
@@ -1086,7 +1087,7 @@ func (s *ChasmSuite) TestNamespaceDelete_WithChasmExecutions() {
 
 		// Wait for visibility records to appear.
 		visQuery := fmt.Sprintf("TemporalNamespaceDivision = '%d'", tests.ArchetypeID)
-		await.Require(cenv.Context(), ss.T(), func(t *await.T) {
+		await.Require(ss.Context(), ss.T(), func(t *await.T) {
 			resp, err := cenv.FrontendClient().ListWorkflowExecutions(t.Context(), &workflowservice.ListWorkflowExecutionsRequest{
 				Namespace: namespaceName,
 				PageSize:  10,
@@ -1097,13 +1098,13 @@ func (s *ChasmSuite) TestNamespaceDelete_WithChasmExecutions() {
 		}, testcore.WaitForESToSettle, 100*time.Millisecond)
 
 		// Delete the namespace, which should trigger DeleteExecution for all CHASM executions.
-		_, err = cenv.OperatorClient().DeleteNamespace(cenv.Context(), &operatorservice.DeleteNamespaceRequest{
+		_, err = cenv.OperatorClient().DeleteNamespace(ss.Context(), &operatorservice.DeleteNamespaceRequest{
 			Namespace: namespaceName,
 		})
 		ss.NoError(err)
 
 		// Verify all CHASM executions are cleaned up from visibility.
-		await.Require(cenv.Context(), ss.T(), func(t *await.T) {
+		await.Require(ss.Context(), ss.T(), func(t *await.T) {
 			resp, err := cenv.FrontendClient().ListWorkflowExecutions(t.Context(), &workflowservice.ListWorkflowExecutionsRequest{
 				Namespace: namespaceName,
 				PageSize:  10,

--- a/tests/client_data_converter_test.go
+++ b/tests/client_data_converter_test.go
@@ -150,7 +150,7 @@ func (s *ClientDataConverterSuite) TestClientDataConverter() {
 		TaskQueue:          env.WorkerTaskQueue(),
 		WorkflowRunTimeout: time.Minute,
 	}
-	ctx := env.Context()
+	ctx := s.Context()
 	env.SdkWorker().RegisterWorkflow(testDataConverterWorkflow)
 	env.SdkWorker().RegisterActivity(testActivity)
 	we, err := env.SdkClient().ExecuteWorkflow(ctx, workflowOptions, testDataConverterWorkflow, tl)
@@ -185,7 +185,7 @@ func (s *ClientDataConverterSuite) TestClientDataConverterFailed() {
 		TaskQueue:          env.WorkerTaskQueue(),
 		WorkflowRunTimeout: time.Minute,
 	}
-	ctx := env.Context()
+	ctx := s.Context()
 
 	env.SdkWorker().RegisterWorkflow(testDataConverterWorkflow)
 	env.SdkWorker().RegisterActivity(testActivity)
@@ -234,7 +234,7 @@ func (s *ClientDataConverterSuite) TestClientDataConverterWithChild() {
 		TaskQueue:          env.WorkerTaskQueue(),
 		WorkflowRunTimeout: time.Minute,
 	}
-	ctx := env.Context()
+	ctx := s.Context()
 	env.SdkWorker().RegisterWorkflow(testParentWorkflow)
 	env.SdkWorker().RegisterWorkflow(testChildWorkflow)
 

--- a/tests/describe_test.go
+++ b/tests/describe_test.go
@@ -52,13 +52,13 @@ func (s *DescribeTestSuite) TestDescribeWorkflowExecution() {
 		Identity:            identity,
 	}
 
-	we, err0 := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 
 	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
 	describeWorkflowExecution := func() (*workflowservice.DescribeWorkflowExecutionResponse, error) {
-		return env.FrontendClient().DescribeWorkflowExecution(testcore.NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+		return env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
 			Namespace: env.Namespace().String(),
 			Execution: &commonpb.WorkflowExecution{
 				WorkflowId: id,
@@ -210,7 +210,7 @@ func (s *DescribeTestSuite) TestDescribeTaskQueue() {
 		Identity:            identity,
 	}
 
-	we, err0 := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 
 	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -265,7 +265,7 @@ func (s *DescribeTestSuite) TestDescribeTaskQueue() {
 
 	// this function poll events from history side
 	testDescribeTaskQueue := func(namespace string, taskqueue *taskqueuepb.TaskQueue, taskqueueType enumspb.TaskQueueType) []*taskqueuepb.PollerInfo {
-		responseInner, errInner := env.FrontendClient().DescribeTaskQueue(testcore.NewContext(), &workflowservice.DescribeTaskQueueRequest{
+		responseInner, errInner := env.FrontendClient().DescribeTaskQueue(s.Context(), &workflowservice.DescribeTaskQueueRequest{
 			Namespace:     namespace,
 			TaskQueue:     taskqueue,
 			TaskQueueType: taskqueueType,

--- a/tests/history_node_cleanup_test.go
+++ b/tests/history_node_cleanup_test.go
@@ -38,7 +38,7 @@ func TestHistoryNodeCleanupSuite(t *testing.T) {
 func (s *HistoryNodeCleanupSuite) TestDeletionOfSingleWorkflow() {
 	env := testcore.NewEnv(s.T())
 	tv := testvars.New(s.T())
-	ctx := env.Context()
+	ctx := s.Context()
 
 	shardID := common.WorkflowIDToHistoryShard(
 		env.NamespaceID().String(),
@@ -92,7 +92,7 @@ func (s *HistoryNodeCleanupSuite) TestDeletionOfSingleWorkflow() {
 func (s *HistoryNodeCleanupSuite) TestDeletionOfWorkflowAfterReset() {
 	env := testcore.NewEnv(s.T())
 	tv := testvars.New(s.T())
-	ctx := env.Context()
+	ctx := s.Context()
 
 	shardID := common.WorkflowIDToHistoryShard(
 		env.NamespaceID().String(),

--- a/tests/links_test.go
+++ b/tests/links_test.go
@@ -497,7 +497,7 @@ func (s *LinksSuite) TestSignalWorkflowExecution_BufferedDuringWorkflowTask() {
 
 	// Poll to move the WFT into "started" state to have the server wait for us to complete it.
 	// This will force the signal to stay in the buffer until the task is finished.
-	pollResp, err := env.FrontendClient().PollWorkflowTaskQueue(env.Context(), &workflowservice.PollWorkflowTaskQueueRequest{
+	pollResp, err := env.FrontendClient().PollWorkflowTaskQueue(s.Context(), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: env.Namespace().String(),
 		TaskQueue: &taskqueuepb.TaskQueue{Name: signalTest.taskQueueName, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:  "test",
@@ -519,7 +519,7 @@ func (s *LinksSuite) TestSignalWorkflowExecution_BufferedDuringWorkflowTask() {
 	s.True(gotRequestInfo.GetBuffered(), "backlink must be buffered while WFT is in progress")
 
 	// Complete the WFT, which flushes the signal to DB with a concrete EventID.
-	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(env.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(s.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace: env.Namespace().String(),
 		Identity:  "test",
 		TaskToken: pollResp.TaskToken,

--- a/tests/namespace_interceptor_test.go
+++ b/tests/namespace_interceptor_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -30,6 +31,7 @@ func (s *NamespaceInterceptorTestSuite) TestNamespaceInterceptorServerRejectsInv
 	id := uuid.NewString()
 	sut := &sutConnector{
 		env:             env,
+		ctx:             s.Context(),
 		identity:        "worker-1",
 		taskQueue:       &taskqueuepb.TaskQueue{Name: id, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		stickyTaskQueue: &taskqueuepb.TaskQueue{Name: "test-sticky-taskqueue", Kind: enumspb.TASK_QUEUE_KIND_STICKY, NormalName: id},
@@ -53,6 +55,7 @@ func (s *NamespaceInterceptorTestSuite) TestNamespaceInterceptorServerRejectsInv
 
 type sutConnector struct {
 	env             *testcore.TestEnv
+	ctx             context.Context
 	identity        string
 	taskQueue       *taskqueuepb.TaskQueue
 	stickyTaskQueue *taskqueuepb.TaskQueue
@@ -61,7 +64,7 @@ type sutConnector struct {
 }
 
 func (b *sutConnector) startWorkflowExecution(ns namespace.Name) error {
-	_, err := b.env.FrontendClient().StartWorkflowExecution(b.env.Context(), &workflowservice.StartWorkflowExecutionRequest{
+	_, err := b.env.FrontendClient().StartWorkflowExecution(b.ctx, &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:           uuid.NewString(),
 		Namespace:           ns.String(),
 		WorkflowId:          b.id,
@@ -76,7 +79,7 @@ func (b *sutConnector) startWorkflowExecution(ns namespace.Name) error {
 }
 
 func (b *sutConnector) pollWorkflowTaskQueue(ns namespace.Name) ([]byte, error) {
-	resp, err := b.env.FrontendClient().PollWorkflowTaskQueue(b.env.Context(), &workflowservice.PollWorkflowTaskQueueRequest{
+	resp, err := b.env.FrontendClient().PollWorkflowTaskQueue(b.ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: ns.String(),
 		TaskQueue: b.taskQueue,
 		Identity:  b.identity,
@@ -89,7 +92,7 @@ func (b *sutConnector) pollWorkflowTaskQueue(ns namespace.Name) ([]byte, error) 
 }
 
 func (b *sutConnector) respondWorkflowTaskCompleted(token []byte, ns namespace.Name) error {
-	_, err := b.env.FrontendClient().RespondWorkflowTaskCompleted(b.env.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err := b.env.FrontendClient().RespondWorkflowTaskCompleted(b.ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace: ns.String(),
 		TaskToken: token,
 		Commands: []*commandpb.Command{

--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -270,7 +270,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes(useTemporalFailures
 
 	testFn := func(s *NexusApiTestSuite, tc testcase, dispatchOnlyByEndpoint bool) {
 		env := newNexusTestEnv(s.T(), useTemporalFailures)
-		endpoint := env.createNexusEndpoint(env.Context(), s.T(), tc.endpointName, testcore.RandomizeStr("task-queue"))
+		endpoint := env.createNexusEndpoint(s.Context(), s.T(), tc.endpointName, testcore.RandomizeStr("task-queue"))
 		var dispatchURL string
 		if dispatchOnlyByEndpoint {
 			dispatchURL = getDispatchByEndpointURL(env.HttpAPIAddress(), endpoint.Id)
@@ -287,14 +287,14 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes(useTemporalFailures
 		s.NoError(err)
 		capture := env.StartNamespaceMetricCapture()
 
-		pollerErrCh := env.nexusTaskPoller(env.Context(), s.T(), endpoint.Spec.Target.GetWorker().TaskQueue, tc.handler)
+		pollerErrCh := env.nexusTaskPoller(s.Context(), s.T(), endpoint.Spec.Target.GetWorker().TaskQueue, tc.handler)
 
 		header := nexus.Header{"key": "value", "temporal-nexus-failure-support": "true"}
 		if tc.timeout > 0 {
 			header[nexus.HeaderRequestTimeout] = tc.timeout.String()
 		}
 
-		result, err := nexusrpc.StartOperation(env.Context(), client, op, "input", nexus.StartOperationOptions{
+		result, err := nexusrpc.StartOperation(s.Context(), client, op, "input", nexus.StartOperationOptions{
 			CallbackURL: "http://localhost/callback",
 			RequestID:   "request-id",
 			Header:      header,
@@ -417,7 +417,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Claims(useTemporalFailures b
 			return &authorization.Claims{Subject: "test"}, nil
 		})
 
-		testEndpoint := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizeStr("test-endpoint"), taskQueue)
+		testEndpoint := env.createNexusEndpoint(s.Context(), s.T(), testcore.RandomizeStr("test-endpoint"), taskQueue)
 		var dispatchURL string
 		if dispatchOnlyByEndpoint {
 			dispatchURL = getDispatchByEndpointURL(env.HttpAPIAddress(), testEndpoint.Id)
@@ -431,11 +431,11 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Claims(useTemporalFailures b
 		var pollerErrCh <-chan error
 		if tc.handler != nil {
 			// only set on valid request
-			pollerErrCh = env.nexusTaskPoller(env.Context(), s.T(), taskQueue, tc.handler)
+			pollerErrCh = env.nexusTaskPoller(s.Context(), s.T(), taskQueue, tc.handler)
 		}
 
 		capture := env.StartGlobalMetricCapture()
-		result, err := nexusrpc.StartOperation(env.Context(), client, op, "input", nexus.StartOperationOptions{
+		result, err := nexusrpc.StartOperation(s.Context(), client, op, "input", nexus.StartOperationOptions{
 			Header: tc.header,
 		})
 		preprocessErrors := capture.Metric("nexus_request_preprocess_errors")
@@ -531,7 +531,7 @@ func (s *NexusApiTestSuite) TestNexusCancelOperation_Outcomes(useTemporalFailure
 
 	testFn := func(s *NexusApiTestSuite, tc testcase, dispatchOnlyByEndpoint bool) {
 		env := newNexusTestEnv(s.T(), useTemporalFailures)
-		endpoint := env.createNexusEndpoint(env.Context(), s.T(), tc.endpointName, testcore.RandomizeStr("task-queue"))
+		endpoint := env.createNexusEndpoint(s.Context(), s.T(), tc.endpointName, testcore.RandomizeStr("task-queue"))
 		var dispatchURL string
 		if dispatchOnlyByEndpoint {
 			dispatchURL = getDispatchByEndpointURL(env.HttpAPIAddress(), endpoint.Id)
@@ -548,7 +548,7 @@ func (s *NexusApiTestSuite) TestNexusCancelOperation_Outcomes(useTemporalFailure
 		s.NoError(err)
 		capture := env.StartNamespaceMetricCapture()
 
-		pollerErrCh := env.nexusTaskPoller(env.Context(), s.T(), endpoint.Spec.Target.GetWorker().TaskQueue, tc.handler)
+		pollerErrCh := env.nexusTaskPoller(s.Context(), s.T(), endpoint.Spec.Target.GetWorker().TaskQueue, tc.handler)
 
 		handle, err := client.NewOperationHandle("operation", "token")
 		s.NoError(err)
@@ -558,7 +558,7 @@ func (s *NexusApiTestSuite) TestNexusCancelOperation_Outcomes(useTemporalFailure
 			header[nexus.HeaderRequestTimeout] = tc.timeout.String()
 		}
 
-		err = handle.Cancel(env.Context(), nexus.CancelOperationOptions{Header: header})
+		err = handle.Cancel(s.Context(), nexus.CancelOperationOptions{Header: header})
 
 		tc.assertion(s, err, headerCapture.lastHeaders)
 		s.NoError(<-pollerErrCh)
@@ -616,7 +616,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_WithNamespaceAndTaskQueue_Su
 		// UpdateWorkerBuildIdCompatibility is the v0.1 (Version Set-based) API gated by DataAPIs.
 		testcore.WithDynamicConfig(dynamicconfig.FrontendEnableWorkerVersioningDataAPIs, true),
 	)
-	ctx, cancel := context.WithCancel(env.Context())
+	ctx, cancel := context.WithCancel(s.Context())
 	defer cancel()
 
 	taskQueue := testcore.RandomizeStr("task-queue")
@@ -670,14 +670,14 @@ func (s *NexusApiTestSuite) TestNexusClientNameMetricPropagation(useTemporalFail
 	const expectedClientName = "temporal-go"
 	taskQueue := testcore.RandomizeStr("tq")
 
-	endpoint := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizeStr("endpoint"), taskQueue)
+	endpoint := env.createNexusEndpoint(s.Context(), s.T(), testcore.RandomizeStr("endpoint"), taskQueue)
 
 	capture := env.StartNamespaceMetricCapture()
 
 	// Start a poller that simulates an SDK worker with a specific client-name.
 	// We build the outgoing metadata from scratch (instead of using NewContext which
 	// sets client-name=temporal-server) so the SDK name is the only value.
-	pollerCtx := metadata.NewOutgoingContext(env.Context(), metadata.Pairs(
+	pollerCtx := metadata.NewOutgoingContext(s.Context(), metadata.Pairs(
 		"client-name", expectedClientName,
 		"client-version", "1.0.0",
 		"supported-server-versions", headers.SupportedServerVersions,
@@ -692,7 +692,7 @@ func (s *NexusApiTestSuite) TestNexusClientNameMetricPropagation(useTemporalFail
 	})
 	s.NoError(err)
 
-	_, err = nexusrpc.StartOperation(env.Context(), client, op, "input", nexus.StartOperationOptions{})
+	_, err = nexusrpc.StartOperation(s.Context(), client, op, "input", nexus.StartOperationOptions{})
 	s.NoError(err)
 	s.NoError(<-pollerErrCh)
 

--- a/tests/nexus_api_validation_test.go
+++ b/tests/nexus_api_validation_test.go
@@ -38,7 +38,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_WithNamespaceAndTa
 	client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: u, Service: "test-service"})
 	s.NoError(err)
 	capture := env.StartNamespaceMetricCaptureFor(namespace)
-	_, err = nexusrpc.StartOperation(env.Context(), client, op, "input", nexus.StartOperationOptions{})
+	_, err = nexusrpc.StartOperation(s.Context(), client, op, "input", nexus.StartOperationOptions{})
 	var handlerError *nexus.HandlerError
 	s.ErrorAs(err, &handlerError)
 	s.Equal(nexus.HandlerErrorTypeNotFound, handlerError.Type)
@@ -63,7 +63,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_WithNamespaceAndTa
 	client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: u, Service: "test-service"})
 	s.NoError(err)
 	capture := env.StartGlobalMetricCapture()
-	_, err = nexusrpc.StartOperation(env.Context(), client, op, "input", nexus.StartOperationOptions{})
+	_, err = nexusrpc.StartOperation(s.Context(), client, op, "input", nexus.StartOperationOptions{})
 	var handlerErr *nexus.HandlerError
 	s.ErrorAs(err, &handlerErr)
 	s.Equal(nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
@@ -181,7 +181,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_Forbidden() {
 			testcore.WithDynamicConfig(dynamicconfig.ExposeAuthorizerErrors, tc.exposeAuthorizerErrors),
 		)
 		taskQueue := testcore.RandomizeStr("task-queue")
-		testEndpoint := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizeStr("test-endpoint"), taskQueue)
+		testEndpoint := env.createNexusEndpoint(s.Context(), s.T(), testcore.RandomizeStr("test-endpoint"), taskQueue)
 
 		env.SetOnAuthorize(tc.onAuthorize(testEndpoint.Spec.Name))
 
@@ -197,7 +197,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_Forbidden() {
 
 		capture := env.StartNamespaceMetricCapture()
 
-		_, err = nexusrpc.StartOperation(env.Context(), client, op, "input", nexus.StartOperationOptions{})
+		_, err = nexusrpc.StartOperation(s.Context(), client, op, "input", nexus.StartOperationOptions{})
 
 		var handlerErr *nexus.HandlerError
 		s.ErrorAs(err, &handlerErr)
@@ -225,7 +225,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_PayloadSizeLimit()
 	testFn := func(s *NexusAPIValidationTestSuite, dispatchOnlyByEndpoint bool) {
 		env := newNexusTestEnv(s.T(), false)
 		taskQueue := testcore.RandomizeStr("task-queue")
-		testEndpoint := env.createNexusEndpoint(env.Context(), s.T(), testcore.RandomizeStr("test-endpoint"), taskQueue)
+		testEndpoint := env.createNexusEndpoint(s.Context(), s.T(), testcore.RandomizeStr("test-endpoint"), taskQueue)
 
 		var dispatchURL string
 		if dispatchOnlyByEndpoint {
@@ -236,7 +236,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_PayloadSizeLimit()
 
 		client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: dispatchURL, Service: "test-service"})
 		s.NoError(err)
-		result, err := nexusrpc.StartOperation(env.Context(), client, op, input, nexus.StartOperationOptions{
+		result, err := nexusrpc.StartOperation(s.Context(), client, op, input, nexus.StartOperationOptions{
 			CallbackURL: "http://localhost/callback",
 			RequestID:   "request-id",
 		})
@@ -263,7 +263,7 @@ func (s *NexusAPIValidationTestSuite) TestNexus_RespondNexusTaskMethods_Verifies
 	ttBytes, err := tt.Marshal()
 	s.NoError(err)
 
-	_, err = env.FrontendClient().RespondNexusTaskCompleted(env.Context(), &workflowservice.RespondNexusTaskCompletedRequest{
+	_, err = env.FrontendClient().RespondNexusTaskCompleted(s.Context(), &workflowservice.RespondNexusTaskCompletedRequest{
 		Namespace: env.ExternalNamespace().String(),
 		Identity:  uuid.NewString(),
 		TaskToken: ttBytes,
@@ -271,7 +271,7 @@ func (s *NexusAPIValidationTestSuite) TestNexus_RespondNexusTaskMethods_Verifies
 	})
 	s.ErrorContains(err, "Operation requested with a token from a different namespace.")
 
-	_, err = env.FrontendClient().RespondNexusTaskFailed(env.Context(), &workflowservice.RespondNexusTaskFailedRequest{
+	_, err = env.FrontendClient().RespondNexusTaskFailed(s.Context(), &workflowservice.RespondNexusTaskFailedRequest{
 		Namespace: env.ExternalNamespace().String(),
 		Identity:  uuid.NewString(),
 		TaskToken: ttBytes,
@@ -291,7 +291,7 @@ func (s *NexusAPIValidationTestSuite) TestNexus_RespondNexusTaskCompleted_Valida
 	ttBytes, err := tt.Marshal()
 	s.NoError(err)
 
-	_, err = env.FrontendClient().RespondNexusTaskCompleted(env.Context(), &workflowservice.RespondNexusTaskCompletedRequest{
+	_, err = env.FrontendClient().RespondNexusTaskCompleted(s.Context(), &workflowservice.RespondNexusTaskCompletedRequest{
 		Namespace: env.Namespace().String(),
 		Identity:  uuid.NewString(),
 		TaskToken: ttBytes,
@@ -323,7 +323,7 @@ func (s *NexusAPIValidationTestSuite) TestNexus_RespondNexusTaskMethods_Validate
 	ttBytes, err := tt.Marshal()
 	s.NoError(err)
 
-	_, err = env.FrontendClient().RespondNexusTaskCompleted(env.Context(), &workflowservice.RespondNexusTaskCompletedRequest{
+	_, err = env.FrontendClient().RespondNexusTaskCompleted(s.Context(), &workflowservice.RespondNexusTaskCompletedRequest{
 		Namespace: env.Namespace().String(),
 		Identity:  uuid.NewString(),
 		TaskToken: ttBytes,
@@ -346,7 +346,7 @@ func (s *NexusAPIValidationTestSuite) TestNexus_RespondNexusTaskMethods_Validate
 	s.ErrorAs(err, &invalidArgumentErr)
 	s.Equal("failure details must be JSON serializable", invalidArgumentErr.Message)
 
-	_, err = env.FrontendClient().RespondNexusTaskFailed(env.Context(), &workflowservice.RespondNexusTaskFailedRequest{
+	_, err = env.FrontendClient().RespondNexusTaskFailed(s.Context(), &workflowservice.RespondNexusTaskFailedRequest{
 		Namespace: env.Namespace().String(),
 		Identity:  uuid.NewString(),
 		TaskToken: ttBytes,
@@ -366,7 +366,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_ByEndpoint_Endpoin
 	client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: u, Service: "test-service"})
 	s.NoError(err)
 	capture := env.StartGlobalMetricCapture()
-	_, err = nexusrpc.StartOperation(env.Context(), client, op, "input", nexus.StartOperationOptions{})
+	_, err = nexusrpc.StartOperation(s.Context(), client, op, "input", nexus.StartOperationOptions{})
 	var handlerErr *nexus.HandlerError
 	s.ErrorAs(err, &handlerErr)
 	s.Equal(nexus.HandlerErrorTypeNotFound, handlerErr.Type)

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -80,7 +80,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelation(chasmEnabled bool
 	}
 
 	env := s.newTestEnv(chasmEnabled)
-	ctx := env.Context()
+	ctx := s.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 
 	firstCancelSeen := false
@@ -292,7 +292,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancellationCrossTree(chasmEn
 	for _, tc := range testCases {
 		s.Run(tc.name, func(s *NexusWorkflowTestSuite) {
 			env := s.newTestEnv(true)
-			ctx := env.Context()
+			ctx := s.Context()
 			taskQueue := testcore.RandomizeStr(s.T().Name())
 
 			env.OverrideDynamicConfig(chasmnexus.EnableChasmWorkflowOperations, tc.enableChasmAtSchedule)
@@ -376,7 +376,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancellationBufferedCrossTree
 	}
 
 	env := s.newTestEnv(true)
-	ctx := env.Context()
+	ctx := s.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 	// Schedule the operation in the HSM tree.
 	env.OverrideDynamicConfig(chasmnexus.EnableChasmWorkflowOperations, false)
@@ -496,7 +496,7 @@ func (s *NexusWorkflowTestSuite) assertNexusOperationTree(ctx context.Context, e
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion(chasmEnabled bool) {
 	env := s.newTestEnv(chasmEnabled)
-	ctx := env.Context()
+	ctx := s.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 
 	handlerLink := &commonpb.Link_WorkflowEvent{
@@ -566,7 +566,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion(chasmEnabled b
 // endpoint, and real workflow type. It runs for both the HSM and CHASM engines.
 func (s *NexusWorkflowTestSuite) TestNexusOperationCallerMetrics(chasmEnabled bool) {
 	env := s.newTestEnv(chasmEnabled)
-	ctx := env.Context()
+	ctx := s.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 
 	h := nexustest.Handler{
@@ -633,7 +633,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationStartsStandaloneActivityBidir
 		{Constraints: dynamicconfig.Constraints{Namespace: env.Namespace().String()}, Value: true},
 	}
 	cluster.OverrideDynamicConfig(s.T(), activity.Enabled, nsValues)
-	ctx := env.Context()
+	ctx := s.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 
 	activityID := testcore.RandomizeStr("saa-via-nexus")
@@ -754,7 +754,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncStandaloneActivityComple
 	}
 	cluster.OverrideDynamicConfig(s.T(), activity.Enabled, nsValues)
 	cluster.OverrideDynamicConfig(s.T(), activity.EnableCallbacks, nsValues)
-	ctx := env.Context()
+	ctx := s.Context()
 
 	callerTQ := testcore.RandomizeStr(s.T().Name() + "-caller")
 	activityTQ := testcore.RandomizeStr(s.T().Name() + "-activity")
@@ -894,7 +894,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncStandaloneActivityComple
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion_LargePayload(chasmEnabled bool) {
 	env := s.newTestEnv(chasmEnabled)
-	ctx := env.Context()
+	ctx := s.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 
 	h := nexustest.Handler{
@@ -933,7 +933,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion_LargePayload(c
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletion(chasmEnabled bool) {
 	env := s.newTestEnv(chasmEnabled)
-	ctx := env.Context()
+	ctx := s.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 
 	testClusterInfo, err := env.FrontendClient().GetClusterInfo(ctx, &workflowservice.GetClusterInfoRequest{})
@@ -1267,7 +1267,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletion(chasmEnabled 
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionBeforeStart(chasmEnabled bool) {
 	env := s.newTestEnv(chasmEnabled)
-	ctx := env.Context()
+	ctx := s.Context()
 	taskQueues := []string{testcore.RandomizeStr(s.T().Name()), testcore.RandomizeStr(s.T().Name())}
 	wfRuns := []client.WorkflowRun{}
 	nexusTasks := []*workflowservice.PollNexusTaskQueueResponse{}
@@ -1526,7 +1526,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionBeforeStart(ch
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncFailure(chasmEnabled bool) {
 	env := s.newTestEnv(chasmEnabled)
-	ctx := env.Context()
+	ctx := s.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 
 	var callbackToken, publicCallbackURL string
@@ -1590,7 +1590,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncFailure(chasmEnabled boo
 func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEnabled bool) {
 	s.Run("NamespaceNotFound", func(s *NexusWorkflowTestSuite) {
 		env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
-		ctx := env.Context()
+		ctx := s.Context()
 		// Generate a token with a non-existent namespace ID
 		tokenWithBadNamespace, err := s.generateValidCallbackToken("namespace-doesnt-exist-id", testcore.RandomizeStr("workflow"), uuid.NewString())
 		s.NoError(err)
@@ -1610,7 +1610,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 
 	s.Run("NamespaceNotFoundNoIdentifier", func(s *NexusWorkflowTestSuite) {
 		env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
-		ctx := env.Context()
+		ctx := s.Context()
 		// Generate a token with a non-existent namespace ID
 		tokenWithBadNamespace, err := s.generateValidCallbackToken("namespace-doesnt-exist-id", testcore.RandomizeStr("workflow"), uuid.NewString())
 		s.NoError(err)
@@ -1630,7 +1630,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 
 	s.Run("OperationTokenTooLong", func(s *NexusWorkflowTestSuite) {
 		env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
-		ctx := env.Context()
+		ctx := s.Context()
 		publicCallbackURL := "http://" + env.HttpAPIAddress() + "/" + commonnexus.RouteCompletionCallback.Path(env.Namespace().String())
 
 		// Generate a valid callback token to get past initial validation
@@ -1657,7 +1657,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 
 	s.Run("OperationTokenTooLongNoIdentifier", func(s *NexusWorkflowTestSuite) {
 		env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())
-		ctx := env.Context()
+		ctx := s.Context()
 		publicCallbackURL := "http://" + env.HttpAPIAddress() + commonnexus.PathCompletionCallbackNoIdentifier
 		// Generate a valid callback token to get past initial validation
 		namespaceID := env.NamespaceID().String()
@@ -1690,7 +1690,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 		publicCallbackURL := "http://" + env.HttpAPIAddress() + "/" + commonnexus.RouteCompletionCallback.Path(env.Namespace().String())
 		// metrics collection is not initialized before callback validation
 		// Send request without callback token, helper does not add token if blank
-		err := s.sendNexusCompletionRequest(env.Context(), publicCallbackURL, completion)
+		err := s.sendNexusCompletionRequest(s.Context(), publicCallbackURL, completion)
 		// Verify we get the correct error response
 		var handlerErr *nexus.HandlerError
 		s.ErrorAs(err, &handlerErr)
@@ -1706,7 +1706,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 		publicCallbackURL := "http://" + env.HttpAPIAddress() + commonnexus.PathCompletionCallbackNoIdentifier
 		// metrics collection is not initialized before callback validation
 		// Send request without callback token, helper does not add token if blank
-		err := s.sendNexusCompletionRequest(env.Context(), publicCallbackURL, completion)
+		err := s.sendNexusCompletionRequest(s.Context(), publicCallbackURL, completion)
 		// Verify we get the correct error response
 		var handlerErr *nexus.HandlerError
 		s.ErrorAs(err, &handlerErr)
@@ -1734,7 +1734,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 		client := nexusrpc.NewCompletionHTTPClient(nexusrpc.CompletionHTTPClientOptions{
 			Serializer: commonnexus.PayloadSerializer,
 		})
-		err = client.CompleteOperation(env.Context(), publicCallbackURL, completion)
+		err = client.CompleteOperation(s.Context(), publicCallbackURL, completion)
 		completionRequests := capture.Metric("nexus_completion_requests")
 		var handlerErr *nexus.HandlerError
 		s.ErrorAs(err, &handlerErr)
@@ -1764,7 +1764,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEn
 		client := nexusrpc.NewCompletionHTTPClient(nexusrpc.CompletionHTTPClientOptions{
 			Serializer: commonnexus.PayloadSerializer,
 		})
-		err = client.CompleteOperation(env.Context(), publicCallbackURL, completion)
+		err = client.CompleteOperation(s.Context(), publicCallbackURL, completion)
 		completionRequests := capture.Metric("nexus_completion_requests")
 		var handlerErr *nexus.HandlerError
 		s.ErrorAs(err, &handlerErr)
@@ -1796,7 +1796,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAuthErrors(cha
 
 	publicCallbackURL := "http://" + env.HttpAPIAddress() + "/" + commonnexus.RouteCompletionCallback.Path(env.Namespace().String())
 	capture := env.StartNamespaceMetricCapture()
-	err = s.sendNexusCompletionRequest(env.Context(), publicCallbackURL, completion)
+	err = s.sendNexusCompletionRequest(s.Context(), publicCallbackURL, completion)
 	completionRequests := capture.Metric("nexus_completion_requests")
 	var handlerErr *nexus.HandlerError
 	s.ErrorAs(err, &handlerErr)
@@ -1826,7 +1826,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAuthErrorsNoId
 	}
 	publicCallbackURL := "http://" + env.HttpAPIAddress() + commonnexus.PathCompletionCallbackNoIdentifier
 	capture := env.StartNamespaceMetricCapture()
-	err = s.sendNexusCompletionRequest(env.Context(), publicCallbackURL, completion)
+	err = s.sendNexusCompletionRequest(s.Context(), publicCallbackURL, completion)
 	completionRequests := capture.Metric("nexus_completion_requests")
 	var handlerErr *nexus.HandlerError
 	s.ErrorAs(err, &handlerErr)
@@ -1845,7 +1845,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionInternalAuth(c
 		nexusoperations.CallbackURLTemplate,
 		"http://INTERNAL/namespaces/{{.NamespaceName}}/nexus/callback")
 
-	ctx := env.Context()
+	ctx := s.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
@@ -1918,7 +1918,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelBeforeStarted_Cancelati
 		s.T().Skip("Blocked on CHASM Nexus cancellation before start support")
 	}
 	env := s.newTestEnv(chasmEnabled)
-	ctx := env.Context()
+	ctx := s.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 
 	canStartCh := make(chan struct{})
@@ -1990,7 +1990,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAfterReset(cha
 		s.T().Skip("Blocked on CHASM Nexus async completion after reset support")
 	}
 	env := s.newTestEnv(chasmEnabled)
-	ctx := env.Context()
+	ctx := s.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 
 	var callbackToken, publicCallbackUrl string
@@ -2591,7 +2591,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncNexusFailure(chasmEnabled
 			}
 		},
 	}
-	endpointName := env.createRandomExternalNexusServer(env.Context(), s.T(), h)
+	endpointName := env.createRandomExternalNexusServer(s.Context(), s.T(), h)
 
 	w := worker.New(
 		env.SdkClient(),
@@ -2610,11 +2610,11 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncNexusFailure(chasmEnabled
 	s.T().Cleanup(w.Stop)
 
 	capture := env.StartNamespaceMetricCapture()
-	run, err := env.SdkClient().ExecuteWorkflow(env.Context(), client.StartWorkflowOptions{
+	run, err := env.SdkClient().ExecuteWorkflow(s.Context(), client.StartWorkflowOptions{
 		TaskQueue: taskQueue,
 	}, callerWF)
 	s.NoError(err)
-	wfErr := run.Get(env.Context(), nil)
+	wfErr := run.Get(s.Context(), nil)
 
 	var handlerErr *nexus.HandlerError
 	s.ErrorAs(wfErr, &handlerErr)
@@ -2863,7 +2863,7 @@ func (s *NexusWorkflowTestSuite) TestNexusAsyncOperationWithMultipleCallers(chas
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationScheduleToCloseTimeout(chasmEnabled bool) {
 	env := s.newTestEnv(chasmEnabled)
-	ctx := env.Context()
+	ctx := s.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
@@ -2936,7 +2936,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationScheduleToCloseTimeout(chasmE
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationScheduleToStartTimeout(chasmEnabled bool) {
 	env := s.newTestEnv(chasmEnabled)
-	ctx := env.Context()
+	ctx := s.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
@@ -3030,7 +3030,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationScheduleToStartTimeout(chasmE
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationStartToCloseTimeout(chasmEnabled bool) {
 	env := s.newTestEnv(chasmEnabled)
-	ctx := env.Context()
+	ctx := s.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 
 	// Handler that starts quickly (returns async) but never completes
@@ -3179,7 +3179,7 @@ func (s *NexusWorkflowTestSuite) sendNexusCompletionRequest(
 // __temporal_system endpoint.
 func (s *NexusWorkflowTestSuite) TestNexusOperationSystemEndpoint(chasmEnabled bool) {
 	env := s.newTestEnv(chasmEnabled)
-	ctx := env.Context()
+	ctx := s.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 
 	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{

--- a/tests/nexus_workflow_update_test.go
+++ b/tests/nexus_workflow_update_test.go
@@ -270,7 +270,7 @@ func (s *NexusWorkflowUpdateTestSuite) assertReappliedUpdateInNewRun(ctx context
 
 func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateAsyncNexusOperation() {
 	env := newNexusTestEnv(s.T(), true, enableUpdateCallbacksOpts()...)
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	cfg := newUpdateNexusTestConfig(s.T())
 
 	h := makeUpdateWithCallbackHandler(env, s.T(), cfg, nil)
@@ -326,7 +326,7 @@ func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateAsyncNexusOperation() {
 
 func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateAsyncAttachedNexusOperation() {
 	env := newNexusTestEnv(s.T(), true, enableUpdateCallbacksOpts()...)
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	cfg := newUpdateNexusTestConfig(s.T())
 
 	h := makeUpdateWithCallbackHandler(env, s.T(), cfg, nil)
@@ -388,7 +388,7 @@ func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateAsyncAttachedNexusOpera
 // The child workflow should only have one update callback (from the first request).
 func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateNoCallbackAttachedOnAlreadyCompletedUpdate() {
 	env := newNexusTestEnv(s.T(), true, enableUpdateCallbacksOpts()...)
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	cfg := newUpdateNexusTestConfig(s.T())
 	cfg.updateID = "already-completed-update-id"
 
@@ -497,7 +497,7 @@ func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateNoCallbackAttachedOnAlr
 // returns update-level callbacks after an update with callbacks is sent.
 func (s *NexusWorkflowUpdateTestSuite) TestDescribeWorkflowShowsUpdateCallbacks() {
 	env := newNexusTestEnv(s.T(), true, enableUpdateCallbacksOpts()...)
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 	updateID := "describe-callback-update-id"
 	callbackURL := "http://localhost:9999/callback"
@@ -593,7 +593,7 @@ func (s *NexusWorkflowUpdateTestSuite) TestDescribeWorkflowShowsUpdateCallbacks(
 // the update is reapplied in the new run and the callback fires when the update completes.
 func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackAfterResetInflightUpdate() {
 	env := newNexusTestEnv(s.T(), true, enableUpdateCallbacksOpts()...)
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	cfg := newUpdateNexusTestConfig(s.T())
 
 	h := makeUpdateWithCallbackHandler(env, s.T(), cfg, nil)
@@ -674,7 +674,7 @@ func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackAfterResetInfli
 // completion callback fires with a failure and the caller's nexus operation fails.
 func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackAfterResetRejectedUpdate() {
 	env := newNexusTestEnv(s.T(), true, enableUpdateCallbacksOpts()...)
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	cfg := newUpdateNexusTestConfig(s.T())
 
 	h := makeUpdateWithCallbackHandler(env, s.T(), cfg, nil)
@@ -772,7 +772,7 @@ func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackAfterResetRejec
 // receives the result via the AttachCallbacks path.
 func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackAfterResetCompletedUpdate() {
 	env := newNexusTestEnv(s.T(), true, enableUpdateCallbacksOpts()...)
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	cfg := newUpdateNexusTestConfig(s.T())
 	cfg.updateID = "reset-completed-update-id"
 
@@ -858,7 +858,7 @@ func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackAfterResetCompl
 // (instead of starting an async operation with callbacks).
 func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateSyncReturnForCompletedWorkflow() {
 	env := newNexusTestEnv(s.T(), true, enableUpdateCallbacksOpts()...)
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	cfg := newUpdateNexusTestConfig(s.T())
 	cfg.updateID = "sync-return-completed-wf-update-id"
 
@@ -921,7 +921,7 @@ func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateSyncReturnForCompletedW
 // the caller's nexus operation completes with a failure.
 func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackOnFailedUpdate() {
 	env := newNexusTestEnv(s.T(), true, enableUpdateCallbacksOpts()...)
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	cfg := newUpdateNexusTestConfig(s.T())
 	cfg.updateID = "failed-update-id"
 
@@ -980,7 +980,7 @@ func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackOnFailedUpdate(
 // nexus operation completes.
 func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackOnWorkflowTerminate() {
 	env := newNexusTestEnv(s.T(), true, enableUpdateCallbacksOpts()...)
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	cfg := newUpdateNexusTestConfig(s.T())
 	cfg.updateID = "terminate-update-id"
 
@@ -1045,7 +1045,7 @@ func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackOnWorkflowTermi
 // This exercises mutable_state_impl.go processCloseCallbacksChasm -> wf.ProcessCloseCallbacks.
 func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackOnWorkflowComplete() {
 	env := newNexusTestEnv(s.T(), true, enableUpdateCallbacksOpts()...)
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	cfg := newUpdateNexusTestConfig(s.T())
 	cfg.updateID = "complete-wf-update-id"
 
@@ -1097,7 +1097,7 @@ func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackOnWorkflowCompl
 // completes with a failure (the old run is closed).
 func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackOnWorkflowContinueAsNew() {
 	env := newNexusTestEnv(s.T(), true, enableUpdateCallbacksOpts()...)
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	cfg := newUpdateNexusTestConfig(s.T())
 	cfg.updateID = "continue-as-new-update-id"
 
@@ -1162,7 +1162,7 @@ func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackOnWorkflowConti
 // and the caller's nexus operation completes with a failure (the old run is closed).
 func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackOnWorkflowFailedWithRetry() {
 	env := newNexusTestEnv(s.T(), true, enableUpdateCallbacksOpts()...)
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	cfg := newUpdateNexusTestConfig(s.T())
 	cfg.updateID = "failed-retry-update-id"
 
@@ -1233,7 +1233,7 @@ func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackOnWorkflowFaile
 // caller. This tests the proper handling of rejection in the callback flow.
 func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackOnRejectedUpdate() {
 	env := newNexusTestEnv(s.T(), true, enableUpdateCallbacksOpts()...)
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	cfg := newUpdateNexusTestConfig(s.T())
 	cfg.updateID = "rejected-update-id"
 
@@ -1299,7 +1299,7 @@ func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackOnRejectedUpdat
 // a RequestId, it is preserved in the WorkflowExecutionUpdateAccepted event's AcceptedRequest.
 func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateRequestIDInAcceptedEvent() {
 	env := newNexusTestEnv(s.T(), true, enableUpdateCallbacksOpts()...)
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 	updateID := "request-id-accepted-test"
 	requestID := uuid.NewString()

--- a/tests/nexus_workflow_update_test.go
+++ b/tests/nexus_workflow_update_test.go
@@ -204,7 +204,7 @@ func (s *NexusWorkflowUpdateTestSuite) newSimpleCallerWF(endpointName, childWfID
 // awaitUpdateAccepted polls the workflow history until a WorkflowExecutionUpdateAccepted
 // event is found, failing the test if it does not appear within 10 seconds.
 func (s *NexusWorkflowUpdateTestSuite) awaitUpdateAccepted(ctx context.Context, env *NexusTestEnv, workflowID, runID string) {
-	await.Require(env.Context(), s.T(), func(t *await.T) {
+	await.Require(s.Context(), s.T(), func(t *await.T) {
 		hist := env.SdkClient().GetWorkflowHistory(ctx, workflowID, runID, false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
 		for hist.HasNext() {
 			event, err := hist.Next()
@@ -562,7 +562,7 @@ func (s *NexusWorkflowUpdateTestSuite) TestDescribeWorkflowShowsUpdateCallbacks(
 	}()
 
 	// Wait until the update is accepted by checking DescribeWorkflowExecution.
-	await.Require(env.Context(), s.T(), func(t *await.T) {
+	await.Require(s.Context(), s.T(), func(t *await.T) {
 		desc, err := env.SdkClient().DescribeWorkflowExecution(ctx, run.GetID(), run.GetRunID())
 		require.NoError(t, err)
 		require.NotNil(t, desc.GetCallbacks(), "callbacks should be present")
@@ -823,7 +823,7 @@ func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackAfterResetCompl
 
 	// The update is reapplied and completes again in the new run.
 	// Wait for the update to complete in the new run before sending the second operation.
-	await.Require(env.Context(), s.T(), func(t *await.T) {
+	await.Require(s.Context(), s.T(), func(t *await.T) {
 		hist := env.SdkClient().GetWorkflowHistory(ctx, cfg.childWfID, resetResp.RunId, false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
 		for hist.HasNext() {
 			event, err := hist.Next()

--- a/tests/pause_workflow_execution_test.go
+++ b/tests/pause_workflow_execution_test.go
@@ -62,18 +62,18 @@ func (s *PauseWorkflowExecutionSuite) newTestEnv(opts ...testcore.TestOption) *p
 	baseOpts := []testcore.TestOption{
 		testcore.WithDynamicConfig(dynamicconfig.WorkflowPauseEnabled, true),
 	}
-	testEnv := testcore.NewEnv(s.T(), append(baseOpts, opts...)...)
+	env := testcore.NewEnv(s.T(), append(baseOpts, opts...)...)
 
-	env := &pauseWorkflowExecutionEnv{
-		TestEnv:             testEnv,
+	pauseEnv := &pauseWorkflowExecutionEnv{
+		TestEnv:             env,
 		testEndSignal:       "test-end",
 		pauseIdentity:       "functional-test",
 		pauseReason:         "pausing workflow for acceptance test",
 		activityCompletedCh: make(chan struct{}, 1),
 	}
 
-	env.workflowFn = func(ctx workflow.Context) (string, error) {
-		env.Logger.Debug("workflow started")
+	pauseEnv.workflowFn = func(ctx workflow.Context) (string, error) {
+		pauseEnv.Logger.Debug("workflow started")
 		ao := workflow.ActivityOptions{
 			StartToCloseTimeout:    5 * time.Second,
 			ScheduleToCloseTimeout: 10 * time.Second,
@@ -81,49 +81,49 @@ func (s *PauseWorkflowExecutionSuite) newTestEnv(opts ...testcore.TestOption) *p
 		ctx = workflow.WithActivityOptions(ctx, ao)
 
 		var activityResult string
-		env.Logger.Debug("executing activity")
-		if err := workflow.ExecuteActivity(ctx, env.activityFn).Get(ctx, &activityResult); err != nil {
+		pauseEnv.Logger.Debug("executing activity")
+		if err := workflow.ExecuteActivity(ctx, pauseEnv.activityFn).Get(ctx, &activityResult); err != nil {
 			return "", err
 		}
 
 		var childResult string
-		env.Logger.Debug("executing child workflow")
-		if err := workflow.ExecuteChildWorkflow(ctx, env.childWorkflowFn).Get(ctx, &childResult); err != nil {
+		pauseEnv.Logger.Debug("executing child workflow")
+		if err := workflow.ExecuteChildWorkflow(ctx, pauseEnv.childWorkflowFn).Get(ctx, &childResult); err != nil {
 			return "", err
 		}
 
-		env.Logger.Debug("waiting to receive signal to complete the workflow")
-		signalCh := workflow.GetSignalChannel(ctx, env.testEndSignal)
+		pauseEnv.Logger.Debug("waiting to receive signal to complete the workflow")
+		signalCh := workflow.GetSignalChannel(ctx, pauseEnv.testEndSignal)
 		var signalPayload string
 		signalCh.Receive(ctx, &signalPayload)
-		env.Logger.Debug("signal received to complete the workflow")
+		pauseEnv.Logger.Debug("signal received to complete the workflow")
 		return signalPayload + activityResult + childResult, nil
 	}
 
-	env.childWorkflowFn = func(ctx workflow.Context) (string, error) {
+	pauseEnv.childWorkflowFn = func(ctx workflow.Context) (string, error) {
 		return "child-workflow", nil
 	}
 
-	env.activityFn = func(ctx context.Context) (string, error) {
-		env.Logger.Debug("activity started")
-		env.activityCompletedOnce.Do(func() {
+	pauseEnv.activityFn = func(ctx context.Context) (string, error) {
+		pauseEnv.Logger.Debug("activity started")
+		pauseEnv.activityCompletedOnce.Do(func() {
 			// blocks until the test case unblocks the activity.
-			<-env.activityCompletedCh
+			<-pauseEnv.activityCompletedCh
 		})
-		env.Logger.Debug("activity completed")
+		pauseEnv.Logger.Debug("activity completed")
 		return "activity", nil
 	}
 
-	env.SdkWorker().RegisterWorkflow(env.workflowFn)
-	env.SdkWorker().RegisterWorkflow(env.childWorkflowFn)
-	env.SdkWorker().RegisterActivity(env.activityFn)
+	pauseEnv.SdkWorker().RegisterWorkflow(pauseEnv.workflowFn)
+	pauseEnv.SdkWorker().RegisterWorkflow(pauseEnv.childWorkflowFn)
+	pauseEnv.SdkWorker().RegisterActivity(pauseEnv.activityFn)
 
 	// Setup for TestPauseWorkflowAndActivity
-	env.activityShouldSucceed.Store(false)
-	env.SdkWorker().RegisterWorkflow(env.workflowWithFailingActivity)
-	env.SdkWorker().RegisterActivity(env.failingActivity)
+	pauseEnv.activityShouldSucceed.Store(false)
+	pauseEnv.SdkWorker().RegisterWorkflow(pauseEnv.workflowWithFailingActivity)
+	pauseEnv.SdkWorker().RegisterActivity(pauseEnv.failingActivity)
 
-	return env
+	return pauseEnv
 }
 
 // failingActivity is an activity that fails until activityShouldSucceed is set to true.

--- a/tests/pause_workflow_execution_test.go
+++ b/tests/pause_workflow_execution_test.go
@@ -62,18 +62,18 @@ func (s *PauseWorkflowExecutionSuite) newTestEnv(opts ...testcore.TestOption) *p
 	baseOpts := []testcore.TestOption{
 		testcore.WithDynamicConfig(dynamicconfig.WorkflowPauseEnabled, true),
 	}
-	env := testcore.NewEnv(s.T(), append(baseOpts, opts...)...)
+	testEnv := testcore.NewEnv(s.T(), append(baseOpts, opts...)...)
 
-	pauseEnv := &pauseWorkflowExecutionEnv{
-		TestEnv:             env,
+	env := &pauseWorkflowExecutionEnv{
+		TestEnv:             testEnv,
 		testEndSignal:       "test-end",
 		pauseIdentity:       "functional-test",
 		pauseReason:         "pausing workflow for acceptance test",
 		activityCompletedCh: make(chan struct{}, 1),
 	}
 
-	pauseEnv.workflowFn = func(ctx workflow.Context) (string, error) {
-		pauseEnv.Logger.Debug("workflow started")
+	env.workflowFn = func(ctx workflow.Context) (string, error) {
+		env.Logger.Debug("workflow started")
 		ao := workflow.ActivityOptions{
 			StartToCloseTimeout:    5 * time.Second,
 			ScheduleToCloseTimeout: 10 * time.Second,
@@ -81,49 +81,49 @@ func (s *PauseWorkflowExecutionSuite) newTestEnv(opts ...testcore.TestOption) *p
 		ctx = workflow.WithActivityOptions(ctx, ao)
 
 		var activityResult string
-		pauseEnv.Logger.Debug("executing activity")
-		if err := workflow.ExecuteActivity(ctx, pauseEnv.activityFn).Get(ctx, &activityResult); err != nil {
+		env.Logger.Debug("executing activity")
+		if err := workflow.ExecuteActivity(ctx, env.activityFn).Get(ctx, &activityResult); err != nil {
 			return "", err
 		}
 
 		var childResult string
-		pauseEnv.Logger.Debug("executing child workflow")
-		if err := workflow.ExecuteChildWorkflow(ctx, pauseEnv.childWorkflowFn).Get(ctx, &childResult); err != nil {
+		env.Logger.Debug("executing child workflow")
+		if err := workflow.ExecuteChildWorkflow(ctx, env.childWorkflowFn).Get(ctx, &childResult); err != nil {
 			return "", err
 		}
 
-		pauseEnv.Logger.Debug("waiting to receive signal to complete the workflow")
-		signalCh := workflow.GetSignalChannel(ctx, pauseEnv.testEndSignal)
+		env.Logger.Debug("waiting to receive signal to complete the workflow")
+		signalCh := workflow.GetSignalChannel(ctx, env.testEndSignal)
 		var signalPayload string
 		signalCh.Receive(ctx, &signalPayload)
-		pauseEnv.Logger.Debug("signal received to complete the workflow")
+		env.Logger.Debug("signal received to complete the workflow")
 		return signalPayload + activityResult + childResult, nil
 	}
 
-	pauseEnv.childWorkflowFn = func(ctx workflow.Context) (string, error) {
+	env.childWorkflowFn = func(ctx workflow.Context) (string, error) {
 		return "child-workflow", nil
 	}
 
-	pauseEnv.activityFn = func(ctx context.Context) (string, error) {
-		pauseEnv.Logger.Debug("activity started")
-		pauseEnv.activityCompletedOnce.Do(func() {
+	env.activityFn = func(ctx context.Context) (string, error) {
+		env.Logger.Debug("activity started")
+		env.activityCompletedOnce.Do(func() {
 			// blocks until the test case unblocks the activity.
-			<-pauseEnv.activityCompletedCh
+			<-env.activityCompletedCh
 		})
-		pauseEnv.Logger.Debug("activity completed")
+		env.Logger.Debug("activity completed")
 		return "activity", nil
 	}
 
-	pauseEnv.SdkWorker().RegisterWorkflow(pauseEnv.workflowFn)
-	pauseEnv.SdkWorker().RegisterWorkflow(pauseEnv.childWorkflowFn)
-	pauseEnv.SdkWorker().RegisterActivity(pauseEnv.activityFn)
+	env.SdkWorker().RegisterWorkflow(env.workflowFn)
+	env.SdkWorker().RegisterWorkflow(env.childWorkflowFn)
+	env.SdkWorker().RegisterActivity(env.activityFn)
 
 	// Setup for TestPauseWorkflowAndActivity
-	pauseEnv.activityShouldSucceed.Store(false)
-	pauseEnv.SdkWorker().RegisterWorkflow(pauseEnv.workflowWithFailingActivity)
-	pauseEnv.SdkWorker().RegisterActivity(pauseEnv.failingActivity)
+	env.activityShouldSucceed.Store(false)
+	env.SdkWorker().RegisterWorkflow(env.workflowWithFailingActivity)
+	env.SdkWorker().RegisterActivity(env.failingActivity)
 
-	return pauseEnv
+	return env
 }
 
 // failingActivity is an activity that fails until activityShouldSucceed is set to true.

--- a/tests/premature_eos_test.go
+++ b/tests/premature_eos_test.go
@@ -80,7 +80,7 @@ func (s *PrematureEosTestSuite) Test_SpeculativeWFTEventsLostAfterSignalMidHisto
 	s.NoError(err)
 
 	// Send an update to create a speculative WFT (event 8 in memory, scheduled but not polled).
-	ctx, cancel := context.WithCancel(testcore.NewContext())
+	ctx, cancel := context.WithCancel(s.Context())
 	defer cancel()
 	updateCh := sendUpdate(ctx, env, tv)
 	defer func() { go func() { <-updateCh }() }()
@@ -111,7 +111,7 @@ func (s *PrematureEosTestSuite) Test_SpeculativeWFTEventsLostAfterSignalMidHisto
 	// the next page. The continuation token encodes NextEventId=8 and PersistenceToken
 	// pointing to the next DB batch — this is the "stale token" that exercises the bug.
 	histPage1, err := env.FrontendClient().GetWorkflowExecutionHistory(
-		testcore.NewContext(),
+		s.Context(),
 		&workflowservice.GetWorkflowExecutionHistoryRequest{
 			Namespace:       env.Namespace().String(),
 			Execution:       wfExecution,
@@ -131,7 +131,7 @@ func (s *PrematureEosTestSuite) Test_SpeculativeWFTEventsLostAfterSignalMidHisto
 	//   8: WorkflowTaskScheduled  (normal WFT scheduled to handle the pending update)
 	//   9: WorkflowExecutionSignaled  (flushed immediately: HasStartedWorkflowTask=false)
 	// After this transaction, freshNextEventId=10.
-	_, signalErr := env.FrontendClient().SignalWorkflowExecution(testcore.NewContext(),
+	_, signalErr := env.FrontendClient().SignalWorkflowExecution(s.Context(),
 		&workflowservice.SignalWorkflowExecutionRequest{
 			Namespace:         env.Namespace().String(),
 			WorkflowExecution: wfExecution,
@@ -143,7 +143,7 @@ func (s *PrematureEosTestSuite) Test_SpeculativeWFTEventsLostAfterSignalMidHisto
 	allEvents := make([]*historypb.HistoryEvent, len(firstPageEvents))
 	copy(allEvents, firstPageEvents)
 	for nextPageToken := staleNextPageToken; nextPageToken != nil; {
-		histResp, histErr := env.FrontendClient().GetWorkflowExecutionHistory(testcore.NewContext(),
+		histResp, histErr := env.FrontendClient().GetWorkflowExecutionHistory(s.Context(),
 			&workflowservice.GetWorkflowExecutionHistoryRequest{
 				Namespace:       env.Namespace().String(),
 				Execution:       wfExecution,

--- a/tests/query_workflow_test.go
+++ b/tests/query_workflow_test.go
@@ -373,7 +373,7 @@ func (s *QueryWorkflowSuite) TestQueryWorkflow_NonStickyMultiPageHistory() {
 
 	tq := env.WorkerTaskQueue()
 	id := "test-query-non-sticky-multi-page"
-	ctx, cancel := context.WithTimeout(env.Context(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(s.Context(), 30*time.Second)
 	defer cancel()
 
 	queryWorker := worker.New(env.SdkClient(), tq, worker.Options{})
@@ -444,7 +444,7 @@ func (s *QueryWorkflowSuite) TestQueryWorkflow_NonStickyMultiPageHistory() {
 
 func (s *QueryWorkflowSuite) TestQueryWorkflow_FailurePropagated() {
 	env := testcore.NewEnv(s.T())
-	ctx := env.Context()
+	ctx := s.Context()
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 
 	workflowRun, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{TaskQueue: taskQueue}, "workflow")

--- a/tests/schedule_migration_test.go
+++ b/tests/schedule_migration_test.go
@@ -53,7 +53,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2AlreadyExists() {
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 	)
 
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	sid := testcore.RandomizeStr("sched-migrate-v2-exists")
 	wid := testcore.RandomizeStr("sched-migrate-v2-exists-wf")
 	wt := testcore.RandomizeStr("sched-migrate-v2-exists-wt")
@@ -215,7 +215,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1BlockedBySentine
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 	)
 
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	sid := testcore.RandomizeStr("sched-migrate-v2-to-v1-sentinel")
 	wid := testcore.RandomizeStr("sched-migrate-v2-to-v1-sentinel-wf")
 	wt := testcore.RandomizeStr("sched-migrate-v2-to-v1-sentinel-wt")
@@ -295,7 +295,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationDynamicConfig() {
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerMigration, true),
 	)
 
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	sid := testcore.RandomizeStr("sched-migrate-dc")
 	wid := testcore.RandomizeStr("sched-migrate-dc-wf")
 	wt := testcore.RandomizeStr("sched-migrate-dc-wt")
@@ -403,7 +403,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2() {
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 	)
 
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	sid := testcore.RandomizeStr("sched-migrate-v1-to-v2")
 	wid := testcore.RandomizeStr("sched-migrate-v1-to-v2-wf")
 	wt := testcore.RandomizeStr("sched-migrate-v1-to-v2-wt")
@@ -541,7 +541,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1() {
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerRouting, false),
 	)
 
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	sid := testcore.RandomizeStr("sched-migrate-v2-to-v1")
 	wid := testcore.RandomizeStr("sched-migrate-v2-to-v1-wf")
 	wt := testcore.RandomizeStr("sched-migrate-v2-to-v1-wt")
@@ -747,7 +747,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1Idempotent() {
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerRouting, false),
 	)
 
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	sid := testcore.RandomizeStr("sched-migrate-v2-to-v1-idem")
 	wid := testcore.RandomizeStr("sched-migrate-v2-to-v1-idem-wf")
 	wt := testcore.RandomizeStr("sched-migrate-v2-to-v1-idem-wt")
@@ -818,7 +818,7 @@ func (s *ScheduleMigrationTestSuite) TestCHASMScheduleDescribeAfterDisablingCrea
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerRouting, true),
 	)
 
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	nsName := env.Namespace().String()
 	nsID := env.NamespaceID().String()
 	sid := testcore.RandomizeStr("sched-routing-after-disable")
@@ -918,7 +918,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1RoutingFallback(
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerRouting, true),
 	)
 
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	sid := testcore.RandomizeStr("sched-v2-to-v1-routing")
 	wid := testcore.RandomizeStr("sched-v2-to-v1-routing-wf")
 	wt := testcore.RandomizeStr("sched-v2-to-v1-routing-wt")
@@ -1053,7 +1053,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleUpdateAfterDelete() {
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerRouting, true),
 	)
 
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	sid := testcore.RandomizeStr("sched-update-after-delete")
 	wid := testcore.RandomizeStr("sched-update-after-delete-wf")
 	wt := testcore.RandomizeStr("sched-update-after-delete-wt")
@@ -1161,7 +1161,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2WithClosedV2() {
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 	)
 
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	sid := testcore.RandomizeStr("sched-migrate-v1-v2-closed")
 	wid := testcore.RandomizeStr("sched-migrate-v1-v2-closed-wf")
 	wt := testcore.RandomizeStr("sched-migrate-v1-v2-closed-wt")
@@ -1629,7 +1629,7 @@ func (s *ScheduleMigrationTestSuite) TestDeleteScheduleContextMetadata() {
 
 	createCHASMSchedule := func(t *testing.T, sid string, sched *schedulepb.Schedule) {
 		_, err := env.GetTestCluster().SchedulerClient().CreateSchedule(
-			testcore.NewContext(),
+			s.Context(),
 			&schedulerpb.CreateScheduleRequest{
 				NamespaceId: env.NamespaceID().String(),
 				FrontendRequest: &workflowservice.CreateScheduleRequest{
@@ -1646,7 +1646,7 @@ func (s *ScheduleMigrationTestSuite) TestDeleteScheduleContextMetadata() {
 
 	createCHASMSentinel := func(t *testing.T, sid string) {
 		_, err := env.GetTestCluster().SchedulerClient().CreateSentinel(
-			testcore.NewContext(),
+			s.Context(),
 			&schedulerpb.CreateSentinelRequest{
 				NamespaceId: env.NamespaceID().String(),
 				Namespace:   env.Namespace().String(),
@@ -1669,7 +1669,7 @@ func (s *ScheduleMigrationTestSuite) TestDeleteScheduleContextMetadata() {
 		inputPayloads, err := sdk.PreferProtoDataConverter.ToPayloads(startArgs)
 		require.NoError(t, err)
 		_, err = env.GetTestCluster().HistoryClient().StartWorkflowExecution(
-			testcore.NewContext(),
+			s.Context(),
 			common.CreateHistoryStartWorkflowRequest(
 				env.NamespaceID().String(),
 				&workflowservice.StartWorkflowExecutionRequest{
@@ -1691,7 +1691,7 @@ func (s *ScheduleMigrationTestSuite) TestDeleteScheduleContextMetadata() {
 
 	createV1DummySentinel := func(t *testing.T, sid string) {
 		_, err := env.GetTestCluster().HistoryClient().StartWorkflowExecution(
-			testcore.NewContext(),
+			s.Context(),
 			common.CreateHistoryStartWorkflowRequest(
 				env.NamespaceID().String(),
 				&workflowservice.StartWorkflowExecutionRequest{
@@ -1713,7 +1713,7 @@ func (s *ScheduleMigrationTestSuite) TestDeleteScheduleContextMetadata() {
 	deleteAndAssertMetadata := func(t *testing.T, sid, expectedWfType, expectedTQ string) {
 		var trailer metadata.MD
 		_, err := env.FrontendClient().DeleteSchedule(
-			testcore.NewContext(),
+			s.Context(),
 			&workflowservice.DeleteScheduleRequest{
 				Namespace:  env.Namespace().String(),
 				ScheduleId: sid,
@@ -1765,7 +1765,7 @@ func (s *ScheduleMigrationTestSuite) TestDeleteScheduleContextMetadata() {
 		sid := testcore.RandomizeStr("sid")
 		createCHASMSentinel(s.T(), sid)
 		_, err := env.FrontendClient().DeleteSchedule(
-			testcore.NewContext(),
+			s.Context(),
 			&workflowservice.DeleteScheduleRequest{
 				Namespace:  env.Namespace().String(),
 				ScheduleId: sid,
@@ -1782,7 +1782,7 @@ func (s *ScheduleMigrationTestSuite) TestDeleteScheduleContextMetadata() {
 	s.Run("NeitherStack", func(s *ScheduleMigrationTestSuite) {
 		sid := testcore.RandomizeStr("nonexistent")
 		_, err := env.FrontendClient().DeleteSchedule(
-			testcore.NewContext(),
+			s.Context(),
 			&workflowservice.DeleteScheduleRequest{
 				Namespace:  env.Namespace().String(),
 				ScheduleId: sid,
@@ -1832,7 +1832,7 @@ func (s *ScheduleMigrationTestSuite) TestPatchScheduleContextMetadata() {
 
 	createCHASMSchedule := func(t *testing.T, sid string, sched *schedulepb.Schedule) {
 		_, err := env.GetTestCluster().SchedulerClient().CreateSchedule(
-			testcore.NewContext(),
+			s.Context(),
 			&schedulerpb.CreateScheduleRequest{
 				NamespaceId: env.NamespaceID().String(),
 				FrontendRequest: &workflowservice.CreateScheduleRequest{
@@ -1860,7 +1860,7 @@ func (s *ScheduleMigrationTestSuite) TestPatchScheduleContextMetadata() {
 		inputPayloads, err := sdk.PreferProtoDataConverter.ToPayloads(startArgs)
 		require.NoError(t, err)
 		_, err = env.GetTestCluster().HistoryClient().StartWorkflowExecution(
-			testcore.NewContext(),
+			s.Context(),
 			common.CreateHistoryStartWorkflowRequest(
 				env.NamespaceID().String(),
 				&workflowservice.StartWorkflowExecutionRequest{
@@ -1883,7 +1883,7 @@ func (s *ScheduleMigrationTestSuite) TestPatchScheduleContextMetadata() {
 	patchAndAssertMetadata := func(t *testing.T, sid, expectedWfType, expectedTQ string) {
 		var trailer metadata.MD
 		_, err := env.FrontendClient().PatchSchedule(
-			testcore.NewContext(),
+			s.Context(),
 			&workflowservice.PatchScheduleRequest{
 				Namespace:  env.Namespace().String(),
 				ScheduleId: sid,
@@ -1918,7 +1918,7 @@ func (s *ScheduleMigrationTestSuite) TestPatchScheduleContextMetadata() {
 	s.Run("CHASMSentinel_V1Gone", func(s *ScheduleMigrationTestSuite) {
 		sid := testcore.RandomizeStr("sid")
 		_, err := env.GetTestCluster().SchedulerClient().CreateSentinel(
-			testcore.NewContext(),
+			s.Context(),
 			&schedulerpb.CreateSentinelRequest{
 				NamespaceId: env.NamespaceID().String(),
 				Namespace:   env.Namespace().String(),
@@ -1928,7 +1928,7 @@ func (s *ScheduleMigrationTestSuite) TestPatchScheduleContextMetadata() {
 		s.NoError(err)
 
 		_, err = env.FrontendClient().PatchSchedule(
-			testcore.NewContext(),
+			s.Context(),
 			&workflowservice.PatchScheduleRequest{
 				Namespace:  env.Namespace().String(),
 				ScheduleId: sid,
@@ -2116,7 +2116,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationRolloutPercent() {
 		testcore.WithDynamicConfig(dynamicconfig.CHASMSchedulerMigrationRolloutPercent, 50),
 	)
 
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 	nsName := env.Namespace().String()
 	nsID := env.NamespaceID().String()
 

--- a/tests/schedule_migration_test.go
+++ b/tests/schedule_migration_test.go
@@ -1627,7 +1627,7 @@ func (s *ScheduleMigrationTestSuite) TestDeleteScheduleContextMetadata() {
 		return
 	}
 
-	createCHASMSchedule := func(t *testing.T, sid string, sched *schedulepb.Schedule) {
+	createCHASMSchedule := func(s *ScheduleMigrationTestSuite, sid string, sched *schedulepb.Schedule) {
 		_, err := env.GetTestCluster().SchedulerClient().CreateSchedule(
 			s.Context(),
 			&schedulerpb.CreateScheduleRequest{
@@ -1641,10 +1641,10 @@ func (s *ScheduleMigrationTestSuite) TestDeleteScheduleContextMetadata() {
 				},
 			},
 		)
-		require.NoError(t, err)
+		s.NoError(err)
 	}
 
-	createCHASMSentinel := func(t *testing.T, sid string) {
+	createCHASMSentinel := func(s *ScheduleMigrationTestSuite, sid string) {
 		_, err := env.GetTestCluster().SchedulerClient().CreateSentinel(
 			s.Context(),
 			&schedulerpb.CreateSentinelRequest{
@@ -1653,10 +1653,10 @@ func (s *ScheduleMigrationTestSuite) TestDeleteScheduleContextMetadata() {
 				ScheduleId:  sid,
 			},
 		)
-		require.NoError(t, err)
+		s.NoError(err)
 	}
 
-	createV1Scheduler := func(t *testing.T, sid string, sched *schedulepb.Schedule) {
+	createV1Scheduler := func(s *ScheduleMigrationTestSuite, sid string, sched *schedulepb.Schedule) {
 		startArgs := &schedulespb.StartScheduleArgs{
 			Schedule: sched,
 			State: &schedulespb.InternalState{
@@ -1667,7 +1667,7 @@ func (s *ScheduleMigrationTestSuite) TestDeleteScheduleContextMetadata() {
 			},
 		}
 		inputPayloads, err := sdk.PreferProtoDataConverter.ToPayloads(startArgs)
-		require.NoError(t, err)
+		s.NoError(err)
 		_, err = env.GetTestCluster().HistoryClient().StartWorkflowExecution(
 			s.Context(),
 			common.CreateHistoryStartWorkflowRequest(
@@ -1686,10 +1686,10 @@ func (s *ScheduleMigrationTestSuite) TestDeleteScheduleContextMetadata() {
 				nil, nil, time.Now().UTC(),
 			),
 		)
-		require.NoError(t, err)
+		s.NoError(err)
 	}
 
-	createV1DummySentinel := func(t *testing.T, sid string) {
+	createV1DummySentinel := func(s *ScheduleMigrationTestSuite, sid string) {
 		_, err := env.GetTestCluster().HistoryClient().StartWorkflowExecution(
 			s.Context(),
 			common.CreateHistoryStartWorkflowRequest(
@@ -1707,10 +1707,10 @@ func (s *ScheduleMigrationTestSuite) TestDeleteScheduleContextMetadata() {
 				nil, nil, time.Now().UTC(),
 			),
 		)
-		require.NoError(t, err)
+		s.NoError(err)
 	}
 
-	deleteAndAssertMetadata := func(t *testing.T, sid, expectedWfType, expectedTQ string) {
+	deleteAndAssertMetadata := func(s *ScheduleMigrationTestSuite, sid, expectedWfType, expectedTQ string) {
 		var trailer metadata.MD
 		_, err := env.FrontendClient().DeleteSchedule(
 			s.Context(),
@@ -1721,49 +1721,49 @@ func (s *ScheduleMigrationTestSuite) TestDeleteScheduleContextMetadata() {
 			},
 			grpc.Trailer(&trailer),
 		)
-		require.NoError(t, err)
-		require.Equal(t, []string{expectedWfType}, trailer.Get("workflow-type"),
+		s.NoError(err)
+		s.Equal([]string{expectedWfType}, trailer.Get("workflow-type"),
 			"workflow-type should match the owning stack's metadata")
-		require.Equal(t, []string{expectedTQ}, trailer.Get("workflow-task-queue"),
+		s.Equal([]string{expectedTQ}, trailer.Get("workflow-task-queue"),
 			"workflow-task-queue should match the owning stack's metadata")
 	}
 
 	// Subtest: Both stacks have real entries. CHASM metadata wins.
 	s.Run("BothStacks", func(s *ScheduleMigrationTestSuite) {
 		sid, wt, tq, sched := newSched()
-		createCHASMSchedule(s.T(), sid, sched)
-		createV1Scheduler(s.T(), sid, sched)
-		deleteAndAssertMetadata(s.T(), sid, wt, tq)
+		createCHASMSchedule(s, sid, sched)
+		createV1Scheduler(s, sid, sched)
+		deleteAndAssertMetadata(s, sid, wt, tq)
 	})
 
 	// Subtest: CHASM has real schedule, V1 has dummy sentinel. CHASM metadata wins.
 	s.Run("CHASMOnly_V1Sentinel", func(s *ScheduleMigrationTestSuite) {
 		sid, wt, tq, sched := newSched()
-		createCHASMSchedule(s.T(), sid, sched)
-		createV1DummySentinel(s.T(), sid)
-		deleteAndAssertMetadata(s.T(), sid, wt, tq)
+		createCHASMSchedule(s, sid, sched)
+		createV1DummySentinel(s, sid)
+		deleteAndAssertMetadata(s, sid, wt, tq)
 	})
 
 	// Subtest: CHASM has sentinel, V1 has real scheduler. V1 metadata wins.
 	s.Run("CHASMSentinel_V1Real", func(s *ScheduleMigrationTestSuite) {
 		sid, _, _, sched := newSched()
-		createCHASMSentinel(s.T(), sid)
-		createV1Scheduler(s.T(), sid, sched)
-		deleteAndAssertMetadata(s.T(), sid, scheduler.WorkflowType, primitives.PerNSWorkerTaskQueue)
+		createCHASMSentinel(s, sid)
+		createV1Scheduler(s, sid, sched)
+		deleteAndAssertMetadata(s, sid, scheduler.WorkflowType, primitives.PerNSWorkerTaskQueue)
 	})
 
 	// Subtest: No CHASM entry, V1 has real scheduler. V1 metadata wins.
 	s.Run("V1Only_NoCHASM", func(s *ScheduleMigrationTestSuite) {
 		sid, _, _, sched := newSched()
-		createV1Scheduler(s.T(), sid, sched)
-		deleteAndAssertMetadata(s.T(), sid, scheduler.WorkflowType, primitives.PerNSWorkerTaskQueue)
+		createV1Scheduler(s, sid, sched)
+		deleteAndAssertMetadata(s, sid, scheduler.WorkflowType, primitives.PerNSWorkerTaskQueue)
 	})
 
 	// Subtest: CHASM has sentinel, V1 has nothing. Delete returns error.
 	// Metering skips error responses so metadata content is irrelevant.
 	s.Run("CHASMSentinel_V1Gone", func(s *ScheduleMigrationTestSuite) {
 		sid := testcore.RandomizeStr("sid")
-		createCHASMSentinel(s.T(), sid)
+		createCHASMSentinel(s, sid)
 		_, err := env.FrontendClient().DeleteSchedule(
 			s.Context(),
 			&workflowservice.DeleteScheduleRequest{
@@ -1830,7 +1830,7 @@ func (s *ScheduleMigrationTestSuite) TestPatchScheduleContextMetadata() {
 		return
 	}
 
-	createCHASMSchedule := func(t *testing.T, sid string, sched *schedulepb.Schedule) {
+	createCHASMSchedule := func(s *ScheduleMigrationTestSuite, sid string, sched *schedulepb.Schedule) {
 		_, err := env.GetTestCluster().SchedulerClient().CreateSchedule(
 			s.Context(),
 			&schedulerpb.CreateScheduleRequest{
@@ -1844,10 +1844,10 @@ func (s *ScheduleMigrationTestSuite) TestPatchScheduleContextMetadata() {
 				},
 			},
 		)
-		require.NoError(t, err)
+		s.NoError(err)
 	}
 
-	createV1Scheduler := func(t *testing.T, sid string, sched *schedulepb.Schedule) {
+	createV1Scheduler := func(s *ScheduleMigrationTestSuite, sid string, sched *schedulepb.Schedule) {
 		startArgs := &schedulespb.StartScheduleArgs{
 			Schedule: sched,
 			State: &schedulespb.InternalState{
@@ -1858,7 +1858,7 @@ func (s *ScheduleMigrationTestSuite) TestPatchScheduleContextMetadata() {
 			},
 		}
 		inputPayloads, err := sdk.PreferProtoDataConverter.ToPayloads(startArgs)
-		require.NoError(t, err)
+		s.NoError(err)
 		_, err = env.GetTestCluster().HistoryClient().StartWorkflowExecution(
 			s.Context(),
 			common.CreateHistoryStartWorkflowRequest(
@@ -1877,10 +1877,10 @@ func (s *ScheduleMigrationTestSuite) TestPatchScheduleContextMetadata() {
 				nil, nil, time.Now().UTC(),
 			),
 		)
-		require.NoError(t, err)
+		s.NoError(err)
 	}
 
-	patchAndAssertMetadata := func(t *testing.T, sid, expectedWfType, expectedTQ string) {
+	patchAndAssertMetadata := func(s *ScheduleMigrationTestSuite, sid, expectedWfType, expectedTQ string) {
 		var trailer metadata.MD
 		_, err := env.FrontendClient().PatchSchedule(
 			s.Context(),
@@ -1893,25 +1893,25 @@ func (s *ScheduleMigrationTestSuite) TestPatchScheduleContextMetadata() {
 			},
 			grpc.Trailer(&trailer),
 		)
-		require.NoError(t, err)
-		require.Equal(t, []string{expectedWfType}, trailer.Get("workflow-type"),
+		s.NoError(err)
+		s.Equal([]string{expectedWfType}, trailer.Get("workflow-type"),
 			"workflow-type should match the owning stack's metadata")
-		require.Equal(t, []string{expectedTQ}, trailer.Get("workflow-task-queue"),
+		s.Equal([]string{expectedTQ}, trailer.Get("workflow-task-queue"),
 			"workflow-task-queue should match the owning stack's metadata")
 	}
 
 	// CHASM schedule: metadata should reflect the schedule's action target.
 	s.Run("CHASMSchedule", func(s *ScheduleMigrationTestSuite) {
 		sid, wt, tq, sched := newSched()
-		createCHASMSchedule(s.T(), sid, sched)
-		patchAndAssertMetadata(s.T(), sid, wt, tq)
+		createCHASMSchedule(s, sid, sched)
+		patchAndAssertMetadata(s, sid, wt, tq)
 	})
 
 	// V1 schedule: metadata should reflect the V1 scheduler workflow.
 	s.Run("V1Schedule", func(s *ScheduleMigrationTestSuite) {
 		sid, _, _, sched := newSched()
-		createV1Scheduler(s.T(), sid, sched)
-		patchAndAssertMetadata(s.T(), sid, scheduler.WorkflowType, primitives.PerNSWorkerTaskQueue)
+		createV1Scheduler(s, sid, sched)
+		patchAndAssertMetadata(s, sid, scheduler.WorkflowType, primitives.PerNSWorkerTaskQueue)
 	})
 
 	// CHASM sentinel with no V1 workflow: patch should fail.

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -401,13 +401,13 @@ func runSharedScheduleTests(t *testing.T, newContext contextFactory) {
 // BUFFER_ONE keeps exactly one start in the buffer while the first workflow
 // is still running.
 func testBufferSizeReportedWhenBuffered(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-buffer-size")
 	wid := testcore.RandomizeStr("sched-buffer-size-wf")
 	wt := testcore.RandomizeStr("sched-buffer-size-wt")
 
-	s.SdkWorker().RegisterWorkflowWithOptions(
+	env.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error {
 			return workflow.Sleep(ctx, time.Hour)
 		},
@@ -425,7 +425,7 @@ func testBufferSizeReportedWhenBuffered(t *testing.T, newContext contextFactory)
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
@@ -434,20 +434,20 @@ func testBufferSizeReportedWhenBuffered(t *testing.T, newContext contextFactory)
 		},
 	}
 
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	ctx := newContext(env.Context())
+	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	var lastDescribe *workflowservice.DescribeScheduleResponse
-	s.Eventually(func() bool {
-		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  s.Namespace().String(),
+	env.Eventually(func() bool {
+		desc, descErr := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  env.Namespace().String(),
 			ScheduleId: sid,
 		})
 		if descErr != nil {
@@ -457,8 +457,8 @@ func testBufferSizeReportedWhenBuffered(t *testing.T, newContext contextFactory)
 		return desc.GetInfo().GetBufferSize() >= 1 && len(desc.GetInfo().GetRunningWorkflows()) >= 1
 	}, 30*time.Second, 500*time.Millisecond, "DescribeSchedule should report BufferSize >= 1 with a running workflow blocking the buffer")
 
-	s.GreaterOrEqual(lastDescribe.GetInfo().GetBufferSize(), int64(1), "BufferSize must reflect at least one buffered start")
-	s.GreaterOrEqual(len(lastDescribe.GetInfo().GetRunningWorkflows()), 1, "expected the buffered fire to be queued behind a running workflow")
+	env.GreaterOrEqual(lastDescribe.GetInfo().GetBufferSize(), int64(1), "BufferSize must reflect at least one buffered start")
+	env.GreaterOrEqual(len(lastDescribe.GetInfo().GetRunningWorkflows()), 1, "expected the buffered fire to be queued behind a running workflow")
 }
 
 // testRecentActionsAdvanceWhilePaused verifies that an in-flight workflow's
@@ -468,7 +468,7 @@ func testBufferSizeReportedWhenBuffered(t *testing.T, newContext contextFactory)
 // from RUNNING to COMPLETED. V1's scheduler workflow does not advance its
 // memo while paused, so the listed status stays at RUNNING until unpause.
 func testRecentActionsAdvanceWhilePaused(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-recentactions-paused")
 	wid := testcore.RandomizeStr("sched-recentactions-paused-wf")
@@ -476,16 +476,16 @@ func testRecentActionsAdvanceWhilePaused(t *testing.T, newContext contextFactory
 
 	// Gate the run so the RUNNING -> COMPLETED transition is driven explicitly.
 	var runs atomic.Int32
-	registerGatedWorkflow(s, wt, &runs)
+	registerGatedWorkflow(env, wt, &runs)
 
-	ctx := newContext(s.Context())
-	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
+	ctx := newContext(env.Context())
+	createSchedule(ctx, t, env, sid, &schedulepb.Schedule{
 		Spec:   intervalSpec(fastInterval),
-		Action: startWorkflowAction(s, wid, wt),
+		Action: startWorkflowAction(env, wid, wt),
 	})
 
 	// Wait for the first workflow to be reported as RUNNING in ListSchedules.
-	running := getScheduleEntryFromVisibility(t, s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	running := getScheduleEntryFromVisibility(t, env, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		return len(ent.Info.RecentActions) >= 1 &&
 			ent.Info.RecentActions[0].GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
 	})
@@ -493,13 +493,13 @@ func testRecentActionsAdvanceWhilePaused(t *testing.T, newContext contextFactory
 	require.NotEmpty(t, runningRunID)
 
 	// Pause, then release the run: its COMPLETED status must surface while paused.
-	patchSchedule(ctx, t, s, sid, &schedulepb.SchedulePatch{Pause: "pausing for the test"})
+	patchSchedule(ctx, t, env, sid, &schedulepb.SchedulePatch{Pause: "pausing for the test"})
 
-	signaled := completeRunningWorkflows(ctx, t, s, sid)
+	signaled := completeRunningWorkflows(ctx, t, env, sid)
 	require.Equal(t, 1, signaled, "exactly one run should be in flight under the default SKIP overlap policy")
 
 	// While paused, the listed RecentActions entry transitions to COMPLETED.
-	getScheduleEntryFromVisibility(t, s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	getScheduleEntryFromVisibility(t, env, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		for _, a := range ent.Info.RecentActions {
 			if a.GetStartWorkflowResult().GetRunId() == runningRunID &&
 				a.GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED {
@@ -519,24 +519,24 @@ func testRecentActionsAdvanceWhilePaused(t *testing.T, newContext contextFactory
 // while paused, so its projected times would freeze at pause time and
 // eventually all sit in the past - hence this test is registered CHASM-only.
 func testFutureActionTimesAdvanceWhilePaused(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-future-actions-paused")
 	wid := testcore.RandomizeStr("sched-future-actions-paused-wf")
 	wt := testcore.RandomizeStr("sched-future-actions-paused-wt")
 
 	var runs atomic.Int32
-	registerCountingWorkflow(s, wt, &runs)
+	registerCountingWorkflow(env, wt, &runs)
 
-	ctx := newContext(s.Context())
-	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
+	ctx := newContext(env.Context())
+	createSchedule(ctx, t, env, sid, &schedulepb.Schedule{
 		Spec:   intervalSpec(fastInterval),
 		State:  &schedulepb.ScheduleState{Paused: true},
-		Action: startWorkflowAction(s, wid, wt),
+		Action: startWorkflowAction(env, wid, wt),
 	})
 
 	// Wait for visibility to surface an initial FutureActionTimes projection.
-	initial := getScheduleEntryFromVisibility(t, s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	initial := getScheduleEntryFromVisibility(t, env, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		return len(ent.Info.FutureActionTimes) > 0
 	})
 	initialFirst := initial.Info.FutureActionTimes[0].AsTime()
@@ -544,7 +544,7 @@ func testFutureActionTimesAdvanceWhilePaused(t *testing.T, newContext contextFac
 	// While still paused, the earliest projected time must advance past the
 	// initial value: the Generator keeps ticking and republishing the
 	// projection, even though no workflows fire.
-	getScheduleEntryFromVisibility(t, s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	getScheduleEntryFromVisibility(t, env, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		return len(ent.Info.FutureActionTimes) > 0 &&
 			ent.Info.FutureActionTimes[0].AsTime().After(initialFirst)
 	})
@@ -557,7 +557,7 @@ func testFutureActionTimesAdvanceWhilePaused(t *testing.T, newContext contextFac
 // deferred start (Attempt=-1 -> 0 in recordCompletedAction), the buffered
 // fire would be stranded.
 func testBufferOneDeferredFiresAfterCompletion(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-buffer-one-deferred")
 	wid := testcore.RandomizeStr("sched-buffer-one-deferred-wf")
@@ -566,12 +566,12 @@ func testBufferOneDeferredFiresAfterCompletion(t *testing.T, newContext contextF
 	// Gate runs so "first running, second buffered" and "deferred fires after
 	// completion" are both reached deterministically.
 	var runs atomic.Int32
-	registerGatedWorkflow(s, wt, &runs)
+	registerGatedWorkflow(env, wt, &runs)
 
-	ctx := newContext(s.Context())
-	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
+	ctx := newContext(env.Context())
+	createSchedule(ctx, t, env, sid, &schedulepb.Schedule{
 		Spec:   intervalSpec(fastInterval),
-		Action: startWorkflowAction(s, wid, wt),
+		Action: startWorkflowAction(env, wid, wt),
 		Policies: &schedulepb.SchedulePolicies{
 			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
 		},
@@ -579,8 +579,8 @@ func testBufferOneDeferredFiresAfterCompletion(t *testing.T, newContext contextF
 
 	// Exactly one workflow runs with exactly one start buffered behind it (BUFFER_ONE caps the buffer at one).
 	await.RequireTruef(t, func() bool {
-		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  s.Namespace().String(),
+		desc, descErr := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  env.Namespace().String(),
 			ScheduleId: sid,
 		})
 		return descErr == nil && desc.GetInfo().GetBufferSize() == 1 && len(desc.GetInfo().GetRunningWorkflows()) == 1
@@ -588,7 +588,7 @@ func testBufferOneDeferredFiresAfterCompletion(t *testing.T, newContext contextF
 	require.Equal(t, int32(1), runs.Load(), "only the first workflow should have fired before the running one completes")
 
 	// Releasing the running workflow must re-enable the deferred start (Attempt=-1 -> 0) so it fires.
-	require.Equal(t, 1, completeRunningWorkflows(ctx, t, s, sid))
+	require.Equal(t, 1, completeRunningWorkflows(ctx, t, env, sid))
 	await.RequireTruef(t, func() bool { return runs.Load() == 2 },
 		awaitTimeout, pollInterval,
 		"deferred start must fire after the running workflow completes - regression for the Attempt=-1 -> 0 re-enable path")
@@ -598,8 +598,8 @@ func testBufferOneDeferredFiresAfterCompletion(t *testing.T, newContext contextF
 	// completed first tick and the still-running deferred start; with no jitter the
 	// deferred start's nominal time is exactly one interval after the first tick's.
 	await.RequireTruef(t, func() bool {
-		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  s.Namespace().String(),
+		desc, descErr := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  env.Namespace().String(),
 			ScheduleId: sid,
 		})
 		if descErr != nil {
@@ -620,7 +620,7 @@ func testBufferOneDeferredFiresAfterCompletion(t *testing.T, newContext contextF
 }
 
 func testDeletedScheduleOperations(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-deleted-ops"
 	wid := "sched-test-deleted-ops-wf"
@@ -637,35 +637,35 @@ func testDeletedScheduleOperations(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 
 	// Create a schedule.
-	_, err := s.FrontendClient().CreateSchedule(newContext(s.Context()), &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	_, err := env.FrontendClient().CreateSchedule(newContext(env.Context()), &workflowservice.CreateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	// Delete the schedule.
-	_, err = s.FrontendClient().DeleteSchedule(newContext(s.Context()), &workflowservice.DeleteScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	_, err = env.FrontendClient().DeleteSchedule(newContext(env.Context()), &workflowservice.DeleteScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Identity:   "test",
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	// Describe should return NotFound.
 	var notFoundErr *serviceerror.NotFound
-	s.Eventually(func() bool {
-		_, descErr := s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
-			Namespace:  s.Namespace().String(),
+	env.Eventually(func() bool {
+		_, descErr := env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
+			Namespace:  env.Namespace().String(),
 			ScheduleId: sid,
 		})
 		return errors.As(descErr, &notFoundErr)
@@ -676,7 +676,7 @@ func testDeletedScheduleOperations(t *testing.T, newContext contextFactory) {
 }
 
 func testBasics(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-basics"
 	wid := "sched-test-basics-wf"
@@ -710,7 +710,7 @@ func testBasics(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					Memo: &commonpb.Memo{
 						Fields: map[string]*commonpb.Payload{"wfmemo1": wfMemo},
 					},
@@ -722,7 +722,7 @@ func testBasics(t *testing.T, newContext contextFactory) {
 		},
 	}
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -747,7 +747,7 @@ func testBasics(t *testing.T, newContext contextFactory) {
 		})
 		return nil
 	}
-	s.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 	workflow2Fn := func(ctx workflow.Context) error {
 		workflow.SideEffect(ctx, func(ctx workflow.Context) any {
 			atomic.AddInt32(&runs2, 1)
@@ -755,55 +755,55 @@ func testBasics(t *testing.T, newContext contextFactory) {
 		})
 		return nil
 	}
-	s.SdkWorker().RegisterWorkflowWithOptions(workflow2Fn, workflow.RegisterOptions{Name: wt2})
+	env.SdkWorker().RegisterWorkflowWithOptions(workflow2Fn, workflow.RegisterOptions{Name: wt2})
 
 	// create
 
-	ctx := newContext(s.Context())
+	ctx := newContext(env.Context())
 	createTime := time.Now()
-	_, err := s.FrontendClient().CreateSchedule(ctx, req)
-	s.NoError(err)
+	_, err := env.FrontendClient().CreateSchedule(ctx, req)
+	env.NoError(err)
 
 	// describe immediately after create and verify FutureActionTimes
-	describeRespAfterCreate, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	describeRespAfterCreate, err := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 	})
-	s.NoError(err)
-	s.NotEmpty(describeRespAfterCreate.Info.FutureActionTimes, "FutureActionTimes should be set immediately after create")
+	env.NoError(err)
+	env.NotEmpty(describeRespAfterCreate.Info.FutureActionTimes, "FutureActionTimes should be set immediately after create")
 	// FutureActionTimes should be in the future (after createTime) and aligned to 5-second intervals
 	for i, fat := range describeRespAfterCreate.Info.FutureActionTimes {
-		s.True(fat.AsTime().After(createTime) || fat.AsTime().Equal(createTime),
+		env.True(fat.AsTime().After(createTime) || fat.AsTime().Equal(createTime),
 			"FutureActionTimes[%d] should be >= createTime", i)
-		s.Equal(int64(0), fat.AsTime().UnixNano()%int64(5*time.Second),
+		env.Equal(int64(0), fat.AsTime().UnixNano()%int64(5*time.Second),
 			"FutureActionTimes[%d] should be aligned to 5-second intervals", i)
 	}
 
 	// sleep until we see two runs, plus a bit more to ensure that the second run has completed
-	s.Eventually(func() bool { return atomic.LoadInt32(&runs) == 2 }, 15*time.Second, 500*time.Millisecond)
+	env.Eventually(func() bool { return atomic.LoadInt32(&runs) == 2 }, 15*time.Second, 500*time.Millisecond)
 	time.Sleep(2 * time.Second) //nolint:forbidigo
 
 	// wait for visibility to stabilize on completed before calling describe,
 	// otherwise their recent actions may flake and differ
 
-	visibilityResponse := getScheduleEntryFromVisibility(t, s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	visibilityResponse := getScheduleEntryFromVisibility(t, env, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		recentActions := ent.GetInfo().GetRecentActions()
 		return len(recentActions) >= 2 && recentActions[1].GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
 	})
 
-	describeResp, err := s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	describeResp, err := env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	// validate describe response
 
 	checkSpec := func(spec *schedulepb.ScheduleSpec) {
-		protorequire.ProtoSliceEqual(s.T(), schedule.Spec.Interval, spec.Interval)
-		s.Nil(spec.Calendar)
-		s.Nil(spec.CronString)
-		s.ProtoElementsMatch([]*schedulepb.StructuredCalendarSpec{
+		protorequire.ProtoSliceEqual(env.T(), schedule.Spec.Interval, spec.Interval)
+		env.Nil(spec.Calendar)
+		env.Nil(spec.CronString)
+		env.ProtoElementsMatch([]*schedulepb.StructuredCalendarSpec{
 			{
 				Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
 				Minute:     []*schedulepb.Range{{Start: 11, End: 11, Step: 1}},
@@ -826,61 +826,61 @@ func testBasics(t *testing.T, newContext contextFactory) {
 	}
 	checkSpec(describeResp.Schedule.Spec)
 
-	s.Equal(enumspb.SCHEDULE_OVERLAP_POLICY_SKIP, describeResp.Schedule.Policies.OverlapPolicy)     // set to default value
-	s.EqualValues(365*24*3600, describeResp.Schedule.Policies.CatchupWindow.AsDuration().Seconds()) // set to default value
+	env.Equal(enumspb.SCHEDULE_OVERLAP_POLICY_SKIP, describeResp.Schedule.Policies.OverlapPolicy)     // set to default value
+	env.EqualValues(365*24*3600, describeResp.Schedule.Policies.CatchupWindow.AsDuration().Seconds()) // set to default value
 
-	s.Equal(schSAValue.Data, describeResp.SearchAttributes.IndexedFields[csaKeyword].Data)
-	s.Equal(schSAIntValue.Data, describeResp.SearchAttributes.IndexedFields[csaInt].Data)
-	s.Equal(schSABoolValue.Data, describeResp.SearchAttributes.IndexedFields[csaBool].Data)
-	s.Nil(describeResp.SearchAttributes.IndexedFields[sadefs.BinaryChecksums])
-	s.Nil(describeResp.SearchAttributes.IndexedFields[sadefs.BuildIds])
-	s.Nil(describeResp.SearchAttributes.IndexedFields[sadefs.TemporalNamespaceDivision])
-	s.Equal(schMemo.Data, describeResp.Memo.Fields["schedmemo1"].Data)
-	s.Equal(wfSAValue.Data, describeResp.Schedule.Action.GetStartWorkflow().SearchAttributes.IndexedFields[csaKeyword].Data)
-	s.Equal(wfMemo.Data, describeResp.Schedule.Action.GetStartWorkflow().Memo.Fields["wfmemo1"].Data)
+	env.Equal(schSAValue.Data, describeResp.SearchAttributes.IndexedFields[csaKeyword].Data)
+	env.Equal(schSAIntValue.Data, describeResp.SearchAttributes.IndexedFields[csaInt].Data)
+	env.Equal(schSABoolValue.Data, describeResp.SearchAttributes.IndexedFields[csaBool].Data)
+	env.Nil(describeResp.SearchAttributes.IndexedFields[sadefs.BinaryChecksums])
+	env.Nil(describeResp.SearchAttributes.IndexedFields[sadefs.BuildIds])
+	env.Nil(describeResp.SearchAttributes.IndexedFields[sadefs.TemporalNamespaceDivision])
+	env.Equal(schMemo.Data, describeResp.Memo.Fields["schedmemo1"].Data)
+	env.Equal(wfSAValue.Data, describeResp.Schedule.Action.GetStartWorkflow().SearchAttributes.IndexedFields[csaKeyword].Data)
+	env.Equal(wfMemo.Data, describeResp.Schedule.Action.GetStartWorkflow().Memo.Fields["wfmemo1"].Data)
 
 	// GreaterOrEqual is used as we may have had other runs start while waiting for visibility
 	durationNear(t, describeResp.Info.CreateTime.AsTime().Sub(createTime), 0)
-	s.GreaterOrEqual(describeResp.Info.ActionCount, int64(2))
-	s.EqualValues(0, describeResp.Info.MissedCatchupWindow)
-	s.EqualValues(0, describeResp.Info.OverlapSkipped)
-	s.GreaterOrEqual(len(describeResp.Info.RunningWorkflows), 0)
-	s.GreaterOrEqual(len(describeResp.Info.RecentActions), 2)
+	env.GreaterOrEqual(describeResp.Info.ActionCount, int64(2))
+	env.EqualValues(0, describeResp.Info.MissedCatchupWindow)
+	env.EqualValues(0, describeResp.Info.OverlapSkipped)
+	env.GreaterOrEqual(len(describeResp.Info.RunningWorkflows), 0)
+	env.GreaterOrEqual(len(describeResp.Info.RecentActions), 2)
 	action0 := describeResp.Info.RecentActions[0]
-	s.WithinRange(action0.ScheduleTime.AsTime(), createTime, time.Now())
-	s.Equal(int64(0), action0.ScheduleTime.AsTime().UnixNano()%int64(5*time.Second))
+	env.WithinRange(action0.ScheduleTime.AsTime(), createTime, time.Now())
+	env.Equal(int64(0), action0.ScheduleTime.AsTime().UnixNano()%int64(5*time.Second))
 	durationNear(t, action0.ActualTime.AsTime().Sub(action0.ScheduleTime.AsTime()), 0)
 
 	// validate list response
 
-	s.Equal(sid, visibilityResponse.ScheduleId)
-	s.Equal(schSAValue.Data, visibilityResponse.SearchAttributes.IndexedFields[csaKeyword].Data)
-	s.Equal(schSAIntValue.Data, describeResp.SearchAttributes.IndexedFields[csaInt].Data)
-	s.Equal(schSABoolValue.Data, describeResp.SearchAttributes.IndexedFields[csaBool].Data)
-	s.Nil(visibilityResponse.SearchAttributes.IndexedFields[sadefs.BinaryChecksums])
-	s.Nil(visibilityResponse.SearchAttributes.IndexedFields[sadefs.BuildIds])
-	s.Nil(visibilityResponse.SearchAttributes.IndexedFields[sadefs.TemporalNamespaceDivision])
-	s.Equal(schMemo.Data, visibilityResponse.Memo.Fields["schedmemo1"].Data)
+	env.Equal(sid, visibilityResponse.ScheduleId)
+	env.Equal(schSAValue.Data, visibilityResponse.SearchAttributes.IndexedFields[csaKeyword].Data)
+	env.Equal(schSAIntValue.Data, describeResp.SearchAttributes.IndexedFields[csaInt].Data)
+	env.Equal(schSABoolValue.Data, describeResp.SearchAttributes.IndexedFields[csaBool].Data)
+	env.Nil(visibilityResponse.SearchAttributes.IndexedFields[sadefs.BinaryChecksums])
+	env.Nil(visibilityResponse.SearchAttributes.IndexedFields[sadefs.BuildIds])
+	env.Nil(visibilityResponse.SearchAttributes.IndexedFields[sadefs.TemporalNamespaceDivision])
+	env.Equal(schMemo.Data, visibilityResponse.Memo.Fields["schedmemo1"].Data)
 	checkSpec(visibilityResponse.Info.Spec)
-	s.Equal(wt, visibilityResponse.Info.WorkflowType.Name)
-	s.False(visibilityResponse.Info.Paused)
-	assertSameRecentActions(s.T(), describeResp, visibilityResponse)
-	assertRecentActionsNoDuplicateRunIDs(s.T(), describeResp.Info.RecentActions)
+	env.Equal(wt, visibilityResponse.Info.WorkflowType.Name)
+	env.False(visibilityResponse.Info.Paused)
+	assertSameRecentActions(env.T(), describeResp, visibilityResponse)
+	assertRecentActionsNoDuplicateRunIDs(env.T(), describeResp.Info.RecentActions)
 
 	// list workflows
 
-	wfResp, err := s.FrontendClient().ListWorkflowExecutions(newContext(s.Context()), &workflowservice.ListWorkflowExecutionsRequest{
-		Namespace: s.Namespace().String(),
+	wfResp, err := env.FrontendClient().ListWorkflowExecutions(newContext(env.Context()), &workflowservice.ListWorkflowExecutionsRequest{
+		Namespace: env.Namespace().String(),
 		PageSize:  5,
 		Query:     "",
 	})
-	s.NoError(err)
-	s.GreaterOrEqual(len(wfResp.Executions), 2) // could have had a 3rd run while waiting for visibility
+	env.NoError(err)
+	env.GreaterOrEqual(len(wfResp.Executions), 2) // could have had a 3rd run while waiting for visibility
 	for _, ex := range wfResp.Executions {
-		s.Equal(wt, ex.Type.Name, "should only see started workflows")
+		env.Equal(wt, ex.Type.Name, "should only see started workflows")
 	}
 	ex0 := wfResp.Executions[0]
-	s.True(strings.HasPrefix(ex0.Execution.WorkflowId, wid))
+	env.True(strings.HasPrefix(ex0.Execution.WorkflowId, wid))
 	matchingRunId := false
 	for _, recentAction := range describeResp.GetInfo().GetRecentActions() {
 		if ex0.GetExecution().GetRunId() == recentAction.GetStartWorkflowResult().GetRunId() {
@@ -888,37 +888,37 @@ func testBasics(t *testing.T, newContext contextFactory) {
 			break
 		}
 	}
-	s.True(matchingRunId, "ListWorkflowExecutions returned a run ID wasn't in the describe response")
-	s.Equal(wt, ex0.Type.Name)
-	s.Nil(ex0.ParentExecution) // not a child workflow
-	s.Equal(wfMemo.Data, ex0.Memo.Fields["wfmemo1"].Data)
-	s.Equal(wfSAValue.Data, ex0.SearchAttributes.IndexedFields[csaKeyword].Data)
-	s.Equal(payload.EncodeString(sid).Data, ex0.SearchAttributes.IndexedFields[sadefs.TemporalScheduledById].Data)
+	env.True(matchingRunId, "ListWorkflowExecutions returned a run ID wasn't in the describe response")
+	env.Equal(wt, ex0.Type.Name)
+	env.Nil(ex0.ParentExecution) // not a child workflow
+	env.Equal(wfMemo.Data, ex0.Memo.Fields["wfmemo1"].Data)
+	env.Equal(wfSAValue.Data, ex0.SearchAttributes.IndexedFields[csaKeyword].Data)
+	env.Equal(payload.EncodeString(sid).Data, ex0.SearchAttributes.IndexedFields[sadefs.TemporalScheduledById].Data)
 	var ex0StartTime time.Time
-	s.NoError(payload.Decode(ex0.SearchAttributes.IndexedFields[sadefs.TemporalScheduledStartTime], &ex0StartTime))
-	s.WithinRange(ex0StartTime, createTime, time.Now())
-	s.Equal(int64(0), ex0StartTime.UnixNano()%int64(5*time.Second))
+	env.NoError(payload.Decode(ex0.SearchAttributes.IndexedFields[sadefs.TemporalScheduledStartTime], &ex0StartTime))
+	env.WithinRange(ex0StartTime, createTime, time.Now())
+	env.Equal(int64(0), ex0StartTime.UnixNano()%int64(5*time.Second))
 
 	// list schedules with search attribute filter
 
-	listResp, err := s.FrontendClient().ListSchedules(newContext(s.Context()), &workflowservice.ListSchedulesRequest{
-		Namespace:       s.Namespace().String(),
+	listResp, err := env.FrontendClient().ListSchedules(newContext(env.Context()), &workflowservice.ListSchedulesRequest{
+		Namespace:       env.Namespace().String(),
 		MaximumPageSize: 5,
 		Query:           "CustomKeywordField = 'schedule sa value' AND TemporalSchedulePaused = false",
 	})
-	s.NoError(err)
-	s.Len(listResp.Schedules, 1)
+	env.NoError(err)
+	env.Len(listResp.Schedules, 1)
 	entry := listResp.Schedules[0]
-	s.Equal(sid, entry.ScheduleId)
+	env.Equal(sid, entry.ScheduleId)
 
 	// list schedules with invalid search attribute filter
 
-	_, err = s.FrontendClient().ListSchedules(newContext(s.Context()), &workflowservice.ListSchedulesRequest{
-		Namespace:       s.Namespace().String(),
+	_, err = env.FrontendClient().ListSchedules(newContext(env.Context()), &workflowservice.ListSchedulesRequest{
+		Namespace:       env.Namespace().String(),
 		MaximumPageSize: 5,
 		Query:           "ExecutionDuration > '1s'",
 	})
-	s.Error(err)
+	env.Error(err)
 
 	// update schedule, no updates to search attributes
 
@@ -926,43 +926,43 @@ func testBasics(t *testing.T, newContext contextFactory) {
 	schedule.Action.GetStartWorkflow().WorkflowType.Name = wt2
 
 	updateTime := time.Now()
-	_, err = s.FrontendClient().UpdateSchedule(newContext(s.Context()), &workflowservice.UpdateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	_, err = env.FrontendClient().UpdateSchedule(newContext(env.Context()), &workflowservice.UpdateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	// wait for one new run
-	s.Eventually(
+	env.Eventually(
 		func() bool { return atomic.LoadInt32(&runs2) == 1 },
 		7*time.Second,
 		500*time.Millisecond,
 	)
 
 	// describe again
-	describeResp, err = s.FrontendClient().DescribeSchedule(
-		newContext(s.Context()),
+	describeResp, err = env.FrontendClient().DescribeSchedule(
+		newContext(env.Context()),
 		&workflowservice.DescribeScheduleRequest{
-			Namespace:  s.Namespace().String(),
+			Namespace:  env.Namespace().String(),
 			ScheduleId: sid,
 		},
 	)
-	s.NoError(err)
+	env.NoError(err)
 
-	s.Len(describeResp.SearchAttributes.GetIndexedFields(), 3)
-	s.Equal(schSAValue.Data, describeResp.SearchAttributes.IndexedFields[csaKeyword].Data)
-	s.Equal(schSAIntValue.Data, describeResp.SearchAttributes.IndexedFields[csaInt].Data)
-	s.Equal(schSABoolValue.Data, describeResp.SearchAttributes.IndexedFields[csaBool].Data)
-	s.Equal(schMemo.Data, describeResp.Memo.Fields["schedmemo1"].Data)
-	s.Equal(wfSAValue.Data, describeResp.Schedule.Action.GetStartWorkflow().SearchAttributes.IndexedFields[csaKeyword].Data)
-	s.Equal(wfMemo.Data, describeResp.Schedule.Action.GetStartWorkflow().Memo.Fields["wfmemo1"].Data)
+	env.Len(describeResp.SearchAttributes.GetIndexedFields(), 3)
+	env.Equal(schSAValue.Data, describeResp.SearchAttributes.IndexedFields[csaKeyword].Data)
+	env.Equal(schSAIntValue.Data, describeResp.SearchAttributes.IndexedFields[csaInt].Data)
+	env.Equal(schSABoolValue.Data, describeResp.SearchAttributes.IndexedFields[csaBool].Data)
+	env.Equal(schMemo.Data, describeResp.Memo.Fields["schedmemo1"].Data)
+	env.Equal(wfSAValue.Data, describeResp.Schedule.Action.GetStartWorkflow().SearchAttributes.IndexedFields[csaKeyword].Data)
+	env.Equal(wfMemo.Data, describeResp.Schedule.Action.GetStartWorkflow().Memo.Fields["wfmemo1"].Data)
 
 	durationNear(t, describeResp.Info.UpdateTime.AsTime().Sub(updateTime), 0)
 	lastAction := describeResp.Info.RecentActions[len(describeResp.Info.RecentActions)-1]
-	s.Equal(int64(1000000000), lastAction.ScheduleTime.AsTime().UnixNano()%int64(5*time.Second), lastAction.ScheduleTime.AsTime().UnixNano())
+	env.Equal(int64(1000000000), lastAction.ScheduleTime.AsTime().UnixNano()%int64(5*time.Second), lastAction.ScheduleTime.AsTime().UnixNano())
 
 	// update schedule and search attributes
 
@@ -972,8 +972,8 @@ func testBasics(t *testing.T, newContext contextFactory) {
 	csaDouble := "CustomDoubleField"
 	schSADoubleValue, _ := payload.Encode(3.14)
 	schSAIntValue, _ = payload.Encode(321)
-	_, err = s.FrontendClient().UpdateSchedule(newContext(s.Context()), &workflowservice.UpdateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	_, err = env.FrontendClient().UpdateSchedule(newContext(env.Context()), &workflowservice.UpdateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -987,15 +987,15 @@ func testBasics(t *testing.T, newContext contextFactory) {
 			},
 		},
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	// wait until search attributes are updated
-	s.EventuallyWithT(
+	env.EventuallyWithT(
 		func(c *assert.CollectT) {
-			describeResp, err = s.FrontendClient().DescribeSchedule(
-				newContext(s.Context()),
+			describeResp, err = env.FrontendClient().DescribeSchedule(
+				newContext(env.Context()),
 				&workflowservice.DescribeScheduleRequest{
-					Namespace:  s.Namespace().String(),
+					Namespace:  env.Namespace().String(),
 					ScheduleId: sid,
 				},
 			)
@@ -1015,23 +1015,23 @@ func testBasics(t *testing.T, newContext contextFactory) {
 	schedule.Spec.Interval[0].Phase = durationpb.New(1 * time.Second)
 	schedule.Action.GetStartWorkflow().WorkflowType.Name = wt2
 
-	_, err = s.FrontendClient().UpdateSchedule(newContext(s.Context()), &workflowservice.UpdateScheduleRequest{
-		Namespace:        s.Namespace().String(),
+	_, err = env.FrontendClient().UpdateSchedule(newContext(env.Context()), &workflowservice.UpdateScheduleRequest{
+		Namespace:        env.Namespace().String(),
 		ScheduleId:       sid,
 		Schedule:         schedule,
 		Identity:         "test",
 		RequestId:        uuid.NewString(),
 		SearchAttributes: &commonpb.SearchAttributes{},
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	// wait until search attributes are updated
-	s.EventuallyWithT(
+	env.EventuallyWithT(
 		func(c *assert.CollectT) {
-			describeResp, err = s.FrontendClient().DescribeSchedule(
-				newContext(s.Context()),
+			describeResp, err = env.FrontendClient().DescribeSchedule(
+				newContext(env.Context()),
 				&workflowservice.DescribeScheduleRequest{
-					Namespace:  s.Namespace().String(),
+					Namespace:  env.Namespace().String(),
 					ScheduleId: sid,
 				},
 			)
@@ -1044,8 +1044,8 @@ func testBasics(t *testing.T, newContext contextFactory) {
 
 	// pause
 
-	_, err = s.FrontendClient().PatchSchedule(newContext(s.Context()), &workflowservice.PatchScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	_, err = env.FrontendClient().PatchSchedule(newContext(env.Context()), &workflowservice.PatchScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Patch: &schedulepb.SchedulePatch{
 			Pause: "because I said so",
@@ -1053,60 +1053,60 @@ func testBasics(t *testing.T, newContext contextFactory) {
 		Identity:  "test",
 		RequestId: uuid.NewString(),
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	time.Sleep(7 * time.Second) //nolint:forbidigo
-	s.EqualValues(1, atomic.LoadInt32(&runs2), "has not run again")
+	env.EqualValues(1, atomic.LoadInt32(&runs2), "has not run again")
 
-	describeResp, err = s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	describeResp, err = env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 	})
-	s.NoError(err)
+	env.NoError(err)
 
-	s.True(describeResp.Schedule.State.Paused)
-	s.Equal("because I said so", describeResp.Schedule.State.Notes)
+	env.True(describeResp.Schedule.State.Paused)
+	env.Equal("because I said so", describeResp.Schedule.State.Notes)
 
 	// don't loop to wait for visibility, we already waited 7s from the patch
-	listResp, err = s.FrontendClient().ListSchedules(newContext(s.Context()), &workflowservice.ListSchedulesRequest{
-		Namespace:       s.Namespace().String(),
+	listResp, err = env.FrontendClient().ListSchedules(newContext(env.Context()), &workflowservice.ListSchedulesRequest{
+		Namespace:       env.Namespace().String(),
 		MaximumPageSize: 5,
 	})
-	s.NoError(err)
-	s.Len(listResp.Schedules, 1)
+	env.NoError(err)
+	env.Len(listResp.Schedules, 1)
 	entry = listResp.Schedules[0]
-	s.Equal(sid, entry.ScheduleId)
-	s.True(entry.Info.Paused)
-	s.Equal("because I said so", entry.Info.Notes)
+	env.Equal(sid, entry.ScheduleId)
+	env.True(entry.Info.Paused)
+	env.Equal("because I said so", entry.Info.Notes)
 
 	// finally delete
 
-	_, err = s.FrontendClient().DeleteSchedule(newContext(s.Context()), &workflowservice.DeleteScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	_, err = env.FrontendClient().DeleteSchedule(newContext(env.Context()), &workflowservice.DeleteScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Identity:   "test",
 	})
-	s.NoError(err)
+	env.NoError(err)
 
-	describeResp, err = s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	describeResp, err = env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 	})
 	var notFoundErr *serviceerror.NotFound
-	s.ErrorAs(err, &notFoundErr)
+	env.ErrorAs(err, &notFoundErr)
 
-	s.Eventually(func() bool { // wait for visibility
-		listResp, err := s.FrontendClient().ListSchedules(newContext(s.Context()), &workflowservice.ListSchedulesRequest{
-			Namespace:       s.Namespace().String(),
+	env.Eventually(func() bool { // wait for visibility
+		listResp, err := env.FrontendClient().ListSchedules(newContext(env.Context()), &workflowservice.ListSchedulesRequest{
+			Namespace:       env.Namespace().String(),
 			MaximumPageSize: 5,
 		})
-		s.NoError(err)
+		env.NoError(err)
 		return len(listResp.Schedules) == 0
 	}, 10*time.Second, 1*time.Second)
 }
 
 func testInput(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-input"
 	wid := "sched-test-input-wf"
@@ -1123,7 +1123,7 @@ func testInput(t *testing.T, newContext contextFactory) {
 	}
 	input2 := map[int]float64{11: 1.4375}
 	inputPayloads, err := payloads.Encode(input1, input2)
-	s.NoError(err)
+	env.NoError(err)
 
 	schedule := &schedulepb.Schedule{
 		Spec: &schedulepb.ScheduleSpec{
@@ -1136,14 +1136,14 @@ func testInput(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					Input:        inputPayloads,
 				},
 			},
 		},
 	}
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -1153,24 +1153,24 @@ func testInput(t *testing.T, newContext contextFactory) {
 	var runs int32
 	workflowFn := func(ctx workflow.Context, arg1 *myData, arg2 map[int]float64) error {
 		workflow.SideEffect(ctx, func(ctx workflow.Context) any {
-			s.Equal(*input1, *arg1)
-			s.Equal(input2, arg2)
+			env.Equal(*input1, *arg1)
+			env.Equal(input2, arg2)
 			atomic.AddInt32(&runs, 1)
 			return 0
 		})
 		return nil
 	}
-	s.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 
-	ctx := newContext(s.Context())
-	_, err = s.FrontendClient().CreateSchedule(ctx, req)
-	s.NoError(err)
+	ctx := newContext(env.Context())
+	_, err = env.FrontendClient().CreateSchedule(ctx, req)
+	env.NoError(err)
 
-	s.Eventually(func() bool { return atomic.LoadInt32(&runs) == 1 }, 8*time.Second, 200*time.Millisecond)
+	env.Eventually(func() bool { return atomic.LoadInt32(&runs) == 1 }, 8*time.Second, 200*time.Millisecond)
 }
 
 func testLastCompletionAndError(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-last"
 	wid := "sched-test-last-wf"
@@ -1187,13 +1187,13 @@ func testLastCompletionAndError(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -1212,36 +1212,36 @@ func testLastCompletionAndError(t *testing.T, newContext contextFactory) {
 
 		var lcr string
 		if workflow.HasLastCompletionResult(ctx) {
-			s.NoError(workflow.GetLastCompletionResult(ctx, &lcr))
+			env.NoError(workflow.GetLastCompletionResult(ctx, &lcr))
 		}
 
 		lastErr := workflow.GetLastError(ctx)
 
 		switch num {
 		case 1:
-			s.Empty(lcr)
-			s.NoError(lastErr)
+			env.Empty(lcr)
+			env.NoError(lastErr)
 			return "this one succeeds", nil
 		case 2:
-			s.NoError(lastErr)
-			s.Equal("this one succeeds", lcr)
+			env.NoError(lastErr)
+			env.Equal("this one succeeds", lcr)
 			return "", errors.New("this one fails")
 		case 3:
-			s.Equal("this one succeeds", lcr)
-			s.ErrorContains(lastErr, "this one fails")
+			env.Equal("this one succeeds", lcr)
+			env.ErrorContains(lastErr, "this one fails")
 			atomic.StoreInt32(&testComplete, 1)
 			return "done", nil
 		default:
 			panic("shouldn't be running anymore")
 		}
 	}
-	s.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, req)
-	s.NoError(err)
+	ctx := newContext(env.Context())
+	_, err := env.FrontendClient().CreateSchedule(ctx, req)
+	env.NoError(err)
 
-	s.Eventually(func() bool { return atomic.LoadInt32(&testComplete) == 1 }, 20*time.Second, 200*time.Millisecond)
+	env.Eventually(func() bool { return atomic.LoadInt32(&testComplete) == 1 }, 20*time.Second, 200*time.Millisecond)
 }
 
 // testScheduleContinuesAfterWorkflowRetryFailure verifies a schedule keeps firing actions
@@ -1252,7 +1252,7 @@ func testScheduleContinuesAfterWorkflowRetryFailure(t *testing.T, newContext con
 	// runs created by retries). That requires the envelope token format, which is gated off by default
 	// for safe rollout, so enable it explicitly here.
 	opts := append(scheduleCommonOpts(t), testcore.WithDynamicConfig(callback.EncodeInternalTokenWithEnvelope, true))
-	s := newScheduleEnv(t, opts...)
+	env := newScheduleEnv(t, opts...)
 
 	sid := testcore.RandomizeStr("sched-retry-fail")
 	wid := testcore.RandomizeStr("sched-retry-fail-wf")
@@ -1265,7 +1265,7 @@ func testScheduleContinuesAfterWorkflowRetryFailure(t *testing.T, newContext con
 		}
 		return errors.New("intentional failure to force a retry")
 	}
-	s.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 
 	schedule := &schedulepb.Schedule{
 		Spec: &schedulepb.ScheduleSpec{
@@ -1278,7 +1278,7 @@ func testScheduleContinuesAfterWorkflowRetryFailure(t *testing.T, newContext con
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					RetryPolicy: &commonpb.RetryPolicy{
 						InitialInterval:    durationpb.New(1 * time.Second),
 						BackoffCoefficient: 1.0,
@@ -1289,9 +1289,9 @@ func testScheduleContinuesAfterWorkflowRetryFailure(t *testing.T, newContext con
 		},
 	}
 
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	ctx := newContext(env.Context())
+	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -1302,9 +1302,9 @@ func testScheduleContinuesAfterWorkflowRetryFailure(t *testing.T, newContext con
 	// Two FAILED actions proves the schedule kept firing past the first retry-failure.
 	var failedActions int
 	var lastDescribe *workflowservice.DescribeScheduleResponse
-	s.Eventually(func() bool {
-		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  s.Namespace().String(),
+	env.Eventually(func() bool {
+		desc, descErr := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  env.Namespace().String(),
 			ScheduleId: sid,
 		})
 		if descErr != nil {
@@ -1321,10 +1321,10 @@ func testScheduleContinuesAfterWorkflowRetryFailure(t *testing.T, newContext con
 	}, 30*time.Second, 500*time.Millisecond,
 		"schedule should keep recording FAILED actions after the workflow retry-fails")
 
-	s.Equal(int32(1), atomic.LoadInt32(&sawRetry), "scheduled workflow should have retried (attempt > 1)")
-	s.GreaterOrEqual(failedActions, 2, "schedule should record multiple retry-failed actions")
-	s.GreaterOrEqual(lastDescribe.GetInfo().GetActionCount(), int64(2))
-	s.False(lastDescribe.GetSchedule().GetState().GetPaused(), "a retry-failed workflow must not pause the schedule")
+	env.Equal(int32(1), atomic.LoadInt32(&sawRetry), "scheduled workflow should have retried (attempt > 1)")
+	env.GreaterOrEqual(failedActions, 2, "schedule should record multiple retry-failed actions")
+	env.GreaterOrEqual(lastDescribe.GetInfo().GetActionCount(), int64(2))
+	env.False(lastDescribe.GetSchedule().GetState().GetPaused(), "a retry-failed workflow must not pause the schedule")
 }
 
 // testScheduledWorkflowContinueAsNewCompletion validates that the CHASM scheduler observes the
@@ -1341,7 +1341,7 @@ func testScheduledWorkflowContinueAsNewCompletion(t *testing.T, newContext conte
 	// completion callback token, which only survives continue-as-new in the envelope token format.
 	// That format is gated off by default for safe rollout, so enable it explicitly here.
 	opts := append(scheduleCommonOpts(t), testcore.WithDynamicConfig(callback.EncodeInternalTokenWithEnvelope, true))
-	s := newScheduleEnv(t, opts...)
+	env := newScheduleEnv(t, opts...)
 
 	sid := testcore.RandomizeStr("sched-can-completion")
 	wid := testcore.RandomizeStr("sched-can-completion-wf")
@@ -1355,7 +1355,7 @@ func testScheduledWorkflowContinueAsNewCompletion(t *testing.T, newContext conte
 		}
 		return nil
 	}
-	s.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 
 	schedule := &schedulepb.Schedule{
 		Spec: &schedulepb.ScheduleSpec{
@@ -1374,21 +1374,21 @@ func testScheduledWorkflowContinueAsNewCompletion(t *testing.T, newContext conte
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	}
 
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, req)
+	ctx := newContext(env.Context())
+	_, err := env.FrontendClient().CreateSchedule(ctx, req)
 	require.NoError(t, err)
 
 	// getCompletionCallback returns the Nexus completion callback the scheduler attached, found in the
@@ -1410,9 +1410,9 @@ func testScheduledWorkflowContinueAsNewCompletion(t *testing.T, newContext conte
 	// callback the scheduler records, not from visibility.)
 	const wantCompleted = 3
 	var completedWFID string
-	s.Eventually(func() bool {
-		desc, descErr := s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
-			Namespace:  s.Namespace().String(),
+	env.Eventually(func() bool {
+		desc, descErr := env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
+			Namespace:  env.Namespace().String(),
 			ScheduleId: sid,
 		})
 		if descErr != nil {
@@ -1432,10 +1432,10 @@ func testScheduledWorkflowContinueAsNewCompletion(t *testing.T, newContext conte
 	// Verify the completion callback was written into both runs of a completed action: the
 	// continued-as-new run (latest) and the original run it continued from. The header (callback
 	// token) must be identical, confirming the callback was propagated intact across continue-as-new.
-	s.NotEmpty(completedWFID)
-	canHist := s.GetHistory(s.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: completedWFID})
+	env.NotEmpty(completedWFID)
+	canHist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: completedWFID})
 	canCB := getCompletionCallback(canHist)
-	s.NotNil(canCB, "continued-as-new run must carry the completion callback")
+	env.NotNil(canCB, "continued-as-new run must carry the completion callback")
 
 	var continuedFromRunID string
 	for _, e := range canHist {
@@ -1444,16 +1444,16 @@ func testScheduledWorkflowContinueAsNewCompletion(t *testing.T, newContext conte
 			break
 		}
 	}
-	s.NotEmpty(continuedFromRunID, "completed action should have continued-as-new")
+	env.NotEmpty(continuedFromRunID, "completed action should have continued-as-new")
 
-	origHist := s.GetHistory(s.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: completedWFID, RunId: continuedFromRunID})
+	origHist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: completedWFID, RunId: continuedFromRunID})
 	origCB := getCompletionCallback(origHist)
-	s.NotNil(origCB, "original run must carry the completion callback")
-	s.Equal(origCB.GetNexus().GetHeader(), canCB.GetNexus().GetHeader(), "completion callback must be propagated intact across continue-as-new")
+	env.NotNil(origCB, "original run must carry the completion callback")
+	env.Equal(origCB.GetNexus().GetHeader(), canCB.GetNexus().GetHeader(), "completion callback must be propagated intact across continue-as-new")
 }
 
 func testListSchedulesReturnsWorkflowStatus(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-list-running"
 	wid := "sched-test-list-running-wf"
@@ -1471,7 +1471,7 @@ func testListSchedulesReturnsWorkflowStatus(t *testing.T, newContext contextFact
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
@@ -1490,65 +1490,65 @@ func testListSchedulesReturnsWorkflowStatus(t *testing.T, newContext contextFact
 		selector.Select(ctx)
 		return nil
 	}
-	s.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:    s.Namespace().String(),
+		Namespace:    env.Namespace().String(),
 		ScheduleId:   sid,
 		Schedule:     schedule,
 		InitialPatch: patch,
 		RequestId:    uuid.NewString(),
 	}
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, req)
-	s.NoError(err)
+	ctx := newContext(env.Context())
+	_, err := env.FrontendClient().CreateSchedule(ctx, req)
+	env.NoError(err)
 
 	// validate RecentActions made it to visibility
-	listResp := getScheduleEntryFromVisibility(t, s, sid, newContext, func(listResp *schedulepb.ScheduleListEntry) bool {
+	listResp := getScheduleEntryFromVisibility(t, env, sid, newContext, func(listResp *schedulepb.ScheduleListEntry) bool {
 		return len(listResp.Info.RecentActions) >= 1
 	})
-	s.Len(listResp.Info.RecentActions, 1)
+	env.Len(listResp.Info.RecentActions, 1)
 
 	a1 := listResp.Info.RecentActions[0]
-	s.True(strings.HasPrefix(a1.StartWorkflowResult.WorkflowId, wid))
-	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, a1.StartWorkflowStatus)
+	env.True(strings.HasPrefix(a1.StartWorkflowResult.WorkflowId, wid))
+	env.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, a1.StartWorkflowStatus)
 
 	// let the started workflow complete
-	_, err = s.FrontendClient().SignalWorkflowExecution(newContext(s.Context()), &workflowservice.SignalWorkflowExecutionRequest{
-		Namespace: s.Namespace().String(),
+	_, err = env.FrontendClient().SignalWorkflowExecution(newContext(env.Context()), &workflowservice.SignalWorkflowExecutionRequest{
+		Namespace: env.Namespace().String(),
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: a1.StartWorkflowResult.WorkflowId,
 			RunId:      a1.StartWorkflowResult.RunId,
 		},
 		SignalName: resumeSignal,
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	// now wait for second recent action to land in visbility
-	listResp = getScheduleEntryFromVisibility(t, s, sid, newContext, func(listResp *schedulepb.ScheduleListEntry) bool {
+	listResp = getScheduleEntryFromVisibility(t, env, sid, newContext, func(listResp *schedulepb.ScheduleListEntry) bool {
 		return len(listResp.Info.RecentActions) >= 2
 	})
 
 	a1 = listResp.Info.RecentActions[0]
 	a2 := listResp.Info.RecentActions[1]
-	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, a1.StartWorkflowStatus)
-	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, a2.StartWorkflowStatus)
+	env.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, a1.StartWorkflowStatus)
+	env.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, a2.StartWorkflowStatus)
 
 	// Also verify that DescribeSchedule's output matches
-	descResp, err := s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	descResp, err := env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 	})
-	s.NoError(err)
-	assertSameRecentActions(s.T(), descResp, listResp)
+	env.NoError(err)
+	assertSameRecentActions(env.T(), descResp, listResp)
 
 	// Verify no duplicate RunIds in recent actions (regression for migration dedup bug).
-	assertRecentActionsNoDuplicateRunIDs(s.T(), descResp.Info.RecentActions)
-	assertRecentActionsNoDuplicateRunIDs(s.T(), listResp.Info.RecentActions)
+	assertRecentActionsNoDuplicateRunIDs(env.T(), descResp.Info.RecentActions)
+	assertRecentActionsNoDuplicateRunIDs(env.T(), listResp.Info.RecentActions)
 }
 
 func testUpdateIntervalTakesEffect(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-update-interval"
 	wid := "sched-test-update-interval-wf"
@@ -1562,7 +1562,7 @@ func testUpdateIntervalTakesEffect(t *testing.T, newContext contextFactory) {
 		})
 		return nil
 	}
-	s.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 
 	// Create schedule with a long interval (300s) - won't fire for 5 minutes.
 	schedule := &schedulepb.Schedule{
@@ -1576,35 +1576,35 @@ func testUpdateIntervalTakesEffect(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	ctx := newContext(env.Context())
+	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	// Update the interval to be very short (1s).
 	schedule.Spec.Interval[0].Interval = durationpb.New(1 * time.Second)
-	_, err = s.FrontendClient().UpdateSchedule(ctx, &workflowservice.UpdateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	_, err = env.FrontendClient().UpdateSchedule(ctx, &workflowservice.UpdateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	// After updating to 1s interval, we should see runs start within a few seconds.
-	s.Eventually(
+	env.Eventually(
 		func() bool { return atomic.LoadInt32(&runs) >= 2 },
 		10*time.Second,
 		500*time.Millisecond,
@@ -1613,7 +1613,7 @@ func testUpdateIntervalTakesEffect(t *testing.T, newContext contextFactory) {
 }
 
 func testListScheduleMatchingTimes(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-list-matching-times"
 
@@ -1628,41 +1628,41 @@ func testListScheduleMatchingTimes(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   "wf-list-matching-times",
 					WorkflowType: &commonpb.WorkflowType{Name: "action"},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	}
 
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, req)
-	s.NoError(err)
+	ctx := newContext(env.Context())
+	_, err := env.FrontendClient().CreateSchedule(ctx, req)
+	env.NoError(err)
 
 	// Query for matching times over a 5-hour window.
 	now := time.Now().UTC().Truncate(time.Hour).Add(time.Hour) // Start of next hour
 	startTime := timestamppb.New(now)
 	endTime := timestamppb.New(now.Add(5 * time.Hour))
 
-	resp, err := s.FrontendClient().ListScheduleMatchingTimes(ctx, &workflowservice.ListScheduleMatchingTimesRequest{
-		Namespace:  s.Namespace().String(),
+	resp, err := env.FrontendClient().ListScheduleMatchingTimes(ctx, &workflowservice.ListScheduleMatchingTimesRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		StartTime:  startTime,
 		EndTime:    endTime,
 	})
-	s.NoError(err)
+	env.NoError(err)
 	// With 1-hour interval over 5 hours, we expect 5 matching times.
-	s.Len(resp.GetStartTime(), 5)
+	env.Len(resp.GetStartTime(), 5)
 }
 
 func testLimitMemoSpecSize(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	expectedLimit := scheduler.CurrentTweakablePolicies.SpecFieldLengthLimit
 
@@ -1677,7 +1677,7 @@ func testLimitMemoSpecSize(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
@@ -1709,22 +1709,22 @@ func testLimitMemoSpecSize(t *testing.T, newContext contextFactory) {
 
 	// Create the schedule.
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	}
-	s.SdkWorker().RegisterWorkflowWithOptions(
+	env.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error { return nil },
 		workflow.RegisterOptions{Name: wt},
 	)
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, req)
-	s.NoError(err)
+	ctx := newContext(env.Context())
+	_, err := env.FrontendClient().CreateSchedule(ctx, req)
+	env.NoError(err)
 
 	// Verify the memo field length limit was enforced.
-	entry := getScheduleEntryFromVisibility(t, s, sid, newContext, nil)
+	entry := getScheduleEntryFromVisibility(t, env, sid, newContext, nil)
 	require.NotNil(t, entry)
 	spec := entry.GetInfo().GetSpec()
 	require.Len(t, spec.GetInterval(), expectedLimit)
@@ -1733,7 +1733,7 @@ func testLimitMemoSpecSize(t *testing.T, newContext contextFactory) {
 }
 
 func testCountSchedules(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	// Create multiple schedules with different paused states
 	sidPrefix := "sched-test-count-"
@@ -1756,7 +1756,7 @@ func testCountSchedules(t *testing.T, newContext contextFactory) {
 					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 						WorkflowId:   fmt.Sprintf("%s-%d", wid, i),
 						WorkflowType: &commonpb.WorkflowType{Name: wt},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					},
 				},
 			},
@@ -1765,37 +1765,37 @@ func testCountSchedules(t *testing.T, newContext contextFactory) {
 			},
 		}
 
-		_, err := s.FrontendClient().CreateSchedule(newContext(s.Context()), &workflowservice.CreateScheduleRequest{
-			Namespace:  s.Namespace().String(),
+		_, err := env.FrontendClient().CreateSchedule(newContext(env.Context()), &workflowservice.CreateScheduleRequest{
+			Namespace:  env.Namespace().String(),
 			ScheduleId: sid,
 			Schedule:   schedule,
 			Identity:   "test",
 			RequestId:  uuid.NewString(),
 		})
-		s.NoError(err)
+		env.NoError(err)
 	}
 
 	// Test basic count (all schedules)
-	s.Eventually(func() bool {
-		countResp, err := s.FrontendClient().CountSchedules(newContext(s.Context()), &workflowservice.CountSchedulesRequest{
-			Namespace: s.Namespace().String(),
+	env.Eventually(func() bool {
+		countResp, err := env.FrontendClient().CountSchedules(newContext(env.Context()), &workflowservice.CountSchedulesRequest{
+			Namespace: env.Namespace().String(),
 		})
 		return err == nil && countResp.Count >= 3
 	}, 15*time.Second, 1*time.Second, "Expected at least 3 schedules")
 
 	// Test count with query filter for paused schedules
-	s.Eventually(func() bool {
-		countResp, err := s.FrontendClient().CountSchedules(newContext(s.Context()), &workflowservice.CountSchedulesRequest{
-			Namespace: s.Namespace().String(),
+	env.Eventually(func() bool {
+		countResp, err := env.FrontendClient().CountSchedules(newContext(env.Context()), &workflowservice.CountSchedulesRequest{
+			Namespace: env.Namespace().String(),
 			Query:     fmt.Sprintf("%s = true", sadefs.TemporalSchedulePaused),
 		})
 		return err == nil && countResp.Count >= 1
 	}, 15*time.Second, 1*time.Second, "Expected at least 1 paused schedule")
 
 	// Test count with query filter for non-paused schedules
-	s.Eventually(func() bool {
-		countResp, err := s.FrontendClient().CountSchedules(newContext(s.Context()), &workflowservice.CountSchedulesRequest{
-			Namespace: s.Namespace().String(),
+	env.Eventually(func() bool {
+		countResp, err := env.FrontendClient().CountSchedules(newContext(env.Context()), &workflowservice.CountSchedulesRequest{
+			Namespace: env.Namespace().String(),
 			Query:     fmt.Sprintf("%s = false", sadefs.TemporalSchedulePaused),
 		})
 		return err == nil && countResp.Count >= 2
@@ -1803,7 +1803,7 @@ func testCountSchedules(t *testing.T, newContext contextFactory) {
 }
 
 func testListSchedulesPagination(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	const numSchedules = 4
 	sidPrefix := "sched-test-pagination-"
@@ -1821,40 +1821,40 @@ func testListSchedulesPagination(t *testing.T, newContext contextFactory) {
 					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 						WorkflowId:   fmt.Sprintf("wf-pagination-%d", i),
 						WorkflowType: &commonpb.WorkflowType{Name: "action"},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					},
 				},
 			},
 		}
-		_, err := s.FrontendClient().CreateSchedule(newContext(s.Context()), &workflowservice.CreateScheduleRequest{
-			Namespace:  s.Namespace().String(),
+		_, err := env.FrontendClient().CreateSchedule(newContext(env.Context()), &workflowservice.CreateScheduleRequest{
+			Namespace:  env.Namespace().String(),
 			ScheduleId: sid,
 			Schedule:   schedule,
 			Identity:   "test",
 			RequestId:  uuid.NewString(),
 		})
-		s.NoError(err)
+		env.NoError(err)
 	}
 
 	// Wait for all schedules to be visible.
-	s.Eventually(func() bool {
-		countResp, err := s.FrontendClient().CountSchedules(newContext(s.Context()), &workflowservice.CountSchedulesRequest{
-			Namespace: s.Namespace().String(),
+	env.Eventually(func() bool {
+		countResp, err := env.FrontendClient().CountSchedules(newContext(env.Context()), &workflowservice.CountSchedulesRequest{
+			Namespace: env.Namespace().String(),
 		})
 		return err == nil && countResp.Count >= numSchedules
 	}, 15*time.Second, 1*time.Second, "Expected all schedules to be visible")
 
 	// Paginate with page size 2 and collect all schedule IDs.
-	ctx := newContext(s.Context())
+	ctx := newContext(env.Context())
 	var allIDs []string
 	var nextPageToken []byte
 	for {
-		resp, err := s.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
-			Namespace:       s.Namespace().String(),
+		resp, err := env.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
+			Namespace:       env.Namespace().String(),
 			MaximumPageSize: 2,
 			NextPageToken:   nextPageToken,
 		})
-		s.NoError(err)
+		env.NoError(err)
 		for _, entry := range resp.Schedules {
 			allIDs = append(allIDs, entry.ScheduleId)
 		}
@@ -1863,18 +1863,18 @@ func testListSchedulesPagination(t *testing.T, newContext contextFactory) {
 			break
 		}
 		// Each page except possibly the last should have entries.
-		s.NotEmpty(resp.Schedules)
+		env.NotEmpty(resp.Schedules)
 	}
 
 	// Verify we found all created schedules.
 	for i := range numSchedules {
 		sid := fmt.Sprintf("%s%d", sidPrefix, i)
-		s.Contains(allIDs, sid, "Expected schedule %s in paginated results", sid)
+		env.Contains(allIDs, sid, "Expected schedule %s in paginated results", sid)
 	}
 }
 
 func testListSchedulesFilterAndEntryFields(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-list-fields"
 	wt := "sched-test-list-fields-wt"
@@ -1895,7 +1895,7 @@ func testListSchedulesFilterAndEntryFields(t *testing.T, newContext contextFacto
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   "wf-" + sid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
@@ -1905,9 +1905,9 @@ func testListSchedulesFilterAndEntryFields(t *testing.T, newContext contextFacto
 		},
 	}
 
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	ctx := newContext(env.Context())
+	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -1923,24 +1923,24 @@ func testListSchedulesFilterAndEntryFields(t *testing.T, newContext contextFacto
 			},
 		},
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	// Wait for the schedule to appear with correct paused state.
-	entry := getScheduleEntryFromVisibility(t, s, sid, newContext, func(e *schedulepb.ScheduleListEntry) bool {
+	entry := getScheduleEntryFromVisibility(t, env, sid, newContext, func(e *schedulepb.ScheduleListEntry) bool {
 		return e.Info.Paused
 	})
 
 	// Verify entry-level fields.
-	s.Equal(schMemo.Data, entry.Memo.Fields["schedmemo1"].Data)
-	s.Equal(schSAValue.Data, entry.SearchAttributes.IndexedFields[csaKeyword].Data)
-	s.Equal(wt, entry.Info.WorkflowType.Name)
-	s.True(entry.Info.Paused)
-	s.Equal("paused for test", entry.Info.Notes)
+	env.Equal(schMemo.Data, entry.Memo.Fields["schedmemo1"].Data)
+	env.Equal(schSAValue.Data, entry.SearchAttributes.IndexedFields[csaKeyword].Data)
+	env.Equal(wt, entry.Info.WorkflowType.Name)
+	env.True(entry.Info.Paused)
+	env.Equal("paused for test", entry.Info.Notes)
 
 	// Filter by TemporalSchedulePaused should find this schedule.
-	s.EventuallyWithT(func(c *assert.CollectT) {
-		listResp, err := s.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
-			Namespace:       s.Namespace().String(),
+	env.EventuallyWithT(func(c *assert.CollectT) {
+		listResp, err := env.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
+			Namespace:       env.Namespace().String(),
 			MaximumPageSize: 10,
 			Query:           fmt.Sprintf("%s = true", sadefs.TemporalSchedulePaused),
 		})
@@ -1953,9 +1953,9 @@ func testListSchedulesFilterAndEntryFields(t *testing.T, newContext contextFacto
 	}, 15*time.Second, 1*time.Second)
 
 	// Filter for paused=false should not include this schedule.
-	s.EventuallyWithT(func(c *assert.CollectT) {
-		listResp, err := s.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
-			Namespace:       s.Namespace().String(),
+	env.EventuallyWithT(func(c *assert.CollectT) {
+		listResp, err := env.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
+			Namespace:       env.Namespace().String(),
 			MaximumPageSize: 10,
 			Query:           fmt.Sprintf("%s = false", sadefs.TemporalSchedulePaused),
 		})
@@ -1967,7 +1967,7 @@ func testListSchedulesFilterAndEntryFields(t *testing.T, newContext contextFacto
 }
 
 func testListSchedulesFilterByScheduleID(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid1 := "sched-filter-by-id-alpha"
 	sid2 := "sched-filter-by-id-beta"
@@ -1984,7 +1984,7 @@ func testListSchedulesFilterByScheduleID(t *testing.T, newContext contextFactory
 					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 						WorkflowId:   "wf-" + sid,
 						WorkflowType: &commonpb.WorkflowType{Name: "action"},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					},
 				},
 			},
@@ -1992,28 +1992,28 @@ func testListSchedulesFilterByScheduleID(t *testing.T, newContext contextFactory
 		}
 	}
 
-	ctx := newContext(s.Context())
+	ctx := newContext(env.Context())
 
 	// Create two schedules.
 	for _, sid := range []string{sid1, sid2} {
-		_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-			Namespace:  s.Namespace().String(),
+		_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+			Namespace:  env.Namespace().String(),
 			ScheduleId: sid,
 			Schedule:   schedule(sid),
 			Identity:   "test",
 			RequestId:  uuid.NewString(),
 		})
-		s.NoError(err)
+		env.NoError(err)
 	}
 
 	// Wait for both schedules to appear in visibility.
-	getScheduleEntryFromVisibility(t, s, sid1, newContext, nil)
-	getScheduleEntryFromVisibility(t, s, sid2, newContext, nil)
+	getScheduleEntryFromVisibility(t, env, sid1, newContext, nil)
+	getScheduleEntryFromVisibility(t, env, sid2, newContext, nil)
 
 	listScheduleIDs := func(query string) []string {
 		t.Helper()
-		listResp, err := s.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
-			Namespace:       s.Namespace().String(),
+		listResp, err := env.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
+			Namespace:       env.Namespace().String(),
 			MaximumPageSize: 10,
 			Query:           query,
 		})
@@ -2086,7 +2086,7 @@ func testListSchedulesFilterByScheduleID(t *testing.T, newContext contextFactory
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			s.EventuallyWithT(func(c *assert.CollectT) {
+			env.EventuallyWithT(func(c *assert.CollectT) {
 				ids := listScheduleIDs(tc.query)
 				require.Len(c, ids, len(tc.wantIDs))
 				for _, want := range tc.wantIDs {
@@ -2098,7 +2098,7 @@ func testListSchedulesFilterByScheduleID(t *testing.T, newContext contextFactory
 }
 
 func testScheduleInternalTaskQueue(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 	errorMessageKeyword := "internal per-namespace task queue"
 
 	// Test CreateSchedule with internal task queue
@@ -2121,15 +2121,15 @@ func testScheduleInternalTaskQueue(t *testing.T, newContext contextFactory) {
 			},
 		}
 		req := &workflowservice.CreateScheduleRequest{
-			Namespace:  s.Namespace().String(),
+			Namespace:  env.Namespace().String(),
 			ScheduleId: sid,
 			Schedule:   schedule,
 			Identity:   "test",
 			RequestId:  uuid.NewString(),
 		}
 
-		ctx := newContext(s.Context())
-		_, err := s.FrontendClient().CreateSchedule(ctx, req)
+		ctx := newContext(env.Context())
+		_, err := env.FrontendClient().CreateSchedule(ctx, req)
 		require.Error(t, err)
 		var invalidArgument *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgument)
@@ -2151,21 +2151,21 @@ func testScheduleInternalTaskQueue(t *testing.T, newContext contextFactory) {
 					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 						WorkflowId:   "wf-update-internal-tq",
 						WorkflowType: &commonpb.WorkflowType{Name: "action"},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					},
 				},
 			},
 		}
 		req := &workflowservice.CreateScheduleRequest{
-			Namespace:  s.Namespace().String(),
+			Namespace:  env.Namespace().String(),
 			ScheduleId: sid,
 			Schedule:   schedule,
 			Identity:   "test",
 			RequestId:  uuid.NewString(),
 		}
 
-		ctx := newContext(s.Context())
-		_, err := s.FrontendClient().CreateSchedule(ctx, req)
+		ctx := newContext(env.Context())
+		_, err := env.FrontendClient().CreateSchedule(ctx, req)
 		require.NoError(t, err)
 
 		// Now try to update with internal task queue
@@ -2174,14 +2174,14 @@ func testScheduleInternalTaskQueue(t *testing.T, newContext contextFactory) {
 			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		}
 		updateReq := &workflowservice.UpdateScheduleRequest{
-			Namespace:  s.Namespace().String(),
+			Namespace:  env.Namespace().String(),
 			ScheduleId: sid,
 			Schedule:   schedule,
 			Identity:   "test",
 			RequestId:  uuid.NewString(),
 		}
 
-		_, err = s.FrontendClient().UpdateSchedule(ctx, updateReq)
+		_, err = env.FrontendClient().UpdateSchedule(ctx, updateReq)
 		require.Error(t, err)
 		var invalidArgument *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgument)
@@ -2190,24 +2190,24 @@ func testScheduleInternalTaskQueue(t *testing.T, newContext contextFactory) {
 }
 
 func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, enableCHASMCallbacks bool) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
-	s.OverrideDynamicConfig(dynamicconfig.EnableCHASMCallbacks, enableCHASMCallbacks)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env.OverrideDynamicConfig(dynamicconfig.EnableCHASMCallbacks, enableCHASMCallbacks)
 
 	sid := "sched-test-double-reset"
 	wid := "sched-test-double-reset-wf"
 	wt := "sched-test-double-reset-wt"
 
-	s.SdkWorker().RegisterWorkflowWithOptions(func(ctx workflow.Context) error {
+	env.SdkWorker().RegisterWorkflowWithOptions(func(ctx workflow.Context) error {
 		ch := workflow.GetSignalChannel(ctx, "complete")
 		var signal any
 		ch.Receive(ctx, &signal)
 		return nil
 	}, workflow.RegisterOptions{Name: wt})
 
-	ctx := newContext(s.Context())
+	ctx := newContext(env.Context())
 
-	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule: &schedulepb.Schedule{
 			Spec: &schedulepb.ScheduleSpec{
@@ -2220,7 +2220,7 @@ func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, e
 					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 						WorkflowId:   wid,
 						WorkflowType: &commonpb.WorkflowType{Name: wt},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					},
 				},
 			},
@@ -2230,10 +2230,10 @@ func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, e
 		},
 		RequestId: uuid.NewString(),
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	// Wait for scheduler to start the workflow and show it as RUNNING.
-	listEntry := getScheduleEntryFromVisibility(t, s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	listEntry := getScheduleEntryFromVisibility(t, env, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		return len(ent.Info.RecentActions) >= 1 &&
 			ent.Info.RecentActions[0].GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
 	})
@@ -2243,21 +2243,21 @@ func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, e
 		RunId:      a1.StartWorkflowResult.RunId,
 	}
 
-	s.WaitForHistoryEvents(`
+	env.WaitForHistoryEvents(`
 		1 WorkflowExecutionStarted
 		2 WorkflowTaskScheduled
 		3 WorkflowTaskStarted
 		4 WorkflowTaskCompleted`,
-		s.GetHistoryFunc(s.Namespace().String(), wfExec),
+		env.GetHistoryFunc(env.Namespace().String(), wfExec),
 		5*time.Second,
 		10*time.Millisecond,
 	)
 
-	origDesc, err := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-		Namespace: s.Namespace().String(),
+	origDesc, err := env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: env.Namespace().String(),
 		Execution: wfExec,
 	})
-	s.NoError(err)
+	env.NoError(err)
 	var originalStartReqID string
 	for reqID, info := range origDesc.GetWorkflowExtendedInfo().GetRequestIdInfos() {
 		if info.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED {
@@ -2265,24 +2265,24 @@ func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, e
 			break
 		}
 	}
-	s.NotEmpty(originalStartReqID, "original run must have a request ID for WorkflowExecutionStarted")
+	env.NotEmpty(originalStartReqID, "original run must have a request ID for WorkflowExecutionStarted")
 
-	resp1, err := s.FrontendClient().ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
-		Namespace:                 s.Namespace().String(),
+	resp1, err := env.FrontendClient().ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
+		Namespace:                 env.Namespace().String(),
 		WorkflowExecution:         wfExec,
 		Reason:                    "double-reset-test-first",
 		WorkflowTaskFinishEventId: 3,
 		RequestId:                 uuid.NewString(),
 	})
-	s.NoError(err)
+	env.NoError(err)
 	resetRun1 := &commonpb.WorkflowExecution{
 		WorkflowId: wfExec.WorkflowId,
 		RunId:      resp1.RunId,
 	}
 
-	s.EventuallyWithT(func(col *assert.CollectT) {
-		resetDesc, err := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-			Namespace: s.Namespace().String(),
+	env.EventuallyWithT(func(col *assert.CollectT) {
+		resetDesc, err := env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
 			Execution: resetRun1,
 		})
 		require.NoError(col, err)
@@ -2297,22 +2297,22 @@ func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, e
 			"start request ID must be preserved across first reset")
 	}, 10*time.Second, 100*time.Millisecond)
 
-	resp2, err := s.FrontendClient().ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
-		Namespace:                 s.Namespace().String(),
+	resp2, err := env.FrontendClient().ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
+		Namespace:                 env.Namespace().String(),
 		WorkflowExecution:         resetRun1,
 		Reason:                    "double-reset-test-second",
 		WorkflowTaskFinishEventId: 3,
 		RequestId:                 uuid.NewString(),
 	})
-	s.NoError(err)
+	env.NoError(err)
 	resetRun2 := &commonpb.WorkflowExecution{
 		WorkflowId: wfExec.WorkflowId,
 		RunId:      resp2.RunId,
 	}
 
-	s.EventuallyWithT(func(col *assert.CollectT) {
-		resetDesc, err := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-			Namespace: s.Namespace().String(),
+	env.EventuallyWithT(func(col *assert.CollectT) {
+		resetDesc, err := env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
 			Execution: resetRun2,
 		})
 		require.NoError(col, err)
@@ -2327,16 +2327,16 @@ func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, e
 			"start request ID must be preserved across double reset")
 	}, 10*time.Second, 100*time.Millisecond)
 
-	_, err = s.FrontendClient().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
-		Namespace: s.Namespace().String(),
+	_, err = env.FrontendClient().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
+		Namespace: env.Namespace().String(),
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: wfExec.WorkflowId,
 		},
 		SignalName: "complete",
 	})
-	s.NoError(err)
+	env.NoError(err)
 
-	getScheduleEntryFromVisibility(t, s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	getScheduleEntryFromVisibility(t, env, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		for _, action := range ent.Info.RecentActions {
 			if action.GetStartWorkflowResult().GetRunId() == wfExec.RunId {
 				return action.GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
@@ -2347,9 +2347,9 @@ func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, e
 }
 
 func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, enableCHASMCallbacks bool) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
-	s.OverrideDynamicConfig(dynamicconfig.EnableCHASMCallbacks, enableCHASMCallbacks)
-	s.OverrideDynamicConfig(
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env.OverrideDynamicConfig(dynamicconfig.EnableCHASMCallbacks, enableCHASMCallbacks)
+	env.OverrideDynamicConfig(
 		callback.AllowedAddresses,
 		[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}},
 	)
@@ -2373,17 +2373,17 @@ func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, en
 		return srv.URL + "/callback"
 	}()
 
-	s.SdkWorker().RegisterWorkflowWithOptions(func(ctx workflow.Context) error {
+	env.SdkWorker().RegisterWorkflowWithOptions(func(ctx workflow.Context) error {
 		sigCh := workflow.GetSignalChannel(ctx, "complete")
 		var signal any
 		sigCh.Receive(ctx, &signal)
 		return nil
 	}, workflow.RegisterOptions{Name: wt})
 
-	ctx := newContext(s.Context())
+	ctx := newContext(env.Context())
 
-	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule: &schedulepb.Schedule{
 			Spec: &schedulepb.ScheduleSpec{
@@ -2396,7 +2396,7 @@ func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, en
 					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 						WorkflowId:   wid,
 						WorkflowType: &commonpb.WorkflowType{Name: wt},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					},
 				},
 			},
@@ -2406,9 +2406,9 @@ func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, en
 		},
 		RequestId: uuid.NewString(),
 	})
-	s.NoError(err)
+	env.NoError(err)
 
-	listEntry := getScheduleEntryFromVisibility(t, s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	listEntry := getScheduleEntryFromVisibility(t, env, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		return len(ent.Info.RecentActions) >= 1 &&
 			ent.Info.RecentActions[0].GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
 	})
@@ -2418,23 +2418,23 @@ func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, en
 		RunId:      a1.StartWorkflowResult.RunId,
 	}
 
-	s.WaitForHistoryEvents(`
+	env.WaitForHistoryEvents(`
 		1 WorkflowExecutionStarted
 		2 WorkflowTaskScheduled
 		3 WorkflowTaskStarted
 		4 WorkflowTaskCompleted`,
-		s.GetHistoryFunc(s.Namespace().String(), wfExec),
+		env.GetHistoryFunc(env.Namespace().String(), wfExec),
 		5*time.Second,
 		10*time.Millisecond,
 	)
 
 	attachRequestID := uuid.NewString()
-	attachResp, err := s.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+	attachResp, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:                attachRequestID,
-		Namespace:                s.Namespace().String(),
+		Namespace:                env.Namespace().String(),
 		WorkflowId:               wfExec.WorkflowId,
 		WorkflowType:             &commonpb.WorkflowType{Name: wt},
-		TaskQueue:                &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		TaskQueue:                &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		WorkflowIdConflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
 		OnConflictOptions: &workflowpb.OnConflictOptions{
 			AttachRequestId:           true,
@@ -2450,37 +2450,37 @@ func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, en
 			},
 		},
 	})
-	s.NoError(err)
-	s.False(attachResp.Started, "expected to attach to existing run, not start a new one")
+	env.NoError(err)
+	env.False(attachResp.Started, "expected to attach to existing run, not start a new one")
 
-	s.WaitForHistoryEvents(`
+	env.WaitForHistoryEvents(`
 		1 WorkflowExecutionStarted
 		2 WorkflowTaskScheduled
 		3 WorkflowTaskStarted
 		4 WorkflowTaskCompleted
 		5 WorkflowExecutionOptionsUpdated`,
-		s.GetHistoryFunc(s.Namespace().String(), wfExec),
+		env.GetHistoryFunc(env.Namespace().String(), wfExec),
 		5*time.Second,
 		10*time.Millisecond,
 	)
 
-	resetResp, err := s.FrontendClient().ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
-		Namespace:                 s.Namespace().String(),
+	resetResp, err := env.FrontendClient().ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
+		Namespace:                 env.Namespace().String(),
 		WorkflowExecution:         wfExec,
 		Reason:                    "reset-with-additional-callback-test",
 		WorkflowTaskFinishEventId: 3,
 		RequestId:                 uuid.NewString(),
 	})
-	s.NoError(err)
+	env.NoError(err)
 	resetRun := &commonpb.WorkflowExecution{
 		WorkflowId: wfExec.WorkflowId,
 		RunId:      resetResp.RunId,
 	}
 
 	var startRequestID string
-	s.EventuallyWithT(func(col *assert.CollectT) {
-		descResp, err := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-			Namespace: s.Namespace().String(),
+	env.EventuallyWithT(func(col *assert.CollectT) {
+		descResp, err := env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
 			Execution: resetRun,
 		})
 		require.NoError(col, err)
@@ -2500,16 +2500,16 @@ func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, en
 			"schedule callback and manually-attached callback must have different request IDs")
 	}, 10*time.Second, 100*time.Millisecond)
 
-	_, err = s.FrontendClient().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
-		Namespace: s.Namespace().String(),
+	_, err = env.FrontendClient().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
+		Namespace: env.Namespace().String(),
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: wfExec.WorkflowId,
 		},
 		SignalName: "complete",
 	})
-	s.NoError(err)
+	env.NoError(err)
 
-	getScheduleEntryFromVisibility(t, s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	getScheduleEntryFromVisibility(t, env, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		for _, action := range ent.Info.RecentActions {
 			if action.GetStartWorkflowResult().GetRunId() == wfExec.RunId {
 				return action.GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
@@ -2520,17 +2520,17 @@ func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, en
 
 	select {
 	case completion := <-ch.requestCh:
-		s.Equal(nexus.OperationStateSucceeded, completion.State)
+		env.Equal(nexus.OperationStateSucceeded, completion.State)
 		ch.requestCompleteCh <- nil
 	case <-time.After(10 * time.Second):
-		s.Fail("timeout waiting for second callback to be delivered")
+		env.Fail("timeout waiting for second callback to be delivered")
 	}
 }
 
 // testCreatesWorkflowSentinel tests that creating a CHASM schedule also starts a
 // dummy workflow to reserve the schedule ID in the V1 workflow ID-space.
 func testCreatesWorkflowSentinel(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sid")
 	wid := testcore.RandomizeStr("wid")
@@ -2547,53 +2547,53 @@ func testCreatesWorkflowSentinel(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	ctx := newContext(env.Context())
+	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   testcore.RandomizeStr("identity"),
 		RequestId:  testcore.RandomizeStr("request-id"),
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	// Verify the dummy workflow was created to reserve the V1 workflow ID.
 	sentinelWfID := scheduler.WorkflowIDPrefix + sid
 	var descResp *workflowservice.DescribeWorkflowExecutionResponse
-	s.Eventually(func() bool {
-		descResp, err = s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-			Namespace: s.Namespace().String(),
+	env.Eventually(func() bool {
+		descResp, err = env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
 			Execution: &commonpb.WorkflowExecution{WorkflowId: sentinelWfID},
 		})
 		return err == nil
 	}, 15*time.Second, 500*time.Millisecond, "dummy sentinel workflow should exist")
-	s.Equal(dummy.DummyWFTypeName, descResp.WorkflowExecutionInfo.Type.Name)
-	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, descResp.WorkflowExecutionInfo.Status)
+	env.Equal(dummy.DummyWFTypeName, descResp.WorkflowExecutionInfo.Type.Name)
+	env.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, descResp.WorkflowExecutionInfo.Status)
 
 	// Verify visibility shows exactly one schedule (not the dummy workflow).
-	getScheduleEntryFromVisibility(t, s, sid, newContext, nil)
-	listResp, err := s.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
-		Namespace:       s.Namespace().String(),
+	getScheduleEntryFromVisibility(t, env, sid, newContext, nil)
+	listResp, err := env.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
+		Namespace:       env.Namespace().String(),
 		MaximumPageSize: 5,
 	})
-	s.NoError(err)
-	s.Len(listResp.Schedules, 1)
+	env.NoError(err)
+	env.Len(listResp.Schedules, 1)
 
-	countResp, err := s.FrontendClient().CountSchedules(ctx, &workflowservice.CountSchedulesRequest{
-		Namespace: s.Namespace().String(),
+	countResp, err := env.FrontendClient().CountSchedules(ctx, &workflowservice.CountSchedulesRequest{
+		Namespace: env.Namespace().String(),
 	})
-	s.NoError(err)
-	s.Equal(int64(1), countResp.Count)
+	env.NoError(err)
+	env.Equal(int64(1), countResp.Count)
 }
 
 func testStateSizeBytesReported(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-state-size")
 	wid := testcore.RandomizeStr("sched-state-size-wf")
@@ -2610,35 +2610,35 @@ func testStateSizeBytesReported(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 		State: &schedulepb.ScheduleState{Paused: true},
 	}
 
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	ctx := newContext(env.Context())
+	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	})
-	s.NoError(err)
+	env.NoError(err)
 
-	desc, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	desc, err := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 	})
-	s.NoError(err)
-	s.Positive(desc.GetInfo().GetStateSizeBytes(), "Describe should report a non-zero StateSizeBytes")
+	env.NoError(err)
+	env.Positive(desc.GetInfo().GetStateSizeBytes(), "Describe should report a non-zero StateSizeBytes")
 }
 
 // testCreatesCHASMSentinel tests that creating a V1 schedule also creates a
 // CHASM sentinel to reserve the schedule ID in the CHASM execution space.
 func testCreatesCHASMSentinel(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sid")
 	wid := testcore.RandomizeStr("wid")
@@ -2655,31 +2655,31 @@ func testCreatesCHASMSentinel(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	ctx := newContext(env.Context())
+	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   testcore.RandomizeStr("identity"),
 		RequestId:  testcore.RandomizeStr("request-id"),
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	// Verify a CHASM sentinel was created to reserve the schedule ID.
 	// DescribeSchedule should return NotFound, as well as CreateSentinel
-	nsID := s.NamespaceID().String()
-	s.Eventually(func() bool {
-		_, descErr := s.GetTestCluster().SchedulerClient().DescribeSchedule(
+	nsID := env.NamespaceID().String()
+	env.Eventually(func() bool {
+		_, descErr := env.GetTestCluster().SchedulerClient().DescribeSchedule(
 			ctx,
 			&schedulerpb.DescribeScheduleRequest{
 				NamespaceId:     nsID,
-				FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: s.Namespace().String(), ScheduleId: sid},
+				FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: env.Namespace().String(), ScheduleId: sid},
 			},
 		)
 		var notFoundErr *serviceerror.NotFound
@@ -2689,12 +2689,12 @@ func testCreatesCHASMSentinel(t *testing.T, newContext contextFactory) {
 
 		// A CHASM CreateSchedule should also fail with NotFound because
 		// the sentinel blocks it.
-		_, createErr := s.GetTestCluster().SchedulerClient().CreateSchedule(
+		_, createErr := env.GetTestCluster().SchedulerClient().CreateSchedule(
 			ctx,
 			&schedulerpb.CreateScheduleRequest{
 				NamespaceId: nsID,
 				FrontendRequest: &workflowservice.CreateScheduleRequest{
-					Namespace:  s.Namespace().String(),
+					Namespace:  env.Namespace().String(),
 					ScheduleId: sid,
 					RequestId:  testcore.RandomizeStr("test-sentinel-check"),
 					Schedule:   schedule,
@@ -2705,25 +2705,25 @@ func testCreatesCHASMSentinel(t *testing.T, newContext contextFactory) {
 	}, 15*time.Second, 500*time.Millisecond, "CHASM sentinel should exist for V1 schedule")
 
 	// Verify visibility shows exactly one schedule (not the sentinel).
-	getScheduleEntryFromVisibility(t, s, sid, newContext, nil)
-	listResp, err := s.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
-		Namespace:       s.Namespace().String(),
+	getScheduleEntryFromVisibility(t, env, sid, newContext, nil)
+	listResp, err := env.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
+		Namespace:       env.Namespace().String(),
 		MaximumPageSize: 5,
 	})
-	s.NoError(err)
-	s.Len(listResp.Schedules, 1)
+	env.NoError(err)
+	env.Len(listResp.Schedules, 1)
 
-	countResp, err := s.FrontendClient().CountSchedules(ctx, &workflowservice.CountSchedulesRequest{
-		Namespace: s.Namespace().String(),
+	countResp, err := env.FrontendClient().CountSchedules(ctx, &workflowservice.CountSchedulesRequest{
+		Namespace: env.Namespace().String(),
 	})
-	s.NoError(err)
-	s.Equal(int64(1), countResp.Count)
+	env.NoError(err)
+	env.Equal(int64(1), countResp.Count)
 }
 
 // testSkipsWorkflowSentinelWhenDisabled asserts that a CHASM CreateSchedule
 // does not start the dummy V1 workflow when EnableCHASMSchedulerSentinels is off.
 func testSkipsWorkflowSentinelWhenDisabled(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, append(scheduleCommonOpts(t),
+	env := newScheduleEnv(t, append(scheduleCommonOpts(t),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerSentinels, false),
 	)...)
 
@@ -2742,37 +2742,37 @@ func testSkipsWorkflowSentinelWhenDisabled(t *testing.T, newContext contextFacto
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	ctx := newContext(env.Context())
+	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   testcore.RandomizeStr("identity"),
 		RequestId:  testcore.RandomizeStr("request-id"),
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	// The dummy V1 workflow that reserves the schedule ID is gated on the
 	// sentinel flag, so it must not exist.
 	sentinelWfID := scheduler.WorkflowIDPrefix + sid
-	_, descErr := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-		Namespace: s.Namespace().String(),
+	_, descErr := env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: env.Namespace().String(),
 		Execution: &commonpb.WorkflowExecution{WorkflowId: sentinelWfID},
 	})
 	var notFoundErr *serviceerror.NotFound
-	s.ErrorAs(descErr, &notFoundErr, "no dummy sentinel workflow should be created when sentinels are disabled")
+	env.ErrorAs(descErr, &notFoundErr, "no dummy sentinel workflow should be created when sentinels are disabled")
 }
 
 // testSkipsCHASMSentinelWhenDisabled asserts that a V1 CreateSchedule does not
 // create a CHASM sentinel when EnableCHASMSchedulerSentinels is off.
 func testSkipsCHASMSentinelWhenDisabled(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, append(scheduleCommonOpts(t),
+	env := newScheduleEnv(t, append(scheduleCommonOpts(t),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerSentinels, false),
 	)...)
 
@@ -2791,42 +2791,42 @@ func testSkipsCHASMSentinelWhenDisabled(t *testing.T, newContext contextFactory)
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	ctx := newContext(env.Context())
+	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   testcore.RandomizeStr("identity"),
 		RequestId:  testcore.RandomizeStr("request-id"),
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	// With no CHASM sentinel reserving the ID, a CHASM CreateSchedule for the
 	// same ID must not be blocked by the NotFound (sentinel) signal.
-	nsID := s.NamespaceID().String()
-	_, createErr := s.GetTestCluster().SchedulerClient().CreateSchedule(
+	nsID := env.NamespaceID().String()
+	_, createErr := env.GetTestCluster().SchedulerClient().CreateSchedule(
 		ctx,
 		&schedulerpb.CreateScheduleRequest{
 			NamespaceId: nsID,
 			FrontendRequest: &workflowservice.CreateScheduleRequest{
-				Namespace:  s.Namespace().String(),
+				Namespace:  env.Namespace().String(),
 				ScheduleId: sid,
 				RequestId:  testcore.RandomizeStr("test-no-sentinel"),
 				Schedule:   schedule,
 			},
 		},
 	)
-	s.NoError(createErr, "no CHASM sentinel should block CreateSchedule when sentinels are disabled, got: %v", createErr)
+	env.NoError(createErr, "no CHASM sentinel should block CreateSchedule when sentinels are disabled, got: %v", createErr)
 }
 
 func testCreateScheduleAlreadyExists(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-already-exists"
 
@@ -2841,31 +2841,31 @@ func testCreateScheduleAlreadyExists(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   "wf-already-exists",
 					WorkflowType: &commonpb.WorkflowType{Name: "action"},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	}
 
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, req)
-	s.NoError(err)
+	ctx := newContext(env.Context())
+	_, err := env.FrontendClient().CreateSchedule(ctx, req)
+	env.NoError(err)
 
 	// Try to create again with a different request ID - should fail with AlreadyExists
 	req.RequestId = uuid.NewString()
-	_, err = s.FrontendClient().CreateSchedule(ctx, req)
-	s.Error(err)
+	_, err = env.FrontendClient().CreateSchedule(ctx, req)
+	env.Error(err)
 
 	var alreadyStarted *serviceerror.WorkflowExecutionAlreadyStarted
-	s.ErrorAs(err, &alreadyStarted)
-	s.Contains(err.Error(), sid)
+	env.ErrorAs(err, &alreadyStarted)
+	env.Contains(err.Error(), sid)
 }
 
 // CreateSchedule is special-cased in the SDKs to translate
@@ -2877,7 +2877,7 @@ func testCreateScheduleDuplicateSdkError(t *testing.T, useCHASM bool) {
 	if useCHASM {
 		opts = append(opts, testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, true))
 	}
-	s := newScheduleEnv(t, opts...)
+	env := newScheduleEnv(t, opts...)
 
 	sid := "sched-test-duplicate-sdk-" + uuid.NewString()[:8]
 	schedOpts := sdkclient.ScheduleOptions{
@@ -2886,22 +2886,22 @@ func testCreateScheduleDuplicateSdkError(t *testing.T, useCHASM bool) {
 		Action: &sdkclient.ScheduleWorkflowAction{
 			ID:        "wf-" + sid,
 			Workflow:  "noop",
-			TaskQueue: s.WorkerTaskQueue(),
+			TaskQueue: env.WorkerTaskQueue(),
 		},
 		Paused: true,
 	}
 
-	ctx := s.Context()
-	handle, err := s.SdkClient().ScheduleClient().Create(ctx, schedOpts)
-	s.NoError(err)
+	ctx := env.Context()
+	handle, err := env.SdkClient().ScheduleClient().Create(ctx, schedOpts)
+	env.NoError(err)
 	defer func() { _ = handle.Delete(context.Background()) }()
 
-	_, err = s.SdkClient().ScheduleClient().Create(ctx, schedOpts)
-	s.ErrorIs(err, temporal.ErrScheduleAlreadyRunning)
+	_, err = env.SdkClient().ScheduleClient().Create(ctx, schedOpts)
+	env.ErrorIs(err, temporal.ErrScheduleAlreadyRunning)
 }
 
 func testPatchRejectsExcessBackfillers(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 	sid := "sched-test-too-many-backfillers"
 	wt := "sched-test-too-many-backfillers-wt"
 
@@ -2916,22 +2916,22 @@ func testPatchRejectsExcessBackfillers(t *testing.T, newContext contextFactory) 
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   "wf-too-many-backfillers",
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 		State: &schedulepb.ScheduleState{Paused: true},
 	}
 
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	ctx := newContext(env.Context())
+	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	// Patch with 50 backfill requests at a time until we reach the limit of 100.
 	now := time.Now()
@@ -2944,8 +2944,8 @@ func testPatchRejectsExcessBackfillers(t *testing.T, newContext contextFactory) 
 				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
 			}
 		}
-		_, err = s.FrontendClient().PatchSchedule(ctx, &workflowservice.PatchScheduleRequest{
-			Namespace:  s.Namespace().String(),
+		_, err = env.FrontendClient().PatchSchedule(ctx, &workflowservice.PatchScheduleRequest{
+			Namespace:  env.Namespace().String(),
 			ScheduleId: sid,
 			Patch: &schedulepb.SchedulePatch{
 				BackfillRequest: backfills,
@@ -2953,12 +2953,12 @@ func testPatchRejectsExcessBackfillers(t *testing.T, newContext contextFactory) 
 			Identity:  "test",
 			RequestId: uuid.NewString(),
 		})
-		s.NoError(err)
+		env.NoError(err)
 	}
 
 	// The next patch should be rejected.
-	_, err = s.FrontendClient().PatchSchedule(ctx, &workflowservice.PatchScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	_, err = env.FrontendClient().PatchSchedule(ctx, &workflowservice.PatchScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Patch: &schedulepb.SchedulePatch{
 			BackfillRequest: []*schedulepb.BackfillRequest{
@@ -2972,21 +2972,21 @@ func testPatchRejectsExcessBackfillers(t *testing.T, newContext contextFactory) 
 		Identity:  "test",
 		RequestId: uuid.NewString(),
 	})
-	s.Error(err)
+	env.Error(err)
 	var failedPrecondition *serviceerror.FailedPrecondition
-	s.ErrorAs(err, &failedPrecondition)
-	s.Contains(err.Error(), "too many concurrent backfillers")
+	env.ErrorAs(err, &failedPrecondition)
+	env.Contains(err.Error(), "too many concurrent backfillers")
 }
 
 func testMigrationCallbackAttach(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sid")
 	wid := testcore.RandomizeStr("wid")
 	wt := testcore.RandomizeStr("wt")
 
 	resumeSignal := "resume"
-	s.SdkWorker().RegisterWorkflowWithOptions(
+	env.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error {
 			workflow.GetSignalChannel(ctx, resumeSignal).Receive(ctx, nil)
 			return nil
@@ -2994,16 +2994,16 @@ func testMigrationCallbackAttach(t *testing.T, newContext contextFactory) {
 		workflow.RegisterOptions{Name: wt},
 	)
 
-	ctx := newContext(s.Context())
-	startResp, err := s.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
-		Namespace:    s.Namespace().String(),
+	ctx := newContext(env.Context())
+	startResp, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+		Namespace:    env.Namespace().String(),
 		WorkflowId:   wid,
 		WorkflowType: &commonpb.WorkflowType{Name: wt},
-		TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:     testcore.RandomizeStr("identity"),
 		RequestId:    testcore.RandomizeStr("request-id"),
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	schedule := &schedulepb.Schedule{
 		Spec: &schedulepb.ScheduleSpec{
@@ -3016,18 +3016,18 @@ func testMigrationCallbackAttach(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 
 	now := time.Now().UTC()
-	nsID := s.NamespaceID().String()
+	nsID := env.NamespaceID().String()
 
 	migrationState := &schedulerpb.SchedulerMigrationState{
 		SchedulerState: &schedulerpb.SchedulerState{
-			Namespace:     s.Namespace().String(),
+			Namespace:     env.Namespace().String(),
 			NamespaceId:   nsID,
 			ScheduleId:    sid,
 			Schedule:      schedule,
@@ -3050,21 +3050,21 @@ func testMigrationCallbackAttach(t *testing.T, newContext contextFactory) {
 			},
 		},
 	}
-	_, err = s.GetTestCluster().SchedulerClient().CreateFromMigrationState(
+	_, err = env.GetTestCluster().SchedulerClient().CreateFromMigrationState(
 		ctx,
 		&schedulerpb.CreateFromMigrationStateRequest{
 			NamespaceId: nsID,
 			State:       migrationState,
 		},
 	)
-	s.NoError(err)
+	env.NoError(err)
 
-	s.Eventually(func() bool {
-		descResp, err := s.GetTestCluster().SchedulerClient().DescribeSchedule(
+	env.Eventually(func() bool {
+		descResp, err := env.GetTestCluster().SchedulerClient().DescribeSchedule(
 			ctx,
 			&schedulerpb.DescribeScheduleRequest{
 				NamespaceId:     nsID,
-				FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: s.Namespace().String(), ScheduleId: sid},
+				FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: env.Namespace().String(), ScheduleId: sid},
 			},
 		)
 		if err != nil {
@@ -3074,22 +3074,22 @@ func testMigrationCallbackAttach(t *testing.T, newContext contextFactory) {
 		return len(running) > 0 && running[0].WorkflowId == wid
 	}, 15*time.Second, 500*time.Millisecond, "CHASM scheduler should show running workflow")
 
-	_, err = s.FrontendClient().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
-		Namespace: s.Namespace().String(),
+	_, err = env.FrontendClient().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
+		Namespace: env.Namespace().String(),
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: wid,
 			RunId:      startResp.RunId,
 		},
 		SignalName: resumeSignal,
 	})
-	s.NoError(err)
+	env.NoError(err)
 
-	s.Eventually(func() bool {
-		descResp, err := s.GetTestCluster().SchedulerClient().DescribeSchedule(
+	env.Eventually(func() bool {
+		descResp, err := env.GetTestCluster().SchedulerClient().DescribeSchedule(
 			ctx,
 			&schedulerpb.DescribeScheduleRequest{
 				NamespaceId:     nsID,
-				FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: s.Namespace().String(), ScheduleId: sid},
+				FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: env.Namespace().String(), ScheduleId: sid},
 			},
 		)
 		if err != nil {
@@ -3109,7 +3109,7 @@ func testMigrationCallbackAttach(t *testing.T, newContext contextFactory) {
 // testCHASMCanListV1Schedules tests that a schedule created in the V1 stack
 // will also be visible in the V2 stack.
 func testCHASMCanListV1Schedules(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "schedule-created-on-v1"
 	schedule := &schedulepb.Schedule{
@@ -3123,13 +3123,13 @@ func testCHASMCanListV1Schedules(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   "wf-",
 					WorkflowType: &commonpb.WorkflowType{Name: "action"},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -3137,12 +3137,12 @@ func testCHASMCanListV1Schedules(t *testing.T, newContext contextFactory) {
 	}
 
 	// Create on V1 stack.
-	_, err := s.FrontendClient().CreateSchedule(newContext(s.Context()), req)
-	s.NoError(err)
+	_, err := env.FrontendClient().CreateSchedule(newContext(env.Context()), req)
+	env.NoError(err)
 
 	// Pause so that `FutureActionTimes` doesn't change between calls.
-	_, err = s.FrontendClient().PatchSchedule(newContext(s.Context()), &workflowservice.PatchScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	_, err = env.FrontendClient().PatchSchedule(newContext(env.Context()), &workflowservice.PatchScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Patch: &schedulepb.SchedulePatch{
 			Pause: "halt",
@@ -3150,37 +3150,37 @@ func testCHASMCanListV1Schedules(t *testing.T, newContext contextFactory) {
 		Identity:  "test",
 		RequestId: uuid.NewString(),
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	// Sanity test, list with V1 handler.
-	v1Entry := getScheduleEntryFromVisibility(t, s, sid, newContext, func(sle *schedulepb.ScheduleListEntry) bool {
+	v1Entry := getScheduleEntryFromVisibility(t, env, sid, newContext, func(sle *schedulepb.ScheduleListEntry) bool {
 		return sle.GetInfo().Paused
 	})
-	s.NotNil(v1Entry.GetInfo())
+	env.NotNil(v1Entry.GetInfo())
 
 	// Count with V1 handler.
-	v1CountResp, err := s.FrontendClient().CountSchedules(newContext(s.Context()), &workflowservice.CountSchedulesRequest{
-		Namespace: s.Namespace().String(),
+	v1CountResp, err := env.FrontendClient().CountSchedules(newContext(env.Context()), &workflowservice.CountSchedulesRequest{
+		Namespace: env.Namespace().String(),
 	})
-	s.NoError(err)
-	s.GreaterOrEqual(v1CountResp.Count, int64(1), "Expected at least 1 schedule with V1 handler")
+	env.NoError(err)
+	env.GreaterOrEqual(v1CountResp.Count, int64(1), "Expected at least 1 schedule with V1 handler")
 
 	// Flip on CHASM experiment and make sure we can still list.
-	chasmEntry := getScheduleEntryFromVisibility(t, s, sid, chasmContextFactory, nil)
-	s.NotNil(chasmEntry.GetInfo())
-	s.ProtoEqual(chasmEntry.GetInfo(), v1Entry.GetInfo())
+	chasmEntry := getScheduleEntryFromVisibility(t, env, sid, chasmContextFactory, nil)
+	env.NotNil(chasmEntry.GetInfo())
+	env.ProtoEqual(chasmEntry.GetInfo(), v1Entry.GetInfo())
 
 	// Count with CHASM handler and verify it matches V1 count.
-	chasmCountResp, err := s.FrontendClient().CountSchedules(chasmContextFactory(s.Context()), &workflowservice.CountSchedulesRequest{
-		Namespace: s.Namespace().String(),
+	chasmCountResp, err := env.FrontendClient().CountSchedules(chasmContextFactory(env.Context()), &workflowservice.CountSchedulesRequest{
+		Namespace: env.Namespace().String(),
 	})
-	s.NoError(err)
-	s.Equal(v1CountResp.Count, chasmCountResp.Count, "CHASM and V1 counts should match")
+	env.NoError(err)
+	env.Equal(v1CountResp.Count, chasmCountResp.Count, "CHASM and V1 counts should match")
 }
 
 // testRefresh applies to V1 scheduler only; V2 does not support/need manual refresh.
 func testRefresh(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-refresh"
 	wid := "sched-test-refresh-wf"
@@ -3205,14 +3205,14 @@ func testRefresh(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:               wid,
 					WorkflowType:             &commonpb.WorkflowType{Name: wt},
-					TaskQueue:                &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:                &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					WorkflowExecutionTimeout: durationpb.New(3 * time.Second),
 				},
 			},
 		},
 	}
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -3225,26 +3225,26 @@ func testRefresh(t *testing.T, newContext contextFactory) {
 			atomic.AddInt32(&runs, 1)
 			return 0
 		})
-		s.NoError(workflow.Sleep(ctx, 10*time.Second)) // longer than execution timeout
+		env.NoError(workflow.Sleep(ctx, 10*time.Second)) // longer than execution timeout
 		return nil
 	}
-	s.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 
-	_, err := s.FrontendClient().CreateSchedule(newContext(s.Context()), req)
-	s.NoError(err)
+	_, err := env.FrontendClient().CreateSchedule(newContext(env.Context()), req)
+	env.NoError(err)
 
-	s.Eventually(func() bool { return atomic.LoadInt32(&runs) == 1 }, 20*time.Second, 200*time.Millisecond)
+	env.Eventually(func() bool { return atomic.LoadInt32(&runs) == 1 }, 20*time.Second, 200*time.Millisecond)
 
 	// workflow has started but is now sleeping. it will timeout in 2 seconds.
 
-	describeResp, err := s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	describeResp, err := env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 	})
-	s.NoError(err)
-	s.Len(describeResp.Info.RunningWorkflows, 1)
+	env.NoError(err)
+	env.Len(describeResp.Info.RunningWorkflows, 1)
 
-	events1 := s.GetHistory(s.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: scheduler.WorkflowIDPrefix + sid})
+	events1 := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: scheduler.WorkflowIDPrefix + sid})
 	expectedHistory := `
   1 WorkflowExecutionStarted
   2 WorkflowTaskScheduled
@@ -3263,26 +3263,26 @@ func testRefresh(t *testing.T, newContext contextFactory) {
  15 WorkflowPropertiesModified
  16 TimerStarted`
 
-	s.EqualHistoryEvents(expectedHistory, events1)
+	env.EqualHistoryEvents(expectedHistory, events1)
 
 	time.Sleep(4 * time.Second) //nolint:forbidigo
 	// now it has timed out, but the scheduler hasn't noticed yet. we can prove it by checking
 	// its history.
 
-	events2 := s.GetHistory(s.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: scheduler.WorkflowIDPrefix + sid})
-	s.EqualHistoryEvents(expectedHistory, events2)
+	events2 := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: scheduler.WorkflowIDPrefix + sid})
+	env.EqualHistoryEvents(expectedHistory, events2)
 
 	// when we describe we'll force a refresh and see it timed out
-	describeResp, err = s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	describeResp, err = env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 	})
-	s.NoError(err)
-	s.Empty(describeResp.Info.RunningWorkflows)
+	env.NoError(err)
+	env.Empty(describeResp.Info.RunningWorkflows)
 
 	// check scheduler has gotten the refresh and done some stuff. signal is sent without waiting so we need to wait.
-	s.Eventually(func() bool {
-		events3 := s.GetHistory(s.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: scheduler.WorkflowIDPrefix + sid})
+	env.Eventually(func() bool {
+		events3 := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: scheduler.WorkflowIDPrefix + sid})
 		return len(events3) > len(events2)
 	}, 5*time.Second, 100*time.Millisecond)
 }
@@ -3290,7 +3290,7 @@ func testRefresh(t *testing.T, newContext contextFactory) {
 // testListBeforeRun only applies to V1, as V2 scheduler does not involve the
 // per-NS worker or workflow.
 func testListBeforeRun(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, append(scheduleCommonOpts(t),
+	env := newScheduleEnv(t, append(scheduleCommonOpts(t),
 		testcore.WithDynamicConfig(dynamicconfig.WorkerPerNamespaceWorkerCount, 0),
 	)...)
 
@@ -3309,13 +3309,13 @@ func testListBeforeRun(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -3324,21 +3324,21 @@ func testListBeforeRun(t *testing.T, newContext contextFactory) {
 
 	startTime := time.Now()
 
-	_, err := s.FrontendClient().CreateSchedule(newContext(s.Context()), req)
-	s.NoError(err)
+	_, err := env.FrontendClient().CreateSchedule(newContext(env.Context()), req)
+	env.NoError(err)
 
-	entry := getScheduleEntryFromVisibility(t, s, sid, newContext, nil)
-	s.NotNil(entry.Info)
-	s.ProtoEqual(schedule.Spec, entry.Info.Spec)
-	s.Equal(wt, entry.Info.WorkflowType.Name)
-	s.False(entry.Info.Paused)
-	s.Greater(len(entry.Info.FutureActionTimes), 1)
-	s.True(entry.Info.FutureActionTimes[0].AsTime().After(startTime))
+	entry := getScheduleEntryFromVisibility(t, env, sid, newContext, nil)
+	env.NotNil(entry.Info)
+	env.ProtoEqual(schedule.Spec, entry.Info.Spec)
+	env.Equal(wt, entry.Info.WorkflowType.Name)
+	env.False(entry.Info.Paused)
+	env.Greater(len(entry.Info.FutureActionTimes), 1)
+	env.True(entry.Info.FutureActionTimes[0].AsTime().After(startTime))
 }
 
 // testRateLimit applies only to V1, as V2 scheduler does not impose its own rate limiting.
 func testRateLimit(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, append(scheduleCommonOpts(t),
+	env := newScheduleEnv(t, append(scheduleCommonOpts(t),
 		testcore.WithDynamicConfig(dynamicconfig.SchedulerNamespaceStartWorkflowRPS, 1.0),
 	)...)
 
@@ -3354,7 +3354,7 @@ func testRateLimit(t *testing.T, newContext contextFactory) {
 		})
 		return nil
 	}
-	s.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 
 	// create 10 copies of the schedule
 	for i := range 10 {
@@ -3369,31 +3369,31 @@ func testRateLimit(t *testing.T, newContext contextFactory) {
 					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 						WorkflowId:   fmt.Sprintf(wid, i),
 						WorkflowType: &commonpb.WorkflowType{Name: wt},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					},
 				},
 			},
 		}
-		_, err := s.FrontendClient().CreateSchedule(newContext(s.Context()), &workflowservice.CreateScheduleRequest{
-			Namespace:  s.Namespace().String(),
+		_, err := env.FrontendClient().CreateSchedule(newContext(env.Context()), &workflowservice.CreateScheduleRequest{
+			Namespace:  env.Namespace().String(),
 			ScheduleId: fmt.Sprintf(sid, i),
 			Schedule:   schedule,
 			Identity:   "test",
 			RequestId:  uuid.NewString(),
 		})
-		s.NoError(err)
+		env.NoError(err)
 	}
 
 	time.Sleep(5 * time.Second) //nolint:forbidigo
 
 	// With no rate limit, we'd see 10/second == 50 workflows run. With a limit of 1/sec, we
 	// expect to see around 5.
-	s.Less(atomic.LoadInt32(&runs), int32(10))
+	env.Less(atomic.LoadInt32(&runs), int32(10))
 }
 
 // testNextTimeCache only applies to V1.
 func testNextTimeCache(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-next-time-cache"
 	wid := "sched-test-next-time-cache-wf"
@@ -3410,13 +3410,13 @@ func testNextTimeCache(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -3431,18 +3431,18 @@ func testNextTimeCache(t *testing.T, newContext contextFactory) {
 		})
 		return nil
 	}
-	s.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 
-	_, err := s.FrontendClient().CreateSchedule(newContext(s.Context()), req)
-	s.NoError(err)
+	_, err := env.FrontendClient().CreateSchedule(newContext(env.Context()), req)
+	env.NoError(err)
 
 	// wait for at least 13 runs
 	const count = 13
-	s.Eventually(func() bool { return runs.Load() >= count }, (count+10)*time.Second, 500*time.Millisecond)
+	env.Eventually(func() bool { return runs.Load() >= count }, (count+10)*time.Second, 500*time.Millisecond)
 
 	// there should be only four side effects for 13 runs, and only two mentioning "Next"
 	// (cache refills)
-	events := s.GetHistory(s.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: scheduler.WorkflowIDPrefix + sid})
+	events := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: scheduler.WorkflowIDPrefix + sid})
 	var sideEffects, nextTimeSideEffects int
 	for _, e := range events {
 		if marker := e.GetMarkerRecordedEventAttributes(); marker.GetMarkerName() == "SideEffect" {
@@ -3467,8 +3467,8 @@ func testNextTimeCache(t *testing.T, newContext contextFactory) {
 		expectedRefills   = (count + expectedCacheSize - 1) / expectedCacheSize
 		uuidCacheRefills  = (count + 9) / 10
 	)
-	s.Equal(expectedRefills+uuidCacheRefills, sideEffects)
-	s.Equal(expectedRefills, nextTimeSideEffects)
+	env.Equal(expectedRefills+uuidCacheRefills, sideEffects)
+	env.Equal(expectedRefills, nextTimeSideEffects)
 }
 
 // getScheduleEntryFromVisibility polls visibility using ListSchedules until it finds a schedule
@@ -3550,13 +3550,13 @@ func assertRecentActionsNoDuplicateRunIDs(t *testing.T, actions []*schedulepb.Sc
 	}
 }
 func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-update-memo"
 	wid := "sched-test-update-memo-wf"
 	wt := "sched-test-update-memo-wt"
 
-	s.SdkWorker().RegisterWorkflowWithOptions(
+	env.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error { return nil },
 		workflow.RegisterOptions{Name: wt},
 	)
@@ -3572,7 +3572,7 @@ func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
@@ -3582,9 +3582,9 @@ func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
 	memo2 := payload.EncodeString("val2")
 
 	// Create schedule with initial memo.
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	ctx := newContext(env.Context())
+	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -3599,8 +3599,8 @@ func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
 	require.NoError(t, err)
 
 	// Verify initial memo.
-	describeResp, err := s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	describeResp, err := env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 	})
 	require.NoError(t, err)
@@ -3609,8 +3609,8 @@ func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
 
 	// Update: replace memo with only key3 (key1 and key2 should be gone).
 	memo3 := payload.EncodeString("new")
-	_, err = s.FrontendClient().UpdateSchedule(newContext(s.Context()), &workflowservice.UpdateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	_, err = env.FrontendClient().UpdateSchedule(newContext(env.Context()), &workflowservice.UpdateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -3624,8 +3624,8 @@ func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
 	require.NoError(t, err)
 
 	// Verify replaced memo.
-	describeResp, err = s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	describeResp, err = env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 	})
 	require.NoError(t, err)
@@ -3634,8 +3634,8 @@ func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
 	require.Equal(t, memo3.Data, describeResp.Memo.Fields["key3"].Data, "key3 should be set")
 
 	// Update with nil memo (no change).
-	_, err = s.FrontendClient().UpdateSchedule(newContext(s.Context()), &workflowservice.UpdateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	_, err = env.FrontendClient().UpdateSchedule(newContext(env.Context()), &workflowservice.UpdateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -3644,16 +3644,16 @@ func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
 	require.NoError(t, err)
 
 	// Verify memo unchanged.
-	describeResp, err = s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	describeResp, err = env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 	})
 	require.NoError(t, err)
 	require.Equal(t, memo3.Data, describeResp.Memo.Fields["key3"].Data, "key3 should be unchanged")
 
 	// Update with empty memo (clear all).
-	_, err = s.FrontendClient().UpdateSchedule(newContext(s.Context()), &workflowservice.UpdateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	_, err = env.FrontendClient().UpdateSchedule(newContext(env.Context()), &workflowservice.UpdateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -3665,8 +3665,8 @@ func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
 	require.NoError(t, err)
 
 	// Verify memo cleared.
-	describeResp, err = s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	describeResp, err = env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 	})
 	require.NoError(t, err)
@@ -3674,13 +3674,13 @@ func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
 }
 
 func testUpdateScheduleMemoRejected(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-update-memo-rejected"
 	wid := "sched-test-update-memo-rejected-wf"
 	wt := "sched-test-update-memo-rejected-wt"
 
-	s.SdkWorker().RegisterWorkflowWithOptions(
+	env.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error { return nil },
 		workflow.RegisterOptions{Name: wt},
 	)
@@ -3696,16 +3696,16 @@ func testUpdateScheduleMemoRejected(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 
 	// Create V1 schedule.
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	ctx := newContext(env.Context())
+	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -3714,8 +3714,8 @@ func testUpdateScheduleMemoRejected(t *testing.T, newContext contextFactory) {
 	require.NoError(t, err)
 
 	// Update with memo should be rejected.
-	_, err = s.FrontendClient().UpdateSchedule(newContext(s.Context()), &workflowservice.UpdateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	_, err = env.FrontendClient().UpdateSchedule(newContext(env.Context()), &workflowservice.UpdateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -3738,13 +3738,13 @@ func testUpdateScheduleMemoOnly(t *testing.T, newContext contextFactory) {
 	// the schedule when the field is nil, similar to how memo and search_attributes are handled.
 	t.Skip("memo-only updates not yet supported: omitting the schedule field unsets the schedule")
 
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-update-memo-only"
 	wid := "sched-test-update-memo-only-wf"
 	wt := "sched-test-update-memo-only-wt"
 
-	s.SdkWorker().RegisterWorkflowWithOptions(
+	env.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error { return nil },
 		workflow.RegisterOptions{Name: wt},
 	)
@@ -3760,7 +3760,7 @@ func testUpdateScheduleMemoOnly(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
@@ -3768,9 +3768,9 @@ func testUpdateScheduleMemoOnly(t *testing.T, newContext contextFactory) {
 
 	// Create schedule with initial memo.
 	memo1 := payload.EncodeString("val1")
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	ctx := newContext(env.Context())
+	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -3783,8 +3783,8 @@ func testUpdateScheduleMemoOnly(t *testing.T, newContext contextFactory) {
 
 	// Update only memo, without setting the schedule field.
 	memo2 := payload.EncodeString("val2")
-	_, err = s.FrontendClient().UpdateSchedule(newContext(s.Context()), &workflowservice.UpdateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	_, err = env.FrontendClient().UpdateSchedule(newContext(env.Context()), &workflowservice.UpdateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
@@ -3795,8 +3795,8 @@ func testUpdateScheduleMemoOnly(t *testing.T, newContext contextFactory) {
 	require.NoError(t, err)
 
 	// Verify memo was updated and schedule is still intact.
-	describeResp, err := s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	describeResp, err := env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 	})
 	require.NoError(t, err)
@@ -3807,14 +3807,14 @@ func testUpdateScheduleMemoOnly(t *testing.T, newContext contextFactory) {
 }
 
 func testCHASMUnpauseResumesProcessing(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-unpause-resumes"
 	wid := "sched-test-unpause-resumes-wf"
 	wt := "sched-test-unpause-resumes-wt"
 
 	var runs int32
-	s.SdkWorker().RegisterWorkflowWithOptions(
+	env.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error {
 			workflow.SideEffect(ctx, func(ctx workflow.Context) any {
 				atomic.AddInt32(&runs, 1)
@@ -3825,8 +3825,8 @@ func testCHASMUnpauseResumesProcessing(t *testing.T, newContext contextFactory) 
 		workflow.RegisterOptions{Name: wt},
 	)
 
-	_, err := s.FrontendClient().CreateSchedule(newContext(s.Context()), &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	_, err := env.FrontendClient().CreateSchedule(newContext(env.Context()), &workflowservice.CreateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule: &schedulepb.Schedule{
 			Spec: &schedulepb.ScheduleSpec{
@@ -3837,7 +3837,7 @@ func testCHASMUnpauseResumesProcessing(t *testing.T, newContext contextFactory) 
 					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 						WorkflowId:   wid,
 						WorkflowType: &commonpb.WorkflowType{Name: wt},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					},
 				},
 			},
@@ -3845,27 +3845,27 @@ func testCHASMUnpauseResumesProcessing(t *testing.T, newContext contextFactory) 
 		Identity:  "test",
 		RequestId: uuid.NewString(),
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	// Wait for the schedule to fire at least once, confirming it's running.
-	s.Eventually(func() bool { return atomic.LoadInt32(&runs) >= 1 }, 15*time.Second, 500*time.Millisecond)
+	env.Eventually(func() bool { return atomic.LoadInt32(&runs) >= 1 }, 15*time.Second, 500*time.Millisecond)
 
 	// Pause.
-	_, err = s.FrontendClient().PatchSchedule(newContext(s.Context()), &workflowservice.PatchScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	_, err = env.FrontendClient().PatchSchedule(newContext(env.Context()), &workflowservice.PatchScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Patch:      &schedulepb.SchedulePatch{Pause: "pausing for test"},
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	// Wait for the already-queued generator task to run after pause. That task
 	// observes paused state, performs no-op scheduling, and then the schedule
 	// becomes quiescent (no new runs over a stability window).
 	stableSamples := 0
 	lastRuns := atomic.LoadInt32(&runs)
-	s.Eventually(func() bool {
+	env.Eventually(func() bool {
 		currentRuns := atomic.LoadInt32(&runs)
 		if currentRuns == lastRuns {
 			stableSamples++
@@ -3878,17 +3878,17 @@ func testCHASMUnpauseResumesProcessing(t *testing.T, newContext contextFactory) 
 	runsBeforeUnpause := atomic.LoadInt32(&runs)
 
 	// Unpause.
-	_, err = s.FrontendClient().PatchSchedule(newContext(s.Context()), &workflowservice.PatchScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	_, err = env.FrontendClient().PatchSchedule(newContext(env.Context()), &workflowservice.PatchScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Patch:      &schedulepb.SchedulePatch{Unpause: "resuming"},
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	// The generator should be kicked immediately on unpause and new runs should follow.
-	s.Eventually(
+	env.Eventually(
 		func() bool { return atomic.LoadInt32(&runs) > runsBeforeUnpause },
 		15*time.Second,
 		500*time.Millisecond,
@@ -3991,32 +3991,32 @@ func testPausedScheduleNeverIdles(t *testing.T, newContext contextFactory) {
 // manual-only pattern - can be created without timing out and remains
 // describable.
 func testPausedEmptySpecStaysOpen(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-paused-empty-spec")
 	wid := testcore.RandomizeStr("sched-paused-empty-spec-wf")
 	wt := testcore.RandomizeStr("sched-paused-empty-spec-wt")
 
 	var runs atomic.Int32
-	registerCountingWorkflow(s, wt, &runs)
+	registerCountingWorkflow(env, wt, &runs)
 
 	// Empty spec + paused: a manual-only schedule. Create must succeed without
 	// timing out (the original regression was "context deadline exceeded").
-	ctx := newContext(s.Context())
+	ctx := newContext(env.Context())
 	createCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	createSchedule(createCtx, t, s, sid, &schedulepb.Schedule{
+	createSchedule(createCtx, t, env, sid, &schedulepb.Schedule{
 		Spec:   &schedulepb.ScheduleSpec{},
 		State:  &schedulepb.ScheduleState{Paused: true},
-		Action: startWorkflowAction(s, wid, wt),
+		Action: startWorkflowAction(env, wid, wt),
 	})
 
 	require.Never(t, func() bool { return runs.Load() > 0 },
 		neverWindow, pollInterval,
 		"empty paused spec must not fire any actions automatically")
 
-	desc, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	desc, err := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 	})
 	require.NoError(t, err)
@@ -4024,7 +4024,7 @@ func testPausedEmptySpecStaysOpen(t *testing.T, newContext contextFactory) {
 
 	// Unpause + TriggerImmediately to sanity-check the schedule is functional,
 	// not just open.
-	patchSchedule(ctx, t, s, sid, &schedulepb.SchedulePatch{
+	patchSchedule(ctx, t, env, sid, &schedulepb.SchedulePatch{
 		Unpause:            "empty-spec-trigger",
 		TriggerImmediately: &schedulepb.TriggerImmediatelyRequest{},
 	})
@@ -4040,46 +4040,46 @@ func testPausedEmptySpecStaysOpen(t *testing.T, newContext contextFactory) {
 // patch on a running schedule fires an extra action and leaves the schedule
 // active.
 func testTriggerImmediatelyOnActiveSchedule(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-trigger-on-active")
 	wid := testcore.RandomizeStr("sched-trigger-on-active-wf")
 	wt := testcore.RandomizeStr("sched-trigger-on-active-wt")
 
 	var runs atomic.Int32
-	registerCountingWorkflow(s, wt, &runs)
+	registerCountingWorkflow(env, wt, &runs)
 
-	ctx := newContext(s.Context())
-	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
+	ctx := newContext(env.Context())
+	createSchedule(ctx, t, env, sid, &schedulepb.Schedule{
 		// Fire a year into the future, keeping the schedule active, but without firing
 		// actions.
 		Spec: &schedulepb.ScheduleSpec{
 			Calendar: []*schedulepb.CalendarSpec{calendarSpec(time.Now().AddDate(1, 0, 0).UTC())},
 		},
-		Action: startWorkflowAction(s, wid, wt),
+		Action: startWorkflowAction(env, wid, wt),
 		Policies: &schedulepb.SchedulePolicies{
 			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
 		},
 	})
 
 	await.RequireTruef(t, func() bool {
-		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  s.Namespace().String(),
+		desc, descErr := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  env.Namespace().String(),
 			ScheduleId: sid,
 		})
 		return descErr == nil && len(desc.Info.FutureActionTimes) > 0
 	}, awaitTimeout, pollInterval, "schedule should reach active state with future actions planned")
 	require.Zero(t, runs.Load(), "no automated action should fire before the trigger")
 
-	patchSchedule(ctx, t, s, sid, triggerPatch(enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL))
+	patchSchedule(ctx, t, env, sid, triggerPatch(enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL))
 	await.RequireTruef(t,
 		func() bool { return runs.Load() == 1 },
 		awaitTimeout, pollInterval,
 		"TriggerImmediately should fire exactly one action on the active schedule",
 	)
 
-	desc, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	desc, err := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 	})
 	require.NoError(t, err)
@@ -4091,20 +4091,20 @@ func testTriggerImmediatelyOnActiveSchedule(t *testing.T, newContext contextFact
 // an action even when the schedule is paused. Manual starts bypass the paused
 // gate via useScheduledAction's Manual carve-out in processBuffer.
 func testTriggerImmediatelyOnPausedSchedule(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-trigger-on-paused")
 	wid := testcore.RandomizeStr("sched-trigger-on-paused-wf")
 	wt := testcore.RandomizeStr("sched-trigger-on-paused-wt")
 
 	var runs atomic.Int32
-	registerCountingWorkflow(s, wt, &runs)
+	registerCountingWorkflow(env, wt, &runs)
 
-	ctx := newContext(s.Context())
-	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
+	ctx := newContext(env.Context())
+	createSchedule(ctx, t, env, sid, &schedulepb.Schedule{
 		Spec:   intervalSpec(fastInterval),
 		State:  &schedulepb.ScheduleState{Paused: true},
-		Action: startWorkflowAction(s, wid, wt),
+		Action: startWorkflowAction(env, wid, wt),
 	})
 
 	// Paused suppresses firing even though the 1s interval would otherwise tick.
@@ -4112,14 +4112,14 @@ func testTriggerImmediatelyOnPausedSchedule(t *testing.T, newContext contextFact
 		neverWindow, pollInterval,
 		"paused schedule must not fire automated actions before the trigger")
 
-	patchSchedule(ctx, t, s, sid, triggerPatch(enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL))
+	patchSchedule(ctx, t, env, sid, triggerPatch(enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL))
 
 	await.RequireTruef(t, func() bool { return runs.Load() == 1 },
 		awaitTimeout, pollInterval,
 		"TriggerImmediately must fire exactly one action despite the schedule being paused")
 
-	desc, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	desc, err := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 	})
 	require.NoError(t, err)
@@ -4130,34 +4130,34 @@ func testTriggerImmediatelyOnPausedSchedule(t *testing.T, newContext contextFact
 // testTriggerImmediatelyAfterActionsExhausted verifies that TriggerImmediately
 // fires an action even on a schedule that has no LimitedActions slots left.
 func testTriggerImmediatelyAfterActionsExhausted(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-trigger-after-exhausted")
 	wid := testcore.RandomizeStr("sched-trigger-after-exhausted-wf")
 	wt := testcore.RandomizeStr("sched-trigger-after-exhausted-wt")
 
 	var runs atomic.Int32
-	registerCountingWorkflow(s, wt, &runs)
+	registerCountingWorkflow(env, wt, &runs)
 
-	ctx := newContext(s.Context())
-	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
+	ctx := newContext(env.Context())
+	createSchedule(ctx, t, env, sid, &schedulepb.Schedule{
 		Spec: intervalSpec(fastInterval),
 		// Start exhausted so no automated action fires.
 		State:  &schedulepb.ScheduleState{LimitedActions: true, RemainingActions: 0},
-		Action: startWorkflowAction(s, wid, wt),
+		Action: startWorkflowAction(env, wid, wt),
 	})
 
 	require.Never(t, func() bool { return runs.Load() > 0 },
 		neverWindow, pollInterval,
 		"exhausted schedule must not auto-fire before the trigger")
 
-	patchSchedule(ctx, t, s, sid, triggerPatch(enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL))
+	patchSchedule(ctx, t, env, sid, triggerPatch(enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL))
 	await.RequireTruef(t, func() bool { return runs.Load() == 1 },
 		awaitTimeout, pollInterval,
 		"TriggerImmediately must fire exactly once despite RemainingActions=0")
 
-	desc, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	desc, err := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 	})
 	require.NoError(t, err)
@@ -4250,7 +4250,7 @@ func testBackfillWithBufferOneOverlap(t *testing.T, newContext contextFactory) {
 	//   go test ./tests/ -run 'TestScheduleCHASM/Backfill/BufferOneOverlap' -v
 	t.Skip("BUFFER_ONE backfill deferred re-enable is broken on both V1 and CHASM; see test doc")
 
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-backfill-buffer-one")
 	wid := testcore.RandomizeStr("sched-backfill-buffer-one-wf")
@@ -4258,22 +4258,22 @@ func testBackfillWithBufferOneOverlap(t *testing.T, newContext contextFactory) {
 
 	// Gate runs so the first-running / one-deferred / rest-dropped sequence is deterministic.
 	var runs atomic.Int32
-	registerGatedWorkflow(s, wt, &runs)
+	registerGatedWorkflow(env, wt, &runs)
 
-	ctx := newContext(s.Context())
-	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
+	ctx := newContext(env.Context())
+	createSchedule(ctx, t, env, sid, &schedulepb.Schedule{
 		Spec:   intervalSpec(fastInterval),
 		State:  &schedulepb.ScheduleState{Paused: true},
-		Action: startWorkflowAction(s, wid, wt),
+		Action: startWorkflowAction(env, wid, wt),
 	})
 
 	now := time.Now().UTC()
-	patchSchedule(ctx, t, s, sid, backfillPatch(now.Add(-5*time.Second), now, enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE))
+	patchSchedule(ctx, t, env, sid, backfillPatch(now.Add(-5*time.Second), now, enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE))
 
 	// First backfill start runs with exactly one buffered behind it (BUFFER_ONE drops the rest).
 	await.RequireTruef(t, func() bool {
-		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  s.Namespace().String(),
+		desc, descErr := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  env.Namespace().String(),
 			ScheduleId: sid,
 		})
 		return descErr == nil && desc.GetInfo().GetBufferSize() == 1 && len(desc.GetInfo().GetRunningWorkflows()) == 1
@@ -4281,7 +4281,7 @@ func testBackfillWithBufferOneOverlap(t *testing.T, newContext contextFactory) {
 	require.Equal(t, int32(1), runs.Load(), "only the first backfill start should have fired so far")
 
 	// Releasing the running start must re-enable the deferred one (Attempt=-1 -> 0) so it fires.
-	require.Equal(t, 1, completeRunningWorkflows(ctx, t, s, sid))
+	require.Equal(t, 1, completeRunningWorkflows(ctx, t, env, sid))
 	await.RequireTruef(t, func() bool { return runs.Load() == 2 },
 		awaitTimeout, pollInterval,
 		"deferred backfill start must fire after the running one completes (Attempt=-1 -> 0 re-enable)")
@@ -4294,21 +4294,21 @@ func testBackfillWithBufferOneOverlap(t *testing.T, newContext contextFactory) {
 // is narrower than the spec interval - no spec tick lands inside it, so no
 // actions fire and the backfiller still drains cleanly.
 func testBackfillRangeSmallerThanInterval(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-backfill-narrow")
 	wid := testcore.RandomizeStr("sched-backfill-narrow-wf")
 	wt := testcore.RandomizeStr("sched-backfill-narrow-wt")
 
 	var runs atomic.Int32
-	registerCountingWorkflow(s, wt, &runs)
+	registerCountingWorkflow(env, wt, &runs)
 
-	ctx := newContext(s.Context())
-	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
+	ctx := newContext(env.Context())
+	createSchedule(ctx, t, env, sid, &schedulepb.Schedule{
 		// noOpInterval (1h) ticks on the hour; the backfill window below is mid-hour.
 		Spec:   intervalSpec(noOpInterval),
 		State:  &schedulepb.ScheduleState{Paused: true},
-		Action: startWorkflowAction(s, wid, wt),
+		Action: startWorkflowAction(env, wid, wt),
 	})
 
 	// A 10s window (above the 1s resolution, below the 1h interval) anchored mid-hour
@@ -4316,7 +4316,7 @@ func testBackfillRangeSmallerThanInterval(t *testing.T, newContext contextFactor
 	prevHour := time.Now().UTC().Truncate(time.Hour).Add(-time.Hour)
 	windowStart := prevHour.Add(20 * time.Minute)
 	windowEnd := windowStart.Add(10 * time.Second)
-	patchSchedule(ctx, t, s, sid, backfillPatch(windowStart, windowEnd, enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL))
+	patchSchedule(ctx, t, env, sid, backfillPatch(windowStart, windowEnd, enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL))
 
 	// No spec tick falls inside a sub-interval window, so no action fires.
 	require.Never(t, func() bool { return runs.Load() > 0 },
@@ -4325,8 +4325,8 @@ func testBackfillRangeSmallerThanInterval(t *testing.T, newContext contextFactor
 
 	// And the schedule must still be describable - the backfiller drained without
 	// firing anything and got cleaned up.
-	_, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	_, err := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 	})
 	require.NoError(t, err, "schedule must remain describable after empty backfill")
@@ -4335,24 +4335,24 @@ func testBackfillRangeSmallerThanInterval(t *testing.T, newContext contextFactor
 // testBackfillWithSkipOverlap verifies that SKIP overlap correctly collapses a
 // multi-tick backfill range to a single workflow execution.
 func testBackfillWithSkipOverlap(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-backfill-skip")
 	wid := testcore.RandomizeStr("sched-backfill-skip-wf")
 	wt := testcore.RandomizeStr("sched-backfill-skip-wt")
 
 	var runs atomic.Int32
-	registerCountingWorkflow(s, wt, &runs)
+	registerCountingWorkflow(env, wt, &runs)
 
-	ctx := newContext(s.Context())
-	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
+	ctx := newContext(env.Context())
+	createSchedule(ctx, t, env, sid, &schedulepb.Schedule{
 		Spec:   intervalSpec(fastInterval),
 		State:  &schedulepb.ScheduleState{Paused: true},
-		Action: startWorkflowAction(s, wid, wt),
+		Action: startWorkflowAction(env, wid, wt),
 	})
 
 	now := time.Now().UTC()
-	patchSchedule(ctx, t, s, sid, backfillPatch(now.Add(-5*time.Second), now, enumspb.SCHEDULE_OVERLAP_POLICY_SKIP))
+	patchSchedule(ctx, t, env, sid, backfillPatch(now.Add(-5*time.Second), now, enumspb.SCHEDULE_OVERLAP_POLICY_SKIP))
 
 	// SKIP collapses the 5-tick backfill to exactly one fire, and it stays there.
 	await.RequireTruef(t, func() bool { return runs.Load() == 1 },
@@ -4364,28 +4364,28 @@ func testBackfillWithSkipOverlap(t *testing.T, newContext contextFactory) {
 }
 
 func testUpdateScheduleRequestIDTooLong(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-update-reqid-too-long"
 	wid := "sched-test-update-reqid-too-long-wf"
 	wt := "sched-test-update-reqid-too-long-wt"
 
-	s.SdkWorker().RegisterWorkflowWithOptions(
+	env.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error { return nil },
 		workflow.RegisterOptions{Name: wt},
 	)
 
 	schedule := &schedulepb.Schedule{
 		Spec:   intervalSpec(noOpInterval),
-		Action: startWorkflowAction(s, wid, wt),
+		Action: startWorkflowAction(env, wid, wt),
 	}
 
-	ctx := newContext(s.Context())
-	createSchedule(ctx, t, s, sid, schedule)
+	ctx := newContext(env.Context())
+	createSchedule(ctx, t, env, sid, schedule)
 
 	// Update with an oversized request ID.
-	_, err := s.FrontendClient().UpdateSchedule(ctx, &workflowservice.UpdateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	_, err := env.FrontendClient().UpdateSchedule(ctx, &workflowservice.UpdateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -4396,7 +4396,7 @@ func testUpdateScheduleRequestIDTooLong(t *testing.T, newContext contextFactory)
 }
 
 func testUpdateScheduleBlobSizeLimit(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t,
+	env := newScheduleEnv(t,
 		append(scheduleCommonOpts(t),
 			testcore.WithDynamicConfig(dynamicconfig.BlobSizeLimitError, 1000),
 			testcore.WithDynamicConfig(dynamicconfig.BlobSizeLimitWarn, 500),
@@ -4407,7 +4407,7 @@ func testUpdateScheduleBlobSizeLimit(t *testing.T, newContext contextFactory) {
 	wid := "sched-test-update-blob-limit-wf"
 	wt := "sched-test-update-blob-limit-wt"
 
-	s.SdkWorker().RegisterWorkflowWithOptions(
+	env.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error { return nil },
 		workflow.RegisterOptions{Name: wt},
 	)
@@ -4423,16 +4423,16 @@ func testUpdateScheduleBlobSizeLimit(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 
 	// Create schedule.
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	ctx := newContext(env.Context())
+	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -4446,8 +4446,8 @@ func testUpdateScheduleBlobSizeLimit(t *testing.T, newContext contextFactory) {
 			"key": {Data: make([]byte, 1001)},
 		},
 	}
-	_, err = s.FrontendClient().UpdateSchedule(newContext(s.Context()), &workflowservice.UpdateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	_, err = env.FrontendClient().UpdateSchedule(newContext(env.Context()), &workflowservice.UpdateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -4469,10 +4469,10 @@ func TestScheduleCreationRolloutPercent(t *testing.T) {
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, true),
 		testcore.WithDynamicConfig(dynamicconfig.CHASMSchedulerCreationRolloutPercent, 50),
 	)
-	s := newScheduleEnv(t, opts...)
-	ctx := s.Context()
-	nsName := s.Namespace().String()
-	nsID := s.NamespaceID().String()
+	env := newScheduleEnv(t, opts...)
+	ctx := env.Context()
+	nsName := env.Namespace().String()
+	nsID := env.NamespaceID().String()
 
 	chasmSID, v1SID := testcore.PickRolloutSplit(t, nsName, 50)
 
@@ -4486,7 +4486,7 @@ func TestScheduleCreationRolloutPercent(t *testing.T) {
 					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 						WorkflowId:   testcore.RandomizeStr("wid"),
 						WorkflowType: &commonpb.WorkflowType{Name: testcore.RandomizeStr("wt")},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					},
 				},
 			},
@@ -4494,7 +4494,7 @@ func TestScheduleCreationRolloutPercent(t *testing.T) {
 	}
 
 	for _, sid := range []string{chasmSID, v1SID} {
-		_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
 			Namespace:  nsName,
 			ScheduleId: sid,
 			Schedule:   mkSchedule(),
@@ -4507,7 +4507,7 @@ func TestScheduleCreationRolloutPercent(t *testing.T) {
 	// A direct CHASM DescribeSchedule succeeds for CHASM-backed schedules and
 	// returns NotFound for V1-backed schedules (whose CHASM key is a sentinel).
 	describeOnCHASM := func(sid string) error {
-		_, err := s.GetTestCluster().SchedulerClient().DescribeSchedule(ctx, &schedulerpb.DescribeScheduleRequest{
+		_, err := env.GetTestCluster().SchedulerClient().DescribeSchedule(ctx, &schedulerpb.DescribeScheduleRequest{
 			NamespaceId:     nsID,
 			FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: nsName, ScheduleId: sid},
 		})
@@ -4527,7 +4527,7 @@ func TestScheduleCreationRolloutPercent(t *testing.T) {
 	// takes a moment to be queryable after creation, so poll.
 	for _, sid := range []string{chasmSID, v1SID} {
 		require.Eventually(t, func() bool {
-			_, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			_, err := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
 				Namespace:  nsName,
 				ScheduleId: sid,
 			})
@@ -4764,29 +4764,29 @@ func testBackfillBlocksIdleClose(t *testing.T, newContext contextFactory) {
 // testMultiRangeBackfillCountedExactlyOnce asserts that the `ActionCount` is
 // correctly counted when multiple backfillers are concurrently running.
 func testMultiRangeBackfillCountedExactlyOnce(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-multi-range-backfill")
 	wid := testcore.RandomizeStr("sched-multi-range-backfill-wf")
 	wt := testcore.RandomizeStr("sched-multi-range-backfill-wt")
 
-	s.SdkWorker().RegisterWorkflowWithOptions(
+	env.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error { return nil },
 		workflow.RegisterOptions{Name: wt},
 	)
 
-	ctx := newContext(s.Context())
-	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
+	ctx := newContext(env.Context())
+	createSchedule(ctx, t, env, sid, &schedulepb.Schedule{
 		// 1m interval; each 2m backfill range below covers a couple of ticks.
 		Spec:   intervalSpec(time.Minute),
 		State:  &schedulepb.ScheduleState{Paused: true},
-		Action: startWorkflowAction(s, wid, wt),
+		Action: startWorkflowAction(env, wid, wt),
 	})
 
 	now := time.Now().UTC()
 	threeYearsAgo := now.Add(-3 * 365 * 24 * time.Hour).Truncate(time.Minute)
 	thirtyMinutesAgo := now.Add(-30 * time.Minute).Truncate(time.Minute)
-	patchSchedule(ctx, t, s, sid, &schedulepb.SchedulePatch{
+	patchSchedule(ctx, t, env, sid, &schedulepb.SchedulePatch{
 		BackfillRequest: []*schedulepb.BackfillRequest{
 			{
 				StartTime:     timestamppb.New(threeYearsAgo.Add(-2 * time.Minute)),
@@ -4802,8 +4802,8 @@ func testMultiRangeBackfillCountedExactlyOnce(t *testing.T, newContext contextFa
 	})
 
 	await.RequireTruef(t, func() bool {
-		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  s.Namespace().String(),
+		desc, descErr := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  env.Namespace().String(),
 			ScheduleId: sid,
 		})
 		if descErr != nil {
@@ -4818,20 +4818,20 @@ func testMultiRangeBackfillCountedExactlyOnce(t *testing.T, newContext contextFa
 // a backfill request to completion, even though the schedule otherwise has no
 // automated actions running.
 func testBackfillOnPausedSchedule(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-backfill-paused")
 	wid := testcore.RandomizeStr("sched-backfill-paused-wf")
 	wt := testcore.RandomizeStr("sched-backfill-paused-wt")
 
 	var runs atomic.Int32
-	registerCountingWorkflow(s, wt, &runs)
+	registerCountingWorkflow(env, wt, &runs)
 
-	ctx := newContext(s.Context())
-	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
+	ctx := newContext(env.Context())
+	createSchedule(ctx, t, env, sid, &schedulepb.Schedule{
 		Spec:   intervalSpec(fastInterval),
 		State:  &schedulepb.ScheduleState{Paused: true},
-		Action: startWorkflowAction(s, wid, wt),
+		Action: startWorkflowAction(env, wid, wt),
 	})
 
 	// Paused suppresses firing even though the 1s interval would otherwise tick.
@@ -4840,7 +4840,7 @@ func testBackfillOnPausedSchedule(t *testing.T, newContext contextFactory) {
 		"paused schedule must not fire automated actions")
 
 	now := time.Now().UTC()
-	patchSchedule(ctx, t, s, sid, backfillPatch(now.Add(-5*time.Second), now, enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL))
+	patchSchedule(ctx, t, env, sid, backfillPatch(now.Add(-5*time.Second), now, enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL))
 
 	await.RequireTruef(t, func() bool { return runs.Load() >= 5 },
 		awaitTimeout, pollInterval,
@@ -4852,7 +4852,7 @@ func testBackfillOnPausedSchedule(t *testing.T, newContext contextFactory) {
 // queryable through the frontend ListSchedules API.
 func TestScheduleNextActionTimeVisibility(t *testing.T) {
 	opts := scheduleCommonOpts(t)
-	s := newScheduleEnv(t, opts...)
+	env := newScheduleEnv(t, opts...)
 
 	v2Sid := testcore.RandomizeStr("sched-next-action-v2")
 	wid := testcore.RandomizeStr("sched-next-action-wf")
@@ -4861,7 +4861,7 @@ func TestScheduleNextActionTimeVisibility(t *testing.T) {
 	// Register a no-op workflow type so a stray fire doesn't generate worker
 	// noise. The schedule is never paused: we want its next action time to stay
 	// populated so it remains queryable.
-	s.SdkWorker().RegisterWorkflowWithOptions(
+	env.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error { return nil },
 		workflow.RegisterOptions{Name: wt},
 	)
@@ -4878,7 +4878,7 @@ func TestScheduleNextActionTimeVisibility(t *testing.T) {
 					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 						WorkflowId:   wid,
 						WorkflowType: &commonpb.WorkflowType{Name: wt},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					},
 				},
 			},
@@ -4886,17 +4886,17 @@ func TestScheduleNextActionTimeVisibility(t *testing.T) {
 	}
 
 	newContext := chasmContextFactory
-	v2Ctx := newContext(s.Context())
+	v2Ctx := newContext(env.Context())
 	createTime := time.Now()
 
-	_, err := s.FrontendClient().CreateSchedule(v2Ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	_, err := env.FrontendClient().CreateSchedule(v2Ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: v2Sid,
 		Schedule:   mkSchedule(),
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	})
-	s.NoError(err)
+	env.NoError(err)
 
 	// The CHASM scheduler publishes its next action time to visibility as the
 	// ScheduleNextActionTime search attribute. The schedule fires on an hourly
@@ -4910,8 +4910,8 @@ func TestScheduleNextActionTimeVisibility(t *testing.T) {
 	)
 
 	require.Eventually(t, func() bool {
-		listResp, err := s.FrontendClient().ListSchedules(v2Ctx, &workflowservice.ListSchedulesRequest{
-			Namespace:       s.Namespace().String(),
+		listResp, err := env.FrontendClient().ListSchedules(v2Ctx, &workflowservice.ListSchedulesRequest{
+			Namespace:       env.Namespace().String(),
 			MaximumPageSize: 100,
 			Query:           query,
 		})
@@ -5154,7 +5154,7 @@ func TestScheduleManyCalendars(t *testing.T) {
 // behind it. The counts aren't surfaced on the list entry, so we assert via the
 // query rather than by reading the entry's SAs.
 func TestScheduleCountsVisibility(t *testing.T) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
 	newContext := chasmContextFactory
 
 	sid := testcore.RandomizeStr("sched-counts-v2")
@@ -5162,7 +5162,7 @@ func TestScheduleCountsVisibility(t *testing.T) {
 	wt := testcore.RandomizeStr("sched-counts-wt")
 
 	// A workflow that holds open so a fire stays running while later fires buffer.
-	s.SdkWorker().RegisterWorkflowWithOptions(
+	env.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error {
 			return workflow.Sleep(ctx, time.Hour)
 		},
@@ -5180,7 +5180,7 @@ func TestScheduleCountsVisibility(t *testing.T) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
@@ -5189,9 +5189,9 @@ func TestScheduleCountsVisibility(t *testing.T) {
 		},
 	}
 
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	ctx := newContext(env.Context())
+	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -5202,8 +5202,8 @@ func TestScheduleCountsVisibility(t *testing.T) {
 	// matchesQuery reports whether the schedule is returned when filtering on the
 	// given search-attribute query.
 	matchesQuery := func(query string) bool {
-		listResp, listErr := s.FrontendClient().ListSchedules(newContext(s.Context()), &workflowservice.ListSchedulesRequest{
-			Namespace:       s.Namespace().String(),
+		listResp, listErr := env.FrontendClient().ListSchedules(newContext(env.Context()), &workflowservice.ListSchedulesRequest{
+			Namespace:       env.Namespace().String(),
 			MaximumPageSize: 5,
 			Query:           query,
 		})

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -39,6 +39,7 @@ import (
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/protorequire"
+	"go.temporal.io/server/common/testing/testcontext"
 	"go.temporal.io/server/service/worker/dummy"
 	"go.temporal.io/server/service/worker/scheduler"
 	"go.temporal.io/server/tests/testcore"
@@ -484,7 +485,7 @@ func testRecentActionsAdvanceWhilePaused(t *testing.T, newContext contextFactory
 	})
 
 	// Wait for the first workflow to be reported as RUNNING in ListSchedules.
-	running := getScheduleEntryFromVisibility(s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	running := getScheduleEntryFromVisibility(t, s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		return len(ent.Info.RecentActions) >= 1 &&
 			ent.Info.RecentActions[0].GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
 	})
@@ -498,7 +499,7 @@ func testRecentActionsAdvanceWhilePaused(t *testing.T, newContext contextFactory
 	require.Equal(t, 1, signaled, "exactly one run should be in flight under the default SKIP overlap policy")
 
 	// While paused, the listed RecentActions entry transitions to COMPLETED.
-	getScheduleEntryFromVisibility(s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	getScheduleEntryFromVisibility(t, s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		for _, a := range ent.Info.RecentActions {
 			if a.GetStartWorkflowResult().GetRunId() == runningRunID &&
 				a.GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED {
@@ -535,7 +536,7 @@ func testFutureActionTimesAdvanceWhilePaused(t *testing.T, newContext contextFac
 	})
 
 	// Wait for visibility to surface an initial FutureActionTimes projection.
-	initial := getScheduleEntryFromVisibility(s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	initial := getScheduleEntryFromVisibility(t, s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		return len(ent.Info.FutureActionTimes) > 0
 	})
 	initialFirst := initial.Info.FutureActionTimes[0].AsTime()
@@ -543,7 +544,7 @@ func testFutureActionTimesAdvanceWhilePaused(t *testing.T, newContext contextFac
 	// While still paused, the earliest projected time must advance past the
 	// initial value: the Generator keeps ticking and republishing the
 	// projection, even though no workflows fire.
-	getScheduleEntryFromVisibility(s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	getScheduleEntryFromVisibility(t, s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		return len(ent.Info.FutureActionTimes) > 0 &&
 			ent.Info.FutureActionTimes[0].AsTime().After(initialFirst)
 	})
@@ -785,7 +786,7 @@ func testBasics(t *testing.T, newContext contextFactory) {
 	// wait for visibility to stabilize on completed before calling describe,
 	// otherwise their recent actions may flake and differ
 
-	visibilityResponse := getScheduleEntryFromVisibility(s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	visibilityResponse := getScheduleEntryFromVisibility(t, s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		recentActions := ent.GetInfo().GetRecentActions()
 		return len(recentActions) >= 2 && recentActions[1].GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
 	})
@@ -1503,7 +1504,7 @@ func testListSchedulesReturnsWorkflowStatus(t *testing.T, newContext contextFact
 	s.NoError(err)
 
 	// validate RecentActions made it to visibility
-	listResp := getScheduleEntryFromVisibility(s, sid, newContext, func(listResp *schedulepb.ScheduleListEntry) bool {
+	listResp := getScheduleEntryFromVisibility(t, s, sid, newContext, func(listResp *schedulepb.ScheduleListEntry) bool {
 		return len(listResp.Info.RecentActions) >= 1
 	})
 	s.Len(listResp.Info.RecentActions, 1)
@@ -1524,7 +1525,7 @@ func testListSchedulesReturnsWorkflowStatus(t *testing.T, newContext contextFact
 	s.NoError(err)
 
 	// now wait for second recent action to land in visbility
-	listResp = getScheduleEntryFromVisibility(s, sid, newContext, func(listResp *schedulepb.ScheduleListEntry) bool {
+	listResp = getScheduleEntryFromVisibility(t, s, sid, newContext, func(listResp *schedulepb.ScheduleListEntry) bool {
 		return len(listResp.Info.RecentActions) >= 2
 	})
 
@@ -1723,7 +1724,7 @@ func testLimitMemoSpecSize(t *testing.T, newContext contextFactory) {
 	s.NoError(err)
 
 	// Verify the memo field length limit was enforced.
-	entry := getScheduleEntryFromVisibility(s, sid, newContext, nil)
+	entry := getScheduleEntryFromVisibility(t, s, sid, newContext, nil)
 	require.NotNil(t, entry)
 	spec := entry.GetInfo().GetSpec()
 	require.Len(t, spec.GetInterval(), expectedLimit)
@@ -1925,7 +1926,7 @@ func testListSchedulesFilterAndEntryFields(t *testing.T, newContext contextFacto
 	s.NoError(err)
 
 	// Wait for the schedule to appear with correct paused state.
-	entry := getScheduleEntryFromVisibility(s, sid, newContext, func(e *schedulepb.ScheduleListEntry) bool {
+	entry := getScheduleEntryFromVisibility(t, s, sid, newContext, func(e *schedulepb.ScheduleListEntry) bool {
 		return e.Info.Paused
 	})
 
@@ -2006,8 +2007,8 @@ func testListSchedulesFilterByScheduleID(t *testing.T, newContext contextFactory
 	}
 
 	// Wait for both schedules to appear in visibility.
-	getScheduleEntryFromVisibility(s, sid1, newContext, nil)
-	getScheduleEntryFromVisibility(s, sid2, newContext, nil)
+	getScheduleEntryFromVisibility(t, s, sid1, newContext, nil)
+	getScheduleEntryFromVisibility(t, s, sid2, newContext, nil)
 
 	listScheduleIDs := func(query string) []string {
 		t.Helper()
@@ -2232,7 +2233,7 @@ func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, e
 	s.NoError(err)
 
 	// Wait for scheduler to start the workflow and show it as RUNNING.
-	listEntry := getScheduleEntryFromVisibility(s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	listEntry := getScheduleEntryFromVisibility(t, s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		return len(ent.Info.RecentActions) >= 1 &&
 			ent.Info.RecentActions[0].GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
 	})
@@ -2335,7 +2336,7 @@ func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, e
 	})
 	s.NoError(err)
 
-	getScheduleEntryFromVisibility(s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	getScheduleEntryFromVisibility(t, s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		for _, action := range ent.Info.RecentActions {
 			if action.GetStartWorkflowResult().GetRunId() == wfExec.RunId {
 				return action.GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
@@ -2407,7 +2408,7 @@ func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, en
 	})
 	s.NoError(err)
 
-	listEntry := getScheduleEntryFromVisibility(s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	listEntry := getScheduleEntryFromVisibility(t, s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		return len(ent.Info.RecentActions) >= 1 &&
 			ent.Info.RecentActions[0].GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
 	})
@@ -2508,7 +2509,7 @@ func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, en
 	})
 	s.NoError(err)
 
-	getScheduleEntryFromVisibility(s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	getScheduleEntryFromVisibility(t, s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		for _, action := range ent.Info.RecentActions {
 			if action.GetStartWorkflowResult().GetRunId() == wfExec.RunId {
 				return action.GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
@@ -2576,7 +2577,7 @@ func testCreatesWorkflowSentinel(t *testing.T, newContext contextFactory) {
 	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, descResp.WorkflowExecutionInfo.Status)
 
 	// Verify visibility shows exactly one schedule (not the dummy workflow).
-	getScheduleEntryFromVisibility(s, sid, newContext, nil)
+	getScheduleEntryFromVisibility(t, s, sid, newContext, nil)
 	listResp, err := s.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
 		Namespace:       s.Namespace().String(),
 		MaximumPageSize: 5,
@@ -2704,7 +2705,7 @@ func testCreatesCHASMSentinel(t *testing.T, newContext contextFactory) {
 	}, 15*time.Second, 500*time.Millisecond, "CHASM sentinel should exist for V1 schedule")
 
 	// Verify visibility shows exactly one schedule (not the sentinel).
-	getScheduleEntryFromVisibility(s, sid, newContext, nil)
+	getScheduleEntryFromVisibility(t, s, sid, newContext, nil)
 	listResp, err := s.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
 		Namespace:       s.Namespace().String(),
 		MaximumPageSize: 5,
@@ -3152,7 +3153,7 @@ func testCHASMCanListV1Schedules(t *testing.T, newContext contextFactory) {
 	s.NoError(err)
 
 	// Sanity test, list with V1 handler.
-	v1Entry := getScheduleEntryFromVisibility(s, sid, newContext, func(sle *schedulepb.ScheduleListEntry) bool {
+	v1Entry := getScheduleEntryFromVisibility(t, s, sid, newContext, func(sle *schedulepb.ScheduleListEntry) bool {
 		return sle.GetInfo().Paused
 	})
 	s.NotNil(v1Entry.GetInfo())
@@ -3165,7 +3166,7 @@ func testCHASMCanListV1Schedules(t *testing.T, newContext contextFactory) {
 	s.GreaterOrEqual(v1CountResp.Count, int64(1), "Expected at least 1 schedule with V1 handler")
 
 	// Flip on CHASM experiment and make sure we can still list.
-	chasmEntry := getScheduleEntryFromVisibility(s, sid, chasmContextFactory, nil)
+	chasmEntry := getScheduleEntryFromVisibility(t, s, sid, chasmContextFactory, nil)
 	s.NotNil(chasmEntry.GetInfo())
 	s.ProtoEqual(chasmEntry.GetInfo(), v1Entry.GetInfo())
 
@@ -3326,7 +3327,7 @@ func testListBeforeRun(t *testing.T, newContext contextFactory) {
 	_, err := s.FrontendClient().CreateSchedule(newContext(s.Context()), req)
 	s.NoError(err)
 
-	entry := getScheduleEntryFromVisibility(s, sid, newContext, nil)
+	entry := getScheduleEntryFromVisibility(t, s, sid, newContext, nil)
 	s.NotNil(entry.Info)
 	s.ProtoEqual(schedule.Spec, entry.Info.Spec)
 	s.Equal(wt, entry.Info.WorkflowType.Name)
@@ -3472,11 +3473,11 @@ func testNextTimeCache(t *testing.T, newContext contextFactory) {
 
 // getScheduleEntryFromVisibility polls visibility using ListSchedules until it finds a schedule
 // with the given id and for which the optional predicate function returns true.
-func getScheduleEntryFromVisibility(env testcore.Env, sid string, newContext contextFactory, predicate func(*schedulepb.ScheduleListEntry) bool) *schedulepb.ScheduleListEntry {
-	env.T().Helper()
+func getScheduleEntryFromVisibility(t *testing.T, env testcore.Env, sid string, newContext contextFactory, predicate func(*schedulepb.ScheduleListEntry) bool) *schedulepb.ScheduleListEntry {
+	t.Helper()
 	var slEntry *schedulepb.ScheduleListEntry
-	require.Eventually(env.T(), func() bool { // wait for visibility
-		listResp, err := env.FrontendClient().ListSchedules(newContext(env.Context()), &workflowservice.ListSchedulesRequest{
+	require.Eventually(t, func() bool { // wait for visibility
+		listResp, err := env.FrontendClient().ListSchedules(newContext(testcontext.For(t)), &workflowservice.ListSchedulesRequest{
 			Namespace:       env.Namespace().String(),
 			MaximumPageSize: 5,
 		})

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -39,7 +39,6 @@ import (
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/protorequire"
-	"go.temporal.io/server/common/testing/testcontext"
 	"go.temporal.io/server/service/worker/dummy"
 	"go.temporal.io/server/service/worker/scheduler"
 	"go.temporal.io/server/tests/testcore"
@@ -401,13 +400,13 @@ func runSharedScheduleTests(t *testing.T, newContext contextFactory) {
 // BUFFER_ONE keeps exactly one start in the buffer while the first workflow
 // is still running.
 func testBufferSizeReportedWhenBuffered(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-buffer-size")
 	wid := testcore.RandomizeStr("sched-buffer-size-wf")
 	wt := testcore.RandomizeStr("sched-buffer-size-wt")
 
-	env.SdkWorker().RegisterWorkflowWithOptions(
+	s.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error {
 			return workflow.Sleep(ctx, time.Hour)
 		},
@@ -425,7 +424,7 @@ func testBufferSizeReportedWhenBuffered(t *testing.T, newContext contextFactory)
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
@@ -434,20 +433,20 @@ func testBufferSizeReportedWhenBuffered(t *testing.T, newContext contextFactory)
 		},
 	}
 
-	ctx := newContext(env.Context())
-	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	var lastDescribe *workflowservice.DescribeScheduleResponse
-	env.Eventually(func() bool {
-		desc, descErr := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  env.Namespace().String(),
+	s.Eventually(func() bool {
+		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
 			ScheduleId: sid,
 		})
 		if descErr != nil {
@@ -457,8 +456,8 @@ func testBufferSizeReportedWhenBuffered(t *testing.T, newContext contextFactory)
 		return desc.GetInfo().GetBufferSize() >= 1 && len(desc.GetInfo().GetRunningWorkflows()) >= 1
 	}, 30*time.Second, 500*time.Millisecond, "DescribeSchedule should report BufferSize >= 1 with a running workflow blocking the buffer")
 
-	env.GreaterOrEqual(lastDescribe.GetInfo().GetBufferSize(), int64(1), "BufferSize must reflect at least one buffered start")
-	env.GreaterOrEqual(len(lastDescribe.GetInfo().GetRunningWorkflows()), 1, "expected the buffered fire to be queued behind a running workflow")
+	s.GreaterOrEqual(lastDescribe.GetInfo().GetBufferSize(), int64(1), "BufferSize must reflect at least one buffered start")
+	s.GreaterOrEqual(len(lastDescribe.GetInfo().GetRunningWorkflows()), 1, "expected the buffered fire to be queued behind a running workflow")
 }
 
 // testRecentActionsAdvanceWhilePaused verifies that an in-flight workflow's
@@ -468,7 +467,7 @@ func testBufferSizeReportedWhenBuffered(t *testing.T, newContext contextFactory)
 // from RUNNING to COMPLETED. V1's scheduler workflow does not advance its
 // memo while paused, so the listed status stays at RUNNING until unpause.
 func testRecentActionsAdvanceWhilePaused(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-recentactions-paused")
 	wid := testcore.RandomizeStr("sched-recentactions-paused-wf")
@@ -476,16 +475,16 @@ func testRecentActionsAdvanceWhilePaused(t *testing.T, newContext contextFactory
 
 	// Gate the run so the RUNNING -> COMPLETED transition is driven explicitly.
 	var runs atomic.Int32
-	registerGatedWorkflow(env, wt, &runs)
+	registerGatedWorkflow(s, wt, &runs)
 
-	ctx := newContext(env.Context())
-	createSchedule(ctx, t, env, sid, &schedulepb.Schedule{
+	ctx := newContext(s.Context())
+	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
 		Spec:   intervalSpec(fastInterval),
-		Action: startWorkflowAction(env, wid, wt),
+		Action: startWorkflowAction(s, wid, wt),
 	})
 
 	// Wait for the first workflow to be reported as RUNNING in ListSchedules.
-	running := getScheduleEntryFromVisibility(t, env, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	running := getScheduleEntryFromVisibility(s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		return len(ent.Info.RecentActions) >= 1 &&
 			ent.Info.RecentActions[0].GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
 	})
@@ -493,13 +492,13 @@ func testRecentActionsAdvanceWhilePaused(t *testing.T, newContext contextFactory
 	require.NotEmpty(t, runningRunID)
 
 	// Pause, then release the run: its COMPLETED status must surface while paused.
-	patchSchedule(ctx, t, env, sid, &schedulepb.SchedulePatch{Pause: "pausing for the test"})
+	patchSchedule(ctx, t, s, sid, &schedulepb.SchedulePatch{Pause: "pausing for the test"})
 
-	signaled := completeRunningWorkflows(ctx, t, env, sid)
+	signaled := completeRunningWorkflows(ctx, t, s, sid)
 	require.Equal(t, 1, signaled, "exactly one run should be in flight under the default SKIP overlap policy")
 
 	// While paused, the listed RecentActions entry transitions to COMPLETED.
-	getScheduleEntryFromVisibility(t, env, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	getScheduleEntryFromVisibility(s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		for _, a := range ent.Info.RecentActions {
 			if a.GetStartWorkflowResult().GetRunId() == runningRunID &&
 				a.GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED {
@@ -519,24 +518,24 @@ func testRecentActionsAdvanceWhilePaused(t *testing.T, newContext contextFactory
 // while paused, so its projected times would freeze at pause time and
 // eventually all sit in the past - hence this test is registered CHASM-only.
 func testFutureActionTimesAdvanceWhilePaused(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-future-actions-paused")
 	wid := testcore.RandomizeStr("sched-future-actions-paused-wf")
 	wt := testcore.RandomizeStr("sched-future-actions-paused-wt")
 
 	var runs atomic.Int32
-	registerCountingWorkflow(env, wt, &runs)
+	registerCountingWorkflow(s, wt, &runs)
 
-	ctx := newContext(env.Context())
-	createSchedule(ctx, t, env, sid, &schedulepb.Schedule{
+	ctx := newContext(s.Context())
+	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
 		Spec:   intervalSpec(fastInterval),
 		State:  &schedulepb.ScheduleState{Paused: true},
-		Action: startWorkflowAction(env, wid, wt),
+		Action: startWorkflowAction(s, wid, wt),
 	})
 
 	// Wait for visibility to surface an initial FutureActionTimes projection.
-	initial := getScheduleEntryFromVisibility(t, env, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	initial := getScheduleEntryFromVisibility(s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		return len(ent.Info.FutureActionTimes) > 0
 	})
 	initialFirst := initial.Info.FutureActionTimes[0].AsTime()
@@ -544,7 +543,7 @@ func testFutureActionTimesAdvanceWhilePaused(t *testing.T, newContext contextFac
 	// While still paused, the earliest projected time must advance past the
 	// initial value: the Generator keeps ticking and republishing the
 	// projection, even though no workflows fire.
-	getScheduleEntryFromVisibility(t, env, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	getScheduleEntryFromVisibility(s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		return len(ent.Info.FutureActionTimes) > 0 &&
 			ent.Info.FutureActionTimes[0].AsTime().After(initialFirst)
 	})
@@ -557,7 +556,7 @@ func testFutureActionTimesAdvanceWhilePaused(t *testing.T, newContext contextFac
 // deferred start (Attempt=-1 -> 0 in recordCompletedAction), the buffered
 // fire would be stranded.
 func testBufferOneDeferredFiresAfterCompletion(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-buffer-one-deferred")
 	wid := testcore.RandomizeStr("sched-buffer-one-deferred-wf")
@@ -566,12 +565,12 @@ func testBufferOneDeferredFiresAfterCompletion(t *testing.T, newContext contextF
 	// Gate runs so "first running, second buffered" and "deferred fires after
 	// completion" are both reached deterministically.
 	var runs atomic.Int32
-	registerGatedWorkflow(env, wt, &runs)
+	registerGatedWorkflow(s, wt, &runs)
 
-	ctx := newContext(env.Context())
-	createSchedule(ctx, t, env, sid, &schedulepb.Schedule{
+	ctx := newContext(s.Context())
+	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
 		Spec:   intervalSpec(fastInterval),
-		Action: startWorkflowAction(env, wid, wt),
+		Action: startWorkflowAction(s, wid, wt),
 		Policies: &schedulepb.SchedulePolicies{
 			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
 		},
@@ -579,8 +578,8 @@ func testBufferOneDeferredFiresAfterCompletion(t *testing.T, newContext contextF
 
 	// Exactly one workflow runs with exactly one start buffered behind it (BUFFER_ONE caps the buffer at one).
 	await.RequireTruef(t, func() bool {
-		desc, descErr := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  env.Namespace().String(),
+		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
 			ScheduleId: sid,
 		})
 		return descErr == nil && desc.GetInfo().GetBufferSize() == 1 && len(desc.GetInfo().GetRunningWorkflows()) == 1
@@ -588,7 +587,7 @@ func testBufferOneDeferredFiresAfterCompletion(t *testing.T, newContext contextF
 	require.Equal(t, int32(1), runs.Load(), "only the first workflow should have fired before the running one completes")
 
 	// Releasing the running workflow must re-enable the deferred start (Attempt=-1 -> 0) so it fires.
-	require.Equal(t, 1, completeRunningWorkflows(ctx, t, env, sid))
+	require.Equal(t, 1, completeRunningWorkflows(ctx, t, s, sid))
 	await.RequireTruef(t, func() bool { return runs.Load() == 2 },
 		awaitTimeout, pollInterval,
 		"deferred start must fire after the running workflow completes - regression for the Attempt=-1 -> 0 re-enable path")
@@ -598,8 +597,8 @@ func testBufferOneDeferredFiresAfterCompletion(t *testing.T, newContext contextF
 	// completed first tick and the still-running deferred start; with no jitter the
 	// deferred start's nominal time is exactly one interval after the first tick's.
 	await.RequireTruef(t, func() bool {
-		desc, descErr := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  env.Namespace().String(),
+		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
 			ScheduleId: sid,
 		})
 		if descErr != nil {
@@ -620,7 +619,7 @@ func testBufferOneDeferredFiresAfterCompletion(t *testing.T, newContext contextF
 }
 
 func testDeletedScheduleOperations(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-deleted-ops"
 	wid := "sched-test-deleted-ops-wf"
@@ -637,35 +636,35 @@ func testDeletedScheduleOperations(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 
 	// Create a schedule.
-	_, err := env.FrontendClient().CreateSchedule(newContext(env.Context()), &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	_, err := s.FrontendClient().CreateSchedule(newContext(s.Context()), &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	// Delete the schedule.
-	_, err = env.FrontendClient().DeleteSchedule(newContext(env.Context()), &workflowservice.DeleteScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	_, err = s.FrontendClient().DeleteSchedule(newContext(s.Context()), &workflowservice.DeleteScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Identity:   "test",
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	// Describe should return NotFound.
 	var notFoundErr *serviceerror.NotFound
-	env.Eventually(func() bool {
-		_, descErr := env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
-			Namespace:  env.Namespace().String(),
+	s.Eventually(func() bool {
+		_, descErr := s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
 			ScheduleId: sid,
 		})
 		return errors.As(descErr, &notFoundErr)
@@ -676,7 +675,7 @@ func testDeletedScheduleOperations(t *testing.T, newContext contextFactory) {
 }
 
 func testBasics(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-basics"
 	wid := "sched-test-basics-wf"
@@ -710,7 +709,7 @@ func testBasics(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					Memo: &commonpb.Memo{
 						Fields: map[string]*commonpb.Payload{"wfmemo1": wfMemo},
 					},
@@ -722,7 +721,7 @@ func testBasics(t *testing.T, newContext contextFactory) {
 		},
 	}
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -747,7 +746,7 @@ func testBasics(t *testing.T, newContext contextFactory) {
 		})
 		return nil
 	}
-	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+	s.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 	workflow2Fn := func(ctx workflow.Context) error {
 		workflow.SideEffect(ctx, func(ctx workflow.Context) any {
 			atomic.AddInt32(&runs2, 1)
@@ -755,55 +754,55 @@ func testBasics(t *testing.T, newContext contextFactory) {
 		})
 		return nil
 	}
-	env.SdkWorker().RegisterWorkflowWithOptions(workflow2Fn, workflow.RegisterOptions{Name: wt2})
+	s.SdkWorker().RegisterWorkflowWithOptions(workflow2Fn, workflow.RegisterOptions{Name: wt2})
 
 	// create
 
-	ctx := newContext(env.Context())
+	ctx := newContext(s.Context())
 	createTime := time.Now()
-	_, err := env.FrontendClient().CreateSchedule(ctx, req)
-	env.NoError(err)
+	_, err := s.FrontendClient().CreateSchedule(ctx, req)
+	s.NoError(err)
 
 	// describe immediately after create and verify FutureActionTimes
-	describeRespAfterCreate, err := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	describeRespAfterCreate, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 	})
-	env.NoError(err)
-	env.NotEmpty(describeRespAfterCreate.Info.FutureActionTimes, "FutureActionTimes should be set immediately after create")
+	s.NoError(err)
+	s.NotEmpty(describeRespAfterCreate.Info.FutureActionTimes, "FutureActionTimes should be set immediately after create")
 	// FutureActionTimes should be in the future (after createTime) and aligned to 5-second intervals
 	for i, fat := range describeRespAfterCreate.Info.FutureActionTimes {
-		env.True(fat.AsTime().After(createTime) || fat.AsTime().Equal(createTime),
+		s.True(fat.AsTime().After(createTime) || fat.AsTime().Equal(createTime),
 			"FutureActionTimes[%d] should be >= createTime", i)
-		env.Equal(int64(0), fat.AsTime().UnixNano()%int64(5*time.Second),
+		s.Equal(int64(0), fat.AsTime().UnixNano()%int64(5*time.Second),
 			"FutureActionTimes[%d] should be aligned to 5-second intervals", i)
 	}
 
 	// sleep until we see two runs, plus a bit more to ensure that the second run has completed
-	env.Eventually(func() bool { return atomic.LoadInt32(&runs) == 2 }, 15*time.Second, 500*time.Millisecond)
+	s.Eventually(func() bool { return atomic.LoadInt32(&runs) == 2 }, 15*time.Second, 500*time.Millisecond)
 	time.Sleep(2 * time.Second) //nolint:forbidigo
 
 	// wait for visibility to stabilize on completed before calling describe,
 	// otherwise their recent actions may flake and differ
 
-	visibilityResponse := getScheduleEntryFromVisibility(t, env, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	visibilityResponse := getScheduleEntryFromVisibility(s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		recentActions := ent.GetInfo().GetRecentActions()
 		return len(recentActions) >= 2 && recentActions[1].GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
 	})
 
-	describeResp, err := env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	describeResp, err := s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	// validate describe response
 
 	checkSpec := func(spec *schedulepb.ScheduleSpec) {
-		protorequire.ProtoSliceEqual(env.T(), schedule.Spec.Interval, spec.Interval)
-		env.Nil(spec.Calendar)
-		env.Nil(spec.CronString)
-		env.ProtoElementsMatch([]*schedulepb.StructuredCalendarSpec{
+		protorequire.ProtoSliceEqual(s.T(), schedule.Spec.Interval, spec.Interval)
+		s.Nil(spec.Calendar)
+		s.Nil(spec.CronString)
+		s.ProtoElementsMatch([]*schedulepb.StructuredCalendarSpec{
 			{
 				Second:     []*schedulepb.Range{{Start: 0, End: 0, Step: 1}},
 				Minute:     []*schedulepb.Range{{Start: 11, End: 11, Step: 1}},
@@ -826,61 +825,61 @@ func testBasics(t *testing.T, newContext contextFactory) {
 	}
 	checkSpec(describeResp.Schedule.Spec)
 
-	env.Equal(enumspb.SCHEDULE_OVERLAP_POLICY_SKIP, describeResp.Schedule.Policies.OverlapPolicy)     // set to default value
-	env.EqualValues(365*24*3600, describeResp.Schedule.Policies.CatchupWindow.AsDuration().Seconds()) // set to default value
+	s.Equal(enumspb.SCHEDULE_OVERLAP_POLICY_SKIP, describeResp.Schedule.Policies.OverlapPolicy)     // set to default value
+	s.EqualValues(365*24*3600, describeResp.Schedule.Policies.CatchupWindow.AsDuration().Seconds()) // set to default value
 
-	env.Equal(schSAValue.Data, describeResp.SearchAttributes.IndexedFields[csaKeyword].Data)
-	env.Equal(schSAIntValue.Data, describeResp.SearchAttributes.IndexedFields[csaInt].Data)
-	env.Equal(schSABoolValue.Data, describeResp.SearchAttributes.IndexedFields[csaBool].Data)
-	env.Nil(describeResp.SearchAttributes.IndexedFields[sadefs.BinaryChecksums])
-	env.Nil(describeResp.SearchAttributes.IndexedFields[sadefs.BuildIds])
-	env.Nil(describeResp.SearchAttributes.IndexedFields[sadefs.TemporalNamespaceDivision])
-	env.Equal(schMemo.Data, describeResp.Memo.Fields["schedmemo1"].Data)
-	env.Equal(wfSAValue.Data, describeResp.Schedule.Action.GetStartWorkflow().SearchAttributes.IndexedFields[csaKeyword].Data)
-	env.Equal(wfMemo.Data, describeResp.Schedule.Action.GetStartWorkflow().Memo.Fields["wfmemo1"].Data)
+	s.Equal(schSAValue.Data, describeResp.SearchAttributes.IndexedFields[csaKeyword].Data)
+	s.Equal(schSAIntValue.Data, describeResp.SearchAttributes.IndexedFields[csaInt].Data)
+	s.Equal(schSABoolValue.Data, describeResp.SearchAttributes.IndexedFields[csaBool].Data)
+	s.Nil(describeResp.SearchAttributes.IndexedFields[sadefs.BinaryChecksums])
+	s.Nil(describeResp.SearchAttributes.IndexedFields[sadefs.BuildIds])
+	s.Nil(describeResp.SearchAttributes.IndexedFields[sadefs.TemporalNamespaceDivision])
+	s.Equal(schMemo.Data, describeResp.Memo.Fields["schedmemo1"].Data)
+	s.Equal(wfSAValue.Data, describeResp.Schedule.Action.GetStartWorkflow().SearchAttributes.IndexedFields[csaKeyword].Data)
+	s.Equal(wfMemo.Data, describeResp.Schedule.Action.GetStartWorkflow().Memo.Fields["wfmemo1"].Data)
 
 	// GreaterOrEqual is used as we may have had other runs start while waiting for visibility
 	durationNear(t, describeResp.Info.CreateTime.AsTime().Sub(createTime), 0)
-	env.GreaterOrEqual(describeResp.Info.ActionCount, int64(2))
-	env.EqualValues(0, describeResp.Info.MissedCatchupWindow)
-	env.EqualValues(0, describeResp.Info.OverlapSkipped)
-	env.GreaterOrEqual(len(describeResp.Info.RunningWorkflows), 0)
-	env.GreaterOrEqual(len(describeResp.Info.RecentActions), 2)
+	s.GreaterOrEqual(describeResp.Info.ActionCount, int64(2))
+	s.EqualValues(0, describeResp.Info.MissedCatchupWindow)
+	s.EqualValues(0, describeResp.Info.OverlapSkipped)
+	s.GreaterOrEqual(len(describeResp.Info.RunningWorkflows), 0)
+	s.GreaterOrEqual(len(describeResp.Info.RecentActions), 2)
 	action0 := describeResp.Info.RecentActions[0]
-	env.WithinRange(action0.ScheduleTime.AsTime(), createTime, time.Now())
-	env.Equal(int64(0), action0.ScheduleTime.AsTime().UnixNano()%int64(5*time.Second))
+	s.WithinRange(action0.ScheduleTime.AsTime(), createTime, time.Now())
+	s.Equal(int64(0), action0.ScheduleTime.AsTime().UnixNano()%int64(5*time.Second))
 	durationNear(t, action0.ActualTime.AsTime().Sub(action0.ScheduleTime.AsTime()), 0)
 
 	// validate list response
 
-	env.Equal(sid, visibilityResponse.ScheduleId)
-	env.Equal(schSAValue.Data, visibilityResponse.SearchAttributes.IndexedFields[csaKeyword].Data)
-	env.Equal(schSAIntValue.Data, describeResp.SearchAttributes.IndexedFields[csaInt].Data)
-	env.Equal(schSABoolValue.Data, describeResp.SearchAttributes.IndexedFields[csaBool].Data)
-	env.Nil(visibilityResponse.SearchAttributes.IndexedFields[sadefs.BinaryChecksums])
-	env.Nil(visibilityResponse.SearchAttributes.IndexedFields[sadefs.BuildIds])
-	env.Nil(visibilityResponse.SearchAttributes.IndexedFields[sadefs.TemporalNamespaceDivision])
-	env.Equal(schMemo.Data, visibilityResponse.Memo.Fields["schedmemo1"].Data)
+	s.Equal(sid, visibilityResponse.ScheduleId)
+	s.Equal(schSAValue.Data, visibilityResponse.SearchAttributes.IndexedFields[csaKeyword].Data)
+	s.Equal(schSAIntValue.Data, describeResp.SearchAttributes.IndexedFields[csaInt].Data)
+	s.Equal(schSABoolValue.Data, describeResp.SearchAttributes.IndexedFields[csaBool].Data)
+	s.Nil(visibilityResponse.SearchAttributes.IndexedFields[sadefs.BinaryChecksums])
+	s.Nil(visibilityResponse.SearchAttributes.IndexedFields[sadefs.BuildIds])
+	s.Nil(visibilityResponse.SearchAttributes.IndexedFields[sadefs.TemporalNamespaceDivision])
+	s.Equal(schMemo.Data, visibilityResponse.Memo.Fields["schedmemo1"].Data)
 	checkSpec(visibilityResponse.Info.Spec)
-	env.Equal(wt, visibilityResponse.Info.WorkflowType.Name)
-	env.False(visibilityResponse.Info.Paused)
-	assertSameRecentActions(env.T(), describeResp, visibilityResponse)
-	assertRecentActionsNoDuplicateRunIDs(env.T(), describeResp.Info.RecentActions)
+	s.Equal(wt, visibilityResponse.Info.WorkflowType.Name)
+	s.False(visibilityResponse.Info.Paused)
+	assertSameRecentActions(s.T(), describeResp, visibilityResponse)
+	assertRecentActionsNoDuplicateRunIDs(s.T(), describeResp.Info.RecentActions)
 
 	// list workflows
 
-	wfResp, err := env.FrontendClient().ListWorkflowExecutions(newContext(env.Context()), &workflowservice.ListWorkflowExecutionsRequest{
-		Namespace: env.Namespace().String(),
+	wfResp, err := s.FrontendClient().ListWorkflowExecutions(newContext(s.Context()), &workflowservice.ListWorkflowExecutionsRequest{
+		Namespace: s.Namespace().String(),
 		PageSize:  5,
 		Query:     "",
 	})
-	env.NoError(err)
-	env.GreaterOrEqual(len(wfResp.Executions), 2) // could have had a 3rd run while waiting for visibility
+	s.NoError(err)
+	s.GreaterOrEqual(len(wfResp.Executions), 2) // could have had a 3rd run while waiting for visibility
 	for _, ex := range wfResp.Executions {
-		env.Equal(wt, ex.Type.Name, "should only see started workflows")
+		s.Equal(wt, ex.Type.Name, "should only see started workflows")
 	}
 	ex0 := wfResp.Executions[0]
-	env.True(strings.HasPrefix(ex0.Execution.WorkflowId, wid))
+	s.True(strings.HasPrefix(ex0.Execution.WorkflowId, wid))
 	matchingRunId := false
 	for _, recentAction := range describeResp.GetInfo().GetRecentActions() {
 		if ex0.GetExecution().GetRunId() == recentAction.GetStartWorkflowResult().GetRunId() {
@@ -888,37 +887,37 @@ func testBasics(t *testing.T, newContext contextFactory) {
 			break
 		}
 	}
-	env.True(matchingRunId, "ListWorkflowExecutions returned a run ID wasn't in the describe response")
-	env.Equal(wt, ex0.Type.Name)
-	env.Nil(ex0.ParentExecution) // not a child workflow
-	env.Equal(wfMemo.Data, ex0.Memo.Fields["wfmemo1"].Data)
-	env.Equal(wfSAValue.Data, ex0.SearchAttributes.IndexedFields[csaKeyword].Data)
-	env.Equal(payload.EncodeString(sid).Data, ex0.SearchAttributes.IndexedFields[sadefs.TemporalScheduledById].Data)
+	s.True(matchingRunId, "ListWorkflowExecutions returned a run ID wasn't in the describe response")
+	s.Equal(wt, ex0.Type.Name)
+	s.Nil(ex0.ParentExecution) // not a child workflow
+	s.Equal(wfMemo.Data, ex0.Memo.Fields["wfmemo1"].Data)
+	s.Equal(wfSAValue.Data, ex0.SearchAttributes.IndexedFields[csaKeyword].Data)
+	s.Equal(payload.EncodeString(sid).Data, ex0.SearchAttributes.IndexedFields[sadefs.TemporalScheduledById].Data)
 	var ex0StartTime time.Time
-	env.NoError(payload.Decode(ex0.SearchAttributes.IndexedFields[sadefs.TemporalScheduledStartTime], &ex0StartTime))
-	env.WithinRange(ex0StartTime, createTime, time.Now())
-	env.Equal(int64(0), ex0StartTime.UnixNano()%int64(5*time.Second))
+	s.NoError(payload.Decode(ex0.SearchAttributes.IndexedFields[sadefs.TemporalScheduledStartTime], &ex0StartTime))
+	s.WithinRange(ex0StartTime, createTime, time.Now())
+	s.Equal(int64(0), ex0StartTime.UnixNano()%int64(5*time.Second))
 
 	// list schedules with search attribute filter
 
-	listResp, err := env.FrontendClient().ListSchedules(newContext(env.Context()), &workflowservice.ListSchedulesRequest{
-		Namespace:       env.Namespace().String(),
+	listResp, err := s.FrontendClient().ListSchedules(newContext(s.Context()), &workflowservice.ListSchedulesRequest{
+		Namespace:       s.Namespace().String(),
 		MaximumPageSize: 5,
 		Query:           "CustomKeywordField = 'schedule sa value' AND TemporalSchedulePaused = false",
 	})
-	env.NoError(err)
-	env.Len(listResp.Schedules, 1)
+	s.NoError(err)
+	s.Len(listResp.Schedules, 1)
 	entry := listResp.Schedules[0]
-	env.Equal(sid, entry.ScheduleId)
+	s.Equal(sid, entry.ScheduleId)
 
 	// list schedules with invalid search attribute filter
 
-	_, err = env.FrontendClient().ListSchedules(newContext(env.Context()), &workflowservice.ListSchedulesRequest{
-		Namespace:       env.Namespace().String(),
+	_, err = s.FrontendClient().ListSchedules(newContext(s.Context()), &workflowservice.ListSchedulesRequest{
+		Namespace:       s.Namespace().String(),
 		MaximumPageSize: 5,
 		Query:           "ExecutionDuration > '1s'",
 	})
-	env.Error(err)
+	s.Error(err)
 
 	// update schedule, no updates to search attributes
 
@@ -926,43 +925,43 @@ func testBasics(t *testing.T, newContext contextFactory) {
 	schedule.Action.GetStartWorkflow().WorkflowType.Name = wt2
 
 	updateTime := time.Now()
-	_, err = env.FrontendClient().UpdateSchedule(newContext(env.Context()), &workflowservice.UpdateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	_, err = s.FrontendClient().UpdateSchedule(newContext(s.Context()), &workflowservice.UpdateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	// wait for one new run
-	env.Eventually(
+	s.Eventually(
 		func() bool { return atomic.LoadInt32(&runs2) == 1 },
 		7*time.Second,
 		500*time.Millisecond,
 	)
 
 	// describe again
-	describeResp, err = env.FrontendClient().DescribeSchedule(
-		newContext(env.Context()),
+	describeResp, err = s.FrontendClient().DescribeSchedule(
+		newContext(s.Context()),
 		&workflowservice.DescribeScheduleRequest{
-			Namespace:  env.Namespace().String(),
+			Namespace:  s.Namespace().String(),
 			ScheduleId: sid,
 		},
 	)
-	env.NoError(err)
+	s.NoError(err)
 
-	env.Len(describeResp.SearchAttributes.GetIndexedFields(), 3)
-	env.Equal(schSAValue.Data, describeResp.SearchAttributes.IndexedFields[csaKeyword].Data)
-	env.Equal(schSAIntValue.Data, describeResp.SearchAttributes.IndexedFields[csaInt].Data)
-	env.Equal(schSABoolValue.Data, describeResp.SearchAttributes.IndexedFields[csaBool].Data)
-	env.Equal(schMemo.Data, describeResp.Memo.Fields["schedmemo1"].Data)
-	env.Equal(wfSAValue.Data, describeResp.Schedule.Action.GetStartWorkflow().SearchAttributes.IndexedFields[csaKeyword].Data)
-	env.Equal(wfMemo.Data, describeResp.Schedule.Action.GetStartWorkflow().Memo.Fields["wfmemo1"].Data)
+	s.Len(describeResp.SearchAttributes.GetIndexedFields(), 3)
+	s.Equal(schSAValue.Data, describeResp.SearchAttributes.IndexedFields[csaKeyword].Data)
+	s.Equal(schSAIntValue.Data, describeResp.SearchAttributes.IndexedFields[csaInt].Data)
+	s.Equal(schSABoolValue.Data, describeResp.SearchAttributes.IndexedFields[csaBool].Data)
+	s.Equal(schMemo.Data, describeResp.Memo.Fields["schedmemo1"].Data)
+	s.Equal(wfSAValue.Data, describeResp.Schedule.Action.GetStartWorkflow().SearchAttributes.IndexedFields[csaKeyword].Data)
+	s.Equal(wfMemo.Data, describeResp.Schedule.Action.GetStartWorkflow().Memo.Fields["wfmemo1"].Data)
 
 	durationNear(t, describeResp.Info.UpdateTime.AsTime().Sub(updateTime), 0)
 	lastAction := describeResp.Info.RecentActions[len(describeResp.Info.RecentActions)-1]
-	env.Equal(int64(1000000000), lastAction.ScheduleTime.AsTime().UnixNano()%int64(5*time.Second), lastAction.ScheduleTime.AsTime().UnixNano())
+	s.Equal(int64(1000000000), lastAction.ScheduleTime.AsTime().UnixNano()%int64(5*time.Second), lastAction.ScheduleTime.AsTime().UnixNano())
 
 	// update schedule and search attributes
 
@@ -972,8 +971,8 @@ func testBasics(t *testing.T, newContext contextFactory) {
 	csaDouble := "CustomDoubleField"
 	schSADoubleValue, _ := payload.Encode(3.14)
 	schSAIntValue, _ = payload.Encode(321)
-	_, err = env.FrontendClient().UpdateSchedule(newContext(env.Context()), &workflowservice.UpdateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	_, err = s.FrontendClient().UpdateSchedule(newContext(s.Context()), &workflowservice.UpdateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -987,15 +986,15 @@ func testBasics(t *testing.T, newContext contextFactory) {
 			},
 		},
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	// wait until search attributes are updated
-	env.EventuallyWithT(
+	s.EventuallyWithT(
 		func(c *assert.CollectT) {
-			describeResp, err = env.FrontendClient().DescribeSchedule(
-				newContext(env.Context()),
+			describeResp, err = s.FrontendClient().DescribeSchedule(
+				newContext(s.Context()),
 				&workflowservice.DescribeScheduleRequest{
-					Namespace:  env.Namespace().String(),
+					Namespace:  s.Namespace().String(),
 					ScheduleId: sid,
 				},
 			)
@@ -1015,23 +1014,23 @@ func testBasics(t *testing.T, newContext contextFactory) {
 	schedule.Spec.Interval[0].Phase = durationpb.New(1 * time.Second)
 	schedule.Action.GetStartWorkflow().WorkflowType.Name = wt2
 
-	_, err = env.FrontendClient().UpdateSchedule(newContext(env.Context()), &workflowservice.UpdateScheduleRequest{
-		Namespace:        env.Namespace().String(),
+	_, err = s.FrontendClient().UpdateSchedule(newContext(s.Context()), &workflowservice.UpdateScheduleRequest{
+		Namespace:        s.Namespace().String(),
 		ScheduleId:       sid,
 		Schedule:         schedule,
 		Identity:         "test",
 		RequestId:        uuid.NewString(),
 		SearchAttributes: &commonpb.SearchAttributes{},
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	// wait until search attributes are updated
-	env.EventuallyWithT(
+	s.EventuallyWithT(
 		func(c *assert.CollectT) {
-			describeResp, err = env.FrontendClient().DescribeSchedule(
-				newContext(env.Context()),
+			describeResp, err = s.FrontendClient().DescribeSchedule(
+				newContext(s.Context()),
 				&workflowservice.DescribeScheduleRequest{
-					Namespace:  env.Namespace().String(),
+					Namespace:  s.Namespace().String(),
 					ScheduleId: sid,
 				},
 			)
@@ -1044,8 +1043,8 @@ func testBasics(t *testing.T, newContext contextFactory) {
 
 	// pause
 
-	_, err = env.FrontendClient().PatchSchedule(newContext(env.Context()), &workflowservice.PatchScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	_, err = s.FrontendClient().PatchSchedule(newContext(s.Context()), &workflowservice.PatchScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Patch: &schedulepb.SchedulePatch{
 			Pause: "because I said so",
@@ -1053,60 +1052,60 @@ func testBasics(t *testing.T, newContext contextFactory) {
 		Identity:  "test",
 		RequestId: uuid.NewString(),
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	time.Sleep(7 * time.Second) //nolint:forbidigo
-	env.EqualValues(1, atomic.LoadInt32(&runs2), "has not run again")
+	s.EqualValues(1, atomic.LoadInt32(&runs2), "has not run again")
 
-	describeResp, err = env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	describeResp, err = s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 	})
-	env.NoError(err)
+	s.NoError(err)
 
-	env.True(describeResp.Schedule.State.Paused)
-	env.Equal("because I said so", describeResp.Schedule.State.Notes)
+	s.True(describeResp.Schedule.State.Paused)
+	s.Equal("because I said so", describeResp.Schedule.State.Notes)
 
 	// don't loop to wait for visibility, we already waited 7s from the patch
-	listResp, err = env.FrontendClient().ListSchedules(newContext(env.Context()), &workflowservice.ListSchedulesRequest{
-		Namespace:       env.Namespace().String(),
+	listResp, err = s.FrontendClient().ListSchedules(newContext(s.Context()), &workflowservice.ListSchedulesRequest{
+		Namespace:       s.Namespace().String(),
 		MaximumPageSize: 5,
 	})
-	env.NoError(err)
-	env.Len(listResp.Schedules, 1)
+	s.NoError(err)
+	s.Len(listResp.Schedules, 1)
 	entry = listResp.Schedules[0]
-	env.Equal(sid, entry.ScheduleId)
-	env.True(entry.Info.Paused)
-	env.Equal("because I said so", entry.Info.Notes)
+	s.Equal(sid, entry.ScheduleId)
+	s.True(entry.Info.Paused)
+	s.Equal("because I said so", entry.Info.Notes)
 
 	// finally delete
 
-	_, err = env.FrontendClient().DeleteSchedule(newContext(env.Context()), &workflowservice.DeleteScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	_, err = s.FrontendClient().DeleteSchedule(newContext(s.Context()), &workflowservice.DeleteScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Identity:   "test",
 	})
-	env.NoError(err)
+	s.NoError(err)
 
-	describeResp, err = env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	describeResp, err = s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 	})
 	var notFoundErr *serviceerror.NotFound
-	env.ErrorAs(err, &notFoundErr)
+	s.ErrorAs(err, &notFoundErr)
 
-	env.Eventually(func() bool { // wait for visibility
-		listResp, err := env.FrontendClient().ListSchedules(newContext(env.Context()), &workflowservice.ListSchedulesRequest{
-			Namespace:       env.Namespace().String(),
+	s.Eventually(func() bool { // wait for visibility
+		listResp, err := s.FrontendClient().ListSchedules(newContext(s.Context()), &workflowservice.ListSchedulesRequest{
+			Namespace:       s.Namespace().String(),
 			MaximumPageSize: 5,
 		})
-		env.NoError(err)
+		s.NoError(err)
 		return len(listResp.Schedules) == 0
 	}, 10*time.Second, 1*time.Second)
 }
 
 func testInput(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-input"
 	wid := "sched-test-input-wf"
@@ -1123,7 +1122,7 @@ func testInput(t *testing.T, newContext contextFactory) {
 	}
 	input2 := map[int]float64{11: 1.4375}
 	inputPayloads, err := payloads.Encode(input1, input2)
-	env.NoError(err)
+	s.NoError(err)
 
 	schedule := &schedulepb.Schedule{
 		Spec: &schedulepb.ScheduleSpec{
@@ -1136,14 +1135,14 @@ func testInput(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					Input:        inputPayloads,
 				},
 			},
 		},
 	}
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -1153,24 +1152,24 @@ func testInput(t *testing.T, newContext contextFactory) {
 	var runs int32
 	workflowFn := func(ctx workflow.Context, arg1 *myData, arg2 map[int]float64) error {
 		workflow.SideEffect(ctx, func(ctx workflow.Context) any {
-			env.Equal(*input1, *arg1)
-			env.Equal(input2, arg2)
+			s.Equal(*input1, *arg1)
+			s.Equal(input2, arg2)
 			atomic.AddInt32(&runs, 1)
 			return 0
 		})
 		return nil
 	}
-	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+	s.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 
-	ctx := newContext(env.Context())
-	_, err = env.FrontendClient().CreateSchedule(ctx, req)
-	env.NoError(err)
+	ctx := newContext(s.Context())
+	_, err = s.FrontendClient().CreateSchedule(ctx, req)
+	s.NoError(err)
 
-	env.Eventually(func() bool { return atomic.LoadInt32(&runs) == 1 }, 8*time.Second, 200*time.Millisecond)
+	s.Eventually(func() bool { return atomic.LoadInt32(&runs) == 1 }, 8*time.Second, 200*time.Millisecond)
 }
 
 func testLastCompletionAndError(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-last"
 	wid := "sched-test-last-wf"
@@ -1187,13 +1186,13 @@ func testLastCompletionAndError(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -1212,36 +1211,36 @@ func testLastCompletionAndError(t *testing.T, newContext contextFactory) {
 
 		var lcr string
 		if workflow.HasLastCompletionResult(ctx) {
-			env.NoError(workflow.GetLastCompletionResult(ctx, &lcr))
+			s.NoError(workflow.GetLastCompletionResult(ctx, &lcr))
 		}
 
 		lastErr := workflow.GetLastError(ctx)
 
 		switch num {
 		case 1:
-			env.Empty(lcr)
-			env.NoError(lastErr)
+			s.Empty(lcr)
+			s.NoError(lastErr)
 			return "this one succeeds", nil
 		case 2:
-			env.NoError(lastErr)
-			env.Equal("this one succeeds", lcr)
+			s.NoError(lastErr)
+			s.Equal("this one succeeds", lcr)
 			return "", errors.New("this one fails")
 		case 3:
-			env.Equal("this one succeeds", lcr)
-			env.ErrorContains(lastErr, "this one fails")
+			s.Equal("this one succeeds", lcr)
+			s.ErrorContains(lastErr, "this one fails")
 			atomic.StoreInt32(&testComplete, 1)
 			return "done", nil
 		default:
 			panic("shouldn't be running anymore")
 		}
 	}
-	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+	s.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 
-	ctx := newContext(env.Context())
-	_, err := env.FrontendClient().CreateSchedule(ctx, req)
-	env.NoError(err)
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, req)
+	s.NoError(err)
 
-	env.Eventually(func() bool { return atomic.LoadInt32(&testComplete) == 1 }, 20*time.Second, 200*time.Millisecond)
+	s.Eventually(func() bool { return atomic.LoadInt32(&testComplete) == 1 }, 20*time.Second, 200*time.Millisecond)
 }
 
 // testScheduleContinuesAfterWorkflowRetryFailure verifies a schedule keeps firing actions
@@ -1252,7 +1251,7 @@ func testScheduleContinuesAfterWorkflowRetryFailure(t *testing.T, newContext con
 	// runs created by retries). That requires the envelope token format, which is gated off by default
 	// for safe rollout, so enable it explicitly here.
 	opts := append(scheduleCommonOpts(t), testcore.WithDynamicConfig(callback.EncodeInternalTokenWithEnvelope, true))
-	env := newScheduleEnv(t, opts...)
+	s := newScheduleEnv(t, opts...)
 
 	sid := testcore.RandomizeStr("sched-retry-fail")
 	wid := testcore.RandomizeStr("sched-retry-fail-wf")
@@ -1265,7 +1264,7 @@ func testScheduleContinuesAfterWorkflowRetryFailure(t *testing.T, newContext con
 		}
 		return errors.New("intentional failure to force a retry")
 	}
-	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+	s.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 
 	schedule := &schedulepb.Schedule{
 		Spec: &schedulepb.ScheduleSpec{
@@ -1278,7 +1277,7 @@ func testScheduleContinuesAfterWorkflowRetryFailure(t *testing.T, newContext con
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					RetryPolicy: &commonpb.RetryPolicy{
 						InitialInterval:    durationpb.New(1 * time.Second),
 						BackoffCoefficient: 1.0,
@@ -1289,9 +1288,9 @@ func testScheduleContinuesAfterWorkflowRetryFailure(t *testing.T, newContext con
 		},
 	}
 
-	ctx := newContext(env.Context())
-	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -1302,9 +1301,9 @@ func testScheduleContinuesAfterWorkflowRetryFailure(t *testing.T, newContext con
 	// Two FAILED actions proves the schedule kept firing past the first retry-failure.
 	var failedActions int
 	var lastDescribe *workflowservice.DescribeScheduleResponse
-	env.Eventually(func() bool {
-		desc, descErr := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  env.Namespace().String(),
+	s.Eventually(func() bool {
+		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
 			ScheduleId: sid,
 		})
 		if descErr != nil {
@@ -1321,10 +1320,10 @@ func testScheduleContinuesAfterWorkflowRetryFailure(t *testing.T, newContext con
 	}, 30*time.Second, 500*time.Millisecond,
 		"schedule should keep recording FAILED actions after the workflow retry-fails")
 
-	env.Equal(int32(1), atomic.LoadInt32(&sawRetry), "scheduled workflow should have retried (attempt > 1)")
-	env.GreaterOrEqual(failedActions, 2, "schedule should record multiple retry-failed actions")
-	env.GreaterOrEqual(lastDescribe.GetInfo().GetActionCount(), int64(2))
-	env.False(lastDescribe.GetSchedule().GetState().GetPaused(), "a retry-failed workflow must not pause the schedule")
+	s.Equal(int32(1), atomic.LoadInt32(&sawRetry), "scheduled workflow should have retried (attempt > 1)")
+	s.GreaterOrEqual(failedActions, 2, "schedule should record multiple retry-failed actions")
+	s.GreaterOrEqual(lastDescribe.GetInfo().GetActionCount(), int64(2))
+	s.False(lastDescribe.GetSchedule().GetState().GetPaused(), "a retry-failed workflow must not pause the schedule")
 }
 
 // testScheduledWorkflowContinueAsNewCompletion validates that the CHASM scheduler observes the
@@ -1341,7 +1340,7 @@ func testScheduledWorkflowContinueAsNewCompletion(t *testing.T, newContext conte
 	// completion callback token, which only survives continue-as-new in the envelope token format.
 	// That format is gated off by default for safe rollout, so enable it explicitly here.
 	opts := append(scheduleCommonOpts(t), testcore.WithDynamicConfig(callback.EncodeInternalTokenWithEnvelope, true))
-	env := newScheduleEnv(t, opts...)
+	s := newScheduleEnv(t, opts...)
 
 	sid := testcore.RandomizeStr("sched-can-completion")
 	wid := testcore.RandomizeStr("sched-can-completion-wf")
@@ -1355,7 +1354,7 @@ func testScheduledWorkflowContinueAsNewCompletion(t *testing.T, newContext conte
 		}
 		return nil
 	}
-	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+	s.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 
 	schedule := &schedulepb.Schedule{
 		Spec: &schedulepb.ScheduleSpec{
@@ -1374,21 +1373,21 @@ func testScheduledWorkflowContinueAsNewCompletion(t *testing.T, newContext conte
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	}
 
-	ctx := newContext(env.Context())
-	_, err := env.FrontendClient().CreateSchedule(ctx, req)
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, req)
 	require.NoError(t, err)
 
 	// getCompletionCallback returns the Nexus completion callback the scheduler attached, found in the
@@ -1410,9 +1409,9 @@ func testScheduledWorkflowContinueAsNewCompletion(t *testing.T, newContext conte
 	// callback the scheduler records, not from visibility.)
 	const wantCompleted = 3
 	var completedWFID string
-	env.Eventually(func() bool {
-		desc, descErr := env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
-			Namespace:  env.Namespace().String(),
+	s.Eventually(func() bool {
+		desc, descErr := s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
 			ScheduleId: sid,
 		})
 		if descErr != nil {
@@ -1432,10 +1431,10 @@ func testScheduledWorkflowContinueAsNewCompletion(t *testing.T, newContext conte
 	// Verify the completion callback was written into both runs of a completed action: the
 	// continued-as-new run (latest) and the original run it continued from. The header (callback
 	// token) must be identical, confirming the callback was propagated intact across continue-as-new.
-	env.NotEmpty(completedWFID)
-	canHist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: completedWFID})
+	s.NotEmpty(completedWFID)
+	canHist := s.GetHistory(s.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: completedWFID})
 	canCB := getCompletionCallback(canHist)
-	env.NotNil(canCB, "continued-as-new run must carry the completion callback")
+	s.NotNil(canCB, "continued-as-new run must carry the completion callback")
 
 	var continuedFromRunID string
 	for _, e := range canHist {
@@ -1444,16 +1443,16 @@ func testScheduledWorkflowContinueAsNewCompletion(t *testing.T, newContext conte
 			break
 		}
 	}
-	env.NotEmpty(continuedFromRunID, "completed action should have continued-as-new")
+	s.NotEmpty(continuedFromRunID, "completed action should have continued-as-new")
 
-	origHist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: completedWFID, RunId: continuedFromRunID})
+	origHist := s.GetHistory(s.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: completedWFID, RunId: continuedFromRunID})
 	origCB := getCompletionCallback(origHist)
-	env.NotNil(origCB, "original run must carry the completion callback")
-	env.Equal(origCB.GetNexus().GetHeader(), canCB.GetNexus().GetHeader(), "completion callback must be propagated intact across continue-as-new")
+	s.NotNil(origCB, "original run must carry the completion callback")
+	s.Equal(origCB.GetNexus().GetHeader(), canCB.GetNexus().GetHeader(), "completion callback must be propagated intact across continue-as-new")
 }
 
 func testListSchedulesReturnsWorkflowStatus(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-list-running"
 	wid := "sched-test-list-running-wf"
@@ -1471,7 +1470,7 @@ func testListSchedulesReturnsWorkflowStatus(t *testing.T, newContext contextFact
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
@@ -1490,65 +1489,65 @@ func testListSchedulesReturnsWorkflowStatus(t *testing.T, newContext contextFact
 		selector.Select(ctx)
 		return nil
 	}
-	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+	s.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:    env.Namespace().String(),
+		Namespace:    s.Namespace().String(),
 		ScheduleId:   sid,
 		Schedule:     schedule,
 		InitialPatch: patch,
 		RequestId:    uuid.NewString(),
 	}
-	ctx := newContext(env.Context())
-	_, err := env.FrontendClient().CreateSchedule(ctx, req)
-	env.NoError(err)
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, req)
+	s.NoError(err)
 
 	// validate RecentActions made it to visibility
-	listResp := getScheduleEntryFromVisibility(t, env, sid, newContext, func(listResp *schedulepb.ScheduleListEntry) bool {
+	listResp := getScheduleEntryFromVisibility(s, sid, newContext, func(listResp *schedulepb.ScheduleListEntry) bool {
 		return len(listResp.Info.RecentActions) >= 1
 	})
-	env.Len(listResp.Info.RecentActions, 1)
+	s.Len(listResp.Info.RecentActions, 1)
 
 	a1 := listResp.Info.RecentActions[0]
-	env.True(strings.HasPrefix(a1.StartWorkflowResult.WorkflowId, wid))
-	env.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, a1.StartWorkflowStatus)
+	s.True(strings.HasPrefix(a1.StartWorkflowResult.WorkflowId, wid))
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, a1.StartWorkflowStatus)
 
 	// let the started workflow complete
-	_, err = env.FrontendClient().SignalWorkflowExecution(newContext(env.Context()), &workflowservice.SignalWorkflowExecutionRequest{
-		Namespace: env.Namespace().String(),
+	_, err = s.FrontendClient().SignalWorkflowExecution(newContext(s.Context()), &workflowservice.SignalWorkflowExecutionRequest{
+		Namespace: s.Namespace().String(),
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: a1.StartWorkflowResult.WorkflowId,
 			RunId:      a1.StartWorkflowResult.RunId,
 		},
 		SignalName: resumeSignal,
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	// now wait for second recent action to land in visbility
-	listResp = getScheduleEntryFromVisibility(t, env, sid, newContext, func(listResp *schedulepb.ScheduleListEntry) bool {
+	listResp = getScheduleEntryFromVisibility(s, sid, newContext, func(listResp *schedulepb.ScheduleListEntry) bool {
 		return len(listResp.Info.RecentActions) >= 2
 	})
 
 	a1 = listResp.Info.RecentActions[0]
 	a2 := listResp.Info.RecentActions[1]
-	env.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, a1.StartWorkflowStatus)
-	env.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, a2.StartWorkflowStatus)
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, a1.StartWorkflowStatus)
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, a2.StartWorkflowStatus)
 
 	// Also verify that DescribeSchedule's output matches
-	descResp, err := env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	descResp, err := s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 	})
-	env.NoError(err)
-	assertSameRecentActions(env.T(), descResp, listResp)
+	s.NoError(err)
+	assertSameRecentActions(s.T(), descResp, listResp)
 
 	// Verify no duplicate RunIds in recent actions (regression for migration dedup bug).
-	assertRecentActionsNoDuplicateRunIDs(env.T(), descResp.Info.RecentActions)
-	assertRecentActionsNoDuplicateRunIDs(env.T(), listResp.Info.RecentActions)
+	assertRecentActionsNoDuplicateRunIDs(s.T(), descResp.Info.RecentActions)
+	assertRecentActionsNoDuplicateRunIDs(s.T(), listResp.Info.RecentActions)
 }
 
 func testUpdateIntervalTakesEffect(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-update-interval"
 	wid := "sched-test-update-interval-wf"
@@ -1562,7 +1561,7 @@ func testUpdateIntervalTakesEffect(t *testing.T, newContext contextFactory) {
 		})
 		return nil
 	}
-	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+	s.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 
 	// Create schedule with a long interval (300s) - won't fire for 5 minutes.
 	schedule := &schedulepb.Schedule{
@@ -1576,35 +1575,35 @@ func testUpdateIntervalTakesEffect(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 
-	ctx := newContext(env.Context())
-	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	// Update the interval to be very short (1s).
 	schedule.Spec.Interval[0].Interval = durationpb.New(1 * time.Second)
-	_, err = env.FrontendClient().UpdateSchedule(ctx, &workflowservice.UpdateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	_, err = s.FrontendClient().UpdateSchedule(ctx, &workflowservice.UpdateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	// After updating to 1s interval, we should see runs start within a few seconds.
-	env.Eventually(
+	s.Eventually(
 		func() bool { return atomic.LoadInt32(&runs) >= 2 },
 		10*time.Second,
 		500*time.Millisecond,
@@ -1613,7 +1612,7 @@ func testUpdateIntervalTakesEffect(t *testing.T, newContext contextFactory) {
 }
 
 func testListScheduleMatchingTimes(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-list-matching-times"
 
@@ -1628,41 +1627,41 @@ func testListScheduleMatchingTimes(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   "wf-list-matching-times",
 					WorkflowType: &commonpb.WorkflowType{Name: "action"},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	}
 
-	ctx := newContext(env.Context())
-	_, err := env.FrontendClient().CreateSchedule(ctx, req)
-	env.NoError(err)
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, req)
+	s.NoError(err)
 
 	// Query for matching times over a 5-hour window.
 	now := time.Now().UTC().Truncate(time.Hour).Add(time.Hour) // Start of next hour
 	startTime := timestamppb.New(now)
 	endTime := timestamppb.New(now.Add(5 * time.Hour))
 
-	resp, err := env.FrontendClient().ListScheduleMatchingTimes(ctx, &workflowservice.ListScheduleMatchingTimesRequest{
-		Namespace:  env.Namespace().String(),
+	resp, err := s.FrontendClient().ListScheduleMatchingTimes(ctx, &workflowservice.ListScheduleMatchingTimesRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		StartTime:  startTime,
 		EndTime:    endTime,
 	})
-	env.NoError(err)
+	s.NoError(err)
 	// With 1-hour interval over 5 hours, we expect 5 matching times.
-	env.Len(resp.GetStartTime(), 5)
+	s.Len(resp.GetStartTime(), 5)
 }
 
 func testLimitMemoSpecSize(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	expectedLimit := scheduler.CurrentTweakablePolicies.SpecFieldLengthLimit
 
@@ -1677,7 +1676,7 @@ func testLimitMemoSpecSize(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
@@ -1709,22 +1708,22 @@ func testLimitMemoSpecSize(t *testing.T, newContext contextFactory) {
 
 	// Create the schedule.
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	}
-	env.SdkWorker().RegisterWorkflowWithOptions(
+	s.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error { return nil },
 		workflow.RegisterOptions{Name: wt},
 	)
-	ctx := newContext(env.Context())
-	_, err := env.FrontendClient().CreateSchedule(ctx, req)
-	env.NoError(err)
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, req)
+	s.NoError(err)
 
 	// Verify the memo field length limit was enforced.
-	entry := getScheduleEntryFromVisibility(t, env, sid, newContext, nil)
+	entry := getScheduleEntryFromVisibility(s, sid, newContext, nil)
 	require.NotNil(t, entry)
 	spec := entry.GetInfo().GetSpec()
 	require.Len(t, spec.GetInterval(), expectedLimit)
@@ -1733,7 +1732,7 @@ func testLimitMemoSpecSize(t *testing.T, newContext contextFactory) {
 }
 
 func testCountSchedules(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	// Create multiple schedules with different paused states
 	sidPrefix := "sched-test-count-"
@@ -1756,7 +1755,7 @@ func testCountSchedules(t *testing.T, newContext contextFactory) {
 					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 						WorkflowId:   fmt.Sprintf("%s-%d", wid, i),
 						WorkflowType: &commonpb.WorkflowType{Name: wt},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					},
 				},
 			},
@@ -1765,37 +1764,37 @@ func testCountSchedules(t *testing.T, newContext contextFactory) {
 			},
 		}
 
-		_, err := env.FrontendClient().CreateSchedule(newContext(env.Context()), &workflowservice.CreateScheduleRequest{
-			Namespace:  env.Namespace().String(),
+		_, err := s.FrontendClient().CreateSchedule(newContext(s.Context()), &workflowservice.CreateScheduleRequest{
+			Namespace:  s.Namespace().String(),
 			ScheduleId: sid,
 			Schedule:   schedule,
 			Identity:   "test",
 			RequestId:  uuid.NewString(),
 		})
-		env.NoError(err)
+		s.NoError(err)
 	}
 
 	// Test basic count (all schedules)
-	env.Eventually(func() bool {
-		countResp, err := env.FrontendClient().CountSchedules(newContext(env.Context()), &workflowservice.CountSchedulesRequest{
-			Namespace: env.Namespace().String(),
+	s.Eventually(func() bool {
+		countResp, err := s.FrontendClient().CountSchedules(newContext(s.Context()), &workflowservice.CountSchedulesRequest{
+			Namespace: s.Namespace().String(),
 		})
 		return err == nil && countResp.Count >= 3
 	}, 15*time.Second, 1*time.Second, "Expected at least 3 schedules")
 
 	// Test count with query filter for paused schedules
-	env.Eventually(func() bool {
-		countResp, err := env.FrontendClient().CountSchedules(newContext(env.Context()), &workflowservice.CountSchedulesRequest{
-			Namespace: env.Namespace().String(),
+	s.Eventually(func() bool {
+		countResp, err := s.FrontendClient().CountSchedules(newContext(s.Context()), &workflowservice.CountSchedulesRequest{
+			Namespace: s.Namespace().String(),
 			Query:     fmt.Sprintf("%s = true", sadefs.TemporalSchedulePaused),
 		})
 		return err == nil && countResp.Count >= 1
 	}, 15*time.Second, 1*time.Second, "Expected at least 1 paused schedule")
 
 	// Test count with query filter for non-paused schedules
-	env.Eventually(func() bool {
-		countResp, err := env.FrontendClient().CountSchedules(newContext(env.Context()), &workflowservice.CountSchedulesRequest{
-			Namespace: env.Namespace().String(),
+	s.Eventually(func() bool {
+		countResp, err := s.FrontendClient().CountSchedules(newContext(s.Context()), &workflowservice.CountSchedulesRequest{
+			Namespace: s.Namespace().String(),
 			Query:     fmt.Sprintf("%s = false", sadefs.TemporalSchedulePaused),
 		})
 		return err == nil && countResp.Count >= 2
@@ -1803,7 +1802,7 @@ func testCountSchedules(t *testing.T, newContext contextFactory) {
 }
 
 func testListSchedulesPagination(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	const numSchedules = 4
 	sidPrefix := "sched-test-pagination-"
@@ -1821,40 +1820,40 @@ func testListSchedulesPagination(t *testing.T, newContext contextFactory) {
 					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 						WorkflowId:   fmt.Sprintf("wf-pagination-%d", i),
 						WorkflowType: &commonpb.WorkflowType{Name: "action"},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					},
 				},
 			},
 		}
-		_, err := env.FrontendClient().CreateSchedule(newContext(env.Context()), &workflowservice.CreateScheduleRequest{
-			Namespace:  env.Namespace().String(),
+		_, err := s.FrontendClient().CreateSchedule(newContext(s.Context()), &workflowservice.CreateScheduleRequest{
+			Namespace:  s.Namespace().String(),
 			ScheduleId: sid,
 			Schedule:   schedule,
 			Identity:   "test",
 			RequestId:  uuid.NewString(),
 		})
-		env.NoError(err)
+		s.NoError(err)
 	}
 
 	// Wait for all schedules to be visible.
-	env.Eventually(func() bool {
-		countResp, err := env.FrontendClient().CountSchedules(newContext(env.Context()), &workflowservice.CountSchedulesRequest{
-			Namespace: env.Namespace().String(),
+	s.Eventually(func() bool {
+		countResp, err := s.FrontendClient().CountSchedules(newContext(s.Context()), &workflowservice.CountSchedulesRequest{
+			Namespace: s.Namespace().String(),
 		})
 		return err == nil && countResp.Count >= numSchedules
 	}, 15*time.Second, 1*time.Second, "Expected all schedules to be visible")
 
 	// Paginate with page size 2 and collect all schedule IDs.
-	ctx := newContext(env.Context())
+	ctx := newContext(s.Context())
 	var allIDs []string
 	var nextPageToken []byte
 	for {
-		resp, err := env.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
-			Namespace:       env.Namespace().String(),
+		resp, err := s.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
+			Namespace:       s.Namespace().String(),
 			MaximumPageSize: 2,
 			NextPageToken:   nextPageToken,
 		})
-		env.NoError(err)
+		s.NoError(err)
 		for _, entry := range resp.Schedules {
 			allIDs = append(allIDs, entry.ScheduleId)
 		}
@@ -1863,18 +1862,18 @@ func testListSchedulesPagination(t *testing.T, newContext contextFactory) {
 			break
 		}
 		// Each page except possibly the last should have entries.
-		env.NotEmpty(resp.Schedules)
+		s.NotEmpty(resp.Schedules)
 	}
 
 	// Verify we found all created schedules.
 	for i := range numSchedules {
 		sid := fmt.Sprintf("%s%d", sidPrefix, i)
-		env.Contains(allIDs, sid, "Expected schedule %s in paginated results", sid)
+		s.Contains(allIDs, sid, "Expected schedule %s in paginated results", sid)
 	}
 }
 
 func testListSchedulesFilterAndEntryFields(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-list-fields"
 	wt := "sched-test-list-fields-wt"
@@ -1895,7 +1894,7 @@ func testListSchedulesFilterAndEntryFields(t *testing.T, newContext contextFacto
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   "wf-" + sid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
@@ -1905,9 +1904,9 @@ func testListSchedulesFilterAndEntryFields(t *testing.T, newContext contextFacto
 		},
 	}
 
-	ctx := newContext(env.Context())
-	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -1923,24 +1922,24 @@ func testListSchedulesFilterAndEntryFields(t *testing.T, newContext contextFacto
 			},
 		},
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	// Wait for the schedule to appear with correct paused state.
-	entry := getScheduleEntryFromVisibility(t, env, sid, newContext, func(e *schedulepb.ScheduleListEntry) bool {
+	entry := getScheduleEntryFromVisibility(s, sid, newContext, func(e *schedulepb.ScheduleListEntry) bool {
 		return e.Info.Paused
 	})
 
 	// Verify entry-level fields.
-	env.Equal(schMemo.Data, entry.Memo.Fields["schedmemo1"].Data)
-	env.Equal(schSAValue.Data, entry.SearchAttributes.IndexedFields[csaKeyword].Data)
-	env.Equal(wt, entry.Info.WorkflowType.Name)
-	env.True(entry.Info.Paused)
-	env.Equal("paused for test", entry.Info.Notes)
+	s.Equal(schMemo.Data, entry.Memo.Fields["schedmemo1"].Data)
+	s.Equal(schSAValue.Data, entry.SearchAttributes.IndexedFields[csaKeyword].Data)
+	s.Equal(wt, entry.Info.WorkflowType.Name)
+	s.True(entry.Info.Paused)
+	s.Equal("paused for test", entry.Info.Notes)
 
 	// Filter by TemporalSchedulePaused should find this schedule.
-	env.EventuallyWithT(func(c *assert.CollectT) {
-		listResp, err := env.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
-			Namespace:       env.Namespace().String(),
+	s.EventuallyWithT(func(c *assert.CollectT) {
+		listResp, err := s.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
+			Namespace:       s.Namespace().String(),
 			MaximumPageSize: 10,
 			Query:           fmt.Sprintf("%s = true", sadefs.TemporalSchedulePaused),
 		})
@@ -1953,9 +1952,9 @@ func testListSchedulesFilterAndEntryFields(t *testing.T, newContext contextFacto
 	}, 15*time.Second, 1*time.Second)
 
 	// Filter for paused=false should not include this schedule.
-	env.EventuallyWithT(func(c *assert.CollectT) {
-		listResp, err := env.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
-			Namespace:       env.Namespace().String(),
+	s.EventuallyWithT(func(c *assert.CollectT) {
+		listResp, err := s.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
+			Namespace:       s.Namespace().String(),
 			MaximumPageSize: 10,
 			Query:           fmt.Sprintf("%s = false", sadefs.TemporalSchedulePaused),
 		})
@@ -1967,7 +1966,7 @@ func testListSchedulesFilterAndEntryFields(t *testing.T, newContext contextFacto
 }
 
 func testListSchedulesFilterByScheduleID(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid1 := "sched-filter-by-id-alpha"
 	sid2 := "sched-filter-by-id-beta"
@@ -1984,7 +1983,7 @@ func testListSchedulesFilterByScheduleID(t *testing.T, newContext contextFactory
 					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 						WorkflowId:   "wf-" + sid,
 						WorkflowType: &commonpb.WorkflowType{Name: "action"},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					},
 				},
 			},
@@ -1992,28 +1991,28 @@ func testListSchedulesFilterByScheduleID(t *testing.T, newContext contextFactory
 		}
 	}
 
-	ctx := newContext(env.Context())
+	ctx := newContext(s.Context())
 
 	// Create two schedules.
 	for _, sid := range []string{sid1, sid2} {
-		_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-			Namespace:  env.Namespace().String(),
+		_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+			Namespace:  s.Namespace().String(),
 			ScheduleId: sid,
 			Schedule:   schedule(sid),
 			Identity:   "test",
 			RequestId:  uuid.NewString(),
 		})
-		env.NoError(err)
+		s.NoError(err)
 	}
 
 	// Wait for both schedules to appear in visibility.
-	getScheduleEntryFromVisibility(t, env, sid1, newContext, nil)
-	getScheduleEntryFromVisibility(t, env, sid2, newContext, nil)
+	getScheduleEntryFromVisibility(s, sid1, newContext, nil)
+	getScheduleEntryFromVisibility(s, sid2, newContext, nil)
 
 	listScheduleIDs := func(query string) []string {
 		t.Helper()
-		listResp, err := env.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
-			Namespace:       env.Namespace().String(),
+		listResp, err := s.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
+			Namespace:       s.Namespace().String(),
 			MaximumPageSize: 10,
 			Query:           query,
 		})
@@ -2086,7 +2085,7 @@ func testListSchedulesFilterByScheduleID(t *testing.T, newContext contextFactory
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			env.EventuallyWithT(func(c *assert.CollectT) {
+			s.EventuallyWithT(func(c *assert.CollectT) {
 				ids := listScheduleIDs(tc.query)
 				require.Len(c, ids, len(tc.wantIDs))
 				for _, want := range tc.wantIDs {
@@ -2098,7 +2097,7 @@ func testListSchedulesFilterByScheduleID(t *testing.T, newContext contextFactory
 }
 
 func testScheduleInternalTaskQueue(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 	errorMessageKeyword := "internal per-namespace task queue"
 
 	// Test CreateSchedule with internal task queue
@@ -2121,15 +2120,15 @@ func testScheduleInternalTaskQueue(t *testing.T, newContext contextFactory) {
 			},
 		}
 		req := &workflowservice.CreateScheduleRequest{
-			Namespace:  env.Namespace().String(),
+			Namespace:  s.Namespace().String(),
 			ScheduleId: sid,
 			Schedule:   schedule,
 			Identity:   "test",
 			RequestId:  uuid.NewString(),
 		}
 
-		ctx := newContext(env.Context())
-		_, err := env.FrontendClient().CreateSchedule(ctx, req)
+		ctx := newContext(s.Context())
+		_, err := s.FrontendClient().CreateSchedule(ctx, req)
 		require.Error(t, err)
 		var invalidArgument *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgument)
@@ -2151,21 +2150,21 @@ func testScheduleInternalTaskQueue(t *testing.T, newContext contextFactory) {
 					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 						WorkflowId:   "wf-update-internal-tq",
 						WorkflowType: &commonpb.WorkflowType{Name: "action"},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					},
 				},
 			},
 		}
 		req := &workflowservice.CreateScheduleRequest{
-			Namespace:  env.Namespace().String(),
+			Namespace:  s.Namespace().String(),
 			ScheduleId: sid,
 			Schedule:   schedule,
 			Identity:   "test",
 			RequestId:  uuid.NewString(),
 		}
 
-		ctx := newContext(env.Context())
-		_, err := env.FrontendClient().CreateSchedule(ctx, req)
+		ctx := newContext(s.Context())
+		_, err := s.FrontendClient().CreateSchedule(ctx, req)
 		require.NoError(t, err)
 
 		// Now try to update with internal task queue
@@ -2174,14 +2173,14 @@ func testScheduleInternalTaskQueue(t *testing.T, newContext contextFactory) {
 			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		}
 		updateReq := &workflowservice.UpdateScheduleRequest{
-			Namespace:  env.Namespace().String(),
+			Namespace:  s.Namespace().String(),
 			ScheduleId: sid,
 			Schedule:   schedule,
 			Identity:   "test",
 			RequestId:  uuid.NewString(),
 		}
 
-		_, err = env.FrontendClient().UpdateSchedule(ctx, updateReq)
+		_, err = s.FrontendClient().UpdateSchedule(ctx, updateReq)
 		require.Error(t, err)
 		var invalidArgument *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgument)
@@ -2190,24 +2189,24 @@ func testScheduleInternalTaskQueue(t *testing.T, newContext contextFactory) {
 }
 
 func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, enableCHASMCallbacks bool) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
-	env.OverrideDynamicConfig(dynamicconfig.EnableCHASMCallbacks, enableCHASMCallbacks)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s.OverrideDynamicConfig(dynamicconfig.EnableCHASMCallbacks, enableCHASMCallbacks)
 
 	sid := "sched-test-double-reset"
 	wid := "sched-test-double-reset-wf"
 	wt := "sched-test-double-reset-wt"
 
-	env.SdkWorker().RegisterWorkflowWithOptions(func(ctx workflow.Context) error {
+	s.SdkWorker().RegisterWorkflowWithOptions(func(ctx workflow.Context) error {
 		ch := workflow.GetSignalChannel(ctx, "complete")
 		var signal any
 		ch.Receive(ctx, &signal)
 		return nil
 	}, workflow.RegisterOptions{Name: wt})
 
-	ctx := newContext(env.Context())
+	ctx := newContext(s.Context())
 
-	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule: &schedulepb.Schedule{
 			Spec: &schedulepb.ScheduleSpec{
@@ -2220,7 +2219,7 @@ func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, e
 					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 						WorkflowId:   wid,
 						WorkflowType: &commonpb.WorkflowType{Name: wt},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					},
 				},
 			},
@@ -2230,10 +2229,10 @@ func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, e
 		},
 		RequestId: uuid.NewString(),
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	// Wait for scheduler to start the workflow and show it as RUNNING.
-	listEntry := getScheduleEntryFromVisibility(t, env, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	listEntry := getScheduleEntryFromVisibility(s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		return len(ent.Info.RecentActions) >= 1 &&
 			ent.Info.RecentActions[0].GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
 	})
@@ -2243,21 +2242,21 @@ func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, e
 		RunId:      a1.StartWorkflowResult.RunId,
 	}
 
-	env.WaitForHistoryEvents(`
+	s.WaitForHistoryEvents(`
 		1 WorkflowExecutionStarted
 		2 WorkflowTaskScheduled
 		3 WorkflowTaskStarted
 		4 WorkflowTaskCompleted`,
-		env.GetHistoryFunc(env.Namespace().String(), wfExec),
+		s.GetHistoryFunc(s.Namespace().String(), wfExec),
 		5*time.Second,
 		10*time.Millisecond,
 	)
 
-	origDesc, err := env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-		Namespace: env.Namespace().String(),
+	origDesc, err := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: s.Namespace().String(),
 		Execution: wfExec,
 	})
-	env.NoError(err)
+	s.NoError(err)
 	var originalStartReqID string
 	for reqID, info := range origDesc.GetWorkflowExtendedInfo().GetRequestIdInfos() {
 		if info.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED {
@@ -2265,24 +2264,24 @@ func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, e
 			break
 		}
 	}
-	env.NotEmpty(originalStartReqID, "original run must have a request ID for WorkflowExecutionStarted")
+	s.NotEmpty(originalStartReqID, "original run must have a request ID for WorkflowExecutionStarted")
 
-	resp1, err := env.FrontendClient().ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
-		Namespace:                 env.Namespace().String(),
+	resp1, err := s.FrontendClient().ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
+		Namespace:                 s.Namespace().String(),
 		WorkflowExecution:         wfExec,
 		Reason:                    "double-reset-test-first",
 		WorkflowTaskFinishEventId: 3,
 		RequestId:                 uuid.NewString(),
 	})
-	env.NoError(err)
+	s.NoError(err)
 	resetRun1 := &commonpb.WorkflowExecution{
 		WorkflowId: wfExec.WorkflowId,
 		RunId:      resp1.RunId,
 	}
 
-	env.EventuallyWithT(func(col *assert.CollectT) {
-		resetDesc, err := env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-			Namespace: env.Namespace().String(),
+	s.EventuallyWithT(func(col *assert.CollectT) {
+		resetDesc, err := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: s.Namespace().String(),
 			Execution: resetRun1,
 		})
 		require.NoError(col, err)
@@ -2297,22 +2296,22 @@ func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, e
 			"start request ID must be preserved across first reset")
 	}, 10*time.Second, 100*time.Millisecond)
 
-	resp2, err := env.FrontendClient().ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
-		Namespace:                 env.Namespace().String(),
+	resp2, err := s.FrontendClient().ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
+		Namespace:                 s.Namespace().String(),
 		WorkflowExecution:         resetRun1,
 		Reason:                    "double-reset-test-second",
 		WorkflowTaskFinishEventId: 3,
 		RequestId:                 uuid.NewString(),
 	})
-	env.NoError(err)
+	s.NoError(err)
 	resetRun2 := &commonpb.WorkflowExecution{
 		WorkflowId: wfExec.WorkflowId,
 		RunId:      resp2.RunId,
 	}
 
-	env.EventuallyWithT(func(col *assert.CollectT) {
-		resetDesc, err := env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-			Namespace: env.Namespace().String(),
+	s.EventuallyWithT(func(col *assert.CollectT) {
+		resetDesc, err := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: s.Namespace().String(),
 			Execution: resetRun2,
 		})
 		require.NoError(col, err)
@@ -2327,16 +2326,16 @@ func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, e
 			"start request ID must be preserved across double reset")
 	}, 10*time.Second, 100*time.Millisecond)
 
-	_, err = env.FrontendClient().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
-		Namespace: env.Namespace().String(),
+	_, err = s.FrontendClient().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
+		Namespace: s.Namespace().String(),
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: wfExec.WorkflowId,
 		},
 		SignalName: "complete",
 	})
-	env.NoError(err)
+	s.NoError(err)
 
-	getScheduleEntryFromVisibility(t, env, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	getScheduleEntryFromVisibility(s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		for _, action := range ent.Info.RecentActions {
 			if action.GetStartWorkflowResult().GetRunId() == wfExec.RunId {
 				return action.GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
@@ -2347,9 +2346,9 @@ func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, e
 }
 
 func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, enableCHASMCallbacks bool) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
-	env.OverrideDynamicConfig(dynamicconfig.EnableCHASMCallbacks, enableCHASMCallbacks)
-	env.OverrideDynamicConfig(
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s.OverrideDynamicConfig(dynamicconfig.EnableCHASMCallbacks, enableCHASMCallbacks)
+	s.OverrideDynamicConfig(
 		callback.AllowedAddresses,
 		[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}},
 	)
@@ -2373,17 +2372,17 @@ func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, en
 		return srv.URL + "/callback"
 	}()
 
-	env.SdkWorker().RegisterWorkflowWithOptions(func(ctx workflow.Context) error {
+	s.SdkWorker().RegisterWorkflowWithOptions(func(ctx workflow.Context) error {
 		sigCh := workflow.GetSignalChannel(ctx, "complete")
 		var signal any
 		sigCh.Receive(ctx, &signal)
 		return nil
 	}, workflow.RegisterOptions{Name: wt})
 
-	ctx := newContext(env.Context())
+	ctx := newContext(s.Context())
 
-	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule: &schedulepb.Schedule{
 			Spec: &schedulepb.ScheduleSpec{
@@ -2396,7 +2395,7 @@ func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, en
 					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 						WorkflowId:   wid,
 						WorkflowType: &commonpb.WorkflowType{Name: wt},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					},
 				},
 			},
@@ -2406,9 +2405,9 @@ func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, en
 		},
 		RequestId: uuid.NewString(),
 	})
-	env.NoError(err)
+	s.NoError(err)
 
-	listEntry := getScheduleEntryFromVisibility(t, env, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	listEntry := getScheduleEntryFromVisibility(s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		return len(ent.Info.RecentActions) >= 1 &&
 			ent.Info.RecentActions[0].GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
 	})
@@ -2418,23 +2417,23 @@ func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, en
 		RunId:      a1.StartWorkflowResult.RunId,
 	}
 
-	env.WaitForHistoryEvents(`
+	s.WaitForHistoryEvents(`
 		1 WorkflowExecutionStarted
 		2 WorkflowTaskScheduled
 		3 WorkflowTaskStarted
 		4 WorkflowTaskCompleted`,
-		env.GetHistoryFunc(env.Namespace().String(), wfExec),
+		s.GetHistoryFunc(s.Namespace().String(), wfExec),
 		5*time.Second,
 		10*time.Millisecond,
 	)
 
 	attachRequestID := uuid.NewString()
-	attachResp, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+	attachResp, err := s.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:                attachRequestID,
-		Namespace:                env.Namespace().String(),
+		Namespace:                s.Namespace().String(),
 		WorkflowId:               wfExec.WorkflowId,
 		WorkflowType:             &commonpb.WorkflowType{Name: wt},
-		TaskQueue:                &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		TaskQueue:                &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		WorkflowIdConflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
 		OnConflictOptions: &workflowpb.OnConflictOptions{
 			AttachRequestId:           true,
@@ -2450,37 +2449,37 @@ func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, en
 			},
 		},
 	})
-	env.NoError(err)
-	env.False(attachResp.Started, "expected to attach to existing run, not start a new one")
+	s.NoError(err)
+	s.False(attachResp.Started, "expected to attach to existing run, not start a new one")
 
-	env.WaitForHistoryEvents(`
+	s.WaitForHistoryEvents(`
 		1 WorkflowExecutionStarted
 		2 WorkflowTaskScheduled
 		3 WorkflowTaskStarted
 		4 WorkflowTaskCompleted
 		5 WorkflowExecutionOptionsUpdated`,
-		env.GetHistoryFunc(env.Namespace().String(), wfExec),
+		s.GetHistoryFunc(s.Namespace().String(), wfExec),
 		5*time.Second,
 		10*time.Millisecond,
 	)
 
-	resetResp, err := env.FrontendClient().ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
-		Namespace:                 env.Namespace().String(),
+	resetResp, err := s.FrontendClient().ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
+		Namespace:                 s.Namespace().String(),
 		WorkflowExecution:         wfExec,
 		Reason:                    "reset-with-additional-callback-test",
 		WorkflowTaskFinishEventId: 3,
 		RequestId:                 uuid.NewString(),
 	})
-	env.NoError(err)
+	s.NoError(err)
 	resetRun := &commonpb.WorkflowExecution{
 		WorkflowId: wfExec.WorkflowId,
 		RunId:      resetResp.RunId,
 	}
 
 	var startRequestID string
-	env.EventuallyWithT(func(col *assert.CollectT) {
-		descResp, err := env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-			Namespace: env.Namespace().String(),
+	s.EventuallyWithT(func(col *assert.CollectT) {
+		descResp, err := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: s.Namespace().String(),
 			Execution: resetRun,
 		})
 		require.NoError(col, err)
@@ -2500,16 +2499,16 @@ func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, en
 			"schedule callback and manually-attached callback must have different request IDs")
 	}, 10*time.Second, 100*time.Millisecond)
 
-	_, err = env.FrontendClient().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
-		Namespace: env.Namespace().String(),
+	_, err = s.FrontendClient().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
+		Namespace: s.Namespace().String(),
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: wfExec.WorkflowId,
 		},
 		SignalName: "complete",
 	})
-	env.NoError(err)
+	s.NoError(err)
 
-	getScheduleEntryFromVisibility(t, env, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+	getScheduleEntryFromVisibility(s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
 		for _, action := range ent.Info.RecentActions {
 			if action.GetStartWorkflowResult().GetRunId() == wfExec.RunId {
 				return action.GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
@@ -2520,17 +2519,17 @@ func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, en
 
 	select {
 	case completion := <-ch.requestCh:
-		env.Equal(nexus.OperationStateSucceeded, completion.State)
+		s.Equal(nexus.OperationStateSucceeded, completion.State)
 		ch.requestCompleteCh <- nil
 	case <-time.After(10 * time.Second):
-		env.Fail("timeout waiting for second callback to be delivered")
+		s.Fail("timeout waiting for second callback to be delivered")
 	}
 }
 
 // testCreatesWorkflowSentinel tests that creating a CHASM schedule also starts a
 // dummy workflow to reserve the schedule ID in the V1 workflow ID-space.
 func testCreatesWorkflowSentinel(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sid")
 	wid := testcore.RandomizeStr("wid")
@@ -2547,53 +2546,53 @@ func testCreatesWorkflowSentinel(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 
-	ctx := newContext(env.Context())
-	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   testcore.RandomizeStr("identity"),
 		RequestId:  testcore.RandomizeStr("request-id"),
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	// Verify the dummy workflow was created to reserve the V1 workflow ID.
 	sentinelWfID := scheduler.WorkflowIDPrefix + sid
 	var descResp *workflowservice.DescribeWorkflowExecutionResponse
-	env.Eventually(func() bool {
-		descResp, err = env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-			Namespace: env.Namespace().String(),
+	s.Eventually(func() bool {
+		descResp, err = s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: s.Namespace().String(),
 			Execution: &commonpb.WorkflowExecution{WorkflowId: sentinelWfID},
 		})
 		return err == nil
 	}, 15*time.Second, 500*time.Millisecond, "dummy sentinel workflow should exist")
-	env.Equal(dummy.DummyWFTypeName, descResp.WorkflowExecutionInfo.Type.Name)
-	env.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, descResp.WorkflowExecutionInfo.Status)
+	s.Equal(dummy.DummyWFTypeName, descResp.WorkflowExecutionInfo.Type.Name)
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, descResp.WorkflowExecutionInfo.Status)
 
 	// Verify visibility shows exactly one schedule (not the dummy workflow).
-	getScheduleEntryFromVisibility(t, env, sid, newContext, nil)
-	listResp, err := env.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
-		Namespace:       env.Namespace().String(),
+	getScheduleEntryFromVisibility(s, sid, newContext, nil)
+	listResp, err := s.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
+		Namespace:       s.Namespace().String(),
 		MaximumPageSize: 5,
 	})
-	env.NoError(err)
-	env.Len(listResp.Schedules, 1)
+	s.NoError(err)
+	s.Len(listResp.Schedules, 1)
 
-	countResp, err := env.FrontendClient().CountSchedules(ctx, &workflowservice.CountSchedulesRequest{
-		Namespace: env.Namespace().String(),
+	countResp, err := s.FrontendClient().CountSchedules(ctx, &workflowservice.CountSchedulesRequest{
+		Namespace: s.Namespace().String(),
 	})
-	env.NoError(err)
-	env.Equal(int64(1), countResp.Count)
+	s.NoError(err)
+	s.Equal(int64(1), countResp.Count)
 }
 
 func testStateSizeBytesReported(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-state-size")
 	wid := testcore.RandomizeStr("sched-state-size-wf")
@@ -2610,35 +2609,35 @@ func testStateSizeBytesReported(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 		State: &schedulepb.ScheduleState{Paused: true},
 	}
 
-	ctx := newContext(env.Context())
-	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	})
-	env.NoError(err)
+	s.NoError(err)
 
-	desc, err := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	desc, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 	})
-	env.NoError(err)
-	env.Positive(desc.GetInfo().GetStateSizeBytes(), "Describe should report a non-zero StateSizeBytes")
+	s.NoError(err)
+	s.Positive(desc.GetInfo().GetStateSizeBytes(), "Describe should report a non-zero StateSizeBytes")
 }
 
 // testCreatesCHASMSentinel tests that creating a V1 schedule also creates a
 // CHASM sentinel to reserve the schedule ID in the CHASM execution space.
 func testCreatesCHASMSentinel(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sid")
 	wid := testcore.RandomizeStr("wid")
@@ -2655,31 +2654,31 @@ func testCreatesCHASMSentinel(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 
-	ctx := newContext(env.Context())
-	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   testcore.RandomizeStr("identity"),
 		RequestId:  testcore.RandomizeStr("request-id"),
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	// Verify a CHASM sentinel was created to reserve the schedule ID.
 	// DescribeSchedule should return NotFound, as well as CreateSentinel
-	nsID := env.NamespaceID().String()
-	env.Eventually(func() bool {
-		_, descErr := env.GetTestCluster().SchedulerClient().DescribeSchedule(
+	nsID := s.NamespaceID().String()
+	s.Eventually(func() bool {
+		_, descErr := s.GetTestCluster().SchedulerClient().DescribeSchedule(
 			ctx,
 			&schedulerpb.DescribeScheduleRequest{
 				NamespaceId:     nsID,
-				FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: env.Namespace().String(), ScheduleId: sid},
+				FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: s.Namespace().String(), ScheduleId: sid},
 			},
 		)
 		var notFoundErr *serviceerror.NotFound
@@ -2689,12 +2688,12 @@ func testCreatesCHASMSentinel(t *testing.T, newContext contextFactory) {
 
 		// A CHASM CreateSchedule should also fail with NotFound because
 		// the sentinel blocks it.
-		_, createErr := env.GetTestCluster().SchedulerClient().CreateSchedule(
+		_, createErr := s.GetTestCluster().SchedulerClient().CreateSchedule(
 			ctx,
 			&schedulerpb.CreateScheduleRequest{
 				NamespaceId: nsID,
 				FrontendRequest: &workflowservice.CreateScheduleRequest{
-					Namespace:  env.Namespace().String(),
+					Namespace:  s.Namespace().String(),
 					ScheduleId: sid,
 					RequestId:  testcore.RandomizeStr("test-sentinel-check"),
 					Schedule:   schedule,
@@ -2705,25 +2704,25 @@ func testCreatesCHASMSentinel(t *testing.T, newContext contextFactory) {
 	}, 15*time.Second, 500*time.Millisecond, "CHASM sentinel should exist for V1 schedule")
 
 	// Verify visibility shows exactly one schedule (not the sentinel).
-	getScheduleEntryFromVisibility(t, env, sid, newContext, nil)
-	listResp, err := env.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
-		Namespace:       env.Namespace().String(),
+	getScheduleEntryFromVisibility(s, sid, newContext, nil)
+	listResp, err := s.FrontendClient().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
+		Namespace:       s.Namespace().String(),
 		MaximumPageSize: 5,
 	})
-	env.NoError(err)
-	env.Len(listResp.Schedules, 1)
+	s.NoError(err)
+	s.Len(listResp.Schedules, 1)
 
-	countResp, err := env.FrontendClient().CountSchedules(ctx, &workflowservice.CountSchedulesRequest{
-		Namespace: env.Namespace().String(),
+	countResp, err := s.FrontendClient().CountSchedules(ctx, &workflowservice.CountSchedulesRequest{
+		Namespace: s.Namespace().String(),
 	})
-	env.NoError(err)
-	env.Equal(int64(1), countResp.Count)
+	s.NoError(err)
+	s.Equal(int64(1), countResp.Count)
 }
 
 // testSkipsWorkflowSentinelWhenDisabled asserts that a CHASM CreateSchedule
 // does not start the dummy V1 workflow when EnableCHASMSchedulerSentinels is off.
 func testSkipsWorkflowSentinelWhenDisabled(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, append(scheduleCommonOpts(t),
+	s := newScheduleEnv(t, append(scheduleCommonOpts(t),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerSentinels, false),
 	)...)
 
@@ -2742,37 +2741,37 @@ func testSkipsWorkflowSentinelWhenDisabled(t *testing.T, newContext contextFacto
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 
-	ctx := newContext(env.Context())
-	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   testcore.RandomizeStr("identity"),
 		RequestId:  testcore.RandomizeStr("request-id"),
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	// The dummy V1 workflow that reserves the schedule ID is gated on the
 	// sentinel flag, so it must not exist.
 	sentinelWfID := scheduler.WorkflowIDPrefix + sid
-	_, descErr := env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-		Namespace: env.Namespace().String(),
+	_, descErr := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: s.Namespace().String(),
 		Execution: &commonpb.WorkflowExecution{WorkflowId: sentinelWfID},
 	})
 	var notFoundErr *serviceerror.NotFound
-	env.ErrorAs(descErr, &notFoundErr, "no dummy sentinel workflow should be created when sentinels are disabled")
+	s.ErrorAs(descErr, &notFoundErr, "no dummy sentinel workflow should be created when sentinels are disabled")
 }
 
 // testSkipsCHASMSentinelWhenDisabled asserts that a V1 CreateSchedule does not
 // create a CHASM sentinel when EnableCHASMSchedulerSentinels is off.
 func testSkipsCHASMSentinelWhenDisabled(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, append(scheduleCommonOpts(t),
+	s := newScheduleEnv(t, append(scheduleCommonOpts(t),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerSentinels, false),
 	)...)
 
@@ -2791,42 +2790,42 @@ func testSkipsCHASMSentinelWhenDisabled(t *testing.T, newContext contextFactory)
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 
-	ctx := newContext(env.Context())
-	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   testcore.RandomizeStr("identity"),
 		RequestId:  testcore.RandomizeStr("request-id"),
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	// With no CHASM sentinel reserving the ID, a CHASM CreateSchedule for the
 	// same ID must not be blocked by the NotFound (sentinel) signal.
-	nsID := env.NamespaceID().String()
-	_, createErr := env.GetTestCluster().SchedulerClient().CreateSchedule(
+	nsID := s.NamespaceID().String()
+	_, createErr := s.GetTestCluster().SchedulerClient().CreateSchedule(
 		ctx,
 		&schedulerpb.CreateScheduleRequest{
 			NamespaceId: nsID,
 			FrontendRequest: &workflowservice.CreateScheduleRequest{
-				Namespace:  env.Namespace().String(),
+				Namespace:  s.Namespace().String(),
 				ScheduleId: sid,
 				RequestId:  testcore.RandomizeStr("test-no-sentinel"),
 				Schedule:   schedule,
 			},
 		},
 	)
-	env.NoError(createErr, "no CHASM sentinel should block CreateSchedule when sentinels are disabled, got: %v", createErr)
+	s.NoError(createErr, "no CHASM sentinel should block CreateSchedule when sentinels are disabled, got: %v", createErr)
 }
 
 func testCreateScheduleAlreadyExists(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-already-exists"
 
@@ -2841,31 +2840,31 @@ func testCreateScheduleAlreadyExists(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   "wf-already-exists",
 					WorkflowType: &commonpb.WorkflowType{Name: "action"},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	}
 
-	ctx := newContext(env.Context())
-	_, err := env.FrontendClient().CreateSchedule(ctx, req)
-	env.NoError(err)
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, req)
+	s.NoError(err)
 
 	// Try to create again with a different request ID - should fail with AlreadyExists
 	req.RequestId = uuid.NewString()
-	_, err = env.FrontendClient().CreateSchedule(ctx, req)
-	env.Error(err)
+	_, err = s.FrontendClient().CreateSchedule(ctx, req)
+	s.Error(err)
 
 	var alreadyStarted *serviceerror.WorkflowExecutionAlreadyStarted
-	env.ErrorAs(err, &alreadyStarted)
-	env.Contains(err.Error(), sid)
+	s.ErrorAs(err, &alreadyStarted)
+	s.Contains(err.Error(), sid)
 }
 
 // CreateSchedule is special-cased in the SDKs to translate
@@ -2877,7 +2876,7 @@ func testCreateScheduleDuplicateSdkError(t *testing.T, useCHASM bool) {
 	if useCHASM {
 		opts = append(opts, testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, true))
 	}
-	env := newScheduleEnv(t, opts...)
+	s := newScheduleEnv(t, opts...)
 
 	sid := "sched-test-duplicate-sdk-" + uuid.NewString()[:8]
 	schedOpts := sdkclient.ScheduleOptions{
@@ -2886,22 +2885,22 @@ func testCreateScheduleDuplicateSdkError(t *testing.T, useCHASM bool) {
 		Action: &sdkclient.ScheduleWorkflowAction{
 			ID:        "wf-" + sid,
 			Workflow:  "noop",
-			TaskQueue: env.WorkerTaskQueue(),
+			TaskQueue: s.WorkerTaskQueue(),
 		},
 		Paused: true,
 	}
 
-	ctx := env.Context()
-	handle, err := env.SdkClient().ScheduleClient().Create(ctx, schedOpts)
-	env.NoError(err)
+	ctx := s.Context()
+	handle, err := s.SdkClient().ScheduleClient().Create(ctx, schedOpts)
+	s.NoError(err)
 	defer func() { _ = handle.Delete(context.Background()) }()
 
-	_, err = env.SdkClient().ScheduleClient().Create(ctx, schedOpts)
-	env.ErrorIs(err, temporal.ErrScheduleAlreadyRunning)
+	_, err = s.SdkClient().ScheduleClient().Create(ctx, schedOpts)
+	s.ErrorIs(err, temporal.ErrScheduleAlreadyRunning)
 }
 
 func testPatchRejectsExcessBackfillers(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 	sid := "sched-test-too-many-backfillers"
 	wt := "sched-test-too-many-backfillers-wt"
 
@@ -2916,22 +2915,22 @@ func testPatchRejectsExcessBackfillers(t *testing.T, newContext contextFactory) 
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   "wf-too-many-backfillers",
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 		State: &schedulepb.ScheduleState{Paused: true},
 	}
 
-	ctx := newContext(env.Context())
-	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	// Patch with 50 backfill requests at a time until we reach the limit of 100.
 	now := time.Now()
@@ -2944,8 +2943,8 @@ func testPatchRejectsExcessBackfillers(t *testing.T, newContext contextFactory) 
 				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
 			}
 		}
-		_, err = env.FrontendClient().PatchSchedule(ctx, &workflowservice.PatchScheduleRequest{
-			Namespace:  env.Namespace().String(),
+		_, err = s.FrontendClient().PatchSchedule(ctx, &workflowservice.PatchScheduleRequest{
+			Namespace:  s.Namespace().String(),
 			ScheduleId: sid,
 			Patch: &schedulepb.SchedulePatch{
 				BackfillRequest: backfills,
@@ -2953,12 +2952,12 @@ func testPatchRejectsExcessBackfillers(t *testing.T, newContext contextFactory) 
 			Identity:  "test",
 			RequestId: uuid.NewString(),
 		})
-		env.NoError(err)
+		s.NoError(err)
 	}
 
 	// The next patch should be rejected.
-	_, err = env.FrontendClient().PatchSchedule(ctx, &workflowservice.PatchScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	_, err = s.FrontendClient().PatchSchedule(ctx, &workflowservice.PatchScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Patch: &schedulepb.SchedulePatch{
 			BackfillRequest: []*schedulepb.BackfillRequest{
@@ -2972,21 +2971,21 @@ func testPatchRejectsExcessBackfillers(t *testing.T, newContext contextFactory) 
 		Identity:  "test",
 		RequestId: uuid.NewString(),
 	})
-	env.Error(err)
+	s.Error(err)
 	var failedPrecondition *serviceerror.FailedPrecondition
-	env.ErrorAs(err, &failedPrecondition)
-	env.Contains(err.Error(), "too many concurrent backfillers")
+	s.ErrorAs(err, &failedPrecondition)
+	s.Contains(err.Error(), "too many concurrent backfillers")
 }
 
 func testMigrationCallbackAttach(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sid")
 	wid := testcore.RandomizeStr("wid")
 	wt := testcore.RandomizeStr("wt")
 
 	resumeSignal := "resume"
-	env.SdkWorker().RegisterWorkflowWithOptions(
+	s.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error {
 			workflow.GetSignalChannel(ctx, resumeSignal).Receive(ctx, nil)
 			return nil
@@ -2994,16 +2993,16 @@ func testMigrationCallbackAttach(t *testing.T, newContext contextFactory) {
 		workflow.RegisterOptions{Name: wt},
 	)
 
-	ctx := newContext(env.Context())
-	startResp, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
-		Namespace:    env.Namespace().String(),
+	ctx := newContext(s.Context())
+	startResp, err := s.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+		Namespace:    s.Namespace().String(),
 		WorkflowId:   wid,
 		WorkflowType: &commonpb.WorkflowType{Name: wt},
-		TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:     testcore.RandomizeStr("identity"),
 		RequestId:    testcore.RandomizeStr("request-id"),
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	schedule := &schedulepb.Schedule{
 		Spec: &schedulepb.ScheduleSpec{
@@ -3016,18 +3015,18 @@ func testMigrationCallbackAttach(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 
 	now := time.Now().UTC()
-	nsID := env.NamespaceID().String()
+	nsID := s.NamespaceID().String()
 
 	migrationState := &schedulerpb.SchedulerMigrationState{
 		SchedulerState: &schedulerpb.SchedulerState{
-			Namespace:     env.Namespace().String(),
+			Namespace:     s.Namespace().String(),
 			NamespaceId:   nsID,
 			ScheduleId:    sid,
 			Schedule:      schedule,
@@ -3050,21 +3049,21 @@ func testMigrationCallbackAttach(t *testing.T, newContext contextFactory) {
 			},
 		},
 	}
-	_, err = env.GetTestCluster().SchedulerClient().CreateFromMigrationState(
+	_, err = s.GetTestCluster().SchedulerClient().CreateFromMigrationState(
 		ctx,
 		&schedulerpb.CreateFromMigrationStateRequest{
 			NamespaceId: nsID,
 			State:       migrationState,
 		},
 	)
-	env.NoError(err)
+	s.NoError(err)
 
-	env.Eventually(func() bool {
-		descResp, err := env.GetTestCluster().SchedulerClient().DescribeSchedule(
+	s.Eventually(func() bool {
+		descResp, err := s.GetTestCluster().SchedulerClient().DescribeSchedule(
 			ctx,
 			&schedulerpb.DescribeScheduleRequest{
 				NamespaceId:     nsID,
-				FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: env.Namespace().String(), ScheduleId: sid},
+				FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: s.Namespace().String(), ScheduleId: sid},
 			},
 		)
 		if err != nil {
@@ -3074,22 +3073,22 @@ func testMigrationCallbackAttach(t *testing.T, newContext contextFactory) {
 		return len(running) > 0 && running[0].WorkflowId == wid
 	}, 15*time.Second, 500*time.Millisecond, "CHASM scheduler should show running workflow")
 
-	_, err = env.FrontendClient().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
-		Namespace: env.Namespace().String(),
+	_, err = s.FrontendClient().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
+		Namespace: s.Namespace().String(),
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: wid,
 			RunId:      startResp.RunId,
 		},
 		SignalName: resumeSignal,
 	})
-	env.NoError(err)
+	s.NoError(err)
 
-	env.Eventually(func() bool {
-		descResp, err := env.GetTestCluster().SchedulerClient().DescribeSchedule(
+	s.Eventually(func() bool {
+		descResp, err := s.GetTestCluster().SchedulerClient().DescribeSchedule(
 			ctx,
 			&schedulerpb.DescribeScheduleRequest{
 				NamespaceId:     nsID,
-				FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: env.Namespace().String(), ScheduleId: sid},
+				FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: s.Namespace().String(), ScheduleId: sid},
 			},
 		)
 		if err != nil {
@@ -3109,7 +3108,7 @@ func testMigrationCallbackAttach(t *testing.T, newContext contextFactory) {
 // testCHASMCanListV1Schedules tests that a schedule created in the V1 stack
 // will also be visible in the V2 stack.
 func testCHASMCanListV1Schedules(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "schedule-created-on-v1"
 	schedule := &schedulepb.Schedule{
@@ -3123,13 +3122,13 @@ func testCHASMCanListV1Schedules(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   "wf-",
 					WorkflowType: &commonpb.WorkflowType{Name: "action"},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -3137,12 +3136,12 @@ func testCHASMCanListV1Schedules(t *testing.T, newContext contextFactory) {
 	}
 
 	// Create on V1 stack.
-	_, err := env.FrontendClient().CreateSchedule(newContext(env.Context()), req)
-	env.NoError(err)
+	_, err := s.FrontendClient().CreateSchedule(newContext(s.Context()), req)
+	s.NoError(err)
 
 	// Pause so that `FutureActionTimes` doesn't change between calls.
-	_, err = env.FrontendClient().PatchSchedule(newContext(env.Context()), &workflowservice.PatchScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	_, err = s.FrontendClient().PatchSchedule(newContext(s.Context()), &workflowservice.PatchScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Patch: &schedulepb.SchedulePatch{
 			Pause: "halt",
@@ -3150,37 +3149,37 @@ func testCHASMCanListV1Schedules(t *testing.T, newContext contextFactory) {
 		Identity:  "test",
 		RequestId: uuid.NewString(),
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	// Sanity test, list with V1 handler.
-	v1Entry := getScheduleEntryFromVisibility(t, env, sid, newContext, func(sle *schedulepb.ScheduleListEntry) bool {
+	v1Entry := getScheduleEntryFromVisibility(s, sid, newContext, func(sle *schedulepb.ScheduleListEntry) bool {
 		return sle.GetInfo().Paused
 	})
-	env.NotNil(v1Entry.GetInfo())
+	s.NotNil(v1Entry.GetInfo())
 
 	// Count with V1 handler.
-	v1CountResp, err := env.FrontendClient().CountSchedules(newContext(env.Context()), &workflowservice.CountSchedulesRequest{
-		Namespace: env.Namespace().String(),
+	v1CountResp, err := s.FrontendClient().CountSchedules(newContext(s.Context()), &workflowservice.CountSchedulesRequest{
+		Namespace: s.Namespace().String(),
 	})
-	env.NoError(err)
-	env.GreaterOrEqual(v1CountResp.Count, int64(1), "Expected at least 1 schedule with V1 handler")
+	s.NoError(err)
+	s.GreaterOrEqual(v1CountResp.Count, int64(1), "Expected at least 1 schedule with V1 handler")
 
 	// Flip on CHASM experiment and make sure we can still list.
-	chasmEntry := getScheduleEntryFromVisibility(t, env, sid, chasmContextFactory, nil)
-	env.NotNil(chasmEntry.GetInfo())
-	env.ProtoEqual(chasmEntry.GetInfo(), v1Entry.GetInfo())
+	chasmEntry := getScheduleEntryFromVisibility(s, sid, chasmContextFactory, nil)
+	s.NotNil(chasmEntry.GetInfo())
+	s.ProtoEqual(chasmEntry.GetInfo(), v1Entry.GetInfo())
 
 	// Count with CHASM handler and verify it matches V1 count.
-	chasmCountResp, err := env.FrontendClient().CountSchedules(chasmContextFactory(env.Context()), &workflowservice.CountSchedulesRequest{
-		Namespace: env.Namespace().String(),
+	chasmCountResp, err := s.FrontendClient().CountSchedules(chasmContextFactory(s.Context()), &workflowservice.CountSchedulesRequest{
+		Namespace: s.Namespace().String(),
 	})
-	env.NoError(err)
-	env.Equal(v1CountResp.Count, chasmCountResp.Count, "CHASM and V1 counts should match")
+	s.NoError(err)
+	s.Equal(v1CountResp.Count, chasmCountResp.Count, "CHASM and V1 counts should match")
 }
 
 // testRefresh applies to V1 scheduler only; V2 does not support/need manual refresh.
 func testRefresh(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-refresh"
 	wid := "sched-test-refresh-wf"
@@ -3205,14 +3204,14 @@ func testRefresh(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:               wid,
 					WorkflowType:             &commonpb.WorkflowType{Name: wt},
-					TaskQueue:                &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:                &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					WorkflowExecutionTimeout: durationpb.New(3 * time.Second),
 				},
 			},
 		},
 	}
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -3225,26 +3224,26 @@ func testRefresh(t *testing.T, newContext contextFactory) {
 			atomic.AddInt32(&runs, 1)
 			return 0
 		})
-		env.NoError(workflow.Sleep(ctx, 10*time.Second)) // longer than execution timeout
+		s.NoError(workflow.Sleep(ctx, 10*time.Second)) // longer than execution timeout
 		return nil
 	}
-	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+	s.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 
-	_, err := env.FrontendClient().CreateSchedule(newContext(env.Context()), req)
-	env.NoError(err)
+	_, err := s.FrontendClient().CreateSchedule(newContext(s.Context()), req)
+	s.NoError(err)
 
-	env.Eventually(func() bool { return atomic.LoadInt32(&runs) == 1 }, 20*time.Second, 200*time.Millisecond)
+	s.Eventually(func() bool { return atomic.LoadInt32(&runs) == 1 }, 20*time.Second, 200*time.Millisecond)
 
 	// workflow has started but is now sleeping. it will timeout in 2 seconds.
 
-	describeResp, err := env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	describeResp, err := s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 	})
-	env.NoError(err)
-	env.Len(describeResp.Info.RunningWorkflows, 1)
+	s.NoError(err)
+	s.Len(describeResp.Info.RunningWorkflows, 1)
 
-	events1 := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: scheduler.WorkflowIDPrefix + sid})
+	events1 := s.GetHistory(s.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: scheduler.WorkflowIDPrefix + sid})
 	expectedHistory := `
   1 WorkflowExecutionStarted
   2 WorkflowTaskScheduled
@@ -3263,26 +3262,26 @@ func testRefresh(t *testing.T, newContext contextFactory) {
  15 WorkflowPropertiesModified
  16 TimerStarted`
 
-	env.EqualHistoryEvents(expectedHistory, events1)
+	s.EqualHistoryEvents(expectedHistory, events1)
 
 	time.Sleep(4 * time.Second) //nolint:forbidigo
 	// now it has timed out, but the scheduler hasn't noticed yet. we can prove it by checking
 	// its history.
 
-	events2 := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: scheduler.WorkflowIDPrefix + sid})
-	env.EqualHistoryEvents(expectedHistory, events2)
+	events2 := s.GetHistory(s.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: scheduler.WorkflowIDPrefix + sid})
+	s.EqualHistoryEvents(expectedHistory, events2)
 
 	// when we describe we'll force a refresh and see it timed out
-	describeResp, err = env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	describeResp, err = s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 	})
-	env.NoError(err)
-	env.Empty(describeResp.Info.RunningWorkflows)
+	s.NoError(err)
+	s.Empty(describeResp.Info.RunningWorkflows)
 
 	// check scheduler has gotten the refresh and done some stuff. signal is sent without waiting so we need to wait.
-	env.Eventually(func() bool {
-		events3 := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: scheduler.WorkflowIDPrefix + sid})
+	s.Eventually(func() bool {
+		events3 := s.GetHistory(s.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: scheduler.WorkflowIDPrefix + sid})
 		return len(events3) > len(events2)
 	}, 5*time.Second, 100*time.Millisecond)
 }
@@ -3290,7 +3289,7 @@ func testRefresh(t *testing.T, newContext contextFactory) {
 // testListBeforeRun only applies to V1, as V2 scheduler does not involve the
 // per-NS worker or workflow.
 func testListBeforeRun(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, append(scheduleCommonOpts(t),
+	s := newScheduleEnv(t, append(scheduleCommonOpts(t),
 		testcore.WithDynamicConfig(dynamicconfig.WorkerPerNamespaceWorkerCount, 0),
 	)...)
 
@@ -3309,13 +3308,13 @@ func testListBeforeRun(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -3324,21 +3323,21 @@ func testListBeforeRun(t *testing.T, newContext contextFactory) {
 
 	startTime := time.Now()
 
-	_, err := env.FrontendClient().CreateSchedule(newContext(env.Context()), req)
-	env.NoError(err)
+	_, err := s.FrontendClient().CreateSchedule(newContext(s.Context()), req)
+	s.NoError(err)
 
-	entry := getScheduleEntryFromVisibility(t, env, sid, newContext, nil)
-	env.NotNil(entry.Info)
-	env.ProtoEqual(schedule.Spec, entry.Info.Spec)
-	env.Equal(wt, entry.Info.WorkflowType.Name)
-	env.False(entry.Info.Paused)
-	env.Greater(len(entry.Info.FutureActionTimes), 1)
-	env.True(entry.Info.FutureActionTimes[0].AsTime().After(startTime))
+	entry := getScheduleEntryFromVisibility(s, sid, newContext, nil)
+	s.NotNil(entry.Info)
+	s.ProtoEqual(schedule.Spec, entry.Info.Spec)
+	s.Equal(wt, entry.Info.WorkflowType.Name)
+	s.False(entry.Info.Paused)
+	s.Greater(len(entry.Info.FutureActionTimes), 1)
+	s.True(entry.Info.FutureActionTimes[0].AsTime().After(startTime))
 }
 
 // testRateLimit applies only to V1, as V2 scheduler does not impose its own rate limiting.
 func testRateLimit(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, append(scheduleCommonOpts(t),
+	s := newScheduleEnv(t, append(scheduleCommonOpts(t),
 		testcore.WithDynamicConfig(dynamicconfig.SchedulerNamespaceStartWorkflowRPS, 1.0),
 	)...)
 
@@ -3354,7 +3353,7 @@ func testRateLimit(t *testing.T, newContext contextFactory) {
 		})
 		return nil
 	}
-	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+	s.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 
 	// create 10 copies of the schedule
 	for i := range 10 {
@@ -3369,31 +3368,31 @@ func testRateLimit(t *testing.T, newContext contextFactory) {
 					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 						WorkflowId:   fmt.Sprintf(wid, i),
 						WorkflowType: &commonpb.WorkflowType{Name: wt},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					},
 				},
 			},
 		}
-		_, err := env.FrontendClient().CreateSchedule(newContext(env.Context()), &workflowservice.CreateScheduleRequest{
-			Namespace:  env.Namespace().String(),
+		_, err := s.FrontendClient().CreateSchedule(newContext(s.Context()), &workflowservice.CreateScheduleRequest{
+			Namespace:  s.Namespace().String(),
 			ScheduleId: fmt.Sprintf(sid, i),
 			Schedule:   schedule,
 			Identity:   "test",
 			RequestId:  uuid.NewString(),
 		})
-		env.NoError(err)
+		s.NoError(err)
 	}
 
 	time.Sleep(5 * time.Second) //nolint:forbidigo
 
 	// With no rate limit, we'd see 10/second == 50 workflows run. With a limit of 1/sec, we
 	// expect to see around 5.
-	env.Less(atomic.LoadInt32(&runs), int32(10))
+	s.Less(atomic.LoadInt32(&runs), int32(10))
 }
 
 // testNextTimeCache only applies to V1.
 func testNextTimeCache(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-next-time-cache"
 	wid := "sched-test-next-time-cache-wf"
@@ -3410,13 +3409,13 @@ func testNextTimeCache(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 	req := &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -3431,18 +3430,18 @@ func testNextTimeCache(t *testing.T, newContext contextFactory) {
 		})
 		return nil
 	}
-	env.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+	s.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 
-	_, err := env.FrontendClient().CreateSchedule(newContext(env.Context()), req)
-	env.NoError(err)
+	_, err := s.FrontendClient().CreateSchedule(newContext(s.Context()), req)
+	s.NoError(err)
 
 	// wait for at least 13 runs
 	const count = 13
-	env.Eventually(func() bool { return runs.Load() >= count }, (count+10)*time.Second, 500*time.Millisecond)
+	s.Eventually(func() bool { return runs.Load() >= count }, (count+10)*time.Second, 500*time.Millisecond)
 
 	// there should be only four side effects for 13 runs, and only two mentioning "Next"
 	// (cache refills)
-	events := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: scheduler.WorkflowIDPrefix + sid})
+	events := s.GetHistory(s.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: scheduler.WorkflowIDPrefix + sid})
 	var sideEffects, nextTimeSideEffects int
 	for _, e := range events {
 		if marker := e.GetMarkerRecordedEventAttributes(); marker.GetMarkerName() == "SideEffect" {
@@ -3467,17 +3466,17 @@ func testNextTimeCache(t *testing.T, newContext contextFactory) {
 		expectedRefills   = (count + expectedCacheSize - 1) / expectedCacheSize
 		uuidCacheRefills  = (count + 9) / 10
 	)
-	env.Equal(expectedRefills+uuidCacheRefills, sideEffects)
-	env.Equal(expectedRefills, nextTimeSideEffects)
+	s.Equal(expectedRefills+uuidCacheRefills, sideEffects)
+	s.Equal(expectedRefills, nextTimeSideEffects)
 }
 
 // getScheduleEntryFromVisibility polls visibility using ListSchedules until it finds a schedule
 // with the given id and for which the optional predicate function returns true.
-func getScheduleEntryFromVisibility(t *testing.T, env testcore.Env, sid string, newContext contextFactory, predicate func(*schedulepb.ScheduleListEntry) bool) *schedulepb.ScheduleListEntry {
-	t.Helper()
+func getScheduleEntryFromVisibility(env testcore.Env, sid string, newContext contextFactory, predicate func(*schedulepb.ScheduleListEntry) bool) *schedulepb.ScheduleListEntry {
+	env.T().Helper()
 	var slEntry *schedulepb.ScheduleListEntry
-	require.Eventually(t, func() bool { // wait for visibility
-		listResp, err := env.FrontendClient().ListSchedules(newContext(testcontext.For(t)), &workflowservice.ListSchedulesRequest{
+	require.Eventually(env.T(), func() bool { // wait for visibility
+		listResp, err := env.FrontendClient().ListSchedules(newContext(env.Context()), &workflowservice.ListSchedulesRequest{
 			Namespace:       env.Namespace().String(),
 			MaximumPageSize: 5,
 		})
@@ -3550,13 +3549,13 @@ func assertRecentActionsNoDuplicateRunIDs(t *testing.T, actions []*schedulepb.Sc
 	}
 }
 func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-update-memo"
 	wid := "sched-test-update-memo-wf"
 	wt := "sched-test-update-memo-wt"
 
-	env.SdkWorker().RegisterWorkflowWithOptions(
+	s.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error { return nil },
 		workflow.RegisterOptions{Name: wt},
 	)
@@ -3572,7 +3571,7 @@ func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
@@ -3582,9 +3581,9 @@ func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
 	memo2 := payload.EncodeString("val2")
 
 	// Create schedule with initial memo.
-	ctx := newContext(env.Context())
-	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -3599,8 +3598,8 @@ func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
 	require.NoError(t, err)
 
 	// Verify initial memo.
-	describeResp, err := env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	describeResp, err := s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 	})
 	require.NoError(t, err)
@@ -3609,8 +3608,8 @@ func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
 
 	// Update: replace memo with only key3 (key1 and key2 should be gone).
 	memo3 := payload.EncodeString("new")
-	_, err = env.FrontendClient().UpdateSchedule(newContext(env.Context()), &workflowservice.UpdateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	_, err = s.FrontendClient().UpdateSchedule(newContext(s.Context()), &workflowservice.UpdateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -3624,8 +3623,8 @@ func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
 	require.NoError(t, err)
 
 	// Verify replaced memo.
-	describeResp, err = env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	describeResp, err = s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 	})
 	require.NoError(t, err)
@@ -3634,8 +3633,8 @@ func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
 	require.Equal(t, memo3.Data, describeResp.Memo.Fields["key3"].Data, "key3 should be set")
 
 	// Update with nil memo (no change).
-	_, err = env.FrontendClient().UpdateSchedule(newContext(env.Context()), &workflowservice.UpdateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	_, err = s.FrontendClient().UpdateSchedule(newContext(s.Context()), &workflowservice.UpdateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -3644,16 +3643,16 @@ func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
 	require.NoError(t, err)
 
 	// Verify memo unchanged.
-	describeResp, err = env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	describeResp, err = s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 	})
 	require.NoError(t, err)
 	require.Equal(t, memo3.Data, describeResp.Memo.Fields["key3"].Data, "key3 should be unchanged")
 
 	// Update with empty memo (clear all).
-	_, err = env.FrontendClient().UpdateSchedule(newContext(env.Context()), &workflowservice.UpdateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	_, err = s.FrontendClient().UpdateSchedule(newContext(s.Context()), &workflowservice.UpdateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -3665,8 +3664,8 @@ func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
 	require.NoError(t, err)
 
 	// Verify memo cleared.
-	describeResp, err = env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	describeResp, err = s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 	})
 	require.NoError(t, err)
@@ -3674,13 +3673,13 @@ func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
 }
 
 func testUpdateScheduleMemoRejected(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-update-memo-rejected"
 	wid := "sched-test-update-memo-rejected-wf"
 	wt := "sched-test-update-memo-rejected-wt"
 
-	env.SdkWorker().RegisterWorkflowWithOptions(
+	s.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error { return nil },
 		workflow.RegisterOptions{Name: wt},
 	)
@@ -3696,16 +3695,16 @@ func testUpdateScheduleMemoRejected(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 
 	// Create V1 schedule.
-	ctx := newContext(env.Context())
-	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -3714,8 +3713,8 @@ func testUpdateScheduleMemoRejected(t *testing.T, newContext contextFactory) {
 	require.NoError(t, err)
 
 	// Update with memo should be rejected.
-	_, err = env.FrontendClient().UpdateSchedule(newContext(env.Context()), &workflowservice.UpdateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	_, err = s.FrontendClient().UpdateSchedule(newContext(s.Context()), &workflowservice.UpdateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -3738,13 +3737,13 @@ func testUpdateScheduleMemoOnly(t *testing.T, newContext contextFactory) {
 	// the schedule when the field is nil, similar to how memo and search_attributes are handled.
 	t.Skip("memo-only updates not yet supported: omitting the schedule field unsets the schedule")
 
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-update-memo-only"
 	wid := "sched-test-update-memo-only-wf"
 	wt := "sched-test-update-memo-only-wt"
 
-	env.SdkWorker().RegisterWorkflowWithOptions(
+	s.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error { return nil },
 		workflow.RegisterOptions{Name: wt},
 	)
@@ -3760,7 +3759,7 @@ func testUpdateScheduleMemoOnly(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
@@ -3768,9 +3767,9 @@ func testUpdateScheduleMemoOnly(t *testing.T, newContext contextFactory) {
 
 	// Create schedule with initial memo.
 	memo1 := payload.EncodeString("val1")
-	ctx := newContext(env.Context())
-	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -3783,8 +3782,8 @@ func testUpdateScheduleMemoOnly(t *testing.T, newContext contextFactory) {
 
 	// Update only memo, without setting the schedule field.
 	memo2 := payload.EncodeString("val2")
-	_, err = env.FrontendClient().UpdateSchedule(newContext(env.Context()), &workflowservice.UpdateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	_, err = s.FrontendClient().UpdateSchedule(newContext(s.Context()), &workflowservice.UpdateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
@@ -3795,8 +3794,8 @@ func testUpdateScheduleMemoOnly(t *testing.T, newContext contextFactory) {
 	require.NoError(t, err)
 
 	// Verify memo was updated and schedule is still intact.
-	describeResp, err := env.FrontendClient().DescribeSchedule(newContext(env.Context()), &workflowservice.DescribeScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	describeResp, err := s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 	})
 	require.NoError(t, err)
@@ -3807,14 +3806,14 @@ func testUpdateScheduleMemoOnly(t *testing.T, newContext contextFactory) {
 }
 
 func testCHASMUnpauseResumesProcessing(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-unpause-resumes"
 	wid := "sched-test-unpause-resumes-wf"
 	wt := "sched-test-unpause-resumes-wt"
 
 	var runs int32
-	env.SdkWorker().RegisterWorkflowWithOptions(
+	s.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error {
 			workflow.SideEffect(ctx, func(ctx workflow.Context) any {
 				atomic.AddInt32(&runs, 1)
@@ -3825,8 +3824,8 @@ func testCHASMUnpauseResumesProcessing(t *testing.T, newContext contextFactory) 
 		workflow.RegisterOptions{Name: wt},
 	)
 
-	_, err := env.FrontendClient().CreateSchedule(newContext(env.Context()), &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	_, err := s.FrontendClient().CreateSchedule(newContext(s.Context()), &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule: &schedulepb.Schedule{
 			Spec: &schedulepb.ScheduleSpec{
@@ -3837,7 +3836,7 @@ func testCHASMUnpauseResumesProcessing(t *testing.T, newContext contextFactory) 
 					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 						WorkflowId:   wid,
 						WorkflowType: &commonpb.WorkflowType{Name: wt},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					},
 				},
 			},
@@ -3845,27 +3844,27 @@ func testCHASMUnpauseResumesProcessing(t *testing.T, newContext contextFactory) 
 		Identity:  "test",
 		RequestId: uuid.NewString(),
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	// Wait for the schedule to fire at least once, confirming it's running.
-	env.Eventually(func() bool { return atomic.LoadInt32(&runs) >= 1 }, 15*time.Second, 500*time.Millisecond)
+	s.Eventually(func() bool { return atomic.LoadInt32(&runs) >= 1 }, 15*time.Second, 500*time.Millisecond)
 
 	// Pause.
-	_, err = env.FrontendClient().PatchSchedule(newContext(env.Context()), &workflowservice.PatchScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	_, err = s.FrontendClient().PatchSchedule(newContext(s.Context()), &workflowservice.PatchScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Patch:      &schedulepb.SchedulePatch{Pause: "pausing for test"},
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	// Wait for the already-queued generator task to run after pause. That task
 	// observes paused state, performs no-op scheduling, and then the schedule
 	// becomes quiescent (no new runs over a stability window).
 	stableSamples := 0
 	lastRuns := atomic.LoadInt32(&runs)
-	env.Eventually(func() bool {
+	s.Eventually(func() bool {
 		currentRuns := atomic.LoadInt32(&runs)
 		if currentRuns == lastRuns {
 			stableSamples++
@@ -3878,17 +3877,17 @@ func testCHASMUnpauseResumesProcessing(t *testing.T, newContext contextFactory) 
 	runsBeforeUnpause := atomic.LoadInt32(&runs)
 
 	// Unpause.
-	_, err = env.FrontendClient().PatchSchedule(newContext(env.Context()), &workflowservice.PatchScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	_, err = s.FrontendClient().PatchSchedule(newContext(s.Context()), &workflowservice.PatchScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Patch:      &schedulepb.SchedulePatch{Unpause: "resuming"},
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	// The generator should be kicked immediately on unpause and new runs should follow.
-	env.Eventually(
+	s.Eventually(
 		func() bool { return atomic.LoadInt32(&runs) > runsBeforeUnpause },
 		15*time.Second,
 		500*time.Millisecond,
@@ -3991,32 +3990,32 @@ func testPausedScheduleNeverIdles(t *testing.T, newContext contextFactory) {
 // manual-only pattern - can be created without timing out and remains
 // describable.
 func testPausedEmptySpecStaysOpen(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-paused-empty-spec")
 	wid := testcore.RandomizeStr("sched-paused-empty-spec-wf")
 	wt := testcore.RandomizeStr("sched-paused-empty-spec-wt")
 
 	var runs atomic.Int32
-	registerCountingWorkflow(env, wt, &runs)
+	registerCountingWorkflow(s, wt, &runs)
 
 	// Empty spec + paused: a manual-only schedule. Create must succeed without
 	// timing out (the original regression was "context deadline exceeded").
-	ctx := newContext(env.Context())
+	ctx := newContext(s.Context())
 	createCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	createSchedule(createCtx, t, env, sid, &schedulepb.Schedule{
+	createSchedule(createCtx, t, s, sid, &schedulepb.Schedule{
 		Spec:   &schedulepb.ScheduleSpec{},
 		State:  &schedulepb.ScheduleState{Paused: true},
-		Action: startWorkflowAction(env, wid, wt),
+		Action: startWorkflowAction(s, wid, wt),
 	})
 
 	require.Never(t, func() bool { return runs.Load() > 0 },
 		neverWindow, pollInterval,
 		"empty paused spec must not fire any actions automatically")
 
-	desc, err := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	desc, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 	})
 	require.NoError(t, err)
@@ -4024,7 +4023,7 @@ func testPausedEmptySpecStaysOpen(t *testing.T, newContext contextFactory) {
 
 	// Unpause + TriggerImmediately to sanity-check the schedule is functional,
 	// not just open.
-	patchSchedule(ctx, t, env, sid, &schedulepb.SchedulePatch{
+	patchSchedule(ctx, t, s, sid, &schedulepb.SchedulePatch{
 		Unpause:            "empty-spec-trigger",
 		TriggerImmediately: &schedulepb.TriggerImmediatelyRequest{},
 	})
@@ -4040,46 +4039,46 @@ func testPausedEmptySpecStaysOpen(t *testing.T, newContext contextFactory) {
 // patch on a running schedule fires an extra action and leaves the schedule
 // active.
 func testTriggerImmediatelyOnActiveSchedule(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-trigger-on-active")
 	wid := testcore.RandomizeStr("sched-trigger-on-active-wf")
 	wt := testcore.RandomizeStr("sched-trigger-on-active-wt")
 
 	var runs atomic.Int32
-	registerCountingWorkflow(env, wt, &runs)
+	registerCountingWorkflow(s, wt, &runs)
 
-	ctx := newContext(env.Context())
-	createSchedule(ctx, t, env, sid, &schedulepb.Schedule{
+	ctx := newContext(s.Context())
+	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
 		// Fire a year into the future, keeping the schedule active, but without firing
 		// actions.
 		Spec: &schedulepb.ScheduleSpec{
 			Calendar: []*schedulepb.CalendarSpec{calendarSpec(time.Now().AddDate(1, 0, 0).UTC())},
 		},
-		Action: startWorkflowAction(env, wid, wt),
+		Action: startWorkflowAction(s, wid, wt),
 		Policies: &schedulepb.SchedulePolicies{
 			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
 		},
 	})
 
 	await.RequireTruef(t, func() bool {
-		desc, descErr := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  env.Namespace().String(),
+		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
 			ScheduleId: sid,
 		})
 		return descErr == nil && len(desc.Info.FutureActionTimes) > 0
 	}, awaitTimeout, pollInterval, "schedule should reach active state with future actions planned")
 	require.Zero(t, runs.Load(), "no automated action should fire before the trigger")
 
-	patchSchedule(ctx, t, env, sid, triggerPatch(enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL))
+	patchSchedule(ctx, t, s, sid, triggerPatch(enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL))
 	await.RequireTruef(t,
 		func() bool { return runs.Load() == 1 },
 		awaitTimeout, pollInterval,
 		"TriggerImmediately should fire exactly one action on the active schedule",
 	)
 
-	desc, err := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	desc, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 	})
 	require.NoError(t, err)
@@ -4091,20 +4090,20 @@ func testTriggerImmediatelyOnActiveSchedule(t *testing.T, newContext contextFact
 // an action even when the schedule is paused. Manual starts bypass the paused
 // gate via useScheduledAction's Manual carve-out in processBuffer.
 func testTriggerImmediatelyOnPausedSchedule(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-trigger-on-paused")
 	wid := testcore.RandomizeStr("sched-trigger-on-paused-wf")
 	wt := testcore.RandomizeStr("sched-trigger-on-paused-wt")
 
 	var runs atomic.Int32
-	registerCountingWorkflow(env, wt, &runs)
+	registerCountingWorkflow(s, wt, &runs)
 
-	ctx := newContext(env.Context())
-	createSchedule(ctx, t, env, sid, &schedulepb.Schedule{
+	ctx := newContext(s.Context())
+	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
 		Spec:   intervalSpec(fastInterval),
 		State:  &schedulepb.ScheduleState{Paused: true},
-		Action: startWorkflowAction(env, wid, wt),
+		Action: startWorkflowAction(s, wid, wt),
 	})
 
 	// Paused suppresses firing even though the 1s interval would otherwise tick.
@@ -4112,14 +4111,14 @@ func testTriggerImmediatelyOnPausedSchedule(t *testing.T, newContext contextFact
 		neverWindow, pollInterval,
 		"paused schedule must not fire automated actions before the trigger")
 
-	patchSchedule(ctx, t, env, sid, triggerPatch(enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL))
+	patchSchedule(ctx, t, s, sid, triggerPatch(enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL))
 
 	await.RequireTruef(t, func() bool { return runs.Load() == 1 },
 		awaitTimeout, pollInterval,
 		"TriggerImmediately must fire exactly one action despite the schedule being paused")
 
-	desc, err := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	desc, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 	})
 	require.NoError(t, err)
@@ -4130,34 +4129,34 @@ func testTriggerImmediatelyOnPausedSchedule(t *testing.T, newContext contextFact
 // testTriggerImmediatelyAfterActionsExhausted verifies that TriggerImmediately
 // fires an action even on a schedule that has no LimitedActions slots left.
 func testTriggerImmediatelyAfterActionsExhausted(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-trigger-after-exhausted")
 	wid := testcore.RandomizeStr("sched-trigger-after-exhausted-wf")
 	wt := testcore.RandomizeStr("sched-trigger-after-exhausted-wt")
 
 	var runs atomic.Int32
-	registerCountingWorkflow(env, wt, &runs)
+	registerCountingWorkflow(s, wt, &runs)
 
-	ctx := newContext(env.Context())
-	createSchedule(ctx, t, env, sid, &schedulepb.Schedule{
+	ctx := newContext(s.Context())
+	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
 		Spec: intervalSpec(fastInterval),
 		// Start exhausted so no automated action fires.
 		State:  &schedulepb.ScheduleState{LimitedActions: true, RemainingActions: 0},
-		Action: startWorkflowAction(env, wid, wt),
+		Action: startWorkflowAction(s, wid, wt),
 	})
 
 	require.Never(t, func() bool { return runs.Load() > 0 },
 		neverWindow, pollInterval,
 		"exhausted schedule must not auto-fire before the trigger")
 
-	patchSchedule(ctx, t, env, sid, triggerPatch(enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL))
+	patchSchedule(ctx, t, s, sid, triggerPatch(enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL))
 	await.RequireTruef(t, func() bool { return runs.Load() == 1 },
 		awaitTimeout, pollInterval,
 		"TriggerImmediately must fire exactly once despite RemainingActions=0")
 
-	desc, err := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	desc, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 	})
 	require.NoError(t, err)
@@ -4250,7 +4249,7 @@ func testBackfillWithBufferOneOverlap(t *testing.T, newContext contextFactory) {
 	//   go test ./tests/ -run 'TestScheduleCHASM/Backfill/BufferOneOverlap' -v
 	t.Skip("BUFFER_ONE backfill deferred re-enable is broken on both V1 and CHASM; see test doc")
 
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-backfill-buffer-one")
 	wid := testcore.RandomizeStr("sched-backfill-buffer-one-wf")
@@ -4258,22 +4257,22 @@ func testBackfillWithBufferOneOverlap(t *testing.T, newContext contextFactory) {
 
 	// Gate runs so the first-running / one-deferred / rest-dropped sequence is deterministic.
 	var runs atomic.Int32
-	registerGatedWorkflow(env, wt, &runs)
+	registerGatedWorkflow(s, wt, &runs)
 
-	ctx := newContext(env.Context())
-	createSchedule(ctx, t, env, sid, &schedulepb.Schedule{
+	ctx := newContext(s.Context())
+	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
 		Spec:   intervalSpec(fastInterval),
 		State:  &schedulepb.ScheduleState{Paused: true},
-		Action: startWorkflowAction(env, wid, wt),
+		Action: startWorkflowAction(s, wid, wt),
 	})
 
 	now := time.Now().UTC()
-	patchSchedule(ctx, t, env, sid, backfillPatch(now.Add(-5*time.Second), now, enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE))
+	patchSchedule(ctx, t, s, sid, backfillPatch(now.Add(-5*time.Second), now, enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE))
 
 	// First backfill start runs with exactly one buffered behind it (BUFFER_ONE drops the rest).
 	await.RequireTruef(t, func() bool {
-		desc, descErr := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  env.Namespace().String(),
+		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
 			ScheduleId: sid,
 		})
 		return descErr == nil && desc.GetInfo().GetBufferSize() == 1 && len(desc.GetInfo().GetRunningWorkflows()) == 1
@@ -4281,7 +4280,7 @@ func testBackfillWithBufferOneOverlap(t *testing.T, newContext contextFactory) {
 	require.Equal(t, int32(1), runs.Load(), "only the first backfill start should have fired so far")
 
 	// Releasing the running start must re-enable the deferred one (Attempt=-1 -> 0) so it fires.
-	require.Equal(t, 1, completeRunningWorkflows(ctx, t, env, sid))
+	require.Equal(t, 1, completeRunningWorkflows(ctx, t, s, sid))
 	await.RequireTruef(t, func() bool { return runs.Load() == 2 },
 		awaitTimeout, pollInterval,
 		"deferred backfill start must fire after the running one completes (Attempt=-1 -> 0 re-enable)")
@@ -4294,21 +4293,21 @@ func testBackfillWithBufferOneOverlap(t *testing.T, newContext contextFactory) {
 // is narrower than the spec interval - no spec tick lands inside it, so no
 // actions fire and the backfiller still drains cleanly.
 func testBackfillRangeSmallerThanInterval(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-backfill-narrow")
 	wid := testcore.RandomizeStr("sched-backfill-narrow-wf")
 	wt := testcore.RandomizeStr("sched-backfill-narrow-wt")
 
 	var runs atomic.Int32
-	registerCountingWorkflow(env, wt, &runs)
+	registerCountingWorkflow(s, wt, &runs)
 
-	ctx := newContext(env.Context())
-	createSchedule(ctx, t, env, sid, &schedulepb.Schedule{
+	ctx := newContext(s.Context())
+	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
 		// noOpInterval (1h) ticks on the hour; the backfill window below is mid-hour.
 		Spec:   intervalSpec(noOpInterval),
 		State:  &schedulepb.ScheduleState{Paused: true},
-		Action: startWorkflowAction(env, wid, wt),
+		Action: startWorkflowAction(s, wid, wt),
 	})
 
 	// A 10s window (above the 1s resolution, below the 1h interval) anchored mid-hour
@@ -4316,7 +4315,7 @@ func testBackfillRangeSmallerThanInterval(t *testing.T, newContext contextFactor
 	prevHour := time.Now().UTC().Truncate(time.Hour).Add(-time.Hour)
 	windowStart := prevHour.Add(20 * time.Minute)
 	windowEnd := windowStart.Add(10 * time.Second)
-	patchSchedule(ctx, t, env, sid, backfillPatch(windowStart, windowEnd, enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL))
+	patchSchedule(ctx, t, s, sid, backfillPatch(windowStart, windowEnd, enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL))
 
 	// No spec tick falls inside a sub-interval window, so no action fires.
 	require.Never(t, func() bool { return runs.Load() > 0 },
@@ -4325,8 +4324,8 @@ func testBackfillRangeSmallerThanInterval(t *testing.T, newContext contextFactor
 
 	// And the schedule must still be describable - the backfiller drained without
 	// firing anything and got cleaned up.
-	_, err := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	_, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 	})
 	require.NoError(t, err, "schedule must remain describable after empty backfill")
@@ -4335,24 +4334,24 @@ func testBackfillRangeSmallerThanInterval(t *testing.T, newContext contextFactor
 // testBackfillWithSkipOverlap verifies that SKIP overlap correctly collapses a
 // multi-tick backfill range to a single workflow execution.
 func testBackfillWithSkipOverlap(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-backfill-skip")
 	wid := testcore.RandomizeStr("sched-backfill-skip-wf")
 	wt := testcore.RandomizeStr("sched-backfill-skip-wt")
 
 	var runs atomic.Int32
-	registerCountingWorkflow(env, wt, &runs)
+	registerCountingWorkflow(s, wt, &runs)
 
-	ctx := newContext(env.Context())
-	createSchedule(ctx, t, env, sid, &schedulepb.Schedule{
+	ctx := newContext(s.Context())
+	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
 		Spec:   intervalSpec(fastInterval),
 		State:  &schedulepb.ScheduleState{Paused: true},
-		Action: startWorkflowAction(env, wid, wt),
+		Action: startWorkflowAction(s, wid, wt),
 	})
 
 	now := time.Now().UTC()
-	patchSchedule(ctx, t, env, sid, backfillPatch(now.Add(-5*time.Second), now, enumspb.SCHEDULE_OVERLAP_POLICY_SKIP))
+	patchSchedule(ctx, t, s, sid, backfillPatch(now.Add(-5*time.Second), now, enumspb.SCHEDULE_OVERLAP_POLICY_SKIP))
 
 	// SKIP collapses the 5-tick backfill to exactly one fire, and it stays there.
 	await.RequireTruef(t, func() bool { return runs.Load() == 1 },
@@ -4364,28 +4363,28 @@ func testBackfillWithSkipOverlap(t *testing.T, newContext contextFactory) {
 }
 
 func testUpdateScheduleRequestIDTooLong(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := "sched-test-update-reqid-too-long"
 	wid := "sched-test-update-reqid-too-long-wf"
 	wt := "sched-test-update-reqid-too-long-wt"
 
-	env.SdkWorker().RegisterWorkflowWithOptions(
+	s.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error { return nil },
 		workflow.RegisterOptions{Name: wt},
 	)
 
 	schedule := &schedulepb.Schedule{
 		Spec:   intervalSpec(noOpInterval),
-		Action: startWorkflowAction(env, wid, wt),
+		Action: startWorkflowAction(s, wid, wt),
 	}
 
-	ctx := newContext(env.Context())
-	createSchedule(ctx, t, env, sid, schedule)
+	ctx := newContext(s.Context())
+	createSchedule(ctx, t, s, sid, schedule)
 
 	// Update with an oversized request ID.
-	_, err := env.FrontendClient().UpdateSchedule(ctx, &workflowservice.UpdateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	_, err := s.FrontendClient().UpdateSchedule(ctx, &workflowservice.UpdateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -4396,7 +4395,7 @@ func testUpdateScheduleRequestIDTooLong(t *testing.T, newContext contextFactory)
 }
 
 func testUpdateScheduleBlobSizeLimit(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t,
+	s := newScheduleEnv(t,
 		append(scheduleCommonOpts(t),
 			testcore.WithDynamicConfig(dynamicconfig.BlobSizeLimitError, 1000),
 			testcore.WithDynamicConfig(dynamicconfig.BlobSizeLimitWarn, 500),
@@ -4407,7 +4406,7 @@ func testUpdateScheduleBlobSizeLimit(t *testing.T, newContext contextFactory) {
 	wid := "sched-test-update-blob-limit-wf"
 	wt := "sched-test-update-blob-limit-wt"
 
-	env.SdkWorker().RegisterWorkflowWithOptions(
+	s.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error { return nil },
 		workflow.RegisterOptions{Name: wt},
 	)
@@ -4423,16 +4422,16 @@ func testUpdateScheduleBlobSizeLimit(t *testing.T, newContext contextFactory) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
 	}
 
 	// Create schedule.
-	ctx := newContext(env.Context())
-	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -4446,8 +4445,8 @@ func testUpdateScheduleBlobSizeLimit(t *testing.T, newContext contextFactory) {
 			"key": {Data: make([]byte, 1001)},
 		},
 	}
-	_, err = env.FrontendClient().UpdateSchedule(newContext(env.Context()), &workflowservice.UpdateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	_, err = s.FrontendClient().UpdateSchedule(newContext(s.Context()), &workflowservice.UpdateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -4469,10 +4468,10 @@ func TestScheduleCreationRolloutPercent(t *testing.T) {
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, true),
 		testcore.WithDynamicConfig(dynamicconfig.CHASMSchedulerCreationRolloutPercent, 50),
 	)
-	env := newScheduleEnv(t, opts...)
-	ctx := env.Context()
-	nsName := env.Namespace().String()
-	nsID := env.NamespaceID().String()
+	s := newScheduleEnv(t, opts...)
+	ctx := s.Context()
+	nsName := s.Namespace().String()
+	nsID := s.NamespaceID().String()
 
 	chasmSID, v1SID := testcore.PickRolloutSplit(t, nsName, 50)
 
@@ -4486,7 +4485,7 @@ func TestScheduleCreationRolloutPercent(t *testing.T) {
 					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 						WorkflowId:   testcore.RandomizeStr("wid"),
 						WorkflowType: &commonpb.WorkflowType{Name: testcore.RandomizeStr("wt")},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					},
 				},
 			},
@@ -4494,7 +4493,7 @@ func TestScheduleCreationRolloutPercent(t *testing.T) {
 	}
 
 	for _, sid := range []string{chasmSID, v1SID} {
-		_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
 			Namespace:  nsName,
 			ScheduleId: sid,
 			Schedule:   mkSchedule(),
@@ -4507,7 +4506,7 @@ func TestScheduleCreationRolloutPercent(t *testing.T) {
 	// A direct CHASM DescribeSchedule succeeds for CHASM-backed schedules and
 	// returns NotFound for V1-backed schedules (whose CHASM key is a sentinel).
 	describeOnCHASM := func(sid string) error {
-		_, err := env.GetTestCluster().SchedulerClient().DescribeSchedule(ctx, &schedulerpb.DescribeScheduleRequest{
+		_, err := s.GetTestCluster().SchedulerClient().DescribeSchedule(ctx, &schedulerpb.DescribeScheduleRequest{
 			NamespaceId:     nsID,
 			FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: nsName, ScheduleId: sid},
 		})
@@ -4527,7 +4526,7 @@ func TestScheduleCreationRolloutPercent(t *testing.T) {
 	// takes a moment to be queryable after creation, so poll.
 	for _, sid := range []string{chasmSID, v1SID} {
 		require.Eventually(t, func() bool {
-			_, err := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			_, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
 				Namespace:  nsName,
 				ScheduleId: sid,
 			})
@@ -4764,29 +4763,29 @@ func testBackfillBlocksIdleClose(t *testing.T, newContext contextFactory) {
 // testMultiRangeBackfillCountedExactlyOnce asserts that the `ActionCount` is
 // correctly counted when multiple backfillers are concurrently running.
 func testMultiRangeBackfillCountedExactlyOnce(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-multi-range-backfill")
 	wid := testcore.RandomizeStr("sched-multi-range-backfill-wf")
 	wt := testcore.RandomizeStr("sched-multi-range-backfill-wt")
 
-	env.SdkWorker().RegisterWorkflowWithOptions(
+	s.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error { return nil },
 		workflow.RegisterOptions{Name: wt},
 	)
 
-	ctx := newContext(env.Context())
-	createSchedule(ctx, t, env, sid, &schedulepb.Schedule{
+	ctx := newContext(s.Context())
+	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
 		// 1m interval; each 2m backfill range below covers a couple of ticks.
 		Spec:   intervalSpec(time.Minute),
 		State:  &schedulepb.ScheduleState{Paused: true},
-		Action: startWorkflowAction(env, wid, wt),
+		Action: startWorkflowAction(s, wid, wt),
 	})
 
 	now := time.Now().UTC()
 	threeYearsAgo := now.Add(-3 * 365 * 24 * time.Hour).Truncate(time.Minute)
 	thirtyMinutesAgo := now.Add(-30 * time.Minute).Truncate(time.Minute)
-	patchSchedule(ctx, t, env, sid, &schedulepb.SchedulePatch{
+	patchSchedule(ctx, t, s, sid, &schedulepb.SchedulePatch{
 		BackfillRequest: []*schedulepb.BackfillRequest{
 			{
 				StartTime:     timestamppb.New(threeYearsAgo.Add(-2 * time.Minute)),
@@ -4802,8 +4801,8 @@ func testMultiRangeBackfillCountedExactlyOnce(t *testing.T, newContext contextFa
 	})
 
 	await.RequireTruef(t, func() bool {
-		desc, descErr := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  env.Namespace().String(),
+		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
 			ScheduleId: sid,
 		})
 		if descErr != nil {
@@ -4818,20 +4817,20 @@ func testMultiRangeBackfillCountedExactlyOnce(t *testing.T, newContext contextFa
 // a backfill request to completion, even though the schedule otherwise has no
 // automated actions running.
 func testBackfillOnPausedSchedule(t *testing.T, newContext contextFactory) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-backfill-paused")
 	wid := testcore.RandomizeStr("sched-backfill-paused-wf")
 	wt := testcore.RandomizeStr("sched-backfill-paused-wt")
 
 	var runs atomic.Int32
-	registerCountingWorkflow(env, wt, &runs)
+	registerCountingWorkflow(s, wt, &runs)
 
-	ctx := newContext(env.Context())
-	createSchedule(ctx, t, env, sid, &schedulepb.Schedule{
+	ctx := newContext(s.Context())
+	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
 		Spec:   intervalSpec(fastInterval),
 		State:  &schedulepb.ScheduleState{Paused: true},
-		Action: startWorkflowAction(env, wid, wt),
+		Action: startWorkflowAction(s, wid, wt),
 	})
 
 	// Paused suppresses firing even though the 1s interval would otherwise tick.
@@ -4840,7 +4839,7 @@ func testBackfillOnPausedSchedule(t *testing.T, newContext contextFactory) {
 		"paused schedule must not fire automated actions")
 
 	now := time.Now().UTC()
-	patchSchedule(ctx, t, env, sid, backfillPatch(now.Add(-5*time.Second), now, enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL))
+	patchSchedule(ctx, t, s, sid, backfillPatch(now.Add(-5*time.Second), now, enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL))
 
 	await.RequireTruef(t, func() bool { return runs.Load() >= 5 },
 		awaitTimeout, pollInterval,
@@ -4852,7 +4851,7 @@ func testBackfillOnPausedSchedule(t *testing.T, newContext contextFactory) {
 // queryable through the frontend ListSchedules API.
 func TestScheduleNextActionTimeVisibility(t *testing.T) {
 	opts := scheduleCommonOpts(t)
-	env := newScheduleEnv(t, opts...)
+	s := newScheduleEnv(t, opts...)
 
 	v2Sid := testcore.RandomizeStr("sched-next-action-v2")
 	wid := testcore.RandomizeStr("sched-next-action-wf")
@@ -4861,7 +4860,7 @@ func TestScheduleNextActionTimeVisibility(t *testing.T) {
 	// Register a no-op workflow type so a stray fire doesn't generate worker
 	// noise. The schedule is never paused: we want its next action time to stay
 	// populated so it remains queryable.
-	env.SdkWorker().RegisterWorkflowWithOptions(
+	s.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error { return nil },
 		workflow.RegisterOptions{Name: wt},
 	)
@@ -4878,7 +4877,7 @@ func TestScheduleNextActionTimeVisibility(t *testing.T) {
 					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 						WorkflowId:   wid,
 						WorkflowType: &commonpb.WorkflowType{Name: wt},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					},
 				},
 			},
@@ -4886,17 +4885,17 @@ func TestScheduleNextActionTimeVisibility(t *testing.T) {
 	}
 
 	newContext := chasmContextFactory
-	v2Ctx := newContext(env.Context())
+	v2Ctx := newContext(s.Context())
 	createTime := time.Now()
 
-	_, err := env.FrontendClient().CreateSchedule(v2Ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	_, err := s.FrontendClient().CreateSchedule(v2Ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: v2Sid,
 		Schedule:   mkSchedule(),
 		Identity:   "test",
 		RequestId:  uuid.NewString(),
 	})
-	env.NoError(err)
+	s.NoError(err)
 
 	// The CHASM scheduler publishes its next action time to visibility as the
 	// ScheduleNextActionTime search attribute. The schedule fires on an hourly
@@ -4910,8 +4909,8 @@ func TestScheduleNextActionTimeVisibility(t *testing.T) {
 	)
 
 	require.Eventually(t, func() bool {
-		listResp, err := env.FrontendClient().ListSchedules(v2Ctx, &workflowservice.ListSchedulesRequest{
-			Namespace:       env.Namespace().String(),
+		listResp, err := s.FrontendClient().ListSchedules(v2Ctx, &workflowservice.ListSchedulesRequest{
+			Namespace:       s.Namespace().String(),
 			MaximumPageSize: 100,
 			Query:           query,
 		})
@@ -5154,7 +5153,7 @@ func TestScheduleManyCalendars(t *testing.T) {
 // behind it. The counts aren't surfaced on the list entry, so we assert via the
 // query rather than by reading the entry's SAs.
 func TestScheduleCountsVisibility(t *testing.T) {
-	env := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 	newContext := chasmContextFactory
 
 	sid := testcore.RandomizeStr("sched-counts-v2")
@@ -5162,7 +5161,7 @@ func TestScheduleCountsVisibility(t *testing.T) {
 	wt := testcore.RandomizeStr("sched-counts-wt")
 
 	// A workflow that holds open so a fire stays running while later fires buffer.
-	env.SdkWorker().RegisterWorkflowWithOptions(
+	s.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error {
 			return workflow.Sleep(ctx, time.Hour)
 		},
@@ -5180,7 +5179,7 @@ func TestScheduleCountsVisibility(t *testing.T) {
 				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 					WorkflowId:   wid,
 					WorkflowType: &commonpb.WorkflowType{Name: wt},
-					TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				},
 			},
 		},
@@ -5189,9 +5188,9 @@ func TestScheduleCountsVisibility(t *testing.T) {
 		},
 	}
 
-	ctx := newContext(env.Context())
-	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  env.Namespace().String(),
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
 		ScheduleId: sid,
 		Schedule:   schedule,
 		Identity:   "test",
@@ -5202,8 +5201,8 @@ func TestScheduleCountsVisibility(t *testing.T) {
 	// matchesQuery reports whether the schedule is returned when filtering on the
 	// given search-attribute query.
 	matchesQuery := func(query string) bool {
-		listResp, listErr := env.FrontendClient().ListSchedules(newContext(env.Context()), &workflowservice.ListSchedulesRequest{
-			Namespace:       env.Namespace().String(),
+		listResp, listErr := s.FrontendClient().ListSchedules(newContext(s.Context()), &workflowservice.ListSchedulesRequest{
+			Namespace:       s.Namespace().String(),
 			MaximumPageSize: 5,
 			Query:           query,
 		})

--- a/tests/schedule_workflow_pause_interaction_test.go
+++ b/tests/schedule_workflow_pause_interaction_test.go
@@ -17,6 +17,7 @@ import (
 	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/testing/await"
+	"go.temporal.io/server/common/testing/testcontext"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
@@ -148,7 +149,7 @@ func setupPausedScheduledWorkflow(
 
 	register(env, wt)
 
-	ctx := newContext(env.Context())
+	ctx := newContext(testcontext.For(t))
 	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
 		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
@@ -338,7 +339,7 @@ func setupPausedTriggeredWorkflow(
 
 	register(env, wt)
 
-	ctx := newContext(env.Context())
+	ctx := newContext(testcontext.For(t))
 	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
 		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,

--- a/tests/schedule_workflow_pause_interaction_test.go
+++ b/tests/schedule_workflow_pause_interaction_test.go
@@ -122,7 +122,7 @@ func pauseInteractionOpts(t *testing.T) []testcore.TestOption {
 
 // scheduledPauseFixture holds the handles produced by setupPausedScheduledWorkflow.
 type scheduledPauseFixture struct {
-	s              *testcore.TestEnv
+	env            *testcore.TestEnv
 	ctx            context.Context
 	sid            string
 	wid            string
@@ -221,7 +221,7 @@ func setupPausedScheduledWorkflow(
 	require.NoError(t, err)
 
 	return &scheduledPauseFixture{
-		s:              env,
+		env:            env,
 		ctx:            ctx,
 		sid:            sid,
 		wid:            wid,
@@ -265,7 +265,7 @@ func testSchedulePauseOverlap(t *testing.T, newContext contextFactory, policy en
 	if expectScheduleProgressesWhilePaused(policy) {
 		// The schedule should keep taking new actions despite the paused workflow.
 		await.RequireTruef(t, func() bool {
-			c, cErr := scheduleActionCount(f.ctx, f.s, f.sid)
+			c, cErr := scheduleActionCount(f.ctx, f.env, f.sid)
 			return cErr == nil && c > f.actionsAtPause
 		}, 20*time.Second, 500*time.Millisecond,
 			"schedule with %s should keep taking actions while its workflow is paused", policy)
@@ -277,7 +277,7 @@ func testSchedulePauseOverlap(t *testing.T, newContext contextFactory, policy en
 		require.Never(
 			t,
 			func() bool {
-				c, cErr := scheduleActionCount(f.ctx, f.s, f.sid)
+				c, cErr := scheduleActionCount(f.ctx, f.env, f.sid)
 				return cErr == nil && c > f.actionsAtPause
 			},
 			8*time.Second,
@@ -294,8 +294,8 @@ func testSchedulePauseUnpauseRecovery(t *testing.T, newContext contextFactory, p
 	f := setupPausedScheduledWorkflow(t, newContext, policy, registerSignalCompletableWorkflow)
 
 	// Unpause the workflow.
-	_, err := f.s.FrontendClient().UnpauseWorkflowExecution(f.ctx, &workflowservice.UnpauseWorkflowExecutionRequest{
-		Namespace:  f.s.Namespace().String(),
+	_, err := f.env.FrontendClient().UnpauseWorkflowExecution(f.ctx, &workflowservice.UnpauseWorkflowExecutionRequest{
+		Namespace:  f.env.Namespace().String(),
 		WorkflowId: f.execution.GetWorkflowId(),
 		RunId:      f.execution.GetRunId(),
 		Identity:   "functional-test",
@@ -305,13 +305,13 @@ func testSchedulePauseUnpauseRecovery(t *testing.T, newContext contextFactory, p
 	require.NoError(t, err)
 
 	// Free the overlap slot so the schedule can progress again.
-	err = f.s.SdkClient().SignalWorkflow(f.ctx, f.execution.GetWorkflowId(), f.execution.GetRunId(), "complete", nil)
+	err = f.env.SdkClient().SignalWorkflow(f.ctx, f.execution.GetWorkflowId(), f.execution.GetRunId(), "complete", nil)
 	require.NoError(t, err)
 
 	// Once the slot frees, the schedule should resume taking actions - the
 	// schedule is blocked only while the workflow is paused, not permanently.
 	await.RequireTruef(t, func() bool {
-		c, cErr := scheduleActionCount(f.ctx, f.s, f.sid)
+		c, cErr := scheduleActionCount(f.ctx, f.env, f.sid)
 		return cErr == nil && c > f.actionsAtPause
 	}, 30*time.Second, 1*time.Second,
 		"schedule with %s should resume taking actions after the workflow is unpaused", policy)
@@ -413,7 +413,7 @@ func setupPausedTriggeredWorkflow(
 	}, workflowStatusWait, workflowStatusPoll)
 
 	return &scheduledPauseFixture{
-		s:         env,
+		env:       env,
 		ctx:       ctx,
 		sid:       sid,
 		wid:       wid,
@@ -451,11 +451,11 @@ func testSchedulePauseContinueAsNew(t *testing.T, newContext contextFactory) {
 
 	// Signal "go" while paused. The signal is recorded but not processed, so the
 	// workflow must not continue-as-new: it stays on the same run, still PAUSED.
-	err := f.s.SdkClient().SignalWorkflow(f.ctx, f.execution.GetWorkflowId(), f.execution.GetRunId(), "go", nil)
+	err := f.env.SdkClient().SignalWorkflow(f.ctx, f.execution.GetWorkflowId(), f.execution.GetRunId(), "go", nil)
 	require.NoError(t, err)
 	require.Never(t, func() bool {
-		d, dErr := f.s.FrontendClient().DescribeWorkflowExecution(f.ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-			Namespace: f.s.Namespace().String(),
+		d, dErr := f.env.FrontendClient().DescribeWorkflowExecution(f.ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: f.env.Namespace().String(),
 			Execution: f.execution,
 		})
 		return dErr == nil && d.GetWorkflowExecutionInfo().GetStatus() != enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED
@@ -464,8 +464,8 @@ func testSchedulePauseContinueAsNew(t *testing.T, newContext contextFactory) {
 
 	// Unpause: the buffered signal is processed, the workflow continues-as-new,
 	// and the continued run completes.
-	_, err = f.s.FrontendClient().UnpauseWorkflowExecution(f.ctx, &workflowservice.UnpauseWorkflowExecutionRequest{
-		Namespace:  f.s.Namespace().String(),
+	_, err = f.env.FrontendClient().UnpauseWorkflowExecution(f.ctx, &workflowservice.UnpauseWorkflowExecutionRequest{
+		Namespace:  f.env.Namespace().String(),
 		WorkflowId: f.execution.GetWorkflowId(),
 		RunId:      f.execution.GetRunId(),
 		Identity:   "functional-test",
@@ -476,8 +476,8 @@ func testSchedulePauseContinueAsNew(t *testing.T, newContext contextFactory) {
 
 	// The latest run of the chain (the continued-as-new run) should complete.
 	await.RequireTruef(t, func() bool {
-		d, dErr := f.s.FrontendClient().DescribeWorkflowExecution(f.ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-			Namespace: f.s.Namespace().String(),
+		d, dErr := f.env.FrontendClient().DescribeWorkflowExecution(f.ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: f.env.Namespace().String(),
 			Execution: &commonpb.WorkflowExecution{WorkflowId: f.execution.GetWorkflowId()},
 		})
 		return dErr == nil && d.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
@@ -486,8 +486,8 @@ func testSchedulePauseContinueAsNew(t *testing.T, newContext contextFactory) {
 	// The scheduler should observe the completion across the continue-as-new
 	// boundary and record it as a COMPLETED action.
 	await.RequireTruef(t, func() bool {
-		desc, descErr := f.s.FrontendClient().DescribeSchedule(f.ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  f.s.Namespace().String(),
+		desc, descErr := f.env.FrontendClient().DescribeSchedule(f.ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  f.env.Namespace().String(),
 			ScheduleId: f.sid,
 		})
 		if descErr != nil {
@@ -531,8 +531,8 @@ func testSchedulePauseReset(t *testing.T, newContext contextFactory) {
 	f := setupPausedTriggeredWorkflow(t, newContext, pauseInteractionOpts(t), "sched-pause-reset", register, afterStart)
 
 	// Reset the paused workflow to a point before it was paused.
-	resetResp, err := f.s.FrontendClient().ResetWorkflowExecution(f.ctx, &workflowservice.ResetWorkflowExecutionRequest{
-		Namespace:                 f.s.Namespace().String(),
+	resetResp, err := f.env.FrontendClient().ResetWorkflowExecution(f.ctx, &workflowservice.ResetWorkflowExecutionRequest{
+		Namespace:                 f.env.Namespace().String(),
 		WorkflowExecution:         f.execution,
 		Reason:                    "schedule-pause-reset",
 		WorkflowTaskFinishEventId: 3,
@@ -547,8 +547,8 @@ func testSchedulePauseReset(t *testing.T, newContext contextFactory) {
 	// The reset run is created from history before the pause event, so it is
 	// running, not paused: reset clears the pause.
 	await.RequireTruef(t, func() bool {
-		d, dErr := f.s.FrontendClient().DescribeWorkflowExecution(f.ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-			Namespace: f.s.Namespace().String(),
+		d, dErr := f.env.FrontendClient().DescribeWorkflowExecution(f.ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: f.env.Namespace().String(),
 			Execution: resetRun,
 		})
 		return dErr == nil && d.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
@@ -556,11 +556,11 @@ func testSchedulePauseReset(t *testing.T, newContext contextFactory) {
 
 	// The scheduler keeps tracking the reset run: signalling it to completion
 	// should be observed and recorded as a COMPLETED action.
-	err = f.s.SdkClient().SignalWorkflow(f.ctx, resetRun.GetWorkflowId(), resetRun.GetRunId(), "complete", nil)
+	err = f.env.SdkClient().SignalWorkflow(f.ctx, resetRun.GetWorkflowId(), resetRun.GetRunId(), "complete", nil)
 	require.NoError(t, err)
 	await.RequireTruef(t, func() bool {
-		desc, descErr := f.s.FrontendClient().DescribeSchedule(f.ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  f.s.Namespace().String(),
+		desc, descErr := f.env.FrontendClient().DescribeSchedule(f.ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  f.env.Namespace().String(),
 			ScheduleId: f.sid,
 		})
 		if descErr != nil {

--- a/tests/schedule_workflow_pause_interaction_test.go
+++ b/tests/schedule_workflow_pause_interaction_test.go
@@ -140,17 +140,17 @@ func setupPausedScheduledWorkflow(
 	policy enumspb.ScheduleOverlapPolicy,
 	register func(s *testcore.TestEnv, wt string),
 ) *scheduledPauseFixture {
-	s := newScheduleEnv(t, pauseInteractionOpts(t)...)
+	env := newScheduleEnv(t, pauseInteractionOpts(t)...)
 
 	sid := testcore.RandomizeStr("sched-pause-" + policy.String())
 	wid := testcore.RandomizeStr("sched-pause-wf-" + policy.String())
 	wt := testcore.RandomizeStr("sched-pause-wt-" + policy.String())
 
-	register(s, wt)
+	register(env, wt)
 
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	ctx := newContext(env.Context())
+	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule: &schedulepb.Schedule{
 			Spec: &schedulepb.ScheduleSpec{
@@ -163,7 +163,7 @@ func setupPausedScheduledWorkflow(
 					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 						WorkflowId:   wid,
 						WorkflowType: &commonpb.WorkflowType{Name: wt},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					},
 				},
 			},
@@ -180,8 +180,8 @@ func setupPausedScheduledWorkflow(
 	// populated for every overlap policy (including ALLOW_ALL).
 	var execution *commonpb.WorkflowExecution
 	await.RequireTruef(t, func() bool {
-		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  s.Namespace().String(),
+		desc, descErr := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  env.Namespace().String(),
 			ScheduleId: sid,
 		})
 		if descErr != nil {
@@ -197,8 +197,8 @@ func setupPausedScheduledWorkflow(
 	}, scheduleStartWait, scheduleStartPoll, "schedule should start its first workflow")
 
 	// Pause that workflow.
-	_, err = s.FrontendClient().PauseWorkflowExecution(ctx, &workflowservice.PauseWorkflowExecutionRequest{
-		Namespace:  s.Namespace().String(),
+	_, err = env.FrontendClient().PauseWorkflowExecution(ctx, &workflowservice.PauseWorkflowExecutionRequest{
+		Namespace:  env.Namespace().String(),
 		WorkflowId: execution.GetWorkflowId(),
 		RunId:      execution.GetRunId(),
 		Identity:   "functional-test",
@@ -209,18 +209,18 @@ func setupPausedScheduledWorkflow(
 
 	// Confirm the workflow reaches PAUSED.
 	await.RequireTrue(t, func() bool {
-		d, dErr := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-			Namespace: s.Namespace().String(),
+		d, dErr := env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
 			Execution: execution,
 		})
 		return dErr == nil && d.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED
 	}, workflowStatusWait, workflowStatusPoll)
 
-	actionsAtPause, err := scheduleActionCount(ctx, s, sid)
+	actionsAtPause, err := scheduleActionCount(ctx, env, sid)
 	require.NoError(t, err)
 
 	return &scheduledPauseFixture{
-		s:              s,
+		s:              env,
 		ctx:            ctx,
 		sid:            sid,
 		wid:            wid,
@@ -330,17 +330,17 @@ func setupPausedTriggeredWorkflow(
 	register func(s *testcore.TestEnv, wt string),
 	afterStart func(s *testcore.TestEnv, firstRun *commonpb.WorkflowExecution),
 ) *scheduledPauseFixture {
-	s := newScheduleEnv(t, opts...)
+	env := newScheduleEnv(t, opts...)
 
 	sid := testcore.RandomizeStr(idPrefix)
 	wid := testcore.RandomizeStr(idPrefix + "-wf")
 	wt := testcore.RandomizeStr(idPrefix + "-wt")
 
-	register(s, wt)
+	register(env, wt)
 
-	ctx := newContext(s.Context())
-	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  s.Namespace().String(),
+	ctx := newContext(env.Context())
+	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  env.Namespace().String(),
 		ScheduleId: sid,
 		Schedule: &schedulepb.Schedule{
 			// Long interval + trigger-immediately so exactly one run starts.
@@ -354,7 +354,7 @@ func setupPausedTriggeredWorkflow(
 					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
 						WorkflowId:   wid,
 						WorkflowType: &commonpb.WorkflowType{Name: wt},
-						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					},
 				},
 			},
@@ -373,8 +373,8 @@ func setupPausedTriggeredWorkflow(
 	// Wait for the first run to start.
 	var firstRun *commonpb.WorkflowExecution
 	await.RequireTruef(t, func() bool {
-		desc, descErr := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
-			Namespace:  s.Namespace().String(),
+		desc, descErr := env.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  env.Namespace().String(),
 			ScheduleId: sid,
 		})
 		if descErr != nil {
@@ -390,12 +390,12 @@ func setupPausedTriggeredWorkflow(
 	}, scheduleStartWait, scheduleStartPoll, "schedule should start its first workflow")
 
 	if afterStart != nil {
-		afterStart(s, firstRun)
+		afterStart(env, firstRun)
 	}
 
 	// Pause the first run.
-	_, err = s.FrontendClient().PauseWorkflowExecution(ctx, &workflowservice.PauseWorkflowExecutionRequest{
-		Namespace:  s.Namespace().String(),
+	_, err = env.FrontendClient().PauseWorkflowExecution(ctx, &workflowservice.PauseWorkflowExecutionRequest{
+		Namespace:  env.Namespace().String(),
 		WorkflowId: firstRun.GetWorkflowId(),
 		RunId:      firstRun.GetRunId(),
 		Identity:   "functional-test",
@@ -404,15 +404,15 @@ func setupPausedTriggeredWorkflow(
 	})
 	require.NoError(t, err)
 	await.RequireTrue(t, func() bool {
-		d, dErr := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-			Namespace: s.Namespace().String(),
+		d, dErr := env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
 			Execution: firstRun,
 		})
 		return dErr == nil && d.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED
 	}, workflowStatusWait, workflowStatusPoll)
 
 	return &scheduledPauseFixture{
-		s:         s,
+		s:         env,
 		ctx:       ctx,
 		sid:       sid,
 		wid:       wid,

--- a/tests/signal_workflow_test.go
+++ b/tests/signal_workflow_test.go
@@ -65,7 +65,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWorkflow(opts []testcore.TestOption)
 	header := &commonpb.Header{
 		Fields: map[string]*commonpb.Payload{"signal header key": payload.EncodeString("signal header value")},
 	}
-	_, err0 := env.FrontendClient().SignalWorkflowExecution(env.Context(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err0 := env.FrontendClient().SignalWorkflowExecution(s.Context(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: env.Namespace().String(),
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -92,7 +92,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWorkflow(opts []testcore.TestOption)
 		Identity:            identity,
 	}
 
-	we, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 
 	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -165,7 +165,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWorkflow(opts []testcore.TestOption)
 	// Send first signal using RunID
 	signalName := "my signal"
 	signalInput := payloads.EncodeString("my signal input")
-	_, err = env.FrontendClient().SignalWorkflowExecution(env.Context(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err = env.FrontendClient().SignalWorkflowExecution(s.Context(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: env.Namespace().String(),
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -193,7 +193,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWorkflow(opts []testcore.TestOption)
 	// Send another signal without RunID
 	signalName = "another signal"
 	signalInput = payloads.EncodeString("another signal input")
-	_, err = env.FrontendClient().SignalWorkflowExecution(env.Context(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err = env.FrontendClient().SignalWorkflowExecution(s.Context(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: env.Namespace().String(),
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -216,7 +216,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWorkflow(opts []testcore.TestOption)
 	s.Equal(identity, signalEvent.GetWorkflowExecutionSignaledEventAttributes().Identity)
 
 	// Terminate workflow execution
-	_, err = env.FrontendClient().TerminateWorkflowExecution(env.Context(), &workflowservice.TerminateWorkflowExecutionRequest{
+	_, err = env.FrontendClient().TerminateWorkflowExecution(s.Context(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace: env.Namespace().String(),
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -228,7 +228,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWorkflow(opts []testcore.TestOption)
 	s.NoError(err)
 
 	// Send signal to terminated workflow
-	_, err = env.FrontendClient().SignalWorkflowExecution(env.Context(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err = env.FrontendClient().SignalWorkflowExecution(s.Context(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: env.Namespace().String(),
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -267,7 +267,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWorkflow_DuplicateRequest(opts []tes
 		Identity:            identity,
 	}
 
-	we, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -354,7 +354,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWorkflow_DuplicateRequest(opts []tes
 		Identity:   identity,
 		RequestId:  requestID,
 	}
-	_, err = env.FrontendClient().SignalWorkflowExecution(env.Context(), signalReqest)
+	_, err = env.FrontendClient().SignalWorkflowExecution(s.Context(), signalReqest)
 	s.NoError(err)
 
 	// Process signal in workflow
@@ -370,7 +370,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWorkflow_DuplicateRequest(opts []tes
 	s.Equal(1, numOfSignaledEvent)
 
 	// Send another signal with same request id
-	_, err = env.FrontendClient().SignalWorkflowExecution(env.Context(), signalReqest)
+	_, err = env.FrontendClient().SignalWorkflowExecution(s.Context(), signalReqest)
 	s.NoError(err)
 
 	// Process signal in workflow
@@ -414,7 +414,7 @@ func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand(opts []testc
 		Identity:            identity,
 	}
 
-	we, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -429,7 +429,7 @@ func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand(opts []testc
 		WorkflowTaskTimeout: durationpb.New(1 * time.Second),
 		Identity:            identity,
 	}
-	we2, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), externalRequest)
+	we2, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), externalRequest)
 	s.NoError(err0)
 	env.Logger.Info("StartWorkflowExecution on external Namespace", tag.WorkflowNamespace(env.ExternalNamespace().String()), tag.WorkflowRunID(we2.RunId))
 
@@ -636,7 +636,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWorkflow_Cron_NoWorkflowTaskCreated(
 	}
 	now := time.Now().UTC()
 
-	we, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 
 	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -644,7 +644,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWorkflow_Cron_NoWorkflowTaskCreated(
 	// Send first signal using RunID
 	signalName := "my signal"
 	signalInput := payloads.EncodeString("my signal input")
-	_, err := env.FrontendClient().SignalWorkflowExecution(env.Context(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err := env.FrontendClient().SignalWorkflowExecution(s.Context(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: env.Namespace().String(),
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -695,7 +695,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWorkflow_WorkflowCloseAttempted(opts
 	workflowType := &commonpb.WorkflowType{Name: wt}
 	taskQueue := &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
 
-	we, err := env.FrontendClient().StartWorkflowExecution(env.Context(), &workflowservice.StartWorkflowExecutionRequest{
+	we, err := env.FrontendClient().StartWorkflowExecution(s.Context(), &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:           uuid.NewString(),
 		Namespace:           env.Namespace().String(),
 		WorkflowId:          id,
@@ -711,7 +711,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWorkflow_WorkflowCloseAttempted(opts
 	attemptCount := 1
 	wtHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
 		if attemptCount == 1 {
-			_, err := env.FrontendClient().SignalWorkflowExecution(env.Context(), &workflowservice.SignalWorkflowExecutionRequest{
+			_, err := env.FrontendClient().SignalWorkflowExecution(s.Context(), &workflowservice.SignalWorkflowExecutionRequest{
 				Namespace: env.Namespace().String(),
 				WorkflowExecution: &commonpb.WorkflowExecution{
 					WorkflowId: id,
@@ -801,7 +801,7 @@ func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand_WithoutRunID
 		Identity:            identity,
 	}
 
-	we, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -816,7 +816,7 @@ func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand_WithoutRunID
 		WorkflowTaskTimeout: durationpb.New(1 * time.Second),
 		Identity:            identity,
 	}
-	we2, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), externalRequest)
+	we2, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), externalRequest)
 	s.NoError(err0)
 	env.Logger.Info("StartWorkflowExecution on external Namespace", tag.WorkflowNamespace(env.ExternalNamespace().String()), tag.WorkflowRunID(we2.RunId))
 
@@ -1020,7 +1020,7 @@ func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand_UnKnownTarge
 		WorkflowTaskTimeout: durationpb.New(1 * time.Second),
 		Identity:            identity,
 	}
-	we, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -1143,7 +1143,7 @@ func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand_SignalSelf(o
 		WorkflowTaskTimeout: durationpb.New(1 * time.Second),
 		Identity:            identity,
 	}
-	we, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -1272,7 +1272,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWithStartWorkflow(opts []testcore.Te
 		Identity:            identity,
 	}
 
-	we, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 
 	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -1377,7 +1377,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWithStartWorkflow(opts []testcore.Te
 		Identity:              identity,
 		WorkflowIdReusePolicy: wfIDReusePolicy,
 	}
-	resp, err := env.FrontendClient().SignalWithStartWorkflowExecution(env.Context(), sRequest)
+	resp, err := env.FrontendClient().SignalWithStartWorkflowExecution(s.Context(), sRequest)
 	s.NoError(err)
 	s.False(resp.Started)
 	s.Equal(we.GetRunId(), resp.GetRunId())
@@ -1394,7 +1394,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWithStartWorkflow(opts []testcore.Te
 	s.Equal(identity, signalEvent.GetWorkflowExecutionSignaledEventAttributes().Identity)
 
 	// Terminate workflow execution
-	_, err = env.FrontendClient().TerminateWorkflowExecution(env.Context(), &workflowservice.TerminateWorkflowExecutionRequest{
+	_, err = env.FrontendClient().TerminateWorkflowExecution(s.Context(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace: env.Namespace().String(),
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -1412,7 +1412,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWithStartWorkflow(opts []testcore.Te
 	sRequest.SignalInput = signalInput
 	sRequest.WorkflowId = id
 
-	resp, err = env.FrontendClient().SignalWithStartWorkflowExecution(env.Context(), sRequest)
+	resp, err = env.FrontendClient().SignalWithStartWorkflowExecution(s.Context(), sRequest)
 	s.NoError(err)
 	s.True(resp.Started)
 	s.NotNil(resp.GetRunId())
@@ -1439,7 +1439,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWithStartWorkflow(opts []testcore.Te
 	sRequest.SignalName = signalName
 	sRequest.SignalInput = signalInput
 	sRequest.WorkflowId = id
-	resp, err = env.FrontendClient().SignalWithStartWorkflowExecution(env.Context(), sRequest)
+	resp, err = env.FrontendClient().SignalWithStartWorkflowExecution(s.Context(), sRequest)
 	s.NoError(err)
 	s.NotNil(resp.GetRunId())
 	s.True(resp.Started)
@@ -1473,7 +1473,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWithStartWorkflow(opts []testcore.Te
 	// Assert visibility is correct
 	s.Eventually(
 		func() bool {
-			listResp, err := env.FrontendClient().ListOpenWorkflowExecutions(env.Context(), listOpenRequest)
+			listResp, err := env.FrontendClient().ListOpenWorkflowExecutions(s.Context(), listOpenRequest)
 			s.NoError(err)
 			return len(listResp.Executions) == 1
 		},
@@ -1482,7 +1482,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWithStartWorkflow(opts []testcore.Te
 	)
 
 	// Terminate workflow execution and assert visibility is correct
-	_, err = env.FrontendClient().TerminateWorkflowExecution(env.Context(), &workflowservice.TerminateWorkflowExecutionRequest{
+	_, err = env.FrontendClient().TerminateWorkflowExecution(s.Context(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace: env.Namespace().String(),
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -1495,7 +1495,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWithStartWorkflow(opts []testcore.Te
 
 	s.Eventually(
 		func() bool {
-			listResp, err := env.FrontendClient().ListOpenWorkflowExecutions(env.Context(), listOpenRequest)
+			listResp, err := env.FrontendClient().ListOpenWorkflowExecutions(s.Context(), listOpenRequest)
 			s.NoError(err)
 			return len(listResp.Executions) == 0
 		},
@@ -1514,7 +1514,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWithStartWorkflow(opts []testcore.Te
 			WorkflowId: id,
 		}},
 	}
-	listClosedResp, err := env.FrontendClient().ListClosedWorkflowExecutions(env.Context(), listClosedRequest)
+	listClosedResp, err := env.FrontendClient().ListClosedWorkflowExecutions(s.Context(), listClosedRequest)
 	s.NoError(err)
 	s.Len(listClosedResp.Executions, 1)
 }
@@ -1548,7 +1548,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWithStartWorkflow_ResolveIDDeduplica
 		Identity:            identity,
 	}
 
-	we, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 
 	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -1652,7 +1652,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWithStartWorkflow_ResolveIDDeduplica
 	s.True(resp.Started)
 
 	// Terminate workflow execution
-	_, err = env.FrontendClient().TerminateWorkflowExecution(env.Context(), &workflowservice.TerminateWorkflowExecutionRequest{
+	_, err = env.FrontendClient().TerminateWorkflowExecution(s.Context(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace: env.Namespace().String(),
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -1665,7 +1665,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWithStartWorkflow_ResolveIDDeduplica
 
 	// test WorkflowIdReusePolicy: AllowDuplicateFailedOnly
 	sRequest.WorkflowIdReusePolicy = enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY
-	resp, err = env.FrontendClient().SignalWithStartWorkflowExecution(env.Context(), sRequest)
+	resp, err = env.FrontendClient().SignalWithStartWorkflowExecution(s.Context(), sRequest)
 	s.NoError(err)
 	s.NotEmpty(resp.GetRunId())
 	s.True(resp.Started)
@@ -1673,13 +1673,13 @@ func (s *SignalWorkflowTestSuite) TestSignalWithStartWorkflow_ResolveIDDeduplica
 	// test WorkflowIdReusePolicy: TerminateIfRunning (for backwards compatibility)
 	prevRunID := resp.RunId
 	sRequest.WorkflowIdReusePolicy = enumspb.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING
-	resp, err = env.FrontendClient().SignalWithStartWorkflowExecution(env.Context(), sRequest)
+	resp, err = env.FrontendClient().SignalWithStartWorkflowExecution(s.Context(), sRequest)
 	s.NoError(err)
 	s.NotEmpty(resp.GetRunId())
 	s.NotEqual(prevRunID, resp.GetRunId())
 	s.True(resp.Started)
 
-	descResp, err := env.FrontendClient().DescribeWorkflowExecution(env.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+	descResp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
 		Namespace: env.Namespace().String(),
 		Execution: &commonpb.WorkflowExecution{WorkflowId: id, RunId: prevRunID},
 	})
@@ -1690,20 +1690,20 @@ func (s *SignalWorkflowTestSuite) TestSignalWithStartWorkflow_ResolveIDDeduplica
 	prevRunID = resp.RunId
 	sRequest.WorkflowIdReusePolicy = enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE
 	sRequest.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING
-	resp, err = env.FrontendClient().SignalWithStartWorkflowExecution(env.Context(), sRequest)
+	resp, err = env.FrontendClient().SignalWithStartWorkflowExecution(s.Context(), sRequest)
 	s.NoError(err)
 	s.NotEmpty(resp.GetRunId())
 	s.NotEqual(prevRunID, resp.GetRunId())
 	s.True(resp.Started)
 
-	descResp, err = env.FrontendClient().DescribeWorkflowExecution(env.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+	descResp, err = env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
 		Namespace: env.Namespace().String(),
 		Execution: &commonpb.WorkflowExecution{WorkflowId: id, RunId: prevRunID},
 	})
 	s.NoError(err)
 	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED, descResp.WorkflowExecutionInfo.Status)
 
-	descResp, err = env.FrontendClient().DescribeWorkflowExecution(env.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+	descResp, err = env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
 		Namespace: env.Namespace().String(),
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -1743,7 +1743,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWithStartWorkflow_StartDelay(opts []
 	}
 
 	reqStartTime := time.Now()
-	we0, startErr := env.FrontendClient().SignalWithStartWorkflowExecution(env.Context(), sRequest)
+	we0, startErr := env.FrontendClient().SignalWithStartWorkflowExecution(s.Context(), sRequest)
 	s.NoError(startErr)
 
 	var signalEvent *historypb.HistoryEvent
@@ -1786,7 +1786,7 @@ func (s *SignalWorkflowTestSuite) TestSignalWithStartWorkflow_StartDelay(opts []
 	s.ProtoEqual(signalInput, signalEvent.GetWorkflowExecutionSignaledEventAttributes().Input)
 	s.Equal(identity, signalEvent.GetWorkflowExecutionSignaledEventAttributes().Identity)
 
-	descResp, descErr := env.FrontendClient().DescribeWorkflowExecution(env.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+	descResp, descErr := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
 		Namespace: env.Namespace().String(),
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: id,

--- a/tests/sizelimit_test.go
+++ b/tests/sizelimit_test.go
@@ -72,7 +72,7 @@ func (s *SizeLimitSuite) TestTerminateWorkflowCausedByHistoryCountLimit() {
 		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
 	}
 
-	we, err0 := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 
 	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -111,7 +111,7 @@ func (s *SizeLimitSuite) TestTerminateWorkflowCausedByHistoryCountLimit() {
 	poller := env.TaskPoller()
 
 	for i := int32(0); i < activityCount-1; i++ {
-		dwResp, err := env.FrontendClient().DescribeWorkflowExecution(testcore.NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+		dwResp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
 			Namespace: env.Namespace().String(),
 			Execution: &commonpb.WorkflowExecution{
 				WorkflowId: id,
@@ -146,7 +146,7 @@ SignalLoop:
 		// Send another signal without RunID
 		signalName := "another signal"
 		signalInput := payloads.EncodeString("another signal input")
-		_, signalErr = env.FrontendClient().SignalWorkflowExecution(testcore.NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+		_, signalErr = env.FrontendClient().SignalWorkflowExecution(s.Context(), &workflowservice.SignalWorkflowExecutionRequest{
 			Namespace: env.Namespace().String(),
 			WorkflowExecution: &commonpb.WorkflowExecution{
 				WorkflowId: id,
@@ -196,7 +196,7 @@ SignalLoop:
 	s.Eventually(
 		func() bool {
 			resp, err1 := env.FrontendClient().ListClosedWorkflowExecutions(
-				testcore.NewContext(),
+				s.Context(),
 				&workflowservice.ListClosedWorkflowExecutionsRequest{
 					Namespace:       env.Namespace().String(),
 					MaximumPageSize: 100,
@@ -253,7 +253,7 @@ func (s *SizeLimitSuite) TestWorkflowFailed_PayloadSizeTooLarge() {
 		Identity:            "worker",
 	}
 
-	we, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)
+	we, err := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err)
 
 	go func() {
@@ -291,7 +291,7 @@ func (s *SizeLimitSuite) TestWorkflowFailed_PayloadSizeTooLarge() {
 		s.FailNow("timed out waiting for workflow task handler to be ready")
 	}
 
-	_, err = env.FrontendClient().SignalWorkflowExecution(testcore.NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err = env.FrontendClient().SignalWorkflowExecution(s.Context(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace:         env.Namespace().String(),
 		WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: id, RunId: we.GetRunId()},
 		SignalName:        "signal-name",
@@ -348,7 +348,7 @@ func (s *SizeLimitSuite) TestTerminateWorkflowCausedByMsSizeLimit() {
 		Identity:            "worker",
 	}
 
-	we, err0 := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 
 	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -377,7 +377,7 @@ func (s *SizeLimitSuite) TestTerminateWorkflowCausedByMsSizeLimit() {
 
 	poller := env.TaskPoller()
 
-	dwResp, err := env.FrontendClient().DescribeWorkflowExecution(testcore.NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+	dwResp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
 		Namespace: env.Namespace().String(),
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -399,7 +399,7 @@ func (s *SizeLimitSuite) TestTerminateWorkflowCausedByMsSizeLimit() {
 	}
 
 	// Send another signal without RunID
-	_, signalErr := env.FrontendClient().SignalWorkflowExecution(testcore.NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, signalErr := env.FrontendClient().SignalWorkflowExecution(s.Context(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: env.Namespace().String(),
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -427,7 +427,7 @@ func (s *SizeLimitSuite) TestTerminateWorkflowCausedByMsSizeLimit() {
 	s.Eventually(
 		func() bool {
 			resp, err1 := env.FrontendClient().ListClosedWorkflowExecutions(
-				testcore.NewContext(),
+				s.Context(),
 				&workflowservice.ListClosedWorkflowExecutionsRequest{
 					Namespace:       env.Namespace().String(),
 					MaximumPageSize: 100,
@@ -477,7 +477,7 @@ func (s *SizeLimitSuite) TestTerminateWorkflowCausedByHistorySizeLimit() {
 		Identity:            "worker",
 	}
 
-	we, err0 := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 
 	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -491,7 +491,7 @@ SignalLoop:
 		signalName := "another signal"
 		signalInput, err := payloads.Encode(largePayload)
 		s.NoError(err)
-		_, signalErr = env.FrontendClient().SignalWorkflowExecution(testcore.NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+		_, signalErr = env.FrontendClient().SignalWorkflowExecution(s.Context(), &workflowservice.SignalWorkflowExecutionRequest{
 			Namespace: env.Namespace().String(),
 			WorkflowExecution: &commonpb.WorkflowExecution{
 				WorkflowId: id,
@@ -532,7 +532,7 @@ SignalLoop:
 	s.Eventually(
 		func() bool {
 			resp, err1 := env.FrontendClient().ListClosedWorkflowExecutions(
-				testcore.NewContext(),
+				s.Context(),
 				&workflowservice.ListClosedWorkflowExecutionsRequest{
 					Namespace:       env.Namespace().String(),
 					MaximumPageSize: 100,

--- a/tests/sizelimit_test.go
+++ b/tests/sizelimit_test.go
@@ -265,8 +265,8 @@ func (s *SizeLimitSuite) TestWorkflowFailed_PayloadSizeTooLarge() {
 
 			select {
 			case <-sigSendDoneChan:
-			case <-env.Context().Done():
-				return nil, env.Context().Err()
+			case <-s.Context().Done():
+				return nil, s.Context().Err()
 			}
 			return &workflowservice.RespondWorkflowTaskCompletedRequest{
 				Commands: []*commandpb.Command{
@@ -287,7 +287,7 @@ func (s *SizeLimitSuite) TestWorkflowFailed_PayloadSizeTooLarge() {
 
 	select {
 	case <-sigReadyToSendChan:
-	case <-env.Context().Done():
+	case <-s.Context().Done():
 		s.FailNow("timed out waiting for workflow task handler to be ready")
 	}
 

--- a/tests/stickytq_test.go
+++ b/tests/stickytq_test.go
@@ -50,7 +50,7 @@ func (s *StickyTqTestSuite) TestStickyTimeoutNonTransientWorkflowTask() {
 		Identity:            identity,
 	}
 
-	we, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 
 	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -120,7 +120,7 @@ func (s *StickyTqTestSuite) TestStickyTimeoutNonTransientWorkflowTask() {
 	env.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
-	_, err = env.FrontendClient().SignalWorkflowExecution(env.Context(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err = env.FrontendClient().SignalWorkflowExecution(s.Context(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace:         env.Namespace().String(),
 		WorkflowExecution: workflowExecution,
 		SignalName:        "signalA",
@@ -161,7 +161,7 @@ WaitForStickyTimeoutLoop:
 		s.NoError(err)
 	}
 
-	_, err = env.FrontendClient().SignalWorkflowExecution(env.Context(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err = env.FrontendClient().SignalWorkflowExecution(s.Context(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace:         env.Namespace().String(),
 		WorkflowExecution: workflowExecution,
 		SignalName:        "signalB",
@@ -247,7 +247,7 @@ func (s *StickyTqTestSuite) TestStickyTaskqueueResetThenTimeout() {
 		Identity:            identity,
 	}
 
-	we, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 
 	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -303,7 +303,7 @@ func (s *StickyTqTestSuite) TestStickyTaskqueueResetThenTimeout() {
 	env.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
-	_, err = env.FrontendClient().SignalWorkflowExecution(env.Context(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err = env.FrontendClient().SignalWorkflowExecution(s.Context(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace:         env.Namespace().String(),
 		WorkflowExecution: workflowExecution,
 		SignalName:        "signalA",
@@ -314,7 +314,7 @@ func (s *StickyTqTestSuite) TestStickyTaskqueueResetThenTimeout() {
 	s.NoError(err)
 
 	// Reset sticky taskqueue before sticky workflow task starts
-	_, err = env.FrontendClient().ResetStickyTaskQueue(env.Context(), &workflowservice.ResetStickyTaskQueueRequest{
+	_, err = env.FrontendClient().ResetStickyTaskQueue(s.Context(), &workflowservice.ResetStickyTaskQueueRequest{
 		Namespace: env.Namespace().String(),
 		Execution: workflowExecution,
 	})
@@ -351,7 +351,7 @@ WaitForStickyTimeoutLoop:
 		s.NoError(err)
 	}
 
-	_, err = env.FrontendClient().SignalWorkflowExecution(env.Context(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err = env.FrontendClient().SignalWorkflowExecution(s.Context(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace:         env.Namespace().String(),
 		WorkflowExecution: workflowExecution,
 		SignalName:        "signalB",

--- a/tests/testcore/context.go
+++ b/tests/testcore/context.go
@@ -9,9 +9,9 @@ import (
 
 // NewContext creates a context with default timeout and RPC headers.
 //
-// NOTE: Test suites should use s.Context() directly because it already includes RPC headers.
-// This function is primarily for legacy tests or creating standalone contexts outside of the
-// TestEnv framework.
+// NOTE: If you're using testcore.NewEnv, you can use env.Context() directly - it already
+// includes RPC headers. This function is primarily for legacy tests or creating standalone
+// contexts outside of the TestEnv framework.
 //
 // If a parent context is provided, the returned context will be canceled when
 // either the timeout expires OR the parent is canceled.

--- a/tests/testcore/context.go
+++ b/tests/testcore/context.go
@@ -9,9 +9,9 @@ import (
 
 // NewContext creates a context with default timeout and RPC headers.
 //
-// NOTE: If you're using testcore.NewEnv, you can use env.Context() directly - it already
-// includes RPC headers. This function is primarily for legacy tests or creating standalone
-// contexts outside of the TestEnv framework.
+// NOTE: Test suites should use s.Context() directly because it already includes RPC headers.
+// This function is primarily for legacy tests or creating standalone contexts outside of the
+// TestEnv framework.
 //
 // If a parent context is provided, the returned context will be canceled when
 // either the timeout expires OR the parent is canceled.

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -660,13 +660,6 @@ func (s *FunctionalTestBase) InjectHook(hook testhooks.Hook) (cleanup func()) {
 	return s.testCluster.host.injectHook(s.T(), hook, scope)
 }
 
-// Context returns a context with RPC headers for use in this test.
-//
-// Deprecated: use the suite's Context method instead.
-func (s *FunctionalTestBase) Context() context.Context {
-	return NewContext()
-}
-
 // CloseShard closes the shard that contains the given workflow.
 // This is a cluster-global operation and cannot be called on shared clusters.
 func (s *FunctionalTestBase) CloseShard(namespaceID string, workflowID string) {

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -661,6 +661,8 @@ func (s *FunctionalTestBase) InjectHook(hook testhooks.Hook) (cleanup func()) {
 }
 
 // Context returns a context with RPC headers for use in this test.
+//
+// Deprecated: use the suite's Context method instead.
 func (s *FunctionalTestBase) Context() context.Context {
 	return NewContext()
 }

--- a/tests/timeskipping_fast_forward_test.go
+++ b/tests/timeskipping_fast_forward_test.go
@@ -38,7 +38,7 @@ func (s *TimeSkippingFastForwardFunctionalSuite) getMutableState(env *testcore.T
 		workflowID,
 		env.GetTestClusterConfig().HistoryConfig.NumHistoryShards,
 	)
-	ms, err := env.GetTestCluster().ExecutionManager().GetWorkflowExecution(testcore.NewContext(), &persistence.GetWorkflowExecutionRequest{
+	ms, err := env.GetTestCluster().ExecutionManager().GetWorkflowExecution(s.Context(), &persistence.GetWorkflowExecutionRequest{
 		ShardID:     shardID,
 		NamespaceID: env.NamespaceID().String(),
 		WorkflowID:  workflowID,
@@ -78,7 +78,7 @@ func (s *TimeSkippingFastForwardFunctionalSuite) TestFastForward_WithActivity() 
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 
 	const (
 		fastForward = 30 * time.Minute
@@ -213,7 +213,7 @@ func (s *TimeSkippingFastForwardFunctionalSuite) TestFastForward_PauseLifecycle(
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
 	env.OverrideDynamicConfig(dynamicconfig.WorkflowPauseEnabled, true)
 	tv := testvars.New(s.T())
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 
 	const (
 		fastForward = 30 * time.Minute
@@ -340,7 +340,7 @@ func (s *TimeSkippingFastForwardFunctionalSuite) TestFastForward_NoUserTimer() {
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 
 	const (
 		fastForward = 30 * time.Minute
@@ -393,7 +393,7 @@ func (s *TimeSkippingFastForwardFunctionalSuite) TestFastForward_NoUserTimer() {
 func (s *TimeSkippingFastForwardFunctionalSuite) TestFastForward_EqualsRunTimeout() {
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 
 	const (
 		runTimeout  = 5 * time.Minute
@@ -447,7 +447,7 @@ func (s *TimeSkippingFastForwardFunctionalSuite) TestEventsOrderOfFastForwardTim
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 
 	const (
 		fastForward = time.Minute

--- a/tests/timeskipping_propagation_test.go
+++ b/tests/timeskipping_propagation_test.go
@@ -102,7 +102,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_Basic() {
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 
 	parentWFType := tv.WorkflowType()
 	childWFType := &commonpb.WorkflowType{Name: parentWFType.Name + "-child"}
@@ -234,7 +234,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_TwoChildren() {
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 
 	parentWFType := tv.WorkflowType()
 	childWFType := &commonpb.WorkflowType{Name: parentWFType.Name + "-child"}
@@ -366,7 +366,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_ThreeGenerations() {
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 
 	gWFType := &commonpb.WorkflowType{Name: tv.WorkflowType().Name + "-g"}
 	pWFType := &commonpb.WorkflowType{Name: tv.WorkflowType().Name + "-p"}
@@ -538,7 +538,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_AdmissionTimestampsS
 		testcore.WithDynamicConfig(dynamicconfig.TimeSkippingEnabled, true),
 	)
 	tv := testvars.New(s.T())
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 
 	parentWFType := tv.WorkflowType()
 	childWFType := &commonpb.WorkflowType{Name: parentWFType.Name + "-child"}
@@ -788,7 +788,7 @@ func (s *TimeSkippingPropagationTestSuite) getMutableState(env *testcore.TestEnv
 		workflowID,
 		env.GetTestClusterConfig().HistoryConfig.NumHistoryShards,
 	)
-	ms, err := env.GetTestCluster().ExecutionManager().GetWorkflowExecution(testcore.NewContext(), &persistence.GetWorkflowExecutionRequest{
+	ms, err := env.GetTestCluster().ExecutionManager().GetWorkflowExecution(s.Context(), &persistence.GetWorkflowExecutionRequest{
 		ShardID:     shardID,
 		NamespaceID: env.NamespaceID().String(),
 		WorkflowID:  workflowID,
@@ -963,7 +963,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInReset() {
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 
 	wfID := tv.WorkflowID()
 
@@ -1107,7 +1107,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInCaN() {
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 
 	wfType := tv.WorkflowType()
 	wfID := tv.WorkflowID()
@@ -1226,7 +1226,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInRetry() {
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 
 	wfType := tv.WorkflowType()
 	wfID := tv.WorkflowID()
@@ -1360,7 +1360,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInCron() {
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 
 	wfType := tv.WorkflowType()
 	wfID := tv.WorkflowID()
@@ -1494,7 +1494,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInCaN_BudgetCapOverChain() {
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 
 	wfType := tv.WorkflowType()
 	wfID := tv.WorkflowID()
@@ -1620,7 +1620,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_PropagationDisabled(
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 
 	parentWFType := tv.WorkflowType()
 	childWFType := &commonpb.WorkflowType{Name: parentWFType.Name + "-child"}

--- a/tests/timeskipping_test.go
+++ b/tests/timeskipping_test.go
@@ -48,7 +48,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_FeatureDisabled() {
 	id := "functional-timeskipping-feature-disabled"
 	tl := "functional-timeskipping-feature-disabled-tq"
 
-	_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(), &workflowservice.StartWorkflowExecutionRequest{
+	_, err := env.FrontendClient().StartWorkflowExecution(s.Context(), &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:           uuid.NewString(),
 		Namespace:           env.Namespace().String(),
 		WorkflowId:          id,
@@ -73,7 +73,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_StartWorkflow_DCEnabled() {
 		FastForward: durationpb.New(time.Hour),
 	}
 
-	resp, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(), &workflowservice.StartWorkflowExecutionRequest{
+	resp, err := env.FrontendClient().StartWorkflowExecution(s.Context(), &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:           uuid.NewString(),
 		Namespace:           env.Namespace().String(),
 		WorkflowId:          tv.WorkflowID(),
@@ -102,7 +102,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_SignalWithStart_DCEnabled() {
 		FastForward: durationpb.New(time.Hour),
 	}
 
-	resp, err := env.FrontendClient().SignalWithStartWorkflowExecution(testcore.NewContext(), &workflowservice.SignalWithStartWorkflowExecutionRequest{
+	resp, err := env.FrontendClient().SignalWithStartWorkflowExecution(s.Context(), &workflowservice.SignalWithStartWorkflowExecutionRequest{
 		RequestId:           uuid.NewString(),
 		Namespace:           env.Namespace().String(),
 		WorkflowId:          tv.WorkflowID(),
@@ -133,7 +133,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_ExecuteMultiOperation_DCEnabled
 		FastForward: durationpb.New(maxElapsedDuration),
 	}
 
-	resp, err := env.FrontendClient().ExecuteMultiOperation(testcore.NewContext(), &workflowservice.ExecuteMultiOperationRequest{
+	resp, err := env.FrontendClient().ExecuteMultiOperation(s.Context(), &workflowservice.ExecuteMultiOperationRequest{
 		Namespace: env.Namespace().String(),
 		Operations: []*workflowservice.ExecuteMultiOperationRequest_Operation{
 			{
@@ -184,7 +184,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_UpdateWorkflowOptions_DCEnabled
 	tv := testvars.New(s.T())
 
 	// Start a workflow without any time-skipping config.
-	startResp, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(), &workflowservice.StartWorkflowExecutionRequest{
+	startResp, err := env.FrontendClient().StartWorkflowExecution(s.Context(), &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:           uuid.NewString(),
 		Namespace:           env.Namespace().String(),
 		WorkflowId:          tv.WorkflowID(),
@@ -198,7 +198,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_UpdateWorkflowOptions_DCEnabled
 
 	// collectOptionsEvents returns all WorkflowExecutionOptionsUpdated events in history order.
 	collectOptionsEvents := func() []*historypb.HistoryEvent {
-		histResp, err := env.FrontendClient().GetWorkflowExecutionHistory(testcore.NewContext(), &workflowservice.GetWorkflowExecutionHistoryRequest{
+		histResp, err := env.FrontendClient().GetWorkflowExecutionHistory(s.Context(), &workflowservice.GetWorkflowExecutionHistoryRequest{
 			Namespace: env.Namespace().String(),
 			Execution: &commonpb.WorkflowExecution{WorkflowId: tv.WorkflowID(), RunId: runID},
 		})
@@ -212,7 +212,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_UpdateWorkflowOptions_DCEnabled
 		return events
 	}
 	updateOptions := func(cfg *commonpb.TimeSkippingConfig) {
-		_, err := env.FrontendClient().UpdateWorkflowExecutionOptions(testcore.NewContext(), &workflowservice.UpdateWorkflowExecutionOptionsRequest{
+		_, err := env.FrontendClient().UpdateWorkflowExecutionOptions(s.Context(), &workflowservice.UpdateWorkflowExecutionOptionsRequest{
 			Namespace:                env.Namespace().String(),
 			WorkflowExecution:        &commonpb.WorkflowExecution{WorkflowId: tv.WorkflowID(), RunId: runID},
 			WorkflowExecutionOptions: &workflowpb.WorkflowExecutionOptions{TimeSkippingConfig: cfg},
@@ -270,7 +270,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_ResetWithUpdateOptions() {
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 
 	// Start a workflow and drain the first workflow task to establish a reset point.
 	startResp, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
@@ -354,7 +354,7 @@ func (s *TimeSkippingTestSuite) getMutableState(env *testcore.TestEnv, workflowI
 		workflowID,
 		env.GetTestClusterConfig().HistoryConfig.NumHistoryShards,
 	)
-	ms, err := env.GetTestCluster().ExecutionManager().GetWorkflowExecution(testcore.NewContext(), &persistence.GetWorkflowExecutionRequest{
+	ms, err := env.GetTestCluster().ExecutionManager().GetWorkflowExecution(s.Context(), &persistence.GetWorkflowExecutionRequest{
 		ShardID:     shardID,
 		NamespaceID: env.NamespaceID().String(),
 		WorkflowID:  workflowID,
@@ -369,7 +369,7 @@ func (s *TimeSkippingTestSuite) getMutableState(env *testcore.TestEnv, workflowI
 // and a caller-specified run timeout. Used by tests that need the run timeout
 // to be long enough to fit a virtual-time skip.
 func (s *TimeSkippingTestSuite) startWorkflowWithTimeSkipping(env *testcore.TestEnv, tv *testvars.TestVars, runTimeout time.Duration) string {
-	resp, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(), &workflowservice.StartWorkflowExecutionRequest{
+	resp, err := env.FrontendClient().StartWorkflowExecution(s.Context(), &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:           uuid.NewString(),
 		Namespace:           env.Namespace().String(),
 		WorkflowId:          tv.WorkflowID(),
@@ -702,7 +702,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_StartWithDelay() {
 	)
 	wallStart := time.Now()
 
-	startResp, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(), &workflowservice.StartWorkflowExecutionRequest{
+	startResp, err := env.FrontendClient().StartWorkflowExecution(s.Context(), &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:           uuid.NewString(),
 		Namespace:           env.Namespace().String(),
 		WorkflowId:          tv.WorkflowID(),
@@ -1001,7 +1001,7 @@ func (s *TimeSkippingTestSuite) TestWorkflowLifecycle_VirtualTimeContract() {
 	// Consequences:
 	//   - CloseTime − StartTime ≈ skip (≈ timerDuration).  (this is virtualDuration)
 	//   - CloseTime − ExecutionTime ≈ skip.  (public reported duration)
-	desc, err := env.FrontendClient().DescribeWorkflowExecution(testcore.NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+	desc, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
 		Namespace: env.Namespace().String(),
 		Execution: &commonpb.WorkflowExecution{WorkflowId: tv.WorkflowID(), RunId: runID},
 	})
@@ -1205,7 +1205,7 @@ func (s *TimeSkippingTestSuite) TestWorkflowLifecycle_VirtualTimeContract() {
 func (s *TimeSkippingFastForwardFunctionalSuite) TestTimeSkipping_ExecutionTimeoutTimesOutIdleWorkflow() {
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 
 	const executionTimeout = 5 * time.Minute
 
@@ -1251,7 +1251,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkippingTransitionEventOrdersAfterOption
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
-	ctx := testcore.NewContext()
+	ctx := s.Context()
 
 	// Start WITHOUT time skipping.
 	startResp, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{

--- a/tests/timeskipping_test.go
+++ b/tests/timeskipping_test.go
@@ -578,7 +578,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_PendingSignalExternalBlocksSkip
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.TimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
-	ctx := env.Context()
+	ctx := s.Context()
 
 	// Target workflow B. No worker polls B; the SignalExternal RPC will land a
 	// WorkflowExecutionSignaled event in B's history directly. Distinct task

--- a/tests/transient_task_test.go
+++ b/tests/transient_task_test.go
@@ -51,7 +51,7 @@ func (s *TransientTaskSuite) TestTransientWorkflowTaskTimeout() {
 		Identity:            identity,
 	}
 
-	we, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	env.NoError(err0)
 	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -142,7 +142,7 @@ func (s *TransientTaskSuite) TestTransientWorkflowTaskHistorySize() {
 		Identity:            identity,
 	}
 
-	we, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	env.NoError(err0)
 	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -364,7 +364,7 @@ func (s *TransientTaskSuite) TestNoTransientWorkflowTaskAfterFlushBufferedEvents
 		Identity:            identity,
 	}
 
-	we, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	env.NoError(err0)
 
 	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -376,7 +376,7 @@ func (s *TransientTaskSuite) TestNoTransientWorkflowTaskAfterFlushBufferedEvents
 		if !continueAsNewAndSignal {
 			continueAsNewAndSignal = true
 			// this will create new event when there is in-flight workflow task, and the new event will be buffered
-			_, err := env.FrontendClient().SignalWorkflowExecution(env.Context(),
+			_, err := env.FrontendClient().SignalWorkflowExecution(s.Context(),
 				&workflowservice.SignalWorkflowExecutionRequest{
 					Namespace: env.Namespace().String(),
 					WorkflowExecution: &commonpb.WorkflowExecution{

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -45,27 +45,27 @@ func speculativeWorkflowTaskOutcomes(
 	return
 }
 
-func clearUpdateRegistryAndAbortPendingUpdates(s *testcore.TestEnv, tv *testvars.TestVars) {
-	closeShard(s, tv.WorkflowID())
+func clearUpdateRegistryAndAbortPendingUpdates(ctx context.Context, env *testcore.TestEnv, tv *testvars.TestVars) {
+	closeShard(ctx, env, tv.WorkflowID())
 }
 
-func loseUpdateRegistryAndAbandonPendingUpdates(s *testcore.TestEnv, tv *testvars.TestVars) {
-	cleanup := s.OverrideDynamicConfig(dynamicconfig.ShardFinalizerTimeout, 0)
+func loseUpdateRegistryAndAbandonPendingUpdates(ctx context.Context, env *testcore.TestEnv, tv *testvars.TestVars) {
+	cleanup := env.OverrideDynamicConfig(dynamicconfig.ShardFinalizerTimeout, 0)
 	defer cleanup()
-	closeShard(s, tv.WorkflowID())
+	closeShard(ctx, env, tv.WorkflowID())
 }
 
-func closeShard(s *testcore.TestEnv, wid string) {
-	s.T().Helper()
+func closeShard(ctx context.Context, env *testcore.TestEnv, wid string) {
+	env.T().Helper()
 
-	resp, err := s.FrontendClient().DescribeNamespace(s.Context(), &workflowservice.DescribeNamespaceRequest{
-		Namespace: s.Namespace().String(),
+	resp, err := env.FrontendClient().DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{
+		Namespace: env.Namespace().String(),
 	})
 	if err != nil {
-		s.T().Fatalf("Failed to describe namespace: %v", err)
+		env.T().Fatalf("Failed to describe namespace: %v", err)
 	}
 
-	s.CloseShard(resp.NamespaceInfo.Id, wid)
+	env.CloseShard(resp.NamespaceInfo.Id, wid)
 }
 
 type WorkflowUpdateSuite struct {
@@ -3410,7 +3410,7 @@ func (s *WorkflowUpdateSuite) TestScheduledSpeculativeWorkflowTask_LostUpdate() 
 	s.Nil(updateResult.response)
 
 	// Lose update registry. Speculative WFT and update registry disappear.
-	loseUpdateRegistryAndAbandonPendingUpdates(env, env.Tv())
+	loseUpdateRegistryAndAbandonPendingUpdates(s.Context(), env, env.Tv())
 
 	// Ensure, there is no WFT.
 	pollCtx, cancel := context.WithTimeout(s.Context(), common.MinLongPollTimeout*2)
@@ -3471,7 +3471,7 @@ func (s *WorkflowUpdateSuite) TestStartedSpeculativeWorkflowTask_LostUpdate() {
 	`, task.History)
 
 			// Lose update registry. Update is lost and NotFound error will be returned to RespondWorkflowTaskCompleted.
-			loseUpdateRegistryAndAbandonPendingUpdates(env, env.Tv())
+			loseUpdateRegistryAndAbandonPendingUpdates(s.Context(), env, env.Tv())
 
 			return env.UpdateAcceptCompleteCommands(env.Tv()), nil
 		case 3:
@@ -3586,7 +3586,7 @@ func (s *WorkflowUpdateSuite) TestFirstNormalWorkflowTask_UpdateResurrectedAfter
 	  3 WorkflowTaskStarted
 	`, task.History)
 			// Clear update registry. Update will be resurrected in registry from acceptance message.
-			clearUpdateRegistryAndAbortPendingUpdates(env, env.Tv())
+			clearUpdateRegistryAndAbortPendingUpdates(s.Context(), env, env.Tv())
 
 			return env.UpdateAcceptCompleteCommands(env.Tv()), nil
 		case 2:
@@ -3964,7 +3964,7 @@ func (s *WorkflowUpdateSuite) TestCompletedSpeculativeWorkflowTask_DeduplicateID
 
 			if tc.CloseShard {
 				// Close shard to make sure that for completed updates deduplication works even after shard reload.
-				closeShard(env, env.Tv().WorkflowID())
+				closeShard(s.Context(), env, env.Tv().WorkflowID())
 			}
 
 			// Send second update with the same ID. It must return immediately.
@@ -4099,7 +4099,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_BecauseOfDif
 	  7 WorkflowTaskStarted`, wt2.History)
 
 	// Clear update registry. Speculative WFT disappears from server.
-	clearUpdateRegistryAndAbortPendingUpdates(env, env.Tv())
+	clearUpdateRegistryAndAbortPendingUpdates(s.Context(), env, env.Tv())
 
 	// Wait for update request to be retry by frontend and recreated in registry. This will create a 3rd WFT as speculative.
 	waitUpdateAdmitted(env, env.Tv())
@@ -4229,7 +4229,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_BecauseOfDif
 	  6 WorkflowTaskStarted`, wt2.History)
 
 	// Clear update registry. Speculative WFT disappears from server.
-	clearUpdateRegistryAndAbortPendingUpdates(env, env.Tv())
+	clearUpdateRegistryAndAbortPendingUpdates(s.Context(), env, env.Tv())
 
 	// Wait for update request to be retry by frontend and recreated in registry. This will create a 3rd WFT as speculative.
 	waitUpdateAdmitted(env, env.Tv())
@@ -4341,7 +4341,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_NewWorkflowT
 	  6 WorkflowTaskStarted`, wt2.History)
 
 	// Clear update registry. Speculative WFT disappears from server.
-	clearUpdateRegistryAndAbortPendingUpdates(env, env.Tv())
+	clearUpdateRegistryAndAbortPendingUpdates(s.Context(), env, env.Tv())
 
 	// Make sure UpdateWorkflowExecution call for the update "1" is retried and new (3rd) WFT is created as speculative with updateID=1.
 	waitUpdateAdmitted(env, tv1)

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -934,7 +934,7 @@ func (s *WorkflowUpdateSuite) TestCompletedWorkflow() {
 		s.NoError(err)
 
 		// Send Update request.
-		updateResultCh := sendUpdate(testcore.NewContext(env.Context()), env, env.Tv())
+		updateResultCh := sendUpdate(testcore.NewContext(s.Context()), env, env.Tv())
 
 		// Accept Update and complete Workflow.
 		_, err = poller.PollAndProcessWorkflowTask(testcore.WithoutRetries)
@@ -946,7 +946,7 @@ func (s *WorkflowUpdateSuite) TestCompletedWorkflow() {
 		s.Equal("Workflow Update failed because the Workflow completed before the Update completed.", updateResult1.response.GetOutcome().GetFailure().GetMessage())
 
 		// Send same Update request again, receiving the same failure.
-		updateResultCh = sendUpdate(testcore.NewContext(env.Context()), env, env.Tv())
+		updateResultCh = sendUpdate(testcore.NewContext(s.Context()), env, env.Tv())
 		updateResult2 := <-updateResultCh
 		s.NoError(updateResult2.err)
 		s.Equal("Workflow Update failed because the Workflow completed before the Update completed.", updateResult2.response.GetOutcome().GetFailure().GetMessage())
@@ -1291,7 +1291,7 @@ func (s *WorkflowUpdateSuite) TestValidateWorkerMessages() {
 				T:                   s.T(),
 			}
 
-			fiveSecondTimeoutCtx, cancel := context.WithTimeout(env.Context(), 5*time.Second)
+			fiveSecondTimeoutCtx, cancel := context.WithTimeout(s.Context(), 5*time.Second)
 			defer cancel()
 			updateResultCh := sendUpdate(fiveSecondTimeoutCtx, env, env.Tv())
 
@@ -2166,7 +2166,7 @@ func (s *WorkflowUpdateSuite) TestSpeculativeWorkflowTask_Fail() {
 	s.NoError(err)
 
 	// Use test context with shorter timeout for this specific operation
-	timeoutCtx, cancel := context.WithTimeout(env.Context(), 2*time.Second)
+	timeoutCtx, cancel := context.WithTimeout(s.Context(), 2*time.Second)
 	defer cancel()
 	updateResultCh := sendUpdate(timeoutCtx, env, env.Tv())
 
@@ -2555,7 +2555,7 @@ func (s *WorkflowUpdateSuite) TestSpeculativeWorkflowTask_StartToCloseTimeout() 
 		WorkflowTaskTimeout: durationpb.New(1 * time.Second), // Important!
 	}
 
-	_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(env.Context()), request)
+	_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(s.Context()), request)
 	s.NoError(err)
 
 	wtHandlerCalls := 0
@@ -2867,7 +2867,7 @@ func (s *WorkflowUpdateSuite) TestStartedSpeculativeWorkflowTask_TerminateWorkfl
 			return nil, nil
 		case 2:
 			// Terminate workflow while speculative WT is running.
-			_, err := env.FrontendClient().TerminateWorkflowExecution(testcore.NewContext(env.Context()), &workflowservice.TerminateWorkflowExecutionRequest{
+			_, err := env.FrontendClient().TerminateWorkflowExecution(testcore.NewContext(s.Context()), &workflowservice.TerminateWorkflowExecutionRequest{
 				Namespace:         env.Namespace().String(),
 				WorkflowExecution: env.Tv().WorkflowExecution(),
 				Reason:            env.Tv().Any().String(),
@@ -2919,7 +2919,7 @@ func (s *WorkflowUpdateSuite) TestStartedSpeculativeWorkflowTask_TerminateWorkfl
 	_, err := poller.PollAndProcessWorkflowTask()
 	s.NoError(err)
 
-	oneSecondTimeoutCtx, cancel := context.WithTimeout(env.Context(), 1*time.Second)
+	oneSecondTimeoutCtx, cancel := context.WithTimeout(s.Context(), 1*time.Second)
 	defer cancel()
 	updateResultCh := sendUpdate(oneSecondTimeoutCtx, env, env.Tv())
 
@@ -2951,7 +2951,7 @@ func (s *WorkflowUpdateSuite) TestStartedSpeculativeWorkflowTask_TerminateWorkfl
 	  7 WorkflowTaskFailed
 	  8 WorkflowExecutionTerminated`, events)
 
-	msResp, err := env.AdminClient().DescribeMutableState(testcore.NewContext(env.Context()), &adminservice.DescribeMutableStateRequest{
+	msResp, err := env.AdminClient().DescribeMutableState(testcore.NewContext(s.Context()), &adminservice.DescribeMutableStateRequest{
 		Namespace: env.Namespace().String(),
 		Execution: env.Tv().WorkflowExecution(),
 		Archetype: chasm.WorkflowArchetype,
@@ -3005,12 +3005,12 @@ func (s *WorkflowUpdateSuite) TestScheduledSpeculativeWorkflowTask_TerminateWork
 	_, err := poller.PollAndProcessWorkflowTask()
 	s.NoError(err)
 
-	oneSecondTimeoutCtx, cancel := context.WithTimeout(env.Context(), 1*time.Second)
+	oneSecondTimeoutCtx, cancel := context.WithTimeout(s.Context(), 1*time.Second)
 	defer cancel()
 	updateResultCh := sendUpdate(oneSecondTimeoutCtx, env, env.Tv())
 
 	// Terminate workflow after speculative WT is scheduled but not started.
-	_, err = env.FrontendClient().TerminateWorkflowExecution(testcore.NewContext(env.Context()), &workflowservice.TerminateWorkflowExecutionRequest{
+	_, err = env.FrontendClient().TerminateWorkflowExecution(testcore.NewContext(s.Context()), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace:         env.Namespace().String(),
 		WorkflowExecution: env.Tv().WorkflowExecution(),
 		Reason:            env.Tv().Any().String(),
@@ -3037,7 +3037,7 @@ func (s *WorkflowUpdateSuite) TestScheduledSpeculativeWorkflowTask_TerminateWork
 	  5 WorkflowExecutionTerminated // Speculative WTScheduled event is not written to history if WF is terminated.
 	`, events)
 
-	msResp, err := env.AdminClient().DescribeMutableState(testcore.NewContext(env.Context()), &adminservice.DescribeMutableStateRequest{
+	msResp, err := env.AdminClient().DescribeMutableState(testcore.NewContext(s.Context()), &adminservice.DescribeMutableStateRequest{
 		Namespace: env.Namespace().String(),
 		Execution: env.Tv().WorkflowExecution(),
 		Archetype: chasm.WorkflowArchetype,
@@ -3224,7 +3224,7 @@ func (s *WorkflowUpdateSuite) TestCompleteWorkflow_AbortUpdates() {
 				_, err := poller.PollAndProcessWorkflowTask()
 				s.NoError(err)
 
-				updateResultCh := sendUpdate(testcore.NewContext(env.Context()), env, tv)
+				updateResultCh := sendUpdate(testcore.NewContext(s.Context()), env, tv)
 
 				// Complete workflow.
 				_, err = poller.PollAndProcessWorkflowTask()
@@ -3254,7 +3254,7 @@ func (s *WorkflowUpdateSuite) TestCompleteWorkflow_AbortUpdates() {
 				}
 
 				// Check that update didn't block workflow completion.
-				descResp, err := env.FrontendClient().DescribeWorkflowExecution(testcore.NewContext(env.Context()), &workflowservice.DescribeWorkflowExecutionRequest{
+				descResp, err := env.FrontendClient().DescribeWorkflowExecution(testcore.NewContext(s.Context()), &workflowservice.DescribeWorkflowExecutionRequest{
 					Namespace: env.Namespace().String(),
 					Execution: tv.WorkflowExecution(),
 				})
@@ -3402,7 +3402,7 @@ func (s *WorkflowUpdateSuite) TestScheduledSpeculativeWorkflowTask_LostUpdate() 
 	_, err := poller.PollAndProcessWorkflowTask()
 	s.NoError(err)
 
-	halfSecondTimeoutCtx, cancel := context.WithTimeout(env.Context(), 500*time.Millisecond)
+	halfSecondTimeoutCtx, cancel := context.WithTimeout(s.Context(), 500*time.Millisecond)
 	defer cancel()
 	updateResult := <-sendUpdate(halfSecondTimeoutCtx, env, env.Tv())
 	s.Error(updateResult.err)
@@ -3413,7 +3413,7 @@ func (s *WorkflowUpdateSuite) TestScheduledSpeculativeWorkflowTask_LostUpdate() 
 	loseUpdateRegistryAndAbandonPendingUpdates(env, env.Tv())
 
 	// Ensure, there is no WFT.
-	pollCtx, cancel := context.WithTimeout(env.Context(), common.MinLongPollTimeout*2)
+	pollCtx, cancel := context.WithTimeout(s.Context(), common.MinLongPollTimeout*2)
 	defer cancel()
 	pollResponse, err := env.FrontendClient().PollWorkflowTaskQueue(pollCtx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: env.Namespace().String(),
@@ -3530,7 +3530,7 @@ func (s *WorkflowUpdateSuite) TestStartedSpeculativeWorkflowTask_LostUpdate() {
 	_, err := poller.PollAndProcessWorkflowTask()
 	s.NoError(err)
 
-	halfSecondTimeoutCtx, cancel := context.WithTimeout(env.Context(), 500*time.Millisecond)
+	halfSecondTimeoutCtx, cancel := context.WithTimeout(s.Context(), 500*time.Millisecond)
 	defer cancel()
 	updateResultCh := sendUpdate(halfSecondTimeoutCtx, env, env.Tv())
 
@@ -3971,7 +3971,7 @@ func (s *WorkflowUpdateSuite) TestCompletedSpeculativeWorkflowTask_DeduplicateID
 			updateResult2 := <-sendUpdateNoError(env, env.Tv())
 
 			// Ensure, there is no new WT.
-			pollCtx, cancel := context.WithTimeout(env.Context(), common.MinLongPollTimeout*2)
+			pollCtx, cancel := context.WithTimeout(s.Context(), common.MinLongPollTimeout*2)
 			defer cancel()
 			pollResponse, err := env.FrontendClient().PollWorkflowTaskQueue(pollCtx, &workflowservice.PollWorkflowTaskQueueRequest{
 				Namespace: env.Namespace().String(),
@@ -4079,7 +4079,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_BecauseOfDif
 	sendUpdateNoError(env, env.Tv())
 
 	// Poll 2nd speculative WT with 1st update.
-	wt2, err := env.FrontendClient().PollWorkflowTaskQueue(testcore.NewContext(env.Context()), &workflowservice.PollWorkflowTaskQueueRequest{
+	wt2, err := env.FrontendClient().PollWorkflowTaskQueue(testcore.NewContext(s.Context()), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: env.Namespace().String(),
 		TaskQueue: env.Tv().TaskQueue(),
 	})
@@ -4109,7 +4109,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_BecauseOfDif
 	s.NoError(err)
 
 	// Poll the 3rd WFT (not speculative anymore) but must have 2nd update.
-	wt3, err := env.FrontendClient().PollWorkflowTaskQueue(testcore.NewContext(env.Context()), &workflowservice.PollWorkflowTaskQueueRequest{
+	wt3, err := env.FrontendClient().PollWorkflowTaskQueue(testcore.NewContext(s.Context()), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: env.Namespace().String(),
 		TaskQueue: env.Tv().TaskQueue(),
 	})
@@ -4131,7 +4131,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_BecauseOfDif
 	  9 WorkflowTaskStarted`, wt3.History)
 
 	// Now try to complete 2nd WT (speculative). It should fail because WorkflowTaskStarted event Id is mismatched.
-	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(testcore.NewContext(env.Context()), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(testcore.NewContext(s.Context()), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace: env.Namespace().String(),
 		TaskToken: wt2.TaskToken,
 		Commands:  env.UpdateAcceptCompleteCommands(env.Tv()),
@@ -4142,7 +4142,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_BecauseOfDif
 	s.Contains(err.Error(), "Workflow task not found")
 
 	// Complete 3rd WT. It should succeed.
-	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(testcore.NewContext(env.Context()), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(testcore.NewContext(s.Context()), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace: env.Namespace().String(),
 		TaskToken: wt3.TaskToken,
 		Commands:  env.UpdateAcceptCompleteCommands(env.Tv()),
@@ -4210,7 +4210,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_BecauseOfDif
 	sendUpdateNoError(env, env.Tv())
 
 	// Poll 2nd speculative WT with 1st update.
-	wt2, err := env.FrontendClient().PollWorkflowTaskQueue(testcore.NewContext(env.Context()), &workflowservice.PollWorkflowTaskQueueRequest{
+	wt2, err := env.FrontendClient().PollWorkflowTaskQueue(testcore.NewContext(s.Context()), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: env.Namespace().String(),
 		TaskQueue: env.Tv().TaskQueue(),
 	})
@@ -4235,7 +4235,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_BecauseOfDif
 	waitUpdateAdmitted(env, env.Tv())
 
 	// Poll for the 3rd speculative WT.
-	wt3, err := env.FrontendClient().PollWorkflowTaskQueue(testcore.NewContext(env.Context()), &workflowservice.PollWorkflowTaskQueueRequest{
+	wt3, err := env.FrontendClient().PollWorkflowTaskQueue(testcore.NewContext(s.Context()), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: env.Namespace().String(),
 		TaskQueue: env.Tv().TaskQueue(),
 	})
@@ -4254,7 +4254,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_BecauseOfDif
 	  6 WorkflowTaskStarted`, wt3.History)
 
 	// Now try to complete 2nd (speculative) WT, it should fail.
-	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(testcore.NewContext(env.Context()), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(testcore.NewContext(s.Context()), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace: env.Namespace().String(),
 		TaskToken: wt2.TaskToken,
 		Commands:  env.UpdateAcceptCompleteCommands(env.Tv()),
@@ -4265,7 +4265,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_BecauseOfDif
 	s.Contains(err.Error(), "Workflow task not found")
 
 	// Try to complete 3rd WT, it should succeed
-	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(testcore.NewContext(env.Context()), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(testcore.NewContext(s.Context()), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace: env.Namespace().String(),
 		TaskToken: wt3.TaskToken,
 		Commands:  env.UpdateAcceptCompleteCommands(env.Tv()),
@@ -4303,7 +4303,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_NewWorkflowT
 	tv1 := env.Tv().WithUpdateIDNumber(1).WithMessageIDNumber(1)
 	tv2 := env.Tv().WithUpdateIDNumber(2).WithMessageIDNumber(2)
 
-	testCtx := testcore.NewContext(env.Context())
+	testCtx := testcore.NewContext(s.Context())
 
 	// Drain first WFT.
 	wt1, err := env.FrontendClient().PollWorkflowTaskQueue(testCtx, &workflowservice.PollWorkflowTaskQueueRequest{
@@ -4650,7 +4650,7 @@ func (s *WorkflowUpdateSuite) TestSpeculativeWorkflowTask_QueryBufferFullDoesNot
 		Err  error
 	}
 
-	queryCtx, cancelQueries := context.WithCancel(env.Context())
+	queryCtx, cancelQueries := context.WithCancel(s.Context())
 	defer cancelQueries()
 
 	queryFn := func(resCh chan<- QueryResult) {
@@ -4873,7 +4873,7 @@ func (s *WorkflowUpdateSuite) TestContinueAsNew_UpdateIsNotCarriedOver() {
 		Identity:  env.Tv().WorkerIdentity(),
 		WorkflowTaskHandler: func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
 			// Send 2nd Update while WFT is running.
-			update2ResponseCh = sendUpdate(env.Context(), env, tv2)
+			update2ResponseCh = sendUpdate(s.Context(), env, tv2)
 			canCommand := &commandpb.Command{
 				CommandType: enumspb.COMMAND_TYPE_CONTINUE_AS_NEW_WORKFLOW_EXECUTION,
 				Attributes: &commandpb.Command_ContinueAsNewWorkflowExecutionCommandAttributes{ContinueAsNewWorkflowExecutionCommandAttributes: &commandpb.ContinueAsNewWorkflowExecutionCommandAttributes{
@@ -4907,7 +4907,7 @@ func (s *WorkflowUpdateSuite) TestContinueAsNew_UpdateIsNotCarriedOver() {
 		T:      s.T(),
 	}
 
-	update1ResponseCh := sendUpdate(env.Context(), env, tv1)
+	update1ResponseCh := sendUpdate(s.Context(), env, tv1)
 	_, err := poller1.PollAndProcessWorkflowTask()
 	s.NoError(err)
 
@@ -5001,7 +5001,7 @@ type multiopsResponseErr struct {
 }
 
 func (s *UpdateWithStartSuite) sendUpdateWithStart(env *testcore.TestEnv, startReq *workflowservice.StartWorkflowExecutionRequest, updateReq *workflowservice.UpdateWorkflowExecutionRequest) chan multiopsResponseErr {
-	ctx := testcore.NewContext(env.Context())
+	ctx := testcore.NewContext(s.Context())
 	capture := env.StartNamespaceMetricCapture()
 
 	retCh := make(chan multiopsResponseErr)
@@ -5163,7 +5163,7 @@ func (s *UpdateWithStartSuite) TestWorkflowIsRunning() {
 			env := testcore.NewEnv(s.T())
 
 			// start workflow
-			_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(env.Context()), s.updateWithStartReq(env, env.Tv()))
+			_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(s.Context()), s.updateWithStartReq(env, env.Tv()))
 			s.NoError(err)
 
 			_, err = env.TaskPoller().PollAndHandleWorkflowTask(env.Tv(), taskpoller.DrainWorkflowTask)
@@ -5220,7 +5220,7 @@ func (s *UpdateWithStartSuite) TestWorkflowIsRunning() {
 			env := testcore.NewEnv(s.T())
 
 			// start workflow
-			_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(env.Context()), s.updateWithStartReq(env, env.Tv()))
+			_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(s.Context()), s.updateWithStartReq(env, env.Tv()))
 			s.NoError(err)
 
 			_, err = env.TaskPoller().PollAndHandleWorkflowTask(env.Tv(), taskpoller.DrainWorkflowTask)
@@ -5275,7 +5275,7 @@ func (s *UpdateWithStartSuite) TestWorkflowIsRunning() {
 			env := testcore.NewEnv(s.T())
 
 			// start workflow
-			firstWF, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(env.Context()), s.updateWithStartReq(env, env.Tv()))
+			firstWF, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(s.Context()), s.updateWithStartReq(env, env.Tv()))
 			s.NoError(err)
 
 			_, err = env.TaskPoller().PollAndHandleWorkflowTask(env.Tv(), taskpoller.DrainWorkflowTask)
@@ -5305,7 +5305,7 @@ func (s *UpdateWithStartSuite) TestWorkflowIsRunning() {
 			s.Equal("success-result-of-"+env.Tv().UpdateID(), testcore.DecodeString(s.T(), updateRep.GetOutcome().GetSuccess()))
 
 			// ensure workflow was terminated
-			descResp, err := env.FrontendClient().DescribeWorkflowExecution(testcore.NewContext(env.Context()),
+			descResp, err := env.FrontendClient().DescribeWorkflowExecution(testcore.NewContext(s.Context()),
 				&workflowservice.DescribeWorkflowExecutionRequest{
 					Namespace: env.Namespace().String(),
 					Execution: &commonpb.WorkflowExecution{WorkflowId: startReq.WorkflowId, RunId: firstWF.RunId},
@@ -5362,7 +5362,7 @@ func (s *UpdateWithStartSuite) TestWorkflowIsRunning() {
 
 	s.Run("workflow id conflict policy fail: abort multi operation", func(s *UpdateWithStartSuite) {
 		env := testcore.NewEnv(s.T())
-		_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(env.Context()), s.updateWithStartReq(env, env.Tv()))
+		_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(s.Context()), s.updateWithStartReq(env, env.Tv()))
 		s.NoError(err)
 
 		// start workflow
@@ -5478,13 +5478,13 @@ func (s *UpdateWithStartSuite) TestWorkflowIsClosed() {
 		env := testcore.NewEnv(s.T())
 
 		// start and terminate workflow
-		initialWorkflow, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(env.Context()), s.updateWithStartReq(env, env.Tv()))
+		initialWorkflow, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(s.Context()), s.updateWithStartReq(env, env.Tv()))
 		s.NoError(err)
 
 		_, err = env.TaskPoller().PollAndHandleWorkflowTask(env.Tv(), taskpoller.DrainWorkflowTask)
 		s.NoError(err)
 
-		_, err = env.FrontendClient().TerminateWorkflowExecution(testcore.NewContext(env.Context()),
+		_, err = env.FrontendClient().TerminateWorkflowExecution(testcore.NewContext(s.Context()),
 			&workflowservice.TerminateWorkflowExecutionRequest{
 				Namespace:         env.Namespace().String(),
 				WorkflowExecution: env.Tv().WorkflowExecution(),
@@ -5532,13 +5532,13 @@ func (s *UpdateWithStartSuite) TestWorkflowIsClosed() {
 		env := testcore.NewEnv(s.T())
 
 		// start and terminate workflow
-		_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(env.Context()), s.updateWithStartReq(env, env.Tv()))
+		_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(s.Context()), s.updateWithStartReq(env, env.Tv()))
 		s.NoError(err)
 
 		_, err = env.TaskPoller().PollAndHandleWorkflowTask(env.Tv(), taskpoller.DrainWorkflowTask)
 		s.NoError(err)
 
-		_, err = env.FrontendClient().TerminateWorkflowExecution(testcore.NewContext(env.Context()),
+		_, err = env.FrontendClient().TerminateWorkflowExecution(testcore.NewContext(s.Context()),
 			&workflowservice.TerminateWorkflowExecutionRequest{
 				Namespace:         env.Namespace().String(),
 				WorkflowExecution: env.Tv().WorkflowExecution(),
@@ -5596,7 +5596,7 @@ func (s *UpdateWithStartSuite) TestWorkflowIsClosed() {
 				requireStartedAndRunning(s.T(), startResp1)
 
 				// terminate workflow
-				_, err = env.FrontendClient().TerminateWorkflowExecution(testcore.NewContext(env.Context()),
+				_, err = env.FrontendClient().TerminateWorkflowExecution(testcore.NewContext(s.Context()),
 					&workflowservice.TerminateWorkflowExecutionRequest{
 						Namespace:         env.Namespace().String(),
 						WorkflowExecution: env.Tv().WorkflowExecution(),
@@ -5629,7 +5629,7 @@ func (s *UpdateWithStartSuite) TestWorkflowStartConflict() {
 
 		// simulate a race condition
 		env.InjectHook(testhooks.NewHook(testhooks.UpdateWithStartInBetweenLockAndStart, func() {
-			_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(env.Context()), startReq)
+			_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(s.Context()), startReq)
 			s.NoError(err)
 		}))
 
@@ -5669,7 +5669,7 @@ func (s *UpdateWithStartSuite) TestUpdateIsAbortedByClosingWorkflow() {
 		env := testcore.NewEnv(s.T())
 
 		// start workflow
-		_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(env.Context()), s.updateWithStartReq(env, env.Tv()))
+		_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(s.Context()), s.updateWithStartReq(env, env.Tv()))
 		s.NoError(err)
 		_, err = env.TaskPoller().PollAndHandleWorkflowTask(env.Tv(), taskpoller.DrainWorkflowTask)
 		s.NoError(err)
@@ -5716,7 +5716,7 @@ func (s *UpdateWithStartSuite) TestUpdateIsAbortedByClosingWorkflow() {
 		env := testcore.NewEnv(s.T())
 
 		// start workflow
-		_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(env.Context()), s.updateWithStartReq(env, env.Tv()))
+		_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(s.Context()), s.updateWithStartReq(env, env.Tv()))
 		s.NoError(err)
 		_, err = env.TaskPoller().PollAndHandleWorkflowTask(env.Tv(), taskpoller.DrainWorkflowTask)
 		s.NoError(err)
@@ -5732,7 +5732,7 @@ func (s *UpdateWithStartSuite) TestUpdateIsAbortedByClosingWorkflow() {
 		waitUpdateAdmitted(env, env.Tv())
 
 		env.InjectHook(testhooks.NewHook(testhooks.UpdateWithStartOnClosingWorkflowRetry, func() {
-			_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(env.Context()), s.updateWithStartReq(env, env.Tv()))
+			_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(s.Context()), s.updateWithStartReq(env, env.Tv()))
 			s.NoError(err)
 		}))
 
@@ -5805,7 +5805,7 @@ func (s *UpdateWithStartSuite) TestReturnUpdateRateLimitError() {
 		testcore.WithDynamicConfig(dynamicconfig.WorkflowExecutionMaxTotalUpdates, 1),
 	)
 
-	ctx := testcore.NewContext(env.Context())
+	ctx := testcore.NewContext(s.Context())
 	startReq := s.updateWithStartReq(env, env.Tv())
 	startReq.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING
 
@@ -5845,7 +5845,7 @@ func (s *UpdateWithStartSuite) TestReturnUpdateInFlightLimitError() {
 		testcore.WithDynamicConfig(dynamicconfig.WorkflowExecutionMaxInFlightUpdates, maxInFlight),
 	)
 
-	ctx := testcore.NewContext(env.Context())
+	ctx := testcore.NewContext(s.Context())
 	startReq := s.updateWithStartReq(env, env.Tv())
 	startReq.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING
 

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -58,7 +58,7 @@ func loseUpdateRegistryAndAbandonPendingUpdates(s *testcore.TestEnv, tv *testvar
 func closeShard(s *testcore.TestEnv, wid string) {
 	s.T().Helper()
 
-	resp, err := s.FrontendClient().DescribeNamespace(testcore.NewContext(s.Context()), &workflowservice.DescribeNamespaceRequest{
+	resp, err := s.FrontendClient().DescribeNamespace(s.Context(), &workflowservice.DescribeNamespaceRequest{
 		Namespace: s.Namespace().String(),
 	})
 	if err != nil {
@@ -934,7 +934,7 @@ func (s *WorkflowUpdateSuite) TestCompletedWorkflow() {
 		s.NoError(err)
 
 		// Send Update request.
-		updateResultCh := sendUpdate(testcore.NewContext(s.Context()), env, env.Tv())
+		updateResultCh := sendUpdate(s.Context(), env, env.Tv())
 
 		// Accept Update and complete Workflow.
 		_, err = poller.PollAndProcessWorkflowTask(testcore.WithoutRetries)
@@ -946,7 +946,7 @@ func (s *WorkflowUpdateSuite) TestCompletedWorkflow() {
 		s.Equal("Workflow Update failed because the Workflow completed before the Update completed.", updateResult1.response.GetOutcome().GetFailure().GetMessage())
 
 		// Send same Update request again, receiving the same failure.
-		updateResultCh = sendUpdate(testcore.NewContext(s.Context()), env, env.Tv())
+		updateResultCh = sendUpdate(s.Context(), env, env.Tv())
 		updateResult2 := <-updateResultCh
 		s.NoError(updateResult2.err)
 		s.Equal("Workflow Update failed because the Workflow completed before the Update completed.", updateResult2.response.GetOutcome().GetFailure().GetMessage())
@@ -2555,7 +2555,7 @@ func (s *WorkflowUpdateSuite) TestSpeculativeWorkflowTask_StartToCloseTimeout() 
 		WorkflowTaskTimeout: durationpb.New(1 * time.Second), // Important!
 	}
 
-	_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(s.Context()), request)
+	_, err := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err)
 
 	wtHandlerCalls := 0
@@ -2867,7 +2867,7 @@ func (s *WorkflowUpdateSuite) TestStartedSpeculativeWorkflowTask_TerminateWorkfl
 			return nil, nil
 		case 2:
 			// Terminate workflow while speculative WT is running.
-			_, err := env.FrontendClient().TerminateWorkflowExecution(testcore.NewContext(s.Context()), &workflowservice.TerminateWorkflowExecutionRequest{
+			_, err := env.FrontendClient().TerminateWorkflowExecution(s.Context(), &workflowservice.TerminateWorkflowExecutionRequest{
 				Namespace:         env.Namespace().String(),
 				WorkflowExecution: env.Tv().WorkflowExecution(),
 				Reason:            env.Tv().Any().String(),
@@ -2951,7 +2951,7 @@ func (s *WorkflowUpdateSuite) TestStartedSpeculativeWorkflowTask_TerminateWorkfl
 	  7 WorkflowTaskFailed
 	  8 WorkflowExecutionTerminated`, events)
 
-	msResp, err := env.AdminClient().DescribeMutableState(testcore.NewContext(s.Context()), &adminservice.DescribeMutableStateRequest{
+	msResp, err := env.AdminClient().DescribeMutableState(s.Context(), &adminservice.DescribeMutableStateRequest{
 		Namespace: env.Namespace().String(),
 		Execution: env.Tv().WorkflowExecution(),
 		Archetype: chasm.WorkflowArchetype,
@@ -3010,7 +3010,7 @@ func (s *WorkflowUpdateSuite) TestScheduledSpeculativeWorkflowTask_TerminateWork
 	updateResultCh := sendUpdate(oneSecondTimeoutCtx, env, env.Tv())
 
 	// Terminate workflow after speculative WT is scheduled but not started.
-	_, err = env.FrontendClient().TerminateWorkflowExecution(testcore.NewContext(s.Context()), &workflowservice.TerminateWorkflowExecutionRequest{
+	_, err = env.FrontendClient().TerminateWorkflowExecution(s.Context(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace:         env.Namespace().String(),
 		WorkflowExecution: env.Tv().WorkflowExecution(),
 		Reason:            env.Tv().Any().String(),
@@ -3037,7 +3037,7 @@ func (s *WorkflowUpdateSuite) TestScheduledSpeculativeWorkflowTask_TerminateWork
 	  5 WorkflowExecutionTerminated // Speculative WTScheduled event is not written to history if WF is terminated.
 	`, events)
 
-	msResp, err := env.AdminClient().DescribeMutableState(testcore.NewContext(s.Context()), &adminservice.DescribeMutableStateRequest{
+	msResp, err := env.AdminClient().DescribeMutableState(s.Context(), &adminservice.DescribeMutableStateRequest{
 		Namespace: env.Namespace().String(),
 		Execution: env.Tv().WorkflowExecution(),
 		Archetype: chasm.WorkflowArchetype,
@@ -3224,7 +3224,7 @@ func (s *WorkflowUpdateSuite) TestCompleteWorkflow_AbortUpdates() {
 				_, err := poller.PollAndProcessWorkflowTask()
 				s.NoError(err)
 
-				updateResultCh := sendUpdate(testcore.NewContext(s.Context()), env, tv)
+				updateResultCh := sendUpdate(s.Context(), env, tv)
 
 				// Complete workflow.
 				_, err = poller.PollAndProcessWorkflowTask()
@@ -3254,7 +3254,7 @@ func (s *WorkflowUpdateSuite) TestCompleteWorkflow_AbortUpdates() {
 				}
 
 				// Check that update didn't block workflow completion.
-				descResp, err := env.FrontendClient().DescribeWorkflowExecution(testcore.NewContext(s.Context()), &workflowservice.DescribeWorkflowExecutionRequest{
+				descResp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
 					Namespace: env.Namespace().String(),
 					Execution: tv.WorkflowExecution(),
 				})
@@ -4079,7 +4079,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_BecauseOfDif
 	sendUpdateNoError(env, env.Tv())
 
 	// Poll 2nd speculative WT with 1st update.
-	wt2, err := env.FrontendClient().PollWorkflowTaskQueue(testcore.NewContext(s.Context()), &workflowservice.PollWorkflowTaskQueueRequest{
+	wt2, err := env.FrontendClient().PollWorkflowTaskQueue(s.Context(), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: env.Namespace().String(),
 		TaskQueue: env.Tv().TaskQueue(),
 	})
@@ -4109,7 +4109,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_BecauseOfDif
 	s.NoError(err)
 
 	// Poll the 3rd WFT (not speculative anymore) but must have 2nd update.
-	wt3, err := env.FrontendClient().PollWorkflowTaskQueue(testcore.NewContext(s.Context()), &workflowservice.PollWorkflowTaskQueueRequest{
+	wt3, err := env.FrontendClient().PollWorkflowTaskQueue(s.Context(), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: env.Namespace().String(),
 		TaskQueue: env.Tv().TaskQueue(),
 	})
@@ -4131,7 +4131,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_BecauseOfDif
 	  9 WorkflowTaskStarted`, wt3.History)
 
 	// Now try to complete 2nd WT (speculative). It should fail because WorkflowTaskStarted event Id is mismatched.
-	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(testcore.NewContext(s.Context()), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(s.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace: env.Namespace().String(),
 		TaskToken: wt2.TaskToken,
 		Commands:  env.UpdateAcceptCompleteCommands(env.Tv()),
@@ -4142,7 +4142,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_BecauseOfDif
 	s.Contains(err.Error(), "Workflow task not found")
 
 	// Complete 3rd WT. It should succeed.
-	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(testcore.NewContext(s.Context()), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(s.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace: env.Namespace().String(),
 		TaskToken: wt3.TaskToken,
 		Commands:  env.UpdateAcceptCompleteCommands(env.Tv()),
@@ -4210,7 +4210,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_BecauseOfDif
 	sendUpdateNoError(env, env.Tv())
 
 	// Poll 2nd speculative WT with 1st update.
-	wt2, err := env.FrontendClient().PollWorkflowTaskQueue(testcore.NewContext(s.Context()), &workflowservice.PollWorkflowTaskQueueRequest{
+	wt2, err := env.FrontendClient().PollWorkflowTaskQueue(s.Context(), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: env.Namespace().String(),
 		TaskQueue: env.Tv().TaskQueue(),
 	})
@@ -4235,7 +4235,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_BecauseOfDif
 	waitUpdateAdmitted(env, env.Tv())
 
 	// Poll for the 3rd speculative WT.
-	wt3, err := env.FrontendClient().PollWorkflowTaskQueue(testcore.NewContext(s.Context()), &workflowservice.PollWorkflowTaskQueueRequest{
+	wt3, err := env.FrontendClient().PollWorkflowTaskQueue(s.Context(), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: env.Namespace().String(),
 		TaskQueue: env.Tv().TaskQueue(),
 	})
@@ -4254,7 +4254,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_BecauseOfDif
 	  6 WorkflowTaskStarted`, wt3.History)
 
 	// Now try to complete 2nd (speculative) WT, it should fail.
-	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(testcore.NewContext(s.Context()), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(s.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace: env.Namespace().String(),
 		TaskToken: wt2.TaskToken,
 		Commands:  env.UpdateAcceptCompleteCommands(env.Tv()),
@@ -4265,7 +4265,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_BecauseOfDif
 	s.Contains(err.Error(), "Workflow task not found")
 
 	// Try to complete 3rd WT, it should succeed
-	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(testcore.NewContext(s.Context()), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(s.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace: env.Namespace().String(),
 		TaskToken: wt3.TaskToken,
 		Commands:  env.UpdateAcceptCompleteCommands(env.Tv()),
@@ -4303,7 +4303,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_NewWorkflowT
 	tv1 := env.Tv().WithUpdateIDNumber(1).WithMessageIDNumber(1)
 	tv2 := env.Tv().WithUpdateIDNumber(2).WithMessageIDNumber(2)
 
-	testCtx := testcore.NewContext(s.Context())
+	testCtx := s.Context()
 
 	// Drain first WFT.
 	wt1, err := env.FrontendClient().PollWorkflowTaskQueue(testCtx, &workflowservice.PollWorkflowTaskQueueRequest{
@@ -5001,7 +5001,7 @@ type multiopsResponseErr struct {
 }
 
 func (s *UpdateWithStartSuite) sendUpdateWithStart(env *testcore.TestEnv, startReq *workflowservice.StartWorkflowExecutionRequest, updateReq *workflowservice.UpdateWorkflowExecutionRequest) chan multiopsResponseErr {
-	ctx := testcore.NewContext(s.Context())
+	ctx := s.Context()
 	capture := env.StartNamespaceMetricCapture()
 
 	retCh := make(chan multiopsResponseErr)
@@ -5163,7 +5163,7 @@ func (s *UpdateWithStartSuite) TestWorkflowIsRunning() {
 			env := testcore.NewEnv(s.T())
 
 			// start workflow
-			_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(s.Context()), s.updateWithStartReq(env, env.Tv()))
+			_, err := env.FrontendClient().StartWorkflowExecution(s.Context(), s.updateWithStartReq(env, env.Tv()))
 			s.NoError(err)
 
 			_, err = env.TaskPoller().PollAndHandleWorkflowTask(env.Tv(), taskpoller.DrainWorkflowTask)
@@ -5220,7 +5220,7 @@ func (s *UpdateWithStartSuite) TestWorkflowIsRunning() {
 			env := testcore.NewEnv(s.T())
 
 			// start workflow
-			_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(s.Context()), s.updateWithStartReq(env, env.Tv()))
+			_, err := env.FrontendClient().StartWorkflowExecution(s.Context(), s.updateWithStartReq(env, env.Tv()))
 			s.NoError(err)
 
 			_, err = env.TaskPoller().PollAndHandleWorkflowTask(env.Tv(), taskpoller.DrainWorkflowTask)
@@ -5275,7 +5275,7 @@ func (s *UpdateWithStartSuite) TestWorkflowIsRunning() {
 			env := testcore.NewEnv(s.T())
 
 			// start workflow
-			firstWF, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(s.Context()), s.updateWithStartReq(env, env.Tv()))
+			firstWF, err := env.FrontendClient().StartWorkflowExecution(s.Context(), s.updateWithStartReq(env, env.Tv()))
 			s.NoError(err)
 
 			_, err = env.TaskPoller().PollAndHandleWorkflowTask(env.Tv(), taskpoller.DrainWorkflowTask)
@@ -5305,7 +5305,7 @@ func (s *UpdateWithStartSuite) TestWorkflowIsRunning() {
 			s.Equal("success-result-of-"+env.Tv().UpdateID(), testcore.DecodeString(s.T(), updateRep.GetOutcome().GetSuccess()))
 
 			// ensure workflow was terminated
-			descResp, err := env.FrontendClient().DescribeWorkflowExecution(testcore.NewContext(s.Context()),
+			descResp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(),
 				&workflowservice.DescribeWorkflowExecutionRequest{
 					Namespace: env.Namespace().String(),
 					Execution: &commonpb.WorkflowExecution{WorkflowId: startReq.WorkflowId, RunId: firstWF.RunId},
@@ -5362,7 +5362,7 @@ func (s *UpdateWithStartSuite) TestWorkflowIsRunning() {
 
 	s.Run("workflow id conflict policy fail: abort multi operation", func(s *UpdateWithStartSuite) {
 		env := testcore.NewEnv(s.T())
-		_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(s.Context()), s.updateWithStartReq(env, env.Tv()))
+		_, err := env.FrontendClient().StartWorkflowExecution(s.Context(), s.updateWithStartReq(env, env.Tv()))
 		s.NoError(err)
 
 		// start workflow
@@ -5478,13 +5478,13 @@ func (s *UpdateWithStartSuite) TestWorkflowIsClosed() {
 		env := testcore.NewEnv(s.T())
 
 		// start and terminate workflow
-		initialWorkflow, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(s.Context()), s.updateWithStartReq(env, env.Tv()))
+		initialWorkflow, err := env.FrontendClient().StartWorkflowExecution(s.Context(), s.updateWithStartReq(env, env.Tv()))
 		s.NoError(err)
 
 		_, err = env.TaskPoller().PollAndHandleWorkflowTask(env.Tv(), taskpoller.DrainWorkflowTask)
 		s.NoError(err)
 
-		_, err = env.FrontendClient().TerminateWorkflowExecution(testcore.NewContext(s.Context()),
+		_, err = env.FrontendClient().TerminateWorkflowExecution(s.Context(),
 			&workflowservice.TerminateWorkflowExecutionRequest{
 				Namespace:         env.Namespace().String(),
 				WorkflowExecution: env.Tv().WorkflowExecution(),
@@ -5532,13 +5532,13 @@ func (s *UpdateWithStartSuite) TestWorkflowIsClosed() {
 		env := testcore.NewEnv(s.T())
 
 		// start and terminate workflow
-		_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(s.Context()), s.updateWithStartReq(env, env.Tv()))
+		_, err := env.FrontendClient().StartWorkflowExecution(s.Context(), s.updateWithStartReq(env, env.Tv()))
 		s.NoError(err)
 
 		_, err = env.TaskPoller().PollAndHandleWorkflowTask(env.Tv(), taskpoller.DrainWorkflowTask)
 		s.NoError(err)
 
-		_, err = env.FrontendClient().TerminateWorkflowExecution(testcore.NewContext(s.Context()),
+		_, err = env.FrontendClient().TerminateWorkflowExecution(s.Context(),
 			&workflowservice.TerminateWorkflowExecutionRequest{
 				Namespace:         env.Namespace().String(),
 				WorkflowExecution: env.Tv().WorkflowExecution(),
@@ -5596,7 +5596,7 @@ func (s *UpdateWithStartSuite) TestWorkflowIsClosed() {
 				requireStartedAndRunning(s.T(), startResp1)
 
 				// terminate workflow
-				_, err = env.FrontendClient().TerminateWorkflowExecution(testcore.NewContext(s.Context()),
+				_, err = env.FrontendClient().TerminateWorkflowExecution(s.Context(),
 					&workflowservice.TerminateWorkflowExecutionRequest{
 						Namespace:         env.Namespace().String(),
 						WorkflowExecution: env.Tv().WorkflowExecution(),
@@ -5629,7 +5629,7 @@ func (s *UpdateWithStartSuite) TestWorkflowStartConflict() {
 
 		// simulate a race condition
 		env.InjectHook(testhooks.NewHook(testhooks.UpdateWithStartInBetweenLockAndStart, func() {
-			_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(s.Context()), startReq)
+			_, err := env.FrontendClient().StartWorkflowExecution(s.Context(), startReq)
 			s.NoError(err)
 		}))
 
@@ -5669,7 +5669,7 @@ func (s *UpdateWithStartSuite) TestUpdateIsAbortedByClosingWorkflow() {
 		env := testcore.NewEnv(s.T())
 
 		// start workflow
-		_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(s.Context()), s.updateWithStartReq(env, env.Tv()))
+		_, err := env.FrontendClient().StartWorkflowExecution(s.Context(), s.updateWithStartReq(env, env.Tv()))
 		s.NoError(err)
 		_, err = env.TaskPoller().PollAndHandleWorkflowTask(env.Tv(), taskpoller.DrainWorkflowTask)
 		s.NoError(err)
@@ -5716,7 +5716,7 @@ func (s *UpdateWithStartSuite) TestUpdateIsAbortedByClosingWorkflow() {
 		env := testcore.NewEnv(s.T())
 
 		// start workflow
-		_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(s.Context()), s.updateWithStartReq(env, env.Tv()))
+		_, err := env.FrontendClient().StartWorkflowExecution(s.Context(), s.updateWithStartReq(env, env.Tv()))
 		s.NoError(err)
 		_, err = env.TaskPoller().PollAndHandleWorkflowTask(env.Tv(), taskpoller.DrainWorkflowTask)
 		s.NoError(err)
@@ -5732,7 +5732,7 @@ func (s *UpdateWithStartSuite) TestUpdateIsAbortedByClosingWorkflow() {
 		waitUpdateAdmitted(env, env.Tv())
 
 		env.InjectHook(testhooks.NewHook(testhooks.UpdateWithStartOnClosingWorkflowRetry, func() {
-			_, err := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(s.Context()), s.updateWithStartReq(env, env.Tv()))
+			_, err := env.FrontendClient().StartWorkflowExecution(s.Context(), s.updateWithStartReq(env, env.Tv()))
 			s.NoError(err)
 		}))
 
@@ -5805,7 +5805,7 @@ func (s *UpdateWithStartSuite) TestReturnUpdateRateLimitError() {
 		testcore.WithDynamicConfig(dynamicconfig.WorkflowExecutionMaxTotalUpdates, 1),
 	)
 
-	ctx := testcore.NewContext(s.Context())
+	ctx := s.Context()
 	startReq := s.updateWithStartReq(env, env.Tv())
 	startReq.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING
 
@@ -5845,7 +5845,7 @@ func (s *UpdateWithStartSuite) TestReturnUpdateInFlightLimitError() {
 		testcore.WithDynamicConfig(dynamicconfig.WorkflowExecutionMaxInFlightUpdates, maxInFlight),
 	)
 
-	ctx := testcore.NewContext(s.Context())
+	ctx := s.Context()
 	startReq := s.updateWithStartReq(env, env.Tv())
 	startReq.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING
 

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -45,29 +45,6 @@ func speculativeWorkflowTaskOutcomes(
 	return
 }
 
-func clearUpdateRegistryAndAbortPendingUpdates(ctx context.Context, env *testcore.TestEnv, tv *testvars.TestVars) {
-	closeShard(ctx, env, tv.WorkflowID())
-}
-
-func loseUpdateRegistryAndAbandonPendingUpdates(ctx context.Context, env *testcore.TestEnv, tv *testvars.TestVars) {
-	cleanup := env.OverrideDynamicConfig(dynamicconfig.ShardFinalizerTimeout, 0)
-	defer cleanup()
-	closeShard(ctx, env, tv.WorkflowID())
-}
-
-func closeShard(ctx context.Context, env *testcore.TestEnv, wid string) {
-	env.T().Helper()
-
-	resp, err := env.FrontendClient().DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{
-		Namespace: env.Namespace().String(),
-	})
-	if err != nil {
-		env.T().Fatalf("Failed to describe namespace: %v", err)
-	}
-
-	env.CloseShard(resp.NamespaceInfo.Id, wid)
-}
-
 type WorkflowUpdateSuite struct {
 	parallelsuite.Suite[*WorkflowUpdateSuite]
 }
@@ -3410,7 +3387,7 @@ func (s *WorkflowUpdateSuite) TestScheduledSpeculativeWorkflowTask_LostUpdate() 
 	s.Nil(updateResult.response)
 
 	// Lose update registry. Speculative WFT and update registry disappear.
-	loseUpdateRegistryAndAbandonPendingUpdates(s.Context(), env, env.Tv())
+	s.loseUpdateRegistryAndAbandonPendingUpdates(env, env.Tv())
 
 	// Ensure, there is no WFT.
 	pollCtx, cancel := context.WithTimeout(s.Context(), common.MinLongPollTimeout*2)
@@ -3471,7 +3448,7 @@ func (s *WorkflowUpdateSuite) TestStartedSpeculativeWorkflowTask_LostUpdate() {
 	`, task.History)
 
 			// Lose update registry. Update is lost and NotFound error will be returned to RespondWorkflowTaskCompleted.
-			loseUpdateRegistryAndAbandonPendingUpdates(s.Context(), env, env.Tv())
+			s.loseUpdateRegistryAndAbandonPendingUpdates(env, env.Tv())
 
 			return env.UpdateAcceptCompleteCommands(env.Tv()), nil
 		case 3:
@@ -3586,7 +3563,7 @@ func (s *WorkflowUpdateSuite) TestFirstNormalWorkflowTask_UpdateResurrectedAfter
 	  3 WorkflowTaskStarted
 	`, task.History)
 			// Clear update registry. Update will be resurrected in registry from acceptance message.
-			clearUpdateRegistryAndAbortPendingUpdates(s.Context(), env, env.Tv())
+			s.clearUpdateRegistryAndAbortPendingUpdates(env, env.Tv())
 
 			return env.UpdateAcceptCompleteCommands(env.Tv()), nil
 		case 2:
@@ -3964,7 +3941,7 @@ func (s *WorkflowUpdateSuite) TestCompletedSpeculativeWorkflowTask_DeduplicateID
 
 			if tc.CloseShard {
 				// Close shard to make sure that for completed updates deduplication works even after shard reload.
-				closeShard(s.Context(), env, env.Tv().WorkflowID())
+				s.closeShard(env, env.Tv().WorkflowID())
 			}
 
 			// Send second update with the same ID. It must return immediately.
@@ -4099,7 +4076,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_BecauseOfDif
 	  7 WorkflowTaskStarted`, wt2.History)
 
 	// Clear update registry. Speculative WFT disappears from server.
-	clearUpdateRegistryAndAbortPendingUpdates(s.Context(), env, env.Tv())
+	s.clearUpdateRegistryAndAbortPendingUpdates(env, env.Tv())
 
 	// Wait for update request to be retry by frontend and recreated in registry. This will create a 3rd WFT as speculative.
 	waitUpdateAdmitted(env, env.Tv())
@@ -4229,7 +4206,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_BecauseOfDif
 	  6 WorkflowTaskStarted`, wt2.History)
 
 	// Clear update registry. Speculative WFT disappears from server.
-	clearUpdateRegistryAndAbortPendingUpdates(s.Context(), env, env.Tv())
+	s.clearUpdateRegistryAndAbortPendingUpdates(env, env.Tv())
 
 	// Wait for update request to be retry by frontend and recreated in registry. This will create a 3rd WFT as speculative.
 	waitUpdateAdmitted(env, env.Tv())
@@ -4341,7 +4318,7 @@ func (s *WorkflowUpdateSuite) TestStaleSpeculativeWorkflowTask_Fail_NewWorkflowT
 	  6 WorkflowTaskStarted`, wt2.History)
 
 	// Clear update registry. Speculative WFT disappears from server.
-	clearUpdateRegistryAndAbortPendingUpdates(s.Context(), env, env.Tv())
+	s.clearUpdateRegistryAndAbortPendingUpdates(env, env.Tv())
 
 	// Make sure UpdateWorkflowExecution call for the update "1" is retried and new (3rd) WFT is created as speculative with updateID=1.
 	waitUpdateAdmitted(env, tv1)
@@ -5890,4 +5867,25 @@ func (s *UpdateWithStartSuite) TestReturnUpdateInFlightLimitError() {
 	case <-ctx.Done():
 		s.Fail("timed out waiting for update")
 	}
+}
+
+func (s *WorkflowUpdateSuite) clearUpdateRegistryAndAbortPendingUpdates(env *testcore.TestEnv, tv *testvars.TestVars) {
+	s.closeShard(env, tv.WorkflowID())
+}
+
+func (s *WorkflowUpdateSuite) loseUpdateRegistryAndAbandonPendingUpdates(env *testcore.TestEnv, tv *testvars.TestVars) {
+	cleanup := env.OverrideDynamicConfig(dynamicconfig.ShardFinalizerTimeout, 0)
+	defer cleanup()
+	s.closeShard(env, tv.WorkflowID())
+}
+
+func (s *WorkflowUpdateSuite) closeShard(env *testcore.TestEnv, wid string) {
+	s.T().Helper()
+
+	resp, err := env.FrontendClient().DescribeNamespace(s.Context(), &workflowservice.DescribeNamespaceRequest{
+		Namespace: env.Namespace().String(),
+	})
+	s.NoError(err, "Failed to describe namespace")
+
+	env.CloseShard(resp.NamespaceInfo.Id, wid)
 }

--- a/tests/user_metadata_test.go
+++ b/tests/user_metadata_test.go
@@ -57,11 +57,11 @@ func (s *UserMetadataSuite) TestUserMetadata() {
 			UserMetadata: metadata,
 		}
 
-		we, err := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
+		we, err := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 		s.NoError(err)
 
 		// Verify that the UserMetadata associated with the start event is returned in the describe response.
-		describeInfo, err := getDescribeWorkflowExecutionInfo(env.Context(), env.FrontendClient(), env.Namespace().String(), tv.WorkflowID(), we.RunId)
+		describeInfo, err := getDescribeWorkflowExecutionInfo(s.Context(), env.FrontendClient(), env.Namespace().String(), tv.WorkflowID(), we.RunId)
 		s.NoError(err)
 		s.EqualExportedValues(metadata, describeInfo.ExecutionConfig.UserMetadata)
 	})
@@ -80,11 +80,11 @@ func (s *UserMetadataSuite) TestUserMetadata() {
 			UserMetadata: metadata,
 		}
 
-		we, err := env.FrontendClient().SignalWithStartWorkflowExecution(env.Context(), request)
+		we, err := env.FrontendClient().SignalWithStartWorkflowExecution(s.Context(), request)
 		s.NoError(err)
 
 		// Verify that the UserMetadata associated with the start event is returned in the describe response.
-		describeInfo, err := getDescribeWorkflowExecutionInfo(env.Context(), env.FrontendClient(), env.Namespace().String(), tv.WorkflowID(), we.RunId)
+		describeInfo, err := getDescribeWorkflowExecutionInfo(s.Context(), env.FrontendClient(), env.Namespace().String(), tv.WorkflowID(), we.RunId)
 		s.NoError(err)
 		s.EqualExportedValues(metadata, describeInfo.ExecutionConfig.UserMetadata)
 	})
@@ -125,11 +125,11 @@ func (s *UserMetadataSuite) TestUserMetadata() {
 			},
 		}
 
-		_, err := env.FrontendClient().ExecuteMultiOperation(env.Context(), request)
+		_, err := env.FrontendClient().ExecuteMultiOperation(s.Context(), request)
 		s.NoError(err)
 
 		// Verify that the UserMetadata associated with the start event is returned in the describe response.
-		describeInfo, err := getDescribeWorkflowExecutionInfo(env.Context(), env.FrontendClient(), env.Namespace().String(), tv.WorkflowID(), "")
+		describeInfo, err := getDescribeWorkflowExecutionInfo(s.Context(), env.FrontendClient(), env.Namespace().String(), tv.WorkflowID(), "")
 		s.NoError(err)
 		s.EqualExportedValues(metadata, describeInfo.ExecutionConfig.UserMetadata)
 	})

--- a/tests/user_timers_test.go
+++ b/tests/user_timers_test.go
@@ -48,7 +48,7 @@ func (s *UserTimersTestSuite) TestUserTimersSequential() {
 		Identity:            identity,
 	}
 
-	we, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 
 	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -7038,7 +7038,7 @@ func (s *Versioning3Suite) TestPinnedCaN_FailedTransientNotificationRefiresDespi
 		testcore.WithDynamicConfig(dynamicconfig.MatchingNumTaskqueueWritePartitions, 1),
 	)
 
-	ctx, cancel := context.WithTimeout(env.Context(), time.Minute)
+	ctx, cancel := context.WithTimeout(s.Context(), time.Minute)
 	defer cancel()
 
 	tv1 := env.Tv().WithBuildIDNumber(1)

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -5119,7 +5119,7 @@ func (s *Versioning3Suite) startWorkflow(
 		VersioningOverride: override,
 	}
 
-	we, err0 := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 	return we.GetRunId()
 }
@@ -5134,7 +5134,7 @@ func (s *Versioning3Suite) queryWorkflow(
 		Query:     tv.Query(),
 	}
 
-	shortCtx, cancel := context.WithTimeout(testcore.NewContext(), common.MinLongPollTimeout)
+	shortCtx, cancel := context.WithTimeout(s.Context(), common.MinLongPollTimeout)
 	defer cancel()
 	response, err := env.FrontendClient().QueryWorkflow(shortCtx, request)
 	return response, err
@@ -8387,7 +8387,7 @@ func (s *Versioning3Suite) TestVersioning3_NoWorkerVersionOnStartedEvents() {
 	updateResultCh2 := sendUpdate(s.Context(), env, tvUpd2)
 
 	// Poll and fail the WFT with deployment options to trigger a transient retry.
-	failCtx := testcore.NewContext()
+	failCtx := s.Context()
 	pollResp, err := env.FrontendClient().PollWorkflowTaskQueue(failCtx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace:         env.Namespace().String(),
 		TaskQueue:         tv.TaskQueue(),

--- a/tests/workflow_buffered_events_test.go
+++ b/tests/workflow_buffered_events_test.go
@@ -52,7 +52,7 @@ func (s *WorkflowBufferedEventsSuite) TestRateLimitBufferedEvents() {
 		Identity:            identity,
 	}
 
-	we, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 
 	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -152,7 +152,7 @@ func (s *WorkflowBufferedEventsSuite) TestBufferedEvents() {
 		Identity:            identity,
 	}
 
-	we, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 
 	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -168,7 +168,7 @@ func (s *WorkflowBufferedEventsSuite) TestBufferedEvents() {
 			signalSent = true
 
 			// this will create new event when there is in-flight workflow task, and the new event will be buffered
-			_, err := env.FrontendClient().SignalWorkflowExecution(env.Context(),
+			_, err := env.FrontendClient().SignalWorkflowExecution(s.Context(),
 				&workflowservice.SignalWorkflowExecutionRequest{
 					Namespace: env.Namespace().String(),
 					WorkflowExecution: &commonpb.WorkflowExecution{
@@ -220,7 +220,7 @@ func (s *WorkflowBufferedEventsSuite) TestBufferedEvents() {
 					AttachRequestId: true,
 				},
 			}
-			resp, err := env.FrontendClient().StartWorkflowExecution(env.Context(), newRequest)
+			resp, err := env.FrontendClient().StartWorkflowExecution(s.Context(), newRequest)
 			s.NoError(err)
 			s.False(resp.Started)
 
@@ -231,7 +231,7 @@ func (s *WorkflowBufferedEventsSuite) TestBufferedEvents() {
 					WorkflowId: id,
 				},
 			}
-			descResp, err := env.FrontendClient().DescribeWorkflowExecution(env.Context(), descRequest)
+			descResp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), descRequest)
 			s.NoError(err)
 			requestIDInfos := descResp.GetWorkflowExtendedInfo().GetRequestIdInfos()
 			s.NotNil(requestIDInfos)
@@ -354,7 +354,7 @@ func (s *WorkflowBufferedEventsSuite) TestBufferedEvents() {
 			WorkflowId: id,
 		},
 	}
-	descResp, err := env.FrontendClient().DescribeWorkflowExecution(env.Context(), descRequest)
+	descResp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), descRequest)
 	s.NoError(err)
 	requestIDInfos := descResp.GetWorkflowExtendedInfo().GetRequestIdInfos()
 	s.NotNil(requestIDInfos)
@@ -390,7 +390,7 @@ func (s *WorkflowBufferedEventsSuite) TestBufferedEventsOutOfOrder() {
 		Identity:            identity,
 	}
 
-	we, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 
 	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))

--- a/tests/workflow_completion_pagination_test.go
+++ b/tests/workflow_completion_pagination_test.go
@@ -61,7 +61,7 @@ func (s *WorkflowCompletionPaginationTestSuite) startWorkflowAndStartWFT(
 	id := uuid.NewString()
 	taskQueue := &taskqueuepb.TaskQueue{Name: id, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
 
-	startResp, err := env.FrontendClient().StartWorkflowExecution(env.Context(), &workflowservice.StartWorkflowExecutionRequest{
+	startResp, err := env.FrontendClient().StartWorkflowExecution(s.Context(), &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:           uuid.NewString(),
 		Namespace:           env.Namespace().String(),
 		WorkflowId:          id,
@@ -75,7 +75,7 @@ func (s *WorkflowCompletionPaginationTestSuite) startWorkflowAndStartWFT(
 
 	we := &commonpb.WorkflowExecution{WorkflowId: id, RunId: startResp.RunId}
 
-	pollResp, err := env.FrontendClient().PollWorkflowTaskQueue(env.Context(), &workflowservice.PollWorkflowTaskQueueRequest{
+	pollResp, err := env.FrontendClient().PollWorkflowTaskQueue(s.Context(), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: env.Namespace().String(),
 		TaskQueue: taskQueue,
 		Identity:  "worker1",
@@ -127,7 +127,7 @@ func (s *WorkflowCompletionPaginationTestSuite) sendIntermediatePages(
 	pages [][]*commandpb.Command,
 ) int32 {
 	for i, page := range pages {
-		resp, err := env.FrontendClient().RespondWorkflowTaskCompleted(env.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+		resp, err := env.FrontendClient().RespondWorkflowTaskCompleted(s.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 			Namespace:        env.Namespace().String(),
 			TaskToken:        taskToken,
 			Commands:         page,
@@ -165,7 +165,7 @@ func (s *WorkflowCompletionPaginationTestSuite) TestLargeMergedCompletion() {
 		},
 	})
 
-	_, err := env.FrontendClient().RespondWorkflowTaskCompleted(env.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err := env.FrontendClient().RespondWorkflowTaskCompleted(s.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace:  env.Namespace().String(),
 		TaskToken:  taskToken,
 		Commands:   finalCommands,
@@ -208,7 +208,7 @@ func (s *WorkflowCompletionPaginationTestSuite) TestLargeMergedContinueAsNew() {
 		},
 	}}
 
-	_, err := env.FrontendClient().RespondWorkflowTaskCompleted(env.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err := env.FrontendClient().RespondWorkflowTaskCompleted(s.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace:  env.Namespace().String(),
 		TaskToken:  taskToken,
 		Commands:   finalCommands,
@@ -233,7 +233,7 @@ func (s *WorkflowCompletionPaginationTestSuite) TestBufferLostOnShardClose() {
 
 	we, _, taskToken := s.startWorkflowAndStartWFT(env, time.Minute)
 
-	_, err := env.FrontendClient().RespondWorkflowTaskCompleted(env.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err := env.FrontendClient().RespondWorkflowTaskCompleted(s.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace:        env.Namespace().String(),
 		TaskToken:        taskToken,
 		Commands:         makeMarkerCommands(1),
@@ -247,7 +247,7 @@ func (s *WorkflowCompletionPaginationTestSuite) TestBufferLostOnShardClose() {
 	env.CloseShard(env.NamespaceID().String(), we.WorkflowId)
 
 	// The final page can no longer find its buffered pages.
-	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(env.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(s.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace: env.Namespace().String(),
 		TaskToken: taskToken,
 		Commands: []*commandpb.Command{{
@@ -276,7 +276,7 @@ func (s *WorkflowCompletionPaginationTestSuite) TestPaginationDisabledRejected()
 	env := testcore.NewEnv(s.T()) // pagination disabled by default
 	_, _, taskToken := s.startWorkflowAndStartWFT(env, time.Minute)
 
-	_, err := env.FrontendClient().RespondWorkflowTaskCompleted(env.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err := env.FrontendClient().RespondWorkflowTaskCompleted(s.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace:        env.Namespace().String(),
 		TaskToken:        taskToken,
 		Commands:         makeMarkerCommands(1),
@@ -299,7 +299,7 @@ func (s *WorkflowCompletionPaginationTestSuite) TestBufferOverflowFailsWorkflowT
 	we, _, taskToken := s.startWorkflowAndStartWFT(env, time.Minute)
 
 	// A single marker already exceeds the limit, failing the workflow task.
-	_, err := env.FrontendClient().RespondWorkflowTaskCompleted(env.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err := env.FrontendClient().RespondWorkflowTaskCompleted(s.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace:        env.Namespace().String(),
 		TaskToken:        taskToken,
 		Commands:         makeMarkerCommands(1),
@@ -322,7 +322,7 @@ func (s *WorkflowCompletionPaginationTestSuite) TestOutOfOrderPagesReassemble() 
 
 	markers := makeMarkerCommands(3)
 	for _, p := range []int32{2, 0, 1} {
-		_, err := env.FrontendClient().RespondWorkflowTaskCompleted(env.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+		_, err := env.FrontendClient().RespondWorkflowTaskCompleted(s.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 			Namespace:        env.Namespace().String(),
 			TaskToken:        taskToken,
 			Commands:         []*commandpb.Command{markers[p]},
@@ -333,7 +333,7 @@ func (s *WorkflowCompletionPaginationTestSuite) TestOutOfOrderPagesReassemble() 
 		s.NoError(err)
 	}
 
-	_, err := env.FrontendClient().RespondWorkflowTaskCompleted(env.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err := env.FrontendClient().RespondWorkflowTaskCompleted(s.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace: env.Namespace().String(),
 		TaskToken: taskToken,
 		Commands: []*commandpb.Command{{
@@ -366,7 +366,7 @@ func (s *WorkflowCompletionPaginationTestSuite) TestResendAfterBufferLost() {
 	we, _, taskToken := s.startWorkflowAndStartWFT(env, time.Minute)
 
 	bufferPage0 := func() {
-		_, err := env.FrontendClient().RespondWorkflowTaskCompleted(env.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+		_, err := env.FrontendClient().RespondWorkflowTaskCompleted(s.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 			Namespace:        env.Namespace().String(),
 			TaskToken:        taskToken,
 			Commands:         makeMarkerCommands(1),
@@ -377,7 +377,7 @@ func (s *WorkflowCompletionPaginationTestSuite) TestResendAfterBufferLost() {
 		s.NoError(err)
 	}
 	completeFinalPage := func() error {
-		_, err := env.FrontendClient().RespondWorkflowTaskCompleted(env.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+		_, err := env.FrontendClient().RespondWorkflowTaskCompleted(s.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 			Namespace: env.Namespace().String(),
 			TaskToken: taskToken,
 			Commands: []*commandpb.Command{{

--- a/tests/workflow_delete_execution_test.go
+++ b/tests/workflow_delete_execution_test.go
@@ -50,7 +50,7 @@ func (s *WorkflowDeleteExecutionSuite) TestDeleteWorkflowExecutionCompletedWorkf
 	var wes []*commonpb.WorkflowExecution
 	// Start numExecutions workflow executions.
 	for i := range numExecutions {
-		we, err := env.FrontendClient().StartWorkflowExecution(env.Context(), &workflowservice.StartWorkflowExecutionRequest{
+		we, err := env.FrontendClient().StartWorkflowExecution(s.Context(), &workflowservice.StartWorkflowExecutionRequest{
 			RequestId:    uuid.NewString(),
 			Namespace:    env.Namespace().String(),
 			WorkflowId:   tv.WithWorkflowIDNumber(i).WorkflowID(),
@@ -93,7 +93,7 @@ func (s *WorkflowDeleteExecutionSuite) TestDeleteWorkflowExecutionCompletedWorkf
 		s.Eventually(
 			func() bool {
 				visibilityResponse, err := env.FrontendClient().ListWorkflowExecutions(
-					env.Context(),
+					s.Context(),
 					&workflowservice.ListWorkflowExecutionsRequest{
 						Namespace:     env.Namespace().String(),
 						PageSize:      1,
@@ -115,7 +115,7 @@ func (s *WorkflowDeleteExecutionSuite) TestDeleteWorkflowExecutionCompletedWorkf
 
 	// Delete workflow executions.
 	for _, we := range wes {
-		_, err := env.FrontendClient().DeleteWorkflowExecution(env.Context(), &workflowservice.DeleteWorkflowExecutionRequest{
+		_, err := env.FrontendClient().DeleteWorkflowExecution(s.Context(), &workflowservice.DeleteWorkflowExecutionRequest{
 			Namespace: env.Namespace().String(),
 			WorkflowExecution: &commonpb.WorkflowExecution{
 				WorkflowId: we.WorkflowId,
@@ -130,7 +130,7 @@ func (s *WorkflowDeleteExecutionSuite) TestDeleteWorkflowExecutionCompletedWorkf
 			func() bool {
 				// Check execution is deleted.
 				describeResponse, err := env.FrontendClient().DescribeWorkflowExecution(
-					env.Context(),
+					s.Context(),
 					&workflowservice.DescribeWorkflowExecutionRequest{
 						Namespace: env.Namespace().String(),
 						Execution: we,
@@ -151,7 +151,7 @@ func (s *WorkflowDeleteExecutionSuite) TestDeleteWorkflowExecutionCompletedWorkf
 
 		// Check history is deleted.
 		historyResponse, err := env.FrontendClient().GetWorkflowExecutionHistory(
-			env.Context(),
+			s.Context(),
 			&workflowservice.GetWorkflowExecutionHistoryRequest{
 				Namespace: env.Namespace().String(),
 				Execution: we,
@@ -165,7 +165,7 @@ func (s *WorkflowDeleteExecutionSuite) TestDeleteWorkflowExecutionCompletedWorkf
 			func() bool {
 				// Check visibility is updated.
 				visibilityResponse, err := env.FrontendClient().ListWorkflowExecutions(
-					env.Context(),
+					s.Context(),
 					&workflowservice.ListWorkflowExecutionsRequest{
 						Namespace:     env.Namespace().String(),
 						PageSize:      1,
@@ -199,7 +199,7 @@ func (s *WorkflowDeleteExecutionSuite) TestDeleteWorkflowExecutionRunningWorkflo
 	var wes []*commonpb.WorkflowExecution
 	// Start numExecutions workflow executions.
 	for i := range numExecutions {
-		we, err := env.FrontendClient().StartWorkflowExecution(env.Context(), &workflowservice.StartWorkflowExecutionRequest{
+		we, err := env.FrontendClient().StartWorkflowExecution(s.Context(), &workflowservice.StartWorkflowExecutionRequest{
 			RequestId:    uuid.NewString(),
 			Namespace:    env.Namespace().String(),
 			WorkflowId:   tv.WithWorkflowIDNumber(i).WorkflowID(),
@@ -219,7 +219,7 @@ func (s *WorkflowDeleteExecutionSuite) TestDeleteWorkflowExecutionRunningWorkflo
 		s.Eventually(
 			func() bool {
 				visibilityResponse, err := env.FrontendClient().ListWorkflowExecutions(
-					env.Context(),
+					s.Context(),
 					&workflowservice.ListWorkflowExecutionsRequest{
 						Namespace:     env.Namespace().String(),
 						PageSize:      1,
@@ -238,7 +238,7 @@ func (s *WorkflowDeleteExecutionSuite) TestDeleteWorkflowExecutionRunningWorkflo
 
 	// Delete workflow executions.
 	for _, we := range wes {
-		_, err := env.FrontendClient().DeleteWorkflowExecution(env.Context(), &workflowservice.DeleteWorkflowExecutionRequest{
+		_, err := env.FrontendClient().DeleteWorkflowExecution(s.Context(), &workflowservice.DeleteWorkflowExecutionRequest{
 			Namespace:         env.Namespace().String(),
 			WorkflowExecution: we,
 		})
@@ -250,7 +250,7 @@ func (s *WorkflowDeleteExecutionSuite) TestDeleteWorkflowExecutionRunningWorkflo
 			func() bool {
 				// Check execution is deleted.
 				describeResponse, err := env.FrontendClient().DescribeWorkflowExecution(
-					env.Context(),
+					s.Context(),
 					&workflowservice.DescribeWorkflowExecutionRequest{
 						Namespace: env.Namespace().String(),
 						Execution: we,
@@ -271,7 +271,7 @@ func (s *WorkflowDeleteExecutionSuite) TestDeleteWorkflowExecutionRunningWorkflo
 
 		// Check history is deleted.
 		historyResponse, err := env.FrontendClient().GetWorkflowExecutionHistory(
-			env.Context(),
+			s.Context(),
 			&workflowservice.GetWorkflowExecutionHistoryRequest{
 				Namespace: env.Namespace().String(),
 				Execution: we,
@@ -285,7 +285,7 @@ func (s *WorkflowDeleteExecutionSuite) TestDeleteWorkflowExecutionRunningWorkflo
 			func() bool {
 				// Check visibility is updated.
 				visibilityResponse, err := env.FrontendClient().ListWorkflowExecutions(
-					env.Context(),
+					s.Context(),
 					&workflowservice.ListWorkflowExecutionsRequest{
 						Namespace:     env.Namespace().String(),
 						PageSize:      1,
@@ -319,7 +319,7 @@ func (s *WorkflowDeleteExecutionSuite) TestDeleteWorkflowExecutionJustTerminated
 	var wes []*commonpb.WorkflowExecution
 	// Start numExecutions workflow executions.
 	for i := range numExecutions {
-		we, err := env.FrontendClient().StartWorkflowExecution(env.Context(), &workflowservice.StartWorkflowExecutionRequest{
+		we, err := env.FrontendClient().StartWorkflowExecution(s.Context(), &workflowservice.StartWorkflowExecutionRequest{
 			RequestId:    uuid.NewString(),
 			Namespace:    env.Namespace().String(),
 			WorkflowId:   tv.WithWorkflowIDNumber(i).WorkflowID(),
@@ -339,7 +339,7 @@ func (s *WorkflowDeleteExecutionSuite) TestDeleteWorkflowExecutionJustTerminated
 		s.Eventually(
 			func() bool {
 				visibilityResponse, err := env.FrontendClient().ListWorkflowExecutions(
-					env.Context(),
+					s.Context(),
 					&workflowservice.ListWorkflowExecutionsRequest{
 						Namespace:     env.Namespace().String(),
 						PageSize:      1,
@@ -365,13 +365,13 @@ func (s *WorkflowDeleteExecutionSuite) TestDeleteWorkflowExecutionJustTerminated
 	// two types of tasks and make sure that they are executed in correct order.
 
 	for i, we := range wes {
-		_, err := env.FrontendClient().TerminateWorkflowExecution(env.Context(), &workflowservice.TerminateWorkflowExecutionRequest{
+		_, err := env.FrontendClient().TerminateWorkflowExecution(s.Context(), &workflowservice.TerminateWorkflowExecutionRequest{
 			Namespace:         env.Namespace().String(),
 			WorkflowExecution: we,
 		})
 		s.NoError(err)
 		env.Logger.Warn("Execution is terminated", tag.Int("number", i), tag.WorkflowID(we.WorkflowId), tag.WorkflowRunID(we.RunId))
-		_, err = env.FrontendClient().DeleteWorkflowExecution(env.Context(), &workflowservice.DeleteWorkflowExecutionRequest{
+		_, err = env.FrontendClient().DeleteWorkflowExecution(s.Context(), &workflowservice.DeleteWorkflowExecutionRequest{
 			Namespace:         env.Namespace().String(),
 			WorkflowExecution: we,
 		})
@@ -384,7 +384,7 @@ func (s *WorkflowDeleteExecutionSuite) TestDeleteWorkflowExecutionJustTerminated
 			func() bool {
 				// Check execution is deleted.
 				describeResponse, err := env.FrontendClient().DescribeWorkflowExecution(
-					env.Context(),
+					s.Context(),
 					&workflowservice.DescribeWorkflowExecutionRequest{
 						Namespace: env.Namespace().String(),
 						Execution: we,
@@ -405,7 +405,7 @@ func (s *WorkflowDeleteExecutionSuite) TestDeleteWorkflowExecutionJustTerminated
 
 		// Check history is deleted.
 		historyResponse, err := env.FrontendClient().GetWorkflowExecutionHistory(
-			env.Context(),
+			s.Context(),
 			&workflowservice.GetWorkflowExecutionHistoryRequest{
 				Namespace: env.Namespace().String(),
 				Execution: we,
@@ -419,7 +419,7 @@ func (s *WorkflowDeleteExecutionSuite) TestDeleteWorkflowExecutionJustTerminated
 			func() bool {
 				// Check visibility is updated.
 				visibilityResponse, err := env.FrontendClient().ListWorkflowExecutions(
-					env.Context(),
+					s.Context(),
 					&workflowservice.ListWorkflowExecutionsRequest{
 						Namespace:     env.Namespace().String(),
 						PageSize:      1,

--- a/tests/workflow_failures_test.go
+++ b/tests/workflow_failures_test.go
@@ -34,8 +34,8 @@ func TestWorkflowFailuresTestSuite(t *testing.T) {
 	parallelsuite.Run(t, &WorkflowFailuresSuite{})
 }
 
-func (suite *WorkflowFailuresSuite) TestWorkflowTimeout() {
-	s := testcore.NewEnv(suite.T())
+func (s *WorkflowFailuresSuite) TestWorkflowTimeout() {
+	env := testcore.NewEnv(s.T())
 	startTime := time.Now().UTC()
 
 	id := "functional-workflow-timeout"
@@ -45,7 +45,7 @@ func (suite *WorkflowFailuresSuite) TestWorkflowTimeout() {
 
 	request := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:           uuid.NewString(),
-		Namespace:           s.Namespace().String(),
+		Namespace:           env.Namespace().String(),
 		WorkflowId:          id,
 		WorkflowType:        &commonpb.WorkflowType{Name: wt},
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
@@ -55,24 +55,24 @@ func (suite *WorkflowFailuresSuite) TestWorkflowTimeout() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 
-	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
+	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
 	time.Sleep(time.Second) //nolint:forbidigo
 
 	var historyEvents []*historypb.HistoryEvent
 GetHistoryLoop:
 	for range 10 {
-		historyEvents = s.GetHistory(s.Namespace().String(), &commonpb.WorkflowExecution{
+		historyEvents = env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{
 			WorkflowId: id,
 			RunId:      we.RunId,
 		})
 
 		lastEvent := historyEvents[len(historyEvents)-1]
 		if lastEvent.GetEventType() != enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT {
-			s.Logger.Warn("Execution not timedout yet. Last event: " + lastEvent.GetEventType().String())
+			env.Logger.Warn("Execution not timedout yet. Last event: " + lastEvent.GetEventType().String())
 			time.Sleep(200 * time.Millisecond) //nolint:forbidigo
 			continue GetHistoryLoop
 		}
@@ -92,8 +92,8 @@ GetHistoryLoop:
 	closedCount := 0
 ListClosedLoop:
 	for range 10 {
-		resp, err3 := s.FrontendClient().ListClosedWorkflowExecutions(testcore.NewContext(), &workflowservice.ListClosedWorkflowExecutionsRequest{
-			Namespace:       s.Namespace().String(),
+		resp, err3 := env.FrontendClient().ListClosedWorkflowExecutions(s.Context(), &workflowservice.ListClosedWorkflowExecutionsRequest{
+			Namespace:       env.Namespace().String(),
 			MaximumPageSize: 100,
 			StartTimeFilter: startFilter,
 			Filters: &workflowservice.ListClosedWorkflowExecutionsRequest_ExecutionFilter{ExecutionFilter: &filterpb.WorkflowExecutionFilter{
@@ -103,7 +103,7 @@ ListClosedLoop:
 		s.NoError(err3)
 		closedCount = len(resp.Executions)
 		if closedCount == 0 {
-			s.Logger.Info("Closed WorkflowExecution is not yet visibile")
+			env.Logger.Info("Closed WorkflowExecution is not yet visibile")
 			time.Sleep(1000 * time.Millisecond) //nolint:forbidigo
 			continue ListClosedLoop
 		}
@@ -112,8 +112,8 @@ ListClosedLoop:
 	s.Equal(1, closedCount)
 }
 
-func (suite *WorkflowFailuresSuite) TestWorkflowTaskFailed() {
-	s := testcore.NewEnv(suite.T())
+func (s *WorkflowFailuresSuite) TestWorkflowTaskFailed() {
+	env := testcore.NewEnv(s.T())
 	id := "functional-workflowtask-failed-test"
 	wt := "functional-workflowtask-failed-test-type"
 	tl := "functional-workflowtask-failed-test-taskqueue"
@@ -123,7 +123,7 @@ func (suite *WorkflowFailuresSuite) TestWorkflowTaskFailed() {
 	// Start workflow execution
 	request := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:           uuid.NewString(),
-		Namespace:           s.Namespace().String(),
+		Namespace:           env.Namespace().String(),
 		WorkflowId:          id,
 		WorkflowType:        &commonpb.WorkflowType{Name: wt},
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
@@ -133,9 +133,9 @@ func (suite *WorkflowFailuresSuite) TestWorkflowTaskFailed() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
-	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
+	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
 	workflowExecution := &commonpb.WorkflowExecution{
 		WorkflowId: id,
@@ -165,9 +165,9 @@ func (suite *WorkflowFailuresSuite) TestWorkflowTaskFailed() {
 
 		// Send signals during workflow task
 		if sendSignal {
-			s.NoError(s.SendSignal(s.Namespace().String(), workflowExecution, "signalC", nil, identity))
-			s.NoError(s.SendSignal(s.Namespace().String(), workflowExecution, "signalD", nil, identity))
-			s.NoError(s.SendSignal(s.Namespace().String(), workflowExecution, "signalE", nil, identity))
+			s.NoError(env.SendSignal(env.Namespace().String(), workflowExecution, "signalC", nil, identity))
+			s.NoError(env.SendSignal(env.Namespace().String(), workflowExecution, "signalD", nil, identity))
+			s.NoError(env.SendSignal(env.Namespace().String(), workflowExecution, "signalE", nil, identity))
 			sendSignal = false
 		}
 
@@ -197,7 +197,7 @@ func (suite *WorkflowFailuresSuite) TestWorkflowTaskFailed() {
 
 		workflowComplete = true
 		time.Sleep(time.Second) //nolint:forbidigo
-		s.Logger.Warn(fmt.Sprintf("PrevStarted: %v, StartedEventID: %v, Size: %v", task.PreviousStartedEventId, task.StartedEventId,
+		env.Logger.Warn(fmt.Sprintf("PrevStarted: %v, StartedEventID: %v, Size: %v", task.PreviousStartedEventId, task.StartedEventId,
 			len(task.History.Events)))
 		lastWorkflowTaskEvent := task.History.Events[task.StartedEventId-1]
 		s.Equal(enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED, lastWorkflowTaskEvent.GetEventType())
@@ -217,24 +217,24 @@ func (suite *WorkflowFailuresSuite) TestWorkflowTaskFailed() {
 	}
 
 	poller := &testcore.TaskPoller{
-		Client:              s.FrontendClient(),
-		Namespace:           s.Namespace().String(),
+		Client:              env.FrontendClient(),
+		Namespace:           env.Namespace().String(),
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
 		WorkflowTaskHandler: wtHandler,
 		ActivityTaskHandler: atHandler,
-		Logger:              s.Logger,
+		Logger:              env.Logger,
 		T:                   s.T(),
 	}
 
 	// Make first workflow task to schedule activity
 	_, err := poller.PollAndProcessWorkflowTask()
-	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
+	env.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	// process activity
 	err = poller.PollAndProcessActivityTask(false)
-	s.Logger.Info("PollAndProcessActivityTask", tag.Error(err))
+	env.Logger.Info("PollAndProcessActivityTask", tag.Error(err))
 	s.NoError(err)
 
 	// fail workflow task 5 times
@@ -243,17 +243,17 @@ func (suite *WorkflowFailuresSuite) TestWorkflowTaskFailed() {
 		s.NoError(err)
 	}
 
-	err = s.SendSignal(s.Namespace().String(), workflowExecution, "signalA", nil, identity)
+	err = env.SendSignal(env.Namespace().String(), workflowExecution, "signalA", nil, identity)
 	s.NoError(err, "failed to send signal to execution")
 
 	// process signal
 	_, err = poller.PollAndProcessWorkflowTask()
-	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
+	env.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.Equal(1, signalCount)
 
 	// send another signal to trigger workflow task
-	err = s.SendSignal(s.Namespace().String(), workflowExecution, "signalB", nil, identity)
+	err = env.SendSignal(env.Namespace().String(), workflowExecution, "signalB", nil, identity)
 	s.NoError(err, "failed to send signal to execution")
 
 	// fail workflow task 2 more times
@@ -278,12 +278,12 @@ func (suite *WorkflowFailuresSuite) TestWorkflowTaskFailed() {
 
 	// Make complete workflow workflow task
 	_, err = poller.PollAndProcessWorkflowTask(testcore.WithExpectedAttemptCount(3))
-	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
+	env.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowComplete)
 	s.Equal(16, signalCount)
 
-	events := s.GetHistory(s.Namespace().String(), workflowExecution)
+	events := env.GetHistory(env.Namespace().String(), workflowExecution)
 	s.EqualHistoryEvents(`
   1 WorkflowExecutionStarted
   2 WorkflowTaskScheduled
@@ -320,8 +320,8 @@ func (suite *WorkflowFailuresSuite) TestWorkflowTaskFailed() {
 	s.GreaterOrEqual(wfCompletedEvent.GetEventTime().AsTime().Sub(lastWorkflowTaskTime), time.Second)
 }
 
-func (suite *WorkflowFailuresSuite) TestRespondWorkflowTaskCompletedReturnsErrorIfInvalidArgument() {
-	s := testcore.NewEnv(suite.T())
+func (s *WorkflowFailuresSuite) TestRespondWorkflowTaskCompletedReturnsErrorIfInvalidArgument() {
+	env := testcore.NewEnv(s.T())
 	id := "functional-respond-workflow-task-completed-test"
 	wt := "functional-respond-workflow-task-completed-test-type"
 	tq := "functional-respond-workflow-task-completed-test-taskqueue"
@@ -329,7 +329,7 @@ func (suite *WorkflowFailuresSuite) TestRespondWorkflowTaskCompletedReturnsError
 
 	request := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:          uuid.NewString(),
-		Namespace:          s.Namespace().String(),
+		Namespace:          env.Namespace().String(),
 		WorkflowId:         id,
 		WorkflowType:       &commonpb.WorkflowType{Name: wt},
 		TaskQueue:          &taskqueuepb.TaskQueue{Name: tq, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
@@ -338,7 +338,7 @@ func (suite *WorkflowFailuresSuite) TestRespondWorkflowTaskCompletedReturnsError
 		Identity:           identity,
 	}
 
-	we0, err0 := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)
+	we0, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 	s.NotNil(we0)
 
@@ -357,13 +357,13 @@ func (suite *WorkflowFailuresSuite) TestRespondWorkflowTaskCompletedReturnsError
 	}
 
 	poller := &testcore.TaskPoller{
-		Client:              s.FrontendClient(),
-		Namespace:           s.Namespace().String(),
+		Client:              env.FrontendClient(),
+		Namespace:           env.Namespace().String(),
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tq, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
 		WorkflowTaskHandler: wtHandler,
 		ActivityTaskHandler: nil,
-		Logger:              s.Logger,
+		Logger:              env.Logger,
 		T:                   s.T(),
 	}
 
@@ -372,7 +372,7 @@ func (suite *WorkflowFailuresSuite) TestRespondWorkflowTaskCompletedReturnsError
 	s.IsType(&serviceerror.InvalidArgument{}, err)
 	s.Equal("BadRecordMarkerAttributes: MarkerName is not set on RecordMarkerCommand.", err.Error())
 
-	historyEvents := s.GetHistory(s.Namespace().String(), &commonpb.WorkflowExecution{
+	historyEvents := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{
 		WorkflowId: id,
 		RunId:      we0.GetRunId(),
 	})

--- a/tests/workflow_memo_test.go
+++ b/tests/workflow_memo_test.go
@@ -64,7 +64,7 @@ func (s *WorkflowMemoTestSuite) TestStartWithMemo() {
 	}
 
 	fn := func() (RunIDGetter, error) {
-		return env.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)
+		return env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	}
 	s.startWithMemoHelper(env, fn, id, &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}, memo, `
   1 WorkflowExecutionStarted {"Memo":{"Fields":{"Info":{"Data":"\"memo-value\""}}}}
@@ -106,7 +106,7 @@ func (s *WorkflowMemoTestSuite) TestSignalWithStartWithMemo() {
 	}
 
 	fn := func() (RunIDGetter, error) {
-		return env.FrontendClient().SignalWithStartWorkflowExecution(testcore.NewContext(), request)
+		return env.FrontendClient().SignalWithStartWorkflowExecution(s.Context(), request)
 	}
 	s.startWithMemoHelper(env, fn, id, &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}, memo, `
   1 WorkflowExecutionStarted {"Memo":{"Fields":{"Info":{"Data":"\"memo-value\""}}}}
@@ -149,7 +149,7 @@ func (s *WorkflowMemoTestSuite) startWithMemoHelper(env *testcore.TestEnv, start
 	var openExecutionInfo *workflowpb.WorkflowExecutionInfo
 	s.EventuallyWithT(
 		func(t *assert.CollectT) {
-			resp, err1 := env.FrontendClient().ListOpenWorkflowExecutions(testcore.NewContext(), &workflowservice.ListOpenWorkflowExecutionsRequest{
+			resp, err1 := env.FrontendClient().ListOpenWorkflowExecutions(s.Context(), &workflowservice.ListOpenWorkflowExecutionsRequest{
 				Namespace:       env.Namespace().String(),
 				MaximumPageSize: 100,
 				StartTimeFilter: &filterpb.StartTimeFilter{
@@ -179,7 +179,7 @@ func (s *WorkflowMemoTestSuite) startWithMemoHelper(env *testcore.TestEnv, start
 		Namespace: env.Namespace().String(),
 		Execution: execution,
 	}
-	descResp, err := env.FrontendClient().DescribeWorkflowExecution(testcore.NewContext(), descRequest)
+	descResp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), descRequest)
 	s.NoError(err)
 	s.ProtoEqual(memo, descResp.WorkflowExecutionInfo.Memo)
 
@@ -193,7 +193,7 @@ func (s *WorkflowMemoTestSuite) startWithMemoHelper(env *testcore.TestEnv, start
 	s.EqualHistoryEvents(expectedHistory, historyEvents)
 
 	// verify DescribeWorkflowExecution result: workflow closed, but close visibility task not completed
-	descResp, err = env.FrontendClient().DescribeWorkflowExecution(testcore.NewContext(), descRequest)
+	descResp, err = env.FrontendClient().DescribeWorkflowExecution(s.Context(), descRequest)
 	s.NoError(err)
 	s.ProtoEqual(memo, descResp.WorkflowExecutionInfo.Memo)
 
@@ -201,7 +201,7 @@ func (s *WorkflowMemoTestSuite) startWithMemoHelper(env *testcore.TestEnv, start
 	var closedExecutionInfo *workflowpb.WorkflowExecutionInfo
 	s.EventuallyWithT(
 		func(t *assert.CollectT) {
-			resp, err1 := env.FrontendClient().ListClosedWorkflowExecutions(testcore.NewContext(), &workflowservice.ListClosedWorkflowExecutionsRequest{
+			resp, err1 := env.FrontendClient().ListClosedWorkflowExecutions(s.Context(), &workflowservice.ListClosedWorkflowExecutionsRequest{
 				Namespace:       env.Namespace().String(),
 				MaximumPageSize: 100,
 				StartTimeFilter: &filterpb.StartTimeFilter{
@@ -222,7 +222,7 @@ func (s *WorkflowMemoTestSuite) startWithMemoHelper(env *testcore.TestEnv, start
 	s.ProtoEqual(memo, closedExecutionInfo.Memo)
 
 	// verify DescribeWorkflowExecution result: workflow closed and close visibility task completed
-	descResp, err = env.FrontendClient().DescribeWorkflowExecution(testcore.NewContext(), descRequest)
+	descResp, err = env.FrontendClient().DescribeWorkflowExecution(s.Context(), descRequest)
 	s.NoError(err)
 	s.ProtoEqual(memo, descResp.WorkflowExecutionInfo.Memo)
 }

--- a/tests/workflow_timer_test.go
+++ b/tests/workflow_timer_test.go
@@ -45,7 +45,7 @@ func (s *WorkflowTimerTestSuite) TestCancelTimer() {
 		Identity:            identity,
 	}
 
-	creatResp, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
+	creatResp, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 	workflowExecution := &commonpb.WorkflowExecution{
 		WorkflowId: id,
@@ -169,7 +169,7 @@ func (s *WorkflowTimerTestSuite) TestCancelTimer_CancelFiredAndBuffered() {
 		Identity:            identity,
 	}
 
-	creatResp, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
+	creatResp, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
 	workflowExecution := &commonpb.WorkflowExecution{
 		WorkflowId: id,

--- a/tests/workflow_type_encoding_test.go
+++ b/tests/workflow_type_encoding_test.go
@@ -38,7 +38,7 @@ func (s *WorkflowTypeEncodingSuite) runWithWorkflowType(env *testcore.TestEnv, w
 	)
 
 	run, err := env.SdkClient().ExecuteWorkflow(
-		env.Context(),
+		s.Context(),
 		sdkclient.StartWorkflowOptions{
 			ID:        testcore.RandomizeStr("wf-trailer"),
 			TaskQueue: env.WorkerTaskQueue(),
@@ -48,7 +48,7 @@ func (s *WorkflowTypeEncodingSuite) runWithWorkflowType(env *testcore.TestEnv, w
 	if err != nil {
 		return err
 	}
-	return run.Get(env.Context(), nil)
+	return run.Get(s.Context(), nil)
 }
 
 func (s *WorkflowTypeEncodingSuite) TestPlainASCII() {


### PR DESCRIPTION
## Why?

`env.Context()` is deprecated.

NOTE: It cannot be deleted yet as `schedules_test.go` makes extensive use of it still. That's a separate effort.