### PR TITLE
Stabilize mixed-brain server rolls

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -485,6 +485,12 @@ jobs:
       - name: Install PostgreSQL schema
         run: make install-schema-postgresql12
 
+      - name: Set up Go for mixed-brain test
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: tests/mixedbrain/go.mod
+          cache: false
+
       - name: Run mixed brain test
         timeout-minutes: 20
         run: ./develop/github/monitor_test.sh make mixed-brain-test
@@ -497,9 +503,13 @@ jobs:
         if: always()
         run: cat .testoutput/memory/memory-snapshot.txt || true
 
-      - name: Print server logs
+      - name: Print current server logs
         if: always()
-        run: cat .testoutput/mixedbrain_process-*.log || true
+        run: cat .testoutput/mixedbrain_process-current-*.log || true
+
+      - name: Print release server logs
+        if: always()
+        run: cat .testoutput/mixedbrain_process-release-*.log || true
 
       - name: Print Omes logs
         if: always()

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -497,13 +497,9 @@ jobs:
         if: always()
         run: cat .testoutput/memory/memory-snapshot.txt || true
 
-      - name: Print current server logs
+      - name: Print server logs
         if: always()
-        run: cat .testoutput/mixedbrain_process-current.log || true
-
-      - name: Print release server logs
-        if: always()
-        run: cat .testoutput/mixedbrain_process-release.log || true
+        run: cat .testoutput/mixedbrain_process-*.log || true
 
       - name: Print Omes logs
         if: always()

--- a/tests/mixedbrain/go.mod
+++ b/tests/mixedbrain/go.mod
@@ -1,17 +1,19 @@
 module go.temporal.io/server/tests/mixedbrain
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/siderolabs/grpc-proxy v0.5.2
 	github.com/stretchr/testify v1.11.1
-	github.com/temporalio/omes v0.0.0-20260528212322-14460bcc246f
+	github.com/temporalio/omes v0.0.0-20260722022749-0bfd1b16c74f
 	go.temporal.io/api v1.63.4-0.20260720155646-7a3ca3626ec2
 	go.temporal.io/server v0.0.0-00010101000000-000000000000
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
 )
+
+replace github.com/temporalio/omes => github.com/chaptersix/omes v0.0.0-20260722022749-0bfd1b16c74f
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/tests/mixedbrain/go.sum
+++ b/tests/mixedbrain/go.sum
@@ -2,6 +2,8 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/chaptersix/omes v0.0.0-20260722022749-0bfd1b16c74f h1:A5eAVBKJgN//QlUXD3blAlyR3cYtGdlF1flgMf0t+58=
+github.com/chaptersix/omes v0.0.0-20260722022749-0bfd1b16c74f/go.mod h1:aDF6zJA/6dff4iXMsYYkCjShCFGtU3o+nZNvf/QOuPM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fullstorydev/grpchan v1.1.1 h1:heQqIJlAv5Cnks9a70GRL2EJke6QQoUB25VGR6TZQas=
@@ -41,8 +43,6 @@ github.com/siderolabs/grpc-proxy v0.5.2 h1:o34tS02IxbX3qeXe0MM99zE2XhfWHuvdBtSWW
 github.com/siderolabs/grpc-proxy v0.5.2/go.mod h1:ygf+gqFxWdymAXuP4qMHTa+j6SvasdcFg3XkhpvUvDw=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/temporalio/omes v0.0.0-20260528212322-14460bcc246f h1:gLnuQgnw6SF4k0J4kMVAWY4h17tt/IhbzZr74D0Tbgc=
-github.com/temporalio/omes v0.0.0-20260528212322-14460bcc246f/go.mod h1:ruo0wxNH1LFUvJ5pcPzf2r3t56X9Joq9lW0/l0efDpk=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=

--- a/tests/mixedbrain/mixed_brain_test.go
+++ b/tests/mixedbrain/mixed_brain_test.go
@@ -2,12 +2,14 @@ package mixedbrain
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -27,7 +29,7 @@ func testDuration() time.Duration {
 		}
 		return d
 	}
-	return 30 * time.Second // locally we want only a smoke test to ensure it works
+	return 2 * time.Minute // locally we want only a smoke test to ensure it works
 }
 
 func logDir(t *testing.T) string {
@@ -78,19 +80,14 @@ var scenarios = []omesScenario{
 	},
 }
 
