### PR TITLE
Monitor child execution NotFound after ChildWorkflowExecutionStarted

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -930,7 +930,12 @@ var (
 		"task_errors_throttled",
 		WithDescription("The number of history task processing errors caused by resource exhausted errors, excluding workflow busy case."),
 	)
-	TaskCorruptionCounter = NewCounterDef("task_errors_corruption")
+	TaskCorruptionCounter  = NewCounterDef("task_errors_corruption")
+	ChildExecutionNotFound = NewCounterDef(
+		"child_execution_not_found",
+		WithDescription("The number of times scheduling a child's first workflow task returned NotFound after the "+
+			"parent had already committed ChildWorkflowExecutionStarted."),
+	)
 	ChasmPureTaskRequests = NewCounterDef(
 		"chasm_pure_task_requests",
 		WithDescription("The number of CHASM pure tasks executed."),

--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -918,7 +918,7 @@ func (t *transferQueueActiveTaskExecutor) processStartChildExecution(
 		// Recovery depends on this separate scheduling request returning ErrWorkflowCompleted. If
 		// child start and first Workflow Task scheduling are combined into one transaction, this
 		// path cannot detect a completion that happened before parent replication arrived.
-		scheduleErr := t.createFirstWorkflowTask(ctx, targetNamespaceID.String(), childExecution, parentClock, childClock)
+		scheduleErr := t.createFirstWorkflowTask(ctx, targetNamespaceID.String(), childExecution, parentClock, childClock, task)
 		if scheduleErr == nil || !isWorkflowCompletedError(scheduleErr) {
 			return scheduleErr
 		}
@@ -1090,7 +1090,7 @@ func (t *transferQueueActiveTaskExecutor) processStartChildExecution(
 			if err != nil {
 				return err
 			}
-			return t.createFirstWorkflowTask(ctx, targetNamespaceID.String(), childExecution, parentClock, childClock)
+			return t.createFirstWorkflowTask(ctx, targetNamespaceID.String(), childExecution, parentClock, childClock, task)
 		}
 		// now if there was no child found after reset then it could mean one of the following.
 		// 1. The parent never got a chance to start the child. So we should go ahead and start one (below)
@@ -1200,7 +1200,7 @@ func (t *transferQueueActiveTaskExecutor) processStartChildExecution(
 	return t.createFirstWorkflowTask(ctx, targetNamespaceID.String(), &commonpb.WorkflowExecution{
 		WorkflowId: childInfo.StartedWorkflowId,
 		RunId:      childRunID,
-	}, parentClock, childClock)
+	}, parentClock, childClock, task)
 }
 
 // getOrphanedChildReplacementInfo returns the parent branch evidence needed to validate a
@@ -1519,6 +1519,7 @@ func (t *transferQueueActiveTaskExecutor) createFirstWorkflowTask(
 	execution *commonpb.WorkflowExecution,
 	parentClock *clockspb.VectorClock,
 	childClock *clockspb.VectorClock,
+	task *tasks.StartChildExecutionTask,
 ) error {
 	_, err := t.historyRawClient.ScheduleWorkflowTask(ctx, &historyservice.ScheduleWorkflowTaskRequest{
 		NamespaceId:         namespaceID,
@@ -1527,6 +1528,9 @@ func (t *transferQueueActiveTaskExecutor) createFirstWorkflowTask(
 		ParentClock:         parentClock,
 		ChildClock:          childClock,
 	})
+	if isUnexpectedChildNotFound(err) {
+		t.recordChildExecutionNotFound(err, task, namespaceID, execution)
+	}
 	return err
 }
 
@@ -1619,6 +1623,38 @@ func (t *transferQueueActiveTaskExecutor) recoverClosedChildCompletion(
 		},
 	})
 	return err
