### PR TITLE
Forward VersioningOverride from a schedule action to the started workflow

### DIFF
--- a/chasm/lib/scheduler/invoker_execute_task_test.go
+++ b/chasm/lib/scheduler/invoker_execute_task_test.go
@@ -7,8 +7,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
+	deploymentpb "go.temporal.io/api/deployment/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
+	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/historyservicemock/v1"
 	schedulespb "go.temporal.io/server/api/schedule/v1"
@@ -17,6 +19,7 @@ import (
 	"go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/testing/mockapi/workflowservicemock/v1"
+	"go.temporal.io/server/common/testing/protorequire"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -781,6 +784,104 @@ func TestExecuteTask_BackoffUsesFrameworkClock(t *testing.T) {
 				"BackoffTime %v looks derived from wall clock, not framework clock", backoff)
 		},
 	})
+}
+
+// A VersioningOverride configured on the schedule's action must be forwarded to the
+// workflow the schedule starts, otherwise the started workflow silently falls back to
+// ordinary version routing.
+func TestExecuteTask_VersioningOverride(t *testing.T) {
+	env := newInvokerExecuteTestEnv(t)
+
+	override := &workflowpb.VersioningOverride{
+		Override: &workflowpb.VersioningOverride_Pinned{
+			Pinned: &workflowpb.VersioningOverride_PinnedOverride{
+				Behavior: workflowpb.VersioningOverride_PINNED_OVERRIDE_BEHAVIOR_PINNED,
+				Version: &deploymentpb.WorkerDeploymentVersion{
+					DeploymentName: "sched-deployment",
+					BuildId:        "sched-build-id",
+				},
+			},
+		},
+	}
+	env.Scheduler.GetSchedule().GetAction().GetStartWorkflow().VersioningOverride = override
+
+	capture := &startWorkflowExecutionRequestCapture{}
+	env.mockFrontendClient.EXPECT().
+		StartWorkflowExecution(gomock.Any(), capture).
+		Times(1).
+		Return(&workflowservice.StartWorkflowExecutionResponse{RunId: "run-id"}, nil)
+
+	startTime := timestamppb.New(env.TimeSource.Now())
+	runExecuteTestCase(t, env, &executeTestCase{
+		InitialBufferedStarts: []*schedulespb.BufferedStart{{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			RequestId:     "req1",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			Attempt:       1,
+		}},
+		ExpectedBufferedStarts:   1,
+		ExpectedRunningWorkflows: 1,
+		ExpectedActionCount:      1,
+		ValidateInvoker: func(t *testing.T, _ *scheduler.Invoker, _ *invokerExecuteTestEnv) {
+			require.NotNil(t, capture.Request)
+			protorequire.ProtoEqual(t, override, capture.Request.GetVersioningOverride())
+		},
+	})
+}
+
+// Control for TestExecuteTask_VersioningOverride: a schedule without an override must not
+// send a non-nil (e.g. empty) override on the start request.
+func TestExecuteTask_NoVersioningOverride(t *testing.T) {
+	env := newInvokerExecuteTestEnv(t)
+
+	capture := &startWorkflowExecutionRequestCapture{}
+	env.mockFrontendClient.EXPECT().
+		StartWorkflowExecution(gomock.Any(), capture).
+		Times(1).
+		Return(&workflowservice.StartWorkflowExecutionResponse{RunId: "run-id"}, nil)
+
+	startTime := timestamppb.New(env.TimeSource.Now())
+	runExecuteTestCase(t, env, &executeTestCase{
+		InitialBufferedStarts: []*schedulespb.BufferedStart{{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			RequestId:     "req1",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			Attempt:       1,
+		}},
+		ExpectedBufferedStarts:   1,
+		ExpectedRunningWorkflows: 1,
+		ExpectedActionCount:      1,
+		ValidateInvoker: func(t *testing.T, _ *scheduler.Invoker, _ *invokerExecuteTestEnv) {
+			require.NotNil(t, capture.Request)
+			require.Nil(t, capture.Request.GetVersioningOverride())
+		},
+	})
+}
+
+// startWorkflowExecutionRequestCapture is a gomock.Matcher that matches any
+// StartWorkflowExecutionRequest and records the last one it saw, so tests can assert on
+// individual fields after the call.
+type startWorkflowExecutionRequestCapture struct {
+	Request *workflowservice.StartWorkflowExecutionRequest
+}
+
+var _ gomock.Matcher = &startWorkflowExecutionRequestCapture{}
+
+func (c *startWorkflowExecutionRequestCapture) String() string {
+	return "any StartWorkflowExecutionRequest"
+}
+
+func (c *startWorkflowExecutionRequestCapture) Matches(x any) bool {
+	req, ok := x.(*workflowservice.StartWorkflowExecutionRequest)
+	if !ok {
+		return false
+	}
+	c.Request = req
+	return true
 }
 
 type startWorkflowExecutionRequestIDMatcher struct {

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -673,6 +673,7 @@ func (h *InvokerExecuteTaskHandler) startWorkflow(
 		WorkflowTaskTimeout:      requestSpec.WorkflowTaskTimeout,
 		WorkflowType:             requestSpec.WorkflowType,
 		Priority:                 requestSpec.Priority,
+		VersioningOverride:       requestSpec.VersioningOverride,
 		ContinuedFailure:         lastCompletionState.Failure,
 		LastCompletionResult: &commonpb.Payloads{
 			Payloads: lcr,

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -1530,6 +1530,7 @@ func (s *scheduler) startWorkflow(
 			ContinuedFailure:         continuedFailure,
 			UserMetadata:             newWorkflow.UserMetadata,
 			Priority:                 newWorkflow.Priority,
+			VersioningOverride:       newWorkflow.VersioningOverride,
 		},
 	}
 	for {

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	commonpb "go.temporal.io/api/common/v1"
+	deploymentpb "go.temporal.io/api/deployment/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
 	schedulepb "go.temporal.io/api/schedule/v1"
@@ -352,6 +353,61 @@ func (s *workflowSuite) TestStart() {
 		Action: action,
 	}, 2)
 	// two iterations to start one workflow: first will sleep, second will start and then sleep again
+	s.True(s.env.IsWorkflowCompleted())
+	s.True(workflow.IsContinueAsNewError(s.env.GetWorkflowError()))
+}
+
+// A VersioningOverride configured on the schedule's action must be forwarded to the
+// workflow the schedule starts, otherwise the started workflow silently falls back to
+// ordinary version routing.
+func (s *workflowSuite) TestStartVersioningOverride() {
+	override := &workflowpb.VersioningOverride{
+		Override: &workflowpb.VersioningOverride_Pinned{
+			Pinned: &workflowpb.VersioningOverride_PinnedOverride{
+				Behavior: workflowpb.VersioningOverride_PINNED_OVERRIDE_BEHAVIOR_PINNED,
+				Version: &deploymentpb.WorkerDeploymentVersion{
+					DeploymentName: "sched-deployment",
+					BuildId:        "sched-build-id",
+				},
+			},
+		},
+	}
+	action := s.defaultAction("myid")
+	action.Action.(*schedulepb.ScheduleAction_StartWorkflow).StartWorkflow.VersioningOverride = override
+
+	s.expectStart(func(req *schedulespb.StartWorkflowRequest) (*schedulespb.StartWorkflowResponse, error) {
+		protoassert.ProtoEqual(s.T(), override, req.Request.GetVersioningOverride())
+		return nil, nil
+	})
+
+	s.run(&schedulepb.Schedule{
+		Spec: &schedulepb.ScheduleSpec{
+			Interval: []*schedulepb.IntervalSpec{{
+				Interval: durationpb.New(55 * time.Minute),
+			}},
+		},
+		Action: action,
+	}, 2)
+	s.True(s.env.IsWorkflowCompleted())
+	s.True(workflow.IsContinueAsNewError(s.env.GetWorkflowError()))
+}
+
+// Control for TestStartVersioningOverride: a schedule without an override must not send
+// a non-nil (e.g. empty) override on the start request.
+func (s *workflowSuite) TestStartNoVersioningOverride() {
+	s.expectStart(func(req *schedulespb.StartWorkflowRequest) (*schedulespb.StartWorkflowResponse, error) {
+		s.Nil(req.Request.GetVersioningOverride())
+		return nil, nil
+	})
+
+	s.run(&schedulepb.Schedule{
+		Spec: &schedulepb.ScheduleSpec{
+			Interval: []*schedulepb.IntervalSpec{{
+				Interval: durationpb.New(55 * time.Minute),
+			}},
+		},
+		Action: s.defaultAction("myid"),
+	}, 2)
 	s.True(s.env.IsWorkflowCompleted())
 	s.True(workflow.IsContinueAsNewError(s.env.GetWorkflowError()))
 }


### PR DESCRIPTION
## Description

A schedule's action embeds `NewWorkflowExecutionInfo`, which carries `VersioningOverride`. CreateSchedule and UpdateSchedule accept and persist the field, and DescribeSchedule reflects it back, but neither scheduler backend forwarded it when the action fired: both `startWorkflow` in `service/worker/scheduler/workflow.go` (V1) and the CHASM invoker's start-request construction in `chasm/lib/scheduler/invoker_tasks.go` (V2) hand-build a `StartWorkflowExecutionRequest` and copy a long list of neighbouring fields — through `Priority` in both cases — while omitting the override.

Scheduled workflows therefore ran under ordinary worker-version routing regardless of the configured pin or auto-upgrade policy, with no error and no signal that the configuration was inert.

This copies the field in both builders, mirroring the existing `Priority` line. Production diff is two lines.

## ⚠️ Behaviour change worth a release note

Once the override reaches history, `startworkflow/api.go` runs `ValidateVersioningOverrideAndGetReactivationEligibility` on it — validation these starts previously never saw, because the field never arrived:

- A **structurally invalid** persisted override now yields `InvalidArgument`, which is non-retryable in both backends, so the start fails once and is dropped.
- A **valid but currently unroutable** pinned version (target not a member of the task queue) yields `FailedPrecondition`, which `IsServiceTransientError` treats as transient. V1 retries the local activity up to `ScheduleToCloseTimeout` (≤1h scheduled / 60s manual); V2 routes it to `RetryableStarts` bounded by `InvokerMaxStartAttempts`. Bounded in both, no runaway loop.

So **a schedule pinned to a decommissioned version will now start failing where it previously started workflows on the default version.** That is the correct meaning of pinning and is the point of the fix, but it is a visible change for anyone who set an override that has been silently inert.

## Why the V1 half is not behind a version gate

Two independent lines of evidence:

1. **Mechanism.** The start request is only ever an *input* to a local activity (`workflow.ExecuteLocalActivity(ctx, s.a.StartWorkflow, req)`). Local-activity inputs are not recorded in history and are not compared on replay — the SDK's `localActivityMarkerData` carries only `{ActivityID, ActivityType, ReplayTime, Attempt, Backoff}`, and `handleLocalActivityMarker` only panics on an `ActivityType` mismatch. Already-executed starts replay their recorded result; only not-yet-run starts see the new field. The `hasMinVersion` gates in this file all guard history-visible things instead — state mutations feeding later decisions, command/timer counts, or signal/query payload shape.
2. **Precedent.** Both prior additions to this exact struct literal landed ungated as bare one-liners: `Priority` in 554fd0039 (#7134) and `UserMetadata` in e0c72f162 (#6462). Neither bumped `SchedulerWorkflowVersion`.

Not a replay risk, but there is a mild *rollout* one: during a mixed-version deploy a schedule bouncing between old and new workers forwards the override on some fires and not others. Benign — each start is independent — and exactly what `Priority`/`UserMetadata` already do. `TestReplays` and `TestReplaysWithDynamicConfigChange` pass.

## One-time override semantics

The finding worried about what a one-time override means for a repeating schedule. Per the proto docs, `OneTime` is scoped to a *single workflow execution* — it routes tasks to the target version until a WFT completes there, then clears — not to the override's lifetime. There is no cross-execution state, so N scheduled starts each independently get their first WFT on the target and then revert. Coherent, not unsafe. Worth documenting for users that it is not "apply once then stop" at the schedule level. `Pinned` and `AutoUpgrade` are unambiguous. No variant is filtered.

## Frontend validation — deliberately not in this PR

`ValidateVersioningOverrideStructure` is the reusable validator, but it and the membership check are called from **history**, not the frontend — the direct `StartWorkflowExecution` frontend path does no override validation at all. Adding it to `validateStartWorkflowArgsForSchedule` would make schedules stricter than direct starts while duplicating a check history already performs. It is also breaking: invalid overrides are accepted and persisted today, so validation would start rejecting `UpdateSchedule` calls on schedules that currently round-trip fine, including no-op updates unrelated to versioning. If wanted, the clean version is structure-only (not membership, which needs a matching client and couples schedule writes to live deployment state), landed separately with a release note.

## Testing

One V1 test and one V2 invoker test with a distinctive pinned override, plus a no-override control in each proving neither backend started emitting a non-nil empty message. Committed before the fix; on unfixed code both show the field absent (`@invalid: true` is protocmp's rendering of the nil got-value):

```
--- FAIL: TestWorkflow/TestStartVersioningOverride       Proto mismatch (-want +got)
--- FAIL: TestExecuteTask_VersioningOverride             Proto mismatch (-want +got)
    - "pinned": {behavior:PINNED_OVERRIDE_BEHAVIOR_PINNED version:{build_id:"sched-build-id" ...}}
    + "@invalid": bool(true)
```

Affects both V1 and V2.

Source: SCH-037, Schedule V2 Bug Review (P1, Needs review, Supported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
