### PR TITLE
SAA / WFA parity fix: do not reset heartbeats by default

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1136,8 +1136,6 @@ func (a *Activity) recordPauseState(
 	a.emitOnPausedMetrics(event.metricsHandler)
 }
 
-// clearHeartbeatDetails discards the heartbeat checkpoint, so that the next attempt starts without
-// one rather than resuming from it.
 func (a *Activity) clearHeartbeatDetails(ctx chasm.MutableContext) {
 	if hb, ok := a.LastHeartbeat.TryGet(ctx); ok {
 		hb.Details = nil
@@ -1145,8 +1143,6 @@ func (a *Activity) clearHeartbeatDetails(ctx chasm.MutableContext) {
 	}
 }
 
-// reset rewinds the activity to attempt 1, keeping the heartbeat checkpoint so that a long-running
-// activity resumes from it, unless the request asked for the checkpoint to be discarded.
 func (a *Activity) reset(ctx chasm.MutableContext, event resetEvent) {
 	attempt := a.LastAttempt.Get(ctx)
 	attempt.Count = 1

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1136,20 +1136,14 @@ func (a *Activity) recordPauseState(
 	a.emitOnPausedMetrics(event.metricsHandler)
 }
 
-func (a *Activity) clearHeartbeatDetails(ctx chasm.MutableContext) {
-	if hb, ok := a.LastHeartbeat.TryGet(ctx); ok {
-		hb.Details = nil
-		hb.RecordedTime = nil
-	}
-}
-
+// reset rewinds the activity to attempt 1. The heartbeat checkpoint is deliberately left in place
+// so that a long-running activity resumes from it on the new attempt.
 func (a *Activity) reset(ctx chasm.MutableContext, event resetEvent) {
 	attempt := a.LastAttempt.Get(ctx)
 	attempt.Count = 1
 	attempt.Stamp++
 	attempt.CurrentRetryInterval = nil
 	attempt.CurrentRetryIntervalSource = activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED
-	a.clearHeartbeatDetails(ctx)
 	dispatchTime := a.dispatchTimeRespectingStartDelay(event.resetTime)
 	attempt.DispatchTime = timestamppb.New(dispatchTime)
 	if timeout := a.GetScheduleToStartTimeout().AsDuration(); timeout > 0 {
@@ -1285,7 +1279,6 @@ func (a *Activity) resetKeepPaused(
 	attempt.CurrentRetryInterval = nil
 	attempt.CurrentRetryIntervalSource = activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED
 	attempt.DispatchTime = nil
-	a.clearHeartbeatDetails(ctx)
 	a.emitOnResetMetrics(metricsHandler)
 	return &activitypb.ResetActivityExecutionResponse{}, nil
 }

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -1136,14 +1136,26 @@ func (a *Activity) recordPauseState(
 	a.emitOnPausedMetrics(event.metricsHandler)
 }
 
-// reset rewinds the activity to attempt 1. The heartbeat checkpoint is deliberately left in place
-// so that a long-running activity resumes from it on the new attempt.
+// clearHeartbeatDetails discards the heartbeat checkpoint, so that the next attempt starts without
+// one rather than resuming from it.
+func (a *Activity) clearHeartbeatDetails(ctx chasm.MutableContext) {
+	if hb, ok := a.LastHeartbeat.TryGet(ctx); ok {
+		hb.Details = nil
+		hb.RecordedTime = nil
+	}
+}
+
+// reset rewinds the activity to attempt 1, keeping the heartbeat checkpoint so that a long-running
+// activity resumes from it, unless the request asked for the checkpoint to be discarded.
 func (a *Activity) reset(ctx chasm.MutableContext, event resetEvent) {
 	attempt := a.LastAttempt.Get(ctx)
 	attempt.Count = 1
 	attempt.Stamp++
 	attempt.CurrentRetryInterval = nil
 	attempt.CurrentRetryIntervalSource = activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED
+	if event.req.GetResetHeartbeat() {
+		a.clearHeartbeatDetails(ctx)
+	}
 	dispatchTime := a.dispatchTimeRespectingStartDelay(event.resetTime)
 	attempt.DispatchTime = timestamppb.New(dispatchTime)
 	if timeout := a.GetScheduleToStartTimeout().AsDuration(); timeout > 0 {
@@ -1223,7 +1235,7 @@ func (a *Activity) handleReset(
 			a.restoreOriginalOptions(ctx)
 		}
 		if frontendReq.GetKeepPaused() {
-			return a.resetKeepPaused(ctx, metricsHandler)
+			return a.resetKeepPaused(ctx, frontendReq, metricsHandler)
 		}
 		// No keepPaused: perform an immediate reset. restoreOriginalOptions (if requested) already
 		// ran above, so skip it in resetImmediately to avoid restoring twice.
@@ -1259,6 +1271,9 @@ func (a *Activity) deferResetWhileRunning(
 	if frontendReq.GetRestoreOriginalOptions() {
 		a.ResetRestoreOptions = true
 	}
+	if frontendReq.GetResetHeartbeat() {
+		a.ResetShouldClearHeartbeat = true
+	}
 	// keepPaused on a paused (PAUSE_REQUESTED) activity preserves the pause: when the worker
 	// yields the activity lands back in PAUSED rather than SCHEDULED.
 	a.ResetShouldPause = keepPaused && pauseRequested
@@ -1271,6 +1286,7 @@ func (a *Activity) deferResetWhileRunning(
 
 func (a *Activity) resetKeepPaused(
 	ctx chasm.MutableContext,
+	frontendReq *workflowservice.ResetActivityExecutionRequest,
 	metricsHandler metrics.Handler,
 ) (*activitypb.ResetActivityExecutionResponse, error) {
 	attempt := a.LastAttempt.Get(ctx)
@@ -1279,6 +1295,9 @@ func (a *Activity) resetKeepPaused(
 	attempt.CurrentRetryInterval = nil
 	attempt.CurrentRetryIntervalSource = activitypb.ACTIVITY_RETRY_INTERVAL_SOURCE_UNSPECIFIED
 	attempt.DispatchTime = nil
+	if frontendReq.GetResetHeartbeat() {
+		a.clearHeartbeatDetails(ctx)
+	}
 	a.emitOnResetMetrics(metricsHandler)
 	return &activitypb.ResetActivityExecutionResponse{}, nil
 }
@@ -1297,6 +1316,7 @@ func (a *Activity) resetImmediately(
 		resetTime = resetTime.Add(time.Duration(rand.Int63n(int64(jitter)))) //nolint:gosec
 	}
 	if err := TransitionReset.Apply(a, ctx, resetEvent{
+		req:            frontendReq,
 		resetTime:      resetTime,
 		metricsHandler: metricsHandler,
 	}); err != nil {
@@ -1595,6 +1615,16 @@ func (a *Activity) applyDeferredOptionRestore(ctx chasm.MutableContext) {
 	}
 	a.ResetRestoreOptions = false
 	a.restoreOriginalOptions(ctx)
+}
+
+// applyDeferredHeartbeatClear applies a Reset(ResetHeartbeat) that was deferred because a worker was
+// running an attempt at reset time (see handleReset).
+func (a *Activity) applyDeferredHeartbeatClear(ctx chasm.MutableContext) {
+	if !a.ResetShouldClearHeartbeat {
+		return
+	}
+	a.ResetShouldClearHeartbeat = false
+	a.clearHeartbeatDetails(ctx)
 }
 
 // restoreOriginalOptions resets the activity's options to the values it was originally scheduled

--- a/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
@@ -292,6 +292,12 @@ type ActivityState struct {
 	// terminate_state this is never cleared; unlike them it may be non-current (the activity may have
 	// since been unpaused), hence the "last" prefix. Its request_id is used to de-dupe pause requests.
 	LastPauseState *ActivityPauseState `protobuf:"bytes,16,opt,name=last_pause_state,json=lastPauseState,proto3" json:"last_pause_state,omitempty"`
+	// Set when a reset with reset_heartbeat=true is requested while a worker is running an attempt
+	// (STARTED / PAUSE_REQUESTED). Discarding the heartbeat checkpoint is deferred so that the
+	// in-flight attempt is left undisturbed; it happens when the worker yields and the activity
+	// transitions out of RESET_REQUESTED. For a non-running activity (SCHEDULED / PAUSED) the
+	// checkpoint is discarded immediately and this flag is not set.
+	ResetShouldClearHeartbeat bool `protobuf:"varint,17,opt,name=reset_should_clear_heartbeat,json=resetShouldClearHeartbeat,proto3" json:"reset_should_clear_heartbeat,omitempty"`
 	// Set when a reset is requested with keep_paused=true on a paused (PAUSE_REQUESTED) activity, so
 	// that when the worker yields the activity lands back in PAUSED rather than SCHEDULED. Consumed
 	// when the activity transitions out of RESET_REQUESTED.
@@ -458,6 +464,13 @@ func (x *ActivityState) GetLastPauseState() *ActivityPauseState {
 		return x.LastPauseState
 	}
 	return nil
+}
+
+func (x *ActivityState) GetResetShouldClearHeartbeat() bool {
+	if x != nil {
+		return x.ResetShouldClearHeartbeat
+	}
+	return false
 }
 
 func (x *ActivityState) GetResetShouldPause() bool {
@@ -1234,7 +1247,7 @@ var File_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto protor
 
 const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawDesc = "" +
 	"\n" +
-	"@temporal/server/chasm/lib/activity/proto/v1/activity_state.proto\x12+temporal.server.chasm.lib.activity.proto.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&temporal/api/activity/v1/message.proto\x1a$temporal/api/common/v1/message.proto\x1a(temporal/api/deployment/v1/message.proto\x1a$temporal/api/enums/v1/workflow.proto\x1a%temporal/api/failure/v1/message.proto\x1a'temporal/api/sdk/v1/user_metadata.proto\x1a'temporal/api/taskqueue/v1/message.proto\"\xf8\f\n" +
+	"@temporal/server/chasm/lib/activity/proto/v1/activity_state.proto\x12+temporal.server.chasm.lib.activity.proto.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&temporal/api/activity/v1/message.proto\x1a$temporal/api/common/v1/message.proto\x1a(temporal/api/deployment/v1/message.proto\x1a$temporal/api/enums/v1/workflow.proto\x1a%temporal/api/failure/v1/message.proto\x1a'temporal/api/sdk/v1/user_metadata.proto\x1a'temporal/api/taskqueue/v1/message.proto\"\xb9\r\n" +
 	"\rActivityState\x12I\n" +
 	"\ractivity_type\x18\x01 \x01(\v2$.temporal.api.common.v1.ActivityTypeR\factivityType\x12C\n" +
 	"\n" +
@@ -1254,7 +1267,8 @@ const file_temporal_server_chasm_lib_activity_proto_v1_activity_state_proto_rawD
 	"startDelay\x12T\n" +
 	"\x10original_options\x18\x0e \x01(\v2).temporal.api.activity.v1.ActivityOptionsR\x0foriginalOptions\x125\n" +
 	"\x17schedule_to_close_stamp\x18\x0f \x01(\x05R\x14scheduleToCloseStamp\x12i\n" +
-	"\x10last_pause_state\x18\x10 \x01(\v2?.temporal.server.chasm.lib.activity.proto.v1.ActivityPauseStateR\x0elastPauseState\x12,\n" +
+	"\x10last_pause_state\x18\x10 \x01(\v2?.temporal.server.chasm.lib.activity.proto.v1.ActivityPauseStateR\x0elastPauseState\x12?\n" +
+	"\x1creset_should_clear_heartbeat\x18\x11 \x01(\bR\x19resetShouldClearHeartbeat\x12,\n" +
 	"\x12reset_should_pause\x18\x12 \x01(\bR\x10resetShouldPause\x12W\n" +
 	"\x1afirst_attempt_started_time\x18\x13 \x01(\v2\x1a.google.protobuf.TimestampR\x17firstAttemptStartedTime\x122\n" +
 	"\x15reset_restore_options\x18\x14 \x01(\bR\x13resetRestoreOptions\x125\n" +

--- a/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
+++ b/chasm/lib/activity/gen/activitypb/v1/activity_state.pb.go
@@ -292,11 +292,10 @@ type ActivityState struct {
 	// terminate_state this is never cleared; unlike them it may be non-current (the activity may have
 	// since been unpaused), hence the "last" prefix. Its request_id is used to de-dupe pause requests.
 	LastPauseState *ActivityPauseState `protobuf:"bytes,16,opt,name=last_pause_state,json=lastPauseState,proto3" json:"last_pause_state,omitempty"`
-	// Set when a reset with reset_heartbeat=true is requested while a worker is running an attempt
-	// (STARTED / PAUSE_REQUESTED). Discarding the heartbeat checkpoint is deferred so that the
-	// in-flight attempt is left undisturbed; it happens when the worker yields and the activity
-	// transitions out of RESET_REQUESTED. For a non-running activity (SCHEDULED / PAUSED) the
-	// checkpoint is discarded immediately and this flag is not set.
+	// Set when a reset with reset_heartbeat=true is requested while a worker is running an attempt.
+	// Consumed when the worker yields and the activity transitions out of RESET_REQUESTED. For an
+	// activity with no attempt in progress the checkpoint is discarded immediately and this flag is
+	// not set.
 	ResetShouldClearHeartbeat bool `protobuf:"varint,17,opt,name=reset_should_clear_heartbeat,json=resetShouldClearHeartbeat,proto3" json:"reset_should_clear_heartbeat,omitempty"`
 	// Set when a reset is requested with keep_paused=true on a paused (PAUSE_REQUESTED) activity, so
 	// that when the worker yields the activity lands back in PAUSED rather than SCHEDULED. Consumed

--- a/chasm/lib/activity/handler.go
+++ b/chasm/lib/activity/handler.go
@@ -458,8 +458,8 @@ func (h *handler) ResetActivityExecution(ctx context.Context, req *activitypb.Re
 					WorkflowId: frontendReq.GetWorkflowId(),
 					RunId:      frontendReq.GetRunId(),
 				},
-				Activity:               &workflowservice.ResetActivityRequest_Id{Id: frontendReq.GetActivityId()},
-				ResetHeartbeat:         true,
+				Activity: &workflowservice.ResetActivityRequest_Id{Id: frontendReq.GetActivityId()},
+				// ResetActivityExecution has no reset_heartbeat flag and keeps the checkpoint.
 				RestoreOriginalOptions: frontendReq.GetRestoreOriginalOptions(),
 				KeepPaused:             frontendReq.GetKeepPaused(),
 				Jitter:                 frontendReq.GetJitter(),

--- a/chasm/lib/activity/handler.go
+++ b/chasm/lib/activity/handler.go
@@ -458,8 +458,8 @@ func (h *handler) ResetActivityExecution(ctx context.Context, req *activitypb.Re
 					WorkflowId: frontendReq.GetWorkflowId(),
 					RunId:      frontendReq.GetRunId(),
 				},
-				Activity: &workflowservice.ResetActivityRequest_Id{Id: frontendReq.GetActivityId()},
-				// ResetActivityExecution has no reset_heartbeat flag and keeps the checkpoint.
+				Activity:               &workflowservice.ResetActivityRequest_Id{Id: frontendReq.GetActivityId()},
+				ResetHeartbeat:         frontendReq.GetResetHeartbeat(),
 				RestoreOriginalOptions: frontendReq.GetRestoreOriginalOptions(),
 				KeepPaused:             frontendReq.GetKeepPaused(),
 				Jitter:                 frontendReq.GetJitter(),

--- a/chasm/lib/activity/model/vocabulary.go
+++ b/chasm/lib/activity/model/vocabulary.go
@@ -42,6 +42,7 @@ type Event struct {
 	Type EventType
 
 	KeepPaused          bool     // Reset: a paused activity stays paused across the reset.
+	ResetHeartbeat      bool     // Reset: discard the persisted heartbeat checkpoint instead of carrying it into the new attempt.
 	HasHeartbeatDetails bool     // Failure response: attach last_heartbeat_details, to be stored as the activity's heartbeat progress.
 	Failure             *Failure // RespondFailed: the failure to send, or nil to respond with no failure at all (as a worker may). A nil failure is retryable.
 }
@@ -90,6 +91,7 @@ var (
 	ResetKeepPaused                                 = Event{Type: ResetType, KeepPaused: true}
 	Unpause                                         = Event{Type: UnpauseType}
 	Reset                                           = Event{Type: ResetType}
+	ResetClearingHeartbeat                          = Event{Type: ResetType, ResetHeartbeat: true}
 	UpdateOptions                                   = Event{Type: UpdateOptionsType}
 	StartToCloseElapses                             = Event{Type: StartToCloseElapsesType}
 	ScheduleToCloseElapses                          = Event{Type: ScheduleToCloseElapsesType}
@@ -157,7 +159,7 @@ func (e Event) String() string {
 		}
 		return fmt.Sprintf("%s[heartbeatDetails=%v,failureType=%d]", e.Type.String(), e.HasHeartbeatDetails, e.Failure.Type)
 	case ResetType:
-		return fmt.Sprintf("%s[keepPaused=%v]", e.Type.String(), e.KeepPaused)
+		return fmt.Sprintf("%s[keepPaused=%v,resetHeartbeat=%v]", e.Type.String(), e.KeepPaused, e.ResetHeartbeat)
 	default:
 		return e.Type.String()
 	}

--- a/chasm/lib/activity/proto/v1/activity_state.proto
+++ b/chasm/lib/activity/proto/v1/activity_state.proto
@@ -128,6 +128,13 @@ message ActivityState {
   // since been unpaused), hence the "last" prefix. Its request_id is used to de-dupe pause requests.
   ActivityPauseState last_pause_state = 16;
 
+  // Set when a reset with reset_heartbeat=true is requested while a worker is running an attempt
+  // (STARTED / PAUSE_REQUESTED). Discarding the heartbeat checkpoint is deferred so that the
+  // in-flight attempt is left undisturbed; it happens when the worker yields and the activity
+  // transitions out of RESET_REQUESTED. For a non-running activity (SCHEDULED / PAUSED) the
+  // checkpoint is discarded immediately and this flag is not set.
+  bool reset_should_clear_heartbeat = 17;
+
   // Set when a reset is requested with keep_paused=true on a paused (PAUSE_REQUESTED) activity, so
   // that when the worker yields the activity lands back in PAUSED rather than SCHEDULED. Consumed
   // when the activity transitions out of RESET_REQUESTED.

--- a/chasm/lib/activity/proto/v1/activity_state.proto
+++ b/chasm/lib/activity/proto/v1/activity_state.proto
@@ -128,11 +128,10 @@ message ActivityState {
   // since been unpaused), hence the "last" prefix. Its request_id is used to de-dupe pause requests.
   ActivityPauseState last_pause_state = 16;
 
-  // Set when a reset with reset_heartbeat=true is requested while a worker is running an attempt
-  // (STARTED / PAUSE_REQUESTED). Discarding the heartbeat checkpoint is deferred so that the
-  // in-flight attempt is left undisturbed; it happens when the worker yields and the activity
-  // transitions out of RESET_REQUESTED. For a non-running activity (SCHEDULED / PAUSED) the
-  // checkpoint is discarded immediately and this flag is not set.
+  // Set when a reset with reset_heartbeat=true is requested while a worker is running an attempt.
+  // Consumed when the worker yields and the activity transitions out of RESET_REQUESTED. For an
+  // activity with no attempt in progress the checkpoint is discarded immediately and this flag is
+  // not set.
   bool reset_should_clear_heartbeat = 17;
 
   // Set when a reset is requested with keep_paused=true on a paused (PAUSE_REQUESTED) activity, so

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -337,8 +337,9 @@ var TransitionCancelRequested = chasm.NewTransition(
 			Reason:      req.GetReason(),
 			RequestTime: timestamppb.New(ctx.Now(a)),
 		}
-		// Cancel takes precedence over a pending reset so clear the flag
+		// Cancel takes precedence over a pending reset so clear its deferred intents
 		a.ResetRestoreOptions = false
+		a.ResetShouldClearHeartbeat = false
 
 		return nil
 	},
@@ -532,6 +533,7 @@ var TransitionAttemptFailedWhilePauseRequested = chasm.NewTransition(
 )
 
 type resetEvent struct {
+	req            *workflowservice.ResetActivityExecutionRequest
 	resetTime      time.Time
 	metricsHandler metrics.Handler
 }
@@ -585,6 +587,7 @@ var TransitionResetAttemptFailedToPaused = chasm.NewTransition(
 		attempt := a.LastAttempt.Get(ctx)
 		a.ResetShouldPause = false
 		a.applyDeferredOptionRestore(ctx)
+		a.applyDeferredHeartbeatClear(ctx)
 		attempt.Count = 1
 		attempt.Stamp++
 		if err := a.recordFailedAttempt(ctx, event.retryInterval, event.retryIntervalSource, event.failure, ctx.Now(a), false); err != nil {
@@ -613,6 +616,7 @@ var TransitionResetAttemptFailedToScheduled = chasm.NewTransition(
 
 		a.ResetShouldPause = false
 		a.applyDeferredOptionRestore(ctx)
+		a.applyDeferredHeartbeatClear(ctx)
 
 		attempt.Count = 1
 		attempt.Stamp++

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -585,7 +585,6 @@ var TransitionResetAttemptFailedToPaused = chasm.NewTransition(
 		attempt := a.LastAttempt.Get(ctx)
 		a.ResetShouldPause = false
 		a.applyDeferredOptionRestore(ctx)
-		a.clearHeartbeatDetails(ctx)
 		attempt.Count = 1
 		attempt.Stamp++
 		if err := a.recordFailedAttempt(ctx, event.retryInterval, event.retryIntervalSource, event.failure, ctx.Now(a), false); err != nil {
@@ -614,7 +613,6 @@ var TransitionResetAttemptFailedToScheduled = chasm.NewTransition(
 
 		a.ResetShouldPause = false
 		a.applyDeferredOptionRestore(ctx)
-		a.clearHeartbeatDetails(ctx)
 
 		attempt.Count = 1
 		attempt.Stamp++

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -1023,7 +1023,7 @@ func TestTransitionCanceled(t *testing.T) {
 	}
 }
 
-func TestTransitionResetClearsHeartbeat(t *testing.T) {
+func TestTransitionResetPreservesHeartbeat(t *testing.T) {
 	ctx := &chasm.MockMutableContext{}
 	ctx.HandleNow = func(chasm.Component) time.Time { return defaultTime }
 	attemptState := &activitypb.ActivityAttemptState{Count: 2}
@@ -1050,11 +1050,11 @@ func TestTransitionResetClearsHeartbeat(t *testing.T) {
 
 	err := TransitionReset.Apply(act, ctx, resetEvent{resetTime: defaultTime, metricsHandler: metrics.NoopMetricsHandler})
 	require.NoError(t, err)
-	require.Nil(t, act.LastHeartbeat.Get(ctx).GetDetails())
-	require.Nil(t, act.LastHeartbeat.Get(ctx).GetRecordedTime())
+	protorequire.ProtoEqual(t, payloads.EncodeString("heartbeat-details"), act.LastHeartbeat.Get(ctx).GetDetails())
+	require.Equal(t, timestamppb.New(defaultTime), act.LastHeartbeat.Get(ctx).GetRecordedTime())
 }
 
-func TestDeferredResetClearsHeartbeat(t *testing.T) {
+func TestDeferredResetPreservesHeartbeat(t *testing.T) {
 	testCases := []struct {
 		name              string
 		transition        chasm.Transition[activitypb.ActivityExecutionStatus, *Activity, rescheduleEvent]
@@ -1114,8 +1114,8 @@ func TestDeferredResetClearsHeartbeat(t *testing.T) {
 			require.Equal(t, tc.expectedStatus, act.Status)
 			require.Equal(t, int32(1), attemptState.Count)
 			require.Nil(t, attemptState.GetCurrentRetryInterval())
-			require.Nil(t, act.LastHeartbeat.Get(ctx).GetDetails())
-			require.Nil(t, act.LastHeartbeat.Get(ctx).GetRecordedTime())
+			protorequire.ProtoEqual(t, payloads.EncodeString("heartbeat-details"), act.LastHeartbeat.Get(ctx).GetDetails())
+			require.Equal(t, timestamppb.New(defaultTime), act.LastHeartbeat.Get(ctx).GetRecordedTime())
 			require.Len(t, ctx.Tasks, tc.expectedTaskCount)
 		})
 	}

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -1023,38 +1023,56 @@ func TestTransitionCanceled(t *testing.T) {
 	}
 }
 
-func TestTransitionResetPreservesHeartbeat(t *testing.T) {
-	ctx := &chasm.MockMutableContext{}
-	ctx.HandleNow = func(chasm.Component) time.Time { return defaultTime }
-	attemptState := &activitypb.ActivityAttemptState{Count: 2}
-	heartbeatState := &activitypb.ActivityHeartbeatState{
-		Details:      payloads.EncodeString("heartbeat-details"),
-		RecordedTime: timestamppb.New(defaultTime),
-	}
+// TestTransitionResetHeartbeat: reset keeps the heartbeat checkpoint unless the request asks for it
+// to be discarded.
+func TestTransitionResetHeartbeat(t *testing.T) {
+	for _, resetHeartbeat := range []bool{false, true} {
+		t.Run(fmt.Sprintf("resetHeartbeat=%v", resetHeartbeat), func(t *testing.T) {
+			ctx := &chasm.MockMutableContext{}
+			ctx.HandleNow = func(chasm.Component) time.Time { return defaultTime }
+			attemptState := &activitypb.ActivityAttemptState{Count: 2}
+			heartbeatState := &activitypb.ActivityHeartbeatState{
+				Details:      payloads.EncodeString("heartbeat-details"),
+				RecordedTime: timestamppb.New(defaultTime),
+			}
 
-	act := &Activity{
-		ActivityState: &activitypb.ActivityState{
-			ActivityType:           &commonpb.ActivityType{Name: "test-activity-type"},
-			RetryPolicy:            defaultRetryPolicy,
-			ScheduleToCloseTimeout: durationpb.New(defaultScheduleToCloseTimeout),
-			ScheduleToStartTimeout: durationpb.New(defaultScheduleToStartTimeout),
-			StartToCloseTimeout:    durationpb.New(defaultStartToCloseTimeout),
-			Status:                 activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
-			ScheduleTime:           timestamppb.New(defaultTime),
-			TaskQueue:              &taskqueuepb.TaskQueue{Name: "test-task-queue"},
-		},
-		LastAttempt:   chasm.NewDataField(ctx, attemptState),
-		LastHeartbeat: chasm.NewDataField(ctx, heartbeatState),
-		Outcome:       chasm.NewDataField(ctx, &activitypb.ActivityOutcome{}),
-	}
+			act := &Activity{
+				ActivityState: &activitypb.ActivityState{
+					ActivityType:           &commonpb.ActivityType{Name: "test-activity-type"},
+					RetryPolicy:            defaultRetryPolicy,
+					ScheduleToCloseTimeout: durationpb.New(defaultScheduleToCloseTimeout),
+					ScheduleToStartTimeout: durationpb.New(defaultScheduleToStartTimeout),
+					StartToCloseTimeout:    durationpb.New(defaultStartToCloseTimeout),
+					Status:                 activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+					ScheduleTime:           timestamppb.New(defaultTime),
+					TaskQueue:              &taskqueuepb.TaskQueue{Name: "test-task-queue"},
+				},
+				LastAttempt:   chasm.NewDataField(ctx, attemptState),
+				LastHeartbeat: chasm.NewDataField(ctx, heartbeatState),
+				Outcome:       chasm.NewDataField(ctx, &activitypb.ActivityOutcome{}),
+			}
 
-	err := TransitionReset.Apply(act, ctx, resetEvent{resetTime: defaultTime, metricsHandler: metrics.NoopMetricsHandler})
-	require.NoError(t, err)
-	protorequire.ProtoEqual(t, payloads.EncodeString("heartbeat-details"), act.LastHeartbeat.Get(ctx).GetDetails())
-	require.Equal(t, timestamppb.New(defaultTime), act.LastHeartbeat.Get(ctx).GetRecordedTime())
+			err := TransitionReset.Apply(act, ctx, resetEvent{
+				req:            &workflowservice.ResetActivityExecutionRequest{ResetHeartbeat: resetHeartbeat},
+				resetTime:      defaultTime,
+				metricsHandler: metrics.NoopMetricsHandler,
+			})
+			require.NoError(t, err)
+			if resetHeartbeat {
+				require.Nil(t, act.LastHeartbeat.Get(ctx).GetDetails())
+				require.Nil(t, act.LastHeartbeat.Get(ctx).GetRecordedTime())
+			} else {
+				protorequire.ProtoEqual(t, payloads.EncodeString("heartbeat-details"), act.LastHeartbeat.Get(ctx).GetDetails())
+				require.Equal(t, timestamppb.New(defaultTime), act.LastHeartbeat.Get(ctx).GetRecordedTime())
+			}
+		})
+	}
 }
 
-func TestDeferredResetPreservesHeartbeat(t *testing.T) {
+// TestDeferredResetHeartbeat: when the reset landed while a worker was running, the heartbeat
+// checkpoint is discarded on the deferred landing only if the request asked for it, in which case
+// the deferred intent is consumed.
+func TestDeferredResetHeartbeat(t *testing.T) {
 	testCases := []struct {
 		name              string
 		transition        chasm.Transition[activitypb.ActivityExecutionStatus, *Activity, rescheduleEvent]
@@ -1079,45 +1097,54 @@ func TestDeferredResetPreservesHeartbeat(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := &chasm.MockMutableContext{}
-			ctx.HandleNow = func(chasm.Component) time.Time { return defaultTime }
-			attemptState := &activitypb.ActivityAttemptState{
-				Count:       3,
-				StartedTime: timestamppb.New(defaultTime),
-			}
-			heartbeatState := &activitypb.ActivityHeartbeatState{
-				Details:      payloads.EncodeString("heartbeat-details"),
-				RecordedTime: timestamppb.New(defaultTime),
-			}
+		for _, shouldClearHeartbeat := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/resetShouldClearHeartbeat=%v", tc.name, shouldClearHeartbeat), func(t *testing.T) {
+				ctx := &chasm.MockMutableContext{}
+				ctx.HandleNow = func(chasm.Component) time.Time { return defaultTime }
+				attemptState := &activitypb.ActivityAttemptState{
+					Count:       3,
+					StartedTime: timestamppb.New(defaultTime),
+				}
+				heartbeatState := &activitypb.ActivityHeartbeatState{
+					Details:      payloads.EncodeString("heartbeat-details"),
+					RecordedTime: timestamppb.New(defaultTime),
+				}
 
-			act := &Activity{
-				ActivityState: &activitypb.ActivityState{
-					ActivityType:            &commonpb.ActivityType{Name: "test-activity-type"},
-					RetryPolicy:             defaultRetryPolicy,
-					ScheduleToCloseTimeout:  durationpb.New(defaultScheduleToCloseTimeout),
-					ScheduleToStartTimeout:  durationpb.New(0),
-					StartToCloseTimeout:     durationpb.New(defaultStartToCloseTimeout),
-					Status:                  activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
-					ScheduleTime:            timestamppb.New(defaultTime),
-					FirstAttemptStartedTime: timestamppb.New(defaultTime),
-					TaskQueue:               &taskqueuepb.TaskQueue{Name: "test-task-queue"},
-					ResetShouldPause:        tc.resetShouldPause,
-				},
-				LastAttempt:   chasm.NewDataField(ctx, attemptState),
-				LastHeartbeat: chasm.NewDataField(ctx, heartbeatState),
-				Outcome:       chasm.NewDataField(ctx, &activitypb.ActivityOutcome{}),
-			}
+				act := &Activity{
+					ActivityState: &activitypb.ActivityState{
+						ActivityType:              &commonpb.ActivityType{Name: "test-activity-type"},
+						RetryPolicy:               defaultRetryPolicy,
+						ScheduleToCloseTimeout:    durationpb.New(defaultScheduleToCloseTimeout),
+						ScheduleToStartTimeout:    durationpb.New(0),
+						StartToCloseTimeout:       durationpb.New(defaultStartToCloseTimeout),
+						Status:                    activitypb.ACTIVITY_EXECUTION_STATUS_RESET_REQUESTED,
+						ScheduleTime:              timestamppb.New(defaultTime),
+						FirstAttemptStartedTime:   timestamppb.New(defaultTime),
+						TaskQueue:                 &taskqueuepb.TaskQueue{Name: "test-task-queue"},
+						ResetShouldPause:          tc.resetShouldPause,
+						ResetShouldClearHeartbeat: shouldClearHeartbeat,
+					},
+					LastAttempt:   chasm.NewDataField(ctx, attemptState),
+					LastHeartbeat: chasm.NewDataField(ctx, heartbeatState),
+					Outcome:       chasm.NewDataField(ctx, &activitypb.ActivityOutcome{}),
+				}
 
-			err := tc.transition.Apply(act, ctx, rescheduleEvent{})
-			require.NoError(t, err)
-			require.Equal(t, tc.expectedStatus, act.Status)
-			require.Equal(t, int32(1), attemptState.Count)
-			require.Nil(t, attemptState.GetCurrentRetryInterval())
-			protorequire.ProtoEqual(t, payloads.EncodeString("heartbeat-details"), act.LastHeartbeat.Get(ctx).GetDetails())
-			require.Equal(t, timestamppb.New(defaultTime), act.LastHeartbeat.Get(ctx).GetRecordedTime())
-			require.Len(t, ctx.Tasks, tc.expectedTaskCount)
-		})
+				err := tc.transition.Apply(act, ctx, rescheduleEvent{})
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedStatus, act.Status)
+				require.Equal(t, int32(1), attemptState.Count)
+				require.Nil(t, attemptState.GetCurrentRetryInterval())
+				require.False(t, act.GetResetShouldClearHeartbeat(), "the deferred intent must be consumed")
+				if shouldClearHeartbeat {
+					require.Nil(t, act.LastHeartbeat.Get(ctx).GetDetails())
+					require.Nil(t, act.LastHeartbeat.Get(ctx).GetRecordedTime())
+				} else {
+					protorequire.ProtoEqual(t, payloads.EncodeString("heartbeat-details"), act.LastHeartbeat.Get(ctx).GetDetails())
+					require.Equal(t, timestamppb.New(defaultTime), act.LastHeartbeat.Get(ctx).GetRecordedTime())
+				}
+				require.Len(t, ctx.Tasks, tc.expectedTaskCount)
+			})
+		}
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.44.0
-	go.temporal.io/api v1.63.5-0.20260803183639-0e1e8c485f37
+	go.temporal.io/api v1.63.5-0.20260804201935-e54fd69950e1
 	go.temporal.io/auto-scaled-workers v0.0.0-20260728174133-979694be4176
 	go.temporal.io/sdk v1.44.0
 	go.uber.org/fx v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -479,8 +479,8 @@ go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0 h1:R
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0/go.mod h1:I89cynRj8y+383o7tEQVg2SVA6SRgDVIouWPUVXjx0U=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0 h1:CQvJSldHRUN6Z8jsUeYv8J0lXRvygALXIzsmAeCcZE0=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0/go.mod h1:xSQ+mEfJe/GjK1LXEyVOoSI1N9JV9ZI923X5kup43W4=
-go.temporal.io/api v1.63.5-0.20260803183639-0e1e8c485f37 h1:ZDICI5Hxc97YsjpE6/WREWkUqQ7qq+ntTH+IbOuTxNw=
-go.temporal.io/api v1.63.5-0.20260803183639-0e1e8c485f37/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
+go.temporal.io/api v1.63.5-0.20260804201935-e54fd69950e1 h1:4PbObRBrax8xa5miZPqn4jf560su1mK4kosbjb7OXbA=
+go.temporal.io/api v1.63.5-0.20260804201935-e54fd69950e1/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
 go.temporal.io/auto-scaled-workers v0.0.0-20260728174133-979694be4176 h1:6AUglT8D3HsbOmV2zwwPpQOmxFXZN4NrMe6Z69n3fSc=
 go.temporal.io/auto-scaled-workers v0.0.0-20260728174133-979694be4176/go.mod h1:hhHijO9XRPIkAflLJJHix61M9FzbRPqk8fSydkcLkqw=
 go.temporal.io/sdk v1.44.0 h1:suitPDukX74rW3/N1FqvEbZTZVJJsxMKhv0KMa/j7pU=

--- a/tests/activity_api_reset_test.go
+++ b/tests/activity_api_reset_test.go
@@ -424,15 +424,26 @@ func requirePayload(t require.TestingT, expected string, pls *commonpb.Payloads)
 	require.Equal(t, expected, actual)
 }
 
+// TestActivityReset_HeartbeatDetails covers the default: a reset rewinds the attempt count but
+// keeps the heartbeat checkpoint. That is reset_heartbeat unset on the legacy API, and the only
+// behavior of the execution API, which has no such flag.
 func (s *ActivityApiResetClientTestSuite) TestActivityReset_HeartbeatDetails() {
-	// Latest reported heartbeat on activity should be available throughout workflow execution or until activity succeeds.
-	// The legacy API clears it only when reset is called with the "reset-heartbeat" flag; the execution API
-	// has no such flag and always keeps it.
-	// 1. Start workflow with single activity
-	// 2. First invocation of activity sets heartbeat details and fails upon request.
-	// 3. Second invocation triggers waits to be triggered, and then send new heartbeat until requested to finish.
-	// 6. Once workflow completes -- we're done.
+	s.runResetHeartbeatDetails(false, true)
+}
 
+// TestActivityReset_HeartbeatDetailsWithResetHeartbeatFlag covers the opt-in clear, which only the
+// legacy API can express.
+func (s *ActivityApiResetClientTestSuite) TestActivityReset_HeartbeatDetailsWithResetHeartbeatFlag() {
+	if s.apiName != "legacy-api" {
+		s.T().Skip("only the legacy ResetActivity API has a reset_heartbeat flag")
+	}
+	s.runResetHeartbeatDetails(true, false)
+}
+
+// runResetHeartbeatDetails runs an activity that heartbeats "first", resets it mid-attempt, then
+// lets that attempt fail so the reset lands on the retry, and checks whether the checkpoint
+// survived. The retried attempt heartbeats "second" to show heartbeating still works afterwards.
+func (s *ActivityApiResetClientTestSuite) runResetHeartbeatDetails(resetHeartbeat, expectPreserved bool) {
 	activityCompleteCh := make(chan struct{})
 	var activityIteration atomic.Int32
 	var activityShouldBreak atomic.Bool
@@ -471,7 +482,7 @@ func (s *ActivityApiResetClientTestSuite) TestActivityReset_HeartbeatDetails() {
 	s.SdkWorker().RegisterActivity(activityFn)
 	s.SdkWorker().RegisterWorkflow(workflowFn)
 
-	wfId := "functional-test-heartbeat-details-after-reset"
+	wfId := testcore.RandomizeStr("wfid-" + s.T().Name())
 	workflowOptions := sdkclient.StartWorkflowOptions{
 		ID:                 wfId,
 		TaskQueue:          s.TaskQueue(),
@@ -495,8 +506,7 @@ func (s *ActivityApiResetClientTestSuite) TestActivityReset_HeartbeatDetails() {
 		require.Equal(t, int32(0), activityIteration.Load())
 	}, 5*time.Second, 500*time.Millisecond)
 
-	// reset the activity, with heartbeats
-	s.NoError(s.resetFn(ctx, workflowRun.GetID(), activityId, true, false))
+	s.NoError(s.resetFn(ctx, workflowRun.GetID(), activityId, resetHeartbeat, false))
 
 	activityIteration.Store(1)
 	activityShouldBreak.Store(true)
@@ -509,8 +519,7 @@ func (s *ActivityApiResetClientTestSuite) TestActivityReset_HeartbeatDetails() {
 		ap := description.PendingActivities[0]
 
 		require.Equal(t, int32(2), ap.Attempt)
-		if s.apiName == "execution-api" {
-			// ResetActivityExecution has no reset_heartbeat flag: it always keeps the checkpoint.
+		if expectPreserved {
 			requirePayload(t, "first", ap.GetHeartbeatDetails())
 		} else {
 			require.Nil(t, ap.HeartbeatDetails)

--- a/tests/activity_api_reset_test.go
+++ b/tests/activity_api_reset_test.go
@@ -67,10 +67,11 @@ func (s *ActivityApiResetClientTestSuite) SetupTest() {
 	if s.apiName == "execution-api" {
 		s.resetFn = func(ctx context.Context, wfID, actID string, resetHeartbeat, keepPaused bool) error {
 			_, err := s.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
-				Namespace:  s.Namespace().String(),
-				WorkflowId: wfID,
-				ActivityId: actID,
-				KeepPaused: keepPaused,
+				Namespace:      s.Namespace().String(),
+				WorkflowId:     wfID,
+				ActivityId:     actID,
+				ResetHeartbeat: resetHeartbeat,
+				KeepPaused:     keepPaused,
 			})
 			return err
 		}
@@ -425,18 +426,13 @@ func requirePayload(t require.TestingT, expected string, pls *commonpb.Payloads)
 }
 
 // TestActivityReset_HeartbeatDetails covers the default: a reset rewinds the attempt count but
-// keeps the heartbeat checkpoint. That is reset_heartbeat unset on the legacy API, and the only
-// behavior of the execution API, which has no such flag.
+// keeps the heartbeat checkpoint.
 func (s *ActivityApiResetClientTestSuite) TestActivityReset_HeartbeatDetails() {
 	s.runResetHeartbeatDetails(false, true)
 }
 
-// TestActivityReset_HeartbeatDetailsWithResetHeartbeatFlag covers the opt-in clear, which only the
-// legacy API can express.
+// TestActivityReset_HeartbeatDetailsWithResetHeartbeatFlag covers the opt-in discard.
 func (s *ActivityApiResetClientTestSuite) TestActivityReset_HeartbeatDetailsWithResetHeartbeatFlag() {
-	if s.apiName != "legacy-api" {
-		s.T().Skip("only the legacy ResetActivity API has a reset_heartbeat flag")
-	}
 	s.runResetHeartbeatDetails(true, false)
 }
 

--- a/tests/activity_api_reset_test.go
+++ b/tests/activity_api_reset_test.go
@@ -426,7 +426,8 @@ func requirePayload(t require.TestingT, expected string, pls *commonpb.Payloads)
 
 func (s *ActivityApiResetClientTestSuite) TestActivityReset_HeartbeatDetails() {
 	// Latest reported heartbeat on activity should be available throughout workflow execution or until activity succeeds.
-	// If activity was reset with "reset-heartbeat" flag, when returned heartbeat details should be nil.
+	// The legacy API clears it only when reset is called with the "reset-heartbeat" flag; the execution API
+	// has no such flag and always keeps it.
 	// 1. Start workflow with single activity
 	// 2. First invocation of activity sets heartbeat details and fails upon request.
 	// 3. Second invocation triggers waits to be triggered, and then send new heartbeat until requested to finish.
@@ -508,8 +509,12 @@ func (s *ActivityApiResetClientTestSuite) TestActivityReset_HeartbeatDetails() {
 		ap := description.PendingActivities[0]
 
 		require.Equal(t, int32(2), ap.Attempt)
-		// make sure heartbeat was reset
-		require.Nil(t, ap.HeartbeatDetails)
+		if s.apiName == "execution-api" {
+			// ResetActivityExecution has no reset_heartbeat flag: it always keeps the checkpoint.
+			requirePayload(t, "first", ap.GetHeartbeatDetails())
+		} else {
+			require.Nil(t, ap.HeartbeatDetails)
+		}
 		require.Equal(t, int32(1), activityIteration.Load())
 	}, 5*time.Second, 500*time.Millisecond)
 

--- a/tests/activity_api_reset_test.go
+++ b/tests/activity_api_reset_test.go
@@ -478,9 +478,9 @@ func (s *ActivityApiResetClientTestSuite) runResetHeartbeatDetails(resetHeartbea
 	s.SdkWorker().RegisterActivity(activityFn)
 	s.SdkWorker().RegisterWorkflow(workflowFn)
 
-	wfId := testcore.RandomizeStr("wfid-" + s.T().Name())
+	wfID := testcore.RandomizeStr("wfid-" + s.T().Name())
 	workflowOptions := sdkclient.StartWorkflowOptions{
-		ID:                 wfId,
+		ID:                 wfID,
 		TaskQueue:          s.TaskQueue(),
 		WorkflowRunTimeout: 20 * time.Second,
 	}

--- a/tests/activity_driver.go
+++ b/tests/activity_driver.go
@@ -58,6 +58,9 @@ const activityInput = "Input"
 // differs from the model.Heartbeat payload so assertions can tell which source was persisted.
 var activityHeartbeatDetails = payloads.EncodeString("failure checkpoint details")
 
+// activityRecordedHeartbeatDetails is the checkpoint payload a driver sends for a model.Heartbeat event.
+var activityRecordedHeartbeatDetails = payloads.EncodeString("heartbeat details")
+
 // timerProcessorMaxShift is the floor the timer queue puts on a task's fire time: it will not fire one
 // earlier than now + this.
 var timerProcessorMaxShift = dynamicconfig.TimerProcessorMaxTimeShift.Get(

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -596,6 +596,63 @@ func (s *activityParityTestSuite) TestLastHeartbeatDetailsPersistedOnAttemptFail
 	}
 }
 
+// Reset rewinds the attempt counter but carries the heartbeat checkpoint into the new attempt, so a
+// long-running activity resumes from where it got to. reset_heartbeat opts out of that: the
+// checkpoint is discarded, and the new attempt starts with none.
+func (s *activityParityTestSuite) TestResetHeartbeatDetails() {
+	env := newActivityParityEnv(s.T())
+	// A long retry interval holds the activity in backoff, so a reset lands while it is SCHEDULED and
+	// no dispatched attempt can pick the checkpoint up before it is read.
+	cfg := activityConfig{MaxAttempts: 3, RetryInterval: activityLongDuration}
+	recorded := activityMarshalPayloads(activityRecordedHeartbeatDetails)
+
+	for _, tc := range []struct {
+		name                     string
+		resetEvent               model.Event
+		expectedHeartbeatDetails []byte
+	}{
+		{name: "Keep", resetEvent: model.Reset, expectedHeartbeatDetails: recorded},
+		{name: "Clear", resetEvent: model.ResetClearingHeartbeat, expectedHeartbeatDetails: nil},
+	} {
+		s.Run(tc.name, func(s *activityParityTestSuite) {
+			// Reset with no attempt in progress: takes effect at once.
+			s.Run("WhileScheduled", func(s *activityParityTestSuite) {
+				trace := []model.Event{model.Poll, model.Heartbeat, model.FailRetryably, tc.resetEvent}
+				s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
+					t := s.T()
+					require.Equal(t, tc.expectedHeartbeatDetails,
+						newWFADriver(t, env, cfg).driveTrace(t, trace).activityInfo(t).LastHeartbeatDetails)
+				})
+				s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
+					t := s.T()
+					require.Equal(t, tc.expectedHeartbeatDetails,
+						newSAADriver(t, env, cfg).driveTrace(t, trace).activityInfo(t).LastHeartbeatDetails)
+				})
+			})
+			// Reset while a worker owns the attempt: deferred until that worker yields
+			s.Run("WhileStarted", func(s *activityParityTestSuite) {
+				trace := []model.Event{model.Poll, model.Heartbeat, tc.resetEvent}
+				s.Run("WorkflowActivity", func(s *activityParityTestSuite) {
+					t := s.T()
+					handle := newWFADriver(t, env, cfg).driveTrace(t, trace)
+					require.Equal(t, recorded, handle.activityInfo(t).LastHeartbeatDetails,
+						"the running attempt must keep reporting its checkpoint until it yields")
+					handle.driveEvent(t, model.FailRetryably)
+					require.Equal(t, tc.expectedHeartbeatDetails, handle.activityInfo(t).LastHeartbeatDetails)
+				})
+				s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
+					t := s.T()
+					handle := newSAADriver(t, env, cfg).driveTrace(t, trace)
+					require.Equal(t, recorded, handle.activityInfo(t).LastHeartbeatDetails,
+						"the running attempt must keep reporting its checkpoint until it yields")
+					handle.driveEvent(t, model.FailRetryably)
+					require.Equal(t, tc.expectedHeartbeatDetails, handle.activityInfo(t).LastHeartbeatDetails)
+				})
+			})
+		})
+	}
+}
+
 func (s *activityParityTestSuite) TestTerminalRetryState() {
 	env := newActivityParityEnv(s.T())
 

--- a/tests/activity_standalone_driver.go
+++ b/tests/activity_standalone_driver.go
@@ -235,7 +235,7 @@ func (a *saaHandle) rpc(_ testing.TB, e model.Event) error {
 	switch e.Type {
 	case model.HeartbeatType:
 		_, err := fc.RecordActivityTaskHeartbeat(a.d.ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
-			Namespace: ns, TaskToken: a.token, Details: payloads.EncodeString("heartbeat details"),
+			Namespace: ns, TaskToken: a.token, Details: activityRecordedHeartbeatDetails,
 		})
 		return err
 	case model.RespondCompletedType:
@@ -298,7 +298,7 @@ func (a *saaHandle) rpc(_ testing.TB, e model.Event) error {
 		return err
 	case model.ResetType:
 		_, err := fc.ResetActivityExecution(a.d.ctx, &workflowservice.ResetActivityExecutionRequest{
-			Namespace: ns, ActivityId: a.activityID, RunId: a.runID, Identity: a.d.env.Tv().ClientIdentity(), KeepPaused: e.KeepPaused,
+			Namespace: ns, ActivityId: a.activityID, RunId: a.runID, Identity: a.d.env.Tv().ClientIdentity(), KeepPaused: e.KeepPaused, ResetHeartbeat: e.ResetHeartbeat,
 		})
 		return err
 	case model.UpdateOptionsType:

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -13160,11 +13160,12 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 				protorequire.ProtoEqual(t, defaultHeartbeatDetails, pollResp2.GetHeartbeatDetails())
 			}
 
-			// Record a new heartbeat on the new attempt
+			// Record a new heartbeat on the new attempt.
+			resetAttemptHeartbeatDetails := payloads.EncodeString("heartbeat details from the reset attempt")
 			_, err = env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
 				Namespace: env.Namespace().String(),
 				TaskToken: pollResp2.TaskToken,
-				Details:   defaultHeartbeatDetails,
+				Details:   resetAttemptHeartbeatDetails,
 				Identity:  defaultIdentity,
 			})
 			require.NoError(t, err)
@@ -13177,7 +13178,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 				IncludeHeartbeatDetails: true,
 			})
 			require.NoError(t, err)
-			require.NotNil(t, desc.GetInfo().GetHeartbeatDetails(), "new heartbeat from reset attempt should be visible")
+			protorequire.ProtoEqual(t, resetAttemptHeartbeatDetails, desc.GetInfo().GetHeartbeatDetails())
 
 			// Complete
 			_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -12553,6 +12553,17 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.NoError(t, err)
 	}
 
+	resetActivityClearingHeartbeat := func(ctx context.Context, t *testing.T, activityID, runID string) {
+		t.Helper()
+		_, err := env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
+			Namespace:      env.Namespace().String(),
+			ActivityId:     activityID,
+			RunId:          runID,
+			ResetHeartbeat: true,
+		})
+		require.NoError(t, err)
+	}
+
 	resetActivityRestoreOriginalOptions := func(ctx context.Context, t *testing.T, activityID, runID string) {
 		t.Helper()
 		_, err := env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
@@ -13002,167 +13013,182 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.NoError(t, err)
 	})
 
-	t.Run("ResetPreservesHeartbeatDetails", func(t *testing.T) {
-		// Activity records heartbeats. Reset rewinds the attempt count but leaves the checkpoint
-		// data in place, so the new attempt 1 resumes from it.
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
+	// Reset of a SCHEDULED activity: the heartbeat checkpoint is kept by default and discarded only
+	// when reset_heartbeat is set, so the new attempt 1 either resumes from it or starts fresh.
+	for _, resetHeartbeat := range []bool{false, true} {
+		t.Run(fmt.Sprintf("ResetHeartbeatDetails/resetHeartbeat=%v", resetHeartbeat), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
 
-		activityID := testcore.RandomizeStr(t.Name())
-		retryPolicy := &commonpb.RetryPolicy{
-			InitialInterval:    durationpb.New(time.Second),
-			BackoffCoefficient: 1.0,
-		}
-		startResp, pollResp1, taskQueue := startAndPollActivity(ctx, t, activityID, retryPolicy)
+			activityID := testcore.RandomizeStr(t.Name())
+			retryPolicy := &commonpb.RetryPolicy{
+				InitialInterval:    durationpb.New(time.Second),
+				BackoffCoefficient: 1.0,
+			}
+			startResp, pollResp1, taskQueue := startAndPollActivity(ctx, t, activityID, retryPolicy)
 
-		// Record a heartbeat
-		_, err := env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
-			Namespace: env.Namespace().String(),
-			TaskToken: pollResp1.TaskToken,
-			Details:   defaultHeartbeatDetails,
-			Identity:  defaultIdentity,
-		})
-		require.NoError(t, err)
-
-		// Verify heartbeat is visible in describe
-		desc, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:               env.Namespace().String(),
-			ActivityId:              activityID,
-			RunId:                   startResp.GetRunId(),
-			IncludeHeartbeatDetails: true,
-		})
-		require.NoError(t, err)
-		require.NotNil(t, desc.GetInfo().GetHeartbeatDetails())
-
-		// Fail the attempt with long backoff
-		failAttemptRetryably(ctx, t, pollResp1.TaskToken, 60*time.Second)
-
-		// Wait for SCHEDULED state
-		await.Require(ctx, t, func(c *await.T) {
-			d, err := env.FrontendClient().DescribeActivityExecution(c.Context(), &workflowservice.DescribeActivityExecutionRequest{
-				Namespace:  env.Namespace().String(),
-				ActivityId: activityID,
-				RunId:      startResp.GetRunId(),
+			// Record a heartbeat
+			_, err := env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
+				Namespace: env.Namespace().String(),
+				TaskToken: pollResp1.TaskToken,
+				Details:   defaultHeartbeatDetails,
+				Identity:  defaultIdentity,
 			})
-			require.NoError(c, err)
-			require.Equal(c, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, d.GetInfo().GetRunState())
-		}, 5*time.Second, 200*time.Millisecond)
+			require.NoError(t, err)
 
-		// Reset keeps the recorded heartbeat state.
-		_, err = env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
-			Namespace:  env.Namespace().String(),
-			ActivityId: activityID,
-			RunId:      startResp.GetRunId(),
+			// Verify heartbeat is visible in describe
+			desc, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:               env.Namespace().String(),
+				ActivityId:              activityID,
+				RunId:                   startResp.GetRunId(),
+				IncludeHeartbeatDetails: true,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, desc.GetInfo().GetHeartbeatDetails())
+
+			// Fail the attempt with long backoff
+			failAttemptRetryably(ctx, t, pollResp1.TaskToken, 60*time.Second)
+
+			// Wait for SCHEDULED state
+			await.Require(ctx, t, func(c *await.T) {
+				d, err := env.FrontendClient().DescribeActivityExecution(c.Context(), &workflowservice.DescribeActivityExecutionRequest{
+					Namespace:  env.Namespace().String(),
+					ActivityId: activityID,
+					RunId:      startResp.GetRunId(),
+				})
+				require.NoError(c, err)
+				require.Equal(c, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, d.GetInfo().GetRunState())
+			}, 5*time.Second, 200*time.Millisecond)
+
+			if resetHeartbeat {
+				resetActivityClearingHeartbeat(ctx, t, activityID, startResp.GetRunId())
+			} else {
+				resetActivity(ctx, t, activityID, startResp.GetRunId())
+			}
+
+			// Poll — attempt 1, with the checkpoint carried over or discarded
+			pollResp2, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+				Namespace: env.Namespace().String(),
+				TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				Identity:  defaultIdentity,
+			})
+			require.NoError(t, err)
+			require.EqualValues(t, 1, pollResp2.Attempt)
+			if resetHeartbeat {
+				require.Empty(t, pollResp2.HeartbeatDetails.GetPayloads())
+			} else {
+				protorequire.ProtoEqual(t, defaultHeartbeatDetails, pollResp2.GetHeartbeatDetails())
+			}
+
+			// Complete
+			_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+				Namespace: env.Namespace().String(),
+				TaskToken: pollResp2.TaskToken,
+				Result:    defaultResult,
+				Identity:  defaultIdentity,
+			})
+			require.NoError(t, err)
 		})
-		require.NoError(t, err)
+	}
 
-		// Poll — attempt 1, heartbeat details carried over
-		pollResp2, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: env.Namespace().String(),
-			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-			Identity:  defaultIdentity,
+	// Reset while the activity is STARTED: both the attempt-count rewind and any discarding of the
+	// heartbeat checkpoint are deferred until the worker yields, leaving the in-flight attempt (and
+	// its checkpoint) undisturbed until then.
+	for _, resetHeartbeat := range []bool{false, true} {
+		t.Run(fmt.Sprintf("ResetHeartbeatDetailsWhileStarted/resetHeartbeat=%v", resetHeartbeat), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			activityID := testcore.RandomizeStr(t.Name())
+			retryPolicy := &commonpb.RetryPolicy{
+				InitialInterval:    durationpb.New(time.Second),
+				BackoffCoefficient: 1.0,
+			}
+			startResp, pollResp1, taskQueue := startAndPollActivity(ctx, t, activityID, retryPolicy)
+
+			// Record a heartbeat while running
+			_, err := env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
+				Namespace: env.Namespace().String(),
+				TaskToken: pollResp1.TaskToken,
+				Details:   defaultHeartbeatDetails,
+				Identity:  defaultIdentity,
+			})
+			require.NoError(t, err)
+
+			// Verify heartbeat is visible
+			desc, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:               env.Namespace().String(),
+				ActivityId:              activityID,
+				RunId:                   startResp.GetRunId(),
+				IncludeHeartbeatDetails: true,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, desc.GetInfo().GetHeartbeatDetails())
+
+			// Reset while STARTED — the reset mutations are deferred.
+			if resetHeartbeat {
+				resetActivityClearingHeartbeat(ctx, t, activityID, startResp.GetRunId())
+			} else {
+				resetActivity(ctx, t, activityID, startResp.GetRunId())
+			}
+
+			// Activity should still be STARTED with heartbeat still visible (reset is deferred)
+			desc, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:               env.Namespace().String(),
+				ActivityId:              activityID,
+				RunId:                   startResp.GetRunId(),
+				IncludeHeartbeatDetails: true,
+			})
+			require.NoError(t, err)
+			require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, desc.GetInfo().GetRunState())
+			require.NotNil(t, desc.GetInfo().GetHeartbeatDetails(), "heartbeat should still be visible before the attempt fails")
+
+			// Fail the running attempt — the deferred reset lands in TransitionRescheduled
+			failAttemptRetryably(ctx, t, pollResp1.TaskToken, 0)
+
+			// Poll retry — attempt=1, heartbeat details carried over
+			pollResp2, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+				Namespace: env.Namespace().String(),
+				TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				Identity:  defaultIdentity,
+			})
+			require.NoError(t, err)
+			require.EqualValues(t, 1, pollResp2.Attempt, "attempt should be reset to 1")
+			if resetHeartbeat {
+				require.Empty(t, pollResp2.HeartbeatDetails.GetPayloads())
+			} else {
+				protorequire.ProtoEqual(t, defaultHeartbeatDetails, pollResp2.GetHeartbeatDetails())
+			}
+
+			// Record a new heartbeat on the new attempt
+			_, err = env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
+				Namespace: env.Namespace().String(),
+				TaskToken: pollResp2.TaskToken,
+				Details:   defaultHeartbeatDetails,
+				Identity:  defaultIdentity,
+			})
+			require.NoError(t, err)
+
+			// Verify new heartbeat is visible in describe
+			desc, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+				Namespace:               env.Namespace().String(),
+				ActivityId:              activityID,
+				RunId:                   startResp.GetRunId(),
+				IncludeHeartbeatDetails: true,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, desc.GetInfo().GetHeartbeatDetails(), "new heartbeat from reset attempt should be visible")
+
+			// Complete
+			_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+				Namespace: env.Namespace().String(),
+				TaskToken: pollResp2.TaskToken,
+				Result:    defaultResult,
+				Identity:  defaultIdentity,
+			})
+			require.NoError(t, err)
 		})
