### PR TITLE
validation to reject negative activity jitter

### DIFF
--- a/chasm/lib/activity/validator.go
+++ b/chasm/lib/activity/validator.go
@@ -759,7 +759,7 @@ func validateAndNormalizeResetActivityExecutionRequest(
 			return serviceerror.NewInvalidArgument("invalid run id: must be a valid UUID")
 		}
 	}
-	return nil
+	return validateJitter(req.GetJitter())
 }
 
 func validateAndNormalizeUnpauseActivityExecutionRequest(
@@ -782,6 +782,13 @@ func validateAndNormalizeUnpauseActivityExecutionRequest(
 		if err != nil {
 			return serviceerror.NewInvalidArgument("invalid run id: must be a valid UUID")
 		}
+	}
+	return validateJitter(req.GetJitter())
+}
+
+func validateJitter(jitter *durationpb.Duration) error {
+	if err := timestamp.ValidateAndCapProtoDuration(jitter); err != nil {
+		return serviceerror.NewInvalidArgumentf("invalid jitter: %v", err)
 	}
 	return nil
 }

--- a/chasm/lib/activity/validator_test.go
+++ b/chasm/lib/activity/validator_test.go
@@ -1061,6 +1061,17 @@ func TestValidateUnpauseActivityExecutionRequest(t *testing.T) {
 		require.ErrorAs(t, err, &invalidArgErr)
 		require.Equal(t, "invalid run id: must be a valid UUID", invalidArgErr.Message)
 	})
+
+	t.Run("NegativeJitter", func(t *testing.T) {
+		req := &workflowservice.UnpauseActivityExecutionRequest{
+			ActivityId: defaultActivityID,
+			Jitter:     durationpb.New(-time.Second),
+		}
+		err := validateAndNormalizeUnpauseActivityExecutionRequest(req, defaultMaxIDLengthLimit)
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Equal(t, "invalid jitter: negative duration", invalidArgErr.Message)
+	})
 }
 
 func TestValidateResetActivityExecutionRequest(t *testing.T) {
@@ -1128,6 +1139,17 @@ func TestValidateResetActivityExecutionRequest(t *testing.T) {
 		var invalidArgErr *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgErr)
 		require.Equal(t, "invalid run id: must be a valid UUID", invalidArgErr.Message)
+	})
+
+	t.Run("NegativeJitter", func(t *testing.T) {
+		req := &workflowservice.ResetActivityExecutionRequest{
+			ActivityId: defaultActivityID,
+			Jitter:     durationpb.New(-time.Second),
+		}
+		err := validateAndNormalizeResetActivityExecutionRequest(req, defaultMaxIDLengthLimit)
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Equal(t, "invalid jitter: negative duration", invalidArgErr.Message)
 	})
 }
 


### PR DESCRIPTION
## What changed?
Added validation that rejects invalid or negative jitter values for reset and unpause activity execution requests. Added regression tests for both request types.

## Why?
Negative jitter could reach workflow activity scheduling and be passed to rand.Int63n, which panics for non-positive arguments. Rejecting it at the request boundary prevents a History service panic and keeps workflow and standalone activity behavior consistent.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)