### PR TITLE
Improve flaky-test report collection and bisecting

### DIFF
--- a/tools/common/github/api.go
+++ b/tools/common/github/api.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	githubAPIURL         = "https://api.github.com"
-	githubAPIRate        = 5
+	DefaultAPIRPS        = 5
 	githubAPIBurst       = 10
 	githubAPIConcurrency = 20
 	githubAPIMaxAttempts = 3
@@ -46,7 +46,7 @@ func newAPIClient() *apiClient {
 	return &apiClient{
 		baseURL:    githubAPIURL,
 		httpClient: &http.Client{Transport: transport},
-		limiter:    rate.NewLimiter(githubAPIRate, githubAPIBurst),
+		limiter:    rate.NewLimiter(DefaultAPIRPS, githubAPIBurst),
 		token:      apiToken,
 		wait:       waitWithContext,
 		now:        time.Now,
@@ -59,6 +59,15 @@ func newAPIClient() *apiClient {
 		maxAttempts:  githubAPIMaxAttempts,
 		requestSlots: make(chan struct{}, githubAPIConcurrency),
 	}
+}
+
+// SetAPIRPS sets the request rate limit for GitHub API requests.
+func SetAPIRPS(rps int) error {
+	if rps < 1 {
+		return fmt.Errorf("GitHub API requests per second must be at least 1")
+	}
+	defaultAPIClient.limiter.SetLimit(rate.Limit(rps))
+	return nil
 }
 
 func (c *apiClient) getJSON(ctx context.Context, path string, out any) (retErr error) {

--- a/tools/common/github/api.go
+++ b/tools/common/github/api.go
@@ -1,0 +1,269 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+const (
+	githubAPIURL         = "https://api.github.com"
+	githubAPIRate        = 5
+	githubAPIBurst       = 10
+	githubAPIConcurrency = 20
+	githubAPIMaxAttempts = 3
+	maxAPIErrorBody      = 4 << 10
+)
+
+type apiClient struct {
+	baseURL       string
+	httpClient    *http.Client
+	limiter       *rate.Limiter
+	token         func(context.Context) (string, error)
+	wait          func(context.Context, time.Duration) error
+	now           func() time.Time
+	jitter        func(time.Duration) time.Duration
+	maxAttempts   int
+	requestSlots  chan struct{}
+	cooldownMu    sync.Mutex
+	cooldownUntil time.Time
+}
+
+var defaultAPIClient = newAPIClient()
+
+func newAPIClient() *apiClient {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.ResponseHeaderTimeout = 30 * time.Second
+	return &apiClient{
+		baseURL:    githubAPIURL,
+		httpClient: &http.Client{Transport: transport},
+		limiter:    rate.NewLimiter(githubAPIRate, githubAPIBurst),
+		token:      apiToken,
+		wait:       waitWithContext,
+		now:        time.Now,
+		jitter: func(max time.Duration) time.Duration {
+			if max <= 0 {
+				return 0
+			}
+			return time.Duration(rand.Int64N(int64(max)))
+		},
+		maxAttempts:  githubAPIMaxAttempts,
+		requestSlots: make(chan struct{}, githubAPIConcurrency),
+	}
+}
+
+func (c *apiClient) getJSON(ctx context.Context, path string, out any) (retErr error) {
+	resp, err := c.get(ctx, path)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("failed to close GitHub response for %s: %w", path, err)
+		}
+	}()
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("failed to parse GitHub response for %s: %w", path, err)
+	}
+	return nil
+}
+
+func (c *apiClient) get(ctx context.Context, path string) (*http.Response, error) {
+	token, err := c.token(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < c.maxAttempts; attempt++ {
+		if err := c.waitForAdmission(ctx); err != nil {
+			return nil, err
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create GitHub request: %w", err)
+		}
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+		if err := c.acquireRequestSlot(ctx); err != nil {
+			return nil, err
+		}
+		resp, err := c.httpClient.Do(req)
+		c.releaseRequestSlot()
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			lastErr = fmt.Errorf("GitHub request failed: %w", err)
+			if attempt+1 == c.maxAttempts {
+				break
+			}
+			if err := c.wait(ctx, c.transientDelay(attempt)); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			c.observePrimaryRateLimit(resp)
+			return resp, nil
+		}
+
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxAPIErrorBody))
+		closeErr := resp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("failed to read GitHub error response: %w", readErr)
+		}
+		if closeErr != nil {
+			return nil, fmt.Errorf("failed to close GitHub error response: %w", closeErr)
+		}
+		lastErr = fmt.Errorf("GitHub returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+
+		delay, retry := c.retryDelay(resp, body, attempt)
+		rateLimited := resp.StatusCode == http.StatusTooManyRequests || isRateLimitResponse(resp, body)
+		if retry && rateLimited {
+			c.extendCooldown(delay)
+		}
+		if !retry || attempt+1 == c.maxAttempts {
+			break
+		}
+		if !rateLimited {
+			if err := c.wait(ctx, delay); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return nil, lastErr
+}
+
+func (c *apiClient) acquireRequestSlot(ctx context.Context) error {
+	if c.requestSlots == nil {
+		return nil
+	}
+	select {
+	case c.requestSlots <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (c *apiClient) releaseRequestSlot() {
+	if c.requestSlots != nil {
+		<-c.requestSlots
+	}
+}
+
+func (c *apiClient) waitForAdmission(ctx context.Context) error {
+	c.cooldownMu.Lock()
+	delay := c.cooldownUntil.Sub(c.now())
+	c.cooldownMu.Unlock()
+	if delay > 0 {
+		if err := c.wait(ctx, delay); err != nil {
+			return err
+		}
+	}
+	return c.limiter.Wait(ctx)
+}
+
+func (c *apiClient) extendCooldown(delay time.Duration) {
+	until := c.now().Add(delay)
+	c.cooldownMu.Lock()
+	if until.After(c.cooldownUntil) {
+		c.cooldownUntil = until
+	}
+	c.cooldownMu.Unlock()
+}
+
+func (c *apiClient) observePrimaryRateLimit(resp *http.Response) {
+	if resp.Header.Get("X-RateLimit-Remaining") != "0" {
+		return
+	}
+	reset, err := strconv.ParseInt(resp.Header.Get("X-RateLimit-Reset"), 10, 64)
+	if err != nil {
+		return
+	}
+	delay := time.Unix(reset, 0).Sub(c.now())
+	if delay > 0 {
+		c.extendCooldown(delay + c.jitter(time.Second))
+	}
+}
+
+func (c *apiClient) retryDelay(resp *http.Response, body []byte, attempt int) (time.Duration, bool) {
+	if resp.StatusCode == http.StatusTooManyRequests || isRateLimitResponse(resp, body) {
+		if delay, ok := retryAfterDelay(resp.Header.Get("Retry-After"), c.now()); ok {
+			return delay + c.jitter(time.Second), true
+		}
+		if resp.Header.Get("X-RateLimit-Remaining") == "0" {
+			if reset, err := strconv.ParseInt(resp.Header.Get("X-RateLimit-Reset"), 10, 64); err == nil {
+				delay := time.Unix(reset, 0).Sub(c.now())
+				if delay < 0 {
+					delay = 0
+				}
+				return delay + c.jitter(time.Second), true
+			}
+		}
+		return time.Minute + c.jitter(time.Second), true
+	}
+
+	switch resp.StatusCode {
+	case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return c.transientDelay(attempt), true
+	default:
+		return 0, false
+	}
+}
+
+func (c *apiClient) transientDelay(attempt int) time.Duration {
+	base := time.Second << attempt
+	return base + c.jitter(base/2)
+}
+
+func isRateLimitResponse(resp *http.Response, body []byte) bool {
+	if resp.StatusCode != http.StatusForbidden {
+		return false
+	}
+	if resp.Header.Get("Retry-After") != "" || resp.Header.Get("X-RateLimit-Remaining") == "0" {
+		return true
+	}
+	message := strings.ToLower(string(body))
+	return strings.Contains(message, "secondary rate limit") ||
+		strings.Contains(message, "rate limit exceeded") ||
+		strings.Contains(message, "abuse detection")
+}
+
+func retryAfterDelay(value string, now time.Time) (time.Duration, bool) {
+	if value == "" {
+		return 0, false
+	}
+	if seconds, err := strconv.Atoi(value); err == nil {
+		return max(time.Duration(seconds)*time.Second, 0), true
+	}
+	if retryAt, err := http.ParseTime(value); err == nil {
+		return max(retryAt.Sub(now), 0), true
+	}
+	return 0, false
+}
+
+func waitWithContext(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/tools/common/github/api_test.go
+++ b/tools/common/github/api_test.go
@@ -30,6 +30,19 @@ func newTestAPIClient(server *httptest.Server) *apiClient {
 	}
 }
 
+func TestSetAPIRPS(t *testing.T) {
+	originalRPS := defaultAPIClient.limiter.Limit()
+	t.Cleanup(func() {
+		defaultAPIClient.limiter.SetLimit(originalRPS)
+	})
+
+	require.NoError(t, SetAPIRPS(25))
+	require.Equal(t, rate.Limit(25), defaultAPIClient.limiter.Limit())
+
+	require.ErrorContains(t, SetAPIRPS(0), "must be at least 1")
+	require.Equal(t, rate.Limit(25), defaultAPIClient.limiter.Limit())
+}
+
 func TestAPIClientHonorsRetryAfter(t *testing.T) {
 	requests := 0
 	writeResult := make(chan error, 1)

--- a/tools/common/github/api_test.go
+++ b/tools/common/github/api_test.go
@@ -1,0 +1,188 @@
+package github
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+)
+
+func writeAPIResponse(w http.ResponseWriter, body string, result chan<- error) {
+	_, err := io.WriteString(w, body)
+	result <- err
+}
+
+func newTestAPIClient(server *httptest.Server) *apiClient {
+	return &apiClient{
+		baseURL:     server.URL,
+		httpClient:  server.Client(),
+		limiter:     rate.NewLimiter(rate.Inf, 1),
+		token:       func(context.Context) (string, error) { return "test-token", nil },
+		wait:        waitWithContext,
+		now:         func() time.Time { return time.Unix(100, 0) },
+		jitter:      func(time.Duration) time.Duration { return 0 },
+		maxAttempts: githubAPIMaxAttempts,
+	}
+}
+
+func TestAPIClientHonorsRetryAfter(t *testing.T) {
+	requests := 0
+	writeResult := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		if requests == 1 {
+			w.Header().Set("Retry-After", "7")
+			http.Error(w, "secondary rate limit", http.StatusTooManyRequests)
+			return
+		}
+		writeAPIResponse(w, `{"value":"ok"}`, writeResult)
+	}))
+	defer server.Close()
+
+	client := newTestAPIClient(server)
+	var delays []time.Duration
+	client.wait = func(_ context.Context, delay time.Duration) error {
+		delays = append(delays, delay)
+		return nil
+	}
+	var response struct {
+		Value string `json:"value"`
+	}
+	require.NoError(t, client.getJSON(context.Background(), "/resource", &response))
+	require.Equal(t, "ok", response.Value)
+	require.NoError(t, <-writeResult)
+	require.Equal(t, 2, requests)
+	require.Equal(t, []time.Duration{7 * time.Second}, delays)
+}
+
+func TestAPIClientHonorsRateLimitReset(t *testing.T) {
+	resp := &http.Response{StatusCode: http.StatusForbidden, Header: http.Header{
+		"X-Ratelimit-Remaining": []string{"0"},
+		"X-Ratelimit-Reset":     []string{"112"},
+	}}
+	client := &apiClient{
+		now:    func() time.Time { return time.Unix(100, 0) },
+		jitter: func(time.Duration) time.Duration { return 0 },
+	}
+	delay, retry := client.retryDelay(resp, nil, 0)
+	require.True(t, retry)
+	require.Equal(t, 12*time.Second, delay)
+}
+
+func TestAPIClientSecondaryLimitFallback(t *testing.T) {
+	resp := &http.Response{StatusCode: http.StatusForbidden, Header: make(http.Header)}
+	client := &apiClient{
+		now:    time.Now,
+		jitter: func(time.Duration) time.Duration { return 0 },
+	}
+	delay, retry := client.retryDelay(resp, []byte("secondary rate limit"), 0)
+	require.True(t, retry)
+	require.Equal(t, time.Minute, delay)
+}
+
+func TestAPIClientRetriesTransientFailures(t *testing.T) {
+	requests := 0
+	writeResult := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		if requests < 3 {
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		writeAPIResponse(w, `{}`, writeResult)
+	}))
+	defer server.Close()
+
+	client := newTestAPIClient(server)
+	var delays []time.Duration
+	client.wait = func(_ context.Context, delay time.Duration) error {
+		delays = append(delays, delay)
+		return nil
+	}
+	require.NoError(t, client.getJSON(context.Background(), "/resource", &struct{}{}))
+	require.NoError(t, <-writeResult)
+	require.Equal(t, 3, requests)
+	require.Equal(t, []time.Duration{time.Second, 2 * time.Second}, delays)
+}
+
+func TestAPIClientDoesNotRetryNonRateLimitClientError(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := newTestAPIClient(server)
+	_, err := client.get(context.Background(), "/resource")
+	require.ErrorContains(t, err, "404 Not Found")
+	require.Equal(t, 1, requests)
+}
+
+func TestAPIClientLimiterBoundsRequests(t *testing.T) {
+	requests := 0
+	writeResult := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		writeAPIResponse(w, `{}`, writeResult)
+	}))
+	defer server.Close()
+
+	client := newTestAPIClient(server)
+	client.limiter = rate.NewLimiter(0, 1)
+	resp, err := client.get(context.Background(), "/first")
+	require.NoError(t, err)
+	require.NoError(t, <-writeResult)
+	require.NoError(t, resp.Body.Close())
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err = client.get(ctx, "/second")
+	require.Error(t, err)
+	require.Equal(t, 1, requests)
+}
+
+func TestAPIClientRequestSlotsAreCancelable(t *testing.T) {
+	client := &apiClient{requestSlots: make(chan struct{}, 1)}
+	client.requestSlots <- struct{}{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, client.acquireRequestSlot(ctx), context.Canceled)
+}
+
+func TestAPIClientSharesPrimaryRateLimitCooldown(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+	client := newTestAPIClient(server)
+	client.now = func() time.Time { return time.Unix(100, 0) }
+	var delays []time.Duration
+	client.wait = func(_ context.Context, delay time.Duration) error {
+		delays = append(delays, delay)
+		return nil
+	}
+
+	client.observePrimaryRateLimit(&http.Response{Header: http.Header{
+		"X-Ratelimit-Remaining": []string{"0"},
+		"X-Ratelimit-Reset":     []string{"112"},
+	}})
+	require.NoError(t, client.waitForAdmission(context.Background()))
+	require.Equal(t, []time.Duration{12 * time.Second}, delays)
+}
+
+func TestAPIClientRetryWaitIsCancelable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		http.Error(w, "secondary rate limit", http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	client := newTestAPIClient(server)
+	client.wait = func(context.Context, time.Duration) error { return context.Canceled }
+	_, err := client.get(context.Background(), "/resource")
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/tools/common/github/artifacts.go
+++ b/tools/common/github/artifacts.go
@@ -3,10 +3,20 @@ package github
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"time"
 )