-		require.NoError(t, err)
-		require.EqualValues(t, 1, pollResp2.Attempt)
-		protorequire.ProtoEqual(t, defaultHeartbeatDetails, pollResp2.GetHeartbeatDetails())
-
-		// Complete
-		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-			Namespace: env.Namespace().String(),
-			TaskToken: pollResp2.TaskToken,
-			Result:    defaultResult,
-			Identity:  defaultIdentity,
-		})
-		require.NoError(t, err)
-	})
-
-	t.Run("ResetWhileStartedPreservesHeartbeatState", func(t *testing.T) {
-		// Reset while the activity is STARTED. The attempt-count rewind is deferred until the
-		// worker yields; the heartbeat checkpoint survives both the reset and the rewind.
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-
-		activityID := testcore.RandomizeStr(t.Name())
-		retryPolicy := &commonpb.RetryPolicy{
-			InitialInterval:    durationpb.New(time.Second),
-			BackoffCoefficient: 1.0,
-		}
-		startResp, pollResp1, taskQueue := startAndPollActivity(ctx, t, activityID, retryPolicy)
-
-		// Record a heartbeat while running
-		_, err := env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
-			Namespace: env.Namespace().String(),
-			TaskToken: pollResp1.TaskToken,
-			Details:   defaultHeartbeatDetails,
-			Identity:  defaultIdentity,
-		})
-		require.NoError(t, err)
-
-		// Verify heartbeat is visible
-		desc, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:               env.Namespace().String(),
-			ActivityId:              activityID,
-			RunId:                   startResp.GetRunId(),
-			IncludeHeartbeatDetails: true,
-		})
-		require.NoError(t, err)
-		require.NotNil(t, desc.GetInfo().GetHeartbeatDetails())
-
-		// Reset while STARTED — the attempt-count rewind is deferred.
-		resetActivity(ctx, t, activityID, startResp.GetRunId())
-
-		// Activity should still be STARTED with heartbeat still visible (reset is deferred)
-		desc, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:               env.Namespace().String(),
-			ActivityId:              activityID,
-			RunId:                   startResp.GetRunId(),
-			IncludeHeartbeatDetails: true,
-		})
-		require.NoError(t, err)
-		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, desc.GetInfo().GetRunState())
-		require.NotNil(t, desc.GetInfo().GetHeartbeatDetails(), "heartbeat should still be visible before the attempt fails")
-
-		// Fail the running attempt — the deferred reset lands in TransitionRescheduled
-		failAttemptRetryably(ctx, t, pollResp1.TaskToken, 0)
-
-		// Poll retry — attempt=1, heartbeat details carried over
-		pollResp2, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
-			Namespace: env.Namespace().String(),
-			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-			Identity:  defaultIdentity,
-		})
-		require.NoError(t, err)
-		require.EqualValues(t, 1, pollResp2.Attempt, "attempt should be reset to 1")
-		protorequire.ProtoEqual(t, defaultHeartbeatDetails, pollResp2.GetHeartbeatDetails())
-
-		// Record a new heartbeat on the new attempt
-		_, err = env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
-			Namespace: env.Namespace().String(),
-			TaskToken: pollResp2.TaskToken,
-			Details:   defaultHeartbeatDetails,
-			Identity:  defaultIdentity,
-		})
-		require.NoError(t, err)
-
-		// Verify new heartbeat is visible in describe
-		desc, err = env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
-			Namespace:               env.Namespace().String(),
-			ActivityId:              activityID,
-			RunId:                   startResp.GetRunId(),
-			IncludeHeartbeatDetails: true,
-		})
-		require.NoError(t, err)
-		require.NotNil(t, desc.GetInfo().GetHeartbeatDetails(), "new heartbeat from reset attempt should be visible")
-
-		// Complete
-		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
-			Namespace: env.Namespace().String(),
-			TaskToken: pollResp2.TaskToken,
-			Result:    defaultResult,
-			Identity:  defaultIdentity,
-		})
-		require.NoError(t, err)
-	})
+	}
 
 	t.Run("TerminalStateReturnsFailedPrecondition", func(t *testing.T) {
 		// Resetting a completed activity should return FailedPrecondition.

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -13002,8 +13002,9 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.NoError(t, err)
 	})
 
