### PR TITLE
Add completion callbacks to SANOs

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -44,7 +44,6 @@ import (
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/activity/gen/activitypb/v1"
 	"go.temporal.io/server/chasm/lib/callback"
-	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/activityoptions"
 	"go.temporal.io/server/common/backoff"
@@ -439,7 +438,7 @@ func (a *Activity) addCompletionCallbacks(
 
 		// requestID (unique per API call) + idx (position within the request) ensures unique,idempotent callback IDs.
 		id := fmt.Sprintf("%s-%d", requestID, idx)
-		callbackObj := callback.NewCallback(requestID, registrationTime, &callbackspb.CallbackState{}, chasmCB)
+		callbackObj := callback.NewCallback(requestID, registrationTime, chasmCB)
 		a.Callbacks[id] = chasm.NewComponentField(ctx, callbackObj)
 	}
 	return nil

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/nexus-rpc/sdk-go/nexus"
 	apiactivitypb "go.temporal.io/api/activity/v1" //nolint:importas
-	callbackpb "go.temporal.io/api/callback/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
@@ -1857,42 +1856,16 @@ func (a *Activity) buildCallbackInfos(ctx chasm.Context) ([]*apiactivitypb.Callb
 	for _, field := range a.Callbacks {
 		cb := field.Get(ctx)
 
-		cbSpec, err := cb.ToAPICallback()
+		cbInfo, err := cb.ToAPICallbackInfo()
 		if err != nil {
 			return nil, err
-		}
-
-		var state enumspb.CallbackState
-		switch cb.Status {
-		case callbackspb.CALLBACK_STATUS_UNSPECIFIED:
-			return nil, serviceerror.NewInternal("callback with UNSPECIFIED state")
-		case callbackspb.CALLBACK_STATUS_STANDBY:
-			state = enumspb.CALLBACK_STATE_STANDBY
-		case callbackspb.CALLBACK_STATUS_SCHEDULED:
-			state = enumspb.CALLBACK_STATE_SCHEDULED
-		case callbackspb.CALLBACK_STATUS_BACKING_OFF:
-			state = enumspb.CALLBACK_STATE_BACKING_OFF
-		case callbackspb.CALLBACK_STATUS_FAILED:
-			state = enumspb.CALLBACK_STATE_FAILED
-		case callbackspb.CALLBACK_STATUS_SUCCEEDED:
-			state = enumspb.CALLBACK_STATE_SUCCEEDED
-		default:
-			return nil, serviceerror.NewInternalf("unknown callback state: %v", cb.Status)
 		}
 
 		cbInfos = append(cbInfos, &apiactivitypb.CallbackInfo{
 			Trigger: &apiactivitypb.CallbackInfo_Trigger{
 				Variant: &apiactivitypb.CallbackInfo_Trigger_ActivityClosed{},
 			},
-			Info: &callbackpb.CallbackInfo{
-				Callback:                cbSpec,
-				RegistrationTime:        cb.RegistrationTime,
-				State:                   state,
-				Attempt:                 cb.Attempt,
-				LastAttemptCompleteTime: cb.LastAttemptCompleteTime,
-				LastAttemptFailure:      cb.LastAttemptFailure,
-				NextAttemptScheduleTime: cb.NextAttemptScheduleTime,
-			},
+			Info: cbInfo,
 		})
 	}
 	return cbInfos, nil

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -411,18 +411,6 @@ func (a *Activity) addCompletionCallbacks(
 	if len(completionCallbacks) == 0 {
 		return nil
 	}
-	// BUG: StartActivityExecution is not idempotent for a request carrying completion callbacks. If the
-	// first call attaches them but its response is lost, the engine dedups the client's retry on request
-	// ID (ChasmEngine.handleExecutionConflict matches the request ID before consulting the conflict
-	// policy) and routes it back here via the handler's on_conflict_options path. Should the activity have
-	// closed in the meantime, the check below rejects the retry with FailedPrecondition, reporting failure
-	// for callbacks that are in fact persisted and already scheduled for delivery.
-	//
-	// The fix is the one attachLinks already applies a few lines down: probe for callbacks previously
-	// attached by this request ID (they are keyed "<requestID>-<idx>") and return nil before the closed
-	// check. See Operation.addCompletionCallbacks in chasm/lib/nexusoperation for the same fix on
-	// standalone Nexus operations. Note that the handler attaches callbacks before links, so today a
-	// request setting both options loses attachLinks' idempotency too.
 	if a.LifecycleState(ctx).IsClosed() {
 		return serviceerror.NewFailedPrecondition("cannot attach callbacks to a closed activity")
 	}

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -411,6 +411,18 @@ func (a *Activity) addCompletionCallbacks(
 	if len(completionCallbacks) == 0 {
 		return nil
 	}
+	// BUG: StartActivityExecution is not idempotent for a request carrying completion callbacks. If the
+	// first call attaches them but its response is lost, the engine dedups the client's retry on request
+	// ID (ChasmEngine.handleExecutionConflict matches the request ID before consulting the conflict
+	// policy) and routes it back here via the handler's on_conflict_options path. Should the activity have
+	// closed in the meantime, the check below rejects the retry with FailedPrecondition, reporting failure
+	// for callbacks that are in fact persisted and already scheduled for delivery.
+	//
+	// The fix is the one attachLinks already applies a few lines down: probe for callbacks previously
+	// attached by this request ID (they are keyed "<requestID>-<idx>") and return nil before the closed
+	// check. See Operation.addCompletionCallbacks in chasm/lib/nexusoperation for the same fix on
+	// standalone Nexus operations. Note that the handler attaches callbacks before links, so today a
+	// request setting both options loses attachLinks' idempotency too.
 	if a.LifecycleState(ctx).IsClosed() {
 		return serviceerror.NewFailedPrecondition("cannot attach callbacks to a closed activity")
 	}

--- a/chasm/lib/callback/component.go
+++ b/chasm/lib/callback/component.go
@@ -40,7 +40,6 @@ type Callback struct {
 func NewCallback(
 	requestID string,
 	registrationTime *timestamppb.Timestamp,
-	state *callbackspb.CallbackState,
 	cb *callbackspb.Callback,
 ) *Callback {
 	return &Callback{

--- a/chasm/lib/callback/component.go
+++ b/chasm/lib/callback/component.go
@@ -5,7 +5,9 @@ import (
 	"maps"
 	"time"
 
+	callbackpb "go.temporal.io/api/callback/v1"
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
 	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
@@ -13,6 +15,7 @@ import (
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/nexus/nexusrpc"
 	queueserrors "go.temporal.io/server/service/history/queues/errors"
+	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -173,6 +176,73 @@ func (c *Callback) ToAPICallback() (*commonpb.Callback, error) {
 	default:
 		return nil, serviceerror.NewInternalf("unsupported CHASM callback type: %T", variant)
 	}
+}
+
+// outcome returns the callback's outcome, or nil if the Callback isn't in a terminal state.
+func (c *Callback) outcome() *callbackpb.CallbackOutcome {
+	switch c.Status {
+	case callbackspb.CALLBACK_STATUS_SUCCEEDED:
+		return &callbackpb.CallbackOutcome{
+			Value: &callbackpb.CallbackOutcome_Success{
+				Success: &emptypb.Empty{},
+			},
+		}
+	case callbackspb.CALLBACK_STATUS_FAILED:
+		// Currently there is no way for a Callback to fail other than due to failed deliveries.
+		// So the last, non-retryable error encountered was LastAttemptFailure.
+		return &callbackpb.CallbackOutcome{
+			Value: &callbackpb.CallbackOutcome_Failure{
+				Failure: common.CloneProto(c.LastAttemptFailure),
+			},
+		}
+	default:
+		return nil
+	}
+}
+
+// APIState converts the CHASM callback status to the API CallbackState enum.
+func (c *Callback) APIState() (enumspb.CallbackState, error) {
+	switch c.Status {
+	case callbackspb.CALLBACK_STATUS_STANDBY:
+		return enumspb.CALLBACK_STATE_STANDBY, nil
+	case callbackspb.CALLBACK_STATUS_SCHEDULED:
+		return enumspb.CALLBACK_STATE_SCHEDULED, nil
+	case callbackspb.CALLBACK_STATUS_BACKING_OFF:
+		return enumspb.CALLBACK_STATE_BACKING_OFF, nil
+	case callbackspb.CALLBACK_STATUS_FAILED:
+		return enumspb.CALLBACK_STATE_FAILED, nil
+	case callbackspb.CALLBACK_STATUS_SUCCEEDED:
+		return enumspb.CALLBACK_STATE_SUCCEEDED, nil
+	case callbackspb.CALLBACK_STATUS_UNSPECIFIED:
+		return enumspb.CALLBACK_STATE_UNSPECIFIED, serviceerror.NewInternal("callback with UNSPECIFIED state")
+	default:
+		return enumspb.CALLBACK_STATE_UNSPECIFIED, serviceerror.NewInternalf("unknown callback state: %v", c.Status)
+	}
+}
+
+// ToAPICallbackInfo returns the API CallbackInfo based on the current state of the CHASM component.
+func (c *Callback) ToAPICallbackInfo() (*callbackpb.CallbackInfo, error) {
+	apiCb, err := c.ToAPICallback()
+	if err != nil {
+		return nil, err
+	}
+	apiState, err := c.APIState()
+	if err != nil {
+		return nil, err
+	}
+
+	info := &callbackpb.CallbackInfo{
+		Callback:         apiCb,
+		RegistrationTime: common.CloneProto(c.RegistrationTime),
+		State:            apiState,
+		// BlockedReason is unimplemented; only the workflow Describe path computes it.
+		Attempt:                 c.Attempt,
+		LastAttemptCompleteTime: common.CloneProto(c.LastAttemptCompleteTime),
+		LastAttemptFailure:      common.CloneProto(c.LastAttemptFailure),
+		NextAttemptScheduleTime: common.CloneProto(c.NextAttemptScheduleTime),
+		Outcome:                 c.outcome(),
+	}
+	return info, nil
 }
 
 // FromAPICallback converts an API callback into a CHASM callback proto.

--- a/chasm/lib/callback/component_test.go
+++ b/chasm/lib/callback/component_test.go
@@ -4,13 +4,16 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	callbackpb "go.temporal.io/api/callback/v1"
 	commonpb "go.temporal.io/api/common/v1"
+	failurepb "go.temporal.io/api/failure/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
 	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/testing/protorequire"
 	queueserrors "go.temporal.io/server/service/history/queues/errors"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 func TestFromAPICallback(t *testing.T) {
@@ -160,4 +163,68 @@ func TestWorkerCallbacksNotSupported(t *testing.T) {
 	require.ErrorAs(t, err, &unprocessableErr)
 	require.ErrorContains(t, err, "unprocessable callback variant")
 	require.ErrorContains(t, err, "Callback_Worker_")
+}
+
+func TestOutcome(t *testing.T) {
+	lastAttemptFailure := &failurepb.Failure{Message: "last attempt"}
+
+	cases := []struct {
+		name string
+
+		// Callback state to set.
+		status             callbackspb.CallbackStatus
+		lastAttemptFailure *failurepb.Failure
+
+		want *callbackpb.CallbackOutcome
+	}{
+		{
+			name:   "unspecified is non-terminal",
+			status: callbackspb.CALLBACK_STATUS_UNSPECIFIED,
+		},
+		{
+			name:   "standby is non-terminal",
+			status: callbackspb.CALLBACK_STATUS_STANDBY,
+		},
+		{
+			name:   "scheduled is non-terminal",
+			status: callbackspb.CALLBACK_STATUS_SCHEDULED,
+		},
+		{
+			name:               "backing off is non-terminal, even with a last attempt failure",
+			status:             callbackspb.CALLBACK_STATUS_BACKING_OFF,
+			lastAttemptFailure: lastAttemptFailure,
+		},
+		{
+			name:   "succeeded",
+			status: callbackspb.CALLBACK_STATUS_SUCCEEDED,
+			want: &callbackpb.CallbackOutcome{
+				Value: &callbackpb.CallbackOutcome_Success{Success: &emptypb.Empty{}},
+			},
+		},
+		{
+			name:               "failed reports the terminal failure",
+			status:             callbackspb.CALLBACK_STATUS_FAILED,
+			lastAttemptFailure: lastAttemptFailure,
+			want: &callbackpb.CallbackOutcome{
+				Value: &callbackpb.CallbackOutcome_Failure{Failure: lastAttemptFailure},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cb := &Callback{
+				CallbackState: &callbackspb.CallbackState{
+					LastAttemptFailure: tc.lastAttemptFailure,
+				},
+			}
+			cb.SetStateMachineState(tc.status)
+
+			got := cb.outcome()
+			protorequire.ProtoEqual(t, tc.want, got)
+			if got.GetFailure() != nil {
+				require.NotSame(t, tc.lastAttemptFailure, got.GetFailure())
+			}
+		})
+	}
 }

--- a/chasm/lib/nexusoperation/callbacks_test.go
+++ b/chasm/lib/nexusoperation/callbacks_test.go
@@ -1,0 +1,521 @@
+package nexusoperation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/callback"
+	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
+	nexusoperationpb "go.temporal.io/server/chasm/lib/nexusoperation/gen/nexusoperationpb/v1"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/testing/protorequire"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const testCallbackURL = "http://localhost:8080/cb"
+
+func newCallbackTestContext() *chasm.MockMutableContext {
+	return &chasm.MockMutableContext{
+		MockContext: chasm.MockContext{
+			HandleNow: func(chasm.Component) time.Time { return defaultTime },
+			HandleExecutionKey: func() chasm.ExecutionKey {
+				return chasm.ExecutionKey{NamespaceID: "ns-id", BusinessID: "op-id", RunID: "run-id"}
+			},
+			HandleNamespaceEntry: func() *namespace.Namespace {
+				return namespace.NewNamespaceForTest(&persistencespb.NamespaceInfo{Name: "ns-name"}, nil, false, nil, 0)
+			},
+			HandleExecutionInfo: func() chasm.ExecutionInfo {
+				return chasm.ExecutionInfo{CloseTime: defaultTime}
+			},
+			GoCtx: context.WithValue(context.Background(), OperationContextKey, &OperationContext{
+				MetricTagConfig: dynamicconfig.GetTypedPropertyFn(NexusMetricTagConfig{}),
+			}),
+		},
+	}
+}
+
+func TestNewStandaloneOperationAttachesCompletionCallbacks(t *testing.T) {
+	t.Parallel()
+
+	newStartReq := func(cbs ...*commonpb.Callback) *nexusoperationpb.StartNexusOperationRequest {
+		return &nexusoperationpb.StartNexusOperationRequest{
+			EndpointId: "endpoint-id",
+			FrontendRequest: &workflowservice.StartNexusOperationExecutionRequest{
+				Namespace:           "ns-name",
+				OperationId:         "op-id",
+				RequestId:           "req-id",
+				Endpoint:            "test-endpoint",
+				Service:             "test-service",
+				Operation:           "test-operation",
+				CompletionCallbacks: cbs,
+			},
+		}
+	}
+
+	t.Run("WithCallbacks", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+
+		req := newStartReq(testNexusCallback(testCallbackURL))
+		op, err := newStandaloneOperation(ctx, req, 10)
+		require.NoError(t, err)
+		require.Equal(t, nexusoperationpb.OPERATION_STATUS_SCHEDULED, op.Status)
+
+		require.Len(t, op.Callbacks, 1)
+		cb := op.Callbacks["req-id-0"].Get(ctx)
+		require.Equal(t, callbackspb.CALLBACK_STATUS_STANDBY, cb.Status)
+		require.Equal(t, testCallbackURL, cb.GetCallback().GetNexus().GetUrl())
+	})
+
+	t.Run("WithoutCallbacks", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+
+		op, err := newStandaloneOperation(ctx, newStartReq(), 10)
+		require.NoError(t, err)
+		require.Nil(t, op.Callbacks)
+	})
+
+	t.Run("EnforcesTheCallersLimit", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+
+		_, err := newStandaloneOperation(ctx, newStartReq(
+			testNexusCallback("http://localhost:8080/url1"),
+			testNexusCallback("http://localhost:8080/url2"),
+		), 1)
+		var failedPreconditionErr *serviceerror.FailedPrecondition
+		require.ErrorAs(t, err, &failedPreconditionErr)
+		require.Contains(t, err.Error(), "cannot attach more than 1 callbacks")
+	})
+}
+
+func TestAddCompletionCallbacks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("AttachesCallbacksInStandby", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+
+		cbs := []*commonpb.Callback{
+			{
+				Variant: &commonpb.Callback_Nexus_{
+					Nexus: &commonpb.Callback_Nexus{
+						Url:    testCallbackURL,
+						Header: map[string]string{"key": "value"},
+					},
+				},
+				Links: []*commonpb.Link{{Variant: &commonpb.Link_WorkflowEvent_{
+					WorkflowEvent: &commonpb.Link_WorkflowEvent{Namespace: "ns-name", WorkflowId: "wf-id"},
+				}}},
+			},
+			testNexusCallback("http://localhost:8080/cb2"),
+		}
+
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", cbs, 10))
+		require.Len(t, op.Callbacks, 2)
+
+		// Keyed by request ID plus position within the request.
+		first, ok := op.Callbacks["req-id-0"]
+		require.True(t, ok)
+		cb := first.Get(ctx)
+		require.Equal(t, callbackspb.CALLBACK_STATUS_STANDBY, cb.Status)
+		require.Equal(t, "req-id", cb.RequestId)
+		require.Equal(t, defaultTime, cb.RegistrationTime.AsTime())
+		require.Equal(t, testCallbackURL, cb.GetCallback().GetNexus().GetUrl())
+		require.Equal(t, map[string]string{"key": "value"}, cb.GetCallback().GetNexus().GetHeader())
+		require.Len(t, cb.GetCallback().GetLinks(), 1)
+
+		second, ok := op.Callbacks["req-id-1"]
+		require.True(t, ok)
+		require.Equal(t, "http://localhost:8080/cb2", second.Get(ctx).GetCallback().GetNexus().GetUrl())
+
+		// STANDBY means no invocation task yet; only the scheduled transition's tasks are present.
+		for _, task := range ctx.Tasks {
+			_, isInvocation := task.Payload.(*callbackspb.InvocationTask)
+			require.False(t, isInvocation, "callbacks must not be invoked while in STANDBY")
+		}
+	})
+
+	t.Run("EmptyListIsANoOp", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", nil, 10))
+		require.Nil(t, op.Callbacks)
+	})
+
+	t.Run("ReAttachingTheSameRequestIsIdempotent", func(t *testing.T) {
+		// A retried start (or a retried on_conflict_options attach) must not duplicate callbacks.
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+		cbs := []*commonpb.Callback{testNexusCallback(testCallbackURL)}
+
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", cbs, 10))
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", cbs, 10))
+		require.Len(t, op.Callbacks, 1)
+	})
+
+	t.Run("ReAttachingTheSameRequestIsIdempotentAfterClose", func(t *testing.T) {
+		// A start request can reach addCompletionCallbacks twice: once creating the operation, then
+		// again if the client retries and the engine dedups on request ID. The operation may have closed
+		// in between, and the retry must still report success for callbacks that are already persisted
+		// rather than FailedPrecondition.
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+		cbs := []*commonpb.Callback{testNexusCallback(testCallbackURL)}
+
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", cbs, 10))
+		require.NoError(t, TransitionSucceeded.Apply(op, ctx, EventSucceeded{}))
+		require.Equal(t, callbackspb.CALLBACK_STATUS_SCHEDULED, op.Callbacks["req-id-0"].Get(ctx).Status)
+
+		tasksBefore := len(ctx.Tasks)
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", cbs, 10))
+
+		// The retry must leave the already-scheduled callback alone: re-attaching would reset it to
+		// STANDBY, stranding a callback the terminal transition had already released for delivery.
+		require.Len(t, op.Callbacks, 1)
+		require.Equal(t, callbackspb.CALLBACK_STATUS_SCHEDULED, op.Callbacks["req-id-0"].Get(ctx).Status)
+		require.Len(t, ctx.Tasks, tasksBefore)
+	})
+
+	t.Run("DistinctRequestsAccumulate", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+		cbs := []*commonpb.Callback{testNexusCallback(testCallbackURL)}
+
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-1", cbs, 10))
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-2", cbs, 10))
+		require.Len(t, op.Callbacks, 2)
+	})
+
+	t.Run("RejectsExceedingTheLimit", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+		cbs := []*commonpb.Callback{testNexusCallback(testCallbackURL), testNexusCallback(testCallbackURL)}
+
+		err := op.addCompletionCallbacks(ctx, "req-id", cbs, 1)
+		var failedPreconditionErr *serviceerror.FailedPrecondition
+		require.ErrorAs(t, err, &failedPreconditionErr)
+		require.Contains(t, err.Error(), "cannot attach more than 1 callbacks")
+		require.Empty(t, op.Callbacks)
+	})
+
+	t.Run("RejectsExceedingTheLimitWithAlreadyAttachedCallbacks", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-1", []*commonpb.Callback{
+			testNexusCallback(testCallbackURL),
+		}, 2))
+
+		err := op.addCompletionCallbacks(ctx, "req-2", []*commonpb.Callback{
+			testNexusCallback(testCallbackURL),
+			testNexusCallback(testCallbackURL),
+		}, 2)
+		var failedPreconditionErr *serviceerror.FailedPrecondition
+		require.ErrorAs(t, err, &failedPreconditionErr)
+		require.Contains(t, err.Error(), "1 callbacks already attached")
+		require.Len(t, op.Callbacks, 1)
+	})
+
+	t.Run("RejectsAClosedOperation", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+		require.NoError(t, TransitionSucceeded.Apply(op, ctx, EventSucceeded{}))
+
+		err := op.addCompletionCallbacks(ctx, "req-id", []*commonpb.Callback{
+			testNexusCallback(testCallbackURL),
+		}, 10)
+		var failedPreconditionErr *serviceerror.FailedPrecondition
+		require.ErrorAs(t, err, &failedPreconditionErr)
+		require.Contains(t, err.Error(), "cannot attach callbacks to a closed nexus operation")
+		require.Empty(t, op.Callbacks)
+	})
+
+	t.Run("RejectsAnEmptyRequestID", func(t *testing.T) {
+		// Callback IDs are derived from the request ID, so without one two distinct requests would
+		// produce colliding keys and silently overwrite each other. The frontend always supplies one
+		// (validator.normalizeRequestID); this guards a history-side caller that did not.
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+
+		err := op.addCompletionCallbacks(ctx, "", []*commonpb.Callback{
+			testNexusCallback(testCallbackURL),
+		}, 10)
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Contains(t, err.Error(), "without a request ID")
+		require.Empty(t, op.Callbacks)
+	})
+}
+
+func TestScheduleCompletionCallbacksOnTerminalTransition(t *testing.T) {
+	t.Parallel()
+
+	timeoutFailure := &failurepb.Failure{
+		Message: "timed out",
+		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{
+			TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
+				TimeoutType: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+			},
+		},
+	}
+
+	// In all scenarios, we expect the CHASM callbacks to be scheduled once the
+	// SANO transitions to a terminal state.
+	for _, tc := range []struct {
+		name           string
+		fromStatus     nexusoperationpb.OperationStatus
+		apply          func(*Operation, *chasm.MockMutableContext) error
+		expectedStatus nexusoperationpb.OperationStatus
+	}{
+		{
+			name: "Succeeded",
+			apply: func(o *Operation, ctx *chasm.MockMutableContext) error {
+				return TransitionSucceeded.Apply(o, ctx, EventSucceeded{})
+			},
+			expectedStatus: nexusoperationpb.OPERATION_STATUS_SUCCEEDED,
+		},
+		{
+			name: "Failed",
+			apply: func(o *Operation, ctx *chasm.MockMutableContext) error {
+				return TransitionFailed.Apply(o, ctx, EventFailed{
+					Failure: &failurepb.Failure{Message: "boom"},
+				})
+			},
+			expectedStatus: nexusoperationpb.OPERATION_STATUS_FAILED,
+		},
+		{
+			name: "Canceled",
+			apply: func(o *Operation, ctx *chasm.MockMutableContext) error {
+				return TransitionCanceled.Apply(o, ctx, EventCanceled{
+					Failure: &failurepb.Failure{Message: "canceled"},
+				})
+			},
+			expectedStatus: nexusoperationpb.OPERATION_STATUS_CANCELED,
+		},
+		{
+			name: "TimedOut",
+			apply: func(o *Operation, ctx *chasm.MockMutableContext) error {
+				return TransitionTimedOut.Apply(o, ctx, EventTimedOut{Failure: timeoutFailure})
+			},
+			expectedStatus: nexusoperationpb.OPERATION_STATUS_TIMED_OUT,
+		},
+		{
+			name: "Terminated",
+			apply: func(o *Operation, ctx *chasm.MockMutableContext) error {
+				_, err := o.Terminate(ctx, chasm.TerminateComponentRequest{
+					RequestID: "terminate-req-id",
+					Reason:    "because",
+				})
+				return err
+			},
+			expectedStatus: nexusoperationpb.OPERATION_STATUS_TERMINATED,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := newCallbackTestContext()
+			op := newScheduledTestOperation(t, ctx)
+			require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", []*commonpb.Callback{
+				testNexusCallback(testCallbackURL),
+			}, 10))
+
+			tasksBefore := len(ctx.Tasks)
+			require.NoError(t, tc.apply(op, ctx))
+			require.Equal(t, tc.expectedStatus, op.Status)
+
+			cb := op.Callbacks["req-id-0"].Get(ctx)
+			require.Equal(t, callbackspb.CALLBACK_STATUS_SCHEDULED, cb.Status)
+
+			// Closing must emit exactly one callback invocation task, routed to the callback's host.
+			newTasks := ctx.Tasks[tasksBefore:]
+			require.Len(t, newTasks, 1)
+			require.IsType(t, &callbackspb.InvocationTask{}, newTasks[0].Payload)
+			require.Equal(t, "http://localhost:8080", newTasks[0].Attributes.Destination)
+		})
+	}
+
+	t.Run("NoCallbacksIsANoOp", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+
+		tasksBefore := len(ctx.Tasks)
+		require.NoError(t, TransitionSucceeded.Apply(op, ctx, EventSucceeded{}))
+		require.Len(t, ctx.Tasks, tasksBefore)
+	})
+}
+
+func TestBuildCompletionCallbackInfos(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NoCallbacks", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newTestOperation()
+
+		infos, err := op.buildCompletionCallbackInfos(ctx)
+		require.NoError(t, err)
+		require.Nil(t, infos)
+	})
+
+	t.Run("ReportsStateAndOutcomePerCallback", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newTestOperation()
+
+		newCB := func(url string, status callbackspb.CallbackStatus) *callback.Callback {
+			cb := callback.NewCallback(
+				"req-id",
+				timestamppb.New(defaultTime),
+				&callbackspb.CallbackState{},
+				&callbackspb.Callback{
+					Variant: &callbackspb.Callback_Nexus_{
+						Nexus: &callbackspb.Callback_Nexus{Url: url},
+					},
+				},
+			)
+			cb.SetStateMachineState(status)
+			return cb
+		}
+
+		failed := newCB("http://localhost:8080/failed", callbackspb.CALLBACK_STATUS_FAILED)
+		failed.TerminalFailure = chasm.NewDataField(ctx, &failurepb.Failure{Message: "boom"})
+		failed.Attempt = 3
+
+		op.Callbacks = chasm.Map[string, *callback.Callback]{
+			"req-id-0": chasm.NewComponentField(ctx, newCB("http://localhost:8080/standby", callbackspb.CALLBACK_STATUS_STANDBY)),
+			"req-id-1": chasm.NewComponentField(ctx, newCB("http://localhost:8080/succeeded", callbackspb.CALLBACK_STATUS_SUCCEEDED)),
+			"req-id-2": chasm.NewComponentField(ctx, failed),
+		}
+
+		infos, err := op.buildCompletionCallbackInfos(ctx)
+		require.NoError(t, err)
+		require.Len(t, infos, 3)
+
+		// Ordering follows the sorted callback IDs, not the (randomized) map iteration order.
+		require.Equal(t, "http://localhost:8080/standby", infos[0].GetInfo().GetCallback().GetNexus().GetUrl())
+		require.Equal(t, enumspb.CALLBACK_STATE_STANDBY, infos[0].GetInfo().GetState())
+		require.Nil(t, infos[0].GetInfo().GetOutcome())
+		require.Equal(t, defaultTime, infos[0].GetInfo().GetRegistrationTime().AsTime())
+		// Every callback on a standalone operation is triggered by the operation completing.
+		require.NotNil(t, infos[0].GetTrigger().GetOperationCompleted())
+
+		require.Equal(t, enumspb.CALLBACK_STATE_SUCCEEDED, infos[1].GetInfo().GetState())
+		require.NotNil(t, infos[1].GetInfo().GetOutcome().GetSuccess())
+
+		require.Equal(t, enumspb.CALLBACK_STATE_FAILED, infos[2].GetInfo().GetState())
+		require.Equal(t, int32(3), infos[2].GetInfo().GetAttempt())
+		protorequire.ProtoEqual(t,
+			&failurepb.Failure{Message: "boom"},
+			infos[2].GetInfo().GetOutcome().GetFailure(),
+		)
+	})
+}
+
+// TestCompletionCallbacksRoundTripThroughTheTree exercises the Callbacks map against a real CHASM tree
+// rather than a mock context, so that a missing component registration or an unserializable field shows
+// up here instead of at runtime.
+func TestCompletionCallbacksRoundTripThroughTheTree(t *testing.T) {
+	logger := log.NewNoopLogger()
+	registry := chasm.NewRegistry(logger)
+	require.NoError(t, registry.Register(&chasm.CoreLibrary{}))
+	require.NoError(t, registry.Register(&Library{
+		componentOnlyLibrary: componentOnlyLibrary{
+			metricTagConfig: dynamicconfig.GetTypedPropertyFn(NexusMetricTagConfig{}),
+		},
+	}))
+	require.NoError(t, registry.Register(callback.NewNilLibrary()))
+
+	timeSource := clock.NewEventTimeSource()
+	timeSource.Update(defaultTime)
+	nodeBackend := &chasm.MockNodeBackend{
+		HandleNextTransitionCount: func() int64 { return 2 },
+		HandleGetCurrentVersion:   func() int64 { return 1 },
+		HandleCurrentVersionedTransition: func() *persistencespb.VersionedTransition {
+			return &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 1}
+		},
+		HandleGetNamespaceEntry: func() *namespace.Namespace {
+			return namespace.NewNamespaceForTest(&persistencespb.NamespaceInfo{Name: "ns-name"}, nil, false, nil, 0)
+		},
+	}
+	root := chasm.NewEmptyTree(registry, timeSource, nodeBackend, chasm.DefaultPathEncoder, logger, metrics.NoopMetricsHandler)
+	ctx := chasm.NewMutableContext(context.Background(), root)
+
+	op := NewOperation(&nexusoperationpb.OperationState{
+		Status:        nexusoperationpb.OPERATION_STATUS_STARTED,
+		Endpoint:      "test-endpoint",
+		ScheduledTime: timestamppb.New(defaultTime),
+	})
+	op.RequestData = chasm.NewDataField(ctx, &nexusoperationpb.OperationRequestData{})
+	op.Visibility = chasm.NewComponentField(ctx, chasm.NewVisibilityWithData(ctx, nil, nil))
+	require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", []*commonpb.Callback{
+		testNexusCallback(testCallbackURL),
+	}, 10))
+	require.NoError(t, root.SetRootComponent(op))
+	_, err := root.CloseTransaction()
+	require.NoError(t, err)
+
+	ctx = chasm.NewMutableContext(context.Background(), root)
+	require.Len(t, op.Callbacks, 1)
+	cb := op.Callbacks["req-id-0"].Get(ctx)
+	require.Equal(t, callbackspb.CALLBACK_STATUS_STANDBY, cb.Status)
+
+	// The callback resolves its parent via a ParentPtr, so the Operation must satisfy
+	// callback.CompletionSource from inside the tree, not just as a compile-time assertion.
+	require.NoError(t, TransitionSucceeded.Apply(op, ctx, EventSucceeded{Result: mustToPayload(t, "result")}))
+	require.Equal(t, callbackspb.CALLBACK_STATUS_SCHEDULED, cb.Status)
+
+	completion, err := cb.CompletionSource.Get(ctx).GetNexusCompletion(ctx, cb.RequestId)
+	require.NoError(t, err)
+	require.Nil(t, completion.Error)
+}
+
+// TestDescribeResponseIncludesCompletionCallbacks covers the plumbing from the component into the
+// DescribeNexusOperationExecution response.
+func TestDescribeResponseIncludesCompletionCallbacks(t *testing.T) {
+	t.Parallel()
+
+	newOp := func(ctx chasm.MutableContext) *Operation {
+		op := newTestOperation()
+		op.RequestData = chasm.NewDataField(ctx, &nexusoperationpb.OperationRequestData{})
+		op.Visibility = chasm.NewComponentField(ctx, chasm.NewVisibilityWithData(ctx, nil, nil))
+		return op
+	}
+	req := &nexusoperationpb.DescribeNexusOperationRequest{
+		FrontendRequest: &workflowservice.DescribeNexusOperationExecutionRequest{},
+	}
+
+	t.Run("WithCallbacks", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newOp(ctx)
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", []*commonpb.Callback{
+			testNexusCallback(testCallbackURL),
+		}, 10))
+
+		resp, err := op.buildDescribeResponse(ctx, req)
+		require.NoError(t, err)
+
+		cbs := resp.GetFrontendResponse().GetCompletionCallbacks()
+		require.Len(t, cbs, 1)
+		require.Equal(t, testCallbackURL, cbs[0].GetInfo().GetCallback().GetNexus().GetUrl())
+		require.Equal(t, enumspb.CALLBACK_STATE_STANDBY, cbs[0].GetInfo().GetState())
+	})
+
+	t.Run("WithoutCallbacks", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newOp(ctx)
+
+		resp, err := op.buildDescribeResponse(ctx, req)
+		require.NoError(t, err)
+		require.Empty(t, resp.GetFrontendResponse().GetCompletionCallbacks())
+	})
+}

