### PR TITLE
Add HTTP fault injection for Nexus requests

### DIFF
--- a/chasm/lib/nexusoperation/fx.go
+++ b/chasm/lib/nexusoperation/fx.go
@@ -20,6 +20,8 @@ import (
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/common/rpc"
+	"go.temporal.io/server/common/rpc/faultinjection"
+	"go.temporal.io/server/common/testing/testhooks"
 	"go.uber.org/fx"
 )
 
@@ -89,9 +91,9 @@ func endpointRegistryLifetimeHooks(lc fx.Lifecycle, registry commonnexus.Endpoin
 // NexusTransportProvider allows customization of the HTTP transport used for Nexus requests.
 type NexusTransportProvider func(namespaceID, serviceName string) http.RoundTripper
 
-func defaultNexusTransportProvider() NexusTransportProvider {
+func defaultNexusTransportProvider(testHooks testhooks.TestHooks) NexusTransportProvider {
 	return func(namespaceID, serviceName string) http.RoundTripper {
-		return http.DefaultTransport
+		return faultinjection.HTTPRoundTripper(http.DefaultTransport, namespaceID, testHooks)
 	}
 }
 

--- a/common/rpc/faultinjection/grpc.go
+++ b/common/rpc/faultinjection/grpc.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"sync"
 	"sync/atomic"
-
-	"go.temporal.io/server/common/testing/testhooks"
-	"google.golang.org/grpc"
 )
 
 // RPCCallback is a callback function for RPC fault injection.
@@ -93,39 +90,4 @@ func (r *RPCFaultGenerator) Generate(ctx context.Context, fullMethod string, req
 		}
 	}
 	return false, nil, nil
-}
-
-// GRPCUnaryServerInterceptor returns a unary server interceptor that checks for
-// dynamically registered fault injection callbacks before and after the handler.
-//
-// This is primarily used for testing, allowing tests to register callbacks that
-// can inspect requests/responses and inject faults on demand.
-//
-// Behavior:
-// - If no generator is registered, the handler proceeds normally.
-// - Callbacks are checked before handler (resp=nil, err=nil). If matched, handler is skipped.
-// - Callbacks are checked after handler with actual resp/err. If matched, returned values are used.
-// - If no callbacks match, the handler's response/error is returned.
-func GRPCUnaryServerInterceptor(testHooks testhooks.TestHooks) grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		generate, ok := testhooks.Get(testHooks, testhooks.RPCFaultGenerator, testhooks.GlobalScope)
-		if !ok {
-			return handler(ctx, req)
-		}
-
-		// Check before handler (can short-circuit)
-		if matched, resp, err := generate(ctx, info.FullMethod, req, nil, nil); matched {
-			return resp, err
-		}
-
-		// Call handler
-		resp, err := handler(ctx, req)
-
-		// Check after handler (can modify response/error)
-		if matched, newResp, newErr := generate(ctx, info.FullMethod, req, resp, err); matched {
-			return newResp, newErr
-		}
-
-		return resp, err
-	}
 }

--- a/common/rpc/faultinjection/grpc.go
+++ b/common/rpc/faultinjection/grpc.go
@@ -1,0 +1,131 @@
+package faultinjection
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"go.temporal.io/server/common/testing/testhooks"
+	"google.golang.org/grpc"
+)
+
+// RPCCallback is a callback function for RPC fault injection.
+// It receives context, method name, request, and response (nil for pre-handler calls).
+//
+// Parameters:
+//   - ctx: the request context
+//   - fullMethod: the full gRPC method name
+//   - req: the request proto message
+//   - resp: the response proto message (nil when called before handler)
+//   - err: the error from handler (nil when called before handler)
+//
+// Returns:
+//   - bool: if true, the callback matched and the returned values should be used.
+//     If false, the callback did not match and other callbacks should be checked.
+//   - any: replacement response (only used if matched is true)
+//   - error: replacement error (only used if matched is true)
+type RPCCallback func(ctx context.Context, fullMethod string, req, resp any, err error) (matched bool, newResp any, newErr error)
+
+// rpcCallbackEntry represents a registered RPC callback with its ID.
+type rpcCallbackEntry struct {
+	id       uint64
+	callback RPCCallback
+}
+
+// RPCFaultGenerator handles fault injection for RPC requests and responses.
+type RPCFaultGenerator struct {
+	mu        sync.RWMutex
+	callbacks []rpcCallbackEntry
+	nextID    atomic.Uint64
+}
+
+// NewRPCFaultGenerator creates a new RPCFaultGenerator instance.
+func NewRPCFaultGenerator() *RPCFaultGenerator {
+	return &RPCFaultGenerator{
+		callbacks: make([]rpcCallbackEntry, 0),
+	}
+}
+
+// RegisterCallback registers an RPC fault injection callback and returns a
+// cleanup function that removes the callback when called.
+func (r *RPCFaultGenerator) RegisterCallback(cb RPCCallback) func() {
+	if r == nil {
+		return func() {}
+	}
+	id := r.nextID.Add(1)
+	entry := rpcCallbackEntry{id: id, callback: cb}
+
+	r.mu.Lock()
+	r.callbacks = append(r.callbacks, entry)
+	r.mu.Unlock()
+
+	return func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		for i, e := range r.callbacks {
+			if e.id == id {
+				r.callbacks = append(r.callbacks[:i], r.callbacks[i+1:]...)
+				return
+			}
+		}
+	}
+}
+
+// Generate checks all registered RPC callbacks for the given request/response.
+// Returns (true, resp, err) if a callback matched, or (false, nil, nil) if no callbacks matched.
+func (r *RPCFaultGenerator) Generate(ctx context.Context, fullMethod string, req, resp any, err error) (bool, any, error) {
+	if r == nil {
+		return false, nil, nil
+	}
+	r.mu.RLock()
+	numCallbacks := len(r.callbacks)
+	if numCallbacks == 0 {
+		r.mu.RUnlock()
+		return false, nil, nil
+	}
+	callbacks := make([]rpcCallbackEntry, numCallbacks)
+	copy(callbacks, r.callbacks)
+	r.mu.RUnlock()
+
+	for _, entry := range callbacks {
+		if matched, newResp, newErr := entry.callback(ctx, fullMethod, req, resp, err); matched {
+			return true, newResp, newErr
+		}
+	}
+	return false, nil, nil
+}
+
+// GRPCUnaryServerInterceptor returns a unary server interceptor that checks for
+// dynamically registered fault injection callbacks before and after the handler.
+//
+// This is primarily used for testing, allowing tests to register callbacks that
+// can inspect requests/responses and inject faults on demand.
+//
+// Behavior:
+// - If no generator is registered, the handler proceeds normally.
+// - Callbacks are checked before handler (resp=nil, err=nil). If matched, handler is skipped.
+// - Callbacks are checked after handler with actual resp/err. If matched, returned values are used.
+// - If no callbacks match, the handler's response/error is returned.
+func GRPCUnaryServerInterceptor(testHooks testhooks.TestHooks) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		generate, ok := testhooks.Get(testHooks, testhooks.RPCFaultGenerator, testhooks.GlobalScope)
+		if !ok {
+			return handler(ctx, req)
+		}
+
+		// Check before handler (can short-circuit)
+		if matched, resp, err := generate(ctx, info.FullMethod, req, nil, nil); matched {
+			return resp, err
+		}
+
+		// Call handler
+		resp, err := handler(ctx, req)
+
+		// Check after handler (can modify response/error)
+		if matched, newResp, newErr := generate(ctx, info.FullMethod, req, resp, err); matched {
+			return newResp, newErr
+		}
+
+		return resp, err
+	}
+}

