### PR TITLE
Resend missing CAN successor instead of DLQ on non-current branch

### DIFF
--- a/service/history/replication/executable_verify_versioned_transition_task.go
+++ b/service/history/replication/executable_verify_versioned_transition_task.go
@@ -161,7 +161,7 @@ func (e *ExecutableVerifyVersionedTransitionTask) Execute() (retErr error) {
 				fmt.Errorf("NamespaceId: %v, workflowId: %v, runId: %v, expected last eventId: %v, versionedTransition: %v",
 					e.NamespaceID, e.WorkflowID, e.RunID, e.taskAttr.NextEventId-1, e.ReplicationTask().VersionedTransition))
 		}
-		return e.verifyNewRunExist(ctx)
+		return e.verifyNewRunExist(ctx, true)
 	}
 
 	// case 2: verify task has newer VersionedTransition, need to sync state
@@ -178,7 +178,7 @@ func (e *ExecutableVerifyVersionedTransitionTask) Execute() (retErr error) {
 	}
 	// case 3: state transition is on non-current branch, but no event to verify
 	if e.taskAttr.NextEventId == common2.EmptyEventID {
-		return e.verifyNewRunExist(ctx)
+		return e.verifyNewRunExist(ctx, false)
 	}
 
 	if len(e.taskAttr.EventVersionHistory) == 0 {
@@ -200,7 +200,7 @@ func (e *ExecutableVerifyVersionedTransitionTask) Execute() (retErr error) {
 	}
 	// case 4: event on non-current branch are up-to-date
 	if versionhistory.IsEqualVersionHistoryItem(lcaItem, lastItem) {
-		return e.verifyNewRunExist(ctx)
+		return e.verifyNewRunExist(ctx, false)
 	}
 	// case 5: event on non-current branch are not up-to-date, we need to backfill events
 	startEventVersion, err := versionhistory.GetVersionHistoryEventVersion(targetHistory, lcaItem.EventId+1)
@@ -219,7 +219,15 @@ func (e *ExecutableVerifyVersionedTransitionTask) Execute() (retErr error) {
 	)
 }
 
