### PR TITLE
Support ExecutionStatus filter in s3store and gcloud visibility archi…

### DIFF
--- a/common/archiver/filestore/query_parser.go
+++ b/common/archiver/filestore/query_parser.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/temporalio/sqlparser"
 	enumspb "go.temporal.io/api/enums/v1"
-	"go.temporal.io/server/common/convert"
 	"go.temporal.io/server/common/sqlquery"
 	"go.temporal.io/server/common/util"
 )
@@ -158,7 +157,7 @@ func (p *queryParser) convertComparisonExpr(compExpr *sqlparser.ComparisonExpr, 
 		if op != "=" {
 			return fmt.Errorf("only operation = is support for %s", ExecutionStatus)
 		}
-		status, err := convertStatusStr(val)
+		status, err := sqlquery.ConvertStatusStr(val)
 		if err != nil {
 			return err
 		}
@@ -201,24 +200,4 @@ func (p *queryParser) convertCloseTime(timestamp time.Time, op string, parsedQue
 		return fmt.Errorf("operator %s is not supported for close time", op)
 	}
 	return nil
-}
-
-func convertStatusStr(statusStr string) (enumspb.WorkflowExecutionStatus, error) {
-	statusStr = strings.ToLower(strings.TrimSpace(statusStr))
-	switch statusStr {
-	case "completed", convert.Int32ToString(int32(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED)):
-		return enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, nil
-	case "failed", convert.Int32ToString(int32(enumspb.WORKFLOW_EXECUTION_STATUS_FAILED)):
-		return enumspb.WORKFLOW_EXECUTION_STATUS_FAILED, nil
-	case "canceled", convert.Int32ToString(int32(enumspb.WORKFLOW_EXECUTION_STATUS_CANCELED)):
-		return enumspb.WORKFLOW_EXECUTION_STATUS_CANCELED, nil
-	case "terminated", convert.Int32ToString(int32(enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED)):
-		return enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED, nil
-	case "continuedasnew", "continued_as_new", convert.Int32ToString(int32(enumspb.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW)):
-		return enumspb.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW, nil
-	case "timedout", "timed_out", convert.Int32ToString(int32(enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT)):
-		return enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT, nil
-	default:
-		return 0, fmt.Errorf("unknown workflow close status: %s", statusStr)
-	}
 }

--- a/common/archiver/gcloud/README.md
+++ b/common/archiver/gcloud/README.md
@@ -54,8 +54,13 @@ Supported column names are
 - StartTime *Date*
 - CloseTime *Date*
 - SearchPrecision *String - Day, Hour, Minute, Second*
+- ExecutionStatus *String - Completed, Failed, Canceled, Terminated, ContinuedAsNew, TimedOut*
 
 One of these fields are required, StartTime or CloseTime and they are mutually exclusive and also SearchPrecision.
+
+ExecutionStatus is not part of the object name, so it is matched after records are read rather than
+narrowing the objects scanned. A page may therefore return fewer than the requested number of records
+while still reporting a next page token.
 
 Searching for a record will be done in times in the UTC timezone
 

--- a/common/archiver/gcloud/query_parser.go
+++ b/common/archiver/gcloud/query_parser.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/temporalio/sqlparser"
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/common/sqlquery"
 )
 
@@ -26,6 +27,7 @@ type (
 		closeTime       time.Time
 		searchPrecision *string
 		runID           *string
+		status          *enumspb.WorkflowExecutionStatus
 		emptyResult     bool
 	}
 )
@@ -38,6 +40,8 @@ const (
 	CloseTime       = "CloseTime"
 	StartTime       = "StartTime"
 	SearchPrecision = "SearchPrecision"
+	// Field name can't be just "Status" because it is reserved keyword in MySQL parser.
+	ExecutionStatus = "ExecutionStatus"
 )
 
 // Precision specific values
@@ -175,6 +179,24 @@ func (p *queryParser) convertComparisonExpr(compExpr *sqlparser.ComparisonExpr, 
 			return nil
 		}
 		parsedQuery.workflowType = new(val)
