### PR TITLE
Adds activity metadata as a part of reset, pause and update activity options

### DIFF
--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -287,11 +287,7 @@ func (h *Handler) RecordActivityTaskHeartbeat(ctx context.Context, request *hist
 		return response, h.convertError(err)
 	}
 
-	if !contextutil.ContextMetadataMarkActivityID(ctx, taskToken.GetActivityId()) {
-		h.throttledLogger.Warn("Failed to mark activity ID in context metadata",
-			tag.WorkflowID(taskToken.GetWorkflowId()),
-			tag.ActivityID(taskToken.GetActivityId()))
-	}
+	h.markActivityIDForContextMetadata(ctx, taskToken.GetActivityId(), taskToken.GetWorkflowId())
 
 	// Handle worklow activity (mutable state backed implementation).
 	namespaceID := namespace.ID(request.GetNamespaceId())
@@ -2349,6 +2345,23 @@ func (h *Handler) SyncWorkflowState(ctx context.Context, request *historyservice
 	return response, nil
 }
 
+// markActivityIDForContextMetadata records the activity ID targeted by a request on the context so
+// that mutable state can resolve it to the activity's type and task queue during closeTransaction
+// (see contextutil.ContextMetadataMarkActivityID). activityID is empty when the request targets
+// activities by type or matches all pending activities: such a request can fan out to several
+// activities, which context metadata cannot attribute to a single one, so it is left unmarked and
+// attribution falls back to the workflow.
+func (h *Handler) markActivityIDForContextMetadata(ctx context.Context, activityID string, workflowID string) {
+	if activityID == "" {
+		return
+	}
+	if !contextutil.ContextMetadataMarkActivityID(ctx, activityID) {
+		h.throttledLogger.Warn("Failed to mark activity ID in context metadata",
+			tag.WorkflowID(workflowID),
+			tag.ActivityID(activityID))
+	}
+}
+
 func (h *Handler) UpdateActivityOptions(
 	ctx context.Context, request *historyservice.UpdateActivityOptionsRequest,
 ) (*historyservice.UpdateActivityOptionsResponse, error) {
@@ -2357,6 +2370,8 @@ func (h *Handler) UpdateActivityOptions(
 	if request.GetNamespaceId() == "" {
 		return nil, h.convertError(errNamespaceNotSet)
 	}
+
+	h.markActivityIDForContextMetadata(ctx, request.GetUpdateRequest().GetId(), workflowID)
 
 	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
@@ -2383,6 +2398,8 @@ func (h *Handler) PauseActivity(
 		return nil, h.convertError(errNamespaceNotSet)
 	}
 
+	h.markActivityIDForContextMetadata(ctx, request.GetFrontendRequest().GetId(), workflowID)
+
 	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
@@ -2408,6 +2425,8 @@ func (h *Handler) UnpauseActivity(
 		return nil, h.convertError(errNamespaceNotSet)
 	}
 
+	h.markActivityIDForContextMetadata(ctx, request.GetFrontendRequest().GetId(), workflowID)
+
 	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
@@ -2432,6 +2451,8 @@ func (h *Handler) ResetActivity(
 	if request.GetNamespaceId() == "" {
 		return nil, h.convertError(errNamespaceNotSet)
 	}
+
+	h.markActivityIDForContextMetadata(ctx, request.GetFrontendRequest().GetId(), workflowID)
 
 	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {

--- a/service/history/handler_test.go
+++ b/service/history/handler_test.go
@@ -9,10 +9,12 @@ import (
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/contextutil"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/membership"
 	"go.temporal.io/server/common/metrics"
@@ -239,4 +241,166 @@ func matchRunID(runID string) gomock.Matcher {
 		ref, ok := x.(chasm.ComponentRef)
 		return ok && ref.RunID == runID
 	})
+}
+
+// TestActivityMutationHandlers_MarkActivityIDInContextMetadata verifies that the activity mutation
+// RPCs mark the targeted activity ID on the context, so that mutable state can resolve it to the
+// activity's type and task queue during closeTransaction and the request is attributed to the
+// activity rather than to its workflow. Requests that target activities by type (or match all
+// pending activities) can fan out to several activities and are deliberately left unmarked.
+func TestActivityMutationHandlers_MarkActivityIDInContextMetadata(t *testing.T) {
+	t.Parallel()
+
+	const (
+		namespaceID = "test-namespace-id"
+		workflowID  = "test-workflow-id"
+		activityID  = "test-activity-id"
+	)
+	execution := &commonpb.WorkflowExecution{WorkflowId: workflowID}
+
+	testCases := []struct {
+		name   string
+		invoke func(context.Context, *Handler) error
+		want   []string
+	}{
+		{
+			name: "PauseActivity by ID",
+			invoke: func(ctx context.Context, h *Handler) error {
+				_, err := h.PauseActivity(ctx, &historyservice.PauseActivityRequest{
+					NamespaceId: namespaceID,
+					FrontendRequest: &workflowservice.PauseActivityRequest{
+						Execution: execution,
+						Activity:  &workflowservice.PauseActivityRequest_Id{Id: activityID},
+					},
+				})
+				return err
+			},
+			want: []string{activityID},
+		},
+		{
+			name: "PauseActivity by type",
+			invoke: func(ctx context.Context, h *Handler) error {
+				_, err := h.PauseActivity(ctx, &historyservice.PauseActivityRequest{
+					NamespaceId: namespaceID,
+					FrontendRequest: &workflowservice.PauseActivityRequest{
+						Execution: execution,
+						Activity:  &workflowservice.PauseActivityRequest_Type{Type: "test-activity-type"},
+					},
+				})
+				return err
+			},
+			want: nil,
+		},
+		{
+			name: "UnpauseActivity by ID",
+			invoke: func(ctx context.Context, h *Handler) error {
+				_, err := h.UnpauseActivity(ctx, &historyservice.UnpauseActivityRequest{
+					NamespaceId: namespaceID,
+					FrontendRequest: &workflowservice.UnpauseActivityRequest{
+						Execution: execution,
+						Activity:  &workflowservice.UnpauseActivityRequest_Id{Id: activityID},
+					},
+				})
+				return err
+			},
+			want: []string{activityID},
+		},
+		{
+			name: "UnpauseActivity unpause all",
+			invoke: func(ctx context.Context, h *Handler) error {
+				_, err := h.UnpauseActivity(ctx, &historyservice.UnpauseActivityRequest{
+					NamespaceId: namespaceID,
+					FrontendRequest: &workflowservice.UnpauseActivityRequest{
+						Execution: execution,
+						Activity:  &workflowservice.UnpauseActivityRequest_UnpauseAll{UnpauseAll: true},
+					},
+				})
+				return err
+			},
+			want: nil,
+		},
+		{
+			name: "ResetActivity by ID",
+			invoke: func(ctx context.Context, h *Handler) error {
+				_, err := h.ResetActivity(ctx, &historyservice.ResetActivityRequest{
+					NamespaceId: namespaceID,
+					FrontendRequest: &workflowservice.ResetActivityRequest{
+						Execution: execution,
+						Activity:  &workflowservice.ResetActivityRequest_Id{Id: activityID},
+					},
+				})
+				return err
+			},
+			want: []string{activityID},
+		},
+		{
+			name: "ResetActivity match all",
+			invoke: func(ctx context.Context, h *Handler) error {
+				_, err := h.ResetActivity(ctx, &historyservice.ResetActivityRequest{
+					NamespaceId: namespaceID,
+					FrontendRequest: &workflowservice.ResetActivityRequest{
+						Execution: execution,
+						Activity:  &workflowservice.ResetActivityRequest_MatchAll{MatchAll: true},
+					},
+				})
+				return err
+			},
+			want: nil,
+		},
+		{
+			name: "UpdateActivityOptions by ID",
+			invoke: func(ctx context.Context, h *Handler) error {
+				_, err := h.UpdateActivityOptions(ctx, &historyservice.UpdateActivityOptionsRequest{
+					NamespaceId: namespaceID,
+					UpdateRequest: &workflowservice.UpdateActivityOptionsRequest{
+						Execution: execution,
+						Activity:  &workflowservice.UpdateActivityOptionsRequest_Id{Id: activityID},
+					},
+				})
+				return err
+			},
+			want: []string{activityID},
+		},
+		{
+			name: "UpdateActivityOptions match all",
+			invoke: func(ctx context.Context, h *Handler) error {
+				_, err := h.UpdateActivityOptions(ctx, &historyservice.UpdateActivityOptionsRequest{
+					NamespaceId: namespaceID,
+					UpdateRequest: &workflowservice.UpdateActivityOptionsRequest{
+						Execution: execution,
+						Activity:  &workflowservice.UpdateActivityOptionsRequest_MatchAll{MatchAll: true},
+					},
+				})
+				return err
+			},
+			want: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			controller := shard.NewMockController(ctrl)
+
+			// Marking happens before the shard lookup, so the mark is observable even though the
+			// lookup fails and the request never reaches the engine.
+			shardLookupErr := errors.New("shard lookup failed")
+			controller.EXPECT().
+				GetShardByNamespaceWorkflow(namespace.ID(namespaceID), workflowID).
+				Return(nil, shardLookupErr)
+
+			h := &Handler{
+				logger:          log.NewNoopLogger(),
+				throttledLogger: log.NewThrottledLogger(log.NewNoopLogger(), func() float64 { return 1 }),
+				metricsHandler:  metrics.NoopMetricsHandler,
+				controller:      controller,
+			}
+
+			ctx := contextutil.WithMetadataContext(context.Background())
+			err := tc.invoke(ctx, h)
+			require.ErrorIs(t, err, shardLookupErr)
+			assert.ElementsMatch(t, tc.want, contextutil.ContextMetadataGetMarkedActivityIDs(ctx))
+		})
+	}
 }

--- a/service/history/handler_test.go
+++ b/service/history/handler_test.go
@@ -400,7 +400,7 @@ func TestActivityMutationHandlers_MarkActivityIDInContextMetadata(t *testing.T) 
 			ctx := contextutil.WithMetadataContext(context.Background())
 			err := tc.invoke(ctx, h)
 			require.ErrorIs(t, err, shardLookupErr)
-			assert.ElementsMatch(t, tc.want, contextutil.ContextMetadataGetMarkedActivityIDs(ctx))
+			require.ElementsMatch(t, tc.want, contextutil.ContextMetadataGetMarkedActivityIDs(ctx))
 		})
 	}
 }

