### PR TITLE
SAA: port CompleteById tests to declarative framework 

### DIFF
--- a/chasm/lib/activity/model/vocabulary.go
+++ b/chasm/lib/activity/model/vocabulary.go
@@ -13,6 +13,7 @@ const (
 	PollType EventType = iota
 	HeartbeatType
 	RespondCompletedType
+	RespondCompletedByIDType
 	RespondFailedType
 	RespondCanceledType
 	RequestCancelType
@@ -48,6 +49,7 @@ var (
 	Poll                   = Event{Type: PollType}
 	Heartbeat              = Event{Type: HeartbeatType}
 	Complete               = Event{Type: RespondCompletedType}
+	CompleteByID           = Event{Type: RespondCompletedByIDType}
 	FailRetryably          = Event{Type: RespondFailedType, Retryable: true}
 	FailNonRetryably       = Event{Type: RespondFailedType, Retryable: false}
 	RespondCanceled        = Event{Type: RespondCanceledType}
@@ -75,6 +77,8 @@ func (t EventType) String() string {
 		return "Heartbeat"
 	case RespondCompletedType:
 		return "RespondCompleted"
+	case RespondCompletedByIDType:
+		return "RespondCompletedByID"
 	case RespondFailedType:
 		return "RespondFailed"
 	case RespondCanceledType:

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	enumspb "go.temporal.io/api/enums/v1"
-	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/chasm/lib/activity/model"

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -7,21 +7,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	commandpb "go.temporal.io/api/command/v1"
-	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/chasm/lib/activity/model"
 	"go.temporal.io/server/common/dynamicconfig"
-	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/retrypolicy"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
-	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 type activityParityTestSuite struct {
@@ -343,126 +338,26 @@ func (s *activityParityTestSuite) TestCancel() {
 }
 
 func (s *activityParityTestSuite) TestCompleteByID_BeforeAnyWorkerStarts() {
+	env := newActivityParityEnv(s.T())
+	trace := []model.Event{model.CompleteByID}
+	cfg := activityConfig{MaxAttempts: 1}
+
 	s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
-		env := testcore.NewEnv(s.T())
-		tv := env.Tv()
-
-		we, err := env.FrontendClient().StartWorkflowExecution(s.Context(), &workflowservice.StartWorkflowExecutionRequest{
-			RequestId:           uuid.NewString(),
-			Namespace:           env.Namespace().String(),
-			WorkflowId:          tv.WorkflowID(),
-			WorkflowType:        tv.WorkflowType(),
-			TaskQueue:           tv.TaskQueue(),
-			WorkflowRunTimeout:  durationpb.New(100 * time.Second),
-			WorkflowTaskTimeout: durationpb.New(10 * time.Second),
-			Identity:            tv.WorkerIdentity(),
-		})
-		s.NoError(err)
-
-		// Schedule the activity, but no poller ever calls PollActivityTaskQueue for it, so it
-		// remains Scheduled indefinitely.
-		_, err = env.TaskPoller().PollAndHandleWorkflowTask(tv,
-			func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
-				return &workflowservice.RespondWorkflowTaskCompletedRequest{
-					Commands: []*commandpb.Command{{
-						CommandType: enumspb.COMMAND_TYPE_SCHEDULE_ACTIVITY_TASK,
-						Attributes: &commandpb.Command_ScheduleActivityTaskCommandAttributes{
-							ScheduleActivityTaskCommandAttributes: &commandpb.ScheduleActivityTaskCommandAttributes{
-								ActivityId:             tv.ActivityID(),
-								ActivityType:           tv.ActivityType(),
-								TaskQueue:              tv.TaskQueue(),
-								Input:                  payloads.EncodeString("input"),
-								ScheduleToCloseTimeout: durationpb.New(time.Minute),
-								StartToCloseTimeout:    durationpb.New(time.Minute),
-							},
-						},
-					}},
-				}, nil
-			})
-		s.NoError(err)
-
-		_, err = env.FrontendClient().RespondActivityTaskCompletedById(s.Context(), &workflowservice.RespondActivityTaskCompletedByIdRequest{
-			Namespace:  env.Namespace().String(),
-			WorkflowId: tv.WorkflowID(),
-			RunId:      we.GetRunId(),
-			ActivityId: tv.ActivityID(),
-			Result:     payloads.EncodeString("result"),
-			Identity:   tv.WorkerIdentity(),
-		})
-		s.NoError(err, "force-completing a scheduled (never-started) workflow activity by ID must succeed")
-
-		// Drain the resulting workflow task and complete the workflow to confirm the completion
-		// was actually applied, not just accepted and dropped.
-		_, err = env.TaskPoller().PollAndHandleWorkflowTask(tv,
-			func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
-				return &workflowservice.RespondWorkflowTaskCompletedRequest{
-					Commands: []*commandpb.Command{{
-						CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
-						Attributes: &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{
-							CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{
-								Result: payloads.EncodeString("done"),
-							},
-						},
-					}},
-				}, nil
-			})
-		s.NoError(err)
-
-		descResp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
-			Namespace: env.Namespace().String(),
-			Execution: &commonpb.WorkflowExecution{WorkflowId: tv.WorkflowID(), RunId: we.GetRunId()},
-		})
-		s.NoError(err)
-		s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, descResp.GetWorkflowExecutionInfo().GetStatus())
+		t := s.T()
+		require.Equal(t,
+			enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED,
+			newWFADriver(t, env, cfg).driveTrace(t, trace).terminalStatus(t),
+		)
 	})
 
 	s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
