### PR TITLE
SAA: fix next attempt and current retry interval in Describe response

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -2,19 +2,22 @@
 //
 // We name 3 times in the lifecycle of an activity attempt:
 //
-// schedule time - the time at which the activity entered SCHEDULED state
-// dispatch time - the time at which the activity task will be dispatched to Matching (AddActivityTask)
-// start time    - the time at which the activity enters STARTED state (Matching task picked up by poller)
+// schedule_time - the time at which the activity entered SCHEDULED state
+// dispatch_time - the time at which the activity task is due to be dispatched to Matching (AddActivityTask)
+// start_time    - the time at which the activity enters STARTED state (Matching task picked up by poller)
 //
-// They are always ordered as: (schedule time) <= (dispatch time) < (start time).
+// They are always ordered as: (schedule_time) <= (dispatch_time) < (start_time).
 //
 // A ScheduleToStart timeout applies to the time between dispatch and start. If there is a delay
 // before dispatch (i.e. a start delay on the first attempt, or a backoff interval / next retry
-// delay on a second or subsequent attempt) then schedule time < dispatch time. Otherwise, they are
+// delay on a second or subsequent attempt) then schedule_time < dispatch_time. Otherwise, they are
 // equal.
 //
 // The main Activity struct has a.ScheduleTime which is the schedule time of the first
 // attempt; i.e. the time at which the activity was created. This is never changed.
+//
+// The naming situation is not perfectly clean. See e.g. the comment below on
+// nextAttemptDispatchTime (which is called next_attempt_schedule_time in the public API).
 
 package activity
 
@@ -352,6 +355,51 @@ func dispatchTimeForRetry(attempt *activitypb.ActivityAttemptState) *timestamppb
 		return timestamppb.New(completeTime.AsTime().Add(retryInterval.AsDuration()))
 	}
 	return nil
+}
+
+// nextAttemptDispatchTime is the dispatch_time of the attempt that is currently being waited for.
+// It is null when the dispatch time has passed, in terminal states, and when paused or when an
+// attempt is in progress, since in those states the dispatch time of a future attempt is unknown:
+// we do not even know if there will be a next attempt.
+//
+// In the public Describe API response of SAA and WFA, this has the name next_attempt_schedule_time.
+// In that field name, the term "schedule_time" is actually a dispatch time; specifically, the
+// dispatch time defined by this method.
+//
+// For WFA, next_attempt_schedule_time is null prior to the first attempt since start delay is not
+// supported, hence the activity is due to be dispatched to Matching as soon as the activity is
+// created. But for SAA, if there's a start delay, then next_attempt_schedule_time is the
+// dispatch_time (non-null).
+func (a *Activity) nextAttemptDispatchTime(ctx chasm.Context, attempt *activitypb.ActivityAttemptState) *timestamppb.Timestamp {
+	if a.hasAttemptInProgress() || a.isPaused() || a.isTerminal() {
+		return nil
+	}
+	if t := a.dispatchTimeForAttempt(attempt); t != nil {
+		if t.AsTime().After(ctx.Now(a)) {
+			return t
+		}
+	}
+	return nil
+}
+
+// currentRetryInterval is the current or next retry interval.
+// - If the activity is currently in retry backoff, then return the current retry interval.
+// - If the activity has an attempt in progress, then return the retry interval that will apply if the attempt fails
+// - Otherwise return nil
+func (a *Activity) currentRetryInterval(ctx chasm.Context, attempt *activitypb.ActivityAttemptState) *durationpb.Duration {
+	switch {
+	case a.hasAttemptInProgress():
+		// The interval a failure now would be retried with — exactly what the retry path decides — or
+		// null if it would not retry (attempts or schedule-to-close time exhausted).
+		if willRetry, interval := a.shouldRetry(ctx, 0); willRetry {
+			return durationpb.New(interval)
+		}
+		return nil
+	case a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED:
+		return attempt.GetCurrentRetryInterval()
+	default:
+		return nil
+	}
 }
 
 // RecordCompleted applies the provided function to record activity completion.