--- a/tests/activity_api_pause_test.go
+++ b/tests/activity_api_pause_test.go
@@ -961,10 +961,17 @@ func TestActivityApiPause_AttributesToActivityInContextMetadata(t *testing.T) {
 
 	activityStartedCn := make(chan struct{}, 1)
 	releaseActivityCn := make(chan struct{})
-	activityFunction := func() (string, error) {
+	// Block on the activity's own context rather than a suite helper: the helper calls FailNow on
+	// timeout, which is only safe on the test goroutine, and the test's own timeout below already
+	// reports a hang.
+	activityFunction := func(activityCtx context.Context) (string, error) {
 		activityStartedCn <- struct{}{}
-		s.WaitForChannel(releaseActivityCn)
-		return "done!", nil
+		select {
+		case <-releaseActivityCn:
+			return "done!", nil
+		case <-activityCtx.Done():
+			return "", activityCtx.Err()
+		}
 	}
 	workflowFn := func(wfCtx workflow.Context) error {
 		var ret string

--- a/tests/activity_api_pause_test.go
+++ b/tests/activity_api_pause_test.go
@@ -1009,6 +1009,8 @@ func TestActivityApiPause_AttributesToActivityInContextMetadata(t *testing.T) {
 		case strings.HasPrefix(key, "activity-task-queue-"):
 			require.Empty(t, gotActivityTaskQueue, "expected metadata for exactly one activity, got %v", entries)
 			gotActivityTaskQueue = value
+		default:
+			// Not activity-scoped (e.g. the workflow's own type and task queue).
 		}
 	}
 	require.Equal(t, activityType, gotActivityType, "trailer entries: %v", entries)

--- a/tests/activity_api_pause_test.go
+++ b/tests/activity_api_pause_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -13,12 +14,19 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
+	sdkactivity "go.temporal.io/sdk/activity"
 	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
+	contextpropagationspb "go.temporal.io/server/api/contextpropagation/v1"
+	"go.temporal.io/server/common/contextutil"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/tests/testcore"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
@@ -930,4 +938,102 @@ func TestActivityApiPauseClientTestSuite(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestActivityApiPause_AttributesToActivityInContextMetadata verifies end to end that PauseActivity
+// marks the targeted activity so that the activity's type and task queue — not just the workflow's —
+// are resolved from mutable state and propagated to the caller in the "contextmetadata-bin" gRPC
+// trailer, the same way RecordActivityTaskHeartbeat does.
+func TestActivityApiPause_AttributesToActivityInContextMetadata(t *testing.T) {
+	t.Parallel()
+
+	const (
+		activityID   = "activity-id"
+		activityType = "PauseAttributionActivity"
+	)
+
+	// The frontend only emits context metadata trailers when this is enabled, and it is read when
+	// the frontend interceptor is constructed, so it must be set at cluster startup.
+	s := testcore.NewEnv(t, testcore.WithDynamicConfig(dynamicconfig.FrontendContextMetadataSetTrailer, true))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	activityStartedCn := make(chan struct{}, 1)
+	releaseActivityCn := make(chan struct{})
+	activityFunction := func() (string, error) {
+		activityStartedCn <- struct{}{}
+		s.WaitForChannel(releaseActivityCn)
+		return "done!", nil
+	}
+	workflowFn := func(wfCtx workflow.Context) error {
+		var ret string
+		return workflow.ExecuteActivity(workflow.WithActivityOptions(wfCtx, workflow.ActivityOptions{
+			ActivityID:             activityID,
+			DisableEagerExecution:  true,
+			StartToCloseTimeout:    15 * time.Minute,
+			ScheduleToCloseTimeout: 30 * time.Minute,
+		}), activityType).Get(wfCtx, &ret)
+	}
+
+	s.SdkWorker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterActivityWithOptions(activityFunction, sdkactivity.RegisterOptions{Name: activityType})
+
+	workflowRun, err := s.SdkClient().ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
+		ID:        testcore.RandomizeStr("wf_id-" + t.Name()),
+		TaskQueue: s.WorkerTaskQueue(),
+	}, workflowFn)
+	require.NoError(t, err)
+
+	s.WaitForChannel(activityStartedCn)
+
+	var trailer metadata.MD
+	_, err = s.FrontendClient().PauseActivity(ctx, &workflowservice.PauseActivityRequest{
+		Namespace: s.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: workflowRun.GetID()},
+		Activity:  &workflowservice.PauseActivityRequest_Id{Id: activityID},
+		Identity:  "test-identity",
+		Reason:    "test-reason",
+	}, grpc.Trailer(&trailer))
+	require.NoError(t, err)
+
+	entries := contextMetadataFromTrailer(t, trailer)
+	// Attribution is keyed by scheduled event ID, which the caller doesn't know, so look up the
+	// single activity entry the way consumers do.
+	var gotActivityType, gotActivityTaskQueue string
+	for key, value := range entries {
+		switch {
+		case strings.HasPrefix(key, "activity-type-"):
+			require.Empty(t, gotActivityType, "expected metadata for exactly one activity, got %v", entries)
+			gotActivityType = value
+		case strings.HasPrefix(key, "activity-task-queue-"):
+			require.Empty(t, gotActivityTaskQueue, "expected metadata for exactly one activity, got %v", entries)
+			gotActivityTaskQueue = value
+		}
+	}
+	require.Equal(t, activityType, gotActivityType, "trailer entries: %v", entries)
+	require.Equal(t, s.WorkerTaskQueue(), gotActivityTaskQueue, "trailer entries: %v", entries)
+	// Workflow attribution is still emitted alongside the activity's.
+	require.NotEmpty(t, entries[contextutil.MetadataKeyWorkflowType], "trailer entries: %v", entries)
+
+	_, err = s.FrontendClient().UnpauseActivity(ctx, &workflowservice.UnpauseActivityRequest{
+		Namespace: s.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: workflowRun.GetID()},
+		Activity:  &workflowservice.UnpauseActivityRequest_Id{Id: activityID},
+	})
+	require.NoError(t, err)
+
+	close(releaseActivityCn)
+	require.NoError(t, workflowRun.Get(ctx, nil))
+}
+
+// contextMetadataFromTrailer decodes the ContextMetadata proto that ContextMetadataInterceptor
+// writes to the "contextmetadata-bin" gRPC trailer.
+func contextMetadataFromTrailer(t *testing.T, trailer metadata.MD) map[string]string {
+	t.Helper()
+	values := trailer.Get("contextmetadata-bin")
+	require.Len(t, values, 1, "expected exactly one contextmetadata-bin trailer, got trailer %v", trailer)
+	var metadataProto contextpropagationspb.ContextMetadata
+	require.NoError(t, proto.Unmarshal([]byte(values[0]), &metadataProto))
+	return metadataProto.GetEntries()
 }


