### PR TITLE
add per-session max skip to time skipping

### DIFF
--- a/api/persistence/v1/executions.pb.go
+++ b/api/persistence/v1/executions.pb.go
@@ -1168,21 +1168,21 @@ func (*WorkflowExecutionInfo_LastWorkflowTaskTimedOutType) isWorkflowExecutionIn
 
 type TimeSkippingInfo struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Current time-skipping configuration applied to the workflow.
+	// Current time-skipping configuration applied to the execution.
 	Config *v13.TimeSkippingConfig `protobuf:"bytes,1,opt,name=config,proto3" json:"config,omitempty"`
-	// Total skipped duration for the current workflow execution run, including any
-	// inherited skipped duration carried over from a preceding execution that started this run.
+	// Total skipped duration for the current execution, including any
+	// inherited skipped duration carried over from a preceding run that started this one.
 	AccumulatedSkippedDuration *durationpb.Duration `protobuf:"bytes,2,opt,name=accumulated_skipped_duration,json=accumulatedSkippedDuration,proto3" json:"accumulated_skipped_duration,omitempty"`
 	// The current fast-forward info for time skipping.
 	FastForwardInfo *FastForwardInfo `protobuf:"bytes,4,opt,name=fast_forward_info,json=fastForwardInfo,proto3" json:"fast_forward_info,omitempty"`
 	// Versioned transition at which this TimeSkippingInfo was last modified (i.e. when a
-	// skip transition changed accumulated_skipped_duration). Used by PartialRefresh to detect
-	// that pending timer tasks must be re-stamped against the new accumulated skip, since a
-	// skip mutates this workflow-level field without bumping any per-timer
-	// last_update_versioned_transition. Mirrors the per-entity stamps on TimerInfo/ActivityInfo.
+	// skip transition changed accumulated_skipped_duration or a request updated the config.)
 	LastUpdateVersionedTransition *VersionedTransition `protobuf:"bytes,5,opt,name=last_update_versioned_transition,json=lastUpdateVersionedTransition,proto3" json:"last_update_versioned_transition,omitempty"`