+}
+
+// isUnexpectedChildNotFound reports whether the child is absent for a reason the parent's committed
+// ChildWorkflowExecutionStarted cannot account for.
+func isUnexpectedChildNotFound(err error) bool {
+	if !common.IsNotFoundError(err) {
+		return false
+	}
+	// A closed child results in ErrWorkflowCompleted, which is also a NotFound
+	return err.Error() != consts.ErrWorkflowCompleted.Error()
+}
+
+// recordChildExecutionNotFound counts and logs the missing child
+func (t *transferQueueActiveTaskExecutor) recordChildExecutionNotFound(
+	err error,
+	task *tasks.StartChildExecutionTask,
+	childNamespaceID string,
+	childExecution *commonpb.WorkflowExecution,
+) {
+	metrics.ChildExecutionNotFound.With(t.metricHandler).Record(1)
+	t.logger.Error(
+		"Child execution not found after ChildWorkflowExecutionStarted was recorded; StartChildExecution task will be dropped",
+		tag.WorkflowNamespaceID(task.NamespaceID),
+		tag.WorkflowID(task.WorkflowID),
+		tag.WorkflowRunID(task.RunID),
+		tag.NewStringTag("child-namespace-id", childNamespaceID),
+		tag.NewStringTag("child-workflow-id", childExecution.GetWorkflowId()),
+		tag.NewStringTag("child-run-id", childExecution.GetRunId()),
+		tag.NewInt64("initiated-event-id", task.InitiatedEventID),
+		tag.Error(err),
+		tag.ErrorType(err),
+	)
 }
 
 func (t *transferQueueActiveTaskExecutor) requestCancelExternalExecutionCompleted(

--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -1529,7 +1529,18 @@ func (t *transferQueueActiveTaskExecutor) createFirstWorkflowTask(
 		ChildClock:          childClock,
 	})
 	if isUnexpectedChildNotFound(err) {
-		t.recordChildExecutionNotFound(err, task, namespaceID, execution)
+		metrics.ChildExecutionNotFound.With(t.metricHandler).Record(1)
+		t.logger.Error(
+			"Child execution not found after ChildWorkflowExecutionStarted was recorded; StartChildExecution task will be dropped",
+			tag.WorkflowNamespaceID(task.NamespaceID),
+			tag.WorkflowID(task.WorkflowID),
+			tag.WorkflowRunID(task.RunID),
+			tag.NewStringTag("child-namespace-id", namespaceID),
+			tag.NewStringTag("child-workflow-id", execution.GetWorkflowId()),
+			tag.NewStringTag("child-run-id", execution.GetRunId()),
+			tag.NewInt64("initiated-event-id", task.InitiatedEventID),
+			tag.Error(err),
+		)
 	}
 	return err
 }
@@ -1633,28 +1644,6 @@ func isUnexpectedChildNotFound(err error) bool {
 	}
 	// A closed child results in ErrWorkflowCompleted, which is also a NotFound
 	return err.Error() != consts.ErrWorkflowCompleted.Error()
-}
-
-// recordChildExecutionNotFound counts and logs the missing child
-func (t *transferQueueActiveTaskExecutor) recordChildExecutionNotFound(
-	err error,
-	task *tasks.StartChildExecutionTask,
-	childNamespaceID string,
-	childExecution *commonpb.WorkflowExecution,
-) {
-	metrics.ChildExecutionNotFound.With(t.metricHandler).Record(1)
-	t.logger.Error(
-		"Child execution not found after ChildWorkflowExecutionStarted was recorded; StartChildExecution task will be dropped",
-		tag.WorkflowNamespaceID(task.NamespaceID),
-		tag.WorkflowID(task.WorkflowID),
-		tag.WorkflowRunID(task.RunID),
-		tag.NewStringTag("child-namespace-id", childNamespaceID),
-		tag.NewStringTag("child-workflow-id", childExecution.GetWorkflowId()),
-		tag.NewStringTag("child-run-id", childExecution.GetRunId()),
-		tag.NewInt64("initiated-event-id", task.InitiatedEventID),
-		tag.Error(err),
-		tag.ErrorType(err),
-	)
 }
 
 func (t *transferQueueActiveTaskExecutor) requestCancelExternalExecutionCompleted(

--- a/service/history/transfer_queue_active_task_executor_test.go
+++ b/service/history/transfer_queue_active_task_executor_test.go
@@ -3274,6 +3274,144 @@ func (s *transferQueueActiveTaskExecutorSuite) recoverClosedChildCompletion(
 	)
 }
 
