### PR TITLE
Fix standalone activity cancellation error parity

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -647,7 +647,7 @@ func (a *Activity) HandleCanceled(
 	if err := a.validateActivityTaskToken(ctx, event.Token, event.Request.GetNamespaceId(), false); err != nil {
 		return nil, err
 	}
-	if a.GetStatus() != activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED {
+	if !TransitionCanceled.Possible(a) {
 		return nil, consts.ErrActivityTaskNotCancelRequested
 	}
 

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -59,6 +59,7 @@ import (
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/tqid"
 	"go.temporal.io/server/common/util"
+	"go.temporal.io/server/service/history/consts"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -645,6 +646,9 @@ func (a *Activity) HandleCanceled(
 ) (*historyservice.RespondActivityTaskCanceledResponse, error) {
 	if err := a.validateActivityTaskToken(ctx, event.Token, event.Request.GetNamespaceId(), false); err != nil {
 		return nil, err
+	}
+	if a.GetStatus() != activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED {
+		return nil, consts.ErrActivityTaskNotCancelRequested
 	}
 
 	metricsHandler, err := a.enrichedMetricsHandler(ctx, metrics.HistoryRespondActivityTaskCanceledScope)

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -16,6 +16,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/retrypolicy"
 	"go.temporal.io/server/common/testing/parallelsuite"
+	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/tests/testcore"
 )
 
@@ -39,6 +40,12 @@ func newActivityParityEnv(t *testing.T) *testcore.TestEnv {
 	cluster.OverrideDynamicConfig(t, activity.Enabled, nsValues(true))
 	cluster.OverrideDynamicConfig(t, activity.EnableStandaloneActivityOperatorCommands, nsValues(true))
 	return env
+}
+
+func assertActivityTaskNotCancelRequested(t *testing.T, err error) {
+	var invalidArgumentErr *serviceerror.InvalidArgument
+	require.ErrorAs(t, err, &invalidArgumentErr)
+	require.Equal(t, consts.ErrActivityTaskNotCancelRequested.Error(), invalidArgumentErr.Message)
 }
 
 // nextRetryDelayOverride is a worker-supplied next_retry_delay, distinct from
@@ -340,21 +347,32 @@ func (s *activityParityTestSuite) TestCancel() {
 func (s *activityParityTestSuite) TestRespondCanceledWithoutRequest() {
 	env := newActivityParityEnv(s.T())
 	cfg := activityConfig{MaxAttempts: 1}
-	assertNotCancelRequested := func(t *testing.T, err error) {
-		var invalidArgumentErr *serviceerror.InvalidArgument
-		require.ErrorAs(t, err, &invalidArgumentErr)
-		require.Equal(t, "unable to mark activity as canceled without activity being request canceled first", invalidArgumentErr.Message)
-	}
 
 	s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
 		t := s.T()
 		handle := newWFADriver(t, env, cfg).driveTrace(t, []model.Event{model.Poll})
-		assertNotCancelRequested(t, handle.rpc(t, model.RespondCanceled))
+		assertActivityTaskNotCancelRequested(t, handle.rpc(t, model.RespondCanceled))
 	})
 	s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
 		t := s.T()
 		handle := newSAADriver(t, env, cfg).driveTrace(t, []model.Event{model.Poll})
-		assertNotCancelRequested(t, handle.rpc(t, model.RespondCanceled))
+		assertActivityTaskNotCancelRequested(t, handle.rpc(t, model.RespondCanceled))
+	})
+}
+
+func (s *activityParityTestSuite) TestRespondCanceledByIDWithoutRequest() {
+	env := newActivityParityEnv(s.T())
+	cfg := activityConfig{MaxAttempts: 1}
+
+	s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
+		t := s.T()
+		handle := newWFADriver(t, env, cfg).driveTrace(t, []model.Event{model.Poll})
+		assertActivityTaskNotCancelRequested(t, handle.respondCanceledByID())
+	})
+	s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
+		t := s.T()
+		handle := newSAADriver(t, env, cfg).driveTrace(t, []model.Event{model.Poll})
+		assertActivityTaskNotCancelRequested(t, handle.respondCanceledByID())
 	})
 }
 

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/chasm/lib/activity/model"
@@ -333,6 +334,27 @@ func (s *activityParityTestSuite) TestCancel() {
 		t := s.T()
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_CANCELED,
 			newSAADriver(t, env, cfg).driveTrace(t, trace).terminalStatus(t))
