### PR TITLE
Refactor SANO validation

### DIFF
--- a/chasm/lib/nexusoperation/frontend.go
+++ b/chasm/lib/nexusoperation/frontend.go
@@ -36,11 +36,9 @@ var ErrStandaloneNexusOperationDisabled = serviceerror.NewUnimplemented("Standal
 type frontendHandler struct {
 	client            nexusoperationpb.NexusOperationServiceClient
 	config            *Config
-	logger            log.Logger
 	namespaceRegistry namespace.Registry
 	endpointRegistry  commonnexus.EndpointRegistry
-	saMapperProvider  searchattribute.MapperProvider
-	saValidator       *searchattribute.Validator
+	validator         *validator
 }
 
 func NewFrontendHandler(
@@ -55,11 +53,9 @@ func NewFrontendHandler(
 	return &frontendHandler{
 		client:            client,
 		config:            config,
-		logger:            logger,
 		namespaceRegistry: namespaceRegistry,
 		endpointRegistry:  endpointRegistry,
-		saMapperProvider:  saMapperProvider,
-		saValidator:       saValidator,
+		validator:         newValidator(config, logger, saMapperProvider, saValidator),
 	}
 }
 
@@ -76,7 +72,7 @@ func (h *frontendHandler) StartNexusOperationExecution(
 		return nil, err
 	}
 
-	if err := validateAndNormalizeStartRequest(req, h.config, h.logger, h.saMapperProvider, h.saValidator); err != nil {
+	if err := h.validator.validateAndNormalizeStartRequest(req); err != nil {
 		return nil, err
 	}
 
@@ -107,7 +103,7 @@ func (h *frontendHandler) DescribeNexusOperationExecution(
 		return nil, err
 	}
 
-	if err := validateAndNormalizeDescribeRequest(req, namespaceID.String(), h.config); err != nil {
+	if err := h.validator.validateAndNormalizeDescribeRequest(req, namespaceID.String()); err != nil {
 		return nil, err
 	}
 
@@ -127,7 +123,7 @@ func (h *frontendHandler) PollNexusOperationExecution(
 		return nil, ErrStandaloneNexusOperationDisabled
 	}
 
-	if err := validateAndNormalizePollRequest(req, h.config); err != nil {
+	if err := h.validator.validateAndNormalizePollRequest(req); err != nil {
 		return nil, err
 	}
 
@@ -248,7 +244,7 @@ func (h *frontendHandler) RequestCancelNexusOperationExecution(
 		return nil, err
 	}
 
-	if err := validateAndNormalizeCancelRequest(req, h.config); err != nil {
+	if err := h.validator.validateAndNormalizeCancelRequest(req); err != nil {
 		return nil, err
 	}
 
@@ -276,7 +272,7 @@ func (h *frontendHandler) TerminateNexusOperationExecution(
 		return nil, err
 	}
 
-	if err := validateAndNormalizeTerminateRequest(req, h.config); err != nil {
+	if err := h.validator.validateAndNormalizeTerminateRequest(req); err != nil {
 		return nil, err
 	}
 
@@ -304,7 +300,7 @@ func (h *frontendHandler) DeleteNexusOperationExecution(
 		return nil, err
 	}
 
-	if err := validateAndNormalizeDeleteRequest(req, h.config); err != nil {
+	if err := h.validator.validateAndNormalizeDeleteRequest(req); err != nil {
 		return nil, err
 	}
 

--- a/chasm/lib/nexusoperation/validator.go
+++ b/chasm/lib/nexusoperation/validator.go
@@ -54,12 +54,9 @@ func newValidator(
 func (v *validator) validateAndNormalizeStartRequest(req *workflowservice.StartNexusOperationExecutionRequest) error {
 	ns := req.GetNamespace()
 
-	requestID, err := v.normalizeRequestID(req.GetRequestId())
-	if err != nil {
+	if err := v.normalizeRequestID(&req.RequestId); err != nil {
 		return err
 	}
-	req.RequestId = requestID
-
 	if err := v.validateOperationID(req.GetOperationId()); err != nil {
 		return err
 	}
@@ -137,22 +134,16 @@ func (v *validator) validateAndNormalizePollRequest(req *workflowservice.PollNex
 }
 
 func (v *validator) validateAndNormalizeCancelRequest(req *workflowservice.RequestCancelNexusOperationExecutionRequest) error {
-	requestID, err := v.normalizeRequestID(req.GetRequestId())
-	if err != nil {
+	if err := v.normalizeRequestID(&req.RequestId); err != nil {
 		return err
 	}
-	req.RequestId = requestID
-
 	return v.validateCancelOrTerminateRequest(req)
 }
 
 func (v *validator) validateAndNormalizeTerminateRequest(req *workflowservice.TerminateNexusOperationExecutionRequest) error {
-	requestID, err := v.normalizeRequestID(req.GetRequestId())
-	if err != nil {
+	if err := v.normalizeRequestID(&req.RequestId); err != nil {
 		return err
 	}
-	req.RequestId = requestID
-
 	return v.validateCancelOrTerminateRequest(req)
 }
 
@@ -240,8 +231,6 @@ func (v *validator) validateAndCapTimeouts(req *workflowservice.StartNexusOperat
 	return nil
 }
 
-// validateInput checks the operation input against the namespace payload size limit, logging a
-// warning when it exceeds the (lower) warning threshold.
 func (v *validator) validateInput(req *workflowservice.StartNexusOperationExecutionRequest) error {
 	ns := req.GetNamespace()
 	inputSize := req.GetInput().Size()
@@ -322,13 +311,13 @@ func (v *validator) normalizeIDPolicies(req *workflowservice.StartNexusOperation
 	}
 }
 
-// normalizeRequestID generates a request ID when the caller didn't provide one, and otherwise
-// validates the one it did.
-func (v *validator) normalizeRequestID(requestID string) (string, error) {
-	if requestID == "" {
-		return uuid.NewString(), nil
+// normalizeRequestID validates the request ID, or sets it to a UUID if empty.
+func (v *validator) normalizeRequestID(requestID *string) error {
+	if *requestID == "" {
+		*requestID = uuid.NewString()
+		return nil
 	}
-	return requestID, v.validateIDLength("request_id", requestID)
+	return v.validateIDLength("request_id", *requestID)
 }
 
 func (v *validator) validateOperationID(operationID string) error {

--- a/chasm/lib/nexusoperation/validator.go
+++ b/chasm/lib/nexusoperation/validator.go
@@ -160,12 +160,7 @@ func (v *validator) validateAndNormalizeDeleteRequest(req *workflowservice.Delet
 	if err := v.validateOperationID(req.GetOperationId()); err != nil {
 		return err
 	}
-	if req.GetRunId() != "" {
-		if err := uuid.Validate(req.GetRunId()); err != nil {
-			return serviceerror.NewInvalidArgument("invalid run id: must be a valid UUID")
-		}
-	}
-	return nil
+	return v.validateRunID(req.GetRunId())
 }
 
 // validateCancelOrTerminateRequest validates the fields the cancel and terminate requests have in

--- a/chasm/lib/nexusoperation/validator.go
+++ b/chasm/lib/nexusoperation/validator.go
@@ -1,14 +1,12 @@
 package nexusoperation
 
 import (
-	"errors"
-	"fmt"
 	"slices"
 	"strings"
 
 	"github.com/google/uuid"
-	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	sdkpb "go.temporal.io/api/sdk/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/chasm"
@@ -19,89 +17,202 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
-// ValidateServiceName checks that the service name does not exceed the configured limit.
-func ValidateServiceName(service string, limit int) error {
-	if len(service) > limit {
-		return fmt.Errorf("service exceeds length limit. Length=%d Limit=%d", len(service), limit)
-	}
-	return nil
+// cancelOrTerminateRequest is the subset of the cancel and terminate requests that are validated the same way.
+type cancelOrTerminateRequest interface {
+	GetNamespace() string
+	GetOperationId() string
+	GetRunId() string
+	GetIdentity() string
+	GetReason() string
 }
 
-// ValidateOperationName checks that the operation name does not exceed the configured limit.
-func ValidateOperationName(operation string, limit int) error {
-	if len(operation) > limit {
-		return fmt.Errorf("operation exceeds length limit. Length=%d Limit=%d", len(operation), limit)
-	}
-	return nil
+// validator validates and normalizes the frontend requests for standalone Nexus operations.
+//
+// Requests are mutated in place: defaults are applied, values are capped to their configured
+// limits, and headers are lower-cased.
+type validator struct {
+	config           *Config
+	logger           log.Logger
+	saMapperProvider searchattribute.MapperProvider
+	saValidator      *searchattribute.Validator
 }
 
-// ValidateAndLowercaseNexusHeaders validates headers and returns a new map with lower-cased keys.
-func ValidateAndLowercaseNexusHeaders(headers map[string]string, disallowed []string, sizeLimit int) (map[string]string, error) {
-	headerLength := 0
-	lowered := make(map[string]string, len(headers))
-	for k, v := range headers {
-		lowerK := strings.ToLower(k)
-		headerLength += len(lowerK) + len(v)
-		if slices.Contains(disallowed, lowerK) {
-			return nil, fmt.Errorf("nexus_header contains a disallowed key: %q", k)
-		}
-		lowered[lowerK] = v
-	}
-	if headerLength > sizeLimit {
-		return nil, errors.New("nexus_header exceeds size limit")
-	}
-	return lowered, nil
-}
-
-// ValidatePayloadSize checks that the payload does not exceed the size limit.
-func ValidatePayloadSize(input *commonpb.Payload, limit int) error {
-	if input.Size() > limit {
-		return errors.New("input exceeds size limit")
-	}
-	return nil
-}
-
-//revive:disable-next-line:cognitive-complexity,cyclomatic
-func validateAndNormalizeStartRequest(
-	req *workflowservice.StartNexusOperationExecutionRequest,
+func newValidator(
 	config *Config,
 	logger log.Logger,
 	saMapperProvider searchattribute.MapperProvider,
 	saValidator *searchattribute.Validator,
-) error {
+) *validator {
+	return &validator{
+		config:           config,
+		logger:           logger,
+		saMapperProvider: saMapperProvider,
+		saValidator:      saValidator,
+	}
+}
+
+func (v *validator) validateAndNormalizeStartRequest(req *workflowservice.StartNexusOperationExecutionRequest) error {
 	ns := req.GetNamespace()
-	if req.GetRequestId() == "" {
-		req.RequestId = uuid.NewString()
-	} else if len(req.GetRequestId()) > config.MaxIDLengthLimit() {
-		return serviceerror.NewInvalidArgumentf("request_id exceeds length limit. Length=%d Limit=%d",
-			len(req.GetRequestId()), config.MaxIDLengthLimit())
+
+	requestID, err := v.normalizeRequestID(req.GetRequestId())
+	if err != nil {
+		return err
 	}
-	if req.GetOperationId() == "" {
-		return serviceerror.NewInvalidArgument("operation_id is required")
+	req.RequestId = requestID
+
+	if err := v.validateOperationID(req.GetOperationId()); err != nil {
+		return err
 	}
-	if len(req.GetOperationId()) > config.MaxIDLengthLimit() {
-		return serviceerror.NewInvalidArgumentf("operation_id exceeds length limit. Length=%d Limit=%d",
-			len(req.GetOperationId()), config.MaxIDLengthLimit())
+	if err := v.validateIDLength("identity", req.GetIdentity()); err != nil {
+		return err
 	}
-	if len(req.GetIdentity()) > config.MaxIDLengthLimit() {
-		return serviceerror.NewInvalidArgumentf("identity exceeds length limit. Length=%d Limit=%d",
-			len(req.GetIdentity()), config.MaxIDLengthLimit())
+	if err := v.validateTarget(req); err != nil {
+		return err
 	}
+	if err := v.validateAndCapTimeouts(req); err != nil {
+		return err
+	}
+	if err := v.validateInput(req); err != nil {
+		return err
+	}
+	if err := v.validateUserMetadata(ns, req.GetUserMetadata()); err != nil {
+		return err
+	}
+
+	loweredHeaders, err := v.validateAndLowercaseHeaders(ns, req.GetNexusHeader())
+	if err != nil {
+		return err
+	}
+	req.NexusHeader = loweredHeaders
+
+	if err := v.validateAndNormalizeSearchAttributes(req); err != nil {
+		return err
+	}
+
+	v.normalizeIDPolicies(req)
+	return nil
+}
+
+func (v *validator) validateAndNormalizeDescribeRequest(
+	req *workflowservice.DescribeNexusOperationExecutionRequest,
+	namespaceID string,
+) error {
+	if err := v.validateOperationID(req.GetOperationId()); err != nil {
+		return err
+	}
+	if len(req.GetLongPollToken()) > 0 && req.GetRunId() == "" {
+		return serviceerror.NewInvalidArgument("run_id is required when long_poll_token is provided")
+	}
+	if err := v.validateRunID(req.GetRunId()); err != nil {
+		return err
+	}
+	if len(req.GetLongPollToken()) > 0 {
+		ref, err := chasm.DeserializeComponentRef(req.GetLongPollToken())
+		if err != nil {
+			return serviceerror.NewInvalidArgument("invalid long poll token")
+		}
+		if ref.NamespaceID != namespaceID {
+			return serviceerror.NewInvalidArgument("long poll token does not match execution")
+		}
+	}
+	return nil
+}
+
+func (v *validator) validateAndNormalizePollRequest(req *workflowservice.PollNexusOperationExecutionRequest) error {
+	// Normalize wait stage: UNSPECIFIED defaults to CLOSED.
+	if req.GetWaitStage() == enumspb.NEXUS_OPERATION_WAIT_STAGE_UNSPECIFIED {
+		req.WaitStage = enumspb.NEXUS_OPERATION_WAIT_STAGE_CLOSED
+	} else {
+		switch req.GetWaitStage() {
+		case enumspb.NEXUS_OPERATION_WAIT_STAGE_STARTED,
+			enumspb.NEXUS_OPERATION_WAIT_STAGE_CLOSED:
+		default:
+			return serviceerror.NewInvalidArgumentf("unsupported wait_stage: %s", req.GetWaitStage())
+		}
+	}
+	if err := v.validateOperationID(req.GetOperationId()); err != nil {
+		return err
+	}
+	return v.validateRunID(req.GetRunId())
+}
+
+func (v *validator) validateAndNormalizeCancelRequest(req *workflowservice.RequestCancelNexusOperationExecutionRequest) error {
+	requestID, err := v.normalizeRequestID(req.GetRequestId())
+	if err != nil {
+		return err
+	}
+	req.RequestId = requestID
+
+	return v.validateCancelOrTerminateRequest(req)
+}
+
+func (v *validator) validateAndNormalizeTerminateRequest(req *workflowservice.TerminateNexusOperationExecutionRequest) error {
+	requestID, err := v.normalizeRequestID(req.GetRequestId())
+	if err != nil {
+		return err
+	}
+	req.RequestId = requestID
+
+	return v.validateCancelOrTerminateRequest(req)
+}
+
+func (v *validator) validateAndNormalizeDeleteRequest(req *workflowservice.DeleteNexusOperationExecutionRequest) error {
+	if err := v.validateOperationID(req.GetOperationId()); err != nil {
+		return err
+	}
+	if req.GetRunId() != "" {
+		if err := uuid.Validate(req.GetRunId()); err != nil {
+			return serviceerror.NewInvalidArgument("invalid run id: must be a valid UUID")
+		}
+	}
+	return nil
+}
+
+// validateCancelOrTerminateRequest validates the fields the cancel and terminate requests have in
+// common.
+func (v *validator) validateCancelOrTerminateRequest(req cancelOrTerminateRequest) error {
+	if err := v.validateOperationID(req.GetOperationId()); err != nil {
+		return err
+	}
+	if err := v.validateRunID(req.GetRunId()); err != nil {
+		return err
+	}
+	if err := v.validateIDLength("identity", req.GetIdentity()); err != nil {
+		return err
+	}
+	if limit := v.config.MaxReasonLength(req.GetNamespace()); len(req.GetReason()) > limit {
+		return serviceerror.NewInvalidArgumentf("reason exceeds length limit. Length=%d Limit=%d",
+			len(req.GetReason()), limit)
+	}
+	return nil
+}
+
+// validateTarget checks the endpoint, service, and operation the request targets.
+func (v *validator) validateTarget(req *workflowservice.StartNexusOperationExecutionRequest) error {
+	ns := req.GetNamespace()
 	if req.GetEndpoint() == "" {
 		return serviceerror.NewInvalidArgument("endpoint is required")
 	}
 	if req.GetService() == "" {
 		return serviceerror.NewInvalidArgument("service is required")
 	}
-	if err := ValidateServiceName(req.GetService(), config.MaxServiceNameLength(ns)); err != nil {
-		return serviceerror.NewInvalidArgument(err.Error())
+	if limit := v.config.MaxServiceNameLength(ns); len(req.GetService()) > limit {
+		return serviceerror.NewInvalidArgumentf("service exceeds length limit. Length=%d Limit=%d",
+			len(req.GetService()), limit)
 	}
 	if req.GetOperation() == "" {
 		return serviceerror.NewInvalidArgument("operation is required")
 	}
-	if err := ValidateOperationName(req.GetOperation(), config.MaxOperationNameLength(ns)); err != nil {
-		return serviceerror.NewInvalidArgument(err.Error())
+	if limit := v.config.MaxOperationNameLength(ns); len(req.GetOperation()) > limit {
+		return serviceerror.NewInvalidArgumentf("operation exceeds length limit. Length=%d Limit=%d",
+			len(req.GetOperation()), limit)
 	}
+	return nil
+}
+
+// validateAndCapTimeouts validates the request timeouts, capping schedule_to_close_timeout to the
+// namespace limit and the remaining timeouts to schedule_to_close_timeout.
+func (v *validator) validateAndCapTimeouts(req *workflowservice.StartNexusOperationExecutionRequest) error {
 	if err := timestamp.ValidateAndCapProtoDuration(req.GetScheduleToCloseTimeout()); err != nil {
 		return serviceerror.NewInvalidArgumentf("schedule_to_close_timeout is invalid: %v", err)
 	}
@@ -113,7 +224,7 @@ func validateAndNormalizeStartRequest(
 	}
 
 	scheduleToCloseTimeout := req.GetScheduleToCloseTimeout().AsDuration()
-	maxTimeout := config.MaxOperationScheduleToCloseTimeout(ns)
+	maxTimeout := v.config.MaxOperationScheduleToCloseTimeout(req.GetNamespace())
 	if maxTimeout > 0 {
 		if scheduleToCloseTimeout == 0 || scheduleToCloseTimeout > maxTimeout {
 			// Apply the effective namespace limit to schedule_to_close_timeout before capping the other timeouts.
@@ -131,210 +242,122 @@ func validateAndNormalizeStartRequest(
 			req.StartToCloseTimeout = req.GetScheduleToCloseTimeout()
 		}
 	}
+	return nil
+}
 
+// validateInput checks the operation input against the namespace payload size limit, logging a
+// warning when it exceeds the (lower) warning threshold.
+func (v *validator) validateInput(req *workflowservice.StartNexusOperationExecutionRequest) error {
+	ns := req.GetNamespace()
 	inputSize := req.GetInput().Size()
-	if inputSize > config.PayloadSizeLimitWarn(ns) {
-		logger.Warn("Nexus Start Operation input size exceeds the warning limit.",
+	if inputSize > v.config.PayloadSizeLimitWarn(ns) {
+		v.logger.Warn("Nexus Start Operation input size exceeds the warning limit.",
 			tag.WorkflowNamespace(ns),
 			tag.OperationID(req.GetOperationId()),
 			tag.BlobSize(int64(inputSize)),
 			tag.BlobSizeViolationOperation("StartNexusOperationExecution"))
 	}
-	if inputSize > config.PayloadSizeLimit(ns) {
-		return serviceerror.NewInvalidArgumentf("input exceeds size limit. Length=%d Limit=%d",
-			inputSize, config.PayloadSizeLimit(ns))
+	if limit := v.config.PayloadSizeLimit(ns); inputSize > limit {
+		return serviceerror.NewInvalidArgumentf("input exceeds size limit. Length=%d Limit=%d", inputSize, limit)
+	}
+	return nil
+}
+
+func (v *validator) validateUserMetadata(ns string, metadata *sdkpb.UserMetadata) error {
+	summarySize := metadata.GetSummary().Size()
+	if limit := v.config.MaxUserMetadataSummarySize(ns); summarySize > limit {
+		return serviceerror.NewInvalidArgumentf(
+			"user_metadata.summary exceeds size limit. Length=%d Limit=%d", summarySize, limit)
+	}
+	detailsSize := metadata.GetDetails().Size()
+	if limit := v.config.MaxUserMetadataDetailsSize(ns); detailsSize > limit {
+		return serviceerror.NewInvalidArgumentf(
+			"user_metadata.details exceeds size limit. Length=%d Limit=%d", detailsSize, limit)
+	}
+	return nil
+}
+
+// validateAndLowercaseHeaders validates the Nexus headers and returns a new map with lower-cased
+// keys.
+func (v *validator) validateAndLowercaseHeaders(ns string, headers map[string]string) (map[string]string, error) {
+	disallowed := v.config.DisallowedOperationHeaders()
+	headerLength := 0
+	lowered := make(map[string]string, len(headers))
+	for k, val := range headers {
+		lowerK := strings.ToLower(k)
+		headerLength += len(lowerK) + len(val)
+		if slices.Contains(disallowed, lowerK) {
+			return nil, serviceerror.NewInvalidArgumentf("nexus_header contains a disallowed key: %q", k)
+		}
+		lowered[lowerK] = val
+	}
+	if headerLength > v.config.MaxOperationHeaderSize(ns) {
+		return nil, serviceerror.NewInvalidArgument("nexus_header exceeds size limit")
+	}
+	return lowered, nil
+}
+
+func (v *validator) validateAndNormalizeSearchAttributes(req *workflowservice.StartNexusOperationExecutionRequest) error {
+	namespaceName := req.GetNamespace()
+
+	// Unalias search attributes for validation.
+	saToValidate := req.SearchAttributes
+	if v.saMapperProvider != nil && saToValidate != nil {
+		var err error
+		saToValidate, err = searchattribute.UnaliasFields(v.saMapperProvider, saToValidate, namespaceName)
+		if err != nil {
+			return err
+		}
 	}
 
-	if summary := req.GetUserMetadata().GetSummary(); summary != nil && summary.Size() > config.MaxUserMetadataSummarySize(ns) {
-		return serviceerror.NewInvalidArgumentf(
-			"user_metadata.summary exceeds size limit. Length=%d Limit=%d",
-			summary.Size(),
-			config.MaxUserMetadataSummarySize(ns),
-		)
-	}
-	if details := req.GetUserMetadata().GetDetails(); details != nil && details.Size() > config.MaxUserMetadataDetailsSize(ns) {
-		return serviceerror.NewInvalidArgumentf(
-			"user_metadata.details exceeds size limit. Length=%d Limit=%d",
-			details.Size(),
-			config.MaxUserMetadataDetailsSize(ns),
-		)
-	}
-
-	loweredHeaders, err := ValidateAndLowercaseNexusHeaders(req.GetNexusHeader(), config.DisallowedOperationHeaders(), config.MaxOperationHeaderSize(ns))
-	if err != nil {
-		return serviceerror.NewInvalidArgument(err.Error())
-	}
-	req.NexusHeader = loweredHeaders
-	if err := validateAndNormalizeSearchAttributes(req, saMapperProvider, saValidator); err != nil {
-		// SA validator already returns properly typed gRPC status errors; no need to re-wrap.
+	if err := v.saValidator.Validate(saToValidate, namespaceName); err != nil {
 		return err
 	}
+
+	return v.saValidator.ValidateSize(saToValidate, namespaceName)
+}
+
+// normalizeIDPolicies applies the default ID reuse and conflict policies.
+func (v *validator) normalizeIDPolicies(req *workflowservice.StartNexusOperationExecutionRequest) {
 	if req.GetIdReusePolicy() == enumspb.NEXUS_OPERATION_ID_REUSE_POLICY_UNSPECIFIED {
 		req.IdReusePolicy = enumspb.NEXUS_OPERATION_ID_REUSE_POLICY_ALLOW_DUPLICATE
 	}
 	if req.GetIdConflictPolicy() == enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_UNSPECIFIED {
 		req.IdConflictPolicy = enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_FAIL
 	}
-	return nil
 }
 
-func validateAndNormalizeDeleteRequest(req *workflowservice.DeleteNexusOperationExecutionRequest, config *Config) error {
-	if req.GetOperationId() == "" {
+// normalizeRequestID generates a request ID when the caller didn't provide one, and otherwise
+// validates the one it did.
+func (v *validator) normalizeRequestID(requestID string) (string, error) {
+	if requestID == "" {
+		return uuid.NewString(), nil
+	}
+	return requestID, v.validateIDLength("request_id", requestID)
+}
+
+func (v *validator) validateOperationID(operationID string) error {
+	if operationID == "" {
 		return serviceerror.NewInvalidArgument("operation_id is required")
 	}
-	if len(req.GetOperationId()) > config.MaxIDLengthLimit() {
-		return serviceerror.NewInvalidArgumentf("operation_id exceeds length limit. Length=%d Limit=%d",
-			len(req.GetOperationId()), config.MaxIDLengthLimit())
+	return v.validateIDLength("operation_id", operationID)
+}
+
+// validateRunID checks that the run ID, if set, is a valid UUID.
+func (v *validator) validateRunID(runID string) error {
+	if runID == "" {
+		return nil
 	}
-	if req.GetRunId() != "" {
-		if err := uuid.Validate(req.GetRunId()); err != nil {
-			return serviceerror.NewInvalidArgument("invalid run id: must be a valid UUID")
-		}
+	if err := uuid.Validate(runID); err != nil {
+		return serviceerror.NewInvalidArgument("run_id is not a valid UUID")
 	}
 	return nil
 }
 
-func validateAndNormalizeDescribeRequest(
-	req *workflowservice.DescribeNexusOperationExecutionRequest,
-	namespaceID string,
-	config *Config,
-) error {
-	if req.GetOperationId() == "" {
-		return serviceerror.NewInvalidArgument("operation_id is required")
-	}
-	if len(req.GetOperationId()) > config.MaxIDLengthLimit() {
-		return serviceerror.NewInvalidArgumentf("operation_id exceeds length limit. Length=%d Limit=%d",
-			len(req.GetOperationId()), config.MaxIDLengthLimit())
-	}
-	if len(req.GetLongPollToken()) > 0 && req.GetRunId() == "" {
-		return serviceerror.NewInvalidArgument("run_id is required when long_poll_token is provided")
-	}
-	if req.GetRunId() != "" {
-		if err := uuid.Validate(req.GetRunId()); err != nil {
-			return serviceerror.NewInvalidArgument("run_id is not a valid UUID")
-		}
-	}
-	if len(req.GetLongPollToken()) > 0 {
-		ref, err := chasm.DeserializeComponentRef(req.GetLongPollToken())
-		if err != nil {
-			return serviceerror.NewInvalidArgument("invalid long poll token")
-		}
-		if ref.NamespaceID != namespaceID {
-			return serviceerror.NewInvalidArgument("long poll token does not match execution")
-		}
+// validateIDLength checks the given field against the shared max ID length limit.
+func (v *validator) validateIDLength(field, value string) error {
+	if limit := v.config.MaxIDLengthLimit(); len(value) > limit {
+		return serviceerror.NewInvalidArgumentf("%s exceeds length limit. Length=%d Limit=%d", field, len(value), limit)
 	}
 	return nil
-}
-
-func validateAndNormalizePollRequest(req *workflowservice.PollNexusOperationExecutionRequest, config *Config) error {
-	// Normalize wait stage: UNSPECIFIED defaults to CLOSED.
-	if req.GetWaitStage() == enumspb.NEXUS_OPERATION_WAIT_STAGE_UNSPECIFIED {
-		req.WaitStage = enumspb.NEXUS_OPERATION_WAIT_STAGE_CLOSED
-	} else {
-		switch req.GetWaitStage() {
-		case enumspb.NEXUS_OPERATION_WAIT_STAGE_STARTED,
-			enumspb.NEXUS_OPERATION_WAIT_STAGE_CLOSED:
-		default:
-			return serviceerror.NewInvalidArgumentf("unsupported wait_stage: %s", req.GetWaitStage())
-		}
-	}
-	if req.GetOperationId() == "" {
-		return serviceerror.NewInvalidArgument("operation_id is required")
-	}
-	if len(req.GetOperationId()) > config.MaxIDLengthLimit() {
-		return serviceerror.NewInvalidArgumentf("operation_id exceeds length limit. Length=%d Limit=%d",
-			len(req.GetOperationId()), config.MaxIDLengthLimit())
-	}
-	if runID := req.GetRunId(); runID != "" {
-		if err := uuid.Validate(runID); err != nil {
-			return serviceerror.NewInvalidArgument("run_id is not a valid UUID")
-		}
-	}
-	return nil
-}
-
-func validateAndNormalizeCancelRequest(req *workflowservice.RequestCancelNexusOperationExecutionRequest, config *Config) error {
-	if req.GetRequestId() == "" {
-		req.RequestId = uuid.NewString()
-	} else if len(req.GetRequestId()) > config.MaxIDLengthLimit() {
-		return serviceerror.NewInvalidArgumentf("request_id exceeds length limit. Length=%d Limit=%d",
-			len(req.GetRequestId()), config.MaxIDLengthLimit())
-	}
-	if req.GetOperationId() == "" {
-		return serviceerror.NewInvalidArgument("operation_id is required")
-	}
-	if len(req.GetOperationId()) > config.MaxIDLengthLimit() {
-		return serviceerror.NewInvalidArgumentf("operation_id exceeds length limit. Length=%d Limit=%d",
-			len(req.GetOperationId()), config.MaxIDLengthLimit())
-	}
-	if runID := req.GetRunId(); runID != "" {
-		if err := uuid.Validate(runID); err != nil {
-			return serviceerror.NewInvalidArgument("run_id is not a valid UUID")
-		}
-	}
-	if len(req.GetIdentity()) > config.MaxIDLengthLimit() {
-		return serviceerror.NewInvalidArgumentf("identity exceeds length limit. Length=%d Limit=%d",
-			len(req.GetIdentity()), config.MaxIDLengthLimit())
-	}
-	if len(req.GetReason()) > config.MaxReasonLength(req.GetNamespace()) {
-		return serviceerror.NewInvalidArgumentf("reason exceeds length limit. Length=%d Limit=%d",
-			len(req.GetReason()), config.MaxReasonLength(req.GetNamespace()))
-	}
-
-	return nil
-}
-
-func validateAndNormalizeTerminateRequest(req *workflowservice.TerminateNexusOperationExecutionRequest, config *Config) error {
-	if req.GetRequestId() == "" {
-		req.RequestId = uuid.NewString()
-	} else if len(req.GetRequestId()) > config.MaxIDLengthLimit() {
-		return serviceerror.NewInvalidArgumentf("request_id exceeds length limit. Length=%d Limit=%d",
-			len(req.GetRequestId()), config.MaxIDLengthLimit())
-	}
-	if req.GetOperationId() == "" {
-		return serviceerror.NewInvalidArgument("operation_id is required")
-	}
-	if len(req.GetOperationId()) > config.MaxIDLengthLimit() {
-		return serviceerror.NewInvalidArgumentf("operation_id exceeds length limit. Length=%d Limit=%d",
-			len(req.GetOperationId()), config.MaxIDLengthLimit())
-	}
-	if runID := req.GetRunId(); runID != "" {
-		if err := uuid.Validate(runID); err != nil {
-			return serviceerror.NewInvalidArgument("run_id is not a valid UUID")
-		}
-	}
-	if len(req.GetIdentity()) > config.MaxIDLengthLimit() {
-		return serviceerror.NewInvalidArgumentf("identity exceeds length limit. Length=%d Limit=%d",
-			len(req.GetIdentity()), config.MaxIDLengthLimit())
-	}
-	if len(req.GetReason()) > config.MaxReasonLength(req.GetNamespace()) {
-		return serviceerror.NewInvalidArgumentf("reason exceeds length limit. Length=%d Limit=%d",
-			len(req.GetReason()), config.MaxReasonLength(req.GetNamespace()))
-	}
-
-	return nil
-}
-
-func validateAndNormalizeSearchAttributes(
-	req *workflowservice.StartNexusOperationExecutionRequest,
-	saMapperProvider searchattribute.MapperProvider,
-	saValidator *searchattribute.Validator,
-) error {
-	namespaceName := req.GetNamespace()
-
-	// Unalias search attributes for validation.
-	saToValidate := req.SearchAttributes
-	if saMapperProvider != nil && saToValidate != nil {
-		var err error
-		saToValidate, err = searchattribute.UnaliasFields(saMapperProvider, saToValidate, namespaceName)
-		if err != nil {
-			return err
-		}
-	}
-
-	if err := saValidator.Validate(saToValidate, namespaceName); err != nil {
-		return err
-	}
-
-	return saValidator.ValidateSize(saToValidate, namespaceName)
 }

--- a/chasm/lib/nexusoperation/validator.go
+++ b/chasm/lib/nexusoperation/validator.go
@@ -17,6 +17,8 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
+const errInvalidRunID = "run_id is not a valid UUID"
+
 // cancelOrTerminateRequest is the subset of the cancel and terminate requests that are validated the same way.
 type cancelOrTerminateRequest interface {
 	GetNamespace() string
@@ -333,7 +335,7 @@ func (v *validator) validateRunID(runID string) error {
 		return nil
 	}
 	if err := uuid.Validate(runID); err != nil {
-		return serviceerror.NewInvalidArgument("run_id is not a valid UUID")
+		return serviceerror.NewInvalidArgument(errInvalidRunID)
 	}
 	return nil
 }

--- a/chasm/lib/nexusoperation/validator_test.go
+++ b/chasm/lib/nexusoperation/validator_test.go
@@ -22,8 +22,6 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
-const errInvalidRunID = "run_id is not a valid UUID"
-
 func newTestValidator(config *Config) *validator {
 	return newValidator(config, log.NewNoopLogger(), nil, nil)
 }

--- a/chasm/lib/nexusoperation/validator_test.go
+++ b/chasm/lib/nexusoperation/validator_test.go
@@ -22,6 +22,10 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
+func newTestValidator(config *Config) *validator {
+	return newValidator(config, log.NewNoopLogger(), nil, nil)
+}
+
 func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockVisibilityManager := manager.NewMockVisibilityManager(ctrl)
@@ -342,7 +346,8 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 			if tc.mutate != nil {
 				tc.mutate(req)
 			}
-			err := validateAndNormalizeStartRequest(req, config, log.NewNoopLogger(), nil, saValidator)
+			err := newValidator(config, log.NewNoopLogger(), nil, saValidator).
+				validateAndNormalizeStartRequest(req)
 			if tc.errMsg != "" {
 				var invalidArgErr *serviceerror.InvalidArgument
 				require.ErrorAs(t, err, &invalidArgErr)
@@ -438,7 +443,7 @@ func TestValidateDescribeNexusOperationExecutionRequest(t *testing.T) {
 			if tc.mutate != nil {
 				tc.mutate(validReq)
 			}
-			err := validateAndNormalizeDescribeRequest(validReq, "test-namespace-id", config)
+			err := newTestValidator(config).validateAndNormalizeDescribeRequest(validReq, "test-namespace-id")
 			if tc.errMsg != "" {
 				var invalidArgErr *serviceerror.InvalidArgument
 				require.ErrorAs(t, err, &invalidArgErr)
@@ -525,7 +530,7 @@ func TestValidateRequestCancelNexusOperationExecutionRequest(t *testing.T) {
 			if tc.mutate != nil {
 				tc.mutate(validReq)
 			}
-			err := validateAndNormalizeCancelRequest(validReq, config)
+			err := newTestValidator(config).validateAndNormalizeCancelRequest(validReq)
 			if tc.errMsg != "" {
 				var invalidArgErr *serviceerror.InvalidArgument
 				require.ErrorAs(t, err, &invalidArgErr)
@@ -589,7 +594,7 @@ func TestValidateDeleteNexusOperationExecutionRequest(t *testing.T) {
 			if tc.mutate != nil {
 				tc.mutate(validReq)
 			}
-			err := validateAndNormalizeDeleteRequest(validReq, config)
+			err := newTestValidator(config).validateAndNormalizeDeleteRequest(validReq)
 			if tc.errMsg != "" {
 				var invalidArgErr *serviceerror.InvalidArgument
 				require.ErrorAs(t, err, &invalidArgErr)
@@ -676,7 +681,7 @@ func TestValidateTerminateNexusOperationExecutionRequest(t *testing.T) {
 			if tc.mutate != nil {
 				tc.mutate(validReq)
 			}
-			err := validateAndNormalizeTerminateRequest(validReq, config)
+			err := newTestValidator(config).validateAndNormalizeTerminateRequest(validReq)
 			if tc.errMsg != "" {
 				var invalidArgErr *serviceerror.InvalidArgument
 				require.ErrorAs(t, err, &invalidArgErr)
@@ -769,7 +774,7 @@ func TestValidatePollNexusOperationExecutionRequest(t *testing.T) {
 			if tc.mutate != nil {
 				tc.mutate(validReq)
 			}
-			err := validateAndNormalizePollRequest(validReq, config)
+			err := newTestValidator(config).validateAndNormalizePollRequest(validReq)
 			if tc.errMsg != "" {
 				var invalidArgErr *serviceerror.InvalidArgument
 				require.ErrorAs(t, err, &invalidArgErr)

--- a/chasm/lib/nexusoperation/validator_test.go
+++ b/chasm/lib/nexusoperation/validator_test.go
@@ -22,6 +22,8 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
+const errInvalidRunID = "run_id is not a valid UUID"
+
 func newTestValidator(config *Config) *validator {
 	return newValidator(config, log.NewNoopLogger(), nil, nil)
 }
@@ -409,7 +411,7 @@ func TestValidateDescribeNexusOperationExecutionRequest(t *testing.T) {
 			mutate: func(r *workflowservice.DescribeNexusOperationExecutionRequest) {
 				r.RunId = "not-a-uuid"
 			},
-			errMsg: "run_id is not a valid UUID",
+			errMsg: errInvalidRunID,
 		},
 		{
 			name: "long_poll_token - requires run_id",
@@ -505,7 +507,7 @@ func TestValidateRequestCancelNexusOperationExecutionRequest(t *testing.T) {
 			mutate: func(r *workflowservice.RequestCancelNexusOperationExecutionRequest) {
 				r.RunId = "not-a-uuid"
 			},
-			errMsg: "run_id is not a valid UUID",
+			errMsg: errInvalidRunID,
 		},
 		{
 			name: "identity - exceeds length limit",
@@ -583,7 +585,7 @@ func TestValidateDeleteNexusOperationExecutionRequest(t *testing.T) {
 			mutate: func(r *workflowservice.DeleteNexusOperationExecutionRequest) {
 				r.RunId = "not-a-valid-uuid"
 			},
-			errMsg: "invalid run id: must be a valid UUID",
+			errMsg: errInvalidRunID,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -656,7 +658,7 @@ func TestValidateTerminateNexusOperationExecutionRequest(t *testing.T) {
 			mutate: func(r *workflowservice.TerminateNexusOperationExecutionRequest) {
 				r.RunId = "not-a-uuid"
 			},
-			errMsg: "run_id is not a valid UUID",
+			errMsg: errInvalidRunID,
 		},
 		{
 			name: "identity - exceeds length limit",
@@ -729,7 +731,7 @@ func TestValidatePollNexusOperationExecutionRequest(t *testing.T) {
 			mutate: func(r *workflowservice.PollNexusOperationExecutionRequest) {
 				r.RunId = "not-a-uuid"
 			},
-			errMsg: "run_id is not a valid UUID",
+			errMsg: errInvalidRunID,
 		},
 		{
 			name: "wait_stage - normalizes UNSPECIFIED to CLOSED",


### PR DESCRIPTION
## What changed?

This PR refactors the validation logic used for SANO from a collection of loose functions, into methods on an unexported `validator` type. (Similar to how `chasm/lib/callback/validator.go` is structured.)

The same checks have all been preserved, although I did fix up one error message string to be consistent with others.

## Why?

The motivation for this refactoring is to make it easier to land the "worker callbacks" feature. That will require expanding the validation checks, and bundling all the dependent parameters on the `type validator struct` is cleaner than needing to wire through a new parameter at every callsite.


## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

I am relying on GenAI in its assertion that the existing validation checks are essentially identical with these changes. Worst case scenario, this alerts which types of SANO requests are accepted or rejected.