-	t.Run("ResetClearsHeartbeatDetails", func(t *testing.T) {
-		// Activity records heartbeats. Reset clears them.
+	t.Run("ResetPreservesHeartbeatDetails", func(t *testing.T) {
+		// Activity records heartbeats. Reset rewinds the attempt count but leaves the checkpoint
+		// data in place, so the new attempt 1 resumes from it.
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
@@ -13047,7 +13048,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 			require.Equal(c, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, d.GetInfo().GetRunState())
 		}, 5*time.Second, 200*time.Millisecond)
 
-		// Reset clears recorded heartbeat state.
+		// Reset keeps the recorded heartbeat state.
 		_, err = env.FrontendClient().ResetActivityExecution(ctx, &workflowservice.ResetActivityExecutionRequest{
 			Namespace:  env.Namespace().String(),
 			ActivityId: activityID,
@@ -13055,7 +13056,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		})
 		require.NoError(t, err)
 
-		// Poll — attempt 1, no heartbeat details
+		// Poll — attempt 1, heartbeat details carried over
 		pollResp2, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
 			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
@@ -13063,7 +13064,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		})
 		require.NoError(t, err)
 		require.EqualValues(t, 1, pollResp2.Attempt)
-		require.Empty(t, pollResp2.HeartbeatDetails.GetPayloads(), "heartbeat details should be cleared after reset")
+		protorequire.ProtoEqual(t, defaultHeartbeatDetails, pollResp2.GetHeartbeatDetails())
 
 		// Complete
 		_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
