### PR TITLE
Align standalone activity failure retries with workflow activities

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -634,7 +634,12 @@ func (a *Activity) HandleFailed(
 	}
 
 	nextRetryDelay := failure.GetApplicationFailureInfo().GetNextRetryDelay().AsDuration()
-	retryState, err := a.tryReschedule(ctx, a.isRetryableFailure(failure), nextRetryDelay, failure)
+	retryState, err := a.tryReschedule(
+		ctx,
+		retrypolicy.IsRetryableFailure(failure, a.GetRetryPolicy().GetNonRetryableErrorTypes()),
+		nextRetryDelay,
+		failure,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -654,25 +659,6 @@ func (a *Activity) HandleFailed(
 	}
 
 	return &historyservice.RespondActivityTaskFailedResponse{}, nil
-}
-
-// isRetryableFailure reports whether a worker-reported activity failure should be retried. A nil
-// failure is retryable. Only application failures are otherwise  retryable, unless the failure
-// marks itself non-retryable or its error type is listed in the retry policy's non-retryable types.
-func (a *Activity) isRetryableFailure(failure *failurepb.Failure) bool {
-	if failure == nil {
-		return true
-	}
-	if serverFailure := failure.GetServerFailureInfo(); serverFailure != nil {
-		return !serverFailure.GetNonRetryable()
-	}
-	appFailure := failure.GetApplicationFailureInfo()
-	if appFailure == nil {
-		return false
-	}
-	isMarkedNonRetryable := appFailure.GetNonRetryable()
-	isNonRetryableType := slices.Contains(a.GetRetryPolicy().GetNonRetryableErrorTypes(), appFailure.GetType())
-	return !isMarkedNonRetryable && !isNonRetryableType
 }
 
 // HandleCanceled updates the activity on activity canceled.

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -663,6 +663,9 @@ func (a *Activity) isRetryableFailure(failure *failurepb.Failure) bool {
 	if failure == nil {
 		return true
 	}
+	if serverFailure := failure.GetServerFailureInfo(); serverFailure != nil {
+		return !serverFailure.GetNonRetryable()
+	}
 	appFailure := failure.GetApplicationFailureInfo()
 	if appFailure == nil {
 		return false

--- a/chasm/lib/activity/model/vocabulary.go
+++ b/chasm/lib/activity/model/vocabulary.go
@@ -42,7 +42,7 @@ type Event struct {
 	Type EventType
 
 	KeepPaused          bool     // Reset: a paused activity stays paused across the reset.
-	HasHeartbeatDetails bool     // RespondFailed: attach last_heartbeat_details, to be stored as the activity's heartbeat progress.
+	HasHeartbeatDetails bool     // Failure response: attach last_heartbeat_details, to be stored as the activity's heartbeat progress.
 	Failure             *Failure // RespondFailed: the failure to send, or nil to respond with no failure at all (as a worker may). A nil failure is retryable.
 }
 

--- a/chasm/lib/activity/model/vocabulary.go
+++ b/chasm/lib/activity/model/vocabulary.go
@@ -48,9 +48,22 @@ type Event struct {
 
 // Failure specifies the failure a RespondFailed event sends.
 type Failure struct {
-	Retryable     bool // whether the failure is retryable. Whether it actually retries also depends on the retry policy.
-	ServerFailure bool // report a ServerFailure rather than the default ApplicationFailure.
+	Type      FailureType
+	Retryable bool // controls the non-retryable flag for application and server failures.
 }
+
+// FailureType identifies the kind of failure a RespondFailed event reports.
+type FailureType int
+
+const (
+	ApplicationFailureType FailureType = iota
+	ServerFailureType
+	StartToCloseTimeoutFailureType
+	HeartbeatTimeoutFailureType
+	ScheduleToStartTimeoutFailureType
+	ScheduleToCloseTimeoutFailureType
+	UnknownFailureType
+)
 
 // Canonical Event values for the variants frequently used in traces
 var (
@@ -64,21 +77,26 @@ var (
 	// FailByIDRetryablyWithServerFailure reports a retryable ServerFailure through the by-ID API. Unlike
 	// the by-token API, the by-ID API accepts a non-application failure, so only this variant can carry a
 	// ServerFailure to the handler.
-	FailByIDRetryablyWithServerFailure = Event{Type: RespondFailedByIDType, Failure: &Failure{Retryable: true, ServerFailure: true}}
-	RespondCanceled                    = Event{Type: RespondCanceledType}
-	RequestCancel                      = Event{Type: RequestCancelType}
-	Terminate                          = Event{Type: TerminateType}
-	Pause                              = Event{Type: PauseType}
-	ResetKeepPaused                    = Event{Type: ResetType, KeepPaused: true}
-	Unpause                            = Event{Type: UnpauseType}
-	Reset                              = Event{Type: ResetType}
-	UpdateOptions                      = Event{Type: UpdateOptionsType}
-	StartToCloseElapses                = Event{Type: StartToCloseElapsesType}
-	ScheduleToCloseElapses             = Event{Type: ScheduleToCloseElapsesType}
-	ScheduleToStartElapses             = Event{Type: ScheduleToStartElapsesType}
-	HeartbeatElapses                   = Event{Type: HeartbeatElapsesType}
-	StartDelayElapses                  = Event{Type: StartDelayElapsesType}
-	BackoffElapses                     = Event{Type: BackoffElapsesType}
+	FailByIDRetryablyWithServerFailure              = Event{Type: RespondFailedByIDType, Failure: &Failure{Type: ServerFailureType, Retryable: true}}
+	FailByIDRetryablyWithStartToCloseTimeoutFailure = Event{Type: RespondFailedByIDType, Failure: &Failure{Type: StartToCloseTimeoutFailureType}}
+	FailByIDRetryablyWithHeartbeatTimeoutFailure    = Event{Type: RespondFailedByIDType, Failure: &Failure{Type: HeartbeatTimeoutFailureType}}
+	FailByIDWithScheduleToStartTimeoutFailure       = Event{Type: RespondFailedByIDType, Failure: &Failure{Type: ScheduleToStartTimeoutFailureType}}
+	FailByIDWithScheduleToCloseTimeoutFailure       = Event{Type: RespondFailedByIDType, Failure: &Failure{Type: ScheduleToCloseTimeoutFailureType}}
+	FailByIDRetryablyWithUnknownFailure             = Event{Type: RespondFailedByIDType, Failure: &Failure{Type: UnknownFailureType}}
+	RespondCanceled                                 = Event{Type: RespondCanceledType}
+	RequestCancel                                   = Event{Type: RequestCancelType}
+	Terminate                                       = Event{Type: TerminateType}
+	Pause                                           = Event{Type: PauseType}
+	ResetKeepPaused                                 = Event{Type: ResetType, KeepPaused: true}
+	Unpause                                         = Event{Type: UnpauseType}
+	Reset                                           = Event{Type: ResetType}
+	UpdateOptions                                   = Event{Type: UpdateOptionsType}
+	StartToCloseElapses                             = Event{Type: StartToCloseElapsesType}
+	ScheduleToCloseElapses                          = Event{Type: ScheduleToCloseElapsesType}
+	ScheduleToStartElapses                          = Event{Type: ScheduleToStartElapsesType}
+	HeartbeatElapses                                = Event{Type: HeartbeatElapsesType}
+	StartDelayElapses                               = Event{Type: StartDelayElapsesType}
+	BackoffElapses                                  = Event{Type: BackoffElapsesType}
 )
 
 // String is a label for an event type.
@@ -134,7 +152,7 @@ func (e Event) String() string {
 		if e.Failure == nil {
 			return fmt.Sprintf("%s[failureOmitted,heartbeatDetails=%v]", e.Type.String(), e.HasHeartbeatDetails)
 		}
-		return fmt.Sprintf("%s[retryable=%v,heartbeatDetails=%v,serverFailure=%v]", e.Type.String(), e.Failure.Retryable, e.HasHeartbeatDetails, e.Failure.ServerFailure)
+		return fmt.Sprintf("%s[retryable=%v,heartbeatDetails=%v,failureType=%d]", e.Type.String(), e.Failure.Retryable, e.HasHeartbeatDetails, e.Failure.Type)
 	case ResetType:
 		return fmt.Sprintf("%s[keepPaused=%v]", e.Type.String(), e.KeepPaused)
 	default:

--- a/chasm/lib/activity/model/vocabulary.go
+++ b/chasm/lib/activity/model/vocabulary.go
@@ -15,6 +15,7 @@ const (
 	RespondCompletedType
 	RespondCompletedByIDType
 	RespondFailedType
+	RespondFailedByIDType
 	RespondCanceledType
 	RequestCancelType
 	TerminateType
@@ -47,32 +48,37 @@ type Event struct {
 
 // Failure specifies the failure a RespondFailed event sends.
 type Failure struct {
-	Retryable bool // whether the failure is retryable. Whether it actually retries also depends on the retry policy.
+	Retryable     bool // whether the failure is retryable. Whether it actually retries also depends on the retry policy.
+	ServerFailure bool // report a ServerFailure rather than the default ApplicationFailure.
 }
 
 // Canonical Event values for the variants frequently used in traces
 var (
-	Poll                   = Event{Type: PollType}
-	Heartbeat              = Event{Type: HeartbeatType}
-	Complete               = Event{Type: RespondCompletedType}
-	CompleteByID           = Event{Type: RespondCompletedByIDType}
-	FailRetryably          = Event{Type: RespondFailedType, Failure: &Failure{Retryable: true}}
-	FailNonRetryably       = Event{Type: RespondFailedType, Failure: &Failure{Retryable: false}}
-	FailWithoutFailure     = Event{Type: RespondFailedType}
-	RespondCanceled        = Event{Type: RespondCanceledType}
-	RequestCancel          = Event{Type: RequestCancelType}
-	Terminate              = Event{Type: TerminateType}
-	Pause                  = Event{Type: PauseType}
-	ResetKeepPaused        = Event{Type: ResetType, KeepPaused: true}
-	Unpause                = Event{Type: UnpauseType}
-	Reset                  = Event{Type: ResetType}
-	UpdateOptions          = Event{Type: UpdateOptionsType}
-	StartToCloseElapses    = Event{Type: StartToCloseElapsesType}
-	ScheduleToCloseElapses = Event{Type: ScheduleToCloseElapsesType}
-	ScheduleToStartElapses = Event{Type: ScheduleToStartElapsesType}
-	HeartbeatElapses       = Event{Type: HeartbeatElapsesType}
-	StartDelayElapses      = Event{Type: StartDelayElapsesType}
-	BackoffElapses         = Event{Type: BackoffElapsesType}
+	Poll               = Event{Type: PollType}
+	Heartbeat          = Event{Type: HeartbeatType}
+	Complete           = Event{Type: RespondCompletedType}
+	CompleteByID       = Event{Type: RespondCompletedByIDType}
+	FailRetryably      = Event{Type: RespondFailedType, Failure: &Failure{Retryable: true}}
+	FailNonRetryably   = Event{Type: RespondFailedType, Failure: &Failure{Retryable: false}}
+	FailWithoutFailure = Event{Type: RespondFailedType}
+	// FailByIDRetryablyWithServerFailure reports a retryable ServerFailure through the by-ID API. Unlike
+	// the by-token API, the by-ID API accepts a non-application failure, so only this variant can carry a
+	// ServerFailure to the handler.
+	FailByIDRetryablyWithServerFailure = Event{Type: RespondFailedByIDType, Failure: &Failure{Retryable: true, ServerFailure: true}}
+	RespondCanceled                    = Event{Type: RespondCanceledType}
+	RequestCancel                      = Event{Type: RequestCancelType}
+	Terminate                          = Event{Type: TerminateType}
+	Pause                              = Event{Type: PauseType}
+	ResetKeepPaused                    = Event{Type: ResetType, KeepPaused: true}
+	Unpause                            = Event{Type: UnpauseType}
+	Reset                              = Event{Type: ResetType}
+	UpdateOptions                      = Event{Type: UpdateOptionsType}
+	StartToCloseElapses                = Event{Type: StartToCloseElapsesType}
+	ScheduleToCloseElapses             = Event{Type: ScheduleToCloseElapsesType}
+	ScheduleToStartElapses             = Event{Type: ScheduleToStartElapsesType}
+	HeartbeatElapses                   = Event{Type: HeartbeatElapsesType}
+	StartDelayElapses                  = Event{Type: StartDelayElapsesType}
+	BackoffElapses                     = Event{Type: BackoffElapsesType}
 )
 
 // String is a label for an event type.
@@ -88,6 +94,8 @@ func (t EventType) String() string {
 		return "RespondCompletedByID"
 	case RespondFailedType:
 		return "RespondFailed"
+	case RespondFailedByIDType:
+		return "RespondFailedByID"
 	case RespondCanceledType:
 		return "RespondCanceled"
 	case RequestCancelType:
@@ -122,11 +130,11 @@ func (t EventType) String() string {
 // String is a label for an event; it includes flags that affect its outcome.
 func (e Event) String() string {
 	switch e.Type {
-	case RespondFailedType:
+	case RespondFailedType, RespondFailedByIDType:
 		if e.Failure == nil {
 			return fmt.Sprintf("%s[failureOmitted,heartbeatDetails=%v]", e.Type.String(), e.HasHeartbeatDetails)
 		}
-		return fmt.Sprintf("%s[retryable=%v,heartbeatDetails=%v]", e.Type.String(), e.Failure.Retryable, e.HasHeartbeatDetails)
+		return fmt.Sprintf("%s[retryable=%v,heartbeatDetails=%v,serverFailure=%v]", e.Type.String(), e.Failure.Retryable, e.HasHeartbeatDetails, e.Failure.ServerFailure)
 	case ResetType:
 		return fmt.Sprintf("%s[keepPaused=%v]", e.Type.String(), e.KeepPaused)
 	default:

--- a/chasm/lib/activity/model/vocabulary.go
+++ b/chasm/lib/activity/model/vocabulary.go
@@ -152,7 +152,10 @@ func (e Event) String() string {
 		if e.Failure == nil {
 			return fmt.Sprintf("%s[failureOmitted,heartbeatDetails=%v]", e.Type.String(), e.HasHeartbeatDetails)
 		}
-		return fmt.Sprintf("%s[retryable=%v,heartbeatDetails=%v,failureType=%d]", e.Type.String(), e.Failure.Retryable, e.HasHeartbeatDetails, e.Failure.Type)
+		if e.Failure.Type == ApplicationFailureType || e.Failure.Type == ServerFailureType {
+			return fmt.Sprintf("%s[retryable=%v,heartbeatDetails=%v,failureType=%d]", e.Type.String(), e.Failure.Retryable, e.HasHeartbeatDetails, e.Failure.Type)
+		}
+		return fmt.Sprintf("%s[heartbeatDetails=%v,failureType=%d]", e.Type.String(), e.HasHeartbeatDetails, e.Failure.Type)
 	case ResetType:
 		return fmt.Sprintf("%s[keepPaused=%v]", e.Type.String(), e.KeepPaused)
 	default:

--- a/common/retrypolicy/retry_policy.go
+++ b/common/retrypolicy/retry_policy.go
@@ -21,7 +21,9 @@ const (
 	TimeoutFailureTypePrefix = "TemporalTimeout:"
 )
 
-// IsRetryableFailure reports whether a failure permits a retry under the given non-retryable error types.
+// IsRetryableFailure reports whether a failure permits a retry under the given non-retryable error
+// types. Canceled, terminated, and schedule-to-start or schedule-to-close timeout failures are not
+// retryable. Nil, wrapper, and unrecognized failures are retryable by default.
 func IsRetryableFailure(failure *failurepb.Failure, nonRetryableTypes []string) bool {
 	if failure == nil {
 		return true

--- a/common/retrypolicy/retry_policy.go
+++ b/common/retrypolicy/retry_policy.go
@@ -1,11 +1,13 @@
 package retrypolicy
 
 import (
+	"slices"
 	"strings"
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -18,6 +20,46 @@ const (
 	// e.g. "TemporalTimeout:StartToClose" or "TemporalTimeout:Heartbeat"
 	TimeoutFailureTypePrefix = "TemporalTimeout:"
 )
+
+// IsRetryableFailure reports whether a failure permits a retry under the given non-retryable error types.
+func IsRetryableFailure(failure *failurepb.Failure, nonRetryableTypes []string) bool {
+	if failure == nil {
+		return true
+	}
+
+	if failure.GetTerminatedFailureInfo() != nil || failure.GetCanceledFailureInfo() != nil {
+		return false
+	}
+
+	if failure.GetTimeoutFailureInfo() != nil {
+		timeoutType := failure.GetTimeoutFailureInfo().GetTimeoutType()
+		if timeoutType == enumspb.TIMEOUT_TYPE_START_TO_CLOSE ||
+			timeoutType == enumspb.TIMEOUT_TYPE_HEARTBEAT {
+			return !slices.Contains(
+				nonRetryableTypes,
+				TimeoutFailureTypePrefix+timeoutType.String(),
+			)
+		}
+
+		return false
+	}
+
+	if failure.GetServerFailureInfo() != nil {
+		return !failure.GetServerFailureInfo().GetNonRetryable()
+	}
+
+	if failure.GetApplicationFailureInfo() != nil {
+		if failure.GetApplicationFailureInfo().GetNonRetryable() {
+			return false
+		}
+
+		return !slices.Contains(
+			nonRetryableTypes,
+			failure.GetApplicationFailureInfo().GetType(),
+		)
+	}
+	return true
+}
 
 // DefaultRetrySettings indicates what the "default" retry settings
 // are if it is not specified on an Activity or for any unset fields

--- a/common/retrypolicy/retry_policy_test.go
+++ b/common/retrypolicy/retry_policy_test.go
@@ -5,10 +5,213 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
+
+func TestIsRetryableFailure(t *testing.T) {
+	testCases := []struct {
+		name              string
+		failure           *failurepb.Failure
+		nonRetryableTypes []string
+		retryable         bool
+	}{
+		{
+			name:      "nil failure",
+			retryable: true,
+		},
+		{
+			name: "terminated failure",
+			failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_TerminatedFailureInfo{TerminatedFailureInfo: &failurepb.TerminatedFailureInfo{}},
+			},
+		},
+		{
+			name: "canceled failure",
+			failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_CanceledFailureInfo{CanceledFailureInfo: &failurepb.CanceledFailureInfo{}},
+			},
+		},
+		{
+			name: "unspecified timeout",
+			failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
+					TimeoutType: enumspb.TIMEOUT_TYPE_UNSPECIFIED,
+				}},
+			},
+		},
+		{
+			name: "start-to-close timeout",
+			failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
+					TimeoutType: enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
+				}},
+			},
+			retryable: true,
+		},
+		{
+			name: "start-to-close timeout excluded",
+			failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
+					TimeoutType: enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
+				}},
+			},
+			nonRetryableTypes: []string{TimeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_START_TO_CLOSE.String()},
+		},
+		{
+			name: "schedule-to-start timeout",
+			failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
+					TimeoutType: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START,
+				}},
+			},
+		},
+		{
+			name: "schedule-to-start timeout excluded",
+			failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
+					TimeoutType: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START,
+				}},
+			},
+			nonRetryableTypes: []string{TimeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START.String()},
+		},
+		{
+			name: "schedule-to-close timeout",
+			failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
+					TimeoutType: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+				}},
+			},
+		},
+		{
+			name: "schedule-to-close timeout excluded",
+			failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
+					TimeoutType: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+				}},
+			},
+			nonRetryableTypes: []string{TimeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE.String()},
+		},
+		{
+			name: "heartbeat timeout",
+			failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
+					TimeoutType: enumspb.TIMEOUT_TYPE_HEARTBEAT,
+				}},
+			},
+			retryable: true,
+		},
+		{
+			name: "heartbeat timeout excluded",
+			failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
+					TimeoutType: enumspb.TIMEOUT_TYPE_HEARTBEAT,
+				}},
+			},
+			nonRetryableTypes: []string{TimeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_HEARTBEAT.String()},
+		},
+		{
+			name: "heartbeat timeout with different timeout excluded",
+			failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
+					TimeoutType: enumspb.TIMEOUT_TYPE_HEARTBEAT,
+				}},
+			},
+			nonRetryableTypes: []string{TimeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_START_TO_CLOSE.String()},
+			retryable:         true,
+		},
+		{
+			name: "heartbeat timeout with unknown timeout excluded",
+			failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
+					TimeoutType: enumspb.TIMEOUT_TYPE_HEARTBEAT,
+				}},
+			},
+			nonRetryableTypes: []string{TimeoutFailureTypePrefix + "unknown timeout type string"},
+			retryable:         true,
+		},
+		{
+			name: "retryable server failure",
+			failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_ServerFailureInfo{ServerFailureInfo: &failurepb.ServerFailureInfo{}},
+			},
+			retryable: true,
+		},
+		{
+			name: "non-retryable server failure",
+			failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_ServerFailureInfo{ServerFailureInfo: &failurepb.ServerFailureInfo{NonRetryable: true}},
+			},
+		},
+		{
+			name: "application failure marked non-retryable",
+			failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{NonRetryable: true}},
+			},
+		},
+		{
+			name: "retryable application failure",
+			failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{Type: "type"}},
+			},
+			retryable: true,
+		},
+		{
+			name: "application failure with different type excluded",
+			failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{Type: "type"}},
+			},
+			nonRetryableTypes: []string{"otherType"},
+			retryable:         true,
+		},
+		{
+			name: "application failure type excluded",
+			failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{Type: "type"}},
+			},
+			nonRetryableTypes: []string{"otherType", "type"},
+		},
+		{
+			name: "application failure type solely excluded",
+			failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{Type: "type"}},
+			},
+			nonRetryableTypes: []string{"type"},
+		},
+		{
+			name: "child workflow failure",
+			failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_ChildWorkflowExecutionFailureInfo{ChildWorkflowExecutionFailureInfo: &failurepb.ChildWorkflowExecutionFailureInfo{}},
+				Cause: &failurepb.Failure{
+					FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{NonRetryable: true}},
+				},
+			},
+			retryable: true,
+		},
+		{
+			name: "child workflow failure containing activity failure",
+			failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_ChildWorkflowExecutionFailureInfo{ChildWorkflowExecutionFailureInfo: &failurepb.ChildWorkflowExecutionFailureInfo{}},
+				Cause: &failurepb.Failure{
+					FailureInfo: &failurepb.Failure_ActivityFailureInfo{ActivityFailureInfo: &failurepb.ActivityFailureInfo{}},
+					Cause: &failurepb.Failure{
+						FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{NonRetryable: true}},
+					},
+				},
+			},
+			retryable: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.retryable, IsRetryableFailure(tc.failure, tc.nonRetryableTypes))
+		})
+	}
+}
 
 func TestEnsureRetryPolicyDefaults(t *testing.T) {
 	defaultRetrySettings := DefaultRetrySettings{

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -2024,9 +2024,10 @@ func (wh *WorkflowHandler) RespondActivityTaskFailedById(ctx context.Context, re
 	}
 
 	req := &workflowservice.RespondActivityTaskFailedRequest{
-		TaskToken: token,
-		Failure:   request.GetFailure(),
-		Identity:  request.Identity,
+		TaskToken:            token,
+		Failure:              request.GetFailure(),
+		Identity:             request.Identity,
+		LastHeartbeatDetails: request.GetLastHeartbeatDetails(),
 	}
 
 	_, err = wh.historyClient.RespondActivityTaskFailed(ctx, &historyservice.RespondActivityTaskFailedRequest{

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -58,6 +58,7 @@ import (
 	"go.temporal.io/server/common/persistence/transitionhistory"
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/common/retrypolicy"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/softassert"
@@ -6787,7 +6788,7 @@ func (ms *MutableStateImpl) RetryActivity(
 		}
 	}
 
-	if !isRetryable(activityFailure, ai.RetryNonRetryableErrorTypes) {
+	if !retrypolicy.IsRetryableFailure(activityFailure, ai.RetryNonRetryableErrorTypes) {
 		return enumspb.RETRY_STATE_NON_RETRYABLE_FAILURE, nil
 	}
 

--- a/service/history/workflow/retry.go
+++ b/service/history/workflow/retry.go
@@ -2,7 +2,6 @@ package workflow
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -41,7 +40,7 @@ func getBackoffInterval(
 	nonRetryableTypes []string,
 ) (time.Duration, enumspb.RetryState) {
 
-	if !isRetryable(failure, nonRetryableTypes) {
+	if !retrypolicy.IsRetryableFailure(failure, nonRetryableTypes) {
 		return backoff.NoBackoff, enumspb.RETRY_STATE_NON_RETRYABLE_FAILURE
 	}
 
@@ -110,45 +109,6 @@ func nextBackoffInterval(
 		return backoff.NoBackoff, enumspb.RETRY_STATE_TIMEOUT
 	}
 	return interval, enumspb.RETRY_STATE_IN_PROGRESS
-}
-
-func isRetryable(failure *failurepb.Failure, nonRetryableTypes []string) bool {
-	if failure == nil {
-		return true
-	}
-
-	if failure.GetTerminatedFailureInfo() != nil || failure.GetCanceledFailureInfo() != nil {
-		return false
-	}
-
-	if failure.GetTimeoutFailureInfo() != nil {
-		timeoutType := failure.GetTimeoutFailureInfo().GetTimeoutType()
-		if timeoutType == enumspb.TIMEOUT_TYPE_START_TO_CLOSE ||
-			timeoutType == enumspb.TIMEOUT_TYPE_HEARTBEAT {
-			return !slices.Contains(
-				nonRetryableTypes,
-				retrypolicy.TimeoutFailureTypePrefix+timeoutType.String(),
-			)
-		}
-
-		return false
-	}
-
-	if failure.GetServerFailureInfo() != nil {
-		return !failure.GetServerFailureInfo().GetNonRetryable()
-	}
-
-	if failure.GetApplicationFailureInfo() != nil {
-		if failure.GetApplicationFailureInfo().GetNonRetryable() {
-			return false
-		}
-
-		return !slices.Contains(
-			nonRetryableTypes,
-			failure.GetApplicationFailureInfo().GetType(),
-		)
-	}
-	return true
 }
 
 // Helpers for creating new retry/cron workflows:

--- a/service/history/workflow/retry_test.go
+++ b/service/history/workflow/retry_test.go
@@ -7,125 +7,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	enumspb "go.temporal.io/api/enums/v1"
-	failurepb "go.temporal.io/api/failure/v1"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/failure"
 	"go.temporal.io/server/common/number"
-	"go.temporal.io/server/common/retrypolicy"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
-
-func Test_IsRetryable(t *testing.T) {
-	a := assert.New(t)
-
-	f := &failurepb.Failure{
-		FailureInfo: &failurepb.Failure_TerminatedFailureInfo{TerminatedFailureInfo: &failurepb.TerminatedFailureInfo{}},
-	}
-	a.False(isRetryable(f, nil))
-
-	f = &failurepb.Failure{
-		FailureInfo: &failurepb.Failure_CanceledFailureInfo{CanceledFailureInfo: &failurepb.CanceledFailureInfo{}},
-	}
-	a.False(isRetryable(f, nil))
-
-	f = &failurepb.Failure{
-		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
-			TimeoutType: enumspb.TIMEOUT_TYPE_UNSPECIFIED,
-		}},
-	}
-	a.False(isRetryable(f, nil))
-
-	f = &failurepb.Failure{
-		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
-			TimeoutType: enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
-		}},
-	}
-	a.True(isRetryable(f, nil))
-	a.False(isRetryable(f, []string{retrypolicy.TimeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_START_TO_CLOSE.String()}))
-
-	f = &failurepb.Failure{
-		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
-			TimeoutType: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START,
-		}},
-	}
-	a.False(isRetryable(f, nil))
-	a.False(isRetryable(f, []string{retrypolicy.TimeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START.String()}))
-
-	f = &failurepb.Failure{
-		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
-			TimeoutType: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
-		}},
-	}
-	a.False(isRetryable(f, nil))
-	a.False(isRetryable(f, []string{retrypolicy.TimeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE.String()}))
-
-	f = &failurepb.Failure{
-		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
-			TimeoutType: enumspb.TIMEOUT_TYPE_HEARTBEAT,
-		}},
-	}
-	a.True(isRetryable(f, nil))
-	a.False(isRetryable(f, []string{retrypolicy.TimeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_HEARTBEAT.String()}))
-	a.True(isRetryable(f, []string{retrypolicy.TimeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_START_TO_CLOSE.String()}))
-	a.True(isRetryable(f, []string{retrypolicy.TimeoutFailureTypePrefix + "unknown timeout type string"}))
-
-	f = &failurepb.Failure{
-		FailureInfo: &failurepb.Failure_ServerFailureInfo{ServerFailureInfo: &failurepb.ServerFailureInfo{
-			NonRetryable: false,
-		}},
-	}
-	a.True(isRetryable(f, nil))
-
-	f = &failurepb.Failure{
-		FailureInfo: &failurepb.Failure_ServerFailureInfo{ServerFailureInfo: &failurepb.ServerFailureInfo{
-			NonRetryable: true,
-		}},
-	}
-	a.False(isRetryable(f, nil))
-
-	f = &failurepb.Failure{
-		FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
-			NonRetryable: true,
-		}},
-	}
-	a.False(isRetryable(f, nil))
-
-	f = &failurepb.Failure{
-		FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
-			NonRetryable: false,
-			Type:         "type",
-		}},
-	}
-	a.True(isRetryable(f, nil))
-	a.True(isRetryable(f, []string{"otherType"}))
-	a.False(isRetryable(f, []string{"otherType", "type"}))
-	a.False(isRetryable(f, []string{"type"}))
-
-	// When any failure is inside ChildWorkflowExecutionFailure, it is always retryable because ChildWorkflow is always retryable.
-	f = &failurepb.Failure{
-		FailureInfo: &failurepb.Failure_ChildWorkflowExecutionFailureInfo{ChildWorkflowExecutionFailureInfo: &failurepb.ChildWorkflowExecutionFailureInfo{}},
-		Cause: &failurepb.Failure{
-			FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
-				NonRetryable: true,
-			}},
-		},
-	}
-	a.True(isRetryable(f, nil))
-
-	f = &failurepb.Failure{
-		FailureInfo: &failurepb.Failure_ChildWorkflowExecutionFailureInfo{ChildWorkflowExecutionFailureInfo: &failurepb.ChildWorkflowExecutionFailureInfo{}},
-		Cause: &failurepb.Failure{
-			FailureInfo: &failurepb.Failure_ActivityFailureInfo{ActivityFailureInfo: &failurepb.ActivityFailureInfo{}},
-			Cause: &failurepb.Failure{
-				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
-					NonRetryable: true,
-				}},
-			},
-		},
-	}
-	a.True(isRetryable(f, nil))
-}
 
 func Test_NonRetriableErrors(t *testing.T) {
 	attempt := int32(1)

--- a/tests/activity_driver.go
+++ b/tests/activity_driver.go
@@ -5,6 +5,7 @@ package tests
 import (
 	"cmp"
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -227,19 +228,44 @@ func respondFailedFailure(e model.Event, nextRetryDelay time.Duration) *failurep
 	if e.Failure == nil {
 		return nil
 	}
-	if e.Failure.ServerFailure {
+	switch e.Failure.Type {
+	case model.ApplicationFailureType:
+		info := &failurepb.ApplicationFailureInfo{Type: "TestFailure", NonRetryable: !e.Failure.Retryable}
+		if nextRetryDelay > 0 {
+			info.NextRetryDelay = durationpb.New(nextRetryDelay)
+		}
+		return &failurepb.Failure{
+			Message:     "test failure",
+			FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: info},
+		}
+	case model.ServerFailureType:
 		return &failurepb.Failure{
 			Message:     "test server failure",
 			FailureInfo: &failurepb.Failure_ServerFailureInfo{ServerFailureInfo: &failurepb.ServerFailureInfo{NonRetryable: !e.Failure.Retryable}},
 		}
+	case model.StartToCloseTimeoutFailureType:
+		return syntheticTimeoutFailure(enumspb.TIMEOUT_TYPE_START_TO_CLOSE)
+	case model.HeartbeatTimeoutFailureType:
+		return syntheticTimeoutFailure(enumspb.TIMEOUT_TYPE_HEARTBEAT)
+	case model.ScheduleToStartTimeoutFailureType:
+		return syntheticTimeoutFailure(enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START)
+	case model.ScheduleToCloseTimeoutFailureType:
+		return syntheticTimeoutFailure(enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE)
+	case model.UnknownFailureType:
+		return &failurepb.Failure{Message: "test unknown failure"}
+	default:
+		panic(fmt.Sprintf("unknown failure type: %d", e.Failure.Type))
 	}
-	info := &failurepb.ApplicationFailureInfo{Type: "TestFailure", NonRetryable: !e.Failure.Retryable}
-	if nextRetryDelay > 0 {
-		info.NextRetryDelay = durationpb.New(nextRetryDelay)
-	}
+}
+
+// syntheticTimeoutFailure creates a worker-reported timeout for the by-ID failure RPC,
+// exercising failure classification rather than the server's timeout-task path.
+func syntheticTimeoutFailure(timeoutType enumspb.TimeoutType) *failurepb.Failure {
 	return &failurepb.Failure{
-		Message:     "test failure",
-		FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: info},
+		Message: "test synthetic timeout failure",
+		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
+			TimeoutType: timeoutType,
+		}},
 	}
 }
 

