### PR TITLE
Honor SchedulePolicies.keep_original_workflow_id

### DIFF
--- a/chasm/lib/scheduler/backfiller_tasks.go
+++ b/chasm/lib/scheduler/backfiller_tasks.go
@@ -12,6 +12,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	queueerrors "go.temporal.io/server/service/history/queues/errors"
+	legacyscheduler "go.temporal.io/server/service/worker/scheduler"
 	"go.uber.org/fx"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -219,7 +220,14 @@ func (b *BackfillerTaskHandler) processTrigger(
 	nowpb := backfiller.GetLastProcessedTime()
 	now := nowpb.AsTime()
 	requestID := generateRequestID(scheduler, backfiller.GetBackfillId(), now, now)
-	workflowID := schedulerinternal.GenerateWorkflowID(scheduler.WorkflowID(), now)
+	workflowID := schedulerinternal.GenerateWorkflowID(
+		scheduler.WorkflowID(),
+		now,
+		legacyscheduler.AppendsTimestamp(
+			overlapPolicy,
+			scheduler.GetSchedule().GetPolicies().GetKeepOriginalWorkflowId(),
+		),
+	)
 	result.BufferedStarts = []*schedulespb.BufferedStart{
 		{
 			NominalTime:   nowpb,

--- a/chasm/lib/scheduler/internal/request_id.go
+++ b/chasm/lib/scheduler/internal/request_id.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -53,6 +54,16 @@ func GenerateWorkflowID(baseWorkflowID string, nominalTime time.Time, appendTime
 	}
 	nominalTimeSec := nominalTime.Truncate(time.Second)
 	return fmt.Sprintf("%s-%s", baseWorkflowID, nominalTimeSec.UTC().Format(time.RFC3339))
+}
+
+// WorkflowIDHasTimestamp reports whether workflowID was generated with nominalTime
+// appended to it, i.e. whether GenerateWorkflowID was called with appendTimestamp set.
+//
+// This is derived purely from the buffered start's own captured state, so it stays
+// correct when the schedule's action workflow ID or keep_original_workflow_id policy
+// changes after the start was buffered.
+func WorkflowIDHasTimestamp(workflowID string, nominalTime time.Time) bool {
+	return strings.HasSuffix(workflowID, "-"+nominalTime.Truncate(time.Second).UTC().Format(time.RFC3339))
 }
 
 // GenerateBackfillerID generates a unique ID for a Backfiller component.

--- a/chasm/lib/scheduler/internal/request_id.go
+++ b/chasm/lib/scheduler/internal/request_id.go
@@ -43,7 +43,14 @@ func GenerateRequestID(
 
 // GenerateWorkflowID generates a deterministic workflow ID for a buffered
 // action by combining the base workflow ID with the truncated nominal time.
-func GenerateWorkflowID(baseWorkflowID string, nominalTime time.Time) string {
+//
+// When appendTimestamp is false (the schedule set keep_original_workflow_id and the
+// action's overlap policy permits it), the base workflow ID is used verbatim, so every
+// action of the schedule reuses the same workflow ID.
+func GenerateWorkflowID(baseWorkflowID string, nominalTime time.Time, appendTimestamp bool) string {
+	if !appendTimestamp {
+		return baseWorkflowID
+	}
 	nominalTimeSec := nominalTime.Truncate(time.Second)
 	return fmt.Sprintf("%s-%s", baseWorkflowID, nominalTimeSec.UTC().Format(time.RFC3339))
 }

--- a/chasm/lib/scheduler/internal/request_id_test.go
+++ b/chasm/lib/scheduler/internal/request_id_test.go
@@ -14,8 +14,16 @@ func TestGenerateWorkflowID(t *testing.T) {
 	baseWorkflowID := "my-workflow"
 	nominalTime := time.Date(2024, 6, 15, 10, 30, 45, 123456789, time.UTC)
 
-	actual := GenerateWorkflowID(baseWorkflowID, nominalTime)
+	actual := GenerateWorkflowID(baseWorkflowID, nominalTime, true)
 	require.Equal(t, "my-workflow-2024-06-15T10:30:45Z", actual)
+}
+
+func TestGenerateWorkflowID_KeepOriginal(t *testing.T) {
+	baseWorkflowID := "my-workflow"
+	nominalTime := time.Date(2024, 6, 15, 10, 30, 45, 123456789, time.UTC)
+
+	actual := GenerateWorkflowID(baseWorkflowID, nominalTime, false)
+	require.Equal(t, "my-workflow", actual)
 }
 
 func TestGenerateRequestID(t *testing.T) {

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -645,8 +645,16 @@ func (h *InvokerExecuteTaskHandler) startWorkflow(
 		}
 	}
 
+	// When the workflow id is reused verbatim across actions (keep_original_workflow_id,
+	// with no timestamp appended), REJECT_DUPLICATE would reject every action after the
+	// first one, since a closed run with that id always exists. Those schedules fall back
+	// to ALLOW_DUPLICATE and rely on RequestId for start deduplication instead.
+	//
+	// The check compares against the action's base workflow id rather than re-deriving
+	// the policy, so it stays correct for starts that were buffered before a schedule
+	// update flipped keep_original_workflow_id.
 	reusePolicy := enumspb.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE
-	if start.Manual {
+	if start.Manual || start.WorkflowId == scheduler.WorkflowID() {
 		reusePolicy = enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE
 	}
 

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -16,6 +16,7 @@ import (
 	schedulespb "go.temporal.io/server/api/schedule/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
+	schedulerinternal "go.temporal.io/server/chasm/lib/scheduler/internal"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -650,11 +651,12 @@ func (h *InvokerExecuteTaskHandler) startWorkflow(
 	// first one, since a closed run with that id always exists. Those schedules fall back
 	// to ALLOW_DUPLICATE and rely on RequestId for start deduplication instead.
 	//
-	// The check compares against the action's base workflow id rather than re-deriving
-	// the policy, so it stays correct for starts that were buffered before a schedule
-	// update flipped keep_original_workflow_id.
+	// The decision is derived from the buffered start's own id and nominal time, not
+	// from the schedule's current action or policies: a start can sit in the buffer
+	// across an update that changes either one, and re-deriving would then pick a
+	// reuse policy that doesn't match the id the start actually carries.
 	reusePolicy := enumspb.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE
-	if start.Manual || start.WorkflowId == scheduler.WorkflowID() {
+	if start.Manual || !schedulerinternal.WorkflowIDHasTimestamp(start.WorkflowId, start.NominalTime.AsTime()) {
 		reusePolicy = enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE
 	}
 

--- a/chasm/lib/scheduler/migration/migration.go
+++ b/chasm/lib/scheduler/migration/migration.go
@@ -71,6 +71,7 @@ func LegacyToCreateFromMigrationStateRequest(
 		state.ScheduleId,
 		state.ConflictToken,
 		getWorkflowID(schedule),
+		schedule.GetPolicies(),
 	)
 
 	runningBufferedStarts := convertRunningWorkflowsToBufferedStarts(
@@ -206,6 +207,7 @@ func convertBufferedStartsLegacyToCHASM(
 	namespaceID, scheduleID string,
 	conflictToken int64,
 	baseWorkflowID string,
+	policies *schedulepb.SchedulePolicies,
 ) []*schedulespb.BufferedStart {
 	if len(v1Starts) == 0 {
 		return nil
@@ -227,9 +229,19 @@ func convertBufferedStartsLegacyToCHASM(
 		}
 
 		if v2Start.WorkflowId == "" {
+			// Mirrors scheduler.AppendsTimestamp, inlined because this package is imported
+			// by the legacy scheduler and so cannot import it back. A buffered start can
+			// carry UNSPECIFIED, which inherits the schedule's policy.
+			overlapPolicy := v1Start.GetOverlapPolicy()
+			if overlapPolicy == enumspb.SCHEDULE_OVERLAP_POLICY_UNSPECIFIED {
+				overlapPolicy = policies.GetOverlapPolicy()
+			}
+			appendTimestamp := overlapPolicy == enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL ||
+				!policies.GetKeepOriginalWorkflowId()
 			v2Start.WorkflowId = schedulerinternal.GenerateWorkflowID(
 				baseWorkflowID,
 				v1Start.GetNominalTime().AsTime(),
+				appendTimestamp,
 			)
 		}
 

--- a/chasm/lib/scheduler/spec_processor.go
+++ b/chasm/lib/scheduler/spec_processor.go
@@ -115,6 +115,13 @@ func (s *SpecProcessorImpl) ProcessTimeRange(
 
 	catchupWindow := catchupWindow(scheduler, tweakables)
 
+	// Whether started workflows get the nominal timestamp appended to their workflow ID.
+	// Constant for the whole range: both inputs are fixed per invocation.
+	appendTimestamp := legacyscheduler.AppendsTimestamp(
+		overlapPolicy,
+		scheduler.GetSchedule().GetPolicies().GetKeepOriginalWorkflowId(),
+	)
+
 	// lastAction is used to set the high water mark for future ProcessTimeRange
 	// invocations. The code below will set a "last action" even when none is taken,
 	// simply to indicate that processing can permanently skip that period of time
@@ -179,7 +186,7 @@ func (s *SpecProcessorImpl) ProcessTimeRange(
 			OverlapPolicy: overlapPolicy,
 			Manual:        manual,
 			RequestId:     generateRequestID(scheduler, backfillID, next.Nominal, next.Next),
-			WorkflowId:    schedulerinternal.GenerateWorkflowID(workflowID, next.Nominal),
+			WorkflowId:    schedulerinternal.GenerateWorkflowID(workflowID, next.Nominal, appendTimestamp),
 		})
 
 		if limit != nil {

--- a/chasm/lib/scheduler/spec_processor_test.go
+++ b/chasm/lib/scheduler/spec_processor_test.go
@@ -290,6 +290,56 @@ func TestProcessTimeRange_Basic(t *testing.T) {
 	require.Less(t, res.NextWakeupTime, end.Add(defaultInterval*2))
 }
 
+func TestProcessTimeRange_KeepOriginalWorkflowID(t *testing.T) {
+	env := newTestEnv(t)
+	ctx := chasm.NewMutableContext(context.Background(), env.Node)
+
+	schedule := defaultSchedule()
+	schedule.Policies.KeepOriginalWorkflowId = true
+	sched, err := scheduler.NewScheduler(ctx, namespace, namespaceID, scheduleID, schedule, nil)
+	require.NoError(t, err)
+	processor := newTestSpecProcessor(env.Ctrl)
+
+	end := time.Now()
+	start := end.Add(-defaultInterval * 5)
+
+	res, err := processor.ProcessTimeRange(sched, start, end, enumspb.SCHEDULE_OVERLAP_POLICY_UNSPECIFIED, sched.WorkflowID(), "", false, nil)
+	require.NoError(t, err)
+	require.Len(t, res.BufferedStarts, 5)
+
+	// Every action reuses the action's workflow ID verbatim, with no timestamp appended.
+	for _, b := range res.BufferedStarts {
+		require.Equal(t, sched.WorkflowID(), b.WorkflowId)
+	}
+}
+
+func TestProcessTimeRange_KeepOriginalWorkflowIDAllowAllStillAppends(t *testing.T) {
+	env := newTestEnv(t)
+	ctx := chasm.NewMutableContext(context.Background(), env.Node)
+
+	schedule := defaultSchedule()
+	schedule.Policies.KeepOriginalWorkflowId = true
+	schedule.Policies.OverlapPolicy = enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL
+	sched, err := scheduler.NewScheduler(ctx, namespace, namespaceID, scheduleID, schedule, nil)
+	require.NoError(t, err)
+	processor := newTestSpecProcessor(env.Ctrl)
+
+	end := time.Now()
+	start := end.Add(-defaultInterval * 5)
+
+	res, err := processor.ProcessTimeRange(sched, start, end, enumspb.SCHEDULE_OVERLAP_POLICY_UNSPECIFIED, sched.WorkflowID(), "", false, nil)
+	require.NoError(t, err)
+	require.Len(t, res.BufferedStarts, 5)
+
+	// ALLOW_ALL permits concurrent runs, which cannot share a workflow ID, so the
+	// timestamp is still appended.
+	for _, b := range res.BufferedStarts {
+		nominalTime := b.NominalTime.AsTime()
+		expectedTimestamp := nominalTime.Truncate(time.Second).Format(time.RFC3339)
+		require.Equal(t, sched.WorkflowID()+"-"+expectedTimestamp, b.WorkflowId)
+	}
+}
+
 func TestProcessTimeRange_ComputeLimitExceeded(t *testing.T) {
 	env := newTestEnv(t)
 	ctx := chasm.NewMutableContext(context.Background(), env.Node)

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -3847,11 +3847,7 @@ func (wh *WorkflowHandler) CreateSchedule(
 		return nil, err
 	}
 
-	if err = wh.validateStartWorkflowArgsForSchedule(
-		namespaceName,
-		request.GetSchedule().GetAction().GetStartWorkflow(),
-		request.GetSchedule().GetPolicies(),
-	); err != nil {
+	if err = wh.validateStartWorkflowArgsForSchedule(namespaceName, request.GetSchedule().GetAction().GetStartWorkflow()); err != nil {
 		return nil, err
 	}
 
@@ -3924,20 +3920,17 @@ func isSchedulerErrorLegacyRoutable(err error) bool {
 func (wh *WorkflowHandler) validateStartWorkflowArgsForSchedule(
 	namespaceName namespace.Name,
 	startWorkflow *workflowpb.NewWorkflowExecutionInfo,
-	policies *schedulepb.SchedulePolicies,
 ) error {
 	if startWorkflow == nil {
 		return nil
 	}
 
-	// Validate the workflow id at the length it will actually be started with: the
-	// scheduler appends a timestamp unless the schedule opted out via
-	// keep_original_workflow_id.
-	workflowIDForValidation := startWorkflow.WorkflowId
-	if scheduler.AppendsTimestamp(policies.GetOverlapPolicy(), policies.GetKeepOriginalWorkflowId()) {
-		workflowIDForValidation += scheduler.AppendedTimestampForValidation
-	}
-	if err := wh.validator.ValidateWorkflowID(workflowIDForValidation); err != nil {
+	// Always validate with room for the appended timestamp, even when the schedule set
+	// keep_original_workflow_id. The overlap policy can be overridden per-action, and an
+	// ALLOW_ALL trigger or backfill appends the timestamp regardless of that policy; since
+	// PatchSchedule doesn't revalidate the resulting id, accepting a base id that only
+	// fits without the suffix would defer the failure to StartWorkflowExecution.
+	if err := wh.validator.ValidateWorkflowID(startWorkflow.WorkflowId + scheduler.AppendedTimestampForValidation); err != nil {
 		return err
 	}
 
@@ -4652,7 +4645,6 @@ func (wh *WorkflowHandler) UpdateSchedule(
 	if err := wh.validateStartWorkflowArgsForSchedule(
 		namespaceName,
 		request.GetSchedule().GetAction().GetStartWorkflow(),
-		request.GetSchedule().GetPolicies(),
 	); err != nil {
 		return nil, err
 	}

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -3847,7 +3847,11 @@ func (wh *WorkflowHandler) CreateSchedule(
 		return nil, err
 	}
 
-	if err = wh.validateStartWorkflowArgsForSchedule(namespaceName, request.GetSchedule().GetAction().GetStartWorkflow()); err != nil {
+	if err = wh.validateStartWorkflowArgsForSchedule(
+		namespaceName,
+		request.GetSchedule().GetAction().GetStartWorkflow(),
+		request.GetSchedule().GetPolicies(),
+	); err != nil {
 		return nil, err
 	}
 
@@ -3920,12 +3924,20 @@ func isSchedulerErrorLegacyRoutable(err error) bool {
 func (wh *WorkflowHandler) validateStartWorkflowArgsForSchedule(
 	namespaceName namespace.Name,
 	startWorkflow *workflowpb.NewWorkflowExecutionInfo,
+	policies *schedulepb.SchedulePolicies,
 ) error {
 	if startWorkflow == nil {
 		return nil
 	}
 
-	if err := wh.validator.ValidateWorkflowID(startWorkflow.WorkflowId + scheduler.AppendedTimestampForValidation); err != nil {
+	// Validate the workflow id at the length it will actually be started with: the
+	// scheduler appends a timestamp unless the schedule opted out via
+	// keep_original_workflow_id.
+	workflowIDForValidation := startWorkflow.WorkflowId
+	if scheduler.AppendsTimestamp(policies.GetOverlapPolicy(), policies.GetKeepOriginalWorkflowId()) {
+		workflowIDForValidation += scheduler.AppendedTimestampForValidation
+	}
+	if err := wh.validator.ValidateWorkflowID(workflowIDForValidation); err != nil {
 		return err
 	}
 
@@ -4640,6 +4652,7 @@ func (wh *WorkflowHandler) UpdateSchedule(
 	if err := wh.validateStartWorkflowArgsForSchedule(
 		namespaceName,
 		request.GetSchedule().GetAction().GetStartWorkflow(),
+		request.GetSchedule().GetPolicies(),
 	); err != nil {
 		return nil, err
 	}

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -66,6 +66,9 @@ const (
 	LimitMemoSpecSize = 11
 	// trigger immediately timestamp is added to the PatchRequest
 	TriggerImmediatelyTimestamp = 12
+	// honor SchedulePolicies.keep_original_workflow_id: don't append the nominal
+	// timestamp to the started workflow id
+	KeepOriginalWorkflowID = 13
 )
 
 const (
@@ -215,7 +218,7 @@ var (
 		ReuseTimer:                        true,
 		NextTimeCacheV2Size:               14, // see note below
 		SpecFieldLengthLimit:              10,
-		Version:                           TriggerImmediatelyTimestamp,
+		Version:                           KeepOriginalWorkflowID,
 	}
 
 	// Note on NextTimeCacheV2Size: This value must be > FutureActionCountForList. Each
@@ -1468,13 +1471,35 @@ func (s *scheduler) recordAction(result *schedulepb.ScheduleActionResult, nonOve
 	}
 }
 
+// AppendsTimestamp reports whether the scheduler appends the nominal timestamp to the
+// workflow id of a started workflow, given the effective overlap policy for the action and
+// the schedule's keep_original_workflow_id policy.
+//
+// SCHEDULE_OVERLAP_POLICY_ALLOW_ALL always appends, overriding keep_original_workflow_id,
+// because concurrent runs cannot share a workflow id. Note that the overlap policy can be
+// overridden per-action (trigger/backfill), so a schedule that keeps the original id may
+// still produce timestamped ids for individual ALLOW_ALL actions.
+func AppendsTimestamp(overlapPolicy enumspb.ScheduleOverlapPolicy, keepOriginalWorkflowID bool) bool {
+	return overlapPolicy == enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL || !keepOriginalWorkflowID
+}
+
 func (s *scheduler) startWorkflow(
 	start *schedulespb.BufferedStart,
 	newWorkflow *workflowpb.NewWorkflowExecutionInfo,
 ) (*schedulepb.ScheduleActionResult, error) {
 	nominalTimeSec := start.NominalTime.AsTime().UTC().Truncate(time.Second)
 	workflowID := newWorkflow.WorkflowId
-	if start.OverlapPolicy == enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL || s.tweakables.AlwaysAppendTimestamp {
+	keepOriginalWorkflowID := s.hasMinVersion(KeepOriginalWorkflowID) &&
+		s.Schedule.Policies.GetKeepOriginalWorkflowId()
+	appendTimestamp := start.OverlapPolicy == enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL ||
+		s.tweakables.AlwaysAppendTimestamp
+	if keepOriginalWorkflowID {
+		// ALLOW_ALL permits concurrent runs, which cannot share a workflow id, so it
+		// overrides the opt-out. A buffered start can carry UNSPECIFIED (it's resolved
+		// in ProcessBuffer), so resolve against the schedule's policy first.
+		appendTimestamp = AppendsTimestamp(s.resolveOverlapPolicy(start.OverlapPolicy), true)
+	}
+	if appendTimestamp {
 		// must match AppendedTimestampForValidation
 		workflowID += "-" + nominalTimeSec.Format(time.RFC3339)
 	}
@@ -1505,8 +1530,13 @@ func (s *scheduler) startWorkflow(
 
 	// Reject duplicates as part of WFID reuse policy when possible, as a measure
 	// against WFT timeouts/failures that lead to non-determinism.
+	//
+	// When the workflow id is reused verbatim across actions (keep_original_workflow_id,
+	// with no timestamp appended), REJECT_DUPLICATE would reject every action after the
+	// first one, since a closed run with that id always exists. Those schedules fall back
+	// to ALLOW_DUPLICATE and rely on RequestId for start deduplication instead.
 	reusePolicy := enumspb.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE
-	if start.Manual {
+	if start.Manual || (keepOriginalWorkflowID && !appendTimestamp) {
 		reusePolicy = enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE
 	}
 

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -354,6 +355,95 @@ func (s *workflowSuite) TestStart() {
 	// two iterations to start one workflow: first will sleep, second will start and then sleep again
 	s.True(s.env.IsWorkflowCompleted())
 	s.True(workflow.IsContinueAsNewError(s.env.GetWorkflowError()))
+}
+
+func (s *workflowSuite) TestStartKeepOriginalWorkflowID() {
+	// keep_original_workflow_id: the started workflow keeps the id from the action
+	// verbatim, with no nominal timestamp appended.
+
+	s.expectStart(func(req *schedulespb.StartWorkflowRequest) (*schedulespb.StartWorkflowResponse, error) {
+		s.Equal("myid", req.Request.WorkflowId)
+		// A verbatim id is reused by every action, so REJECT_DUPLICATE would reject
+		// every action after the first one.
+		s.Equal(enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE, req.Request.WorkflowIdReusePolicy)
+		return nil, nil
+	})
+
+	s.run(&schedulepb.Schedule{
+		Spec: &schedulepb.ScheduleSpec{
+			Interval: []*schedulepb.IntervalSpec{{
+				Interval: durationpb.New(55 * time.Minute),
+			}},
+		},
+		Action: s.defaultAction("myid"),
+		Policies: &schedulepb.SchedulePolicies{
+			KeepOriginalWorkflowId: true,
+		},
+	}, 2)
+	s.True(s.env.IsWorkflowCompleted())
+	s.True(workflow.IsContinueAsNewError(s.env.GetWorkflowError()))
+}
+
+func (s *workflowSuite) TestStartKeepOriginalWorkflowIDAllowAllStillAppends() {
+	// ALLOW_ALL permits concurrent runs, which cannot share a workflow id, so it
+	// overrides keep_original_workflow_id.
+
+	s.expectStart(func(req *schedulespb.StartWorkflowRequest) (*schedulespb.StartWorkflowResponse, error) {
+		s.Equal("myid-2022-06-01T00:15:00Z", req.Request.WorkflowId)
+		s.Equal(enumspb.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE, req.Request.WorkflowIdReusePolicy)
+		return nil, nil
+	})
+
+	s.run(&schedulepb.Schedule{
+		Spec: &schedulepb.ScheduleSpec{
+			Interval: []*schedulepb.IntervalSpec{{
+				Interval: durationpb.New(55 * time.Minute),
+			}},
+		},
+		Action: s.defaultAction("myid"),
+		Policies: &schedulepb.SchedulePolicies{
+			KeepOriginalWorkflowId: true,
+			OverlapPolicy:          enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+		},
+	}, 2)
+	s.True(s.env.IsWorkflowCompleted())
+	s.True(workflow.IsContinueAsNewError(s.env.GetWorkflowError()))
+}
+
+func TestAppendsTimestamp(t *testing.T) {
+	for _, tc := range []struct {
+		name                   string
+		overlapPolicy          enumspb.ScheduleOverlapPolicy
+		keepOriginalWorkflowID bool
+		expected               bool
+	}{
+		{
+			name:          "default appends",
+			overlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP,
+			expected:      true,
+		},
+		{
+			name:                   "keep original suppresses append",
+			overlapPolicy:          enumspb.SCHEDULE_OVERLAP_POLICY_SKIP,
+			keepOriginalWorkflowID: true,
+			expected:               false,
+		},
+		{
+			name:          "allow all appends",
+			overlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			expected:      true,
+		},
+		{
+			name:                   "allow all overrides keep original",
+			overlapPolicy:          enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			keepOriginalWorkflowID: true,
+			expected:               true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, AppendsTimestamp(tc.overlapPolicy, tc.keepOriginalWorkflowID))
+		})
+	}
 }
 
 func (s *workflowSuite) TestInitialPatch() {

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -511,6 +511,11 @@ func runSharedScheduleTests(t *testing.T, newContext contextFactory) {
 	t.Run("TestListSchedulesFilterByScheduleId", func(t *testing.T) { t.Parallel(); testListSchedulesFilterByScheduleID(t, newContext) })
 	t.Run("TestBufferSizeReportedWhenBuffered", func(t *testing.T) { t.Parallel(); testBufferSizeReportedWhenBuffered(t, newContext) })
 	t.Run("TestBufferOneDeferredFiresAfterCompletion", func(t *testing.T) { t.Parallel(); testBufferOneDeferredFiresAfterCompletion(t, newContext) })
+	t.Run("TestKeepOriginalWorkflowID", func(t *testing.T) { t.Parallel(); testKeepOriginalWorkflowID(t, newContext) })
+	t.Run("TestKeepOriginalWorkflowIDAllowAllStillAppends", func(t *testing.T) {
+		t.Parallel()
+		testKeepOriginalWorkflowIDAllowAllStillAppends(t, newContext)
+	})
 }
 
 // testBufferSizeReportedWhenBuffered verifies that ScheduleInfo.BufferSize is
@@ -780,6 +785,103 @@ func testBufferOneDeferredFiresAfterCompletion(t *testing.T, newContext contextF
 			deferred.GetScheduleTime().AsTime().Sub(first.GetScheduleTime().AsTime()) == fastInterval
 	}, awaitTimeout, pollInterval,
 		"deferred fire must be the start buffered one interval after the first tick, not a later fresh action")
+}
+
+// testKeepOriginalWorkflowID verifies that SchedulePolicies.KeepOriginalWorkflowId
+// starts every action with the action's workflow id verbatim, with no nominal
+// timestamp appended.
+//
+// Reaching two runs is the substantive assertion, not just the id format: with a
+// reused id, a closed run with that id exists after the first action, so a
+// REJECT_DUPLICATE reuse policy would reject every subsequent action and the count
+// would stick at 1.
+func testKeepOriginalWorkflowID(t *testing.T, newContext contextFactory) {
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+
+	sid := testcore.RandomizeStr("sched-keep-original-id")
+	wid := testcore.RandomizeStr("sched-keep-original-id-wf")
+	wt := testcore.RandomizeStr("sched-keep-original-id-wt")
+
+	var runs atomic.Int32
+	registerCountingWorkflow(s, wt, &runs)
+
+	ctx := newContext(s.Context())
+	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
+		Spec:   intervalSpec(fastInterval),
+		Action: startWorkflowAction(s, wid, wt),
+		Policies: &schedulepb.SchedulePolicies{
+			KeepOriginalWorkflowId: true,
+		},
+	})
+
+	await.RequireTruef(t, func() bool { return runs.Load() >= 2 },
+		awaitTimeout, pollInterval,
+		"a second action must start even though the first run already used this workflow id")
+
+	// Every started workflow used the id verbatim.
+	wfResp, err := s.FrontendClient().ListWorkflowExecutions(ctx, &workflowservice.ListWorkflowExecutionsRequest{
+		Namespace: s.Namespace().String(),
+		PageSize:  5,
+		Query:     fmt.Sprintf("WorkflowType = %q", wt),
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, wfResp.Executions)
+	for _, ex := range wfResp.Executions {
+		require.Equal(t, wid, ex.Execution.WorkflowId,
+			"no timestamp should be appended when KeepOriginalWorkflowId is set")
+	}
+
+	// The schedule agrees: its recorded actions point at the verbatim id too.
+	desc, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, desc.GetInfo().GetRecentActions())
+	for _, a := range desc.GetInfo().GetRecentActions() {
+		require.Equal(t, wid, a.GetStartWorkflowResult().GetWorkflowId())
+	}
+}
+
+// testKeepOriginalWorkflowIDAllowAllStillAppends verifies that ALLOW_ALL overrides
+// the opt-out: concurrent runs cannot share a workflow id, so the timestamp is
+// still appended.
+func testKeepOriginalWorkflowIDAllowAllStillAppends(t *testing.T, newContext contextFactory) {
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+
+	sid := testcore.RandomizeStr("sched-keep-original-allow-all")
+	wid := testcore.RandomizeStr("sched-keep-original-allow-all-wf")
+	wt := testcore.RandomizeStr("sched-keep-original-allow-all-wt")
+
+	var runs atomic.Int32
+	registerCountingWorkflow(s, wt, &runs)
+
+	ctx := newContext(s.Context())
+	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
+		Spec:   intervalSpec(fastInterval),
+		Action: startWorkflowAction(s, wid, wt),
+		Policies: &schedulepb.SchedulePolicies{
+			KeepOriginalWorkflowId: true,
+			OverlapPolicy:          enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+		},
+	})
+
+	await.RequireTruef(t, func() bool { return runs.Load() >= 2 },
+		awaitTimeout, pollInterval, "expected at least two actions to start")
+
+	wfResp, err := s.FrontendClient().ListWorkflowExecutions(ctx, &workflowservice.ListWorkflowExecutionsRequest{
+		Namespace: s.Namespace().String(),
+		PageSize:  5,
+		Query:     fmt.Sprintf("WorkflowType = %q", wt),
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, wfResp.Executions)
+	for _, ex := range wfResp.Executions {
+		require.NotEqual(t, wid, ex.Execution.WorkflowId,
+			"ALLOW_ALL must still append a timestamp so concurrent runs get distinct ids")
+		require.True(t, strings.HasPrefix(ex.Execution.WorkflowId, wid+"-"),
+			"expected %q to be the base id plus a timestamp", ex.Execution.WorkflowId)
+	}
 }
 
 func testDeletedScheduleOperations(t *testing.T, newContext contextFactory) {


### PR DESCRIPTION
## What changed

`SchedulePolicies.keep_original_workflow_id` was added to the API in temporalio/api#357 and implemented on the server in #5447, which was then partially reverted in #5480 — "we're going to implement it in a slightly different way and want to do a release from main without having to retain this specific workflow logic." Since then the field has been accepted and stored but ignored: both schedulers unconditionally append the nominal timestamp, so a schedule that sets the field is silently given timestamped ids anyway.

This is a fresh attempt at that "slightly different way." No API/proto change is needed; the field is already in the vendored `go.temporal.io/api v1.63.4`.

- **V1** (`service/worker/scheduler`): the append is gated on a new `KeepOriginalWorkflowID` workflow version, so replay of existing histories is unaffected.
- **V2** (`chasm/lib/scheduler`): the decision is threaded through `GenerateWorkflowID` at buffering time, plus the trigger and V1→V2 migration paths.
- **Frontend**: unchanged behavior. Validation keeps reserving room for the appended timestamp unconditionally — see the reuse/validation note below.

Closes #4795. Unblocks temporalio/features#727 (closed as unprioritized pending server support) and temporalio/cli#910 (closed as not planned, routed here).

## How this differs from the reverted #5447

Three things, addressing what I understand to be the problems with the original:

1. **Workflow versioning.** #5447 changed `startWorkflow`'s logic unconditionally, with no `SchedulerWorkflowVersion` gate — which matches the revert's stated concern about retaining specific workflow logic across a release. This adds `KeepOriginalWorkflowID = 13` and gates on `hasMinVersion`, so recorded histories replay unchanged. The existing replay tests pass.

2. **`ALLOW_ALL` no longer collides.** #5447's `InternalWorkflowIdRepresentation` ignored the overlap policy, so `ALLOW_ALL` + `keep_original_workflow_id` produced the *same* id for concurrent runs. The follow-up that would have rejected that combination (#5456) was closed unmerged. Here `ALLOW_ALL` always appends and overrides the opt-out, expressed in one shared helper (`scheduler.AppendsTimestamp`) used by both schedulers and the frontend — so the combination is safe rather than rejected. Note the overlap policy can be overridden per-action, so a keep-original schedule can still emit a timestamped id for an individual `ALLOW_ALL` trigger or backfill.

3. **Workflow id reuse policy.** This constraint post-dates the original attempt: #8035 (Jul 2025) set `REJECT_DUPLICATE` for scheduled starts. With an id reused verbatim, a closed run with that id exists after the first action, so `REJECT_DUPLICATE` would reject *every* subsequent action — the feature cannot work without relaxing it. Opted-in schedules fall back to `ALLOW_DUPLICATE` and rely on `RequestId` for start deduplication, which is deterministic per buffered start in both schedulers (batched side-effect UUID in V1, `GenerateRequestID` in V2). Default behavior is byte-identical; only opted-in schedules change.

   In V2 the decision is derived from the buffered start's own id and nominal time (`WorkflowIDHasTimestamp`), not from the schedule's current action or policies — a start can sit in the buffer across an update to either, and re-deriving would pick a reuse policy that doesn't match the id the start actually carries.

   Relatedly, frontend id-length validation still reserves room for the suffix unconditionally: the overlap policy can be overridden per-action, an `ALLOW_ALL` trigger or backfill appends the timestamp regardless of the schedule's policy, and `PatchSchedule` doesn't revalidate. Validating without the suffix would accept a base id that only fits unsuffixed and defer the failure to `StartWorkflowExecution`.

**This is the part I'd most like reviewed** — it trades away the guard described in #8035's comment ("a measure against WFT timeouts/failures that lead to non-determinism") for the schedules that opt in. If you'd rather keep `REJECT_DUPLICATE` and instead reject `keep_original_workflow_id` at the API boundary, that's a coherent alternative and I'm happy to switch.

Also relevant to sequencing: the revert discussion suggested this would land after CHASM schedules. That's now in place, and this change covers V2 as well as V1 — in V2 the resolved id already rides on `BufferedStart.WorkflowId`, which makes the opt-out a buffering-time decision rather than a start-time one.

## Review already applied

Codex flagged two real defects on the first commit, both fixed in `8c4fe1f`: the V2 reuse-policy decision broke when a buffered start outlived a change to the action's workflow id, and conditional id-length validation dropped suffix headroom that a per-action `ALLOW_ALL` override still needs.

## Known limitation, not addressed

With a stable id there's a residual race where the scheduler's view of the previous run lags and a start hits `WorkflowExecutionAlreadyStarted`; the overlap policies are what normally prevent it. `CANCEL_OTHER`/`TERMINATE_OTHER` could be tightened with `WorkflowIdConflictPolicy: TERMINATE_EXISTING`. Left out to keep this focused — happy to add.

## Testing

- `service/worker/scheduler`: full suite green, including the recorded-history replay tests. New: `TestStartKeepOriginalWorkflowID`, `TestStartKeepOriginalWorkflowIDAllowAllStillAppends`, table test for `AppendsTimestamp`.
- `chasm/lib/scheduler/...`: full suite green. New: `TestProcessTimeRange_KeepOriginalWorkflowID`, `TestProcessTimeRange_KeepOriginalWorkflowIDAllowAllStillAppends`, `TestGenerateWorkflowID_KeepOriginal`.
- `service/frontend`: schedule tests green.
- `gofmt` and `go vet` clean on all touched files.

- `tests/schedule_test.go`: `TestKeepOriginalWorkflowID` and `TestKeepOriginalWorkflowIDAllowAllStillAppends`, registered in `runSharedScheduleTests` so both run against V1 and CHASM. Reaching two runs is the substantive assertion, not the id format: a `REJECT_DUPLICATE` regression would stall the count at one. (#5447 covered this by flipping the shared `TestBasics` to the new policy; these are separate cases so `TestBasics` keeps exercising the default path.)

## Note

I have not signed the CLA yet; I'll sort that before this would be mergeable. Flagging it rather than leaving it to the bot.
