### PR TITLE
Add duplicated redirect metrics

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -713,11 +713,15 @@ var (
 		"client_requests",
 		WithDescription("The number of requests sent by the client to an individual service, keyed by `service_role` and `operation`."),
 	)
-	ClientFailures                   = NewCounterDef("client_errors")
-	ClientLatency                    = NewTimerDef("client_latency")
-	ClientRedirectionRequests        = NewCounterDef("client_redirection_requests")
-	ClientRedirectionFailures        = NewCounterDef("client_redirection_errors")
-	ClientRedirectionLatency         = NewTimerDef("client_redirection_latency")
+	ClientFailures            = NewCounterDef("client_errors")
+	ClientLatency             = NewTimerDef("client_latency")
+	ClientRedirectionRequests = NewCounterDef("client_redirection_requests")
+	ClientRedirectionFailures = NewCounterDef("client_redirection_errors")
+	ClientRedirectionLatency  = NewTimerDef("client_redirection_latency")
+	ClientDuplicatedRedirects = NewCounterDef(
+		"client_duplicated_redirects",
+		WithDescription("The number of requests forwarded from another cluster for a namespace that is passive in the receiving cluster."),
+	)
 	StateTransitionCount             = NewDimensionlessHistogramDef("state_transition_count")
 	HistorySize                      = NewBytesHistogramDef("history_size")
 	HistoryCount                     = NewDimensionlessHistogramDef("history_count")

--- a/common/rpc/interceptor/redirection.go
+++ b/common/rpc/interceptor/redirection.go
@@ -307,6 +307,7 @@ func (i *Redirection) handleRedirectAPIInvocation(
 	var err error
 
 	scope, startTime := i.BeforeCall(dcRedirectionMetricsPrefix + methodName)
+	i.recordForwardedRequestOnPassiveCluster(ctx, methodName, namespaceName)
 	defer func() {
 		i.AfterCall(scope, startTime, targetClusterName, namespaceName.String(), retError)
 	}()
@@ -331,6 +332,46 @@ func (i *Redirection) handleRedirectAPIInvocation(
 		return err
 	})
 	return resp, err
+}
+
+func (i *Redirection) recordForwardedRequestOnPassiveCluster(
+	ctx context.Context,
+	methodName string,
+	namespaceName namespace.Name,
+) {
+	sourceClusterValues := metadata.ValueFromIncomingContext(ctx, DCRedirectionSourceCellHeaderName)
+	if len(sourceClusterValues) == 0 || sourceClusterValues[0] == "" || sourceClusterValues[0] == i.currentClusterName {
+		return
+	}
+	namespaceEntry, err := i.namespaceCache.GetNamespace(namespaceName)
+	if err != nil {
+		return
+	}
+	i.RecordForwardedRequestOnPassiveCluster(
+		sourceClusterValues[0],
+		dcRedirectionMetricsPrefix+methodName,
+		namespaceEntry,
+		GetRoutingKeyFromContext(ctx),
+	)
+}
+
+// RecordForwardedRequestOnPassiveCluster records requests sent by another cluster to a cluster
+// where the namespace is passive.
+func (i *Redirection) RecordForwardedRequestOnPassiveCluster(
+	sourceCluster string,
+	operation string,
+	namespaceEntry *namespace.Namespace,
+	routingKey namespace.RoutingKey,
+) {
+	if sourceCluster == "" || sourceCluster == i.currentClusterName ||
+		!namespaceEntry.IsGlobalNamespace() || namespaceEntry.ActiveClusterName(routingKey) == i.currentClusterName {
+		return
+	}
+	metricsHandler, _ := i.BeforeCall(operation)
+	metrics.ClientDuplicatedRedirects.With(metricsHandler).Record(1,
+		metrics.NamespaceTag(namespaceEntry.Name().String()),
+		metrics.SourceClusterTag(sourceCluster),
+	)
 }
 
 func (i *Redirection) BeforeCall(

--- a/common/rpc/interceptor/redirection_test.go
+++ b/common/rpc/interceptor/redirection_test.go
@@ -370,6 +370,87 @@ func (s *redirectionInterceptorSuite) TestHandleGlobalAPIInvocation_NamespaceNot
 	s.IsType(&serviceerror.NamespaceNotFound{}, err)
 }
 
