### PR TITLE
Record SAA task schedule-to-start latency

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -293,9 +293,11 @@ func (a *Activity) HandleStarted(ctx chasm.MutableContext, request *historyservi
 		}
 		return nil, err
 	}
-	metrics.TaskScheduleToStartLatency.With(a.taskScheduleToStartMetricsHandler(ctx)).Record(
-		lastAttempt.GetStartedTime().AsTime().Sub(dispatchTime.AsTime()),
-	)
+	if dispatchTime != nil {
+		metrics.TaskScheduleToStartLatency.With(a.taskScheduleToStartMetricsHandler(ctx)).Record(
+			lastAttempt.GetStartedTime().AsTime().Sub(dispatchTime.AsTime()),
+		)
+	}
 	return a.GenerateRecordActivityTaskStartedResponse(ctx, request.GetPollRequest().GetNamespace())
 }
 

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -286,13 +286,32 @@ func (a *Activity) HandleStarted(ctx chasm.MutableContext, request *historyservi
 	if lastAttempt.GetStamp() != request.GetStamp() {
 		return nil, serviceerrors.NewObsoleteMatchingTask("activity attempt stamp mismatch")
 	}
+	dispatchTime := a.dispatchTimeForAttempt(lastAttempt)
 	if err := TransitionStarted.Apply(a, ctx, request); err != nil {
 		if errors.Is(err, chasm.ErrInvalidTransition) {
 			return nil, serviceerrors.NewObsoleteMatchingTask(err.Error())
 		}
 		return nil, err
 	}
+	metrics.TaskScheduleToStartLatency.With(a.taskScheduleToStartMetricsHandler(ctx)).Record(
+		lastAttempt.GetStartedTime().AsTime().Sub(dispatchTime.AsTime()),
+	)
 	return a.GenerateRecordActivityTaskStartedResponse(ctx, request.GetPollRequest().GetNamespace())
+}
+
+func (a *Activity) taskScheduleToStartMetricsHandler(ctx chasm.Context) metrics.Handler {
+	actCtx := activityContextFromChasm(ctx)
+	namespaceEntry := ctx.NamespaceEntry()
+	namespaceName := namespaceEntry.Name().String()
+	taskQueue := a.GetTaskQueue().GetName()
+	return metrics.GetPerTaskQueuePartitionTypeScope(
+		a.baseMetricsHandler(ctx, metrics.HistoryRecordActivityTaskStartedScope),
+		namespaceName,
+		tqid.UnsafeTaskQueueFamily(namespaceEntry.ID().String(), taskQueue).
+			TaskQueue(enumspb.TASK_QUEUE_TYPE_ACTIVITY).
+			RootPartition(),
+		actCtx.config.BreakdownMetricsByTaskQueue(namespaceName, taskQueue, enumspb.TASK_QUEUE_TYPE_ACTIVITY),
+	)
 }
 
 // GenerateRecordActivityTaskStartedResponse generates the response for HandleStarted.

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -167,6 +167,7 @@ func TestHandleStarted(t *testing.T) {
 		requestStamp   int32
 		startRequestID string
 		requestID      string
+		metricSamples  int
 		checkOutcome   func(t *testing.T, response *historyservice.RecordActivityTaskStartedResponse, err error)
 	}{
 		{
@@ -175,6 +176,7 @@ func TestHandleStarted(t *testing.T) {
 			attemptStamp:   testStamp,
 			requestStamp:   testStamp,
 			requestID:      testRequestID,
+			metricSamples:  1,
 			checkOutcome: func(t *testing.T, response *historyservice.RecordActivityTaskStartedResponse, err error) {
 				require.Equal(t, int32(1), response.Attempt)
 				require.NoError(t, err)
@@ -277,16 +279,32 @@ func TestHandleStarted(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			metricsHandler := metricstest.NewCaptureHandler()
+			metricCapture := metricsHandler.StartCapture()
+			defer metricsHandler.StopCapture(metricCapture)
+			namespaceEntry := namespace.NewLocalNamespaceForTest(
+				&persistencespb.NamespaceInfo{Id: "test-namespace-id", Name: "test-namespace"},
+				&persistencespb.NamespaceConfig{},
+				"active-cluster",
+			)
 			// Setup mock context
 			ctx := &chasm.MockMutableContext{
 				MockContext: chasm.MockContext{
 					HandleNow: func(chasm.Component) time.Time { return testTime },
 					HandleExecutionKey: func() chasm.ExecutionKey {
 						return chasm.ExecutionKey{
-							BusinessID: "test-activity-id",
-							RunID:      "test-run-id",
+							NamespaceID: "test-namespace-id",
+							BusinessID:  "test-activity-id",
+							RunID:       "test-run-id",
 						}
 					},
+					HandleNamespaceEntry: func() *namespace.Namespace { return namespaceEntry },
+					HandleMetricsHandler: func() metrics.Handler { return metricsHandler },
+					GoCtx: context.WithValue(context.Background(), ctxKeyActivityContext, &activityContext{
+						config: &Config{
+							BreakdownMetricsByTaskQueue: dynamicconfig.GetBoolPropertyFnFilteredByTaskQueue(true),
+						},
+					}),
 				},
 			}
 
@@ -342,6 +360,11 @@ func TestHandleStarted(t *testing.T) {
 			response, err := activity.HandleStarted(ctx, request)
 
 			tc.checkOutcome(t, response, err)
+			recordings := metricCapture.Snapshot()[metrics.TaskScheduleToStartLatency.Name()]
+			require.Len(t, recordings, tc.metricSamples)
+			if tc.metricSamples > 0 {
+				require.Equal(t, 30*time.Second, recordings[0].Value)
+			}
 		})
 	}
 }

--- a/service/history/api/recordactivitytaskstarted/api.go
+++ b/service/history/api/recordactivitytaskstarted/api.go
@@ -267,23 +267,19 @@ func recordActivityTaskStarted(
 		return nil, rejectCodeUndefined, err
 	}
 
-	// A schedule time is always known for an attempt that a worker has started; skip the metric
-	// rather than report a latency measured from the zero time.
-	if ai.GetScheduledTime() != nil {
-		scheduleToStartLatency := ai.GetStartedTime().AsTime().Sub(ai.GetScheduledTime().AsTime())
-		metrics.TaskScheduleToStartLatency.With(
-			metrics.GetPerTaskQueuePartitionTypeScope(
-				taggedMetrics,
-				namespaceName,
-				// passing the root partition all the time as we don't care about partition ID in this metric
-				tqid.UnsafeTaskQueueFamily(namespaceEntry.ID().String(),
-					ai.GetTaskQueue()).TaskQueue(enumspb.TASK_QUEUE_TYPE_ACTIVITY).RootPartition(),
-				shardContext.GetConfig().BreakdownMetricsByTaskQueue(namespaceName,
-					ai.GetTaskQueue(),
-					enumspb.TASK_QUEUE_TYPE_ACTIVITY),
-			),
-		).Record(scheduleToStartLatency)
-	}
+	scheduleToStartLatency := ai.GetStartedTime().AsTime().Sub(ai.GetScheduledTime().AsTime())
+	metrics.TaskScheduleToStartLatency.With(
+		metrics.GetPerTaskQueuePartitionTypeScope(
+			taggedMetrics,
+			namespaceName,
+			// passing the root partition all the time as we don't care about partition ID in this metric
+			tqid.UnsafeTaskQueueFamily(namespaceEntry.ID().String(),
+				ai.GetTaskQueue()).TaskQueue(enumspb.TASK_QUEUE_TYPE_ACTIVITY).RootPartition(),
+			shardContext.GetConfig().BreakdownMetricsByTaskQueue(namespaceName,
+				ai.GetTaskQueue(),
+				enumspb.TASK_QUEUE_TYPE_ACTIVITY),
+		),
+	).Record(scheduleToStartLatency)
 
 	response.Clock = clock
 

--- a/service/history/api/recordactivitytaskstarted/api.go
+++ b/service/history/api/recordactivitytaskstarted/api.go
@@ -267,19 +267,23 @@ func recordActivityTaskStarted(
 		return nil, rejectCodeUndefined, err
 	}
 
-	scheduleToStartLatency := ai.GetStartedTime().AsTime().Sub(ai.GetScheduledTime().AsTime())
-	metrics.TaskScheduleToStartLatency.With(
-		metrics.GetPerTaskQueuePartitionTypeScope(
-			taggedMetrics,
-			namespaceName,
-			// passing the root partition all the time as we don't care about partition ID in this metric
-			tqid.UnsafeTaskQueueFamily(namespaceEntry.ID().String(),
-				ai.GetTaskQueue()).TaskQueue(enumspb.TASK_QUEUE_TYPE_ACTIVITY).RootPartition(),
-			shardContext.GetConfig().BreakdownMetricsByTaskQueue(namespaceName,
-				ai.GetTaskQueue(),
-				enumspb.TASK_QUEUE_TYPE_ACTIVITY),
-		),
-	).Record(scheduleToStartLatency)
+	// A schedule time is always known for an attempt that a worker has started; skip the metric
+	// rather than report a latency measured from the zero time.
+	if ai.GetScheduledTime() != nil {
+		scheduleToStartLatency := ai.GetStartedTime().AsTime().Sub(ai.GetScheduledTime().AsTime())
+		metrics.TaskScheduleToStartLatency.With(
+			metrics.GetPerTaskQueuePartitionTypeScope(
+				taggedMetrics,
+				namespaceName,
+				// passing the root partition all the time as we don't care about partition ID in this metric
+				tqid.UnsafeTaskQueueFamily(namespaceEntry.ID().String(),
+					ai.GetTaskQueue()).TaskQueue(enumspb.TASK_QUEUE_TYPE_ACTIVITY).RootPartition(),
+				shardContext.GetConfig().BreakdownMetricsByTaskQueue(namespaceName,
+					ai.GetTaskQueue(),
+					enumspb.TASK_QUEUE_TYPE_ACTIVITY),
+			),
+		).Record(scheduleToStartLatency)
+	}
 
 	response.Clock = clock
 

--- a/tests/activity_metrics_parity_test.go
+++ b/tests/activity_metrics_parity_test.go
@@ -11,10 +11,92 @@ import (
 	"github.com/stretchr/testify/require"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/chasm/lib/activity/model"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
+	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/testing/await"
 )
+
+func (s *activityParityTestSuite) TestScheduleToStartMetric() {
+	type scenario struct {
+		name           string
+		trace          []model.Event
+		expectedStarts int
+	}
+	type captureResult struct {
+		recordings []*metricstest.CapturedRecording
+		namespace  string
+		taskQueue  string
+	}
+
+	scenarios := []scenario{
+		{name: "FirstAttempt", trace: []model.Event{model.Poll}, expectedStarts: 1},
+		{
+			name:           "RetryAttempt",
+			trace:          []model.Event{model.Poll, model.FailRetryably, model.BackoffElapses, model.Poll},
+			expectedStarts: 2,
+		},
+	}
+	capture := func(t *testing.T, standalone, breakdownByTaskQueue bool, trace []model.Event) captureResult {
+		env := newActivityParityEnv(t)
+		env.GetTestCluster().OverrideDynamicConfig(t, dynamicconfig.MetricsBreakdownByTaskQueue,
+			[]dynamicconfig.ConstrainedValue{{
+				Constraints: dynamicconfig.Constraints{Namespace: env.Namespace().String()},
+				Value:       breakdownByTaskQueue,
+			}})
+		metricCapture := env.StartNamespaceMetricCapture()
+
+		var taskQueue string
+		if standalone {
+			taskQueue = newSAADriver(t, env, activityConfig{}).driveTrace(t, trace).taskQueue
+		} else {
+			taskQueue = newWFADriver(t, env, activityConfig{}).driveTrace(t, trace).taskQueue
+		}
+		recordings := metricCapture.CollectMetric(metrics.TaskScheduleToStartLatency.Name(), func(rec *metricstest.CapturedRecording) bool {
+			return rec.Tags["operation"] == metrics.HistoryRecordActivityTaskStartedScope &&
+				rec.Tags["task_type"] == enumspb.TASK_QUEUE_TYPE_ACTIVITY.String()
+		})
+		return captureResult{recordings: recordings, namespace: env.Namespace().String(), taskQueue: taskQueue}
+	}
+	check := func(t *testing.T, implementation string, result captureResult, breakdownByTaskQueue bool, expectedStarts int) {
+		require.Len(t, result.recordings, expectedStarts,
+			"%s must record schedule-to-start latency once for every accepted worker start", implementation)
+		taskQueue := "__omitted__"
+		if breakdownByTaskQueue {
+			taskQueue = result.taskQueue
+		}
+		expectedTags := map[string]string{
+			"namespace":    result.namespace,
+			"operation":    metrics.HistoryRecordActivityTaskStartedScope,
+			"partition":    "__normal__",
+			"service_name": string(primitives.HistoryService),
+			"task_type":    enumspb.TASK_QUEUE_TYPE_ACTIVITY.String(),
+			"taskqueue":    taskQueue,
+		}
+		for _, recording := range result.recordings {
+			require.Equal(t, expectedTags, recording.Tags, "%s metric tags must match the activity-task start scope", implementation)
+		}
+	}
+
+	for _, breakdownByTaskQueue := range []bool{true, false} {
+		breakdownName := "TaskQueueBreakdownEnabled"
+		if !breakdownByTaskQueue {
+			breakdownName = "TaskQueueBreakdownDisabled"
+		}
+		s.Run(breakdownName, func(s *activityParityTestSuite) {
+			for _, sc := range scenarios {
+				s.Run(sc.name, func(s *activityParityTestSuite) {
+					t := s.T()
+					wfa := capture(t, false, breakdownByTaskQueue, sc.trace)
+					saa := capture(t, true, breakdownByTaskQueue, sc.trace)
+					check(t, "WFA", wfa, breakdownByTaskQueue, sc.expectedStarts)
+					check(t, "SAA", saa, breakdownByTaskQueue, sc.expectedStarts)
+				})
+			}
+		})
+	}
+}
 
 func (s *activityParityTestSuite) TestWFASAAMetricsParity() {
 	type activityMetric struct {

--- a/tests/activity_metrics_parity_test.go
+++ b/tests/activity_metrics_parity_test.go
@@ -18,6 +18,18 @@ import (
 	"go.temporal.io/server/common/testing/await"
 )
 
+// TestScheduleToStartMetric asserts that SAA and WFA both record task_schedule_to_start_latency,
+// identically, whenever a worker starts an activity attempt. Recordings from workflow-task starts
+// share the metric name, so only those tagged with the activity-task start operation and task type
+// are collected.
+//
+// Each case drives the same trace through both implementations and asserts on the resulting
+// recordings:
+//   - one sample per accepted worker start: FirstAttempt records once, RetryAttempt records again
+//     when the worker picks up the attempt scheduled after the retry backoff;
+//   - the exact tag set of the activity-task start scope, under both settings of
+//     MetricsBreakdownByTaskQueue, which decides whether "taskqueue" carries the real name or the
+//     "__omitted__" placeholder that keeps metric cardinality down.
 func (s *activityParityTestSuite) TestScheduleToStartMetric() {
 	type scenario struct {
 		name           string


### PR DESCRIPTION
## What changed?
- Emit schedule-to-start latency metric when SAA starts
- The metric distribution (which is per-task queue) will now contain data points from both SAA and WFA. This is reasonable because there's nothing about SAA that implies that its time in matching backlog should have a different distribution.

## Why?
- Required metric; WFA parity

## How did you test it?
- [X] added new functional test(s)




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change on the activity-start path; no auth or persistence behavior changes, with parity tests limiting regression risk.
> 
> **Overview**
> Standalone activities (SAA) now emit **`task_schedule_to_start_latency`** when an attempt is actually started in **`HandleStarted`**, matching workflow-embedded activities (WFA). Latency is **started time minus dispatch time** (captured before the state transition), and the sample uses the same per–task-queue partition scope and **`MetricsBreakdownByTaskQueue`** tagging as the existing History activity-start path. Idempotent **`RecordActivityTaskStarted`** retries still skip the metric.
> 
> **Tests:** unit coverage in **`TestHandleStarted`** (one sample on successful start, none on idempotent/error paths) and a new parity test **`TestScheduleToStartMetric`** that compares SAA vs WFA for first attempt and retry, with task-queue breakdown on and off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d236c8e0e5b00d8531fbbc1d62d8a3a2f4664508. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->