### PR TITLE
Reject empty workflow ID in CreateSchedule

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -3925,6 +3925,12 @@ func (wh *WorkflowHandler) validateStartWorkflowArgsForSchedule(
 		return nil
 	}
 
+	if startWorkflow.WorkflowId == "" {
+		return workflow.ErrWorkflowIDNotSet
+	}
+
+	// The scheduler may append a timestamp to the workflow ID, so check the length limit
+	// against the longest ID it can produce.
 	if err := wh.validator.ValidateWorkflowID(startWorkflow.WorkflowId + scheduler.AppendedTimestampForValidation); err != nil {
 		return err
 	}

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -5072,6 +5072,64 @@ func (s *WorkflowHandlerSuite) TestPatchSchedule_TriggerImmediatelyScheduledTime
 	}
 }
 
+func (s *WorkflowHandlerSuite) TestCreateSchedule_StartWorkflowValidation() {
+	config := s.newConfig()
+	config.EnableSchedules = dc.GetBoolPropertyFnFilteredByNamespace(true)
+	wh := s.getWorkflowHandler(config)
+	ctx := context.Background()
+	s.mockSearchAttributesMapperProvider.EXPECT().GetMapper(gomock.Any()).Return(nil, nil).AnyTimes()
+
+	newRequest := func(startWorkflow *workflowpb.NewWorkflowExecutionInfo) *workflowservice.CreateScheduleRequest {
+		return &workflowservice.CreateScheduleRequest{
+			Namespace:  s.testNamespace.String(),
+			ScheduleId: "test-schedule",
+			RequestId:  uuid.NewString(),
+			Schedule: &schedulepb.Schedule{
+				Action: &schedulepb.ScheduleAction{
+					Action: &schedulepb.ScheduleAction_StartWorkflow{
+						StartWorkflow: startWorkflow,
+					},
+				},
+			},
+		}
+	}
+
+	s.Run("empty workflow ID should return error", func() {
+		request := newRequest(&workflowpb.NewWorkflowExecutionInfo{
+			WorkflowId:   "",
+			WorkflowType: &commonpb.WorkflowType{Name: "test-workflow-type"},
+			TaskQueue:    &taskqueuepb.TaskQueue{Name: "test-tq", Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		})
+
+		resp, err := wh.CreateSchedule(ctx, request)
+		s.Nil(resp)
+		s.Equal(workflow.ErrWorkflowIDNotSet, err)
+	})
+
+	s.Run("workflow ID too long should return error", func() {
+		request := newRequest(&workflowpb.NewWorkflowExecutionInfo{
+			WorkflowId:   strings.Repeat("a", config.MaxIDLengthLimit()),
+			WorkflowType: &commonpb.WorkflowType{Name: "test-workflow-type"},
+			TaskQueue:    &taskqueuepb.TaskQueue{Name: "test-tq", Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		})
+
+		resp, err := wh.CreateSchedule(ctx, request)
+		s.Nil(resp)
+		s.ErrorContains(err, "WorkflowId exceeds maximum allowed length")
+	})
+
+	s.Run("missing workflow type should return error", func() {
+		request := newRequest(&workflowpb.NewWorkflowExecutionInfo{
+			WorkflowId: "test-workflow-id",
+			TaskQueue:  &taskqueuepb.TaskQueue{Name: "test-tq", Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		})
+
+		resp, err := wh.CreateSchedule(ctx, request)
+		s.Nil(resp)
+		s.Equal(errWorkflowTypeNotSet, err)
+	})
+}
+
 func (s *WorkflowHandlerSuite) TestPatchSchedule_ValidationAndErrors() {
 	config := s.newConfig()
 	config.EnableSchedules = dc.GetBoolPropertyFnFilteredByNamespace(true)


### PR DESCRIPTION
## What changed?
`validateStartWorkflowArgsForSchedule` now rejects an empty `startWorkflow.WorkflowId` with the existing `ErrWorkflowIDNotSet` sentinel before running the length check, which still validates `WorkflowId + AppendedTimestampForValidation` unchanged. Added sub-tests for the empty, valid, and over-length cases following the `TestPatchSchedule_ValidationAndErrors` table pattern.

## Why?
The only workflow ID validation on this path ran against the ID with `AppendedTimestampForValidation` already concatenated. Since that constant is a non-empty 21-character string, the validator's empty check was unreachable, so schedules could be created with an empty workflow ID. When the overlap policy does not append a timestamp the scheduled runs all start with the literal ID `""`, and when it does, the appended nominal time has one-second resolution, so two triggers in the same second collide. That produces the intermittent workflow-ID-conflict errors described in the issue.

Refs #6188. Flagging honestly: that issue was never maintainer-confirmed, and this is a validation tightening, so if you would rather default the ID (for example from the schedule ID) or address the collision in the scheduler instead, I am happy to rework it.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)

The new empty-workflow-ID sub-case fails before the fix (the request runs past validation into `createScheduleWorkflow`) and passes after it. The full `WorkflowHandlerSuite` passes.

## Potential risks
This tightens validation on a public API: `CreateSchedule` requests with an empty workflow ID that previously succeeded (and misbehaved later) now fail with `InvalidArgument`. Anyone depending on the old behavior would break on upgrade; if that needs gating behind dynamic config, I can add it.
