### PR TITLE
Return non-nil response from PollNexusTaskQueue on empty long poll

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -6308,7 +6308,14 @@ func (wh *WorkflowHandler) PollNexusTaskQueue(ctx context.Context, request *work
 		return nil, err
 	}
 
-	return matchingResponse.GetResponse(), nil
+	// matchingResponse.GetResponse() is nil when the long poll returned no task. Unlike the
+	// workflow/activity handlers, which build a fresh response struct, the Nexus handler passes
+	// matching's response through directly, so a nil here would surface as a typed-nil pointer
+	// wrapped in a non-nil interface to downstream interceptors. Return an empty response instead.
+	if resp := matchingResponse.GetResponse(); resp != nil {
+		return resp, nil
+	}
+	return &workflowservice.PollNexusTaskQueueResponse{}, nil
 }
 
 func (wh *WorkflowHandler) RespondNexusTaskCompleted(ctx context.Context, request *workflowservice.RespondNexusTaskCompletedRequest) (_ *workflowservice.RespondNexusTaskCompletedResponse, retError error) {

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -6308,10 +6308,9 @@ func (wh *WorkflowHandler) PollNexusTaskQueue(ctx context.Context, request *work
 		return nil, err
 	}
 
-	// matchingResponse.GetResponse() is nil when the long poll returned no task. Unlike the
-	// workflow/activity handlers, which build a fresh response struct, the Nexus handler passes
-	// matching's response through directly, so a nil here would surface as a typed-nil pointer
-	// wrapped in a non-nil interface to downstream interceptors. Return an empty response instead.
+	// matchingResponse.GetResponse() is nil when the long poll returned no task. To align
+	// with the workflow/activity handlers, an empty response is returned instead. This prevents
+	// the typed-nil pointer wrapped in a non-nil interface from surfacing to downstream interceptors.
 	if resp := matchingResponse.GetResponse(); resp != nil {
 		return resp, nil
 	}

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -358,6 +358,29 @@ func (s *WorkflowHandlerSuite) TestRespondNexusTaskFailed_PreservesTaskQueueKind
 	}
 }
 
+func (s *WorkflowHandlerSuite) TestPollNexusTaskQueue_EmptyLongPollReturnsNonNilResponse() {
+	config := s.newConfig()
+	wh := s.getWorkflowHandler(config)
+
+	s.mockNamespaceCache.EXPECT().GetNamespaceID(s.testNamespace).Return(s.testNamespaceID, nil).AnyTimes()
+
+	// An empty long poll: matching returns a response whose inner Response is nil. The handler
+	// must not surface that as a typed-nil pointer, which would panic downstream interceptors.
+	s.mockMatchingClient.EXPECT().
+		PollNexusTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&matchingservice.PollNexusTaskQueueResponse{}, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	resp, err := wh.PollNexusTaskQueue(ctx, &workflowservice.PollNexusTaskQueueRequest{
+		Namespace: s.testNamespace.String(),
+		TaskQueue: &taskqueuepb.TaskQueue{Name: "test-tq", Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+	})
+	s.NoError(err)
+	s.NotNil(resp)
+}
+
 func (s *WorkflowHandlerSuite) TestCheckWorkerDeploymentReadRateLimitResourceExhaustedScope() {
 	rateLimiter := quotas.NewMockRequestRateLimiter(s.controller)
 	wh := &WorkflowHandler{


### PR DESCRIPTION
## What changed?

`WorkflowHandler.PollNexusTaskQueue` now returns an empty `&workflowservice.PollNexusTaskQueueResponse{}` for an empty response from matching.

## Why?

Aligns what the workflow/activity poll handlers already do.

The mismatch caused a downstream interceptor on the poll response to NPE despite a check for `resp == nil` (which passes for nil interfaces).

## How did you test it?
- [x] added new unit test(s)
