### PR TITLE
Fix service pending request gauge cleanup

### DIFF
--- a/common/rpc/interceptor/concurrent_request_limit.go
+++ b/common/rpc/interceptor/concurrent_request_limit.go
@@ -179,7 +179,7 @@ func (ni *ConcurrentRequestLimitInterceptor) metricCounter(
 	return counter
 }
 
-func (c *pendingRequestCounter) add(token int, mh metrics.Handler) int32 {
+func (c *pendingRequestCounter) add(token int, mh metrics.Handler) {
 	c.Lock()
 	defer c.Unlock()
 
@@ -187,7 +187,6 @@ func (c *pendingRequestCounter) add(token int, mh metrics.Handler) int32 {
 	// emit a stale value last.
 	c.count += int32(token)
 	mh.Gauge(metrics.ServicePendingRequests.Name()).Record(float64(c.count))
-	return c.count
 }
 
 func (ni *ConcurrentRequestLimitInterceptor) getCounterKey(

--- a/common/rpc/interceptor/concurrent_request_limit.go
+++ b/common/rpc/interceptor/concurrent_request_limit.go
@@ -104,7 +104,10 @@ func (ni *ConcurrentRequestLimitInterceptor) Allow(
 
 	counter := ni.counter(namespaceName, methodName)
 	count := atomic.AddInt32(counter, int32(token))
-	cleanup := func() { atomic.AddInt32(counter, -int32(token)) }
+	cleanup := func() {
+		count := atomic.AddInt32(counter, -int32(token))
+		mh.Gauge(metrics.ServicePendingRequests.Name()).Record(float64(count))
+	}
 
 	mh.Gauge(metrics.ServicePendingRequests.Name()).Record(float64(count))
 

--- a/common/rpc/interceptor/concurrent_request_limit.go
+++ b/common/rpc/interceptor/concurrent_request_limit.go
@@ -3,7 +3,6 @@ package interceptor
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
@@ -28,7 +27,12 @@ type (
 		tokens map[string]int
 
 		sync.Mutex
-		activeTokensCount map[string]*int32
+		activeTokensCount map[string]*pendingRequestCounter
+	}
+
+	pendingRequestCounter struct {
+		sync.Mutex
+		count int32
 	}
 )
 
@@ -62,7 +66,7 @@ func NewConcurrentRequestLimitInterceptor(
 			log.With(logger, tag.ComponentLongPollHandler, tag.ScopeNamespace),
 		),
 		tokens:            tokens,
-		activeTokensCount: make(map[string]*int32),
+		activeTokensCount: make(map[string]*pendingRequestCounter),
 	}
 }
 
@@ -103,13 +107,8 @@ func (ni *ConcurrentRequestLimitInterceptor) Allow(
 	}
 
 	counter := ni.counter(namespaceName, methodName)
-	count := atomic.AddInt32(counter, int32(token))
-	cleanup := func() {
-		count := atomic.AddInt32(counter, -int32(token))
-		mh.Gauge(metrics.ServicePendingRequests.Name()).Record(float64(count))
-	}
-
-	mh.Gauge(metrics.ServicePendingRequests.Name()).Record(float64(count))
+	count := counter.add(token, mh)
+	cleanup := func() { counter.add(-token, mh) }
 
 	// frontend.namespaceCount is applied per poller type temporarily to prevent
 	// one poller type to take all token waiting in the long poll.
@@ -122,7 +121,7 @@ func (ni *ConcurrentRequestLimitInterceptor) Allow(
 func (ni *ConcurrentRequestLimitInterceptor) counter(
 	namespace namespace.Name,
 	methodName string,
-) *int32 {
+) *pendingRequestCounter {
 	key := ni.getTokenKey(namespace, methodName)
 
 	ni.Lock()
@@ -130,10 +129,21 @@ func (ni *ConcurrentRequestLimitInterceptor) counter(
 
 	counter, ok := ni.activeTokensCount[key]
 	if !ok {
-		counter = new(int32)
+		counter = new(pendingRequestCounter)
 		ni.activeTokensCount[key] = counter
 	}
 	return counter
+}
+
+func (c *pendingRequestCounter) add(token int, mh metrics.Handler) int32 {
+	c.Lock()
+	defer c.Unlock()
+
+	// Keep the transition and recording ordered so concurrent updates cannot
+	// emit a stale value last.
+	c.count += int32(token)
+	mh.Gauge(metrics.ServicePendingRequests.Name()).Record(float64(c.count))
+	return c.count
 }
 
 func (ni *ConcurrentRequestLimitInterceptor) getTokenKey(

--- a/common/rpc/interceptor/concurrent_request_limit.go
+++ b/common/rpc/interceptor/concurrent_request_limit.go
@@ -3,10 +3,12 @@ package interceptor
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/common/api"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -27,7 +29,8 @@ type (
 		tokens map[string]int
 
 		sync.Mutex
-		activeTokensCount map[string]*pendingRequestCounter
+		activeTokensCount     map[string]*int32
+		pendingRequestMetrics map[string]*pendingRequestCounter
 	}
 
 	pendingRequestCounter struct {
@@ -65,8 +68,9 @@ func NewConcurrentRequestLimitInterceptor(
 			},
 			log.With(logger, tag.ComponentLongPollHandler, tag.ScopeNamespace),
 		),
-		tokens:            tokens,
-		activeTokensCount: make(map[string]*pendingRequestCounter),
+		tokens:                tokens,
+		activeTokensCount:     make(map[string]*int32),
+		pendingRequestMetrics: make(map[string]*pendingRequestCounter),
 	}
 }
 
@@ -93,6 +97,24 @@ func (ni *ConcurrentRequestLimitInterceptor) Allow(
 	mh metrics.Handler,
 	req any,
 ) (func(), error) {
+	return ni.AllowWithMetricKey(
+		namespaceName,
+		methodName,
+		telemetryUnaryOverrideOperationTag(methodName, api.MethodName(methodName), req),
+		mh,
+		req,
+	)
+}
+
+// AllowWithMetricKey applies quota accounting by methodName while recording
+// pending requests under the operation-tag identity in metricKey.
+func (ni *ConcurrentRequestLimitInterceptor) AllowWithMetricKey(
+	namespaceName namespace.Name,
+	methodName string,
+	metricKey string,
+	mh metrics.Handler,
+	req any,
+) (func(), error) {
 	// token will default to 0
 	token := ni.tokens[methodName]
 
@@ -106,9 +128,14 @@ func (ni *ConcurrentRequestLimitInterceptor) Allow(
 		return func() {}, nil
 	}
 
-	counter := ni.counter(namespaceName, methodName)
-	count := counter.add(token, mh)
-	cleanup := func() { counter.add(-token, mh) }
+	tokenCounter := ni.counter(namespaceName, methodName)
+	count := atomic.AddInt32(tokenCounter, int32(token))
+	metricCounter := ni.metricCounter(namespaceName, metricKey)
+	metricCounter.add(token, mh)
+	cleanup := func() {
+		atomic.AddInt32(tokenCounter, -int32(token))
+		metricCounter.add(-token, mh)
+	}
 
 	// frontend.namespaceCount is applied per poller type temporarily to prevent
 	// one poller type to take all token waiting in the long poll.
@@ -121,16 +148,33 @@ func (ni *ConcurrentRequestLimitInterceptor) Allow(
 func (ni *ConcurrentRequestLimitInterceptor) counter(
 	namespace namespace.Name,
 	methodName string,
-) *pendingRequestCounter {
-	key := ni.getTokenKey(namespace, methodName)
+) *int32 {
+	key := ni.getCounterKey(namespace, methodName)
 
 	ni.Lock()
 	defer ni.Unlock()
 
 	counter, ok := ni.activeTokensCount[key]
 	if !ok {
-		counter = new(pendingRequestCounter)
+		counter = new(int32)
 		ni.activeTokensCount[key] = counter
+	}
+	return counter
+}
+
+func (ni *ConcurrentRequestLimitInterceptor) metricCounter(
+	namespace namespace.Name,
+	metricKey string,
+) *pendingRequestCounter {
+	key := ni.getCounterKey(namespace, metricKey)
+
+	ni.Lock()
+	defer ni.Unlock()
+
+	counter, ok := ni.pendingRequestMetrics[key]
+	if !ok {
+		counter = new(pendingRequestCounter)
+		ni.pendingRequestMetrics[key] = counter
 	}
 	return counter
 }
@@ -146,9 +190,9 @@ func (c *pendingRequestCounter) add(token int, mh metrics.Handler) int32 {
 	return c.count
 }
 
-func (ni *ConcurrentRequestLimitInterceptor) getTokenKey(
-	namespace namespace.Name,
-	methodName string,
+func (ni *ConcurrentRequestLimitInterceptor) getCounterKey(
+	namespaceName namespace.Name,
+	key string,
 ) string {
-	return namespace.String() + "/" + methodName
+	return namespaceName.String() + "/" + key
 }

--- a/common/rpc/interceptor/concurrent_request_limit_test.go
+++ b/common/rpc/interceptor/concurrent_request_limit_test.go
@@ -2,7 +2,9 @@ package interceptor
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,9 +16,12 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/quotas/calculator"
 	"go.temporal.io/server/common/quotas/quotastest"
+	"go.temporal.io/server/common/testing/await"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
 )
+
+const pendingRequestLimitTestMethodName = "/temporal.api.workflowservice.v1.WorkflowService/PollWorkflowTaskQueue"
 
 type nsCountLimitTestCase struct {
 	// name of the test case
@@ -145,18 +150,6 @@ func TestNamespaceCountLimitInterceptor_Intercept(t *testing.T) {
 func TestConcurrentRequestLimitInterceptor_AllowRecordsPendingRequestsOnCleanup(t *testing.T) {
 	t.Parallel()
 
-	const methodName = "/temporal.api.workflowservice.v1.WorkflowService/PollWorkflowTaskQueue"
-	newInterceptor := func() *ConcurrentRequestLimitInterceptor {
-		return NewConcurrentRequestLimitInterceptor(
-			nil,
-			quotastest.NewFakeMemberCounter(1),
-			log.NewNoopLogger(),
-			dynamicconfig.GetIntPropertyFnFilteredByNamespace(1),
-			dynamicconfig.GetIntPropertyFnFilteredByNamespace(0),
-			map[string]int{methodName: 1},
-		)
-	}
-
 	t.Run("admitted request", func(t *testing.T) {
 		t.Parallel()
 
@@ -164,9 +157,9 @@ func TestConcurrentRequestLimitInterceptor_AllowRecordsPendingRequestsOnCleanup(
 		capture := metricsHandler.StartCapture()
 		defer metricsHandler.StopCapture(capture)
 
-		cleanup, err := newInterceptor().Allow(
+		cleanup, err := newConcurrentRequestLimitInterceptorForTest(1).Allow(
 			namespace.Name("test-namespace"),
-			methodName,
+			pendingRequestLimitTestMethodName,
 			metricsHandler,
 			nil,
 		)
@@ -183,11 +176,11 @@ func TestConcurrentRequestLimitInterceptor_AllowRecordsPendingRequestsOnCleanup(
 		metricsHandler := metricstest.NewCaptureHandler()
 		capture := metricsHandler.StartCapture()
 		defer metricsHandler.StopCapture(capture)
-		interceptor := newInterceptor()
+		interceptor := newConcurrentRequestLimitInterceptorForTest(1)
 
 		admittedCleanup, err := interceptor.Allow(
 			namespace.Name("test-namespace"),
-			methodName,
+			pendingRequestLimitTestMethodName,
 			metricsHandler,
 			nil,
 		)
@@ -195,7 +188,7 @@ func TestConcurrentRequestLimitInterceptor_AllowRecordsPendingRequestsOnCleanup(
 
 		rejectedCleanup, err := interceptor.Allow(
 			namespace.Name("test-namespace"),
-			methodName,
+			pendingRequestLimitTestMethodName,
 			metricsHandler,
 			nil,
 		)
@@ -209,6 +202,59 @@ func TestConcurrentRequestLimitInterceptor_AllowRecordsPendingRequestsOnCleanup(
 	})
 }
 
+func TestPendingRequestCounter_AddSerializesRecordings(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name         string
+		initialCount int32
+		token        int
+		expected     []float64
+	}{
+		{name: "admissions", token: 1, expected: []float64{1, 2}},
+		{name: "cleanups", initialCount: 2, token: -1, expected: []float64{1, 0}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			captureHandler := metricstest.NewCaptureHandler()
+			capture := captureHandler.StartCapture()
+			defer captureHandler.StopCapture(capture)
+			metricsHandler := &blockingMetricsHandler{Handler: captureHandler}
+			counter := pendingRequestCounter{count: tc.initialCount}
+
+			blocked, release := metricsHandler.blockNextPendingRequestRecording()
+			defer release()
+
+			firstDone := runAsync(func() { counter.add(tc.token, metricsHandler) })
+			<-blocked
+			secondDone := runAsync(func() { counter.add(tc.token, metricsHandler) })
+
+			require.Never(t, func() bool {
+				return isClosed(secondDone)
+			}, 100*time.Millisecond, 10*time.Millisecond)
+
+			release()
+			await.RequireTrue(t, func() bool {
+				return isClosed(firstDone) && isClosed(secondDone)
+			}, time.Second, 10*time.Millisecond)
+
+			requirePendingRequestRecordings(t, capture, tc.expected...)
+		})
+	}
+}
+
+func newConcurrentRequestLimitInterceptorForTest(limit int) *ConcurrentRequestLimitInterceptor {
+	return NewConcurrentRequestLimitInterceptor(
+		nil,
+		quotastest.NewFakeMemberCounter(1),
+		log.NewNoopLogger(),
+		dynamicconfig.GetIntPropertyFnFilteredByNamespace(limit),
+		dynamicconfig.GetIntPropertyFnFilteredByNamespace(0),
+		map[string]int{pendingRequestLimitTestMethodName: 1},
+	)
+}
+
 func requirePendingRequestRecordings(t *testing.T, capture *metricstest.Capture, expected ...float64) {
 	t.Helper()
 
@@ -217,6 +263,68 @@ func requirePendingRequestRecordings(t *testing.T, capture *metricstest.Capture,
 	for i, expectedValue := range expected {
 		require.InDelta(t, expectedValue, recordings[i].Value, 0)
 	}
+}
+
+type blockingMetricsHandler struct {
+	metrics.Handler
+
+	mu        sync.Mutex
+	blockNext bool
+	blocked   chan struct{}
+	release   chan struct{}
+}
+
+func (h *blockingMetricsHandler) blockNextPendingRequestRecording() (<-chan struct{}, func()) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	blocked := make(chan struct{})
+	release := make(chan struct{})
+	h.blockNext = true
+	h.blocked = blocked
+	h.release = release
+
+	return blocked, sync.OnceFunc(func() { close(release) })
+}
+
+func (h *blockingMetricsHandler) Gauge(name string) metrics.GaugeIface {
+	gauge := h.Handler.Gauge(name)
+	if name != metrics.ServicePendingRequests.Name() {
+		return gauge
+	}
+
+	return metrics.GaugeFunc(func(value float64, tags ...metrics.Tag) {
+		h.mu.Lock()
+		block := h.blockNext
+		blocked := h.blocked
+		release := h.release
+		h.blockNext = false
+		h.mu.Unlock()
+
+		if block {
+			close(blocked)
+			<-release
+		}
+		gauge.Record(value, tags...)
+	})
+}
+
+func isClosed(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}
+
+func runAsync(f func()) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		f()
+	}()
+	return done
 }
 
 // run the test case by simulating a bunch of blocked pollers, sending a final request, and verifying that it is either

--- a/common/rpc/interceptor/concurrent_request_limit_test.go
+++ b/common/rpc/interceptor/concurrent_request_limit_test.go
@@ -5,9 +5,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/quotas/calculator"
 	"go.temporal.io/server/common/quotas/quotastest"
@@ -136,6 +139,83 @@ func TestNamespaceCountLimitInterceptor_Intercept(t *testing.T) {
 			t.Parallel()
 			tc.run(t)
 		})
+	}
+}
+
+func TestConcurrentRequestLimitInterceptor_AllowRecordsPendingRequestsOnCleanup(t *testing.T) {
+	t.Parallel()
+
+	const methodName = "/temporal.api.workflowservice.v1.WorkflowService/PollWorkflowTaskQueue"
+	newInterceptor := func() *ConcurrentRequestLimitInterceptor {
+		return NewConcurrentRequestLimitInterceptor(
+			nil,
+			quotastest.NewFakeMemberCounter(1),
+			log.NewNoopLogger(),
+			dynamicconfig.GetIntPropertyFnFilteredByNamespace(1),
+			dynamicconfig.GetIntPropertyFnFilteredByNamespace(0),
+			map[string]int{methodName: 1},
+		)
+	}
+
+	t.Run("admitted request", func(t *testing.T) {
+		t.Parallel()
+
+		metricsHandler := metricstest.NewCaptureHandler()
+		capture := metricsHandler.StartCapture()
+		defer metricsHandler.StopCapture(capture)
+
+		cleanup, err := newInterceptor().Allow(
+			namespace.Name("test-namespace"),
+			methodName,
+			metricsHandler,
+			nil,
+		)
+		require.NoError(t, err)
+
+		cleanup()
+
+		requirePendingRequestRecordings(t, capture, 1, 0)
+	})
+
+	t.Run("rejected request", func(t *testing.T) {
+		t.Parallel()
+
+		metricsHandler := metricstest.NewCaptureHandler()
+		capture := metricsHandler.StartCapture()
+		defer metricsHandler.StopCapture(capture)
+		interceptor := newInterceptor()
+
+		admittedCleanup, err := interceptor.Allow(
+			namespace.Name("test-namespace"),
+			methodName,
+			metricsHandler,
+			nil,
+		)
+		require.NoError(t, err)
+
+		rejectedCleanup, err := interceptor.Allow(
+			namespace.Name("test-namespace"),
+			methodName,
+			metricsHandler,
+			nil,
+		)
+		require.ErrorIs(t, err, ErrNamespaceCountLimitServerBusy)
+
+		rejectedCleanup()
+		requirePendingRequestRecordings(t, capture, 1, 2, 1)
+
+		admittedCleanup()
+		requirePendingRequestRecordings(t, capture, 1, 2, 1, 0)
+	})
+}
+
+func requirePendingRequestRecordings(t *testing.T, capture *metricstest.Capture, expected ...float64) {
+	t.Helper()
+
+	recordings := capture.Snapshot()[metrics.ServicePendingRequests.Name()]
+	require.Len(t, recordings, len(expected))
+	for i, expectedValue := range expected {
+		require.InDelta(t, expectedValue, recordings[i].Value, 0)
 	}
 }
 

--- a/common/rpc/interceptor/concurrent_request_limit_test.go
+++ b/common/rpc/interceptor/concurrent_request_limit_test.go
@@ -202,6 +202,34 @@ func TestConcurrentRequestLimitInterceptor_AllowRecordsPendingRequestsOnCleanup(
 	})
 }
 
+func TestConcurrentRequestLimitInterceptor_AllowUsesEmittedOperationMetricKey(t *testing.T) {
+	t.Parallel()
+
+	const methodName = "/temporal.api.workflowservice.v1.WorkflowService/GetWorkflowExecutionHistory"
+	interceptor := newConcurrentRequestLimitInterceptorWithTokensForTest(1, map[string]int{
+		methodName: 1,
+	})
+	metricsHandler := metricstest.NewCaptureHandler()
+	capture := metricsHandler.StartCapture()
+	defer metricsHandler.StopCapture(capture)
+
+	cleanup, err := interceptor.Allow(
+		namespace.Name("test-namespace"),
+		methodName,
+		metricsHandler,
+		&workflowservice.GetWorkflowExecutionHistoryRequest{WaitNewEvent: true},
+	)
+	require.NoError(t, err)
+	cleanup()
+
+	require.Contains(
+		t,
+		interceptor.pendingRequestMetrics,
+		interceptor.getCounterKey(namespace.Name("test-namespace"), metrics.FrontendPollWorkflowExecutionHistoryScope),
+	)
+	requirePendingRequestRecordings(t, capture, 1, 0)
+}
+
 func TestPendingRequestCounter_AddSerializesRecordings(t *testing.T) {
 	t.Parallel()
 
@@ -244,14 +272,103 @@ func TestPendingRequestCounter_AddSerializesRecordings(t *testing.T) {
 	}
 }
 
+func TestConcurrentRequestLimitInterceptor_AllowWithMetricKeyTracksNexusSeries(t *testing.T) {
+	t.Parallel()
+
+	const (
+		endpointAPIName  = "/temporal.api.nexusservice.v1.NexusService/DispatchByEndpoint"
+		namespaceAPIName = "/temporal.api.nexusservice.v1.NexusService/DispatchByNamespaceAndTaskQueue"
+		startMetricKey   = "StartNexusOperation"
+		cancelMetricKey  = "CancelNexusOperation"
+	)
+
+	t.Run("shared series across limiter buckets", func(t *testing.T) {
+		t.Parallel()
+
+		captureHandler := metricstest.NewCaptureHandler()
+		capture := captureHandler.StartCapture()
+		defer captureHandler.StopCapture(capture)
+		metricsHandler := captureHandler.WithTags(metrics.OperationTag(startMetricKey))
+		interceptor := newConcurrentRequestLimitInterceptorWithTokensForTest(2, map[string]int{
+			endpointAPIName:  1,
+			namespaceAPIName: 1,
+		})
+
+		firstCleanup, err := interceptor.AllowWithMetricKey(
+			namespace.Name("test-namespace"),
+			endpointAPIName,
+			startMetricKey,
+			metricsHandler,
+			nil,
+		)
+		require.NoError(t, err)
+		secondCleanup, err := interceptor.AllowWithMetricKey(
+			namespace.Name("test-namespace"),
+			namespaceAPIName,
+			startMetricKey,
+			metricsHandler,
+			nil,
+		)
+		require.NoError(t, err)
+
+		firstCleanup()
+		secondCleanup()
+		requirePendingRequestRecordings(t, capture, 1, 2, 1, 0)
+	})
+
+	t.Run("separate operation series in one limiter bucket", func(t *testing.T) {
+		t.Parallel()
+
+		captureHandler := metricstest.NewCaptureHandler()
+		capture := captureHandler.StartCapture()
+		defer captureHandler.StopCapture(capture)
+		startMetricsHandler := captureHandler.WithTags(metrics.OperationTag(startMetricKey))
+		cancelMetricsHandler := captureHandler.WithTags(metrics.OperationTag(cancelMetricKey))
+		interceptor := newConcurrentRequestLimitInterceptorWithTokensForTest(2, map[string]int{
+			endpointAPIName: 1,
+		})
+
+		startCleanup, err := interceptor.AllowWithMetricKey(
+			namespace.Name("test-namespace"),
+			endpointAPIName,
+			startMetricKey,
+			startMetricsHandler,
+			nil,
+		)
+		require.NoError(t, err)
+		cancelCleanup, err := interceptor.AllowWithMetricKey(
+			namespace.Name("test-namespace"),
+			endpointAPIName,
+			cancelMetricKey,
+			cancelMetricsHandler,
+			nil,
+		)
+		require.NoError(t, err)
+
+		startCleanup()
+		cancelCleanup()
+		requirePendingRequestRecordingsForOperation(t, capture, startMetricKey, 1, 0)
+		requirePendingRequestRecordingsForOperation(t, capture, cancelMetricKey, 1, 0)
+	})
+}
+
 func newConcurrentRequestLimitInterceptorForTest(limit int) *ConcurrentRequestLimitInterceptor {
+	return newConcurrentRequestLimitInterceptorWithTokensForTest(limit, map[string]int{
+		pendingRequestLimitTestMethodName: 1,
+	})
+}
+
+func newConcurrentRequestLimitInterceptorWithTokensForTest(
+	limit int,
+	tokens map[string]int,
+) *ConcurrentRequestLimitInterceptor {
 	return NewConcurrentRequestLimitInterceptor(
 		nil,
 		quotastest.NewFakeMemberCounter(1),
 		log.NewNoopLogger(),
 		dynamicconfig.GetIntPropertyFnFilteredByNamespace(limit),
 		dynamicconfig.GetIntPropertyFnFilteredByNamespace(0),
-		map[string]int{pendingRequestLimitTestMethodName: 1},
+		tokens,
 	)
 }
 
@@ -259,6 +376,26 @@ func requirePendingRequestRecordings(t *testing.T, capture *metricstest.Capture,
 	t.Helper()
 
 	recordings := capture.Snapshot()[metrics.ServicePendingRequests.Name()]
+	require.Len(t, recordings, len(expected))
+	for i, expectedValue := range expected {
+		require.InDelta(t, expectedValue, recordings[i].Value, 0)
+	}
+}
+
+func requirePendingRequestRecordingsForOperation(
+	t *testing.T,
+	capture *metricstest.Capture,
+	operation string,
+	expected ...float64,
+) {
+	t.Helper()
+
+	var recordings []*metricstest.CapturedRecording
+	for _, recording := range capture.Snapshot()[metrics.ServicePendingRequests.Name()] {
+		if recording.Tags[metrics.OperationTagName] == operation {
+			recordings = append(recordings, recording)
+		}
+	}
 	require.Len(t, recordings, len(expected))
 	for i, expectedValue := range expected {
 		require.InDelta(t, expectedValue, recordings[i].Value, 0)

--- a/service/frontend/nexus_completion_http_handler.go
+++ b/service/frontend/nexus_completion_http_handler.go
@@ -577,7 +577,13 @@ func (c *requestContext) interceptRequest(ctx context.Context, request *nexusrpc
 		}
 	})
 
-	cleanup, err := c.NamespaceConcurrencyLimitInterceptor.Allow(c.namespace.Name(), nexusCompletionAPIName, c.metricsHandlerForInterceptors, request)
+	cleanup, err := c.NamespaceConcurrencyLimitInterceptor.AllowWithMetricKey(
+		c.namespace.Name(),
+		nexusCompletionAPIName,
+		nexusCompletionMethodNameForMetrics,
+		c.metricsHandlerForInterceptors,
+		request,
+	)
 	c.cleanupFunctions = append(c.cleanupFunctions, func(error) { cleanup() })
 	if err != nil {
 		c.outcomeTag = metrics.OutcomeTag("namespace_concurrency_limited")

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -222,9 +222,10 @@ func (c *operationContext) interceptRequest(
 		}
 	})
 
-	cleanup, err := c.namespaceConcurrencyLimitInterceptor.Allow(
+	cleanup, err := c.namespaceConcurrencyLimitInterceptor.AllowWithMetricKey(
 		c.namespace.Name(),
 		c.apiName,
+		c.method,
 		c.metricsHandlerForInterceptors,
 		request,
 	)


### PR DESCRIPTION
## What changed
- record `ServicePendingRequests` after request cleanup as well as admission
- keep pending-request metric updates ordered by emitted operation series when limiter buckets differ
- add regression coverage for completion, rejection, concurrent updates, and Nexus operation series

## Validation
- `go test -tags test_dep ./common/rpc/interceptor`
- `go test -tags test_dep ./service/frontend -run TestNexus`
- `go test -tags disable_grpc_modules,test_dep ./common/rpc/... -count=1`
- `make lint-code`