### PR TITLE
feat(tls): allow configuring min and max TLS versions

### DIFF
--- a/common/auth/tls_config_helper.go
+++ b/common/auth/tls_config_helper.go
@@ -15,22 +15,36 @@ import (
 
 var ErrTLSConfig = errors.New("unable to config TLS")
 
-// Helper methods for creating tls.Config structs to ensure MinVersion is 1.3
+// Helper methods for creating tls.Config structs. These default to MinVersion 1.2 with
+// MaxVersion left to the Go runtime. The WithVersions variants accept explicit bounds.
 
 func NewEmptyTLSConfig() *tls.Config {
-	return &tls.Config{
-		MinVersion: tls.VersionTLS12,
+	return newEmptyTLSConfig(TLSVersions{})
+}
+
+func newEmptyTLSConfig(versions TLSVersions) *tls.Config {
+	c := &tls.Config{
 		NextProtos: []string{
 			"h2",
 		},
 	}
+	versions.apply(c)
+	return c
 }
 
 func NewTLSConfigForServer(
 	serverName string,
 	enableHostVerification bool,
 ) *tls.Config {
-	c := NewEmptyTLSConfig()
+	return newTLSConfigForServer(serverName, enableHostVerification, TLSVersions{})
+}
+
+func newTLSConfigForServer(
+	serverName string,
+	enableHostVerification bool,
+	versions TLSVersions,
+) *tls.Config {
+	c := newEmptyTLSConfig(versions)
 	c.ServerName = serverName
 	c.InsecureSkipVerify = !enableHostVerification
 	return c
@@ -42,7 +56,19 @@ func NewDynamicTLSClientConfig(
 	serverName string,
 	enableHostVerification bool,
 ) *tls.Config {
-	c := NewTLSConfigForServer(serverName, enableHostVerification)
+	return NewDynamicTLSClientConfigWithVersions(getCert, rootCAs, serverName, enableHostVerification, TLSVersions{})
+}
+
+// NewDynamicTLSClientConfigWithVersions is NewDynamicTLSClientConfig restricted to the given
+// TLS protocol version bounds.
+func NewDynamicTLSClientConfigWithVersions(
+	getCert func() (*tls.Certificate, error),
+	rootCAs *x509.CertPool,
+	serverName string,
+	enableHostVerification bool,
+	versions TLSVersions,
+) *tls.Config {
+	c := newTLSConfigForServer(serverName, enableHostVerification, versions)
 
 	if getCert != nil {
 		c.GetClientCertificate = func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
@@ -60,7 +86,19 @@ func NewTLSConfigWithCertsAndCAs(
 	clientCAs *x509.CertPool,
 	logger log.Logger,
 ) *tls.Config {
-	c := NewEmptyTLSConfig()
+	return NewTLSConfigWithCertsAndCAsWithVersions(clientAuth, certificates, clientCAs, logger, TLSVersions{})
+}
+
+// NewTLSConfigWithCertsAndCAsWithVersions is NewTLSConfigWithCertsAndCAs restricted to the
+// given TLS protocol version bounds.
+func NewTLSConfigWithCertsAndCAsWithVersions(
+	clientAuth tls.ClientAuthType,
+	certificates []tls.Certificate,
+	clientCAs *x509.CertPool,
+	logger log.Logger,
+	versions TLSVersions,
+) *tls.Config {
+	c := newEmptyTLSConfig(versions)
 	c.ClientAuth = clientAuth
 	c.Certificates = certificates
 	c.ClientCAs = clientCAs

--- a/common/auth/tls_version.go
+++ b/common/auth/tls_version.go
@@ -1,0 +1,67 @@
+package auth
+
+import (
+	"cmp"
+	"crypto/tls"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+)
+
+// DefaultMinTLSVersion is the minimum TLS version used when it is not set in configuration.
+const DefaultMinTLSVersion = tls.VersionTLS12
+
+var supportedTLSVersions = map[string]uint16{
+	"1.2": tls.VersionTLS12,
+	"1.3": tls.VersionTLS13,
+}
+
+type (
+	// TLSVersions holds the TLS protocol version bounds applied to a tls.Config.
+	// The zero value keeps the historical behavior: minimum TLS 1.2 and maximum
+	// picked by the Go runtime.
+	TLSVersions struct {
+		Min uint16
+		Max uint16
+	}
+)
+
+// NewTLSVersions parses minVersion and maxVersion configuration values.
+// Both are optional, supported values are "1.2" and "1.3".
+func NewTLSVersions(minVersion string, maxVersion string) (TLSVersions, error) {
+	var versions TLSVersions
+	var err error
+
+	versions.Min, err = parseTLSVersion(minVersion)
+	if err != nil {
+		return TLSVersions{}, fmt.Errorf("%w: invalid minVersion: %w", ErrTLSConfig, err)
+	}
+	versions.Max, err = parseTLSVersion(maxVersion)
+	if err != nil {
+		return TLSVersions{}, fmt.Errorf("%w: invalid maxVersion: %w", ErrTLSConfig, err)
+	}
+	if versions.Min != 0 && versions.Max != 0 && versions.Max < versions.Min {
+		return TLSVersions{}, fmt.Errorf("%w: maxVersion %q is lower than minVersion %q", ErrTLSConfig, maxVersion, minVersion)
+	}
+	return versions, nil
+}
+
+// apply sets version bounds on a tls.Config, defaulting the minimum when unset.
+func (v TLSVersions) apply(config *tls.Config) {
+	config.MinVersion = cmp.Or(v.Min, uint16(DefaultMinTLSVersion))
+	config.MaxVersion = v.Max
+}
+
+func parseTLSVersion(version string) (uint16, error) {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return 0, nil
+	}
+	parsed, ok := supportedTLSVersions[version]
+	if !ok {
+		return 0, fmt.Errorf("%q is not a supported TLS version, expected one of: %s",
+			version, strings.Join(slices.Sorted(maps.Keys(supportedTLSVersions)), ", "))
+	}
+	return parsed, nil
+}

--- a/common/auth/tls_version_test.go
+++ b/common/auth/tls_version_test.go
@@ -1,0 +1,98 @@
+package auth
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTLSVersions(t *testing.T) {
+	testCases := []struct {
+		name        string
+		minVersion  string
+		maxVersion  string
+		expectedMin uint16
+		expectedMax uint16
+		expectedErr bool
+	}{
+		{
+			name: "not set",
+		},
+		{
+			name:        "min only",
+			minVersion:  "1.3",
+			expectedMin: tls.VersionTLS13,
+		},
+		{
+			name:        "max only",
+			maxVersion:  "1.2",
+			expectedMax: tls.VersionTLS12,
+		},
+		{
+			name:        "pinned to 1.3",
+			minVersion:  "1.3",
+			maxVersion:  "1.3",
+			expectedMin: tls.VersionTLS13,
+			expectedMax: tls.VersionTLS13,
+		},
+		{
+			name:        "surrounding whitespace is ignored",
+			minVersion:  " 1.2 ",
+			expectedMin: tls.VersionTLS12,
+		},
+		{
+			name:       "whitespace only means unset",
+			minVersion: "  ",
+			maxVersion: "\t",
+		},
+		{
+			name:        "unknown min version",
+			minVersion:  "1.4",
+			expectedErr: true,
+		},
+		{
+			name:        "unsupported min version",
+			minVersion:  "1.1",
+			expectedErr: true,
+		},
+		{
+			name:        "unknown max version",
+			maxVersion:  "TLSv1.3",
+			expectedErr: true,
+		},
+		{
+			name:        "max lower than min",
+			minVersion:  "1.3",
+			maxVersion:  "1.2",
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			versions, err := NewTLSVersions(tc.minVersion, tc.maxVersion)
+			if tc.expectedErr {
+				require.ErrorIs(t, err, ErrTLSConfig)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedMin, versions.Min)
+			require.Equal(t, tc.expectedMax, versions.Max)
+		})
+	}
+}
+
+func TestTLSVersionsApply(t *testing.T) {
+	// The exported constructors and zero bounds both keep the historical defaults.
+	for _, config := range []*tls.Config{NewEmptyTLSConfig(), newEmptyTLSConfig(TLSVersions{})} {
+		require.Equal(t, uint16(tls.VersionTLS12), config.MinVersion)
+		require.Zero(t, config.MaxVersion)
+	}
+
+	versions, err := NewTLSVersions("1.3", "1.3")
+	require.NoError(t, err)
+	pinned := newEmptyTLSConfig(versions)
+	require.Equal(t, uint16(tls.VersionTLS13), pinned.MinVersion)
+	require.Equal(t, uint16(tls.VersionTLS13), pinned.MaxVersion)
+}

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -191,6 +191,13 @@ type (
 
 		// Requires clients to authenticate with a certificate when connecting, otherwise known as mutual TLS.
 		RequireClientAuth bool `yaml:"requireClientAuth"`
+
+		// Optional - Minimum TLS protocol version accepted by this listener: "1.2" or "1.3".
+		// Defaults to "1.2" when not set.
+		MinVersion string `yaml:"minVersion"`
+		// Optional - Maximum TLS protocol version accepted by this listener: "1.2" or "1.3".
+		// When not set, the highest version supported by the runtime is used.
+		MaxVersion string `yaml:"maxVersion"`
 	}
 
 	// ClientTLS contains TLS configuration for clients within the Temporal Cluster to connect to Temporal nodes.
@@ -216,6 +223,13 @@ type (
 		// Optional - Use TLS even is neither client certificate nor root CAs are configured
 		// This is for non-mTLS cases when client validates serve against a set of trusted CA certificates configured in the environment
 		ForceTLS bool `yaml:"forceTLS"`
+
+		// Optional - Minimum TLS protocol version offered by this client: "1.2" or "1.3".
+		// Defaults to "1.2" when not set.
+		MinVersion string `yaml:"minVersion"`
+		// Optional - Maximum TLS protocol version offered by this client: "1.2" or "1.3".
+		// When not set, the highest version supported by the runtime is used.
+		MaxVersion string `yaml:"maxVersion"`
 	}
 
 	// WorkerTLS contains TLS configuration for system workers within the Temporal Cluster to connect to Temporal frontend.

--- a/common/rpc/encryption/local_store_per_host_cert_provider_map.go
+++ b/common/rpc/encryption/local_store_per_host_cert_provider_map.go
@@ -1,9 +1,12 @@
 package encryption
 
 import (
+	"cmp"
+	"fmt"
 	"strings"
 	"time"
 
+	"go.temporal.io/server/common/auth"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 )
@@ -14,29 +17,76 @@ var _ CertExpirationChecker = (*localStorePerHostCertProviderMap)(nil)
 type localStorePerHostCertProviderMap struct {
 	certProviderCache map[string]CertProvider
 	clientAuthCache   map[string]bool
+	tlsVersionsCache  map[string]auth.TLSVersions
+}
+
+// perHostTLSSettings is a host override with its host name normalized and its TLS protocol
+// version bounds resolved.
+type perHostTLSSettings struct {
+	server   config.ServerTLS
+	versions auth.TLSVersions
+}
+
+// resolvePerHostTLSSettings normalizes host names and resolves version bounds, inheriting the
+// group bounds for the ones an override does not set, so that adding a host override cannot
+// silently widen the range configured for the group.
+//
+// Host names that collide after normalization are rejected: map iteration order would otherwise
+// decide which of them supplies the TLS version bounds, making the effective policy differ
+// between restarts. It only reads configuration: no providers are created, so it is safe to
+// call before anything that would need to be cleaned up on failure.
+func resolvePerHostTLSSettings(group *config.GroupTLS) (map[string]perHostTLSSettings, error) {
+	if group.PerHostOverrides == nil {
+		return nil, nil
+	}
+
+	resolved := make(map[string]perHostTLSSettings, len(group.PerHostOverrides))
+	for host, settings := range group.PerHostOverrides {
+		normalized := strings.ToLower(host)
+		if _, ok := resolved[normalized]; ok {
+			return nil, fmt.Errorf("duplicate host override %q: host names are matched case insensitively", normalized)
+		}
+
+		versions, err := auth.NewTLSVersions(
+			inheritTLSVersion(settings.MinVersion, group.Server.MinVersion),
+			inheritTLSVersion(settings.MaxVersion, group.Server.MaxVersion),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("invalid TLS settings for host %q: %w", host, err)
+		}
+		resolved[normalized] = perHostTLSSettings{server: settings, versions: versions}
+	}
+	return resolved, nil
+}
+
+// inheritTLSVersion falls back to the group value when the override is not set. Values are
+// trimmed first, so that a blank override inherits instead of resolving to the default.
+func inheritTLSVersion(override string, group string) string {
+	return cmp.Or(strings.TrimSpace(override), strings.TrimSpace(group))
 }
 
 func newLocalStorePerHostCertProviderMap(
-	overrides map[string]config.ServerTLS,
+	perHostSettings map[string]perHostTLSSettings,
 	certProviderFactory CertProviderFactory,
 	refreshInterval time.Duration,
 	logger log.Logger,
 ) *localStorePerHostCertProviderMap {
 
 	providerMap := &localStorePerHostCertProviderMap{}
-	if overrides == nil {
+	if perHostSettings == nil {
 		return providerMap
 	}
 
-	providerMap.certProviderCache = make(map[string]CertProvider, len(overrides))
-	providerMap.clientAuthCache = make(map[string]bool, len(overrides))
+	providerMap.certProviderCache = make(map[string]CertProvider, len(perHostSettings))
+	providerMap.clientAuthCache = make(map[string]bool, len(perHostSettings))
+	providerMap.tlsVersionsCache = make(map[string]auth.TLSVersions, len(perHostSettings))
 
-	for host, settings := range overrides {
-		lcHost := strings.ToLower(host)
-
-		provider := certProviderFactory(&config.GroupTLS{Server: settings}, nil, nil, refreshInterval, logger)
-		providerMap.certProviderCache[lcHost] = provider
-		providerMap.clientAuthCache[lcHost] = settings.RequireClientAuth
+	// Host names are already normalized by resolvePerHostTLSSettings.
+	for host, settings := range perHostSettings {
+		providerMap.certProviderCache[host] = certProviderFactory(
+			&config.GroupTLS{Server: settings.server}, nil, nil, refreshInterval, logger)
+		providerMap.clientAuthCache[host] = settings.server.RequireClientAuth
+		providerMap.tlsVersionsCache[host] = settings.versions
 	}
 
 	return providerMap
@@ -56,6 +106,12 @@ func (f *localStorePerHostCertProviderMap) GetCertProvider(hostName string) (Cer
 	}
 	clientAuthRequired := f.clientAuthCache[lcHostName]
 	return cachedCertProvider, clientAuthRequired, nil
+}
+
+// getTLSVersions implements perHostTLSVersionsProvider.
+func (f *localStorePerHostCertProviderMap) getTLSVersions(hostName string) (auth.TLSVersions, bool) {
+	versions, ok := f.tlsVersionsCache[strings.ToLower(hostName)]
+	return versions, ok
 }
 
 func (f *localStorePerHostCertProviderMap) GetExpiringCerts(timeWindow time.Duration,

--- a/common/rpc/encryption/local_store_tls_provider.go
+++ b/common/rpc/encryption/local_store_tls_provider.go
@@ -55,6 +55,13 @@ var _ CertExpirationChecker = (*localStoreTlsProvider)(nil)
 func NewLocalStoreTlsProvider(tlsConfig *config.RootTLS, metricsHandler metrics.Handler, logger log.Logger, certProviderFactory CertProviderFactory,
 ) (TLSConfigProvider, error) {
 
+	// Resolved before any cert provider is created: providers may start refresh goroutines
+	// that would be left running if construction failed afterwards.
+	frontendPerHostSettings, err := resolvePerHostTLSSettings(&tlsConfig.Frontend)
+	if err != nil {
+		return nil, err
+	}
+
 	internodeProvider := certProviderFactory(&tlsConfig.Internode, nil, nil, tlsConfig.RefreshInterval, logger)
 	var workerProvider CertProvider
 	if isSystemWorker(tlsConfig) { // explicit system worker config
@@ -75,7 +82,7 @@ func NewLocalStoreTlsProvider(tlsConfig *config.RootTLS, metricsHandler metrics.
 		frontendCertProvider:        certProviderFactory(&tlsConfig.Frontend, nil, nil, tlsConfig.RefreshInterval, logger),
 		workerCertProvider:          workerProvider,
 		frontendPerHostCertProviderMap: newLocalStorePerHostCertProviderMap(
-			tlsConfig.Frontend.PerHostOverrides, certProviderFactory, tlsConfig.RefreshInterval, logger),
+			frontendPerHostSettings, certProviderFactory, tlsConfig.RefreshInterval, logger),
 		remoteClusterClientCertProvider: remoteClusterClientCertProvider,
 		RWMutex:                         sync.RWMutex{},
 		settings:                        tlsConfig,
@@ -114,8 +121,12 @@ func (s *localStoreTlsProvider) GetInternodeClientConfig() (*tls.Config, error) 
 	return s.getOrCreateConfig(
 		&s.cachedInternodeClientConfig,
 		func() (*tls.Config, error) {
+			versions, err := auth.NewTLSVersions(client.MinVersion, client.MaxVersion)
+			if err != nil {
+				return nil, err
+			}
 			return newClientTLSConfig(s.internodeClientCertProvider, client.ServerName,
-				s.settings.Internode.Server.RequireClientAuth, false, !client.DisableHostVerification)
+				s.settings.Internode.Server.RequireClientAuth, false, !client.DisableHostVerification, versions)
 		},
 		s.settings.Internode.IsClientEnabled(),
 	)
@@ -135,8 +146,12 @@ func (s *localStoreTlsProvider) GetFrontendClientConfig() (*tls.Config, error) {
 	return s.getOrCreateConfig(
 		&s.cachedFrontendClientConfig,
 		func() (*tls.Config, error) {
+			versions, err := auth.NewTLSVersions(client.MinVersion, client.MaxVersion)
+			if err != nil {
+				return nil, err
+			}
 			return newClientTLSConfig(s.workerCertProvider, client.ServerName,
-				useTLS, true, !client.DisableHostVerification)
+				useTLS, true, !client.DisableHostVerification, versions)
 		},
 		useTLS,
 	)
@@ -151,12 +166,17 @@ func (s *localStoreTlsProvider) GetRemoteClusterClientConfig(hostname string) (*
 	return s.getOrCreateRemoteClusterClientConfig(
 		hostname,
 		func() (*tls.Config, error) {
+			versions, err := auth.NewTLSVersions(groupTLS.Client.MinVersion, groupTLS.Client.MaxVersion)
+			if err != nil {
+				return nil, err
+			}
 			return newClientTLSConfig(
 				s.remoteClusterClientCertProvider[key],
 				groupTLS.Client.ServerName,
 				groupTLS.Server.RequireClientAuth,
 				false,
-				!groupTLS.Client.DisableHostVerification)
+				!groupTLS.Client.DisableHostVerification,
+				versions)
 		},
 		groupTLS.IsClientEnabled(),
 	)
@@ -289,9 +309,18 @@ func newServerTLSConfig(
 ) (*tls.Config, error) {
 
 	clientAuthRequired := config.Server.RequireClientAuth
-	tlsConfig, err := getServerTLSConfigFromCertProvider(certProvider, clientAuthRequired, "", "", logger)
+	versions, err := auth.NewTLSVersions(config.Server.MinVersion, config.Server.MaxVersion)
 	if err != nil {
 		return nil, err
+	}
+	tlsConfig, err := getServerTLSConfigFromCertProvider(certProvider, clientAuthRequired, versions, "", "", logger)
+	if err != nil {
+		return nil, err
+	}
+
+	var versionsProvider perHostTLSVersionsProvider
+	if provider, ok := perHostCertProviderMap.(perHostTLSVersionsProvider); ok {
+		versionsProvider = provider
 	}
 
 	tlsConfig.GetConfigForClient = func(c *tls.ClientHelloInfo) (*tls.Config, error) {
@@ -308,13 +337,19 @@ func newServerTLSConfig(
 			}
 
 			if perHostCertProvider != nil {
-				return getServerTLSConfigFromCertProvider(perHostCertProvider, hostClientAuthRequired, remoteAddress, c.ServerName, logger)
+				hostVersions := versions
+				if versionsProvider != nil {
+					if v, ok := versionsProvider.getTLSVersions(c.ServerName); ok {
+						hostVersions = v
+					}
+				}
+				return getServerTLSConfigFromCertProvider(perHostCertProvider, hostClientAuthRequired, hostVersions, remoteAddress, c.ServerName, logger)
 			}
 			logger.Warn("cannot find a per-host provider for attempted incoming TLS connection. returning default TLS configuration",
 				tag.ServerName(c.ServerName), tag.Address(remoteAddress))
-			return getServerTLSConfigFromCertProvider(certProvider, clientAuthRequired, remoteAddress, c.ServerName, logger)
+			return getServerTLSConfigFromCertProvider(certProvider, clientAuthRequired, versions, remoteAddress, c.ServerName, logger)
 		}
-		return getServerTLSConfigFromCertProvider(certProvider, clientAuthRequired, remoteAddress, c.ServerName, logger)
+		return getServerTLSConfigFromCertProvider(certProvider, clientAuthRequired, versions, remoteAddress, c.ServerName, logger)
 	}
 
 	return tlsConfig, nil
@@ -323,6 +358,7 @@ func newServerTLSConfig(
 func getServerTLSConfigFromCertProvider(
 	certProvider CertProvider,
 	requireClientAuth bool,
+	versions auth.TLSVersions,
 	remoteAddress string,
 	serverName string,
 	logger log.Logger) (*tls.Config, error) {
@@ -356,11 +392,12 @@ func getServerTLSConfigFromCertProvider(
 	if remoteAddress != "" { // remoteAddress=="" when we return initial tls.Config object when configuring server
 		logger.Debug("returning TLS config for connection", tag.Address(remoteAddress), tag.ServerName(serverName))
 	}
-	return auth.NewTLSConfigWithCertsAndCAs(
+	return auth.NewTLSConfigWithCertsAndCAsWithVersions(
 		clientAuthType,
 		[]tls.Certificate{*serverCert},
 		clientCaPool,
-		logger), nil
+		logger,
+		versions), nil
 }
 
 func newClientTLSConfig(
@@ -369,6 +406,7 @@ func newClientTLSConfig(
 	isAuthRequired bool,
 	isWorker bool,
 	enableHostVerification bool,
+	versions auth.TLSVersions,
 ) (*tls.Config, error) {
 	// Optional ServerCA for client if not already trusted by host
 	serverCa, err := clientProvider.FetchServerRootCAsForClient(isWorker)
@@ -393,11 +431,12 @@ func newClientTLSConfig(
 		}
 	}
 
-	return auth.NewDynamicTLSClientConfig(
+	return auth.NewDynamicTLSClientConfigWithVersions(
 		getCert,
 		serverCa,
 		serverName,
 		enableHostVerification,
+		versions,
 	), nil
 }
 

--- a/common/rpc/encryption/test_dynamic_tlsconfig_provider.go
+++ b/common/rpc/encryption/test_dynamic_tlsconfig_provider.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"time"
 
+	"go.temporal.io/server/common/auth"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 )
@@ -28,7 +29,12 @@ func (t *TestDynamicTLSConfigProvider) GetInternodeServerConfig() (*tls.Config, 
 }
 
 func (t *TestDynamicTLSConfigProvider) GetInternodeClientConfig() (*tls.Config, error) {
-	return newClientTLSConfig(t.InternodeClientCertProvider, t.settings.Internode.Client.ServerName, true, false, true)
+	client := &t.settings.Internode.Client
+	versions, err := auth.NewTLSVersions(client.MinVersion, client.MaxVersion)
+	if err != nil {
+		return nil, err
+	}
+	return newClientTLSConfig(t.InternodeClientCertProvider, client.ServerName, true, false, true, versions)
 }
 
 func (t *TestDynamicTLSConfigProvider) GetFrontendServerConfig() (*tls.Config, error) {
@@ -36,7 +42,12 @@ func (t *TestDynamicTLSConfigProvider) GetFrontendServerConfig() (*tls.Config, e
 }
 
 func (t *TestDynamicTLSConfigProvider) GetFrontendClientConfig() (*tls.Config, error) {
-	return newClientTLSConfig(t.WorkerCertProvider, t.settings.Frontend.Client.ServerName, true, false, true)
+	client := &t.settings.Frontend.Client
+	versions, err := auth.NewTLSVersions(client.MinVersion, client.MaxVersion)
+	if err != nil {
+		return nil, err
+	}
+	return newClientTLSConfig(t.WorkerCertProvider, client.ServerName, true, false, true, versions)
 }
 
 func (t *TestDynamicTLSConfigProvider) GetExpiringCerts(timeWindow time.Duration) (expiring CertExpirationMap, expired CertExpirationMap, err error) {

--- a/common/rpc/encryption/tls_factory.go
+++ b/common/rpc/encryption/tls_factory.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"go.temporal.io/server/common/auth"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
@@ -37,6 +38,13 @@ type (
 		GetCertProvider(hostName string) (provider CertProvider, clientAuthRequired bool, err error)
 		GetExpiringCerts(timeWindow time.Duration) (expiring CertExpirationMap, expired CertExpirationMap, err error)
 		NumberOfHosts() int
+	}
+
+	// perHostTLSVersionsProvider is optionally implemented by a PerHostCertProviderMap to
+	// supply per-host TLS protocol version bounds. Implementations that do not provide them
+	// fall back to the bounds configured for the group.
+	perHostTLSVersionsProvider interface {
+		getTLSVersions(hostName string) (auth.TLSVersions, bool)
 	}
 
 	CertThumbprint [16]byte
@@ -82,7 +90,25 @@ func validateRootTLS(cfg *config.RootTLS) error {
 	if err := validateGroupTLS(&cfg.Frontend); err != nil {
 		return err
 	}
+	for name, groupTLS := range cfg.RemoteClusters {
+		// Remote cluster groups have never been covered by the checks above. Only the
+		// version bounds are validated here, so that configurations that pass today
+		// keep starting up.
+		if err := validateTLSVersions(&groupTLS); err != nil {
+			return fmt.Errorf("invalid TLS settings for remote cluster %q: %w", name, err)
+		}
+	}
 	return validateWorkerTLS(&cfg.SystemWorker)
+}
+
+func validateTLSVersions(cfg *config.GroupTLS) error {
+	if _, err := auth.NewTLSVersions(cfg.Server.MinVersion, cfg.Server.MaxVersion); err != nil {
+		return fmt.Errorf("invalid ServerTLS: %w", err)
+	}
+	if _, err := auth.NewTLSVersions(cfg.Client.MinVersion, cfg.Client.MaxVersion); err != nil {
+		return fmt.Errorf("invalid ClientTLS: %w", err)
+	}
+	return nil
 }
 
 func validateGroupTLS(cfg *config.GroupTLS) error {
@@ -130,6 +156,9 @@ func validateServerTLS(cfg *config.ServerTLS) error {
 	if len(cfg.ClientCAFiles) > 0 && len(cfg.ClientCAData) > 0 {
 		return fmt.Errorf("cannot specify ClientCAFiles and ClientCAData at the same time")
 	}
+	if _, err := auth.NewTLSVersions(cfg.MinVersion, cfg.MaxVersion); err != nil {
+		return fmt.Errorf("invalid ServerTLS: %w", err)
+	}
 	return nil
 }
 
@@ -142,6 +171,9 @@ func validateClientTLS(cfg *config.ClientTLS) error {
 	}
 	if len(cfg.RootCAData) > 0 && len(cfg.RootCAFiles) > 0 {
 		return fmt.Errorf("cannot specify RootCAFiles and RootCAData at the same time")
+	}
+	if _, err := auth.NewTLSVersions(cfg.MinVersion, cfg.MaxVersion); err != nil {
+		return fmt.Errorf("invalid ClientTLS: %w", err)
 	}
 	return nil
 }

--- a/common/rpc/encryption/tls_version_test.go
+++ b/common/rpc/encryption/tls_version_test.go
@@ -1,0 +1,298 @@
+package encryption
+
+import (
+	"crypto/tls"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/tests/testutils"
+)
+
+// serverCertProvider is a stubCertProvider that serves a real certificate, which is required
+// to build a server side tls.Config.
+type serverCertProvider struct {
+	stubCertProvider
+	cert *tls.Certificate
+}
+
+func (s *serverCertProvider) FetchServerCertificate() (*tls.Certificate, error) {
+	return s.cert, nil
+}
+
+func newTestServerTLSProvider(t *testing.T, cfg config.RootTLS, cert *tls.Certificate) TLSConfigProvider {
+	t.Helper()
+	factory := func(_ *config.GroupTLS, _ *config.WorkerTLS, _ *config.ClientTLS, _ time.Duration, _ log.Logger) CertProvider {
+		return &serverCertProvider{cert: cert}
+	}
+	provider, err := NewLocalStoreTlsProvider(&cfg, metrics.NoopMetricsHandler, log.NewTestLogger(), factory)
+	require.NoError(t, err)
+	return provider
+}
+
+func TestClientTLSVersions(t *testing.T) {
+	cfg := config.RootTLS{
+		Internode: config.GroupTLS{
+			Client: config.ClientTLS{ForceTLS: true, MinVersion: "1.3", MaxVersion: "1.3"},
+		},
+		Frontend: config.GroupTLS{
+			Client: config.ClientTLS{ForceTLS: true},
+		},
+	}
+	provider := newTestTLSProvider(t, cfg)
+
+	internodeCfg, err := provider.GetInternodeClientConfig()
+	require.NoError(t, err)
+	require.NotNil(t, internodeCfg)
+	require.Equal(t, uint16(tls.VersionTLS13), internodeCfg.MinVersion)
+	require.Equal(t, uint16(tls.VersionTLS13), internodeCfg.MaxVersion)
+
+	// Not configured, defaults are preserved
+	frontendCfg, err := provider.GetFrontendClientConfig()
+	require.NoError(t, err)
+	require.NotNil(t, frontendCfg)
+	require.Equal(t, uint16(tls.VersionTLS12), frontendCfg.MinVersion)
+	require.Zero(t, frontendCfg.MaxVersion)
+}
+
+func TestRemoteClusterClientTLSVersions(t *testing.T) {
+	cfg := config.RootTLS{
+		RemoteClusters: map[string]config.GroupTLS{
+			"cluster-a.example.com": {
+				Client: config.ClientTLS{ForceTLS: true, MinVersion: "1.3"},
+			},
+		},
+	}
+	provider := newTestTLSProvider(t, cfg)
+
+	tlsCfg, err := provider.GetRemoteClusterClientConfig("cluster-a.example.com")
+	require.NoError(t, err)
+	require.NotNil(t, tlsCfg)
+	require.Equal(t, uint16(tls.VersionTLS13), tlsCfg.MinVersion)
+}
+
+func TestServerTLSVersions(t *testing.T) {
+	certs, _, _, err := testutils.GenerateTestCerts(t.TempDir(), "127.0.0.1", 1)
+	require.NoError(t, err)
+
+	cfg := config.RootTLS{
+		Frontend: config.GroupTLS{
+			Server: config.ServerTLS{KeyFile: "foo", MinVersion: "1.3"},
+			PerHostOverrides: map[string]config.ServerTLS{
+				"inherits.example.com": {KeyFile: "foo"},
+				"blank.example.com":    {KeyFile: "foo", MinVersion: " "},
+				"legacy.example.com":   {KeyFile: "foo", MinVersion: "1.2", MaxVersion: "1.2"},
+			},
+		},
+		Internode: config.GroupTLS{
+			Server: config.ServerTLS{KeyFile: "foo"},
+		},
+	}
+	provider := newTestServerTLSProvider(t, cfg, certs[0])
+
+	frontendCfg, err := provider.GetFrontendServerConfig()
+	require.NoError(t, err)
+	require.NotNil(t, frontendCfg)
+	require.Equal(t, uint16(tls.VersionTLS13), frontendCfg.MinVersion)
+	require.Zero(t, frontendCfg.MaxVersion)
+
+	// Not configured, defaults are preserved
+	internodeCfg, err := provider.GetInternodeServerConfig()
+	require.NoError(t, err)
+	require.NotNil(t, internodeCfg)
+	require.Equal(t, uint16(tls.VersionTLS12), internodeCfg.MinVersion)
+	require.Zero(t, internodeCfg.MaxVersion)
+
+	// Go negotiates the protocol version after GetConfigForClient, so the config returned
+	// for a host override is the one that takes effect.
+	serverConn, clientConn := net.Pipe()
+	defer func() { _ = serverConn.Close() }()
+	defer func() { _ = clientConn.Close() }()
+
+	configForHost := func(serverName string) *tls.Config {
+		hostCfg, err := frontendCfg.GetConfigForClient(&tls.ClientHelloInfo{
+			ServerName: serverName,
+			Conn:       serverConn,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, hostCfg)
+		return hostCfg
+	}
+
+	// An override without its own bounds inherits them from the group, so adding a host
+	// override cannot silently widen the range.
+	inherited := configForHost("inherits.example.com")
+	require.Equal(t, uint16(tls.VersionTLS13), inherited.MinVersion)
+	require.Zero(t, inherited.MaxVersion)
+
+	// A blank value counts as unset, so it inherits rather than falling back to the default.
+	blank := configForHost("blank.example.com")
+	require.Equal(t, uint16(tls.VersionTLS13), blank.MinVersion)
+
+	// Explicit per-host bounds win over the group.
+	overridden := configForHost("legacy.example.com")
+	require.Equal(t, uint16(tls.VersionTLS12), overridden.MinVersion)
+	require.Equal(t, uint16(tls.VersionTLS12), overridden.MaxVersion)
+}
+
+func TestPerHostSettingsRejectDuplicateHostNames(t *testing.T) {
+	// Without this check, map iteration order would decide whether TLS 1.2 or TLS 1.3 is the
+	// minimum for this host, so the effective policy could differ between restarts.
+	cfg := config.RootTLS{
+		Frontend: config.GroupTLS{
+			Server: config.ServerTLS{KeyFile: "foo", MinVersion: "1.3"},
+			PerHostOverrides: map[string]config.ServerTLS{
+				"EXAMPLE.COM": {KeyFile: "upper", MinVersion: "1.2", MaxVersion: "1.2"},
+				"example.com": {KeyFile: "lower"},
+			},
+		},
+	}
+
+	for range 50 {
+		_, err := NewLocalStoreTlsProvider(&cfg, metrics.NoopMetricsHandler, log.NewTestLogger(), stubCertProviderFactory)
+		require.ErrorContains(t, err, `duplicate host override "example.com"`)
+	}
+
+	// Host names that only differ from each other are fine.
+	cfg.Frontend.PerHostOverrides = map[string]config.ServerTLS{
+		"EXAMPLE.COM": {KeyFile: "upper"},
+		"other.com":   {KeyFile: "lower"},
+	}
+	_, err := NewLocalStoreTlsProvider(&cfg, metrics.NoopMetricsHandler, log.NewTestLogger(), stubCertProviderFactory)
+	require.NoError(t, err)
+}
+
+func TestHostOverrideInheritedVersionsAreValidated(t *testing.T) {
+	// Inherited minVersion 1.3 combined with the per-host maxVersion 1.2 is an empty range.
+	cfg := config.RootTLS{
+		Frontend: config.GroupTLS{
+			Server: config.ServerTLS{KeyFile: "foo", MinVersion: "1.3"},
+			PerHostOverrides: map[string]config.ServerTLS{
+				"legacy.example.com": {KeyFile: "foo", MaxVersion: "1.2"},
+			},
+		},
+	}
+	_, err := NewLocalStoreTlsProvider(&cfg, metrics.NoopMetricsHandler, log.NewTestLogger(), stubCertProviderFactory)
+	require.ErrorContains(t, err, "legacy.example.com")
+}
+
+func TestServerRejectsClientBelowMinVersion(t *testing.T) {
+	certs, caPool, _, err := testutils.GenerateTestCerts(t.TempDir(), "127.0.0.1", 1)
+	require.NoError(t, err)
+
+	cfg := config.RootTLS{
+		Frontend: config.GroupTLS{
+			Server: config.ServerTLS{KeyFile: "foo", MinVersion: "1.3"},
+		},
+	}
+	provider := newTestServerTLSProvider(t, cfg, certs[0])
+	serverCfg, err := provider.GetFrontendServerConfig()
+	require.NoError(t, err)
+
+	handshake := func(clientMaxVersion uint16) (clientErr error, serverErr error) {
+		serverConn, clientConn := net.Pipe()
+		defer func() { _ = serverConn.Close() }()
+		defer func() { _ = clientConn.Close() }()
+
+		serverErrCh := make(chan error, 1)
+		go func() {
+			serverErrCh <- tls.Server(serverConn, serverCfg).Handshake()
+		}()
+
+		clientErr = tls.Client(clientConn, &tls.Config{
+			RootCAs:    caPool,
+			ServerName: "127.0.0.1",
+			MinVersion: tls.VersionTLS12,
+			MaxVersion: clientMaxVersion,
+		}).Handshake()
+		return clientErr, <-serverErrCh
+	}
+
+	// The failure must be about the protocol version, not about the certificate, otherwise
+	// this test would keep passing if version enforcement were dropped.
+	clientErr, serverErr := handshake(tls.VersionTLS12)
+	require.ErrorContains(t, clientErr, "protocol version not supported")
+	require.ErrorContains(t, serverErr, "client offered only unsupported versions")
+
+	clientErr, serverErr = handshake(tls.VersionTLS13)
+	require.NoError(t, clientErr)
+	require.NoError(t, serverErr)
+}
+
+func TestInvalidHostOverrideTLSVersionFailsProviderCreation(t *testing.T) {
+	cfg := config.RootTLS{
+		Frontend: config.GroupTLS{
+			PerHostOverrides: map[string]config.ServerTLS{
+				"legacy.example.com": {KeyFile: "foo", MinVersion: "1.4"},
+			},
+		},
+	}
+	_, err := NewLocalStoreTlsProvider(&cfg, metrics.NoopMetricsHandler, log.NewTestLogger(), stubCertProviderFactory)
+	require.ErrorContains(t, err, "legacy.example.com")
+}
+
+func TestValidateTLSVersions(t *testing.T) {
+	testCases := []struct {
+		name string
+		cfg  config.RootTLS
+	}{
+		{
+			name: "invalid frontend server version",
+			cfg:  config.RootTLS{Frontend: config.GroupTLS{Server: config.ServerTLS{MinVersion: "1.4"}}},
+		},
+		{
+			name: "invalid internode client version",
+			cfg:  config.RootTLS{Internode: config.GroupTLS{Client: config.ClientTLS{MaxVersion: "1.1"}}},
+		},
+		{
+			name: "max lower than min",
+			cfg:  config.RootTLS{Frontend: config.GroupTLS{Server: config.ServerTLS{MinVersion: "1.3", MaxVersion: "1.2"}}},
+		},
+		{
+			name: "invalid host override version",
+			cfg: config.RootTLS{Frontend: config.GroupTLS{
+				PerHostOverrides: map[string]config.ServerTLS{"foo": {MinVersion: "1.4"}},
+			}},
+		},
+		{
+			name: "invalid remote cluster version",
+			cfg: config.RootTLS{RemoteClusters: map[string]config.GroupTLS{
+				"cluster-a": {Client: config.ClientTLS{MinVersion: "1.4"}},
+			}},
+		},
+		{
+			name: "invalid system worker client version",
+			cfg:  config.RootTLS{SystemWorker: config.WorkerTLS{Client: config.ClientTLS{MinVersion: "1.4"}}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Error(t, validateRootTLS(&tc.cfg))
+		})
+	}
+
+	t.Run("remote cluster error names the cluster", func(t *testing.T) {
+		err := validateRootTLS(&config.RootTLS{RemoteClusters: map[string]config.GroupTLS{
+			"cluster-a": {Client: config.ClientTLS{MinVersion: "1.4"}},
+		}})
+		require.ErrorContains(t, err, "cluster-a")
+	})
+
+	t.Run("remote clusters keep passing the checks they were never subject to", func(t *testing.T) {
+		require.NoError(t, validateRootTLS(&config.RootTLS{RemoteClusters: map[string]config.GroupTLS{
+			"cluster-a": {Client: config.ClientTLS{
+				RootCAFiles: []string{"ca.pem"},
+				RootCAData:  []string{"Y2E="},
+			}},
+		}}))
+	})
+
+	require.NoError(t, validateRootTLS(&config.RootTLS{
+		Frontend: config.GroupTLS{Server: config.ServerTLS{MinVersion: "1.2", MaxVersion: "1.3"}},
+	}))
+}


### PR DESCRIPTION
## What changed?
  Added `minVersion` and `maxVersion` to `ServerTLS` and `ClientTLS`, so TLS protocol versions can be restricted per group:

```yml
  global:
    tls:
      internode:
        server: {minVersion: "1.3", maxVersion: "1.3"}
      frontend:
        server: {minVersion: "1.3"}
        hostOverrides:
          legacy.example.com: {certFile: ..., keyFile: ..., minVersion: "1.2"}
```

  Supported values are "1.2" and "1.3". Both fields are optional; leaving them unset keeps the current behavior (minimum 1.2, maximum chosen by the runtime). The settings apply to internode, frontend, `frontend.hostOverrides`, `systemWorker.client` and `remoteClusters.*.client`.

  Details worth calling out:

  - Host overrides inherit the group bounds unless they set their own, so adding an override cannot silently widen the range configured for the group. Per-SNI bounds work because Go negotiates the protocol version after `GetConfigForClient`.
  - Invalid values fail at startup rather than at the first handshake. Parsing happens before any cert provider is created, so a failure does not leave certificate refresh goroutines running.
  - Host override names that collide after case normalization are now rejected. Previously map iteration order picked the winner, which would have made the effective version policy differ between restarts.
  - Remote cluster groups are now validated, but for version bounds only. They were never covered by the other checks, and extending those checks here would reject configurations that start today.
  - Fixed the stale comment in `tls_config_helper.go` noted in the issue: it claimed MinVersion is 1.3 while the code sets 1.2.

  The published signatures in `common/auth` are unchanged. Explicit bounds go through two new functions, `NewDynamicTLSClientConfigWithVersions` and `NewTLSConfigWithCertsAndCAsWithVersions`.


## Why?

Closes #10839. 

The minimum TLS version was hardcoded to 1.2 and the maximum was not set at all, so there was no way to pin a deployment to TLS 1.3.

## How did you test it?
  - [x] built
  - [ ] run locally and tested manually
  - [x] covered by existing tests
  - [x] added new unit test(s)
  - [ ] added new functional test(s)

  New tests cover version parsing (valid, unsupported, blank, `max < min`), resolved bounds on server and client configs, host override inheritance and explicit overrides, duplicate host name rejection, and startup validation for every group. One test performs a real handshake over net.Pipe: a server pinned to 1.3 rejects a client capped at 1.2 with a protocol version error, and accepts a 1.3 client.

  `make lint-code` is clean, and `go test -race` passes for `common/auth` and `common/rpc/encryption`.

## Potential risks

  - A configuration whose `hostOverrides` contains host names differing only in case will now fail to start. Such a configuration is already non-deterministic today, but this turns a silent problem into a startup
  error.
  - `internode` settings also govern the ringpop membership channel, not just gRPC. Pinning internode to 1.3 changes both.
  - Persistence connections (Cassandra, SQL, Elasticsearch) and `tdbg` use a separate TLS config struct and are not covered. An operator hardening the cluster may reasonably assume they are.
  - Setting `maxVersion` on the frontend server caps external SDK clients; this is expressible now, but is not what the issue asked for.