+
+var fallbackToken struct {
+	sync.Once
+	value string
+	err   error
+}
 
 // Artifact represents a downloadable GitHub Actions artifact.
 type Artifact struct {
@@ -47,15 +57,71 @@ func ListRunArtifacts(ctx context.Context, repo string, runID int64) ([]Artifact
 
 // DownloadArtifact downloads a single GitHub Actions artifact zip file.
 func DownloadArtifact(ctx context.Context, repo string, artifactID int64, outputDir string) (string, error) {
-	zipPath := filepath.Join(outputDir, fmt.Sprintf("artifact-%d.zip", artifactID))
+	path := fmt.Sprintf("/repos/%s/actions/artifacts/%d/zip", repo, artifactID)
+	return downloadArtifact(ctx, defaultAPIClient, path, artifactID, outputDir)
+}
 
-	output, err := commandOutput(ctx, 60*time.Second, "api", fmt.Sprintf("/repos/%s/actions/artifacts/%d/zip", repo, artifactID))
+func apiToken(ctx context.Context) (string, error) {
+	if token := os.Getenv("GH_TOKEN"); token != "" {
+		return token, nil
+	}
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		return token, nil
+	}
+
+	fallbackToken.Do(func() {
+		output, err := commandOutput(ctx, defaultTimeout, "auth", "token")
+		fallbackToken.value = strings.TrimSpace(string(output))
+		fallbackToken.err = err
+	})
+	if fallbackToken.err != nil {
+		return "", fmt.Errorf("failed to get GitHub token: %w", fallbackToken.err)
+	}
+	if fallbackToken.value == "" {
+		return "", fmt.Errorf("GitHub token is empty")
+	}
+	return fallbackToken.value, nil
+}
+
+func downloadArtifact(
+	ctx context.Context,
+	client *apiClient,
+	path string,
+	artifactID int64,
+	outputDir string,
+) (_ string, retErr error) {
+	resp, err := client.get(ctx, path)
 	if err != nil {
 		return "", fmt.Errorf("failed to download artifact %d: %w", artifactID, err)
 	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("failed to close artifact %d response: %w", artifactID, err)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+		return "", fmt.Errorf("failed to download artifact %d: GitHub returned %s: %s", artifactID, resp.Status, strings.TrimSpace(string(body)))
+	}
 
-	if err := os.WriteFile(zipPath, output, 0644); err != nil {
-		return "", fmt.Errorf("failed to write artifact zip %d: %w", artifactID, err)
+	tempFile, err := os.CreateTemp(outputDir, fmt.Sprintf("artifact-%d-*.zip", artifactID))
+	if err != nil {
+		return "", fmt.Errorf("failed to create artifact %d file: %w", artifactID, err)
+	}
+	tempPath := tempFile.Name()
+	defer func() { _ = os.Remove(tempPath) }()
+
+	if _, err := io.Copy(tempFile, resp.Body); err != nil {
+		_ = tempFile.Close()
+		return "", fmt.Errorf("failed to write artifact %d: %w", artifactID, err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return "", fmt.Errorf("failed to close artifact %d file: %w", artifactID, err)
+	}
+
+	zipPath := filepath.Join(outputDir, fmt.Sprintf("artifact-%d.zip", artifactID))
+	if err := os.Rename(tempPath, zipPath); err != nil {
+		return "", fmt.Errorf("failed to finalize artifact %d: %w", artifactID, err)
 	}
 
 	return zipPath, nil

--- a/tools/common/github/artifacts_test.go
+++ b/tools/common/github/artifacts_test.go
@@ -1,0 +1,63 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownloadArtifact(t *testing.T) {
+	const contents = "zip contents"
+	type requestResult struct {
+		authorization string
+		accept        string
+		writeErr      error
+	}
+	requests := make(chan requestResult, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(contents))
+		requests <- requestResult{
+			authorization: r.Header.Get("Authorization"),
+			accept:        r.Header.Get("Accept"),
+			writeErr:      err,
+		}
+	}))
+	defer server.Close()
+
+	path, err := downloadArtifact(context.Background(), newTestAPIClient(server), "", 123, t.TempDir())
+	require.NoError(t, err)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, contents, string(data))
+	request := <-requests
+	require.NoError(t, request.writeErr)
+	require.Equal(t, "Bearer test-token", request.authorization)
+	require.Equal(t, "application/vnd.github+json", request.accept)
+}
+
+func TestDownloadArtifactHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	client := newTestAPIClient(server)
+	client.maxAttempts = 1
+	_, err := downloadArtifact(context.Background(), client, "", 123, t.TempDir())
+	require.ErrorContains(t, err, "429 Too Many Requests")
+	require.ErrorContains(t, err, "rate limited")
+}
+
+func TestDownloadArtifactCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer server.Close()
+	_, err := downloadArtifact(ctx, newTestAPIClient(server), "", 123, t.TempDir())
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/tools/common/github/client.go
+++ b/tools/common/github/client.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -13,14 +12,7 @@ import (
 const defaultTimeout = 30 * time.Second
 
 func getJSON(ctx context.Context, path string, out any) error {
-	output, err := commandOutput(ctx, defaultTimeout, "api", path)
-	if err != nil {
-		return err
-	}
-	if err := json.Unmarshal(output, out); err != nil {
-		return fmt.Errorf("failed to parse GitHub response for %s: %w", path, err)
-	}
-	return nil
+	return defaultAPIClient.getJSON(ctx, path, out)
 }
 
 func commandOutput(ctx context.Context, timeout time.Duration, args ...string) ([]byte, error) {

--- a/tools/common/github/runs.go
+++ b/tools/common/github/runs.go
@@ -17,7 +17,7 @@ const (
 	ConclusionFailure Conclusion = "failure"
 )
 
-// Run represents a GitHub Actions workflow run returned by the gh CLI.
+// Run represents a GitHub Actions workflow run.
 type Run struct {
 	DatabaseID         int64         `json:"databaseId"`
 	Number             int           `json:"number"`
@@ -128,7 +128,7 @@ type RunListOptions struct {
 	All        bool
 }
 
-// ListRuns retrieves workflow runs through the gh CLI.
+// ListRuns retrieves workflow runs.
 func ListRuns(ctx context.Context, opts RunListOptions) ([]Run, error) {
 	if opts.WorkflowID != 0 {
 		return listWorkflowRuns(ctx, opts)

--- a/tools/flakereport/aggregation.go
+++ b/tools/flakereport/aggregation.go
@@ -1,0 +1,95 @@
+package flakereport
+
+type testRunSummary struct {
+	totalRuns int
+	tests     map[string]*summarizedTestRuns
+	suiteRuns map[string]map[suiteRunIdentity]struct{}
+}
+
+type summarizedTestRuns struct {
+	totalRuns     int
+	failures      int
+	byWorkflowRun map[int64]commitRunCounts
+}
+
+type suiteRunIdentity struct {
+	runID      int64
+	matrixName string
+}
+
+func newTestRunSummary() *testRunSummary {
+	return &testRunSummary{
+		tests:     make(map[string]*summarizedTestRuns),
+		suiteRuns: make(map[string]map[suiteRunIdentity]struct{}),
+	}
+}
+
+func (s *testRunSummary) add(runs []TestRun) {
+	s.totalRuns += len(runs)
+	for _, run := range runs {
+		if run.Skipped {
+			continue
+		}
+
+		testName := normalizeTestName(run.Name)
+		testRuns := s.tests[testName]
+		if testRuns == nil {
+			testRuns = &summarizedTestRuns{byWorkflowRun: make(map[int64]commitRunCounts)}
+			s.tests[testName] = testRuns
+		}
+		testRuns.totalRuns++
+		counts := testRuns.byWorkflowRun[run.RunID]
+		if run.Failed {
+			testRuns.failures++
+			counts.fails++
+		} else {
+			counts.passes++
+		}
+		testRuns.byWorkflowRun[run.RunID] = counts
+
+		if isGoTestSuite(run.SuiteName) {
+			if s.suiteRuns[run.SuiteName] == nil {
+				s.suiteRuns[run.SuiteName] = make(map[suiteRunIdentity]struct{})
+			}
+			s.suiteRuns[run.SuiteName][suiteRunIdentity{runID: run.RunID, matrixName: run.MatrixName}] = struct{}{}
+		}
+	}
+}
+
+func (s *testRunSummary) merge(other *testRunSummary) {
+	if other == nil {
+		return
+	}
+	s.totalRuns += other.totalRuns
+	for testName, otherRuns := range other.tests {
+		testRuns := s.tests[testName]
+		if testRuns == nil {
+			testRuns = &summarizedTestRuns{byWorkflowRun: make(map[int64]commitRunCounts)}
+			s.tests[testName] = testRuns
+		}
+		testRuns.totalRuns += otherRuns.totalRuns
+		testRuns.failures += otherRuns.failures
+		for runID, otherCounts := range otherRuns.byWorkflowRun {
+			counts := testRuns.byWorkflowRun[runID]
+			counts.passes += otherCounts.passes
+			counts.fails += otherCounts.fails
+			testRuns.byWorkflowRun[runID] = counts
+		}
+	}
+	for suiteName, otherRuns := range other.suiteRuns {
+		if s.suiteRuns[suiteName] == nil {
+			s.suiteRuns[suiteName] = make(map[suiteRunIdentity]struct{})
+		}
+		for run := range otherRuns {
+			s.suiteRuns[suiteName][run] = struct{}{}
+		}
+	}
+}
+
+func (s *testRunSummary) countsByTest() map[string]int {
+	counts := make(map[string]int, len(s.tests))
+	for testName, runs := range s.tests {
+		counts[testName] = runs.totalRuns
+	}
+	return counts
+}

--- a/tools/flakereport/aggregation_test.go
+++ b/tools/flakereport/aggregation_test.go
@@ -1,0 +1,37 @@
+package flakereport
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTestRunSummaryAddAndMerge(t *testing.T) {
+	left := newTestRunSummary()
+	left.add([]TestRun{
+		{Name: "TestSuite/TestCase (retry 1)", SuiteName: "TestSuite", RunID: 10, MatrixName: "sqlite"},
+		{Name: "TestSuite/TestCase (final)", SuiteName: "TestSuite", RunID: 10, MatrixName: "sqlite", Failed: true},
+		{Name: "TestSuite/TestSkipped", SuiteName: "TestSuite", RunID: 10, MatrixName: "sqlite", Skipped: true},
+	})
+
+	right := newTestRunSummary()
+	right.add([]TestRun{
+		{Name: "TestSuite/TestCase", SuiteName: "TestSuite", RunID: 11, MatrixName: "mysql8", Failed: true},
+		{Name: "TestFunction", SuiteName: "TestFunction", RunID: 11, MatrixName: "mysql8"},
+	})
+	left.merge(right)
+
+	require.Equal(t, 5, left.totalRuns)
+	require.Equal(t, map[string]int{
+		"TestSuite/TestCase": 3,
+		"TestFunction":       1,
+	}, left.countsByTest())
+
+	testRuns := left.tests["TestSuite/TestCase"]
+	require.Equal(t, 3, testRuns.totalRuns)
+	require.Equal(t, 2, testRuns.failures)
+	require.Equal(t, commitRunCounts{passes: 1, fails: 1}, testRuns.byWorkflowRun[10])
+	require.Equal(t, commitRunCounts{fails: 1}, testRuns.byWorkflowRun[11])
+	require.Len(t, left.suiteRuns["TestSuite"], 2)
+	require.NotContains(t, left.suiteRuns, "TestFunction")
+}

--- a/tools/flakereport/bisect.go
+++ b/tools/flakereport/bisect.go
@@ -18,6 +18,22 @@ const (
 	minBisectRuns     = 30 // skip test if ran fewer than this many times total
 )
 
+type testRunIndex struct {
+	commitOrder []string
+	tests       map[string]*indexedTestRuns
+}
+
+type indexedTestRuns struct {
+	totalRuns int
+	failures  int
+	byCommit  map[int]commitRunCounts
+}
+
+type commitRunCounts struct {
+	passes int
+	fails  int
+}
+
 // logBeta returns log(Beta(a, b)) = lgamma(a) + lgamma(b) - lgamma(a+b).
 func logBeta(a, b float64) float64 {
 	la, _ := math.Lgamma(a)
@@ -60,60 +76,69 @@ func logSumExpNormalize(logWeights []float64) []float64 {
 	return probs
 }
 
-// buildObservations groups TestRun records for a single (normalized) test name by commit SHA
-// and returns them sorted chronologically using the commit order slice.
-// runToSHA maps workflow RunID → commit SHA.
-// commitOrder lists SHAs from oldest to newest.
-// Runs whose SHA is not in commitOrder are skipped (e.g. from force-pushes or unrelated branches).
-func buildObservations(testName string, runs []TestRun, commitOrderSlice []string, runToSHA map[int64]string) []CommitObservation {
-	// Build commit index map: SHA → index
+// buildTestRunIndex maps summarized workflow runs onto commits. Runs whose SHA is not in
+// commitOrder remain in test-level totals but are excluded from commit observations.
+func buildTestRunIndex(summary *testRunSummary, commitOrderSlice []string, runToSHA map[int64]string) *testRunIndex {
 	commitIdx := make(map[string]int, len(commitOrderSlice))
 	for i, sha := range commitOrderSlice {
 		commitIdx[sha] = i
 	}
 
-	// Aggregate pass/fail counts per commit SHA for this test
-	type counts struct{ passes, fails int }
-	bySHA := make(map[string]*counts)
+	index := &testRunIndex{
+		commitOrder: commitOrderSlice,
+		tests:       make(map[string]*indexedTestRuns),
+	}
+	for testName, summarizedRuns := range summary.tests {
+		testRuns := &indexedTestRuns{
+			totalRuns: summarizedRuns.totalRuns,
+			failures:  summarizedRuns.failures,
+			byCommit:  make(map[int]commitRunCounts),
+		}
+		index.tests[testName] = testRuns
 
-	for _, run := range runs {
-		if run.Skipped {
-			continue
-		}
-		if normalizeTestName(run.Name) != testName {
-			continue
-		}
-		sha, ok := runToSHA[run.RunID]
-		if !ok || sha == "" {
-			continue
-		}
-		if _, inOrder := commitIdx[sha]; !inOrder {
-			continue
-		}
-		if bySHA[sha] == nil {
-			bySHA[sha] = &counts{}
-		}
-		if run.Failed {
-			bySHA[sha].fails++
-		} else {
-			bySHA[sha].passes++
+		for runID, runCounts := range summarizedRuns.byWorkflowRun {
+			sha, ok := runToSHA[runID]
+			if !ok || sha == "" {
+				continue
+			}
+			idx, inOrder := commitIdx[sha]
+			if !inOrder {
+				continue
+			}
+
+			counts := testRuns.byCommit[idx]
+			counts.passes += runCounts.passes
+			counts.fails += runCounts.fails
+			testRuns.byCommit[idx] = counts
 		}
 	}
+	return index
+}
 
-	// Convert to slice and sort by commit index
-	obs := make([]CommitObservation, 0, len(bySHA))
-	for sha, c := range bySHA {
+// buildObservations returns the indexed observations for a test in commit order.
+func buildObservations(testName string, index *testRunIndex) []CommitObservation {
+	testRuns := index.tests[testName]
+	if testRuns == nil {
+		return nil
+	}
+
+	commitIndexes := make([]int, 0, len(testRuns.byCommit))
+	for idx := range testRuns.byCommit {
+		commitIndexes = append(commitIndexes, idx)
+	}
+	sort.Ints(commitIndexes)
+
+	obs := make([]CommitObservation, 0, len(commitIndexes))
+	for _, idx := range commitIndexes {
+		counts := testRuns.byCommit[idx]
 		obs = append(obs, CommitObservation{
-			CommitSHA: sha,
-			CommitIdx: commitIdx[sha],
+			CommitSHA: index.commitOrder[idx],
+			CommitIdx: idx,
 			Prior:     1.0, // uniform prior; adjusted by heuristics if enabled
-			Passes:    c.passes,
-			Fails:     c.fails,
+			Passes:    counts.passes,
+			Fails:     counts.fails,
 		})
 	}
-	sort.Slice(obs, func(i, j int) bool {
-		return obs[i].CommitIdx < obs[j].CommitIdx
-	})
 	return obs
 }
 
@@ -243,8 +268,8 @@ func allFilesMatchSuffixes(files, suffixes []string) bool {
 // commitMetas is a pre-populated, read-only cache of commit metadata (SHA → github.Commit).
 //
 //nolint:revive // Keep the bisect pipeline linear so the filtering steps remain reviewable.
-func runBisectForTest(cfg BisectConfig, testName string, allRuns []TestRun, commitOrderSlice []string, runToSHA map[int64]string, commitMetas map[string]github.Commit) TestBisectReport {
-	obs := buildObservations(testName, allRuns, commitOrderSlice, runToSHA)
+func runBisectForTest(cfg BisectConfig, testName string, index *testRunIndex, commitMetas map[string]github.Commit) TestBisectReport {
+	obs := buildObservations(testName, index)
 
 	totalPasses, totalFails := 0, 0
 	for _, o := range obs {
@@ -349,42 +374,22 @@ func runBisectForTest(cfg BisectConfig, testName string, allRuns []TestRun, comm
 	}
 }
 
-// selectTopFlakyTests selects the top-N flakiest tests that meet minimum signal thresholds.
-// allRuns is the full set of test runs. Returns normalized test names sorted by failure rate desc.
-func selectTopFlakyTests(allRuns []TestRun, cfg BisectConfig) []string {
-	type testStats struct {
-		fails int
-		total int
-	}
-	stats := make(map[string]*testStats)
-	for _, run := range allRuns {
-		if run.Skipped {
-			continue
-		}
-		name := normalizeTestName(run.Name)
-		if stats[name] == nil {
-			stats[name] = &testStats{}
-		}
-		stats[name].total++
-		if run.Failed {
-			stats[name].fails++
-		}
-	}
-
+// selectTopFlakyTests selects the top-N flakiest indexed tests that meet minimum signal thresholds.
+func selectTopFlakyTests(index *testRunIndex, cfg BisectConfig) []string {
 	type ranked struct {
 		name  string
 		rate  float64
 		fails int
 	}
 	var candidates []ranked
-	for name, s := range stats {
-		if s.fails < cfg.MinFailures || s.total < cfg.MinRuns {
+	for name, runs := range index.tests {
+		if runs.failures < cfg.MinFailures || runs.totalRuns < cfg.MinRuns {
 			continue
 		}
 		candidates = append(candidates, ranked{
 			name:  name,
-			rate:  float64(s.fails) / float64(s.total),
-			fails: s.fails,
+			rate:  float64(runs.failures) / float64(runs.totalRuns),
+			fails: runs.failures,
 		})
 	}
 
@@ -407,9 +412,17 @@ func selectTopFlakyTests(allRuns []TestRun, cfg BisectConfig) []string {
 	return names
 }
 
-// runBisectAnalysis is the top-level bisect orchestrator called from the generate command.
-// It runs bisect for the top-N flakiest tests and returns their reports.
-func runBisectAnalysis(ctx context.Context, cfg BisectConfig, allRuns []TestRun, workflowRuns []github.Run) ([]TestBisectReport, error) {
+type bisectPreparation struct {
+	runToSHA    map[int64]string
+	commitOrder []string
+	commitMetas map[string]github.Commit
+}
+
+func prepareBisectAnalysis(ctx context.Context, cfg BisectConfig, workflowRuns []github.Run) (*bisectPreparation, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	// Build runID → SHA map from workflow runs
 	runToSHA := make(map[int64]string, len(workflowRuns))
 	var oldestSHA string
@@ -440,16 +453,6 @@ func runBisectAnalysis(ctx context.Context, cfg BisectConfig, allRuns []TestRun,
 	}
 	fmt.Printf("Commit range: %d commits\n", len(commitOrderSlice))
 
-	// Select qualifying flaky tests
-	targetTests := selectTopFlakyTests(allRuns, cfg)
-	if cfg.TopN > 0 {
-		fmt.Printf("Selected %d tests for bisect analysis (top %d, min %d failures, min %d runs)\n",
-			len(targetTests), cfg.TopN, cfg.MinFailures, cfg.MinRuns)
-	} else {
-		fmt.Printf("Selected %d tests for bisect analysis (all qualifying, min %d failures, min %d runs)\n",
-			len(targetTests), cfg.MinFailures, cfg.MinRuns)
-	}
-
 	// Pre-fetch commit metadata for all unique SHAs that appear in the run set.
 	// Fetching once here (deduplicated, in parallel) avoids O(tests × commits) serial
 	// subprocess calls — the dominant cost of the bisect pipeline.
@@ -462,18 +465,62 @@ func runBisectAnalysis(ctx context.Context, cfg BisectConfig, allRuns []TestRun,
 		}
 	}
 	commitMetas := fetchCommitMetasParallel(ctx, cfg.Repo, uniqueSHAs, defaultConcurrency)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	fmt.Printf("Fetched metadata for %d/%d unique commits\n", len(commitMetas), len(uniqueSHAs))
+	return &bisectPreparation{
+		runToSHA:    runToSHA,
+		commitOrder: commitOrderSlice,
+		commitMetas: commitMetas,
+	}, nil
+}
+
+func runPreparedBisectAnalysis(
+	ctx context.Context,
+	cfg BisectConfig,
+	summary *testRunSummary,
+	preparation *bisectPreparation,
+) ([]TestBisectReport, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	// Index runs once so each test's bisection only visits its own observations.
+	testRuns := buildTestRunIndex(summary, preparation.commitOrder, preparation.runToSHA)
+
+	// Select qualifying flaky tests
+	targetTests := selectTopFlakyTests(testRuns, cfg)
+	if cfg.TopN > 0 {
+		fmt.Printf("Selected %d tests for bisect analysis (top %d, min %d failures, min %d runs)\n",
+			len(targetTests), cfg.TopN, cfg.MinFailures, cfg.MinRuns)
+	} else {
+		fmt.Printf("Selected %d tests for bisect analysis (all qualifying, min %d failures, min %d runs)\n",
+			len(targetTests), cfg.MinFailures, cfg.MinRuns)
+	}
 
 	// Run bisect for each test
 	reports := make([]TestBisectReport, 0, len(targetTests))
 	for _, testName := range targetTests {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		start := time.Now()
-		report := runBisectForTest(cfg, testName, allRuns, commitOrderSlice, runToSHA, commitMetas)
+		report := runBisectForTest(cfg, testName, testRuns, preparation.commitMetas)
 		fmt.Printf("  Bisected %s in %s (skipped=%v)\n", testName, time.Since(start).Round(time.Millisecond), report.Skipped)
 		reports = append(reports, report)
 	}
 
 	return reports, nil
+}
+
+// runBisectAnalysis is the top-level bisect orchestrator called from tests and other tools.
+func runBisectAnalysis(ctx context.Context, cfg BisectConfig, summary *testRunSummary, workflowRuns []github.Run) ([]TestBisectReport, error) {
+	preparation, err := prepareBisectAnalysis(ctx, cfg, workflowRuns)
+	if err != nil {
+		return nil, err
+	}
+	return runPreparedBisectAnalysis(ctx, cfg, summary, preparation)
 }
 
 // fetchCommitMetasParallel fetches commit metadata for a list of SHAs concurrently,

--- a/tools/flakereport/bisect_test.go
+++ b/tools/flakereport/bisect_test.go
@@ -1,6 +1,7 @@
 package flakereport
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -295,9 +296,13 @@ func TestBuildObservations(t *testing.T) {
 		{Name: "TestFoo", Failed: false, RunID: 999},
 	}
 
-	obs := buildObservations("TestFoo", runs, commitOrderSlice, runToSHA)
+	index := buildTestRunIndex(summarizeTestRuns(runs), commitOrderSlice, runToSHA)
+	obs := buildObservations("TestFoo", index)
 
+	require.Equal(t, 12, index.tests["TestFoo"].totalRuns)
+	require.Equal(t, 4, index.tests["TestFoo"].failures)
 	require.Len(t, obs, 4, "should have one observation per commit with data")
+	require.Empty(t, buildObservations("TestMissing", index))
 
 	// Verify chronological ordering
 	for i := 1; i < len(obs); i++ {
@@ -348,14 +353,14 @@ func TestSelectTopFlakyTests(t *testing.T) {
 	t.Run("excludes tests below MinFailures threshold", func(t *testing.T) {
 		runs := makeRunsForTest("TestLowFails", 100, 2) // 2 failures: below minBisectFailures=5
 		cfg := BisectConfig{TopN: 10, MinFailures: 5, MinRuns: 10}
-		result := selectTopFlakyTests(runs, cfg)
+		result := selectTopFlakyTests(buildTestRunIndex(summarizeTestRuns(runs), nil, nil), cfg)
 		assert.NotContains(t, result, "TestLowFails")
 	})
 
 	t.Run("excludes tests below MinRuns threshold", func(t *testing.T) {
 		runs := makeRunsForTest("TestFewRuns", 10, 6) // only 10 total runs: below minBisectRuns=30
 		cfg := BisectConfig{TopN: 10, MinFailures: 5, MinRuns: 30}
-		result := selectTopFlakyTests(runs, cfg)
+		result := selectTopFlakyTests(buildTestRunIndex(summarizeTestRuns(runs), nil, nil), cfg)
 		assert.NotContains(t, result, "TestFewRuns")
 	})
 
@@ -366,7 +371,7 @@ func TestSelectTopFlakyTests(t *testing.T) {
 		runs = append(runs, makeRunsForTest("TestHighRate", 40, 20)...)
 		runs = append(runs, makeRunsForTest("TestLowRate", 40, 10)...)
 		cfg := BisectConfig{TopN: 10, MinFailures: 5, MinRuns: 30}
-		result := selectTopFlakyTests(runs, cfg)
+		result := selectTopFlakyTests(buildTestRunIndex(summarizeTestRuns(runs), nil, nil), cfg)
 		require.GreaterOrEqual(t, len(result), 2)
 		assert.Equal(t, "TestHighRate", result[0])
 		assert.Equal(t, "TestLowRate", result[1])
@@ -378,7 +383,7 @@ func TestSelectTopFlakyTests(t *testing.T) {
 			runs = append(runs, makeRunsForTest("TestFlaky"+string(rune('A'+i)), 40, 10)...)
 		}
 		cfg := BisectConfig{TopN: 3, MinFailures: 5, MinRuns: 30}
-		result := selectTopFlakyTests(runs, cfg)
+		result := selectTopFlakyTests(buildTestRunIndex(summarizeTestRuns(runs), nil, nil), cfg)
 		assert.Len(t, result, 3)
 	})
 
@@ -388,7 +393,7 @@ func TestSelectTopFlakyTests(t *testing.T) {
 			{Name: "TestSkipped", Skipped: true, Failed: true},
 		}
 		cfg := BisectConfig{TopN: 10, MinFailures: 1, MinRuns: 1}
-		result := selectTopFlakyTests(runs, cfg)
+		result := selectTopFlakyTests(buildTestRunIndex(summarizeTestRuns(runs), nil, nil), cfg)
 		assert.NotContains(t, result, "TestSkipped")
 	})
 
@@ -402,7 +407,7 @@ func TestSelectTopFlakyTests(t *testing.T) {
 			runs = append(runs, TestRun{Name: "TestFlaky (retry 1)", Failed: true})
 		}
 		cfg := BisectConfig{TopN: 10, MinFailures: 5, MinRuns: 30}
-		result := selectTopFlakyTests(runs, cfg)
+		result := selectTopFlakyTests(buildTestRunIndex(summarizeTestRuns(runs), nil, nil), cfg)
 		require.Len(t, result, 1)
 		assert.Equal(t, "TestFlaky", result[0])
 	})
@@ -508,7 +513,8 @@ func TestRunBisectForTestDirectionFilter(t *testing.T) {
 		MinProbability: 0.5,
 	}
 
-	report := runBisectForTest(cfg, "TestFoo", allRuns, commitOrderSlice, runToSHA, nil)
+	index := buildTestRunIndex(summarizeTestRuns(allRuns), commitOrderSlice, runToSHA)
+	report := runBisectForTest(cfg, "TestFoo", index, nil)
 
 	// The only high-probability transition point (sha5, where rate dropped 80%→0%) should be
 	// filtered out by the direction filter, leaving no actionable suspects.
@@ -547,12 +553,50 @@ func TestRunBisectForTestDirectionFilterKeepsIntroduction(t *testing.T) {
 		MinProbability: 0.5,
 	}
 
-	report := runBisectForTest(cfg, "TestFoo", allRuns, commitOrderSlice, runToSHA, nil)
+	index := buildTestRunIndex(summarizeTestRuns(allRuns), commitOrderSlice, runToSHA)
+	report := runBisectForTest(cfg, "TestFoo", index, nil)
 
 	require.False(t, report.Skipped, "report should not be skipped: a real introduction exists")
 	require.NotEmpty(t, report.TopSuspects)
 	assert.Equal(t, "sha3", report.TopSuspects[0].CommitSHA, "sha3 should be the top suspect")
 	assert.Greater(t, report.TopSuspects[0].Probability, 0.5)
+}
+
+func BenchmarkTestRunIndex(b *testing.B) {
+	const (
+		testCount   = 1000
+		commitCount = 20
+		runsPerTest = 100
+	)
+
+	commitOrderSlice := make([]string, commitCount)
+	runToSHA := make(map[int64]string, commitCount)
+	for i := range commitCount {
+		sha := fmt.Sprintf("sha-%d", i)
+		commitOrderSlice[i] = sha
+		runToSHA[int64(i)] = sha
+	}
+
+	runs := make([]TestRun, 0, testCount*runsPerTest)
+	for testIdx := range testCount {
+		name := fmt.Sprintf("Test%d", testIdx)
+		for runIdx := range runsPerTest {
+			runs = append(runs, TestRun{
+				Name:   name,
+				Failed: runIdx%10 == 0,
+				RunID:  int64(runIdx % commitCount),
+			})
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		index := buildTestRunIndex(summarizeTestRuns(runs), commitOrderSlice, runToSHA)
+		for testName := range index.tests {
+			buildObservations(testName, index)
+		}
+	}
 }
 
 // makeRunsForTest creates a slice of TestRun with the given total count and failure count.
@@ -566,4 +610,10 @@ func makeRunsForTest(name string, total, failures int) []TestRun {
 		}
 	}
 	return runs
+}
+
+func summarizeTestRuns(runs []TestRun) *testRunSummary {
+	summary := newTestRunSummary()
+	summary.add(runs)
+	return summary
 }

--- a/tools/flakereport/flakereport.go
+++ b/tools/flakereport/flakereport.go
@@ -10,6 +10,7 @@ import (
 	"github.com/urfave/cli/v2"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/tools/common/github"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -141,55 +142,141 @@ func fetchAndAnalyzeWorkflowRuns(ctx context.Context, repo string, workflowID in
 	return runs, successfulRuns, nil
 }
 
-// collectArtifactJobs collects all artifact jobs from workflow runs
-func collectArtifactJobs(ctx context.Context, repo string, runs []github.Run, tempDir string) ([]ArtifactJob, error) {
-	fmt.Println("\n=== Collecting artifacts ===")
-	var jobs []ArtifactJob
-	totalArtifacts := 0
+type artifactRunResult struct {
+	index     int
+	run       github.Run
+	artifacts []github.Artifact
+	err       error
+}
 
-	for i, run := range runs {
-		artifacts, err := fetchRunArtifacts(ctx, repo, run.DatabaseID)
-		if err != nil {
-			fmt.Printf("Warning: Failed to fetch artifacts for run %d: %v\n", run.DatabaseID, err)
-			continue
-		}
+type artifactDiscoveryResult struct {
+	jobs []ArtifactJob
+	err  error
+}
 
-		if len(artifacts) == 0 {
-			fmt.Printf("Run %d/%d (ID: %d, CreatedAt: %s): No test artifacts found\n",
-				i+1, len(runs), run.DatabaseID, run.CreatedAt.Format(time.RFC3339Nano))
-			continue
-		}
+type bisectPreparationResult struct {
+	preparation *bisectPreparation
+	err         error
+}
 
-		fmt.Printf("Run %d/%d (ID: %d, CreatedAt: %s): Found %d artifacts\n",
-			i+1, len(runs), run.DatabaseID, run.CreatedAt.Format(time.RFC3339Nano), len(artifacts))
+type fetchRunArtifactsFunc func(context.Context, string, int64) ([]github.Artifact, error)
 
-		for _, artifact := range artifacts {
-			totalArtifacts++
-			jobs = append(jobs, ArtifactJob{
-				Repo:         repo,
-				RunID:        run.DatabaseID,
-				RunCreatedAt: run.CreatedAt,
-				Artifact:     artifact,
-				TempDir:      tempDir,
-				RunNumber:    i + 1,
-				TotalRuns:    len(runs),
-				ArtifactNum:  totalArtifacts,
+func streamArtifactJobs(
+	ctx context.Context,
+	repo string,
+	runs []github.Run,
+	tempDir string,
+) (<-chan ArtifactJob, <-chan artifactDiscoveryResult) {
+	return streamArtifactJobsWithFetcher(ctx, repo, runs, tempDir, fetchRunArtifacts)
+}
+
+func streamArtifactJobsWithFetcher(
+	ctx context.Context,
+	repo string,
+	runs []github.Run,
+	tempDir string,
+	fetchArtifacts fetchRunArtifactsFunc,
+) (<-chan ArtifactJob, <-chan artifactDiscoveryResult) {
+	jobs := make(chan ArtifactJob, defaultConcurrency)
+	done := make(chan artifactDiscoveryResult, 1)
+	runResults := make(chan artifactRunResult, defaultConcurrency)
+
+	go func() {
+		g, groupCtx := errgroup.WithContext(ctx)
+		g.SetLimit(defaultConcurrency)
+		for i, run := range runs {
+			g.Go(func() error {
+				artifacts, err := fetchArtifacts(groupCtx, repo, run.DatabaseID)
+				select {
+				case runResults <- artifactRunResult{index: i, run: run, artifacts: artifacts, err: err}:
+					return nil
+				case <-groupCtx.Done():
+					return groupCtx.Err()
+				}
 			})
 		}
+		_ = g.Wait()
+		close(runResults)
+	}()
+
+	go func() {
+		defer close(jobs)
+		result := artifactDiscoveryResult{}
+		artifactNum := 0
+		for runResult := range runResults {
+			if runResult.err != nil {
+				fmt.Printf("Warning: Failed to fetch artifacts for run %d: %v\n", runResult.run.DatabaseID, runResult.err)
+				continue
+			}
+			if len(runResult.artifacts) == 0 {
+				fmt.Printf("Run %d/%d (ID: %d, CreatedAt: %s): No test artifacts found\n",
+					runResult.index+1, len(runs), runResult.run.DatabaseID, runResult.run.CreatedAt.Format(time.RFC3339Nano))
+				continue
+			}
+
+			fmt.Printf("Run %d/%d (ID: %d, CreatedAt: %s): Found %d artifacts\n",
+				runResult.index+1, len(runs), runResult.run.DatabaseID,
+				runResult.run.CreatedAt.Format(time.RFC3339Nano), len(runResult.artifacts))
+			for _, artifact := range runResult.artifacts {
+				artifactNum++
+				job := ArtifactJob{
+					Repo:         repo,
+					RunID:        runResult.run.DatabaseID,
+					RunCreatedAt: runResult.run.CreatedAt,
+					Artifact:     artifact,
+					TempDir:      tempDir,
+					RunNumber:    runResult.index + 1,
+					TotalRuns:    len(runs),
+					ArtifactNum:  artifactNum,
+				}
+				result.jobs = append(result.jobs, job)
+				select {
+				case jobs <- job:
+				case <-ctx.Done():
+					result.err = ctx.Err()
+					done <- result
+					return
+				}
+			}
+		}
+		result.err = ctx.Err()
+		fmt.Printf("\nTotal artifacts discovered: %d\n", len(result.jobs))
+		done <- result
+	}()
+
+	return jobs, done
+}
+
+func processWorkflowArtifacts(
+	ctx context.Context,
+	repo string,
+	runs []github.Run,
+	tempDir string,
+	concurrency int,
+) ([]TestFailure, *testRunSummary, []ArtifactJob, int, error) {
+	if concurrency < 1 {
+		return nil, nil, nil, 0, fmt.Errorf("concurrency must be at least 1")
 	}
 
-	fmt.Printf("\nTotal artifacts to process: %d\n", totalArtifacts)
-	return jobs, nil
+	jobs, discoveryDone := streamArtifactJobs(ctx, repo, runs, tempDir)
+	failures, summary, processed, processErr := processArtifactStream(ctx, jobs, concurrency)
+	discovery := <-discoveryDone
+	if processErr != nil {
+		return nil, nil, discovery.jobs, processed, processErr
+	}
+	if discovery.err != nil {
+		return nil, nil, discovery.jobs, processed, discovery.err
+	}
+	return failures, summary, discovery.jobs, processed, nil
 }
 
 // buildReportSummary builds the complete report summary from processed data
 func buildReportSummary(flakyReports, timeoutReports, crashReports, ciBreakerReports []TestReport,
 	suiteReports []SuiteReport,
-	allFailures []TestFailure, allTestRuns []TestRun, runs []github.Run, successfulRuns int) *ReportSummary {
+	allFailures []TestFailure, totalTestRuns int, runs []github.Run, successfulRuns int) *ReportSummary {
 
 	// Calculate overall failure rate
 	overallFailureRate := 0.0
-	totalTestRuns := len(allTestRuns)
 	if totalTestRuns > 0 {
 		overallFailureRate = (float64(len(allFailures)) / float64(totalTestRuns)) * 1000.0
 	}
@@ -267,23 +354,49 @@ func runGenerateCommand(c *cli.Context) (err error) {
 		}
 	}()
 
-	// Collect all artifacts
-	jobs, err := collectArtifactJobs(ctx, repo, runs, tempDir)
-	if err != nil {
-		return err
+	var bisectCfg BisectConfig
+	var bisectPreparationDone <-chan bisectPreparationResult
+	if runBisect {
+		bisectCfg = BisectConfig{
+			Repo:           repo,
+			TopN:           bisectTopN,
+			MinFailures:    minBisectFailures,
+			MinRuns:        minBisectRuns,
+			MinProbability: bisectMinProbability,
+		}
+		preparationDone := make(chan bisectPreparationResult, 1)
+		bisectPreparationDone = preparationDone
+		go func() {
+			bisectRuns := runs
+			if bisectDays > days {
+				bisectSince := now.AddDate(0, 0, -bisectDays)
+				fmt.Printf("Fetching incremental runs for bisect (days %d–%d)...\n", days, bisectDays)
+				extraRuns, _, extraErr := fetchAndAnalyzeWorkflowRuns(ctx, repo, workflowID, branch, bisectSince, reportSince)
+				if extraErr != nil {
+					fmt.Printf("Warning: Failed to fetch bisect runs: %v\n", extraErr)
+				} else {
+					bisectRuns = append(extraRuns, runs...)
+				}
+			}
+			preparation, prepErr := prepareBisectAnalysis(ctx, bisectCfg, bisectRuns)
+			preparationDone <- bisectPreparationResult{preparation: preparation, err: prepErr}
+		}()
 	}
 
-	// Process artifacts in parallel
-	fmt.Println("\n=== Processing artifacts in parallel ===")
-	allFailures, allTestRuns, processedArtifacts := processArtifactsParallel(ctx, jobs, concurrency)
+	// Discover, download, and parse artifacts as a bounded pipeline.
+	fmt.Println("\n=== Discovering and processing artifacts ===")
+	allFailures, testRuns, jobs, processedArtifacts, err := processWorkflowArtifacts(ctx, repo, runs, tempDir, concurrency)
+	if err != nil {
+		return fmt.Errorf("failed to process artifacts: %w", err)
+	}
 
 	fmt.Println("\n=== Processing Results ===")
-	fmt.Printf("Total test runs: %d\n", len(allTestRuns))
+	fmt.Printf("Total test runs: %d\n", testRuns.totalRuns)
 	fmt.Printf("Total test failures found: %d\n", len(allFailures))
 	fmt.Printf("Processed artifacts: %d\n", processedArtifacts)
 
 	// Count test runs by name for failure rate calculation
-	testRunCounts := countTestRuns(allTestRuns)
+	testRunCounts := testRuns.countsByTest()
 
 	// Group failures by test name, then remove parent entries whose subtests were observed.
 	grouped := groupFailuresByTest(allFailures)
@@ -309,43 +422,29 @@ func runGenerateCommand(c *cli.Context) (err error) {
 	ciBreakerReports := convertCIBreakersToReports(ciBreakerMap, ciBreakCounts, len(runs), repo, maxLinks, reportWindow)
 
 	// Compute suite-level breakdown
-	suiteReports := generateSuiteReports(allFailures, allTestRuns)
+	suiteReports := generateSuiteReports(allFailures, testRuns.suiteRuns)
 	fmt.Printf("Suites: %d\n", len(suiteReports))
 
 	// Build summary
 	summary := buildReportSummary(
 		flakyReports, timeoutReports, crashReports, ciBreakerReports,
 		suiteReports,
-		allFailures, allTestRuns, runs, successfulRuns,
+		allFailures, testRuns.totalRuns, runs, successfulRuns,
 	)
 
 	// Optionally run Bayesian bisect analysis
 	var bisectReports []TestBisectReport
 	if runBisect {
 		fmt.Println("\n=== Running Bayesian bisect analysis ===")
-		// Extend the run set with the incremental window (days→bisectDays) to avoid
-		// re-fetching runs we already have from the report window.
-		bisectRuns := runs
-		if bisectDays > days {
-			bisectSince := now.AddDate(0, 0, -bisectDays)
-			fmt.Printf("Fetching incremental runs for bisect (days %d–%d)...\n", days, bisectDays)
-			extraRuns, _, extraErr := fetchAndAnalyzeWorkflowRuns(ctx, repo, workflowID, branch, bisectSince, reportSince)
-			if extraErr != nil {
-				fmt.Printf("Warning: Failed to fetch bisect runs: %v\n", extraErr)
-			} else {
-				bisectRuns = append(extraRuns, runs...)
+		preparationResult := <-bisectPreparationDone
+		if preparationResult.err != nil {
+			fmt.Printf("Warning: Bisect preparation failed: %v\n", preparationResult.err)
+		} else {
+			var analysisErr error
+			bisectReports, analysisErr = runPreparedBisectAnalysis(ctx, bisectCfg, testRuns, preparationResult.preparation)
+			if analysisErr != nil {
+				fmt.Printf("Warning: Bisect analysis failed: %v\n", analysisErr)
 			}
-		}
-		bisectCfg := BisectConfig{
-			Repo:           repo,
-			TopN:           bisectTopN,
-			MinFailures:    minBisectFailures,
-			MinRuns:        minBisectRuns,
-			MinProbability: bisectMinProbability,
-		}
-		bisectReports, err = runBisectAnalysis(ctx, bisectCfg, allTestRuns, bisectRuns)
-		if err != nil {
-			fmt.Printf("Warning: Bisect analysis failed: %v\n", err)
 		}
 	}
 

--- a/tools/flakereport/flakereport.go
+++ b/tools/flakereport/flakereport.go
@@ -66,6 +66,11 @@ func NewCliApp() *cli.App {
 					Value: defaultConcurrency,
 					Usage: "Number of parallel workers for artifact processing",
 				},
+				&cli.IntFlag{
+					Name:  "rps",
+					Value: github.DefaultAPIRPS,
+					Usage: "Maximum GitHub API requests per second",
+				},
 				&cli.StringFlag{
 					Name:  "output-dir",
 					Value: "out",
@@ -305,6 +310,7 @@ func runGenerateCommand(c *cli.Context) (err error) {
 	workflowID := c.Int64("workflow-id")
 	maxLinks := c.Int("max-links")
 	concurrency := c.Int("concurrency")
+	rps := c.Int("rps")
 	outputDir := c.String("output-dir")
 	slackWebhook := c.String("slack-webhook")
 	runID := c.String("run-id")
@@ -320,6 +326,9 @@ func runGenerateCommand(c *cli.Context) (err error) {
 			sendFailureNotification(slackWebhook, runID, refName, sha, repo, err)
 		}
 	}()
+	if err := github.SetAPIRPS(rps); err != nil {
+		return err
+	}
 
 	fmt.Println("Starting flaky test report generation...")
 	fmt.Printf("Repository: %s\n", repo)
@@ -327,6 +336,7 @@ func runGenerateCommand(c *cli.Context) (err error) {
 	fmt.Printf("Lookback days: %d\n", days)
 	fmt.Printf("Workflow ID: %d\n", workflowID)
 	fmt.Printf("Parallel workers: %d\n", concurrency)
+	fmt.Printf("GitHub API requests per second: %d\n", rps)
 
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)

--- a/tools/flakereport/flakereport_test.go
+++ b/tools/flakereport/flakereport_test.go
@@ -1,0 +1,41 @@
+package flakereport
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/tools/common/github"
+)
+
+func TestStreamArtifactJobsEmitsCompletedRunImmediately(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	runs := []github.Run{
+		{DatabaseID: 1},
+		{DatabaseID: 2},
+	}
+	releaseSlowRun := make(chan struct{})
+	fetch := func(ctx context.Context, _ string, runID int64) ([]github.Artifact, error) {
+		if runID == 1 {
+			select {
+			case <-releaseSlowRun:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+		return []github.Artifact{{ID: runID, Name: "junit"}}, nil
+	}
+
+	jobs, done := streamArtifactJobsWithFetcher(ctx, "temporalio/temporal", runs, t.TempDir(), fetch)
+	firstJob := <-jobs
+	require.Equal(t, int64(2), firstJob.RunID)
+	close(releaseSlowRun)
+	for range jobs {
+	}
+	result := <-done
+	require.NoError(t, result.err)
+	require.Len(t, result.jobs, 2)
+}

--- a/tools/flakereport/flakereport_test.go
+++ b/tools/flakereport/flakereport_test.go
@@ -6,8 +6,24 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
 	"go.temporal.io/server/tools/common/github"
 )
+
+func TestGenerateCommandRPSFlag(t *testing.T) {
+	app := NewCliApp()
+	command := app.Commands[0]
+	for _, flag := range command.Flags {
+		intFlag, ok := flag.(*cli.IntFlag)
+		if !ok || intFlag.Name != "rps" {
+			continue
+		}
+		require.Equal(t, github.DefaultAPIRPS, intFlag.Value)
+		require.Equal(t, "Maximum GitHub API requests per second", intFlag.Usage)
+		return
+	}
+	t.Fatal("generate command does not define an rps flag")
+}
 
 func TestStreamArtifactJobsEmitsCompletedRunImmediately(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/tools/flakereport/github.go
+++ b/tools/flakereport/github.go
@@ -59,7 +59,7 @@ func fetchRunArtifacts(ctx context.Context, repo string, runID int64) ([]github.
 }
 
 // extractArtifactZip extracts zip file and returns paths to JUnit XML files
-func extractArtifactZip(zipPath, outputDir string) ([]string, error) {
+func extractArtifactZip(ctx context.Context, zipPath, outputDir string) ([]string, error) {
 	r, err := zip.OpenReader(zipPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open zip file %s: %w", zipPath, err)
@@ -73,6 +73,9 @@ func extractArtifactZip(zipPath, outputDir string) ([]string, error) {
 	var xmlFiles []string
 
 	for _, f := range r.File {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		// Skip directories
 		if f.FileInfo().IsDir() {
 			continue
@@ -100,7 +103,7 @@ func extractArtifactZip(zipPath, outputDir string) ([]string, error) {
 		}
 
 		// Copy content
-		_, err = io.Copy(outFile, rc)
+		_, err = io.Copy(outFile, contextReader{ctx: ctx, reader: rc})
 		if closeErr := rc.Close(); closeErr != nil {
 			_ = outFile.Close()
 			return nil, fmt.Errorf("failed to close zip file reader: %w", closeErr)

--- a/tools/flakereport/parallel.go
+++ b/tools/flakereport/parallel.go
@@ -3,12 +3,16 @@ package flakereport
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"time"
 
 	"go.temporal.io/server/tools/common/github"
 )
+
+const maxFailureSamplesPerArtifact = 3
 
 // ArtifactJob represents a job to download and process an artifact
 type ArtifactJob struct {
@@ -25,58 +29,107 @@ type ArtifactJob struct {
 // ArtifactResult represents the result of processing an artifact
 type ArtifactResult struct {
 	Failures []TestFailure
-	AllRuns  []TestRun
+	Summary  *testRunSummary
 	Error    error
 }
 
+type downloadedArtifact struct {
+	Job     ArtifactJob
+	ZipPath string
+	Error   error
+}
+
+type artifactDownloadFunc func(context.Context, ArtifactJob) downloadedArtifact
+type artifactParseFunc func(context.Context, downloadedArtifact) ArtifactResult
+
 // processArtifactsParallel downloads and processes artifacts in parallel with a worker pool
-// Returns: all failures, all test runs, and count of successfully processed artifacts
-func processArtifactsParallel(ctx context.Context, jobs []ArtifactJob, concurrency int) ([]TestFailure, []TestRun, int) {
+// Returns: all failures, summarized test runs, and count of successfully processed artifacts.
+func processArtifactsParallel(ctx context.Context, jobs []ArtifactJob, concurrency int) ([]TestFailure, *testRunSummary, int, error) {
+	if concurrency < 1 {
+		return nil, nil, 0, fmt.Errorf("concurrency must be at least 1")
+	}
 	if len(jobs) == 0 {
-		return nil, nil, 0
+		return nil, newTestRunSummary(), 0, nil
 	}
 
-	totalArtifacts := len(jobs)
-
-	// Create channels
-	jobChan := make(chan ArtifactJob, totalArtifacts)
-	resultChan := make(chan ArtifactResult, totalArtifacts)
-
-	// Start worker pool
-	var wg sync.WaitGroup
-	for range concurrency {
-		wg.Add(1)
-		go worker(ctx, jobChan, resultChan, totalArtifacts, &wg)
-	}
-
-	// Send jobs to workers
+	jobChan := make(chan ArtifactJob, concurrency)
 	go func() {
+		defer close(jobChan)
 		for _, job := range jobs {
-			jobChan <- job
+			select {
+			case jobChan <- job:
+			case <-ctx.Done():
+				return
+			}
 		}
-		close(jobChan)
+	}()
+	return processArtifactStream(ctx, jobChan, concurrency)
+}
+
+func processArtifactStream(ctx context.Context, jobs <-chan ArtifactJob, downloadConcurrency int) ([]TestFailure, *testRunSummary, int, error) {
+	if downloadConcurrency < 1 {
+		return nil, nil, 0, fmt.Errorf("concurrency must be at least 1")
+	}
+
+	parseConcurrency := min(downloadConcurrency, runtime.GOMAXPROCS(0))
+	return processArtifactStreamWithFunctions(
+		ctx,
+		jobs,
+		downloadConcurrency,
+		parseConcurrency,
+		downloadArtifactJob,
+		processDownloadedArtifact,
+	)
+}
+
+func processArtifactStreamWithFunctions(
+	ctx context.Context,
+	jobs <-chan ArtifactJob,
+	downloadConcurrency int,
+	parseConcurrency int,
+	download artifactDownloadFunc,
+	parse artifactParseFunc,
+) ([]TestFailure, *testRunSummary, int, error) {
+	if downloadConcurrency < 1 || parseConcurrency < 1 {
+		return nil, nil, 0, fmt.Errorf("worker concurrency must be at least 1")
+	}
+	downloaded := make(chan downloadedArtifact, downloadConcurrency)
+	results := make(chan ArtifactResult, parseConcurrency)
+
+	var downloadWG sync.WaitGroup
+	for range downloadConcurrency {
+		downloadWG.Add(1)
+		go downloadWorker(ctx, jobs, downloaded, download, &downloadWG)
+	}
+	go func() {
+		downloadWG.Wait()
+		close(downloaded)
 	}()
 
-	// Wait for all workers to finish
+	var parseWG sync.WaitGroup
+	for range parseConcurrency {
+		parseWG.Add(1)
+		go parseWorker(ctx, downloaded, results, parse, &parseWG)
+	}
 	go func() {
-		wg.Wait()
-		close(resultChan)
+		parseWG.Wait()
+		close(results)
 	}()
 
 	// Collect results
 	var allFailures []TestFailure
-	var allTestRuns []TestRun
+	summary := newTestRunSummary()
 	processedArtifacts := 0
 	errorCount := 0
 
-	for result := range resultChan {
+	for result := range results {
 		if result.Error != nil {
 			errorCount++
 			// Error already logged by worker
 			continue
 		}
 		allFailures = append(allFailures, result.Failures...)
-		allTestRuns = append(allTestRuns, result.AllRuns...)
+		summary.merge(result.Summary)
 		processedArtifacts++
 	}
 
@@ -84,49 +137,127 @@ func processArtifactsParallel(ctx context.Context, jobs []ArtifactJob, concurren
 		fmt.Printf("Warning: %d artifacts failed to process\n", errorCount)
 	}
 
-	return allFailures, allTestRuns, processedArtifacts
+	if err := ctx.Err(); err != nil {
+		return nil, nil, processedArtifacts, err
+	}
+	return allFailures, summary, processedArtifacts, nil
 }
 
-// worker processes jobs from the job channel
-func worker(ctx context.Context, jobs <-chan ArtifactJob, results chan<- ArtifactResult, totalArtifacts int, wg *sync.WaitGroup) {
+func downloadWorker(
+	ctx context.Context,
+	jobs <-chan ArtifactJob,
+	downloaded chan<- downloadedArtifact,
+	download artifactDownloadFunc,
+	wg *sync.WaitGroup,
+) {
 	defer wg.Done()
 
-	for job := range jobs {
-		result := processArtifactJob(ctx, job, totalArtifacts)
-		results <- result
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case job, ok := <-jobs:
+			if !ok {
+				return
+			}
+			result := download(ctx, job)
+			select {
+			case downloaded <- result:
+			case <-ctx.Done():
+				return
+			}
+		}
 	}
 }
 
-// processArtifactJob downloads and processes a single artifact
-func processArtifactJob(ctx context.Context, job ArtifactJob, totalArtifacts int) ArtifactResult {
-	var result ArtifactResult
+func downloadArtifactJob(ctx context.Context, job ArtifactJob) downloadedArtifact {
+	result := downloadedArtifact{Job: job}
+	if err := ctx.Err(); err != nil {
+		result.Error = err
+		return result
+	}
 
-	fmt.Printf("  [%d/%d] Run %d/%d: Downloading artifact %s (ID: %d)...\n",
-		job.ArtifactNum, totalArtifacts, job.RunNumber, job.TotalRuns,
+	fmt.Printf("  [artifact %d] Run %d/%d: Downloading %s (ID: %d)...\n",
+		job.ArtifactNum, job.RunNumber, job.TotalRuns,
 		job.Artifact.Name, job.Artifact.ID)
 
-	// Download artifact
 	zipPath, err := github.DownloadArtifact(ctx, job.Repo, job.Artifact.ID, job.TempDir)
 	if err != nil {
 		result.Error = fmt.Errorf("failed to download artifact %d: %w", job.Artifact.ID, err)
 		fmt.Printf("  Warning: %v\n", result.Error)
 		return result
 	}
+	result.ZipPath = zipPath
+	return result
+}
+
+func parseWorker(
+	ctx context.Context,
+	downloaded <-chan downloadedArtifact,
+	results chan<- ArtifactResult,
+	parse artifactParseFunc,
+	wg *sync.WaitGroup,
+) {
+	defer wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case artifact, ok := <-downloaded:
+			if !ok {
+				return
+			}
+			result := parse(ctx, artifact)
+			select {
+			case results <- result:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+func processDownloadedArtifact(ctx context.Context, downloaded downloadedArtifact) ArtifactResult {
+	result := ArtifactResult{Summary: newTestRunSummary()}
+	if downloaded.Error != nil {
+		result.Error = downloaded.Error
+		return result
+	}
+	job := downloaded.Job
+	defer func() {
+		if err := os.Remove(downloaded.ZipPath); err != nil && !os.IsNotExist(err) {
+			fmt.Printf("  Warning: Failed to remove artifact %d ZIP: %v\n", job.Artifact.ID, err)
+		}
+	}()
 
 	// Extract XML files
-	xmlFiles, err := extractArtifactZip(zipPath, job.TempDir)
+	extractDir := filepath.Join(job.TempDir, fmt.Sprintf("artifact-%d", job.Artifact.ID))
+	if err := os.MkdirAll(extractDir, 0o755); err != nil {
+		result.Error = fmt.Errorf("failed to create extraction directory for artifact %d: %w", job.Artifact.ID, err)
+		return result
+	}
+	defer func() {
+		if err := os.RemoveAll(extractDir); err != nil {
+			fmt.Printf("  Warning: Failed to remove artifact %d extraction directory: %v\n", job.Artifact.ID, err)
+		}
+	}()
+	xmlFiles, err := extractArtifactZip(ctx, downloaded.ZipPath, extractDir)
 	if err != nil {
 		result.Error = fmt.Errorf("failed to extract artifact %d: %w", job.Artifact.ID, err)
 		fmt.Printf("  Warning: %v\n", result.Error)
 		return result
 	}
 
-	fmt.Printf("  [%d/%d] Extracted %d XML files from %s\n",
-		job.ArtifactNum, totalArtifacts, len(xmlFiles), job.Artifact.Name)
+	fmt.Printf("  [artifact %d] Extracted %d XML files from %s\n",
+		job.ArtifactNum, len(xmlFiles), job.Artifact.Name)
 
 	// Parse JUnit XML files
 	for _, xmlFile := range xmlFiles {
-		suites, err := parseJUnitFile(xmlFile)
+		if err := ctx.Err(); err != nil {
+			result.Error = err
+			return result
+		}
+		suites, err := parseJUnitFile(ctx, xmlFile)
 		if err != nil {
 			fmt.Printf("  Warning: Failed to parse %s: %v\n", filepath.Base(xmlFile), err)
 			continue
@@ -139,13 +270,17 @@ func processArtifactJob(ctx context.Context, job ArtifactJob, totalArtifacts int
 		// Extract all test runs for failure rate calculation
 		_, jobID, matrixName := parseArtifactName(job.Artifact.Name)
 		testRuns := extractAllTestRuns(suites, job.RunID, jobID, matrixName)
-		result.AllRuns = append(result.AllRuns, testRuns...)
+		result.Summary.add(testRuns)
+		if err := ctx.Err(); err != nil {
+			result.Error = err
+			return result
+		}
 	}
 
-	fmt.Printf("  [%d/%d] Found %d failures from %d test runs in %s\n",
-		job.ArtifactNum, totalArtifacts, len(result.Failures), len(result.AllRuns), job.Artifact.Name)
+	fmt.Printf("  [artifact %d] Found %d failures from %d test runs in %s\n",
+		job.ArtifactNum, len(result.Failures), result.Summary.totalRuns, job.Artifact.Name)
 
-	for i := 0; i < len(result.Failures); i++ {
+	for i := 0; i < min(len(result.Failures), maxFailureSamplesPerArtifact); i++ {
 		fmt.Printf("    Sample failure %d: %s\n", i+1, result.Failures[i].Name)
 	}
 

--- a/tools/flakereport/parallel_test.go
+++ b/tools/flakereport/parallel_test.go
@@ -1,0 +1,118 @@
+package flakereport
+
+import (
+	"archive/zip"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/tools/common/github"
+)
+
+func TestProcessArtifactsParallelRejectsInvalidConcurrency(t *testing.T) {
+	_, _, _, err := processArtifactsParallel(context.Background(), nil, 0)
+	require.ErrorContains(t, err, "concurrency must be at least 1")
+}
+
+func TestProcessArtifactsParallelCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _, _, err := processArtifactsParallel(ctx, []ArtifactJob{{}}, 1)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestArtifactPipelineOverlapsDownloadsAndParsing(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	jobs := make(chan ArtifactJob, 2)
+	jobs <- ArtifactJob{Artifact: github.Artifact{ID: 1}}
+	jobs <- ArtifactJob{Artifact: github.Artifact{ID: 2}}
+	close(jobs)
+
+	parseStarted := make(chan struct{})
+	secondDownloaded := make(chan struct{})
+	releaseParse := make(chan struct{})
+	download := func(ctx context.Context, job ArtifactJob) downloadedArtifact {
+		if job.Artifact.ID == 2 {
+			select {
+			case <-parseStarted:
+				close(secondDownloaded)
+			case <-ctx.Done():
+				return downloadedArtifact{Job: job, Error: ctx.Err()}
+			}
+		}
+		return downloadedArtifact{Job: job}
+	}
+	parse := func(ctx context.Context, artifact downloadedArtifact) ArtifactResult {
+		if artifact.Job.Artifact.ID == 1 {
+			close(parseStarted)
+			select {
+			case <-releaseParse:
+			case <-ctx.Done():
+				return ArtifactResult{Summary: newTestRunSummary(), Error: ctx.Err()}
+			}
+		}
+		summary := newTestRunSummary()
+		summary.add([]TestRun{{Name: "TestPipeline", RunID: artifact.Job.Artifact.ID}})
+		return ArtifactResult{Summary: summary}
+	}
+
+	type pipelineResult struct {
+		summary   *testRunSummary
+		processed int
+		err       error
+	}
+	done := make(chan pipelineResult, 1)
+	go func() {
+		_, summary, processed, err := processArtifactStreamWithFunctions(ctx, jobs, 2, 1, download, parse)
+		done <- pipelineResult{summary: summary, processed: processed, err: err}
+	}()
+
+	select {
+	case <-secondDownloaded:
+		close(releaseParse)
+	case <-ctx.Done():
+		t.Fatal("second download did not finish while the first artifact was parsing")
+	}
+
+	result := <-done
+	require.NoError(t, result.err)
+	require.Equal(t, 2, result.processed)
+	require.Equal(t, 2, result.summary.totalRuns)
+}
+
+func TestProcessDownloadedArtifactParsesAndCleansTemporaryFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	zipPath := filepath.Join(tempDir, "artifact-42.zip")
+	zipFile, err := os.Create(zipPath)
+	require.NoError(t, err)
+	zipWriter := zip.NewWriter(zipFile)
+	entry, err := zipWriter.Create("results.xml")
+	require.NoError(t, err)
+	_, err = entry.Write([]byte(`<testsuites tests="1" failures="1"><testsuite name="suite" tests="1" failures="1"><testcase name="TestStandalone"><failure message="failed"/></testcase></testsuite></testsuites>`))
+	require.NoError(t, err)
+	require.NoError(t, zipWriter.Close())
+	require.NoError(t, zipFile.Close())
+
+	result := processDownloadedArtifact(context.Background(), downloadedArtifact{
+		Job: ArtifactJob{
+			RunID:       7,
+			Artifact:    github.Artifact{ID: 42, Name: "junit-xml--7--8--1--unit-test"},
+			TempDir:     tempDir,
+			ArtifactNum: 1,
+		},
+		ZipPath: zipPath,
+	})
+	require.NoError(t, result.Error)
+	require.Len(t, result.Failures, 1)
+	require.Equal(t, 1, result.Summary.totalRuns)
+	_, err = os.Stat(zipPath)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Stat(filepath.Join(tempDir, "artifact-42"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}

--- a/tools/flakereport/parser.go
+++ b/tools/flakereport/parser.go
@@ -1,8 +1,10 @@
 package flakereport
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"sort"
@@ -16,8 +18,22 @@ import (
 var finalRegex = regexp.MustCompile(`\s*\(final\)$`)
 var trailingSuffixRegex = regexp.MustCompile(`\s*\([^)]+\)$`)
 
-// parseJUnitFile reads and parses a single JUnit XML file
-func parseJUnitFile(filePath string) (*junit.Testsuites, error) {
+type contextReader struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+func (r contextReader) Read(p []byte) (int, error) {
+	select {
+	case <-r.ctx.Done():
+		return 0, r.ctx.Err()
+	default:
+		return r.reader.Read(p)
+	}
+}
+
+// parseJUnitFile reads and parses a single JUnit XML file.
+func parseJUnitFile(ctx context.Context, filePath string) (*junit.Testsuites, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %s: %w", filePath, err)
@@ -29,14 +45,14 @@ func parseJUnitFile(filePath string) (*junit.Testsuites, error) {
 	}()
 
 	var testsuites junit.Testsuites
-	decoder := xml.NewDecoder(file)
+	decoder := xml.NewDecoder(contextReader{ctx: ctx, reader: file})
 	if err := decoder.Decode(&testsuites); err != nil {
 		// Try parsing as a single testsuite
 		if _, seekErr := file.Seek(0, 0); seekErr != nil {
 			return nil, fmt.Errorf("failed to seek file %s: %w", filePath, seekErr)
 		}
 		var testsuite junit.Testsuite
-		decoder = xml.NewDecoder(file)
+		decoder = xml.NewDecoder(contextReader{ctx: ctx, reader: file})
 		if err := decoder.Decode(&testsuite); err != nil {
 			return nil, fmt.Errorf("failed to parse JUnit XML %s: %w", filePath, err)
 		}
@@ -138,21 +154,6 @@ func groupFailuresByTest(failures []TestFailure) map[string][]TestFailure {
 	}
 
 	return grouped
-}
-
-// countTestRuns counts total runs (including successes) by normalized test name
-func countTestRuns(allRuns []TestRun) map[string]int {
-	counts := make(map[string]int)
-
-	for _, run := range allRuns {
-		// Only count non-skipped tests
-		if !run.Skipped {
-			normalizedName := normalizeTestName(run.Name)
-			counts[normalizedName]++
-		}
-	}
-
-	return counts
 }
 
 // classifyFailure returns "timeout", "crash", or "flaky" based on the test name.
@@ -332,10 +333,6 @@ func analyzeArtifactForCIBreakers(artifactID string, artifactFailures []TestFail
 		ciBreakers[normalized] = append(ciBreakers[normalized], failure)
 	}
 
-	for testName := range ciBreakers {
-		fmt.Printf("  CI BREAKER: %s (artifact %s)\n", testName, artifactID)
-	}
-
 	return ciBreakers
 }
 
@@ -413,35 +410,12 @@ func identifyCIBreakers(failures []TestFailure) (map[string][]TestFailure, map[s
 	return ciBreakers, ciBreakCount
 }
 
-// suiteRunKey returns a string that uniquely identifies a single (CI run × DB config) pair.
-// Each workflow run may spawn multiple matrix jobs sharing the same RunID but with distinct
-// MatrixNames (DB configs). Keying by (RunID, MatrixName) ensures shards belonging to the
-// same run+config are counted once, regardless of how many shard JobIDs they produce.
-func suiteRunKey(runID int64, matrixName string) string {
-	return fmt.Sprintf("%d:%s", runID, matrixName)
-}
-
 // generateSuiteReports creates per-suite flake breakdown from all failures and test runs.
 // Suite flake rate = % of (CI run × DB config) pairs where the suite had at least one
 // non-retry failure.
-func generateSuiteReports(allFailures []TestFailure, allTestRuns []TestRun) []SuiteReport {
-	// Track unique (CI run × DB config) pairs per suite (denominator).
-	// Using MatrixName avoids the inflation caused by per-shard JobIDs: suites whose
-	// test methods are spread across N shards would otherwise be counted N times per
-	// (run × DB config).
-	suiteRuns := make(map[string]map[string]bool)
-	for _, run := range allTestRuns {
-		if run.Skipped || !isGoTestSuite(run.SuiteName) {
-			continue
-		}
-		if suiteRuns[run.SuiteName] == nil {
-			suiteRuns[run.SuiteName] = make(map[string]bool)
-		}
-		suiteRuns[run.SuiteName][suiteRunKey(run.RunID, run.MatrixName)] = true
-	}
-
+func generateSuiteReports(allFailures []TestFailure, suiteRuns map[string]map[suiteRunIdentity]struct{}) []SuiteReport {
 	// Track (CI run × DB config) pairs with non-retry failures per suite (numerator)
-	suiteFailedRuns := make(map[string]map[string]bool)
+	suiteFailedRuns := make(map[string]map[suiteRunIdentity]struct{})
 	suiteLastFailure := make(map[string]time.Time)
 	for _, failure := range allFailures {
 		if !isGoTestSuite(failure.SuiteName) {
@@ -452,10 +426,10 @@ func generateSuiteReports(allFailures []TestFailure, allTestRuns []TestRun) []Su
 			continue
 		}
 		if suiteFailedRuns[failure.SuiteName] == nil {
-			suiteFailedRuns[failure.SuiteName] = make(map[string]bool)
+			suiteFailedRuns[failure.SuiteName] = make(map[suiteRunIdentity]struct{})
 		}
-		runKey := suiteRunKey(failure.RunID, failure.MatrixName)
-		suiteFailedRuns[failure.SuiteName][runKey] = true
+		run := suiteRunIdentity{runID: failure.RunID, matrixName: failure.MatrixName}
+		suiteFailedRuns[failure.SuiteName][run] = struct{}{}
 		if failure.Timestamp.After(suiteLastFailure[failure.SuiteName]) {
 			suiteLastFailure[failure.SuiteName] = failure.Timestamp
 		}

--- a/tools/flakereport/parser_test.go
+++ b/tools/flakereport/parser_test.go
@@ -256,7 +256,9 @@ func TestGenerateSuiteReports(t *testing.T) {
 		{SuiteName: "TestHealthySuite", Name: "TestOk", RunID: 2, MatrixName: "db-a"},
 	}
 
-	reports := generateSuiteReports(failures, allRuns)
+	summary := newTestRunSummary()
+	summary.add(allRuns)
+	reports := generateSuiteReports(failures, summary.suiteRuns)
 
 	// Should have SuiteA and SuiteB (SuiteC is all skipped)
 	require.Len(t, reports, 2)


### PR DESCRIPTION
## What changed?
- Add a rate-limited GitHub API client for efficiently retrieving workflow, artifact, and commit data.
- Aggregate test runs once and reuse the index for report generation and bisect analysis.
- Add parallel processing and coverage for API handling, aggregation, parsing, and report/bisect behavior.

## Why?
The flaky-test report needs to process a large workflow history without redundant work or exceeding GitHub API limits.

## How did you test it?
- [x] added new unit test(s)
- [x] checked the diff for whitespace errors
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new functional test(s)

## Potential risks
GitHub API changes may still encounter unexpected response or rate-limit behavior at production scale; the client applies bounded concurrency, retries, and cooldowns.