### PR TITLE
Fix activity exponential retry overflow clamping

### DIFF
--- a/common/backoff/retry.go
+++ b/common/backoff/retry.go
@@ -173,12 +173,14 @@ func IgnoreErrors(errorsToExclude []error) func(error) bool {
 // initial duration, coefficient, and current attempt number.
 type BackoffCalculatorAlgorithmFunc func(duration *durationpb.Duration, coefficient float64, currentAttempt int32) time.Duration
 
-// ExponentialBackoffAlgorithm calculates the backoff duration using exponential algorithm.
-// The result is initInterval * (backoffCoefficient ^ (currentAttempt - 1)).
-// If the calculation overflows int64, it returns the maximum possible duration. A negative result will also never be returned.
+// ExponentialBackoffAlgorithm calculates the backoff duration as `initInterval * (backoffCoefficient ^ (currentAttempt - 1))`.
+// The result is clamped to [0, math.MaxInt64].
 func ExponentialBackoffAlgorithm(initInterval *durationpb.Duration, backoffCoefficient float64, currentAttempt int32) time.Duration {
 	result := float64(initInterval.AsDuration().Nanoseconds()) * math.Pow(backoffCoefficient, float64(currentAttempt-1))
-	return time.Duration(max(0, min(int64(result), math.MaxInt64)))
+	if result >= float64(math.MaxInt64) {
+		return time.Duration(math.MaxInt64)
+	}
+	return time.Duration(max(0, int64(result)))
 }
 
 // MakeBackoffAlgorithm creates a BackoffCalculatorAlgorithmFunc that returns a fixed delay if requestedDelay is non-nil,

--- a/common/backoff/retry_test.go
+++ b/common/backoff/retry_test.go
@@ -2,12 +2,15 @@ package backoff
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 type (
@@ -275,4 +278,22 @@ var retryEverything IsRetryable = nil
 
 func (e *someError) Error() string {
 	return "Some Error"
+}
+
+// TestExponentialBackoffOverflow verifies overflow handling when
+// initInterval * coefficient^(attempt-1) exceeds MaxInt64.
+func TestExponentialBackoffOverflow(t *testing.T) {
+	t.Run("Calculation clamps to MaxInt64", func(t *testing.T) {
+		interval := ExponentialBackoffAlgorithm(durationpb.New(time.Nanosecond), 2.0, 65)
+		require.Equal(t, time.Duration(math.MaxInt64), interval)
+	})
+
+	t.Run("Interval still capped to MaximumInterval", func(t *testing.T) {
+		interval := CalculateExponentialRetryInterval(&commonpb.RetryPolicy{
+			InitialInterval:    durationpb.New(time.Second),
+			BackoffCoefficient: 2.0,
+			MaximumInterval:    durationpb.New(100 * time.Second),
+		}, 100)
+		require.Equal(t, 100*time.Second, interval)
+	})
 }


### PR DESCRIPTION
## What changed?
Fix clamping of retry interval from exponential backoff calculation 

## Why?
It was incorrectly returning 0 instead of `MaxInt64`.
This bug would have affected a SAA at around attempt 35 with default settings -- the retry interval would suddenly have gone to zero. 

## How did you test it?
- [x] added new unit test(s)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to retry interval math with targeted tests; fixes incorrect zero-delay behavior on high attempt counts.
> 
> **Overview**
> Fixes **exponential backoff** so huge `initInterval * coefficient^(attempt-1)` values clamp to **`math.MaxInt64`** instead of collapsing to **zero** when the float result overflows `int64` on conversion.
> 
> `ExponentialBackoffAlgorithm` now checks overflow on the float path before casting; docs note the **[0, MaxInt64]** clamp. New tests cover the overflow case (~attempt 65 with tiny interval) and confirm **`CalculateExponentialRetryInterval`** still respects **`MaximumInterval`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5053e09a85a622948f4b24f92e79e9ade1b7c65e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->