### PR TITLE
Enable standalone activities for mixed brain dev server

### DIFF
--- a/tests/mixedbrain/mixed_brain_test.go
+++ b/tests/mixedbrain/mixed_brain_test.go
@@ -159,7 +159,7 @@ func TestMixedBrain(t *testing.T) {
 			ClusterEndpoint: devserver.ClusterEndpoint{
 				RPCAddress: currentSrv.FrontendHostPort(),
 			},
-			// TODO: remove this once the release server defaults to standalone activities on. Currently the downgrade version of 1.3x has SAA defaulted to off.
+			// TODO: remove this once the release server defaults to standalone activities on. Currently the downgrade version of 1.31 has SAA defaulted to off.
 			DynamicConfigValues: map[string]any{
 				"activity.enableStandalone": true,
 			},

--- a/tests/mixedbrain/mixed_brain_test.go
+++ b/tests/mixedbrain/mixed_brain_test.go
@@ -159,6 +159,10 @@ func TestMixedBrain(t *testing.T) {
 			ClusterEndpoint: devserver.ClusterEndpoint{
 				RPCAddress: currentSrv.FrontendHostPort(),
 			},
+			// TODO: remove this once the release server defaults to standalone activities on. Currently the downgrade version of 1.3x has SAA defaulted to off.
+			DynamicConfigValues: map[string]any{
+				"activity.enableStandalone": true,
+			},
 		})
 	})
 	if t.Failed() {


### PR DESCRIPTION
## What changed?
Enable the `activity.enableStandalone` dynamic config on the release server in the mixed-brain test. 

## Why?
omes `throughput_stress` auto-enables standalone-activity load when the namespace reports support. The current server (1.32) defaults it on, so omes sends SAA calls; the previous release (v1.31.2) defaults it off, so calls routed to the release frontend were rejected (`Unimplemented: "Standalone  activity is disabled"`), stalling workflows until the run timed out. Enabling the DC on the release server matches a real rolling-upgrade cluster and lets the test exercise SAA across both versions instead of failing on every branch. 

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

