### PR TITLE
[Patch] Stop reapply from falling back to CHASM when HSM has no such operation

### DIFF
--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -1100,24 +1100,23 @@ func reapplyEvents(
 			}
 		default:
 			// Nexus operations (and other state-machine-backed components) can be backed by either the HSM tree or the
-			// CHASM tree, and both coexist on the same mutable state. Reset must rebuild the op regardless of which
-			// framework owns it.
-			// TODO(follow-up): the completion-token resolution path (HSM StateMachineRef vs CHASM
-			// ComponentRef) also needs the same fallback; see the completion handler in nexusoperation.
+			// CHASM tree, and both coexist on the same mutable state. An op missing from the HSM tree is skipped
+			// rather than looked up in CHASM; see cherryPickHSMEvent.
 			outcome, err := cherryPickHSMEvent(mutableState, stateMachineRegistry, event, resetReapplyExcludeTypes)
 			if err != nil {
 				return reappliedEvents, err
 			}
 			if outcome == cherryPickFallback {
-				// HSM doesn't own this op (unknown type, or component not in the HSM tree): try the CHASM tree.
+				// HSM doesn't define this event type: try the CHASM tree.
 				outcome, err = cherryPickChasmEvent(ctx, mutableState, chasmWorkflowRegistry, event, resetReapplyExcludeTypes)
 				if err != nil {
 					return reappliedEvents, err
 				}
 			}
 			if outcome != cherryPickApplied {
-				// Either skipped (recognized but not cherry-pickable) or unhandled by both frameworks.
-				// Only reapply hardcoded events above or ones cherry-picked in HSM or CHASM.
+				// Skipped for one of three reasons: not cherry-pickable, the component is missing from the
+				// HSM tree, or neither framework defines the event type. Only reapply hardcoded events
+				// above or ones cherry-picked in HSM or CHASM.
 				continue
 			}
 			mutableState.AddHistoryEvent(event.EventType, func(he *historypb.HistoryEvent) {
@@ -1143,8 +1142,10 @@ const (
 	// (e.g. excluded by reset-reapply-exclude-types, or not a cherry-pickable transition). The event
 	// must be skipped, NOT routed to the other framework, to avoid double-applying.
 	cherryPickSkipped
-	// cherryPickFallback: this framework doesn't own the op (unknown event type, or the component is
-	// not in this tree). The caller should try the other framework.
+	// cherryPickFallback: this framework doesn't define the event type, so the caller should try the
+	// other framework. A component missing from this framework's tree is skipped, not a fallback.
+	// HSM and CHASM define the same event types today, so this outcome only ever reaches CHASM's
+	// registry lookup, never its cherry-pick.
 	cherryPickFallback
 )
 
@@ -1163,8 +1164,11 @@ func cherryPickHSMEvent(
 	if err := def.CherryPick(mutableState.HSM(), event, resetReapplyExcludeTypes); err != nil {
 		switch {
 		case errors.Is(err, hsm.ErrStateMachineNotFound):
-			// The op isn't in the HSM tree. It may live in the CHASM tree instead, so fall back.
-			return cherryPickFallback, nil
+			// The op isn't in the HSM tree. On the replication reapply path it is usually in no tree at
+			// all: unlike reset, the batch is not guaranteed to share a prefix with the surviving branch,
+			// so events for operations that only existed on the discarded branch are normal. Skip rather
+			// than fall back to CHASM, whose NotFound for a missing op aborts the whole batch.
+			return cherryPickSkipped, nil
 		case errors.Is(err, hsm.ErrNotCherryPickable), errors.Is(err, hsm.ErrInvalidTransition):
 			// Recognized by HSM but intentionally not cherry-pickable here; skip without falling back.
 			return cherryPickSkipped, nil
@@ -1176,8 +1180,11 @@ func cherryPickHSMEvent(
 }
 
 // cherryPickChasmEvent attempts to cherry-pick an event against the CHASM workflow tree. It mirrors cherryPickHSMEvent.
-// As the last framework tried, an event type it doesn't define is skipped (nothing left to fall back to), and a
-// CHASM-defined event on a workflow without CHASM enabled returns an error rather than being silently dropped.
+// As the last framework tried, an event type it doesn't define is skipped: there is nothing left to fall back to.
+//
+// HSM and CHASM register the same Nexus event types, and cherryPickHSMEvent no longer falls back when a component is
+// missing from the HSM tree, so callers only reach the registry lookup below. Everything past it, including the
+// ChasmEnabled check, is unreachable until some CHASM library defines an event type HSM does not.
 func cherryPickChasmEvent(
 	ctx context.Context,
 	mutableState historyi.MutableState,

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -1144,8 +1144,6 @@ const (
 	cherryPickSkipped
 	// cherryPickFallback: this framework doesn't define the event type, so the caller should try the
 	// other framework. A component missing from this framework's tree is skipped, not a fallback.
-	// HSM and CHASM define the same event types today, so this outcome only ever reaches CHASM's
-	// registry lookup, never its cherry-pick.
 	cherryPickFallback
 )
 
@@ -1164,10 +1162,10 @@ func cherryPickHSMEvent(
 	if err := def.CherryPick(mutableState.HSM(), event, resetReapplyExcludeTypes); err != nil {
 		switch {
 		case errors.Is(err, hsm.ErrStateMachineNotFound):
-			// The op isn't in the HSM tree. On the replication reapply path it is usually in no tree at
-			// all: unlike reset, the batch is not guaranteed to share a prefix with the surviving branch,
-			// so events for operations that only existed on the discarded branch are normal. Skip rather
-			// than fall back to CHASM, whose NotFound for a missing op aborts the whole batch.
+			// The op isn't in the HSM tree. Skip rather than falling back to CHASM: on the replication
+			// path the op is usually in no tree at all, and CHASM's NotFound for a missing op would abort
+			// the whole batch. The cost is that reset reapply drops completions for CHASM-owned ops.
+			// See https://github.com/temporalio/temporal/issues/11384.
 			return cherryPickSkipped, nil
 		case errors.Is(err, hsm.ErrNotCherryPickable), errors.Is(err, hsm.ErrInvalidTransition):
 			// Recognized by HSM but intentionally not cherry-pickable here; skip without falling back.
@@ -1184,7 +1182,7 @@ func cherryPickHSMEvent(
 //
 // HSM and CHASM register the same Nexus event types, and cherryPickHSMEvent no longer falls back when a component is
 // missing from the HSM tree, so callers only reach the registry lookup below. Everything past it, including the
-// ChasmEnabled check, is unreachable until some CHASM library defines an event type HSM does not.
+// ChasmEnabled check, is unreachable until https://github.com/temporalio/temporal/issues/11384 is fixed.
 func cherryPickChasmEvent(
 	ctx context.Context,
 	mutableState historyi.MutableState,

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -2009,11 +2009,13 @@ func (l fakeChasmLibrary) CommandHandlers() map[enumspb.CommandType]chasmworkflo
 
 func (l fakeChasmLibrary) EventDefinitions() []chasmworkflow.EventDefinition { return l.defs }
 
-func newChasmRegistryWithEvent(eventType enumspb.EventType, cherryPickErr error) *chasmworkflow.Registry {
+// newChasmRegistryWithEvent registers a single fake definition. chasmworkflow.Registry.Register
+// dedupes by Go type, so one fakeChasmEventDefinition per registry is the limit.
+func (s *workflowResetterSuite) newChasmRegistryWithEvent(eventType enumspb.EventType, cherryPickErr error) *chasmworkflow.Registry {
 	reg := chasmworkflow.NewRegistry()
-	_ = reg.Register(fakeChasmLibrary{defs: []chasmworkflow.EventDefinition{
+	s.Require().NoError(reg.Register(fakeChasmLibrary{defs: []chasmworkflow.EventDefinition{
 		&fakeChasmEventDefinition{eventType: eventType, cherryPickErr: cherryPickErr},
-	}})
+	}}))
 	return reg
 }
 
@@ -2041,14 +2043,14 @@ func (s *workflowResetterSuite) TestCherryPickChasmEvent() {
 		{
 			// A CHASM-defined event on a workflow without CHASM enabled is an error, not a silent skip.
 			name:        "chasm disabled is an error",
-			registry:    newChasmRegistryWithEvent(eventType, nil),
+			registry:    s.newChasmRegistryWithEvent(eventType, nil),
 			setupMock:   func(ms *historyi.MockMutableState) { ms.EXPECT().ChasmEnabled().Return(false) },
 			wantOutcome: cherryPickSkipped,
 			wantErrMsg:  "CHASM is not enabled for this workflow",
 		},
 		{
 			name:     "component lookup error is skipped",
-			registry: newChasmRegistryWithEvent(eventType, nil),
+			registry: s.newChasmRegistryWithEvent(eventType, nil),
 			setupMock: func(ms *historyi.MockMutableState) {
 				ms.EXPECT().ChasmEnabled().Return(true)
 				ms.EXPECT().ChasmWorkflowComponent(gomock.Any()).Return(nil, nil, cherryPickErr)
@@ -2058,7 +2060,7 @@ func (s *workflowResetterSuite) TestCherryPickChasmEvent() {
 		},
 		{
 			name:     "not-cherry-pickable is skipped without error",
-			registry: newChasmRegistryWithEvent(eventType, chasmworkflow.ErrEventNotCherryPickable),
+			registry: s.newChasmRegistryWithEvent(eventType, chasmworkflow.ErrEventNotCherryPickable),
 			setupMock: func(ms *historyi.MockMutableState) {
 				ms.EXPECT().ChasmEnabled().Return(true)
 				ms.EXPECT().ChasmWorkflowComponent(gomock.Any()).Return(nil, nil, nil)
@@ -2067,7 +2069,7 @@ func (s *workflowResetterSuite) TestCherryPickChasmEvent() {
 		},
 		{
 			name:     "cherry-pick error is skipped and surfaced",
-			registry: newChasmRegistryWithEvent(eventType, cherryPickErr),
+			registry: s.newChasmRegistryWithEvent(eventType, cherryPickErr),
 			setupMock: func(ms *historyi.MockMutableState) {
 				ms.EXPECT().ChasmEnabled().Return(true)
 				ms.EXPECT().ChasmWorkflowComponent(gomock.Any()).Return(nil, nil, nil)
@@ -2077,7 +2079,7 @@ func (s *workflowResetterSuite) TestCherryPickChasmEvent() {
 		},
 		{
 			name:     "owned by chasm is applied",
-			registry: newChasmRegistryWithEvent(eventType, nil),
+			registry: s.newChasmRegistryWithEvent(eventType, nil),
 			setupMock: func(ms *historyi.MockMutableState) {
 				ms.EXPECT().ChasmEnabled().Return(true)
 				ms.EXPECT().ChasmWorkflowComponent(gomock.Any()).Return(nil, nil, nil)
@@ -2118,7 +2120,7 @@ func (s *workflowResetterSuite) TestReapplyEventsHSMToChasmFallback() {
 		ms.EXPECT().AddHistoryEvent(eventType, gomock.Any()).Return(&historypb.HistoryEvent{})
 
 		applied, err := reapplyEvents(
-			context.Background(), ms, nil, smReg, newChasmRegistryWithEvent(eventType, nil),
+			context.Background(), ms, nil, smReg, s.newChasmRegistryWithEvent(eventType, nil),
 			[]*historypb.HistoryEvent{event}, nil, "", true,
 		)
 		s.NoError(err)
@@ -2135,6 +2137,43 @@ func (s *workflowResetterSuite) TestReapplyEventsHSMToChasmFallback() {
 		s.NoError(err)
 		s.Empty(applied)
 	})
+}
+
+// TestReapplyEventsHSMNotFoundDoesNotConsultChasm pins that an operation HSM reports as missing is
+// skipped outright, even though CHASM defines the same event type and would apply it. Falling back to
+// CHASM is what regressed replication reapply: a replicated batch is not guaranteed to share a prefix
+// with the surviving branch, so events for operations that only existed on a discarded branch are
+// normal, and CHASM answers those with a NotFound that aborts the entire batch.
+func (s *workflowResetterSuite) TestReapplyEventsHSMNotFoundDoesNotConsultChasm() {
+	const eventType = enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED
+
+	// Both paths reach this branch. Replication carries events for operations that only existed on a
+	// discarded branch; reset reaches it when resetting to a point before the operation was scheduled,
+	// because ScheduledEventDefinition.CherryPick never rebuilds the operation into the new tree.
+	for _, tc := range []struct {
+		name    string
+		isReset bool
+	}{
+		{name: "replication", isReset: false},
+		{name: "reset", isReset: true},
+	} {
+		s.Run(tc.name, func() {
+			ms := historyi.NewMockMutableState(s.controller)
+			ms.EXPECT().HSM().Return(nil).AnyTimes()
+			// No ChasmEnabled expectation on purpose: cherryPickChasmEvent calls it as soon as the
+			// registry recognizes the event type, so consulting CHASM fails on an unexpected call.
+
+			applied, err := reapplyEvents(
+				context.Background(), ms, nil,
+				newHSMRegistryWithEvent(eventType, hsm.ErrStateMachineNotFound),
+				s.newChasmRegistryWithEvent(eventType, nil),
+				[]*historypb.HistoryEvent{{EventId: 5, EventType: eventType}}, nil, "", tc.isReset,
+			)
+
+			s.NoError(err, "a missing operation must not surface as an error")
+			s.Empty(applied, "the event must be skipped, not applied")
+		})
+	}
 }
 
 // fakeHSMEventDefinition is an hsm.EventDefinition whose CherryPick returns a configurable error, letting tests drive
@@ -2175,10 +2214,10 @@ func (s *workflowResetterSuite) TestCherryPickHSMEvent() {
 			wantOutcome: cherryPickFallback,
 		},
 		{
-			name:        "state machine not found falls back",
+			name:        "state machine not found is skipped without falling back",
 			registry:    newHSMRegistryWithEvent(eventType, hsm.ErrStateMachineNotFound),
 			expectHSM:   true,
-			wantOutcome: cherryPickFallback,
+			wantOutcome: cherryPickSkipped,
 		},
 		{
 			name:        "not-cherry-pickable is skipped without error",

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -2141,39 +2141,27 @@ func (s *workflowResetterSuite) TestReapplyEventsHSMToChasmFallback() {
 
 // TestReapplyEventsHSMNotFoundDoesNotConsultChasm pins that an operation HSM reports as missing is
 // skipped outright, even though CHASM defines the same event type and would apply it. Falling back to
-// CHASM is what regressed replication reapply: a replicated batch is not guaranteed to share a prefix
-// with the surviving branch, so events for operations that only existed on a discarded branch are
-// normal, and CHASM answers those with a NotFound that aborts the entire batch.
+// CHASM is what regressed replication reapply; see https://github.com/temporalio/temporal/issues/11384.
 func (s *workflowResetterSuite) TestReapplyEventsHSMNotFoundDoesNotConsultChasm() {
 	const eventType = enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED
 
-	// Both paths reach this branch. Replication carries events for operations that only existed on a
-	// discarded branch; reset reaches it when resetting to a point before the operation was scheduled,
-	// because ScheduledEventDefinition.CherryPick never rebuilds the operation into the new tree.
-	for _, tc := range []struct {
-		name    string
-		isReset bool
-	}{
-		{name: "replication", isReset: false},
-		{name: "reset", isReset: true},
-	} {
-		s.Run(tc.name, func() {
-			ms := historyi.NewMockMutableState(s.controller)
-			ms.EXPECT().HSM().Return(nil).AnyTimes()
-			// No ChasmEnabled expectation on purpose: cherryPickChasmEvent calls it as soon as the
-			// registry recognizes the event type, so consulting CHASM fails on an unexpected call.
+	// Both reset and replication reach this branch, and one case covers both: reapplyEvents reads
+	// isReset only in the hardcoded CancelRequested and Terminated cases, which a Nexus event never
+	// reaches.
+	ms := historyi.NewMockMutableState(s.controller)
+	ms.EXPECT().HSM().Return(nil).AnyTimes()
+	// No ChasmEnabled expectation on purpose: cherryPickChasmEvent calls it as soon as the registry
+	// recognizes the event type, so consulting CHASM fails on an unexpected call.
 
-			applied, err := reapplyEvents(
-				context.Background(), ms, nil,
-				newHSMRegistryWithEvent(eventType, hsm.ErrStateMachineNotFound),
-				s.newChasmRegistryWithEvent(eventType, nil),
-				[]*historypb.HistoryEvent{{EventId: 5, EventType: eventType}}, nil, "", tc.isReset,
-			)
+	applied, err := reapplyEvents(
+		context.Background(), ms, nil,
+		newHSMRegistryWithEvent(eventType, hsm.ErrStateMachineNotFound),
+		s.newChasmRegistryWithEvent(eventType, nil),
+		[]*historypb.HistoryEvent{{EventId: 5, EventType: eventType}}, nil, "", false,
+	)
 
-			s.NoError(err, "a missing operation must not surface as an error")
-			s.Empty(applied, "the event must be skipped, not applied")
-		})
-	}
+	s.NoError(err, "a missing operation must not surface as an error")
+	s.Empty(applied, "the event must be skipped, not applied")
 }
 
 // fakeHSMEventDefinition is an hsm.EventDefinition whose CherryPick returns a configurable error, letting tests drive

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -1232,6 +1232,12 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletion(chasmEnabled 
 	s.Empty(hist[wftCompletedIdx].Links)
 	wftCompletedEventID := hist[wftCompletedIdx].EventId
 
+	// Reset reapply of a Nexus completion is HSM-only: cherryPickHSMEvent skips an operation missing
+	// from the HSM tree rather than falling back to CHASM.
+	if chasmEnabled {
+		return
+	}
+
 	// Reset the workflow and check that the completion event has been reapplied.
 	resp, err := env.FrontendClient().ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
 		Namespace:                 env.Namespace().String(),

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -1232,12 +1232,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletion(chasmEnabled 
 	s.Empty(hist[wftCompletedIdx].Links)
 	wftCompletedEventID := hist[wftCompletedIdx].EventId
 
-	// Reset reapply of a Nexus completion is HSM-only: cherryPickHSMEvent skips an operation missing
-	// from the HSM tree rather than falling back to CHASM.
-	if chasmEnabled {
-		return
-	}
-
 	// Reset the workflow and check that the completion event has been reapplied.
 	resp, err := env.FrontendClient().ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
 		Namespace:                 env.Namespace().String(),
@@ -1249,7 +1243,14 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletion(chasmEnabled 
 	s.NoError(err)
 
 	resetHist1 := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: resp.RunId})
-	s.RequireHistoryEvent(resetHist1, enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED)
+	if chasmEnabled {
+		// Reset reapply is HSM-only, so a CHASM-owned operation's completion is not reapplied, though
+		// the reset itself must still succeed. Becomes RequireHistoryEvent on both rails once
+		// https://github.com/temporalio/temporal/issues/11384 is fixed.
+		s.RequireNoHistoryEvent(resetHist1, enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED)
+	} else {
+		s.RequireHistoryEvent(resetHist1, enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED)
+	}
 
 	// Reset the workflow again to the same point with enumspb.RESET_REAPPLY_EXCLUDE_TYPE_NEXUS option
 	// and verify that the completion event has been excluded.


### PR DESCRIPTION
## What changed?

This PR cherry-picks the commits from PR #11381.

## Why?

See the source PR for more context. In short, an earlier commit introduced some unintended behavior changes for failover scenarios. The changes in question restores the earlier behavior. 

Other than comments and tests, the functional change is reverting `cherryPickFallback` and going back to the origonal behavior of `cherryPickSkip`.

## How did you test it?

- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

This scenario is very much in the weeds, and I'm relying on the newly added unit tests and CI/CD to catch any problems. The original issue was only found via MCS testing via `bench-go`. However, the actual functional difference is (in theory) very small and isolated. It's just that it's also at the very bottom of a great number of moving parts!
