### PR TITLE
fix(saa): RESET_REQUESTED(keepPaused=true) maps to runState=PAUSED

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1658,16 +1658,20 @@ func InternalStatusToAPIStatus(status activitypb.ActivityExecutionStatus) enumsp
 	}
 }
 
-func internalStatusToRunState(status activitypb.ActivityExecutionStatus) enumspb.PendingActivityState {
+func (a *Activity) runState() enumspb.PendingActivityState {
+	status := a.GetStatus()
 	switch status {
 	case activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED:
 		return enumspb.PENDING_ACTIVITY_STATE_SCHEDULED
-	case activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
-		activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED:
-		// RESET_REQUESTED surfaces as STARTED externally — the worker is still executing
-		// under its existing task token; the public PendingActivityState enum does not have
-		// a RESET_REQUESTED variant. The reset is surfaced to the worker via
+	case activitypb.ACTIVITY_EXECUTION_STATUS_STARTED:
+		return enumspb.PENDING_ACTIVITY_STATE_STARTED
+	case activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED:
+		// The worker is still executing under its existing task token; the public PendingActivityState
+		// enum does not have a RESET_REQUESTED variant. The reset is surfaced to the worker via
 		// ActivityReset=true on its next heartbeat response.
+		if a.isPaused() {
+			return enumspb.PENDING_ACTIVITY_STATE_PAUSE_REQUESTED
+		}
 		return enumspb.PENDING_ACTIVITY_STATE_STARTED
 	case activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED:
 		return enumspb.PENDING_ACTIVITY_STATE_CANCEL_REQUESTED
@@ -1692,7 +1696,7 @@ func (a *Activity) buildActivityExecutionInfo(
 	request *workflowservice.DescribeActivityExecutionRequest,
 ) *apiactivitypb.ActivityExecutionInfo {
 	status := InternalStatusToAPIStatus(a.GetStatus())
-	runState := internalStatusToRunState(a.GetStatus())
+	runState := a.runState()
 
 	requestData := a.RequestData.Get(ctx)
 	attempt := a.LastAttempt.Get(ctx)

--- a/chasm/lib/activity/model/vocabulary.go
+++ b/chasm/lib/activity/model/vocabulary.go
@@ -15,6 +15,7 @@ const (
 	RespondCanceledType
 	RequestCancelType
 	PauseType
+	ResetType
 
 	// Timer events
 
@@ -33,7 +34,8 @@ const (
 type Event struct {
 	Type EventType
 
-	Retryable bool // RespondFailed: the failure is retryable. Whether it actually retries also depends on the retry policy.
+	Retryable  bool // RespondFailed: the failure is retryable. Whether it actually retries also depends on the retry policy.
+	KeepPaused bool // Reset: a paused activity stays paused across the reset.
 }
 
 // Canonical Event values for the variants frequently used in traces
@@ -43,6 +45,7 @@ var (
 	RespondCanceled        = Event{Type: RespondCanceledType}
 	RequestCancel          = Event{Type: RequestCancelType}
 	Pause                  = Event{Type: PauseType}
+	ResetKeepPaused        = Event{Type: ResetType, KeepPaused: true}
 	StartToCloseElapses    = Event{Type: StartToCloseElapsesType}
 	ScheduleToCloseElapses = Event{Type: ScheduleToCloseElapsesType}
 	ScheduleToStartElapses = Event{Type: ScheduleToStartElapsesType}
@@ -64,6 +67,8 @@ func (t EventType) String() string {
 		return "RequestCancel"
 	case PauseType:
 		return "Pause"
+	case ResetType:
+		return "Reset"
 	case ScheduleToStartElapsesType:
 		return "ScheduleToStartElapses"
 	case ScheduleToCloseElapsesType:
@@ -83,8 +88,12 @@ func (t EventType) String() string {
 
 // String is a label for an event; it includes flags that affect its outcome.
 func (e Event) String() string {
-	if e.Type == RespondFailedType {
+	switch e.Type {
+	case RespondFailedType:
 		return fmt.Sprintf("%s[retryable=%v]", e.Type.String(), e.Retryable)
+	case ResetType:
+		return fmt.Sprintf("%s[keepPaused=%v]", e.Type.String(), e.KeepPaused)
+	default:
+		return e.Type.String()
 	}
-	return e.Type.String()
 }

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -201,6 +201,25 @@ func (s *activityParityTestSuite) TestCurrentRetryIntervalAndNextAttemptSchedule
 	})
 }
 
+// Resetting a running paused activity with keepPaused preserves the pending pause while the worker
+// still owns its task. Describe must continue to report PAUSE_REQUESTED until that worker yields.
+func (s *activityParityTestSuite) TestPauseRequestedAfterResetKeepPaused() {
+	env := newActivityParityEnv(s.T())
+	trace := []model.Event{model.Poll, model.Pause, model.ResetKeepPaused}
+	cfg := activityConfig{MaxAttempts: 3, RetryInterval: activityLongDuration}
+
+	s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
+		t := s.T()
+		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_PAUSE_REQUESTED,
+			newWFADriver(t, env, cfg).driveTrace(t, trace).activityInfo(t).RunState)
+	})
+	s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
+		t := s.T()
+		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_PAUSE_REQUESTED,
+			newSAADriver(t, env, cfg).driveTrace(t, trace).activityInfo(t).RunState)
+	})
+}
+
 // TestCancel drives a running activity through cancellation in both implementations. RequestCancel uses the
 // standalone activity RPC for SAA and workflow cancellation for WFA; the worker then acknowledges the
 // request with RespondActivityTaskCanceled.

--- a/tests/activity_standalone_driver.go
+++ b/tests/activity_standalone_driver.go
@@ -230,6 +230,11 @@ func (a *saaHandle) rpc(_ testing.TB, e model.Event) error {
 			Namespace: ns, ActivityId: a.activityID, RunId: a.runID, Identity: a.d.env.Tv().ClientIdentity(), Reason: "drive", RequestId: uuid.NewString(),
 		})
 		return err
