### PR TITLE
Dedupe CHASM scheduler Patch and Update by request ID

### DIFF
--- a/chasm/lib/scheduler/export_test.go
+++ b/chasm/lib/scheduler/export_test.go
@@ -47,6 +47,9 @@ func (i *Invoker) RunningWorkflowID(requestID string) string {
 // RecentActionCount exposes the completed-retention limit for tests.
 const RecentActionCount = recentActionCount
 
+// MaxRecentMutationRequestIDs exposes the mutation dedup window size for tests.
+const MaxRecentMutationRequestIDs = maxRecentMutationRequestIDs
+
 // ApplyCompletedRetention exposes applyCompletedRetention for tests.
 func (i *Invoker) ApplyCompletedRetention() {
 	i.applyCompletedRetention()

--- a/chasm/lib/scheduler/gen/schedulerpb/v1/message.pb.go
+++ b/chasm/lib/scheduler/gen/schedulerpb/v1/message.pb.go
@@ -54,8 +54,14 @@ type SchedulerState struct {
 	// Surfaced as the ScheduleIdleCloseTime search attribute for stuck-schedule
 	// detection.
 	IdleCloseTime *timestamppb.Timestamp `protobuf:"bytes,12,opt,name=idle_close_time,json=idleCloseTime,proto3" json:"idle_close_time,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// Request IDs of recently applied mutations (PatchSchedule and
+	// UpdateSchedule), oldest first. A mutation whose request ID is already
+	// present is a retry, and is acknowledged without being applied again. The
+	// list is trimmed to the most recent entries, so it only covers retries that
+	// arrive within a handful of subsequent mutations.
+	RecentMutationRequestIds []string `protobuf:"bytes,13,rep,name=recent_mutation_request_ids,json=recentMutationRequestIds,proto3" json:"recent_mutation_request_ids,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *SchedulerState) Reset() {
@@ -154,6 +160,13 @@ func (x *SchedulerState) GetWorkflowMigration() *WorkflowMigrationState {
 func (x *SchedulerState) GetIdleCloseTime() *timestamppb.Timestamp {
 	if x != nil {
 		return x.IdleCloseTime
+	}
+	return nil
+}
+
+func (x *SchedulerState) GetRecentMutationRequestIds() []string {
+	if x != nil {
+		return x.RecentMutationRequestIds
 	}
 	return nil
 }
@@ -712,7 +725,7 @@ var File_temporal_server_chasm_lib_scheduler_proto_v1_message_proto protoreflect
 
 const file_temporal_server_chasm_lib_scheduler_proto_v1_message_proto_rawDesc = "" +
 	"\n" +
-	":temporal/server/chasm/lib/scheduler/proto/v1/message.proto\x12,temporal.server.chasm.lib.scheduler.proto.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a$temporal/api/common/v1/message.proto\x1a%temporal/api/failure/v1/message.proto\x1a&temporal/api/schedule/v1/message.proto\x1a-temporal/server/api/schedule/v1/message.proto\"\x82\x04\n" +
+	":temporal/server/chasm/lib/scheduler/proto/v1/message.proto\x12,temporal.server.chasm.lib.scheduler.proto.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a$temporal/api/common/v1/message.proto\x1a%temporal/api/failure/v1/message.proto\x1a&temporal/api/schedule/v1/message.proto\x1a-temporal/server/api/schedule/v1/message.proto\"\xc1\x04\n" +
 	"\x0eSchedulerState\x12>\n" +
 	"\bschedule\x18\x02 \x01(\v2\".temporal.api.schedule.v1.ScheduleR\bschedule\x12:\n" +
 	"\x04info\x18\x03 \x01(\v2&.temporal.api.schedule.v1.ScheduleInfoR\x04info\x12\x1c\n" +
@@ -725,7 +738,8 @@ const file_temporal_server_chasm_lib_scheduler_proto_v1_message_proto_rawDesc = 
 	"\bsentinel\x18\n" +
 	" \x01(\bR\bsentinel\x12s\n" +
 	"\x12workflow_migration\x18\v \x01(\v2D.temporal.server.chasm.lib.scheduler.proto.v1.WorkflowMigrationStateR\x11workflowMigration\x12B\n" +
-	"\x0fidle_close_time\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\ridleCloseTime\"z\n" +
+	"\x0fidle_close_time\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\ridleCloseTime\x12=\n" +
+	"\x1brecent_mutation_request_ids\x18\r \x03(\tR\x18recentMutationRequestIds\"z\n" +
 	"\x16WorkflowMigrationState\x120\n" +
 	"\x14pre_migration_paused\x18\x01 \x01(\bR\x12preMigrationPaused\x12.\n" +
 	"\x13pre_migration_notes\x18\x02 \x01(\tR\x11preMigrationNotes\"\xa8\x01\n" +

--- a/chasm/lib/scheduler/proto/v1/message.proto
+++ b/chasm/lib/scheduler/proto/v1/message.proto
@@ -42,6 +42,13 @@ message SchedulerState {
   // Surfaced as the ScheduleIdleCloseTime search attribute for stuck-schedule
   // detection.
   google.protobuf.Timestamp idle_close_time = 12;
+
+  // Request IDs of recently applied mutations (PatchSchedule and
+  // UpdateSchedule), oldest first. A mutation whose request ID is already
+  // present is a retry, and is acknowledged without being applied again. The
+  // list is trimmed to the most recent entries, so it only covers retries that
+  // arrive within a handful of subsequent mutations.
+  repeated string recent_mutation_request_ids = 13;
 }
 
 // WorkflowMigrationState tracks the state of an in-progress V2-to-V1 migration.

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -108,6 +108,12 @@ const (
 
 	// Maximum number of backfillers allowed on a single scheduler.
 	maxBackfillers = 100
+
+	// How many recently applied mutation (Patch/Update) request IDs to retain
+	// for deduplicating retries. Retries land within moments of the original
+	// request, so a short window is enough; the list is persisted with the
+	// scheduler's state, so it must stay small.
+	maxRecentMutationRequestIDs = 10
 )
 
 var (
@@ -881,6 +887,13 @@ func (s *Scheduler) Update(
 	if s.WorkflowMigration != nil {
 		return nil, ErrMigrationPending
 	}
+	// A retry of an already applied update carries a conflict token that the
+	// first attempt has since consumed, so dedup must come first.
+	if s.isDuplicateMutation(req.FrontendRequest.GetRequestId()) {
+		return &schedulerpb.UpdateScheduleResponse{
+			FrontendResponse: &workflowservice.UpdateScheduleResponse{},
+		}, nil
+	}
 	if !s.validateConflictToken(req.FrontendRequest.ConflictToken) {
 		return nil, ErrConflictTokenMismatch
 	}
@@ -912,6 +925,7 @@ func (s *Scheduler) Update(
 
 	s.Info.UpdateTime = timestamppb.New(ctx.Now(s))
 	s.updateConflictToken()
+	s.recordMutationRequestID(req.FrontendRequest.GetRequestId())
 	s.getOrCreateEventLog(ctx).LogEvent(ctx, "updated via API")
 
 	// Since the spec may have been updated, kick off the generator.
@@ -938,6 +952,14 @@ func (s *Scheduler) Patch(
 	if s.WorkflowMigration != nil {
 		return nil, ErrMigrationPending
 	}
+	// Patch isn't naturally idempotent: every TriggerImmediately and
+	// BackfillRequest adds a Backfiller, which goes on to start workflows. A
+	// retry must be acknowledged without running those actions again.
+	if s.isDuplicateMutation(req.FrontendRequest.GetRequestId()) {
+		return &schedulerpb.PatchScheduleResponse{
+			FrontendResponse: &workflowservice.PatchScheduleResponse{},
+		}, nil
+	}
 	// Handle paused status.
 	if req.FrontendRequest.Patch.Pause != "" {
 		s.Schedule.State.Paused = true
@@ -956,6 +978,7 @@ func (s *Scheduler) Patch(
 
 	s.Info.UpdateTime = timestamppb.New(ctx.Now(s))
 	s.updateConflictToken()
+	s.recordMutationRequestID(req.FrontendRequest.GetRequestId())
 
 	// Since the paused state may have been updated, kick off the generator.
 	s.Generator.Get(ctx).Generate(ctx)
@@ -963,6 +986,28 @@ func (s *Scheduler) Patch(
 	return &schedulerpb.PatchScheduleResponse{
 		FrontendResponse: &workflowservice.PatchScheduleResponse{},
 	}, nil
+}
+
+// isDuplicateMutation reports whether a mutation carrying requestID has already
+// been applied recently. Patch and Update share one window, matching V1, where
+// both arrive as signals and are deduplicated by the workflow's signal request
+// IDs regardless of which mutation they carry. An empty request ID never
+// deduplicates: neither API requires one.
+func (s *Scheduler) isDuplicateMutation(requestID string) bool {
+	return requestID != "" && slices.Contains(s.RecentMutationRequestIds, requestID)
+}
+
+// recordMutationRequestID appends requestID to the dedup window, dropping the
+// oldest entries beyond maxRecentMutationRequestIDs.
+func (s *Scheduler) recordMutationRequestID(requestID string) {
+	if requestID == "" {
+		return
+	}
+
+	s.RecentMutationRequestIds = append(s.RecentMutationRequestIds, requestID)
+	if excess := len(s.RecentMutationRequestIds) - maxRecentMutationRequestIDs; excess > 0 {
+		s.RecentMutationRequestIds = slices.Clone(s.RecentMutationRequestIds[excess:])
+	}
 }
 
 func (s *Scheduler) generateConflictToken() []byte {

--- a/chasm/lib/scheduler/scheduler_request_id_test.go
+++ b/chasm/lib/scheduler/scheduler_request_id_test.go
@@ -3,6 +3,7 @@ package scheduler_test
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"slices"
 	"testing"
 	"time"
@@ -122,6 +123,32 @@ func TestPatch_EmptyRequestIDIsNotDeduped(t *testing.T) {
 	_, err = sched.Patch(ctx, patchRequest(""))
 	require.NoError(t, err)
 	require.Len(t, addedBackfillerIDs(firstPatchIDs, backfillerIDs(sched)), 2)
+}
+
+// TestPatch_DedupWindowIsBounded pins that the retained request IDs are
+// trimmed, so a busy schedule can't grow its persisted state without bound.
+func TestPatch_DedupWindowIsBounded(t *testing.T) {
+	sched, ctx, node := setupSchedulerForTest(t)
+
+	for i := range 50 {
+		_, err := sched.Patch(ctx, &schedulerpb.PatchScheduleRequest{
+			NamespaceId: namespaceID,
+			FrontendRequest: &workflowservice.PatchScheduleRequest{
+				Namespace:  namespace,
+				ScheduleId: scheduleID,
+				RequestId:  fmt.Sprintf("patch-request-%d", i),
+				Patch:      &schedulepb.SchedulePatch{Pause: "pausing"},
+			},
+		})
+		require.NoError(t, err)
+		_, err = node.CloseTransaction()
+		require.NoError(t, err)
+		ctx = chasm.NewMutableContext(context.Background(), node)
+	}
+
+	require.Len(t, sched.RecentMutationRequestIds, scheduler.MaxRecentMutationRequestIDs)
+	require.Equal(t, "patch-request-49", sched.RecentMutationRequestIds[len(sched.RecentMutationRequestIds)-1],
+		"the most recent request IDs are the ones retained")
 }
 
 // TestUpdate_DuplicateRequestIDIsIdempotent pins that a retried UpdateSchedule

--- a/chasm/lib/scheduler/scheduler_request_id_test.go
+++ b/chasm/lib/scheduler/scheduler_request_id_test.go
@@ -1,0 +1,193 @@
+package scheduler_test
+
+import (
+	"context"
+	"encoding/binary"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	schedulepb "go.temporal.io/api/schedule/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/scheduler"
+	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// patchRequest returns a patch request that creates two backfillers: one for
+// the immediate trigger, one for the range backfill.
+func patchRequest(requestID string) *schedulerpb.PatchScheduleRequest {
+	base := time.Now().UTC().Add(-time.Hour)
+	return &schedulerpb.PatchScheduleRequest{
+		NamespaceId: namespaceID,
+		FrontendRequest: &workflowservice.PatchScheduleRequest{
+			Namespace:  namespace,
+			ScheduleId: scheduleID,
+			RequestId:  requestID,
+			Patch: &schedulepb.SchedulePatch{
+				TriggerImmediately: &schedulepb.TriggerImmediatelyRequest{},
+				BackfillRequest: []*schedulepb.BackfillRequest{
+					{
+						StartTime: timestamppb.New(base),
+						EndTime:   timestamppb.New(base.Add(30 * time.Minute)),
+					},
+				},
+			},
+		},
+	}
+}
+
+// backfillerIDs returns the scheduler's current backfill IDs. Backfillers are
+// removed as they complete, so tests compare ID sets across a patch rather than
+// counting survivors.
+func backfillerIDs(sched *scheduler.Scheduler) []string {
+	ids := make([]string, 0, len(sched.Backfillers))
+	for id := range sched.Backfillers {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+func addedBackfillerIDs(before, after []string) []string {
+	var added []string
+	for _, id := range after {
+		if !slices.Contains(before, id) {
+			added = append(added, id)
+		}
+	}
+	return added
+}
+
+func serializedConflictToken(t int64) []byte {
+	token := make([]byte, 8)
+	binary.LittleEndian.PutUint64(token, uint64(t))
+	return token
+}
+
+// TestPatch_DuplicateRequestIDDoesNotDuplicateActions pins that a retried
+// PatchSchedule carrying the same request ID is applied exactly once. Each
+// TriggerImmediately and BackfillRequest adds its own Backfiller, which goes on
+// to start workflows, so a re-applied patch runs the manual actions twice.
+func TestPatch_DuplicateRequestIDDoesNotDuplicateActions(t *testing.T) {
+	sched, ctx, node := setupSchedulerForTest(t)
+
+	_, err := sched.Patch(ctx, patchRequest("patch-request-1"))
+	require.NoError(t, err)
+	firstPatchIDs := backfillerIDs(sched)
+	require.Len(t, firstPatchIDs, 2)
+	_, err = node.CloseTransaction()
+	require.NoError(t, err)
+
+	// Retry of the same request, e.g. after the caller timed out.
+	ctx = chasm.NewMutableContext(context.Background(), node)
+	_, err = sched.Patch(ctx, patchRequest("patch-request-1"))
+	require.NoError(t, err, "a retried patch must succeed idempotently")
+	require.Empty(t, addedBackfillerIDs(firstPatchIDs, backfillerIDs(sched)),
+		"retried patch with the same request ID must not create additional backfillers")
+}
+
+// TestPatch_DistinctRequestIDsApplyIndependently guards against over-deduping:
+// two genuinely different patches must both be applied.
+func TestPatch_DistinctRequestIDsApplyIndependently(t *testing.T) {
+	sched, ctx, node := setupSchedulerForTest(t)
+
+	_, err := sched.Patch(ctx, patchRequest("patch-request-1"))
+	require.NoError(t, err)
+	firstPatchIDs := backfillerIDs(sched)
+	_, err = node.CloseTransaction()
+	require.NoError(t, err)
+
+	ctx = chasm.NewMutableContext(context.Background(), node)
+	_, err = sched.Patch(ctx, patchRequest("patch-request-2"))
+	require.NoError(t, err)
+	require.Len(t, addedBackfillerIDs(firstPatchIDs, backfillerIDs(sched)), 2)
+}
+
+// TestPatch_EmptyRequestIDIsNotDeduped documents that dedup is opt-in on the
+// request ID: PatchSchedule does not require one, and patches without an ID
+// keep their pre-existing at-least-once behavior.
+func TestPatch_EmptyRequestIDIsNotDeduped(t *testing.T) {
+	sched, ctx, node := setupSchedulerForTest(t)
+
+	_, err := sched.Patch(ctx, patchRequest(""))
+	require.NoError(t, err)
+	firstPatchIDs := backfillerIDs(sched)
+	_, err = node.CloseTransaction()
+	require.NoError(t, err)
+
+	ctx = chasm.NewMutableContext(context.Background(), node)
+	_, err = sched.Patch(ctx, patchRequest(""))
+	require.NoError(t, err)
+	require.Len(t, addedBackfillerIDs(firstPatchIDs, backfillerIDs(sched)), 2)
+}
+
+// TestUpdate_DuplicateRequestIDIsIdempotent pins that a retried UpdateSchedule
+// carrying the same request ID succeeds instead of failing on its (already
+// consumed) conflict token, and does not bump the conflict token twice.
+func TestUpdate_DuplicateRequestIDIsIdempotent(t *testing.T) {
+	sched, ctx, node := setupSchedulerForTest(t)
+
+	initialToken := sched.ConflictToken
+	updateRequest := func() *schedulerpb.UpdateScheduleRequest {
+		return &schedulerpb.UpdateScheduleRequest{
+			NamespaceId: namespaceID,
+			FrontendRequest: &workflowservice.UpdateScheduleRequest{
+				Namespace:     namespace,
+				ScheduleId:    scheduleID,
+				Schedule:      defaultSchedule(),
+				RequestId:     "update-request-1",
+				ConflictToken: serializedConflictToken(initialToken),
+			},
+		}
+	}
+
+	_, err := sched.Update(ctx, updateRequest())
+	require.NoError(t, err)
+	require.Equal(t, initialToken+1, sched.ConflictToken)
+	_, err = node.CloseTransaction()
+	require.NoError(t, err)
+
+	ctx = chasm.NewMutableContext(context.Background(), node)
+	_, err = sched.Update(ctx, updateRequest())
+	require.NoError(t, err, "a retried update must succeed idempotently")
+	require.Equal(t, initialToken+1, sched.ConflictToken,
+		"retried update with the same request ID must not bump the conflict token again")
+}
+
+// TestUpdate_DistinctRequestIDStillConflicts guards against over-deduping: a
+// genuinely different update carrying a stale conflict token must still be
+// rejected.
+func TestUpdate_DistinctRequestIDStillConflicts(t *testing.T) {
+	sched, ctx, node := setupSchedulerForTest(t)
+
+	initialToken := sched.ConflictToken
+	_, err := sched.Update(ctx, &schedulerpb.UpdateScheduleRequest{
+		NamespaceId: namespaceID,
+		FrontendRequest: &workflowservice.UpdateScheduleRequest{
+			Namespace:     namespace,
+			ScheduleId:    scheduleID,
+			Schedule:      defaultSchedule(),
+			RequestId:     "update-request-1",
+			ConflictToken: serializedConflictToken(initialToken),
+		},
+	})
+	require.NoError(t, err)
+	_, err = node.CloseTransaction()
+	require.NoError(t, err)
+
+	ctx = chasm.NewMutableContext(context.Background(), node)
+	_, err = sched.Update(ctx, &schedulerpb.UpdateScheduleRequest{
+		NamespaceId: namespaceID,
+		FrontendRequest: &workflowservice.UpdateScheduleRequest{
+			Namespace:     namespace,
+			ScheduleId:    scheduleID,
+			Schedule:      defaultSchedule(),
+			RequestId:     "update-request-2",
+			ConflictToken: serializedConflictToken(initialToken),
+		},
+	})
+	require.ErrorIs(t, err, scheduler.ErrConflictTokenMismatch)
+}


### PR DESCRIPTION
## Description

`PatchSchedule` and `UpdateSchedule` accept a request ID, but the CHASM scheduler never read it: `chasm.UpdateComponent` takes no request-ID parameter, and neither `Scheduler.Patch` nor `Scheduler.Update` looked at `FrontendRequest.RequestId`.

A retried `PatchSchedule` was therefore applied twice, and because every `TriggerImmediately` and `BackfillRequest` adds its own `Backfiller`, the retry **started the manual actions a second time** — duplicate triggers and backfills, bounded only by `maxBackfillers`. A retried `UpdateSchedule` failed with `ErrConflictTokenMismatch` on the token its own first attempt had consumed.

The V1 path is unaffected: it forwards the request ID into `SignalWorkflowExecution` and gets signal dedup for free.

This retains the request IDs of recently applied mutations on the scheduler's persisted state and acknowledges a repeat without re-applying it.

## ⚠️ Adds a persisted proto field

New `repeated string recent_mutation_request_ids = 13` on `SchedulerState`, with `message.pb.go` regenerated via `make protoc` (the only generated file that changed repo-wide). This is the only branch in this batch touching the wire format.

Bounding: oldest-first, trimmed to the last 10 on every insert by `recordMutationRequestID`, mirroring `applyCompletedRetention`'s tail-keep style. ~10 UUIDs ≈ 400 bytes, hard-capped regardless of patch rate; pinned by `TestPatch_DedupWindowIsBounded` over 50 patches. Patch and Update share one window, matching V1's single signal-request-ID namespace. An empty request ID never dedupes, since neither API requires one.

The dedup check sits after the sentinel/closed/migration guards and, for Update, *before* `validateConflictToken` — a retry necessarily carries a consumed token.

## Why this is component-level and not a framework change

CHASM's only request-ID primitive is `chasm.WithRequestID`, documented for `StartExecution`/`UpdateWithStartExecution` only; `ChasmEngine.UpdateComponent` consumes `options.RequestID` purely for error conversion and logging. There is no attach/lookup on the update path.

Component-owned dedup is the sanctioned pattern, with direct in-tree precedent in the sibling library: `chasm/lib/activity` dedupes Terminate, RequestCancel and Pause by storing the request ID in its own persisted state. `chasm/engine.go` states it explicitly for `RefConsistencyLevelCurrentRun`: "Callers relying on this level must re-establish identity in component logic (e.g. by request ID)." No framework escalation was warranted.

## Does Update's conflict token already cover it? No

Two gaps: `validateConflictToken` returns true for a nil token and the token is optional in the API, so token-less clients get no protection; and even with a token supplied, the first attempt consumes it, so the retry gets `ErrConflictTokenMismatch` (FailedPrecondition) rather than an idempotent success. Update's double-apply is benign in state terms (full replacement) — the visible harm is a double conflict-token bump, a reset `UpdateTime` and a spurious `Generate`. **Patch is the real gap.**

## Testing

Committed before the fix; the two dedup tests failed 5/5 runs and the three guard tests passed 5/5:

```
--- FAIL: TestPatch_DuplicateRequestIDDoesNotDuplicateActions
    Should be empty, but was [032bd66e-... a916bf52-...]
    retried patch with the same request ID must not create additional backfillers
--- FAIL: TestUpdate_DuplicateRequestIDIsIdempotent
    Received unexpected error: [mismatched conflict token]
```

Test-design note: `BackfillerTask` is a CHASM *pure* task, so it executes inline during `CloseTransaction` and deletes completed backfillers. Counting survivors across a transaction boundary is flaky (2 → 0/1/2); the committed tests compare backfill-ID *sets* before/after the retry instead. Green under `-count=2 -test.shuffle=on`.

## Flagged, not done

- Whether the frontend should start *requiring* a non-empty request ID on Patch/Update (as `CreateSchedule` does) is an API-compatibility decision. Today dedup is opt-in and a caller omitting the ID keeps the old at-least-once behaviour.
- Adjacent and unaddressed: `DeleteSchedule` and `MigrateToWorkflow` take no request ID either, so a retried Delete returns `ErrClosed` rather than an idempotent success.

Source: "Patch and Update requests don't use requestID to achieve idempotency", Schedule V2 Bug Review (P1, Confirmed, Supported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