--- a/common/rpc/faultinjection/grpc_test.go
+++ b/common/rpc/faultinjection/grpc_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestGRPCUnaryServerInterceptor_NoGenerator(t *testing.T) {
+	t.Parallel()
+
 	interceptor := GRPCUnaryServerInterceptor(testhooks.NewTestHooks())
 	response, err := interceptor(
 		context.Background(),
@@ -28,6 +30,8 @@ func TestGRPCUnaryServerInterceptor_NoGenerator(t *testing.T) {
 }
 
 func TestGRPCUnaryServerInterceptor_BeforeHandler(t *testing.T) {
+	t.Parallel()
+
 	testHooks := testhooks.NewTestHooks()
 	injectedErr := errors.New("injected")
 	testhooks.Set(
@@ -57,6 +61,8 @@ func TestGRPCUnaryServerInterceptor_BeforeHandler(t *testing.T) {
 }
 
 func TestGRPCUnaryServerInterceptor_AfterHandler(t *testing.T) {
+	t.Parallel()
+
 	testHooks := testhooks.NewTestHooks()
 	testhooks.Set(
 		testHooks,

--- a/common/rpc/faultinjection/grpc_test.go
+++ b/common/rpc/faultinjection/grpc_test.go
@@ -1,0 +1,85 @@
+//go:build test_dep
+
+package faultinjection
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/testing/testhooks"
+	"google.golang.org/grpc"
+)
+
+func TestGRPCUnaryServerInterceptor_NoGenerator(t *testing.T) {
+	interceptor := GRPCUnaryServerInterceptor(testhooks.NewTestHooks())
+	response, err := interceptor(
+		context.Background(),
+		"request",
+		&grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"},
+		func(context.Context, any) (any, error) {
+			return "response", nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, "response", response)
+}
+
+func TestGRPCUnaryServerInterceptor_BeforeHandler(t *testing.T) {
+	testHooks := testhooks.NewTestHooks()
+	injectedErr := errors.New("injected")
+	testhooks.Set(
+		testHooks,
+		testhooks.RPCFaultGenerator,
+		func(context.Context, string, any, any, error) (bool, any, error) {
+			return true, nil, injectedErr
+		},
+		testhooks.GlobalScope,
+	)
+	interceptor := GRPCUnaryServerInterceptor(testHooks)
+	handlerCalled := false
+
+	response, err := interceptor(
+		context.Background(),
+		"request",
+		&grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"},
+		func(context.Context, any) (any, error) {
+			handlerCalled = true
+			return "response", nil
+		},
+	)
+
+	require.ErrorIs(t, err, injectedErr)
+	require.Nil(t, response)
+	require.False(t, handlerCalled)
+}
+
+func TestGRPCUnaryServerInterceptor_AfterHandler(t *testing.T) {
+	testHooks := testhooks.NewTestHooks()
+	testhooks.Set(
+		testHooks,
+		testhooks.RPCFaultGenerator,
+		func(_ context.Context, _ string, _ any, response any, _ error) (bool, any, error) {
+			if response == nil {
+				return false, nil, nil
+			}
+			return true, "replacement", nil
+		},
+		testhooks.GlobalScope,
+	)
+	interceptor := GRPCUnaryServerInterceptor(testHooks)
+
+	response, err := interceptor(
+		context.Background(),
+		"request",
+		&grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"},
+		func(context.Context, any) (any, error) {
+			return "response", nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, "replacement", response)
+}

--- a/common/rpc/faultinjection/http.go
+++ b/common/rpc/faultinjection/http.go
@@ -1,0 +1,16 @@
+package faultinjection
+
+import "net/http"
+
+// HTTPFaultRequest is passed as the `req` argument to the fault generator for HTTP calls,
+// so a callback can namespace-scope a fault via GetNamespaceId (matching the gRPC
+// convention, where the request proto exposes the namespace) and, if it needs to, inspect
+// the underlying request.
+type HTTPFaultRequest struct {
+	NamespaceID string
+	Request     *http.Request
+}
+
+// GetNamespaceId lets namespace-scoped fault callbacks match HTTP calls the same way they
+// match gRPC requests.
+func (r *HTTPFaultRequest) GetNamespaceId() string { return r.NamespaceID }

--- a/common/rpc/faultinjection/http_test.go
+++ b/common/rpc/faultinjection/http_test.go
@@ -1,0 +1,115 @@
+//go:build test_dep
+
+package faultinjection
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/testing/testhooks"
+)
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func TestHTTPRoundTripper_NoGenerator(t *testing.T) {
+	t.Parallel()
+
+	expected := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("response")),
+	}
+	base := roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return expected, nil
+	})
+	request, err := http.NewRequest(http.MethodPost, "http://example.com/service/operation", nil)
+	require.NoError(t, err)
+
+	response, err := HTTPRoundTripper(base, "namespace-id", testhooks.NewTestHooks()).RoundTrip(request)
+
+	require.NoError(t, err)
+	require.Same(t, expected, response)
+}
+
+func TestHTTPRoundTripper_BeforeRequest(t *testing.T) {
+	t.Parallel()
+
+	testHooks := testhooks.NewTestHooks()
+	injectedErr := errors.New("injected")
+	request, err := http.NewRequest(http.MethodPost, "http://example.com/service/operation", nil)
+	require.NoError(t, err)
+	testhooks.Set(
+		testHooks,
+		testhooks.RPCFaultGenerator,
+		func(_ context.Context, method string, faultRequest, response any, err error) (bool, any, error) {
+			require.Equal(t, "HTTP POST /service/operation", method)
+			httpFaultRequest, ok := faultRequest.(*HTTPFaultRequest)
+			require.True(t, ok)
+			require.Equal(t, "namespace-id", httpFaultRequest.NamespaceID)
+			require.Same(t, request, httpFaultRequest.Request)
+			require.Nil(t, response)
+			require.NoError(t, err)
+			return true, nil, injectedErr
+		},
+		testhooks.GlobalScope,
+	)
+	baseCalled := false
+	base := roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		baseCalled = true
+		return nil, nil
+	})
+
+	response, err := HTTPRoundTripper(base, "namespace-id", testHooks).RoundTrip(request)
+
+	require.ErrorIs(t, err, injectedErr)
+	require.Nil(t, response)
+	require.False(t, baseCalled)
+}
+
+func TestHTTPRoundTripper_AfterRequest(t *testing.T) {
+	t.Parallel()
+
+	testHooks := testhooks.NewTestHooks()
+	injectedErr := errors.New("injected")
+	testhooks.Set(
+		testHooks,
+		testhooks.RPCFaultGenerator,
+		func(_ context.Context, _ string, _ any, response any, _ error) (bool, any, error) {
+			if response == nil {
+				return false, nil, nil
+			}
+			return true, nil, injectedErr
+		},
+		testhooks.GlobalScope,
+	)
+	body := &closeTracker{Reader: strings.NewReader("response")}
+	base := roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
+	})
+	request, err := http.NewRequest(http.MethodPost, "http://example.com/service/operation", nil)
+	require.NoError(t, err)
+
+	response, err := HTTPRoundTripper(base, "namespace-id", testHooks).RoundTrip(request)
+
+	require.ErrorIs(t, err, injectedErr)
+	require.Nil(t, response)
+	require.True(t, body.closed)
+}
+
+type closeTracker struct {
+	io.Reader
+	closed bool
+}
+
+func (b *closeTracker) Close() error {
+	b.closed = true
+	return nil
+}

