### PR TITLE
SAA: declarative functional tests

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -2,22 +2,19 @@
 //
 // We name 3 times in the lifecycle of an activity attempt:
 //
-// schedule_time - the time at which the activity entered SCHEDULED state
-// dispatch_time - the time at which the activity task is due to be dispatched to Matching (AddActivityTask)
-// start_time    - the time at which the activity enters STARTED state (Matching task picked up by poller)
+// schedule time - the time at which the activity entered SCHEDULED state
+// dispatch time - the time at which the activity task will be dispatched to Matching (AddActivityTask)
+// start time    - the time at which the activity enters STARTED state (Matching task picked up by poller)
 //
-// They are always ordered as: (schedule_time) <= (dispatch_time) < (start_time).
+// They are always ordered as: (schedule time) <= (dispatch time) < (start time).
 //
 // A ScheduleToStart timeout applies to the time between dispatch and start. If there is a delay
 // before dispatch (i.e. a start delay on the first attempt, or a backoff interval / next retry
-// delay on a second or subsequent attempt) then schedule_time < dispatch_time. Otherwise, they are
+// delay on a second or subsequent attempt) then schedule time < dispatch time. Otherwise, they are
 // equal.
 //
 // The main Activity struct has a.ScheduleTime which is the schedule time of the first
 // attempt; i.e. the time at which the activity was created. This is never changed.
-//
-// The naming situation is not perfectly clean. See e.g. the comment below on
-// nextAttemptDispatchTime (which is called next_attempt_schedule_time in the public API).
 
 package activity
 
@@ -355,51 +352,6 @@ func dispatchTimeForRetry(attempt *activitypb.ActivityAttemptState) *timestamppb
 		return timestamppb.New(completeTime.AsTime().Add(retryInterval.AsDuration()))
 	}
 	return nil
-}
-
-// nextAttemptDispatchTime is the dispatch_time of the attempt that is currently being waited for.
-// It is null when the dispatch time has passed, in terminal states, and when paused or when an
-// attempt is in progress, since in those states the dispatch time of a future attempt is unknown:
-// we do not even know if there will be a next attempt.
-//
-// In the public Describe API response of SAA and WFA, this has the name next_attempt_schedule_time.
-// In that field name, the term "schedule_time" is actually a dispatch time; specifically, the
-// dispatch time defined by this method.
-//
-// For WFA, next_attempt_schedule_time is null prior to the first attempt since start delay is not
-// supported, hence the activity is due to be dispatched to Matching as soon as the activity is
-// created. But for SAA, if there's a start delay, then next_attempt_schedule_time is the
-// dispatch_time (non-null).
-func (a *Activity) nextAttemptDispatchTime(ctx chasm.Context, attempt *activitypb.ActivityAttemptState) *timestamppb.Timestamp {
-	if a.hasAttemptInProgress() || a.isPaused() || a.isTerminal() {
-		return nil
-	}
-	if t := a.dispatchTimeForAttempt(attempt); t != nil {
-		if t.AsTime().After(ctx.Now(a)) {
-			return t
-		}
-	}
-	return nil
-}
-
-// currentRetryInterval is the current or next retry interval.
-// - If the activity is currently in retry backoff, then return the current retry interval.
-// - If the activity has an attempt in progress, then return the retry interval that will apply if the attempt fails
-// - Otherwise return nil
-func (a *Activity) currentRetryInterval(ctx chasm.Context, attempt *activitypb.ActivityAttemptState) *durationpb.Duration {
-	switch {
-	case a.hasAttemptInProgress():
-		// The interval a failure now would be retried with — exactly what the retry path decides — or
-		// null if it would not retry (attempts or schedule-to-close time exhausted).
-		if willRetry, interval := a.shouldRetry(ctx, 0); willRetry {
-			return durationpb.New(interval)
-		}
-		return nil
-	case a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED:
-		return attempt.GetCurrentRetryInterval()
-	default:
-		return nil
-	}
 }
 
 // RecordCompleted applies the provided function to record activity completion.
