### PR TITLE
Surface canceled CHASM Nexus operations as CanceledError

### DIFF
--- a/chasm/lib/nexusoperation/operation_tasks_test.go
+++ b/chasm/lib/nexusoperation/operation_tasks_test.go
@@ -585,6 +585,32 @@ func TestInvocationTaskHandler_HTTP(t *testing.T) {
 	}
 }
 
+// TestNewInvocationResult_CanceledBareFailure guards the sync completion path's
+// commonnexus.EnsureCanceledFailureInfo call site. A canceled operation whose failure body carries no
+// recognized Temporal type metadata converts to a non-canceled failure; newInvocationResult must still
+// surface it as a CanceledFailure so the operation is recorded canceled rather than failed.
+func TestNewInvocationResult_CanceledBareFailure(t *testing.T) {
+	t.Parallel()
+
+	// Mirror the wire shape the client reconstructs for an older/non-Temporal server: an
+	// OperationError wrapping a bare failure cause, with the wrapper marked for unwrapping.
+	opErr := &nexus.OperationError{
+		State:   nexus.OperationStateCanceled,
+		Message: "operation canceled from handler",
+		Cause:   &nexus.FailureError{Failure: nexus.Failure{Message: "cause"}},
+	}
+	require.NoError(t, nexusrpc.MarkAsWrapperError(nexusrpc.DefaultFailureConverter(), opErr))
+
+	result, err := newInvocationResult(nil, opErr)
+	require.NoError(t, err)
+
+	cancel, ok := result.(invocationResultCancel)
+	require.True(t, ok, "canceled operation error must produce a cancel result")
+	require.NotNil(t, cancel.failure.GetCanceledFailureInfo(),
+		"a canceled completion with a bare (non-Temporal) failure body must surface as CanceledFailure")
+	require.Equal(t, "cause", cancel.failure.GetMessage())
+}
+
 func TestInvocationTaskHandler_Validate(t *testing.T) {
 	testCases := []struct {
 		name        string

--- a/chasm/lib/nexusoperation/operation_tasks_test.go
+++ b/chasm/lib/nexusoperation/operation_tasks_test.go
@@ -585,15 +585,11 @@ func TestInvocationTaskHandler_HTTP(t *testing.T) {
 	}
 }
 
-// TestNewInvocationResult_CanceledBareFailure guards the sync completion path's
-// commonnexus.EnsureCanceledFailureInfo call site. A canceled operation whose failure body carries no
-// recognized Temporal type metadata converts to a non-canceled failure; newInvocationResult must still
-// surface it as a CanceledFailure so the operation is recorded canceled rather than failed.
+// TestNewInvocationResult_CanceledBareFailure guards sync canceled completions whose
+// unwrapped cause is a bare Nexus failure.
 func TestNewInvocationResult_CanceledBareFailure(t *testing.T) {
 	t.Parallel()
 
-	// Mirror the wire shape the client reconstructs for an older/non-Temporal server: an
-	// OperationError wrapping a bare failure cause, with the wrapper marked for unwrapping.
 	opErr := &nexus.OperationError{
 		State:   nexus.OperationStateCanceled,
 		Message: "operation canceled from handler",
@@ -607,7 +603,7 @@ func TestNewInvocationResult_CanceledBareFailure(t *testing.T) {
 	cancel, ok := result.(invocationResultCancel)
 	require.True(t, ok, "canceled operation error must produce a cancel result")
 	require.NotNil(t, cancel.failure.GetCanceledFailureInfo(),
-		"a canceled completion with a bare (non-Temporal) failure body must surface as CanceledFailure")
+		"bare canceled failures must surface as CanceledFailure")
 	require.Equal(t, "cause", cancel.failure.GetMessage())
 }
 

--- a/chasm/lib/nexusoperation/task_handler_helpers.go
+++ b/chasm/lib/nexusoperation/task_handler_helpers.go
@@ -275,7 +275,7 @@ func newInvocationResult(
 			return nil, err
 		}
 		if opErr.State == nexus.OperationStateCanceled {
-			failure = commonnexus.EnsureCanceledFailureInfo(failure)
+			failure = commonnexus.CoerceToCanceledFailure(failure)
 			return invocationResultCancel{failure: failure}, nil
 		}
 		return invocationResultFail{failure: failure}, nil

--- a/chasm/lib/nexusoperation/task_handler_helpers.go
+++ b/chasm/lib/nexusoperation/task_handler_helpers.go
@@ -275,6 +275,7 @@ func newInvocationResult(
 			return nil, err
 		}
 		if opErr.State == nexus.OperationStateCanceled {
+			failure = commonnexus.EnsureCanceledFailureInfo(failure)
 			return invocationResultCancel{failure: failure}, nil
 		}
 		return invocationResultFail{failure: failure}, nil

--- a/common/nexus/failure.go
+++ b/common/nexus/failure.go
@@ -14,6 +14,7 @@ import (
 	failurepb "go.temporal.io/api/failure/v1"
 	nexuspb "go.temporal.io/api/nexus/v1"
 	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -183,24 +184,21 @@ func TemporalFailureToNexusFailureInPlace(failure *failurepb.Failure) (nexus.Fai
 	}, nil
 }
 
-// EnsureCanceledFailureInfo makes failure surface as a Temporal CanceledError, preserving the
-// message, source, stack trace, encoded attributes, and cause. Call it only for canceled operations:
-// old SDKs and non-Temporal handlers may send a canceled completion whose converted cause is a plain
-// ApplicationFailure, which would otherwise surface as an ApplicationError to the caller.
-func EnsureCanceledFailureInfo(failure *failurepb.Failure) *failurepb.Failure {
-	if failure.GetCanceledFailureInfo() != nil {
+// CoerceToCanceledFailure replaces failure's FailureInfo with CanceledFailureInfo so it
+// surfaces as a Temporal CanceledError. Every other field is left unchanged.
+//
+// Call it only for canceled operations: old SDKs and non-Temporal handlers may send a canceled
+// completion whose converted cause is a plain ApplicationFailure, which would otherwise surface as
+// an ApplicationError to the caller.
+func CoerceToCanceledFailure(failure *failurepb.Failure) *failurepb.Failure {
+	if failure == nil || failure.GetCanceledFailureInfo() != nil {
 		return failure
 	}
-	return &failurepb.Failure{
-		Message:           failure.GetMessage(),
-		Source:            failure.GetSource(),
-		StackTrace:        failure.GetStackTrace(),
-		EncodedAttributes: failure.GetEncodedAttributes(),
-		FailureInfo: &failurepb.Failure_CanceledFailureInfo{
-			CanceledFailureInfo: &failurepb.CanceledFailureInfo{},
-		},
-		Cause: failure.GetCause(),
+	canceled := common.CloneProto(failure)
+	canceled.FailureInfo = &failurepb.Failure_CanceledFailureInfo{
+		CanceledFailureInfo: &failurepb.CanceledFailureInfo{},
 	}
+	return canceled
 }
 
 // NexusFailureToTemporalFailure converts a Nexus Failure to an API proto Failure.

--- a/common/nexus/failure.go
+++ b/common/nexus/failure.go
@@ -183,6 +183,26 @@ func TemporalFailureToNexusFailureInPlace(failure *failurepb.Failure) (nexus.Fai
 	}, nil
 }
 
+// EnsureCanceledFailureInfo makes failure surface as a Temporal CanceledError, preserving the
+// message, source, stack trace, encoded attributes, and cause. Call it only for canceled operations:
+// old SDKs and non-Temporal handlers may send a canceled completion whose converted cause is a plain
+// ApplicationFailure, which would otherwise surface as an ApplicationError to the caller.
+func EnsureCanceledFailureInfo(failure *failurepb.Failure) *failurepb.Failure {
+	if failure.GetCanceledFailureInfo() != nil {
+		return failure
+	}
+	return &failurepb.Failure{
+		Message:           failure.GetMessage(),
+		Source:            failure.GetSource(),
+		StackTrace:        failure.GetStackTrace(),
+		EncodedAttributes: failure.GetEncodedAttributes(),
+		FailureInfo: &failurepb.Failure_CanceledFailureInfo{
+			CanceledFailureInfo: &failurepb.CanceledFailureInfo{},
+		},
+		Cause: failure.GetCause(),
+	}
+}
+
 // NexusFailureToTemporalFailure converts a Nexus Failure to an API proto Failure.
 // If the failure metadata "type" field is set to the fullname of the temporal API Failure message, the failure is
 // reconstructed using protojson.Unmarshal on the failure details field. Otherwise, the failure is reconstructed

--- a/common/nexus/failure_test.go
+++ b/common/nexus/failure_test.go
@@ -13,6 +13,42 @@ import (
 	"go.temporal.io/server/common/testing/protorequire"
 )
 
+func TestEnsureCanceledFailureInfo(t *testing.T) {
+	t.Run("already a CanceledFailure is returned unchanged", func(t *testing.T) {
+		f := &failurepb.Failure{
+			Message:     "canceled",
+			FailureInfo: &failurepb.Failure_CanceledFailureInfo{CanceledFailureInfo: &failurepb.CanceledFailureInfo{}},
+		}
+		require.Same(t, f, EnsureCanceledFailureInfo(f))
+	})
+
+	t.Run("non-canceled failure is rebuilt as a CanceledFailure, preserving fields", func(t *testing.T) {
+		cause := &failurepb.Failure{Message: "cause"}
+		encoded := mustToPayload(t, "encoded message")
+		// A plain / non-Temporal canceled failure converts to a non-canceled failure (here an
+		// ApplicationFailure). This is the branch the CHASM completion paths rely on.
+		in := &failurepb.Failure{
+			Message:           "canceled from handler",
+			Source:            "GoSDK",
+			StackTrace:        "stack trace here",
+			EncodedAttributes: encoded,
+			FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+				ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{Type: "SomeError"},
+			},
+			Cause: cause,
+		}
+
+		got := EnsureCanceledFailureInfo(in)
+
+		require.NotNil(t, got.GetCanceledFailureInfo(), "must surface as a CanceledFailure")
+		require.Equal(t, "canceled from handler", got.GetMessage())
+		require.Equal(t, "GoSDK", got.GetSource())
+		require.Equal(t, "stack trace here", got.GetStackTrace())
+		protorequire.ProtoEqual(t, encoded, got.GetEncodedAttributes())
+		protorequire.ProtoEqual(t, cause, got.GetCause())
+	})
+}
+
 func TestRoundTrip_ApplicationFailure(t *testing.T) {
 	original := &failurepb.Failure{
 		Message:           "application error",

--- a/common/nexus/failure_test.go
+++ b/common/nexus/failure_test.go
@@ -13,13 +13,13 @@ import (
 	"go.temporal.io/server/common/testing/protorequire"
 )
 
-func TestEnsureCanceledFailureInfo(t *testing.T) {
+func TestCoerceToCanceledFailure(t *testing.T) {
 	t.Run("already a CanceledFailure is returned unchanged", func(t *testing.T) {
 		f := &failurepb.Failure{
 			Message:     "canceled",
 			FailureInfo: &failurepb.Failure_CanceledFailureInfo{CanceledFailureInfo: &failurepb.CanceledFailureInfo{}},
 		}
-		require.Same(t, f, EnsureCanceledFailureInfo(f))
+		require.Same(t, f, CoerceToCanceledFailure(f))
 	})
 
 	t.Run("non-canceled failure is rebuilt as a CanceledFailure, preserving fields", func(t *testing.T) {
@@ -38,7 +38,7 @@ func TestEnsureCanceledFailureInfo(t *testing.T) {
 			Cause: cause,
 		}
 
-		got := EnsureCanceledFailureInfo(in)
+		got := CoerceToCanceledFailure(in)
 
 		require.NotNil(t, got.GetCanceledFailureInfo(), "must surface as a CanceledFailure")
 		require.Equal(t, "canceled from handler", got.GetMessage())

--- a/components/nexusoperations/completion.go
+++ b/components/nexusoperations/completion.go
@@ -88,7 +88,7 @@ func handleOperationError(
 
 		return FailedEventDefinition{}.Apply(node.Parent, event)
 	case nexus.OperationStateCanceled:
-		originalCause = commonnexus.EnsureCanceledFailureInfo(originalCause)
+		originalCause = commonnexus.CoerceToCanceledFailure(originalCause)
 		event := node.AddHistoryEvent(enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCELED, func(e *historypb.HistoryEvent) {
 			// We must assign to this property, linter doesn't like this.
 			// nolint:revive

--- a/components/nexusoperations/completion.go
+++ b/components/nexusoperations/completion.go
@@ -88,17 +88,7 @@ func handleOperationError(
 
 		return FailedEventDefinition{}.Apply(node.Parent, event)
 	case nexus.OperationStateCanceled:
-		if originalCause.GetCanceledFailureInfo() == nil {
-			// Old SDKs may send an ApplicationFailure for canceled operation causes.
-			originalCause = &failurepb.Failure{
-				Message:    originalCause.GetMessage(),
-				StackTrace: originalCause.GetStackTrace(),
-				FailureInfo: &failurepb.Failure_CanceledFailureInfo{
-					CanceledFailureInfo: &failurepb.CanceledFailureInfo{},
-				},
-				Cause: originalCause.GetCause(),
-			}
-		}
+		originalCause = commonnexus.EnsureCanceledFailureInfo(originalCause)
 		event := node.AddHistoryEvent(enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCELED, func(e *historypb.HistoryEvent) {
 			// We must assign to this property, linter doesn't like this.
 			// nolint:revive

--- a/service/frontend/nexus_completion_http_handler.go
+++ b/service/frontend/nexus_completion_http_handler.go
@@ -387,7 +387,7 @@ func (h *nexusCompletionHandler) completeChasmOperation(
 		}
 		// A canceled completion must carry CanceledFailureInfo so that it is recorded as canceled instead of failed.
 		if req.State == nexus.OperationStateCanceled {
-			failure = commonnexus.EnsureCanceledFailureInfo(failure)
+			failure = commonnexus.CoerceToCanceledFailure(failure)
 		}
 		hr.Outcome = &historyservice.CompleteNexusOperationChasmRequest_Failure{
 			Failure: failure,

--- a/service/frontend/nexus_completion_http_handler.go
+++ b/service/frontend/nexus_completion_http_handler.go
@@ -385,6 +385,10 @@ func (h *nexusCompletionHandler) completeChasmOperation(
 			logger.Error("cannot convert nexus failure from completion request", tag.Error(err))
 			return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid failure content")
 		}
+		// A canceled completion must carry CanceledFailureInfo so that it is recorded as canceled instead of failed.
+		if req.State == nexus.OperationStateCanceled {
+			failure = commonnexus.EnsureCanceledFailureInfo(failure)
+		}
 		hr.Outcome = &historyservice.CompleteNexusOperationChasmRequest_Failure{
 			Failure: failure,
 		}

--- a/service/frontend/nexus_completion_http_handler_test.go
+++ b/service/frontend/nexus_completion_http_handler_test.go
@@ -201,3 +201,31 @@ func TestCompleteOperation_FrameworkFallback(t *testing.T) {
 		})
 	}
 }
+
+// TestCompleteChasmOperation_CanceledBareFailure guards that bare canceled failures are
+// normalized before the CHASM completion request reaches history; otherwise the operation is
+// recorded as failed instead of canceled.
+func TestCompleteChasmOperation_CanceledBareFailure(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	client := historyservicemock.NewMockHistoryServiceClient(ctrl)
+	var captured *historyservice.CompleteNexusOperationChasmRequest
+	client.EXPECT().CompleteNexusOperationChasm(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *historyservice.CompleteNexusOperationChasmRequest, _ ...grpc.CallOption) (*historyservice.CompleteNexusOperationChasmResponse, error) {
+			captured = req
+			return &historyservice.CompleteNexusOperationChasmResponse{}, nil
+		})
+
+	h := &nexusCompletionHandler{HistoryClient: client}
+	req := &nexusrpc.CompletionRequest{
+		State: nexus.OperationStateCanceled,
+		Error: &nexus.OperationError{
+			State:           nexus.OperationStateCanceled,
+			OriginalFailure: &nexus.Failure{Message: "operation canceled"},
+		},
+	}
+	require.NoError(t, h.completeChasmOperation(context.Background(), log.NewNoopLogger(), chasmCompletionToken(t), nil, req, nil))
+	require.NotNil(t, captured.GetFailure().GetCanceledFailureInfo(),
+		"canceled completion must carry CanceledFailureInfo")
+}

--- a/service/frontend/nexus_completion_http_handler_test.go
+++ b/service/frontend/nexus_completion_http_handler_test.go
@@ -202,9 +202,8 @@ func TestCompleteOperation_FrameworkFallback(t *testing.T) {
 	}
 }
 
-// TestCompleteChasmOperation_CanceledBareFailure guards that bare canceled failures are
-// normalized before the CHASM completion request reaches history; otherwise the operation is
-// recorded as failed instead of canceled.
+// TestCompleteChasmOperation_CanceledBareFailure guards bare canceled failures
+// on the CHASM async completion path.
 func TestCompleteChasmOperation_CanceledBareFailure(t *testing.T) {
 	t.Parallel()
 
@@ -227,5 +226,5 @@ func TestCompleteChasmOperation_CanceledBareFailure(t *testing.T) {
 	}
 	require.NoError(t, h.completeChasmOperation(context.Background(), log.NewNoopLogger(), chasmCompletionToken(t), nil, req, nil))
 	require.NotNil(t, captured.GetFailure().GetCanceledFailureInfo(),
-		"canceled completion must carry CanceledFailureInfo")
+		"bare canceled failures must carry CanceledFailureInfo")
 }

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -1494,66 +1494,110 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionBeforeStart(ch
 }
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncFailure(chasmEnabled bool) {
-	env := s.newTestEnv(chasmEnabled)
-	ctx := s.Context()
-	taskQueue := testcore.RandomizeStr(s.T().Name())
-
-	var callbackToken, publicCallbackURL string
-
-	h := nexustest.Handler{
-		OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
-			callbackToken = options.CallbackHeader.Get(commonnexus.CallbackTokenHeader)
-			publicCallbackURL = options.CallbackURL
-			return &nexus.HandlerStartOperationResultAsync{OperationToken: "test"}, nil
+	testCases := []struct {
+		name            string
+		completionError *nexus.OperationError
+		expectedEvent   enumspb.EventType
+		// Asserted in the workflow: the Go SDK strips the NexusOperationError wrapper when the
+		// returned error wraps a CanceledError.
+		checkWorkflowError func(err error) error
+	}{
+		{
+			name:            "Failed",
+			completionError: nexus.NewOperationFailedErrorf("test operation failed"),
+			expectedEvent:   enumspb.EVENT_TYPE_NEXUS_OPERATION_FAILED,
+			checkWorkflowError: func(err error) error {
+				var opErr *temporal.NexusOperationError
+				if !errors.As(err, &opErr) {
+					return fmt.Errorf("expected NexusOperationError, got %w", err)
+				}
+				if _, ok := errors.AsType[*temporal.ApplicationError](opErr); !ok {
+					return fmt.Errorf("expected ApplicationError, got %w", err)
+				}
+				if !strings.Contains(opErr.Error(), "test operation failed") {
+					return fmt.Errorf("expected error to contain %q, got %w", "test operation failed", err)
+				}
+				return nil
+			},
+		},
+		{
+			// A bare failure body carries no CanceledFailureInfo, but must still be recorded as canceled.
+			name: "CanceledBareFailure",
+			completionError: &nexus.OperationError{
+				State: nexus.OperationStateCanceled,
+				Cause: &nexus.FailureError{Failure: nexus.Failure{Message: "operation canceled"}},
+			},
+			expectedEvent: enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCELED,
+			checkWorkflowError: func(err error) error {
+				var opErr *temporal.NexusOperationError
+				if !errors.As(err, &opErr) {
+					return fmt.Errorf("expected NexusOperationError, got %w", err)
+				}
+				if _, ok := errors.AsType[*temporal.CanceledError](opErr); !ok {
+					return fmt.Errorf("expected CanceledError, got %w", err)
+				}
+				return nil
+			},
 		},
 	}
-	endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
 
-	callerWF := func(ctx workflow.Context) error {
-		c := workflow.NewNexusClient(endpointName, "service")
-		fut := c.ExecuteOperation(ctx, "operation", "input", workflow.NexusOperationOptions{})
-		return fut.Get(ctx, nil)
+	for _, tc := range testCases {
+		s.Run(tc.name, func(s *NexusWorkflowTestSuite) {
+			env := s.newTestEnv(chasmEnabled)
+			ctx := s.Context()
+			taskQueue := testcore.RandomizeStr(s.T().Name())
+
+			var callbackToken, publicCallbackURL string
+
+			h := nexustest.Handler{
+				OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
+					callbackToken = options.CallbackHeader.Get(commonnexus.CallbackTokenHeader)
+					publicCallbackURL = options.CallbackURL
+					return &nexus.HandlerStartOperationResultAsync{OperationToken: "test"}, nil
+				},
+			}
+			endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
+
+			checkWorkflowError := tc.checkWorkflowError
+			callerWF := func(ctx workflow.Context) error {
+				c := workflow.NewNexusClient(endpointName, "service")
+				fut := c.ExecuteOperation(ctx, "operation", "input", workflow.NexusOperationOptions{})
+				return checkWorkflowError(fut.Get(ctx, nil))
+			}
+
+			w := worker.New(env.SdkClient(), taskQueue, worker.Options{})
+			w.RegisterWorkflow(callerWF)
+			s.NoError(w.Start())
+			defer w.Stop()
+
+			run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+				TaskQueue: taskQueue,
+			}, callerWF)
+			s.NoError(err)
+
+			// Wait for the handler to be called by checking for the NexusOperationStarted event.
+			s.EventuallyWithT(func(t *assert.CollectT) {
+				hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: run.GetID()})
+				historyrequire.New(t).RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED)
+			}, time.Second*10, time.Millisecond*200)
+
+			completion := nexusrpc.CompleteOperationOptions{
+				Error:  tc.completionError,
+				Header: nexus.Header{commonnexus.CallbackTokenHeader: callbackToken},
+			}
+			capture := env.StartNamespaceMetricCapture()
+			err = s.sendNexusCompletionRequest(ctx, publicCallbackURL, completion)
+			completionRequests := capture.Metric("nexus_completion_requests")
+			s.NoError(err)
+			s.Len(completionRequests, 1)
+			s.Subset(completionRequests[0].Tags, map[string]string{"namespace": env.Namespace().String(), "outcome": "success"})
+
+			s.NoError(run.Get(ctx, nil))
+
+			hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: run.GetID()})
+			s.RequireHistoryEvent(hist, tc.expectedEvent)
+		})
 	}
-
-	w := worker.New(env.SdkClient(), taskQueue, worker.Options{})
-	w.RegisterWorkflow(callerWF)
-	s.NoError(w.Start())
-	defer w.Stop()
-
-	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
-		TaskQueue: taskQueue,
-	}, callerWF)
-	s.NoError(err)
-
-	// Wait for the handler to be called by checking for the NexusOperationStarted event.
-	s.EventuallyWithT(func(t *assert.CollectT) {
-		hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: run.GetID()})
-		historyrequire.New(t).RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED)
-	}, time.Second*10, time.Millisecond*200)
-
-	// Send a valid - failed completion request.
-	completion := nexusrpc.CompleteOperationOptions{
-		Error:  nexus.NewOperationFailedErrorf("test operation failed"),
-		Header: nexus.Header{commonnexus.CallbackTokenHeader: callbackToken},
-	}
-	capture := env.StartNamespaceMetricCapture()
-	err = s.sendNexusCompletionRequest(ctx, publicCallbackURL, completion)
-	completionRequests := capture.Metric("nexus_completion_requests")
-	s.NoError(err)
-	s.Len(completionRequests, 1)
-	s.Subset(completionRequests[0].Tags, map[string]string{"namespace": env.Namespace().String(), "outcome": "success"})
-
-	// Wait for the workflow to complete and verify the error.
-	err = run.Get(ctx, nil)
-	var wee *temporal.WorkflowExecutionError
-	s.ErrorAs(err, &wee)
-
-	var noe *temporal.NexusOperationError
-	s.ErrorAs(wee, &noe)
-	s.Contains(noe.Error(), "test operation failed")
-
-	hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: run.GetID()})
-	s.RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_FAILED)
 }
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEnabled bool) {


### PR DESCRIPTION
## What changed?

Adds a shared `CoerceToCanceledFailure` helper and uses it for canceled Nexus operations on both CHASM and HSM paths.

This ensures a canceled operation is returned as a `CanceledError`, even when its underlying failure is not already a Temporal `CanceledFailure`. The helper preserves the original failure details, including its message, source, stack trace, encoded attributes, and cause.

## Why?

On the CHASM path, some canceled Nexus operations could appear as `ApplicationError`s. Async completions could also be recorded as failed instead of canceled.

This change restores consistent canceled-operation behavior across CHASM and HSM, while avoiding loss of failure details on the HSM path.

## How did you test it?

- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

## Potential risks

Low. The change only affects operations already marked as canceled whose converted cause is missing `CanceledFailureInfo`.
On the HSM path, canceled failures now retain `source` and `encoded_attributes`, which were previously dropped.