### PR TITLE
Disable standalone activity start delay dynamic config default value

### DIFF
--- a/chasm/lib/activity/config.go
+++ b/chasm/lib/activity/config.go
@@ -30,7 +30,7 @@ var (
 
 	StartDelayEnabled = dynamicconfig.NewNamespaceBoolSetting(
 		"activity.startDelayEnabled",
-		true,
+		false,
 		`Allows non-zero start_delay on StartActivityExecution requests.`,
 	)
 

--- a/service/frontend/namespace_handler_test.go
+++ b/service/frontend/namespace_handler_test.go
@@ -386,7 +386,7 @@ func (s *namespaceHandlerCommonSuite) TestCapabilitiesAndLimits() {
 	s.True(resp.NamespaceInfo.Capabilities.ReportedProblemsSearchAttribute)
 	s.True(resp.NamespaceInfo.Capabilities.WorkerHeartbeats)
 	s.True(resp.NamespaceInfo.Capabilities.StandaloneActivities)
-	s.True(resp.NamespaceInfo.Capabilities.StandaloneActivityStartDelay)
+	s.False(resp.NamespaceInfo.Capabilities.StandaloneActivityStartDelay)
 	s.False(resp.NamespaceInfo.Capabilities.StandaloneActivityBatchOperations)
 	s.False(resp.NamespaceInfo.Capabilities.WorkflowPause)
 	s.False(resp.NamespaceInfo.Capabilities.StandaloneNexusOperation)

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -115,6 +115,7 @@ func (s *standaloneActivityTestSuite) newTestEnv(opts ...testcore.TestOption) *s
 	cluster.OverrideDynamicConfig(s.T(), dynamicconfig.EnableChasm, nsValues(true))
 	cluster.OverrideDynamicConfig(s.T(), activity.Enabled, nsValues(true))
 	cluster.OverrideDynamicConfig(s.T(), activity.EnableCallbacks, nsValues(true))
+	cluster.OverrideDynamicConfig(s.T(), activity.StartDelayEnabled, nsValues(true))
 	return env
 }
 


### PR DESCRIPTION
## What changed?
Disable standalone activity start delay dynamic config default value

## Why?
Revert back to default until GA date. Safe to do as the flip to true has not been released yet.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