@@ -1707,7 +1659,7 @@ func (a *Activity) buildActivityExecutionInfo(
 		Attempt:                 attempt.GetCount(),
 		CanceledReason:          a.CancelState.GetReason(),
 		CloseTime:               closeTime,
-		CurrentRetryInterval:    a.currentRetryInterval(ctx, attempt),
+		CurrentRetryInterval:    attempt.GetCurrentRetryInterval(),
 		ExecutionDuration:       executionDuration,
 		ExecutionTime:           timestamppb.New(a.firstDispatchTime()),
 		ExpirationTime:          expirationTime,
@@ -1721,7 +1673,7 @@ func (a *Activity) buildActivityExecutionInfo(
 		LastWorkerIdentity:      attempt.GetLastWorkerIdentity(),
 		SdkName:                 attempt.GetSdkName(),
 		SdkVersion:              attempt.GetSdkVersion(),
-		NextAttemptScheduleTime: a.nextAttemptDispatchTime(ctx, attempt),
+		NextAttemptScheduleTime: dispatchTimeForRetry(attempt),
 		Priority:                a.GetPriority(),
 		RetryPolicy:             a.GetRetryPolicy(),
 		RunId:                   key.RunID,

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -2,19 +2,22 @@
 //
 // We name 3 times in the lifecycle of an activity attempt:
 //
-// schedule time - the time at which the activity entered SCHEDULED state
-// dispatch time - the time at which the activity task will be dispatched to Matching (AddActivityTask)
-// start time    - the time at which the activity enters STARTED state (Matching task picked up by poller)
+// schedule_time - the time at which the activity entered SCHEDULED state
+// dispatch_time - the time at which the activity task is due to be dispatched to Matching (AddActivityTask)
+// start_time    - the time at which the activity enters STARTED state (Matching task picked up by poller)
 //
-// They are always ordered as: (schedule time) <= (dispatch time) < (start time).
+// They are always ordered as: (schedule_time) <= (dispatch_time) < (start_time).
 //
 // A ScheduleToStart timeout applies to the time between dispatch and start. If there is a delay
 // before dispatch (i.e. a start delay on the first attempt, or a backoff interval / next retry
-// delay on a second or subsequent attempt) then schedule time < dispatch time. Otherwise, they are
+// delay on a second or subsequent attempt) then schedule_time < dispatch_time. Otherwise, they are
 // equal.
 //
 // The main Activity struct has a.ScheduleTime which is the schedule time of the first
 // attempt; i.e. the time at which the activity was created. This is never changed.
+//
+// The naming situation is not perfectly clean. See e.g. the comment below on
+// nextAttemptDispatchTime (which is called next_attempt_schedule_time in the public API).
 
 package activity
 
@@ -352,6 +355,51 @@ func dispatchTimeForRetry(attempt *activitypb.ActivityAttemptState) *timestamppb
 		return timestamppb.New(completeTime.AsTime().Add(retryInterval.AsDuration()))
 	}
 	return nil
+}
+
+// nextAttemptDispatchTime is the dispatch_time of the attempt that is currently being waited for.
+// It is null when the dispatch time has passed, in terminal states, and when paused or when an
+// attempt is in progress, since in those states the dispatch time of a future attempt is unknown:
+// we do not even know if there will be a next attempt.
+//
+// In the public Describe API response of SAA and WFA, this has the name next_attempt_schedule_time.
+// In that field name, the term "schedule_time" is actually a dispatch time; specifically, the
+// dispatch time defined by this method.
+//
+// For WFA, next_attempt_schedule_time is null prior to the first attempt since start delay is not
+// supported, hence the activity is due to be dispatched to Matching as soon as the activity is
+// created. But for SAA, if there's a start delay, then next_attempt_schedule_time is the
+// dispatch_time (non-null).
+func (a *Activity) nextAttemptDispatchTime(ctx chasm.Context, attempt *activitypb.ActivityAttemptState) *timestamppb.Timestamp {
+	if a.hasAttemptInProgress() || a.isPaused() || a.isTerminal() {
+		return nil
+	}
+	if t := a.dispatchTimeForAttempt(attempt); t != nil {
+		if t.AsTime().After(ctx.Now(a)) {
+			return t
+		}
+	}
+	return nil
+}
+
+// currentRetryInterval is the current or next retry interval.
+// - If the activity is currently in retry backoff, then return the current retry interval.
+// - If the activity has an attempt in progress, then return the retry interval that will apply if the attempt fails
+// - Otherwise return nil
+func (a *Activity) currentRetryInterval(ctx chasm.Context, attempt *activitypb.ActivityAttemptState) *durationpb.Duration {
+	switch {
+	case a.hasAttemptInProgress():
+		// The interval a failure now would be retried with — exactly what the retry path decides — or
+		// null if it would not retry (attempts or schedule-to-close time exhausted).
+		if willRetry, interval := a.shouldRetry(ctx, 0); willRetry {
+			return durationpb.New(interval)
+		}
+		return nil
+	case a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED:
+		return attempt.GetCurrentRetryInterval()
+	default:
+		return nil
+	}
 }
 
 // RecordCompleted applies the provided function to record activity completion.
