### PR TITLE
Remove stale goroutine-leak ignores from leak regression test

### DIFF
--- a/tests/leakcheck/leak_test.go
+++ b/tests/leakcheck/leak_test.go
@@ -36,9 +36,6 @@ var goleakOpts = []goleak.Option{
 	goleak.IgnoreTopFunction("google.golang.org/grpc/internal/grpcsync.(*CallbackSerializer).run"),
 	goleak.IgnoreAnyFunction("google.golang.org/grpc.(*addrConn).resetTransportAndUnlock"),
 	goleak.IgnoreTopFunction("google.golang.org/grpc/internal/balancer/gracefulswitch.(*Balancer).updateSubConnState"),
-	goleak.IgnoreTopFunction("go.temporal.io/server/client/matching.(*partitionCache).Start.func1"),
-	goleak.IgnoreTopFunction("go.temporal.io/server/client/matching.watchMembershipForEviction"),
-	goleak.IgnoreTopFunction("go.temporal.io/server/client/history.watchMembershipForClose[...]"),
 	goleak.IgnoreTopFunction("go.temporal.io/server/common/membership.(*grpcResolver).listen"),
 
 	// TODO: worker-service and persistence goroutine leaks.


### PR DESCRIPTION
## What changed?
Remove three `goleak.IgnoreTopFunction` entries in `tests/leakcheck/leak_test.go` that point at functions which no longer exist:
- `matching.watchMembershipForEviction` and `matching.(*partitionCache).Start.func1` — #10816 gave the matching client a deterministic `Stop()`, removed both ignores, and confirmed both goroutines are 0 after teardown. #10844 (merged a day later) accidentally re-added them via rebase.
- `history.watchMembershipForClose[...]` — #10844 replaced this package-level watcher with a `Stop()`-driven `c.watchMembership` on a `goro.Handle`; the ignore should have been removed there but was left behind.

## Why?
The referenced goroutines are now stopped deterministically on cluster shutdown, so the ignores mask nothing and only invite confusion.

## How did you test it?
- [x] built
- [x] covered by existing tests
