### PR TITLE
Preserve IDs for migrated scheduler starts

### DIFF
--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -66,6 +66,8 @@ const (
 	LimitMemoSpecSize = 11
 	// trigger immediately timestamp is added to the PatchRequest
 	TriggerImmediatelyTimestamp = 12
+	// preserve workflow and request IDs assigned to starts migrated from CHASM
+	PreserveMigratedStartIDs = 13
 )
 
 const (
@@ -215,7 +217,7 @@ var (
 		ReuseTimer:                        true,
 		NextTimeCacheV2Size:               14, // see note below
 		SpecFieldLengthLimit:              10,
-		Version:                           TriggerImmediatelyTimestamp,
+		Version:                           PreserveMigratedStartIDs,
 	}
 
 	// Note on NextTimeCacheV2Size: This value must be > FutureActionCountForList. Each
@@ -1473,8 +1475,15 @@ func (s *scheduler) startWorkflow(
 	newWorkflow *workflowpb.NewWorkflowExecutionInfo,
 ) (*schedulepb.ScheduleActionResult, error) {
 	nominalTimeSec := start.NominalTime.AsTime().UTC().Truncate(time.Second)
-	workflowID := newWorkflow.WorkflowId
-	if start.OverlapPolicy == enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL || s.tweakables.AlwaysAppendTimestamp {
+	workflowID := ""
+	if s.hasMinVersion(PreserveMigratedStartIDs) {
+		workflowID = start.WorkflowId
+	}
+	if workflowID == "" {
+		workflowID = newWorkflow.WorkflowId
+	}
+	if (!s.hasMinVersion(PreserveMigratedStartIDs) || start.WorkflowId == "") &&
+		(start.OverlapPolicy == enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL || s.tweakables.AlwaysAppendTimestamp) {
 		// must match AppendedTimestampForValidation
 		workflowID += "-" + nominalTimeSec.Format(time.RFC3339)
 	}
@@ -1510,6 +1519,13 @@ func (s *scheduler) startWorkflow(
 		reusePolicy = enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE
 	}
 
+	requestID := ""
+	if s.hasMinVersion(PreserveMigratedStartIDs) {
+		requestID = start.RequestId
+	}
+	if requestID == "" {
+		requestID = s.newUUIDString()
+	}
 	req := &schedulespb.StartWorkflowRequest{
 		Request: &workflowservice.StartWorkflowExecutionRequest{
 			WorkflowId:               workflowID,
@@ -1520,7 +1536,7 @@ func (s *scheduler) startWorkflow(
 			WorkflowRunTimeout:       newWorkflow.WorkflowRunTimeout,
 			WorkflowTaskTimeout:      newWorkflow.WorkflowTaskTimeout,
 			Identity:                 s.identity(),
-			RequestId:                s.newUUIDString(),
+			RequestId:                requestID,
 			WorkflowIdReusePolicy:    reusePolicy,
 			RetryPolicy:              newWorkflow.RetryPolicy,
 			Memo:                     newWorkflow.Memo,

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -332,6 +332,7 @@ func (s *workflowSuite) TestStart() {
 		s.Nil(req.Request.LastCompletionResult)
 		s.Nil(req.Request.ContinuedFailure)
 		s.Equal("myid-2022-06-01T00:15:00Z", req.Request.WorkflowId)
+		s.NotEmpty(req.Request.RequestId)
 		s.Equal("mywf", req.Request.WorkflowType.Name)
 		s.Equal("mytq", req.Request.TaskQueue.Name)
 		s.Equal(`"value"`, payload.ToString(req.Request.Memo.Fields["mymemo"]))
@@ -354,6 +355,64 @@ func (s *workflowSuite) TestStart() {
 	// two iterations to start one workflow: first will sleep, second will start and then sleep again
 	s.True(s.env.IsWorkflowCompleted())
 	s.True(workflow.IsContinueAsNewError(s.env.GetWorkflowError()))
+}
+
+func (s *workflowSuite) TestMigratedBufferedStartPreservesIdempotencyIDs() {
+	s.expectStart(func(req *schedulespb.StartWorkflowRequest) (*schedulespb.StartWorkflowResponse, error) {
+		s.Equal("migrated-workflow-id", req.Request.WorkflowId)
+		s.Equal("migrated-request-id", req.Request.RequestId)
+		return nil, nil
+	})
+
+	CurrentTweakablePolicies.IterationsBeforeContinueAsNew = 1
+	s.env.SetStartTime(baseStartTime)
+	s.env.ExecuteWorkflow(SchedulerWorkflow, s.migratedStartScheduleArgs())
+	s.True(s.env.IsWorkflowCompleted())
+	s.True(workflow.IsContinueAsNewError(s.env.GetWorkflowError()))
+}
+
+func (s *workflowSuite) TestMigratedBufferedStartUsesLegacyIDsAtOldVersion() {
+	previousTweakables := CurrentTweakablePolicies
+	defer func() { CurrentTweakablePolicies = previousTweakables }()
+	CurrentTweakablePolicies.Version = TriggerImmediatelyTimestamp
+
+	s.expectStart(func(req *schedulespb.StartWorkflowRequest) (*schedulespb.StartWorkflowResponse, error) {
+		s.Equal("configured-workflow-id-2022-06-01T00:00:00Z", req.Request.WorkflowId)
+		s.NotEmpty(req.Request.RequestId)
+		s.NotEqual("migrated-request-id", req.Request.RequestId)
+		return nil, nil
+	})
+
+	CurrentTweakablePolicies.IterationsBeforeContinueAsNew = 1
+	s.env.SetStartTime(baseStartTime)
+	s.env.ExecuteWorkflow(SchedulerWorkflow, s.migratedStartScheduleArgs())
+	s.True(s.env.IsWorkflowCompleted())
+	s.True(workflow.IsContinueAsNewError(s.env.GetWorkflowError()))
+}
+
+func (s *workflowSuite) migratedStartScheduleArgs() *schedulespb.StartScheduleArgs {
+	return &schedulespb.StartScheduleArgs{
+		Schedule: &schedulepb.Schedule{
+			Spec: &schedulepb.ScheduleSpec{
+				Interval: []*schedulepb.IntervalSpec{{Interval: durationpb.New(time.Hour)}},
+			},
+			Action: s.defaultAction("configured-workflow-id"),
+		},
+		State: &schedulespb.InternalState{
+			Namespace:     "myns",
+			NamespaceId:   "mynsid",
+			ScheduleId:    "myschedule",
+			ConflictToken: InitialConflictToken,
+			BufferedStarts: []*schedulespb.BufferedStart{{
+				NominalTime:   timestamppb.New(baseStartTime),
+				ActualTime:    timestamppb.New(baseStartTime),
+				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+				Manual:        true,
+				RequestId:     "migrated-request-id",
+				WorkflowId:    "migrated-workflow-id",
+			}},
+		},
+	}
 }
 
 func (s *workflowSuite) TestInitialPatch() {


### PR DESCRIPTION
## What changed?
- Added V1 scheduler workflow version 13.
- V1 now prefers non-empty workflow and request IDs already stored on migrated CHASM buffered starts.
- Native V1 starts and older workflow versions retain the existing workflow-ID derivation and UUID generation behavior.

## Why?
V2-to-V1 migration copies pending buffered starts with their CHASM workflow and request IDs, but V1 previously discarded those values when starting the workflow. That broke idempotency identity across the migration handoff.

The workflow-version gate keeps replay behavior stable for histories that recorded the legacy ID generation path.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

`go test -tags test_dep ./service/worker/scheduler -count=1`

## Potential risks
The end-to-end duplicate-run impact of an already-succeeded CHASM start racing migration has not been reproduced against the frontend. This change preserves the identity needed for frontend deduplication but does not add a stronger drain barrier for already-running CHASM execute tasks.