### PR TITLE
(WIP) add time-skipping info to describe workflow executions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.44.0
-	go.temporal.io/api v1.63.4-0.20260714232926-421d65d20788
+	go.temporal.io/api v1.63.4-0.20260716034231-233d261c148d
 	go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee
 	go.temporal.io/sdk v1.41.1
 	go.uber.org/fx v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -479,8 +479,8 @@ go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0 h1:R
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0/go.mod h1:I89cynRj8y+383o7tEQVg2SVA6SRgDVIouWPUVXjx0U=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0 h1:CQvJSldHRUN6Z8jsUeYv8J0lXRvygALXIzsmAeCcZE0=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0/go.mod h1:xSQ+mEfJe/GjK1LXEyVOoSI1N9JV9ZI923X5kup43W4=
-go.temporal.io/api v1.63.4-0.20260714232926-421d65d20788 h1:DKu23a0yZmAPoFgcaJsEFAwzdB3wFlZcpKUdgELPYDw=
-go.temporal.io/api v1.63.4-0.20260714232926-421d65d20788/go.mod h1:0k75tRljEuELWGeXjEZZO7zYqBln4+1FrG6+IMOMy7Q=
+go.temporal.io/api v1.63.4-0.20260716034231-233d261c148d h1:hxvzdpO1Th9OQnTGpz2cDK8nE3NtcD5KIqMfd0keXOc=
+go.temporal.io/api v1.63.4-0.20260716034231-233d261c148d/go.mod h1:0k75tRljEuELWGeXjEZZO7zYqBln4+1FrG6+IMOMy7Q=
 go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee h1:y6A65Iml06cR3CpxW2Zn8FQLjniPDTnN4jtr69UZxXI=
 go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee/go.mod h1:hhHijO9XRPIkAflLJJHix61M9FzbRPqk8fSydkcLkqw=
 go.temporal.io/sdk v1.41.1 h1:yOpvsHyDD1lNuwlGBv/SUodCPhjv9nDeC9lLHW/fJUA=

--- a/service/history/api/describeworkflow/api.go
+++ b/service/history/api/describeworkflow/api.go
@@ -60,6 +60,32 @@ func clonePayloadMap(source map[string]*commonpb.Payload) map[string]*commonpb.P
 	return target
 }
 