@@ -1659,7 +1707,7 @@ func (a *Activity) buildActivityExecutionInfo(
 		Attempt:                 attempt.GetCount(),
 		CanceledReason:          a.CancelState.GetReason(),
 		CloseTime:               closeTime,
-		CurrentRetryInterval:    attempt.GetCurrentRetryInterval(),
+		CurrentRetryInterval:    a.currentRetryInterval(ctx, attempt),
 		ExecutionDuration:       executionDuration,
 		ExecutionTime:           timestamppb.New(a.firstDispatchTime()),
 		ExpirationTime:          expirationTime,
@@ -1673,7 +1721,7 @@ func (a *Activity) buildActivityExecutionInfo(
 		LastWorkerIdentity:      attempt.GetLastWorkerIdentity(),
 		SdkName:                 attempt.GetSdkName(),
 		SdkVersion:              attempt.GetSdkVersion(),
-		NextAttemptScheduleTime: dispatchTimeForRetry(attempt),
+		NextAttemptScheduleTime: a.nextAttemptDispatchTime(ctx, attempt),
 		Priority:                a.GetPriority(),
 		RetryPolicy:             a.GetRetryPolicy(),
 		RunId:                   key.RunID,

--- a/chasm/lib/activity/model/vocabulary.go
+++ b/chasm/lib/activity/model/vocabulary.go
@@ -18,6 +18,7 @@ const (
 	RespondCompleted
 	RespondFailed
 	BackoffElapses
+	Pause
 )
 
 // Event is an EventKind together with flags describing the RPC

--- a/tests/activity_standalone_harness.go
+++ b/tests/activity_standalone_harness.go
@@ -149,6 +149,11 @@ func (a *saaHandle) rpc(e model.Event) error {
 			Namespace: ns, TaskToken: a.token, Identity: "worker", Failure: saaFailure(e.Retryable),
 		})
 		return err
+	case model.Pause:
+		_, err := fc.PauseActivityExecution(a.h.ctx, &workflowservice.PauseActivityExecutionRequest{
+			Namespace: ns, ActivityId: a.activityID, RunId: a.runID, Identity: "worker", Reason: "drive",
+		})
+		return err
 	default:
 		return fmt.Errorf("saaHarness: unhandled event kind %v", e.Kind)
 	}
@@ -227,4 +232,5 @@ var (
 	saaFailRetryably      = model.Event{Kind: model.RespondFailed, Retryable: true}
 	saaBackoffDelayElapse = model.Event{Kind: model.BackoffElapses}
 	saaComplete           = model.Event{Kind: model.RespondCompleted}
+	saaPause              = model.Event{Kind: model.Pause}
 )

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -21,6 +21,7 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/server/chasm/lib/activity"
+	"go.temporal.io/server/chasm/lib/activity/model"
 	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -3553,6 +3554,143 @@ func (s *standaloneActivityTestSuite) TestScheduleToStartTimeout() {
 		"expected ScheduleToStartTimeout but is %s", describeResp.GetOutcome().GetFailure().GetTimeoutFailureInfo().GetTimeoutType())
 }
 
