### PR TITLE
perf: use UnloggedBatch for DeleteHistoryBranch

### DIFF
--- a/common/persistence/cassandra/history_store.go
+++ b/common/persistence/cassandra/history_store.go
@@ -85,6 +85,9 @@ func (h *HistoryStore) AppendHistoryNodes(
 	}
 
 	treeInfoDataBlob := request.TreeInfo
+	// Both statements target the same tree_id but different tables (history_tree, history_node).
+	// LoggedBatch ensures atomicity across tables. ScyllaDB optimizes single-partition
+	// logged batches to unlogged internally, so no performance penalty on ScyllaDB.
 	batch := h.Session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
 	batch.Query(v2templateInsertTree,
 		branchInfo.TreeId,
@@ -270,7 +273,10 @@ func (h *HistoryStore) DeleteHistoryBranch(
 	request *p.InternalDeleteHistoryBranchRequest,
 ) error {
 
-	batch := h.Session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
+	// UnloggedBatch: statements span history_tree and history_node tables (same tree_id
+	// partition key). Partial failure only leaves orphaned data that the scavenger cleans up.
+	// Avoids batchlog coordinator overhead on Cassandra; ScyllaDB already optimizes this.
+	batch := h.Session.NewBatch(gocql.UnloggedBatch).WithContext(ctx)
 	batch.Query(v2templateDeleteBranch, request.BranchInfo.TreeId, request.BranchInfo.BranchId)
 
 	// delete each branch range


### PR DESCRIPTION
## Motivation

`DeleteHistoryBranch` uses `LoggedBatch` to delete rows across `history_tree` and `history_node` tables. This incurs batchlog coordination overhead on Cassandra even though the operation targets a single partition key (`tree_id`). Since this is a deletion/cleanup path, the atomicity guarantee of a logged batch is unnecessary — orphaned rows are already handled by the scavenger.

## Changes

- `common/persistence/cassandra/history_store.go`: switched `DeleteHistoryBranch` from `LoggedBatch` to `UnloggedBatch`
- `AppendHistoryNodes` remains on `LoggedBatch` (write path needs atomicity)

## Safety

- Single-partition batch — no cross-partition consistency concern
- Scavenger cleans up orphaned history data in case of partial failure
- ScyllaDB is unaffected (already optimizes single-partition logged batches to unlogged)

## Tests

- `common/persistence/cassandra` (13 tests): ✅ passed
- `common/persistence` (75 tests): ✅ passed
- `common/persistence/client` (55 tests): ✅ passed