### PR TITLE
scheduler: treat non-positive catchup window as unset (CHASM)

### DIFF
--- a/chasm/lib/scheduler/generator_tasks_test.go
+++ b/chasm/lib/scheduler/generator_tasks_test.go
@@ -403,7 +403,7 @@ func TestGeneratorTask_CatchupWindowResolvesNonPositiveToDefault(t *testing.T) {
 			} else {
 				require.Less(t, len(invoker.BufferedStarts), 5,
 					"a below-min window is clamped to MinCatchupWindow and should drop older actions")
-				require.Greater(t, sched.Info.MissedCatchupWindow, int64(0),
+				require.Positive(t, sched.Info.MissedCatchupWindow,
 					"actions older than the enforced window should be counted as missed")
 			}
 		})

--- a/chasm/lib/scheduler/generator_tasks_test.go
+++ b/chasm/lib/scheduler/generator_tasks_test.go
@@ -17,6 +17,7 @@ import (
 	"go.temporal.io/server/service/history/tasks"
 	legacyscheduler "go.temporal.io/server/service/worker/scheduler"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -350,4 +351,61 @@ func TestUnpause_ResumesProcessing(t *testing.T) {
 	// side-effect tasks to start workflows. Without the fix, nothing runs.
 	require.True(t, env.HasTask(&tasks.ChasmTask{}, chasm.TaskScheduledTimeImmediate),
 		"schedule should resume processing after unpause")
+}
+
+// A nil or non-positive catchup window means "unset" and resolves to the
+// default (large) window, so automated actions that were missed while the
+// schedule was behind are caught up rather than dropped. Only a positive value
+// below the minimum is clamped up to MinCatchupWindow, which the final case
+// exercises to prove the window is actually enforced (so the "nothing missed"
+// result for the non-positive cases is meaningful, not a dead counter).
+//
+// With the default tweakables (MinCatchupWindow=10s, DefaultCatchupWindow=365d),
+// rewinding the high water mark by 5 intervals yields 5 automated actions each
+// 1-5 minutes old. Under the fix, a zero/negative window resolves to the default
+// and all 5 are caught up; under the old behavior it resolved to the 10s minimum
+// and all 5 would be dropped.
+func TestGeneratorTask_CatchupWindowResolvesNonPositiveToDefault(t *testing.T) {
+	cases := []struct {
+		name          string
+		catchupWindow *durationpb.Duration
+		caughtUp      bool // true: default window catches up all actions; false: window is enforced
+	}{
+		{"nil resolves to default", nil, true},
+		{"zero resolves to default", durationpb.New(0), true},
+		{"negative resolves to default", durationpb.New(-5 * time.Second), true},
+		{"below-min positive is clamped and enforced", durationpb.New(time.Second), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newTestEnv(t)
+			handler := newGeneratorHandler(env)
+
+			ctx := env.MutableContext()
+			sched := env.Scheduler
+			sched.Schedule.Policies.CatchupWindow = tc.catchupWindow
+
+			generator := sched.Generator.Get(ctx)
+			invoker := sched.Invoker.Get(ctx)
+
+			// Rewind the high water mark so the range yields 5 automated actions,
+			// each between 1 and 5 minutes old (all older than MinCatchupWindow).
+			hwm := ctx.Now(generator).UTC().Add(-defaultInterval * 5)
+			generator.LastProcessedTime = timestamppb.New(hwm)
+
+			require.NoError(t, handler.Execute(ctx, generator, chasm.TaskAttributes{}, &schedulerpb.GeneratorTask{}))
+
+			if tc.caughtUp {
+				require.Len(t, invoker.BufferedStarts, 5,
+					"a non-positive window should resolve to the default and catch up every missed action")
+				require.Zero(t, sched.Info.MissedCatchupWindow,
+					"no action should be missed when the window resolves to the default")
+			} else {
+				require.Less(t, len(invoker.BufferedStarts), 5,
+					"a below-min window is clamped to MinCatchupWindow and should drop older actions")
+				require.Greater(t, sched.Info.MissedCatchupWindow, int64(0),
+					"actions older than the enforced window should be counted as missed")
+			}
+		})
+	}
 }