+func (s *standaloneActivityTestSuite) TestDescribeNextAttemptScheduleTimeAndCurrentRetryInterval() {
+	env := s.newTestEnv()
+	t := s.T()
+
+	// First attempt within its start delay: the dispatch is pending in the future.
+	t.Run("StartDelayPending", func(t *testing.T) {
+		info := s.driveTrace(t, env, saaTrace{
+			trace:        []model.Event{},
+			startDelayed: true,
+		}).describe(t).GetInfo()
+
+		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
+			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, info.GetRunState())
+			require.Equal(t, info.GetExecutionTime().AsTime(), info.GetNextAttemptScheduleTime().AsTime())
+		})
+
+		t.Run("CurrentRetryInterval", func(t *testing.T) {
+			info := s.driveTrace(t, env, saaTrace{
+				trace:        []model.Event{},
+				startDelayed: true,
+			}).describe(t).GetInfo()
+			require.Nil(t, info.GetCurrentRetryInterval())
+		})
+	})
+
+	// First attempt running: no pending next dispatch.
+	t.Run("FirstAttemptRunning", func(t *testing.T) {
+		info := s.driveTrace(t, env, saaTrace{
+			trace:         []model.Event{saaPoll},
+			maxAttempts:   3,
+			retryInterval: saaDelayWindow,
+		}).describe(t).GetInfo()
+
+		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
+			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, info.GetRunState())
+			require.Nil(t, info.GetNextAttemptScheduleTime())
+		})
+
+		t.Run("CurrentRetryInterval", func(t *testing.T) {
+			require.Equal(t, saaDelayWindow, info.GetCurrentRetryInterval().AsDuration())
+		})
+	})
+
+	// Backing off before the retry dispatches.
+	t.Run("BackingOffBeforeRetry", func(t *testing.T) {
+		info := s.driveTrace(t, env, saaTrace{
+			trace:         []model.Event{saaPoll, saaFailRetryably},
+			maxAttempts:   3,
+			retryInterval: saaDelayWindow,
+		}).describe(t).GetInfo()
+
+		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
+			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, info.GetRunState())
+			require.True(t, info.GetNextAttemptScheduleTime().AsTime().After(time.Now()))
+		})
+
+		t.Run("CurrentRetryInterval", func(t *testing.T) {
+			require.Equal(t, saaDelayWindow, info.GetCurrentRetryInterval().AsDuration())
+		})
+	})
+
+	// Retry dispatched to Matching but not yet picked up.
+	t.Run("RetryQueuedNotStarted", func(t *testing.T) {
+		info := s.driveTrace(t, env, saaTrace{
+			trace:         []model.Event{saaPoll, saaFailRetryably, saaBackoffDelayElapse},
+			maxAttempts:   3,
+			retryInterval: saaDelayWindow,
+		}).describe(t).GetInfo()
+
+		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
+			require.EqualValues(t, 2, info.GetAttempt())
+			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, info.GetRunState())
+			require.Nil(t, info.GetNextAttemptScheduleTime())
+		})
+
+		t.Run("CurrentRetryInterval", func(t *testing.T) {
+			require.Equal(t, saaDelayWindow, info.GetCurrentRetryInterval().AsDuration())
+		})
+	})
+
+	// Retry attempt running with a further retry permitted.
+	t.Run("RetryAttemptRunning", func(t *testing.T) {
+		info := s.driveTrace(t, env, saaTrace{
+			trace:         []model.Event{saaPoll, saaFailRetryably, saaBackoffDelayElapse, saaPoll},
+			maxAttempts:   3,
+			retryInterval: saaDelayWindow,
+		}).describe(t).GetInfo()
+
+		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
+			require.EqualValues(t, 2, info.GetAttempt())
+			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, info.GetRunState())
+			require.Nil(t, info.GetNextAttemptScheduleTime())
+		})
+
+		t.Run("CurrentRetryInterval", func(t *testing.T) {
+			require.Equal(t, saaDelayWindow, info.GetCurrentRetryInterval().AsDuration())
+		})
+	})
+
+	// Final attempt running with no retries remaining.
+	t.Run("FinalAttemptRunning", func(t *testing.T) {
+		info := s.driveTrace(t, env, saaTrace{
+			trace:         []model.Event{saaPoll, saaFailRetryably, saaBackoffDelayElapse, saaPoll},
+			maxAttempts:   2,
+			retryInterval: saaDelayWindow,
+		}).describe(t).GetInfo()
+
+		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
+			require.EqualValues(t, 2, info.GetAttempt())
+			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, info.GetRunState())
+			require.Nil(t, info.GetNextAttemptScheduleTime())
+		})
+
+		t.Run("CurrentRetryInterval", func(t *testing.T) {
+			require.Nil(t, info.GetCurrentRetryInterval())
+		})
+	})
+
+	// Terminal (completed after a retry): no attempt is pending or running.
+	t.Run("Completed", func(t *testing.T) {
+		info := s.driveTrace(t, env, saaTrace{
+			trace:         []model.Event{saaPoll, saaFailRetryably, saaBackoffDelayElapse, saaPoll, saaComplete},
+			maxAttempts:   3,
+			retryInterval: saaDelayWindow,
+		}).describe(t).GetInfo()
+
+		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
+			require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, info.GetStatus())
+			require.Nil(t, info.GetNextAttemptScheduleTime())
+		})
+
+		t.Run("CurrentRetryInterval", func(t *testing.T) {
+			require.Nil(t, info.GetCurrentRetryInterval())
+		})
+	})
+}
+
 func (s *standaloneActivityTestSuite) TestDescribeActivityExecution() {
 	s.Run("NoWait", func(s *standaloneActivityTestSuite) {
 		t := s.T()
@@ -3838,6 +3976,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution() {
 				ActivityId:             activityID,
 				ActivityType:           env.Tv().ActivityType(),
 				Attempt:                1,
+				CurrentRetryInterval:   durationpb.New(time.Second),
 				HeartbeatTimeout:       durationpb.New(0),
 				LastWorkerIdentity:     defaultIdentity,
 				RetryPolicy:            defaultRetryPolicy,

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -3565,14 +3565,9 @@ func (s *standaloneActivityTestSuite) TestDescribeNextAttemptScheduleTimeAndCurr
 			startDelayed: true,
 		}).describe(t).GetInfo()
 
-		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
-			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, info.GetRunState())
-			require.Equal(t, info.GetExecutionTime().AsTime(), info.GetNextAttemptScheduleTime().AsTime())
-		})
-
-		t.Run("CurrentRetryInterval", func(t *testing.T) {
-			require.Nil(t, info.GetCurrentRetryInterval())
-		})
+		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, info.GetRunState())
+		require.Equal(t, info.GetExecutionTime().AsTime(), info.GetNextAttemptScheduleTime().AsTime())
+		require.Nil(t, info.GetCurrentRetryInterval())
 	})
 
 	// First attempt running: no pending next dispatch.