-		env := testcore.NewEnv(s.T(),
-			testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
-			testcore.WithDynamicConfig(activity.Enabled, true),
+		t := s.T()
+		activity := newSAADriver(t, env, cfg).driveTrace(t, trace)
+		require.Equal(t,
+			enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED,
+			activity.terminalStatus(t),
 		)
-		tv := env.Tv()
-
-		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
-			Namespace:           env.Namespace().String(),
-			ActivityId:          tv.ActivityID(),
-			ActivityType:        tv.ActivityType(),
-			Identity:            tv.WorkerIdentity(),
-			Input:               payloads.EncodeString("input"),
-			TaskQueue:           tv.TaskQueue(),
-			StartToCloseTimeout: durationpb.New(time.Minute),
-			RequestId:           uuid.NewString(),
-		})
-		s.NoError(err)
-		s.True(startResp.GetStarted())
-
-		// No poller ever calls PollActivityTaskQueue for it, so it remains Scheduled indefinitely.
-		descBefore, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  env.Namespace().String(),
-			ActivityId: tv.ActivityID(),
-			RunId:      startResp.GetRunId(),
-		})
-		s.NoError(err)
-		s.Equal(enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, descBefore.GetInfo().GetRunState())
-
-		_, err = env.FrontendClient().RespondActivityTaskCompletedById(s.Context(), &workflowservice.RespondActivityTaskCompletedByIdRequest{
-			Namespace:  env.Namespace().String(),
-			RunId:      startResp.GetRunId(),
-			ActivityId: tv.ActivityID(),
-			Result:     payloads.EncodeString("result"),
-			Identity:   tv.WorkerIdentity(),
-		})
-		s.NoError(err, "force-completing a scheduled (never-started) standalone activity by ID must succeed, matching workflow-activity behavior")
-
-		descAfter, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:      env.Namespace().String(),
-			ActivityId:     tv.ActivityID(),
-			RunId:          startResp.GetRunId(),
-			IncludeOutcome: true,
-		})
-		s.NoError(err)
-		s.Equal(enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, descAfter.GetInfo().GetStatus())
-		s.NotNil(descAfter.GetInfo().GetLastStartedTime(),
+		require.NotNil(t, activity.describe(t).GetInfo().GetLastStartedTime(),
 			"a force-completed activity must still record a started time, even though no worker ever started it")
 	})
 }
