### PR TITLE
Fix nexus operation cancellation retry dedup

### DIFF
--- a/chasm/lib/nexusoperation/operation.go
+++ b/chasm/lib/nexusoperation/operation.go
@@ -175,8 +175,8 @@ func (o *Operation) RequestCancel(
 	req *nexusoperationpb.CancellationState,
 ) error {
 	// A cancel retry can arrive after the operation closed, so dedupe before rejecting terminal states.
-	existingCancellation, cancellationRequested := o.Cancellation.TryGet(ctx)
-	if cancellationRequested &&
+	existingCancellation, hasCanceled := o.Cancellation.TryGet(ctx)
+	if hasCanceled &&
 		existingCancellation.GetRequestId() == req.GetRequestId() {
 		return nil
 	}
@@ -185,7 +185,7 @@ func (o *Operation) RequestCancel(
 		return ErrOperationAlreadyCompleted
 	}
 
-	if cancellationRequested {
+	if hasCanceled {
 		existingReqID := existingCancellation.GetRequestId()
 		return fmt.Errorf("%w with request ID %s", ErrCancellationAlreadyRequested, existingReqID)
 	}

--- a/chasm/lib/nexusoperation/operation.go
+++ b/chasm/lib/nexusoperation/operation.go
@@ -174,6 +174,7 @@ func (o *Operation) RequestCancel(
 	ctx chasm.MutableContext,
 	req *nexusoperationpb.CancellationState,
 ) error {
+	// A cancel retry can arrive after the operation closed, so dedupe before rejecting terminal states.
 	existingCancellation, cancellationRequested := o.Cancellation.TryGet(ctx)
 	if cancellationRequested &&
 		existingCancellation.GetRequestId() == req.GetRequestId() {

--- a/chasm/lib/nexusoperation/operation.go
+++ b/chasm/lib/nexusoperation/operation.go
@@ -174,17 +174,19 @@ func (o *Operation) RequestCancel(
 	ctx chasm.MutableContext,
 	req *nexusoperationpb.CancellationState,
 ) error {
+	existingCancellation, cancellationRequested := o.Cancellation.TryGet(ctx)
+	if cancellationRequested &&
+		existingCancellation.GetRequestId() == req.GetRequestId() {
+		return nil
+	}
+
 	if !TransitionCanceled.Possible(o) {
 		return ErrOperationAlreadyCompleted
 	}
 
-	if existingCancellation, ok := o.Cancellation.TryGet(ctx); ok {
+	if cancellationRequested {
 		existingReqID := existingCancellation.GetRequestId()
-		newReqID := req.GetRequestId()
-		if existingReqID != newReqID {
-			return fmt.Errorf("%w with request ID %s", ErrCancellationAlreadyRequested, existingReqID)
-		}
-		return nil
+		return fmt.Errorf("%w with request ID %s", ErrCancellationAlreadyRequested, existingReqID)
 	}
 
 	cancel := newCancellation(req)

--- a/chasm/lib/nexusoperation/operation_test.go
+++ b/chasm/lib/nexusoperation/operation_test.go
@@ -25,6 +25,45 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+func TestRequestCancelDeduplicationAfterTerminalState(t *testing.T) {
+	const requestID = "cancel-request-id"
+
+	newCanceledOperation := func() (*Operation, *chasm.MockMutableContext) {
+		ctx := &chasm.MockMutableContext{}
+		op := newTestOperation()
+		op.Status = nexusoperationpb.OPERATION_STATUS_CANCELED
+		op.Cancellation = chasm.NewComponentField(
+			ctx,
+			newCancellation(&nexusoperationpb.CancellationState{
+				RequestId: requestID,
+			}),
+		)
+		return op, ctx
+	}
+
+	t.Run("same request", func(t *testing.T) {
+		op, ctx := newCanceledOperation()
+
+		err := op.RequestCancel(ctx, &nexusoperationpb.CancellationState{
+			RequestId: requestID,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, nexusoperationpb.OPERATION_STATUS_CANCELED, op.Status)
+	})
+
+	t.Run("new request", func(t *testing.T) {
+		op, ctx := newCanceledOperation()
+
+		err := op.RequestCancel(ctx, &nexusoperationpb.CancellationState{
+			RequestId: "new-request-id",
+		})
+
+		require.ErrorIs(t, err, ErrOperationAlreadyCompleted)
+		require.Equal(t, nexusoperationpb.OPERATION_STATUS_CANCELED, op.Status)
+	})
+}
+
 func TestIsWaitStageReached(t *testing.T) {
 	t.Parallel()
 

--- a/chasm/lib/nexusoperation/operation_test.go
+++ b/chasm/lib/nexusoperation/operation_test.go
@@ -42,6 +42,7 @@ func TestRequestCancelDeduplicationAfterTerminalState(t *testing.T) {
 	}
 
 	t.Run("same request", func(t *testing.T) {
+		// With the same RequestId, the cancellation is idempotent, and returns a successful response.
 		op, ctx := newCanceledOperation()
 
 		err := op.RequestCancel(ctx, &nexusoperationpb.CancellationState{
@@ -53,6 +54,7 @@ func TestRequestCancelDeduplicationAfterTerminalState(t *testing.T) {
 	})
 
 	t.Run("new request", func(t *testing.T) {
+		// With a new RequestId, the operation now fails. It is already completed.
 		op, ctx := newCanceledOperation()
 
 		err := op.RequestCancel(ctx, &nexusoperationpb.CancellationState{

--- a/tests/nexus_standalone_test.go
+++ b/tests/nexus_standalone_test.go
@@ -953,6 +953,66 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 		s.Contains(err.Error(), "cancellation already requested")
 	})
 
+	s.Run("RetryAfterTerminalStateAndIDReuse", func(s *NexusStandaloneTestSuite) {
+		env := s.newTestEnv()
+		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
+
+		firstStartResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId: "test-op",
+			Endpoint:    endpointName,
+		})
+		s.NoError(err)
+
+		cancelRequest := &workflowservice.RequestCancelNexusOperationExecutionRequest{
+			Namespace:   env.Namespace().String(),
+			OperationId: "test-op",
+			RunId:       firstStartResp.RunId,
+			RequestId:   "cancel-request-id",
+		}
+		_, err = env.FrontendClient().RequestCancelNexusOperationExecution(
+			s.Context(),
+			cancelRequest,
+		)
+		s.NoError(err)
+
+		_, err = env.FrontendClient().TerminateNexusOperationExecution(
+			s.Context(),
+			&workflowservice.TerminateNexusOperationExecutionRequest{
+				Namespace:   env.Namespace().String(),
+				OperationId: "test-op",
+				RunId:       firstStartResp.RunId,
+				RequestId:   "terminate-request-id",
+			},
+		)
+		s.NoError(err)
+
+		secondStartResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId: "test-op",
+			Endpoint:    endpointName,
+			RequestId:   "second-start-request-id",
+		})
+		s.NoError(err)
+		s.NotEqual(firstStartResp.RunId, secondStartResp.RunId)
+
+		// The retry targets the closed execution and must not cancel its replacement.
+		_, err = env.FrontendClient().RequestCancelNexusOperationExecution(
+			s.Context(),
+			cancelRequest,
+		)
+		s.NoError(err)
+
+		describeResp, err := env.FrontendClient().DescribeNexusOperationExecution(
+			s.Context(),
+			&workflowservice.DescribeNexusOperationExecutionRequest{
+				Namespace:   env.Namespace().String(),
+				OperationId: "test-op",
+				RunId:       secondStartResp.RunId,
+			},
+		)
+		s.NoError(err)
+		s.Nil(describeResp.GetInfo().GetCancellationInfo())
+	})
+
 	s.Run("RequestCancel_ForwardsOriginalNexusHeaders", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
 		taskHeaderCh := make(chan string, 1)

--- a/tests/nexus_standalone_test.go
+++ b/tests/nexus_standalone_test.go
@@ -1011,17 +1011,6 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 		)
 		s.NoError(err)
 		s.Nil(describeResp.GetInfo().GetCancellationInfo())
-
-		describeResp, err = env.FrontendClient().DescribeNexusOperationExecution(
-			s.Context(),
-			&workflowservice.DescribeNexusOperationExecutionRequest{
-				Namespace:   env.Namespace().String(),
-				OperationId: "test-op",
-				RunId:       firstStartResp.RunId,
-			},
-		)
-		s.NoError(err)
-		s.Equal(int32(1), describeResp.GetInfo().GetCancellationInfo().GetAttempt())
 	})
 
 	s.Run("RequestCancel_ForwardsOriginalNexusHeaders", func(s *NexusStandaloneTestSuite) {

--- a/tests/nexus_standalone_test.go
+++ b/tests/nexus_standalone_test.go
@@ -1011,6 +1011,17 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 		)
 		s.NoError(err)
 		s.Nil(describeResp.GetInfo().GetCancellationInfo())
+
+		describeResp, err = env.FrontendClient().DescribeNexusOperationExecution(
+			s.Context(),
+			&workflowservice.DescribeNexusOperationExecutionRequest{
+				Namespace:   env.Namespace().String(),
+				OperationId: "test-op",
+				RunId:       firstStartResp.RunId,
+			},
+		)
+		s.NoError(err)
+		s.Equal(int32(1), describeResp.GetInfo().GetCancellationInfo().GetAttempt())
 	})
 
 	s.Run("RequestCancel_ForwardsOriginalNexusHeaders", func(s *NexusStandaloneTestSuite) {


### PR DESCRIPTION
## What changed?
* Deduplicate cancel retries before terminal-state validation
* Added tests covering terminal-state retries and run-qualified retries after operation ID reuse.

## Why?
A delayed retry can arrive after the original activity has closed.
Deduplication must still recognize that retry, and callers must pin cancellation to a run_id so activity ID reuse cannot
redirect the request to a replacement execution.

See also: https://github.com/temporalio/temporal/pull/11344

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)
