### PR TITLE
Forward StartNexusOperationExecution under selected-apis-forwarding

### DIFF
--- a/common/rpc/interceptor/dc_redirection_policy.go
+++ b/common/rpc/interceptor/dc_redirection_policy.go
@@ -57,6 +57,7 @@ type (
 
 // selectedAPIsForwardingRedirectionPolicyWhitelistedAPIs contains a list of APIs which can be redirected
 var selectedAPIsForwardingRedirectionPolicyWhitelistedAPIs = map[string]struct{}{
+	// Workflow APIs
 	"StartWorkflowExecution":           {},
 	"SignalWithStartWorkflowExecution": {},
 	"SignalWorkflowExecution":          {},
@@ -64,11 +65,18 @@ var selectedAPIsForwardingRedirectionPolicyWhitelistedAPIs = map[string]struct{}
 	"TerminateWorkflowExecution":       {},
 	"DeleteWorkflowExecution":          {},
 	"QueryWorkflow":                    {},
-	"StartActivityExecution":           {},
-	"RequestCancelActivityExecution":   {},
-	"TerminateActivityExecution":       {},
-	"DeleteActivityExecution":          {},
-	"StartNexusOperationExecution":     {},
+
+	// Standalone Activity APIs
+	"StartActivityExecution":         {},
+	"RequestCancelActivityExecution": {},
+	"TerminateActivityExecution":     {},
+	"DeleteActivityExecution":        {},
+
+	// Standalone Nexus Operation APIs
+	"StartNexusOperationExecution":         {},
+	"RequestCancelNexusOperationExecution": {},
+	"TerminateNexusOperationExecution":     {},
+	"DeleteNexusOperationExecution":        {},
 }
 
 // RedirectionPolicyGenerator generate corresponding redirection policy

--- a/common/rpc/interceptor/dc_redirection_policy.go
+++ b/common/rpc/interceptor/dc_redirection_policy.go
@@ -68,6 +68,7 @@ var selectedAPIsForwardingRedirectionPolicyWhitelistedAPIs = map[string]struct{}
 	"RequestCancelActivityExecution":   {},
 	"TerminateActivityExecution":       {},
 	"DeleteActivityExecution":          {},
+	"StartNexusOperationExecution":     {},
 }
 
 // RedirectionPolicyGenerator generate corresponding redirection policy


### PR DESCRIPTION
Adds Standalone Nexus Operation APIs to `selectedAPIsForwardingRedirectionPolicyWhitelistedAPIs`.
