### PR TITLE
[Scheduler] Cap V2 RecentActions in Memo at 5 items (instead of 10+running)

### DIFF
--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -1046,10 +1046,8 @@ func (s *Scheduler) ListInfo(
 	generator := s.Generator.Get(ctx)
 	invoker := s.Invoker.Get(ctx)
 
-	// Hard-cap the memo's recent-action list. recentActions() includes running
-	// starts, which aren't subject to completed-action retention, so the raw
-	// projection can grow with live action count. Keep the most recently started
-	// actions so the persisted memo stays bounded.
+	// Hard-cap the memo's recent-action list by length after sorting by actual time
+	// (ascending towards most recent).
 	recentActions := invoker.recentActions()
 	slices.SortFunc(recentActions, func(a, b *schedulepb.ScheduleActionResult) int {
 		return a.GetActualTime().AsTime().Compare(b.GetActualTime().AsTime())

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -91,6 +91,12 @@ const (
 	// How many recent actions to keep on the Info.RecentActions list.
 	recentActionCount = 10
 
+	// How many recent actions to surface on the ScheduleListInfo memo. Unlike
+	// Describe, the memo is persisted to visibility, so it must be hard-capped:
+	// recentActions() includes running starts, which aren't bounded by
+	// completed-action retention. Mirrors V1's RecentActionCountForList.
+	recentActionCountForList = 5
+
 	// Item limit per spec field on the ScheduleInfo memo.
 	listInfoSpecFieldLimit = 10
 
@@ -1040,12 +1046,22 @@ func (s *Scheduler) ListInfo(
 	generator := s.Generator.Get(ctx)
 	invoker := s.Invoker.Get(ctx)
 
+	// Hard-cap the memo's recent-action list. recentActions() includes running
+	// starts, which aren't subject to completed-action retention, so the raw
+	// projection can grow with live action count. Keep the most recently started
+	// actions so the persisted memo stays bounded.
+	recentActions := invoker.recentActions()
+	slices.SortFunc(recentActions, func(a, b *schedulepb.ScheduleActionResult) int {
+		return a.GetActualTime().AsTime().Compare(b.GetActualTime().AsTime())
+	})
+	recentActions = util.SliceTail(recentActions, recentActionCountForList)
+
 	return &schedulepb.ScheduleListInfo{
 		Spec:              spec,
 		WorkflowType:      s.Schedule.Action.GetStartWorkflow().GetWorkflowType(),
 		Notes:             s.Schedule.State.Notes,
 		Paused:            s.Schedule.State.Paused,
-		RecentActions:     invoker.recentActions(),
+		RecentActions:     recentActions,
 		FutureActionTimes: generator.FutureActionTimes,
 	}
 }

--- a/chasm/lib/scheduler/scheduler_test.go
+++ b/chasm/lib/scheduler/scheduler_test.go
@@ -2,6 +2,7 @@ package scheduler_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -43,6 +44,49 @@ func TestListInfo(t *testing.T) {
 	require.NotNil(t, listInfo.WorkflowType)
 	require.NotEmpty(t, listInfo.FutureActionTimes)
 	require.Equal(t, expectedFutureTimes, listInfo.FutureActionTimes)
+}
+
+// TestListInfo_RecentActionsCapped verifies that the ScheduleListInfo memo
+// hard-caps RecentActions. recentActions() includes running starts, which
+// aren't bounded by completed-action retention, so without the cap the
+// persisted memo would grow with the number of live starts. The cap keeps the
+// most recently started actions.
+func TestListInfo_RecentActionsCapped(t *testing.T) {
+	sched, ctx, _ := setupSchedulerForTest(t)
+
+	// Anchor in the past so every start/close time is a plausible already-happened
+	// action; the +i minutes below stay well before now.
+	base := time.Now().UTC().Add(-time.Hour)
+	// Twelve started workflows, more than the memo cap. StartTimes are inserted
+	// out of order to prove selection is by recency, not buffer position.
+	order := []int{7, 2, 11, 0, 5, 9, 1, 8, 3, 10, 4, 6}
+	var starts []*schedulespb.BufferedStart
+	for _, i := range order {
+		start := &schedulespb.BufferedStart{
+			RequestId:  fmt.Sprintf("req-%d", i),
+			WorkflowId: fmt.Sprintf("wf-%d", i),
+			RunId:      fmt.Sprintf("run-%d", i),
+			StartTime:  timestamppb.New(base.Add(time.Duration(i) * time.Minute)),
+		}
+		// Mix in some completed starts alongside running ones; the cap spans both.
+		if i%2 == 0 {
+			start.Completed = &schedulespb.CompletedResult{
+				Status:    enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+				CloseTime: timestamppb.New(base.Add(time.Duration(i) * time.Minute)),
+			}
+		}
+		starts = append(starts, start)
+	}
+	sched.Invoker.Get(ctx).BufferedStarts = starts
+
+	listInfo := sched.ListInfo(ctx)
+
+	// Capped to the memo limit, keeping the most recent by start time, ascending.
+	require.Len(t, listInfo.RecentActions, 5)
+	for idx, action := range listInfo.RecentActions {
+		wantIdx := 7 + idx // most recent five: wf-7 .. wf-11
+		require.Equal(t, fmt.Sprintf("wf-%d", wantIdx), action.GetStartWorkflowResult().GetWorkflowId())
+	}
 }
 
 func TestCreateSchedulerFromMigration(t *testing.T) {

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -468,6 +468,7 @@ func runSharedScheduleTests(t *testing.T, newContext contextFactory) {
 	t.Run("TestLastCompletionAndError", func(t *testing.T) { t.Parallel(); testLastCompletionAndError(t, newContext) })
 	t.Run("TestScheduleContinuesAfterWorkflowRetryFailure", func(t *testing.T) { t.Parallel(); testScheduleContinuesAfterWorkflowRetryFailure(t, newContext) })
 	t.Run("TestListSchedulesReturnsWorkflowStatus", func(t *testing.T) { t.Parallel(); testListSchedulesReturnsWorkflowStatus(t, newContext) })
+	t.Run("TestListSchedulesRecentActionsCapped", func(t *testing.T) { t.Parallel(); testListSchedulesRecentActionsCapped(t, newContext) })
 	t.Run("TestUpdateIntervalTakesEffect", func(t *testing.T) { t.Parallel(); testUpdateIntervalTakesEffect(t, newContext) })
 	t.Run("TestListScheduleMatchingTimes", func(t *testing.T) { t.Parallel(); testListScheduleMatchingTimes(t, newContext) })
 	t.Run("TestLimitMemoSpecSize", func(t *testing.T) { t.Parallel(); testLimitMemoSpecSize(t, newContext) })
@@ -1706,6 +1707,53 @@ func testListSchedulesReturnsWorkflowStatus(t *testing.T, newContext contextFact
 	// Verify no duplicate RunIds in recent actions (regression for migration dedup bug).
 	assertRecentActionsNoDuplicateRunIDs(s.T(), descResp.Info.RecentActions)
 	assertRecentActionsNoDuplicateRunIDs(s.T(), listResp.Info.RecentActions)
+}
+
+// testListSchedulesRecentActionsCapped verifies that RecentActions on the
+// ListSchedules visibility memo stay hard-capped, independent of the (larger)
+// window DescribeSchedule reports. The memo is persisted to visibility, so it
+// must stay bounded no matter how many actions the schedule takes. Both the V1
+// and V2 (CHASM) schedulers apply this cap, so it runs as a shared test.
+func testListSchedulesRecentActionsCapped(t *testing.T, newContext contextFactory) {
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	ctx := newContext(testcore.NewContext())
+
+	// The list memo caps RecentActions at this many entries (V1
+	// RecentActionCountForList / V2 recentActionCountForList).
+	const memoCap = 5
+
+	sid := testcore.RandomizeStr("sched-list-cap")
+	wid := testcore.RandomizeStr("sched-list-cap-wf")
+	wt := testcore.RandomizeStr("sched-list-cap-wt")
+
+	// A workflow that returns immediately, so actions accrue quickly as completed
+	// recent actions; a fast interval fires more than the memo cap in short order.
+	var runs atomic.Int32
+	registerCountingWorkflow(s, wt, &runs)
+	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
+		Spec:   intervalSpec(fastInterval),
+		Action: startWorkflowAction(s, wid, wt),
+	})
+
+	// DescribeSchedule reports a wider recent-action window than the memo. Wait
+	// until it exceeds the cap, proving the two projections are independent.
+	var describeResp *workflowservice.DescribeScheduleResponse
+	require.Eventually(t, func() bool {
+		var err error
+		describeResp, err = s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+		})
+		return err == nil && len(describeResp.GetInfo().GetRecentActions()) > memoCap
+	}, awaitTimeout, pollInterval, "DescribeSchedule should report more than %d recent actions", memoCap)
+
+	// The ListSchedules memo must stay capped even though more actions exist.
+	listResp := getScheduleEntryFromVisibility(s, sid, newContext, func(ent *schedulepb.ScheduleListEntry) bool {
+		return len(ent.GetInfo().GetRecentActions()) >= memoCap
+	})
+	require.Len(t, listResp.Info.RecentActions, memoCap,
+		"ListSchedules memo RecentActions must be capped at %d (Describe reported %d)",
+		memoCap, len(describeResp.Info.RecentActions))
 }
 
 func testUpdateIntervalTakesEffect(t *testing.T, newContext contextFactory) {


### PR DESCRIPTION
## What changed?
- V2's Memo provider now caps the number of RecentActions recorded to a hard limit of 5. Previously, it would have been the same as Describe's limit (10), plus any running workflows (usually 1 or 0).

## Why?
- Match V1 behavior, avoid storing too much in visi

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)