--- a/chasm/lib/scheduler/spec_processor.go
+++ b/chasm/lib/scheduler/spec_processor.go
@@ -241,10 +241,10 @@ func (s *SpecProcessorImpl) checkNextScheduleResult(
 
 func catchupWindow(s *Scheduler, tweakables Tweakables) time.Duration {
 	cw := s.Schedule.GetPolicies().GetCatchupWindow()
-	if cw == nil {
+	// Only a positive value below the minimum is clamped up
+	if cw == nil || cw.AsDuration() <= 0 {
 		return tweakables.DefaultCatchupWindow
 	}
-
 	return max(cw.AsDuration(), tweakables.MinCatchupWindow)
 }
 

--- a/chasm/lib/scheduler/spec_processor_test.go
+++ b/chasm/lib/scheduler/spec_processor_test.go
@@ -157,6 +157,41 @@ func TestProcessTimeRange_CatchupWindow(t *testing.T) {
 	require.Len(t, res.BufferedStarts, 5)
 }
 
+// A nil or zero catchup window means "not specified" and resolves to the 1-year
+// default, not the 10s minimum. Actions older than the minimum but well within
+// the default must still be buffered, not dropped as "missed catchup window".
+func TestProcessTimeRange_CatchupWindowNilOrZeroUsesDefault(t *testing.T) {
+	cases := []struct {
+		name          string
+		catchupWindow *durationpb.Duration
+	}{
+		{"nil", nil},
+		{"zero", durationpb.New(0)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newTestEnv(t)
+			ctx := chasm.NewMutableContext(context.Background(), env.Node)
+
+			sch := defaultSchedule()
+			sch.Policies.CatchupWindow = tc.catchupWindow
+			sched, err := scheduler.NewScheduler(ctx, namespace, namespaceID, scheduleID, sch, nil)
+			require.NoError(t, err)
+			processor := newTestSpecProcessor(env.Ctrl)
+
+			// Five actions, each 1..5 minutes old, all older than the 10s minimum.
+			end := time.Now()
+			start := end.Add(-5 * defaultInterval)
+
+			res, err := processor.ProcessTimeRange(sched, start, end, enumspb.SCHEDULE_OVERLAP_POLICY_UNSPECIFIED, sched.WorkflowID(), "", false, nil)
+			require.NoError(t, err)
+			// Resolved to the 1-year default, so none are past the window: all are
+			// buffered. Under the bug (zero => clamped to 10s), all five would drop.
+			require.Len(t, res.BufferedStarts, 5)
+		})
+	}
+}
+
 func TestProcessTimeRange_Limit(t *testing.T) {
 	env := newTestEnv(t)
 	ctx := chasm.NewMutableContext(context.Background(), env.Node)


### PR DESCRIPTION
## What changed?
In the CHASM (V2) scheduler, treat a non-positive (zero or negative) schedule
catchup window the same as unset: return the default catchup window instead of
clamping up to the minimum. Only a positive value below the minimum is clamped up.
Change is in `chasm/lib/scheduler/spec_processor.go` (`catchupWindow`).

## Why?
Previously only a `nil` catchup window fell back to the default; a zero or
negative value slipped through to `max(cw, MinCatchupWindow)` and was silently
clamped up to the minimum. A non-positive value is effectively "unset/invalid"
and should resolve to the default.

## How did you test it?
- [x] built
- [x] covered by existing tests
- [x] added new unit test(s)

Added a component level functional test (Generator) for now. 

Ideally, we'd add a server-level test that creates schedules with different catchup window values and verifies the result via DescribeSchedule. However, that doesn't currently validate the intended behavior because the describe logic overwrites the catchup window in some cases (see: https://github.com/temporalio/temporal/blob/main/chasm/lib/scheduler/scheduler.go#L697-L699). Will work on this fix next as it needs more plumbing and also add this specific test in the next PR.

## Potential risks
Behavior change for any schedule that explicitly sets a catchup window <= 0:
it now resolves to DefaultCatchupWindow instead of MinCatchupWindow.