### PR TITLE
Fix propagation-race flake in TaskQueueStats versioning tests

### DIFF
--- a/tests/task_queue_stats_test.go
+++ b/tests/task_queue_stats_test.go
@@ -232,6 +232,20 @@ func (s *TaskQueueStatsVersionSuite) TestCurrentVersionAbsorbsUnversionedBacklog
 	// Stopping the pollers so that we verify the backlog expectations
 	cancelPoller()
 
+	// Wait for the current-version routing to propagate before enqueuing, otherwise the
+	// unversioned workflows can be added before the task queue knows about the current
+	// version and end up attributed to the wrong (unversioned) backlog. See #10773.
+	env.waitForTaskQueueVersioningInfo(
+		s,
+		&taskqueuepb.TaskQueue{Name: tqName, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		worker_versioning.ExternalWorkerDeploymentVersionToStringV31(&deploymentpb.WorkerDeploymentVersion{
+			DeploymentName: deploymentName,
+			BuildId:        currentBuildID,
+		}),
+		"",
+		0,
+	)
+
 	// Enqueue unversioned backlog
 	unversionedWorkflowCount := 10 * env.partitionCount
 	s.startUnversionedWorkflows(env, unversionedWorkflowCount, tqName)
@@ -484,6 +498,20 @@ func (s *TaskQueueStatsVersionSuite) TestCurrentAbsorbsUnversionedBacklog_WhenRa
 	rampPercentage := 20
 	s.setRampingVersion(env, deploymentName, "", rampPercentage)
 
+	// Wait for the current/ramping routing to propagate before enqueuing, otherwise the
+	// unversioned workflows can be added before the task queue knows about the routing
+	// config and end up attributed to the wrong backlog. See #10773.
+	env.waitForTaskQueueVersioningInfo(
+		s,
+		&taskqueuepb.TaskQueue{Name: tqName, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		worker_versioning.ExternalWorkerDeploymentVersionToStringV31(&deploymentpb.WorkerDeploymentVersion{
+			DeploymentName: deploymentName,
+			BuildId:        currentBuildID,
+		}),
+		worker_versioning.UnversionedVersionId,
+		float32(rampPercentage),
+	)
+
 	// Enqueue unversioned backlog.
 	unversionedWorkflowCount := 10 * env.partitionCount
 	s.startUnversionedWorkflows(env, unversionedWorkflowCount, tqName)
@@ -545,6 +573,20 @@ func (s *TaskQueueStatsVersionSuite) TestRampingAbsorbsUnversionedBacklog_WhenCu
 	rampPercentage := 30
 	s.setRampingVersion(env, deploymentName, rampingBuildID, rampPercentage)
 
+	// Wait for the current/ramping routing to propagate before enqueuing, otherwise the
+	// unversioned workflows can be added before the task queue knows about the routing
+	// config and end up attributed to the wrong backlog. See #10773.
+	env.waitForTaskQueueVersioningInfo(
+		s,
+		&taskqueuepb.TaskQueue{Name: tqName, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		worker_versioning.UnversionedVersionId,
+		worker_versioning.ExternalWorkerDeploymentVersionToStringV31(&deploymentpb.WorkerDeploymentVersion{
+			DeploymentName: deploymentName,
+			BuildId:        rampingBuildID,
+		}),
+		float32(rampPercentage),
+	)
+
 	// Enqueue unversioned backlog.
 	unversionedWorkflowCount := 10 * env.partitionCount
 	s.startUnversionedWorkflows(env, unversionedWorkflowCount, tqName)
@@ -604,6 +646,20 @@ func (s *TaskQueueStatsVersionSuite) TestInactiveVersionDoesNotAbsorbUnversioned
 
 	// Stopping the pollers so that we verify the backlog expectations
 	cancelPoller()
+
+	// Wait for the current-version routing to propagate before enqueuing, otherwise the
+	// unversioned workflows can be added before the task queue knows about the current
+	// version and end up attributed to the wrong (unversioned) backlog. See #10773.
+	env.waitForTaskQueueVersioningInfo(
+		s,
+		&taskqueuepb.TaskQueue{Name: tqName, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		worker_versioning.ExternalWorkerDeploymentVersionToStringV31(&deploymentpb.WorkerDeploymentVersion{
+			DeploymentName: deploymentName,
+			BuildId:        currentBuildID,
+		}),
+		"",
+		0,
+	)
 
 	// Enqueue unversioned backlog.
 	unversionedWorkflows := 10 * env.partitionCount


### PR DESCRIPTION
The versioning stats tests set the current/ramping deployment version and then immediately enqueue an unversioned backlog. Whether the current version "absorbs" the unversioned backlog is decided at task-add time from the task queue's propagated routing config, so enqueuing before that config has propagated permanently mis-attributes the tasks and the s.Await stat checks can never converge -> flake.

#10773 fixed this for TestRampingAndCurrentAbsorbUnversionedBacklog by waiting for the versioning info (waitForTaskQueueVersioningInfo) before enqueuing. The four sibling tests share the exact same set-version-then-enqueue pattern but were never given the wait:

  - TestCurrentVersionAbsorbsUnversionedBacklog_NoRamping
  - TestCurrentAbsorbsUnversionedBacklog_WhenRampingToUnversioned
  - TestRampingAbsorbsUnversionedBacklog_WhenCurrentIsUnversioned
  - TestInactiveVersionDoesNotAbsorbUnversionedBacklog

Apply the same wait to all four. Validated: the NoTaskForwardNoPollForwardAllowSync and ForceTaskForwardNoPollForwardAllowSync suites both pass.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

