### PR TITLE
Add e2e functional test for cluster removal over-blocking fix 

### DIFF
--- a/tests/xdc/base.go
+++ b/tests/xdc/base.go
@@ -54,6 +54,11 @@ type (
 		logger                 log.Logger
 		dynamicConfigOverrides map[dynamicconfig.Key]any
 
+		// clusterNames, if set, overrides the default two-cluster ("active"/"standby")
+		// topology. setupSuite provisions one TestCluster per name and connects every
+		// pair, so any count is supported. Leave empty for the historical two clusters.
+		clusterNames []string
+
 		startTime          time.Time
 		onceClusterConnect sync.Once
 
@@ -65,7 +70,7 @@ type (
 
 // TODO (alex): this should be gone.
 func (s *xdcBaseSuite) clusterReplicationConfig() []*replicationpb.ClusterReplicationConfig {
-	config := make([]*replicationpb.ClusterReplicationConfig, 2)
+	config := make([]*replicationpb.ClusterReplicationConfig, len(s.clusters))
 	for ci, c := range s.clusters {
 		config[ci] = &replicationpb.ClusterReplicationConfig{
 			ClusterName: c.ClusterName(),
@@ -102,55 +107,54 @@ func (s *xdcBaseSuite) setupSuite(opts ...testcore.TestClusterOption) {
 	s.dynamicConfigOverrides[dynamicconfig.OutboundProcessorMaxPollInterval.Key()] = time.Second * 3
 
 	persistenceDefaults := testcore.GetPersistenceTestDefaults()
-	clusterConfigs := []*testcore.TestClusterConfig{
-		{
-			ClusterMetadata: cluster.Config{
-				EnableGlobalNamespace:    true,
-				FailoverVersionIncrement: 10,
-			},
-			HistoryConfig: testcore.HistoryConfig{
-				NumHistoryShards: cmp.Or(params.NumHistoryShards, 1),
-			},
-			Persistence: persistenceDefaults,
-		},
-		{
-			ClusterMetadata: cluster.Config{
-				EnableGlobalNamespace:    true,
-				FailoverVersionIncrement: 10,
-			},
-			HistoryConfig: testcore.HistoryConfig{
-				NumHistoryShards: cmp.Or(params.NumHistoryShards, 1),
-			},
-			Persistence: persistenceDefaults,
-		},
+
+	// The default topology is two clusters, named "active" and "standby". Suites
+	// that need a different number of clusters set s.clusterNames before calling
+	// setupSuite; everything below (including the connect-every-pair loop) scales
+	// to any cluster count.
+	clusterBaseNames := s.clusterNames
+	if len(clusterBaseNames) == 0 {
+		clusterBaseNames = []string{"active", "standby"}
 	}
 
-	s.clusters = make([]*testcore.TestCluster, len(clusterConfigs))
 	suffix := common.GenerateRandomString(5)
+	clusterConfigs := make([]*testcore.TestClusterConfig, len(clusterBaseNames))
+	s.clusters = make([]*testcore.TestCluster, len(clusterBaseNames))
 
 	testClusterFactory := testcore.NewTestClusterFactory()
-	for clusterIndex, clusterName := range []string{"active_" + suffix, "standby_" + suffix} {
-		clusterConfigs[clusterIndex].DynamicConfigOverrides = s.dynamicConfigOverrides
-		clusterConfigs[clusterIndex].DCRedirectionPolicy = params.DCRedirectionPolicy
-		clusterConfigs[clusterIndex].ClusterMetadata.MasterClusterName = clusterName
-		clusterConfigs[clusterIndex].ClusterMetadata.CurrentClusterName = clusterName
-		clusterConfigs[clusterIndex].ClusterMetadata.EnableGlobalNamespace = true
-		clusterConfigs[clusterIndex].Persistence.DBName += "_" + clusterName
-		clusterConfigs[clusterIndex].ClusterMetadata.ClusterInformation = map[string]cluster.ClusterInformation{
-			clusterName: {
-				Enabled:                true,
-				InitialFailoverVersion: int64(clusterIndex + 1),
-				// RPCAddress and HTTPAddress will be filled in
+	for clusterIndex, baseName := range clusterBaseNames {
+		clusterName := baseName + "_" + suffix
+		clusterConfig := &testcore.TestClusterConfig{
+			ClusterMetadata: cluster.Config{
+				EnableGlobalNamespace:    true,
+				FailoverVersionIncrement: 10,
+				MasterClusterName:        clusterName,
+				CurrentClusterName:       clusterName,
+				ClusterInformation: map[string]cluster.ClusterInformation{
+					clusterName: {
+						Enabled:                true,
+						InitialFailoverVersion: int64(clusterIndex + 1),
+						// RPCAddress and HTTPAddress will be filled in
+					},
+				},
 			},
+			HistoryConfig: testcore.HistoryConfig{
+				NumHistoryShards: cmp.Or(params.NumHistoryShards, 1),
+			},
+			Persistence:               persistenceDefaults,
+			DynamicConfigOverrides:    s.dynamicConfigOverrides,
+			DCRedirectionPolicy:       params.DCRedirectionPolicy,
+			EnableArchival:            params.EnableArchival,
+			AdditionalServerOptions:   params.AdditionalServerOptions,
+			EnableMetricsCapture:      true,
+			EnableHistoryTaskRecorder: params.EnableHistoryTaskRecorder,
+			EnableReplicationRecorder: params.EnableReplicationRecorder,
 		}
-		clusterConfigs[clusterIndex].EnableArchival = params.EnableArchival
-		clusterConfigs[clusterIndex].AdditionalServerOptions = params.AdditionalServerOptions
-		clusterConfigs[clusterIndex].EnableMetricsCapture = true
-		clusterConfigs[clusterIndex].EnableHistoryTaskRecorder = params.EnableHistoryTaskRecorder
-		clusterConfigs[clusterIndex].EnableReplicationRecorder = params.EnableReplicationRecorder
+		clusterConfig.Persistence.DBName += "_" + clusterName
+		clusterConfigs[clusterIndex] = clusterConfig
 
 		var err error
-		s.clusters[clusterIndex], err = testClusterFactory.NewCluster(s.T(), clusterConfigs[clusterIndex], log.With(s.logger, tag.ClusterName(clusterName)))
+		s.clusters[clusterIndex], err = testClusterFactory.NewCluster(s.T(), clusterConfig, log.With(s.logger, tag.ClusterName(clusterName)))
 		s.Require().NoError(err)
 	}
 

--- a/tests/xdc/remove_remote_cluster_test.go
+++ b/tests/xdc/remove_remote_cluster_test.go
@@ -1,14 +1,15 @@
 package xdc
 
 import (
+	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/tests/testcore"
 )
 
@@ -110,7 +111,7 @@ func (s *RemoveRemoteClusterTestSuite) TestRemoveRemoteCluster_OrphanedNamespace
 	// namespace's cluster list). updateNamespaceClusters only waits for the
 	// clusters that remain in the list, so wait for cluster0 explicitly, then let
 	// its namespace cache refresh so RemoveRemoteCluster reads the updated view.
-	s.EventuallyWithT(func(t *assert.CollectT) {
+	await.Require(context.Background(), s.T(), func(t *await.T) {
 		resp := s.describeNamespace(t, cluster0, ns, true)
 		require.ElementsMatch(t,
 			[]string{s.clusters[1].ClusterName(), s.clusters[2].ClusterName()},

--- a/tests/xdc/remove_remote_cluster_test.go
+++ b/tests/xdc/remove_remote_cluster_test.go
@@ -1,0 +1,127 @@
+package xdc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/tests/testcore"
+)
+
+type (
+	// RemoveRemoteClusterTestSuite exercises the namespace-reference guard that
+	// RemoveRemoteCluster runs before disconnecting a remote cluster (see
+	// service/frontend/cluster_removal_validation.go). It is an end-to-end
+	// regression suite for temporalio/temporal#10997, which fixed cluster removal
+	// over-blocking on stale/orphaned namespace records.
+	//
+	// It uses three clusters because the interesting case -- an orphaned namespace
+	// that references the cluster being removed but that the current cluster is no
+	// longer a member of -- can only be represented by a multi-cluster namespace
+	// listing two clusters, neither of which is the cluster running the removal.
+	RemoveRemoteClusterTestSuite struct {
+		xdcBaseSuite
+	}
+)
+
+func TestRemoveRemoteClusterTestSuite(t *testing.T) {
+	t.Parallel()
+	s := new(RemoveRemoteClusterTestSuite)
+	suite.Run(t, s)
+}
+
+func (s *RemoveRemoteClusterTestSuite) SetupSuite() {
+	if s.dynamicConfigOverrides == nil {
+		s.dynamicConfigOverrides = make(map[dynamicconfig.Key]any)
+	}
+	// Three clusters are required to reproduce the orphaned-namespace case: the
+	// orphan record must be a multi-cluster global namespace that lists two
+	// clusters, neither of which is the cluster running RemoveRemoteCluster.
+	s.clusterNames = []string{"cluster0", "cluster1", "cluster2"}
+	s.setupSuite()
+}
+
+func (s *RemoveRemoteClusterTestSuite) SetupTest() {
+	s.setupTest()
+}
+
+func (s *RemoveRemoteClusterTestSuite) TearDownSuite() {
+	s.tearDownSuite()
+}
+
+// TestRemoveRemoteCluster_BlockedByReferencingNamespace guards the still-correct
+// half of the validation: when a global namespace lists both the current cluster
+// and the cluster being removed, the current cluster is actively relying on that
+// replication link, so the removal must stay blocked.
+func (s *RemoveRemoteClusterTestSuite) TestRemoveRemoteCluster_BlockedByReferencingNamespace() {
+	ctx := testcore.NewContext()
+
+	cluster0 := s.clusters[0] // where RemoveRemoteCluster is invoked
+	cluster1 := s.clusters[1] // the cluster to be removed
+
+	// Global namespace active on cluster0 and replicated to cluster1. cluster0 is
+	// a member and depends on cluster1, so removing cluster1 must be rejected.
+	ns := s.createNamespace(true, []*testcore.TestCluster{cluster0, cluster1})
+
+	_, err := cluster0.AdminClient().RemoveRemoteCluster(ctx, &adminservice.RemoveRemoteClusterRequest{
+		ClusterName: cluster1.ClusterName(),
+	})
+	s.Error(err)
+	var failedPrecondition *serviceerror.FailedPrecondition
+	s.ErrorAs(err, &failedPrecondition)
+	s.Contains(err.Error(), "cannot remove cluster")
+	// The rejection must name the namespace that still binds the two clusters.
+	s.Contains(err.Error(), ns)
+}
+
+// TestRemoveRemoteCluster_OrphanedNamespaceDoesNotBlock is the direct regression
+// test for #10997. It reproduces the orphaned namespace record that caused the
+// over-blocking incident and asserts that removal now succeeds.
+//
+// Before #10997 this call returned a FailedPrecondition because the local
+// registry still listed the cluster being removed, even though the current
+// cluster no longer participated in that namespace.
+func (s *RemoveRemoteClusterTestSuite) TestRemoveRemoteCluster_OrphanedNamespaceDoesNotBlock() {
+	ctx := testcore.NewContext()
+
+	cluster0 := s.clusters[0] // where RemoveRemoteCluster is invoked
+	cluster2 := s.clusters[2] // the cluster to be removed
+
+	// Create a global namespace spanning all three clusters, active on cluster0.
+	ns := s.createNamespace(true, s.clusters)
+
+	// Re-home the namespace off cluster0, leaving behind the orphaned record that
+	// motivated the fix. A namespace's active cluster must remain in its cluster
+	// list, so cluster0 cannot be dropped while active: first fail the namespace
+	// over to cluster1, then shrink the cluster list to {cluster1, cluster2}. The
+	// shrink is replicated to cluster0 and applied to its local namespace record,
+	// but the record itself is never deleted -- so cluster0's registry now holds a
+	// multi-cluster namespace that references cluster2 while cluster0 itself is no
+	// longer a member. This mirrors an orphan left behind after a namespace
+	// migration re-homes a namespace onto other clusters.
+	s.failover(ns, 0, s.clusters[1].ClusterName(), 2)
+	s.updateNamespaceClusters(ns, 0, []*testcore.TestCluster{s.clusters[1], s.clusters[2]})
+
+	// Wait until cluster0 observes the orphaned record (itself dropped from the
+	// namespace's cluster list). updateNamespaceClusters only waits for the
+	// clusters that remain in the list, so wait for cluster0 explicitly, then let
+	// its namespace cache refresh so RemoveRemoteCluster reads the updated view.
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		resp := s.describeNamespace(t, cluster0, ns, true)
+		require.ElementsMatch(t,
+			[]string{s.clusters[1].ClusterName(), s.clusters[2].ClusterName()},
+			s.namespaceClusterNames(resp))
+	}, replicationWaitTime, replicationCheckInterval)
+	s.waitForNamespaceCacheRefresh()
+
+	// cluster0 is not a member of the orphaned namespace, so removing cluster2
+	// cannot sever any replication cluster0 relies on -> removal must succeed.
+	_, err := cluster0.AdminClient().RemoveRemoteCluster(ctx, &adminservice.RemoveRemoteClusterRequest{
+		ClusterName: cluster2.ClusterName(),
+	})
+	s.NoError(err)
+}


### PR DESCRIPTION
## What changed?

Adds an xdc regression suite for RemoveRemoteCluster over-blocking on stale/orphaned namespace records which is fixed in #10997.

The suite uses three clusters (the minimum needed to represent an orphan: a multi-cluster namespace listing two clusters, neither being the cluster running the removal) and covers:

- OrphanedNamespaceDoesNotBlock: a namespace is re-homed off cluster0 (fail over to cluster1, then shrink its cluster list to drop cluster0), leaving cluster0 with an orphan record that references cluster2 but that cluster0 is no longer a member of. Removing cluster2 from cluster0 must succeed. This fails against the pre-#10997 validation (verified by temporarily reverting the fix).
- BlockedByReferencingNamespace: a namespace listing both the current and the removed cluster still blocks removal.

Generalizes xdcBaseSuite.setupSuite to support N clusters via an optional clusterNames field; the default remains the two-cluster active/standby topology, so existing suites are unaffected.

## Why?

Adding a new functional test so overblocking on cluster removal edge cases could be surfaced earlier in the testing cycle.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)


