### PR TITLE
Fix CHASM pause-on-failure conflict token

### DIFF
--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -674,6 +674,7 @@ func (s *Scheduler) HandleNexusCompletion(
 			strings.ToLower(wfStatus.String()),
 			workflowID,
 		)
+		s.updateConflictToken()
 	}
 
 	// Record the completed action in the Invoker.

--- a/chasm/lib/scheduler/scheduler_nexus_completion_test.go
+++ b/chasm/lib/scheduler/scheduler_nexus_completion_test.go
@@ -9,10 +9,12 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
+	workflowservice "go.temporal.io/api/workflowservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	schedulespb "go.temporal.io/server/api/schedule/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/scheduler"
+	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -193,6 +195,64 @@ func TestHandleNexusCompletion_PauseOnFailure(t *testing.T) {
 	}
 
 	executeNexusCompletion(t, tc)
+}
+
+func TestPauseOnFailureInvalidatesConflictToken(t *testing.T) {
+	sched, ctx, node := setupSchedulerForTest(t)
+	sched.Schedule.Policies.PauseOnFailure = true
+	sched.Invoker.Get(ctx).BufferedStarts = []*schedulespb.BufferedStart{
+		{
+			RequestId:  "req-1",
+			WorkflowId: "wf-1",
+			RunId:      "run-1",
+			Attempt:    1,
+		},
+	}
+	_, err := node.CloseTransaction()
+	require.NoError(t, err)
+
+	describeResponse, err := sched.Describe(
+		chasm.NewContext(context.Background(), node),
+		&schedulerpb.DescribeScheduleRequest{
+			NamespaceId: namespaceID,
+			FrontendRequest: &workflowservice.DescribeScheduleRequest{
+				Namespace:  namespace,
+				ScheduleId: scheduleID,
+			},
+		},
+		newLegacySpecBuilder(0, 0),
+	)
+	require.NoError(t, err)
+	staleDescription := describeResponse.GetFrontendResponse()
+	require.False(t, staleDescription.GetSchedule().GetState().GetPaused())
+
+	ctx = chasm.NewMutableContext(context.Background(), node)
+	err = sched.HandleNexusCompletion(ctx, &persistencespb.ChasmNexusCompletion{
+		RequestId: "req-1",
+		Outcome: &persistencespb.ChasmNexusCompletion_Failure{
+			Failure: &failurepb.Failure{Message: "workflow failed"},
+		},
+		CloseTime: timestamppb.Now(),
+	})
+	require.NoError(t, err)
+	_, err = node.CloseTransaction()
+	require.NoError(t, err)
+	require.True(t, sched.Schedule.GetState().GetPaused())
+	require.NotEmpty(t, sched.Schedule.GetState().GetNotes())
+
+	ctx = chasm.NewMutableContext(context.Background(), node)
+	_, err = sched.Update(ctx, &schedulerpb.UpdateScheduleRequest{
+		NamespaceId: namespaceID,
+		FrontendRequest: &workflowservice.UpdateScheduleRequest{
+			Namespace:     namespace,
+			ScheduleId:    scheduleID,
+			Schedule:      staleDescription.GetSchedule(),
+			ConflictToken: staleDescription.GetConflictToken(),
+		},
+	})
+	require.ErrorIs(t, err, scheduler.ErrConflictTokenMismatch)
+	require.True(t, sched.Schedule.GetState().GetPaused())
+	require.NotEmpty(t, sched.Schedule.GetState().GetNotes())
 }
 
 // TestHandleNexusCompletion_Idempotent verifies that handling a completion for an

--- a/chasm/lib/scheduler/scheduler_nexus_completion_test.go
+++ b/chasm/lib/scheduler/scheduler_nexus_completion_test.go
@@ -9,7 +9,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
-	workflowservice "go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/api/workflowservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	schedulespb "go.temporal.io/server/api/schedule/v1"
 	"go.temporal.io/server/chasm"


### PR DESCRIPTION
## What changed?
- Increment the CHASM scheduler conflict token when pause-on-failure changes the persisted paused state and notes.
- Add a regression test covering a stale Describe token used by Update after the automatic pause commits.

## Why?
A token-protected Update could previously replace the entire schedule using a token captured before pause-on-failure, silently clearing the automatic pause and its explanatory notes. Invalidating the token keeps optimistic concurrency behavior aligned with the fields Update replaces and with the V1 scheduler.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

```
go test -tags test_dep ./chasm/lib/scheduler -run 'Test(HandleNexusCompletion_PauseOnFailure|PauseOnFailureInvalidatesConflictToken)$' -count=1
```

## Potential risks
Token-protected updates already in flight when pause-on-failure commits will now fail with a conflict-token mismatch and must be retried. Updates that intentionally omit the conflict token remain unconditional.