--- a/common/rpc/faultinjection/interceptor_noop.go
+++ b/common/rpc/faultinjection/interceptor_noop.go
@@ -1,0 +1,13 @@
+//go:build !test_dep
+
+package faultinjection
+
+import (
+	"go.temporal.io/server/common/testing/testhooks"
+	"google.golang.org/grpc"
+)
+
+// GRPCUnaryServerInterceptor returns nil when test hooks are disabled.
+func GRPCUnaryServerInterceptor(testhooks.TestHooks) grpc.UnaryServerInterceptor {
+	return nil
+}

--- a/common/rpc/faultinjection/interceptor_noop.go
+++ b/common/rpc/faultinjection/interceptor_noop.go
@@ -3,15 +3,11 @@
 package faultinjection
 
 import (
-	"context"
-
 	"go.temporal.io/server/common/testing/testhooks"
 	"google.golang.org/grpc"
 )
 
-// GRPCUnaryServerInterceptor returns a pass-through interceptor when test hooks are disabled.
+// GRPCUnaryServerInterceptor returns nil when test hooks are disabled.
 func GRPCUnaryServerInterceptor(testhooks.TestHooks) grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		return handler(ctx, req)
-	}
+	return nil
 }

--- a/common/rpc/faultinjection/interceptor_noop.go
+++ b/common/rpc/faultinjection/interceptor_noop.go
@@ -3,11 +3,15 @@
 package faultinjection
 
 import (
+	"context"
+
 	"go.temporal.io/server/common/testing/testhooks"
 	"google.golang.org/grpc"
 )
 
-// GRPCUnaryServerInterceptor returns nil when test hooks are disabled.
+// GRPCUnaryServerInterceptor returns a pass-through interceptor when test hooks are disabled.
 func GRPCUnaryServerInterceptor(testhooks.TestHooks) grpc.UnaryServerInterceptor {
-	return nil
+	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		return handler(ctx, req)
+	}
 }

--- a/common/rpc/faultinjection/interceptor_noop.go
+++ b/common/rpc/faultinjection/interceptor_noop.go
@@ -3,6 +3,8 @@
 package faultinjection
 
 import (
+	"net/http"
+
 	"go.temporal.io/server/common/testing/testhooks"
 	"google.golang.org/grpc"
 )
@@ -10,4 +12,9 @@ import (
 // GRPCUnaryServerInterceptor returns nil when test hooks are disabled.
 func GRPCUnaryServerInterceptor(testhooks.TestHooks) grpc.UnaryServerInterceptor {
 	return nil
+}
+
+// HTTPRoundTripper returns base unchanged when test hooks are disabled.
+func HTTPRoundTripper(base http.RoundTripper, _ string, _ testhooks.TestHooks) http.RoundTripper {
+	return base
 }

--- a/common/rpc/faultinjection/interceptor_testdep.go
+++ b/common/rpc/faultinjection/interceptor_testdep.go
@@ -1,0 +1,45 @@
+//go:build test_dep
+
+package faultinjection
+
+import (
+	"context"
+
+	"go.temporal.io/server/common/testing/testhooks"
+	"google.golang.org/grpc"
+)
+
+// GRPCUnaryServerInterceptor returns a unary server interceptor that checks for
+// dynamically registered fault injection callbacks before and after the handler.
+//
+// This is primarily used for testing, allowing tests to register callbacks that
+// can inspect requests/responses and inject faults on demand.
+//
+// Behavior:
+// - If no generator is registered, the handler proceeds normally.
+// - Callbacks are checked before handler (resp=nil, err=nil). If matched, handler is skipped.
+// - Callbacks are checked after handler with actual resp/err. If matched, returned values are used.
+// - If no callbacks match, the handler's response/error is returned.
+func GRPCUnaryServerInterceptor(testHooks testhooks.TestHooks) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		generate, ok := testhooks.Get(testHooks, testhooks.RPCFaultGenerator, testhooks.GlobalScope)
+		if !ok {
+			return handler(ctx, req)
+		}
+
+		// Check before handler (can short-circuit)
+		if matched, resp, err := generate(ctx, info.FullMethod, req, nil, nil); matched {
+			return resp, err
+		}
+
+		// Call handler
+		resp, err := handler(ctx, req)
+
+		// Check after handler (can modify response/error)
+		if matched, newResp, newErr := generate(ctx, info.FullMethod, req, resp, err); matched {
+			return newResp, newErr
+		}
+
+		return resp, err
+	}
+}

--- a/common/rpc/faultinjection/interceptor_testdep.go
+++ b/common/rpc/faultinjection/interceptor_testdep.go
@@ -4,6 +4,7 @@ package faultinjection
 
 import (
 	"context"
+	"net/http"
 
 	"go.temporal.io/server/common/testing/testhooks"
 	"google.golang.org/grpc"
@@ -42,4 +43,45 @@ func GRPCUnaryServerInterceptor(testHooks testhooks.TestHooks) grpc.UnaryServerI
 
 		return resp, err
 	}
+}
+
+// HTTPRoundTripper wraps base so outbound HTTP calls (e.g. Nexus operation invocations to a
+// handler) pass through the same RPCFaultGenerator seam as gRPC: a registered callback can
+// hold (block, then decline), fail, or pass each call. The synthetic method handed to the
+// generator is "HTTP <METHOD> <path>". namespaceID scopes the call to its owning namespace.
+func HTTPRoundTripper(base http.RoundTripper, namespaceID string, testHooks testhooks.TestHooks) http.RoundTripper {
+	return &faultRoundTripper{base: base, namespaceID: namespaceID, testHooks: testHooks}
+}
+
+type faultRoundTripper struct {
+	base        http.RoundTripper
+	namespaceID string
+	testHooks   testhooks.TestHooks
+}
+
+func (f *faultRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	generate, ok := testhooks.Get(f.testHooks, testhooks.RPCFaultGenerator, testhooks.GlobalScope)
+	if !ok {
+		return f.base.RoundTrip(r)
+	}
+	method := "HTTP " + r.Method + " " + r.URL.Path
+	req := &HTTPFaultRequest{NamespaceID: f.namespaceID, Request: r}
+
+	// Before the call: a matching callback can fail it (return an error) or hold it (block,
+	// then decline the match so the call proceeds). A match without an error is ignored here
+	// (RoundTrip must not return a nil response and nil error).
+	if matched, _, err := generate(r.Context(), method, req, nil, nil); matched && err != nil {
+		return nil, err
+	}
+
+	resp, callErr := f.base.RoundTrip(r)
+
+	// After the call: a matching callback may replace the outcome with an error.
+	if matched, _, err := generate(r.Context(), method, req, resp, callErr); matched && err != nil {
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+		return nil, err
+	}
+	return resp, callErr
 }