+func (s *redirectionInterceptorSuite) TestRecordForwardedRequestOnPassiveCluster() {
+	metricsHandler := metricstest.NewCaptureHandler()
+	capture := metricsHandler.StartCapture()
+	defer metricsHandler.StopCapture(capture)
+
+	namespaceName := namespace.Name("test-namespace")
+	namespaceEntry := namespace.NewGlobalNamespaceForTest(
+		&persistencespb.NamespaceInfo{Id: uuid.NewString(), Name: namespaceName.String()},
+		&persistencespb.NamespaceConfig{Retention: timestamp.DurationFromDays(1)},
+		&persistencespb.NamespaceReplicationConfig{
+			ActiveClusterName: cluster.TestAlternativeClusterName,
+			Clusters: []string{
+				cluster.TestCurrentClusterName,
+				cluster.TestAlternativeClusterName,
+			},
+		},
+		1,
+	)
+	s.namespaceCache.EXPECT().GetNamespace(namespaceName).Return(namespaceEntry, nil)
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+		DCRedirectionSourceCellHeaderName: cluster.TestAlternativeClusterName,
+	}))
+	s.redirector.metricsHandler = metricsHandler
+	s.redirector.recordForwardedRequestOnPassiveCluster(ctx, "SignalWorkflowExecution", namespaceName)
+
+	recordings := capture.Snapshot()[metrics.ClientDuplicatedRedirects.Name()]
+	s.Len(recordings, 1)
+	s.Equal(int64(1), recordings[0].Value)
+	s.Equal(map[string]string{
+		"namespace":      namespaceName.String(),
+		"operation":      "DCRedirectionSignalWorkflowExecution",
+		"service_role":   metrics.DCRedirectionRoleTagValue,
+		"source_cluster": cluster.TestAlternativeClusterName,
+	}, recordings[0].Tags)
+}
+
+func (s *redirectionInterceptorSuite) TestRecordForwardedRequestOnActiveCluster_NoMetric() {
+	metricsHandler := metricstest.NewCaptureHandler()
+	capture := metricsHandler.StartCapture()
+	defer metricsHandler.StopCapture(capture)
+
+	namespaceName := namespace.Name("test-namespace")
+	namespaceEntry := namespace.NewGlobalNamespaceForTest(
+		&persistencespb.NamespaceInfo{Id: uuid.NewString(), Name: namespaceName.String()},
+		&persistencespb.NamespaceConfig{Retention: timestamp.DurationFromDays(1)},
+		&persistencespb.NamespaceReplicationConfig{
+			ActiveClusterName: cluster.TestCurrentClusterName,
+			Clusters: []string{
+				cluster.TestCurrentClusterName,
+				cluster.TestAlternativeClusterName,
+			},
+		},
+		1,
+	)
+	s.namespaceCache.EXPECT().GetNamespace(namespaceName).Return(namespaceEntry, nil)
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+		DCRedirectionSourceCellHeaderName: cluster.TestAlternativeClusterName,
+	}))
+	s.redirector.metricsHandler = metricsHandler
+	s.redirector.recordForwardedRequestOnPassiveCluster(ctx, "SignalWorkflowExecution", namespaceName)
+
+	s.Empty(capture.Snapshot()[metrics.ClientDuplicatedRedirects.Name()])
+}
+
+func (s *redirectionInterceptorSuite) TestRecordNonForwardedRequestOnPassiveCluster_NoMetric() {
+	metricsHandler := metricstest.NewCaptureHandler()
+	capture := metricsHandler.StartCapture()
+	defer metricsHandler.StopCapture(capture)
+
+	s.redirector.metricsHandler = metricsHandler
+	s.redirector.recordForwardedRequestOnPassiveCluster(context.Background(), "SignalWorkflowExecution", namespace.Name("test-namespace"))
+	localSourceContext := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+		DCRedirectionSourceCellHeaderName: cluster.TestCurrentClusterName,
+	}))
+	s.redirector.recordForwardedRequestOnPassiveCluster(localSourceContext, "SignalWorkflowExecution", namespace.Name("test-namespace"))
+
+	s.Empty(capture.Snapshot()[metrics.ClientDuplicatedRedirects.Name()])
+}
+
 func (s *redirectionInterceptorSuite) TestRedirectionAllowed_Empty() {
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{}))
 	allowed := s.redirector.RedirectionAllowed(ctx)


### PR DESCRIPTION
## What changed?
Add a duplicate request forwarding metric

## Why?
Add a duplicate request forwarding metric to detect namespace active inconsistent state.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