-func (e *ExecutableVerifyVersionedTransitionTask) verifyNewRunExist(ctx context.Context) error {
+// verifyNewRunExist confirms the continue-as-new successor (NewRunId) is present on this cluster.
+//
+// onCurrentBranch distinguishes the caller. On the current branch (case 1) the successor was created
+// atomically with the parent's CAN transition, which is already applied — so a miss is a genuine gap
+// (created-then-removed / corruption) and remains non-retryable DataLoss so it stays visible. On a
+// non-current branch (cases 3 & 4) the successor may legitimately not be materialized yet (replication
+// lag, or a losing multi-cluster CAN-conflict branch), so we recover by resending it via SyncState
+// rather than dead-lettering.
+func (e *ExecutableVerifyVersionedTransitionTask) verifyNewRunExist(ctx context.Context, onCurrentBranch bool) error {
 	if len(e.taskAttr.NewRunId) == 0 {
 		return nil
 	}
@@ -228,9 +236,24 @@ func (e *ExecutableVerifyVersionedTransitionTask) verifyNewRunExist(ctx context.
 	case nil:
 		return nil
 	case *serviceerror.NotFound:
-		return softassert.UnexpectedDataLoss(e.Logger, "workflow new run not found",
-			fmt.Errorf("NamespaceId: %v, workflowId: %v, runId: %v, newRunId: %v",
-				e.NamespaceID, e.WorkflowID, e.RunID, e.taskAttr.NewRunId))
+		if onCurrentBranch {
+			return softassert.UnexpectedDataLoss(e.Logger, "workflow new run not found",
+				fmt.Errorf("NamespaceId: %v, workflowId: %v, runId: %v, newRunId: %v",
+					e.NamespaceID, e.WorkflowID, e.RunID, e.taskAttr.NewRunId))
+		}
+		// Non-current branch: re-pull the new run from the source, mirroring the parent-resend in
+		// Execute (cases 2 & 5) and #7757. SyncState handles every outcome (present->create,
+		// source-missing->cleanup, transient->retry) without dead-lettering; genuinely unrecoverable
+		// cases still DLQ via the bounded retry policy.
+		return serviceerrors.NewSyncState(
+			"new run not replicated yet",
+			e.NamespaceID,
+			e.WorkflowID,
+			e.taskAttr.NewRunId,
+			e.taskAttr.GetArchetypeId(),
+			nil,
+			nil,
+		)
 	default:
 		return err
 	}

--- a/service/history/replication/executable_verify_versioned_transition_task_test.go
+++ b/service/history/replication/executable_verify_versioned_transition_task_test.go
@@ -500,6 +500,101 @@ func (s *executableVerifyVersionedTransitionTaskSuite) TestExecute_NonCurrentBra
 	s.NoError(err)
 }
 
+func (s *executableVerifyVersionedTransitionTaskSuite) TestExecute_NonCurrentBranch_NewRunNotFound() {
+	// Case 4: the verify's transition is on a NON-current branch (e.g. a losing multi-cluster
+	// CAN-conflict branch) whose events have reconciled to the current (winner) branch, but the
+	// successor (NewRunId) has not replicated here yet. This must recover by resending the new run
+	// via SyncState — NOT dead-letter as DataLoss (that is reserved for the current-branch case).
+	taskNextEvent := int64(10)
+	replicationTask := &replicationspb.ReplicationTask{
+		TaskType:     enumsspb.REPLICATION_TASK_TYPE_VERIFY_VERSIONED_TRANSITION_TASK,
+		SourceTaskId: s.taskID,
+		Attributes: &replicationspb.ReplicationTask_VerifyVersionedTransitionTaskAttributes{
+			VerifyVersionedTransitionTaskAttributes: &replicationspb.VerifyVersionedTransitionTaskAttributes{
+				NamespaceId: s.namespaceID,
+				WorkflowId:  s.workflowID,
+				RunId:       s.runID,
+				NextEventId: taskNextEvent,
+				NewRunId:    s.newRunID,
+				EventVersionHistory: []*historyspb.VersionHistoryItem{
+					{
+						EventId: 9,
+						Version: 1,
+					},
+				},
+				ArchetypeId: chasm.WorkflowArchetypeID,
+			},
+		},
+		VersionedTransition: &persistencespb.VersionedTransition{
+			NamespaceFailoverVersion: 1,
+			TransitionCount:          4,
+		},
+	}
+	s.executableTask.EXPECT().TerminalState().Return(false)
+	s.executableTask.EXPECT().MarkExecutionStart()
+	s.executableTask.EXPECT().ReplicationTask().Return(replicationTask).AnyTimes()
+	s.executableTask.EXPECT().GetNamespaceInfo(gomock.Any(), s.task.NamespaceID, gomock.Any()).Return(
+		uuid.NewString(), true, nil,
+	).AnyTimes()
+
+	mu := historyi.NewMockMutableState(s.controller)
+	mu.EXPECT().CloneToProto().Return(
+		&persistencespb.WorkflowMutableState{
+			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
+				TransitionHistory: []*persistencespb.VersionedTransition{
+					{NamespaceFailoverVersion: 1, TransitionCount: 3},
+					{NamespaceFailoverVersion: 3, TransitionCount: 6},
+				},
+				VersionHistories: &historyspb.VersionHistories{
+					Histories: []*historyspb.VersionHistory{
+						{
+							BranchToken: []byte{1, 2, 3},
+							Items: []*historyspb.VersionHistoryItem{
+								{
+									EventId: 5,
+									Version: 1,
+								},
+								{
+									EventId: 10,
+									Version: 3,
+								},
+							},
+						},
+						{
+							BranchToken: []byte{1, 2, 3, 4},
+							Items: []*historyspb.VersionHistoryItem{
+								{
+									EventId: 10,
+									Version: 1,
+								},
+							},
+						},
+					},
+				},
+			},
+			NextEventId: taskNextEvent,
+		},
+	).AnyTimes()
+
+	s.mockGetMutableState(s.namespaceID, s.workflowID, s.runID, mu, nil)
+	s.mockGetMutableState(s.namespaceID, s.workflowID, s.newRunID, nil, serviceerror.NewNotFound("workflow not found"))
+
+	task := NewExecutableVerifyVersionedTransitionTask(
+		s.toolBox,
+		s.taskID,
+		time.Now(),
+		s.sourceClusterName,
+		s.sourceShardKey,
+		replicationTask,
+	)
+	task.ExecutableTask = s.executableTask
+
+	err := task.Execute()
+	s.ErrorAs(err, new(*serviceerrors.SyncState))
+	// The resend targets the NEW run, so its own replication path re-pulls and applies it.
+	s.Equal(s.newRunID, err.(*serviceerrors.SyncState).RunId)
+}
+
 func (s *executableVerifyVersionedTransitionTaskSuite) TestExecute_NonCurrentBranch_NotUpToDate() {
 	taskNextEvent := int64(10)
 	replicationTask := &replicationspb.ReplicationTask{


### PR DESCRIPTION
## What changed?

Address an edge case in VerifyVersionedTransition that causes the task to DLQ when new CAN run id does not exists on the receiver.   Change the logic to attempt to recover/self-heal reusing the recovery machinery already in use for a missing/stale parent.

## Why?

This is a valid edge case that could occur under the following sequence of events.

1. **Source generates the CAN.** The parent's long timer fires on the source (active) cluster and the workflow continues-as-new. This produces a `SYNC_VERSIONED_TRANSITION` task carrying the successor's `NewRunInfo`, bound for the target. Under replication lag it is not yet applied on the target.
2. **Failover.** The namespace fails over; the target becomes the new active cluster, on a higher failover version.
3. **Target replays the CAN.** The new active replays the same still-pending timer and generates its *own* CAN event — a second successor on its higher-version branch. This branches the parent's history from the source's. The higher failover version wins, so both clusters converge on the target's branch (the "winner"); the source's successor is the "loser".
4. **gRPC stream reset.** The cross-cluster replication stream resets — for reasons unrelated to the failover (a history shard moved to another host, a pod restart, a network blip, etc.). The source's CAN SYNC from step 1 was still never applied on the target.
5. **SYNC → VERIFY downgrade.** On reconnect the source re-reads that un-acked transition. Its progress cache still marks the transition "sent" (marked at *build* time, and preserved across stream resets), so instead of re-shipping the state-bearing SYNC it ships a **content-free VERIFY** carrying only the loser's `new_run_id`.
6. **Verify lands on the winner branch.** The target processes the VERIFY. Its current branch is the winner (step 3), so the loser's transition is on a non-current branch → **case 4**. `verifyNewRunExist` then looks up the loser's `new_run_id`, which was never created on the target (it lost the conflict) → `NotFound`.
7. **Fatal step.** `verifyNewRunExist` (`executable_verify_versioned_transition_task.go`) turns that `NotFound` into `softassert.UnexpectedDataLoss(...)`. `DataLoss` is non-retryable (`executable_task.go`), so the task goes straight to the DLQ on the first miss, with no attempt to recover.

This change should self-heal this scenario.   More detail on the edge case can be found [here](https://app.notion.com/p/temporalio/s-aw026-ReplicationTaskEnqueuedToDLQ-fix-proposal-VerifyVersionedTransition-3ab8fc5677388053861dcff056ce9de5?source=copy_link) 

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)


