### PR TITLE
Prevent scheduler retries past catchup deadline

### DIFF
--- a/chasm/lib/scheduler/export_test.go
+++ b/chasm/lib/scheduler/export_test.go
@@ -59,10 +59,25 @@ func (i *Invoker) RecordExecuteResult(
 	completed []*schedulespb.BufferedStart,
 	retryable []*schedulespb.BufferedStart,
 ) (newlyStarted, droppedDuplicates int) {
-	return i.recordExecuteResult(ctx, &executeResult{
+	newlyStarted, droppedDuplicates, _ = i.recordExecuteResult(ctx, &executeResult{
 		CompletedStarts: completed,
 		RetryableStarts: retryable,
 	})
+	return newlyStarted, droppedDuplicates
+}
+
+func (i *Invoker) RecordExpiredExecuteResult(
+	ctx chasm.MutableContext,
+	start *schedulespb.BufferedStart,
+	actionRunning bool,
+) map[bool]int64 {
+	_, _, missedCatchupByActionRunning := i.recordExecuteResult(ctx, &executeResult{
+		ExpiredStarts: []expiredStart{{
+			start:         start,
+			actionRunning: actionRunning,
+		}},
+	})
+	return missedCatchupByActionRunning
 }
 
 func (b *BackfillerTaskHandler) AllowedBufferedStarts(

--- a/chasm/lib/scheduler/invoker.go
+++ b/chasm/lib/scheduler/invoker.go
@@ -137,8 +137,17 @@ type executeResult struct {
 	// Starts that failed with a non-retryable error can be removed from the buffer.
 	FailedStarts []*schedulespb.BufferedStart
 
+	// Starts that expired after promotion can be removed from the buffer and
+	// counted as missed, unless another execution already recorded their RunId.
+	ExpiredStarts []expiredStart
+
 	CompletedCancels    []*commonpb.WorkflowExecution
 	CompletedTerminates []*commonpb.WorkflowExecution
+}
+
+type expiredStart struct {
+	start         *schedulespb.BufferedStart
+	actionRunning bool
 }
 
 // Append combines two executeResults (no deduplication is done).
@@ -147,6 +156,7 @@ func (e *executeResult) Append(o executeResult) executeResult {
 		CompletedStarts:     append(e.CompletedStarts, o.CompletedStarts...),
 		RetryableStarts:     append(e.RetryableStarts, o.RetryableStarts...),
 		FailedStarts:        append(e.FailedStarts, o.FailedStarts...),
+		ExpiredStarts:       append(e.ExpiredStarts, o.ExpiredStarts...),
 		CompletedCancels:    append(e.CompletedCancels, o.CompletedCancels...),
 		CompletedTerminates: append(e.CompletedTerminates, o.CompletedTerminates...),
 	}
@@ -157,12 +167,17 @@ func (e *executeResult) Append(o executeResult) executeResult {
 // (starts that transitioned from "no RunId" to "has RunId" in this call) and
 // the number of completed results that were dropped because they were previously
 // recorded.
-func (i *Invoker) recordExecuteResult(ctx chasm.MutableContext, result *executeResult) (newlyStarted, droppedDuplicates int) {
+func (i *Invoker) recordExecuteResult(
+	ctx chasm.MutableContext,
+	result *executeResult,
+) (newlyStarted, droppedDuplicates int, missedCatchupByActionRunning map[bool]int64) {
 	completed := make(map[string]*schedulespb.BufferedStart) // request ID -> BufferedStart with RunId/StartTime
 	failed := make(map[string]bool)                          // request ID -> is present
 	retryable := make(map[string]*schedulespb.BufferedStart) // request ID -> *BufferedStart
+	expired := make(map[string]bool)                         // request ID -> action was running
 	canceled := make(map[string]bool)                        // run ID -> is present
 	terminated := make(map[string]bool)                      // run ID -> is present
+	missedCatchupByActionRunning = make(map[bool]int64)
 
 	for _, start := range result.CompletedStarts {
 		completed[start.RequestId] = start
@@ -172,6 +187,9 @@ func (i *Invoker) recordExecuteResult(ctx chasm.MutableContext, result *executeR
 	}
 	for _, start := range result.RetryableStarts {
 		retryable[start.RequestId] = start
+	}
+	for _, expiry := range result.ExpiredStarts {
+		expired[expiry.start.RequestId] = expiry.actionRunning
 	}
 	for _, wf := range result.CompletedCancels {
 		canceled[wf.RunId] = true
@@ -184,11 +202,15 @@ func (i *Invoker) recordExecuteResult(ctx chasm.MutableContext, result *executeR
 	removedStarts := 0
 	retriedStarts := 0
 	i.BufferedStarts = slices.DeleteFunc(i.GetBufferedStarts(), func(start *schedulespb.BufferedStart) bool {
-		failed := failed[start.RequestId]
-		if failed {
+		remove := failed[start.RequestId]
+		if actionRunning, ok := expired[start.RequestId]; ok && start.GetRunId() == "" {
+			remove = true
+			missedCatchupByActionRunning[actionRunning]++
+		}
+		if remove {
 			removedStarts++
 		}
-		return failed
+		return remove
 	})
 	i.CancelWorkflows = slices.DeleteFunc(i.GetCancelWorkflows(), func(we *commonpb.WorkflowExecution) bool {
 		canceled := canceled[we.RunId]
@@ -233,7 +255,7 @@ func (i *Invoker) recordExecuteResult(ctx chasm.MutableContext, result *executeR
 			retriedStarts))
 
 	i.addTasks(ctx)
-	return newlyStarted, droppedDuplicates
+	return newlyStarted, droppedDuplicates, missedCatchupByActionRunning
 }
 
 // runningWorkflowID returns the workflow ID associated with the given

--- a/chasm/lib/scheduler/invoker_execute_task_test.go
+++ b/chasm/lib/scheduler/invoker_execute_task_test.go
@@ -286,6 +286,73 @@ func TestExecuteTask_RetryableFailure(t *testing.T) {
 	})
 }
 
+func TestExecuteTask_DropsExpiredRetry(t *testing.T) {
+	env := newInvokerExecuteTestEnv(t)
+	now := env.TimeSource.Now()
+	startTime := timestamppb.New(now.Add(-defaultCatchupWindow * 2))
+
+	runExecuteTestCase(t, env, &executeTestCase{
+		InitialBufferedStarts: []*schedulespb.BufferedStart{{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			RequestId:     "expired-retry",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			Attempt:       2,
+		}},
+		ExpectedMissedCatchupWindow: 1,
+	})
+}
+
+func TestExecuteTask_RetryAtCatchupDeadlineIsAllowed(t *testing.T) {
+	env := newInvokerExecuteTestEnv(t)
+	now := env.TimeSource.Now()
+	startTime := timestamppb.New(now.Add(-defaultCatchupWindow))
+
+	env.mockFrontendClient.EXPECT().
+		StartWorkflowExecution(gomock.Any(), startWorkflowExecutionRequestIDMatches("boundary-retry")).
+		Return(&workflowservice.StartWorkflowExecutionResponse{RunId: "run-id"}, nil)
+
+	runExecuteTestCase(t, env, &executeTestCase{
+		InitialBufferedStarts: []*schedulespb.BufferedStart{{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			RequestId:     "boundary-retry",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			Attempt:       2,
+		}},
+		ExpectedBufferedStarts:   1,
+		ExpectedRunningWorkflows: 1,
+		ExpectedActionCount:      1,
+	})
+}
+
+func TestExecuteTask_DoesNotExpireManualRetry(t *testing.T) {
+	env := newInvokerExecuteTestEnv(t)
+	now := env.TimeSource.Now()
+	startTime := timestamppb.New(now.Add(-defaultCatchupWindow * 2))
+
+	env.mockFrontendClient.EXPECT().
+		StartWorkflowExecution(gomock.Any(), startWorkflowExecutionRequestIDMatches("manual-retry")).
+		Return(&workflowservice.StartWorkflowExecutionResponse{RunId: "run-id"}, nil)
+
+	runExecuteTestCase(t, env, &executeTestCase{
+		InitialBufferedStarts: []*schedulespb.BufferedStart{{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			Manual:        true,
+			RequestId:     "manual-retry",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			Attempt:       2,
+		}},
+		ExpectedBufferedStarts:   1,
+		ExpectedRunningWorkflows: 1,
+		ExpectedActionCount:      1,
+	})
+}
+
 // A buffered start fails when a duplicate workflow has already been started.
 func TestExecuteTask_AlreadyStarted(t *testing.T) {
 	env := newInvokerExecuteTestEnv(t)
@@ -549,6 +616,26 @@ func TestExecuteTask_RecordResultIdempotentOnRetryableRace(t *testing.T) {
 	live := invoker.BufferedStarts[0]
 	require.Equal(t, int64(1), live.Attempt, "Attempt must not be incremented on a started entry")
 	require.Nil(t, live.BackoffTime, "BackoffTime must not be set on a started entry")
+}
+
+func TestExecuteTask_RecordResultIdempotentOnExpiredRace(t *testing.T) {
+	env := newTestEnv(t)
+	ctx := env.MutableContext()
+	invoker := env.Scheduler.Invoker.Get(ctx)
+	invoker.BufferedStarts = []*schedulespb.BufferedStart{{
+		RequestId:  "req",
+		WorkflowId: "wf",
+		Attempt:    2,
+		RunId:      "winning-run",
+	}}
+
+	missed := invoker.RecordExpiredExecuteResult(ctx, &schedulespb.BufferedStart{
+		RequestId: "req",
+	}, false)
+
+	require.Empty(t, missed)
+	require.Len(t, invoker.BufferedStarts, 1)
+	require.Equal(t, "winning-run", invoker.BufferedStarts[0].GetRunId())
 }
 
 func TestExecuteTask_EventLog(t *testing.T) {

--- a/chasm/lib/scheduler/invoker_process_buffer_task_test.go
+++ b/chasm/lib/scheduler/invoker_process_buffer_task_test.go
@@ -389,6 +389,49 @@ func TestProcessBufferTask_BackingOffReady(t *testing.T) {
 	})
 }
 
+func TestProcessBufferTask_DropsExpiredRetry(t *testing.T) {
+	env := newTestEnv(t)
+	env.Scheduler.Schedule.State.LimitedActions = true
+	env.Scheduler.Schedule.State.RemainingActions = 2
+	now := env.TimeSource.Now()
+	startTime := timestamppb.New(now.Add(-defaultCatchupWindow * 2))
+
+	runProcessBufferTestCase(t, env, &processBufferTestCase{
+		InitialBufferedStarts: []*schedulespb.BufferedStart{{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			RequestId:     "expired-retry",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			Attempt:       2,
+			BackoffTime:   timestamppb.New(now.Add(-time.Minute)),
+		}},
+		ExpectedBufferedStarts:      0,
+		ExpectedMissedCatchupWindow: 1,
+	})
+	require.Equal(t, int64(2), env.Scheduler.Schedule.State.RemainingActions)
+}
+
+func TestProcessBufferTask_DoesNotExpireManualRetry(t *testing.T) {
+	env := newTestEnv(t)
+	now := env.TimeSource.Now()
+	startTime := timestamppb.New(now.Add(-defaultCatchupWindow * 2))
+
+	runProcessBufferTestCase(t, env, &processBufferTestCase{
+		InitialBufferedStarts: []*schedulespb.BufferedStart{{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			Manual:        true,
+			RequestId:     "manual-retry",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			Attempt:       2,
+			BackoffTime:   timestamppb.New(now.Add(-time.Minute)),
+		}},
+		ExpectedBufferedStarts: 1,
+	})
+}
+
 // A buffered start with an overlap policy to terminate other workflows is processed.
 func TestProcessBufferTask_NeedsTerminate(t *testing.T) {
 	env := newTestEnv(t)

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -169,6 +169,7 @@ func (h *InvokerExecuteTaskHandler) Execute(
 	var lastCompletionState *schedulerpb.LastCompletionResult
 	var schedulerRef []byte
 	var now time.Time
+	var missedCatchupByActionRunning map[bool]int64
 
 	// Read and deep copy returned components, since we'll continue to access them
 	// outside of this function (outside of the MS lock).
@@ -237,8 +238,16 @@ func (h *InvokerExecuteTaskHandler) Execute(
 			s := i.Scheduler.Get(ctx)
 			// Use newlyStarted (not len(result.CompletedStarts)) so a concurrent
 			// ExecuteTask's duplicate StartWorkflow can't inflate ActionCount.
-			newlyStarted, droppedDuplicates := i.recordExecuteResult(ctx, &result)
-			s.recordActionResult(&schedulerActionResult{actionCount: int64(newlyStarted)})
+			newlyStarted, droppedDuplicates, recordedMissedCatchup := i.recordExecuteResult(ctx, &result)
+			missedCatchupByActionRunning = recordedMissedCatchup
+			totalMissedCatchup := int64(0)
+			for _, count := range missedCatchupByActionRunning {
+				totalMissedCatchup += count
+			}
+			s.recordActionResult(&schedulerActionResult{
+				actionCount:         int64(newlyStarted),
+				missedCatchupWindow: totalMissedCatchup,
+			})
 			if droppedDuplicates > 0 {
 				h.recordDuplicateExecuteDrops(s, droppedDuplicates)
 			}
@@ -248,6 +257,16 @@ func (h *InvokerExecuteTaskHandler) Execute(
 	)
 	if err != nil {
 		return fmt.Errorf("failed to update component state: %w", err)
+	}
+
+	for actionRunning, count := range missedCatchupByActionRunning {
+		newTaggedMetricsHandler(h.metricsHandler, scheduler).WithTags(
+			metrics.StringTag(metrics.ScheduleMissedReasonTag, metrics.ScheduleMissedReasonBufferExpired),
+			metrics.StringTag(metrics.ScheduleActionRunningTag, fmt.Sprintf("%t", actionRunning)),
+		).Counter(metrics.ScheduleMissedCatchupWindow.Name()).Record(count)
+		newTaggedMetricsHandler(h.metricsHandler, scheduler).
+			Counter(metrics.ScheduleBufferedStartDropped.Name()).
+			Record(count, metrics.ReasonTag(bufferedStartDroppedMissedCatchup))
 	}
 
 	return nil
@@ -355,8 +374,20 @@ func (h *InvokerExecuteTaskHandler) startWorkflows(
 
 	var wg sync.WaitGroup
 	var resultMutex sync.Mutex
+	isRunning := len(invoker.runningWorkflowExecutions()) > 0
 
 	for _, start := range invoker.getEligibleBufferedStarts() {
+		deadline := startWorkflowDeadline(h.config, scheduler, start)
+		if !start.GetManual() && now.After(deadline) {
+			resultMutex.Lock()
+			result.ExpiredStarts = append(result.ExpiredStarts, expiredStart{
+				start:         common.CloneProto(start),
+				actionRunning: isRunning || start.GetDesiredTime().AsTime().After(deadline),
+			})
+			resultMutex.Unlock()
+			continue
+		}
+
 		// Starts that haven't been executed yet will remain in `BufferedStarts`,
 		// without change, so another ExecuteTask will be immediately created to continue
 		// processing in a new task.
@@ -517,9 +548,10 @@ func (h *InvokerProcessBufferTaskHandler) processBuffer(
 	// window doesn't consume a LimitedActions slot.
 	droppedCounter := newTaggedMetricsHandler(h.metricsHandler, scheduler).
 		Counter(metrics.ScheduleBufferedStartDropped.Name())
+	now := ctx.Now(invoker)
 	for _, start := range readyStarts {
-		deadline := h.startWorkflowDeadline(ctx, scheduler, start)
-		if ctx.Now(invoker).After(deadline) {
+		deadline := startWorkflowDeadline(h.config, scheduler, start)
+		if !start.GetManual() && now.After(deadline) {
 			// Action was buffered in time but expired before execution
 			// (e.g., due to overlap deferral, retries, or system delay).
 			// Only emit the metric if the schedule would have run this
@@ -556,6 +588,23 @@ func (h *InvokerProcessBufferTaskHandler) processBuffer(
 		return !keep
 	})
 
+	for _, start := range invoker.GetBufferedStarts() {
+		if start.GetAttempt() < 1 ||
+			start.GetManual() ||
+			start.GetRunId() != "" ||
+			start.GetCompleted() != nil {
+			continue
+		}
+		deadline := startWorkflowDeadline(h.config, scheduler, start)
+		if !now.After(deadline) {
+			continue
+		}
+		actionRunning := isRunning || start.GetDesiredTime().AsTime().After(deadline)
+		result.missedCatchupByActionRunning[actionRunning]++
+		result.discardStarts = append(result.discardStarts, start)
+		droppedCounter.Record(1, metrics.ReasonTag(bufferedStartDroppedMissedCatchup))
+	}
+
 	// Terminate overrides cancel if both are requested.
 	if action.NeedTerminate {
 		result.terminateWorkflows = runningWorkflows
@@ -585,28 +634,15 @@ func (h *InvokerExecuteTaskHandler) applyBackoff(start *schedulespb.BufferedStar
 	start.BackoffTime = timestamppb.New(now.Add(delay))
 }
 
-// startWorkflowDeadline returns the latest time at which a buffered workflow
-// should be started, instead of dropped. The deadline puts an upper bound on
-// the number of retry attempts per buffered start.
-func (h *InvokerProcessBufferTaskHandler) startWorkflowDeadline(
-	ctx chasm.Context,
+// startWorkflowDeadline returns the latest time at which an automated buffered
+// workflow should be started.
+func startWorkflowDeadline(
+	config *Config,
 	scheduler *Scheduler,
 	start *schedulespb.BufferedStart,
 ) time.Time {
-	var timeout time.Duration
-
-	if start.Manual {
-		// For manual starts, use a default value in the future, as the catchup window
-		// doesn't apply. Manual starts may only time out through max attempt count,
-		// not deadline.
-		return ctx.Now(scheduler).Add(time.Hour)
-	}
-
-	// Set request deadline based on the schedule's catchup window, which is the
-	// latest time that it's acceptable to start this workflow.
-	tweakables := h.config.Tweakables(scheduler.Namespace)
-	timeout = catchupWindow(scheduler, tweakables)
-
+	tweakables := config.Tweakables(scheduler.Namespace)
+	timeout := catchupWindow(scheduler, tweakables)
 	timeout = max(timeout, startWorkflowMinDeadline)
 
 	return start.ActualTime.AsTime().Add(timeout)

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -691,29 +691,19 @@ func (h *InvokerExecuteTaskHandler) startWorkflow(
 		return err
 	}
 	request := &workflowservice.StartWorkflowExecutionRequest{
-		CompletionCallbacks:      []*commonpb.Callback{callback},
-		Header:                   requestSpec.Header,
-		Identity:                 scheduler.identity(),
-		Input:                    requestSpec.Input,
-		Memo:                     requestSpec.Memo,
-		Namespace:                scheduler.Namespace,
-		RequestId:                start.RequestId,
-		RetryPolicy:              requestSpec.RetryPolicy,
-		SearchAttributes:         scheduler.startWorkflowSearchAttributes(start.NominalTime.AsTime()),
-		TaskQueue:                requestSpec.TaskQueue,
-		UserMetadata:             requestSpec.UserMetadata,
-		WorkflowExecutionTimeout: requestSpec.WorkflowExecutionTimeout,
-		WorkflowId:               start.WorkflowId,
-		WorkflowIdReusePolicy:    reusePolicy,
-		WorkflowRunTimeout:       requestSpec.WorkflowRunTimeout,
-		WorkflowTaskTimeout:      requestSpec.WorkflowTaskTimeout,
-		WorkflowType:             requestSpec.WorkflowType,
-		Priority:                 requestSpec.Priority,
-		ContinuedFailure:         lastCompletionState.Failure,
+		CompletionCallbacks:   []*commonpb.Callback{callback},
+		Identity:              scheduler.identity(),
+		Namespace:             scheduler.Namespace,
+		RequestId:             start.RequestId,
+		SearchAttributes:      scheduler.startWorkflowSearchAttributes(start.NominalTime.AsTime()),
+		WorkflowId:            start.WorkflowId,
+		WorkflowIdReusePolicy: reusePolicy,
+		ContinuedFailure:      lastCompletionState.Failure,
 		LastCompletionResult: &commonpb.Payloads{
 			Payloads: lcr,
 		},
 	}
+	applyNewWorkflowExecutionInfo(request, requestSpec)
 
 	result, err := h.frontendClient.StartWorkflowExecution(ctx, request)
 	if err != nil {

--- a/chasm/lib/scheduler/workflow_info.go
+++ b/chasm/lib/scheduler/workflow_info.go
@@ -1,0 +1,26 @@
+package scheduler
+
+import (
+	workflowpb "go.temporal.io/api/workflow/v1"
+	"go.temporal.io/api/workflowservice/v1"
+)
+
+// applyNewWorkflowExecutionInfo copies fields that the CHASM scheduler forwards
+// unchanged from a schedule action to a workflow start request.
+func applyNewWorkflowExecutionInfo(
+	request *workflowservice.StartWorkflowExecutionRequest,
+	info *workflowpb.NewWorkflowExecutionInfo,
+) {
+	request.WorkflowType = info.WorkflowType
+	request.TaskQueue = info.TaskQueue
+	request.Input = info.Input
+	request.WorkflowExecutionTimeout = info.WorkflowExecutionTimeout
+	request.WorkflowRunTimeout = info.WorkflowRunTimeout
+	request.WorkflowTaskTimeout = info.WorkflowTaskTimeout
+	request.RetryPolicy = info.RetryPolicy
+	request.Memo = info.Memo
+	request.Header = info.Header
+	request.UserMetadata = info.UserMetadata
+	request.VersioningOverride = info.VersioningOverride
+	request.Priority = info.Priority
+}

--- a/chasm/lib/scheduler/workflow_info_test.go
+++ b/chasm/lib/scheduler/workflow_info_test.go
@@ -1,0 +1,126 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	sdkpb "go.temporal.io/api/sdk/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	workflowpb "go.temporal.io/api/workflow/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/common/testing/protorequire"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+type workflowInfoFieldPolicy int
+
+const (
+	workflowInfoFieldForwarded workflowInfoFieldPolicy = iota
+	workflowInfoFieldTransformed
+	workflowInfoFieldUnsupported
+)
+
+var workflowInfoFieldPolicies = map[protoreflect.Name]workflowInfoFieldPolicy{
+	"workflow_id":                workflowInfoFieldTransformed,
+	"workflow_type":              workflowInfoFieldForwarded,
+	"task_queue":                 workflowInfoFieldForwarded,
+	"input":                      workflowInfoFieldForwarded,
+	"workflow_execution_timeout": workflowInfoFieldForwarded,
+	"workflow_run_timeout":       workflowInfoFieldForwarded,
+	"workflow_task_timeout":      workflowInfoFieldForwarded,
+	"workflow_id_reuse_policy":   workflowInfoFieldTransformed,
+	"retry_policy":               workflowInfoFieldForwarded,
+	"cron_schedule":              workflowInfoFieldUnsupported,
+	"memo":                       workflowInfoFieldForwarded,
+	"search_attributes":          workflowInfoFieldTransformed,
+	"header":                     workflowInfoFieldForwarded,
+	"user_metadata":              workflowInfoFieldForwarded,
+	"versioning_override":        workflowInfoFieldForwarded,
+	"priority":                   workflowInfoFieldForwarded,
+}
+
+func TestNewWorkflowExecutionInfoFieldPoliciesAreComplete(t *testing.T) {
+	fields := (&workflowpb.NewWorkflowExecutionInfo{}).ProtoReflect().Descriptor().Fields()
+	require.Len(t, workflowInfoFieldPolicies, fields.Len())
+	for i := range fields.Len() {
+		field := fields.Get(i)
+		require.Contains(t, workflowInfoFieldPolicies, field.Name())
+	}
+	for name := range workflowInfoFieldPolicies {
+		require.NotNil(t, fields.ByName(name))
+	}
+}
+
+func TestApplyNewWorkflowExecutionInfo(t *testing.T) {
+	info := &workflowpb.NewWorkflowExecutionInfo{
+		WorkflowId:               "action-workflow-id",
+		WorkflowType:             &commonpb.WorkflowType{Name: "workflow-type"},
+		TaskQueue:                &taskqueuepb.TaskQueue{Name: "task-queue"},
+		Input:                    &commonpb.Payloads{},
+		WorkflowExecutionTimeout: durationpb.New(time.Hour),
+		WorkflowRunTimeout:       durationpb.New(time.Minute),
+		WorkflowTaskTimeout:      durationpb.New(time.Second),
+		WorkflowIdReusePolicy:    enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
+		RetryPolicy:              &commonpb.RetryPolicy{MaximumAttempts: 3},
+		CronSchedule:             "@daily",
+		Memo:                     &commonpb.Memo{},
+		SearchAttributes:         &commonpb.SearchAttributes{},
+		Header:                   &commonpb.Header{},
+		UserMetadata:             &sdkpb.UserMetadata{},
+		VersioningOverride:       &workflowpb.VersioningOverride{},
+		Priority:                 &commonpb.Priority{},
+	}
+	searchAttributes := &commonpb.SearchAttributes{}
+	request := &workflowservice.StartWorkflowExecutionRequest{
+		WorkflowId:            "scheduler-workflow-id",
+		WorkflowIdReusePolicy: enumspb.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
+		SearchAttributes:      searchAttributes,
+	}
+
+	applyNewWorkflowExecutionInfo(request, info)
+
+	infoMessage := info.ProtoReflect()
+	requestMessage := request.ProtoReflect()
+	for name, policy := range workflowInfoFieldPolicies {
+		if policy != workflowInfoFieldForwarded {
+			continue
+		}
+		infoField := infoMessage.Descriptor().Fields().ByName(name)
+		requestField := requestMessage.Descriptor().Fields().ByName(name)
+		require.NotNil(t, requestField)
+		require.True(t, infoMessage.Has(infoField), "populate forwarded field %q in the test fixture", name)
+		require.True(t, requestMessage.Has(requestField), "forward field %q", name)
+		require.False(t, infoField.IsList() || infoField.IsMap(), "extend the assertion for collection field %q", name)
+		if infoField.Kind() == protoreflect.MessageKind {
+			require.True(t, proto.Equal(
+				infoMessage.Get(infoField).Message().Interface(),
+				requestMessage.Get(requestField).Message().Interface(),
+			), "forward field %q unchanged", name)
+		} else {
+			require.Equal(t, infoMessage.Get(infoField).Interface(), requestMessage.Get(requestField).Interface())
+		}
+	}
+
+	protorequire.ProtoEqual(t, &workflowservice.StartWorkflowExecutionRequest{
+		WorkflowId:               "scheduler-workflow-id",
+		WorkflowType:             info.WorkflowType,
+		TaskQueue:                info.TaskQueue,
+		Input:                    info.Input,
+		WorkflowExecutionTimeout: info.WorkflowExecutionTimeout,
+		WorkflowRunTimeout:       info.WorkflowRunTimeout,
+		WorkflowTaskTimeout:      info.WorkflowTaskTimeout,
+		WorkflowIdReusePolicy:    enumspb.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
+		RetryPolicy:              info.RetryPolicy,
+		Memo:                     info.Memo,
+		SearchAttributes:         searchAttributes,
+		Header:                   info.Header,
+		UserMetadata:             info.UserMetadata,
+		VersioningOverride:       info.VersioningOverride,
+		Priority:                 info.Priority,
+	}, request)
+}


### PR DESCRIPTION
## What changed?

- Recheck automated buffered-start catch-up deadlines when retry backoff wakes ProcessBuffer.
- Recheck the deadline immediately before each start RPC so Execute-task delay cannot start an expired action.
- Drop and account expired retries as `buffer_expired` missed-catch-up actions, while preserving already-recorded runs.
- Keep manual starts exempt and leave an already-consumed limited-action slot spent.
- Centralize unchanged `NewWorkflowExecutionInfo` forwarding for the CHASM scheduler.
- Add a descriptor-backed field policy so future API fields require an explicit forwarded, transformed, or unsupported decision.

## Why?

After a retryable `StartWorkflowExecution` failure, the buffered start moves to `Attempt > 0`. ProcessBuffer previously excluded attempt-positive starts, while Execute eligibility checked only attempt, RunID, and backoff. A delayed retry could therefore issue a start RPC after `ActualTime + CatchupWindow` without recording a missed action.

The CHASM request builder also listed forwarded workflow fields inline. New fields added to `NewWorkflowExecutionInfo` could therefore be accepted by CreateSchedule or UpdateSchedule but omitted from the eventual workflow start. The descriptor contract fails whenever the source proto gains an unclassified field, and the mapper test verifies every field classified as forwarded is present unchanged in the start request.

## How did you test it?

- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

Validation:

- `go test -tags test_dep ./chasm/lib/scheduler -count=1`
- `go test -race -tags test_dep ./chasm/lib/scheduler -run 'TestExecuteTask_(DropsExpiredRetry|RetryAtCatchupDeadlineIsAllowed|DoesNotExpireManualRetry|RecordResultIdempotentOnExpiredRace)' -count=1`
- `make lint-code`

## Potential risks

A retryable start error can have an uncertain server-side outcome. Once the catch-up deadline expires, this change stops using the same request ID to reconcile that outcome; if the original RPC succeeded but its response was lost, the workflow may run while the scheduler has dropped its buffered entry. The already-consumed `RemainingActions` slot is intentionally not refunded for that reason.

The forwarding contract is intentionally CHASM-only; the V1 scheduler remains unchanged.