+	case model.ResetType:
+		_, err := fc.ResetActivityExecution(a.d.ctx, &workflowservice.ResetActivityExecutionRequest{
+			Namespace: ns, ActivityId: a.activityID, RunId: a.runID, Identity: a.d.env.Tv().ClientIdentity(), KeepPaused: e.KeepPaused,
+		})
+		return err
 	default:
 		return fmt.Errorf("saaDriver: unhandled event type %v", e.Type)
 	}

--- a/tests/activity_workflow_driver.go
+++ b/tests/activity_workflow_driver.go
@@ -282,6 +282,11 @@ func (a *wfaHandle) rpc(t testing.TB, e model.Event) error {
 			Namespace: ns, WorkflowId: a.workflowID, ActivityId: a.activityID, RunId: a.runID, Identity: a.d.env.Tv().ClientIdentity(), Reason: "drive", RequestId: uuid.NewString(),
 		})
 		return err
+	case model.ResetType:
+		_, err := fc.ResetActivityExecution(a.d.ctx, &workflowservice.ResetActivityExecutionRequest{
+			Namespace: ns, WorkflowId: a.workflowID, ActivityId: a.activityID, RunId: a.runID, Identity: a.d.env.Tv().ClientIdentity(), KeepPaused: e.KeepPaused,
+		})
+		return err
 	default:
 		return fmt.Errorf("wfaDriver: unhandled event type %v", e.Type)
 	}


### PR DESCRIPTION
## What changed?
- Preserve `PAUSE_REQUESTED` in Describe when a running standalone activity is reset with `keep_paused=true`.
- Add workflow/standalone parity coverage for this state transition.

## Why?
A deferred reset changed the public run state to `STARTED`, hiding the pending pause despite the activity being guaranteed to land paused.

## How did you test it?
- [x] added new functional test(s)
- [x] covered by existing tests

## Potential risks
Low: only the Describe run-state projection for deferred keep-paused resets changes.