@@ -471,145 +366,21 @@ func (s *activityParityTestSuite) TestCompleteByID_BeforeAnyWorkerStarts() {
 // the activity is Paused (a never-started activity that had a pause requested before any worker
 // picked it up) — Paused has no attempt in progress, just like Scheduled.
 func (s *activityParityTestSuite) TestCompleteByID_WhilePaused() {
+	env := newActivityParityEnv(s.T())
+	trace := []model.Event{model.Pause, model.CompleteByID}
+	cfg := activityConfig{MaxAttempts: 1}
+	const expected = enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED
+
 	s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
-		env := testcore.NewEnv(s.T())
-		tv := env.Tv()
-
-		we, err := env.FrontendClient().StartWorkflowExecution(s.Context(), &workflowservice.StartWorkflowExecutionRequest{
-			RequestId:           uuid.NewString(),
-			Namespace:           env.Namespace().String(),
-			WorkflowId:          tv.WorkflowID(),
-			WorkflowType:        tv.WorkflowType(),
-			TaskQueue:           tv.TaskQueue(),
-			WorkflowRunTimeout:  durationpb.New(100 * time.Second),
-			WorkflowTaskTimeout: durationpb.New(10 * time.Second),
-			Identity:            tv.WorkerIdentity(),
-		})
-		s.NoError(err)
-
-		// Schedule the activity, but no poller ever calls PollActivityTaskQueue for it, so it
-		// remains Scheduled indefinitely.
-		_, err = env.TaskPoller().PollAndHandleWorkflowTask(tv,
-			func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
-				return &workflowservice.RespondWorkflowTaskCompletedRequest{
-					Commands: []*commandpb.Command{{
-						CommandType: enumspb.COMMAND_TYPE_SCHEDULE_ACTIVITY_TASK,
-						Attributes: &commandpb.Command_ScheduleActivityTaskCommandAttributes{
-							ScheduleActivityTaskCommandAttributes: &commandpb.ScheduleActivityTaskCommandAttributes{
-								ActivityId:             tv.ActivityID(),
-								ActivityType:           tv.ActivityType(),
-								TaskQueue:              tv.TaskQueue(),
-								Input:                  payloads.EncodeString("input"),
-								ScheduleToCloseTimeout: durationpb.New(time.Minute),
-								StartToCloseTimeout:    durationpb.New(time.Minute),
-							},
-						},
-					}},
-				}, nil
-			})
-		s.NoError(err)
-
-		_, err = env.FrontendClient().PauseActivity(s.Context(), &workflowservice.PauseActivityRequest{
-			Namespace: env.Namespace().String(),
-			Execution: &commonpb.WorkflowExecution{WorkflowId: tv.WorkflowID()},
-			Activity:  &workflowservice.PauseActivityRequest_Id{Id: tv.ActivityID()},
-			Identity:  tv.WorkerIdentity(),
-			RequestId: uuid.NewString(),
-		})
-		s.NoError(err)
-
-		_, err = env.FrontendClient().RespondActivityTaskCompletedById(s.Context(), &workflowservice.RespondActivityTaskCompletedByIdRequest{
-			Namespace:  env.Namespace().String(),
-			WorkflowId: tv.WorkflowID(),
-			RunId:      we.GetRunId(),
-			ActivityId: tv.ActivityID(),
-			Result:     payloads.EncodeString("result"),
-			Identity:   tv.WorkerIdentity(),
-		})
-		s.NoError(err, "force-completing a paused (never-started) workflow activity by ID must succeed")
-
-		// Drain the resulting workflow task and complete the workflow to confirm the completion
-		// was actually applied, not just accepted and dropped.
-		_, err = env.TaskPoller().PollAndHandleWorkflowTask(tv,
-			func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
-				return &workflowservice.RespondWorkflowTaskCompletedRequest{
-					Commands: []*commandpb.Command{{
-						CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
-						Attributes: &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{
-							CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{
-								Result: payloads.EncodeString("done"),
-							},
-						},
-					}},
-				}, nil
-			})
-		s.NoError(err)
-
-		descResp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
-			Namespace: env.Namespace().String(),
-			Execution: &commonpb.WorkflowExecution{WorkflowId: tv.WorkflowID(), RunId: we.GetRunId()},
-		})
-		s.NoError(err)
-		s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, descResp.GetWorkflowExecutionInfo().GetStatus())
+		t := s.T()
+		require.Equal(t, expected, newWFADriver(t, env, cfg).driveTrace(t, trace).terminalStatus(t))
 	})
 
 	s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