@@ -1659,7 +1707,7 @@ func (a *Activity) buildActivityExecutionInfo(
 		Attempt:                 attempt.GetCount(),
 		CanceledReason:          a.CancelState.GetReason(),
 		CloseTime:               closeTime,
-		CurrentRetryInterval:    attempt.GetCurrentRetryInterval(),
+		CurrentRetryInterval:    a.currentRetryInterval(ctx, attempt),
 		ExecutionDuration:       executionDuration,
 		ExecutionTime:           timestamppb.New(a.firstDispatchTime()),
 		ExpirationTime:          expirationTime,
@@ -1673,7 +1721,7 @@ func (a *Activity) buildActivityExecutionInfo(
 		LastWorkerIdentity:      attempt.GetLastWorkerIdentity(),
 		SdkName:                 attempt.GetSdkName(),
 		SdkVersion:              attempt.GetSdkVersion(),
-		NextAttemptScheduleTime: dispatchTimeForRetry(attempt),
+		NextAttemptScheduleTime: a.nextAttemptDispatchTime(ctx, attempt),
 		Priority:                a.GetPriority(),
 		RetryPolicy:             a.GetRetryPolicy(),
 		RunId:                   key.RunID,

--- a/chasm/lib/activity/model/vocabulary.go
+++ b/chasm/lib/activity/model/vocabulary.go
@@ -1,0 +1,28 @@
+// Package model is a test-only behavioral model of the CHASM activity archetype: an
+// implementation-independent description of how an activity should behave. It should never be
+// imported by the server binary.
+//
+// Drivers can be written that realize these events for Standalone Activity or for Workflow Activity.
+package model
+
+// Config contains start-time activity options.
+type Config struct {
+	MaxAttempts int32 // 0 = unlimited
+}
+
+// EventKind enumerates the events the model covers.
+type EventKind int
+
+const (
+	Poll EventKind = iota
+	RespondCompleted
+	RespondFailed
+	BackoffElapses
+)
+
+// Event is an EventKind together with flags describing the RPC
+type Event struct {
+	Kind EventKind
+
+	Retryable bool // RespondFailed: the failure is retryable.
+}

--- a/tests/activity_standalone_harness.go
+++ b/tests/activity_standalone_harness.go
@@ -1,0 +1,228 @@
+package tests
+
+// Driver for standalone-activity (SAA) tests: starts an activity and drives it through a scripted
+// sequence of events (a trace), realizing each event as the corresponding frontend RPC / poll /
+// wall-clock wait. It does not make assertions about behavior.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/chasm/lib/activity/model"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/payloads"
+	"go.temporal.io/server/tests/testcore"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+// saaInput is the activity input every driven activity is started with. Defined here (not in a
+// _test.go file) so this driver builds as part of the non-test package.
+var saaInput = payloads.EncodeString("Input")
+
+// --- driver --------------------------------------------------------------------------------
+
+type saaHarness struct {
+	env     *testcore.TestEnv
+	ctx     context.Context
+	cfg     model.Config
+	counter int
+	// activity-id prefix so that subtests don't collide.
+	idBase        string
+	startDelay    time.Duration
+	retryInterval time.Duration // defaults to a short backoff
+	// bounds a "must dispatch" poll; defaults to 10s.
+	positivePollTimeout time.Duration
+}
+
+// saaWallClockSettle is slack added to a wall-clock event's clock when waiting for it to fire.
+const saaWallClockSettle = 2 * time.Second
+
+// saaPollTimeout bounds a poll: just above common.MinLongPollTimeout.
+const saaPollTimeout = common.MinLongPollTimeout + time.Second
+
+// saaHandle is a handle to one activity instance
+type saaHandle struct {
+	h          *saaHarness
+	activityID string
+	taskQueue  string
+	runID      string
+	token      []byte
+}
+
+// driveTrace runs a trace (a sequence of events) for a fresh activity, realizing each event against
+// the server, returning a handle to it at the reached state.
+func (h *saaHarness) driveTrace(t require.TestingT, trace []model.Event) *saaHandle {
+	a := h.start(t)
+	for _, e := range trace {
+		a.driveEvent(t, e)
+	}
+	return a
+}
+
+// driveEvent advances the activity by one event: a poll captures the dispatched token; a wall-clock
+// event is realized by waiting for its configured time window; any other event is its RPC (which
+// must succeed).
+func (a *saaHandle) driveEvent(t require.TestingT, e model.Event) {
+	h := a.h
+	switch e.Kind {
+	case model.Poll:
+		timeout := 10 * time.Second
+		if h.positivePollTimeout > 0 {
+			timeout = h.positivePollTimeout
+		}
+		a.token = a.pollForTask(t, timeout).GetTaskToken()
+	case model.BackoffElapses:
+		// No time-skip in a real-server test: sleep out the backoff.
+		time.Sleep(h.retryInterval + saaWallClockSettle) //nolint:forbidigo
+	default:
+		require.NoError(t, a.rpc(e))
+	}
+}
+
+func (h *saaHarness) start(t require.TestingT) *saaHandle {
+	h.counter++
+	id := fmt.Sprintf("%s-%d", h.idBase, h.counter)
+	resp, err := h.env.FrontendClient().StartActivityExecution(h.ctx, h.startRequest(id, id))
+	require.NoError(t, err)
+	return &saaHandle{h: h, activityID: id, taskQueue: id, runID: resp.RunId}
+}
+
+func (h *saaHarness) startRequest(activityID, taskQueue string) *workflowservice.StartActivityExecutionRequest {
+	interval := 200 * time.Millisecond
+	if h.retryInterval > 0 {
+		interval = h.retryInterval
+	}
+	req := &workflowservice.StartActivityExecutionRequest{
+		Namespace:           h.env.Namespace().String(),
+		ActivityId:          activityID,
+		ActivityType:        h.env.Tv().ActivityType(),
+		Identity:            "worker",
+		Input:               saaInput,
+		TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+		StartToCloseTimeout: durationpb.New(time.Hour),
+		RetryPolicy: &commonpb.RetryPolicy{
+			InitialInterval:    durationpb.New(interval),
+			BackoffCoefficient: 1.0,
+			MaximumInterval:    durationpb.New(interval),
+			MaximumAttempts:    h.cfg.MaxAttempts,
+		},
+		RequestId: uuid.NewString(),
+	}
+	if h.startDelay > 0 {
+		req.StartDelay = durationpb.New(h.startDelay)
+	}
+	return req
+}
+
+// describe returns the DescribeActivityExecution response.
+func (a *saaHandle) describe() (*workflowservice.DescribeActivityExecutionResponse, error) {
+	return a.h.env.FrontendClient().DescribeActivityExecution(a.h.ctx, &workflowservice.DescribeActivityExecutionRequest{
+		Namespace:          a.h.env.Namespace().String(),
+		ActivityId:         a.activityID,
+		RunId:              a.runID,
+		IncludeOutcome:     true,
+		IncludeLastFailure: true,
+	})
+}
+
+// rpc performs the RPC for a non-Poll, non-wall-clock event and returns its error.
+func (a *saaHandle) rpc(e model.Event) error {
+	fc := a.h.env.FrontendClient()
+	ns := a.h.env.Namespace().String()
+	switch e.Kind {
+	case model.RespondCompleted:
+		_, err := fc.RespondActivityTaskCompleted(a.h.ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: ns, TaskToken: a.token, Identity: "worker",
+		})
+		return err
+	case model.RespondFailed:
+		_, err := fc.RespondActivityTaskFailed(a.h.ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: ns, TaskToken: a.token, Identity: "worker", Failure: saaFailure(e.Retryable),
+		})
+		return err
+	default:
+		return fmt.Errorf("saaHarness: unhandled event kind %v", e.Kind)
+	}
+}
+
+func (a *saaHandle) pollForTask(t require.TestingT, timeout time.Duration) *workflowservice.PollActivityTaskQueueResponse {
+	ctx, cancel := context.WithTimeout(a.h.ctx, timeout)
+	defer cancel()
+	resp, err := a.h.env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+		Namespace: a.h.env.Namespace().String(),
+		TaskQueue: &taskqueuepb.TaskQueue{Name: a.taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		Identity:  "worker",
+	})
+	// Matching signals "waited, found nothing" with an empty response and a nil error, so a genuine
+	// no-task result never surfaces as an error.
+	if err != nil {
+		// The poll did not complete cleanly.
+		if deadline, ok := a.h.ctx.Deadline(); ok && time.Until(deadline) < common.MinLongPollTimeout {
+			require.FailNowf(t, "saaHarness: test context budget exhausted before the poll could run",
+				"time left: %.1fs (need >= %s); raise TEMPORAL_TEST_TIMEOUT or use `go test -timeout`. error: %v",
+				time.Until(deadline).Seconds(), common.MinLongPollTimeout, err)
+		}
+		require.FailNowf(t, "saaHarness: PollActivityTaskQueue did not complete cleanly",
+			"the server rejected the poll or returned an unexpected error (a no-task result would be an empty response, not an error). error: %v", err)
+	}
+	// Empty response with a nil error means "waited, no task available".
+	require.NotEmptyf(t, resp.GetActivityId(), "saaHarness: scripted Poll found no dispatched task within %s (still in backoff / start-delay, already started, or terminal)", timeout)
+	return resp
+}
+
+func saaFailure(retryable bool) *failurepb.Failure {
+	return &failurepb.Failure{
+		Message: "drive",
+		FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+			ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{Type: "drive", NonRetryable: !retryable},
+		},
+	}
+}
+
+// --- traces --------------------------------------------------------------------------------
+//
+// A trace is an event sequence run once on one fresh activity.
+
+type saaTrace struct {
+	trace         []model.Event
+	maxAttempts   int32         // RetryPolicy MaximumAttempts (0 = unlimited)
+	startDelayed  bool          // activity created with a start_delay; the window length is derived (see startDelay)
+	retryInterval time.Duration // RetryPolicy interval; how long the driver waits for BackoffElapses
+}
+
+// config derives the model Config from the trace.
+func (tr saaTrace) config() model.Config {
+	return model.Config{MaxAttempts: tr.maxAttempts}
+}
+
+// startDelay is the activity's start_delay duration: if the activity is start-delayed then the
+// value used is long enough to stay open for the whole trace.
+func (tr saaTrace) startDelay() time.Duration {
+	if !tr.startDelayed {
+		return 0
+	}
+	return saaLongStartDelay
+}
+
+// saaDelayWindow is the dispatch-backoff interval: long enough that a describe issued right after a
+// failure still observes the state before the retry dispatches; short enough that waiting it out
+// stays within the test budget.
+const saaDelayWindow = 5 * time.Second
+
+// saaLongStartDelay keeps a first attempt in its start-delay window for the whole trace, so the
+// activity stays SCHEDULED and pending dispatch.
+const saaLongStartDelay = time.Hour
+
+var (
+	saaPoll               = model.Event{Kind: model.Poll}
+	saaFailRetryably      = model.Event{Kind: model.RespondFailed, Retryable: true}
+	saaBackoffDelayElapse = model.Event{Kind: model.BackoffElapses}
+)

