### PR TITLE
treat nil failures as retryable in SAA

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -612,14 +612,8 @@ func (a *Activity) HandleFailed(
 		a.emitHeartbeatMetrics(ctx, details)
 	}
 
-	appFailure := failure.GetApplicationFailureInfo()
-	// A nil failure is treated as retryable for parity with WFA (see service/history/workflow/retry.go:isRetryable).
-	isRetryable := failure == nil ||
-		(appFailure != nil &&
-			!appFailure.GetNonRetryable() &&
-			!slices.Contains(a.GetRetryPolicy().GetNonRetryableErrorTypes(), appFailure.GetType()))
-
-	retryState, err := a.tryReschedule(ctx, isRetryable, appFailure.GetNextRetryDelay().AsDuration(), failure)
+	nextRetryDelay := failure.GetApplicationFailureInfo().GetNextRetryDelay().AsDuration()
+	retryState, err := a.tryReschedule(ctx, a.isRetryableFailure(failure), nextRetryDelay, failure)
 	if err != nil {
 		return nil, err
 	}
@@ -639,6 +633,24 @@ func (a *Activity) HandleFailed(
 	}
 
 	return &historyservice.RespondActivityTaskFailedResponse{}, nil
+}
+
+// isRetryableFailure reports whether a worker-reported activity failure should be retried. A nil
+// (omitted) failure is retryable, matching workflow activities (see
+// service/history/workflow/retry.go:isRetryable). Any other failure is retryable only when it is an
+// application failure that neither marks itself non-retryable nor names an error type the retry
+// policy lists as non-retryable.
+func (a *Activity) isRetryableFailure(failure *failurepb.Failure) bool {
+	if failure == nil {
+		return true
+	}
+	appFailure := failure.GetApplicationFailureInfo()
+	if appFailure == nil {
+		return false
+	}
+	isMarkedNonRetryable := appFailure.GetNonRetryable()
+	isNonRetryableType := slices.Contains(a.GetRetryPolicy().GetNonRetryableErrorTypes(), appFailure.GetType())
+	return !isMarkedNonRetryable && !isNonRetryableType
 }
 
 // HandleCanceled updates the activity on activity canceled.

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -636,10 +636,8 @@ func (a *Activity) HandleFailed(
 }
 
 // isRetryableFailure reports whether a worker-reported activity failure should be retried. A nil
