### PR TITLE
Disable standalone activity on-conflict request ID attachment

### DIFF
--- a/chasm/lib/activity/handler.go
+++ b/chasm/lib/activity/handler.go
@@ -122,6 +122,7 @@ func (h *handler) StartActivityExecution(ctx context.Context, req *activitypb.St
 
 	// Apply on_conflict_options to an existing activity.
 	// TODO: Use chasm.UpdateWithStartExecution to avoid a second transaction once the engine supports BusinessIDConflictPolicyFail in the updateFn path.
+	// TODO: Atomically attach request ID, callbacks, and links once CHASM supports request ID updates.
 	cbs := frontendReq.GetCompletionCallbacks()
 	links := frontendReq.GetLinks()
 	onConflict := frontendReq.GetOnConflictOptions()

--- a/chasm/lib/activity/validator.go
+++ b/chasm/lib/activity/validator.go
@@ -242,10 +242,8 @@ func validateAndNormalizeIDPolicy(req *workflowservice.StartActivityExecutionReq
 }
 
 // validateOnConflictOptions validates the on_conflict_options of a start request:
-//   - attach_completion_callbacks requires attach_request_id. A completion callback is recorded
-//     against the request ID (see addCompletionCallbacks, which keys the callback by request ID).
-//   - attach_request_id requires at least one completion callback or link, since attaching a
-//     request ID is only meaningful alongside something to attach.
+//   - attach_request_id is not supported until CHASM can persist request IDs on running executions.
+//   - attach_completion_callbacks requires attach_request_id.
 //
 // attach_links is independent and may be set on its own.
 func validateOnConflictOptions(req *workflowservice.StartActivityExecutionRequest) error {
@@ -253,15 +251,14 @@ func validateOnConflictOptions(req *workflowservice.StartActivityExecutionReques
 	if onConflictOptions == nil {
 		return nil
 	}
+	if onConflictOptions.GetAttachRequestId() {
+		// TODO: Remove this once CHASM supports atomic request ID updates.
+		return serviceerror.NewInvalidArgument(
+			"on_conflict_options: attach_request_id is not currently supported for standalone activities")
+	}
 	if onConflictOptions.GetAttachCompletionCallbacks() && !onConflictOptions.GetAttachRequestId() {
 		return serviceerror.NewInvalidArgument(
 			"on_conflict_options: attach_completion_callbacks requires attach_request_id to be set")
-	}
-	if onConflictOptions.GetAttachRequestId() &&
-		len(req.GetCompletionCallbacks()) == 0 &&
-		len(req.GetLinks()) == 0 {
-		return serviceerror.NewInvalidArgument(
-			"on_conflict_options: attach_request_id requires at least one completion callback or link")
 	}
 	return nil
 }

--- a/chasm/lib/activity/validator_test.go
+++ b/chasm/lib/activity/validator_test.go
@@ -856,7 +856,10 @@ func TestValidateOnConflictOptions(t *testing.T) {
 				AttachCompletionCallbacks: true,
 			},
 		}
-		require.NoError(t, validateOnConflictOptions(req))
+		err := validateOnConflictOptions(req)
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Contains(t, invalidArgErr.Message, "attach_request_id is not currently supported for standalone activities")
 	})
 
 	t.Run("AttachLinksOnly", func(t *testing.T) {
@@ -868,7 +871,6 @@ func TestValidateOnConflictOptions(t *testing.T) {
 	})
 
 	t.Run("AttachRequestIdWithLink", func(t *testing.T) {
-		// A request ID alongside a link is valid (request ID has something to attach to).
 		req := &workflowservice.StartActivityExecutionRequest{
 			Links: []*commonpb.Link{{}},
 			OnConflictOptions: &commonpb.OnConflictOptions{
@@ -876,7 +878,10 @@ func TestValidateOnConflictOptions(t *testing.T) {
 				AttachLinks:     true,
 			},
 		}
-		require.NoError(t, validateOnConflictOptions(req))
+		err := validateOnConflictOptions(req)
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Contains(t, invalidArgErr.Message, "attach_request_id is not currently supported for standalone activities")
 	})
 
 	t.Run("AttachCallbacksWithoutRequestId", func(t *testing.T) {
@@ -897,7 +902,7 @@ func TestValidateOnConflictOptions(t *testing.T) {
 		err := validateOnConflictOptions(req)
 		var invalidArgErr *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgErr)
-		require.Contains(t, invalidArgErr.Message, "attach_request_id requires at least one completion callback or link")
+		require.Contains(t, invalidArgErr.Message, "attach_request_id is not currently supported for standalone activities")
 	})
 
 	t.Run("AttachRequestIdAndCallbacksWithoutCallbackProvided", func(t *testing.T) {
@@ -910,7 +915,7 @@ func TestValidateOnConflictOptions(t *testing.T) {
 		err := validateOnConflictOptions(req)
 		var invalidArgErr *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgErr)
-		require.Contains(t, invalidArgErr.Message, "attach_request_id requires at least one completion callback or link")
+		require.Contains(t, invalidArgErr.Message, "attach_request_id is not currently supported for standalone activities")
 	})
 }
 

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -275,6 +275,7 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 		})
 
 		t.Run("OnConflictOptions", func(t *testing.T) {
+			t.Skip("TODO: Re-enable once CHASM supports atomic request ID updates")
 			env.OverrideDynamicConfig(
 				callback.AllowedAddresses,
 				[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}},


### PR DESCRIPTION
## What changed?
  - Reject standalone activity starts with OnConflictOptions.attach_request_id=true.
  - Preserve link-only on-conflict attachment.
  - Temporarily skip functional tests that require CHASM request-ID updates.
  - Add TODOs for restoring atomic request-ID, callback, and link attachment.
  - 
## Why?
CHASM cannot currently attach request IDs to a running execution. Accepting this option makes on-conflict callback attachment non-idempotent and violates the public request-ID contract. The guard prevents users from relying on incomplete behavior until CHASM supports atomic execution-level request-ID updates.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Requests using OnConflictOptions.attach_request_id=true now return InvalidArgument, including requests that would create a new activity without encountering a conflict. Normal completion callbacks, top-level request IDs, and link-only on-conflict attachment remain supported.