### PR TITLE
Include LastDeploymentVersion in buildActivityExecutionInfo

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1733,6 +1733,7 @@ func (a *Activity) buildActivityExecutionInfo(
 		LastHeartbeatTime:       heartbeat.GetRecordedTime(),
 		LastStartedTime:         attempt.GetStartedTime(),
 		LastWorkerIdentity:      attempt.GetLastWorkerIdentity(),
+		LastDeploymentVersion:   attempt.GetLastDeploymentVersion(),
 		SdkName:                 attempt.GetSdkName(),
 		SdkVersion:              attempt.GetSdkVersion(),
 		NextAttemptScheduleTime: a.nextAttemptDispatchTime(ctx, attempt),

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	apiactivitypb "go.temporal.io/api/activity/v1" //nolint:importas
 	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/deployment/v1"
 	sdkpb "go.temporal.io/api/sdk/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
@@ -1327,4 +1328,44 @@ func TestHandleReset_RestoreOriginalOptions_RejectsMissingOriginalOptions(t *tes
 
 	require.Error(t, err)
 	require.Equal(t, "current-task-queue", activity.GetTaskQueue().GetName())
+}
+
+// TestBuildActivityExecutionInfo_IncludeLastDeploymentVersion ensures that the
+// LastDeploymentVersion from the last attempt is included in the returned
+// ActivityExecutionInfo.
+func TestBuildActivityExecutionInfo_IncludeLastDeploymentVersion(t *testing.T) {
+	ctx := &chasm.MockMutableContext{
+		MockContext: chasm.MockContext{
+			HandleNow: func(chasm.Component) time.Time { return time.Unix(0, 0) },
+		},
+	}
+
+	activity := &Activity{
+		ActivityState: &activitypb.ActivityState{
+			Status:                 activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+			ActivityType:           &commonpb.ActivityType{Name: "T"},
+			TaskQueue:              &taskqueuepb.TaskQueue{Name: "current-task-queue"},
+			ScheduleToCloseTimeout: durationpb.New(30 * time.Second),
+			StartToCloseTimeout:    durationpb.New(10 * time.Second),
+			OriginalOptions:        nil,
+		},
+		LastAttempt: chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{
+			LastDeploymentVersion: &deployment.WorkerDeploymentVersion{
+				DeploymentName: "test-deployment",
+				BuildId:        "test-build-1",
+			},
+		}),
+		RequestData: chasm.NewDataField(ctx, &activitypb.ActivityRequestData{}),
+		Visibility:  chasm.NewComponentField(ctx, &chasm.Visibility{}),
+	}
+
+	resp, err := activity.buildDescribeActivityExecutionResponse(ctx, &activitypb.DescribeActivityExecutionRequest{
+		FrontendRequest: &workflowservice.DescribeActivityExecutionRequest{},
+	})
+
+	require.NoError(t, err)
+	info := resp.FrontendResponse.GetInfo()
+	require.NotNil(t, info.GetLastDeploymentVersion())
+	require.Equal(t, "test-deployment", info.GetLastDeploymentVersion().GetDeploymentName())
+	require.Equal(t, "test-build-1", info.GetLastDeploymentVersion().GetBuildId())
 }

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	apiactivitypb "go.temporal.io/api/activity/v1" //nolint:importas
 	commonpb "go.temporal.io/api/common/v1"
-	"go.temporal.io/api/deployment/v1"
+	deploymentpb "go.temporal.io/api/deployment/v1"
 	sdkpb "go.temporal.io/api/sdk/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
@@ -1350,7 +1350,7 @@ func TestBuildActivityExecutionInfo_IncludeLastDeploymentVersion(t *testing.T) {
 			OriginalOptions:        nil,
 		},
 		LastAttempt: chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{
-			LastDeploymentVersion: &deployment.WorkerDeploymentVersion{
+			LastDeploymentVersion: &deploymentpb.WorkerDeploymentVersion{
 				DeploymentName: "test-deployment",
 				BuildId:        "test-build-1",
 			},

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -12,7 +12,9 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/server/api/deployment/v1"
 	"go.temporal.io/server/api/historyservice/v1"
+	"go.temporal.io/server/api/taskqueue/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/activity/gen/activitypb/v1"
 	"go.temporal.io/server/common/headers"
@@ -365,6 +367,12 @@ func TestTransitionStarted(t *testing.T) {
 		PollRequest: &workflowservice.PollActivityTaskQueueRequest{
 			Identity: "test-worker",
 		},
+		VersionDirective: &taskqueue.TaskVersionDirective{
+			DeploymentVersion: &deployment.WorkerDeploymentVersion{
+				DeploymentName: "test-deployment",
+				BuildId:        "test-build-1",
+			},
+		},
 	})
 	require.NoError(t, err)
 	require.Equal(t, activitypb.ACTIVITY_EXECUTION_STATUS_STARTED, activity.Status)
@@ -373,6 +381,12 @@ func TestTransitionStarted(t *testing.T) {
 	require.Equal(t, "test-worker", attemptState.LastWorkerIdentity)
 	require.Equal(t, headers.ClientNameGoSDK, attemptState.SdkName)
 	require.Equal(t, temporal.SDKVersion, attemptState.SdkVersion)
+
+	// Verify last deployment version
+	deploymentVersion := attemptState.GetLastDeploymentVersion()
+	require.NotNil(t, deploymentVersion)
+	require.Equal(t, "test-deployment", deploymentVersion.GetDeploymentName())
+	require.Equal(t, "test-build-1", deploymentVersion.GetBuildId())
 
 	// Verify added tasks
 	require.Len(t, ctx.Tasks, 1)

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -12,9 +12,9 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/temporal"
-	"go.temporal.io/server/api/deployment/v1"
+	deploymentspb "go.temporal.io/server/api/deployment/v1"
 	"go.temporal.io/server/api/historyservice/v1"
-	"go.temporal.io/server/api/taskqueue/v1"
+	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/activity/gen/activitypb/v1"
 	"go.temporal.io/server/common/headers"
@@ -367,8 +367,8 @@ func TestTransitionStarted(t *testing.T) {
 		PollRequest: &workflowservice.PollActivityTaskQueueRequest{
 			Identity: "test-worker",
 		},
-		VersionDirective: &taskqueue.TaskVersionDirective{
-			DeploymentVersion: &deployment.WorkerDeploymentVersion{
+		VersionDirective: &taskqueuespb.TaskVersionDirective{
+			DeploymentVersion: &deploymentspb.WorkerDeploymentVersion{
 				DeploymentName: "test-deployment",
 				BuildId:        "test-build-1",
 			},


### PR DESCRIPTION
## What changed?
Include LastDeploymentVersion in ActivityExecutionInfo returned by 
buildActivityExecutionInfo.

## Why?
TransitionStarted persists the poller’s deployment version for the started activity,
but buildActivityExecutionInfo never assigns the LastDeploymentVersion field. 
Thus Describe always reports nil even when the state contains the value.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