--- a/tests/activity_driver.go
+++ b/tests/activity_driver.go
@@ -227,11 +227,13 @@ func respondFailedFailure(e model.Event, nextRetryDelay time.Duration) *failurep
 	if e.Failure == nil {
 		return nil
 	}
-	return activityFailure(e.Failure.Retryable, nextRetryDelay)
-}
-
-func activityFailure(retryable bool, nextRetryDelay time.Duration) *failurepb.Failure {
-	info := &failurepb.ApplicationFailureInfo{Type: "TestFailure", NonRetryable: !retryable}
+	if e.Failure.ServerFailure {
+		return &failurepb.Failure{
+			Message:     "test server failure",
+			FailureInfo: &failurepb.Failure_ServerFailureInfo{ServerFailureInfo: &failurepb.ServerFailureInfo{NonRetryable: !e.Failure.Retryable}},
+		}
+	}
+	info := &failurepb.ApplicationFailureInfo{Type: "TestFailure", NonRetryable: !e.Failure.Retryable}
 	if nextRetryDelay > 0 {
 		info.NextRetryDelay = durationpb.New(nextRetryDelay)
 	}

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -121,6 +121,72 @@ func (s *activityParityTestSuite) TestRetryableServerFailureIsRetried() {
 	})
 }
 
+// Failures submitted through RespondActivityTaskFailedById use the same retry classification for
+// standalone and workflow activities, including non-application failures a worker synthesizes.
+func (s *activityParityTestSuite) TestSyntheticFailuresHaveRetryParity() {
+	env := newActivityParityEnv(s.T())
+	cfg := activityConfig{MaxAttempts: 3, RetryInterval: activityLongDuration}
+	retryableFailures := []struct {
+		name  string
+		event model.Event
+	}{
+		{name: "StartToCloseTimeout", event: model.FailByIDRetryablyWithStartToCloseTimeoutFailure},
+		{name: "HeartbeatTimeout", event: model.FailByIDRetryablyWithHeartbeatTimeoutFailure},
+		{name: "UnknownFailure", event: model.FailByIDRetryablyWithUnknownFailure},
+	}
+	wantRetry := activityInfo{
+		RunState:                   enumspb.PENDING_ACTIVITY_STATE_SCHEDULED,
+		Attempt:                    2,
+		CurrentRetryInterval:       activityLongDuration,
+		NextAttemptScheduleTimeSet: true,
+	}
+
+	for _, tc := range retryableFailures {
+		s.Run(tc.name, func(s *activityParityTestSuite) {
+			trace := []model.Event{model.Poll, tc.event}
+			s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
+				t := s.T()
+				require.Equal(t, wantRetry, newWFADriver(t, env, cfg).driveTrace(t, trace).activityInfo(t))
+			})
+			s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
+				t := s.T()
+				require.Equal(t, wantRetry, newSAADriver(t, env, cfg).driveTrace(t, trace).activityInfo(t))
+			})
+		})
+	}
+
+	// Both implementations close these failures without retrying. WFA surfaces them as timed out,
+	// while SAA surfaces worker-reported timeouts as failed, so terminal status itself is not parity.
+	nonRetryableTimeouts := []struct {
+		name  string
+		event model.Event
+	}{
+		{name: "ScheduleToStartTimeout", event: model.FailByIDWithScheduleToStartTimeoutFailure},
+		{name: "ScheduleToCloseTimeout", event: model.FailByIDWithScheduleToCloseTimeoutFailure},
+	}
+	for _, tc := range nonRetryableTimeouts {
+		s.Run(tc.name, func(s *activityParityTestSuite) {
+			trace := []model.Event{model.Poll, tc.event}
+			s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
+				t := s.T()
+				outcome := newWFADriver(t, env, cfg).driveTrace(t, trace).terminalOutcome(t)
+				require.Contains(t, []enumspb.ActivityExecutionStatus{
+					enumspb.ACTIVITY_EXECUTION_STATUS_FAILED,
+					enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT,
+				}, outcome.status)
+			})
+			s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
+				t := s.T()
+				outcome := newSAADriver(t, env, cfg).driveTrace(t, trace).terminalOutcome(t)
+				require.Contains(t, []enumspb.ActivityExecutionStatus{
+					enumspb.ACTIVITY_EXECUTION_STATUS_FAILED,
+					enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT,
+				}, outcome.status)
+			})
+		})
+	}
+}
+
 // A terminal timeout must chain the application failure that drove its retries as its Cause, so an SDK
 // can expose the real failure.
 func (s *activityParityTestSuite) TestTimeoutPreservesUnderlyingFailureCause() {

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -553,25 +553,22 @@ func (s *activityParityTestSuite) TestLastHeartbeatDetailsPersistedOnAttemptFail
 	env := newActivityParityEnv(s.T())
 	cfg := activityConfig{MaxAttempts: 2}
 
-	trace := []model.Event{model.Poll, {Type: model.RespondFailedType, Failure: &model.Failure{Retryable: true}, HasHeartbeatDetails: true}}
 	expected := activityMarshalPayloads(activityHeartbeatDetails)
-	s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
-		t := s.T()
-		require.Equal(t, expected,
-			newWFADriver(t, env, cfg).driveTrace(t, trace).activityInfo(t).LastHeartbeatDetails)
-	})
-	s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
-		t := s.T()
-		d := newSAADriver(t, env, cfg)
-		require.Equal(t, expected,
-			d.driveTrace(t, trace).activityInfo(t).LastHeartbeatDetails)
-
-		// For SAA we additionally confirm that it's persisted even if the failure is terminal. WFA
-		// drops the pending activity from MS at this point.
-		terminal := []model.Event{model.Poll, {Type: model.RespondFailedType, Failure: &model.Failure{Retryable: false}, HasHeartbeatDetails: true}}
-		require.Equal(t, expected,
-			d.driveTrace(t, terminal).activityInfo(t).LastHeartbeatDetails)
-	})
+	for _, eventType := range []model.EventType{model.RespondFailedType, model.RespondFailedByIDType} {
+		s.Run(eventType.String(), func(s *activityParityTestSuite) {
+			trace := []model.Event{model.Poll, {Type: eventType, Failure: &model.Failure{Retryable: true}, HasHeartbeatDetails: true}}
+			s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
+				t := s.T()
+				require.Equal(t, expected,
+					newWFADriver(t, env, cfg).driveTrace(t, trace).activityInfo(t).LastHeartbeatDetails)
+			})
+			s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
+				t := s.T()
+				require.Equal(t, expected,
+					newSAADriver(t, env, cfg).driveTrace(t, trace).activityInfo(t).LastHeartbeatDetails)
+			})
+		})
+	}
 }
 
 func (s *activityParityTestSuite) TestTerminalRetryState() {

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -167,19 +167,17 @@ func (s *activityParityTestSuite) TestSyntheticFailuresHaveRetryParity() {
 			trace := []model.Event{model.Poll, tc.event}
 			s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
 				t := s.T()
-				outcome := newWFADriver(t, env, cfg).driveTrace(t, trace).terminalOutcome(t)
-				require.Contains(t, []enumspb.ActivityExecutionStatus{
-					enumspb.ACTIVITY_EXECUTION_STATUS_FAILED,
-					enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT,
-				}, outcome.status)
+				require.Equal(t, activityTerminalOutcome{
+					status:     enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT,
+					retryState: enumspb.RETRY_STATE_TIMEOUT,
+				}, newWFADriver(t, env, cfg).driveTrace(t, trace).terminalOutcome(t))
 			})
 			s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
 				t := s.T()
