### PR TITLE
namespace replication: extract shared replicate-gate and detail->wire converter (no behavior change)

### DIFF
--- a/common/namespace/nsreplication/conversion_test.go
+++ b/common/namespace/nsreplication/conversion_test.go
@@ -1,0 +1,189 @@
+package nsreplication
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/api/enums/v1"
+	namespacepb "go.temporal.io/api/namespace/v1"
+	replicationpb "go.temporal.io/api/replication/v1"
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	replicationspb "go.temporal.io/server/api/replication/v1"
+	"go.temporal.io/server/common/testing/protorequire"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// TestShouldReplicateNamespace pins the replicate/skip gate that an eventual
+// CHASM-based transport will share with the legacy queue path. In particular it
+// locks in that a DELETED namespace is never replicated regardless of
+// globalness/cluster count, so both transports make the identical decision.
+func TestShouldReplicateNamespace(t *testing.T) {
+	testCases := []struct {
+		name               string
+		isGlobal           bool
+		clusters           []string
+		clusterListChanged bool
+		state              enumspb.NamespaceState
+		want               bool
+	}{
+		{
+			name:     "local namespace never replicates",
+			isGlobal: false,
+			clusters: []string{"a", "b"},
+			state:    enumspb.NAMESPACE_STATE_REGISTERED,
+			want:     false,
+		},
+		{
+			name:     "global single cluster, no list change",
+			isGlobal: true,
+			clusters: []string{"a"},
+			state:    enumspb.NAMESPACE_STATE_REGISTERED,
+			want:     false,
+		},
+		{
+			name:               "global single cluster, list changed",
+			isGlobal:           true,
+			clusters:           []string{"a"},
+			clusterListChanged: true,
+			state:              enumspb.NAMESPACE_STATE_REGISTERED,
+			want:               true,
+		},
+		{
+			name:     "global multi cluster, registered",
+			isGlobal: true,
+			clusters: []string{"a", "b"},
+			state:    enumspb.NAMESPACE_STATE_REGISTERED,
+			want:     true,
+		},
+		{
+			name:     "global multi cluster, deprecated",
+			isGlobal: true,
+			clusters: []string{"a", "b"},
+			state:    enumspb.NAMESPACE_STATE_DEPRECATED,
+			want:     true,
+		},
+		{
+			name:     "global multi cluster, DELETED is never replicated",
+			isGlobal: true,
+			clusters: []string{"a", "b"},
+			state:    enumspb.NAMESPACE_STATE_DELETED,
+			want:     false,
+		},
+		{
+			name:               "DELETED not replicated even when list changed",
+			isGlobal:           true,
+			clusters:           []string{"a", "b"},
+			clusterListChanged: true,
+			state:              enumspb.NAMESPACE_STATE_DELETED,
+			want:               false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ShouldReplicateNamespace(tc.isGlobal, tc.clusters, tc.clusterListChanged, tc.state)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestNamespaceDetailToTaskAttributes pins the detail->wire converter that an
+// eventual CHASM-based transport will also build its requests through. Pinning
+// the full field set here guards against the "field replicated by one transport
+// but dropped by the other" failure mode: any replicated field added to
+// NamespaceTaskAttributes must be threaded through this function or this test
+// fails. Today only HandleTransmissionTask calls it.
+func TestNamespaceDetailToTaskAttributes(t *testing.T) {
+	failoverTime := timestamppb.New(time.Unix(12345, 0).UTC())
+	detail := &persistencespb.NamespaceDetail{
+		Info: &persistencespb.NamespaceInfo{
+			Id:          "ns-id",
+			Name:        "ns-name",
+			State:       enumspb.NAMESPACE_STATE_REGISTERED,
+			Description: "desc",
+			Owner:       "owner@example.com",
+			Data:        map[string]string{"k": "v"},
+		},
+		Config: &persistencespb.NamespaceConfig{
+			Retention:               durationpb.New(24 * time.Hour),
+			HistoryArchivalState:    enumspb.ARCHIVAL_STATE_ENABLED,
+			HistoryArchivalUri:      "s3://history",
+			VisibilityArchivalState: enumspb.ARCHIVAL_STATE_ENABLED,
+			VisibilityArchivalUri:   "s3://visibility",
+			BadBinaries: &namespacepb.BadBinaries{
+				Binaries: map[string]*namespacepb.BadBinaryInfo{"bad": {Reason: "nope"}},
+			},
+			CustomSearchAttributeAliases: map[string]string{"Bool01": "alias"},
+		},
+		ReplicationConfig: &persistencespb.NamespaceReplicationConfig{
+			ActiveClusterName: "active",
+			State:             enumspb.REPLICATION_STATE_NORMAL,
+			Clusters:          []string{"active", "standby"},
+			FailoverHistory: []*persistencespb.FailoverStatus{
+				{FailoverTime: failoverTime, FailoverVersion: 7},
+			},
+		},
+		ConfigVersion:   3,
+		FailoverVersion: 11,
+	}
+
+	want := &replicationspb.NamespaceTaskAttributes{
+		NamespaceOperation: enumsspb.NAMESPACE_OPERATION_UPDATE,
+		Id:                 "ns-id",
+		Info: &namespacepb.NamespaceInfo{
+			Name:        "ns-name",
+			State:       enumspb.NAMESPACE_STATE_REGISTERED,
+			Description: "desc",
+			OwnerEmail:  "owner@example.com",
+			Data:        map[string]string{"k": "v"},
+		},
+		Config: &namespacepb.NamespaceConfig{
+			WorkflowExecutionRetentionTtl: durationpb.New(24 * time.Hour),
+			HistoryArchivalState:          enumspb.ARCHIVAL_STATE_ENABLED,
+			HistoryArchivalUri:            "s3://history",
+			VisibilityArchivalState:       enumspb.ARCHIVAL_STATE_ENABLED,
+			VisibilityArchivalUri:         "s3://visibility",
+			BadBinaries: &namespacepb.BadBinaries{
+				Binaries: map[string]*namespacepb.BadBinaryInfo{"bad": {Reason: "nope"}},
+			},
+			CustomSearchAttributeAliases: map[string]string{"Bool01": "alias"},
+		},
+		ReplicationConfig: &replicationpb.NamespaceReplicationConfig{
+			ActiveClusterName: "active",
+			State:             enumspb.REPLICATION_STATE_NORMAL,
+			Clusters: []*replicationpb.ClusterReplicationConfig{
+				{ClusterName: "active"},
+				{ClusterName: "standby"},
+			},
+		},
+		ConfigVersion:   3,
+		FailoverVersion: 11,
+		FailoverHistory: []*replicationpb.FailoverStatus{
+			{FailoverTime: failoverTime, FailoverVersion: 7},
+		},
+	}
+
+	got := NamespaceDetailToTaskAttributes(enumsspb.NAMESPACE_OPERATION_UPDATE, detail)
+	protorequire.ProtoEqual(t, want, got)
+}
+
+// TestNamespaceDetailToTaskAttributes_NonNormalStateDropped pins the special-case:
+// the replication State is only carried on the wire when it is NORMAL. A HANDOVER
+// (or any non-NORMAL) state must be dropped, matching the legacy queue behavior.
+func TestNamespaceDetailToTaskAttributes_NonNormalStateDropped(t *testing.T) {
+	detail := &persistencespb.NamespaceDetail{
+		Info:   &persistencespb.NamespaceInfo{Id: "ns-id", Name: "ns-name", State: enumspb.NAMESPACE_STATE_REGISTERED},
+		Config: &persistencespb.NamespaceConfig{},
+		ReplicationConfig: &persistencespb.NamespaceReplicationConfig{
+			ActiveClusterName: "active",
+			State:             enumspb.REPLICATION_STATE_HANDOVER,
+			Clusters:          []string{"active", "standby"},
+		},
+	}
+
+	got := NamespaceDetailToTaskAttributes(enumsspb.NAMESPACE_OPERATION_UPDATE, detail)
+	require.Equal(t, enumspb.REPLICATION_STATE_UNSPECIFIED, got.GetReplicationConfig().GetState())
+}

--- a/common/namespace/nsreplication/transmission_task_handler.go
+++ b/common/namespace/nsreplication/transmission_task_handler.go
@@ -65,60 +65,130 @@ func (r *replicator) HandleTransmissionTask(
 	forceReplicate bool,
 ) error {
 
-	if !forceReplicate {
-		if !isGlobalNamespace {
-			return nil
-		}
-		if len(replicationConfig.Clusters) <= 1 && !replicationClusterListUpdated {
-			return nil
-		}
-	}
 	if info.State == enumspb.NAMESPACE_STATE_DELETED {
-		// Don't replicate deleted namespace changes.
+		// Deleted namespaces are never replicated through this path (even under
+		// forceReplicate); namespace deletion is coordinated separately.
+		return nil
+	}
+	if !forceReplicate && !ShouldReplicateNamespace(
+		isGlobalNamespace,
+		replicationConfig.GetClusters(),
+		replicationClusterListUpdated,
+		info.State,
+	) {
 		return nil
 	}
 
-	taskType := enumsspb.REPLICATION_TASK_TYPE_NAMESPACE_TASK
-	task := &replicationspb.ReplicationTask_NamespaceTaskAttributes{
-		NamespaceTaskAttributes: &replicationspb.NamespaceTaskAttributes{
-			NamespaceOperation: namespaceOperation,
-			Id:                 info.Id,
-			Info: &namespacepb.NamespaceInfo{
-				Name:        info.Name,
-				State:       info.State,
-				Description: info.Description,
-				OwnerEmail:  info.Owner,
-				Data:        info.Data,
-			},
-			Config: &namespacepb.NamespaceConfig{
-				WorkflowExecutionRetentionTtl: config.Retention,
-				HistoryArchivalState:          config.HistoryArchivalState,
-				HistoryArchivalUri:            config.HistoryArchivalUri,
-				VisibilityArchivalState:       config.VisibilityArchivalState,
-				VisibilityArchivalUri:         config.VisibilityArchivalUri,
-				BadBinaries:                   config.BadBinaries,
-				CustomSearchAttributeAliases:  config.CustomSearchAttributeAliases,
-			},
-			ReplicationConfig: &replicationpb.NamespaceReplicationConfig{
-				ActiveClusterName: replicationConfig.ActiveClusterName,
-				Clusters:          convertClusterReplicationConfigToProto(replicationConfig.Clusters),
-			},
-			ConfigVersion:   configVersion,
-			FailoverVersion: failoverVersion,
-			FailoverHistory: convertFailoverHistoryToReplicationProto(failoverHistoy),
+	// Build the wire payload through the shared converter. Extracting this build
+	// step is groundwork for an eventual CHASM-based namespace replication
+	// transport: when that path is added it will build its requests through this
+	// same converter, so the detail->wire conversion can never diverge between the
+	// two transports. Today only this legacy queue path calls it. FailoverHistory
+	// is threaded in explicitly because callers pass it separately from
+	// replicationConfig.
+	detail := &persistencespb.NamespaceDetail{
+		Info:   info,
+		Config: config,
+		ReplicationConfig: &persistencespb.NamespaceReplicationConfig{
+			ActiveClusterName: replicationConfig.GetActiveClusterName(),
+			State:             replicationConfig.GetState(),
+			Clusters:          replicationConfig.GetClusters(),
+			FailoverHistory:   failoverHistoy,
 		},
-	}
-
-	if replicationConfig.State == enumspb.REPLICATION_STATE_NORMAL {
-		task.NamespaceTaskAttributes.ReplicationConfig.State = replicationConfig.State
+		ConfigVersion:   configVersion,
+		FailoverVersion: failoverVersion,
 	}
 
 	return r.namespaceReplicationQueue.Publish(
 		ctx,
 		&replicationspb.ReplicationTask{
-			TaskType:   taskType,
-			Attributes: task,
+			TaskType: enumsspb.REPLICATION_TASK_TYPE_NAMESPACE_TASK,
+			Attributes: &replicationspb.ReplicationTask_NamespaceTaskAttributes{
+				NamespaceTaskAttributes: NamespaceDetailToTaskAttributes(namespaceOperation, detail),
+			},
 		})
+}
+
+// ShouldReplicateNamespace reports whether a namespace mutation must be
+// propagated to peer clusters at all. It is extracted from HandleTransmissionTask
+// as a standalone gate in preparation for an eventual CHASM-based namespace
+// replication transport: that path will share this exact replicate/skip decision
+// so the two transports can never diverge on which mutations replicate. Today
+// only the legacy queue path (HandleTransmissionTask) calls it.
+//
+// A mutation replicates only when the namespace is global, has a peer to
+// replicate to (more than one cluster, or the cluster list just changed), and
+// is not being deleted (namespace deletion is coordinated through a separate
+// path and must never be pushed to peers).
+func ShouldReplicateNamespace(
+	isGlobalNamespace bool,
+	clusters []string,
+	replicationClusterListUpdated bool,
+	state enumspb.NamespaceState,
+) bool {
+	if state == enumspb.NAMESPACE_STATE_DELETED {
+		return false
+	}
+	if !isGlobalNamespace {
+		return false
+	}
+	if len(clusters) <= 1 && !replicationClusterListUpdated {
+		return false
+	}
+	return true
+}
+
+// NamespaceDetailToTaskAttributes converts a namespace detail into the
+// NamespaceTaskAttributes wire shape consumed by the receiver-side
+// apply-if-higher logic (TaskExecutor).
+//
+// It is extracted here as the single source of truth for that conversion in
+// preparation for an eventual CHASM-based namespace replication transport: when
+// that path is added it will build its outbound requests through this same
+// function, so a replicated field can never be emitted by one transport and
+// silently dropped by the other. Today only the legacy queue path
+// (HandleTransmissionTask) calls it; the extraction itself is a pure
+// no-behavior-change refactor.
+func NamespaceDetailToTaskAttributes(
+	namespaceOperation enumsspb.NamespaceOperation,
+	detail *persistencespb.NamespaceDetail,
+) *replicationspb.NamespaceTaskAttributes {
+	info := detail.GetInfo()
+	config := detail.GetConfig()
+	replicationConfig := detail.GetReplicationConfig()
+
+	attributes := &replicationspb.NamespaceTaskAttributes{
+		NamespaceOperation: namespaceOperation,
+		Id:                 info.GetId(),
+		Info: &namespacepb.NamespaceInfo{
+			Name:        info.GetName(),
+			State:       info.GetState(),
+			Description: info.GetDescription(),
+			OwnerEmail:  info.GetOwner(),
+			Data:        info.GetData(),
+		},
+		Config: &namespacepb.NamespaceConfig{
+			WorkflowExecutionRetentionTtl: config.GetRetention(),
+			HistoryArchivalState:          config.GetHistoryArchivalState(),
+			HistoryArchivalUri:            config.GetHistoryArchivalUri(),
+			VisibilityArchivalState:       config.GetVisibilityArchivalState(),
+			VisibilityArchivalUri:         config.GetVisibilityArchivalUri(),
+			BadBinaries:                   config.GetBadBinaries(),
+			CustomSearchAttributeAliases:  config.GetCustomSearchAttributeAliases(),
+		},
+		ReplicationConfig: &replicationpb.NamespaceReplicationConfig{
+			ActiveClusterName: replicationConfig.GetActiveClusterName(),
+			Clusters:          convertClusterReplicationConfigToProto(replicationConfig.GetClusters()),
+		},
+		ConfigVersion:   detail.GetConfigVersion(),
+		FailoverVersion: detail.GetFailoverVersion(),
+		FailoverHistory: convertFailoverHistoryToReplicationProto(replicationConfig.GetFailoverHistory()),
+	}
+
+	if replicationConfig.GetState() == enumspb.REPLICATION_STATE_NORMAL {
+		attributes.ReplicationConfig.State = replicationConfig.GetState()
+	}
+	return attributes
 }
 
 func convertClusterReplicationConfigToProto(

--- a/common/namespace/nsreplication/transmission_task_handler_test.go
+++ b/common/namespace/nsreplication/transmission_task_handler_test.go
@@ -632,3 +632,105 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_R
 	)
 	s.Require().NoError(err)
 }
+
+// The three cases below pin the force/gate/deleted interaction that the shared
+// ShouldReplicateNamespace refactor reordered (the DELETED check moved ahead of
+// the force/global/cluster gate). Every other test in this suite passes
+// forceReplicate=false and a non-deleted state, so these are the only ones that
+// exercise the reordered branch.
+
+// TestHandleTransmissionTask_ForceReplicate_BypassesGate: forceReplicate must
+// publish even for a non-global, single-cluster namespace that the replicate
+// gate would otherwise skip.
+func (s *transmissionTaskSuite) TestHandleTransmissionTask_ForceReplicate_BypassesGate() {
+	info := &persistencespb.NamespaceInfo{
+		Id:    primitives.NewUUID().String(),
+		Name:  "force-ns",
+		State: enumspb.NAMESPACE_STATE_REGISTERED,
+	}
+	config := &persistencespb.NamespaceConfig{Retention: durationpb.New(24 * time.Hour)}
+	replicationConfig := &persistencespb.NamespaceReplicationConfig{
+		ActiveClusterName: "cluster-a",
+		Clusters:          []string{"cluster-a"}, // non-global + single cluster: gate would skip
+	}
+
+	// Payload correctness is pinned by the other tests via the shared converter;
+	// here we only assert that forceReplicate overrides the gate and publishes.
+	s.namespaceReplicationQueue.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+	err := s.namespaceReplicator.HandleTransmissionTask(
+		context.Background(),
+		enumsspb.NAMESPACE_OPERATION_UPDATE,
+		info,
+		config,
+		replicationConfig,
+		false, // replicationClusterListUpdated
+		int64(0),
+		int64(1),
+		false, // isGlobalNamespace
+		nil,
+		true, // forceReplicate
+	)
+	s.Require().NoError(err)
+}
+
+// TestHandleTransmissionTask_ForceReplicate_DeletedNotReplicated: a DELETED
+// namespace must never be replicated, even under forceReplicate. No Publish
+// expectation is set, so controller.Finish() fails if Publish is called.
+func (s *transmissionTaskSuite) TestHandleTransmissionTask_ForceReplicate_DeletedNotReplicated() {
+	info := &persistencespb.NamespaceInfo{
+		Id:    primitives.NewUUID().String(),
+		Name:  "deleted-ns",
+		State: enumspb.NAMESPACE_STATE_DELETED,
+	}
+	config := &persistencespb.NamespaceConfig{Retention: durationpb.New(24 * time.Hour)}
+	replicationConfig := &persistencespb.NamespaceReplicationConfig{
+		ActiveClusterName: "cluster-a",
+		Clusters:          []string{"cluster-a", "cluster-b"},
+	}
+
+	err := s.namespaceReplicator.HandleTransmissionTask(
+		context.Background(),
+		enumsspb.NAMESPACE_OPERATION_UPDATE,
+		info,
+		config,
+		replicationConfig,
+		false, // replicationClusterListUpdated
+		int64(0),
+		int64(1),
+		true, // isGlobalNamespace
+		nil,
+		true, // forceReplicate
+	)
+	s.Require().NoError(err)
+}
+
+// TestHandleTransmissionTask_DeletedNotReplicated: a DELETED global multi-cluster
+// namespace is not replicated on the normal (non-force) path either.
+func (s *transmissionTaskSuite) TestHandleTransmissionTask_DeletedNotReplicated() {
+	info := &persistencespb.NamespaceInfo{
+		Id:    primitives.NewUUID().String(),
+		Name:  "deleted-ns",
+		State: enumspb.NAMESPACE_STATE_DELETED,
+	}
+	config := &persistencespb.NamespaceConfig{Retention: durationpb.New(24 * time.Hour)}
+	replicationConfig := &persistencespb.NamespaceReplicationConfig{
+		ActiveClusterName: "cluster-a",
+		Clusters:          []string{"cluster-a", "cluster-b"},
+	}
+
+	err := s.namespaceReplicator.HandleTransmissionTask(
+		context.Background(),
+		enumsspb.NAMESPACE_OPERATION_UPDATE,
+		info,
+		config,
+		replicationConfig,
+		false, // replicationClusterListUpdated
+		int64(0),
+		int64(1),
+		true, // isGlobalNamespace
+		nil,
+		false, // forceReplicate
+	)
+	s.Require().NoError(err)
+}


### PR DESCRIPTION
## What
Extracts two pure functions out of `HandleTransmissionTask` in `common/namespace/nsreplication`:
- **`ShouldReplicateNamespace`** — the replicate/skip gate (global + has-a-peer + not-deleted).
- **`NamespaceDetailToTaskAttributes`** — the `NamespaceDetail` → `NamespaceTaskAttributes` wire conversion consumed by the receiver-side apply-if-higher logic (`TaskExecutor`).

`HandleTransmissionTask` is rewritten to call them. No new caller is added.

## Why
Groundwork for an eventual CHASM-based namespace replication transport. That path will share the **same gate** and the **same detail→wire converter**, so the two transports can never diverge on *which* mutations replicate or on the *payload shape* they emit. Landing it standalone lets this be reviewed purely as "queue path unchanged." Today only the legacy queue path uses the extracted functions.

## No behavior change
The only logic movement is the `DELETED` short-circuit now running ahead of the gate — outcome-equivalent: `DELETED` always returned `nil` (skip) before and after, and non-global / single-cluster still skip only when `!forceReplicate`.

**Proof:** the pre-existing `transmission_task_handler_test.go` — which pins the exact `Publish(&ReplicationTask{...})` payload via gomock — is **unchanged** and still green. Any dropped or renamed field would fail it.

## Tests added
- `conversion_test.go` — direct unit tests for both extracted functions, incl. the NORMAL-only replication-`State` special case.
- 3 gate cases in `transmission_task_handler_test.go` (`ForceReplicate_BypassesGate`, `ForceReplicate_DeletedNotReplicated`, `DeletedNotReplicated`) covering the reordered force/deleted/gate branch.

## Verification
- `go build ./...` clean
- `go test ./common/namespace/nsreplication/...` green
- `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)