### PR TITLE
Fix standalone activity timeout type on retry deadline

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -564,11 +564,11 @@ func (a *Activity) HandleFailed(
 		!appFailure.GetNonRetryable() &&
 		!slices.Contains(a.GetRetryPolicy().GetNonRetryableErrorTypes(), appFailure.GetType())
 
-	rescheduled, err := a.tryReschedule(ctx, isRetryable, appFailure.GetNextRetryDelay().AsDuration(), failure)
+	retryState, err := a.tryReschedule(ctx, isRetryable, appFailure.GetNextRetryDelay().AsDuration(), failure)
 	if err != nil {
 		return nil, err
 	}
-	if rescheduled {
+	if retryState == enumspb.RETRY_STATE_IN_PROGRESS {
 		a.emitOnAttemptFailedMetrics(ctx, metricsHandler)
 
 		return &historyservice.RespondActivityTaskFailedResponse{}, nil
@@ -1205,11 +1205,15 @@ func (a *Activity) resetImmediately(
 	return &activitypb.ResetActivityExecutionResponse{}, nil
 }
 
-// recordScheduleToStartOrCloseTimeoutFailure records schedule-to-start or schedule-to-close timeouts. Such timeouts are not retried so we
-// set the outcome failure directly and leave the attempt failure as is.
-func (a *Activity) recordScheduleToStartOrCloseTimeoutFailure(ctx chasm.MutableContext, timeoutType enumspb.TimeoutType) error {
+// recordScheduleToStartOrCloseTimeoutFailure records schedule-to-start or schedule-to-close timeout outcomes. Such
+// timeouts are not retried, so we set the outcome failure directly and leave the attempt failure as is.
+func (a *Activity) recordScheduleToStartOrCloseTimeoutFailure(
+	ctx chasm.MutableContext,
+	timeoutType enumspb.TimeoutType,
+	message string,
+) error {
 	failure := &failurepb.Failure{
-		Message: fmt.Sprintf(common.FailureReasonActivityTimeout, timeoutType.String()),
+		Message: message,
 		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{
 			TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
 				TimeoutType:          timeoutType,
@@ -1264,21 +1268,24 @@ func (a *Activity) recordFailedAttempt(
 	return nil
 }
 
-// tryReschedule attempts to reschedule the activity for retry. Returns true if rescheduled, false
-// if retry is not possible. It handles the cases of pause and reset requests that were received
-// while the last attempt was in progress. failureRetryable reports whether the failure itself
-// permits a retry (timeouts always do; RespondActivityTaskFailed depends on the failure).
+// tryReschedule attempts to reschedule the activity for retry. It handles the cases of pause and
+// reset requests that were received while the last attempt was in progress. failureRetryable
+// reports whether the failure itself permits a retry (timeouts always do; RespondActivityTaskFailed
+// depends on the failure).
 func (a *Activity) tryReschedule(
 	ctx chasm.MutableContext,
 	failureRetryable bool,
 	overridingRetryInterval time.Duration,
 	failure *failurepb.Failure,
-) (bool, error) {
-	shouldRetry, retryInterval := a.shouldRetry(ctx, overridingRetryInterval)
+) (enumspb.RetryState, error) {
+	retryState, retryInterval := a.shouldRetry(ctx, overridingRetryInterval)
+	if !failureRetryable {
+		retryState = enumspb.RETRY_STATE_NON_RETRYABLE_FAILURE
+	}
 	resetRequested := a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED
 	// A pending reset request is always honored, regardless of retryability or the should retry result.
-	if !resetRequested && !(failureRetryable && shouldRetry) { //nolint:staticcheck // QF1001: DeMorgan rearrangement would not be an improvement
-		return false, nil
+	if !resetRequested && retryState != enumspb.RETRY_STATE_IN_PROGRESS {
+		return retryState, nil
 	}
 	retryIntervalSource := activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_RETRY_POLICY
 	if overridingRetryInterval > 0 {
@@ -1287,30 +1294,35 @@ func (a *Activity) tryReschedule(
 	event := rescheduleEvent{retryInterval: retryInterval, retryIntervalSource: retryIntervalSource, failure: failure}
 	switch a.GetStatus() {
 	case activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED:
-		return true, TransitionAttemptFailedWhilePauseRequested.Apply(a, ctx, event)
+		return enumspb.RETRY_STATE_IN_PROGRESS, TransitionAttemptFailedWhilePauseRequested.Apply(a, ctx, event)
 	case activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED:
 		if a.ResetKeepPaused {
-			return true, TransitionResetAttemptFailedToPaused.Apply(a, ctx, event)
+			return enumspb.RETRY_STATE_IN_PROGRESS, TransitionResetAttemptFailedToPaused.Apply(a, ctx, event)
 		}
-		return true, TransitionResetAttemptFailedToScheduled.Apply(a, ctx, event)
+		return enumspb.RETRY_STATE_IN_PROGRESS, TransitionResetAttemptFailedToScheduled.Apply(a, ctx, event)
 	default:
-		return true, TransitionRescheduled.Apply(a, ctx, event)
+		return enumspb.RETRY_STATE_IN_PROGRESS, TransitionRescheduled.Apply(a, ctx, event)
 	}
 }
 
-func (a *Activity) shouldRetry(ctx chasm.Context, overridingRetryInterval time.Duration) (bool, time.Duration) {
+func (a *Activity) shouldRetry(ctx chasm.Context, overridingRetryInterval time.Duration) (enumspb.RetryState, time.Duration) {
 	if !TransitionRescheduled.Possible(a) &&
 		!TransitionAttemptFailedWhilePauseRequested.Possible(a) &&
 		!TransitionResetAttemptFailedToScheduled.Possible(a) &&
 		!TransitionResetAttemptFailedToPaused.Possible(a) {
-		return false, 0
+		return enumspb.RETRY_STATE_UNSPECIFIED, 0
 	}
 	attempt := a.LastAttempt.Get(ctx)
 	retryPolicy := a.RetryPolicy
-
-	enoughAttempts := retryPolicy.GetMaximumAttempts() == 0 || attempt.GetCount() < retryPolicy.GetMaximumAttempts()
 	enoughTime, retryInterval := a.hasEnoughTimeForRetry(ctx, overridingRetryInterval)
-	return enoughAttempts && enoughTime, retryInterval
+
+	if retryPolicy.GetMaximumAttempts() > 0 && attempt.GetCount() >= retryPolicy.GetMaximumAttempts() {
+		return enumspb.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED, retryInterval
+	}
+	if !enoughTime {
+		return enumspb.RETRY_STATE_TIMEOUT, retryInterval
+	}
+	return enumspb.RETRY_STATE_IN_PROGRESS, retryInterval
 }
 
 // hasEnoughTimeForRetry checks if there is enough time left in the schedule-to-close timeout. If sufficient time

--- a/chasm/lib/activity/activity_tasks.go
+++ b/chasm/lib/activity/activity_tasks.go
@@ -187,7 +187,7 @@ func (h *startToCloseTimeoutTaskHandler) Execute(
 	_ chasm.TaskAttributes,
 	_ *activitypb.StartToCloseTimeoutTask,
 ) error {
-	rescheduled, err := activity.tryReschedule(ctx, true, 0, createStartToCloseTimeoutFailure())
+	retryState, err := activity.tryReschedule(ctx, true, 0, createStartToCloseTimeoutFailure())
 	if err != nil {
 		return err
 	}
@@ -197,7 +197,7 @@ func (h *startToCloseTimeoutTaskHandler) Execute(
 		return err
 	}
 
-	if rescheduled {
+	if retryState == enumspb.RETRY_STATE_IN_PROGRESS {
 		activity.emitOnAttemptTimedOutMetrics(ctx, metricsHandler, enumspb.TIMEOUT_TYPE_START_TO_CLOSE)
 
 		return nil
@@ -205,6 +205,7 @@ func (h *startToCloseTimeoutTaskHandler) Execute(
 
 	return TransitionTimedOut.Apply(activity, ctx, timeoutEvent{
 		timeoutType:    enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
+		retryState:     retryState,
 		metricsHandler: metricsHandler,
 		fromStatus:     activity.GetStatus(),
 	})
@@ -265,7 +266,7 @@ func (h *heartbeatTimeoutTaskHandler) Execute(
 	_ chasm.TaskAttributes,
 	_ *activitypb.HeartbeatTimeoutTask,
 ) error {
-	rescheduled, err := activity.tryReschedule(ctx, true, 0, createHeartbeatTimeoutFailure())
+	retryState, err := activity.tryReschedule(ctx, true, 0, createHeartbeatTimeoutFailure())
 	if err != nil {
 		return err
 	}
@@ -275,13 +276,14 @@ func (h *heartbeatTimeoutTaskHandler) Execute(
 		return err
 	}
 
-	if rescheduled {
+	if retryState == enumspb.RETRY_STATE_IN_PROGRESS {
 		activity.emitOnAttemptTimedOutMetrics(ctx, metricsHandler, enumspb.TIMEOUT_TYPE_HEARTBEAT)
 		return nil
 	}
 
 	return TransitionTimedOut.Apply(activity, ctx, timeoutEvent{
 		timeoutType:    enumspb.TIMEOUT_TYPE_HEARTBEAT,
+		retryState:     retryState,
 		metricsHandler: metricsHandler,
 		fromStatus:     activity.GetStatus(),
 	})

--- a/chasm/lib/activity/activity_tasks_test.go
+++ b/chasm/lib/activity/activity_tasks_test.go
@@ -1,13 +1,24 @@
 package activity
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/activity/gen/activitypb/v1"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
+	"go.temporal.io/server/common/namespace"
+	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestScheduleToCloseTimeoutTaskValidateStamp(t *testing.T) {
@@ -48,6 +59,121 @@ func TestScheduleToCloseTimeoutTaskValidateStamp(t *testing.T) {
 			)
 			require.NoError(t, err)
 			require.Equal(t, tc.wantValid, valid)
+		})
+	}
+}
+
+func TestAttemptTimeoutTaskTerminalFailureType(t *testing.T) {
+	testCases := []struct {
+		name                string
+		timeoutType         enumspb.TimeoutType
+		maximumAttempts     int32
+		scheduleToClose     time.Duration
+		expectedTimeoutType enumspb.TimeoutType
+		expectedMessage     string
+	}{
+		{
+			name:                "start to close deadline exhausted",
+			timeoutType:         enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
+			scheduleToClose:     2 * time.Second,
+			expectedTimeoutType: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+			expectedMessage:     common.FailureReasonActivityRetryScheduleToCloseTimeout,
+		},
+		{
+			name:                "heartbeat deadline exhausted",
+			timeoutType:         enumspb.TIMEOUT_TYPE_HEARTBEAT,
+			scheduleToClose:     2 * time.Second,
+			expectedTimeoutType: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+			expectedMessage:     common.FailureReasonActivityRetryScheduleToCloseTimeout,
+		},
+		{
+			name:                "start to close maximum attempts reached",
+			timeoutType:         enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
+			maximumAttempts:     1,
+			scheduleToClose:     time.Minute,
+			expectedTimeoutType: enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
+		},
+		{
+			name:                "heartbeat maximum attempts reached",
+			timeoutType:         enumspb.TIMEOUT_TYPE_HEARTBEAT,
+			maximumAttempts:     1,
+			scheduleToClose:     time.Minute,
+			expectedTimeoutType: enumspb.TIMEOUT_TYPE_HEARTBEAT,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			nsRegistry := namespace.NewMockRegistry(ctrl)
+			nsRegistry.EXPECT().GetNamespaceName(gomock.Any()).Return(namespace.Name("test-namespace"), nil)
+
+			metricsHandler := metricstest.NewCaptureHandler()
+			capture := metricsHandler.StartCapture()
+			defer metricsHandler.StopCapture(capture)
+			ctx := &chasm.MockMutableContext{
+				MockContext: chasm.MockContext{
+					HandleNow:            func(chasm.Component) time.Time { return defaultTime.Add(1500 * time.Millisecond) },
+					HandleMetricsHandler: func() metrics.Handler { return metricsHandler },
+					GoCtx: context.WithValue(context.Background(), ctxKeyActivityContext, &activityContext{
+						config: &Config{
+							BreakdownMetricsByTaskQueue: dynamicconfig.GetBoolPropertyFnFilteredByTaskQueue(false),
+						},
+						namespaceRegistry: nsRegistry,
+					}),
+				},
+			}
+			activity := &Activity{
+				ActivityState: &activitypb.ActivityState{
+					ActivityType: &commonpb.ActivityType{Name: "test-activity-type"},
+					RetryPolicy: &commonpb.RetryPolicy{
+						InitialInterval:    durationpb.New(time.Second),
+						BackoffCoefficient: 1,
+						MaximumAttempts:    tc.maximumAttempts,
+					},
+					ScheduleTime:           timestamppb.New(defaultTime),
+					ScheduleToCloseTimeout: durationpb.New(tc.scheduleToClose),
+					Status:                 activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
+					TaskQueue:              &taskqueuepb.TaskQueue{Name: "test-task-queue"},
+				},
+				LastAttempt: chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{
+					Count:       1,
+					StartedTime: timestamppb.New(defaultTime),
+				}),
+				Outcome: chasm.NewDataField(ctx, &activitypb.ActivityOutcome{}),
+				LastHeartbeat: chasm.NewDataField(ctx, &activitypb.ActivityHeartbeatState{
+					Details: &commonpb.Payloads{Payloads: []*commonpb.Payload{{Data: []byte("heartbeat details")}}},
+				}),
+			}
+
+			var err error
+			switch tc.timeoutType {
+			case enumspb.TIMEOUT_TYPE_START_TO_CLOSE:
+				err = newStartToCloseTimeoutTaskHandler().Execute(ctx, activity, chasm.TaskAttributes{}, &activitypb.StartToCloseTimeoutTask{})
+			case enumspb.TIMEOUT_TYPE_HEARTBEAT:
+				err = newHeartbeatTimeoutTaskHandler().Execute(ctx, activity, chasm.TaskAttributes{}, &activitypb.HeartbeatTimeoutTask{})
+			default:
+				t.Fatalf("unexpected timeout type: %v", tc.timeoutType)
+			}
+			require.NoError(t, err)
+
+			terminalFailure := activity.outcome(ctx).GetFailure()
+			require.Equal(t, tc.expectedTimeoutType, terminalFailure.GetTimeoutFailureInfo().GetTimeoutType())
+			if tc.expectedMessage != "" {
+				require.Equal(t, tc.expectedMessage, terminalFailure.GetMessage())
+				require.NotNil(t, activity.Outcome.Get(ctx).GetFailed())
+			} else {
+				require.Nil(t, activity.Outcome.Get(ctx).GetVariant())
+			}
+			lastFailure := activity.LastAttempt.Get(ctx).GetLastFailureDetails().GetFailure()
+			require.Equal(t, tc.timeoutType, lastFailure.GetTimeoutFailureInfo().GetTimeoutType())
+			require.Equal(t, lastFailure.GetTimeoutFailureInfo().GetLastHeartbeatDetails(), terminalFailure.GetTimeoutFailureInfo().GetLastHeartbeatDetails())
+
+			for _, metricName := range []string{metrics.ActivityTimeout.Name(), metrics.ActivityTaskTimeout.Name()} {
+				recordings := capture.Snapshot()[metricName]
+				require.Len(t, recordings, 1)
+				require.Equal(t, tc.timeoutType.String(), recordings[0].Tags["timeout_type"])
+			}
 		})
 	}
 }

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -12,6 +12,7 @@ import (
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/activity/gen/activitypb/v1"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/metrics"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -358,6 +359,7 @@ var TransitionCanceled = chasm.NewTransition(
 type timeoutEvent struct {
 	metricsHandler metrics.Handler
 	timeoutType    enumspb.TimeoutType
+	retryState     enumspb.RetryState
 	fromStatus     activitypb.ActivityExecutionStatus
 }
 
@@ -380,7 +382,11 @@ var TransitionTimedOut = chasm.NewTransition(
 			switch timeoutType {
 			case enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START,
 				enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE:
-				err = a.recordScheduleToStartOrCloseTimeoutFailure(ctx, timeoutType)
+				err = a.recordScheduleToStartOrCloseTimeoutFailure(
+					ctx,
+					timeoutType,
+					fmt.Sprintf(common.FailureReasonActivityTimeout, timeoutType.String()),
+				)
 			case enumspb.TIMEOUT_TYPE_START_TO_CLOSE:
 				failure := createStartToCloseTimeoutFailure()
 				failure.GetTimeoutFailureInfo().LastHeartbeatDetails = a.lastHeartbeatDetails(ctx)
@@ -394,6 +400,15 @@ var TransitionTimedOut = chasm.NewTransition(
 			}
 			if err != nil {
 				return err
+			}
+			if event.retryState == enumspb.RETRY_STATE_TIMEOUT {
+				if err := a.recordScheduleToStartOrCloseTimeoutFailure(
+					ctx,
+					enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+					common.FailureReasonActivityRetryScheduleToCloseTimeout,
+				); err != nil {
+					return err
+				}
 			}
 
 			a.emitOnTimedOutMetrics(ctx, event.metricsHandler, timeoutType, event.fromStatus)

--- a/common/util.go
+++ b/common/util.go
@@ -93,6 +93,8 @@ const (
 
 	// FailureReasonActivityTimeout is failureReason for when an activity times out, with %v as the timeout type.
 	FailureReasonActivityTimeout = "activity %v timeout"
+	// FailureReasonActivityRetryScheduleToCloseTimeout is failureReason for when an activity retry cannot be scheduled before its schedule-to-close timeout.
+	FailureReasonActivityRetryScheduleToCloseTimeout = "Not enough time to schedule next retry before activity ScheduleToClose timeout, giving up retrying"
 	// FailureReasonCompleteResultExceedsLimit is failureReason for complete result exceeds limit
 	FailureReasonCompleteResultExceedsLimit = "Complete result exceeds size limit."
 	// FailureReasonFailureDetailsExceedsLimit is failureReason for failure details exceeds limit

--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -315,7 +315,7 @@ func (t *timerQueueActiveTaskExecutor) processSingleActivityTimeoutTask(
 	// always resolved as failed.
 	if retryState == enumspb.RETRY_STATE_TIMEOUT && timerSequenceID.TimerType != enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START {
 		timeoutFailure = failure.NewTimeoutFailure(
-			"Not enough time to schedule next retry before activity ScheduleToClose timeout, giving up retrying",
+			common.FailureReasonActivityRetryScheduleToCloseTimeout,
 			enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
 		)
 	}

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -5739,6 +5739,56 @@ func (s *standaloneActivityTestSuite) TestHeartbeat() {
 			"expected timeout type=Heartbeat but is %s", pollResp.GetOutcome().GetFailure().GetTimeoutFailureInfo().GetTimeoutType())
 	})
 
+	// The 30-second retry delay cannot fit before the 10-second ScheduleToClose deadline, so the
+	// activity completes as ScheduleToClose as soon as the one-second Heartbeat timeout fires.
+	// Describe still preserves Heartbeat as the last attempt failure.
+	t.Run("HeartbeatTimeoutReportsScheduleToCloseWhenRetryCannotFit", func(t *testing.T) {
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		startResp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+			Namespace:              env.Namespace().String(),
+			ActivityId:             activityID,
+			ActivityType:           env.Tv().ActivityType(),
+			TaskQueue:              &taskqueuepb.TaskQueue{Name: taskQueue},
+			StartToCloseTimeout:    durationpb.New(time.Minute),
+			ScheduleToCloseTimeout: durationpb.New(10 * time.Second),
+			HeartbeatTimeout:       durationpb.New(time.Second),
+			RetryPolicy: &commonpb.RetryPolicy{
+				InitialInterval:    durationpb.New(30 * time.Second),
+				BackoffCoefficient: 1,
+				MaximumAttempts:    2,
+			},
+		})
+		require.NoError(t, err)
+
+		pollTaskResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
+			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, pollTaskResp.TaskToken)
+
+		pollResp, err := env.FrontendClient().PollActivityExecution(ctx, &workflowservice.PollActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.RunId,
+		})
+		require.NoError(t, err)
+		failure := pollResp.GetOutcome().GetFailure()
+		require.Equal(t, enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, failure.GetTimeoutFailureInfo().GetTimeoutType())
+		require.Equal(t, common.FailureReasonActivityRetryScheduleToCloseTimeout, failure.GetMessage())
+
+		describeResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:          env.Namespace().String(),
+			ActivityId:         activityID,
+			RunId:              startResp.RunId,
+			IncludeLastFailure: true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, enumspb.TIMEOUT_TYPE_HEARTBEAT, describeResp.GetInfo().GetLastFailure().GetTimeoutFailureInfo().GetTimeoutType())
+	})
+
 	t.Run("HeartbeatDetailsSurfacedOnTimeout", func(t *testing.T) {
 		// Start activity (no retries), worker accepts task and records a heartbeat with details,
 		// then stops heartbeating so the heartbeat timeout fires.


### PR DESCRIPTION
## What changed?
Standalone activities now report SCHEDULE_TO_CLOSE when a StartToClose or Heartbeat timeout cannot be retried before the ScheduleToClose deadline. The original attempt timeout remains available as the last failure, and metrics retain the original timeout type.

## Why?
Standalone activities previously differed from workflow activities by reporting the original attempt timeout after retry give-up. This aligns both implementations while preserving attempt-level diagnostics for customers.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [X] added new unit test(s)
- [X] added new functional test(s)

