### PR TITLE
Retry worker deployment propagation until complete

### DIFF
--- a/service/worker/workerdeployment/propagation_retry_test.go
+++ b/service/worker/workerdeployment/propagation_retry_test.go
@@ -1,0 +1,153 @@
+package workerdeployment
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	deploymentpb "go.temporal.io/api/deployment/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+	deploymentspb "go.temporal.io/server/api/deployment/v1"
+	"go.temporal.io/server/common/testing/testvars"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func syncUnversionedRampTestWorkflow(
+	ctx workflow.Context,
+	args *deploymentspb.WorkerDeploymentWorkflowArgs,
+) error {
+	runner := &WorkflowRunner{WorkerDeploymentWorkflowArgs: args}
+	return runner.syncUnversionedRamp(ctx, &deploymentspb.SyncVersionStateUpdateArgs{
+		RoutingUpdateTime: timestamppb.New(workflow.Now(ctx)),
+		RampingSinceTime:  timestamppb.New(workflow.Now(ctx)),
+		RampPercentage:    50,
+	})
+}
+
+func syncVersionDataTestWorkflow(
+	ctx workflow.Context,
+	args *deploymentspb.WorkerDeploymentVersionWorkflowArgs,
+) error {
+	runner := &VersionWorkflowRunner{WorkerDeploymentVersionWorkflowArgs: args}
+	return runner.syncVersionDataToTaskQueues(ctx, &deploymentspb.DeploymentVersionData{
+		Version:           args.VersionState.Version,
+		RoutingUpdateTime: timestamppb.New(workflow.Now(ctx)),
+	})
+}
+
+func TestSyncUnversionedRampRetriesUntilBatchPropagationCompletes(t *testing.T) {
+	t.Parallel()
+
+	tv := testvars.New(t)
+	var testSuite testsuite.WorkflowTestSuite
+	env := testSuite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(syncUnversionedRampTestWorkflow)
+
+	var activities *Activities
+	env.OnActivity(activities.DescribeVersionFromWorkerDeployment, mock.Anything, mock.Anything).Return(
+		&deploymentspb.DescribeVersionFromWorkerDeploymentActivityResult{
+			TaskQueueInfos: []*deploymentpb.WorkerDeploymentVersionInfo_VersionTaskQueueInfo{
+				{
+					Name: tv.TaskQueue().Name,
+					Type: enumspb.TASK_QUEUE_TYPE_WORKFLOW,
+				},
+			},
+		},
+		nil,
+	)
+
+	var syncAttempts atomic.Int32
+	env.OnActivity(activities.SyncDeploymentVersionUserDataFromWorkerDeployment, mock.Anything, mock.Anything).Return(
+		func(context.Context, *deploymentspb.SyncDeploymentVersionUserDataRequest) (*deploymentspb.SyncDeploymentVersionUserDataResponse, error) {
+			if syncAttempts.Add(1) <= int32(defaultActivityOptions.RetryPolicy.MaximumAttempts) {
+				return nil, errors.New("transient sync failure")
+			}
+			return &deploymentspb.SyncDeploymentVersionUserDataResponse{
+				TaskQueueMaxVersions: map[string]int64{tv.TaskQueue().Name: 1},
+			}, nil
+		},
+	)
+
+	var propagationAttempts atomic.Int32
+	env.OnActivity(activities.CheckUnversionedRampUserDataPropagation, mock.Anything, mock.Anything).Return(
+		func(context.Context, *deploymentspb.CheckWorkerDeploymentUserDataPropagationRequest) error {
+			if propagationAttempts.Add(1) <= int32(defaultActivityOptions.RetryPolicy.MaximumAttempts) {
+				return errors.New("transient propagation failure")
+			}
+			return nil
+		},
+	)
+
+	env.ExecuteWorkflow(syncUnversionedRampTestWorkflow, &deploymentspb.WorkerDeploymentWorkflowArgs{
+		DeploymentName: tv.DeploymentSeries(),
+		State: &deploymentspb.WorkerDeploymentLocalState{
+			SyncBatchSize: 1,
+			RoutingConfig: &deploymentpb.RoutingConfig{
+				CurrentVersion: tv.DeploymentVersionString(),
+			},
+		},
+	})
+
+	require.NoError(t, env.GetWorkflowError())
+	expectedAttempts := int32(defaultActivityOptions.RetryPolicy.MaximumAttempts) + 1
+	require.Equal(t, expectedAttempts, syncAttempts.Load())
+	require.Equal(t, expectedAttempts, propagationAttempts.Load())
+	env.AssertExpectations(t)
+}
+
+func TestSyncVersionDataRetriesUntilBatchPropagationCompletes(t *testing.T) {
+	t.Parallel()
+
+	tv := testvars.New(t)
+	var testSuite testsuite.WorkflowTestSuite
+	env := testSuite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(syncVersionDataTestWorkflow)
+
+	var activities *VersionActivities
+	var syncAttempts atomic.Int32
+	env.OnActivity(activities.SyncDeploymentVersionUserData, mock.Anything, mock.Anything).Return(
+		func(context.Context, *deploymentspb.SyncDeploymentVersionUserDataRequest) (*deploymentspb.SyncDeploymentVersionUserDataResponse, error) {
+			if syncAttempts.Add(1) <= int32(defaultActivityOptions.RetryPolicy.MaximumAttempts) {
+				return nil, errors.New("transient sync failure")
+			}
+			return &deploymentspb.SyncDeploymentVersionUserDataResponse{
+				TaskQueueMaxVersions: map[string]int64{tv.TaskQueue().Name: 1},
+			}, nil
+		},
+	)
+
+	var propagationAttempts atomic.Int32
+	env.OnActivity(activities.CheckWorkerDeploymentUserDataPropagation, mock.Anything, mock.Anything).Return(
+		func(context.Context, *deploymentspb.CheckWorkerDeploymentUserDataPropagationRequest) error {
+			if propagationAttempts.Add(1) <= int32(defaultActivityOptions.RetryPolicy.MaximumAttempts) {
+				return errors.New("transient propagation failure")
+			}
+			return nil
+		},
+	)
+
+	env.ExecuteWorkflow(syncVersionDataTestWorkflow, &deploymentspb.WorkerDeploymentVersionWorkflowArgs{
+		VersionState: &deploymentspb.VersionLocalState{
+			Version:       tv.DeploymentVersion(),
+			SyncBatchSize: 1,
+			TaskQueueFamilies: map[string]*deploymentspb.VersionLocalState_TaskQueueFamilyData{
+				tv.TaskQueue().Name: {
+					TaskQueues: map[int32]*deploymentspb.TaskQueueVersionData{
+						int32(enumspb.TASK_QUEUE_TYPE_WORKFLOW): {},
+					},
+				},
+			},
+		},
+	})
+
+	require.NoError(t, env.GetWorkflowError())
+	expectedAttempts := int32(defaultActivityOptions.RetryPolicy.MaximumAttempts) + 1
+	require.Equal(t, expectedAttempts, syncAttempts.Load())
+	require.Equal(t, expectedAttempts, propagationAttempts.Load())
+	env.AssertExpectations(t)
+}