@@ -3583,14 +3578,9 @@ func (s *standaloneActivityTestSuite) TestDescribeNextAttemptScheduleTimeAndCurr
 			retryInterval: saaDelayWindow,
 		}).describe(t).GetInfo()
 
-		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
-			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, info.GetRunState())
-			require.Nil(t, info.GetNextAttemptScheduleTime())
-		})
-
-		t.Run("CurrentRetryInterval", func(t *testing.T) {
-			require.Equal(t, saaDelayWindow, info.GetCurrentRetryInterval().AsDuration())
-		})
+		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, info.GetRunState())
+		require.Nil(t, info.GetNextAttemptScheduleTime())
+		require.Equal(t, saaDelayWindow, info.GetCurrentRetryInterval().AsDuration())
 	})
 
 	// Backing off before the retry dispatches.
@@ -3601,14 +3591,9 @@ func (s *standaloneActivityTestSuite) TestDescribeNextAttemptScheduleTimeAndCurr
 			retryInterval: saaDelayWindow,
 		}).describe(t).GetInfo()
 
-		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
-			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, info.GetRunState())
-			require.True(t, info.GetNextAttemptScheduleTime().AsTime().After(time.Now()))
-		})
-
-		t.Run("CurrentRetryInterval", func(t *testing.T) {
-			require.Equal(t, saaDelayWindow, info.GetCurrentRetryInterval().AsDuration())
-		})
+		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, info.GetRunState())
+		require.True(t, info.GetNextAttemptScheduleTime().AsTime().After(time.Now()))
+		require.Equal(t, saaDelayWindow, info.GetCurrentRetryInterval().AsDuration())
 	})
 
 	// Retry dispatched to Matching but not yet picked up.
@@ -3619,15 +3604,10 @@ func (s *standaloneActivityTestSuite) TestDescribeNextAttemptScheduleTimeAndCurr
 			retryInterval: saaDelayWindow,
 		}).describe(t).GetInfo()
 
-		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
-			require.EqualValues(t, 2, info.GetAttempt())
-			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, info.GetRunState())
-			require.Nil(t, info.GetNextAttemptScheduleTime())
-		})
-
-		t.Run("CurrentRetryInterval", func(t *testing.T) {
-			require.Equal(t, saaDelayWindow, info.GetCurrentRetryInterval().AsDuration())
-		})
+		require.EqualValues(t, 2, info.GetAttempt())
+		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, info.GetRunState())
+		require.Nil(t, info.GetNextAttemptScheduleTime())
+		require.Equal(t, saaDelayWindow, info.GetCurrentRetryInterval().AsDuration())
 	})
 
 	// Retry attempt running with a further retry permitted.
@@ -3638,15 +3618,10 @@ func (s *standaloneActivityTestSuite) TestDescribeNextAttemptScheduleTimeAndCurr
 			retryInterval: saaDelayWindow,
 		}).describe(t).GetInfo()
 
-		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
-			require.EqualValues(t, 2, info.GetAttempt())
-			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, info.GetRunState())
-			require.Nil(t, info.GetNextAttemptScheduleTime())
-		})
-
-		t.Run("CurrentRetryInterval", func(t *testing.T) {
-			require.Equal(t, saaDelayWindow, info.GetCurrentRetryInterval().AsDuration())
-		})
+		require.EqualValues(t, 2, info.GetAttempt())
+		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, info.GetRunState())
+		require.Nil(t, info.GetNextAttemptScheduleTime())
+		require.Equal(t, saaDelayWindow, info.GetCurrentRetryInterval().AsDuration())
 	})
 
 	// Final attempt running with no retries remaining.
@@ -3657,15 +3632,10 @@ func (s *standaloneActivityTestSuite) TestDescribeNextAttemptScheduleTimeAndCurr
 			retryInterval: saaDelayWindow,
 		}).describe(t).GetInfo()
 