--- a/common/testing/testhooks/hooks.go
+++ b/common/testing/testhooks/hooks.go
@@ -30,6 +30,7 @@ var (
 	HistoryTransferTaskInterceptor           = newKey[func(historytasks.Task, func()), namespace.ID]()
 	HistoryDLQTaskDeleteInterceptor          = newKey[func(context.Context, *historyservice.DeleteDLQTasksRequest, func(context.Context, *historyservice.DeleteDLQTasksRequest) (*historyservice.DeleteDLQTasksResponse, error)) (*historyservice.DeleteDLQTasksResponse, error), global]()
 	NamespaceReplicationTaskInterceptor      = newKey[func(context.Context, *replicationspb.NamespaceTaskAttributes, func() error) error, namespace.Name]()
+	RPCFaultGenerator                        = newKey[func(context.Context, string, any, any, error) (bool, any, error), global]()
 )
 
 // keyID is a unique identifier for a key, used as a map key.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -185,7 +185,29 @@ or if there's no SDK support for that API available yet.
 
 You'll find a fully initialized task poller in any functional test suite, look for `s.TaskPoller`.
 
-_NOTE: The previous `testcore.TaskPoller` has been deprecated and should not be used in new code._
+_NOTE_: The previous `testcore.TaskPoller` has been deprecated and should not be used in new code._
+
+### gRPC fault injection
+
+The `testcore` package injects faults into gRPC calls by intercepting requests and responses.
+The fault function determines which RPCs trigger a fault and returns the error to inject.
+Only the first matching request is affected.
+
+**Example:**
+
+```go
+testcore.InjectRPCFault(s.T(), s.GetTestCluster(),
+    func(req, _ any, _ error) error {
+        r, ok := req.(*matchingservice.AddWorkflowTaskRequest)
+        if ok {
+            return serviceerror.NewNotFound("injected fault")
+        }
+        return nil
+    })
+```
+
+The fault function receives `(req, resp, err)`. For pre-handler calls, `resp` and `err` are nil.
+Return an error to inject the fault, or nil to skip. The test fails if the fault never triggers.
 
 ### testhooks package
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -191,7 +191,7 @@ _NOTE_: The previous `testcore.TaskPoller` has been deprecated and should not be
 
 The `testcore` package injects faults into gRPC calls by intercepting requests and responses.
 The fault function determines which RPCs trigger a fault and returns the error to inject.
-Every matching request is affected until the fault is unregistered.
+`InjectRPCFault` returns a cleanup function that can be used to remove the fault again.
 
 **Example:**
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -191,7 +191,7 @@ _NOTE_: The previous `testcore.TaskPoller` has been deprecated and should not be
 
 The `testcore` package injects faults into gRPC calls by intercepting requests and responses.
 The fault function determines which RPCs trigger a fault and returns the error to inject.
-Only the first matching request is affected.
+Every matching request is affected until the fault is unregistered.
 
 **Example:**
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -191,7 +191,7 @@ _NOTE_: The previous `testcore.TaskPoller` has been deprecated and should not be
 
 The `testcore` package injects faults into gRPC calls by intercepting requests and responses.
 The fault function determines which RPCs trigger a fault and returns the error to inject.
-`InjectRPCFault` returns a cleanup function that can be used to remove the fault again.
+It returns a cleanup function that can be used to remove the fault again.
 
 **Example:**
 

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -309,7 +309,9 @@ func GrpcServerOptionsProvider(
 		// TODO: Deprecate WithChainedFrontendGrpcInterceptors and provide a inner custom interceptor
 		unaryInterceptors = append(unaryInterceptors, customInterceptors...)
 	}
-	unaryInterceptors = append(unaryInterceptors, faultinjection.GRPCUnaryServerInterceptor(testHooks))
+	if faultInterceptor := faultinjection.GRPCUnaryServerInterceptor(testHooks); faultInterceptor != nil {
+		unaryInterceptors = append(unaryInterceptors, faultInterceptor)
+	}
 	// retry interceptor should be the most inner interceptor
 	unaryInterceptors = append(unaryInterceptors, retryableInterceptor.Intercept)
 

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -294,11 +294,6 @@ func GrpcServerOptionsProvider(
 		redirectionInterceptor.Intercept,
 		// Telemetry interceptor must be after redirection to ensure metrics are recorded in the correct cluster
 		telemetryInterceptor.UnaryIntercept,
-	}
-	if faultInterceptor := faultinjection.GRPCUnaryServerInterceptor(testHooks); faultInterceptor != nil {
-		unaryInterceptors = append(unaryInterceptors, faultInterceptor)
-	}
-	unaryInterceptors = append(unaryInterceptors,
 		healthInterceptor.Intercept,
 		namespaceValidatorInterceptor.StateValidationIntercept,
 		namespaceCountLimiterInterceptor.Intercept,
@@ -309,11 +304,12 @@ func GrpcServerOptionsProvider(
 		slowRequestLoggerInterceptor.Intercept,
 		chasmRequestVisibilityInterceptor.Intercept,
 		contextMetadataInterceptor.Intercept,
-	)
+	}
 	if len(customInterceptors) > 0 {
 		// TODO: Deprecate WithChainedFrontendGrpcInterceptors and provide a inner custom interceptor
 		unaryInterceptors = append(unaryInterceptors, customInterceptors...)
 	}
