### PR TITLE
Close leaked resources during shutdown [Do not merge]

### DIFF
--- a/client/client_bean.go
+++ b/client/client_bean.go
@@ -29,9 +29,8 @@ type (
 		GetRemoteAdminClient(string) (adminservice.AdminServiceClient, error)
 		GetRemoteFrontendClient(string) (grpc.ClientConnInterface, workflowservice.WorkflowServiceClient, error)
 		// Close deterministically releases bean-held resources on shutdown: it
-		// stops the history and matching clients (their daemon goroutines and
-		// cached gRPC connections) and unregisters the cluster metadata change
-		// callback.
+		// stops the history and matching clients, closes frontend connections,
+		// and unregisters the cluster metadata change callback.
 		Close()
 	}
 
@@ -133,6 +132,7 @@ func (h *clientBeanImpl) Close() {
 			s.Stop()
 		}
 	}
+	h.factory.Close()
 }
 
 func (h *clientBeanImpl) GetHistoryClient() historyservice.HistoryServiceClient {

--- a/client/client_factory_mock.go
+++ b/client/client_factory_mock.go
@@ -51,6 +51,18 @@ func (m *MockFactory) EXPECT() *MockFactoryMockRecorder {
 	return m.recorder
 }
 
+// Close mocks base method.
+func (m *MockFactory) Close() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Close")
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockFactoryMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockFactory)(nil).Close))
+}
+
 // NewHistoryClientWithTimeout mocks base method.
 func (m *MockFactory) NewHistoryClientWithTimeout(timeout time.Duration) (historyservice.HistoryServiceClient, error) {
 	m.ctrl.T.Helper()

--- a/client/clientfactory.go
+++ b/client/clientfactory.go
@@ -3,6 +3,7 @@
 package client
 
 import (
+	"sync"
 	"time"
 
 	"go.temporal.io/api/workflowservice/v1"
@@ -16,6 +17,7 @@ import (
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/membership"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
@@ -33,6 +35,7 @@ type (
 		NewLocalFrontendClientWithTimeout(timeout time.Duration, longPollTimeout time.Duration) (grpc.ClientConnInterface, workflowservice.WorkflowServiceClient, error)
 		NewRemoteAdminClientWithTimeout(rpcAddress string, timeout time.Duration, largeTimeout time.Duration) adminservice.AdminServiceClient
 		NewLocalAdminClientWithTimeout(timeout time.Duration, largeTimeout time.Duration) (adminservice.AdminServiceClient, error)
+		Close()
 	}
 
 	// FactoryProvider can be used to provide a customized client Factory implementation.
@@ -61,6 +64,10 @@ type (
 		numberOfHistoryShards int32
 		logger                log.Logger
 		throttledLogger       log.Logger
+
+		connectionsLock sync.Mutex
+		connections     map[*grpc.ClientConn]struct{}
+		closed          bool
 	}
 
 	factoryProviderImpl struct {
@@ -157,7 +164,7 @@ func (cf *rpcClientFactory) NewRemoteFrontendClientWithTimeout(
 	timeout time.Duration,
 	longPollTimeout time.Duration,
 ) (grpc.ClientConnInterface, workflowservice.WorkflowServiceClient) {
-	connection := cf.rpcFactory.CreateRemoteFrontendGRPCConnection(rpcAddress)
+	connection := cf.trackConnection(cf.rpcFactory.CreateRemoteFrontendGRPCConnection(rpcAddress))
 	client := workflowservice.NewWorkflowServiceClient(connection)
 	return connection, cf.newFrontendClient(client, timeout, longPollTimeout)
 }
@@ -166,7 +173,7 @@ func (cf *rpcClientFactory) NewLocalFrontendClientWithTimeout(
 	timeout time.Duration,
 	longPollTimeout time.Duration,
 ) (grpc.ClientConnInterface, workflowservice.WorkflowServiceClient, error) {
-	connection := cf.rpcFactory.CreateLocalFrontendGRPCConnection()
+	connection := cf.trackConnection(cf.rpcFactory.CreateLocalFrontendGRPCConnection())
 	client := workflowservice.NewWorkflowServiceClient(connection)
 	return connection, cf.newFrontendClient(client, timeout, longPollTimeout), nil
 }
@@ -176,7 +183,7 @@ func (cf *rpcClientFactory) NewRemoteAdminClientWithTimeout(
 	timeout time.Duration,
 	largeTimeout time.Duration,
 ) adminservice.AdminServiceClient {
-	connection := cf.rpcFactory.CreateRemoteFrontendGRPCConnection(rpcAddress)
+	connection := cf.trackConnection(cf.rpcFactory.CreateRemoteFrontendGRPCConnection(rpcAddress))
 	client := adminservice.NewAdminServiceClient(connection)
 	return cf.newAdminClient(client, timeout, largeTimeout)
 }
@@ -185,9 +192,46 @@ func (cf *rpcClientFactory) NewLocalAdminClientWithTimeout(
 	timeout time.Duration,
 	longPollTimeout time.Duration,
 ) (adminservice.AdminServiceClient, error) {
-	connection := cf.rpcFactory.CreateLocalFrontendGRPCConnection()
+	connection := cf.trackConnection(cf.rpcFactory.CreateLocalFrontendGRPCConnection())
 	client := adminservice.NewAdminServiceClient(connection)
 	return cf.newAdminClient(client, timeout, longPollTimeout), nil
+}
+
+// Close releases all frontend connections created by the factory. It is safe
+// to call more than once.
+func (cf *rpcClientFactory) Close() {
+	cf.connectionsLock.Lock()
+	if cf.closed {
+		cf.connectionsLock.Unlock()
+		return
+	}
+	cf.closed = true
+	connections := cf.connections
+	cf.connections = nil
+	cf.connectionsLock.Unlock()
+
+	for connection := range connections {
+		if err := connection.Close(); err != nil {
+			cf.logger.Warn("Error closing frontend gRPC connection on shutdown", tag.Error(err))
+		}
+	}
+}
+
+func (cf *rpcClientFactory) trackConnection(connection *grpc.ClientConn) *grpc.ClientConn {
+	cf.connectionsLock.Lock()
+	defer cf.connectionsLock.Unlock()
+
+	if cf.closed {
+		if err := connection.Close(); err != nil {
+			cf.logger.Warn("Error closing frontend gRPC connection after shutdown", tag.Error(err))
+		}
+		return connection
+	}
+	if cf.connections == nil {
+		cf.connections = make(map[*grpc.ClientConn]struct{})
+	}
+	cf.connections[connection] = struct{}{}
+	return connection
 }
 
 func (cf *rpcClientFactory) newAdminClient(

--- a/common/resource/fx.go
+++ b/common/resource/fx.go
@@ -385,6 +385,7 @@ func ArchiverProviderProvider(
 }
 
 func SdkClientFactoryProvider(
+	lc fx.Lifecycle,
 	cfg *config.Config,
 	tlsConfigProvider encryption.TLSConfigProvider,
 	metricsHandler metrics.Handler,
@@ -396,13 +397,15 @@ func SdkClientFactoryProvider(
 	if err != nil {
 		return nil, err
 	}
-	return sdk.NewClientFactory(
+	factory := sdk.NewClientFactory(
 		frontendURL,
 		frontendTLSConfig,
 		metricsHandler,
 		logger,
 		dynamicconfig.WorkerStickyCacheSize.Get(dc),
-	), nil
+	)
+	lc.Append(fx.StopHook(factory.Close))
+	return factory, nil
 }
 
 func DCRedirectionPolicyProvider(cfg *config.Config) config.DCRedirectionPolicy {

--- a/common/sdk/factory.go
+++ b/common/sdk/factory.go
@@ -31,6 +31,7 @@ type (
 		NewClient(options sdkclient.Options) sdkclient.Client
 		GetSystemClient() sdkclient.Client
 		NewWorker(client sdkclient.Client, taskQueue string, options sdkworker.Options) sdkworker.Worker
+		Close()
 	}
 
 	clientFactory struct {
@@ -42,6 +43,11 @@ type (
 		systemSdkClient sdkclient.Client
 		stickyCacheSize dynamicconfig.IntPropertyFn
 		once            sync.Once
+		closeOnce       sync.Once
+
+		clientsLock    sync.Mutex
+		derivedClients []sdkclient.Client
+		closed         bool
 	}
 )
 
@@ -85,6 +91,16 @@ func (f *clientFactory) NewClient(options sdkclient.Options) sdkclient.Client {
 	if err != nil {
 		f.logger.Fatal("error creating sdk client", tag.Error(err))
 	}
+
+	f.clientsLock.Lock()
+	if f.closed {
+		f.clientsLock.Unlock()
+		client.Close()
+		return client
+	}
+	f.derivedClients = append(f.derivedClients, client)
+	f.clientsLock.Unlock()
+
 	return client
 }
 
@@ -123,6 +139,24 @@ func (f *clientFactory) NewWorker(
 	options sdkworker.Options,
 ) sdkworker.Worker {
 	return sdkworker.New(client, taskQueue, options)
+}
+
+// Close releases the shared SDK client. It is safe to call more than once.
+func (f *clientFactory) Close() {
+	f.closeOnce.Do(func() {
+		f.clientsLock.Lock()
+		derivedClients := f.derivedClients
+		f.derivedClients = nil
+		f.closed = true
+		f.clientsLock.Unlock()
+
+		for _, client := range derivedClients {
+			client.Close()
+		}
+		if f.systemSdkClient != nil {
+			f.systemSdkClient.Close()
+		}
+	})
 }
 
 // Overwrite the 'client-name' and 'client-version' headers on gRPC requests sent using the Go SDK

--- a/common/sdk/factory_mock.go
+++ b/common/sdk/factory_mock.go
@@ -41,6 +41,18 @@ func (m *MockClientFactory) EXPECT() *MockClientFactoryMockRecorder {
 	return m.recorder
 }
 
+// Close mocks base method.
+func (m *MockClientFactory) Close() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Close")
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockClientFactoryMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockClientFactory)(nil).Close))
+}
+
 // GetSystemClient mocks base method.
 func (m *MockClientFactory) GetSystemClient() client.Client {
 	m.ctrl.T.Helper()

--- a/common/versioninfo/caller.go
+++ b/common/versioninfo/caller.go
@@ -2,6 +2,7 @@ package versioninfo
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -20,7 +21,7 @@ func NewCaller() Caller {
 	return Caller{"https", "version-info.temporal.io"}
 }
 
-func (c Caller) Call(r *VersionCheckRequest) (*VersionCheckResponse, error) {
+func (c Caller) Call(ctx context.Context, r *VersionCheckRequest) (*VersionCheckResponse, error) {
 	err := validateRequest(r)
 	if err != nil {
 		return nil, err
@@ -30,6 +31,7 @@ func (c Caller) Call(r *VersionCheckRequest) (*VersionCheckResponse, error) {
 		DisableKeepAlives:   true,
 		MaxIdleConnsPerHost: -1,
 	}
+	defer tr.CloseIdleConnections()
 	if c.Scheme == "https" {
 		tr.TLSClientConfig = &tls.Config{}
 	}
@@ -38,7 +40,7 @@ func (c Caller) Call(r *VersionCheckRequest) (*VersionCheckResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest("POST", u.String(), bytes.NewReader(reqBody))
+	req, err := http.NewRequestWithContext(ctx, "POST", u.String(), bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, err
 	}

--- a/common/versioninfo/caller_test.go
+++ b/common/versioninfo/caller_test.go
@@ -1,6 +1,7 @@
 package versioninfo_test
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -69,7 +70,7 @@ func TestPostInfo(t *testing.T) {
 		Name:    "sdk-java",
 		Version: "3.11",
 	}}
-	_, err = caller.Call(&versioninfo.VersionCheckRequest{
+	_, err = caller.Call(context.Background(), &versioninfo.VersionCheckRequest{
 		Product:   "server",
 		Version:   "0.1",
 		ClusterID: "foo",

--- a/service/frontend/version_checker.go
+++ b/service/frontend/version_checker.go
@@ -48,11 +48,14 @@ func NewVersionChecker(
 func (vc *VersionChecker) Start() {
 	if vc.config.EnableServerVersionCheck() {
 		vc.startOnce.Do(func() {
-			// TODO: specify a timeout for the context
-			ctx := headers.SetCallerInfo(
-				context.TODO(),
+			ctx, cancel := context.WithCancel(headers.SetCallerInfo(
+				context.Background(),
 				headers.SystemBackgroundHighCallerInfo,
-			)
+			))
+			go func() {
+				<-vc.shutdownChan
+				cancel()
+			}()
 
 			go vc.versionCheckLoop(ctx)
 		})
@@ -105,7 +108,7 @@ func (vc *VersionChecker) performVersionCheck(
 		metrics.VersionCheckFailedCount.With(vc.metricsHandler).Record(1)
 		return
 	}
-	resp, err := vc.getVersionInfo(req)
+	resp, err := vc.getVersionInfo(ctx, req)
 	if err != nil {
 		metrics.VersionCheckRequestFailedCount.With(vc.metricsHandler).Record(1)
 		metrics.VersionCheckFailedCount.With(vc.metricsHandler).Record(1)
@@ -146,8 +149,8 @@ func (vc *VersionChecker) createVersionCheckRequest(metadata *persistence.GetClu
 	}, nil
 }
 
-func (vc *VersionChecker) getVersionInfo(req *versioninfo.VersionCheckRequest) (*versioninfo.VersionCheckResponse, error) {
-	return versioninfo.NewCaller().Call(req)
+func (vc *VersionChecker) getVersionInfo(ctx context.Context, req *versioninfo.VersionCheckRequest) (*versioninfo.VersionCheckResponse, error) {
+	return versioninfo.NewCaller().Call(ctx, req)
 }
 
 func (vc *VersionChecker) saveVersionInfo(ctx context.Context, resp *versioninfo.VersionCheckResponse) error {

--- a/service/worker/parentclosepolicy/processor.go
+++ b/service/worker/parentclosepolicy/processor.go
@@ -52,6 +52,7 @@ type (
 		logger           log.Logger
 		currentCluster   string
 		hostInfo         membership.HostInfo
+		worker           worker.Worker
 	}
 )
 
@@ -75,7 +76,15 @@ func (s *Processor) Start() error {
 	processorWorker.RegisterWorkflowWithOptions(ProcessorWorkflow, workflow.RegisterOptions{Name: processorWFTypeName})
 	processorWorker.RegisterActivityWithOptions(ProcessorActivity, activity.RegisterOptions{Name: processorActivityName})
 
+	s.worker = processorWorker
 	return processorWorker.Start()
+}
+
+// Stop stops the parent-close-policy SDK worker.
+func (s *Processor) Stop() {
+	if s.worker != nil {
+		s.worker.Stop()
+	}
 }
 
 func getWorkerOptions(p *Processor) worker.Options {

--- a/service/worker/scanner/scanner.go
+++ b/service/worker/scanner/scanner.go
@@ -106,6 +106,7 @@ type (
 		context         scannerContext
 		wg              sync.WaitGroup
 		lifecycleCancel context.CancelFunc
+		workers         []worker.Worker
 	}
 )
 
@@ -209,10 +210,11 @@ func (s *Scanner) Start() error {
 		work.RegisterWorkflowWithOptions(build_ids.BuildIdScavangerWorkflow, workflow.RegisterOptions{Name: build_ids.BuildIdScavangerWorkflowName})
 		work.RegisterActivityWithOptions(buildIdsActivities.ScavengeBuildIds, activity.RegisterOptions{Name: build_ids.BuildIdScavangerActivityName})
 
-		// TODO: Nothing is gracefully stopping these workers or listening for fatal errors.
+		// Stop gracefully stops this worker, but fatal errors are not currently handled.
 		if err := work.Start(); err != nil {
 			return err
 		}
+		s.workers = append(s.workers, work)
 	}
 
 	siOpts := s.context.cfg.ScheduleInvariantsScannerOptions()
@@ -236,10 +238,11 @@ func (s *Scanner) Start() error {
 			work.RegisterWorkflowWithOptions(scheduleinvariants.OverdueNextActionTimeWorkflow, workflow.RegisterOptions{Name: scheduleinvariants.OverdueNextActionTimeWorkflowName})
 			work.RegisterActivityWithOptions(scheduleActivities.ScanOverdueNextActionTime, activity.RegisterOptions{Name: scheduleinvariants.OverdueNextActionTimeActivityName})
 
-			// TODO: Nothing is gracefully stopping these workers or listening for fatal errors.
+			// Stop gracefully stops this worker, but fatal errors are not currently handled.
 			if err := work.Start(); err != nil {
 				return err
 			}
+			s.workers = append(s.workers, work)
 		}
 
 		if siOpts.StuckOpenEnabled {
@@ -253,6 +256,7 @@ func (s *Scanner) Start() error {
 			if err := work.Start(); err != nil {
 				return err
 			}
+			s.workers = append(s.workers, work)
 		}
 
 		if siOpts.UnknownStateEnabled {
@@ -266,6 +270,7 @@ func (s *Scanner) Start() error {
 			if err := work.Start(); err != nil {
 				return err
 			}
+			s.workers = append(s.workers, work)
 		}
 	}
 
@@ -280,10 +285,11 @@ func (s *Scanner) Start() error {
 		work.RegisterActivityWithOptions(HistoryScavengerActivity, activity.RegisterOptions{Name: historyScavengerActivityName})
 		work.RegisterActivityWithOptions(ExecutionsScavengerActivity, activity.RegisterOptions{Name: executionsScavengerActivityName})
 
-		// TODO: Nothing is gracefully stopping these workers or listening for fatal errors.
+		// Stop gracefully stops this worker, but fatal errors are not currently handled.
 		if err := work.Start(); err != nil {
 			return err
 		}
+		s.workers = append(s.workers, work)
 	}
 
 	return nil
@@ -291,6 +297,9 @@ func (s *Scanner) Start() error {
 
 func (s *Scanner) Stop() {
 	s.lifecycleCancel()
+	for _, w := range s.workers {
+		w.Stop()
+	}
 	s.wg.Wait()
 }
 

--- a/service/worker/scanner/scanner_test.go
+++ b/service/worker/scanner/scanner_test.go
@@ -224,6 +224,7 @@ func (s *scannerTestSuite) TestScannerEnabled() {
 				worker.EXPECT().RegisterActivityWithOptions(gomock.Any(), gomock.Any()).AnyTimes()
 				worker.EXPECT().RegisterWorkflowWithOptions(gomock.Any(), gomock.Any()).AnyTimes()
 				worker.EXPECT().Start()
+				worker.EXPECT().Stop()
 				mockSdkClientFactory.EXPECT().NewWorker(gomock.Any(), sc.TaskQueueName, gomock.Any()).Return(worker)
 				mockSdkClientFactory.EXPECT().GetSystemClient().Return(mockSdkClient).AnyTimes()
 				mockSdkClient.EXPECT().ExecuteWorkflow(gomock.Any(), gomock.Any(), sc.WFTypeName,
@@ -299,6 +300,7 @@ func (s *scannerTestSuite) TestScannerShutdown() {
 	worker.EXPECT().RegisterActivityWithOptions(gomock.Any(), gomock.Any()).AnyTimes()
 	worker.EXPECT().RegisterWorkflowWithOptions(gomock.Any(), gomock.Any()).AnyTimes()
 	worker.EXPECT().Start()
+	worker.EXPECT().Stop()
 	mockSdkClientFactory.EXPECT().NewWorker(gomock.Any(), gomock.Any(), gomock.Any()).Return(worker)
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -66,6 +66,7 @@ type (
 
 		workerManager                    *workerManager
 		perNamespaceWorkerManager        *PerNamespaceWorkerManager
+		parentClosePolicyProcessor       *parentclosepolicy.Processor
 		scanner                          *scanner.Scanner
 		matchingClient                   matchingservice.MatchingServiceClient
 		namespaceReplicationTaskExecutor nsreplication.TaskExecutor
@@ -297,6 +298,9 @@ func (s *Service) Stop() {
 	s.scanner.Stop()
 	s.perNamespaceWorkerManager.Stop()
 	s.workerManager.Stop()
+	if s.parentClosePolicyProcessor != nil {
+		s.parentClosePolicyProcessor.Stop()
+	}
 	s.visibilityManager.Close()
 
 	s.server.GracefulStop()
@@ -325,6 +329,7 @@ func (s *Service) startParentClosePolicyProcessor() {
 			tag.Error(err),
 		)
 	}
+	s.parentClosePolicyProcessor = processor
 }
 
 func (s *Service) initScanner(serializer serialization.Serializer) error {

--- a/tests/leakcheck/leak_test.go
+++ b/tests/leakcheck/leak_test.go
@@ -25,19 +25,6 @@ var goleakOpts = []goleak.Option{
 	// By design: sqlite keeps one *sql.DB per file DSN for the process lifetime.
 	goleak.IgnoreTopFunction("database/sql.(*DB).connectionOpener"),
 
-	// TODO: gRPC connection goroutines leaked because history/matching
-	// connection pools are not closed on cluster shutdown.
-	//
-	// IgnoreAnyFunction (rather than IgnoreTopFunction) for addrConn's
-	// reconnect loop: a goroutine caught mid-reconnect can have any of
-	// several functions (fmt/channelz logging, context.Err, ...) at the
-	// top of the stack depending on exactly when it was snapshotted, but
-	// resetTransportAndUnlock is always present as a caller.
-	goleak.IgnoreTopFunction("google.golang.org/grpc/internal/grpcsync.(*CallbackSerializer).run"),
-	goleak.IgnoreAnyFunction("google.golang.org/grpc.(*addrConn).resetTransportAndUnlock"),
-	goleak.IgnoreTopFunction("google.golang.org/grpc/internal/balancer/gracefulswitch.(*Balancer).updateSubConnState"),
-	goleak.IgnoreTopFunction("go.temporal.io/server/common/membership.(*grpcResolver).listen"),
-
 	// TODO: worker-service and persistence goroutine leaks.
 	goleak.IgnoreTopFunction("net/http.(*persistConn).readLoop"),
 	goleak.IgnoreTopFunction("net/http.(*persistConn).writeLoop"),

--- a/tests/leakcheck/leak_test.go
+++ b/tests/leakcheck/leak_test.go
@@ -24,19 +24,6 @@ import (
 var goleakOpts = []goleak.Option{
 	// By design: sqlite keeps one *sql.DB per file DSN for the process lifetime.
 	goleak.IgnoreTopFunction("database/sql.(*DB).connectionOpener"),
-
-	// TODO: worker-service and persistence goroutine leaks.
-	goleak.IgnoreTopFunction("net/http.(*persistConn).readLoop"),
-	goleak.IgnoreTopFunction("net/http.(*persistConn).writeLoop"),
-
-	// TODO: SDK worker goroutines not fully stopped on cluster shutdown.
-	goleak.IgnoreTopFunction("go.temporal.io/sdk/internal.(*baseWorker).runEagerTaskDispatcher"),
-	goleak.IgnoreTopFunction("go.temporal.io/sdk/internal.(*baseWorker).runTaskDispatcher"),
-	goleak.IgnoreTopFunction("go.temporal.io/sdk/internal.(*localActivityTunnel).getTask"),
-	goleak.IgnoreTopFunction("go.temporal.io/sdk/internal.(*sharedNamespaceWorker).run"),
-	goleak.IgnoreTopFunction("go.temporal.io/sdk/internal/common/backoff.(*ConcurrentRetrier).throttleInternal"),
-	goleak.IgnoreAnyFunction("go.temporal.io/sdk/internal.(*basePoller).doPoll"),
-	goleak.IgnoreAnyFunction("go.temporal.io/sdk/internal.(*basePoller).doPoll.func1"),
 }
 
 var objectLeakOpts = []objectleak.Option{
@@ -47,7 +34,7 @@ var objectLeakOpts = []objectleak.Option{
 	objectleak.WithExpected("FunctionalTestBase.testCluster.host*"),
 	objectleak.WithExpected("FunctionalTestBase.testCluster.testBase*"),
 	objectleak.WithExpected("FunctionalTestBase.testClusterConfig"),
-	// TODO: This is not fully garbage collected because of the goroutine leak above. Nothing to be done here.
+	// Closed SDK client internals remain reachable after worker shutdown.
 	objectleak.WithExpected("sdkClient*"),
 }
 

--- a/tests/testcore/clients.go
+++ b/tests/testcore/clients.go
@@ -31,6 +31,7 @@ import (
 	"go.temporal.io/server/common/rpc/encryption"
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/testing/testhooks"
+	"go.uber.org/fx"
 	"google.golang.org/grpc"
 )
 
@@ -211,6 +212,12 @@ func (c *clients) ensureMatching() {
 
 func (c *clients) close() []error {
 	var errs []error
+	if c.matching.client != nil {
+		if s, ok := c.matching.client.(interface{ Stop() }); ok {
+			s.Stop()
+		}
+		c.matching.client = nil
+	}
 	for _, conn := range []*grpc.ClientConn{
 		c.frontend.conn,
 		c.history.conn,
@@ -318,6 +325,7 @@ func (f *clientFactory) NewRemoteAdminClientWithTimeout(rpcAddress string, timeo
 }
 
 func sdkClientFactoryProvider(
+	lc fx.Lifecycle,
 	grpcResolver *membership.GRPCResolver,
 	metricsHandler metrics.Handler,
 	logger log.Logger,
@@ -331,11 +339,13 @@ func sdkClientFactoryProvider(
 			panic(err)
 		}
 	}
-	return sdk.NewClientFactory(
+	factory := sdk.NewClientFactory(
 		grpcResolver.MakeURL(primitives.FrontendService),
 		tlsConfig,
 		metricsHandler,
 		logger,
 		dynamicconfig.WorkerStickyCacheSize.Get(dc),
 	)
+	lc.Append(fx.StopHook(factory.Close))
+	return factory
 }


### PR DESCRIPTION
## What changed?

Close frontend gRPC connections and SDK clients when their owning factories shut down. Stop parent-close-policy and scanner SDK workers during worker service shutdown, cancel in-flight version-check HTTP requests during frontend shutdown, and remove the corresponding goleak exclusions.

## Why?

Test cluster shutdown left client connections, SDK workers, and HTTP requests active. Their background goroutines remained after shutdown and required several goleak exclusions.

## How did you test it?

- [x] built
- [x] covered by existing tests
- [ ] run locally and tested manually
- [ ] added new unit test(s)
- [ ] added new functional test(s)

Ran the full leak test, including 15 measured iterations, with all non-SQLite goleak exclusions removed. Also ran the affected Go package tests, `make fmt-imports`, and `make lint-code`.

## Potential risks

The change adds shutdown ownership to shared client factories and worker services. Close operations are idempotent, and newly created connections are closed immediately after factory shutdown.
