### PR TITLE
Ensure chasm_node_maps entries deleted in DeleteWorkflowExecution for SQL backends

### DIFF
--- a/common/persistence/sql/execution.go
+++ b/common/persistence/sql/execution.go
@@ -636,6 +636,15 @@ func (m *sqlExecutionStore) DeleteWorkflowExecution(
 		if err != nil {
 			return fmt.Errorf("failed to execute DeleteAllFromSignalsRequestedSets: %w", err)
 		}
+		_, err = tx.DeleteAllFromChasmNodeMaps(ctx, sqlplugin.ChasmNodeMapsAllFilter{
+			ShardID:     request.ShardID,
+			NamespaceID: namespaceID,
+			WorkflowID:  request.WorkflowID,
+			RunID:       runID,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to execute DeleteAllFromChasmNodeMaps: %w", err)
+		}
 		_, err = tx.DeleteFromBufferedEvents(ctx, sqlplugin.BufferedEventsFilter{
 			ShardID:     request.ShardID,
 			NamespaceID: namespaceID,

--- a/common/persistence/tests/execution_mutable_state.go
+++ b/common/persistence/tests/execution_mutable_state.go
@@ -6,12 +6,12 @@ import (
 	"maps"
 	"math"
 	"math/rand"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -2704,10 +2704,16 @@ func (s *ExecutionMutableStateSuite) AssertMissingFromDB(
 	if s.MutableStateTableCounts != nil {
 		counts, err := s.MutableStateTableCounts(s.Ctx, s.ShardID, namespaceID, workflowID, runID)
 		s.NoError(err)
-		// assert (non-fatal) so every offending table is reported, not just the first.
+		// Collect all offending tables into one assertion so every leak is
+		// reported, not just the first (a per-table require would stop at one).
+		var orphaned []string
 		for table, n := range counts {
-			assert.Zerof(s.T(), n, "orphaned rows in %s after delete", table)
+			if n != 0 {
+				orphaned = append(orphaned, fmt.Sprintf("%s=%d", table, n))
+			}
 		}
+		sort.Strings(orphaned)
+		s.Emptyf(orphaned, "orphaned rows after delete: %v", orphaned)
 	}
 }
 

--- a/common/persistence/tests/execution_mutable_state.go
+++ b/common/persistence/tests/execution_mutable_state.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -47,6 +48,12 @@ type (
 		ExecutionManager  p.ExecutionManager
 		HistoryBranchUtil p.HistoryBranchUtil
 		Logger            log.Logger
+
+		// MutableStateTableCounts reports surviving row counts per table that SQL
+		// uses to persist a WorkflowMutableState's sub-collections. SQL entrypoints
+		// wire it from the raw DB; nil on Cassandra, where these live as columns on
+		// the executions row and can't be queried alone.
+		MutableStateTableCounts func(ctx context.Context, shardID int32, namespaceID, workflowID, runID string) (map[string]int, error)
 
 		Ctx    context.Context
 		Cancel context.CancelFunc
@@ -2691,6 +2698,17 @@ func (s *ExecutionMutableStateSuite) AssertMissingFromDB(
 	})
 	s.IsType(&serviceerror.NotFound{}, err)
 	s.EqualError(err, fmt.Sprintf("workflow execution not found for workflow ID %q and run ID %q", workflowID, runID))
+
+	// GetWorkflowExecution short-circuits on the missing executions row, so it
+	// can't see orphaned child-table rows; check them directly where possible.
+	if s.MutableStateTableCounts != nil {
+		counts, err := s.MutableStateTableCounts(s.Ctx, s.ShardID, namespaceID, workflowID, runID)
+		s.NoError(err)
+		// assert (non-fatal) so every offending table is reported, not just the first.
+		for table, n := range counts {
+			assert.Zerof(s.T(), n, "orphaned rows in %s after delete", table)
+		}
+	}
 }
 
 func (s *ExecutionMutableStateSuite) AssertHEEqualWithDB(branchToken []byte, events ...[]*p.WorkflowEvents) {

--- a/common/persistence/tests/execution_mutable_state.go
+++ b/common/persistence/tests/execution_mutable_state.go
@@ -49,10 +49,9 @@ type (
 		HistoryBranchUtil p.HistoryBranchUtil
 		Logger            log.Logger
 
-		// MutableStateTableCounts reports surviving row counts per table that SQL
-		// uses to persist a WorkflowMutableState's sub-collections. SQL entrypoints
-		// wire it from the raw DB; nil on Cassandra, where these live as columns on
-		// the executions row and can't be queried alone.
+		// MutableStateTableCounts reports per-table surviving row counts for a run's
+		// mutable-state sub-collections. Wired from the raw DB by SQL entrypoints;
+		// nil on Cassandra, where these live as columns on the executions row.
 		MutableStateTableCounts func(ctx context.Context, shardID int32, namespaceID, workflowID, runID string) (map[string]int, error)
 
 		Ctx    context.Context

--- a/common/persistence/tests/mutable_state_tables.go
+++ b/common/persistence/tests/mutable_state_tables.go
@@ -1,0 +1,90 @@
+package tests
+
+import (
+	"context"
+
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+	"go.temporal.io/server/common/primitives"
+)
+
+// sqlMutableStateTableCounts reports surviving row counts per table that SQL uses
+// to persist a WorkflowMutableState's sub-collections, so delete assertions can
+// detect orphaned rows (e.g. chasm_node_maps). Omits the anchor executions row
+// (verified via GetWorkflowExecution) and the current_executions /
+// current_chasm_executions pointers, which DeleteCurrentWorkflowExecution clears
+// rather than DeleteWorkflowExecution.
+func sqlMutableStateTableCounts(
+	db sqlplugin.DB,
+) func(ctx context.Context, shardID int32, namespaceID, workflowID, runID string) (map[string]int, error) {
+	return func(ctx context.Context, shardID int32, namespaceID, workflowID, runID string) (map[string]int, error) {
+		nsID := primitives.MustParseUUID(namespaceID)
+		rID := primitives.MustParseUUID(runID)
+		counts := make(map[string]int)
+
+		activity, err := db.SelectAllFromActivityInfoMaps(ctx, sqlplugin.ActivityInfoMapsAllFilter{
+			ShardID: shardID, NamespaceID: nsID, WorkflowID: workflowID, RunID: rID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		counts["activity_info_maps"] = len(activity)
+
+		timer, err := db.SelectAllFromTimerInfoMaps(ctx, sqlplugin.TimerInfoMapsAllFilter{
+			ShardID: shardID, NamespaceID: nsID, WorkflowID: workflowID, RunID: rID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		counts["timer_info_maps"] = len(timer)
+
+		child, err := db.SelectAllFromChildExecutionInfoMaps(ctx, sqlplugin.ChildExecutionInfoMapsAllFilter{
+			ShardID: shardID, NamespaceID: nsID, WorkflowID: workflowID, RunID: rID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		counts["child_execution_info_maps"] = len(child)
+
+		requestCancel, err := db.SelectAllFromRequestCancelInfoMaps(ctx, sqlplugin.RequestCancelInfoMapsAllFilter{
+			ShardID: shardID, NamespaceID: nsID, WorkflowID: workflowID, RunID: rID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		counts["request_cancel_info_maps"] = len(requestCancel)
+
+		signal, err := db.SelectAllFromSignalInfoMaps(ctx, sqlplugin.SignalInfoMapsAllFilter{
+			ShardID: shardID, NamespaceID: nsID, WorkflowID: workflowID, RunID: rID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		counts["signal_info_maps"] = len(signal)
+
+		signalsRequested, err := db.SelectAllFromSignalsRequestedSets(ctx, sqlplugin.SignalsRequestedSetsAllFilter{
+			ShardID: shardID, NamespaceID: nsID, WorkflowID: workflowID, RunID: rID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		counts["signals_requested_sets"] = len(signalsRequested)
+
+		buffered, err := db.SelectFromBufferedEvents(ctx, sqlplugin.BufferedEventsFilter{
+			ShardID: shardID, NamespaceID: nsID, WorkflowID: workflowID, RunID: rID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		counts["buffered_events"] = len(buffered)
+
+		chasm, err := db.SelectAllFromChasmNodeMaps(ctx, sqlplugin.ChasmNodeMapsAllFilter{
+			ShardID: shardID, NamespaceID: nsID, WorkflowID: workflowID, RunID: rID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		counts["chasm_node_maps"] = len(chasm)
+
+		return counts, nil
+	}
+}

--- a/common/persistence/tests/mutable_state_tables.go
+++ b/common/persistence/tests/mutable_state_tables.go
@@ -7,12 +7,10 @@ import (
 	"go.temporal.io/server/common/primitives"
 )
 
-// sqlMutableStateTableCounts reports surviving row counts per table that SQL uses
-// to persist a WorkflowMutableState's sub-collections, so delete assertions can
-// detect orphaned rows (e.g. chasm_node_maps). Omits the anchor executions row
-// (verified via GetWorkflowExecution) and the current_executions /
-// current_chasm_executions pointers, which DeleteCurrentWorkflowExecution clears
-// rather than DeleteWorkflowExecution.
+// sqlMutableStateTableCounts reports per-table surviving row counts for a
+// WorkflowMutableState's sub-collections, so delete assertions can spot orphans.
+// Omits the executions anchor (covered by GetWorkflowExecution) and the current_*
+// pointers (cleared by DeleteCurrentWorkflowExecution, not DeleteWorkflowExecution).
 func sqlMutableStateTableCounts(
 	db sqlplugin.DB,
 ) func(ctx context.Context, shardID int32, namespaceID, workflowID, runID string) (map[string]int, error) {

--- a/common/persistence/tests/mysql_test.go
+++ b/common/persistence/tests/mysql_test.go
@@ -50,6 +50,11 @@ func TestMySQLExecutionMutableStateStoreSuite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
+	db, err := sql.NewSQLDB(sqlplugin.DbKindMain, testData.Cfg, resolver.NewNoopResolver(), testData.Logger, metrics.NoopMetricsHandler)
+	if err != nil {
+		t.Fatalf("unable to create MySQL DB: %v", err)
+	}
+	defer func() { _ = db.Close() }()
 
 	s := NewExecutionMutableStateSuite(
 		t,
@@ -58,6 +63,7 @@ func TestMySQLExecutionMutableStateStoreSuite(t *testing.T) {
 		serialization.NewSerializer(),
 		testData.Logger,
 	)
+	s.MutableStateTableCounts = sqlMutableStateTableCounts(db)
 	suite.Run(t, s)
 }
 

--- a/common/persistence/tests/postgresql_test.go
+++ b/common/persistence/tests/postgresql_test.go
@@ -54,6 +54,11 @@ func (p *PostgreSQLSuite) TestPostgreSQLExecutionMutableStateStoreSuite() {
 	if err != nil {
 		p.T().Fatalf("unable to create PostgreSQL DB: %v", err)
 	}
+	db, err := sql.NewSQLDB(sqlplugin.DbKindMain, testData.Cfg, resolver.NewNoopResolver(), testData.Logger, metrics.NoopMetricsHandler)
+	if err != nil {
+		p.T().Fatalf("unable to create PostgreSQL DB: %v", err)
+	}
+	defer func() { _ = db.Close() }()
 
 	s := NewExecutionMutableStateSuite(
 		p.T(),
@@ -62,6 +67,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLExecutionMutableStateStoreSuite() {
 		serialization.NewSerializer(),
 		testData.Logger,
 	)
+	s.MutableStateTableCounts = sqlMutableStateTableCounts(db)
 	suite.Run(p.T(), s)
 }
 

--- a/common/persistence/tests/sqlite_test.go
+++ b/common/persistence/tests/sqlite_test.go
@@ -111,7 +111,12 @@ func TestSQLiteExecutionMutableStateStoreSuite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
+	db, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), logger, metrics.NoopMetricsHandler)
+	if err != nil {
+		t.Fatalf("unable to create SQLite DB: %v", err)
+	}
 	defer func() {
+		_ = db.Close()
 		factory.Close()
 	}()
 
@@ -122,6 +127,7 @@ func TestSQLiteExecutionMutableStateStoreSuite(t *testing.T) {
 		serialization.NewSerializer(),
 		logger,
 	)
+	s.MutableStateTableCounts = sqlMutableStateTableCounts(db)
 	suite.Run(t, s)
 }
 
@@ -327,7 +333,12 @@ func TestSQLiteFileExecutionMutableStateStoreSuite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
+	db, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), logger, metrics.NoopMetricsHandler)
+	if err != nil {
+		t.Fatalf("unable to create SQLite DB: %v", err)
+	}
 	defer func() {
+		_ = db.Close()
 		factory.Close()
 	}()
 
@@ -338,6 +349,7 @@ func TestSQLiteFileExecutionMutableStateStoreSuite(t *testing.T) {
 		serialization.NewSerializer(),
 		logger,
 	)
+	s.MutableStateTableCounts = sqlMutableStateTableCounts(db)
 	suite.Run(t, s)
 }
 

--- a/common/persistence/tests/sqlite_test.go
+++ b/common/persistence/tests/sqlite_test.go
@@ -3,13 +3,17 @@ package tests
 import (
 	"context"
 	gosql "database/sql"
+	"fmt"
 	"math"
 	"os"
 	"path"
+	"slices"
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/config"
@@ -129,6 +133,71 @@ func TestSQLiteExecutionMutableStateStoreSuite(t *testing.T) {
 	)
 	s.MutableStateTableCounts = sqlMutableStateTableCounts(db)
 	suite.Run(t, s)
+}
+
+// TestSQLiteMutableStateTableConformance fails if a mutable-state table is added
+// without a matching delete in DeleteWorkflowExecution: it discovers every table
+// keyed by (shard_id, namespace_id, workflow_id, run_id, +>=1 more) — the shape
+// unique to mutable-state child tables — and asserts it matches what
+// sqlMutableStateTableCounts accounts for.
+func TestSQLiteMutableStateTableConformance(t *testing.T) {
+	t.Parallel()
+	cfg := NewSQLiteFileConfig()
+	SetupSQLiteDatabase(t, cfg)
+	t.Cleanup(func() { _ = os.Remove(cfg.DatabaseName) })
+
+	// Known set = the reader's map keys (single source of truth). The run need not
+	// exist; each covered table still yields a zero-count key.
+	mdb, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mdb.Close() })
+	counts, err := sqlMutableStateTableCounts(mdb)(context.Background(), 1, uuid.NewString(), "conformance-wf", uuid.NewString())
+	require.NoError(t, err)
+	var known []string
+	for table := range counts {
+		known = append(known, table)
+	}
+
+	discovered := discoverMutableStateTables(t, cfg)
+
+	require.ElementsMatch(t, known, discovered,
+		"mutable-state tables in the schema don't match the set DeleteWorkflowExecution accounts for; "+
+			"a table with a (shard_id, namespace_id, workflow_id, run_id, ...) primary key was likely added or removed "+
+			"without updating DeleteWorkflowExecution and sqlMutableStateTableCounts")
+}
+
+// discoverMutableStateTables returns the tables in the SQLite schema whose
+// primary key begins with (shard_id, namespace_id, workflow_id, run_id) and has at
+// least one further column.
+func discoverMutableStateTables(t *testing.T, cfg *config.SQL) []string {
+	t.Helper()
+	xdb, err := sqlx.Open("sqlite", cfg.DatabaseName)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = xdb.Close() })
+
+	var tableNames []string
+	require.NoError(t, xdb.Select(&tableNames,
+		`SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'`))
+
+	keyPrefix := []string{"shard_id", "namespace_id", "workflow_id", "run_id"}
+	var discovered []string
+	for _, name := range tableNames {
+		pk := sqlitePrimaryKeyColumns(t, xdb, name)
+		if len(pk) > len(keyPrefix) && slices.Equal(pk[:len(keyPrefix)], keyPrefix) {
+			discovered = append(discovered, name)
+		}
+	}
+	return discovered
+}
+
+// sqlitePrimaryKeyColumns returns a table's primary-key columns in key order.
+func sqlitePrimaryKeyColumns(t *testing.T, xdb *sqlx.DB, table string) []string {
+	t.Helper()
+	var pk []string
+	// table name comes from sqlite_master (trusted); a pragma argument can't be bound.
+	require.NoError(t, xdb.Select(&pk,
+		fmt.Sprintf("SELECT name FROM pragma_table_info('%s') WHERE pk > 0 ORDER BY pk", table)))
+	return pk
 }
 
 func TestSQLiteExecutionMutableStateTaskStoreSuite(t *testing.T) {


### PR DESCRIPTION
## What changed?
`sqlExecutionStore.DeleteWorkflowExecution` now also deletes from `chasm_node_maps`, alongside the other mutable-state sub-collection tables.

Added a `MutableStateTableCounts` hook to `ExecutionMutableStateSuite` (wired from the raw DB by the SQL entrypoints, nil on Cassandra) so `AssertMissingFromDB` verifies every mutable-state sub-collection table is empty after delete, not just that the execution is gone. This runs on the existing delete tests across SQLite/MySQL/PostgreSQL.

## Why?
On SQL backends, deleting a workflow execution left orphaned `chasm_node_maps` rows: the delete path cleared seven sibling sub-collection tables plus `executions` but omitted `chasm_node_maps`, and nothing else reclaims them — an unbounded storage leak on any deleted CHASM-bearing run. Cassandra is unaffected (CHASM nodes are a column on the `executions` row). The assertion gap is why this went unnoticed: `AssertMissingFromDB` only checked `GetWorkflowExecution`, which returns `NotFound` from the missing `executions` row before ever reading child tables.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)

The augmented `AssertMissingFromDB` fails on `chasm_node_maps` before the fix and passes after, on the existing SQL delete tests. Verified manually on SQLite by creating a CHASM scheduler execution and confirming its `chasm_node_maps` rows are removed when the run is deleted (via namespace deletion).

## Potential risks
Low. The change adds one delete within the existing `DeleteWorkflowExecution` transaction (no new persistence surface — `DeleteAllFromChasmNodeMaps` already exists on all three drivers), keyed identically to its siblings. Pre-existing orphaned rows from before this fix are not cleaned up.