+// makeTimeSkippingInfo converts the persisted time-skipping state into the
+// public common.v1.TimeSkippingInfo. CurrentTime is the execution's virtual
+// clock; IsRunning tracks the config's enabled flag, which the server clears
+// once a fast-forward completes.
+func makeTimeSkippingInfo(mutableState historyi.MutableState) *commonpb.TimeSkippingInfo {
+	tsi := mutableState.GetExecutionInfo().GetTimeSkippingInfo()
+	info := &commonpb.TimeSkippingInfo{
+		CurrentTime: timestamppb.New(mutableState.Now()),
+		IsRunning:   tsi.GetConfig().GetEnabled(),
+	}
+	if ff := tsi.GetFastForwardInfo(); ff != nil {
+		var createTime *timestamppb.Timestamp
+		// The server sets target = create + fast_forward, so recover the
+		// creation virtual time by subtracting the configured duration.
+		if target := ff.GetTargetTime(); target != nil {
+			createTime = timestamppb.New(target.AsTime().Add(-tsi.GetConfig().GetFastForward().AsDuration()))
+		}
+		info.FastForward = &commonpb.TimeSkippingInfo_TimeSkippingFastForwardInfo{
+			CreateTime:   createTime,
+			TargetTime:   ff.GetTargetTime(),
+			HasCompleted: ff.GetHasReached(),
+		}
+	}
+	return info
+}
+
 func Invoke(
 	ctx context.Context,
 	req *historyservice.DescribeWorkflowExecutionRequest,
@@ -162,6 +188,10 @@ func Invoke(
 
 	if mutableState.IsResetRun() {
 		result.WorkflowExtendedInfo.LastResetTime = executionState.StartTime
+	}
+
+	if executionInfo.TimeSkippingInfo != nil {
+		result.WorkflowExtendedInfo.TimeSkippingInfo = makeTimeSkippingInfo(mutableState)
 	}
 
 	if shard.GetConfig().ExternalPayloadsEnabled(namespaceName) {

--- a/service/history/api/describeworkflow/api.go
+++ b/service/history/api/describeworkflow/api.go
@@ -60,33 +60,72 @@ func clonePayloadMap(source map[string]*commonpb.Payload) map[string]*commonpb.P
 	return target
 }
 
-// makeTimeSkippingInfo converts the persisted time-skipping state into the
-// public common.v1.TimeSkippingInfo. CurrentTime is the execution's virtual
-// clock; IsRunning tracks the config's enabled flag, which the server clears
-// once a fast-forward completes.
-func makeTimeSkippingInfo(mutableState historyi.MutableState) *commonpb.TimeSkippingInfo {
-	tsi := mutableState.GetExecutionInfo().GetTimeSkippingInfo()
-	info := &commonpb.TimeSkippingInfo{
-		CurrentTime: timestamppb.New(mutableState.Now()),
-		IsRunning:   tsi.GetConfig().GetEnabled(),
-	}
-	if ff := tsi.GetFastForwardInfo(); ff != nil {
-		var createTime *timestamppb.Timestamp
-		// The server sets target = create + fast_forward, so recover the
-		// creation virtual time by subtracting the configured duration.
-		if target := ff.GetTargetTime(); target != nil {
-			createTime = timestamppb.New(target.AsTime().Add(-tsi.GetConfig().GetFastForward().AsDuration()))
-		}
-		info.FastForward = &commonpb.TimeSkippingInfo_TimeSkippingFastForwardInfo{
-			CreateTime:   createTime,
-			TargetTime:   ff.GetTargetTime(),
-			HasCompleted: ff.GetHasReached(),
-		}
-	}
-	return info
+// ExecutionNotifier delivers time-skipping fast-forward updates for an execution: Subscribe returns
+// a channel that receives the current TimeSkippingInfo whenever the fast-forward changes (set,
+// reset, cleared, or completed), plus an unsubscribe function. It fires on close-transaction, no
+// history event required.
+type ExecutionNotifier interface {
+	Subscribe(key chasm.ExecutionKey) (<-chan *commonpb.TimeSkippingInfo, func())
 }
 
+// Invoke handles DescribeWorkflowExecution. When the request sets WaitTimeskippingCompletion and
+// the execution has a pending time-skipping fast-forward, it blocks until the fast-forward
+// completes (or is cleared) or the request context deadline is reached, returning the latest state
+// in either case.
 func Invoke(
+	ctx context.Context,
+	req *historyservice.DescribeWorkflowExecutionRequest,
+	shard historyi.ShardContext,
+	workflowConsistencyChecker api.WorkflowConsistencyChecker,
+	persistenceVisibilityMgr manager.VisibilityManager,
+	outboundQueueCBPool *circuitbreakerpool.OutboundQueueCircuitBreakerPool,
+	executionNotifier ExecutionNotifier,
+) (*historyservice.DescribeWorkflowExecutionResponse, error) {
+	if !req.GetRequest().GetWaitTimeskippingCompletion() || executionNotifier == nil {
+		return describeOnce(ctx, req, shard, workflowConsistencyChecker, persistenceVisibilityMgr, outboundQueueCBPool)
+	}
+
+	executionKey := chasm.ExecutionKey{
+		NamespaceID: req.NamespaceId,
+		BusinessID:  req.Request.Execution.WorkflowId,
+		RunID:       req.Request.Execution.RunId,
+	}
+	// Subscribe before the initial read: any fast-forward change after we subscribe is delivered on
+	// the channel, and any change before it is reflected in the read below, so we never miss the
+	// completion. This waits without holding the workflow lock.
+	channel, unsubscribe := executionNotifier.Subscribe(executionKey)
+	defer unsubscribe()
+
+	result, err := describeOnce(ctx, req, shard, workflowConsistencyChecker, persistenceVisibilityMgr, outboundQueueCBPool)
+	if err != nil {
+		return nil, err
+	}
+	if !fastForwardPending(result.GetWorkflowExtendedInfo().GetTimeSkippingInfo()) {
+		return result, nil
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Deadline reached: return the latest state with the fast-forward still pending.
+			return result, nil
+		case info := <-channel:
+			// The notification carries the fresh TimeSkippingInfo; patch it into the response so
+			// waiters get up-to-date fast-forward info and virtual time without re-reading.
+			result.WorkflowExtendedInfo.TimeSkippingInfo = info
+			if !fastForwardPending(info) {
+				return result, nil
+			}
+		}
+	}
+}
+
+func fastForwardPending(info *commonpb.TimeSkippingInfo) bool {
+	ff := info.GetFastForward()
+	return ff != nil && !ff.GetHasCompleted()
+}
+
+func describeOnce(
 	ctx context.Context,
 	req *historyservice.DescribeWorkflowExecutionRequest,
 	shard historyi.ShardContext,
@@ -190,9 +229,10 @@ func Invoke(
 		result.WorkflowExtendedInfo.LastResetTime = executionState.StartTime
 	}
 
-	if executionInfo.TimeSkippingInfo != nil {
-		result.WorkflowExtendedInfo.TimeSkippingInfo = makeTimeSkippingInfo(mutableState)
-	}
+	result.WorkflowExtendedInfo.TimeSkippingInfo = workflow.BuildTimeSkippingInfo(
+		executionInfo.GetTimeSkippingInfo(),
+		mutableState.Now(),
+	)
 
 	if shard.GetConfig().ExternalPayloadsEnabled(namespaceName) {
 		executionStats := executionInfo.GetExecutionStats()

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -92,6 +92,7 @@ var Module = fx.Options(
 	service.PersistenceLazyLoadedServiceResolverModule,
 	fx.Provide(ServiceResolverProvider),
 	fx.Provide(EventNotifierProvider),
+	fx.Provide(NewTimeSkippingFastForwardNotifier),
 	fx.Provide(HistoryEngineFactoryProvider),
 	fx.Provide(HandlerProvider),
 	fx.Provide(HistoryServiceServerProvider),

--- a/service/history/history_engine.go
+++ b/service/history/history_engine.go
@@ -102,52 +102,53 @@ import (
 
 type (
 	historyEngineImpl struct {
-		status                     int32
-		currentClusterName         string
-		shardContext               historyi.ShardContext
-		timeSource                 clock.TimeSource
-		clusterMetadata            cluster.Metadata
-		executionManager           persistence.ExecutionManager
-		queueProcessors            map[tasks.Category]queues.Queue
-		replicationAckMgr          replication.AckManager
-		nDCHistoryReplicator       ndc.HistoryReplicator
-		nDCHistoryImporter         ndc.HistoryImporter
-		nDCActivityStateReplicator ndc.ActivityStateReplicator
-		nDCWorkflowStateReplicator ndc.WorkflowStateReplicator
-		nDCHSMStateReplicator      ndc.HSMStateReplicator
-		replicationProcessorMgr    replication.TaskProcessor
-		eventNotifier              events.Notifier
-		tokenSerializer            *tasktoken.Serializer
-		metricsHandler             metrics.Handler
-		logger                     log.Logger
-		throttledLogger            log.Logger
-		config                     *configs.Config
-		workflowRebuilder          workflowRebuilder
-		workflowResetter           ndc.WorkflowResetter
-		sdkClientFactory           sdk.ClientFactory
-		eventsReapplier            ndc.EventsReapplier
-		matchingClient             matchingservice.MatchingServiceClient
-		rawMatchingClient          matchingservice.MatchingServiceClient
-		replicationDLQHandler      replication.DLQHandler
-		persistenceVisibilityMgr   manager.VisibilityManager
-		searchAttributesValidator  *searchattribute.Validator
-		workflowDeleteManager      deletemanager.DeleteManager
-		serializer                 serialization.Serializer
-		workflowConsistencyChecker api.WorkflowConsistencyChecker
-		chasmEngine                chasm.Engine
-		versionChecker             headers.VersionChecker
-		versionCache               worker_versioning.VersionMembershipAndReactivationStatusCache
-		workerDeploymentClient     workerdeployment.Client
-		routingInfoCache           worker_versioning.RoutingInfoCache
-		tracer                     trace.Tracer
-		taskCategoryRegistry       tasks.TaskCategoryRegistry
-		commandHandlerRegistry     *workflow.CommandHandlerRegistry
-		chasmWorkflowRegistry      *chasmworkflow.Registry
-		workflowCache              wcache.Cache
-		replicationProgressCache   replication.ProgressCache
-		syncStateRetriever         replication.SyncStateRetriever
-		outboundQueueCBPool        *circuitbreakerpool.OutboundQueueCircuitBreakerPool
-		testHooks                  testhooks.TestHooks
+		status                          int32
+		currentClusterName              string
+		shardContext                    historyi.ShardContext
+		timeSource                      clock.TimeSource
+		clusterMetadata                 cluster.Metadata
+		executionManager                persistence.ExecutionManager
+		queueProcessors                 map[tasks.Category]queues.Queue
+		replicationAckMgr               replication.AckManager
+		nDCHistoryReplicator            ndc.HistoryReplicator
+		nDCHistoryImporter              ndc.HistoryImporter
+		nDCActivityStateReplicator      ndc.ActivityStateReplicator
+		nDCWorkflowStateReplicator      ndc.WorkflowStateReplicator
+		nDCHSMStateReplicator           ndc.HSMStateReplicator
+		replicationProcessorMgr         replication.TaskProcessor
+		eventNotifier                   events.Notifier
+		tokenSerializer                 *tasktoken.Serializer
+		metricsHandler                  metrics.Handler
+		logger                          log.Logger
+		throttledLogger                 log.Logger
+		config                          *configs.Config
+		workflowRebuilder               workflowRebuilder
+		workflowResetter                ndc.WorkflowResetter
+		sdkClientFactory                sdk.ClientFactory
+		eventsReapplier                 ndc.EventsReapplier
+		matchingClient                  matchingservice.MatchingServiceClient
+		rawMatchingClient               matchingservice.MatchingServiceClient
+		replicationDLQHandler           replication.DLQHandler
+		persistenceVisibilityMgr        manager.VisibilityManager
+		searchAttributesValidator       *searchattribute.Validator
+		workflowDeleteManager           deletemanager.DeleteManager
+		serializer                      serialization.Serializer
+		workflowConsistencyChecker      api.WorkflowConsistencyChecker
+		chasmEngine                     chasm.Engine
+		timeSkippingFastForwardNotifier *TimeSkippingFastForwardNotifier
+		versionChecker                  headers.VersionChecker
+		versionCache                    worker_versioning.VersionMembershipAndReactivationStatusCache
+		workerDeploymentClient          workerdeployment.Client
+		routingInfoCache                worker_versioning.RoutingInfoCache
+		tracer                          trace.Tracer
+		taskCategoryRegistry            tasks.TaskCategoryRegistry
+		commandHandlerRegistry          *workflow.CommandHandlerRegistry
+		chasmWorkflowRegistry           *chasmworkflow.Registry
+		workflowCache                   wcache.Cache
+		replicationProgressCache        replication.ProgressCache
+		syncStateRetriever              replication.SyncStateRetriever
+		outboundQueueCBPool             *circuitbreakerpool.OutboundQueueCircuitBreakerPool
+		testHooks                       testhooks.TestHooks
 	}
 )
 
@@ -181,6 +182,7 @@ func NewEngineWithShardContext(
 	persistenceRateLimiter quotas.RequestRateLimiter,
 	testHooks testhooks.TestHooks,
 	chasmEngine chasm.Engine,
+	timeSkippingFastForwardNotifier *TimeSkippingFastForwardNotifier,
 ) historyi.Engine {
 	currentClusterName := shard.GetClusterMetadata().GetCurrentClusterName()
 
@@ -203,39 +205,40 @@ func NewEngineWithShardContext(
 	)
 
 	historyEngImpl := &historyEngineImpl{
-		status:                     common.DaemonStatusInitialized,
-		currentClusterName:         currentClusterName,
-		shardContext:               shard,
-		clusterMetadata:            shard.GetClusterMetadata(),
-		timeSource:                 shard.GetTimeSource(),
-		executionManager:           executionManager,
-		tokenSerializer:            tasktoken.NewSerializer(),
-		logger:                     log.With(logger, tag.ComponentHistoryEngine),
-		throttledLogger:            log.With(shard.GetThrottledLogger(), tag.ComponentHistoryEngine),
-		metricsHandler:             shard.GetMetricsHandler(),
-		eventNotifier:              eventNotifier,
-		config:                     config,
-		sdkClientFactory:           sdkClientFactory,
-		matchingClient:             matchingClient,
-		rawMatchingClient:          rawMatchingClient,
-		persistenceVisibilityMgr:   persistenceVisibilityMgr,
-		workflowDeleteManager:      workflowDeleteManager,
-		serializer:                 serializer,
-		workflowConsistencyChecker: workflowConsistencyChecker,
-		versionChecker:             headers.NewDefaultVersionChecker(),
-		tracer:                     tracerProvider.Tracer(consts.LibraryName),
-		taskCategoryRegistry:       taskCategoryRegistry,
-		commandHandlerRegistry:     commandHandlerRegistry,
-		chasmWorkflowRegistry:      chasmWorkflowRegistry,
-		workflowCache:              workflowCache,
-		replicationProgressCache:   replicationProgressCache,
-		syncStateRetriever:         syncStateRetriever,
-		outboundQueueCBPool:        outboundQueueCBPool,
-		testHooks:                  testHooks,
-		chasmEngine:                chasmEngine,
-		versionCache:               versionCache,
-		workerDeploymentClient:     workerDeploymentClient,
-		routingInfoCache:           routingInfoCache,
+		status:                          common.DaemonStatusInitialized,
+		currentClusterName:              currentClusterName,
+		shardContext:                    shard,
+		clusterMetadata:                 shard.GetClusterMetadata(),
+		timeSource:                      shard.GetTimeSource(),
+		executionManager:                executionManager,
+		tokenSerializer:                 tasktoken.NewSerializer(),
+		logger:                          log.With(logger, tag.ComponentHistoryEngine),
+		throttledLogger:                 log.With(shard.GetThrottledLogger(), tag.ComponentHistoryEngine),
+		metricsHandler:                  shard.GetMetricsHandler(),
+		eventNotifier:                   eventNotifier,
+		config:                          config,
+		sdkClientFactory:                sdkClientFactory,
+		matchingClient:                  matchingClient,
+		rawMatchingClient:               rawMatchingClient,
+		persistenceVisibilityMgr:        persistenceVisibilityMgr,
+		workflowDeleteManager:           workflowDeleteManager,
+		serializer:                      serializer,
+		workflowConsistencyChecker:      workflowConsistencyChecker,
+		versionChecker:                  headers.NewDefaultVersionChecker(),
+		tracer:                          tracerProvider.Tracer(consts.LibraryName),
+		taskCategoryRegistry:            taskCategoryRegistry,
+		commandHandlerRegistry:          commandHandlerRegistry,
+		chasmWorkflowRegistry:           chasmWorkflowRegistry,
+		workflowCache:                   workflowCache,
+		replicationProgressCache:        replicationProgressCache,
+		syncStateRetriever:              syncStateRetriever,
+		outboundQueueCBPool:             outboundQueueCBPool,
+		testHooks:                       testHooks,
+		chasmEngine:                     chasmEngine,
+		timeSkippingFastForwardNotifier: timeSkippingFastForwardNotifier,
+		versionCache:                    versionCache,
+		workerDeploymentClient:          workerDeploymentClient,
+		routingInfoCache:                routingInfoCache,
 	}
 
 	historyEngImpl.queueProcessors = make(map[tasks.Category]queues.Queue)
@@ -533,6 +536,7 @@ func (e *historyEngineImpl) DescribeWorkflowExecution(
 		e.workflowConsistencyChecker,
 		e.persistenceVisibilityMgr,
 		e.outboundQueueCBPool,
+		e.timeSkippingFastForwardNotifier,
 	)
 }
 
@@ -881,6 +885,12 @@ func (e *historyEngineImpl) NotifyNewHistoryEvent(
 func (e *historyEngineImpl) NotifyChasmExecution(executionKey chasm.ExecutionKey, componentRef []byte) {
 	if e.chasmEngine != nil {
 		e.chasmEngine.NotifyExecution(executionKey)
+	}
+}
+
+func (e *historyEngineImpl) NotifyTimeSkippingFastForwardUpdate(executionKey chasm.ExecutionKey, info *commonpb.TimeSkippingInfo) {
+	if e.timeSkippingFastForwardNotifier != nil {
+		e.timeSkippingFastForwardNotifier.Notify(executionKey, info)
 	}
 }
 

--- a/service/history/history_engine_factory.go
+++ b/service/history/history_engine_factory.go
@@ -52,6 +52,7 @@ type (
 		PersistenceRateLimiter          replication.PersistenceRateLimiter
 		TestHooks                       testhooks.TestHooks
 		ChasmEngine                     chasm.Engine
+		TimeSkippingFastForwardNotifier *TimeSkippingFastForwardNotifier
 		VersionMembershipCache          worker_versioning.VersionMembershipAndReactivationStatusCache
 		WorkerDeploymentClient          workerdeployment.Client
 		RoutingInfoCache                worker_versioning.RoutingInfoCache
@@ -94,5 +95,6 @@ func (f *historyEngineFactory) CreateEngine(
 		f.PersistenceRateLimiter,
 		f.TestHooks,
 		f.ChasmEngine,
+		f.TimeSkippingFastForwardNotifier,
 	)
 }

--- a/service/history/interfaces/engine.go
+++ b/service/history/interfaces/engine.go
@@ -102,6 +102,7 @@ type (
 		NotifyNewHistoryEvent(event *events.Notification)
 		NotifyNewTasks(tasks map[tasks.Category][]tasks.Task)
 		NotifyChasmExecution(executionKey chasm.ExecutionKey, componentRef []byte)
+		NotifyTimeSkippingFastForwardUpdate(executionKey chasm.ExecutionKey, info *commonpb.TimeSkippingInfo)
 		// TODO(bergundy): This Environment should be host level once shard level workflow cache is deprecated.
 		StateMachineEnvironment(operationTag metrics.Tag) hsm.Environment
 

--- a/service/history/interfaces/engine_mock.go
+++ b/service/history/interfaces/engine_mock.go
@@ -426,6 +426,18 @@ func (mr *MockEngineMockRecorder) NotifyChasmExecution(executionKey, componentRe
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyChasmExecution", reflect.TypeOf((*MockEngine)(nil).NotifyChasmExecution), executionKey, componentRef)
 }
 
+// NotifyTimeSkippingFastForwardUpdate mocks base method.
+func (m *MockEngine) NotifyTimeSkippingFastForwardUpdate(executionKey chasm.ExecutionKey, info *common.TimeSkippingInfo) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "NotifyTimeSkippingFastForwardUpdate", executionKey, info)
+}
+
+// NotifyTimeSkippingFastForwardUpdate indicates an expected call of NotifyTimeSkippingFastForwardUpdate.
+func (mr *MockEngineMockRecorder) NotifyTimeSkippingFastForwardUpdate(executionKey, info any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyTimeSkippingFastForwardUpdate", reflect.TypeOf((*MockEngine)(nil).NotifyTimeSkippingFastForwardUpdate), executionKey, info)
+}
+
 // NotifyNewHistoryEvent mocks base method.
 func (m *MockEngine) NotifyNewHistoryEvent(event *events.Notification) {
 	m.ctrl.T.Helper()

--- a/service/history/interfaces/mutable_state.go
+++ b/service/history/interfaces/mutable_state.go
@@ -423,6 +423,10 @@ type (
 		// ToRealTime converts a virtual timestamp from mutable state to wall-clock time,
 		// adjusting for accumulated skipped duration which may have happened.
 		ToRealTime(virtualTime time.Time) time.Time
+		// GetTimeSkippingFastForwardUpdate returns the TimeSkippingInfo captured at the last
+		// close-transaction when the fast-forward changed (nil otherwise), for broadcasting to
+		// DescribeWorkflowExecution waiters after a successful active persist.
+		GetTimeSkippingFastForwardUpdate() *commonpb.TimeSkippingInfo
 		AddWorkflowExecutionTimeSkippingTransitionedEvent(
 			ctx context.Context, targetTime time.Time, disabledAfterFastForward bool) (*historypb.HistoryEvent, error)
 		ApplyWorkflowExecutionTimeSkippingTransitionedEvent(ctx context.Context, event *historypb.HistoryEvent) error

--- a/service/history/interfaces/mutable_state_mock.go
+++ b/service/history/interfaces/mutable_state_mock.go
@@ -3731,6 +3731,20 @@ func (mr *MockMutableStateMockRecorder) ToRealTime(virtualTime any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ToRealTime", reflect.TypeOf((*MockMutableState)(nil).ToRealTime), virtualTime)
 }
 
+// GetTimeSkippingFastForwardUpdate mocks base method.
+func (m *MockMutableState) GetTimeSkippingFastForwardUpdate() *common.TimeSkippingInfo {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTimeSkippingFastForwardUpdate")
+	ret0, _ := ret[0].(*common.TimeSkippingInfo)
+	return ret0
+}
+
+// GetTimeSkippingFastForwardUpdate indicates an expected call of GetTimeSkippingFastForwardUpdate.
+func (mr *MockMutableStateMockRecorder) GetTimeSkippingFastForwardUpdate() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTimeSkippingFastForwardUpdate", reflect.TypeOf((*MockMutableState)(nil).GetTimeSkippingFastForwardUpdate))
+}
+
 // UpdateActivity mocks base method.
 func (m *MockMutableState) UpdateActivity(arg0 int64, arg1 ActivityUpdater) error {
 	m.ctrl.T.Helper()

--- a/service/history/timeskipping_notifier.go
+++ b/service/history/timeskipping_notifier.go
@@ -1,0 +1,75 @@
+package history
+
+import (
+	"sync"
+
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/server/chasm"
+)
+
+// TimeSkippingFastForwardNotifier broadcasts time-skipping fast-forward updates to all waiters of an
+// execution (e.g. DescribeWorkflowExecution long-polls). Unlike ChasmNotifier, it delivers a payload
+// so waiters can act on the fresh TimeSkippingInfo without re-reading mutable state. Each subscriber
+// gets its own coalescing channel (buffer of one holding the latest update) so a terminal update is
+// never lost even if the subscriber is momentarily busy.
+type TimeSkippingFastForwardNotifier struct {
+	lock        sync.Mutex
+	nextID      int64
+	subscribers map[chasm.ExecutionKey]map[int64]chan *commonpb.TimeSkippingInfo
+}
+
+func NewTimeSkippingFastForwardNotifier() *TimeSkippingFastForwardNotifier {
+	return &TimeSkippingFastForwardNotifier{
+		subscribers: make(map[chasm.ExecutionKey]map[int64]chan *commonpb.TimeSkippingInfo),
+	}
+}
+
+// Subscribe returns a channel that receives the current TimeSkippingInfo whenever the execution's
+// fast-forward changes, along with an unsubscribe function. The channel is coalescing: it only ever
+// holds the latest update. The caller must call unsubscribe when done; it is safe to call multiple
+// times.
+func (n *TimeSkippingFastForwardNotifier) Subscribe(
+	key chasm.ExecutionKey,
+) (<-chan *commonpb.TimeSkippingInfo, func()) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+
+	id := n.nextID
+	n.nextID++
+	ch := make(chan *commonpb.TimeSkippingInfo, 1)
+	byID, ok := n.subscribers[key]
+	if !ok {
+		byID = make(map[int64]chan *commonpb.TimeSkippingInfo)
+		n.subscribers[key] = byID
+	}
+	byID[id] = ch
+
+	return ch, sync.OnceFunc(func() {
+		n.lock.Lock()
+		defer n.lock.Unlock()
+		if byID, ok := n.subscribers[key]; ok {
+			delete(byID, id)
+			if len(byID) == 0 {
+				delete(n.subscribers, key)
+			}
+		}
+	})
+}
+
+// Notify delivers info to every subscriber of key, replacing any pending update so each subscriber
+// always sees the latest.
+func (n *TimeSkippingFastForwardNotifier) Notify(key chasm.ExecutionKey, info *commonpb.TimeSkippingInfo) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+	for _, ch := range n.subscribers[key] {
+		// Drop a stale pending update, then enqueue the latest; both sends are non-blocking.
+		select {
+		case <-ch:
+		default:
+		}
+		select {
+		case ch <- info:
+		default:
+		}
+	}
+}

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -866,6 +866,20 @@ func (c *ContextImpl) UpdateWorkflowExecutionWithNew(
 		return err
 	}
 
+	// Broadcast a time-skipping fast-forward update to active waiters (e.g. DescribeWorkflowExecution)
+	// after the write is durable. Only on the active path; replication has no waiters to notify.
+	if updateWorkflowTransactionPolicy == historyi.TransactionPolicyActive {
+		if update := c.MutableState.GetTimeSkippingFastForwardUpdate(); update != nil {
+			if engine, err := shardContext.GetEngine(ctx); err == nil {
+				engine.NotifyTimeSkippingFastForwardUpdate(chasm.ExecutionKey{
+					NamespaceID: c.workflowKey.NamespaceID,
+					BusinessID:  c.workflowKey.WorkflowID,
+					RunID:       c.workflowKey.RunID,
+				}, update)
+			}
+		}
+	}
+
 	emitStateTransitionCount(c.metricsHandler, shardContext.GetClusterMetadata(), c.MutableState)
 	emitStateTransitionCount(c.metricsHandler, shardContext.GetClusterMetadata(), newMutableState)
 

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -216,6 +216,17 @@ type (
 		// timeSkippingInfoUpdated is used to track if executionInfo.TimeSkippingInfo is updated.
 		timeSkippingInfoUpdated bool
 
+		// timeSkippingFastForwardUpdated is set when the time-skipping fast-forward changed in this
+		// transaction (set, reset, cleared, or completed). It drives an execution-level
+		// notification carrying the current TimeSkippingInfo to waiters (e.g.
+		// DescribeWorkflowExecution), and is reset at close-transaction.
+		timeSkippingFastForwardUpdated bool
+
+		// pendingTimeSkippingFastForwardUpdate holds the TimeSkippingInfo (built with ms.Now())
+		// captured at the last close-transaction when the fast-forward changed, so the workflow
+		// context can broadcast it to waiters after a successful active persist. Nil when unchanged.
+		pendingTimeSkippingFastForwardUpdate *commonpb.TimeSkippingInfo
+
 		// in memory fields to track potential reapply events that needs to be reapplied during workflow update
 		// should only be used in the state based replication as state based replication does not have
 		// event inside history builder. This is only for x-run reapply (from zombie wf to current wf)
@@ -7524,6 +7535,10 @@ func (ms *MutableStateImpl) CloseTransactionAsMutation(
 		Checksum:        result.checksum,
 	}
 
+	// Capture the fast-forward update (built with ms.Now()) before cleanupTransaction resets the
+	// dirty flag; the workflow context reads it after a successful active persist to notify waiters.
+	ms.pendingTimeSkippingFastForwardUpdate = ms.timeSkippingFastForwardUpdate()
+
 	ms.checksum = result.checksum
 	if err := ms.cleanupTransaction(); err != nil {
 		return nil, nil, err
@@ -7568,6 +7583,8 @@ func (ms *MutableStateImpl) CloseTransactionAsSnapshot(
 		DBRecordVersion: ms.dbRecordVersion,
 		Checksum:        result.checksum,
 	}
+
+	ms.pendingTimeSkippingFastForwardUpdate = ms.timeSkippingFastForwardUpdate()
 
 	ms.checksum = result.checksum
 	if err := ms.cleanupTransaction(); err != nil {
@@ -8371,6 +8388,7 @@ func (ms *MutableStateImpl) cleanupTransaction() error {
 	ms.workflowTaskUpdated = false
 	ms.isResetStateUpdated = false
 	ms.timeSkippingInfoUpdated = false
+	ms.timeSkippingFastForwardUpdated = false
 	ms.updateInfoUpdated = make(map[string]struct{})
 	ms.timerInfosUserDataUpdated = make(map[string]struct{})
 	ms.activityInfosUserDataUpdated = make(map[int64]struct{})

--- a/service/history/workflow/timeskipping.go
+++ b/service/history/workflow/timeskipping.go
@@ -70,6 +70,7 @@ func (ms *MutableStateImpl) applyFastForward(propagatedTargetTime *timestamppb.T
 	if !tsc.GetEnabled() || tsc.GetFastForward().AsDuration() <= 0 {
 		if tsi.FastForwardInfo != nil {
 			tsi.FastForwardInfo = nil
+			ms.timeSkippingFastForwardUpdated = true
 		}
 		return
 	}
@@ -93,6 +94,7 @@ func (ms *MutableStateImpl) applyFastForward(propagatedTargetTime *timestamppb.T
 		HasReached:                    false,
 		LastUpdateVersionedTransition: currentVersionedTransition,
 	}
+	ms.timeSkippingFastForwardUpdated = true
 	ms.AddTasks(&tasks.TimeSkippingTimerTask{
 		WorkflowKey:         ms.GetWorkflowKey(),
 		VisibilityTimestamp: targetTime,
@@ -121,6 +123,36 @@ func (ms *MutableStateImpl) wrapExecutionTimes(initialSkippedDuration *durationp
 	if !timeNotSet(ms.executionInfo.WorkflowExecutionExpirationTime) {
 		ms.executionInfo.WorkflowExecutionExpirationTime = timestamppb.New(ms.executionInfo.WorkflowExecutionExpirationTime.AsTime().Add(accum))
 	}
+}
+
+// BuildTimeSkippingInfo converts the persisted time-skipping state into the public
+// common.v1.TimeSkippingInfo. virtualTime is the execution's current virtual clock (CurrentTime).
+// It returns nil when the execution has no time-skipping state.
+func BuildTimeSkippingInfo(
+	tsi *persistencespb.TimeSkippingInfo,
+	virtualTime time.Time,
+) *commonpb.TimeSkippingInfo {
+	if tsi == nil {
+		return nil
+	}
+	info := &commonpb.TimeSkippingInfo{
+		CurrentTime: timestamppb.New(virtualTime),
+		IsRunning:   tsi.GetConfig().GetEnabled(),
+	}
+	if ff := tsi.GetFastForwardInfo(); ff != nil {
+		var createTime *timestamppb.Timestamp
+		// The server sets target = create + fast_forward, so recover the creation virtual time
+		// by subtracting the configured duration.
+		if target := ff.GetTargetTime(); target != nil {
+			createTime = timestamppb.New(target.AsTime().Add(-tsi.GetConfig().GetFastForward().AsDuration()))
+		}
+		info.FastForward = &commonpb.TimeSkippingInfo_TimeSkippingFastForwardInfo{
+			CreateTime:   createTime,
+			TargetTime:   ff.GetTargetTime(),
+			HasCompleted: ff.GetHasReached(),
+		}
+	}
+	return info
 }
 
 // -- Propagation Methods of Time Skipping
@@ -503,10 +535,27 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionTimeSkippingTransitionedEvent(
 	tsi.Config.Enabled = !attr.GetDisabledAfterFastForward()
 	if attr.GetDisabledAfterFastForward() && tsi.GetFastForwardInfo() != nil {
 		tsi.FastForwardInfo.HasReached = true
+		ms.timeSkippingFastForwardUpdated = true
 	}
 
 	ms.timeSkippingInfoUpdated = true
 	return nil
+}
+
+// timeSkippingFastForwardUpdate returns the current TimeSkippingInfo to broadcast to waiters when
+// the fast-forward changed in this transaction, or nil when it did not.
+func (ms *MutableStateImpl) timeSkippingFastForwardUpdate() *commonpb.TimeSkippingInfo {
+	if !ms.timeSkippingFastForwardUpdated {
+		return nil
+	}
+	return BuildTimeSkippingInfo(ms.executionInfo.GetTimeSkippingInfo(), ms.Now())
+}
+
+// GetTimeSkippingFastForwardUpdate returns the TimeSkippingInfo captured at the last
+// close-transaction when the fast-forward changed (nil when it did not), so the workflow context
+// can broadcast it to waiters after a successful active persist.
+func (ms *MutableStateImpl) GetTimeSkippingFastForwardUpdate() *commonpb.TimeSkippingInfo {
+	return ms.pendingTimeSkippingFastForwardUpdate
 }
 
 func (ms *MutableStateImpl) closeTransactionRegenTimerTasksForWorkflowTimeSkipping(


### PR DESCRIPTION
## What changed?
- add time skipping info in `DescribeWorkflowExecution`
- add a waiting mechanism for time-skipping fast-forward completion in DescribeWorkflowExecutionReq 

Why?
to provide virtual time and notification of fast-forward completion to client side, and for fast-forward
completion, an API supports waiting is more convenient


## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

