### PR TITLE
Standalone Activities: Include heartbeat details on timeout failures

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -644,18 +644,17 @@ func (a *Activity) handleCancellationRequested(ctx chasm.MutableContext, request
 // recordScheduleToStartOrCloseTimeoutFailure records schedule-to-start or schedule-to-close timeouts. Such timeouts are not retried so we
 // set the outcome failure directly and leave the attempt failure as is.
 func (a *Activity) recordScheduleToStartOrCloseTimeoutFailure(ctx chasm.MutableContext, timeoutType enumspb.TimeoutType) error {
-	outcome := a.Outcome.Get(ctx)
-
 	failure := &failurepb.Failure{
 		Message: fmt.Sprintf(common.FailureReasonActivityTimeout, timeoutType.String()),
 		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{
 			TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
-				TimeoutType: timeoutType,
+				TimeoutType:          timeoutType,
+				LastHeartbeatDetails: a.lastHeartbeatDetails(ctx),
 			},
 		},
 	}
 
-	outcome.Variant = &activitypb.ActivityOutcome_Failed_{
+	a.Outcome.Get(ctx).Variant = &activitypb.ActivityOutcome_Failed_{
 		Failed: &activitypb.ActivityOutcome_Failed{
 			Failure: failure,
 		},
@@ -773,6 +772,16 @@ func createHeartbeatTimeoutFailure() *failurepb.Failure {
 			},
 		},
 	}
+}
+
+// lastHeartbeatDetails returns the details recorded by the most recent heartbeat, or nil if
+// the activity never heartbeated.
+func (a *Activity) lastHeartbeatDetails(ctx chasm.Context) *commonpb.Payloads {
+	heartbeat, ok := a.LastHeartbeat.TryGet(ctx)
+	if !ok {
+		return nil
+	}
+	return heartbeat.GetDetails()
 }
 
 // RecordHeartbeat records a heartbeat for the activity.

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -371,9 +371,11 @@ var TransitionTimedOut = chasm.NewTransition(
 				err = a.recordScheduleToStartOrCloseTimeoutFailure(ctx, timeoutType)
 			case enumspb.TIMEOUT_TYPE_START_TO_CLOSE:
 				failure := createStartToCloseTimeoutFailure()
+				failure.GetTimeoutFailureInfo().LastHeartbeatDetails = a.lastHeartbeatDetails(ctx)
 				err = a.recordFailedAttempt(ctx, 0, failure, ctx.Now(a), true)
 			case enumspb.TIMEOUT_TYPE_HEARTBEAT:
 				failure := createHeartbeatTimeoutFailure()
+				failure.GetTimeoutFailureInfo().LastHeartbeatDetails = a.lastHeartbeatDetails(ctx)
 				err = a.recordFailedAttempt(ctx, 0, failure, ctx.Now(a), true)
 			default:
 				err = fmt.Errorf("unhandled activity timeout: %v", timeoutType)

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -325,10 +325,11 @@ func TestTransitionStarted(t *testing.T) {
 
 func TestTransitionTimedout(t *testing.T) {
 	testCases := []struct {
-		name         string
-		startStatus  activitypb.ActivityExecutionStatus
-		timeoutType  enumspb.TimeoutType
-		attemptCount int32
+		name             string
+		startStatus      activitypb.ActivityExecutionStatus
+		timeoutType      enumspb.TimeoutType
+		attemptCount     int32
+		heartbeatDetails *commonpb.Payloads
 	}{
 		{
 			name:         "schedule to start timeout",
@@ -343,19 +344,28 @@ func TestTransitionTimedout(t *testing.T) {
 			attemptCount: 3,
 		},
 		{
-			name:         "schedule to close timeout from started status",
-			startStatus:  activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
-			timeoutType:  enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
-			attemptCount: 4,
+			name:             "schedule to close timeout from started status with heartbeat details",
+			startStatus:      activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
+			timeoutType:      enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+			attemptCount:     4,
+			heartbeatDetails: payloads.EncodeString("schedule-to-close-heartbeat"),
 		},
 		{
-			name:         "start to close timeout",
-			startStatus:  activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
-			timeoutType:  enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
-			attemptCount: 5,
+			name:             "start to close timeout with heartbeat details",
+			startStatus:      activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
+			timeoutType:      enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
+			attemptCount:     5,
+			heartbeatDetails: payloads.EncodeString("start-to-close-heartbeat"),
 		},
 		{
-			name:         "heartbeat timeout",
+			name:             "heartbeat timeout with heartbeat details",
+			startStatus:      activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
+			timeoutType:      enumspb.TIMEOUT_TYPE_HEARTBEAT,
+			attemptCount:     2,
+			heartbeatDetails: payloads.EncodeString("heartbeat-details"),
+		},
+		{
+			name:         "heartbeat timeout without heartbeat details",
 			startStatus:  activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
 			timeoutType:  enumspb.TIMEOUT_TYPE_HEARTBEAT,
 			attemptCount: 2,
@@ -380,6 +390,11 @@ func TestTransitionTimedout(t *testing.T) {
 				},
 				LastAttempt: chasm.NewDataField(ctx, attemptState),
 				Outcome:     chasm.NewDataField(ctx, outcome),
+			}
+			if tc.heartbeatDetails != nil {
+				activity.LastHeartbeat = chasm.NewDataField(ctx, &activitypb.ActivityHeartbeatState{
+					Details: tc.heartbeatDetails,
+				})
 			}
 
 			controller := gomock.NewController(t)
@@ -419,17 +434,24 @@ func TestTransitionTimedout(t *testing.T) {
 				// Timeout failure is recorded in outcome but not attempt state
 				require.Nil(t, attemptState.GetLastFailureDetails())
 				require.Nil(t, attemptState.GetCompleteTime())
-				require.NotNil(t, outcome.GetFailed().GetFailure())
-				// do something
+				outcomeFailure := outcome.GetFailed().GetFailure()
+				require.NotNil(t, outcomeFailure)
+				// The last heartbeat details must be surfaced on the timeout failure so callers can
+				// inspect the activity's last reported progress.
+				protorequire.ProtoEqual(t, tc.heartbeatDetails, outcomeFailure.GetTimeoutFailureInfo().GetLastHeartbeatDetails())
 			case enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
 				enumspb.TIMEOUT_TYPE_HEARTBEAT:
 				// Timeout failure is recorded in attempt state only. TransitionTimedOut should only be called when there
 				// are no more retries. Retries go through TransitionRescheduled.
-				require.NotNil(t, attemptState.GetLastFailureDetails().GetFailure())
+				recordedFailure := attemptState.GetLastFailureDetails().GetFailure()
+				require.NotNil(t, recordedFailure)
 				require.NotNil(t, attemptState.GetLastFailureDetails().GetTime())
 				require.NotNil(t, attemptState.GetCompleteTime())
 				require.Nil(t, attemptState.GetCurrentRetryInterval())
 				require.Nil(t, outcome.GetVariant())
+				// The last heartbeat details must be surfaced on the timeout failure so callers can
+				// inspect the activity's last reported progress.
+				protorequire.ProtoEqual(t, tc.heartbeatDetails, recordedFailure.GetTimeoutFailureInfo().GetLastHeartbeatDetails())
 
 			default:
 				t.Fatalf("unexpected timeout type: %v", tc.timeoutType)

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -5520,6 +5520,66 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 			"expected timeout type=Heartbeat but is %s", pollResp.GetOutcome().GetFailure().GetTimeoutFailureInfo().GetTimeoutType())
 	})
 
+	t.Run("HeartbeatDetailsSurfacedOnTimeout", func(t *testing.T) {
+		// Start activity (no retries), worker accepts task and records a heartbeat with details,
+		// then stops heartbeating so the heartbeat timeout fires.
+		// Verify: the timeout failure surfaces the last reported heartbeat details, matching the
+		// workflow-embedded activity behavior.
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          activityID,
+			ActivityType:        env.Tv().ActivityType(),
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout: durationpb.New(1 * time.Minute),
+			HeartbeatTimeout:    durationpb.New(1 * time.Second),
+			RetryPolicy: &commonpb.RetryPolicy{
+				MaximumAttempts: 1, // No retries
+			},
+		})
+		require.NoError(t, err)
+
+		// Worker accepts task (starts the activity)
+		pollTaskResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
+			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, pollTaskResp.TaskToken)
+
+		// Worker records a heartbeat with details, then stops heartbeating.
+		heartbeatDetails := payloads.EncodeString("progress before timeout")
+		_, err = env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
+			Namespace: env.Namespace().String(),
+			TaskToken: pollTaskResp.TaskToken,
+			Details:   heartbeatDetails,
+		})
+		require.NoError(t, err)
+
+		// Long poll for completion (heartbeat timeout will fire)
+		pollResp, err := env.FrontendClient().PollActivityExecution(ctx, &workflowservice.PollActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		timeoutFailureInfo := pollResp.GetOutcome().GetFailure().GetTimeoutFailureInfo()
+		require.Equal(t, enumspb.TIMEOUT_TYPE_HEARTBEAT, timeoutFailureInfo.GetTimeoutType(),
+			"expected timeout type=Heartbeat but is %s", timeoutFailureInfo.GetTimeoutType())
+		protorequire.ProtoEqual(t, heartbeatDetails, timeoutFailureInfo.GetLastHeartbeatDetails())
+
+		// The details are also surfaced via DescribeActivityExecution.
+		desc, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		protorequire.ProtoEqual(t, heartbeatDetails, desc.GetInfo().GetHeartbeatDetails())
+	})
+
 	t.Run("ActivityRetriesOnHeartbeatTimeout", func(t *testing.T) {
 		// Start activity (with retries), worker accepts task, time passes beyond
 		// heartbeat timeout, worker never heartbeats.


### PR DESCRIPTION
## What changed?
For Standalone Activities include heartbeat details on timeout failures.

## Why?
Match behaviour of regular activities.

## How did you test it?
- [ ] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to timeout failure protobuf fields with parity tests; no auth or scheduling logic changes.
> 
> **Overview**
> Standalone activities now attach **last heartbeat details** to activity timeout failures, aligning with workflow-embedded activities.
> 
> A new `lastHeartbeatDetails` helper reads the most recent heartbeat from `LastHeartbeat`. **Schedule-to-start** and **schedule-to-close** timeouts set `TimeoutFailureInfo.LastHeartbeatDetails` on the outcome failure; **start-to-close** and **heartbeat** timeouts set it on the attempt failure when the activity times out with no retries left.
> 
> Unit tests in `statemachine_test` and a functional test `HeartbeatDetailsSurfacedOnTimeout` verify the details appear on poll/describe outcomes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 126c09cd5ce69e17f17c83f903c298c01661ea4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->