### PR TITLE
Only attach the nexus_operation self-link for standalone CHASM Nexus operations

### DIFF
--- a/chasm/lib/nexusoperation/operation.go
+++ b/chasm/lib/nexusoperation/operation.go
@@ -296,19 +296,24 @@ func (o *Operation) loadStartArgs(
 		if err != nil {
 			return startArgs{}, err
 		}
+		// Workflow-backed operation: the store already appends a caller link (a workflow_event
+		// link pointing at the NexusOperationScheduled event); no further action here.
 	} else {
+		// Standalone operation: there is no workflow caller, so add a nexus_operation self-link
+		// as the caller link for the completion callback.
 		requestData := o.RequestData.Get(ctx)
 		invocationData = InvocationData{
 			Input:  requestData.GetInput(),
 			Header: requestData.GetNexusHeader(),
+			NexusLinks: []nexus.Link{
+				commonnexus.ConvertLinkNexusOperationToNexusLink(&commonpb.Link_NexusOperation{
+					Namespace:   ctx.NamespaceEntry().Name().String(),
+					OperationId: ctx.ExecutionKey().BusinessID,
+					RunId:       ctx.ExecutionKey().RunID,
+				}),
+			},
 		}
 	}
-	invocationData.NexusLinks = append(invocationData.NexusLinks,
-		commonnexus.ConvertLinkNexusOperationToNexusLink(&commonpb.Link_NexusOperation{
-			Namespace:   ctx.NamespaceEntry().Name().String(),
-			OperationId: ctx.ExecutionKey().BusinessID,
-			RunId:       ctx.ExecutionKey().RunID,
-		}))
 
 	serializedRef, err := ctx.Ref(o)
 	if err != nil {

--- a/chasm/lib/nexusoperation/operation_tasks_test.go
+++ b/chasm/lib/nexusoperation/operation_tasks_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"slices"
 	"testing"
 	"text/template"
 	"time"
@@ -238,16 +237,10 @@ func TestInvocationTaskHandler_HTTP(t *testing.T) {
 		{
 			name: "async start",
 			onStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
-				if len(options.Links) != 2 {
-					return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "expected 2 links, got %d", len(options.Links))
+				if len(options.Links) != 1 {
+					return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "expected 1 link, got %d", len(options.Links))
 				}
-				workflowEventLinkIdx := slices.IndexFunc(options.Links, func(link nexus.Link) bool {
-					return link.Type == string((&commonpb.Link_WorkflowEvent{}).ProtoReflect().Descriptor().FullName())
-				})
-				if workflowEventLinkIdx == -1 {
-					return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "missing workflow event link")
-				}
-				link, err := commonnexus.ConvertNexusLinkToLinkWorkflowEvent(options.Links[workflowEventLinkIdx])
+				link, err := commonnexus.ConvertNexusLinkToLinkWorkflowEvent(options.Links[0])
 				if err != nil {
 					return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "failed to convert link: %v", err)
 				}
@@ -264,13 +257,6 @@ func TestInvocationTaskHandler_HTTP(t *testing.T) {
 				}
 				if !proto.Equal(expectedLink, link) {
 					return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "link mismatch: got %v, want %v", link, expectedLink)
