### PR TITLE
Make RecordActivityTaskStarted idempotent during cancel/pause/reset

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -278,8 +278,8 @@ func (a *Activity) HandleStarted(ctx chasm.MutableContext, request *historyservi
 	*historyservice.RecordActivityTaskStartedResponse, error,
 ) {
 	lastAttempt := a.LastAttempt.Get(ctx)
-	// If already started, return existing response if request ID matches to make retry idempotent, else error.
-	if a.StateMachineState() == activitypb.ACTIVITY_EXECUTION_STATUS_STARTED && request.GetRequestId() == lastAttempt.GetStartRequestId() {
+	// Return the existing response for a matching retry while the attempt is still in progress.
+	if a.hasAttemptInProgress() && request.GetRequestId() == lastAttempt.GetStartRequestId() {
 		return a.GenerateRecordActivityTaskStartedResponse(ctx, request.GetPollRequest().GetNamespace())
 	}
 	if lastAttempt.GetStamp() != request.GetStamp() {

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -155,6 +155,10 @@ func TestHandleStarted(t *testing.T) {
 	testTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 	testRequestID := "test-request-id"
 	testStamp := int32(1)
+	// startedTime is the StartedTime set on an in-progress attempt during setup. The idempotent
+	// retry cases assert the response echoes it, rather than testTime (the mocked now) that a fresh
+	// transition would stamp, proving no new transition occurred.
+	startedTime := timestamppb.New(testTime.Add(-1 * time.Minute))
 
 	testCases := []struct {
 		name           string
@@ -186,6 +190,56 @@ func TestHandleStarted(t *testing.T) {
 			checkOutcome: func(t *testing.T, response *historyservice.RecordActivityTaskStartedResponse, err error) {
 				require.Equal(t, int32(1), response.Attempt)
 				require.NoError(t, err)
+			},
+		},
+		{
+			name:           "idempotent retry - cancel requested",
+			activityStatus: activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
+			attemptStamp:   testStamp,
+			requestStamp:   testStamp,
+			startRequestID: testRequestID,
+			requestID:      testRequestID,
+			checkOutcome: func(t *testing.T, response *historyservice.RecordActivityTaskStartedResponse, err error) {
+				require.NoError(t, err)
+				require.Equal(t, int32(1), response.Attempt)
+				require.Equal(t, startedTime, response.StartedTime)
+			},
+		},
+		{
+			name:           "error - cancel requested with different request ID",
+			activityStatus: activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
+			attemptStamp:   testStamp,
+			requestStamp:   testStamp,
+			startRequestID: "different-request-id",
+			requestID:      testRequestID,
+			checkOutcome: func(t *testing.T, response *historyservice.RecordActivityTaskStartedResponse, err error) {
+				require.ErrorAs(t, err, new(*serviceerrors.ObsoleteMatchingTask))
+			},
+		},
+		{
+			name:           "idempotent retry - pause requested",
+			activityStatus: activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED,
+			attemptStamp:   testStamp,
+			requestStamp:   testStamp,
+			startRequestID: testRequestID,
+			requestID:      testRequestID,
+			checkOutcome: func(t *testing.T, response *historyservice.RecordActivityTaskStartedResponse, err error) {
+				require.NoError(t, err)
+				require.Equal(t, int32(1), response.Attempt)
+				require.Equal(t, startedTime, response.StartedTime)
+			},
+		},
+		{
+			name:           "idempotent retry - reset requested",
+			activityStatus: activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
+			attemptStamp:   testStamp,
+			requestStamp:   testStamp,
+			startRequestID: testRequestID,
+			requestID:      testRequestID,
+			checkOutcome: func(t *testing.T, response *historyservice.RecordActivityTaskStartedResponse, err error) {
+				require.NoError(t, err)
+				require.Equal(t, int32(1), response.Attempt)
+				require.Equal(t, startedTime, response.StartedTime)
 			},
 		},
 		{
@@ -242,8 +296,13 @@ func TestHandleStarted(t *testing.T) {
 				Stamp:          tc.attemptStamp,
 				StartRequestId: tc.startRequestID,
 			}
-			if tc.activityStatus == activitypb.ACTIVITY_EXECUTION_STATUS_STARTED {
-				attemptState.StartedTime = timestamppb.New(testTime.Add(-1 * time.Minute))
+			// Only the in-progress statuses (matching hasAttemptInProgress) have a started attempt.
+			switch tc.activityStatus {
+			case activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
+				activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
+				activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED,
+				activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED:
+				attemptState.StartedTime = startedTime
 			}
 
 			// Determine heartbeat timeout based on test case

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -303,6 +303,8 @@ func TestHandleStarted(t *testing.T) {
 				activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED,
 				activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED:
 				attemptState.StartedTime = startedTime
+			default:
+				// Not-yet-started statuses (scheduled, terminal) leave StartedTime unset.
 			}
 
 			// Determine heartbeat timeout based on test case

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -296,15 +296,9 @@ func TestHandleStarted(t *testing.T) {
 				Stamp:          tc.attemptStamp,
 				StartRequestId: tc.startRequestID,
 			}
-			// Only the in-progress statuses (matching hasAttemptInProgress) have a started attempt.
-			switch tc.activityStatus {
-			case activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
-				activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
-				activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED,
-				activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED:
+			// A recorded start request ID means this attempt was previously started.
+			if tc.startRequestID != "" {
 				attemptState.StartedTime = startedTime
-			default:
-				// Not-yet-started statuses (scheduled, terminal) leave StartedTime unset.
 			}
 
 			// Determine heartbeat timeout based on test case


### PR DESCRIPTION
## What changed?
Activity.HandleStarted now returns the existing started response for an idempotent retry whenever the attempt is still in progress, not only when the status is exactly STARTED. 

## Why?
The idempotency check was too narrow. RecordActivityTaskStarted can be retried by matching, and cancel/pause/reset requests can flip the activity status while an attempt is still running on a worker. When that happened before the retry arrived, the status was no longer STARTED, so the retry stopped matching, fell through to TransitionStarted, and failed with ObsoleteMatchingTask even though it was a legitimate duplicate of an in-progress attempt.                                                                                            

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

