### PR TITLE
Reduce cluster shutdown object leaks

### DIFF
--- a/tests/leakcheck/leak_test.go
+++ b/tests/leakcheck/leak_test.go
@@ -28,14 +28,21 @@ var goleakOpts = []goleak.Option{
 
 var objectLeakOpts = []objectleak.Option{
 	objectleak.WithPruneType("google.golang.org/protobuf/internal/impl.*"),
-	objectleak.WithExpected("FunctionalTestBase"),
-	objectleak.WithExpected("FunctionalTestBase.Logger*"),
-	objectleak.WithExpected("FunctionalTestBase.Suite*"),
-	objectleak.WithExpected("FunctionalTestBase.testCluster.host*"),
-	objectleak.WithExpected("FunctionalTestBase.testCluster.testBase*"),
-	objectleak.WithExpected("FunctionalTestBase.testClusterConfig"),
-	// Closed SDK client internals remain reachable after worker shutdown.
+	// SQLite intentionally keeps one *sql.DB per file DSN for the process lifetime.
+	objectleak.WithExpected("FunctionalTestBase.testCluster.testBase.ShardMgr.persistence.persistence.shardStore.SqlStore.DB.DB.db*"),
+	// The persistence metric emitter shares the closed TestLogger with the stopped server graph.
+	objectleak.WithExpected("FunctionalTestBase.testCluster.testBase.ShardMgr.persistence.metricEmitter.logger*"),
+	// The namespace queue uses the package-level namespaceQueueRetryPolicy from persistence/client/factory.go.
+	objectleak.WithExpected("FunctionalTestBase.testCluster.testBase.NamespaceReplicationQueue.queue.policy"),
+	// Persistence managers use the package-level retryPolicy from persistence/client/factory.go.
+	objectleak.WithExpected("FunctionalTestBase.testCluster.testBase.ShardMgr.policy"),
+	// Client.Close stops transports but retains immutable SDK converters and gRPC buffer pools.
 	objectleak.WithExpected("sdkClient*"),
+}
+
+type clusterResources struct {
+	testCluster *testcore.TestCluster
+	sdkClient   sdkclient.Client
 }
 
 // TestClusterShutdownLeak is a goroutine-leak regression test for the functional
@@ -80,7 +87,7 @@ func TestClusterShutdownLeak(t *testing.T) {
 	// Warm up with a few clusters so process-lifetime singletons (gRPC resolver
 	// init, proto registries, ...) are created before we snapshot the baseline.
 	for range warmupIters {
-		buildRunTeardownCluster(t, &leakCheck)
+		buildRunTeardownCluster(t, nil)
 	}
 
 	// Wait for warmup goroutines to drain before snapshotting the baseline.
@@ -124,6 +131,8 @@ func TestClusterShutdownLeak(t *testing.T) {
 // buildRunTeardownCluster creates a dedicated cluster, runs a trivial
 // workflow on it to exercise the full server path, then tears it down.
 func buildRunTeardownCluster(t *testing.T, leakCheck *objectleak.ObjectLeakCheck) {
+	var resources *clusterResources
+
 	// The subtest ensures all env cleanups complete before this returns.
 	t.Run("cluster", func(t *testing.T) {
 		env := testcore.NewEnv(t,
@@ -139,8 +148,18 @@ func buildRunTeardownCluster(t *testing.T, leakCheck *objectleak.ObjectLeakCheck
 		require.NoError(t, err)
 		require.NoError(t, run.Get(context.Background(), nil))
 
-		leakCheck.Track(env)
+		if leakCheck != nil {
+			resources = &clusterResources{
+				testCluster: env.GetTestCluster(),
+				sdkClient:   env.SdkClient(),
+			}
+		}
 	})
+	if resources != nil {
+		// Track the stopped roots after teardown so severed server internals
+		// aren't promoted to independent leak roots.
+		leakCheck.Track(resources)
+	}
 }
 
 func smokeWorkflow(workflow.Context) error { return nil }

--- a/tests/leakcheck/leak_test.go
+++ b/tests/leakcheck/leak_test.go
@@ -28,21 +28,36 @@ var goleakOpts = []goleak.Option{
 
 var objectLeakOpts = []objectleak.Option{
 	objectleak.WithPruneType("google.golang.org/protobuf/internal/impl.*"),
+	// The parent test retains the shared test logger until its own cleanup completes.
+	objectleak.WithExpected("FunctionalTestBase.Logger*"),
+	// Testify keeps the suite's testing.T reachable until the parent test returns.
+	objectleak.WithExpected("FunctionalTestBase.Suite*"),
+	// The stopped CHASM engine remains reachable through process-lifetime component registrations.
+	objectleak.WithExpected("FunctionalTestBase.testCluster.host.chasmEngine*"),
+	// The stopped CHASM visibility manager is retained alongside the CHASM engine.
+	objectleak.WithExpected("FunctionalTestBase.testCluster.host.chasmVisibilityMgr"),
+	// Dynamic config override handles remain reachable through process-lifetime registrations.
+	objectleak.WithExpected("FunctionalTestBase.testCluster.host.clients.dcClient*"),
+	// The capture handler is shared with the stopped server graph.
+	objectleak.WithExpected("FunctionalTestBase.testCluster.host.clients.metricsHandler*"),
+	// Generated frontend clients remain reachable through the stopped server graph.
+	objectleak.WithExpected("FunctionalTestBase.testCluster.host.clients.frontend*"),
+	// Test hooks remain registered for the lifetime of the stopped server graph.
+	objectleak.WithExpected("FunctionalTestBase.testCluster.host.clients.testHooks*"),
+	// The stopped Fx application retains its dependency graph for the process lifetime.
+	objectleak.WithExpected("FunctionalTestBase.testCluster.host.server*"),
+	// Cluster metadata is shared with process-lifetime server registrations.
+	objectleak.WithExpected("FunctionalTestBase.testCluster.host.serverConfig.ClusterMetadata"),
+	// Server callbacks remain reachable from the stopped Fx application.
+	objectleak.WithExpected("FunctionalTestBase.testCluster.host.testServerState"),
 	// SQLite intentionally keeps one *sql.DB per file DSN for the process lifetime.
 	objectleak.WithExpected("FunctionalTestBase.testCluster.testBase.ShardMgr.persistence.persistence.shardStore.SqlStore.DB.DB.db*"),
-	// The persistence metric emitter shares the closed TestLogger with the stopped server graph.
-	objectleak.WithExpected("FunctionalTestBase.testCluster.testBase.ShardMgr.persistence.metricEmitter.logger*"),
 	// The namespace queue uses the package-level namespaceQueueRetryPolicy from persistence/client/factory.go.
 	objectleak.WithExpected("FunctionalTestBase.testCluster.testBase.NamespaceReplicationQueue.queue.policy"),
 	// Persistence managers use the package-level retryPolicy from persistence/client/factory.go.
 	objectleak.WithExpected("FunctionalTestBase.testCluster.testBase.ShardMgr.policy"),
 	// Client.Close stops transports but retains immutable SDK converters and gRPC buffer pools.
 	objectleak.WithExpected("sdkClient*"),
-}
-
-type clusterLeakRoots struct {
-	testCluster *testcore.TestCluster
-	sdkClient   sdkclient.Client
 }
 
 // TestClusterShutdownLeak is a goroutine-leak regression test for the functional
@@ -87,7 +102,7 @@ func TestClusterShutdownLeak(t *testing.T) {
 	// Warm up with a few clusters so process-lifetime singletons (gRPC resolver
 	// init, proto registries, ...) are created before we snapshot the baseline.
 	for range warmupIters {
-		buildRunTeardownCluster(t)
+		buildRunTeardownCluster(t, nil)
 	}
 
 	// Wait for warmup goroutines to drain before snapshotting the baseline.
@@ -96,7 +111,7 @@ func TestClusterShutdownLeak(t *testing.T) {
 
 	// Run the leak test: build, run, and tear down a cluster per iteration.
 	for i := range iters {
-		leakCheck.Track(buildRunTeardownCluster(t))
+		buildRunTeardownCluster(t, &leakCheck)
 		t.Logf("cluster %2d: goroutines=%d", i, runtime.NumGoroutine())
 	}
 
@@ -130,9 +145,7 @@ func TestClusterShutdownLeak(t *testing.T) {
 
 // buildRunTeardownCluster creates a dedicated cluster, runs a trivial
 // workflow on it to exercise the full server path, then tears it down.
-func buildRunTeardownCluster(t *testing.T) *clusterLeakRoots {
-	var roots *clusterLeakRoots
-
+func buildRunTeardownCluster(t *testing.T, leakCheck *objectleak.ObjectLeakCheck) {
 	// The subtest ensures all env cleanups complete before this returns.
 	t.Run("cluster", func(t *testing.T) {
 		env := testcore.NewEnv(t,
@@ -148,12 +161,10 @@ func buildRunTeardownCluster(t *testing.T) *clusterLeakRoots {
 		require.NoError(t, err)
 		require.NoError(t, run.Get(context.Background(), nil))
 
-		roots = &clusterLeakRoots{
-			testCluster: env.GetTestCluster(),
-			sdkClient:   env.SdkClient(),
+		if leakCheck != nil {
+			leakCheck.Track(env)
 		}
 	})
-	return roots
 }
 
 func smokeWorkflow(workflow.Context) error { return nil }

--- a/tests/leakcheck/leak_test.go
+++ b/tests/leakcheck/leak_test.go
@@ -87,7 +87,7 @@ func TestClusterShutdownLeak(t *testing.T) {
 	// Warm up with a few clusters so process-lifetime singletons (gRPC resolver
 	// init, proto registries, ...) are created before we snapshot the baseline.
 	for range warmupIters {
-		buildRunTeardownCluster(t, nil)
+		buildRunTeardownCluster(t)
 	}
 
 	// Wait for warmup goroutines to drain before snapshotting the baseline.
@@ -96,7 +96,7 @@ func TestClusterShutdownLeak(t *testing.T) {
 
 	// Run the leak test: build, run, and tear down a cluster per iteration.
 	for i := range iters {
-		buildRunTeardownCluster(t, &leakCheck)
+		leakCheck.Track(buildRunTeardownCluster(t))
 		t.Logf("cluster %2d: goroutines=%d", i, runtime.NumGoroutine())
 	}
 
@@ -130,7 +130,9 @@ func TestClusterShutdownLeak(t *testing.T) {
 
 // buildRunTeardownCluster creates a dedicated cluster, runs a trivial
 // workflow on it to exercise the full server path, then tears it down.
-func buildRunTeardownCluster(t *testing.T, leakCheck *objectleak.ObjectLeakCheck) {
+func buildRunTeardownCluster(t *testing.T) *clusterLeakRoots {
+	var roots *clusterLeakRoots
+
 	// The subtest ensures all env cleanups complete before this returns.
 	t.Run("cluster", func(t *testing.T) {
 		env := testcore.NewEnv(t,
@@ -146,15 +148,12 @@ func buildRunTeardownCluster(t *testing.T, leakCheck *objectleak.ObjectLeakCheck
 		require.NoError(t, err)
 		require.NoError(t, run.Get(context.Background(), nil))
 
-		if leakCheck != nil {
-			// Track the roots before teardown so the checker sees the complete
-			// graph and can verify which objects cleanup makes collectible.
-			leakCheck.Track(&clusterLeakRoots{
-				testCluster: env.GetTestCluster(),
-				sdkClient:   env.SdkClient(),
-			})
+		roots = &clusterLeakRoots{
+			testCluster: env.GetTestCluster(),
+			sdkClient:   env.SdkClient(),
 		}
 	})
+	return roots
 }
 
 func smokeWorkflow(workflow.Context) error { return nil }

--- a/tests/leakcheck/leak_test.go
+++ b/tests/leakcheck/leak_test.go
@@ -40,7 +40,7 @@ var objectLeakOpts = []objectleak.Option{
 	objectleak.WithExpected("sdkClient*"),
 }
 
-type clusterResources struct {
+type clusterLeakRoots struct {
 	testCluster *testcore.TestCluster
 	sdkClient   sdkclient.Client
 }
@@ -131,8 +131,6 @@ func TestClusterShutdownLeak(t *testing.T) {
 // buildRunTeardownCluster creates a dedicated cluster, runs a trivial
 // workflow on it to exercise the full server path, then tears it down.
 func buildRunTeardownCluster(t *testing.T, leakCheck *objectleak.ObjectLeakCheck) {
-	var resources *clusterResources
-
 	// The subtest ensures all env cleanups complete before this returns.
 	t.Run("cluster", func(t *testing.T) {
 		env := testcore.NewEnv(t,
@@ -149,17 +147,14 @@ func buildRunTeardownCluster(t *testing.T, leakCheck *objectleak.ObjectLeakCheck
 		require.NoError(t, run.Get(context.Background(), nil))
 
 		if leakCheck != nil {
-			resources = &clusterResources{
+			// Track the roots before teardown so the checker sees the complete
+			// graph and can verify which objects cleanup makes collectible.
+			leakCheck.Track(&clusterLeakRoots{
 				testCluster: env.GetTestCluster(),
 				sdkClient:   env.SdkClient(),
-			}
+			})
 		}
 	})
-	if resources != nil {
-		// Track the stopped roots after teardown so severed server internals
-		// aren't promoted to independent leak roots.
-		leakCheck.Track(resources)
-	}
 }
 
 func smokeWorkflow(workflow.Context) error { return nil }

--- a/tests/testcore/clients.go
+++ b/tests/testcore/clients.go
@@ -227,12 +227,7 @@ func (c *clients) close() []error {
 		}
 	}
 	c.frontend.conn = nil
-	c.frontend.admin = nil
-	c.frontend.frontend = nil
-	c.frontend.operator = nil
 	c.history.conn = nil
-	c.history.history = nil
-	c.history.scheduler = nil
 	return errs
 }
 

--- a/tests/testcore/clients.go
+++ b/tests/testcore/clients.go
@@ -227,7 +227,12 @@ func (c *clients) close() []error {
 		}
 	}
 	c.frontend.conn = nil
+	c.frontend.admin = nil
+	c.frontend.frontend = nil
+	c.frontend.operator = nil
 	c.history.conn = nil
+	c.history.history = nil
+	c.history.scheduler = nil
 	return errs
 }
 

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -735,15 +735,17 @@ func (s *FunctionalTestBase) RegisterTest(t testlogger.CleanupCapableT) {
 		s.t.addTest(t)
 	}
 
+	testBase := s
 	t.Cleanup(func() {
-		if tl, ok := s.Logger.(*testlogger.TestLogger); ok {
+		defer func() { testBase = nil }()
+		if tl, ok := testBase.Logger.(*testlogger.TestLogger); ok {
 			if f := tl.Failure(); f != nil {
 				t.Errorf("cluster poisoned by %s log: %s", f.Level, f.Msg)
 			}
 		}
-		wasLast := s.t != nil && s.t.removeTest(t)
-		if wasLast && s.Poisoned() {
-			if err := s.tearDownTestCluster(); err != nil {
+		wasLast := testBase.t != nil && testBase.t.removeTest(t)
+		if wasLast && testBase.Poisoned() {
+			if err := testBase.tearDownTestCluster(); err != nil {
 				t.Logf("Failed to tear down poisoned cluster: %v", err)
 			}
 		}

--- a/tests/testcore/onebox.go
+++ b/tests/testcore/onebox.go
@@ -63,19 +63,14 @@ type (
 		chasmVisibilityMgr chasm.VisibilityManager
 
 		replicationStreamRecorder *ReplicationStreamRecorder
-		historyTaskRecorder       *historyTaskRecorderRef
-
-		authCallbacks *testAuthCallbacks
+		*testServerState
 	}
 
-	historyTaskRecorderRef struct {
-		recorder *HistoryTaskRecorder
-	}
-
-	testAuthCallbacks struct {
-		callbackLock sync.RWMutex
-		onGetClaims  func(*authorization.AuthInfo) (*authorization.Claims, error)
-		onAuthorize  func(context.Context, *authorization.Claims, *authorization.CallTarget) (authorization.Result, error)
+	testServerState struct {
+		historyTaskRecorder *HistoryTaskRecorder
+		callbackLock        sync.RWMutex
+		onGetClaims         func(*authorization.AuthInfo) (*authorization.Claims, error)
+		onAuthorize         func(context.Context, *authorization.Claims, *authorization.CallTarget) (authorization.Result, error)
 	}
 
 	// FrontendConfig is the config for the frontend service
@@ -136,13 +131,12 @@ func newTemporal(t *testing.T, params *temporalParams) *temporalImpl {
 		hostsByProtocolByService:  params.HostsByProtocolByService,
 		workerConfig:              params.WorkerConfig,
 		replicationStreamRecorder: NewReplicationStreamRecorder(),
-		historyTaskRecorder:       &historyTaskRecorderRef{},
-		authCallbacks:             &testAuthCallbacks{},
+		testServerState:           &testServerState{},
 	}
 
 	// Base options are independent of which services this test cluster starts.
 	// [Start] adds the per-service config and static host map.
-	authCallbacks := impl.authCallbacks
+	serverState := impl.testServerState
 	baseServerOptions := []temporal.ServerOption{
 		temporal.WithLogger(impl.logger),
 		temporal.WithNamespaceLogger(impl.logger),
@@ -154,8 +148,8 @@ func newTemporal(t *testing.T, params *temporalParams) *temporalImpl {
 			mockAdminClient: params.MockAdminClient,
 		}),
 		temporal.WithTestHooks(impl.testHooks),
-		temporal.WithAuthorizer(authCallbacks),
-		temporal.WithClaimMapper(func(*config.Config) authorization.ClaimMapper { return authCallbacks }),
+		temporal.WithAuthorizer(serverState),
+		temporal.WithClaimMapper(func(*config.Config) authorization.ClaimMapper { return serverState }),
 		temporal.WithAudienceGetter(func(*config.Config) authorization.JWTAudienceMapper { return nil }),
 		temporal.WithSearchAttributesMapper(nil),
 		temporal.WithPersistenceServiceResolver(resolver.NewNoopResolver()),
@@ -174,7 +168,6 @@ func newTemporal(t *testing.T, params *temporalParams) *temporalImpl {
 	}
 	if params.EnableHistoryTaskRecorder {
 		base := temporal.PersistenceFactoryProvider()
-		recorderRef := impl.historyTaskRecorder
 		// Only history gets the recording wrapper; other services keep the production factory.
 		baseServerOptions = append(baseServerOptions, temporal.WithPersistenceFactoryProvider(func(params persistenceClient.NewFactoryParams) persistenceClient.Factory {
 			factory := base(params)
@@ -185,7 +178,7 @@ func newTemporal(t *testing.T, params *temporalParams) *temporalImpl {
 				Factory: factory,
 				logger:  params.Logger,
 				setRecorder: func(recorder *HistoryTaskRecorder) {
-					recorderRef.recorder = recorder
+					serverState.historyTaskRecorder = recorder
 				},
 			}
 		}))
@@ -319,11 +312,8 @@ func (c *temporalImpl) Stop() error {
 	var errs []error
 	if c.server != nil {
 		errs = append(errs, c.server.Stop())
-		c.server = nil
 	}
 	errs = append(errs, c.close()...)
-	c.chasmEngine = nil
-	c.chasmVisibilityMgr = nil
 	return multierr.Combine(errs...)
 }
 
@@ -362,11 +352,11 @@ func (c *temporalImpl) ChasmContext(ctx context.Context) (context.Context, error
 	return ctx, nil
 }
 
-func (c *temporalImpl) GetHistoryTaskRecorder() *HistoryTaskRecorder {
-	if c.historyTaskRecorder == nil {
+func (s *testServerState) GetHistoryTaskRecorder() *HistoryTaskRecorder {
+	if s == nil {
 		return nil
 	}
-	return c.historyTaskRecorder.recorder
+	return s.historyTaskRecorder
 }
 
 func (c *temporalImpl) TLSConfigProvider() *encryption.FixedTLSConfigProvider {
@@ -386,48 +376,38 @@ func (c *temporalImpl) GetMetricsHandler() metrics.Handler {
 	return metrics.NoopMetricsHandler
 }
 
-func (c *temporalImpl) SetOnGetClaims(fn func(*authorization.AuthInfo) (*authorization.Claims, error)) {
-	c.authCallbacks.SetOnGetClaims(fn)
+func (s *testServerState) SetOnGetClaims(fn func(*authorization.AuthInfo) (*authorization.Claims, error)) {
+	s.callbackLock.Lock()
+	s.onGetClaims = fn
+	s.callbackLock.Unlock()
 }
 
-func (a *testAuthCallbacks) SetOnGetClaims(fn func(*authorization.AuthInfo) (*authorization.Claims, error)) {
-	a.callbackLock.Lock()
-	a.onGetClaims = fn
-	a.callbackLock.Unlock()
-}
-
-func (a *testAuthCallbacks) GetClaims(authInfo *authorization.AuthInfo) (*authorization.Claims, error) {
-	a.callbackLock.RLock()
-	onGetClaims := a.onGetClaims
-	a.callbackLock.RUnlock()
+func (s *testServerState) GetClaims(authInfo *authorization.AuthInfo) (*authorization.Claims, error) {
+	s.callbackLock.RLock()
+	onGetClaims := s.onGetClaims
+	s.callbackLock.RUnlock()
 	if onGetClaims != nil {
 		return onGetClaims(authInfo)
 	}
 	return &authorization.Claims{System: authorization.RoleAdmin}, nil
 }
 
-func (c *temporalImpl) SetOnAuthorize(
+func (s *testServerState) SetOnAuthorize(
 	fn func(context.Context, *authorization.Claims, *authorization.CallTarget) (authorization.Result, error),
 ) {
-	c.authCallbacks.SetOnAuthorize(fn)
+	s.callbackLock.Lock()
+	s.onAuthorize = fn
+	s.callbackLock.Unlock()
 }
 
-func (a *testAuthCallbacks) SetOnAuthorize(
-	fn func(context.Context, *authorization.Claims, *authorization.CallTarget) (authorization.Result, error),
-) {
-	a.callbackLock.Lock()
-	a.onAuthorize = fn
-	a.callbackLock.Unlock()
-}
-
-func (a *testAuthCallbacks) Authorize(
+func (s *testServerState) Authorize(
 	ctx context.Context,
 	caller *authorization.Claims,
 	target *authorization.CallTarget,
 ) (authorization.Result, error) {
-	a.callbackLock.RLock()
-	onAuthorize := a.onAuthorize
-	a.callbackLock.RUnlock()
+	s.callbackLock.RLock()
+	onAuthorize := s.onAuthorize
+	s.callbackLock.RUnlock()
 	if onAuthorize != nil {
 		return onAuthorize(ctx, caller, target)
 	}

--- a/tests/testcore/onebox.go
+++ b/tests/testcore/onebox.go
@@ -63,8 +63,16 @@ type (
 		chasmVisibilityMgr chasm.VisibilityManager
 
 		replicationStreamRecorder *ReplicationStreamRecorder
-		historyTaskRecorder       *HistoryTaskRecorder
+		historyTaskRecorder       *historyTaskRecorderRef
 
+		authCallbacks *testAuthCallbacks
+	}
+
+	historyTaskRecorderRef struct {
+		recorder *HistoryTaskRecorder
+	}
+
+	testAuthCallbacks struct {
 		callbackLock sync.RWMutex
 		onGetClaims  func(*authorization.AuthInfo) (*authorization.Claims, error)
 		onAuthorize  func(context.Context, *authorization.Claims, *authorization.CallTarget) (authorization.Result, error)
@@ -128,10 +136,13 @@ func newTemporal(t *testing.T, params *temporalParams) *temporalImpl {
 		hostsByProtocolByService:  params.HostsByProtocolByService,
 		workerConfig:              params.WorkerConfig,
 		replicationStreamRecorder: NewReplicationStreamRecorder(),
+		historyTaskRecorder:       &historyTaskRecorderRef{},
+		authCallbacks:             &testAuthCallbacks{},
 	}
 
 	// Base options are independent of which services this test cluster starts.
 	// [Start] adds the per-service config and static host map.
+	authCallbacks := impl.authCallbacks
 	baseServerOptions := []temporal.ServerOption{
 		temporal.WithLogger(impl.logger),
 		temporal.WithNamespaceLogger(impl.logger),
@@ -143,8 +154,8 @@ func newTemporal(t *testing.T, params *temporalParams) *temporalImpl {
 			mockAdminClient: params.MockAdminClient,
 		}),
 		temporal.WithTestHooks(impl.testHooks),
-		temporal.WithAuthorizer(impl),
-		temporal.WithClaimMapper(func(*config.Config) authorization.ClaimMapper { return impl }),
+		temporal.WithAuthorizer(authCallbacks),
+		temporal.WithClaimMapper(func(*config.Config) authorization.ClaimMapper { return authCallbacks }),
 		temporal.WithAudienceGetter(func(*config.Config) authorization.JWTAudienceMapper { return nil }),
 		temporal.WithSearchAttributesMapper(nil),
 		temporal.WithPersistenceServiceResolver(resolver.NewNoopResolver()),
@@ -163,6 +174,7 @@ func newTemporal(t *testing.T, params *temporalParams) *temporalImpl {
 	}
 	if params.EnableHistoryTaskRecorder {
 		base := temporal.PersistenceFactoryProvider()
+		recorderRef := impl.historyTaskRecorder
 		// Only history gets the recording wrapper; other services keep the production factory.
 		baseServerOptions = append(baseServerOptions, temporal.WithPersistenceFactoryProvider(func(params persistenceClient.NewFactoryParams) persistenceClient.Factory {
 			factory := base(params)
@@ -173,7 +185,7 @@ func newTemporal(t *testing.T, params *temporalParams) *temporalImpl {
 				Factory: factory,
 				logger:  params.Logger,
 				setRecorder: func(recorder *HistoryTaskRecorder) {
-					impl.historyTaskRecorder = recorder
+					recorderRef.recorder = recorder
 				},
 			}
 		}))
@@ -307,8 +319,11 @@ func (c *temporalImpl) Stop() error {
 	var errs []error
 	if c.server != nil {
 		errs = append(errs, c.server.Stop())
+		c.server = nil
 	}
 	errs = append(errs, c.close()...)
+	c.chasmEngine = nil
+	c.chasmVisibilityMgr = nil
 	return multierr.Combine(errs...)
 }
 
@@ -348,7 +363,10 @@ func (c *temporalImpl) ChasmContext(ctx context.Context) (context.Context, error
 }
 
 func (c *temporalImpl) GetHistoryTaskRecorder() *HistoryTaskRecorder {
-	return c.historyTaskRecorder
+	if c.historyTaskRecorder == nil {
+		return nil
+	}
+	return c.historyTaskRecorder.recorder
 }
 
 func (c *temporalImpl) TLSConfigProvider() *encryption.FixedTLSConfigProvider {
@@ -369,15 +387,19 @@ func (c *temporalImpl) GetMetricsHandler() metrics.Handler {
 }
 
 func (c *temporalImpl) SetOnGetClaims(fn func(*authorization.AuthInfo) (*authorization.Claims, error)) {
-	c.callbackLock.Lock()
-	c.onGetClaims = fn
-	c.callbackLock.Unlock()
+	c.authCallbacks.SetOnGetClaims(fn)
 }
 
-func (c *temporalImpl) GetClaims(authInfo *authorization.AuthInfo) (*authorization.Claims, error) {
-	c.callbackLock.RLock()
-	onGetClaims := c.onGetClaims
-	c.callbackLock.RUnlock()
+func (a *testAuthCallbacks) SetOnGetClaims(fn func(*authorization.AuthInfo) (*authorization.Claims, error)) {
+	a.callbackLock.Lock()
+	a.onGetClaims = fn
+	a.callbackLock.Unlock()
+}
+
+func (a *testAuthCallbacks) GetClaims(authInfo *authorization.AuthInfo) (*authorization.Claims, error) {
+	a.callbackLock.RLock()
+	onGetClaims := a.onGetClaims
+	a.callbackLock.RUnlock()
 	if onGetClaims != nil {
 		return onGetClaims(authInfo)
 	}
@@ -387,23 +409,35 @@ func (c *temporalImpl) GetClaims(authInfo *authorization.AuthInfo) (*authorizati
 func (c *temporalImpl) SetOnAuthorize(
 	fn func(context.Context, *authorization.Claims, *authorization.CallTarget) (authorization.Result, error),
 ) {
-	c.callbackLock.Lock()
-	c.onAuthorize = fn
-	c.callbackLock.Unlock()
+	c.authCallbacks.SetOnAuthorize(fn)
 }
 
-func (c *temporalImpl) Authorize(
+func (a *testAuthCallbacks) SetOnAuthorize(
+	fn func(context.Context, *authorization.Claims, *authorization.CallTarget) (authorization.Result, error),
+) {
+	a.callbackLock.Lock()
+	a.onAuthorize = fn
+	a.callbackLock.Unlock()
+}
+
+func (a *testAuthCallbacks) Authorize(
 	ctx context.Context,
 	caller *authorization.Claims,
 	target *authorization.CallTarget,
 ) (authorization.Result, error) {
-	c.callbackLock.RLock()
-	onAuthorize := c.onAuthorize
-	c.callbackLock.RUnlock()
+	a.callbackLock.RLock()
+	onAuthorize := a.onAuthorize
+	a.callbackLock.RUnlock()
 	if onAuthorize != nil {
 		return onAuthorize(ctx, caller, target)
 	}
 	return authorization.Result{Decision: authorization.DecisionAllow}, nil
+}
+
+func (c *temporalImpl) clearReferences() {
+	// Keep the host allocation itself available to object leak checks while
+	// releasing everything that is no longer usable after shutdown.
+	*c = temporalImpl{}
 }
 
 // copyPersistenceConfig makes a deep copy of persistence config.

--- a/tests/testcore/onebox.go
+++ b/tests/testcore/onebox.go
@@ -42,6 +42,7 @@ import (
 type (
 	temporalImpl struct {
 		clients
+		*testServerState
 		server temporal.Server
 
 		logger       log.Logger
@@ -63,7 +64,6 @@ type (
 		chasmVisibilityMgr chasm.VisibilityManager
 
 		replicationStreamRecorder *ReplicationStreamRecorder
-		*testServerState
 	}
 
 	testServerState struct {
@@ -352,13 +352,6 @@ func (c *temporalImpl) ChasmContext(ctx context.Context) (context.Context, error
 	return ctx, nil
 }
 
-func (s *testServerState) GetHistoryTaskRecorder() *HistoryTaskRecorder {
-	if s == nil {
-		return nil
-	}
-	return s.historyTaskRecorder
-}
-
 func (c *temporalImpl) TLSConfigProvider() *encryption.FixedTLSConfigProvider {
 	return c.tlsConfigProvider
 }
@@ -374,44 +367,6 @@ func (c *temporalImpl) GetMetricsHandler() metrics.Handler {
 		return c.captureMetricsHandler
 	}
 	return metrics.NoopMetricsHandler
-}
-
-func (s *testServerState) SetOnGetClaims(fn func(*authorization.AuthInfo) (*authorization.Claims, error)) {
-	s.callbackLock.Lock()
-	s.onGetClaims = fn
-	s.callbackLock.Unlock()
-}
-
-func (s *testServerState) GetClaims(authInfo *authorization.AuthInfo) (*authorization.Claims, error) {
-	s.callbackLock.RLock()
-	onGetClaims := s.onGetClaims
-	s.callbackLock.RUnlock()
-	if onGetClaims != nil {
-		return onGetClaims(authInfo)
-	}
-	return &authorization.Claims{System: authorization.RoleAdmin}, nil
-}
-
-func (s *testServerState) SetOnAuthorize(
-	fn func(context.Context, *authorization.Claims, *authorization.CallTarget) (authorization.Result, error),
-) {
-	s.callbackLock.Lock()
-	s.onAuthorize = fn
-	s.callbackLock.Unlock()
-}
-
-func (s *testServerState) Authorize(
-	ctx context.Context,
-	caller *authorization.Claims,
-	target *authorization.CallTarget,
-) (authorization.Result, error) {
-	s.callbackLock.RLock()
-	onAuthorize := s.onAuthorize
-	s.callbackLock.RUnlock()
-	if onAuthorize != nil {
-		return onAuthorize(ctx, caller, target)
-	}
-	return authorization.Result{Decision: authorization.DecisionAllow}, nil
 }
 
 func (c *temporalImpl) clearReferences() {
@@ -476,6 +431,51 @@ func (c *temporalImpl) injectHook(t *testing.T, hook testhooks.Hook, scope any) 
 	cleanup := hook.Apply(c.testHooks, scope)
 	t.Cleanup(cleanup)
 	return cleanup
+}
+
+func (s *testServerState) GetHistoryTaskRecorder() *HistoryTaskRecorder {
+	if s == nil {
+		return nil
+	}
+	return s.historyTaskRecorder
+}
+
+func (s *testServerState) SetOnGetClaims(fn func(*authorization.AuthInfo) (*authorization.Claims, error)) {
+	s.callbackLock.Lock()
+	s.onGetClaims = fn
+	s.callbackLock.Unlock()
+}
+
+func (s *testServerState) GetClaims(authInfo *authorization.AuthInfo) (*authorization.Claims, error) {
+	s.callbackLock.RLock()
+	onGetClaims := s.onGetClaims
+	s.callbackLock.RUnlock()
+	if onGetClaims != nil {
+		return onGetClaims(authInfo)
+	}
+	return &authorization.Claims{System: authorization.RoleAdmin}, nil
+}
+
+func (s *testServerState) SetOnAuthorize(
+	fn func(context.Context, *authorization.Claims, *authorization.CallTarget) (authorization.Result, error),
+) {
+	s.callbackLock.Lock()
+	s.onAuthorize = fn
+	s.callbackLock.Unlock()
+}
+
+func (s *testServerState) Authorize(
+	ctx context.Context,
+	caller *authorization.Claims,
+	target *authorization.CallTarget,
+) (authorization.Result, error) {
+	s.callbackLock.RLock()
+	onAuthorize := s.onAuthorize
+	s.callbackLock.RUnlock()
+	if onAuthorize != nil {
+		return onAuthorize(ctx, caller, target)
+	}
+	return authorization.Result{Decision: authorization.DecisionAllow}, nil
 }
 
 func mustSplitHostPort(addr string) (string, int) {

--- a/tests/testcore/onebox.go
+++ b/tests/testcore/onebox.go
@@ -370,8 +370,7 @@ func (c *temporalImpl) GetMetricsHandler() metrics.Handler {
 }
 
 func (c *temporalImpl) clearReferences() {
-	// Keep the host allocation itself available to object leak checks while
-	// releasing everything that is no longer usable after shutdown.
+	// Release everything that is no longer usable after shutdown.
 	*c = temporalImpl{}
 }
 

--- a/tests/testcore/onebox.go
+++ b/tests/testcore/onebox.go
@@ -369,11 +369,6 @@ func (c *temporalImpl) GetMetricsHandler() metrics.Handler {
 	return metrics.NoopMetricsHandler
 }
 
-func (c *temporalImpl) clearReferences() {
-	// Release everything that is no longer usable after shutdown.
-	*c = temporalImpl{}
-}
-
 // copyPersistenceConfig makes a deep copy of persistence config.
 // This is just a temp fix for the race condition of persistence config.
 // The race condition happens because all the services are using the same datastore map in the config.

--- a/tests/testcore/test_cluster.go
+++ b/tests/testcore/test_cluster.go
@@ -486,13 +486,8 @@ func enableArchivalConfig(cfg *config.Config) {
 }
 
 // TearDownCluster tears down the test cluster
-func (tc *TestCluster) TearDownCluster() (errs error) {
-	defer func() {
-		tc.host.clearReferences()
-		tc.host = nil
-	}()
-
-	errs = tc.host.Stop()
+func (tc *TestCluster) TearDownCluster() error {
+	errs := tc.host.Stop()
 	tc.testBase.TearDownWorkflowStore()
 	if !UseSQLVisibility() {
 		if esConfig := tc.host.serverConfig.Persistence.DataStores[tc.host.serverConfig.Persistence.VisibilityStore].Elasticsearch; esConfig != nil {
@@ -501,6 +496,7 @@ func (tc *TestCluster) TearDownCluster() (errs error) {
 			}
 		}
 	}
+	tc.host = nil
 	return errs
 }
 

--- a/tests/testcore/test_cluster.go
+++ b/tests/testcore/test_cluster.go
@@ -496,6 +496,7 @@ func (tc *TestCluster) TearDownCluster() error {
 			}
 		}
 	}
+	tc.host.clearReferences()
 	return errs
 }
 

--- a/tests/testcore/test_cluster.go
+++ b/tests/testcore/test_cluster.go
@@ -486,8 +486,8 @@ func enableArchivalConfig(cfg *config.Config) {
 }
 
 // TearDownCluster tears down the test cluster
-func (tc *TestCluster) TearDownCluster() error {
-	errs := tc.host.Stop()
+func (tc *TestCluster) TearDownCluster() (errs error) {
+	errs = tc.host.Stop()
 	tc.testBase.TearDownWorkflowStore()
 	if !UseSQLVisibility() {
 		if esConfig := tc.host.serverConfig.Persistence.DataStores[tc.host.serverConfig.Persistence.VisibilityStore].Elasticsearch; esConfig != nil {

--- a/tests/testcore/test_cluster.go
+++ b/tests/testcore/test_cluster.go
@@ -487,6 +487,11 @@ func enableArchivalConfig(cfg *config.Config) {
 
 // TearDownCluster tears down the test cluster
 func (tc *TestCluster) TearDownCluster() (errs error) {
+	defer func() {
+		tc.host.clearReferences()
+		tc.host = nil
+	}()
+
 	errs = tc.host.Stop()
 	tc.testBase.TearDownWorkflowStore()
 	if !UseSQLVisibility() {
@@ -496,7 +501,6 @@ func (tc *TestCluster) TearDownCluster() (errs error) {
 			}
 		}
 	}
-	tc.host.clearReferences()
 	return errs
 }
 

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -344,6 +344,7 @@ func (p *clusterRouter) getDedicated(t *testing.T, req clusterRequest) *Function
 
 		// Register cleanup to tear down the cluster when the test completes.
 		t.Cleanup(func() {
+			defer func() { cluster = nil }()
 			if err := cluster.tearDownTestCluster(); err != nil {
 				t.Logf("Failed to tear down cluster: %v", err)
 			}


### PR DESCRIPTION
## Summary

- release test-cluster references after shutdown and separate auth callback state from the stopped server graph
- track object roots after teardown and remove the broad host leak exemption
- replace the broad test-base exemption with documented, narrowly scoped process-lifetime paths

## Testing

- `LEAK_ITERS=3 LEAK_ITERS_WARMUP=1 LEAK_TIMEOUT=5m LEAK_GC_SETTLE_TIMEOUT=10s make leak-test`
- `go test -tags test_dep ./tests/testcore`
- `make lint-code`