### PR TITLE
Reload client root CAs for new TLS handshakes

### DIFF
--- a/common/auth/dynamic_root_ca_test.go
+++ b/common/auth/dynamic_root_ca_test.go
@@ -1,0 +1,151 @@
+package auth
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type dynamicRootCATestCA struct {
+	cert *x509.Certificate
+	key  *ecdsa.PrivateKey
+	pool *x509.CertPool
+}
+
+func newDynamicRootCATestCA(t *testing.T, commonName string) *dynamicRootCATestCA {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	pool := x509.NewCertPool()
+	pool.AddCert(cert)
+	return &dynamicRootCATestCA{cert: cert, key: key, pool: pool}
+}
+
+func (ca *dynamicRootCATestCA) issueLeaf(t *testing.T, dnsName string) *x509.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: dnsName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{dnsName},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, ca.cert, &key.PublicKey, ca.key)
+	require.NoError(t, err)
+	leaf, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return leaf
+}
+
+func connState(serverName string, peerCerts ...*x509.Certificate) tls.ConnectionState {
+	return tls.ConnectionState{
+		ServerName:       serverName,
+		PeerCertificates: peerCerts,
+	}
+}
+
+func TestNewTLSConfigForServerWithRootCAProvider(t *testing.T) {
+	const serverName = "temporal-frontend.local"
+
+	ca1 := newDynamicRootCATestCA(t, "ca1")
+	ca2 := newDynamicRootCATestCA(t, "ca2")
+	leaf1 := ca1.issueLeaf(t, serverName)
+	leaf2 := ca2.issueLeaf(t, serverName)
+
+	t.Run("resolves roots per handshake", func(t *testing.T) {
+		activePool := ca1.pool
+		c := NewTLSConfigForServerWithRootCAProvider(serverName, true,
+			func() (*x509.CertPool, error) { return activePool, nil })
+
+		require.True(t, c.InsecureSkipVerify)
+		require.NotNil(t, c.VerifyConnection)
+
+		require.NoError(t, c.VerifyConnection(connState(serverName, leaf1)))
+		require.Error(t, c.VerifyConnection(connState(serverName, leaf2)))
+
+		// A provider swap is observed by subsequent verifications of the same config.
+		activePool = ca2.pool
+		require.NoError(t, c.VerifyConnection(connState(serverName, leaf2)))
+		require.Error(t, c.VerifyConnection(connState(serverName, leaf1)))
+	})
+
+	t.Run("verifies identity against negotiated SNI with static fallback", func(t *testing.T) {
+		c := NewTLSConfigForServerWithRootCAProvider(serverName, true,
+			func() (*x509.CertPool, error) { return ca1.pool, nil })
+
+		require.Error(t, c.VerifyConnection(connState("wrong.host", leaf1)))
+		// Empty SNI (e.g. literal-IP dial) falls back to the configured serverName.
+		require.NoError(t, c.VerifyConnection(connState("", leaf1)))
+	})
+
+	t.Run("fails closed without any identity", func(t *testing.T) {
+		c := NewTLSConfigForServerWithRootCAProvider("", true,
+			func() (*x509.CertPool, error) { return ca1.pool, nil })
+
+		require.ErrorContains(t, c.VerifyConnection(connState("", leaf1)),
+			"cannot verify server identity")
+	})
+
+	t.Run("fails closed with nil provider", func(t *testing.T) {
+		c := NewTLSConfigForServerWithRootCAProvider(serverName, true, nil)
+
+		require.ErrorContains(t, c.VerifyConnection(connState(serverName, leaf1)),
+			"root CA provider is not configured")
+	})
+
+	t.Run("propagates provider errors", func(t *testing.T) {
+		providerErr := errors.New("provider boom")
+		c := NewTLSConfigForServerWithRootCAProvider(serverName, true,
+			func() (*x509.CertPool, error) { return nil, providerErr })
+
+		require.ErrorIs(t, c.VerifyConnection(connState(serverName, leaf1)), providerErr)
+	})
+
+	t.Run("rejects empty peer certificates", func(t *testing.T) {
+		c := NewTLSConfigForServerWithRootCAProvider(serverName, true,
+			func() (*x509.CertPool, error) { return ca1.pool, nil })
+
+		require.ErrorContains(t, c.VerifyConnection(connState(serverName)),
+			"server presented no certificates")
+	})
+
+	t.Run("disabled host verification ignores the provider", func(t *testing.T) {
+		c := NewTLSConfigForServerWithRootCAProvider(serverName, false,
+			func() (*x509.CertPool, error) { return nil, errors.New("must not be called") })
+
+		// Legacy no-verification config: stdlib skip-verify, no custom verifier.
+		require.True(t, c.InsecureSkipVerify)
+		require.Nil(t, c.VerifyConnection)
+	})
+}

