### PR TITLE
perf: replace MapScan with typed Scan in ScyllaDB/Cassandra persistence loops

### DIFF
--- a/common/persistence/cassandra/history_store.go
+++ b/common/persistence/cassandra/history_store.go
@@ -175,10 +175,30 @@ func (h *HistoryStore) ReadHistoryBranch(
 	}
 
 	nodes := make([]p.InternalHistoryNode, 0, request.PageSize)
-	message := make(map[string]any)
-	for iter.MapScan(message) {
-		nodes = append(nodes, convertHistoryNode(message))
-		message = make(map[string]any)
+	var nodeID, prevTxnID, txnID int64
+	var data []byte
+	var dataEncoding string
+	if request.MetadataOnly {
+		// Column order must match v2templateReadHistoryNodeMetadata SELECT clause.
+		for iter.Scan(&nodeID, &prevTxnID, &txnID) {
+			nodes = append(nodes, p.InternalHistoryNode{
+				NodeID:            nodeID,
+				PrevTransactionID: prevTxnID,
+				TransactionID:     txnID,
+			})
+		}
+	} else {
+		// Column order must match v2templateReadHistoryNode / v2templateReadHistoryNodeReverse SELECT clause.
+		for iter.Scan(&nodeID, &prevTxnID, &txnID, &data, &dataEncoding) {
+			dataCopy := make([]byte, len(data))
+			copy(dataCopy, data)
+			nodes = append(nodes, p.InternalHistoryNode{
+				NodeID:            nodeID,
+				PrevTransactionID: prevTxnID,
+				TransactionID:     txnID,
+				Events:            p.NewDataBlob(dataCopy, dataEncoding),
+			})
+		}
 	}
 
 	if err := iter.Close(); err != nil {
@@ -319,10 +339,12 @@ func (h *HistoryStore) GetAllHistoryTreeBranches(
 	var encoding string
 
 	for iter.Scan(&treeUUID, &branchUUID, &data, &encoding) {
+		dataCopy := make([]byte, len(data))
+		copy(dataCopy, data)
 		branch := p.InternalHistoryBranchDetail{
 			TreeID:   treeUUID,
 			BranchID: branchUUID,
-			Data:     data,
+			Data:     dataCopy,
 			Encoding: encoding,
 		}
 		branches = append(branches, branch)
@@ -375,7 +397,9 @@ func (h *HistoryStore) GetHistoryTreeContainingBranch(
 		var data []byte
 		var encoding string
 		for iter.Scan(&branchUUID, &data, &encoding) {
-			treeInfos = append(treeInfos, p.NewDataBlob(data, encoding))
+			dataCopy := make([]byte, len(data))
+			copy(dataCopy, data)
+			treeInfos = append(treeInfos, p.NewDataBlob(dataCopy, encoding))
 
 			branchUUID = ""
 			data = []byte{}
@@ -398,27 +422,6 @@ func (h *HistoryStore) GetHistoryTreeContainingBranch(
 
 func (h *HistoryStore) GetHistoryBranchUtil() p.HistoryBranchUtil {
 	return h.HistoryBranchUtil
-}
-
-func convertHistoryNode(
-	message map[string]any,
-) p.InternalHistoryNode {
-	nodeID := message["node_id"].(int64)
-	prevTxnID := message["prev_txn_id"].(int64)
-	txnID := message["txn_id"].(int64)
-
-	var data []byte
-	var dataEncoding string
-	if _, ok := message["data"]; ok {
-		data = message["data"].([]byte)
-		dataEncoding = message["data_encoding"].(string)
-	}
-	return p.InternalHistoryNode{
-		NodeID:            nodeID,
-		PrevTransactionID: prevTxnID,
-		TransactionID:     txnID,
-		Events:            p.NewDataBlob(data, dataEncoding),
-	}
 }
 
 func convertTimeoutError(err error) error {

--- a/common/persistence/cassandra/history_store.go
+++ b/common/persistence/cassandra/history_store.go
@@ -1,6 +1,7 @@
 package cassandra
 
 import (
+	"bytes"
 	"context"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -175,10 +176,29 @@ func (h *HistoryStore) ReadHistoryBranch(
 	}
 
 	nodes := make([]p.InternalHistoryNode, 0, request.PageSize)
-	message := make(map[string]any)
-	for iter.MapScan(message) {
-		nodes = append(nodes, convertHistoryNode(message))
-		message = make(map[string]any)
+	var nodeID, prevTxnID, txnID int64
+	var data []byte
+	var dataEncoding string
+	if request.MetadataOnly {
+		// Column order must match v2templateReadHistoryNodeMetadata SELECT clause.
+		for iter.Scan(&nodeID, &prevTxnID, &txnID) {
+			nodes = append(nodes, p.InternalHistoryNode{
+				NodeID:            nodeID,
+				PrevTransactionID: prevTxnID,
+				TransactionID:     txnID,
+			})
+		}
+	} else {
+		// Column order must match v2templateReadHistoryNode / v2templateReadHistoryNodeReverse SELECT clause.
+		for iter.Scan(&nodeID, &prevTxnID, &txnID, &data, &dataEncoding) {
+			dataCopy := bytes.Clone(data)
+			nodes = append(nodes, p.InternalHistoryNode{
+				NodeID:            nodeID,
+				PrevTransactionID: prevTxnID,
+				TransactionID:     txnID,
+				Events:            p.NewDataBlob(dataCopy, dataEncoding),
+			})
+		}
 	}
 
 	if err := iter.Close(); err != nil {
@@ -319,10 +339,11 @@ func (h *HistoryStore) GetAllHistoryTreeBranches(
 	var encoding string
 
 	for iter.Scan(&treeUUID, &branchUUID, &data, &encoding) {
+		dataCopy := bytes.Clone(data)
 		branch := p.InternalHistoryBranchDetail{
 			TreeID:   treeUUID,
 			BranchID: branchUUID,
-			Data:     data,
+			Data:     dataCopy,
 			Encoding: encoding,
 		}
 		branches = append(branches, branch)
@@ -375,7 +396,8 @@ func (h *HistoryStore) GetHistoryTreeContainingBranch(
 		var data []byte
 		var encoding string
 		for iter.Scan(&branchUUID, &data, &encoding) {
-			treeInfos = append(treeInfos, p.NewDataBlob(data, encoding))
+			dataCopy := bytes.Clone(data)
+			treeInfos = append(treeInfos, p.NewDataBlob(dataCopy, encoding))
 
 			branchUUID = ""
 			data = []byte{}
@@ -398,27 +420,6 @@ func (h *HistoryStore) GetHistoryTreeContainingBranch(
 
 func (h *HistoryStore) GetHistoryBranchUtil() p.HistoryBranchUtil {
 	return h.HistoryBranchUtil
-}
-
-func convertHistoryNode(
-	message map[string]any,
-) p.InternalHistoryNode {
-	nodeID := message["node_id"].(int64)
-	prevTxnID := message["prev_txn_id"].(int64)
-	txnID := message["txn_id"].(int64)
-
-	var data []byte
-	var dataEncoding string
-	if _, ok := message["data"]; ok {
-		data = message["data"].([]byte)
-		dataEncoding = message["data_encoding"].(string)
-	}
-	return p.InternalHistoryNode{
-		NodeID:            nodeID,
-		PrevTransactionID: prevTxnID,
-		TransactionID:     txnID,
-		Events:            p.NewDataBlob(data, dataEncoding),
-	}
 }
 
 func convertTimeoutError(err error) error {

--- a/common/persistence/cassandra/matching_task_store_user_data.go
+++ b/common/persistence/cassandra/matching_task_store_user_data.go
@@ -138,28 +138,15 @@ func (d *userDataStore) ListTaskQueueUserDataEntries(ctx context.Context, reques
 	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter()
 
 	response := &p.InternalListTaskQueueUserDataEntriesResponse{}
-	row := make(map[string]any)
-	for iter.MapScan(row) {
-		taskQueue, err := getTypedFieldFromRow[string]("task_queue_name", row)
-		if err != nil {
-			return nil, err
-		}
-		data, err := getTypedFieldFromRow[[]byte]("data", row)
-		if err != nil {
-			return nil, err
-		}
-		dataEncoding, err := getTypedFieldFromRow[string]("data_encoding", row)
-		if err != nil {
-			return nil, err
-		}
-		version, err := getTypedFieldFromRow[int64]("version", row)
-		if err != nil {
-			return nil, err
-		}
-
-		response.Entries = append(response.Entries, p.InternalTaskQueueUserDataEntry{TaskQueue: taskQueue, Data: p.NewDataBlob(data, dataEncoding), Version: version})
-
-		row = make(map[string]any) // Reinitialize map as initialized fails on unmarshalling
+	var taskQueue string
+	var data []byte
+	var dataEncoding string
+	var version int64
+	// Column order must match templateListTaskQueueUserDataQuery SELECT clause.
+	for iter.Scan(&taskQueue, &data, &dataEncoding, &version) {
+		dataCopy := make([]byte, len(data))
+		copy(dataCopy, data)
+		response.Entries = append(response.Entries, p.InternalTaskQueueUserDataEntry{TaskQueue: taskQueue, Data: p.NewDataBlob(dataCopy, dataEncoding), Version: version})
 	}
 	if len(iter.PageState()) > 0 {
 		response.NextPageToken = iter.PageState()
@@ -176,23 +163,12 @@ func (d *userDataStore) GetTaskQueuesByBuildId(ctx context.Context, request *p.G
 	iter := query.PageSize(listTaskQueueNamesByBuildIdPageSize).Iter()
 
 	var taskQueues []string
-	row := make(map[string]any)
+	var taskQueue string
 
 	for {
-		for iter.MapScan(row) {
-			taskQueueRaw, ok := row["task_queue_name"]
-			if !ok {
-				return nil, newFieldNotFoundError("task_queue_name", row)
-			}
-			taskQueue, ok := taskQueueRaw.(string)
-			if !ok {
-				var stringType string
-				return nil, newPersistedTypeMismatchError("task_queue_name", stringType, taskQueueRaw, row)
-			}
-
+		// Column order must match templateListTaskQueueNamesByBuildIdQuery SELECT clause.
+		for iter.Scan(&taskQueue) {
 			taskQueues = append(taskQueues, taskQueue)
-
-			row = make(map[string]any) // Reinitialize map as initialized fails on unmarshalling
 		}
 		if len(iter.PageState()) == 0 {
 			break

--- a/common/persistence/cassandra/matching_task_store_user_data.go
+++ b/common/persistence/cassandra/matching_task_store_user_data.go
@@ -1,6 +1,7 @@
 package cassandra
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -138,28 +139,14 @@ func (d *userDataStore) ListTaskQueueUserDataEntries(ctx context.Context, reques
 	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter()
 
 	response := &p.InternalListTaskQueueUserDataEntriesResponse{}
-	row := make(map[string]any)
-	for iter.MapScan(row) {
-		taskQueue, err := getTypedFieldFromRow[string]("task_queue_name", row)
-		if err != nil {
-			return nil, err
-		}
-		data, err := getTypedFieldFromRow[[]byte]("data", row)
-		if err != nil {
-			return nil, err
-		}
-		dataEncoding, err := getTypedFieldFromRow[string]("data_encoding", row)
-		if err != nil {
-			return nil, err
-		}
-		version, err := getTypedFieldFromRow[int64]("version", row)
-		if err != nil {
-			return nil, err
-		}
-
-		response.Entries = append(response.Entries, p.InternalTaskQueueUserDataEntry{TaskQueue: taskQueue, Data: p.NewDataBlob(data, dataEncoding), Version: version})
-
-		row = make(map[string]any) // Reinitialize map as initialized fails on unmarshalling
+	var taskQueue string
+	var data []byte
+	var dataEncoding string
+	var version int64
+	// Column order must match templateListTaskQueueUserDataQuery SELECT clause.
+	for iter.Scan(&taskQueue, &data, &dataEncoding, &version) {
+		dataCopy := bytes.Clone(data)
+		response.Entries = append(response.Entries, p.InternalTaskQueueUserDataEntry{TaskQueue: taskQueue, Data: p.NewDataBlob(dataCopy, dataEncoding), Version: version})
 	}
 	if len(iter.PageState()) > 0 {
 		response.NextPageToken = iter.PageState()
@@ -176,23 +163,12 @@ func (d *userDataStore) GetTaskQueuesByBuildId(ctx context.Context, request *p.G
 	iter := query.PageSize(listTaskQueueNamesByBuildIdPageSize).Iter()
 
 	var taskQueues []string
-	row := make(map[string]any)
+	var taskQueue string
 
 	for {
-		for iter.MapScan(row) {
-			taskQueueRaw, ok := row["task_queue_name"]
-			if !ok {
-				return nil, newFieldNotFoundError("task_queue_name", row)
-			}
-			taskQueue, ok := taskQueueRaw.(string)
-			if !ok {
-				var stringType string
-				return nil, newPersistedTypeMismatchError("task_queue_name", stringType, taskQueueRaw, row)
-			}
-
+		// Column order must match templateListTaskQueueNamesByBuildIdQuery SELECT clause.
+		for iter.Scan(&taskQueue) {
 			taskQueues = append(taskQueues, taskQueue)
-
-			row = make(map[string]any) // Reinitialize map as initialized fails on unmarshalling
 		}
 		if len(iter.PageState()) == 0 {
 			break

--- a/common/persistence/cassandra/matching_task_store_v1.go
+++ b/common/persistence/cassandra/matching_task_store_v1.go
@@ -154,35 +154,17 @@ func (d *matchingTaskStoreV1) GetTasks(
 	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter()
 
 	response := &p.InternalGetTasksResponse{}
-	task := make(map[string]any)
-	for iter.MapScan(task) {
-		_, ok := task["task_id"]
-		if !ok { // no tasks, but static column record returned
+	var taskID *int64
+	var taskVal []byte
+	var encodingVal string
+	// Column order must match templateGetTasksQuery SELECT clause.
+	for iter.Scan(&taskID, &taskVal, &encodingVal) {
+		if taskID == nil { // no tasks, but static column record returned
 			continue
 		}
-
-		rawTask, ok := task["task"]
-		if !ok {
-			return nil, newFieldNotFoundError("task", task)
-		}
-		taskVal, ok := rawTask.([]byte)
-		if !ok {
-			var byteSliceType []byte
-			return nil, newPersistedTypeMismatchError("task", byteSliceType, rawTask, task)
-		}
-
-		rawEncoding, ok := task["task_encoding"]
-		if !ok {
-			return nil, newFieldNotFoundError("task_encoding", task)
-		}
-		encodingVal, ok := rawEncoding.(string)
-		if !ok {
-			var byteSliceType []byte
-			return nil, newPersistedTypeMismatchError("task_encoding", byteSliceType, rawEncoding, task)
-		}
-		response.Tasks = append(response.Tasks, p.NewDataBlob(taskVal, encodingVal))
-
-		task = make(map[string]any) // Reinitialize map as initialized fails on unmarshalling
+		dataCopy := make([]byte, len(taskVal))
+		copy(dataCopy, taskVal)
+		response.Tasks = append(response.Tasks, p.NewDataBlob(dataCopy, encodingVal))
 	}
 	if len(iter.PageState()) > 0 {
 		response.NextPageToken = iter.PageState()

--- a/common/persistence/cassandra/matching_task_store_v1.go
+++ b/common/persistence/cassandra/matching_task_store_v1.go
@@ -1,6 +1,7 @@
 package cassandra
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -154,35 +155,16 @@ func (d *matchingTaskStoreV1) GetTasks(
 	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter()
 
 	response := &p.InternalGetTasksResponse{}
-	task := make(map[string]any)
-	for iter.MapScan(task) {
-		_, ok := task["task_id"]
-		if !ok { // no tasks, but static column record returned
+	var taskID *int64
+	var taskVal []byte
+	var encodingVal string
+	// Column order must match templateGetTasksQuery SELECT clause.
+	for iter.Scan(&taskID, &taskVal, &encodingVal) {
+		if taskID == nil { // no tasks, but static column record returned
 			continue
 		}
-
-		rawTask, ok := task["task"]
-		if !ok {
-			return nil, newFieldNotFoundError("task", task)
-		}
-		taskVal, ok := rawTask.([]byte)
-		if !ok {
-			var byteSliceType []byte
-			return nil, newPersistedTypeMismatchError("task", byteSliceType, rawTask, task)
-		}
-
-		rawEncoding, ok := task["task_encoding"]
-		if !ok {
-			return nil, newFieldNotFoundError("task_encoding", task)
-		}
-		encodingVal, ok := rawEncoding.(string)
-		if !ok {
-			var byteSliceType []byte
-			return nil, newPersistedTypeMismatchError("task_encoding", byteSliceType, rawEncoding, task)
-		}
-		response.Tasks = append(response.Tasks, p.NewDataBlob(taskVal, encodingVal))
-
-		task = make(map[string]any) // Reinitialize map as initialized fails on unmarshalling
+		dataCopy := bytes.Clone(taskVal)
+		response.Tasks = append(response.Tasks, p.NewDataBlob(dataCopy, encodingVal))
 	}
 	if len(iter.PageState()) > 0 {
 		response.NextPageToken = iter.PageState()

--- a/common/persistence/cassandra/matching_task_store_v2.go
+++ b/common/persistence/cassandra/matching_task_store_v2.go
@@ -172,35 +172,17 @@ func (d *matchingTaskStoreV2) GetTasks(
 	iter := query.WithContext(ctx).PageSize(request.PageSize).PageState(request.NextPageToken).Iter()
 
 	response := &p.InternalGetTasksResponse{}
-	task := make(map[string]any)
-	for iter.MapScan(task) {
-		_, ok := task["task_id"]
-		if !ok { // no tasks, but static column record returned
+	var taskID *int64
+	var taskVal []byte
+	var encodingVal string
+	// Column order must match templateGetTasksQuery_v2 / templateGetTasksQuery_v2_limit SELECT clause.
+	for iter.Scan(&taskID, &taskVal, &encodingVal) {
+		if taskID == nil { // no tasks, but static column record returned
 			continue
 		}
-
-		rawTask, ok := task["task"]
-		if !ok {
-			return nil, newFieldNotFoundError("task", task)
-		}
-		taskVal, ok := rawTask.([]byte)
-		if !ok {
-			var byteSliceType []byte
-			return nil, newPersistedTypeMismatchError("task", byteSliceType, rawTask, task)
-		}
-
-		rawEncoding, ok := task["task_encoding"]
-		if !ok {
-			return nil, newFieldNotFoundError("task_encoding", task)
-		}
-		encodingVal, ok := rawEncoding.(string)
-		if !ok {
-			var byteSliceType []byte
-			return nil, newPersistedTypeMismatchError("task_encoding", byteSliceType, rawEncoding, task)
-		}
-		response.Tasks = append(response.Tasks, p.NewDataBlob(taskVal, encodingVal))
-
-		task = make(map[string]any) // Reinitialize map as initialized fails on unmarshalling
+		dataCopy := make([]byte, len(taskVal))
+		copy(dataCopy, taskVal)
+		response.Tasks = append(response.Tasks, p.NewDataBlob(dataCopy, encodingVal))
 	}
 	if len(iter.PageState()) > 0 {
 		response.NextPageToken = iter.PageState()

--- a/common/persistence/cassandra/matching_task_store_v2.go
+++ b/common/persistence/cassandra/matching_task_store_v2.go
@@ -1,6 +1,7 @@
 package cassandra
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -172,35 +173,16 @@ func (d *matchingTaskStoreV2) GetTasks(
 	iter := query.WithContext(ctx).PageSize(request.PageSize).PageState(request.NextPageToken).Iter()
 
 	response := &p.InternalGetTasksResponse{}
-	task := make(map[string]any)
-	for iter.MapScan(task) {
-		_, ok := task["task_id"]
-		if !ok { // no tasks, but static column record returned
+	var taskID *int64
+	var taskVal []byte
+	var encodingVal string
+	// Column order must match templateGetTasksQuery_v2 / templateGetTasksQuery_v2_limit SELECT clause.
+	for iter.Scan(&taskID, &taskVal, &encodingVal) {
+		if taskID == nil { // no tasks, but static column record returned
 			continue
 		}
-
-		rawTask, ok := task["task"]
-		if !ok {
-			return nil, newFieldNotFoundError("task", task)
-		}
-		taskVal, ok := rawTask.([]byte)
-		if !ok {
-			var byteSliceType []byte
-			return nil, newPersistedTypeMismatchError("task", byteSliceType, rawTask, task)
-		}
-
-		rawEncoding, ok := task["task_encoding"]
-		if !ok {
-			return nil, newFieldNotFoundError("task_encoding", task)
-		}
-		encodingVal, ok := rawEncoding.(string)
-		if !ok {
-			var byteSliceType []byte
-			return nil, newPersistedTypeMismatchError("task_encoding", byteSliceType, rawEncoding, task)
-		}
-		response.Tasks = append(response.Tasks, p.NewDataBlob(taskVal, encodingVal))
-
-		task = make(map[string]any) // Reinitialize map as initialized fails on unmarshalling
+		dataCopy := bytes.Clone(taskVal)
+		response.Tasks = append(response.Tasks, p.NewDataBlob(dataCopy, encodingVal))
 	}
 	if len(iter.PageState()) > 0 {
 		response.NextPageToken = iter.PageState()

--- a/common/persistence/cassandra/mutable_state_store.go
+++ b/common/persistence/cassandra/mutable_state_store.go
@@ -1060,28 +1060,28 @@ func (d *MutableStateStore) ListConcreteExecutions(
 	iter := query.PageSize(request.PageSize).PageState(request.PageToken).Iter()
 
 	response := &p.InternalListConcreteExecutionsResponse{}
-	result := make(map[string]any)
-	for iter.MapScan(result) {
-		if execution, ok := result["execution"]; ok {
-			executionBytes, ok := execution.([]byte)
-			if !ok {
-				return nil, newPersistedTypeMismatchError("execution", "", executionBytes, result)
-			}
-
-			if len(executionBytes) == 0 {
-				// current record has no value in execution column.
-				result = make(map[string]any)
-				continue
-			}
-
-			state, err := mutableStateFromRow(result)
-			if err != nil {
-				return nil, err
-			}
-			response.States = append(response.States, state)
+	var runID []byte
+	var execution []byte
+	var executionEncoding string
+	var executionState []byte
+	var executionStateEncoding string
+	var nextEventID int64
+	// Column order must match templateListWorkflowExecutionQuery SELECT clause.
+	for iter.Scan(&runID, &execution, &executionEncoding, &executionState, &executionStateEncoding, &nextEventID) {
+		if len(execution) == 0 {
+			continue
 		}
 
-		result = make(map[string]any)
+		execCopy := make([]byte, len(execution))
+		copy(execCopy, execution)
+		stateCopy := make([]byte, len(executionState))
+		copy(stateCopy, executionState)
+		state := &p.InternalWorkflowMutableState{
+			ExecutionInfo:  p.NewDataBlob(execCopy, executionEncoding),
+			ExecutionState: p.NewDataBlob(stateCopy, executionStateEncoding),
+			NextEventID:    nextEventID,
+		}
+		response.States = append(response.States, state)
 	}
 	if len(iter.PageState()) > 0 {
 		response.NextPageToken = iter.PageState()

--- a/common/persistence/cassandra/mutable_state_store.go
+++ b/common/persistence/cassandra/mutable_state_store.go
@@ -1,6 +1,7 @@
 package cassandra
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"time"
@@ -1060,28 +1061,26 @@ func (d *MutableStateStore) ListConcreteExecutions(
 	iter := query.PageSize(request.PageSize).PageState(request.PageToken).Iter()
 
 	response := &p.InternalListConcreteExecutionsResponse{}
-	result := make(map[string]any)
-	for iter.MapScan(result) {
-		if execution, ok := result["execution"]; ok {
-			executionBytes, ok := execution.([]byte)
-			if !ok {
-				return nil, newPersistedTypeMismatchError("execution", "", executionBytes, result)
-			}
-
-			if len(executionBytes) == 0 {
-				// current record has no value in execution column.
-				result = make(map[string]any)
-				continue
-			}
-
-			state, err := mutableStateFromRow(result)
-			if err != nil {
-				return nil, err
-			}
-			response.States = append(response.States, state)
+	var runID []byte
+	var execution []byte
+	var executionEncoding string
+	var executionState []byte
+	var executionStateEncoding string
+	var nextEventID int64
+	// Column order must match templateListWorkflowExecutionQuery SELECT clause.
+	for iter.Scan(&runID, &execution, &executionEncoding, &executionState, &executionStateEncoding, &nextEventID) {
+		if len(execution) == 0 {
+			continue
 		}
 
-		result = make(map[string]any)
+		execCopy := bytes.Clone(execution)
+		stateCopy := bytes.Clone(executionState)
+		state := &p.InternalWorkflowMutableState{
+			ExecutionInfo:  p.NewDataBlob(execCopy, executionEncoding),
+			ExecutionState: p.NewDataBlob(stateCopy, executionStateEncoding),
+			NextEventID:    nextEventID,
+		}
+		response.States = append(response.States, state)
 	}
 	if len(iter.PageState()) > 0 {
 		response.NextPageToken = iter.PageState()

--- a/common/persistence/cassandra/nexus_endpoint_store.go
+++ b/common/persistence/cassandra/nexus_endpoint_store.go
@@ -343,32 +343,19 @@ func (s *NexusEndpointStore) getTableVersion(ctx context.Context) (int64, error)
 func (s *NexusEndpointStore) getEndpointList(iter gocql.Iter) ([]p.InternalNexusEndpoint, error) {
 	var endpoints []p.InternalNexusEndpoint
 
-	row := make(map[string]any)
-	for iter.MapScan(row) {
-		id, err := getTypedFieldFromRow[any]("id", row)
-		if err != nil {
-			return nil, err
-		}
-		version, err := getTypedFieldFromRow[int64]("version", row)
-		if err != nil {
-			return nil, err
-		}
-		data, err := getTypedFieldFromRow[[]byte]("data", row)
-		if err != nil {
-			return nil, err
-		}
-		dataEncoding, err := getTypedFieldFromRow[string]("data_encoding", row)
-		if err != nil {
-			return nil, err
-		}
-
+	var id any
+	var data []byte
+	var dataEncoding string
+	var version int64
+	// Column order must match templateBaseListEndpointsQuery SELECT clause.
+	for iter.Scan(&id, &data, &dataEncoding, &version) {
+		dataCopy := make([]byte, len(data))
+		copy(dataCopy, data)
 		endpoints = append(endpoints, p.InternalNexusEndpoint{
 			ID:      gocql.UUIDToString(id),
 			Version: version,
-			Data:    p.NewDataBlob(data, dataEncoding),
+			Data:    p.NewDataBlob(dataCopy, dataEncoding),
 		})
-
-		row = make(map[string]any)
 	}
 
 	return endpoints, nil

--- a/common/persistence/cassandra/nexus_endpoint_store.go
+++ b/common/persistence/cassandra/nexus_endpoint_store.go
@@ -1,6 +1,7 @@
 package cassandra
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -343,32 +344,18 @@ func (s *NexusEndpointStore) getTableVersion(ctx context.Context) (int64, error)
 func (s *NexusEndpointStore) getEndpointList(iter gocql.Iter) ([]p.InternalNexusEndpoint, error) {
 	var endpoints []p.InternalNexusEndpoint
 
-	row := make(map[string]any)
-	for iter.MapScan(row) {
-		id, err := getTypedFieldFromRow[any]("id", row)
-		if err != nil {
-			return nil, err
-		}
-		version, err := getTypedFieldFromRow[int64]("version", row)
-		if err != nil {
-			return nil, err
-		}
-		data, err := getTypedFieldFromRow[[]byte]("data", row)
-		if err != nil {
-			return nil, err
-		}
-		dataEncoding, err := getTypedFieldFromRow[string]("data_encoding", row)
-		if err != nil {
-			return nil, err
-		}
-
+	var id any
+	var data []byte
+	var dataEncoding string
+	var version int64
+	// Column order must match templateBaseListEndpointsQuery SELECT clause.
+	for iter.Scan(&id, &data, &dataEncoding, &version) {
+		dataCopy := bytes.Clone(data)
 		endpoints = append(endpoints, p.InternalNexusEndpoint{
 			ID:      gocql.UUIDToString(id),
 			Version: version,
-			Data:    p.NewDataBlob(data, dataEncoding),
+			Data:    p.NewDataBlob(dataCopy, dataEncoding),
 		})
-
-		row = make(map[string]any)
 	}
 
 	return endpoints, nil

--- a/common/persistence/cassandra/queue_store.go
+++ b/common/persistence/cassandra/queue_store.go
@@ -138,11 +138,21 @@ func (q *QueueStore) ReadMessages(
 	iter := query.Iter()
 
 	var result []*persistence.QueueMessage
-	message := make(map[string]any)
-	for iter.MapScan(message) {
-		queueMessage := convertQueueMessage(message)
-		result = append(result, queueMessage)
-		message = make(map[string]any)
+	var id int64
+	var data []byte
+	var encoding string
+	// Column order must match templateGetMessagesQuery SELECT clause.
+	for iter.Scan(&id, &data, &encoding) {
+		if encoding == "" {
+			encoding = enumspb.ENCODING_TYPE_PROTO3.String()
+		}
+		dataCopy := make([]byte, len(data))
+		copy(dataCopy, data)
+		result = append(result, &persistence.QueueMessage{
+			ID:       id,
+			Data:     dataCopy,
+			Encoding: encoding,
+		})
 	}
 
 	if err := iter.Close(); err != nil {
@@ -169,11 +179,21 @@ func (q *QueueStore) ReadMessagesFromDLQ(
 	iter := query.PageSize(pageSize).PageState(pageToken).Iter()
 
 	var result []*persistence.QueueMessage
-	message := make(map[string]any)
-	for iter.MapScan(message) {
-		queueMessage := convertQueueMessage(message)
-		result = append(result, queueMessage)
-		message = make(map[string]any)
+	var id int64
+	var data []byte
+	var encoding string
+	// Column order must match templateGetMessagesFromDLQQuery SELECT clause.
+	for iter.Scan(&id, &data, &encoding) {
+		if encoding == "" {
+			encoding = enumspb.ENCODING_TYPE_PROTO3.String()
+		}
+		dataCopy := make([]byte, len(data))
+		copy(dataCopy, data)
+		result = append(result, &persistence.QueueMessage{
+			ID:       id,
+			Data:     dataCopy,
+			Encoding: encoding,
+		})
 	}
 
 	var nextPageToken []byte
@@ -365,23 +385,6 @@ func (q *QueueStore) initializeDLQMetadata(
 		return q.insertInitialQueueMetadataRecord(ctx, q.getDLQTypeFromQueueType(), blob)
 	}
 	return err
-}
-
-func convertQueueMessage(
-	message map[string]any,
-) *persistence.QueueMessage {
-
-	id := message["message_id"].(int64)
-	data := message["message_payload"].([]byte)
-	encoding := message["message_encoding"].(string)
-	if encoding == "" {
-		encoding = enumspb.ENCODING_TYPE_PROTO3.String()
-	}
-	return &persistence.QueueMessage{
-		ID:       id,
-		Data:     data,
-		Encoding: encoding,
-	}
 }
 
 func convertQueueMetadata(

--- a/common/persistence/cassandra/queue_store.go
+++ b/common/persistence/cassandra/queue_store.go
@@ -1,6 +1,7 @@
 package cassandra
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -138,11 +139,20 @@ func (q *QueueStore) ReadMessages(
 	iter := query.Iter()
 
 	var result []*persistence.QueueMessage
-	message := make(map[string]any)
-	for iter.MapScan(message) {
-		queueMessage := convertQueueMessage(message)
-		result = append(result, queueMessage)
-		message = make(map[string]any)
+	var id int64
+	var data []byte
+	var encoding string
+	// Column order must match templateGetMessagesQuery SELECT clause.
+	for iter.Scan(&id, &data, &encoding) {
+		if encoding == "" {
+			encoding = enumspb.ENCODING_TYPE_PROTO3.String()
+		}
+		dataCopy := bytes.Clone(data)
+		result = append(result, &persistence.QueueMessage{
+			ID:       id,
+			Data:     dataCopy,
+			Encoding: encoding,
+		})
 	}
 
 	if err := iter.Close(); err != nil {
@@ -169,11 +179,20 @@ func (q *QueueStore) ReadMessagesFromDLQ(
 	iter := query.PageSize(pageSize).PageState(pageToken).Iter()
 
 	var result []*persistence.QueueMessage
-	message := make(map[string]any)
-	for iter.MapScan(message) {
-		queueMessage := convertQueueMessage(message)
-		result = append(result, queueMessage)
-		message = make(map[string]any)
+	var id int64
+	var data []byte
+	var encoding string
+	// Column order must match templateGetMessagesFromDLQQuery SELECT clause.
+	for iter.Scan(&id, &data, &encoding) {
+		if encoding == "" {
+			encoding = enumspb.ENCODING_TYPE_PROTO3.String()
+		}
+		dataCopy := bytes.Clone(data)
+		result = append(result, &persistence.QueueMessage{
+			ID:       id,
+			Data:     dataCopy,
+			Encoding: encoding,
+		})
 	}
 
 	var nextPageToken []byte
@@ -365,23 +384,6 @@ func (q *QueueStore) initializeDLQMetadata(
 		return q.insertInitialQueueMetadataRecord(ctx, q.getDLQTypeFromQueueType(), blob)
 	}
 	return err
-}
-
-func convertQueueMessage(
-	message map[string]any,
-) *persistence.QueueMessage {
-
-	id := message["message_id"].(int64)
-	data := message["message_payload"].([]byte)
-	encoding := message["message_encoding"].(string)
-	if encoding == "" {
-		encoding = enumspb.ENCODING_TYPE_PROTO3.String()
-	}
-	return &persistence.QueueMessage{
-		ID:       id,
-		Data:     data,
-		Encoding: encoding,
-	}
 }
 
 func convertQueueMetadata(


### PR DESCRIPTION
Replace `iter.MapScan(message)` with `iter.Scan(&var1, &var2, ...)` across 7 Cassandra store files.

MapScan reads column values into a `map[string]any`, allocating a map header, per-column interface{} wrappers, and key strings for every row. Typed Scan reads directly into pre-declared local variables on the stack, eliminating per-row heap allocations.

Also adds defensive byte copies for all `[]byte` columns to guard against gocql internal buffer reuse (matches existing conventions in the codebase).

**Files changed:**
- `common/persistence/cassandra/history_store.go` — ReadHistoryBranch, GetAllHistoryTreeBranches, GetHistoryTreeContainingBranch
- `common/persistence/cassandra/matching_task_store_user_data.go` — ListTaskQueueUserDataEntries, GetTaskQueuesByBuildId
- `common/persistence/cassandra/matching_task_store_v1.go` — GetTasks
- `common/persistence/cassandra/matching_task_store_v2.go` — GetTasks
- `common/persistence/cassandra/mutable_state_store.go` — ListConcreteExecutions
- `common/persistence/cassandra/nexus_endpoint_store.go` — ListEndpoints
- `common/persistence/cassandra/queue_store.go` — ReadMessages, ReadMessagesFromDLQ

7 files changed, 119 insertions(+), 186 deletions(-)