### PR TITLE
Add `wf_reported_problems_set` and `wf_reported_problems_cleared` Metrics

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -726,7 +726,15 @@ var (
 	TimeBetweenShardInfoUpdates      = NewTimerDef("time_between_shardinfo_update")
 	SearchAttributesSize             = NewBytesHistogramDef("search_attributes_size")
 	MemoSize                         = NewBytesHistogramDef("memo_size")
-	TooManyPendingChildWorkflows     = NewCounterDef(
+	WorkflowReportedProblemsSet      = NewCounterDef(
+		"wf_reported_problems_set",
+		WithDescription("Incremented when the TemporalReportedProblems search attribute is set or updated on a workflow after consecutive workflow task problems."),
+	)
+	WorkflowReportedProblemsCleared = NewCounterDef(
+		"wf_reported_problems_cleared",
+		WithDescription("Incremented when the TemporalReportedProblems search attribute is cleared after a workflow task completes successfully."),
+	)
+	TooManyPendingChildWorkflows = NewCounterDef(
 		"wf_too_many_pending_child_workflows",
 		WithDescription("The number of Workflow Tasks failed because they would cause the limit on the number of pending child workflows to be exceeded. See https://t.mp/limits for more information."),
 	)

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -7002,16 +7002,19 @@ func (ms *MutableStateImpl) updatePauseInfoSearchAttribute() error {
 
 func (ms *MutableStateImpl) UpdateReportedProblemsSearchAttribute() error {
 	var reportedProblems []string
+	problemCause := "unknown"
 	switch wftFailure := ms.executionInfo.LastWorkflowTaskFailure.(type) {
 	case *persistencespb.WorkflowExecutionInfo_LastWorkflowTaskFailureCause:
+		problemCause = fmt.Sprintf("WorkflowTaskFailedCause%s", wftFailure.LastWorkflowTaskFailureCause.String())
 		reportedProblems = []string{
 			"category=WorkflowTaskFailed",
-			fmt.Sprintf("cause=WorkflowTaskFailedCause%s", wftFailure.LastWorkflowTaskFailureCause.String()),
+			fmt.Sprintf("cause=%s", problemCause),
 		}
 	case *persistencespb.WorkflowExecutionInfo_LastWorkflowTaskTimedOutType:
+		problemCause = fmt.Sprintf("WorkflowTaskTimedOutCause%s", wftFailure.LastWorkflowTaskTimedOutType.String())
 		reportedProblems = []string{
 			"category=WorkflowTaskTimedOut",
-			fmt.Sprintf("cause=WorkflowTaskTimedOutCause%s", wftFailure.LastWorkflowTaskTimedOutType.String()),
+			fmt.Sprintf("cause=%s", problemCause),
 		}
 	}
 
@@ -7043,6 +7046,12 @@ func (ms *MutableStateImpl) UpdateReportedProblemsSearchAttribute() error {
 	// Log the search attribute change
 	ms.logReportedProblemsChange(existingProblems, reportedProblems)
 
+	metrics.WorkflowReportedProblemsSet.With(ms.metricsHandler.WithTags(
+		metrics.NamespaceTag(ms.GetNamespaceEntry().Name().String()),
+		metrics.StringTag("cause", problemCause),
+		metrics.WorkflowTypeTag(ms.GetExecutionInfo().WorkflowTypeName),
+	)).Record(1)
+
 	ms.updateSearchAttributes(map[string]*commonpb.Payload{sadefs.TemporalReportedProblems: reportedProblemsPayload})
 	return ms.taskGenerator.GenerateUpsertVisibilityTask()
 }
@@ -7059,6 +7068,11 @@ func (ms *MutableStateImpl) RemoveReportedProblemsSearchAttribute() error {
 
 	// Log the removal of the search attribute
 	ms.logReportedProblemsChange(ms.decodeReportedProblems(temporalReportedProblems), nil)
+
+	metrics.WorkflowReportedProblemsCleared.With(ms.metricsHandler.WithTags(
+		metrics.NamespaceTag(ms.GetNamespaceEntry().Name().String()),
+		metrics.WorkflowTypeTag(ms.GetExecutionInfo().WorkflowTypeName),
+	)).Record(1)
 
 	ms.executionInfo.LastWorkflowTaskFailure = nil
 

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -8244,6 +8244,46 @@ func (s *mutableStateSuite) TestUpdateActivityProgress_HeartbeatCountMetric() {
 	s.Contains(s.testScope.Snapshot().Counters(), counterKey("false"))
 }
 
+func (s *mutableStateSuite) TestReportedProblems_SetAndClearMetrics() {
+	nsName := s.namespaceEntry.Name().String()
+	const wfType = "TestReportedProblemsWorkflowType"
+	const cause = "WorkflowTaskFailedCauseWorkflowWorkerUnhandledFailure"
+	setKey := "test.wf_reported_problems_set+cause=" + cause +
+		",namespace=" + nsName + ",operation=WorkflowContext,service_name=history,workflowType=" + wfType
+	clearedKey := "test.wf_reported_problems_cleared+namespace=" + nsName +
+		",operation=WorkflowContext,service_name=history,workflowType=" + wfType
+
+	counterValue := func(key string) int64 {
+		if c := s.testScope.Snapshot().Counters()[key]; c != nil {
+			return c.Value()
+		}
+		return 0
+	}
+
+	// Simulate consecutive WFT failures having recorded a failure cause.
+	s.mutableState.executionInfo.WorkflowTypeName = wfType
+	s.mutableState.executionInfo.LastWorkflowTaskFailure = &persistencespb.WorkflowExecutionInfo_LastWorkflowTaskFailureCause{
+		LastWorkflowTaskFailureCause: enumspb.WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE,
+	}
+
+	// Setting the search attribute emits the "set" counter once, tagged with namespace,
+	// cause, and (unconditionally) workflow type.
+	s.NoError(s.mutableState.UpdateReportedProblemsSearchAttribute())
+	s.Equal(int64(1), counterValue(setKey))
+
+	// Re-running with an unchanged problem set is a no-op and must not increment the counter.
+	s.NoError(s.mutableState.UpdateReportedProblemsSearchAttribute())
+	s.Equal(int64(1), counterValue(setKey))
+
+	// Clearing (workflow becomes unstuck) emits the "cleared" counter once.
+	s.NoError(s.mutableState.RemoveReportedProblemsSearchAttribute())
+	s.Equal(int64(1), counterValue(clearedKey))
+
+	// Removing again is a no-op (attribute already absent) and must not increment.
+	s.NoError(s.mutableState.RemoveReportedProblemsSearchAttribute())
+	s.Equal(int64(1), counterValue(clearedKey))
+}
+
 // scheduleCompletedWFTForBatchIDTest puts the suite's mutable state into a
 // configuration where the next Add*Event call lands in its own size-rolled
 // batch, then completes a WFT and returns the WFT-completed event


### PR DESCRIPTION

## What changed?
This PR adds `wf_reported_problems_set` and `wf_reported_problems_cleared` metrics.

These are counter metrics that are incremented exactly when the corresponding search attribute is set or cleared (`TemporalReportedProblems`)

## Why?
We are looking for a way to help our users with reliably identifying and alerting on situations when workflows in their namespaces are not making progress for any reason.

At present - there are several ways to do this but none appear to be quite as reliable.

For example - client side workflow task failures do not trigger on _server_ side issues. We had a case where users tried cross-namespace signalling. Workflow task 'succeeds' on the SDK side but only the server side sees WFT failure and increments a metric. Afaik something like payload size can also be a reason for server side rejection though maybe SDKs check it themselves now. This should also help with s2s timeouts where workflows are stuck because workers are dead.

Conversely - a single transient workflow task failure that is immediately retried afterwards should not be a reason to page someone. In other words - either client or server side WFT failure metrics don't show if the workflow is persistently stuck.

## Notes

We added counters for both addition and removal of the search attribute for completeness but are ok with only having addition.

We are also ok with not having WF type tag though it looks to be canonically present throughout the repo despite potentially being dynamic and high cardinality.

We are also ok to close this if there was already a better way to do this that we did not think of.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

~Pending test: deploy a cherry-pick on top of our current Temporal version in a fork~
**UPD:**
Deployed this commit to our sandbox cluster and forced WFT failure (workflow type not registered)
Found `wf_reported_problems_set` metric reported with correct 'namespace', 'workflowtype' tags and 'cause:workflowtaskfailedcauseunspecified'

(we use datadog so it may be mangling casing)

## Potential risks
This technically adds metric costs