+	unaryInterceptors = append(unaryInterceptors, faultinjection.GRPCUnaryServerInterceptor(testHooks))
 	// retry interceptor should be the most inner interceptor
 	unaryInterceptors = append(unaryInterceptors, retryableInterceptor.Intercept)
 

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -41,6 +41,7 @@ import (
 	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/common/rpc"
 	"go.temporal.io/server/common/rpc/encryption"
+	"go.temporal.io/server/common/rpc/faultinjection"
 	"go.temporal.io/server/common/rpc/interceptor"
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/searchattribute"
@@ -248,6 +249,7 @@ func GrpcServerOptionsProvider(
 	customInterceptors []grpc.UnaryServerInterceptor,
 	customStreamInterceptors []grpc.StreamServerInterceptor,
 	metricsHandler metrics.Handler,
+	testHooks testhooks.TestHooks,
 ) GrpcServerOptions {
 	kep := keepalive.EnforcementPolicy{
 		MinTime:             serviceConfig.KeepAliveMinTime(),
@@ -292,6 +294,7 @@ func GrpcServerOptionsProvider(
 		redirectionInterceptor.Intercept,
 		// Telemetry interceptor must be after redirection to ensure metrics are recorded in the correct cluster
 		telemetryInterceptor.UnaryIntercept,
+		faultinjection.GRPCUnaryServerInterceptor(testHooks),
 		healthInterceptor.Intercept,
 		namespaceValidatorInterceptor.StateValidationIntercept,
 		namespaceCountLimiterInterceptor.Intercept,

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -294,7 +294,11 @@ func GrpcServerOptionsProvider(
 		redirectionInterceptor.Intercept,
 		// Telemetry interceptor must be after redirection to ensure metrics are recorded in the correct cluster
 		telemetryInterceptor.UnaryIntercept,
-		faultinjection.GRPCUnaryServerInterceptor(testHooks),
+	}
+	if faultInterceptor := faultinjection.GRPCUnaryServerInterceptor(testHooks); faultInterceptor != nil {
+		unaryInterceptors = append(unaryInterceptors, faultInterceptor)
+	}
+	unaryInterceptors = append(unaryInterceptors,
 		healthInterceptor.Intercept,
 		namespaceValidatorInterceptor.StateValidationIntercept,
 		namespaceCountLimiterInterceptor.Intercept,
@@ -305,7 +309,7 @@ func GrpcServerOptionsProvider(
 		slowRequestLoggerInterceptor.Intercept,
 		chasmRequestVisibilityInterceptor.Intercept,
 		contextMetadataInterceptor.Intercept,
-	}
+	)
 	if len(customInterceptors) > 0 {
 		// TODO: Deprecate WithChainedFrontendGrpcInterceptors and provide a inner custom interceptor
 		unaryInterceptors = append(unaryInterceptors, customInterceptors...)

--- a/service/fx.go
+++ b/service/fx.go
@@ -165,9 +165,11 @@ func getUnaryInterceptors(params GrpcServerOptionsParams) []grpc.UnaryServerInte
 		metrics.NewServerMetricsContextInjectorInterceptor(),
 		metrics.NewServerMetricsTrailerPropagatorInterceptor(params.Logger),
 		params.TelemetryInterceptor.UnaryIntercept,
-		faultinjection.GRPCUnaryServerInterceptor(params.TestHooks),
 	}
 
+	if faultInterceptor := faultinjection.GRPCUnaryServerInterceptor(params.TestHooks); faultInterceptor != nil {
+		interceptors = append(interceptors, faultInterceptor)
+	}
 	interceptors = append(interceptors, params.AdditionalInterceptors...)
 
 	if params.NamespaceRateLimitInterceptor != nil {

--- a/service/fx.go
+++ b/service/fx.go
@@ -13,8 +13,10 @@ import (
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/quotas/calculator"
 	"go.temporal.io/server/common/rpc"
+	"go.temporal.io/server/common/rpc/faultinjection"
 	"go.temporal.io/server/common/rpc/interceptor"
 	"go.temporal.io/server/common/telemetry"
+	"go.temporal.io/server/common/testing/testhooks"
 	"go.uber.org/fx"
 	"google.golang.org/grpc"
 )
@@ -50,6 +52,7 @@ type (
 		ContextMetadataInterceptor    *interceptor.ContextMetadataInterceptor `optional:"true"`
 		AdditionalInterceptors        []grpc.UnaryServerInterceptor           `optional:"true"`
 		AdditionalStreamInterceptors  []grpc.StreamServerInterceptor          `optional:"true"`
+		TestHooks                     testhooks.TestHooks
 	}
 )
 
@@ -162,6 +165,7 @@ func getUnaryInterceptors(params GrpcServerOptionsParams) []grpc.UnaryServerInte
 		metrics.NewServerMetricsContextInjectorInterceptor(),
 		metrics.NewServerMetricsTrailerPropagatorInterceptor(params.Logger),
 		params.TelemetryInterceptor.UnaryIntercept,
+		faultinjection.GRPCUnaryServerInterceptor(params.TestHooks),
 	}
 
 	interceptors = append(interceptors, params.AdditionalInterceptors...)

--- a/service/fx.go
+++ b/service/fx.go
@@ -179,7 +179,9 @@ func getUnaryInterceptors(params GrpcServerOptionsParams) []grpc.UnaryServerInte
 		interceptors = append(interceptors, params.ContextMetadataInterceptor.Intercept)
 	}
 
-	interceptors = append(interceptors, faultinjection.GRPCUnaryServerInterceptor(params.TestHooks))
+	if faultInterceptor := faultinjection.GRPCUnaryServerInterceptor(params.TestHooks); faultInterceptor != nil {
+		interceptors = append(interceptors, faultInterceptor)
+	}
 
 	return append(interceptors, params.RetryableInterceptor.Intercept)
 }

--- a/service/fx.go
+++ b/service/fx.go
@@ -167,9 +167,6 @@ func getUnaryInterceptors(params GrpcServerOptionsParams) []grpc.UnaryServerInte
 		params.TelemetryInterceptor.UnaryIntercept,
 	}
 
-	if faultInterceptor := faultinjection.GRPCUnaryServerInterceptor(params.TestHooks); faultInterceptor != nil {
-		interceptors = append(interceptors, faultInterceptor)
-	}
 	interceptors = append(interceptors, params.AdditionalInterceptors...)
 
 	if params.NamespaceRateLimitInterceptor != nil {
@@ -181,6 +178,8 @@ func getUnaryInterceptors(params GrpcServerOptionsParams) []grpc.UnaryServerInte
 	if params.ContextMetadataInterceptor != nil {
 		interceptors = append(interceptors, params.ContextMetadataInterceptor.Intercept)
 	}
+
+	interceptors = append(interceptors, faultinjection.GRPCUnaryServerInterceptor(params.TestHooks))
 
 	return append(interceptors, params.RetryableInterceptor.Intercept)
 }

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"slices"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -44,6 +46,7 @@ import (
 	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/common/nexus/nexustest"
 	"go.temporal.io/server/common/payloads"
+	"go.temporal.io/server/common/rpc/faultinjection"
 	"go.temporal.io/server/common/testing/historyrequire"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/common/testing/protorequire"
@@ -1922,11 +1925,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelBeforeStarted_Cancelati
 
 	h := nexustest.Handler{
 		OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
-			select {
-			case <-canStartCh:
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			}
 			return &nexus.HandlerStartOperationResultAsync{OperationToken: "test"}, nil
 		},
 		OnCancelOperation: func(ctx context.Context, service, operation, token string, options nexus.CancelOperationOptions) error {
@@ -1935,6 +1933,20 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelBeforeStarted_Cancelati
 		},
 	}
 	endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
