### PR TITLE
Fix CHASM initial schedule pause state

### DIFF
--- a/chasm/chasmtest/test_engine.go
+++ b/chasm/chasmtest/test_engine.go
@@ -15,9 +15,11 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/service/history/tasks"
 )
@@ -537,6 +539,13 @@ func (e *Engine) newExecution(key chasm.ExecutionKey) *execution {
 			return definition.NewWorkflowKey(key.NamespaceID, key.BusinessID, key.RunID)
 		},
 		HandleIsWorkflow: func() bool { return false },
+		HandleGetNamespaceEntry: func() *namespace.Namespace {
+			return namespace.NewLocalNamespaceForTest(
+				&persistencespb.NamespaceInfo{Id: key.NamespaceID, Name: key.NamespaceID},
+				&persistencespb.NamespaceConfig{},
+				cluster.TestCurrentClusterName,
+			)
+		},
 		// GetExecutionState returns the current lifecycle state, which CloseTransaction
 		// uses to decide whether to call UpdateWorkflowStateStatus on the backend.
 		HandleGetExecutionState: func() *persistencespb.WorkflowExecutionState {

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -147,9 +147,7 @@ func NewScheduler(
 	}
 	sched.setNullableFields()
 	sched.Info.CreateTime = timestamppb.New(ctx.Now(sched))
-	for range sched.applyPausePatch(ctx, patch) {
-		sched.updateConflictToken()
-	}
+	sched.applyPausePatch(ctx, patch)
 
 	invoker := NewInvoker(ctx)
 	sched.Invoker = chasm.NewComponentField(ctx, invoker)
@@ -223,26 +221,20 @@ func (s *Scheduler) setNullableFields() {
 	}
 }
 
