### PR TITLE
Fix PostgreSQL test database teardown with active connections

### DIFF
--- a/common/persistence/sql/sqlplugin/postgresql/admin.go
+++ b/common/persistence/sql/sqlplugin/postgresql/admin.go
@@ -3,6 +3,8 @@ package postgresql
 import (
 	"fmt"
 	"time"
+
+	"go.temporal.io/server/common/backoff"
 )
 
 const (
@@ -40,7 +42,8 @@ const (
 	// TODO https://github.com/uber/cadence/issues/2893
 	createDatabaseQuery = `CREATE DATABASE "%v"`
 
-	dropDatabaseQuery = "DROP DATABASE IF EXISTS %v"
+	dropDatabaseQuery                 = "DROP DATABASE IF EXISTS %v"
+	terminateDatabaseConnectionsQuery = `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()`
 
 	listTablesQuery = "select table_name from information_schema.tables where table_schema='public'"
 
@@ -129,4 +132,20 @@ func (pdb *db) CreateDatabase(name string) error {
 // DropDatabase drops a database
 func (pdb *db) DropDatabase(name string) error {
 	return pdb.Exec(fmt.Sprintf(dropDatabaseQuery, name))
+}
+
+// ForceDropDatabase drops a database after terminating its active connections.
+func (pdb *db) ForceDropDatabase(name string) error {
+	return backoff.ThrottleRetry(
+		func() error {
+			if err := pdb.Exec(terminateDatabaseConnectionsQuery, name); err != nil {
+				return err
+			}
+			return pdb.DropDatabase(name)
+		},
+		backoff.NewExponentialRetryPolicy(100*time.Millisecond).
+			WithMaximumInterval(time.Second).
+			WithExpirationInterval(10*time.Second),
+		pdb.dbDriver.IsObjectInUseError,
+	)
 }

--- a/common/persistence/sql/sqlplugin/postgresql/driver/interface.go
+++ b/common/persistence/sql/sqlplugin/postgresql/driver/interface.go
@@ -8,6 +8,7 @@ const (
 	// check http://www.postgresql.org/docs/9.3/static/errcodes-appendix.html
 	dupEntryCode            = "23505"
 	dupDatabaseCode         = "42P04"
+	objectInUseCode         = "55006"
 	readOnlyTransactionCode = "25006"
 	cannotConnectNowCode    = "57P03"
 	featureNotSupportedCode = "0A000"
@@ -24,6 +25,7 @@ type Driver interface {
 	CreateRefreshableConnection(buildDSN func() (string, error)) (*sqlx.DB, error)
 	IsDupEntryError(error) bool
 	IsDupDatabaseError(error) bool
+	IsObjectInUseError(error) bool
 	IsConnNeedsRefreshError(error) bool
 }
 

--- a/common/persistence/sql/sqlplugin/postgresql/driver/pgx.go
+++ b/common/persistence/sql/sqlplugin/postgresql/driver/pgx.go
@@ -77,6 +77,11 @@ func (p *PGXDriver) IsDupDatabaseError(err error) bool {
 	return ok && pqErr.Code == dupDatabaseCode
 }
 
+func (p *PGXDriver) IsObjectInUseError(err error) bool {
+	pgxErr, ok := err.(*pgconn.PgError)
+	return ok && pgxErr.Code == objectInUseCode
+}
+
 func (p *PGXDriver) IsConnNeedsRefreshError(err error) bool {
 	pqErr, ok := err.(*pgconn.PgError)
 	if !ok {

--- a/common/persistence/sql/sqlplugin/postgresql/driver/pq.go
+++ b/common/persistence/sql/sqlplugin/postgresql/driver/pq.go
@@ -43,6 +43,11 @@ func (p *PQDriver) IsDupDatabaseError(err error) bool {
 	return ok && pqErr.Code == dupDatabaseCode
 }
 
+func (p *PQDriver) IsObjectInUseError(err error) bool {
+	pqErr, ok := err.(*pq.Error)
+	return ok && pqErr.Code == objectInUseCode
+}
+
 func (p *PQDriver) IsConnNeedsRefreshError(err error) bool {
 	pqErr, ok := err.(*pq.Error)
 	if !ok {

--- a/common/persistence/sql/test_sql_persistence.go
+++ b/common/persistence/sql/test_sql_persistence.go
@@ -29,6 +29,10 @@ type TestCluster struct {
 	logger         log.Logger
 }
 
+type forceDatabaseDropper interface {
+	ForceDropDatabase(database string) error
+}
+
 // NewTestCluster returns a new SQL test cluster
 func NewTestCluster(
 	pluginName string,
@@ -140,7 +144,13 @@ func (s *TestCluster) DropDatabase() {
 	cfg2.DatabaseName = ""
 	db := s.newAdminDB(sqlplugin.DbKindUnknown, &cfg2)
 	defer s.closeAdminDB(db)
-	if err := db.DropDatabase(s.cfg.DatabaseName); err != nil {
+	var err error
+	if dropper, ok := db.(forceDatabaseDropper); ok {
+		err = dropper.ForceDropDatabase(s.cfg.DatabaseName)
+	} else {
+		err = db.DropDatabase(s.cfg.DatabaseName)
+	}
+	if err != nil {
 		panic(err)
 	}
 	s.logger.Info("dropped database", tag.String("database", s.cfg.DatabaseName))

--- a/common/persistence/tests/postgresql_test.go
+++ b/common/persistence/tests/postgresql_test.go
@@ -15,6 +15,7 @@ import (
 	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/postgresql" // register plugins
 	sqltests "go.temporal.io/server/common/persistence/sql/sqlplugin/tests"
 	"go.temporal.io/server/common/resolver"
+	"go.temporal.io/server/temporal/environment"
 )
 
 type PostgreSQLSuite struct {
@@ -680,6 +681,38 @@ func (p *PostgreSQLSuite) TestPostgreSQLClosedConnectionError() {
 
 	s := newConnectionSuite(p.T(), testData.Factory)
 	suite.Run(p.T(), s)
+}
+
+func (p *PostgreSQLSuite) TestPostgreSQLTestClusterDropsDatabaseWithOpenConnection() {
+	cfg := NewPostgreSQLConfig(p.pluginName, p.connectAttrs)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+
+	db, err := sql.NewSQLAdminDB(
+		sqlplugin.DbKindUnknown,
+		cfg,
+		resolver.NewNoopResolver(),
+		log.NewTestLogger(),
+		metrics.NoopMetricsHandler,
+	)
+	p.Require().NoError(err)
+	p.T().Cleanup(func() {
+		p.Require().NoError(db.Close())
+		TearDownPostgreSQLDatabase(p.T(), cfg)
+	})
+
+	testCluster := sql.NewTestCluster(
+		cfg.PluginName,
+		cfg.DatabaseName,
+		cfg.User,
+		cfg.Password,
+		environment.GetPostgreSQLAddress(),
+		environment.GetPostgreSQLPort(),
+		cfg.ConnectAttributes,
+		"",
+		nil,
+		log.NewTestLogger(),
+	)
+	testCluster.DropDatabase()
 }
 
 func (p *PostgreSQLSuite) TestPGQueueV2() {


### PR DESCRIPTION
## What changed?
- Added PostgreSQL force-drop support for ephemeral test databases.
- Test teardown now terminates remaining database sessions before dropping the database.
- Retries only PostgreSQL SQLSTATE 55006 for up to 10 seconds.

## Why?
CI cluster recycling, restored by [1ce34021ed](https://github.com/temporalio/temporal/commit/1ce34021ed4359d40e067c79b18854593cac44de), drops and recreates test databases after 50 leases. The failing job (https://github.com/temporalio/temporal/actions/runs/29874785269/job/88783211517?pr=11199) showed that PostgreSQL still had three backend sessions when the test cluster attempted a normal `DROP DATABASE`:
```
panic: pq: database "test_f731ae852663430a8565631a" is being accessed by other users (55006) [recovered, repanicked]
DETAIL: There are 3 other sessions using the database.
STATEMENT: DROP DATABASE IF EXISTS test_f731ae852663430a8565631a
```

## How did you test it?

- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)

## Potential risks

Force-drop terminates every connection to the target test database. This is limited to test-cluster teardown, where no active leases should remain. If lease accounting is incorrect, an active test could lose its database connection. Retries are bounded to 10 seconds and only occur for `SQLSTATE 55006`.