### PR TITLE
Add idempotency for standalone activity operator requests

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -962,14 +962,10 @@ func (a *Activity) handlePauseRequested(ctx chasm.MutableContext, req *activityp
 		return &activitypb.PauseActivityExecutionResponse{}, nil
 	}
 
-	if a.isTerminal() {
-		return nil, serviceerror.NewFailedPreconditionf("activity is in terminal state %v", a.GetStatus())
-	}
-	if a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED {
-		return nil, serviceerror.NewFailedPrecondition("cannot pause an activity with a pending cancellation")
-	}
-	if a.isPaused() {
-		return nil, serviceerror.NewFailedPrecondition("activity is already paused")
+	canPause := TransitionPaused.Possible(a)
+	canRequestPause := TransitionPauseRequested.Possible(a)
+	if !canPause && !canRequestPause {
+		return nil, serviceerror.NewFailedPreconditionf("activity is in non-pausable state %v", a.GetStatus())
 	}
 
 	metricsHandler, err := a.enrichedMetricsHandler(ctx, metrics.ActivityPausedScope)
@@ -978,28 +974,32 @@ func (a *Activity) handlePauseRequested(ctx chasm.MutableContext, req *activityp
 	}
 
 	event := pauseEvent{req: req.GetFrontendRequest(), metricsHandler: metricsHandler}
-	switch a.GetStatus() {
-	case activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED:
+	if canPause {
 		if err := TransitionPaused.Apply(a, ctx, event); err != nil {
 			return nil, err
 		}
-	case activitypb.ACTIVITY_EXECUTION_STATUS_STARTED:
+	} else {
 		if err := TransitionPauseRequested.Apply(a, ctx, event); err != nil {
 			return nil, err
 		}
-	default:
-		return nil, serviceerror.NewFailedPreconditionf("activity is in non-pausable state %v", a.GetStatus())
 	}
 	return &activitypb.PauseActivityExecutionResponse{}, nil
 }
 
 func (a *Activity) handleUnpauseRequested(ctx chasm.MutableContext, req *activitypb.UnpauseActivityExecutionRequest) (
-	*activitypb.UnpauseActivityExecutionResponse, error,
+	_ *activitypb.UnpauseActivityExecutionResponse, retErr error,
 ) {
 	frontendReq := req.GetFrontendRequest()
 	requestID := frontendReq.GetRequestId()
 	if requestID != "" && requestID == a.GetLastUnpauseRequestId() {
 		return &activitypb.UnpauseActivityExecutionResponse{}, nil
+	}
+	if requestID != "" {
+		defer func() {
+			if retErr == nil {
+				a.LastUnpauseRequestId = requestID
+			}
+		}()
 	}
 
 	if a.isTerminal() {
@@ -1007,9 +1007,6 @@ func (a *Activity) handleUnpauseRequested(ctx chasm.MutableContext, req *activit
 	}
 	// TODO(sean): this should be FailedPrecondition, instead of no-op. And remove persisting LastUnpauseRequestId since it fails
 	if !a.isPaused() {
-		if requestID != "" {
-			a.LastUnpauseRequestId = requestID
-		}
 		return &activitypb.UnpauseActivityExecutionResponse{}, nil
 	}
 
@@ -1032,9 +1029,6 @@ func (a *Activity) handleUnpauseRequested(ctx chasm.MutableContext, req *activit
 		a.ResetKeepPaused = false
 	default:
 		return nil, serviceerror.NewFailedPreconditionf("activity is in non-unpausable state %v", a.GetStatus())
-	}
-	if requestID != "" {
-		a.LastUnpauseRequestId = requestID
 	}
 	a.emitOnUnpausedMetrics(metricsHandler)
 	return &activitypb.UnpauseActivityExecutionResponse{}, nil
@@ -1165,11 +1159,18 @@ func (a *Activity) reset(ctx chasm.MutableContext, event resetEvent) {
 func (a *Activity) handleReset(
 	ctx chasm.MutableContext,
 	req *activitypb.ResetActivityExecutionRequest,
-) (*activitypb.ResetActivityExecutionResponse, error) {
+) (_ *activitypb.ResetActivityExecutionResponse, retErr error) {
 	frontendReq := req.GetFrontendRequest()
 	requestID := frontendReq.GetRequestId()
 	if requestID != "" && requestID == a.GetLastResetRequestId() {
 		return &activitypb.ResetActivityExecutionResponse{}, nil
+	}
+	if requestID != "" {
+		defer func() {
+			if retErr == nil {
+				a.LastResetRequestId = requestID
+			}
+		}()
 	}
 
 	if frontendReq.GetRestoreOriginalOptions() {
@@ -1183,7 +1184,6 @@ func (a *Activity) handleReset(
 		return nil, err
 	}
 
-	var resp *activitypb.ResetActivityExecutionResponse
 	switch a.Status {
 	case activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED:
 		return nil, serviceerror.NewFailedPrecondition("cannot reset an activity with a pending cancellation")
@@ -1193,32 +1193,24 @@ func (a *Activity) handleReset(
 		// TODO (dan): define desired behavior and implement
 		return nil, serviceerror.NewFailedPrecondition("cannot reset an activity with a pending reset")
 	case activitypb.ACTIVITY_EXECUTION_STATUS_STARTED, activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED:
-		resp, err = a.deferResetWhileRunning(ctx, frontendReq, metricsHandler)
+		return a.deferResetWhileRunning(ctx, frontendReq, metricsHandler)
 	case activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED:
 		// No worker is running; restore takes effect immediately.
 		if frontendReq.GetRestoreOriginalOptions() {
 			a.restoreOriginalOptions(ctx)
 		}
 		if frontendReq.GetKeepPaused() {
-			resp, err = a.resetKeepPaused(ctx, metricsHandler)
-		} else {
-			// No keepPaused: perform an immediate reset. restoreOriginalOptions (if requested) already
-			// ran above, so skip it in resetImmediately to avoid restoring twice.
-			resp, err = a.resetImmediately(ctx, frontendReq, metricsHandler, false)
+			return a.resetKeepPaused(ctx, metricsHandler)
 		}
+		// No keepPaused: perform an immediate reset. restoreOriginalOptions (if requested) already
+		// ran above, so skip it in resetImmediately to avoid restoring twice.
+		return a.resetImmediately(ctx, frontendReq, metricsHandler, false)
 	case activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED:
-		resp, err = a.resetImmediately(ctx, frontendReq, metricsHandler, frontendReq.GetRestoreOriginalOptions())
+		return a.resetImmediately(ctx, frontendReq, metricsHandler, frontendReq.GetRestoreOriginalOptions())
 	default:
 		// Terminal or unspecified state.
 		return nil, serviceerror.NewFailedPrecondition("activity execution is not running")
 	}
-	if err != nil {
-		return nil, err
-	}
-	if requestID != "" {
-		a.LastResetRequestId = requestID
-	}
-	return resp, nil
 }
 
 // deferResetWhileRunning defers reset mutations (option restore, heartbeat details clear,

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -690,6 +690,7 @@ func (a *Activity) UpdateActivityExecutionOptions(
 	frontendReq := req.GetFrontendRequest()
 	requestID := frontendReq.GetRequestId()
 	if requestID != "" && requestID == a.GetLastUpdateOptionsRequestId() {
+		// A repeated request ID returns the current options, which may differ from the original response.
 		return a.updateActivityExecutionOptionsResponse(), nil
 	}
 
@@ -1004,6 +1005,7 @@ func (a *Activity) handleUnpauseRequested(ctx chasm.MutableContext, req *activit
 	if a.isTerminal() {
 		return nil, serviceerror.NewFailedPreconditionf("activity is in terminal state %v", a.GetStatus())
 	}
+	// TODO(sean): this should be FailedPrecondition, instead of no-op. And remove persisting LastUnpauseRequestId since it fails
 	if !a.isPaused() {
 		if requestID != "" {
 			a.LastUnpauseRequestId = requestID

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -953,12 +953,6 @@ func (a *Activity) handleCancellationRequested(ctx chasm.MutableContext, request
 func (a *Activity) handlePauseRequested(ctx chasm.MutableContext, req *activitypb.PauseActivityExecutionRequest) (
 	*activitypb.PauseActivityExecutionResponse, error,
 ) {
-	if a.isTerminal() {
-		return nil, serviceerror.NewFailedPreconditionf("activity is in terminal state %v", a.GetStatus())
-	}
-	if a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED {
-		return nil, serviceerror.NewFailedPrecondition("cannot pause an activity with a pending cancellation")
-	}
 	// Deduplicate a replay of a request that already paused this activity, even if the
 	// activity has since been unpaused. Without this check, a delayed replay of an old
 	// Pause request would silently re-pause an activity that a later Unpause resumed.
@@ -967,6 +961,12 @@ func (a *Activity) handlePauseRequested(ctx chasm.MutableContext, req *activityp
 		return &activitypb.PauseActivityExecutionResponse{}, nil
 	}
 
+	if a.isTerminal() {
+		return nil, serviceerror.NewFailedPreconditionf("activity is in terminal state %v", a.GetStatus())
+	}
+	if a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED {
+		return nil, serviceerror.NewFailedPrecondition("cannot pause an activity with a pending cancellation")
+	}
 	if a.isPaused() {
 		return nil, serviceerror.NewFailedPrecondition("activity is already paused")
 	}
@@ -1199,11 +1199,11 @@ func (a *Activity) handleReset(
 		}
 		if frontendReq.GetKeepPaused() {
 			resp, err = a.resetKeepPaused(ctx, metricsHandler)
-			break
+		} else {
+			// No keepPaused: perform an immediate reset. restoreOriginalOptions (if requested) already
+			// ran above, so skip it in resetImmediately to avoid restoring twice.
+			resp, err = a.resetImmediately(ctx, frontendReq, metricsHandler, false)
 		}
-		// No keepPaused: perform an immediate reset. restoreOriginalOptions (if requested) already
-		// ran above, so skip it in resetImmediately to avoid restoring twice.
-		resp, err = a.resetImmediately(ctx, frontendReq, metricsHandler, false)
 	case activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED:
 		resp, err = a.resetImmediately(ctx, frontendReq, metricsHandler, frontendReq.GetRestoreOriginalOptions())
 	default:

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -687,6 +687,12 @@ func (a *Activity) UpdateActivityExecutionOptions(
 	ctx chasm.MutableContext,
 	req *activitypb.UpdateActivityExecutionOptionsRequest,
 ) (*activitypb.UpdateActivityExecutionOptionsResponse, error) {
+	frontendReq := req.GetFrontendRequest()
+	requestID := frontendReq.GetRequestId()
+	if requestID != "" && requestID == a.GetLastUpdateOptionsRequestId() {
+		return a.updateActivityExecutionOptionsResponse(), nil
+	}
+
 	switch a.Status {
 	case activitypb.ACTIVITY_EXECUTION_STATUS_CANCELED,
 		activitypb.ACTIVITY_EXECUTION_STATUS_COMPLETED,
@@ -697,8 +703,6 @@ func (a *Activity) UpdateActivityExecutionOptions(
 		return nil, serviceerror.NewFailedPreconditionf("Cannot update options for activity in state %s", a.Status.String())
 	default:
 	}
-
-	frontendReq := req.GetFrontendRequest()
 
 	if frontendReq.GetRestoreOriginal() {
 		if err := validateOriginalOptionsRestorable(a.GetOriginalOptions()); err != nil {
@@ -776,6 +780,13 @@ func (a *Activity) UpdateActivityExecutionOptions(
 	}
 	a.emitOnUpdateOptionsMetrics(metricsHandler)
 
+	if requestID != "" {
+		a.LastUpdateOptionsRequestId = requestID
+	}
+	return a.updateActivityExecutionOptionsResponse(), nil
+}
+
+func (a *Activity) updateActivityExecutionOptionsResponse() *activitypb.UpdateActivityExecutionOptionsResponse {
 	return &activitypb.UpdateActivityExecutionOptionsResponse{
 		FrontendResponse: &workflowservice.UpdateActivityExecutionOptionsResponse{
 			ActivityOptions: &apiactivitypb.ActivityOptions{
@@ -789,7 +800,7 @@ func (a *Activity) UpdateActivityExecutionOptions(
 				StartDelay:             a.GetStartDelay(),
 			},
 		},
-	}, nil
+	}
 }
 
 // shouldRecalculateCurrentRetryInterval reports whether the pending retry's CurrentRetryInterval
@@ -984,10 +995,19 @@ func (a *Activity) handlePauseRequested(ctx chasm.MutableContext, req *activityp
 func (a *Activity) handleUnpauseRequested(ctx chasm.MutableContext, req *activitypb.UnpauseActivityExecutionRequest) (
 	*activitypb.UnpauseActivityExecutionResponse, error,
 ) {
+	frontendReq := req.GetFrontendRequest()
+	requestID := frontendReq.GetRequestId()
+	if requestID != "" && requestID == a.GetLastUnpauseRequestId() {
+		return &activitypb.UnpauseActivityExecutionResponse{}, nil
+	}
+
 	if a.isTerminal() {
 		return nil, serviceerror.NewFailedPreconditionf("activity is in terminal state %v", a.GetStatus())
 	}
 	if !a.isPaused() {
+		if requestID != "" {
+			a.LastUnpauseRequestId = requestID
+		}
 		return &activitypb.UnpauseActivityExecutionResponse{}, nil
 	}
 
@@ -996,7 +1016,7 @@ func (a *Activity) handleUnpauseRequested(ctx chasm.MutableContext, req *activit
 		return nil, err
 	}
 
-	event := unpauseEvent{req: req.GetFrontendRequest(), metricsHandler: metricsHandler}
+	event := unpauseEvent{req: frontendReq, metricsHandler: metricsHandler}
 	switch a.GetStatus() {
 	case activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED:
 		if err := TransitionUnpaused.Apply(a, ctx, event); err != nil {
@@ -1010,6 +1030,9 @@ func (a *Activity) handleUnpauseRequested(ctx chasm.MutableContext, req *activit
 		a.ResetKeepPaused = false
 	default:
 		return nil, serviceerror.NewFailedPreconditionf("activity is in non-unpausable state %v", a.GetStatus())
+	}
+	if requestID != "" {
+		a.LastUnpauseRequestId = requestID
 	}
 	a.emitOnUnpausedMetrics(metricsHandler)
 	return &activitypb.UnpauseActivityExecutionResponse{}, nil
@@ -1137,8 +1160,15 @@ func (a *Activity) reset(ctx chasm.MutableContext, event resetEvent) {
 // takes effect on the new attempt 1.
 //
 // For CANCEL_REQUESTED activities: rejected with FailedPrecondition; cancel takes precedence.
-func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetActivityExecutionRequest) (*activitypb.ResetActivityExecutionResponse, error) {
+func (a *Activity) handleReset(
+	ctx chasm.MutableContext,
+	req *activitypb.ResetActivityExecutionRequest,
+) (*activitypb.ResetActivityExecutionResponse, error) {
 	frontendReq := req.GetFrontendRequest()
+	requestID := frontendReq.GetRequestId()
+	if requestID != "" && requestID == a.GetLastResetRequestId() {
+		return &activitypb.ResetActivityExecutionResponse{}, nil
+	}
 
 	if frontendReq.GetRestoreOriginalOptions() {
 		if err := validateOriginalOptionsRestorable(a.GetOriginalOptions()); err != nil {
@@ -1151,6 +1181,7 @@ func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetAc
 		return nil, err
 	}
 
+	var resp *activitypb.ResetActivityExecutionResponse
 	switch a.Status {
 	case activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED:
 		return nil, serviceerror.NewFailedPrecondition("cannot reset an activity with a pending cancellation")
@@ -1160,24 +1191,32 @@ func (a *Activity) handleReset(ctx chasm.MutableContext, req *activitypb.ResetAc
 		// TODO (dan): define desired behavior and implement
 		return nil, serviceerror.NewFailedPrecondition("cannot reset an activity with a pending reset")
 	case activitypb.ACTIVITY_EXECUTION_STATUS_STARTED, activitypb.ACTIVITY_EXECUTION_STATUS_PAUSE_REQUESTED:
-		return a.deferResetWhileRunning(ctx, frontendReq, metricsHandler)
+		resp, err = a.deferResetWhileRunning(ctx, frontendReq, metricsHandler)
 	case activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED:
 		// No worker is running; restore takes effect immediately.
 		if frontendReq.GetRestoreOriginalOptions() {
 			a.restoreOriginalOptions(ctx)
 		}
 		if frontendReq.GetKeepPaused() {
-			return a.resetKeepPaused(ctx, metricsHandler)
+			resp, err = a.resetKeepPaused(ctx, metricsHandler)
+			break
 		}
 		// No keepPaused: perform an immediate reset. restoreOriginalOptions (if requested) already
 		// ran above, so skip it in resetImmediately to avoid restoring twice.
-		return a.resetImmediately(ctx, frontendReq, metricsHandler, false)
+		resp, err = a.resetImmediately(ctx, frontendReq, metricsHandler, false)
 	case activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED:
-		return a.resetImmediately(ctx, frontendReq, metricsHandler, frontendReq.GetRestoreOriginalOptions())
+		resp, err = a.resetImmediately(ctx, frontendReq, metricsHandler, frontendReq.GetRestoreOriginalOptions())
 	default:
 		// Terminal or unspecified state.
 		return nil, serviceerror.NewFailedPrecondition("activity execution is not running")
 	}
+	if err != nil {
+		return nil, err
+	}
+	if requestID != "" {
+		a.LastResetRequestId = requestID
+	}
+	return resp, nil
 }
 
 // deferResetWhileRunning defers reset mutations (option restore, heartbeat details clear,

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -948,6 +948,36 @@ func TestUpdateStartedActivityExecutionOptionsDoesNotBumpStartedStamp(t *testing
 	require.Equal(t, originalStartedStamp, attempt.GetStartedStamp())
 }
 
+func TestHandlePauseRequestedRequestID(t *testing.T) {
+	t.Run("deduplicates before state validation", func(t *testing.T) {
+		for _, status := range []activitypb.ActivityExecutionStatus{
+			activitypb.ACTIVITY_EXECUTION_STATUS_COMPLETED,
+			activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
+		} {
+			t.Run(status.String(), func(t *testing.T) {
+				activity := &Activity{
+					ActivityState: &activitypb.ActivityState{
+						Status: status,
+						LastPauseState: &activitypb.ActivityPauseState{
+							RequestId: "pause-request-id",
+						},
+					},
+				}
+
+				_, err := activity.handlePauseRequested(
+					&chasm.MockMutableContext{},
+					&activitypb.PauseActivityExecutionRequest{
+						FrontendRequest: &workflowservice.PauseActivityExecutionRequest{
+							RequestId: "pause-request-id",
+						},
+					},
+				)
+				require.NoError(t, err)
+			})
+		}
+	})
+}
+
 func TestHandleUnpauseRequestedRequestID(t *testing.T) {
 	t.Run("deduplicates latest request ID", func(t *testing.T) {
 		ctx := newOperatorCommandTestContext(t)

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -935,6 +935,7 @@ func TestUpdateStartedActivityExecutionOptionsDoesNotBumpStartedStamp(t *testing
 	_, err := activity.UpdateActivityExecutionOptions(ctx, &activitypb.UpdateActivityExecutionOptionsRequest{
 		FrontendRequest: &workflowservice.UpdateActivityExecutionOptionsRequest{
 			ActivityId: "test-activity-id",
+			RequestId:  "update-request-id",
 			ActivityOptions: &apiactivitypb.ActivityOptions{
 				HeartbeatTimeout: durationpb.New(2 * time.Minute),
 			},
@@ -945,6 +946,219 @@ func TestUpdateStartedActivityExecutionOptionsDoesNotBumpStartedStamp(t *testing
 
 	require.Equal(t, originalStamp+1, attempt.GetStamp())
 	require.Equal(t, originalStartedStamp, attempt.GetStartedStamp())
+}
+
+func TestHandleUnpauseRequestedRequestID(t *testing.T) {
+	t.Run("deduplicates latest request ID", func(t *testing.T) {
+		ctx := newOperatorCommandTestContext(t)
+		activity := &Activity{
+			ActivityState: &activitypb.ActivityState{
+				ActivityType:           &commonpb.ActivityType{Name: "test-activity-type"},
+				Status:                 activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED,
+				TaskQueue:              &taskqueuepb.TaskQueue{Name: "test-task-queue"},
+				LastUnpauseRequestId:   "unpause-request-id",
+				ScheduleToStartTimeout: durationpb.New(time.Minute),
+			},
+			LastAttempt: chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{Count: 3}),
+		}
+
+		_, err := activity.handleUnpauseRequested(ctx, &activitypb.UnpauseActivityExecutionRequest{
+			FrontendRequest: &workflowservice.UnpauseActivityExecutionRequest{
+				RequestId: "unpause-request-id",
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED, activity.GetStatus())
+		require.Equal(t, int32(3), activity.LastAttempt.Get(ctx).GetCount())
+	})
+
+	t.Run("records successful no-op request ID", func(t *testing.T) {
+		ctx := &chasm.MockMutableContext{}
+		activity := &Activity{
+			ActivityState: &activitypb.ActivityState{
+				Status: activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+			},
+		}
+
+		_, err := activity.handleUnpauseRequested(ctx, &activitypb.UnpauseActivityExecutionRequest{
+			FrontendRequest: &workflowservice.UnpauseActivityExecutionRequest{
+				RequestId: "unpause-request-id",
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, "unpause-request-id", activity.GetLastUnpauseRequestId())
+	})
+
+	t.Run("does not record failed request ID", func(t *testing.T) {
+		ctx := &chasm.MockMutableContext{}
+		activity := &Activity{
+			ActivityState: &activitypb.ActivityState{
+				Status:               activitypb.ACTIVITY_EXECUTION_STATUS_COMPLETED,
+				LastUnpauseRequestId: "previous-unpause-request-id",
+			},
+		}
+
+		_, err := activity.handleUnpauseRequested(ctx, &activitypb.UnpauseActivityExecutionRequest{
+			FrontendRequest: &workflowservice.UnpauseActivityExecutionRequest{
+				RequestId: "failed-unpause-request-id",
+			},
+		})
+		require.Error(t, err)
+		require.Equal(t, "previous-unpause-request-id", activity.GetLastUnpauseRequestId())
+	})
+}
+
+func TestHandleResetRequestID(t *testing.T) {
+	t.Run("deduplicates latest request ID", func(t *testing.T) {
+		ctx := newOperatorCommandTestContext(t)
+		activity := &Activity{
+			ActivityState: &activitypb.ActivityState{
+				ActivityType:       &commonpb.ActivityType{Name: "test-activity-type"},
+				Status:             activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+				TaskQueue:          &taskqueuepb.TaskQueue{Name: "test-task-queue"},
+				LastResetRequestId: "reset-request-id",
+			},
+			LastAttempt: chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{Count: 3}),
+		}
+
+		_, err := activity.handleReset(ctx, &activitypb.ResetActivityExecutionRequest{
+			FrontendRequest: &workflowservice.ResetActivityExecutionRequest{
+				RequestId: "reset-request-id",
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, int32(3), activity.LastAttempt.Get(ctx).GetCount())
+	})
+
+	t.Run("records successful request ID", func(t *testing.T) {
+		ctx := newOperatorCommandTestContext(t)
+		activity := &Activity{
+			ActivityState: &activitypb.ActivityState{
+				ActivityType: &commonpb.ActivityType{Name: "test-activity-type"},
+				Status:       activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+				TaskQueue:    &taskqueuepb.TaskQueue{Name: "test-task-queue"},
+			},
+			LastAttempt: chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{Count: 3}),
+		}
+
+		_, err := activity.handleReset(ctx, &activitypb.ResetActivityExecutionRequest{
+			FrontendRequest: &workflowservice.ResetActivityExecutionRequest{
+				RequestId: "reset-request-id",
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, "reset-request-id", activity.GetLastResetRequestId())
+	})
+
+	t.Run("does not record failed request ID", func(t *testing.T) {
+		ctx := newOperatorCommandTestContext(t)
+		activity := &Activity{
+			ActivityState: &activitypb.ActivityState{
+				ActivityType:       &commonpb.ActivityType{Name: "test-activity-type"},
+				Status:             activitypb.ACTIVITY_EXECUTION_STATUS_COMPLETED,
+				TaskQueue:          &taskqueuepb.TaskQueue{Name: "test-task-queue"},
+				LastResetRequestId: "previous-reset-request-id",
+			},
+		}
+
+		_, err := activity.handleReset(ctx, &activitypb.ResetActivityExecutionRequest{
+			FrontendRequest: &workflowservice.ResetActivityExecutionRequest{
+				RequestId: "failed-reset-request-id",
+			},
+		})
+		require.Error(t, err)
+		require.Equal(t, "previous-reset-request-id", activity.GetLastResetRequestId())
+	})
+}
+
+func TestUpdateActivityExecutionOptionsRequestID(t *testing.T) {
+	t.Run("deduplicates latest request ID", func(t *testing.T) {
+		ctx := &chasm.MockMutableContext{}
+		activity := &Activity{
+			ActivityState: &activitypb.ActivityState{
+				Status:                     activitypb.ACTIVITY_EXECUTION_STATUS_COMPLETED,
+				TaskQueue:                  &taskqueuepb.TaskQueue{Name: "current-task-queue"},
+				LastUpdateOptionsRequestId: "update-request-id",
+			},
+		}
+
+		resp, err := activity.UpdateActivityExecutionOptions(ctx, &activitypb.UpdateActivityExecutionOptionsRequest{
+			FrontendRequest: &workflowservice.UpdateActivityExecutionOptionsRequest{
+				RequestId: "update-request-id",
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, "current-task-queue", resp.GetFrontendResponse().GetActivityOptions().GetTaskQueue().GetName())
+	})
+
+	t.Run("records successful request ID", func(t *testing.T) {
+		ctx := newOperatorCommandTestContext(t)
+		activity := &Activity{
+			ActivityState: &activitypb.ActivityState{
+				ActivityType:           &commonpb.ActivityType{Name: "test-activity-type"},
+				Status:                 activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
+				TaskQueue:              &taskqueuepb.TaskQueue{Name: "test-task-queue"},
+				ScheduleToCloseTimeout: durationpb.New(10 * time.Minute),
+				ScheduleToStartTimeout: durationpb.New(2 * time.Minute),
+				StartToCloseTimeout:    durationpb.New(3 * time.Minute),
+				HeartbeatTimeout:       durationpb.New(time.Minute),
+			},
+			LastAttempt: chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{
+				Count:        1,
+				Stamp:        7,
+				StartedStamp: 7,
+			}),
+			Outcome: chasm.NewDataField(ctx, &activitypb.ActivityOutcome{}),
+		}
+
+		_, err := activity.UpdateActivityExecutionOptions(ctx, &activitypb.UpdateActivityExecutionOptionsRequest{
+			FrontendRequest: &workflowservice.UpdateActivityExecutionOptionsRequest{
+				RequestId: "update-request-id",
+				ActivityOptions: &apiactivitypb.ActivityOptions{
+					HeartbeatTimeout: durationpb.New(2 * time.Minute),
+				},
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"heartbeat_timeout"}},
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, "update-request-id", activity.GetLastUpdateOptionsRequestId())
+	})
+
+	t.Run("does not record failed request ID", func(t *testing.T) {
+		ctx := &chasm.MockMutableContext{}
+		activity := &Activity{
+			ActivityState: &activitypb.ActivityState{
+				Status:                     activitypb.ACTIVITY_EXECUTION_STATUS_COMPLETED,
+				LastUpdateOptionsRequestId: "previous-update-request-id",
+			},
+		}
+
+		_, err := activity.UpdateActivityExecutionOptions(ctx, &activitypb.UpdateActivityExecutionOptionsRequest{
+			FrontendRequest: &workflowservice.UpdateActivityExecutionOptionsRequest{
+				RequestId: "failed-update-request-id",
+			},
+		})
+		require.Error(t, err)
+		require.Equal(t, "previous-update-request-id", activity.GetLastUpdateOptionsRequestId())
+	})
+}
+
+func newOperatorCommandTestContext(t *testing.T) *chasm.MockMutableContext {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	nsRegistry := namespace.NewMockRegistry(ctrl)
+	nsRegistry.EXPECT().GetNamespaceName(gomock.Any()).Return(namespace.Name("test-namespace"), nil).AnyTimes()
+	return &chasm.MockMutableContext{
+		MockContext: chasm.MockContext{
+			HandleNow: func(chasm.Component) time.Time { return time.Unix(0, 0) },
+			GoCtx: context.WithValue(context.Background(), ctxKeyActivityContext, &activityContext{
+				config: &Config{
+					BreakdownMetricsByTaskQueue: dynamicconfig.GetBoolPropertyFnFilteredByTaskQueue(true),
+				},
+				namespaceRegistry: nsRegistry,
+			}),
+		},
+	}
 }
 
 func TestContextMetadata(t *testing.T) {
@@ -1434,10 +1648,12 @@ func TestUpdateActivityExecutionOptions_RestoreOriginal_RejectsMissingOriginalOp
 		FrontendRequest: &workflowservice.UpdateActivityExecutionOptionsRequest{
 			ActivityId:      "act",
 			RestoreOriginal: true,
+			RequestId:       "failed-update-request-id",
 		},
 	})
 
 	require.Error(t, err)
+	require.Empty(t, activity.GetLastUpdateOptionsRequestId())
 	require.Equal(t, "current-task-queue", activity.GetTaskQueue().GetName())
 	require.Equal(t, 30*time.Second, activity.GetScheduleToCloseTimeout().AsDuration())
 	require.Equal(t, 10*time.Second, activity.GetStartToCloseTimeout().AsDuration())
@@ -1469,9 +1685,11 @@ func TestHandleReset_RestoreOriginalOptions_RejectsMissingOriginalOptions(t *tes
 		FrontendRequest: &workflowservice.ResetActivityExecutionRequest{
 			ActivityId:             "act",
 			RestoreOriginalOptions: true,
+			RequestId:              "failed-reset-request-id",
 		},
 	})
 
 	require.Error(t, err)
+	require.Empty(t, activity.GetLastResetRequestId())
 	require.Equal(t, "current-task-queue", activity.GetTaskQueue().GetName())
 }

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -948,34 +948,33 @@ func TestUpdateStartedActivityExecutionOptionsDoesNotBumpStartedStamp(t *testing
 	require.Equal(t, originalStartedStamp, attempt.GetStartedStamp())
 }
 
-func TestHandlePauseRequestedRequestID(t *testing.T) {
-	t.Run("deduplicates before state validation", func(t *testing.T) {
-		for _, status := range []activitypb.ActivityExecutionStatus{
-			activitypb.ACTIVITY_EXECUTION_STATUS_COMPLETED,
-			activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
-		} {
-			t.Run(status.String(), func(t *testing.T) {
-				activity := &Activity{
-					ActivityState: &activitypb.ActivityState{
-						Status: status,
-						LastPauseState: &activitypb.ActivityPauseState{
-							RequestId: "pause-request-id",
-						},
+func TestHandlePauseRequestedDedupBeforeValidation(t *testing.T) {
+	for _, status := range []activitypb.ActivityExecutionStatus{
+		activitypb.ACTIVITY_EXECUTION_STATUS_COMPLETED,
+		activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
+	} {
+		t.Run(status.String(), func(t *testing.T) {
+			activity := &Activity{
+				ActivityState: &activitypb.ActivityState{
+					Status: status,
+					LastPauseState: &activitypb.ActivityPauseState{
+						RequestId: "pause-request-id",
 					},
-				}
+				},
+			}
 
-				_, err := activity.handlePauseRequested(
-					&chasm.MockMutableContext{},
-					&activitypb.PauseActivityExecutionRequest{
-						FrontendRequest: &workflowservice.PauseActivityExecutionRequest{
-							RequestId: "pause-request-id",
-						},
+			_, err := activity.handlePauseRequested(
+				&chasm.MockMutableContext{},
+				&activitypb.PauseActivityExecutionRequest{
+					FrontendRequest: &workflowservice.PauseActivityExecutionRequest{
+						RequestId: "pause-request-id",
 					},
-				)
-				require.NoError(t, err)
-			})
-		}
-	})
+				},
+			)
+			require.NoError(t, err)
+			require.Equal(t, status, activity.GetStatus())
+		})
+	}
 }
 
 func TestHandleUnpauseRequestedRequestID(t *testing.T) {

--- a/chasm/lib/activity/frontend.go
+++ b/chasm/lib/activity/frontend.go
@@ -555,7 +555,7 @@ func (h *frontendHandler) UpdateActivityExecutionOptions(
 		return nil, ErrStandaloneActivityOperatorCommandsDisabled
 	}
 
-	if err := validateAndNormalizeUpdateOptionsRequest(
+	if err := validateAndNormalizeUpdateActivityExecutionOptionsRequest(
 		req,
 		h.config.DefaultActivityRetryPolicy,
 		h.config.MaxIDLengthLimit(),

--- a/chasm/lib/activity/frontend.go
+++ b/chasm/lib/activity/frontend.go
@@ -555,7 +555,7 @@ func (h *frontendHandler) UpdateActivityExecutionOptions(
 		return nil, ErrStandaloneActivityOperatorCommandsDisabled
 	}
 
-	if err := validateUpdateActivityExecutionOptionsRequest(
+	if err := validateAndNormalizeUpdateOptionsRequest(
 		req,
 		h.config.DefaultActivityRetryPolicy,
 		h.config.MaxIDLengthLimit(),

--- a/chasm/lib/activity/frontend_test.go
+++ b/chasm/lib/activity/frontend_test.go
@@ -209,7 +209,7 @@ func TestRequestIdStableAcrossRetries(t *testing.T) {
 			RestoreOriginal: true,
 		}
 		validateTwice(t, req, func() error {
-			return validateUpdateActivityExecutionOptionsRequest(req, getDefaultRetrySettings, defaultMaxIDLengthLimit)
+			return validateAndNormalizeUpdateOptionsRequest(req, getDefaultRetrySettings, defaultMaxIDLengthLimit)
 		})
 	})
 }

--- a/chasm/lib/activity/frontend_test.go
+++ b/chasm/lib/activity/frontend_test.go
@@ -181,4 +181,35 @@ func TestRequestIdStableAcrossRetries(t *testing.T) {
 				req, defaultMaxIDLengthLimit, defaultBlobSizeLimitError, defaultBlobSizeLimitWarn, log.NewNoopLogger())
 		})
 	})
+
+	t.Run("unpause/server-generated", func(t *testing.T) {
+		req := &workflowservice.UnpauseActivityExecutionRequest{
+			Namespace:  "test-namespace",
+			ActivityId: "test-activity",
+		}
+		validateTwice(t, req, func() error {
+			return validateAndNormalizeUnpauseActivityExecutionRequest(req, defaultMaxIDLengthLimit)
+		})
+	})
+
+	t.Run("reset/server-generated", func(t *testing.T) {
+		req := &workflowservice.ResetActivityExecutionRequest{
+			Namespace:  "test-namespace",
+			ActivityId: "test-activity",
+		}
+		validateTwice(t, req, func() error {
+			return validateAndNormalizeResetActivityExecutionRequest(req, defaultMaxIDLengthLimit)
+		})
+	})
+
+	t.Run("update-options/server-generated", func(t *testing.T) {
+		req := &workflowservice.UpdateActivityExecutionOptionsRequest{
+			Namespace:       "test-namespace",
+			ActivityId:      "test-activity",
+			RestoreOriginal: true,
+		}
+		validateTwice(t, req, func() error {
+			return validateUpdateActivityExecutionOptionsRequest(req, getDefaultRetrySettings, defaultMaxIDLengthLimit)
+		})
+	})
 }

--- a/chasm/lib/activity/frontend_test.go
+++ b/chasm/lib/activity/frontend_test.go
@@ -209,7 +209,7 @@ func TestRequestIdStableAcrossRetries(t *testing.T) {
 			RestoreOriginal: true,
 		}
 		validateTwice(t, req, func() error {
-			return validateAndNormalizeUpdateOptionsRequest(req, getDefaultRetrySettings, defaultMaxIDLengthLimit)
+			return validateAndNormalizeUpdateActivityExecutionOptionsRequest(req, getDefaultRetrySettings, defaultMaxIDLengthLimit)
 		})
 	})
 }

--- a/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
@@ -307,11 +307,11 @@ type ActivityState struct {
 	// non-running activity (SCHEDULED / PAUSED) the restore is applied immediately and this flag is
 	// not set. Reset while in CANCEL_REQUESTED or RESET_REQUESTED is rejected.
 	ResetRestoreOptions bool `protobuf:"varint,20,opt,name=reset_restore_options,json=resetRestoreOptions,proto3" json:"reset_restore_options,omitempty"`
-	// Used to de-dupe the most recent successful unpause request, including no-ops.
+	// Used to de-dupe unpause requests.
 	LastUnpauseRequestId string `protobuf:"bytes,21,opt,name=last_unpause_request_id,json=lastUnpauseRequestId,proto3" json:"last_unpause_request_id,omitempty"`
-	// Used to de-dupe the most recent successful reset request.
+	// Used to de-dupe reset requests.
 	LastResetRequestId string `protobuf:"bytes,22,opt,name=last_reset_request_id,json=lastResetRequestId,proto3" json:"last_reset_request_id,omitempty"`
-	// Used to de-dupe the most recent successful update request.
+	// Used to de-dupe update requests.
 	LastUpdateOptionsRequestId string `protobuf:"bytes,23,opt,name=last_update_options_request_id,json=lastUpdateOptionsRequestId,proto3" json:"last_update_options_request_id,omitempty"`
 	unknownFields              protoimpl.UnknownFields
 	sizeCache                  protoimpl.SizeCache

--- a/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
@@ -308,11 +308,11 @@ type ActivityState struct {
 	// non-running activity (SCHEDULED / PAUSED) the restore is applied immediately and this flag is
 	// not set. Reset while in CANCEL_REQUESTED or RESET_REQUESTED is rejected.
 	ResetRestoreOptions bool `protobuf:"varint,20,opt,name=reset_restore_options,json=resetRestoreOptions,proto3" json:"reset_restore_options,omitempty"`
-	// Used to de-dupe unpause requests.
+	// Used to de-dupe the most recent successful unpause request, including no-ops.
 	LastUnpauseRequestId string `protobuf:"bytes,21,opt,name=last_unpause_request_id,json=lastUnpauseRequestId,proto3" json:"last_unpause_request_id,omitempty"`
-	// Used to de-dupe reset requests.
+	// Used to de-dupe the most recent successful reset request.
 	LastResetRequestId string `protobuf:"bytes,22,opt,name=last_reset_request_id,json=lastResetRequestId,proto3" json:"last_reset_request_id,omitempty"`
-	// Used to de-dupe update requests.
+	// Used to de-dupe the most recent successful update request.
 	LastUpdateOptionsRequestId string `protobuf:"bytes,23,opt,name=last_update_options_request_id,json=lastUpdateOptionsRequestId,proto3" json:"last_update_options_request_id,omitempty"`
 	unknownFields              protoimpl.UnknownFields
 	sizeCache                  protoimpl.SizeCache

--- a/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
@@ -308,8 +308,14 @@ type ActivityState struct {
 	// non-running activity (SCHEDULED / PAUSED) the restore is applied immediately and this flag is
 	// not set. Reset while in CANCEL_REQUESTED or RESET_REQUESTED is rejected.
 	ResetRestoreOptions bool `protobuf:"varint,20,opt,name=reset_restore_options,json=resetRestoreOptions,proto3" json:"reset_restore_options,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// Used to de-dupe unpause requests.
+	LastUnpauseRequestId string `protobuf:"bytes,21,opt,name=last_unpause_request_id,json=lastUnpauseRequestId,proto3" json:"last_unpause_request_id,omitempty"`
+	// Used to de-dupe reset requests.
+	LastResetRequestId string `protobuf:"bytes,22,opt,name=last_reset_request_id,json=lastResetRequestId,proto3" json:"last_reset_request_id,omitempty"`
+	// Used to de-dupe update requests.
+	LastUpdateOptionsRequestId string `protobuf:"bytes,23,opt,name=last_update_options_request_id,json=lastUpdateOptionsRequestId,proto3" json:"last_update_options_request_id,omitempty"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *ActivityState) Reset() {
@@ -473,6 +479,27 @@ func (x *ActivityState) GetResetRestoreOptions() bool {
 		return x.ResetRestoreOptions
 	}
 	return false
+}
+
+func (x *ActivityState) GetLastUnpauseRequestId() string {
+	if x != nil {
+		return x.LastUnpauseRequestId
+	}
+	return ""
+}
+
+func (x *ActivityState) GetLastResetRequestId() string {
+	if x != nil {
+		return x.LastResetRequestId
+	}
+	return ""
+}
+
+func (x *ActivityState) GetLastUpdateOptionsRequestId() string {
+	if x != nil {
+		return x.LastUpdateOptionsRequestId
+	}
+	return ""
 }
 
 type ActivityCancelState struct {
@@ -1198,7 +1225,7 @@ var File_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto protor
 
 const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawDesc = "" +
 	"\n" +
-	"@temporal/server/chasm/lib/activity/proto/v1/activity_state.proto\x12+temporal.server.chasm.lib.activity.proto.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&temporal/api/activity/v1/message.proto\x1a$temporal/api/common/v1/message.proto\x1a(temporal/api/deployment/v1/message.proto\x1a%temporal/api/failure/v1/message.proto\x1a'temporal/api/sdk/v1/user_metadata.proto\x1a'temporal/api/taskqueue/v1/message.proto\"\xc8\v\n" +
+	"@temporal/server/chasm/lib/activity/proto/v1/activity_state.proto\x12+temporal.server.chasm.lib.activity.proto.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&temporal/api/activity/v1/message.proto\x1a$temporal/api/common/v1/message.proto\x1a(temporal/api/deployment/v1/message.proto\x1a%temporal/api/failure/v1/message.proto\x1a'temporal/api/sdk/v1/user_metadata.proto\x1a'temporal/api/taskqueue/v1/message.proto\"\xf6\f\n" +
 	"\rActivityState\x12I\n" +
 	"\ractivity_type\x18\x01 \x01(\v2$.temporal.api.common.v1.ActivityTypeR\factivityType\x12C\n" +
 	"\n" +
@@ -1221,7 +1248,10 @@ const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawD
 	"\x10last_pause_state\x18\x10 \x01(\v2?.temporal.server.chasm.lib.activity.proto.v1.ActivityPauseStateR\x0elastPauseState\x12*\n" +
 	"\x11reset_keep_paused\x18\x12 \x01(\bR\x0fresetKeepPaused\x12W\n" +
 	"\x1afirst_attempt_started_time\x18\x13 \x01(\v2\x1a.google.protobuf.TimestampR\x17firstAttemptStartedTime\x122\n" +
-	"\x15reset_restore_options\x18\x14 \x01(\bR\x13resetRestoreOptions\"\xa7\x01\n" +
+	"\x15reset_restore_options\x18\x14 \x01(\bR\x13resetRestoreOptions\x125\n" +
+	"\x17last_unpause_request_id\x18\x15 \x01(\tR\x14lastUnpauseRequestId\x121\n" +
+	"\x15last_reset_request_id\x18\x16 \x01(\tR\x12lastResetRequestId\x12B\n" +
+	"\x1elast_update_options_request_id\x18\x17 \x01(\tR\x1alastUpdateOptionsRequestId\"\xa7\x01\n" +
 	"\x13ActivityCancelState\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x01 \x01(\tR\trequestId\x12=\n" +

--- a/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
@@ -289,8 +289,7 @@ type ActivityState struct {
 	ScheduleToCloseStamp int32 `protobuf:"varint,15,opt,name=schedule_to_close_stamp,json=scheduleToCloseStamp,proto3" json:"schedule_to_close_stamp,omitempty"`
 	// The most recent pause request, if the activity has ever been paused. Like cancel_state and
 	// terminate_state this is never cleared; unlike them it may be non-current (the activity may have
-	// since been unpaused), hence the "last" prefix. No logic gates on this field — it is descriptive
-	// metadata only.
+	// since been unpaused), hence the "last" prefix. Its request_id is used to de-dupe pause requests.
 	LastPauseState *ActivityPauseState `protobuf:"bytes,16,opt,name=last_pause_state,json=lastPauseState,proto3" json:"last_pause_state,omitempty"`
 	// Set when a reset is requested with keep_paused=true on a paused (PAUSE_REQUESTED) activity, so
 	// that when the worker yields the activity lands back in PAUSED rather than SCHEDULED. Consumed

--- a/chasm/lib/activity/handler.go
+++ b/chasm/lib/activity/handler.go
@@ -413,6 +413,7 @@ func (h *handler) PauseActivityExecution(ctx context.Context, req *activitypb.Pa
 func (h *handler) UnpauseActivityExecution(ctx context.Context, req *activitypb.UnpauseActivityExecutionRequest) (*activitypb.UnpauseActivityExecutionResponse, error) {
 	frontendReq := req.GetFrontendRequest()
 	if frontendReq.GetWorkflowId() != "" {
+		// TODO: Forward the request ID once workflow activity unpause supports idempotency.
 		_, err := h.historyHandler.UnpauseActivity(ctx, &historyservice.UnpauseActivityRequest{
 			NamespaceId: req.GetNamespaceId(),
 			FrontendRequest: &workflowservice.UnpauseActivityRequest{
@@ -450,6 +451,7 @@ func (h *handler) UnpauseActivityExecution(ctx context.Context, req *activitypb.
 func (h *handler) ResetActivityExecution(ctx context.Context, req *activitypb.ResetActivityExecutionRequest) (*activitypb.ResetActivityExecutionResponse, error) {
 	frontendReq := req.GetFrontendRequest()
 	if frontendReq.GetWorkflowId() != "" {
+		// TODO: Forward the request ID once workflow activity reset supports idempotency.
 		_, err := h.historyHandler.ResetActivity(ctx, &historyservice.ResetActivityRequest{
 			NamespaceId: req.GetNamespaceId(),
 			FrontendRequest: &workflowservice.ResetActivityRequest{
@@ -492,6 +494,7 @@ func (h *handler) ResetActivityExecution(ctx context.Context, req *activitypb.Re
 func (h *handler) UpdateActivityExecutionOptions(ctx context.Context, req *activitypb.UpdateActivityExecutionOptionsRequest) (*activitypb.UpdateActivityExecutionOptionsResponse, error) {
 	frontendReq := req.GetFrontendRequest()
 	if frontendReq.GetWorkflowId() != "" {
+		// TODO: Forward the request ID once workflow activity options updates support idempotency.
 		resp, err := h.historyHandler.UpdateActivityOptions(ctx, &historyservice.UpdateActivityOptionsRequest{
 			NamespaceId: req.GetNamespaceId(),
 			UpdateRequest: &workflowservice.UpdateActivityOptionsRequest{

--- a/chasm/lib/activity/proto/v1/activity_state.proto
+++ b/chasm/lib/activity/proto/v1/activity_state.proto
@@ -124,8 +124,7 @@ message ActivityState {
 
   // The most recent pause request, if the activity has ever been paused. Like cancel_state and
   // terminate_state this is never cleared; unlike them it may be non-current (the activity may have
-  // since been unpaused), hence the "last" prefix. No logic gates on this field — it is descriptive
-  // metadata only.
+  // since been unpaused), hence the "last" prefix. Its request_id is used to de-dupe pause requests.
   ActivityPauseState last_pause_state = 16;
 
   // Set when a reset is requested with keep_paused=true on a paused (PAUSE_REQUESTED) activity, so

--- a/chasm/lib/activity/proto/v1/activity_state.proto
+++ b/chasm/lib/activity/proto/v1/activity_state.proto
@@ -146,6 +146,15 @@ message ActivityState {
   // non-running activity (SCHEDULED / PAUSED) the restore is applied immediately and this flag is
   // not set. Reset while in CANCEL_REQUESTED or RESET_REQUESTED is rejected.
   bool reset_restore_options = 20;
+
+  // Used to de-dupe unpause requests.
+  string last_unpause_request_id = 21;
+
+  // Used to de-dupe reset requests.
+  string last_reset_request_id = 22;
+
+  // Used to de-dupe update requests.
+  string last_update_options_request_id = 23;
 }
 
 message ActivityCancelState {

--- a/chasm/lib/activity/proto/v1/activity_state.proto
+++ b/chasm/lib/activity/proto/v1/activity_state.proto
@@ -146,13 +146,13 @@ message ActivityState {
   // not set. Reset while in CANCEL_REQUESTED or RESET_REQUESTED is rejected.
   bool reset_restore_options = 20;
 
-  // Used to de-dupe the most recent successful unpause request, including no-ops.
+  // Used to de-dupe unpause requests.
   string last_unpause_request_id = 21;
 
-  // Used to de-dupe the most recent successful reset request.
+  // Used to de-dupe reset requests.
   string last_reset_request_id = 22;
 
-  // Used to de-dupe the most recent successful update request.
+  // Used to de-dupe update requests.
   string last_update_options_request_id = 23;
 }
 

--- a/chasm/lib/activity/proto/v1/activity_state.proto
+++ b/chasm/lib/activity/proto/v1/activity_state.proto
@@ -147,13 +147,13 @@ message ActivityState {
   // not set. Reset while in CANCEL_REQUESTED or RESET_REQUESTED is rejected.
   bool reset_restore_options = 20;
 
-  // Used to de-dupe unpause requests.
+  // Used to de-dupe the most recent successful unpause request, including no-ops.
   string last_unpause_request_id = 21;
 
-  // Used to de-dupe reset requests.
+  // Used to de-dupe the most recent successful reset request.
   string last_reset_request_id = 22;
 
-  // Used to de-dupe update requests.
+  // Used to de-dupe the most recent successful update request.
   string last_update_options_request_id = 23;
 }
 

--- a/chasm/lib/activity/validator.go
+++ b/chasm/lib/activity/validator.go
@@ -475,7 +475,7 @@ var supportedActivityOptionsUpdatePaths = map[string]struct{}{
 }
 
 //nolint:revive // cyclomatic: per-field validation of a field-mask update requires explicit handling of each field
-func validateAndNormalizeUpdateOptionsRequest(
+func validateAndNormalizeUpdateActivityExecutionOptionsRequest(
 	req *workflowservice.UpdateActivityExecutionOptionsRequest,
 	getDefaultActivityRetrySettings dynamicconfig.TypedPropertyFnWithNamespaceFilter[retrypolicy.DefaultRetrySettings],
 	maxIDLengthLimit int,

--- a/chasm/lib/activity/validator.go
+++ b/chasm/lib/activity/validator.go
@@ -475,7 +475,7 @@ var supportedActivityOptionsUpdatePaths = map[string]struct{}{
 }
 
 //nolint:revive // cyclomatic: per-field validation of a field-mask update requires explicit handling of each field
-func validateUpdateActivityExecutionOptionsRequest(
+func validateAndNormalizeUpdateOptionsRequest(
 	req *workflowservice.UpdateActivityExecutionOptionsRequest,
 	getDefaultActivityRetrySettings dynamicconfig.TypedPropertyFnWithNamespaceFilter[retrypolicy.DefaultRetrySettings],
 	maxIDLengthLimit int,
@@ -785,9 +785,6 @@ func validateAndNormalizeUnpauseActivityExecutionRequest(
 }
 
 func validateAndNormalizeRequestID(requestID *string, maxIDLengthLimit int) error {
-	if requestID == nil {
-		return serviceerror.NewInvalidArgument("RequestId is nil")
-	}
 	if *requestID == "" {
 		*requestID = uuid.NewString()
 	}

--- a/chasm/lib/activity/validator.go
+++ b/chasm/lib/activity/validator.go
@@ -413,10 +413,6 @@ func validateAndNormalizeRequestCancelActivityExecutionRequest(
 	blobSizeLimitWarn dynamicconfig.IntPropertyFnWithNamespaceFilter,
 	logger log.Logger,
 ) error {
-	if req.GetRequestId() == "" {
-		req.RequestId = uuid.NewString()
-	}
-
 	if req.GetActivityId() == "" {
 		return serviceerror.NewInvalidArgument("activity ID is required")
 	}
@@ -426,9 +422,8 @@ func validateAndNormalizeRequestCancelActivityExecutionRequest(
 			len(req.GetActivityId()), maxIDLengthLimit)
 	}
 
-	if len(req.GetRequestId()) > maxIDLengthLimit {
-		return serviceerror.NewInvalidArgumentf("request ID exceeds length limit. Length=%d Limit=%d",
-			len(req.GetRequestId()), maxIDLengthLimit)
+	if err := validateAndNormalizeRequestID(&req.RequestId, maxIDLengthLimit); err != nil {
+		return err
 	}
 
 	if len(req.GetIdentity()) > maxIDLengthLimit {
@@ -485,6 +480,10 @@ func validateUpdateActivityExecutionOptionsRequest(
 	getDefaultActivityRetrySettings dynamicconfig.TypedPropertyFnWithNamespaceFilter[retrypolicy.DefaultRetrySettings],
 	maxIDLengthLimit int,
 ) error {
+	if err := validateAndNormalizeRequestID(&req.RequestId, maxIDLengthLimit); err != nil {
+		return err
+	}
+
 	if req.GetActivityId() == "" {
 		return serviceerror.NewInvalidArgument("activity ID is required")
 	}
@@ -649,10 +648,6 @@ func validateAndNormalizeTerminateActivityExecutionRequest(
 	blobSizeLimitWarn dynamicconfig.IntPropertyFnWithNamespaceFilter,
 	logger log.Logger,
 ) error {
-	if req.GetRequestId() == "" {
-		req.RequestId = uuid.NewString()
-	}
-
 	if req.GetActivityId() == "" {
 		return serviceerror.NewInvalidArgument("activity ID is required")
 	}
@@ -662,9 +657,8 @@ func validateAndNormalizeTerminateActivityExecutionRequest(
 			len(req.GetActivityId()), maxIDLengthLimit)
 	}
 
-	if len(req.GetRequestId()) > maxIDLengthLimit {
-		return serviceerror.NewInvalidArgumentf("request ID exceeds length limit. Length=%d Limit=%d",
-			len(req.GetRequestId()), maxIDLengthLimit)
+	if err := validateAndNormalizeRequestID(&req.RequestId, maxIDLengthLimit); err != nil {
+		return err
 	}
 
 	if len(req.GetIdentity()) > maxIDLengthLimit {
@@ -701,12 +695,8 @@ func validateAndNormalizePauseActivityExecutionRequest(
 	blobSizeLimitWarn dynamicconfig.IntPropertyFnWithNamespaceFilter,
 	logger log.Logger,
 ) error {
-	if req.GetRequestId() == "" {
-		req.RequestId = uuid.NewString()
-	}
-	if len(req.GetRequestId()) > maxIDLengthLimit {
-		return serviceerror.NewInvalidArgumentf("request ID exceeds length limit. Length=%d Limit=%d",
-			len(req.GetRequestId()), maxIDLengthLimit)
+	if err := validateAndNormalizeRequestID(&req.RequestId, maxIDLengthLimit); err != nil {
+		return err
 	}
 	if req.GetActivityId() == "" {
 		return serviceerror.NewInvalidArgument("activity ID is required")
@@ -742,6 +732,10 @@ func validateAndNormalizeResetActivityExecutionRequest(
 	req *workflowservice.ResetActivityExecutionRequest,
 	maxIDLengthLimit int,
 ) error {
+	if err := validateAndNormalizeRequestID(&req.RequestId, maxIDLengthLimit); err != nil {
+		return err
+	}
+
 	if req.GetActivityId() == "" {
 		return serviceerror.NewInvalidArgument("activity ID is required")
 	}
@@ -766,6 +760,10 @@ func validateAndNormalizeUnpauseActivityExecutionRequest(
 	req *workflowservice.UnpauseActivityExecutionRequest,
 	maxIDLengthLimit int,
 ) error {
+	if err := validateAndNormalizeRequestID(&req.RequestId, maxIDLengthLimit); err != nil {
+		return err
+	}
+
 	if req.GetActivityId() == "" {
 		return serviceerror.NewInvalidArgument("activity ID is required")
 	}
@@ -784,6 +782,20 @@ func validateAndNormalizeUnpauseActivityExecutionRequest(
 		}
 	}
 	return validateJitter(req.GetJitter())
+}
+
+func validateAndNormalizeRequestID(requestID *string, maxIDLengthLimit int) error {
+	if requestID == nil {
+		return serviceerror.NewInvalidArgument("RequestId is nil")
+	}
+	if *requestID == "" {
+		*requestID = uuid.NewString()
+	}
+	if len(*requestID) > maxIDLengthLimit {
+		return serviceerror.NewInvalidArgumentf("request ID exceeds length limit. Length=%d Limit=%d",
+			len(*requestID), maxIDLengthLimit)
+	}
+	return nil
 }
 
 func validateJitter(jitter *durationpb.Duration) error {

--- a/chasm/lib/activity/validator_test.go
+++ b/chasm/lib/activity/validator_test.go
@@ -484,6 +484,37 @@ func TestRequestIDGeneratedWhenMissing(t *testing.T) {
 		require.NotEmpty(t, req.GetRequestId(), "server must generate a request ID when client omits it")
 		require.NoError(t, validateUUID(req.GetRequestId()), "generated request ID must be a valid UUID")
 	})
+
+	t.Run("UnpauseActivityExecution", func(t *testing.T) {
+		req := &workflowservice.UnpauseActivityExecutionRequest{
+			ActivityId: defaultActivityID,
+		}
+		err := validateAndNormalizeUnpauseActivityExecutionRequest(req, maxIDLengthLimit)
+		require.NoError(t, err)
+		require.NotEmpty(t, req.GetRequestId(), "server must generate a request ID when client omits it")
+		require.NoError(t, validateUUID(req.GetRequestId()), "generated request ID must be a valid UUID")
+	})
+
+	t.Run("ResetActivityExecution", func(t *testing.T) {
+		req := &workflowservice.ResetActivityExecutionRequest{
+			ActivityId: defaultActivityID,
+		}
+		err := validateAndNormalizeResetActivityExecutionRequest(req, maxIDLengthLimit)
+		require.NoError(t, err)
+		require.NotEmpty(t, req.GetRequestId(), "server must generate a request ID when client omits it")
+		require.NoError(t, validateUUID(req.GetRequestId()), "generated request ID must be a valid UUID")
+	})
+
+	t.Run("UpdateActivityExecutionOptions", func(t *testing.T) {
+		req := &workflowservice.UpdateActivityExecutionOptionsRequest{
+			ActivityId:      defaultActivityID,
+			RestoreOriginal: true,
+		}
+		err := validateUpdateActivityExecutionOptionsRequest(req, getDefaultRetrySettings, maxIDLengthLimit)
+		require.NoError(t, err)
+		require.NotEmpty(t, req.GetRequestId(), "server must generate a request ID when client omits it")
+		require.NoError(t, validateUUID(req.GetRequestId()), "generated request ID must be a valid UUID")
+	})
 }
 
 func validateUUID(s string) error {
@@ -540,6 +571,37 @@ func TestRequestIDTooLong(t *testing.T) {
 			RequestId:  tooLong,
 		}
 		err := validateAndNormalizePauseActivityExecutionRequest(req, maxIDLengthLimit, blobLimit, blobLimit, logger)
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+	})
+
+	t.Run("UnpauseActivityExecution", func(t *testing.T) {
+		req := &workflowservice.UnpauseActivityExecutionRequest{
+			ActivityId: defaultActivityID,
+			RequestId:  tooLong,
+		}
+		err := validateAndNormalizeUnpauseActivityExecutionRequest(req, maxIDLengthLimit)
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+	})
+
+	t.Run("ResetActivityExecution", func(t *testing.T) {
+		req := &workflowservice.ResetActivityExecutionRequest{
+			ActivityId: defaultActivityID,
+			RequestId:  tooLong,
+		}
+		err := validateAndNormalizeResetActivityExecutionRequest(req, maxIDLengthLimit)
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+	})
+
+	t.Run("UpdateActivityExecutionOptions", func(t *testing.T) {
+		req := &workflowservice.UpdateActivityExecutionOptionsRequest{
+			ActivityId:      defaultActivityID,
+			RestoreOriginal: true,
+			RequestId:       tooLong,
+		}
+		err := validateUpdateActivityExecutionOptionsRequest(req, getDefaultRetrySettings, maxIDLengthLimit)
 		var invalidArgErr *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgErr)
 	})

--- a/chasm/lib/activity/validator_test.go
+++ b/chasm/lib/activity/validator_test.go
@@ -510,7 +510,7 @@ func TestRequestIDGeneratedWhenMissing(t *testing.T) {
 			ActivityId:      defaultActivityID,
 			RestoreOriginal: true,
 		}
-		err := validateAndNormalizeUpdateOptionsRequest(req, getDefaultRetrySettings, maxIDLengthLimit)
+		err := validateAndNormalizeUpdateActivityExecutionOptionsRequest(req, getDefaultRetrySettings, maxIDLengthLimit)
 		require.NoError(t, err)
 		require.NotEmpty(t, req.GetRequestId(), "server must generate a request ID when client omits it")
 		require.NoError(t, validateUUID(req.GetRequestId()), "generated request ID must be a valid UUID")
@@ -601,7 +601,7 @@ func TestRequestIDTooLong(t *testing.T) {
 			RestoreOriginal: true,
 			RequestId:       tooLong,
 		}
-		err := validateAndNormalizeUpdateOptionsRequest(req, getDefaultRetrySettings, maxIDLengthLimit)
+		err := validateAndNormalizeUpdateActivityExecutionOptionsRequest(req, getDefaultRetrySettings, maxIDLengthLimit)
 		var invalidArgErr *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgErr)
 	})

--- a/chasm/lib/activity/validator_test.go
+++ b/chasm/lib/activity/validator_test.go
@@ -510,7 +510,7 @@ func TestRequestIDGeneratedWhenMissing(t *testing.T) {
 			ActivityId:      defaultActivityID,
 			RestoreOriginal: true,
 		}
-		err := validateUpdateActivityExecutionOptionsRequest(req, getDefaultRetrySettings, maxIDLengthLimit)
+		err := validateAndNormalizeUpdateOptionsRequest(req, getDefaultRetrySettings, maxIDLengthLimit)
 		require.NoError(t, err)
 		require.NotEmpty(t, req.GetRequestId(), "server must generate a request ID when client omits it")
 		require.NoError(t, validateUUID(req.GetRequestId()), "generated request ID must be a valid UUID")
@@ -601,7 +601,7 @@ func TestRequestIDTooLong(t *testing.T) {
 			RestoreOriginal: true,
 			RequestId:       tooLong,
 		}
-		err := validateUpdateActivityExecutionOptionsRequest(req, getDefaultRetrySettings, maxIDLengthLimit)
+		err := validateAndNormalizeUpdateOptionsRequest(req, getDefaultRetrySettings, maxIDLengthLimit)
 		var invalidArgErr *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgErr)
 	})

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.44.0
-	go.temporal.io/api v1.63.5-0.20260730194729-ba94140a7640
+	go.temporal.io/api v1.63.5-0.20260730203810-e7387ebd980e
 	go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee
 	go.temporal.io/sdk v1.44.0
 	go.uber.org/fx v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -479,8 +479,8 @@ go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0 h1:R
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0/go.mod h1:I89cynRj8y+383o7tEQVg2SVA6SRgDVIouWPUVXjx0U=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0 h1:CQvJSldHRUN6Z8jsUeYv8J0lXRvygALXIzsmAeCcZE0=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0/go.mod h1:xSQ+mEfJe/GjK1LXEyVOoSI1N9JV9ZI923X5kup43W4=
-go.temporal.io/api v1.63.5-0.20260730194729-ba94140a7640 h1:jA7eUGPMrhXi35QHD0FM+bqPCmajFgoTUjn8cVnDRAY=
-go.temporal.io/api v1.63.5-0.20260730194729-ba94140a7640/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
+go.temporal.io/api v1.63.5-0.20260730203810-e7387ebd980e h1:kUL8YTxElWLVqorcA26Kr7xujAk7B1lPedl/x9Q7Gx4=
+go.temporal.io/api v1.63.5-0.20260730203810-e7387ebd980e/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
 go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee h1:y6A65Iml06cR3CpxW2Zn8FQLjniPDTnN4jtr69UZxXI=
 go.temporal.io/auto-scaled-workers v0.0.0-20260706201056-4320b34799ee/go.mod h1:hhHijO9XRPIkAflLJJHix61M9FzbRPqk8fSydkcLkqw=
 go.temporal.io/sdk v1.44.0 h1:suitPDukX74rW3/N1FqvEbZTZVJJsxMKhv0KMa/j7pU=

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -8537,6 +8537,42 @@ func (s *standaloneActivityTestSuite) TestUpdateActivityExecutionOptions() {
 		}
 	})
 
+	// Apply an update, terminate the activity, then retry the same request ID. The retry must be
+	// deduplicated before terminal-state validation.
+	t.Run("DuplicateRequestIDSucceeds", func(t *testing.T) {
+		ctx := testcore.NewContext()
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		updateReq := &workflowservice.UpdateActivityExecutionOptionsRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.GetRunId(),
+			RequestId:  "update-request-id",
+			ActivityOptions: &activitypb.ActivityOptions{
+				HeartbeatTimeout: durationpb.New(30 * time.Second),
+			},
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"heartbeat_timeout"}},
+		}
+
+		_, err := env.FrontendClient().UpdateActivityExecutionOptions(ctx, updateReq)
+		require.NoError(t, err)
+
+		_, err = env.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.GetRunId(),
+			RequestId:  "terminate-request-id",
+		})
+		require.NoError(t, err)
+
+		updateResp, err := env.FrontendClient().UpdateActivityExecutionOptions(ctx, updateReq)
+		require.NoError(t, err)
+		require.Equal(t, 30*time.Second,
+			updateResp.GetActivityOptions().GetHeartbeatTimeout().AsDuration())
+	})
+
 	t.Run("ChangeRetryInterval", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 		defer cancel()
@@ -12176,6 +12212,44 @@ func (s *standaloneActivityTestSuite) TestUnpauseActivityExecution() {
 		require.NoError(t, err)
 	})
 
+	// Record a no-op unpause, pause the activity, then retry the same unpause request ID. The retry
+	// must not undo the later pause.
+	t.Run("DuplicateRequestIDDoesNotUndoLaterPause", func(t *testing.T) {
+		ctx := testcore.NewContext()
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		unpauseReq := &workflowservice.UnpauseActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.GetRunId(),
+			RequestId:  "unpause-request-id",
+		}
+
+		_, err := env.FrontendClient().UnpauseActivityExecution(ctx, unpauseReq)
+		require.NoError(t, err)
+
+		_, err = env.FrontendClient().PauseActivityExecution(ctx, &workflowservice.PauseActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.GetRunId(),
+			RequestId:  "pause-request-id",
+		})
+		require.NoError(t, err)
+
+		_, err = env.FrontendClient().UnpauseActivityExecution(ctx, unpauseReq)
+		require.NoError(t, err)
+
+		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.GetRunId(),
+		})
+		require.NoError(t, err)
+		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_PAUSED, descResp.GetInfo().GetRunState())
+	})
+
 	t.Run("UnpauseWithResetAttempts", func(t *testing.T) {
 		ctx := testcore.NewContext()
 
@@ -12754,6 +12828,37 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 			require.Equal(c, state, desc.GetInfo().GetRunState())
 		}, 5*time.Second, 100*time.Millisecond)
 	}
+
+	// Reset while scheduled, start the reset attempt, then retry the same request ID. The retry
+	// must not transition the started activity to RESET_REQUESTED, which heartbeat would report.
+	t.Run("DuplicateRequestIDWhileStartedIsNoOp", func(t *testing.T) {
+		ctx := testcore.NewContext()
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		resetReq := &workflowservice.ResetActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      startResp.GetRunId(),
+			RequestId:  "reset-request-id",
+		}
+
+		_, err := env.FrontendClient().ResetActivityExecution(ctx, resetReq)
+		require.NoError(t, err)
+
+		pollResp := env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, startResp.GetRunId())
+
+		_, err = env.FrontendClient().ResetActivityExecution(ctx, resetReq)
+		require.NoError(t, err)
+
+		heartbeatResp, err := env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
+			Namespace: env.Namespace().String(),
+			TaskToken: pollResp.GetTaskToken(),
+		})
+		require.NoError(t, err)
+		require.False(t, heartbeatResp.GetActivityReset())
+	})
 
 	t.Run("AfterRetry", func(t *testing.T) {
 		// Start activity, let it fail twice (attempt 3 backing off with long interval),

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -12212,6 +12212,7 @@ func (s *standaloneActivityTestSuite) TestUnpauseActivityExecution() {
 		require.NoError(t, err)
 	})
 
+	// TODO(sean): unpause should fail instead of no-op. Tailor to expect request ID not save on failedprecondition.
 	// Record a no-op unpause, pause the activity, then retry the same unpause request ID. The retry
 	// must not undo the later pause.
 	t.Run("DuplicateRequestIDDoesNotUndoLaterPause", func(t *testing.T) {

--- a/tests/mixedbrain/go.mod
+++ b/tests/mixedbrain/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/siderolabs/grpc-proxy v0.5.2
 	github.com/stretchr/testify v1.11.1
 	github.com/temporalio/omes v0.0.0-20260529203146-c6ee1f56c726
-	go.temporal.io/api v1.63.5-0.20260730194729-ba94140a7640
+	go.temporal.io/api v1.63.5-0.20260730203810-e7387ebd980e
 	go.temporal.io/server v0.0.0-00010101000000-000000000000
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11

--- a/tests/mixedbrain/go.sum
+++ b/tests/mixedbrain/go.sum
@@ -55,8 +55,8 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/6gtIk=
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
-go.temporal.io/api v1.63.5-0.20260730194729-ba94140a7640 h1:jA7eUGPMrhXi35QHD0FM+bqPCmajFgoTUjn8cVnDRAY=
-go.temporal.io/api v1.63.5-0.20260730194729-ba94140a7640/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
+go.temporal.io/api v1.63.5-0.20260730203810-e7387ebd980e h1:kUL8YTxElWLVqorcA26Kr7xujAk7B1lPedl/x9Q7Gx4=
+go.temporal.io/api v1.63.5-0.20260730203810-e7387ebd980e/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=


### PR DESCRIPTION
## What changed?
Added request-ID-based idempotency for standalone activity unpause, reset, and update-options operations. Successful request IDs are persisted in activity state and duplicate requests are handled as no-ops. 

## Why?
These APIs can be retried after timeouts or transient failures. Persisting the latest successful request ID prevents duplicate mutations, including delayed unpause retries undoing a later pause. Workflow-backed activity support will follow separately.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [X] added new unit test(s)
- [X] added new functional test(s)

