### PR TITLE
Fix SAA deferred restore cancellation test coverage

### DIFF
--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -907,6 +907,22 @@ func TestTransitionCancelRequested(t *testing.T) {
 	require.NotNil(t, cancelState.GetRequestTime())
 }
 
+func TestTransitionCancelRequestedClearsDeferredOptionRestore(t *testing.T) {
+	ctx := &chasm.MockMutableContext{}
+	ctx.HandleNow = func(chasm.Component) time.Time { return defaultTime }
+	activity := &Activity{
+		ActivityState: &activitypb.ActivityState{
+			Status:              activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
+			ResetRestoreOptions: true,
+		},
+	}
+
+	err := TransitionCancelRequested.Apply(activity, ctx, &workflowservice.RequestCancelActivityExecutionRequest{})
+	require.NoError(t, err)
+	require.Equal(t, activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED, activity.Status)
+	require.False(t, activity.ResetRestoreOptions)
+}
+
 func TestTransitionCanceled(t *testing.T) {
 	testCases := []struct {
 		name       string

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -13508,10 +13508,8 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		waitForState(ctx, t, activityID, startResp.GetRunId(), enumspb.PENDING_ACTIVITY_STATE_PAUSED)
 	})
 
-	// UpdateOptions while a Reset(RestoreOriginalOptions) is deferred (worker still running, restore
-	// pending) is rejected outright: the pending restore unconditionally overwrites every option
-	// field from OriginalOptions when it lands (see applyDeferredOptionRestore). UpdateOptions is
-	// also rejected for every RESET_REQUESTED activity, regardless of whether a restore is pending.
+	// UpdateOptions is rejected for any RESET_REQUESTED activity, which includes the window while a
+	// Reset(RestoreOriginalOptions) is deferred because the worker is still running.
 	t.Run("UpdateOptionsWhileDeferredRestorePendingFails", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -13510,9 +13510,8 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 
 	// UpdateOptions while a Reset(RestoreOriginalOptions) is deferred (worker still running, restore
 	// pending) is rejected outright: the pending restore unconditionally overwrites every option
-	// field from OriginalOptions when it lands (see applyDeferredOptionRestore), so an intervening
-	// UpdateOptions call would silently be reverted rather than take effect. RESET_REQUESTED without
-	// a pending restore still permits updates (see UpdateOptionsPreservesTimeoutsWhileResetRequested).
+	// field from OriginalOptions when it lands (see applyDeferredOptionRestore). UpdateOptions is
+	// also rejected for every RESET_REQUESTED activity, regardless of whether a restore is pending.
 	t.Run("UpdateOptionsWhileDeferredRestorePendingFails", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
@@ -13545,51 +13544,6 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.ErrorAs(t, err, &failedPreconditionErr)
 
 		completeAttempt(ctx, t, pollResp1.TaskToken)
-	})
-
-	// UpdateOptionsAllowedAfterDeferredRestoreSupersededByCancel: once a cancellation supersedes a
-	// deferred Reset(RestoreOriginalOptions), the restore can never land, so the pending-restore
-	// guard on UpdateOptions must not outlive it — otherwise UpdateOptions would be rejected for the
-	// rest of the activity's life instead of just the window during which the restore was pending.
-	t.Run("UpdateOptionsAllowedAfterDeferredRestoreSupersededByCancel", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-
-		activityID := testcore.RandomizeStr(t.Name())
-		startResp, pollResp1, _ := startAndPollActivity(ctx, t, activityID, &commonpb.RetryPolicy{
-			InitialInterval:    durationpb.New(time.Second),
-			BackoffCoefficient: 1.0,
-		})
-		require.EqualValues(t, 1, pollResp1.Attempt)
-
-		_, err := env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
-			Namespace:              env.Namespace().String(),
-			ActivityId:             activityID,
-			RunId:                  startResp.GetRunId(),
-			RestoreOriginalOptions: true,
-		})
-		require.NoError(t, err)
-
-		_, err = env.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
-			Namespace:  env.Namespace().String(),
-			ActivityId: activityID,
-			RunId:      startResp.GetRunId(),
-			Identity:   defaultIdentity,
-			Reason:     "test-cancel",
-			RequestId:  testcore.RandomizeStr(t.Name()),
-		})
-		require.NoError(t, err)
-
-		_, err = env.FrontendClient().UpdateActivityExecutionOptions(ctx, &workflowservice.UpdateActivityExecutionOptionsRequest{
-			Namespace:  env.Namespace().String(),
-			ActivityId: activityID,
-			RunId:      startResp.GetRunId(),
-			ActivityOptions: &activitypb.ActivityOptions{
-				StartToCloseTimeout: durationpb.New(30 * time.Second),
-			},
-			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"start_to_close_timeout"}},
-		})
-		require.NoError(t, err, "the superseded restore must not block UpdateOptions once cancel is pending")
 	})
 
 	// startAttemptWithTimeouts starts a SAA with the given per-attempt timeouts and retry policy and


### PR DESCRIPTION
## What changed?
Removed the UpdateOptionsAllowedAfterDeferredRestoreSupersededByCancel functional test and added focused unit coverage verifying that TransitionCancelRequested clears ResetRestoreOptions.

Also corrected the nearby comment claiming that UpdateOptions was permitted in RESET_REQUESTED when no restore was pending.

## Why?
PR #11394 disallowed UpdateOptions in CANCEL_REQUESTED and RESET_REQUESTED. PR #11358 later added a conflicting test expecting an update to succeed after cancel superseded a deferred restore.

The test was removed instead of changed to expect an error because that result is already covered by UpdateWhileCancelRequestedFails. It also could not verify whether the deferred restore flag was cleared: both a cleared and stale flag produce the same FailedPrecondition while the activity is CANCEL_REQUESTED.

## How did you test it?
- [X] built
- [] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)
