### PR TITLE
matching: rework tasks_added emission per followup discussion

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1258,7 +1258,7 @@ var (
 	TaskQueueStoppedCounter                           = NewCounterDef("task_queue_stopped")
 	TasksAddedCounter                                 = NewCounterDef(
 		"tasks_added",
-		WithDescription("Number of tasks arriving at a physical task queue, broken down by add result, forwarding, and versioning behavior"),
+		WithDescription("Number of tasks added at their origin partition, broken down by add result, forwarding, and versioning behavior"),
 	)
 	TaskWriteThrottlePerTaskQueueCounter = NewCounterDef("task_write_throttle_count")
 	TaskWriteLatencyPerTaskQueue         = NewTimerDef("task_write_latency")

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -322,12 +322,12 @@ func PollResultTag(result string) Tag {
 	return Tag{Key: pollResultTagName, Value: result}
 }
 
+// TaskAddResult values for the tasks_added metric. Only outcomes for tasks that were
+// actually added are recorded (sync-matched or spooled to the backlog); error/rejection
+// outcomes are covered by the Add*Task metrics instead.
 const (
-	TaskAddResultSyncMatch        = "sync_match"
-	TaskAddResultSyncMatchUnavail = "sync_match_unavailable"
-	TaskAddResultBacklog          = "backlog"
-	TaskAddResultThrottled        = "throttled"
-	TaskAddResultFailure          = "failure"
+	TaskAddResultSyncMatch = "sync_match"
+	TaskAddResultBacklog   = "backlog"
 )
 
 func TaskAddResultTag(result string) Tag {

--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -105,20 +105,24 @@ func (tm *TaskMatcher) recycleToken(*internalTask) {
 //   - ratelimit is exceeded (does not apply to query task)
 //   - context deadline is exceeded
 //   - task is matched and consumer returns error in response channel
-func (tm *TaskMatcher) Offer(ctx context.Context, task *internalTask) (bool, error) {
+//
+// Offer returns whether the task was matched, whether it was forwarded to another partition to
+// attempt a remote sync match (true regardless of whether that forward matched, so the origin
+// partition can tag the tasks_added metric), and any error.
+func (tm *TaskMatcher) Offer(ctx context.Context, task *internalTask) (matched, forwarded bool, err error) {
 	if !tm.isBacklogNegligible() {
 		// To ensure better dispatch ordering, we block sync match when a significant backlog is present.
 		// Note that this check does not make a noticeable difference for history tasks, as they do not wait for a
 		// poller to become available. In presence of a backlog the chance of a poller being available when sync match
 		// request comes is almost zero.
 		// This check is mostly effective for the sync match requests that come from child partitions for spooled tasks.
-		return false, nil
+		return false, false, nil
 	}
 
 	if !task.isForwarded() {
 		if err := tm.rateLimiter.Wait(ctx); err != nil {
 			metrics.SyncThrottlePerTaskQueueCounter.With(tm.metricsHandler).Record(1)
-			return false, err
+			return false, false, err
 		}
 		// because we waited on the rate limiter to offer this task,
 		// attach the rate limiter's RecycleToken func to the task
@@ -137,14 +141,16 @@ func (tm *TaskMatcher) Offer(ctx context.Context, task *internalTask) (bool, err
 			if err.startErr == nil && !task.isForwarded() {
 				tm.emitDispatchLatency(task, false)
 			}
-			return true, err.startErr
+			return true, false, err.startErr
 		}
-		return false, nil
+		return false, false, nil
 	default:
 		// no poller waiting for tasks, try forwarding this task to the
 		// root partition if possible
 		select {
 		case token := <-tm.fwdrAddReqTokenC():
+			// We attempted a remote sync match via forwarding; report forwarded=true below
+			// regardless of whether the forward matched.
 			if err := tm.fwdr.ForwardTask(ctx, task); err == nil {
 				// task was remotely sync matched on the parent partition
 				token.release()
@@ -152,20 +158,22 @@ func (tm *TaskMatcher) Offer(ctx context.Context, task *internalTask) (bool, err
 					// if there are multiple forwarding hops, only the initial source partition emits this metric
 					tm.emitDispatchLatency(task, true)
 				}
-				return true, nil
+				return true, true, nil
 			}
 			token.release()
+			return false, true, nil
 		default:
 			if !tm.isForwardingAllowed() && // we are the root partition and forwarding is not possible
 				task.source == enumsspb.TASK_SOURCE_DB_BACKLOG && // task was from backlog (stored in db)
 				task.isForwarded() { // task came from a child partition
 				// a forwarded backlog task from a child partition, block trying
 				// to match with a poller until ctx timeout
-				return tm.offerOrTimeout(ctx, task)
+				matched, err := tm.offerOrTimeout(ctx, task)
+				return matched, false, err
 			}
 		}
 
-		return false, nil
+		return false, false, nil
 	}
 }
 

--- a/service/matching/matcher_test.go
+++ b/service/matching/matcher_test.go
@@ -123,7 +123,7 @@ func (t *MatcherTestSuite) TestLocalSyncMatch() {
 	time.Sleep(10 * time.Millisecond)
 	task := newInternalTaskForSyncMatch(randomTaskInfo().Data, nil, 0, nil)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	syncMatch, err := t.childMatcher.Offer(ctx, task)
+	syncMatch, _, err := t.childMatcher.Offer(ctx, task)
 	cancel()
 	t.NoError(err)
 	t.True(syncMatch)
@@ -195,11 +195,11 @@ func (t *MatcherTestSuite) testRemoteSyncMatch(taskSource enumsspb.TaskSource) {
 				// blocks - so we don't need to do this
 				time.Sleep(10 * time.Millisecond)
 			}
-			remoteSyncMatch, err = t.rootMatcher.Offer(ctx, task)
+			remoteSyncMatch, _, err = t.rootMatcher.Offer(ctx, task)
 		},
 	).Return(&matchingservice.AddWorkflowTaskResponse{}, nil)
 
-	_, err0 := t.childMatcher.Offer(ctx, task)
+	_, _, err0 := t.childMatcher.Offer(ctx, task)
 	t.NoError(err0)
 	cancel()
 	t.NotNil(req)
@@ -243,7 +243,7 @@ func (t *MatcherTestSuite) TestRejectSyncMatchWhenBacklog() {
 	// Since the partition currently has no pollers, the test verifies that the task is not blocked locally
 	// by asserting a context cancellation due to a timeout never occurred and we received a *false* due to a
 	// non-negligible backlog.
-	happened, err := t.rootMatcher.Offer(newCtx, syncMatchTask)
+	happened, _, err := t.rootMatcher.Offer(newCtx, syncMatchTask)
 	if newCtx.Err() != nil {
 		t.FailNow("waited on a local poller due to a negligible backlog")
 
@@ -467,7 +467,7 @@ func (t *MatcherTestSuite) TestSyncMatchFailure() {
 		},
 	).Return(&matchingservice.AddWorkflowTaskResponse{}, errMatchingHostThrottleTest)
 
-	syncMatch, err := t.childMatcher.Offer(ctx, task)
+	syncMatch, _, err := t.childMatcher.Offer(ctx, task)
 	cancel()
 	t.NotNil(req)
 	t.NoError(err)
@@ -760,7 +760,7 @@ func (t *MatcherTestSuite) TestMustOfferRemoteMatch() {
 			req = arg1
 			task := newInternalTaskForSyncMatch(task.event.AllocatedTaskInfo.Data, req.ForwardInfo, 0, nil)
 			close(pollSigC)
-			remoteSyncMatch, err = t.rootMatcher.Offer(ctx, task)
+			remoteSyncMatch, _, err = t.rootMatcher.Offer(ctx, task)
 		},
 	).Return(&matchingservice.AddWorkflowTaskResponse{}, nil)
 

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -719,13 +719,13 @@ func (c *physicalTaskQueueManagerImpl) GetInternalTaskQueueStatus() []*taskqueue
 	return status
 }
 
-func (c *physicalTaskQueueManagerImpl) TrySyncMatch(ctx context.Context, task *internalTask) (syncMatchOutcome, error) {
+func (c *physicalTaskQueueManagerImpl) TrySyncMatch(ctx context.Context, task *internalTask) (syncMatchOutcome, bool, error) {
 	if !task.isForwarded() {
 		// request sent by history service
 		c.liveness.markAlive()
 		c.incTaskTracker(c.tasksAdded, priorityKey(task.getPriority().GetPriorityKey()), 1)
 		if disable, _ := testhooks.Get(c.partitionMgr.engine.testHooks, testhooks.MatchingDisableSyncMatch, c.partitionMgr.ns.ID()); disable {
-			return syncMatchNoPoller, nil
+			return syncMatchNoPoller, false, nil
 		}
 	}
 
@@ -736,11 +736,11 @@ func (c *physicalTaskQueueManagerImpl) TrySyncMatch(ctx context.Context, task *i
 	childCtx, cancel := contextutil.WithDeadlineBuffer(ctx, c.config.SyncMatchWaitDuration(), time.Second)
 	defer cancel()
 
-	matched, err := c.oldMatcher.Offer(childCtx, task)
+	matched, forwarded, err := c.oldMatcher.Offer(childCtx, task)
 	if matched {
-		return syncMatchSuccess, err
+		return syncMatchSuccess, forwarded, err
 	}
-	return syncMatchNoPoller, err
+	return syncMatchNoPoller, forwarded, err
 }
 
 func (c *physicalTaskQueueManagerImpl) ensureRegisteredInDeploymentVersion(

--- a/service/matching/physical_task_queue_manager_interface.go
+++ b/service/matching/physical_task_queue_manager_interface.go
@@ -36,8 +36,10 @@ type (
 		// MarkAlive updates the liveness timer to keep this physicalTaskQueueManager alive.
 		MarkAlive()
 		// TrySyncMatch tries to match task to a local or remote poller. Returns a syncMatchOutcome
-		// indicating success or the reason the match failed.
-		TrySyncMatch(ctx context.Context, task *internalTask) (syncMatchOutcome, error)
+		// indicating success or the reason the match failed, and whether the task was forwarded to
+		// another partition to attempt a remote sync match (true regardless of whether that forward
+		// matched), so the origin partition can tag the tasks_added metric.
+		TrySyncMatch(ctx context.Context, task *internalTask) (syncMatchOutcome, bool, error)
 		// SpoolTask spools a task to persistence to be matched asynchronously when a poller is available.
 		SpoolTask(taskInfo *persistencespb.TaskInfo) error
 		// TODO(pri): old matcher cleanup
@@ -71,8 +73,11 @@ type (
 		// GetFairnessWeightOverrides returns current fairness weight overrides for this queue.
 		GetFairnessWeightOverrides() fairnessWeightOverrides
 		UpdateRemotePriorityBacklogs(remotePriorityBacklogSet)
-		// RecordTaskAdd records the outcome of a task add to this physical queue using
-		// the queue's tagged metrics handler, so all per-physical-queue labels are included.
+		// RecordTaskAdd records that a task was added to this physical queue, tagged with the add
+		// result (sync_match or backlog), whether the origin partition forwarded the task for a
+		// remote sync match, and the versioning behavior. It uses the queue's tagged metrics
+		// handler, so all per-physical-queue labels are included. It should only be called on the
+		// origin (non-forwarded) partition and only for tasks that were actually added.
 		RecordTaskAdd(result string, forwarded bool, behavior enumspb.VersioningBehavior)
 	}
 )

--- a/service/matching/physical_task_queue_manager_mock.go
+++ b/service/matching/physical_task_queue_manager_mock.go
@@ -382,12 +382,13 @@ func (mr *MockphysicalTaskQueueManagerMockRecorder) Stop(arg0 any) *gomock.Call 
 }
 
 // TrySyncMatch mocks base method.
-func (m *MockphysicalTaskQueueManager) TrySyncMatch(ctx context.Context, task *internalTask) (syncMatchOutcome, error) {
+func (m *MockphysicalTaskQueueManager) TrySyncMatch(ctx context.Context, task *internalTask) (syncMatchOutcome, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TrySyncMatch", ctx, task)
 	ret0, _ := ret[0].(syncMatchOutcome)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // TrySyncMatch indicates an expected call of TrySyncMatch.

--- a/service/matching/pri_matcher.go
+++ b/service/matching/pri_matcher.go
@@ -384,20 +384,24 @@ func (tm *priTaskMatcher) forwardPolls(
 //   - ratelimit is exceeded (does not apply to query task)
 //   - context deadline is exceeded
 //   - task is matched and consumer returns error in response channel
+//
+// The returned bool reports whether the task was forwarded to another partition to attempt a
+// remote sync match (true regardless of whether that forward matched), so the origin partition
+// can tag the tasks_added metric.
 
-func (tm *priTaskMatcher) Offer(ctx context.Context, task *internalTask) (syncMatchOutcome, error) {
-	finish := func() (syncMatchOutcome, error) {
+func (tm *priTaskMatcher) Offer(ctx context.Context, task *internalTask) (syncMatchOutcome, bool, error) {
+	finish := func() (syncMatchOutcome, bool, error) {
 		res, ok := task.getResponse()
 		if !softassert.That(tm.logger, ok, "expected a sync match task") {
-			return syncMatchUnspecified, nil
+			return syncMatchUnspecified, false, nil
 		}
 		if res.forwarded {
 			if res.forwardErr == nil {
 				// task was remotely sync matched on the parent partition
 				tm.emitDispatchLatency(task, true)
-				return syncMatchSuccess, nil
+				return syncMatchSuccess, true, nil
 			}
-			return syncMatchNoPoller, nil // forward error, give up here
+			return syncMatchNoPoller, true, nil // forward error, give up here
 		}
 		// TODO(pri): can we just always do this on the parent and simplify this to:
 		// if res.startErr == nil { tm.emitDispatchLatency(task, task.isForwarded) }
@@ -407,7 +411,7 @@ func (tm *priTaskMatcher) Offer(ctx context.Context, task *internalTask) (syncMa
 		}
 		// TODO: when startErr is non-nil (e.g. busy workflow), the task was not actually
 		// dispatched. This should return a failure outcome instead of syncMatchSuccess.
-		return syncMatchSuccess, res.startErr
+		return syncMatchSuccess, false, res.startErr
 	}
 
 	// Fast path if we have a waiting poller (or forwarder).
@@ -418,23 +422,23 @@ func (tm *priTaskMatcher) Offer(ctx context.Context, task *internalTask) (syncMa
 	case syncMatchSuccess:
 		return finish()
 	case syncMatchBacklogPresent:
-		return outcome, nil
+		return outcome, false, nil
 	default:
 		// We only block if we are the root and the task is forwarded from a backlog.
 		// Otherwise, stop here.
 		if tm.isForwardingAllowed() ||
 			task.source != enumsspb.TASK_SOURCE_DB_BACKLOG ||
 			!task.isForwarded() {
-			return outcome, nil
+			return outcome, false, nil
 		}
 	}
 
 	res := tm.data.EnqueueTaskAndWait([]context.Context{ctx, tm.tqCtx}, task)
 	if res.ctxErr != nil {
-		return syncMatchNoPoller, res.ctxErr
+		return syncMatchNoPoller, false, res.ctxErr
 	}
 	if !softassert.That(tm.logger, res.poller != nil, "expeced poller from match") {
-		return syncMatchNoPoller, nil
+		return syncMatchNoPoller, false, nil
 	}
 
 	return finish()

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -612,26 +612,25 @@ reredirectTask:
 	}
 
 	behavior := directive.GetBehavior()
-	forwarded := params.forwardInfo != nil
 
 	var outcome syncMatchOutcome
+	// forwardedForSyncMatch reports whether the origin partition forwarded this task onward to
+	// attempt a remote sync match; it tags the tasks_added metric. False if we never got as far
+	// as attempting a sync match (e.g. not active in this cluster).
+	var forwardedForSyncMatch bool
 	if isActive {
-		outcome, err = syncMatchQueue.TrySyncMatch(ctx, syncMatchTask)
+		outcome, forwardedForSyncMatch, err = syncMatchQueue.TrySyncMatch(ctx, syncMatchTask)
 		syncMatched = outcome == syncMatchSuccess
 		if syncMatched && !pm.shouldBacklogSyncMatchTaskOnError(err) {
-			// Only fire hooks for non-forwarded tasks. Forwarded tasks already had hooks fired
-			// on the child partition that originally received the task.
-			if !forwarded {
+			// Only fire hooks and record the add for non-forwarded tasks. Forwarded tasks already
+			// had hooks fired and the add recorded on the origin partition that received the task,
+			// so we avoid double counting here.
+			if params.forwardInfo == nil {
 				// We should not use targetVersion because targetVersion is always routing-config-deriven.
 				// For pinned workflows, targetVersion is not necessarily the same as the pinned version.
 				pm.processTaskAddHooks(ctx, syncMatchQueue.QueueKey().Version().WorkerDeploymentVersionS(), outcome)
+				syncMatchQueue.RecordTaskAdd(metrics.TaskAddResultSyncMatch, forwardedForSyncMatch, behavior)
 			}
-
-			syncMatchResult := metrics.TaskAddResultSyncMatch
-			if err != nil {
-				syncMatchResult = taskAddErrResult(err)
-			}
-			syncMatchQueue.RecordTaskAdd(syncMatchResult, forwarded, behavior)
 
 			// Build ID is not returned for sync match. The returned build ID is used by History to update
 			// mutable state (and visibility) when the first workflow task is spooled.
@@ -647,8 +646,8 @@ reredirectTask:
 	}
 
 	if spoolQueue == nil {
-		// This means the task is being forwarded. Child partition will persist the task when sync match fails.
-		syncMatchQueue.RecordTaskAdd(metrics.TaskAddResultSyncMatchUnavail, forwarded, behavior)
+		// This means the task is being forwarded. The origin partition will record the add and
+		// persist the task when sync match fails.
 		return "", false, errRemoteSyncMatchFailed
 	}
 
@@ -660,7 +659,6 @@ reredirectTask:
 
 	err = spoolQueue.SpoolTask(params.taskInfo)
 	if err == nil {
-		spoolQueue.RecordTaskAdd(metrics.TaskAddResultBacklog, forwarded, behavior)
 		// We should not use targetVersion because targetVersion is always routing-config-deriven.
 		// For pinned workflows, targetVersion is not necessarily the same as the pinned version.
 		// Also, note that we use syncMatchQueue's version, and not spoolQueue's version. This is
@@ -668,8 +666,7 @@ reredirectTask:
 		// Unpinned tasks are written to the default queue for late binding, in case target version
 		// changes by the time they can be dispatched.
 		pm.processTaskAddHooks(ctx, syncMatchQueue.QueueKey().Version().WorkerDeploymentVersionS(), outcome)
-	} else {
-		spoolQueue.RecordTaskAdd(taskAddErrResult(err), forwarded, behavior)
+		spoolQueue.RecordTaskAdd(metrics.TaskAddResultBacklog, forwardedForSyncMatch, behavior)
 	}
 
 	return assignedBuildId, false, err
@@ -697,14 +694,6 @@ func (pm *taskQueuePartitionManagerImpl) processTaskAddHooks(ctx context.Context
 			SyncMatchOutcome:  hookOutcome,
 		})
 	}
-}
-
-func taskAddErrResult(err error) string {
-	var resourceExhausted *serviceerror.ResourceExhausted
-	if errors.As(err, &resourceExhausted) {
-		return metrics.TaskAddResultThrottled
-	}
-	return metrics.TaskAddResultFailure
 }
 
 func (pm *taskQueuePartitionManagerImpl) shouldBacklogSyncMatchTaskOnError(err error) bool {

--- a/service/matching/task_queue_partition_manager_test.go
+++ b/service/matching/task_queue_partition_manager_test.go
@@ -1819,6 +1819,98 @@ func (s *PartitionManagerTestSuite) TestTaskAddHooks_ForwardedNoSyncMatch_HooksN
 	s.Require().Empty(hook.getCalls())
 }
 
+func (s *PartitionManagerTestSuite) TestTasksAddedMetric_Backlog() {
+	// A task with no poller available is spooled to the backlog. tasks_added should be emitted
+	// once, tagged with task_add_result=backlog and forwarded=false.
+	pm, capture, cleanup := s.setupPartitionManagerWithCapture(testPartitionManagerConfig{loadTime: time.Minute})
+	defer cleanup()
+
+	_, syncMatched, err := pm.AddTask(context.Background(), addTaskParams{
+		taskInfo: &persistencespb.TaskInfo{
+			NamespaceId: namespaceID,
+			RunId:       "run",
+			WorkflowId:  "wf",
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().False(syncMatched)
+
+	recs := capture.Snapshot()[metrics.TasksAddedCounter.Name()]
+	s.Require().Len(recs, 1)
+	s.Equal(metrics.TaskAddResultBacklog, recs[0].Tags["task_add_result"])
+	s.Equal("false", recs[0].Tags["forwarded"])
+}
+
+func (s *PartitionManagerTestSuite) TestTasksAddedMetric_SyncMatch() {
+	// A task that sync-matches a waiting poller should emit tasks_added once, tagged with
+	// task_add_result=sync_match and forwarded=false (matched locally, not forwarded).
+	pm, capture, cleanup := s.setupPartitionManagerWithCapture(testPartitionManagerConfig{loadTime: time.Minute})
+	defer cleanup()
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		task, _, _ := pm.PollTask(ctx, &pollMetadata{
+			workerVersionCapabilities: &commonpb.WorkerVersionCapabilities{},
+		})
+		if task != nil && task.responseC != nil {
+			close(task.responseC)
+		}
+	}()
+
+	pq := pm.defaultQueue().(*physicalTaskQueueManagerImpl)
+	await.RequireTrue(s.T(), pq.matcher.HasWaitingPoller, 2*time.Second, time.Millisecond)
+
+	_, syncMatched, err := pm.AddTask(context.Background(), addTaskParams{
+		taskInfo: &persistencespb.TaskInfo{
+			NamespaceId: namespaceID,
+			RunId:       "run",
+			WorkflowId:  "wf",
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().True(syncMatched)
+
+	recs := capture.Snapshot()[metrics.TasksAddedCounter.Name()]
+	s.Require().Len(recs, 1)
+	s.Equal(metrics.TaskAddResultSyncMatch, recs[0].Tags["task_add_result"])
+	s.Equal("false", recs[0].Tags["forwarded"])
+}
+
+func (s *PartitionManagerTestSuite) TestTasksAddedMetric_NotEmittedForForwardedAdd() {
+	// tasks_added is emitted only on the origin (child) partition. A task forwarded to and
+	// sync-matched on this (parent) partition must not emit it, to avoid double counting.
+	pm, capture, cleanup := s.setupPartitionManagerWithCapture(testPartitionManagerConfig{loadTime: time.Minute})
+	defer cleanup()
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		task, _, _ := pm.PollTask(ctx, &pollMetadata{
+			workerVersionCapabilities: &commonpb.WorkerVersionCapabilities{},
+		})
+		if task != nil && task.responseC != nil {
+			close(task.responseC)
+		}
+	}()
+
+	pq := pm.defaultQueue().(*physicalTaskQueueManagerImpl)
+	await.RequireTrue(s.T(), pq.matcher.HasWaitingPoller, 2*time.Second, time.Millisecond)
+
+	_, syncMatched, err := pm.AddTask(context.Background(), addTaskParams{
+		taskInfo: &persistencespb.TaskInfo{
+			NamespaceId: namespaceID,
+			RunId:       "run",
+			WorkflowId:  "wf",
+		},
+		forwardInfo: &taskqueuespb.TaskForwardInfo{SourcePartition: "child-partition"},
+	})
+	s.Require().NoError(err)
+	s.Require().True(syncMatched)
+
+	s.Require().Empty(capture.Snapshot()[metrics.TasksAddedCounter.Name()])
+}
+
 func (s *PartitionManagerTestSuite) TestTaskAddHooks_MultipleHooksInvoked() {
 	hook1 := &capturingTaskMatchHook{}
 	hook2 := &capturingTaskMatchHook{}


### PR DESCRIPTION
## What changed?
- Emit once at the origin partition; stop double-counting forwarded sync-matches (never emit on the forwarded/parent side).
- Redefine the `forwarded` tag to mean "the origin partition forwarded this task onward to attempt a remote sync match" (true regardless of the result), threaded out of TrySyncMatch and both matchers' Offer as a return value rather than stored on the internalTask struct.
- Scope the metric to tasks actually added (where processTaskAddHooks fires): only sync_match and backlog are emitted. Retire the throttled/failure/sync_match_unavailable values; those error/rejection cases are covered by the Add*Task metrics instead.

## Why?
Addresses some follow-on conversations we had after the original was merged, but scoped to not change the schema at this point.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)