### PR DESCRIPTION
## What changed?
Populates activity type/task queue information on context if available for in-line activity operations.

## Why?
Enables more information for debugging, metrics, etc.

## How did you test it?
- [x ] built
- [ ] run locally and tested manually
- [x ] covered by existing tests
- [x ] added new unit test(s)
- [ ] added new functional test(s)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only context metadata on existing RPC paths; fan-out requests unchanged; covered by unit and integration tests.
> 
> **Overview**
> **Activity-scoped context metadata** is now recorded for inline activity control APIs when the request targets a single activity by ID, matching the existing heartbeat behavior.
> 
> The history handler introduces **`markActivityIDForContextMetadata`**, which stamps the activity ID on the request context so mutable state can resolve **activity type and task queue** during `closeTransaction` and surface them in gRPC **context metadata** trailers. **`RecordActivityTaskHeartbeat`** uses this helper; **`PauseActivity`**, **`UnpauseActivity`**, **`ResetActivity`**, and **`UpdateActivityOptions`** call it before shard lookup. **Empty activity IDs** (pause/unpause/reset/update by type, match-all, unpause-all) are intentionally **not** marked because attribution cannot pick one activity.
> 
> Coverage adds **handler unit tests** for mark vs. no-mark cases and an **integration test** that `PauseActivity` returns the expected activity type and task queue in the `contextmetadata-bin` trailer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29e715c8e43690db6f2547aa393f186e51a41b72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->