### PR TITLE
Persist Callback terminal failures

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/nexus-rpc/sdk-go/nexus"
 	apiactivitypb "go.temporal.io/api/activity/v1" //nolint:importas
-	callbackpb "go.temporal.io/api/callback/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
@@ -1857,42 +1856,16 @@ func (a *Activity) buildCallbackInfos(ctx chasm.Context) ([]*apiactivitypb.Callb
 	for _, field := range a.Callbacks {
 		cb := field.Get(ctx)
 
-		cbSpec, err := cb.ToAPICallback()
+		cbInfo, err := cb.ToAPICallbackInfo(ctx)
 		if err != nil {
 			return nil, err
-		}
-
-		var state enumspb.CallbackState
-		switch cb.Status {
-		case callbackspb.CALLBACK_STATUS_UNSPECIFIED:
-			return nil, serviceerror.NewInternal("callback with UNSPECIFIED state")
-		case callbackspb.CALLBACK_STATUS_STANDBY:
-			state = enumspb.CALLBACK_STATE_STANDBY
-		case callbackspb.CALLBACK_STATUS_SCHEDULED:
-			state = enumspb.CALLBACK_STATE_SCHEDULED
-		case callbackspb.CALLBACK_STATUS_BACKING_OFF:
-			state = enumspb.CALLBACK_STATE_BACKING_OFF
-		case callbackspb.CALLBACK_STATUS_FAILED:
-			state = enumspb.CALLBACK_STATE_FAILED
-		case callbackspb.CALLBACK_STATUS_SUCCEEDED:
-			state = enumspb.CALLBACK_STATE_SUCCEEDED
-		default:
-			return nil, serviceerror.NewInternalf("unknown callback state: %v", cb.Status)
 		}
 
 		cbInfos = append(cbInfos, &apiactivitypb.CallbackInfo{
 			Trigger: &apiactivitypb.CallbackInfo_Trigger{
 				Variant: &apiactivitypb.CallbackInfo_Trigger_ActivityClosed{},
 			},
-			Info: &callbackpb.CallbackInfo{
-				Callback:                cbSpec,
-				RegistrationTime:        cb.RegistrationTime,
-				State:                   state,
-				Attempt:                 cb.Attempt,
-				LastAttemptCompleteTime: cb.LastAttemptCompleteTime,
-				LastAttemptFailure:      cb.LastAttemptFailure,
-				NextAttemptScheduleTime: cb.NextAttemptScheduleTime,
-			},
+			Info: cbInfo,
 		})
 	}
 	return cbInfos, nil

--- a/chasm/lib/callback/component.go
+++ b/chasm/lib/callback/component.go
@@ -240,12 +240,9 @@ func (c *Callback) ToAPICallbackInfo(ctx chasm.Context) (*callbackpb.CallbackInf
 	return info, nil
 }
 
+// APIState converts the CHASM callback status to the API CallbackState enum.
 func (c *Callback) APIState() (enumspb.CallbackState, error) {
-	const unspecified = enumspb.CALLBACK_STATE_UNSPECIFIED
-
 	switch c.Status {
-	case callbackspb.CALLBACK_STATUS_UNSPECIFIED:
-		return unspecified, serviceerror.NewInternal("callback with UNSPECIFIED state")
 	case callbackspb.CALLBACK_STATUS_STANDBY:
 		return enumspb.CALLBACK_STATE_STANDBY, nil
 	case callbackspb.CALLBACK_STATUS_SCHEDULED:
@@ -256,9 +253,10 @@ func (c *Callback) APIState() (enumspb.CallbackState, error) {
 		return enumspb.CALLBACK_STATE_FAILED, nil
 	case callbackspb.CALLBACK_STATUS_SUCCEEDED:
 		return enumspb.CALLBACK_STATE_SUCCEEDED, nil
+	case callbackspb.CALLBACK_STATUS_UNSPECIFIED:
+		return enumspb.CALLBACK_STATE_UNSPECIFIED, serviceerror.NewInternal("callback with UNSPECIFIED state")
 	default:
-		err := serviceerror.NewInternalf("unknown callback state: %v", c.Status)
-		return unspecified, err
+		return enumspb.CALLBACK_STATE_UNSPECIFIED, serviceerror.NewInternalf("unknown callback state: %v", c.Status)
 	}
 }
 

--- a/chasm/lib/callback/component.go
+++ b/chasm/lib/callback/component.go
@@ -5,7 +5,10 @@ import (
 	"maps"
 	"time"
 
+	callbackpb "go.temporal.io/api/callback/v1"
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
 	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
@@ -13,6 +16,7 @@ import (
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/nexus/nexusrpc"
 	queueserrors "go.temporal.io/server/service/history/queues/errors"
+	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -29,6 +33,9 @@ type Callback struct {
 
 	// Persisted internal state
 	*callbackspb.CallbackState
+	// The failure that terminated the callback. May differ from LastAttemptFailure when the callback
+	// fails for a reason other than a delivery attempt, such as a timeout (once supported).
+	TerminalFailure chasm.Field[*failurepb.Failure]
 
 	// Interface to retrieve Nexus operation completion data
 	CompletionSource chasm.ParentPtr[CompletionSource]
@@ -143,6 +150,36 @@ func (c *Callback) saveResult(
 	}
 }
 
+// outcome returns the callback's outcome, or nil if the Callback isn't in a terminal state.
+// The returned proto is a copy, safe to use after the CHASM context closes.
+func (c *Callback) outcome(ctx chasm.Context) *callbackpb.CallbackOutcome {
+	switch c.Status {
+	case callbackspb.CALLBACK_STATUS_SUCCEEDED:
+		return &callbackpb.CallbackOutcome{
+			Value: &callbackpb.CallbackOutcome_Success{
+				Success: &emptypb.Empty{},
+			},
+		}
+	case callbackspb.CALLBACK_STATUS_FAILED:
+		failure, ok := c.TerminalFailure.TryGet(ctx)
+		if !ok {
+			// TerminalFailure will not be present on Callbacks which failed before the field was added
+			// to the CHASM component. So fallback to including the LastAttemptFailure.
+			//
+			// This is still accurate, since we didn't have any way a callback could fail outside of
+			// the callback's invocation failure before we added the TerminalFailure field.
+			failure = c.LastAttemptFailure
+		}
+		return &callbackpb.CallbackOutcome{
+			Value: &callbackpb.CallbackOutcome_Failure{
+				Failure: common.CloneProto(failure),
+			},
+		}
+	default:
+		return nil
+	}
+}
+
 // ToAPICallback converts a CHASM callback to API callback proto.
 func (c *Callback) ToAPICallback() (*commonpb.Callback, error) {
 	// Convert CHASM callback proto to API callback proto
@@ -172,6 +209,56 @@ func (c *Callback) ToAPICallback() (*commonpb.Callback, error) {
 		return res, nil
 	default:
 		return nil, serviceerror.NewInternalf("unsupported CHASM callback type: %T", variant)
+	}
+}
+
+// ToAPICallbackInfo returns the API CallbackInfo based on the current state of the CHASM component.
+// A deep copy is made of proto fields, so the response can outlive the CHASM context.
+func (c *Callback) ToAPICallbackInfo(ctx chasm.Context) (*callbackpb.CallbackInfo, error) {
+	apiCb, err := c.ToAPICallback()
+	if err != nil {
+		return nil, err
+	}
+	apiState, err := c.APIState()
+	if err != nil {
+		return nil, err
+	}
+
+	info := &callbackpb.CallbackInfo{
+		Callback:         apiCb,
+		RegistrationTime: common.CloneProto(c.RegistrationTime),
+		State:            apiState,
+		// Surfacing why a callback is blocked, e.g. currently backing off due to circuit breaker,
+		// is not currently implemented.
+		BlockedReason:           "",
+		Attempt:                 c.Attempt,
+		LastAttemptCompleteTime: common.CloneProto(c.LastAttemptCompleteTime),
+		LastAttemptFailure:      common.CloneProto(c.LastAttemptFailure),
+		NextAttemptScheduleTime: common.CloneProto(c.NextAttemptScheduleTime),
+		Outcome:                 c.outcome(ctx),
+	}
+	return info, nil
+}
+
+func (c *Callback) APIState() (enumspb.CallbackState, error) {
+	const unspecified = enumspb.CALLBACK_STATE_UNSPECIFIED
+
+	switch c.Status {
+	case callbackspb.CALLBACK_STATUS_UNSPECIFIED:
+		return unspecified, serviceerror.NewInternal("callback with UNSPECIFIED state")
+	case callbackspb.CALLBACK_STATUS_STANDBY:
+		return enumspb.CALLBACK_STATE_STANDBY, nil
+	case callbackspb.CALLBACK_STATUS_SCHEDULED:
+		return enumspb.CALLBACK_STATE_SCHEDULED, nil
+	case callbackspb.CALLBACK_STATUS_BACKING_OFF:
+		return enumspb.CALLBACK_STATE_BACKING_OFF, nil
+	case callbackspb.CALLBACK_STATUS_FAILED:
+		return enumspb.CALLBACK_STATE_FAILED, nil
+	case callbackspb.CALLBACK_STATUS_SUCCEEDED:
+		return enumspb.CALLBACK_STATE_SUCCEEDED, nil
+	default:
+		err := serviceerror.NewInternalf("unknown callback state: %v", c.Status)
+		return unspecified, err
 	}
 }
 

--- a/chasm/lib/callback/component_test.go
+++ b/chasm/lib/callback/component_test.go
@@ -4,13 +4,16 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	callbackpb "go.temporal.io/api/callback/v1"
 	commonpb "go.temporal.io/api/common/v1"
+	failurepb "go.temporal.io/api/failure/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
 	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/testing/protorequire"
 	queueserrors "go.temporal.io/server/service/history/queues/errors"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 func TestFromAPICallback(t *testing.T) {
@@ -160,4 +163,81 @@ func TestWorkerCallbacksNotSupported(t *testing.T) {
 	require.ErrorAs(t, err, &unprocessableErr)
 	require.ErrorContains(t, err, "unprocessable callback variant")
 	require.ErrorContains(t, err, "Callback_Worker_")
+}
+
+func TestOutcome(t *testing.T) {
+	terminalFailure := &failurepb.Failure{Message: "terminal"}
+	lastAttemptFailure := &failurepb.Failure{Message: "last attempt"}
+
+	cases := []struct {
+		name string
+
+		// Callback state to set.
+		status             callbackspb.CallbackStatus
+		lastAttemptFailure *failurepb.Failure
+		terminalFailure    *failurepb.Failure
+
+		want *callbackpb.CallbackOutcome
+	}{
+		{
+			name:   "unspecified is non-terminal",
+			status: callbackspb.CALLBACK_STATUS_UNSPECIFIED,
+		},
+		{
+			name:   "standby is non-terminal",
+			status: callbackspb.CALLBACK_STATUS_STANDBY,
+		},
+		{
+			name:   "scheduled is non-terminal",
+			status: callbackspb.CALLBACK_STATUS_SCHEDULED,
+		},
+		{
+			name:               "backing off is non-terminal, even with a last attempt failure",
+			status:             callbackspb.CALLBACK_STATUS_BACKING_OFF,
+			lastAttemptFailure: lastAttemptFailure,
+		},
+		{
+			name:   "succeeded",
+			status: callbackspb.CALLBACK_STATUS_SUCCEEDED,
+			want: &callbackpb.CallbackOutcome{
+				Value: &callbackpb.CallbackOutcome_Success{Success: &emptypb.Empty{}},
+			},
+		},
+		{
+			name:               "failed reports the terminal failure",
+			status:             callbackspb.CALLBACK_STATUS_FAILED,
+			lastAttemptFailure: lastAttemptFailure,
+			terminalFailure:    terminalFailure,
+			want: &callbackpb.CallbackOutcome{
+				Value: &callbackpb.CallbackOutcome_Failure{Failure: terminalFailure},
+			},
+		},
+		{
+			name:               "failed falls back to the last attempt failure when TerminalFailure is unset",
+			status:             callbackspb.CALLBACK_STATUS_FAILED,
+			lastAttemptFailure: lastAttemptFailure,
+			terminalFailure:    nil,
+			want: &callbackpb.CallbackOutcome{
+				Value: &callbackpb.CallbackOutcome_Failure{Failure: lastAttemptFailure},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mctx := &chasm.MockMutableContext{}
+			cb := &Callback{
+				CallbackState: &callbackspb.CallbackState{
+					LastAttemptFailure: tc.lastAttemptFailure,
+				},
+			}
+			cb.SetStateMachineState(tc.status)
+			if tc.terminalFailure != nil {
+				cb.TerminalFailure = chasm.NewDataField(mctx, tc.terminalFailure)
+			}
+
+			got := cb.outcome(mctx)
+			protorequire.ProtoEqual(t, tc.want, got)
+		})
+	}
 }

--- a/chasm/lib/callback/statemachine.go
+++ b/chasm/lib/callback/statemachine.go
@@ -8,6 +8,7 @@ import (
 	failurepb "go.temporal.io/api/failure/v1"
 	"go.temporal.io/server/chasm"
 	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -94,7 +95,8 @@ var TransitionFailed = chasm.NewTransition(
 	callbackspb.CALLBACK_STATUS_FAILED,
 	func(cb *Callback, ctx chasm.MutableContext, event EventFailed) error {
 		cb.recordAttempt(event.Time)
-		cb.LastAttemptFailure = &failurepb.Failure{
+
+		failure := &failurepb.Failure{
 			Message: event.Err.Error(),
 			FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
 				ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
@@ -102,6 +104,8 @@ var TransitionFailed = chasm.NewTransition(
 				},
 			},
 		}
+		cb.LastAttemptFailure = failure
+		cb.TerminalFailure = chasm.NewDataField(ctx, common.CloneProto(failure))
 		return nil
 	},
 )

--- a/chasm/lib/callback/statemachine_test.go
+++ b/chasm/lib/callback/statemachine_test.go
@@ -9,6 +9,7 @@ import (
 	"go.temporal.io/server/chasm"
 	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
 	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/common/testing/protorequire"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -106,6 +107,11 @@ func TestValidTransitions(t *testing.T) {
 	require.True(t, callback.LastAttemptFailure.GetApplicationFailureInfo().NonRetryable)
 	require.Equal(t, currentTime, callback.LastAttemptCompleteTime.AsTime())
 	require.Nil(t, callback.NextAttemptScheduleTime)
+	// The terminal failure should be structurally but not referentially equal to LastAttemptFailure.
+	terminalFailure, ok := callback.TerminalFailure.TryGet(mctx)
+	require.True(t, ok)
+	protorequire.ProtoEqual(t, callback.LastAttemptFailure, terminalFailure)
+	require.NotSame(t, callback.LastAttemptFailure, terminalFailure)
 
 	// Assert task is not generated, failed is terminal
 	require.Empty(t, mctx.Tasks)

--- a/chasm/lib/callback/tasks_test.go
+++ b/chasm/lib/callback/tasks_test.go
@@ -86,7 +86,7 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 		name                  string
 		caller                HTTPCaller
 		expectedMetricOutcome string
-		assertOutcome         func(*testing.T, *Callback, error)
+		assertOutcome         func(*testing.T, chasm.Context, *Callback, error)
 	}{
 		{
 			name: "success",
@@ -94,7 +94,7 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 				return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
 			},
 			expectedMetricOutcome: "success",
-			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+			assertOutcome: func(t *testing.T, _ chasm.Context, cb *Callback, err error) {
 				require.NoError(t, err)
 				require.Equal(t, callbackspb.CALLBACK_STATUS_SUCCEEDED, cb.Status)
 			},
@@ -105,7 +105,7 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 				return nil, errors.New("fake failure")
 			},
 			expectedMetricOutcome: "unknown-error",
-			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+			assertOutcome: func(t *testing.T, _ chasm.Context, cb *Callback, err error) {
 				var destDownErr *queueserrors.DestinationDownError
 				require.ErrorAs(t, err, &destDownErr)
 				require.Equal(t, callbackspb.CALLBACK_STATUS_BACKING_OFF, cb.Status)
@@ -117,10 +117,16 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 				return &http.Response{StatusCode: 500, Body: http.NoBody}, nil
 			},
 			expectedMetricOutcome: "handler-error:INTERNAL",
-			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+			assertOutcome: func(t *testing.T, ctx chasm.Context, cb *Callback, err error) {
 				var destDownErr *queueserrors.DestinationDownError
 				require.ErrorAs(t, err, &destDownErr)
 				require.Equal(t, callbackspb.CALLBACK_STATUS_BACKING_OFF, cb.Status)
+
+				// The LastAttemptFailure is set but not TerminalFailure, because the error is retryable.
+				require.NotNil(t, cb.LastAttemptFailure)
+				require.Contains(t, cb.LastAttemptFailure.GetMessage(), "handler error (INTERNAL)")
+				_, hasTerminalFailure := cb.TerminalFailure.TryGet(ctx)
+				require.False(t, hasTerminalFailure)
 			},
 		},
 		{
@@ -129,9 +135,16 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 				return &http.Response{StatusCode: 400, Body: http.NoBody}, nil
 			},
 			expectedMetricOutcome: "handler-error:BAD_REQUEST",
-			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+			assertOutcome: func(t *testing.T, ctx chasm.Context, cb *Callback, err error) {
 				require.NoError(t, err)
 				require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
+
+				// Non-retryable failure sets both LastAttemptFailure and TerminalFailure.
+				require.NotNil(t, cb.LastAttemptFailure)
+				require.Contains(t, cb.LastAttemptFailure.GetMessage(), "handler error (BAD_REQUEST)")
+				terminalFailure, hasTerminalFailure := cb.TerminalFailure.TryGet(ctx)
+				require.True(t, hasTerminalFailure)
+				require.Contains(t, terminalFailure.GetMessage(), "handler error (BAD_REQUEST)")
 			},
 		},
 	}
@@ -261,16 +274,16 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 			)
 
 			// Verify outcome by reading component state directly.
-			resultCallback, err := chasm.ReadComponent(
+			_, err = chasm.ReadComponent(
 				engineCtx,
 				callbackRef,
-				func(c *Callback, _ chasm.Context, _ struct{}) (*Callback, error) {
-					return c, nil
+				func(c *Callback, chasmCtx chasm.Context, _ struct{}) (struct{}, error) {
+					tc.assertOutcome(t, chasmCtx, c, executeErr)
+					return struct{}{}, nil
 				},
 				struct{}{},
 			)
 			require.NoError(t, err)
-			tc.assertOutcome(t, resultCallback, executeErr)
 		})
 	}
 }

