### PR TITLE
Report failed task starts as unmatched

### DIFF
--- a/service/matching/matcher_data.go
+++ b/service/matching/matcher_data.go
@@ -44,6 +44,8 @@ const (
 	syncMatchNoPoller
 	// A poller was available but rate limiting blocked the match.
 	syncMatchRateLimited
+	// A poller accepted the task, but the task could not be started.
+	syncMatchStartFailed
 )
 
 type taskForwarderType int32

--- a/service/matching/pri_matcher.go
+++ b/service/matching/pri_matcher.go
@@ -405,9 +405,10 @@ func (tm *priTaskMatcher) Offer(ctx context.Context, task *internalTask) (syncMa
 		if res.startErr == nil && !task.isForwarded() {
 			tm.emitDispatchLatency(task, false)
 		}
-		// TODO: when startErr is non-nil (e.g. busy workflow), the task was not actually
-		// dispatched. This should return a failure outcome instead of syncMatchSuccess.
-		return syncMatchSuccess, res.startErr
+		if res.startErr != nil {
+			return syncMatchStartFailed, res.startErr
+		}
+		return syncMatchSuccess, nil
 	}
 
 	// Fast path if we have a waiting poller (or forwarder).

--- a/service/matching/pri_matcher_test.go
+++ b/service/matching/pri_matcher_test.go
@@ -17,6 +17,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/common/tqid"
@@ -195,6 +196,62 @@ func (s *PriMatcherSuite) TestForwardPollRetriesOnResourceExhausted() {
 		require.True(t, task.isStarted(), "task should be a started (forwarded) task")
 		require.Equal(t, taskToken, task.started.workflowTaskInfo.TaskToken)
 	})