-// (omitted) failure is retryable, matching workflow activities (see
-// service/history/workflow/retry.go:isRetryable). Any other failure is retryable only when it is an
-// application failure that neither marks itself non-retryable nor names an error type the retry
-// policy lists as non-retryable.
+// failure is retryable. Only application failures are otherwise  retryable, unless the failure
+// marks itself non-retryable or its error type is listed in the retry policy's non-retryable types.
 func (a *Activity) isRetryableFailure(failure *failurepb.Failure) bool {
 	if failure == nil {
 		return true

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -613,9 +613,11 @@ func (a *Activity) HandleFailed(
 	}
 
 	appFailure := failure.GetApplicationFailureInfo()
-	isRetryable := appFailure != nil &&
-		!appFailure.GetNonRetryable() &&
-		!slices.Contains(a.GetRetryPolicy().GetNonRetryableErrorTypes(), appFailure.GetType())
+	// A nil failure is treated as retryable for parity with WFA (see service/history/workflow/retry.go:isRetryable).
+	isRetryable := failure == nil ||
+		(appFailure != nil &&
+			!appFailure.GetNonRetryable() &&
+			!slices.Contains(a.GetRetryPolicy().GetNonRetryableErrorTypes(), appFailure.GetType()))
 
 	retryState, err := a.tryReschedule(ctx, isRetryable, appFailure.GetNextRetryDelay().AsDuration(), failure)
 	if err != nil {

--- a/chasm/lib/activity/model/vocabulary.go
+++ b/chasm/lib/activity/model/vocabulary.go
@@ -40,9 +40,15 @@ const (
 type Event struct {
 	Type EventType
 
-	Retryable           bool // RespondFailed: the failure is retryable. Whether it actually retries also depends on the retry policy.
-	KeepPaused          bool // Reset: a paused activity stays paused across the reset.
-	HasHeartbeatDetails bool // RespondFailed: attach last_heartbeat_details, to be stored as the activity's heartbeat progress.
+	KeepPaused          bool     // Reset: a paused activity stays paused across the reset.
+	HasHeartbeatDetails bool     // RespondFailed: attach last_heartbeat_details, to be stored as the activity's heartbeat progress.
+	Failure             *Failure // RespondFailed: the failure to send, or nil to respond with no failure at all (as a worker may). A nil failure is retryable.
+}
+
+// Failure specifies the failure a RespondFailed event sends. Its zero value is the default failure
+// used now; a nil *Failure on the event means the worker responds with no failure at all.
+type Failure struct {
+	Retryable bool // whether the failure is retryable. Whether it actually retries also depends on the retry policy.
 }
 
 // Canonical Event values for the variants frequently used in traces
@@ -51,8 +57,9 @@ var (
 	Heartbeat              = Event{Type: HeartbeatType}
 	Complete               = Event{Type: RespondCompletedType}
 	CompleteByID           = Event{Type: RespondCompletedByIDType}
-	FailRetryably          = Event{Type: RespondFailedType, Retryable: true}
-	FailNonRetryably       = Event{Type: RespondFailedType, Retryable: false}
+	FailRetryably          = Event{Type: RespondFailedType, Failure: &Failure{Retryable: true}}
+	FailNonRetryably       = Event{Type: RespondFailedType, Failure: &Failure{Retryable: false}}
+	FailWithoutFailure     = Event{Type: RespondFailedType}
 	RespondCanceled        = Event{Type: RespondCanceledType}
 	RequestCancel          = Event{Type: RequestCancelType}
 	Terminate              = Event{Type: TerminateType}
@@ -117,7 +124,10 @@ func (t EventType) String() string {
 func (e Event) String() string {
 	switch e.Type {
 	case RespondFailedType:
-		return fmt.Sprintf("%s[retryable=%v,heartbeatDetails=%v]", e.Type.String(), e.Retryable, e.HasHeartbeatDetails)
+		if e.Failure == nil {
+			return fmt.Sprintf("%s[omitted]", e.Type.String())
+		}
+		return fmt.Sprintf("%s[retryable=%v]", e.Type.String(), e.Failure.Retryable)
 	case ResetType:
 		return fmt.Sprintf("%s[keepPaused=%v]", e.Type.String(), e.KeepPaused)
 	default:

--- a/chasm/lib/activity/model/vocabulary.go
+++ b/chasm/lib/activity/model/vocabulary.go
@@ -45,8 +45,7 @@ type Event struct {
 	Failure             *Failure // RespondFailed: the failure to send, or nil to respond with no failure at all (as a worker may). A nil failure is retryable.
 }
 
-// Failure specifies the failure a RespondFailed event sends. Its zero value is the default failure
-// used now; a nil *Failure on the event means the worker responds with no failure at all.
+// Failure specifies the failure a RespondFailed event sends.
 type Failure struct {
 	Retryable bool // whether the failure is retryable. Whether it actually retries also depends on the retry policy.
 }
@@ -125,9 +124,9 @@ func (e Event) String() string {
 	switch e.Type {
 	case RespondFailedType:
 		if e.Failure == nil {
-			return fmt.Sprintf("%s[omitted]", e.Type.String())
+			return fmt.Sprintf("%s[failureOmitted,heartbeatDetails=%v]", e.Type.String(), e.HasHeartbeatDetails)
 		}
-		return fmt.Sprintf("%s[retryable=%v]", e.Type.String(), e.Failure.Retryable)
+		return fmt.Sprintf("%s[retryable=%v,heartbeatDetails=%v]", e.Type.String(), e.Failure.Retryable, e.HasHeartbeatDetails)
 	case ResetType:
 		return fmt.Sprintf("%s[keepPaused=%v]", e.Type.String(), e.KeepPaused)
 	default:

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -259,12 +259,6 @@ var TransitionFailed = chasm.NewTransition(
 			// simply has no result yet, and polls forever. (Workflow activities tolerate a nil failure
 			// because the SDK wraps the failed history event in an ActivityError; a standalone activity
 			// returns the raw outcome with no such wrapper.)
-			// A worker may respond failed without a Failure. Synthesize a generic terminal failure so
-			// the closed activity still exposes a consumable outcome; otherwise PollActivityExecution
-			// returns a nil outcome and a client cannot tell the closed activity apart from one that
-			// simply has no result yet, and polls forever. (Workflow activities tolerate a nil failure
-			// because the SDK wraps the failed history event in an ActivityError; a standalone activity
-			// returns the raw outcome with no such wrapper.)
 			failure := req.GetFailure()
 			if failure == nil {
 				failure = &failurepb.Failure{Message: "activity task failed without failure details"}

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -253,11 +253,28 @@ var TransitionFailed = chasm.NewTransition(
 			attempt := a.LastAttempt.Get(ctx)
 			attempt.LastWorkerIdentity = req.GetIdentity()
 
-			if err := a.recordFailedAttempt(ctx, 0, activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED, req.GetFailure(), ctx.Now(a), true); err != nil {
+			// A worker may respond failed without a Failure. Synthesize a generic terminal failure so
+			// the closed activity still exposes a consumable outcome; otherwise PollActivityExecution
+			// returns a nil outcome and a client cannot tell the closed activity apart from one that
+			// simply has no result yet, and polls forever. (Workflow activities tolerate a nil failure
+			// because the SDK wraps the failed history event in an ActivityError; a standalone activity
+			// returns the raw outcome with no such wrapper.)
+			// A worker may respond failed without a Failure. Synthesize a generic terminal failure so
+			// the closed activity still exposes a consumable outcome; otherwise PollActivityExecution
+			// returns a nil outcome and a client cannot tell the closed activity apart from one that
+			// simply has no result yet, and polls forever. (Workflow activities tolerate a nil failure
+			// because the SDK wraps the failed history event in an ActivityError; a standalone activity
+			// returns the raw outcome with no such wrapper.)
+			failure := req.GetFailure()
+			if failure == nil {
+				failure = &failurepb.Failure{Message: "activity task failed without failure details"}
+			}
+
+			if err := a.recordFailedAttempt(ctx, 0, activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED, failure, ctx.Now(a), true); err != nil {
 				return err
 			}
 
-			a.emitOnFailedMetrics(ctx, event.baseHandler, event.enrichedHandler, req.GetFailure())
+			a.emitOnFailedMetrics(ctx, event.baseHandler, event.enrichedHandler, failure)
 
 			return nil
 		})

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -268,7 +268,7 @@ var TransitionFailed = chasm.NewTransition(
 				return err
 			}
 
-			a.emitOnFailedMetrics(ctx, event.baseHandler, event.enrichedHandler, failure)
+			a.emitOnFailedMetrics(ctx, event.baseHandler, event.enrichedHandler, req.GetFailure())
 
 			return nil
 		})

--- a/tests/activity_driver.go
+++ b/tests/activity_driver.go
@@ -221,6 +221,15 @@ func isDispatchDelayEvent(et model.EventType) bool {
 	return et == model.StartDelayElapsesType || et == model.BackoffElapsesType
 }
 
+// respondFailedFailure is the Failure a RespondFailed event carries, or nil when the event omits it
+// (modeling a worker that calls RespondActivityTaskFailed without a Failure).
+func respondFailedFailure(e model.Event, nextRetryDelay time.Duration) *failurepb.Failure {
+	if e.Failure == nil {
+		return nil
+	}
+	return activityFailure(e.Failure.Retryable, nextRetryDelay)
+}
+
 func activityFailure(retryable bool, nextRetryDelay time.Duration) *failurepb.Failure {
 	info := &failurepb.ApplicationFailureInfo{Type: "TestFailure", NonRetryable: !retryable}
 	if nextRetryDelay > 0 {

--- a/tests/activity_metrics_parity_test.go
+++ b/tests/activity_metrics_parity_test.go
@@ -72,7 +72,7 @@ func (s *activityParityTestSuite) TestMetrics() {
 		{name: "TerminalTimeout", trace: []model.Event{model.Poll, model.StartToCloseElapses}, cfg: activityConfig{MaxAttempts: 1, StartToClose: activityShortTimeout}, anchor: metrics.ActivityTimeout.Name()},
 		{name: "RetryableTimeout", trace: []model.Event{model.Poll, model.StartToCloseElapses}, cfg: activityConfig{MaxAttempts: 2, StartToClose: activityShortTimeout}, anchor: metrics.ActivityTaskTimeout.Name()},
 		{name: "RetryableTaskFailure", trace: []model.Event{model.Poll, model.FailRetryably}, cfg: activityConfig{MaxAttempts: 2}},
-		{name: "RetryableTaskFailureWithHeartbeatDetails", trace: []model.Event{model.Poll, {Type: model.RespondFailedType, Retryable: true, HasHeartbeatDetails: true}}, cfg: activityConfig{MaxAttempts: 2}},
+		{name: "RetryableTaskFailureWithHeartbeatDetails", trace: []model.Event{model.Poll, {Type: model.RespondFailedType, Failure: &model.Failure{Retryable: true}, HasHeartbeatDetails: true}}, cfg: activityConfig{MaxAttempts: 2}},
 		{name: "Heartbeat", trace: []model.Event{model.Poll, model.Heartbeat}, cfg: activityConfig{MaxAttempts: 1}},
 		{name: "Pause", trace: []model.Event{model.Poll, model.Pause}, cfg: activityConfig{MaxAttempts: 1}},
 		{name: "Unpause", trace: []model.Event{model.Poll, model.Pause, model.Unpause}, cfg: activityConfig{MaxAttempts: 1}},

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -422,7 +422,7 @@ func (s *activityParityTestSuite) TestLastHeartbeatDetailsPersistedOnAttemptFail
 	env := newActivityParityEnv(s.T())
 	cfg := activityConfig{MaxAttempts: 2}
 
-	trace := []model.Event{model.Poll, {Type: model.RespondFailedType, Retryable: true, HasHeartbeatDetails: true}}
+	trace := []model.Event{model.Poll, {Type: model.RespondFailedType, Failure: &model.Failure{Retryable: true}, HasHeartbeatDetails: true}}
 	expected := activityMarshalPayloads(activityHeartbeatDetails)
 	s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
 		t := s.T()
@@ -437,7 +437,7 @@ func (s *activityParityTestSuite) TestLastHeartbeatDetailsPersistedOnAttemptFail
 
 		// For SAA we additionally confirm that it's persisted even if the failure is terminal. WFA
 		// drops the pending activity from MS at this point.
-		terminal := []model.Event{model.Poll, {Type: model.RespondFailedType, Retryable: false, HasHeartbeatDetails: true}}
+		terminal := []model.Event{model.Poll, {Type: model.RespondFailedType, Failure: &model.Failure{Retryable: false}, HasHeartbeatDetails: true}}
 		require.Equal(t, expected,
 			d.driveTrace(t, terminal).activityInfo(t).LastHeartbeatDetails)
 	})

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -215,7 +215,7 @@ func (s *activityParityTestSuite) TestNilFailureExhaustedClosesWithConsumableOut
 	trace := []model.Event{model.Poll, model.FailWithoutFailure}
 
 	h := newSAADriver(t, env, cfg).driveTrace(t, trace)
-	require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_FAILED, h.terminalStatus(t))
+	require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_FAILED, h.terminalOutcome(t).status)
 	require.NotNil(t, h.describe(t).GetOutcome().GetFailure(),
 		"a standalone activity that failed without worker-supplied details must still expose a terminal failure")
 }

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -179,6 +179,47 @@ func (s *activityParityTestSuite) TestRetriedTimeoutDoesNotChainPriorFailure() {
 	}
 }
 
+// A RespondActivityTaskFailed with an omitted Failure is retryable, for parity with workflow
+// activities: rather than closing the activity with no consumable outcome, the server backs it off
+// for another attempt.
+func (s *activityParityTestSuite) TestNilFailureIsRetryable() {
+	env := newActivityParityEnv(s.T())
+	cfg := activityConfig{MaxAttempts: 3, RetryInterval: activityLongDuration}
+	trace := []model.Event{model.Poll, model.FailWithoutFailure}
+	want := activityInfo{
+		RunState:                   enumspb.PENDING_ACTIVITY_STATE_SCHEDULED,
+		Attempt:                    2,
+		CurrentRetryInterval:       activityLongDuration,
+		NextAttemptScheduleTimeSet: true,
+	}
+
+	s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
+		t := s.T()
+		require.Equal(t, want, newWFADriver(t, env, cfg).driveTrace(t, trace).activityInfo(t))
+	})
+	s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
+		t := s.T()
+		require.Equal(t, want, newSAADriver(t, env, cfg).driveTrace(t, trace).activityInfo(t))
+	})
+}
+
+// A standalone activity that exhausts its retries after failing without a Failure must still close
+// with a consumable terminal failure. Otherwise PollActivityExecution returns a nil outcome and a
+// client cannot tell the closed activity apart from one that simply has no result yet, so it polls
+// forever. Workflow activities have no equivalent gap because the SDK surfaces an ActivityError even
+// for a nil cause, so this is a standalone-only assertion.
+func (s *activityParityTestSuite) TestNilFailureExhaustedClosesWithConsumableOutcome() {
+	env := newActivityParityEnv(s.T())
+	t := s.T()
+	cfg := activityConfig{MaxAttempts: 1}
+	trace := []model.Event{model.Poll, model.FailWithoutFailure}
+
+	h := newSAADriver(t, env, cfg).driveTrace(t, trace)
+	require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_FAILED, h.terminalStatus(t))
+	require.NotNil(t, h.describe(t).GetOutcome().GetFailure(),
+		"a standalone activity that failed without worker-supplied details must still expose a terminal failure")
+}
+
 // current_retry_interval and next_attempt_schedule_time are reported while a retry is backing off
 // (before it is dispatched to Matching), and for next_attempt_schedule_time also during start delay
 // (SAA only). Once the attempt is dispatched, or while the activity is paused, both are nil.

--- a/tests/activity_standalone_driver.go
+++ b/tests/activity_standalone_driver.go
@@ -238,9 +238,13 @@ func (a *saaHandle) rpc(_ testing.TB, e model.Event) error {
 		})
 		return err
 	case model.RespondFailedType:
-		_, err := fc.RespondActivityTaskFailed(a.d.ctx, &workflowservice.RespondActivityTaskFailedRequest{
+		req := &workflowservice.RespondActivityTaskFailedRequest{
 			Namespace: ns, TaskToken: a.token, Identity: a.d.env.Tv().WorkerIdentity(), Failure: respondFailedFailure(e, a.cfg.NextRetryDelay),
-		})
+		}
+		if e.HasHeartbeatDetails {
+			req.LastHeartbeatDetails = activityHeartbeatDetails
+		}
+		_, err := fc.RespondActivityTaskFailed(a.d.ctx, req)
 		return err
 	case model.RespondCanceledType:
 		_, err := fc.RespondActivityTaskCanceled(a.d.ctx, &workflowservice.RespondActivityTaskCanceledRequest{

--- a/tests/activity_standalone_driver.go
+++ b/tests/activity_standalone_driver.go
@@ -238,13 +238,9 @@ func (a *saaHandle) rpc(_ testing.TB, e model.Event) error {
 		})
 		return err
 	case model.RespondFailedType:
-		req := &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace: ns, TaskToken: a.token, Identity: a.d.env.Tv().WorkerIdentity(), Failure: activityFailure(e.Retryable, a.cfg.NextRetryDelay),
-		}
-		if e.HasHeartbeatDetails {
-			req.LastHeartbeatDetails = activityHeartbeatDetails
-		}
-		_, err := fc.RespondActivityTaskFailed(a.d.ctx, req)
+		_, err := fc.RespondActivityTaskFailed(a.d.ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: ns, TaskToken: a.token, Identity: a.d.env.Tv().WorkerIdentity(), Failure: respondFailedFailure(e, a.cfg.NextRetryDelay),
+		})
 		return err
 	case model.RespondCanceledType:
 		_, err := fc.RespondActivityTaskCanceled(a.d.ctx, &workflowservice.RespondActivityTaskCanceledRequest{

--- a/tests/activity_workflow_driver.go
+++ b/tests/activity_workflow_driver.go
@@ -283,14 +283,12 @@ func (a *wfaHandle) rpc(t testing.TB, e model.Event) error {
 		return err
 	case model.RespondFailedType:
 		req := &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace: ns, TaskToken: a.token, Identity: a.d.env.Tv().WorkerIdentity(), Failure: activityFailure(e.Failure.Retryable, a.cfg.NextRetryDelay),
+			Namespace: ns, TaskToken: a.token, Identity: a.d.env.Tv().WorkerIdentity(), Failure: respondFailedFailure(e, a.cfg.NextRetryDelay),
 		}
 		if e.HasHeartbeatDetails {
 			req.LastHeartbeatDetails = activityHeartbeatDetails
 		}
-		_, err := fc.RespondActivityTaskFailed(a.d.ctx, &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace: ns, TaskToken: a.token, Identity: a.d.env.Tv().WorkerIdentity(), Failure: respondFailedFailure(e, a.cfg.NextRetryDelay),
-		})
+		_, err := fc.RespondActivityTaskFailed(a.d.ctx, req)
 		return err
 	case model.RespondCanceledType:
 		_, err := fc.RespondActivityTaskCanceled(a.d.ctx, &workflowservice.RespondActivityTaskCanceledRequest{

--- a/tests/activity_workflow_driver.go
+++ b/tests/activity_workflow_driver.go
@@ -283,12 +283,14 @@ func (a *wfaHandle) rpc(t testing.TB, e model.Event) error {
 		return err
 	case model.RespondFailedType:
 		req := &workflowservice.RespondActivityTaskFailedRequest{
-			Namespace: ns, TaskToken: a.token, Identity: a.d.env.Tv().WorkerIdentity(), Failure: activityFailure(e.Retryable, a.cfg.NextRetryDelay),
+			Namespace: ns, TaskToken: a.token, Identity: a.d.env.Tv().WorkerIdentity(), Failure: activityFailure(e.Failure.Retryable, a.cfg.NextRetryDelay),
 		}
 		if e.HasHeartbeatDetails {
 			req.LastHeartbeatDetails = activityHeartbeatDetails
 		}
-		_, err := fc.RespondActivityTaskFailed(a.d.ctx, req)
+		_, err := fc.RespondActivityTaskFailed(a.d.ctx, &workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: ns, TaskToken: a.token, Identity: a.d.env.Tv().WorkerIdentity(), Failure: respondFailedFailure(e, a.cfg.NextRetryDelay),
+		})
 		return err
 	case model.RespondCanceledType:
 		_, err := fc.RespondActivityTaskCanceled(a.d.ctx, &workflowservice.RespondActivityTaskCanceledRequest{


### PR DESCRIPTION
## What changed?

`Activity.HandleFailed` now treats a `RespondActivityTaskFailed` request with an omitted `Failure` as retryable, matching WFA behavior. Previously a nil failure was treated as non-retryable and the SAA closed as `FAILED`.

## Why?

This achieves parity for SAA with workflow activities.

## How did you test it?

- [x] covered by existing tests
- [x] added new functional test(s)

## Potential risks
This is a behavioral change, but was a bug in the original implementation