### PR TITLE
SAA: cleanup

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -861,14 +861,18 @@ func (a *Activity) handleCancellationRequested(ctx chasm.MutableContext, request
 		return &activitypb.RequestCancelActivityExecutionResponse{}, nil
 	}
 
+	hasAttemptInProgress := a.hasAttemptInProgress()
+
 	// Always transition to CancelRequested
+	// TODO: this is questionable, since CancelRequested is otherwise a state that implies an attempt
+	// is in progress.
 	if err := TransitionCancelRequested.Apply(a, ctx, req); err != nil {
 		return nil, err
 	}
 
 	// Transition to Canceled if no attempt in progress; otherwise wait for worker response.
 	originalStatus := a.GetStatus()
-	if !a.hasAttemptInProgress() {
+	if !hasAttemptInProgress {
 		metricsHandler, err := a.enrichMetricsHandler(ctx, metrics.HistoryRespondActivityTaskCanceledScope)
 		if err != nil {
 			return nil, err

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -144,6 +144,18 @@ func (a *Activity) isTerminal() bool {
 	}
 }
 
+func (a *Activity) hasAttemptInProgress() bool {
+	switch a.GetStatus() {
+	case activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
+		activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
+		activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED,
+		activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED:
+		return true
+	default:
+		return false
+	}
+}
+
 // LifecycleState implements the chasm.Component interface.
 func (a *Activity) LifecycleState(_ chasm.Context) chasm.LifecycleState {
 	switch a.Status {
@@ -587,9 +599,9 @@ func (a *Activity) HandleCanceled(
 	}
 
 	if err := TransitionCanceled.Apply(a, ctx, cancelEvent{
-		details:    event.Request.GetCancelRequest().GetDetails(),
-		handler:    metricsHandler,
-		fromStatus: a.GetStatus(),
+		details:        event.Request.GetCancelRequest().GetDetails(),
+		metricsHandler: metricsHandler,
+		fromStatus:     a.GetStatus(),
 	}); err != nil {
 		return nil, err
 	}
@@ -849,31 +861,26 @@ func (a *Activity) handleCancellationRequested(ctx chasm.MutableContext, request
 		return &activitypb.RequestCancelActivityExecutionResponse{}, nil
 	}
 
-	// SCHEDULED and PAUSED activities have no active worker token so cancel immediately.
-	// STARTED and CANCEL_REQUESTED activities wait for the worker to respond.
-	originalStatus := a.GetStatus()
-	isCancelImmediately := originalStatus == activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED ||
-		originalStatus == activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED
-
+	// Always transition to CancelRequested
 	if err := TransitionCancelRequested.Apply(a, ctx, req); err != nil {
 		return nil, err
 	}
 
-	if isCancelImmediately {
-		details := &commonpb.Payloads{
-			Payloads: []*commonpb.Payload{
-				payload.EncodeString(req.GetReason()),
-			},
-		}
-
+	// Transition to Canceled if no attempt in progress; otherwise wait for worker response.
+	originalStatus := a.GetStatus()
+	if !a.hasAttemptInProgress() {
 		metricsHandler, err := a.enrichMetricsHandler(ctx, metrics.HistoryRespondActivityTaskCanceledScope)
 		if err != nil {
 			return nil, err
 		}
 		err = TransitionCanceled.Apply(a, ctx, cancelEvent{
-			details:    details,
-			handler:    metricsHandler,
-			fromStatus: originalStatus,
+			metricsHandler: metricsHandler,
+			fromStatus:     originalStatus,
+			details: &commonpb.Payloads{
+				Payloads: []*commonpb.Payload{
+					payload.EncodeString(req.GetReason()),
+				},
+			},
 		})
 		if err != nil {
 			return nil, err
@@ -1358,10 +1365,7 @@ func (a *Activity) reissueDispatchAndScheduleToStart(ctx chasm.MutableContext, a
 // updated) timeouts. No-op unless the activity is in a status where a worker holds the task token
 // (STARTED / CANCEL_REQUESTED / PAUSE_REQUESTED / RESET_REQUESTED).
 func (a *Activity) reissueRunningAttemptTimers(ctx chasm.MutableContext, attempt *activitypb.ActivityAttemptState) {
-	if a.GetStatus() != activitypb.ACTIVITY_EXECUTION_STATUS_STARTED &&
-		a.GetStatus() != activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED &&
-		a.GetStatus() != activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED &&
-		a.GetStatus() != activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED {
+	if !a.hasAttemptInProgress() {
 		return
 	}
 	if timeout := a.GetStartToCloseTimeout().AsDuration(); timeout > 0 {
@@ -1795,10 +1799,7 @@ func (a *Activity) validateActivityTaskToken(
 	token *tokenspb.Task,
 	requestNamespaceID string,
 ) error {
-	if a.Status != activitypb.ACTIVITY_EXECUTION_STATUS_STARTED &&
-		a.Status != activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED &&
-		a.Status != activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED &&
-		a.Status != activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED {
+	if !a.hasAttemptInProgress() {
 		return serviceerror.NewNotFound("activity task not found")
 	}
 	if token.Attempt != ByIDTokenAttempt && token.Attempt != a.LastAttempt.Get(ctx).GetCount() {

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -862,6 +862,7 @@ func (a *Activity) handleCancellationRequested(ctx chasm.MutableContext, request
 	}
 
 	hasAttemptInProgress := a.hasAttemptInProgress()
+	originalStatus := a.GetStatus()
 
 	// Always transition to CancelRequested
 	// TODO: this is questionable, since CancelRequested is otherwise a state that implies an attempt
@@ -871,7 +872,6 @@ func (a *Activity) handleCancellationRequested(ctx chasm.MutableContext, request
 	}
 
 	// Transition to Canceled if no attempt in progress; otherwise wait for worker response.
-	originalStatus := a.GetStatus()
 	if !hasAttemptInProgress {
 		metricsHandler, err := a.enrichMetricsHandler(ctx, metrics.HistoryRespondActivityTaskCanceledScope)
 		if err != nil {

--- a/chasm/lib/activity/activity_tasks.go
+++ b/chasm/lib/activity/activity_tasks.go
@@ -174,11 +174,8 @@ func (h *startToCloseTimeoutTaskHandler) Validate(
 	_ chasm.TaskAttributes,
 	task *activitypb.StartToCloseTimeoutTask,
 ) (bool, error) {
-	valid := ((activity.Status == activitypb.ACTIVITY_EXECUTION_STATUS_STARTED ||
-		activity.Status == activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED ||
-		activity.Status == activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED ||
-		activity.Status == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED) &&
-		task.Stamp == activity.LastAttempt.Get(ctx).GetStamp())
+	valid := activity.hasAttemptInProgress() &&
+		task.Stamp == activity.LastAttempt.Get(ctx).GetStamp()
 	return valid, nil
 }
 
@@ -237,10 +234,7 @@ func (h *heartbeatTimeoutTaskHandler) Validate(
 	// On the i-th execution of this function, we look back into the past and determine whether the
 	// last heartbeat was received after hb_i. If so, we reject this timeout task. Otherwise, the
 	// Execute function runs and we fail the attempt.
-	if activity.Status != activitypb.ACTIVITY_EXECUTION_STATUS_STARTED &&
-		activity.Status != activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED &&
-		activity.Status != activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED &&
-		activity.Status != activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED {
+	if !activity.hasAttemptInProgress() {
 		return false, nil
 	}
 	// Task attempt must still match current attempt.

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -18,6 +18,8 @@ import (
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/activity/gen/activitypb/v1"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/namespace"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.uber.org/mock/gomock"
@@ -253,6 +255,83 @@ func TestActivityTerminate(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, activitypb.ACTIVITY_EXECUTION_STATUS_TERMINATED, activity.Status)
 			}
+		})
+	}
+}
+
+// Check that we do not emit a StartToCloseLatency metric when cancelling an activity that has no
+// attempt in progress. Cancelling a SCHEDULED or PAUSED activity transitions straight to Canceled,
+// and the status captured before the CancelRequested transition must be forwarded so that the
+// metric is not emitted.
+func TestHandleCancellationRequestedDirectCancelMetrics(t *testing.T) {
+	testCases := []struct {
+		name   string
+		status activitypb.ActivityExecutionStatus
+	}{
+		{
+			name:   "scheduled during retry backoff, stale StartedTime",
+			status: activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+		},
+		{
+			name:   "paused during retry backoff, stale StartedTime",
+			status: activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			nsRegistry := namespace.NewMockRegistry(ctrl)
+			nsRegistry.EXPECT().GetNamespaceName(gomock.Any()).Return(namespace.Name("test-namespace"), nil).AnyTimes()
+
+			metricsHandler := metricstest.NewCaptureHandler()
+			capture := metricsHandler.StartCapture()
+
+			ctx := &chasm.MockMutableContext{
+				MockContext: chasm.MockContext{
+					HandleNow:            func(chasm.Component) time.Time { return defaultTime },
+					HandleMetricsHandler: func() metrics.Handler { return metricsHandler },
+					GoCtx: context.WithValue(context.Background(), ctxKeyActivityContext, &activityContext{
+						config: &Config{
+							BreakdownMetricsByTaskQueue: dynamicconfig.GetBoolPropertyFnFilteredByTaskQueue(true),
+						},
+						namespaceRegistry: nsRegistry,
+					}),
+				},
+			}
+
+			activity := &Activity{
+				ActivityState: &activitypb.ActivityState{
+					ActivityType:           &commonpb.ActivityType{Name: "test-activity-type"},
+					RetryPolicy:            defaultRetryPolicy,
+					Status:                 tc.status,
+					ScheduleTime:           timestamppb.New(defaultTime),
+					TaskQueue:              &taskqueuepb.TaskQueue{Name: "test-task-queue"},
+					ScheduleToCloseTimeout: durationpb.New(defaultScheduleToCloseTimeout),
+					ScheduleToStartTimeout: durationpb.New(defaultScheduleToStartTimeout),
+					StartToCloseTimeout:    durationpb.New(defaultStartToCloseTimeout),
+				},
+				// A stale StartedTime from a prior attempt: no attempt is currently running, so
+				// StartToCloseLatency must not be recorded on cancellation.
+				LastAttempt: chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{
+					Count:       1,
+					StartedTime: timestamppb.New(defaultTime),
+				}),
+				Outcome: chasm.NewDataField(ctx, &activitypb.ActivityOutcome{}),
+			}
+
+			_, err := activity.handleCancellationRequested(ctx, &activitypb.RequestCancelActivityExecutionRequest{
+				FrontendRequest: &workflowservice.RequestCancelActivityExecutionRequest{Reason: "test"},
+			})
+			require.NoError(t, err)
+			require.Equal(t, activitypb.ACTIVITY_EXECUTION_STATUS_CANCELED, activity.Status)
+
+			snapshot := capture.Snapshot()
+			require.NotEmpty(t, snapshot[metrics.ActivityCancel.Name()])
+			require.NotEmpty(t, snapshot[metrics.ActivityScheduleToCloseLatency.Name()])
+			require.Empty(t, snapshot[metrics.ActivityStartToCloseLatency.Name()],
+				"no attempt was running; StartToCloseLatency must not be recorded")
 		})
 	}
 }

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -322,9 +322,9 @@ var TransitionCancelRequested = chasm.NewTransition(
 )
 
 type cancelEvent struct {
-	details    *commonpb.Payloads
-	handler    metrics.Handler
-	fromStatus activitypb.ActivityExecutionStatus
+	details        *commonpb.Payloads
+	metricsHandler metrics.Handler
+	fromStatus     activitypb.ActivityExecutionStatus
 }
 
 // TransitionCanceled transitions to Canceled status.
@@ -351,7 +351,7 @@ var TransitionCanceled = chasm.NewTransition(
 				},
 			}
 
-			a.emitOnCanceledMetrics(ctx, event.handler, event.fromStatus)
+			a.emitOnCanceledMetrics(ctx, event.metricsHandler, event.fromStatus)
 
 			return nil
 		})

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -772,9 +772,9 @@ func TestTransitionCanceled(t *testing.T) {
 			metricsHandler.EXPECT().Counter(metrics.ActivityCancel.Name()).Return(counterCancel)
 
 			err := TransitionCanceled.Apply(activity, ctx, cancelEvent{
-				details:    payloads.EncodeString("Details"),
-				handler:    metricsHandler,
-				fromStatus: tc.fromStatus,
+				details:        payloads.EncodeString("Details"),
+				metricsHandler: metricsHandler,
+				fromStatus:     tc.fromStatus,
 			})
 			require.NoError(t, err)
 			require.Equal(t, activitypb.ACTIVITY_EXECUTION_STATUS_CANCELED, activity.Status)

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -495,7 +495,7 @@ func (h *Handler) RespondActivityTaskFailed(ctx context.Context, request *histor
 	return resp, nil
 }
 
-// RespondActivityTaskCanceled - records failure of an activity task
+// RespondActivityTaskCanceled - records cancellation of an activity task
 func (h *Handler) RespondActivityTaskCanceled(ctx context.Context, request *historyservice.RespondActivityTaskCanceledRequest) (*historyservice.RespondActivityTaskCanceledResponse, error) {
 	taskToken, err := h.tokenSerializer.Deserialize(request.CancelRequest.GetTaskToken())
 	if err != nil {


### PR DESCRIPTION
## What changed?
No behavior change. New activity helper predicate `a.hasAttemptInProgress()`. Clarify name of metric handler on cancel event struct.

## Why?
Readability, error-proneness

## How did you test it?
- [ ] covered by existing tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor and naming with explicit regression test for cancel metrics; intended behavior unchanged aside from clearer cancel/metrics wiring.
> 
> **Overview**
> Introduces **`hasAttemptInProgress()`** on standalone activity CHASM components so “worker holds a task token” means **STARTED**, **CANCEL_REQUESTED**, **PAUSE_REQUESTED**, or **RESET_REQUESTED**, replacing repeated four-way status checks in token validation, running-attempt timer reissue, and start-to-close / heartbeat timeout task validation.
> 
> **Cancellation** now always applies **`TransitionCancelRequested`** first, then completes to **Canceled** immediately when no attempt was in progress (using status captured **before** that transition as **`fromStatus`** for metrics). **`cancelEvent`** renames **`handler`** → **`metricsHandler`**.
> 
> Adds **`TestHandleCancellationRequestedDirectCancelMetrics`** to assert **StartToCloseLatency** is not emitted when canceling **SCHEDULED** / **PAUSED** activities with stale **StartedTime**. History handler comment for **RespondActivityTaskCanceled** is corrected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4cc45f979c5bed844fab5cda1822c90f3aa2c86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->