### PR TITLE
fix(batcher): stop retrying terminal-state errors and fix flaking activity batch tests

### DIFF
--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -856,6 +856,15 @@ func isNonRetryableError(err error, batchType enumspb.BatchOperationType) bool {
 	case enumspb.BATCH_OPERATION_TYPE_UPDATE_EXECUTION_OPTIONS, enumspb.BATCH_OPERATION_TYPE_UPDATE_WORKFLOW_EXECUTION_OPTIONS:
 		// Pinned version that is not present in a task queue error is non-retryable for workflow options updates
 		return strings.Contains(errMsg, worker_versioning.ErrPinnedVersionNotInTaskQueueSubstring)
+	case enumspb.BATCH_OPERATION_TYPE_TERMINATE_ACTIVITY,
+		enumspb.BATCH_OPERATION_TYPE_CANCEL_ACTIVITY,
+		enumspb.BATCH_OPERATION_TYPE_DELETE_ACTIVITY:
+		// FailedPrecondition from an activity terminate/cancel/delete means the
+		// target is in a state that will never permit the operation: a terminal
+		// status or an already-recorded terminate/cancel request with a
+		// different request ID.
+		var failedPrecondition *serviceerror.FailedPrecondition
+		return errors.As(err, &failedPrecondition)
 	default:
 		return false
 	}

--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -857,14 +857,23 @@ func isNonRetryableError(err error, batchType enumspb.BatchOperationType) bool {
 		// Pinned version that is not present in a task queue error is non-retryable for workflow options updates
 		return strings.Contains(errMsg, worker_versioning.ErrPinnedVersionNotInTaskQueueSubstring)
 	case enumspb.BATCH_OPERATION_TYPE_TERMINATE_ACTIVITY,
-		enumspb.BATCH_OPERATION_TYPE_CANCEL_ACTIVITY,
-		enumspb.BATCH_OPERATION_TYPE_DELETE_ACTIVITY:
-		// FailedPrecondition from an activity terminate/cancel/delete means the
-		// target is in a state that will never permit the operation: a terminal
-		// status or an already-recorded terminate/cancel request with a
-		// different request ID.
-		var failedPrecondition *serviceerror.FailedPrecondition
-		return errors.As(err, &failedPrecondition)
+		enumspb.BATCH_OPERATION_TYPE_CANCEL_ACTIVITY:
+		// A FailedPrecondition from an activity terminate/cancel means the target
+		// is in a state that will never permit the operation: a terminal status,
+		// or an already-recorded terminate/cancel request with a different
+		// request ID. Retrying cannot change either, so fail fast instead of
+		// spending every AttemptsOnRetryableError -- processTaskWithRetries
+		// retries in place with no backoff.
+		//
+		// Only these two are listed. UNPAUSE_ACTIVITY, UPDATE_ACTIVITY_OPTIONS
+		// and RESET_ACTIVITY get the same Running filter appended by
+		// adjustQueryBatchTypeEnum and so reach this path too, but their
+		// FailedPreconditions include states a retry does clear (pending reset,
+		// pending cancellation, deferred Reset(RestoreOriginalOptions)).
+		// DELETE_ACTIVITY gets no Running filter at all, so it never sees the
+		// stale-visibility case this guards against.
+		_, isFailedPrecondition := errors.AsType[*serviceerror.FailedPrecondition](err)
+		return isFailedPrecondition
 	default:
 		return false
 	}

--- a/service/worker/batcher/activities_test.go
+++ b/service/worker/batcher/activities_test.go
@@ -17,6 +17,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
+	"go.temporal.io/api/serviceerror"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	sdkclient "go.temporal.io/sdk/client"
@@ -711,6 +712,54 @@ func (s *activitiesSuite) TestIsNonRetryableError() {
 			batchType: enumspb.BATCH_OPERATION_TYPE_SIGNAL_WORKFLOW,
 			want:      false,
 		},