--- a/service/worker/workerdeployment/version_workflow.go
+++ b/service/worker/workerdeployment/version_workflow.go
@@ -931,7 +931,6 @@ func (d *VersionWorkflowRunner) handleSyncState(ctx workflow.Context, args *depl
 		// sync version information to all the task queues
 		err = d.syncVersionDataToTaskQueues(ctx, versionData)
 		if err != nil {
-			// TODO (Shivam): Compensation functions required to roll back the local state + activity changes.
 			return nil, err
 		}
 		// apply changes to current and ramping
@@ -1309,8 +1308,8 @@ func (d *VersionWorkflowRunner) syncVersionDataToTaskQueues(ctx workflow.Context
 	}
 
 	// calling SyncDeploymentVersionUserData for each batch
+	activityCtx := workflow.WithActivityOptions(ctx, propagationActivityOptions)
 	for _, batch := range batches {
-		activityCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
 		var syncRes deploymentspb.SyncDeploymentVersionUserDataResponse
 
 		err := workflow.ExecuteActivity(activityCtx, d.a.SyncDeploymentVersionUserData, &deploymentspb.SyncDeploymentVersionUserDataRequest{

--- a/service/worker/workerdeployment/workflow.go
+++ b/service/worker/workerdeployment/workflow.go
@@ -1674,30 +1674,29 @@ func (d *WorkflowRunner) syncUnversionedRamp(ctx workflow.Context, versionUpdate
 	}
 
 	// calling SyncDeploymentVersionUserData for each batch
+	propagationCtx := workflow.WithActivityOptions(ctx, propagationActivityOptions)
 	for _, batch := range batches {
 		var syncRes deploymentspb.SyncDeploymentVersionUserDataResponse
 
-		err = workflow.ExecuteActivity(activityCtx, d.a.SyncDeploymentVersionUserDataFromWorkerDeployment, &deploymentspb.SyncDeploymentVersionUserDataRequest{
+		err = workflow.ExecuteActivity(propagationCtx, d.a.SyncDeploymentVersionUserDataFromWorkerDeployment, &deploymentspb.SyncDeploymentVersionUserDataRequest{
 			DeploymentName: d.DeploymentName,
 			Version:        nil,
 			ForgetVersion:  false,
 			Sync:           batch,
 		}).Get(ctx, &syncRes)
 		if err != nil {
-			// TODO (Shivam): Compensation functions required to roll back the local state + activity changes.
 			return err
 		}
 
 		if len(syncRes.TaskQueueMaxVersions) > 0 {
 			// wait for propagation
 			err = workflow.ExecuteActivity(
-				activityCtx,
+				propagationCtx,
 				d.a.CheckUnversionedRampUserDataPropagation,
 				&deploymentspb.CheckWorkerDeploymentUserDataPropagationRequest{
 					TaskQueueMaxVersions: syncRes.TaskQueueMaxVersions,
 				}).Get(ctx, nil)
 			if err != nil {
-				// TODO (Shivam): Compensation functions required to roll back the local state + activity changes.
 				return err
 			}
 		}


### PR DESCRIPTION
## What changed?

  - Use durable unlimited retries for legacy batched deployment user-data writes and propagation checks.
  - Apply the fix to both deployment and version workflows.
  - Add failure-injection tests covering retries beyond the previous five-attempt limit.

  ## Why?

  A failed batch could partially update task queues before exhausting retries, leaving deployment routing inconsistent.

  These writes are timestamp-gated and idempotent, so retrying until propagation completes safely converges task queues without a potentially unsafe concurrent rollback. This
  also matches the existing asynchronous propagation strategy.

  ## How did you test it?

  - [x] `go test -tags test_dep ./service/worker/workerdeployment -count=1`
  - [x] `make fmt-imports`
  - [x] `make lint-code`
  - [x] Added new unit tests

  ## Potential risks

  A persistent retryable Matching failure now keeps the update pending instead of returning after partial propagation. Retry backoff limits additional load, and this behavior
  prevents local and task-queue routing state from diverging.
