### PR TITLE
Remove system.enableNamespaceHandoverWait dynamic config

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -130,11 +130,6 @@ for signal / start / signal with start API if namespace is not active`,
 		false,
 		`ForceNamespaceSelectedAPIAutoForwarding forces selective (whitelist) API forwarding for the namespace when true, overriding all-apis-forwarding policy for that namespace`,
 	)
-	EnableNamespaceHandoverWait = NewNamespaceBoolSetting(
-		"system.enableNamespaceHandoverWait",
-		false,
-		`EnableNamespaceHandoverWait whether waiting for namespace replication state update before serve the request`,
-	)
 	TransactionSizeLimit = NewGlobalIntSetting(
 		"system.transactionSizeLimit",
 		primitives.DefaultTransactionSizeLimit,

--- a/common/rpc/interceptor/namespace_handover.go
+++ b/common/rpc/interceptor/namespace_handover.go
@@ -28,7 +28,6 @@ type (
 	NamespaceHandoverInterceptor struct {
 		namespaceRegistry                      namespace.Registry
 		timeSource                             clock.TimeSource
-		enabledForNS                           dynamicconfig.BoolPropertyFnWithNamespaceFilter
 		nsCacheRefreshInterval                 dynamicconfig.DurationPropertyFn
 		metricsHandler                         metrics.Handler
 		logger                                 log.Logger
@@ -59,7 +58,6 @@ func NewNamespaceHandoverInterceptor(
 	}
 
 	return &NamespaceHandoverInterceptor{
-		enabledForNS:                           dynamicconfig.EnableNamespaceHandoverWait.Get(dc),
 		nsCacheRefreshInterval:                 dynamicconfig.NamespaceCacheRefreshInterval.Get(dc),
 		namespaceRegistry:                      namespaceRegistry,
 		metricsHandler:                         metricsHandler,
@@ -109,7 +107,7 @@ func (i *NamespaceHandoverInterceptor) Intercept(
 	methodName := api.MethodName(info.FullMethod)
 	namespaceName := MustGetNamespaceName(i.namespaceRegistry, req)
 
-	if namespaceName != namespace.EmptyName && i.enabledForNS(namespaceName.String()) {
+	if namespaceName != namespace.EmptyName {
 		var waitTime *time.Duration
 		defer func() {
 			if waitTime != nil {


### PR DESCRIPTION
## What changed?
Removes the `system.enableNamespaceHandoverWait` dynamic config and the per-namespace gate it controlled in `NamespaceHandoverInterceptor`.

- Deleted the `EnableNamespaceHandoverWait` setting from `common/dynamicconfig/constants.go`.
- Removed the `enabledForNS` field and its `.Get(dc)` wiring from the interceptor.
- The handover-wait now applies unconditionally: `Intercept` runs the wait for any request whose namespace is in `REPLICATION_STATE_HANDOVER` (methods in the allowed-during-handover set remain exempt).

Net effect: the feature graduates from a per-namespace toggle (OSS default `false`) to always-on.

## Why?
The namespace-handover wait is a correctness mechanism that briefly holds requests while a namespace transitions replication state, so callers don't hit a namespace mid-handover. It is already enabled in production, and gating it behind a dynamic config adds configuration surface without a real use case for turning it off. Making it unconditional removes a foot-gun and simplifies the interceptor.

## How did you test it?
- [x] built (`go build ./common/...`, `go vet`, `gofmt` clean)
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- **Behavior change for OSS deployments**: the config previously defaulted to `false`, so OSS clusters that never set it will now perform the handover wait. This only affects requests to namespaces actively in `REPLICATION_STATE_HANDOVER`, and the wait is bounded by the request deadline / namespace cache refresh interval, but it is a behavioral change worth calling out.
- No way to disable the wait remains; if an operator needs an escape hatch, that would need to be reintroduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