+	})
+}
+
+func (s *activityParityTestSuite) TestRespondCanceledWithoutRequest() {
+	env := newActivityParityEnv(s.T())
+	cfg := activityConfig{MaxAttempts: 1}
+	assertNotCancelRequested := func(t *testing.T, err error) {
+		var invalidArgumentErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgumentErr)
+		require.Equal(t, "unable to mark activity as canceled without activity being request canceled first", invalidArgumentErr.Message)
+	}
+
+	s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
+		t := s.T()
+		handle := newWFADriver(t, env, cfg).driveTrace(t, []model.Event{model.Poll})
+		assertNotCancelRequested(t, handle.rpc(t, model.RespondCanceled))
+	})
+	s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
+		t := s.T()
+		handle := newSAADriver(t, env, cfg).driveTrace(t, []model.Event{model.Poll})
+		assertNotCancelRequested(t, handle.rpc(t, model.RespondCanceled))
 	})
 }
 

--- a/tests/activity_standalone_driver.go
+++ b/tests/activity_standalone_driver.go
@@ -206,6 +206,19 @@ func saaActivityInfo(i *activitypb.ActivityExecutionInfo) activityInfo {
 	}
 }
 
+func (a *saaHandle) respondCanceledByID() error {
+	_, err := a.d.env.FrontendClient().RespondActivityTaskCanceledById(
+		a.d.ctx,
+		&workflowservice.RespondActivityTaskCanceledByIdRequest{
+			Namespace:  a.d.env.Namespace().String(),
+			ActivityId: a.activityID,
+			RunId:      a.runID,
+			Identity:   a.d.env.Tv().WorkerIdentity(),
+		},
+	)
+	return err
+}
+
 // rpc performs the frontend RPC for a non-Poll, non-timer event and returns its error.
 func (a *saaHandle) rpc(_ testing.TB, e model.Event) error {
 	fc := a.d.env.FrontendClient()

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -1771,6 +1771,7 @@ func (s *standaloneActivityTestSuite) TestFail() {
 func (s *standaloneActivityTestSuite) TestRequestCancel() {
 	env := s.newTestEnv()
 	t := s.T()
+	ctx := s.Context()
 
 	t.Run("ByToken", func(t *testing.T) {
 
@@ -1992,29 +1993,51 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 	})
 
 	t.Run("FailsIfNeverRequested", func(t *testing.T) {
-
-		activityID := testcore.RandomizeStr(t.Name())
-		taskQueue := testcore.RandomizeStr(t.Name())
-
-		startResp := env.startAndValidateActivity(s.Context(), t, activityID, taskQueue)
-		runID := startResp.RunId
-
-		pollTaskResp := env.pollActivityTaskAndValidate(s.Context(), t, activityID, taskQueue, runID)
-
-		details := &commonpb.Payloads{
-			Payloads: []*commonpb.Payload{
-				payload.EncodeString("Canceled Details"),
+		testCases := []struct {
+			name    string
+			respond func(activityID, runID string, taskToken []byte) error
+		}{
+			{
+				name: "ByToken",
+				respond: func(_, _ string, taskToken []byte) error {
+					_, err := env.FrontendClient().RespondActivityTaskCanceled(ctx, &workflowservice.RespondActivityTaskCanceledRequest{
+						Namespace: env.Namespace().String(),
+						TaskToken: taskToken,
+						Details:   payloads.EncodeString("Canceled Details"),
+						Identity:  "new-worker",
+					})
+					return err
+				},
+			},
+			{
+				name: "ByID",
+				respond: func(activityID, runID string, _ []byte) error {
+					_, err := env.FrontendClient().RespondActivityTaskCanceledById(ctx, &workflowservice.RespondActivityTaskCanceledByIdRequest{
+						Namespace:  env.Namespace().String(),
+						ActivityId: activityID,
+						RunId:      runID,
+						Details:    payloads.EncodeString("Canceled Details"),
+						Identity:   "new-worker",
+					})
+					return err
+				},
 			},
 		}
 
-		_, err := env.FrontendClient().RespondActivityTaskCanceled(s.Context(), &workflowservice.RespondActivityTaskCanceledRequest{
-			Namespace: env.Namespace().String(),
-			TaskToken: pollTaskResp.TaskToken,
-			Details:   details,
-			Identity:  "new-worker",
-		})
-		var failedPreconditionErr *serviceerror.FailedPrecondition
-		require.ErrorAs(t, err, &failedPreconditionErr)
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				activityID := testcore.RandomizeStr(t.Name())
+				taskQueue := testcore.RandomizeStr(t.Name())
+
+				startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
+				pollTaskResp := env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, startResp.RunId)
+
+				err := tc.respond(activityID, startResp.RunId, pollTaskResp.TaskToken)
+				var invalidArgumentErr *serviceerror.InvalidArgument
+				require.ErrorAs(t, err, &invalidArgumentErr)
+				require.Equal(t, "unable to mark activity as canceled without activity being request canceled first", invalidArgumentErr.Message)
+			})
+		}
 	})
 
 	t.Run("DuplicateRequestIDSucceeds", func(t *testing.T) {

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -1771,7 +1771,6 @@ func (s *standaloneActivityTestSuite) TestFail() {
 func (s *standaloneActivityTestSuite) TestRequestCancel() {
 	env := s.newTestEnv()
 	t := s.T()
-	ctx := s.Context()
 
 	t.Run("ByToken", func(t *testing.T) {
 
@@ -1990,54 +1989,6 @@ func (s *standaloneActivityTestSuite) TestRequestCancel() {
 			Identity: env.Tv().WorkerIdentity(),
 		})
 		require.NoError(t, err)
-	})
-
-	t.Run("FailsIfNeverRequested", func(t *testing.T) {
-		testCases := []struct {
-			name    string
-			respond func(activityID, runID string, taskToken []byte) error
-		}{
-			{
-				name: "ByToken",
-				respond: func(_, _ string, taskToken []byte) error {
-					_, err := env.FrontendClient().RespondActivityTaskCanceled(ctx, &workflowservice.RespondActivityTaskCanceledRequest{
-						Namespace: env.Namespace().String(),
-						TaskToken: taskToken,
-						Details:   payloads.EncodeString("Canceled Details"),
-						Identity:  "new-worker",
-					})
-					return err
-				},
-			},
-			{
-				name: "ByID",
-				respond: func(activityID, runID string, _ []byte) error {
-					_, err := env.FrontendClient().RespondActivityTaskCanceledById(ctx, &workflowservice.RespondActivityTaskCanceledByIdRequest{
-						Namespace:  env.Namespace().String(),
-						ActivityId: activityID,
-						RunId:      runID,
-						Details:    payloads.EncodeString("Canceled Details"),
-						Identity:   "new-worker",
-					})
-					return err
-				},
-			},
-		}
-
-		for _, tc := range testCases {
-			t.Run(tc.name, func(t *testing.T) {
-				activityID := testcore.RandomizeStr(t.Name())
-				taskQueue := testcore.RandomizeStr(t.Name())
-
-				startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
-				pollTaskResp := env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, startResp.RunId)
-
-				err := tc.respond(activityID, startResp.RunId, pollTaskResp.TaskToken)
-				var invalidArgumentErr *serviceerror.InvalidArgument
-				require.ErrorAs(t, err, &invalidArgumentErr)
-				require.Equal(t, "unable to mark activity as canceled without activity being request canceled first", invalidArgumentErr.Message)
-			})
-		}
 	})
 
 	t.Run("DuplicateRequestIDSucceeds", func(t *testing.T) {

--- a/tests/activity_workflow_driver.go
+++ b/tests/activity_workflow_driver.go
@@ -255,6 +255,20 @@ func (a *wfaHandle) waitForCancelRequested(t testing.TB) {
 	}, activityDriverTimeout, activityDriverPollInterval)
 }
 
+func (a *wfaHandle) respondCanceledByID() error {
+	_, err := a.d.env.FrontendClient().RespondActivityTaskCanceledById(
+		a.d.ctx,
+		&workflowservice.RespondActivityTaskCanceledByIdRequest{
+			Namespace:  a.d.env.Namespace().String(),
+			WorkflowId: a.workflowID,
+			ActivityId: a.activityID,
+			RunId:      a.runID,
+			Identity:   a.d.env.Tv().WorkerIdentity(),
+		},
+	)
+	return err
+}
+
 // rpc performs the frontend RPC for a non-Poll, non-timer event and returns its error.
 func (a *wfaHandle) rpc(t testing.TB, e model.Event) error {
 	fc := a.d.env.FrontendClient()


### PR DESCRIPTION
## What changed?
Added an explicit precondition check for standalone activity cancellation responses. RespondActivityTaskCanceled now requires the activity to be in CANCEL_REQUESTED and returns the established ErrActivityTaskNotCancelRequested error otherwise.

## Why?
Standalone activities previously exposed an internal invalid-transition error when a worker reported cancellation without a prior cancellation request. Workflow activities return a stable InvalidArgument API error for the same scenario.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [X] added new functional test(s)
