### PR TITLE
Programmable persistence fault injection

### DIFF
--- a/common/persistence/faultinjection/registry.go
+++ b/common/persistence/faultinjection/registry.go
@@ -1,0 +1,126 @@
+package faultinjection
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"go.temporal.io/server/common/config"
+)
+
+type (
+	// Target identifies the persistence operation a fault callback may act on. It is an
+	// alias for config.FaultInjectionTarget so a FaultRegistry plugs directly into the
+	// existing config.FaultInjection.Injector seam.
+	Target = config.FaultInjectionTarget
+
+	// Callback decides whether to inject a fault for the given target. Returning a nil
+	// error lets the operation proceed to the real store. Callbacks must be safe for
+	// concurrent use.
+	Callback func(Target) error
+
+	// faultCallback is the internal callback shape. Unlike the public Callback it can
+	// return a *fault, which additionally carries the "execute the real operation, then
+	// fail" semantics used by the ExecuteAndTimeout config error.
+	faultCallback func(Target) *fault
+
+	callbackEntry struct {
+		id       uint64
+		callback faultCallback
+	}
+
+	// FaultRegistry is a thread-safe, ordered set of fault-injection callbacks. It is the
+	// generic core of persistence fault injection: the store wrapper registers the
+	// YAML-configured faults as one callback and the runtime config.Injector as another,
+	// so config-based injection is just a special case. Its Inject method matches
+	// config.FaultInjector, so a registry can be used directly as
+	// config.FaultInjection.Injector to inject faults programmatically from tests.
+	FaultRegistry struct {
+		mu        sync.RWMutex
+		callbacks []callbackEntry
+		nextID    atomic.Uint64
+	}
+)
+
+// NewFaultRegistry returns an empty FaultRegistry.
+func NewFaultRegistry() *FaultRegistry {
+	return &FaultRegistry{}
+}
+
+// RegisterCallback registers a fault-injection callback and returns a cleanup function
+// that removes it when called.
+func (r *FaultRegistry) RegisterCallback(cb Callback) func() {
+	return r.register(func(t Target) *fault {
+		err := cb(t)
+		if err == nil {
+			return nil
+		}
+		f := newFaultFromError(err, 1.0)
+		return &f
+	})
+}
+
+// register adds an internal faultCallback and returns a cleanup function.
+func (r *FaultRegistry) register(cb faultCallback) func() {
+	if r == nil {
+		return func() {}
+	}
+	id := r.nextID.Add(1)
+
+	r.mu.Lock()
+	r.callbacks = append(r.callbacks, callbackEntry{id: id, callback: cb})
+	r.mu.Unlock()
+
+	return func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		for i, e := range r.callbacks {
+			if e.id == id {
+				r.callbacks = append(r.callbacks[:i], r.callbacks[i+1:]...)
+				return
+			}
+		}
+	}
+}
+
+// HasCallbacks returns true if there is at least one registered callback.
+func (r *FaultRegistry) HasCallbacks() bool {
+	if r == nil {
+		return false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.callbacks) > 0
+}
+
+// Generate runs the registered callbacks in registration order and returns the first
+// fault produced, or nil if none of them inject a fault.
+func (r *FaultRegistry) Generate(t Target) *fault {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	if len(r.callbacks) == 0 {
+		r.mu.RUnlock()
+		return nil
+	}
+	callbacks := make([]callbackEntry, len(r.callbacks))
+	copy(callbacks, r.callbacks)
+	r.mu.RUnlock()
+
+	for _, e := range callbacks {
+		if f := e.callback(t); f != nil {
+			return f
+		}
+	}
+	return nil
+}
+
+// Inject adapts the registry to config.FaultInjector so it can be assigned directly to
+// config.FaultInjection.Injector.
+func (r *FaultRegistry) Inject(t Target) error {
+	f := r.Generate(t)
+	if f == nil {
+		return nil
+	}
+	return f.err
+}

--- a/common/persistence/faultinjection/store_fault_generator.go
+++ b/common/persistence/faultinjection/store_fault_generator.go
@@ -5,41 +5,63 @@ import (
 )
 
 type (
-	// storeFaultInjector is an implementation of faultGenerator that will inject errors into the persistence layer
-	// using runtime injectors or per-method configuration.
+	// storeFaultInjector is an implementation of faultGenerator that injects errors into
+	// the persistence layer using a FaultRegistry. Both the per-method YAML configuration
+	// and the runtime config.Injector are registered as regular callbacks, so config-based
+	// fault injection is a special case of the generic programmable registry.
 	storeFaultInjector struct {
 		storeName config.DataStoreName
-		injectors []faultInjector
+		registry  *FaultRegistry
 	}
-
-	faultInjector func(config.FaultInjectionTarget) *fault
 )
 