--- a/service/history/api/describeworkflow/api.go
+++ b/service/history/api/describeworkflow/api.go
@@ -19,7 +19,6 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
 	chasmcallback "go.temporal.io/server/chasm/lib/callback"
-	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
 	"go.temporal.io/server/chasm/lib/nexusoperation"
 	chasmworkflow "go.temporal.io/server/chasm/lib/workflow"
 	"go.temporal.io/server/common"
@@ -595,8 +594,8 @@ func buildCallbackInfoFromChasm(
 // buildChasmCallbackInfo converts a single CHASM callback to API CallbackInfo format.
 // Returns nil if the callback should not be included in the response.
 func buildChasmCallbackInfo(
-	ctx context.Context,
-	namespaceID string,
+	_ context.Context,
+	_ string,
 	cb *chasmcallback.Callback,
 	trigger *workflowpb.CallbackInfo_Trigger,
 	circuitBreakerState func(destination string) bool,
@@ -607,27 +606,16 @@ func buildChasmCallbackInfo(
 		return nil, nil
 	}
 
+	// The workflow.CallbackInfo proto forks the fields from callback.CallbackInfo
+	// rather than embedding it (unlike activity.CallbackInfo). There is some drift
+	// between the two, e.g. workflow.CallbackInfo does not contain the outcome.
 	cbSpec, err := cb.ToAPICallback()
 	if err != nil {
 		return nil, err
 	}
-
-	var state enumspb.CallbackState
-	switch cb.Status {
-	case callbackspb.CALLBACK_STATUS_UNSPECIFIED:
-		return nil, serviceerror.NewInternal("callback with UNSPECIFIED state")
-	case callbackspb.CALLBACK_STATUS_STANDBY:
-		state = enumspb.CALLBACK_STATE_STANDBY
-	case callbackspb.CALLBACK_STATUS_SCHEDULED:
-		state = enumspb.CALLBACK_STATE_SCHEDULED
-	case callbackspb.CALLBACK_STATUS_BACKING_OFF:
-		state = enumspb.CALLBACK_STATE_BACKING_OFF
-	case callbackspb.CALLBACK_STATUS_FAILED:
-		state = enumspb.CALLBACK_STATE_FAILED
-	case callbackspb.CALLBACK_STATUS_SUCCEEDED:
-		state = enumspb.CALLBACK_STATE_SUCCEEDED
-	default:
-		return nil, serviceerror.NewInternalf("unknown callback state: %v", cb.Status)
+	state, err := cb.APIState()
+	if err != nil {
+		return nil, err
 	}
 
 	blockedReason := ""

--- a/service/history/api/describeworkflow/api.go
+++ b/service/history/api/describeworkflow/api.go
@@ -518,7 +518,7 @@ func buildCallbackInfosFromChasm(
 			Variant: &workflowpb.CallbackInfo_Trigger_WorkflowClosed{},
 		}
 
-		callbackInfo, err := buildCallbackInfoFromChasm(ctx, namespaceID, callback, trigger, outboundQueueCBPool)
+		callbackInfo, err := buildCallbackInfoFromChasm(namespaceID, callback, trigger, outboundQueueCBPool)
 		if err != nil {
 			logger.Error(
 				"failed to build callback info from CHASM callback",
@@ -549,7 +549,7 @@ func buildCallbackInfosFromChasm(
 				},
 			}
 
-			callbackInfo, err := buildCallbackInfoFromChasm(ctx, namespaceID, callback, trigger, outboundQueueCBPool)
+			callbackInfo, err := buildCallbackInfoFromChasm(namespaceID, callback, trigger, outboundQueueCBPool)
 			if err != nil {
 				logger.Error(
 					"failed to build callback info from CHASM update callback",
@@ -572,7 +572,6 @@ func buildCallbackInfosFromChasm(
 
 // buildCallbackInfoFromChasm converts a single CHASM callback to API format.
 func buildCallbackInfoFromChasm(
-	ctx context.Context,
 	namespaceID namespace.ID,
 	callback *chasmcallback.Callback,
 	trigger *workflowpb.CallbackInfo_Trigger,
@@ -588,14 +587,12 @@ func buildCallbackInfoFromChasm(
 		return cb.State() != gobreaker.StateClosed
 	}
 
-	return buildChasmCallbackInfo(ctx, namespaceID.String(), callback, trigger, circuitBreakerState)
+	return buildChasmCallbackInfo(callback, trigger, circuitBreakerState)
 }
 
 // buildChasmCallbackInfo converts a single CHASM callback to API CallbackInfo format.
 // Returns nil if the callback should not be included in the response.
 func buildChasmCallbackInfo(
-	_ context.Context,
-	_ string,
 	cb *chasmcallback.Callback,
 	trigger *workflowpb.CallbackInfo_Trigger,
 	circuitBreakerState func(destination string) bool,
@@ -629,12 +626,12 @@ func buildChasmCallbackInfo(
 	return &workflowpb.CallbackInfo{
 		Callback:                cbSpec,
 		Trigger:                 trigger,
-		RegistrationTime:        cb.RegistrationTime,
+		RegistrationTime:        common.CloneProto(cb.RegistrationTime),
 		State:                   state,
 		Attempt:                 cb.Attempt,
-		LastAttemptCompleteTime: cb.LastAttemptCompleteTime,
-		LastAttemptFailure:      cb.LastAttemptFailure,
-		NextAttemptScheduleTime: cb.NextAttemptScheduleTime,
+		LastAttemptCompleteTime: common.CloneProto(cb.LastAttemptCompleteTime),
+		LastAttemptFailure:      common.CloneProto(cb.LastAttemptFailure),
+		NextAttemptScheduleTime: common.CloneProto(cb.NextAttemptScheduleTime),
 		BlockedReason:           blockedReason,
 	}, nil
 }

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/stretchr/testify/require"
 	activitypb "go.temporal.io/api/activity/v1"
+	callbackpb "go.temporal.io/api/callback/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
@@ -9886,6 +9887,52 @@ func (env *standaloneActivityEnv) runNexusCompletionHTTPServer(t *testing.T, h *
 	return srv.URL
 }
 
+// awaitCallbackInfoWhere polls DescribeActivityExecution until the activity's single completion
+// callback satisfies check, and returns that CallbackInfo.
+func (env *standaloneActivityEnv) awaitCallbackInfoWhere(
+	ctx context.Context,
+	t *testing.T,
+	activityID string,
+	check func(c *await.T, cbInfo *callbackpb.CallbackInfo),
+) *callbackpb.CallbackInfo {
+	t.Helper()
+
+	var cbInfo *callbackpb.CallbackInfo
+	awaitFn := func(c *await.T) {
+		descResp, err := env.FrontendClient().DescribeActivityExecution(c.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+		})
+		require.NoError(c, err)
+		require.Len(c, descResp.GetCallbacks(), 1)
+		cbInfo = descResp.GetCallbacks()[0].GetInfo()
+		require.NotNil(c, cbInfo)
+		check(c, cbInfo)
+	}
+
+	const (
+		timeout      = 10 * time.Second
+		pollInterval = 100 * time.Millisecond
+	)
+	await.Require(ctx, t, awaitFn, timeout, pollInterval)
+	return cbInfo
+}
+
+// awaitCallbackInfo polls until the activity's single completion callback reaches wantState.
+func (env *standaloneActivityEnv) awaitCallbackInfo(
+	ctx context.Context,
+	t *testing.T,
+	activityID string,
+	wantState enumspb.CallbackState,
+) *callbackpb.CallbackInfo {
+	t.Helper()
+
+	return env.awaitCallbackInfoWhere(ctx, t, activityID, func(c *await.T, cbInfo *callbackpb.CallbackInfo) {
+		require.Equal(c, wantState, cbInfo.GetState())
+	})
+}
+
+// Tests verifying that completion callbacks attached to standalone Activities get triggered.
 func (s *standaloneActivityTestSuite) TestCallbacks() {
 	env := s.newTestEnv()
 	t := s.T()
@@ -10034,6 +10081,8 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		require.Equal(t, callbackURL, cbInfo.GetInfo().GetCallback().GetNexus().GetUrl())
 		require.Equal(t, enumspb.CALLBACK_STATE_STANDBY, cbInfo.GetInfo().GetState())
 		require.NotNil(t, cbInfo.GetInfo().GetRegistrationTime())
+		// Confirm there is no outcome, because the callback hasn't been triggered.
+		require.Nil(t, cbInfo.GetInfo().GetOutcome())
 	})
 
 	t.Run("ExceedsMaxCallbacksLimit", func(t *testing.T) {
@@ -10136,6 +10185,10 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, descResp.GetInfo().GetStatus())
+
+		// Wait for the callback to complete and verify.
+		cbInfo := env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SUCCEEDED)
+		require.NotNil(t, cbInfo.GetOutcome().GetSuccess())
 	})
 
 	t.Run("FailsWithCallbacks", func(t *testing.T) {
@@ -10210,6 +10263,11 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_FAILED, descResp.GetInfo().GetStatus())
+
+		// Wait for the callback to complete and verify.
+		// The Activity may have failed, but the callback reporting the failure should be successful.
+		cbInfo := env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SUCCEEDED)
+		require.NotNil(t, cbInfo.GetOutcome().GetSuccess())
 	})
 
 	t.Run("TerminatedWithCallbacks", func(t *testing.T) {
@@ -10285,6 +10343,10 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_TERMINATED, descResp.GetInfo().GetStatus())
+
+		// Wait for the callback to complete and verify.
+		cbInfo := env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SUCCEEDED)
+		require.NotNil(t, cbInfo.GetOutcome().GetSuccess())
 	})
 
 	t.Run("CanceledWithCallbacks", func(t *testing.T) {
@@ -10365,6 +10427,10 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_CANCELED, descResp.GetInfo().GetStatus())
+
+		// Wait for the callback to complete and verify.
+		cbInfo := env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SUCCEEDED)
+		require.NotNil(t, cbInfo.GetOutcome().GetSuccess())
 	})
 
 	// This test covers the timeout callback path using schedule-to-start, but the callback behavior
