### PR TITLE
fix: Make InvokerMaxStartAttempts an inclusive bound

### DIFF
--- a/chasm/lib/scheduler/invoker_execute_task_test.go
+++ b/chasm/lib/scheduler/invoker_execute_task_test.go
@@ -1,6 +1,7 @@
 package scheduler_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -18,6 +19,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/testing/mockapi/workflowservicemock/v1"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -92,16 +94,7 @@ func runExecuteTestCase(t *testing.T, env *invokerExecuteTestEnv, c *executeTest
 	// Set LastProcessedTime to current time to ensure time checks pass.
 	invoker.LastProcessedTime = timestamppb.New(env.TimeSource.Now())
 
-	// Set expectations. The read and update calls will also update the Scheduler
-	// component, within the same transition.
-	env.ExpectReadComponent(ctx, invoker)
-	env.ExpectUpdateComponent(ctx, invoker)
-
-	// Create engine context for side effect task execution.
-	engineCtx := env.EngineContext()
-	err := env.handler.Execute(engineCtx, chasm.ComponentRef{}, chasm.TaskAttributes{}, &schedulerpb.InvokerExecuteTask{})
-	require.NoError(t, err)
-	require.NoError(t, env.CloseTransaction())
+	executeTaskOnce(t, env, ctx, invoker)
 
 	// Validate the results.
 	// BufferedStarts now includes both pending and running starts (they're kept after starting).
@@ -126,6 +119,25 @@ func runExecuteTestCase(t *testing.T, env *invokerExecuteTestEnv, c *executeTest
 	if c.ValidateInvoker != nil {
 		c.ValidateInvoker(t, invoker, env)
 	}
+}
+
+// executeTaskOnce runs a single InvokerExecuteTask pass against the live
+// Invoker and commits the resulting transition. Shared by the single-pass
+// table driver (runExecuteTestCase) and by tests that need to drive several
+// Execute passes in sequence.
+func executeTaskOnce(t *testing.T, env *invokerExecuteTestEnv, ctx chasm.MutableContext, invoker *scheduler.Invoker) {
+	t.Helper()
+
+	// Set expectations. The read and update calls will also update the Scheduler
+	// component, within the same transition.
+	env.ExpectReadComponent(ctx, invoker)
+	env.ExpectUpdateComponent(ctx, invoker)
+
+	// Create engine context for side effect task execution.
+	engineCtx := env.EngineContext()
+	err := env.handler.Execute(engineCtx, chasm.ComponentRef{}, chasm.TaskAttributes{}, &schedulerpb.InvokerExecuteTask{})
+	require.NoError(t, err)
+	require.NoError(t, env.CloseTransaction())
 }
 
 // Execute success case.
@@ -317,6 +329,9 @@ func TestExecuteTask_AlreadyStarted(t *testing.T) {
 }
 
 // A buffered start fails from having exceeded its maximum retry limit.
+// InvokerMaxStartAttempts is an inclusive bound on the 1-based attempt number,
+// so the first attempt that is refused locally (zero RPCs, start dropped) is
+// the one past the limit.
 func TestExecuteTask_ExceedsMaxAttempts(t *testing.T) {
 	env := newInvokerExecuteTestEnv(t)
 	startTime := timestamppb.New(env.TimeSource.Now())
@@ -328,7 +343,7 @@ func TestExecuteTask_ExceedsMaxAttempts(t *testing.T) {
 			Manual:        false,
 			RequestId:     "req",
 			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
-			Attempt:       scheduler.InvokerMaxStartAttempts,
+			Attempt:       scheduler.InvokerMaxStartAttempts + 1,
 		},
 	}
 
@@ -338,6 +353,127 @@ func TestExecuteTask_ExceedsMaxAttempts(t *testing.T) {
 		ExpectedRunningWorkflows: 0,
 		ExpectedActionCount:      0,
 	})