--- a/chasm/lib/nexusoperation/config.go
+++ b/chasm/lib/nexusoperation/config.go
@@ -6,6 +6,7 @@ import (
 	"text/template"
 	"time"
 
+	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/config"
@@ -33,6 +34,12 @@ var Enabled = dynamicconfig.NewNamespaceBoolSetting(
 	"nexusoperation.enableStandalone",
 	false,
 	`Toggles standalone Nexus operation functionality on the server.`,
+)
+
+var EnableNexusCallbacks = dynamicconfig.NewNamespaceBoolSetting(
+	"nexusoperation.enableNexusCallbacks",
+	false,
+	`Allows attaching Nexus completion callbacks to standalone Nexus operation executions.`,
 )
 
 var EnableChasmWorkflowOperations = dynamicconfig.NewNamespaceBoolSetting(
@@ -243,6 +250,8 @@ Added for safety. Defaults to true. Likely to be removed in future server versio
 type Config struct {
 	Enabled                                    dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	EnableChasm                                dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	EnableNexusCallbacks                       dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	MaxCallbacksPerExecution                   dynamicconfig.IntPropertyFnWithNamespaceFilter
 	EnableChasmNexusWorkflowOperations         dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	ChasmNexusWorkflowOperationsRolloutPercent dynamicconfig.IntPropertyFnWithNamespaceFilter
 	NumHistoryShards                           int32
@@ -275,6 +284,8 @@ func configProvider(dc *dynamicconfig.Collection, cfg *config.Persistence) *Conf
 	return &Config{
 		Enabled:                            Enabled.Get(dc),
 		EnableChasm:                        dynamicconfig.EnableChasm.Get(dc),
+		EnableNexusCallbacks:               EnableNexusCallbacks.Get(dc),
+		MaxCallbacksPerExecution:           callback.MaxPerExecution.Get(dc),
 		EnableChasmNexusWorkflowOperations: EnableChasmWorkflowOperations.Get(dc),
 		ChasmNexusWorkflowOperationsRolloutPercent: ChasmWorkflowOperationsRolloutPercent.Get(dc),
 		NumHistoryShards:                   cfg.NumHistoryShards,

--- a/chasm/lib/nexusoperation/frontend.go
+++ b/chasm/lib/nexusoperation/frontend.go
@@ -9,6 +9,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/callback"
 	nexusoperationpb "go.temporal.io/server/chasm/lib/nexusoperation/gen/nexusoperationpb/v1"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
@@ -49,13 +50,14 @@ func NewFrontendHandler(
 	endpointRegistry commonnexus.EndpointRegistry,
 	saMapperProvider searchattribute.MapperProvider,
 	saValidator *searchattribute.Validator,
+	callbackValidator callback.Validator,
 ) FrontendHandler {
 	return &frontendHandler{
 		client:            client,
 		config:            config,
 		namespaceRegistry: namespaceRegistry,
 		endpointRegistry:  endpointRegistry,
-		validator:         newValidator(config, logger, saMapperProvider, saValidator),
+		validator:         newValidator(config, logger, saMapperProvider, saValidator, callbackValidator),
 	}
 }
 
@@ -72,7 +74,7 @@ func (h *frontendHandler) StartNexusOperationExecution(
 		return nil, err
 	}
 
-	if err := h.validator.validateAndNormalizeStartRequest(req); err != nil {
+	if err := h.validator.validateAndNormalizeStartRequest(ctx, req); err != nil {
 		return nil, err
 	}
 

--- a/chasm/lib/nexusoperation/handler.go
+++ b/chasm/lib/nexusoperation/handler.go
@@ -35,14 +35,19 @@ func (h *handler) StartNexusOperation(
 	defer log.CapturePanic(h.logger, &err)
 
 	frontendReq := req.GetFrontendRequest()
+	// Read once, so it's consistent for both the creation and on-conflict paths,
+	// despite being in two transactions.
+	maxCallbacks := h.config.MaxCallbacksPerExecution(frontendReq.GetNamespace())
 
-	result, err := chasm.StartExecution[*Operation](
+	result, err := chasm.StartExecution(
 		ctx,
 		chasm.ExecutionKey{
 			NamespaceID: req.GetNamespaceId(),
 			BusinessID:  frontendReq.GetOperationId(),
 		},
-		newStandaloneOperation,
+		func(mutableCtx chasm.MutableContext, req *nexusoperationpb.StartNexusOperationRequest) (*Operation, error) {
+			return newStandaloneOperation(mutableCtx, req, maxCallbacks)
+		},
 		req,
 		chasm.WithRequestID(frontendReq.GetRequestId()),
 		chasm.WithBusinessIDPolicy(
@@ -51,6 +56,8 @@ func (h *handler) StartNexusOperation(
 		),
 	)
 	if err != nil {
+		// ExecutionAlreadyStarted would only be returned if the IDConflictPolicy were FAIL.
+		// Otherwise, we'd return the existing SANO. (And apply the OnConflictOptions next.)
 		if alreadyStartedErr, ok := errors.AsType[*chasm.ExecutionAlreadyStartedError](err); ok {
 			return nil, serviceerror.NewNexusOperationExecutionAlreadyStartedf(
 				alreadyStartedErr.CurrentRequestID,
@@ -63,12 +70,45 @@ func (h *handler) StartNexusOperation(
 		return nil, err
 	}
 
+	if !result.Created {
+		if err := h.applyOnConflictOptions(ctx, result.ExecutionKey, frontendReq, maxCallbacks); err != nil {
+			return nil, err
+		}
+	}
+
 	return &nexusoperationpb.StartNexusOperationResponse{
 		FrontendResponse: &workflowservice.StartNexusOperationExecutionResponse{
 			RunId:   result.ExecutionKey.RunID,
 			Started: result.Created,
 		},
 	}, nil
+}
+
+// applyOnConflictOptions applies the request's on_conflict_options to a SANO.
+func (h *handler) applyOnConflictOptions(
+	ctx context.Context,
+	key chasm.ExecutionKey,
+	req *workflowservice.StartNexusOperationExecutionRequest,
+	maxCallbacks int,
+) error {
+	cbs := req.GetCompletionCallbacks()
+	attachCallbacks := req.GetOnConflictOptions().GetAttachCompletionCallbacks() && len(cbs) > 0
+	if !attachCallbacks {
+		return nil
+	}
+
+	requestID := req.GetRequestId()
+	// TODO: Use chasm.UpdateWithStartExecution to avoid a second transaction once the engine supports
+	// BusinessIDConflictPolicyFail in the updateFn path. (Same for standalone Activities.)
+	_, _, err := chasm.UpdateComponent(
+		ctx,
+		chasm.NewComponentRef[*Operation](key),
+		func(o *Operation, ctx chasm.MutableContext, _ any) (any, error) {
+			return nil, o.addCompletionCallbacks(ctx, requestID, cbs, maxCallbacks)
+		},
+		nil,
+	)
+	return err
 }
 
 // DescribeNexusOperation queries current operation state, optionally as a long-poll that waits

--- a/chasm/lib/nexusoperation/operation.go
+++ b/chasm/lib/nexusoperation/operation.go
@@ -421,20 +421,15 @@ func (o *Operation) getOrCreateOutcome(ctx chasm.MutableContext) *nexusoperation
 	return outcome
 }
 
-// addCompletionCallbacks creates the child CHASM callback components. They will be in the STANDBY
-// state until this Operation reaches a terminal state.
+// addCompletionCallbacks creates the child CHASM callback components. They stay in STANDBY until this
+// Operation reaches a terminal state.
 //
-// Callbacks are keyed by requestID plus their position within the request, so re-attaching the same
-// request (a client retry, or a retried on_conflict_options attach) is a no-op rather than a duplicate.
-// This is why a request ID is required to be set if there are completion callbacks.
+// Callbacks are keyed by request ID plus their position within the request, so re-attaching the same
+// request is a no-op rather than a duplicate. The idempotency probe runs before the closed check, so a
+// retry still succeeds if the operation closed after the first attach.
 //
-// The idempotency check runs before the closed check, so that a client whose first attach succeeded but
-// whose response was lost still sees success when it retries, even if the operation closed in between.
-// Rejecting that retry would report failure for work that is in fact persisted.
-//
-// maxCallbacks is checked here as well as by the frontend because the two checks cover different things:
-// callback.Validator bounds the callbacks when starting SANOs. This verifies that later callbacks added
-// via on_conflict_options don't exceed the limit.
+// maxCallbacks is re-checked here because callback.Validator only bounds the callbacks on the start
+// request; callbacks added later via on_conflict_options bypass it.
 func (o *Operation) addCompletionCallbacks(
 	ctx chasm.MutableContext,
 	requestID string,

--- a/chasm/lib/nexusoperation/operation.go
+++ b/chasm/lib/nexusoperation/operation.go
@@ -3,6 +3,7 @@ package nexusoperation
 import (
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 	"time"
 
@@ -12,14 +13,18 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
 	nexuspb "go.temporal.io/api/nexus/v1"
+	apinexusoperationpb "go.temporal.io/api/nexusoperation/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/callback"
+	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
 	nexusoperationpb "go.temporal.io/server/chasm/lib/nexusoperation/gen/nexusoperationpb/v1"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/metrics"
 	commonnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/softassert"
 	queueserrors "go.temporal.io/server/service/history/queues/errors"
@@ -40,6 +45,7 @@ var _ chasm.RootComponent = (*Operation)(nil)
 var _ chasm.StateMachine[nexusoperationpb.OperationStatus] = (*Operation)(nil)
 var _ chasm.VisibilitySearchAttributesProvider = (*Operation)(nil)
 var _ chasm.NexusCompletionHandler = (*Operation)(nil)
+var _ callback.CompletionSource = (*Operation)(nil)
 
 // ErrCancellationAlreadyRequested is returned when a cancellation has already been requested for an operation.
 var ErrCancellationAlreadyRequested = serviceerror.NewFailedPrecondition("cancellation already requested")
@@ -99,6 +105,10 @@ type Operation struct {
 	Cancellation chasm.Field[*Cancellation]
 	Outcome      chasm.Field[*nexusoperationpb.OperationOutcome]
 	Visibility   chasm.Field[*chasm.Visibility]
+
+	// Callbacks holds completion callbacks to be invoked when this reaches a terminal state.
+	// Keyed by completionCallbackID(requestID, index).
+	Callbacks chasm.Map[string, *callback.Callback]
 }
 
 // NewOperation creates a new Operation component with the given persisted state.
@@ -109,6 +119,7 @@ func NewOperation(state *nexusoperationpb.OperationState) *Operation {
 func newStandaloneOperation(
 	ctx chasm.MutableContext,
 	req *nexusoperationpb.StartNexusOperationRequest,
+	maxCallbacks int,
 ) (*Operation, error) {
 	frontendReq := req.GetFrontendRequest()
 	op := NewOperation(&nexusoperationpb.OperationState{
@@ -133,6 +144,14 @@ func newStandaloneOperation(
 		frontendReq.GetSearchAttributes().GetIndexedFields(),
 		nil,
 	))
+	if err := op.addCompletionCallbacks(
+		ctx,
+		frontendReq.GetRequestId(),
+		frontendReq.GetCompletionCallbacks(),
+		maxCallbacks,
+	); err != nil {
+		return nil, err
+	}
 	if err := TransitionScheduled.Apply(op, ctx, EventScheduled{}); err != nil {
 		return nil, err
 	}
@@ -390,7 +409,7 @@ func (o *Operation) resolveUnsuccessfully(ctx chasm.MutableContext, failure *fai
 
 	// NextAttemptScheduleTime is only valid in BACKING_OFF; clear on close
 	o.NextAttemptScheduleTime = nil
-	return nil
+	return o.scheduleCompletionCallbacks(ctx)
 }
 
 func (o *Operation) getOrCreateOutcome(ctx chasm.MutableContext) *nexusoperationpb.OperationOutcome {
@@ -400,6 +419,159 @@ func (o *Operation) getOrCreateOutcome(ctx chasm.MutableContext) *nexusoperation
 	outcome := &nexusoperationpb.OperationOutcome{}
 	o.Outcome = chasm.NewDataField(ctx, outcome)
 	return outcome
+}
+
+// addCompletionCallbacks creates the child CHASM callback components. They will be in the STANDBY
+// state until this Operation reaches a terminal state.
+//
+// Callbacks are keyed by requestID plus their position within the request, so re-attaching the same
+// request (a client retry, or a retried on_conflict_options attach) is a no-op rather than a duplicate.
+// This is why a request ID is required to be set if there are completion callbacks.
+//
+// The idempotency check runs before the closed check, so that a client whose first attach succeeded but
+// whose response was lost still sees success when it retries, even if the operation closed in between.
+// Rejecting that retry would report failure for work that is in fact persisted.
+//
+// maxCallbacks is checked here as well as by the frontend because the two checks cover different things:
+// callback.Validator bounds the callbacks when starting SANOs. This verifies that later callbacks added
+// via on_conflict_options don't exceed the limit.
+func (o *Operation) addCompletionCallbacks(
+	ctx chasm.MutableContext,
+	requestID string,
+	completionCallbacks []*commonpb.Callback,
+	maxCallbacks int,
+) error {
+	if len(completionCallbacks) == 0 {
+		return nil
+	}
+	if requestID == "" {
+		return serviceerror.NewInvalidArgument("cannot attach completion callbacks without a request ID")
+	}
+	// Attaching is atomic, so the presence of the first key means this request already attached all of
+	// its callbacks. See the note above on why this precedes the closed check.
+	if _, ok := o.Callbacks[completionCallbackID(requestID, 0)]; ok {
+		return nil
+	}
+	if o.isClosed() {
+		return serviceerror.NewFailedPrecondition("cannot attach callbacks to a closed nexus operation")
+	}
+
+	currentCount := len(o.Callbacks)
+	if len(completionCallbacks)+currentCount > maxCallbacks {
+		return serviceerror.NewFailedPreconditionf(
+			"cannot attach more than %d callbacks to a nexus operation (%d callbacks already attached)",
+			maxCallbacks,
+			currentCount,
+		)
+	}
+
+	if o.Callbacks == nil {
+		o.Callbacks = make(chasm.Map[string, *callback.Callback], len(completionCallbacks))
+	}
+
+	registrationTime := timestamppb.New(ctx.Now(o))
+	for idx, cb := range completionCallbacks {
+		chasmCB, err := callback.FromAPICallback(cb)
+		if err != nil {
+			return err
+		}
+		callbackObj := callback.NewCallback(requestID, registrationTime, &callbackspb.CallbackState{}, chasmCB)
+		o.Callbacks[completionCallbackID(requestID, idx)] = chasm.NewComponentField(ctx, callbackObj)
+	}
+	return nil
+}
+
+// completionCallbackID defines the stable key used for keeping track of attached completion callbacks.
+func completionCallbackID(requestID string, idx int) string {
+	return fmt.Sprintf("%s-%d", requestID, idx)
+}
+
+// scheduleCompletionCallbacks releases every STANDBY completion callback for delivery. Called from each
+// terminal transition.
+func (o *Operation) scheduleCompletionCallbacks(ctx chasm.MutableContext) error {
+	return callback.ScheduleStandbyCallbacks(ctx, o.Callbacks)
+}
+
+// GetNexusCompletion implements callback.CompletionSource, providing the result of the Nexus operation.
+func (o *Operation) GetNexusCompletion(ctx chasm.Context, _ string) (nexusrpc.CompleteOperationOptions, error) {
+	if !o.isClosed() {
+		return nexusrpc.CompleteOperationOptions{}, serviceerror.NewInternal("nexus operation has not completed yet")
+	}
+
+	key := ctx.ExecutionKey()
+	backLink := commonnexus.ConvertLinkNexusOperationToNexusLink(&commonpb.Link_NexusOperation{
+		Namespace:   ctx.NamespaceEntry().Name().String(),
+		OperationId: key.BusinessID,
+		RunId:       key.RunID,
+	})
+
+	opts := nexusrpc.CompleteOperationOptions{
+		StartTime: o.GetScheduledTime().AsTime(),
+		CloseTime: ctx.ExecutionInfo().CloseTime,
+		Links:     []nexus.Link{backLink},
+	}
+
+	result, failure := o.outcome(ctx)
+	if o.Status == nexusoperationpb.OPERATION_STATUS_SUCCEEDED {
+		opts.Result = result
+		return opts, nil
+	}
+	if failure == nil {
+		return nexusrpc.CompleteOperationOptions{},
+			serviceerror.NewInternalf("nexus operation in status %v has no outcome", o.Status)
+	}
+
+	state := nexus.OperationStateFailed
+	message := "operation failed"
+	if o.Status == nexusoperationpb.OPERATION_STATUS_CANCELED {
+		state = nexus.OperationStateCanceled
+		message = "operation canceled"
+	}
+
+	nf, err := commonnexus.TemporalFailureToNexusFailure(failure)
+	if err != nil {
+		return nexusrpc.CompleteOperationOptions{}, serviceerror.NewInternalf("failed to convert failure: %v", err)
+	}
+	opErr := &nexus.OperationError{
+		State:   state,
+		Message: message,
+		Cause:   &nexus.FailureError{Failure: nf},
+	}
+	if err := nexusrpc.MarkAsWrapperError(nexusrpc.DefaultFailureConverter(), opErr); err != nil {
+		return nexusrpc.CompleteOperationOptions{}, err
+	}
+	opts.Error = opErr
+	return opts, nil
+}
+
+// buildCompletionCallbackInfos projects the attached completion callbacks onto the API surface for the
+// describe response.
+func (o *Operation) buildCompletionCallbackInfos(ctx chasm.Context) ([]*apinexusoperationpb.CallbackInfo, error) {
+	if len(o.Callbacks) == 0 {
+		return nil, nil
+	}
+
+	// All standalone Nexus operation callbacks have the same trigger.
+	trigger := &apinexusoperationpb.CallbackInfo_Trigger{
+		Variant: &apinexusoperationpb.CallbackInfo_Trigger_OperationCompleted{
+			OperationCompleted: &apinexusoperationpb.CallbackInfo_OperationCompleted{},
+		},
+	}
+
+	// Iterate in key order so that the response ordering is stable across calls.
+	sortedCallbackKeys := slices.Sorted(maps.Keys(o.Callbacks))
+	infos := make([]*apinexusoperationpb.CallbackInfo, 0, len(o.Callbacks))
+	for _, id := range sortedCallbackKeys {
+		info, err := o.Callbacks[id].Get(ctx).ToAPICallbackInfo(ctx)
+		if err != nil {
+			return nil, err
+		}
+		infos = append(infos, &apinexusoperationpb.CallbackInfo{
+			Trigger: trigger,
+			Info:    info,
+		})
+	}
+	return infos, nil
 }
 
 func (o *Operation) Terminate(
@@ -438,10 +610,16 @@ func (o *Operation) buildDescribeResponse(
 		return nil, err
 	}
 
+	callbackInfos, err := o.buildCompletionCallbackInfos(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	resp := &workflowservice.DescribeNexusOperationExecutionResponse{
-		RunId:         ctx.ExecutionKey().RunID,
-		Info:          o.buildExecutionInfo(ctx),
-		LongPollToken: token,
+		RunId:               ctx.ExecutionKey().RunID,
+		Info:                o.buildExecutionInfo(ctx),
+		LongPollToken:       token,
+		CompletionCallbacks: callbackInfos,
 	}
 	if req.GetFrontendRequest().GetIncludeInput() {
 		resp.Input = o.RequestData.Get(ctx).GetInput()

--- a/chasm/lib/nexusoperation/operation_statemachine.go
+++ b/chasm/lib/nexusoperation/operation_statemachine.go
@@ -190,8 +190,8 @@ var TransitionSucceeded = chasm.NewTransition(
 		}
 
 		o.emitOnSucceededMetrics(ctx, closeTime)
-		// Terminal state - no tasks to emit.
-		return nil
+		// Schedule the SANO's completion callbacks.
+		return o.scheduleCompletionCallbacks(ctx)
 	},
 )
 

--- a/chasm/lib/nexusoperation/validator.go
+++ b/chasm/lib/nexusoperation/validator.go
@@ -1,15 +1,18 @@
 package nexusoperation
 
 import (
+	"context"
 	"slices"
 	"strings"
 
 	"github.com/google/uuid"
+	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	sdkpb "go.temporal.io/api/sdk/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/primitives/timestamp"
@@ -33,10 +36,11 @@ type cancelOrTerminateRequest interface {
 // Requests are mutated in place: defaults are applied, values are capped to their configured
 // limits, and headers are lower-cased.
 type validator struct {
-	config           *Config
-	logger           log.Logger
-	saMapperProvider searchattribute.MapperProvider
-	saValidator      *searchattribute.Validator
+	config            *Config
+	logger            log.Logger
+	saMapperProvider  searchattribute.MapperProvider
+	saValidator       *searchattribute.Validator
+	callbackValidator callback.Validator
 }
 
 func newValidator(
@@ -44,16 +48,21 @@ func newValidator(
 	logger log.Logger,
 	saMapperProvider searchattribute.MapperProvider,
 	saValidator *searchattribute.Validator,
+	callbackValidator callback.Validator,
 ) *validator {
 	return &validator{
-		config:           config,
-		logger:           logger,
-		saMapperProvider: saMapperProvider,
-		saValidator:      saValidator,
+		config:            config,
+		logger:            logger,
+		saMapperProvider:  saMapperProvider,
+		saValidator:       saValidator,
+		callbackValidator: callbackValidator,
 	}
 }
 
-func (v *validator) validateAndNormalizeStartRequest(req *workflowservice.StartNexusOperationExecutionRequest) error {
+func (v *validator) validateAndNormalizeStartRequest(
+	ctx context.Context,
+	req *workflowservice.StartNexusOperationExecutionRequest,
+) error {
 	ns := req.GetNamespace()
 
 	if err := v.normalizeRequestID(&req.RequestId); err != nil {
@@ -85,6 +94,12 @@ func (v *validator) validateAndNormalizeStartRequest(req *workflowservice.StartN
 	req.NexusHeader = loweredHeaders
 
 	if err := v.validateAndNormalizeSearchAttributes(req); err != nil {
+		return err
+	}
+	if err := v.validateAndNormalizeCompletionCallbacks(ctx, req); err != nil {
+		return err
+	}
+	if err := v.validateOnConflictOptions(req); err != nil {
 		return err
 	}
 
@@ -311,6 +326,55 @@ func (v *validator) normalizeIDPolicies(req *workflowservice.StartNexusOperation
 	if req.GetIdConflictPolicy() == enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_UNSPECIFIED {
 		req.IdConflictPolicy = enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_FAIL
 	}
+}
+
+// validateAndNormalizeCompletionCallbacks checks that the request's completion callbacks are
+// permitted for the namespace and only use supported variants.
+func (v *validator) validateAndNormalizeCompletionCallbacks(
+	ctx context.Context,
+	req *workflowservice.StartNexusOperationExecutionRequest,
+) error {
+	cbs := req.GetCompletionCallbacks()
+	if len(cbs) == 0 {
+		return nil
+	}
+	if !v.config.EnableNexusCallbacks(req.GetNamespace()) {
+		return serviceerror.NewInvalidArgument("completion callbacks are not enabled for this namespace")
+	}
+	for i, cb := range cbs {
+		if _, ok := cb.GetVariant().(*commonpb.Callback_Nexus_); !ok {
+			return serviceerror.NewInvalidArgumentf(
+				"completion_callbacks[%d]: unsupported callback variant: %T", i, cb.GetVariant())
+		}
+	}
+	return v.callbackValidator.Validate(ctx, req.GetNamespace(), cbs)
+}
+
+// validateOnConflictOptions validates the on_conflict_options of a start request:
+//   - attach_links is not supported: StartNexusOperationExecutionRequest has no links field, so there is
+//     nothing to attach. Reject rather than silently drop the caller's intent.
+//   - attach_completion_callbacks requires attach_request_id, since it embedded into the keys we use to
+//     persist them on the Operation's Callbacks map.
+//   - attach_request_id requires at least one completion callback, since attaching a request ID is only
+//     meaningful alongside something to attach.
+func (v *validator) validateOnConflictOptions(req *workflowservice.StartNexusOperationExecutionRequest) error {
+	onConflictOptions := req.GetOnConflictOptions()
+	if onConflictOptions == nil {
+		return nil
+	}
+	if onConflictOptions.GetAttachLinks() {
+		return serviceerror.NewUnimplemented(
+			"on_conflict_options: attach_links is not supported for Nexus operation executions")
+	}
+	if onConflictOptions.GetAttachCompletionCallbacks() && !onConflictOptions.GetAttachRequestId() {
+		return serviceerror.NewInvalidArgument(
+			"on_conflict_options: attach_completion_callbacks requires attach_request_id to be set")
+	}
+	if onConflictOptions.GetAttachRequestId() && len(req.GetCompletionCallbacks()) == 0 {
+		return serviceerror.NewInvalidArgument(
+			"on_conflict_options: attach_request_id requires at least one completion callback")
+	}
+	return nil
 }
 
 // normalizeRequestID validates the request ID, or sets it to a UUID if empty.

--- a/chasm/lib/nexusoperation/validator_test.go
+++ b/chasm/lib/nexusoperation/validator_test.go
@@ -1,6 +1,8 @@
 package nexusoperation
 
 import (
+	"context"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -8,10 +10,12 @@ import (
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	apinexusoperationpb "go.temporal.io/api/nexusoperation/v1"
 	sdkpb "go.temporal.io/api/sdk/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
@@ -23,7 +27,31 @@ import (
 )
 
 func newTestValidator(config *Config) *validator {
-	return newValidator(config, log.NewNoopLogger(), nil, nil)
+	return newValidator(config, log.NewNoopLogger(), nil, nil, newTestCallbackValidator())
+}
+
+// Returns a callback.Validator that accepts any well-formed callback.
+func newTestCallbackValidator() callback.Validator {
+	return callback.NewValidator(
+		func(string) int { return 10 },
+		func(string) int { return 1000 },
+		func(string) int { return 4096 },
+		func(string) callback.AddressMatchRules {
+			return callback.AddressMatchRules{
+				Rules: []callback.AddressMatchRule{
+					{Regexp: regexp.MustCompile(`.*`), AllowInsecure: true},
+				},
+			}
+		},
+	)
+}
+
+func testNexusCallback(url string) *commonpb.Callback {
+	return &commonpb.Callback{
+		Variant: &commonpb.Callback_Nexus_{
+			Nexus: &commonpb.Callback_Nexus{Url: url},
+		},
+	}
 }
 
 func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
@@ -56,6 +84,7 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 		MaxOperationHeaderSize:             func(string) int { return 10 },
 		DisallowedOperationHeaders:         func() []string { return []string{"disallowed-header"} },
 		MaxOperationScheduleToCloseTimeout: func(string) time.Duration { return time.Hour },
+		EnableNexusCallbacks:               func(string) bool { return true },
 	}
 
 	for _, tc := range []struct {
@@ -328,6 +357,33 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 			},
 			errMsg: "exceeds size limit",
 		},
+		{
+			name: "completion_callbacks - accepts the nexus variant",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.CompletionCallbacks = []*commonpb.Callback{testNexusCallback("http://localhost/cb")}
+			},
+		},
+		{
+			name: "completion_callbacks - rejects a non-nexus variant",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.CompletionCallbacks = []*commonpb.Callback{{
+					Variant: &commonpb.Callback_Internal_{
+						Internal: &commonpb.Callback_Internal{Data: []byte("data")},
+					},
+				}}
+			},
+			errMsg: "completion_callbacks[0]: unsupported callback variant",
+		},
+		{
+			name: "on_conflict_options - attach_completion_callbacks requires attach_request_id",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.CompletionCallbacks = []*commonpb.Callback{testNexusCallback("http://localhost/cb")}
+				r.OnConflictOptions = &apinexusoperationpb.OnConflictOptions{
+					AttachCompletionCallbacks: true,
+				}
+			},
+			errMsg: "attach_completion_callbacks requires attach_request_id",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			req := &workflowservice.StartNexusOperationExecutionRequest{
@@ -346,8 +402,8 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 			if tc.mutate != nil {
 				tc.mutate(req)
 			}
-			err := newValidator(config, log.NewNoopLogger(), nil, saValidator).
-				validateAndNormalizeStartRequest(req)
+			err := newValidator(config, log.NewNoopLogger(), nil, saValidator, newTestCallbackValidator()).
+				validateAndNormalizeStartRequest(context.Background(), req)
 			if tc.errMsg != "" {
 				var invalidArgErr *serviceerror.InvalidArgument
 				require.ErrorAs(t, err, &invalidArgErr)
@@ -787,4 +843,163 @@ func TestValidatePollNexusOperationExecutionRequest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateAndNormalizeCompletionCallbacks(t *testing.T) {
+	t.Parallel()
+
+	newReq := func(cbs ...*commonpb.Callback) *workflowservice.StartNexusOperationExecutionRequest {
+		return &workflowservice.StartNexusOperationExecutionRequest{
+			Namespace:           "default",
+			CompletionCallbacks: cbs,
+		}
+	}
+	enabled := newTestValidator(&Config{EnableNexusCallbacks: func(string) bool { return true }})
+	disabled := newTestValidator(&Config{EnableNexusCallbacks: func(string) bool { return false }})
+
+	t.Run("NoCallbacksSkipsTheEnabledCheck", func(t *testing.T) {
+		// The namespace flag must not be consulted when no callbacks were requested, so that existing
+		// callers are unaffected by it. A nil getter would panic if it were.
+		require.NoError(t, newTestValidator(&Config{}).
+			validateAndNormalizeCompletionCallbacks(context.Background(), newReq()))
+	})
+
+	t.Run("Enabled", func(t *testing.T) {
+		require.NoError(t, enabled.validateAndNormalizeCompletionCallbacks(
+			context.Background(),
+			newReq(testNexusCallback("http://localhost/cb"), testNexusCallback("http://localhost/cb2")),
+		))
+	})
+
+	t.Run("Disabled", func(t *testing.T) {
+		err := disabled.validateAndNormalizeCompletionCallbacks(
+			context.Background(), newReq(testNexusCallback("http://localhost/cb")))
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Contains(t, err.Error(), "completion callbacks are not enabled for this namespace")
+	})
+
+	t.Run("RejectsInternalVariant", func(t *testing.T) {
+		err := enabled.validateAndNormalizeCompletionCallbacks(context.Background(), newReq(&commonpb.Callback{
+			Variant: &commonpb.Callback_Internal_{
+				Internal: &commonpb.Callback_Internal{Data: []byte("data")},
+			},
+		}))
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Contains(t, err.Error(), "completion_callbacks[0]: unsupported callback variant")
+	})
+
+	t.Run("RejectsWorkerVariant", func(t *testing.T) {
+		// Worker callbacks are a newer API addition that standalone Nexus operations do not support yet.
+		err := enabled.validateAndNormalizeCompletionCallbacks(context.Background(), newReq(
+			testNexusCallback("http://localhost/cb"),
+			&commonpb.Callback{
+				Variant: &commonpb.Callback_Worker_{Worker: &commonpb.Callback_Worker{}},
+			},
+		))
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Contains(t, err.Error(), "completion_callbacks[1]: unsupported callback variant")
+	})
+
+	t.Run("RejectsUnsetVariant", func(t *testing.T) {
+		err := enabled.validateAndNormalizeCompletionCallbacks(
+			context.Background(), newReq(&commonpb.Callback{}))
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Contains(t, err.Error(), "completion_callbacks[0]: unsupported callback variant")
+	})
+
+	t.Run("DelegatesToTheCallbackValidator", func(t *testing.T) {
+		// The delegate lower-cases the callback headers in place.
+		cb := testNexusCallback("http://localhost/cb")
+		cb.GetNexus().Header = map[string]string{"Some-Key": "value"}
+		require.NoError(t, enabled.validateAndNormalizeCompletionCallbacks(context.Background(), newReq(cb)))
+		require.Equal(t, map[string]string{"some-key": "value"}, cb.GetNexus().GetHeader())
+	})
+}
+
+func TestValidateOnConflictOptions(t *testing.T) {
+	t.Parallel()
+
+	// on_conflict_options validation is config-independent.
+	v := newTestValidator(&Config{})
+	cb := testNexusCallback("http://localhost/cb")
+
+	t.Run("Unset", func(t *testing.T) {
+		require.NoError(t, v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{}))
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		require.NoError(t, v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			OnConflictOptions: &apinexusoperationpb.OnConflictOptions{},
+		}))
+	})
+
+	t.Run("AttachRequestIdAndCallbacksWithCallback", func(t *testing.T) {
+		require.NoError(t, v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			CompletionCallbacks: []*commonpb.Callback{cb},
+			OnConflictOptions: &apinexusoperationpb.OnConflictOptions{
+				AttachRequestId:           true,
+				AttachCompletionCallbacks: true,
+			},
+		}))
+	})
+
+	t.Run("AttachRequestIdOnlyWithCallback", func(t *testing.T) {
+		require.NoError(t, v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			CompletionCallbacks: []*commonpb.Callback{cb},
+			OnConflictOptions:   &apinexusoperationpb.OnConflictOptions{AttachRequestId: true},
+		}))
+	})
+
+	t.Run("AttachCallbacksWithoutAttachRequestId", func(t *testing.T) {
+		err := v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			CompletionCallbacks: []*commonpb.Callback{cb},
+			OnConflictOptions: &apinexusoperationpb.OnConflictOptions{
+				AttachCompletionCallbacks: true,
+			},
+		})
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Contains(t, err.Error(), "attach_completion_callbacks requires attach_request_id")
+	})
+
+	t.Run("AttachRequestIdWithoutCallback", func(t *testing.T) {
+		err := v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			OnConflictOptions: &apinexusoperationpb.OnConflictOptions{AttachRequestId: true},
+		})
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Contains(t, err.Error(), "attach_request_id requires at least one completion callback")
+	})
+
+	t.Run("AttachRequestIdAndCallbacksWithoutCallbackProvided", func(t *testing.T) {
+		err := v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			OnConflictOptions: &apinexusoperationpb.OnConflictOptions{
+				AttachRequestId:           true,
+				AttachCompletionCallbacks: true,
+			},
+		})
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Contains(t, err.Error(), "attach_request_id requires at least one completion callback")
+	})
+
+	t.Run("AttachLinksIsUnimplemented", func(t *testing.T) {
+		// StartNexusOperationExecutionRequest carries no links, so honoring attach_links is impossible.
+		// Reject loudly rather than silently dropping the caller's intent.
+		err := v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			CompletionCallbacks: []*commonpb.Callback{cb},
+			OnConflictOptions: &apinexusoperationpb.OnConflictOptions{
+				AttachRequestId:           true,
+				AttachCompletionCallbacks: true,
+				AttachLinks:               true,
+			},
+		})
+		var unimplementedErr *serviceerror.Unimplemented
+		require.ErrorAs(t, err, &unimplementedErr)
+		require.Contains(t, err.Error(), "attach_links is not supported")
+	})
 }

--- a/chasm/lib/workflow/workflow.go
+++ b/chasm/lib/workflow/workflow.go
@@ -173,7 +173,7 @@ func addCallbacksToMap(
 			// Already registered, skip to avoid overwriting.
 			continue
 		}
-		callbackObj := callback.NewCallback(requestID, eventTime, &callbackspb.CallbackState{}, chasmCB)
+		callbackObj := callback.NewCallback(requestID, eventTime, chasmCB)
 		target[id] = chasm.NewComponentField(ctx, callbackObj)
 	}
 	return nil

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -237,6 +237,7 @@ func (s *WorkflowHandlerSuite) getWorkflowHandler(config *Config) *WorkflowHandl
 			nil,
 			s.mockResource.GetSearchAttributesMapperProvider(),
 			nil,
+			nil,
 		),
 		nil, // Not testing CHASM registry here
 		quotas.NoopRequestRateLimiter,

--- a/service/history/api/describeworkflow/api.go
+++ b/service/history/api/describeworkflow/api.go
@@ -19,7 +19,6 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
 	chasmcallback "go.temporal.io/server/chasm/lib/callback"
-	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
 	"go.temporal.io/server/chasm/lib/nexusoperation"
 	chasmworkflow "go.temporal.io/server/chasm/lib/workflow"
 	"go.temporal.io/server/common"
@@ -278,7 +277,6 @@ func Invoke(
 			)
 		}
 		chasmCallbackInfos, err := buildCallbackInfosFromChasm(
-			ctx,
 			namespaceID,
 			wf,
 			chasmCtx,
@@ -502,7 +500,6 @@ func buildCallbackInfosFromHSM(
 // buildCallbackInfosFromChasm reads callbacks from the CHASM workflow component and converts them to API format.
 // TODO(long-nt-tran): move this to chasm/lib/workflow/workflow.go to be within the CHASM workflow context.
 func buildCallbackInfosFromChasm(
-	ctx context.Context,
 	namespaceID namespace.ID,
 	wf *chasmworkflow.Workflow,
 	chasmCtx chasm.Context,
@@ -519,7 +516,7 @@ func buildCallbackInfosFromChasm(
 			Variant: &workflowpb.CallbackInfo_Trigger_WorkflowClosed{},
 		}
 
-		callbackInfo, err := buildCallbackInfoFromChasm(ctx, namespaceID, callback, trigger, outboundQueueCBPool)
+		callbackInfo, err := buildCallbackInfoFromChasm(namespaceID, callback, trigger, outboundQueueCBPool)
 		if err != nil {
 			logger.Error(
 				"failed to build callback info from CHASM callback",
@@ -550,7 +547,7 @@ func buildCallbackInfosFromChasm(
 				},
 			}
 
-			callbackInfo, err := buildCallbackInfoFromChasm(ctx, namespaceID, callback, trigger, outboundQueueCBPool)
+			callbackInfo, err := buildCallbackInfoFromChasm(namespaceID, callback, trigger, outboundQueueCBPool)
 			if err != nil {
 				logger.Error(
 					"failed to build callback info from CHASM update callback",
@@ -573,7 +570,6 @@ func buildCallbackInfosFromChasm(
 
 // buildCallbackInfoFromChasm converts a single CHASM callback to API format.
 func buildCallbackInfoFromChasm(
-	ctx context.Context,
 	namespaceID namespace.ID,
 	callback *chasmcallback.Callback,
 	trigger *workflowpb.CallbackInfo_Trigger,
@@ -589,14 +585,12 @@ func buildCallbackInfoFromChasm(
 		return cb.State() != gobreaker.StateClosed
 	}
 
-	return buildChasmCallbackInfo(ctx, namespaceID.String(), callback, trigger, circuitBreakerState)
+	return buildChasmCallbackInfo(callback, trigger, circuitBreakerState)
 }
 
 // buildChasmCallbackInfo converts a single CHASM callback to API CallbackInfo format.
 // Returns nil if the callback should not be included in the response.
 func buildChasmCallbackInfo(
-	ctx context.Context,
-	namespaceID string,
 	cb *chasmcallback.Callback,
 	trigger *workflowpb.CallbackInfo_Trigger,
 	circuitBreakerState func(destination string) bool,
@@ -611,23 +605,9 @@ func buildChasmCallbackInfo(
 	if err != nil {
 		return nil, err
 	}
-
-	var state enumspb.CallbackState
-	switch cb.Status {
-	case callbackspb.CALLBACK_STATUS_UNSPECIFIED:
-		return nil, serviceerror.NewInternal("callback with UNSPECIFIED state")
-	case callbackspb.CALLBACK_STATUS_STANDBY:
-		state = enumspb.CALLBACK_STATE_STANDBY
-	case callbackspb.CALLBACK_STATUS_SCHEDULED:
-		state = enumspb.CALLBACK_STATE_SCHEDULED
-	case callbackspb.CALLBACK_STATUS_BACKING_OFF:
-		state = enumspb.CALLBACK_STATE_BACKING_OFF
-	case callbackspb.CALLBACK_STATUS_FAILED:
-		state = enumspb.CALLBACK_STATE_FAILED
-	case callbackspb.CALLBACK_STATUS_SUCCEEDED:
-		state = enumspb.CALLBACK_STATE_SUCCEEDED
-	default:
-		return nil, serviceerror.NewInternalf("unknown callback state: %v", cb.Status)
+	state, err := cb.APIState()
+	if err != nil {
+		return nil, err
 	}
 
 	blockedReason := ""
@@ -638,15 +618,18 @@ func buildChasmCallbackInfo(
 		}
 	}
 
+	// The workflow.CallbackInfo proto forks the fields from callback.CallbackInfo
+	// rather than embedding it (unlike activity.CallbackInfo). There is some drift
+	// between the two, e.g. workflow.CallbackInfo does not contain the outcome.
 	return &workflowpb.CallbackInfo{
 		Callback:                cbSpec,
 		Trigger:                 trigger,
-		RegistrationTime:        cb.RegistrationTime,
+		RegistrationTime:        common.CloneProto(cb.RegistrationTime),
 		State:                   state,
 		Attempt:                 cb.Attempt,
-		LastAttemptCompleteTime: cb.LastAttemptCompleteTime,
-		LastAttemptFailure:      cb.LastAttemptFailure,
-		NextAttemptScheduleTime: cb.NextAttemptScheduleTime,
+		LastAttemptCompleteTime: common.CloneProto(cb.LastAttemptCompleteTime),
+		LastAttemptFailure:      common.CloneProto(cb.LastAttemptFailure),
+		NextAttemptScheduleTime: common.CloneProto(cb.NextAttemptScheduleTime),
 		BlockedReason:           blockedReason,
 	}, nil
 }

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/stretchr/testify/require"
 	activitypb "go.temporal.io/api/activity/v1"
+	callbackpb "go.temporal.io/api/callback/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
@@ -9886,6 +9887,31 @@ func (env *standaloneActivityEnv) runNexusCompletionHTTPServer(t *testing.T, h *
 	return srv.URL
 }
 
+// awaitCallbackInfo polls DescribeActivityExecution until the activity's single completion
+// callback reaches wantState, and returns that CallbackInfo.
+func (env *standaloneActivityEnv) awaitCallbackInfo(
+	ctx context.Context,
+	t *testing.T,
+	activityID string,
+	wantState enumspb.CallbackState,
+) *callbackpb.CallbackInfo {
+	t.Helper()
+	var cbInfo *callbackpb.CallbackInfo
+	await.Require(ctx, t, func(c *await.T) {
+		descResp, err := env.FrontendClient().DescribeActivityExecution(c.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+		})
+		require.NoError(c, err)
+		require.Len(c, descResp.GetCallbacks(), 1)
+		cbInfo = descResp.GetCallbacks()[0].GetInfo()
+		require.NotNil(c, cbInfo)
+		require.Equal(c, wantState, cbInfo.GetState())
+	}, 10*time.Second, 100*time.Millisecond)
+	return cbInfo
+}
+
+// Tests verifying that completion callbacks attached to standalone Activities get triggered.
 func (s *standaloneActivityTestSuite) TestCallbacks() {
 	env := s.newTestEnv()
 	t := s.T()
@@ -10034,6 +10060,8 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		require.Equal(t, callbackURL, cbInfo.GetInfo().GetCallback().GetNexus().GetUrl())
 		require.Equal(t, enumspb.CALLBACK_STATE_STANDBY, cbInfo.GetInfo().GetState())
 		require.NotNil(t, cbInfo.GetInfo().GetRegistrationTime())
+		// Confirm there is no outcome, because the callback hasn't been triggered.
+		require.Nil(t, cbInfo.GetInfo().GetOutcome())
 	})
 
 	t.Run("ExceedsMaxCallbacksLimit", func(t *testing.T) {
@@ -10136,6 +10164,10 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, descResp.GetInfo().GetStatus())
+
+		// Wait for the callback to complete and verify.
+		cbInfo := env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SUCCEEDED)
+		require.NotNil(t, cbInfo.GetOutcome().GetSuccess())
 	})
 
 	t.Run("FailsWithCallbacks", func(t *testing.T) {
@@ -10210,6 +10242,11 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_FAILED, descResp.GetInfo().GetStatus())
+
+		// Wait for the callback to complete and verify.
+		// The Activity may have failed, but the callback reporting the failure should be successful.
+		cbInfo := env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SUCCEEDED)
+		require.NotNil(t, cbInfo.GetOutcome().GetSuccess())
 	})
 
 	t.Run("TerminatedWithCallbacks", func(t *testing.T) {
@@ -10285,6 +10322,10 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_TERMINATED, descResp.GetInfo().GetStatus())
+
+		// Wait for the callback to complete and verify.
+		cbInfo := env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SUCCEEDED)
+		require.NotNil(t, cbInfo.GetOutcome().GetSuccess())
 	})
 
 	t.Run("CanceledWithCallbacks", func(t *testing.T) {
@@ -10365,6 +10406,10 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_CANCELED, descResp.GetInfo().GetStatus())
+
+		// Wait for the callback to complete and verify.
+		cbInfo := env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SUCCEEDED)
+		require.NotNil(t, cbInfo.GetOutcome().GetSuccess())
 	})
 
 	// This test covers the timeout callback path using schedule-to-start, but the callback behavior
@@ -10428,6 +10473,112 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT, descResp.GetInfo().GetStatus())
+
+		// Confirm the callback was successful. (Receiving the timeout failure, verified above.)
+		cbInfo := env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SUCCEEDED)
+		require.NotNil(t, cbInfo.GetOutcome().GetSuccess())
+	})
+
+	// Verify that if the callback fails to be delivered for some reason, that the failure is
+	// persisted correctly and available from the Describe operation.
+	t.Run("CallbackDeliveryFailure", func(t *testing.T) {
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		ch := &completionHandler{
+			requestCh:         make(chan *nexusrpc.CompletionRequest, 1),
+			requestCompleteCh: make(chan error, 1),
+		}
+		defer func() {
+			close(ch.requestCh)
+			close(ch.requestCompleteCh)
+		}()
+		callbackAddress := env.runNexusCompletionHTTPServer(t, ch)
+
+		// Start and successfully complete a standalone Activity.
+		_, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:    env.Namespace().String(),
+			ActivityId:   activityID,
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
+			Input:        defaultInput,
+			TaskQueue: &taskqueuepb.TaskQueue{
+				Name: taskQueue,
+			},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			RequestId:           env.Tv().Any().String(),
+			CompletionCallbacks: []*commonpb.Callback{{
+				Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: callbackAddress}},
+			}},
+		})
+		require.NoError(t, err)
+
+		pollResp, err := env.FrontendClient().PollActivityTaskQueue(s.Context(), &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
+			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			Identity:  env.Tv().WorkerIdentity(),
+		})
+		require.NoError(t, err)
+
+		_, err = env.FrontendClient().RespondActivityTaskCompleted(s.Context(), &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
+			TaskToken: pollResp.TaskToken,
+			Result:    defaultResult,
+			Identity:  defaultIdentity,
+		})
+		require.NoError(t, err)
+
+		// Simulate the completion handler returning a retryable error followed by
+		// an unretryable error. Confirm the SAA's CallbackInfo includes the terminal
+		// failure.
+		for deliveryAttempt := 1; deliveryAttempt <= 2; deliveryAttempt++ {
+			select {
+			case completion := <-ch.requestCh:
+				// Pull the completion request from the channel.
+				require.Equal(t, nexus.OperationStateSucceeded, completion.State)
+				if deliveryAttempt == 1 {
+					// The first attempt to deliver the Activity's completion callback reports a retryable error.
+					// Call Describe and confirm the Callback has just been scheduled.
+					cbInfo := env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SCHEDULED)
+					require.EqualValues(t, 0, cbInfo.GetAttempt()) // zero attempts so far.
+					require.Nil(t, cbInfo.GetLastAttemptFailure())
+					require.Nil(t, cbInfo.GetOutcome())
+
+					// Retryable error.
+					ch.requestCompleteCh <- nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUnavailable, "delivery #1")
+				} else {
+					// The second attempt to deliver the Activity's completion callback should report a
+					// non-retryable error.
+					// Call Describe and confirm the CallbackInfo describes the previous delivery attempt.
+					cbInfo := env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SCHEDULED)
+					require.EqualValues(t, 1, cbInfo.GetAttempt()) // 1 attempt so far, the 2nd is in-progress.
+					require.NotNil(t, cbInfo.GetLastAttemptFailure())
+					require.Equal(t, "handler error (UNAVAILABLE): delivery #1", cbInfo.GetLastAttemptFailure().GetMessage())
+					require.Nil(t, cbInfo.GetOutcome())
+
+					// Unretryable error.
+					ch.requestCompleteCh <- nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "delivery #2")
+				}
+
+			case <-s.Context().Done():
+				require.Fail(t, "timed out waiting for completion callback")
+			}
+		}
+
+		// Verify the Activity is in completed state.
+		descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+		})
+		require.NoError(t, err)
+		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, descResp.GetInfo().GetStatus())
+
+		// Verify the completion callback delivery has failed.
+		cbInfo := env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_FAILED)
+		// Both the last delivery failure and the terminal failure come from delivery #2.
+		const lastDeliveryFailureMessage = "handler error (BAD_REQUEST): delivery #2"
+		require.Equal(t, lastDeliveryFailureMessage, cbInfo.GetLastAttemptFailure().GetMessage())
+		require.Equal(t, lastDeliveryFailureMessage, cbInfo.GetOutcome().GetFailure().GetMessage())
 	})
 }
 
