### PR TITLE
refactor(tools): share Slack utilities

### DIFF
--- a/tools/ci-notify/app.go
+++ b/tools/ci-notify/app.go
@@ -147,7 +147,7 @@ func runAlertCommand(c *cli.Context) error {
 	message := BuildFailureMessage(report)
 
 	logger.Info("Sending Slack notification")
-	if err := SendSlackMessage(slackWebhook, message); err != nil {
+	if err := message.Send(slackWebhook); err != nil {
 		logger.Error("Failed to send Slack message", zap.Error(err))
 		// Don't fail CI if notification fails
 		return nil
@@ -222,7 +222,7 @@ func runDigestCommand(c *cli.Context) error {
 	message := BuildSuccessReportMessage(report)
 
 	logger.Info("Sending Slack notification")
-	if err := SendSlackMessage(slackWebhook, message); err != nil {
+	if err := message.Send(slackWebhook); err != nil {
 		logger.Error("Failed to send Slack message", zap.Error(err))
 		// Don't fail CI if reporting fails
 		return nil

--- a/tools/ci-notify/app_test.go
+++ b/tools/ci-notify/app_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/server/tools/common/github"
+	"go.temporal.io/server/tools/common/slack"
 )
 
 func TestBuildFailureMessage(t *testing.T) {
@@ -33,26 +34,26 @@ func TestBuildFailureMessage(t *testing.T) {
 		TotalJobs: 5,
 	}
 
-	require.Equal(t, &SlackMessage{
+	require.Equal(t, &slack.Message{
 		Text: "CI Failed on Main",
-		Blocks: []SlackBlock{
+		Blocks: []slack.Block{
 			{
 				Type: "section",
-				Text: &SlackText{
+				Text: &slack.Text{
 					Type: "mrkdwn",
 					Text: ":rotating_light: *CI Failed on Main Branch* :rotating_light:",
 				},
 			},
 			{
 				Type: "section",
-				Text: &SlackText{
+				Text: &slack.Text{
 					Type: "mrkdwn",
 					Text: "*Failures (2):* `TestHistoryWorkflow`, `TestMatchingWorkflow`",
 				},
 			},
 			{
 				Type: "section",
-				Text: &SlackText{
+				Text: &slack.Text{
 					Type: "mrkdwn",
 					Text: "*Failed jobs (2/5):* " +
 						"<https://github.com/temporalio/temporal/actions/runs/123456/job/1|test-job-1>, " +
@@ -61,7 +62,7 @@ func TestBuildFailureMessage(t *testing.T) {
 			},
 			{
 				Type: "section",
-				Text: &SlackText{
+				Text: &slack.Text{
 					Type: "mrkdwn",
 					Text: "<https://github.com/temporalio/temporal/actions/runs/123456|View Run>",
 				},
@@ -108,26 +109,26 @@ func TestSlackMessageStructure(t *testing.T) {
 		TotalJobs: 3,
 	}
 
-	require.Equal(t, &SlackMessage{
+	require.Equal(t, &slack.Message{
 		Text: "CI Failed on Main",
-		Blocks: []SlackBlock{
+		Blocks: []slack.Block{
 			{
 				Type: "section",
-				Text: &SlackText{
+				Text: &slack.Text{
 					Type: "mrkdwn",
 					Text: ":rotating_light: *CI Failed on Main Branch* :rotating_light:",
 				},
 			},
 			{
 				Type: "section",
-				Text: &SlackText{
+				Text: &slack.Text{
 					Type: "mrkdwn",
 					Text: "*Failed jobs (1/3):* <http://example.com/job1|job1>",
 				},
 			},
 			{
 				Type: "section",
-				Text: &SlackText{
+				Text: &slack.Text{
 					Type: "mrkdwn",
 					Text: "<https://github.com/temporalio/temporal/actions/runs/123|View Run>",
 				},
@@ -158,9 +159,9 @@ func TestBuildFailureMessageLimitsFailures(t *testing.T) {
 	msg := BuildFailureMessage(report)
 
 	require.Len(t, msg.Blocks, 4)
-	require.Equal(t, SlackBlock{
+	require.Equal(t, slack.Block{
 		Type: "section",
-		Text: &SlackText{
+		Text: &slack.Text{
 			Type: "mrkdwn",
 			Text: "*Failures (6):* `Test01`, `Test02`, `Test03`, `Test04`, `Test05`",
 		},

--- a/tools/ci-notify/slack.go
+++ b/tools/ci-notify/slack.go
@@ -1,45 +1,18 @@
 package cinotify
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"strings"
-	"time"
+
+	"go.temporal.io/server/tools/common/slack"
 )
 
 const maxFailures = 5
 
-// SlackMessage represents a Slack Block Kit message
-type SlackMessage struct {
-	Text   string       `json:"text"`
-	Blocks []SlackBlock `json:"blocks"`
-}
-
-// SlackBlock represents a block in the Slack message
-type SlackBlock struct {
-	Type   string      `json:"type"`
-	Text   *SlackText  `json:"text,omitempty"`
-	Fields []SlackText `json:"fields,omitempty"`
-}
-
-// SlackText represents text content in a Slack block
-type SlackText struct {
-	Type string `json:"type"`
-	Text string `json:"text"`
-}
-
 // BuildFailureMessage creates a Slack message for CI failure
-func BuildFailureMessage(report *FailureReport) *SlackMessage {
-	// Header with alert emoji
-	headerBlock := SlackBlock{
-		Type: "section",
-		Text: &SlackText{
-			Type: "mrkdwn",
-			Text: ":rotating_light: *CI Failed on Main Branch* :rotating_light:",
-		},
-	}
+func BuildFailureMessage(report *FailureReport) *slack.Message {
+	message := slack.NewMessage("CI Failed on Main")
+	message.AddSection(":rotating_light: *CI Failed on Main Branch* :rotating_light:")
 
 	// List of failed jobs
 	var failedJobNames []string
@@ -48,18 +21,6 @@ func BuildFailureMessage(report *FailureReport) *SlackMessage {
 			fmt.Sprintf("<%s|%s>", job.URL, job.Name))
 	}
 
-	jobsBlock := SlackBlock{
-		Type: "section",
-		Text: &SlackText{
-			Type: "mrkdwn",
-			Text: fmt.Sprintf("*Failed jobs (%d/%d):* %s",
-				len(report.FailedJobs),
-				report.TotalJobs,
-				strings.Join(failedJobNames, ", ")),
-		},
-	}
-
-	blocks := []SlackBlock{headerBlock}
 	if len(report.Failures) > 0 {
 		failures := report.Failures
 		if len(failures) > maxFailures {
@@ -70,32 +31,21 @@ func BuildFailureMessage(report *FailureReport) *SlackMessage {
 		for _, failure := range failures {
 			failureLines = append(failureLines, fmt.Sprintf("`%s`", failure))
 		}
-		blocks = append(blocks, SlackBlock{
-			Type: "section",
-			Text: &SlackText{
-				Type: "mrkdwn",
-				Text: fmt.Sprintf("*Failures (%d):* %s",
-					len(report.Failures),
-					strings.Join(failureLines, ", ")),
-			},
-		})
+		message.AddSection(fmt.Sprintf(
+			"*Failures (%d):* %s",
+			len(report.Failures),
+			strings.Join(failureLines, ", "),
+		))
 	}
-	blocks = append(blocks, jobsBlock)
 
-	// Link to run
-	linkBlock := SlackBlock{
-		Type: "section",
-		Text: &SlackText{
-			Type: "mrkdwn",
-			Text: fmt.Sprintf("<%s|View Run>", report.Run.URL),
-		},
-	}
-	blocks = append(blocks, linkBlock)
-
-	return &SlackMessage{
-		Text:   "CI Failed on Main",
-		Blocks: blocks,
-	}
+	message.AddSection(fmt.Sprintf(
+		"*Failed jobs (%d/%d):* %s",
+		len(report.FailedJobs),
+		report.TotalJobs,
+		strings.Join(failedJobNames, ", "),
+	))
+	message.AddSection(fmt.Sprintf("<%s|View Run>", report.Run.URL))
+	return message
 }
 
 // FormatMessageForDebug formats the message for console output
@@ -120,99 +70,33 @@ func FormatMessageForDebug(report *FailureReport) string {
 	return sb.String()
 }
 
-// SendSlackMessage sends the message to Slack webhook
-func SendSlackMessage(webhookURL string, message *SlackMessage) error {
-	payload, err := json.Marshal(message)
-	if err != nil {
-		return fmt.Errorf("failed to marshal message: %w", err)
-	}
-
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-	}
-
-	resp, err := client.Post(webhookURL, "application/json", bytes.NewBuffer(payload))
-	if err != nil {
-		return fmt.Errorf("failed to send message: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("slack returned status %d", resp.StatusCode)
-	}
-
-	return nil
-}
-
 // BuildSuccessReportMessage creates a Slack message for success report
-func BuildSuccessReportMessage(report *DigestReport) *SlackMessage {
-	// Header
-	headerBlock := SlackBlock{
-		Type: "section",
-		Text: &SlackText{
-			Type: "mrkdwn",
-			Text: fmt.Sprintf(":chart_with_upwards_trend: *Weekly CI Report - %s Branch*", report.Branch),
-		},
-	}
+func BuildSuccessReportMessage(report *DigestReport) *slack.Message {
+	message := slack.NewMessage(fmt.Sprintf("Weekly CI Report - %s Branch", report.Branch))
+	message.AddSection(fmt.Sprintf(":chart_with_upwards_trend: *Weekly CI Report - %s Branch*", report.Branch))
+	message.AddSection(fmt.Sprintf(
+		"*Report Period:* %s to %s",
+		report.StartDate.Format("Jan 2, 2006"),
+		report.EndDate.Format("Jan 2, 2006"),
+	))
+	message.AddFields(
+		fmt.Sprintf("*Success Rate:*\n%.1f%%", report.SuccessRate),
+		fmt.Sprintf("*Total Runs:*\n%d", report.TotalRuns),
+		fmt.Sprintf("*Failed Runs:*\n%d", report.FailedRuns),
+		fmt.Sprintf("*Successful Runs:*\n%d", report.SuccessfulRuns),
+		fmt.Sprintf("*Average Duration:*\n%s", formatDuration(report.AverageDuration)),
+		fmt.Sprintf("*Median Duration:*\n%s", formatDuration(report.MedianDuration)),
+	)
+	message.AddSection(fmt.Sprintf(
+		"*Run Duration Distribution:*\n"+
+			"• Under 20 minutes: %.1f%%\n"+
+			"• Under 25 minutes: %.1f%%\n"+
+			"• Under 30 minutes: %.1f%%",
+		report.Under20MinutesPercent,
+		report.Under25MinutesPercent,
+		report.Under30MinutesPercent,
+	))
 
-	// Period
-	periodBlock := SlackBlock{
-		Type: "section",
-		Text: &SlackText{
-			Type: "mrkdwn",
-			Text: fmt.Sprintf("*Report Period:* %s to %s",
-				report.StartDate.Format("Jan 2, 2006"),
-				report.EndDate.Format("Jan 2, 2006")),
-		},
-	}
-
-	// Metrics grid
-	metricsBlock := SlackBlock{
-		Type: "section",
-		Fields: []SlackText{
-			{
-				Type: "mrkdwn",
-				Text: fmt.Sprintf("*Success Rate:*\n%.1f%%", report.SuccessRate),
-			},
-			{
-				Type: "mrkdwn",
-				Text: fmt.Sprintf("*Total Runs:*\n%d", report.TotalRuns),
-			},
-			{
-				Type: "mrkdwn",
-				Text: fmt.Sprintf("*Failed Runs:*\n%d", report.FailedRuns),
-			},
-			{
-				Type: "mrkdwn",
-				Text: fmt.Sprintf("*Successful Runs:*\n%d", report.SuccessfulRuns),
-			},
-			{
-				Type: "mrkdwn",
-				Text: fmt.Sprintf("*Average Duration:*\n%s", formatDuration(report.AverageDuration)),
-			},
-			{
-				Type: "mrkdwn",
-				Text: fmt.Sprintf("*Median Duration:*\n%s", formatDuration(report.MedianDuration)),
-			},
-		},
-	}
-
-	// Timing percentiles section
-	timingBlock := SlackBlock{
-		Type: "section",
-		Text: &SlackText{
-			Type: "mrkdwn",
-			Text: fmt.Sprintf("*Run Duration Distribution:*\n"+
-				"• Under 20 minutes: %.1f%%\n"+
-				"• Under 25 minutes: %.1f%%\n"+
-				"• Under 30 minutes: %.1f%%",
-				report.Under20MinutesPercent,
-				report.Under25MinutesPercent,
-				report.Under30MinutesPercent),
-		},
-	}
-
-	blocks := []SlackBlock{headerBlock, periodBlock, metricsBlock, timingBlock}
 	slowestRuns := report.slowestRuns(3)
 	if len(slowestRuns) > 0 {
 		var slowest []string
@@ -224,19 +108,10 @@ func BuildSuccessReportMessage(report *DigestReport) *SlackMessage {
 				run.Conclusion,
 			))
 		}
-		blocks = append(blocks, SlackBlock{
-			Type: "section",
-			Text: &SlackText{
-				Type: "mrkdwn",
-				Text: fmt.Sprintf("*Slowest Runs:*\n%s", strings.Join(slowest, "\n")),
-			},
-		})
+		message.AddSection(fmt.Sprintf("*Slowest Runs:*\n%s", strings.Join(slowest, "\n")))
 	}
 
-	return &SlackMessage{
-		Text:   fmt.Sprintf("Weekly CI Report - %s Branch", report.Branch),
-		Blocks: blocks,
-	}
+	return message
 }
 
 // FormatReportForDebug formats the success report for console output

--- a/tools/common/slack/message.go
+++ b/tools/common/slack/message.go
@@ -1,0 +1,104 @@
+package slack
+
+import "strings"
+
+const (
+	maxHeaderTextCharacters  = 150
+	maxSectionTextCharacters = 3000
+	maxFieldTextCharacters   = 2000
+	truncationSuffix         = "\n\n...(truncated due to length)"
+)
+
+// Message represents a Slack Block Kit message.
+type Message struct {
+	Text   string  `json:"text"`
+	Blocks []Block `json:"blocks"`
+}
+
+// Block represents a block in a Slack message.
+type Block struct {
+	Type   string `json:"type"`
+	Text   *Text  `json:"text,omitempty"`
+	Fields []Text `json:"fields,omitempty"`
+}
+
+// Text represents text content in a Slack block.
+type Text struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// NewMessage creates an empty Slack message with fallback notification text.
+func NewMessage(text string) *Message {
+	return &Message{Text: text}
+}
+
+// AddHeader appends a plain-text header block.
+func (m *Message) AddHeader(text string) {
+	m.Blocks = append(m.Blocks, Block{
+		Type: "header",
+		Text: &Text{
+			Type: "plain_text",
+			Text: truncate(text, maxHeaderTextCharacters),
+		},
+	})
+}
+
+// AddSection appends a Markdown section block.
+func (m *Message) AddSection(text string) {
+	m.Blocks = append(m.Blocks, Block{
+		Type: "section",
+		Text: &Text{
+			Type: "mrkdwn",
+			Text: truncate(text, maxSectionTextCharacters),
+		},
+	})
+}
+
+// AddFields appends a section containing Markdown fields.
+func (m *Message) AddFields(fields ...string) {
+	if len(fields) == 0 {
+		return
+	}
+
+	textFields := make([]Text, 0, len(fields))
+	for _, field := range fields {
+		textFields = append(textFields, Text{
+			Type: "mrkdwn",
+			Text: truncate(field, maxFieldTextCharacters),
+		})
+	}
+	m.Blocks = append(m.Blocks, Block{
+		Type:   "section",
+		Fields: textFields,
+	})
+}
+
+// RenderMarkdown renders the message blocks as Markdown.
+func (m *Message) RenderMarkdown() string {
+	var sb strings.Builder
+	for _, block := range m.Blocks {
+		if block.Text != nil {
+			sb.WriteString(block.Text.Text)
+			sb.WriteString("\n\n")
+		}
+		for _, field := range block.Fields {
+			sb.WriteString(field.Text)
+			sb.WriteString("\n")
+		}
+		if len(block.Fields) > 0 {
+			sb.WriteString("\n")
+		}
+	}
+	return sb.String()
+}
+
+func truncate(text string, limit int) string {
+	runes := []rune(text)
+	if len(runes) <= limit {
+		return text
+	}
+
+	suffix := []rune(truncationSuffix)
+	return string(runes[:limit-len(suffix)]) + truncationSuffix
+}

--- a/tools/common/slack/message_test.go
+++ b/tools/common/slack/message_test.go
@@ -1,0 +1,63 @@
+package slack
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageBlocks(t *testing.T) {
+	message := NewMessage("fallback")
+	message.AddHeader("Report")
+	message.AddSection("*Summary:* complete")
+	message.AddFields("*Runs:*\n10", "*Failures:*\n2")
+
+	require.Equal(t, &Message{
+		Text: "fallback",
+		Blocks: []Block{
+			{
+				Type: "header",
+				Text: &Text{
+					Type: "plain_text",
+					Text: "Report",
+				},
+			},
+			{
+				Type: "section",
+				Text: &Text{
+					Type: "mrkdwn",
+					Text: "*Summary:* complete",
+				},
+			},
+			{
+				Type: "section",
+				Fields: []Text{
+					{
+						Type: "mrkdwn",
+						Text: "*Runs:*\n10",
+					},
+					{
+						Type: "mrkdwn",
+						Text: "*Failures:*\n2",
+					},
+				},
+			},
+		},
+	}, message)
+	require.Equal(t, "Report\n\n*Summary:* complete\n\n*Runs:*\n10\n*Failures:*\n2\n\n", message.RenderMarkdown())
+}
+
+func TestMessageTruncatesBlockText(t *testing.T) {
+	message := NewMessage("fallback")
+	message.AddHeader(strings.Repeat("h", maxHeaderTextCharacters+1))
+	message.AddSection(strings.Repeat("界", maxSectionTextCharacters+1))
+	message.AddFields(strings.Repeat("f", maxFieldTextCharacters+1))
+
+	require.Len(t, []rune(message.Blocks[0].Text.Text), maxHeaderTextCharacters)
+	require.Len(t, []rune(message.Blocks[1].Text.Text), maxSectionTextCharacters)
+	require.Len(t, []rune(message.Blocks[2].Fields[0].Text), maxFieldTextCharacters)
+	require.True(t, utf8.ValidString(message.Blocks[1].Text.Text))
+	require.True(t, strings.HasSuffix(message.Blocks[1].Text.Text, truncationSuffix))
+}

--- a/tools/common/slack/webhook.go
+++ b/tools/common/slack/webhook.go
@@ -1,0 +1,50 @@
+package slack
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+var webhookHTTPClient = &http.Client{
+	Timeout: 30 * time.Second,
+}
+
+// Send posts the message to a Slack webhook.
+func (m *Message) Send(webhookURL string) (retErr error) {
+	if webhookURL == "" {
+		return errors.New("webhook URL is empty")
+	}
+	if m == nil {
+		return errors.New("slack message is nil")
+	}
+
+	payload, err := json.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("failed to marshal Slack message: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, webhookURL, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create Slack request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := webhookHTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send Slack request: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("failed to close Slack response: %w", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected Slack response status: %s", resp.Status)
+	}
+	return nil
+}

--- a/tools/common/slack/webhook_test.go
+++ b/tools/common/slack/webhook_test.go
@@ -1,0 +1,59 @@
+package slack
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageSend(t *testing.T) {
+	type receivedRequest struct {
+		contentType string
+		body        []byte
+		err         error
+	}
+	received := make(chan receivedRequest, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		received <- receivedRequest{
+			contentType: r.Header.Get("Content-Type"),
+			body:        body,
+			err:         err,
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	message := NewMessage("fallback")
+	message.AddSection("details")
+	require.NoError(t, message.Send(server.URL))
+
+	request := <-received
+	require.NoError(t, request.err)
+	require.Equal(t, "application/json", request.contentType)
+
+	var sent Message
+	require.NoError(t, json.Unmarshal(request.body, &sent))
+	require.Equal(t, message, &sent)
+}
+
+func TestMessageSendRejectsEmptyWebhookURL(t *testing.T) {
+	require.EqualError(t, NewMessage("fallback").Send(""), "webhook URL is empty")
+}
+
+func TestMessageSendRejectsUnsuccessfulResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	require.EqualError(
+		t,
+		NewMessage("fallback").Send(server.URL),
+		"unexpected Slack response status: 400 Bad Request",
+	)
+}

--- a/tools/flakereport/flakereport.go
+++ b/tools/flakereport/flakereport.go
@@ -373,11 +373,13 @@ func runGenerateCommand(c *cli.Context) (err error) {
 	message := buildSuccessMessage(summary, runID, repo, days)
 	if slackWebhook != "" {
 		fmt.Println("\n=== Sending Slack notification ===")
-		if err := message.send(slackWebhook); err != nil {
+		if err := message.Send(slackWebhook); err != nil {
 			fmt.Printf("Warning: Failed to send Slack notification: %v\n", err)
+		} else {
+			fmt.Println("Slack notification sent successfully")
 		}
 	} else {
-		md := message.renderMarkdown()
+		md := message.RenderMarkdown()
 		if writeErr := os.WriteFile(filepath.Join(outputDir, "slack-report.md"), []byte(md), 0644); writeErr != nil {
 			fmt.Printf("Warning: Failed to write slack-report.md: %v\n", writeErr)
 		}
@@ -394,7 +396,7 @@ func sendFailureNotification(webhookURL, runID, refName, sha, repo string, err e
 
 	fmt.Println("Sending failure notification to Slack...")
 	message := buildFailureMessage(runID, refName, sha, repo)
-	if sendErr := message.send(webhookURL); sendErr != nil {
+	if sendErr := message.Send(webhookURL); sendErr != nil {
 		fmt.Printf("Warning: Failed to send failure notification: %v\n", sendErr)
 	}
 }

--- a/tools/flakereport/slack.go
+++ b/tools/flakereport/slack.go
@@ -1,46 +1,16 @@
 package flakereport
 
 import (
-	"bytes"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 	"sort"
 	"strings"
-	"time"
 
 	"go.temporal.io/server/tools/common/github"
+	"go.temporal.io/server/tools/common/slack"
 )
 
-// SlackMessage represents Slack Block Kit message
-type SlackMessage struct {
-	Text   string       `json:"text"`
-	Blocks []SlackBlock `json:"blocks"`
-}
-
-type SlackBlock struct {
-	Type   string      `json:"type"`
-	Text   *SlackText  `json:"text,omitempty"`
-	Fields []SlackText `json:"fields,omitempty"`
-}
-
-type SlackText struct {
-	Type string `json:"type"`
-	Text string `json:"text"`
-}
-
-// truncateToSlackLimit truncates text to stay within Slack's block text limit
-// Slack blocks have a 3000 character limit per text field
-func truncateToSlackLimit(text string, limit int) string {
-	if len(text) <= limit {
-		return text
-	}
-	return text[:limit-50] + "\n\n...(truncated due to length)"
-}
-
 // buildSuccessMessage creates success notification with report summary
-func buildSuccessMessage(summary *ReportSummary, runID, repo string, days int) *SlackMessage {
+func buildSuccessMessage(summary *ReportSummary, runID, repo string, days int) *slack.Message {
 	// Calculate CI success rate
 	ciSuccessRate := 0.0
 	if summary.TotalWorkflowRuns > 0 {
@@ -60,26 +30,9 @@ func buildSuccessMessage(summary *ReportSummary, runID, repo string, days int) *
 		summary.TotalFlakyCount,
 		len(summary.Timeouts))
 
-	// Build message
-	msg := &SlackMessage{
-		Text: "Flaky Tests Report Generated",
-		Blocks: []SlackBlock{
-			{
-				Type: "header",
-				Text: &SlackText{
-					Type: "plain_text",
-					Text: fmt.Sprintf("Flaky Tests Report - Last %d Days", days),
-				},
-			},
-			{
-				Type: "section",
-				Text: &SlackText{
-					Type: "mrkdwn",
-					Text: truncateToSlackLimit(summaryText, 2900), // Keep under 3000 char limit
-				},
-			},
-		},
-	}
+	msg := slack.NewMessage("Flaky Tests Report Generated")
+	msg.AddHeader(fmt.Sprintf("Flaky Tests Report - Last %d Days", days))
+	msg.AddSection(summaryText)
 
 	// Add CI breakers details
 	if lines := formatReportLines(summary.CIBreakers); len(lines) > 0 {
@@ -87,13 +40,7 @@ func buildSuccessMessage(summary *ReportSummary, runID, repo string, days int) *
 			lines = lines[:slackMaxListItems]
 		}
 		text := fmt.Sprintf("*CI Breakers (top %d):*\n%s", slackMaxListItems, strings.Join(lines, "\n"))
-		msg.Blocks = append(msg.Blocks, SlackBlock{
-			Type: "section",
-			Text: &SlackText{
-				Type: "mrkdwn",
-				Text: truncateToSlackLimit(text, 2900),
-			},
-		})
+		msg.AddSection(text)
 	}
 
 	// Add flaky tests details (already sorted by failure rate)
@@ -108,25 +55,13 @@ func buildSuccessMessage(summary *ReportSummary, runID, repo string, days int) *
 			lines = lines[:slackMaxListItems]
 		}
 		text := fmt.Sprintf("*Flaky Tests (top %d):*\n%s", slackMaxListItems, strings.Join(lines, "\n"))
-		msg.Blocks = append(msg.Blocks, SlackBlock{
-			Type: "section",
-			Text: &SlackText{
-				Type: "mrkdwn",
-				Text: truncateToSlackLimit(text, 2900),
-			},
-		})
+		msg.AddSection(text)
 	}
 
 	// Add link to report
 	if runID != "" {
 		linkURL := github.RunURL(repo, runID)
-		msg.Blocks = append(msg.Blocks, SlackBlock{
-			Type: "section",
-			Text: &SlackText{
-				Type: "mrkdwn",
-				Text: fmt.Sprintf("<%s|Report & Artifacts>", linkURL),
-			},
-		})
+		msg.AddSection(fmt.Sprintf("<%s|Report & Artifacts>", linkURL))
 	}
 
 	return msg
@@ -135,7 +70,7 @@ func buildSuccessMessage(summary *ReportSummary, runID, repo string, days int) *
 // addBisectSection appends a Bayesian bisect section to an existing Slack message.
 // TODO seankane: after validating this methodology can identify problematic commits
 // add the section to the Slack message.
-func (msg *SlackMessage) addBisectSection(reports []TestBisectReport, repo string) {
+func addBisectSection(msg *slack.Message, reports []TestBisectReport, repo string) {
 	// Count qualifying
 	qualifying := 0
 	for _, r := range reports {
@@ -182,13 +117,10 @@ func (msg *SlackMessage) addBisectSection(reports []TestBisectReport, repo strin
 
 	if len(lines) == 0 {
 		// No multi-test suspects; just report the count
-		msg.Blocks = append(msg.Blocks, SlackBlock{
-			Type: "section",
-			Text: &SlackText{
-				Type: "mrkdwn",
-				Text: fmt.Sprintf("*🔍 Commit Suspects (Bayesian)*\n%d tests analyzed. See GitHub summary for details.", qualifying),
-			},
-		})
+		msg.AddSection(fmt.Sprintf(
+			"*🔍 Commit Suspects (Bayesian)*\n%d tests analyzed. See GitHub summary for details.",
+			qualifying,
+		))
 		return
 	}
 
@@ -200,121 +132,25 @@ func (msg *SlackMessage) addBisectSection(reports []TestBisectReport, repo strin
 
 	text := fmt.Sprintf("*🔍 Hot Commits (Bayesian, implicated in 2+ tests):*\n%s\n\nSee GitHub summary for full details.",
 		strings.Join(lines, "\n"))
-	msg.Blocks = append(msg.Blocks, SlackBlock{
-		Type: "section",
-		Text: &SlackText{
-			Type: "mrkdwn",
-			Text: truncateToSlackLimit(text, 2900),
-		},
-	})
+	msg.AddSection(text)
 }
 
 // buildFailureMessage creates failure notification
-func buildFailureMessage(runID, refName, sha, repo string) *SlackMessage {
-	msg := &SlackMessage{
-		Text: "Flaky Tests Report Generation Failed",
-		Blocks: []SlackBlock{
-			{
-				Type: "header",
-				Text: &SlackText{
-					Type: "plain_text",
-					Text: "Flaky Tests Report Generation Failed",
-				},
-			},
-			{
-				Type: "section",
-				Fields: []SlackText{
-					{
-						Type: "mrkdwn",
-						Text: fmt.Sprintf("*Run ID:*\n%s", runID),
-					},
-					{
-						Type: "mrkdwn",
-						Text: fmt.Sprintf("*Branch:*\n%s", refName),
-					},
-					{
-						Type: "mrkdwn",
-						Text: fmt.Sprintf("*Commit:*\n%.7s", sha),
-					},
-					{
-						Type: "mrkdwn",
-						Text: "*Status:*\nFailed",
-					},
-				},
-			},
-		},
-	}
+func buildFailureMessage(runID, refName, sha, repo string) *slack.Message {
+	msg := slack.NewMessage("Flaky Tests Report Generation Failed")
+	msg.AddHeader("Flaky Tests Report Generation Failed")
+	msg.AddFields(
+		fmt.Sprintf("*Run ID:*\n%s", runID),
+		fmt.Sprintf("*Branch:*\n%s", refName),
+		fmt.Sprintf("*Commit:*\n%.7s", sha),
+		"*Status:*\nFailed",
+	)
 
 	// Add link to workflow run
 	if runID != "" {
 		linkURL := github.RunURL(repo, runID)
-		msg.Blocks = append(msg.Blocks, SlackBlock{
-			Type: "section",
-			Text: &SlackText{
-				Type: "mrkdwn",
-				Text: fmt.Sprintf("<%s|View Workflow Run>", linkURL),
-			},
-		})
+		msg.AddSection(fmt.Sprintf("<%s|View Workflow Run>", linkURL))
 	}
 
 	return msg
-}
-
-// renderMarkdown renders a SlackMessage as markdown, treating each block's text as markdown.
-func (msg *SlackMessage) renderMarkdown() string {
-	var sb strings.Builder
-	for _, block := range msg.Blocks {
-		if block.Text != nil {
-			sb.WriteString(block.Text.Text)
-			sb.WriteString("\n\n")
-		}
-		for _, field := range block.Fields {
-			sb.WriteString(field.Text)
-			sb.WriteString("\n")
-		}
-		if len(block.Fields) > 0 {
-			sb.WriteString("\n")
-		}
-	}
-	return sb.String()
-}
-
-// send sends message to webhook URL
-func (msg *SlackMessage) send(webhookURL string) error {
-	if webhookURL == "" {
-		return errors.New("webhook URL is empty")
-	}
-
-	jsonData, err := json.Marshal(msg)
-	if err != nil {
-		return fmt.Errorf("failed to marshal message: %w", err)
-	}
-
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-	}
-
-	req, err := http.NewRequest("POST", webhookURL, bytes.NewBuffer(jsonData))
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to send request: %w", err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Printf("Warning: Failed to close response body: %v\n", err)
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-	}
-
-	fmt.Println("Slack notification sent successfully")
-	return nil
 }


### PR DESCRIPTION
## What changed?
* Extracted shared Slack Block Kit message construction, Markdown rendering, text-limit truncation, and webhook delivery into `tools/common/slack`.
* Migrated `ci-notify` and `flakereport` to use the shared package while preserving their report-specific content and ordering.

## Why?
Both tools maintained duplicate Slack payload types and webhook logic.

## How did you test it?
- [x] covered by existing tests
- [x] added new unit test(s)

## Potential risks

Slack block text is now centrally truncated to Slack’s documented per-block limits. This affects only oversized content and prevents rejected webhook payloads.