--- a/common/auth/tls_config_helper.go
+++ b/common/auth/tls_config_helper.go
@@ -36,6 +36,74 @@ func NewTLSConfigForServer(
 	return c
 }
 
+// NewTLSConfigForServerWithRootCAProvider creates a client TLS configuration
+// that resolves its root CA pool through getRootCAs on every new handshake
+// instead of freezing a pool at construction time. Go has no client-side
+// per-handshake RootCAs hook, so host-verifying configurations disable the
+// built-in verifier and perform the equivalent chain and identity checks in
+// VerifyConnection with the freshly resolved pool.
+//
+// Contract:
+//   - enableHostVerification=false returns the legacy no-verification config;
+//     getRootCAs is ignored entirely.
+//   - a nil getRootCAs fails every host-verifying handshake (fail closed).
+//   - a nil pool returned by getRootCAs falls back to the system trust store,
+//     matching the prior static-config behavior.
+//   - ConnectionState.VerifiedChains is not populated for these connections;
+//     the chain built in VerifyConnection is checked and discarded.
+func NewTLSConfigForServerWithRootCAProvider(
+	serverName string,
+	enableHostVerification bool,
+	getRootCAs func() (*x509.CertPool, error),
+) *tls.Config {
+	c := NewTLSConfigForServer(serverName, enableHostVerification)
+	if !enableHostVerification {
+		return c
+	}
+
+	// Required to bypass the frozen RootCAs field. VerifyConnection below performs
+	// the full chain and identity verification using the current cached CA pool.
+	// Note: with InsecureSkipVerify set, crypto/tls does not populate
+	// ConnectionState.VerifiedChains, so downstream consumers must not rely on
+	// it; the chain built in VerifyConnection is checked and discarded.
+	c.InsecureSkipVerify = true
+	c.VerifyConnection = func(state tls.ConnectionState) error {
+		if len(state.PeerCertificates) == 0 {
+			return errors.New("tls: server presented no certificates")
+		}
+		if getRootCAs == nil {
+			return errors.New("tls: root CA provider is not configured")
+		}
+
+		rootCAs, err := getRootCAs()
+		if err != nil {
+			return fmt.Errorf("tls: failed to load root CAs for verification: %w", err)
+		}
+
+		verifyName := state.ServerName
+		if verifyName == "" {
+			verifyName = serverName
+		}
+		if verifyName == "" {
+			return errors.New("tls: cannot verify server identity: connection provided no SNI and no ServerName is configured")
+		}
+
+		opts := x509.VerifyOptions{
+			Roots:         rootCAs,
+			Intermediates: x509.NewCertPool(),
+			DNSName:       verifyName,
+		}
+		for _, cert := range state.PeerCertificates[1:] {
+			opts.Intermediates.AddCert(cert)
+		}
+
+		_, err = state.PeerCertificates[0].Verify(opts)
+		return err
+	}
+
+	return c
+}
+
 func NewDynamicTLSClientConfig(
 	getCert func() (*tls.Certificate, error),
 	rootCAs *x509.CertPool,

--- a/common/rpc/encryption/dynamic_client_ca_test.go
+++ b/common/rpc/encryption/dynamic_client_ca_test.go
@@ -1,0 +1,290 @@
+package encryption
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/testing/await"
+)
+
+type testCA struct {
+	cert *x509.Certificate
+	key  *ecdsa.PrivateKey
+	pool *x509.CertPool
+}
+
+func newTestCA(t *testing.T, commonName string) *testCA {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	pool := x509.NewCertPool()
+	pool.AddCert(cert)
+	return &testCA{cert: cert, key: key, pool: pool}
+}
+
+func (ca *testCA) issueLeaf(t *testing.T, name string) tls.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: name},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	if ip := net.ParseIP(name); ip != nil {
+		template.IPAddresses = []net.IP{ip}
+	} else {
+		template.DNSNames = []string{name}
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, ca.cert, &key.PublicKey, ca.key)
+	require.NoError(t, err)
+	leaf, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	return tls.Certificate{
+		Certificate: [][]byte{der},
+		PrivateKey:  key,
+		Leaf:        leaf,
+	}
+}
+
+func clientHandshake(t *testing.T, clientConfig *tls.Config, serverLeaf tls.Certificate) error {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, listener.Close())
+	}()
+
+	serverErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		defer func() {
+			_ = conn.Close()
+		}()
+
+		if err := conn.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+			serverErr <- err
+			return
+		}
+		server := tls.Server(conn, &tls.Config{Certificates: []tls.Certificate{serverLeaf}})
+		serverErr <- server.Handshake()
+	}()
+
+	conn, err := net.DialTimeout("tcp", listener.Addr().String(), 5*time.Second)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, conn.Close())
+	}()
+
+	require.NoError(t, conn.SetDeadline(time.Now().Add(5*time.Second)))
+	client := tls.Client(conn, clientConfig)
+	clientErr := client.Handshake()
+	<-serverErr
+	return clientErr
+}
+
+func clientHandshakeWithServerName(
+	t *testing.T,
+	clientConfig *tls.Config,
+	serverName string,
+	serverLeaf tls.Certificate,
+) error {
+	t.Helper()
+
+	tlsConfig := clientConfig.Clone()
+	tlsConfig.ServerName = serverName
+	return clientHandshake(t, tlsConfig, serverLeaf)
+}
+
+func poolTrusts(pool *x509.CertPool, leaf *x509.Certificate) bool {
+	if pool == nil {
+		return false
+	}
+	_, err := leaf.Verify(x509.VerifyOptions{Roots: pool})
+	return err == nil
+}
+
+func writeCABundle(t *testing.T, path string, certificates ...*x509.Certificate) {
+	t.Helper()
+
+	var buffer bytes.Buffer
+	for _, certificate := range certificates {
+		require.NoError(t, pem.Encode(&buffer, &pem.Block{Type: "CERTIFICATE", Bytes: certificate.Raw}))
+	}
+	require.NoError(t, os.WriteFile(path, buffer.Bytes(), 0o600))
+}
+
+func TestClientTLSConfigPicksUpCARotation(t *testing.T) {
+	const serverName = "temporal-frontend.local"
+
+	ca1 := newTestCA(t, "ca1")
+	ca2 := newTestCA(t, "ca2")
+	leaf1 := ca1.issueLeaf(t, serverName)
+	leaf2 := ca2.issueLeaf(t, serverName)
+	provider := NewTestDynamicCertProvider(nil, ca1.pool, ca2.pool, config.GroupTLS{})
+
+	clientConfig, err := newClientTLSConfig(provider, serverName, false, false, true)
+	require.NoError(t, err)
+
+	require.NoError(t, clientHandshake(t, clientConfig, leaf1))
+	require.Error(t, clientHandshake(t, clientConfig, leaf2))
+
+	provider.SwitchToWrongServerRootCACerts()
+
+	require.NoError(t, clientHandshake(t, clientConfig, leaf2))
+	require.Error(t, clientHandshake(t, clientConfig, leaf1))
+}
+
+func TestClientTLSConfigServerNameVerification(t *testing.T) {
+	ca := newTestCA(t, "ca")
+	dnsLeaf := ca.issueLeaf(t, "real.host")
+	ipLeaf := ca.issueLeaf(t, "127.0.0.1")
+	noIPSANLeaf := ca.issueLeaf(t, "some.host")
+
+	tests := []struct {
+		name             string
+		staticServerName string
+		dialServerName   string
+		leaf             tls.Certificate
+		wantErr          bool
+	}{
+		{
+			name:           "DNS dial verifies negotiated authority",
+			dialServerName: "real.host",
+			leaf:           dnsLeaf,
+		},
+		{
+			name:           "DNS dial rejects mismatched authority",
+			dialServerName: "wrong.host",
+			leaf:           dnsLeaf,
+			wantErr:        true,
+		},
+		{
+			name:             "IP dial verifies configured IP SAN",
+			staticServerName: "127.0.0.1",
+			dialServerName:   "127.0.0.1",
+			leaf:             ipLeaf,
+		},
+		{
+			name:             "IP dial rejects missing IP SAN",
+			staticServerName: "127.0.0.1",
+			dialServerName:   "127.0.0.1",
+			leaf:             noIPSANLeaf,
+			wantErr:          true,
+		},
+		{
+			name:           "IP dial without configured server name fails closed",
+			dialServerName: "127.0.0.1",
+			leaf:           ipLeaf,
+			wantErr:        true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			provider := NewTestDynamicCertProvider(nil, ca.pool, ca.pool, config.GroupTLS{})
+			clientConfig, err := newClientTLSConfig(provider, test.staticServerName, false, false, true)
+			require.NoError(t, err)
+
+			err = clientHandshakeWithServerName(t, clientConfig, test.dialServerName, test.leaf)
+			if test.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestClientTLSConfigRejectsNilRootCAProvider(t *testing.T) {
+	ca := newTestCA(t, "ca")
+	leaf := ca.issueLeaf(t, "real.host")
+	clientConfig := newDynamicTLSClientConfig(nil, nil, "real.host", true)
+
+	require.ErrorContains(t, clientHandshake(t, clientConfig, leaf), "root CA provider is not configured")
+}
+
+func TestClientTLSConfigDisableHostVerificationIsLegacy(t *testing.T) {
+	trusted := newTestCA(t, "trusted")
+	untrusted := newTestCA(t, "untrusted")
+	leaf := untrusted.issueLeaf(t, "whatever.host")
+	provider := NewTestDynamicCertProvider(nil, trusted.pool, trusted.pool, config.GroupTLS{})
+
+	clientConfig, err := newClientTLSConfig(provider, "expected.host", false, false, false)
+	require.NoError(t, err)
+	require.NoError(t, clientHandshake(t, clientConfig, leaf))
+}
+
+func TestLocalStoreCertProviderReloadsAppendedCABundle(t *testing.T) {
+	ca1 := newTestCA(t, "ca1")
+	ca2 := newTestCA(t, "ca2")
+	leaf1 := ca1.issueLeaf(t, "svc").Leaf
+	leaf2 := ca2.issueLeaf(t, "svc").Leaf
+
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	writeCABundle(t, path, ca1.cert)
+
+	tlsConfig := config.GroupTLS{Client: config.ClientTLS{RootCAFiles: []string{path}}}
+	provider := NewLocalStoreCertProvider(&tlsConfig, nil, nil, 20*time.Millisecond, log.NewNoopLogger())
+	defer provider.(*localStoreCertProvider).Close()
+
+	pool, err := provider.FetchServerRootCAsForClient(false)
+	require.NoError(t, err)
+	require.True(t, poolTrusts(pool, leaf1))
+	require.False(t, poolTrusts(pool, leaf2))
+
+	writeCABundle(t, path, ca1.cert, ca2.cert)
+	await.RequireTrue(t, func() bool {
+		pool, err := provider.FetchServerRootCAsForClient(false)
+		return err == nil && poolTrusts(pool, leaf1) && poolTrusts(pool, leaf2)
+	}, 3*time.Second, 20*time.Millisecond)
+
+	writeCABundle(t, path, ca2.cert)
+	await.RequireTrue(t, func() bool {
+		pool, err := provider.FetchServerRootCAsForClient(false)
+		return err == nil && poolTrusts(pool, leaf2) && !poolTrusts(pool, leaf1)
+	}, 3*time.Second, 20*time.Millisecond)
+}

--- a/common/rpc/encryption/local_store_cert_provider.go
+++ b/common/rpc/encryption/local_store_cert_provider.go
@@ -456,22 +456,22 @@ func buildCAPool(cas []string, getBytes loadOrDecodeDataFunc) (*x509.CertPool, [
 			return nil, nil, errors.New("unknown failure constructing cert pool for ca")
 		}
 
-		cert, err := parseCert(caBytes)
+		parsed, err := parseCerts(caBytes)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to parse x509 certificate: %w", err)
 		}
-		certs = append(certs, cert)
+		certs = append(certs, parsed...)
 	}
 	return caPool, certs, nil
 }
 
 // logic borrowed from tls.X509KeyPair()
-func parseCert(bytes []byte) (*x509.Certificate, error) {
+func parseCerts(pemBytes []byte) ([]*x509.Certificate, error) {
 
 	var certBytes [][]byte
 	for {
 		var certDERBlock *pem.Block
-		certDERBlock, bytes = pem.Decode(bytes)
+		certDERBlock, pemBytes = pem.Decode(pemBytes)
 		if certDERBlock == nil {
 			break
 		}
@@ -481,9 +481,18 @@ func parseCert(bytes []byte) (*x509.Certificate, error) {
 	}
 
 	if len(certBytes) == 0 || len(certBytes[0]) == 0 {
-		return nil, fmt.Errorf("failed to decode PEM certificate data")
+		return nil, errors.New("failed to decode PEM certificate data")
 	}
-	return x509.ParseCertificate(certBytes[0])
+
+	certs := make([]*x509.Certificate, 0, len(certBytes))
+	for _, der := range certBytes {
+		cert, err := x509.ParseCertificate(der)
+		if err != nil {
+			return nil, err
+		}
+		certs = append(certs, cert)
+	}
+	return certs, nil
 }
 
 func appendError(aggregatedErr error, err error) error {

--- a/common/rpc/encryption/local_store_tls_provider.go
+++ b/common/rpc/encryption/local_store_tls_provider.go
@@ -3,6 +3,7 @@ package encryption
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"maps"
 	"path"
@@ -363,6 +364,71 @@ func getServerTLSConfigFromCertProvider(
 		logger), nil
 }
 
+// newDynamicTLSClientConfig keeps the dynamic-root workaround private to the
+// local-store TLS provider. Go has no client-side per-handshake RootCAs hook, so
+// host-verifying clients disable the built-in verifier and perform the equivalent
+// chain and identity checks in VerifyConnection with the current cached CA pool.
+func newDynamicTLSClientConfig(
+	getCert tlsCertFetcher,
+	getRootCAs func() (*x509.CertPool, error),
+	serverName string,
+	enableHostVerification bool,
+) *tls.Config {
+	c := auth.NewTLSConfigForServer(serverName, enableHostVerification)
+
+	if getCert != nil {
+		c.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return getCert()
+		}
+	}
+
+	if !enableHostVerification {
+		return c
+	}
+
+	// Required to bypass the frozen RootCAs field. VerifyConnection below performs
+	// the full chain and identity verification using the current cached CA pool.
+	// Note: with InsecureSkipVerify set, crypto/tls does not populate
+	// ConnectionState.VerifiedChains, so downstream consumers must not rely on
+	// it; the chain built in VerifyConnection is checked and discarded.
+	c.InsecureSkipVerify = true
+	c.VerifyConnection = func(state tls.ConnectionState) error {
+		if len(state.PeerCertificates) == 0 {
+			return errors.New("tls: server presented no certificates")
+		}
+		if getRootCAs == nil {
+			return errors.New("tls: root CA provider is not configured")
+		}
+
+		rootCAs, err := getRootCAs()
+		if err != nil {
+			return fmt.Errorf("tls: failed to load root CAs for verification: %w", err)
+		}
+
+		verifyName := state.ServerName
+		if verifyName == "" {
+			verifyName = serverName
+		}
+		if verifyName == "" {
+			return errors.New("tls: cannot verify server identity: connection provided no SNI and no ServerName is configured")
+		}
+
+		opts := x509.VerifyOptions{
+			Roots:         rootCAs,
+			Intermediates: x509.NewCertPool(),
+			DNSName:       verifyName,
+		}
+		for _, cert := range state.PeerCertificates[1:] {
+			opts.Intermediates.AddCert(cert)
+		}
+
+		_, err = state.PeerCertificates[0].Verify(opts)
+		return err
+	}
+
+	return c
+}
+
 func newClientTLSConfig(
 	clientProvider CertProvider,
 	serverName string,
@@ -370,10 +436,13 @@ func newClientTLSConfig(
 	isWorker bool,
 	enableHostVerification bool,
 ) (*tls.Config, error) {
-	// Optional ServerCA for client if not already trusted by host
-	serverCa, err := clientProvider.FetchServerRootCAsForClient(isWorker)
-	if err != nil {
+	// Validate the CA source at construction time, then resolve the cached pool
+	// on every handshake so provider refreshes apply to already-created clients.
+	if _, err := clientProvider.FetchServerRootCAsForClient(isWorker); err != nil {
 		return nil, fmt.Errorf("failed to load client ca: %v", err)
+	}
+	getRootCAs := func() (*x509.CertPool, error) {
+		return clientProvider.FetchServerRootCAsForClient(isWorker)
 	}
 
 	var getCert tlsCertFetcher
@@ -393,9 +462,9 @@ func newClientTLSConfig(
 		}
 	}
 
-	return auth.NewDynamicTLSClientConfig(
+	return newDynamicTLSClientConfig(
 		getCert,
-		serverCa,
+		getRootCAs,
 		serverName,
 		enableHostVerification,
 	), nil

--- a/common/rpc/encryption/local_store_tls_provider.go
+++ b/common/rpc/encryption/local_store_tls_provider.go
@@ -3,7 +3,6 @@ package encryption
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"errors"
 	"fmt"
 	"maps"
 	"path"
@@ -364,66 +363,22 @@ func getServerTLSConfigFromCertProvider(
 		logger), nil
 }
 
-// newDynamicTLSClientConfig keeps the dynamic-root workaround private to the
-// local-store TLS provider. Go has no client-side per-handshake RootCAs hook, so
-// host-verifying clients disable the built-in verifier and perform the equivalent
-// chain and identity checks in VerifyConnection with the current cached CA pool.
 func newDynamicTLSClientConfig(
 	getCert tlsCertFetcher,
 	getRootCAs func() (*x509.CertPool, error),
 	serverName string,
 	enableHostVerification bool,
 ) *tls.Config {
-	c := auth.NewTLSConfigForServer(serverName, enableHostVerification)
+	c := auth.NewTLSConfigForServerWithRootCAProvider(
+		serverName,
+		enableHostVerification,
+		getRootCAs,
+	)
 
 	if getCert != nil {
 		c.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 			return getCert()
 		}
-	}
-
-	if !enableHostVerification {
-		return c
-	}
-
-	// Required to bypass the frozen RootCAs field. VerifyConnection below performs
-	// the full chain and identity verification using the current cached CA pool.
-	// Note: with InsecureSkipVerify set, crypto/tls does not populate
-	// ConnectionState.VerifiedChains, so downstream consumers must not rely on
-	// it; the chain built in VerifyConnection is checked and discarded.
-	c.InsecureSkipVerify = true
-	c.VerifyConnection = func(state tls.ConnectionState) error {
-		if len(state.PeerCertificates) == 0 {
-			return errors.New("tls: server presented no certificates")
-		}
-		if getRootCAs == nil {
-			return errors.New("tls: root CA provider is not configured")
-		}
-
-		rootCAs, err := getRootCAs()
-		if err != nil {
-			return fmt.Errorf("tls: failed to load root CAs for verification: %w", err)
-		}
-
-		verifyName := state.ServerName
-		if verifyName == "" {
-			verifyName = serverName
-		}
-		if verifyName == "" {
-			return errors.New("tls: cannot verify server identity: connection provided no SNI and no ServerName is configured")
-		}
-
-		opts := x509.VerifyOptions{
-			Roots:         rootCAs,
-			Intermediates: x509.NewCertPool(),
-			DNSName:       verifyName,
-		}
-		for _, cert := range state.PeerCertificates[1:] {
-			opts.Intermediates.AddCert(cert)
-		}
-
-		_, err = state.PeerCertificates[0].Verify(opts)
-		return err
 	}
 
 	return c


### PR DESCRIPTION
Fixes #11230

## What changed?
- Resolve the local-store client root CA pool for every new TLS handshake instead of freezing it when the client `tls.Config` is created.
- Expose the dynamic-root construction as `auth.NewTLSConfigForServerWithRootCAProvider`, layered on the existing `NewTLSConfigForServer`; the local-store provider is a thin consumer that only adds the client certificate fetcher.
- Keep certificate file I/O on the existing background refresh path; handshakes only read the cached pool through the provider.
- Parse every certificate in a PEM CA bundle so overlap rotations such as old CA + new CA are detected by the local-store provider.
- Add real TLS handshake tests covering CA rotation, hostname and IP verification, missing root providers, disabled hostname verification, and background bundle refresh, plus direct contract tests for the new `common/auth` API (per-handshake root resolution, SNI fallback, fail-closed paths).

## Why?
The local-store certificate provider refreshes CA files periodically, but client TLS configurations currently retain the initial `RootCAs` pointer. New connections therefore continue to trust the old CA until the process recreates its TLS client configuration or restarts.

Resolving the cached CA pool during each handshake lets newly established connections observe a completed background refresh without adding filesystem I/O to the connection path. Parsing the complete PEM bundle also allows a staged CA rotation where old and new roots overlap.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

Commands:
```sh
go test -tags test_dep -race ./common/auth ./common/rpc/encryption ./common/rpc
go test -tags test_dep -race ./common/rpc/encryption -run "Test(ClientTLSConfig|LocalStoreCertProviderReloadsAppendedCABundle)" -count=20
GOLANGCI_LINT_BASE_REV=upstream/main GOLANGCI_LINT_FIX=false make lint-code
make fmt-imports
```

## Potential risks
Go does not expose a client-side callback for dynamically selecting `RootCAs`. Host-verifying clients therefore use `VerifyConnection` to perform explicit X.509 chain and server identity verification with the current cached roots. This means `ConnectionState.VerifiedChains` is not populated for these client connections.

The change does not terminate existing TLS connections. A refreshed CA pool is used on the next handshake or reconnect, preserving existing connection semantics.
