### PR TITLE
Use immediate queue for already-due activity dispatch tasks

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1049,7 +1049,7 @@ func (a *Activity) unpause(
 	}
 	ctx.AddTask(
 		a,
-		chasm.TaskAttributes{ScheduledTime: dispatchTime},
+		a.activityDispatchTaskAttributes(ctx, dispatchTime),
 		a.newActivityDispatchTask(ctx))
 }
 
@@ -1108,7 +1108,7 @@ func (a *Activity) reset(ctx chasm.MutableContext, event resetEvent) {
 	}
 	ctx.AddTask(
 		a,
-		chasm.TaskAttributes{ScheduledTime: dispatchTime},
+		a.activityDispatchTaskAttributes(ctx, dispatchTime),
 		a.newActivityDispatchTask(ctx),
 	)
 	a.emitOnResetMetrics(event.handler)
@@ -1449,7 +1449,7 @@ func (a *Activity) reissueDispatchAndScheduleToStart(ctx chasm.MutableContext, a
 	attempt.DispatchTime = timestamppb.New(dispatchTime)
 	ctx.AddTask(
 		a,
-		chasm.TaskAttributes{ScheduledTime: dispatchTime},
+		a.activityDispatchTaskAttributes(ctx, dispatchTime),
 		a.newActivityDispatchTask(ctx),
 	)
 	if timeout := a.GetScheduleToStartTimeout().AsDuration(); timeout > 0 {
@@ -1505,6 +1505,16 @@ func (a *Activity) dispatchTimeRespectingStartDelay(t time.Time) time.Time {
 		return dispatchTime
 	}
 	return t
+}
+
+// activityDispatchTaskAttributes routes a task that is already due through the immediate queue. A
+// timer task will not execute before now + TimerProcessorMaxTimeShift (~1s), so scheduling an
+// already-due task as a timer delays it for no reason.
+func (a *Activity) activityDispatchTaskAttributes(ctx chasm.MutableContext, scheduledTime time.Time) chasm.TaskAttributes {
+	if scheduledTime.After(ctx.Now(a)) {
+		return chasm.TaskAttributes{ScheduledTime: scheduledTime}
+	}
+	return chasm.TaskAttributes{}
 }
 
 // reissueScheduleToClose bumps the ScheduleToCloseStamp and re-emits the ScheduleToClose timeout task

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -73,13 +73,9 @@ var TransitionScheduled = chasm.NewTransition(
 				&activitypb.ScheduleToCloseTimeoutTask{Stamp: a.GetScheduleToCloseStamp()})
 		}
 
-		dispatchAttrs := chasm.TaskAttributes{}
-		if dispatchTime.After(a.ScheduleTime.AsTime()) {
-			dispatchAttrs.ScheduledTime = dispatchTime
-		}
 		ctx.AddTask(
 			a,
-			dispatchAttrs,
+			a.activityDispatchTaskAttributes(ctx, dispatchTime),
 			a.newActivityDispatchTask(ctx))
 
 		return nil
@@ -122,9 +118,7 @@ var TransitionRescheduled = chasm.NewTransition(
 
 		ctx.AddTask(
 			a,
-			chasm.TaskAttributes{
-				ScheduledTime: retryScheduledTime,
-			},
+			a.activityDispatchTaskAttributes(ctx, retryScheduledTime),
 			a.newActivityDispatchTask(ctx))
 
 		return nil
@@ -606,9 +600,7 @@ var TransitionResetAttemptFailedToScheduled = chasm.NewTransition(
 		}
 		ctx.AddTask(
 			a,
-			chasm.TaskAttributes{
-				ScheduledTime: dispatchTime,
-			},
+			a.activityDispatchTaskAttributes(ctx, dispatchTime),
 			a.newActivityDispatchTask(ctx))
 
 		return nil


### PR DESCRIPTION
## What changed?
Do not set scheduled time in side-effect task attributes unless it is in the future. I.e. use the immediate queue for already-due side-effect tasks.

## Why?
Setting a schedule time causes it to use the timer task queue. Timer tasks do not (or probably do not?) fire in anything less than 1s (see `TimerProcessorMaxTimeShift`). Therefore using timer tasks for already-due tasks introduces an unecessary ~1s delay.

Covered by existing tests. I did also write a test specifically for this, but it requires a CHASM test engine change: https://github.com/temporalio/temporal/pull/11288. I think this could be done automatically at the framework level (in `ctx.AddTask()`) for side-effect tasks. I don't think either of those points need block this PR.

## How did you test it?
- [x] covered by existing tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when CHASM activity dispatch tasks are enqueued relative to wall clock, which affects activity latency to Matching across many state transitions; behavior is intentional and covered by existing tests but is on the core activity execution path.
> 
> **Overview**
> **Activity dispatch tasks that are already due no longer get a `ScheduledTime`, so they run on the immediate queue instead of the timer queue.**
> 
> A new `activityDispatchTaskAttributes` helper only sets `ScheduledTime` when the dispatch time is after `ctx.Now`. All paths that enqueue `ActivityDispatchTask` (initial schedule, retry reschedule, unpause, reset, options reissue, reset-after-worker-yield) now use it instead of always passing `dispatchTime` as the scheduled time.
> 
> This avoids an extra ~1s delay from `TimerProcessorMaxTimeShift` when a dispatch is due immediately. The old initial-schedule path that skipped `ScheduledTime` only when `dispatchTime` was after `ScheduleTime` is folded into the same now-based rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 318df7cfc03775da463d36ba5fc1616f6f40cd92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->