### PR TITLE
fix(cache): prevent negative cache_pinned_usage

### DIFF
--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -253,6 +253,10 @@ func (c *lru) Delete(key any) {
 }
 
 // Release decrements the ref count of a pinned element.
+//
+// CONSIDER(ekalinin): references are identified by key only, so a release owed for an entry that
+// was deleted lands on whatever was re-inserted under that key and unpins it while its real holder
+// is still using it. Telling them apart needs per-entry identity in the Cache interface.
 func (c *lru) Release(key any) {
 	if c.maxSize == 0 || !c.pin {
 		return
@@ -265,13 +269,26 @@ func (c *lru) Release(key any) {
 		return
 	}
 	entry := elt.Value.(*entryImpl)
+	if entry.refCount <= 0 {
+		// Release without a matching reference. Entries are looked up by key, so this happens when
+		// the key was deleted and re-inserted while the caller still owed a release for the entry
+		// that is gone. Letting refCount go negative would pin the entry forever, since both
+		// eviction and TTL expiry require refCount == 0.
+		return
+	}
 	entry.refCount--
+	// Entry size might have changed. Recalculate size and evict entries if necessary.
+	newEntrySize := getSize(entry.value)
 	if entry.refCount == 0 {
 		c.pinnedSize -= entry.Size()
 		metrics.CachePinnedUsage.With(c.metricsHandler).Record(float64(c.pinnedSize))
+	} else if newEntrySize != entry.Size() {
+		// Entry stays pinned, so pinnedSize must follow the size change applied below. Otherwise
+		// the release that unpins the entry would subtract a size different from the one added
+		// when the entry was pinned, and pinnedSize would drift, possibly below zero.
+		c.pinnedSize += newEntrySize - entry.Size()
+		metrics.CachePinnedUsage.With(c.metricsHandler).Record(float64(c.pinnedSize))
 	}
-	// Entry size might have changed. Recalculate size and evict entries if necessary.
-	newEntrySize := getSize(entry.value)
 	c.currSize = c.calculateNewCacheSize(newEntrySize, entry.Size())
 	entry.size = newEntrySize
 	if c.currSize > c.maxSize {
@@ -381,6 +398,12 @@ func (c *lru) deleteInternal(element *list.Element) {
 	entry := c.byAccess.Remove(element).(*entryImpl)
 	c.currSize -= entry.Size()
 	metrics.CacheUsage.With(c.metricsHandler).Record(float64(c.currSize))
+	if entry.refCount > 0 {
+		// Entry is gone from the cache, so its subsequent Release won't find it and won't
+		// be able to give the pinned bytes back.
+		c.pinnedSize -= entry.Size()
+		metrics.CachePinnedUsage.With(c.metricsHandler).Record(float64(c.pinnedSize))
+	}
 	metrics.CacheEntryAgeOnEviction.With(c.metricsHandler).Record(c.timeSource.Now().UTC().Sub(entry.createTime))
 	delete(c.byKey, entry.key)
 

--- a/common/cache/lru_test.go
+++ b/common/cache/lru_test.go
@@ -695,6 +695,134 @@ func TestCache_ItemSizeChangeBeforeRelease(t *testing.T) {
 	require.Equal(t, 2, cache.Size())
 }
 
+func TestCache_PinnedUsageItemSizeChangeBetweenReleases(t *testing.T) {
+	t.Parallel()
+
+	metricsHandler := metricstest.NewCaptureHandler()
+	cache := NewWithMetrics(10, &Options{Pin: true}, metricsHandler)
+
+	entry := &testEntryWithCacheSize{cacheSize: 1}
+	key := uuid.New()
+
+	capture := metricsHandler.StartCapture()
+	_, err := cache.PutIfNotExist(key, entry)
+	require.NoError(t, err)
+	// Second reference to the same entry, ref count is 2 now.
+	require.Equal(t, entry, cache.Get(key))
+	require.Equal(t, 1, lastPinnedUsage(t, capture))
+
+	// Entry grows while it is still pinned by the second reference.
+	entry.cacheSize = 5
+	cache.Release(key)
+	require.Equal(t, 5, lastPinnedUsage(t, capture))
+
+	cache.Release(key)
+	require.Equal(t, 0, lastPinnedUsage(t, capture))
+}
+
+func TestCache_PinnedUsageDeleteWhilePinned(t *testing.T) {
+	t.Parallel()
+
+	metricsHandler := metricstest.NewCaptureHandler()
+	cache := NewWithMetrics(10, &Options{Pin: true}, metricsHandler)
+
+	entry := &testEntryWithCacheSize{cacheSize: 4}
+	key := uuid.New()
+
+	capture := metricsHandler.StartCapture()
+	_, err := cache.PutIfNotExist(key, entry)
+	require.NoError(t, err)
+	require.Equal(t, 4, lastPinnedUsage(t, capture))
+
+	// Entry is deleted while still pinned, the subsequent Release is a no-op.
+	cache.Delete(key)
+	cache.Release(key)
+	require.Equal(t, 0, lastPinnedUsage(t, capture))
+}
+
+// Release resolves entries by key, so a release still owed for an entry that was deleted lands on
+// whatever was re-inserted under that key and unpins it early. Telling the two apart needs the
+// reference to identify the entry it belongs to, which the Cache interface does not carry, so this
+// test only pins down that the counters stay consistent: pinnedSize is given back exactly once and
+// the entry stays evictable instead of being stranded with a negative ref count.
+func TestCache_StaleReleaseAfterReInsert(t *testing.T) {
+	t.Parallel()
+
+	ttl := time.Minute
+	timeSource := clock.NewEventTimeSource()
+	metricsHandler := metricstest.NewCaptureHandler()
+	cache := NewWithMetrics(10,
+		&Options{
+			TTL:        ttl,
+			Pin:        true,
+			TimeSource: timeSource,
+		},
+		metricsHandler,
+	)
+
+	oldEntry := &testEntryWithCacheSize{cacheSize: 1}
+	newEntry := &testEntryWithCacheSize{cacheSize: 8}
+	key := uuid.New()
+
+	capture := metricsHandler.StartCapture()
+	_, err := cache.PutIfNotExist(key, oldEntry)
+	require.NoError(t, err)
+
+	cache.Delete(key)
+	_, err = cache.PutIfNotExist(key, newEntry)
+	require.NoError(t, err)
+	require.Equal(t, 8, lastPinnedUsage(t, capture))
+
+	// The release still owed for oldEntry lands on newEntry and unpins it early. Undesirable, but
+	// pre-existing and out of reach of this fix.
+	cache.Release(key)
+	require.Equal(t, 0, lastPinnedUsage(t, capture))
+
+	// The release owed for newEntry no longer has a reference to give back.
+	newEntry.cacheSize = 2
+	cache.Release(key)
+	require.Equal(t, 0, lastPinnedUsage(t, capture))
+
+	timeSource.Advance(2 * ttl)
+	require.Nil(t, cache.Get(key))
+	require.Equal(t, 0, cache.Size())
+}
+
+func TestCache_StaleReleaseKeepsEntryEvictable(t *testing.T) {
+	t.Parallel()
+
+	ttl := time.Minute
+	timeSource := clock.NewEventTimeSource()
+	cache := New(10,
+		&Options{
+			TTL:        ttl,
+			Pin:        true,
+			TimeSource: timeSource,
+		},
+	)
+
+	key := uuid.New()
+	_, err := cache.PutIfNotExist(key, &testEntryWithCacheSize{cacheSize: 3})
+	require.NoError(t, err)
+
+	cache.Release(key)
+	// Extra release without a matching reference must not drive the ref count below zero:
+	// both eviction and TTL expiry require refCount == 0.
+	cache.Release(key)
+
+	timeSource.Advance(2 * ttl)
+	require.Nil(t, cache.Get(key))
+	require.Equal(t, 0, cache.Size())
+}
+
+// lastPinnedUsage returns the most recent value recorded for the cache_pinned_usage metric.
+func lastPinnedUsage(t *testing.T, capture *metricstest.Capture) int {
+	t.Helper()
+	recordings := capture.Snapshot()[metrics.CachePinnedUsage.Name()]
+	require.NotEmpty(t, recordings)
+	return int(recordings[len(recordings)-1].Value.(float64))
+}
+
 func TestCache_InvokeLifecycleCallbacks(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed?

Three accounting fixes for pin-mode caches in `common/cache/lru.go`:

1. `Release` keeps `pinnedSize` in sync with `entry.size` - when a release leaves the entry pinned, `pinnedSize` gets the same delta that is applied to `entry.size` a few lines below.
2. `deleteInternal` gives the pinned bytes back when removing an entry with `refCount > 0`. The subsequent `Release` cannot do it, since the key is already gone from `byKey`.
3. `Release` returns early instead of driving `refCount` below zero.

## Why?

`cache_pinned_usage` was reported at `-4.7e7` on v1.29.1 with `history.cacheSizeBasedLimit` enabled (#9954).

`pinnedSize` is a sum over the pinned entries, so it can only go negative if the sum stops matching its members. `Release` recomputes `entry.size` on **every** call, but touched `pinnedSize` only on the `0→1` and `1→0` ref count transitions. A release that left the entry pinned refreshed `entry.size` without adjusting the sum, and the release that finally unpinned the entry subtracted a size that had never been added:

```
PutIfNotExist  refCount 0→1   pinnedSize += 1   entry.size = 1
Get            refCount 1→2   -                 -
                              (value grows, CacheSize() = 5)
Release        refCount 2→1   -                 entry.size = 5   <- sum not updated
Release        refCount 1→0   pinnedSize -= 5                    -> -4
```

This is routine in the history cache: `PutIfNotExist` stores a fresh `workflow.NewContext` whose `CacheSize()` is just the key lengths while `MutableState == nil` (`service/history/workflow/context.go:1456`), mutable state is loaded afterwards, and concurrent `GetOrCreateWorkflowExecution` callers raise the ref count above 1 while blocking on `workflowCtx.Lock`.

The other two changes close the same invariant from the other side. `deleteInternal` leaked the pinned bytes upward and permanently inflated the gauge. A negative `refCount` stranded the entry for good, because eviction and TTL expiry both require `refCount == 0` (`lru.go:444`, `lru.go:456`); it is reachable by a release owed for an entry that was deleted and re-inserted under the same key, and by a plain extra `Release`.

Considered and rejected: snapshotting the pinned size on the entry at pin time. It balances the counter but freezes the reported size for the whole pin cycle, which conflicts with the expected behavior stated in the issue.

## How did you test it?
- [x] built
- [x] covered by existing tests
- [x] added new unit test(s)

Five new tests in `common/cache/lru_test.go`, each verified to fail before its corresponding change:

| Test | Before |
|---|---|
| `TestCache_PinnedUsageItemSizeChangeBetweenReleases` | `-4` |
| `TestCache_PinnedUsageDeleteWhilePinned` | `4` instead of `0` |
| `TestCache_StaleReleaseAfterReInsert` | `-6`, entry survived `2×TTL` |
| `TestCache_StaleReleaseKeepsEntryEvictable` | entry survived `2×TTL` |

```
go test -tags test_dep -race -count=2 ./common/cache/...            ok
go test -tags test_dep ./service/history/workflow/cache/...         ok
go test -tags test_dep ./service/matching/...                       ok
make lint-code                                                      0 issues
```

## Potential risks

Behavior is confined to `opts.Pin == true`. The only such cache in the tree is the history mutable state cache (`service/history/workflow/cache/cache.go:107`); `Pin: false` callers never enter `updateEntryRefCount` or `Release`'s pinned branches.

The early return in `Release` changes behavior for a release that owns no reference: previously it decremented into negative territory and recomputed `currSize`, now it does nothing. That path is already a corrupt state, and leaving `refCount` at `0` restores evictability. Metric emission rate is unchanged for entries whose size does not change; a pinned entry that grows emits one extra sample per release.

Not addressed here: `Release(key any)` identifies a reference by key only, so a release owed for a deleted entry still unpins whatever was re-inserted under that key, while its real holder is still using it. Fixing that needs per-entry identity in the `cache.Cache` interface and affects every consumer, so it is left as a `CONSIDER` note above `Release`. No production caller invokes `Delete` on the pin-mode cache today.

Closes #9954
