### PR TITLE
SAA vs WFA metrics parity

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1969,11 +1969,6 @@ func (a *Activity) validateActivityTaskToken(
 	return nil
 }
 
-// Metrics about data carried by activity tasks use the base handler plus operation. Metrics about
-// the activity lifecycle additionally use task queue, activity type, workflow type, and versioning
-// behavior. Per-record tags such as timeout_type and has_details are added when recording the
-// metric.
-
 // baseMetricsHandler adds only the operation tag.
 func (a *Activity) baseMetricsHandler(ctx chasm.Context, operation string) metrics.Handler {
 	return ctx.MetricsHandler().WithTags(metrics.OperationTag(operation))

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"math/rand"
 	"slices"
+	"strconv"
 	"time"
 
 	"github.com/nexus-rpc/sdk-go/nexus"
@@ -568,14 +569,16 @@ func (a *Activity) HandleCompleted(
 		return nil, err
 	}
 
-	metricsHandler, err := a.enrichMetricsHandler(ctx, metrics.HistoryRespondActivityTaskCompletedScope)
+	baseHandler := a.baseMetricsHandler(ctx, metrics.HistoryRespondActivityTaskCompletedScope)
+	enrichedHandler, err := a.enrichedMetricsHandler(ctx, metrics.HistoryRespondActivityTaskCompletedScope)
 	if err != nil {
 		return nil, err
 	}
 
 	if err := TransitionCompleted.Apply(a, ctx, completeEvent{
-		req:            event.Request,
-		metricsHandler: metricsHandler,
+		req:             event.Request,
+		baseHandler:     baseHandler,
+		enrichedHandler: enrichedHandler,
 	}); err != nil {
 		return nil, err
 	}
@@ -593,7 +596,8 @@ func (a *Activity) HandleFailed(
 		return nil, err
 	}
 
-	metricsHandler, err := a.enrichMetricsHandler(ctx, metrics.HistoryRespondActivityTaskFailedScope)
+	baseHandler := a.baseMetricsHandler(ctx, metrics.HistoryRespondActivityTaskFailedScope)
+	enrichedHandler, err := a.enrichedMetricsHandler(ctx, metrics.HistoryRespondActivityTaskFailedScope)
 	if err != nil {
 		return nil, err
 	}
@@ -609,14 +613,15 @@ func (a *Activity) HandleFailed(
 		return nil, err
 	}
 	if retryState == enumspb.RETRY_STATE_IN_PROGRESS {
-		a.emitOnAttemptFailedMetrics(ctx, metricsHandler)
+		a.emitOnAttemptFailedMetrics(ctx, enrichedHandler)
 
 		return &historyservice.RespondActivityTaskFailedResponse{}, nil
 	}
 
 	if err := TransitionFailed.Apply(a, ctx, failedEvent{
-		req:            event.Request,
-		metricsHandler: metricsHandler,
+		req:             event.Request,
+		baseHandler:     baseHandler,
+		enrichedHandler: enrichedHandler,
 	}); err != nil {
 		return nil, err
 	}
@@ -633,7 +638,7 @@ func (a *Activity) HandleCanceled(
 		return nil, err
 	}
 
-	metricsHandler, err := a.enrichMetricsHandler(ctx, metrics.HistoryRespondActivityTaskCanceledScope)
+	metricsHandler, err := a.enrichedMetricsHandler(ctx, metrics.HistoryRespondActivityTaskCanceledScope)
 	if err != nil {
 		return nil, err
 	}
@@ -667,7 +672,7 @@ func (a *Activity) Terminate(
 		return chasm.TerminateComponentResponse{}, nil
 	}
 
-	metricsHandler, err := a.enrichMetricsHandler(ctx, metrics.ActivityTerminatedScope)
+	metricsHandler, err := a.enrichedMetricsHandler(ctx, metrics.ActivityTerminatedScope)
 	if err != nil {
 		return chasm.TerminateComponentResponse{}, err
 	}
@@ -765,7 +770,7 @@ func (a *Activity) UpdateActivityExecutionOptions(
 		a.reissueDispatchAndScheduleToStart(ctx, attempt)
 	}
 
-	metricsHandler, err := a.enrichMetricsHandler(ctx, metrics.ActivityUpdateOptionsScope)
+	metricsHandler, err := a.enrichedMetricsHandler(ctx, metrics.ActivityUpdateOptionsScope)
 	if err != nil {
 		return nil, err
 	}
@@ -913,7 +918,7 @@ func (a *Activity) handleCancellationRequested(ctx chasm.MutableContext, request
 
 	// Transition to Canceled if no attempt in progress; otherwise wait for worker response.
 	if !hasAttemptInProgress {
-		metricsHandler, err := a.enrichMetricsHandler(ctx, metrics.HistoryRespondActivityTaskCanceledScope)
+		metricsHandler, err := a.enrichedMetricsHandler(ctx, metrics.HistoryRespondActivityTaskCanceledScope)
 		if err != nil {
 			return nil, err
 		}
@@ -955,7 +960,7 @@ func (a *Activity) handlePauseRequested(ctx chasm.MutableContext, req *activityp
 		return nil, serviceerror.NewFailedPrecondition("activity is already paused")
 	}
 
-	metricsHandler, err := a.enrichMetricsHandler(ctx, metrics.ActivityPausedScope)
+	metricsHandler, err := a.enrichedMetricsHandler(ctx, metrics.ActivityPausedScope)
 	if err != nil {
 		return nil, err
 	}
@@ -986,7 +991,7 @@ func (a *Activity) handleUnpauseRequested(ctx chasm.MutableContext, req *activit
 		return &activitypb.UnpauseActivityExecutionResponse{}, nil
 	}
 
-	metricsHandler, err := a.enrichMetricsHandler(ctx, metrics.ActivityUnpausedScope)
+	metricsHandler, err := a.enrichedMetricsHandler(ctx, metrics.ActivityUnpausedScope)
 	if err != nil {
 		return nil, err
 	}
@@ -1111,7 +1116,7 @@ func (a *Activity) reset(ctx chasm.MutableContext, event resetEvent) {
 		chasm.TaskAttributes{ScheduledTime: dispatchTime},
 		a.newActivityDispatchTask(ctx),
 	)
-	a.emitOnResetMetrics(event.handler)
+	a.emitOnResetMetrics(event.metricsHandler)
 }
 
 // handleReset handles the activity execution reset.
@@ -1141,7 +1146,7 @@ func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetAc
 		}
 	}
 
-	metricsHandler, err := a.enrichMetricsHandler(ctx, metrics.ActivityResetScope)
+	metricsHandler, err := a.enrichedMetricsHandler(ctx, metrics.ActivityResetScope)
 	if err != nil {
 		return nil, err
 	}
@@ -1237,8 +1242,8 @@ func (a *Activity) resetImmediately(
 		resetTime = resetTime.Add(time.Duration(rand.Int63n(int64(jitter)))) //nolint:gosec
 	}
 	if err := TransitionReset.Apply(a, ctx, resetEvent{
-		resetTime: resetTime,
-		handler:   metricsHandler,
+		resetTime:      resetTime,
+		metricsHandler: metricsHandler,
 	}); err != nil {
 		return nil, err
 	}
@@ -1599,10 +1604,11 @@ func (a *Activity) RecordHeartbeat(
 	if err != nil {
 		return nil, err
 	}
+	details := input.Request.GetHeartbeatRequest().GetDetails()
 	prevHeartbeat, _ := a.LastHeartbeat.TryGet(ctx)
 	a.LastHeartbeat = chasm.NewDataField(ctx, &activitypb.ActivityHeartbeatState{
 		RecordedTime:        timestamppb.New(ctx.Now(a)),
-		Details:             input.Request.GetHeartbeatRequest().GetDetails(),
+		Details:             details,
 		TotalHeartbeatCount: prevHeartbeat.GetTotalHeartbeatCount() + 1,
 	})
 	if heartbeatTimeout := a.GetHeartbeatTimeout().AsDuration(); heartbeatTimeout > 0 {
@@ -1616,6 +1622,14 @@ func (a *Activity) RecordHeartbeat(
 			},
 		)
 	}