-// newStoreFaultInjector returns a new instance of a data store fault injector that will inject errors
-// into the persistence layer based on the provided configuration.
+// newStoreFaultInjector returns a new instance of a data store fault injector that will
+// inject errors into the persistence layer based on the provided configuration and/or
+// runtime injector. It returns false when neither is configured.
 func newStoreFaultInjector(
 	storeName config.DataStoreName,
 	cfg *config.FaultInjectionDataStoreConfig,
 	injector config.FaultInjector,
 ) (*storeFaultInjector, bool) {
-	var injectors []faultInjector
-	if injector != nil {
-		injectors = append(injectors, runtimeFaultInjector(injector))
-	}
+	registry := NewFaultRegistry()
 	if len(cfg.Methods) > 0 {
-		injectors = append(injectors, configuredFaultInjector(cfg))
+		registry.register(configCallback(cfg))
 	}
-	if len(injectors) == 0 {
+	if injector != nil {
+		registry.register(injectorCallback(injector))
+	}
+	if !registry.HasCallbacks() {
 		return nil, false
 	}
 	return &storeFaultInjector{
 		storeName: storeName,
-		injectors: injectors,
+		registry:  registry,
 	}, true
 }
 
-func runtimeFaultInjector(injector config.FaultInjector) faultInjector {
-	return func(target config.FaultInjectionTarget) *fault {
+// configCallback builds a faultCallback from per-method YAML configuration.
+func configCallback(cfg *config.FaultInjectionDataStoreConfig) faultCallback {
+	methodFaultGenerators := make(map[string]faultGenerator, len(cfg.Methods))
+	for methodName, methodConfig := range cfg.Methods {
+		var faults []fault
+		for errName, errRate := range methodConfig.Errors {
+			faults = append(faults, newFault(errName, errRate, methodName))
+		}
+		methodFaultGenerators[methodName] = newMethodFaultGenerator(faults, methodConfig.Seed)
+	}
+	return func(target Target) *fault {
+		methodGenerator, ok := methodFaultGenerators[target.Method]
+		if !ok {
+			return nil
+		}
+		return methodGenerator.generate(target.Method)
+	}
+}
+
+// injectorCallback adapts a config.FaultInjector (a programmable hook set through config)
+// into a faultCallback.
+func injectorCallback(injector config.FaultInjector) faultCallback {
+	return func(target Target) *fault {
 		err := injector(target)
 		if err == nil {
 			return nil
@@ -49,38 +71,15 @@ func runtimeFaultInjector(injector config.FaultInjector) faultInjector {
 	}
 }
 
-func configuredFaultInjector(cfg *config.FaultInjectionDataStoreConfig) faultInjector {
-	methodFaultGenerators := make(map[string]faultGenerator, len(cfg.Methods))
-	for methodName, methodConfig := range cfg.Methods {
-		var faults []fault
-		for errName, errRate := range methodConfig.Errors {
-			faults = append(faults, newFault(errName, errRate, methodName))
-		}
-		methodFaultGenerators[methodName] = newMethodFaultGenerator(faults, methodConfig.Seed)
-	}
-	return func(target config.FaultInjectionTarget) *fault {
-		methodGenerator, ok := methodFaultGenerators[target.Method]
-		if !ok {
-			return nil
-		}
-		return methodGenerator.generate(target.Method)
-	}
-}
-
-// generate returns a fault from the first injector that chooses to inject one.
-// When this method returns nil, the persistence layer uses the real implementation.
+// generate returns a fault from the registry. When this method returns nil, the
+// persistence layer uses the real implementation.
 func (d *storeFaultInjector) generate(methodName string, requests ...any) *fault {
-	target := config.FaultInjectionTarget{
+	target := Target{
 		Store:  d.storeName,
 		Method: methodName,
 	}
 	if len(requests) > 0 {
 		target.Request = requests[0]
 	}
-	for _, injector := range d.injectors {
-		if f := injector(target); f != nil {
-			return f
-		}
-	}
-	return nil
+	return d.registry.Generate(target)
 }

--- a/tests/acquire_shard_test.go
+++ b/tests/acquire_shard_test.go
@@ -3,12 +3,15 @@ package tests
 import (
 	"context"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/faultinjection"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
 )
@@ -76,9 +79,9 @@ func (r *logRecorder) record(msg string, tags ...tag.Tag) {
 }
 
 // newEnv builds a logs channel + logRecorder and starts a dedicated single-shard
-// cluster wired to that recorder with the given fault injection config. The
+// cluster wired to that recorder with the given fault injection option. The
 // cluster is torn down automatically via t.Cleanup inside NewEnv.
-func (s *AcquireShardSuite) newEnv(fi *config.FaultInjection) chan logRecord {
+func (s *AcquireShardSuite) newEnv(faultOpt testcore.TestOption) chan logRecord {
 	// Server startup happens when the cluster is created, but the test doesn't
 	// listen on the log channel until afterward. So the buffer needs to be big
 	// enough to hold all server-startup logs, which are currently about 190 lines.
@@ -87,7 +90,7 @@ func (s *AcquireShardSuite) newEnv(fi *config.FaultInjection) chan logRecord {
 		s.T(),
 		testcore.WithLogger(newLogRecorder(logs)),
 		testcore.WithHistoryShardCount(1),
-		testcore.WithPersistenceFaultInjection(fi),
+		faultOpt,
 	)
 	return logs
 }
@@ -95,8 +98,13 @@ func (s *AcquireShardSuite) newEnv(fi *config.FaultInjection) chan logRecord {
 // TestOwnershipLost_DoesNotRetry verifies that we do not retry acquiring the shard
 // when we get an ownership lost error.
 func (s *AcquireShardSuite) TestOwnershipLost_DoesNotRetry() {
-	logs := s.newEnv((&config.FaultInjection{}).
-		WithError(config.ShardStoreName, "UpdateShard", "ShardOwnershipLost", 1.0))
+	reg := faultinjection.NewFaultRegistry()
+	logs := s.newEnv(testcore.InjectPersistenceFault(s.T(), reg,
+		func(faultinjection.Target) error {
+			return &persistence.ShardOwnershipLostError{Msg: "injected shard ownership lost"}
+		},
+		testcore.WithStore(config.ShardStoreName),
+		testcore.WithMethod("UpdateShard")))
 
 	ctx, cancel := context.WithTimeout(s.Context(), time.Second*10)
 	defer cancel()
@@ -130,8 +138,13 @@ func (s *AcquireShardSuite) TestOwnershipLost_DoesNotRetry() {
 // TestDeadlineExceeded_DoesRetry verifies that we do retry acquiring the shard when
 // we get a deadline exceeded error because that should be considered a transient error.
 func (s *AcquireShardSuite) TestDeadlineExceeded_DoesRetry() {
-	logs := s.newEnv((&config.FaultInjection{}).
-		WithError(config.ShardStoreName, "UpdateShard", "DeadlineExceeded", 1.0))
+	reg := faultinjection.NewFaultRegistry()
+	logs := s.newEnv(testcore.InjectPersistenceFault(s.T(), reg,
+		func(faultinjection.Target) error {
+			return context.DeadlineExceeded
+		},
+		testcore.WithStore(config.ShardStoreName),
+		testcore.WithMethod("UpdateShard")))
 
 	ctx, cancel := context.WithTimeout(s.Context(), time.Second*10)
 	defer cancel()
@@ -160,11 +173,20 @@ func (s *AcquireShardSuite) TestDeadlineExceeded_DoesRetry() {
 
 // TestEventualSuccess verifies that we eventually succeed in acquiring the shard when
 // we get a deadline exceeded error followed by a successful acquire shard call.
-// To make this test deterministic, the fault injection method seed is fixed.
+// The fault fails exactly the first UpdateShard call and then lets subsequent calls
+// through, so the test is deterministic without relying on a fixed RNG seed.
 func (s *AcquireShardSuite) TestEventualSuccess() {
-	logs := s.newEnv((&config.FaultInjection{}).
-		WithError(config.ShardStoreName, "UpdateShard", "DeadlineExceeded", 0.5).
-		WithMethodSeed(config.ShardStoreName, "UpdateShard", 43))
+	reg := faultinjection.NewFaultRegistry()
+	var updateShardCalls atomic.Int32
+	logs := s.newEnv(testcore.InjectPersistenceFault(s.T(), reg,
+		func(faultinjection.Target) error {
+			if updateShardCalls.Add(1) == 1 {
+				return context.DeadlineExceeded
+			}
+			return nil
+		},
+		testcore.WithStore(config.ShardStoreName),
+		testcore.WithMethod("UpdateShard")))
 
 	ctx, cancel := context.WithTimeout(s.Context(), time.Second*10)
 	defer cancel()

--- a/tests/testcore/persistence_fault.go
+++ b/tests/testcore/persistence_fault.go
@@ -1,0 +1,92 @@
+package testcore
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/persistence/faultinjection"
+)
+
+// PersistenceFault determines whether a fault should be injected for a persistence
+// operation. It receives the target (data store, method, and request) and returns the
+// error to inject, or nil to let the operation reach the real data store.
+type PersistenceFault func(target faultinjection.Target) error
+
+// PersistenceFaultOption configures the behavior of [InjectPersistenceFault].
+type PersistenceFaultOption func(*persistenceFaultOptions)
+
+type persistenceFaultOptions struct {
+	store  config.DataStoreName
+	method string
+}
+
+// WithStore filters faults to only fire for the given data store,
+// e.g. config.ShardStoreName.
+func WithStore(store config.DataStoreName) PersistenceFaultOption {
+	return func(o *persistenceFaultOptions) {
+		o.store = store
+	}
+}
+
+// WithMethod filters faults to only fire for the given data store method,
+// e.g. "UpdateShard".
+func WithMethod(method string) PersistenceFaultOption {
+	return func(o *persistenceFaultOptions) {
+		o.method = method
+	}
+}
+
+// InjectPersistenceFault registers a programmable persistence fault on reg and returns a
+// [TestOption] that wires reg into the test cluster (via the existing config.Injector
+// seam). The fault function decides which operations fail and with what error; the
+// optional WithStore/WithMethod filters narrow the target. The test fails during cleanup
+// if the fault never fired.
+//
+// Because the fault is wired through config, it is active from the first persistence call
+// (including server startup), so it can also exercise startup-time paths such as shard
+// acquisition.
+//
+// Example:
+//
+//	reg := faultinjection.NewFaultRegistry()
+//	env := testcore.NewEnv(s.T(),
+//	    testcore.WithHistoryShardCount(1),
+//	    testcore.InjectPersistenceFault(s.T(), reg,
+//	        func(faultinjection.Target) error {
+//	            return &persistence.ShardOwnershipLostError{Msg: "injected fault"}
+//	        },
+//	        testcore.WithStore(config.ShardStoreName),
+//	        testcore.WithMethod("UpdateShard")))
+func InjectPersistenceFault(t testing.TB, reg *faultinjection.FaultRegistry, fault PersistenceFault, opts ...PersistenceFaultOption) TestOption {
+	t.Helper()
+
+	var options persistenceFaultOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	var fired atomic.Bool
+	reg.RegisterCallback(func(target faultinjection.Target) error {
+		if options.store != "" && target.Store != options.store {
+			return nil
+		}
+		if options.method != "" && target.Method != options.method {
+			return nil
+		}
+		if injectedErr := fault(target); injectedErr != nil {
+			fired.Store(true)
+			t.Logf("Persistence fault injection fired: %s.%s", target.Store, target.Method)
+			return injectedErr
+		}
+		return nil
+	})
+
+	t.Cleanup(func() {
+		if !fired.Load() {
+			t.Error("persistence fault injection was registered but never fired - the fault was never injected")
+		}
+	})
+
+	return WithPersistenceFaultInjection(&config.FaultInjection{Injector: reg.Inject})
+}


### PR DESCRIPTION
## What

Makes persistence fault injection **programmable** through a small `FaultRegistry`, reusing the existing `config.FaultInjection.Injector` seam so there is **no new plumbing** (no test hook, no factory-signature or fx changes).

- **`FaultRegistry`** (`registry.go`) is the generic core: an ordered, thread-safe set of callbacks. Its `Inject` method matches `config.FaultInjector`, so a registry drops straight into `config.FaultInjection.Injector`.
- **Config becomes a special case.** The store wrapper now backs itself with a `FaultRegistry` and registers the per-method YAML config and the runtime injector as ordinary callbacks. `NewFaultInjectionDatastoreFactory` / `newStoreFaultInjector` signatures are unchanged.
- **`testcore.InjectPersistenceFault`** registers a programmable, filtered fault (`WithStore` / `WithMethod`) and returns a `TestOption` that wires the registry via the existing `WithPersistenceFaultInjection`. It asserts the fault fired. Because it flows through config, it's active from the first persistence call, so it can exercise **startup-time** paths like shard acquisition.

## Example / motivation

Converts `acquire_shard_test.go`. `TestEventualSuccess` previously faked determinism with a `0.5` error rate plus a hardcoded RNG seed:

```go
// before
logs := s.newEnv((&config.FaultInjection{}).
    WithError(config.ShardStoreName, "UpdateShard", "DeadlineExceeded", 0.5).
    WithMethodSeed(config.ShardStoreName, "UpdateShard", 43))
```

```go
// after — deterministic, no magic seed
reg := faultinjection.NewFaultRegistry()
var updateShardCalls atomic.Int32
logs := s.newEnv(testcore.InjectPersistenceFault(s.T(), reg,
    func(faultinjection.Target) error {
        if updateShardCalls.Add(1) == 1 {
            return context.DeadlineExceeded
        }
        return nil
    },
    testcore.WithStore(config.ShardStoreName),
    testcore.WithMethod("UpdateShard")))
```

## Notes

- The programmable seam returns an `error`; the YAML-only `ExecuteAndTimeout` ("run then fail") semantic remains available through config.
- `make unit-test` for the faultinjection package passes; `TestAcquireShardSuite` passes against a real cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)