### PR TITLE
Fix concurrent request limiter charging non long-poll requests

### DIFF
--- a/common/rpc/interceptor/concurrent_request_limit.go
+++ b/common/rpc/interceptor/concurrent_request_limit.go
@@ -95,11 +95,21 @@ func (ni *ConcurrentRequestLimitInterceptor) Allow(
 	if token == 0 {
 		return func() {}, nil
 	}
-	// for GetWorkflowExecutionHistoryRequest, we only care about long poll requests
-	longPollReq, ok := req.(*workflowservice.GetWorkflowExecutionHistoryRequest)
-	if ok && !longPollReq.WaitNewEvent {
-		// ignore non-long-poll GetHistory calls.
-		return func() {}, nil
+	// Some APIs are only long-running when their long-poll parameter is set
+	switch req.(type) {
+	case *workflowservice.GetWorkflowExecutionHistoryRequest:
+		if !IsLongPollGetWorkflowExecutionHistoryRequest(req) {
+			return func() {}, nil
+		}
+	case *workflowservice.DescribeActivityExecutionRequest:
+		if !IsLongPollDescribeActivityExecutionRequest(req) {
+			return func() {}, nil
+		}
+	case *workflowservice.DescribeNexusOperationExecutionRequest:
+		if !IsLongPollDescribeNexusOperationExecutionRequest(req) {
+			return func() {}, nil
+		}
+	default:
 	}
 
 	counter := ni.counter(namespaceName, methodName)

--- a/common/rpc/interceptor/concurrent_request_limit_test.go
+++ b/common/rpc/interceptor/concurrent_request_limit_test.go
@@ -131,6 +131,58 @@ func TestNamespaceCountLimitInterceptor_Intercept(t *testing.T) {
 			},
 			expectRateLimit: false,
 		},
+		{
+			name:               "long poll describe activity execution",
+			request:            &workflowservice.DescribeActivityExecutionRequest{LongPollToken: []byte("token")},
+			numBlockedRequests: 3,
+			perInstanceLimit:   2,
+			globalLimit:        4,
+			memberCounter:      quotastest.NewFakeMemberCounter(2),
+			methodName:         "/temporal.api.workflowservice.v1.WorkflowService/DescribeActivityExecution",
+			tokens: map[string]int{
+				"/temporal.api.workflowservice.v1.WorkflowService/DescribeActivityExecution": 1,
+			},
+			expectRateLimit: true,
+		},
+		{
+			name:               "non-long poll describe activity execution",
+			request:            &workflowservice.DescribeActivityExecutionRequest{},
+			numBlockedRequests: 3,
+			perInstanceLimit:   2,
+			globalLimit:        4,
+			memberCounter:      quotastest.NewFakeMemberCounter(2),
+			methodName:         "/temporal.api.workflowservice.v1.WorkflowService/DescribeActivityExecution",
+			tokens: map[string]int{
+				"/temporal.api.workflowservice.v1.WorkflowService/DescribeActivityExecution": 1,
+			},
+			expectRateLimit: false,
+		},
+		{
+			name:               "long poll describe nexus operation execution",
+			request:            &workflowservice.DescribeNexusOperationExecutionRequest{LongPollToken: []byte("token")},
+			numBlockedRequests: 3,
+			perInstanceLimit:   2,
+			globalLimit:        4,
+			memberCounter:      quotastest.NewFakeMemberCounter(2),
+			methodName:         "/temporal.api.workflowservice.v1.WorkflowService/DescribeNexusOperationExecution",
+			tokens: map[string]int{
+				"/temporal.api.workflowservice.v1.WorkflowService/DescribeNexusOperationExecution": 1,
+			},
+			expectRateLimit: true,
+		},
+		{
+			name:               "non-long poll describe nexus operation execution",
+			request:            &workflowservice.DescribeNexusOperationExecutionRequest{},
+			numBlockedRequests: 3,
+			perInstanceLimit:   2,
+			globalLimit:        4,
+			memberCounter:      quotastest.NewFakeMemberCounter(2),
+			methodName:         "/temporal.api.workflowservice.v1.WorkflowService/DescribeNexusOperationExecution",
+			tokens: map[string]int{
+				"/temporal.api.workflowservice.v1.WorkflowService/DescribeNexusOperationExecution": 1,
+			},
+			expectRateLimit: false,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/common/rpc/interceptor/namespace_rate_limit.go
+++ b/common/rpc/interceptor/namespace_rate_limit.go
@@ -6,7 +6,6 @@ import (
 
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
-	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
@@ -156,24 +155,4 @@ func (ni *NamespaceRateLimitInterceptorImpl) Allow(namespaceName namespace.Name,
 		return ErrNamespaceRateLimitServerBusy
 	}
 	return nil
-}
-
-func IsLongPollGetWorkflowExecutionHistoryRequest(
-	req any,
-) bool {
-	switch request := req.(type) {
-	case *workflowservice.GetWorkflowExecutionHistoryRequest:
-		return request.GetWaitNewEvent()
-	}
-	return false
-}
-
-func IsLongPollDescribeActivityExecutionRequest(
-	req any,
-) bool {
-	switch request := req.(type) {
-	case *workflowservice.DescribeActivityExecutionRequest:
-		return len(request.GetLongPollToken()) > 0
-	}
-	return false
 }

--- a/common/rpc/interceptor/request.go
+++ b/common/rpc/interceptor/request.go
@@ -1,0 +1,37 @@
+package interceptor
+
+import (
+	"go.temporal.io/api/workflowservice/v1"
+)
+
+// The following helpers classify whether a request is in long-poll mode. Several APIs are only
+// long-running when their long-poll parameter is set; otherwise they are cheap point-reads.
+func IsLongPollGetWorkflowExecutionHistoryRequest(
+	req any,
+) bool {
+	switch request := req.(type) {
+	case *workflowservice.GetWorkflowExecutionHistoryRequest:
+		return request.GetWaitNewEvent()
+	}
+	return false
+}
+
+func IsLongPollDescribeActivityExecutionRequest(
+	req any,
+) bool {
+	switch request := req.(type) {
+	case *workflowservice.DescribeActivityExecutionRequest:
+		return len(request.GetLongPollToken()) > 0
+	}
+	return false
+}
+
+func IsLongPollDescribeNexusOperationExecutionRequest(
+	req any,
+) bool {
+	switch request := req.(type) {
+	case *workflowservice.DescribeNexusOperationExecutionRequest:
+		return len(request.GetLongPollToken()) > 0
+	}
+	return false
+}


### PR DESCRIPTION
## What changed?
ConcurrentRequestLimitInterceptor.Allow only exempted non-long-poll GetWorkflowExecutionHistory from the long-running concurrency quota. DescribeActivityExecution and DescribeNexusOperationExecution are also long-running only when their long_poll_token is set, but every call (including plain point-reads) was charged a token. Now all three are gated on their long-poll parameter.

## Why?
Plain DescribeActivityExecution / DescribeNexusOperationExecution calls could be rejected with "namespace concurrent poller limit exceeded" under load despite not being long-running, and could starve real long-poll capacity.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Seems safe, because the original intent is to charge only long polls