@@ -13075,10 +13076,9 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.NoError(t, err)
 	})
 
-	t.Run("ResetClearsHeartbeatState", func(t *testing.T) {
-		// Reset while the activity is STARTED.
-		// The heartbeat clear is deferred — it only takes effect on the next retry,
-		// matching the behavior of the workflow activity HeartbeatDetails reset test.
+	t.Run("ResetWhileStartedPreservesHeartbeatState", func(t *testing.T) {
+		// Reset while the activity is STARTED. The attempt-count rewind is deferred until the
+		// worker yields; the heartbeat checkpoint survives both the reset and the rewind.
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
@@ -13108,7 +13108,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.NoError(t, err)
 		require.NotNil(t, desc.GetInfo().GetHeartbeatDetails())
 
-		// Reset while STARTED — heartbeat clearing is deferred.
+		// Reset while STARTED — the attempt-count rewind is deferred.
 		resetActivity(ctx, t, activityID, startResp.GetRunId())
 
 		// Activity should still be STARTED with heartbeat still visible (reset is deferred)
@@ -13122,10 +13122,10 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		require.Equal(t, enumspb.PENDING_ACTIVITY_STATE_STARTED, desc.GetInfo().GetRunState())
 		require.NotNil(t, desc.GetInfo().GetHeartbeatDetails(), "heartbeat should still be visible before the attempt fails")
 
-		// Fail the running attempt — triggers deferred reset+heartbeat clear in TransitionRescheduled
+		// Fail the running attempt — the deferred reset lands in TransitionRescheduled
 		failAttemptRetryably(ctx, t, pollResp1.TaskToken, 0)
 
-		// Poll retry — attempt=1, heartbeat details cleared
+		// Poll retry — attempt=1, heartbeat details carried over
 		pollResp2, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
 			Namespace: env.Namespace().String(),
 			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
@@ -13133,7 +13133,7 @@ func (s *standaloneActivityTestSuite) TestResetActivityExecution() {
 		})
 		require.NoError(t, err)
 		require.EqualValues(t, 1, pollResp2.Attempt, "attempt should be reset to 1")
-		require.Empty(t, pollResp2.HeartbeatDetails.GetPayloads(), "heartbeat details should be cleared after deferred reset")
+		protorequire.ProtoEqual(t, defaultHeartbeatDetails, pollResp2.GetHeartbeatDetails())
 
 		// Record a new heartbeat on the new attempt
 		_, err = env.FrontendClient().RecordActivityTaskHeartbeat(ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{

--- a/tests/activity_workflow_driver.go
+++ b/tests/activity_workflow_driver.go
@@ -280,7 +280,7 @@ func (a *wfaHandle) rpc(t testing.TB, e model.Event) error {
 	switch e.Type {
 	case model.HeartbeatType:
 		_, err := fc.RecordActivityTaskHeartbeat(a.d.ctx, &workflowservice.RecordActivityTaskHeartbeatRequest{
-			Namespace: ns, TaskToken: a.token, Details: payloads.EncodeString("heartbeat details"),
+			Namespace: ns, TaskToken: a.token, Details: activityRecordedHeartbeatDetails,
 		})
 		return err
 	case model.RespondCompletedType:
@@ -343,7 +343,7 @@ func (a *wfaHandle) rpc(t testing.TB, e model.Event) error {
 		return err
 	case model.ResetType:
 		_, err := fc.ResetActivityExecution(a.d.ctx, &workflowservice.ResetActivityExecutionRequest{
-			Namespace: ns, WorkflowId: a.workflowID, ActivityId: a.activityID, RunId: a.runID, Identity: a.d.env.Tv().ClientIdentity(), KeepPaused: e.KeepPaused,
+			Namespace: ns, WorkflowId: a.workflowID, ActivityId: a.activityID, RunId: a.runID, Identity: a.d.env.Tv().ClientIdentity(), KeepPaused: e.KeepPaused, ResetHeartbeat: e.ResetHeartbeat,
 		})
 		return err
 	case model.UpdateOptionsType:

--- a/tests/mixedbrain/go.mod
+++ b/tests/mixedbrain/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/siderolabs/grpc-proxy v0.5.2
 	github.com/stretchr/testify v1.11.1
 	github.com/temporalio/omes v0.0.0-20260529203146-c6ee1f56c726
-	go.temporal.io/api v1.63.5-0.20260803183639-0e1e8c485f37
+	go.temporal.io/api v1.63.5-0.20260804201935-e54fd69950e1
 	go.temporal.io/server v0.0.0-00010101000000-000000000000
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11

--- a/tests/mixedbrain/go.sum
+++ b/tests/mixedbrain/go.sum
@@ -55,8 +55,8 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/6gtIk=
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
-go.temporal.io/api v1.63.5-0.20260803183639-0e1e8c485f37 h1:ZDICI5Hxc97YsjpE6/WREWkUqQ7qq+ntTH+IbOuTxNw=
-go.temporal.io/api v1.63.5-0.20260803183639-0e1e8c485f37/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
+go.temporal.io/api v1.63.5-0.20260804201935-e54fd69950e1 h1:4PbObRBrax8xa5miZPqn4jf560su1mK4kosbjb7OXbA=
+go.temporal.io/api v1.63.5-0.20260804201935-e54fd69950e1/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=


### PR DESCRIPTION
## What changed?
- Do not reset heartbeats by default
- Honor `reset_heartbeat` flag

## Why?
- Parity with WFA
- This product behavior makes sense: a user with a long-running activity using exponential backoff on attempt 10 may wish to reset the attempt counter in order that the next retry backoff is short, and yet preserve their checkpointed progress.

## How did you test it?
- [x] modified existing functional test(s)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes activity reset semantics and persisted state for heartbeat checkpoints across immediate and deferred reset paths; behavior is well-covered by tests but affects long-running activity retry/reset workflows.
> 
> **Overview**
> Activity reset now **rewinds the attempt counter** but **keeps persisted heartbeat checkpoint details by default**, matching workflow-activity behavior. Clearing heartbeats is **opt-in** via `reset_heartbeat` / `ResetHeartbeat` on reset APIs.
> 
> CHASM activity state adds `reset_should_clear_heartbeat` for resets requested while a worker is still running; clearing runs when the attempt yields (same deferred pattern as `restore_original_options`). Immediate reset paths (`reset`, `resetKeepPaused`) and cancel-on-reset-request clear that deferred flag only when the flag is set.
> 
> Standalone activity reset forwarding no longer forces `ResetHeartbeat: true`; it passes the client request. Model/events add `ResetClearingHeartbeat`; parity and functional tests cover keep vs clear for scheduled and started activities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09fb7a0bd18a2064af9b774b9e08ef422956f39d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->