-		env := testcore.NewEnv(s.T(),
-			testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
-			testcore.WithDynamicConfig(activity.Enabled, true),
-			testcore.WithDynamicConfig(activity.EnableStandaloneActivityOperatorCommands, true),
-		)
-		tv := env.Tv()
-
-		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
-			Namespace:           env.Namespace().String(),
-			ActivityId:          tv.ActivityID(),
-			ActivityType:        tv.ActivityType(),
-			Identity:            tv.WorkerIdentity(),
-			Input:               payloads.EncodeString("input"),
-			TaskQueue:           tv.TaskQueue(),
-			StartToCloseTimeout: durationpb.New(time.Minute),
-			RequestId:           uuid.NewString(),
-		})
-		s.NoError(err)
-		s.True(startResp.GetStarted())
-
-		// No poller ever calls PollActivityTaskQueue for it, so it remains Scheduled until paused.
-		_, err = env.FrontendClient().PauseActivityExecution(s.Context(), &workflowservice.PauseActivityExecutionRequest{
-			Namespace:  env.Namespace().String(),
-			ActivityId: tv.ActivityID(),
-			RunId:      startResp.GetRunId(),
-			Identity:   tv.WorkerIdentity(),
-			Reason:     "test-pause",
-		})
-		s.NoError(err)
-
-		descBefore, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:  env.Namespace().String(),
-			ActivityId: tv.ActivityID(),
-			RunId:      startResp.GetRunId(),
-		})
-		s.NoError(err)
-		s.Equal(enumspb.PENDING_ACTIVITY_STATE_PAUSED, descBefore.GetInfo().GetRunState())
-
-		_, err = env.FrontendClient().RespondActivityTaskCompletedById(s.Context(), &workflowservice.RespondActivityTaskCompletedByIdRequest{
-			Namespace:  env.Namespace().String(),
-			RunId:      startResp.GetRunId(),
-			ActivityId: tv.ActivityID(),
-			Result:     payloads.EncodeString("result"),
-			Identity:   tv.WorkerIdentity(),
-		})
-		s.NoError(err, "force-completing a paused (never-started) standalone activity by ID must succeed, matching workflow-activity behavior")
-
-		descAfter, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:      env.Namespace().String(),
-			ActivityId:     tv.ActivityID(),
-			RunId:          startResp.GetRunId(),
-			IncludeOutcome: true,
-		})
-		s.NoError(err)
-		s.Equal(enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, descAfter.GetInfo().GetStatus())
-		s.NotNil(descAfter.GetInfo().GetLastStartedTime(),
+		t := s.T()
+		activity := newSAADriver(t, env, cfg).driveTrace(t, trace)
+		require.Equal(t, expected, activity.terminalStatus(t))
+		require.NotNil(t, activity.describe(t).GetInfo().GetLastStartedTime(),
 			"a force-completed activity must still record a started time, even though no worker ever started it")
 	})
 }

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -353,9 +353,9 @@ func (s *activityParityTestSuite) TestCompleteByID() {
 			trace: []model.Event{model.Pause, model.CompleteByID},
 		},
 	}