@@ -10476,15 +10627,6 @@ func (s *standaloneActivityTestSuite) TestCallbacksDisabled() {
 		})
 		require.ErrorContains(t, err, "completion callbacks are not enabled for this namespace")
 	})
-}
-
-func (s *standaloneActivityTestSuite) runNexusCompletionHTTPServer(t *testing.T, h *completionHandler) string {
-	hh := nexusrpc.NewCompletionHTTPHandler(nexusrpc.CompletionHandlerOptions{Handler: h})
-	srv := httptest.NewServer(hh)
-	t.Cleanup(func() {
-		srv.Close()
-	})
-	return srv.URL
 }
 
 func (s *standaloneActivityTestSuite) TestPauseActivityExecution() {

--- a/tests/nexus_standalone_callbacks_test.go
+++ b/tests/nexus_standalone_callbacks_test.go
@@ -1,0 +1,373 @@
+package tests
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	apinexusoperationpb "go.temporal.io/api/nexusoperation/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/chasm/lib/callback"
+	"go.temporal.io/server/chasm/lib/nexusoperation"
+	commonnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/nexus/nexusrpc"
+	"go.temporal.io/server/common/nexus/nexustest"
+	"go.temporal.io/server/common/testing/testvars"
+	"go.temporal.io/server/tests/testcore"
+)
+
+// newCallbackTestEnv builds an env with standalone Nexus operations and their completion callbacks
+// enabled, and with the callback address allowlist opened up so that a local httptest server is a
+// valid callback target.
+func (s *NexusStandaloneTestSuite) newCallbackTestEnv() *NexusTestEnv {
+	env := s.newTestEnv(testcore.WithDynamicConfig(nexusoperation.EnableNexusCallbacks, true))
+	env.OverrideDynamicConfig(
+		callback.AllowedAddresses,
+		[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}},
+	)
+	return env
+}
+
+// runNexusCompletionHTTPServer stands up a Nexus completion endpoint and returns its URL, for use as
+// the target of a completion callback.
+func (s *NexusStandaloneTestSuite) runNexusCompletionHTTPServer(t *testing.T, h *completionHandler) string {
+	srv := httptest.NewServer(nexusrpc.NewCompletionHTTPHandler(nexusrpc.CompletionHandlerOptions{Handler: h}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func newCompletionHandler(t *testing.T) *completionHandler {
+	h := &completionHandler{
+		requestCh:         make(chan *nexusrpc.CompletionRequest, 1),
+		requestCompleteCh: make(chan error, 1),
+	}
+	t.Cleanup(func() {
+		close(h.requestCh)
+		close(h.requestCompleteCh)
+	})
+	return h
+}
+
+// awaitCompletion returns the next completion delivered to the handler, acknowledging it before
+// returning. Assertions must run against the returned value rather than inside the handler: leaving
+// the handler blocked stalls the server's Close and makes the callback look like a delivery timeout,
+// which turns any assertion failure into a test timeout instead of a readable failure.
+func (s *NexusStandaloneTestSuite) awaitCompletion(h *completionHandler) *nexusrpc.CompletionRequest {
+	s.T().Helper()
+
+	select {
+	case completion := <-h.requestCh:
+		h.requestCompleteCh <- nil
+		return completion
+	case <-s.Context().Done():
+		s.FailNow("timed out waiting for the completion callback")
+		return nil
+	}
+}
+
+func nexusCompletionCallback(url string) *commonpb.Callback {
+	return &commonpb.Callback{
+		Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: url}},
+	}
+}
+
+// awaitCallbackInfos polls DescribeNexusOperationExecution until it reports wantCount callbacks all in
+// wantState, and returns them.
+func (s *NexusStandaloneTestSuite) awaitCallbackInfos(
+	env *NexusTestEnv,
+	operationID string,
+	wantCount int,
+	wantState enumspb.CallbackState,
+) []*apinexusoperationpb.CallbackInfo {
+	s.T().Helper()
+
+	var infos []*apinexusoperationpb.CallbackInfo
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+			Namespace:   env.Namespace().String(),
+			OperationId: operationID,
+		})
+		require.NoError(t, err)
+		infos = descResp.GetCompletionCallbacks()
+		require.Len(t, infos, wantCount)
+		for _, info := range infos {
+			require.Equal(t, wantState, info.GetInfo().GetState())
+		}
+	}, 15*time.Second, 100*time.Millisecond)
+	return infos
+}
+
+// TestStandaloneNexusOperationCallbacks covers completion callbacks attached to a standalone Nexus
+// operation: that they are delivered when the operation closes, that they are reported by describe,
+// and that unsupported requests are rejected.
+func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCallbacks() {
+	s.Run("DeliveredOnSuccess", func(s *NexusStandaloneTestSuite) {
+		env := s.newCallbackTestEnv()
+		t := s.T()
+
+		// The handler completes the operation synchronously, so it closes as soon as it is dispatched.
+		endpointName := env.createRandomExternalNexusServer(s.Context(), t, nexustest.Handler{
+			OnStartOperation: func(
+				ctx context.Context,
+				service, operation string,
+				input *nexus.LazyValue,
+				options nexus.StartOperationOptions,
+			) (nexus.HandlerStartOperationResult[any], error) {
+				return &nexus.HandlerStartOperationResultSync[any]{Value: "operation-result"}, nil
+			},
+		})
+
+		handler := newCompletionHandler(t)
+		callbackURL := s.runNexusCompletionHTTPServer(t, handler)
+
+		operationID := testvars.New(t).Any().String()
+		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         operationID,
+			Endpoint:            endpointName,
+			CompletionCallbacks: []*commonpb.Callback{nexusCompletionCallback(callbackURL)},
+		})
+		s.NoError(err)
+		s.True(startResp.GetStarted())
+
+		completion := s.awaitCompletion(handler)
+		s.Equal(nexus.OperationStateSucceeded, completion.State)
+		s.Nil(completion.Error)
+		s.False(completion.StartTime.IsZero())
+		s.False(completion.CloseTime.IsZero())
+		// The completion carries a back-link to the operation that produced it.
+		wantLink := commonnexus.ConvertLinkNexusOperationToNexusLink(&commonpb.Link_NexusOperation{
+			Namespace:   env.Namespace().String(),
+			OperationId: operationID,
+			RunId:       startResp.GetRunId(),
+		})
+		s.Len(completion.Links, 1)
+		if len(completion.Links) == 1 {
+			s.Equal(wantLink.URL.String(), completion.Links[0].URL.String())
+			s.Equal(wantLink.Type, completion.Links[0].Type)
+		}
+
+		infos := s.awaitCallbackInfos(env, operationID, 1, enumspb.CALLBACK_STATE_SUCCEEDED)
+		s.Equal(callbackURL, infos[0].GetInfo().GetCallback().GetNexus().GetUrl())
+		s.NotNil(infos[0].GetInfo().GetOutcome().GetSuccess())
+		s.NotNil(infos[0].GetTrigger().GetOperationCompleted())
+	})
+
+	s.Run("DeliveredOnFailure", func(s *NexusStandaloneTestSuite) {
+		env := s.newCallbackTestEnv()
+		t := s.T()
+
+		endpointName := env.createRandomExternalNexusServer(s.Context(), t, nexustest.Handler{
+			OnStartOperation: func(
+				ctx context.Context,
+				service, operation string,
+				input *nexus.LazyValue,
+				options nexus.StartOperationOptions,
+			) (nexus.HandlerStartOperationResult[any], error) {
+				return nil, &nexus.OperationError{
+					State: nexus.OperationStateFailed,
+					Cause: &nexus.FailureError{Failure: nexus.Failure{Message: "deliberate failure"}},
+				}
+			},
+		})
+
+		handler := newCompletionHandler(t)
+		callbackURL := s.runNexusCompletionHTTPServer(t, handler)
+
+		operationID := testvars.New(t).Any().String()
+		_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         operationID,
+			Endpoint:            endpointName,
+			CompletionCallbacks: []*commonpb.Callback{nexusCompletionCallback(callbackURL)},
+		})
+		s.NoError(err)
+
+		completion := s.awaitCompletion(handler)
+		s.Equal(nexus.OperationStateFailed, completion.State)
+		s.Require().NotNil(completion.Error)
+		var failureErr *nexus.FailureError
+		s.Require().ErrorAs(completion.Error.Cause, &failureErr)
+		// The handler's error is wrapped as an OperationError whose cause carries the original
+		// message, which is how a Nexus operation failure round-trips through a completion.
+		tFailure, convErr := commonnexus.NexusFailureToTemporalFailure(failureErr.Failure)
+		s.NoError(convErr)
+		s.Equal("OperationError", tFailure.GetApplicationFailureInfo().GetType())
+		s.Equal("deliberate failure", tFailure.GetCause().GetMessage())
+
+		s.awaitCallbackInfos(env, operationID, 1, enumspb.CALLBACK_STATE_SUCCEEDED)
+	})
+
+	s.Run("DescribeReportsStandbyBeforeClose", func(s *NexusStandaloneTestSuite) {
+		env := s.newCallbackTestEnv()
+		t := s.T()
+
+		// The operation stays STARTED, so its callbacks stay in STANDBY.
+		endpointName := env.createRandomExternalNexusServer(s.Context(), t, nexustest.Handler{
+			OnStartOperation: func(
+				ctx context.Context,
+				service, operation string,
+				input *nexus.LazyValue,
+				options nexus.StartOperationOptions,
+			) (nexus.HandlerStartOperationResult[any], error) {
+				return &nexus.HandlerStartOperationResultAsync{OperationToken: "test-operation-token"}, nil
+			},
+		})
+
+		operationID := testvars.New(t).Any().String()
+		_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId: operationID,
+			Endpoint:    endpointName,
+			CompletionCallbacks: []*commonpb.Callback{
+				nexusCompletionCallback("http://localhost/cb1"),
+				nexusCompletionCallback("http://localhost/cb2"),
+			},
+		})
+		s.NoError(err)
+
+		infos := s.awaitCallbackInfos(env, operationID, 2, enumspb.CALLBACK_STATE_STANDBY)
+		for _, info := range infos {
+			s.Nil(info.GetInfo().GetOutcome())
+			s.NotNil(info.GetInfo().GetRegistrationTime())
+		}
+	})
+
+	s.Run("AttachOnConflict", func(s *NexusStandaloneTestSuite) {
+		env := s.newCallbackTestEnv()
+		t := s.T()
+
+		endpointName := env.createRandomExternalNexusServer(s.Context(), t, nexustest.Handler{
+			OnStartOperation: func(
+				ctx context.Context,
+				service, operation string,
+				input *nexus.LazyValue,
+				options nexus.StartOperationOptions,
+			) (nexus.HandlerStartOperationResult[any], error) {
+				return &nexus.HandlerStartOperationResultAsync{OperationToken: "test-operation-token"}, nil
+			},
+		})
+
+		operationID := testvars.New(t).Any().String()
+		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         operationID,
+			Endpoint:            endpointName,
+			RequestId:           "first-request",
+			CompletionCallbacks: []*commonpb.Callback{nexusCompletionCallback("http://localhost/cb1")},
+		})
+		s.NoError(err)
+		s.True(startResp.GetStarted())
+
+		attachReq := &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         operationID,
+			Endpoint:            endpointName,
+			RequestId:           "second-request",
+			CompletionCallbacks: []*commonpb.Callback{nexusCompletionCallback("http://localhost/cb2")},
+			IdConflictPolicy:    enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_USE_EXISTING,
+			OnConflictOptions: &apinexusoperationpb.OnConflictOptions{
+				AttachRequestId:           true,
+				AttachCompletionCallbacks: true,
+			},
+		}
+		attachResp, err := s.startNexusOperation(env, attachReq)
+		s.NoError(err)
+		s.False(attachResp.GetStarted(), "the second request must not have created an operation")
+		s.Equal(startResp.GetRunId(), attachResp.GetRunId())
+
+		infos := s.awaitCallbackInfos(env, operationID, 2, enumspb.CALLBACK_STATE_STANDBY)
+		s.Equal("http://localhost/cb1", infos[0].GetInfo().GetCallback().GetNexus().GetUrl())
+		s.Equal("http://localhost/cb2", infos[1].GetInfo().GetCallback().GetNexus().GetUrl())
+
+		// Replaying the same attach must not duplicate the callback it already attached.
+		_, err = s.startNexusOperation(env, attachReq)
+		s.NoError(err)
+		s.awaitCallbackInfos(env, operationID, 2, enumspb.CALLBACK_STATE_STANDBY)
+	})
+
+	s.Run("RejectsUnsupportedVariants", func(s *NexusStandaloneTestSuite) {
+		env := s.newCallbackTestEnv()
+		t := s.T()
+
+		endpointName := env.createRandomExternalNexusServer(s.Context(), t, nexustest.Handler{})
+
+		for name, cb := range map[string]*commonpb.Callback{
+			// Worker callbacks are a newer API addition that standalone Nexus operations, like
+			// standalone activities, do not support yet.
+			"worker": {Variant: &commonpb.Callback_Worker_{Worker: &commonpb.Callback_Worker{
+				TaskQueueName: "completions-task-queue",
+				Service:       "HTTPAdapter",
+				Operation:     "DeliverAsWebhook",
+			}}},
+			"internal": {Variant: &commonpb.Callback_Internal_{Internal: &commonpb.Callback_Internal{
+				Data: []byte("data"),
+			}}},
+			"unset": {},
+		} {
+			s.Run(name, func(s *NexusStandaloneTestSuite) {
+				_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
+					OperationId:         testvars.New(s.T()).Any().String(),
+					Endpoint:            endpointName,
+					CompletionCallbacks: []*commonpb.Callback{cb},
+				})
+				var invalidArgErr *serviceerror.InvalidArgument
+				s.ErrorAs(err, &invalidArgErr)
+				s.ErrorContains(err, "unsupported callback variant")
+			})
+		}
+	})
+
+	s.Run("RejectsAttachLinks", func(s *NexusStandaloneTestSuite) {
+		env := s.newCallbackTestEnv()
+
+		// The start request carries no links, so attach_links cannot be honored.
+		_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         testvars.New(s.T()).Any().String(),
+			Endpoint:            env.createRandomExternalNexusServer(s.Context(), s.T(), nexustest.Handler{}),
+			CompletionCallbacks: []*commonpb.Callback{nexusCompletionCallback("http://localhost/cb")},
+			OnConflictOptions: &apinexusoperationpb.OnConflictOptions{
+				AttachRequestId:           true,
+				AttachCompletionCallbacks: true,
+				AttachLinks:               true,
+			},
+		})
+		var unimplementedErr *serviceerror.Unimplemented
+		s.ErrorAs(err, &unimplementedErr)
+		s.ErrorContains(err, "attach_links is not supported")
+	})
+}
+
+// TestStandaloneNexusOperationCallbacksDisabled confirms the per-namespace feature flag gates the
+// whole surface, including the on-conflict attach path.
+func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCallbacksDisabled() {
+	// newTestEnv leaves nexusoperation.EnableNexusCallbacks at its default of false.
+	env := s.newTestEnv()
+	endpointName := env.createRandomExternalNexusServer(s.Context(), s.T(), nexustest.Handler{})
+	cbs := []*commonpb.Callback{nexusCompletionCallback("http://localhost/cb")}
+
+	s.Run("StartWithCallbacksFails", func(s *NexusStandaloneTestSuite) {
+		_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         testvars.New(s.T()).Any().String(),
+			Endpoint:            endpointName,
+			CompletionCallbacks: cbs,
+		})
+		s.ErrorContains(err, "completion callbacks are not enabled for this namespace")
+	})
+
+	s.Run("OnConflictAttachCallbacksFails", func(s *NexusStandaloneTestSuite) {
+		_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         testvars.New(s.T()).Any().String(),
+			Endpoint:            endpointName,
+			CompletionCallbacks: cbs,
+			IdConflictPolicy:    enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_USE_EXISTING,
+			OnConflictOptions: &apinexusoperationpb.OnConflictOptions{
+				AttachRequestId:           true,
+				AttachCompletionCallbacks: true,
+			},
+		})
+		s.ErrorContains(err, "completion callbacks are not enabled for this namespace")
+	})
+}

