### PR TITLE
Apply Callback Validator to Workflow Update Callbacks

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -886,7 +886,7 @@ func (wh *WorkflowHandler) convertToHistoryMultiOperationItem(
 		if updateReq.Namespace != "" && updateReq.Namespace != namespaceName.String() {
 			return nil, "", errMultiOpNamespaceMismatch
 		}
-		if err := wh.prepareUpdateWorkflowRequest(updateReq); err != nil {
+		if err := wh.prepareUpdateWorkflowRequest(ctx, namespaceName, updateReq); err != nil {
 			return nil, "", err
 		}
 		if updateReq.FirstExecutionRunId != "" {
@@ -5378,7 +5378,7 @@ func (wh *WorkflowHandler) UpdateWorkflowExecution(
 ) (_ *workflowservice.UpdateWorkflowExecutionResponse, retError error) {
 	defer log.CapturePanic(wh.logger, &retError)
 
-	if err := wh.prepareUpdateWorkflowRequest(request); err != nil {
+	if err := wh.prepareUpdateWorkflowRequest(ctx, namespace.Name(request.GetNamespace()), request); err != nil {
 		return nil, err
 	}
 
@@ -5409,6 +5409,8 @@ func (wh *WorkflowHandler) UpdateWorkflowExecution(
 }
 
 func (wh *WorkflowHandler) prepareUpdateWorkflowRequest(
+	ctx context.Context,
+	namespaceName namespace.Name,
 	request *workflowservice.UpdateWorkflowExecutionRequest,
 ) error {
 	if request == nil {
@@ -5456,6 +5458,12 @@ func (wh *WorkflowHandler) prepareUpdateWorkflowRequest(
 	if request.WaitPolicy.LifecycleStage == enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED &&
 		!wh.config.EnableUpdateWorkflowExecutionAsyncAccepted(request.Namespace) {
 		return errUpdateWorkflowExecutionAsyncAcceptedNotAllowed
+	}
+
+	if cbs := request.GetRequest().GetCompletionCallbacks(); len(cbs) > 0 {
+		if err := wh.callbackValidator.Validate(ctx, namespaceName.String(), cbs); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -5649,6 +5649,50 @@ func (s *WorkflowHandlerSuite) TestUpdateWorkflowExecutionOptions_TimeSkipping_D
 	s.ErrorContains(err, "The Time-Skipping feature is not enabled for namespace")
 }
 
+func (s *WorkflowHandlerSuite) TestPrepareUpdateWorkflowRequest_ValidatesCompletionCallbacks() {
+	wh := s.getWorkflowHandler(s.newConfig())
+	newRequest := func(callbacks []*commonpb.Callback) *workflowservice.UpdateWorkflowExecutionRequest {
+		return &workflowservice.UpdateWorkflowExecutionRequest{
+			Namespace:         s.testNamespace.String(),
+			WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: testWorkflowID},
+			Request: &updatepb.Request{
+				Meta:                &updatepb.Meta{UpdateId: "update-id"},
+				Input:               &updatepb.Input{Name: "update-name"},
+				RequestId:           "request-id",
+				CompletionCallbacks: callbacks,
+			},
+		}
+	}
+
+	s.Run("invalid callback", func() {
+		err := wh.prepareUpdateWorkflowRequest(
+			context.Background(),
+			s.testNamespace,
+			newRequest([]*commonpb.Callback{{}}),
+		)
+
+		var unimplemented *serviceerror.Unimplemented
+		s.ErrorAs(err, &unimplemented)
+		s.ErrorContains(err, "unknown callback variant")
+	})
+
+	s.Run("normalizes callback headers", func() {
+		request := newRequest([]*commonpb.Callback{{
+			Variant: &commonpb.Callback_Nexus_{
+				Nexus: &commonpb.Callback_Nexus{
+					Url:    "http://localhost/callback",
+					Header: map[string]string{"X-Request-ID": "value"},
+				},
+			},
+		}})
+
+		err := wh.prepareUpdateWorkflowRequest(context.Background(), s.testNamespace, request)
+
+		s.NoError(err)
+		s.Equal(map[string]string{"x-request-id": "value"}, request.GetRequest().GetCompletionCallbacks()[0].GetNexus().GetHeader())
+	})
+}
+
 func (s *WorkflowHandlerSuite) TestUpdateActivityOptions_Priority() {
 	config := s.newConfig()
 	wh := s.getWorkflowHandler(config)

--- a/tests/nexus_workflow_update_test.go
+++ b/tests/nexus_workflow_update_test.go
@@ -19,6 +19,7 @@ import (
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/nexus/nexustest"
@@ -150,6 +151,10 @@ func enableUpdateCallbacksOpts() []testcore.TestOption {
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMCallbacks, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableWorkflowUpdateCallbacks, true),
+		testcore.WithDynamicConfig(
+			callback.AllowedAddresses,
+			[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}},
+		),
 	}
 }
 

--- a/tests/update_workflow_sdk_test.go
+++ b/tests/update_workflow_sdk_test.go
@@ -15,6 +15,7 @@ import (
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
@@ -392,6 +393,10 @@ func (s *UpdateWorkflowSdkSuite) TestUpdateSameRequestIDDeduplicatesCallbacks() 
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMCallbacks, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableWorkflowUpdateCallbacks, true),
+		testcore.WithDynamicConfig(
+			callback.AllowedAddresses,
+			[]any{map[string]any{"Pattern": "localhost:9999", "AllowInsecure": true}},
+		),
 	)
 
 	requestID1 := env.Tv().RequestID()

--- a/tests/update_workflow_sdk_test.go
+++ b/tests/update_workflow_sdk_test.go
@@ -469,3 +469,32 @@ func (s *UpdateWorkflowSdkSuite) TestUpdateSameRequestIDDeduplicatesCallbacks() 
 	s.NoError(env.SdkClient().SignalWorkflow(s.Context(), run.GetID(), run.GetRunID(), "complete-update", nil))
 	s.NoError(env.SdkClient().SignalWorkflow(s.Context(), run.GetID(), run.GetRunID(), "stop", nil))
 }
+
+func (s *UpdateWorkflowSdkSuite) TestUpdateRejectsInvalidCallbackURL() {
+	env := testcore.NewEnv(s.T(),
+		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
+		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMCallbacks, true),
+		testcore.WithDynamicConfig(dynamicconfig.EnableWorkflowUpdateCallbacks, true),
+	)
+
+	_, err := env.FrontendClient().UpdateWorkflowExecution(s.Context(), &workflowservice.UpdateWorkflowExecutionRequest{
+		Namespace:         env.Namespace().String(),
+		WorkflowExecution: env.Tv().WorkflowExecution(),
+		WaitPolicy: &updatepb.WaitPolicy{
+			LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+		},
+		Request: &updatepb.Request{
+			Meta:      &updatepb.Meta{UpdateId: env.Tv().UpdateID()},
+			Input:     &updatepb.Input{Name: env.Tv().HandlerName()},
+			RequestId: env.Tv().RequestID(),
+			CompletionCallbacks: []*commonpb.Callback{{
+				Variant: &commonpb.Callback_Nexus_{
+					Nexus: &commonpb.Callback_Nexus{Url: "temporal://not-internal"},
+				},
+			}},
+		},
+	})
+	var invalidArgument *serviceerror.InvalidArgument
+	s.ErrorAs(err, &invalidArgument)
+	s.ErrorContains(err, "invalid url: unknown scheme")
+}


### PR DESCRIPTION
## What changed?
Apply Callback Validator to Workflow Update Callbacks

## Why?
We should consistently apply the validator in all cases. 

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request validation on a user-facing API path; invalid callbacks are rejected earlier, which may surface errors for previously accepted bad URLs but improves security consistency with start-workflow.
> 
> **Overview**
> **Workflow update** requests with `completion_callbacks` now run through the same **callback validator** used for workflow start, including multi-op update paths that call `prepareUpdateWorkflowRequest`.
> 
> `prepareUpdateWorkflowRequest` takes `ctx` and namespace so validation can enforce allowed callback URLs and normalize Nexus callback headers before the request reaches history.
> 
> Tests add unit coverage for invalid variants and header normalization, plus functional tests that configure `callback.AllowedAddresses` and reject disallowed callback URLs on update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d699d6de4e1eff7a8f6f202799f6e6ff3f16a541. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->