### PR TITLE
Add action type tag to schedule action delay metric

### DIFF
--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -713,7 +713,8 @@ func (h *InvokerExecuteTaskHandler) startWorkflow(
 		desiredTime := cmp.Or(start.DesiredTime, start.ActualTime)
 		metricsHandler.
 			Timer(metrics.ScheduleActionDelay.Name()).
-			Record(actualStartTime.Sub(desiredTime.AsTime()))
+			Record(actualStartTime.Sub(desiredTime.AsTime()),
+				metrics.StringTag(metrics.ScheduleActionTypeTag, metrics.ScheduleActionStartWorkflow))
 		// Record total delay from original schedule time, including any overlap policy wait.
 		metricsHandler.
 			Timer(metrics.ScheduleActionE2EDelay.Name()).

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -1550,7 +1550,9 @@ func (s *scheduler) startWorkflow(
 		if !start.Manual {
 			// record metric only for _scheduled_ actions, not trigger/backfill, otherwise it's not meaningful
 			desiredTime := cmp.Or(start.DesiredTime, start.ActualTime)
-			s.metrics.Timer(metrics.ScheduleActionDelay.Name()).Record(res.RealStartTime.AsTime().Sub(desiredTime.AsTime()))
+			s.metrics.WithTags(map[string]string{
+				metrics.ScheduleActionTypeTag: metrics.ScheduleActionStartWorkflow,
+			}).Timer(metrics.ScheduleActionDelay.Name()).Record(res.RealStartTime.AsTime().Sub(desiredTime.AsTime()))
 			// Record total delay from original schedule time, including any overlap policy wait.
 			s.metrics.Timer(metrics.ScheduleActionE2EDelay.Name()).Record(res.RealStartTime.AsTime().Sub(start.ActualTime.AsTime()))
 		}


### PR DESCRIPTION
## What changed?

Add the `schedule_action=start_workflow` tag to the `schedule_action_delay` metric emitted by both the legacy and CHASM schedulers.

## Why?

The action-delay metric omitted the action type dimension already used by the schedule action success and error metrics. This prevented customer-facing metric consumers from grouping or filtering action delay consistently.

## How did you test it?

- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

```text
go test -tags test_dep ./service/worker/scheduler ./chasm/lib/scheduler
```