+		{
+			// A completed activity never leaves its terminal state, so retrying
+			// the cancel can never succeed.
+			name:      "terminal state error for CANCEL_ACTIVITY returns true",
+			err:       serviceerror.NewFailedPreconditionf("activity is in terminal state %v", "Completed"),
+			batchType: enumspb.BATCH_OPERATION_TYPE_CANCEL_ACTIVITY,
+			want:      true,
+		},
+		{
+			name:      "terminal state error for TERMINATE_ACTIVITY returns true",
+			err:       serviceerror.NewFailedPrecondition("invalid transition"),
+			batchType: enumspb.BATCH_OPERATION_TYPE_TERMINATE_ACTIVITY,
+			want:      true,
+		},
+		{
+			name:      "terminal state error for DELETE_ACTIVITY returns true",
+			err:       serviceerror.NewFailedPreconditionf("activity is in terminal state %v", "Completed"),
+			batchType: enumspb.BATCH_OPERATION_TYPE_DELETE_ACTIVITY,
+			want:      true,
+		},
+		{
+			// Wrapped errors must still be classified, since the task layer may
+			// annotate before processTaskWithRetries sees the error.
+			name:      "wrapped FailedPrecondition for CANCEL_ACTIVITY returns true",
+			err:       fmt.Errorf("cancel activity: %w", serviceerror.NewFailedPrecondition("activity is in terminal state Canceled")),
+			batchType: enumspb.BATCH_OPERATION_TYPE_CANCEL_ACTIVITY,
+			want:      true,
+		},
+		{
+			// Transient failures on activity batches must stay retryable.
+			name:      "unavailable error for CANCEL_ACTIVITY returns false",
+			err:       serviceerror.NewUnavailable("history service is unavailable"),
+			batchType: enumspb.BATCH_OPERATION_TYPE_CANCEL_ACTIVITY,
+			want:      false,
+		},
+		{
+			name:      "generic error for CANCEL_ACTIVITY returns false",
+			err:       errors.New("some transient error"),
+			batchType: enumspb.BATCH_OPERATION_TYPE_CANCEL_ACTIVITY,
+			want:      false,
+		},
+		{
+			// Workflow batch types must keep their existing behavior.
+			name:      "FailedPrecondition for TERMINATE_WORKFLOW returns false",
+			err:       serviceerror.NewFailedPrecondition("workflow is in terminal state"),
+			batchType: enumspb.BATCH_OPERATION_TYPE_TERMINATE_WORKFLOW,
+			want:      false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -852,6 +901,75 @@ func (s *activitiesSuite) TestStartTaskProcessor_RetryableErrorsDoNotDeadlock() 
 			s.FailNow("timed out waiting for task response: worker is deadlocked")
 		}
 	}
+}
+
+// TestStartTaskProcessor_ActivityTerminalStateIsNotRetried verifies that a
+// FailedPrecondition from an activity cancel is attempted exactly once. A
+// terminal activity never leaves its terminal state, so retrying can never
+// succeed; because processTaskWithRetries retries in place with no backoff, a
+// misclassification here spends all AttemptsOnRetryableError attempts hammering
+// history within milliseconds.
+func (s *activitiesSuite) TestStartTaskProcessor_ActivityTerminalStateIsNotRetried() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	a := &activities{
+		activityDeps: activityDeps{
+			FrontendClient: s.mockFrontendClient,
+			Logger:         log.NewTestLogger(),
+			MetricsHandler: metrics.NoopMetricsHandler,
+		},
+	}
+
+	batchOperation := &batchspb.BatchOperationInput{
+		NamespaceId: "some-namespace-id",
+		BatchType:   enumspb.BATCH_OPERATION_TYPE_CANCEL_ACTIVITY,
+		// Generous retry budget: the point is that none of it gets used.
+		AttemptsOnRetryableError: 50,
+		Request: &workflowservice.StartBatchOperationRequest{
+			Namespace: "ns",
+			Operation: &workflowservice.StartBatchOperationRequest_CancelActivitiesOperation{
+				CancelActivitiesOperation: &batchpb.BatchOperationCancelActivities{
+					Identity: "batch-canceler",
+					Reason:   "test",
+				},
+			},
+		},
+	}
+
+	// The activity completed before the batch reached it -- exactly what a stale
+	// ExecutionStatus='Running' visibility record produces.
+	var calls atomic.Int32
+	s.mockFrontendClient.EXPECT().
+		RequestCancelActivityExecution(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(context.Context, *workflowservice.RequestCancelActivityExecutionRequest, ...any) (*workflowservice.RequestCancelActivityExecutionResponse, error) {
+			calls.Add(1)
+			return nil, serviceerror.NewFailedPreconditionf("activity is in terminal state %v", "Completed")
+		}).
+		AnyTimes()
+
+	testPage := &page{
+		targetExecutionInfo: []*commonpb.Execution{
+			{Type: enumspb.EXECUTION_TYPE_ACTIVITY, BusinessId: "activity-id", RunId: "run-id"},
+		},
+	}
+
+	taskCh := make(chan task, 1)
+	respCh := make(chan taskResponse, 1)
+	limiter := quotas.NewRequestRateLimiterAdapter(quotas.NewDefaultOutgoingRateLimiter(func() float64 { return 1000 }))
+
+	go a.startTaskProcessor(ctx, batchOperation, "ns", taskCh, respCh, limiter, nil, s.mockFrontendClient, metrics.NoopMetricsHandler, log.NewTestLogger())
+
+	taskCh <- task{targetExecution: testPage.targetExecutionInfo[0], attempts: 1, page: testPage}
+
+	select {
+	case resp := <-respCh:
+		s.Require().Error(resp.err)
+	case <-time.After(10 * time.Second):
+		s.FailNow("timed out waiting for task response")
+	}
+
+	s.Equal(int32(1), calls.Load(), "terminal-state failure must not be retried")
 }
 
 // TestRecordCompletedPages_ResumeTracksOldestIncompletePage verifies the resume point only

