### PR TITLE
Add dynamic config to flip skip persistence optimization

### DIFF
--- a/chasm/node_backend_mock.go
+++ b/chasm/node_backend_mock.go
@@ -27,6 +27,7 @@ type MockNodeBackend struct {
 	HandleGetCurrentVersion           func() int64
 	HandleNextTransitionCount         func() int64
 	HandleGetApproximatePersistedSize func() int
+	HandleChasmSkipPersistenceEnabled func() bool
 	HandleCurrentVersionedTransition  func() *persistencespb.VersionedTransition
 	HandleGetWorkflowKey              func() definition.WorkflowKey
 	HandleUpdateWorkflowStateStatus   func(state enumsspb.WorkflowExecutionState, status enumspb.WorkflowExecutionStatus) (bool, error)
@@ -69,6 +70,13 @@ func (m *MockNodeBackend) GetApproximatePersistedSize() int {
 		return m.HandleGetApproximatePersistedSize()
 	}
 	return 0
+}
+
+func (m *MockNodeBackend) ChasmSkipPersistenceEnabled() bool {
+	if m.HandleChasmSkipPersistenceEnabled != nil {
+		return m.HandleChasmSkipPersistenceEnabled()
+	}
+	return false
 }
 
 func (m *MockNodeBackend) GetCurrentVersion() int64 {

--- a/chasm/skip_persistence_test.go
+++ b/chasm/skip_persistence_test.go
@@ -16,11 +16,41 @@ func (s *nodeSuite) minimalTestComponent() *TestComponent {
 	}
 }
 
+func (s *nodeSuite) newSkipPersistenceTestTree(
+	serializedNodes map[string]*persistencespb.ChasmNode,
+	enabled func() bool,
+) *Node {
+	if len(serializedNodes) == 0 {
+		return NewEmptyTree(
+			s.registry,
+			s.timeSource,
+			s.nodeBackend,
+			s.nodePathEncoder,
+			s.logger,
+			s.metricsHandler,
+			WithSkipPersistenceIfClean(enabled),
+		)
+	}
+
+	root, err := NewTreeFromDB(
+		serializedNodes,
+		s.registry,
+		s.timeSource,
+		s.nodeBackend,
+		s.nodePathEncoder,
+		s.logger,
+		s.metricsHandler,
+		WithSkipPersistenceIfClean(enabled),
+	)
+	s.NoError(err)
+	return root
+}
+
 func (s *nodeSuite) TestSkipPersistenceIfClean_NewNode() {
 	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 1 }
 	s.nodeBackend.HandleGetCurrentVersion = func() int64 { return 1 }
 
