### PR TITLE
Reject malformed interval and phase duration protobufs at schedule intake

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -979,6 +979,13 @@ of Timeout and if no activity is seen even after that the connection is closed.`
 		true,
 		`FrontendEnableSchedules enables schedule-related RPCs in the frontend`,
 	)
+	FrontendEnforceScheduleDurationValidation = NewGlobalBoolSetting(
+		"frontend.enforceScheduleDurationValidation",
+		true,
+		`FrontendEnforceScheduleDurationValidation rejects CreateSchedule/UpdateSchedule requests whose
+interval or phase durations are not valid google.protobuf.Duration messages. When disabled, such
+requests are logged and allowed through instead of being rejected.`,
+	)
 	// [cleanup-wv-pre-release]
 	EnableDeployments = NewNamespaceBoolSetting(
 		"system.enableDeployments",

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -165,6 +165,9 @@ type Config struct {
 
 	// Enable schedule-related RPCs
 	EnableSchedules dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	// Reject schedules whose interval/phase durations are malformed protobufs. When
+	// disabled, such schedules are logged and allowed through.
+	EnforceScheduleDurationValidation dynamicconfig.BoolPropertyFn
 
 	// Enable CHASM tree infrastructure
 	EnableChasm dynamicconfig.BoolPropertyFnWithNamespaceFilter
@@ -363,6 +366,7 @@ func NewConfig(
 		MaxFairnessWeightOverrideConfigLimit: dynamicconfig.MatchingMaxFairnessKeyWeightOverrides.Get(dc),
 
 		EnableSchedules:                      dynamicconfig.FrontendEnableSchedules.Get(dc),
+		EnforceScheduleDurationValidation:    dynamicconfig.FrontendEnforceScheduleDurationValidation.Get(dc),
 		EnableChasm:                          dynamicconfig.EnableChasm.Get(dc),
 		EnableCHASMSchedulerCreation:         dynamicconfig.EnableCHASMSchedulerCreation.Get(dc),
 		CHASMSchedulerCreationRolloutPercent: dynamicconfig.CHASMSchedulerCreationRolloutPercent.Get(dc),

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -6854,9 +6854,41 @@ func (wh *WorkflowHandler) validateSchedulePayloadSize(
 	)
 }
 
+// validateScheduleIntervalDurations rejects interval and phase durations that are not
+// valid google.protobuf.Duration messages (mismatched seconds/nanos signs, nanos outside
+// the +/-999999999 range, or seconds outside the +/-10000 year range).
+//
+// The spec compiler only looks at the *normalized* Go duration, so malformed wire values
+// such as {seconds: 2, nanos: -1} pass its semantic interval/phase checks and get
+// persisted verbatim. This check lives at frontend intake rather than in the compiler
+// because the compiler also runs inside the V1 scheduler workflow, where a new error
+// would change replay behavior for already-persisted schedules.
+//
+// Malformed durations are rejected outright rather than canonicalized or capped:
+// timestamp.ValidateAndCapProtoDuration mutates large values, which would be a silent
+// behavior change for schedule specs.
+func validateScheduleIntervalDurations(spec *schedulepb.ScheduleSpec) error {
+	for _, interval := range spec.GetInterval() {
+		if d := interval.GetInterval(); d != nil {
+			if err := d.CheckValid(); err != nil {
+				return fmt.Errorf("interval is not a valid duration: %w", err)
+			}
+		}
+		if d := interval.GetPhase(); d != nil {
+			if err := d.CheckValid(); err != nil {
+				return fmt.Errorf("phase is not a valid duration: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
 func (wh *WorkflowHandler) canonicalizeScheduleSpec(schedule *schedulepb.Schedule) error {
 	if schedule.Spec == nil {
 		schedule.Spec = &schedulepb.ScheduleSpec{}
+	}
+	if err := validateScheduleIntervalDurations(schedule.Spec); err != nil {
+		return serviceerror.NewInvalidArgumentf("Invalid schedule spec: %v", err)
 	}
 	compiledSpec, err := wh.scheduleSpecBuilder.NewCompiledSpec(schedule.Spec)
 	if err != nil {

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -6854,19 +6854,6 @@ func (wh *WorkflowHandler) validateSchedulePayloadSize(
 	)
 }
 
-// validateScheduleIntervalDurations rejects interval and phase durations that are not
-// valid google.protobuf.Duration messages (mismatched seconds/nanos signs, nanos outside
-// the +/-999999999 range, or seconds outside the +/-10000 year range).
-//
-// The spec compiler only looks at the *normalized* Go duration, so malformed wire values
-// such as {seconds: 2, nanos: -1} pass its semantic interval/phase checks and get
-// persisted verbatim. This check lives at frontend intake rather than in the compiler
-// because the compiler also runs inside the V1 scheduler workflow, where a new error
-// would change replay behavior for already-persisted schedules.
-//
-// Malformed durations are rejected outright rather than canonicalized or capped:
-// timestamp.ValidateAndCapProtoDuration mutates large values, which would be a silent
-// behavior change for schedule specs.
 func validateScheduleIntervalDurations(spec *schedulepb.ScheduleSpec) error {
 	for _, interval := range spec.GetInterval() {
 		if d := interval.GetInterval(); d != nil {
@@ -6888,7 +6875,11 @@ func (wh *WorkflowHandler) canonicalizeScheduleSpec(schedule *schedulepb.Schedul
 		schedule.Spec = &schedulepb.ScheduleSpec{}
 	}
 	if err := validateScheduleIntervalDurations(schedule.Spec); err != nil {
-		return serviceerror.NewInvalidArgumentf("Invalid schedule spec: %v", err)
+		if wh.config.EnforceScheduleDurationValidation() {
+			return serviceerror.NewInvalidArgumentf("Invalid schedule spec: %v", err)
+		}
+		wh.throttledLogger.Warn("Accepting schedule spec with malformed duration: validation enforcement is disabled",
+			tag.Error(err))
 	}
 	compiledSpec, err := wh.scheduleSpecBuilder.NewCompiledSpec(schedule.Spec)
 	if err != nil {

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -5266,14 +5266,26 @@ func (s *WorkflowHandlerSuite) TestPatchSchedule_ValidationAndErrors() {
 // carry (10000 years). Anything beyond it fails durationpb's CheckValid.
 const maxProtoDurationSeconds = int64(315576000000)
 
+// newScheduleSpecHandler builds the minimum WorkflowHandler that canonicalizeScheduleSpec
+// needs: a config, a spec builder, and a logger for the non-enforcing path. configure is
+// nil to exercise the shipped dynamic config defaults.
+func newScheduleSpecHandler(configure func(*Config)) *WorkflowHandler {
+	config := NewConfig(dc.NewNoopCollection(), numHistoryShards)
+	if configure != nil {
+		configure(config)
+	}
+	return &WorkflowHandler{
+		config:              config,
+		throttledLogger:     log.NewNoopLogger(),
+		scheduleSpecBuilder: scheduler.NewSpecBuilder(func() int { return 0 }, func() int { return 0 }),
+	}
+}
+
 // Regression test for SCH-057. Malformed interval/phase duration protobufs (mismatched
 // seconds/nanos signs, nanos outside the protobuf range, seconds outside the protobuf
 // range) normalize to Go durations that satisfy the semantic interval checks, so schedule
 // intake used to accept them and persist the invalid wire form verbatim.
-func (s *WorkflowHandlerSuite) TestCanonicalizeScheduleSpec_IntervalDurationValidation() {
-	config := s.newConfig()
-	wh := s.getWorkflowHandler(config)
-
+func TestCanonicalizeScheduleSpec_IntervalDurationValidation(t *testing.T) {
 	testCases := []struct {
 		name        string
 		interval    *durationpb.Duration
@@ -5367,7 +5379,8 @@ func (s *WorkflowHandlerSuite) TestCanonicalizeScheduleSpec_IntervalDurationVali
 	}
 
 	for _, tc := range testCases {
-		s.Run(tc.name, func() {
+		t.Run(tc.name, func(t *testing.T) {
+			wh := newScheduleSpecHandler(nil)
 			schedule := &schedulepb.Schedule{
 				Spec: &schedulepb.ScheduleSpec{
 					Interval: []*schedulepb.IntervalSpec{{
@@ -5379,12 +5392,12 @@ func (s *WorkflowHandlerSuite) TestCanonicalizeScheduleSpec_IntervalDurationVali
 
 			err := wh.canonicalizeScheduleSpec(schedule)
 			if tc.errContains == "" {
-				s.NoError(err)
+				require.NoError(t, err)
 				return
 			}
 			var invalidArgument *serviceerror.InvalidArgument
-			s.ErrorAs(err, &invalidArgument)
-			s.Contains(err.Error(), tc.errContains)
+			require.ErrorAs(t, err, &invalidArgument)
+			require.Contains(t, err.Error(), tc.errContains)
 		})
 	}
 }
@@ -5392,7 +5405,7 @@ func (s *WorkflowHandlerSuite) TestCanonicalizeScheduleSpec_IntervalDurationVali
 // The duration validation is enforced by default, but operators can turn enforcement off
 // with frontend.enforceScheduleDurationValidation. With it off, a malformed duration is
 // logged and allowed through, and the spec still compiles on its normalized value.
-func (s *WorkflowHandlerSuite) TestCanonicalizeScheduleSpec_DurationValidationKillSwitch() {
+func TestCanonicalizeScheduleSpec_DurationValidationKillSwitch(t *testing.T) {
 	testCases := []struct {
 		name string
 		// configure is nil when the case exercises the shipped default.
@@ -5419,12 +5432,8 @@ func (s *WorkflowHandlerSuite) TestCanonicalizeScheduleSpec_DurationValidationKi
 	}
 
 	for _, tc := range testCases {
-		s.Run(tc.name, func() {
-			config := s.newConfig()
-			if tc.configure != nil {
-				tc.configure(config)
-			}
-			wh := s.getWorkflowHandler(config)
+		t.Run(tc.name, func(t *testing.T) {
+			wh := newScheduleSpecHandler(tc.configure)
 
 			schedule := &schedulepb.Schedule{
 				Spec: &schedulepb.ScheduleSpec{
@@ -5437,13 +5446,13 @@ func (s *WorkflowHandlerSuite) TestCanonicalizeScheduleSpec_DurationValidationKi
 			err := wh.canonicalizeScheduleSpec(schedule)
 			if tc.errContains != "" {
 				var invalidArgument *serviceerror.InvalidArgument
-				s.ErrorAs(err, &invalidArgument)
-				s.Contains(err.Error(), tc.errContains)
+				require.ErrorAs(t, err, &invalidArgument)
+				require.Contains(t, err.Error(), tc.errContains)
 				return
 			}
-			s.NoError(err)
+			require.NoError(t, err)
 			// Canonicalization still ran, on the malformed duration's normalized value.
-			s.Equal(2*time.Second-time.Nanosecond,
+			require.Equal(t, 2*time.Second-time.Nanosecond,
 				schedule.GetSpec().GetInterval()[0].GetInterval().AsDuration())
 		})
 	}

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -5379,13 +5379,12 @@ func (s *WorkflowHandlerSuite) TestCanonicalizeScheduleSpec_IntervalDurationVali
 
 			err := wh.canonicalizeScheduleSpec(schedule)
 			if tc.errContains == "" {
-				assert.NoError(s.T(), err)
+				s.NoError(err)
 				return
 			}
 			var invalidArgument *serviceerror.InvalidArgument
-			if assert.ErrorAs(s.T(), err, &invalidArgument) {
-				assert.Contains(s.T(), err.Error(), tc.errContains)
-			}
+			s.ErrorAs(err, &invalidArgument)
+			s.Contains(err.Error(), tc.errContains)
 		})
 	}
 }

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -5390,6 +5390,42 @@ func (s *WorkflowHandlerSuite) TestCanonicalizeScheduleSpec_IntervalDurationVali
 	}
 }
 
+// The duration validation is enforced by default, but operators can turn enforcement off
+// with frontend.enforceScheduleDurationValidation. With it off, a malformed duration is
+// logged and allowed through, and the spec still compiles on its normalized value.
+func (s *WorkflowHandlerSuite) TestCanonicalizeScheduleSpec_DurationValidationKillSwitch() {
+	malformedSchedule := func() *schedulepb.Schedule {
+		return &schedulepb.Schedule{
+			Spec: &schedulepb.ScheduleSpec{
+				Interval: []*schedulepb.IntervalSpec{{
+					Interval: &durationpb.Duration{Seconds: 2, Nanos: -1},
+				}},
+			},
+		}
+	}
+
+	s.Run("enforced by default", func() {
+		wh := s.getWorkflowHandler(s.newConfig())
+
+		err := wh.canonicalizeScheduleSpec(malformedSchedule())
+		var invalidArgument *serviceerror.InvalidArgument
+		s.ErrorAs(err, &invalidArgument)
+		s.Contains(err.Error(), "interval is not a valid duration")
+	})
+
+	s.Run("enforcement disabled", func() {
+		config := s.newConfig()
+		config.EnforceScheduleDurationValidation = dc.GetBoolPropertyFn(false)
+		wh := s.getWorkflowHandler(config)
+
+		schedule := malformedSchedule()
+		s.NoError(wh.canonicalizeScheduleSpec(schedule))
+		// Canonicalization still ran, on the malformed duration's normalized value.
+		s.Equal(2*time.Second-time.Nanosecond,
+			schedule.GetSpec().GetInterval()[0].GetInterval().AsDuration())
+	})
+}
+
 // Regression test for SCH-057: CreateSchedule and UpdateSchedule must reject malformed
 // interval duration protobufs with InvalidArgument before either the V1 or the CHASM
 // backend is invoked.

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -5393,36 +5393,60 @@ func (s *WorkflowHandlerSuite) TestCanonicalizeScheduleSpec_IntervalDurationVali
 // with frontend.enforceScheduleDurationValidation. With it off, a malformed duration is
 // logged and allowed through, and the spec still compiles on its normalized value.
 func (s *WorkflowHandlerSuite) TestCanonicalizeScheduleSpec_DurationValidationKillSwitch() {
-	malformedSchedule := func() *schedulepb.Schedule {
-		return &schedulepb.Schedule{
-			Spec: &schedulepb.ScheduleSpec{
-				Interval: []*schedulepb.IntervalSpec{{
-					Interval: &durationpb.Duration{Seconds: 2, Nanos: -1},
-				}},
+	testCases := []struct {
+		name string
+		// configure is nil when the case exercises the shipped default.
+		configure   func(*Config)
+		errContains string
+	}{
+		{
+			name:        "enforced by default",
+			errContains: "interval is not a valid duration",
+		},
+		{
+			name: "enforcement explicitly enabled",
+			configure: func(c *Config) {
+				c.EnforceScheduleDurationValidation = dc.GetBoolPropertyFn(true)
 			},
-		}
+			errContains: "interval is not a valid duration",
+		},
+		{
+			name: "enforcement disabled",
+			configure: func(c *Config) {
+				c.EnforceScheduleDurationValidation = dc.GetBoolPropertyFn(false)
+			},
+		},
 	}
 
-	s.Run("enforced by default", func() {
-		wh := s.getWorkflowHandler(s.newConfig())
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			config := s.newConfig()
+			if tc.configure != nil {
+				tc.configure(config)
+			}
+			wh := s.getWorkflowHandler(config)
 
-		err := wh.canonicalizeScheduleSpec(malformedSchedule())
-		var invalidArgument *serviceerror.InvalidArgument
-		s.ErrorAs(err, &invalidArgument)
-		s.Contains(err.Error(), "interval is not a valid duration")
-	})
+			schedule := &schedulepb.Schedule{
+				Spec: &schedulepb.ScheduleSpec{
+					Interval: []*schedulepb.IntervalSpec{{
+						Interval: &durationpb.Duration{Seconds: 2, Nanos: -1},
+					}},
+				},
+			}
 
-	s.Run("enforcement disabled", func() {
-		config := s.newConfig()
-		config.EnforceScheduleDurationValidation = dc.GetBoolPropertyFn(false)
-		wh := s.getWorkflowHandler(config)
-
-		schedule := malformedSchedule()
-		s.NoError(wh.canonicalizeScheduleSpec(schedule))
-		// Canonicalization still ran, on the malformed duration's normalized value.
-		s.Equal(2*time.Second-time.Nanosecond,
-			schedule.GetSpec().GetInterval()[0].GetInterval().AsDuration())
-	})
+			err := wh.canonicalizeScheduleSpec(schedule)
+			if tc.errContains != "" {
+				var invalidArgument *serviceerror.InvalidArgument
+				s.ErrorAs(err, &invalidArgument)
+				s.Contains(err.Error(), tc.errContains)
+				return
+			}
+			s.NoError(err)
+			// Canonicalization still ran, on the malformed duration's normalized value.
+			s.Equal(2*time.Second-time.Nanosecond,
+				schedule.GetSpec().GetInterval()[0].GetInterval().AsDuration())
+		})
+	}
 }
 
 // Regression test for SCH-057: CreateSchedule and UpdateSchedule must reject malformed

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -5262,6 +5262,188 @@ func (s *WorkflowHandlerSuite) TestPatchSchedule_ValidationAndErrors() {
 	})
 }
 
+// maxProtoDurationSeconds is the largest seconds value a google.protobuf.Duration may
+// carry (10000 years). Anything beyond it fails durationpb's CheckValid.
+const maxProtoDurationSeconds = int64(315576000000)
+
+// Regression test for SCH-057. Malformed interval/phase duration protobufs (mismatched
+// seconds/nanos signs, nanos outside the protobuf range, seconds outside the protobuf
+// range) normalize to Go durations that satisfy the semantic interval checks, so schedule
+// intake used to accept them and persist the invalid wire form verbatim.
+func (s *WorkflowHandlerSuite) TestCanonicalizeScheduleSpec_IntervalDurationValidation() {
+	config := s.newConfig()
+	wh := s.getWorkflowHandler(config)
+
+	testCases := []struct {
+		name        string
+		interval    *durationpb.Duration
+		phase       *durationpb.Duration
+		errContains string
+	}{
+		// Valid boundary values: these must keep working, and must not be capped or
+		// otherwise rewritten by the validation.
+		{
+			name:     "minimum valid interval",
+			interval: &durationpb.Duration{Seconds: 1},
+		},
+		{
+			name:     "maximum valid nanos",
+			interval: &durationpb.Duration{Seconds: 1, Nanos: 999999999},
+		},
+		{
+			name:     "valid interval and phase",
+			interval: durationpb.New(time.Hour),
+			phase:    durationpb.New(30 * time.Minute),
+		},
+		{
+			name:     "maximum protobuf seconds",
+			interval: &durationpb.Duration{Seconds: maxProtoDurationSeconds},
+		},
+		{
+			name:     "zero phase is valid",
+			interval: durationpb.New(time.Hour),
+			phase:    &durationpb.Duration{},
+		},
+
+		// Malformed protobuf wire values.
+		{
+			name:        "interval with mismatched signs",
+			interval:    &durationpb.Duration{Seconds: 2, Nanos: -1},
+			errContains: "interval is not a valid duration",
+		},
+		{
+			name:        "interval with nanos at 1e9",
+			interval:    &durationpb.Duration{Nanos: 1000000000},
+			errContains: "interval is not a valid duration",
+		},
+		{
+			name:        "interval with seconds above the protobuf range",
+			interval:    &durationpb.Duration{Seconds: maxProtoDurationSeconds + 1},
+			errContains: "interval is not a valid duration",
+		},
+		{
+			name:        "interval with seconds below the protobuf range",
+			interval:    &durationpb.Duration{Seconds: -maxProtoDurationSeconds - 1},
+			errContains: "interval is not a valid duration",
+		},
+		{
+			name:        "phase with nanos at 1e9",
+			interval:    &durationpb.Duration{Seconds: 2},
+			phase:       &durationpb.Duration{Nanos: 1000000000},
+			errContains: "phase is not a valid duration",
+		},
+		{
+			name:        "phase with mismatched signs",
+			interval:    durationpb.New(10 * time.Second),
+			phase:       &durationpb.Duration{Seconds: 1, Nanos: -1},
+			errContains: "phase is not a valid duration",
+		},
+		{
+			name:        "phase with nanos at -1e9",
+			interval:    durationpb.New(10 * time.Second),
+			phase:       &durationpb.Duration{Nanos: -1000000000},
+			errContains: "phase is not a valid duration",
+		},
+
+		// Controls: well-formed protobufs that violate the pre-existing semantic checks
+		// must still be rejected with the pre-existing messages.
+		{
+			name:        "normalized interval below the minimum",
+			interval:    &durationpb.Duration{Nanos: 500000000},
+			errContains: "interval is too small",
+		},
+		{
+			name:        "negative phase",
+			interval:    durationpb.New(10 * time.Second),
+			phase:       &durationpb.Duration{Seconds: -1},
+			errContains: "phase is negative",
+		},
+		{
+			name:        "phase not less than interval",
+			interval:    durationpb.New(10 * time.Second),
+			phase:       durationpb.New(10 * time.Second),
+			errContains: "phase cannot be greater than Interval",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			schedule := &schedulepb.Schedule{
+				Spec: &schedulepb.ScheduleSpec{
+					Interval: []*schedulepb.IntervalSpec{{
+						Interval: tc.interval,
+						Phase:    tc.phase,
+					}},
+				},
+			}
+
+			err := wh.canonicalizeScheduleSpec(schedule)
+			if tc.errContains == "" {
+				assert.NoError(s.T(), err)
+				return
+			}
+			var invalidArgument *serviceerror.InvalidArgument
+			if assert.ErrorAs(s.T(), err, &invalidArgument) {
+				assert.Contains(s.T(), err.Error(), tc.errContains)
+			}
+		})
+	}
+}
+
+// Regression test for SCH-057: CreateSchedule and UpdateSchedule must reject malformed
+// interval duration protobufs with InvalidArgument before either the V1 or the CHASM
+// backend is invoked.
+func (s *WorkflowHandlerSuite) TestCreateUpdateSchedule_RejectsMalformedIntervalDuration() {
+	config := s.newConfig()
+	config.EnableSchedules = dc.GetBoolPropertyFnFilteredByNamespace(true)
+	wh := s.getWorkflowHandler(config)
+	ctx := context.Background()
+
+	// Mismatched seconds/nanos signs normalize to ~2s, and nanos=1e9 normalizes to 1s,
+	// so both satisfy the semantic interval/phase checks while being invalid on the wire.
+	malformedSchedule := func() *schedulepb.Schedule {
+		return &schedulepb.Schedule{
+			Spec: &schedulepb.ScheduleSpec{
+				Interval: []*schedulepb.IntervalSpec{{
+					Interval: &durationpb.Duration{Seconds: 2, Nanos: -1},
+					Phase:    &durationpb.Duration{Nanos: 1000000000},
+				}},
+			},
+		}
+	}
+
+	// No backend call is expected: the scheduler (CHASM) client is nil in this suite and
+	// the history client mock has no expectations registered, so reaching either backend
+	// fails the test.
+	s.Run("CreateSchedule", func() {
+		resp, err := wh.CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+			Namespace:  s.testNamespace.String(),
+			ScheduleId: "test-schedule",
+			Schedule:   malformedSchedule(),
+			RequestId:  uuid.NewString(),
+			Identity:   "test-identity",
+		})
+		s.Nil(resp)
+		var invalidArgument *serviceerror.InvalidArgument
+		s.ErrorAs(err, &invalidArgument)
+		s.Contains(err.Error(), "not a valid duration")
+	})
+
+	s.Run("UpdateSchedule", func() {
+		resp, err := wh.UpdateSchedule(ctx, &workflowservice.UpdateScheduleRequest{
+			Namespace:  s.testNamespace.String(),
+			ScheduleId: "test-schedule",
+			Schedule:   malformedSchedule(),
+			RequestId:  uuid.NewString(),
+			Identity:   "test-identity",
+		})
+		s.Nil(resp)
+		var invalidArgument *serviceerror.InvalidArgument
+		s.ErrorAs(err, &invalidArgument)
+		s.Contains(err.Error(), "not a valid duration")
+	})
+}
+
 func (s *WorkflowHandlerSuite) TestUpdateSchedule_ValidationAndErrors() {
 	config := s.newConfig()
 	config.EnableSchedules = dc.GetBoolPropertyFnFilteredByNamespace(true)


### PR DESCRIPTION
## Description

Adds a validation guard for schedule creation, affecting V1 and V2 schedules. Returns a 4XX error if fails. A killswitch is added in case this runs afoul of some behaviour change. 

Affects both Update and Create codepaths.

## Testing

Committed before the fix. The load-bearing failure is the last one — with a malformed spec, `CreateSchedule` ran past validation into `createScheduleWorkflow` and hit the V1 backend, proving the request reached persistence:

```
--- FAIL: .../interval_with_mismatched_signs        An error is expected but got nil
--- FAIL: .../interval_with_nanos_at_1e9            An error is expected but got nil
--- FAIL: .../phase_with_nanos_at_1e9               An error is expected but got nil
--- FAIL: TestCreateUpdateSchedule_RejectsMalformedIntervalDuration/CreateSchedule
    Unexpected call to *namespace.MockRegistry.GetNamespaceID([test-namespace])
```

All five valid-boundary rows and all three semantic controls (`interval is too small`, `phase is negative`, `phase cannot be greater than Interval`) passed before the fix and still pass, with unchanged messages.

Scope is deliberately limited to durations; `StartTime`/`EndTime` protobufs (SCH-058) were closed as no-action and are untouched.

Source: SCH-057, Schedule V2 Bug Review (P1, Confirmed, Supported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