+}
+
+func (s *PriMatcherSuite) TestOfferStartFailureIsNotSyncMatch() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tq := tqid.UnsafeTaskQueueFamily("nsid", "tq").TaskQueue(enumspb.TASK_QUEUE_TYPE_WORKFLOW)
+	partition := tq.RootPartition()
+	cfg := newTaskQueueConfig(tq, NewConfig(dynamicconfig.NewNoopCollection()), "nsname")
+
+	rateLimitManager := newRateLimitManager(&mockUserDataManager{}, cfg, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
+	rateLimitManager.Start()
+	defer rateLimitManager.Stop()
+
+	tm := newPriTaskMatcher(
+		ctx,
+		cfg,
+		partition,
+		nil,
+		nil,
+		nil,
+		s.logger,
+		metrics.NoopMetricsHandler,
+		rateLimitManager,
+		func() {},
+		func() {},
+	)
+	tm.Start()
+	defer tm.Stop()
+
+	startErr := serviceerror.NewResourceExhausted(
+		enumspb.RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW,
+		"workflow is busy",
+	)
+	pollDone := make(chan error, 1)
+	go func() {
+		task, err := tm.Poll(ctx, &pollMetadata{})
+		if err != nil {
+			pollDone <- err
+			return
+		}
+		task.finish(taskFinishResult{err: startErr})
+		pollDone <- nil
+	}()
+	await.RequireTrue(s.T(), tm.HasWaitingPoller, 2*time.Second, time.Millisecond)
+
+	outcome, err := tm.Offer(ctx, newInternalTaskForSyncMatch(
+		&persistencespb.TaskInfo{CreateTime: timestamppb.Now()},
+		nil,
+		0,
+		nil,
+	))
+
+	s.Require().ErrorIs(err, startErr)
+	s.Equal(syncMatchStartFailed, outcome)
+	s.Require().NoError(<-pollDone)
 }
 
 // TestValidatorDrop_SetsDropReason verifies that when the root-partition validator

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -618,7 +618,8 @@ reredirectTask:
 	if isActive {
 		outcome, err = syncMatchQueue.TrySyncMatch(ctx, syncMatchTask)
 		syncMatched = outcome == syncMatchSuccess
-		if syncMatched && !pm.shouldBacklogSyncMatchTaskOnError(err) {
+		taskReachedPoller := syncMatched || outcome == syncMatchStartFailed
+		if taskReachedPoller && !pm.shouldBacklogSyncMatchTaskOnError(err) {
 			// Only fire hooks for non-forwarded tasks. Forwarded tasks already had hooks fired
 			// on the child partition that originally received the task.
 			if !forwarded {

--- a/service/matching/task_queue_partition_manager_test.go
+++ b/service/matching/task_queue_partition_manager_test.go
@@ -1357,6 +1357,7 @@ type capturingTaskMatchHook struct {
 type capturedTaskMatchDetails struct {
 	TaskQueueName     string
 	TaskQueueType     enumspb.TaskQueueType
+	IsSyncMatch       bool
 	SyncMatchOutcome  hooks.SyncMatchOutcome
 	DeploymentVersion *deploymentpb.WorkerDeploymentVersion
 }
@@ -1379,6 +1380,7 @@ func (h *capturingTaskMatchHook) ProcessTaskAdd(ctx context.Context, event *hook
 	details := capturedTaskMatchDetails{
 		TaskQueueName:    h.taskQueueName,
 		TaskQueueType:    h.taskQueueType,
+		IsSyncMatch:      event.IsSyncMatch,
 		SyncMatchOutcome: event.SyncMatchOutcome,
 	}
 	if event.DeploymentVersion != nil {
@@ -1662,6 +1664,53 @@ func (s *PartitionManagerTestSuite) TestTaskAddHooks_AddHookNoSyncMatch() {
 	s.Require().Len(calls, 1)
 	s.Equal(taskQueueName, calls[0].TaskQueueName)
 	s.Equal(enumspb.TASK_QUEUE_TYPE_WORKFLOW, calls[0].TaskQueueType)
+	s.Equal(hooks.SyncMatchOutcomeNotMatched, calls[0].SyncMatchOutcome)
+}
+
+func (s *PartitionManagerTestSuite) TestTaskAddHooks_BusyWorkflowStartFailure() {
+	if !s.newMatcher {
+		s.T().Skip("start failure outcome is only available in the new matcher")
+	}
+
+	hook := &capturingTaskMatchHook{}
+	pm, cleanup := s.setupPartitionManagerWithTaskHookFactories([]hooks.TaskHookFactory{hook})
+	defer cleanup()
+
+	startErr := serviceerror.NewResourceExhausted(
+		enumspb.RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW,
+		"workflow is busy",
+	)
+	pollDone := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		task, _, err := pm.PollTask(ctx, &pollMetadata{
+			workerVersionCapabilities: &commonpb.WorkerVersionCapabilities{},
+		})
+		if err != nil {
+			pollDone <- err
+			return
+		}
+		task.finish(taskFinishResult{err: startErr})
+		pollDone <- nil
+	}()
+	pq := pm.defaultQueue().(*physicalTaskQueueManagerImpl)
+	await.RequireTrue(s.T(), pq.matcher.HasWaitingPoller, 2*time.Second, time.Millisecond)
+
+	_, syncMatched, err := pm.AddTask(context.Background(), addTaskParams{
+		taskInfo: &persistencespb.TaskInfo{
+			NamespaceId: namespaceID,
+			RunId:       "run",
+			WorkflowId:  "wf",
+		},
+	})
+	s.Require().NoError(err)
+	s.False(syncMatched)
+	s.Require().NoError(<-pollDone)
+
+	calls := hook.getCalls()
+	s.Require().Len(calls, 1)
+	s.False(calls[0].IsSyncMatch)
 	s.Equal(hooks.SyncMatchOutcomeNotMatched, calls[0].SyncMatchOutcome)
 }
 


### PR DESCRIPTION
## What changed?

  - Added a distinct matcher outcome for tasks accepted by a poller but not started.
  - Report busy-workflow start failures to hooks as `IsSyncMatch=false` and `NotMatched`.
  - Preserve backlog spooling for busy workflows and existing handling for other start errors.
  - Added matcher and partition-manager hook regression tests.

  ## Why?

  A poller returning `RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW` does not dispatch the task. Reporting it as a successful sync match gave routing, scaling, and accounting hooks
  incorrect information even though the task was subsequently backlogged.

  ## How did you test it?

  - [x] `go test -tags test_dep ./service/matching -count=1`
  - [x] `make fmt-imports`
  - [x] `make lint-code`
  - [x] Added new unit tests

  ## Potential risks

  The new internal outcome changes hook reporting for all poller start failures from successful to unmatched. Non-busy error handling and busy-workflow backlog behavior
  remain unchanged.
