### PR TITLE
matching: resume gc after acks that land during an in-flight gc pass

### DIFF
--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -573,18 +573,18 @@ func (s *BacklogManagerTestSuite) TestGCResumesAfterAckDuringInFlightGC() {
 			CreateTime: timestamp.TimeNowPtrUtc(),
 		}))
 	}
-	s.Eventually(func() bool { return s.capturedTasksLen() == taskCount },
+	await.RequireTrue(s.T(), func() bool { return s.capturedTasksLen() == taskCount },
 		5*time.Second, 10*time.Millisecond)
 	tasks := s.capturedTasks()
 
 	// Ack the first task normally and let its gc pass settle, so gc starts caught up.
 	tasks[0].finish(taskFinishResult{consumedToken: true})
-	s.Eventually(func() bool {
+	await.RequireTrue(s.T(), func() bool {
 		tr.lock.Lock()
 		defer tr.lock.Unlock()
 		return !tr.inGC && tr.gcAckLevel == tr.ackLevel
 	}, 5*time.Second, 10*time.Millisecond)
-	s.EqualValues(taskCount-1, s.taskMgr.getTaskCount(queue))
+	s.Equal(taskCount-1, s.taskMgr.getTaskCount(queue))
 
 	// Now hold a gc pass open and ack the rest. Each of those acks advances the ack level but
 	// skips its own gc.
@@ -605,7 +605,7 @@ func (s *BacklogManagerTestSuite) TestGCResumesAfterAckDuringInFlightGC() {
 	// tasks acked in the meantime.
 	tr.doGC(inFlightAckLevel)
 
-	s.Eventually(func() bool { return s.taskMgr.getTaskCount(queue) == 0 },
+	await.RequireTruef(s.T(), func() bool { return s.taskMgr.getTaskCount(queue) == 0 },
 		5*time.Second, 10*time.Millisecond,
 		"gc should resume for tasks acked during the in-flight pass")
 }

--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -544,6 +544,72 @@ func (s *BacklogManagerTestSuite) TestApproximateBacklogCount_ResetOnGapDrain() 
 	s.Zero(db.getTotalApproximateBacklogCount())
 }
 
+// Tasks acked while a gc pass is in flight skip their own gc because inGC is set, and gc is
+// otherwise only triggered by completeTask. The finishing pass has to notice that the ack level
+// moved, or those rows sit in the store until the next task completes.
+func (s *BacklogManagerTestSuite) TestGCResumesAfterAckDuringInFlightGC() {
+	if !s.newMatcher || s.fairness {
+		s.T().Skip("only for priority backlog manager")
+	}
+
+	// GC on every ack, so the batch size limit doesn't hide the behavior under test.
+	s.cfgcli.OverrideValue(dynamicconfig.MatchingMaxTaskDeleteBatchSize.Key(), 1)
+
+	blm := s.blm.(*priBacklogManagerImpl)
+	queue := s.ptqMgr.QueueKey()
+
+	s.setupToCaptureTasks()
+
+	s.blm.Start()
+	defer s.blm.Stop()
+	s.Require().NoError(s.blm.WaitUntilInitialized(context.Background()))
+
+	tr := blm.subqueues[subqueueZero]
+
+	const taskCount = 3
+	for range taskCount {
+		s.Require().NoError(s.blm.SpoolTask(&persistencespb.TaskInfo{
+			ExpiryTime: timestamp.TimeNowPtrUtcAddSeconds(3000),
+			CreateTime: timestamp.TimeNowPtrUtc(),
+		}))
+	}
+	s.Eventually(func() bool { return s.capturedTasksLen() == taskCount },
+		5*time.Second, 10*time.Millisecond)
+	tasks := s.capturedTasks()
+
+	// Ack the first task normally and let its gc pass settle, so gc starts caught up.
+	tasks[0].finish(taskFinishResult{consumedToken: true})
+	s.Eventually(func() bool {
+		tr.lock.Lock()
+		defer tr.lock.Unlock()
+		return !tr.inGC && tr.gcAckLevel == tr.ackLevel
+	}, 5*time.Second, 10*time.Millisecond)
+	s.EqualValues(taskCount-1, s.taskMgr.getTaskCount(queue))
+
+	// Now hold a gc pass open and ack the rest. Each of those acks advances the ack level but
+	// skips its own gc.
+	tr.lock.Lock()
+	tr.inGC = true
+	inFlightAckLevel := tr.ackLevel
+	tr.lock.Unlock()
+
+	for _, t := range tasks[1:] {
+		t.finish(taskFinishResult{consumedToken: true})
+	}
+
+	tr.lock.Lock()
+	s.Greater(tr.ackLevel, inFlightAckLevel, "acks should have advanced the ack level")
+	tr.lock.Unlock()
+
+	// Complete the in-flight pass at the level it captured. It must start another pass for the
+	// tasks acked in the meantime.
+	tr.doGC(inFlightAckLevel)
+
+	s.Eventually(func() bool { return s.taskMgr.getTaskCount(queue) == 0 },
+		5*time.Second, 10*time.Millisecond,
+		"gc should resume for tasks acked during the in-flight pass")
+}
+
 func (s *BacklogManagerTestSuite) TestSyncState_UnloadsOnOwnershipLoss() {
 	if !s.newMatcher {
 		s.T().Skip("SyncState is only used by the new backlog manager")

--- a/service/matching/pri_task_reader.go
+++ b/service/matching/pri_task_reader.go
@@ -530,6 +530,11 @@ func (tr *priTaskReader) doGC(ackLevel int64) {
 	if wasComplete {
 		tr.gcAckLevel = ackLevel
 	}
+	// Tasks acked while this pass was running skipped their own gc because inGC was set,
+	// and gc is only otherwise triggered by completeTask. Re-check here so that the tail
+	// doesn't sit undeleted until the next task completes. shouldGCLocked still applies
+	// the batch size and interval limits, so this doesn't change gc pacing.
+	tr.maybeGCLocked()
 }
 
 func (tr *priTaskReader) doGCAt(ackLevel int64) (bool, error) {


### PR DESCRIPTION
Update: Thinking about this more, I'm going to see if I can just document+test this and not actually touch the logic. This is too far into the weeds that I wouldn't feel comfortable touching anything.

---

I've noticed a flaky test when working on an unrelated PR. I asked my pal Claude to look into it, and this is the result. I would not bet my life that this analysis is 100% perfect, but it all sounds reasonable.

But do take a look at the potential risk about "chaining" GCs. That part looks a little suspect, since `doGC(..)` calls `maybeGCLocked(..)` which calls `doGC(..)` IFF `tr.shouldGCLocked()` is `true`.

### Why is this flaky now?

I asked Claude to do a git bisect to figure out when this test started failing. And it turns out its been flakey since at least the last 16 months! From Claude:

> And no commit "introduced" it in the sense of breaking working code. 62f3d931e (#7469, "Re-use unit tests") did two things at once — it started running matchingEngineSuite against the new matcher, and it changed doGC() to doGC(ackLevel int64). The prior doGC() read tr.ackLevel live at execution time, so it deleted up to the current ack level and swept up acks that landed mid-pass. Capturing the level at launch closed that accidental coverage — and the same commit switched on the test that would have caught it.

But apparently the percentage of failures has been relatively low, with 3 retry attempts per job leading to a 1-in-40 to 1-in-200 chance of failing a job outright.

---

## What changed?

- `priTaskReader.doGC` now calls `maybeGCLocked` before returning, so a gc pass that
  finishes will start another one if the ack level moved while it was running.
- Added `TestGCResumesAfterAckDuringInFlightGC` in `backlog_manager_test.go`.

## Why?

`TestMatchingEngine_Pri_Suite/TestMultipleWorkersLesserNumberOfPollersThanTasksNoDBErrors`
has been failing in the `Unit test` job (e.g. [this run](https://github.com/temporalio/temporal/actions/runs/30672422202/job/91293023694), which failed all 3 attempts) with:

```
Error: "1501" is not less than or equal to "1500"
```

The test asserts that `ApproximateBacklogCount` never under-counts the rows actually in
the DB. It was failing because one task row was being left in the store permanently.

`maybeGCLocked` skips starting a gc pass while one is already running (`inGC`), and gc is
only ever triggered from `completeTask`. So:

1. A task is acked. `completeTask` decrements the backlog count synchronously and launches
   `doGC(ackLevel)` in a goroutine, capturing the ack level at launch time.
2. Another task is acked while that goroutine is still running. `shouldGCLocked` sees
   `inGC == true` and returns false, so no pass is scheduled for the new, higher ack level.
3. The in-flight pass finishes, sets `gcAckLevel` to the older level it captured, and clears
   `inGC`. Nothing re-checks whether the ack level moved.
4. Once the pollers stop, no further ack occurs, and the row for the last acked task is
   never deleted.

Instrumenting the gc decision path confirmed this: in every failing run the last
`shouldGCLocked` call bailed at the `inGC` branch, and the divergence never converged even
after re-sampling for 2s (`db=1501 backlog=1500 ackLevel=996 gcAckLevel=995 inGC=false`).

Production impact is minor — the rows are below the ack level so they are never
re-dispatched, and the next completed task or `FinalGC` on a draining unload cleans them up.
But the invariant the test asserts genuinely did not hold.

`shouldGCLocked` still applies the batch size and interval limits after this change, so gc
pacing is unchanged. As a side effect, a partial batch (`wasComplete == false`) now keeps
draining instead of stalling until the next ack.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

The two affected tests (`TestMultipleWorkersLesserNumberOfPollersThanTasksNoDBErrors` and
`TestLesserNumberOfPollersThanTasksNoDBErrors`) failed **20 of 200** runs before this change
and **0 of 200** after. The counterfactual was run by stashing only `pri_task_reader.go`, so
the test file was identical in both cases.

`TestGCResumesAfterAckDuringInFlightGC` reproduces the race deterministically rather than
relying on that timing: it holds a gc pass open via `inGC`, acks tasks, then completes the
pass at its captured ack level and asserts the store drains. It fails without the fix
("condition never satisfied") and passes with it.

Full `service/matching` package passes with `-race -shuffle on`.

## Potential risks

- **GC passes can now chain.** Each pass ends by re-checking, so in principle it could loop.
  It is bounded: `shouldGCLocked` returns false at `gcGap == 0`, every pass that does not
  advance `gcAckLevel` still deletes up to `MaxTaskDeleteBatchSize` rows (so it makes
  progress), and the error path returns before re-triggering, so a failing store cannot spin.
- **Slightly more delete throughput** on a backlog draining faster than one batch per task
  completion. That work was previously deferred to the next ack rather than avoided, and the
  batch size and interval limits still apply.
- **`fairTaskReader` is not fixed here.** It has the same `inGC` skip
  (`fair_task_reader.go:699`), but it zeroes `numToGC` after each pass, so the same one-line
  change would not fix it — it needs separate accounting work. The Fair suite's version of
  this assertion uses `InDelta(±2)`, so it is not what is failing CI.