+	env := newActivityParityEnv(s.T())
 	for _, tc := range testCases {
 		s.Run(tc.name, func(s *activityParityTestSuite) {
-			env := newActivityParityEnv(s.T())
 			s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
 				t := s.T()
 				require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, newWFADriver(t, env, cfg).driveTrace(t, tc.trace).terminalStatus(t))

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -336,7 +336,8 @@ func (s *activityParityTestSuite) TestCancel() {
 	})
 }
 
-// TestCompleteByID tests force-completing an activity by ID.
+// Force-completing an activity by ID must work whenever no attempt is in progress: while Scheduled
+// and never started, and while Paused before any worker picked it up.
 func (s *activityParityTestSuite) TestCompleteByID() {
 	type testCase struct {
 		name  string

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -362,9 +362,9 @@ func (s *activityParityTestSuite) TestCompleteByID() {
 			})
 			s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
 				t := s.T()
-				activity := newSAADriver(t, env, cfg).driveTrace(t, tc.trace)
-				require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, activity.terminalStatus(t))
-				require.NotNil(t, activity.describe(t).GetInfo().GetLastStartedTime(),
+				a := newSAADriver(t, env, cfg).driveTrace(t, tc.trace)
+				require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, a.terminalStatus(t))
+				require.NotNil(t, a.describe(t).GetInfo().GetLastStartedTime(),
 					"a force-completed activity must still record a started time, even though no worker ever started it")
 			})
 		})

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -337,50 +337,37 @@ func (s *activityParityTestSuite) TestCancel() {
 	})
 }
 
-func (s *activityParityTestSuite) TestCompleteByID_BeforeAnyWorkerStarts() {
-	env := newActivityParityEnv(s.T())
-	trace := []model.Event{model.CompleteByID}
+// TestCompleteByID tests force-completing an activity by ID.
+func (s *activityParityTestSuite) TestCompleteByID() {
+	type testCase struct {
+		name  string
+		trace []model.Event
+	}
 	cfg := activityConfig{MaxAttempts: 1}
-
-	s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
-		t := s.T()
-		require.Equal(t,
-			enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED,
-			newWFADriver(t, env, cfg).driveTrace(t, trace).terminalStatus(t),
-		)
-	})
-
-	s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
-		t := s.T()
-		activity := newSAADriver(t, env, cfg).driveTrace(t, trace)
-		require.Equal(t,
-			enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED,
-			activity.terminalStatus(t),
-		)
-		require.NotNil(t, activity.describe(t).GetInfo().GetLastStartedTime(),
-			"a force-completed activity must still record a started time, even though no worker ever started it")
-	})
-}
-
-// TestCompleteByID_WhilePaused asserts that force-completing an activity by ID also works while
-// the activity is Paused (a never-started activity that had a pause requested before any worker
-// picked it up) — Paused has no attempt in progress, just like Scheduled.
-func (s *activityParityTestSuite) TestCompleteByID_WhilePaused() {
-	env := newActivityParityEnv(s.T())
-	trace := []model.Event{model.Pause, model.CompleteByID}
-	cfg := activityConfig{MaxAttempts: 1}
-	const expected = enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED
-
-	s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
-		t := s.T()
-		require.Equal(t, expected, newWFADriver(t, env, cfg).driveTrace(t, trace).terminalStatus(t))
-	})
-
-	s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
-		t := s.T()
-		activity := newSAADriver(t, env, cfg).driveTrace(t, trace)
-		require.Equal(t, expected, activity.terminalStatus(t))
-		require.NotNil(t, activity.describe(t).GetInfo().GetLastStartedTime(),
-			"a force-completed activity must still record a started time, even though no worker ever started it")
-	})
+	testCases := []testCase{
+		{
+			name:  "BeforeStarted",
+			trace: []model.Event{model.CompleteByID},
+		},
+		{
+			name:  "WhilePaused",
+			trace: []model.Event{model.Pause, model.CompleteByID},
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.name, func(s *activityParityTestSuite) {
+			env := newActivityParityEnv(s.T())
+			s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
+				t := s.T()
+				require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, newWFADriver(t, env, cfg).driveTrace(t, tc.trace).terminalStatus(t))
+			})
+			s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
+				t := s.T()
+				activity := newSAADriver(t, env, cfg).driveTrace(t, tc.trace)
+				require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, activity.terminalStatus(t))
+				require.NotNil(t, activity.describe(t).GetInfo().GetLastStartedTime(),
+					"a force-completed activity must still record a started time, even though no worker ever started it")
+			})
+		})
+	}
 }