-				outcome := newSAADriver(t, env, cfg).driveTrace(t, trace).terminalOutcome(t)
-				require.Contains(t, []enumspb.ActivityExecutionStatus{
-					enumspb.ACTIVITY_EXECUTION_STATUS_FAILED,
-					enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT,
-				}, outcome.status)
+				require.Equal(t, activityTerminalOutcome{
+					status:     enumspb.ACTIVITY_EXECUTION_STATUS_FAILED,
+					retryState: enumspb.RETRY_STATE_NON_RETRYABLE_FAILURE,
+				}, newSAADriver(t, env, cfg).driveTrace(t, trace).terminalOutcome(t))
 			})
 		})
 	}

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -94,9 +94,7 @@ func (s *activityParityTestSuite) TestNonRetryableErrorTypes() {
 
 // A retryable ServerFailure reported through RespondActivityTaskFailedById must be retried, exactly
 // like a retryable ApplicationFailure. Only the by-ID API accepts a non-application failure (the
-// by-token API rejects one), so this is the surface a ServerFailure reaches the handler through. SAA
-// previously derived retryability from ApplicationFailureInfo alone and closed a ServerFailure
-// terminally, while WFA scheduled another attempt.
+// by-token API rejects one), so this is the path a ServerFailure reaches the handler through.
 func (s *activityParityTestSuite) TestRetryableServerFailureIsRetried() {
 	env := newActivityParityEnv(s.T())
 	cfg := activityConfig{MaxAttempts: 3, RetryInterval: activityLongDuration}

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -92,6 +92,35 @@ func (s *activityParityTestSuite) TestNonRetryableErrorTypes() {
 	})
 }
 