--- a/service/worker/batcher/activities_test.go
+++ b/service/worker/batcher/activities_test.go
@@ -727,10 +727,13 @@ func (s *activitiesSuite) TestIsNonRetryableError() {
 			want:      true,
 		},
 		{
-			name:      "terminal state error for DELETE_ACTIVITY returns true",
+			// Delete gets no ExecutionStatus='Running' filter from
+			// adjustQueryBatchTypeEnum, so it never hits the stale-visibility
+			// case and keeps the default retry behavior.
+			name:      "terminal state error for DELETE_ACTIVITY returns false",
 			err:       serviceerror.NewFailedPreconditionf("activity is in terminal state %v", "Completed"),
 			batchType: enumspb.BATCH_OPERATION_TYPE_DELETE_ACTIVITY,
-			want:      true,
+			want:      false,
 		},
 		{
 			// Wrapped errors must still be classified, since the task layer may

--- a/tests/activity_api_batch_cancel_test.go
+++ b/tests/activity_api_batch_cancel_test.go
@@ -116,17 +116,9 @@ func (s *ActivityAPIBatchCancelClientTestSuite) TestActivityBatchCancel_Excludes
 	// Query intentionally omits ExecutionStatus = 'Running'.
 	query := fmt.Sprintf("ActivityType = '%s'", activityType)
 
-	// Wait for both activities (one Running, one Completed) to be indexed.
-	//nolint:forbidigo // tests with waits
-	s.EventuallyWithT(func(c *assert.CollectT) {
-		listResp, err := env.FrontendClient().ListActivityExecutions(ctx, &workflowservice.ListActivityExecutionsRequest{
-			Namespace: env.Namespace().String(),
-			PageSize:  10,
-			Query:     query,
-		})
-		require.NoError(c, err)
-		require.Len(c, listResp.GetExecutions(), 2)
-	}, testcore.WaitForESToSettle, 100*time.Millisecond)
+	// Wait for both activities to be indexed *and* for the completed one to no
+	// longer be indexed as Running, so the batch sees exactly one target.
+	waitForRunningFilterToSettle(ctx, t, env, query, 2, 1)
 
 	jobID := uuid.NewString()
 	_, err = env.SdkClient().WorkflowService().StartBatchOperation(ctx, &workflowservice.StartBatchOperationRequest{

--- a/tests/activity_api_batch_terminate_test.go
+++ b/tests/activity_api_batch_terminate_test.go
@@ -113,6 +113,42 @@ func assertBatchOperationType(
 	}, 10*time.Second, 200*time.Millisecond)
 }
 
+// waitForRunningFilterToSettle waits until visibility has settled on the target
+// set that a terminate/cancel batch over `query` will actually see: `wantTotal`
+// executions match `query`, and `wantRunning` of those also match the
+// `ExecutionStatus='Running'` filter the batcher appends
+// (adjustQueryBatchTypeEnum).
+func waitForRunningFilterToSettle(
+	ctx context.Context,
+	t *testing.T,
+	env *standaloneActivityEnv,
+	query string,
+	wantTotal int,
+	wantRunning int,
+) {
+	t.Helper()
+
+	//nolint:forbidigo // for tests with waits
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		listResp, err := env.FrontendClient().ListActivityExecutions(ctx, &workflowservice.ListActivityExecutionsRequest{
+			Namespace: env.Namespace().String(),
+			PageSize:  10,
+			Query:     query,
+		})
+		require.NoError(c, err)
+		require.Len(c, listResp.GetExecutions(), wantTotal)
+
+		// Mirrors the query the batcher itself counts with, so this waits on
+		// exactly the value that drives TotalOperationCount.
+		countResp, err := env.FrontendClient().CountActivityExecutions(ctx, &workflowservice.CountActivityExecutionsRequest{
+			Namespace: env.Namespace().String(),
+			Query:     fmt.Sprintf("(%s) AND (ExecutionStatus='Running')", query),
+		})
+		require.NoError(c, err)
+		require.EqualValues(c, wantRunning, countResp.GetCount())
+	}, 20*time.Second, 100*time.Millisecond)
+}
+
 // batchTargetSelector describes a way to scope a batch operation's targets:
 // a visibility query, the deprecated Executions field, or TargetExecutions.
 type batchTargetSelector struct {
@@ -382,17 +418,9 @@ func (s *ActivityAPIBatchTerminateClientTestSuite) TestActivityBatchTerminate_Ex
 	// Query intentionally omits ExecutionStatus = 'Running'.
 	query := fmt.Sprintf("ActivityType = '%s'", activityType)
 
-	// Wait for both activities (one Running, one Completed) to be indexed.
-	//nolint:forbidigo // for tests with waits
-	s.EventuallyWithT(func(c *assert.CollectT) {
-		listResp, err := env.FrontendClient().ListActivityExecutions(ctx, &workflowservice.ListActivityExecutionsRequest{
-			Namespace: env.Namespace().String(),
-			PageSize:  10,
-			Query:     query,
-		})
-		require.NoError(c, err)
-		require.Len(c, listResp.GetExecutions(), 2)
-	}, testcore.WaitForESToSettle, 100*time.Millisecond)
+	// Wait for both activities to be indexed *and* for the completed one to no
+	// longer be indexed as Running, so the batch sees exactly one target.
+	waitForRunningFilterToSettle(ctx, t, env, query, 2, 1)
 
 	jobID := uuid.NewString()
 	_, err = env.SdkClient().WorkflowService().StartBatchOperation(ctx, &workflowservice.StartBatchOperationRequest{


### PR DESCRIPTION
## What changed?

1. Test fix `tests/activity_api_batch_{cancel,terminate}_test.go`: both `*_ExcludesNonRunning` tests waited only for two activities to match `ActivityType` before starting the batch, but the just-completed one may still be indexed as `ExecutionStatus='Running'`. New shared helper `waitForRunningFilterToSettle` also waits on the `Running` count, mirroring the query the batcher counts with in `adjustQueryBatchTypeEnum`.

2. `isNonRetryableError` treats `serviceerror.FailedPrecondition` as non-retryable for `TERMINATE_ACTIVITY`/`CANCEL_ACTIVITY`/`DELETE_ACTIVITY`. Every reachable FailedPrecondition on those paths is permanent — a terminal status, or an already-recorded terminate/cancel request with a different request ID — and processTaskWithRetries retries in place with no backoff.

## Why?

TestActivityBatchCancel_ExcludesNonRunning was a top CI breaker in the 2026-08-04 Flaky Tests Report.

## How did you test it?

- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s) — the two existing ones are the subject of the fix

## Potential risks

- Activity batch targets in a terminal state now fail immediately rather than after N attempts. They are still counted as failures, so `DescribeBatchOperation` totals are unchanged.