-				}
-				protoLinks := commonnexus.ConvertLinksToProto(options.Links)
-				if protoLinks[1].GetType() != "temporal.api.common.v1.Link.NexusOperation" {
-					return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "unexpected nexus operation link type: %v", protoLinks[1].GetType())
-				}
-				if protoLinks[1].GetUrl() != "temporal:///namespaces/ns-name/nexus-operations/wf-id/run-id/details" {
-					return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "unexpected nexus operation link URL: %v", protoLinks[1].GetUrl())
 				}
 				nexus.AddHandlerLinks(ctx, handlerNexusLink)
 				return &nexus.HandlerStartOperationResultAsync{
@@ -990,9 +976,8 @@ func TestInvocationTaskHandler_SystemEndpoint(t *testing.T) {
 			setupHistoryClient: func(ctrl *gomock.Controller) *historyservicemock.MockHistoryServiceClient {
 				client := historyservicemock.NewMockHistoryServiceClient(ctrl)
 				client.EXPECT().StartNexusOperation(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, request *historyservice.StartNexusOperationRequest, _ ...grpc.CallOption) (*historyservice.StartNexusOperationResponse, error) {
-					require.Len(t, request.GetRequest().GetLinks(), 2)
+					require.Len(t, request.GetRequest().GetLinks(), 1)
 					require.Equal(t, "temporal.api.common.v1.Link.WorkflowEvent", request.GetRequest().GetLinks()[0].GetType())
-					require.Equal(t, "temporal.api.common.v1.Link.NexusOperation", request.GetRequest().GetLinks()[1].GetType())
 
 					return &historyservice.StartNexusOperationResponse{
 						Response: &nexuspb.StartOperationResponse{
@@ -1028,9 +1013,8 @@ func TestInvocationTaskHandler_SystemEndpoint(t *testing.T) {
 			setupHistoryClient: func(ctrl *gomock.Controller) *historyservicemock.MockHistoryServiceClient {
 				client := historyservicemock.NewMockHistoryServiceClient(ctrl)
 				client.EXPECT().StartNexusOperation(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, request *historyservice.StartNexusOperationRequest, opts ...grpc.CallOption) (*historyservice.StartNexusOperationResponse, error) {
-					require.Len(t, request.GetRequest().GetLinks(), 2)
+					require.Len(t, request.GetRequest().GetLinks(), 1)
 					require.Equal(t, "temporal.api.common.v1.Link.WorkflowEvent", request.GetRequest().GetLinks()[0].GetType())
-					require.Equal(t, "temporal.api.common.v1.Link.NexusOperation", request.GetRequest().GetLinks()[1].GetType())
 
 					var input testProcessorInput
 					if err := payloads.Decode(&commonpb.Payloads{Payloads: []*commonpb.Payload{request.Request.Payload}}, &input); err != nil {

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -652,9 +652,8 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationStartsStandaloneActivityBidir
 			input *nexus.LazyValue,
 			options nexus.StartOperationOptions,
 		) (nexus.HandlerStartOperationResult[any], error) {
-			// Build the NexusOperation back-link the SAA should record as its caller.
-			// In chasm mode the caller workflow's identifiers are surfaced to the handler
-			// via options.Links; we mirror them here using the closed-over run.
+			// Build the NexusOperation back-link the SAA should record as its caller,
+			// derived from the closed-over caller workflow run.
 			nexusOpBackLink := &commonpb.Link{
 				Variant: &commonpb.Link_NexusOperation_{
 					NexusOperation: &commonpb.Link_NexusOperation{
@@ -971,18 +970,10 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletion(chasmEnabled 
 				s.Equal(testClusterInfo.GetClusterId(), options.CallbackHeader.Get("source"))
 			}
 
-			expectedLinkCount := 1
-			if chasmEnabled {
-				expectedLinkCount = 2
-			}
-			s.Len(options.Links, expectedLinkCount)
+			s.Len(options.Links, 1)
 
 			// Verify workflow event link is present
-			workflowEventLinkIdx := slices.IndexFunc(options.Links, func(link nexus.Link) bool {
-				return link.Type == string((&commonpb.Link_WorkflowEvent{}).ProtoReflect().Descriptor().FullName())
-			})
-			s.NotEqual(-1, workflowEventLinkIdx)
-			workflowEventLink, err := commonnexus.ConvertNexusLinkToLinkWorkflowEvent(options.Links[workflowEventLinkIdx])
+			workflowEventLink, err := commonnexus.ConvertNexusLinkToLinkWorkflowEvent(options.Links[0])
 			s.NoError(err)
 			protorequire.ProtoEqual(s.T(), &commonpb.Link_WorkflowEvent{
 				Namespace:  env.Namespace().String(),
@@ -1001,21 +992,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletion(chasmEnabled 
 					},
 				},
 			}, workflowEventLink)
-
-			// Verify nexus operation link is present
-			if chasmEnabled {
-				nexusOperationLinkIdx := slices.IndexFunc(options.Links, func(link nexus.Link) bool {
-					return link.Type == string((&commonpb.Link_NexusOperation{}).ProtoReflect().Descriptor().FullName())
-				})
-				s.NotEqual(-1, nexusOperationLinkIdx)
-				expectedNexusOperationLink := commonnexus.ConvertLinkNexusOperationToNexusLink(&commonpb.Link_NexusOperation{
-					Namespace:   env.Namespace().String(),
-					OperationId: run.GetID(),
-					RunId:       run.GetRunID(),
-				})
-				s.Equal(expectedNexusOperationLink.URL.String(), options.Links[nexusOperationLinkIdx].URL.String())
-				s.Equal(expectedNexusOperationLink.Type, options.Links[nexusOperationLinkIdx].Type)
-			}
 
 			callbackToken = options.CallbackHeader.Get(commonnexus.CallbackTokenHeader)
 			publicCallbackURL = options.CallbackURL


### PR DESCRIPTION
## What changed?
Workflow-triggered Nexus operations on the CHASM rail attached **two** links to the completion callback — the `workflow_event` link (pointing at the `NexusOperationScheduled` caller event) plus an extra `nexus_operation` self-link — whereas HSM (and thus workflow-backed operations) emit only the `workflow_event` link.

The `nexus_operation` self-link append in `Operation.loadStartArgs` was added for **standalone** Nexus operations (which have no workflow caller and so need a self-link) but fired unconditionally. This moves it into the standalone branch (`Store == nil`), so workflow-backed operations match HSM's single-link behavior while standalone operations keep their self-link.

## Why?
HSM↔CHASM parity for workflow-triggered Nexus operations. Discovered while running the Go SDK Nexus tests against a CHASM-backed server: `TestAsyncOperationFromWorkflow/OpSuccessful` passes on the HSM rail but failed on the CHASM rail with 2 links vs the expected 1.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

Ran the Go SDK `TestAsyncOperationFromWorkflow` suite against a local server with CHASM-backed Nexus workflow operations enabled: `OpSuccessful` now passes on the CHASM rail (single `workflow_event` link), and the HSM rail is unchanged (still one link).

## Potential risks
Low. The change is confined to link construction in `Operation.loadStartArgs`:
- Standalone Nexus operations are unaffected — they still receive the `nexus_operation` self-link.
- Workflow-backed operations lose the redundant `nexus_operation` self-link and keep the `workflow_event` link, matching HSM. 