--- a/tests/activity_standalone_harness.go
+++ b/tests/activity_standalone_harness.go
@@ -23,8 +23,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
-// saaInput is the activity input every driven activity is started with. Defined here (not in a
-// _test.go file) so this driver builds as part of the non-test package.
+// saaInput is the activity input every driven activity is started with.
 var saaInput = payloads.EncodeString("Input")
 
 // --- driver --------------------------------------------------------------------------------
@@ -123,14 +122,16 @@ func (h *saaHarness) startRequest(activityID, taskQueue string) *workflowservice
 }
 
 // describe returns the DescribeActivityExecution response.
-func (a *saaHandle) describe() (*workflowservice.DescribeActivityExecutionResponse, error) {
-	return a.h.env.FrontendClient().DescribeActivityExecution(a.h.ctx, &workflowservice.DescribeActivityExecutionRequest{
+func (a *saaHandle) describe(t require.TestingT) *workflowservice.DescribeActivityExecutionResponse {
+	resp, err := a.h.env.FrontendClient().DescribeActivityExecution(a.h.ctx, &workflowservice.DescribeActivityExecutionRequest{
 		Namespace:          a.h.env.Namespace().String(),
 		ActivityId:         a.activityID,
 		RunId:              a.runID,
 		IncludeOutcome:     true,
 		IncludeLastFailure: true,
 	})
+	require.NoError(t, err)
+	return resp
 }
 
 // rpc performs the RPC for a non-Poll, non-wall-clock event and returns its error.
@@ -225,4 +226,5 @@ var (
 	saaPoll               = model.Event{Kind: model.Poll}
 	saaFailRetryably      = model.Event{Kind: model.RespondFailed, Retryable: true}
 	saaBackoffDelayElapse = model.Event{Kind: model.BackoffElapses}
+	saaComplete           = model.Event{Kind: model.RespondCompleted}
 )

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -36,7 +36,6 @@ import (
 	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/common/testing/protorequire"
-	"go.temporal.io/server/common/testing/testcontext"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -122,9 +121,8 @@ func (s *standaloneActivityTestSuite) newTestEnv(opts ...testcore.TestOption) *s
 // driveTrace runs a trace (a sequence of events) for a fresh activity, realizing each event against
 // the server, returning a handle to it at the reached state.
 func (s *standaloneActivityTestSuite) driveTrace(t *testing.T, env *standaloneActivityEnv, tr saaTrace) *saaHandle {
-	ctx := testcontext.For(t)
 	h := &saaHarness{
-		env: env.TestEnv, ctx: ctx,
+		env: env.TestEnv, ctx: s.Context(),
 		idBase:        testcore.RandomizeStr(t.Name()),
 		cfg:           tr.config(),
 		startDelay:    tr.startDelay(),

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -21,6 +21,7 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/server/chasm/lib/activity"
+	"go.temporal.io/server/chasm/lib/activity/model"
 	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -36,6 +37,7 @@ import (
 	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/common/testing/protorequire"
+	"go.temporal.io/server/common/testing/testcontext"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -116,6 +118,23 @@ func (s *standaloneActivityTestSuite) newTestEnv(opts ...testcore.TestOption) *s
 	cluster.OverrideDynamicConfig(s.T(), activity.Enabled, nsValues(true))
 	cluster.OverrideDynamicConfig(s.T(), activity.EnableCallbacks, nsValues(true))
 	return env
+}
+
+// driveTrace runs a trace (a sequence of events) for a fresh activity, realizing each event against
+// the server, returning a handle to it at the reached state.
+func (s *standaloneActivityTestSuite) driveTrace(t *testing.T, env *standaloneActivityEnv, tr saaTrace) *saaHandle {
+	ctx := testcontext.For(t)
+	h := &saaHarness{
+		env: env.TestEnv, ctx: ctx,
+		idBase:        testcore.RandomizeStr(t.Name()),
+		cfg:           tr.config(),
+		startDelay:    tr.startDelay(),
+		retryInterval: tr.retryInterval,
+		// "Dispatchable" must mean "dispatches promptly", so bound the positive poll just above the
+		// long-poll minimum — that is how a queued retry is told from one still in backoff.
+		positivePollTimeout: saaPollTimeout,
+	}
+	return h.driveTrace(t, tr.trace)
 }
 
 func (s *standaloneActivityTestSuite) TestIDReusePolicy() {
@@ -3533,6 +3552,142 @@ func (s *standaloneActivityTestSuite) TestScheduleToStartTimeout() {
 	require.NotNil(t, describeResp.GetInfo().GetCloseTime())
 	require.Equal(t, enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START, describeResp.GetOutcome().GetFailure().GetTimeoutFailureInfo().GetTimeoutType(),
 		"expected ScheduleToStartTimeout but is %s", describeResp.GetOutcome().GetFailure().GetTimeoutFailureInfo().GetTimeoutType())
+}
+
+func (s *standaloneActivityTestSuite) TestDescribeNextAttemptScheduleTimeAndCurrentRetryInterval() {
+	env := s.newTestEnv()
+	t := s.T()
+
+	// First attempt within its start delay: the dispatch is pending in the future.
+	t.Run("StartDelayPending", func(t *testing.T) {
+		desc, err := s.driveTrace(t, env, saaTrace{trace: []model.Event{}, startDelayed: true}).describe()
+		require.NoError(t, err)
+		info := desc.GetInfo()
+
+		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
+			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, info.GetRunState())
+			require.Equal(t, info.GetExecutionTime().AsTime(), info.GetNextAttemptScheduleTime().AsTime())
+		})
+
+		t.Run("CurrentRetryInterval", func(t *testing.T) {
+			require.Nil(t, info.GetCurrentRetryInterval())
+		})
+	})
+
+	// First attempt running: no pending next dispatch.
+	t.Run("FirstAttemptRunning", func(t *testing.T) {
+		desc, err := s.driveTrace(t, env, saaTrace{trace: []model.Event{saaPoll}, maxAttempts: 3, retryInterval: saaDelayWindow}).describe()
+		require.NoError(t, err)
+		info := desc.GetInfo()
+
+		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
+			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, info.GetRunState())
+			require.Nil(t, info.GetNextAttemptScheduleTime())
+		})
+
+		t.Run("CurrentRetryInterval", func(t *testing.T) {
+			require.Equal(t, saaDelayWindow, info.GetCurrentRetryInterval().AsDuration())
+		})
+	})
+
+	// Backing off before the retry dispatches.
+	t.Run("BackingOffBeforeRetry", func(t *testing.T) {
+		desc, err := s.driveTrace(t, env, saaTrace{trace: []model.Event{saaPoll, saaFailRetryably}, maxAttempts: 3, retryInterval: saaDelayWindow}).describe()
+		require.NoError(t, err)
+		info := desc.GetInfo()
+
+		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
+			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, info.GetRunState())
+			require.True(t, info.GetNextAttemptScheduleTime().AsTime().After(time.Now()))
+		})
+
+		t.Run("CurrentRetryInterval", func(t *testing.T) {
+			require.Equal(t, saaDelayWindow, info.GetCurrentRetryInterval().AsDuration())
+		})
+	})
+
+	// Retry dispatched to Matching but not yet picked up.
+	t.Run("RetryQueuedNotStarted", func(t *testing.T) {
+		desc, err := s.driveTrace(t, env, saaTrace{
+			trace:         []model.Event{saaPoll, saaFailRetryably, saaBackoffDelayElapse},
+			maxAttempts:   3,
+			retryInterval: saaDelayWindow,
+		}).describe()
+		require.NoError(t, err)
+		info := desc.GetInfo()
+
+		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
+			require.EqualValues(t, 2, info.GetAttempt())
+			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, info.GetRunState())
+			require.Nil(t, info.GetNextAttemptScheduleTime())
+		})
+
+		t.Run("CurrentRetryInterval", func(t *testing.T) {
+			require.Equal(t, saaDelayWindow, info.GetCurrentRetryInterval().AsDuration())
+		})
+	})
+
+	// Retry attempt running with a further retry permitted.
+	t.Run("RetryAttemptRunning", func(t *testing.T) {
+		desc, err := s.driveTrace(t, env, saaTrace{
+			trace:         []model.Event{saaPoll, saaFailRetryably, saaBackoffDelayElapse, saaPoll},
+			maxAttempts:   3,
+			retryInterval: saaDelayWindow,
+		}).describe()
+		require.NoError(t, err)
+		info := desc.GetInfo()
+
+		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
+			require.EqualValues(t, 2, info.GetAttempt())
+			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, info.GetRunState())
+			require.Nil(t, info.GetNextAttemptScheduleTime())
+		})
+
+		t.Run("CurrentRetryInterval", func(t *testing.T) {
+			require.Equal(t, saaDelayWindow, info.GetCurrentRetryInterval().AsDuration())
+		})
+	})
+
+	// Final attempt running with no retries remaining.
+	t.Run("FinalAttemptRunning", func(t *testing.T) {
+		desc, err := s.driveTrace(t, env, saaTrace{
+			trace:         []model.Event{saaPoll, saaFailRetryably, saaBackoffDelayElapse, saaPoll},
+			maxAttempts:   2,
+			retryInterval: saaDelayWindow,
+		}).describe()
+		require.NoError(t, err)
+		info := desc.GetInfo()
+
+		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
+			require.EqualValues(t, 2, info.GetAttempt())
+			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, info.GetRunState())
+			require.Nil(t, info.GetNextAttemptScheduleTime())
+		})
+
+		t.Run("CurrentRetryInterval", func(t *testing.T) {
+			require.Nil(t, info.GetCurrentRetryInterval())
+		})
+	})
+
+	// Terminal (completed after a retry): no attempt is pending or running.
+	t.Run("Completed", func(t *testing.T) {
+		desc, err := s.driveTrace(t, env, saaTrace{
+			trace:         []model.Event{saaPoll, saaFailRetryably, saaBackoffDelayElapse, saaPoll, {Kind: model.RespondCompleted}},
+			maxAttempts:   3,
+			retryInterval: saaDelayWindow,
+		}).describe()
+		require.NoError(t, err)
+		info := desc.GetInfo()
+
+		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
+			require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, info.GetStatus())
+			require.Nil(t, info.GetNextAttemptScheduleTime())
+		})
+
+		t.Run("CurrentRetryInterval", func(t *testing.T) {
+			require.Nil(t, info.GetCurrentRetryInterval())
+		})
+	})
 }
 
 func (s *standaloneActivityTestSuite) TestDescribeActivityExecution() {

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -3560,9 +3560,10 @@ func (s *standaloneActivityTestSuite) TestDescribeNextAttemptScheduleTimeAndCurr
 
 	// First attempt within its start delay: the dispatch is pending in the future.
 	t.Run("StartDelayPending", func(t *testing.T) {
-		desc, err := s.driveTrace(t, env, saaTrace{trace: []model.Event{}, startDelayed: true}).describe()
-		require.NoError(t, err)
-		info := desc.GetInfo()
+		info := s.driveTrace(t, env, saaTrace{
+			trace:        []model.Event{},
+			startDelayed: true,
+		}).describe(t).GetInfo()
 
 		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
 			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, info.GetRunState())
@@ -3570,15 +3571,21 @@ func (s *standaloneActivityTestSuite) TestDescribeNextAttemptScheduleTimeAndCurr
 		})
 
 		t.Run("CurrentRetryInterval", func(t *testing.T) {
+			info := s.driveTrace(t, env, saaTrace{
+				trace:        []model.Event{},
+				startDelayed: true,
+			}).describe(t).GetInfo()
 			require.Nil(t, info.GetCurrentRetryInterval())
 		})
 	})
 
 	// First attempt running: no pending next dispatch.
 	t.Run("FirstAttemptRunning", func(t *testing.T) {
-		desc, err := s.driveTrace(t, env, saaTrace{trace: []model.Event{saaPoll}, maxAttempts: 3, retryInterval: saaDelayWindow}).describe()
-		require.NoError(t, err)
-		info := desc.GetInfo()
+		info := s.driveTrace(t, env, saaTrace{
+			trace:         []model.Event{saaPoll},
+			maxAttempts:   3,
+			retryInterval: saaDelayWindow,
+		}).describe(t).GetInfo()
 
 		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
 			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, info.GetRunState())
@@ -3592,9 +3599,11 @@ func (s *standaloneActivityTestSuite) TestDescribeNextAttemptScheduleTimeAndCurr
 
 	// Backing off before the retry dispatches.
 	t.Run("BackingOffBeforeRetry", func(t *testing.T) {
-		desc, err := s.driveTrace(t, env, saaTrace{trace: []model.Event{saaPoll, saaFailRetryably}, maxAttempts: 3, retryInterval: saaDelayWindow}).describe()
-		require.NoError(t, err)
-		info := desc.GetInfo()
+		info := s.driveTrace(t, env, saaTrace{
+			trace:         []model.Event{saaPoll, saaFailRetryably},
+			maxAttempts:   3,
+			retryInterval: saaDelayWindow,
+		}).describe(t).GetInfo()
 
 		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
 			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, info.GetRunState())
@@ -3608,13 +3617,11 @@ func (s *standaloneActivityTestSuite) TestDescribeNextAttemptScheduleTimeAndCurr
 
 	// Retry dispatched to Matching but not yet picked up.
 	t.Run("RetryQueuedNotStarted", func(t *testing.T) {
-		desc, err := s.driveTrace(t, env, saaTrace{
+		info := s.driveTrace(t, env, saaTrace{
 			trace:         []model.Event{saaPoll, saaFailRetryably, saaBackoffDelayElapse},
 			maxAttempts:   3,
 			retryInterval: saaDelayWindow,
-		}).describe()
-		require.NoError(t, err)
-		info := desc.GetInfo()
+		}).describe(t).GetInfo()
 
 		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
 			require.EqualValues(t, 2, info.GetAttempt())
@@ -3629,13 +3636,11 @@ func (s *standaloneActivityTestSuite) TestDescribeNextAttemptScheduleTimeAndCurr
 
 	// Retry attempt running with a further retry permitted.
 	t.Run("RetryAttemptRunning", func(t *testing.T) {
-		desc, err := s.driveTrace(t, env, saaTrace{
+		info := s.driveTrace(t, env, saaTrace{
 			trace:         []model.Event{saaPoll, saaFailRetryably, saaBackoffDelayElapse, saaPoll},
 			maxAttempts:   3,
 			retryInterval: saaDelayWindow,
-		}).describe()
-		require.NoError(t, err)
-		info := desc.GetInfo()
+		}).describe(t).GetInfo()
 
 		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
 			require.EqualValues(t, 2, info.GetAttempt())
@@ -3650,13 +3655,11 @@ func (s *standaloneActivityTestSuite) TestDescribeNextAttemptScheduleTimeAndCurr
 
 	// Final attempt running with no retries remaining.
 	t.Run("FinalAttemptRunning", func(t *testing.T) {
-		desc, err := s.driveTrace(t, env, saaTrace{
+		info := s.driveTrace(t, env, saaTrace{
 			trace:         []model.Event{saaPoll, saaFailRetryably, saaBackoffDelayElapse, saaPoll},
 			maxAttempts:   2,
 			retryInterval: saaDelayWindow,
-		}).describe()
-		require.NoError(t, err)
-		info := desc.GetInfo()
+		}).describe(t).GetInfo()
 
 		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
 			require.EqualValues(t, 2, info.GetAttempt())
@@ -3671,13 +3674,11 @@ func (s *standaloneActivityTestSuite) TestDescribeNextAttemptScheduleTimeAndCurr
 
 	// Terminal (completed after a retry): no attempt is pending or running.
 	t.Run("Completed", func(t *testing.T) {
-		desc, err := s.driveTrace(t, env, saaTrace{
-			trace:         []model.Event{saaPoll, saaFailRetryably, saaBackoffDelayElapse, saaPoll, {Kind: model.RespondCompleted}},
+		info := s.driveTrace(t, env, saaTrace{
+			trace:         []model.Event{saaPoll, saaFailRetryably, saaBackoffDelayElapse, saaPoll, saaComplete},
 			maxAttempts:   3,
 			retryInterval: saaDelayWindow,
-		}).describe()
-		require.NoError(t, err)
-		info := desc.GetInfo()
+		}).describe(t).GetInfo()
 
 		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
 			require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, info.GetStatus())

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -21,7 +21,6 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/server/chasm/lib/activity"
-	"go.temporal.io/server/chasm/lib/activity/model"
 	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -3554,143 +3553,6 @@ func (s *standaloneActivityTestSuite) TestScheduleToStartTimeout() {
 		"expected ScheduleToStartTimeout but is %s", describeResp.GetOutcome().GetFailure().GetTimeoutFailureInfo().GetTimeoutType())
 }
 
-func (s *standaloneActivityTestSuite) TestDescribeNextAttemptScheduleTimeAndCurrentRetryInterval() {
-	env := s.newTestEnv()
-	t := s.T()
-
-	// First attempt within its start delay: the dispatch is pending in the future.
-	t.Run("StartDelayPending", func(t *testing.T) {
-		info := s.driveTrace(t, env, saaTrace{
-			trace:        []model.Event{},
-			startDelayed: true,
-		}).describe(t).GetInfo()
-
-		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
-			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, info.GetRunState())
-			require.Equal(t, info.GetExecutionTime().AsTime(), info.GetNextAttemptScheduleTime().AsTime())
-		})
-
-		t.Run("CurrentRetryInterval", func(t *testing.T) {
-			info := s.driveTrace(t, env, saaTrace{
-				trace:        []model.Event{},
-				startDelayed: true,
-			}).describe(t).GetInfo()
-			require.Nil(t, info.GetCurrentRetryInterval())
-		})
-	})
-
-	// First attempt running: no pending next dispatch.
-	t.Run("FirstAttemptRunning", func(t *testing.T) {
-		info := s.driveTrace(t, env, saaTrace{
-			trace:         []model.Event{saaPoll},
-			maxAttempts:   3,
-			retryInterval: saaDelayWindow,
-		}).describe(t).GetInfo()
-
-		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
-			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, info.GetRunState())
-			require.Nil(t, info.GetNextAttemptScheduleTime())
-		})
-
-		t.Run("CurrentRetryInterval", func(t *testing.T) {
-			require.Equal(t, saaDelayWindow, info.GetCurrentRetryInterval().AsDuration())
-		})
-	})
-
-	// Backing off before the retry dispatches.
-	t.Run("BackingOffBeforeRetry", func(t *testing.T) {
-		info := s.driveTrace(t, env, saaTrace{
-			trace:         []model.Event{saaPoll, saaFailRetryably},
-			maxAttempts:   3,
-			retryInterval: saaDelayWindow,
-		}).describe(t).GetInfo()
-
-		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
-			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, info.GetRunState())
-			require.True(t, info.GetNextAttemptScheduleTime().AsTime().After(time.Now()))
-		})
-
-		t.Run("CurrentRetryInterval", func(t *testing.T) {
-			require.Equal(t, saaDelayWindow, info.GetCurrentRetryInterval().AsDuration())
-		})
-	})
-
-	// Retry dispatched to Matching but not yet picked up.
-	t.Run("RetryQueuedNotStarted", func(t *testing.T) {
-		info := s.driveTrace(t, env, saaTrace{
-			trace:         []model.Event{saaPoll, saaFailRetryably, saaBackoffDelayElapse},
-			maxAttempts:   3,
-			retryInterval: saaDelayWindow,
-		}).describe(t).GetInfo()
-
-		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
-			require.EqualValues(t, 2, info.GetAttempt())
-			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, info.GetRunState())
-			require.Nil(t, info.GetNextAttemptScheduleTime())
-		})
-
-		t.Run("CurrentRetryInterval", func(t *testing.T) {
-			require.Equal(t, saaDelayWindow, info.GetCurrentRetryInterval().AsDuration())
-		})
-	})
-
-	// Retry attempt running with a further retry permitted.
-	t.Run("RetryAttemptRunning", func(t *testing.T) {
-		info := s.driveTrace(t, env, saaTrace{
-			trace:         []model.Event{saaPoll, saaFailRetryably, saaBackoffDelayElapse, saaPoll},
-			maxAttempts:   3,
-			retryInterval: saaDelayWindow,
-		}).describe(t).GetInfo()
-
-		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
-			require.EqualValues(t, 2, info.GetAttempt())
-			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, info.GetRunState())
-			require.Nil(t, info.GetNextAttemptScheduleTime())
-		})
-
-		t.Run("CurrentRetryInterval", func(t *testing.T) {
-			require.Equal(t, saaDelayWindow, info.GetCurrentRetryInterval().AsDuration())
-		})
-	})
-
-	// Final attempt running with no retries remaining.
-	t.Run("FinalAttemptRunning", func(t *testing.T) {
-		info := s.driveTrace(t, env, saaTrace{
-			trace:         []model.Event{saaPoll, saaFailRetryably, saaBackoffDelayElapse, saaPoll},
-			maxAttempts:   2,
-			retryInterval: saaDelayWindow,
-		}).describe(t).GetInfo()
-
-		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
-			require.EqualValues(t, 2, info.GetAttempt())
-			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, info.GetRunState())
-			require.Nil(t, info.GetNextAttemptScheduleTime())
-		})
-
-		t.Run("CurrentRetryInterval", func(t *testing.T) {
-			require.Nil(t, info.GetCurrentRetryInterval())
-		})
-	})
-
-	// Terminal (completed after a retry): no attempt is pending or running.
-	t.Run("Completed", func(t *testing.T) {
-		info := s.driveTrace(t, env, saaTrace{
-			trace:         []model.Event{saaPoll, saaFailRetryably, saaBackoffDelayElapse, saaPoll, saaComplete},
-			maxAttempts:   3,
-			retryInterval: saaDelayWindow,
-		}).describe(t).GetInfo()
-
-		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
-			require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, info.GetStatus())
-			require.Nil(t, info.GetNextAttemptScheduleTime())
-		})
-
-		t.Run("CurrentRetryInterval", func(t *testing.T) {
-			require.Nil(t, info.GetCurrentRetryInterval())
-		})
-	})
-}
-
 func (s *standaloneActivityTestSuite) TestDescribeActivityExecution() {
 	s.Run("NoWait", func(s *standaloneActivityTestSuite) {
 		t := s.T()
@@ -3976,7 +3838,6 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution() {
 				ActivityId:             activityID,
 				ActivityType:           env.Tv().ActivityType(),
 				Attempt:                1,
-				CurrentRetryInterval:   durationpb.New(time.Second),
 				HeartbeatTimeout:       durationpb.New(0),
 				LastWorkerIdentity:     defaultIdentity,
 				RetryPolicy:            defaultRetryPolicy,

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -3976,6 +3976,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution() {
 				ActivityId:             activityID,
 				ActivityType:           env.Tv().ActivityType(),
 				Attempt:                1,
+				CurrentRetryInterval:   durationpb.New(time.Second),
 				HeartbeatTimeout:       durationpb.New(0),
 				LastWorkerIdentity:     defaultIdentity,
 				RetryPolicy:            defaultRetryPolicy,


### PR DESCRIPTION
## What changed?
- introduce utilities for writing SAA functional tests declaratively

The test harness introduces a utility `driveTrace()` which allows specifying a sequence of events (RPCs, timeouts, etc) that must be executed against the server, in order to get a standalone activity into a desired state for making test assertions.


See https://github.com/temporalio/temporal/pull/11150/changes for an example of using this to write tests.

## Why?
- Make the SAA test suite more readable and less error-prone. It has grown to ~15k LOC, and was becoming unmanageable.

The events are expressed in a vocabulary that does not import anything from the real implementation. One advantage of this is that we will be able to verify parity between WFA and SAA by making it possible for WFA tests to use the same vocabulary to define a target state to make test assertions against. It also makes model-based testing possible -- i.e. it would allow us to perform automated assertion checking by defining model state machine transition functions. 

## How did you test it?
- [x] added new functional test(s)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only code and a test-only model package; no production server paths or runtime behavior changes.
> 
> **Overview**
> Adds **declarative standalone-activity (SAA) functional test infrastructure**: tests can describe an event trace (poll, complete/fail, backoff elapse) and drive a fresh activity to a known state before asserting.
> 
> Introduces `chasm/lib/activity/model` with an implementation-agnostic **event vocabulary** (`Poll`, `RespondCompleted`, `RespondFailed`, `BackoffElapses`, plus retry flags and start options) intended for SAA drivers, future workflow-activity parity, and model-based testing.
> 
> Adds `tests/activity_standalone_harness.go`, which **realizes** each trace step via frontend RPCs (start, poll with bounded timeout, respond, wall-clock sleep for backoff) and returns an `saaHandle` for describe/assertions. The standalone activity test suite gains `driveTrace(t, env, saaTrace)` to wire harness config (retry policy, start delay, poll timeout) from trace metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 933f707c084a46cd32f7193e9f87fad5b4b17932. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->