### PR TITLE
Reset TaskLatency accumulation on failover

### DIFF
--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -390,6 +390,9 @@ func (e *executableImpl) Execute() (retErr error) {
 		// reset task priority since it changes between active/standby
 		e.resetAttempt()
 		e.priority = e.priorityAssigner.Assign(e)
+		// reset accumulated in-memory latency: time accrued under the previous
+		// active/standby regime must not be reported as this regime's TaskLatency
+		e.inMemoryNoUserLatency = 0
 	}
 	e.lastActiveness = resp.ExecutedAsActive
 

--- a/service/history/queues/executable_test.go
+++ b/service/history/queues/executable_test.go
@@ -313,6 +313,63 @@ func (s *executableSuite) TestExecute_InMemoryNoUserLatency_MultipleAttempts() {
 	}
 }
 
+func (s *executableSuite) TestExecute_InMemoryNoUserLatency_ResetOnStandbyToActiveFlip() {
+	// A task accrues in-memory latency while executing as standby, then the namespace fails
+	// over and the same task completes as active. The standby-accrued latency must be reset on
+	// the standby->active flip so the TaskLatency recorded at Ack reflects only the active
+	// attempt, not the (large) standby wait carried over from before the failover.
+	const standbyScheduleLatency = 500 * time.Millisecond
+	const standbyAttemptLatency = 4 * time.Second
+	const activeScheduleLatency = 10 * time.Millisecond
+	const activeAttemptLatency = 20 * time.Millisecond
+
+	executable := s.newTestExecutable()
+
+	now := time.Now()
+	s.timeSource.Update(now)
+	executable.SetScheduledTime(now)
+
+	// Standby attempt: not ready (retryable error), accrues ~4.5s.
+	now = now.Add(standbyScheduleLatency)
+	s.timeSource.Update(now)
+	s.mockExecutor.EXPECT().Execute(gomock.Any(), executable).Do(func(_ context.Context, _ any) {
+		now = now.Add(standbyAttemptLatency)
+		s.timeSource.Update(now)
+	}).Return(queues.ExecuteResponse{
+		ExecutedAsActive: false,
+		ExecutionErr:     serviceerror.NewUnavailable("standby task not ready"),
+	})
+	err := executable.Execute()
+	s.Error(err)
+	err = executable.HandleErr(err)
+	s.Error(err)
+	s.mockScheduler.EXPECT().TrySubmit(executable).Return(true)
+	executable.Nack(err) // resets scheduledTime to now; inMemoryNoUserLatency now holds the standby wait
+
+	// Failover: the same task now executes as active and succeeds.
+	now = now.Add(activeScheduleLatency)
+	s.timeSource.Update(now)
+	s.mockExecutor.EXPECT().Execute(gomock.Any(), executable).Do(func(_ context.Context, _ any) {
+		now = now.Add(activeAttemptLatency)
+		s.timeSource.Update(now)
+	}).Return(queues.ExecuteResponse{
+		ExecutedAsActive: true,
+		ExecutionErr:     nil,
+	})
+	s.NoError(executable.Execute())
+
+	capture := s.metricsHandler.StartCapture()
+	executable.Ack()
+	snapshot := capture.Snapshot()
+
+	recordings := snapshot[metrics.TaskLatency.Name()]
+	s.Len(recordings, 1)
+	got, ok := recordings[0].Value.(time.Duration)
+	s.True(ok)
+	// Only the active attempt should be counted; the ~4.5s standby accrual must have been reset.
+	s.Equal(activeScheduleLatency+activeAttemptLatency, got)
+}
+
 func (s *executableSuite) TestExecute_CapturePanic() {
 	executable := s.newTestExecutable()
 


### PR DESCRIPTION
## What changed?
Reset the accumulated in-memory task latency on the standby to active
flip. The failover block
already resets `attempt` and `priority` when the execution regime changes; it
now also resets `inMemoryNoUserLatency`, so latency accounting restarts for the new regime. Added
appropriate unit testing.

## Why?
On a global-namespace (XDC) failover, a history task that accrued latency while its namespace was
standby keeps that accumulation when it flips to active and completes — so the standby wait gets
reported as active-side `TaskLatency`. In a 2-cluster repro this showed as
~4s on `TransferActiveTaskWorkflowTask` right after failover versus a ~5ms baseline.
Resetting the counter mirrors what the block already does for `attempt`.

(`TaskQueueLatency` intentionally left unchanged: it's end-to-end from task generation by
definition, so the standby wait legitimately counts, and it isn't alerted on.)

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- The failover block also fires on a task's first execution (`lastActiveness` defaults to `false`),
  so the reset runs there too — harmless, since the counter is ~0 at that point.
- The block is symmetric, so an active to standby flip now also resets the counter; standby-side
  `TaskLatency` after such a flip excludes prior active accrual, consistent with the regime-change
  intent.
- Metric-value change: `TaskLatency` for failover-spanning tasks will drop (the standby wait is no
  longer included). This is the intended correction, but any dashboard/alert that had adapted to the
  inflated post-failover values will see lower numbers.
