### PR TITLE
perf: use clear() instead of make() in cleanupTransaction

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -8348,33 +8348,33 @@ func (ms *MutableStateImpl) closeTransactionPrepareReplicationTasks(
 }
 
 func (ms *MutableStateImpl) cleanupTransaction() error {
-	ms.updateActivityInfos = make(map[int64]*persistencespb.ActivityInfo)
-	ms.deleteActivityInfos = make(map[int64]struct{})
-	ms.syncActivityTasks = make(map[int64]struct{})
+	clear(ms.updateActivityInfos)
+	clear(ms.deleteActivityInfos)
+	clear(ms.syncActivityTasks)
 
-	ms.updateTimerInfos = make(map[string]*persistencespb.TimerInfo)
-	ms.deleteTimerInfos = make(map[string]struct{})
+	clear(ms.updateTimerInfos)
+	clear(ms.deleteTimerInfos)
 
-	ms.updateChildExecutionInfos = make(map[int64]*persistencespb.ChildExecutionInfo)
-	ms.deleteChildExecutionInfos = make(map[int64]struct{})
+	clear(ms.updateChildExecutionInfos)
+	clear(ms.deleteChildExecutionInfos)
 
-	ms.updateRequestCancelInfos = make(map[int64]*persistencespb.RequestCancelInfo)
-	ms.deleteRequestCancelInfos = make(map[int64]struct{})
+	clear(ms.updateRequestCancelInfos)
+	clear(ms.deleteRequestCancelInfos)
 
-	ms.updateSignalInfos = make(map[int64]*persistencespb.SignalInfo)
-	ms.deleteSignalInfos = make(map[int64]struct{})
+	clear(ms.updateSignalInfos)
+	clear(ms.deleteSignalInfos)
 
-	ms.updateSignalRequestedIDs = make(map[string]struct{})
-	ms.deleteSignalRequestedIDs = make(map[string]struct{})
+	clear(ms.updateSignalRequestedIDs)
+	clear(ms.deleteSignalRequestedIDs)
 
 	ms.visibilityUpdated = false
 	ms.executionStateUpdated = false
 	ms.workflowTaskUpdated = false
 	ms.isResetStateUpdated = false
 	ms.timeSkippingInfoUpdated = false
-	ms.updateInfoUpdated = make(map[string]struct{})
-	ms.timerInfosUserDataUpdated = make(map[string]struct{})
-	ms.activityInfosUserDataUpdated = make(map[int64]struct{})
+	clear(ms.updateInfoUpdated)
+	clear(ms.timerInfosUserDataUpdated)
+	clear(ms.activityInfosUserDataUpdated)
 	ms.reapplyEventsCandidate = nil
 	ms.subStateMachineDeleted = false
 	ms.replayEventBatchID = common.EmptyEventID


### PR DESCRIPTION
## Motivation

`cleanupTransaction()` runs after every workflow task and resets 16 internal maps by allocating new ones with `make()`. These maps are hot-path fields that hold updates across transactions. Reallocating discards the existing backing arrays unnecessarily.

## Changes

Replaced 16 `make()` calls with `clear()` to zero the map entries while keeping the underlying bucket arrays for reuse. This saves allocation and GC pressure on the workflow-task hot path.

## Tests

- `service/history/workflow` (1075 tests): ✅ passed