### PR TITLE
Scheduler (CHASM): resolve catchup window in describe

### DIFF
--- a/chasm/lib/scheduler/export_test.go
+++ b/chasm/lib/scheduler/export_test.go
@@ -44,6 +44,13 @@ func (i *Invoker) RunningWorkflowID(requestID string) string {
 	return i.runningWorkflowID(requestID)
 }
 
+func ContextWithTweakables(ctx chasm.Context, tweakables Tweakables) chasm.Context {
+	config := Config{
+		Tweakables: func(string) Tweakables { return tweakables },
+	}
+	return chasm.ContextWithValue(ctx, tweakablesCtxKey, config.Tweakables)
+}
+
 // RecentActionCount exposes the completed-retention limit for tests.
 const RecentActionCount = recentActionCount
 

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -697,10 +697,9 @@ func (s *Scheduler) Describe(
 	if schedule.GetPolicies().GetOverlapPolicy() == enumspb.SCHEDULE_OVERLAP_POLICY_UNSPECIFIED {
 		schedule.Policies.OverlapPolicy = s.overlapPolicy()
 	}
-	if !schedule.GetPolicies().GetCatchupWindow().IsValid() {
-		// TODO - this should be set from Tweakables.DefaultCatchupWindow.
-		schedule.Policies.CatchupWindow = durationpb.New(365 * 24 * time.Hour)
-	}
+	schedule.Policies.CatchupWindow = durationpb.New(
+		catchupWindow(s, tweakablesFromContext(ctx)),
+	)
 	cleanSpec(schedule.Spec)
 
 	generator := s.Generator.Get(ctx)

--- a/chasm/lib/scheduler/scheduler_test.go
+++ b/chasm/lib/scheduler/scheduler_test.go
@@ -778,24 +778,20 @@ func TestScheduler_Describe_ResolvesCatchupWindowFromTweakables(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		window   time.Duration
+		window   *durationpb.Duration
 		expected time.Duration
 	}{
-		{name: "unset", expected: tweakables.DefaultCatchupWindow},
-		{name: "zero", window: 0, expected: tweakables.DefaultCatchupWindow},
-		{name: "negative", window: -time.Second, expected: tweakables.DefaultCatchupWindow},
-		{name: "below minimum", window: time.Minute, expected: tweakables.MinCatchupWindow},
-		{name: "above minimum", window: time.Hour, expected: time.Hour},
+		{name: "unset", window: nil, expected: tweakables.DefaultCatchupWindow},
+		{name: "zero", window: durationpb.New(0), expected: tweakables.DefaultCatchupWindow},
+		{name: "negative", window: durationpb.New(-time.Second), expected: tweakables.DefaultCatchupWindow},
+		{name: "below minimum", window: durationpb.New(time.Minute), expected: tweakables.MinCatchupWindow},
+		{name: "above minimum", window: durationpb.New(time.Hour), expected: time.Hour},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			sched, ctx, _ := setupSchedulerForTest(t)
-			if tc.name == "unset" {
-				sched.Schedule.Policies.CatchupWindow = nil
-			} else {
-				sched.Schedule.Policies.CatchupWindow = durationpb.New(tc.window)
-			}
+			sched.Schedule.Policies.CatchupWindow = tc.window
 			persistedWindow := sched.Schedule.Policies.CatchupWindow
 
 			resp, err := sched.Describe(

--- a/chasm/lib/scheduler/scheduler_test.go
+++ b/chasm/lib/scheduler/scheduler_test.go
@@ -23,6 +23,7 @@ import (
 	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/service/history/tasks"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -768,4 +769,43 @@ func TestScheduler_Describe_DoesNotMutateCachedComponent(t *testing.T) {
 		"Describe must not write the default catch-up window back onto the cached component")
 	require.Nil(t, generator.GetFutureActionTimes(),
 		"Describe must not store computed FutureActionTimes back onto the Generator")
+}
+
+func TestScheduler_Describe_ResolvesCatchupWindowFromTweakables(t *testing.T) {
+	tweakables := scheduler.DefaultTweakables
+	tweakables.DefaultCatchupWindow = 2 * time.Hour
+	tweakables.MinCatchupWindow = 5 * time.Minute
+
+	testCases := []struct {
+		name     string
+		window   time.Duration
+		expected time.Duration
+	}{
+		{name: "unset", expected: tweakables.DefaultCatchupWindow},
+		{name: "zero", window: 0, expected: tweakables.DefaultCatchupWindow},
+		{name: "negative", window: -time.Second, expected: tweakables.DefaultCatchupWindow},
+		{name: "below minimum", window: time.Minute, expected: tweakables.MinCatchupWindow},
+		{name: "above minimum", window: time.Hour, expected: time.Hour},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sched, ctx, _ := setupSchedulerForTest(t)
+			if tc.name == "unset" {
+				sched.Schedule.Policies.CatchupWindow = nil
+			} else {
+				sched.Schedule.Policies.CatchupWindow = durationpb.New(tc.window)
+			}
+			persistedWindow := sched.Schedule.Policies.CatchupWindow
+
+			resp, err := sched.Describe(
+				scheduler.ContextWithTweakables(ctx, tweakables),
+				&schedulerpb.DescribeScheduleRequest{},
+				newLegacySpecBuilder(0, 0),
+			)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, resp.GetFrontendResponse().GetSchedule().GetPolicies().GetCatchupWindow().AsDuration())
+			require.Same(t, persistedWindow, sched.Schedule.Policies.CatchupWindow)
+		})
+	}
 }

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -421,6 +421,10 @@ func TestScheduleCHASM(t *testing.T) {
 	t.Run("TestUpdateScheduleMemoOnly", func(t *testing.T) { t.Parallel(); testUpdateScheduleMemoOnly(t, newContext) })
 	t.Run("TestStateSizeBytesReported", func(t *testing.T) { t.Parallel(); testStateSizeBytesReported(t, newContext) })
 	t.Run("TestBufferOverrunDropsActions", func(t *testing.T) { t.Parallel(); testBufferOverrunDropsActions(t, newContext) })
+	t.Run("TestDescribeCatchupWindowAfterCreateAndUpdate", func(t *testing.T) {
+		t.Parallel()
+		testDescribeCatchupWindowAfterCreateAndUpdate(t)
+	})
 	t.Run("IdleClose", func(t *testing.T) {
 		t.Parallel()
 		testScheduleClosesFromIdle(t, newContext)
@@ -444,6 +448,56 @@ func TestScheduleCHASM(t *testing.T) {
 		t.Parallel()
 		testPauseOnFailureIgnoresCancelTerminate(t, newContext, stopByTerminate)
 	})
+}
+
+func testDescribeCatchupWindowAfterCreateAndUpdate(t *testing.T) {
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+
+	ctx := chasmContextFactory(t.Context())
+	sid := testcore.RandomizeStr("sched-catchup-window-desc")
+	schedule := &schedulepb.Schedule{
+		Spec:     intervalSpec(noOpInterval),
+		Action:   startWorkflowAction(s, "catchup-window-wf", "catchup-window-wt"),
+		Policies: &schedulepb.SchedulePolicies{},
+		State:    &schedulepb.ScheduleState{Paused: true},
+	}
+	createSchedule(ctx, t, s, sid, schedule)
+
+	describe := func(t *testing.T) time.Duration {
+		t.Helper()
+		resp, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+		})
+		require.NoError(t, err)
+		return resp.GetSchedule().GetPolicies().GetCatchupWindow().AsDuration()
+	}
+	require.Equal(t, chasmscheduler.DefaultTweakables.DefaultCatchupWindow, describe(t))
+
+	updates := []struct {
+		name     string
+		window   time.Duration
+		expected time.Duration
+	}{
+		{name: "zero", expected: chasmscheduler.DefaultTweakables.DefaultCatchupWindow},
+		{name: "negative", window: -time.Second, expected: chasmscheduler.DefaultTweakables.DefaultCatchupWindow},
+		{name: "below minimum", window: time.Second, expected: chasmscheduler.DefaultTweakables.MinCatchupWindow},
+		{name: "above minimum", window: time.Hour, expected: time.Hour},
+	}
+	for _, tc := range updates {
+		t.Run(tc.name, func(t *testing.T) {
+			schedule.Policies.CatchupWindow = durationpb.New(tc.window)
+			_, err := s.FrontendClient().UpdateSchedule(ctx, &workflowservice.UpdateScheduleRequest{
+				Namespace:  s.Namespace().String(),
+				ScheduleId: sid,
+				Schedule:   schedule,
+				Identity:   "test",
+				RequestId:  uuid.NewString(),
+			})
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, describe(t))
+		})
+	}
 }
 
 func TestScheduleV1(t *testing.T) {

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -39,6 +39,7 @@ import (
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/protorequire"
+	"go.temporal.io/server/common/testing/testcontext"
 	"go.temporal.io/server/service/worker/dummy"
 	"go.temporal.io/server/service/worker/scheduler"
 	"go.temporal.io/server/tests/testcore"
@@ -453,7 +454,7 @@ func TestScheduleCHASM(t *testing.T) {
 func testDescribeCatchupWindowAfterCreateAndUpdate(t *testing.T) {
 	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
 
-	ctx := chasmContextFactory(t.Context())
+	ctx := chasmContextFactory(testcontext.For(t))
 	sid := testcore.RandomizeStr("sched-catchup-window-desc")
 	schedule := &schedulepb.Schedule{
 		Spec:     intervalSpec(noOpInterval),
@@ -476,17 +477,18 @@ func testDescribeCatchupWindowAfterCreateAndUpdate(t *testing.T) {
 
 	updates := []struct {
 		name     string
-		window   time.Duration
+		window   *durationpb.Duration
 		expected time.Duration
 	}{
-		{name: "zero", expected: chasmscheduler.DefaultTweakables.DefaultCatchupWindow},
-		{name: "negative", window: -time.Second, expected: chasmscheduler.DefaultTweakables.DefaultCatchupWindow},
-		{name: "below minimum", window: time.Second, expected: chasmscheduler.DefaultTweakables.MinCatchupWindow},
-		{name: "above minimum", window: time.Hour, expected: time.Hour},
+		{name: "unset", expected: chasmscheduler.DefaultTweakables.DefaultCatchupWindow},
+		{name: "zero", window: durationpb.New(0), expected: chasmscheduler.DefaultTweakables.DefaultCatchupWindow},
+		{name: "negative", window: durationpb.New(-time.Second), expected: chasmscheduler.DefaultTweakables.DefaultCatchupWindow},
+		{name: "below minimum", window: durationpb.New(time.Second), expected: chasmscheduler.DefaultTweakables.MinCatchupWindow},
+		{name: "above minimum", window: durationpb.New(time.Hour), expected: time.Hour},
 	}
 	for _, tc := range updates {
 		t.Run(tc.name, func(t *testing.T) {
-			schedule.Policies.CatchupWindow = durationpb.New(tc.window)
+			schedule.Policies.CatchupWindow = tc.window
 			_, err := s.FrontendClient().UpdateSchedule(ctx, &workflowservice.UpdateScheduleRequest{
 				Namespace:  s.Namespace().String(),
 				ScheduleId: sid,


### PR DESCRIPTION
## What changed?

Updated the CHASM scheduler's DescribeSchedule response to resolve the effective catchup window using the namespace's scheduler tweakables.

DescribeSchedule now reports:
- nil, zero, or negative values as `DefaultCatchupWindow`
- positive values below the minimum as `MinCatchupWindow`
- values at or above the minimum unchanged

The resolution is applied to a cloned schedule, leaving persisted scheduler state unchanged.

## Why?

DescribeSchedule previously used a hard-coded one-year default and did not consistently report the same effective catchup window used during schedule processing.

Using the existing catchup-window resolver keeps DescribeSchedule consistent with runtime behavior and namespace-specific dynamic configuration.

## V1 and V2 behavior

V1 and V2 currently differ when the configured catchup window is zero or negative:

- V1 treats zero or negative values as below the minimum and resolves them to `MinCatchupWindow`.
- V2 treats zero or negative values as unset and resolves them to `DefaultCatchupWindow`.
- Both implementations clamp positive values below the minimum to `MinCatchupWindow`.

This PR changes only the CHASM/V2 DescribeSchedule path and does not modify V1 behavior.

## How did you test it?

- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

Commands run:

- `go test -tags test_dep ./chasm/lib/scheduler`
- `go test -tags test_dep ./tests -run 'TestScheduleCHASM/TestDescribeCatchupWindowAfterCreateAndUpdate' -count=1`
- `make lint-code`

`testBasics` already performs create→describe and update→describe, including the unset/default case, but it is shared by V1 and V2. Since zero/negative semantics currently differ between the implementations, adding those cases there would break V1 coverage. A focused CHASM-only functional test was added instead.

The CHASM-only test covers create with an unset catchup window, followed by updates with zero, negative, positive-below-minimum, and above-minimum values.

Local testing:
1. http://localhost:3000/ + UI side override to allow <10 secs
2. Create schedule with catchup window 0 secs. Load it and verify it shows as 10 secs.
3. DC changes to switch to CHASM. Repeat(2) to verify its set as 1 year.

## Potential risks

DescribeSchedule now returns the effective catchup window rather than the raw persisted value for non-positive and below-minimum values. This matches the value used by CHASM schedule processing.

### V1 and V2 migration

This PR changes only the CHASM DescribeSchedule response. It does not normalize the persisted schedule policy or change migration payloads, so the existing migration behavior remains:

- **V1 → V2:** V1 eagerly normalizes zero or negative values to an explicit `MinCatchupWindow`. Migration copies that positive duration, so V2 continues using the minimum.
- **V2 → V1:** V2 persists the original zero or negative value and treats it as unset/default at runtime. Migration currently copies that raw value. V1 then resolves it to `MinCatchupWindow`, potentially changing the effective behavior from the V2 default to the V1 minimum.
- **Unset:** The target implementation resolves the unset value using its own default. Behavior could change if the source and target defaults differ.
- **Positive below minimum:** The target implementation applies its own minimum. Behavior could change if the source and target minimums differ.
- **At or above minimum:** The explicit value is preserved across migration.

Resolving or persisting the effective catchup window during migration is outside the scope of this PR.