-		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
-			require.EqualValues(t, 2, info.GetAttempt())
-			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, info.GetRunState())
-			require.Nil(t, info.GetNextAttemptScheduleTime())
-		})
-
-		t.Run("CurrentRetryInterval", func(t *testing.T) {
-			require.Nil(t, info.GetCurrentRetryInterval())
-		})
+		require.EqualValues(t, 2, info.GetAttempt())
+		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, info.GetRunState())
+		require.Nil(t, info.GetNextAttemptScheduleTime())
+		require.Nil(t, info.GetCurrentRetryInterval())
 	})
 
 	// Terminal (completed after a retry): no attempt is pending or running.
@@ -3676,14 +3646,9 @@ func (s *standaloneActivityTestSuite) TestDescribeNextAttemptScheduleTimeAndCurr
 			retryInterval: saaDelayWindow,
 		}).describe(t).GetInfo()
 
-		t.Run("NextAttemptScheduleTime", func(t *testing.T) {
-			require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, info.GetStatus())
-			require.Nil(t, info.GetNextAttemptScheduleTime())
-		})
-
-		t.Run("CurrentRetryInterval", func(t *testing.T) {
-			require.Nil(t, info.GetCurrentRetryInterval())
-		})
+		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, info.GetStatus())
+		require.Nil(t, info.GetNextAttemptScheduleTime())
+		require.Nil(t, info.GetCurrentRetryInterval())
 	})
 }
 

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -3571,10 +3571,6 @@ func (s *standaloneActivityTestSuite) TestDescribeNextAttemptScheduleTimeAndCurr
 		})
 
 		t.Run("CurrentRetryInterval", func(t *testing.T) {
-			info := s.driveTrace(t, env, saaTrace{
-				trace:        []model.Event{},
-				startDelayed: true,
-			}).describe(t).GetInfo()
 			require.Nil(t, info.GetCurrentRetryInterval())
 		})
 	})

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -3650,6 +3650,20 @@ func (s *standaloneActivityTestSuite) TestDescribeNextAttemptScheduleTimeAndCurr
 		require.Nil(t, info.GetNextAttemptScheduleTime())
 		require.Nil(t, info.GetCurrentRetryInterval())
 	})
+
+	// Paused while backing off before a retry: dispatch is suspended, so neither a next dispatch
+	// nor a current retry interval is reported (even though the attempt carries a stored interval).
+	t.Run("PausedDuringBackoff", func(t *testing.T) {
+		info := s.driveTrace(t, env, saaTrace{
+			trace:         []model.Event{saaPoll, saaFailRetryably, saaPause},
+			maxAttempts:   3,
+			retryInterval: saaDelayWindow,
+		}).describe(t).GetInfo()
+
+		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_PAUSED, info.GetRunState())
+		require.Nil(t, info.GetNextAttemptScheduleTime())
+		require.Nil(t, info.GetCurrentRetryInterval())
+	})
 }
 
 func (s *standaloneActivityTestSuite) TestDescribeActivityExecution() {


### PR DESCRIPTION
## What changed?
- repro and fix bugs related to next attempt and current retry interval in the describe response

## Why?
- Fixes correctness bugs

## How did you test it?
- [x] added new functional test(s)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public Describe field semantics for activity execution info; behavior is aligned with retry/dispatch logic and covered by new functional tests, but clients relying on the previous incorrect values may see different responses.
> 
> **Overview**
> **Describe** for standalone activities now derives **`next_attempt_schedule_time`** and **`current_retry_interval`** from activity state instead of echoing raw attempt fields.
> 
> **`NextAttemptScheduleTime`** is set only when a future dispatch is still pending (e.g. start delay or retry backoff not yet elapsed). It is cleared when an attempt is running, the task is already queued for Matching, the execution is paused or terminal, or the dispatch time is in the past.
> 
> **`CurrentRetryInterval`** reflects the interval in retry backoff while **SCHEDULED**, the interval **`shouldRetry`** would use if a running attempt failed (or null on the final attempt), and null in terminal or paused states.
> 
> Comments at the top of `activity.go` clarify **schedule_time** vs **dispatch_time** naming (including the public API name **`next_attempt_schedule_time`**). Tests add a **Pause** harness event and a matrix of Describe scenarios across start delay, backoff, retry queue, running attempts, completion, and pause.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5803f00e10124b536ebd79c6e3f4b005adeb29ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->