-	unknownFields                 protoimpl.UnknownFields
-	sizeCache                     protoimpl.SizeCache
+	// Tracks the number of times a time-skipping transition has occurred since time skipping
+	// was most recently enabled. It is reset every time the skipping config is updated.
+	SessionSkipCount int32 `protobuf:"varint,6,opt,name=session_skip_count,json=sessionSkipCount,proto3" json:"session_skip_count,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *TimeSkippingInfo) Reset() {
@@ -1241,6 +1241,13 @@ func (x *TimeSkippingInfo) GetLastUpdateVersionedTransition() *VersionedTransiti
 		return x.LastUpdateVersionedTransition
 	}
 	return nil
+}
+
+func (x *TimeSkippingInfo) GetSessionSkipCount() int32 {
+	if x != nil {
+		return x.SessionSkipCount
+	}
+	return 0
 }
 
 type FastForwardInfo struct {
@@ -5072,12 +5079,13 @@ const file_temporal_server_api_persistence_v1_executions_proto_rawDesc = "" +
 	"&ChildrenInitializedPostResetPointEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12H\n" +
 	"\x05value\x18\x02 \x01(\v22.temporal.server.api.persistence.v1.ResetChildInfoR\x05value:\x028\x01B\x1c\n" +
-	"\x1alast_workflow_task_failureJ\x04\b\b\x10\tJ\x04\b\x0e\x10\x0fJ\x04\b\x0f\x10\x10J\x04\b\x10\x10\x11J\x04\bp\x10qJ\x04\b,\x10-J\x04\b-\x10.J\x04\b/\x100J\x04\b0\x101J\x04\b1\x102J\x04\b2\x103\"\xbd\x03\n" +
+	"\x1alast_workflow_task_failureJ\x04\b\b\x10\tJ\x04\b\x0e\x10\x0fJ\x04\b\x0f\x10\x10J\x04\b\x10\x10\x11J\x04\bp\x10qJ\x04\b,\x10-J\x04\b-\x10.J\x04\b/\x100J\x04\b0\x101J\x04\b1\x102J\x04\b2\x103\"\xeb\x03\n" +
 	"\x10TimeSkippingInfo\x12B\n" +
 	"\x06config\x18\x01 \x01(\v2*.temporal.api.common.v1.TimeSkippingConfigR\x06config\x12[\n" +
 	"\x1caccumulated_skipped_duration\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\x1aaccumulatedSkippedDuration\x12_\n" +
 	"\x11fast_forward_info\x18\x04 \x01(\v23.temporal.server.api.persistence.v1.FastForwardInfoR\x0ffastForwardInfo\x12\x80\x01\n" +
-	" last_update_versioned_transition\x18\x05 \x01(\v27.temporal.server.api.persistence.v1.VersionedTransitionR\x1dlastUpdateVersionedTransitionJ\x04\b\x03\x10\x04R\x1ecurrent_elapsed_duration_bound\"\x89\x02\n" +
+	" last_update_versioned_transition\x18\x05 \x01(\v27.temporal.server.api.persistence.v1.VersionedTransitionR\x1dlastUpdateVersionedTransition\x12,\n" +
+	"\x12session_skip_count\x18\x06 \x01(\x05R\x10sessionSkipCountJ\x04\b\x03\x10\x04R\x1ecurrent_elapsed_duration_bound\"\x89\x02\n" +
 	"\x0fFastForwardInfo\x12;\n" +
 	"\vtarget_time\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
 	"targetTime\x12\x1f\n" +

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -3587,4 +3587,9 @@ WorkerActivitiesPerSecond, MaxConcurrentActivityTaskPollers.
 		false,
 		`WorkflowTimeSkippingEnabled is a "feature enable" flag. When enabled it allows clients to skip time in executions.`,
 	)
+	WorkflowTimeSkippingMaxSkipPerSession = NewNamespaceIntSetting(
+		"frontend.WorkflowTimeSkippingMaxSkipPerSession",
+		100,
+		"WorkflowTimeSkippingMaxSkipPerSession limits the skip number allowed since time-skipping was most recently enabled.",
+	)
 )

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -3589,7 +3589,7 @@ WorkerActivitiesPerSecond, MaxConcurrentActivityTaskPollers.
 	)
 	WorkflowTimeSkippingMaxSkipPerSession = NewNamespaceIntSetting(
 		"frontend.WorkflowTimeSkippingMaxSkipPerSession",
-		100,
-		"WorkflowTimeSkippingMaxSkipPerSession limits the skip number allowed since time-skipping was most recently enabled.",
+		200,
+		"WorkflowTimeSkippingMaxSkipPerSession is the default max-skip-per-session applied to requests that don't set one; callers may override it with a higher value.",
 	)
 )

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.44.0
-	go.temporal.io/api v1.63.4-0.20260719232400-f9e031effa8f
+	go.temporal.io/api v1.63.4-0.20260720212511-a086e3776097
 	go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee
 	go.temporal.io/sdk v1.41.1
 	go.uber.org/fx v1.24.0

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.44.0
-	go.temporal.io/api v1.63.4-0.20260720212511-a086e3776097
+	go.temporal.io/api v1.63.4-0.20260721004603-5b46a7132865
 	go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee
 	go.temporal.io/sdk v1.41.1
 	go.uber.org/fx v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -479,14 +479,8 @@ go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0 h1:R
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0/go.mod h1:I89cynRj8y+383o7tEQVg2SVA6SRgDVIouWPUVXjx0U=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0 h1:CQvJSldHRUN6Z8jsUeYv8J0lXRvygALXIzsmAeCcZE0=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0/go.mod h1:xSQ+mEfJe/GjK1LXEyVOoSI1N9JV9ZI923X5kup43W4=
-go.temporal.io/api v1.63.4-0.20260717222957-a7fa39a3059e h1:C+TZVpBtNBXy/wrNbBfEuf7issm17e3u00fe9+c2AHI=
-go.temporal.io/api v1.63.4-0.20260717222957-a7fa39a3059e/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
-go.temporal.io/api v1.63.4-0.20260719230552-aa57c3fcca1f h1:0zzkFoXOLDG/0OVNtxFtPuXsrKtUAt36VCVQwQfm1/8=
-go.temporal.io/api v1.63.4-0.20260719230552-aa57c3fcca1f/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
-go.temporal.io/api v1.63.4-0.20260719232400-f9e031effa8f h1:TSvmg1+WUZ4qk4jvU+aDjwi5kQ5CkDqaaRFjtB9r8/M=
-go.temporal.io/api v1.63.4-0.20260719232400-f9e031effa8f/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
-go.temporal.io/api v1.63.4-0.20260720212511-a086e3776097 h1:v8VMzpUmOlrQpxP4SFJ8Egc+RWr2mhSmukiRZyyCJR0=
-go.temporal.io/api v1.63.4-0.20260720212511-a086e3776097/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
+go.temporal.io/api v1.63.4-0.20260721004603-5b46a7132865 h1:36YmI5RPBNSYT37vPbcG2QF7xqek1/6JD49kA8rcPv4=
+go.temporal.io/api v1.63.4-0.20260721004603-5b46a7132865/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
 go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee h1:y6A65Iml06cR3CpxW2Zn8FQLjniPDTnN4jtr69UZxXI=
 go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee/go.mod h1:hhHijO9XRPIkAflLJJHix61M9FzbRPqk8fSydkcLkqw=
 go.temporal.io/sdk v1.41.1 h1:yOpvsHyDD1lNuwlGBv/SUodCPhjv9nDeC9lLHW/fJUA=

--- a/go.sum
+++ b/go.sum
@@ -485,6 +485,8 @@ go.temporal.io/api v1.63.4-0.20260719230552-aa57c3fcca1f h1:0zzkFoXOLDG/0OVNtxFt
 go.temporal.io/api v1.63.4-0.20260719230552-aa57c3fcca1f/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
 go.temporal.io/api v1.63.4-0.20260719232400-f9e031effa8f h1:TSvmg1+WUZ4qk4jvU+aDjwi5kQ5CkDqaaRFjtB9r8/M=
 go.temporal.io/api v1.63.4-0.20260719232400-f9e031effa8f/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
+go.temporal.io/api v1.63.4-0.20260720212511-a086e3776097 h1:v8VMzpUmOlrQpxP4SFJ8Egc+RWr2mhSmukiRZyyCJR0=
+go.temporal.io/api v1.63.4-0.20260720212511-a086e3776097/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
 go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee h1:y6A65Iml06cR3CpxW2Zn8FQLjniPDTnN4jtr69UZxXI=
 go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee/go.mod h1:hhHijO9XRPIkAflLJJHix61M9FzbRPqk8fSydkcLkqw=
 go.temporal.io/sdk v1.41.1 h1:yOpvsHyDD1lNuwlGBv/SUodCPhjv9nDeC9lLHW/fJUA=

--- a/proto/internal/temporal/server/api/persistence/v1/executions.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/executions.proto
@@ -338,6 +338,10 @@ message TimeSkippingInfo {
   // Versioned transition at which this TimeSkippingInfo was last modified (i.e. when a
   // skip transition changed accumulated_skipped_duration or a request updated the config.)
   VersionedTransition last_update_versioned_transition = 5;
+  
+  // Tracks the number of times a time-skipping transition has occurred since time skipping
+  // was most recently enabled. It is reset every time the skipping config is updated.
+  int32 session_skip_count = 6;
 }
 
 message FastForwardInfo {

--- a/proto/internal/temporal/server/api/persistence/v1/executions.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/executions.proto
@@ -338,7 +338,7 @@ message TimeSkippingInfo {
   // Versioned transition at which this TimeSkippingInfo was last modified (i.e. when a
   // skip transition changed accumulated_skipped_duration or a request updated the config.)
   VersionedTransition last_update_versioned_transition = 5;
-  
+
   // Tracks the number of times a time-skipping transition has occurred since time skipping
   // was most recently enabled. It is reset every time the skipping config is updated.
   int32 session_skip_count = 6;

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -238,6 +238,7 @@ type Config struct {
 	PollerAutoscalingAutoEnroll             dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	WorkflowPauseEnabled                    dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	WorkflowTimeSkippingEnabled             dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	WorkflowTimeSkippingMaxSkipPerSession   dynamicconfig.IntPropertyFnWithNamespaceFilter
 	StandaloneNexusOperationsEnabled        dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	EnableWorkflowTaskCompletionPagination  dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
@@ -414,6 +415,7 @@ func NewConfig(
 		PollerAutoscalingAutoEnroll:             dynamicconfig.PollerAutoscalingAutoEnroll.Get(dc),
 		WorkflowPauseEnabled:                    dynamicconfig.WorkflowPauseEnabled.Get(dc),
 		WorkflowTimeSkippingEnabled:             dynamicconfig.WorkflowTimeSkippingEnabled.Get(dc),
+		WorkflowTimeSkippingMaxSkipPerSession:   dynamicconfig.WorkflowTimeSkippingMaxSkipPerSession.Get(dc),
 		StandaloneNexusOperationsEnabled:        chasmnexus.Enabled.Get(dc),
 		EnableWorkflowTaskCompletionPagination:  dynamicconfig.EnableWorkflowTaskCompletionPagination.Get(dc),
 

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -694,13 +694,13 @@ func (wh *WorkflowHandler) prepareStartWorkflowRequest(
 		return nil, err
 	}
 
-	if err := wh.validateTimeSkippingConfig(request.GetTimeSkippingConfig(), namespaceName); err != nil {
+	if err := wh.validateAndPopulateTimeSkippingConfig(request.GetTimeSkippingConfig(), namespaceName); err != nil {
 		return nil, err
 	}
 	return request, nil
 }
 
-func (wh *WorkflowHandler) validateTimeSkippingConfig(
+func (wh *WorkflowHandler) validateAndPopulateTimeSkippingConfig(
 	tsc *commonpb.TimeSkippingConfig,
 	ns namespace.Name,
 ) error {
@@ -713,6 +713,10 @@ func (wh *WorkflowHandler) validateTimeSkippingConfig(
 			"The Time-Skipping feature is not enabled for namespace %s",
 			ns.String(),
 		)
+	}
+	if tsc.GetMaxSkipPerSession() <= 0 {
+		defaultMaxSkipPerSession := wh.config.WorkflowTimeSkippingMaxSkipPerSession(ns.String())
+		tsc.MaxSkipPerSession = max(1, int32(defaultMaxSkipPerSession))
 	}
 
 	if !tsc.GetEnabled() {
@@ -2348,7 +2352,7 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 	}
 
 	namespaceName := namespace.Name(request.GetNamespace())
-	if err := wh.validateTimeSkippingConfig(request.GetTimeSkippingConfig(), namespaceName); err != nil {
+	if err := wh.validateAndPopulateTimeSkippingConfig(request.GetTimeSkippingConfig(), namespaceName); err != nil {
 		return nil, err
 	}
 
@@ -2400,7 +2404,7 @@ func (wh *WorkflowHandler) ResetWorkflowExecution(ctx context.Context, request *
 
 	for _, postOp := range request.GetPostResetOperations() {
 		if updateOpts := postOp.GetUpdateWorkflowOptions(); updateOpts != nil {
-			if err := wh.validateTimeSkippingConfig(
+			if err := wh.validateAndPopulateTimeSkippingConfig(
 				updateOpts.GetWorkflowExecutionOptions().GetTimeSkippingConfig(),
 				namespace.Name(request.GetNamespace()),
 			); err != nil {
@@ -5777,7 +5781,7 @@ func (wh *WorkflowHandler) StartBatchOperation(
 		identity = op.ResetOperation.GetIdentity()
 		for _, postOp := range op.ResetOperation.GetPostResetOperations() {
 			if updateOpts := postOp.GetUpdateWorkflowOptions(); updateOpts != nil {
-				if err := wh.validateTimeSkippingConfig(
+				if err := wh.validateAndPopulateTimeSkippingConfig(
 					updateOpts.GetWorkflowExecutionOptions().GetTimeSkippingConfig(),
 					namespace.Name(request.GetNamespace()),
 				); err != nil {
@@ -5788,7 +5792,7 @@ func (wh *WorkflowHandler) StartBatchOperation(
 	case *workflowservice.StartBatchOperationRequest_UpdateWorkflowOptionsOperation:
 		input.BatchType = enumspb.BATCH_OPERATION_TYPE_UPDATE_EXECUTION_OPTIONS
 		identity = op.UpdateWorkflowOptionsOperation.GetIdentity()
-		if err := wh.validateTimeSkippingConfig(
+		if err := wh.validateAndPopulateTimeSkippingConfig(
 			op.UpdateWorkflowOptionsOperation.GetWorkflowExecutionOptions().GetTimeSkippingConfig(),
 			namespace.Name(request.GetNamespace()),
 		); err != nil {
@@ -6860,7 +6864,7 @@ func (wh *WorkflowHandler) UpdateWorkflowExecutionOptions(
 	if err := priorities.Validate(opts.GetPriority()); err != nil {
 		return nil, err
 	}
-	if err := wh.validateTimeSkippingConfig(opts.GetTimeSkippingConfig(), namespace.Name(request.GetNamespace())); err != nil {
+	if err := wh.validateAndPopulateTimeSkippingConfig(opts.GetTimeSkippingConfig(), namespace.Name(request.GetNamespace())); err != nil {
 		return nil, err
 	}
 

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -3560,27 +3560,55 @@ func (s *WorkflowHandlerSuite) TestValidateTimeSkippingConfig() {
 	var invalidArgumentErr *serviceerror.InvalidArgument
 
 	// nil config is valid
-	s.Require().NoError(wh.validateTimeSkippingConfig(nil, s.testNamespace))
+	s.Require().NoError(wh.validateAndPopulateTimeSkippingConfig(nil, s.testNamespace))
 
 	// config with enabled=false but dynamic config disabled returns error
 	config.WorkflowTimeSkippingEnabled = dc.GetBoolPropertyFnFilteredByNamespace(false)
-	s.Require().ErrorAs(wh.validateTimeSkippingConfig(&commonpb.TimeSkippingConfig{Enabled: false}, s.testNamespace), &unimplementedErr)
+	s.Require().ErrorAs(wh.validateAndPopulateTimeSkippingConfig(&commonpb.TimeSkippingConfig{Enabled: false}, s.testNamespace), &unimplementedErr)
 
 	// config with enabled=true but dynamic config disabled returns error
-	s.Require().ErrorAs(wh.validateTimeSkippingConfig(&commonpb.TimeSkippingConfig{Enabled: true}, s.testNamespace), &unimplementedErr)
+	s.Require().ErrorAs(wh.validateAndPopulateTimeSkippingConfig(&commonpb.TimeSkippingConfig{Enabled: true}, s.testNamespace), &unimplementedErr)
 
 	// config with enabled=false and dynamic config enabled is valid
 	config.WorkflowTimeSkippingEnabled = dc.GetBoolPropertyFnFilteredByNamespace(true)
-	s.Require().NoError(wh.validateTimeSkippingConfig(&commonpb.TimeSkippingConfig{Enabled: false}, s.testNamespace))
+	s.Require().NoError(wh.validateAndPopulateTimeSkippingConfig(&commonpb.TimeSkippingConfig{Enabled: false}, s.testNamespace))
 
 	// config with enabled=true and dynamic config enabled is valid
-	s.Require().NoError(wh.validateTimeSkippingConfig(&commonpb.TimeSkippingConfig{Enabled: true}, s.testNamespace))
+	s.Require().NoError(wh.validateAndPopulateTimeSkippingConfig(&commonpb.TimeSkippingConfig{Enabled: true}, s.testNamespace))
 
-	s.Require().ErrorAs(wh.validateTimeSkippingConfig(&commonpb.TimeSkippingConfig{
+	s.Require().ErrorAs(wh.validateAndPopulateTimeSkippingConfig(&commonpb.TimeSkippingConfig{
 		Enabled: false, FastForward: durationpb.New(time.Second * 10)}, s.testNamespace), &invalidArgumentErr)
 
-	s.Require().ErrorAs(wh.validateTimeSkippingConfig(&commonpb.TimeSkippingConfig{
+	s.Require().ErrorAs(wh.validateAndPopulateTimeSkippingConfig(&commonpb.TimeSkippingConfig{
 		Enabled: true, FastForward: durationpb.New(time.Second * -10)}, s.testNamespace), &invalidArgumentErr)
+
+	// MaxSkipPerSession is populated from dynamic config: a per-namespace override wins for that
+	// namespace, a constraint-less (per-cell) value is the fallback for other namespaces, and a
+	// value already set on the request is left untouched.
+	const otherNamespace = "other-namespace"
+	maxSkipClient := dc.StaticClient{
+		dc.WorkflowTimeSkippingEnabled.Key(): true,
+		dc.WorkflowTimeSkippingMaxSkipPerSession.Key(): []dc.ConstrainedValue{
+			{Value: 42}, // per-cell (constraint-less) value
+			{Constraints: dc.Constraints{Namespace: s.testNamespace.String()}, Value: 7}, // per-namespace override
+		},
+	}
+	maxSkipWH := s.getWorkflowHandler(NewConfig(dc.NewCollection(maxSkipClient, log.NewNoopLogger()), numHistoryShards))
+
+	// namespace with a per-namespace override uses that value
+	tsc := &commonpb.TimeSkippingConfig{Enabled: true}
+	s.Require().NoError(maxSkipWH.validateAndPopulateTimeSkippingConfig(tsc, s.testNamespace))
+	s.Require().Equal(int32(7), tsc.GetMaxSkipPerSession())
+
+	// namespace without a per-namespace setting falls back to the per-cell value
+	tsc = &commonpb.TimeSkippingConfig{Enabled: true}
+	s.Require().NoError(maxSkipWH.validateAndPopulateTimeSkippingConfig(tsc, namespace.Name(otherNamespace)))
+	s.Require().Equal(int32(42), tsc.GetMaxSkipPerSession())
+
+	// a value already on the request is preserved, not overwritten by dynamic config
+	tsc = &commonpb.TimeSkippingConfig{Enabled: true, MaxSkipPerSession: 999}
+	s.Require().NoError(maxSkipWH.validateAndPopulateTimeSkippingConfig(tsc, s.testNamespace))
+	s.Require().Equal(int32(999), tsc.GetMaxSkipPerSession())
 }
 
 // TestExecuteMultiOperation_TimeSkipping_DCDisabled verifies that when the DC gate is off,

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -3193,9 +3193,7 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionStartedEvent(
 	ms.executionInfo.Priority = event.Priority
 
 	if tsc, stateProp := event.GetTimeSkippingConfig(), event.GetTimeSkippingStatePropagation(); tsc != nil || stateProp.GetInitialSkippedDuration().AsDuration() > 0 {
-		if err := ms.initTimeSkippingInfo(tsc, stateProp); err != nil {
-			return err
-		}
+		ms.initTimeSkippingInfo(tsc, stateProp)
 	}
 
 	ms.approximateSize += ms.executionInfo.Size()
@@ -5944,13 +5942,9 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionOptionsUpdatedEvent(event *his
 		tsc := attributes.GetTimeSkippingConfig()
 		tsi := ms.GetExecutionInfo().GetTimeSkippingInfo()
 		if tsi == nil {
-			if err := ms.initTimeSkippingInfo(tsc, nil); err != nil {
-				return err
-			}
+			ms.initTimeSkippingInfo(tsc, nil)
 		} else {
-			if err := ms.updateTimeSkippingInfo(tsc); err != nil {
-				return err
-			}
+			ms.updateTimeSkippingInfo(tsc)
 		}
 	}
 

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -1039,7 +1039,7 @@ func isPathAffectedByDelete(deletePath []hsm.Key, timerPath []*persistencespb.St
 // refreshTasksForTimeSkipping).
 func (r *TaskGeneratorImpl) RegenerateTimerTasksForTimeSkipping() error {
 
-	if accumulatedSkippedDuration(r.mutableState.GetExecutionInfo()) <= 0 {
+	if NewTimeSkippingInfoUtil(r.mutableState.GetExecutionInfo().GetTimeSkippingInfo()).GetAccumulatedSkippedDuration() <= 0 {
 		return nil
 	}
 

--- a/service/history/workflow/timeskipping.go
+++ b/service/history/workflow/timeskipping.go
@@ -531,9 +531,8 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionTimeSkippingTransitionedEvent(
 		tsi.AccumulatedSkippedDuration = durationpb.New(asd)
 	}
 	// update enabled state
-	tsi.Config.Enabled = !attr.GetDisabledAfterFastForward()
 	if attr.GetDisabledAfterFastForward() && tsi.GetFastForwardInfo() != nil {
-		tsi.FastForwardInfo.HasReached = true
+		tsi.GetFastForwardInfo().HasReached = true
 		tsi.Config.Enabled = false
 	}
 	// update skip

--- a/service/history/workflow/timeskipping.go
+++ b/service/history/workflow/timeskipping.go
@@ -25,38 +25,35 @@ import (
 func (ms *MutableStateImpl) initTimeSkippingInfo(
 	config *commonpb.TimeSkippingConfig,
 	timeSkippingStatePropagation *commonpb.TimeSkippingStatePropagation,
-) error {
+) {
 	initialSkip := timeSkippingStatePropagation.GetInitialSkippedDuration()
 	if config == nil && initialSkip == nil {
-		return nil
-	}
-
-	if ms.executionInfo.TimeSkippingInfo != nil {
-		return serviceerror.NewInternal("time skipping info already initialized")
+		return
 	}
 
 	ms.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
 		Config:                     config,
 		AccumulatedSkippedDuration: initialSkip,
+		SessionSkipCount:           timeSkippingStatePropagation.GetInitialSkipCount(),
 	}
 	ms.wrapTimeSourceWithTimeSkipping()
 	ms.wrapExecutionTimes(initialSkip)
 	ms.applyFastForward(timeSkippingStatePropagation.GetFastForwardTargetTime())
+
 	ms.timeSkippingInfoUpdated = true
-	return nil
 }
 
 func (ms *MutableStateImpl) updateTimeSkippingInfo(
 	config *commonpb.TimeSkippingConfig,
-) error {
+) {
 	tsi := ms.executionInfo.GetTimeSkippingInfo()
 	if tsi == nil {
-		return serviceerror.NewInternal("time skipping info not initialized when updating")
+		return
 	}
 	ms.executionInfo.TimeSkippingInfo.Config = config
 	ms.applyFastForward(nil)
 	ms.timeSkippingInfoUpdated = true
-	return nil
+	tsi.SessionSkipCount = 0
 }
 
 // applyFastForward (re)computes the FastForwardInfo using the new TimeSkippingConfig (TSC) and propagated time-skippingstates.
@@ -131,57 +128,74 @@ func (ms *MutableStateImpl) wrapExecutionTimes(initialSkippedDuration *durationp
 func propagateTimeSkippingToNextRun(
 	source *persistencespb.WorkflowExecutionInfo,
 ) (*commonpb.TimeSkippingConfig, *commonpb.TimeSkippingStatePropagation) {
-	previousTSC := source.GetTimeSkippingInfo().GetConfig()
+
+	tsi := source.GetTimeSkippingInfo()
+	util := NewTimeSkippingInfoUtil(tsi)
 
 	// if disabled, we just return nil for the new TSC
 	var newTSC *commonpb.TimeSkippingConfig
-	if previousTSC.GetEnabled() {
-		newTSC = common.CloneProto(previousTSC)
+	if util.IsEnabled() {
+		newTSC = common.CloneProto(tsi.GetConfig())
 	}
 
+	// state propagation (virtual time, fast forward, skip count)
 	var stateProp *commonpb.TimeSkippingStatePropagation
-	if accum := accumulatedSkippedDuration(source); accum > 0 {
+	if accum := util.GetAccumulatedSkippedDuration(); accum > 0 {
 		stateProp = &commonpb.TimeSkippingStatePropagation{
 			InitialSkippedDuration: durationpb.New(accum),
 		}
 	}
-
-	if ff := source.GetTimeSkippingInfo().GetFastForwardInfo(); ff != nil && !ff.GetHasReached() {
+	if util.HasPendingFastForward() {
 		if stateProp == nil {
 			stateProp = &commonpb.TimeSkippingStatePropagation{}
 		}
-		stateProp.FastForwardTargetTime = ff.GetTargetTime()
+		stateProp.FastForwardTargetTime = tsi.GetFastForwardInfo().GetTargetTime()
+	}
+	// The skip count is scoped to a session; once time skipping is disabled the session has
+	// ended, so the count does not carry to the next run.
+	if skipCount := tsi.GetSessionSkipCount(); skipCount > 0 && util.IsEnabled() {
+		if stateProp == nil {
+			stateProp = &commonpb.TimeSkippingStatePropagation{}
+		}
+		stateProp.InitialSkipCount = skipCount
 	}
 	return newTSC, stateProp
 }
 
-// propagateTimeSkippingToChild makes sure the start time of the child workflow execution
-// is shifted forward by the accumulated skipped duration.
-// FastForward is never propagated to children.
+// propagateTimeSkippingToChild snapshots the parent's time skipping into a child workflow. The
+// child shares the parent's virtual clock (its start time is shifted forward by the parent's
+// accumulated skipped duration) but is otherwise a fresh execution:
+//   - FastForward is per-execution and is never propagated to children.
+//   - The child starts a fresh skip session: SessionSkipCount is not propagated (starts at 0).
+//   - It does inherit the parent's per-session budget (MaxSkipPerSession). Children start
+//     internally, bypassing the frontend that populates the default budget, so inheriting the
+//     parent's already-resolved limit avoids a 0 that would disable skipping on the first skip.
 func propagateTimeSkippingToChild(
 	source *persistencespb.WorkflowExecutionInfo,
 ) (*commonpb.TimeSkippingConfig, *commonpb.TimeSkippingStatePropagation) {
-	accum := accumulatedSkippedDuration(source)
+	tsi := source.GetTimeSkippingInfo()
+	tsc := tsi.GetConfig()
+	util := NewTimeSkippingInfoUtil(tsi)
+
+	accum := util.GetAccumulatedSkippedDuration()
 	var stateProp *commonpb.TimeSkippingStatePropagation
 	if accum > 0 {
 		stateProp = &commonpb.TimeSkippingStatePropagation{
 			InitialSkippedDuration: durationpb.New(accum),
+			InitialSkipCount:       0,
 		}
 	}
 
-	enabled := source.GetTimeSkippingInfo().GetConfig().GetEnabled()
-	disablePropagation := source.GetTimeSkippingInfo().GetConfig().GetDisablePropagation()
-	if !enabled || disablePropagation {
+	// only propagates state
+	if !util.IsEnabled() || tsc.GetDisablePropagation() {
 		return nil, stateProp
 	}
 
+	// propagate both config and state
 	return &commonpb.TimeSkippingConfig{
-		Enabled: enabled,
+		Enabled:           true,
+		MaxSkipPerSession: tsc.GetMaxSkipPerSession(),
 	}, stateProp
-}
-
-func accumulatedSkippedDuration(source *persistencespb.WorkflowExecutionInfo) time.Duration {
-	return source.GetTimeSkippingInfo().GetAccumulatedSkippedDuration().AsDuration()
 }
 
 // =============================================================================
@@ -201,7 +215,7 @@ func (ms *MutableStateImpl) wrapTimeSourceWithTimeSkipping() {
 }
 
 func (ms *MutableStateImpl) accumulatedSkippedDuration() time.Duration {
-	return accumulatedSkippedDuration(ms.executionInfo)
+	return NewTimeSkippingInfoUtil(ms.GetExecutionInfo().GetTimeSkippingInfo()).GetAccumulatedSkippedDuration()
 }
 
 // =============================================================================
@@ -263,14 +277,21 @@ func (t *timeSkippingTransition) GateByFastForward(ff *persistencespb.FastForwar
 // Time Skipping Utility Functions
 // =============================================================================
 
+func NewTimeSkippingInfoUtil(tsi *persistencespb.TimeSkippingInfo) *TimeSkippingInfoUtil {
+	return &TimeSkippingInfoUtil{tsi: tsi}
+}
+
 // TimeSkippingInfoUtil provides read-only helpers over a TimeSkippingInfo, guarding against nil
 // info/config/fast-forward so callers don't have to repeat the nil checks.
 type TimeSkippingInfoUtil struct {
 	tsi *persistencespb.TimeSkippingInfo
 }
 
-func NewTimeSkippingInfoUtil(tsi *persistencespb.TimeSkippingInfo) *TimeSkippingInfoUtil {
-	return &TimeSkippingInfoUtil{tsi: tsi}
+func (util *TimeSkippingInfoUtil) GetAccumulatedSkippedDuration() time.Duration {
+	if util == nil || util.tsi == nil {
+		return 0
+	}
+	return util.tsi.GetAccumulatedSkippedDuration().AsDuration()
 }
 
 // HasPendingFastForward reports whether time skipping is enabled and carries a fast-forward that has
@@ -291,7 +312,7 @@ func (util *TimeSkippingInfoUtil) HasPendingFastForward() bool {
 // IsEnabled reports whether time skipping is enabled. Nil-safe: a nil util, nil info, or nil config
 // all yield false.
 func (util *TimeSkippingInfoUtil) IsEnabled() bool {
-	if util == nil {
+	if util == nil || util.tsi == nil {
 		return false
 	}
 	return util.tsi.GetConfig().GetEnabled()
@@ -490,7 +511,6 @@ func (ms *MutableStateImpl) AddWorkflowExecutionTimeSkippingTransitionedEvent(
 
 func (ms *MutableStateImpl) ApplyWorkflowExecutionTimeSkippingTransitionedEvent(ctx context.Context, event *historypb.HistoryEvent) error {
 	// todo: merge with chasm time skipping
-
 	attr := event.GetWorkflowExecutionTimeSkippingTransitionedEventAttributes()
 	tsi := ms.executionInfo.GetTimeSkippingInfo()
 
@@ -514,6 +534,12 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionTimeSkippingTransitionedEvent(
 	tsi.Config.Enabled = !attr.GetDisabledAfterFastForward()
 	if attr.GetDisabledAfterFastForward() && tsi.GetFastForwardInfo() != nil {
 		tsi.FastForwardInfo.HasReached = true
+		tsi.Config.Enabled = false
+	}
+	// update skip
+	tsi.SessionSkipCount += 1
+	if tsi.SessionSkipCount >= tsi.Config.GetMaxSkipPerSession() && tsi.Config.Enabled {
+		tsi.Config.Enabled = false
 	}
 
 	ms.timeSkippingInfoUpdated = true

--- a/service/history/workflow/timeskipping_test.go
+++ b/service/history/workflow/timeskipping_test.go
@@ -138,23 +138,68 @@ func (s *mutableStateSuite) TestPropagateTimeSkippingToNextRun_FastForwardInfo()
 		s.Nil(stateProp, "no accumulated time and no active fast-forward means nothing to propagate")
 	})
 
-	s.Run("NilTimeSkippingInfoPropagatesNothing", func() {
+	s.Run("NoTimeSkippingInfoPropagatesNothing", func() {
 		tsc, stateProp := propagateTimeSkippingToNextRun(&persistencespb.WorkflowExecutionInfo{})
 		s.Nil(tsc)
 		s.Nil(stateProp)
 	})
+
+	s.Run("SkipCountAloneStillPropagates", func() {
+		tsc, stateProp := propagateTimeSkippingToNextRun(&persistencespb.WorkflowExecutionInfo{
+			TimeSkippingInfo: &persistencespb.TimeSkippingInfo{
+				Config:           &commonpb.TimeSkippingConfig{Enabled: true, MaxSkipPerSession: 50},
+				SessionSkipCount: 2,
+			},
+		})
+		s.Require().NotNil(tsc)
+		s.Require().NotNil(stateProp)
+		s.Nil(stateProp.GetInitialSkippedDuration())
+		s.Equal(int32(2), stateProp.GetInitialSkipCount())
+		s.Equal(int32(50), tsc.MaxSkipPerSession)
+	})
+
+	s.Run("FullPropagationOfAllTimeSippingStates", func() {
+		tsc, stateProp := propagateTimeSkippingToNextRun(&persistencespb.WorkflowExecutionInfo{
+			TimeSkippingInfo: &persistencespb.TimeSkippingInfo{
+				Config:                     &commonpb.TimeSkippingConfig{Enabled: true, MaxSkipPerSession: 50},
+				AccumulatedSkippedDuration: durationpb.New(time.Hour),
+				SessionSkipCount:           3,
+			},
+		})
+		s.Require().NotNil(tsc)
+		s.Equal(int32(50), tsc.GetMaxSkipPerSession())
+		s.Require().NotNil(stateProp)
+		s.Equal(int32(3), stateProp.GetInitialSkipCount())
+	})
+
+	s.Run("SessionSkipCountWontPropagateWhenTimeSkippingDisabled", func() {
+		tsc, stateProp := propagateTimeSkippingToNextRun(&persistencespb.WorkflowExecutionInfo{
+			TimeSkippingInfo: &persistencespb.TimeSkippingInfo{
+				Config:                     &commonpb.TimeSkippingConfig{Enabled: false, MaxSkipPerSession: 50},
+				AccumulatedSkippedDuration: durationpb.New(time.Hour),
+				SessionSkipCount:           3,
+			},
+		})
+		s.Nil(tsc)
+		s.Require().NotNil(stateProp)
+		s.Equal(int32(0), stateProp.GetInitialSkipCount())
+	})
 }
 
 func (s *mutableStateSuite) TestSnapshotTimeSkippingInfo_ForChildWorkflows() {
+	accumSkip := time.Hour
+	sessionMaxSkipCount := int32(10)
 	newSource := func() *persistencespb.WorkflowExecutionInfo {
 		s.mutableState.timeSource = clock.NewEventTimeSource()
 		return &persistencespb.WorkflowExecutionInfo{
 			TimeSkippingInfo: &persistencespb.TimeSkippingInfo{
 				Config: &commonpb.TimeSkippingConfig{
-					Enabled:     true,
-					FastForward: durationpb.New(3 * time.Hour),
+					Enabled:           true,
+					FastForward:       durationpb.New(3 * time.Hour),
+					MaxSkipPerSession: sessionMaxSkipCount,
 				},
-				AccumulatedSkippedDuration: durationpb.New(time.Hour),
+				AccumulatedSkippedDuration: durationpb.New(accumSkip),
+				SessionSkipCount:           3,
 				FastForwardInfo: &persistencespb.FastForwardInfo{
 					TargetTime: timestamppb.New(s.mutableState.timeSource.Now().Add(3 * time.Hour)),
 					HasReached: false,
@@ -163,12 +208,25 @@ func (s *mutableStateSuite) TestSnapshotTimeSkippingInfo_ForChildWorkflows() {
 		}
 	}
 
-	s.Run("child workflows have no fast-forward", func() {
-		tsc, propagatedState := propagateTimeSkippingToChild(newSource())
+	s.Run("nil-safe check", func() {
+		tsc, propagatedState := propagateTimeSkippingToChild(&persistencespb.WorkflowExecutionInfo{})
+		s.Nil(tsc)
+		s.Nil(propagatedState)
+	})
+
+	s.Run("a valid full propagation of config and virtual time", func() {
+		src := newSource()
+		tsc, propagatedState := propagateTimeSkippingToChild(src)
 		s.Require().NotNil(tsc)
 		s.True(tsc.GetEnabled())
+		// no fast-forward
 		s.Nil(tsc.GetFastForward())
-		s.Equal(time.Hour, propagatedState.GetInitialSkippedDuration().AsDuration())
+		// has virtual time
+		s.Equal(accumSkip, propagatedState.GetInitialSkippedDuration().AsDuration())
+		// has config of max skip
+		s.Equal(sessionMaxSkipCount, tsc.GetMaxSkipPerSession())
+		// no accumulated session skip
+		s.Equal(int32(0), propagatedState.GetInitialSkipCount())
 	})
 
 	s.Run("child workflow propagation can be turned off", func() {
@@ -177,8 +235,9 @@ func (s *mutableStateSuite) TestSnapshotTimeSkippingInfo_ForChildWorkflows() {
 		tsc, propagatedState := propagateTimeSkippingToChild(src)
 		s.Nil(tsc)
 		s.Require().NotNil(propagatedState)
-		s.Equal(time.Hour, propagatedState.GetInitialSkippedDuration().AsDuration(),
-			"virtual time is always propagated, even when config propagation is disabled")
+		s.Equal(accumSkip, propagatedState.GetInitialSkippedDuration().AsDuration())
+		s.Equal(int32(0), propagatedState.GetInitialSkipCount())
+		s.Nil(propagatedState.GetFastForwardTargetTime())
 	})
 
 	s.Run("nil config still propagates virtual time", func() {
@@ -187,12 +246,13 @@ func (s *mutableStateSuite) TestSnapshotTimeSkippingInfo_ForChildWorkflows() {
 		tsc, propagatedState := propagateTimeSkippingToChild(src)
 		s.Nil(tsc)
 		s.Require().NotNil(propagatedState)
+		s.Equal(int32(0), propagatedState.GetInitialSkipCount())
 		s.Equal(time.Hour, propagatedState.GetInitialSkippedDuration().AsDuration(),
 			"virtual time is always propagated, even when config propagation is disabled")
 		s.Nil(propagatedState.GetFastForwardTargetTime())
 	})
 
-	s.Run("disablePropagation still propagates virtual time", func() {
+	s.Run("disabled propagation still propagates virtual time", func() {
 		src := newSource()
 		src.TimeSkippingInfo.Config.Enabled = false
 		tsc, propagatedState := propagateTimeSkippingToChild(src)
@@ -201,7 +261,7 @@ func (s *mutableStateSuite) TestSnapshotTimeSkippingInfo_ForChildWorkflows() {
 		s.Equal(time.Hour, propagatedState.GetInitialSkippedDuration().AsDuration(),
 			"virtual time is always propagated, even when config propagation is disabled")
 		s.Nil(propagatedState.GetFastForwardTargetTime())
-
+		s.Equal(int32(0), propagatedState.GetInitialSkipCount())
 	})
 
 }
@@ -360,7 +420,7 @@ func (s *mutableStateSuite) TestInitTimeSkippingInfo() {
 		s.mutableState.timeSource = clock.NewEventTimeSource()
 		baseTime := s.mutableState.timeSource.Now()
 		s.NotPanics(func() {
-			s.Require().NoError(s.mutableState.initTimeSkippingInfo(nil, nil))
+			s.mutableState.initTimeSkippingInfo(nil, nil)
 		})
 		s.Nil(s.mutableState.executionInfo.TimeSkippingInfo)
 		s.Equal(baseTime, s.mutableState.Now())
@@ -376,7 +436,7 @@ func (s *mutableStateSuite) TestInitTimeSkippingInfo() {
 			Enabled:     true,
 			FastForward: durationpb.New(3 * time.Hour)}
 
-		s.Require().NoError(s.mutableState.initTimeSkippingInfo(cfg, nil))
+		s.mutableState.initTimeSkippingInfo(cfg, nil)
 		s.Equal(baseTime, s.mutableState.Now())
 		tsi := s.mutableState.executionInfo.GetTimeSkippingInfo()
 		s.Require().NotNil(tsi)
@@ -409,7 +469,7 @@ func (s *mutableStateSuite) TestInitTimeSkippingInfo() {
 			InitialSkippedDuration: durationpb.New(hasSkipped),
 			FastForwardTargetTime:  timestamppb.New(targetTime),
 		}
-		s.Require().NoError(s.mutableState.initTimeSkippingInfo(cfg, propagation))
+		s.mutableState.initTimeSkippingInfo(cfg, propagation)
 
 		tsi := s.mutableState.executionInfo.GetTimeSkippingInfo()
 		s.Require().NotNil(tsi)
@@ -418,20 +478,44 @@ func (s *mutableStateSuite) TestInitTimeSkippingInfo() {
 		s.Equal(targetTime.UTC(),
 			tsi.GetFastForwardInfo().GetTargetTime().AsTime())
 	})
+
+	s.Run("SessionSkipCountSeededFromPropagation", func() {
+		s.mutableState.timeSource = clock.NewEventTimeSource()
+		s.mutableState.executionInfo.TimeSkippingInfo = nil
+		cfg := &commonpb.TimeSkippingConfig{Enabled: true}
+		propagation := &commonpb.TimeSkippingStatePropagation{InitialSkipCount: 4}
+
+		s.mutableState.initTimeSkippingInfo(cfg, propagation)
+
+		tsi := s.mutableState.executionInfo.GetTimeSkippingInfo()
+		s.Require().NotNil(tsi)
+		s.Equal(int32(4), tsi.GetSessionSkipCount())
+	})
+
+	s.Run("SessionSkipCountDefaultsToZeroWithoutPropagation", func() {
+		s.mutableState.timeSource = clock.NewEventTimeSource()
+		s.mutableState.executionInfo.TimeSkippingInfo = nil
+		cfg := &commonpb.TimeSkippingConfig{Enabled: true}
+
+		s.mutableState.initTimeSkippingInfo(cfg, nil)
+
+		tsi := s.mutableState.executionInfo.GetTimeSkippingInfo()
+		s.Require().NotNil(tsi)
+		s.Equal(int32(0), tsi.GetSessionSkipCount())
+	})
 }
 
 func (s *mutableStateSuite) TestUpdateTimeSkippingInfo() {
 
 	// update assumes the TS info was already initialized; updating a workflow that never
-	// started time skipping is an internal error and must not initialize it as a side effect.
-	s.Run("ErrorWhenTimeSkippingInfoNil", func() {
+	// started time skipping is a no-op and must not initialize it as a side effect.
+	s.Run("NoopWhenTimeSkippingInfoNil", func() {
 		s.mutableState.executionInfo.TimeSkippingInfo = nil
 		s.mutableState.timeSkippingInfoUpdated = false
 
-		err := s.mutableState.updateTimeSkippingInfo(&commonpb.TimeSkippingConfig{Enabled: true})
-		s.Error(err)
+		s.mutableState.updateTimeSkippingInfo(&commonpb.TimeSkippingConfig{Enabled: true})
 		s.Nil(s.mutableState.executionInfo.GetTimeSkippingInfo(), "must not initialize TS info on update")
-		s.False(s.mutableState.timeSkippingInfoUpdated, "must not mark updated on a failed update")
+		s.False(s.mutableState.timeSkippingInfoUpdated, "must not mark updated when there is nothing to update")
 	})
 
 	s.Run("UpdateTimeSkippingInfo_UpdateWithNil", func() {
@@ -451,7 +535,7 @@ func (s *mutableStateSuite) TestUpdateTimeSkippingInfo() {
 		}
 		s.mutableState.executionInfo.TimeSkippingInfo = currentTSI
 		s.mutableState.timeSkippingInfoUpdated = false
-		s.Require().NoError(s.mutableState.updateTimeSkippingInfo(nil))
+		s.mutableState.updateTimeSkippingInfo(nil)
 		newTSI := s.mutableState.executionInfo.GetTimeSkippingInfo()
 		s.Require().NotNil(newTSI)
 		s.Nil(newTSI.GetConfig())
@@ -480,7 +564,7 @@ func (s *mutableStateSuite) TestUpdateTimeSkippingInfo() {
 			FastForward:        durationpb.New(2 * time.Hour),
 			DisablePropagation: true,
 		}
-		s.Require().NoError(s.mutableState.updateTimeSkippingInfo(newConfig))
+		s.mutableState.updateTimeSkippingInfo(newConfig)
 		newTSI := s.mutableState.executionInfo.GetTimeSkippingInfo()
 
 		s.Require().NotNil(newTSI)
@@ -519,7 +603,7 @@ func (s *mutableStateSuite) TestUpdateTimeSkippingInfo() {
 			Enabled:     true,
 			FastForward: durationpb.New(2 * time.Hour),
 		}
-		s.Require().NoError(s.mutableState.updateTimeSkippingInfo(tsc2))
+		s.mutableState.updateTimeSkippingInfo(tsc2)
 		tsc2TSI := s.mutableState.executionInfo.GetTimeSkippingInfo()
 
 		s.Require().NotNil(tsc2TSI)
@@ -535,13 +619,32 @@ func (s *mutableStateSuite) TestUpdateTimeSkippingInfo() {
 		tsc3 := &commonpb.TimeSkippingConfig{
 			Enabled: false,
 		}
-		s.Require().NoError(s.mutableState.updateTimeSkippingInfo(tsc3))
+		s.mutableState.updateTimeSkippingInfo(tsc3)
 		tsc3TSI := s.mutableState.executionInfo.GetTimeSkippingInfo()
 		s.Require().NotNil(tsc3TSI)
 		s.True(proto.Equal(tsc3, tsc3TSI.GetConfig()))
 		s.Nil(tsc3TSI.GetFastForwardInfo())
 		s.Equal(time.Hour, tsc3TSI.GetAccumulatedSkippedDuration().AsDuration())
 
+	})
+
+	// Updating the config restarts the skip session: the per-session skip counter from the
+	// previous session must be cleared.
+	s.Run("ClearsSessionSkipCount", func() {
+		s.mutableState.timeSource = clock.NewEventTimeSource()
+		s.mutableState.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
+			Config: &commonpb.TimeSkippingConfig{
+				Enabled:           false,
+				MaxSkipPerSession: 10,
+			},
+			SessionSkipCount: 7,
+		}
+
+		s.mutableState.updateTimeSkippingInfo(&commonpb.TimeSkippingConfig{Enabled: true, MaxSkipPerSession: 10})
+
+		tsi := s.mutableState.executionInfo.GetTimeSkippingInfo()
+		s.Require().NotNil(tsi)
+		s.Equal(int32(0), tsi.GetSessionSkipCount())
 	})
 }
 
@@ -1245,6 +1348,83 @@ func (s *mutableStateSuite) TestApplyWorkflowExecutionTimeSkippingTransitionedEv
 		accumulated := s.mutableState.GetExecutionInfo().TimeSkippingInfo.AccumulatedSkippedDuration
 		s.Require().Equal(2*time.Hour, accumulated.AsDuration())
 	})
+
+	// Regression: a fast-forward-completion transition must both disable the config and record
+	// the fast-forward as reached. A previous bug left Enabled unchanged on this path.
+	s.Run("FastForwardCompletionDisables", func() {
+		targetTime := baseTime.Add(2 * time.Hour)
+		s.mutableState.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
+			Config: &commonpb.TimeSkippingConfig{
+				Enabled:     true,
+				FastForward: durationpb.New(2 * time.Hour),
+			},
+			FastForwardInfo: &persistencespb.FastForwardInfo{
+				TargetTime: timestamppb.New(targetTime),
+				HasReached: false,
+			},
+		}
+
+		err := s.mutableState.ApplyWorkflowExecutionTimeSkippingTransitionedEvent(
+			context.Background(),
+			makeEvent(baseTime, &targetTime, true),
+		)
+		s.Require().NoError(err)
+
+		tsi := s.mutableState.GetExecutionInfo().TimeSkippingInfo
+		s.Require().False(tsi.GetConfig().GetEnabled())
+		s.Require().True(tsi.GetFastForwardInfo().GetHasReached())
+	})
+
+	// Every applied transition increments SessionSkipCount by one, and once the count reaches
+	// the per-session cap the config is disabled.
+	s.Run("SessionSkipCountIncrementsUntilCapDisables", func() {
+		s.mutableState.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
+			Config: &commonpb.TimeSkippingConfig{
+				Enabled:           true,
+				MaxSkipPerSession: 2,
+			},
+		}
+		targetTime := baseTime.Add(time.Hour)
+
+		// first skip: count 1, below cap, stays enabled
+		err := s.mutableState.ApplyWorkflowExecutionTimeSkippingTransitionedEvent(
+			context.Background(),
+			makeEvent(baseTime, &targetTime, false),
+		)
+		s.Require().NoError(err)
+		tsi := s.mutableState.GetExecutionInfo().TimeSkippingInfo
+		s.Require().Equal(int32(1), tsi.GetSessionSkipCount())
+		s.Require().True(tsi.GetConfig().GetEnabled())
+
+		// second skip: count reaches the cap of 2, disables
+		err = s.mutableState.ApplyWorkflowExecutionTimeSkippingTransitionedEvent(
+			context.Background(),
+			makeEvent(baseTime, &targetTime, false),
+		)
+		s.Require().NoError(err)
+		s.Require().Equal(int32(2), tsi.GetSessionSkipCount())
+		s.Require().False(tsi.GetConfig().GetEnabled())
+	})
+
+	// A MaxSkipPerSession of 0 caps on the very first skip (1 >= 0), disabling immediately.
+	// The frontend guarantees a populated config carries at least 1, so a 0 reaching the
+	// runtime (e.g. a config that never had the cap populated) kills skipping right away.
+	s.Run("SessionSkipCountCapsImmediatelyWhenMaxUnset", func() {
+		s.mutableState.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
+			Config: &commonpb.TimeSkippingConfig{Enabled: true},
+		}
+		targetTime := baseTime.Add(time.Hour)
+
+		err := s.mutableState.ApplyWorkflowExecutionTimeSkippingTransitionedEvent(
+			context.Background(),
+			makeEvent(baseTime, &targetTime, false),
+		)
+		s.Require().NoError(err)
+
+		tsi := s.mutableState.GetExecutionInfo().TimeSkippingInfo
+		s.Require().Equal(int32(1), tsi.GetSessionSkipCount())
+		s.Require().False(tsi.GetConfig().GetEnabled())
+	})
 }
 
 func (s *mutableStateSuite) TestWrapTimeSourceWithTimeSkipping() {
@@ -1338,12 +1518,36 @@ func (s *mutableStateSuite) TestTimeSkippingInfoUtil() {
 		s.False(util.IsEnabled())
 	})
 
+	s.Run("NilReceiverSafe", func() {
+		var util *TimeSkippingInfoUtil
+		s.False(util.IsEnabled())
+		s.False(util.HasPendingFastForward())
+		s.Zero(util.GetAccumulatedSkippedDuration())
+		s.Nil(util.ToDescribeInfo(time.Now()))
+	})
+
 	s.Run("NilFFISafe", func() {
 		s.mutableState.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
 			Config:          &commonpb.TimeSkippingConfig{Enabled: true},
 			FastForwardInfo: nil,
 		}
 		util := NewTimeSkippingInfoUtil(s.mutableState.executionInfo.TimeSkippingInfo)
+		s.False(util.HasPendingFastForward())
+	})
+
+	s.Run("NoPendingFastForwardWhenTargetTimeNil", func() {
+		util := NewTimeSkippingInfoUtil(&persistencespb.TimeSkippingInfo{
+			Config:          &commonpb.TimeSkippingConfig{Enabled: true},
+			FastForwardInfo: &persistencespb.FastForwardInfo{HasReached: false, TargetTime: nil},
+		})
+		s.False(util.HasPendingFastForward())
+	})
+
+	s.Run("NoPendingFastForwardWhenTargetTimeZero", func() {
+		util := NewTimeSkippingInfoUtil(&persistencespb.TimeSkippingInfo{
+			Config:          &commonpb.TimeSkippingConfig{Enabled: true},
+			FastForwardInfo: &persistencespb.FastForwardInfo{HasReached: false, TargetTime: timestamppb.New(time.Time{})},
+		})
 		s.False(util.HasPendingFastForward())
 	})
 
@@ -1401,6 +1605,20 @@ func (s *mutableStateSuite) TestTimeSkippingInfoUtil() {
 		}
 		util := NewTimeSkippingInfoUtil(s.mutableState.executionInfo.TimeSkippingInfo)
 		s.True(util.IsEnabled())
+	})
+
+	s.Run("IsEnabledNilConfig", func() {
+		util := NewTimeSkippingInfoUtil(&persistencespb.TimeSkippingInfo{Config: nil})
+		s.False(util.IsEnabled())
+	})
+
+	s.Run("GetAccumulatedSkippedDuration", func() {
+		s.Zero(NewTimeSkippingInfoUtil(nil).GetAccumulatedSkippedDuration(), "nil info")
+		s.Zero(NewTimeSkippingInfoUtil(&persistencespb.TimeSkippingInfo{}).GetAccumulatedSkippedDuration(), "unset duration")
+		util := NewTimeSkippingInfoUtil(&persistencespb.TimeSkippingInfo{
+			AccumulatedSkippedDuration: durationpb.New(90 * time.Minute),
+		})
+		s.Equal(90*time.Minute, util.GetAccumulatedSkippedDuration())
 	})
 
 	s.Run("ToDescribeInfoNilTSI", func() {

--- a/tests/timeskipping_propagation_test.go
+++ b/tests/timeskipping_propagation_test.go
@@ -213,6 +213,124 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_Basic() {
 		"initiated event InitialSkippedDuration == parent's AccumulatedSkippedDuration at command time (1h)")
 }
 
+// TestTSPInChildWf_InheritsBudgetFreshCount verifies that a child inherits the parent's
+// per-session budget (MaxSkipPerSession) but starts a fresh skip count. Children start
+// internally, bypassing the frontend that populates the default budget — so without inheriting
+// the parent's limit the child's config would carry MaxSkipPerSession=0 and time skipping would
+// disable after its very first skip. The child here skips TWICE, which is only possible because
+// it inherited the parent's budget (5) rather than 0.
+func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_InheritsBudgetFreshCount() {
+	env := testcore.NewEnv(s.T())
+	env.OverrideDynamicConfig(dynamicconfig.WorkflowTimeSkippingEnabled, true)
+	tv := testvars.New(s.T())
+	ctx := s.Context()
+
+	parentWFType := tv.WorkflowType()
+	childWFType := &commonpb.WorkflowType{Name: parentWFType.Name + "-child"}
+	parentWFID := tv.WorkflowID()
+	childWFID := parentWFID + "-child"
+
+	// A distinctive budget (not the dynamic-config default of 100) so the value observed on the
+	// child unambiguously came from the parent's config. Small, but above each run's skip count.
+	const maxSkip = 5
+
+	startWall := time.Now()
+
+	parentStart, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           uuid.NewString(),
+		Namespace:           env.Namespace().String(),
+		WorkflowId:          parentWFID,
+		WorkflowType:        parentWFType,
+		TaskQueue:           tv.TaskQueue(),
+		WorkflowRunTimeout:  durationpb.New(24 * time.Hour),
+		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+		TimeSkippingConfig:  &commonpb.TimeSkippingConfig{Enabled: true, MaxSkipPerSession: maxSkip},
+	})
+	s.NoError(err)
+	parentRunID := parentStart.RunId
+
+	ns := env.Namespace().String()
+	tq := tv.TaskQueue()
+
+	parentStarted, parentKickedOff, parentDone := false, false, false
+	parentHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		fired := firedTimers(task)
+		if !parentStarted {
+			parentStarted = true
+			return cmdsResponse(timerCmd("t1", time.Hour)), nil
+		}
+		if fired["t1"] && !parentKickedOff {
+			parentKickedOff = true
+			return cmdsResponse(
+				childCmd(ns, childWFID, childWFType, tq),
+				timerCmd("t2", time.Hour),
+			), nil
+		}
+		if fired["t2"] && !parentDone {
+			parentDone = true
+			return cmdsResponse(completeCmd()), nil
+		}
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{}, nil
+	}
+
+	// The child skips twice: tc1 then tc2. Under the old bug (MaxSkipPerSession=0) skipping would
+	// disable after tc1 and tc2 would never be skipped, hanging the test.
+	childStarted, childSecond, childDone := false, false, false
+	childHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		fired := firedTimers(task)
+		if !childStarted {
+			childStarted = true
+			return cmdsResponse(timerCmd("tc1", 2*time.Hour)), nil
+		}
+		if fired["tc1"] && !childSecond {
+			childSecond = true
+			return cmdsResponse(timerCmd("tc2", 2*time.Hour)), nil
+		}
+		if fired["tc2"] && !childDone {
+			childDone = true
+			return cmdsResponse(completeCmd()), nil
+		}
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{}, nil
+	}
+
+	dispatch := typeDispatch(map[string]wftHandler{
+		parentWFType.Name: parentHandler,
+		childWFType.Name:  childHandler,
+	})
+
+	s.drivePollsUntilClosed(ctx, env, tv, dispatch, parentWFID, parentRunID, 20)
+
+	elapsed := time.Since(startWall)
+	s.Less(elapsed, 2*time.Minute, "wall-clock elapsed (%s) should be far less than the virtual time skipped", elapsed)
+
+	// ---- Child: inherited the budget, ran a fresh session, skipped twice ----
+	childMS := s.getMutableStateByID(ctx, env, childWFID)
+	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED, childMS.State.ExecutionState.State)
+	childTSI := childMS.State.ExecutionInfo.GetTimeSkippingInfo()
+	s.NotNil(childTSI)
+	s.True(childTSI.GetConfig().GetEnabled(), "child skipping stayed enabled across both skips")
+	s.Equal(int32(maxSkip), childTSI.GetConfig().GetMaxSkipPerSession(),
+		"child inherits the parent's per-session budget")
+	s.Equal(int32(2), childTSI.GetSessionSkipCount(),
+		"child ran a fresh session: only its own two skips, not the parent's count")
+
+	// ---- Parent: its own budget and count are independent of the child's ----
+	parentMS := s.getMutableState(env, parentWFID, parentRunID)
+	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED, parentMS.State.ExecutionState.State)
+	parentTSI := parentMS.State.ExecutionInfo.GetTimeSkippingInfo()
+	s.Equal(int32(maxSkip), parentTSI.GetConfig().GetMaxSkipPerSession())
+	s.Equal(int32(2), parentTSI.GetSessionSkipCount(), "parent skipped t1 and t2")
+
+	// The initiated event's TimeSkippingConfig snapshot carries the inherited budget but no count.
+	initEvents := s.initiatedChildEvents(ctx, env, parentWFID, parentRunID)
+	s.Len(initEvents, 1)
+	initAttrs := initEvents[0].GetStartChildWorkflowExecutionInitiatedEventAttributes()
+	s.Equal(int32(maxSkip), initAttrs.GetTimeSkippingConfig().GetMaxSkipPerSession(),
+		"initiated-event snapshot carries the inherited budget")
+	s.Equal(int32(0), initAttrs.GetTimeSkippingStatePropagation().GetInitialSkipCount(),
+		"child does not inherit the parent's running skip count")
+}
+
 // TestTSPInChildWf_TwoChildren verifies that:
 //   - All children started in the same WFT inherit the parent's TimeSkippingConfig
 //     and have their AccumulatedSkippedDuration seeded to the parent's accumulated
@@ -1194,6 +1312,96 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInCaN() {
 		"started event retains InitialSkippedDuration=1h (run 1's accumulated at CaN time); applyTimeSkippingConfig uses it to seed AccumulatedSkippedDuration on the MS but the event snapshot is unchanged")
 }
 
+// TestTSPInCaN_SkipSessionPropagated verifies that continue-as-new carries the whole skip
+// session forward: the per-session budget (MaxSkipPerSession, via the cloned config) AND the
+// running SessionSkipCount (via InitialSkipCount). Run 1 skips once (count 1) then CaNs with a
+// budget of 10; run 2 boots with the count seeded to 1, skips once more (count 2), and still
+// sees the same budget.
+func (s *TimeSkippingPropagationTestSuite) TestTSPInCaN_SkipSessionPropagated() {
+	env := testcore.NewEnv(s.T())
+	env.OverrideDynamicConfig(dynamicconfig.WorkflowTimeSkippingEnabled, true)
+	tv := testvars.New(s.T())
+	ctx := s.Context()
+
+	wfType := tv.WorkflowType()
+	wfID := tv.WorkflowID()
+	tq := tv.TaskQueue()
+
+	// A distinctive budget (not the dynamic-config default of 100) so a propagated value is
+	// unambiguously the one from run 1's config. 10 is high enough that neither run hits the cap.
+	const maxSkip = 10
+
+	start1, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           uuid.NewString(),
+		Namespace:           env.Namespace().String(),
+		WorkflowId:          wfID,
+		WorkflowType:        wfType,
+		TaskQueue:           tq,
+		WorkflowRunTimeout:  durationpb.New(24 * time.Hour),
+		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+		TimeSkippingConfig:  &commonpb.TimeSkippingConfig{Enabled: true, MaxSkipPerSession: maxSkip},
+	})
+	s.NoError(err)
+	run1ID := start1.RunId
+
+	state := 0
+	handler := func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		fired := firedTimers(task)
+		switch {
+		case state == 0:
+			state = 1
+			return cmdsResponse(timerCmd("t1", time.Hour)), nil
+		case state == 1 && fired["t1"]:
+			state = 2
+			return cmdsResponse(continueAsNewCmd(wfType, tq)), nil
+		case state == 2:
+			state = 3
+			return cmdsResponse(timerCmd("t2", 2*time.Hour)), nil
+		case state == 3 && fired["t2"]:
+			state = 4
+			return cmdsResponse(completeCmd()), nil
+		}
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{}, nil
+	}
+
+	// Empty runID so describe follows the chain to the current run (run 2 after CaN).
+	s.drivePollsUntilClosed(ctx, env, tv, handler, wfID, "", 20)
+
+	// ---- Run 1: skipped once (t1), CaN'd with the budget still enabled ----
+	run1MS := s.getMutableState(env, wfID, run1ID)
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW, run1MS.State.ExecutionState.Status)
+	run1TSI := run1MS.State.ExecutionInfo.GetTimeSkippingInfo()
+	s.NotNil(run1TSI)
+	s.Equal(int32(maxSkip), run1TSI.GetConfig().GetMaxSkipPerSession())
+	s.Equal(int32(1), run1TSI.GetSessionSkipCount(), "run 1 skipped once for t1")
+
+	// ---- Run 2: inherits both the budget and the running count ----
+	run2MS := s.getMutableStateByID(ctx, env, wfID)
+	run2ID := run2MS.State.ExecutionState.RunId
+	s.NotEqual(run1ID, run2ID, "run 2 should have a new run ID")
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, run2MS.State.ExecutionState.Status)
+	run2TSI := run2MS.State.ExecutionInfo.GetTimeSkippingInfo()
+	s.NotNil(run2TSI, "run 2 should have TimeSkippingInfo propagated from run 1")
+	s.Equal(int32(maxSkip), run2TSI.GetConfig().GetMaxSkipPerSession(),
+		"run 2 inherits the same per-session budget from run 1's cloned config")
+	s.Equal(int32(2), run2TSI.GetSessionSkipCount(),
+		"run 2 count = 1 inherited from run 1 + 1 for its own skip (t2)")
+
+	// Run 2's WorkflowExecutionStarted event carries both in the propagated snapshot.
+	hist2, err := env.FrontendClient().GetWorkflowExecutionHistory(ctx, &workflowservice.GetWorkflowExecutionHistoryRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: wfID, RunId: run2ID},
+	})
+	s.NoError(err)
+	s.NotEmpty(hist2.History.Events)
+	startedAttr := hist2.History.Events[0].GetWorkflowExecutionStartedEventAttributes()
+	s.NotNil(startedAttr)
+	s.Equal(int32(maxSkip), startedAttr.GetTimeSkippingConfig().GetMaxSkipPerSession(),
+		"started event TSC carries the propagated budget")
+	s.Equal(int32(1), startedAttr.GetTimeSkippingStatePropagation().GetInitialSkipCount(),
+		"started event carries run 1's SessionSkipCount as InitialSkipCount")
+}
+
 // TestTSPInRetry verifies that a retried run is a same-lineage continuation: it inherits
 // the previous attempt's current TimeSkippingConfig AND its in-flight accumulated skip.
 //
@@ -1367,8 +1575,9 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInCron() {
 	tq := tv.TaskQueue()
 
 	inputCfg := &commonpb.TimeSkippingConfig{
-		Enabled:     true,
-		FastForward: durationpb.New(time.Hour),
+		Enabled:           true,
+		FastForward:       durationpb.New(time.Hour),
+		MaxSkipPerSession: 50,
 	}
 
 	startWall := time.Now()

--- a/tests/timeskipping_test.go
+++ b/tests/timeskipping_test.go
@@ -32,6 +32,11 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
+// defaultMaxSkipPerSession mirrors the compiled default of
+// dynamicconfig.WorkflowTimeSkippingMaxSkipPerSession. The frontend populates a request's
+// unset MaxSkipPerSession with this value, so tests that leave it empty expect it back.
+const defaultMaxSkipPerSession = 100
+
 type TimeSkippingTestSuite struct {
 	parallelsuite.Suite[*TimeSkippingTestSuite]
 }
@@ -68,6 +73,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_StartWorkflow_DCEnabled() {
 	env.OverrideDynamicConfig(dynamicconfig.WorkflowTimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 
+	// Request leaves MaxSkipPerSession empty; the frontend populates it from dynamic config.
 	inputConfig := &commonpb.TimeSkippingConfig{
 		Enabled:     true,
 		FastForward: durationpb.New(time.Hour),
@@ -87,6 +93,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_StartWorkflow_DCEnabled() {
 
 	ms := s.getMutableState(env, tv.WorkflowID(), resp.RunId)
 	s.True(ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig().GetEnabled())
+	inputConfig.MaxSkipPerSession = defaultMaxSkipPerSession // frontend populated this from dynamic config
 	s.True(proto.Equal(inputConfig, ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig()))
 }
 
@@ -97,6 +104,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_SignalWithStart_DCEnabled() {
 	env.OverrideDynamicConfig(dynamicconfig.WorkflowTimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
 
+	// Request leaves MaxSkipPerSession empty; the frontend populates it from dynamic config.
 	inputConfig := &commonpb.TimeSkippingConfig{
 		Enabled:     true,
 		FastForward: durationpb.New(time.Hour),
@@ -116,6 +124,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_SignalWithStart_DCEnabled() {
 	s.NoError(err)
 
 	ms := s.getMutableState(env, tv.WorkflowID(), resp.RunId)
+	inputConfig.MaxSkipPerSession = defaultMaxSkipPerSession // frontend populated this from dynamic config
 	s.True(proto.Equal(inputConfig, ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig()))
 }
 
@@ -128,6 +137,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_ExecuteMultiOperation_DCEnabled
 	tv := testvars.New(s.T())
 	maxElapsedDuration := time.Hour
 
+	// Request leaves MaxSkipPerSession empty; the frontend populates it from dynamic config.
 	inputConfig := &commonpb.TimeSkippingConfig{
 		Enabled:     true,
 		FastForward: durationpb.New(maxElapsedDuration),
@@ -168,6 +178,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_ExecuteMultiOperation_DCEnabled
 
 	runID := resp.GetResponses()[0].GetStartWorkflow().GetRunId()
 	ms := s.getMutableState(env, tv.WorkflowID(), runID)
+	inputConfig.MaxSkipPerSession = defaultMaxSkipPerSession // frontend populated this from dynamic config
 	s.True(proto.Equal(inputConfig, ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig()))
 }
 
@@ -225,12 +236,14 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_UpdateWorkflowOptions_DCEnabled
 	ms := s.getMutableState(env, tv.WorkflowID(), runID)
 	s.Nil(ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig())
 
-	// First update: enable with a max_elapsed_duration.
+	// First update: enable with a max_elapsed_duration. MaxSkipPerSession is left empty and
+	// populated by the frontend from dynamic config; the persisted config and event carry it.
 	config1 := &commonpb.TimeSkippingConfig{
 		Enabled:     true,
 		FastForward: durationpb.New(time.Hour),
 	}
 	updateOptions(config1)
+	config1.MaxSkipPerSession = defaultMaxSkipPerSession
 
 	ms = s.getMutableState(env, tv.WorkflowID(), runID)
 	s.True(proto.Equal(config1, ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig()))
@@ -244,6 +257,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_UpdateWorkflowOptions_DCEnabled
 		FastForward: durationpb.New(2 * time.Hour),
 	}
 	updateOptions(config2)
+	config2.MaxSkipPerSession = defaultMaxSkipPerSession
 
 	ms = s.getMutableState(env, tv.WorkflowID(), runID)
 	s.True(proto.Equal(config2, ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig()))
@@ -251,9 +265,11 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_UpdateWorkflowOptions_DCEnabled
 	s.Len(events, 2)
 	s.True(proto.Equal(config2, events[1].GetWorkflowExecutionOptionsUpdatedEventAttributes().GetTimeSkippingConfig()))
 
-	// Third update: disable time-skipping.
+	// Third update: disable time-skipping. The frontend's default-populate runs even for a
+	// disabled config, so MaxSkipPerSession still comes back set.
 	config3 := &commonpb.TimeSkippingConfig{Enabled: false}
 	updateOptions(config3)
+	config3.MaxSkipPerSession = defaultMaxSkipPerSession
 
 	ms = s.getMutableState(env, tv.WorkflowID(), runID)
 	s.True(proto.Equal(config3, ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig()))
@@ -327,8 +343,9 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_ResetWithUpdateOptions() {
 	s.NoError(err)
 	newRunID := resetResp.RunId
 
-	// New run's mutable state must have the config.
+	// New run's mutable state must have the config (MaxSkipPerSession populated by the frontend).
 	ms := s.getMutableState(env, tv.WorkflowID(), newRunID)
+	inputConfig.MaxSkipPerSession = defaultMaxSkipPerSession
 	s.True(proto.Equal(inputConfig, ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig()))
 
 	// New run's history must contain a WorkflowExecutionOptionsUpdated event with the config.

--- a/tests/timeskipping_test.go
+++ b/tests/timeskipping_test.go
@@ -35,7 +35,7 @@ import (
 // defaultMaxSkipPerSession mirrors the compiled default of
 // dynamicconfig.WorkflowTimeSkippingMaxSkipPerSession. The frontend populates a request's
 // unset MaxSkipPerSession with this value, so tests that leave it empty expect it back.
-const defaultMaxSkipPerSession = 100
+const defaultMaxSkipPerSession = 200
 
 type TimeSkippingTestSuite struct {
 	parallelsuite.Suite[*TimeSkippingTestSuite]


### PR DESCRIPTION
## What changed?

(for config)
1. validate and populate `session_max_skip_count` before setting time-skipping config
2. add a per-ns dc to set the default value of `session_max_skip_count`

(for runtime)
4. time skipping transition bumps `session_skip_count`
5.  `session_skip_count` propagates over a chain of runs if time skipping is still enabled
6. fixed a bug that fast-forward completion doesn't disable time skipping
7. add disable reason just for debugging purpose

## Why?
time skipping removes backoffs and max skip provides a way to stop unexpected unlimited retires or schedules over a chain of runs within an execution

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)