+}
+
+// Boundary control: a start sitting at exactly InvokerMaxStartAttempts is still
+// within budget, so its RPC is issued and a success there is recorded normally.
+func TestExecuteTask_SucceedsOnFinalAttempt(t *testing.T) {
+	env := newInvokerExecuteTestEnv(t)
+	startTime := timestamppb.New(env.TimeSource.Now())
+
+	env.mockFrontendClient.EXPECT().
+		StartWorkflowExecution(gomock.Any(), startWorkflowExecutionRequestIDMatches("final")).
+		Times(1).
+		Return(&workflowservice.StartWorkflowExecutionResponse{RunId: "run-id"}, nil)
+
+	runExecuteTestCase(t, env, &executeTestCase{
+		InitialBufferedStarts: []*schedulespb.BufferedStart{{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			Manual:        false,
+			RequestId:     "final",
+			WorkflowId:    "wf",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			Attempt:       scheduler.InvokerMaxStartAttempts,
+		}},
+		ExpectedBufferedStarts:   1,
+		ExpectedRunningWorkflows: 1,
+		ExpectedActionCount:      1,
+	})
+}
+
+// InvokerMaxStartAttempts is documented as the maximum number of start
+// attempts, so a continuously retryable start must produce exactly that many
+// StartWorkflowExecution RPCs before it is dropped. Attempts are 1-based:
+// recordProcessBufferResult readies a start at Attempt 1, so the bound has to
+// be inclusive for the constant to mean what it says.
+//
+// This drives the real task order for a single automatic start - ProcessBuffer
+// promotes it, then ProcessBuffer (advancing the high-water mark past each
+// persisted backoff) and Execute alternate - and counts the RPCs.
+func TestExecuteTask_RetriesUpToMaxStartAttempts(t *testing.T) {
+	env := newInvokerExecuteTestEnv(t)
+	processBufferHandler := newProcessBufferHandler(env.testEnv)
+
+	var rpcCount int
+	env.mockFrontendClient.EXPECT().
+		StartWorkflowExecution(gomock.Any(), startWorkflowExecutionRequestIDMatches("retry")).
+		AnyTimes().
+		DoAndReturn(func(_ context.Context, _ *workflowservice.StartWorkflowExecutionRequest, _ ...grpc.CallOption) (*workflowservice.StartWorkflowExecutionResponse, error) {
+			rpcCount++
+			return nil, serviceerror.NewDeadlineExceeded("transient")
+		})
+
+	// Seed a single automatic, unprocessed buffered start (Attempt == 0), as the
+	// Generator would.
+	startTime := timestamppb.New(env.TimeSource.Now())
+	ctx := env.MutableContext()
+	invoker := env.Scheduler.Invoker.Get(ctx)
+	invoker.BufferedStarts = []*schedulespb.BufferedStart{{
+		NominalTime:   startTime,
+		ActualTime:    startTime,
+		DesiredTime:   startTime,
+		Manual:        false,
+		RequestId:     "retry",
+		WorkflowId:    "wf",
+		OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+	}}
+	invoker.LastProcessedTime = timestamppb.New(env.TimeSource.Now())
+	require.NoError(t, env.CloseTransaction())
+
+	// Attempt numbers observed at the head of each Execute pass.
+	var attempted []int64
+	maxIterations := 2*scheduler.InvokerMaxStartAttempts + 5
+	iterations := 0
+	for ; iterations < maxIterations; iterations++ {
+		starts := env.Scheduler.Invoker.Get(env.ReadContext()).GetBufferedStarts()
+		if len(starts) == 0 {
+			// The start was dropped: the retry budget is spent.
+			break
+		}
+
+		// Advance the framework clock to the persisted backoff deadline, which is
+		// where addTasks scheduled the next ProcessBuffer timer. This has to happen
+		// before the transaction's context is created, since chasm.Context.Now is
+		// captured at construction - as it is when the real timer task fires at its
+		// deadline. BackoffTime is framework-clock derived (see
+		// TestExecuteTask_BackoffUsesFrameworkClock), so the EventTimeSource is the
+		// only clock involved.
+		if backoffTime := starts[0].GetBackoffTime(); backoffTime != nil &&
+			backoffTime.AsTime().After(env.TimeSource.Now()) {
+			env.TimeSource.Update(backoffTime.AsTime())
+		}
+
+		ctx := env.MutableContext()
+		invoker := env.Scheduler.Invoker.Get(ctx)
+		require.NoError(t, processBufferHandler.Execute(ctx, invoker, chasm.TaskAttributes{}, &schedulerpb.InvokerProcessBufferTask{}))
+		require.NoError(t, env.CloseTransaction())
+
+		ctx = env.MutableContext()
+		invoker = env.Scheduler.Invoker.Get(ctx)
+		if starts := invoker.GetBufferedStarts(); len(starts) > 0 {
+			attempted = append(attempted, starts[0].GetAttempt())
+		}
+		executeTaskOnce(t, env, ctx, invoker)
+	}
+	require.Less(t, iterations, maxIterations, "retry loop never terminated")
+
+	require.Equal(t, scheduler.InvokerMaxStartAttempts, rpcCount,
+		"a continuously retryable start must issue exactly InvokerMaxStartAttempts StartWorkflowExecution RPCs")
+
+	// The executed attempt numbers must be a contiguous 1..InvokerMaxStartAttempts
+	// run, followed by the local refusal pass that drops the start.
+	var expectedAttempts []int64
+	for i := int64(1); i <= scheduler.InvokerMaxStartAttempts+1; i++ {
+		expectedAttempts = append(expectedAttempts, i)
+	}
+	require.Equal(t, expectedAttempts, attempted)
+
+	ctx = env.MutableContext()
+	invoker = env.Scheduler.Invoker.Get(ctx)
+	require.Empty(t, invoker.GetBufferedStarts(), "the exhausted start must be dropped from the buffer")
+	require.Equal(t, int64(0), env.Scheduler.Info.ActionCount, "no action was ever started")
 }
 
 // An execute task runs with cancels/terminations queued, which fail to execute.

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -81,7 +81,13 @@ const (
 	// Lower bound for the deadline in which buffered actions are dropped.
 	startWorkflowMinDeadline = 5 * time.Second
 
-	// Upper bound on how many times starting an individual buffered action should be retried.
+	// InvokerMaxStartAttempts is the maximum number of StartWorkflowExecution
+	// RPCs issued for an individual buffered action, counting the first call.
+	// Attempt numbers are 1-based: recordProcessBufferResult readies a start at
+	// Attempt 1, and each retryable failure increments it. The bound is
+	// therefore inclusive - a start is refused locally (and dropped) only once
+	// its Attempt exceeds this value - so a value of 10 permits ten start RPCs,
+	// i.e. the initial call plus nine retries.
 	InvokerMaxStartAttempts = 10 // TODO - dial this up/remove it
 )
 