-	rootNode := NewEmptyTree(s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
+	rootNode := s.newSkipPersistenceTestTree(nil, func() bool { return true })
 	s.NoError(rootNode.SetRootComponent(s.minimalTestComponent()))
 
 	mutation, err := rootNode.CloseTransaction()
@@ -34,7 +64,7 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_LoadedUnmodified() {
 	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 1 }
 	s.nodeBackend.HandleGetCurrentVersion = func() int64 { return 1 }
 
-	rootNode := NewEmptyTree(s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
+	rootNode := s.newSkipPersistenceTestTree(nil, func() bool { return true })
 	s.NoError(rootNode.SetRootComponent(s.minimalTestComponent()))
 
 	firstMutation, err := rootNode.CloseTransaction()
@@ -49,8 +79,7 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_LoadedUnmodified() {
 	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 2 }
 	s.nodeBackend.HandleGetCurrentVersion = func() int64 { return 1 }
 
-	rootNode2, err := NewTreeFromDB(persistedNodes, s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
-	s.NoError(err)
+	rootNode2 := s.newSkipPersistenceTestTree(persistedNodes, func() bool { return true })
 
 	ctx := NewMutableContext(context.Background(), rootNode2)
 	_, err = rootNode2.Component(ctx, ComponentRef{})
@@ -71,7 +100,7 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_LoadedModified() {
 	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 1 }
 	s.nodeBackend.HandleGetCurrentVersion = func() int64 { return 1 }
 
-	rootNode := NewEmptyTree(s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
+	rootNode := s.newSkipPersistenceTestTree(nil, func() bool { return true })
 	s.NoError(rootNode.SetRootComponent(s.minimalTestComponent()))
 
 	firstMutation, err := rootNode.CloseTransaction()
@@ -81,8 +110,7 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_LoadedModified() {
 	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 2 }
 	s.nodeBackend.HandleGetCurrentVersion = func() int64 { return 1 }
 
-	rootNode2, err := NewTreeFromDB(persistedNodes, s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
-	s.NoError(err)
+	rootNode2 := s.newSkipPersistenceTestTree(persistedNodes, func() bool { return true })
 
 	ctx := NewMutableContext(context.Background(), rootNode2)
 	component, err := rootNode2.Component(ctx, ComponentRef{})
@@ -105,7 +133,7 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_WithNewTask() {
 	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 1 }
 	s.nodeBackend.HandleGetCurrentVersion = func() int64 { return 1 }
 
-	rootNode := NewEmptyTree(s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
+	rootNode := s.newSkipPersistenceTestTree(nil, func() bool { return true })
 	s.NoError(rootNode.SetRootComponent(s.minimalTestComponent()))
 
 	firstMutation, err := rootNode.CloseTransaction()
@@ -115,8 +143,7 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_WithNewTask() {
 	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 2 }
 	s.nodeBackend.HandleGetCurrentVersion = func() int64 { return 1 }
 
-	rootNode2, err := NewTreeFromDB(persistedNodes, s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
-	s.NoError(err)
+	rootNode2 := s.newSkipPersistenceTestTree(persistedNodes, func() bool { return true })
 
 	ctx := NewMutableContext(context.Background(), rootNode2)
 	component, err := rootNode2.Component(ctx, ComponentRef{})
@@ -138,7 +165,7 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_DeleteUnpersistedNode() {
 	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 1 }
 	s.nodeBackend.HandleGetCurrentVersion = func() int64 { return 1 }
 
-	rootNode := NewEmptyTree(s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
+	rootNode := s.newSkipPersistenceTestTree(nil, func() bool { return true })
 	s.NoError(rootNode.SetRootComponent(&TestComponent{
 		ComponentData: &persistencespb.WorkflowExecutionState{RunId: "root"},
 		SubComponent1: NewComponentField(nil, &TestSubComponent1{
@@ -155,4 +182,38 @@ func (s *nodeSuite) TestSkipPersistenceIfClean_DeleteUnpersistedNode() {
 
 	s.Contains(mutation.UpdatedNodes, "", "root still needs initial persistence")
 	s.Empty(mutation.DeletedNodes, "node created and deleted before first persistence must not emit a tombstone")
+}
+
+func (s *nodeSuite) TestSkipPersistenceIfClean_DynamicConfig() {
+	s.nodeBackend.HandleNextTransitionCount = func() int64 { return 1 }
+	s.nodeBackend.HandleGetCurrentVersion = func() int64 { return 1 }
+
+	rootNode := s.newSkipPersistenceTestTree(nil, func() bool { return false })
+	s.NoError(rootNode.SetRootComponent(s.minimalTestComponent()))
+
+	firstMutation, err := rootNode.CloseTransaction()
+	s.NoError(err)
+	persistedNodes := common.CloneProtoMap(firstMutation.UpdatedNodes)
+
+	enabled := false
+	nextTransitionCount := int64(2)
+	s.nodeBackend.HandleNextTransitionCount = func() int64 { return nextTransitionCount }
+	rootNode2 := s.newSkipPersistenceTestTree(persistedNodes, func() bool { return enabled })
+
+	ctx := NewMutableContext(context.Background(), rootNode2)
+	_, err = rootNode2.Component(ctx, ComponentRef{})
+	s.NoError(err)
+	mutation, err := rootNode2.CloseTransaction()
+	s.NoError(err)
+	s.Contains(mutation.UpdatedNodes, "", "disabled optimization must preserve pre-optimization persistence behavior")
+	s.Equal(int64(2), rootNode2.serializedNode.GetMetadata().GetLastUpdateVersionedTransition().GetTransitionCount())
+
+	enabled = true
+	nextTransitionCount = 3
+	_, err = rootNode2.Component(ctx, ComponentRef{})
+	s.NoError(err)
+	mutation, err = rootNode2.CloseTransaction()
+	s.NoError(err)
+	s.NotContains(mutation.UpdatedNodes, "", "enabled optimization must omit an unchanged node")
+	s.Equal(int64(2), rootNode2.serializedNode.GetMetadata().GetLastUpdateVersionedTransition().GetTransitionCount())
 }

--- a/chasm/skip_persistence_test.go
+++ b/chasm/skip_persistence_test.go
@@ -20,6 +20,7 @@ func (s *nodeSuite) newSkipPersistenceTestTree(
 	serializedNodes map[string]*persistencespb.ChasmNode,
 	enabled func() bool,
 ) *Node {
+	s.nodeBackend.HandleChasmSkipPersistenceEnabled = enabled
 	if len(serializedNodes) == 0 {
 		return NewEmptyTree(
 			s.registry,
@@ -28,7 +29,6 @@ func (s *nodeSuite) newSkipPersistenceTestTree(
 			s.nodePathEncoder,
 			s.logger,
 			s.metricsHandler,
-			WithSkipPersistenceIfClean(enabled),
 		)
 	}
 
@@ -40,7 +40,6 @@ func (s *nodeSuite) newSkipPersistenceTestTree(
 		s.nodePathEncoder,
 		s.logger,
 		s.metricsHandler,
-		WithSkipPersistenceIfClean(enabled),
 	)
 	s.NoError(err)
 	return root

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -142,12 +142,13 @@ type (
 
 	// nodeBase is a set of dependencies and states shared by all nodes in a CHASM tree.
 	nodeBase struct {
-		registry       *Registry
-		timeSource     clock.TimeSource
-		backend        NodeBackend
-		pathEncoder    NodePathEncoder
-		logger         log.Logger
-		metricsHandler metrics.Handler
+		registry                       *Registry
+		timeSource                     clock.TimeSource
+		backend                        NodeBackend
+		pathEncoder                    NodePathEncoder
+		logger                         log.Logger
+		metricsHandler                 metrics.Handler
+		enableSkipPersistenceIfCleanFn func() bool
 
 		// Following fields are changes accumulated in this transaction,
 		// and will get cleaned up after CloseTransaction().
@@ -196,6 +197,13 @@ type (
 	// including the node n itself.
 	NodesSnapshot struct {
 		Nodes map[string]*persistencespb.ChasmNode // encoded node path -> chasm node
+	}
+
+	// TreeOption configures a CHASM tree.
+	TreeOption func(*treeOptions)
+
+	treeOptions struct {
+		enableSkipPersistenceIfCleanFn func() bool
 	}
 
 	// NodeBackend is a set of methods needed from MutableState.
@@ -253,6 +261,14 @@ type (
 	}
 )
 
+// WithSkipPersistenceIfClean controls whether CloseTransaction omits nodes whose serialized data is unchanged.
+// The function is evaluated for every transaction so callers can provide a dynamic configuration value.
+func WithSkipPersistenceIfClean(enabled func() bool) TreeOption {
+	return func(options *treeOptions) {
+		options.enableSkipPersistenceIfCleanFn = enabled
+	}
+}
+
 // IsEmpty reports whether the mutation contains no node updates or deletions.
 func (m NodesMutation) IsEmpty() bool {
 	return len(m.UpdatedNodes) == 0 && len(m.DeletedNodes) == 0
@@ -269,15 +285,16 @@ func NewTreeFromDB(
 	pathEncoder NodePathEncoder,
 	logger log.Logger,
 	metricsHandler metrics.Handler,
+	options ...TreeOption,
 ) (*Node, error) {
 	if len(serializedNodes) == 0 {
-		root := NewEmptyTree(registry, timeSource, backend, pathEncoder, logger, metricsHandler)
+		root := NewEmptyTree(registry, timeSource, backend, pathEncoder, logger, metricsHandler, options...)
 		// NewEmptyTree initializes the serializedNode to an empty component node,
 		root.serializedNode.Metadata.GetComponentAttributes().TypeId = WorkflowArchetypeID
 		return root, nil
 	}
 
-	root := newTreeHelper(registry, timeSource, backend, pathEncoder, logger, metricsHandler)
+	root := newTreeHelper(registry, timeSource, backend, pathEncoder, logger, metricsHandler, options...)
 	for encodedPath, serializedNode := range serializedNodes {
 		nodePath, err := pathEncoder.Decode(encodedPath)
 		if err != nil {
@@ -300,8 +317,9 @@ func NewEmptyTree(
 	pathEncoder NodePathEncoder,
 	logger log.Logger,
 	metricsHandler metrics.Handler,
+	options ...TreeOption,
 ) *Node {
-	root := newTreeHelper(registry, timeSource, backend, pathEncoder, logger, metricsHandler)
+	root := newTreeHelper(registry, timeSource, backend, pathEncoder, logger, metricsHandler, options...)
 
 	// If serializedNodes is empty, it means that this new tree.
 	// Initialize empty serializedNode.
@@ -322,14 +340,23 @@ func newTreeHelper(
 	pathEncoder NodePathEncoder,
 	logger log.Logger,
 	metricsHandler metrics.Handler,
+	options ...TreeOption,
 ) *Node {
+	treeOptions := treeOptions{
+		enableSkipPersistenceIfCleanFn: func() bool { return false },
+	}
+	for _, option := range options {
+		option(&treeOptions)
+	}
+
 	base := &nodeBase{
-		registry:       registry,
-		timeSource:     timeSource,
-		backend:        backend,
-		pathEncoder:    pathEncoder,
-		logger:         logger,
-		metricsHandler: metricsHandler,
+		registry:                       registry,
+		timeSource:                     timeSource,
+		backend:                        backend,
+		pathEncoder:                    pathEncoder,
+		logger:                         logger,
+		metricsHandler:                 metricsHandler,
+		enableSkipPersistenceIfCleanFn: treeOptions.enableSkipPersistenceIfCleanFn,
 
 		mutation: NodesMutation{
 			UpdatedNodes: make(map[string]*persistencespb.ChasmNode),
@@ -439,6 +466,9 @@ func (n *Node) markSubtreeDirty() {
 	}
 }
 
+// clearAncestorNodeValues invalidates hydrated component ancestors after tree-structure changes.
+// Replication must always call this for child-only mutations because the source may omit an
+// unchanged parent component when its skip-persistence optimization is enabled.
 func (n *Node) clearAncestorNodeValues(parent *Node) {
 	for node := parent; node != nil; node = node.parent {
 		if node.serializedNode == nil || !node.isComponent() || node.value == nil {
@@ -1933,6 +1963,7 @@ func (n *Node) closeTransactionForceUpdateVisibility(
 }
 
 func (n *Node) closeTransactionSerializeNodes() error {
+	skipPersistenceIfClean := n.enableSkipPersistenceIfCleanFn()
 	for nodePath, node := range n.andAllChildren() {
 		if node.valueState > valueStateNeedSerialize {
 			return serviceerror.NewInternalf("invalid valueState for serializing: %v", node.valueState)
@@ -1954,7 +1985,8 @@ func (n *Node) closeTransactionSerializeNodes() error {
 		prevVersionedTransition := common.CloneProto(
 			node.serializedNode.GetMetadata().GetLastUpdateVersionedTransition(),
 		)
-		skipIfClean := (node.isComponent() || node.isData() || node.isMap()) &&
+		skipIfClean := skipPersistenceIfClean &&
+			(node.isComponent() || node.isData() || node.isMap()) &&
 			prevVersionedTransition != nil &&
 			!node.hasNewTransactionSideEffects()
 		var prevData *commonpb.DataBlob

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -142,13 +142,12 @@ type (
 
 	// nodeBase is a set of dependencies and states shared by all nodes in a CHASM tree.
 	nodeBase struct {
-		registry                       *Registry
-		timeSource                     clock.TimeSource
-		backend                        NodeBackend
-		pathEncoder                    NodePathEncoder
-		logger                         log.Logger
-		metricsHandler                 metrics.Handler
-		enableSkipPersistenceIfCleanFn func() bool
+		registry       *Registry
+		timeSource     clock.TimeSource
+		backend        NodeBackend
+		pathEncoder    NodePathEncoder
+		logger         log.Logger
+		metricsHandler metrics.Handler
 
 		// Following fields are changes accumulated in this transaction,
 		// and will get cleaned up after CloseTransaction().
@@ -199,13 +198,6 @@ type (
 		Nodes map[string]*persistencespb.ChasmNode // encoded node path -> chasm node
 	}
 
-	// TreeOption configures a CHASM tree.
-	TreeOption func(*treeOptions)
-
-	treeOptions struct {
-		enableSkipPersistenceIfCleanFn func() bool
-	}
-
 	// NodeBackend is a set of methods needed from MutableState.
 	//
 	// This is for breaking cycle dependency between
@@ -216,6 +208,7 @@ type (
 		GetExecutionState() *persistencespb.WorkflowExecutionState
 		GetExecutionInfo() *persistencespb.WorkflowExecutionInfo
 		GetApproximatePersistedSize() int
+		ChasmSkipPersistenceEnabled() bool
 		GetNamespaceEntry() *namespace.Namespace
 		GetCurrentVersion() int64
 		NextTransitionCount() int64
@@ -261,14 +254,6 @@ type (
 	}
 )
 
-// WithSkipPersistenceIfClean controls whether CloseTransaction omits nodes whose serialized data is unchanged.
-// The function is evaluated for every transaction so callers can provide a dynamic configuration value.
-func WithSkipPersistenceIfClean(enabled func() bool) TreeOption {
-	return func(options *treeOptions) {
-		options.enableSkipPersistenceIfCleanFn = enabled
-	}
-}
-
 // IsEmpty reports whether the mutation contains no node updates or deletions.
 func (m NodesMutation) IsEmpty() bool {
 	return len(m.UpdatedNodes) == 0 && len(m.DeletedNodes) == 0
@@ -285,16 +270,15 @@ func NewTreeFromDB(
 	pathEncoder NodePathEncoder,
 	logger log.Logger,
 	metricsHandler metrics.Handler,
-	options ...TreeOption,
 ) (*Node, error) {
 	if len(serializedNodes) == 0 {
-		root := NewEmptyTree(registry, timeSource, backend, pathEncoder, logger, metricsHandler, options...)
+		root := NewEmptyTree(registry, timeSource, backend, pathEncoder, logger, metricsHandler)
 		// NewEmptyTree initializes the serializedNode to an empty component node,
 		root.serializedNode.Metadata.GetComponentAttributes().TypeId = WorkflowArchetypeID
 		return root, nil
 	}
 
-	root := newTreeHelper(registry, timeSource, backend, pathEncoder, logger, metricsHandler, options...)
+	root := newTreeHelper(registry, timeSource, backend, pathEncoder, logger, metricsHandler)
 	for encodedPath, serializedNode := range serializedNodes {
 		nodePath, err := pathEncoder.Decode(encodedPath)
 		if err != nil {
@@ -317,9 +301,8 @@ func NewEmptyTree(
 	pathEncoder NodePathEncoder,
 	logger log.Logger,
 	metricsHandler metrics.Handler,
-	options ...TreeOption,
 ) *Node {
-	root := newTreeHelper(registry, timeSource, backend, pathEncoder, logger, metricsHandler, options...)
+	root := newTreeHelper(registry, timeSource, backend, pathEncoder, logger, metricsHandler)
 
 	// If serializedNodes is empty, it means that this new tree.
 	// Initialize empty serializedNode.
@@ -340,23 +323,14 @@ func newTreeHelper(
 	pathEncoder NodePathEncoder,
 	logger log.Logger,
 	metricsHandler metrics.Handler,
-	options ...TreeOption,
 ) *Node {
-	treeOptions := treeOptions{
-		enableSkipPersistenceIfCleanFn: func() bool { return false },
-	}
-	for _, option := range options {
-		option(&treeOptions)
-	}
-
 	base := &nodeBase{
-		registry:                       registry,
-		timeSource:                     timeSource,
-		backend:                        backend,
-		pathEncoder:                    pathEncoder,
-		logger:                         logger,
-		metricsHandler:                 metricsHandler,
-		enableSkipPersistenceIfCleanFn: treeOptions.enableSkipPersistenceIfCleanFn,
+		registry:       registry,
+		timeSource:     timeSource,
+		backend:        backend,
+		pathEncoder:    pathEncoder,
+		logger:         logger,
+		metricsHandler: metricsHandler,
 
 		mutation: NodesMutation{
 			UpdatedNodes: make(map[string]*persistencespb.ChasmNode),
@@ -1963,7 +1937,7 @@ func (n *Node) closeTransactionForceUpdateVisibility(
 }
 
 func (n *Node) closeTransactionSerializeNodes() error {
-	skipPersistenceIfClean := n.enableSkipPersistenceIfCleanFn()
+	skipPersistenceIfClean := n.backend.ChasmSkipPersistenceEnabled()
 	for nodePath, node := range n.andAllChildren() {
 		if node.valueState > valueStateNeedSerialize {
 			return serviceerror.NewInternalf("invalid valueState for serializing: %v", node.valueState)

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -1155,7 +1155,16 @@ func (s *nodeSuite) TestApplyMutation_InvalidatesHydratedMapAncestors() {
 		mutation NodesMutation,
 		expected map[string]string,
 	) {
-		target, err := s.newTestTree(common.CloneProtoMap(persistedNodes))
+		target, err := NewTreeFromDB(
+			common.CloneProtoMap(persistedNodes),
+			s.registry,
+			s.timeSource,
+			s.nodeBackend,
+			s.nodePathEncoder,
+			s.logger,
+			s.metricsHandler,
+			WithSkipPersistenceIfClean(func() bool { return false }),
+		)
 		s.NoError(err)
 		component, err := target.Component(NewContext(context.Background(), target), ComponentRef{})
 		s.NoError(err)
@@ -4621,10 +4630,11 @@ func (s *nodeSuite) TestAndAllChildren_PathIndependence() {
 func (s *nodeSuite) newTestTree(
 	serializedNodes map[string]*persistencespb.ChasmNode,
 ) (*Node, error) {
+	options := []TreeOption{WithSkipPersistenceIfClean(func() bool { return true })}
 	if len(serializedNodes) == 0 {
-		return NewEmptyTree(s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler), nil
+		return NewEmptyTree(s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler, options...), nil
 	}
-	return NewTreeFromDB(serializedNodes, s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
+	return NewTreeFromDB(serializedNodes, s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler, options...)
 }
 
 func (s *nodeSuite) emptyDataBlob() *commonpb.DataBlob {

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -1155,6 +1155,7 @@ func (s *nodeSuite) TestApplyMutation_InvalidatesHydratedMapAncestors() {
 		mutation NodesMutation,
 		expected map[string]string,
 	) {
+		s.nodeBackend.HandleChasmSkipPersistenceEnabled = func() bool { return false }
 		target, err := NewTreeFromDB(
 			common.CloneProtoMap(persistedNodes),
 			s.registry,
@@ -1163,7 +1164,6 @@ func (s *nodeSuite) TestApplyMutation_InvalidatesHydratedMapAncestors() {
 			s.nodePathEncoder,
 			s.logger,
 			s.metricsHandler,
-			WithSkipPersistenceIfClean(func() bool { return false }),
 		)
 		s.NoError(err)
 		component, err := target.Component(NewContext(context.Background(), target), ComponentRef{})
@@ -4630,11 +4630,11 @@ func (s *nodeSuite) TestAndAllChildren_PathIndependence() {
 func (s *nodeSuite) newTestTree(
 	serializedNodes map[string]*persistencespb.ChasmNode,
 ) (*Node, error) {
-	options := []TreeOption{WithSkipPersistenceIfClean(func() bool { return true })}
+	s.nodeBackend.HandleChasmSkipPersistenceEnabled = func() bool { return true }
 	if len(serializedNodes) == 0 {
-		return NewEmptyTree(s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler, options...), nil
+		return NewEmptyTree(s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler), nil
 	}
-	return NewTreeFromDB(serializedNodes, s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler, options...)
+	return NewTreeFromDB(serializedNodes, s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
 }
 
 func (s *nodeSuite) emptyDataBlob() *commonpb.DataBlob {

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -3101,6 +3101,14 @@ Requires service restart to take effect.`,
 		true,
 		"Use real chasm tree implementation instead of the noop one",
 	)
+	EnableCHASMSkipPersistence = NewNamespaceBoolSetting(
+		"history.enableCHASMSkipPersistence",
+		false,
+		`EnableCHASMSkipPersistence controls whether CHASM CloseTransaction omits nodes whose serialized data is unchanged.
+This optimization should only be enabled after every cluster that may receive CHASM replication supports invalidating
+hydrated ancestor components when applying child-node mutations.`,
+	)
+
 	ChasmMaxInMemoryPureTasks = NewGlobalIntSetting(
 		"history.chasmMaxInMemoryPureTasks",
 		32,

--- a/service/history/chasm_engine_test.go
+++ b/service/history/chasm_engine_test.go
@@ -1071,6 +1071,8 @@ func (s *chasmEngineSuite) TestPollComponent_SetsContextMetadata() {
 
 // TestPollComponent_Success_Wait tests the waiting behavior of PollComponent.
 func (s *chasmEngineSuite) TestPollComponent_Success_Wait() {
+	s.config.EnableCHASMSkipPersistence = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
+
 	testCases := []struct {
 		name          string
 		useEmptyRunID bool

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -75,6 +75,7 @@ type Config struct {
 	MaxCallbacksPerExecution                   dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MaxCallbacksPerUpdateID                    dynamicconfig.IntPropertyFnWithNamespaceFilter
 	EnableChasm                                dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	EnableCHASMSkipPersistence                 dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	EnableChasmNexusWorkflowOperations         dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	ChasmNexusWorkflowOperationsRolloutPercent dynamicconfig.IntPropertyFnWithNamespaceFilter
 	EnableCHASMCallbacks                       dynamicconfig.BoolPropertyFnWithNamespaceFilter
@@ -505,6 +506,7 @@ func NewConfig(
 		MaxCallbacksPerExecution:                   callback.MaxPerExecution.Get(dc),
 		MaxCallbacksPerUpdateID:                    dynamicconfig.MaxCallbacksPerUpdateID.Get(dc),
 		EnableChasm:                                dynamicconfig.EnableChasm.Get(dc),
+		EnableCHASMSkipPersistence:                 dynamicconfig.EnableCHASMSkipPersistence.Get(dc),
 		EnableChasmNexusWorkflowOperations:         nexusoperation.EnableChasmWorkflowOperations.Get(dc),
 		ChasmNexusWorkflowOperationsRolloutPercent: nexusoperation.ChasmWorkflowOperationsRolloutPercent.Get(dc),
 		ChasmMaxInMemoryPureTasks:                  dynamicconfig.ChasmMaxInMemoryPureTasks.Get(dc),

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -429,6 +429,7 @@ func NewMutableState(
 			chasm.DefaultPathEncoder,
 			logger,
 			shard.GetMetricsHandler().WithTags(metrics.NamespaceTag(namespaceName)),
+			chasm.WithSkipPersistenceIfClean(s.chasmSkipPersistenceEnabled),
 		)
 	}
 
@@ -588,6 +589,7 @@ func NewMutableStateFromDB(
 			chasm.DefaultPathEncoder,
 			mutableState.logger, // this logger is tagged with execution key.
 			shard.GetMetricsHandler().WithTags(metrics.NamespaceTag(namespaceEntry.Name().String())),
+			chasm.WithSkipPersistenceIfClean(mutableState.chasmSkipPersistenceEnabled),
 		)
 		if err != nil {
 			return nil, err
@@ -686,6 +688,11 @@ func (ms *MutableStateImpl) ChasmTree() historyi.ChasmTree {
 func (ms *MutableStateImpl) ChasmEnabled() bool {
 	_, isNoop := ms.chasmTree.(*noopChasmTree)
 	return !isNoop
+}
+
+func (ms *MutableStateImpl) chasmSkipPersistenceEnabled() bool {
+	return ms.config.EnableCHASMSkipPersistence != nil &&
+		ms.config.EnableCHASMSkipPersistence(ms.GetNamespaceEntry().Name().String())
 }
 
 // chasmCallbacksEnabled returns true if CHASM callbacks are enabled for this workflow.

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -429,7 +429,6 @@ func NewMutableState(
 			chasm.DefaultPathEncoder,
 			logger,
 			shard.GetMetricsHandler().WithTags(metrics.NamespaceTag(namespaceName)),
-			chasm.WithSkipPersistenceIfClean(s.chasmSkipPersistenceEnabled),
 		)
 	}
 
@@ -589,7 +588,6 @@ func NewMutableStateFromDB(
 			chasm.DefaultPathEncoder,
 			mutableState.logger, // this logger is tagged with execution key.
 			shard.GetMetricsHandler().WithTags(metrics.NamespaceTag(namespaceEntry.Name().String())),
-			chasm.WithSkipPersistenceIfClean(mutableState.chasmSkipPersistenceEnabled),
 		)
 		if err != nil {
 			return nil, err
@@ -690,7 +688,7 @@ func (ms *MutableStateImpl) ChasmEnabled() bool {
 	return !isNoop
 }
 
-func (ms *MutableStateImpl) chasmSkipPersistenceEnabled() bool {
+func (ms *MutableStateImpl) ChasmSkipPersistenceEnabled() bool {
 	return ms.config.EnableCHASMSkipPersistence != nil &&
 		ms.config.EnableCHASMSkipPersistence(ms.GetNamespaceEntry().Name().String())
 }


### PR DESCRIPTION
## What changed?
Add dynamic config to flip skip persistence optimization.

## Why?
Allow backwards compatible rollout of skip persistence flag.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)