+	detailsSize := details.Size()
+	metricsHandler := a.baseMetricsHandler(ctx, metrics.HistoryRecordActivityTaskHeartbeatScope)
+	emitPayloadSizeMetric(metricsHandler, detailsSize)
+	metrics.ActivityHeartbeatCount.With(metricsHandler).Record(
+		1,
+		metrics.StringTag("has_details", strconv.FormatBool(detailsSize > 0)),
+	)
+
 	response := &historyservice.RecordActivityTaskHeartbeatResponse{}
 	switch a.Status {
 	case activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED:
@@ -1955,7 +1969,18 @@ func (a *Activity) validateActivityTaskToken(
 	return nil
 }
 
-func (a *Activity) enrichMetricsHandler(ctx chasm.Context, operationTag string) (metrics.Handler, error) {
+// Metrics about data carried by activity tasks use the base handler plus operation. Metrics about
+// the activity lifecycle additionally use task queue, activity type, workflow type, and versioning
+// behavior. Per-record tags such as timeout_type and has_details are added when recording the
+// metric.
+
+// baseMetricsHandler adds only the operation tag.
+func (a *Activity) baseMetricsHandler(ctx chasm.Context, operation string) metrics.Handler {
+	return ctx.MetricsHandler().WithTags(metrics.OperationTag(operation))
+}
+
+// enrichedMetricsHandler adds standard activity tags in addition to the operation tag.
+func (a *Activity) enrichedMetricsHandler(ctx chasm.Context, operation string) (metrics.Handler, error) {
 	// activityContextFromChasm panics if the context value is missing; this is intentional and
 	// indicates a library registration bug rather than a runtime error.
 	actCtx := activityContextFromChasm(ctx)
@@ -1970,74 +1995,88 @@ func (a *Activity) enrichMetricsHandler(ctx chasm.Context, operationTag string) 
 		namespaceName.String(),
 		tqid.UnsafeTaskQueueFamily(namespaceName.String(), taskQueueFamily),
 		breakdownMetricsByTaskQueue(namespaceName.String(), taskQueueFamily, enumspb.TASK_QUEUE_TYPE_ACTIVITY),
-		metrics.OperationTag(operationTag),
+		metrics.OperationTag(operation),
 		metrics.ActivityTypeTag(a.GetActivityType().GetName()),
 		metrics.VersioningBehaviorTag(enumspb.VERSIONING_BEHAVIOR_UNSPECIFIED),
 		metrics.WorkflowTypeTag(WorkflowTypeTag),
 	), nil
 }
 
-func (a *Activity) emitOnAttemptTimedOutMetrics(ctx chasm.Context, handler metrics.Handler, timeoutType enumspb.TimeoutType) {
-	attempt := a.LastAttempt.Get(ctx)
-	startedTime := attempt.GetStartedTime().AsTime()
-
-	latency := time.Since(startedTime)
-	metrics.ActivityStartToCloseLatency.With(handler).Record(latency)
-
+func (a *Activity) emitOnAttemptTimedOutMetrics(metricsHandler metrics.Handler, timeoutType enumspb.TimeoutType) {
 	timeoutTag := metrics.StringTag("timeout_type", timeoutType.String())
-	metrics.ActivityTaskTimeout.With(handler).Record(1, timeoutTag)
+	metrics.ActivityTaskTimeout.With(metricsHandler).Record(1, timeoutTag)
 }
 
-func (a *Activity) emitOnAttemptFailedMetrics(ctx chasm.Context, handler metrics.Handler) {
+func (a *Activity) emitOnAttemptFailedMetrics(ctx chasm.Context, metricsHandler metrics.Handler) {
 	attempt := a.LastAttempt.Get(ctx)
 	startedTime := attempt.GetStartedTime().AsTime()
 
 	latency := time.Since(startedTime)
-	metrics.ActivityStartToCloseLatency.With(handler).Record(latency)
+	metrics.ActivityStartToCloseLatency.With(metricsHandler).Record(latency)
 
-	metrics.ActivityTaskFail.With(handler).Record(1)
+	metrics.ActivityTaskFail.With(metricsHandler).Record(1)
 }
 
-func (a *Activity) emitOnCompletedMetrics(ctx chasm.Context, handler metrics.Handler, attemptWasStarted bool) {
+// emitPayloadSizeMetric records the serialized size of a user payload.
+func emitPayloadSizeMetric(metricsHandler metrics.Handler, size int) {
+	if size > 0 {
+		metrics.ActivityPayloadSize.With(metricsHandler).Record(int64(size))
+	}
+}
+
+func (a *Activity) emitOnCompletedMetrics(
+	ctx chasm.Context,
+	baseHandler metrics.Handler,
+	enrichedHandler metrics.Handler,
+	result *commonpb.Payloads,
+	attemptWasStarted bool,
+) {
 	attempt := a.LastAttempt.Get(ctx)
 	startedTime := attempt.GetStartedTime().AsTime()
 
 	if attemptWasStarted {
 		startToCloseLatency := time.Since(startedTime)
-		metrics.ActivityStartToCloseLatency.With(handler).Record(startToCloseLatency)
+		metrics.ActivityStartToCloseLatency.With(enrichedHandler).Record(startToCloseLatency)
 	}
 
 	scheduleToCloseLatency := time.Since(a.GetScheduleTime().AsTime())
-	metrics.ActivityScheduleToCloseLatency.With(handler).Record(scheduleToCloseLatency)
+	metrics.ActivityScheduleToCloseLatency.With(enrichedHandler).Record(scheduleToCloseLatency)
 
-	metrics.ActivitySuccess.With(handler).Record(1)
+	metrics.ActivitySuccess.With(enrichedHandler).Record(1)
+	emitPayloadSizeMetric(baseHandler, result.Size())
 }
 
-func (a *Activity) emitOnFailedMetrics(ctx chasm.Context, handler metrics.Handler) {
+func (a *Activity) emitOnFailedMetrics(
+	ctx chasm.Context,
+	baseHandler metrics.Handler,
+	enrichedHandler metrics.Handler,
+	failure *failurepb.Failure,
+) {
 	attempt := a.LastAttempt.Get(ctx)
 	startedTime := attempt.GetStartedTime().AsTime()
 
 	startToCloseLatency := time.Since(startedTime)
-	metrics.ActivityStartToCloseLatency.With(handler).Record(startToCloseLatency)
+	metrics.ActivityStartToCloseLatency.With(enrichedHandler).Record(startToCloseLatency)
 
 	scheduleToCloseLatency := time.Since(a.GetScheduleTime().AsTime())
-	metrics.ActivityScheduleToCloseLatency.With(handler).Record(scheduleToCloseLatency)
+	metrics.ActivityScheduleToCloseLatency.With(enrichedHandler).Record(scheduleToCloseLatency)
 
-	metrics.ActivityTaskFail.With(handler).Record(1)
-	metrics.ActivityFail.With(handler).Record(1)
+	metrics.ActivityTaskFail.With(enrichedHandler).Record(1)
+	metrics.ActivityFail.With(enrichedHandler).Record(1)
+	emitPayloadSizeMetric(baseHandler, failure.Size())
 }
 
 func (a *Activity) emitOnTerminatedMetrics(
-	handler metrics.Handler,
+	metricsHandler metrics.Handler,
 ) {
 	// Terminated activities do not count as properly finished activities so we do not
 	// record any of the latency metrics.
-	metrics.ActivityTerminate.With(handler).Record(1)
+	metrics.ActivityTerminate.With(metricsHandler).Record(1)
 }
 
 func (a *Activity) emitOnCanceledMetrics(
 	ctx chasm.Context,
-	handler metrics.Handler,
+	metricsHandler metrics.Handler,
 	fromStatus activitypb.ActivityExecutionStatus,
 ) {
 	// Record start-to-close latency only while an attempt is running. SCHEDULED (incl. retry
@@ -2046,62 +2085,50 @@ func (a *Activity) emitOnCanceledMetrics(
 		fromStatus != activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED
 	if attemptRunning {
 		if startedTime := a.LastAttempt.Get(ctx).GetStartedTime(); startedTime != nil {
-			metrics.ActivityStartToCloseLatency.With(handler).Record(time.Since(startedTime.AsTime()))
+			metrics.ActivityStartToCloseLatency.With(metricsHandler).Record(time.Since(startedTime.AsTime()))
 		}
 	}
 
 	scheduleToCloseLatency := time.Since(a.GetScheduleTime().AsTime())
-	metrics.ActivityScheduleToCloseLatency.With(handler).Record(scheduleToCloseLatency)
+	metrics.ActivityScheduleToCloseLatency.With(metricsHandler).Record(scheduleToCloseLatency)
 
-	metrics.ActivityCancel.With(handler).Record(1)
+	metrics.ActivityCancel.With(metricsHandler).Record(1)
 }
 
 func (a *Activity) emitOnTimedOutMetrics(
-	ctx chasm.Context,
-	handler metrics.Handler,
+	metricsHandler metrics.Handler,
 	timeoutType enumspb.TimeoutType,
-	fromStatus activitypb.ActivityExecutionStatus,
 ) {
-	// Record start-to-close latency only while an attempt is running. SCHEDULED (incl. retry
-	// backoff) and PAUSED have no running attempt and a possibly-stale StartedTime.
-	attemptRunning := fromStatus != activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED &&
-		fromStatus != activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED
-	if attemptRunning {
-		if startedTime := a.LastAttempt.Get(ctx).GetStartedTime(); startedTime != nil {
-			metrics.ActivityStartToCloseLatency.With(handler).Record(time.Since(startedTime.AsTime()))
-		}
-	}
-
 	scheduleToCloseLatency := time.Since(a.GetScheduleTime().AsTime())
-	metrics.ActivityScheduleToCloseLatency.With(handler).Record(scheduleToCloseLatency)
+	metrics.ActivityScheduleToCloseLatency.With(metricsHandler).Record(scheduleToCloseLatency)
 
 	timeoutTag := metrics.StringTag("timeout_type", timeoutType.String())
-	metrics.ActivityTaskTimeout.With(handler).Record(1, timeoutTag)
-	metrics.ActivityTimeout.With(handler).Record(1, timeoutTag)
+	metrics.ActivityTaskTimeout.With(metricsHandler).Record(1, timeoutTag)
+	metrics.ActivityTimeout.With(metricsHandler).Record(1, timeoutTag)
 }
 
 func (a *Activity) emitOnPausedMetrics(
-	handler metrics.Handler,
+	metricsHandler metrics.Handler,
 ) {
-	metrics.ActivityPause.With(handler).Record(1)
+	metrics.ActivityPause.With(metricsHandler).Record(1)
 }
 
 func (a *Activity) emitOnUpdateOptionsMetrics(
-	handler metrics.Handler,
+	metricsHandler metrics.Handler,
 ) {
-	metrics.ActivityUpdateOptions.With(handler).Record(1)
+	metrics.ActivityUpdateOptions.With(metricsHandler).Record(1)
 }
 
 func (a *Activity) emitOnUnpausedMetrics(
-	handler metrics.Handler,
+	metricsHandler metrics.Handler,
 ) {
-	metrics.ActivityUnpause.With(handler).Record(1)
+	metrics.ActivityUnpause.With(metricsHandler).Record(1)
 }
 
 func (a *Activity) emitOnResetMetrics(
-	handler metrics.Handler,
+	metricsHandler metrics.Handler,
 ) {
-	metrics.ActivityReset.With(handler).Record(1)
+	metrics.ActivityReset.With(metricsHandler).Record(1)
 }
 
 // SearchAttributes implements chasm.VisibilitySearchAttributesProvider interface.

--- a/chasm/lib/activity/activity_tasks.go
+++ b/chasm/lib/activity/activity_tasks.go
@@ -102,7 +102,7 @@ func (h *scheduleToStartTimeoutTaskHandler) Execute(
 	_ chasm.TaskAttributes,
 	_ *activitypb.ScheduleToStartTimeoutTask,
 ) error {
-	metricsHandler, err := activity.enrichMetricsHandler(ctx, metrics.TimerActiveTaskActivityTimeoutScope)
+	metricsHandler, err := activity.enrichedMetricsHandler(ctx, metrics.TimerActiveTaskActivityTimeoutScope)
 	if err != nil {
 		return err
 	}
@@ -110,7 +110,6 @@ func (h *scheduleToStartTimeoutTaskHandler) Execute(
 	event := timeoutEvent{
 		timeoutType:    enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START,
 		metricsHandler: metricsHandler,
-		fromStatus:     activity.GetStatus(),
 	}
 
 	return TransitionTimedOut.Apply(activity, ctx, event)
@@ -149,14 +148,13 @@ func (h *scheduleToCloseTimeoutTaskHandler) Execute(
 	_ chasm.TaskAttributes,
 	_ *activitypb.ScheduleToCloseTimeoutTask,
 ) error {
-	metricsHandler, err := activity.enrichMetricsHandler(ctx, metrics.TimerActiveTaskActivityTimeoutScope)
+	metricsHandler, err := activity.enrichedMetricsHandler(ctx, metrics.TimerActiveTaskActivityTimeoutScope)
 	if err != nil {
 		return err
 	}
 	event := timeoutEvent{
 		timeoutType:    enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
 		metricsHandler: metricsHandler,
-		fromStatus:     activity.GetStatus(),
 	}
 
 	return TransitionTimedOut.Apply(activity, ctx, event)
@@ -197,13 +195,13 @@ func (h *startToCloseTimeoutTaskHandler) Execute(
 		return err
 	}
 
-	metricsHandler, err := activity.enrichMetricsHandler(ctx, metrics.TimerActiveTaskActivityTimeoutScope)
+	metricsHandler, err := activity.enrichedMetricsHandler(ctx, metrics.TimerActiveTaskActivityTimeoutScope)
 	if err != nil {
 		return err
 	}
 
 	if retryState == enumspb.RETRY_STATE_IN_PROGRESS {
-		activity.emitOnAttemptTimedOutMetrics(ctx, metricsHandler, enumspb.TIMEOUT_TYPE_START_TO_CLOSE)
+		activity.emitOnAttemptTimedOutMetrics(metricsHandler, enumspb.TIMEOUT_TYPE_START_TO_CLOSE)
 
 		return nil
 	}
@@ -212,7 +210,6 @@ func (h *startToCloseTimeoutTaskHandler) Execute(
 		timeoutType:    enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
 		retryState:     retryState,
 		metricsHandler: metricsHandler,
-		fromStatus:     activity.GetStatus(),
 	})
 }
 
@@ -281,13 +278,13 @@ func (h *heartbeatTimeoutTaskHandler) Execute(
 		return err
 	}
 
-	metricsHandler, err := activity.enrichMetricsHandler(ctx, metrics.TimerActiveTaskActivityTimeoutScope)
+	metricsHandler, err := activity.enrichedMetricsHandler(ctx, metrics.TimerActiveTaskActivityTimeoutScope)
 	if err != nil {
 		return err
 	}
 
 	if retryState == enumspb.RETRY_STATE_IN_PROGRESS {
-		activity.emitOnAttemptTimedOutMetrics(ctx, metricsHandler, enumspb.TIMEOUT_TYPE_HEARTBEAT)
+		activity.emitOnAttemptTimedOutMetrics(metricsHandler, enumspb.TIMEOUT_TYPE_HEARTBEAT)
 		return nil
 	}
 
@@ -295,6 +292,5 @@ func (h *heartbeatTimeoutTaskHandler) Execute(
 		timeoutType:    enumspb.TIMEOUT_TYPE_HEARTBEAT,
 		retryState:     retryState,
 		metricsHandler: metricsHandler,
-		fromStatus:     activity.GetStatus(),
 	})
 }

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -615,6 +615,98 @@ func TestRecordHeartbeatPauseResetCancelFlags(t *testing.T) {
 	}
 }
 
+func TestRecordHeartbeatMetrics(t *testing.T) {
+	const (
+		namespaceID   = "test-namespace-id"
+		namespaceName = "test-namespace"
+		activityID    = "test-activity-id"
+		runID         = "test-run-id"
+		attempt       = int32(1)
+	)
+	componentRef, err := (&persistencespb.ChasmComponentRef{
+		NamespaceId: namespaceID,
+		BusinessId:  activityID,
+		RunId:       runID,
+	}).Marshal()
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name       string
+		details    *commonpb.Payloads
+		hasDetails string
+	}{
+		{name: "without details", hasDetails: "false"},
+		{
+			name: "with details",
+			details: &commonpb.Payloads{Payloads: []*commonpb.Payload{{
+				Data: []byte("heartbeat details"),
+			}}},
+			hasDetails: "true",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			captureHandler := metricstest.NewCaptureHandler()
+			capture := captureHandler.StartCapture()
+			ctx := &chasm.MockMutableContext{
+				MockContext: chasm.MockContext{
+					HandleNow: func(chasm.Component) time.Time { return defaultTime },
+					HandleExecutionKey: func() chasm.ExecutionKey {
+						return chasm.ExecutionKey{
+							NamespaceID: namespaceID,
+							BusinessID:  activityID,
+							RunID:       runID,
+						}
+					},
+					HandleMetricsHandler: func() metrics.Handler {
+						return captureHandler.WithTags(metrics.NamespaceTag(namespaceName))
+					},
+				},
+			}
+			act := &Activity{
+				ActivityState: &activitypb.ActivityState{
+					Status:           activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
+					HeartbeatTimeout: durationpb.New(0),
+				},
+				LastAttempt: chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{Count: attempt}),
+			}
+			_, err := act.RecordHeartbeat(ctx, WithToken[*historyservice.RecordActivityTaskHeartbeatRequest]{
+				Token: &tokenspb.Task{
+					NamespaceId:  namespaceID,
+					Attempt:      attempt,
+					ComponentRef: componentRef,
+				},
+				Request: &historyservice.RecordActivityTaskHeartbeatRequest{
+					NamespaceId: namespaceID,
+					HeartbeatRequest: &workflowservice.RecordActivityTaskHeartbeatRequest{
+						Details: tc.details,
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			snapshot := capture.Snapshot()
+			heartbeatCount := snapshot[metrics.ActivityHeartbeatCount.Name()]
+			require.Len(t, heartbeatCount, 1)
+			require.Equal(t, int64(1), heartbeatCount[0].Value)
+			require.Equal(t, namespaceName, heartbeatCount[0].Tags["namespace"])
+			require.Equal(t, metrics.HistoryRecordActivityTaskHeartbeatScope, heartbeatCount[0].Tags["operation"])
+			require.Equal(t, tc.hasDetails, heartbeatCount[0].Tags["has_details"])
+
+			payloadSize := snapshot[metrics.ActivityPayloadSize.Name()]
+			if tc.details == nil {
+				require.Empty(t, payloadSize)
+			} else {
+				require.Len(t, payloadSize, 1)
+				require.Equal(t, int64(tc.details.Size()), payloadSize[0].Value)
+				require.Equal(t, namespaceName, payloadSize[0].Tags["namespace"])
+				require.Equal(t, metrics.HistoryRecordActivityTaskHeartbeatScope, payloadSize[0].Tags["operation"])
+			}
+		})
+	}
+}
+
 func TestActivityTaskTokenAttemptStampRejectsTokenFromBeforeAttemptReset(t *testing.T) {
 	testTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 	const (

--- a/chasm/lib/activity/handler.go
+++ b/chasm/lib/activity/handler.go
@@ -88,12 +88,6 @@ func (h *handler) StartActivityExecution(ctx context.Context, req *activitypb.St
 				return nil, err
 			}
 
-			metricsHandler := newActivity.baseMetricsHandler(
-				mutableContext,
-				metrics.HistoryRecordActivityTaskStartedScope,
-			)
-			emitPayloadSizeMetric(metricsHandler, request.GetInput().Size())
-
 			if cbs := request.GetCompletionCallbacks(); len(cbs) > 0 {
 				if err := newActivity.addCompletionCallbacks(mutableContext, request.GetRequestId(), cbs, maxCallbacks); err != nil {
 					return nil, err
@@ -124,6 +118,16 @@ func (h *handler) StartActivityExecution(ctx context.Context, req *activitypb.St
 		}
 
 		return nil, err
+	}
+
+	if result.Created {
+		emitPayloadSizeMetric(
+			h.metricsHandler.WithTags(
+				metrics.NamespaceTag(frontendReq.GetNamespace()),
+				metrics.OperationTag(metrics.HistoryRecordActivityTaskStartedScope),
+			),
+			frontendReq.GetInput().Size(),
+		)
 	}
 
 	// Apply on_conflict_options to an existing activity.

--- a/chasm/lib/activity/handler.go
+++ b/chasm/lib/activity/handler.go
@@ -88,6 +88,12 @@ func (h *handler) StartActivityExecution(ctx context.Context, req *activitypb.St
 				return nil, err
 			}
 
+			metricsHandler := newActivity.baseMetricsHandler(
+				mutableContext,
+				metrics.HistoryRecordActivityTaskStartedScope,
+			)
+			emitPayloadSizeMetric(metricsHandler, request.GetInput().Size())
+
 			if cbs := request.GetCompletionCallbacks(); len(cbs) > 0 {
 				if err := newActivity.addCompletionCallbacks(mutableContext, request.GetRequestId(), cbs, maxCallbacks); err != nil {
 					return nil, err

--- a/chasm/lib/activity/model/vocabulary.go
+++ b/chasm/lib/activity/model/vocabulary.go
@@ -11,11 +11,16 @@ type EventType int
 const (
 	// RPC events
 	PollType EventType = iota
+	HeartbeatType
+	RespondCompletedType
 	RespondFailedType
 	RespondCanceledType
 	RequestCancelType
+	TerminateType
 	PauseType
+	UnpauseType
 	ResetType
+	UpdateOptionsType
 
 	// Timer events
 
@@ -41,11 +46,18 @@ type Event struct {
 // Canonical Event values for the variants frequently used in traces
 var (
 	Poll                   = Event{Type: PollType}
+	Heartbeat              = Event{Type: HeartbeatType}
+	Complete               = Event{Type: RespondCompletedType}
 	FailRetryably          = Event{Type: RespondFailedType, Retryable: true}
+	FailNonRetryably       = Event{Type: RespondFailedType, Retryable: false}
 	RespondCanceled        = Event{Type: RespondCanceledType}
 	RequestCancel          = Event{Type: RequestCancelType}
+	Terminate              = Event{Type: TerminateType}
 	Pause                  = Event{Type: PauseType}
 	ResetKeepPaused        = Event{Type: ResetType, KeepPaused: true}
+	Unpause                = Event{Type: UnpauseType}
+	Reset                  = Event{Type: ResetType}
+	UpdateOptions          = Event{Type: UpdateOptionsType}
 	StartToCloseElapses    = Event{Type: StartToCloseElapsesType}
 	ScheduleToCloseElapses = Event{Type: ScheduleToCloseElapsesType}
 	ScheduleToStartElapses = Event{Type: ScheduleToStartElapsesType}
@@ -59,16 +71,26 @@ func (t EventType) String() string {
 	switch t {
 	case PollType:
 		return "Poll"
+	case HeartbeatType:
+		return "Heartbeat"
+	case RespondCompletedType:
+		return "RespondCompleted"
 	case RespondFailedType:
 		return "RespondFailed"
 	case RespondCanceledType:
 		return "RespondCanceled"
 	case RequestCancelType:
 		return "RequestCancel"
+	case TerminateType:
+		return "Terminate"
 	case PauseType:
 		return "Pause"
+	case UnpauseType:
+		return "Unpause"
 	case ResetType:
 		return "Reset"
+	case UpdateOptionsType:
+		return "UpdateOptions"
 	case ScheduleToStartElapsesType:
 		return "ScheduleToStartElapses"
 	case ScheduleToCloseElapsesType:

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -181,8 +181,9 @@ var TransitionStarted = chasm.NewTransition(
 )
 
 type completeEvent struct {
-	req            *historyservice.RespondActivityTaskCompletedRequest
-	metricsHandler metrics.Handler
+	req             *historyservice.RespondActivityTaskCompletedRequest
+	baseHandler     metrics.Handler
+	enrichedHandler metrics.Handler
 }
 
 // TransitionCompleted transitions to Completed status. SCHEDULED and PAUSED are included because
@@ -221,7 +222,7 @@ var TransitionCompleted = chasm.NewTransition(
 				},
 			}
 
-			a.emitOnCompletedMetrics(ctx, event.metricsHandler, attemptWasStarted)
+			a.emitOnCompletedMetrics(ctx, event.baseHandler, event.enrichedHandler, req.GetResult(), attemptWasStarted)
 
 			return nil
 		})
@@ -229,8 +230,9 @@ var TransitionCompleted = chasm.NewTransition(
 )
 
 type failedEvent struct {
-	req            *historyservice.RespondActivityTaskFailedRequest
-	metricsHandler metrics.Handler
+	req             *historyservice.RespondActivityTaskFailedRequest
+	baseHandler     metrics.Handler
+	enrichedHandler metrics.Handler
 }
 
 // TransitionFailed transitions to Failed status.
@@ -258,7 +260,7 @@ var TransitionFailed = chasm.NewTransition(
 				return err
 			}
 
-			a.emitOnFailedMetrics(ctx, event.metricsHandler)
+			a.emitOnFailedMetrics(ctx, event.baseHandler, event.enrichedHandler, req.GetFailure())
 
 			return nil
 		})
@@ -373,7 +375,6 @@ type timeoutEvent struct {
 	metricsHandler metrics.Handler
 	timeoutType    enumspb.TimeoutType
 	retryState     enumspb.RetryState
-	fromStatus     activitypb.ActivityExecutionStatus
 }
 
 // TransitionTimedOut transitions to TimedOut status.
@@ -424,7 +425,7 @@ var TransitionTimedOut = chasm.NewTransition(
 				}
 			}
 
-			a.emitOnTimedOutMetrics(ctx, event.metricsHandler, timeoutType, event.fromStatus)
+			a.emitOnTimedOutMetrics(event.metricsHandler, timeoutType)
 
 			return nil
 		})
@@ -511,8 +512,8 @@ var TransitionAttemptFailedWhilePauseRequested = chasm.NewTransition(
 )
 
 type resetEvent struct {
-	resetTime time.Time
-	handler   metrics.Handler
+	resetTime      time.Time
+	metricsHandler metrics.Handler
 }
 
 // TransitionReset resets a SCHEDULED or PAUSED activity back to attempt 1. The stamp is bumped to

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -440,12 +440,6 @@ func TestTransitionTimedout(t *testing.T) {
 			timeoutType:  enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
 			attemptCount: 5,
 		},
-		{
-			name:         "heartbeat timeout",
-			startStatus:  activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
-			timeoutType:  enumspb.TIMEOUT_TYPE_HEARTBEAT,
-			attemptCount: 2,
-		},
 	}
 
 	for _, tc := range testCases {

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -388,11 +388,6 @@ func TestTransitionTimedout(t *testing.T) {
 		timeoutType      enumspb.TimeoutType
 		attemptCount     int32
 		heartbeatDetails *commonpb.Payloads
-		// hasStartedTime seeds the attempt with a StartedTime. It is stale (from a prior attempt)
-		// when the activity is not currently running, e.g. during retry backoff.
-		hasStartedTime bool
-		// expectStartToCloseLatency is true only when an attempt was actively running at timeout.
-		expectStartToCloseLatency bool
 	}{
 		{
 			name:         "schedule to start timeout, never started",
@@ -407,22 +402,18 @@ func TestTransitionTimedout(t *testing.T) {
 			attemptCount: 1,
 		},
 		{
-			name:                      "schedule to close timeout from started status with heartbeat details",
-			startStatus:               activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
-			timeoutType:               enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
-			attemptCount:              4,
-			heartbeatDetails:          payloads.EncodeString("schedule-to-close-heartbeat"),
-			hasStartedTime:            true,
-			expectStartToCloseLatency: true,
+			name:             "schedule to close timeout from started status with heartbeat details",
+			startStatus:      activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
+			timeoutType:      enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+			attemptCount:     4,
+			heartbeatDetails: payloads.EncodeString("schedule-to-close-heartbeat"),
 		},
 		{
-			name:                      "start to close timeout with heartbeat details",
-			startStatus:               activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
-			timeoutType:               enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
-			attemptCount:              5,
-			heartbeatDetails:          payloads.EncodeString("start-to-close-heartbeat"),
-			hasStartedTime:            true,
-			expectStartToCloseLatency: true,
+			name:             "start to close timeout with heartbeat details",
+			startStatus:      activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
+			timeoutType:      enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
+			attemptCount:     5,
+			heartbeatDetails: payloads.EncodeString("start-to-close-heartbeat"),
 		},
 		{
 			name:             "heartbeat timeout with heartbeat details",
@@ -438,28 +429,22 @@ func TestTransitionTimedout(t *testing.T) {
 			attemptCount: 2,
 		},
 		{
-			name:                      "schedule to close timeout from started status",
-			startStatus:               activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
-			timeoutType:               enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
-			attemptCount:              4,
-			hasStartedTime:            true,
-			expectStartToCloseLatency: true,
+			name:         "schedule to close timeout from started status",
+			startStatus:  activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
+			timeoutType:  enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+			attemptCount: 4,
 		},
 		{
-			name:                      "start to close timeout",
-			startStatus:               activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
-			timeoutType:               enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
-			attemptCount:              5,
-			hasStartedTime:            true,
-			expectStartToCloseLatency: true,
+			name:         "start to close timeout",
+			startStatus:  activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
+			timeoutType:  enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
+			attemptCount: 5,
 		},
 		{
-			name:                      "heartbeat timeout",
-			startStatus:               activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
-			timeoutType:               enumspb.TIMEOUT_TYPE_HEARTBEAT,
-			attemptCount:              2,
-			hasStartedTime:            true,
-			expectStartToCloseLatency: true,
+			name:         "heartbeat timeout",
+			startStatus:  activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
+			timeoutType:  enumspb.TIMEOUT_TYPE_HEARTBEAT,
+			attemptCount: 2,
 		},
 	}
 
@@ -467,9 +452,6 @@ func TestTransitionTimedout(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := &chasm.MockMutableContext{}
 			attemptState := &activitypb.ActivityAttemptState{Count: tc.attemptCount}
-			if tc.hasStartedTime {
-				attemptState.StartedTime = timestamppb.New(defaultTime)
-			}
 			outcome := &activitypb.ActivityOutcome{}
 
 			activity := &Activity{
@@ -494,12 +476,6 @@ func TestTransitionTimedout(t *testing.T) {
 			controller := gomock.NewController(t)
 			metricsHandler := metrics.NewMockHandler(controller)
 
-			if tc.expectStartToCloseLatency {
-				timerStartToCloseLatency := metrics.NewMockTimerIface(controller)
-				timerStartToCloseLatency.EXPECT().Record(gomock.Any()).Times(1)
-				metricsHandler.EXPECT().Timer(metrics.ActivityStartToCloseLatency.Name()).Return(timerStartToCloseLatency)
-			}
-
 			timerScheduleToCloseLatency := metrics.NewMockTimerIface(controller)
 			timerScheduleToCloseLatency.EXPECT().Record(gomock.Any()).Times(1)
 			metricsHandler.EXPECT().Timer(metrics.ActivityScheduleToCloseLatency.Name()).Return(timerScheduleToCloseLatency)
@@ -517,7 +493,6 @@ func TestTransitionTimedout(t *testing.T) {
 			event := timeoutEvent{
 				timeoutType:    tc.timeoutType,
 				metricsHandler: metricsHandler,
-				fromStatus:     tc.startStatus,
 			}
 
 			err := TransitionTimedOut.Apply(activity, ctx, event)
@@ -582,19 +557,24 @@ func TestTransitionCompleted(t *testing.T) {
 	payload := payloads.EncodeString("Done")
 
 	controller := gomock.NewController(t)
-	metricsHandler := metrics.NewMockHandler(controller)
+	baseHandler := metrics.NewMockHandler(controller)
+	enrichedHandler := metrics.NewMockHandler(controller)
 
 	timerStartToCloseLatency := metrics.NewMockTimerIface(controller)
 	timerStartToCloseLatency.EXPECT().Record(gomock.Any()).Times(1)
-	metricsHandler.EXPECT().Timer(metrics.ActivityStartToCloseLatency.Name()).Return(timerStartToCloseLatency)
+	enrichedHandler.EXPECT().Timer(metrics.ActivityStartToCloseLatency.Name()).Return(timerStartToCloseLatency)
 
 	timerScheduleToCloseLatency := metrics.NewMockTimerIface(controller)
 	timerScheduleToCloseLatency.EXPECT().Record(gomock.Any()).Times(1)
-	metricsHandler.EXPECT().Timer(metrics.ActivityScheduleToCloseLatency.Name()).Return(timerScheduleToCloseLatency)
+	enrichedHandler.EXPECT().Timer(metrics.ActivityScheduleToCloseLatency.Name()).Return(timerScheduleToCloseLatency)
 
 	counterSuccess := metrics.NewMockCounterIface(controller)
 	counterSuccess.EXPECT().Record(int64(1)).Times(1)
-	metricsHandler.EXPECT().Counter(metrics.ActivitySuccess.Name()).Return(counterSuccess)
+	enrichedHandler.EXPECT().Counter(metrics.ActivitySuccess.Name()).Return(counterSuccess)
+
+	counterPayloadSize := metrics.NewMockCounterIface(controller)
+	counterPayloadSize.EXPECT().Record(int64(payload.Size())).Times(1)
+	baseHandler.EXPECT().Counter(metrics.ActivityPayloadSize.Name()).Return(counterPayloadSize)
 
 	req := &historyservice.RespondActivityTaskCompletedRequest{
 		CompleteRequest: &workflowservice.RespondActivityTaskCompletedRequest{
@@ -604,8 +584,9 @@ func TestTransitionCompleted(t *testing.T) {
 	}
 
 	err := TransitionCompleted.Apply(activity, ctx, completeEvent{
-		req:            req,
-		metricsHandler: metricsHandler,
+		req:             req,
+		baseHandler:     baseHandler,
+		enrichedHandler: enrichedHandler,
 	})
 	require.NoError(t, err)
 	require.Equal(t, activitypb.ACTIVITY_EXECUTION_STATUS_COMPLETED, activity.Status)
@@ -649,18 +630,23 @@ func TestTransitionCompleted_ForceCompleteWithNoAttempt(t *testing.T) {
 			payload := payloads.EncodeString("Done")
 
 			controller := gomock.NewController(t)
-			metricsHandler := metrics.NewMockHandler(controller)
+			baseHandler := metrics.NewMockHandler(controller)
+			enrichedHandler := metrics.NewMockHandler(controller)
 
 			// No attempt was ever started, so ActivityStartToCloseLatency must not be recorded.
-			metricsHandler.EXPECT().Timer(metrics.ActivityStartToCloseLatency.Name()).Times(0)
+			enrichedHandler.EXPECT().Timer(metrics.ActivityStartToCloseLatency.Name()).Times(0)
 
 			timerScheduleToCloseLatency := metrics.NewMockTimerIface(controller)
 			timerScheduleToCloseLatency.EXPECT().Record(gomock.Any()).Times(1)
-			metricsHandler.EXPECT().Timer(metrics.ActivityScheduleToCloseLatency.Name()).Return(timerScheduleToCloseLatency)
+			enrichedHandler.EXPECT().Timer(metrics.ActivityScheduleToCloseLatency.Name()).Return(timerScheduleToCloseLatency)
 
 			counterSuccess := metrics.NewMockCounterIface(controller)
 			counterSuccess.EXPECT().Record(int64(1)).Times(1)
-			metricsHandler.EXPECT().Counter(metrics.ActivitySuccess.Name()).Return(counterSuccess)
+			enrichedHandler.EXPECT().Counter(metrics.ActivitySuccess.Name()).Return(counterSuccess)
+
+			counterPayloadSize := metrics.NewMockCounterIface(controller)
+			counterPayloadSize.EXPECT().Record(int64(payload.Size())).Times(1)
+			baseHandler.EXPECT().Counter(metrics.ActivityPayloadSize.Name()).Return(counterPayloadSize)
 
 			req := &historyservice.RespondActivityTaskCompletedRequest{
 				CompleteRequest: &workflowservice.RespondActivityTaskCompletedRequest{
@@ -670,8 +656,9 @@ func TestTransitionCompleted_ForceCompleteWithNoAttempt(t *testing.T) {
 			}
 
 			err := TransitionCompleted.Apply(activity, ctx, completeEvent{
-				req:            req,
-				metricsHandler: metricsHandler,
+				req:             req,
+				baseHandler:     baseHandler,
+				enrichedHandler: enrichedHandler,
 			})
 			require.NoError(t, err)
 			require.Equal(t, activitypb.ACTIVITY_EXECUTION_STATUS_COMPLETED, activity.Status)
@@ -711,23 +698,28 @@ func TestTransitionFailed(t *testing.T) {
 	}
 
 	controller := gomock.NewController(t)
-	metricsHandler := metrics.NewMockHandler(controller)
+	baseHandler := metrics.NewMockHandler(controller)
+	enrichedHandler := metrics.NewMockHandler(controller)
 
 	timerStartToCloseLatency := metrics.NewMockTimerIface(controller)
 	timerStartToCloseLatency.EXPECT().Record(gomock.Any()).Times(1)
-	metricsHandler.EXPECT().Timer(metrics.ActivityStartToCloseLatency.Name()).Return(timerStartToCloseLatency)
+	enrichedHandler.EXPECT().Timer(metrics.ActivityStartToCloseLatency.Name()).Return(timerStartToCloseLatency)
 
 	timerScheduleToCloseLatency := metrics.NewMockTimerIface(controller)
 	timerScheduleToCloseLatency.EXPECT().Record(gomock.Any()).Times(1)
-	metricsHandler.EXPECT().Timer(metrics.ActivityScheduleToCloseLatency.Name()).Return(timerScheduleToCloseLatency)
+	enrichedHandler.EXPECT().Timer(metrics.ActivityScheduleToCloseLatency.Name()).Return(timerScheduleToCloseLatency)
 
 	counterFail := metrics.NewMockCounterIface(controller)
 	counterFail.EXPECT().Record(int64(1)).Times(1)
-	metricsHandler.EXPECT().Counter(metrics.ActivityFail.Name()).Return(counterFail)
+	enrichedHandler.EXPECT().Counter(metrics.ActivityFail.Name()).Return(counterFail)
 
 	counterTaskFail := metrics.NewMockCounterIface(controller)
 	counterTaskFail.EXPECT().Record(int64(1)).Times(1)
-	metricsHandler.EXPECT().Counter(metrics.ActivityTaskFail.Name()).Return(counterTaskFail)
+	enrichedHandler.EXPECT().Counter(metrics.ActivityTaskFail.Name()).Return(counterTaskFail)
+
+	counterPayloadSize := metrics.NewMockCounterIface(controller)
+	counterPayloadSize.EXPECT().Record(int64(failure.Size())).Times(1)
+	baseHandler.EXPECT().Counter(metrics.ActivityPayloadSize.Name()).Return(counterPayloadSize)
 
 	req := &historyservice.RespondActivityTaskFailedRequest{
 		FailedRequest: &workflowservice.RespondActivityTaskFailedRequest{
@@ -738,8 +730,9 @@ func TestTransitionFailed(t *testing.T) {
 	}
 
 	err := TransitionFailed.Apply(activity, ctx, failedEvent{
-		req:            req,
-		metricsHandler: metricsHandler,
+		req:             req,
+		baseHandler:     baseHandler,
+		enrichedHandler: enrichedHandler,
 	})
 
 	require.NoError(t, err)
@@ -970,7 +963,7 @@ func TestTransitionResetClearsHeartbeat(t *testing.T) {
 		Outcome:       chasm.NewDataField(ctx, &activitypb.ActivityOutcome{}),
 	}
 
-	err := TransitionReset.Apply(act, ctx, resetEvent{resetTime: defaultTime, handler: metrics.NoopMetricsHandler})
+	err := TransitionReset.Apply(act, ctx, resetEvent{resetTime: defaultTime, metricsHandler: metrics.NoopMetricsHandler})
 	require.NoError(t, err)
 	require.Nil(t, act.LastHeartbeat.Get(ctx).GetDetails())
 	require.Nil(t, act.LastHeartbeat.Get(ctx).GetRecordedTime())
@@ -1090,7 +1083,7 @@ func TestTransitionResetFromPaused(t *testing.T) {
 				Outcome:     chasm.NewDataField(ctx, &activitypb.ActivityOutcome{}),
 			}
 
-			err := TransitionReset.Apply(act, ctx, resetEvent{resetTime: defaultTime, handler: metrics.NoopMetricsHandler})
+			err := TransitionReset.Apply(act, ctx, resetEvent{resetTime: defaultTime, metricsHandler: metrics.NoopMetricsHandler})
 			require.NoError(t, err)
 			require.Equal(t, activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED, act.Status)
 			require.Equal(t, int32(1), attemptState.Count)
@@ -1128,7 +1121,7 @@ func TestTransitionResetClearsCurrentRetryInterval(t *testing.T) {
 		Outcome:     chasm.NewDataField(ctx, &activitypb.ActivityOutcome{}),
 	}
 
-	err := TransitionReset.Apply(act, ctx, resetEvent{resetTime: defaultTime, handler: metrics.NoopMetricsHandler})
+	err := TransitionReset.Apply(act, ctx, resetEvent{resetTime: defaultTime, metricsHandler: metrics.NoopMetricsHandler})
 	require.NoError(t, err)
 	require.Nil(t, attemptState.GetCurrentRetryInterval(), "TransitionReset must clear CurrentRetryInterval")
 	require.Equal(t, int32(1), attemptState.Count, "TransitionReset must reset Count to 1")

--- a/tests/activity_metrics_parity_test.go
+++ b/tests/activity_metrics_parity_test.go
@@ -22,6 +22,7 @@ func (s *activityParityTestSuite) TestWFASAAMetricsParity() {
 		compared         bool
 		counter          bool
 		baseHandler      bool
+		legacyWFAHandler bool
 		recordingTagKeys []string
 	}
 	type scenario struct {
@@ -42,6 +43,11 @@ func (s *activityParityTestSuite) TestWFASAAMetricsParity() {
 		"versioning_behavior",
 		"workflowType",
 	}
+	legacyWFATagKeys := []string{
+		"activity_targeting_method",
+		"namespace",
+		"service_name",
+	}
 	catalog := []activityMetric{
 		{name: metrics.ActivitySuccess.Name(), compared: true, counter: true},
 		{name: metrics.ActivityFail.Name(), compared: true, counter: true},
@@ -52,10 +58,10 @@ func (s *activityParityTestSuite) TestWFASAAMetricsParity() {
 		{name: metrics.ActivityTaskTimeout.Name(), compared: true, counter: true, recordingTagKeys: []string{"timeout_type"}},
 		{name: metrics.ActivityStartToCloseLatency.Name(), compared: true},
 		{name: metrics.ActivityScheduleToCloseLatency.Name(), compared: true},
-		{name: metrics.ActivityPause.Name(), compared: true, counter: true},
-		{name: metrics.ActivityUnpause.Name(), compared: true, counter: true},
-		{name: metrics.ActivityReset.Name(), compared: true, counter: true},
-		{name: metrics.ActivityUpdateOptions.Name(), compared: true, counter: true},
+		{name: metrics.ActivityPause.Name(), compared: true, counter: true, legacyWFAHandler: true},
+		{name: metrics.ActivityUnpause.Name(), compared: true, counter: true, legacyWFAHandler: true},
+		{name: metrics.ActivityReset.Name(), compared: true, counter: true, legacyWFAHandler: true},
+		{name: metrics.ActivityUpdateOptions.Name(), compared: true, counter: true, legacyWFAHandler: true},
 		{name: metrics.ActivityHeartbeatCount.Name(), compared: true, counter: true, baseHandler: true},
 		{name: metrics.ActivityPayloadSize.Name(), compared: true, counter: true, baseHandler: true},
 	}
@@ -195,18 +201,30 @@ func (s *activityParityTestSuite) TestWFASAAMetricsParity() {
 				}
 				s.Run(metric.name, func(s *activityParityTestSuite) {
 					t := s.T()
-					tagKeys := seriesTagKeys(wfa[metric.name])
-					if !metric.baseHandler && len(wfa[metric.name]) > 0 {
-						expectedTagKeys := append([]string{}, perActivityTagKeys...)
-						expectedTagKeys = append(expectedTagKeys, metric.recordingTagKeys...)
-						sort.Strings(expectedTagKeys)
-						require.Equal(t, expectedTagKeys, tagKeys,
-							"WFA must use the standard per-activity tag keys")
+					wfaTagKeys := seriesTagKeys(wfa[metric.name])
+					saaTagKeys := seriesTagKeys(saa[metric.name])
+					comparisonTagKeys := wfaTagKeys
+					if metric.legacyWFAHandler && len(wfa[metric.name]) > 0 {
+						require.Equal(t, legacyWFATagKeys, wfaTagKeys,
+							"WFA currently emits this metric from its legacy activity handler")
+						for _, rec := range wfa[metric.name] {
+							require.Equal(t, "id", rec.Tags["activity_targeting_method"])
+						}
+						require.Equal(t, perActivityTagKeys, saaTagKeys,
+							"SAA must use the standard per-activity tag keys")
+						comparisonTagKeys = []string{"namespace", "service_name"}
+					} else {
+						if !metric.baseHandler && len(wfa[metric.name]) > 0 {
+							expectedTagKeys := append([]string{}, perActivityTagKeys...)
+							expectedTagKeys = append(expectedTagKeys, metric.recordingTagKeys...)
+							sort.Strings(expectedTagKeys)
+							require.Equal(t, expectedTagKeys, wfaTagKeys,
+								"WFA must use the standard per-activity tag keys")
+						}
+						require.Equal(t, wfaTagKeys, saaTagKeys, "WFA and SAA tag keys must match")
 					}
-					require.Equal(t, tagKeys, seriesTagKeys(saa[metric.name]),
-						"WFA and SAA tag keys must match")
-					wfaSeries := metricSeries(t, "WFA", wfa[metric.name], tagKeys, metric.counter)
-					saaSeries := metricSeries(t, "SAA", saa[metric.name], tagKeys, metric.counter)
+					wfaSeries := metricSeries(t, "WFA", wfa[metric.name], comparisonTagKeys, metric.counter)
+					saaSeries := metricSeries(t, "SAA", saa[metric.name], comparisonTagKeys, metric.counter)
 					if metric.counter {
 						require.Equal(t, wfaSeries, saaSeries, "WFA and SAA counter values must match")
 					} else {

--- a/tests/activity_metrics_parity_test.go
+++ b/tests/activity_metrics_parity_test.go
@@ -1,0 +1,219 @@
+package tests
+
+// SAA vs WFA metrics parity tests.
+
+import (
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/chasm/lib/activity/model"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
+	"go.temporal.io/server/common/testing/await"
+)
+
+func (s *activityParityTestSuite) TestWFASAAMetricsParity() {
+	type activityMetric struct {
+		name             string
+		compared         bool
+		counter          bool
+		baseHandler      bool
+		recordingTagKeys []string
+	}
+	type scenario struct {
+		name    string
+		trace   []model.Event
+		cfg     activityConfig
+		saaOnly bool
+		anchor  string
+	}
+	type recordings map[string][]*metricstest.CapturedRecording
+
+	perActivityTagKeys := []string{
+		"activityType",
+		"namespace",
+		"operation",
+		"service_name",
+		"taskqueue",
+		"versioning_behavior",
+		"workflowType",
+	}
+	catalog := []activityMetric{
+		{name: metrics.ActivitySuccess.Name(), compared: true, counter: true},
+		{name: metrics.ActivityFail.Name(), compared: true, counter: true},
+		{name: metrics.ActivityTaskFail.Name(), compared: true, counter: true},
+		{name: metrics.ActivityCancel.Name(), compared: true, counter: true},
+		{name: metrics.ActivityTerminate.Name()},
+		{name: metrics.ActivityTimeout.Name(), compared: true, counter: true, recordingTagKeys: []string{"timeout_type"}},
+		{name: metrics.ActivityTaskTimeout.Name(), compared: true, counter: true, recordingTagKeys: []string{"timeout_type"}},
+		{name: metrics.ActivityStartToCloseLatency.Name(), compared: true},
+		{name: metrics.ActivityScheduleToCloseLatency.Name(), compared: true},
+		{name: metrics.ActivityPause.Name(), compared: true, counter: true},
+		{name: metrics.ActivityUnpause.Name(), compared: true, counter: true},
+		{name: metrics.ActivityReset.Name(), compared: true, counter: true},
+		{name: metrics.ActivityUpdateOptions.Name(), compared: true, counter: true},
+		{name: metrics.ActivityHeartbeatCount.Name(), compared: true, counter: true, baseHandler: true},
+		{name: metrics.ActivityPayloadSize.Name(), compared: true, counter: true, baseHandler: true},
+	}
+	scenarios := []scenario{
+		{name: "Success", trace: []model.Event{model.Poll, model.Complete}, cfg: activityConfig{MaxAttempts: 1}},
+		{name: "TerminalFailure", trace: []model.Event{model.Poll, model.FailNonRetryably}, cfg: activityConfig{MaxAttempts: 1}},
+		{name: "Cancel", trace: []model.Event{model.Poll, model.RequestCancel, model.RespondCanceled}, cfg: activityConfig{MaxAttempts: 1}},
+		{name: "TerminalTimeout", trace: []model.Event{model.Poll, model.StartToCloseElapses}, cfg: activityConfig{MaxAttempts: 1, StartToClose: activityShortTimeout}, anchor: metrics.ActivityTimeout.Name()},
+		{name: "RetryableTimeout", trace: []model.Event{model.Poll, model.StartToCloseElapses}, cfg: activityConfig{MaxAttempts: 2, StartToClose: activityShortTimeout}, anchor: metrics.ActivityTaskTimeout.Name()},
+		{name: "RetryableTaskFailure", trace: []model.Event{model.Poll, model.FailRetryably}, cfg: activityConfig{MaxAttempts: 2}},
+		{name: "Heartbeat", trace: []model.Event{model.Poll, model.Heartbeat}, cfg: activityConfig{MaxAttempts: 1}},
+		{name: "Pause", trace: []model.Event{model.Poll, model.Pause}, cfg: activityConfig{MaxAttempts: 1}},
+		{name: "Unpause", trace: []model.Event{model.Poll, model.Pause, model.Unpause}, cfg: activityConfig{MaxAttempts: 1}},
+		{name: "Reset", trace: []model.Event{model.Poll, model.Reset}, cfg: activityConfig{MaxAttempts: 1}},
+		{name: "UpdateOptions", trace: []model.Event{model.Poll, model.UpdateOptions}, cfg: activityConfig{MaxAttempts: 1}},
+		{name: "Terminate", trace: []model.Event{model.Poll, model.Terminate}, cfg: activityConfig{MaxAttempts: 1}, saaOnly: true},
+	}
+	expectedTimeoutType := func(trace []model.Event) string {
+		for _, event := range trace {
+			switch event.Type {
+			case model.StartToCloseElapsesType:
+				return enumspb.TIMEOUT_TYPE_START_TO_CLOSE.String()
+			case model.ScheduleToCloseElapsesType:
+				return enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE.String()
+			case model.ScheduleToStartElapsesType:
+				return enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START.String()
+			case model.HeartbeatElapsesType:
+				return enumspb.TIMEOUT_TYPE_HEARTBEAT.String()
+			default:
+			}
+		}
+		return ""
+	}
+	captureMetrics := func(t *testing.T, sc scenario, standalone bool) (recordings, string) {
+		env := newActivityParityEnv(t)
+		capture := env.StartNamespaceMetricCapture()
+		if standalone {
+			newSAADriver(t, env, sc.cfg).driveTrace(t, sc.trace)
+		} else {
+			newWFADriver(t, env, sc.cfg).driveTrace(t, sc.trace)
+		}
+
+		if sc.anchor != "" {
+			await.RequireTrue(t, func() bool {
+				return len(capture.Metric(sc.anchor)) > 0
+			}, 15*time.Second, 100*time.Millisecond)
+		}
+
+		result := make(recordings, len(catalog))
+		for _, metric := range catalog {
+			if recs := capture.Metric(metric.name); len(recs) > 0 {
+				result[metric.name] = recs
+			}
+		}
+		return result, env.Namespace().String()
+	}
+	seriesTagKeys := func(recs []*metricstest.CapturedRecording) []string {
+		seen := make(map[string]struct{})
+		for _, rec := range recs {
+			for key := range rec.Tags {
+				seen[key] = struct{}{}
+			}
+		}
+		keys := make([]string, 0, len(seen))
+		for key := range seen {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		return keys
+	}
+	metricSeries := func(
+		t *testing.T,
+		implementation string,
+		recs []*metricstest.CapturedRecording,
+		tagKeys []string,
+		counter bool,
+	) map[string]int64 {
+		series := make(map[string]int64)
+		for _, rec := range recs {
+			tags := make([]string, 0, len(tagKeys))
+			for _, key := range tagKeys {
+				value, ok := rec.Tags[key]
+				require.True(t, ok, "%s metric recording must have tag %q", implementation, key)
+				// These identify the distinct test executions rather than metric behavior.
+				switch key {
+				case "activityType", "namespace", "taskqueue", "workflowType":
+					value = ""
+				default:
+				}
+				tags = append(tags, key+"="+value)
+			}
+			key := strings.Join(tags, "\x00")
+			if counter {
+				value, ok := rec.Value.(int64)
+				require.True(t, ok, "%s counter recording must have an int64 value", implementation)
+				series[key] += value
+			} else {
+				series[key]++
+			}
+		}
+		return series
+	}
+
+	for _, sc := range scenarios {
+		s.Run(sc.name, func(s *activityParityTestSuite) {
+			t := s.T()
+			saa, saaNS := captureMetrics(t, sc, true)
+			checkTags := func(implementation string, emitted recordings, namespace string) {
+				for name, recs := range emitted {
+					for _, rec := range recs {
+						require.Equal(t, namespace, rec.Tags["namespace"],
+							"%s %s must be tagged with the namespace it was driven in", implementation, name)
+					}
+				}
+				if timeoutType := expectedTimeoutType(sc.trace); timeoutType != "" {
+					for _, name := range []string{metrics.ActivityTaskTimeout.Name(), metrics.ActivityTimeout.Name()} {
+						for _, rec := range emitted[name] {
+							require.Equal(t, timeoutType, rec.Tags["timeout_type"],
+								"%s %s must carry the timeout_type that fired", implementation, name)
+						}
+					}
+				}
+			}
+			checkTags("SAA", saa, saaNS)
+
+			if sc.saaOnly {
+				require.NotEmpty(t, saa[metrics.ActivityTerminate.Name()],
+					"terminating a standalone activity must emit activity_terminate")
+				return
+			}
+
+			wfa, wfaNS := captureMetrics(t, sc, false)
+			checkTags("WFA", wfa, wfaNS)
+			for _, metric := range catalog {
+				if !metric.compared {
+					continue
+				}
+				s.Run(metric.name, func(s *activityParityTestSuite) {
+					t := s.T()
+					tagKeys := seriesTagKeys(wfa[metric.name])
+					if !metric.baseHandler && len(wfa[metric.name]) > 0 {
+						expectedTagKeys := append([]string{}, perActivityTagKeys...)
+						expectedTagKeys = append(expectedTagKeys, metric.recordingTagKeys...)
+						sort.Strings(expectedTagKeys)
+						require.Equal(t, expectedTagKeys, tagKeys,
+							"WFA must use the standard per-activity tag keys")
+					}
+					require.Equal(t, tagKeys, seriesTagKeys(saa[metric.name]),
+						"WFA and SAA tag keys must match")
+					wfaSeries := metricSeries(t, "WFA", wfa[metric.name], tagKeys, metric.counter)
+					saaSeries := metricSeries(t, "SAA", saa[metric.name], tagKeys, metric.counter)
+					if metric.counter {
+						require.Equal(t, wfaSeries, saaSeries, "WFA and SAA counter values must match")
+					} else {
+						require.Equal(t, wfaSeries, saaSeries, "WFA and SAA timer sample counts must match")
+					}
+				})
+			}
+		})
+	}
+}

--- a/tests/activity_standalone_driver.go
+++ b/tests/activity_standalone_driver.go
@@ -24,6 +24,7 @@ import (
 	"go.temporal.io/server/common/testing/testcontext"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -209,6 +210,17 @@ func (a *saaHandle) rpc(_ testing.TB, e model.Event) error {
 	fc := a.d.env.FrontendClient()
 	ns := a.d.env.Namespace().String()
 	switch e.Type {
+	case model.HeartbeatType:
+		_, err := fc.RecordActivityTaskHeartbeat(a.d.ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
+			Namespace: ns, TaskToken: a.token, Details: payloads.EncodeString("heartbeat details"),
+		})
+		return err
+	case model.RespondCompletedType:
+		_, err := fc.RespondActivityTaskCompleted(a.d.ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: ns, TaskToken: a.token, Identity: a.d.env.Tv().WorkerIdentity(),
+			Result: payloads.EncodeString("result"),
+		})
+		return err
 	case model.RespondFailedType:
 		_, err := fc.RespondActivityTaskFailed(a.d.ctx, &workflowservice.RespondActivityTaskFailedRequest{
 			Namespace: ns, TaskToken: a.token, Identity: a.d.env.Tv().WorkerIdentity(), Failure: activityFailure(e.Retryable, a.cfg.NextRetryDelay),
@@ -225,14 +237,32 @@ func (a *saaHandle) rpc(_ testing.TB, e model.Event) error {
 			Reason: "drive", RequestId: uuid.NewString(),
 		})
 		return err
+	case model.TerminateType:
+		_, err := fc.TerminateActivityExecution(a.d.ctx, &workflowservice.TerminateActivityExecutionRequest{
+			Namespace: ns, ActivityId: a.activityID, RunId: a.runID, Identity: a.d.env.Tv().ClientIdentity(),
+			Reason: "drive", RequestId: uuid.NewString(),
+		})
+		return err
 	case model.PauseType:
 		_, err := fc.PauseActivityExecution(a.d.ctx, &workflowservice.PauseActivityExecutionRequest{
 			Namespace: ns, ActivityId: a.activityID, RunId: a.runID, Identity: a.d.env.Tv().ClientIdentity(), Reason: "drive", RequestId: uuid.NewString(),
 		})
 		return err
+	case model.UnpauseType:
+		_, err := fc.UnpauseActivityExecution(a.d.ctx, &workflowservice.UnpauseActivityExecutionRequest{
+			Namespace: ns, ActivityId: a.activityID, RunId: a.runID, Identity: a.d.env.Tv().ClientIdentity(),
+		})
+		return err
 	case model.ResetType:
 		_, err := fc.ResetActivityExecution(a.d.ctx, &workflowservice.ResetActivityExecutionRequest{
 			Namespace: ns, ActivityId: a.activityID, RunId: a.runID, Identity: a.d.env.Tv().ClientIdentity(), KeepPaused: e.KeepPaused,
+		})
+		return err
+	case model.UpdateOptionsType:
+		_, err := fc.UpdateActivityExecutionOptions(a.d.ctx, &workflowservice.UpdateActivityExecutionOptionsRequest{
+			Namespace: ns, ActivityId: a.activityID, RunId: a.runID, Identity: a.d.env.Tv().ClientIdentity(),
+			ActivityOptions: &activitypb.ActivityOptions{HeartbeatTimeout: durationpb.New(time.Hour)},
+			UpdateMask:      &fieldmaskpb.FieldMask{Paths: []string{"heartbeat_timeout"}},
 		})
 		return err
 	default:

--- a/tests/activity_workflow_driver.go
+++ b/tests/activity_workflow_driver.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	activitypb "go.temporal.io/api/activity/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
@@ -23,9 +24,12 @@ import (
 	sdkworker "go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
 	"go.temporal.io/server/chasm/lib/activity/model"
+	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/testcontext"
 	"go.temporal.io/server/tests/testcore"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -255,6 +259,17 @@ func (a *wfaHandle) rpc(t testing.TB, e model.Event) error {
 	fc := a.d.env.FrontendClient()
 	ns := a.d.env.Namespace().String()
 	switch e.Type {
+	case model.HeartbeatType:
+		_, err := fc.RecordActivityTaskHeartbeat(a.d.ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
+			Namespace: ns, TaskToken: a.token, Details: payloads.EncodeString("heartbeat details"),
+		})
+		return err
+	case model.RespondCompletedType:
+		_, err := fc.RespondActivityTaskCompleted(a.d.ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: ns, TaskToken: a.token, Identity: a.d.env.Tv().WorkerIdentity(),
+			Result: payloads.EncodeString("result"),
+		})
+		return err
 	case model.RespondFailedType:
 		_, err := fc.RespondActivityTaskFailed(a.d.ctx, &workflowservice.RespondActivityTaskFailedRequest{
 			Namespace: ns, TaskToken: a.token, Identity: a.d.env.Tv().WorkerIdentity(), Failure: activityFailure(e.Retryable, a.cfg.NextRetryDelay),
@@ -282,9 +297,21 @@ func (a *wfaHandle) rpc(t testing.TB, e model.Event) error {
 			Namespace: ns, WorkflowId: a.workflowID, ActivityId: a.activityID, RunId: a.runID, Identity: a.d.env.Tv().ClientIdentity(), Reason: "drive", RequestId: uuid.NewString(),
 		})
 		return err
+	case model.UnpauseType:
+		_, err := fc.UnpauseActivityExecution(a.d.ctx, &workflowservice.UnpauseActivityExecutionRequest{
+			Namespace: ns, WorkflowId: a.workflowID, ActivityId: a.activityID, RunId: a.runID, Identity: a.d.env.Tv().ClientIdentity(),
+		})
+		return err
 	case model.ResetType:
 		_, err := fc.ResetActivityExecution(a.d.ctx, &workflowservice.ResetActivityExecutionRequest{
 			Namespace: ns, WorkflowId: a.workflowID, ActivityId: a.activityID, RunId: a.runID, Identity: a.d.env.Tv().ClientIdentity(), KeepPaused: e.KeepPaused,
+		})
+		return err
+	case model.UpdateOptionsType:
+		_, err := fc.UpdateActivityExecutionOptions(a.d.ctx, &workflowservice.UpdateActivityExecutionOptionsRequest{
+			Namespace: ns, WorkflowId: a.workflowID, ActivityId: a.activityID, RunId: a.runID, Identity: a.d.env.Tv().ClientIdentity(),
+			ActivityOptions: &activitypb.ActivityOptions{HeartbeatTimeout: durationpb.New(time.Hour)},
+			UpdateMask:      &fieldmaskpb.FieldMask{Paths: []string{"heartbeat_timeout"}},
 		})
 		return err
 	default:


### PR DESCRIPTION
## What changed

- Adds SAA payload-size and heartbeat-count metrics.
- Bring SAA metric tags into parity with WFA
- Bring SAA timeout metric behavior into parity with WFA by omitting start-to-close latency when an attempt times out.


## Why
- Correctness / parity with de-facto correct WFA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes observable metrics and timeout latency recording in the activity execution path; parity tests reduce regression risk but dashboards or alerts keyed on old SAA timeout latency may shift.
> 
> **Overview**
> Standalone activity (SAA) metrics are brought in line with workflow-embedded activity (WFA) behavior and coverage.
> 
> **Handler split:** Metrics use a **base** handler (namespace + `operation` only) for payload-size and heartbeat counters, and an **enriched** handler (per-activity tags: activity type, task queue, workflow type, etc.) for success/fail/latency counters. Complete and fail responses record **`activity_payload_size`** on the base handler from result/failure serialized size; heartbeats record **`activity_heartbeat_count`** (with `has_details`) and payload size when details are present. New standalone activities emit payload size for schedule input on **`RecordActivityTaskStarted`**.
> 
> **Timeout parity:** Terminal and retryable attempt timeouts no longer emit **`activity_start_to_close_latency`** on the timed-out path (matching WFA). Attempt-level timeout counters are unchanged.
> 
> **Verification:** Integration **`TestWFASAAMetricsParity`** drives shared event traces against WFA and SAA and compares metric names, tags, and values; test drivers gain RPCs for heartbeat, complete, terminate, unpause, and update-options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df982df3817bda2782bdbba29e44832395b5742d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->