### PR TITLE
Preserve MySQL visibility rollback errors

### DIFF
--- a/common/persistence/sql/sqlplugin/mysql/visibility.go
+++ b/common/persistence/sql/sqlplugin/mysql/visibility.go
@@ -82,6 +82,13 @@ func buildOnDuplicateKeyUpdate(fields ...string) string {
 	return fmt.Sprintf("ON DUPLICATE KEY UPDATE %s", strings.Join(items, ", "))
 }
 
+func combineRollbackError(operationErr error, rollbackErr error) error {
+	if rollbackErr == nil || errors.Is(rollbackErr, sql.ErrTxDone) {
+		return operationErr
+	}
+	return fmt.Errorf("transaction rollback failed: %w", errors.Join(rollbackErr, operationErr))
+}
+
 // InsertIntoVisibility inserts a row into visibility table. If an row already exist,
 // its left as such and no update will be made
 func (mdb *db) InsertIntoVisibility(
@@ -102,12 +109,7 @@ func (mdb *db) InsertIntoVisibility(
 		return nil, err
 	}
 	defer func() {
-		err := tx.Rollback()
-		// If the error is sql.ErrTxDone, it means the transaction already closed, so ignore error.
-		if err != nil && !errors.Is(err, sql.ErrTxDone) {
-			// Transaction rollback error should never happen, unless db connection was lost.
-			retError = fmt.Errorf("transaction rollback failed: %w", retError)
-		}
+		retError = combineRollbackError(retError, tx.Rollback())
 	}()
 	result, err = tx.NamedExecContext(ctx, templateInsertWorkflowExecution, finalRow)
 	if err != nil {
@@ -146,12 +148,7 @@ func (mdb *db) ReplaceIntoVisibility(
 		return nil, err
 	}
 	defer func() {
-		err := tx.Rollback()
-		// If the error is sql.ErrTxDone, it means the transaction already closed, so ignore error.
-		if err != nil && !errors.Is(err, sql.ErrTxDone) {
-			// Transaction rollback error should never happen, unless db connection was lost.
-			retError = fmt.Errorf("transaction rollback failed: %w", retError)
-		}
+		retError = combineRollbackError(retError, tx.Rollback())
 	}()
 	result, err = tx.NamedExecContext(ctx, templateUpsertWorkflowExecution, finalRow)
 	if err != nil {
@@ -190,12 +187,7 @@ func (mdb *db) DeleteFromVisibility(
 		return nil, err
 	}
 	defer func() {
-		err := tx.Rollback()
-		// If the error is sql.ErrTxDone, it means the transaction already closed, so ignore error.
-		if err != nil && !errors.Is(err, sql.ErrTxDone) {
-			// Transaction rollback error should never happen, unless db connection was lost.
-			retError = fmt.Errorf("transaction rollback failed: %w", retError)
-		}
+		retError = combineRollbackError(retError, tx.Rollback())
 	}()
 	_, err = tx.NamedExecContext(ctx, templateDeleteCustomSearchAttributes, filter)
 	if err != nil {

--- a/common/persistence/sql/sqlplugin/mysql/visibility_test.go
+++ b/common/persistence/sql/sqlplugin/mysql/visibility_test.go
@@ -1,0 +1,29 @@
+package mysql
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCombineRollbackError(t *testing.T) {
+	operationErr := errors.New("operation failed")
+	rollbackErr := errors.New("rollback failed")
+
+	err := combineRollbackError(operationErr, rollbackErr)
+
+	require.ErrorIs(t, err, operationErr)
+	require.ErrorIs(t, err, rollbackErr)
+	require.ErrorContains(t, err, "transaction rollback failed")
+}
+
+func TestCombineRollbackError_IgnoresClosedTransaction(t *testing.T) {
+	operationErr := errors.New("operation failed")
+
+	err := combineRollbackError(operationErr, sql.ErrTxDone)
+
+	require.ErrorIs(t, err, operationErr)
+	require.NotErrorIs(t, err, sql.ErrTxDone)
+}


### PR DESCRIPTION
## What changed?

  - Fixed rollback handling in MySQL visibility insert, replace, and delete paths.
  - Added a shared helper that preserves both the original operation error and rollback error.
  - Continued ignoring `sql.ErrTxDone` for already-completed transactions.
  - Added regression tests for the returned error chain.

  ## Why?

  The rollback handlers wrapped `retError` instead of the error returned by `tx.Rollback()`. This discarded the rollback or connection failure precisely when transaction
  state was uncertain.

  Both errors are now discoverable through `errors.Is`, preserving diagnostic and retry-classification information.

  ## How did you test it?

  - [x] `go test -tags test_dep ./common/persistence/sql/sqlplugin/mysql -count=1`
  - [x] `make fmt-imports`
  - [x] `make lint-code`
  - [x] Added new unit tests

  ## Potential risks

  Returned errors can now contain both the operation and rollback failures, which may change exact error strings. Error-chain inspection remains compatible and is more
  complete.