### PR TITLE
Hot fix for cluster removal on global namespace

### DIFF
--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -1289,7 +1289,7 @@ func (adh *AdminHandler) RemoveRemoteCluster(
 ) (_ *adminservice.RemoveRemoteClusterResponse, retError error) {
 	defer log.CapturePanic(adh.logger, &retError)
 
-	if err := validateClusterNotInUseByNamespaces(adh.namespaceRegistry, request.GetClusterName()); err != nil {
+	if err := validateClusterNotInUseByNamespaces(adh.namespaceRegistry, adh.clusterMetadata.GetCurrentClusterName(), request.GetClusterName()); err != nil {
 		return nil, err
 	}
 

--- a/service/frontend/admin_handler_test.go
+++ b/service/frontend/admin_handler_test.go
@@ -96,6 +96,8 @@ type (
 		namespaceID    namespace.ID
 		namespaceEntry *namespace.Namespace
 
+		currentClusterName string
+
 		handler *AdminHandler
 	}
 )
@@ -191,7 +193,8 @@ func (s *adminHandlerSuite) SetupTest() {
 		tasks.NewDefaultTaskCategoryRegistry(),
 		s.mockResource.GetMatchingClient(),
 	}
-	s.mockMetadata.EXPECT().GetCurrentClusterName().Return(uuid.NewString()).AnyTimes()
+	s.currentClusterName = "current-cluster"
+	s.mockMetadata.EXPECT().GetCurrentClusterName().Return(s.currentClusterName).AnyTimes()
 	s.mockExecutionMgr.EXPECT().GetName().Return("mock-execution-manager").AnyTimes()
 	s.mockVisibilityMgr.EXPECT().GetStoreNames().Return([]string{"mock-vis-store"})
 
@@ -547,12 +550,15 @@ func (s *adminHandlerSuite) Test_RemoveRemoteCluster_Error() {
 
 func (s *adminHandlerSuite) Test_RemoveRemoteCluster_BlockedByGlobalNamespace() {
 	var clusterName = "cluster"
+	// The namespace lists both the current cluster and the cluster being
+	// removed, so removing clusterName would sever a link the current cluster
+	// relies on -> blocked.
 	globalNS := namespace.NewGlobalNamespaceForTest(
 		&persistencespb.NamespaceInfo{Name: "global-ns"},
 		nil,
 		&persistencespb.NamespaceReplicationConfig{
-			ActiveClusterName: "other",
-			Clusters:          []string{"other", clusterName},
+			ActiveClusterName: s.currentClusterName,
+			Clusters:          []string{s.currentClusterName, clusterName},
 		},
 		1,
 	)
@@ -562,6 +568,60 @@ func (s *adminHandlerSuite) Test_RemoveRemoteCluster_BlockedByGlobalNamespace() 
 	var failedPrecondition *serviceerror.FailedPrecondition
 	s.Require().ErrorAs(err, &failedPrecondition)
 	s.Contains(err.Error(), "global-ns")
+}
+
+// Test_RemoveRemoteCluster_OrphanedNamespaceDoesNotBlock covers the case that
+// motivated adding the current-cluster membership check: the local registry
+// holds a stale copy of a global namespace that references clusterName but that
+// the current cluster is no longer a member of (e.g. left behind after a
+// namespace migration re-homed the namespace). Removing clusterName cannot
+// strand any replication the current cluster performs, so it must be allowed.
+func (s *adminHandlerSuite) Test_RemoveRemoteCluster_OrphanedNamespaceDoesNotBlock() {
+	var clusterName = "cluster"
+	orphanedNS := namespace.NewGlobalNamespaceForTest(
+		&persistencespb.NamespaceInfo{Name: "orphaned-ns"},
+		nil,
+		&persistencespb.NamespaceReplicationConfig{
+			ActiveClusterName: "other",
+			// References clusterName but NOT s.currentClusterName.
+			Clusters: []string{"other", clusterName},
+		},
+		1,
+	)
+	s.mockNamespaceCache.EXPECT().GetAllNamespaces().Return([]*namespace.Namespace{orphanedNS})
+	s.mockClusterMetadataManager.EXPECT().DeleteClusterMetadata(
+		gomock.Any(),
+		&persistence.DeleteClusterMetadataRequest{ClusterName: clusterName},
+	).Return(nil)
+
+	_, err := s.handler.RemoveRemoteCluster(context.Background(), &adminservice.RemoveRemoteClusterRequest{ClusterName: clusterName})
+	s.NoError(err)
+}
+
+// Test_RemoveRemoteCluster_UnrelatedNamespaceDoesNotBlock covers the other half
+// of the conjunction: the current cluster participates in a multi-cluster
+// namespace, but that namespace does not involve the cluster being removed, so
+// removing it endangers nothing.
+func (s *adminHandlerSuite) Test_RemoveRemoteCluster_UnrelatedNamespaceDoesNotBlock() {
+	var clusterName = "cluster"
+	unrelatedNS := namespace.NewGlobalNamespaceForTest(
+		&persistencespb.NamespaceInfo{Name: "unrelated-ns"},
+		nil,
+		&persistencespb.NamespaceReplicationConfig{
+			ActiveClusterName: s.currentClusterName,
+			// Includes the current cluster but NOT clusterName.
+			Clusters: []string{s.currentClusterName, "another-cluster"},
+		},
+		1,
+	)
+	s.mockNamespaceCache.EXPECT().GetAllNamespaces().Return([]*namespace.Namespace{unrelatedNS})
+	s.mockClusterMetadataManager.EXPECT().DeleteClusterMetadata(
+		gomock.Any(),
+		&persistence.DeleteClusterMetadataRequest{ClusterName: clusterName},
+	).Return(nil)
+
+	_, err := s.handler.RemoveRemoteCluster(context.Background(), &adminservice.RemoveRemoteClusterRequest{ClusterName: clusterName})
+	s.NoError(err)
 }
 
 func (s *adminHandlerSuite) Test_RemoveRemoteCluster_DeletedNamespaceDoesNotBlock() {

--- a/service/frontend/cluster_removal_validation.go
+++ b/service/frontend/cluster_removal_validation.go
@@ -8,16 +8,44 @@ import (
 	"go.temporal.io/server/common/namespace"
 )
 
-// validateClusterNotInUseByNamespaces returns an error if any active
-// multi-cluster namespace still references clusterName in its replication
-// cluster list. Single-cluster namespaces (local, or global with only one
-// cluster) are ignored because they do not replicate. Namespaces in
-// NAMESPACE_STATE_DELETED are ignored because the delete worker is tearing
-// them down and cluster connectivity is not required for that teardown. The
-// check reads from the in-memory namespace registry, which may lag persistence
-// by up to the configured refresh interval.
+// validateClusterNotInUseByNamespaces guards RemoveRemoteCluster, which runs on
+// currentClusterName and deletes clusterName from that cluster's cluster-metadata
+// registry (i.e. "disconnect currentClusterName from clusterName"). It returns an
+// error only when a single active multi-cluster namespace lists BOTH
+// currentClusterName and clusterName in its replication cluster set, because that
+// is the only situation where the removal would sever a replication link the
+// current cluster is actually relying on and leave the namespace pointing at a
+// cluster the registry no longer knows about.
+//
+// Both membership checks are required, and neither alone is sufficient:
+//
+//   - Requiring clusterName membership alone (the original check) over-blocks on
+//     stale/orphaned records. The local registry can hold copies of global
+//     namespaces that currentClusterName was once a member of but is no longer —
+//     e.g. after a namespace migration re-homes a namespace onto a different
+//     cluster, the replicated update that drops currentClusterName from the
+//     namespace's cluster set is applied to the local record but the record
+//     itself is never deleted. Such an orphan still lists clusterName, yet
+//     removing clusterName cannot strand any replication currentClusterName
+//     performs, because currentClusterName does not participate in that namespace.
+//
+//   - Requiring currentClusterName membership alone over-blocks on unrelated
+//     namespaces. currentClusterName may participate in many multi-cluster
+//     namespaces that have nothing to do with clusterName; removing clusterName
+//     only endangers the ones that clusterName also belongs to.
+//
+// The dangerous case is the conjunction within one namespace, hence the &&.
+//
+// Namespaces are skipped when: they are single-cluster (local, or global with
+// only one cluster) and therefore do not replicate; or they are in
+// NAMESPACE_STATE_DELETED, because the delete worker is tearing them down and
+// cluster connectivity is not required for that teardown.
+//
+// The check reads from the in-memory namespace registry, which may lag
+// persistence by up to the configured refresh interval.
 func validateClusterNotInUseByNamespaces(
 	namespaceRegistry namespace.Registry,
+	currentClusterName string,
 	clusterName string,
 ) error {
 	for _, ns := range namespaceRegistry.GetAllNamespaces() {
@@ -27,7 +55,11 @@ func validateClusterNotInUseByNamespaces(
 		if ns.State() == enumspb.NAMESPACE_STATE_DELETED {
 			continue
 		}
-		if ns.IsOnCluster(clusterName) {
+		// Only block when the current cluster and the cluster being removed both
+		// participate in this namespace (see the doc comment for why both terms
+		// are required). This ignores orphaned records the current cluster is no
+		// longer a member of, and namespaces that do not involve clusterName.
+		if ns.IsOnCluster(currentClusterName) && ns.IsOnCluster(clusterName) {
 			return serviceerror.NewFailedPrecondition(fmt.Sprintf(
 				"cannot remove cluster %q: still referenced by namespace %q",
 				clusterName, ns.Name().String(),

--- a/service/frontend/operator_handler.go
+++ b/service/frontend/operator_handler.go
@@ -698,7 +698,7 @@ func (h *OperatorHandlerImpl) RemoveRemoteCluster(
 		return nil, serviceerror.NewNotFound("The cluster to be deleted cannot be found in clusters cache.")
 	}
 
-	if err := validateClusterNotInUseByNamespaces(h.namespaceRegistry, request.GetClusterName()); err != nil {
+	if err := validateClusterNotInUseByNamespaces(h.namespaceRegistry, h.clusterMetadata.GetCurrentClusterName(), request.GetClusterName()); err != nil {
 		return nil, err
 	}
 

--- a/service/frontend/operator_handler_test.go
+++ b/service/frontend/operator_handler_test.go
@@ -49,6 +49,8 @@ type (
 		controller   *gomock.Controller
 		mockResource *resourcetest.Test
 
+		currentClusterName string
+
 		handler *OperatorHandlerImpl
 	}
 )
@@ -61,7 +63,8 @@ func TestOperatorHandlerSuite(t *testing.T) {
 func (s *operatorHandlerSuite) SetupTest() {
 	s.controller = gomock.NewController(s.T())
 	s.mockResource = resourcetest.NewTest(s.controller, primitives.FrontendService)
-	s.mockResource.ClusterMetadata.EXPECT().GetCurrentClusterName().Return(uuid.NewString()).AnyTimes()
+	s.currentClusterName = "current-cluster"
+	s.mockResource.ClusterMetadata.EXPECT().GetCurrentClusterName().Return(s.currentClusterName).AnyTimes()
 
 	endpointClient := newNexusEndpointClient(
 		newNexusEndpointClientConfig(dynamicconfig.NewNoopCollection()),
@@ -1167,12 +1170,15 @@ func (s *operatorHandlerSuite) Test_RemoveRemoteCluster_Error() {
 
 func (s *operatorHandlerSuite) Test_RemoveRemoteCluster_BlockedByGlobalNamespace() {
 	var clusterName = "cluster"
+	// The namespace lists both the current cluster and the cluster being
+	// removed, so removing clusterName would sever a link the current cluster
+	// relies on -> blocked.
 	globalNS := namespace.NewGlobalNamespaceForTest(
 		&persistencespb.NamespaceInfo{Name: "global-ns"},
 		nil,
 		&persistencespb.NamespaceReplicationConfig{
-			ActiveClusterName: "other",
-			Clusters:          []string{"other", clusterName},
+			ActiveClusterName: s.currentClusterName,
+			Clusters:          []string{s.currentClusterName, clusterName},
 		},
 		1,
 	)
@@ -1183,6 +1189,62 @@ func (s *operatorHandlerSuite) Test_RemoveRemoteCluster_BlockedByGlobalNamespace
 	var failedPrecondition *serviceerror.FailedPrecondition
 	s.Require().ErrorAs(err, &failedPrecondition)
 	s.Contains(err.Error(), "global-ns")
+}
+
+// Test_RemoveRemoteCluster_OrphanedNamespaceDoesNotBlock covers the case that
+// motivated adding the current-cluster membership check: the local registry
+// holds a stale copy of a global namespace that references clusterName but that
+// the current cluster is no longer a member of (e.g. left behind after a
+// namespace migration re-homed the namespace). Removing clusterName cannot
+// strand any replication the current cluster performs, so it must be allowed.
+func (s *operatorHandlerSuite) Test_RemoveRemoteCluster_OrphanedNamespaceDoesNotBlock() {
+	var clusterName = "cluster"
+	orphanedNS := namespace.NewGlobalNamespaceForTest(
+		&persistencespb.NamespaceInfo{Name: "orphaned-ns"},
+		nil,
+		&persistencespb.NamespaceReplicationConfig{
+			ActiveClusterName: "other",
+			// References clusterName but NOT s.currentClusterName.
+			Clusters: []string{"other", clusterName},
+		},
+		1,
+	)
+	s.mockResource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(map[string]cluster.ClusterInformation{clusterName: {}})
+	s.mockResource.NamespaceCache.EXPECT().GetAllNamespaces().Return([]*namespace.Namespace{orphanedNS})
+	s.mockResource.ClusterMetadataMgr.EXPECT().DeleteClusterMetadata(
+		gomock.Any(),
+		&persistence.DeleteClusterMetadataRequest{ClusterName: clusterName},
+	).Return(nil)
+
+	_, err := s.handler.RemoveRemoteCluster(context.Background(), &operatorservice.RemoveRemoteClusterRequest{ClusterName: clusterName})
+	s.NoError(err)
+}
+
+// Test_RemoveRemoteCluster_UnrelatedNamespaceDoesNotBlock covers the other half
+// of the conjunction: the current cluster participates in a multi-cluster
+// namespace, but that namespace does not involve the cluster being removed, so
+// removing it endangers nothing.
+func (s *operatorHandlerSuite) Test_RemoveRemoteCluster_UnrelatedNamespaceDoesNotBlock() {
+	var clusterName = "cluster"
+	unrelatedNS := namespace.NewGlobalNamespaceForTest(
+		&persistencespb.NamespaceInfo{Name: "unrelated-ns"},
+		nil,
+		&persistencespb.NamespaceReplicationConfig{
+			ActiveClusterName: s.currentClusterName,
+			// Includes the current cluster but NOT clusterName.
+			Clusters: []string{s.currentClusterName, "another-cluster"},
+		},
+		1,
+	)
+	s.mockResource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(map[string]cluster.ClusterInformation{clusterName: {}})
+	s.mockResource.NamespaceCache.EXPECT().GetAllNamespaces().Return([]*namespace.Namespace{unrelatedNS})
+	s.mockResource.ClusterMetadataMgr.EXPECT().DeleteClusterMetadata(
+		gomock.Any(),
+		&persistence.DeleteClusterMetadataRequest{ClusterName: clusterName},
+	).Return(nil)
+
+	_, err := s.handler.RemoveRemoteCluster(context.Background(), &operatorservice.RemoveRemoteClusterRequest{ClusterName: clusterName})
+	s.NoError(err)
 }
 
 func (s *operatorHandlerSuite) Test_RemoveRemoteCluster_DeletedNamespaceDoesNotBlock() {


### PR DESCRIPTION
## What changed?

<!-- Give a brief description of what the commit or commits included in this
patch do. -->

### Original PRs
https://github.com/temporalio/temporal/pull/10997

<!-- Link the original PR(s) here. -->

## Why is this necessary as a patch?
We had an incident yesterday and this could cause the replication stuck and build up the task backlog

<!-- Why can't we wait until the next release? -->
Without the patch we will need to pause all migrations.


## What testing or retesting is appropriate for this patch after merge?

<!-- E.g., do we need to rerun VCR? OSS Longhaul? Some subset of those? Manual
validation? Etc. -->

<!-- As part of answering this, it is usually helpful to describe what testing
has already been done. -->
