### PR TITLE
Reject nil patch in PatchSchedule

### DIFF
--- a/service/frontend/errors.go
+++ b/service/frontend/errors.go
@@ -45,6 +45,7 @@ var (
 	errIDReusePolicyNotAllowed                            = serviceerror.NewInvalidArgument("Scheduled workflow must not contain WorkflowIDReusePolicy")
 	errBatchJobIDNotSet                                   = serviceerror.NewInvalidArgument("JobId is not set on request.")
 	errScheduleIDNotSet                                   = serviceerror.NewInvalidArgument("ScheduleId is not set on request.")
+	errSchedulePatchNotSet                                = serviceerror.NewInvalidArgument("Patch is not set on request.")
 	errIdentityNotSet                                     = serviceerror.NewInvalidArgument("Identity is not set on request.")
 	errMigrationTargetNotSet                              = serviceerror.NewInvalidArgument("Target is not set on request.")
 	errNamespaceNotSet                                    = serviceerror.NewInvalidArgument("Namespace is not set on request.")

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -4777,6 +4777,10 @@ func (wh *WorkflowHandler) PatchSchedule(
 		return nil, errRequestNotSet
 	}
 
+	if request.GetPatch() == nil {
+		return nil, errSchedulePatchNotSet
+	}
+
 	if !wh.config.EnableSchedules(request.Namespace) {
 		return nil, errSchedulesNotAllowed
 	}

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -5084,6 +5084,19 @@ func (s *WorkflowHandlerSuite) TestPatchSchedule_ValidationAndErrors() {
 		s.Equal(errRequestNotSet, err)
 	})
 
+	s.Run("nil patch should return error", func() {
+		request := &workflowservice.PatchScheduleRequest{
+			Namespace:  s.testNamespace.String(),
+			ScheduleId: "test-schedule",
+			Patch:      nil,
+		}
+
+		resp, err := wh.PatchSchedule(ctx, request)
+		s.Nil(resp)
+		var invalidArgErr *serviceerror.InvalidArgument
+		s.ErrorAs(err, &invalidArgErr)
+	})
+
 	s.Run("schedules disabled should return error", func() {
 		disabledConfig := s.newConfig()
 		disabledConfig.EnableSchedules = dc.GetBoolPropertyFnFilteredByNamespace(false)


### PR DESCRIPTION
## Description

`WorkflowHandler.PatchSchedule` validated only the top-level request, the `frontend.enableSchedules` gate and the request-ID length before reading `request.Patch.Pause` and `request.Patch.Unpause` as direct field accesses, so a well-formed `PatchScheduleRequest` that simply omits the `patch` message nil-dereferenced inside the handler. The deferred `log.CapturePanic` swallowed the crash and returned `serviceerror.Internal` plus a stack-trace error log, meaning plain malformed client input was reported as a server fault and could be retried indefinitely at the cost of repeated panic construction and log volume.

This adds an explicit `request.GetPatch() == nil` guard right after the top-level nil check that returns a new `errSchedulePatchNotSet` InvalidArgument error, matching the existing `err*NotSet` conventions in `service/frontend/errors.go`.

Note the line immediately below the panicking one already used the safe getter (`request.Patch.GetTriggerImmediately()`), so the handler was internally inconsistent.

## Reviewable decision

The guard is placed **before** the `EnableSchedules` gate, as the finding recommends. Consequence: a nil-patch request in a namespace with schedules disabled now returns `InvalidArgument` rather than `errSchedulesNotAllowed`. No existing test depends on that combination, but if you'd prefer the feature gate to win, moving the guard one block down is a one-line change.

## Testing

New `nil patch should return error` subtest in the existing `TestPatchSchedule_ValidationAndErrors` table. Committed before the fix; on unfixed code it fails with the nil deref recovered into `Internal`:

```
--- FAIL: TestWorkflowHandlerSuite/TestPatchSchedule_ValidationAndErrors/nil_patch_should_return_error
    Error: Should be in error chain:
      expected: *serviceerror.InvalidArgument
      in chain: "runtime error: invalid memory address or nil pointer dereference" (*serviceerror.Internal)
```

`go test -tags test_dep ./service/frontend/... -count=1` passes.

Source: SCH-060, Schedule V2 Bug Review (P1, Confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
