### PR TITLE
Expose standalone activity retry state

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1373,7 +1373,8 @@ func (a *Activity) tryReschedule(
 	overridingRetryInterval time.Duration,
 	failure *failurepb.Failure,
 ) (enumspb.RetryState, error) {
-	if a.GetRetryPolicy() == nil {
+	resetRequested := a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED
+	if !resetRequested && a.GetRetryPolicy() == nil {
 		return enumspb.RETRY_STATE_RETRY_POLICY_NOT_SET, nil
 	}
 	if a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED {
@@ -1383,7 +1384,6 @@ func (a *Activity) tryReschedule(
 	if !failureRetryable {
 		retryState = enumspb.RETRY_STATE_NON_RETRYABLE_FAILURE
 	}
-	resetRequested := a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED
 	// A pending reset request is always honored, regardless of retryability or the should retry result.
 	if !resetRequested && retryState != enumspb.RETRY_STATE_IN_PROGRESS {
 		return retryState, nil

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1041,7 +1041,7 @@ func (a *Activity) handleUnpauseRequested(ctx chasm.MutableContext, req *activit
 			return nil, err
 		}
 	case activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED:
-		a.ResetKeepPaused = false
+		a.ResetShouldPause = false
 	default:
 		return nil, serviceerror.NewFailedPreconditionf("activity is in non-unpausable state %v", a.GetStatus())
 	}
@@ -1057,7 +1057,7 @@ func (a *Activity) isPaused() bool {
 		activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED:
 		return true
 	case activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED:
-		return a.GetResetKeepPaused()
+		return a.GetResetShouldPause()
 	default:
 		return false
 	}
@@ -1253,7 +1253,7 @@ func (a *Activity) deferResetWhileRunning(
 	}
 	// keepPaused on a paused (PAUSE_REQUESTED) activity preserves the pause: when the worker
 	// yields the activity lands back in PAUSED rather than SCHEDULED.
-	a.ResetKeepPaused = keepPaused && pauseRequested
+	a.ResetShouldPause = keepPaused && pauseRequested
 	if err := TransitionResetRequested.Apply(a, ctx, nil); err != nil {
 		return nil, err
 	}
@@ -1376,7 +1376,7 @@ func (a *Activity) tryReschedule(
 	status := a.GetStatus()
 	if status == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED {
 		event := rescheduleEvent{failure: failure}
-		if a.ResetKeepPaused {
+		if a.ResetShouldPause {
 			return enumspb.RETRY_STATE_IN_PROGRESS, TransitionResetAttemptFailedToPaused.Apply(a, ctx, event)
 		}
 		return enumspb.RETRY_STATE_IN_PROGRESS, TransitionResetAttemptFailedToScheduled.Apply(a, ctx, event)

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -629,6 +629,7 @@ func (a *Activity) HandleFailed(
 
 	if err := TransitionFailed.Apply(a, ctx, failedEvent{
 		req:             event.Request,
+		retryState:      retryState,
 		baseHandler:     baseHandler,
 		enrichedHandler: enrichedHandler,
 	}); err != nil {
@@ -1372,6 +1373,12 @@ func (a *Activity) tryReschedule(
 	overridingRetryInterval time.Duration,
 	failure *failurepb.Failure,
 ) (enumspb.RetryState, error) {
+	if a.GetRetryPolicy() == nil {
+		return enumspb.RETRY_STATE_RETRY_POLICY_NOT_SET, nil
+	}
+	if a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED {
+		return enumspb.RETRY_STATE_CANCEL_REQUESTED, nil
+	}
 	retryState, retryInterval := a.shouldRetry(ctx, overridingRetryInterval)
 	if !failureRetryable {
 		retryState = enumspb.RETRY_STATE_NON_RETRYABLE_FAILURE
@@ -1938,7 +1945,8 @@ func (a *Activity) outcome(ctx chasm.Context) *apiactivitypb.ActivityExecutionOu
 	}
 	if failure := a.terminalFailure(ctx); failure != nil {
 		return &apiactivitypb.ActivityExecutionOutcome{
-			Value: &apiactivitypb.ActivityExecutionOutcome_Failure{Failure: failure},
+			Value:      &apiactivitypb.ActivityExecutionOutcome_Failure{Failure: failure},
+			RetryState: activityOutcome.GetRetryState(),
 		}
 	}
 	return nil

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1373,19 +1373,25 @@ func (a *Activity) tryReschedule(
 	overridingRetryInterval time.Duration,
 	failure *failurepb.Failure,
 ) (enumspb.RetryState, error) {
-	resetRequested := a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED
-	if !resetRequested && a.GetRetryPolicy() == nil {
+	status := a.GetStatus()
+	if status == activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED {
+		event := rescheduleEvent{failure: failure}
+		if a.ResetKeepPaused {
+			return enumspb.RETRY_STATE_IN_PROGRESS, TransitionResetAttemptFailedToPaused.Apply(a, ctx, event)
+		}
+		return enumspb.RETRY_STATE_IN_PROGRESS, TransitionResetAttemptFailedToScheduled.Apply(a, ctx, event)
+	}
+	if a.GetRetryPolicy() == nil {
 		return enumspb.RETRY_STATE_RETRY_POLICY_NOT_SET, nil
 	}
-	if a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED {
+	if status == activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED {
 		return enumspb.RETRY_STATE_CANCEL_REQUESTED, nil
 	}
 	retryState, retryInterval := a.shouldRetry(ctx, overridingRetryInterval)
 	if !failureRetryable {
 		retryState = enumspb.RETRY_STATE_NON_RETRYABLE_FAILURE
 	}
-	// A pending reset request is always honored, regardless of retryability or the should retry result.
-	if !resetRequested && retryState != enumspb.RETRY_STATE_IN_PROGRESS {
+	if retryState != enumspb.RETRY_STATE_IN_PROGRESS {
 		return retryState, nil
 	}
 	retryIntervalSource := activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_RETRY_POLICY
@@ -1393,14 +1399,9 @@ func (a *Activity) tryReschedule(
 		retryIntervalSource = activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_WORKER_OVERRIDE
 	}
 	event := rescheduleEvent{retryInterval: retryInterval, retryIntervalSource: retryIntervalSource, failure: failure}
-	switch a.GetStatus() {
+	switch status {
 	case activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED:
 		return enumspb.RETRY_STATE_IN_PROGRESS, TransitionAttemptFailedWhilePauseRequested.Apply(a, ctx, event)
-	case activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED:
-		if a.ResetKeepPaused {
-			return enumspb.RETRY_STATE_IN_PROGRESS, TransitionResetAttemptFailedToPaused.Apply(a, ctx, event)
-		}
-		return enumspb.RETRY_STATE_IN_PROGRESS, TransitionResetAttemptFailedToScheduled.Apply(a, ctx, event)
 	default:
 		return enumspb.RETRY_STATE_IN_PROGRESS, TransitionRescheduled.Apply(a, ctx, event)
 	}
@@ -1408,9 +1409,7 @@ func (a *Activity) tryReschedule(
 
 func (a *Activity) shouldRetry(ctx chasm.Context, overridingRetryInterval time.Duration) (enumspb.RetryState, time.Duration) {
 	if !TransitionRescheduled.Possible(a) &&
-		!TransitionAttemptFailedWhilePauseRequested.Possible(a) &&
-		!TransitionResetAttemptFailedToScheduled.Possible(a) &&
-		!TransitionResetAttemptFailedToPaused.Possible(a) {
+		!TransitionAttemptFailedWhilePauseRequested.Possible(a) {
 		return enumspb.RETRY_STATE_UNSPECIFIED, 0
 	}
 	attempt := a.LastAttempt.Get(ctx)

--- a/chasm/lib/activity/activity_tasks.go
+++ b/chasm/lib/activity/activity_tasks.go
@@ -109,6 +109,7 @@ func (h *scheduleToStartTimeoutTaskHandler) Execute(
 
 	event := timeoutEvent{
 		timeoutType:    enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START,
+		retryState:     enumspb.RETRY_STATE_TIMEOUT,
 		metricsHandler: metricsHandler,
 	}
 
@@ -152,8 +153,14 @@ func (h *scheduleToCloseTimeoutTaskHandler) Execute(
 	if err != nil {
 		return err
 	}
+	retryState := enumspb.RETRY_STATE_TIMEOUT
+	if activity.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED {
+		retryState = enumspb.RETRY_STATE_CANCEL_REQUESTED
+	}
+
 	event := timeoutEvent{
 		timeoutType:    enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+		retryState:     retryState,
 		metricsHandler: metricsHandler,
 	}
 

--- a/chasm/lib/activity/activity_tasks_test.go
+++ b/chasm/lib/activity/activity_tasks_test.go
@@ -16,6 +16,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/retrypolicy"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -63,13 +64,16 @@ func TestScheduleToCloseTimeoutTaskValidateStamp(t *testing.T) {
 	}
 }
 
-func TestAttemptTimeoutTaskTerminalFailureType(t *testing.T) {
+func TestTimeoutTaskTerminalFailure(t *testing.T) {
 	testCases := []struct {
 		name                string
 		timeoutType         enumspb.TimeoutType
+		startStatus         activitypb.ActivityExecutionStatus
 		maximumAttempts     int32
 		scheduleToClose     time.Duration
+		nonRetryable        bool
 		expectedTimeoutType enumspb.TimeoutType
+		expectedRetryState  enumspb.RetryState
 		expectedMessage     string
 	}{
 		{
@@ -77,6 +81,7 @@ func TestAttemptTimeoutTaskTerminalFailureType(t *testing.T) {
 			timeoutType:         enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
 			scheduleToClose:     2 * time.Second,
 			expectedTimeoutType: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+			expectedRetryState:  enumspb.RETRY_STATE_TIMEOUT,
 			expectedMessage:     common.FailureReasonActivityRetryScheduleToCloseTimeout,
 		},
 		{
@@ -84,6 +89,7 @@ func TestAttemptTimeoutTaskTerminalFailureType(t *testing.T) {
 			timeoutType:         enumspb.TIMEOUT_TYPE_HEARTBEAT,
 			scheduleToClose:     2 * time.Second,
 			expectedTimeoutType: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+			expectedRetryState:  enumspb.RETRY_STATE_TIMEOUT,
 			expectedMessage:     common.FailureReasonActivityRetryScheduleToCloseTimeout,
 		},
 		{
@@ -92,6 +98,7 @@ func TestAttemptTimeoutTaskTerminalFailureType(t *testing.T) {
 			maximumAttempts:     1,
 			scheduleToClose:     time.Minute,
 			expectedTimeoutType: enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
+			expectedRetryState:  enumspb.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED,
 		},
 		{
 			name:                "heartbeat maximum attempts reached",
@@ -99,6 +106,31 @@ func TestAttemptTimeoutTaskTerminalFailureType(t *testing.T) {
 			maximumAttempts:     1,
 			scheduleToClose:     time.Minute,
 			expectedTimeoutType: enumspb.TIMEOUT_TYPE_HEARTBEAT,
+			expectedRetryState:  enumspb.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED,
+		},
+		{
+			name:                "start to close non-retryable timeout",
+			timeoutType:         enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
+			scheduleToClose:     time.Minute,
+			nonRetryable:        true,
+			expectedTimeoutType: enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
+			expectedRetryState:  enumspb.RETRY_STATE_NON_RETRYABLE_FAILURE,
+		},
+		{
+			name:                "start to close cancellation requested",
+			timeoutType:         enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
+			startStatus:         activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
+			scheduleToClose:     time.Minute,
+			expectedTimeoutType: enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
+			expectedRetryState:  enumspb.RETRY_STATE_CANCEL_REQUESTED,
+		},
+		{
+			name:                "schedule to close cancellation requested",
+			timeoutType:         enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+			startStatus:         activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
+			scheduleToClose:     time.Minute,
+			expectedTimeoutType: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+			expectedRetryState:  enumspb.RETRY_STATE_CANCEL_REQUESTED,
 		},
 	}
 
@@ -123,17 +155,27 @@ func TestAttemptTimeoutTaskTerminalFailureType(t *testing.T) {
 					}),
 				},
 			}
+			retryPolicy := &commonpb.RetryPolicy{
+				InitialInterval:    durationpb.New(time.Second),
+				BackoffCoefficient: 1,
+				MaximumAttempts:    tc.maximumAttempts,
+			}
+			if tc.nonRetryable {
+				retryPolicy.NonRetryableErrorTypes = []string{
+					retrypolicy.TimeoutFailureTypePrefix + tc.timeoutType.String(),
+				}
+			}
+			startStatus := tc.startStatus
+			if startStatus == activitypb.ACTIVITY_EXECUTION_STATUS_UNSPECIFIED {
+				startStatus = activitypb.ACTIVITY_EXECUTION_STATUS_STARTED
+			}
 			activity := &Activity{
 				ActivityState: &activitypb.ActivityState{
-					ActivityType: &commonpb.ActivityType{Name: "test-activity-type"},
-					RetryPolicy: &commonpb.RetryPolicy{
-						InitialInterval:    durationpb.New(time.Second),
-						BackoffCoefficient: 1,
-						MaximumAttempts:    tc.maximumAttempts,
-					},
+					ActivityType:           &commonpb.ActivityType{Name: "test-activity-type"},
+					RetryPolicy:            retryPolicy,
 					ScheduleTime:           timestamppb.New(defaultTime),
 					ScheduleToCloseTimeout: durationpb.New(tc.scheduleToClose),
-					Status:                 activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
+					Status:                 startStatus,
 					TaskQueue:              &taskqueuepb.TaskQueue{Name: "test-task-queue"},
 				},
 				LastAttempt: chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{
@@ -148,6 +190,8 @@ func TestAttemptTimeoutTaskTerminalFailureType(t *testing.T) {
 
 			var err error
 			switch tc.timeoutType {
+			case enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE:
+				err = newScheduleToCloseTimeoutTaskHandler().Execute(ctx, activity, chasm.TaskAttributes{}, &activitypb.ScheduleToCloseTimeoutTask{})
 			case enumspb.TIMEOUT_TYPE_START_TO_CLOSE:
 				err = newStartToCloseTimeoutTaskHandler().Execute(ctx, activity, chasm.TaskAttributes{}, &activitypb.StartToCloseTimeoutTask{})
 			case enumspb.TIMEOUT_TYPE_HEARTBEAT:
@@ -159,15 +203,22 @@ func TestAttemptTimeoutTaskTerminalFailureType(t *testing.T) {
 
 			terminalFailure := activity.outcome(ctx).GetFailure()
 			require.Equal(t, tc.expectedTimeoutType, terminalFailure.GetTimeoutFailureInfo().GetTimeoutType())
+			require.Equal(t, tc.expectedRetryState, activity.outcome(ctx).GetRetryState())
 			if tc.expectedMessage != "" {
 				require.Equal(t, tc.expectedMessage, terminalFailure.GetMessage())
+			}
+			if tc.timeoutType == enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE || tc.expectedMessage != "" {
 				require.NotNil(t, activity.Outcome.Get(ctx).GetFailed())
 			} else {
 				require.Nil(t, activity.Outcome.Get(ctx).GetVariant())
 			}
-			lastFailure := activity.LastAttempt.Get(ctx).GetLastFailureDetails().GetFailure()
-			require.Equal(t, tc.timeoutType, lastFailure.GetTimeoutFailureInfo().GetTimeoutType())
-			require.Equal(t, lastFailure.GetTimeoutFailureInfo().GetLastHeartbeatDetails(), terminalFailure.GetTimeoutFailureInfo().GetLastHeartbeatDetails())
+			if tc.timeoutType == enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE {
+				require.Nil(t, activity.LastAttempt.Get(ctx).GetLastFailureDetails())
+			} else {
+				lastFailure := activity.LastAttempt.Get(ctx).GetLastFailureDetails().GetFailure()
+				require.Equal(t, tc.timeoutType, lastFailure.GetTimeoutFailureInfo().GetTimeoutType())
+				require.Equal(t, lastFailure.GetTimeoutFailureInfo().GetLastHeartbeatDetails(), terminalFailure.GetTimeoutFailureInfo().GetLastHeartbeatDetails())
+			}
 
 			for _, metricName := range []string{metrics.ActivityTimeout.Name(), metrics.ActivityTaskTimeout.Name()} {
 				recordings := capture.Snapshot()[metricName]

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -37,22 +37,32 @@ func TestTryRescheduleRetryStatePrecedence(t *testing.T) {
 		status      activitypb.ActivityExecutionStatus
 		retryPolicy *commonpb.RetryPolicy
 		expected    enumspb.RetryState
+		finalStatus activitypb.ActivityExecutionStatus
 	}{
 		{
-			name:     "retry policy not set",
-			status:   activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
-			expected: enumspb.RETRY_STATE_RETRY_POLICY_NOT_SET,
+			name:        "retry policy not set",
+			status:      activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
+			expected:    enumspb.RETRY_STATE_RETRY_POLICY_NOT_SET,
+			finalStatus: activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
 		},
 		{
-			name:     "retry policy not set takes precedence over cancellation",
-			status:   activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
-			expected: enumspb.RETRY_STATE_RETRY_POLICY_NOT_SET,
+			name:        "retry policy not set takes precedence over cancellation",
+			status:      activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
+			expected:    enumspb.RETRY_STATE_RETRY_POLICY_NOT_SET,
+			finalStatus: activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
 		},
 		{
 			name:        "cancellation requested",
 			status:      activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
 			retryPolicy: defaultRetryPolicy,
 			expected:    enumspb.RETRY_STATE_CANCEL_REQUESTED,
+			finalStatus: activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
+		},
+		{
+			name:        "reset requested takes precedence over retry policy not set",
+			status:      activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
+			expected:    enumspb.RETRY_STATE_IN_PROGRESS,
+			finalStatus: activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
 		},
 	}
 
@@ -79,6 +89,7 @@ func TestTryRescheduleRetryStatePrecedence(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, retryState)
+			require.Equal(t, tc.finalStatus, activity.GetStatus())
 		})
 	}
 }

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -725,12 +725,12 @@ func TestRecordHeartbeatPauseResetCancelFlags(t *testing.T) {
 	require.NoError(t, err)
 
 	testCases := []struct {
-		name            string
-		status          activitypb.ActivityExecutionStatus
-		resetKeepPaused bool
-		wantPaused      bool
-		wantReset       bool
-		wantCancel      bool
+		name             string
+		status           activitypb.ActivityExecutionStatus
+		resetShouldPause bool
+		wantPaused       bool
+		wantReset        bool
+		wantCancel       bool
 	}{
 		{
 			name:   "no pause or reset returns zero flags",
@@ -750,10 +750,10 @@ func TestRecordHeartbeatPauseResetCancelFlags(t *testing.T) {
 			wantPaused: true,
 		},
 		{
-			name:            "reset with keep-paused propagates only reset",
-			status:          activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
-			resetKeepPaused: true,
-			wantReset:       true,
+			name:             "reset with keep-paused propagates only reset",
+			status:           activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
+			resetShouldPause: true,
+			wantReset:        true,
 		},
 		{
 			name:       "cancel requested status propagates CancelRequested",
@@ -781,7 +781,7 @@ func TestRecordHeartbeatPauseResetCancelFlags(t *testing.T) {
 				ActivityState: &activitypb.ActivityState{
 					Status:           tc.status,
 					HeartbeatTimeout: durationpb.New(0),
-					ResetKeepPaused:  tc.resetKeepPaused,
+					ResetShouldPause: tc.resetShouldPause,
 				},
 				LastAttempt: chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{Count: attempt}),
 			}

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 	apiactivitypb "go.temporal.io/api/activity/v1" //nolint:importas
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
 	sdkpb "go.temporal.io/api/sdk/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
@@ -28,6 +30,58 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+func TestTryRescheduleRetryStatePrecedence(t *testing.T) {
+	testCases := []struct {
+		name        string
+		status      activitypb.ActivityExecutionStatus
+		retryPolicy *commonpb.RetryPolicy
+		expected    enumspb.RetryState
+	}{
+		{
+			name:     "retry policy not set",
+			status:   activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
+			expected: enumspb.RETRY_STATE_RETRY_POLICY_NOT_SET,
+		},
+		{
+			name:     "retry policy not set takes precedence over cancellation",
+			status:   activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
+			expected: enumspb.RETRY_STATE_RETRY_POLICY_NOT_SET,
+		},
+		{
+			name:        "cancellation requested",
+			status:      activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
+			retryPolicy: defaultRetryPolicy,
+			expected:    enumspb.RETRY_STATE_CANCEL_REQUESTED,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := &chasm.MockMutableContext{
+				MockContext: chasm.MockContext{
+					HandleNow: func(chasm.Component) time.Time {
+						return defaultTime.Add(2 * time.Second)
+					},
+				},
+			}
+			activity := &Activity{
+				ActivityState: &activitypb.ActivityState{
+					Status:                 tc.status,
+					RetryPolicy:            tc.retryPolicy,
+					ScheduleTime:           timestamppb.New(defaultTime),
+					ScheduleToCloseTimeout: durationpb.New(time.Second),
+				},
+				LastAttempt: chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{Count: 1}),
+			}
+
+			retryState, err := activity.tryReschedule(ctx, false, 0, &failurepb.Failure{})
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, retryState)
+		})
+	}
+}
 
 func TestSearchAttributesIncludesExecutionTime(t *testing.T) {
 	testTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)

--- a/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
@@ -1234,7 +1234,7 @@ var File_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto protor
 
 const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawDesc = "" +
 	"\n" +
-	"@temporal/server/chasm/lib/activity/proto/v1/activity_state.proto\x12+temporal.server.chasm.lib.activity.proto.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&temporal/api/activity/v1/message.proto\x1a$temporal/api/common/v1/message.proto\x1a(temporal/api/deployment/v1/message.proto\x1a%temporal/api/failure/v1/message.proto\x1a'temporal/api/sdk/v1/user_metadata.proto\x1a'temporal/api/taskqueue/v1/message.proto\"\xf6\f\n" +
+	"@temporal/server/chasm/lib/activity/proto/v1/activity_state.proto\x12+temporal.server.chasm.lib.activity.proto.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&temporal/api/activity/v1/message.proto\x1a$temporal/api/common/v1/message.proto\x1a(temporal/api/deployment/v1/message.proto\x1a$temporal/api/enums/v1/workflow.proto\x1a%temporal/api/failure/v1/message.proto\x1a'temporal/api/sdk/v1/user_metadata.proto\x1a'temporal/api/taskqueue/v1/message.proto\"\xf6\f\n" +
 	"\rActivityState\x12I\n" +
 	"\ractivity_type\x18\x01 \x01(\v2$.temporal.api.common.v1.ActivityTypeR\factivityType\x12C\n" +
 	"\n" +

--- a/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
@@ -15,7 +15,8 @@ import (
 	v12 "go.temporal.io/api/activity/v1"
 	v1 "go.temporal.io/api/common/v1"
 	v13 "go.temporal.io/api/deployment/v1"
-	v15 "go.temporal.io/api/failure/v1"
+	v15 "go.temporal.io/api/enums/v1"
+	v16 "go.temporal.io/api/failure/v1"
 	v14 "go.temporal.io/api/sdk/v1"
 	v11 "go.temporal.io/api/taskqueue/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
@@ -1000,7 +1001,9 @@ type ActivityOutcome struct {
 	//
 	//	*ActivityOutcome_Successful_
 	//	*ActivityOutcome_Failed_
-	Variant       isActivityOutcome_Variant `protobuf_oneof:"variant"`
+	Variant isActivityOutcome_Variant `protobuf_oneof:"variant"`
+	// The retry state associated with an unsuccessful activity execution.
+	RetryState    v15.RetryState `protobuf:"varint,3,opt,name=retry_state,json=retryState,proto3,enum=temporal.api.enums.v1.RetryState" json:"retry_state,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1060,6 +1063,13 @@ func (x *ActivityOutcome) GetFailed() *ActivityOutcome_Failed {
 	return nil
 }
 
+func (x *ActivityOutcome) GetRetryState() v15.RetryState {
+	if x != nil {
+		return x.RetryState
+	}
+	return v15.RetryState(0)
+}
+
 type isActivityOutcome_Variant interface {
 	isActivityOutcome_Variant()
 }
@@ -1081,7 +1091,7 @@ type ActivityAttemptState_LastFailureDetails struct {
 	// The last time the activity attempt failed.
 	Time *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=time,proto3" json:"time,omitempty"`
 	// Failure details from the last failed attempt.
-	Failure       *v15.Failure `protobuf:"bytes,2,opt,name=failure,proto3" json:"failure,omitempty"`
+	Failure       *v16.Failure `protobuf:"bytes,2,opt,name=failure,proto3" json:"failure,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1123,7 +1133,7 @@ func (x *ActivityAttemptState_LastFailureDetails) GetTime() *timestamppb.Timesta
 	return nil
 }
 
-func (x *ActivityAttemptState_LastFailureDetails) GetFailure() *v15.Failure {
+func (x *ActivityAttemptState_LastFailureDetails) GetFailure() *v16.Failure {
 	if x != nil {
 		return x.Failure
 	}
@@ -1178,7 +1188,7 @@ type ActivityOutcome_Failed struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Only filled on schedule-to-start timeouts, schedule-to-close timeouts or terminations. All other attempt
 	// failures will be recorded in ActivityAttemptState.last_failure_details.
-	Failure       *v15.Failure `protobuf:"bytes,1,opt,name=failure,proto3" json:"failure,omitempty"`
+	Failure       *v16.Failure `protobuf:"bytes,1,opt,name=failure,proto3" json:"failure,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1213,7 +1223,7 @@ func (*ActivityOutcome_Failed) Descriptor() ([]byte, []int) {
 	return file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawDescGZIP(), []int{7, 1}
 }
 
-func (x *ActivityOutcome_Failed) GetFailure() *v15.Failure {
+func (x *ActivityOutcome_Failed) GetFailure() *v16.Failure {
 	if x != nil {
 		return x.Failure
 	}
@@ -1294,12 +1304,14 @@ const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawD
 	"\x13ActivityRequestData\x126\n" +
 	"\x05input\x18\x01 \x01(\v2 .temporal.api.common.v1.PayloadsR\x05input\x126\n" +
 	"\x06header\x18\x02 \x01(\v2\x1e.temporal.api.common.v1.HeaderR\x06header\x12J\n" +
-	"\ruser_metadata\x18\x03 \x01(\v2!.temporal.api.sdk.v1.UserMetadataB\x02\x18\x01R\fuserMetadata\"\xf4\x02\n" +
+	"\ruser_metadata\x18\x03 \x01(\v2!.temporal.api.sdk.v1.UserMetadataB\x02\x18\x01R\fuserMetadata\"\xb8\x03\n" +
 	"\x0fActivityOutcome\x12i\n" +
 	"\n" +
 	"successful\x18\x01 \x01(\v2G.temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.SuccessfulH\x00R\n" +
 	"successful\x12]\n" +
-	"\x06failed\x18\x02 \x01(\v2C.temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.FailedH\x00R\x06failed\x1aF\n" +
+	"\x06failed\x18\x02 \x01(\v2C.temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.FailedH\x00R\x06failed\x12B\n" +
+	"\vretry_state\x18\x03 \x01(\x0e2!.temporal.api.enums.v1.RetryStateR\n" +
+	"retryState\x1aF\n" +
 	"\n" +
 	"Successful\x128\n" +
 	"\x06output\x18\x01 \x01(\v2 .temporal.api.common.v1.PayloadsR\x06output\x1aD\n" +
@@ -1364,7 +1376,8 @@ var file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_goType
 	(*v1.Payloads)(nil),                             // 21: temporal.api.common.v1.Payloads
 	(*v1.Header)(nil),                               // 22: temporal.api.common.v1.Header
 	(*v14.UserMetadata)(nil),                        // 23: temporal.api.sdk.v1.UserMetadata
-	(*v15.Failure)(nil),                             // 24: temporal.api.failure.v1.Failure
+	(v15.RetryState)(0),                             // 24: temporal.api.enums.v1.RetryState
+	(*v16.Failure)(nil),                             // 25: temporal.api.failure.v1.Failure
 }
 var file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_depIdxs = []int32{
 	13, // 0: temporal.server.chasm.lib.activity.proto.v1.ActivityState.activity_type:type_name -> temporal.api.common.v1.ActivityType
@@ -1399,15 +1412,16 @@ var file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_depIdx
 	23, // 29: temporal.server.chasm.lib.activity.proto.v1.ActivityRequestData.user_metadata:type_name -> temporal.api.sdk.v1.UserMetadata
 	11, // 30: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.successful:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Successful
 	12, // 31: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.failed:type_name -> temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Failed
-	17, // 32: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.LastFailureDetails.time:type_name -> google.protobuf.Timestamp
-	24, // 33: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.LastFailureDetails.failure:type_name -> temporal.api.failure.v1.Failure
-	21, // 34: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Successful.output:type_name -> temporal.api.common.v1.Payloads
-	24, // 35: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Failed.failure:type_name -> temporal.api.failure.v1.Failure
-	36, // [36:36] is the sub-list for method output_type
-	36, // [36:36] is the sub-list for method input_type
-	36, // [36:36] is the sub-list for extension type_name
-	36, // [36:36] is the sub-list for extension extendee
-	0,  // [0:36] is the sub-list for field type_name
+	24, // 32: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.retry_state:type_name -> temporal.api.enums.v1.RetryState
+	17, // 33: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.LastFailureDetails.time:type_name -> google.protobuf.Timestamp
+	25, // 34: temporal.server.chasm.lib.activity.proto.v1.ActivityAttemptState.LastFailureDetails.failure:type_name -> temporal.api.failure.v1.Failure
+	21, // 35: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Successful.output:type_name -> temporal.api.common.v1.Payloads
+	25, // 36: temporal.server.chasm.lib.activity.proto.v1.ActivityOutcome.Failed.failure:type_name -> temporal.api.failure.v1.Failure
+	37, // [37:37] is the sub-list for method output_type
+	37, // [37:37] is the sub-list for method input_type
+	37, // [37:37] is the sub-list for extension type_name
+	37, // [37:37] is the sub-list for extension extendee
+	0,  // [0:37] is the sub-list for field type_name
 }
 
 func init() { file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_init() }

--- a/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
@@ -295,7 +295,7 @@ type ActivityState struct {
 	// Set when a reset is requested with keep_paused=true on a paused (PAUSE_REQUESTED) activity, so
 	// that when the worker yields the activity lands back in PAUSED rather than SCHEDULED. Consumed
 	// when the activity transitions out of RESET_REQUESTED.
-	ResetKeepPaused bool `protobuf:"varint,18,opt,name=reset_keep_paused,json=resetKeepPaused,proto3" json:"reset_keep_paused,omitempty"`
+	ResetShouldPause bool `protobuf:"varint,18,opt,name=reset_should_pause,json=resetShouldPause,proto3" json:"reset_should_pause,omitempty"`
 	// Time at which a worker first picked up the activity (the first attempt's started time). Set
 	// once on the first SCHEDULED->STARTED transition and never updated thereafter, so it survives
 	// retries and resets. Used as the discriminator for whether start_delay still applies on
@@ -460,9 +460,9 @@ func (x *ActivityState) GetLastPauseState() *ActivityPauseState {
 	return nil
 }
 
-func (x *ActivityState) GetResetKeepPaused() bool {
+func (x *ActivityState) GetResetShouldPause() bool {
 	if x != nil {
-		return x.ResetKeepPaused
+		return x.ResetShouldPause
 	}
 	return false
 }
@@ -1234,7 +1234,7 @@ var File_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto protor
 
 const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawDesc = "" +
 	"\n" +
-	"@temporal/server/chasm/lib/activity/proto/v1/activity_state.proto\x12+temporal.server.chasm.lib.activity.proto.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&temporal/api/activity/v1/message.proto\x1a$temporal/api/common/v1/message.proto\x1a(temporal/api/deployment/v1/message.proto\x1a$temporal/api/enums/v1/workflow.proto\x1a%temporal/api/failure/v1/message.proto\x1a'temporal/api/sdk/v1/user_metadata.proto\x1a'temporal/api/taskqueue/v1/message.proto\"\xf6\f\n" +
+	"@temporal/server/chasm/lib/activity/proto/v1/activity_state.proto\x12+temporal.server.chasm.lib.activity.proto.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&temporal/api/activity/v1/message.proto\x1a$temporal/api/common/v1/message.proto\x1a(temporal/api/deployment/v1/message.proto\x1a$temporal/api/enums/v1/workflow.proto\x1a%temporal/api/failure/v1/message.proto\x1a'temporal/api/sdk/v1/user_metadata.proto\x1a'temporal/api/taskqueue/v1/message.proto\"\xf8\f\n" +
 	"\rActivityState\x12I\n" +
 	"\ractivity_type\x18\x01 \x01(\v2$.temporal.api.common.v1.ActivityTypeR\factivityType\x12C\n" +
 	"\n" +
@@ -1254,8 +1254,8 @@ const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawD
 	"startDelay\x12T\n" +
 	"\x10original_options\x18\x0e \x01(\v2).temporal.api.activity.v1.ActivityOptionsR\x0foriginalOptions\x125\n" +
 	"\x17schedule_to_close_stamp\x18\x0f \x01(\x05R\x14scheduleToCloseStamp\x12i\n" +
-	"\x10last_pause_state\x18\x10 \x01(\v2?.temporal.server.chasm.lib.activity.proto.v1.ActivityPauseStateR\x0elastPauseState\x12*\n" +
-	"\x11reset_keep_paused\x18\x12 \x01(\bR\x0fresetKeepPaused\x12W\n" +
+	"\x10last_pause_state\x18\x10 \x01(\v2?.temporal.server.chasm.lib.activity.proto.v1.ActivityPauseStateR\x0elastPauseState\x12,\n" +
+	"\x12reset_should_pause\x18\x12 \x01(\bR\x10resetShouldPause\x12W\n" +
 	"\x1afirst_attempt_started_time\x18\x13 \x01(\v2\x1a.google.protobuf.TimestampR\x17firstAttemptStartedTime\x122\n" +
 	"\x15reset_restore_options\x18\x14 \x01(\bR\x13resetRestoreOptions\x125\n" +
 	"\x17last_unpause_request_id\x18\x15 \x01(\tR\x14lastUnpauseRequestId\x121\n" +

--- a/chasm/lib/activity/proto/v1/activity_state.proto
+++ b/chasm/lib/activity/proto/v1/activity_state.proto
@@ -131,7 +131,7 @@ message ActivityState {
   // Set when a reset is requested with keep_paused=true on a paused (PAUSE_REQUESTED) activity, so
   // that when the worker yields the activity lands back in PAUSED rather than SCHEDULED. Consumed
   // when the activity transitions out of RESET_REQUESTED.
-  bool reset_keep_paused = 18;
+  bool reset_should_pause = 18;
 
   // Time at which a worker first picked up the activity (the first attempt's started time). Set
   // once on the first SCHEDULED->STARTED transition and never updated thereafter, so it survives

--- a/chasm/lib/activity/proto/v1/activity_state.proto
+++ b/chasm/lib/activity/proto/v1/activity_state.proto
@@ -7,6 +7,7 @@ import "google/protobuf/timestamp.proto";
 import "temporal/api/activity/v1/message.proto";
 import "temporal/api/common/v1/message.proto";
 import "temporal/api/deployment/v1/message.proto";
+import "temporal/api/enums/v1/workflow.proto";
 import "temporal/api/failure/v1/message.proto";
 import "temporal/api/sdk/v1/user_metadata.proto";
 import "temporal/api/taskqueue/v1/message.proto";
@@ -293,4 +294,7 @@ message ActivityOutcome {
     Successful successful = 1;
     Failed failed = 2;
   }
+
+  // The retry state associated with an unsuccessful activity execution.
+  temporal.api.enums.v1.RetryState retry_state = 3;
 }

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -541,7 +541,7 @@ var TransitionReset = chasm.NewTransition(
 )
 
 // TransitionResetRequested transitions a STARTED or PAUSE_REQUESTED activity to RESET_REQUESTED.
-// PAUSE_REQUESTED is allowed when the operator issues reset with keepPaused=true: ResetKeepPaused is
+// PAUSE_REQUESTED is allowed when the operator issues reset with keepPaused=true: ResetShouldPause is
 // set so the activity lands back in PAUSED (not SCHEDULED) when the worker yields. The worker is
 // still in charge of the activity; it will be notified via
 // ActivityReset=true on its next heartbeat response, its task token is not invalidated by this
@@ -559,7 +559,7 @@ var TransitionResetRequested = chasm.NewTransition(
 )
 
 // TransitionResetAttemptFailedToPaused transitions RESET_REQUESTED → PAUSED. It is performed
-// when the worker yields in RESET_REQUESTED with ResetKeepPaused set (i.e. reset was issued with
+// when the worker yields in RESET_REQUESTED with ResetShouldPause set (i.e. reset was issued with
 // keepPaused=true while the activity was in PAUSE_REQUESTED). The failed attempt is recorded, the
 // attempt count is reset to 1, and no dispatch task is emitted — the activity stays paused until
 // an explicit unpause.
@@ -570,7 +570,7 @@ var TransitionResetAttemptFailedToPaused = chasm.NewTransition(
 	activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED,
 	func(a *Activity, ctx chasm.MutableContext, event rescheduleEvent) error {
 		attempt := a.LastAttempt.Get(ctx)
-		a.ResetKeepPaused = false
+		a.ResetShouldPause = false
 		a.applyDeferredOptionRestore(ctx)
 		a.clearHeartbeatDetails(ctx)
 		attempt.Count = 1
@@ -599,7 +599,7 @@ var TransitionResetAttemptFailedToScheduled = chasm.NewTransition(
 		attempt := a.LastAttempt.Get(ctx)
 		currentTime := ctx.Now(a)
 
-		a.ResetKeepPaused = false
+		a.ResetShouldPause = false
 		a.applyDeferredOptionRestore(ctx)
 		a.clearHeartbeatDetails(ctx)
 

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -231,6 +231,7 @@ var TransitionCompleted = chasm.NewTransition(
 
 type failedEvent struct {
 	req             *historyservice.RespondActivityTaskFailedRequest
+	retryState      enumspb.RetryState
 	baseHandler     metrics.Handler
 	enrichedHandler metrics.Handler
 }
@@ -247,6 +248,7 @@ var TransitionFailed = chasm.NewTransition(
 	func(a *Activity, ctx chasm.MutableContext, event failedEvent) error {
 		return a.StoreOrSelf(ctx).RecordCompleted(ctx, func(ctx chasm.MutableContext) error {
 			req := event.req.GetFailedRequest()
+			a.Outcome.Get(ctx).RetryState = event.retryState
 
 			attempt := a.LastAttempt.Get(ctx)
 			attempt.LastWorkerIdentity = req.GetIdentity()
@@ -387,6 +389,7 @@ var TransitionTimedOut = chasm.NewTransition(
 		timeoutType := event.timeoutType
 
 		return a.StoreOrSelf(ctx).RecordCompleted(ctx, func(ctx chasm.MutableContext) error {
+			a.Outcome.Get(ctx).RetryState = event.retryState
 			priorAttemptFailure := a.LastAttempt.Get(ctx).GetLastFailureDetails().GetFailure()
 			var err error
 			switch timeoutType {
@@ -414,7 +417,11 @@ var TransitionTimedOut = chasm.NewTransition(
 			if err != nil {
 				return err
 			}
-			if event.retryState == enumspb.RETRY_STATE_TIMEOUT {
+
+			retryPreventedByScheduleToClose := event.retryState == enumspb.RETRY_STATE_TIMEOUT &&
+				(timeoutType == enumspb.TIMEOUT_TYPE_START_TO_CLOSE ||
+					timeoutType == enumspb.TIMEOUT_TYPE_HEARTBEAT)
+			if retryPreventedByScheduleToClose {
 				if err := a.recordScheduleToStartOrCloseTimeoutFailure(
 					ctx,
 					enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -2,6 +2,7 @@ package activity
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/activity/gen/activitypb/v1"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/payloads"
@@ -484,8 +486,14 @@ func TestTransitionTimedout(t *testing.T) {
 			counterTaskTimeout.EXPECT().Record(int64(1), timeoutTag).Times(1)
 			metricsHandler.EXPECT().Counter(metrics.ActivityTaskTimeout.Name()).Return(counterTaskTimeout)
 
+			retryState := enumspb.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED
+			if tc.timeoutType == enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START ||
+				tc.timeoutType == enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE {
+				retryState = enumspb.RETRY_STATE_TIMEOUT
+			}
 			event := timeoutEvent{
 				timeoutType:    tc.timeoutType,
+				retryState:     retryState,
 				metricsHandler: metricsHandler,
 			}
 
@@ -502,6 +510,8 @@ func TestTransitionTimedout(t *testing.T) {
 				require.Nil(t, attemptState.GetCompleteTime())
 				outcomeFailure := outcome.GetFailed().GetFailure()
 				require.NotNil(t, outcomeFailure)
+				require.Equal(t, tc.timeoutType, outcomeFailure.GetTimeoutFailureInfo().GetTimeoutType())
+				require.Equal(t, fmt.Sprintf(common.FailureReasonActivityTimeout, tc.timeoutType.String()), outcomeFailure.GetMessage())
 				// The last heartbeat details must be surfaced on the timeout failure so callers can
 				// inspect the activity's last reported progress.
 				protorequire.ProtoEqual(t, tc.heartbeatDetails, outcomeFailure.GetTimeoutFailureInfo().GetLastHeartbeatDetails())
@@ -523,6 +533,8 @@ func TestTransitionTimedout(t *testing.T) {
 				t.Fatalf("unexpected timeout type: %v", tc.timeoutType)
 			}
 
+			require.Equal(t, retryState, outcome.GetRetryState())
+			require.Equal(t, retryState, activity.outcome(ctx).GetRetryState())
 			require.Empty(t, ctx.Tasks)
 		})
 	}
@@ -783,6 +795,7 @@ func TestTransitionFailed(t *testing.T) {
 
 	err := TransitionFailed.Apply(activity, ctx, failedEvent{
 		req:             req,
+		retryState:      enumspb.RETRY_STATE_NON_RETRYABLE_FAILURE,
 		baseHandler:     baseHandler,
 		enrichedHandler: enrichedHandler,
 	})
@@ -795,6 +808,8 @@ func TestTransitionFailed(t *testing.T) {
 	protorequire.ProtoEqual(t, failure, attemptState.GetLastFailureDetails().GetFailure())
 	require.NotNil(t, attemptState.GetLastFailureDetails().GetTime())
 	require.Nil(t, outcome.GetFailed())
+	require.Equal(t, enumspb.RETRY_STATE_NON_RETRYABLE_FAILURE, outcome.GetRetryState())
+	require.Equal(t, enumspb.RETRY_STATE_NON_RETRYABLE_FAILURE, activity.outcome(ctx).GetRetryState())
 }
 
 func TestTransitionTerminated(t *testing.T) {

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -1042,21 +1042,21 @@ func TestDeferredResetClearsHeartbeat(t *testing.T) {
 	testCases := []struct {
 		name              string
 		transition        chasm.Transition[activitypb.ActivityExecutionStatus, *Activity, rescheduleEvent]
-		resetKeepPaused   bool
+		resetShouldPause  bool
 		expectedStatus    activitypb.ActivityExecutionStatus
 		expectedTaskCount int
 	}{
 		{
 			name:              "scheduled",
 			transition:        TransitionResetAttemptFailedToScheduled,
-			resetKeepPaused:   false,
+			resetShouldPause:  false,
 			expectedStatus:    activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
 			expectedTaskCount: 1,
 		},
 		{
 			name:              "paused",
 			transition:        TransitionResetAttemptFailedToPaused,
-			resetKeepPaused:   true,
+			resetShouldPause:  true,
 			expectedStatus:    activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED,
 			expectedTaskCount: 0,
 		},
@@ -1086,7 +1086,7 @@ func TestDeferredResetClearsHeartbeat(t *testing.T) {
 					ScheduleTime:            timestamppb.New(defaultTime),
 					FirstAttemptStartedTime: timestamppb.New(defaultTime),
 					TaskQueue:               &taskqueuepb.TaskQueue{Name: "test-task-queue"},
-					ResetKeepPaused:         tc.resetKeepPaused,
+					ResetShouldPause:        tc.resetShouldPause,
 				},
 				LastAttempt:   chasm.NewDataField(ctx, attemptState),
 				LastHeartbeat: chasm.NewDataField(ctx, heartbeatState),

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -388,6 +388,7 @@ func TestTransitionTimedout(t *testing.T) {
 		name             string
 		startStatus      activitypb.ActivityExecutionStatus
 		timeoutType      enumspb.TimeoutType
+		retryState       enumspb.RetryState
 		attemptCount     int32
 		heartbeatDetails *commonpb.Payloads
 	}{
@@ -395,18 +396,21 @@ func TestTransitionTimedout(t *testing.T) {
 			name:         "schedule to start timeout, never started",
 			startStatus:  activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
 			timeoutType:  enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START,
+			retryState:   enumspb.RETRY_STATE_TIMEOUT,
 			attemptCount: 1,
 		},
 		{
 			name:         "schedule to close timeout from scheduled, never started",
 			startStatus:  activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
 			timeoutType:  enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+			retryState:   enumspb.RETRY_STATE_TIMEOUT,
 			attemptCount: 1,
 		},
 		{
 			name:             "schedule to close timeout from started status with heartbeat details",
 			startStatus:      activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
 			timeoutType:      enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+			retryState:       enumspb.RETRY_STATE_TIMEOUT,
 			attemptCount:     4,
 			heartbeatDetails: payloads.EncodeString("schedule-to-close-heartbeat"),
 		},
@@ -414,6 +418,7 @@ func TestTransitionTimedout(t *testing.T) {
 			name:             "start to close timeout with heartbeat details",
 			startStatus:      activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
 			timeoutType:      enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
+			retryState:       enumspb.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED,
 			attemptCount:     5,
 			heartbeatDetails: payloads.EncodeString("start-to-close-heartbeat"),
 		},
@@ -421,6 +426,7 @@ func TestTransitionTimedout(t *testing.T) {
 			name:             "heartbeat timeout with heartbeat details",
 			startStatus:      activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
 			timeoutType:      enumspb.TIMEOUT_TYPE_HEARTBEAT,
+			retryState:       enumspb.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED,
 			attemptCount:     2,
 			heartbeatDetails: payloads.EncodeString("heartbeat-details"),
 		},
@@ -428,18 +434,21 @@ func TestTransitionTimedout(t *testing.T) {
 			name:         "heartbeat timeout without heartbeat details",
 			startStatus:  activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
 			timeoutType:  enumspb.TIMEOUT_TYPE_HEARTBEAT,
+			retryState:   enumspb.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED,
 			attemptCount: 2,
 		},
 		{
 			name:         "schedule to close timeout from started status",
 			startStatus:  activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
 			timeoutType:  enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+			retryState:   enumspb.RETRY_STATE_TIMEOUT,
 			attemptCount: 4,
 		},
 		{
 			name:         "start to close timeout",
 			startStatus:  activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
 			timeoutType:  enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
+			retryState:   enumspb.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED,
 			attemptCount: 5,
 		},
 	}
@@ -486,14 +495,9 @@ func TestTransitionTimedout(t *testing.T) {
 			counterTaskTimeout.EXPECT().Record(int64(1), timeoutTag).Times(1)
 			metricsHandler.EXPECT().Counter(metrics.ActivityTaskTimeout.Name()).Return(counterTaskTimeout)
 
-			retryState := enumspb.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED
-			if tc.timeoutType == enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START ||
-				tc.timeoutType == enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE {
-				retryState = enumspb.RETRY_STATE_TIMEOUT
-			}
 			event := timeoutEvent{
 				timeoutType:    tc.timeoutType,
-				retryState:     retryState,
+				retryState:     tc.retryState,
 				metricsHandler: metricsHandler,
 			}
 
@@ -533,8 +537,8 @@ func TestTransitionTimedout(t *testing.T) {
 				t.Fatalf("unexpected timeout type: %v", tc.timeoutType)
 			}
 
-			require.Equal(t, retryState, outcome.GetRetryState())
-			require.Equal(t, retryState, activity.outcome(ctx).GetRetryState())
+			require.Equal(t, tc.retryState, outcome.GetRetryState())
+			require.Equal(t, tc.retryState, activity.outcome(ctx).GetRetryState())
 			require.Empty(t, ctx.Tasks)
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.44.0
-	go.temporal.io/api v1.63.5-0.20260730203810-e7387ebd980e
+	go.temporal.io/api v1.63.5-0.20260731164320-beafdd4b0d8f
 	go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee
 	go.temporal.io/sdk v1.44.0
 	go.uber.org/fx v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -479,8 +479,8 @@ go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0 h1:R
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0/go.mod h1:I89cynRj8y+383o7tEQVg2SVA6SRgDVIouWPUVXjx0U=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0 h1:CQvJSldHRUN6Z8jsUeYv8J0lXRvygALXIzsmAeCcZE0=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0/go.mod h1:xSQ+mEfJe/GjK1LXEyVOoSI1N9JV9ZI923X5kup43W4=
-go.temporal.io/api v1.63.5-0.20260730203810-e7387ebd980e h1:kUL8YTxElWLVqorcA26Kr7xujAk7B1lPedl/x9Q7Gx4=
-go.temporal.io/api v1.63.5-0.20260730203810-e7387ebd980e/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
+go.temporal.io/api v1.63.5-0.20260731164320-beafdd4b0d8f h1:n/cM2e930fSKURv5NSlvx0LaXEpyQY06Uo5MizOKYhU=
+go.temporal.io/api v1.63.5-0.20260731164320-beafdd4b0d8f/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
 go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee h1:y6A65Iml06cR3CpxW2Zn8FQLjniPDTnN4jtr69UZxXI=
 go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee/go.mod h1:hhHijO9XRPIkAflLJJHix61M9FzbRPqk8fSydkcLkqw=
 go.temporal.io/sdk v1.44.0 h1:suitPDukX74rW3/N1FqvEbZTZVJJsxMKhv0KMa/j7pU=

--- a/tests/activity_driver.go
+++ b/tests/activity_driver.go
@@ -283,17 +283,15 @@ func driveActivityEvent(t testing.TB, a drivenActivity, e model.Event) {
 // does not within (window + margin).
 func awaitActivityTimeout(t testing.TB, a drivenActivity, e model.Event, deadline time.Time) {
 	state := a.driverState()
+	want := timeoutType(e)
+	var got activityTimeoutInfo
 	await.Require(state.ctx, t, func(t *await.T) {
-		got := a.timeoutInfo(t)
-		t.Require().Truef(got.reportsTimeout(e, state.startedAttempt),
-			"%s: activity reports timeout %s at attempt %d (terminal=%v) after timeout event %s on attempt %d",
-			e, got.timeout, got.attempt, got.terminal, timeoutType(e), state.startedAttempt)
+		got = a.timeoutInfo(t)
+		fired := got.timeout == want && (got.terminal || got.attempt > state.startedAttempt)
+		t.Require().Truef(fired,
+			"%s: activity reports timeout %s at attempt %d (terminal=%v), want %s after attempt %d",
+			e, got.timeout, got.attempt, got.terminal, want, state.startedAttempt)
 	}, max(0, time.Until(deadline)), activityDriverPollInterval)
-}
-
-func (i activityTimeoutInfo) reportsTimeout(e model.Event, startedAttempt int32) bool {
-	attemptEnded := i.terminal || i.attempt > startedAttempt
-	return i.timeout == timeoutType(e) && attemptEnded
 }
 
 // awaitActivityDispatchDelay waits until the server no longer reports a future dispatch deadline.

--- a/tests/activity_driver.go
+++ b/tests/activity_driver.go
@@ -137,6 +137,13 @@ type activityInfo struct {
 	LastHeartbeatDetails       []byte
 }
 
+// activityTerminalOutcome is user-visible terminal activity state projected from SAA's
+// ActivityExecutionOutcome and WFA's workflow result.
+type activityTerminalOutcome struct {
+	status     enumspb.ActivityExecutionStatus
+	retryState enumspb.RetryState
+}
+
 // activityDriverTimeout bounds a wait for something the server should do promptly: dispatch a task to
 // poll for, schedule the activity a workflow owns, close an activity the trace has finished with. A
 // wait for a configured window is bounded by that window plus activityDriverTimerMargin instead.
@@ -276,14 +283,22 @@ func driveActivityEvent(t testing.TB, a drivenActivity, e model.Event) {
 // does not within (window + margin).
 func awaitActivityTimeout(t testing.TB, a drivenActivity, e model.Event, deadline time.Time) {
 	state := a.driverState()
-	want := timeoutType(e)
-	var got activityTimeoutInfo
+	eventTimeoutType := timeoutType(e)
+	var reported activityTimeoutInfo
 	await.Require(state.ctx, t, func(t *await.T) {
-		got = a.timeoutInfo(t)
-		fired := got.timeout == want && (got.terminal || got.attempt > state.startedAttempt)
-		t.Require().Truef(fired,
-			"%s: activity reports timeout %s at attempt %d (terminal=%v), want %s after attempt %d",
-			e, got.timeout, got.attempt, got.terminal, want, state.startedAttempt)
+		reported = a.timeoutInfo(t)
+		// A terminal attempt timeout is reported as schedule-to-close when there is not enough
+		// time remaining to schedule another attempt.
+		attemptTimeoutReportedAsScheduleToClose := reported.terminal &&
+			reported.timeout == enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE &&
+			(eventTimeoutType == enumspb.TIMEOUT_TYPE_START_TO_CLOSE ||
+				eventTimeoutType == enumspb.TIMEOUT_TYPE_HEARTBEAT)
+		timeoutEventObserved := reported.timeout == eventTimeoutType ||
+			attemptTimeoutReportedAsScheduleToClose
+		attemptEnded := reported.terminal || reported.attempt > state.startedAttempt
+		t.Require().Truef(timeoutEventObserved && attemptEnded,
+			"%s: activity reports timeout %s at attempt %d (terminal=%v) after timeout event %s on attempt %d",
+			e, reported.timeout, reported.attempt, reported.terminal, eventTimeoutType, state.startedAttempt)
 	}, max(0, time.Until(deadline)), activityDriverPollInterval)
 }
 

--- a/tests/activity_driver.go
+++ b/tests/activity_driver.go
@@ -283,23 +283,17 @@ func driveActivityEvent(t testing.TB, a drivenActivity, e model.Event) {
 // does not within (window + margin).
 func awaitActivityTimeout(t testing.TB, a drivenActivity, e model.Event, deadline time.Time) {
 	state := a.driverState()
-	eventTimeoutType := timeoutType(e)
-	var reported activityTimeoutInfo
 	await.Require(state.ctx, t, func(t *await.T) {
-		reported = a.timeoutInfo(t)
-		// A terminal attempt timeout is reported as schedule-to-close when there is not enough
-		// time remaining to schedule another attempt.
-		attemptTimeoutReportedAsScheduleToClose := reported.terminal &&
-			reported.timeout == enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE &&
-			(eventTimeoutType == enumspb.TIMEOUT_TYPE_START_TO_CLOSE ||
-				eventTimeoutType == enumspb.TIMEOUT_TYPE_HEARTBEAT)
-		timeoutEventObserved := reported.timeout == eventTimeoutType ||
-			attemptTimeoutReportedAsScheduleToClose
-		attemptEnded := reported.terminal || reported.attempt > state.startedAttempt
-		t.Require().Truef(timeoutEventObserved && attemptEnded,
+		got := a.timeoutInfo(t)
+		t.Require().Truef(got.reportsTimeout(e, state.startedAttempt),
 			"%s: activity reports timeout %s at attempt %d (terminal=%v) after timeout event %s on attempt %d",
-			e, reported.timeout, reported.attempt, reported.terminal, eventTimeoutType, state.startedAttempt)
+			e, got.timeout, got.attempt, got.terminal, timeoutType(e), state.startedAttempt)
 	}, max(0, time.Until(deadline)), activityDriverPollInterval)
+}
+
+func (i activityTimeoutInfo) reportsTimeout(e model.Event, startedAttempt int32) bool {
+	attemptEnded := i.terminal || i.attempt > startedAttempt
+	return i.timeout == timeoutType(e) && attemptEnded
 }
 
 // awaitActivityDispatchDelay waits until the server no longer reports a future dispatch deadline.

--- a/tests/activity_driver_test.go
+++ b/tests/activity_driver_test.go
@@ -12,6 +12,52 @@ import (
 	"go.temporal.io/server/common/testing/await"
 )
 
+func TestActivityTimeoutInfoReportsTimeout(t *testing.T) {
+	testCases := []struct {
+		name           string
+		info           activityTimeoutInfo
+		event          model.Event
+		startedAttempt int32
+		expected       bool
+	}{
+		{
+			name:     "terminal exact timeout",
+			info:     activityTimeoutInfo{timeout: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, terminal: true},
+			event:    model.ScheduleToCloseElapses,
+			expected: true,
+		},
+		{
+			name:           "retry advanced beyond started attempt",
+			info:           activityTimeoutInfo{timeout: enumspb.TIMEOUT_TYPE_START_TO_CLOSE, attempt: 2},
+			event:          model.StartToCloseElapses,
+			startedAttempt: 1,
+			expected:       true,
+		},
+		{
+			name:           "timeout has not ended started attempt",
+			info:           activityTimeoutInfo{timeout: enumspb.TIMEOUT_TYPE_START_TO_CLOSE, attempt: 1},
+			event:          model.StartToCloseElapses,
+			startedAttempt: 1,
+		},
+		{
+			name:  "terminal schedule-to-close does not report start-to-close",
+			info:  activityTimeoutInfo{timeout: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, terminal: true},
+			event: model.StartToCloseElapses,
+		},
+		{
+			name:  "terminal schedule-to-close does not report heartbeat",
+			info:  activityTimeoutInfo{timeout: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, terminal: true},
+			event: model.HeartbeatElapses,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.info.reportsTimeout(tc.event, tc.startedAttempt))
+		})
+	}
+}
+
 // TestDriversRecognizeTimeoutObservedBeforeWait reproduces a race in awaitTimeout: a retryable timeout
 // may fire after Poll returns but before awaitTimeout takes its first observation. The timeout has
 // already rescheduled attempt 2 by then, and the driver must recognize it rather than wait for a

--- a/tests/activity_driver_test.go
+++ b/tests/activity_driver_test.go
@@ -12,52 +12,6 @@ import (
 	"go.temporal.io/server/common/testing/await"
 )
 
-func TestActivityTimeoutInfoReportsTimeout(t *testing.T) {
-	testCases := []struct {
-		name           string
-		info           activityTimeoutInfo
-		event          model.Event
-		startedAttempt int32
-		expected       bool
-	}{
-		{
-			name:     "terminal exact timeout",
-			info:     activityTimeoutInfo{timeout: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, terminal: true},
-			event:    model.ScheduleToCloseElapses,
-			expected: true,
-		},
-		{
-			name:           "retry advanced beyond started attempt",
-			info:           activityTimeoutInfo{timeout: enumspb.TIMEOUT_TYPE_START_TO_CLOSE, attempt: 2},
-			event:          model.StartToCloseElapses,
-			startedAttempt: 1,
-			expected:       true,
-		},
-		{
-			name:           "timeout has not ended started attempt",
-			info:           activityTimeoutInfo{timeout: enumspb.TIMEOUT_TYPE_START_TO_CLOSE, attempt: 1},
-			event:          model.StartToCloseElapses,
-			startedAttempt: 1,
-		},
-		{
-			name:  "terminal schedule-to-close does not report start-to-close",
-			info:  activityTimeoutInfo{timeout: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, terminal: true},
-			event: model.StartToCloseElapses,
-		},
-		{
-			name:  "terminal schedule-to-close does not report heartbeat",
-			info:  activityTimeoutInfo{timeout: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, terminal: true},
-			event: model.HeartbeatElapses,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expected, tc.info.reportsTimeout(tc.event, tc.startedAttempt))
-		})
-	}
-}
-
 // TestDriversRecognizeTimeoutObservedBeforeWait reproduces a race in awaitTimeout: a retryable timeout
 // may fire after Poll returns but before awaitTimeout takes its first observation. The timeout has
 // already rescheduled attempt 2 by then, and the driver must recognize it rather than wait for a

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -411,7 +411,10 @@ func (s *activityParityTestSuite) TestTerminalRetryState() {
 		trace    []model.Event
 		expected activityTerminalOutcome
 	}{
+		// Terminal status FAILED
 		{
+			// Terminal status FAILED; there were no more retries due to non-retryable failure from
+			// worker, despite a second attempt being available.
 			name:  "NonRetryableFailure",
 			cfg:   activityConfig{MaxAttempts: 2},
 			trace: []model.Event{model.Poll, model.FailNonRetryably},
@@ -421,6 +424,8 @@ func (s *activityParityTestSuite) TestTerminalRetryState() {
 			},
 		},
 		{
+			// Terminal status FAILED; there were no more retries due to retries exhausted, despite
+			// retryable failure from worker.
 			name:  "MaximumAttemptsReachedAfterFailure",
 			cfg:   activityConfig{MaxAttempts: 1},
 			trace: []model.Event{model.Poll, model.FailRetryably},
@@ -430,6 +435,9 @@ func (s *activityParityTestSuite) TestTerminalRetryState() {
 			},
 		},
 		{
+			// Terminal status FAILED; there were no more retries due to timeout: the retry backoff
+			// would run past the schedule-to-close deadline, so server times it out without
+			// waiting.
 			name: "FailureRetryPreventedByScheduleToClose",
 			cfg: activityConfig{
 				RetryInterval:   activityLongDuration,
@@ -442,6 +450,8 @@ func (s *activityParityTestSuite) TestTerminalRetryState() {
 			},
 		},
 		{
+			// Terminal status FAILED; there were no more retries due to cancel-requested; retries
+			// are also exhausted, but cancellation has precedence as the reason.
 			name:  "CancelRequestedBeforeFailure",
 			cfg:   activityConfig{MaxAttempts: 1},
 			trace: []model.Event{model.Poll, model.RequestCancel, model.FailRetryably},
@@ -450,7 +460,10 @@ func (s *activityParityTestSuite) TestTerminalRetryState() {
 				retryState: enumspb.RETRY_STATE_CANCEL_REQUESTED,
 			},
 		},
+		// Terminal status TIMED_OUT
 		{
+			// Terminal status TIMED_OUT; there were no more retries due to timeout, because no
+			// worker polled hence schedule-to-start timeout.
 			name:  "ScheduleToStartTimeout",
 			trace: []model.Event{model.ScheduleToStartElapses},
 			expected: activityTerminalOutcome{
@@ -459,6 +472,8 @@ func (s *activityParityTestSuite) TestTerminalRetryState() {
 			},
 		},
 		{
+			// Terminal status TIMED_OUT; there were no more retries due to timeout, because worker
+			// held on to attempt until schedule-to-close fired.
 			name:  "ScheduleToCloseTimeout",
 			trace: []model.Event{model.Poll, model.ScheduleToCloseElapses},
 			expected: activityTerminalOutcome{
@@ -467,6 +482,8 @@ func (s *activityParityTestSuite) TestTerminalRetryState() {
 			},
 		},
 		{
+			// Terminal status TIMED_OUT; there were no more retries due to retries exhausted,
+			// despite the start-to-close timeout being retryable.
 			name:  "MaximumAttemptsReachedAfterAttemptTimeout",
 			cfg:   activityConfig{MaxAttempts: 1},
 			trace: []model.Event{model.Poll, model.StartToCloseElapses},
@@ -476,6 +493,9 @@ func (s *activityParityTestSuite) TestTerminalRetryState() {
 			},
 		},
 		{
+			// Similar to FailureRetryPreventedByScheduleToClose, but we cause it to terminate in
+			// TIMED_OUT by letting start-to-close elapse (we can't use an explicit
+			// model.StartToCloseElapses in the trace because the two drivers see it differently)
 			name: "AttemptTimeoutRetryPreventedByScheduleToClose",
 			cfg: activityConfig{
 				RetryInterval:   activityLongDuration,
@@ -489,6 +509,9 @@ func (s *activityParityTestSuite) TestTerminalRetryState() {
 			},
 		},
 		{
+			// Terminal status TIMED_OUT; there were no more retries due to cancellation pending
+			// when the start-to-close deadline elapsed. Retries are also exhausted, but
+			// cancellation has precedence as the reason.
 			name:  "CancelRequestedBeforeAttemptTimeout",
 			cfg:   activityConfig{MaxAttempts: 1},
 			trace: []model.Event{model.Poll, model.RequestCancel, model.StartToCloseElapses},
@@ -498,6 +521,10 @@ func (s *activityParityTestSuite) TestTerminalRetryState() {
 			},
 		},
 		{
+			// Terminal status TIMED_OUT; there were no more retries due to cancellation pending
+			// when the schedule-to-close deadline elapses. No MaxAttempts is needed here, unlike
+			// the previous case (CancelRequestedBeforeAttemptTimeout): a schedule-to-close timeout
+			// closes the activity without consulting the retry policy at all.
 			name:  "CancelRequestedBeforeScheduleToCloseTimeout",
 			trace: []model.Event{model.Poll, model.RequestCancel, model.ScheduleToCloseElapses},
 			expected: activityTerminalOutcome{

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -101,14 +101,14 @@ func (s *activityParityTestSuite) TestTimeoutPreservesUnderlyingFailureCause() {
 			require.True(t, ok)
 			appErr, ok := errors.AsType[*temporal.ApplicationError](timeout.Unwrap())
 			require.True(t, ok)
-			require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT, activity.terminalStatus(t), message)
+			require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT, activity.terminalOutcome(t).status, message)
 			require.Equal(t, "TestFailure", appErr.Type(), message)
 			require.Equal(t, "test failure", appErr.Message(), message)
 		})
 		t.Run("StandaloneActivity", func(t *testing.T) {
 			activity := newSAADriver(t, env, cfg).driveTrace(t, trace)
 			cause := activity.describe(t).GetOutcome().GetFailure().GetCause()
-			require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT, activity.terminalStatus(t), message)
+			require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT, activity.terminalOutcome(t).status, message)
 			require.Equal(t, "TestFailure", cause.GetApplicationFailureInfo().GetType(), message)
 			require.Equal(t, "test failure", cause.GetMessage(), message)
 		})
@@ -362,12 +362,12 @@ func (s *activityParityTestSuite) TestCompleteByID() {
 		s.Run(tc.name, func(s *activityParityTestSuite) {
 			s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
 				t := s.T()
-				require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, newWFADriver(t, env, cfg).driveTrace(t, tc.trace).terminalStatus(t))
+				require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, newWFADriver(t, env, cfg).driveTrace(t, tc.trace).terminalOutcome(t).status)
 			})
 			s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
 				t := s.T()
 				a := newSAADriver(t, env, cfg).driveTrace(t, tc.trace)
-				require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, a.terminalStatus(t))
+				require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, a.terminalOutcome(t).status)
 				require.NotNil(t, a.describe(t).GetInfo().GetLastStartedTime(),
 					"a force-completed activity must still record a started time, even though no worker ever started it")
 			})

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -59,13 +59,17 @@ func (s *activityParityTestSuite) TestNonRetryableErrorTypes() {
 		}
 
 		t.Run("WorkflowActivity", func(t *testing.T) {
-			require.Equalf(t, enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT,
-				newWFADriver(t, env, cfg).driveTrace(t, trace).terminalStatus(t),
+			require.Equalf(t, activityTerminalOutcome{
+				status:     enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT,
+				retryState: enumspb.RETRY_STATE_NON_RETRYABLE_FAILURE,
+			}, newWFADriver(t, env, cfg).driveTrace(t, trace).terminalOutcome(t),
 				"a %s timeout marked non-retryable must fail the activity terminally, not retry it", timeoutType(timeout))
 		})
 		t.Run("StandaloneActivity", func(t *testing.T) {
-			require.Equalf(t, enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT,
-				newSAADriver(t, env, cfg).driveTrace(t, trace).terminalStatus(t),
+			require.Equalf(t, activityTerminalOutcome{
+				status:     enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT,
+				retryState: enumspb.RETRY_STATE_NON_RETRYABLE_FAILURE,
+			}, newSAADriver(t, env, cfg).driveTrace(t, trace).terminalOutcome(t),
 				"a %s timeout marked non-retryable must fail the activity terminally, not retry it", timeoutType(timeout))
 		})
 	}
@@ -323,16 +327,15 @@ func (s *activityParityTestSuite) TestCancel() {
 	env := newActivityParityEnv(s.T())
 	trace := []model.Event{model.Poll, model.RequestCancel, model.RespondCanceled}
 	cfg := activityConfig{MaxAttempts: 1}
+	expected := activityTerminalOutcome{status: enumspb.ACTIVITY_EXECUTION_STATUS_CANCELED}
 
 	s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
 		t := s.T()
-		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_CANCELED,
-			newWFADriver(t, env, cfg).driveTrace(t, trace).terminalStatus(t))
+		require.Equal(t, expected, newWFADriver(t, env, cfg).driveTrace(t, trace).terminalOutcome(t))
 	})
 	s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
 		t := s.T()
-		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_CANCELED,
-			newSAADriver(t, env, cfg).driveTrace(t, trace).terminalStatus(t))
+		require.Equal(t, expected, newSAADriver(t, env, cfg).driveTrace(t, trace).terminalOutcome(t))
 	})
 }
 
@@ -397,4 +400,121 @@ func (s *activityParityTestSuite) TestLastHeartbeatDetailsPersistedOnAttemptFail
 		require.Equal(t, expected,
 			d.driveTrace(t, terminal).activityInfo(t).LastHeartbeatDetails)
 	})
+}
+
+func (s *activityParityTestSuite) TestTerminalRetryState() {
+	env := newActivityParityEnv(s.T())
+
+	testCases := []struct {
+		name     string
+		cfg      activityConfig
+		trace    []model.Event
+		expected activityTerminalOutcome
+	}{
+		{
+			name:  "NonRetryableFailure",
+			cfg:   activityConfig{MaxAttempts: 2},
+			trace: []model.Event{model.Poll, model.FailNonRetryably},
+			expected: activityTerminalOutcome{
+				status:     enumspb.ACTIVITY_EXECUTION_STATUS_FAILED,
+				retryState: enumspb.RETRY_STATE_NON_RETRYABLE_FAILURE,
+			},
+		},
+		{
+			name:  "MaximumAttemptsReachedAfterFailure",
+			cfg:   activityConfig{MaxAttempts: 1},
+			trace: []model.Event{model.Poll, model.FailRetryably},
+			expected: activityTerminalOutcome{
+				status:     enumspb.ACTIVITY_EXECUTION_STATUS_FAILED,
+				retryState: enumspb.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED,
+			},
+		},
+		{
+			name: "FailureRetryPreventedByScheduleToClose",
+			cfg: activityConfig{
+				RetryInterval:   activityLongDuration,
+				ScheduleToClose: time.Hour,
+			},
+			trace: []model.Event{model.Poll, model.FailRetryably},
+			expected: activityTerminalOutcome{
+				status:     enumspb.ACTIVITY_EXECUTION_STATUS_FAILED,
+				retryState: enumspb.RETRY_STATE_TIMEOUT,
+			},
+		},
+		{
+			name:  "CancelRequestedBeforeFailure",
+			cfg:   activityConfig{MaxAttempts: 1},
+			trace: []model.Event{model.Poll, model.RequestCancel, model.FailRetryably},
+			expected: activityTerminalOutcome{
+				status:     enumspb.ACTIVITY_EXECUTION_STATUS_FAILED,
+				retryState: enumspb.RETRY_STATE_CANCEL_REQUESTED,
+			},
+		},
+		{
+			name:  "ScheduleToStartTimeout",
+			trace: []model.Event{model.ScheduleToStartElapses},
+			expected: activityTerminalOutcome{
+				status:     enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT,
+				retryState: enumspb.RETRY_STATE_TIMEOUT,
+			},
+		},
+		{
+			name:  "ScheduleToCloseTimeout",
+			trace: []model.Event{model.Poll, model.ScheduleToCloseElapses},
+			expected: activityTerminalOutcome{
+				status:     enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT,
+				retryState: enumspb.RETRY_STATE_TIMEOUT,
+			},
+		},
+		{
+			name:  "MaximumAttemptsReachedAfterAttemptTimeout",
+			cfg:   activityConfig{MaxAttempts: 1},
+			trace: []model.Event{model.Poll, model.StartToCloseElapses},
+			expected: activityTerminalOutcome{
+				status:     enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT,
+				retryState: enumspb.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED,
+			},
+		},
+		{
+			name: "AttemptTimeoutRetryPreventedByScheduleToClose",
+			cfg: activityConfig{
+				RetryInterval:   activityLongDuration,
+				ScheduleToClose: time.Hour,
+			},
+			trace: []model.Event{model.Poll, model.StartToCloseElapses},
+			expected: activityTerminalOutcome{
+				status:     enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT,
+				retryState: enumspb.RETRY_STATE_TIMEOUT,
+			},
+		},
+		{
+			name:  "CancelRequestedBeforeAttemptTimeout",
+			cfg:   activityConfig{MaxAttempts: 1},
+			trace: []model.Event{model.Poll, model.RequestCancel, model.StartToCloseElapses},
+			expected: activityTerminalOutcome{
+				status:     enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT,
+				retryState: enumspb.RETRY_STATE_CANCEL_REQUESTED,
+			},
+		},
+		{
+			name:  "CancelRequestedBeforeScheduleToCloseTimeout",
+			trace: []model.Event{model.Poll, model.RequestCancel, model.ScheduleToCloseElapses},
+			expected: activityTerminalOutcome{
+				status:     enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT,
+				retryState: enumspb.RETRY_STATE_CANCEL_REQUESTED,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func(s *activityParityTestSuite) {
+			t := s.T()
+			t.Run("WorkflowActivity", func(t *testing.T) {
+				require.Equal(t, tc.expected, newWFADriver(t, env, tc.cfg).driveTrace(t, tc.trace).terminalOutcome(t))
+			})
+			t.Run("StandaloneActivity", func(t *testing.T) {
+				require.Equal(t, tc.expected, newSAADriver(t, env, tc.cfg).driveTrace(t, tc.trace).terminalOutcome(t))
+			})
+		})
+	}
 }

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -14,7 +14,6 @@ import (
 	"go.temporal.io/server/chasm/lib/activity/model"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/retrypolicy"
-	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
 )
@@ -477,6 +476,19 @@ func (s *activityParityTestSuite) TestTerminalRetryState() {
 			},
 		},
 		{
+			name: "AttemptTimeoutRetryPreventedByScheduleToClose",
+			cfg: activityConfig{
+				RetryInterval:   activityLongDuration,
+				StartToClose:    activityShortTimeout,
+				ScheduleToClose: time.Hour,
+			},
+			trace: []model.Event{model.Poll},
+			expected: activityTerminalOutcome{
+				status:     enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT,
+				retryState: enumspb.RETRY_STATE_TIMEOUT,
+			},
+		},
+		{
 			name:  "CancelRequestedBeforeAttemptTimeout",
 			cfg:   activityConfig{MaxAttempts: 1},
 			trace: []model.Event{model.Poll, model.RequestCancel, model.StartToCloseElapses},
@@ -506,39 +518,4 @@ func (s *activityParityTestSuite) TestTerminalRetryState() {
 			})
 		})
 	}
-
-	s.Run("AttemptTimeoutRetryPreventedByScheduleToClose", func(s *activityParityTestSuite) {
-		t := s.T()
-		cfg := activityConfig{
-			RetryInterval:   activityLongDuration,
-			StartToClose:    activityShortTimeout,
-			ScheduleToClose: time.Hour,
-		}
-		expected := activityTerminalOutcome{
-			status:     enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT,
-			retryState: enumspb.RETRY_STATE_TIMEOUT,
-		}
-
-		t.Run("WorkflowActivity", func(t *testing.T) {
-			a := newWFADriver(t, env, cfg).start(t, cfg)
-			a.driveEvent(t, model.Poll)
-			// WFA reports schedule-to-close when an attempt timeout leaves too little time for a
-			// retry. The one-hour deadline ensures the schedule-to-close timer cannot be the cause.
-			await.Require(a.driverState().ctx, t, func(t *await.T) {
-				reported := a.timeoutInfo(t)
-				t.Require().Truef(
-					reported.terminal && reported.timeout == enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
-					"activity reports timeout %s at attempt %d (terminal=%v)",
-					reported.timeout,
-					reported.attempt,
-					reported.terminal,
-				)
-			}, cfg.StartToClose+activityDriverTimerMargin, activityDriverPollInterval)
-			require.Equal(t, expected, a.terminalOutcome(t))
-		})
-		t.Run("StandaloneActivity", func(t *testing.T) {
-			trace := []model.Event{model.Poll, model.StartToCloseElapses}
-			require.Equal(t, expected, newSAADriver(t, env, cfg).driveTrace(t, trace).terminalOutcome(t))
-		})
-	})
 }

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -14,6 +14,7 @@ import (
 	"go.temporal.io/server/chasm/lib/activity/model"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/retrypolicy"
+	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
 )
@@ -476,18 +477,6 @@ func (s *activityParityTestSuite) TestTerminalRetryState() {
 			},
 		},
 		{
-			name: "AttemptTimeoutRetryPreventedByScheduleToClose",
-			cfg: activityConfig{
-				RetryInterval:   activityLongDuration,
-				ScheduleToClose: time.Hour,
-			},
-			trace: []model.Event{model.Poll, model.StartToCloseElapses},
-			expected: activityTerminalOutcome{
-				status:     enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT,
-				retryState: enumspb.RETRY_STATE_TIMEOUT,
-			},
-		},
-		{
 			name:  "CancelRequestedBeforeAttemptTimeout",
 			cfg:   activityConfig{MaxAttempts: 1},
 			trace: []model.Event{model.Poll, model.RequestCancel, model.StartToCloseElapses},
@@ -517,4 +506,39 @@ func (s *activityParityTestSuite) TestTerminalRetryState() {
 			})
 		})
 	}
+
+	s.Run("AttemptTimeoutRetryPreventedByScheduleToClose", func(s *activityParityTestSuite) {
+		t := s.T()
+		cfg := activityConfig{
+			RetryInterval:   activityLongDuration,
+			StartToClose:    activityShortTimeout,
+			ScheduleToClose: time.Hour,
+		}
+		expected := activityTerminalOutcome{
+			status:     enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT,
+			retryState: enumspb.RETRY_STATE_TIMEOUT,
+		}
+
+		t.Run("WorkflowActivity", func(t *testing.T) {
+			a := newWFADriver(t, env, cfg).start(t, cfg)
+			a.driveEvent(t, model.Poll)
+			// WFA reports schedule-to-close when an attempt timeout leaves too little time for a
+			// retry. The one-hour deadline ensures the schedule-to-close timer cannot be the cause.
+			await.Require(a.driverState().ctx, t, func(t *await.T) {
+				reported := a.timeoutInfo(t)
+				t.Require().Truef(
+					reported.terminal && reported.timeout == enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+					"activity reports timeout %s at attempt %d (terminal=%v)",
+					reported.timeout,
+					reported.attempt,
+					reported.terminal,
+				)
+			}, cfg.StartToClose+activityDriverTimerMargin, activityDriverPollInterval)
+			require.Equal(t, expected, a.terminalOutcome(t))
+		})
+		t.Run("StandaloneActivity", func(t *testing.T) {
+			trace := []model.Event{model.Poll, model.StartToCloseElapses}
+			require.Equal(t, expected, newSAADriver(t, env, cfg).driveTrace(t, trace).terminalOutcome(t))
+		})
+	})
 }

--- a/tests/activity_standalone_driver.go
+++ b/tests/activity_standalone_driver.go
@@ -168,10 +168,10 @@ func (a *saaHandle) activityInfo(t require.TestingT) activityInfo {
 	return saaActivityInfo(a.describe(t).GetInfo())
 }
 
-// terminalStatus waits for the activity to reach a terminal state and reports it.
+// terminalOutcome waits for the activity to reach a terminal state and reports it.
 // PollActivityExecution resolves once the activity is no longer running. An empty response means the
 // server's long-poll window expired, so resubmit.
-func (a *saaHandle) terminalStatus(t require.TestingT) enumspb.ActivityExecutionStatus {
+func (a *saaHandle) terminalOutcome(t require.TestingT) activityTerminalOutcome {
 	deadline := time.Now().Add(activityDriverTimeout)
 	for time.Now().Before(deadline) {
 		ctx, cancel := context.WithDeadline(a.d.ctx, deadline)
@@ -188,12 +188,21 @@ func (a *saaHandle) terminalStatus(t require.TestingT) enumspb.ActivityExecution
 			break // the deadline cancelled the long poll
 		}
 		if resp.GetRunId() != "" {
-			return a.describe(t).GetInfo().GetStatus()
+			describeResponse := a.describe(t)
+			return activityTerminalOutcome{
+				status:     describeResponse.GetInfo().GetStatus(),
+				retryState: describeResponse.GetOutcome().GetRetryState(),
+			}
 		}
 	}
-	t.Errorf("the activity did not reach a terminal status within %s of the trace finishing. Last observed: %+v",
-		activityDriverTimeout, a.activityInfo(t))
-	return enumspb.ACTIVITY_EXECUTION_STATUS_UNSPECIFIED
+	require.FailNow(
+		t,
+		"activity did not reach a terminal status",
+		"within %s of the trace finishing; last observed: %+v",
+		activityDriverTimeout,
+		a.activityInfo(t),
+	)
+	return activityTerminalOutcome{}
 }
 
 func saaActivityInfo(i *activitypb.ActivityExecutionInfo) activityInfo {

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -13575,7 +13575,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 
 	t.Run("StartedWithPauseStateKeepPausedFalse", func(t *testing.T) {
 		// PAUSE_REQUESTED activity (STARTED status), reset with keepPaused=false.
-		// Reset is deferred; without ResetKeepPaused the next retry dispatches instead of pausing.
+		// Reset is deferred; without ResetShouldPause the next retry dispatches instead of pausing.
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
@@ -13590,7 +13590,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		pauseActivity(ctx, t, activityID, startResp.GetRunId())
 		waitForState(ctx, t, activityID, startResp.GetRunId(), enumspb.PENDING_ACTIVITY_STATE_PAUSE_REQUESTED)
 
-		// Reset with keepPaused=false — deferred; ResetKeepPaused stays false so dispatch isn't blocked.
+		// Reset with keepPaused=false — deferred; ResetShouldPause stays false so dispatch isn't blocked.
 		_, err := env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
 			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
@@ -13622,7 +13622,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 
 	t.Run("StartedWithPauseStateKeepPausedTrue", func(t *testing.T) {
 		// PAUSE_REQUESTED activity (STARTED status), reset with keepPaused=true.
-		// Reset is deferred; ResetKeepPaused is set so after the retry the activity stays paused.
+		// Reset is deferred; ResetShouldPause is set so after the retry the activity stays paused.
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
@@ -13637,7 +13637,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		pauseActivity(ctx, t, activityID, startResp.GetRunId())
 		waitForState(ctx, t, activityID, startResp.GetRunId(), enumspb.PENDING_ACTIVITY_STATE_PAUSE_REQUESTED)
 
-		// Reset with keepPaused=true — deferred; ResetKeepPaused should be set.
+		// Reset with keepPaused=true — deferred; ResetShouldPause should be set.
 		_, err := env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
 			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -3318,6 +3318,7 @@ func (s *standaloneActivityTestSuite) Test_ScheduleToCloseTimeout_WithRetry() {
 	require.NoError(t, err)
 	require.Equal(t, enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, pollActivityResp.GetOutcome().GetFailure().GetTimeoutFailureInfo().GetTimeoutType(),
 		"expected ScheduleToCloseTimeout but is %s", pollActivityResp.GetOutcome().GetFailure().GetTimeoutFailureInfo().GetTimeoutType())
+	require.Equal(t, enumspb.RETRY_STATE_TIMEOUT, pollActivityResp.GetOutcome().GetRetryState())
 
 	describeResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
 		Namespace:  env.Namespace().String(),
@@ -3432,6 +3433,7 @@ func (s *standaloneActivityTestSuite) TestStartToCloseTimeout() {
 
 	require.NotNil(t, describeResp3.GetOutcome().GetFailure())
 	protorequire.ProtoEqual(t, failure, describeResp3.GetOutcome().GetFailure())
+	require.Equal(t, enumspb.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED, describeResp3.GetOutcome().GetRetryState())
 	require.Equal(t, enumspb.TIMEOUT_TYPE_START_TO_CLOSE, describeResp3.GetOutcome().GetFailure().GetTimeoutFailureInfo().GetTimeoutType(),
 		"expected StartToCloseTimeout but is %s", describeResp3.GetOutcome().GetFailure().GetTimeoutFailureInfo().GetTimeoutType())
 }
@@ -3483,6 +3485,7 @@ func (s *standaloneActivityTestSuite) TestStartToCloseTimeout_WhileCancelRequest
 	require.Equal(t, enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
 		pollOutcome.GetOutcome().GetFailure().GetTimeoutFailureInfo().GetTimeoutType(),
 		"activity in CANCEL_REQUESTED should still time out via START_TO_CLOSE")
+	require.Equal(t, enumspb.RETRY_STATE_CANCEL_REQUESTED, pollOutcome.GetOutcome().GetRetryState())
 }
 
 // TestScheduleToStartTimeout tests that a schedule-to-start timeout is recorded after the activity is
@@ -3534,6 +3537,7 @@ func (s *standaloneActivityTestSuite) TestScheduleToStartTimeout() {
 	require.NotNil(t, describeResp.GetInfo().GetCloseTime())
 	require.Equal(t, enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START, describeResp.GetOutcome().GetFailure().GetTimeoutFailureInfo().GetTimeoutType(),
 		"expected ScheduleToStartTimeout but is %s", describeResp.GetOutcome().GetFailure().GetTimeoutFailureInfo().GetTimeoutType())
+	require.Equal(t, enumspb.RETRY_STATE_TIMEOUT, describeResp.GetOutcome().GetRetryState())
 }
 
 func (s *standaloneActivityTestSuite) TestDescribeActivityExecution() {
@@ -4026,6 +4030,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution() {
 				outcomeValidator: func(t *testing.T, response *workflowservice.DescribeActivityExecutionResponse) {
 					protorequire.ProtoEqual(t, defaultResult, response.GetOutcome().GetResult())
 					require.Nil(t, response.GetOutcome().GetFailure())
+					require.Equal(t, enumspb.RETRY_STATE_UNSPECIFIED, response.GetOutcome().GetRetryState())
 				},
 			},
 			{
@@ -4043,6 +4048,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution() {
 				outcomeValidator: func(t *testing.T, response *workflowservice.DescribeActivityExecutionResponse) {
 					protorequire.ProtoEqual(t, defaultFailure, response.GetOutcome().GetFailure())
 					require.Nil(t, response.GetOutcome().GetResult())
+					require.Equal(t, enumspb.RETRY_STATE_NON_RETRYABLE_FAILURE, response.GetOutcome().GetRetryState())
 				},
 			},
 			{
@@ -4061,6 +4067,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution() {
 					require.NotNil(t, response.GetOutcome().GetFailure())
 					require.NotNil(t, response.GetOutcome().GetFailure().GetTerminatedFailureInfo())
 					require.Nil(t, response.GetOutcome().GetResult())
+					require.Equal(t, enumspb.RETRY_STATE_UNSPECIFIED, response.GetOutcome().GetRetryState())
 				},
 			},
 		}
@@ -4496,6 +4503,7 @@ func (s *standaloneActivityTestSuite) TestPollActivityExecution() {
 			},
 			completionValidationFn: func(t *testing.T, response *workflowservice.PollActivityExecutionResponse) {
 				protorequire.ProtoEqual(t, defaultResult, response.GetOutcome().GetResult())
+				require.Equal(t, enumspb.RETRY_STATE_UNSPECIFIED, response.GetOutcome().GetRetryState())
 			},
 		},
 		{
@@ -4532,6 +4540,7 @@ func (s *standaloneActivityTestSuite) TestPollActivityExecution() {
 			completionValidationFn: func(t *testing.T, response *workflowservice.PollActivityExecutionResponse) {
 				require.NotNil(t, response.GetOutcome().GetFailure())
 				require.NotNil(t, response.GetOutcome().GetFailure().GetCanceledFailureInfo())
+				require.Equal(t, enumspb.RETRY_STATE_UNSPECIFIED, response.GetOutcome().GetRetryState())
 			},
 		},
 		{
@@ -4548,6 +4557,7 @@ func (s *standaloneActivityTestSuite) TestPollActivityExecution() {
 			completionValidationFn: func(t *testing.T, response *workflowservice.PollActivityExecutionResponse) {
 				require.NotNil(t, response.GetOutcome().GetFailure())
 				require.NotNil(t, response.GetOutcome().GetFailure().GetTerminatedFailureInfo())
+				require.Equal(t, enumspb.RETRY_STATE_UNSPECIFIED, response.GetOutcome().GetRetryState())
 			},
 		},
 	}

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -3433,6 +3433,7 @@ func (s *standaloneActivityTestSuite) TestStartToCloseTimeout() {
 
 	require.NotNil(t, describeResp3.GetOutcome().GetFailure())
 	protorequire.ProtoEqual(t, failure, describeResp3.GetOutcome().GetFailure())
+	// The attempt timed out, but no retry followed because MaximumAttempts was reached.
 	require.Equal(t, enumspb.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED, describeResp3.GetOutcome().GetRetryState())
 	require.Equal(t, enumspb.TIMEOUT_TYPE_START_TO_CLOSE, describeResp3.GetOutcome().GetFailure().GetTimeoutFailureInfo().GetTimeoutType(),
 		"expected StartToCloseTimeout but is %s", describeResp3.GetOutcome().GetFailure().GetTimeoutFailureInfo().GetTimeoutType())

--- a/tests/activity_workflow_driver.go
+++ b/tests/activity_workflow_driver.go
@@ -205,23 +205,27 @@ func (a *wfaHandle) activityInfo(t require.TestingT) activityInfo {
 	return info
 }
 
-// terminalStatus waits for the activity to reach a terminal state and reports it. A workflow activity's
+// terminalOutcome waits for the activity to reach a terminal state and reports it. A workflow activity's
 // terminal status is not in PendingActivities, so it is read from the workflow-result error's cause.
-func (a *wfaHandle) terminalStatus(t require.TestingT) enumspb.ActivityExecutionStatus {
+func (a *wfaHandle) terminalOutcome(t require.TestingT) activityTerminalOutcome {
 	err := a.run.Get(a.d.ctx, nil)
 	if err == nil {
-		return enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED
+		return activityTerminalOutcome{status: enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED}
 	}
 	// A canceled activity is returned as a bare CanceledError, not wrapped in an ActivityError.
 	if _, ok := errors.AsType[*temporal.CanceledError](err); ok {
-		return enumspb.ACTIVITY_EXECUTION_STATUS_CANCELED
+		return activityTerminalOutcome{status: enumspb.ACTIVITY_EXECUTION_STATUS_CANCELED}
 	}
 	var actErr *temporal.ActivityError
 	require.ErrorAs(t, err, &actErr)
-	if _, ok := actErr.Unwrap().(*temporal.TimeoutError); ok {
-		return enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT
+	outcome := activityTerminalOutcome{
+		status:     enumspb.ACTIVITY_EXECUTION_STATUS_FAILED,
+		retryState: actErr.RetryState(),
 	}
-	return enumspb.ACTIVITY_EXECUTION_STATUS_FAILED
+	if _, ok := actErr.Unwrap().(*temporal.TimeoutError); ok {
+		outcome.status = enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT
+	}
+	return outcome
 }
 
 // activityInfoIfInProgress returns the shared activity projection and whether the activity still has

--- a/tests/mixedbrain/go.mod
+++ b/tests/mixedbrain/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/siderolabs/grpc-proxy v0.5.2
 	github.com/stretchr/testify v1.11.1
 	github.com/temporalio/omes v0.0.0-20260529203146-c6ee1f56c726
-	go.temporal.io/api v1.63.5-0.20260730203810-e7387ebd980e
+	go.temporal.io/api v1.63.5-0.20260731164320-beafdd4b0d8f
 	go.temporal.io/server v0.0.0-00010101000000-000000000000
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11

--- a/tests/mixedbrain/go.sum
+++ b/tests/mixedbrain/go.sum
@@ -55,8 +55,8 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/6gtIk=
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
-go.temporal.io/api v1.63.5-0.20260730203810-e7387ebd980e h1:kUL8YTxElWLVqorcA26Kr7xujAk7B1lPedl/x9Q7Gx4=
-go.temporal.io/api v1.63.5-0.20260730203810-e7387ebd980e/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
+go.temporal.io/api v1.63.5-0.20260731164320-beafdd4b0d8f h1:n/cM2e930fSKURv5NSlvx0LaXEpyQY06Uo5MizOKYhU=
+go.temporal.io/api v1.63.5-0.20260731164320-beafdd4b0d8f/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=


### PR DESCRIPTION
## What changed?
Exposed RetryState on standalone activity execution outcomes and persisted it in activity state. Retry evaluation now records terminal reasons including retry policy not set, cancellation requested, non-retryable failure, maximum attempts reached, and timeout.

## Why?
Standalone activities previously collapsed retry decisions into a boolean, preventing callers from distinguishing why an activity stopped retrying. This brings standalone activity behavior and observability into parity with workflow activities.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [X] added new functional test(s)

## Potential risks
During a rolling upgrade, activities closed by an older server may return RETRY_STATE_UNSPECIFIED. Existing closed activities also remain unspecified because retry state was not previously persisted. Older clients safely ignore the new protobuf field.
