### PR TITLE
Record SAA task schedule-to-start latency

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -292,7 +292,27 @@ func (a *Activity) HandleStarted(ctx chasm.MutableContext, request *historyservi
 		}
 		return nil, err
 	}
+	if dispatchTime := a.dispatchTimeForAttempt(lastAttempt); dispatchTime != nil {
+		metrics.TaskScheduleToStartLatency.With(a.taskScheduleToStartMetricsHandler(ctx)).Record(
+			lastAttempt.GetStartedTime().AsTime().Sub(dispatchTime.AsTime()),
+		)
+	}
 	return a.GenerateRecordActivityTaskStartedResponse(ctx, request.GetPollRequest().GetNamespace())
+}
+
+func (a *Activity) taskScheduleToStartMetricsHandler(ctx chasm.Context) metrics.Handler {
+	actCtx := activityContextFromChasm(ctx)
+	namespaceEntry := ctx.NamespaceEntry()
+	namespaceName := namespaceEntry.Name().String()
+	taskQueue := a.GetTaskQueue().GetName()
+	return metrics.GetPerTaskQueuePartitionTypeScope(
+		a.baseMetricsHandler(ctx, metrics.HistoryRecordActivityTaskStartedScope),
+		namespaceName,
+		tqid.UnsafeTaskQueueFamily(namespaceEntry.ID().String(), taskQueue).
+			TaskQueue(enumspb.TASK_QUEUE_TYPE_ACTIVITY).
+			RootPartition(),
+		actCtx.config.BreakdownMetricsByTaskQueue(namespaceName, taskQueue, enumspb.TASK_QUEUE_TYPE_ACTIVITY),
+	)
 }
 
 // GenerateRecordActivityTaskStartedResponse generates the response for HandleStarted.

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -1,6 +1,7 @@
 package activity
 
 import (
+	"cmp"
 	"context"
 	"testing"
 	"time"
@@ -232,6 +233,10 @@ func TestHandleStarted(t *testing.T) {
 		requestStamp   int32
 		startRequestID string
 		requestID      string
+		attemptCount   int32
+		dispatchTime   *timestamppb.Timestamp
+		metricSamples  int
+		metricLatency  time.Duration
 		checkOutcome   func(t *testing.T, response *historyservice.RecordActivityTaskStartedResponse, err error)
 	}{
 		{
@@ -240,8 +245,27 @@ func TestHandleStarted(t *testing.T) {
 			attemptStamp:   testStamp,
 			requestStamp:   testStamp,
 			requestID:      testRequestID,
+			metricSamples:  1,
+			metricLatency:  30 * time.Second,
 			checkOutcome: func(t *testing.T, response *historyservice.RecordActivityTaskStartedResponse, err error) {
 				require.Equal(t, int32(1), response.Attempt)
+				require.NoError(t, err)
+			},
+		},
+		{
+			// Latency is measured from the attempt's dispatch time, 10s ago, not from the schedule
+			// time 30s ago: a retry excludes the earlier attempts and the backoff between them.
+			name:           "successful transition from scheduled - retry attempt",
+			activityStatus: activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+			attemptStamp:   testStamp,
+			requestStamp:   testStamp,
+			requestID:      testRequestID,
+			attemptCount:   2,
+			dispatchTime:   timestamppb.New(testTime.Add(-10 * time.Second)),
+			metricSamples:  1,
+			metricLatency:  10 * time.Second,
+			checkOutcome: func(t *testing.T, response *historyservice.RecordActivityTaskStartedResponse, err error) {
+				require.Equal(t, int32(2), response.Attempt)
 				require.NoError(t, err)
 			},
 		},
@@ -342,24 +366,41 @@ func TestHandleStarted(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			metricsHandler := metricstest.NewCaptureHandler()
+			metricCapture := metricsHandler.StartCapture()
+			defer metricsHandler.StopCapture(metricCapture)
+			namespaceEntry := namespace.NewLocalNamespaceForTest(
+				&persistencespb.NamespaceInfo{Id: "test-namespace-id", Name: "test-namespace"},
+				&persistencespb.NamespaceConfig{},
+				"active-cluster",
+			)
 			// Setup mock context
 			ctx := &chasm.MockMutableContext{
 				MockContext: chasm.MockContext{
 					HandleNow: func(chasm.Component) time.Time { return testTime },
 					HandleExecutionKey: func() chasm.ExecutionKey {
 						return chasm.ExecutionKey{
-							BusinessID: "test-activity-id",
-							RunID:      "test-run-id",
+							NamespaceID: "test-namespace-id",
+							BusinessID:  "test-activity-id",
+							RunID:       "test-run-id",
 						}
 					},
+					HandleNamespaceEntry: func() *namespace.Namespace { return namespaceEntry },
+					HandleMetricsHandler: func() metrics.Handler { return metricsHandler },
+					GoCtx: context.WithValue(context.Background(), ctxKeyActivityContext, &activityContext{
+						config: &Config{
+							BreakdownMetricsByTaskQueue: dynamicconfig.GetBoolPropertyFnFilteredByTaskQueue(true),
+						},
+					}),
 				},
 			}
 
 			// Setup activity state
 			attemptState := &activitypb.ActivityAttemptState{
-				Count:          1,
+				Count:          cmp.Or(tc.attemptCount, 1),
 				Stamp:          tc.attemptStamp,
 				StartRequestId: tc.startRequestID,
+				DispatchTime:   tc.dispatchTime,
 			}
 			// A recorded start request ID means this attempt was previously started.
 			if tc.startRequestID != "" {
@@ -407,6 +448,11 @@ func TestHandleStarted(t *testing.T) {
 			response, err := activity.HandleStarted(ctx, request)
 
 			tc.checkOutcome(t, response, err)
+			recordings := metricCapture.Snapshot()[metrics.TaskScheduleToStartLatency.Name()]
+			require.Len(t, recordings, tc.metricSamples)
+			if tc.metricSamples > 0 {
+				require.Equal(t, tc.metricLatency, recordings[0].Value)
+			}
 		})
 	}
 }

--- a/tests/activity_metrics_parity_test.go
+++ b/tests/activity_metrics_parity_test.go
@@ -11,10 +11,97 @@ import (
 	"github.com/stretchr/testify/require"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/chasm/lib/activity/model"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
+	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/testing/await"
 )
+
+// TestScheduleToStartMetric asserts that SAA and WFA record task_schedule_to_start_latency
+// identically: one sample per accepted worker start, with the same tags. Workflow-task starts share
+// the metric name, so only recordings tagged with the activity-task start operation and task type
+// are collected. Both settings of MetricsBreakdownByTaskQueue are covered, since it decides whether
+// "taskqueue" carries the real name or the "__omitted__" cardinality placeholder.
+func (s *activityParityTestSuite) TestScheduleToStartMetric() {
+	type scenario struct {
+		name           string
+		trace          []model.Event
+		expectedStarts int
+	}
+	type captureResult struct {
+		recordings []*metricstest.CapturedRecording
+		namespace  string
+		taskQueue  string
+	}
+
+	scenarios := []scenario{
+		{name: "FirstAttempt", trace: []model.Event{model.Poll}, expectedStarts: 1},
+		{
+			name:           "RetryAttempt",
+			trace:          []model.Event{model.Poll, model.FailRetryably, model.BackoffElapses, model.Poll},
+			expectedStarts: 2,
+		},
+	}
+	capture := func(t *testing.T, standalone, breakdownByTaskQueue bool, trace []model.Event) captureResult {
+		env := newActivityParityEnv(t)
+		env.GetTestCluster().OverrideDynamicConfig(t, dynamicconfig.MetricsBreakdownByTaskQueue,
+			[]dynamicconfig.ConstrainedValue{{
+				Constraints: dynamicconfig.Constraints{Namespace: env.Namespace().String()},
+				Value:       breakdownByTaskQueue,
+			}})
+		metricCapture := env.StartNamespaceMetricCapture()
+
+		var taskQueue string
+		if standalone {
+			taskQueue = newSAADriver(t, env, activityConfig{}).driveTrace(t, trace).taskQueue
+		} else {
+			taskQueue = newWFADriver(t, env, activityConfig{}).driveTrace(t, trace).taskQueue
+		}
+		recordings := metricCapture.CollectMetric(metrics.TaskScheduleToStartLatency.Name(), func(rec *metricstest.CapturedRecording) bool {
+			return rec.Tags["operation"] == metrics.HistoryRecordActivityTaskStartedScope &&
+				rec.Tags["task_type"] == enumspb.TASK_QUEUE_TYPE_ACTIVITY.String()
+		})
+		return captureResult{recordings: recordings, namespace: env.Namespace().String(), taskQueue: taskQueue}
+	}
+	check := func(t *testing.T, implementation string, result captureResult, breakdownByTaskQueue bool, expectedStarts int) {
+		require.Len(t, result.recordings, expectedStarts,
+			"%s must record schedule-to-start latency once for every accepted worker start", implementation)
+		taskQueue := "__omitted__"
+		if breakdownByTaskQueue {
+			taskQueue = result.taskQueue
+		}
+		expectedTags := map[string]string{
+			"namespace":    result.namespace,
+			"operation":    metrics.HistoryRecordActivityTaskStartedScope,
+			"partition":    "__normal__",
+			"service_name": string(primitives.HistoryService),
+			"task_type":    enumspb.TASK_QUEUE_TYPE_ACTIVITY.String(),
+			"taskqueue":    taskQueue,
+		}
+		for _, recording := range result.recordings {
+			require.Equal(t, expectedTags, recording.Tags, "%s metric tags must match the activity-task start scope", implementation)
+		}
+	}
+
+	for _, breakdownByTaskQueue := range []bool{true, false} {
+		breakdownName := "TaskQueueBreakdownEnabled"
+		if !breakdownByTaskQueue {
+			breakdownName = "TaskQueueBreakdownDisabled"
+		}
+		s.Run(breakdownName, func(s *activityParityTestSuite) {
+			for _, sc := range scenarios {
+				s.Run(sc.name, func(s *activityParityTestSuite) {
+					t := s.T()
+					wfa := capture(t, false, breakdownByTaskQueue, sc.trace)
+					saa := capture(t, true, breakdownByTaskQueue, sc.trace)
+					check(t, "WFA", wfa, breakdownByTaskQueue, sc.expectedStarts)
+					check(t, "SAA", saa, breakdownByTaskQueue, sc.expectedStarts)
+				})
+			}
+		})
+	}
+}
 
 func (s *activityParityTestSuite) TestMetrics() {
 	type activityMetric struct {


### PR DESCRIPTION
## What changed?
- Emit schedule-to-start latency metric when SAA starts
- The metric distribution (which is per-task queue) will now contain data points from both SAA and WFA. This is reasonable because there's nothing about SAA that implies that its time in matching backlog should have a different distribution.

## Why?
- Required metric; WFA parity

## How did you test it?
- [X] added new functional test(s)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds observability only on the activity-start path after a successful transition; no auth, persistence, or matching behavior changes. Shared metric name with workflow tasks is filtered by operation/tags in tests.
> 
> **Overview**
> **Standalone activities (SAA)** now emit `task_schedule_to_start_latency` when History accepts an activity task start in `HandleStarted`, matching workflow-embedded activity (WFA) behavior and filling a required metrics gap.
> 
> Latency is **started time minus attempt dispatch time** (via `dispatchTimeForAttempt`), not raw schedule time—so retries measure backlog from the current attempt’s dispatch, excluding prior attempts and backoff.
> 
> Samples use the same per-task-queue partition scope as WFA (`HistoryRecordActivityTaskStartedScope`, activity task type, `MetricsBreakdownByTaskQueue` → real task queue name vs `__omitted__`). Idempotent `RecordActivityTaskStarted` replays do not record again.
> 
> Unit tests in `activity_test` assert sample count and latency for first start and retry; functional parity tests cover SAA vs WFA for first attempt and retry across task-queue breakdown settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e702b65ccd3fff73bf4376c2f1cdf7995c25f51c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->