### PR TITLE
Cherry-pick #11153: Return non-nil response from PollNexusTaskQueue on empty long poll

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -6139,7 +6139,13 @@ func (wh *WorkflowHandler) PollNexusTaskQueue(ctx context.Context, request *work
 		return nil, err
 	}
 
-	return matchingResponse.GetResponse(), nil
+	// matchingResponse.GetResponse() is nil when the long poll returned no task. To align
+	// with the workflow/activity handlers, an empty response is returned instead. This prevents
+	// the typed-nil pointer wrapped in a non-nil interface from surfacing to downstream interceptors.
+	if resp := matchingResponse.GetResponse(); resp != nil {
+		return resp, nil
+	}
+	return &workflowservice.PollNexusTaskQueueResponse{}, nil
 }
 
 func (wh *WorkflowHandler) RespondNexusTaskCompleted(ctx context.Context, request *workflowservice.RespondNexusTaskCompletedRequest) (_ *workflowservice.RespondNexusTaskCompletedResponse, retError error) {

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -247,6 +247,29 @@ func (s *WorkflowHandlerSuite) getWorkflowHandler(config *Config) *WorkflowHandl
 	)
 }
 
+func (s *WorkflowHandlerSuite) TestPollNexusTaskQueue_EmptyLongPollReturnsNonNilResponse() {
+	config := s.newConfig()
+	wh := s.getWorkflowHandler(config)
+
+	s.mockNamespaceCache.EXPECT().GetNamespaceID(s.testNamespace).Return(s.testNamespaceID, nil).AnyTimes()
+
+	// An empty long poll: matching returns a response whose inner Response is nil. The handler
+	// must not surface that as a typed-nil pointer, which would panic downstream interceptors.
+	s.mockMatchingClient.EXPECT().
+		PollNexusTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&matchingservice.PollNexusTaskQueueResponse{}, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	resp, err := wh.PollNexusTaskQueue(ctx, &workflowservice.PollNexusTaskQueueRequest{
+		Namespace: s.testNamespace.String(),
+		TaskQueue: &taskqueuepb.TaskQueue{Name: "test-tq", Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+	})
+	s.NoError(err)
+	s.NotNil(resp)
+}
+
 func (s *WorkflowHandlerSuite) TestCheckWorkerDeploymentReadRateLimitResourceExhaustedScope() {
 	rateLimiter := quotas.NewMockRequestRateLimiter(s.controller)
 	wh := &WorkflowHandler{


### PR DESCRIPTION
## What changed?
Cherry-pick of #11153 (approved and merged) onto `cloud/v1.32.0-159`.

