### PR TITLE
Fix RateLimitingActive always false in DescribeTaskQueue responses

### DIFF
--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -24,6 +24,7 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
 	"go.temporal.io/server/client/matching"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/cache"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -1731,19 +1732,13 @@ func (pm *taskQueuePartitionManagerImpl) ephemeralDataChanged(data *taskqueuespb
 
 func cloneTaskQueueStats(in *taskqueuepb.TaskQueueStats) *taskqueuepb.TaskQueueStats {
 	if in == nil {
-		return &taskqueuepb.TaskQueueStats{ApproximateBacklogAge: durationpb.New(0)}
+		in = &taskqueuepb.TaskQueueStats{}
 	}
-	age := in.GetApproximateBacklogAge()
-	if age == nil {
-		age = durationpb.New(0)
+	out := common.CloneProto(in)
+	if out.ApproximateBacklogAge == nil {
+		out.ApproximateBacklogAge = durationpb.New(0)
 	}
-	return &taskqueuepb.TaskQueueStats{
-		ApproximateBacklogCount: in.GetApproximateBacklogCount(),
-		ApproximateBacklogAge:   durationpb.New(age.AsDuration()),
-		TasksAddRate:            in.GetTasksAddRate(),
-		TasksDispatchRate:       in.GetTasksDispatchRate(),
-		RateLimitingActive:      in.GetRateLimitingActive(),
-	}
+	return out
 }
 
 func cloneStatsByPriority(in map[int32]*taskqueuepb.TaskQueueStats) map[int32]*taskqueuepb.TaskQueueStats {

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -1742,6 +1742,7 @@ func cloneTaskQueueStats(in *taskqueuepb.TaskQueueStats) *taskqueuepb.TaskQueueS
 		ApproximateBacklogAge:   durationpb.New(age.AsDuration()),
 		TasksAddRate:            in.GetTasksAddRate(),
 		TasksDispatchRate:       in.GetTasksDispatchRate(),
+		RateLimitingActive:      in.GetRateLimitingActive(),
 	}
 }
 
@@ -1800,12 +1801,14 @@ func splitTaskQueueStatsByRampPercentage(
 		ApproximateBacklogAge:   currentAge,
 		TasksAddRate:            in.GetTasksAddRate() - rampAddRate,
 		TasksDispatchRate:       in.GetTasksDispatchRate() - rampDispatchRate,
+		RateLimitingActive:      in.GetRateLimitingActive(),
 	}
 	rampShare = &taskqueuepb.TaskQueueStats{
 		ApproximateBacklogCount: rampCount,
 		ApproximateBacklogAge:   rampAge,
 		TasksAddRate:            rampAddRate,
 		TasksDispatchRate:       rampDispatchRate,
+		RateLimitingActive:      in.GetRateLimitingActive(),
 	}
 	return currentShare, rampShare
 }

--- a/service/matching/task_queue_partition_manager_test.go
+++ b/service/matching/task_queue_partition_manager_test.go
@@ -2197,3 +2197,54 @@ func TestWorkerCommandsPollTask_VersioningFieldsIgnored(t *testing.T) {
 		})
 	}
 }
+
+func TestCloneTaskQueueStats_PreservesAllFields(t *testing.T) {
+	original := &taskqueuepb.TaskQueueStats{
+		ApproximateBacklogCount: 42,
+		ApproximateBacklogAge:   durationpb.New(5 * time.Minute),
+		TasksAddRate:            10.5,
+		TasksDispatchRate:       8.3,
+		RateLimitingActive:      true,
+	}
+	cloned := cloneTaskQueueStats(original)
+
+	require.Equal(t, original.ApproximateBacklogCount, cloned.ApproximateBacklogCount)
+	require.Equal(t, original.ApproximateBacklogAge.AsDuration(), cloned.ApproximateBacklogAge.AsDuration())
+	require.InDelta(t, original.TasksAddRate, cloned.TasksAddRate, 1e-9)
+	require.InDelta(t, original.TasksDispatchRate, cloned.TasksDispatchRate, 1e-9)
+	require.True(t, cloned.RateLimitingActive)
+}
+
+func TestCloneTaskQueueStats_Nil(t *testing.T) {
+	cloned := cloneTaskQueueStats(nil)
+	require.NotNil(t, cloned)
+	require.False(t, cloned.RateLimitingActive)
+}
+
+func TestSplitTaskQueueStatsByRampPercentage_PreservesRateLimitingActive(t *testing.T) {
+	original := &taskqueuepb.TaskQueueStats{
+		ApproximateBacklogCount: 10,
+		ApproximateBacklogAge:   durationpb.New(2 * time.Minute),
+		TasksAddRate:            20,
+		TasksDispatchRate:       15,
+		RateLimitingActive:      true,
+	}
+	currentShare, rampShare := splitTaskQueueStatsByRampPercentage(original, 30)
+
+	require.True(t, currentShare.RateLimitingActive, "currentShare should preserve RateLimitingActive")
+	require.True(t, rampShare.RateLimitingActive, "rampShare should preserve RateLimitingActive")
+}
+
+func TestSplitTaskQueueStatsByRampPercentage_RateLimitingFalse(t *testing.T) {
+	original := &taskqueuepb.TaskQueueStats{
+		ApproximateBacklogCount: 10,
+		ApproximateBacklogAge:   durationpb.New(2 * time.Minute),
+		TasksAddRate:            20,
+		TasksDispatchRate:       15,
+		RateLimitingActive:      false,
+	}
+	currentShare, rampShare := splitTaskQueueStatsByRampPercentage(original, 30)
+
+	require.False(t, currentShare.RateLimitingActive)
+	require.False(t, rampShare.RateLimitingActive)
+}