-// applyPausePatch applies the pause-related fields from a patch and returns
-// the number of state transitions applied.
-func (s *Scheduler) applyPausePatch(ctx chasm.MutableContext, patch *schedulepb.SchedulePatch) int {
+func (s *Scheduler) applyPausePatch(ctx chasm.MutableContext, patch *schedulepb.SchedulePatch) {
 	if patch == nil {
-		return 0
+		return
 	}
-	transitions := 0
 	if patch.Pause != "" {
 		s.Schedule.State.Paused = true
 		s.Schedule.State.Notes = patch.Pause
 		s.getOrCreateEventLog(ctx).LogEvent(ctx, fmt.Sprintf("paused via API: %s", patch.Pause))
-		transitions++
 	}
 	if patch.Unpause != "" {
 		s.Schedule.State.Paused = false
 		s.Schedule.State.Notes = patch.Unpause
 		s.getOrCreateEventLog(ctx).LogEvent(ctx, fmt.Sprintf("unpaused via API: %s", patch.Unpause))
-		transitions++
 	}
-	return transitions
 }
 
 // handlePatch creates backfillers to fulfill the given patch request.

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -147,6 +147,9 @@ func NewScheduler(
 	}
 	sched.setNullableFields()
 	sched.Info.CreateTime = timestamppb.New(ctx.Now(sched))
+	for range sched.applyPausePatch(ctx, patch) {
+		sched.updateConflictToken()
+	}
 
 	invoker := NewInvoker(ctx)
 	sched.Invoker = chasm.NewComponentField(ctx, invoker)
@@ -218,6 +221,28 @@ func (s *Scheduler) setNullableFields() {
 	if s.Schedule.State == nil {
 		s.Schedule.State = &schedulepb.ScheduleState{}
 	}
+}
+
+// applyPausePatch applies the pause-related fields from a patch and returns
+// the number of state transitions applied.
+func (s *Scheduler) applyPausePatch(ctx chasm.MutableContext, patch *schedulepb.SchedulePatch) int {
+	if patch == nil {
+		return 0
+	}
+	transitions := 0
+	if patch.Pause != "" {
+		s.Schedule.State.Paused = true
+		s.Schedule.State.Notes = patch.Pause
+		s.getOrCreateEventLog(ctx).LogEvent(ctx, fmt.Sprintf("paused via API: %s", patch.Pause))
+		transitions++
+	}
+	if patch.Unpause != "" {
+		s.Schedule.State.Paused = false
+		s.Schedule.State.Notes = patch.Unpause
+		s.getOrCreateEventLog(ctx).LogEvent(ctx, fmt.Sprintf("unpaused via API: %s", patch.Unpause))
+		transitions++
+	}
+	return transitions
 }
 
 // handlePatch creates backfillers to fulfill the given patch request.
@@ -941,17 +966,7 @@ func (s *Scheduler) Patch(
 	if s.WorkflowMigration != nil {
 		return nil, ErrMigrationPending
 	}
-	// Handle paused status.
-	if req.FrontendRequest.Patch.Pause != "" {
-		s.Schedule.State.Paused = true
-		s.Schedule.State.Notes = req.FrontendRequest.Patch.Pause
-		s.getOrCreateEventLog(ctx).LogEvent(ctx, fmt.Sprintf("paused via API: %s", req.FrontendRequest.Patch.Pause))
-	}
-	if req.FrontendRequest.Patch.Unpause != "" {
-		s.Schedule.State.Paused = false
-		s.Schedule.State.Notes = req.FrontendRequest.Patch.Unpause
-		s.getOrCreateEventLog(ctx).LogEvent(ctx, fmt.Sprintf("unpaused via API: %s", req.FrontendRequest.Patch.Unpause))
-	}
+	s.applyPausePatch(ctx, req.FrontendRequest.Patch)
 
 	if err := s.handlePatch(ctx, req.FrontendRequest.Patch); err != nil {
 		return nil, err

--- a/chasm/lib/scheduler/scheduler_test.go
+++ b/chasm/lib/scheduler/scheduler_test.go
@@ -15,6 +15,7 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	schedulespb "go.temporal.io/server/api/schedule/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/chasmtest"
 	"go.temporal.io/server/chasm/lib/scheduler"
 	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common/payload"
@@ -22,6 +23,7 @@ import (
 	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/service/history/tasks"
+	legacyscheduler "go.temporal.io/server/service/worker/scheduler"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -44,6 +46,76 @@ func TestListInfo(t *testing.T) {
 	require.NotNil(t, listInfo.WorkflowType)
 	require.NotEmpty(t, listInfo.FutureActionTimes)
 	require.Equal(t, expectedFutureTimes, listInfo.FutureActionTimes)
+}
+
+func TestCreateScheduler_InitialPauseState(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialPaused bool
+		patch         *schedulepb.SchedulePatch
+		wantPaused    bool
+		wantNotes     string
+		wantToken     int64
+	}{
+		{
+			name:       "pause",
+			patch:      &schedulepb.SchedulePatch{Pause: "maintenance"},
+			wantPaused: true,
+			wantNotes:  "maintenance",
+			wantToken:  legacyscheduler.InitialConflictToken + 1,
+		},
+		{
+			name:          "unpause",
+			initialPaused: true,
+			patch:         &schedulepb.SchedulePatch{Unpause: "resume"},
+			wantPaused:    false,
+			wantNotes:     "resume",
+			wantToken:     legacyscheduler.InitialConflictToken + 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			logger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)
+			registry := chasm.NewRegistry(logger)
+			require.NoError(t, registry.Register(&chasm.CoreLibrary{}))
+			require.NoError(t, registry.Register(newTestLibrary(logger, newRealSpecProcessor(ctrl, logger))))
+			testEngine := chasmtest.NewEngine(t, registry)
+			engineCtx := chasm.NewEngineContext(context.Background(), testEngine)
+			input := defaultSchedule()
+			input.State.Paused = tc.initialPaused
+
+			result, err := chasm.StartExecution(
+				engineCtx,
+				chasm.ExecutionKey{NamespaceID: namespaceID, BusinessID: scheduleID},
+				scheduler.CreateScheduler,
+				&schedulerpb.CreateScheduleRequest{
+					NamespaceId: namespaceID,
+					FrontendRequest: &workflowservice.CreateScheduleRequest{
+						Namespace:    namespace,
+						ScheduleId:   scheduleID,
+						Schedule:     input,
+						InitialPatch: tc.patch,
+					},
+				},
+			)
+			require.NoError(t, err)
+
+			_, err = chasm.ReadComponent(
+				engineCtx,
+				chasm.NewComponentRef[*scheduler.Scheduler](result.ExecutionKey),
+				func(sched *scheduler.Scheduler, _ chasm.Context, _ struct{}) (struct{}, error) {
+					require.Equal(t, tc.wantPaused, sched.Schedule.State.Paused)
+					require.Equal(t, tc.wantNotes, sched.Schedule.State.Notes)
+					require.Equal(t, tc.wantToken, sched.ConflictToken)
+					return struct{}{}, nil
+				},
+				struct{}{},
+			)
+			require.NoError(t, err)
+		})
+	}
 }
 
 // TestListInfo_RecentActionsCapped verifies that the ScheduleListInfo memo

--- a/chasm/lib/scheduler/scheduler_test.go
+++ b/chasm/lib/scheduler/scheduler_test.go
@@ -62,7 +62,7 @@ func TestCreateScheduler_InitialPauseState(t *testing.T) {
 			patch:      &schedulepb.SchedulePatch{Pause: "maintenance"},
 			wantPaused: true,
 			wantNotes:  "maintenance",
-			wantToken:  legacyscheduler.InitialConflictToken + 1,
+			wantToken:  legacyscheduler.InitialConflictToken,
 		},
 		{
 			name:          "unpause",
@@ -70,7 +70,7 @@ func TestCreateScheduler_InitialPauseState(t *testing.T) {
 			patch:         &schedulepb.SchedulePatch{Unpause: "resume"},
 			wantPaused:    false,
 			wantNotes:     "resume",
-			wantToken:     legacyscheduler.InitialConflictToken + 1,
+			wantToken:     legacyscheduler.InitialConflictToken,
 		},
 	}
 


### PR DESCRIPTION
## What changed?
- Apply InitialPatch pause and unpause state before generator and backfiller work is armed.
- Add CHASM test-engine coverage for initial pause and unpause creation.
- Give the CHASM test engine a default local namespace entry.

## Why?
CHASM-backed schedules previously ignored InitialPatch.Pause and InitialPatch.Unpause, unlike workflow-backed schedules.