### PR TITLE
Enable host level events cache by default

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1912,7 +1912,7 @@ This can help reduce effects of shard movement.`,
 	)
 	EnableHostLevelEventsCache = NewGlobalBoolSetting(
 		"history.enableHostLevelEventsCache",
-		false,
+		true,
 		`EnableHostLevelEventsCache controls if the events cache is host level. Requires service restart to take effect.`,
 	)
 	AcquireShardInterval = NewGlobalDurationSetting(


### PR DESCRIPTION
## What changed?

Flip the default of `history.enableHostLevelEventsCache` from `false` to `true`, so history shards share a single host-level events cache instead of each allocating a shard-level one.

## Why?

We have been using host level history cache for a while. We can now enable it in code by default.

## How did you test it?
- [x] built
- [x] covered by existing tests