+
+	var faultInjected atomic.Bool
+	env.InjectRPCFault(func(req, resp any, _ error) error {
+		httpRequest, ok := req.(*faultinjection.HTTPFaultRequest)
+		if !ok || resp != nil || httpRequest.Request.Method != http.MethodPost || faultInjected.Swap(true) {
+			return nil
+		}
+		select {
+		case <-canStartCh:
+			return errors.New("injected HTTP fault")
+		case <-httpRequest.Request.Context().Done():
+			return httpRequest.Request.Context().Err()
+		}
+	})
 
 	callerWF := func(ctx workflow.Context) error {
 		opCtx, cancel := workflow.WithCancel(ctx)

--- a/tests/testcore/fault_injection.go
+++ b/tests/testcore/fault_injection.go
@@ -1,0 +1,104 @@
+package testcore
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+)
+
+// RPCFault determines whether a fault should be injected for a given RPC.
+// It receives the request, response, and error.
+// For pre-handler calls, resp and err are nil.
+// Return the error to inject, or nil to not inject a fault.
+type RPCFault func(req, resp any, err error) error
+
+// RPCFaultOption configures the behavior of [InjectRPCFault].
+type RPCFaultOption func(*rpcFaultOptions)
+
+type rpcFaultOptions struct {
+	namespaceID   string
+	namespaceName string
+}
+
+// WithNamespaceID filters faults to only fire for requests whose GetNamespaceId()
+// matches the given namespace ID.
+func WithNamespaceID(id string) RPCFaultOption {
+	return func(o *rpcFaultOptions) {
+		o.namespaceID = id
+	}
+}
+
+// WithNamespaceName filters faults to only fire for requests whose GetNamespace()
+// matches the given namespace name.
+func WithNamespaceName(name string) RPCFaultOption {
+	return func(o *rpcFaultOptions) {
+		o.namespaceName = name
+	}
+}
+
+// InjectRPCFault registers a fault injection that applies to all services
+// (frontend, history, matching). The fault function determines which requests
+// trigger a fault and what error to return.
+//
+// The fault function is called twice per RPC: before the handler (resp=nil, err=nil)
+// and after. Returning an error before handler short-circuits; returning after
+// modifies the response.
+//
+// Returns a cleanup function that disables the fault injection when called.
+// The test fails if the fault is never injected before the test completes.
+//
+// Example:
+//
+//	testcore.InjectRPCFault(s.T(), s.GetTestCluster(),
+//	    func(req, _ any, _ error) error {
+//	        r, ok := req.(*matchingservice.AddWorkflowTaskRequest)
+//	        if ok {
+//	            return serviceerror.NewNotFound("injected fault")
+//	        }
+//	        return nil
+//	    })
+func InjectRPCFault(t testing.TB, tc *TestCluster, fault RPCFault, opts ...RPCFaultOption) func() {
+	t.Helper()
+
+	var options rpcFaultOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	generator := tc.Host().GetFaultInjector()
+	if generator == nil {
+		t.Fatal("fault injector is nil")
+		return func() {}
+	}
+
+	var fired atomic.Bool
+
+	unregister := generator.RegisterCallback(func(ctx context.Context, fullMethod string, req, resp any, err error) (bool, any, error) {
+		if options.namespaceID != "" {
+			if r, ok := req.(interface{ GetNamespaceId() string }); ok && r.GetNamespaceId() != options.namespaceID {
+				return false, nil, nil
+			}
+		}
+		if options.namespaceName != "" {
+			if r, ok := req.(interface{ GetNamespace() string }); ok && r.GetNamespace() != options.namespaceName {
+				return false, nil, nil
+			}
+		}
+
+		if injectedErr := fault(req, resp, err); injectedErr != nil {
+			fired.Store(true)
+			t.Logf("Fault injection fired: %T", req)
+			return true, nil, injectedErr
+		}
+		return false, nil, nil
+	})
+
+	t.Cleanup(func() {
+		unregister()
+		if !fired.Load() {
+			t.Error("fault injection was registered but never fired - the fault was never injected")
+		}
+	})
+
+	return unregister
+}

--- a/tests/testcore/fault_injection.go
+++ b/tests/testcore/fault_injection.go
@@ -38,16 +38,16 @@ func (o rpcFaultOptions) matchesNamespace(req any) bool {
 	return false
 }
 
-// WithNamespaceID filters faults to only fire for requests whose GetNamespaceId()
-// matches the given namespace ID.
+// WithNamespaceID matches requests that expose the given namespace ID.
+// When combined with [WithNamespaceName], matching either option is sufficient.
 func WithNamespaceID(id string) RPCFaultOption {
 	return func(o *rpcFaultOptions) {
 		o.namespaceID = id
 	}
 }
 