+// The parent committed ChildWorkflowExecutionStarted, so the child existed, yet scheduling its first workflow task
+// returns NotFound. Check that it is captured in metrics.
+func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_ChildNotFound_Counted() {
+	captureHandler := metricstest.NewCaptureHandler()
+	s.transferQueueActiveTaskExecutor.metricHandler = captureHandler
+	capture := captureHandler.StartCapture()
+	defer captureHandler.StopCapture(capture)
+
+	childWorkflowID, childRunID, transferTask := s.setupStartedChildForNotFoundTest()
+
+	s.mockHistoryClient.EXPECT().ScheduleWorkflowTask(gomock.Any(), gomock.Any()).Return(
+		nil, serviceerror.NewNotFound("workflow not found"),
+	)
+
+	resp := s.transferQueueActiveTaskExecutor.Execute(context.Background(), s.newTaskExecutable(transferTask))
+	s.Error(resp.ExecutionErr)
+	s.IsType(&serviceerror.NotFound{}, resp.ExecutionErr)
+
+	recordings := capture.Snapshot()[metrics.ChildExecutionNotFound.Name()]
+	s.Len(recordings, 1)
+	s.Equal(int64(1), recordings[0].Value)
+	// Namespace attribution comes from the log, matching the other metrics on this executor's handler.
+	s.Empty(recordings[0].Tags)
+	s.NotEmpty(childWorkflowID)
+	s.NotEmpty(childRunID)
+}
+
+// A closed child answers ErrWorkflowCompleted, a legitimate NotFound.
+func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_ChildNotFound_ClosedChildExcluded() {
+	captureHandler := metricstest.NewCaptureHandler()
+	s.transferQueueActiveTaskExecutor.metricHandler = captureHandler
+	capture := captureHandler.StartCapture()
+	defer captureHandler.StopCapture(capture)
+
+	_, _, transferTask := s.setupStartedChildForNotFoundTest()
+
+	overTheWire := serviceerror.FromStatus(serviceerror.ToStatus(consts.ErrWorkflowCompleted))
+	s.NotErrorIs(overTheWire, consts.ErrWorkflowCompleted) // only the message survives the hop
+	s.mockHistoryClient.EXPECT().ScheduleWorkflowTask(gomock.Any(), gomock.Any()).Return(nil, overTheWire)
+
+	resp := s.transferQueueActiveTaskExecutor.Execute(context.Background(), s.newTaskExecutable(transferTask))
+	s.Error(resp.ExecutionErr)
+	s.Empty(capture.Snapshot()[metrics.ChildExecutionNotFound.Name()])
+}
+
+// A deleted target namespace is a legitimate reason for the child to be absent, so it must not be counted.
+func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_ChildNotFound_NamespaceNotFoundExcluded() {
+	captureHandler := metricstest.NewCaptureHandler()
+	s.transferQueueActiveTaskExecutor.metricHandler = captureHandler
+	capture := captureHandler.StartCapture()
+	defer captureHandler.StopCapture(capture)
+
+	_, _, transferTask := s.setupStartedChildForNotFoundTest()
+
+	s.mockHistoryClient.EXPECT().ScheduleWorkflowTask(gomock.Any(), gomock.Any()).Return(
+		nil, serviceerror.NewNamespaceNotFound(s.childNamespace.String()),
+	)
+
+	resp := s.transferQueueActiveTaskExecutor.Execute(context.Background(), s.newTaskExecutable(transferTask))
+	s.Error(resp.ExecutionErr)
+	s.Empty(capture.Snapshot()[metrics.ChildExecutionNotFound.Name()])
+}
+
+// Builds a parent whose ChildWorkflowExecutionStarted is already committed, so the task takes the childStarted branch
+// straight to createFirstWorkflowTask.
+func (s *transferQueueActiveTaskExecutorSuite) setupStartedChildForNotFoundTest() (string, string, *tasks.StartChildExecutionTask) {
+	execution := &commonpb.WorkflowExecution{
+		WorkflowId: "some random workflow ID",
+		RunId:      uuid.NewString(),
+	}
+	workflowType := "some random workflow type"
+	taskQueueName := "some random task queue"
+
+	childWorkflowID := "some random child workflow ID"
+	childRunID := uuid.NewString()
+	childWorkflowType := "some random child workflow type"
+	childTaskQueueName := "some random child task queue"
+
+	mutableState := workflow.TestGlobalMutableState(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetWorkflowId(), execution.GetRunId())
+	_, err := mutableState.AddWorkflowExecutionStartedEvent(
+		execution,
+		&historyservice.StartWorkflowExecutionRequest{
+			Attempt:     1,
+			NamespaceId: s.namespaceID.String(),
+			StartRequest: &workflowservice.StartWorkflowExecutionRequest{
+				WorkflowType:             &commonpb.WorkflowType{Name: workflowType},
+				TaskQueue:                &taskqueuepb.TaskQueue{Name: taskQueueName},
+				WorkflowExecutionTimeout: durationpb.New(2 * time.Second),
+				WorkflowTaskTimeout:      durationpb.New(1 * time.Second),
+			},
+		},
+	)
+	s.NoError(err)
+
+	wt := addWorkflowTaskScheduledEvent(mutableState)
+	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.NewString())
+	wt.StartedEventID = event.GetEventId()
+	event = addWorkflowTaskCompletedEvent(&s.Suite, mutableState, wt.ScheduledEventID, wt.StartedEventID, "some random identity")
+
+	taskID := s.mustGenerateTaskID()
+
+	event, ci := addStartChildWorkflowExecutionInitiatedEvent(
+		mutableState,
+		event.GetEventId(),
+		s.childNamespace,
+		s.childNamespaceID,
+		childWorkflowID,
+		childWorkflowType,
+		childTaskQueueName,
+		nil,
+		1*time.Second,
+		1*time.Second,
+		1*time.Second,
+		enumspb.PARENT_CLOSE_POLICY_TERMINATE,
+	)
+
+	transferTask := &tasks.StartChildExecutionTask{
+		WorkflowKey: definition.NewWorkflowKey(
+			s.namespaceID.String(),
+			execution.GetWorkflowId(),
+			execution.GetRunId(),
+		),
+		Version:             s.version,
+		TaskID:              taskID,
+		InitiatedEventID:    event.GetEventId(),
+		VisibilityTimestamp: time.Now().UTC(),
+	}
+	childClock := vclock.NewVectorClock(rand.Int63(), rand.Int31(), rand.Int63())
+	event = addChildWorkflowExecutionStartedEvent(mutableState, event.GetEventId(), childWorkflowID, childRunID, childWorkflowType, childClock)
+	mutableState.FlushBufferedEvents()
+	ci.StartedEventId = event.GetEventId()
+
+	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
+	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
+
+	return childWorkflowID, childRunID, transferTask
+}
+
 func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Duplication() {
 	execution := &commonpb.WorkflowExecution{
 		WorkflowId: "some random workflow ID",

--- a/service/history/transfer_queue_active_task_executor_test.go
+++ b/service/history/transfer_queue_active_task_executor_test.go
@@ -3282,7 +3282,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Ch
 	capture := captureHandler.StartCapture()
 	defer captureHandler.StopCapture(capture)
 
-	childWorkflowID, childRunID, transferTask := s.setupStartedChildForNotFoundTest()
+	transferTask := s.setupStartedChildForNotFoundTest()
 
 	s.mockHistoryClient.EXPECT().ScheduleWorkflowTask(gomock.Any(), gomock.Any()).Return(
 		nil, serviceerror.NewNotFound("workflow not found"),
@@ -3290,15 +3290,10 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Ch
 
 	resp := s.transferQueueActiveTaskExecutor.Execute(context.Background(), s.newTaskExecutable(transferTask))
 	s.Error(resp.ExecutionErr)
-	s.IsType(&serviceerror.NotFound{}, resp.ExecutionErr)
 
 	recordings := capture.Snapshot()[metrics.ChildExecutionNotFound.Name()]
 	s.Len(recordings, 1)
 	s.Equal(int64(1), recordings[0].Value)
-	// Namespace attribution comes from the log, matching the other metrics on this executor's handler.
-	s.Empty(recordings[0].Tags)
-	s.NotEmpty(childWorkflowID)
-	s.NotEmpty(childRunID)
 }
 
 // A closed child answers ErrWorkflowCompleted, a legitimate NotFound.
@@ -3308,10 +3303,13 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Ch
 	capture := captureHandler.StartCapture()
 	defer captureHandler.StopCapture(capture)
 
-	_, _, transferTask := s.setupStartedChildForNotFoundTest()
+	transferTask := s.setupStartedChildForNotFoundTest()
+
+	// Completion recovery answers this same error with its own GetMutableState round trip; this test
+	// covers only the metric exclusion.
+	s.transferQueueActiveTaskExecutor.config.EnableChildWorkflowCompletionRecovery = func(string) bool { return false }
 
 	overTheWire := serviceerror.FromStatus(serviceerror.ToStatus(consts.ErrWorkflowCompleted))
-	s.NotErrorIs(overTheWire, consts.ErrWorkflowCompleted) // only the message survives the hop
 	s.mockHistoryClient.EXPECT().ScheduleWorkflowTask(gomock.Any(), gomock.Any()).Return(nil, overTheWire)
 
 	resp := s.transferQueueActiveTaskExecutor.Execute(context.Background(), s.newTaskExecutable(transferTask))
@@ -3326,7 +3324,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Ch
 	capture := captureHandler.StartCapture()
 	defer captureHandler.StopCapture(capture)
 
-	_, _, transferTask := s.setupStartedChildForNotFoundTest()
+	transferTask := s.setupStartedChildForNotFoundTest()
 
 	s.mockHistoryClient.EXPECT().ScheduleWorkflowTask(gomock.Any(), gomock.Any()).Return(
 		nil, serviceerror.NewNamespaceNotFound(s.childNamespace.String()),
@@ -3339,7 +3337,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Ch
 
 // Builds a parent whose ChildWorkflowExecutionStarted is already committed, so the task takes the childStarted branch
 // straight to createFirstWorkflowTask.
-func (s *transferQueueActiveTaskExecutorSuite) setupStartedChildForNotFoundTest() (string, string, *tasks.StartChildExecutionTask) {
+func (s *transferQueueActiveTaskExecutorSuite) setupStartedChildForNotFoundTest() *tasks.StartChildExecutionTask {
 	execution := &commonpb.WorkflowExecution{
 		WorkflowId: "some random workflow ID",
 		RunId:      uuid.NewString(),
@@ -3409,7 +3407,7 @@ func (s *transferQueueActiveTaskExecutorSuite) setupStartedChildForNotFoundTest(
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
-	return childWorkflowID, childRunID, transferTask
+	return transferTask
 }
 
 func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Duplication() {


### PR DESCRIPTION
## What changed?
`createFirstWorkflowTask` now emits a counter (`child_execution_not_found`) and an Error log when `ScheduleWorkflowTask` returns NotFound for a child. `NamespaceNotFound` and `ErrWorkflowCompleted` are excluded. No behavior change: the error is still returned as-is and the task is still acked.

## Why?
Callers arrive only after `ChildWorkflowExecutionStarted` was committed, so the parent asserts the child exists. A potential NotFound on child execution would contradict that, and `isInvalidTaskError` would drop the task, leaving the child created but never scheduled. Publish a metric and monitor it, in case if it happens.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [ ] covered by existing tests
- [X] added new unit test(s)
- [X] added new functional test(s)

Also simulated NotFound error thrown from the store, resulting in corruption. The error was logged.

## Potential risks
There could be some cases I didn't consider. But I explicitly not changing the behavior to monitor it first.
