### PR TITLE
Keep an unstarted backfill's start boundary inclusive across V2-to-V1 migration

### DIFF
--- a/chasm/lib/scheduler/backfiller_tasks.go
+++ b/chasm/lib/scheduler/backfiller_tasks.go
@@ -165,7 +165,7 @@ func (b *BackfillerTaskHandler) processBackfill(
 	} else {
 		// On the first attempt, the start time is set slightly behind in order to make
 		// the backfill start time inclusive.
-		startTime = request.GetStartTime().AsTime().Add(-1 * time.Millisecond)
+		startTime = request.GetStartTime().AsTime().Add(-schedulescommon.InclusiveBackfillStartOffset)
 	}
 	endTime := request.GetEndTime().AsTime()
 	specResult, err := b.specProcessor.ProcessTimeRange(

--- a/chasm/lib/scheduler/migration/backfill_boundary_test.go
+++ b/chasm/lib/scheduler/migration/backfill_boundary_test.go
@@ -1,0 +1,134 @@
+package migration_test
+
+// This file lives in the external test package (migration_test) because it
+// imports the V1 scheduler package to compile a real schedule spec, and
+// service/worker/scheduler imports the migration package.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	schedulepb "go.temporal.io/api/schedule/v1"
+	workflowpb "go.temporal.io/api/workflow/v1"
+	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
+	"go.temporal.io/server/chasm/lib/scheduler/migration"
+	legacyscheduler "go.temporal.io/server/service/worker/scheduler"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// newHourlyTestSchedule returns a schedule whose spec matches exactly on the
+// hour, so that a backfill starting at 12:00:00Z has a matching action at its
+// own start boundary.
+func newHourlyTestSchedule() *schedulepb.Schedule {
+	return &schedulepb.Schedule{
+		Spec: &schedulepb.ScheduleSpec{
+			Interval: []*schedulepb.IntervalSpec{{Interval: durationpb.New(time.Hour)}},
+		},
+		Action: &schedulepb.ScheduleAction{
+			Action: &schedulepb.ScheduleAction_StartWorkflow{
+				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+					WorkflowId:   "test-wf",
+					WorkflowType: &commonpb.WorkflowType{Name: "test-wf-type"},
+				},
+			},
+		},
+		Policies: &schedulepb.SchedulePolicies{CatchupWindow: durationpb.New(time.Hour)},
+		State:    &schedulepb.ScheduleState{},
+	}
+}
+
+// nextTimeAfter compiles the schedule's spec with the real V1 spec builder and
+// returns the first matching time strictly after the given cursor. This is the
+// same search V1's processBackfills performs over OngoingBackfills.
+func nextTimeAfter(t *testing.T, schedule *schedulepb.Schedule, after time.Time) time.Time {
+	t.Helper()
+	specBuilder := legacyscheduler.NewSpecBuilder(func() int { return 0 }, func() int { return 0 })
+	cspec, err := specBuilder.NewCompiledSpec(schedule.Spec)
+	require.NoError(t, err)
+	res, err := cspec.GetNextTime("", after)
+	require.NoError(t, err)
+	return res.Nominal
+}
+
+// TestCHASMToLegacyBackfillStartBoundary verifies that a V2-to-V1 migration
+// preserves the inclusivity of a backfill's start boundary. V1 stores an
+// already-shifted cursor in OngoingBackfills (patch intake subtracts 1ms) and
+// then searches strictly after it, so an unstarted backfiller must be exported
+// pre-shifted or the action landing exactly on the backfill start is skipped.
+func TestCHASMToLegacyBackfillStartBoundary(t *testing.T) {
+	backfillStart := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	backfillEnd := time.Date(2024, 6, 1, 18, 0, 0, 0, time.UTC)
+	migrationTime := time.Date(2024, 6, 1, 19, 0, 0, 0, time.UTC)
+	schedule := newHourlyTestSchedule()
+
+	newSchedulerState := func() *schedulerpb.SchedulerState {
+		return &schedulerpb.SchedulerState{
+			Namespace:     "ns",
+			NamespaceId:   "ns-id",
+			ScheduleId:    "sched-id",
+			ConflictToken: 1,
+			Schedule:      schedule,
+			Info:          &schedulepb.ScheduleInfo{},
+		}
+	}
+	newRangeBackfiller := func(attempt int64, lastProcessed *timestamppb.Timestamp) map[string]*schedulerpb.BackfillerState {
+		return map[string]*schedulerpb.BackfillerState{
+			"bf-1": {
+				BackfillId:        "bf-1",
+				Attempt:           attempt,
+				LastProcessedTime: lastProcessed,
+				Request: &schedulerpb.BackfillerState_BackfillRequest{
+					BackfillRequest: &schedulepb.BackfillRequest{
+						StartTime:     timestamppb.New(backfillStart),
+						EndTime:       timestamppb.New(backfillEnd),
+						OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("unstarted backfiller keeps its start boundary inclusive", func(t *testing.T) {
+		// Attempt == 0: CHASM has not processed anything yet, so the stored
+		// request still carries the user's inclusive start time.
+		backfillers := newRangeBackfiller(0, nil)
+
+		args := migration.CHASMToLegacyStartScheduleArgs(
+			newSchedulerState(), nil, nil, backfillers, nil, nil, nil, migrationTime)
+
+		require.Len(t, args.State.OngoingBackfills, 1)
+		cursor := args.State.OngoingBackfills[0].StartTime.AsTime()
+
+		// Boundary semantics: V1 searches strictly after the stored cursor, so
+		// the 12:00 action must still be generated.
+		require.Equal(t, backfillStart, nextTimeAfter(t, schedule, cursor),
+			"the action at the backfill start boundary must not be skipped after migration")
+
+		// V1's own patch intake would have stored 11:59:59.999 for a backfill
+		// requested to start (inclusively) at 12:00:00.
+		require.Equal(t, backfillStart.Add(-time.Millisecond), cursor,
+			"unstarted backfill must be exported with V1's inclusive-boundary offset applied")
+	})
+
+	t.Run("attempted backfiller keeps its exclusive watermark", func(t *testing.T) {
+		// Attempt > 0: LastProcessedTime is a watermark for work already done,
+		// so V1 must resume strictly after it. No offset may be applied here.
+		lastProcessed := timestamppb.New(backfillStart)
+		backfillers := newRangeBackfiller(2, lastProcessed)
+
+		args := migration.CHASMToLegacyStartScheduleArgs(
+			newSchedulerState(), nil, nil, backfillers, nil, nil, nil, migrationTime)
+
+		require.Len(t, args.State.OngoingBackfills, 1)
+		cursor := args.State.OngoingBackfills[0].StartTime.AsTime()
+
+		require.Equal(t, backfillStart, cursor,
+			"an attempted backfiller must export its watermark unshifted")
+		require.Equal(t, backfillStart.Add(time.Hour), nextTimeAfter(t, schedule, cursor),
+			"an already-processed action must not be regenerated after migration")
+	})
+}

--- a/chasm/lib/scheduler/migration/migration.go
+++ b/chasm/lib/scheduler/migration/migration.go
@@ -468,7 +468,18 @@ func convertBackfillersCHASMToLegacy(
 		if request := backfiller.GetBackfillRequest(); request != nil {
 			backfill := common.CloneProto(request)
 			if backfiller.GetAttempt() > 0 && backfiller.GetLastProcessedTime() != nil {
+				// The backfiller has already made progress, so its watermark is the
+				// last time processed. V1 resumes strictly after the stored cursor,
+				// which matches V2's own advance-by-next convention: no offset here.
 				backfill.StartTime = common.CloneProto(backfiller.GetLastProcessedTime())
+			} else if start := backfill.GetStartTime(); start != nil {
+				// The backfiller hasn't run yet, so the request still carries the
+				// user's inclusive start time. V2 applies the inclusive-boundary
+				// offset when the backfiller first runs, but V1 expects it to have
+				// been applied already at patch intake. Apply it now, or V1 would
+				// skip an action landing exactly on the backfill's start.
+				backfill.StartTime = timestamppb.New(
+					start.AsTime().Add(-schedulescommon.InclusiveBackfillStartOffset))
 			}
 			ongoing = append(ongoing, backfill)
 			continue

--- a/common/schedules/backfill.go
+++ b/common/schedules/backfill.go
@@ -1,0 +1,17 @@
+package schedules
+
+import "time"
+
+// InclusiveBackfillStartOffset is subtracted from a backfill request's start time
+// before it is used as the cursor of a next-time search.
+//
+// Both scheduler implementations search for matching times strictly *after* a
+// cursor, but a backfill's start time is inclusive: an action landing exactly on
+// the requested start must be generated. Shifting the cursor back by this offset
+// encodes that inclusivity.
+//
+// V1 applies the offset once, at patch intake, and stores the shifted value in
+// InternalState.OngoingBackfills. V2 applies it when a Backfiller runs for the
+// first time (Attempt == 0), leaving the stored request untouched. Migration
+// between the two must therefore translate between those representations.
+const InclusiveBackfillStartOffset = time.Millisecond

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -25,6 +25,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/primitives/timestamp"
+	schedulescommon "go.temporal.io/server/common/schedules"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/util"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -481,7 +482,7 @@ func (s *scheduler) processPatch(patch *schedulepb.SchedulePatch) {
 		// the start time of the backfill matched the schedule's spec, it would
 		// not be executed. This new version makes it inclusive instead.
 		if s.hasMinVersion(InclusiveBackfillStartTime) {
-			startTime := timestamp.TimeValue(bfr.GetStartTime()).Add(-1 * time.Millisecond)
+			startTime := timestamp.TimeValue(bfr.GetStartTime()).Add(-schedulescommon.InclusiveBackfillStartOffset)
 			bfr.StartTime = timestamppb.New(startTime)
 		}
 		if s.hasMinVersion(IncrementalBackfill) {


### PR DESCRIPTION
## Description

V1 encodes a backfill's inclusive start boundary by subtracting one millisecond at patch intake and storing that already-shifted value in `InternalState.OngoingBackfills`, because `processBackfills` searches strictly *after* the stored cursor. CHASM instead keeps the user's unmodified `BackfillRequest.StartTime` and applies the same offset transiently, at processing time, on a backfiller's first attempt only.

`convertBackfillersCHASMToLegacy` bridged only the progressed case: an `Attempt > 0` backfiller correctly exports its `LastProcessedTime` watermark, but an `Attempt == 0` backfiller was cloned unchanged. A schedule action landing exactly on the requested backfill start was therefore silently dropped after an admin rollback migration.

This applies V1's inclusive-boundary offset when exporting an unstarted range and leaves the watermark path alone.

## Note on scope

The previously duplicated `-1 * time.Millisecond` literal is lifted into `schedules.InclusiveBackfillStartOffset` in a new leaf package `common/schedules`, so the V1 workflow, the CHASM backfiller task and the migration converter all reference one definition instead of a third copy. That puts `service/worker/scheduler/workflow.go` in the diff — it is a literal-to-constant swap with an identical value, so it cannot change replay behaviour, but reviewers may prefer the constant extraction split out or folded into an existing package.

On `hasMinVersion(InclusiveBackfillStartTime)`: no version gate is needed. Migrated backfills never traverse `processPatch` — migration writes `State.OngoingBackfills` directly into `StartScheduleArgs` — so intake normalization is skipped entirely and the converter is the only place the pre-shift can happen. Separately, a freshly started migrated workflow reads `CurrentTweakablePolicies.Version` (12) which is well past `InclusiveBackfillStartTime` (4), so inclusive semantics are the contract there regardless.

## Testing

New `backfill_boundary_test.go` asserts **boundary semantics**, not just the exported timestamp: it compiles a real hourly spec and checks that a next-time search after the exported cursor returns the boundary instant. Committed before the fix; on unfixed code:

```
--- FAIL: TestCHASMToLegacyBackfillStartBoundary/unstarted_backfiller_keeps_its_start_boundary_inclusive
    expected: 2024-06-01 12:00:00 +0000 UTC
    actual  : 2024-06-01 13:00:00 +0000 UTC
    the action at the backfill start boundary must not be skipped after migration
```

An `Attempt > 0` control passed before and after, proving the watermark cursor still resumes exclusively. No `Attempt == 0` backfill case existed anywhere in `migration_test.go` before this.

Source: SCH-020, Schedule V2 Bug Review (P1, Confirmed, Supported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
