### PR TITLE
Move worker APIs from visibility to api rate limiter

### DIFF
--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -170,6 +170,9 @@ var (
 		"/temporal.api.workflowservice.v1.WorkflowService/DescribeWorkerDeployment":                     3,
 		"/temporal.api.workflowservice.v1.WorkflowService/DescribeNexusOperationExecution":              3,
 		"/temporal.api.workflowservice.v1.WorkflowService/ValidateWorkerDeploymentVersionComputeConfig": 3,
+		"/temporal.api.workflowservice.v1.WorkflowService/ListWorkers":                                 3,
+		"/temporal.api.workflowservice.v1.WorkflowService/DescribeWorker":                               3,
+		"/temporal.api.workflowservice.v1.WorkflowService/CountWorkers":                                 3,
 
 		// P3: Progress APIs for reporting cancellations and failures.
 		// They are relatively low priority as the tasks need to be retried anyway.
@@ -216,9 +219,6 @@ var (
 		"/temporal.api.workflowservice.v1.WorkflowService/ListClosedWorkflowExecutions":   1,
 		"/temporal.api.workflowservice.v1.WorkflowService/ListWorkflowExecutions":         1,
 		"/temporal.api.workflowservice.v1.WorkflowService/ListArchivedWorkflowExecutions": 1,
-		"/temporal.api.workflowservice.v1.WorkflowService/ListWorkers":                    1,
-		"/temporal.api.workflowservice.v1.WorkflowService/CountWorkers":                   1,
-		"/temporal.api.workflowservice.v1.WorkflowService/DescribeWorker":                 1,
 		"/temporal.api.workflowservice.v1.WorkflowService/CountActivityExecutions":        1,
 		"/temporal.api.workflowservice.v1.WorkflowService/ListActivityExecutions":         1,
 		"/temporal.api.workflowservice.v1.WorkflowService/CountNexusOperationExecutions":  1,

--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -170,7 +170,7 @@ var (
 		"/temporal.api.workflowservice.v1.WorkflowService/DescribeWorkerDeployment":                     3,
 		"/temporal.api.workflowservice.v1.WorkflowService/DescribeNexusOperationExecution":              3,
 		"/temporal.api.workflowservice.v1.WorkflowService/ValidateWorkerDeploymentVersionComputeConfig": 3,
-		"/temporal.api.workflowservice.v1.WorkflowService/ListWorkers":                                 3,
+		"/temporal.api.workflowservice.v1.WorkflowService/ListWorkers":                                  3,
 		"/temporal.api.workflowservice.v1.WorkflowService/DescribeWorker":                               3,
 		"/temporal.api.workflowservice.v1.WorkflowService/CountWorkers":                                 3,
 

--- a/service/frontend/configs/quotas_test.go
+++ b/service/frontend/configs/quotas_test.go
@@ -94,9 +94,6 @@ func (s *quotasSuite) TestVisibilityAPIs() {
 		"/temporal.api.workflowservice.v1.WorkflowService/ListClosedWorkflowExecutions":   {},
 		"/temporal.api.workflowservice.v1.WorkflowService/ListWorkflowExecutions":         {},
 		"/temporal.api.workflowservice.v1.WorkflowService/ListArchivedWorkflowExecutions": {},
-		"/temporal.api.workflowservice.v1.WorkflowService/ListWorkers":                    {},
-		"/temporal.api.workflowservice.v1.WorkflowService/CountWorkers":                   {},
-		"/temporal.api.workflowservice.v1.WorkflowService/DescribeWorker":                 {},
 
 		"/temporal.api.workflowservice.v1.WorkflowService/GetWorkerTaskReachability":         {},
 		"/temporal.api.workflowservice.v1.WorkflowService/ListSchedules":                     {},


### PR DESCRIPTION
## What
Move ListWorkers, DescribeWorker, and CountWorkers from `VisibilityAPIToPriority` to `APIToPriority`.
Changed priority to  P3 to be aligned with other status Querying APIs.

## Why
Today, these APIs are served by matching and not visibility.

## How did you test it?
Updated unit tests