-// WithNamespaceName filters faults to only fire for requests whose GetNamespace()
-// matches the given namespace name.
+// WithNamespaceName matches requests that expose the given namespace name.
+// When combined with [WithNamespaceID], matching either option is sufficient.
 func WithNamespaceName(name string) RPCFaultOption {
 	return func(o *rpcFaultOptions) {
 		o.namespaceName = name

--- a/tests/testcore/fault_injection.go
+++ b/tests/testcore/fault_injection.go
@@ -20,6 +20,35 @@ type rpcFaultOptions struct {
 	namespaceName string
 }
 
+func (o rpcFaultOptions) matchesNamespace(req any) bool {
+	if o.namespaceID == "" && o.namespaceName == "" {
+		return true
+	}
+
+	matched := false
+	if o.namespaceID != "" {
+		if r, ok := req.(interface{ GetNamespaceId() string }); ok {
+			if namespaceID := r.GetNamespaceId(); namespaceID != "" {
+				if namespaceID != o.namespaceID {
+					return false
+				}
+				matched = true
+			}
+		}
+	}
+	if o.namespaceName != "" {
+		if r, ok := req.(interface{ GetNamespace() string }); ok {
+			if namespaceName := r.GetNamespace(); namespaceName != "" {
+				if namespaceName != o.namespaceName {
+					return false
+				}
+				matched = true
+			}
+		}
+	}
+	return matched
+}
+
 // WithNamespaceID filters faults to only fire for requests whose GetNamespaceId()
 // matches the given namespace ID.
 func WithNamespaceID(id string) RPCFaultOption {
@@ -74,15 +103,8 @@ func InjectRPCFault(t testing.TB, tc *TestCluster, fault RPCFault, opts ...RPCFa
 	var fired atomic.Bool
 
 	unregister := generator.RegisterCallback(func(ctx context.Context, fullMethod string, req, resp any, err error) (bool, any, error) {
-		if options.namespaceID != "" {
-			if r, ok := req.(interface{ GetNamespaceId() string }); ok && r.GetNamespaceId() != options.namespaceID {
-				return false, nil, nil
-			}
-		}
-		if options.namespaceName != "" {
-			if r, ok := req.(interface{ GetNamespace() string }); ok && r.GetNamespace() != options.namespaceName {
-				return false, nil, nil
-			}
+		if !options.matchesNamespace(req) {
+			return false, nil, nil
 		}
 
 		if injectedErr := fault(req, resp, err); injectedErr != nil {

--- a/tests/testcore/fault_injection.go
+++ b/tests/testcore/fault_injection.go
@@ -25,28 +25,17 @@ func (o rpcFaultOptions) matchesNamespace(req any) bool {
 		return true
 	}
 
-	matched := false
 	if o.namespaceID != "" {
-		if r, ok := req.(interface{ GetNamespaceId() string }); ok {
-			if namespaceID := r.GetNamespaceId(); namespaceID != "" {
-				if namespaceID != o.namespaceID {
-					return false
-				}
-				matched = true
-			}
+		if r, ok := req.(interface{ GetNamespaceId() string }); ok && r.GetNamespaceId() == o.namespaceID {
+			return true
 		}
 	}
 	if o.namespaceName != "" {
-		if r, ok := req.(interface{ GetNamespace() string }); ok {
-			if namespaceName := r.GetNamespace(); namespaceName != "" {
-				if namespaceName != o.namespaceName {
-					return false
-				}
-				matched = true
-			}
+		if r, ok := req.(interface{ GetNamespace() string }); ok && r.GetNamespace() == o.namespaceName {
+			return true
 		}
 	}
-	return matched
+	return false
 }
 
 // WithNamespaceID filters faults to only fire for requests whose GetNamespaceId()

--- a/tests/testcore/fault_injection_test.go
+++ b/tests/testcore/fault_injection_test.go
@@ -1,0 +1,88 @@
+//go:build test_dep
+
+package testcore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/api/matchingservice/v1"
+)
+
+func TestRPCFaultOptionsMatchesNamespace(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		options rpcFaultOptions
+		request any
+		matches bool
+	}{
+		{
+			name:    "no filters",
+			request: struct{}{},
+			matches: true,
+		},
+		{
+			name:    "matching namespace ID",
+			options: rpcFaultOptions{namespaceID: "namespace-id"},
+			request: &matchingservice.AddWorkflowTaskRequest{NamespaceId: "namespace-id"},
+			matches: true,
+		},
+		{
+			name: "matching namespace ID with both filters",
+			options: rpcFaultOptions{
+				namespaceID:   "namespace-id",
+				namespaceName: "namespace-name",
+			},
+			request: &matchingservice.AddWorkflowTaskRequest{NamespaceId: "namespace-id"},
+			matches: true,
+		},
+		{
+			name:    "mismatched namespace ID",
+			options: rpcFaultOptions{namespaceID: "namespace-id"},
+			request: &matchingservice.AddWorkflowTaskRequest{NamespaceId: "other-namespace-id"},
+		},
+		{
+			name:    "empty namespace ID",
+			options: rpcFaultOptions{namespaceID: "namespace-id"},
+			request: &matchingservice.AddWorkflowTaskRequest{},
+		},
+		{
+			name:    "matching namespace name",
+			options: rpcFaultOptions{namespaceName: "namespace-name"},
+			request: &workflowservice.StartWorkflowExecutionRequest{Namespace: "namespace-name"},
+			matches: true,
+		},
+		{
+			name: "matching namespace name with both filters",
+			options: rpcFaultOptions{
+				namespaceID:   "namespace-id",
+				namespaceName: "namespace-name",
+			},
+			request: &workflowservice.StartWorkflowExecutionRequest{Namespace: "namespace-name"},
+			matches: true,
+		},
+		{
+			name:    "mismatched namespace name",
+			options: rpcFaultOptions{namespaceName: "namespace-name"},
+			request: &workflowservice.StartWorkflowExecutionRequest{Namespace: "other-namespace-name"},
+		},
+		{
+			name: "namespace-less request",
+			options: rpcFaultOptions{
+				namespaceID:   "namespace-id",
+				namespaceName: "namespace-name",
+			},
+			request: struct{}{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.matches, tc.options.matchesNamespace(tc.request))
+		})
+	}
+}

--- a/tests/testcore/onebox.go
+++ b/tests/testcore/onebox.go
@@ -32,6 +32,7 @@ import (
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/rpc/auth"
 	"go.temporal.io/server/common/rpc/encryption"
+	rpcfaultinjection "go.temporal.io/server/common/rpc/faultinjection"
 	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/components/nexusoperations"
 	"go.temporal.io/server/temporal"
@@ -64,6 +65,7 @@ type (
 
 		replicationStreamRecorder *ReplicationStreamRecorder
 		historyTaskRecorder       *HistoryTaskRecorder
+		faultInjector             *rpcfaultinjection.RPCFaultGenerator
 
 		callbackLock sync.RWMutex
 		onGetClaims  func(*authorization.AuthInfo) (*authorization.Claims, error)
@@ -128,7 +130,9 @@ func newTemporal(t *testing.T, params *temporalParams) *temporalImpl {
 		hostsByProtocolByService:  params.HostsByProtocolByService,
 		workerConfig:              params.WorkerConfig,
 		replicationStreamRecorder: NewReplicationStreamRecorder(),
+		faultInjector:             rpcfaultinjection.NewRPCFaultGenerator(),
 	}
+	testhooks.Set(impl.testHooks, testhooks.RPCFaultGenerator, impl.faultInjector.Generate, testhooks.GlobalScope)
 
 	// Base options are independent of which services this test cluster starts.
 	// [Start] adds the per-service config and static host map.
@@ -349,6 +353,10 @@ func (c *temporalImpl) ChasmContext(ctx context.Context) (context.Context, error
 
 func (c *temporalImpl) GetHistoryTaskRecorder() *HistoryTaskRecorder {
 	return c.historyTaskRecorder
+}
+
+func (c *temporalImpl) GetFaultInjector() *rpcfaultinjection.RPCFaultGenerator {
+	return c.faultInjector
 }
 
 func (c *temporalImpl) TLSConfigProvider() *encryption.FixedTLSConfigProvider {

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -441,6 +441,17 @@ func (e *TestEnv) Tv() *testvars.TestVars {
 	return e.tv
 }
 
+// InjectRPCFault registers a fault injection scoped to this test's namespace.
+// Both namespace ID and name filters are applied automatically.
+// Returns a cleanup function that disables the fault.
+func (e *TestEnv) InjectRPCFault(fault RPCFault, opts ...RPCFaultOption) func() {
+	opts = append([]RPCFaultOption{
+		WithNamespaceID(e.nsID.String()),
+		WithNamespaceName(e.nsName.String()),
+	}, opts...)
+	return InjectRPCFault(e.t, e.GetTestCluster(), fault, opts...)
+}
+
 // Context returns the test-level timeout context with RPC version headers already included.
 // This context will be canceled when the test timeout occurs. Use this directly for all RPC
 // operations - no need to wrap with NewContext or add headers manually.

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -442,7 +442,8 @@ func (e *TestEnv) Tv() *testvars.TestVars {
 }
 
 // InjectRPCFault registers a fault injection scoped to this test's namespace.
-// Both namespace ID and name filters are applied automatically.
+// Requests match either the namespace ID or name filter, depending on which
+// namespace field they expose. Requests without either field are ignored.
 // Returns a cleanup function that disables the fault.
 func (e *TestEnv) InjectRPCFault(fault RPCFault, opts ...RPCFaultOption) func() {
 	opts = append([]RPCFaultOption{

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -18,11 +18,13 @@ import (
 	updatepb "go.temporal.io/api/update/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
+	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/common/testing/protoutils"
 	"go.temporal.io/server/common/testing/taskpoller"
@@ -1380,15 +1382,35 @@ func (s *WorkflowUpdateSuite) TestStickySpeculativeWorkflowTask_AcceptComplete_S
 	env := testcore.NewEnv(s.T())
 	mustStartWorkflow(env, env.Tv())
 
-	wtHandlerCalls := 0
-	wtHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
-		wtHandlerCalls++
-		switch wtHandlerCalls {
-		case 1:
-			// Completes first WT with empty command list.
-			return nil, nil
-		case 2:
-			// Worker gets full history because update was issued after sticky worker is gone.
+	// Drain existing WT from regular task queue, respond with sticky attributes to enable sticky task queue.
+	_, err := env.TaskPoller().PollAndHandleWorkflowTask(env.Tv(),
+		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+			return &workflowservice.RespondWorkflowTaskCompletedRequest{
+				StickyAttributes: env.Tv().StickyExecutionAttributes(10 * time.Second),
+			}, nil
+		})
+	s.NoError(err)
+
+	// Inject StickyWorkerUnavailable for AddWorkflowTask on the sticky queue.
+	// This causes history to fall back to the normal queue.
+	env.InjectRPCFault(
+		func(req, resp any, _ error) error {
+			r, ok := req.(*matchingservice.AddWorkflowTaskRequest)
+			if ok && resp == nil && r.GetTaskQueue().GetKind() == enumspb.TASK_QUEUE_KIND_STICKY {
+				return serviceerrors.NewStickyWorkerUnavailable()
+			}
+			return nil
+		})
+
+	// Send an update. History tries sticky queue first, gets StickyWorkerUnavailable,
+	// and falls back to the normal queue.
+	updateResultCh := sendUpdateNoError(env, env.Tv())
+
+	// Process update in workflow task from non-sticky task queue.
+	res, err := env.TaskPoller().PollAndHandleWorkflowTask(env.Tv(),
+		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+			// Full history from event 1 confirms the task came from the normal queue
+			// (sticky queue would send partial history starting after the last completed WT).
 			s.EqualHistory(`
 	  1 WorkflowExecutionStarted
 	  2 WorkflowTaskScheduled
@@ -1397,20 +1419,7 @@ func (s *WorkflowUpdateSuite) TestStickySpeculativeWorkflowTask_AcceptComplete_S
 	  5 WorkflowTaskScheduled // Speculative WT.
 	  6 WorkflowTaskStarted
 	`, task.History)
-			return env.UpdateAcceptCompleteCommands(env.Tv()), nil
-		default:
-			s.Failf("wtHandler called too many times", "wtHandler shouldn't be called %d times", wtHandlerCalls)
-			return nil, nil
-		}
-	}
 
-	msgHandlerCalls := 0
-	msgHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*protocolpb.Message, error) {
-		msgHandlerCalls++
-		switch msgHandlerCalls {
-		case 1:
-			return nil, nil
-		case 2:
 			updRequestMsg := task.Messages[0]
 			updRequest := protoutils.UnmarshalAny[*updatepb.Request](s.T(), updRequestMsg.GetBody())
 
@@ -1418,52 +1427,16 @@ func (s *WorkflowUpdateSuite) TestStickySpeculativeWorkflowTask_AcceptComplete_S
 			s.Equal(env.Tv().HandlerName(), updRequest.GetInput().GetName())
 			s.EqualValues(5, updRequestMsg.GetEventId())
 
-			return env.UpdateAcceptCompleteMessages(env.Tv(), updRequestMsg), nil
-		default:
-			s.Failf("msgHandler called too many times", "msgHandler shouldn't be called %d times", msgHandlerCalls)
-			return nil, nil
-		}
-	}
-
-	//nolint:staticcheck // SA1019 TaskPoller replacement needed
-	poller := &testcore.TaskPoller{
-		Client:                       env.FrontendClient(),
-		Namespace:                    env.Namespace().String(),
-		TaskQueue:                    env.Tv().TaskQueue(),
-		StickyTaskQueue:              env.Tv().StickyTaskQueue(),
-		StickyScheduleToStartTimeout: 3 * time.Second,
-		Identity:                     env.Tv().WorkerIdentity(),
-		WorkflowTaskHandler:          wtHandler,
-		MessageHandler:               msgHandler,
-		Logger:                       env.Logger,
-		T:                            s.T(),
-	}
-
-	// Drain existing WT from regular task queue, but respond with sticky enabled response to enable stick task queue.
-	_, err := poller.PollAndProcessWorkflowTask(testcore.WithRespondSticky, testcore.WithoutRetries)
-	s.NoError(err)
-
-	env.Logger.Info("Sleep 10+ seconds to make sure stickyPollerUnavailableWindow time has passed.")
-	time.Sleep(10*time.Second + 100*time.Millisecond) //nolint:forbidigo
-	env.Logger.Info("Sleep 10+ seconds is done.")
-
-	// Now send an update. It should try sticky task queue first, but got "StickyWorkerUnavailable" error
-	// and resend it to normal.
-	// This can be observed in wtHandler: if history is partial => sticky task queue is used.
-	updateResultCh := sendUpdateNoError(env, env.Tv())
-
-	// Process update in workflow task from non-sticky task queue.
-	res, err := poller.PollAndProcessWorkflowTask(testcore.WithoutRetries)
+			return &workflowservice.RespondWorkflowTaskCompletedRequest{
+				Commands: env.UpdateAcceptCompleteCommands(env.Tv()),
+				Messages: env.UpdateAcceptCompleteMessages(env.Tv(), updRequestMsg),
+			}, nil
+		})
 	s.NoError(err)
 	s.NotNil(res)
 	updateResult := <-updateResultCh
 	s.Equal("success-result-of-"+env.Tv().UpdateID(), testcore.DecodeString(s.T(), updateResult.GetOutcome().GetSuccess()))
-	s.EqualValues(0, res.NewTask.ResetHistoryEventId)
-
-	s.Equal(2, wtHandlerCalls)
-	s.Equal(2, msgHandlerCalls)
-
-	events := env.GetHistory(env.Namespace().String(), env.Tv().WorkflowExecution())
+	s.EqualValues(0, res.ResetHistoryEventId)
 
 	s.EqualHistoryEvents(`
 	  1 WorkflowExecutionStarted
@@ -1475,7 +1448,7 @@ func (s *WorkflowUpdateSuite) TestStickySpeculativeWorkflowTask_AcceptComplete_S
 	  7 WorkflowTaskCompleted
 	  8 WorkflowExecutionUpdateAccepted {"AcceptedRequestSequencingEventId": 5} // WTScheduled event which delivered update to the worker.
 	  9 WorkflowExecutionUpdateCompleted {"AcceptedEventId": 8}
-	`, events)
+	`, env.GetHistory(env.Namespace().String(), env.Tv().WorkflowExecution()))
 }
 
 func (s *WorkflowUpdateSuite) TestFirstNormalScheduledWorkflowTask_Reject() {


### PR DESCRIPTION
Depends on #9076.

## What changed?

- Route outbound Nexus HTTP requests through the programmable RPC fault injector in test builds.
- Add focused transport tests.
- Use HTTP fault injection in the cancellation-before-start Nexus functional test.

## Why?

This enables deterministic tests for outbound Nexus HTTP failures and request holds using the same namespace-scoped fault injection API as gRPC.

## How did you test it?

- `go test -tags test_dep ./common/rpc/faultinjection ./tests/testcore`
- `go test ./common/rpc/faultinjection ./chasm/lib/nexusoperation`
- `go test -tags test_dep ./tests -run 'TestNexusWorkflowTestSuite(HSM|CHASM)/TestNexusOperationCancelBeforeStarted_CancelationEventuallyDelivered$' -count=1 -timeout=5m`