### PR TITLE
Migrate PollerPQ to an intrusive linked list.

### DIFF
--- a/service/matching/matcher_data.go
+++ b/service/matching/matcher_data.go
@@ -15,7 +15,6 @@ import (
 )
 
 const (
-	invalidHeapIndex        = -13     // use unusual value to stand out in panics
 	maxPriorityLevels       = 60      // maximum value for priority levels (fits in a bitfield with a few bits reserved)
 	effectivePriorityFactor = 10      // multiply priority level by this to leave room for intermediate levels
 	pollForwarderPriority   = 1000000 // lower than any other priority. must be > maxPriorityLevels*effectivePriorityFactor.
@@ -79,7 +78,7 @@ func (p *pollerList) Len() int {
 }
 
 func (p *pollerList) Add(poller *waitingPoller) {
-	poller.matchHeapIndex = 0 // non-negative: signals "in queue"
+	poller.queued = true
 
 	// Insert after the last local poller: at the tail for a forwarder, or just before
 	// the forwarders (which stay grouped at the tail) for a local poller.
@@ -118,7 +117,7 @@ func (p *pollerList) Remove(poller *waitingPoller) {
 		p.tail = poller.prev
 	}
 	poller.prev, poller.next = nil, nil
-	poller.matchHeapIndex = invalidHeapIndex
+	poller.queued = false
 	p.count--
 }
 
@@ -167,7 +166,7 @@ func newTaskBTree() taskBTree {
 }
 
 func (b *taskBTree) Add(task *internalTask) {
-	task.matchHeapIndex = 0 // non-negative: signals "in queue"
+	task.queued = true
 	b.tree.Set(task)
 	if task.source == enumsspb.TASK_SOURCE_DB_BACKLOG && task.forwardInfo == nil {
 		b.ages.record(task.event.Data.CreateTime, 1)
@@ -176,7 +175,7 @@ func (b *taskBTree) Add(task *internalTask) {
 
 func (b *taskBTree) Remove(task *internalTask) {
 	b.tree.Delete(task)
-	task.matchHeapIndex = invalidHeapIndex
+	task.queued = false
 	if task.source == enumsspb.TASK_SOURCE_DB_BACKLOG && task.forwardInfo == nil {
 		b.ages.record(task.event.Data.CreateTime, -1)
 	}
@@ -199,7 +198,7 @@ func (b *taskBTree) ForEachTask(pred func(*internalTask) bool, post func(*intern
 	})
 	for _, task := range toRemove {
 		b.tree.Delete(task)
-		task.matchHeapIndex = invalidHeapIndex
+		task.queued = false
 		if task.source == enumsspb.TASK_SOURCE_DB_BACKLOG && task.forwardInfo == nil {
 			b.ages.record(task.event.Data.CreateTime, -1)
 		}
@@ -270,7 +269,7 @@ func (d *matcherData) RemoveTask(task *internalTask) {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 
-	if task.matchHeapIndex >= 0 {
+	if task.queued {
 		d.tasks.Remove(task)
 	}
 }
@@ -340,9 +339,9 @@ func (d *matcherData) EnqueuePollerAndWait(ctxs []context.Context, poller *waiti
 			defer d.lock.Unlock()
 
 			if poller.matchResult == nil {
-				// if poll was being forwarded, it would be absent from heap even though
-				// matchResult == nil
-				if poller.matchHeapIndex >= 0 {
+				// if poll was being forwarded, it would be absent from the queue even
+				// though matchResult == nil
+				if poller.queued {
 					d.pollers.Remove(poller)
 				}
 				poller.wake(d.logger, &matchResult{ctxErr: ctx.Err(), ctxErrIdx: i})
@@ -621,9 +620,9 @@ func (d *matcherData) HasWaitingPoller() bool {
 
 type waitableMatchResult struct {
 	// these fields are under matcherData.lock even though they're embedded in other structs
-	matchCond      sync.Cond
-	matchResult    *matchResult
-	matchHeapIndex int // non-negative while queued (in pollerList or taskBTree), invalidHeapIndex otherwise
+	matchCond   sync.Cond
+	matchResult *matchResult
+	queued      bool // true while in a queue (pollerList or taskBTree)
 }
 
 func (w *waitableMatchResult) initMatch(d *matcherData) {
@@ -636,7 +635,7 @@ func (w *waitableMatchResult) initMatch(d *matcherData) {
 // w must not be in queues anymore.
 func (w *waitableMatchResult) wake(logger log.Logger, res *matchResult) {
 	softassert.That(logger, w.matchResult == nil, "wake called twice")
-	softassert.That(logger, w.matchHeapIndex < 0, "wake called but still in heap")
+	softassert.That(logger, !w.queued, "wake called but still queued")
 	w.matchResult = res
 	w.matchCond.Signal()
 }

--- a/service/matching/matcher_data.go
+++ b/service/matching/matcher_data.go
@@ -69,6 +69,7 @@ const maxTokens = 1
 // and removal is O(1) given the poller. There are only ever a handful of forwarders, so
 // keeping them grouped at the tail on insert is cheap.
 type pollerList struct {
+	logger     log.Logger
 	head, tail *waitingPoller
 	count      int
 }
@@ -78,6 +79,7 @@ func (p *pollerList) Len() int {
 }
 
 func (p *pollerList) Add(poller *waitingPoller) {
+	softassert.That(p.logger, !poller.queued, "adding poller that is already queued")
 	poller.queued = true
 
 	// Insert after the last local poller: at the tail for a forwarder, or just before
@@ -106,6 +108,7 @@ func (p *pollerList) Add(poller *waitingPoller) {
 }
 
 func (p *pollerList) Remove(poller *waitingPoller) {
+	softassert.That(p.logger, poller.queued, "removing poller that is not queued")
 	if poller.prev != nil {
 		poller.prev.next = poller.next
 	} else {
@@ -221,7 +224,7 @@ type matcherData struct {
 	reconsiderForwardTimer resettableTimer
 
 	// waiting pollers and tasks
-	// invariant: all pollers and tasks in these data structures have matchResult == nil
+	// invariant: all pollers and tasks in these data structures have matchResult == nil and queued == true
 	pollers pollerList
 	tasks   taskBTree
 
@@ -240,6 +243,7 @@ func newMatcherData(config *taskQueueConfig, logger log.Logger, timeSource clock
 		canForward:       canForward,
 		rateLimitManager: rateLimitManager,
 		onRateLimited:    onRateLimited,
+		pollers:          pollerList{logger: logger},
 		tasks:            newTaskBTree(),
 	}
 }
@@ -622,7 +626,6 @@ type waitableMatchResult struct {
 	// these fields are under matcherData.lock even though they're embedded in other structs
 	matchCond   sync.Cond
 	matchResult *matchResult
-	queued      bool // true while in a queue (pollerList or taskBTree)
 }
 
 func (w *waitableMatchResult) initMatch(d *matcherData) {
@@ -632,10 +635,10 @@ func (w *waitableMatchResult) initMatch(d *matcherData) {
 
 // call with matcherData.lock held.
 // w.matchResult must be nil (can't call wake twice).
-// w must not be in queues anymore.
+// w must not be queued anymore. We don't assert that here: queued lives on the outer
+// struct now, not w, and callers always Remove (which asserts it) before waking.
 func (w *waitableMatchResult) wake(logger log.Logger, res *matchResult) {
 	softassert.That(logger, w.matchResult == nil, "wake called twice")
-	softassert.That(logger, !w.queued, "wake called but still queued")
 	w.matchResult = res
 	w.matchCond.Signal()
 }

--- a/service/matching/matcher_data.go
+++ b/service/matching/matcher_data.go
@@ -1,7 +1,6 @@
 package matching
 
 import (
-	"container/heap"
 	"context"
 	"sync"
 	"time"
@@ -62,58 +61,65 @@ const (
 // Currently we only use 1 token at a time.
 const maxTokens = 1
 
-type pollerPQ struct {
-	heap []*waitingPoller
+// pollerList is an intrusive doubly-linked list of waiting pollers. Pollers are matched
+// by walking from the head, so the list is kept in the order we want to match them:
+// FIFO (insertion order), except that task forwarders/validators are kept after all
+// local pollers so a task is matched to a local poller in preference to a forwarder.
+//
+// It's intrusive (next/prev live in waitingPoller) so there's no per-poller allocation
+// and removal is O(1) given the poller. There are only ever a handful of forwarders, so
+// keeping them grouped at the tail on insert is cheap.
+type pollerList struct {
+	head, tail *waitingPoller
+	count      int
 }
 
-// implements heap.Interface
-func (p *pollerPQ) Len() int {
-	return len(p.heap)
+func (p *pollerList) Len() int {
+	return p.count
 }
 
-// implements heap.Interface, do not call directly
-func (p *pollerPQ) Less(i int, j int) bool {
-	a, b := p.heap[i], p.heap[j]
-	// task forwarders/validators have lower priority than local polls
-	aIsForwarder := a.taskForwarderType != notTaskForwarder
-	bIsForwarder := b.taskForwarderType != notTaskForwarder
-	if !aIsForwarder && bIsForwarder {
-		return true
-	} else if aIsForwarder && !bIsForwarder {
-		return false
+func (p *pollerList) Add(poller *waitingPoller) {
+	poller.matchHeapIndex = 0 // non-negative: signals "in queue"
+
+	// Insert after the last local poller: at the tail for a forwarder, or just before
+	// the forwarders (which stay grouped at the tail) for a local poller.
+	at := p.tail
+	if poller.taskForwarderType == notTaskForwarder {
+		for at != nil && at.taskForwarderType != notTaskForwarder {
+			at = at.prev
+		}
 	}
-	return a.startTime.Before(b.startTime)
+
+	next := p.head
+	if at != nil {
+		next = at.next
+		at.next = poller
+	} else {
+		p.head = poller
+	}
+	poller.prev, poller.next = at, next
+	if next != nil {
+		next.prev = poller
+	} else {
+		p.tail = poller
+	}
+	p.count++
 }
 
-func (p *pollerPQ) Add(poller *waitingPoller) {
-	heap.Push(p, poller)
-}
-
-func (p *pollerPQ) Remove(poller *waitingPoller) {
-	heap.Remove(p, poller.matchHeapIndex)
-}
-
-// implements heap.Interface, do not call directly
-func (p *pollerPQ) Swap(i int, j int) {
-	p.heap[i], p.heap[j] = p.heap[j], p.heap[i]
-	p.heap[i].matchHeapIndex = i
-	p.heap[j].matchHeapIndex = j
-}
-
-// implements heap.Interface, do not call directly
-func (p *pollerPQ) Push(x any) {
-	poller := x.(*waitingPoller) // nolint:revive
-	poller.matchHeapIndex = len(p.heap)
-	p.heap = append(p.heap, poller)
-}
-
-// implements heap.Interface, do not call directly
-func (p *pollerPQ) Pop() any {
-	last := len(p.heap) - 1
-	poller := p.heap[last]
-	p.heap = p.heap[:last]
+func (p *pollerList) Remove(poller *waitingPoller) {
+	if poller.prev != nil {
+		poller.prev.next = poller.next
+	} else {
+		p.head = poller.next
+	}
+	if poller.next != nil {
+		poller.next.prev = poller.prev
+	} else {
+		p.tail = poller.prev
+	}
+	poller.prev, poller.next = nil, nil
 	poller.matchHeapIndex = invalidHeapIndex
-	return poller
+	p.count--
 }
 
 // taskBTree is a priority-ordered collection of tasks backed by a B-tree.
@@ -217,7 +223,7 @@ type matcherData struct {
 
 	// waiting pollers and tasks
 	// invariant: all pollers and tasks in these data structures have matchResult == nil
-	pollers pollerPQ
+	pollers pollerList
 	tasks   taskBTree
 
 	lastPoller time.Time // most recent poll start time
@@ -439,7 +445,7 @@ func (d *matcherData) findMatch(allowForwarding bool, now int64) (matchedTask *i
 		}
 
 		var matched *waitingPoller
-		for _, poller := range d.pollers.heap {
+		for poller := d.pollers.head; poller != nil; poller = poller.next {
 			// can't match cases:
 			if poller.queryOnly && !task.isQuery() && !task.isPollForwarder() {
 				// query-only poll only matches with query (but can match poll forwarder)
@@ -603,7 +609,7 @@ func (d *matcherData) TimeSinceLastPoll() time.Duration {
 func (d *matcherData) HasWaitingPoller() bool {
 	d.lock.Lock()
 	defer d.lock.Unlock()
-	for _, p := range d.pollers.heap {
+	for p := d.pollers.head; p != nil; p = p.next {
 		if p.taskForwarderType == notTaskForwarder {
 			return true
 		}
@@ -617,7 +623,7 @@ type waitableMatchResult struct {
 	// these fields are under matcherData.lock even though they're embedded in other structs
 	matchCond      sync.Cond
 	matchResult    *matchResult
-	matchHeapIndex int // current heap index for easy removal
+	matchHeapIndex int // non-negative while queued (in pollerList or taskBTree), invalidHeapIndex otherwise
 }
 
 func (w *waitableMatchResult) initMatch(d *matcherData) {

--- a/service/matching/matcher_data_test.go
+++ b/service/matching/matcher_data_test.go
@@ -976,7 +976,7 @@ func (s *MatcherDataSuite) TestFindMatch() {
 					MinPriority: tc.pollerMinPriority,
 				}
 			}
-			s.md.pollers = pollerList{}
+			s.md.pollers = pollerList{logger: s.md.logger}
 			s.md.pollers.Add(poller)
 
 			// Call findMatch

--- a/service/matching/matcher_data_test.go
+++ b/service/matching/matcher_data_test.go
@@ -976,7 +976,8 @@ func (s *MatcherDataSuite) TestFindMatch() {
 					MinPriority: tc.pollerMinPriority,
 				}
 			}
-			s.md.pollers.heap = []*waitingPoller{poller}
+			s.md.pollers = pollerList{}
+			s.md.pollers.Add(poller)
 
 			// Call findMatch
 			s.md.lock.Lock()

--- a/service/matching/pri_matcher.go
+++ b/service/matching/pri_matcher.go
@@ -48,6 +48,7 @@ type priTaskMatcher struct {
 
 type waitingPoller struct {
 	waitableMatchResult
+	prev, next        *waitingPoller // intrusive links for pollerList; nil when not queued
 	startTime         time.Time
 	forwardCtx        context.Context   // non-nil iff poll can be forwarded
 	pollMetadata      *pollMetadata     // non-nil iff poll can be forwarded

--- a/service/matching/pri_matcher.go
+++ b/service/matching/pri_matcher.go
@@ -53,6 +53,7 @@ type waitingPoller struct {
 	forwardCtx        context.Context   // non-nil iff poll can be forwarded
 	pollMetadata      *pollMetadata     // non-nil iff poll can be forwarded
 	queryOnly         bool              // if true, poller can be given only query task, otherwise any task
+	queued            bool              // true while in matcherData.pollers
 	taskForwarderType taskForwarderType // type of task forwarder (if any)
 }
 

--- a/service/matching/task.go
+++ b/service/matching/task.go
@@ -67,6 +67,9 @@ type (
 		// redirectedFromBacklog is true if this task was redirectedFromBacklog from the backlog it was read from
 		// (V2 and V3 versioning).
 		redirectedFromBacklog bool
+		// queued is true while this task is in matcherData.tasks. It's a matcher field (see below)
+		// but lives here so it packs into the padding next to redirectedFromBacklog.
+		queued bool
 		// pollerScalingDecision is assigned when the queue has advice to give to the poller about whether
 		// it should adjust its poller count
 		pollerScalingDecision *taskqueuepb.PollerScalingDecision


### PR DESCRIPTION
## What changed?
Migrated the priority heap in PollerPQ to an instrusive linked list.

## Why?
The priority queue is not exactly needed, we were not really utilizing the properties of it.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

