### PR TITLE
Cover terminated workflow completion status mapping in the CHASM scheduler

### DIFF
--- a/chasm/lib/scheduler/scheduler_nexus_completion_test.go
+++ b/chasm/lib/scheduler/scheduler_nexus_completion_test.go
@@ -253,6 +253,92 @@ func TestHandleNexusCompletion_Canceled(t *testing.T) {
 	executeNexusCompletion(t, tc)
 }
 
+// TestHandleNexusCompletion_Terminated verifies that a terminated workflow
+// completion is recorded with TERMINATED status, not FAILED. The completion
+// carries no explicit status: executionStatusFromFailure reconstructs it from
+// the failure's FailureInfo shape, and a missing Failure_TerminatedFailureInfo
+// case there silently degrades to the FAILED default.
+func TestHandleNexusCompletion_Terminated(t *testing.T) {
+	tc := nexusCompletionTestCase{
+		name: "terminated completion",
+		setupInvoker: func(invoker *scheduler.Invoker) {
+			invoker.BufferedStarts = []*schedulespb.BufferedStart{
+				{
+					RequestId:  "req-1",
+					WorkflowId: "wf-1",
+					RunId:      "run-1",
+					Attempt:    1,
+					ActualTime: timestamppb.New(time.Now().Add(-1 * time.Minute)),
+					StartTime:  timestamppb.New(time.Now().Add(-30 * time.Second)),
+				},
+			}
+		},
+		completion: &persistencespb.ChasmNexusCompletion{
+			RequestId: "req-1",
+			Outcome: &persistencespb.ChasmNexusCompletion_Failure{
+				Failure: &failurepb.Failure{
+					Message: "workflow terminated",
+					FailureInfo: &failurepb.Failure_TerminatedFailureInfo{
+						TerminatedFailureInfo: &failurepb.TerminatedFailureInfo{},
+					},
+				},
+			},
+			CloseTime: timestamppb.New(time.Now()),
+		},
+		expectPaused: false,
+		expectStatus: enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED,
+	}
+
+	executeNexusCompletion(t, tc)
+}
+
+// TestHandleNexusCompletion_TerminatedDoesNotPauseOnFailure pins the current
+// pause-on-failure policy: countsAsFailureForPause treats only FAILED and
+// TIMED_OUT as failures, so terminating a run of a PauseOnFailure schedule --
+// a routine operator action, not an application failure -- must leave the
+// schedule running and its notes untouched. Companion to
+// TestCanceledWorkflowDoesNotPauseByDefault in pause_on_cancel_test.go.
+func TestHandleNexusCompletion_TerminatedDoesNotPauseOnFailure(t *testing.T) {
+	tc := nexusCompletionTestCase{
+		name: "terminated completion with pause on failure",
+		setupInvoker: func(invoker *scheduler.Invoker) {
+			invoker.BufferedStarts = []*schedulespb.BufferedStart{
+				{
+					RequestId:  "req-1",
+					WorkflowId: "wf-1",
+					RunId:      "run-1",
+					Attempt:    1,
+					ActualTime: timestamppb.New(time.Now().Add(-1 * time.Minute)),
+					StartTime:  timestamppb.New(time.Now().Add(-30 * time.Second)),
+				},
+			}
+		},
+		setupScheduler: func(sched *scheduler.Scheduler) {
+			sched.Schedule.Policies.PauseOnFailure = true
+		},
+		completion: &persistencespb.ChasmNexusCompletion{
+			RequestId: "req-1",
+			Outcome: &persistencespb.ChasmNexusCompletion_Failure{
+				Failure: &failurepb.Failure{
+					Message: "workflow terminated",
+					FailureInfo: &failurepb.Failure_TerminatedFailureInfo{
+						TerminatedFailureInfo: &failurepb.TerminatedFailureInfo{},
+					},
+				},
+			},
+			CloseTime: timestamppb.New(time.Now()),
+		},
+		expectPaused: false,
+		expectStatus: enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED,
+		validateScheduler: func(t *testing.T, sched *scheduler.Scheduler, _ chasm.Context) {
+			require.Empty(t, sched.Schedule.State.Notes,
+				"a terminated run must not write pause notes on a PauseOnFailure schedule")
+		},
+	}
+
+	executeNexusCompletion(t, tc)
+}
+
 // Deferred starts (Attempt==-1, set by ProcessBuffer when overlap policy
 // holds them back) must be re-enabled when a running workflow completes.
 // recordCompletedAction flips -1 to 0; the immediate ProcessBufferTask


### PR DESCRIPTION
## Description

**This is test-only coverage for an already-shipped fix, not a new fix.**

Commit 9180ddc88 (#11163) added the `Failure_TerminatedFailureInfo` case to `executionStatusFromFailure`, so a terminated V2-scheduled workflow is recorded as `WORKFLOW_EXECUTION_STATUS_TERMINATED` rather than falling through to the `FAILED` default, and it made `countsAsFailureForPause` deliberately exclude TERMINATED so terminating a run cannot silently pause a `PauseOnFailure` schedule.

Both behaviours were only exercised by the functional test `testPauseOnFailureIgnoresCancelTerminate` in `tests/schedule_test.go`, which needs a live server and detects a regression as a polling timeout. No unit test in `chasm/lib/scheduler` asserted either.

This adds two cases to `scheduler_nexus_completion_test.go`, beside the existing canceled-mapping case and using the same harness:

- the recorded status on the completed `BufferedStart` is `TERMINATED`
- a terminated completion leaves a `PauseOnFailure` schedule unpaused with empty notes

## Proof the tests bite

Deleting the mapping case locally makes both fail immediately:

```
--- FAIL: TestHandleNexusCompletion_Terminated
    expected: 5   actual: 3          (TERMINATED vs FAILED)
--- FAIL: TestHandleNexusCompletion_TerminatedDoesNotPauseOnFailure
    expected: false  actual: true    (spurious pause)
```

The sabotage was reverted before committing; the diff touches exactly one file and no production code.

## Unrelated finding, flagged not fixed

`Tweakables.CanceledTerminatedCountAsFailures` in `chasm/lib/scheduler/config.go` is read by no V2 code path — `countsAsFailureForPause` takes only a status and has no access to config. V1 has an identically-named field on its own `Tweakables` that *is* honoured (`service/worker/scheduler/workflow.go`), so V2 silently ignores an operator who sets it. Neither is exposed as a dynamic config key today. Left alone: it's a product decision (keep V1's configurability, or retire the knob?).

Source: SCH-014, Schedule V2 Bug Review (P1, Needs review, Qualified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
