### PR TITLE
Recover orphaned child workflows after force failover

### DIFF
--- a/api/historyservice/v1/request_response.pb.go
+++ b/api/historyservice/v1/request_response.pb.go
@@ -202,8 +202,8 @@ type StartWorkflowExecutionRequest struct {
 	// WorkflowExecutionStartedEvent.
 	DeclinedTargetVersionUpgrade *v17.DeclinedTargetVersionUpgrade `protobuf:"bytes,17,opt,name=declined_target_version_upgrade,json=declinedTargetVersionUpgrade,proto3" json:"declined_target_version_upgrade,omitempty"`
 	TimeSkippingStatePropagation *v14.TimeSkippingStatePropagation `protobuf:"bytes,19,opt,name=time_skipping_state_propagation,json=timeSkippingStatePropagation,proto3" json:"time_skipping_state_propagation,omitempty"`
-	// Allows a parent retrying an orphaned child start after failover to replace its own open child.
-	// Ownership is verified while holding the conflicting execution's lock.
+	// Set when the parent has established that a conflicting execution can only be its own child, orphaned by an
+	// initiation that lost conflict resolution after a force failover.
 	ZombifyConflictingChild bool `protobuf:"varint,20,opt,name=zombify_conflicting_child,json=zombifyConflictingChild,proto3" json:"zombify_conflicting_child,omitempty"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache

--- a/api/historyservice/v1/request_response.pb.go
+++ b/api/historyservice/v1/request_response.pb.go
@@ -202,8 +202,11 @@ type StartWorkflowExecutionRequest struct {
 	// WorkflowExecutionStartedEvent.
 	DeclinedTargetVersionUpgrade *v17.DeclinedTargetVersionUpgrade `protobuf:"bytes,17,opt,name=declined_target_version_upgrade,json=declinedTargetVersionUpgrade,proto3" json:"declined_target_version_upgrade,omitempty"`
 	TimeSkippingStatePropagation *v14.TimeSkippingStatePropagation `protobuf:"bytes,19,opt,name=time_skipping_state_propagation,json=timeSkippingStatePropagation,proto3" json:"time_skipping_state_propagation,omitempty"`
-	unknownFields                protoimpl.UnknownFields
-	sizeCache                    protoimpl.SizeCache
+	// Allows a parent retrying an orphaned child start after failover to replace its own open child.
+	// Ownership is verified while holding the conflicting execution's lock.
+	ZombifyConflictingChild bool `protobuf:"varint,20,opt,name=zombify_conflicting_child,json=zombifyConflictingChild,proto3" json:"zombify_conflicting_child,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
 }
 
 func (x *StartWorkflowExecutionRequest) Reset() {
@@ -360,6 +363,13 @@ func (x *StartWorkflowExecutionRequest) GetTimeSkippingStatePropagation() *v14.T
 		return x.TimeSkippingStatePropagation
 	}
 	return nil
+}
+
+func (x *StartWorkflowExecutionRequest) GetZombifyConflictingChild() bool {
+	if x != nil {
+		return x.ZombifyConflictingChild
+	}
+	return false
 }
 
 type StartWorkflowExecutionResponse struct {
@@ -10713,7 +10723,7 @@ const file_temporal_server_api_historyservice_v1_request_response_proto_rawDesc 
 	"task_token\x18\x06 \x01(\tR\ttaskToken\x12\x1d\n" +
 	"\n" +
 	"task_infos\x18\a \x01(\tR\ttaskInfos\x12.\n" +
-	"\x13chasm_component_ref\x18\b \x01(\tR\x11chasmComponentRef\"\x84\r\n" +
+	"\x13chasm_component_ref\x18\b \x01(\tR\x11chasmComponentRef\"\xc0\r\n" +
 	"\x1dStartWorkflowExecutionRequest\x12!\n" +
 	"\fnamespace_id\x18\x01 \x01(\tR\vnamespaceId\x12c\n" +
 	"\rstart_request\x18\x02 \x01(\v2>.temporal.api.workflowservice.v1.StartWorkflowExecutionRequestR\fstartRequest\x12h\n" +
@@ -10733,7 +10743,8 @@ const file_temporal_server_api_historyservice_v1_request_response_proto_rawDesc 
 	"\x18inherited_pinned_version\x18\x0f \x01(\v23.temporal.api.deployment.v1.WorkerDeploymentVersionR\x16inheritedPinnedVersion\x12s\n" +
 	"\x1binherited_auto_upgrade_info\x18\x10 \x01(\v24.temporal.api.deployment.v1.InheritedAutoUpgradeInfoR\x18inheritedAutoUpgradeInfo\x12|\n" +
 	"\x1fdeclined_target_version_upgrade\x18\x11 \x01(\v25.temporal.api.history.v1.DeclinedTargetVersionUpgradeR\x1cdeclinedTargetVersionUpgrade\x12{\n" +
-	"\x1ftime_skipping_state_propagation\x18\x13 \x01(\v24.temporal.api.common.v1.TimeSkippingStatePropagationR\x1ctimeSkippingStatePropagation:\x1f\x92\xc4\x03\x1b*\x19start_request.workflow_idJ\x04\b\x12\x10\x13\"\xb1\x03\n" +
+	"\x1ftime_skipping_state_propagation\x18\x13 \x01(\v24.temporal.api.common.v1.TimeSkippingStatePropagationR\x1ctimeSkippingStatePropagation\x12:\n" +
+	"\x19zombify_conflicting_child\x18\x14 \x01(\bR\x17zombifyConflictingChild:\x1f\x92\xc4\x03\x1b*\x19start_request.workflow_idJ\x04\b\x12\x10\x13\"\xb1\x03\n" +
 	"\x1eStartWorkflowExecutionResponse\x12\x15\n" +
 	"\x06run_id\x18\x01 \x01(\tR\x05runId\x12?\n" +
 	"\x05clock\x18\x02 \x01(\v2).temporal.server.api.clock.v1.VectorClockR\x05clock\x12n\n" +

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2633,6 +2633,14 @@ where the user has set an explicit RetryPolicy, but not specified all the fields
 		true,
 		`Allows resetting of workflows with pending children when set to true`,
 	)
+	EnableOrphanedChildWorkflowReclaim = NewNamespaceBoolSetting(
+		"history.enableOrphanedChildWorkflowReclaim",
+		false,
+		`Allows a parent to replace an open child created by an initiation that lost conflict resolution
+after force failover. The conflicting run is verified and marked zombie in the same transaction that
+creates its replacement. This defaults to false because the replacement may repeat work already
+performed by the orphaned child`,
+	)
 	HistoryMaxAutoResetPoints = NewNamespaceIntSetting(
 		"history.historyMaxAutoResetPoints",
 		primitives.DefaultHistoryMaxAutoResetPoints,

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2633,8 +2633,8 @@ where the user has set an explicit RetryPolicy, but not specified all the fields
 		true,
 		`Allows resetting of workflows with pending children when set to true`,
 	)