@@ -10428,6 +10494,10 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT, descResp.GetInfo().GetStatus())
+
+		// Wait for the callback to complete and verify.
+		cbInfo := env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SUCCEEDED)
+		require.NotNil(t, cbInfo.GetOutcome().GetSuccess())
 	})
 }
 

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -10474,9 +10474,128 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT, descResp.GetInfo().GetStatus())
 
-		// Wait for the callback to complete and verify.
+		// Confirm the callback was successful. (Receiving the timeout failure, verified above.)
 		cbInfo := env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SUCCEEDED)
 		require.NotNil(t, cbInfo.GetOutcome().GetSuccess())
+	})
+
+	// Verify that if the callback fails to be delivered for some reason, that the failure is
+	// persisted correctly and available from the Describe operation.
+	t.Run("CallbackDeliveryFailure", func(t *testing.T) {
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		ch := &completionHandler{
+			requestCh:         make(chan *nexusrpc.CompletionRequest, 1),
+			requestCompleteCh: make(chan error, 1),
+		}
+		defer func() {
+			close(ch.requestCh)
+			close(ch.requestCompleteCh)
+		}()
+		callbackAddress := env.runNexusCompletionHTTPServer(t, ch)
+
+		// Start and successfully complete a standalone Activity.
+		_, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:    env.Namespace().String(),
+			ActivityId:   activityID,
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
+			Input:        defaultInput,
+			TaskQueue: &taskqueuepb.TaskQueue{
+				Name: taskQueue,
+			},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			RequestId:           env.Tv().Any().String(),
+			CompletionCallbacks: []*commonpb.Callback{{
+				Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: callbackAddress}},
+			}},
+		})
+		require.NoError(t, err)
+
+		pollResp, err := env.FrontendClient().PollActivityTaskQueue(s.Context(), &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
+			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			Identity:  env.Tv().WorkerIdentity(),
+		})
+		require.NoError(t, err)
+
+		_, err = env.FrontendClient().RespondActivityTaskCompleted(s.Context(), &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
+			TaskToken: pollResp.TaskToken,
+			Result:    defaultResult,
+			Identity:  defaultIdentity,
+		})
+		require.NoError(t, err)
+
+		// Simulate the completion handler returning a retryable error followed by
+		// an unretryable error. Confirm the SAA's CallbackInfo includes the terminal
+		// failure.
+		var deliveryAttempt int
+		for deliveryAttempt < 2 {
+			select {
+			case completion := <-ch.requestCh:
+				deliveryAttempt++
+
+				// Pull the completion request from the channel.
+				require.Equal(t, nexus.OperationStateSucceeded, completion.State)
+				// The first attempt to deliver the Activity's completion callback reports a retyrable error.
+				if deliveryAttempt == 1 {
+					// Call Describe and confirm the Callback has just been scheduled.
+					cbInfo := env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SCHEDULED)
+					require.EqualValues(t, 0, cbInfo.Attempt) // zero attempts so far.
+					require.Nil(t, cbInfo.LastAttemptFailure)
+					require.Nil(t, cbInfo.GetOutcome())
+
+					// Retryable error.
+					ch.requestCompleteCh <- nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUnavailable, "delivery #1")
+					break
+				}
+				// The second attempt to deliver the Activity's completion callback should report a
+				// non-retryable error.
+				if deliveryAttempt == 2 {
+					// Call Describe and confirm the CallbackInfo describes the previous delivery attempt.
+					cbInfo := env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SCHEDULED)
+					require.EqualValues(t, 1, cbInfo.Attempt) // 1 attempt so far, the 2nd is in-progress.
+					lastAttemptFailure := cbInfo.GetLastAttemptFailure()
+					require.NotNil(t, lastAttemptFailure)
+					require.Equal(t, "handler error (UNAVAILABLE): delivery #1", lastAttemptFailure.GetMessage())
+					require.Nil(t, cbInfo.GetOutcome())
+
+					// Unretryable error.
+					ch.requestCompleteCh <- nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "delivery #2")
+					break
+				}
+				panic("should be unreachable")
+
+			case <-s.Context().Done():
+				require.Fail(t, "timed out waiting for completion callback")
+			}
+		}
+
+		// Verify the Activity is in completed state.
+		descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+		})
+		require.NoError(t, err)
+		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, descResp.GetInfo().GetStatus())
+
+		// Verify the completion callback delivery has failed.
+		cbInfo := env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_FAILED)
+		require.Nil(t, cbInfo.GetOutcome().GetSuccess())
+
+		// The last delivery failure should be from delivery #2.
+		const lastDeliveryFailureMessage = "handler error (BAD_REQUEST): delivery #2"
+		lastAttemptFailure := cbInfo.GetLastAttemptFailure()
+		require.NotNil(t, lastAttemptFailure)
+		require.Equal(t, lastDeliveryFailureMessage, lastAttemptFailure.GetMessage())
+
+		// Confirm the outcome / terminal failure as well.
+		// (No way to test something like the Callback itself timing out since that isn't supported ATM.)
+		terminalFailure := cbInfo.GetOutcome().GetFailure()
+		require.NotNil(t, terminalFailure)
+		require.Equal(t, lastDeliveryFailureMessage, terminalFailure.GetMessage())
 	})
 }
 
