### PR TITLE
Enable CHASM callbacks by default

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -3136,7 +3136,7 @@ existing workflows to attach callbacks.`,
 
 	EnableCHASMCallbacks = NewNamespaceBoolSetting(
 		"history.enableCHASMCallbacks",
-		false,
+		true,
 		`Controls whether new callbacks are created using the CHASM implementation
 instead of the previous HSM backed implementation.`,
 	)

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -283,8 +283,14 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_UseExisting_OnConflictOpt
 				testcore.WithDynamicConfig(callback.AllowedAddresses, allowedAddresses),
 			}
 			if tc.MaxCallbacksPerWorkflow > 0 {
+				// Set both the legacy (HSM) and CHASM callback limits so the limit is
+				// enforced regardless of which callback implementation is active.
 				opts = append(opts, testcore.WithDynamicConfig(
 					dynamicconfig.MaxCallbacksPerWorkflow,
+					tc.MaxCallbacksPerWorkflow,
+				))
+				opts = append(opts, testcore.WithDynamicConfig(
+					callback.MaxPerExecution,
 					tc.MaxCallbacksPerWorkflow,
 				))
 			}

--- a/tests/xdc/nexus_state_replication_test.go
+++ b/tests/xdc/nexus_state_replication_test.go
@@ -82,6 +82,13 @@ func (s *NexusStateReplicationSuite) SetupSuite() {
 			Timeout:     1 * time.Second,
 		},
 	}
+	if !s.enableTransitionHistory {
+		// CHASM callbacks rely on transition history for replication (their outbound
+		// task fails with "state has empty transition history" otherwise), so when
+		// transition history is disabled fall back to the legacy HSM callback
+		// implementation, which works with event-based replication.
+		s.dynamicConfigOverrides[dynamicconfig.EnableCHASMCallbacks.Key()] = false
+	}
 	s.setupSuite()
 }
 


### PR DESCRIPTION
## What changed?

Changed the dynamic config default for "history.enableCHASMCallbacks" to true.

## Why?

The feature has been stable for a while now and is the preferred implementation.