### PR TITLE
Stop reapply from falling back to CHASM when HSM has no such operation

### DIFF
--- a/service/history/ndc/events_reapplier.go
+++ b/service/history/ndc/events_reapplier.go
@@ -61,7 +61,7 @@ func (r *EventsReapplierImpl) ReapplyEvents(
 	if !ms.IsWorkflowExecutionRunning() {
 		return nil, serviceerror.NewInternal("unable to reapply events to closed workflow.")
 	}
-	reappliedEvents, err := reapplyEvents(ctx, ms, updateRegistry, r.stateMachineRegistry, r.chasmWorkflowRegistry, historyEvents, nil, runID, false)
+	reappliedEvents, err := reapplyEvents(ctx, ms, updateRegistry, r.stateMachineRegistry, r.chasmWorkflowRegistry, historyEvents, nil, runID, false, r.logger)
 	if err != nil {
 		return nil, err
 	}

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -1100,24 +1100,23 @@ func reapplyEvents(
 			}
 		default:
 			// Nexus operations (and other state-machine-backed components) can be backed by either the HSM tree or the
-			// CHASM tree, and both coexist on the same mutable state. Reset must rebuild the op regardless of which
-			// framework owns it.
-			// TODO(follow-up): the completion-token resolution path (HSM StateMachineRef vs CHASM
-			// ComponentRef) also needs the same fallback; see the completion handler in nexusoperation.
+			// CHASM tree, and both coexist on the same mutable state. An op missing from the HSM tree is skipped
+			// rather than looked up in CHASM; see cherryPickHSMEvent.
 			outcome, err := cherryPickHSMEvent(mutableState, stateMachineRegistry, event, resetReapplyExcludeTypes)
 			if err != nil {
 				return reappliedEvents, err
 			}
 			if outcome == cherryPickFallback {
-				// HSM doesn't own this op (unknown type, or component not in the HSM tree): try the CHASM tree.
+				// HSM doesn't define this event type: try the CHASM tree.
 				outcome, err = cherryPickChasmEvent(ctx, mutableState, chasmWorkflowRegistry, event, resetReapplyExcludeTypes)
 				if err != nil {
 					return reappliedEvents, err
 				}
 			}
 			if outcome != cherryPickApplied {
-				// Either skipped (recognized but not cherry-pickable) or unhandled by both frameworks.
-				// Only reapply hardcoded events above or ones cherry-picked in HSM or CHASM.
+				// Skipped for one of three reasons: not cherry-pickable, the component is missing from the
+				// HSM tree, or neither framework defines the event type. Only reapply hardcoded events
+				// above or ones cherry-picked in HSM or CHASM.
 				continue
 			}
 			mutableState.AddHistoryEvent(event.EventType, func(he *historypb.HistoryEvent) {
@@ -1143,8 +1142,10 @@ const (
 	// (e.g. excluded by reset-reapply-exclude-types, or not a cherry-pickable transition). The event
 	// must be skipped, NOT routed to the other framework, to avoid double-applying.
 	cherryPickSkipped
-	// cherryPickFallback: this framework doesn't own the op (unknown event type, or the component is
-	// not in this tree). The caller should try the other framework.
+	// cherryPickFallback: this framework doesn't define the event type, so the caller should try the
+	// other framework. A component missing from this framework's tree is skipped, not a fallback.
+	// HSM and CHASM define the same event types today, so this outcome only ever reaches CHASM's
+	// registry lookup, never its cherry-pick.
 	cherryPickFallback
 )
 
@@ -1163,8 +1164,11 @@ func cherryPickHSMEvent(
 	if err := def.CherryPick(mutableState.HSM(), event, resetReapplyExcludeTypes); err != nil {
 		switch {
 		case errors.Is(err, hsm.ErrStateMachineNotFound):
-			// The op isn't in the HSM tree. It may live in the CHASM tree instead, so fall back.
-			return cherryPickFallback, nil
+			// The op isn't in the HSM tree. On the replication reapply path it is usually in no tree at
+			// all: unlike reset, the batch is not guaranteed to share a prefix with the surviving branch,
+			// so events for operations that only existed on the discarded branch are normal. Skip rather
+			// than fall back to CHASM, whose NotFound for a missing op aborts the whole batch.
+			return cherryPickSkipped, nil
 		case errors.Is(err, hsm.ErrNotCherryPickable), errors.Is(err, hsm.ErrInvalidTransition):
 			// Recognized by HSM but intentionally not cherry-pickable here; skip without falling back.
 			return cherryPickSkipped, nil
@@ -1176,8 +1180,11 @@ func cherryPickHSMEvent(
 }
 
 // cherryPickChasmEvent attempts to cherry-pick an event against the CHASM workflow tree. It mirrors cherryPickHSMEvent.
-// As the last framework tried, an event type it doesn't define is skipped (nothing left to fall back to), and a
-// CHASM-defined event on a workflow without CHASM enabled returns an error rather than being silently dropped.
+// As the last framework tried, an event type it doesn't define is skipped: there is nothing left to fall back to.
+//
+// HSM and CHASM register the same Nexus event types, and cherryPickHSMEvent no longer falls back when a component is
+// missing from the HSM tree, so callers only reach the registry lookup below. Everything past it, including the
+// ChasmEnabled check, is unreachable until some CHASM library defines an event type HSM does not.
 func cherryPickChasmEvent(
 	ctx context.Context,
 	mutableState historyi.MutableState,

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -921,6 +921,7 @@ func (r *workflowResetterImpl) reapplyEvents(
 		resetReapplyExcludeTypes,
 		"",
 		true,
+		r.logger,
 	)
 }
 
@@ -934,6 +935,7 @@ func reapplyEvents(
 	resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]struct{},
 	runIdForDeduplication string,
 	isReset bool,
+	logger log.Logger,
 ) ([]*historypb.HistoryEvent, error) {
 	// TODO (dan): This implementation is the result of unifying two previous implementations, one of which did
 	// deduplication. Can we always/never do this deduplication, or must it be decided by the caller?
@@ -1102,7 +1104,7 @@ func reapplyEvents(
 			// Nexus operations (and other state-machine-backed components) can be backed by either the HSM tree or the
 			// CHASM tree, and both coexist on the same mutable state. An op missing from the HSM tree is skipped
 			// rather than looked up in CHASM; see cherryPickHSMEvent.
-			outcome, err := cherryPickHSMEvent(mutableState, stateMachineRegistry, event, resetReapplyExcludeTypes)
+			outcome, err := cherryPickHSMEvent(mutableState, stateMachineRegistry, event, resetReapplyExcludeTypes, isReset, logger)
 			if err != nil {
 				return reappliedEvents, err
 			}
@@ -1153,6 +1155,8 @@ func cherryPickHSMEvent(
 	stateMachineRegistry *hsm.Registry,
 	event *historypb.HistoryEvent,
 	resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]struct{},
+	isReset bool,
+	logger log.Logger,
 ) (cherryPickOutcome, error) {
 	def, ok := stateMachineRegistry.EventDefinition(event.GetEventType())
 	if !ok {
@@ -1166,6 +1170,7 @@ func cherryPickHSMEvent(
 			// path the op is usually in no tree at all, and CHASM's NotFound for a missing op would abort
 			// the whole batch. The cost is that reset reapply drops completions for CHASM-owned ops.
 			// See https://github.com/temporalio/temporal/issues/11384.
+			logSkippedOperation(mutableState, event, isReset, logger)
 			return cherryPickSkipped, nil
 		case errors.Is(err, hsm.ErrNotCherryPickable), errors.Is(err, hsm.ErrInvalidTransition):
 			// Recognized by HSM but intentionally not cherry-pickable here; skip without falling back.
@@ -1175,6 +1180,32 @@ func cherryPickHSMEvent(
 		}
 	}
 	return cherryPickApplied, nil
+}
+
+// logSkippedOperation records an event that reapply dropped because its component is missing from the HSM tree.
+//
+// The level differs by path because the same condition means different things. On the reset path a missing component
+// means a completion is silently dropped from the reset run, which is user-visible and worth a warning. On the
+// replication path the op is usually in no tree at all, so the skip is routine and stays at debug to keep from
+// drowning out the reset case.
+func logSkippedOperation(
+	mutableState historyi.MutableState,
+	event *historypb.HistoryEvent,
+	isReset bool,
+	logger log.Logger,
+) {
+	logAtLevel := logger.Debug
+	if isReset {
+		logAtLevel = logger.Warn
+	}
+	workflowKey := mutableState.GetWorkflowKey()
+	logAtLevel("skipping reapply of event: state machine not found in HSM tree",
+		tag.WorkflowNamespaceID(workflowKey.NamespaceID),
+		tag.WorkflowID(workflowKey.WorkflowID),
+		tag.WorkflowRunID(workflowKey.RunID),
+		tag.WorkflowEventID(event.GetEventId()),
+		tag.NewStringerTag("wf-history-event-type", event.GetEventType()),
+	)
 }
 
 // cherryPickChasmEvent attempts to cherry-pick an event against the CHASM workflow tree. It mirrors cherryPickHSMEvent.

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -1144,8 +1144,6 @@ const (
 	cherryPickSkipped
 	// cherryPickFallback: this framework doesn't define the event type, so the caller should try the
 	// other framework. A component missing from this framework's tree is skipped, not a fallback.
-	// HSM and CHASM define the same event types today, so this outcome only ever reaches CHASM's
-	// registry lookup, never its cherry-pick.
 	cherryPickFallback
 )
 
@@ -1164,10 +1162,10 @@ func cherryPickHSMEvent(
 	if err := def.CherryPick(mutableState.HSM(), event, resetReapplyExcludeTypes); err != nil {
 		switch {
 		case errors.Is(err, hsm.ErrStateMachineNotFound):
-			// The op isn't in the HSM tree. On the replication reapply path it is usually in no tree at
-			// all: unlike reset, the batch is not guaranteed to share a prefix with the surviving branch,
-			// so events for operations that only existed on the discarded branch are normal. Skip rather
-			// than fall back to CHASM, whose NotFound for a missing op aborts the whole batch.
+			// The op isn't in the HSM tree. Skip rather than falling back to CHASM: on the replication
+			// path the op is usually in no tree at all, and CHASM's NotFound for a missing op would abort
+			// the whole batch. The cost is that reset reapply drops completions for CHASM-owned ops.
+			// See https://github.com/temporalio/temporal/issues/11384.
 			return cherryPickSkipped, nil
 		case errors.Is(err, hsm.ErrNotCherryPickable), errors.Is(err, hsm.ErrInvalidTransition):
 			// Recognized by HSM but intentionally not cherry-pickable here; skip without falling back.
@@ -1184,7 +1182,7 @@ func cherryPickHSMEvent(
 //
 // HSM and CHASM register the same Nexus event types, and cherryPickHSMEvent no longer falls back when a component is
 // missing from the HSM tree, so callers only reach the registry lookup below. Everything past it, including the
-// ChasmEnabled check, is unreachable until some CHASM library defines an event type HSM does not.
+// ChasmEnabled check, is unreachable until https://github.com/temporalio/temporal/issues/11384 is fixed.
 func cherryPickChasmEvent(
 	ctx context.Context,
 	mutableState historyi.MutableState,

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -2009,11 +2009,13 @@ func (l fakeChasmLibrary) CommandHandlers() map[enumspb.CommandType]chasmworkflo
 
 func (l fakeChasmLibrary) EventDefinitions() []chasmworkflow.EventDefinition { return l.defs }
 
-func newChasmRegistryWithEvent(eventType enumspb.EventType, cherryPickErr error) *chasmworkflow.Registry {
+// newChasmRegistryWithEvent registers a single fake definition. chasmworkflow.Registry.Register
+// dedupes by Go type, so one fakeChasmEventDefinition per registry is the limit.
+func (s *workflowResetterSuite) newChasmRegistryWithEvent(eventType enumspb.EventType, cherryPickErr error) *chasmworkflow.Registry {
 	reg := chasmworkflow.NewRegistry()
-	_ = reg.Register(fakeChasmLibrary{defs: []chasmworkflow.EventDefinition{
+	s.Require().NoError(reg.Register(fakeChasmLibrary{defs: []chasmworkflow.EventDefinition{
 		&fakeChasmEventDefinition{eventType: eventType, cherryPickErr: cherryPickErr},
-	}})
+	}}))
 	return reg
 }
 
@@ -2041,14 +2043,14 @@ func (s *workflowResetterSuite) TestCherryPickChasmEvent() {
 		{
 			// A CHASM-defined event on a workflow without CHASM enabled is an error, not a silent skip.
 			name:        "chasm disabled is an error",
-			registry:    newChasmRegistryWithEvent(eventType, nil),
+			registry:    s.newChasmRegistryWithEvent(eventType, nil),
 			setupMock:   func(ms *historyi.MockMutableState) { ms.EXPECT().ChasmEnabled().Return(false) },
 			wantOutcome: cherryPickSkipped,
 			wantErrMsg:  "CHASM is not enabled for this workflow",
 		},
 		{
 			name:     "component lookup error is skipped",
-			registry: newChasmRegistryWithEvent(eventType, nil),
+			registry: s.newChasmRegistryWithEvent(eventType, nil),
 			setupMock: func(ms *historyi.MockMutableState) {
 				ms.EXPECT().ChasmEnabled().Return(true)
 				ms.EXPECT().ChasmWorkflowComponent(gomock.Any()).Return(nil, nil, cherryPickErr)
@@ -2058,7 +2060,7 @@ func (s *workflowResetterSuite) TestCherryPickChasmEvent() {
 		},
 		{
 			name:     "not-cherry-pickable is skipped without error",
-			registry: newChasmRegistryWithEvent(eventType, chasmworkflow.ErrEventNotCherryPickable),
+			registry: s.newChasmRegistryWithEvent(eventType, chasmworkflow.ErrEventNotCherryPickable),
 			setupMock: func(ms *historyi.MockMutableState) {
 				ms.EXPECT().ChasmEnabled().Return(true)
 				ms.EXPECT().ChasmWorkflowComponent(gomock.Any()).Return(nil, nil, nil)
@@ -2067,7 +2069,7 @@ func (s *workflowResetterSuite) TestCherryPickChasmEvent() {
 		},
 		{
 			name:     "cherry-pick error is skipped and surfaced",
-			registry: newChasmRegistryWithEvent(eventType, cherryPickErr),
+			registry: s.newChasmRegistryWithEvent(eventType, cherryPickErr),
 			setupMock: func(ms *historyi.MockMutableState) {
 				ms.EXPECT().ChasmEnabled().Return(true)
 				ms.EXPECT().ChasmWorkflowComponent(gomock.Any()).Return(nil, nil, nil)
@@ -2077,7 +2079,7 @@ func (s *workflowResetterSuite) TestCherryPickChasmEvent() {
 		},
 		{
 			name:     "owned by chasm is applied",
-			registry: newChasmRegistryWithEvent(eventType, nil),
+			registry: s.newChasmRegistryWithEvent(eventType, nil),
 			setupMock: func(ms *historyi.MockMutableState) {
 				ms.EXPECT().ChasmEnabled().Return(true)
 				ms.EXPECT().ChasmWorkflowComponent(gomock.Any()).Return(nil, nil, nil)
@@ -2118,7 +2120,7 @@ func (s *workflowResetterSuite) TestReapplyEventsHSMToChasmFallback() {
 		ms.EXPECT().AddHistoryEvent(eventType, gomock.Any()).Return(&historypb.HistoryEvent{})
 
 		applied, err := reapplyEvents(
-			context.Background(), ms, nil, smReg, newChasmRegistryWithEvent(eventType, nil),
+			context.Background(), ms, nil, smReg, s.newChasmRegistryWithEvent(eventType, nil),
 			[]*historypb.HistoryEvent{event}, nil, "", true,
 		)
 		s.NoError(err)
@@ -2135,6 +2137,43 @@ func (s *workflowResetterSuite) TestReapplyEventsHSMToChasmFallback() {
 		s.NoError(err)
 		s.Empty(applied)
 	})
+}
+
+// TestReapplyEventsHSMNotFoundDoesNotConsultChasm pins that an operation HSM reports as missing is
+// skipped outright, even though CHASM defines the same event type and would apply it. Falling back to
+// CHASM is what regressed replication reapply: a replicated batch is not guaranteed to share a prefix
+// with the surviving branch, so events for operations that only existed on a discarded branch are
+// normal, and CHASM answers those with a NotFound that aborts the entire batch.
+func (s *workflowResetterSuite) TestReapplyEventsHSMNotFoundDoesNotConsultChasm() {
+	const eventType = enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED
+
+	// Both paths reach this branch. Replication carries events for operations that only existed on a
+	// discarded branch; reset reaches it when resetting to a point before the operation was scheduled,
+	// because ScheduledEventDefinition.CherryPick never rebuilds the operation into the new tree.
+	for _, tc := range []struct {
+		name    string
+		isReset bool
+	}{
+		{name: "replication", isReset: false},
+		{name: "reset", isReset: true},
+	} {
+		s.Run(tc.name, func() {
+			ms := historyi.NewMockMutableState(s.controller)
+			ms.EXPECT().HSM().Return(nil).AnyTimes()
+			// No ChasmEnabled expectation on purpose: cherryPickChasmEvent calls it as soon as the
+			// registry recognizes the event type, so consulting CHASM fails on an unexpected call.
+
+			applied, err := reapplyEvents(
+				context.Background(), ms, nil,
+				newHSMRegistryWithEvent(eventType, hsm.ErrStateMachineNotFound),
+				s.newChasmRegistryWithEvent(eventType, nil),
+				[]*historypb.HistoryEvent{{EventId: 5, EventType: eventType}}, nil, "", tc.isReset,
+			)
+
+			s.NoError(err, "a missing operation must not surface as an error")
+			s.Empty(applied, "the event must be skipped, not applied")
+		})
+	}
 }
 
 // fakeHSMEventDefinition is an hsm.EventDefinition whose CherryPick returns a configurable error, letting tests drive
@@ -2175,10 +2214,10 @@ func (s *workflowResetterSuite) TestCherryPickHSMEvent() {
 			wantOutcome: cherryPickFallback,
 		},
 		{
-			name:        "state machine not found falls back",
+			name:        "state machine not found is skipped without falling back",
 			registry:    newHSMRegistryWithEvent(eventType, hsm.ErrStateMachineNotFound),
 			expectHSM:   true,
-			wantOutcome: cherryPickFallback,
+			wantOutcome: cherryPickSkipped,
 		},
 		{
 			name:        "not-cherry-pickable is skipped without error",

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -2141,39 +2141,27 @@ func (s *workflowResetterSuite) TestReapplyEventsHSMToChasmFallback() {
 
 // TestReapplyEventsHSMNotFoundDoesNotConsultChasm pins that an operation HSM reports as missing is
 // skipped outright, even though CHASM defines the same event type and would apply it. Falling back to
-// CHASM is what regressed replication reapply: a replicated batch is not guaranteed to share a prefix
-// with the surviving branch, so events for operations that only existed on a discarded branch are
-// normal, and CHASM answers those with a NotFound that aborts the entire batch.
+// CHASM is what regressed replication reapply; see https://github.com/temporalio/temporal/issues/11384.
 func (s *workflowResetterSuite) TestReapplyEventsHSMNotFoundDoesNotConsultChasm() {
 	const eventType = enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED
 
-	// Both paths reach this branch. Replication carries events for operations that only existed on a
-	// discarded branch; reset reaches it when resetting to a point before the operation was scheduled,
-	// because ScheduledEventDefinition.CherryPick never rebuilds the operation into the new tree.
-	for _, tc := range []struct {
-		name    string
-		isReset bool
-	}{
-		{name: "replication", isReset: false},
-		{name: "reset", isReset: true},
-	} {
-		s.Run(tc.name, func() {
-			ms := historyi.NewMockMutableState(s.controller)
-			ms.EXPECT().HSM().Return(nil).AnyTimes()
-			// No ChasmEnabled expectation on purpose: cherryPickChasmEvent calls it as soon as the
-			// registry recognizes the event type, so consulting CHASM fails on an unexpected call.
+	// Both reset and replication reach this branch, and one case covers both: reapplyEvents reads
+	// isReset only in the hardcoded CancelRequested and Terminated cases, which a Nexus event never
+	// reaches.
+	ms := historyi.NewMockMutableState(s.controller)
+	ms.EXPECT().HSM().Return(nil).AnyTimes()
+	// No ChasmEnabled expectation on purpose: cherryPickChasmEvent calls it as soon as the registry
+	// recognizes the event type, so consulting CHASM fails on an unexpected call.
 
-			applied, err := reapplyEvents(
-				context.Background(), ms, nil,
-				newHSMRegistryWithEvent(eventType, hsm.ErrStateMachineNotFound),
-				s.newChasmRegistryWithEvent(eventType, nil),
-				[]*historypb.HistoryEvent{{EventId: 5, EventType: eventType}}, nil, "", tc.isReset,
-			)
+	applied, err := reapplyEvents(
+		context.Background(), ms, nil,
+		newHSMRegistryWithEvent(eventType, hsm.ErrStateMachineNotFound),
+		s.newChasmRegistryWithEvent(eventType, nil),
+		[]*historypb.HistoryEvent{{EventId: 5, EventType: eventType}}, nil, "", false,
+	)
 
-			s.NoError(err, "a missing operation must not surface as an error")
-			s.Empty(applied, "the event must be skipped, not applied")
-		})
-	}
+	s.NoError(err, "a missing operation must not surface as an error")
+	s.Empty(applied, "the event must be skipped, not applied")
 }
 
 // fakeHSMEventDefinition is an hsm.EventDefinition whose CherryPick returns a configurable error, letting tests drive

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -31,11 +31,13 @@ import (
 	"go.temporal.io/server/common/failure"
 	"go.temporal.io/server/common/locks"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/versionhistory"
+	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/components/nexusoperations"
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/hsm"
@@ -1197,7 +1199,7 @@ func (s *workflowResetterSuite) TestReapplyEvents_WithPendingChildren() {
 
 		for _, tc := range testcases {
 			s.Run(tc.name+" "+tcReset.name, func() {
-				_, err := reapplyEvents(context.Background(), mutableState, nil, nil, chasmworkflow.NewRegistry(), tc.events, nil, "", tcReset.isReset)
+				_, err := reapplyEvents(context.Background(), mutableState, nil, nil, chasmworkflow.NewRegistry(), tc.events, nil, "", tcReset.isReset, s.logger)
 				s.NoError(err)
 			})
 		}
@@ -1264,7 +1266,7 @@ func (s *workflowResetterSuite) TestReapplyEvents_WithNoPendingChildren() {
 
 		for _, tc := range testCases {
 			s.Run(tc.name+" "+tcReset.name, func() {
-				_, err := reapplyEvents(context.Background(), mutableState, nil, nil, chasmworkflow.NewRegistry(), tc.events, nil, "", tcReset.isReset)
+				_, err := reapplyEvents(context.Background(), mutableState, nil, nil, chasmworkflow.NewRegistry(), tc.events, nil, "", tcReset.isReset, s.logger)
 				s.NoError(err)
 			})
 		}
@@ -1499,7 +1501,7 @@ func (s *workflowResetterSuite) TestReapplyEvents() {
 				}
 			}
 
-			appliedEvents, err := reapplyEvents(context.Background(), ms, nil, smReg, chasmworkflow.NewRegistry(), events, nil, "", tc.isReset)
+			appliedEvents, err := reapplyEvents(context.Background(), ms, nil, smReg, chasmworkflow.NewRegistry(), events, nil, "", tc.isReset, s.logger)
 			s.NoError(err)
 
 			s.Equal(tc.expected, appliedEvents)
@@ -1570,7 +1572,7 @@ func (s *workflowResetterSuite) TestReapplyEvents_Excludes() {
 		enumspb.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: {},
 		enumspb.RESET_REAPPLY_EXCLUDE_TYPE_NEXUS:  {},
 	}
-	reappliedEvents, err := reapplyEvents(context.Background(), ms, nil, smReg, chasmworkflow.NewRegistry(), events, excludes, "", false)
+	reappliedEvents, err := reapplyEvents(context.Background(), ms, nil, smReg, chasmworkflow.NewRegistry(), events, excludes, "", false, s.logger)
 	s.Empty(reappliedEvents)
 	s.NoError(err)
 
@@ -1596,7 +1598,7 @@ func (s *workflowResetterSuite) TestReapplyEvents_Excludes() {
 		},
 	}
 	events = append(events, event7, event8)
-	reappliedEvents, err = reapplyEvents(context.Background(), ms, nil, smReg, chasmworkflow.NewRegistry(), events, excludes, "", true)
+	reappliedEvents, err = reapplyEvents(context.Background(), ms, nil, smReg, chasmworkflow.NewRegistry(), events, excludes, "", true, s.logger)
 	s.Empty(reappliedEvents)
 	s.NoError(err)
 }
@@ -1891,7 +1893,7 @@ func (s *workflowResetterSuite) TestReapplyEvents_WorkflowOptionsUpdated_Complet
 			events := []*historypb.HistoryEvent{event}
 
 			// Call reapplyEvents and expect an error
-			appliedEvents, err := reapplyEvents(context.Background(), ms, nil, smReg, chasmworkflow.NewRegistry(), events, nil, "", true)
+			appliedEvents, err := reapplyEvents(context.Background(), ms, nil, smReg, chasmworkflow.NewRegistry(), events, nil, "", true, s.logger)
 			s.Error(err)
 			s.Contains(err.Error(), tc.expectedErrorContains)
 			s.Empty(appliedEvents)
@@ -1939,7 +1941,7 @@ func (s *workflowResetterSuite) TestReapplyEvents_WorkflowOptionsUpdated_Complet
 	events := []*historypb.HistoryEvent{event}
 
 	// Call reapplyEvents - should skip the event (no error, no applied events)
-	appliedEvents, err := reapplyEvents(context.Background(), ms, nil, smReg, chasmworkflow.NewRegistry(), events, nil, "", true)
+	appliedEvents, err := reapplyEvents(context.Background(), ms, nil, smReg, chasmworkflow.NewRegistry(), events, nil, "", true, s.logger)
 	s.NoError(err)
 	s.Empty(appliedEvents) // Event should be skipped
 }
@@ -1977,7 +1979,7 @@ func (s *workflowResetterSuite) TestReapplyEvents_WorkflowOptionsUpdated_WithTim
 		attr.GetWorkflowUpdateOptions(),
 	).Return(&historypb.HistoryEvent{}, nil)
 
-	appliedEvents, err := reapplyEvents(context.Background(), ms, nil, smReg, chasmworkflow.NewRegistry(), []*historypb.HistoryEvent{event}, nil, "", true)
+	appliedEvents, err := reapplyEvents(context.Background(), ms, nil, smReg, chasmworkflow.NewRegistry(), []*historypb.HistoryEvent{event}, nil, "", true, s.logger)
 	s.NoError(err)
 	s.Len(appliedEvents, 1)
 }
@@ -2121,7 +2123,7 @@ func (s *workflowResetterSuite) TestReapplyEventsHSMToChasmFallback() {
 
 		applied, err := reapplyEvents(
 			context.Background(), ms, nil, smReg, s.newChasmRegistryWithEvent(eventType, nil),
-			[]*historypb.HistoryEvent{event}, nil, "", true,
+			[]*historypb.HistoryEvent{event}, nil, "", true, s.logger,
 		)
 		s.NoError(err)
 		s.Equal([]*historypb.HistoryEvent{event}, applied)
@@ -2132,7 +2134,7 @@ func (s *workflowResetterSuite) TestReapplyEventsHSMToChasmFallback() {
 
 		applied, err := reapplyEvents(
 			context.Background(), ms, nil, smReg, chasmworkflow.NewRegistry(),
-			[]*historypb.HistoryEvent{event}, nil, "", true,
+			[]*historypb.HistoryEvent{event}, nil, "", true, s.logger,
 		)
 		s.NoError(err)
 		s.Empty(applied)
@@ -2150,6 +2152,7 @@ func (s *workflowResetterSuite) TestReapplyEventsHSMNotFoundDoesNotConsultChasm(
 	// reaches.
 	ms := historyi.NewMockMutableState(s.controller)
 	ms.EXPECT().HSM().Return(nil).AnyTimes()
+	ms.EXPECT().GetWorkflowKey().Return(tests.WorkflowKey).AnyTimes()
 	// No ChasmEnabled expectation on purpose: cherryPickChasmEvent calls it as soon as the registry
 	// recognizes the event type, so consulting CHASM fails on an unexpected call.
 
@@ -2157,7 +2160,7 @@ func (s *workflowResetterSuite) TestReapplyEventsHSMNotFoundDoesNotConsultChasm(
 		context.Background(), ms, nil,
 		newHSMRegistryWithEvent(eventType, hsm.ErrStateMachineNotFound),
 		s.newChasmRegistryWithEvent(eventType, nil),
-		[]*historypb.HistoryEvent{{EventId: 5, EventType: eventType}}, nil, "", false,
+		[]*historypb.HistoryEvent{{EventId: 5, EventType: eventType}}, nil, "", false, s.logger,
 	)
 
 	s.NoError(err, "a missing operation must not surface as an error")
@@ -2186,15 +2189,20 @@ func newHSMRegistryWithEvent(eventType enumspb.EventType, cherryPickErr error) *
 
 func (s *workflowResetterSuite) TestCherryPickHSMEvent() {
 	const eventType = enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED
-	event := &historypb.HistoryEvent{EventType: eventType}
+	event := &historypb.HistoryEvent{EventId: 5, EventType: eventType}
 	cherryPickErr := errors.New("cherry-pick failed")
+	workflowKey := definition.NewWorkflowKey("test-namespace-id", "test-workflow-id", "test-run-id")
+	warnLevel, debugLevel := testlogger.Warn, testlogger.Debug
 
 	testCases := []struct {
 		name        string
 		registry    *hsm.Registry
 		expectHSM   bool
+		isReset     bool
 		wantOutcome cherryPickOutcome
 		wantErr     error
+		// wantSkipLog, when set, is the level the missing-component log line must be emitted at.
+		wantSkipLog *testlogger.Level
 	}{
 		{
 			name:        "event type unknown to hsm falls back",
@@ -2202,10 +2210,19 @@ func (s *workflowResetterSuite) TestCherryPickHSMEvent() {
 			wantOutcome: cherryPickFallback,
 		},
 		{
-			name:        "state machine not found is skipped without falling back",
+			name:        "state machine not found on the reset path warns",
+			registry:    newHSMRegistryWithEvent(eventType, hsm.ErrStateMachineNotFound),
+			expectHSM:   true,
+			isReset:     true,
+			wantOutcome: cherryPickSkipped,
+			wantSkipLog: &warnLevel,
+		},
+		{
+			name:        "state machine not found on the replication path only logs at debug",
 			registry:    newHSMRegistryWithEvent(eventType, hsm.ErrStateMachineNotFound),
 			expectHSM:   true,
 			wantOutcome: cherryPickSkipped,
+			wantSkipLog: &debugLevel,
 		},
 		{
 			name:        "not-cherry-pickable is skipped without error",
@@ -2241,13 +2258,25 @@ func (s *workflowResetterSuite) TestCherryPickHSMEvent() {
 				ms.EXPECT().HSM().Return(nil)
 			}
 
-			outcome, err := cherryPickHSMEvent(ms, tc.registry, event, nil)
+			logger := testlogger.NewTestLogger(s.T(), testlogger.FailOnAnyUnexpectedError)
+			var skipLog *testlogger.Expectation
+			if tc.wantSkipLog != nil {
+				// Pin the run ID too: the log line is only actionable if it identifies the workflow.
+				ms.EXPECT().GetWorkflowKey().Return(workflowKey)
+				skipLog = logger.Expect(*tc.wantSkipLog, "state machine not found in HSM tree",
+					tag.WorkflowRunID(workflowKey.RunID))
+			}
+
+			outcome, err := cherryPickHSMEvent(ms, tc.registry, event, nil, tc.isReset, logger)
 
 			s.Equal(tc.wantOutcome, outcome)
 			if tc.wantErr != nil {
 				s.ErrorIs(err, tc.wantErr)
 			} else {
 				s.NoError(err)
+			}
+			if skipLog != nil {
+				s.True(skipLog.Matched(), "expected the skipped-operation line at the %v level", *tc.wantSkipLog)
 			}
 		})
 	}

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -1205,12 +1205,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletion(chasmEnabled 
 	s.Empty(hist[wftCompletedIdx].Links)
 	wftCompletedEventID := hist[wftCompletedIdx].EventId
 
-	// Reset reapply of a Nexus completion is HSM-only: cherryPickHSMEvent skips an operation missing
-	// from the HSM tree rather than falling back to CHASM.
-	if chasmEnabled {
-		return
-	}
-
 	// Reset the workflow and check that the completion event has been reapplied.
 	resp, err := env.FrontendClient().ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
 		Namespace:                 env.Namespace().String(),
@@ -1222,7 +1216,14 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletion(chasmEnabled 
 	s.NoError(err)
 
 	resetHist1 := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: resp.RunId})
-	s.RequireHistoryEvent(resetHist1, enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED)
+	if chasmEnabled {
+		// Reset reapply is HSM-only, so a CHASM-owned operation's completion is not reapplied, though
+		// the reset itself must still succeed. Becomes RequireHistoryEvent on both rails once
+		// https://github.com/temporalio/temporal/issues/11384 is fixed.
+		s.RequireNoHistoryEvent(resetHist1, enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED)
+	} else {
+		s.RequireHistoryEvent(resetHist1, enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED)
+	}
 
 	// Reset the workflow again to the same point with enumspb.RESET_REAPPLY_EXCLUDE_TYPE_NEXUS option
 	// and verify that the completion event has been excluded.

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -1205,6 +1205,12 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletion(chasmEnabled 
 	s.Empty(hist[wftCompletedIdx].Links)
 	wftCompletedEventID := hist[wftCompletedIdx].EventId
 
+	// Reset reapply of a Nexus completion is HSM-only: cherryPickHSMEvent skips an operation missing
+	// from the HSM tree rather than falling back to CHASM.
+	if chasmEnabled {
+		return
+	}
+
 	// Reset the workflow and check that the completion event has been reapplied.
 	resp, err := env.FrontendClient().ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
 		Namespace:                 env.Namespace().String(),


### PR DESCRIPTION
## What changed?

`cherryPickHSMEvent` treats `hsm.ErrStateMachineNotFound` as skippable again instead of routing the event to the CHASM tree, restoring the behavior from before #10986. That is the whole behavior change — one line.

- `service/history/ndc/workflow_resetter.go` — the routing change, plus comment cleanup on the surrounding cherry-pick helpers.
- `service/history/ndc/workflow_resetter_test.go` — updated the existing `state machine not found` case, and added `TestReapplyEventsHSMNotFoundDoesNotConsultChasm`, which asserts the event is skipped, no error surfaces, and CHASM is **never consulted**.
- `tests/nexus_workflow_test.go` — the post-reset assertion in `TestNexusOperationAsyncCompletion` now branches on the rail: `RequireHistoryEvent` on HSM, `RequireNoHistoryEvent` on CHASM. Both resets still run on both rails, so the `RESET_REAPPLY_EXCLUDE_TYPE_NEXUS` coverage and the "reset itself still succeeds" assertion are kept on the CHASM rail.

## Why?

**Full background, root cause, and the shape of the real fix are captured in #11384.** In short: reapply cannot distinguish "the CHASM tree owns this Nexus operation" from "no tree owns it", because CHASM answers a missing operation with a bare `serviceerror.NotFound`. Reapply is fail-fast and `BackfillWorkflow` commits only on a clean return, so one such event discards an entire replication batch — including completions already applied earlier in the same batch.

This was diagnosed against an MCN handover failure in `TestReconfigureMCNReplicaWithBenchGoOnTestEnv`, where one Nexus operation's completion was applied at batch index 0 and then discarded 80 times because an unrelated operation at index 8 existed in neither tree.

The reset path is affected too, not only replication, which rules out the narrower fix of gating the fallback on `!isReset`. Details in #11384.

**This PR is the workaround, not the fix.** It restores pre-#10986 skip semantics so the failures stop; #11384 tracks doing it properly.

## How did you test it?

- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

Verified locally on sqlite:

| scope | result |
|---|---|
| `service/history/ndc` unit tests | green |
| Nexus + Callbacks + Reset + Workflow functional suites | 648 PASS / 0 FAIL |
| XDC Nexus state replication, all 3 variants incl. `Chasm` | 19 PASS / 0 FAIL |
| `TestNexusOperationAsyncCompletion`, both HSM and CHASM rails | PASS |

Both new assertions are mutation-checked rather than merely green. Restoring the fallback:

- fails the unit test on an unexpected `ChasmEnabled()` call, and
- fails the CHASM functional test at the post-reset `RequireNoHistoryEvent`.

Across the three functional test files touched by CHASM Nexus work since #10986 (`nexus_workflow_test.go`, `nexus_standalone_test.go`, `xdc/nexus_state_replication_test.go`), exactly one assertion depended on the fallback — the one now branched on the rail. `TestNexusOperationSurvivesResetCrossTree`, both cancellation cross-tree tests, and `TestNexusOperationChasmReplicatedWithMixedFlag` all pass unchanged.

## Review iteration

This went through several rounds of review, which changed the test strategy more than the fix. Worth knowing if you're re-reading after an earlier round:

- The functional-test guard started as a top-of-test `Skip`, became a mid-test early `return`, and is now a per-rail branch on the single assertion that actually differs. The earlier forms dropped passing CHASM coverage (completion-token validation, the async-completion happy path, and the exclude-types block) as collateral.
- The new unit test started as a nine-subtest loop over every Nexus event type, then two subtests over `isReset`, and is now a single case. Both loops were vacuous: `chasmworkflow.Registry.Register` dedupes by Go type so only one definition ever registered, and `reapplyEvents` reads `isReset` only in the hardcoded `CancelRequested` / `Terminated` cases, which a Nexus event never reaches.
- Several rounds went into comment accuracy around what is and isn't reachable after this change. Those comments are now short and defer to #11384 rather than restating the analysis in four places.

## Potential risks

**This does not itself demonstrate the MCN handover failure is fixed.** The failure is a replication branch-fork under handover, which no local test constructs; validation needs the bench-go repro (~1 in 2–3 hit rate). Local results show the fix restores pre-#10986 skip semantics without collateral damage, nothing more.

Reset reapply of a Nexus completion for a CHASM-tree operation is silently skipped again — the bug #10986 fixed. Unreachable while CHASM Nexus operations are not rolled out, but the feature cannot ship until #11384 is addressed. The CHASM-rail assertion in `TestNexusOperationAsyncCompletion` pins that regression, so it will flip to `RequireHistoryEvent` as part of the real fix rather than being forgotten.

Two related defects are left in place deliberately, since neither is reachable once the fallback is gone: CHASM's bare `NotFound` on a missing operation, and `cherryPickChasmEvent` returning `serviceerror.Internal` when CHASM is disabled. Both are tracked in #11384, along with the `TODO(follow-up)` about completion-token resolution that this PR removes from the code.