@@ -622,7 +628,9 @@ func (h *InvokerExecuteTaskHandler) startWorkflow(
 ) error {
 	requestSpec := scheduler.GetSchedule().GetAction().GetStartWorkflow()
 
-	if start.Attempt >= InvokerMaxStartAttempts {
+	// Inclusive bound: Attempt is 1-based, so the attempt numbered
+	// InvokerMaxStartAttempts is the last one that gets an RPC.
+	if start.Attempt > InvokerMaxStartAttempts {
 		return errRetryLimitExceeded
 	}
 


### PR DESCRIPTION
## Description

`InvokerMaxStartAttempts` is named and commented as "the maximum number of start attempts", but the invoker numbers the first executable attempt 1 (`recordProcessBufferResult` promotes a ready buffered start from 0 to 1) and `startWorkflow` rejected `Attempt >= InvokerMaxStartAttempts` before rate limiting and before building the RPC. So a continuously retryable start issued only **nine** `StartWorkflowExecution` calls, and the tenth execute pass merely ran the local check, classified `errRetryLimitExceeded` as non-retryable and dropped the start.

This changes the check to `Attempt > InvokerMaxStartAttempts` so the constant means ten actual start RPCs (initial call plus nine retries), and rewrites the constant's comment to state the 1-based, inclusive semantics explicitly so it cannot drift again. Production diff is two hunks.

## Reviewable decision

This is the deliberately chosen half of a two-way decision. The alternative is to keep the exclusive comparison and instead rename/redocument the constant as an exclusive attempt-number ceiling (nine RPCs). I picked the inclusive reading because the name and comment both say "maximum number of start attempts" and matching the name is less surprising than redocumenting it as a ceiling. Flipping to the other reading is a one-line change plus test updates; there is no product-level contract pinning the exact count.

## Backoff impact

`applyBackoff` still keys off the attempt that just failed, so the per-attempt schedule is unchanged — only one more term exists at the tail. Under production config (initial 1s, max 60s) the RPC envelope for an exhausted start goes from ~243s to ~303s, with the drop pass moving from ~303s to ~363s: one extra RPC, no re-shaped curve. The rate-limiter reservation is still taken only at `Attempt == 1`, so the extra attempt consumes no extra permit.

## Testing

New `TestExecuteTask_RetriesUpToMaxStartAttempts` drives one automatic buffered start through the real ProcessBuffer/Execute task order against an always-retryable frontend. Committed before the fix; on unfixed code:

```
--- FAIL: TestExecuteTask_RetriesUpToMaxStartAttempts
    expected: 10  actual: 9
    a continuously retryable start must issue exactly InvokerMaxStartAttempts StartWorkflowExecution RPCs
--- FAIL: TestExecuteTask_SucceedsOnFinalAttempt
    missing call(s) to StartWorkflowExecution(StartWorkflowExecutionRequest{RequestId: "final"})
```

Boundary controls included: success at the limit is recorded, an entry past the limit makes zero RPCs. The test also asserts the executed attempt sequence is exactly `1..11` and that `ActionCount` stays 0.

Independent of the temporal-deadline gap (SCH-055), which is fixed separately.

Source: SCH-039, Schedule V2 Bug Review (P1, Needs review, Supported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
