### PR TITLE
fix: bound worker-deployment control-plane activities so a lost task cannot wedge registration

### DIFF
--- a/service/worker/workerdeployment/util.go
+++ b/service/worker/workerdeployment/util.go
@@ -122,8 +122,9 @@ var (
 )
 
 var (
-	defaultActivityOptions = workflow.ActivityOptions{
-		StartToCloseTimeout: 1 * time.Minute,
+	DefaultActivityOptions = workflow.ActivityOptions{
+		StartToCloseTimeout:    1 * time.Minute,
+		ScheduleToCloseTimeout: 2 * time.Minute,
 		RetryPolicy: &temporal.RetryPolicy{
 			InitialInterval: 100 * time.Millisecond,
 			MaximumAttempts: 5,

--- a/service/worker/workerdeployment/version_workflow.go
+++ b/service/worker/workerdeployment/version_workflow.go
@@ -332,7 +332,7 @@ func (d *VersionWorkflowRunner) run(ctx workflow.Context) error {
 		// First ensure deployment workflow is running
 		//nolint:staticcheck // SA1019
 		if !d.VersionState.StartedDeploymentWorkflow {
-			activityCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
+			activityCtx := workflow.WithActivityOptions(ctx, DefaultActivityOptions)
 			err := workflow.ExecuteActivity(activityCtx, d.a.StartWorkerDeploymentWorkflow, &deploymentspb.StartWorkerDeploymentRequest{
 				DeploymentName: d.VersionState.Version.DeploymentName,
 				RequestId:      d.newUUID(ctx),
@@ -452,7 +452,7 @@ func (d *VersionWorkflowRunner) handleUpdateVersionComputeConfig(ctx workflow.Co
 		DeploymentName: d.VersionState.Version.DeploymentName,
 		BuildId:        d.VersionState.Version.BuildId,
 	}
-	activityCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
+	activityCtx := workflow.WithActivityOptions(ctx, DefaultActivityOptions)
 	var computeConfigSummary *computepb.ComputeConfigSummary
 	err := workflow.ExecuteActivity(activityCtx, d.a.UpdateWorkerControllerInstance, &deploymentspb.UpdateWorkerControllerInstanceInput{
 		Version:             apiVersion,
@@ -545,7 +545,7 @@ func (d *VersionWorkflowRunner) handleDeleteVersion(ctx workflow.Context, args *
 		}
 	}
 
-	activityCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
+	activityCtx := workflow.WithActivityOptions(ctx, DefaultActivityOptions)
 
 	// Manual deletion of versions is only possible when:
 	// 1. The version is not current or ramping (checked in the deployment wf)
@@ -682,7 +682,7 @@ func (d *VersionWorkflowRunner) doesVersionHaveActivePollers(ctx workflow.Contex
 		TaskQueuesAndTypes:      tqNameToTypes,
 		WorkerDeploymentVersion: d.VersionState.Version,
 	}
-	activityCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
+	activityCtx := workflow.WithActivityOptions(ctx, DefaultActivityOptions)
 	var hasPollers bool
 	err := workflow.ExecuteActivity(activityCtx, d.a.CheckIfTaskQueuesHavePollers, checkPollersReq).Get(ctx, &hasPollers)
 	if err != nil {
@@ -1113,7 +1113,7 @@ func (d *VersionWorkflowRunner) refreshDrainageInfo(ctx workflow.Context) {
 		}
 	}
 
-	activityCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
+	activityCtx := workflow.WithActivityOptions(ctx, DefaultActivityOptions)
 	var a *VersionActivities
 	var newInfo *deploymentpb.VersionDrainageInfo
 	err = workflow.ExecuteActivity(
@@ -1263,7 +1263,7 @@ func (d *VersionWorkflowRunner) syncVersionDataToComputeStatus(ctx workflow.Cont
 			logger := workflow.GetLogger(ctx)
 
 			var result deploymentpb.ComputeStatus
-			resp := workflow.ExecuteActivity(workflow.WithActivityOptions(ctx, defaultActivityOptions), d.a.DescribeWorkerControllerInstanceStatus, state.GetVersion())
+			resp := workflow.ExecuteActivity(workflow.WithActivityOptions(ctx, DefaultActivityOptions), d.a.DescribeWorkerControllerInstanceStatus, state.GetVersion())
 			if err := resp.Get(ctx, &result); err != nil {
 				logger.Error("failed to sync compute status", "error", err)
 			} else if result.ProviderValidation != nil {
@@ -1310,7 +1310,7 @@ func (d *VersionWorkflowRunner) syncVersionDataToTaskQueues(ctx workflow.Context
 
 	// calling SyncDeploymentVersionUserData for each batch
 	for _, batch := range batches {
-		activityCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
+		activityCtx := workflow.WithActivityOptions(ctx, DefaultActivityOptions)
 		var syncRes deploymentspb.SyncDeploymentVersionUserDataResponse
 
 		err := workflow.ExecuteActivity(activityCtx, d.a.SyncDeploymentVersionUserData, &deploymentspb.SyncDeploymentVersionUserDataRequest{

--- a/service/worker/workerdeployment/workflow.go
+++ b/service/worker/workerdeployment/workflow.go
@@ -563,7 +563,7 @@ func (d *WorkflowRunner) handleCreateWorkerDeploymentVersion(ctx workflow.Contex
 	computeConfig := args.GetComputeConfig()
 	var computeConfigSummary *computepb.ComputeConfigSummary
 	if computeConfig != nil {
-		updateCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
+		updateCtx := workflow.WithActivityOptions(ctx, DefaultActivityOptions)
 		err = workflow.ExecuteActivity(updateCtx, d.a.UpdateWorkerControllerInstanceFromDeployment, &deploymentspb.UpdateWorkerControllerInstanceInput{
 			Version:             worker_versioning.ExternalWorkerDeploymentVersionFromVersion(versionObj),
 			Identity:            args.GetIdentity(),
@@ -579,7 +579,7 @@ func (d *WorkflowRunner) handleCreateWorkerDeploymentVersion(ctx workflow.Contex
 	}
 
 	// Start the version workflow via activity.
-	activityCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
+	activityCtx := workflow.WithActivityOptions(ctx, DefaultActivityOptions)
 	err = workflow.ExecuteActivity(activityCtx, d.a.StartWorkerDeploymentVersionWorkflow, &deploymentspb.StartWorkerDeploymentVersionRequest{
 		DeploymentName: versionObj.DeploymentName,
 		BuildId:        versionObj.BuildId,
@@ -589,7 +589,7 @@ func (d *WorkflowRunner) handleCreateWorkerDeploymentVersion(ctx workflow.Contex
 	}).Get(ctx, nil)
 	if err != nil {
 		if computeConfig != nil {
-			deleteCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
+			deleteCtx := workflow.WithActivityOptions(ctx, DefaultActivityOptions)
 			deleteErr := workflow.ExecuteActivity(deleteCtx, d.a.DeleteWorkerControllerInstanceFromDeployment, &deploymentspb.DeleteWorkerControllerInstanceInput{
 				Version:  worker_versioning.ExternalWorkerDeploymentVersionFromVersion(versionObj),
 				Identity: args.GetIdentity(),
@@ -685,7 +685,7 @@ func (d *WorkflowRunner) handleRegisterWorker(ctx workflow.Context, args *deploy
 	}
 
 	// Register task-queue worker in version workflow.
-	activityCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
+	activityCtx := workflow.WithActivityOptions(ctx, DefaultActivityOptions)
 	err = workflow.ExecuteActivity(activityCtx, d.a.RegisterWorkerInVersion, &deploymentspb.RegisterWorkerInVersionArgs{
 		TaskQueueName: args.TaskQueueName,
 		TaskQueueType: args.TaskQueueType,
@@ -1137,7 +1137,7 @@ func (d *WorkflowRunner) validateDeleteVersion(args *deploymentspb.DeleteVersion
 
 func (d *WorkflowRunner) deleteVersion(ctx workflow.Context, args *deploymentspb.DeleteVersionArgs) error {
 	// ask version to delete itself
-	activityCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
+	activityCtx := workflow.WithActivityOptions(ctx, DefaultActivityOptions)
 	var res deploymentspb.SyncVersionStateActivityResult
 	err := workflow.ExecuteActivity(activityCtx, d.a.DeleteWorkerDeploymentVersion, &deploymentspb.DeleteVersionActivityArgs{
 		Identity:         args.Identity,
@@ -1558,7 +1558,7 @@ func (d *WorkflowRunner) syncVersion(ctx workflow.Context, targetVersion string,
 	} else {
 		reqID = d.newUUID(ctx)
 	}
-	activityCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
+	activityCtx := workflow.WithActivityOptions(ctx, DefaultActivityOptions)
 	var res deploymentspb.SyncVersionStateActivityResult
 	err := workflow.ExecuteActivity(activityCtx, d.a.SyncWorkerDeploymentVersion, &deploymentspb.SyncVersionStateActivityArgs{
 		DeploymentName: d.DeploymentName,
@@ -1617,7 +1617,7 @@ func (d *WorkflowRunner) signalDemoteVersion(ctx workflow.Context, version strin
 
 // syncUnversionedRamp should not be called in async mode
 func (d *WorkflowRunner) syncUnversionedRamp(ctx workflow.Context, versionUpdateArgs *deploymentspb.SyncVersionStateUpdateArgs) error {
-	activityCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
+	activityCtx := workflow.WithActivityOptions(ctx, DefaultActivityOptions)
 
 	// DescribeVersion activity to get all the task queues in the current version, or the ramping version if current is nil
 	version := d.State.RoutingConfig.CurrentVersion //nolint:staticcheck // SA1019: worker versioning v0.31
@@ -1707,7 +1707,7 @@ func (d *WorkflowRunner) syncUnversionedRamp(ctx workflow.Context, versionUpdate
 }
 
 func (d *WorkflowRunner) isVersionMissingTaskQueues(ctx workflow.Context, prevCurrentVersion string, newCurrentVersion string) (bool, error) {
-	activityCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
+	activityCtx := workflow.WithActivityOptions(ctx, DefaultActivityOptions)
 	var res deploymentspb.IsVersionMissingTaskQueuesResult
 	err := workflow.ExecuteActivity(activityCtx, d.a.IsVersionMissingTaskQueues, &deploymentspb.IsVersionMissingTaskQueuesArgs{
 		PrevCurrentVersion: prevCurrentVersion,
@@ -1717,7 +1717,7 @@ func (d *WorkflowRunner) isVersionMissingTaskQueues(ctx workflow.Context, prevCu
 }
 
 func (d *WorkflowRunner) startVersion(ctx workflow.Context, args *deploymentspb.StartWorkerDeploymentVersionRequest) error {
-	activityCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
+	activityCtx := workflow.WithActivityOptions(ctx, DefaultActivityOptions)
 	return workflow.ExecuteActivity(activityCtx, d.a.StartWorkerDeploymentVersionWorkflow, args).Get(ctx, nil)
 }
 

--- a/tests/lost_activity_task_test.go
+++ b/tests/lost_activity_task_test.go
@@ -1,0 +1,179 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/api/enums/v1"
+	sdkclient "go.temporal.io/sdk/client"
+	sdkworker "go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/testing/await"
+	"go.temporal.io/server/common/testing/parallelsuite"
+	"go.temporal.io/server/common/testing/testcontext"
+	"go.temporal.io/server/service/worker/workerdeployment"
+	"go.temporal.io/server/tests/testcore"
+)
+
+const (
+	lostTaskInjectedErr = "lost-activity-task-injected-failure"
+	lostTaskActivityTQ  = "lost-activity-task-activity-tq"
+	lostTaskGracePeriod = 30 * time.Second
+)
+
+func lostTaskControlPlaneOptions() workflow.ActivityOptions {
+	opts := workerdeployment.DefaultActivityOptions
+	opts.TaskQueue = lostTaskActivityTQ
+	return opts
+}
+
+func lostTaskReleaseWindow() time.Duration {
+	return workerdeployment.DefaultActivityOptions.ScheduleToCloseTimeout + lostTaskGracePeriod
+}
+
+type LostActivityTaskSuite struct {
+	parallelsuite.Suite[*LostActivityTaskSuite]
+}
+
+func TestLostActivityTaskSuite(t *testing.T) {
+	parallelsuite.RunLegacySequential(t, &LostActivityTaskSuite{}) //nolint:staticcheck // SA1019: needs a dedicated cluster with persistence fault injection.
+}
+
+type lostActivityTaskEnv struct {
+	*testcore.TestEnv
+
+	failEnqueue   atomic.Bool
+	injectedCount atomic.Int32
+	activityRuns  atomic.Int32
+
+	createTasksMu   sync.Mutex
+	createTasksSeen map[string]int
+}
+
+func (e *lostActivityTaskEnv) recordCreateTasks(tq string) {
+	e.createTasksMu.Lock()
+	defer e.createTasksMu.Unlock()
+	if e.createTasksSeen == nil {
+		e.createTasksSeen = map[string]int{}
+	}
+	e.createTasksSeen[tq]++
+}
+
+func (e *lostActivityTaskEnv) createTasksReport() map[string]int {
+	e.createTasksMu.Lock()
+	defer e.createTasksMu.Unlock()
+	out := make(map[string]int, len(e.createTasksSeen))
+	for k, v := range e.createTasksSeen {
+		out[k] = v
+	}
+	return out
+}
+
+func (e *lostActivityTaskEnv) countingActivity(context.Context) error {
+	e.activityRuns.Add(1)
+	return nil
+}
+
+func (e *lostActivityTaskEnv) controlPlaneWorkflow(ctx workflow.Context) error {
+	return workflow.ExecuteActivity(
+		workflow.WithActivityOptions(ctx, lostTaskControlPlaneOptions()), e.countingActivity,
+	).Get(ctx, nil)
+}
+
+func (e *lostActivityTaskEnv) stillRunning(ctx context.Context, run sdkclient.WorkflowRun) bool {
+	desc, err := e.SdkClient().DescribeWorkflowExecution(ctx, run.GetID(), run.GetRunID())
+	if err != nil {
+		return true
+	}
+	return desc.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
+}
+
+func (s *LostActivityTaskSuite) newTestEnv() *lostActivityTaskEnv {
+	e := &lostActivityTaskEnv{}
+	e.TestEnv = testcore.NewEnv(s.T(),
+		testcore.WithPersistenceFaultInjection(&config.FaultInjection{
+			Injector: func(target config.FaultInjectionTarget) error {
+				if target.Store != config.TaskStoreName || target.Method != "CreateTasks" {
+					return nil
+				}
+				req, ok := target.Request.(*persistence.InternalCreateTasksRequest)
+				if !ok {
+					return nil
+				}
+				e.recordCreateTasks(req.TaskQueue)
+				if !strings.Contains(req.TaskQueue, lostTaskActivityTQ) {
+					return nil
+				}
+				if !e.failEnqueue.Load() {
+					return nil
+				}
+				e.injectedCount.Add(1)
+				return errors.New(lostTaskInjectedErr)
+			},
+		}),
+		testcore.WithDynamicConfig(dynamicconfig.HistoryTaskDLQEnabled, true),
+		testcore.WithDynamicConfig(dynamicconfig.HistoryTaskDLQErrorPattern, lostTaskInjectedErr),
+	)
+	return e
+}
+
+func (s *LostActivityTaskSuite) startRun(
+	env *lostActivityTaskEnv, wf any, idPrefix string,
+) sdkclient.WorkflowRun {
+	env.SdkWorker().RegisterWorkflow(wf)
+	run, err := env.SdkClient().ExecuteWorkflow(s.Context(), sdkclient.StartWorkflowOptions{
+		ID:        idPrefix + uuid.NewString(),
+		TaskQueue: env.WorkerTaskQueue(),
+	}, wf)
+	s.NoError(err)
+	return run
+}
+
+func (s *LostActivityTaskSuite) awaitActivityLost(env *lostActivityTaskEnv, run sdkclient.WorkflowRun) {
+	await.Require(s.Context(), s.T(), func(t *await.T) {
+		require.Positive(t, env.injectedCount.Load(),
+			"fault was never injected; CreateTasks calls seen: %v", env.createTasksReport())
+		desc, err := env.SdkClient().DescribeWorkflowExecution(s.Context(), run.GetID(), run.GetRunID())
+		require.NoError(t, err)
+		require.Len(t, desc.GetPendingActivities(), 1, "expected exactly one pending activity")
+		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED,
+			desc.GetPendingActivities()[0].GetState(), "activity should be SCHEDULED, never started")
+	}, 30*time.Second, 200*time.Millisecond)
+	s.Zero(env.activityRuns.Load(), "activity must never have executed")
+}
+
+func (s *LostActivityTaskSuite) TestLostActivityTask_ControlPlaneOptionsReleaseCaller() {
+	testcontext.For(s.T(), testcontext.WithTimeout(lostTaskReleaseWindow()+90*time.Second))
+
+	env := s.newTestEnv()
+	env.failEnqueue.Store(true)
+
+	run := s.startRun(env, env.controlPlaneWorkflow, "lost-activity-control-plane-")
+	s.awaitActivityLost(env, run)
+
+	env.failEnqueue.Store(false)
+	w := sdkworker.New(env.SdkClient(), lostTaskActivityTQ, sdkworker.Options{})
+	w.RegisterActivity(env.countingActivity)
+	s.NoError(w.Start())
+	defer w.Stop()
+
+	s.Eventually(func() bool { return !env.stillRunning(s.Context(), run) },
+		lostTaskReleaseWindow(), time.Second,
+		"the activity task was lost and %v bounds no end-to-end deadline, so nothing fails "+
+			"the never-started attempt, the retry policy cannot advance, and the caller waits "+
+			"forever. Set ScheduleToCloseTimeout on DefaultActivityOptions in "+
+			"service/worker/workerdeployment/util.go.",
+		workerdeployment.DefaultActivityOptions)
+
+	s.Zero(env.activityRuns.Load(), "activity must never have executed")
+}


### PR DESCRIPTION
Fixes #11402

## What changed?

- Added `ScheduleToCloseTimeout` to the two activity option sets in `service/worker/workerdeployment/util.go`: `DefaultActivityOptions` (2 min) Previously only bounded only `StartToCloseTimeout`.
- Renamed `defaultActivityOptions` to `DefaultActivityOptions` so the new functional test can assert against the real struct rather than a copy of its shape. Mechanical rename, 17 call sites in `workflow.go` and `version_workflow.go`, no logic change.
- Added `tests/lost_activity_task_test.go`, a functional test that loses an activity task and asserts the caller is released.

## Why?

`StartToCloseTimeout` bounds an attempt that has *started*. An attempt whose activity task is never delivered has no deadline at all: no `ActivityTimeout` timer task exists for it, so nothing ever fails it and the retry policy cannot advance past it.

`RegisterWorkerInVersion` and `SyncDeploymentVersionUserData` run under these options from inside an `Update` handler. So when such a task is lost, the activity stays `PENDING_ACTIVITY_STATE_SCHEDULED` and the `Update` stays `WORKFLOW_EXECUTION_UPDATE_ACCEPTED` forever. The task queue is then permanently unpollable for that deployment version, and every activity poll is answered with:

```
Unavailable: task queue is not ready to process polls from this deployment version, try again shortly
```

which is misleading, because the state is terminal without operator action.

We hit this in production and it persisted for **44 hours**. A brief matching outage left `RegisterWorkerInVersion`'s retry task parked in the history timer DLQ, and nothing re-drives a DLQ'd task. Workflow tasks kept flowing normally the whole time, so the deployment looked healthy while activity dispatch was dead. Recovery required `tdbg admin workflow refresh_tasks` on the entity workflow.

## How did you test it?

- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)

`tests/lost_activity_task_test.go` runs on a real in-process cluster and is coupled to the production struct, so reverting the fix turns it red:

| `DefaultActivityOptions.ScheduleToCloseTimeout` | result |
| --- | --- |
| unset (before this PR) | **FAIL** in 30s |
| `2 * time.Minute` | **PASS** in 120s |

How it loses the task: the activity runs on a task queue with no poller, so matching cannot sync-match and must persist it via `TaskStore.CreateTasks`. Persistence fault injection fails that call, and `history.TaskDLQErrorPattern` is set to the injected error so the transfer task is parked in the DLQ rather than retried. The test then removes the fault *and* starts a worker on that queue: a merely backlogged task would be delivered at that point, a parked one never is. It also asserts the fault actually fired and that the activity never executed, so it cannot pass vacuously.

The assertion window is derived from `DefaultActivityOptions.ScheduleToCloseTimeout`, so it tracks the option instead of hardcoding a duration, and an unset timeout produces a fast failure rather than a long wait.

Also verified `go test ./service/worker/workerdeployment/...`, `go vet`, and `gofmt`.

## Potential risks

- **Behaviour change.** These activities can now fail where they previously blocked indefinitely, so the `Update` handlers will observe an error in cases that used to hang. That is the intent, but callers do see a new failure mode.
- **The rename adds churn.** `workflow.go` and `version_workflow.go` change in 17 places with no logic change. It exists solely so the functional test can read the real options; if you would rather keep the diff to `util.go`, the test can be reverted to asserting a copy of the option shape, at the cost of no longer failing when the fix is reverted.
- **Test duration is bounded by the real timeout**, so it takes ~2 minutes and will change if the timeout does. It raises the test-scoped context ceiling above the 90s default for that reason.
