### PR TITLE
CHASM test engine bug fixes

### DIFF
--- a/chasm/chasmtest/test_engine.go
+++ b/chasm/chasmtest/test_engine.go
@@ -613,13 +613,12 @@ func (e *Engine) updateComponentInExecution(
 	ref chasm.ComponentRef,
 	updateFn func(chasm.MutableContext, chasm.Component) error,
 ) ([]byte, error) {
-	chasmCtx := chasm.NewContext(ctx, execution.node)
-	component, err := execution.node.Component(chasmCtx, ref)
+	mutableCtx := chasm.NewMutableContext(ctx, execution.node)
+	component, err := execution.node.Component(mutableCtx, ref)
 	if err != nil {
 		return nil, err
 	}
 
-	mutableCtx := chasm.NewMutableContext(ctx, execution.node)
 	if err := updateFn(mutableCtx, component); err != nil {
 		return nil, err
 	}

--- a/chasm/chasmtest/test_engine.go
+++ b/chasm/chasmtest/test_engine.go
@@ -48,6 +48,8 @@ type (
 		backend   *chasm.MockNodeBackend
 		root      chasm.RootComponent
 		requestID string
+		// commitTransition advances the backend's committed transition count.
+		commitTransition func()
 	}
 
 	businessKey struct {
@@ -439,7 +441,7 @@ func (e *Engine) startNew(
 	if err := exec.node.SetRootComponent(root); err != nil {
 		return chasm.StartExecutionResult{}, err
 	}
-	if _, err = exec.node.CloseTransaction(); err != nil {
+	if err = exec.closeTransaction(); err != nil {
 		return chasm.StartExecutionResult{}, err
 	}
 
@@ -482,7 +484,7 @@ func (e *Engine) startAndUpdateNew(
 	if err := updateFn(mutableCtx, root); err != nil {
 		return chasm.EngineUpdateWithStartExecutionResult{}, err
 	}
-	if _, err = exec.node.CloseTransaction(); err != nil {
+	if err = exec.closeTransaction(); err != nil {
 		return chasm.EngineUpdateWithStartExecutionResult{}, err
 	}
 
@@ -515,13 +517,11 @@ func (e *Engine) newExecution(key chasm.ExecutionKey) *execution {
 	)
 
 	backend := &chasm.MockNodeBackend{
-		// NextTransitionCount increments on every CloseTransaction call, matching
-		// the real engine's per transition monotonic counter.
+		// NextTransitionCount is the count the in-flight transaction will commit as.
 		HandleNextTransitionCount: func() int64 {
 			bsMu.Lock()
 			defer bsMu.Unlock()
-			transitionCount++
-			return transitionCount
+			return transitionCount + 1
 		},
 		// CurrentVersionedTransition reflects the latest committed transition count.
 		HandleCurrentVersionedTransition: func() *persistencespb.VersionedTransition {
@@ -569,7 +569,21 @@ func (e *Engine) newExecution(key chasm.ExecutionKey) *execution {
 			e.logger,
 			e.metrics,
 		),
+		commitTransition: func() {
+			bsMu.Lock()
+			defer bsMu.Unlock()
+			transitionCount++
+		},
 	}
+}
+
+// closeTransaction closes the execution's transaction and commits its transition count.
+func (x *execution) closeTransaction() error {
+	if _, err := x.node.CloseTransaction(); err != nil {
+		return err
+	}
+	x.commitTransition()
+	return nil
 }
 
 // executionForRef looks up an execution by the ref's RunID when present, or falls back
@@ -610,7 +624,7 @@ func (e *Engine) updateComponentInExecution(
 		return nil, err
 	}
 
-	if _, err = execution.node.CloseTransaction(); err != nil {
+	if err = execution.closeTransaction(); err != nil {
 		return nil, err
 	}
 

--- a/chasm/chasmtest/test_engine_test.go
+++ b/chasm/chasmtest/test_engine_test.go
@@ -1,0 +1,74 @@
+// Tests for the test engine.
+package chasmtest_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/chasmtest"
+	"go.temporal.io/server/chasm/lib/tests"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/payload"
+	"go.temporal.io/server/service/history/tasks"
+)
+
+// TestTasksArePhysicallyGenerated: a task a component adds must reach the backend as a physical task, in
+// the category its TaskAttributes imply.
+func TestTasksArePhysicallyGenerated(t *testing.T) {
+	const ttl = time.Hour
+
+	t.Run("added while starting", func(t *testing.T) {
+		e, ref := startStore(t, ttl)
+		require.Equal(t, 1, countTasks(t, e, ref, tasks.CategoryTimer))
+	})
+
+}
+
+func startStore(t *testing.T, ttl time.Duration) (*chasmtest.Engine, chasm.ComponentRef) {
+	registry := chasm.NewRegistry(log.NewNoopLogger())
+	require.NoError(t, registry.Register(&chasm.CoreLibrary{}))
+	require.NoError(t, registry.Register(tests.Library))
+
+	ts := clock.NewEventTimeSource()
+	ts.Update(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+	e := chasmtest.NewEngine(t, registry, chasmtest.WithTimeSource(ts))
+
+	key := chasm.ExecutionKey{NamespaceID: "test-ns", BusinessID: "store"}
+	result, err := chasm.StartExecution(engineContext(e), key,
+		func(mc chasm.MutableContext, _ any) (*tests.PayloadStore, error) {
+			store, err := tests.NewPayloadStore(mc)
+			if err != nil {
+				return nil, err
+			}
+			return store, addPayload(store, mc, "first", ttl)
+		}, nil)
+	require.NoError(t, err)
+
+	key.RunID = result.ExecutionKey.RunID
+	return e, chasm.NewComponentRef[*tests.PayloadStore](key)
+}
+
+// addPayload stores one payload, which schedules a TTL task when ttl is non-zero.
+func addPayload(store *tests.PayloadStore, mc chasm.MutableContext, key string, ttl time.Duration) error {
+	_, err := store.AddPayload(mc, tests.AddPayloadRequest{
+		PayloadKey: key,
+		Payload:    payload.EncodeString("payload"),
+		TTL:        ttl,
+	})
+	return err
+}
+
+// countTasks is how many physical tasks the execution has accumulated in the given category.
+func countTasks(t *testing.T, e *chasmtest.Engine, ref chasm.ComponentRef, category tasks.Category) int {
+	byCategory, err := e.Tasks(ref)
+	require.NoError(t, err)
+	return len(byCategory[category])
+}
+
+func engineContext(e *chasmtest.Engine) context.Context {
+	return chasm.NewEngineContext(context.Background(), e)
+}

--- a/chasm/chasmtest/test_engine_test.go
+++ b/chasm/chasmtest/test_engine_test.go
@@ -17,7 +17,8 @@ import (
 )
 
 // TestTasksArePhysicallyGenerated: a task a component adds must reach the backend as a physical task, in
-// the category its TaskAttributes imply.
+// the category its TaskAttributes imply, whether it was added while starting the execution or while
+// updating it.
 func TestTasksArePhysicallyGenerated(t *testing.T) {
 	const ttl = time.Hour
 
@@ -26,6 +27,16 @@ func TestTasksArePhysicallyGenerated(t *testing.T) {
 		require.Equal(t, 1, countTasks(t, e, ref, tasks.CategoryTimer))
 	})
 
+	t.Run("added while updating", func(t *testing.T) {
+		e, ref := startStore(t, 0)
+		require.Equal(t, 0, countTasks(t, e, ref, tasks.CategoryTimer))
+		_, _, err := chasm.UpdateComponent(engineContext(e), ref,
+			func(s *tests.PayloadStore, mc chasm.MutableContext, _ any) (any, error) {
+				return nil, addPayload(s, mc, "second", ttl)
+			}, nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, countTasks(t, e, ref, tasks.CategoryTimer))
+	})
 }
 
 func startStore(t *testing.T, ttl time.Duration) (*chasmtest.Engine, chasm.ComponentRef) {


### PR DESCRIPTION
## What changed?
Fix two bugs in the CHASM test engine:
- next transition count was being mutated on reads
- in the update component path, component was not being marked dirty, hence VT was not advancing

Both of these bugs caused VT mismatches, which were causing logical tasks not to be generated.

The PR has 4 commits: repro1, fix1, repro2, fix2.

## Why?
Test machinery was behaving incorrectly

## How did you test it?
- [x] added new unit test(s)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to `chasmtest` test infrastructure; production CHASM engine is untouched.
> 
> **Overview**
> Fixes the in-memory CHASM **test engine** so versioned transitions and task materialization match production behavior.
> 
> **Versioned transition counting:** `HandleNextTransitionCount` no longer increments the committed counter on read. It returns `transitionCount + 1` for the in-flight transaction, and `commitTransition` bumps the counter only after a successful `CloseTransaction` (via new `execution.closeTransaction()` on start, update-with-start, and update paths).
> 
> **Component updates:** `updateComponentInExecution` loads the target component through `MutableContext` instead of a read-only context, so updates mark the component dirty and the transition count advances as expected.
> 
> Adds `TestTasksArePhysicallyGenerated` to assert TTL timer tasks land on the mock backend both when scheduled at start and on a later `UpdateComponent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 036371de9038e948838895a5559ae6b85f07b039. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->