### PR TITLE
Allow Omes worker toolchain updates

### DIFF
--- a/tests/mixedbrain/mixed_brain_test.go
+++ b/tests/mixedbrain/mixed_brain_test.go
@@ -253,6 +253,7 @@ func runOmes(t *testing.T, binary, serverAddr, logPath string, duration time.Dur
 
 		var buf bytes.Buffer
 		cmd := exec.CommandContext(t.Context(), binary, args...)
+		cmd.Env = append(os.Environ(), "GOTOOLCHAIN=auto") // Omes workers may require a newer toolchain
 		cmd.Stdout = logFile
 		cmd.Stderr = io.MultiWriter(logFile, &buf)
 		cmd.Cancel = func() error { return cmd.Process.Signal(syscall.SIGTERM) }


### PR DESCRIPTION
Fixes
```
2026-07-15T22:53:17.530Z	FATAL	omes/run_scenario_with_worker.go:25	worker did not start: failed building worker: failed preparing: failed go mod tidy: exit status 1
```

([logs](https://github.com/temporalio/temporal/actions/runs/29456542348/job/87491076147#step:10:15))