### PR TITLE
docs(archival): document s3store endpoint options

### DIFF
--- a/common/archiver/s3store/README.md
+++ b/common/archiver/s3store/README.md
@@ -30,6 +30,19 @@ namespaceDefaults:
       URI: "s3://<bucket-name>"
 ```
 
+### S3-compatible endpoints
+
+The archiver uses the AWS SDK, so it also works against any S3-compatible object store. Amazon S3 needs no extra settings. For other stores (Backblaze B2, Cloudflare R2, MinIO) set `endpoint` to the store's S3 API endpoint, and set `s3ForcePathStyle` to `true` if the store does not support virtual-hosted-style bucket addressing.
+```
+      s3store:
+        region: "us-east-1"
+        endpoint: "https://s3.example-region.example.com"
+        s3ForcePathStyle: true
+        logLevel: 0
+```
+
+`config/development-cass-s3.yaml` contains a complete example that points at a local endpoint.
+
 ## Visibility query syntax
 You can query the visibility store by using the `tctl workflow listarchived` command
 


### PR DESCRIPTION
## What changed?
Added a short "S3-compatible endpoints" subsection to `common/archiver/s3store/README.md` documenting the `endpoint` and `s3ForcePathStyle` options of the `s3store` archival provider, with a small config snippet and a pointer to `config/development-cass-s3.yaml`. Docs only, no code changes.

## Why?
Both options already exist and are already honored: `common/config/config.go` declares them on `S3Archiver` (`endpoint`, `s3ForcePathStyle`), and both `history_archiver.go` and `visibility_archiver.go` pass them straight through to `s3.Options.BaseEndpoint` and `s3.Options.UsePathStyle`. `config/development-cass-s3.yaml` depends on them to talk to localstack. The README configuration sample never mentions either key, so anyone pointing archival at an S3 API other than the AWS default has to read the source or reverse-engineer the dev config to discover they are supported.

## How did you test it?
- [x] covered by existing tests

Markdown-only change. I did verify that the snippet I documented unmarshals into `config.S3Archiver` exactly as written, so the key names and casing in the README match the yaml tags in `common/config/config.go`.