--- a/tests/activity_standalone_driver.go
+++ b/tests/activity_standalone_driver.go
@@ -221,6 +221,12 @@ func (a *saaHandle) rpc(_ testing.TB, e model.Event) error {
 			Result: payloads.EncodeString("result"),
 		})
 		return err
+	case model.RespondCompletedByIDType:
+		_, err := fc.RespondActivityTaskCompletedById(a.d.ctx, &workflowservice.RespondActivityTaskCompletedByIdRequest{
+			Namespace: ns, RunId: a.runID, ActivityId: a.activityID, Identity: a.d.env.Tv().WorkerIdentity(),
+			Result: payloads.EncodeString("result"),
+		})
+		return err
 	case model.RespondFailedType:
 		_, err := fc.RespondActivityTaskFailed(a.d.ctx, &workflowservice.RespondActivityTaskFailedRequest{
 			Namespace: ns, TaskToken: a.token, Identity: a.d.env.Tv().WorkerIdentity(), Failure: activityFailure(e.Retryable, a.cfg.NextRetryDelay),

--- a/tests/activity_workflow_driver.go
+++ b/tests/activity_workflow_driver.go
@@ -270,6 +270,12 @@ func (a *wfaHandle) rpc(t testing.TB, e model.Event) error {
 			Result: payloads.EncodeString("result"),
 		})
 		return err
+	case model.RespondCompletedByIDType:
+		_, err := fc.RespondActivityTaskCompletedById(a.d.ctx, &workflowservice.RespondActivityTaskCompletedByIdRequest{
+			Namespace: ns, WorkflowId: a.workflowID, RunId: a.runID, ActivityId: a.activityID, Identity: a.d.env.Tv().WorkerIdentity(),
+			Result: payloads.EncodeString("result"),
+		})
+		return err
 	case model.RespondFailedType:
 		_, err := fc.RespondActivityTaskFailed(a.d.ctx, &workflowservice.RespondActivityTaskFailedRequest{
 			Namespace: ns, TaskToken: a.token, Identity: a.d.env.Tv().WorkerIdentity(), Failure: activityFailure(e.Retryable, a.cfg.NextRetryDelay),


### PR DESCRIPTION
## What changed?
- Port SAA/WFA `CompleteById` tests to declarative framework 

## Why?
- We will gain additional test assertions when the declarative tests are wired up to the spec (model)
- Easier to read and reason about the tests: 225 LOC reduction

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test helpers and parity tests; no production activity execution paths are modified.
> 
> **Overview**
> Extends the shared activity **trace vocabulary** with **`RespondCompletedByIDType`** / **`model.CompleteByID`**, and teaches the **workflow-activity** and **standalone-activity** parity drivers to issue **`RespondActivityTaskCompletedById`** when that event appears in a trace.
> 
> **`TestCompleteByID`** replaces two large hand-written suites (`BeforeAnyWorkerStarts` and `WhilePaused`) with table-driven traces (`CompleteByID` alone, or `Pause` then `CompleteByID`), still asserting **WFA/SAA parity**, terminal **COMPLETED**, and that force-completed SAA runs record **`LastStartedTime`** without a worker poll.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d18754d3a4d4ffd29d491c9d353936b337fdd1fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->