### PR TITLE
Fix hung callers on concurrent Nexus Updates

### DIFF
--- a/service/history/api/updateworkflow/api.go
+++ b/service/history/api/updateworkflow/api.go
@@ -165,15 +165,18 @@ func (u *Updater) ApplyRequest(
 		return nil, err
 	}
 
-	callbacksAttached, err := u.upd.AttachCallbacks(updateRequest, workflow.WithEffects(effect.Immediate(ctx), ms))
-	if err != nil {
-		return nil, err
-	}
-	if callbacksAttached {
-		return &api.UpdateWorkflowAction{
-			Noop:               false,
-			CreateWorkflowTask: false,
-		}, nil
+	if alreadyExisted {
+		// Attach is only required for updates that already exist
+		callbacksAttached, err := u.upd.AttachCallbacksOnDuplicateUpdates(updateRequest, workflow.WithEffects(effect.Immediate(ctx), ms))
+		if err != nil {
+			return nil, err
+		}
+		if callbacksAttached {
+			return &api.UpdateWorkflowAction{
+				Noop:               false,
+				CreateWorkflowTask: false,
+			}, nil
+		}
 	}
 
 	// If WT is scheduled, but not started, updates will be attached to it, when WT is started.

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -370,8 +370,8 @@ func (u *Update) Admit(
 	return nil
 }
 
-// AttachCallbacks attaches completion callbacks from a second caller to an update
-// that has already progressed past admission. If the update is accepted, it writes
+// AttachCallbacksOnDuplicateUpdates attaches completion callbacks from a second caller to an update
+// that has already progressed to admission. If the update is accepted, it writes
 // a WorkflowExecutionOptionsUpdatedEvent with the caller's callbacks and request ID.
 // If the update is in stateSent (sent to worker, not yet accepted), callbacks are
 // buffered in memory and flushed when the update is accepted. If the update is
@@ -381,7 +381,7 @@ func (u *Update) Admit(
 // Returns (true, nil) if the caller should proceed (callbacks attached or update already completed),
 // (false, nil) if the update is in an early state where attachment does not apply,
 // or (false, error) if the update is in a transient state where the caller should retry.
-func (u *Update) AttachCallbacks(
+func (u *Update) AttachCallbacksOnDuplicateUpdates(
 	req *updatepb.Request,
 	eventStore EventStore,
 ) (isCallbackAttached bool, err error) {
@@ -401,20 +401,23 @@ func (u *Update) AttachCallbacks(
 		stateProvisionallyAborted:
 		// Provisional states are transient — they exist only between an event write
 		// and its OnAfterCommit callback within a single workflow task completion
-		// transaction. In practice, AttachCallbacks should never see these states because
+		// transaction. In practice, AttachCallbacksOnDuplicateUpdates should never see these states because
 		// a new UpdateWorkflowExecution API call must acquire the workflow lock,
 		// which means the previous transaction has already committed and provisional
 		// states have resolved. This guard is kept defensively in case future code
-		// paths call AttachCallbacks within the same transaction.
+		// paths call AttachCallbacksOnDuplicateUpdates within the same transaction.
 		return false, serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW, "workflow update is not yet accepted, please retry")
 
-	case stateSent:
+	case stateAdmitted, stateSent:
+		// stateAdmitted: if update is Admitted but hasn't yet proceeded to Sent, attach should
+		// still happen so that the callbacks for the duplicate request fire when update completes
 		// stateSent: the update has been sent to the worker but not yet accepted.
 		// Buffer the callbacks in memory; they will be flushed to the event store
 		// when the update is accepted in onAcceptanceMsg.
 		// Returning (true, nil) is safe because:
 		// - The caller already holds the workflow lock
-		// - A workflow task already exists (the update was sent via one)
+		// - A workflow task either already exists (stateSent: the update was sent via one)
+		// or it will be created if required for moving it to Sent(stateAdmitted)
 		// - No new workflow task is needed — just buffer until acceptance
 		// - The event will be written atomically with acceptance
 		// If the Update struct is lost (registry cleared), the abort mechanism fires

--- a/service/history/workflow/update/update_test.go
+++ b/service/history/workflow/update/update_test.go
@@ -1259,7 +1259,7 @@ func TestAttachCallbacks(t *testing.T) {
 		store, capturedOptions := capturingStore(effects)
 		upd := update.NewAccepted(tv.UpdateID(), testAcceptedEventID)
 
-		fired, err := upd.AttachCallbacks(testRequest, store)
+		fired, err := upd.AttachCallbacksOnDuplicateUpdates(testRequest, store)
 		require.NoError(t, err)
 		require.True(t, fired)
 		require.Len(t, *capturedOptions, 1)
@@ -1273,7 +1273,7 @@ func TestAttachCallbacks(t *testing.T) {
 		store, eventCreated := trackingStore(effects)
 		upd := update.NewCompleted(tv.UpdateID(), future.NewReadyFuture[*updatepb.Outcome](successOutcome, nil))
 
-		fired, err := upd.AttachCallbacks(testRequest, store)
+		fired, err := upd.AttachCallbacksOnDuplicateUpdates(testRequest, store)
 		require.NoError(t, err)
 		require.True(t, fired)
 		require.False(t, *eventCreated, "should not attach callbacks when update is already completed")
@@ -1284,21 +1284,26 @@ func TestAttachCallbacks(t *testing.T) {
 		store, eventCreated := trackingStore(effects)
 		upd := update.New(tv.UpdateID())
 
-		fired, err := upd.AttachCallbacks(testRequest, store)
+		fired, err := upd.AttachCallbacksOnDuplicateUpdates(testRequest, store)
 		require.NoError(t, err)
 		require.False(t, fired)
 		require.False(t, *eventCreated)
 	})
 
-	t.Run("on stateAdmitted returns false without creating event", func(t *testing.T) {
+	t.Run("stateAdmitted buffers callbacks and flushes on acceptance", func(t *testing.T) {
 		effects := &effect.Buffer{}
-		store, eventCreated := trackingStore(effects)
-		upd := update.NewAdmitted(tv.UpdateID(), nil)
+		store, optionsEventCount := countingOptionsStore(effects)
+		upd := update.New(tv.UpdateID())
+		mustAdmit(t, store, upd)
+		effects.Apply(context.Background())
 
-		fired, err := upd.AttachCallbacks(testRequest, store)
+		fired, err := upd.AttachCallbacksOnDuplicateUpdates(testRequest, store)
 		require.NoError(t, err)
-		require.False(t, fired)
-		require.False(t, *eventCreated)
+		require.True(t, fired)
+
+		require.NoError(t, accept(t, store, upd))
+		effects.Apply(context.Background())
+		require.Equal(t, 1, *optionsEventCount, "should flush one admission buffered callback on acceptance")
 	})
 
 	t.Run("on stateSent buffers callbacks and returns true", func(t *testing.T) {
@@ -1310,7 +1315,7 @@ func TestAttachCallbacks(t *testing.T) {
 		msg := send(t, upd, skipAlreadySent)
 		require.NotNil(t, msg)
 
-		fired, err := upd.AttachCallbacks(testRequest, store)
+		fired, err := upd.AttachCallbacksOnDuplicateUpdates(testRequest, store)
 		require.NoError(t, err)
 		require.True(t, fired)
 
@@ -1330,10 +1335,10 @@ func TestAttachCallbacks(t *testing.T) {
 		_ = send(t, upd, skipAlreadySent)
 
 		// Call AttachCallbacks twice with the same requestID.
-		fired1, err := upd.AttachCallbacks(testRequest, store)
+		fired1, err := upd.AttachCallbacksOnDuplicateUpdates(testRequest, store)
 		require.NoError(t, err)
 		require.True(t, fired1)
-		fired2, err := upd.AttachCallbacks(testRequest, store)
+		fired2, err := upd.AttachCallbacksOnDuplicateUpdates(testRequest, store)
 		require.NoError(t, err)
 		require.True(t, fired2)
 
@@ -1363,10 +1368,10 @@ func TestAttachCallbacks(t *testing.T) {
 			RequestId:           "request-2",
 			CompletionCallbacks: testCallbacks,
 		}
-		fired1, err := upd.AttachCallbacks(req1, store)
+		fired1, err := upd.AttachCallbacksOnDuplicateUpdates(req1, store)
 		require.NoError(t, err)
 		require.True(t, fired1)
-		fired2, err := upd.AttachCallbacks(req2, store)
+		fired2, err := upd.AttachCallbacksOnDuplicateUpdates(req2, store)
 		require.NoError(t, err)
 		require.True(t, fired2)
 
@@ -1387,7 +1392,7 @@ func TestAttachCallbacks(t *testing.T) {
 		effects.Apply(context.Background())
 		_ = send(t, upd, skipAlreadySent)
 
-		fired, err := upd.AttachCallbacks(testRequest, store)
+		fired, err := upd.AttachCallbacksOnDuplicateUpdates(testRequest, store)
 		require.NoError(t, err)
 		require.True(t, fired)
 
@@ -1413,7 +1418,7 @@ func TestAttachCallbacks(t *testing.T) {
 		effects.Apply(context.Background())
 		_ = send(t, upd, skipAlreadySent)
 
-		fired, err := upd.AttachCallbacks(testRequest, store)
+		fired, err := upd.AttachCallbacksOnDuplicateUpdates(testRequest, store)
 		require.NoError(t, err)
 		require.True(t, fired)
 
@@ -1433,7 +1438,7 @@ func TestAttachCallbacks(t *testing.T) {
 		// Accept but do NOT apply effects — update is in stateProvisionallyAccepted.
 		require.NoError(t, accept(t, store, upd))
 
-		fired, err := upd.AttachCallbacks(testRequest, store)
+		fired, err := upd.AttachCallbacksOnDuplicateUpdates(testRequest, store)
 		require.False(t, fired)
 		require.Error(t, err)
 		var resourceExhaustedErr *serviceerror.ResourceExhausted
@@ -1448,7 +1453,7 @@ func TestAttachCallbacks(t *testing.T) {
 		effects.Apply(context.Background())
 		_ = send(t, upd, skipAlreadySent)
 
-		fired, err := upd.AttachCallbacks(testRequest, store)
+		fired, err := upd.AttachCallbacksOnDuplicateUpdates(testRequest, store)
 		require.NoError(t, err)
 		require.True(t, fired)
 
@@ -1467,7 +1472,7 @@ func TestAttachCallbacks(t *testing.T) {
 		effects.Apply(context.Background())
 		_ = send(t, upd, skipAlreadySent)
 
-		fired, err := upd.AttachCallbacks(testRequest, store)
+		fired, err := upd.AttachCallbacksOnDuplicateUpdates(testRequest, store)
 		require.NoError(t, err)
 		require.True(t, fired)
 
@@ -1488,7 +1493,7 @@ func TestAttachCallbacks(t *testing.T) {
 		effects.Apply(context.Background())
 		_ = send(t, upd, skipAlreadySent)
 
-		fired, err := upd.AttachCallbacks(testRequest, store)
+		fired, err := upd.AttachCallbacksOnDuplicateUpdates(testRequest, store)
 		require.NoError(t, err)
 		require.True(t, fired)
 
@@ -1497,7 +1502,7 @@ func TestAttachCallbacks(t *testing.T) {
 		_ = send(t, upd2, skipAlreadySent)
 
 		// Same requestID can buffer again on new struct.
-		fired2, err := upd2.AttachCallbacks(testRequest, store)
+		fired2, err := upd2.AttachCallbacksOnDuplicateUpdates(testRequest, store)
 		require.NoError(t, err)
 		require.True(t, fired2)
 
@@ -1516,7 +1521,7 @@ func TestAttachCallbacks(t *testing.T) {
 		}
 		upd := update.NewAccepted(tv.UpdateID(), testAcceptedEventID)
 
-		fired, err := upd.AttachCallbacks(testRequest, store)
+		fired, err := upd.AttachCallbacksOnDuplicateUpdates(testRequest, store)
 		require.NoError(t, err)
 		require.True(t, fired)
 		require.Equal(t, 0, *optionsEventCount,
@@ -1536,7 +1541,7 @@ func TestAttachCallbacks(t *testing.T) {
 		}
 		upd := update.NewAccepted(tv.UpdateID(), testAcceptedEventID)
 
-		fired, err := upd.AttachCallbacks(testRequest, store)
+		fired, err := upd.AttachCallbacksOnDuplicateUpdates(testRequest, store)
 		require.False(t, fired)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "store error")
@@ -1551,7 +1556,7 @@ func TestAttachCallbacks(t *testing.T) {
 			Input: &updatepb.Input{Name: "not_empty"},
 		}
 
-		fired, err := upd.AttachCallbacks(emptyRequest, store)
+		fired, err := upd.AttachCallbacksOnDuplicateUpdates(emptyRequest, store)
 		require.NoError(t, err)
 		require.False(t, fired, "should return false when no callbacks to attach — preserves existing caller behavior")
 		require.False(t, *eventCreated, "should not create event when no callbacks and no request ID")
@@ -1575,7 +1580,7 @@ func TestAttachCallbacks(t *testing.T) {
 		}
 		upd := update.NewAccepted(tv.UpdateID(), testAcceptedEventID)
 
-		fired, err := upd.AttachCallbacks(testRequest, store)
+		fired, err := upd.AttachCallbacksOnDuplicateUpdates(testRequest, store)
 		require.NoError(t, err)
 		require.True(t, fired, "should return true so caller can wait on existing update")
 		require.False(t, eventCreated, "should not create event for duplicate requestID")
@@ -1589,7 +1594,7 @@ func TestAttachCallbacks(t *testing.T) {
 		}
 		upd := update.NewAccepted(tv.UpdateID(), testAcceptedEventID)
 
-		fired, err := upd.AttachCallbacks(testRequest, store)
+		fired, err := upd.AttachCallbacksOnDuplicateUpdates(testRequest, store)
 		require.NoError(t, err)
 		require.True(t, fired)
 		require.Len(t, *capturedOptions, 1)

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -19,10 +20,12 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/chasm"
+	chasmcb "go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/common/testing/protoutils"
 	"go.temporal.io/server/common/testing/taskpoller"
@@ -527,6 +530,72 @@ func (s *WorkflowUpdateSuite) TestNormalScheduledWorkflowTask_AcceptComplete() {
 	`, events)
 		})
 	}
+}
+
+func (s *WorkflowUpdateSuite) TestDuplicateUpdate_AttachesCallbackWhileAdmitted() {
+	env := testcore.NewEnv(s.T(),
+		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
+		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMCallbacks, true),
+		testcore.WithDynamicConfig(dynamicconfig.EnableWorkflowUpdateCallbacks, true),
+		testcore.WithDynamicConfig(chasmcb.AllowedAddresses,
+			[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}}),
+	)
+
+	runID := mustStartWorkflow(env, env.Tv()) // leaves a pending first WFT (unprocessed)
+	tv := env.Tv().WithRunID(runID)
+	const cbURL1, cbURL2 = "temporal://cb1", "temporal://cb2"
+
+	// enqueue an update request with given callbackURL
+	sendUpdateWithCallback := func(callbackURL string) {
+		go func() {
+			// fire and forget, no assertions inside goroutines - will be indirectly verified later on instead
+			_, _ = env.FrontendClient().UpdateWorkflowExecution(testcore.NewContext(),
+				&workflowservice.UpdateWorkflowExecutionRequest{
+					Namespace:         env.Namespace().String(),
+					WorkflowExecution: tv.WorkflowExecution(),
+					WaitPolicy:        &updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED},
+					Request: &updatepb.Request{
+						Meta:      &updatepb.Meta{UpdateId: tv.UpdateID()}, // use stable updateID
+						Input:     &updatepb.Input{Name: tv.HandlerName(), Args: payloads.EncodeString("args")},
+						RequestId: uuid.NewString(), // unique requestIDs to simulate multiple calls without reqID dedup
+						CompletionCallbacks: []*commonpb.Callback{{
+							Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: callbackURL}},
+						}},
+					},
+				})
+		}()
+		waitUpdateAdmitted(env, tv) // just wait until admission
+	}
+
+	sendUpdateWithCallback(cbURL1) // original: admitted, not yet sent
+	sendUpdateWithCallback(cbURL2) // duplicate: arrives while original still only admitted, NOT sent/later
+
+	// Now accept and complete the single update which will have both callbacks
+	poller := taskpoller.New(s.TB(), env.FrontendClient(), env.Namespace().String())
+	_, err := poller.
+		PollWorkflowTask(&workflowservice.PollWorkflowTaskQueueRequest{}).
+		HandleTask(tv, func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+			return &workflowservice.RespondWorkflowTaskCompletedRequest{
+				Commands: env.UpdateAcceptCompleteCommands(tv),
+				Messages: env.UpdateAcceptCompleteMessages(tv, task.Messages[0]),
+			}, nil
+		})
+	s.Require().NoError(err)
+
+	// finally, check both callbacks exist
+	workflowExecDesc, err := env.FrontendClient().DescribeWorkflowExecution(testcore.NewContext(),
+		&workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(), Execution: tv.WorkflowExecution(),
+		})
+	s.Require().NoError(err)
+	got := map[string]bool{}
+	for _, cb := range workflowExecDesc.GetCallbacks() {
+		if u := cb.GetTrigger().GetUpdateWorkflowExecutionCompleted(); u != nil && u.GetUpdateId() == tv.UpdateID() {
+			got[cb.GetCallback().GetNexus().GetUrl()] = true
+		}
+	}
+	s.True(got[cbURL1], "original callback URL should be listed")
+	s.True(got[cbURL2], "duplicate callback URL should also be listed")
 }
 
 func (s *WorkflowUpdateSuite) TestRunningWorkflowTask_NewEmptySpeculativeWorkflowTask_Rejected() {


### PR DESCRIPTION
## What changed?

Attach callbacks for duplicate updates when the original update is still in stateAdmitted 

## Why?

The callbacks for duplicates updates(same updateID) are attached when the original req is in stateSent and later - after admission. 
But if the req is admitted but not yet sent - which can happen in rare cases if multiple nexus updates fire at the same time - the second request never attaches its callbacks and as a result, the second update caller will never complete as its callbacks are never registered 
The fix is to also attach callbacks on stateAdmitted - this will ensure that all the callbacks are registered and fired when request completes. To protect against new requests going into this branch, moved the AttachCallbacks behind the alreadyExists gate - we should only try to attach if its a duplicate request 

Addresses/found by https://github.com/temporalio/sdk-go/issues/2479

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