+// A retryable ServerFailure reported through RespondActivityTaskFailedById must be retried, exactly
+// like a retryable ApplicationFailure. Only the by-ID API accepts a non-application failure (the
+// by-token API rejects one), so this is the surface a ServerFailure reaches the handler through. SAA
+// previously derived retryability from ApplicationFailureInfo alone and closed a ServerFailure
+// terminally, while WFA scheduled another attempt.
+func (s *activityParityTestSuite) TestRetryableServerFailureIsRetried() {
+	env := newActivityParityEnv(s.T())
+	cfg := activityConfig{MaxAttempts: 3, RetryInterval: activityLongDuration}
+	trace := []model.Event{model.Poll, model.FailByIDRetryablyWithServerFailure}
+	// A second attempt is scheduled and backing off, rather than the activity going terminal.
+	expected := activityInfo{
+		RunState:                   enumspb.PENDING_ACTIVITY_STATE_SCHEDULED,
+		Attempt:                    2,
+		CurrentRetryInterval:       activityLongDuration,
+		NextAttemptScheduleTimeSet: true,
+	}
+
+	s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
+		t := s.T()
+		require.Equal(t, expected, newWFADriver(t, env, cfg).driveTrace(t, trace).activityInfo(t),
+			"a retryable ServerFailure must schedule another attempt, not fail terminally")
+	})
+	s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
+		t := s.T()
+		require.Equal(t, expected, newSAADriver(t, env, cfg).driveTrace(t, trace).activityInfo(t),
+			"a retryable ServerFailure must schedule another attempt, not fail terminally")
+	})
+}
+
 // A terminal timeout must chain the application failure that drove its retries as its Cause, so an SDK
 // can expose the real failure.
 func (s *activityParityTestSuite) TestTimeoutPreservesUnderlyingFailureCause() {

--- a/tests/activity_standalone_driver.go
+++ b/tests/activity_standalone_driver.go
@@ -260,10 +260,14 @@ func (a *saaHandle) rpc(_ testing.TB, e model.Event) error {
 		_, err := fc.RespondActivityTaskFailed(a.d.ctx, req)
 		return err
 	case model.RespondFailedByIDType:
-		_, err := fc.RespondActivityTaskFailedById(a.d.ctx, &workflowservice.RespondActivityTaskFailedByIdRequest{
+		req := &workflowservice.RespondActivityTaskFailedByIdRequest{
 			Namespace: ns, RunId: a.runID, ActivityId: a.activityID, Identity: a.d.env.Tv().WorkerIdentity(),
 			Failure: respondFailedFailure(e, a.cfg.NextRetryDelay),
-		})
+		}
+		if e.HasHeartbeatDetails {
+			req.LastHeartbeatDetails = activityHeartbeatDetails
+		}
+		_, err := fc.RespondActivityTaskFailedById(a.d.ctx, req)
 		return err
 	case model.RespondCanceledType:
 		_, err := fc.RespondActivityTaskCanceled(a.d.ctx, &workflowservice.RespondActivityTaskCanceledRequest{

--- a/tests/activity_standalone_driver.go
+++ b/tests/activity_standalone_driver.go
@@ -259,6 +259,12 @@ func (a *saaHandle) rpc(_ testing.TB, e model.Event) error {
 		}
 		_, err := fc.RespondActivityTaskFailed(a.d.ctx, req)
 		return err
+	case model.RespondFailedByIDType:
+		_, err := fc.RespondActivityTaskFailedById(a.d.ctx, &workflowservice.RespondActivityTaskFailedByIdRequest{
+			Namespace: ns, RunId: a.runID, ActivityId: a.activityID, Identity: a.d.env.Tv().WorkerIdentity(),
+			Failure: respondFailedFailure(e, a.cfg.NextRetryDelay),
+		})
+		return err
 	case model.RespondCanceledType:
 		_, err := fc.RespondActivityTaskCanceled(a.d.ctx, &workflowservice.RespondActivityTaskCanceledRequest{
 			Namespace: ns, TaskToken: a.token, Identity: a.d.env.Tv().WorkerIdentity(),

--- a/tests/activity_workflow_driver.go
+++ b/tests/activity_workflow_driver.go
@@ -305,10 +305,14 @@ func (a *wfaHandle) rpc(t testing.TB, e model.Event) error {
 		_, err := fc.RespondActivityTaskFailed(a.d.ctx, req)
 		return err
 	case model.RespondFailedByIDType:
-		_, err := fc.RespondActivityTaskFailedById(a.d.ctx, &workflowservice.RespondActivityTaskFailedByIdRequest{
+		req := &workflowservice.RespondActivityTaskFailedByIdRequest{
 			Namespace: ns, WorkflowId: a.workflowID, RunId: a.runID, ActivityId: a.activityID, Identity: a.d.env.Tv().WorkerIdentity(),
 			Failure: respondFailedFailure(e, a.cfg.NextRetryDelay),
-		})
+		}
+		if e.HasHeartbeatDetails {
+			req.LastHeartbeatDetails = activityHeartbeatDetails
+		}
+		_, err := fc.RespondActivityTaskFailedById(a.d.ctx, req)
 		return err
 	case model.RespondCanceledType:
 		_, err := fc.RespondActivityTaskCanceled(a.d.ctx, &workflowservice.RespondActivityTaskCanceledRequest{

--- a/tests/activity_workflow_driver.go
+++ b/tests/activity_workflow_driver.go
@@ -304,6 +304,12 @@ func (a *wfaHandle) rpc(t testing.TB, e model.Event) error {
 		}
 		_, err := fc.RespondActivityTaskFailed(a.d.ctx, req)
 		return err
+	case model.RespondFailedByIDType:
+		_, err := fc.RespondActivityTaskFailedById(a.d.ctx, &workflowservice.RespondActivityTaskFailedByIdRequest{
+			Namespace: ns, WorkflowId: a.workflowID, RunId: a.runID, ActivityId: a.activityID, Identity: a.d.env.Tv().WorkerIdentity(),
+			Failure: respondFailedFailure(e, a.cfg.NextRetryDelay),
+		})
+		return err
 	case model.RespondCanceledType:
 		_, err := fc.RespondActivityTaskCanceled(a.d.ctx, &workflowservice.RespondActivityTaskCanceledRequest{
 			Namespace: ns, TaskToken: a.token, Identity: a.d.env.Tv().WorkerIdentity(),


### PR DESCRIPTION
## What changed?

Moved activity failure retry classification into a shared helper used by standalone activities, workflow activities, and workflow retries.

Standalone activities now use the same retry classification as workflow activities for failures reported through `RespondActivityTaskFailedById`. This includes retryable `ServerFailure`s, worker-reported start-to-close and heartbeat timeouts, and otherwise unrecognized failure variants. Schedule-to-start and schedule-to-close timeouts remain non-retryable.

## Why?

Standalone activities previously treated non-application failures as non-retryable. Sharing the existing workflow retry classifier keeps retry behavior consistent across SAA, WFA, and workflow retries.