+	case ExecutionStatus:
+		val, err := sqlquery.ExtractStringValue(valStr)
+		if err != nil {
+			// if failed to extract string value, it means user input close status as a number
+			val = valStr
+		}
+		if op != "=" {
+			return fmt.Errorf("only operation = is support for %s", ExecutionStatus)
+		}
+		status, err := sqlquery.ConvertStatusStr(val)
+		if err != nil {
+			return err
+		}
+		if parsedQuery.status != nil && *parsedQuery.status != status {
+			parsedQuery.emptyResult = true
+			return nil
+		}
+		parsedQuery.status = &status
 	case SearchPrecision:
 		val, err := sqlquery.ExtractStringValue(valStr)
 		if err != nil {

--- a/common/archiver/gcloud/query_parser_test.go
+++ b/common/archiver/gcloud/query_parser_test.go
@@ -1,0 +1,84 @@
+package gcloud
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	enumspb "go.temporal.io/api/enums/v1"
+)
+
+type queryParserSuite struct {
+	*require.Assertions
+	suite.Suite
+
+	parser QueryParser
+}
+
+func TestQueryParserSuite(t *testing.T) {
+	suite.Run(t, new(queryParserSuite))
+}
+
+func (s *queryParserSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+	s.parser = NewQueryParser()
+}
+
+func (s *queryParserSuite) TestParseExecutionStatus() {
+	const commonQueryPart = "CloseTime = 1000 and SearchPrecision = 'Day' and "
+
+	testCases := []struct {
+		query       string
+		expectErr   bool
+		status      *enumspb.WorkflowExecutionStatus
+		emptyResult bool
+	}{
+		{
+			query:  commonQueryPart + "ExecutionStatus = \"Completed\"",
+			status: new(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED),
+		},
+		{
+			query:  commonQueryPart + "ExecutionStatus = 'failed'",
+			status: new(enumspb.WORKFLOW_EXECUTION_STATUS_FAILED),
+		},
+		{
+			query:  commonQueryPart + "ExecutionStatus = 'TIMED_OUT'",
+			status: new(enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT),
+		},
+		{
+			query:  commonQueryPart + "ExecutionStatus = 4",
+			status: new(enumspb.WORKFLOW_EXECUTION_STATUS_CANCELED),
+		},
+		{
+			// no ExecutionStatus filter leaves the field unset
+			query:  "CloseTime = 1000 and SearchPrecision = 'Day'",
+			status: nil,
+		},
+		{
+			// conflicting values can never match, matching how gcloud treats
+			// conflicting WorkflowId/RunId/WorkflowType filters
+			query:       commonQueryPart + "ExecutionStatus = 'Failed' and ExecutionStatus = 'Completed'",
+			status:      new(enumspb.WORKFLOW_EXECUTION_STATUS_FAILED),
+			emptyResult: true,
+		},
+		{
+			query:     commonQueryPart + "ExecutionStatus = \"unknown\"",
+			expectErr: true,
+		},
+		{
+			query:     commonQueryPart + "ExecutionStatus > \"Failed\"",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		parsedQuery, err := s.parser.Parse(tc.query)
+		if tc.expectErr {
+			s.Error(err, tc.query)
+			continue
+		}
+		s.NoError(err, tc.query)
+		s.Equal(tc.status, parsedQuery.status, tc.query)
+		s.Equal(tc.emptyResult, parsedQuery.emptyResult, tc.query)
+	}
+}

--- a/common/archiver/gcloud/visibility_archiver.go
+++ b/common/archiver/gcloud/visibility_archiver.go
@@ -253,6 +253,12 @@ func (v *visibilityArchiver) queryPrefix(ctx context.Context, uri archiver.URI, 
 			return nil, &serviceerror.InvalidArgument{Message: err.Error()}
 		}
 
+		// ExecutionStatus is not part of the filename, so it can only be matched after the
+		// record is decoded. Skip non-matching records before converting them.
+		if request.parsedQuery.status != nil && record.Status != *request.parsedQuery.status {
+			continue
+		}
+
 		executionInfo, err := convertToExecutionInfo(record, saTypeMap)
 		if err != nil {
 			return nil, serviceerror.NewInternal(err.Error())

--- a/common/archiver/gcloud/visibility_archiver_test.go
+++ b/common/archiver/gcloud/visibility_archiver_test.go
@@ -264,6 +264,41 @@ func (s *visibilityArchiverSuite) TestQuery_Success_NoNextPageToken() {
 	s.ProtoEqual(ei, response.Executions[0])
 }
 
+func (s *visibilityArchiverSuite) TestQuery_Success_ExecutionStatusFilter() {
+	ctx := context.Background()
+	URI, err := archiver.NewURI("gs://my-bucket-cad/temporal_archival/visibility")
+	s.NoError(err)
+	filename := "closeTimeout_2020-02-05T09:56:14Z_test-workflow-id_MobileOnlyWorkflow::processMobileOnly_test-run-id.visibility"
+	storageWrapper := connector.NewMockClient(s.controller)
+	storageWrapper.EXPECT().Exist(gomock.Any(), URI, gomock.Any()).Return(false, nil)
+	storageWrapper.EXPECT().QueryWithFilters(gomock.Any(), URI, gomock.Any(), 10, 0, gomock.Any()).Return([]string{filename}, true, 1, nil)
+	storageWrapper.EXPECT().Get(gomock.Any(), URI, "test-namespace-id/"+filename).Return([]byte(exampleVisibilityRecord), nil)
+
+	visibilityArchiver := newVisibilityArchiver(s.logger, s.metricsHandler, storageWrapper)
+
+	// the archived record is Completed, so a Failed filter must exclude it
+	mockParser := NewMockQueryParser(s.controller)
+	dayPrecision := "Day"
+	closeTime, _ := time.Parse(time.RFC3339, "2019-10-04T11:00:00+00:00")
+	mockParser.EXPECT().Parse(gomock.Any()).Return(&parsedQuery{
+		closeTime:       closeTime,
+		searchPrecision: &dayPrecision,
+		workflowID:      new(testWorkflowID),
+		status:          new(enumspb.WORKFLOW_EXECUTION_STATUS_FAILED),
+	}, nil)
+	visibilityArchiver.queryParser = mockParser
+	request := &archiver.QueryVisibilityRequest{
+		NamespaceID: testNamespaceID,
+		PageSize:    10,
+		Query:       "parsed by mockParser",
+	}
+
+	response, err := visibilityArchiver.Query(ctx, URI, request, searchattribute.TestNameTypeMap())
+	s.NoError(err)
+	s.NotNil(response)
+	s.Empty(response.Executions)
+}
+
 func (s *visibilityArchiverSuite) TestQuery_Success_SmallPageSize() {
 	pageSize := 2
 	ctx := context.Background()

--- a/common/archiver/s3store/README.md
+++ b/common/archiver/s3store/README.md
@@ -41,8 +41,13 @@ Supported column names are
 - StartTime *Date*
 - CloseTime *Date*
 - SearchPrecision *String - Day, Hour, Minute, Second*
+- ExecutionStatus *String - Completed, Failed, Canceled, Terminated, ContinuedAsNew, TimedOut*
 
 WorkflowId or WorkflowTypeName is required. If filtering on date use StartTime or CloseTime in combination with SearchPrecision.
+
+ExecutionStatus is not part of the S3 key, so it is matched after records are read rather than
+narrowing the keys scanned. A page may therefore return fewer than the requested number of records
+while still reporting a next page token.
 
 Searching for a record will be done in times in the UTC timezone
 

--- a/common/archiver/s3store/query_parser.go
+++ b/common/archiver/s3store/query_parser.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/temporalio/sqlparser"
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/common/sqlquery"
 )
 
@@ -25,6 +26,7 @@ type (
 		startTime        *time.Time
 		closeTime        *time.Time
 		searchPrecision  *string
+		status           *enumspb.WorkflowExecutionStatus
 	}
 )
 
@@ -35,6 +37,8 @@ const (
 	StartTime        = "StartTime"
 	CloseTime        = "CloseTime"
 	SearchPrecision  = "SearchPrecision"
+	// Field name can't be just "Status" because it is reserved keyword in MySQL parser.
+	ExecutionStatus = "ExecutionStatus"
 )
 
 // Precision specific values
@@ -145,6 +149,23 @@ func (p *queryParser) convertComparisonExpr(compExpr *sqlparser.ComparisonExpr, 
 			return fmt.Errorf("can not query %s multiple times", WorkflowID)
 		}
 		parsedQuery.workflowID = new(val)
+	case ExecutionStatus:
+		val, err := sqlquery.ExtractStringValue(valStr)
+		if err != nil {
+			// if failed to extract string value, it means user input close status as a number
+			val = valStr
+		}
+		if op != "=" {
+			return fmt.Errorf("only operation = is support for %s", ExecutionStatus)
+		}
+		if parsedQuery.status != nil {
+			return fmt.Errorf("can not query %s multiple times", ExecutionStatus)
+		}
+		status, err := sqlquery.ConvertStatusStr(val)
+		if err != nil {
+			return err
+		}
+		parsedQuery.status = &status
 	case CloseTime:
 		timestamp, err := sqlquery.ConvertToTime(valStr)
 		if err != nil {

--- a/common/archiver/s3store/query_parser_test.go
+++ b/common/archiver/s3store/query_parser_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	enumspb "go.temporal.io/api/enums/v1"
 )
 
 type queryParserSuite struct {
@@ -22,6 +23,73 @@ func TestQueryParserSuite(t *testing.T) {
 func (s *queryParserSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 	s.parser = NewQueryParser()
+}
+
+func (s *queryParserSuite) TestParseExecutionStatus() {
+	const commonQueryPart = "WorkflowId = \"random workflowID\" and "
+
+	testCases := []struct {
+		query       string
+		expectErr   bool
+		parsedQuery *parsedQuery
+	}{
+		{
+			query:     commonQueryPart + "ExecutionStatus = \"Completed\"",
+			expectErr: false,
+			parsedQuery: &parsedQuery{
+				status: new(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED),
+			},
+		},
+		{
+			query:     commonQueryPart + "ExecutionStatus = 'failed'",
+			expectErr: false,
+			parsedQuery: &parsedQuery{
+				status: new(enumspb.WORKFLOW_EXECUTION_STATUS_FAILED),
+			},
+		},
+		{
+			query:     commonQueryPart + "ExecutionStatus = 'TIMED_OUT'",
+			expectErr: false,
+			parsedQuery: &parsedQuery{
+				status: new(enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT),
+			},
+		},
+		{
+			query:     commonQueryPart + "ExecutionStatus = 4",
+			expectErr: false,
+			parsedQuery: &parsedQuery{
+				status: new(enumspb.WORKFLOW_EXECUTION_STATUS_CANCELED),
+			},
+		},
+		{
+			// no ExecutionStatus filter leaves the field unset
+			query:       "WorkflowId = \"random workflowID\"",
+			expectErr:   false,
+			parsedQuery: &parsedQuery{},
+		},
+		{
+			query:     commonQueryPart + "ExecutionStatus = \"unknown\"",
+			expectErr: true,
+		},
+		{
+			query:     commonQueryPart + "ExecutionStatus > \"Failed\"",
+			expectErr: true,
+		},
+		{
+			query:     commonQueryPart + "ExecutionStatus = 'Failed' and ExecutionStatus = 'Completed'",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		parsedQuery, err := s.parser.Parse(tc.query)
+		if tc.expectErr {
+			s.Error(err)
+			continue
+		}
+		s.NoError(err)
+		s.Equal(tc.parsedQuery.status, parsedQuery.status)
+	}
 }
 
 func (s *queryParserSuite) TestParseWorkflowIDAndWorkflowTypeName() {

--- a/common/archiver/s3store/visibility_archiver.go
+++ b/common/archiver/s3store/visibility_archiver.go
@@ -351,6 +351,11 @@ func (v *visibilityArchiver) queryPrefix(
 		if err != nil {
 			return nil, serviceerror.NewInternal(err.Error())
 		}
+		// ExecutionStatus is not part of the S3 key, so it can only be matched after the
+		// record is decoded. Skip non-matching records before converting them.
+		if request.parsedQuery.status != nil && record.Status != *request.parsedQuery.status {
+			continue
+		}
 		executionInfo, err := convertToExecutionInfo(record, saTypeMap)
 		if err != nil {
 			return nil, serviceerror.NewInternal(err.Error())

--- a/common/archiver/s3store/visibility_archiver_test.go
+++ b/common/archiver/s3store/visibility_archiver_test.go
@@ -631,6 +631,68 @@ func (s *visibilityArchiverSuite) TestArchiveAndQuery() {
 	s.Equal(ei, executions[2])
 }
 
+func (s *visibilityArchiverSuite) TestArchiveAndQuery_ExecutionStatusFilter() {
+	visibilityArchiver := s.newTestVisibilityArchiver()
+	URI, err := archiver.NewURI(testBucketURI + "/archive-and-query-status")
+	s.NoError(err)
+
+	records := []*archiverspb.VisibilityRecord{
+		{
+			NamespaceId:      testNamespaceID,
+			Namespace:        testNamespace,
+			WorkflowId:       testWorkflowID,
+			RunId:            testRunID + "-failed",
+			WorkflowTypeName: testWorkflowTypeName,
+			StartTime:        timestamp.UnixOrZeroTimePtr(1),
+			CloseTime:        timestamp.UnixOrZeroTimePtr(int64(time.Hour)),
+			Status:           enumspb.WORKFLOW_EXECUTION_STATUS_FAILED,
+			HistoryLength:    101,
+		},
+		{
+			NamespaceId:      testNamespaceID,
+			Namespace:        testNamespace,
+			WorkflowId:       testWorkflowID,
+			RunId:            testRunID + "-completed",
+			WorkflowTypeName: testWorkflowTypeName,
+			StartTime:        timestamp.UnixOrZeroTimePtr(1),
+			CloseTime:        timestamp.UnixOrZeroTimePtr(int64(2 * time.Hour)),
+			Status:           enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			HistoryLength:    101,
+		},
+	}
+	for _, record := range records {
+		s.NoError(visibilityArchiver.Archive(context.Background(), URI, record))
+	}
+
+	mockParser := NewMockQueryParser(s.controller)
+	mockParser.EXPECT().Parse(gomock.Any()).Return(&parsedQuery{
+		workflowID: new(testWorkflowID),
+		status:     new(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED),
+	}, nil).AnyTimes()
+	visibilityArchiver.queryParser = mockParser
+
+	request := &archiver.QueryVisibilityRequest{
+		NamespaceID: testNamespaceID,
+		PageSize:    10,
+		Query:       "parsed by mockParser",
+	}
+	executions := []*workflowpb.WorkflowExecutionInfo{}
+	first := true
+	for first || request.NextPageToken != nil {
+		response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap())
+		s.NoError(err)
+		s.NotNil(response)
+		executions = append(executions, response.Executions...)
+		request.NextPageToken = response.NextPageToken
+		first = false
+	}
+
+	// only the COMPLETED record matches; the FAILED one is filtered out
+	s.Len(executions, 1)
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, executions[0].Status)
+	s.Equal(testRunID+"-completed", executions[0].Execution.RunId)
+}
+
 func (s *visibilityArchiverSuite) setupVisibilityDirectory() {
 	s.visibilityRecords = []*archiverspb.VisibilityRecord{
 		{

--- a/common/sqlquery/query.go
+++ b/common/sqlquery/query.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"time"
 
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common/convert"
 	"go.temporal.io/server/common/primitives/timestamp"
 )
 
@@ -37,6 +39,28 @@ func ExtractStringValue(s string) (string, error) {
 		return s[1 : len(s)-1], nil
 	}
 	return "", fmt.Errorf("value %s is not a string value", s)
+}
+
+// ConvertStatusStr converts a workflow execution status filter value to its enum
+// representation. Both the status name and its numeric value are accepted.
+func ConvertStatusStr(statusStr string) (enumspb.WorkflowExecutionStatus, error) {
+	statusStr = strings.ToLower(strings.TrimSpace(statusStr))
+	switch statusStr {
+	case "completed", convert.Int32ToString(int32(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED)):
+		return enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, nil
+	case "failed", convert.Int32ToString(int32(enumspb.WORKFLOW_EXECUTION_STATUS_FAILED)):
+		return enumspb.WORKFLOW_EXECUTION_STATUS_FAILED, nil
+	case "canceled", convert.Int32ToString(int32(enumspb.WORKFLOW_EXECUTION_STATUS_CANCELED)):
+		return enumspb.WORKFLOW_EXECUTION_STATUS_CANCELED, nil
+	case "terminated", convert.Int32ToString(int32(enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED)):
+		return enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED, nil
+	case "continuedasnew", "continued_as_new", convert.Int32ToString(int32(enumspb.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW)):
+		return enumspb.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW, nil
+	case "timedout", "timed_out", convert.Int32ToString(int32(enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT)):
+		return enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT, nil
+	default:
+		return 0, fmt.Errorf("unknown workflow close status: %s", statusStr)
+	}
 }
 
 func ExtractIntValue(s string) (int, error) {


### PR DESCRIPTION
## What changed?
s3store and gcloud visibility archivers now accept `ExecutionStatus` in archived queries. filestore already did, the other two rejected it with `unknown filter name: ExecutionStatus`. Also moved `convertStatusStr` from filestore to `common/sqlquery` as `ConvertStatusStr`, next to the parse helpers all three share. Body unchanged.

## Why?
Requested in #8648. Status is already on the record (`VisibilityRecord.Status`) and already returned, so only the filter was missing. It's not in the S3 key or GCS object name, so it can't narrow the keys scanned. I match it after decode, same order filestore uses (decode, match, convert), so filtered records skip search attribute parsing. Indexing it would change the archival layout and anything archived earlier would stop matching. @yycptt asked whether a non-index column was good enough and that never got answered, so I went non-index. Happy to change direction.

## How did you test it?
- [x] built
- [x] covered by existing tests
- [x] added new unit test(s)

`go test -race -count=1 ./common/archiver/... ./common/sqlquery/...`

## Potential risks
Inert unless a query sets `ExecutionStatus`: both `queryAll` paths pass an empty `parsedQuery`, and nil status short-circuits to existing behavior. Additive only, s3store still requires `WorkflowId`/`WorkflowTypeName` and gcloud still requires a time range plus `SearchPrecision`. Matching after read means a page can return fewer records than requested while still reporting a next page token, same as s3store's existing `queryAll` key filter, noted in both READMEs. Conflicting filters follow each parser's convention: s3store errors on a repeat, gcloud sets `emptyResult`.