-	EnableOrphanedChildWorkflowReclaim = NewNamespaceBoolSetting(
-		"history.enableOrphanedChildWorkflowReclaim",
+	EnableOrphanedChildWorkflowReplacement = NewNamespaceBoolSetting(
+		"history.enableOrphanedChildWorkflowReplacement",
 		false,
 		`Allows a parent to replace an open child created by an initiation that lost conflict resolution
 after force failover. The conflicting run is verified and marked zombie in the same transaction that

--- a/proto/internal/temporal/server/api/historyservice/v1/request_response.proto
+++ b/proto/internal/temporal/server/api/historyservice/v1/request_response.proto
@@ -106,8 +106,8 @@ message StartWorkflowExecutionRequest {
   temporal.api.history.v1.DeclinedTargetVersionUpgrade declined_target_version_upgrade = 17;
   reserved 18;
   temporal.api.common.v1.TimeSkippingStatePropagation time_skipping_state_propagation = 19;
-  // Allows a parent retrying an orphaned child start after failover to replace its own open child.
-  // Ownership is verified while holding the conflicting execution's lock.
+  // Set when the parent has established that a conflicting execution can only be its own child, orphaned by an
+  // initiation that lost conflict resolution after a force failover.
   bool zombify_conflicting_child = 20;
 }
 

--- a/proto/internal/temporal/server/api/historyservice/v1/request_response.proto
+++ b/proto/internal/temporal/server/api/historyservice/v1/request_response.proto
@@ -106,6 +106,9 @@ message StartWorkflowExecutionRequest {
   temporal.api.history.v1.DeclinedTargetVersionUpgrade declined_target_version_upgrade = 17;
   reserved 18;
   temporal.api.common.v1.TimeSkippingStatePropagation time_skipping_state_propagation = 19;
+  // Allows a parent retrying an orphaned child start after failover to replace its own open child.
+  // Ownership is verified while holding the conflicting execution's lock.
+  bool zombify_conflicting_child = 20;
 }
 
 message StartWorkflowExecutionResponse {

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -557,6 +557,13 @@ func (s *Starter) resolveDuplicateWorkflowID(
 	}
 }
 
+// shouldZombifyConflictingChild routes a duplicate start to the atomic zombify action only when
+//  1. the parent explicitly requests orphaned-child recovery
+//  2. the conflict policy would otherwise fail the start
+//  3. the reuse policy permits a new run
+//  4. the current execution is still open according to the persistence snapshot.
+//
+// The action revalidates the execution under the child lock before zombifying it.
 func (s *Starter) shouldZombifyConflictingChild(currentState enumsspb.WorkflowExecutionState) bool {
 	if !s.request.GetZombifyConflictingChild() ||
 		s.request.StartRequest.GetWorkflowIdConflictPolicy() != enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL {

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -10,6 +10,7 @@ import (
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
+	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/chasm"
@@ -446,21 +447,30 @@ func (s *Starter) resolveDuplicateWorkflowID(
 	// previously created workflow context.
 	newRunID := primitives.NewUUID().String()
 
-	currentExecutionUpdateAction, err := api.ResolveDuplicateWorkflowID(
-		s.shardContext,
-		workflowKey,
-		s.namespace,
-		newRunID,
-		currentWorkflowConditionFailed.State,
-		currentWorkflowConditionFailed.Status,
-		currentWorkflowConditionFailed.RequestIDs,
-		currentWorkflowConditionFailed.FirstExecutionRunID,
-		s.request.StartRequest.GetWorkflowIdReusePolicy(),
-		s.request.StartRequest.GetWorkflowIdConflictPolicy(),
-		currentWorkflowStartTime,
-		s.request.ParentExecutionInfo,
-		s.request.ChildWorkflowOnly,
-	)
+	var currentExecutionUpdateAction api.UpdateWorkflowActionFunc
+	var err error
+	if s.shouldZombifyConflictingChild(currentWorkflowConditionFailed.State) {
+		currentExecutionUpdateAction = api.ZombifyConflictingChildAction(
+			s.request.ParentExecutionInfo,
+			s.shardContext.GetLogger(),
+		)
+	} else {
+		currentExecutionUpdateAction, err = api.ResolveDuplicateWorkflowID(
+			s.shardContext,
+			workflowKey,
+			s.namespace,
+			newRunID,
+			currentWorkflowConditionFailed.State,
+			currentWorkflowConditionFailed.Status,
+			currentWorkflowConditionFailed.RequestIDs,
+			currentWorkflowConditionFailed.FirstExecutionRunID,
+			s.request.StartRequest.GetWorkflowIdReusePolicy(),
+			s.request.StartRequest.GetWorkflowIdConflictPolicy(),
+			currentWorkflowStartTime,
+			s.request.ParentExecutionInfo,
+			s.request.ChildWorkflowOnly,
+		)
+	}
 
 	switch {
 	case errors.Is(err, api.ErrUseCurrentExecution):
@@ -545,6 +555,20 @@ func (s *Starter) resolveDuplicateWorkflowID(
 	default:
 		return nil, StartErr, err
 	}
+}
+
+func (s *Starter) shouldZombifyConflictingChild(currentState enumsspb.WorkflowExecutionState) bool {
+	if !s.request.GetZombifyConflictingChild() ||
+		s.request.StartRequest.GetWorkflowIdConflictPolicy() != enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL {
+		return false
+	}
+	reusePolicy := s.request.StartRequest.GetWorkflowIdReusePolicy()
+	if reusePolicy != enumspb.WORKFLOW_ID_REUSE_POLICY_UNSPECIFIED &&
+		reusePolicy != enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE {
+		return false
+	}
+	return currentState == enumsspb.WORKFLOW_EXECUTION_STATE_CREATED ||
+		currentState == enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING
 }
 
 // respondToRetriedRequest provides a response in case a start request is retried.

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -449,9 +449,18 @@ func (s *Starter) resolveDuplicateWorkflowID(
 
 	var currentExecutionUpdateAction api.UpdateWorkflowActionFunc
 	var err error
-	if s.shouldZombifyConflictingChild(currentWorkflowConditionFailed.State) {
+	currentIsOpen := currentWorkflowConditionFailed.State == enumsspb.WORKFLOW_EXECUTION_STATE_CREATED ||
+		currentWorkflowConditionFailed.State == enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING
+	if s.request.GetZombifyConflictingChild() && currentIsOpen {
+		// currentIsOpen is routing, not a duplicate of the action's own liveness check: a durably
+		// closed run is not a replaceable orphan and belongs on the reuse-policy path below. Drop it
+		// and a closed child retries the zombify path forever on ErrWorkflowCompleted, which is only
+		// a race signal when the snapshot said open.
+		// TODO: handle orphan closed child run
 		currentExecutionUpdateAction = api.ZombifyConflictingChildAction(
 			s.request.ParentExecutionInfo,
+			s.request.StartRequest.GetWorkflowIdConflictPolicy(),
+			s.request.StartRequest.GetWorkflowIdReusePolicy(),
 			s.shardContext.GetLogger(),
 		)
 	} else {
@@ -555,27 +564,6 @@ func (s *Starter) resolveDuplicateWorkflowID(
 	default:
 		return nil, StartErr, err
 	}
-}
-
-// shouldZombifyConflictingChild routes a duplicate start to the atomic zombify action only when
-//  1. the parent explicitly requests orphaned-child recovery
-//  2. the conflict policy would otherwise fail the start
-//  3. the reuse policy permits a new run
-//  4. the current execution is still open according to the persistence snapshot.
-//
-// The action revalidates the execution under the child lock before zombifying it.
-func (s *Starter) shouldZombifyConflictingChild(currentState enumsspb.WorkflowExecutionState) bool {
-	if !s.request.GetZombifyConflictingChild() ||
-		s.request.StartRequest.GetWorkflowIdConflictPolicy() != enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL {
-		return false
-	}
-	reusePolicy := s.request.StartRequest.GetWorkflowIdReusePolicy()
-	if reusePolicy != enumspb.WORKFLOW_ID_REUSE_POLICY_UNSPECIFIED &&
-		reusePolicy != enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE {
-		return false
-	}
-	return currentState == enumsspb.WORKFLOW_EXECUTION_STATE_CREATED ||
-		currentState == enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING
 }
 
 // respondToRetriedRequest provides a response in case a start request is retried.

--- a/service/history/api/workflow_id_dedup.go
+++ b/service/history/api/workflow_id_dedup.go
@@ -11,6 +11,8 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	workflowspb "go.temporal.io/server/api/workflow/v1"
 	"go.temporal.io/server/common/definition"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/service/history/consts"
@@ -233,6 +235,86 @@ func terminateWorkflowAction(
 			nil, // No links necessary.
 		)
 	}, nil
+}
+
+// ZombifyConflictingChildAction validates and marks the conflicting child as a zombie while holding
+// its lock. The replacement is then created in the same transaction.
+func ZombifyConflictingChildAction(
+	parentExecutionInfo *workflowspb.ParentExecutionInfo,
+	logger log.Logger,
+) UpdateWorkflowActionFunc {
+	return func(workflowLease WorkflowLease) (*UpdateWorkflowAction, error) {
+		mutableState := workflowLease.GetMutableState()
+		if err := validateOrphanedChild(mutableState, parentExecutionInfo); err != nil {
+			if !errors.Is(err, consts.ErrWorkflowCompleted) {
+				logger.Warn(
+					"Unable to zombify conflicting child workflow.",
+					tag.WorkflowNamespaceID(mutableState.GetWorkflowKey().NamespaceID),
+					tag.WorkflowID(mutableState.GetWorkflowKey().WorkflowID),
+					tag.WorkflowRunID(mutableState.GetWorkflowKey().RunID),
+					tag.Error(err),
+				)
+			}
+			return nil, err
+		}
+
+		if _, err := mutableState.UpdateWorkflowStateStatus(
+			enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE,
+			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+		); err != nil {
+			return nil, err
+		}
+
+		logger.Info(
+			"Zombified conflicting child workflow.",
+			tag.WorkflowNamespaceID(mutableState.GetWorkflowKey().NamespaceID),
+			tag.WorkflowID(mutableState.GetWorkflowKey().WorkflowID),
+			tag.WorkflowRunID(mutableState.GetWorkflowKey().RunID),
+		)
+		// Reuse same post-action as a termination: no workflow task, and in-flight Workflow Updates must be
+		// aborted because a zombie run will never make progress again.
+		return UpdateWorkflowTerminate, nil
+	}
+}
+
+// validateOrphanedChild allows a conflicting child run to be zombified only when
+//  1. the child is still open
+//  2. parent execution metadata is present
+//  3. the parent namespace ID, workflow ID, and run ID match the requesting parent
+//  4. the child's initiated event ID/version tuple differs from the reissued initiation.
+func validateOrphanedChild(
+	mutableState historyi.MutableState,
+	parentExecutionInfo *workflowspb.ParentExecutionInfo,
+) error {
+	if !mutableState.IsWorkflowExecutionRunning() {
+		return consts.ErrWorkflowCompleted
+	}
+
+	executionState := mutableState.GetExecutionState()
+	alreadyStartedErr := func() error {
+		return generateWorkflowAlreadyStartedError(
+			"Workflow execution is already running. WorkflowId: %v, RunId: %v.",
+			executionState.GetRequestIds(),
+			mutableState.GetWorkflowKey(),
+			executionState.GetFirstExecutionRunId(),
+		)
+	}
+	if parentExecutionInfo == nil {
+		return alreadyStartedErr()
+	}
+
+	executionInfo := mutableState.GetExecutionInfo()
+	if executionInfo.GetParentNamespaceId() != parentExecutionInfo.GetNamespaceId() ||
+		executionInfo.GetParentWorkflowId() != parentExecutionInfo.GetExecution().GetWorkflowId() ||
+		executionInfo.GetParentRunId() != parentExecutionInfo.GetExecution().GetRunId() {
+		return alreadyStartedErr()
+	}
+
+	if executionInfo.GetParentInitiatedId() == parentExecutionInfo.GetInitiatedId() &&
+		executionInfo.GetParentInitiatedVersion() == parentExecutionInfo.GetInitiatedVersion() {
+		return alreadyStartedErr()
+	}
+	return nil
 }
 
 func generateWorkflowAlreadyStartedError(

--- a/service/history/api/workflow_id_dedup.go
+++ b/service/history/api/workflow_id_dedup.go
@@ -241,11 +241,13 @@ func terminateWorkflowAction(
 // its lock. The replacement is then created in the same transaction.
 func ZombifyConflictingChildAction(
 	parentExecutionInfo *workflowspb.ParentExecutionInfo,
+	conflictPolicy enumspb.WorkflowIdConflictPolicy,
+	reusePolicy enumspb.WorkflowIdReusePolicy,
 	logger log.Logger,
 ) UpdateWorkflowActionFunc {
 	return func(workflowLease WorkflowLease) (*UpdateWorkflowAction, error) {
 		mutableState := workflowLease.GetMutableState()
-		if err := validateOrphanedChild(mutableState, parentExecutionInfo); err != nil {
+		if err := validateOrphanedChild(mutableState, parentExecutionInfo, conflictPolicy, reusePolicy); err != nil {
 			if !errors.Is(err, consts.ErrWorkflowCompleted) {
 				logger.Warn(
 					"Unable to zombify conflicting child workflow.",
@@ -277,14 +279,18 @@ func ZombifyConflictingChildAction(
 	}
 }
 
-// validateOrphanedChild allows a conflicting child run to be zombified only when
-//  1. the child is still open
-//  2. parent execution metadata is present
-//  3. the parent namespace ID, workflow ID, and run ID match the requesting parent
-//  4. the child's initiated event ID/version tuple differs from the reissued initiation.
+// validateOrphanedChild rejects anything that is not an open child of exactly this parent descending
+// from an initiation other than the one being reissued. It reads live mutable state under the
+// conflicting run's lock, so no check can go stale before the zombify.
+//
+// The policy checks are assertions: startChildWorkflow always sends conflict policy FAIL and the
+// child command's own reuse policy. Rejecting on them matches normal duplicate resolution, which for
+// an open run also returns WorkflowExecutionAlreadyStarted.
 func validateOrphanedChild(
 	mutableState historyi.MutableState,
 	parentExecutionInfo *workflowspb.ParentExecutionInfo,
+	conflictPolicy enumspb.WorkflowIdConflictPolicy,
+	reusePolicy enumspb.WorkflowIdReusePolicy,
 ) error {
 	if !mutableState.IsWorkflowExecutionRunning() {
 		return consts.ErrWorkflowCompleted
@@ -298,6 +304,13 @@ func validateOrphanedChild(
 			mutableState.GetWorkflowKey(),
 			executionState.GetFirstExecutionRunId(),
 		)
+	}
+	if conflictPolicy != enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL {
+		return alreadyStartedErr()
+	}
+	if reusePolicy != enumspb.WORKFLOW_ID_REUSE_POLICY_UNSPECIFIED &&
+		reusePolicy != enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE {
+		return alreadyStartedErr()
 	}
 	if parentExecutionInfo == nil {
 		return alreadyStartedErr()

--- a/service/history/api/workflow_id_dedup_test.go
+++ b/service/history/api/workflow_id_dedup_test.go
@@ -109,10 +109,40 @@ func TestZombifyConflictingChildAction(t *testing.T) {
 		parent          *workflowspb.ParentExecutionInfo
 		mutateInfo      func(*persistencespb.WorkflowExecutionInfo)
 		firstRunID      string
+		conflictPolicy  enumspb.WorkflowIdConflictPolicy
+		reusePolicy     enumspb.WorkflowIdReusePolicy
 		expectCompleted bool
 		expectConflict  bool
 	}{
 		{name: "same parent different initiation", running: true, parent: parentExecutionInfo},
+		{
+			name:           "unspecified reuse policy",
+			running:        true,
+			parent:         parentExecutionInfo,
+			reusePolicy:    enumspb.WORKFLOW_ID_REUSE_POLICY_UNSPECIFIED,
+			conflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL,
+		},
+		{
+			name:           "reuse policy rejects duplicates",
+			running:        true,
+			parent:         parentExecutionInfo,
+			reusePolicy:    enumspb.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
+			expectConflict: true,
+		},
+		{
+			name:           "reuse policy allows failed duplicates only",
+			running:        true,
+			parent:         parentExecutionInfo,
+			reusePolicy:    enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
+			expectConflict: true,
+		},
+		{
+			name:           "conflict policy would not fail the start",
+			running:        true,
+			parent:         parentExecutionInfo,
+			conflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING,
+			expectConflict: true,
+		},
 		{
 			name:            "closed child",
 			parent:          parentExecutionInfo,
@@ -198,7 +228,14 @@ func TestZombifyConflictingChildAction(t *testing.T) {
 				).Return(true, nil)
 			}
 
-			action, err := ZombifyConflictingChildAction(tc.parent, log.NewTestLogger())(
+			conflictPolicy := tc.conflictPolicy
+			if conflictPolicy == enumspb.WORKFLOW_ID_CONFLICT_POLICY_UNSPECIFIED {
+				// What startChildWorkflow always sends on this path.
+				conflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL
+			}
+			action, err := ZombifyConflictingChildAction(
+				tc.parent, conflictPolicy, tc.reusePolicy, log.NewTestLogger(),
+			)(
 				NewWorkflowLease(nil, nil, mutableState),
 			)
 			switch {

--- a/service/history/api/workflow_id_dedup_test.go
+++ b/service/history/api/workflow_id_dedup_test.go
@@ -7,13 +7,19 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
+	enumsspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	workflowspb "go.temporal.io/server/api/workflow/v1"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/service/history/consts"
+	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tests"
 	"go.uber.org/mock/gomock"
@@ -77,6 +83,135 @@ func TestResolveDuplicateWorkflowStart(t *testing.T) {
 		} else {
 			assert.NoError(t, err)
 		}
+	}
+}
+
+func TestZombifyConflictingChildAction(t *testing.T) {
+	const (
+		parentNamespaceID = "parent-namespace"
+		parentWorkflowID  = "parent-workflow"
+		parentRunID       = "parent-run"
+		childRunID        = "child-run"
+	)
+	parentExecutionInfo := &workflowspb.ParentExecutionInfo{
+		NamespaceId: parentNamespaceID,
+		Execution: &commonpb.WorkflowExecution{
+			WorkflowId: parentWorkflowID,
+			RunId:      parentRunID,
+		},
+		InitiatedId:      75,
+		InitiatedVersion: 925,
+	}
+
+	testCases := []struct {
+		name            string
+		running         bool
+		parent          *workflowspb.ParentExecutionInfo
+		mutateInfo      func(*persistencespb.WorkflowExecutionInfo)
+		firstRunID      string
+		expectCompleted bool
+		expectConflict  bool
+	}{
+		{name: "same parent different initiation", running: true, parent: parentExecutionInfo},
+		{
+			name:            "closed child",
+			parent:          parentExecutionInfo,
+			expectCompleted: true,
+		},
+		{name: "missing parent", running: true, expectConflict: true},
+		{
+			name:    "different parent namespace",
+			running: true,
+			parent:  parentExecutionInfo,
+			mutateInfo: func(info *persistencespb.WorkflowExecutionInfo) {
+				info.ParentNamespaceId = "other-namespace"
+			},
+			expectConflict: true,
+		},
+		{
+			name:    "different parent workflow",
+			running: true,
+			parent:  parentExecutionInfo,
+			mutateInfo: func(info *persistencespb.WorkflowExecutionInfo) {
+				info.ParentWorkflowId = "other-workflow"
+			},
+			expectConflict: true,
+		},
+		{
+			name:    "different parent run",
+			running: true,
+			parent:  parentExecutionInfo,
+			mutateInfo: func(info *persistencespb.WorkflowExecutionInfo) {
+				info.ParentRunId = "other-run"
+			},
+			expectConflict: true,
+		},
+		{
+			name:    "exact initiation is not relinked or replaced",
+			running: true,
+			parent:  parentExecutionInfo,
+			mutateInfo: func(info *persistencespb.WorkflowExecutionInfo) {
+				info.ParentInitiatedId = parentExecutionInfo.GetInitiatedId()
+				info.ParentInitiatedVersion = parentExecutionInfo.GetInitiatedVersion()
+			},
+			expectConflict: true,
+		},
+		{
+			name:       "successor child run can be zombified",
+			running:    true,
+			parent:     parentExecutionInfo,
+			firstRunID: "first-child-run",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			executionInfo := &persistencespb.WorkflowExecutionInfo{
+				ParentNamespaceId:      parentNamespaceID,
+				ParentWorkflowId:       parentWorkflowID,
+				ParentRunId:            parentRunID,
+				ParentInitiatedId:      72,
+				ParentInitiatedVersion: 892,
+			}
+			if tc.mutateInfo != nil {
+				tc.mutateInfo(executionInfo)
+			}
+			firstRunID := tc.firstRunID
+			if firstRunID == "" {
+				firstRunID = childRunID
+			}
+			executionState := &persistencespb.WorkflowExecutionState{
+				RunId:               childRunID,
+				FirstExecutionRunId: firstRunID,
+			}
+			workflowKey := definition.NewWorkflowKey("child-namespace", "child-workflow", childRunID)
+
+			mutableState := historyi.NewMockMutableState(gomock.NewController(t))
+			mutableState.EXPECT().IsWorkflowExecutionRunning().Return(tc.running)
+			mutableState.EXPECT().GetExecutionInfo().Return(executionInfo).AnyTimes()
+			mutableState.EXPECT().GetExecutionState().Return(executionState).AnyTimes()
+			mutableState.EXPECT().GetWorkflowKey().Return(workflowKey).AnyTimes()
+			if !tc.expectCompleted && !tc.expectConflict {
+				mutableState.EXPECT().UpdateWorkflowStateStatus(
+					enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE,
+					enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+				).Return(true, nil)
+			}
+
+			action, err := ZombifyConflictingChildAction(tc.parent, log.NewTestLogger())(
+				NewWorkflowLease(nil, nil, mutableState),
+			)
+			switch {
+			case tc.expectCompleted:
+				require.ErrorIs(t, err, consts.ErrWorkflowCompleted)
+			case tc.expectConflict:
+				var alreadyStarted *serviceerror.WorkflowExecutionAlreadyStarted
+				require.ErrorAs(t, err, &alreadyStarted)
+			default:
+				require.NoError(t, err)
+				require.Same(t, UpdateWorkflowTerminate, action)
+			}
+		})
 	}
 }
 

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -60,6 +60,9 @@ type Config struct {
 	AllowResetWithPendingChildren dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	MaxAutoResetPoints            dynamicconfig.IntPropertyFnWithNamespaceFilter
 
+	// Child workflow related settings.
+	EnableOrphanedChildWorkflowReclaim dynamicconfig.BoolPropertyFnWithNamespaceFilter
+
 	// HistoryCache settings
 	// Change of these configs require shard restart
 	HistoryCacheLimitSizeBased                 bool
@@ -473,6 +476,7 @@ func NewConfig(
 		ShutdownDrainDuration:                dynamicconfig.HistoryShutdownDrainDuration.Get(dc),
 		StartupMembershipJoinDelay:           dynamicconfig.HistoryStartupMembershipJoinDelay.Get(dc),
 		AllowResetWithPendingChildren:        dynamicconfig.AllowResetWithPendingChildren.Get(dc),
+		EnableOrphanedChildWorkflowReclaim:   dynamicconfig.EnableOrphanedChildWorkflowReclaim.Get(dc),
 		MaxAutoResetPoints:                   dynamicconfig.HistoryMaxAutoResetPoints.Get(dc),
 		DefaultWorkflowTaskTimeout:           dynamicconfig.DefaultWorkflowTaskTimeout.Get(dc),
 

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -60,8 +60,7 @@ type Config struct {
 	AllowResetWithPendingChildren dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	MaxAutoResetPoints            dynamicconfig.IntPropertyFnWithNamespaceFilter
 
-	// Child workflow related settings.
-	EnableOrphanedChildWorkflowReclaim dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	EnableOrphanedChildWorkflowReplacement dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
 	// HistoryCache settings
 	// Change of these configs require shard restart
@@ -461,24 +460,24 @@ func NewConfig(
 		EnableSeparateReplicationEnableFlag:           dynamicconfig.EnableSeparateReplicationEnableFlag.Get(dc),
 		HistoryReplicationDLQV2:                       dynamicconfig.EnableHistoryReplicationDLQV2.Get(dc),
 
-		RPS:                                  dynamicconfig.HistoryRPS.Get(dc),
-		NamespaceRPS:                         dynamicconfig.HistoryNamespaceRPS.Get(dc),
-		OperatorRPSRatio:                     dynamicconfig.OperatorRPSRatio.Get(dc),
-		MaxIDLengthLimit:                     dynamicconfig.MaxIDLengthLimit.Get(dc),
-		PersistenceMaxQPS:                    dynamicconfig.HistoryPersistenceMaxQPS.Get(dc),
-		PersistenceGlobalMaxQPS:              dynamicconfig.HistoryPersistenceGlobalMaxQPS.Get(dc),
-		PersistenceNamespaceMaxQPS:           dynamicconfig.HistoryPersistenceNamespaceMaxQPS.Get(dc),
-		PersistenceGlobalNamespaceMaxQPS:     dynamicconfig.HistoryPersistenceGlobalNamespaceMaxQPS.Get(dc),
-		PersistencePerShardNamespaceMaxQPS:   dynamicconfig.HistoryPersistencePerShardNamespaceMaxQPS.Get(dc),
-		PersistenceDynamicRateLimitingParams: dynamicconfig.HistoryPersistenceDynamicRateLimitingParams.Get(dc),
-		PersistenceQPSBurstRatio:             dynamicconfig.PersistenceQPSBurstRatio.Get(dc),
-		AlignMembershipChange:                dynamicconfig.HistoryAlignMembershipChange.Get(dc),
-		ShutdownDrainDuration:                dynamicconfig.HistoryShutdownDrainDuration.Get(dc),
-		StartupMembershipJoinDelay:           dynamicconfig.HistoryStartupMembershipJoinDelay.Get(dc),
-		AllowResetWithPendingChildren:        dynamicconfig.AllowResetWithPendingChildren.Get(dc),
-		EnableOrphanedChildWorkflowReclaim:   dynamicconfig.EnableOrphanedChildWorkflowReclaim.Get(dc),
-		MaxAutoResetPoints:                   dynamicconfig.HistoryMaxAutoResetPoints.Get(dc),
-		DefaultWorkflowTaskTimeout:           dynamicconfig.DefaultWorkflowTaskTimeout.Get(dc),
+		RPS:                                    dynamicconfig.HistoryRPS.Get(dc),
+		NamespaceRPS:                           dynamicconfig.HistoryNamespaceRPS.Get(dc),
+		OperatorRPSRatio:                       dynamicconfig.OperatorRPSRatio.Get(dc),
+		MaxIDLengthLimit:                       dynamicconfig.MaxIDLengthLimit.Get(dc),
+		PersistenceMaxQPS:                      dynamicconfig.HistoryPersistenceMaxQPS.Get(dc),
+		PersistenceGlobalMaxQPS:                dynamicconfig.HistoryPersistenceGlobalMaxQPS.Get(dc),
+		PersistenceNamespaceMaxQPS:             dynamicconfig.HistoryPersistenceNamespaceMaxQPS.Get(dc),
+		PersistenceGlobalNamespaceMaxQPS:       dynamicconfig.HistoryPersistenceGlobalNamespaceMaxQPS.Get(dc),
+		PersistencePerShardNamespaceMaxQPS:     dynamicconfig.HistoryPersistencePerShardNamespaceMaxQPS.Get(dc),
+		PersistenceDynamicRateLimitingParams:   dynamicconfig.HistoryPersistenceDynamicRateLimitingParams.Get(dc),
+		PersistenceQPSBurstRatio:               dynamicconfig.PersistenceQPSBurstRatio.Get(dc),
+		AlignMembershipChange:                  dynamicconfig.HistoryAlignMembershipChange.Get(dc),
+		ShutdownDrainDuration:                  dynamicconfig.HistoryShutdownDrainDuration.Get(dc),
+		StartupMembershipJoinDelay:             dynamicconfig.HistoryStartupMembershipJoinDelay.Get(dc),
+		AllowResetWithPendingChildren:          dynamicconfig.AllowResetWithPendingChildren.Get(dc),
+		EnableOrphanedChildWorkflowReplacement: dynamicconfig.EnableOrphanedChildWorkflowReplacement.Get(dc),
+		MaxAutoResetPoints:                     dynamicconfig.HistoryMaxAutoResetPoints.Get(dc),
+		DefaultWorkflowTaskTimeout:             dynamicconfig.DefaultWorkflowTaskTimeout.Get(dc),
 
 		MaxLocalParentWorkflowVerificationDuration: dynamicconfig.MaxLocalParentWorkflowVerificationDuration.Get(dc),
 

--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -1116,7 +1116,6 @@ func (t *transferQueueActiveTaskExecutor) processStartChildExecution(
 		startOptions.zombifyConflictingChild = t.canZombifyConflictingChild(
 			mutableState,
 			childInfo,
-			attributes,
 			parentNamespaceName,
 		)
 	}
@@ -1186,34 +1185,21 @@ func (t *transferQueueActiveTaskExecutor) processStartChildExecution(
 	}, parentClock, childClock)
 }
 
-// canZombifyConflictingChild allows a conflicting child run to be zombified only when
-//  1. the feature is enabled
-//  2. the reuse policy permits a new run
-//  3. the child workflow ID does not identify the parent workflow in the same namespace
-//  4. no other pending child on the parent's accepted branch uses the same workflow ID.
+// canZombifyConflictingChild let the parent decide if a collision found by child can be zombified.
 func (t *transferQueueActiveTaskExecutor) canZombifyConflictingChild(
 	mutableState historyi.MutableState,
 	childInfo *persistencespb.ChildExecutionInfo,
-	attributes *historypb.StartChildWorkflowExecutionInitiatedEventAttributes,
 	parentNamespaceName namespace.Name,
 ) bool {
 	if !t.config.EnableOrphanedChildWorkflowReplacement(parentNamespaceName.String()) {
 		return false
 	}
-	reusePolicy := attributes.GetWorkflowIdReusePolicy()
-	if reusePolicy != enumspb.WORKFLOW_ID_REUSE_POLICY_UNSPECIFIED &&
-		reusePolicy != enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE {
+	if childInfo.GetStartedWorkflowId() == mutableState.GetExecutionInfo().GetWorkflowId() {
 		return false
 	}
-	executionInfo := mutableState.GetExecutionInfo()
-	childNamespaceMatchesParent := childInfo.GetNamespaceId() == executionInfo.GetNamespaceId()
-	if childInfo.GetNamespaceId() == "" {
-		childNamespaceMatchesParent = childInfo.GetNamespace() == parentNamespaceName.String()
-	}
-	if childNamespaceMatchesParent &&
-		childInfo.GetStartedWorkflowId() == executionInfo.GetWorkflowId() {
-		return false
-	}
+	// A parent that legitimately starts a second child under the same workflow ID
+	// still holds the earlier initiation as a pending child. For this case, we shouldn't
+	// zombify the running child.
 	for initiatedEventID, pendingChild := range mutableState.GetPendingChildExecutionInfos() {
 		if initiatedEventID != childInfo.GetInitiatedEventId() &&
 			pendingChild.GetStartedWorkflowId() == childInfo.GetStartedWorkflowId() {

--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -1112,9 +1112,7 @@ func (t *transferQueueActiveTaskExecutor) processStartChildExecution(
 	startOptions := startChildWorkflowOptions{
 		terminateExisting: shouldTerminateAndStartChild,
 	}
-	if shouldTerminateAndStartChild {
-		startOptions.reusePolicyOverride = enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE
-	} else {
+	if !shouldTerminateAndStartChild {
 		startOptions.zombifyConflictingChild = t.canZombifyConflictingChild(
 			mutableState,
 			childInfo,
@@ -1130,9 +1128,11 @@ func (t *transferQueueActiveTaskExecutor) processStartChildExecution(
 		if versioningOverride != nil && worker_versioning.IsPinnedVersionNotInTaskQueueError(err) {
 			// TODO(Shivam): Revisit this string-based classification and consider a typed error if more callers need it.
 			failedCause = enumspb.START_CHILD_WORKFLOW_EXECUTION_FAILED_CAUSE_INVALID_VERSIONING_OVERRIDE
-		} else if common.IsServiceTransientError(err) || common.IsContextDeadlineExceededErr(err) {
-			return err
 		} else {
+			if common.IsServiceTransientError(err) || common.IsContextDeadlineExceededErr(err) {
+				// for retryable error just return
+				return err
+			}
 			switch err.(type) {
 			case *serviceerror.WorkflowExecutionAlreadyStarted:
 				failedCause = enumspb.START_CHILD_WORKFLOW_EXECUTION_FAILED_CAUSE_WORKFLOW_ALREADY_EXISTS
@@ -1197,7 +1197,7 @@ func (t *transferQueueActiveTaskExecutor) canZombifyConflictingChild(
 	attributes *historypb.StartChildWorkflowExecutionInitiatedEventAttributes,
 	parentNamespaceName namespace.Name,
 ) bool {
-	if !t.config.EnableOrphanedChildWorkflowReclaim(parentNamespaceName.String()) {
+	if !t.config.EnableOrphanedChildWorkflowReplacement(parentNamespaceName.String()) {
 		return false
 	}
 	reusePolicy := attributes.GetWorkflowIdReusePolicy()
@@ -1317,7 +1317,6 @@ type startChildWorkflowParams struct {
 type startChildWorkflowOptions struct {
 	terminateExisting       bool
 	zombifyConflictingChild bool
-	reusePolicyOverride     enumspb.WorkflowIdReusePolicy
 }
 
 func (t *transferQueueActiveTaskExecutor) processResetWorkflow(
@@ -1781,10 +1780,6 @@ func (t *transferQueueActiveTaskExecutor) startChildWorkflow(
 		Priority:                 params.priority,
 		TimeSkippingConfig:       params.attributes.GetTimeSkippingConfig(),
 	}
-	if options.reusePolicyOverride != enumspb.WORKFLOW_ID_REUSE_POLICY_UNSPECIFIED {
-		startRequest.WorkflowIdReusePolicy = options.reusePolicyOverride
-	}
-
 	request := common.CreateHistoryStartWorkflowRequest(
 		params.targetNamespaceID.String(),
 		startRequest,
@@ -1814,6 +1809,7 @@ func (t *transferQueueActiveTaskExecutor) startChildWorkflow(
 	}
 
 	if options.terminateExisting {
+		request.StartRequest.WorkflowIdReusePolicy = enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE
 		request.StartRequest.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING
 		request.ChildWorkflowOnly = true
 	} else {

--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -1092,35 +1092,47 @@ func (t *transferQueueActiveTaskExecutor) processStartChildExecution(
 		},
 	}
 
-	childRunID, childClock, err := t.startWorkflow(
-		ctx,
-		task,
-		parentNamespaceName,
-		targetNamespaceName,
-		namespace.ID(targetNamespaceID),
-		childInfo.CreateRequestId,
-		attributes,
-		sourceVersionStamp,
-		rootExecutionInfo,
-		inheritedBuildID,
-		initiatedEvent.GetUserMetadata(),
-		shouldTerminateAndStartChild,
-		inheritedVersioningOverride,
-		inheritedPinnedVersion,
-		priorities.Merge(mutableState.GetExecutionInfo().Priority, attributes.Priority),
-		inheritedAutoUpgradeInfo,
-	)
+	childPriority := priorities.Merge(mutableState.GetExecutionInfo().Priority, attributes.Priority)
+	startParams := &startChildWorkflowParams{
+		task:                        task,
+		parentNamespaceName:         parentNamespaceName,
+		targetNamespaceName:         targetNamespaceName,
+		targetNamespaceID:           namespace.ID(targetNamespaceID),
+		requestID:                   childInfo.CreateRequestId,
+		attributes:                  attributes,
+		sourceVersionStamp:          sourceVersionStamp,
+		rootExecutionInfo:           rootExecutionInfo,
+		inheritedBuildID:            inheritedBuildID,
+		userMetadata:                initiatedEvent.GetUserMetadata(),
+		inheritedVersioningOverride: inheritedVersioningOverride,
+		inheritedPinnedVersion:      inheritedPinnedVersion,
+		priority:                    childPriority,
+		inheritedAutoUpgradeInfo:    inheritedAutoUpgradeInfo,
+	}
+	startOptions := startChildWorkflowOptions{
+		terminateExisting: shouldTerminateAndStartChild,
+	}
+	if shouldTerminateAndStartChild {
+		startOptions.reusePolicyOverride = enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE
+	} else {
+		startOptions.zombifyConflictingChild = t.canZombifyConflictingChild(
+			mutableState,
+			childInfo,
+			attributes,
+			parentNamespaceName,
+		)
+	}
+
+	childRunID, childClock, err := t.startChildWorkflow(ctx, startParams, startOptions)
 	if err != nil {
 		t.logger.Debug("Failed to start child workflow execution", tag.Error(err))
 		var failedCause enumspb.StartChildWorkflowExecutionFailedCause
 		if versioningOverride != nil && worker_versioning.IsPinnedVersionNotInTaskQueueError(err) {
 			// TODO(Shivam): Revisit this string-based classification and consider a typed error if more callers need it.
 			failedCause = enumspb.START_CHILD_WORKFLOW_EXECUTION_FAILED_CAUSE_INVALID_VERSIONING_OVERRIDE
+		} else if common.IsServiceTransientError(err) || common.IsContextDeadlineExceededErr(err) {
+			return err
 		} else {
-			if common.IsServiceTransientError(err) || common.IsContextDeadlineExceededErr(err) {
-				// for retryable error just return
-				return err
-			}
 			switch err.(type) {
 			case *serviceerror.WorkflowExecutionAlreadyStarted:
 				failedCause = enumspb.START_CHILD_WORKFLOW_EXECUTION_FAILED_CAUSE_WORKFLOW_ALREADY_EXISTS
@@ -1174,6 +1186,43 @@ func (t *transferQueueActiveTaskExecutor) processStartChildExecution(
 	}, parentClock, childClock)
 }
 
+// canZombifyConflictingChild allows a conflicting child run to be zombified only when
+//  1. the feature is enabled
+//  2. the reuse policy permits a new run
+//  3. the child workflow ID does not identify the parent workflow in the same namespace
+//  4. no other pending child on the parent's accepted branch uses the same workflow ID.
+func (t *transferQueueActiveTaskExecutor) canZombifyConflictingChild(
+	mutableState historyi.MutableState,
+	childInfo *persistencespb.ChildExecutionInfo,
+	attributes *historypb.StartChildWorkflowExecutionInitiatedEventAttributes,
+	parentNamespaceName namespace.Name,
+) bool {
+	if !t.config.EnableOrphanedChildWorkflowReclaim(parentNamespaceName.String()) {
+		return false
+	}
+	reusePolicy := attributes.GetWorkflowIdReusePolicy()
+	if reusePolicy != enumspb.WORKFLOW_ID_REUSE_POLICY_UNSPECIFIED &&
+		reusePolicy != enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE {
+		return false
+	}
+	executionInfo := mutableState.GetExecutionInfo()
+	childNamespaceMatchesParent := childInfo.GetNamespaceId() == executionInfo.GetNamespaceId()
+	if childInfo.GetNamespaceId() == "" {
+		childNamespaceMatchesParent = childInfo.GetNamespace() == parentNamespaceName.String()
+	}
+	if childNamespaceMatchesParent &&
+		childInfo.GetStartedWorkflowId() == executionInfo.GetWorkflowId() {
+		return false
+	}
+	for initiatedEventID, pendingChild := range mutableState.GetPendingChildExecutionInfos() {
+		if initiatedEventID != childInfo.GetInitiatedEventId() &&
+			pendingChild.GetStartedWorkflowId() == childInfo.GetStartedWorkflowId() {
+			return false
+		}
+	}
+	return true
+}
+
 // verifyChildWorkflow describes the childWorkflowID and identifies its parent. It then checks if the current run was derived from that parent by comparing the OriginalRunID value.
 // It returns the child's runID if the checks pass. Empty runID is returned if the check doesn't pass.
 func (t *transferQueueActiveTaskExecutor) verifyChildWorkflow(
@@ -1210,8 +1259,12 @@ func (t *transferQueueActiveTaskExecutor) verifyChildWorkflow(
 	}
 
 	childsParentRunID := response.WorkflowExecutionInfo.ParentExecution.RunId
-	// Check if the child's parent was the base run for the current run.
-	if childsParentRunID == mutableState.GetExecutionInfo().OriginalExecutionRunId {
+	// Check if the child's parent was the base run for the current run, or is the current run itself.
+	// The latter matters for reset runs: OriginalExecutionRunId points to the pre-reset run, so a child
+	// of the current reset run would otherwise fall through and try to re-acquire the context we already
+	// hold (deadlock). Recognizing the current run id here avoids that.
+	if childsParentRunID == mutableState.GetExecutionInfo().OriginalExecutionRunId ||
+		childsParentRunID == mutableState.GetWorkflowKey().RunID {
 		return response.WorkflowExecutionInfo.Execution.RunId, response.WorkflowExecutionInfo.FirstRunId, nil
 	}
 
@@ -1242,6 +1295,29 @@ func (t *transferQueueActiveTaskExecutor) verifyChildWorkflow(
 	}
 
 	return "", "", nil
+}
+
+type startChildWorkflowParams struct {
+	task                        *tasks.StartChildExecutionTask
+	parentNamespaceName         namespace.Name
+	targetNamespaceName         namespace.Name
+	targetNamespaceID           namespace.ID
+	requestID                   string
+	attributes                  *historypb.StartChildWorkflowExecutionInitiatedEventAttributes
+	sourceVersionStamp          *commonpb.WorkerVersionStamp
+	rootExecutionInfo           *workflowspb.RootExecutionInfo
+	inheritedBuildID            string
+	userMetadata                *sdkpb.UserMetadata
+	inheritedVersioningOverride *workflowpb.VersioningOverride
+	inheritedPinnedVersion      *deploymentpb.WorkerDeploymentVersion
+	priority                    *commonpb.Priority
+	inheritedAutoUpgradeInfo    *deploymentpb.InheritedAutoUpgradeInfo
+}
+
+type startChildWorkflowOptions struct {
+	terminateExisting       bool
+	zombifyConflictingChild bool
+	reusePolicyOverride     enumspb.WorkflowIdReusePolicy
 }
 
 func (t *transferQueueActiveTaskExecutor) processResetWorkflow(
@@ -1671,86 +1747,77 @@ func (t *transferQueueActiveTaskExecutor) signalExternalExecution(
 	return err
 }
 
-func (t *transferQueueActiveTaskExecutor) startWorkflow(
+func (t *transferQueueActiveTaskExecutor) startChildWorkflow(
 	ctx context.Context,
-	task *tasks.StartChildExecutionTask,
-	namespace namespace.Name,
-	targetNamespace namespace.Name,
-	targetNamespaceID namespace.ID,
-	childRequestID string,
-	attributes *historypb.StartChildWorkflowExecutionInitiatedEventAttributes,
-	sourceVersionStamp *commonpb.WorkerVersionStamp,
-	rootExecutionInfo *workflowspb.RootExecutionInfo,
-	inheritedBuildId string,
-	userMetadata *sdkpb.UserMetadata,
-	shouldTerminateAndStartChild bool,
-	inheritedVersioningOverride *workflowpb.VersioningOverride,
-	inheritedPinnedVersion *deploymentpb.WorkerDeploymentVersion,
-	priority *commonpb.Priority,
-	inheritedAutoUpgradeInfo *deploymentpb.InheritedAutoUpgradeInfo,
+	params *startChildWorkflowParams,
+	options startChildWorkflowOptions,
 ) (string, *clockspb.VectorClock, error) {
-	versioningOverride := inheritedVersioningOverride
-	if attributes.GetVersioningOverride() != nil {
-		versioningOverride = attributes.GetVersioningOverride()
+	versioningOverride := params.inheritedVersioningOverride
+	if params.attributes.GetVersioningOverride() != nil {
+		versioningOverride = params.attributes.GetVersioningOverride()
 	}
 
 	startRequest := &workflowservice.StartWorkflowExecutionRequest{
-		Namespace:                targetNamespace.String(),
-		WorkflowId:               attributes.WorkflowId,
-		WorkflowType:             attributes.WorkflowType,
-		TaskQueue:                attributes.TaskQueue,
-		Input:                    attributes.Input,
-		Header:                   attributes.Header,
-		WorkflowExecutionTimeout: attributes.WorkflowExecutionTimeout,
-		WorkflowRunTimeout:       attributes.WorkflowRunTimeout,
-		WorkflowTaskTimeout:      attributes.WorkflowTaskTimeout,
+		Namespace:                params.targetNamespaceName.String(),
+		WorkflowId:               params.attributes.WorkflowId,
+		WorkflowType:             params.attributes.WorkflowType,
+		TaskQueue:                params.attributes.TaskQueue,
+		Input:                    params.attributes.Input,
+		Header:                   params.attributes.Header,
+		WorkflowExecutionTimeout: params.attributes.WorkflowExecutionTimeout,
+		WorkflowRunTimeout:       params.attributes.WorkflowRunTimeout,
+		WorkflowTaskTimeout:      params.attributes.WorkflowTaskTimeout,
 
 		// Use the same request ID to dedupe StartWorkflowExecution calls
-		RequestId:                childRequestID,
-		WorkflowIdReusePolicy:    attributes.WorkflowIdReusePolicy,
+		RequestId:                params.requestID,
+		WorkflowIdReusePolicy:    params.attributes.WorkflowIdReusePolicy,
 		WorkflowIdConflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL,
-		RetryPolicy:              attributes.RetryPolicy,
-		CronSchedule:             attributes.CronSchedule,
-		Memo:                     attributes.Memo,
-		SearchAttributes:         attributes.SearchAttributes,
-		UserMetadata:             userMetadata,
+		RetryPolicy:              params.attributes.RetryPolicy,
+		CronSchedule:             params.attributes.CronSchedule,
+		Memo:                     params.attributes.Memo,
+		SearchAttributes:         params.attributes.SearchAttributes,
+		UserMetadata:             params.userMetadata,
 		VersioningOverride:       versioningOverride,
-		Priority:                 priority,
-		TimeSkippingConfig:       attributes.GetTimeSkippingConfig(),
+		Priority:                 params.priority,
+		TimeSkippingConfig:       params.attributes.GetTimeSkippingConfig(),
+	}
+	if options.reusePolicyOverride != enumspb.WORKFLOW_ID_REUSE_POLICY_UNSPECIFIED {
+		startRequest.WorkflowIdReusePolicy = options.reusePolicyOverride
 	}
 
 	request := common.CreateHistoryStartWorkflowRequest(
-		targetNamespaceID.String(),
+		params.targetNamespaceID.String(),
 		startRequest,
 		&workflowspb.ParentExecutionInfo{
-			NamespaceId: task.NamespaceID,
-			Namespace:   namespace.String(),
+			NamespaceId: params.task.NamespaceID,
+			Namespace:   params.parentNamespaceName.String(),
 			Execution: &commonpb.WorkflowExecution{
-				WorkflowId: task.WorkflowID,
-				RunId:      task.RunID,
+				WorkflowId: params.task.WorkflowID,
+				RunId:      params.task.RunID,
 			},
-			InitiatedId:      task.InitiatedEventID,
-			InitiatedVersion: task.Version,
-			Clock:            vclock.NewVectorClock(t.shardContext.GetClusterMetadata().GetClusterID(), t.shardContext.GetShardID(), task.TaskID),
+			InitiatedId:      params.task.InitiatedEventID,
+			InitiatedVersion: params.task.Version,
+			Clock:            vclock.NewVectorClock(t.shardContext.GetClusterMetadata().GetClusterID(), t.shardContext.GetShardID(), params.task.TaskID),
 		},
-		rootExecutionInfo,
+		params.rootExecutionInfo,
 		t.shardContext.GetTimeSource().Now(),
 	)
 
-	request.SourceVersionStamp = sourceVersionStamp
-	request.InheritedBuildId = inheritedBuildId
-	request.InheritedPinnedVersion = inheritedPinnedVersion
-	request.TimeSkippingStatePropagation = attributes.GetTimeSkippingStatePropagation()
+	request.SourceVersionStamp = params.sourceVersionStamp
+	request.InheritedBuildId = params.inheritedBuildID
+	request.InheritedPinnedVersion = params.inheritedPinnedVersion
+	request.TimeSkippingStatePropagation = params.attributes.GetTimeSkippingStatePropagation()
 
 	// Only set the AutoUpgrade info if the Pinned version is not set.
 	if request.InheritedPinnedVersion == nil {
-		request.InheritedAutoUpgradeInfo = inheritedAutoUpgradeInfo
+		request.InheritedAutoUpgradeInfo = params.inheritedAutoUpgradeInfo
 	}
 
-	if shouldTerminateAndStartChild {
-		request.StartRequest.WorkflowIdReusePolicy = enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE
+	if options.terminateExisting {
 		request.StartRequest.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING
 		request.ChildWorkflowOnly = true
+	} else {
+		request.ZombifyConflictingChild = options.zombifyConflictingChild
 	}
 
 	response, err := t.historyRawClient.StartWorkflowExecution(ctx, request)

--- a/service/history/transfer_queue_active_task_executor_test.go
+++ b/service/history/transfer_queue_active_task_executor_test.go
@@ -2695,7 +2695,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestCanZombifyConflictingChild() 
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
-			s.mockShard.GetConfig().EnableOrphanedChildWorkflowReclaim = func(string) bool {
+			s.mockShard.GetConfig().EnableOrphanedChildWorkflowReplacement = func(string) bool {
 				return tc.enabled
 			}
 			mutableState := historyi.NewMockMutableState(gomock.NewController(s.T()))
@@ -2718,7 +2718,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestCanZombifyConflictingChild() 
 	}
 
 	s.Run("child workflow ID collides with parent", func() {
-		s.mockShard.GetConfig().EnableOrphanedChildWorkflowReclaim = func(string) bool { return true }
+		s.mockShard.GetConfig().EnableOrphanedChildWorkflowReplacement = func(string) bool { return true }
 		mutableState := historyi.NewMockMutableState(gomock.NewController(s.T()))
 		mutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
 			NamespaceId: "same-namespace",

--- a/service/history/transfer_queue_active_task_executor_test.go
+++ b/service/history/transfer_queue_active_task_executor_test.go
@@ -2620,11 +2620,126 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Fa
 		rootExecutionInfo,
 		nil,
 	)).Return(nil, serviceerror.NewWorkflowExecutionAlreadyStarted("msg", "", ""))
+	// Orphaned-child replacement is opt-in, so this request carries no zombify intent and records
+	// StartChildExecutionFailed(WORKFLOW_ALREADY_EXISTS) exactly as it did before that feature.
 	s.mockExecutionMgr.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(tests.UpdateWorkflowExecutionResponse, nil)
 	s.mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(s.namespaceEntry.IsGlobalNamespace(), s.version).Return(cluster.TestCurrentClusterName).AnyTimes()
 
 	resp := s.transferQueueActiveTaskExecutor.Execute(context.Background(), s.newTaskExecutable(transferTask))
 	s.NoError(resp.ExecutionErr)
+}
+
+func (s *transferQueueActiveTaskExecutorSuite) TestCanZombifyConflictingChild() {
+	const childWorkflowID = "child-workflow"
+	childInfo := &persistencespb.ChildExecutionInfo{
+		InitiatedEventId:  75,
+		StartedWorkflowId: childWorkflowID,
+	}
+
+	testCases := []struct {
+		name            string
+		enabled         bool
+		reusePolicy     enumspb.WorkflowIdReusePolicy
+		pendingChildren map[int64]*persistencespb.ChildExecutionInfo
+		expected        bool
+	}{
+		{
+			name:            "disabled",
+			pendingChildren: map[int64]*persistencespb.ChildExecutionInfo{75: childInfo},
+		},
+		{
+			name:            "allow duplicate",
+			enabled:         true,
+			reusePolicy:     enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+			pendingChildren: map[int64]*persistencespb.ChildExecutionInfo{75: childInfo},
+			expected:        true,
+		},
+		{
+			name:            "unspecified reuse policy",
+			enabled:         true,
+			pendingChildren: map[int64]*persistencespb.ChildExecutionInfo{75: childInfo},
+			expected:        true,
+		},
+		{
+			name:            "reject duplicate",
+			enabled:         true,
+			reusePolicy:     enumspb.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
+			pendingChildren: map[int64]*persistencespb.ChildExecutionInfo{75: childInfo},
+		},
+		{
+			name:            "allow duplicate failed only",
+			enabled:         true,
+			reusePolicy:     enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
+			pendingChildren: map[int64]*persistencespb.ChildExecutionInfo{75: childInfo},
+		},
+		{
+			name:        "another accepted child uses the workflow ID",
+			enabled:     true,
+			reusePolicy: enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+			pendingChildren: map[int64]*persistencespb.ChildExecutionInfo{
+				72: {InitiatedEventId: 72, StartedWorkflowId: childWorkflowID},
+				75: childInfo,
+			},
+		},
+		{
+			name:        "other accepted children use different workflow IDs",
+			enabled:     true,
+			reusePolicy: enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+			pendingChildren: map[int64]*persistencespb.ChildExecutionInfo{
+				72: {InitiatedEventId: 72, StartedWorkflowId: "other-child"},
+				75: childInfo,
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.mockShard.GetConfig().EnableOrphanedChildWorkflowReclaim = func(string) bool {
+				return tc.enabled
+			}
+			mutableState := historyi.NewMockMutableState(gomock.NewController(s.T()))
+			mutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
+				NamespaceId: "parent-namespace",
+				WorkflowId:  "parent-workflow",
+			}).AnyTimes()
+			mutableState.EXPECT().GetPendingChildExecutionInfos().Return(tc.pendingChildren).AnyTimes()
+			attributes := &historypb.StartChildWorkflowExecutionInitiatedEventAttributes{
+				WorkflowIdReusePolicy: tc.reusePolicy,
+			}
+
+			s.Equal(tc.expected, s.transferQueueActiveTaskExecutor.canZombifyConflictingChild(
+				mutableState,
+				childInfo,
+				attributes,
+				tests.Namespace,
+			))
+		})
+	}
+
+	s.Run("child workflow ID collides with parent", func() {
+		s.mockShard.GetConfig().EnableOrphanedChildWorkflowReclaim = func(string) bool { return true }
+		mutableState := historyi.NewMockMutableState(gomock.NewController(s.T()))
+		mutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
+			NamespaceId: "same-namespace",
+			WorkflowId:  "same-workflow",
+		})
+		selfChild := &persistencespb.ChildExecutionInfo{
+			InitiatedEventId:  75,
+			Namespace:         tests.Namespace.String(),
+			StartedWorkflowId: "same-workflow",
+		}
+		attributes := &historypb.StartChildWorkflowExecutionInitiatedEventAttributes{
+			WorkflowIdReusePolicy: enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+		}
+
+		s.False(s.transferQueueActiveTaskExecutor.canZombifyConflictingChild(
+			mutableState,
+			selfChild,
+			attributes,
+			tests.Namespace,
+		))
+	})
 }
 
 func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Failure_InvalidVersioningOverride() {

--- a/service/history/transfer_queue_active_task_executor_test.go
+++ b/service/history/transfer_queue_active_task_executor_test.go
@@ -2636,10 +2636,11 @@ func (s *transferQueueActiveTaskExecutorSuite) TestCanZombifyConflictingChild() 
 		StartedWorkflowId: childWorkflowID,
 	}
 
+	// Policy checks live in api.validateOrphanedChild, under the conflicting run's lock; see
+	// TestValidateOrphanedChild. This decides only what the parent alone can decide.
 	testCases := []struct {
 		name            string
 		enabled         bool
-		reusePolicy     enumspb.WorkflowIdReusePolicy
 		pendingChildren map[int64]*persistencespb.ChildExecutionInfo
 		expected        bool
 	}{
@@ -2648,43 +2649,22 @@ func (s *transferQueueActiveTaskExecutorSuite) TestCanZombifyConflictingChild() 
 			pendingChildren: map[int64]*persistencespb.ChildExecutionInfo{75: childInfo},
 		},
 		{
-			name:            "allow duplicate",
-			enabled:         true,
-			reusePolicy:     enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
-			pendingChildren: map[int64]*persistencespb.ChildExecutionInfo{75: childInfo},
-			expected:        true,
-		},
-		{
-			name:            "unspecified reuse policy",
+			name:            "only this initiation holds the workflow ID",
 			enabled:         true,
 			pendingChildren: map[int64]*persistencespb.ChildExecutionInfo{75: childInfo},
 			expected:        true,
 		},
 		{
-			name:            "reject duplicate",
-			enabled:         true,
-			reusePolicy:     enumspb.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
-			pendingChildren: map[int64]*persistencespb.ChildExecutionInfo{75: childInfo},
-		},
-		{
-			name:            "allow duplicate failed only",
-			enabled:         true,
-			reusePolicy:     enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
-			pendingChildren: map[int64]*persistencespb.ChildExecutionInfo{75: childInfo},
-		},
-		{
-			name:        "another accepted child uses the workflow ID",
-			enabled:     true,
-			reusePolicy: enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+			name:    "another accepted child uses the workflow ID",
+			enabled: true,
 			pendingChildren: map[int64]*persistencespb.ChildExecutionInfo{
 				72: {InitiatedEventId: 72, StartedWorkflowId: childWorkflowID},
 				75: childInfo,
 			},
 		},
 		{
-			name:        "other accepted children use different workflow IDs",
-			enabled:     true,
-			reusePolicy: enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+			name:    "other accepted children use different workflow IDs",
+			enabled: true,
 			pendingChildren: map[int64]*persistencespb.ChildExecutionInfo{
 				72: {InitiatedEventId: 72, StartedWorkflowId: "other-child"},
 				75: childInfo,
@@ -2704,19 +2684,17 @@ func (s *transferQueueActiveTaskExecutorSuite) TestCanZombifyConflictingChild() 
 				WorkflowId:  "parent-workflow",
 			}).AnyTimes()
 			mutableState.EXPECT().GetPendingChildExecutionInfos().Return(tc.pendingChildren).AnyTimes()
-			attributes := &historypb.StartChildWorkflowExecutionInitiatedEventAttributes{
-				WorkflowIdReusePolicy: tc.reusePolicy,
-			}
 
 			s.Equal(tc.expected, s.transferQueueActiveTaskExecutor.canZombifyConflictingChild(
 				mutableState,
 				childInfo,
-				attributes,
 				tests.Namespace,
 			))
 		})
 	}
 
+	// The parent's lock is held across startChildWorkflow, so the zombify transaction must never be
+	// pointed at the parent itself.
 	s.Run("child workflow ID collides with parent", func() {
 		s.mockShard.GetConfig().EnableOrphanedChildWorkflowReplacement = func(string) bool { return true }
 		mutableState := historyi.NewMockMutableState(gomock.NewController(s.T()))
@@ -2729,14 +2707,10 @@ func (s *transferQueueActiveTaskExecutorSuite) TestCanZombifyConflictingChild() 
 			Namespace:         tests.Namespace.String(),
 			StartedWorkflowId: "same-workflow",
 		}
-		attributes := &historypb.StartChildWorkflowExecutionInitiatedEventAttributes{
-			WorkflowIdReusePolicy: enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
-		}
 
 		s.False(s.transferQueueActiveTaskExecutor.canZombifyConflictingChild(
 			mutableState,
 			selfChild,
-			attributes,
 			tests.Namespace,
 		))
 	})

--- a/tests/ndc/child_workflow_force_failover_test.go
+++ b/tests/ndc/child_workflow_force_failover_test.go
@@ -1,0 +1,695 @@
+package ndc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
+	replicationpb "go.temporal.io/api/replication/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/api/adminservicemock/v1"
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	historyspb "go.temporal.io/server/api/history/v1"
+	"go.temporal.io/server/api/historyservice/v1"
+	replicationspb "go.temporal.io/server/api/replication/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/headers"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/testing/await"
+	"go.temporal.io/server/common/testing/protorequire"
+	"go.temporal.io/server/tests/testcore"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// ChildWorkflowForceFailoverSuite reproduces the "orphaned child after force failover" bug.
+//
+// Real cluster = cluster-a (initialFailoverVersion 1). We inject, via replication into the
+// passive cluster-a:
+//   - a child workflow created by the OLD active (cluster-b, version 2), whose parent pointer
+//     (parentInitiatedEventId=5, parentInitiatedEventVersion=2) is NOT on the parent's winning branch.
+//   - a parent workflow whose winning/current branch (cluster-c, version 3) ends with a pending
+//     StartChildWorkflowExecutionInitiated (event 5) for the SAME child workflow id.
+//
+// We then force-failover the namespace to cluster-a (making the real cluster active) and
+// RefreshWorkflowTasks on the parent. This regenerates the parent's StartChildExecution transfer
+// task, which the active executor processes: startWorkflow finds the child already exists and
+// currently records START_CHILD_WORKFLOW_EXECUTION_FAILED(WORKFLOW_ALREADY_EXISTS), orphaning the child.
+type ChildWorkflowForceFailoverSuite struct {
+	*require.Assertions
+	protorequire.ProtoAssertions
+	suite.Suite
+
+	testClusterFactory testcore.TestClusterFactory
+	controller         *gomock.Controller
+	cluster            *testcore.TestCluster
+	serializer         serialization.Serializer
+	logger             log.Logger
+	mockAdminClient    map[string]adminservice.AdminServiceClient
+
+	namespace   namespace.Name
+	namespaceID namespace.ID
+}
+
+const (
+	oldActiveVersion = int64(2) // cluster-b: where the child was created (losing branch).
+	winningVersion   = int64(3) // cluster-c: parent's winning branch (higher version wins).
+)
+
+func TestChildWorkflowForceFailoverSuite(t *testing.T) {
+	suite.Run(t, new(ChildWorkflowForceFailoverSuite))
+}
+
+func (s *ChildWorkflowForceFailoverSuite) SetupSuite() {
+	s.logger = log.NewTestLogger()
+	s.serializer = serialization.NewSerializer()
+	s.testClusterFactory = testcore.NewTestClusterFactory()
+
+	clusterConfigs := clustersConfig("cluster-a", "cluster-b", "cluster-c")
+	clusterConfigs[0].WorkerConfig = testcore.WorkerConfig{DisableWorker: true}
+	// Replacing an orphaned child suppresses an existing workflow, so it ships opt-in.
+	clusterConfigs[0].DynamicConfigOverrides = map[dynamicconfig.Key]any{
+		dynamicconfig.EnableOrphanedChildWorkflowReclaim.Key(): true,
+	}
+
+	s.controller = gomock.NewController(s.T())
+	mockStreamClient := adminservicemock.NewMockAdminService_StreamWorkflowReplicationMessagesClient(s.controller)
+	mockStreamClient.EXPECT().Send(gomock.Any()).Return(nil).AnyTimes()
+	mockStreamClient.EXPECT().Recv().Return(&adminservice.StreamWorkflowReplicationMessagesResponse{
+		Attributes: &adminservice.StreamWorkflowReplicationMessagesResponse_Messages{
+			Messages: &replicationspb.WorkflowReplicationMessages{
+				ReplicationTasks:           []*replicationspb.ReplicationTask{},
+				ExclusiveHighWatermark:     100,
+				ExclusiveHighWatermarkTime: timestamppb.New(time.Unix(0, 100)),
+			},
+		},
+	}, nil).AnyTimes()
+	mockStreamClient.EXPECT().CloseSend().Return(nil).AnyTimes()
+
+	mockRemoteClient := adminservicemock.NewMockAdminServiceClient(s.controller)
+	mockRemoteClient.EXPECT().GetReplicationMessages(gomock.Any(), gomock.Any()).Return(
+		&adminservice.GetReplicationMessagesResponse{
+			ShardMessages: make(map[int32]*replicationspb.ReplicationMessages),
+		}, nil).AnyTimes()
+	mockRemoteClient.EXPECT().StreamWorkflowReplicationMessages(gomock.Any()).Return(mockStreamClient, nil).AnyTimes()
+	mockOtherClient := adminservicemock.NewMockAdminServiceClient(s.controller)
+	mockOtherClient.EXPECT().GetReplicationMessages(gomock.Any(), gomock.Any()).Return(
+		&adminservice.GetReplicationMessagesResponse{
+			ShardMessages: make(map[int32]*replicationspb.ReplicationMessages),
+		}, nil).AnyTimes()
+	mockOtherClient.EXPECT().StreamWorkflowReplicationMessages(gomock.Any()).Return(mockStreamClient, nil).AnyTimes()
+	s.mockAdminClient = map[string]adminservice.AdminServiceClient{
+		"cluster-b": mockRemoteClient,
+		"cluster-c": mockOtherClient,
+	}
+	clusterConfigs[0].MockAdminClient = s.mockAdminClient
+
+	cluster, err := s.testClusterFactory.NewCluster(s.T(), clusterConfigs[0], log.With(s.logger, tag.ClusterName(clusterName[0])))
+	s.Require().NoError(err)
+	s.cluster = cluster
+}
+
+func (s *ChildWorkflowForceFailoverSuite) TearDownSuite() {
+	s.controller.Finish()
+	s.NoError(s.cluster.TearDownCluster())
+}
+
+func (s *ChildWorkflowForceFailoverSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+	s.ProtoAssertions = protorequire.New(s.T())
+	// Fresh global namespace per test, initially active on cluster-b so the real cluster-a is passive
+	// and accepts replicated events. Each test then force-fails-over to cluster-a.
+	s.registerNamespace()
+}
+
+func (s *ChildWorkflowForceFailoverSuite) registerNamespace() {
+	s.namespace = namespace.Name("child-ff-ndc-" + common.GenerateRandomString(5))
+	frontend := s.cluster.FrontendClient()
+	_, err := frontend.RegisterNamespace(s.newContext(), &workflowservice.RegisterNamespaceRequest{
+		Namespace:                        s.namespace.String(),
+		IsGlobalNamespace:                true,
+		Clusters:                         clusterReplicationConfig,
+		ActiveClusterName:                clusterName[1], // cluster-b: real cluster-a is passive.
+		WorkflowExecutionRetentionPeriod: durationpb.New(24 * time.Hour),
+	})
+	s.Require().NoError(err)
+	time.Sleep(2 * testcore.NamespaceCacheRefreshInterval) //nolint:forbidigo
+
+	resp, err := frontend.DescribeNamespace(s.newContext(), &workflowservice.DescribeNamespaceRequest{Namespace: s.namespace.String()})
+	s.Require().NoError(err)
+	s.namespaceID = namespace.ID(resp.GetNamespaceInfo().GetId())
+	s.logger.Info("Registered namespace", tag.WorkflowNamespace(s.namespace.String()), tag.WorkflowNamespaceID(s.namespaceID.String()))
+}
+
+func (s *ChildWorkflowForceFailoverSuite) newContext() context.Context {
+	ctx := testcore.NewContext()
+	return headers.SetCallerInfo(ctx, headers.NewCallerInfo(s.namespace.String(), headers.CallerTypeAPI, ""))
+}
+
+// TestOrphanChild_Case1_ChildStartedOnly reproduces Case 1: the orphaned child has only
+// WorkflowExecutionStarted (its first workflow task not yet scheduled).
+func (s *ChildWorkflowForceFailoverSuite) TestOrphanChild_Case1_ChildStartedOnly() {
+	parentID, parentRunID := s.newParent()
+	childID, childRunID, taskqueue := s.newChild()
+
+	childEvents := []*historypb.HistoryEvent{s.childStartedEvent(parentID, parentRunID, childRunID, taskqueue)}
+	childVH := []*historyspb.VersionHistoryItem{{EventId: 1, Version: oldActiveVersion}}
+
+	s.plantOrphanAndFailover(parentID, parentRunID, childID, childRunID, childEvents, childVH, enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE)
+	s.assertChildAdopted(parentID, parentRunID, childID, childRunID)
+}
+
+// TestOrphanChild_Case2_ChildWorkflowTaskScheduled reproduces Case 2: the orphaned child has
+// WorkflowExecutionStarted + WorkflowTaskScheduled (its first workflow task scheduled but not run).
+func (s *ChildWorkflowForceFailoverSuite) TestOrphanChild_Case2_ChildWorkflowTaskScheduled() {
+	parentID, parentRunID := s.newParent()
+	childID, childRunID, taskqueue := s.newChild()
+
+	childEvents := []*historypb.HistoryEvent{
+		s.childStartedEvent(parentID, parentRunID, childRunID, taskqueue),
+		{
+			EventId:   2,
+			Version:   oldActiveVersion,
+			EventTime: timestamppb.New(time.Now().UTC()),
+			EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED,
+			Attributes: &historypb.HistoryEvent_WorkflowTaskScheduledEventAttributes{WorkflowTaskScheduledEventAttributes: &historypb.WorkflowTaskScheduledEventAttributes{
+				TaskQueue:           &taskqueuepb.TaskQueue{Name: taskqueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				StartToCloseTimeout: durationpb.New(10 * time.Second),
+				Attempt:             1,
+			}},
+		},
+	}
+	childVH := []*historyspb.VersionHistoryItem{{EventId: 2, Version: oldActiveVersion}}
+
+	s.plantOrphanAndFailover(parentID, parentRunID, childID, childRunID, childEvents, childVH, enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE)
+	s.assertChildAdopted(parentID, parentRunID, childID, childRunID)
+}
+
+// TestOrphanChild_Case3_ChildClosed covers a CLOSED orphaned child. Adopting its completed result is
+// the correct end state but is a proposal only (see child_workflow_force_failover_case3_proposal.md).
+// Until then the fix must at least be SAFE: it must NOT replace a closed child (that
+// would re-run its activities/side effects) — it falls back to StartChildExecutionFailed and leaves the
+// completed child untouched.
+func (s *ChildWorkflowForceFailoverSuite) TestOrphanChild_Case3_ChildClosed() {
+	parentID, parentRunID := s.newParent()
+	childID, childRunID, taskqueue := s.newChild()
+
+	childEvents := s.closedChildEvents(parentID, parentRunID, childRunID, taskqueue)
+	childVH := []*historyspb.VersionHistoryItem{{EventId: int64(len(childEvents)), Version: oldActiveVersion}}
+
+	// REJECT_DUPLICATE so the closed child yields WorkflowExecutionAlreadyStarted (rather than silently
+	// starting a fresh run under ALLOW_DUPLICATE, which reuse policy explicitly permits).
+	s.plantOrphanAndFailover(parentID, parentRunID, childID, childRunID, childEvents, childVH, enumspb.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE)
+
+	startFailed, cause, childStarted := s.waitForChildStartOutcome(parentID, parentRunID)
+	s.True(startFailed, "closed child must fall back to StartChildExecutionFailed, not be re-run")
+	s.Equal(enumspb.START_CHILD_WORKFLOW_EXECUTION_FAILED_CAUSE_WORKFLOW_ALREADY_EXISTS, cause)
+	s.False(childStarted)
+
+	// The closed child must be untouched: the current run is still the original, completed run.
+	desc, err := s.cluster.FrontendClient().DescribeWorkflowExecution(s.newContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: s.namespace.String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: childID}, // no run id => current run
+	})
+	s.NoError(err)
+	s.Equal(childRunID, desc.GetWorkflowExecutionInfo().GetExecution().GetRunId(), "closed child must not be re-run into a new run")
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, desc.GetWorkflowExecutionInfo().GetStatus())
+}
+
+// TestOrphanChild_ExecutedChild_Zombified covers an orphaned child that has already completed a
+// workflow task and scheduled an activity. The old run is suppressed rather than terminated before
+// the replacement run is created.
+func (s *ChildWorkflowForceFailoverSuite) TestOrphanChild_ExecutedChild_Zombified() {
+	parentID, parentRunID := s.newParent()
+	childID, childRunID, taskqueue := s.newChild()
+
+	childEvents := s.executedChildEvents(parentID, parentRunID, childRunID, taskqueue)
+	childVH := []*historyspb.VersionHistoryItem{{EventId: int64(len(childEvents)), Version: oldActiveVersion}}
+
+	s.plantOrphanAndFailover(parentID, parentRunID, childID, childRunID, childEvents, childVH, enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE)
+	s.assertChildAdopted(parentID, parentRunID, childID, childRunID)
+}
+
+// TestOrphanChild_OperatorStartedSameId verifies that atomic ownership validation rejects an
+// unrelated workflow holding the child workflow ID.
+func (s *ChildWorkflowForceFailoverSuite) TestOrphanChild_OperatorStartedSameId() {
+	parentID, parentRunID := s.newParent()
+	childID, operatorRunID, taskqueue := s.newChild()
+
+	// A standalone (parentless) running workflow occupying the child workflow id.
+	operatorEvents := []*historypb.HistoryEvent{
+		{
+			EventId:   1,
+			Version:   oldActiveVersion,
+			EventTime: timestamppb.New(time.Now().UTC()),
+			EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+			Attributes: &historypb.HistoryEvent_WorkflowExecutionStartedEventAttributes{WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{
+				WorkflowType:        &commonpb.WorkflowType{Name: "operator-workflow-type"},
+				TaskQueue:           &taskqueuepb.TaskQueue{Name: taskqueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				WorkflowRunTimeout:  durationpb.New(1000 * time.Second),
+				WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+				// no ParentWorkflowExecution => not a child of anyone
+				OriginalExecutionRunId: operatorRunID,
+				FirstExecutionRunId:    operatorRunID,
+				Attempt:                1,
+			}},
+		},
+	}
+	operatorVH := []*historyspb.VersionHistoryItem{{EventId: 1, Version: oldActiveVersion}}
+
+	s.plantOrphanAndFailover(parentID, parentRunID, childID, operatorRunID, operatorEvents, operatorVH, enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE)
+
+	// The parent must fail the start rather than adopt/terminate the unrelated workflow.
+	startFailed, cause, childStarted := s.waitForChildStartOutcome(parentID, parentRunID)
+	s.True(startFailed, "expected StartChildExecutionFailed for the unrelated workflow id")
+	s.Equal(enumspb.START_CHILD_WORKFLOW_EXECUTION_FAILED_CAUSE_WORKFLOW_ALREADY_EXISTS, cause)
+	s.False(childStarted, "parent must not adopt the operator's workflow as its child")
+
+	// And the operator's workflow must be untouched (still running).
+	desc, err := s.cluster.FrontendClient().DescribeWorkflowExecution(s.newContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: s.namespace.String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: childID, RunId: operatorRunID},
+	})
+	s.NoError(err)
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, desc.GetWorkflowExecutionInfo().GetStatus(),
+		"operator's workflow must not be terminated by the parent's child start")
+}
+
+// TestOrphanChild_SelfWorkflowIdCollision verifies that a child start using the parent's own workflow
+// ID fails without attempting to lock the parent recursively.
+func (s *ChildWorkflowForceFailoverSuite) TestOrphanChild_SelfWorkflowIdCollision() {
+	parentID, parentRunID := s.newParent()
+	taskqueue := "child-ff-taskqueue"
+
+	// Parent's winning branch ends in a pending StartChild whose child id == the parent's own id. No
+	// separate child is planted; the "existing" workflow the start collides with is the parent itself.
+	s.replicate(parentID, parentRunID, []*historyspb.VersionHistoryItem{{EventId: 5, Version: winningVersion}},
+		s.parentEventsWithPendingChild(parentRunID, parentID /* childID == parentID */, taskqueue, winningVersion, enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE))
+
+	s.failoverToRealCluster()
+	s.refreshWorkflowTasks(parentID, parentRunID)
+
+	// Must fail fast rather than deadlock on describing the locked parent.
+	startFailed, cause, childStarted := s.waitForChildStartOutcome(parentID, parentRunID)
+	s.True(startFailed, "self-id child collision must record StartChildExecutionFailed, not deadlock")
+	s.Equal(enumspb.START_CHILD_WORKFLOW_EXECUTION_FAILED_CAUSE_WORKFLOW_ALREADY_EXISTS, cause)
+	s.False(childStarted)
+}
+
+func (s *ChildWorkflowForceFailoverSuite) newParent() (parentID, parentRunID string) {
+	return "parent-wf-" + uuid.NewString(), uuid.NewString()
+}
+
+func (s *ChildWorkflowForceFailoverSuite) newChild() (childID, childRunID, taskqueue string) {
+	return "child-wf-" + uuid.NewString(), uuid.NewString(), "child-ff-taskqueue"
+}
+
+// plantOrphanAndFailover plants the orphaned child + a parent whose winning branch (version 3) ends
+// in a pending StartChildWorkflowExecutionInitiated for the same child id, force-fails-over to the
+// real cluster, and refreshes the parent's tasks to regenerate the StartChildExecution transfer task.
+func (s *ChildWorkflowForceFailoverSuite) plantOrphanAndFailover(
+	parentID string,
+	parentRunID string,
+	childID string,
+	childRunID string,
+	childEvents []*historypb.HistoryEvent,
+	childVH []*historyspb.VersionHistoryItem,
+	reusePolicy enumspb.WorkflowIdReusePolicy,
+) {
+	taskqueue := "child-ff-taskqueue"
+
+	// 1) Plant the orphaned child (created by the old active, version 2), whose parent pointer
+	//    (initiatedEventId=5, version=2) points at the parent's LOSING branch.
+	s.replicate(childID, childRunID, childVH, childEvents)
+
+	// 2) Plant the parent's stale LOSING branch (v2) — this replicates the lower-FV events (incl. the
+	//    child's initiation at ev5@v2) and creates the workflow with the v2 branch current. Sent as two
+	//    batches so ev3 is a batch boundary the winning branch can fork at.
+	s.replicateBatches(parentID, parentRunID,
+		[]*historyspb.VersionHistoryItem{{EventId: 5, Version: oldActiveVersion}},
+		s.parentLosingBranch(parentRunID, childID, taskqueue))
+
+	// 3) Plant the parent's WINNING branch (v3), forking after the shared prefix (ev3). Higher FV, so
+	//    NDC conflict resolution makes it current and demotes the v2 branch to non-current. Its pending
+	//    StartChild (ev8) is what the transfer task will process after failover.
+	s.replicate(parentID, parentRunID,
+		[]*historyspb.VersionHistoryItem{{EventId: 3, Version: oldActiveVersion}, {EventId: 8, Version: winningVersion}},
+		s.parentWinningBranchSuffix(childID, taskqueue, reusePolicy))
+
+	// 4) Force-failover to make the real cluster active.
+	s.failoverToRealCluster()
+
+	// 5) Regenerate the parent's StartChildExecution transfer task on the now-active cluster.
+	s.refreshWorkflowTasks(parentID, parentRunID)
+}
+
+// childStartedEvent builds the child's WorkflowExecutionStarted event whose parent pointer references
+// the parent at (initiatedEventId=5, version=oldActiveVersion) — not on the parent's winning branch.
+func (s *ChildWorkflowForceFailoverSuite) childStartedEvent(parentID, parentRunID, childRunID, taskqueue string) *historypb.HistoryEvent {
+	return &historypb.HistoryEvent{
+		EventId:   1,
+		Version:   oldActiveVersion,
+		EventTime: timestamppb.New(time.Now().UTC()),
+		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+		Attributes: &historypb.HistoryEvent_WorkflowExecutionStartedEventAttributes{WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{
+			WorkflowType:                &commonpb.WorkflowType{Name: "child-workflow-type"},
+			TaskQueue:                   &taskqueuepb.TaskQueue{Name: taskqueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			WorkflowRunTimeout:          durationpb.New(1000 * time.Second),
+			WorkflowTaskTimeout:         durationpb.New(10 * time.Second),
+			ParentWorkflowNamespace:     s.namespace.String(),
+			ParentWorkflowNamespaceId:   s.namespaceID.String(),
+			ParentWorkflowExecution:     &commonpb.WorkflowExecution{WorkflowId: parentID, RunId: parentRunID},
+			ParentInitiatedEventId:      5,
+			ParentInitiatedEventVersion: oldActiveVersion,
+			OriginalExecutionRunId:      childRunID,
+			FirstExecutionRunId:         childRunID,
+			Attempt:                     1,
+		}},
+	}
+}
+
+// executedChildEvents builds a child history for a run that is still RUNNING but has already executed:
+// its first workflow task completed and it scheduled an activity. That makes
+// LastCompletedWorkflowTaskStartedEventId and ActivityCount non-zero, which is what marks it unsafe to
+// terminate and restart.
+func (s *ChildWorkflowForceFailoverSuite) executedChildEvents(parentID, parentRunID, childRunID, taskqueue string) []*historypb.HistoryEvent {
+	v := oldActiveVersion
+	return []*historypb.HistoryEvent{
+		s.childStartedEvent(parentID, parentRunID, childRunID, taskqueue),
+		s.evWFTScheduled(2, v, taskqueue),
+		s.evWFTStarted(3, v, 2),
+		s.evWFTCompleted(4, v, 2, 3),
+		{
+			EventId: 5, Version: v, EventTime: timestamppb.New(time.Now().UTC()),
+			EventType: enumspb.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED,
+			Attributes: &historypb.HistoryEvent_ActivityTaskScheduledEventAttributes{ActivityTaskScheduledEventAttributes: &historypb.ActivityTaskScheduledEventAttributes{
+				WorkflowTaskCompletedEventId: 4,
+				ActivityId:                   "0",
+				ActivityType:                 &commonpb.ActivityType{Name: "child-activity-type"},
+				TaskQueue:                    &taskqueuepb.TaskQueue{Name: taskqueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				ScheduleToCloseTimeout:       durationpb.New(100 * time.Second),
+				ScheduleToStartTimeout:       durationpb.New(100 * time.Second),
+				StartToCloseTimeout:          durationpb.New(100 * time.Second),
+				HeartbeatTimeout:             durationpb.New(100 * time.Second),
+			}},
+		},
+	}
+}
+
+// closedChildEvents builds a full child history that ends in WorkflowExecutionCompleted.
+func (s *ChildWorkflowForceFailoverSuite) closedChildEvents(parentID, parentRunID, childRunID, taskqueue string) []*historypb.HistoryEvent {
+	started := s.childStartedEvent(parentID, parentRunID, childRunID, taskqueue)
+	return []*historypb.HistoryEvent{
+		started,
+		{
+			EventId: 2, Version: oldActiveVersion, EventTime: timestamppb.New(time.Now().UTC()),
+			EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED,
+			Attributes: &historypb.HistoryEvent_WorkflowTaskScheduledEventAttributes{WorkflowTaskScheduledEventAttributes: &historypb.WorkflowTaskScheduledEventAttributes{
+				TaskQueue: &taskqueuepb.TaskQueue{Name: taskqueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}, StartToCloseTimeout: durationpb.New(10 * time.Second), Attempt: 1,
+			}},
+		},
+		{
+			EventId: 3, Version: oldActiveVersion, EventTime: timestamppb.New(time.Now().UTC()),
+			EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED,
+			Attributes: &historypb.HistoryEvent_WorkflowTaskStartedEventAttributes{WorkflowTaskStartedEventAttributes: &historypb.WorkflowTaskStartedEventAttributes{
+				ScheduledEventId: 2, Identity: "worker", RequestId: uuid.NewString(),
+			}},
+		},
+		{
+			EventId: 4, Version: oldActiveVersion, EventTime: timestamppb.New(time.Now().UTC()),
+			EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,
+			Attributes: &historypb.HistoryEvent_WorkflowTaskCompletedEventAttributes{WorkflowTaskCompletedEventAttributes: &historypb.WorkflowTaskCompletedEventAttributes{
+				ScheduledEventId: 2, StartedEventId: 3, Identity: "worker",
+			}},
+		},
+		{
+			EventId: 5, Version: oldActiveVersion, EventTime: timestamppb.New(time.Now().UTC()),
+			EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED,
+			Attributes: &historypb.HistoryEvent_WorkflowExecutionCompletedEventAttributes{WorkflowExecutionCompletedEventAttributes: &historypb.WorkflowExecutionCompletedEventAttributes{
+				WorkflowTaskCompletedEventId: 4,
+			}},
+		},
+	}
+}
+
+// assertChildAdopted asserts the FIXED behavior: the parent replaces the orphaned child after
+// suppressing the old run — it records CHILD_WORKFLOW_EXECUTION_STARTED and never
+// START_CHILD_WORKFLOW_EXECUTION_FAILED.
+// This FAILS before the fix (parent records StartChildExecutionFailed / WORKFLOW_ALREADY_EXISTS).
+func (s *ChildWorkflowForceFailoverSuite) assertChildAdopted(parentID, parentRunID, childID, origChildRunID string) {
+	startFailed, cause, childStarted := s.waitForChildStartOutcome(parentID, parentRunID)
+	s.False(startFailed, "BUG: parent recorded StartChildExecutionFailed(%s) instead of replacing the orphaned child", cause)
+	s.True(childStarted, "expected parent to record ChildWorkflowExecutionStarted after adopting the child")
+
+	oldChild, err := s.cluster.AdminClient().DescribeMutableState(s.newContext(), &adminservice.DescribeMutableStateRequest{
+		Namespace: s.namespace.String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: childID, RunId: origChildRunID},
+		Archetype: chasm.WorkflowArchetype,
+	})
+	s.NoError(err)
+	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE,
+		oldChild.GetDatabaseMutableState().GetExecutionState().GetState())
+
+	currentChild, err := s.cluster.FrontendClient().DescribeWorkflowExecution(s.newContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: s.namespace.String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: childID},
+	})
+	s.NoError(err)
+	s.NotEqual(origChildRunID, currentChild.GetWorkflowExecutionInfo().GetExecution().GetRunId())
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, currentChild.GetWorkflowExecutionInfo().GetStatus())
+}
+
+// waitForChildStartOutcome blocks until the parent records either a child-start failure or a
+// child-started event, then returns the observed outcome.
+func (s *ChildWorkflowForceFailoverSuite) waitForChildStartOutcome(parentID, parentRunID string) (startFailed bool, cause enumspb.StartChildWorkflowExecutionFailedCause, childStarted bool) {
+	await.RequireTruef(s.T(), func() bool {
+		startFailed, cause, childStarted = s.parentChildStartOutcome(parentID, parentRunID)
+		return startFailed || childStarted
+	}, 30*time.Second, 500*time.Millisecond, "no start-child outcome on the parent yet")
+	return startFailed, cause, childStarted
+}
+
+// --- parent history event builders ---
+//
+// The parent is modeled with two real NDC branches, as a force failover produces:
+//   - a stale LOSING branch at oldActiveVersion (v2): the in-flight WT (ev3) completes and initiates
+//     the child at ev5 — this is where the replicated child's parent pointer (5, v2) lives;
+//   - a WINNING branch at winningVersion (v3): forks after ev3 (the in-flight WT is failed with
+//     FAILOVER_CLOSE_COMMAND, rescheduled, and re-run), re-issuing the child at ev8.
+// v3 > v2, so conflict resolution makes the winning branch current and keeps the losing branch as a
+// non-current version history — exactly the state on the new active after the failover.
+
+func (s *ChildWorkflowForceFailoverSuite) evWFStarted(id, version int64, runID, taskqueue string) *historypb.HistoryEvent {
+	return &historypb.HistoryEvent{
+		EventId: id, Version: version, EventTime: timestamppb.New(time.Now().UTC()),
+		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+		Attributes: &historypb.HistoryEvent_WorkflowExecutionStartedEventAttributes{WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{
+			WorkflowType:             &commonpb.WorkflowType{Name: "parent-workflow-type"},
+			TaskQueue:                &taskqueuepb.TaskQueue{Name: taskqueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			WorkflowRunTimeout:       durationpb.New(1000 * time.Second),
+			WorkflowTaskTimeout:      durationpb.New(10 * time.Second),
+			OriginalExecutionRunId:   runID,
+			FirstExecutionRunId:      runID,
+			Attempt:                  1,
+			FirstWorkflowTaskBackoff: durationpb.New(0),
+		}},
+	}
+}
+
+func (s *ChildWorkflowForceFailoverSuite) evWFTScheduled(id, version int64, taskqueue string) *historypb.HistoryEvent {
+	return &historypb.HistoryEvent{
+		EventId: id, Version: version, EventTime: timestamppb.New(time.Now().UTC()),
+		EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED,
+		Attributes: &historypb.HistoryEvent_WorkflowTaskScheduledEventAttributes{WorkflowTaskScheduledEventAttributes: &historypb.WorkflowTaskScheduledEventAttributes{
+			TaskQueue: &taskqueuepb.TaskQueue{Name: taskqueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}, StartToCloseTimeout: durationpb.New(10 * time.Second), Attempt: 1,
+		}},
+	}
+}
+
+func (s *ChildWorkflowForceFailoverSuite) evWFTStarted(id, version, schedID int64) *historypb.HistoryEvent {
+	return &historypb.HistoryEvent{
+		EventId: id, Version: version, EventTime: timestamppb.New(time.Now().UTC()),
+		EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED,
+		Attributes: &historypb.HistoryEvent_WorkflowTaskStartedEventAttributes{WorkflowTaskStartedEventAttributes: &historypb.WorkflowTaskStartedEventAttributes{
+			ScheduledEventId: schedID, Identity: "worker", RequestId: uuid.NewString(),
+		}},
+	}
+}
+
+func (s *ChildWorkflowForceFailoverSuite) evWFTCompleted(id, version, schedID, startedID int64) *historypb.HistoryEvent {
+	return &historypb.HistoryEvent{
+		EventId: id, Version: version, EventTime: timestamppb.New(time.Now().UTC()),
+		EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,
+		Attributes: &historypb.HistoryEvent_WorkflowTaskCompletedEventAttributes{WorkflowTaskCompletedEventAttributes: &historypb.WorkflowTaskCompletedEventAttributes{
+			ScheduledEventId: schedID, StartedEventId: startedID, Identity: "worker",
+		}},
+	}
+}
+
+func (s *ChildWorkflowForceFailoverSuite) evWFTFailedFailover(id, version, schedID, startedID int64) *historypb.HistoryEvent {
+	return &historypb.HistoryEvent{
+		EventId: id, Version: version, EventTime: timestamppb.New(time.Now().UTC()),
+		EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_FAILED,
+		Attributes: &historypb.HistoryEvent_WorkflowTaskFailedEventAttributes{WorkflowTaskFailedEventAttributes: &historypb.WorkflowTaskFailedEventAttributes{
+			ScheduledEventId: schedID, StartedEventId: startedID, Cause: enumspb.WORKFLOW_TASK_FAILED_CAUSE_FAILOVER_CLOSE_COMMAND, Identity: "history-service",
+		}},
+	}
+}
+
+func (s *ChildWorkflowForceFailoverSuite) evStartChildInitiated(id, version, wftCompletedID int64, childID, taskqueue string, reusePolicy enumspb.WorkflowIdReusePolicy) *historypb.HistoryEvent {
+	return &historypb.HistoryEvent{
+		EventId: id, Version: version, EventTime: timestamppb.New(time.Now().UTC()),
+		EventType: enumspb.EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED,
+		Attributes: &historypb.HistoryEvent_StartChildWorkflowExecutionInitiatedEventAttributes{StartChildWorkflowExecutionInitiatedEventAttributes: &historypb.StartChildWorkflowExecutionInitiatedEventAttributes{
+			Namespace:                    s.namespace.String(),
+			NamespaceId:                  s.namespaceID.String(),
+			WorkflowId:                   childID,
+			WorkflowType:                 &commonpb.WorkflowType{Name: "child-workflow-type"},
+			TaskQueue:                    &taskqueuepb.TaskQueue{Name: taskqueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			WorkflowTaskCompletedEventId: wftCompletedID,
+			WorkflowRunTimeout:           durationpb.New(1000 * time.Second),
+			WorkflowTaskTimeout:          durationpb.New(10 * time.Second),
+			ParentClosePolicy:            enumspb.PARENT_CLOSE_POLICY_ABANDON,
+			WorkflowIdReusePolicy:        reusePolicy,
+		}},
+	}
+}
+
+// parentLosingBranch: events 1-5 at oldActiveVersion (v2), in TWO batches split after ev3. Ends with
+// StartChildInitiated at ev5 — the initiation the replicated child (parentInitiatedEventId=5,
+// version=2) points at. Version history [{5,2}]. The split makes ev3 a batch boundary so the winning
+// branch can fork there (NDC can only branch at a batch boundary).
+func (s *ChildWorkflowForceFailoverSuite) parentLosingBranch(runID, childID, taskqueue string) [][]*historypb.HistoryEvent {
+	v := oldActiveVersion
+	return [][]*historypb.HistoryEvent{
+		{ // batch 1: ends at ev3 (the fork point / in-flight WT)
+			s.evWFStarted(1, v, runID, taskqueue),
+			s.evWFTScheduled(2, v, taskqueue),
+			s.evWFTStarted(3, v, 2),
+		},
+		{ // batch 2: WT completes and initiates the child
+			s.evWFTCompleted(4, v, 2, 3),
+			s.evStartChildInitiated(5, v, 4, childID, taskqueue, enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE),
+		},
+	}
+}
+
+// parentWinningBranchSuffix: events 4-8 at winningVersion (v3), forking after the shared prefix (ev3).
+// The in-flight WT is failed (FAILOVER), rescheduled, re-run, and re-issues the child at ev8 (pending).
+// Version history [{3,2},{8,3}].
+func (s *ChildWorkflowForceFailoverSuite) parentWinningBranchSuffix(childID, taskqueue string, reusePolicy enumspb.WorkflowIdReusePolicy) []*historypb.HistoryEvent {
+	v := winningVersion
+	return []*historypb.HistoryEvent{
+		s.evWFTFailedFailover(4, v, 2, 3),
+		s.evWFTScheduled(5, v, taskqueue),
+		s.evWFTStarted(6, v, 5),
+		s.evWFTCompleted(7, v, 5, 6),
+		s.evStartChildInitiated(8, v, 7, childID, taskqueue, reusePolicy),
+	}
+}
+
+// parentEventsWithPendingChild builds a single-branch parent history (events 1-5) whose last event is a
+// pending StartChildWorkflowExecutionInitiated at the given version. Used where a divergent branch is
+// not needed (e.g. the self-id collision test).
+func (s *ChildWorkflowForceFailoverSuite) parentEventsWithPendingChild(
+	runID string,
+	childID string,
+	taskqueue string,
+	version int64,
+	reusePolicy enumspb.WorkflowIdReusePolicy,
+) []*historypb.HistoryEvent {
+	return []*historypb.HistoryEvent{
+		s.evWFStarted(1, version, runID, taskqueue),
+		s.evWFTScheduled(2, version, taskqueue),
+		s.evWFTStarted(3, version, 2),
+		s.evWFTCompleted(4, version, 2, 3),
+		s.evStartChildInitiated(5, version, 4, childID, taskqueue, reusePolicy),
+	}
+}
+
+// replicate injects a single batch of history events into the passive cluster via ReplicateEventsV2.
+func (s *ChildWorkflowForceFailoverSuite) replicate(
+	workflowID string,
+	runID string,
+	versionHistoryItems []*historyspb.VersionHistoryItem,
+	events []*historypb.HistoryEvent,
+) {
+	blob, err := s.serializer.SerializeEvents(events)
+	s.NoError(err)
+	req := &historyservice.ReplicateEventsV2Request{
+		NamespaceId:         s.namespaceID.String(),
+		WorkflowExecution:   &commonpb.WorkflowExecution{WorkflowId: workflowID, RunId: runID},
+		VersionHistoryItems: versionHistoryItems,
+		Events:              blob,
+	}
+	_, err = s.cluster.HistoryClient().ReplicateEventsV2(s.newContext(), req)
+	s.NoError(err, "failed to replicate events for %s", workflowID)
+}
+
+// replicateBatches injects multiple contiguous batches of history events (each its own ReplicateEventsV2
+// call, all carrying the same full version history), so batch boundaries exist where later branches fork.
+func (s *ChildWorkflowForceFailoverSuite) replicateBatches(
+	workflowID string,
+	runID string,
+	versionHistoryItems []*historyspb.VersionHistoryItem,
+	batches [][]*historypb.HistoryEvent,
+) {
+	for _, batch := range batches {
+		s.replicate(workflowID, runID, versionHistoryItems, batch)
+	}
+}
+
+// failoverToRealCluster force-fails-over the namespace to cluster-a (the real cluster), making it active.
+func (s *ChildWorkflowForceFailoverSuite) failoverToRealCluster() {
+	_, err := s.cluster.FrontendClient().UpdateNamespace(s.newContext(), &workflowservice.UpdateNamespaceRequest{
+		Namespace: s.namespace.String(),
+		ReplicationConfig: &replicationpb.NamespaceReplicationConfig{
+			ActiveClusterName: clusterName[0], // cluster-a
+		},
+	})
+	s.Require().NoError(err)
+	time.Sleep(2 * testcore.NamespaceCacheRefreshInterval) //nolint:forbidigo
+}
+
+func (s *ChildWorkflowForceFailoverSuite) refreshWorkflowTasks(workflowID, runID string) {
+	_, err := s.cluster.AdminClient().RefreshWorkflowTasks(s.newContext(), &adminservice.RefreshWorkflowTasksRequest{
+		NamespaceId: s.namespaceID.String(),
+		Execution:   &commonpb.WorkflowExecution{WorkflowId: workflowID, RunId: runID},
+	})
+	s.Require().NoError(err)
+}
+
+// parentChildStartOutcome scans the parent history for the child-start outcome.
+func (s *ChildWorkflowForceFailoverSuite) parentChildStartOutcome(workflowID, runID string) (startFailed bool, cause enumspb.StartChildWorkflowExecutionFailedCause, childStarted bool) {
+	resp, err := s.cluster.FrontendClient().GetWorkflowExecutionHistory(s.newContext(), &workflowservice.GetWorkflowExecutionHistoryRequest{
+		Namespace: s.namespace.String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: workflowID, RunId: runID},
+	})
+	if err != nil {
+		return false, enumspb.START_CHILD_WORKFLOW_EXECUTION_FAILED_CAUSE_UNSPECIFIED, false
+	}
+	for _, e := range resp.GetHistory().GetEvents() {
+		switch e.GetEventType() {
+		case enumspb.EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_FAILED:
+			return true, e.GetStartChildWorkflowExecutionFailedEventAttributes().GetCause(), childStarted
+		case enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED:
+			childStarted = true
+		default:
+		}
+	}
+	return startFailed, enumspb.START_CHILD_WORKFLOW_EXECUTION_FAILED_CAUSE_UNSPECIFIED, childStarted
+}

--- a/tests/ndc/child_workflow_force_failover_test.go
+++ b/tests/ndc/child_workflow_force_failover_test.go
@@ -83,7 +83,7 @@ func (s *ChildWorkflowForceFailoverSuite) SetupSuite() {
 	clusterConfigs[0].WorkerConfig = testcore.WorkerConfig{DisableWorker: true}
 	// Replacing an orphaned child suppresses an existing workflow, so it ships opt-in.
 	clusterConfigs[0].DynamicConfigOverrides = map[dynamicconfig.Key]any{
-		dynamicconfig.EnableOrphanedChildWorkflowReclaim.Key(): true,
+		dynamicconfig.EnableOrphanedChildWorkflowReplacement.Key(): true,
 	}
 
 	s.controller = gomock.NewController(s.T())


### PR DESCRIPTION
## What changed?
Allow a parent to mark an open child from a losing initiation as zombie and create its replacement atomically when the reuse policy permits.

Validate ownership and initiation metadata under the child lock while preserving normal deduplication for accepted children.

- Added a namespace-scoped dynamic config, `EnableOrphanedChildWorkflowReplacement`, disabled by default.
- When starting a child encounters an existing open execution, allow replacement only when:
   -  the feature is enabled;
   - the reuse policy permits another run;
   - the existing child belongs to the requesting parent;
   - the existing child is still open (CREATED or RUNNING);
   - the existing child’s initiation event ID/version differs from the parent’s accepted initiation;
   - no pending child on the parent’s accepted branch already uses the same workflow ID.


## Why?
After a force failover, the new active cluster may accept a parent branch that does not contain the initiation responsible for an already-replicated child. Retrying the child start then fails with a workflow ID conflict, leaving the parent unable to make progress.
The conflicting child cannot safely be relinked because it belongs to a losing initiation. Marking it zombie prevents it from making progress on the new active cluster, while atomically creating a replacement lets the accepted parent branch continue.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

## Potential risks

The losing child remains in zombie state until replication catches it up or closes it.