### PR TITLE
[CHASM] reject custom search attributes with Temporal prefix

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -190,11 +190,14 @@ func NewStandaloneActivity(
 	ctx chasm.MutableContext,
 	request *workflowservice.StartActivityExecutionRequest,
 ) (*Activity, error) {
-	visibility := chasm.NewVisibilityWithData(
+	visibility, err := chasm.NewVisibilityWithData(
 		ctx,
 		request.GetSearchAttributes().GetIndexedFields(),
 		nil,
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	activity := &Activity{
 		ActivityState: &activitypb.ActivityState{

--- a/chasm/lib/nexusoperation/operation.go
+++ b/chasm/lib/nexusoperation/operation.go
@@ -128,11 +128,15 @@ func newStandaloneOperation(
 		UserMetadata: frontendReq.GetUserMetadata(),
 		Identity:     frontendReq.GetIdentity(),
 	})
-	op.Visibility = chasm.NewComponentField(ctx, chasm.NewVisibilityWithData(
+	visibility, err := chasm.NewVisibilityWithData(
 		ctx,
 		frontendReq.GetSearchAttributes().GetIndexedFields(),
 		nil,
-	))
+	)
+	if err != nil {
+		return nil, err
+	}
+	op.Visibility = chasm.NewComponentField(ctx, visibility)
 	if err := TransitionScheduled.Apply(op, ctx, EventScheduled{}); err != nil {
 		return nil, err
 	}

--- a/chasm/lib/nexusoperation/operation_test.go
+++ b/chasm/lib/nexusoperation/operation_test.go
@@ -366,13 +366,15 @@ func TestOperation_BuildExecutionInfo_ReturnsIsolatedSearchAttributes(t *testing
 
 	op := NewOperation(&nexusoperationpb.OperationState{Status: nexusoperationpb.OPERATION_STATUS_STARTED})
 	op.RequestData = chasm.NewDataField(ctx, &nexusoperationpb.OperationRequestData{})
-	op.Visibility = chasm.NewComponentField(ctx, chasm.NewVisibilityWithData(
+	vis, err := chasm.NewVisibilityWithData(
 		ctx,
 		map[string]*commonpb.Payload{"saKey": payload.EncodeString("v")},
 		nil,
-	))
+	)
+	require.NoError(t, err)
+	op.Visibility = chasm.NewComponentField(ctx, vis)
 	require.NoError(t, root.SetRootComponent(op))
-	_, err := root.CloseTransaction()
+	_, err = root.CloseTransaction()
 	require.NoError(t, err)
 
 	ctx = chasm.NewMutableContext(context.Background(), root)

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -255,7 +255,9 @@ func CreateScheduler(
 
 	// Update visibility with custom attributes.
 	visibility := sched.Visibility.Get(ctx)
-	visibility.MergeCustomSearchAttributes(ctx, req.FrontendRequest.GetSearchAttributes().GetIndexedFields())
+	if err := visibility.MergeCustomSearchAttributes(ctx, req.FrontendRequest.GetSearchAttributes().GetIndexedFields()); err != nil {
+		return nil, err
+	}
 	visibility.MergeCustomMemo(ctx, req.FrontendRequest.GetMemo().GetFields())
 
 	return sched, nil
@@ -303,7 +305,9 @@ func CreateSchedulerFromMigration(
 
 	visibility := chasm.NewVisibility(ctx)
 	sched.Visibility = chasm.NewComponentField(ctx, visibility)
-	visibility.MergeCustomSearchAttributes(ctx, state.GetSearchAttributes())
+	if err := visibility.MergeCustomSearchAttributes(ctx, state.GetSearchAttributes()); err != nil {
+		return nil, err
+	}
 	visibility.MergeCustomMemo(ctx, state.GetMemo())
 
 	// Defer generation until SchedulerCallbacksTask resolves stale running-workflow
@@ -871,7 +875,10 @@ func (s *Scheduler) Update(
 		oldVisibility := s.Visibility.Get(ctx)
 		oldMemo := oldVisibility.CustomMemo(ctx)
 
-		visibility := chasm.NewVisibilityWithData(ctx, req.FrontendRequest.GetSearchAttributes().GetIndexedFields(), oldMemo)
+		visibility, err := chasm.NewVisibilityWithData(ctx, req.FrontendRequest.GetSearchAttributes().GetIndexedFields(), oldMemo)
+		if err != nil {
+			return nil, err
+		}
 		s.Visibility = chasm.NewComponentField(ctx, visibility)
 	}
 

--- a/chasm/lib/scheduler/scheduler_test.go
+++ b/chasm/lib/scheduler/scheduler_test.go
@@ -665,7 +665,7 @@ func TestScheduler_Describe_ReturnsIsolatedVisibilityMaps(t *testing.T) {
 
 	vis := sched.Visibility.Get(ctx)
 	vis.MergeCustomMemo(ctx, map[string]*commonpb.Payload{"memoKey": payload.EncodeString("v")})
-	vis.MergeCustomSearchAttributes(ctx, map[string]*commonpb.Payload{"saKey": payload.EncodeString("v")})
+	require.NoError(t, vis.MergeCustomSearchAttributes(ctx, map[string]*commonpb.Payload{"saKey": payload.EncodeString("v")}))
 
 	resp, err := sched.Describe(ctx, &schedulerpb.DescribeScheduleRequest{
 		NamespaceId: namespaceID,

--- a/chasm/visibility.go
+++ b/chasm/visibility.go
@@ -195,7 +195,11 @@ func NewVisibilityWithData(
 	mutableContext MutableContext,
 	customSearchAttributes map[string]*commonpb.Payload,
 	customMemo map[string]*commonpb.Payload,
-) *Visibility {
+) (*Visibility, error) {
+	if err := validateNoReservedSearchAttributes(customSearchAttributes); err != nil {
+		return nil, err
+	}
+
 	visibility := &Visibility{
 		Data: &persistencespb.ChasmVisibilityData{
 			TransitionCount: 0,
@@ -221,7 +225,23 @@ func NewVisibilityWithData(
 	}
 
 	visibility.generateTask(mutableContext)
-	return visibility
+	return visibility, nil
+}
+
+// validateNoReservedSearchAttributes rejects any custom search attribute whose name uses
+// the reserved `Temporal` prefix. System search attributes (e.g. TemporalScheduledStartTime,
+// TemporalSchedulePaused) all use this prefix and must never be written as custom search
+// attributes. Validation is atomic: if any key is reserved, the entire input is rejected.
+func validateNoReservedSearchAttributes(customSearchAttributes map[string]*commonpb.Payload) error {
+	for name := range customSearchAttributes {
+		if strings.HasPrefix(name, sadefs.ReservedPrefix) {
+			return serviceerror.NewInvalidArgumentf(
+				"custom search attribute %q uses the reserved %q prefix and cannot be set",
+				name, sadefs.ReservedPrefix,
+			)
+		}
+	}
+	return nil
 }
 
 func (v *Visibility) LifecycleState(_ Context) LifecycleState {
@@ -251,9 +271,13 @@ func (v *Visibility) CustomSearchAttributes(
 func (v *Visibility) MergeCustomSearchAttributes(
 	mutableContext MutableContext,
 	customSearchAttributes map[string]*commonpb.Payload,
-) {
+) error {
 	if len(customSearchAttributes) == 0 {
-		return
+		return nil
+	}
+
+	if err := validateNoReservedSearchAttributes(customSearchAttributes); err != nil {
+		return err
 	}
 
 	currentSA, ok := v.SA.TryGet(mutableContext)
@@ -271,6 +295,7 @@ func (v *Visibility) MergeCustomSearchAttributes(
 	}
 
 	v.generateTask(mutableContext)
+	return nil
 }
 
 // ReplaceCustomSearchAttributes replaces the existing custom search attribute fields with the provided ones.
@@ -279,7 +304,11 @@ func (v *Visibility) MergeCustomSearchAttributes(
 func (v *Visibility) ReplaceCustomSearchAttributes(
 	mutableContext MutableContext,
 	customSearchAttributes map[string]*commonpb.Payload,
-) {
+) error {
+	if err := validateNoReservedSearchAttributes(customSearchAttributes); err != nil {
+		return err
+	}
+
 	// Filter out nil/empty payload values.
 	filteredSA := payload.MergeMapOfPayload(nil, customSearchAttributes)
 
@@ -287,7 +316,7 @@ func (v *Visibility) ReplaceCustomSearchAttributes(
 		_, ok := v.SA.TryGet(mutableContext)
 		if !ok {
 			// Already empty, no-op
-			return
+			return nil
 		}
 
 		v.SA = NewEmptyField[*commonpb.SearchAttributes]()
@@ -299,6 +328,7 @@ func (v *Visibility) ReplaceCustomSearchAttributes(
 	}
 
 	v.generateTask(mutableContext)
+	return nil
 }
 
 // CustomMemo returns the stored custom memo fields.

--- a/chasm/visibility_test.go
+++ b/chasm/visibility_test.go
@@ -6,9 +6,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/serviceerror"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/payload"
+	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/testing/protorequire"
 )
 
@@ -77,7 +79,7 @@ func (s *visibilitySuite) TestMergeCustomSearchAttributes() {
 	floatKey, floatVal := "floatKey", 3.14
 
 	// Add SA via Visibility struct method.
-	s.visibility.MergeCustomSearchAttributes(
+	err := s.visibility.MergeCustomSearchAttributes(
 		s.mockMutableContext,
 		map[string]*commonpb.Payload{
 			stringKey: s.mustEncode(stringVal),
@@ -85,6 +87,7 @@ func (s *visibilitySuite) TestMergeCustomSearchAttributes() {
 			floatKey:  s.mustEncode(floatVal),
 		},
 	)
+	s.NoError(err)
 	s.Len(s.mockMutableContext.Tasks, 1)
 	s.assertTaskPayload(2, s.mockMutableContext.Tasks[0].Payload)
 
@@ -92,7 +95,7 @@ func (s *visibilitySuite) TestMergeCustomSearchAttributes() {
 	s.Len(sa, 3)
 
 	var actualStringVal string
-	err := payload.Decode(sa[stringKey], &actualStringVal)
+	err = payload.Decode(sa[stringKey], &actualStringVal)
 	s.NoError(err)
 	s.Equal(stringVal, actualStringVal)
 
@@ -107,7 +110,7 @@ func (s *visibilitySuite) TestMergeCustomSearchAttributes() {
 	s.Equal(floatVal, actualFloatVal)
 
 	// Test remove search attributes by setting payload to nil.
-	s.visibility.MergeCustomSearchAttributes(s.mockMutableContext, map[string]*commonpb.Payload{
+	err = s.visibility.MergeCustomSearchAttributes(s.mockMutableContext, map[string]*commonpb.Payload{
 		intKey:   s.mustEncode(intVal),
 		floatKey: nil,
 	})
@@ -120,10 +123,11 @@ func (s *visibilitySuite) TestMergeCustomSearchAttributes() {
 	s.Len(sa, 2, "intKey and stringKey should remain")
 
 	// Test removing all search attributes also removes the node.
-	s.visibility.MergeCustomSearchAttributes(s.mockMutableContext, map[string]*commonpb.Payload{
+	err = s.visibility.MergeCustomSearchAttributes(s.mockMutableContext, map[string]*commonpb.Payload{
 		stringKey: nil,
 		intKey:    nil,
 	})
+	s.NoError(err)
 	s.Len(s.mockMutableContext.Tasks, 3)
 	s.assertTaskPayload(4, s.mockMutableContext.Tasks[2].Payload)
 	_, ok := s.visibility.SA.TryGet(s.mockContext)
@@ -145,7 +149,8 @@ func (s *visibilitySuite) TestNewVisibilityWithData_FilterNilSearchAttributes() 
 		"nilKey1": nil,
 		"nilKey2": nil,
 	}
-	visibility := NewVisibilityWithData(s.mockMutableContext, customSearchAttributes, customMemo)
+	visibility, err := NewVisibilityWithData(s.mockMutableContext, customSearchAttributes, customMemo)
+	s.NoError(err)
 	// SA should have only 1 field (nil values filtered out)
 	s.Len(visibility.SA.Get(s.mockContext).IndexedFields, 1)
 	s.NotNil(visibility.SA.Get(s.mockContext).IndexedFields[stringKey])
@@ -161,7 +166,7 @@ func (s *visibilitySuite) TestReplaceCustomSearchAttributes() {
 	byteKey, byteVal := "byteKey", []byte{0x01, 0x02, 0x03}
 
 	// Set up some initial SA.
-	s.visibility.ReplaceCustomSearchAttributes(
+	err := s.visibility.ReplaceCustomSearchAttributes(
 		s.mockMutableContext,
 		map[string]*commonpb.Payload{
 			stringKey: s.mustEncode(stringVal),
@@ -169,6 +174,7 @@ func (s *visibilitySuite) TestReplaceCustomSearchAttributes() {
 			floatKey:  s.mustEncode(floatVal),
 		},
 	)
+	s.NoError(err)
 	s.Len(s.mockMutableContext.Tasks, 1)
 	s.assertTaskPayload(2, s.mockMutableContext.Tasks[0].Payload)
 
@@ -176,13 +182,14 @@ func (s *visibilitySuite) TestReplaceCustomSearchAttributes() {
 	s.Len(sa, 3)
 
 	// Set to a new set of SA, non-existing keys should be removed.
-	s.visibility.ReplaceCustomSearchAttributes(
+	err = s.visibility.ReplaceCustomSearchAttributes(
 		s.mockMutableContext,
 		map[string]*commonpb.Payload{
 			floatKey: s.mustEncode(floatVal),
 			byteKey:  s.mustEncode(byteVal),
 		},
 	)
+	s.NoError(err)
 	s.Len(s.mockMutableContext.Tasks, 2)
 	s.assertTaskPayload(3, s.mockMutableContext.Tasks[1].Payload)
 
@@ -190,10 +197,11 @@ func (s *visibilitySuite) TestReplaceCustomSearchAttributes() {
 	s.Len(sa, 2)
 
 	// Setting to an empty map should remove the node.
-	s.visibility.ReplaceCustomSearchAttributes(
+	err = s.visibility.ReplaceCustomSearchAttributes(
 		s.mockMutableContext,
 		map[string]*commonpb.Payload{},
 	)
+	s.NoError(err)
 	s.Len(s.mockMutableContext.Tasks, 3)
 	s.assertTaskPayload(4, s.mockMutableContext.Tasks[2].Payload)
 	_, ok := s.visibility.SA.TryGet(s.mockContext)
@@ -201,13 +209,14 @@ func (s *visibilitySuite) TestReplaceCustomSearchAttributes() {
 	s.Nil(s.visibility.CustomSearchAttributes(s.mockContext))
 
 	// Test that nil values are filtered out during replace.
-	s.visibility.ReplaceCustomSearchAttributes(
+	err = s.visibility.ReplaceCustomSearchAttributes(
 		s.mockMutableContext,
 		map[string]*commonpb.Payload{
 			stringKey: s.mustEncode(stringVal),
 			intKey:    nil, // Should be filtered out
 		},
 	)
+	s.NoError(err)
 	s.Len(s.mockMutableContext.Tasks, 4)
 	s.assertTaskPayload(5, s.mockMutableContext.Tasks[3].Payload)
 
@@ -217,18 +226,87 @@ func (s *visibilitySuite) TestReplaceCustomSearchAttributes() {
 	s.Nil(sa[intKey])
 
 	// Test that replacing with all nil values removes the node.
-	s.visibility.ReplaceCustomSearchAttributes(
+	err = s.visibility.ReplaceCustomSearchAttributes(
 		s.mockMutableContext,
 		map[string]*commonpb.Payload{
 			stringKey: nil,
 			intKey:    nil,
 		},
 	)
+	s.NoError(err)
 	s.Len(s.mockMutableContext.Tasks, 5)
 	s.assertTaskPayload(6, s.mockMutableContext.Tasks[4].Payload)
 	_, ok = s.visibility.SA.TryGet(s.mockContext)
 	s.False(ok)
 	s.Nil(s.visibility.CustomSearchAttributes(s.mockContext))
+}
+
+func (s *visibilitySuite) TestMergeCustomSearchAttributes_RejectsReservedPrefix() {
+	reservedKey := sadefs.TemporalScheduledStartTime // "TemporalScheduledStartTime"
+
+	// A single reserved-prefix key is rejected.
+	err := s.visibility.MergeCustomSearchAttributes(s.mockMutableContext, map[string]*commonpb.Payload{
+		reservedKey: s.mustEncode("2020-01-01T00:00:00Z"),
+	})
+	var invalidArg *serviceerror.InvalidArgument
+	s.ErrorAs(err, &invalidArg)
+
+	// Rejection is atomic: no SA is written and no visibility task is generated even when a
+	// valid key is present alongside the reserved one.
+	err = s.visibility.MergeCustomSearchAttributes(s.mockMutableContext, map[string]*commonpb.Payload{
+		"validKey":  s.mustEncode("value"),
+		reservedKey: s.mustEncode("2020-01-01T00:00:00Z"),
+	})
+	s.ErrorAs(err, &invalidArg)
+	s.Empty(s.mockMutableContext.Tasks)
+	s.Nil(s.visibility.CustomSearchAttributes(s.mockContext))
+}
+
+func (s *visibilitySuite) TestReplaceCustomSearchAttributes_RejectsReservedPrefix() {
+	// Seed with a valid SA so we can verify rejection leaves existing state untouched.
+	err := s.visibility.ReplaceCustomSearchAttributes(s.mockMutableContext, map[string]*commonpb.Payload{
+		"validKey": s.mustEncode("value"),
+	})
+	s.NoError(err)
+	s.Len(s.mockMutableContext.Tasks, 1)
+
+	// A reserved-prefix key (mixed with a valid one) is rejected atomically: no new task and
+	// the previously stored SA is unchanged.
+	err = s.visibility.ReplaceCustomSearchAttributes(s.mockMutableContext, map[string]*commonpb.Payload{
+		"anotherKey":                  s.mustEncode("value"),
+		sadefs.TemporalSchedulePaused: s.mustEncode(true),
+	})
+	var invalidArg *serviceerror.InvalidArgument
+	s.ErrorAs(err, &invalidArg)
+	s.Len(s.mockMutableContext.Tasks, 1, "no new visibility task should be generated")
+	sa := s.visibility.CustomSearchAttributes(s.mockContext)
+	s.Len(sa, 1)
+	s.NotNil(sa["validKey"])
+}
+
+func (s *visibilitySuite) TestNewVisibilityWithData_RejectsReservedPrefix() {
+	visibility, err := NewVisibilityWithData(
+		s.mockMutableContext,
+		map[string]*commonpb.Payload{
+			sadefs.TemporalScheduledById: s.mustEncode("schedule-id"),
+		},
+		nil,
+	)
+	var invalidArg *serviceerror.InvalidArgument
+	s.ErrorAs(err, &invalidArg)
+	s.Nil(visibility)
+}
+
+func (s *visibilitySuite) TestMergeCustomSearchAttributes_AllowsNonReservedKey() {
+	// A key that merely contains "Temporal" but does not start with the reserved prefix is
+	// a valid custom search attribute.
+	err := s.visibility.MergeCustomSearchAttributes(s.mockMutableContext, map[string]*commonpb.Payload{
+		"MyTemporalField": s.mustEncode("value"),
+	})
+	s.NoError(err)
+	sa := s.visibility.CustomSearchAttributes(s.mockContext)
+	s.Len(sa, 1)
+	s.NotNil(sa["MyTemporalField"])
 }
 
 func (s *visibilitySuite) TestMergeCustomMemo() {


### PR DESCRIPTION
## What changed?
Reject custom search attributes with Temporal prefix

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)
