### PR TITLE
Fix standalone activity token validation during rolling upgrades

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1909,7 +1909,12 @@ func (a *Activity) validateActivityTaskToken(
 	if token.Attempt != ByIDTokenAttempt && token.Attempt != a.LastAttempt.Get(ctx).GetCount() {
 		return serviceerror.NewNotFound("activity task not found")
 	}
-	if token.GetActivityAttemptStamp() != 0 && token.GetActivityAttemptStamp() != a.LastAttempt.Get(ctx).GetStartedStamp() {
+	tokenStamp := token.GetActivityAttemptStamp()
+	startedStamp := a.LastAttempt.Get(ctx).GetStartedStamp()
+	// Matching versions without stamped tokens leave tokenStamp zero;
+	// History versions without StartedStamp persistence leave startedStamp zero.
+	requiresLegacyStampCompatibility := tokenStamp == 0 || startedStamp == 0
+	if !requiresLegacyStampCompatibility && tokenStamp != startedStamp {
 		return serviceerror.NewNotFound("activity task not found")
 	}
 

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -653,13 +653,12 @@ func TestActivityTaskTokenAttemptStampRejectsTokenFromBeforeAttemptReset(t *test
 	require.NoError(t, err)
 }
 
-func TestActivityTaskTokenWithoutAttemptStampAcceptedForCurrentRetryAttempt(t *testing.T) {
+func TestActivityTaskTokenLegacyStampCompatibility(t *testing.T) {
 	testTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 	const (
 		namespaceID = "test-namespace-id"
 		activityID  = "test-activity-id"
 		runID       = "test-run-id"
-		attempt     = int32(2)
 	)
 
 	componentRef, err := (&persistencespb.ChasmComponentRef{
@@ -682,32 +681,69 @@ func TestActivityTaskTokenWithoutAttemptStampAcceptedForCurrentRetryAttempt(t *t
 		},
 	}
 
-	act := &Activity{
-		ActivityState: &activitypb.ActivityState{
-			Status:           activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
-			HeartbeatTimeout: durationpb.New(0),
+	testCases := []struct {
+		name         string
+		attempt      int32
+		tokenStamp   int32
+		currentStamp int32
+		startedStamp int32
+	}{
+		{
+			name:         "token from Matching without attempt stamp",
+			attempt:      2,
+			currentStamp: 11,
+			startedStamp: 8,
 		},
-		LastAttempt: chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{
-			Count:        attempt,
-			Stamp:        11,
-			StartedStamp: 8,
-		}),
-	}
-	token := &tokenspb.Task{
-		NamespaceId:  namespaceID,
-		Attempt:      attempt,
-		ComponentRef: componentRef,
-	}
-	req := &historyservice.RecordActivityTaskHeartbeatRequest{
-		NamespaceId:      namespaceID,
-		HeartbeatRequest: &workflowservice.RecordActivityTaskHeartbeatRequest{},
+		{
+			name:         "token and state without attempt stamps",
+			attempt:      1,
+			currentStamp: 7,
+		},
+		{
+			name:         "state from History without StartedStamp persistence",
+			attempt:      1,
+			tokenStamp:   7,
+			currentStamp: 7,
+		},
+		{
+			name:         "state from History without StartedStamp persistence after options update",
+			attempt:      1,
+			tokenStamp:   7,
+			currentStamp: 8,
+		},
 	}
 
-	_, err = act.RecordHeartbeat(ctx, WithToken[*historyservice.RecordActivityTaskHeartbeatRequest]{
-		Token:   token,
-		Request: req,
-	})
-	require.NoError(t, err)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			act := &Activity{
+				ActivityState: &activitypb.ActivityState{
+					Status:           activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
+					HeartbeatTimeout: durationpb.New(0),
+				},
+				LastAttempt: chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{
+					Count:        tc.attempt,
+					Stamp:        tc.currentStamp,
+					StartedStamp: tc.startedStamp,
+				}),
+			}
+			token := &tokenspb.Task{
+				NamespaceId:          namespaceID,
+				Attempt:              tc.attempt,
+				ComponentRef:         componentRef,
+				ActivityAttemptStamp: tc.tokenStamp,
+			}
+			req := &historyservice.RecordActivityTaskHeartbeatRequest{
+				NamespaceId:      namespaceID,
+				HeartbeatRequest: &workflowservice.RecordActivityTaskHeartbeatRequest{},
+			}
+
+			_, heartbeatErr := act.RecordHeartbeat(ctx, WithToken[*historyservice.RecordActivityTaskHeartbeatRequest]{
+				Token:   token,
+				Request: req,
+			})
+			require.NoError(t, heartbeatErr)
+		})
+	}
 }
 
 func TestUpdateStartedActivityExecutionOptionsDoesNotBumpStartedStamp(t *testing.T) {


### PR DESCRIPTION
## What changed?
Updated standalone activity task-token validation to support mixed-version rollouts. Tokens are stamp-validated only when both the token stamp and persisted started stamp are available. Added tests covering legacy Matching tokens, legacy History state, and options updates.

## Why?
Older Matching versions do not include attempt stamps in worker tokens, while older History versions do not persist StartedStamp. During a rolling upgrade, strict comparison could reject valid heartbeats or completions after shard ownership moved to an upgraded History pod.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)
