### PR TITLE
Enable version reactivation signals by default

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -3209,7 +3209,7 @@ but existing callbacks will still be processed and fired.`,
 
 	EnableVersionReactivationSignals = NewGlobalBoolSetting(
 		"history.enableVersionReactivationSignals",
-		false,
+		true,
 		`EnableVersionReactivationSignals controls whether reactivation signals are sent to version workflows
 		when workflows are pinned to a potentially DRAINED/INACTIVE version. Set to false to disable signals
 		globally if load becomes problematic.`,


### PR DESCRIPTION
## What changed?

- Changed the global default for `history.enableVersionReactivationSignals` from `false` to `true`.
- Explicit dynamic-config overrides can still disable the signals if needed.

## Why?

Version reactivation signals should be enabled by default so workflows pinned to a drained or inactive deployment version cause that version's drainage state to be reactivated.

## Testing

Not run; this is a one-line dynamic-config default change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default behavior for worker deployment versioning and adds history→worker signal traffic; impact is mitigated by the existing global kill switch and dedup cache settings.
> 
> **Overview**
> Turns on **version reactivation signals** cluster-wide by default by changing the built-in default for dynamic config `history.enableVersionReactivationSignals` from `false` to `true`.
> 
> When enabled, history sends reactivation signals to deployment **version workflows** so pinned workflows on a **DRAINED** or **INACTIVE** version can drive that version’s drainage state back toward active handling. Deployments that relied on the old default stay off until they set an explicit override; operators can still set the key to `false` if signal volume or load is a concern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b6fb110a258c5fa4d7ca7415b40da94c96751d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->