### PR TITLE
Enable github actions review bot for ACT

### DIFF
--- a/.github/workflows/claude-review-teams.yml
+++ b/.github/workflows/claude-review-teams.yml
@@ -14,7 +14,7 @@ env:
   # Space- or newline-separated list of temporalio team slugs whose
   # members' PRs should receive an automated Claude review. Empty means only
   # PRs labeled with REVIEW_OPT_IN_LABEL by a temporalio org member are reviewed.
-  REVIEW_TEAMS: "nexus"
+  REVIEW_TEAMS: "nexus act"
   REVIEW_OPT_IN_LABEL: request-claude-review
   REVIEW_OPT_OUT_LABEL: skip-claude-review
 


### PR DESCRIPTION
WISOTT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow env change; no application, auth, or data-path changes—only who gets optional automated reviews.
> 
> **Overview**
> **Extends automated Claude PR reviews** to members of the `act` GitHub team in addition to `nexus`.
> 
> The workflow env `REVIEW_TEAMS` is updated from `"nexus"` to `"nexus act"`. Existing behavior is unchanged: team slugs are still space-separated, and PRs still need to pass the same eligibility checks (org membership, repo write, no skip label, etc.) before a review runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d284ec5445997b90560e361b95ecd8a7e75fe2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->