### PR TITLE
[ES VisibilityStore] Return ResourceExhausted error when ES returns 429

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -383,7 +384,7 @@ func (s *VisibilityStore) ListWorkflowExecutions(
 
 	searchResult, err := s.esClient.Search(ctx, p)
 	if err != nil {
-		return nil, ConvertElasticsearchClientError("ListWorkflowExecutions failed", err)
+		return nil, ConvertElasticsearchClientError("ListWorkflowExecutions failed", err, s.logger)
 	}
 
 	return s.GetListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, nil)
@@ -406,7 +407,7 @@ func (s *VisibilityStore) ListChasmExecutions(
 
 	searchResult, err := s.esClient.Search(ctx, p)
 	if err != nil {
-		return nil, ConvertElasticsearchClientError("ListChasmExecutions failed", err)
+		return nil, ConvertElasticsearchClientError("ListChasmExecutions failed", err, s.logger)
 	}
 
 	return s.GetListWorkflowExecutionsResponse(
@@ -460,7 +461,7 @@ func (s *VisibilityStore) CountChasmExecutions(
 
 	count, err := s.esClient.Count(ctx, s.index, queryParams.Query)
 	if err != nil {
-		return nil, ConvertElasticsearchClientError("CountChasmExecutions failed", err)
+		return nil, ConvertElasticsearchClientError("CountChasmExecutions failed", err, s.logger)
 	}
 
 	return &store.InternalCountExecutionsResponse{Count: count}, nil
@@ -491,7 +492,7 @@ func (s *VisibilityStore) CountWorkflowExecutions(
 
 	count, err := s.esClient.Count(ctx, s.index, queryParams.Query)
 	if err != nil {
-		return nil, ConvertElasticsearchClientError("CountWorkflowExecutions failed", err)
+		return nil, ConvertElasticsearchClientError("CountWorkflowExecutions failed", err, s.logger)
 	}
 
 	return &store.InternalCountExecutionsResponse{Count: count}, nil
@@ -536,7 +537,7 @@ func (s *VisibilityStore) countGroupByExecutions(
 		termsAgg,
 	)
 	if err != nil {
-		return nil, ConvertElasticsearchClientError("CountWorkflowExecutions failed", err)
+		return nil, ConvertElasticsearchClientError("CountWorkflowExecutions failed", err, s.logger)
 	}
 	return s.parseCountGroupByResponse(esResponse, groupByFields, chasmMapper)
 }
@@ -548,7 +549,7 @@ func (s *VisibilityStore) GetWorkflowExecution(
 	docID := GetDocID(request.WorkflowID, request.RunID)
 	result, err := s.esClient.Get(ctx, s.index, docID)
 	if err != nil {
-		return nil, ConvertElasticsearchClientError("GetWorkflowExecution failed", err)
+		return nil, ConvertElasticsearchClientError("GetWorkflowExecution failed", err, s.logger)
 	}
 
 	typeMap, err := s.searchAttributesProvider.GetSearchAttributes(s.index, false)
@@ -1285,15 +1286,23 @@ func finishParseJSONValue(val any, t enumspb.IndexedValueType) (any, error) {
 	panic(fmt.Sprintf("Unknown field type: %v", t))
 }
 
-func ConvertElasticsearchClientError(message string, err error) error {
-	errMessage := fmt.Sprintf("%s: %s", message, detailedErrorMessage(err))
+func ConvertElasticsearchClientError(message string, err error, logger log.Logger) error {
+	// This message is returned to client, avoiding including too much details.
+	errMessage := fmt.Sprintf("%s: %s", message, shortErrorMessage(err))
 	var elasticErr *elastic.Error
 	switch {
 	case errors.As(err, &elasticErr):
+		// Logging the full error message, useful for debugging.
+		logger.Error(message, tag.ESResponseStatus(elasticErr.Status), tag.Error(err))
 		switch elasticErr.Status {
-		case 400: // BadRequest
+		case http.StatusBadRequest:
 			// Returning InvalidArgument error will prevent retry on a caller side.
 			return serviceerror.NewInvalidArgument(errMessage)
+		case http.StatusTooManyRequests:
+			return serviceerror.NewResourceExhausted(
+				enumspb.RESOURCE_EXHAUSTED_CAUSE_SYSTEM_OVERLOADED,
+				errMessage,
+			)
 		}
 		return serviceerror.NewUnavailable(errMessage)
 	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
@@ -1301,6 +1310,22 @@ func ConvertElasticsearchClientError(message string, err error) error {
 	}
 
 	return serviceerror.NewUnavailable(errMessage)
+}
+
+func shortErrorMessage(err error) string {
+	if elasticErr, ok := errors.AsType[*elastic.Error](err); ok {
+		msg := fmt.Sprintf(
+			"Elasticsearch: Error %d (%s)",
+			elasticErr.Status,
+			http.StatusText(elasticErr.Status),
+		)
+		if elasticErr.Status == http.StatusBadRequest && elasticErr.Details != nil &&
+			elasticErr.Details.Reason != "" {
+			msg += fmt.Sprintf(": %s [type=%s]", elasticErr.Details.Reason, elasticErr.Details.Type)
+		}
+		return msg
+	}
+	return err.Error()
 }
 
 func detailedErrorMessage(err error) string {
@@ -1316,10 +1341,10 @@ func detailedErrorMessage(err error) string {
 	sb.WriteString(elasticErr.Error())
 	sb.WriteString(", root causes:")
 	for i, rootCause := range elasticErr.Details.RootCause {
-		sb.WriteString(fmt.Sprintf(" %s [type=%s]", rootCause.Reason, rootCause.Type))
-		if i != len(elasticErr.Details.RootCause)-1 {
+		if i > 0 {
 			sb.WriteRune(',')
 		}
+		fmt.Fprintf(&sb, " %s [type=%s]", rootCause.Reason, rootCause.Type)
 	}
 	return sb.String()
 }

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -10,7 +10,6 @@ import (
 	"math"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/olivere/elastic/v7"
@@ -1299,10 +1298,11 @@ func ConvertElasticsearchClientError(message string, err error, logger log.Logge
 			// Returning InvalidArgument error will prevent retry on a caller side.
 			return serviceerror.NewInvalidArgument(errMessage)
 		case http.StatusTooManyRequests:
-			return serviceerror.NewResourceExhausted(
-				enumspb.RESOURCE_EXHAUSTED_CAUSE_SYSTEM_OVERLOADED,
-				errMessage,
-			)
+			return &serviceerror.ResourceExhausted{
+				Cause:   enumspb.RESOURCE_EXHAUSTED_CAUSE_SYSTEM_OVERLOADED,
+				Scope:   enumspb.RESOURCE_EXHAUSTED_SCOPE_SYSTEM,
+				Message: errMessage,
+			}
 		}
 		return serviceerror.NewUnavailable(errMessage)
 	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
@@ -1315,7 +1315,7 @@ func ConvertElasticsearchClientError(message string, err error, logger log.Logge
 func shortErrorMessage(err error) string {
 	if elasticErr, ok := errors.AsType[*elastic.Error](err); ok {
 		msg := fmt.Sprintf(
-			"Elasticsearch: Error %d (%s)",
+			"VisibilityStore: Error %d (%s)",
 			elasticErr.Status,
 			http.StatusText(elasticErr.Status),
 		)
@@ -1326,27 +1326,6 @@ func shortErrorMessage(err error) string {
 		return msg
 	}
 	return err.Error()
-}
-
-func detailedErrorMessage(err error) string {
-	var elasticErr *elastic.Error
-	if !errors.As(err, &elasticErr) ||
-		elasticErr.Details == nil ||
-		len(elasticErr.Details.RootCause) == 0 ||
-		(len(elasticErr.Details.RootCause) == 1 && elasticErr.Details.RootCause[0].Reason == elasticErr.Details.Reason) {
-		return err.Error()
-	}
-
-	var sb strings.Builder
-	sb.WriteString(elasticErr.Error())
-	sb.WriteString(", root causes:")
-	for i, rootCause := range elasticErr.Details.RootCause {
-		if i > 0 {
-			sb.WriteRune(',')
-		}
-		fmt.Fprintf(&sb, " %s [type=%s]", rootCause.Reason, rootCause.Type)
-	}
-	return sb.String()
 }
 
 func isDefaultSorter(sorter []elastic.Sorter) bool {

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -949,7 +949,7 @@ func (s *ESVisibilitySuite) TestListWorkflowExecutions_Error() {
 	s.Error(err)
 	var invalidArgErr *serviceerror.InvalidArgument
 	s.ErrorAs(err, &invalidArgErr)
-	s.Equal("ListWorkflowExecutions failed: Elasticsearch: Error 400 (Bad Request): error reason [type=]", invalidArgErr.Message)
+	s.Equal("ListWorkflowExecutions failed: VisibilityStore: Error 400 (Bad Request): error reason [type=]", invalidArgErr.Message)
 
 	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, p *client.SearchParameters) (*elastic.SearchResult, error) {
@@ -963,7 +963,7 @@ func (s *ESVisibilitySuite) TestListWorkflowExecutions_Error() {
 	_, err = s.visibilityStore.ListWorkflowExecutions(context.Background(), request)
 	var unavailableErr *serviceerror.Unavailable
 	s.ErrorAs(err, &unavailableErr)
-	s.Equal("ListWorkflowExecutions failed: Elasticsearch: Error 500 (Internal Server Error)", unavailableErr.Message)
+	s.Equal("ListWorkflowExecutions failed: VisibilityStore: Error 500 (Internal Server Error)", unavailableErr.Message)
 
 	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, p *client.SearchParameters) (*elastic.SearchResult, error) {
@@ -977,7 +977,7 @@ func (s *ESVisibilitySuite) TestListWorkflowExecutions_Error() {
 	_, err = s.visibilityStore.ListWorkflowExecutions(context.Background(), request)
 	var resourceExhaustedErr *serviceerror.ResourceExhausted
 	s.ErrorAs(err, &resourceExhaustedErr)
-	s.Equal("ListWorkflowExecutions failed: Elasticsearch: Error 429 (Too Many Requests)", resourceExhaustedErr.Message)
+	s.Equal("ListWorkflowExecutions failed: VisibilityStore: Error 429 (Too Many Requests)", resourceExhaustedErr.Message)
 }
 
 func (s *ESVisibilitySuite) TestListOpenWorkflowExecutionsWithNamespaceDivision() {
@@ -1456,59 +1456,6 @@ func (s *ESVisibilitySuite) TestGetWorkflowExecution() {
 	_, ok := err.(*serviceerror.Unavailable)
 	s.True(ok)
 	s.Contains(err.Error(), "GetWorkflowExecution failed")
-}
-
-func (s *ESVisibilitySuite) Test_detailedErrorMessage() {
-	err := errors.New("test message")
-	s.Equal("test message", detailedErrorMessage(err))
-
-	err = &elastic.Error{
-		Status: 500,
-	}
-	s.Equal("elastic: Error 500 (Internal Server Error)", detailedErrorMessage(err))
-
-	err = &elastic.Error{
-		Status: 500,
-		Details: &elastic.ErrorDetails{
-			Type:   "some type",
-			Reason: "some reason",
-		},
-	}
-	s.Equal("elastic: Error 500 (Internal Server Error): some reason [type=some type]", detailedErrorMessage(err))
-
-	err = &elastic.Error{
-		Status: 500,
-		Details: &elastic.ErrorDetails{
-			Type:   "some type",
-			Reason: "some reason",
-			RootCause: []*elastic.ErrorDetails{
-				{
-					Type:   "some type",
-					Reason: "some reason",
-				},
-			},
-		},
-	}
-	s.Equal("elastic: Error 500 (Internal Server Error): some reason [type=some type]", detailedErrorMessage(err))
-
-	err = &elastic.Error{
-		Status: 500,
-		Details: &elastic.ErrorDetails{
-			Type:   "some type",
-			Reason: "some reason",
-			RootCause: []*elastic.ErrorDetails{
-				{
-					Type:   "some other type1",
-					Reason: "some other reason1",
-				},
-				{
-					Type:   "some other type2",
-					Reason: "some other reason2",
-				},
-			},
-		},
-	}
-	s.Equal("elastic: Error 500 (Internal Server Error): some reason [type=some type], root causes: some other reason1 [type=some other type1], some other reason2 [type=some other type2]", detailedErrorMessage(err))
 }
 
 func (s *ESVisibilitySuite) TestProcessPageToken() {

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -949,7 +949,7 @@ func (s *ESVisibilitySuite) TestListWorkflowExecutions_Error() {
 	s.Error(err)
 	var invalidArgErr *serviceerror.InvalidArgument
 	s.ErrorAs(err, &invalidArgErr)
-	s.Equal("ListWorkflowExecutions failed: elastic: Error 400 (Bad Request): error reason [type=]", invalidArgErr.Message)
+	s.Equal("ListWorkflowExecutions failed: Elasticsearch: Error 400 (Bad Request): error reason [type=]", invalidArgErr.Message)
 
 	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, p *client.SearchParameters) (*elastic.SearchResult, error) {
@@ -963,7 +963,21 @@ func (s *ESVisibilitySuite) TestListWorkflowExecutions_Error() {
 	_, err = s.visibilityStore.ListWorkflowExecutions(context.Background(), request)
 	var unavailableErr *serviceerror.Unavailable
 	s.ErrorAs(err, &unavailableErr)
-	s.Equal("ListWorkflowExecutions failed: elastic: Error 500 (Internal Server Error): error reason [type=]", unavailableErr.Message)
+	s.Equal("ListWorkflowExecutions failed: Elasticsearch: Error 500 (Internal Server Error)", unavailableErr.Message)
+
+	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, p *client.SearchParameters) (*elastic.SearchResult, error) {
+			return nil, &elastic.Error{
+				Status: 429,
+				Details: &elastic.ErrorDetails{
+					Reason: "error reason",
+				},
+			}
+		})
+	_, err = s.visibilityStore.ListWorkflowExecutions(context.Background(), request)
+	var resourceExhaustedErr *serviceerror.ResourceExhausted
+	s.ErrorAs(err, &resourceExhaustedErr)
+	s.Equal("ListWorkflowExecutions failed: Elasticsearch: Error 429 (Too Many Requests)", resourceExhaustedErr.Message)
 }
 
 func (s *ESVisibilitySuite) TestListOpenWorkflowExecutionsWithNamespaceDivision() {


### PR DESCRIPTION
## What changed?
- Return `serviceerror.ResourceExhausted` from ES VisibilityStore when Elasticsearch returns 429 error.
- Simplified the error message returned to the client to include just the error status code, except for BadRequest error as it might provide some useful message to the client. A detailed error message is logged.

## Why?
ResourceExhausted error better translates 429 error instead of Unavailable.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

