### PR TITLE
Fix Claude review checkout for fork PRs

### DIFF
--- a/.github/workflows/claude-review-teams.yml
+++ b/.github/workflows/claude-review-teams.yml
@@ -226,11 +226,15 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.check-review-eligibility.outputs.head_sha }}
           path: pr-head
+          persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - name: Claude PR review
         uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
## What changed?
- Pin both Claude review checkouts to actions/checkout v7.
- Disable persisted Git credentials for both checkouts.
- Explicitly allow the gated PR-head checkout from forks.

## Why?
actions/checkout now rejects fork PR code in `pull_request_target` workflows unless the checkout explicitly opts in. This workflow already gates reviews on trusted organization membership and repository permissions, resolves an immutable head SHA, and treats the checked-out PR as review input rather than executable code. The v7 upgrade also uses Node 24.