### PR TITLE
Cache the internal frontend gRPC connection

### DIFF
--- a/common/rpc/local_frontend_conn_test.go
+++ b/common/rpc/local_frontend_conn_test.go
@@ -1,0 +1,44 @@
+package rpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/primitives"
+)
+
+// TestCreateLocalFrontendGRPCConnectionIsCached verifies that the internal
+// frontend connection is dialed once and reused across calls.
+//
+// Callers of CreateLocalFrontendGRPCConnection never close the connection it
+// returns, so dialing a fresh one per call leaked a grpc.ClientConn — and the
+// background goroutines it owns — on every RPC that went through it. Its HTTP
+// sibling, CreateLocalFrontendHTTPClient, has always been cached this way.
+func TestCreateLocalFrontendGRPCConnectionIsCached(t *testing.T) {
+	f := NewFactory(
+		nil,
+		primitives.FrontendService,
+		log.NewNoopLogger(),
+		metrics.NoopMetricsHandler,
+		nil,
+		"localhost:7233",
+		"",
+		0,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	first := f.CreateLocalFrontendGRPCConnection()
+	second := f.CreateLocalFrontendGRPCConnection()
+
+	require.NotNil(t, first)
+	require.Same(t, first, second,
+		"expected the internal frontend connection to be reused; a new connection per call leaks goroutines")
+
+	t.Cleanup(func() { _ = first.Close() })
+}

--- a/common/rpc/rpc.go
+++ b/common/rpc/rpc.go
@@ -56,6 +56,11 @@ type RPCFactory struct {
 	monitor                  membership.Monitor
 	// A OnceValues wrapper for createLocalFrontendHTTPClient.
 	localFrontendClient func() (*common.FrontendHTTPClient, error)
+	// A OnceValue wrapper for createLocalFrontendGRPCConnection. The connection is
+	// shared: grpc.ClientConn is safe for concurrent use and multiplexes requests,
+	// and callers never close it, so dialing per call only leaks connections and
+	// their background goroutines.
+	localFrontendGRPCConn func() *grpc.ClientConn
 
 	// TODO: Remove these flags once the keepalive settings are rolled out
 	EnableInternodeServerKeepalive bool
@@ -104,6 +109,7 @@ func NewFactory(
 	}
 	f.grpcListener = sync.OnceValue(f.createGRPCListener)
 	f.localFrontendClient = sync.OnceValues(f.createLocalFrontendHTTPClient)
+	f.localFrontendGRPCConn = sync.OnceValue(f.createLocalFrontendGRPCConnection)
 	return f
 }
 
@@ -259,8 +265,14 @@ func (d *RPCFactory) CreateRemoteFrontendGRPCConnection(rpcAddress string) *grpc
 	return d.dial(rpcAddress, tlsClientConfig, append(additionalDialOptions, keepAliveOption)...)
 }
 
-// CreateLocalFrontendGRPCConnection creates connection for internal frontend calls
+// CreateLocalFrontendGRPCConnection returns the shared connection for internal
+// frontend calls, dialing it on first use.
 func (d *RPCFactory) CreateLocalFrontendGRPCConnection() *grpc.ClientConn {
+	return d.localFrontendGRPCConn()
+}
+
+// createLocalFrontendGRPCConnection creates connection for internal frontend calls
+func (d *RPCFactory) createLocalFrontendGRPCConnection() *grpc.ClientConn {
 	additionalDialOptions := append([]grpc.DialOption{}, d.perServiceDialOptions[primitives.InternalFrontendService]...)
 
 	return d.dial(d.frontendURL, d.frontendTLSConfig, additionalDialOptions...)


### PR DESCRIPTION
## What changed?

`RPCFactory.CreateLocalFrontendGRPCConnection` dialed a fresh `grpc.ClientConn` on every call. Its HTTP sibling, `CreateLocalFrontendHTTPClient`, has always been cached behind `sync.OnceValues` (`rpc.go:106`) — this brings the gRPC path in line with it via `sync.OnceValue`.

## Why?

No caller ever closes the connection this returns:

- `NewLocalFrontendClientWithTimeout` returns it as its first value, and all six SearchAttributes call sites in `service/frontend/operator_handler.go` and `service/frontend/admin_handler.go` discard it (`_, client, err := ...`).
- `NewLocalAdminClientWithTimeout` and `NewLocalOperatorClientWithTimeout` do not return it at all, so their callers have no way to close it.
- `client_bean.go` retains the connection for the lifetime of the bean, so sharing a single connection is compatible with existing usage.

Every call therefore leaked a `ClientConn` and the goroutines it owns (`grpcsync.(*CallbackSerializer).run`, `dns.(*dnsResolver).watcher`, `transport.(*http2Server).keepalive`), with growth roughly linear in call count and nothing reclaiming it short of a process restart.

`grpc.ClientConn` is safe for concurrent use and multiplexes requests over a single connection, so a shared instance is the intended usage rather than a workaround.

## Scope

This covers the local/internal frontend connection, which is the path behind the six SearchAttributes call sites in #11289. The two `AddOrUpdateRemoteCluster` sites go through `CreateRemoteFrontendGRPCConnection(rpcAddress)`, which is per-address and would need a keyed cache with a lifecycle for evicting removed clusters — deliberately left out here to keep this change small. Happy to follow up on it separately.

Refs #11289

## How did you test it?

Added `TestCreateLocalFrontendGRPCConnectionIsCached`, asserting that two calls return the same `*grpc.ClientConn`. Against the previous behaviour it fails with two distinct pointers:

```
--- FAIL: TestCreateLocalFrontendGRPCConnectionIsCached
    Messages: expected the internal frontend connection to be reused; a new connection per call leaks goroutines
```

`common/rpc` passes, and `common/rpc` + `client` build clean with `gofmt` clean.

## Potential risks

The connection is now shared rather than per-call. That matches how the HTTP client already behaves and how `client_bean.go` already holds the connection, and gRPC multiplexes concurrent RPCs over one connection, so no behavioural change is expected for callers. Anything that assumed an independent connection per call would be affected, but no such caller exists today — none of them retain or close it.

Disclosure: this change was prepared with the assistance of an AI coding agent. The analysis, fix, and test were verified against the source before submitting.