-// TestMixedBrain starts two servers in parallel, one using the current branch's source
-// and the other using the latest release tag. It then runs the Omes
-// throughput_stress and scheduler_stress scenarios to ensure that the mixed
-// brain works correctly.
+// TestMixedBrain starts two current and two release servers, then replaces each
+// server once while Omes exercises the mixed-version cluster.
 // Uses PostgreSQL because older release config templates do not support SQLite.
 func TestMixedBrain(t *testing.T) {
 	tmpDir := t.TempDir()
 	logRoot := logDir(t)
 
 	omesBinary := filepath.Join(tmpDir, "omes-bin")
-
-	currentLog := filepath.Join(logRoot, "mixedbrain_process-current.log")
-	releaseLog := filepath.Join(logRoot, "mixedbrain_process-release.log")
 
 	var releaseTag string
 	t.Run("setup", func(t *testing.T) {
@@ -121,99 +118,159 @@ func TestMixedBrain(t *testing.T) {
 		t.Fatalf("mixedbrain requires PostgreSQL because older release config templates do not support SQLite")
 	}
 	persistence := devserver.PersistenceOptions{Driver: persistenceDriver}
-
-	var currentSrv, releaseSrv *devserver.Server
-	var currentLogFile, releaseLogFile *os.File
-	var conn *grpc.ClientConn
-	var proxy *frontendProxy
+	instances := []*serverInstance{
+		{
+			name:    "current-0",
+			version: "current",
+			logPath: filepath.Join(logRoot, "mixedbrain_process-current-0.log"),
+			options: devserver.Options{SourceDir: sourceRoot(), Persistence: persistence},
+		},
+		{
+			name:    "current-1",
+			version: "current",
+			logPath: filepath.Join(logRoot, "mixedbrain_process-current-1.log"),
+			options: devserver.Options{SourceDir: sourceRoot(), Persistence: persistence},
+		},
+		{
+			name:    "release-0",
+			version: "release",
+			logPath: filepath.Join(logRoot, "mixedbrain_process-release-0.log"),
+			options: devserver.Options{Ref: releaseTag, Persistence: persistence},
+		},
+		{
+			name:    "release-1",
+			version: "release",
+			logPath: filepath.Join(logRoot, "mixedbrain_process-release-1.log"),
+			options: devserver.Options{Ref: releaseTag, Persistence: persistence},
+		},
+	}
+	for _, instance := range instances {
+		if err := os.Remove(instance.logPath); !os.IsNotExist(err) {
+			require.NoError(t, err)
+		}
+	}
+	t.Cleanup(func() {
+		for _, instance := range instances {
+			if err := instance.stop(); err != nil {
+				t.Errorf("stop %s during cleanup: %v", instance.name, err)
+			}
+		}
+	})
 	runID := fmt.Sprintf("mixed-brain-%d", time.Now().Unix())
 
-	t.Run("start current server", func(st *testing.T) {
-		// Server processes use the parent t so their context survives this sub-test.
-		currentSrv, currentLogFile = startDevServer(t, "current", currentLog, devserver.Options{
-			SourceDir:   sourceRoot(),
-			Persistence: persistence,
-		})
-
-		var err error
-		conn, err = grpc.NewClient(currentSrv.FrontendHostPort(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	t.Run("start servers", func(st *testing.T) {
+		require.NoError(st, instances[0].start(t.Context(), ""))
+		conn, err := grpc.NewClient(instances[0].frontendAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 		require.NoError(st, err)
+		defer func() { _ = conn.Close() }()
 
-		// This ensures the current server is fully booted before starting the release
-		// server. Registering every scenario's namespace here gives them the full
-		// cluster-formation window to propagate to all services before Omes connects.
 		for _, s := range scenarios {
 			registerNamespace(st, conn, s.namespace)
 		}
-	})
-	if t.Failed() {
-		return
-	}
-	defer func() { _ = conn.Close() }()
-
-	t.Run("start release server", func(_ *testing.T) {
-		releaseSrv, releaseLogFile = startDevServer(t, "release", releaseLog, devserver.Options{
-			Ref:         releaseTag,
-			Persistence: persistence,
-			ClusterEndpoint: devserver.ClusterEndpoint{
-				RPCAddress: currentSrv.FrontendHostPort(),
-			},
-		})
+		for _, instance := range instances[1:] {
+			require.NoError(st, instance.start(t.Context(), instances[0].frontendAddress()))
+		}
 	})
 	if t.Failed() {
 		return
 	}
 
 	t.Run("form cluster", func(st *testing.T) {
-		waitForClusterFormation(st, conn, 90*time.Second, currentSrv.Ports(), releaseSrv.Ports())
+		conn, err := grpc.NewClient(instances[0].frontendAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+		require.NoError(st, err)
+		defer func() { _ = conn.Close() }()
+		waitForClusterFormation(st, conn, 90*time.Second, instancePorts(instances)...)
 	})
 	if t.Failed() {
 		return
 	}
 
-	t.Run("run omes", func(st *testing.T) {
+	proxy := startFrontendProxy(t)
+	t.Cleanup(proxy.stop)
+	for _, instance := range instances {
+		require.NoError(t, proxy.AddBackend(instance.name, instance.version, instance.frontendAddress()))
+	}
+
+	t.Run("run omes and roll servers", func(st *testing.T) {
+		conn, err := grpc.NewClient(instances[0].frontendAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+		require.NoError(st, err)
+		defer func() { _ = conn.Close() }()
+
 		// The scenario's run ID determines its task queue (omes-<run ID>).
 		// throughput_stress owns the Nexus endpoint, so target its task queue.
 		throughput := scenarios[0]
 		createNexusEndpoint(st, conn, nexusEndpoint, throughput.namespace, "omes-"+runID+"-"+throughput.name)
 
-		proxy = startFrontendProxy(st, currentSrv.FrontendHostPort(), releaseSrv.FrontendHostPort())
-		st.Cleanup(proxy.stop)
-
+		duration := testDuration()
+		workloadDeadline := time.Now().Add(duration)
+		finalSoak := duration / 5
+		omesCtx, cancelOmes := context.WithCancel(st.Context())
+		results := make(chan omesResult, len(scenarios))
+		var omesWG sync.WaitGroup
+		defer omesWG.Wait()
+		defer cancelOmes()
 		for _, scenario := range scenarios {
-			st.Run(scenario.name, func(sst *testing.T) {
-				sst.Parallel()
+			omesWG.Go(func() {
 				logPath := filepath.Join(logRoot, "mixedbrain_omes_"+scenario.name+".log")
-				runOmes(sst, omesBinary, proxy.addr(), logPath, testDuration(), scenario, runID+"-"+scenario.name)
+				err := runOmes(omesCtx, st, omesBinary, proxy.addr(), logPath, duration, scenario, runID+"-"+scenario.name)
+				results <- omesResult{name: scenario.name, err: err}
 			})
 		}
-	})
-	if t.Failed() {
-		return
-	}
 
-	t.Run("verify", func(st *testing.T) {
-		requireServerAlive(st, "current", currentSrv.FrontendHostPort())
-		requireServerAlive(st, "release", releaseSrv.FrontendHostPort())
+		workloadCtx, cancelWorkload := context.WithDeadline(st.Context(), workloadDeadline)
+		defer cancelWorkload()
+		require.NoError(st, waitForProxyTraffic(workloadCtx, proxy))
 
-		for i, backend := range []string{"current", "release"} {
-			count := proxy.callCount[i].Load()
-			st.Logf("Proxy RPCs to %s: %d", backend, count)
-			require.Positive(st, count, "expected proxy to route RPCs to %s server", backend)
+		rollOrder := []*serverInstance{instances[0], instances[2], instances[1], instances[3]}
+		for i, instance := range rollOrder {
+			remainingRolls := len(rollOrder) - i
+			dwell := (time.Until(workloadDeadline) - finalSoak) / time.Duration(remainingRolls)
+			require.Positive(st, dwell, "workload deadline elapsed before replacing %s", instance.name)
+			require.NoError(st, waitForRollDwell(workloadCtx, dwell, results))
+			st.Logf("Replacing %s with %v remaining", instance.name, time.Until(workloadDeadline))
+			require.NoError(st, replaceServer(t.Context(), workloadCtx, proxy, instance, instances))
+		}
+
+		for range scenarios {
+			select {
+			case result := <-results:
+				require.NoError(st, result.err, "Omes %s failed", result.name)
+			case <-st.Context().Done():
+				st.Fatalf("Omes did not complete: %v", context.Cause(st.Context()))
+			}
 		}
 	})
+	if !t.Failed() {
+		t.Run("verify", func(st *testing.T) {
+			for _, instance := range instances {
+				requireServerAlive(st, instance.name, instance.frontendAddress())
+				count, ok := proxy.BackendCallCount(instance.name)
+				require.True(st, ok)
+				st.Logf("Proxy RPCs to %s: %d", instance.name, count)
+				require.Positive(st, count, "expected proxy to route RPCs to %s", instance.name)
+			}
+			for _, version := range []string{"current", "release"} {
+				require.Positive(st, proxy.VersionCallCount(version), "expected proxy traffic to %s servers", version)
+			}
+		})
+	}
 
 	// Stop the servers so their logs are fully flushed, then scan them for
 	// panics, soft-assertion failures, and other problems that don't surface as
 	// a process exit. Runs regardless of whether "verify" failed, since a crashed
 	// server's log is exactly what we want to inspect.
-	_ = currentSrv.Stop()
-	_ = releaseSrv.Stop()
-	_ = currentLogFile.Close()
-	_ = releaseLogFile.Close()
+	for _, instance := range instances {
+		if err := instance.stop(); err != nil {
+			t.Errorf("stop %s: %v", instance.name, err)
+		}
+	}
 
 	t.Run("scan server logs", func(st *testing.T) {
-		problems, err := scanServerLogs(serverLogValidators, currentLog, releaseLog)
+		logPaths := make([]string, 0, len(instances))
+		for _, instance := range instances {
+			logPaths = append(logPaths, instance.logPath)
+		}
+		problems, err := scanServerLogs(serverLogValidators, logPaths...)
 		require.NoError(st, err)
 		for _, p := range problems {
 			st.Error(p)
@@ -221,20 +278,132 @@ func TestMixedBrain(t *testing.T) {
 	})
 }
 
+type omesResult struct {
+	name string
+	err  error
+}
+
+func instancePorts(instances []*serverInstance) []devserver.Ports {
+	ports := make([]devserver.Ports, 0, len(instances))
+	for _, instance := range instances {
+		if instance.server != nil {
+			ports = append(ports, instance.ports)
+		}
+	}
+	return ports
+}
+
+func waitForProxyTraffic(ctx context.Context, proxy *frontendProxy) error {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if proxy.VersionCallCount("current")+proxy.VersionCallCount("release") > 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for Omes proxy traffic: %w", context.Cause(ctx))
+		case <-ticker.C:
+		}
+	}
+}
+
+func waitForRollDwell(ctx context.Context, dwell time.Duration, results <-chan omesResult) error {
+	timer := time.NewTimer(dwell)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case result := <-results:
+		if result.err != nil {
+			return fmt.Errorf("Omes %s failed before server roll completed: %w", result.name, result.err)
+		}
+		return fmt.Errorf("Omes %s completed before server roll completed", result.name)
+	case <-ctx.Done():
+		return fmt.Errorf("wait before server roll: %w", context.Cause(ctx))
+	}
+}
+
+func replaceServer(
+	startCtx context.Context,
+	membershipCtx context.Context,
+	proxy *frontendProxy,
+	instance *serverInstance,
+	instances []*serverInstance,
+) error {
+	if err := proxy.RemoveBackend(instance.name); err != nil {
+		return fmt.Errorf("remove %s from proxy: %w", instance.name, err)
+	}
+
+	oldPorts := instance.ports
+	if err := instance.stop(); err != nil {
+		return fmt.Errorf("stop %s: %w", instance.name, err)
+	}
+	var clusterEndpoint string
+	for _, candidate := range instances {
+		if candidate.server != nil {
+			clusterEndpoint = candidate.frontendAddress()
+			break
+		}
+	}
+	if clusterEndpoint == "" {
+		return fmt.Errorf("replace %s: no surviving frontend", instance.name)
+	}
+	if err := waitForClusterMembership(membershipCtx, instances, []devserver.Ports{oldPorts}); err != nil {
+		return fmt.Errorf("wait for %s to leave membership: %w", instance.name, err)
+	}
+	if err := instance.start(startCtx, clusterEndpoint); err != nil {
+		return err
+	}
+	if err := waitForClusterMembership(membershipCtx, instances, nil); err != nil {
+		return fmt.Errorf("wait for replacement %s to join membership: %w", instance.name, err)
+	}
+	if err := proxy.AddBackend(instance.name, instance.version, instance.frontendAddress()); err != nil {
+		return fmt.Errorf("re-add %s to proxy: %w", instance.name, err)
+	}
+	return nil
+}
+
+func waitForClusterMembership(ctx context.Context, instances []*serverInstance, absent []devserver.Ports) error {
+	present := instancePorts(instances)
+	for _, instance := range instances {
+		if instance.server == nil {
+			continue
+		}
+		if err := waitForMembership(ctx, instance.frontendAddress(), present, absent); err != nil {
+			return fmt.Errorf("wait for %s membership: %w", instance.name, err)
+		}
+	}
+	return nil
+}
+
 // runOmes runs the given Omes scenario against serverAddr under the given run ID.
 // Retries if Omes fails due to search attribute not being ready yet.
 // Deducts elapsed time from duration on retry so total wall time stays bounded.
-func runOmes(t *testing.T, binary, serverAddr, logPath string, duration time.Duration, scenario omesScenario, runID string) {
+func runOmes(
+	ctx context.Context,
+	t *testing.T,
+	binary string,
+	serverAddr string,
+	logPath string,
+	duration time.Duration,
+	scenario omesScenario,
+	runID string,
+) error {
 	t.Helper()
 	t.Logf("Running Omes %s for %v against %s", scenario.name, duration, serverAddr)
 
 	started := time.Now()
 	for {
 		remaining := duration - time.Since(started)
-		require.Greater(t, remaining, 10*time.Second, "Omes never started successfully, check %s", logPath)
+		if remaining <= 10*time.Second {
+			return fmt.Errorf("Omes never started successfully, check %s", logPath)
+		}
 
 		logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-		require.NoError(t, err)
+		if err != nil {
+			return err
+		}
 
 		args := []string{
 			"run-scenario-with-worker",
@@ -252,7 +421,7 @@ func runOmes(t *testing.T, binary, serverAddr, logPath string, duration time.Dur
 		}
 
 		var buf bytes.Buffer
-		cmd := exec.CommandContext(t.Context(), binary, args...)
+		cmd := exec.CommandContext(ctx, binary, args...)
 		cmd.Env = append(os.Environ(), "GOTOOLCHAIN=auto") // Omes workers may require a newer toolchain
 		cmd.Stdout = logFile
 		cmd.Stderr = io.MultiWriter(logFile, &buf)
@@ -260,12 +429,20 @@ func runOmes(t *testing.T, binary, serverAddr, logPath string, duration time.Dur
 		cmd.WaitDelay = 15 * time.Second
 
 		err = cmd.Run()
-		_ = logFile.Close()
+		closeErr := logFile.Close()
 		if err != nil && strings.Contains(buf.String(), "no mapping defined for search attribute") {
+			if closeErr != nil {
+				return fmt.Errorf("close Omes log %s: %w", logPath, closeErr)
+			}
 			t.Log("Omes failed due to search attributes not ready, retrying...")
 			continue
 		}
-		require.NoError(t, err, "Omes scenario failed, check %s", logPath)
-		return
+		if err != nil {
+			return fmt.Errorf("Omes scenario failed, check %s: %w", logPath, err)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("close Omes log %s: %w", logPath, closeErr)
+		}
+		return nil
 	}
 }

--- a/tests/mixedbrain/proxy_util.go
+++ b/tests/mixedbrain/proxy_util.go
@@ -2,6 +2,7 @@ package mixedbrain
 
 import (
 	"context"
+	"errors"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -10,54 +11,52 @@ import (
 	"github.com/siderolabs/grpc-proxy/proxy"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	_ "google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
-// frontendProxy is a gRPC proxy that distributes RPCs round-robin across
-// multiple frontend backends, ensuring Omes exercises both servers.
-type frontendProxy struct {
-	listener  net.Listener
-	server    *grpc.Server
-	conns     []*grpc.ClientConn
-	backends  []proxy.Backend
-	callCount []atomic.Int64
-	next      atomic.Int64
-	wg        sync.WaitGroup
+var (
+	errBackendAlreadyActive  = errors.New("backend is already active")
+	errBackendNotFound       = errors.New("backend is not active")
+	errBackendVersionChanged = errors.New("backend version changed")
+)
+
+type frontendBackend struct {
+	name    string
+	version string
+	backend proxy.Backend
+	count   atomic.Int64
 }
 
-func startFrontendProxy(t *testing.T, addresses ...string) *frontendProxy {
+// frontendProxy is a gRPC proxy that distributes RPCs round-robin across the
+// active frontend backends.
+type frontendProxy struct {
+	listener net.Listener
+	server   *grpc.Server
+
+	mu       sync.RWMutex
+	active   []*frontendBackend
+	backends map[string]*frontendBackend
+	conns    []*grpc.ClientConn
+	next     atomic.Uint64
+
+	wg sync.WaitGroup
+}
+
+func startFrontendProxy(t *testing.T) *frontendProxy {
 	t.Helper()
-	require.NotEmpty(t, addresses)
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
 	p := &frontendProxy{
-		listener:  listener,
-		conns:     make([]*grpc.ClientConn, 0, len(addresses)),
-		backends:  make([]proxy.Backend, 0, len(addresses)),
-		callCount: make([]atomic.Int64, len(addresses)),
+		listener: listener,
+		backends: make(map[string]*frontendBackend),
 	}
 	codec := proxy.Codec()
-	for _, address := range addresses {
-		conn, err := grpc.NewClient(
-			address,
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-			grpc.WithDefaultCallOptions(grpc.ForceCodecV2(codec)),
-		)
-		require.NoError(t, err)
-		p.conns = append(p.conns, conn)
-		p.backends = append(p.backends, &proxy.SingleBackend{
-			GetConn: func(ctx context.Context) (context.Context, *grpc.ClientConn, error) {
-				md, _ := metadata.FromIncomingContext(ctx)
-				outCtx := metadata.NewOutgoingContext(ctx, md.Copy())
-				return outCtx, conn, nil
-			},
-		})
-	}
-
 	p.server = grpc.NewServer(
 		grpc.ForceServerCodecV2(codec),
 		grpc.UnknownServiceHandler(proxy.TransparentHandler(p.director)),
@@ -72,18 +71,108 @@ func (p *frontendProxy) addr() string {
 	return p.listener.Addr().String()
 }
 
+func (p *frontendProxy) AddBackend(name, version, address string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if existing, ok := p.backends[name]; ok {
+		for _, active := range p.active {
+			if active == existing {
+				return errBackendAlreadyActive
+			}
+		}
+		if existing.version != version {
+			return errBackendVersionChanged
+		}
+	}
+
+	codec := proxy.Codec()
+	conn, err := grpc.NewClient(
+		address,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.ForceCodecV2(codec)),
+	)
+	if err != nil {
+		return err
+	}
+	backend := &proxy.SingleBackend{
+		GetConn: func(ctx context.Context) (context.Context, *grpc.ClientConn, error) {
+			md, _ := metadata.FromIncomingContext(ctx)
+			return metadata.NewOutgoingContext(ctx, md.Copy()), conn, nil
+		},
+	}
+
+	entry, ok := p.backends[name]
+	if !ok {
+		entry = &frontendBackend{name: name, version: version}
+		p.backends[name] = entry
+	}
+	entry.backend = backend
+	p.active = append(p.active, entry)
+	p.conns = append(p.conns, conn)
+	return nil
+}
+
+func (p *frontendProxy) RemoveBackend(name string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	entry, ok := p.backends[name]
+	if !ok {
+		return errBackendNotFound
+	}
+	for i, active := range p.active {
+		if active == entry {
+			p.active = append(p.active[:i], p.active[i+1:]...)
+			return nil
+		}
+	}
+	return errBackendNotFound
+}
+
+func (p *frontendProxy) BackendCallCount(name string) (int64, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	backend, ok := p.backends[name]
+	if !ok {
+		return 0, false
+	}
+	return backend.count.Load(), true
+}
+
+func (p *frontendProxy) VersionCallCount(version string) int64 {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	var count int64
+	for _, backend := range p.backends {
+		if backend.version == version {
+			count += backend.count.Load()
+		}
+	}
+	return count
+}
+
 func (p *frontendProxy) stop() {
 	p.server.Stop()
+	p.mu.Lock()
 	for _, conn := range p.conns {
 		_ = conn.Close()
 	}
+	p.active = nil
+	p.mu.Unlock()
 	_ = p.listener.Close()
 	p.wg.Wait()
 }
 
-func (p *frontendProxy) director(ctx context.Context, _ string) (proxy.Mode, []proxy.Backend, error) {
-	idx := int(p.next.Add(1)-1) % len(p.backends)
-	p.callCount[idx].Add(1)
+func (p *frontendProxy) director(context.Context, string) (proxy.Mode, []proxy.Backend, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if len(p.active) == 0 {
+		return proxy.One2One, nil, status.Error(codes.Unavailable, "no frontend backends are active")
+	}
 
-	return proxy.One2One, p.backends[idx : idx+1], nil
+	idx := p.next.Add(1) - 1
+	backend := p.active[idx%uint64(len(p.active))]
+	backend.count.Add(1)
+	return proxy.One2One, []proxy.Backend{backend.backend}, nil
 }

--- a/tests/mixedbrain/proxy_util_test.go
+++ b/tests/mixedbrain/proxy_util_test.go
@@ -1,0 +1,103 @@
+package mixedbrain
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestFrontendProxyRoundRobin(t *testing.T) {
+	p := startFrontendProxy(t)
+	t.Cleanup(p.stop)
+	require.NoError(t, p.AddBackend("current-0", "current", "127.0.0.1:1"))
+	require.NoError(t, p.AddBackend("release-0", "release", "127.0.0.1:2"))
+
+	for range 6 {
+		_, _, err := p.director(context.Background(), "")
+		require.NoError(t, err)
+	}
+
+	current, ok := p.BackendCallCount("current-0")
+	require.True(t, ok)
+	require.Equal(t, int64(3), current)
+	require.Equal(t, int64(3), p.VersionCallCount("release"))
+}
+
+func TestFrontendProxyReplacementPreservesCount(t *testing.T) {
+	p := startFrontendProxy(t)
+	t.Cleanup(p.stop)
+	require.NoError(t, p.AddBackend("current-0", "current", "127.0.0.1:1"))
+	_, _, err := p.director(context.Background(), "")
+	require.NoError(t, err)
+
+	require.NoError(t, p.RemoveBackend("current-0"))
+	require.NoError(t, p.AddBackend("current-0", "current", "127.0.0.1:2"))
+	_, _, err = p.director(context.Background(), "")
+	require.NoError(t, err)
+
+	count, ok := p.BackendCallCount("current-0")
+	require.True(t, ok)
+	require.Equal(t, int64(2), count)
+}
+
+func TestFrontendProxyBackendErrors(t *testing.T) {
+	p := startFrontendProxy(t)
+	t.Cleanup(p.stop)
+
+	require.ErrorIs(t, p.RemoveBackend("missing"), errBackendNotFound)
+	require.NoError(t, p.AddBackend("current-0", "current", "127.0.0.1:1"))
+	require.ErrorIs(t, p.AddBackend("current-0", "current", "127.0.0.1:2"), errBackendAlreadyActive)
+	require.NoError(t, p.RemoveBackend("current-0"))
+	require.ErrorIs(t, p.RemoveBackend("current-0"), errBackendNotFound)
+	require.ErrorIs(t, p.AddBackend("current-0", "release", "127.0.0.1:2"), errBackendVersionChanged)
+}
+
+func TestFrontendProxyUnavailableWithNoBackends(t *testing.T) {
+	p := startFrontendProxy(t)
+	t.Cleanup(p.stop)
+
+	_, _, err := p.director(context.Background(), "")
+	require.Equal(t, codes.Unavailable, status.Code(err))
+}
+
+func TestFrontendProxyConcurrentAddRemoveAndRoute(t *testing.T) {
+	p := startFrontendProxy(t)
+	t.Cleanup(p.stop)
+	require.NoError(t, p.AddBackend("stable", "current", "127.0.0.1:1"))
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 8)
+	for range 8 {
+		wg.Go(func() {
+			for range 500 {
+				_, _, err := p.director(context.Background(), "")
+				if err != nil {
+					errs <- fmt.Errorf("route request: %w", err)
+					return
+				}
+			}
+		})
+	}
+	for i := range 100 {
+		name := "churn"
+		require.NoError(t, p.AddBackend(name, "release", "127.0.0.1:2"))
+		_, _, err := p.director(context.Background(), "")
+		require.NoError(t, err)
+		require.NoError(t, p.RemoveBackend(name), i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	stable, ok := p.BackendCallCount("stable")
+	require.True(t, ok)
+	require.Positive(t, stable)
+	require.Positive(t, p.VersionCallCount("release"))
+}

--- a/tests/mixedbrain/server_util.go
+++ b/tests/mixedbrain/server_util.go
@@ -2,6 +2,8 @@ package mixedbrain
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"os"
 	"strconv"
@@ -20,6 +22,62 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
+
+type serverInstance struct {
+	name    string
+	version string
+	logPath string
+	options devserver.Options
+
+	server  *devserver.Server
+	ports   devserver.Ports
+	logFile *os.File
+}
+
+func (s *serverInstance) start(ctx context.Context, clusterEndpoint string) error {
+	logFile, err := os.OpenFile(s.logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return fmt.Errorf("open %s log: %w", s.name, err)
+	}
+
+	options := s.options
+	options.Output = logFile
+	options.ClusterEndpoint = devserver.ClusterEndpoint{RPCAddress: clusterEndpoint}
+	if s.ports != (devserver.Ports{}) {
+		options.Ports = &s.ports
+	}
+	server, err := devserver.Start(ctx, options)
+	if err != nil {
+		return errors.Join(fmt.Errorf("start %s server: %w", s.name, err), logFile.Close())
+	}
+
+	s.server = server
+	s.ports = server.Ports()
+	s.logFile = logFile
+	return nil
+}
+
+func (s *serverInstance) stop() error {
+	var errs []error
+	if s.server != nil {
+		if err := s.server.Stop(); err != nil {
+			errs = append(errs, err)
+		}
+		s.server = nil
+	}
+	if s.logFile != nil {
+		errs = append(errs, s.logFile.Close())
+		s.logFile = nil
+	}
+	return errors.Join(errs...)
+}
+
+func (s *serverInstance) frontendAddress() string {
+	if s.server == nil {
+		return ""
+	}
+	return s.server.FrontendHostPort()
+}
 
 func registerNamespace(t *testing.T, conn *grpc.ClientConn, namespace string) {
 	t.Helper()
@@ -64,27 +122,6 @@ func createNexusEndpoint(t *testing.T, conn *grpc.ClientConn, endpointName, name
 		st, ok := status.FromError(err)
 		return ok && st.Code() == codes.AlreadyExists
 	}, retryTimeout, time.Second, "failed to create nexus endpoint %s", endpointName)
-}
-
-func startDevServer(t *testing.T, name, logPath string, opts devserver.Options) (*devserver.Server, *os.File) {
-	t.Helper()
-
-	f, err := os.Create(logPath)
-	require.NoError(t, err)
-
-	var srv *devserver.Server
-	t.Cleanup(func() {
-		if srv != nil {
-			_ = srv.Stop()
-		}
-	})
-	t.Cleanup(func() { _ = f.Close() })
-
-	opts.Output = f
-	srv, err = devserver.Start(t.Context(), opts)
-	require.NoError(t, err, "start %s server", name)
-
-	return srv, f
 }
 
 // waitForClusterFormation waits until the server's reachable members include
@@ -133,6 +170,86 @@ func waitForClusterFormation(t *testing.T, conn *grpc.ClientConn, timeout time.D
 		}
 		return true
 	}, timeout, time.Second, "cluster did not form within %v", timeout)
+}
+
+func waitForMembership(
+	ctx context.Context,
+	frontendAddress string,
+	present []devserver.Ports,
+	absent []devserver.Ports,
+) error {
+	conn, err := grpc.NewClient(frontendAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+	client := adminservice.NewAdminServiceClient(conn)
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	var lastErr error
+	for {
+		requestCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		resp, err := client.DescribeCluster(requestCtx, &adminservice.DescribeClusterRequest{})
+		cancel()
+		if err == nil {
+			seen := membershipPorts(resp.GetMembershipInfo().GetReachableMembers())
+			if membershipMatches(seen, present, absent) {
+				return nil
+			}
+			lastErr = fmt.Errorf("membership has not converged")
+		} else {
+			lastErr = err
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for membership: %w (last error: %v)", context.Cause(ctx), lastErr)
+		case <-ticker.C:
+		}
+	}
+}
+
+func membershipPorts(members []string) map[int]struct{} {
+	seen := make(map[int]struct{}, len(members))
+	for _, member := range members {
+		_, portString, err := net.SplitHostPort(member)
+		if err != nil {
+			continue
+		}
+		port, err := strconv.Atoi(portString)
+		if err == nil {
+			seen[port] = struct{}{}
+		}
+	}
+	return seen
+}
+
+func membershipMatches(seen map[int]struct{}, present, absent []devserver.Ports) bool {
+	for _, ports := range present {
+		for _, port := range serverMembershipPorts(ports) {
+			if _, ok := seen[port]; !ok {
+				return false
+			}
+		}
+	}
+	for _, ports := range absent {
+		for _, port := range serverMembershipPorts(ports) {
+			if _, ok := seen[port]; ok {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func serverMembershipPorts(ports devserver.Ports) []int {
+	return []int{
+		ports.FrontendMembership,
+		ports.HistoryMembership,
+		ports.MatchingMembership,
+		ports.WorkerMembership,
+	}
 }
 
 func requireServerAlive(t *testing.T, name, address string) {


### PR DESCRIPTION
## Summary
- roll four mixed-version server instances while OMES workloads run
- retain each instance's port allocation across replacements and verify membership convergence
- route through a mutable frontend proxy and add proxy lifecycle coverage
- temporarily resolve OMES from the exact commit in temporalio/omes#426; replace this with the upstream pseudo-version after it merges

## Root cause
Replacement dev servers were allocated new ports, leaving clients able to dial departed frontend addresses.

## Validation
- go test -tags test_dep ./devserver (OMES)
- go test -tags test_dep -run TestFrontendProxy . (mixedbrain)
- make lint-code
- PERSISTENCE_DRIVER=postgres12 MIXED_BRAIN_TEST_DURATION=2m make mixed-brain-test