--- a/tests/nexus_standalone_callbacks_test.go
+++ b/tests/nexus_standalone_callbacks_test.go
@@ -108,8 +108,9 @@ func (s *NexusStandaloneTestSuite) awaitCallbackInfos(
 // operation: that they are delivered when the operation closes, that they are reported by describe,
 // and that unsupported requests are rejected.
 func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCallbacks() {
+	env := s.newCallbackTestEnv()
+
 	s.Run("DeliveredOnSuccess", func(s *NexusStandaloneTestSuite) {
-		env := s.newCallbackTestEnv()
 		t := s.T()
 
 		// The handler completes the operation synchronously, so it closes as soon as it is dispatched.
@@ -160,7 +161,6 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCallbacks() {
 	})
 
 	s.Run("DeliveredOnFailure", func(s *NexusStandaloneTestSuite) {
-		env := s.newCallbackTestEnv()
 		t := s.T()
 
 		endpointName := env.createRandomExternalNexusServer(s.Context(), t, nexustest.Handler{
@@ -204,7 +204,6 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCallbacks() {
 	})
 
 	s.Run("DescribeReportsStandbyBeforeClose", func(s *NexusStandaloneTestSuite) {
-		env := s.newCallbackTestEnv()
 		t := s.T()
 
 		// The operation stays STARTED, so its callbacks stay in STANDBY.
@@ -238,7 +237,6 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCallbacks() {
 	})
 
 	s.Run("AttachOnConflict", func(s *NexusStandaloneTestSuite) {
-		env := s.newCallbackTestEnv()
 		t := s.T()
 
 		endpointName := env.createRandomExternalNexusServer(s.Context(), t, nexustest.Handler{
@@ -289,7 +287,6 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCallbacks() {
 	})
 
 	s.Run("RejectsUnsupportedVariants", func(s *NexusStandaloneTestSuite) {
-		env := s.newCallbackTestEnv()
 		t := s.T()
 
 		endpointName := env.createRandomExternalNexusServer(s.Context(), t, nexustest.Handler{})
@@ -321,8 +318,6 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCallbacks() {
 	})
 
 	s.Run("RejectsAttachLinks", func(s *NexusStandaloneTestSuite) {
-		env := s.newCallbackTestEnv()
-
 		// The start request carries no links, so attach_links cannot be honored.
 		_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
 			OperationId:         testvars.New(s.T()).Any().String(),


### PR DESCRIPTION
⚠️ This is part of a stacked PR set, to be merged into `chrsmith/wc-persist-callback-terminal-failures`. This will not go directly into `main`, until the overall feature is code complete.

---

## What changed?

The API surface area for the worker callbacks feature adds a new `completion_callbacks` field to SANOs, allowing users to register callbacks to be executed when the SANO completes. (Just like standalone Activities.)

This PR implements that feature for SANO, allowing completion callbacks to be added, executed, and for their status to be reported by the `DescribeNexusOperationExecution` endpoint.

However, this new capability is guarded by a per-namespace dynamic config value `"nexusoperation.enableNexusCallbacks"`. Attempts to attach worker callbacks to SANO will fail, and namespaces will need to opt-into using this new feature.

## Why?

This is part of the overall worker callbacks feature. (With worker callbacks being a specific kind of completion callback you can attach to SANO.) Worker-variant callbacks are still not supported in this PR. Only Nexus- and Internal- variant callbacks will be accepted, if the feature is enabled.

## How did you test it?

- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

## Potential risks

- It's essentially a new feature, and so there are lots of edge cases we need to consider. For example, that repeated calls to `Start-` are idempotent. That the `on_conflict_options` are honored, etc. Otherwise, we run the risk of SANO being slightly inconsistent with how completion callbacks work for standalone Activities.

> I added a comment to call out a minor bug in standalone Activities. It's already on the ACT team's radar. On the [SAA bugs punch list](https://app.notion.com/p/temporalio/SAA-bug-claims-3a08fc5677388009a690cff570aeaa45?source=copy_link).
> "FT C9. On-conflict callback attachment is not idempotent or atomic"

