### PR TITLE
activity-parity: allow SAA to be manually completed by ID

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -564,7 +564,7 @@ func (a *Activity) HandleCompleted(
 	ctx chasm.MutableContext,
 	event RespondCompletedEvent,
 ) (*historyservice.RespondActivityTaskCompletedResponse, error) {
-	if err := a.validateActivityTaskToken(ctx, event.Token, event.Request.GetNamespaceId()); err != nil {
+	if err := a.validateActivityTaskToken(ctx, event.Token, event.Request.GetNamespaceId(), true); err != nil {
 		return nil, err
 	}
 
@@ -589,7 +589,7 @@ func (a *Activity) HandleFailed(
 	ctx chasm.MutableContext,
 	event RespondFailedEvent,
 ) (*historyservice.RespondActivityTaskFailedResponse, error) {
-	if err := a.validateActivityTaskToken(ctx, event.Token, event.Request.GetNamespaceId()); err != nil {
+	if err := a.validateActivityTaskToken(ctx, event.Token, event.Request.GetNamespaceId(), false); err != nil {
 		return nil, err
 	}
 
@@ -629,7 +629,7 @@ func (a *Activity) HandleCanceled(
 	ctx chasm.MutableContext,
 	event RespondCancelledEvent,
 ) (*historyservice.RespondActivityTaskCanceledResponse, error) {
-	if err := a.validateActivityTaskToken(ctx, event.Token, event.Request.GetNamespaceId()); err != nil {
+	if err := a.validateActivityTaskToken(ctx, event.Token, event.Request.GetNamespaceId(), false); err != nil {
 		return nil, err
 	}
 
@@ -1595,7 +1595,7 @@ func (a *Activity) RecordHeartbeat(
 	ctx chasm.MutableContext,
 	input WithToken[*historyservice.RecordActivityTaskHeartbeatRequest],
 ) (*historyservice.RecordActivityTaskHeartbeatResponse, error) {
-	err := a.validateActivityTaskToken(ctx, input.Token, input.Request.GetNamespaceId())
+	err := a.validateActivityTaskToken(ctx, input.Token, input.Request.GetNamespaceId(), false)
 	if err != nil {
 		return nil, err
 	}
@@ -1911,12 +1911,21 @@ func (a *Activity) StoreOrSelf(ctx chasm.Context) ActivityStore {
 }
 
 // validateActivityTaskToken validates a task token against the current activity state.
+//
+// allowForceCompleteFromScheduled permits a by-ID token to pass even though the activity has no
+// attempt in progress yet, as long as it is Scheduled. Only HandleCompleted sets this, mirroring
+// the workflow-activity behavior of letting RespondActivityTaskCompletedById force-complete an
+// activity before any worker has started it.
 func (a *Activity) validateActivityTaskToken(
 	ctx chasm.Context,
 	token *tokenspb.Task,
 	requestNamespaceID string,
+	allowForceCompleteFromScheduled bool,
 ) error {
-	if !a.hasAttemptInProgress() {
+	forceCompleteFromScheduled := allowForceCompleteFromScheduled &&
+		token.Attempt == ByIDTokenAttempt &&
+		a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED
+	if !a.hasAttemptInProgress() && !forceCompleteFromScheduled {
 		return serviceerror.NewNotFound("activity task not found")
 	}
 	if token.Attempt != ByIDTokenAttempt && token.Attempt != a.LastAttempt.Get(ctx).GetCount() {

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1912,20 +1912,20 @@ func (a *Activity) StoreOrSelf(ctx chasm.Context) ActivityStore {
 
 // validateActivityTaskToken validates a task token against the current activity state.
 //
-// allowForceCompleteFromScheduled permits a by-ID token to pass even though the activity has no
-// attempt in progress yet, as long as it is Scheduled. Only HandleCompleted sets this, mirroring
-// the workflow-activity behavior of letting RespondActivityTaskCompletedById force-complete an
+// allowForceCompleteWithNoAttempt permits a by-ID token to pass even though the activity has no
+// attempt in progress (Scheduled or Paused). Only HandleCompleted sets this, mirroring the
+// workflow-activity behavior of letting RespondActivityTaskCompletedById force-complete an
 // activity before any worker has started it.
 func (a *Activity) validateActivityTaskToken(
 	ctx chasm.Context,
 	token *tokenspb.Task,
 	requestNamespaceID string,
-	allowForceCompleteFromScheduled bool,
+	allowForceCompleteWithNoAttempt bool,
 ) error {
-	forceCompleteFromScheduled := allowForceCompleteFromScheduled &&
+	forceCompleteWithNoAttempt := allowForceCompleteWithNoAttempt &&
 		token.Attempt == ByIDTokenAttempt &&
-		a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED
-	if !a.hasAttemptInProgress() && !forceCompleteFromScheduled {
+		!a.hasAttemptInProgress()
+	if !a.hasAttemptInProgress() && !forceCompleteWithNoAttempt {
 		return serviceerror.NewNotFound("activity task not found")
 	}
 	if token.Attempt != ByIDTokenAttempt && token.Attempt != a.LastAttempt.Get(ctx).GetCount() {
@@ -1998,11 +1998,11 @@ func (a *Activity) emitOnAttemptFailedMetrics(ctx chasm.Context, handler metrics
 	metrics.ActivityTaskFail.With(handler).Record(1)
 }
 
-func (a *Activity) emitOnCompletedMetrics(ctx chasm.Context, handler metrics.Handler) {
+func (a *Activity) emitOnCompletedMetrics(ctx chasm.Context, handler metrics.Handler, attemptWasStarted bool) {
 	attempt := a.LastAttempt.Get(ctx)
 	startedTime := attempt.GetStartedTime().AsTime()
 
-	if a.GetStatus() != activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED {
+	if attemptWasStarted {
 		startToCloseLatency := time.Since(startedTime)
 		metrics.ActivityStartToCloseLatency.With(handler).Record(startToCloseLatency)
 	}

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -2002,8 +2002,10 @@ func (a *Activity) emitOnCompletedMetrics(ctx chasm.Context, handler metrics.Han
 	attempt := a.LastAttempt.Get(ctx)
 	startedTime := attempt.GetStartedTime().AsTime()
 
-	startToCloseLatency := time.Since(startedTime)
-	metrics.ActivityStartToCloseLatency.With(handler).Record(startToCloseLatency)
+	if a.GetStatus() != activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED {
+		startToCloseLatency := time.Since(startedTime)
+		metrics.ActivityStartToCloseLatency.With(handler).Record(startToCloseLatency)
+	}
 
 	scheduleToCloseLatency := time.Since(a.GetScheduleTime().AsTime())
 	metrics.ActivityScheduleToCloseLatency.With(handler).Record(scheduleToCloseLatency)

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -188,6 +188,7 @@ type completeEvent struct {
 // TransitionCompleted transitions to Completed status.
 var TransitionCompleted = chasm.NewTransition(
 	[]activitypb.ActivityExecutionStatus{
+		activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
 		activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
 		activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
 		activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED,
@@ -199,6 +200,12 @@ var TransitionCompleted = chasm.NewTransition(
 			req := event.req.GetCompleteRequest()
 
 			attempt := a.LastAttempt.Get(ctx)
+			if a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED {
+				attempt.StartedTime = timestamppb.New(ctx.Now(a))
+				if a.FirstAttemptStartedTime == nil {
+					a.FirstAttemptStartedTime = attempt.StartedTime
+				}
+			}
 			attempt.CompleteTime = timestamppb.New(ctx.Now(a))
 			attempt.LastWorkerIdentity = req.GetIdentity()
 			outcome := a.Outcome.Get(ctx)

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -185,10 +185,13 @@ type completeEvent struct {
 	metricsHandler metrics.Handler
 }
 
-// TransitionCompleted transitions to Completed status.
+// TransitionCompleted transitions to Completed status. SCHEDULED and PAUSED are included because
+// RespondActivityTaskCompletedById can force-complete an activity that has no attempt in
+// progress, mirroring workflow-activity behavior.
 var TransitionCompleted = chasm.NewTransition(
 	[]activitypb.ActivityExecutionStatus{
 		activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+		activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED,
 		activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
 		activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
 		activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED,
@@ -199,8 +202,11 @@ var TransitionCompleted = chasm.NewTransition(
 		return a.StoreOrSelf(ctx).RecordCompleted(ctx, func(ctx chasm.MutableContext) error {
 			req := event.req.GetCompleteRequest()
 
+			attemptWasStarted := a.hasAttemptInProgress()
 			attempt := a.LastAttempt.Get(ctx)
-			if a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED {
+			if !attemptWasStarted {
+				// RespondActivityTaskCompletedById can complete an activity when no attempt is in
+				// progress.
 				attempt.StartedTime = timestamppb.New(ctx.Now(a))
 				if a.FirstAttemptStartedTime == nil {
 					a.FirstAttemptStartedTime = attempt.StartedTime
@@ -215,7 +221,7 @@ var TransitionCompleted = chasm.NewTransition(
 				},
 			}
 
-			a.emitOnCompletedMetrics(ctx, event.metricsHandler)
+			a.emitOnCompletedMetrics(ctx, event.metricsHandler, attemptWasStarted)
 
 			return nil
 		})

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -615,6 +615,62 @@ func TestTransitionCompleted(t *testing.T) {
 	protorequire.ProtoEqual(t, payload, outcome.GetSuccessful().GetOutput())
 }
 
+// TestTransitionCompleted_FromScheduled covers force-completing an activity by ID before any
+// worker has started it (RespondActivityTaskCompletedById). Since no attempt ever started,
+// ActivityStartToCloseLatency must not be emitted, mirroring the WFA behavior in
+// respondactivitytaskcompleted/api.go of leaving attemptStartedTime zero when the started event
+// is fabricated.
+func TestTransitionCompleted_FromScheduled(t *testing.T) {
+	ctx := &chasm.MockMutableContext{}
+	ctx.HandleNow = func(chasm.Component) time.Time { return defaultTime }
+	attemptState := &activitypb.ActivityAttemptState{Count: 1}
+	outcome := &activitypb.ActivityOutcome{}
+
+	activity := &Activity{
+		ActivityState: &activitypb.ActivityState{
+			ActivityType:           &commonpb.ActivityType{Name: "test-activity-type"},
+			RetryPolicy:            defaultRetryPolicy,
+			ScheduleToCloseTimeout: durationpb.New(defaultScheduleToCloseTimeout),
+			ScheduleToStartTimeout: durationpb.New(defaultScheduleToStartTimeout),
+			StartToCloseTimeout:    durationpb.New(defaultStartToCloseTimeout),
+			Status:                 activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+			TaskQueue:              &taskqueuepb.TaskQueue{Name: "test-task-queue"},
+		},
+		LastAttempt: chasm.NewDataField(ctx, attemptState),
+		Outcome:     chasm.NewDataField(ctx, outcome),
+	}
+
+	payload := payloads.EncodeString("Done")
+
+	controller := gomock.NewController(t)
+	metricsHandler := metrics.NewMockHandler(controller)
+
+	// The activity never had a started attempt, so ActivityStartToCloseLatency must not be recorded.
+	metricsHandler.EXPECT().Timer(metrics.ActivityStartToCloseLatency.Name()).Times(0)
+
+	timerScheduleToCloseLatency := metrics.NewMockTimerIface(controller)
+	timerScheduleToCloseLatency.EXPECT().Record(gomock.Any()).Times(1)
+	metricsHandler.EXPECT().Timer(metrics.ActivityScheduleToCloseLatency.Name()).Return(timerScheduleToCloseLatency)
+
+	counterSuccess := metrics.NewMockCounterIface(controller)
+	counterSuccess.EXPECT().Record(int64(1)).Times(1)
+	metricsHandler.EXPECT().Counter(metrics.ActivitySuccess.Name()).Return(counterSuccess)
+
+	req := &historyservice.RespondActivityTaskCompletedRequest{
+		CompleteRequest: &workflowservice.RespondActivityTaskCompletedRequest{
+			Result:   payload,
+			Identity: "worker",
+		},
+	}
+
+	err := TransitionCompleted.Apply(activity, ctx, completeEvent{
+		req:            req,
+		metricsHandler: metricsHandler,
+	})
+	require.NoError(t, err)
+	require.Equal(t, activitypb.ACTIVITY_EXECUTION_STATUS_COMPLETED, activity.Status)
+}
+
 func TestTransitionFailed(t *testing.T) {
 	ctx := &chasm.MockMutableContext{}
 	ctx.HandleNow = func(chasm.Component) time.Time { return defaultTime }

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -615,60 +615,68 @@ func TestTransitionCompleted(t *testing.T) {
 	protorequire.ProtoEqual(t, payload, outcome.GetSuccessful().GetOutput())
 }
 
-// TestTransitionCompleted_FromScheduled covers force-completing an activity by ID before any
-// worker has started it (RespondActivityTaskCompletedById). Since no attempt ever started,
+// TestTransitionCompleted_ForceCompleteWithNoAttempt covers force-completing an activity by ID
+// before any worker has started it (RespondActivityTaskCompletedById), from both SCHEDULED and
+// PAUSED — neither has an attempt in progress. Since no attempt ever started,
 // ActivityStartToCloseLatency must not be emitted, mirroring the WFA behavior in
 // respondactivitytaskcompleted/api.go of leaving attemptStartedTime zero when the started event
 // is fabricated.
-func TestTransitionCompleted_FromScheduled(t *testing.T) {
-	ctx := &chasm.MockMutableContext{}
-	ctx.HandleNow = func(chasm.Component) time.Time { return defaultTime }
-	attemptState := &activitypb.ActivityAttemptState{Count: 1}
-	outcome := &activitypb.ActivityOutcome{}
+func TestTransitionCompleted_ForceCompleteWithNoAttempt(t *testing.T) {
+	for _, fromStatus := range []activitypb.ActivityExecutionStatus{
+		activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+		activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED,
+	} {
+		t.Run(fromStatus.String(), func(t *testing.T) {
+			ctx := &chasm.MockMutableContext{}
+			ctx.HandleNow = func(chasm.Component) time.Time { return defaultTime }
+			attemptState := &activitypb.ActivityAttemptState{Count: 1}
+			outcome := &activitypb.ActivityOutcome{}
 
-	activity := &Activity{
-		ActivityState: &activitypb.ActivityState{
-			ActivityType:           &commonpb.ActivityType{Name: "test-activity-type"},
-			RetryPolicy:            defaultRetryPolicy,
-			ScheduleToCloseTimeout: durationpb.New(defaultScheduleToCloseTimeout),
-			ScheduleToStartTimeout: durationpb.New(defaultScheduleToStartTimeout),
-			StartToCloseTimeout:    durationpb.New(defaultStartToCloseTimeout),
-			Status:                 activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
-			TaskQueue:              &taskqueuepb.TaskQueue{Name: "test-task-queue"},
-		},
-		LastAttempt: chasm.NewDataField(ctx, attemptState),
-		Outcome:     chasm.NewDataField(ctx, outcome),
+			activity := &Activity{
+				ActivityState: &activitypb.ActivityState{
+					ActivityType:           &commonpb.ActivityType{Name: "test-activity-type"},
+					RetryPolicy:            defaultRetryPolicy,
+					ScheduleToCloseTimeout: durationpb.New(defaultScheduleToCloseTimeout),
+					ScheduleToStartTimeout: durationpb.New(defaultScheduleToStartTimeout),
+					StartToCloseTimeout:    durationpb.New(defaultStartToCloseTimeout),
+					Status:                 fromStatus,
+					TaskQueue:              &taskqueuepb.TaskQueue{Name: "test-task-queue"},
+				},
+				LastAttempt: chasm.NewDataField(ctx, attemptState),
+				Outcome:     chasm.NewDataField(ctx, outcome),
+			}
+
+			payload := payloads.EncodeString("Done")
+
+			controller := gomock.NewController(t)
+			metricsHandler := metrics.NewMockHandler(controller)
+
+			// No attempt was ever started, so ActivityStartToCloseLatency must not be recorded.
+			metricsHandler.EXPECT().Timer(metrics.ActivityStartToCloseLatency.Name()).Times(0)
+
+			timerScheduleToCloseLatency := metrics.NewMockTimerIface(controller)
+			timerScheduleToCloseLatency.EXPECT().Record(gomock.Any()).Times(1)
+			metricsHandler.EXPECT().Timer(metrics.ActivityScheduleToCloseLatency.Name()).Return(timerScheduleToCloseLatency)
+
+			counterSuccess := metrics.NewMockCounterIface(controller)
+			counterSuccess.EXPECT().Record(int64(1)).Times(1)
+			metricsHandler.EXPECT().Counter(metrics.ActivitySuccess.Name()).Return(counterSuccess)
+
+			req := &historyservice.RespondActivityTaskCompletedRequest{
+				CompleteRequest: &workflowservice.RespondActivityTaskCompletedRequest{
+					Result:   payload,
+					Identity: "worker",
+				},
+			}
+
+			err := TransitionCompleted.Apply(activity, ctx, completeEvent{
+				req:            req,
+				metricsHandler: metricsHandler,
+			})
+			require.NoError(t, err)
+			require.Equal(t, activitypb.ACTIVITY_EXECUTION_STATUS_COMPLETED, activity.Status)
+		})
 	}
-
-	payload := payloads.EncodeString("Done")
-
-	controller := gomock.NewController(t)
-	metricsHandler := metrics.NewMockHandler(controller)
-
-	// The activity never had a started attempt, so ActivityStartToCloseLatency must not be recorded.
-	metricsHandler.EXPECT().Timer(metrics.ActivityStartToCloseLatency.Name()).Times(0)
-
-	timerScheduleToCloseLatency := metrics.NewMockTimerIface(controller)
-	timerScheduleToCloseLatency.EXPECT().Record(gomock.Any()).Times(1)
-	metricsHandler.EXPECT().Timer(metrics.ActivityScheduleToCloseLatency.Name()).Return(timerScheduleToCloseLatency)
-
-	counterSuccess := metrics.NewMockCounterIface(controller)
-	counterSuccess.EXPECT().Record(int64(1)).Times(1)
-	metricsHandler.EXPECT().Counter(metrics.ActivitySuccess.Name()).Return(counterSuccess)
-
-	req := &historyservice.RespondActivityTaskCompletedRequest{
-		CompleteRequest: &workflowservice.RespondActivityTaskCompletedRequest{
-			Result:   payload,
-			Identity: "worker",
-		},
-	}
-
-	err := TransitionCompleted.Apply(activity, ctx, completeEvent{
-		req:            req,
-		metricsHandler: metricsHandler,
-	})
-	require.NoError(t, err)
-	require.Equal(t, activitypb.ACTIVITY_EXECUTION_STATUS_COMPLETED, activity.Status)
 }
 
 func TestTransitionFailed(t *testing.T) {

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -461,6 +461,7 @@ func (s *activityParityTestSuite) TestCompleteByID_WhilePaused() {
 		env := testcore.NewEnv(s.T(),
 			testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 			testcore.WithDynamicConfig(activity.Enabled, true),
+			testcore.WithDynamicConfig(activity.EnableStandaloneActivityOperatorCommands, true),
 		)
 		tv := env.Tv()
 

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -366,5 +366,7 @@ func (s *activityParityTestSuite) TestCompleteByID_BeforeAnyWorkerStarts() {
 		})
 		s.NoError(err)
 		s.Equal(enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, descAfter.GetInfo().GetStatus())
+		s.NotNil(descAfter.GetInfo().GetLastStartedTime(),
+			"a force-completed activity must still record a started time, even though no worker ever started it")
 	})
 }

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -6,14 +6,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	commandpb "go.temporal.io/api/command/v1"
+	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/chasm/lib/activity/model"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/retrypolicy"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 type activityParityTestSuite struct {
@@ -237,5 +243,128 @@ func (s *activityParityTestSuite) TestCancel() {
 		t := s.T()
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_CANCELED,
 			newSAADriver(t, env, cfg).driveTrace(t, trace).terminalStatus(t))
+	})
+}
+
+func (s *activityParityTestSuite) TestCompleteByID_BeforeAnyWorkerStarts() {
+	s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
+		env := testcore.NewEnv(s.T())
+		tv := env.Tv()
+
+		we, err := env.FrontendClient().StartWorkflowExecution(s.Context(), &workflowservice.StartWorkflowExecutionRequest{
+			RequestId:           uuid.NewString(),
+			Namespace:           env.Namespace().String(),
+			WorkflowId:          tv.WorkflowID(),
+			WorkflowType:        tv.WorkflowType(),
+			TaskQueue:           tv.TaskQueue(),
+			WorkflowRunTimeout:  durationpb.New(100 * time.Second),
+			WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+			Identity:            tv.WorkerIdentity(),
+		})
+		s.NoError(err)
+
+		// Schedule the activity, but no poller ever calls PollActivityTaskQueue for it, so it
+		// remains Scheduled indefinitely.
+		_, err = env.TaskPoller().PollAndHandleWorkflowTask(tv,
+			func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+				return &workflowservice.RespondWorkflowTaskCompletedRequest{
+					Commands: []*commandpb.Command{{
+						CommandType: enumspb.COMMAND_TYPE_SCHEDULE_ACTIVITY_TASK,
+						Attributes: &commandpb.Command_ScheduleActivityTaskCommandAttributes{
+							ScheduleActivityTaskCommandAttributes: &commandpb.ScheduleActivityTaskCommandAttributes{
+								ActivityId:             tv.ActivityID(),
+								ActivityType:           tv.ActivityType(),
+								TaskQueue:              tv.TaskQueue(),
+								Input:                  payloads.EncodeString("input"),
+								ScheduleToCloseTimeout: durationpb.New(time.Minute),
+								StartToCloseTimeout:    durationpb.New(time.Minute),
+							},
+						},
+					}},
+				}, nil
+			})
+		s.NoError(err)
+
+		_, err = env.FrontendClient().RespondActivityTaskCompletedById(s.Context(), &workflowservice.RespondActivityTaskCompletedByIdRequest{
+			Namespace:  env.Namespace().String(),
+			WorkflowId: tv.WorkflowID(),
+			RunId:      we.GetRunId(),
+			ActivityId: tv.ActivityID(),
+			Result:     payloads.EncodeString("result"),
+			Identity:   tv.WorkerIdentity(),
+		})
+		s.NoError(err, "force-completing a scheduled (never-started) workflow activity by ID must succeed")
+
+		// Drain the resulting workflow task and complete the workflow to confirm the completion
+		// was actually applied, not just accepted and dropped.
+		_, err = env.TaskPoller().PollAndHandleWorkflowTask(tv,
+			func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+				return &workflowservice.RespondWorkflowTaskCompletedRequest{
+					Commands: []*commandpb.Command{{
+						CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
+						Attributes: &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{
+							CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{
+								Result: payloads.EncodeString("done"),
+							},
+						},
+					}},
+				}, nil
+			})
+		s.NoError(err)
+
+		descResp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
+			Execution: &commonpb.WorkflowExecution{WorkflowId: tv.WorkflowID(), RunId: we.GetRunId()},
+		})
+		s.NoError(err)
+		s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, descResp.GetWorkflowExecutionInfo().GetStatus())
+	})
+
+	s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
+		env := testcore.NewEnv(s.T(),
+			testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
+			testcore.WithDynamicConfig(activity.Enabled, true),
+		)
+		tv := env.Tv()
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          tv.ActivityID(),
+			ActivityType:        tv.ActivityType(),
+			Identity:            tv.WorkerIdentity(),
+			Input:               payloads.EncodeString("input"),
+			TaskQueue:           tv.TaskQueue(),
+			StartToCloseTimeout: durationpb.New(time.Minute),
+			RequestId:           uuid.NewString(),
+		})
+		s.NoError(err)
+		s.True(startResp.GetStarted())
+
+		// No poller ever calls PollActivityTaskQueue for it, so it remains Scheduled indefinitely.
+		descBefore, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: tv.ActivityID(),
+			RunId:      startResp.GetRunId(),
+		})
+		s.NoError(err)
+		s.Equal(enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, descBefore.GetInfo().GetRunState())
+
+		_, err = env.FrontendClient().RespondActivityTaskCompletedById(s.Context(), &workflowservice.RespondActivityTaskCompletedByIdRequest{
+			Namespace:  env.Namespace().String(),
+			RunId:      startResp.GetRunId(),
+			ActivityId: tv.ActivityID(),
+			Result:     payloads.EncodeString("result"),
+			Identity:   tv.WorkerIdentity(),
+		})
+		s.NoError(err, "force-completing a scheduled (never-started) standalone activity by ID must succeed, matching workflow-activity behavior")
+
+		descAfter, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:      env.Namespace().String(),
+			ActivityId:     tv.ActivityID(),
+			RunId:          startResp.GetRunId(),
+			IncludeOutcome: true,
+		})
+		s.NoError(err)
+		s.Equal(enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, descAfter.GetInfo().GetStatus())
 	})
 }

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -370,3 +370,149 @@ func (s *activityParityTestSuite) TestCompleteByID_BeforeAnyWorkerStarts() {
 			"a force-completed activity must still record a started time, even though no worker ever started it")
 	})
 }
+
+// TestCompleteByID_WhilePaused asserts that force-completing an activity by ID also works while
+// the activity is Paused (a never-started activity that had a pause requested before any worker
+// picked it up) — Paused has no attempt in progress, just like Scheduled.
+func (s *activityParityTestSuite) TestCompleteByID_WhilePaused() {
+	s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
+		env := testcore.NewEnv(s.T())
+		tv := env.Tv()
+
+		we, err := env.FrontendClient().StartWorkflowExecution(s.Context(), &workflowservice.StartWorkflowExecutionRequest{
+			RequestId:           uuid.NewString(),
+			Namespace:           env.Namespace().String(),
+			WorkflowId:          tv.WorkflowID(),
+			WorkflowType:        tv.WorkflowType(),
+			TaskQueue:           tv.TaskQueue(),
+			WorkflowRunTimeout:  durationpb.New(100 * time.Second),
+			WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+			Identity:            tv.WorkerIdentity(),
+		})
+		s.NoError(err)
+
+		// Schedule the activity, but no poller ever calls PollActivityTaskQueue for it, so it
+		// remains Scheduled indefinitely.
+		_, err = env.TaskPoller().PollAndHandleWorkflowTask(tv,
+			func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+				return &workflowservice.RespondWorkflowTaskCompletedRequest{
+					Commands: []*commandpb.Command{{
+						CommandType: enumspb.COMMAND_TYPE_SCHEDULE_ACTIVITY_TASK,
+						Attributes: &commandpb.Command_ScheduleActivityTaskCommandAttributes{
+							ScheduleActivityTaskCommandAttributes: &commandpb.ScheduleActivityTaskCommandAttributes{
+								ActivityId:             tv.ActivityID(),
+								ActivityType:           tv.ActivityType(),
+								TaskQueue:              tv.TaskQueue(),
+								Input:                  payloads.EncodeString("input"),
+								ScheduleToCloseTimeout: durationpb.New(time.Minute),
+								StartToCloseTimeout:    durationpb.New(time.Minute),
+							},
+						},
+					}},
+				}, nil
+			})
+		s.NoError(err)
+
+		_, err = env.FrontendClient().PauseActivity(s.Context(), &workflowservice.PauseActivityRequest{
+			Namespace: env.Namespace().String(),
+			Execution: &commonpb.WorkflowExecution{WorkflowId: tv.WorkflowID()},
+			Activity:  &workflowservice.PauseActivityRequest_Id{Id: tv.ActivityID()},
+			Identity:  tv.WorkerIdentity(),
+			RequestId: uuid.NewString(),
+		})
+		s.NoError(err)
+
+		_, err = env.FrontendClient().RespondActivityTaskCompletedById(s.Context(), &workflowservice.RespondActivityTaskCompletedByIdRequest{
+			Namespace:  env.Namespace().String(),
+			WorkflowId: tv.WorkflowID(),
+			RunId:      we.GetRunId(),
+			ActivityId: tv.ActivityID(),
+			Result:     payloads.EncodeString("result"),
+			Identity:   tv.WorkerIdentity(),
+		})
+		s.NoError(err, "force-completing a paused (never-started) workflow activity by ID must succeed")
+
+		// Drain the resulting workflow task and complete the workflow to confirm the completion
+		// was actually applied, not just accepted and dropped.
+		_, err = env.TaskPoller().PollAndHandleWorkflowTask(tv,
+			func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+				return &workflowservice.RespondWorkflowTaskCompletedRequest{
+					Commands: []*commandpb.Command{{
+						CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
+						Attributes: &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{
+							CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{
+								Result: payloads.EncodeString("done"),
+							},
+						},
+					}},
+				}, nil
+			})
+		s.NoError(err)
+
+		descResp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
+			Execution: &commonpb.WorkflowExecution{WorkflowId: tv.WorkflowID(), RunId: we.GetRunId()},
+		})
+		s.NoError(err)
+		s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, descResp.GetWorkflowExecutionInfo().GetStatus())
+	})
+
+	s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
+		env := testcore.NewEnv(s.T(),
+			testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
+			testcore.WithDynamicConfig(activity.Enabled, true),
+		)
+		tv := env.Tv()
+
+		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:           env.Namespace().String(),
+			ActivityId:          tv.ActivityID(),
+			ActivityType:        tv.ActivityType(),
+			Identity:            tv.WorkerIdentity(),
+			Input:               payloads.EncodeString("input"),
+			TaskQueue:           tv.TaskQueue(),
+			StartToCloseTimeout: durationpb.New(time.Minute),
+			RequestId:           uuid.NewString(),
+		})
+		s.NoError(err)
+		s.True(startResp.GetStarted())
+
+		// No poller ever calls PollActivityTaskQueue for it, so it remains Scheduled until paused.
+		_, err = env.FrontendClient().PauseActivityExecution(s.Context(), &workflowservice.PauseActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: tv.ActivityID(),
+			RunId:      startResp.GetRunId(),
+			Identity:   tv.WorkerIdentity(),
+			Reason:     "test-pause",
+		})
+		s.NoError(err)
+
+		descBefore, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: tv.ActivityID(),
+			RunId:      startResp.GetRunId(),
+		})
+		s.NoError(err)
+		s.Equal(enumspb.PENDING_ACTIVITY_STATE_PAUSED, descBefore.GetInfo().GetRunState())
+
+		_, err = env.FrontendClient().RespondActivityTaskCompletedById(s.Context(), &workflowservice.RespondActivityTaskCompletedByIdRequest{
+			Namespace:  env.Namespace().String(),
+			RunId:      startResp.GetRunId(),
+			ActivityId: tv.ActivityID(),
+			Result:     payloads.EncodeString("result"),
+			Identity:   tv.WorkerIdentity(),
+		})
+		s.NoError(err, "force-completing a paused (never-started) standalone activity by ID must succeed, matching workflow-activity behavior")
+
+		descAfter, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:      env.Namespace().String(),
+			ActivityId:     tv.ActivityID(),
+			RunId:          startResp.GetRunId(),
+			IncludeOutcome: true,
+		})
+		s.NoError(err)
+		s.Equal(enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, descAfter.GetInfo().GetStatus())
+		s.NotNil(descAfter.GetInfo().GetLastStartedTime(),
+			"a force-completed activity must still record a started time, even though no worker ever started it")
+	})
+}


### PR DESCRIPTION
## What changed?
`RespondActivityTaskCompletedById` can now force-complete an SAA from the `Scheduled` state.

## Why?
Workflow activities allow force completing an activity before any worker starts it. 

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [X] added new functional test(s)
  - Added a new file `tests/activity_parity_test.go` to hold all tests related to parity of workflow activities and standalone activities.
  - 
## Potential risks
NA