--- a/tests/task_queue_test.go
+++ b/tests/task_queue_test.go
@@ -380,6 +380,71 @@ func (s *TaskQueueSuite) TestTaskQueueAPIRateLimitZero() {
 	s.Empty(runTimes, "No activities should run when API rate limit is 0")
 }
 
+// TestDescribeTaskQueue_RateLimitingActive verifies that the RateLimitingActive field
+// in TaskQueueStats is correctly propagated through DescribeTaskQueue when rate limiting
+// is active on a task queue.
+func (s *TaskQueueSuite) TestDescribeTaskQueue_RateLimitingActive() {
+	const (
+		apiRPS            = 1.0
+		taskCount         = 10
+		activityTaskQueue = "RateLimitTestDescribe"
+		activityName      = "rateLimitedActivity"
+		workerRPS         = 50.0
+		drainTimeout      = 15 * time.Second
+	)
+
+	env := s.newTestEnv(
+		testcore.WithDynamicConfig(dynamicconfig.MatchingNumTaskqueueReadPartitions, 1),
+		testcore.WithDynamicConfig(dynamicconfig.MatchingNumTaskqueueWritePartitions, 1),
+		testcore.WithDynamicConfig(dynamicconfig.TaskQueueInfoByBuildIdTTL, 1*time.Millisecond),
+	)
+
+	var (
+		mu       sync.Mutex
+		runTimes []time.Time
+		wg       sync.WaitGroup
+	)
+
+	_, cancel, activityWorker, wfWorker := s.configureRateLimitAndLaunchWorkflows(
+		env,
+		activityTaskQueue,
+		activityName,
+		taskCount,
+		workerRPS,
+		drainTimeout,
+		&runTimes,
+		&wg,
+		apiRPS,
+		&mu,
+	)
+	defer cancel()
+	defer activityWorker.Stop()
+	defer wfWorker.Stop()
+
+	// Poll DescribeTaskQueue until RateLimitingActive is true.
+	// The rate limit is 1 RPS with 10 tasks, so rate limiting should kick in quickly.
+	s.Eventually(func() bool {
+		resp, err := env.FrontendClient().DescribeTaskQueue(s.Context(), &workflowservice.DescribeTaskQueueRequest{
+			Namespace:     env.Namespace().String(),
+			TaskQueue:     &taskqueuepb.TaskQueue{Name: activityTaskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			TaskQueueType: enumspb.TASK_QUEUE_TYPE_ACTIVITY,
+			ApiMode:       enumspb.DESCRIBE_TASK_QUEUE_MODE_ENHANCED,
+			ReportStats:   true,
+		})
+		if err != nil {
+			return false
+		}
+		for _, typeInfo := range resp.GetVersionsInfo() {
+			for _, info := range typeInfo.GetTypesInfo() {
+				if info.GetStats().GetRateLimitingActive() {
+					return true
+				}
+			}
+		}
+		return false
+	}, 10*time.Second, 200*time.Millisecond, "DescribeTaskQueue should report RateLimitingActive=true when rate limiting is active")
+}
+
 func (s *TaskQueueSuite) TestTaskQueueRateLimit_UpdateFromWorkerConfigAndAPI() {
 	const (
 		workerSetRPS      = 2.0 // Worker rate limit for activities

--- a/tests/task_queue_test.go
+++ b/tests/task_queue_test.go
@@ -423,25 +423,17 @@ func (s *TaskQueueSuite) TestDescribeTaskQueue_RateLimitingActive() {
 
 	// Poll DescribeTaskQueue until RateLimitingActive is true.
 	// The rate limit is 1 RPS with 10 tasks, so rate limiting should kick in quickly.
-	s.Eventually(func() bool {
+	s.AwaitTruef(func() bool {
 		resp, err := env.FrontendClient().DescribeTaskQueue(s.Context(), &workflowservice.DescribeTaskQueueRequest{
 			Namespace:     env.Namespace().String(),
 			TaskQueue:     &taskqueuepb.TaskQueue{Name: activityTaskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 			TaskQueueType: enumspb.TASK_QUEUE_TYPE_ACTIVITY,
-			ApiMode:       enumspb.DESCRIBE_TASK_QUEUE_MODE_ENHANCED,
 			ReportStats:   true,
 		})
 		if err != nil {
 			return false
 		}
-		for _, typeInfo := range resp.GetVersionsInfo() {
-			for _, info := range typeInfo.GetTypesInfo() {
-				if info.GetStats().GetRateLimitingActive() {
-					return true
-				}
-			}
-		}
-		return false
+		return resp.GetStats().GetRateLimitingActive()
 	}, 10*time.Second, 200*time.Millisecond, "DescribeTaskQueue should report RateLimitingActive=true when rate limiting is active")
 }
 


### PR DESCRIPTION
## What
Replace the hand-rolled `cloneTaskQueueStats` with `common.CloneProto` so new `TaskQueueStats` fields propagate automatically. Also add `RateLimitingActive` to the two struct literals in `splitTaskQueueStatsByRampPercentage`.

## Why
[#10944](https://github.com/temporalio/temporal/pull/10944) added `RateLimitingActive` to `TaskQueueStats` but missed updating these hand-rolled struct constructions. The field was silently zeroed, causing `DescribeTaskQueue` and `DescribeWorkerDeploymentVersion` to always report `false`.

## How did you test it?
- **Unit**: tests for `cloneTaskQueueStats` and `splitTaskQueueStatsByRampPercentage` verifying the field survives both transforms.
- **Functional**: `TestDescribeTaskQueue_RateLimitingActive` — sets a 1 RPS API rate limit, drives traffic, and asserts `RateLimitingActive == true` in the `DescribeTaskQueue` response end-to-end.