### PR TITLE
test(mixedbrain): fix nexus-enabled/nexus-endpoint mismatch breaking mixed brain test

### DIFF
--- a/tests/mixedbrain/mixed_brain_test.go
+++ b/tests/mixedbrain/mixed_brain_test.go
@@ -67,6 +67,7 @@ var scenarios = []omesScenario{
 		namespace: "throughput-stress",
 		options: []string{
 			"internal-iterations=10",
+			"nexus-enabled=true",
 			"nexus-endpoint=" + nexusEndpoint,
 		},
 	},


### PR DESCRIPTION
## Summary
- The `Mixed brain test` job has been consistently failing on `main` (and on unrelated PRs, e.g. #11276) with:
  ```
  scenario failed: failed to parse scenario configuration: nexus-endpoint was set but nexus-enabled is false
  ```
- `tests/mixedbrain` builds Omes fresh from `omes@main` on every run (see `downloadAndBuildOmes`), so it's exposed to upstream changes. Omes's `throughput_stress` scenario now validates that `nexus-endpoint` can't be set unless `nexus-enabled=true` is also set (see `scenarios/throughput_stress.go`), but our `throughput_stress` scenario options in `mixed_brain_test.go` only set `nexus-endpoint` without `nexus-enabled=true`.
- This fixes it by explicitly passing `nexus-enabled=true` alongside `nexus-endpoint`.

## Test plan
- [x] `go build ./...` and `go vet ./...` in `tests/mixedbrain` pass
- [ ] CI `Mixed brain test` job passes on this PR