@@ -10525,15 +10644,6 @@ func (s *standaloneActivityTestSuite) TestCallbacksDisabled() {
 		})
 		require.ErrorContains(t, err, "completion callbacks are not enabled for this namespace")
 	})
-}
-
-func (s *standaloneActivityTestSuite) runNexusCompletionHTTPServer(t *testing.T, h *completionHandler) string {
-	hh := nexusrpc.NewCompletionHTTPHandler(nexusrpc.CompletionHandlerOptions{Handler: h})
-	srv := httptest.NewServer(hh)
-	t.Cleanup(func() {
-		srv.Close()
-	})
-	return srv.URL
 }
 
 func (s *standaloneActivityTestSuite) TestPauseActivityExecution() {

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -9887,18 +9887,17 @@ func (env *standaloneActivityEnv) runNexusCompletionHTTPServer(t *testing.T, h *
 	return srv.URL
 }
 
-// awaitCallbackInfoWhere polls DescribeActivityExecution until the activity's single completion
-// callback satisfies check, and returns that CallbackInfo.
-func (env *standaloneActivityEnv) awaitCallbackInfoWhere(
+// awaitCallbackInfo polls DescribeActivityExecution until the activity's single completion
+// callback reaches wantState, and returns that CallbackInfo.
+func (env *standaloneActivityEnv) awaitCallbackInfo(
 	ctx context.Context,
 	t *testing.T,
 	activityID string,
-	check func(c *await.T, cbInfo *callbackpb.CallbackInfo),
+	wantState enumspb.CallbackState,
 ) *callbackpb.CallbackInfo {
 	t.Helper()
-
 	var cbInfo *callbackpb.CallbackInfo
-	awaitFn := func(c *await.T) {
+	await.Require(ctx, t, func(c *await.T) {
 		descResp, err := env.FrontendClient().DescribeActivityExecution(c.Context(), &workflowservice.DescribeActivityExecutionRequest{
 			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
@@ -9907,29 +9906,9 @@ func (env *standaloneActivityEnv) awaitCallbackInfoWhere(
 		require.Len(c, descResp.GetCallbacks(), 1)
 		cbInfo = descResp.GetCallbacks()[0].GetInfo()
 		require.NotNil(c, cbInfo)
-		check(c, cbInfo)
-	}
-
-	const (
-		timeout      = 10 * time.Second
-		pollInterval = 100 * time.Millisecond
-	)
-	await.Require(ctx, t, awaitFn, timeout, pollInterval)
-	return cbInfo
-}
-
-// awaitCallbackInfo polls until the activity's single completion callback reaches wantState.
-func (env *standaloneActivityEnv) awaitCallbackInfo(
-	ctx context.Context,
-	t *testing.T,
-	activityID string,
-	wantState enumspb.CallbackState,
-) *callbackpb.CallbackInfo {
-	t.Helper()
-
-	return env.awaitCallbackInfoWhere(ctx, t, activityID, func(c *await.T, cbInfo *callbackpb.CallbackInfo) {
 		require.Equal(c, wantState, cbInfo.GetState())
-	})
+	}, 10*time.Second, 100*time.Millisecond)
+	return cbInfo
 }
 
 // Tests verifying that completion callbacks attached to standalone Activities get triggered.


### PR DESCRIPTION
⚠️ This is part of a stacked PR set, to be merged into `chrsmith/wc-add-worker-cb-variant`. This will not go directly into `main`.

---

## What changed?

Add a new field to the CHASM Callback component to persist the terminal failure of a CHASM Callback.

The [CallbackState](https://github.com/temporalio/temporal/blob/main/chasm/lib/callback/proto/v1/message.proto#L11) that includes a `last_attempt_failure` field which is set whenever there is a delivery error.   This would contain the terminal failure for the CHASM callback as long as the _only_ way the callback could fail is due to a non-retryable delivery. (And not a cancellation, timeout, etc.)

We now have a separate `TerminalFailure` field, stored separately than the `last_attempt_failure`. (This is to avoid growing the size of the persisted `CallbackState` proto, as well as reducing the size of database writes since the `TerminalFailure` will only be written once.)

## Why?

Currently, there is no need for this field. Because it is not possible to cancel a CHASM Callback, or for it to timeout, the terminal failure can be _inferred_ by referencing the `last_attempt_failure`.

However, we will want CHASM Callbacks to support "external" failures. If not for the worker callbacks feature, then for manual completions down the road. Also, it avoids any confusion or ambiguity about whether `last_attempt_failure` is the _terminal_ failure, or just the last (retryable) delivery error.

## How did you test it?

- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

- Adding a new CHASM field can be tricky, because when loading existing CHASM components the field may-or-may-not be present. In this case, we fall back to `last_attempt_failure` if `TerminalFailure` is not present, which is sufficient.

- If a CHASM component is persisted with the new `TerminalFailure` field, and then the server is _downgraded_, the next write for the CHASM component will _delete_ the "unknown" `TerminalFailure` field. Because of the fallback to `last_attempt_failure`, this too is accounted for.
