### PR TITLE
Fix flaky partition scaling functional tests

### DIFF
--- a/tests/partition_scaling_test.go
+++ b/tests/partition_scaling_test.go
@@ -32,6 +32,8 @@ func scalerEnvOptions(dcPartitions int) []testcore.TestOption {
 			BatchSize:          1,           // always go directly to scaler
 			BackgroundInterval: time.Second, // ping scaler often and drain faster
 			DrainBufferTime:    time.Second, // drain faster
+			ShrinkRatio:        1.0,         // allow fast shrinking
+			ShrinkDelta:        100,         // allow fast shrinking
 		}),
 	}
 }
@@ -99,8 +101,8 @@ func TestPartitionScaling_Down(t *testing.T) {
 		Fixed:   4,
 	})
 
-	t.Log("wait until 4,5 see no new tasks over a 1s window")
-	await.Require(s.Context(), t, scalerBacklogUnchanged(s, s.Tv(), time.Second, 4, 5), 15*time.Second, time.Millisecond)
+	t.Log("wait until 4,5 see no new tasks over a 2s window")
+	await.Require(s.Context(), t, scalerBacklogUnchanged(s, s.Tv(), 2*time.Second, 4, 5), 15*time.Second, time.Millisecond)
 
 	t.Log("stop sending tasks")
 	stopTasks()
@@ -175,8 +177,8 @@ func TestPartitionScaling_Down_FromDC(t *testing.T) {
 		Fixed:   4,
 	})
 
-	t.Log("wait until 4,5 see no new tasks over a 1s window")
-	await.Require(s.Context(), t, scalerBacklogUnchanged(s, s.Tv(), time.Second, 4, 5), 15*time.Second, time.Millisecond)
+	t.Log("wait until 4,5 see no new tasks over a 2s window")
+	await.Require(s.Context(), t, scalerBacklogUnchanged(s, s.Tv(), 2*time.Second, 4, 5), 15*time.Second, time.Millisecond)
 
 	t.Log("stop sending tasks")
 	stopTasks()

--- a/tests/partition_scaling_test.go
+++ b/tests/partition_scaling_test.go
@@ -102,6 +102,7 @@ func TestPartitionScaling_Down(t *testing.T) {
 	})
 
 	t.Log("wait until 4,5 see no new tasks over a 2s window")
+	// nolint:staticcheck // until we rewrite the test
 	await.Require(s.Context(), t, scalerBacklogUnchanged(s, s.Tv(), 2*time.Second, 4, 5), 15*time.Second, time.Millisecond)
 
 	t.Log("stop sending tasks")
@@ -178,6 +179,7 @@ func TestPartitionScaling_Down_FromDC(t *testing.T) {
 	})
 
 	t.Log("wait until 4,5 see no new tasks over a 2s window")
+	// nolint:staticcheck // until we rewrite the test
 	await.Require(s.Context(), t, scalerBacklogUnchanged(s, s.Tv(), 2*time.Second, 4, 5), 15*time.Second, time.Millisecond)
 
 	t.Log("stop sending tasks")


### PR DESCRIPTION
## What changed?
Override ShrinkRatio + ShrinkDelta in partition scaling functional tests.

## Why?
Without these, the scale down that the tests are expecting is partially blocked. They worked sort of by accident, so I increased the 1s window to 2s to make sure it's really fixed.

## How did you test it?
Fixed test and ran 20 times
