### PR TITLE
Add validation of standalone activity user metadata

### DIFF
--- a/chasm/lib/activity/config.go
+++ b/chasm/lib/activity/config.go
@@ -59,6 +59,8 @@ type Config struct {
 	MaxIDLengthLimit                         dynamicconfig.IntPropertyFn
 	MaxCallbacksPerExecution                 dynamicconfig.IntPropertyFnWithNamespaceFilter
 	DefaultActivityRetryPolicy               dynamicconfig.TypedPropertyFnWithNamespaceFilter[retrypolicy.DefaultRetrySettings]
+	MaxUserMetadataDetailsSize               dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxUserMetadataSummarySize               dynamicconfig.IntPropertyFnWithNamespaceFilter
 	StartDelayEnabled                        dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	VisibilityMaxPageSize                    dynamicconfig.IntPropertyFnWithNamespaceFilter
 }
@@ -77,6 +79,8 @@ func ConfigProvider(dc *dynamicconfig.Collection) *Config {
 		MaxIDLengthLimit:                         dynamicconfig.MaxIDLengthLimit.Get(dc),
 		StartDelayEnabled:                        StartDelayEnabled.Get(dc),
 		MaxCallbacksPerExecution:                 callback.MaxPerExecution.Get(dc),
+		MaxUserMetadataDetailsSize:               dynamicconfig.MaxUserMetadataDetailsSize.Get(dc),
+		MaxUserMetadataSummarySize:               dynamicconfig.MaxUserMetadataSummarySize.Get(dc),
 		VisibilityMaxPageSize:                    dynamicconfig.FrontendVisibilityMaxPageSize.Get(dc),
 	}
 }

