### PR TITLE
SAA: persist heartbeat checkpoint data on failure

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -601,7 +601,15 @@ func (a *Activity) HandleFailed(
 	if err != nil {
 		return nil, err
 	}
-	failure := event.Request.GetFailedRequest().GetFailure()
+	failedRequest := event.Request.GetFailedRequest()
+	failure := failedRequest.GetFailure()
+
+	if details := failedRequest.GetLastHeartbeatDetails(); details != nil {
+		heartbeat := a.getOrCreateLastHeartbeat(ctx)
+		heartbeat.Details = details
+		heartbeat.RecordedTime = timestamppb.New(ctx.Now(a))
+		a.emitHeartbeatMetrics(ctx, details)
+	}
 
 	appFailure := failure.GetApplicationFailureInfo()
 	isRetryable := appFailure != nil &&
@@ -1662,13 +1670,7 @@ func (a *Activity) RecordHeartbeat(
 			},
 		)
 	}
-	detailsSize := details.Size()
-	metricsHandler := a.baseMetricsHandler(ctx, metrics.HistoryRecordActivityTaskHeartbeatScope)
-	emitPayloadSizeMetric(metricsHandler, detailsSize)
-	metrics.ActivityHeartbeatCount.With(metricsHandler).Record(
-		1,
-		metrics.StringTag("has_details", strconv.FormatBool(detailsSize > 0)),
-	)
+	a.emitHeartbeatMetrics(ctx, details)
 
 	response := &historyservice.RecordActivityTaskHeartbeatResponse{}
 	switch a.Status {
@@ -2057,6 +2059,17 @@ func emitPayloadSizeMetric(metricsHandler metrics.Handler, size int) {
 	if size > 0 {
 		metrics.ActivityPayloadSize.With(metricsHandler).Record(int64(size))
 	}
+}
+
+// emitHeartbeatMetrics records the heartbeat count and payload size for heartbeat details.
+func (a *Activity) emitHeartbeatMetrics(ctx chasm.Context, details *commonpb.Payloads) {
+	metricsHandler := a.baseMetricsHandler(ctx, metrics.HistoryRecordActivityTaskHeartbeatScope)
+	detailsSize := details.Size()
+	emitPayloadSizeMetric(metricsHandler, detailsSize)
+	metrics.ActivityHeartbeatCount.With(metricsHandler).Record(
+		1,
+		metrics.StringTag("has_details", strconv.FormatBool(detailsSize > 0)),
+	)
 }
 
 func (a *Activity) emitOnCompletedMetrics(

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -608,6 +608,7 @@ func (a *Activity) HandleFailed(
 		heartbeat := a.getOrCreateLastHeartbeat(ctx)
 		heartbeat.Details = details
 		heartbeat.RecordedTime = timestamppb.New(ctx.Now(a))
+		heartbeat.TotalHeartbeatCount++
 		a.emitHeartbeatMetrics(ctx, details)
 	}
 

--- a/chasm/lib/activity/model/vocabulary.go
+++ b/chasm/lib/activity/model/vocabulary.go
@@ -40,8 +40,9 @@ const (
 type Event struct {
 	Type EventType
 
-	Retryable  bool // RespondFailed: the failure is retryable. Whether it actually retries also depends on the retry policy.
-	KeepPaused bool // Reset: a paused activity stays paused across the reset.
+	Retryable           bool // RespondFailed: the failure is retryable. Whether it actually retries also depends on the retry policy.
+	KeepPaused          bool // Reset: a paused activity stays paused across the reset.
+	HasHeartbeatDetails bool // RespondFailed: attach last_heartbeat_details, to be stored as the activity's heartbeat progress.
 }
 
 // Canonical Event values for the variants frequently used in traces
@@ -116,7 +117,7 @@ func (t EventType) String() string {
 func (e Event) String() string {
 	switch e.Type {
 	case RespondFailedType:
-		return fmt.Sprintf("%s[retryable=%v]", e.Type.String(), e.Retryable)
+		return fmt.Sprintf("%s[retryable=%v,heartbeatDetails=%v]", e.Type.String(), e.Retryable, e.HasHeartbeatDetails)
 	case ResetType:
 		return fmt.Sprintf("%s[keepPaused=%v]", e.Type.String(), e.KeepPaused)
 	default:

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -248,11 +248,6 @@ var TransitionFailed = chasm.NewTransition(
 		return a.StoreOrSelf(ctx).RecordCompleted(ctx, func(ctx chasm.MutableContext) error {
 			req := event.req.GetFailedRequest()
 
-			if details := req.GetLastHeartbeatDetails(); details != nil {
-				heartbeat := a.getOrCreateLastHeartbeat(ctx)
-				heartbeat.Details = details
-				heartbeat.RecordedTime = timestamppb.New(ctx.Now(a))
-			}
 			attempt := a.LastAttempt.Get(ctx)
 			attempt.LastWorkerIdentity = req.GetIdentity()
 

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -726,7 +726,6 @@ func TestTransitionFailed(t *testing.T) {
 	ctx := &chasm.MockMutableContext{}
 	ctx.HandleNow = func(chasm.Component) time.Time { return defaultTime }
 	attemptState := &activitypb.ActivityAttemptState{Count: 1}
-	heartbeatState := &activitypb.ActivityHeartbeatState{}
 	outcome := &activitypb.ActivityOutcome{}
 
 	activity := &Activity{
@@ -739,9 +738,8 @@ func TestTransitionFailed(t *testing.T) {
 			Status:                 activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
 			TaskQueue:              &taskqueuepb.TaskQueue{Name: "test-task-queue"},
 		},
-		LastAttempt:   chasm.NewDataField(ctx, attemptState),
-		LastHeartbeat: chasm.NewDataField(ctx, heartbeatState),
-		Outcome:       chasm.NewDataField(ctx, outcome),
+		LastAttempt: chasm.NewDataField(ctx, attemptState),
+		Outcome:     chasm.NewDataField(ctx, outcome),
 	}
 
 	failure := &failurepb.Failure{

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -744,7 +744,6 @@ func TestTransitionFailed(t *testing.T) {
 		Outcome:       chasm.NewDataField(ctx, outcome),
 	}
 
-	heartbeatDetails := payloads.EncodeString("Heartbeat")
 	failure := &failurepb.Failure{
 		Message: "Failed Activity",
 		FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
@@ -779,9 +778,8 @@ func TestTransitionFailed(t *testing.T) {
 
 	req := &historyservice.RespondActivityTaskFailedRequest{
 		FailedRequest: &workflowservice.RespondActivityTaskFailedRequest{
-			Failure:              failure,
-			LastHeartbeatDetails: heartbeatDetails,
-			Identity:             "worker",
+			Failure:  failure,
+			Identity: "worker",
 		},
 	}
 
@@ -796,8 +794,6 @@ func TestTransitionFailed(t *testing.T) {
 	require.EqualValues(t, 1, attemptState.Count)
 	require.Equal(t, "worker", attemptState.GetLastWorkerIdentity())
 	require.NotNil(t, attemptState.GetCompleteTime())
-	protorequire.ProtoEqual(t, heartbeatDetails, heartbeatState.GetDetails())
-	require.NotNil(t, heartbeatState.GetRecordedTime())
 	protorequire.ProtoEqual(t, failure, attemptState.GetLastFailureDetails().GetFailure())
 	require.NotNil(t, attemptState.GetLastFailureDetails().GetTime())
 	require.Nil(t, outcome.GetFailed())

--- a/tests/activity_driver.go
+++ b/tests/activity_driver.go
@@ -9,12 +9,14 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/chasm/lib/activity/model"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/testing/await"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -49,6 +51,10 @@ type activityConfig struct {
 
 // activityInput is what both SAA and WFA send, so a worker sees the same input either way.
 const activityInput = "Input"
+
+// activityHeartbeatDetails is the checkpoint payload a driver attaches to RespondActivityTaskFailed when
+// the event sets HasHeartbeatDetails; the server stores it as the activity's last heartbeat progress.
+var activityHeartbeatDetails = payloads.EncodeString("heartbeat details")
 
 // timerProcessorMaxShift is the floor the timer queue puts on a task's fire time: it will not fire one
 // earlier than now + this.
@@ -127,6 +133,7 @@ type activityInfo struct {
 	Attempt                    int32
 	CurrentRetryInterval       time.Duration
 	NextAttemptScheduleTimeSet bool
+	LastHeartbeatDetails       []byte
 }
 
 // activityDriverTimeout bounds a wait for something the server should do promptly: dispatch a task to
@@ -320,4 +327,15 @@ func awaitActivityDispatchDelay(
 		t.Errorf("%s: the activity stopped being in progress before the driver observed its delayed dispatch becoming due; last observed: %+v",
 			e, details)
 	}
+}
+
+func activityMarshalPayloads(p *commonpb.Payloads) []byte {
+	if p == nil {
+		return nil
+	}
+	b, err := p.Marshal()
+	if err != nil {
+		panic("marshaling payloads failed: " + err.Error())
+	}
+	return b
 }

--- a/tests/activity_driver.go
+++ b/tests/activity_driver.go
@@ -53,8 +53,9 @@ type activityConfig struct {
 const activityInput = "Input"
 
 // activityHeartbeatDetails is the checkpoint payload a driver attaches to RespondActivityTaskFailed when
-// the event sets HasHeartbeatDetails; the server stores it as the activity's last heartbeat progress.
-var activityHeartbeatDetails = payloads.EncodeString("heartbeat details")
+// the event sets HasHeartbeatDetails; the server stores it as the activity's last heartbeat progress. It
+// differs from the model.Heartbeat payload so assertions can tell which source was persisted.
+var activityHeartbeatDetails = payloads.EncodeString("failure checkpoint details")
 
 // timerProcessorMaxShift is the floor the timer queue puts on a task's fire time: it will not fire one
 // earlier than now + this.

--- a/tests/activity_metrics_parity_test.go
+++ b/tests/activity_metrics_parity_test.go
@@ -72,6 +72,7 @@ func (s *activityParityTestSuite) TestWFASAAMetricsParity() {
 		{name: "TerminalTimeout", trace: []model.Event{model.Poll, model.StartToCloseElapses}, cfg: activityConfig{MaxAttempts: 1, StartToClose: activityShortTimeout}, anchor: metrics.ActivityTimeout.Name()},
 		{name: "RetryableTimeout", trace: []model.Event{model.Poll, model.StartToCloseElapses}, cfg: activityConfig{MaxAttempts: 2, StartToClose: activityShortTimeout}, anchor: metrics.ActivityTaskTimeout.Name()},
 		{name: "RetryableTaskFailure", trace: []model.Event{model.Poll, model.FailRetryably}, cfg: activityConfig{MaxAttempts: 2}},
+		{name: "RetryableTaskFailureWithHeartbeatDetails", trace: []model.Event{model.Poll, {Type: model.RespondFailedType, Retryable: true, HasHeartbeatDetails: true}}, cfg: activityConfig{MaxAttempts: 2}},
 		{name: "Heartbeat", trace: []model.Event{model.Poll, model.Heartbeat}, cfg: activityConfig{MaxAttempts: 1}},
 		{name: "Pause", trace: []model.Event{model.Poll, model.Pause}, cfg: activityConfig{MaxAttempts: 1}},
 		{name: "Unpause", trace: []model.Event{model.Poll, model.Pause, model.Unpause}, cfg: activityConfig{MaxAttempts: 1}},

--- a/tests/activity_metrics_parity_test.go
+++ b/tests/activity_metrics_parity_test.go
@@ -16,7 +16,7 @@ import (
 	"go.temporal.io/server/common/testing/await"
 )
 
-func (s *activityParityTestSuite) TestWFASAAMetricsParity() {
+func (s *activityParityTestSuite) TestMetrics() {
 	type activityMetric struct {
 		name             string
 		compared         bool

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -379,21 +379,22 @@ func (s *activityParityTestSuite) TestLastHeartbeatDetailsPersistedOnAttemptFail
 	cfg := activityConfig{MaxAttempts: 2}
 
 	trace := []model.Event{model.Poll, {Type: model.RespondFailedType, Retryable: true, HasHeartbeatDetails: true}}
+	expected := activityMarshalPayloads(activityHeartbeatDetails)
 	s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
 		t := s.T()
-		require.NotEmpty(t,
+		require.Equal(t, expected,
 			newWFADriver(t, env, cfg).driveTrace(t, trace).activityInfo(t).LastHeartbeatDetails)
 	})
 	s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
 		t := s.T()
 		d := newSAADriver(t, env, cfg)
-		require.NotEmpty(t,
+		require.Equal(t, expected,
 			d.driveTrace(t, trace).activityInfo(t).LastHeartbeatDetails)
 
 		// For SAA we additionally confirm that it's persisted even if the failure is terminal. WFA
 		// drops the pending activity from MS at this point.
 		terminal := []model.Event{model.Poll, {Type: model.RespondFailedType, Retryable: false, HasHeartbeatDetails: true}}
-		require.NotEmpty(t,
+		require.Equal(t, expected,
 			d.driveTrace(t, terminal).activityInfo(t).LastHeartbeatDetails)
 	})
 }

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -371,3 +371,29 @@ func (s *activityParityTestSuite) TestCompleteByID() {
 		})
 	}
 }
+
+// When a worker fails an attempt it can send a final checkpoint payload to be stored as the last
+// heartbeat details. This must be persisted for a retryable failure.
+func (s *activityParityTestSuite) TestLastHeartbeatDetailsPersistedOnAttemptFailure() {
+	env := newActivityParityEnv(s.T())
+	cfg := activityConfig{MaxAttempts: 2}
+
+	trace := []model.Event{model.Poll, {Type: model.RespondFailedType, Retryable: true, HasHeartbeatDetails: true}}
+	s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
+		t := s.T()
+		require.NotEmpty(t,
+			newWFADriver(t, env, cfg).driveTrace(t, trace).activityInfo(t).LastHeartbeatDetails)
+	})
+	s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
+		t := s.T()
+		d := newSAADriver(t, env, cfg)
+		require.NotEmpty(t,
+			d.driveTrace(t, trace).activityInfo(t).LastHeartbeatDetails)
+
+		// For SAA we additionally confirm that it's persisted even if the failure is terminal. WFA
+		// drops the pending activity from MS at this point.
+		terminal := []model.Event{model.Poll, {Type: model.RespondFailedType, Retryable: false, HasHeartbeatDetails: true}}
+		require.NotEmpty(t,
+			d.driveTrace(t, terminal).activityInfo(t).LastHeartbeatDetails)
+	})
+}

--- a/tests/activity_standalone_driver.go
+++ b/tests/activity_standalone_driver.go
@@ -202,6 +202,7 @@ func saaActivityInfo(i *activitypb.ActivityExecutionInfo) activityInfo {
 		Attempt:                    i.GetAttempt(),
 		CurrentRetryInterval:       i.GetCurrentRetryInterval().AsDuration().Round(time.Second),
 		NextAttemptScheduleTimeSet: i.GetNextAttemptScheduleTime() != nil,
+		LastHeartbeatDetails:       activityMarshalPayloads(i.GetHeartbeatDetails()),
 	}
 }
 
@@ -228,9 +229,13 @@ func (a *saaHandle) rpc(_ testing.TB, e model.Event) error {
 		})
 		return err
 	case model.RespondFailedType:
-		_, err := fc.RespondActivityTaskFailed(a.d.ctx, &workflowservice.RespondActivityTaskFailedRequest{
+		req := &workflowservice.RespondActivityTaskFailedRequest{
 			Namespace: ns, TaskToken: a.token, Identity: a.d.env.Tv().WorkerIdentity(), Failure: activityFailure(e.Retryable, a.cfg.NextRetryDelay),
-		})
+		}
+		if e.HasHeartbeatDetails {
+			req.LastHeartbeatDetails = activityHeartbeatDetails
+		}
+		_, err := fc.RespondActivityTaskFailed(a.d.ctx, req)
 		return err
 	case model.RespondCanceledType:
 		_, err := fc.RespondActivityTaskCanceled(a.d.ctx, &workflowservice.RespondActivityTaskCanceledRequest{

--- a/tests/activity_workflow_driver.go
+++ b/tests/activity_workflow_driver.go
@@ -242,6 +242,7 @@ func wfaActivityInfo(p *workflowpb.PendingActivityInfo) activityInfo {
 		Attempt:                    p.GetAttempt(),
 		CurrentRetryInterval:       p.GetCurrentRetryInterval().AsDuration().Round(time.Second),
 		NextAttemptScheduleTimeSet: p.GetNextAttemptScheduleTime() != nil,
+		LastHeartbeatDetails:       activityMarshalPayloads(p.GetHeartbeatDetails()),
 	}
 }
 
@@ -277,9 +278,13 @@ func (a *wfaHandle) rpc(t testing.TB, e model.Event) error {
 		})
 		return err
 	case model.RespondFailedType:
-		_, err := fc.RespondActivityTaskFailed(a.d.ctx, &workflowservice.RespondActivityTaskFailedRequest{
+		req := &workflowservice.RespondActivityTaskFailedRequest{
 			Namespace: ns, TaskToken: a.token, Identity: a.d.env.Tv().WorkerIdentity(), Failure: activityFailure(e.Retryable, a.cfg.NextRetryDelay),
-		})
+		}
+		if e.HasHeartbeatDetails {
+			req.LastHeartbeatDetails = activityHeartbeatDetails
+		}
+		_, err := fc.RespondActivityTaskFailed(a.d.ctx, req)
 		return err
 	case model.RespondCanceledType:
 		_, err := fc.RespondActivityTaskCanceled(a.d.ctx, &workflowservice.RespondActivityTaskCanceledRequest{


### PR DESCRIPTION
## What changed?
- Persist payload sent with attempt failure as last heartbeat details
- Emit metrics associated with that codepath for WFA parity

## Why?
- The first is a relatively bad bug: an activity attempt should be able to have the latest checkpoint data sent in and persisted with a retryable failure, but SAA was not persisting it
- SAA vs WFA metrics parity

## How did you test it?
- [x] added new functional test(s)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes activity failure and retry persistence where workers rely on checkpoint data; scope is narrow with new SAA/WFA parity tests, but incorrect handling could affect retries or observability.
> 
> **Overview**
> Standalone activities (SAA) now **persist `LastHeartbeatDetails` from `RespondActivityTaskFailed`** before deciding whether to retry or fail terminally. Previously that checkpoint lived only on the terminal `TransitionFailed` path, so **retryable failures dropped the worker’s final progress payload**.
> 
> Heartbeat handling on failure now mirrors a normal heartbeat: update last-heartbeat state (details, recorded time, count) and record metrics via a shared **`emitHeartbeatMetrics`** helper used by **`RecordHeartbeat`** as well.
> 
> Trace drivers and parity tests gain **`HasHeartbeatDetails`** on failed-respond events, plus coverage that WFA and SAA expose the same stored heartbeat details (including terminal SAA failures).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a013d1627fe66a4a0cae371df752410fd4358413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->