--- a/chasm/lib/activity/frontend.go
+++ b/chasm/lib/activity/frontend.go
@@ -405,11 +405,7 @@ func (h *frontendHandler) validateAndPopulateStartRequest(
 
 	err = validateAndNormalizeStartRequest(
 		req,
-		h.config.MaxIDLengthLimit(),
-		h.config.BlobSizeLimitError,
-		h.config.BlobSizeLimitWarn,
-		h.config.MaxUserMetadataSummarySize,
-		h.config.MaxUserMetadataDetailsSize,
+		h.config,
 		h.logger,
 		h.saMapperProvider,
 		h.saValidator,

--- a/chasm/lib/activity/frontend.go
+++ b/chasm/lib/activity/frontend.go
@@ -408,6 +408,8 @@ func (h *frontendHandler) validateAndPopulateStartRequest(
 		h.config.MaxIDLengthLimit(),
 		h.config.BlobSizeLimitError,
 		h.config.BlobSizeLimitWarn,
+		h.config.MaxUserMetadataSummarySize,
+		h.config.MaxUserMetadataDetailsSize,
 		h.logger,
 		h.saMapperProvider,
 		h.saValidator,

--- a/chasm/lib/activity/frontend_test.go
+++ b/chasm/lib/activity/frontend_test.go
@@ -104,6 +104,8 @@ func TestRequestIdStableAcrossRetries(t *testing.T) {
 			BlobSizeLimitWarn:          defaultBlobSizeLimitWarn,
 			MaxIDLengthLimit:           func() int { return defaultMaxIDLengthLimit },
 			DefaultActivityRetryPolicy: getDefaultRetrySettings,
+			MaxUserMetadataDetailsSize: defaultMaxUserMetadataDetailsSize,
+			MaxUserMetadataSummarySize: defaultMaxUserMetadataSummarySize,
 		},
 		linkValidator: newLinkValidator(
 			defaultMaxLinksPerRequest,

--- a/chasm/lib/activity/validator.go
+++ b/chasm/lib/activity/validator.go
@@ -366,15 +366,12 @@ func validateAndNormalizePollActivityExecutionRequest(
 
 func validateAndNormalizeStartRequest(
 	req *workflowservice.StartActivityExecutionRequest,
-	maxIDLengthLimit int,
-	blobSizeLimitError dynamicconfig.IntPropertyFnWithNamespaceFilter,
-	blobSizeLimitWarn dynamicconfig.IntPropertyFnWithNamespaceFilter,
-	maxUserMetadataSummarySize dynamicconfig.IntPropertyFnWithNamespaceFilter,
-	maxUserMetadataDetailsSize dynamicconfig.IntPropertyFnWithNamespaceFilter,
+	config *Config,
 	logger log.Logger,
 	saMapperProvider searchattribute.MapperProvider,
 	saValidator *searchattribute.Validator,
 ) error {
+	maxIDLengthLimit := config.MaxIDLengthLimit()
 	if len(req.GetRequestId()) > maxIDLengthLimit {
 		return serviceerror.NewInvalidArgumentf("request ID exceeds length limit. Length=%d Limit=%d",
 			len(req.GetRequestId()), maxIDLengthLimit)
@@ -392,8 +389,8 @@ func validateAndNormalizeStartRequest(
 	if err := validateBlobSize(
 		req.GetActivityId(),
 		"StartActivityExecution",
-		blobSizeLimitError,
-		blobSizeLimitWarn,
+		config.BlobSizeLimitError,
+		config.BlobSizeLimitWarn,
 		req.Input.Size(),
 		logger,
 		req.GetNamespace()); err != nil {
@@ -402,8 +399,7 @@ func validateAndNormalizeStartRequest(
 	if err := validateUserMetadata(
 		req.GetNamespace(),
 		req.GetUserMetadata(),
-		maxUserMetadataSummarySize,
-		maxUserMetadataDetailsSize,
+		config,
 	); err != nil {
 		return err
 	}
@@ -420,16 +416,15 @@ func validateAndNormalizeStartRequest(
 func validateUserMetadata(
 	namespaceName string,
 	metadata *sdkpb.UserMetadata,
-	maxSummarySize dynamicconfig.IntPropertyFnWithNamespaceFilter,
-	maxDetailsSize dynamicconfig.IntPropertyFnWithNamespaceFilter,
+	config *Config,
 ) error {
 	summarySize := metadata.GetSummary().Size()
-	if limit := maxSummarySize(namespaceName); summarySize > limit {
+	if limit := config.MaxUserMetadataSummarySize(namespaceName); summarySize > limit {
 		return serviceerror.NewInvalidArgumentf(
 			"user_metadata.summary exceeds size limit. Length=%d Limit=%d", summarySize, limit)
 	}
 	detailsSize := metadata.GetDetails().Size()
-	if limit := maxDetailsSize(namespaceName); detailsSize > limit {
+	if limit := config.MaxUserMetadataDetailsSize(namespaceName); detailsSize > limit {
 		return serviceerror.NewInvalidArgumentf(
 			"user_metadata.details exceeds size limit. Length=%d Limit=%d", detailsSize, limit)
 	}

--- a/chasm/lib/activity/validator.go
+++ b/chasm/lib/activity/validator.go
@@ -7,6 +7,7 @@ import (
 	activitypb "go.temporal.io/api/activity/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	sdkpb "go.temporal.io/api/sdk/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/common"
@@ -368,6 +369,8 @@ func validateAndNormalizeStartRequest(
 	maxIDLengthLimit int,
 	blobSizeLimitError dynamicconfig.IntPropertyFnWithNamespaceFilter,
 	blobSizeLimitWarn dynamicconfig.IntPropertyFnWithNamespaceFilter,
+	maxUserMetadataSummarySize dynamicconfig.IntPropertyFnWithNamespaceFilter,
+	maxUserMetadataDetailsSize dynamicconfig.IntPropertyFnWithNamespaceFilter,
 	logger log.Logger,
 	saMapperProvider searchattribute.MapperProvider,
 	saValidator *searchattribute.Validator,
@@ -396,6 +399,14 @@ func validateAndNormalizeStartRequest(
 		req.GetNamespace()); err != nil {
 		return serviceerror.NewInvalidArgument("input exceeds length limit")
 	}
+	if err := validateUserMetadata(
+		req.GetNamespace(),
+		req.GetUserMetadata(),
+		maxUserMetadataSummarySize,
+		maxUserMetadataDetailsSize,
+	); err != nil {
+		return err
+	}
 
 	if req.GetSearchAttributes() != nil {
 		if err := validateAndNormalizeSearchAttributes(req, saMapperProvider, saValidator); err != nil {
@@ -403,6 +414,25 @@ func validateAndNormalizeStartRequest(
 		}
 	}
 
+	return nil
+}
+
+func validateUserMetadata(
+	namespaceName string,
+	metadata *sdkpb.UserMetadata,
+	maxSummarySize dynamicconfig.IntPropertyFnWithNamespaceFilter,
+	maxDetailsSize dynamicconfig.IntPropertyFnWithNamespaceFilter,
+) error {
+	summarySize := metadata.GetSummary().Size()
+	if limit := maxSummarySize(namespaceName); summarySize > limit {
+		return serviceerror.NewInvalidArgumentf(
+			"user_metadata.summary exceeds size limit. Length=%d Limit=%d", summarySize, limit)
+	}
+	detailsSize := metadata.GetDetails().Size()
+	if limit := maxDetailsSize(namespaceName); detailsSize > limit {
+		return serviceerror.NewInvalidArgumentf(
+			"user_metadata.details exceeds size limit. Length=%d Limit=%d", detailsSize, limit)
+	}
 	return nil
 }
 

--- a/chasm/lib/activity/validator_test.go
+++ b/chasm/lib/activity/validator_test.go
@@ -10,6 +10,7 @@ import (
 	activitypb "go.temporal.io/api/activity/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	sdkpb "go.temporal.io/api/sdk/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
@@ -46,6 +47,12 @@ var (
 	}
 	defaultBlobSizeLimitWarn = func(ns string) int {
 		return 32
+	}
+	defaultMaxUserMetadataSummarySize = func(ns string) int {
+		return 400
+	}
+	defaultMaxUserMetadataDetailsSize = func(ns string) int {
+		return 20000
 	}
 	defaultMaxLinksPerRequest = func(ns string) int {
 		return 10
@@ -411,9 +418,11 @@ func newTestFrontendHandler(
 ) *frontendHandler {
 	return &frontendHandler{
 		config: &Config{
-			BlobSizeLimitError: blobSizeLimitError,
-			BlobSizeLimitWarn:  blobSizeLimitWarn,
-			MaxIDLengthLimit:   func() int { return maxIDLengthLimit },
+			BlobSizeLimitError:         blobSizeLimitError,
+			BlobSizeLimitWarn:          blobSizeLimitWarn,
+			MaxIDLengthLimit:           func() int { return maxIDLengthLimit },
+			MaxUserMetadataDetailsSize: defaultMaxUserMetadataDetailsSize,
+			MaxUserMetadataSummarySize: defaultMaxUserMetadataSummarySize,
 		},
 		logger: log.NewNoopLogger(),
 	}
@@ -434,6 +443,8 @@ func TestRequestIDGeneratedWhenMissing(t *testing.T) {
 				BlobSizeLimitWarn:          defaultBlobSizeLimitWarn,
 				MaxIDLengthLimit:           func() int { return maxIDLengthLimit },
 				DefaultActivityRetryPolicy: dynamicconfig.GetTypedPropertyFnFilteredByNamespace(getDefaultRetrySettings("")),
+				MaxUserMetadataDetailsSize: defaultMaxUserMetadataDetailsSize,
+				MaxUserMetadataSummarySize: defaultMaxUserMetadataSummarySize,
 			},
 			linkValidator: newLinkValidator(
 				defaultMaxLinksPerRequest,
@@ -540,7 +551,7 @@ func TestRequestIDTooLong(t *testing.T) {
 			RetryPolicy:         &commonpb.RetryPolicy{},
 			RequestId:           tooLong,
 		}
-		err := validateAndNormalizeStartRequest(req, h.config.MaxIDLengthLimit(), h.config.BlobSizeLimitError, h.config.BlobSizeLimitWarn, h.logger, h.saMapperProvider, h.saValidator)
+		err := validateAndNormalizeStartRequest(req, h.config.MaxIDLengthLimit(), h.config.BlobSizeLimitError, h.config.BlobSizeLimitWarn, defaultMaxUserMetadataSummarySize, defaultMaxUserMetadataDetailsSize, h.logger, h.saMapperProvider, h.saValidator)
 		var invalidArgErr *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgErr)
 	})
@@ -622,7 +633,7 @@ func TestValidateStandAloneRequestIDTooLong(t *testing.T) {
 	}
 
 	h := newTestFrontendHandler(defaultBlobSizeLimitError, defaultBlobSizeLimitWarn, defaultMaxIDLengthLimit)
-	err := validateAndNormalizeStartRequest(req, h.config.MaxIDLengthLimit(), h.config.BlobSizeLimitError, h.config.BlobSizeLimitWarn, h.logger, h.saMapperProvider, h.saValidator)
+	err := validateAndNormalizeStartRequest(req, h.config.MaxIDLengthLimit(), h.config.BlobSizeLimitError, h.config.BlobSizeLimitWarn, defaultMaxUserMetadataSummarySize, defaultMaxUserMetadataDetailsSize, h.logger, h.saMapperProvider, h.saValidator)
 	var invalidArgErr *serviceerror.InvalidArgument
 	require.ErrorAs(t, err, &invalidArgErr)
 }
@@ -642,7 +653,7 @@ func TestValidateStandAloneInputTooLarge(t *testing.T) {
 	}
 
 	h := newTestFrontendHandler(defaultBlobSizeLimitError, defaultBlobSizeLimitWarn, defaultMaxIDLengthLimit)
-	err := validateAndNormalizeStartRequest(req, h.config.MaxIDLengthLimit(), h.config.BlobSizeLimitError, h.config.BlobSizeLimitWarn, h.logger, h.saMapperProvider, h.saValidator)
+	err := validateAndNormalizeStartRequest(req, h.config.MaxIDLengthLimit(), h.config.BlobSizeLimitError, h.config.BlobSizeLimitWarn, defaultMaxUserMetadataSummarySize, defaultMaxUserMetadataDetailsSize, h.logger, h.saMapperProvider, h.saValidator)
 	var invalidArgErr *serviceerror.InvalidArgument
 	require.ErrorAs(t, err, &invalidArgErr)
 }
@@ -669,8 +680,70 @@ func TestValidateStandAloneInputWarningSizeShouldSucceed(t *testing.T) {
 		func(ns string) int { return payloadSize },
 		defaultMaxIDLengthLimit,
 	)
-	err := validateAndNormalizeStartRequest(req, h.config.MaxIDLengthLimit(), h.config.BlobSizeLimitError, h.config.BlobSizeLimitWarn, h.logger, h.saMapperProvider, h.saValidator)
+	err := validateAndNormalizeStartRequest(req, h.config.MaxIDLengthLimit(), h.config.BlobSizeLimitError, h.config.BlobSizeLimitWarn, defaultMaxUserMetadataSummarySize, defaultMaxUserMetadataDetailsSize, h.logger, h.saMapperProvider, h.saValidator)
 	require.NoError(t, err)
+}
+
+func TestValidateStandaloneUserMetadata(t *testing.T) {
+	summary := &commonpb.Payload{Data: []byte("summary")}
+	details := &commonpb.Payload{Data: []byte("details")}
+
+	tests := []struct {
+		name         string
+		metadata     *sdkpb.UserMetadata
+		summaryLimit int
+		detailsLimit int
+		errContains  string
+	}{
+		{
+			name:         "summary exceeds size limit",
+			metadata:     &sdkpb.UserMetadata{Summary: summary},
+			summaryLimit: summary.Size() - 1,
+			detailsLimit: details.Size(),
+			errContains:  "user_metadata.summary exceeds size limit",
+		},
+		{
+			name:         "details exceeds size limit",
+			metadata:     &sdkpb.UserMetadata{Details: details},
+			summaryLimit: summary.Size(),
+			detailsLimit: details.Size() - 1,
+			errContains:  "user_metadata.details exceeds size limit",
+		},
+		{
+			name:         "payloads at size limits",
+			metadata:     &sdkpb.UserMetadata{Summary: summary, Details: details},
+			summaryLimit: summary.Size(),
+			detailsLimit: details.Size(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := &workflowservice.StartActivityExecutionRequest{
+				Namespace:    defaultNamespaceID,
+				ActivityId:   defaultActivityID,
+				UserMetadata: test.metadata,
+			}
+			err := validateAndNormalizeStartRequest(
+				req,
+				defaultMaxIDLengthLimit,
+				defaultBlobSizeLimitError,
+				defaultBlobSizeLimitWarn,
+				func(string) int { return test.summaryLimit },
+				func(string) int { return test.detailsLimit },
+				log.NewNoopLogger(),
+				nil,
+				nil,
+			)
+			if test.errContains == "" {
+				require.NoError(t, err)
+				return
+			}
+			var invalidArgument *serviceerror.InvalidArgument
+			require.ErrorAs(t, err, &invalidArgument)
+			require.ErrorContains(t, err, test.errContains)
+		})
+	}
 }
 
 func TestValidateStandAlone_IDPolicyShouldDefault(t *testing.T) {
@@ -687,7 +760,7 @@ func TestValidateStandAlone_IDPolicyShouldDefault(t *testing.T) {
 	}
 
 	h := newTestFrontendHandler(defaultBlobSizeLimitError, defaultBlobSizeLimitWarn, defaultMaxIDLengthLimit)
-	err := validateAndNormalizeStartRequest(req, h.config.MaxIDLengthLimit(), h.config.BlobSizeLimitError, h.config.BlobSizeLimitWarn, h.logger, h.saMapperProvider, h.saValidator)
+	err := validateAndNormalizeStartRequest(req, h.config.MaxIDLengthLimit(), h.config.BlobSizeLimitError, h.config.BlobSizeLimitWarn, defaultMaxUserMetadataSummarySize, defaultMaxUserMetadataDetailsSize, h.logger, h.saMapperProvider, h.saValidator)
 
 	require.NoError(t, err)
 	require.Equal(t, enumspb.ACTIVITY_ID_REUSE_POLICY_ALLOW_DUPLICATE, req.IdReusePolicy)

--- a/chasm/lib/activity/validator_test.go
+++ b/chasm/lib/activity/validator_test.go
@@ -551,7 +551,7 @@ func TestRequestIDTooLong(t *testing.T) {
 			RetryPolicy:         &commonpb.RetryPolicy{},
 			RequestId:           tooLong,
 		}
-		err := validateAndNormalizeStartRequest(req, h.config.MaxIDLengthLimit(), h.config.BlobSizeLimitError, h.config.BlobSizeLimitWarn, defaultMaxUserMetadataSummarySize, defaultMaxUserMetadataDetailsSize, h.logger, h.saMapperProvider, h.saValidator)
+		err := validateAndNormalizeStartRequest(req, h.config, h.logger, h.saMapperProvider, h.saValidator)
 		var invalidArgErr *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgErr)
 	})
@@ -633,7 +633,7 @@ func TestValidateStandAloneRequestIDTooLong(t *testing.T) {
 	}
 
 	h := newTestFrontendHandler(defaultBlobSizeLimitError, defaultBlobSizeLimitWarn, defaultMaxIDLengthLimit)
-	err := validateAndNormalizeStartRequest(req, h.config.MaxIDLengthLimit(), h.config.BlobSizeLimitError, h.config.BlobSizeLimitWarn, defaultMaxUserMetadataSummarySize, defaultMaxUserMetadataDetailsSize, h.logger, h.saMapperProvider, h.saValidator)
+	err := validateAndNormalizeStartRequest(req, h.config, h.logger, h.saMapperProvider, h.saValidator)
 	var invalidArgErr *serviceerror.InvalidArgument
 	require.ErrorAs(t, err, &invalidArgErr)
 }
@@ -653,7 +653,7 @@ func TestValidateStandAloneInputTooLarge(t *testing.T) {
 	}
 
 	h := newTestFrontendHandler(defaultBlobSizeLimitError, defaultBlobSizeLimitWarn, defaultMaxIDLengthLimit)
-	err := validateAndNormalizeStartRequest(req, h.config.MaxIDLengthLimit(), h.config.BlobSizeLimitError, h.config.BlobSizeLimitWarn, defaultMaxUserMetadataSummarySize, defaultMaxUserMetadataDetailsSize, h.logger, h.saMapperProvider, h.saValidator)
+	err := validateAndNormalizeStartRequest(req, h.config, h.logger, h.saMapperProvider, h.saValidator)
 	var invalidArgErr *serviceerror.InvalidArgument
 	require.ErrorAs(t, err, &invalidArgErr)
 }
@@ -680,7 +680,7 @@ func TestValidateStandAloneInputWarningSizeShouldSucceed(t *testing.T) {
 		func(ns string) int { return payloadSize },
 		defaultMaxIDLengthLimit,
 	)
-	err := validateAndNormalizeStartRequest(req, h.config.MaxIDLengthLimit(), h.config.BlobSizeLimitError, h.config.BlobSizeLimitWarn, defaultMaxUserMetadataSummarySize, defaultMaxUserMetadataDetailsSize, h.logger, h.saMapperProvider, h.saValidator)
+	err := validateAndNormalizeStartRequest(req, h.config, h.logger, h.saMapperProvider, h.saValidator)
 	require.NoError(t, err)
 }
 
@@ -699,13 +699,13 @@ func TestValidateStandaloneUserMetadata(t *testing.T) {
 			name:         "summary exceeds size limit",
 			metadata:     &sdkpb.UserMetadata{Summary: summary},
 			summaryLimit: summary.Size() - 1,
-			detailsLimit: details.Size(),
+			detailsLimit: details.Size() + 1000,
 			errContains:  "user_metadata.summary exceeds size limit",
 		},
 		{
 			name:         "details exceeds size limit",
 			metadata:     &sdkpb.UserMetadata{Details: details},
-			summaryLimit: summary.Size(),
+			summaryLimit: summary.Size() + 1000,
 			detailsLimit: details.Size() - 1,
 			errContains:  "user_metadata.details exceeds size limit",
 		},
@@ -719,22 +719,31 @@ func TestValidateStandaloneUserMetadata(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			req := &workflowservice.StartActivityExecutionRequest{
-				Namespace:    defaultNamespaceID,
-				ActivityId:   defaultActivityID,
-				UserMetadata: test.metadata,
+			h := &frontendHandler{
+				config: &Config{
+					BlobSizeLimitError:         defaultBlobSizeLimitError,
+					BlobSizeLimitWarn:          defaultBlobSizeLimitWarn,
+					DefaultActivityRetryPolicy: getDefaultRetrySettings,
+					MaxIDLengthLimit:           func() int { return defaultMaxIDLengthLimit },
+					MaxUserMetadataSummarySize: func(string) int { return test.summaryLimit },
+					MaxUserMetadataDetailsSize: func(string) int { return test.detailsLimit },
+				},
+				linkValidator: newLinkValidator(
+					defaultMaxLinksPerRequest,
+					func(string) int { return 2000 },
+					defaultLinkMaxSize,
+				),
+				logger: log.NewNoopLogger(),
 			}
-			err := validateAndNormalizeStartRequest(
-				req,
-				defaultMaxIDLengthLimit,
-				defaultBlobSizeLimitError,
-				defaultBlobSizeLimitWarn,
-				func(string) int { return test.summaryLimit },
-				func(string) int { return test.detailsLimit },
-				log.NewNoopLogger(),
-				nil,
-				nil,
-			)
+			req := &workflowservice.StartActivityExecutionRequest{
+				Namespace:           defaultNamespaceID,
+				ActivityId:          defaultActivityID,
+				ActivityType:        &commonpb.ActivityType{Name: defaultActivityType},
+				TaskQueue:           &taskqueuepb.TaskQueue{Name: defaultTaskQueue},
+				StartToCloseTimeout: durationpb.New(10 * time.Second),
+				UserMetadata:        test.metadata,
+			}
+			_, err := h.validateAndPopulateStartRequest(t.Context(), req, namespace.ID(defaultNamespaceID))
 			if test.errContains == "" {
 				require.NoError(t, err)
 				return
@@ -760,7 +769,7 @@ func TestValidateStandAlone_IDPolicyShouldDefault(t *testing.T) {
 	}
 
 	h := newTestFrontendHandler(defaultBlobSizeLimitError, defaultBlobSizeLimitWarn, defaultMaxIDLengthLimit)
-	err := validateAndNormalizeStartRequest(req, h.config.MaxIDLengthLimit(), h.config.BlobSizeLimitError, h.config.BlobSizeLimitWarn, defaultMaxUserMetadataSummarySize, defaultMaxUserMetadataDetailsSize, h.logger, h.saMapperProvider, h.saValidator)
+	err := validateAndNormalizeStartRequest(req, h.config, h.logger, h.saMapperProvider, h.saValidator)
 
 	require.NoError(t, err)
 	require.Equal(t, enumspb.ACTIVITY_ID_REUSE_POLICY_ALLOW_DUPLICATE, req.IdReusePolicy)


### PR DESCRIPTION
## What changed?
Added user_metadata summary and details size validation to StartActivityExecution, using the existing namespace-specific limits and matching standalone Nexus operation behavior.

## Why?
Standalone activities previously persisted user_metadata without enforcing its configured size limits. This made the limits inconsistent across top-level executions and allowed oversized metadata to reach persistence.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

