### PR TITLE
Schedule v2 replay fidelity

### DIFF
--- a/chasm/chasmtest/task_helpers.go
+++ b/chasm/chasmtest/task_helpers.go
@@ -6,7 +6,33 @@ import (
 	"time"
 
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/service/history/tasks"
 )
+
+// NextTaskTime returns the earliest non-visibility CHASM physical task after
+// the supplied time. Physical tasks can be stale; callers should execute task
+// validation when the returned time is reached.
+func (e *Engine) NextTaskTime(ref chasm.ComponentRef, after time.Time) (time.Time, bool, error) {
+	exec, err := e.executionForRef(ref)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+
+	var next time.Time
+	for category, categoryTasks := range exec.backend.TasksByCategory {
+		if category == tasks.CategoryVisibility {
+			continue
+		}
+		for _, task := range categoryTasks {
+			visibilityTime := task.GetVisibilityTime()
+			if !visibilityTime.After(after) || (!next.IsZero() && !visibilityTime.Before(next)) {
+				continue
+			}
+			next = visibilityTime
+		}
+	}
+	return next, !next.IsZero(), nil
+}
 
 // ExecutePureTask validates and executes a pure task atomically via [Engine.UpdateComponent].
 // It returns taskDropped set to true if [chasm.PureTaskHandler.Validate] returns (false, nil),
@@ -78,6 +104,44 @@ func (e *Engine) FirePureTasks(ref chasm.ComponentRef, referenceTime time.Time) 
 
 	if err := exec.closeTransaction(); err != nil {
 		return executed, err
+	}
+	return executed, nil
+}
+
+// FireSideEffectTasks executes side-effect tasks due by referenceTime. Stale physical
+// tasks are ignored after their logical task has been removed from the tree.
+func (e *Engine) FireSideEffectTasks(ref chasm.ComponentRef, referenceTime time.Time) (executed int, err error) {
+	exec, err := e.executionForRef(ref)
+	if err != nil {
+		return 0, err
+	}
+	engineCtx := chasm.NewEngineContext(context.Background(), e)
+	for category, categoryTasks := range exec.backend.TasksByCategory {
+		if category == tasks.CategoryVisibility {
+			continue
+		}
+		for _, task := range categoryTasks {
+			chasmTask, ok := task.(*tasks.ChasmTask)
+			if !ok || chasmTask.GetVisibilityTime().After(referenceTime) {
+				continue
+			}
+			inTree, valid, err := exec.node.ValidateSideEffectTask(engineCtx, chasmTask)
+			if err != nil {
+				return executed, err
+			}
+			if !inTree || !valid {
+				continue
+			}
+			if err := exec.node.ExecuteSideEffectTask(
+				engineCtx,
+				exec.key,
+				chasmTask,
+				func(chasm.NodeBackend, chasm.Context, chasm.Component) error { return nil },
+			); err != nil {
+				return executed, err
+			}
+			executed++
+		}
 	}
 	return executed, nil
 }

--- a/chasm/chasmtest/test_engine_test.go
+++ b/chasm/chasmtest/test_engine_test.go
@@ -118,6 +118,21 @@ func TestStartExecutionDeduplicatesUpdateRequestID(t *testing.T) {
 	require.Equal(t, 0, startCount)
 }
 
+func TestNextTaskTime(t *testing.T) {
+	const ttl = time.Hour
+	e, ref := startStore(t, ttl)
+	start := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	next, ok, err := e.NextTaskTime(ref, start)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, start.Add(ttl), next)
+
+	_, ok, err = e.NextTaskTime(ref, next)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
 func startStore(
 	t *testing.T,
 	ttl time.Duration,

--- a/chasm/lib/scheduler/history_replay_test.go
+++ b/chasm/lib/scheduler/history_replay_test.go
@@ -1,0 +1,3958 @@
+package scheduler_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
+	historypb "go.temporal.io/api/history/v1"
+	schedulepb "go.temporal.io/api/schedule/v1"
+	"go.temporal.io/api/serviceerror"
+	workflowpb "go.temporal.io/api/workflow/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/interceptor"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/api/historyservice/v1"
+	"go.temporal.io/server/api/historyservicemock/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	schedulespb "go.temporal.io/server/api/schedule/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/chasmtest"
+	"go.temporal.io/server/chasm/lib/scheduler"
+	"go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
+	"go.temporal.io/server/chasm/lib/scheduler/migration"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/searchattribute/sadefs"
+	"go.temporal.io/server/common/testing/mockapi/workflowservicemock/v1"
+	"go.temporal.io/server/common/testing/protorequire"
+	"go.temporal.io/server/common/testing/testlogger"
+	legacyscheduler "go.temporal.io/server/service/worker/scheduler"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	downloadedHistoryDirectoryEnv = "SCHEDULE_V1_HISTORY_DIR"
+	replayReportPathEnv           = "SCHEDULE_V2_REPLAY_REPORT"
+	replayFailOnEnv               = "SCHEDULE_V2_REPLAY_FAIL_ON"
+	replayReportRedactEnv         = "SCHEDULE_V2_REPLAY_REDACT"
+	replayMaxDeadlinesEnv         = "SCHEDULE_V2_REPLAY_MAX_DEADLINES"
+	replayMaxTasksEnv             = "SCHEDULE_V2_REPLAY_MAX_TASKS"
+	replayMaxStartsEnv            = "SCHEDULE_V2_REPLAY_MAX_STARTS"
+	replayCheckpointEveryEnv      = "SCHEDULE_V2_REPLAY_CHECKPOINT_EVERY"
+	replayReportVersion           = 10
+	defaultReplayMaxDeadlines     = 10_000
+	defaultReplayMaxTasks         = 100_000
+	defaultReplayMaxStarts        = 10_000
+)
+
+type replayClassification string
+
+const (
+	replayClassificationMatch        replayClassification = "match"
+	replayClassificationTimingOnly   replayClassification = "timing_only"
+	replayClassificationKnownCompat  replayClassification = "known_compatibility"
+	replayClassificationSignificant  replayClassification = "significant"
+	replayClassificationUnsupported  replayClassification = "unsupported"
+	replayClassificationInconclusive replayClassification = "inconclusive"
+)
+
+type replayDivergence struct {
+	Classification   replayClassification    `json:"classification"`
+	Kind             string                  `json:"kind"`
+	Message          string                  `json:"message"`
+	WorkflowID       string                  `json:"workflowId,omitempty"`
+	V1Time           *time.Time              `json:"v1Time,omitempty"`
+	CHASMTime        *time.Time              `json:"chasmTime,omitempty"`
+	Fields           []string                `json:"fields,omitempty"`
+	FieldDifferences []replayFieldDifference `json:"fieldDifferences,omitempty"`
+	KnownDifference  string                  `json:"knownDifference,omitempty"`
+}
+
+type replayFieldDifference struct {
+	Field       string             `json:"field"`
+	V1          replayValueSummary `json:"v1"`
+	CHASM       replayValueSummary `json:"chasm"`
+	SafeDetails []string           `json:"safeDetails,omitempty"`
+}
+
+type replayValueSummary struct {
+	Present   bool     `json:"present"`
+	Count     int      `json:"count,omitempty"`
+	Encodings []string `json:"encodings,omitempty"`
+	Digest    string   `json:"digest,omitempty"`
+}
+
+type replayCaseResult struct {
+	History               string                  `json:"history,omitempty"`
+	Namespace             string                  `json:"namespace"`
+	ScheduleID            string                  `json:"scheduleId"`
+	Classification        replayClassification    `json:"classification"`
+	Cohorts               []string                `json:"cohorts,omitempty"`
+	V1Starts              []string                `json:"v1Starts"`
+	CHASMStarts           []string                `json:"chasmStarts"`
+	FirstActionDifference *replayActionDifference `json:"firstActionDifference,omitempty"`
+	ReplayInputs          replayInputSummary      `json:"replayInputs"`
+	V1ActionCount         int64                   `json:"v1ActionCount"`
+	CHASMActionCount      int64                   `json:"chasmActionCount"`
+	CHASMState            replayStateSnapshot     `json:"chasmState"`
+	ReplayStats           replayStats             `json:"replayStats"`
+	Divergences           []replayDivergence      `json:"divergences,omitempty"`
+}
+
+type replayInputSummary struct {
+	HistoryStartTime        time.Time                    `json:"historyStartTime"`
+	FirstDecisionTime       time.Time                    `json:"firstDecisionTime"`
+	LastProcessedTime       *time.Time                   `json:"lastProcessedTime,omitempty"`
+	CreateTime              *time.Time                   `json:"createTime,omitempty"`
+	UpdateTime              *time.Time                   `json:"updateTime,omitempty"`
+	OverlapPolicy           string                       `json:"overlapPolicy,omitempty"`
+	CatchupWindow           string                       `json:"catchupWindow,omitempty"`
+	BufferedStarts          int                          `json:"bufferedStarts"`
+	RunningWorkflows        int                          `json:"runningWorkflows"`
+	OngoingBackfills        int                          `json:"ongoingBackfills"`
+	TriggerImmediately      bool                         `json:"triggerImmediately"`
+	InitialPatchBackfills   int                          `json:"initialPatchBackfills"`
+	InitialBufferedStarts   []replayBufferedStartSummary `json:"initialBufferedStarts,omitempty"`
+	Paused                  bool                         `json:"paused"`
+	LimitedActions          bool                         `json:"limitedActions"`
+	RemainingActions        int64                        `json:"remainingActions"`
+	CalendarSpecs           int                          `json:"calendarSpecs"`
+	StructuredCalendarSpecs int                          `json:"structuredCalendarSpecs"`
+	IntervalSpecs           int                          `json:"intervalSpecs"`
+	CronExpressions         int                          `json:"cronExpressions"`
+	TimeZoneName            string                       `json:"timeZoneName,omitempty"`
+	Jitter                  string                       `json:"jitter,omitempty"`
+	PersistedNextTimeCache  bool                         `json:"persistedNextTimeCache"`
+	CompanionCompletions    int                          `json:"companionCompletions"`
+}
+
+type replayBufferedStartSummary struct {
+	NominalTime   *time.Time `json:"nominalTime,omitempty"`
+	ActualTime    *time.Time `json:"actualTime,omitempty"`
+	DesiredTime   *time.Time `json:"desiredTime,omitempty"`
+	OverlapPolicy string     `json:"overlapPolicy,omitempty"`
+	Manual        bool       `json:"manual"`
+	HasWorkflowID bool       `json:"hasWorkflowId"`
+	HasRunID      bool       `json:"hasRunId"`
+}
+
+type replayActionDifference struct {
+	Index           int        `json:"index"`
+	V1WorkflowID    string     `json:"v1WorkflowId,omitempty"`
+	CHASMWorkflowID string     `json:"chasmWorkflowId,omitempty"`
+	V1Time          *time.Time `json:"v1Time,omitempty"`
+	CHASMTime       *time.Time `json:"chasmTime,omitempty"`
+}
+
+type replayStats struct {
+	Deadlines       int    `json:"deadlines"`
+	PureTasks       int    `json:"pureTasks"`
+	SideEffectTasks int    `json:"sideEffectTasks"`
+	Starts          int    `json:"starts"`
+	Cancels         int    `json:"cancels"`
+	Terminates      int    `json:"terminates"`
+	BudgetExceeded  string `json:"budgetExceeded,omitempty"`
+}
+
+type replayBudget struct {
+	maxDeadlines int
+	maxTasks     int
+	maxStarts    int
+	stats        replayStats
+	exceeded     *replayBudgetExceededError
+}
+
+type replayBudgetExceededError struct {
+	dimension string
+	limit     int
+}
+
+func (e *replayBudgetExceededError) Error() string {
+	return fmt.Sprintf("replay %s budget exceeded limit %d", e.dimension, e.limit)
+}
+
+type replayStateSnapshot struct {
+	LastProcessedTime *time.Time `json:"lastProcessedTime,omitempty"`
+	Paused            bool       `json:"paused"`
+	MissedCatchup     int64      `json:"missedCatchupWindow"`
+	OverlapSkipped    int64      `json:"overlapSkipped"`
+	BufferDropped     int64      `json:"bufferDropped"`
+	BufferedStarts    []string   `json:"bufferedStarts,omitempty"`
+}
+
+type replayReport struct {
+	Version       int                       `json:"version"`
+	Redacted      bool                      `json:"redacted"`
+	Summary       map[string]int            `json:"summary"`
+	CohortSummary map[string]map[string]int `json:"cohortSummary,omitempty"`
+	Collections   []replayCollectionSummary `json:"collections,omitempty"`
+	Cases         []replayCaseResult        `json:"cases"`
+}
+
+type replayCheckpoint struct {
+	Version   int                `json:"version"`
+	Directory string             `json:"directory"`
+	Cases     []replayCaseResult `json:"cases"`
+}
+
+type replayCollectionSummary struct {
+	Manifest          string         `json:"manifest"`
+	Namespace         string         `json:"namespace"`
+	Seed              string         `json:"seed"`
+	ServerVersion     string         `json:"serverVersion,omitempty"`
+	CollectorVersion  string         `json:"collectorVersion,omitempty"`
+	ListedPopulation  int            `json:"listedPopulation"`
+	Inspected         int            `json:"inspected"`
+	V1Inspected       int            `json:"v1Inspected"`
+	BaseSelected      int            `json:"baseSelected"`
+	SelectedSchedules int            `json:"selectedSchedules"`
+	CollectionStatus  map[string]int `json:"collectionStatus"`
+}
+
+type replayCollectionManifest struct {
+	Namespace        string `json:"namespace"`
+	Seed             string `json:"seed"`
+	ServerVersion    string `json:"serverVersion"`
+	CollectorVersion string `json:"collectorVersion"`
+	ListedPopulation int    `json:"listedPopulation"`
+	Inspected        int    `json:"inspected"`
+	V1Inspected      int    `json:"v1Inspected"`
+	BaseSelected     int    `json:"baseSelected"`
+	Cases            []struct {
+		ScheduleID string `json:"scheduleId"`
+		Status     string `json:"status"`
+	} `json:"cases"`
+}
+
+type observedStart struct {
+	workflowID string
+	runID      string
+	time       time.Time
+	request    *workflowservice.StartWorkflowExecutionRequest
+}
+
+type observedStartFailure struct {
+	workflowID string
+	time       time.Time
+	request    *workflowservice.StartWorkflowExecutionRequest
+}
+
+type observedStartAttempt struct {
+	workflowID                   string
+	runID                        string
+	time                         time.Time
+	request                      *workflowservice.StartWorkflowExecutionRequest
+	workflowTaskCompletedEventID int64
+	failureType                  string
+	failed                       bool
+}
+
+type chasmStart struct {
+	workflowID string
+	time       time.Time
+}
+
+type workflowExecutionKey struct {
+	workflowID string
+	runID      string
+}
+
+type workflowExecutionMap map[workflowExecutionKey]workflowExecutionKey
+
+type workflowExecutionNotStartedError struct {
+	execution workflowExecutionKey
+}
+
+func (e *workflowExecutionNotStartedError) Error() string {
+	return fmt.Sprintf(
+		"V1 workflow %q run %q completed before CHASM emitted its corresponding start; this is a scheduling/timing divergence",
+		e.execution.workflowID,
+		e.execution.runID,
+	)
+}
+
+type ambiguousWorkflowExecutionError struct {
+	workflowID string
+}
+
+func (e *ambiguousWorkflowExecutionError) Error() string {
+	return fmt.Sprintf("V1 workflow %q completion does not identify a run and matches multiple CHASM executions", e.workflowID)
+}
+
+type scheduledWatch struct {
+	request *schedulespb.WatchWorkflowRequest
+}
+
+type observedWatchCompletion struct {
+	request                      *schedulespb.WatchWorkflowRequest
+	response                     *schedulespb.WatchWorkflowResponse
+	eventID                      int64
+	workflowTaskCompletedEventID int64
+	observedTime                 time.Time
+	bypassExecutionMap           bool
+}
+
+type inferredCompletionInput struct {
+	time time.Time
+}
+
+type localActivityMarkerMetadata struct {
+	ActivityID   string
+	ActivityType string
+	Attempt      int32
+}
+
+type v1HistoryTrace struct {
+	args          *schedulespb.StartScheduleArgs
+	history       *historypb.History
+	starts        []observedStart
+	failedStarts  []observedStartFailure
+	startAttempts []observedStartAttempt
+	watches       map[int64]scheduledWatch
+	startsByEvent map[int64]*schedulespb.StartWorkflowRequest
+	localWatches  map[int64]observedWatchCompletion
+	startTime     time.Time
+	expectedSpec  *schedulepb.Schedule
+	searchAttrs   *commonpb.SearchAttributes
+	memo          *commonpb.Memo
+	baseActions   int64
+	capturedIDs   bool
+	captureIssues int
+	startRetries  int
+	tweakables    []observedTweakables
+}
+
+type observedTweakables struct {
+	time     time.Time
+	policies legacyscheduler.TweakablePolicies
+}
+
+func groupObservedStartAttempts(attempts []observedStartAttempt) map[string][]observedStartAttempt {
+	grouped := make(map[string][]observedStartAttempt)
+	for _, attempt := range attempts {
+		if attempt.workflowID != "" {
+			grouped[attempt.workflowID] = append(grouped[attempt.workflowID], attempt)
+		}
+	}
+	return grouped
+}
+
+func TestDownloadedV1HistoriesAgainstCHASM(t *testing.T) {
+	directory := os.Getenv(downloadedHistoryDirectoryEnv)
+	if directory == "" {
+		t.Skipf("%s is not set", downloadedHistoryDirectoryEnv)
+	}
+	paths, err := filepath.Glob(filepath.Join(directory, "*.json.gz"))
+	require.NoError(t, err)
+	nestedPaths, err := filepath.Glob(filepath.Join(directory, "*", "*.json.gz"))
+	require.NoError(t, err)
+	paths = append(paths, nestedPaths...)
+	sort.Strings(paths)
+	require.NotEmpty(t, paths)
+	companionCompletions, err := readCompanionActionCompletions(directory)
+	require.NoError(t, err)
+	reportPath := os.Getenv(replayReportPathEnv)
+	checkpointPath := ""
+	results := make([]replayCaseResult, 0, len(paths))
+	if reportPath != "" {
+		checkpointPath = reportPath + ".checkpoint"
+		checkpoint, err := readReplayCheckpoint(checkpointPath, directory)
+		require.NoError(t, err)
+		results = append(results, checkpoint...)
+	}
+	completed := make(map[string]struct{}, len(results))
+	for _, result := range results {
+		completed[result.History] = struct{}{}
+	}
+	checkpointEvery := replayLimitFromEnvironment(t, replayCheckpointEveryEnv, 250)
+	for _, path := range paths {
+		path := path
+		if _, ok := completed[path]; ok {
+			continue
+		}
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			history := readReplayHistory(t, path)
+			result := replayV1HistoryAgainstCHASMWithCompletions(t, history, companionCompletions[path])
+			result.History = path
+			results = append(results, result)
+			if replayResultFails(result, os.Getenv(replayFailOnEnv)) {
+				t.Errorf("V1/CHASM replay classified as %s: %v", result.Classification, result.Divergences)
+			}
+		})
+		if checkpointPath != "" && len(results)%checkpointEvery == 0 {
+			require.NoError(t, writeReplayCheckpoint(checkpointPath, directory, results))
+		}
+	}
+	if reportPath != "" {
+		redact := os.Getenv(replayReportRedactEnv) != "false"
+		collections, err := readReplayCollectionSummaries(directory)
+		require.NoError(t, err)
+		require.NoError(t, writeReplayReportWithCollections(reportPath, results, collections, redact))
+		if err := os.Remove(checkpointPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			require.NoError(t, err)
+		}
+	}
+}
+
+func TestTimerActivationByWorkflowTaskPreservesTimerAcrossRetry(t *testing.T) {
+	history := &historypb.History{Events: []*historypb.HistoryEvent{
+		{EventId: 1, EventType: enumspb.EVENT_TYPE_TIMER_FIRED},
+		{EventId: 2, EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_TIMED_OUT},
+		{EventId: 3, EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED},
+	}}
+
+	require.Equal(t, map[int64]int64{3: 1}, timerActivationByWorkflowTask(history))
+}
+
+func TestTimerActivationByWorkflowTaskPreservesTimerAcrossForcedWorkflowTask(t *testing.T) {
+	history := &historypb.History{Events: []*historypb.HistoryEvent{
+		{EventId: 1, EventType: enumspb.EVENT_TYPE_TIMER_FIRED},
+		{EventId: 2, EventTime: timestamppb.New(time.Unix(100, 0)), EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED},
+		{EventId: 3, EventTime: timestamppb.New(time.Unix(100, 1)), EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED},
+		{EventId: 4, EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED},
+		{EventId: 5, EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED},
+		{EventId: 6, EventType: enumspb.EVENT_TYPE_MARKER_RECORDED},
+	}}
+
+	require.Equal(t, map[int64]int64{2: 1, 5: 1}, timerActivationByWorkflowTask(history))
+}
+
+func TestV1HistoryAgainstCHASM_TimeSkippingStart(t *testing.T) {
+	startTime := time.Unix(100, 0).UTC()
+	args := &schedulespb.StartScheduleArgs{
+		Schedule: &schedulepb.Schedule{
+			Spec: &schedulepb.ScheduleSpec{Interval: []*schedulepb.IntervalSpec{{
+				Interval: durationpb.New(10 * time.Second),
+			}}},
+			Action: &schedulepb.ScheduleAction{Action: &schedulepb.ScheduleAction_StartWorkflow{
+				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+					WorkflowId: "action", WorkflowType: &commonpb.WorkflowType{Name: "type"},
+				},
+			}},
+			Policies: &schedulepb.SchedulePolicies{OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL},
+			State:    &schedulepb.ScheduleState{},
+		},
+		Info: &schedulepb.ScheduleInfo{},
+		State: &schedulespb.InternalState{
+			Namespace: "namespace", NamespaceId: "namespace-id", ScheduleId: "schedule-id",
+			LastProcessedTime: timestamppb.New(startTime),
+		},
+	}
+	history := &historypb.History{Events: []*historypb.HistoryEvent{
+		{
+			EventId: 1, EventTime: timestamppb.New(startTime), EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+			Attributes: &historypb.HistoryEvent_WorkflowExecutionStartedEventAttributes{
+				WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{Input: mustPayloads(t, args)},
+			},
+		},
+		{
+			EventId: 2, EventTime: timestamppb.New(startTime.Add(11 * time.Second)), EventType: enumspb.EVENT_TYPE_TIMER_FIRED,
+			Attributes: &historypb.HistoryEvent_TimerFiredEventAttributes{TimerFiredEventAttributes: &historypb.TimerFiredEventAttributes{}},
+		},
+		{
+			EventId: 3, EventTime: timestamppb.New(startTime.Add(11 * time.Second)), EventType: enumspb.EVENT_TYPE_MARKER_RECORDED,
+			Attributes: &historypb.HistoryEvent_MarkerRecordedEventAttributes{MarkerRecordedEventAttributes: &historypb.MarkerRecordedEventAttributes{
+				MarkerName: "LocalActivity",
+				Details: map[string]*commonpb.Payloads{
+					"data":   mustPayloads(t, struct{ ActivityType string }{ActivityType: "StartWorkflow"}),
+					"result": mustPayloads(t, &schedulespb.StartWorkflowResponse{RunId: "observed-run-id"}),
+				},
+			}},
+		},
+	}}
+
+	result := replayV1HistoryAgainstCHASM(t, history)
+	require.Equal(t, replayClassificationInconclusive, result.Classification)
+	require.Contains(t, replayDivergenceKinds(result), "action_request_unavailable")
+}
+
+func TestV1HistoryAgainstCHASM_ReplayBudgetExceeded(t *testing.T) {
+	t.Setenv(replayMaxDeadlinesEnv, "1")
+	startTime := time.Unix(100, 0).UTC()
+	args := &schedulespb.StartScheduleArgs{
+		Schedule: &schedulepb.Schedule{
+			Spec: &schedulepb.ScheduleSpec{Interval: []*schedulepb.IntervalSpec{{
+				Interval: durationpb.New(time.Second),
+			}}},
+			Action: &schedulepb.ScheduleAction{Action: &schedulepb.ScheduleAction_StartWorkflow{
+				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{WorkflowId: "action", WorkflowType: &commonpb.WorkflowType{Name: "type"}},
+			}},
+			State: &schedulepb.ScheduleState{},
+		},
+		Info: &schedulepb.ScheduleInfo{},
+		State: &schedulespb.InternalState{
+			Namespace: "namespace", NamespaceId: "namespace-id", ScheduleId: "schedule-id",
+			LastProcessedTime: timestamppb.New(startTime),
+		},
+	}
+	history := &historypb.History{Events: []*historypb.HistoryEvent{
+		{
+			EventId: 1, EventTime: timestamppb.New(startTime), EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+			Attributes: &historypb.HistoryEvent_WorkflowExecutionStartedEventAttributes{
+				WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{Input: mustPayloads(t, args)},
+			},
+		},
+		{
+			EventId: 2, EventTime: timestamppb.New(startTime.Add(5 * time.Second)), EventType: enumspb.EVENT_TYPE_TIMER_FIRED,
+			Attributes: &historypb.HistoryEvent_TimerFiredEventAttributes{
+				TimerFiredEventAttributes: &historypb.TimerFiredEventAttributes{},
+			},
+		},
+	}}
+
+	result := replayV1HistoryAgainstCHASM(t, history)
+	require.Equal(t, replayClassificationInconclusive, result.Classification)
+	require.Equal(t, []string{"replay_budget_exceeded"}, replayDivergenceKinds(result))
+	require.Equal(t, "deadlines", result.ReplayStats.BudgetExceeded)
+	require.Empty(t, result.V1Starts)
+	require.Len(t, result.CHASMStarts, 1)
+}
+
+func TestV1HistoryAgainstCHASM_OverlapPolicyExternalEffects(t *testing.T) {
+	for _, testCase := range []struct {
+		name               string
+		overlapPolicy      enumspb.ScheduleOverlapPolicy
+		expectedCancels    int
+		expectedTerminates int
+	}{
+		{
+			name: "cancel", overlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_CANCEL_OTHER,
+			expectedCancels: 1,
+		},
+		{
+			name: "terminate", overlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_TERMINATE_OTHER,
+			expectedTerminates: 1,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			startTime := time.Unix(100, 0).UTC()
+			args := &schedulespb.StartScheduleArgs{
+				Schedule: &schedulepb.Schedule{
+					Spec: &schedulepb.ScheduleSpec{},
+					Action: &schedulepb.ScheduleAction{Action: &schedulepb.ScheduleAction_StartWorkflow{
+						StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+							WorkflowId: "action", WorkflowType: &commonpb.WorkflowType{Name: "type"},
+						},
+					}},
+					State: &schedulepb.ScheduleState{},
+				},
+				Info: &schedulepb.ScheduleInfo{RunningWorkflows: []*commonpb.WorkflowExecution{{
+					WorkflowId: "running-workflow", RunId: "running-run-id",
+				}}},
+				InitialPatch: &schedulepb.SchedulePatch{TriggerImmediately: &schedulepb.TriggerImmediatelyRequest{
+					OverlapPolicy: testCase.overlapPolicy,
+				}},
+				State: &schedulespb.InternalState{
+					Namespace: "namespace", NamespaceId: "namespace-id", ScheduleId: "schedule-id",
+					LastProcessedTime: timestamppb.New(startTime),
+				},
+			}
+			history := &historypb.History{Events: []*historypb.HistoryEvent{{
+				EventId: 1, EventTime: timestamppb.New(startTime), EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+				Attributes: &historypb.HistoryEvent_WorkflowExecutionStartedEventAttributes{
+					WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{Input: mustPayloads(t, args)},
+				},
+			}}}
+
+			result := replayV1HistoryAgainstCHASM(t, history)
+			require.Equal(t, testCase.expectedCancels, result.ReplayStats.Cancels)
+			require.Equal(t, testCase.expectedTerminates, result.ReplayStats.Terminates)
+		})
+	}
+}
+
+func TestV1HistoryAgainstCHASM_MissingInitialState(t *testing.T) {
+	history := &historypb.History{Events: []*historypb.HistoryEvent{{
+		EventId: 1, EventTime: timestamppb.Now(), EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+		Attributes: &historypb.HistoryEvent_WorkflowExecutionStartedEventAttributes{
+			WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{},
+		},
+	}}}
+
+	result := replayV1HistoryAgainstCHASM(t, history)
+	require.Equal(t, replayClassificationUnsupported, result.Classification)
+	require.Equal(t, []string{"initial_state_unavailable"}, replayDivergenceKinds(result))
+}
+
+func TestCaptureV1LocalActivities(t *testing.T) {
+	history := readReplayHistory(t, filepath.Join(
+		"..", "..", "..", "service", "worker", "scheduler", "testdata", "replay_v1.21.3.json.gz",
+	))
+	capture := captureV1LocalActivities(t, history)
+	require.Len(t, capture.startsByActivityID, 10)
+	require.Len(t, capture.watchesByActivityID, 9)
+	for _, request := range capture.startsByActivityID {
+		require.NotEmpty(t, request.GetRequest().GetWorkflowId())
+	}
+	for _, request := range capture.watchesByActivityID {
+		require.NotEmpty(t, request.GetExecution().GetWorkflowId())
+	}
+	trace := extractV1HistoryTrace(t, history)
+	require.Len(t, trace.localWatches, 9)
+	for _, start := range trace.starts {
+		require.NotEmpty(t, start.workflowID)
+	}
+}
+
+func TestExtractV1HistoryTraceCapturesStartFailure(t *testing.T) {
+	args := &schedulespb.StartScheduleArgs{
+		Schedule: &schedulepb.Schedule{Spec: &schedulepb.ScheduleSpec{}, State: &schedulepb.ScheduleState{}},
+		Info:     &schedulepb.ScheduleInfo{},
+		State:    &schedulespb.InternalState{Namespace: "namespace", NamespaceId: "namespace-id", ScheduleId: "schedule-id"},
+	}
+	request := &schedulespb.StartWorkflowRequest{Request: &workflowservice.StartWorkflowExecutionRequest{WorkflowId: "failed-workflow"}}
+	history := &historypb.History{Events: []*historypb.HistoryEvent{
+		{
+			EventId: 1, EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+			Attributes: &historypb.HistoryEvent_WorkflowExecutionStartedEventAttributes{
+				WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{Input: mustPayloads(t, args)},
+			},
+		},
+		{
+			EventId: 2, EventType: enumspb.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED,
+			Attributes: &historypb.HistoryEvent_ActivityTaskScheduledEventAttributes{
+				ActivityTaskScheduledEventAttributes: &historypb.ActivityTaskScheduledEventAttributes{
+					ActivityType: &commonpb.ActivityType{Name: "StartWorkflow"}, Input: mustPayloads(t, request),
+				},
+			},
+		},
+		{
+			EventId: 3, EventType: enumspb.EVENT_TYPE_ACTIVITY_TASK_FAILED,
+			Attributes: &historypb.HistoryEvent_ActivityTaskFailedEventAttributes{
+				ActivityTaskFailedEventAttributes: &historypb.ActivityTaskFailedEventAttributes{ScheduledEventId: 2},
+			},
+		},
+	}}
+	trace := extractV1HistoryTrace(t, history)
+	require.Empty(t, trace.starts)
+	require.Len(t, trace.failedStarts, 1)
+	require.Equal(t, "failed-workflow", trace.failedStarts[0].workflowID)
+	require.Len(t, trace.startAttempts, 1)
+	require.True(t, trace.startAttempts[0].failed)
+}
+
+func TestV1TweakablesFromMarker(t *testing.T) {
+	expected := legacyscheduler.TweakablePolicies{
+		DefaultCatchupWindow: 3 * time.Hour,
+		MinCatchupWindow:     7 * time.Second,
+		MaxBufferSize:        42,
+	}
+	event := &historypb.HistoryEvent{Attributes: &historypb.HistoryEvent_MarkerRecordedEventAttributes{
+		MarkerRecordedEventAttributes: &historypb.MarkerRecordedEventAttributes{
+			MarkerName: "MutableSideEffect",
+			Details: map[string]*commonpb.Payloads{
+				"data": mustPayloads(t, "tweakables", mustPayloads(t, expected)),
+			},
+		},
+	}}
+	actual, ok, err := v1TweakablesFromMarker(event)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, expected, actual)
+}
+
+func TestGroupObservedStartAttemptsPreservesOutcomeOrder(t *testing.T) {
+	attempts := []observedStartAttempt{
+		{workflowID: "same-id", runID: "successful-run"},
+		{workflowID: "other-id", failed: true},
+		{workflowID: "same-id", failed: true},
+	}
+
+	grouped := groupObservedStartAttempts(attempts)
+	require.Equal(t, []observedStartAttempt{
+		{workflowID: "same-id", runID: "successful-run"},
+		{workflowID: "same-id", failed: true},
+	}, grouped["same-id"])
+}
+
+func TestNormalizeScheduleForComparison(t *testing.T) {
+	expected := &schedulepb.Schedule{
+		Spec:  &schedulepb.ScheduleSpec{},
+		State: &schedulepb.ScheduleState{LimitedActions: true, RemainingActions: 2},
+	}
+	actual := &schedulepb.Schedule{
+		Spec:     &schedulepb.ScheduleSpec{},
+		Policies: &schedulepb.SchedulePolicies{},
+		State:    &schedulepb.ScheduleState{LimitedActions: true},
+	}
+	protorequire.ProtoEqual(t, normalizeScheduleForComparison(expected), normalizeScheduleForComparison(actual))
+}
+
+func TestApplyExpectedPatchHandlesUnavailableState(t *testing.T) {
+	applyExpectedPatch(nil, &schedulepb.SchedulePatch{Pause: "pause"})
+
+	schedule := &schedulepb.Schedule{}
+	applyExpectedPatch(schedule, &schedulepb.SchedulePatch{Pause: "pause"})
+	require.True(t, schedule.GetState().GetPaused())
+	require.Equal(t, "pause", schedule.GetState().GetNotes())
+}
+
+func TestApplyExpectedWatchCompletionPauseOnFailure(t *testing.T) {
+	schedule := &schedulepb.Schedule{Policies: &schedulepb.SchedulePolicies{PauseOnFailure: true}}
+	request := &schedulespb.WatchWorkflowRequest{
+		Execution: &commonpb.WorkflowExecution{WorkflowId: "workflow-id"},
+	}
+	applyExpectedWatchCompletion(schedule, request, &schedulespb.WatchWorkflowResponse{
+		Status: enumspb.WORKFLOW_EXECUTION_STATUS_FAILED,
+		ResultFailure: &schedulespb.WatchWorkflowResponse_Failure{
+			Failure: &failurepb.Failure{Message: "failure-message"},
+		},
+	})
+
+	require.True(t, schedule.GetState().GetPaused())
+	require.Equal(t, "paused due to workflow failure: workflow-id: failure-message", schedule.GetState().GetNotes())
+	require.True(t, isGeneratedPauseOnFailureNote(schedule.GetState().GetNotes()))
+}
+
+func TestWatchResponseFromActionHistory(t *testing.T) {
+	closeTime := timestamppb.New(time.Unix(123, 0))
+	result := &commonpb.Payloads{Payloads: []*commonpb.Payload{{Data: []byte("result")}}}
+	history := &historypb.History{Events: []*historypb.HistoryEvent{{
+		EventTime: closeTime,
+		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED,
+		Attributes: &historypb.HistoryEvent_WorkflowExecutionCompletedEventAttributes{
+			WorkflowExecutionCompletedEventAttributes: &historypb.WorkflowExecutionCompletedEventAttributes{Result: result},
+		},
+	}}}
+
+	response, ok := watchResponseFromActionHistory(history)
+	require.True(t, ok)
+	require.Equal(t, enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, response.GetStatus())
+	require.Equal(t, result, response.GetResult())
+	require.Equal(t, closeTime, response.GetCloseTime())
+
+	history.Events[0].GetWorkflowExecutionCompletedEventAttributes().NewExecutionRunId = "continued-run"
+	_, ok = watchResponseFromActionHistory(history)
+	require.False(t, ok)
+}
+
+func TestReadCompanionActionCompletions(t *testing.T) {
+	directory := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(directory, "namespace", "actions"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(directory, "collection.tsv"), []byte(
+		"namespace\tschedule_id\trun_index\thistory\nnamespace\tschedule\t0\tnamespace/schedule.json.gz\n",
+	), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(directory, "action-collection.tsv"), []byte(
+		"namespace\tschedule_id\tschedule_run_index\tworkflow_id\tfirst_run_id\trun_id\taction_run_index\thistory\n"+
+			"namespace\tschedule\t0\taction\tfirst-run\tlast-run\t1\tnamespace/actions/action.json.gz\n",
+	), 0o600))
+	closeTime := timestamppb.New(time.Unix(123, 0))
+	history := &historypb.History{Events: []*historypb.HistoryEvent{{
+		EventTime: closeTime,
+		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED,
+		Attributes: &historypb.HistoryEvent_WorkflowExecutionCanceledEventAttributes{
+			WorkflowExecutionCanceledEventAttributes: &historypb.WorkflowExecutionCanceledEventAttributes{},
+		},
+	}}}
+	data, err := protojson.Marshal(history)
+	require.NoError(t, err)
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	_, err = writer.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	require.NoError(t, os.WriteFile(filepath.Join(directory, "namespace", "actions", "action.json.gz"), compressed.Bytes(), 0o600))
+
+	completions, err := readCompanionActionCompletions(directory)
+	require.NoError(t, err)
+	require.Len(t, completions[filepath.Join(directory, "namespace", "schedule.json.gz")], 1)
+	completion := completions[filepath.Join(directory, "namespace", "schedule.json.gz")][0]
+	require.Equal(t, "action", completion.request.GetExecution().GetWorkflowId())
+	require.Equal(t, "first-run", completion.request.GetFirstExecutionRunId())
+	require.Equal(t, enumspb.WORKFLOW_EXECUTION_STATUS_CANCELED, completion.response.GetStatus())
+	require.Equal(t, closeTime.AsTime(), completion.observedTime)
+}
+
+func TestFilterObservedCompanionCompletions(t *testing.T) {
+	start := time.Unix(100, 0)
+	runningResult, err := converter.GetDefaultDataConverter().ToPayloads(&schedulespb.WatchWorkflowResponse{
+		Status: enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+	})
+	require.NoError(t, err)
+	trace := &v1HistoryTrace{
+		history: &historypb.History{Events: []*historypb.HistoryEvent{
+			{EventTime: timestamppb.New(start)},
+			{
+				EventTime: timestamppb.New(start.Add(time.Second)),
+				EventType: enumspb.EVENT_TYPE_ACTIVITY_TASK_COMPLETED,
+				Attributes: &historypb.HistoryEvent_ActivityTaskCompletedEventAttributes{
+					ActivityTaskCompletedEventAttributes: &historypb.ActivityTaskCompletedEventAttributes{
+						ScheduledEventId: 1,
+						Result:           runningResult,
+					},
+				},
+			},
+			{EventTime: timestamppb.New(start.Add(10 * time.Second))},
+		}},
+		watches: map[int64]scheduledWatch{1: {request: &schedulespb.WatchWorkflowRequest{
+			Execution: &commonpb.WorkflowExecution{WorkflowId: "running-only"}, FirstExecutionRunId: "run-1",
+		}}},
+		localWatches: map[int64]observedWatchCompletion{2: {
+			request: &schedulespb.WatchWorkflowRequest{
+				Execution: &commonpb.WorkflowExecution{WorkflowId: "already-observed"}, FirstExecutionRunId: "run-2",
+			},
+			response: &schedulespb.WatchWorkflowResponse{Status: enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED},
+		}},
+	}
+	completions := []observedWatchCompletion{
+		{request: &schedulespb.WatchWorkflowRequest{Execution: &commonpb.WorkflowExecution{WorkflowId: "running-only"}, FirstExecutionRunId: "run-1"}, observedTime: start.Add(time.Second)},
+		{request: &schedulespb.WatchWorkflowRequest{Execution: &commonpb.WorkflowExecution{WorkflowId: "already-observed"}, FirstExecutionRunId: "run-2"}, observedTime: start.Add(2 * time.Second)},
+		{request: &schedulespb.WatchWorkflowRequest{Execution: &commonpb.WorkflowExecution{WorkflowId: "within-horizon"}, FirstExecutionRunId: "run-3"}, observedTime: start.Add(3 * time.Second)},
+		{request: &schedulespb.WatchWorkflowRequest{Execution: &commonpb.WorkflowExecution{WorkflowId: "after-horizon"}, FirstExecutionRunId: "run-4"}, observedTime: start.Add(11 * time.Second)},
+	}
+
+	filtered := filterObservedCompanionCompletions(trace, completions, start)
+	require.Len(t, filtered, 2)
+	require.Equal(t, "running-only", filtered[0].request.GetExecution().GetWorkflowId())
+	require.Equal(t, "within-horizon", filtered[1].request.GetExecution().GetWorkflowId())
+}
+
+func TestResolveObservedWorkflowExecution(t *testing.T) {
+	executionMap := workflowExecutionMap{
+		{workflowID: "v1-workflow", runID: "v1-run"}: {workflowID: "chasm-workflow", runID: "chasm-run"},
+	}
+
+	execution, err := resolveObservedWorkflowExecution(executionMap, true, workflowExecutionKey{workflowID: "v1-workflow", runID: "v1-run"})
+	require.NoError(t, err)
+	require.Equal(t, workflowExecutionKey{workflowID: "chasm-workflow", runID: "chasm-run"}, execution)
+
+	execution, err = resolveObservedWorkflowExecution(executionMap, false, workflowExecutionKey{workflowID: "unmapped-workflow", runID: "unmapped-run"})
+	require.NoError(t, err)
+	require.Equal(t, workflowExecutionKey{workflowID: "unmapped-workflow", runID: "unmapped-run"}, execution)
+
+	_, err = resolveObservedWorkflowExecution(executionMap, true, workflowExecutionKey{workflowID: "not-started", runID: "not-started-run"})
+	require.EqualError(t, err,
+		`V1 workflow "not-started" run "not-started-run" completed before CHASM emitted its corresponding start; this is a scheduling/timing divergence`,
+	)
+}
+
+func TestResolveObservedWorkflowExecutionWithoutRunID(t *testing.T) {
+	executionMap := workflowExecutionMap{
+		{workflowID: "v1-workflow", runID: "v1-run"}: {workflowID: "chasm-workflow", runID: "chasm-run"},
+	}
+
+	execution, err := resolveObservedWorkflowExecution(executionMap, true, workflowExecutionKey{workflowID: "v1-workflow"})
+	require.NoError(t, err)
+	require.Equal(t, workflowExecutionKey{workflowID: "chasm-workflow", runID: "chasm-run"}, execution)
+
+	executionMap[workflowExecutionKey{workflowID: "v1-workflow", runID: "v1-run-2"}] = workflowExecutionKey{workflowID: "chasm-workflow", runID: "chasm-run-2"}
+	_, err = resolveObservedWorkflowExecution(executionMap, true, workflowExecutionKey{workflowID: "v1-workflow"})
+	require.EqualError(t, err, `V1 workflow "v1-workflow" completion does not identify a run and matches multiple CHASM executions`)
+	divergence := replayCompletionErrorDivergence(err, &schedulespb.WatchWorkflowRequest{
+		Execution: &commonpb.WorkflowExecution{WorkflowId: "v1-workflow"},
+	}, time.Unix(100, 0), true)
+	require.Equal(t, replayClassificationInconclusive, divergence.Classification)
+	require.Equal(t, "ambiguous_completion", divergence.Kind)
+}
+
+func TestSeedCarriedWorkflowExecutions(t *testing.T) {
+	executionMap := make(workflowExecutionMap)
+	seedCarriedWorkflowExecutions(executionMap, []*schedulespb.BufferedStart{
+		{WorkflowId: "running", RunId: "running-run"},
+		{WorkflowId: "pending"},
+		{WorkflowId: "completed", RunId: "completed-run", Completed: &schedulespb.CompletedResult{}},
+	})
+
+	require.Equal(t, workflowExecutionMap{
+		{workflowID: "running", runID: "running-run"}: {workflowID: "running", runID: "running-run"},
+	}, executionMap)
+}
+
+func TestReplayReport(t *testing.T) {
+	results := []replayCaseResult{
+		{
+			Namespace: "customer", ScheduleID: "matching", Cohorts: []string{"spec_interval"}, Classification: replayClassificationMatch,
+			FirstActionDifference: &replayActionDifference{Index: 3, V1WorkflowID: "v1-sensitive", CHASMWorkflowID: "chasm-sensitive"},
+		},
+		{ScheduleID: "different", Classification: replayClassificationSignificant},
+	}
+	path := filepath.Join(t.TempDir(), "report.json")
+	require.NoError(t, writeReplayReport(path, results, false))
+	reportInfo, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), reportInfo.Mode().Perm())
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var report replayReport
+	require.NoError(t, json.Unmarshal(data, &report))
+	require.Equal(t, 10, report.Version)
+	require.False(t, report.Redacted)
+	require.Equal(t, map[string]int{"match": 1, "significant": 1}, report.Summary)
+	require.Equal(t, map[string]map[string]int{"spec_interval": {"match": 1}}, report.CohortSummary)
+	require.Equal(t, results, report.Cases)
+
+	redactedPath := filepath.Join(t.TempDir(), "redacted-report.json")
+	require.NoError(t, writeReplayReport(redactedPath, results, true))
+	redactedData, err := os.ReadFile(redactedPath)
+	require.NoError(t, err)
+	require.NotContains(t, string(redactedData), "customer")
+	require.NotContains(t, string(redactedData), "matching")
+	require.NotContains(t, string(redactedData), "v1-sensitive")
+	require.NotContains(t, string(redactedData), "chasm-sensitive")
+	require.Contains(t, string(redactedData), "sha256:")
+
+	require.True(t, replayResultFails(results[1], "significant"))
+	require.False(t, replayResultFails(results[1], "none"))
+	require.True(t, replayResultFails(replayCaseResult{Classification: replayClassificationTimingOnly}, "all"))
+	require.False(t, replayResultFails(replayCaseResult{Classification: replayClassificationKnownCompat}, "significant"))
+	require.True(t, replayResultFails(replayCaseResult{Classification: replayClassificationKnownCompat}, "all"))
+}
+
+func TestReplayCheckpoint(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "report.checkpoint")
+	results := []replayCaseResult{{History: "one.json.gz", Classification: replayClassificationTimingOnly}}
+	require.NoError(t, writeReplayCheckpoint(path, "/corpus", results))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	loaded, err := readReplayCheckpoint(path, "/corpus")
+	require.NoError(t, err)
+	require.Equal(t, results, loaded)
+
+	_, err = readReplayCheckpoint(path, "/different-corpus")
+	require.ErrorContains(t, err, "expected version")
+	loaded, err = readReplayCheckpoint(filepath.Join(t.TempDir(), "missing"), "/corpus")
+	require.NoError(t, err)
+	require.Nil(t, loaded)
+}
+
+func TestFirstReplayActionDifference(t *testing.T) {
+	base := time.Unix(100, 0).UTC()
+	v1 := []observedStart{
+		{workflowID: "same", time: base},
+		{workflowID: "v1-different", time: base.Add(time.Second)},
+	}
+	chasmStarts := []chasmStart{
+		{workflowID: "same", time: base},
+		{workflowID: "chasm-different", time: base.Add(2 * time.Second)},
+	}
+
+	difference := firstReplayActionDifference(v1, chasmStarts)
+	require.Equal(t, 1, difference.Index)
+	require.Equal(t, "v1-different", difference.V1WorkflowID)
+	require.Equal(t, "chasm-different", difference.CHASMWorkflowID)
+	require.Equal(t, base.Add(time.Second), *difference.V1Time)
+	require.Equal(t, base.Add(2*time.Second), *difference.CHASMTime)
+	require.Nil(t, firstReplayActionDifference(v1, []chasmStart{{workflowID: "same", time: base}, {workflowID: "v1-different", time: base.Add(time.Second)}}))
+}
+
+func TestFirstDifferenceFollowsLocalWatch(t *testing.T) {
+	trace := &v1HistoryTrace{
+		history: &historypb.History{Events: []*historypb.HistoryEvent{{
+			EventId: 7,
+			Attributes: &historypb.HistoryEvent_MarkerRecordedEventAttributes{MarkerRecordedEventAttributes: &historypb.MarkerRecordedEventAttributes{
+				WorkflowTaskCompletedEventId: 5,
+			}},
+		}}},
+		startAttempts: []observedStartAttempt{{workflowID: "next", workflowTaskCompletedEventID: 5}},
+		localWatches: map[int64]observedWatchCompletion{7: {
+			response:                     &schedulespb.WatchWorkflowResponse{Status: enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED},
+			workflowTaskCompletedEventID: 5,
+		}},
+	}
+	difference := &replayActionDifference{V1WorkflowID: "next"}
+	require.True(t, firstDifferenceFollowsLocalWatch(trace, difference))
+	trace.localWatches[7].response.Status = enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
+	require.False(t, firstDifferenceFollowsLocalWatch(trace, difference))
+}
+
+func TestAnnotateActionSequenceCascade(t *testing.T) {
+	divergences := []replayDivergence{
+		{Classification: replayClassificationSignificant, Kind: "missing_action", WorkflowID: "v1-root"},
+		{Classification: replayClassificationSignificant, Kind: "extra_action", WorkflowID: "chasm-root"},
+		{Classification: replayClassificationSignificant, Kind: "action_request", WorkflowID: "later"},
+		{Classification: replayClassificationSignificant, Kind: "missing_action", WorkflowID: "later"},
+		{Classification: replayClassificationSignificant, Kind: "action_count"},
+	}
+	difference := &replayActionDifference{V1WorkflowID: "v1-root", CHASMWorkflowID: "chasm-root"}
+	annotateActionSequenceCascade(divergences, difference, true)
+	require.Equal(t, "v1_local_watch_ordering", divergences[0].KnownDifference)
+	require.Equal(t, "v1_local_watch_ordering", divergences[1].KnownDifference)
+	for _, divergence := range divergences[2:] {
+		require.Equal(t, replayClassificationInconclusive, divergence.Classification)
+		require.Equal(t, "action_sequence_cascade", divergence.KnownDifference)
+	}
+
+	divergences = []replayDivergence{
+		{Classification: replayClassificationSignificant, Kind: "missing_action", WorkflowID: "v1-root"},
+		{Classification: replayClassificationInconclusive, Kind: "extra_action", WorkflowID: "chasm-root"},
+	}
+	annotateActionSequenceCascade(divergences, difference, false)
+	require.Equal(t, replayClassificationInconclusive, divergences[0].Classification)
+	require.Equal(t, "action_sequence_cascade", divergences[0].KnownDifference)
+}
+
+func TestFirstActionEvidence(t *testing.T) {
+	target := time.Unix(100, 0).UTC()
+	patch := &schedulepb.SchedulePatch{TriggerImmediately: &schedulepb.TriggerImmediatelyRequest{}}
+	immediateHistory := &historypb.History{Events: []*historypb.HistoryEvent{{
+		EventTime: timestamppb.New(target), EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED,
+		Attributes: &historypb.HistoryEvent_WorkflowExecutionSignaledEventAttributes{
+			WorkflowExecutionSignaledEventAttributes: &historypb.WorkflowExecutionSignaledEventAttributes{
+				SignalName: legacyscheduler.SignalNamePatch, Input: mustPayloads(t, patch),
+			},
+		},
+	}}}
+	require.True(t, firstDifferenceIsImmediateTrigger(immediateHistory, target))
+
+	timeoutHistory := &historypb.History{Events: []*historypb.HistoryEvent{
+		{EventTime: timestamppb.New(target.Add(time.Millisecond)), EventType: enumspb.EVENT_TYPE_TIMER_FIRED},
+		{EventTime: timestamppb.New(target.Add(time.Second)), EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_TIMED_OUT},
+	}}
+	require.True(t, workflowTaskTimedOutForDeadline(timeoutHistory, target))
+	timeoutHistory.Events[1].EventType = enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED
+	require.False(t, workflowTaskTimedOutForDeadline(timeoutHistory, target))
+}
+
+func TestAnnotateHistoryRunBoundary(t *testing.T) {
+	divergences := []replayDivergence{{
+		Classification: replayClassificationSignificant,
+		Kind:           "extra_action",
+		WorkflowID:     "next-run-action",
+	}}
+	difference := &replayActionDifference{CHASMWorkflowID: "next-run-action"}
+	history := &historypb.History{Events: []*historypb.HistoryEvent{{
+		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW,
+	}}}
+	annotateHistoryRunBoundary(divergences, difference, history)
+	require.Equal(t, replayClassificationInconclusive, divergences[0].Classification)
+	require.Equal(t, "history_run_boundary", divergences[0].KnownDifference)
+}
+
+func TestNormalizeStartWorkflowRequest(t *testing.T) {
+	v1 := &workflowservice.StartWorkflowExecutionRequest{
+		Namespace: "namespace", Identity: "v1", RequestId: "v1-request",
+		WorkflowId: "workflow", Input: mustPayloads(t, "input"),
+	}
+	chasmRequest := proto.CloneOf(v1)
+	chasmRequest.Namespace = ""
+	chasmRequest.Identity = "chasm"
+	chasmRequest.RequestId = "chasm-request"
+	chasmRequest.LastCompletionResult = &commonpb.Payloads{}
+	protorequire.ProtoEqual(t, normalizeStartWorkflowRequest(v1), normalizeStartWorkflowRequest(chasmRequest))
+	chasmRequest.Input = mustPayloads(t, "different")
+	require.False(t, proto.Equal(normalizeStartWorkflowRequest(v1), normalizeStartWorkflowRequest(chasmRequest)))
+}
+
+func TestStartWorkflowRequestFieldDifferences(t *testing.T) {
+	v1ScheduledTime := time.Unix(100, 0).UTC()
+	chasmScheduledTime := v1ScheduledTime.Add(1500 * time.Millisecond)
+	v1ScheduledPayload, err := converter.GetDefaultDataConverter().ToPayload(v1ScheduledTime)
+	require.NoError(t, err)
+	chasmScheduledPayload, err := converter.GetDefaultDataConverter().ToPayload(chasmScheduledTime)
+	require.NoError(t, err)
+	v1 := &workflowservice.StartWorkflowExecutionRequest{
+		SearchAttributes: &commonpb.SearchAttributes{IndexedFields: map[string]*commonpb.Payload{
+			sadefs.TemporalScheduledStartTime: v1ScheduledPayload,
+		}},
+		LastCompletionResult: mustPayloads(t, "one", "two"),
+		ContinuedFailure: &failurepb.Failure{
+			FailureInfo: &failurepb.Failure_ApplicationFailureInfo{},
+		},
+	}
+	chasmRequest := &workflowservice.StartWorkflowExecutionRequest{
+		SearchAttributes: &commonpb.SearchAttributes{IndexedFields: map[string]*commonpb.Payload{
+			sadefs.TemporalScheduledStartTime: chasmScheduledPayload,
+		}},
+		LastCompletionResult: mustPayloads(t, "one"),
+		ContinuedFailure: &failurepb.Failure{
+			FailureInfo: &failurepb.Failure_TimeoutFailureInfo{},
+		},
+	}
+	fields := startWorkflowRequestDifferenceFields(v1, chasmRequest)
+	differences := startWorkflowRequestFieldDifferences(v1, chasmRequest, fields)
+
+	require.ElementsMatch(t, []string{"continued_failure", "last_completion_result", "search_attributes"}, fields)
+	require.Len(t, differences, 3)
+	var searchDetails []string
+	for _, difference := range differences {
+		require.NotEmpty(t, difference.V1.Digest)
+		require.NotEmpty(t, difference.CHASM.Digest)
+		if difference.Field == "search_attributes" {
+			searchDetails = difference.SafeDetails
+		}
+	}
+	require.NotEmpty(t, searchDetails)
+	require.Contains(t, searchDetails[0], sadefs.TemporalScheduledStartTime)
+
+	redacted := redactReplayResults([]replayCaseResult{{Divergences: []replayDivergence{{FieldDifferences: differences}}}})
+	for _, difference := range redacted[0].Divergences[0].FieldDifferences {
+		require.Empty(t, difference.V1.Digest)
+		require.Empty(t, difference.CHASM.Digest)
+	}
+}
+
+func TestNormalizeStartWorkflowRequestIgnoresScheduledTimeSubsecondPrecision(t *testing.T) {
+	v1ScheduledPayload, err := sadefs.EncodeValue(time.Unix(100, 0).UTC(), enumspb.INDEXED_VALUE_TYPE_DATETIME)
+	require.NoError(t, err)
+	chasmScheduledPayload, err := sadefs.EncodeValue(time.Unix(100, 500_000_000).UTC(), enumspb.INDEXED_VALUE_TYPE_DATETIME)
+	require.NoError(t, err)
+	v1 := &workflowservice.StartWorkflowExecutionRequest{SearchAttributes: &commonpb.SearchAttributes{IndexedFields: map[string]*commonpb.Payload{
+		sadefs.TemporalScheduledStartTime: v1ScheduledPayload,
+	}}}
+	chasmRequest := &workflowservice.StartWorkflowExecutionRequest{SearchAttributes: &commonpb.SearchAttributes{IndexedFields: map[string]*commonpb.Payload{
+		sadefs.TemporalScheduledStartTime: chasmScheduledPayload,
+	}}}
+
+	protorequire.ProtoEqual(t, normalizeStartWorkflowRequest(v1), normalizeStartWorkflowRequest(chasmRequest))
+}
+
+func mustPayloads(t *testing.T, values ...any) *commonpb.Payloads {
+	t.Helper()
+	payloads, err := converter.GetDefaultDataConverter().ToPayloads(values...)
+	require.NoError(t, err)
+	return payloads
+}
+
+func replayV1HistoryAgainstCHASM(t *testing.T, history *historypb.History) replayCaseResult {
+	return replayV1HistoryAgainstCHASMWithCompletions(t, history, nil)
+}
+
+func replayV1HistoryAgainstCHASMWithCompletions(
+	t *testing.T,
+	history *historypb.History,
+	companionCompletions []observedWatchCompletion,
+) replayCaseResult {
+	t.Helper()
+	trace := extractV1HistoryTrace(t, history)
+	replayStartTime := v1FirstDecisionTime(trace.history, trace.startTime)
+	result := replayCaseResult{
+		Namespace:      trace.args.GetState().GetNamespace(),
+		ScheduleID:     trace.args.GetState().GetScheduleId(),
+		Classification: replayClassificationMatch,
+		Cohorts:        replayHistoryCohorts(trace),
+		ReplayInputs:   summarizeReplayInputs(trace),
+	}
+	result.ReplayInputs.CompanionCompletions = len(companionCompletions)
+	budget := newReplayBudget(t)
+	for _, start := range trace.starts {
+		result.V1Starts = append(result.V1Starts, start.workflowID)
+	}
+	if trace.captureIssues != 0 {
+		result.Classification = replayClassificationInconclusive
+		result.Divergences = []replayDivergence{{
+			Classification: replayClassificationInconclusive,
+			Kind:           "local_activity_capture_unavailable",
+			Message:        fmt.Sprintf("%d V1 local activity marker(s) could not be associated with replayed invocations", trace.captureIssues),
+		}}
+		return result
+	}
+	if trace.args.GetSchedule() == nil || trace.args.GetState() == nil {
+		result.Classification = replayClassificationUnsupported
+		result.Divergences = []replayDivergence{{
+			Classification: replayClassificationUnsupported,
+			Kind:           "initial_state_unavailable",
+			Message:        "V1 history does not contain the schedule and internal state required to initialize CHASM replay",
+		}}
+		return result
+	}
+	logger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)
+	ctrl := gomock.NewController(t)
+	frontendClient := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	historyClient := historyservicemock.NewMockHistoryServiceClient(ctrl)
+	initialLocalCompletions := localCompletionsInFirstWorkflowTask(trace)
+	initialCompletionsByWorkflowID := make(map[string]observedWatchCompletion, len(initialLocalCompletions))
+	initialRunningWorkflowIDs := make(map[string]struct{}, len(trace.args.GetInfo().GetRunningWorkflows()))
+	for _, execution := range trace.args.GetInfo().GetRunningWorkflows() {
+		initialRunningWorkflowIDs[execution.GetWorkflowId()] = struct{}{}
+	}
+	initialMigrationCompletionWorkflowTasks := make(map[int64]struct{}, len(initialLocalCompletions))
+	initialMigrationCompletionResultUnavailable := false
+	for _, completion := range initialLocalCompletions {
+		workflowID := completion.request.GetExecution().GetWorkflowId()
+		initialCompletionsByWorkflowID[workflowID] = completion
+		if _, ok := initialRunningWorkflowIDs[workflowID]; ok {
+			initialMigrationCompletionWorkflowTasks[completion.workflowTaskCompletedEventID] = struct{}{}
+			if completion.response.GetStatus() != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING {
+				initialMigrationCompletionResultUnavailable = true
+			}
+		}
+	}
+
+	var actionMu sync.Mutex
+	startIndex := 0
+	executionMap := make(workflowExecutionMap)
+	var chasmStarts []chasmStart
+	var divergences []replayDivergence
+	var firstUnobservedExtraTime *time.Time
+	var firstInferredCompletionTime *time.Time
+	var pendingCompletions []observedWatchCompletion
+	syntheticallyCompletedWorkflowIDs := make(map[string]struct{})
+	completionErrorDivergence := func(
+		err error,
+		request *schedulespb.WatchWorkflowRequest,
+		observedTime time.Time,
+		v1Time bool,
+	) replayDivergence {
+		divergence := replayCompletionErrorDivergence(err, request, observedTime, v1Time)
+		if firstUnobservedExtraTime != nil && !observedTime.Before(*firstUnobservedExtraTime) {
+			divergence.Classification = replayClassificationInconclusive
+			divergence.KnownDifference = "unobserved_extra_action_cascade"
+			divergence.Message += "; an earlier CHASM-only action has no observed completion, so subsequent workflow identity mapping is not reproducible"
+		}
+		return divergence
+	}
+	if trace.startRetries != 0 {
+		divergences = append(divergences, replayDivergence{
+			Classification: replayClassificationInconclusive,
+			Kind:           "start_retry_unobservable",
+			Message:        fmt.Sprintf("%d V1 StartWorkflow local activities retried without recording the intermediate failure", trace.startRetries),
+		})
+	}
+	startsByWorkflowID := make(map[string][]observedStart, len(trace.starts))
+	for _, start := range trace.starts {
+		if start.workflowID != "" {
+			startsByWorkflowID[start.workflowID] = append(startsByWorkflowID[start.workflowID], start)
+		}
+	}
+	attemptsByWorkflowID := groupObservedStartAttempts(trace.startAttempts)
+	consumedAttempts := make(map[string]int, len(attemptsByWorkflowID))
+	timeSource := clock.NewEventTimeSource()
+	timeSource.Update(replayStartTime)
+	frontendClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).AnyTimes().
+		DoAndReturn(func(_ context.Context, request *workflowservice.StartWorkflowExecutionRequest, _ ...grpc.CallOption) (*workflowservice.StartWorkflowExecutionResponse, error) {
+			if request.GetWorkflowIdConflictPolicy() == enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING {
+				return &workflowservice.StartWorkflowExecutionResponse{}, nil
+			}
+			actionMu.Lock()
+			defer actionMu.Unlock()
+			budget.addStart()
+			workflowID := request.GetWorkflowId()
+			chasmTime := timeSource.Now().UTC()
+			if attempts := attemptsByWorkflowID[workflowID]; consumedAttempts[workflowID] < len(attempts) {
+				attempt := attempts[consumedAttempts[workflowID]]
+				consumedAttempts[workflowID]++
+				if !proto.Equal(normalizeStartWorkflowRequest(attempt.request), normalizeStartWorkflowRequest(request)) {
+					fields := startWorkflowRequestDifferenceFields(attempt.request, request)
+					message := "V1 and CHASM emitted different StartWorkflowExecution requests"
+					if attempt.failed {
+						message = "V1 and CHASM emitted different failed StartWorkflowExecution requests"
+					}
+					classification := replayClassificationSignificant
+					knownDifference := ""
+					if slices.Contains(fields, "input") &&
+						workflowTaskContainsUpdateBeforeStart(trace.history, attempt.workflowTaskCompletedEventID) {
+						classification = replayClassificationInconclusive
+						knownDifference = "v1_workflow_task_input_ordering"
+						message += "; V1 processed an update delivered with the same workflow task, after the replay had already fired the nominal CHASM deadline"
+					} else if _, sameWorkflowTask := initialMigrationCompletionWorkflowTasks[attempt.workflowTaskCompletedEventID]; (slices.Contains(fields, "last_completion_result") || slices.Contains(fields, "continued_failure")) &&
+						(sameWorkflowTask || initialMigrationCompletionResultUnavailable && len(chasmStarts) == 0) {
+						classification = replayClassificationKnownCompat
+						knownDifference = "migration_running_completion_result_unavailable"
+						message += "; migration refreshed the running workflow through DescribeWorkflowExecution, which exposes terminal status and close time but not its completion result or failure payload"
+					} else if slices.Contains(fields, "last_completion_result") &&
+						workflowTaskContainsTerminalLocalWatch(trace, attempt.workflowTaskCompletedEventID) {
+						classification = replayClassificationInconclusive
+						knownDifference = "v1_local_watch_ordering"
+						message += "; V1 applied a local WatchWorkflow completion earlier in the same workflow task, after the replay had already fired the nominal CHASM deadline"
+					} else if firstInferredCompletionTime != nil {
+						classification = replayClassificationInconclusive
+						knownDifference = "completion_inferred_from_v1_start"
+						message += "; an earlier workflow completion was inferred from a later V1 non-overlapping start, so result-dependent request state is not directly observable"
+					} else if firstUnobservedExtraTime != nil && !chasmTime.Before(*firstUnobservedExtraTime) {
+						classification = replayClassificationInconclusive
+						knownDifference = "unobserved_extra_action_cascade"
+						message += "; an earlier CHASM-only action has no observed completion, so downstream request state is not reproducible"
+					}
+					divergences = append(divergences, replayDivergence{
+						Classification:   classification,
+						Kind:             "action_request",
+						Message:          message,
+						WorkflowID:       workflowID,
+						V1Time:           timePointer(attempt.time),
+						CHASMTime:        timePointer(chasmTime),
+						Fields:           fields,
+						FieldDifferences: startWorkflowRequestFieldDifferences(attempt.request, request, fields),
+						KnownDifference:  knownDifference,
+					})
+				}
+				if attempt.failed {
+					return nil, serviceerror.NewInvalidArgument("replayed V1 StartWorkflow failure")
+				}
+				chasmStarts = append(chasmStarts, chasmStart{workflowID: workflowID, time: chasmTime})
+				executionMap[workflowExecutionKey{workflowID: attempt.workflowID, runID: attempt.runID}] = workflowExecutionKey{
+					workflowID: request.GetWorkflowId(),
+					runID:      attempt.runID,
+				}
+				startIndex++
+				if !attempt.time.IsZero() && !attempt.time.Equal(chasmTime) {
+					divergences = append(divergences, replayDivergence{
+						Classification: replayClassificationTimingOnly,
+						Kind:           "action_time",
+						Message:        "V1 and CHASM emitted the same workflow start at different observed times",
+						WorkflowID:     workflowID,
+						V1Time:         timePointer(attempt.time),
+						CHASMTime:      timePointer(chasmTime),
+					})
+				}
+				return &workflowservice.StartWorkflowExecutionResponse{RunId: attempt.runID}, nil
+			}
+			chasmStarts = append(chasmStarts, chasmStart{workflowID: workflowID, time: chasmTime})
+			if len(startsByWorkflowID) == 0 && startIndex < len(trace.starts) {
+				start := trace.starts[startIndex]
+				startIndex++
+				return &workflowservice.StartWorkflowExecutionResponse{RunId: start.runID}, nil
+			}
+			divergences = append(divergences, replayDivergence{
+				Classification: replayClassificationSignificant,
+				Kind:           "extra_action",
+				Message:        fmt.Sprintf("CHASM emitted workflow start %q not present in V1 history", workflowID),
+				WorkflowID:     workflowID,
+				CHASMTime:      timePointer(chasmTime),
+			})
+			if firstUnobservedExtraTime == nil {
+				firstUnobservedExtraTime = timePointer(chasmTime)
+			}
+			return &workflowservice.StartWorkflowExecutionResponse{RunId: fmt.Sprintf("chasm-replay-extra-%d", len(chasmStarts))}, nil
+		})
+	historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).AnyTimes().
+		DoAndReturn(func(_ context.Context, request *historyservice.DescribeWorkflowExecutionRequest, _ ...grpc.CallOption) (*historyservice.DescribeWorkflowExecutionResponse, error) {
+			status := enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
+			var closeTime *timestamppb.Timestamp
+			if completion, ok := initialCompletionsByWorkflowID[request.GetRequest().GetExecution().GetWorkflowId()]; ok &&
+				completion.response.GetStatus() != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING {
+				status = completion.response.GetStatus()
+				closeTime = completion.response.GetCloseTime()
+			}
+			return &historyservice.DescribeWorkflowExecutionResponse{
+				WorkflowExecutionInfo: &workflowpb.WorkflowExecutionInfo{
+					Execution: request.GetRequest().GetExecution(),
+					Status:    status,
+					CloseTime: closeTime,
+				},
+			}, nil
+		})
+	historyClient.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), gomock.Any()).AnyTimes().
+		DoAndReturn(func(_ context.Context, _ *historyservice.RequestCancelWorkflowExecutionRequest, _ ...grpc.CallOption) (*historyservice.RequestCancelWorkflowExecutionResponse, error) {
+			actionMu.Lock()
+			defer actionMu.Unlock()
+			budget.stats.Cancels++
+			return &historyservice.RequestCancelWorkflowExecutionResponse{}, nil
+		})
+	historyClient.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).AnyTimes().
+		DoAndReturn(func(_ context.Context, request *historyservice.TerminateWorkflowExecutionRequest, _ ...grpc.CallOption) (*historyservice.TerminateWorkflowExecutionResponse, error) {
+			actionMu.Lock()
+			defer actionMu.Unlock()
+			budget.stats.Terminates++
+			syntheticallyCompletedWorkflowIDs[request.GetTerminateRequest().GetWorkflowExecution().GetWorkflowId()] = struct{}{}
+			pendingCompletions = append(pendingCompletions, observedWatchCompletion{
+				request: &schedulespb.WatchWorkflowRequest{
+					Execution: proto.CloneOf(request.GetTerminateRequest().GetWorkflowExecution()),
+				},
+				response:           &schedulespb.WatchWorkflowResponse{Status: enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED},
+				observedTime:       timeSource.Now(),
+				bypassExecutionMap: true,
+			})
+			return &historyservice.TerminateWorkflowExecutionResponse{}, nil
+		})
+
+	registry := chasm.NewRegistry(logger)
+	require.NoError(t, registry.Register(&chasm.CoreLibrary{}))
+	require.NoError(t, registry.Register(newHistoryReplayLibrary(logger, frontendClient, historyClient, trace, timeSource)))
+	engine := chasmtest.NewEngine(t, registry, chasmtest.WithTimeSource(timeSource))
+	engineCtx := chasm.NewEngineContext(context.Background(), engine)
+	rootRef := chasm.NewComponentRef[*scheduler.Scheduler](chasm.ExecutionKey{
+		NamespaceID: trace.args.GetState().GetNamespaceId(),
+		BusinessID:  trace.args.GetState().GetScheduleId(),
+	})
+
+	handler := scheduler.NewTestHandler(logger)
+	initialInfo := trace.args.GetInfo()
+	if initialInfo == nil {
+		initialInfo = &schedulepb.ScheduleInfo{}
+	}
+	migrationRequest := migration.LegacyToCreateFromMigrationStateRequest(
+		trace.args.GetSchedule(),
+		initialInfo,
+		trace.args.GetState(),
+		trace.searchAttrs,
+		trace.memo,
+		replayStartTime,
+	)
+	seedCarriedWorkflowExecutions(executionMap, migrationRequest.GetState().GetInvokerState().GetBufferedStarts())
+	_, err := handler.TestCreateFromMigrationState(engineCtx, migrationRequest)
+	require.NoError(t, err)
+	if initialPatch := trace.args.GetInitialPatch(); initialPatch != nil {
+		applyExpectedPatch(trace.expectedSpec, initialPatch)
+		_, err = handler.PatchSchedule(engineCtx, &schedulerpb.PatchScheduleRequest{
+			NamespaceId: trace.args.GetState().GetNamespaceId(),
+			FrontendRequest: &workflowservice.PatchScheduleRequest{
+				Namespace:  trace.args.GetState().GetNamespace(),
+				ScheduleId: trace.args.GetState().GetScheduleId(),
+				Patch:      proto.CloneOf(initialPatch),
+			},
+		})
+		require.NoError(t, err)
+	}
+	processedLocalCompletions := make(map[int64]struct{})
+	for _, completion := range initialLocalCompletions {
+		applyExpectedWatchCompletion(trace.expectedSpec, completion.request, completion.response)
+		if _, handledByMigrationCallback := initialRunningWorkflowIDs[completion.request.GetExecution().GetWorkflowId()]; handledByMigrationCallback {
+			processedLocalCompletions[completion.eventID] = struct{}{}
+			continue
+		}
+		applied, err := applyObservedWatchCompletion(
+			engineCtx, rootRef, executionMap, trace.capturedIDs, completion.request, completion.response,
+		)
+		if err != nil {
+			divergences = append(divergences, completionErrorDivergence(err, completion.request, replayStartTime, true))
+			applied = true
+		}
+		if applied {
+			processedLocalCompletions[completion.eventID] = struct{}{}
+		}
+	}
+	if err := drainCHASMTasks(engine, rootRef, replayStartTime, budget); err != nil {
+		return replayBudgetExceededResult(t, result, budget, chasmStarts, err)
+	}
+	currentTime := replayStartTime
+	earlyLocalCompletions := localCompletionsByActivationEvent(trace)
+	inferredCompletions := inferredV1Completions(trace)
+	companionCompletions = filterObservedCompanionCompletions(trace, companionCompletions, replayStartTime)
+	result.ReplayInputs.CompanionCompletions = len(companionCompletions)
+	companionIndex := 0
+	applyPendingCompletions := func(now time.Time) error {
+		for {
+			appliedAny := false
+			remaining := pendingCompletions[:0]
+			for _, completion := range pendingCompletions {
+				if _, alreadyCompleted := syntheticallyCompletedWorkflowIDs[completion.request.GetExecution().GetWorkflowId()]; alreadyCompleted && !completion.bypassExecutionMap {
+					appliedAny = true
+					continue
+				}
+				applied, err := applyObservedWatchCompletion(
+					engineCtx,
+					rootRef,
+					executionMap,
+					trace.capturedIDs && !completion.bypassExecutionMap,
+					completion.request,
+					completion.response,
+				)
+				if err != nil {
+					if completion.bypassExecutionMap {
+						appliedAny = true
+						continue
+					}
+					divergences = append(divergences, completionErrorDivergence(err, completion.request, now, false))
+					applied = true
+				}
+				if applied {
+					appliedAny = true
+				} else {
+					remaining = append(remaining, completion)
+				}
+			}
+			pendingCompletions = remaining
+			if !appliedAny {
+				return nil
+			}
+			if err := drainCHASMTasks(engine, rootRef, now, budget); err != nil {
+				return err
+			}
+		}
+	}
+	if err := applyPendingCompletions(replayStartTime); err != nil {
+		return replayBudgetExceededResult(t, result, budget, chasmStarts, err)
+	}
+
+	for _, event := range trace.history.GetEvents()[1:] {
+		now := event.GetEventTime().AsTime()
+		if now.Before(currentTime) {
+			now = currentTime
+		}
+		for companionIndex < len(companionCompletions) && !companionCompletions[companionIndex].observedTime.After(now) {
+			completion := companionCompletions[companionIndex]
+			companionIndex++
+			if _, alreadyCompleted := syntheticallyCompletedWorkflowIDs[completion.request.GetExecution().GetWorkflowId()]; alreadyCompleted {
+				continue
+			}
+			if err := advanceCHASMTime(
+				engine, rootRef, timeSource, budget, &currentTime, completion.observedTime, false, applyPendingCompletions,
+			); err != nil {
+				return replayBudgetExceededResult(t, result, budget, chasmStarts, err)
+			}
+			applyExpectedWatchCompletion(trace.expectedSpec, completion.request, completion.response)
+			applied, err := applyObservedWatchCompletion(
+				engineCtx, rootRef, executionMap, trace.capturedIDs, completion.request, completion.response,
+			)
+			if err != nil {
+				divergences = append(divergences, completionErrorDivergence(err, completion.request, completion.observedTime, true))
+				applied = true
+			}
+			if !applied {
+				pendingCompletions = append(pendingCompletions, completion)
+			}
+			if err := drainCHASMTasks(engine, rootRef, completion.observedTime, budget); err != nil {
+				return replayBudgetExceededResult(t, result, budget, chasmStarts, err)
+			}
+			if err := applyPendingCompletions(completion.observedTime); err != nil {
+				return replayBudgetExceededResult(t, result, budget, chasmStarts, err)
+			}
+		}
+		for _, completion := range earlyLocalCompletions[event.GetEventId()] {
+			if _, alreadyCompleted := syntheticallyCompletedWorkflowIDs[completion.request.GetExecution().GetWorkflowId()]; alreadyCompleted {
+				processedLocalCompletions[completion.eventID] = struct{}{}
+				continue
+			}
+			applyExpectedWatchCompletion(trace.expectedSpec, completion.request, completion.response)
+			applied, err := applyObservedWatchCompletion(
+				engineCtx, rootRef, executionMap, trace.capturedIDs, completion.request, completion.response,
+			)
+			if err != nil {
+				divergences = append(divergences, completionErrorDivergence(err, completion.request, now, true))
+				processedLocalCompletions[completion.eventID] = struct{}{}
+				continue
+			}
+			if !applied {
+				pendingCompletions = append(pendingCompletions, completion)
+			}
+			processedLocalCompletions[completion.eventID] = struct{}{}
+		}
+		if inferred, ok := inferredCompletions[event.GetEventId()]; ok {
+			workflowIDs, err := applyInferredV1Completions(engineCtx, rootRef, executionMap, inferred.time)
+			if err != nil {
+				divergences = append(divergences, replayDivergence{
+					Classification: replayClassificationInconclusive,
+					Kind:           "inferred_completion",
+					Message:        err.Error(),
+					V1Time:         timePointer(inferred.time),
+				})
+			} else if len(workflowIDs) != 0 {
+				if firstInferredCompletionTime == nil {
+					firstInferredCompletionTime = timePointer(inferred.time)
+				}
+				for _, workflowID := range workflowIDs {
+					divergences = append(divergences, replayDivergence{
+						Classification:  replayClassificationInconclusive,
+						Kind:            "inferred_completion",
+						Message:         "V1 emitted a later SKIP-policy start without recording the preceding workflow completion; replay inferred only that the preceding workflow had closed",
+						WorkflowID:      workflowID,
+						V1Time:          timePointer(inferred.time),
+						KnownDifference: "completion_inferred_from_v1_start",
+					})
+				}
+			}
+		}
+		if err := advanceCHASMTime(
+			engine,
+			rootRef,
+			timeSource,
+			budget,
+			&currentTime,
+			now,
+			!isV1ExternalInput(trace, event),
+			applyPendingCompletions,
+		); err != nil {
+			return replayBudgetExceededResult(t, result, budget, chasmStarts, err)
+		}
+		switch event.GetEventType() {
+		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED:
+			if err := applyV1Signal(engineCtx, handler, trace, event); err != nil {
+				divergences = append(divergences, replayDivergence{
+					Classification: replayClassificationUnsupported,
+					Kind:           "external_input",
+					Message:        err.Error(),
+					V1Time:         timePointer(now),
+				})
+			}
+		case enumspb.EVENT_TYPE_ACTIVITY_TASK_COMPLETED:
+			if completion, ok := observedActivityCompletion(t, trace, event); ok {
+				if _, alreadyCompleted := syntheticallyCompletedWorkflowIDs[completion.request.GetExecution().GetWorkflowId()]; alreadyCompleted {
+					break
+				}
+				applyExpectedWatchCompletion(trace.expectedSpec, completion.request, completion.response)
+				applied, err := applyObservedWatchCompletion(
+					engineCtx, rootRef, executionMap, trace.capturedIDs, completion.request, completion.response,
+				)
+				if err != nil {
+					divergences = append(divergences, completionErrorDivergence(err, completion.request, now, true))
+					applied = true
+				}
+				if !applied {
+					divergences = append(divergences, replayDivergence{
+						Classification: replayClassificationTimingOnly,
+						Kind:           "completion_before_start",
+						Message:        "V1 observed workflow completion before CHASM emitted the corresponding start",
+						WorkflowID:     completion.request.GetExecution().GetWorkflowId(),
+						V1Time:         timePointer(now),
+					})
+					pendingCompletions = append(pendingCompletions, completion)
+				}
+			}
+		case enumspb.EVENT_TYPE_MARKER_RECORDED:
+			if completion, ok := trace.localWatches[event.GetEventId()]; ok {
+				if _, processed := processedLocalCompletions[event.GetEventId()]; processed {
+					break
+				}
+				if _, alreadyCompleted := syntheticallyCompletedWorkflowIDs[completion.request.GetExecution().GetWorkflowId()]; alreadyCompleted {
+					break
+				}
+				applyExpectedWatchCompletion(trace.expectedSpec, completion.request, completion.response)
+				applied, err := applyObservedWatchCompletion(
+					engineCtx, rootRef, executionMap, trace.capturedIDs, completion.request, completion.response,
+				)
+				if err != nil {
+					divergences = append(divergences, completionErrorDivergence(err, completion.request, now, true))
+					applied = true
+				}
+				if !applied {
+					divergences = append(divergences, replayDivergence{
+						Classification: replayClassificationTimingOnly,
+						Kind:           "completion_before_start",
+						Message:        "V1 observed workflow completion before CHASM emitted the corresponding start",
+						WorkflowID:     completion.request.GetExecution().GetWorkflowId(),
+						V1Time:         timePointer(now),
+					})
+					pendingCompletions = append(pendingCompletions, completion)
+				}
+			}
+		default:
+		}
+		if err := drainCHASMTasks(engine, rootRef, now, budget); err != nil {
+			return replayBudgetExceededResult(t, result, budget, chasmStarts, err)
+		}
+		if err := applyPendingCompletions(now); err != nil {
+			return replayBudgetExceededResult(t, result, budget, chasmStarts, err)
+		}
+	}
+
+	actionMu.Lock()
+	checkedAttempts := make(map[string]int, len(trace.startAttempts))
+	for _, attempt := range trace.startAttempts {
+		if attempt.workflowID != "" {
+			position := checkedAttempts[attempt.workflowID]
+			checkedAttempts[attempt.workflowID]++
+			if consumedAttempts[attempt.workflowID] <= position {
+				kind := "missing_action"
+				message := fmt.Sprintf("V1 emitted workflow start %q but CHASM did not", attempt.workflowID)
+				classification := replayClassificationSignificant
+				knownDifference := ""
+				if attempt.failed {
+					kind = "missing_action_attempt"
+					message = fmt.Sprintf("V1 attempted workflow start %q but CHASM did not", attempt.workflowID)
+					if strings.Contains(attempt.failureType, "WorkflowExecutionAlreadyStarted") {
+						classification = replayClassificationKnownCompat
+						knownDifference = "duplicate_start_attempt_avoided"
+						message += "; V1's attempt only observed that the workflow ID was already running"
+					}
+				}
+				if firstUnobservedExtraTime != nil && !attempt.time.Before(*firstUnobservedExtraTime) {
+					classification = replayClassificationInconclusive
+					knownDifference = "unobserved_extra_action_cascade"
+					message += "; an earlier CHASM-only action has no observed completion, so downstream overlap decisions are not reproducible"
+				}
+				divergences = append(divergences, replayDivergence{
+					Classification:  classification,
+					Kind:            kind,
+					Message:         message,
+					WorkflowID:      attempt.workflowID,
+					V1Time:          timePointer(attempt.time),
+					KnownDifference: knownDifference,
+				})
+			}
+		}
+	}
+	if len(startsByWorkflowID) == 0 && startIndex != len(trace.starts) {
+		divergences = append(divergences, replayDivergence{
+			Classification: replayClassificationSignificant,
+			Kind:           "action_count",
+			Message:        fmt.Sprintf("V1 emitted %d workflow starts and CHASM emitted %d", len(trace.starts), startIndex),
+		})
+	}
+	if len(trace.starts) != 0 && len(startsByWorkflowID) == 0 {
+		divergences = append(divergences, replayDivergence{
+			Classification: replayClassificationInconclusive,
+			Kind:           "action_request_unavailable",
+			Message:        "V1 history did not expose StartWorkflowExecution requests for field-level comparison",
+		})
+	}
+	for _, start := range chasmStarts {
+		result.CHASMStarts = append(result.CHASMStarts, start.workflowID)
+	}
+	result.FirstActionDifference = firstReplayActionDifference(trace.starts, chasmStarts)
+	actionMu.Unlock()
+	if len(pendingCompletions) != 0 {
+		divergences = append(divergences, replayDivergence{
+			Classification: replayClassificationInconclusive,
+			Kind:           "unapplied_completion",
+			Message:        fmt.Sprintf("%d V1 workflow completions remained beyond the replay horizon", len(pendingCompletions)),
+		})
+	}
+	_, err = chasm.ReadComponent(engineCtx, rootRef,
+		func(s *scheduler.Scheduler, chasmCtx chasm.Context, _ struct{}) (struct{}, error) {
+			expectedSchedule := normalizeScheduleForComparison(trace.expectedSpec)
+			chasmSchedule := normalizeScheduleForComparison(s.GetSchedule())
+			if !proto.Equal(expectedSchedule, chasmSchedule) {
+				fields := scheduleDifferenceFields(expectedSchedule, chasmSchedule)
+				classification := replayClassificationSignificant
+				knownDifference := ""
+				message := "final normalized schedule state differs"
+				if slices.Equal(fields, []string{"state.notes"}) &&
+					expectedSchedule.GetState().GetPaused() && chasmSchedule.GetState().GetPaused() &&
+					isGeneratedPauseOnFailureNote(expectedSchedule.GetState().GetNotes()) &&
+					isGeneratedPauseOnFailureNote(chasmSchedule.GetState().GetNotes()) {
+					classification = replayClassificationKnownCompat
+					knownDifference = "pause_on_failure_note_format"
+					message += "; both schedulers paused after a workflow failure but use different generated note text"
+				}
+				divergences = append(divergences, replayDivergence{
+					Classification:  classification,
+					Kind:            "schedule_state",
+					Message:         message,
+					Fields:          fields,
+					KnownDifference: knownDifference,
+				})
+			}
+			expectedActionCount := trace.baseActions + int64(len(trace.starts))
+			result.V1ActionCount = expectedActionCount
+			result.CHASMActionCount = s.GetInfo().GetActionCount()
+			result.CHASMState.Paused = s.GetSchedule().GetState().GetPaused()
+			result.CHASMState.MissedCatchup = s.GetInfo().GetMissedCatchupWindow()
+			result.CHASMState.OverlapSkipped = s.GetInfo().GetOverlapSkipped()
+			result.CHASMState.BufferDropped = s.GetInfo().GetBufferDropped()
+			if lastProcessedTime := s.Generator.Get(chasmCtx).GetLastProcessedTime(); lastProcessedTime != nil {
+				result.CHASMState.LastProcessedTime = timePointer(lastProcessedTime.AsTime())
+			}
+			for _, start := range s.Invoker.Get(chasmCtx).GetBufferedStarts() {
+				result.CHASMState.BufferedStarts = append(result.CHASMState.BufferedStarts, fmt.Sprintf(
+					"workflow=%s run=%s completed=%t",
+					start.GetWorkflowId(),
+					start.GetRunId(),
+					start.GetCompleted() != nil,
+				))
+			}
+			if expectedActionCount != s.GetInfo().GetActionCount() {
+				classification := replayClassificationSignificant
+				knownDifference := ""
+				message := fmt.Sprintf(
+					"V1 action count is %d and CHASM action count is %d",
+					expectedActionCount,
+					s.GetInfo().GetActionCount(),
+				)
+				if firstUnobservedExtraTime != nil {
+					classification = replayClassificationInconclusive
+					knownDifference = "unobserved_extra_action_cascade"
+					message += "; the final count follows a CHASM-only action whose completion is absent from V1 history"
+				}
+				divergences = append(divergences, replayDivergence{
+					Classification:  classification,
+					Kind:            "action_count",
+					Message:         message,
+					KnownDifference: knownDifference,
+				})
+			}
+			return struct{}{}, nil
+		}, struct{}{})
+	require.NoError(t, err)
+	result.Divergences = deduplicateReplayDivergences(divergences)
+	annotateKnownCompatibilityDivergences(result.Divergences, result.Cohorts, result.V1ActionCount, result.CHASMActionCount)
+	annotateFirstActionEvidence(result.Divergences, result.FirstActionDifference, trace)
+	annotatePersistedNextTimeCache(result.Divergences, result.FirstActionDifference, trace.history)
+	annotateActionSequenceCascade(result.Divergences, result.FirstActionDifference, firstDifferenceFollowsLocalWatch(trace, result.FirstActionDifference))
+	annotateHistoryRunBoundary(result.Divergences, result.FirstActionDifference, trace.history)
+	result.Classification = classifyReplayDivergences(result.Divergences)
+	result.ReplayStats = budget.stats
+	return result
+}
+
+func scheduleDifferenceFields(v1, chasmSchedule *schedulepb.Schedule) []string {
+	var fields []string
+	if !proto.Equal(v1.GetSpec(), chasmSchedule.GetSpec()) {
+		fields = append(fields, "spec")
+	}
+	if !proto.Equal(v1.GetAction(), chasmSchedule.GetAction()) {
+		fields = append(fields, "action")
+	}
+	if !proto.Equal(v1.GetPolicies(), chasmSchedule.GetPolicies()) {
+		fields = append(fields, "policies")
+	}
+	if v1.GetState().GetPaused() != chasmSchedule.GetState().GetPaused() {
+		fields = append(fields, "state.paused")
+	}
+	if v1.GetState().GetLimitedActions() != chasmSchedule.GetState().GetLimitedActions() {
+		fields = append(fields, "state.limited_actions")
+	}
+	if v1.GetState().GetRemainingActions() != chasmSchedule.GetState().GetRemainingActions() {
+		fields = append(fields, "state.remaining_actions")
+	}
+	if v1.GetState().GetNotes() != chasmSchedule.GetState().GetNotes() {
+		fields = append(fields, "state.notes")
+	}
+	return fields
+}
+
+func summarizeReplayInputs(trace *v1HistoryTrace) replayInputSummary {
+	summary := replayInputSummary{
+		HistoryStartTime:        trace.startTime,
+		FirstDecisionTime:       v1FirstDecisionTime(trace.history, trace.startTime),
+		OverlapPolicy:           trace.args.GetSchedule().GetPolicies().GetOverlapPolicy().String(),
+		BufferedStarts:          len(trace.args.GetState().GetBufferedStarts()),
+		RunningWorkflows:        len(trace.args.GetInfo().GetRunningWorkflows()),
+		OngoingBackfills:        len(trace.args.GetState().GetOngoingBackfills()),
+		TriggerImmediately:      trace.args.GetInitialPatch().GetTriggerImmediately() != nil,
+		InitialPatchBackfills:   len(trace.args.GetInitialPatch().GetBackfillRequest()),
+		Paused:                  trace.args.GetSchedule().GetState().GetPaused(),
+		LimitedActions:          trace.args.GetSchedule().GetState().GetLimitedActions(),
+		RemainingActions:        trace.args.GetSchedule().GetState().GetRemainingActions(),
+		CalendarSpecs:           len(trace.args.GetSchedule().GetSpec().GetCalendar()),
+		StructuredCalendarSpecs: len(trace.args.GetSchedule().GetSpec().GetStructuredCalendar()),
+		IntervalSpecs:           len(trace.args.GetSchedule().GetSpec().GetInterval()),
+		CronExpressions:         len(trace.args.GetSchedule().GetSpec().GetCronString()),
+		TimeZoneName:            trace.args.GetSchedule().GetSpec().GetTimezoneName(),
+		PersistedNextTimeCache:  historyHasV1NextTimeCache(trace.history),
+	}
+	if jitter := trace.args.GetSchedule().GetSpec().GetJitter(); jitter != nil {
+		summary.Jitter = jitter.AsDuration().String()
+	}
+	if catchupWindow := trace.args.GetSchedule().GetPolicies().GetCatchupWindow(); catchupWindow != nil {
+		summary.CatchupWindow = catchupWindow.AsDuration().String()
+	}
+	if lastProcessedTime := trace.args.GetState().GetLastProcessedTime(); lastProcessedTime != nil {
+		summary.LastProcessedTime = timePointer(lastProcessedTime.AsTime())
+	}
+	if createTime := trace.args.GetInfo().GetCreateTime(); createTime != nil {
+		summary.CreateTime = timePointer(createTime.AsTime())
+	}
+	if updateTime := trace.args.GetInfo().GetUpdateTime(); updateTime != nil {
+		summary.UpdateTime = timePointer(updateTime.AsTime())
+	}
+	for _, start := range trace.args.GetState().GetBufferedStarts() {
+		buffered := replayBufferedStartSummary{
+			OverlapPolicy: start.GetOverlapPolicy().String(),
+			Manual:        start.GetManual(),
+			HasWorkflowID: start.GetWorkflowId() != "",
+			HasRunID:      start.GetRunId() != "",
+		}
+		if nominalTime := start.GetNominalTime(); nominalTime != nil {
+			buffered.NominalTime = timePointer(nominalTime.AsTime())
+		}
+		if actualTime := start.GetActualTime(); actualTime != nil {
+			buffered.ActualTime = timePointer(actualTime.AsTime())
+		}
+		if desiredTime := start.GetDesiredTime(); desiredTime != nil {
+			buffered.DesiredTime = timePointer(desiredTime.AsTime())
+		}
+		summary.InitialBufferedStarts = append(summary.InitialBufferedStarts, buffered)
+	}
+	return summary
+}
+
+func isV1ExternalInput(trace *v1HistoryTrace, event *historypb.HistoryEvent) bool {
+	switch event.GetEventType() {
+	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED:
+		return true
+	case enumspb.EVENT_TYPE_ACTIVITY_TASK_COMPLETED:
+		_, ok := trace.watches[event.GetActivityTaskCompletedEventAttributes().GetScheduledEventId()]
+		return ok
+	case enumspb.EVENT_TYPE_MARKER_RECORDED:
+		_, ok := trace.localWatches[event.GetEventId()]
+		return ok
+	default:
+		return false
+	}
+}
+
+func advanceCHASMTime(
+	engine *chasmtest.Engine,
+	rootRef chasm.ComponentRef,
+	timeSource *clock.EventTimeSource,
+	budget *replayBudget,
+	currentTime *time.Time,
+	target time.Time,
+	inclusive bool,
+	afterDrain func(time.Time) error,
+) error {
+	for {
+		next, ok, err := engine.NextTaskTime(rootRef, *currentTime)
+		if err != nil {
+			return err
+		}
+		if !ok || next.After(target) || (!inclusive && next.Equal(target)) {
+			break
+		}
+		if err := budget.addDeadline(); err != nil {
+			return err
+		}
+		timeSource.Update(next)
+		*currentTime = next
+		if err := drainCHASMTasks(engine, rootRef, next, budget); err != nil {
+			return err
+		}
+		if err := afterDrain(next); err != nil {
+			return err
+		}
+	}
+	timeSource.Update(target)
+	*currentTime = target
+	return nil
+}
+
+func normalizeScheduleForComparison(schedule *schedulepb.Schedule) *schedulepb.Schedule {
+	normalized := proto.CloneOf(schedule)
+	if normalized.GetState() != nil {
+		// Workflow history exposes action decisions but not enough information to
+		// reconstruct whether every observed start consumed the scheduled-action
+		// limit (manual triggers and backfills do not). Compare durable
+		// configuration here and report action counts separately.
+		normalized.State.LimitedActions = false
+		normalized.State.RemainingActions = 0
+	}
+	if proto.Equal(normalized.GetPolicies(), &schedulepb.SchedulePolicies{}) {
+		normalized.Policies = nil
+	}
+	if proto.Equal(normalized.GetState(), &schedulepb.ScheduleState{}) {
+		normalized.State = nil
+	}
+	return normalized
+}
+
+func normalizeStartWorkflowRequest(request *workflowservice.StartWorkflowExecutionRequest) *workflowservice.StartWorkflowExecutionRequest {
+	if request == nil {
+		return nil
+	}
+	normalized := proto.CloneOf(request)
+	normalized.Identity = ""
+	normalized.Namespace = ""
+	normalized.RequestId = ""
+	normalized.CompletionCallbacks = nil
+	normalized.RequestEagerExecution = false
+	if len(normalized.GetLastCompletionResult().GetPayloads()) == 0 {
+		normalized.LastCompletionResult = nil
+	}
+	for name, payload := range normalized.GetSearchAttributes().GetIndexedFields() {
+		if name == sadefs.TemporalScheduledStartTime {
+			if scheduledTime, ok := decodeDateTimeSearchAttribute(payload); ok {
+				encoded, err := sadefs.EncodeValue(scheduledTime.Truncate(time.Second), enumspb.INDEXED_VALUE_TYPE_DATETIME)
+				if err == nil {
+					normalized.SearchAttributes.IndexedFields[name] = encoded
+					payload = encoded
+				}
+			}
+		}
+		if strings.HasPrefix(name, "TemporalScheduled") {
+			delete(payload.Metadata, "type")
+		}
+	}
+	return normalized
+}
+
+func startWorkflowRequestDifferenceFields(
+	v1 *workflowservice.StartWorkflowExecutionRequest,
+	chasmRequest *workflowservice.StartWorkflowExecutionRequest,
+) []string {
+	v1 = normalizeStartWorkflowRequest(v1)
+	chasmRequest = normalizeStartWorkflowRequest(chasmRequest)
+	if v1 == nil || chasmRequest == nil {
+		return []string{"request"}
+	}
+	var fields []string
+	addScalar := func(name string, different bool) {
+		if different {
+			fields = append(fields, name)
+		}
+	}
+	addProto := func(name string, v1Value, chasmValue proto.Message) {
+		if !proto.Equal(v1Value, chasmValue) {
+			fields = append(fields, name)
+		}
+	}
+	addScalar("workflow_id", v1.GetWorkflowId() != chasmRequest.GetWorkflowId())
+	addProto("workflow_type", v1.GetWorkflowType(), chasmRequest.GetWorkflowType())
+	addProto("task_queue", v1.GetTaskQueue(), chasmRequest.GetTaskQueue())
+	addProto("input", v1.GetInput(), chasmRequest.GetInput())
+	addProto("workflow_execution_timeout", v1.GetWorkflowExecutionTimeout(), chasmRequest.GetWorkflowExecutionTimeout())
+	addProto("workflow_run_timeout", v1.GetWorkflowRunTimeout(), chasmRequest.GetWorkflowRunTimeout())
+	addProto("workflow_task_timeout", v1.GetWorkflowTaskTimeout(), chasmRequest.GetWorkflowTaskTimeout())
+	addScalar("workflow_id_reuse_policy", v1.GetWorkflowIdReusePolicy() != chasmRequest.GetWorkflowIdReusePolicy())
+	addScalar("workflow_id_conflict_policy", v1.GetWorkflowIdConflictPolicy() != chasmRequest.GetWorkflowIdConflictPolicy())
+	addProto("retry_policy", v1.GetRetryPolicy(), chasmRequest.GetRetryPolicy())
+	addScalar("cron_schedule", v1.GetCronSchedule() != chasmRequest.GetCronSchedule())
+	addProto("memo", v1.GetMemo(), chasmRequest.GetMemo())
+	addProto("search_attributes", v1.GetSearchAttributes(), chasmRequest.GetSearchAttributes())
+	addProto("header", v1.GetHeader(), chasmRequest.GetHeader())
+	addProto("continued_failure", v1.GetContinuedFailure(), chasmRequest.GetContinuedFailure())
+	addProto("last_completion_result", v1.GetLastCompletionResult(), chasmRequest.GetLastCompletionResult())
+	addProto("workflow_start_delay", v1.GetWorkflowStartDelay(), chasmRequest.GetWorkflowStartDelay())
+	addProto("user_metadata", v1.GetUserMetadata(), chasmRequest.GetUserMetadata())
+	addProto("versioning_override", v1.GetVersioningOverride(), chasmRequest.GetVersioningOverride())
+	addProto("on_conflict_options", v1.GetOnConflictOptions(), chasmRequest.GetOnConflictOptions())
+	addProto("priority", v1.GetPriority(), chasmRequest.GetPriority())
+	addProto("eager_worker_deployment_options", v1.GetEagerWorkerDeploymentOptions(), chasmRequest.GetEagerWorkerDeploymentOptions())
+	addProto("time_skipping_config", v1.GetTimeSkippingConfig(), chasmRequest.GetTimeSkippingConfig())
+	linksDiffer := len(v1.GetLinks()) != len(chasmRequest.GetLinks())
+	if !linksDiffer {
+		for index := range v1.GetLinks() {
+			if !proto.Equal(v1.GetLinks()[index], chasmRequest.GetLinks()[index]) {
+				linksDiffer = true
+				break
+			}
+		}
+	}
+	addScalar("links", linksDiffer)
+	if len(fields) == 0 && !proto.Equal(v1, chasmRequest) {
+		fields = append(fields, "other")
+	}
+	return fields
+}
+
+func startWorkflowRequestFieldDifferences(
+	v1 *workflowservice.StartWorkflowExecutionRequest,
+	chasmRequest *workflowservice.StartWorkflowExecutionRequest,
+	fields []string,
+) []replayFieldDifference {
+	v1 = normalizeStartWorkflowRequest(v1)
+	chasmRequest = normalizeStartWorkflowRequest(chasmRequest)
+	differences := make([]replayFieldDifference, 0, len(fields))
+	for _, field := range fields {
+		difference := replayFieldDifference{
+			Field: field,
+			V1:    summarizeReplayValue(startWorkflowRequestFieldMessage(v1, field)),
+			CHASM: summarizeReplayValue(startWorkflowRequestFieldMessage(chasmRequest, field)),
+		}
+		switch field {
+		case "search_attributes":
+			difference.SafeDetails = searchAttributeSafeDifferences(v1.GetSearchAttributes(), chasmRequest.GetSearchAttributes())
+		case "continued_failure":
+			difference.SafeDetails = []string{
+				fmt.Sprintf("v1_failure_info=%T", v1.GetContinuedFailure().GetFailureInfo()),
+				fmt.Sprintf("chasm_failure_info=%T", chasmRequest.GetContinuedFailure().GetFailureInfo()),
+			}
+		default:
+		}
+		differences = append(differences, difference)
+	}
+	return differences
+}
+
+func startWorkflowRequestFieldMessage(
+	request *workflowservice.StartWorkflowExecutionRequest,
+	field string,
+) proto.Message {
+	if request == nil {
+		return nil
+	}
+	switch field {
+	case "workflow_type":
+		return request.GetWorkflowType()
+	case "task_queue":
+		return request.GetTaskQueue()
+	case "input":
+		return request.GetInput()
+	case "workflow_execution_timeout":
+		return request.GetWorkflowExecutionTimeout()
+	case "workflow_run_timeout":
+		return request.GetWorkflowRunTimeout()
+	case "workflow_task_timeout":
+		return request.GetWorkflowTaskTimeout()
+	case "retry_policy":
+		return request.GetRetryPolicy()
+	case "memo":
+		return request.GetMemo()
+	case "search_attributes":
+		return request.GetSearchAttributes()
+	case "header":
+		return request.GetHeader()
+	case "continued_failure":
+		return request.GetContinuedFailure()
+	case "last_completion_result":
+		return request.GetLastCompletionResult()
+	case "workflow_start_delay":
+		return request.GetWorkflowStartDelay()
+	case "user_metadata":
+		return request.GetUserMetadata()
+	case "versioning_override":
+		return request.GetVersioningOverride()
+	case "on_conflict_options":
+		return request.GetOnConflictOptions()
+	case "priority":
+		return request.GetPriority()
+	case "eager_worker_deployment_options":
+		return request.GetEagerWorkerDeploymentOptions()
+	case "time_skipping_config":
+		return request.GetTimeSkippingConfig()
+	default:
+		return nil
+	}
+}
+
+func summarizeReplayValue(message proto.Message) replayValueSummary {
+	if message == nil || !message.ProtoReflect().IsValid() {
+		return replayValueSummary{}
+	}
+	data, err := proto.MarshalOptions{Deterministic: true}.Marshal(message)
+	if err != nil {
+		return replayValueSummary{Present: true}
+	}
+	digest := sha256.Sum256(data)
+	summary := replayValueSummary{Present: true, Count: 1, Digest: fmt.Sprintf("sha256:%x", digest[:12])}
+	var payloads []*commonpb.Payload
+	switch value := message.(type) {
+	case *commonpb.Payloads:
+		payloads = value.GetPayloads()
+		summary.Count = len(payloads)
+	case *commonpb.SearchAttributes:
+		summary.Count = len(value.GetIndexedFields())
+		for _, payload := range value.GetIndexedFields() {
+			payloads = append(payloads, payload)
+		}
+	case *commonpb.Memo:
+		summary.Count = len(value.GetFields())
+		for _, payload := range value.GetFields() {
+			payloads = append(payloads, payload)
+		}
+	case *commonpb.Header:
+		summary.Count = len(value.GetFields())
+		for _, payload := range value.GetFields() {
+			payloads = append(payloads, payload)
+		}
+	default:
+	}
+	encodings := make(map[string]struct{})
+	for _, payload := range payloads {
+		if encoding := string(payload.GetMetadata()["encoding"]); encoding != "" {
+			encodings[encoding] = struct{}{}
+		}
+	}
+	for encoding := range encodings {
+		summary.Encodings = append(summary.Encodings, encoding)
+	}
+	sort.Strings(summary.Encodings)
+	return summary
+}
+
+func searchAttributeSafeDifferences(v1, chasmValue *commonpb.SearchAttributes) []string {
+	keys := make(map[string]struct{})
+	for key := range v1.GetIndexedFields() {
+		keys[key] = struct{}{}
+	}
+	for key := range chasmValue.GetIndexedFields() {
+		keys[key] = struct{}{}
+	}
+	orderedKeys := make([]string, 0, len(keys))
+	for key := range keys {
+		orderedKeys = append(orderedKeys, key)
+	}
+	sort.Strings(orderedKeys)
+	result := make([]string, 0, len(orderedKeys))
+	for _, key := range orderedKeys {
+		v1Payload, v1Present := v1.GetIndexedFields()[key]
+		chasmPayload, chasmPresent := chasmValue.GetIndexedFields()[key]
+		if proto.Equal(v1Payload, chasmPayload) {
+			continue
+		}
+		keyReference := replayOpaqueID(key)
+		if sadefs.IsReserved(key) {
+			keyReference = key
+		}
+		if key == sadefs.TemporalScheduledStartTime {
+			v1Time, v1OK := decodeDateTimeSearchAttribute(v1Payload)
+			chasmTime, chasmOK := decodeDateTimeSearchAttribute(chasmPayload)
+			if v1OK && chasmOK {
+				result = append(result, fmt.Sprintf("%s:v1=%s,chasm=%s", key, v1Time.Format(time.RFC3339Nano), chasmTime.Format(time.RFC3339Nano)))
+				continue
+			}
+		}
+		result = append(result, fmt.Sprintf("%s:v1_present=%t,chasm_present=%t", keyReference, v1Present, chasmPresent))
+	}
+	return result
+}
+
+func decodeDateTimeSearchAttribute(payload *commonpb.Payload) (time.Time, bool) {
+	value, err := sadefs.DecodeValue(payload, enumspb.INDEXED_VALUE_TYPE_DATETIME, false)
+	if err != nil {
+		return time.Time{}, false
+	}
+	decoded, ok := value.(time.Time)
+	return decoded, ok
+}
+
+func replayHistoryCohorts(trace *v1HistoryTrace) []string {
+	cohorts := make(map[string]struct{})
+	if len(trace.failedStarts) != 0 {
+		cohorts["start_failure"] = struct{}{}
+	}
+	spec := trace.args.GetSchedule().GetSpec()
+	if len(spec.GetInterval()) != 0 {
+		cohorts["spec_interval"] = struct{}{}
+	}
+	if len(spec.GetCalendar()) != 0 || len(spec.GetStructuredCalendar()) != 0 {
+		cohorts["spec_calendar"] = struct{}{}
+	}
+	if len(spec.GetCronString()) != 0 {
+		cohorts["spec_cron"] = struct{}{}
+	}
+	if trace.args.GetSchedule().GetState().GetPaused() {
+		cohorts["paused"] = struct{}{}
+	}
+	overlap := trace.args.GetSchedule().GetPolicies().GetOverlapPolicy().String()
+	cohorts["overlap_"+strings.ToLower(strings.TrimPrefix(overlap, "SCHEDULE_OVERLAP_POLICY_"))] = struct{}{}
+	for _, event := range trace.history.GetEvents() {
+		if event.GetEventType() != enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED {
+			continue
+		}
+		attributes := event.GetWorkflowExecutionSignaledEventAttributes()
+		switch attributes.GetSignalName() {
+		case legacyscheduler.SignalNameUpdate:
+			cohorts["update"] = struct{}{}
+		case legacyscheduler.SignalNamePatch:
+			var patch schedulepb.SchedulePatch
+			if converter.GetDefaultDataConverter().FromPayloads(attributes.GetInput(), &patch) == nil {
+				if len(patch.GetBackfillRequest()) != 0 {
+					cohorts["backfill"] = struct{}{}
+				}
+				if patch.GetPause() != "" || patch.GetUnpause() != "" {
+					cohorts["pause_interaction"] = struct{}{}
+				}
+			}
+		}
+	}
+	result := make([]string, 0, len(cohorts))
+	for cohort := range cohorts {
+		result = append(result, cohort)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func timePointer(value time.Time) *time.Time {
+	value = value.UTC()
+	return &value
+}
+
+func newReplayBudget(t *testing.T) *replayBudget {
+	t.Helper()
+	return &replayBudget{
+		maxDeadlines: replayLimitFromEnvironment(t, replayMaxDeadlinesEnv, defaultReplayMaxDeadlines),
+		maxTasks:     replayLimitFromEnvironment(t, replayMaxTasksEnv, defaultReplayMaxTasks),
+		maxStarts:    replayLimitFromEnvironment(t, replayMaxStartsEnv, defaultReplayMaxStarts),
+	}
+}
+
+func replayLimitFromEnvironment(t *testing.T, name string, defaultValue int) int {
+	t.Helper()
+	value := os.Getenv(name)
+	if value == "" {
+		return defaultValue
+	}
+	limit, err := strconv.Atoi(value)
+	require.NoError(t, err, "%s must be an integer", name)
+	require.Positive(t, limit, "%s must be positive", name)
+	return limit
+}
+
+func (b *replayBudget) addDeadline() error {
+	b.stats.Deadlines++
+	return b.check("deadlines", b.stats.Deadlines, b.maxDeadlines)
+}
+
+func (b *replayBudget) addTasks(pure, sideEffect int) error {
+	b.stats.PureTasks += pure
+	b.stats.SideEffectTasks += sideEffect
+	return b.check("tasks", b.stats.PureTasks+b.stats.SideEffectTasks, b.maxTasks)
+}
+
+func (b *replayBudget) addStart() {
+	b.stats.Starts++
+	_ = b.check("starts", b.stats.Starts, b.maxStarts)
+}
+
+func (b *replayBudget) check(dimension string, value, limit int) error {
+	if b.exceeded != nil {
+		return b.exceeded
+	}
+	if value <= limit {
+		return nil
+	}
+	b.exceeded = &replayBudgetExceededError{dimension: dimension, limit: limit}
+	b.stats.BudgetExceeded = dimension
+	return b.exceeded
+}
+
+func replayBudgetExceededResult(
+	t *testing.T,
+	result replayCaseResult,
+	budget *replayBudget,
+	chasmStarts []chasmStart,
+	err error,
+) replayCaseResult {
+	t.Helper()
+	var budgetErr *replayBudgetExceededError
+	require.ErrorAs(t, err, &budgetErr)
+	result.ReplayStats = budget.stats
+	for _, start := range chasmStarts {
+		result.CHASMStarts = append(result.CHASMStarts, start.workflowID)
+	}
+	result.Classification = replayClassificationInconclusive
+	result.Divergences = []replayDivergence{{
+		Classification: replayClassificationInconclusive,
+		Kind:           "replay_budget_exceeded",
+		Message:        budgetErr.Error(),
+	}}
+	return result
+}
+
+func deduplicateReplayDivergences(divergences []replayDivergence) []replayDivergence {
+	seen := make(map[string]struct{}, len(divergences))
+	result := make([]replayDivergence, 0, len(divergences))
+	for _, divergence := range divergences {
+		key := fmt.Sprintf("%s\x00%s\x00%s", divergence.Classification, divergence.Kind, divergence.WorkflowID)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, divergence)
+	}
+	return result
+}
+
+func firstReplayActionDifference(v1Starts []observedStart, chasmStarts []chasmStart) *replayActionDifference {
+	shared := min(len(v1Starts), len(chasmStarts))
+	index := 0
+	for index < shared && v1Starts[index].workflowID == chasmStarts[index].workflowID {
+		index++
+	}
+	if index == len(v1Starts) && index == len(chasmStarts) {
+		return nil
+	}
+	difference := &replayActionDifference{Index: index}
+	if index < len(v1Starts) {
+		difference.V1WorkflowID = v1Starts[index].workflowID
+		difference.V1Time = timePointer(v1Starts[index].time)
+	}
+	if index < len(chasmStarts) {
+		difference.CHASMWorkflowID = chasmStarts[index].workflowID
+		difference.CHASMTime = timePointer(chasmStarts[index].time)
+	}
+	return difference
+}
+
+func firstDifferenceFollowsLocalWatch(trace *v1HistoryTrace, difference *replayActionDifference) bool {
+	if difference == nil || difference.V1WorkflowID == "" {
+		return false
+	}
+	for _, attempt := range trace.startAttempts {
+		if attempt.workflowID != difference.V1WorkflowID || attempt.workflowTaskCompletedEventID == 0 {
+			continue
+		}
+		for _, completion := range trace.localWatches {
+			if completion.workflowTaskCompletedEventID == attempt.workflowTaskCompletedEventID &&
+				completion.response.GetStatus() != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func workflowTaskContainsTerminalLocalWatch(trace *v1HistoryTrace, completedEventID int64) bool {
+	for _, completion := range trace.localWatches {
+		if completion.workflowTaskCompletedEventID == completedEventID &&
+			completion.response.GetStatus() != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING {
+			return true
+		}
+	}
+	return false
+}
+
+func replayFailureType(failure *failurepb.Failure) string {
+	for failure != nil {
+		if failure.GetApplicationFailureInfo().GetType() != "" {
+			return failure.GetApplicationFailureInfo().GetType()
+		}
+		failure = failure.GetCause()
+	}
+	return ""
+}
+
+func annotateActionSequenceCascade(
+	divergences []replayDivergence,
+	difference *replayActionDifference,
+	followsLocalWatch bool,
+) {
+	if difference == nil {
+		return
+	}
+	v1RootReviewed := false
+	chasmRootReviewed := false
+	for index := range divergences {
+		divergence := &divergences[index]
+		v1RootReviewed = v1RootReviewed ||
+			(divergence.Kind == "missing_action" && divergence.WorkflowID == difference.V1WorkflowID &&
+				divergence.Classification != replayClassificationSignificant)
+		chasmRootReviewed = chasmRootReviewed ||
+			(divergence.Kind == "extra_action" && divergence.WorkflowID == difference.CHASMWorkflowID &&
+				divergence.Classification != replayClassificationSignificant)
+	}
+	for index := range divergences {
+		divergence := &divergences[index]
+		if divergence.Classification != replayClassificationSignificant {
+			continue
+		}
+		isV1Root := divergence.Kind == "missing_action" && divergence.WorkflowID == difference.V1WorkflowID
+		isCHASMRoot := divergence.Kind == "extra_action" && divergence.WorkflowID == difference.CHASMWorkflowID
+		if followsLocalWatch && (isV1Root || isCHASMRoot) {
+			divergence.Classification = replayClassificationInconclusive
+			divergence.KnownDifference = "v1_local_watch_ordering"
+			divergence.Message += "; V1 applied a local WatchWorkflow completion earlier in the same workflow task before selecting this action"
+			continue
+		}
+		if (isV1Root && chasmRootReviewed) || (isCHASMRoot && v1RootReviewed) {
+			divergence.Classification = replayClassificationInconclusive
+			divergence.KnownDifference = "action_sequence_cascade"
+			divergence.Message += "; this is the counterpart of an already-explained first action difference"
+			continue
+		}
+		if isV1Root || isCHASMRoot {
+			continue
+		}
+		switch divergence.Kind {
+		case "action_request", "missing_action", "extra_action", "action_count":
+			divergence.Classification = replayClassificationInconclusive
+			divergence.KnownDifference = "action_sequence_cascade"
+			divergence.Message += "; request and overlap state are no longer comparable after the first action identity difference"
+		}
+	}
+}
+
+func annotateFirstActionEvidence(
+	divergences []replayDivergence,
+	difference *replayActionDifference,
+	trace *v1HistoryTrace,
+) {
+	if difference == nil || difference.CHASMWorkflowID == "" || difference.CHASMTime == nil {
+		return
+	}
+	classification := replayClassification("")
+	knownDifference := ""
+	message := ""
+	if firstDifferenceIsImmediateTrigger(trace.history, *difference.CHASMTime) {
+		classification = replayClassificationKnownCompat
+		knownDifference = "legacy_immediate_trigger_timestamp"
+		message = "; V1 selected the trigger time when its workflow task executed while CHASM used the persisted request timestamp"
+	} else if workflowTaskTimedOutForDeadline(trace.history, *difference.CHASMTime) {
+		classification = replayClassificationInconclusive
+		knownDifference = "v1_workflow_task_timeout"
+		message = "; a V1 workflow task timed out after this deadline, so an unrecorded local start attempt cannot be excluded"
+	} else if catchupWindow := effectiveV1CatchupWindowAt(trace, *difference.CHASMTime); catchupWindow != nil && *catchupWindow <= 0 {
+		classification = replayClassificationKnownCompat
+		knownDifference = "zero_catchup_window"
+		message = "; V1 clamps an explicit zero catchup window to its minimum while CHASM resolves it to the default"
+	}
+	if classification == "" {
+		return
+	}
+	for index := range divergences {
+		divergence := &divergences[index]
+		if divergence.Classification == replayClassificationSignificant &&
+			divergence.Kind == "extra_action" && divergence.WorkflowID == difference.CHASMWorkflowID {
+			divergence.Classification = classification
+			divergence.KnownDifference = knownDifference
+			divergence.Message += message
+		}
+	}
+}
+
+func annotatePersistedNextTimeCache(
+	divergences []replayDivergence,
+	difference *replayActionDifference,
+	history *historypb.History,
+) {
+	if difference == nil || !historyHasV1NextTimeCache(history) {
+		return
+	}
+	for index := range divergences {
+		divergence := &divergences[index]
+		if divergence.Classification != replayClassificationSignificant {
+			continue
+		}
+		if divergence.Kind == "missing_action" && divergence.WorkflowID == difference.V1WorkflowID ||
+			divergence.Kind == "extra_action" && divergence.WorkflowID == difference.CHASMWorkflowID {
+			divergence.Classification = replayClassificationInconclusive
+			divergence.KnownDifference = "v1_persisted_next_time_cache"
+			divergence.Message += "; V1 selected this action from a history-persisted NextTimeCache whose values are not replayed into the CHASM spec processor"
+		}
+	}
+}
+
+func historyHasV1NextTimeCache(history *historypb.History) bool {
+	for _, event := range history.GetEvents() {
+		attributes := event.GetMarkerRecordedEventAttributes()
+		if attributes.GetMarkerName() != "SideEffect" {
+			continue
+		}
+		for _, payloads := range attributes.GetDetails() {
+			for _, payload := range payloads.GetPayloads() {
+				if string(payload.GetMetadata()["messageType"]) == "temporal.server.api.schedule.v1.NextTimeCache" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func firstDifferenceIsImmediateTrigger(history *historypb.History, target time.Time) bool {
+	for _, event := range history.GetEvents() {
+		if event.GetEventType() != enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED ||
+			event.GetEventTime().AsTime() != target ||
+			event.GetWorkflowExecutionSignaledEventAttributes().GetSignalName() != legacyscheduler.SignalNamePatch {
+			continue
+		}
+		var patch schedulepb.SchedulePatch
+		if converter.GetDefaultDataConverter().FromPayloads(
+			event.GetWorkflowExecutionSignaledEventAttributes().GetInput(), &patch,
+		) == nil && patch.GetTriggerImmediately() != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func workflowTaskTimedOutForDeadline(history *historypb.History, target time.Time) bool {
+	foundTimer := false
+	for _, event := range history.GetEvents() {
+		if !foundTimer {
+			if event.GetEventType() == enumspb.EVENT_TYPE_TIMER_FIRED {
+				eventTime := event.GetEventTime().AsTime()
+				foundTimer = !eventTime.Before(target) && eventTime.Sub(target) <= time.Minute
+			}
+			continue
+		}
+		switch event.GetEventType() {
+		case enumspb.EVENT_TYPE_WORKFLOW_TASK_TIMED_OUT:
+			return true
+		case enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED:
+			return false
+		default:
+		}
+	}
+	return false
+}
+
+func effectiveV1CatchupWindowAt(trace *v1HistoryTrace, target time.Time) *time.Duration {
+	var catchupWindow *time.Duration
+	set := func(duration *durationpb.Duration) {
+		if duration == nil {
+			catchupWindow = nil
+			return
+		}
+		value := duration.AsDuration()
+		catchupWindow = &value
+	}
+	set(trace.args.GetSchedule().GetPolicies().GetCatchupWindow())
+	for _, event := range trace.history.GetEvents() {
+		if event.GetEventTime().AsTime().After(target) ||
+			event.GetWorkflowExecutionSignaledEventAttributes().GetSignalName() != legacyscheduler.SignalNameUpdate {
+			continue
+		}
+		var update schedulespb.FullUpdateRequest
+		if converter.GetDefaultDataConverter().FromPayloads(
+			event.GetWorkflowExecutionSignaledEventAttributes().GetInput(), &update,
+		) == nil {
+			set(update.GetSchedule().GetPolicies().GetCatchupWindow())
+		}
+	}
+	return catchupWindow
+}
+
+func annotateHistoryRunBoundary(
+	divergences []replayDivergence,
+	difference *replayActionDifference,
+	history *historypb.History,
+) {
+	events := history.GetEvents()
+	if difference == nil || difference.V1WorkflowID != "" || difference.CHASMWorkflowID == "" || len(events) == 0 ||
+		events[len(events)-1].GetEventType() != enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW {
+		return
+	}
+	for index := range divergences {
+		divergence := &divergences[index]
+		if divergence.Classification == replayClassificationSignificant &&
+			divergence.Kind == "extra_action" && divergence.WorkflowID == difference.CHASMWorkflowID {
+			divergence.Classification = replayClassificationInconclusive
+			divergence.KnownDifference = "history_run_boundary"
+			divergence.Message += "; the V1 run continued as new immediately after this deadline, so the action may be recorded in the next history"
+		}
+	}
+}
+
+func classifyReplayDivergences(divergences []replayDivergence) replayClassification {
+	classification := replayClassificationMatch
+	for _, divergence := range divergences {
+		if replayClassificationSeverity(divergence.Classification) > replayClassificationSeverity(classification) {
+			classification = divergence.Classification
+		}
+	}
+	return classification
+}
+
+func annotateKnownCompatibilityDivergences(
+	divergences []replayDivergence,
+	cohorts []string,
+	v1ActionCount int64,
+	chasmActionCount int64,
+) {
+	usesSkip := slices.Contains(cohorts, "overlap_skip") || slices.Contains(cohorts, "overlap_unspecified")
+	var missingAction, extraAction *replayDivergence
+	if usesSkip && v1ActionCount == chasmActionCount {
+		for index := range divergences {
+			divergence := &divergences[index]
+			if divergence.Classification != replayClassificationSignificant {
+				continue
+			}
+			switch divergence.Kind {
+			case "missing_action":
+				if missingAction != nil {
+					missingAction = nil
+					usesSkip = false
+				} else {
+					missingAction = divergence
+				}
+			case "extra_action":
+				if extraAction != nil {
+					extraAction = nil
+					usesSkip = false
+				} else {
+					extraAction = divergence
+				}
+			}
+		}
+	}
+	for index := range divergences {
+		divergence := &divergences[index]
+		if divergence.Classification == replayClassificationSignificant &&
+			divergence.Kind == "action_request" &&
+			slices.Equal(divergence.Fields, []string{"versioning_override"}) {
+			divergence.Classification = replayClassificationKnownCompat
+			divergence.KnownDifference = "v2_versioning_override_forwarding"
+			continue
+		}
+		if divergence.Classification == replayClassificationSignificant &&
+			divergence.Kind == "action_request" &&
+			slices.Equal(divergence.Fields, []string{"continued_failure"}) {
+			divergence.Classification = replayClassificationKnownCompat
+			divergence.KnownDifference = "terminal_failure_propagation"
+			continue
+		}
+		if usesSkip && missingAction != nil && extraAction != nil && (divergence == missingAction || divergence == extraAction) {
+			divergence.Classification = replayClassificationKnownCompat
+			divergence.KnownDifference = "skip_deadline_boundary"
+		}
+	}
+}
+
+func workflowTaskContainsUpdateBeforeStart(history *historypb.History, completedEventID int64) bool {
+	if history == nil || completedEventID == 0 {
+		return false
+	}
+	var startedEventID int64
+	for _, event := range history.GetEvents() {
+		if event.GetEventId() == completedEventID {
+			attributes := event.GetWorkflowTaskCompletedEventAttributes()
+			startedEventID = attributes.GetStartedEventId()
+			break
+		}
+	}
+	if startedEventID == 0 {
+		return false
+	}
+	activationStart := int64(0)
+	for _, event := range history.GetEvents() {
+		if event.GetEventId() >= startedEventID {
+			break
+		}
+		switch event.GetEventType() {
+		case enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,
+			enumspb.EVENT_TYPE_WORKFLOW_TASK_FAILED,
+			enumspb.EVENT_TYPE_WORKFLOW_TASK_TIMED_OUT:
+			activationStart = event.GetEventId()
+		default:
+		}
+	}
+	for _, event := range history.GetEvents() {
+		if event.GetEventId() <= activationStart || event.GetEventId() >= startedEventID {
+			continue
+		}
+		if event.GetWorkflowExecutionSignaledEventAttributes().GetSignalName() == legacyscheduler.SignalNameUpdate {
+			return true
+		}
+	}
+	return false
+}
+
+func TestWorkflowTaskContainsUpdateBeforeStart(t *testing.T) {
+	history := &historypb.History{Events: []*historypb.HistoryEvent{
+		{EventId: 2, EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED},
+		{EventId: 3, EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED, Attributes: &historypb.HistoryEvent_WorkflowExecutionSignaledEventAttributes{
+			WorkflowExecutionSignaledEventAttributes: &historypb.WorkflowExecutionSignaledEventAttributes{SignalName: legacyscheduler.SignalNameUpdate},
+		}},
+		{EventId: 4, EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED},
+		{EventId: 5, EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED, Attributes: &historypb.HistoryEvent_WorkflowTaskCompletedEventAttributes{
+			WorkflowTaskCompletedEventAttributes: &historypb.WorkflowTaskCompletedEventAttributes{ScheduledEventId: 2, StartedEventId: 4},
+		}},
+	}}
+	require.True(t, workflowTaskContainsUpdateBeforeStart(history, 5))
+	require.False(t, workflowTaskContainsUpdateBeforeStart(history, 0))
+
+	history.Events[1].EventId = 6
+	require.False(t, workflowTaskContainsUpdateBeforeStart(history, 5))
+}
+
+func TestAnnotateKnownCompatibilityDivergences(t *testing.T) {
+	divergences := []replayDivergence{
+		{Classification: replayClassificationSignificant, Kind: "missing_action"},
+		{Classification: replayClassificationSignificant, Kind: "extra_action"},
+		{Classification: replayClassificationInconclusive, Kind: "unapplied_completion"},
+		{Classification: replayClassificationSignificant, Kind: "action_request", Fields: []string{"continued_failure"}},
+		{Classification: replayClassificationSignificant, Kind: "action_request", Fields: []string{"input"}},
+		{Classification: replayClassificationSignificant, Kind: "action_request", Fields: []string{"versioning_override"}},
+	}
+
+	annotateKnownCompatibilityDivergences(divergences, []string{"overlap_unspecified"}, 2, 2)
+	require.Equal(t, replayClassificationKnownCompat, divergences[0].Classification)
+	require.Equal(t, "skip_deadline_boundary", divergences[0].KnownDifference)
+	require.Equal(t, replayClassificationKnownCompat, divergences[1].Classification)
+	require.Equal(t, "skip_deadline_boundary", divergences[1].KnownDifference)
+	require.Equal(t, replayClassificationInconclusive, divergences[2].Classification)
+	require.Empty(t, divergences[2].KnownDifference)
+	require.Equal(t, replayClassificationKnownCompat, divergences[3].Classification)
+	require.Equal(t, "terminal_failure_propagation", divergences[3].KnownDifference)
+	require.Equal(t, replayClassificationSignificant, divergences[4].Classification)
+	require.Equal(t, replayClassificationKnownCompat, divergences[5].Classification)
+	require.Equal(t, "v2_versioning_override_forwarding", divergences[5].KnownDifference)
+
+	divergences = append(divergences, replayDivergence{Classification: replayClassificationSignificant, Kind: "missing_action"})
+	annotateKnownCompatibilityDivergences(divergences, []string{"overlap_skip"}, 3, 2)
+	require.Equal(t, replayClassificationSignificant, divergences[6].Classification)
+}
+
+func replayDivergenceKinds(result replayCaseResult) []string {
+	kinds := make([]string, 0, len(result.Divergences))
+	for _, divergence := range result.Divergences {
+		kinds = append(kinds, divergence.Kind)
+	}
+	return kinds
+}
+
+func uniqueReplayDivergenceKinds(result replayCaseResult) []string {
+	unique := make(map[string]struct{}, len(result.Divergences))
+	for _, kind := range replayDivergenceKinds(result) {
+		unique[kind] = struct{}{}
+	}
+	kinds := make([]string, 0, len(unique))
+	for kind := range unique {
+		kinds = append(kinds, kind)
+	}
+	sort.Strings(kinds)
+	return kinds
+}
+
+func replayDivergenceFields(result replayCaseResult, kind string) []string {
+	unique := make(map[string]struct{})
+	for _, divergence := range result.Divergences {
+		if divergence.Kind == kind {
+			for _, field := range divergence.Fields {
+				unique[field] = struct{}{}
+			}
+		}
+	}
+	fields := make([]string, 0, len(unique))
+	for field := range unique {
+		fields = append(fields, field)
+	}
+	sort.Strings(fields)
+	return fields
+}
+
+func replayClassificationSeverity(classification replayClassification) int {
+	switch classification {
+	case replayClassificationUnsupported:
+		return 5
+	case replayClassificationSignificant:
+		return 4
+	case replayClassificationInconclusive:
+		return 3
+	case replayClassificationKnownCompat:
+		return 2
+	case replayClassificationTimingOnly:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func replayResultFails(result replayCaseResult, failOn string) bool {
+	switch failOn {
+	case "", "significant":
+		return result.Classification == replayClassificationSignificant ||
+			result.Classification == replayClassificationUnsupported
+	case "all":
+		return result.Classification != replayClassificationMatch
+	case "none":
+		return false
+	default:
+		return true
+	}
+}
+
+func writeReplayReport(path string, results []replayCaseResult, redact bool) error {
+	return writeReplayReportWithCollections(path, results, nil, redact)
+}
+
+func readReplayCheckpoint(path, directory string) ([]replayCaseResult, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var checkpoint replayCheckpoint
+	if err := json.Unmarshal(data, &checkpoint); err != nil {
+		return nil, fmt.Errorf("decode replay checkpoint %q: %w", path, err)
+	}
+	if checkpoint.Version != replayReportVersion || checkpoint.Directory != directory {
+		return nil, fmt.Errorf(
+			"replay checkpoint %q is for version %d directory %q, expected version %d directory %q",
+			path,
+			checkpoint.Version,
+			checkpoint.Directory,
+			replayReportVersion,
+			directory,
+		)
+	}
+	return checkpoint.Cases, nil
+}
+
+func writeReplayCheckpoint(path, directory string, results []replayCaseResult) error {
+	checkpoint := replayCheckpoint{Version: replayReportVersion, Directory: directory, Cases: results}
+	data, err := json.Marshal(checkpoint)
+	if err != nil {
+		return err
+	}
+	temporaryPath := path + ".tmp"
+	if err := os.WriteFile(temporaryPath, data, 0o600); err != nil {
+		return err
+	}
+	if err := os.Chmod(temporaryPath, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(temporaryPath, path)
+}
+
+func writeReplayReportWithCollections(
+	path string,
+	results []replayCaseResult,
+	collections []replayCollectionSummary,
+	redact bool,
+) error {
+	reportResults := results
+	if redact {
+		reportResults = redactReplayResults(results)
+		collections = redactCollectionSummaries(collections)
+	}
+	report := replayReport{
+		Version:       replayReportVersion,
+		Redacted:      redact,
+		Summary:       make(map[string]int),
+		CohortSummary: make(map[string]map[string]int),
+		Collections:   collections,
+		Cases:         reportResults,
+	}
+	for _, result := range results {
+		report.Summary[string(result.Classification)]++
+		for _, cohort := range result.Cohorts {
+			if report.CohortSummary[cohort] == nil {
+				report.CohortSummary[cohort] = make(map[string]int)
+			}
+			report.CohortSummary[cohort][string(result.Classification)]++
+		}
+	}
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o600)
+}
+
+func readReplayCollectionSummaries(directory string) ([]replayCollectionSummary, error) {
+	paths, err := filepath.Glob(filepath.Join(directory, "*", "collection-manifest.json"))
+	if err != nil {
+		return nil, err
+	}
+	summaries := make([]replayCollectionSummary, 0, len(paths))
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		var manifest replayCollectionManifest
+		if err := json.Unmarshal(data, &manifest); err != nil {
+			return nil, fmt.Errorf("decode collection manifest %q: %w", path, err)
+		}
+		summary := replayCollectionSummary{
+			Manifest: path, Namespace: manifest.Namespace, Seed: manifest.Seed,
+			ServerVersion: manifest.ServerVersion, CollectorVersion: manifest.CollectorVersion,
+			ListedPopulation: manifest.ListedPopulation, Inspected: manifest.Inspected,
+			V1Inspected: manifest.V1Inspected, BaseSelected: manifest.BaseSelected,
+			CollectionStatus: make(map[string]int),
+		}
+		for _, record := range manifest.Cases {
+			summary.CollectionStatus[record.Status]++
+		}
+		selectedSchedules := make(map[string]struct{})
+		for _, record := range manifest.Cases {
+			if record.Status == "collected" {
+				selectedSchedules[record.ScheduleID] = struct{}{}
+			}
+		}
+		summary.SelectedSchedules = len(selectedSchedules)
+		summaries = append(summaries, summary)
+	}
+	return summaries, nil
+}
+
+func redactCollectionSummaries(collections []replayCollectionSummary) []replayCollectionSummary {
+	redacted := append([]replayCollectionSummary(nil), collections...)
+	for index := range redacted {
+		redacted[index].Manifest = replayOpaqueID(redacted[index].Manifest)
+		redacted[index].Namespace = replayOpaqueID(redacted[index].Namespace)
+	}
+	return redacted
+}
+
+func redactReplayResults(results []replayCaseResult) []replayCaseResult {
+	redacted := make([]replayCaseResult, len(results))
+	for index, result := range results {
+		redacted[index] = result
+		redacted[index].Namespace = replayOpaqueID(result.Namespace)
+		redacted[index].ScheduleID = replayOpaqueID(result.ScheduleID)
+		redacted[index].History = replayOpaqueID(result.History)
+		redacted[index].V1Starts = redactStrings(result.V1Starts)
+		redacted[index].CHASMStarts = redactStrings(result.CHASMStarts)
+		if result.FirstActionDifference != nil {
+			firstDifference := *result.FirstActionDifference
+			redacted[index].FirstActionDifference = &firstDifference
+			redacted[index].FirstActionDifference.V1WorkflowID = replayOpaqueID(result.FirstActionDifference.V1WorkflowID)
+			redacted[index].FirstActionDifference.CHASMWorkflowID = replayOpaqueID(result.FirstActionDifference.CHASMWorkflowID)
+		}
+		redacted[index].CHASMState.BufferedStarts = redactStrings(result.CHASMState.BufferedStarts)
+		redacted[index].Divergences = append([]replayDivergence(nil), result.Divergences...)
+		for divergenceIndex := range redacted[index].Divergences {
+			divergence := &redacted[index].Divergences[divergenceIndex]
+			divergence.WorkflowID = replayOpaqueID(divergence.WorkflowID)
+			divergence.Message = "redacted " + divergence.Kind + " divergence"
+			divergence.FieldDifferences = append([]replayFieldDifference(nil), divergence.FieldDifferences...)
+			for fieldIndex := range divergence.FieldDifferences {
+				divergence.FieldDifferences[fieldIndex].V1.Digest = ""
+				divergence.FieldDifferences[fieldIndex].CHASM.Digest = ""
+			}
+		}
+	}
+	return redacted
+}
+
+func redactStrings(values []string) []string {
+	redacted := make([]string, len(values))
+	for index, value := range values {
+		redacted[index] = replayOpaqueID(value)
+	}
+	return redacted
+}
+
+func replayOpaqueID(value string) string {
+	if value == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(value))
+	return fmt.Sprintf("sha256:%x", sum[:12])
+}
+
+func newHistoryReplayLibrary(
+	logger log.Logger,
+	frontendClient workflowservice.WorkflowServiceClient,
+	historyClient *historyservicemock.MockHistoryServiceClient,
+	trace *v1HistoryTrace,
+	timeSource *clock.EventTimeSource,
+) *scheduler.Library {
+	config := defaultConfig()
+	config.Tweakables = func(string) scheduler.Tweakables {
+		result := scheduler.DefaultTweakables
+		if len(trace.tweakables) != 0 {
+			result.DefaultCatchupWindow = trace.tweakables[0].policies.DefaultCatchupWindow
+			result.MinCatchupWindow = trace.tweakables[0].policies.MinCatchupWindow
+			result.MaxBufferSize = trace.tweakables[0].policies.MaxBufferSize
+			result.CanceledTerminatedCountAsFailures = trace.tweakables[0].policies.CanceledTerminatedCountAsFailures
+		}
+		for _, change := range trace.tweakables {
+			if change.time.After(timeSource.Now()) {
+				break
+			}
+			result.DefaultCatchupWindow = change.policies.DefaultCatchupWindow
+			result.MinCatchupWindow = change.policies.MinCatchupWindow
+			result.MaxBufferSize = change.policies.MaxBufferSize
+			result.CanceledTerminatedCountAsFailures = change.policies.CanceledTerminatedCountAsFailures
+		}
+		return result
+	}
+	specProcessor := scheduler.NewSpecProcessor(config, metrics.NoopMetricsHandler, logger, newLegacySpecBuilder(0, 0))
+	invokerOptions := scheduler.InvokerTaskHandlerOptions{
+		Config:         config,
+		MetricsHandler: metrics.NoopMetricsHandler,
+		BaseLogger:     logger,
+		SpecProcessor:  specProcessor,
+		HistoryClient:  historyClient,
+		FrontendClient: frontendClient,
+	}
+	return scheduler.NewLibrary(
+		config,
+		nil,
+		scheduler.NewSchedulerIdleTaskHandler(scheduler.SchedulerIdleTaskHandlerOptions{
+			Config: config, MetricsHandler: metrics.NoopMetricsHandler, BaseLogger: logger,
+		}),
+		scheduler.NewSchedulerCallbacksTaskHandler(scheduler.SchedulerCallbacksTaskHandlerOptions{
+			Config: config, HistoryClient: historyClient, FrontendClient: frontendClient,
+		}),
+		scheduler.NewGeneratorTaskHandler(scheduler.GeneratorTaskHandlerOptions{
+			Config: config, MetricsHandler: metrics.NoopMetricsHandler, BaseLogger: logger,
+			SpecProcessor: specProcessor, SpecBuilder: newLegacySpecBuilder(0, 0),
+		}),
+		scheduler.NewInvokerExecuteTaskHandler(invokerOptions),
+		scheduler.NewInvokerProcessBufferTaskHandler(invokerOptions),
+		scheduler.NewBackfillerTaskHandler(scheduler.BackfillerTaskHandlerOptions{
+			Config: config, MetricsHandler: metrics.NoopMetricsHandler, BaseLogger: logger, SpecProcessor: specProcessor,
+		}),
+		scheduler.NewSchedulerMigrateToWorkflowTaskHandler(scheduler.SchedulerMigrateToWorkflowTaskHandlerOptions{
+			Config: config, MetricsHandler: metrics.NoopMetricsHandler, BaseLogger: logger, HistoryClient: historyClient,
+		}),
+	)
+}
+
+func drainCHASMTasks(engine *chasmtest.Engine, rootRef chasm.ComponentRef, now time.Time, budget *replayBudget) error {
+	for range 1000 {
+		pure, err := engine.FirePureTasks(rootRef, now)
+		if err != nil {
+			return err
+		}
+		sideEffect, err := engine.FireSideEffectTasks(rootRef, now)
+		if err != nil {
+			return err
+		}
+		if err := budget.addTasks(pure, sideEffect); err != nil {
+			return err
+		}
+		if pure+sideEffect == 0 {
+			return nil
+		}
+	}
+	return errors.New("CHASM task drain did not converge")
+}
+
+func applyV1Signal(
+	ctx context.Context,
+	handler interface {
+		UpdateSchedule(context.Context, *schedulerpb.UpdateScheduleRequest) (*schedulerpb.UpdateScheduleResponse, error)
+		PatchSchedule(context.Context, *schedulerpb.PatchScheduleRequest) (*schedulerpb.PatchScheduleResponse, error)
+	},
+	trace *v1HistoryTrace,
+	event *historypb.HistoryEvent,
+) error {
+	attributes := event.GetWorkflowExecutionSignaledEventAttributes()
+	switch attributes.GetSignalName() {
+	case legacyscheduler.SignalNameUpdate:
+		var update schedulespb.FullUpdateRequest
+		if err := converter.GetDefaultDataConverter().FromPayloads(attributes.GetInput(), &update); err != nil {
+			return fmt.Errorf("decode V1 update signal: %w", err)
+		}
+		trace.expectedSpec = proto.CloneOf(update.GetSchedule())
+		_, err := handler.UpdateSchedule(ctx, &schedulerpb.UpdateScheduleRequest{
+			NamespaceId: trace.args.GetState().GetNamespaceId(),
+			FrontendRequest: &workflowservice.UpdateScheduleRequest{
+				Namespace:        trace.args.GetState().GetNamespace(),
+				ScheduleId:       trace.args.GetState().GetScheduleId(),
+				Schedule:         proto.CloneOf(update.GetSchedule()),
+				SearchAttributes: proto.CloneOf(update.GetSearchAttributes()),
+			},
+		})
+		return err
+	case legacyscheduler.SignalNamePatch:
+		var patch schedulepb.SchedulePatch
+		if err := converter.GetDefaultDataConverter().FromPayloads(attributes.GetInput(), &patch); err != nil {
+			return fmt.Errorf("decode V1 patch signal: %w", err)
+		}
+		applyExpectedPatch(trace.expectedSpec, &patch)
+		_, err := handler.PatchSchedule(ctx, &schedulerpb.PatchScheduleRequest{
+			NamespaceId: trace.args.GetState().GetNamespaceId(),
+			FrontendRequest: &workflowservice.PatchScheduleRequest{
+				Namespace: trace.args.GetState().GetNamespace(), ScheduleId: trace.args.GetState().GetScheduleId(), Patch: &patch,
+			},
+		})
+		return err
+	case legacyscheduler.SignalNameRefresh, legacyscheduler.SignalNameForceCAN:
+		return nil
+	case legacyscheduler.SignalNameMigrateToChasm:
+		return errors.New("history contains a live migration signal")
+	default:
+		return fmt.Errorf("unsupported V1 scheduler signal %q", attributes.GetSignalName())
+	}
+}
+
+func applyExpectedPatch(schedule *schedulepb.Schedule, patch *schedulepb.SchedulePatch) {
+	if schedule == nil {
+		return
+	}
+	if schedule.GetState() == nil {
+		schedule.State = &schedulepb.ScheduleState{}
+	}
+	if patch.GetPause() != "" {
+		schedule.GetState().Paused = true
+		schedule.GetState().Notes = patch.GetPause()
+	}
+	if patch.GetUnpause() != "" {
+		schedule.GetState().Paused = false
+		schedule.GetState().Notes = patch.GetUnpause()
+	}
+}
+
+func applyExpectedWatchCompletion(
+	schedule *schedulepb.Schedule,
+	request *schedulespb.WatchWorkflowRequest,
+	response *schedulespb.WatchWorkflowResponse,
+) {
+	if schedule == nil || !schedule.GetPolicies().GetPauseOnFailure() || schedule.GetState().GetPaused() {
+		return
+	}
+	if schedule.GetState() == nil {
+		schedule.State = &schedulepb.ScheduleState{}
+	}
+	workflowID := request.GetExecution().GetWorkflowId()
+	switch response.GetStatus() {
+	case enumspb.WORKFLOW_EXECUTION_STATUS_FAILED:
+		schedule.State.Paused = true
+		schedule.State.Notes = fmt.Sprintf(
+			"paused due to workflow failure: %s: %s",
+			workflowID,
+			response.GetFailure().GetMessage(),
+		)
+	case enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT:
+		schedule.State.Paused = true
+		schedule.State.Notes = fmt.Sprintf("paused due to workflow timeout: %s", workflowID)
+	}
+}
+
+func isGeneratedPauseOnFailureNote(note string) bool {
+	return strings.HasPrefix(note, "paused due to workflow failure: ") ||
+		strings.HasPrefix(note, "paused due to workflow timeout: ") ||
+		strings.HasPrefix(note, "paused, workflow failed: ") ||
+		strings.HasPrefix(note, "paused, workflow timed_out: ")
+}
+
+func observedActivityCompletion(
+	t *testing.T,
+	trace *v1HistoryTrace,
+	event *historypb.HistoryEvent,
+) (observedWatchCompletion, bool) {
+	t.Helper()
+	attributes := event.GetActivityTaskCompletedEventAttributes()
+	watch, ok := trace.watches[attributes.GetScheduledEventId()]
+	if !ok {
+		return observedWatchCompletion{}, false
+	}
+	var response schedulespb.WatchWorkflowResponse
+	require.NoError(t, converter.GetDefaultDataConverter().FromPayloads(attributes.GetResult(), &response))
+	return observedWatchCompletion{request: watch.request, response: &response}, true
+}
+
+func applyObservedWatchCompletion(
+	ctx context.Context,
+	rootRef chasm.ComponentRef,
+	executionMap workflowExecutionMap,
+	strictWorkflowMapping bool,
+	request *schedulespb.WatchWorkflowRequest,
+	response *schedulespb.WatchWorkflowResponse,
+) (bool, error) {
+	if response.GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING {
+		return true, nil
+	}
+	observedExecution := workflowExecutionKey{
+		workflowID: request.GetExecution().GetWorkflowId(),
+		runID:      request.GetExecution().GetRunId(),
+	}
+	targetExecution, err := resolveObservedWorkflowExecution(executionMap, strictWorkflowMapping, observedExecution)
+	if err != nil {
+		var notStartedErr *workflowExecutionNotStartedError
+		if errors.As(err, &notStartedErr) {
+			return false, nil
+		}
+		return false, err
+	}
+	_, _, err = chasm.UpdateComponent(ctx, rootRef,
+		func(s *scheduler.Scheduler, mutableCtx chasm.MutableContext, _ struct{}) (struct{}, error) {
+			invoker := s.Invoker.Get(mutableCtx)
+			var requestID string
+			matches := 0
+			bufferedState := make([]string, 0, len(invoker.GetBufferedStarts()))
+			for _, start := range invoker.GetBufferedStarts() {
+				bufferedState = append(bufferedState, fmt.Sprintf(
+					"%s(run=%s,completed=%t)", start.GetWorkflowId(), start.GetRunId(), start.GetCompleted() != nil,
+				))
+				if start.GetWorkflowId() == targetExecution.workflowID &&
+					(targetExecution.runID == "" || start.GetRunId() == targetExecution.runID) {
+					if start.GetCompleted() != nil {
+						return struct{}{}, nil
+					}
+					matches++
+					requestID = start.GetRequestId()
+				}
+			}
+			if matches > 1 {
+				return struct{}{}, fmt.Errorf(
+					"running workflow %q completion matches multiple CHASM buffered starts",
+					targetExecution.workflowID,
+				)
+			}
+			if requestID == "" {
+				return struct{}{}, fmt.Errorf(
+					"running workflow %q run %q (V1 workflow %q run %q) not found in CHASM; buffered starts: %v",
+					targetExecution.workflowID,
+					targetExecution.runID,
+					observedExecution.workflowID,
+					observedExecution.runID,
+					bufferedState,
+				)
+			}
+			return struct{}{}, s.HandleNexusCompletion(mutableCtx, nexusCompletion(response, requestID))
+		}, struct{}{})
+	return err == nil, err
+}
+
+func applyInferredV1Completions(
+	ctx context.Context,
+	rootRef chasm.ComponentRef,
+	executionMap workflowExecutionMap,
+	completionTime time.Time,
+) ([]string, error) {
+	targets := make(map[workflowExecutionKey]struct{}, len(executionMap))
+	for _, target := range executionMap {
+		targets[target] = struct{}{}
+	}
+	var completed []string
+	_, _, err := chasm.UpdateComponent(ctx, rootRef,
+		func(s *scheduler.Scheduler, mutableCtx chasm.MutableContext, _ struct{}) (struct{}, error) {
+			if s.GetSchedule().GetPolicies().GetOverlapPolicy() != enumspb.SCHEDULE_OVERLAP_POLICY_SKIP {
+				return struct{}{}, nil
+			}
+			for _, start := range s.Invoker.Get(mutableCtx).GetBufferedStarts() {
+				if start.GetCompleted() != nil || start.GetRequestId() == "" {
+					continue
+				}
+				if _, ok := targets[workflowExecutionKey{workflowID: start.GetWorkflowId(), runID: start.GetRunId()}]; !ok {
+					continue
+				}
+				response := &schedulespb.WatchWorkflowResponse{
+					Status:    enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+					CloseTime: timestamppb.New(completionTime),
+				}
+				if err := s.HandleNexusCompletion(mutableCtx, nexusCompletion(response, start.GetRequestId())); err != nil {
+					return struct{}{}, err
+				}
+				completed = append(completed, start.GetWorkflowId())
+			}
+			return struct{}{}, nil
+		}, struct{}{})
+	return completed, err
+}
+
+func inferredV1Completions(trace *v1HistoryTrace) map[int64]inferredCompletionInput {
+	timerByWorkflowTask := timerActivationByWorkflowTask(trace.history)
+
+	inferred := make(map[int64]inferredCompletionInput)
+	hasPrevious := false
+	for index := range trace.startAttempts {
+		attempt := &trace.startAttempts[index]
+		if attempt.failed || attempt.workflowID == "" {
+			continue
+		}
+		if hasPrevious {
+			if timerEventID := timerByWorkflowTask[attempt.workflowTaskCompletedEventID]; timerEventID != 0 {
+				inferred[timerEventID] = inferredCompletionInput{time: attempt.time}
+			}
+		}
+		hasPrevious = true
+	}
+	return inferred
+}
+
+func localCompletionsByActivationEvent(trace *v1HistoryTrace) map[int64][]observedWatchCompletion {
+	timerByWorkflowTask := timerActivationByWorkflowTask(trace.history)
+	completions := make(map[int64][]observedWatchCompletion)
+	for _, event := range trace.history.GetEvents() {
+		completion, ok := trace.localWatches[event.GetEventId()]
+		if !ok {
+			continue
+		}
+		if timerEventID := timerByWorkflowTask[completion.workflowTaskCompletedEventID]; timerEventID != 0 {
+			completions[timerEventID] = append(completions[timerEventID], completion)
+		}
+	}
+	return completions
+}
+
+func localCompletionsInFirstWorkflowTask(trace *v1HistoryTrace) []observedWatchCompletion {
+	var firstCompletedEventID int64
+	for _, event := range trace.history.GetEvents() {
+		if event.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED {
+			firstCompletedEventID = event.GetEventId()
+			break
+		}
+	}
+	var completions []observedWatchCompletion
+	for _, event := range trace.history.GetEvents() {
+		if completion, ok := trace.localWatches[event.GetEventId()]; ok &&
+			completion.workflowTaskCompletedEventID == firstCompletedEventID {
+			completions = append(completions, completion)
+		}
+	}
+	return completions
+}
+
+func filterObservedCompanionCompletions(
+	trace *v1HistoryTrace,
+	completions []observedWatchCompletion,
+	replayStartTime time.Time,
+) []observedWatchCompletion {
+	observed := make(map[workflowExecutionKey]struct{})
+	for _, completion := range trace.localWatches {
+		if completion.response.GetStatus() != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING {
+			observed[watchExecutionKey(completion.request)] = struct{}{}
+		}
+	}
+	for _, event := range trace.history.GetEvents() {
+		attributes := event.GetActivityTaskCompletedEventAttributes()
+		watch, ok := trace.watches[attributes.GetScheduledEventId()]
+		if !ok {
+			continue
+		}
+		var response schedulespb.WatchWorkflowResponse
+		if converter.GetDefaultDataConverter().FromPayloads(attributes.GetResult(), &response) == nil &&
+			response.GetStatus() != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING {
+			observed[watchExecutionKey(watch.request)] = struct{}{}
+		}
+	}
+	horizon := trace.history.GetEvents()[len(trace.history.GetEvents())-1].GetEventTime().AsTime()
+	filtered := make([]observedWatchCompletion, 0, len(completions))
+	for _, completion := range completions {
+		if completion.observedTime.Before(replayStartTime) || completion.observedTime.After(horizon) {
+			continue
+		}
+		key := watchExecutionKey(completion.request)
+		if _, ok := observed[key]; ok {
+			continue
+		}
+		observed[key] = struct{}{}
+		filtered = append(filtered, completion)
+	}
+	sort.Slice(filtered, func(i, j int) bool {
+		return filtered[i].observedTime.Before(filtered[j].observedTime)
+	})
+	return filtered
+}
+
+func watchExecutionKey(request *schedulespb.WatchWorkflowRequest) workflowExecutionKey {
+	runID := request.GetExecution().GetRunId()
+	if runID == "" {
+		runID = request.GetFirstExecutionRunId()
+	}
+	return workflowExecutionKey{workflowID: request.GetExecution().GetWorkflowId(), runID: runID}
+}
+
+func timerActivationByWorkflowTask(history *historypb.History) map[int64]int64 {
+	timerByWorkflowTask := make(map[int64]int64)
+	var timerEventID int64
+	for index, event := range history.GetEvents() {
+		switch event.GetEventType() {
+		case enumspb.EVENT_TYPE_TIMER_FIRED:
+			timerEventID = event.GetEventId()
+		case enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED:
+			if timerEventID != 0 {
+				timerByWorkflowTask[event.GetEventId()] = timerEventID
+			}
+			if index+1 >= len(history.GetEvents()) ||
+				history.GetEvents()[index+1].GetEventType() != enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED {
+				timerEventID = 0
+			}
+		default:
+		}
+	}
+	return timerByWorkflowTask
+}
+
+func v1FirstDecisionTime(history *historypb.History, fallback time.Time) time.Time {
+	for _, event := range history.GetEvents() {
+		if event.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED {
+			return event.GetEventTime().AsTime()
+		}
+	}
+	return fallback
+}
+
+func replayCompletionErrorDivergence(
+	err error,
+	request *schedulespb.WatchWorkflowRequest,
+	observedTime time.Time,
+	v1Time bool,
+) replayDivergence {
+	divergence := replayDivergence{
+		Classification: replayClassificationSignificant,
+		Kind:           "completion_state",
+		Message:        err.Error(),
+		WorkflowID:     request.GetExecution().GetWorkflowId(),
+	}
+	var ambiguousErr *ambiguousWorkflowExecutionError
+	if errors.As(err, &ambiguousErr) {
+		divergence.Classification = replayClassificationInconclusive
+		divergence.Kind = "ambiguous_completion"
+	}
+	if v1Time {
+		divergence.V1Time = timePointer(observedTime)
+	} else {
+		divergence.CHASMTime = timePointer(observedTime)
+	}
+	return divergence
+}
+
+func seedCarriedWorkflowExecutions(executionMap workflowExecutionMap, starts []*schedulespb.BufferedStart) {
+	for _, start := range starts {
+		if start.GetRunId() == "" || start.GetCompleted() != nil {
+			continue
+		}
+		execution := workflowExecutionKey{workflowID: start.GetWorkflowId(), runID: start.GetRunId()}
+		executionMap[execution] = execution
+	}
+}
+
+func resolveObservedWorkflowExecution(
+	executionMap workflowExecutionMap,
+	strict bool,
+	observed workflowExecutionKey,
+) (workflowExecutionKey, error) {
+	execution, mapped := executionMap[observed]
+	if mapped {
+		return execution, nil
+	}
+	if observed.runID == "" {
+		var match workflowExecutionKey
+		matches := 0
+		for source, target := range executionMap {
+			if source.workflowID == observed.workflowID {
+				match = target
+				matches++
+			}
+		}
+		if matches == 1 {
+			return match, nil
+		}
+		if matches > 1 {
+			return workflowExecutionKey{}, &ambiguousWorkflowExecutionError{workflowID: observed.workflowID}
+		}
+	}
+	if !strict {
+		return observed, nil
+	}
+	return workflowExecutionKey{}, &workflowExecutionNotStartedError{execution: observed}
+}
+
+func nexusCompletion(response *schedulespb.WatchWorkflowResponse, requestID string) *persistencespb.ChasmNexusCompletion {
+	completion := &persistencespb.ChasmNexusCompletion{
+		RequestId: requestID,
+		CloseTime: response.GetCloseTime(),
+	}
+	if response.GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED {
+		var result *commonpb.Payload
+		if len(response.GetResult().GetPayloads()) != 0 {
+			result = response.GetResult().GetPayloads()[0]
+		}
+		completion.Outcome = &persistencespb.ChasmNexusCompletion_Success{Success: result}
+		return completion
+	}
+	failure := proto.CloneOf(response.GetFailure())
+	if failure == nil {
+		failure = &failurepb.Failure{}
+	}
+	switch response.GetStatus() {
+	case enumspb.WORKFLOW_EXECUTION_STATUS_CANCELED:
+		failure.FailureInfo = &failurepb.Failure_CanceledFailureInfo{CanceledFailureInfo: &failurepb.CanceledFailureInfo{}}
+	case enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT:
+		failure.FailureInfo = &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{}}
+	case enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED:
+		failure.FailureInfo = &failurepb.Failure_TerminatedFailureInfo{TerminatedFailureInfo: &failurepb.TerminatedFailureInfo{}}
+	default:
+	}
+	completion.Outcome = &persistencespb.ChasmNexusCompletion_Failure{Failure: failure}
+	return completion
+}
+
+func extractV1HistoryTrace(t *testing.T, history *historypb.History) *v1HistoryTrace {
+	t.Helper()
+	require.NotEmpty(t, history.GetEvents())
+	started := history.GetEvents()[0].GetWorkflowExecutionStartedEventAttributes()
+	require.NotNil(t, started)
+	var args schedulespb.StartScheduleArgs
+	require.NoError(t, converter.GetDefaultDataConverter().FromPayloads(started.GetInput(), &args))
+	trace := &v1HistoryTrace{
+		args:          &args,
+		history:       history,
+		watches:       make(map[int64]scheduledWatch),
+		startsByEvent: make(map[int64]*schedulespb.StartWorkflowRequest),
+		localWatches:  make(map[int64]observedWatchCompletion),
+		startTime:     history.GetEvents()[0].GetEventTime().AsTime(),
+		expectedSpec:  proto.CloneOf(args.GetSchedule()),
+		searchAttrs:   started.GetSearchAttributes(),
+		memo:          started.GetMemo(),
+		baseActions:   args.GetInfo().GetActionCount(),
+	}
+	localActivities := captureV1LocalActivities(t, history)
+	trace.capturedIDs = localActivities != nil
+	for _, event := range history.GetEvents() {
+		switch event.GetEventType() {
+		case enumspb.EVENT_TYPE_MARKER_RECORDED:
+			if policies, ok, err := v1TweakablesFromMarker(event); ok {
+				require.NoError(t, err)
+				trace.tweakables = append(trace.tweakables, observedTweakables{
+					time: event.GetEventTime().AsTime(), policies: policies,
+				})
+			}
+			metadata := localActivityMetadata(t, event)
+			if metadata.ActivityType == "StartWorkflow" {
+				if metadata.Attempt > 1 {
+					trace.startRetries++
+				}
+				if failure := event.GetMarkerRecordedEventAttributes().GetFailure(); failure != nil {
+					if localActivities == nil {
+						trace.captureIssues++
+						continue
+					}
+					request, ok := localActivities.startsByActivityID[metadata.ActivityID]
+					if !ok {
+						trace.captureIssues++
+						continue
+					}
+					trace.failedStarts = append(trace.failedStarts, observedStartFailure{
+						workflowID: request.GetRequest().GetWorkflowId(), time: event.GetEventTime().AsTime(),
+						request: proto.CloneOf(request.GetRequest()),
+					})
+					trace.startAttempts = append(trace.startAttempts, observedStartAttempt{
+						workflowID: request.GetRequest().GetWorkflowId(), time: event.GetEventTime().AsTime(),
+						request: proto.CloneOf(request.GetRequest()), failed: true,
+						workflowTaskCompletedEventID: event.GetMarkerRecordedEventAttributes().GetWorkflowTaskCompletedEventId(),
+						failureType:                  replayFailureType(failure),
+					})
+					continue
+				}
+				var response schedulespb.StartWorkflowResponse
+				details := event.GetMarkerRecordedEventAttributes().GetDetails()
+				require.NoError(t, converter.GetDefaultDataConverter().FromPayloads(details["result"], &response))
+				start := observedStart{runID: response.GetRunId(), time: event.GetEventTime().AsTime()}
+				if localActivities != nil {
+					request, ok := localActivities.startsByActivityID[metadata.ActivityID]
+					if !ok {
+						trace.captureIssues++
+						continue
+					}
+					start.workflowID = request.GetRequest().GetWorkflowId()
+					start.request = proto.CloneOf(request.GetRequest())
+				}
+				trace.starts = append(trace.starts, start)
+				trace.startAttempts = append(trace.startAttempts, observedStartAttempt{
+					workflowID: start.workflowID, runID: start.runID, time: start.time,
+					request: proto.CloneOf(start.request), workflowTaskCompletedEventID: event.GetMarkerRecordedEventAttributes().GetWorkflowTaskCompletedEventId(),
+				})
+			}
+			if metadata.ActivityType == "WatchWorkflow" {
+				if localActivities == nil {
+					trace.captureIssues++
+					continue
+				}
+				request, ok := localActivities.watchesByActivityID[metadata.ActivityID]
+				if !ok {
+					trace.captureIssues++
+					continue
+				}
+				var response schedulespb.WatchWorkflowResponse
+				details := event.GetMarkerRecordedEventAttributes().GetDetails()
+				require.NoError(t, converter.GetDefaultDataConverter().FromPayloads(details["result"], &response))
+				trace.localWatches[event.GetEventId()] = observedWatchCompletion{
+					request:                      request,
+					response:                     &response,
+					eventID:                      event.GetEventId(),
+					workflowTaskCompletedEventID: event.GetMarkerRecordedEventAttributes().GetWorkflowTaskCompletedEventId(),
+				}
+			}
+		case enumspb.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED:
+			attributes := event.GetActivityTaskScheduledEventAttributes()
+			switch attributes.GetActivityType().GetName() {
+			case "WatchWorkflow":
+				var request schedulespb.WatchWorkflowRequest
+				require.NoError(t, converter.GetDefaultDataConverter().FromPayloads(attributes.GetInput(), &request))
+				trace.watches[event.GetEventId()] = scheduledWatch{request: &request}
+			case "StartWorkflow":
+				var request schedulespb.StartWorkflowRequest
+				require.NoError(t, converter.GetDefaultDataConverter().FromPayloads(attributes.GetInput(), &request))
+				trace.startsByEvent[event.GetEventId()] = &request
+			}
+		case enumspb.EVENT_TYPE_ACTIVITY_TASK_COMPLETED:
+			attributes := event.GetActivityTaskCompletedEventAttributes()
+			request, ok := trace.startsByEvent[attributes.GetScheduledEventId()]
+			if !ok {
+				continue
+			}
+			var response schedulespb.StartWorkflowResponse
+			require.NoError(t, converter.GetDefaultDataConverter().FromPayloads(attributes.GetResult(), &response))
+			start := observedStart{
+				workflowID: request.GetRequest().GetWorkflowId(), runID: response.GetRunId(),
+				time: event.GetEventTime().AsTime(), request: proto.CloneOf(request.GetRequest()),
+			}
+			trace.starts = append(trace.starts, start)
+			trace.startAttempts = append(trace.startAttempts, observedStartAttempt{
+				workflowID: start.workflowID, runID: start.runID, time: start.time,
+				request: proto.CloneOf(start.request),
+			})
+		case enumspb.EVENT_TYPE_ACTIVITY_TASK_FAILED:
+			attributes := event.GetActivityTaskFailedEventAttributes()
+			request, ok := trace.startsByEvent[attributes.GetScheduledEventId()]
+			if ok {
+				trace.failedStarts = append(trace.failedStarts, observedStartFailure{
+					workflowID: request.GetRequest().GetWorkflowId(), time: event.GetEventTime().AsTime(),
+					request: proto.CloneOf(request.GetRequest()),
+				})
+				trace.startAttempts = append(trace.startAttempts, observedStartAttempt{
+					workflowID: request.GetRequest().GetWorkflowId(), time: event.GetEventTime().AsTime(),
+					request: proto.CloneOf(request.GetRequest()), failed: true,
+				})
+			}
+		case enumspb.EVENT_TYPE_ACTIVITY_TASK_TIMED_OUT:
+			attributes := event.GetActivityTaskTimedOutEventAttributes()
+			request, ok := trace.startsByEvent[attributes.GetScheduledEventId()]
+			if ok {
+				trace.failedStarts = append(trace.failedStarts, observedStartFailure{
+					workflowID: request.GetRequest().GetWorkflowId(), time: event.GetEventTime().AsTime(),
+					request: proto.CloneOf(request.GetRequest()),
+				})
+				trace.startAttempts = append(trace.startAttempts, observedStartAttempt{
+					workflowID: request.GetRequest().GetWorkflowId(), time: event.GetEventTime().AsTime(),
+					request: proto.CloneOf(request.GetRequest()), failed: true,
+				})
+			}
+		default:
+		}
+	}
+	return trace
+}
+
+func v1TweakablesFromMarker(event *historypb.HistoryEvent) (legacyscheduler.TweakablePolicies, bool, error) {
+	attributes := event.GetMarkerRecordedEventAttributes()
+	if attributes.GetMarkerName() != "MutableSideEffect" {
+		return legacyscheduler.TweakablePolicies{}, false, nil
+	}
+	var id string
+	var encoded commonpb.Payloads
+	if err := converter.GetDefaultDataConverter().FromPayloads(attributes.GetDetails()["data"], &id, &encoded); err != nil {
+		return legacyscheduler.TweakablePolicies{}, false, err
+	}
+	if id != "tweakables" {
+		return legacyscheduler.TweakablePolicies{}, false, nil
+	}
+	var policies legacyscheduler.TweakablePolicies
+	if err := converter.GetDefaultDataConverter().FromPayloads(&encoded, &policies); err != nil {
+		return legacyscheduler.TweakablePolicies{}, false, err
+	}
+	return policies, true, nil
+}
+
+type localActivityCapture struct {
+	interceptor.WorkerInterceptorBase
+
+	nextActivityID      int
+	startsByActivityID  map[string]*schedulespb.StartWorkflowRequest
+	watchesByActivityID map[string]*schedulespb.WatchWorkflowRequest
+}
+
+func (c *localActivityCapture) InterceptWorkflow(
+	_ workflow.Context,
+	next interceptor.WorkflowInboundInterceptor,
+) interceptor.WorkflowInboundInterceptor {
+	return &localActivityCaptureInbound{
+		WorkflowInboundInterceptorBase: interceptor.WorkflowInboundInterceptorBase{Next: next},
+		capture:                        c,
+	}
+}
+
+type localActivityCaptureInbound struct {
+	interceptor.WorkflowInboundInterceptorBase
+	capture *localActivityCapture
+}
+
+func (i *localActivityCaptureInbound) Init(outbound interceptor.WorkflowOutboundInterceptor) error {
+	return i.Next.Init(&localActivityCaptureOutbound{
+		WorkflowOutboundInterceptorBase: interceptor.WorkflowOutboundInterceptorBase{Next: outbound},
+		capture:                         i.capture,
+	})
+}
+
+type localActivityCaptureOutbound struct {
+	interceptor.WorkflowOutboundInterceptorBase
+	capture *localActivityCapture
+}
+
+func (o *localActivityCaptureOutbound) ExecuteLocalActivity(
+	ctx workflow.Context,
+	activityType string,
+	args ...interface{},
+) workflow.Future {
+	// Default local activity IDs follow invocation order; the fixture test verifies this
+	// association against the IDs persisted in LocalActivity markers.
+	o.capture.nextActivityID++
+	activityID := fmt.Sprint(o.capture.nextActivityID)
+	if len(args) == 1 {
+		switch request := args[0].(type) {
+		case *schedulespb.StartWorkflowRequest:
+			if activityType == "StartWorkflow" {
+				o.capture.startsByActivityID[activityID] = proto.CloneOf(request)
+			}
+		case *schedulespb.WatchWorkflowRequest:
+			if activityType == "WatchWorkflow" {
+				o.capture.watchesByActivityID[activityID] = proto.CloneOf(request)
+			}
+		default:
+		}
+	}
+	return o.Next.ExecuteLocalActivity(ctx, activityType, args...)
+}
+
+func captureV1LocalActivities(t *testing.T, history *historypb.History) *localActivityCapture {
+	t.Helper()
+	if !historySupportsLocalActivityCapture(t, history) {
+		return nil
+	}
+	capture := &localActivityCapture{
+		startsByActivityID:  make(map[string]*schedulespb.StartWorkflowRequest),
+		watchesByActivityID: make(map[string]*schedulespb.WatchWorkflowRequest),
+	}
+	replayer, err := worker.NewWorkflowReplayerWithOptions(worker.WorkflowReplayerOptions{
+		DataConverter: converter.GetDefaultDataConverter(),
+		Interceptors:  []interceptor.WorkerInterceptor{capture},
+	})
+	require.NoError(t, err)
+	replayer.RegisterWorkflowWithOptions(
+		legacyscheduler.SchedulerWorkflow,
+		workflow.RegisterOptions{Name: legacyscheduler.WorkflowType},
+	)
+	require.NoError(t, replayer.ReplayWorkflowHistory(log.NewSdkLogger(log.NewTestLogger()), proto.CloneOf(history)))
+	return capture
+}
+
+func historySupportsLocalActivityCapture(t *testing.T, history *historypb.History) bool {
+	t.Helper()
+	hasLocalActivity := false
+	hasWorkflowTask := false
+	for _, event := range history.GetEvents() {
+		switch event.GetEventType() {
+		case enumspb.EVENT_TYPE_MARKER_RECORDED:
+			hasLocalActivity = hasLocalActivity || localActivityMetadata(t, event).ActivityType != ""
+		case enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED:
+			hasWorkflowTask = true
+		default:
+		}
+	}
+	return hasLocalActivity && hasWorkflowTask
+}
+
+func localActivityMetadata(t *testing.T, event *historypb.HistoryEvent) localActivityMarkerMetadata {
+	t.Helper()
+	attributes := event.GetMarkerRecordedEventAttributes()
+	if attributes.GetMarkerName() != "LocalActivity" {
+		return localActivityMarkerMetadata{}
+	}
+	var metadata localActivityMarkerMetadata
+	require.NoError(t, converter.GetDefaultDataConverter().FromPayloads(attributes.GetDetails()["data"], &metadata))
+	return metadata
+}
+
+func readReplayHistory(t *testing.T, path string) *historypb.History {
+	t.Helper()
+	file, err := os.Open(path)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, file.Close()) }()
+	reader, err := gzip.NewReader(file)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, reader.Close()) }()
+	history, err := client.HistoryFromJSON(reader, client.HistoryJSONOptions{})
+	require.NoError(t, err)
+	return history
+}
+
+func readCompanionActionCompletions(directory string) (map[string][]observedWatchCompletion, error) {
+	scheduleIndex, err := readTSV(filepath.Join(directory, "collection.tsv"))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	actionIndex, err := readTSV(filepath.Join(directory, "action-collection.tsv"))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	type scheduleRunKey struct {
+		namespace  string
+		scheduleID string
+		runIndex   string
+	}
+	schedulePaths := make(map[scheduleRunKey]string)
+	for _, row := range scheduleIndex {
+		if len(row) != 4 {
+			return nil, fmt.Errorf("invalid collection.tsv row with %d columns", len(row))
+		}
+		schedulePaths[scheduleRunKey{namespace: row[0], scheduleID: row[1], runIndex: row[2]}] = filepath.Join(directory, row[3])
+	}
+
+	result := make(map[string][]observedWatchCompletion)
+	for _, row := range actionIndex {
+		if len(row) != 8 {
+			return nil, fmt.Errorf("invalid action-collection.tsv row with %d columns", len(row))
+		}
+		schedulePath := schedulePaths[scheduleRunKey{namespace: row[0], scheduleID: row[1], runIndex: row[2]}]
+		if schedulePath == "" {
+			return nil, fmt.Errorf("action history %q has no source schedule history", row[7])
+		}
+		history, err := readReplayHistoryFile(filepath.Join(directory, row[7]))
+		if err != nil {
+			return nil, err
+		}
+		response, ok := watchResponseFromActionHistory(history)
+		if !ok {
+			continue
+		}
+		result[schedulePath] = append(result[schedulePath], observedWatchCompletion{
+			request: &schedulespb.WatchWorkflowRequest{
+				Execution:           &commonpb.WorkflowExecution{WorkflowId: row[3]},
+				FirstExecutionRunId: row[4],
+			},
+			response:     response,
+			observedTime: response.GetCloseTime().AsTime(),
+		})
+	}
+	return result, nil
+}
+
+func readTSV(path string) ([][]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	reader := csv.NewReader(file)
+	reader.Comma = '\t'
+	records, err := reader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("read %q: %w", path, err)
+	}
+	if len(records) == 0 {
+		return nil, fmt.Errorf("%q is empty", path)
+	}
+	return records[1:], nil
+}
+
+func readReplayHistoryFile(path string) (*historypb.History, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open replay history %q: %w", path, err)
+	}
+	defer file.Close()
+	reader, err := gzip.NewReader(file)
+	if err != nil {
+		return nil, fmt.Errorf("open compressed replay history %q: %w", path, err)
+	}
+	defer reader.Close()
+	history, err := client.HistoryFromJSON(reader, client.HistoryJSONOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("decode replay history %q: %w", path, err)
+	}
+	return history, nil
+}
+
+func watchResponseFromActionHistory(history *historypb.History) (*schedulespb.WatchWorkflowResponse, bool) {
+	if len(history.GetEvents()) == 0 {
+		return nil, false
+	}
+	event := history.GetEvents()[len(history.GetEvents())-1]
+	response := &schedulespb.WatchWorkflowResponse{CloseTime: event.GetEventTime()}
+	switch event.GetEventType() {
+	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED:
+		if event.GetWorkflowExecutionCompletedEventAttributes().GetNewExecutionRunId() != "" {
+			return nil, false
+		}
+		response.Status = enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
+		response.ResultFailure = &schedulespb.WatchWorkflowResponse_Result{
+			Result: event.GetWorkflowExecutionCompletedEventAttributes().GetResult(),
+		}
+	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED:
+		if event.GetWorkflowExecutionFailedEventAttributes().GetNewExecutionRunId() != "" {
+			return nil, false
+		}
+		response.Status = enumspb.WORKFLOW_EXECUTION_STATUS_FAILED
+		response.ResultFailure = &schedulespb.WatchWorkflowResponse_Failure{
+			Failure: event.GetWorkflowExecutionFailedEventAttributes().GetFailure(),
+		}
+	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED:
+		response.Status = enumspb.WORKFLOW_EXECUTION_STATUS_CANCELED
+	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED:
+		response.Status = enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED
+	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT:
+		if event.GetWorkflowExecutionTimedOutEventAttributes().GetNewExecutionRunId() != "" {
+			return nil, false
+		}
+		response.Status = enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT
+	default:
+		return nil, false
+	}
+	return response, true
+}

--- a/chasm/lib/scheduler/testdata/v1-replay/manifest.json
+++ b/chasm/lib/scheduler/testdata/v1-replay/manifest.json
@@ -1,0 +1,24 @@
+{
+  "version": 2,
+  "source": {
+    "server": "1.30.2",
+    "goSdk": "1.44.0",
+    "scheduleImplementation": "v1"
+  },
+  "corpus": "current-v1",
+  "capture": {
+    "automatedStop": "remaining-actions",
+    "teardownPause": false
+  },
+  "scenarios": [
+    "interval",
+    "calendar",
+    "cron",
+    "jitter",
+    "update",
+    "pause-unpause",
+    "backfill-allow-all",
+    "buffer-all-running",
+    "skip-running"
+  ]
+}

--- a/cmd/tools/schedule-v2-replay/README.md
+++ b/cmd/tools/schedule-v2-replay/README.md
@@ -1,0 +1,162 @@
+# Schedule V1 to V2 replay harness
+
+This read-only harness downloads legacy scheduler workflow histories through
+`GetWorkflowExecutionHistory`, verifies that they still replay against Schedule V1, and then
+drives fresh in-memory Schedule V2 instances with the CHASM test engine. Production history files
+contain raw payloads and must be treated as sensitive data.
+
+The CHASM replay starts from the `StartScheduleArgs` in event 1 and advances a virtual clock to
+each CHASM task deadline and V1 external input in chronological order. External inputs at a shared
+timestamp are applied before timer work. The harness applies update and patch signals, returns
+observed workflow-start results through mocked clients, and applies observed workflow completions
+as CHASM callbacks. It compares workflow IDs, normalized `StartWorkflowExecution` requests, action
+counts, and final schedule configuration, and reports selected CHASM scheduler counters.
+In the current corpus every schedule action is `StartWorkflow`, so an action mismatch means a
+workflow execution was started by only one implementation.
+
+V1 may record `WatchWorkflow` as either a normal activity or a local activity. For local
+activities, the marker contains the result but not the watched workflow ID. The harness therefore
+performs a deterministic V1 SDK replay with an outbound workflow interceptor, pairs each captured
+watch request with its marker, and applies the result at the marker's original timestamp. This
+preserves overlap-policy behavior without guessing which running workflow completed.
+Final observed start failures are applied to CHASM. A successful local activity marker records its
+attempt count but not intermediate failure details, so histories with transient local-activity
+retries are classified as `inconclusive` instead of inventing an error sequence.
+
+The harness does not replace CHASM's scheduling calculations with V1 decisions. A completion that
+arrives before CHASM's corresponding start is held until that start occurs. Equal action decisions
+at different observed times are classified as `timing_only`. Approved subsecond-only differences
+in `TemporalScheduledStartTime` are normalized before request comparison. The exact-deadline
+`SKIP` behavior and terminal `ContinuedFailure` propagation are reported as
+`known_compatibility`; they remain counted and visible but do not fail the default `significant`
+gate. Other extra or missing workflow IDs, action counts, request inputs, or final state remain
+`significant`. An extra CHASM action receives a synthetic successful start response, so one
+mismatch does not create an artificial retry cascade.
+
+Continue-as-new histories can begin with running workflows. The harness seeds their workflow/run
+identity from the migrated buffered-start state before applying later completion events. A
+completion without a run ID is applied only when exactly one execution with that workflow ID is
+known; an ambiguous completion is `inconclusive` instead of being guessed.
+
+No API that updates, signals, patches, pauses, or migrates a live schedule is called. The tool has
+no migration option.
+
+Run the read-only replay:
+
+```sh
+go run ./cmd/tools/schedule-v2-replay \
+  -address localhost:7233 \
+  -namespace default \
+  -schedule-id my-schedule \
+  -history-out /tmp/my-schedule-history.json.gz
+```
+
+Replay a sample from every namespace and save each history:
+
+```sh
+./cmd/tools/schedule-v2-replay/replay-sample.sh \
+  --acknowledge-sensitive-data \
+  --address localhost:7233 \
+  --sample-size 10 \
+  --history-dir /tmp/schedule-v1-replay-histories \
+  --report /tmp/schedule-v2-replay-report.json
+```
+
+Replay consumes terminal companion histories whose close time is within the corresponding
+schedule-history horizon. It deduplicates completions already recorded by V1 `WatchWorkflow`
+activities and ignores running action histories without a close event. An archived or expired
+history is reported as unavailable while schedule-history collection continues.
+
+The history directory must be an approved encrypted local volume that is not synchronized or
+checked into source control. The collector creates directories with mode `0700`, writes histories
+and manifests atomically with mode `0600`, uses opaque hashed filenames, and records checksums. It
+rejects an existing history directory that is accessible by group or other users.
+Reports redact production identifiers by default; pass `--unredacted-report` only for restricted
+local triage. Report version 10 includes companion action-workflow completion evidence, migration callback refresh behavior, the first differing action, replay input summaries, named known-compatibility and
+inconclusive causal findings, and payload-safe request diagnostics: presence, element counts,
+encodings, reserved scheduled-time values, and failure-info types. The unredacted report also
+contains deterministic payload digests; neither report contains decoded user payload values.
+
+Long replays write a mode-`0600` atomic checkpoint beside the report every 250 histories and
+resume it when the report version and corpus directory match. Use `--checkpoint-every N` to change
+the interval and `--replay-timeout DURATION` to change the default 30-minute Go test timeout. Put
+the report on a writable restricted volume; the history corpus itself may be read-only.
+
+Restrict the sample to one namespace:
+
+```sh
+./cmd/tools/schedule-v2-replay/replay-sample.sh \
+  --acknowledge-sensitive-data \
+  --namespace payments \
+  --sample-size 25 \
+  --history-dir /tmp/payments-schedule-histories
+```
+
+Batch mode lists the full namespace population and orders candidates by a deterministic hash of
+the seed, namespace, and schedule ID. It collects a uniform base sample, then continues scanning to
+top up behavioral cohorts for spec type, overlap policy, pause/update/backfill interactions,
+workflow completion, and start failures. V2-only schedules are skipped because they have no SDK
+workflow history. The defaults collect at most three continue-as-new runs from the last 30 days,
+inspect at most 20 times the base sample, run two namespaces concurrently, and issue at most two
+production API requests per second globally. Event and byte limits prevent unbounded histories.
+
+Each namespace has a resumable collection manifest containing the sampling parameters, population
+and scan counts, server and collector versions, run horizon, per-case errors, checksums, cohorts,
+and truncation status. Changing a fidelity-affecting option requires a new history directory or
+`--no-resume`.
+
+Collection and replay can run independently:
+
+```sh
+./cmd/tools/schedule-v2-replay/replay-sample.sh \
+  --collect-only --acknowledge-sensitive-data \
+  --namespace payments --sample-size 100 \
+  --history-dir /approved-encrypted-volume/payments
+
+./cmd/tools/schedule-v2-replay/replay-sample.sh \
+  --replay-only --history-dir /approved-encrypted-volume/payments \
+  --report /tmp/payments-redacted-report.json --fail-on none
+```
+
+Replay work is bounded independently of wall-clock test timeout. Defaults are 10,000 virtual
+deadlines, 100,000 CHASM tasks, and 10,000 workflow starts per history. Override them with
+`--max-replay-deadlines`, `--max-replay-tasks`, and `--max-replay-starts`. Exceeding a limit emits
+`replay_budget_exceeded` with counters and classifies the case as `inconclusive`; it does not emit
+partial missing-action comparisons.
+
+In combined mode, replay still runs over successfully collected histories when individual
+collection cases fail, and the command exits nonzero after both phases. Use `--fail-on all` to
+include timing-only and inconclusive results, or `--fail-on none` to collect evidence without
+failing the replay phase. Targeted cohort counts are for finding bug classes and must not be used
+as fleet-wide prevalence estimates.
+
+The production identity needs only `ListNamespaces`, `ListSchedules`,
+`DescribeWorkflowExecution`, `GetWorkflowExecutionHistory`, and `GetSystemInfo`. The collector
+never calls a schedule mutation API. Remove raw histories according to the approved retention
+policy after triage.
+
+Generate the current-V1 conformance corpus against a disposable local server configured to create
+V1 schedules:
+
+```sh
+go run ./cmd/tools/schedule-v2-replay \
+  -generate-scenarios \
+  -namespace default \
+  -history-dir ./chasm/lib/scheduler/testdata/v1-replay \
+  -timeout 2m
+```
+
+The generator creates and deletes nine schedules covering interval, calendar, cron, jitter,
+update, pause/unpause, backfill with `ALLOW_ALL`, and long-running actions with `BUFFER_ALL` and
+`SKIP`. It refuses to continue if the server creates a CHASM schedule instead of a V1 scheduler
+workflow. Each generated history is first replayed through the V1 SDK before being saved. Run the
+saved corpus through the offline comparison with `replay-sample.sh` or by setting
+`SCHEDULE_V1_HISTORY_DIR`, `SCHEDULE_V2_REPLAY_REPORT`, and `SCHEDULE_V2_REPLAY_FAIL_ON` for
+`TestDownloadedV1HistoriesAgainstCHASM`.
+
+Histories under `service/worker/scheduler/testdata` are useful as a historical compatibility
+corpus, but should be run separately with `SCHEDULE_V2_REPLAY_FAIL_ON=none`: old V1 releases can
+have intentional or already-known next-time and backfill-boundary behavior. Newly generated
+current-V1 histories are the significant-divergence gate.
+
+Set `TEMPORAL_API_KEY` for API-key authentication and pass `--tls` when connecting over TLS.

--- a/cmd/tools/schedule-v2-replay/action_histories.go
+++ b/cmd/tools/schedule-v2-replay/action_histories.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"fmt"
+
+	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/interceptor"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+	schedulespb "go.temporal.io/server/api/schedule/v1"
+	"go.temporal.io/server/common/log"
+	workerscheduler "go.temporal.io/server/service/worker/scheduler"
+	"google.golang.org/protobuf/proto"
+)
+
+type actionExecution struct {
+	WorkflowID string
+	RunID      string
+}
+
+type actionStartCapture struct {
+	interceptor.WorkerInterceptorBase
+
+	nextActivityID int
+	starts         map[string]*schedulespb.StartWorkflowRequest
+}
+
+func (c *actionStartCapture) InterceptWorkflow(
+	_ workflow.Context,
+	next interceptor.WorkflowInboundInterceptor,
+) interceptor.WorkflowInboundInterceptor {
+	return &actionStartCaptureInbound{
+		WorkflowInboundInterceptorBase: interceptor.WorkflowInboundInterceptorBase{Next: next},
+		capture:                        c,
+	}
+}
+
+type actionStartCaptureInbound struct {
+	interceptor.WorkflowInboundInterceptorBase
+	capture *actionStartCapture
+}
+
+func (i *actionStartCaptureInbound) Init(outbound interceptor.WorkflowOutboundInterceptor) error {
+	return i.Next.Init(&actionStartCaptureOutbound{
+		WorkflowOutboundInterceptorBase: interceptor.WorkflowOutboundInterceptorBase{Next: outbound},
+		capture:                         i.capture,
+	})
+}
+
+type actionStartCaptureOutbound struct {
+	interceptor.WorkflowOutboundInterceptorBase
+	capture *actionStartCapture
+}
+
+func (o *actionStartCaptureOutbound) ExecuteLocalActivity(
+	ctx workflow.Context,
+	activityType string,
+	args ...interface{},
+) workflow.Future {
+	o.capture.nextActivityID++
+	if activityType == "StartWorkflow" && len(args) == 1 {
+		if request, ok := args[0].(*schedulespb.StartWorkflowRequest); ok {
+			o.capture.starts[fmt.Sprint(o.capture.nextActivityID)] = proto.CloneOf(request)
+		}
+	}
+	return o.Next.ExecuteLocalActivity(ctx, activityType, args...)
+}
+
+func extractActionExecutions(history *historypb.History) ([]actionExecution, error) {
+	localStarts, err := captureLocalActionStarts(history)
+	if err != nil {
+		return nil, err
+	}
+
+	startsByScheduledEvent := make(map[int64]*schedulespb.StartWorkflowRequest)
+	seen := make(map[actionExecution]struct{})
+	var executions []actionExecution
+	appendExecution := func(workflowID, runID string) {
+		if workflowID == "" || runID == "" {
+			return
+		}
+		execution := actionExecution{WorkflowID: workflowID, RunID: runID}
+		if _, ok := seen[execution]; ok {
+			return
+		}
+		seen[execution] = struct{}{}
+		executions = append(executions, execution)
+	}
+
+	for _, event := range history.GetEvents() {
+		switch event.GetEventType() {
+		case enumspb.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED:
+			attributes := event.GetActivityTaskScheduledEventAttributes()
+			if attributes.GetActivityType().GetName() != "StartWorkflow" {
+				continue
+			}
+			var request schedulespb.StartWorkflowRequest
+			if err := converter.GetDefaultDataConverter().FromPayloads(attributes.GetInput(), &request); err != nil {
+				return nil, fmt.Errorf("decode StartWorkflow activity request: %w", err)
+			}
+			startsByScheduledEvent[event.GetEventId()] = &request
+		case enumspb.EVENT_TYPE_ACTIVITY_TASK_COMPLETED:
+			attributes := event.GetActivityTaskCompletedEventAttributes()
+			request, ok := startsByScheduledEvent[attributes.GetScheduledEventId()]
+			if !ok {
+				continue
+			}
+			var response schedulespb.StartWorkflowResponse
+			if err := converter.GetDefaultDataConverter().FromPayloads(attributes.GetResult(), &response); err != nil {
+				return nil, fmt.Errorf("decode StartWorkflow activity response: %w", err)
+			}
+			appendExecution(request.GetRequest().GetWorkflowId(), response.GetRunId())
+		case enumspb.EVENT_TYPE_MARKER_RECORDED:
+			attributes := event.GetMarkerRecordedEventAttributes()
+			if attributes.GetMarkerName() != "LocalActivity" || attributes.GetFailure() != nil {
+				continue
+			}
+			var metadata struct {
+				ActivityID   string
+				ActivityType string
+			}
+			if err := converter.GetDefaultDataConverter().FromPayloads(attributes.GetDetails()["data"], &metadata); err != nil {
+				return nil, fmt.Errorf("decode local activity metadata: %w", err)
+			}
+			if metadata.ActivityType != "StartWorkflow" {
+				continue
+			}
+			request, ok := localStarts[metadata.ActivityID]
+			if !ok {
+				return nil, fmt.Errorf("local StartWorkflow activity %q was not captured during replay", metadata.ActivityID)
+			}
+			var response schedulespb.StartWorkflowResponse
+			if err := converter.GetDefaultDataConverter().FromPayloads(attributes.GetDetails()["result"], &response); err != nil {
+				return nil, fmt.Errorf("decode local StartWorkflow response: %w", err)
+			}
+			appendExecution(request.GetRequest().GetWorkflowId(), response.GetRunId())
+		}
+	}
+	return executions, nil
+}
+
+func captureLocalActionStarts(history *historypb.History) (map[string]*schedulespb.StartWorkflowRequest, error) {
+	if !historyHasLocalActionStart(history) {
+		return nil, nil
+	}
+	capture := &actionStartCapture{starts: make(map[string]*schedulespb.StartWorkflowRequest)}
+	replayer, err := worker.NewWorkflowReplayerWithOptions(worker.WorkflowReplayerOptions{
+		DataConverter: converter.GetDefaultDataConverter(),
+		Interceptors:  []interceptor.WorkerInterceptor{capture},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create action extraction replayer: %w", err)
+	}
+	replayer.RegisterWorkflowWithOptions(
+		workerscheduler.SchedulerWorkflow,
+		workflow.RegisterOptions{Name: workerscheduler.WorkflowType},
+	)
+	if err := replayer.ReplayWorkflowHistory(log.NewSdkLogger(log.NewNoopLogger()), proto.CloneOf(history)); err != nil {
+		return nil, fmt.Errorf("capture local StartWorkflow activities: %w", err)
+	}
+	return capture.starts, nil
+}
+
+func historyHasLocalActionStart(history *historypb.History) bool {
+	for _, event := range history.GetEvents() {
+		attributes := event.GetMarkerRecordedEventAttributes()
+		if attributes.GetMarkerName() != "LocalActivity" {
+			continue
+		}
+		var metadata struct {
+			ActivityType string
+		}
+		if converter.GetDefaultDataConverter().FromPayloads(attributes.GetDetails()["data"], &metadata) == nil &&
+			metadata.ActivityType == "StartWorkflow" {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/tools/schedule-v2-replay/collector.go
+++ b/cmd/tools/schedule-v2-replay/collector.go
@@ -1,0 +1,686 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
+	schedulepb "go.temporal.io/api/schedule/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/converter"
+	schedulespb "go.temporal.io/server/api/schedule/v1"
+	"go.temporal.io/server/common/primitives"
+	legacyscheduler "go.temporal.io/server/service/worker/scheduler"
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+const collectionManifestVersion = 1
+
+type collectionManifest struct {
+	Version          int              `json:"version"`
+	Namespace        string           `json:"namespace"`
+	Seed             string           `json:"seed"`
+	CapturedAt       time.Time        `json:"capturedAt"`
+	ServerVersion    string           `json:"serverVersion,omitempty"`
+	CollectorVersion string           `json:"collectorVersion,omitempty"`
+	ListedPopulation int              `json:"listedPopulation"`
+	LastCandidateKey string           `json:"lastCandidateKey,omitempty"`
+	Inspected        int              `json:"inspected"`
+	V1Inspected      int              `json:"v1Inspected"`
+	BaseSelected     int              `json:"baseSelected"`
+	SampleSize       int              `json:"sampleSize"`
+	CohortSize       int              `json:"cohortSize"`
+	MaxRuns          int              `json:"maxRuns"`
+	MaxRunAge        time.Duration    `json:"maxRunAge"`
+	MaxHistoryEvents int              `json:"maxHistoryEvents"`
+	MaxHistoryBytes  int64            `json:"maxHistoryBytes"`
+	Cases            []collectionCase `json:"cases"`
+}
+
+type collectionCase struct {
+	ScheduleID string    `json:"scheduleId"`
+	RunID      string    `json:"runId"`
+	History    string    `json:"history,omitempty"`
+	Checksum   string    `json:"sha256,omitempty"`
+	Events     int       `json:"events,omitempty"`
+	Bytes      int64     `json:"bytes,omitempty"`
+	CapturedAt time.Time `json:"capturedAt"`
+	Cohorts    []string  `json:"cohorts,omitempty"`
+	Status     string    `json:"status"`
+	Error      string    `json:"error,omitempty"`
+}
+
+type scheduleCandidate struct {
+	scheduleID string
+	key        string
+}
+
+type historyLimitError struct {
+	events int
+	bytes  int64
+}
+
+func (e *historyLimitError) Error() string {
+	return fmt.Sprintf("history exceeds collection limit at %d events and %d protobuf bytes", e.events, e.bytes)
+}
+
+func runCollectionBatch(parent context.Context, opts options) error {
+	if opts.maxScan == 0 {
+		opts.maxScan = opts.sampleSize * 20
+	}
+	if err := ensureSecureDirectory(opts.historyDir); err != nil {
+		return err
+	}
+
+	limiter := rate.NewLimiter(rate.Limit(opts.requestsPerSecond), max(1, opts.concurrency))
+	namespaces := []string{opts.namespace}
+	if opts.allNamespaces {
+		c, err := dialClient(opts, opts.namespace)
+		if err != nil {
+			return err
+		}
+		namespaces, err = listNamespacesLimited(parent, c, opts, limiter)
+		c.Close()
+		if err != nil {
+			return err
+		}
+	}
+	systemClient, err := dialClient(opts, opts.namespace)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(parent, opts.timeout)
+	systemInfo, systemInfoErr := retryAPI(ctx, limiter, func() (*workflowservice.GetSystemInfoResponse, error) {
+		return systemClient.WorkflowService().GetSystemInfo(ctx, &workflowservice.GetSystemInfoRequest{})
+	})
+	cancel()
+	systemClient.Close()
+	if systemInfoErr != nil {
+		return fmt.Errorf("get server version: %w", systemInfoErr)
+	}
+	opts.serverVersion = systemInfo.GetServerVersion()
+
+	semaphore := make(chan struct{}, opts.concurrency)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var failures int
+	for _, namespace := range namespaces {
+		namespace := namespace
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			semaphore <- struct{}{}
+			defer func() { <-semaphore }()
+			failed, err := collectNamespace(parent, opts, namespace, limiter)
+			mu.Lock()
+			defer mu.Unlock()
+			failures += failed
+			if err != nil {
+				failures++
+				_, _ = fmt.Fprintf(os.Stderr, "namespace=%q: %v\n", namespace, err)
+			}
+		}()
+	}
+	wg.Wait()
+	if failures != 0 {
+		return fmt.Errorf("collection completed with %d failure(s); completed histories remain replayable", failures)
+	}
+	return nil
+}
+
+func listNamespacesLimited(parent context.Context, c client.Client, opts options, limiter *rate.Limiter) ([]string, error) {
+	var namespaces []string
+	var nextPageToken []byte
+	for {
+		ctx, cancel := context.WithTimeout(parent, opts.timeout)
+		response, err := retryAPI(ctx, limiter, func() (*workflowservice.ListNamespacesResponse, error) {
+			return c.WorkflowService().ListNamespaces(ctx, &workflowservice.ListNamespacesRequest{
+				PageSize: 100, NextPageToken: nextPageToken,
+			})
+		})
+		cancel()
+		if err != nil {
+			return nil, fmt.Errorf("list namespaces: %w", err)
+		}
+		for _, namespace := range response.GetNamespaces() {
+			if name := namespace.GetNamespaceInfo().GetName(); name != "" {
+				namespaces = append(namespaces, name)
+			}
+		}
+		nextPageToken = response.GetNextPageToken()
+		if len(nextPageToken) == 0 {
+			sort.Strings(namespaces)
+			return namespaces, nil
+		}
+	}
+}
+
+func collectNamespace(parent context.Context, opts options, namespace string, limiter *rate.Limiter) (int, error) {
+	c, err := dialClient(opts, namespace)
+	if err != nil {
+		return 0, err
+	}
+	defer c.Close()
+
+	candidates, err := listScheduleCandidates(parent, c, opts, namespace, limiter)
+	if err != nil {
+		return 0, err
+	}
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].key < candidates[j].key })
+
+	directory := filepath.Join(opts.historyDir, opaqueID(namespace))
+	if err := ensureSecureDirectory(directory); err != nil {
+		return 0, err
+	}
+	manifestPath := filepath.Join(directory, "collection-manifest.json")
+	manifest := collectionManifest{
+		Version: collectionManifestVersion, Namespace: namespace, Seed: opts.sampleSeed,
+		CapturedAt: time.Now().UTC(), ListedPopulation: len(candidates), SampleSize: opts.sampleSize,
+		CohortSize: opts.cohortSize, MaxRuns: opts.maxRuns, MaxRunAge: opts.maxRunAge,
+		MaxHistoryEvents: opts.maxHistoryEvents, MaxHistoryBytes: opts.maxHistoryBytes,
+		CollectorVersion: opts.collectorVersion, ServerVersion: opts.serverVersion,
+	}
+	if opts.resume {
+		if loaded, loadErr := loadCollectionManifest(manifestPath); loadErr == nil {
+			if loaded.Seed != opts.sampleSeed || loaded.SampleSize != opts.sampleSize || loaded.CohortSize != opts.cohortSize ||
+				loaded.MaxRuns != opts.maxRuns || loaded.MaxRunAge != opts.maxRunAge ||
+				loaded.MaxHistoryEvents != opts.maxHistoryEvents || loaded.MaxHistoryBytes != opts.maxHistoryBytes {
+				return 0, errors.New("existing manifest collection options differ; choose another history directory or disable -resume")
+			}
+			if err := validateManifestFiles(loaded); err != nil {
+				return 0, err
+			}
+			manifest = loaded
+		} else if !errors.Is(loadErr, os.ErrNotExist) {
+			return 0, loadErr
+		}
+	}
+
+	cohortCounts := make(map[string]int)
+	selectedSchedules := make(map[string]struct{})
+	for _, record := range manifest.Cases {
+		if record.Status == "collected" {
+			selectedSchedules[record.ScheduleID] = struct{}{}
+		}
+	}
+	for scheduleID := range selectedSchedules {
+		for _, record := range manifest.Cases {
+			if record.ScheduleID == scheduleID {
+				for _, cohort := range record.Cohorts {
+					cohortCounts[cohort]++
+				}
+				break
+			}
+		}
+	}
+
+	limit := min(len(candidates), opts.maxScan)
+	startIndex := 0
+	if manifest.LastCandidateKey != "" {
+		startIndex = sort.Search(len(candidates), func(index int) bool {
+			return candidates[index].key > manifest.LastCandidateKey
+		})
+	} else if manifest.Inspected != 0 {
+		startIndex = min(manifest.Inspected, len(candidates))
+	}
+	var failures int
+	for index := startIndex; index < limit; index++ {
+		candidate := candidates[index]
+		manifest.Inspected++
+		manifest.LastCandidateKey = candidate.key
+		current, runID, isV1, collectErr := inspectCurrentRun(parent, c, opts, namespace, candidate.scheduleID, limiter)
+		if collectErr != nil {
+			failures++
+			manifest.Cases = append(manifest.Cases, failedCollectionCase(candidate.scheduleID, runID, nil, collectErr))
+			if err := writeCollectionManifest(manifestPath, manifest); err != nil {
+				return failures, err
+			}
+			continue
+		}
+		if !isV1 {
+			if err := writeCollectionManifest(manifestPath, manifest); err != nil {
+				return failures, err
+			}
+			continue
+		}
+		manifest.V1Inspected++
+		cohorts := historyCohorts(current)
+		selected := manifest.BaseSelected < opts.sampleSize
+		if !selected {
+			for _, cohort := range cohorts {
+				if cohortCounts[cohort] < opts.cohortSize {
+					selected = true
+					break
+				}
+			}
+		}
+		if !selected {
+			if err := writeCollectionManifest(manifestPath, manifest); err != nil {
+				return failures, err
+			}
+			continue
+		}
+		if manifest.BaseSelected < opts.sampleSize {
+			manifest.BaseSelected++
+		}
+		for _, cohort := range cohorts {
+			cohortCounts[cohort]++
+		}
+		selectedSchedules[candidate.scheduleID] = struct{}{}
+
+		runHistory := current
+		for runIndex := 0; runIndex < opts.maxRuns && runID != ""; runIndex++ {
+			if runIndex > 0 {
+				runHistory, collectErr = downloadHistoryLimited(parent, c, opts, namespace, primitives.ScheduleWorkflowIDPrefix+candidate.scheduleID, runID, limiter)
+				if collectErr == nil {
+					collectErr = replayHistory(runHistory)
+				}
+			}
+			if collectErr != nil {
+				failures++
+				manifest.Cases = append(manifest.Cases, failedCollectionCase(candidate.scheduleID, runID, cohorts, collectErr))
+				break
+			}
+			if runIndex > 0 && runHistory.GetEvents()[0].GetEventTime().AsTime().Before(manifest.CapturedAt.Add(-opts.maxRunAge)) {
+				break
+			}
+			record, writeErr := saveCollectedHistory(opts.historyDir, namespace, candidate.scheduleID, runID, cohorts, runHistory)
+			if writeErr != nil {
+				failures++
+				manifest.Cases = append(manifest.Cases, failedCollectionCase(candidate.scheduleID, runID, cohorts, writeErr))
+				break
+			}
+			manifest.Cases = append(manifest.Cases, record)
+			started := runHistory.GetEvents()[0].GetWorkflowExecutionStartedEventAttributes()
+			runID = started.GetContinuedExecutionRunId()
+		}
+		if err := writeCollectionManifest(manifestPath, manifest); err != nil {
+			return failures, err
+		}
+	}
+
+	fmt.Printf("COLLECTION_SUMMARY namespace=%q listed=%d inspected=%d v1=%d selected=%d runs=%d failures=%d manifest=%q\n",
+		namespace, manifest.ListedPopulation, manifest.Inspected, manifest.V1Inspected, len(selectedSchedules), len(manifest.Cases), failures, manifestPath)
+	return failures, nil
+}
+
+func listScheduleCandidates(parent context.Context, c client.Client, opts options, namespace string, limiter *rate.Limiter) ([]scheduleCandidate, error) {
+	var candidates []scheduleCandidate
+	seen := make(map[string]struct{})
+	var nextPageToken []byte
+	for {
+		ctx, cancel := context.WithTimeout(parent, opts.timeout)
+		response, err := retryAPI(ctx, limiter, func() (*workflowservice.ListSchedulesResponse, error) {
+			return c.WorkflowService().ListSchedules(ctx, &workflowservice.ListSchedulesRequest{
+				Namespace: namespace, MaximumPageSize: 100, NextPageToken: nextPageToken,
+			})
+		})
+		cancel()
+		if err != nil {
+			return nil, fmt.Errorf("list schedules: %w", err)
+		}
+		for _, entry := range response.GetSchedules() {
+			candidates = appendUniqueScheduleCandidate(candidates, seen, opts.sampleSeed, namespace, entry.GetScheduleId())
+		}
+		nextPageToken = response.GetNextPageToken()
+		if len(nextPageToken) == 0 {
+			return candidates, nil
+		}
+	}
+}
+
+func appendUniqueScheduleCandidate(
+	candidates []scheduleCandidate,
+	seen map[string]struct{},
+	seed string,
+	namespace string,
+	scheduleID string,
+) []scheduleCandidate {
+	if scheduleID == "" {
+		return candidates
+	}
+	if _, ok := seen[scheduleID]; ok {
+		return candidates
+	}
+	seen[scheduleID] = struct{}{}
+	return append(candidates, scheduleCandidate{
+		scheduleID: scheduleID,
+		key:        sampleKey(seed, namespace, scheduleID),
+	})
+}
+
+func inspectCurrentRun(parent context.Context, c client.Client, opts options, namespace, scheduleID string, limiter *rate.Limiter) (*historypb.History, string, bool, error) {
+	ctx, cancel := context.WithTimeout(parent, opts.timeout)
+	response, err := retryAPI(ctx, limiter, func() (*workflowservice.DescribeWorkflowExecutionResponse, error) {
+		return c.DescribeWorkflowExecution(ctx, primitives.ScheduleWorkflowIDPrefix+scheduleID, "")
+	})
+	cancel()
+	if err != nil {
+		var notFound *serviceerror.NotFound
+		if errors.As(err, &notFound) {
+			return nil, "", false, nil
+		}
+		return nil, "", false, fmt.Errorf("describe legacy scheduler workflow: %w", err)
+	}
+	runID := response.GetWorkflowExecutionInfo().GetExecution().GetRunId()
+	history, err := downloadHistoryLimited(parent, c, opts, namespace, primitives.ScheduleWorkflowIDPrefix+scheduleID, runID, limiter)
+	if err != nil || !isV1ScheduleHistory(history) {
+		return history, runID, false, err
+	}
+	return history, runID, true, replayHistory(history)
+}
+
+func isV1ScheduleHistory(history *historypb.History) bool {
+	if len(history.GetEvents()) == 0 {
+		return false
+	}
+	started := history.GetEvents()[0].GetWorkflowExecutionStartedEventAttributes()
+	if started == nil {
+		return false
+	}
+	var args schedulespb.StartScheduleArgs
+	if converter.GetDefaultDataConverter().FromPayloads(started.GetInput(), &args) != nil {
+		return false
+	}
+	return args.GetSchedule() != nil && args.GetState() != nil
+}
+
+func downloadHistoryLimited(parent context.Context, c client.Client, opts options, namespace, workflowID, runID string, limiter *rate.Limiter) (*historypb.History, error) {
+	history := &historypb.History{}
+	var nextPageToken []byte
+	var size int64
+	for {
+		ctx, cancel := context.WithTimeout(parent, opts.timeout)
+		response, err := retryAPI(ctx, limiter, func() (*workflowservice.GetWorkflowExecutionHistoryResponse, error) {
+			return c.WorkflowService().GetWorkflowExecutionHistory(ctx, &workflowservice.GetWorkflowExecutionHistoryRequest{
+				Namespace:              namespace,
+				Execution:              &commonpb.WorkflowExecution{WorkflowId: workflowID, RunId: runID},
+				MaximumPageSize:        100,
+				NextPageToken:          nextPageToken,
+				HistoryEventFilterType: enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT,
+				SkipArchival:           true,
+			})
+		})
+		cancel()
+		if err != nil {
+			return nil, fmt.Errorf("download workflow history: %w", err)
+		}
+		for _, event := range response.GetHistory().GetEvents() {
+			size += int64(proto.Size(event))
+			if len(history.Events)+1 > opts.maxHistoryEvents || size > opts.maxHistoryBytes {
+				return nil, &historyLimitError{events: len(history.Events) + 1, bytes: size}
+			}
+			history.Events = append(history.Events, event)
+		}
+		nextPageToken = response.GetNextPageToken()
+		if len(nextPageToken) == 0 {
+			break
+		}
+	}
+	if len(history.Events) == 0 {
+		return nil, errors.New("downloaded workflow history is empty")
+	}
+	return history, nil
+}
+
+func retryAPI[T any](ctx context.Context, limiter *rate.Limiter, operation func() (T, error)) (T, error) {
+	var zero T
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		if err := limiter.Wait(ctx); err != nil {
+			return zero, err
+		}
+		result, err := operation()
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+		code := status.Code(err)
+		if code != codes.Unavailable && code != codes.ResourceExhausted && code != codes.Aborted {
+			return zero, err
+		}
+		timer := time.NewTimer(time.Duration(1<<attempt) * 250 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return zero, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return zero, fmt.Errorf("production API retry limit exhausted: %w", lastErr)
+}
+
+func historyCohorts(history *historypb.History) []string {
+	cohorts := make(map[string]struct{})
+	if len(history.GetEvents()) == 0 {
+		return nil
+	}
+	started := history.GetEvents()[0].GetWorkflowExecutionStartedEventAttributes()
+	var args schedulespb.StartScheduleArgs
+	if converter.GetDefaultDataConverter().FromPayloads(started.GetInput(), &args) == nil {
+		spec := args.GetSchedule().GetSpec()
+		if len(spec.GetInterval()) != 0 {
+			cohorts["spec_interval"] = struct{}{}
+		}
+		if len(spec.GetCalendar()) != 0 || len(spec.GetStructuredCalendar()) != 0 {
+			cohorts["spec_calendar"] = struct{}{}
+		}
+		if len(spec.GetCronString()) != 0 {
+			cohorts["spec_cron"] = struct{}{}
+		}
+		if args.GetSchedule().GetState().GetPaused() {
+			cohorts["paused"] = struct{}{}
+		}
+		overlap := args.GetSchedule().GetPolicies().GetOverlapPolicy().String()
+		cohorts["overlap_"+strings.ToLower(strings.TrimPrefix(overlap, "SCHEDULE_OVERLAP_POLICY_"))] = struct{}{}
+	}
+	activityTypes := make(map[int64]string)
+	for _, event := range history.GetEvents() {
+		switch event.GetEventType() {
+		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED:
+			attributes := event.GetWorkflowExecutionSignaledEventAttributes()
+			switch attributes.GetSignalName() {
+			case legacyscheduler.SignalNameUpdate:
+				cohorts["update"] = struct{}{}
+			case legacyscheduler.SignalNamePatch:
+				var patch schedulepb.SchedulePatch
+				if converter.GetDefaultDataConverter().FromPayloads(attributes.GetInput(), &patch) == nil {
+					if len(patch.GetBackfillRequest()) != 0 {
+						cohorts["backfill"] = struct{}{}
+					}
+					if patch.GetPause() != "" || patch.GetUnpause() != "" {
+						cohorts["pause_interaction"] = struct{}{}
+					}
+				}
+			}
+		case enumspb.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED:
+			attributes := event.GetActivityTaskScheduledEventAttributes()
+			activityTypes[event.GetEventId()] = attributes.GetActivityType().GetName()
+			if attributes.GetActivityType().GetName() == "WatchWorkflow" {
+				cohorts["workflow_completion"] = struct{}{}
+			}
+		case enumspb.EVENT_TYPE_ACTIVITY_TASK_FAILED, enumspb.EVENT_TYPE_ACTIVITY_TASK_TIMED_OUT:
+			var scheduledEventID int64
+			if event.GetActivityTaskFailedEventAttributes() != nil {
+				scheduledEventID = event.GetActivityTaskFailedEventAttributes().GetScheduledEventId()
+			} else {
+				scheduledEventID = event.GetActivityTaskTimedOutEventAttributes().GetScheduledEventId()
+			}
+			if activityTypes[scheduledEventID] == "StartWorkflow" {
+				cohorts["start_failure"] = struct{}{}
+			}
+		case enumspb.EVENT_TYPE_MARKER_RECORDED:
+			attributes := event.GetMarkerRecordedEventAttributes()
+			if attributes.GetMarkerName() != "LocalActivity" {
+				continue
+			}
+			var metadata struct {
+				ActivityType string
+				Attempt      int32
+			}
+			if converter.GetDefaultDataConverter().FromPayloads(attributes.GetDetails()["data"], &metadata) != nil {
+				continue
+			}
+			if metadata.ActivityType == "WatchWorkflow" {
+				cohorts["workflow_completion"] = struct{}{}
+			}
+			if metadata.ActivityType == "StartWorkflow" && attributes.GetFailure() != nil {
+				cohorts["start_failure"] = struct{}{}
+			}
+			if metadata.ActivityType == "StartWorkflow" && metadata.Attempt > 1 {
+				cohorts["start_retry"] = struct{}{}
+			}
+		}
+	}
+	result := make([]string, 0, len(cohorts))
+	for cohort := range cohorts {
+		result = append(result, cohort)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func saveCollectedHistory(root, namespace, scheduleID, runID string, cohorts []string, history *historypb.History) (collectionCase, error) {
+	path := filepath.Join(root, opaqueID(namespace), opaqueID(scheduleID)+"-"+opaqueID(runID)+".json.gz")
+	checksum, size, err := writeHistorySecure(path, history)
+	record := collectionCase{
+		ScheduleID: scheduleID, RunID: runID, History: path, Checksum: checksum,
+		Events: len(history.GetEvents()), Bytes: size, CapturedAt: time.Now().UTC(), Cohorts: cohorts, Status: "collected",
+	}
+	return record, err
+}
+
+func failedCollectionCase(scheduleID, runID string, cohorts []string, err error) collectionCase {
+	statusName := "failed"
+	var limitErr *historyLimitError
+	if errors.As(err, &limitErr) {
+		statusName = "truncated"
+	}
+	return collectionCase{
+		ScheduleID: scheduleID, RunID: runID, CapturedAt: time.Now().UTC(), Cohorts: cohorts,
+		Status: statusName, Error: err.Error(),
+	}
+}
+
+func loadCollectionManifest(path string) (collectionManifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return collectionManifest{}, err
+	}
+	var manifest collectionManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return collectionManifest{}, fmt.Errorf("decode collection manifest: %w", err)
+	}
+	if manifest.Version != collectionManifestVersion {
+		return collectionManifest{}, fmt.Errorf("unsupported collection manifest version %d", manifest.Version)
+	}
+	return manifest, nil
+}
+
+func writeCollectionManifest(path string, manifest collectionManifest) error {
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode collection manifest: %w", err)
+	}
+	return atomicWrite(path, append(data, '\n'), 0o600)
+}
+
+func validateManifestFiles(manifest collectionManifest) error {
+	for _, record := range manifest.Cases {
+		if record.Status != "collected" {
+			continue
+		}
+		file, err := os.Open(record.History)
+		if err != nil {
+			return fmt.Errorf("open collected history %q: %w", record.History, err)
+		}
+		info, statErr := file.Stat()
+		if statErr != nil {
+			_ = file.Close()
+			return fmt.Errorf("inspect collected history %q: %w", record.History, statErr)
+		}
+		if info.Mode().Perm()&0o077 != 0 {
+			_ = file.Close()
+			return fmt.Errorf("collected history %q must not be accessible by group or other users", record.History)
+		}
+		if record.Bytes != 0 && info.Size() != record.Bytes {
+			_ = file.Close()
+			return fmt.Errorf("collected history %q size differs from manifest", record.History)
+		}
+		hash := sha256.New()
+		_, copyErr := io.Copy(hash, file)
+		closeErr := file.Close()
+		if copyErr != nil {
+			return fmt.Errorf("checksum collected history %q: %w", record.History, copyErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("close collected history %q: %w", record.History, closeErr)
+		}
+		if hex.EncodeToString(hash.Sum(nil)) != record.Checksum {
+			return fmt.Errorf("collected history %q checksum differs from manifest", record.History)
+		}
+	}
+	return nil
+}
+
+func ensureSecureDirectory(path string) error {
+	info, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			return fmt.Errorf("create secure history directory: %w", err)
+		}
+		info, err = os.Stat(path)
+	}
+	if err != nil {
+		return fmt.Errorf("inspect history directory: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("history path %q is not a directory", path)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf("history directory %q must not be accessible by group or other users", path)
+	}
+	return nil
+}
+
+func sampleKey(seed, namespace, scheduleID string) string {
+	sum := sha256.Sum256([]byte(seed + "\x00" + namespace + "\x00" + scheduleID))
+	return hex.EncodeToString(sum[:])
+}
+
+func opaqueID(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:12])
+}
+
+func currentBuildRevision() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+	for _, setting := range info.Settings {
+		if setting.Key == "vcs.revision" {
+			return setting.Value
+		}
+	}
+	return "unknown"
+}

--- a/cmd/tools/schedule-v2-replay/main.go
+++ b/cmd/tools/schedule-v2-replay/main.go
@@ -1,0 +1,360 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/primitives"
+	workerscheduler "go.temporal.io/server/service/worker/scheduler"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+type options struct {
+	address           string
+	namespace         string
+	scheduleID        string
+	runID             string
+	historyOut        string
+	timeout           time.Duration
+	tls               bool
+	serverName        string
+	batch             bool
+	allNamespaces     bool
+	sampleSize        int
+	cohortSize        int
+	sampleSeed        string
+	maxRuns           int
+	maxRunAge         time.Duration
+	maxScan           int
+	maxHistoryEvents  int
+	maxHistoryBytes   int64
+	requestsPerSecond float64
+	concurrency       int
+	resume            bool
+	sensitiveDataAck  bool
+	collectorVersion  string
+	serverVersion     string
+	historyDir        string
+	extractActions    string
+	generateScenarios bool
+	scenarioPrefix    string
+}
+
+func main() {
+	opts, err := parseFlags(os.Args[1:])
+	if err != nil {
+		os.Exit(2)
+	}
+	if err := run(context.Background(), opts); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "schedule-v2-replay: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func parseFlags(args []string) (options, error) {
+	var opts options
+	flags := flag.NewFlagSet("schedule-v2-replay", flag.ContinueOnError)
+	flags.StringVar(&opts.address, "address", "localhost:7233", "Temporal frontend address")
+	flags.StringVar(&opts.namespace, "namespace", "default", "Temporal namespace")
+	flags.StringVar(&opts.scheduleID, "schedule-id", "", "schedule ID (required)")
+	flags.StringVar(&opts.runID, "run-id", "", "legacy scheduler workflow run ID; defaults to the current run")
+	flags.StringVar(&opts.historyOut, "history-out", "", "optional path for the downloaded JSON history (.gz is supported)")
+	flags.DurationVar(&opts.timeout, "timeout", time.Minute, "timeout for API calls")
+	flags.BoolVar(&opts.tls, "tls", false, "enable TLS")
+	flags.StringVar(&opts.serverName, "tls-server-name", "", "TLS server name override")
+	flags.BoolVar(&opts.batch, "batch", false, "replay a sample of V1 schedules")
+	flags.BoolVar(&opts.allNamespaces, "all-namespaces", false, "sample schedules from every namespace (requires -batch)")
+	flags.IntVar(&opts.sampleSize, "sample-size", 10, "maximum V1 schedules to replay per namespace in batch mode")
+	flags.IntVar(&opts.cohortSize, "cohort-size", 2, "targeted examples per behavioral cohort in batch mode")
+	flags.StringVar(&opts.sampleSeed, "sample-seed", "schedule-v2-replay", "deterministic batch sampling seed")
+	flags.IntVar(&opts.maxRuns, "max-runs", 3, "maximum continue-as-new runs to collect per schedule")
+	flags.DurationVar(&opts.maxRunAge, "max-run-age", 30*24*time.Hour, "maximum age of collected continue-as-new runs")
+	flags.IntVar(&opts.maxScan, "max-scan", 0, "maximum schedules to inspect per namespace; defaults to 20 times sample-size")
+	flags.IntVar(&opts.maxHistoryEvents, "max-history-events", 100000, "maximum events to collect per workflow run")
+	flags.Int64Var(&opts.maxHistoryBytes, "max-history-bytes", 50<<20, "maximum protobuf bytes to collect per workflow run")
+	flags.Float64Var(&opts.requestsPerSecond, "requests-per-second", 2, "maximum production API requests per second")
+	flags.IntVar(&opts.concurrency, "concurrency", 2, "maximum namespaces collected concurrently")
+	flags.BoolVar(&opts.resume, "resume", true, "resume collection from namespace manifests")
+	flags.BoolVar(&opts.sensitiveDataAck, "acknowledge-sensitive-data", false, "confirm that the history directory is approved for raw production data")
+	flags.StringVar(&opts.collectorVersion, "collector-version", currentBuildRevision(), "collector source revision recorded in manifests")
+	flags.StringVar(&opts.historyDir, "history-dir", "schedule-v1-replay-histories", "batch history output directory")
+	flags.StringVar(&opts.extractActions, "extract-action-executions", "", "print successful action workflow ID/run ID pairs from a saved V1 schedule history")
+	flags.BoolVar(&opts.generateScenarios, "generate-scenarios", false, "create disposable V1 conformance scenarios and save their histories")
+	flags.StringVar(&opts.scenarioPrefix, "scenario-prefix", "schedule-v1-conformance", "schedule ID prefix for generated scenarios")
+	if err := flags.Parse(args); err != nil {
+		return options{}, err
+	}
+	if opts.batch && opts.generateScenarios {
+		return options{}, errors.New("-batch and -generate-scenarios are mutually exclusive")
+	}
+	if opts.batch {
+		if opts.scheduleID != "" || opts.runID != "" || opts.historyOut != "" {
+			return options{}, errors.New("-schedule-id, -run-id, and -history-out are single-schedule options")
+		}
+		if opts.sampleSize <= 0 {
+			return options{}, errors.New("-sample-size must be greater than zero")
+		}
+		if opts.cohortSize < 0 || opts.maxRuns <= 0 || opts.maxRunAge <= 0 || opts.maxScan < 0 || opts.maxHistoryEvents <= 0 || opts.maxHistoryBytes <= 0 {
+			return options{}, errors.New("batch limits must be positive; -cohort-size may be zero")
+		}
+		if opts.sampleSeed == "" || opts.requestsPerSecond <= 0 || opts.concurrency <= 0 {
+			return options{}, errors.New("batch sampling and rate-limit options must be positive and non-empty")
+		}
+		if opts.historyDir == "" {
+			return options{}, errors.New("-history-dir is required in batch mode")
+		}
+		if !opts.sensitiveDataAck {
+			return options{}, errors.New("-acknowledge-sensitive-data is required in batch mode")
+		}
+	} else if opts.allNamespaces {
+		return options{}, errors.New("-all-namespaces requires -batch")
+	} else if opts.generateScenarios {
+		if opts.historyDir == "" {
+			return options{}, errors.New("-history-dir is required with -generate-scenarios")
+		}
+		if opts.scenarioPrefix == "" {
+			return options{}, errors.New("-scenario-prefix is required with -generate-scenarios")
+		}
+	}
+	return opts, nil
+}
+
+func run(parent context.Context, opts options) error {
+	if opts.extractActions != "" {
+		history, err := readHistoryFile(opts.extractActions)
+		if err != nil {
+			return err
+		}
+		executions, err := extractActionExecutions(history)
+		if err != nil {
+			return err
+		}
+		for _, execution := range executions {
+			fmt.Printf("%s\t%s\n", execution.WorkflowID, execution.RunID)
+		}
+		return nil
+	}
+	if opts.batch {
+		return runBatch(parent, opts)
+	}
+	if opts.generateScenarios {
+		return generateScenarioFixtures(parent, opts)
+	}
+	if opts.scheduleID == "" {
+		return errors.New("-schedule-id is required")
+	}
+	ctx, cancel := context.WithTimeout(parent, opts.timeout)
+	defer cancel()
+
+	clientOpts := client.Options{
+		HostPort:  opts.address,
+		Namespace: opts.namespace,
+		Identity:  "schedule-v2-replay",
+	}
+	if opts.tls {
+		clientOpts.ConnectionOptions.TLS = &tls.Config{ServerName: opts.serverName, MinVersion: tls.VersionTLS12}
+	}
+	if apiKey := os.Getenv("TEMPORAL_API_KEY"); apiKey != "" {
+		clientOpts.Credentials = client.NewAPIKeyStaticCredentials(apiKey)
+	}
+	c, err := client.Dial(clientOpts)
+	if err != nil {
+		return fmt.Errorf("dial Temporal: %w", err)
+	}
+	defer c.Close()
+
+	workflowID := primitives.ScheduleWorkflowIDPrefix + opts.scheduleID
+	runID, err := resolveRunID(ctx, c, workflowID, opts.runID)
+	if err != nil {
+		return err
+	}
+	history, err := downloadHistory(ctx, c, workflowID, runID)
+	if err != nil {
+		return err
+	}
+	if opts.historyOut != "" {
+		if err := writeHistory(opts.historyOut, history); err != nil {
+			return err
+		}
+	}
+	if err := replayHistory(history); err != nil {
+		return fmt.Errorf("V1 replay failed: %w", err)
+	}
+	fmt.Printf("V1 replay passed: schedule=%q run=%q events=%d\n", opts.scheduleID, runID, len(history.Events))
+
+	return nil
+}
+
+func readHistoryFile(path string) (*historypb.History, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open history: %w", err)
+	}
+	defer file.Close()
+	var reader io.Reader = file
+	if strings.HasSuffix(path, ".gz") {
+		gzipReader, err := gzip.NewReader(file)
+		if err != nil {
+			return nil, fmt.Errorf("open compressed history: %w", err)
+		}
+		defer gzipReader.Close()
+		reader = gzipReader
+	}
+	history, err := client.HistoryFromJSON(reader, client.HistoryJSONOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("decode history: %w", err)
+	}
+	return history, nil
+}
+
+func runBatch(parent context.Context, opts options) error {
+	return runCollectionBatch(parent, opts)
+}
+
+func dialClient(opts options, namespace string) (client.Client, error) {
+	clientOpts := client.Options{
+		HostPort:  opts.address,
+		Namespace: namespace,
+		Identity:  "schedule-v2-replay",
+	}
+	if opts.tls {
+		clientOpts.ConnectionOptions.TLS = &tls.Config{ServerName: opts.serverName, MinVersion: tls.VersionTLS12}
+	}
+	if apiKey := os.Getenv("TEMPORAL_API_KEY"); apiKey != "" {
+		clientOpts.Credentials = client.NewAPIKeyStaticCredentials(apiKey)
+	}
+	c, err := client.Dial(clientOpts)
+	if err != nil {
+		return nil, fmt.Errorf("dial Temporal namespace %q: %w", namespace, err)
+	}
+	return c, nil
+}
+
+func safePathComponent(value string) string {
+	hash := sha256.Sum256([]byte(value))
+	name := strings.Map(func(r rune) rune {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || strings.ContainsRune("._-", r) {
+			return r
+		}
+		return '_'
+	}, value)
+	name = strings.Trim(name, ".")
+	if len(name) > 80 {
+		name = name[:80]
+	}
+	if name == "" {
+		name = "schedule"
+	}
+	return fmt.Sprintf("%s-%x", name, hash[:6])
+}
+
+func resolveRunID(ctx context.Context, c client.Client, workflowID, runID string) (string, error) {
+	resp, err := c.DescribeWorkflowExecution(ctx, workflowID, runID)
+	if err != nil {
+		return "", fmt.Errorf("describe legacy scheduler workflow: %w", err)
+	}
+	info := resp.GetWorkflowExecutionInfo()
+	return info.GetExecution().GetRunId(), nil
+}
+
+func downloadHistory(ctx context.Context, c client.Client, workflowID, runID string) (*historypb.History, error) {
+	iter := c.GetWorkflowHistory(ctx, workflowID, runID, false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+	history := &historypb.History{}
+	for iter.HasNext() {
+		event, err := iter.Next()
+		if err != nil {
+			return nil, fmt.Errorf("download workflow history: %w", err)
+		}
+		history.Events = append(history.Events, event)
+	}
+	if len(history.Events) == 0 {
+		return nil, errors.New("downloaded workflow history is empty")
+	}
+	return history, nil
+}
+
+func replayHistory(history *historypb.History) error {
+	replayer := worker.NewWorkflowReplayer()
+	replayer.RegisterWorkflowWithOptions(
+		workerscheduler.SchedulerWorkflow,
+		workflow.RegisterOptions{Name: workerscheduler.WorkflowType},
+	)
+	return replayer.ReplayWorkflowHistory(log.NewSdkLogger(log.NewTestLogger()), proto.CloneOf(history))
+}
+
+func writeHistory(path string, history *historypb.History) error {
+	_, _, err := writeHistorySecure(path, history)
+	return err
+}
+
+func writeHistorySecure(path string, history *historypb.History) (string, int64, error) {
+	data, err := (protojson.MarshalOptions{Indent: "  ", UseProtoNames: true}).Marshal(history)
+	if err != nil {
+		return "", 0, fmt.Errorf("marshal history: %w", err)
+	}
+	if strings.HasSuffix(path, ".gz") {
+		var compressed bytes.Buffer
+		gz := gzip.NewWriter(&compressed)
+		if _, err := gz.Write(data); err != nil {
+			return "", 0, fmt.Errorf("compress history: %w", err)
+		}
+		if err := gz.Close(); err != nil {
+			return "", 0, fmt.Errorf("compress history: %w", err)
+		}
+		data = compressed.Bytes()
+	}
+	if err := atomicWrite(path, data, 0o600); err != nil {
+		return "", 0, err
+	}
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("%x", sum), int64(len(data)), nil
+}
+
+func atomicWrite(path string, data []byte, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".schedule-v2-replay-*")
+	if err != nil {
+		return fmt.Errorf("create temporary output: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer func() { _ = os.Remove(temporaryPath) }()
+	if err := temporary.Chmod(mode); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("secure temporary output: %w", err)
+	}
+	if _, err := temporary.Write(data); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("write temporary output: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("sync temporary output: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close temporary output: %w", err)
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return fmt.Errorf("replace output: %w", err)
+	}
+	return nil
+}

--- a/cmd/tools/schedule-v2-replay/main_test.go
+++ b/cmd/tools/schedule-v2-replay/main_test.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
+	schedulepb "go.temporal.io/api/schedule/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/converter"
+	schedulespb "go.temporal.io/server/api/schedule/v1"
+)
+
+func TestWriteHistoryProducesReplayCompatibleGzipJSON(t *testing.T) {
+	history := &historypb.History{Events: []*historypb.HistoryEvent{{
+		EventId:   1,
+		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+		Attributes: &historypb.HistoryEvent_WorkflowExecutionStartedEventAttributes{
+			WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{},
+		},
+	}}}
+	path := filepath.Join(t.TempDir(), "history.json.gz")
+	require.NoError(t, writeHistory(path, history))
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	gz, err := gzip.NewReader(f)
+	require.NoError(t, err)
+	decoded, err := client.HistoryFromJSON(gz, client.HistoryJSONOptions{})
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+	require.NoError(t, f.Close())
+	require.Equal(t, history, decoded)
+}
+
+func TestIsV1ScheduleHistoryRequiresInitialState(t *testing.T) {
+	history := &historypb.History{Events: []*historypb.HistoryEvent{{
+		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+		Attributes: &historypb.HistoryEvent_WorkflowExecutionStartedEventAttributes{
+			WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{},
+		},
+	}}}
+	require.False(t, isV1ScheduleHistory(history))
+
+	args := &schedulespb.StartScheduleArgs{
+		Schedule: &schedulepb.Schedule{},
+		State:    &schedulespb.InternalState{},
+	}
+	input, err := converter.GetDefaultDataConverter().ToPayloads(args)
+	require.NoError(t, err)
+	history.Events[0].GetWorkflowExecutionStartedEventAttributes().Input = input
+	require.True(t, isV1ScheduleHistory(history))
+}
+
+func TestExtractActionExecutionsFromActivities(t *testing.T) {
+	request, err := converter.GetDefaultDataConverter().ToPayloads(&schedulespb.StartWorkflowRequest{
+		Request: &workflowservice.StartWorkflowExecutionRequest{WorkflowId: "action-workflow"},
+	})
+	require.NoError(t, err)
+	response, err := converter.GetDefaultDataConverter().ToPayloads(&schedulespb.StartWorkflowResponse{RunId: "action-run"})
+	require.NoError(t, err)
+	history := &historypb.History{Events: []*historypb.HistoryEvent{
+		{
+			EventId:   1,
+			EventType: enumspb.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED,
+			Attributes: &historypb.HistoryEvent_ActivityTaskScheduledEventAttributes{
+				ActivityTaskScheduledEventAttributes: &historypb.ActivityTaskScheduledEventAttributes{
+					ActivityType: &commonpb.ActivityType{Name: "StartWorkflow"},
+					Input:        request,
+				},
+			},
+		},
+		{
+			EventId:   2,
+			EventType: enumspb.EVENT_TYPE_ACTIVITY_TASK_COMPLETED,
+			Attributes: &historypb.HistoryEvent_ActivityTaskCompletedEventAttributes{
+				ActivityTaskCompletedEventAttributes: &historypb.ActivityTaskCompletedEventAttributes{
+					ScheduledEventId: 1,
+					Result:           response,
+				},
+			},
+		},
+	}}
+
+	executions, err := extractActionExecutions(history)
+	require.NoError(t, err)
+	require.Equal(t, []actionExecution{{WorkflowID: "action-workflow", RunID: "action-run"}}, executions)
+}
+
+func TestAppendUniqueScheduleCandidate(t *testing.T) {
+	seen := make(map[string]struct{})
+	var candidates []scheduleCandidate
+	candidates = appendUniqueScheduleCandidate(candidates, seen, "seed", "namespace", "schedule")
+	candidates = appendUniqueScheduleCandidate(candidates, seen, "seed", "namespace", "schedule")
+	candidates = appendUniqueScheduleCandidate(candidates, seen, "seed", "namespace", "")
+
+	require.Equal(t, []scheduleCandidate{{
+		scheduleID: "schedule",
+		key:        sampleKey("seed", "namespace", "schedule"),
+	}}, candidates)
+}
+
+func TestSafePathComponent(t *testing.T) {
+	component := safePathComponent("../team/schedule")
+	require.NotContains(t, component, "/")
+	require.NotContains(t, component, "..")
+	require.Equal(t, component, safePathComponent("../team/schedule"))
+	require.NotEqual(t, component, safePathComponent("../team_schedule"))
+	require.LessOrEqual(t, len(safePathComponent(strings.Repeat("a", 300))), 93)
+}
+
+func TestParseFlagsValidatesBatchOptions(t *testing.T) {
+	opts, err := parseFlags([]string{"-batch", "-all-namespaces", "-sample-size", "5", "-history-dir", t.TempDir(), "-acknowledge-sensitive-data"})
+	require.NoError(t, err)
+	require.True(t, opts.batch)
+	require.True(t, opts.allNamespaces)
+	require.Equal(t, 5, opts.sampleSize)
+
+	_, err = parseFlags([]string{"-batch", "-sample-size", "0", "-acknowledge-sensitive-data"})
+	require.EqualError(t, err, "-sample-size must be greater than zero")
+	_, err = parseFlags([]string{"-batch"})
+	require.EqualError(t, err, "-acknowledge-sensitive-data is required in batch mode")
+	_, err = parseFlags([]string{"-migrate"})
+	require.ErrorContains(t, err, "flag provided but not defined: -migrate")
+
+	opts, err = parseFlags([]string{"-generate-scenarios", "-history-dir", t.TempDir()})
+	require.NoError(t, err)
+	require.True(t, opts.generateScenarios)
+	_, err = parseFlags([]string{"-generate-scenarios", "-batch"})
+	require.EqualError(t, err, "-batch and -generate-scenarios are mutually exclusive")
+}
+
+func TestCollectionManifestRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "manifest.json")
+	expected := collectionManifest{
+		Version: collectionManifestVersion, Namespace: "payments", Seed: "seed",
+		SampleSize: 10, CohortSize: 2, MaxRuns: 3,
+		Cases: []collectionCase{{ScheduleID: "schedule", RunID: "run", Status: "collected"}},
+	}
+	require.NoError(t, writeCollectionManifest(path, expected))
+	actual, err := loadCollectionManifest(path)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestValidateManifestFilesDetectsCorruption(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "history.json.gz")
+	checksum, _, err := writeHistorySecure(path, &historypb.History{Events: []*historypb.HistoryEvent{{EventId: 1}}})
+	require.NoError(t, err)
+	manifest := collectionManifest{Cases: []collectionCase{{Status: "collected", History: path, Checksum: checksum}}}
+	require.NoError(t, validateManifestFiles(manifest))
+	require.NoError(t, os.WriteFile(path, []byte("corrupt"), 0o600))
+	require.ErrorContains(t, validateManifestFiles(manifest), "checksum differs")
+}
+
+func TestEnsureSecureDirectoryRejectsBroadPermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "histories")
+	require.NoError(t, os.Mkdir(path, 0o700))
+	require.NoError(t, os.Chmod(path, 0o755))
+	require.ErrorContains(t, ensureSecureDirectory(path), "must not be accessible")
+	require.NoError(t, os.Chmod(path, 0o700))
+	require.NoError(t, ensureSecureDirectory(path))
+}
+
+func TestProductionIdentifiersAreDeterministicAndOpaque(t *testing.T) {
+	require.Equal(t, sampleKey("seed", "namespace", "schedule"), sampleKey("seed", "namespace", "schedule"))
+	require.NotEqual(t, sampleKey("seed", "namespace", "schedule"), sampleKey("other", "namespace", "schedule"))
+	require.NotContains(t, opaqueID("customer-namespace"), "customer")
+	require.Len(t, opaqueID("customer-namespace"), 24)
+}
+
+func TestFixtureScenariosCoverConformanceMatrix(t *testing.T) {
+	scenarios := fixtureScenarios()
+	names := make([]string, 0, len(scenarios))
+	for _, scenario := range scenarios {
+		names = append(names, scenario.name)
+		require.Positive(t, scenario.targetActions)
+		if scenario.name != "backfill-allow-all" {
+			require.Positive(t, scenario.remainingActions)
+		}
+	}
+	require.Equal(t, []string{
+		"interval",
+		"calendar",
+		"cron",
+		"jitter",
+		"update",
+		"pause-unpause",
+		"backfill-allow-all",
+		"buffer-all-running",
+		"skip-running",
+	}, names)
+}
+
+func TestReplayExistingScheduleHistories(t *testing.T) {
+	paths, err := filepath.Glob("../../../service/worker/scheduler/testdata/replay_*.json.gz")
+	require.NoError(t, err)
+	require.NotEmpty(t, paths)
+	for _, path := range paths {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			f, err := os.Open(path)
+			require.NoError(t, err)
+			gz, err := gzip.NewReader(f)
+			require.NoError(t, err)
+			history, err := client.HistoryFromJSON(gz, client.HistoryJSONOptions{})
+			require.NoError(t, err)
+			require.NoError(t, gz.Close())
+			require.NoError(t, f.Close())
+			require.NoError(t, replayHistory(history))
+		})
+	}
+}

--- a/cmd/tools/schedule-v2-replay/replay-sample.sh
+++ b/cmd/tools/schedule-v2-replay/replay-sample.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+
+set -u -o pipefail
+
+address="localhost:7233"
+namespace=""
+sample_size="10"
+cohort_size="2"
+sample_seed="schedule-v2-replay"
+max_runs="3"
+max_run_age="720h"
+max_scan="0"
+max_history_events="100000"
+max_history_bytes="52428800"
+max_replay_deadlines="10000"
+max_replay_tasks="100000"
+max_replay_starts="10000"
+requests_per_second="2"
+concurrency="2"
+resume="true"
+history_dir="schedule-v1-replay-histories"
+timeout="1m"
+replay_timeout="30m"
+checkpoint_every="250"
+tls="false"
+tls_server_name=""
+report="schedule-v2-replay-report.json"
+fail_on="significant"
+mode="both"
+redact="true"
+sensitive_data_ack="false"
+
+usage() {
+  echo "Usage: $0 [--collect-only|--replay-only] [--acknowledge-sensitive-data] [--namespace NAME] [--sample-size N] [--cohort-size N] [--sample-seed SEED] [--max-runs N] [--max-run-age DURATION] [--max-scan N] [--max-replay-deadlines N] [--max-replay-tasks N] [--max-replay-starts N] [--checkpoint-every N] [--replay-timeout DURATION] [--requests-per-second N] [--concurrency N] [--history-dir DIR] [--report FILE] [--unredacted-report] [--fail-on significant|all|none] [--address HOST:PORT] [--timeout DURATION] [--tls] [--tls-server-name NAME]"
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --address)
+      address="$2"
+      shift 2
+      ;;
+    --namespace)
+      namespace="$2"
+      shift 2
+      ;;
+    --sample-size)
+      sample_size="$2"
+      shift 2
+      ;;
+    --cohort-size)
+      cohort_size="$2"
+      shift 2
+      ;;
+    --sample-seed)
+      sample_seed="$2"
+      shift 2
+      ;;
+    --max-runs)
+      max_runs="$2"
+      shift 2
+      ;;
+    --max-run-age)
+      max_run_age="$2"
+      shift 2
+      ;;
+    --max-scan)
+      max_scan="$2"
+      shift 2
+      ;;
+    --max-history-events)
+      max_history_events="$2"
+      shift 2
+      ;;
+    --max-history-bytes)
+      max_history_bytes="$2"
+      shift 2
+      ;;
+    --max-replay-deadlines)
+      max_replay_deadlines="$2"
+      shift 2
+      ;;
+    --max-replay-tasks)
+      max_replay_tasks="$2"
+      shift 2
+      ;;
+    --max-replay-starts)
+      max_replay_starts="$2"
+      shift 2
+      ;;
+    --checkpoint-every)
+      checkpoint_every="$2"
+      shift 2
+      ;;
+    --replay-timeout)
+      replay_timeout="$2"
+      shift 2
+      ;;
+    --requests-per-second)
+      requests_per_second="$2"
+      shift 2
+      ;;
+    --concurrency)
+      concurrency="$2"
+      shift 2
+      ;;
+    --no-resume)
+      resume="false"
+      shift
+      ;;
+    --collect-only)
+      if [[ "$mode" != "both" ]]; then
+        echo "--collect-only and --replay-only are mutually exclusive" >&2
+        exit 2
+      fi
+      mode="collect"
+      shift
+      ;;
+    --replay-only)
+      if [[ "$mode" != "both" ]]; then
+        echo "--collect-only and --replay-only are mutually exclusive" >&2
+        exit 2
+      fi
+      mode="replay"
+      shift
+      ;;
+    --history-dir)
+      history_dir="$2"
+      shift 2
+      ;;
+    --timeout)
+      timeout="$2"
+      shift 2
+      ;;
+    --report)
+      report="$2"
+      shift 2
+      ;;
+    --fail-on)
+      fail_on="$2"
+      shift 2
+      ;;
+    --unredacted-report)
+      redact="false"
+      shift
+      ;;
+    --acknowledge-sensitive-data)
+      sensitive_data_ack="true"
+      shift
+      ;;
+    --tls)
+      tls="true"
+      shift
+      ;;
+    --tls-server-name)
+      tls_server_name="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$fail_on" in
+  significant|all|none) ;;
+  *)
+    echo "Invalid --fail-on value: $fail_on" >&2
+    exit 2
+    ;;
+esac
+for replay_limit in "$max_replay_deadlines" "$max_replay_tasks" "$max_replay_starts"; do
+  if [[ ! "$replay_limit" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Replay limits must be positive integers" >&2
+    exit 2
+  fi
+done
+if [[ "$mode" != "replay" && "$sensitive_data_ack" != "true" ]]; then
+  echo "--acknowledge-sensitive-data is required when collecting production histories" >&2
+  exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../../.." && pwd)"
+collector_version="$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || echo unknown)"
+args=(
+  go run ./cmd/tools/schedule-v2-replay
+  -batch
+  -address "$address"
+  -sample-size "$sample_size"
+  -cohort-size "$cohort_size"
+  -sample-seed "$sample_seed"
+  -max-runs "$max_runs"
+  -max-run-age "$max_run_age"
+  -max-scan "$max_scan"
+  -max-history-events "$max_history_events"
+  -max-history-bytes "$max_history_bytes"
+  -requests-per-second "$requests_per_second"
+  -concurrency "$concurrency"
+  -collector-version "$collector_version"
+  -resume="$resume"
+  -history-dir "$history_dir"
+  -timeout "$timeout"
+)
+if [[ "$sensitive_data_ack" == "true" ]]; then
+  args+=(-acknowledge-sensitive-data)
+fi
+
+if [[ -n "$namespace" ]]; then
+  args+=(-namespace "$namespace")
+else
+  args+=(-all-namespaces)
+fi
+if [[ "$tls" == "true" ]]; then
+  args+=(-tls)
+fi
+if [[ -n "$tls_server_name" ]]; then
+  args+=(-tls-server-name "$tls_server_name")
+fi
+
+cd "$repo_root" || exit 1
+collection_failed="false"
+if [[ "$mode" != "replay" ]]; then
+  if ! "${args[@]}"; then
+    collection_failed="true"
+  fi
+fi
+if [[ "$mode" == "collect" ]]; then
+  [[ "$collection_failed" == "false" ]]
+  exit $?
+fi
+
+history_test_dir="$history_dir"
+report_path="$report"
+if [[ "$history_test_dir" != /* ]]; then
+  history_test_dir="$repo_root/$history_test_dir"
+fi
+if [[ "$report_path" != /* ]]; then
+  report_path="$repo_root/$report_path"
+fi
+export SCHEDULE_V1_HISTORY_DIR="$history_test_dir"
+export SCHEDULE_V2_REPLAY_REPORT="$report_path"
+export SCHEDULE_V2_REPLAY_FAIL_ON="$fail_on"
+export SCHEDULE_V2_REPLAY_REDACT="$redact"
+export SCHEDULE_V2_REPLAY_MAX_DEADLINES="$max_replay_deadlines"
+export SCHEDULE_V2_REPLAY_MAX_TASKS="$max_replay_tasks"
+export SCHEDULE_V2_REPLAY_MAX_STARTS="$max_replay_starts"
+export SCHEDULE_V2_REPLAY_CHECKPOINT_EVERY="$checkpoint_every"
+replay_failed="false"
+if ! go test -tags test_dep ./chasm/lib/scheduler \
+  -run '^TestDownloadedV1HistoriesAgainstCHASM$' \
+  -count=1 -timeout "$replay_timeout"; then
+  replay_failed="true"
+fi
+if [[ "$collection_failed" == "true" || "$replay_failed" == "true" ]]; then
+  exit 1
+fi

--- a/cmd/tools/schedule-v2-replay/scenarios.go
+++ b/cmd/tools/schedule-v2-replay/scenarios.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/common/primitives"
+)
+
+const scenarioWorkflowType = "schedule-v1-replay-fixture-workflow"
+
+type fixtureScenario struct {
+	name             string
+	spec             client.ScheduleSpec
+	overlap          enumspb.ScheduleOverlapPolicy
+	runFor           time.Duration
+	paused           bool
+	immediate        bool
+	remainingActions int
+	targetActions    int
+	interact         func(context.Context, client.ScheduleHandle) error
+}
+
+func generateScenarioFixtures(parent context.Context, opts options) error {
+	c, err := dialClient(opts, opts.namespace)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	taskQueue := opts.scenarioPrefix + "-task-queue"
+	w := worker.New(c, taskQueue, worker.Options{})
+	w.RegisterWorkflowWithOptions(scenarioWorkflow, workflow.RegisterOptions{Name: scenarioWorkflowType})
+	if err := w.Start(); err != nil {
+		return fmt.Errorf("start fixture worker: %w", err)
+	}
+	defer w.Stop()
+
+	for _, scenario := range fixtureScenarios() {
+		if err := generateScenarioFixture(parent, c, opts, taskQueue, scenario); err != nil {
+			return fmt.Errorf("scenario %q: %w", scenario.name, err)
+		}
+	}
+	return nil
+}
+
+func generateScenarioFixture(
+	parent context.Context,
+	c client.Client,
+	opts options,
+	taskQueue string,
+	scenario fixtureScenario,
+) error {
+	ctx, cancel := context.WithTimeout(parent, opts.timeout)
+	defer cancel()
+
+	scheduleID := opts.scenarioPrefix + "-" + scenario.name
+	handle, err := c.ScheduleClient().Create(ctx, client.ScheduleOptions{
+		ID:   scheduleID,
+		Spec: scenario.spec,
+		Action: &client.ScheduleWorkflowAction{
+			ID:        scheduleID + "-action",
+			Workflow:  scenarioWorkflowType,
+			Args:      []interface{}{scenario.runFor},
+			TaskQueue: taskQueue,
+		},
+		Overlap:            scenario.overlap,
+		Paused:             scenario.paused,
+		RemainingActions:   scenario.remainingActions,
+		TriggerImmediately: scenario.immediate,
+	})
+	if err != nil {
+		return fmt.Errorf("create schedule: %w", err)
+	}
+
+	workflowID := primitives.ScheduleWorkflowIDPrefix + scheduleID
+	runID, scenarioErr := resolveRunID(ctx, c, workflowID, "")
+	if scenarioErr != nil {
+		scenarioErr = fmt.Errorf("schedule was not created as a V1 workflow; disable CHASM schedule creation for fixture generation: %w", scenarioErr)
+	}
+	if scenarioErr == nil && scenario.interact != nil {
+		scenarioErr = scenario.interact(ctx, handle)
+	}
+	if scenarioErr == nil {
+		scenarioErr = waitForActions(ctx, handle, scenario.targetActions)
+	}
+	if scenarioErr == nil {
+		settleFor := time.Second
+		if scenario.runFor > 0 {
+			settleFor = scenario.runFor + time.Second
+		}
+		timer := time.NewTimer(settleFor)
+		select {
+		case <-ctx.Done():
+			scenarioErr = fmt.Errorf("wait for fixture history to settle: %w", ctx.Err())
+		case <-timer.C:
+		}
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+	}
+	cleanupCtx, cleanupCancel := context.WithTimeout(parent, 10*time.Second)
+	defer cleanupCancel()
+	deleteErr := handle.Delete(cleanupCtx)
+	if deleteErr != nil {
+		deleteErr = fmt.Errorf("delete disposable schedule: %w", deleteErr)
+	}
+	if scenarioErr != nil || deleteErr != nil {
+		return errors.Join(scenarioErr, deleteErr)
+	}
+
+	history, err := downloadHistory(ctx, c, workflowID, runID)
+	if err != nil {
+		return err
+	}
+	if err := replayHistory(history); err != nil {
+		return fmt.Errorf("generated V1 history does not replay: %w", err)
+	}
+	path := filepath.Join(opts.historyDir, "current-v1", scenario.name+".json.gz")
+	if err := writeHistory(path, history); err != nil {
+		return err
+	}
+	fmt.Printf("FIXTURE_PASS scenario=%q events=%d history=%q\n", scenario.name, len(history.Events), path)
+	return nil
+}
+
+func fixtureScenarios() []fixtureScenario {
+	everySecond := client.ScheduleSpec{Intervals: []client.ScheduleIntervalSpec{{Every: time.Second}}}
+	quick := func(name string, spec client.ScheduleSpec) fixtureScenario {
+		return fixtureScenario{
+			name: name, spec: spec, overlap: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			immediate: true, remainingActions: 1, targetActions: 2,
+		}
+	}
+	return []fixtureScenario{
+		quick("interval", everySecond),
+		quick("calendar", client.ScheduleSpec{Calendars: []client.ScheduleCalendarSpec{{
+			Second:     []client.ScheduleRange{{Start: 0, End: 59, Step: 1}},
+			Minute:     []client.ScheduleRange{{Start: 0, End: 59, Step: 1}},
+			Hour:       []client.ScheduleRange{{Start: 0, End: 23, Step: 1}},
+			DayOfMonth: []client.ScheduleRange{{Start: 1, End: 31, Step: 1}},
+			Month:      []client.ScheduleRange{{Start: 1, End: 12, Step: 1}},
+			DayOfWeek:  []client.ScheduleRange{{Start: 0, End: 6, Step: 1}},
+		}}}),
+		quick("cron", client.ScheduleSpec{CronExpressions: []string{"*/1 * * * * * *"}}),
+		quick("jitter", client.ScheduleSpec{
+			Intervals: []client.ScheduleIntervalSpec{{Every: 2 * time.Second}},
+			Jitter:    time.Second,
+		}),
+		{
+			name: "update", spec: client.ScheduleSpec{Intervals: []client.ScheduleIntervalSpec{{Every: time.Hour}}},
+			overlap: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL, paused: true, remainingActions: 2, targetActions: 2,
+			interact: func(ctx context.Context, handle client.ScheduleHandle) error {
+				if err := handle.Update(ctx, client.ScheduleUpdateOptions{DoUpdate: func(input client.ScheduleUpdateInput) (*client.ScheduleUpdate, error) {
+					input.Description.Schedule.Spec = &everySecond
+					return &client.ScheduleUpdate{Schedule: &input.Description.Schedule}, nil
+				}}); err != nil {
+					return fmt.Errorf("update schedule: %w", err)
+				}
+				return handle.Unpause(ctx, client.ScheduleUnpauseOptions{Note: "updated fixture"})
+			},
+		},
+		{
+			name: "pause-unpause", spec: everySecond, overlap: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			immediate: true, remainingActions: 1, targetActions: 2,
+			interact: func(ctx context.Context, handle client.ScheduleHandle) error {
+				if err := handle.Pause(ctx, client.SchedulePauseOptions{Note: "fixture pause"}); err != nil {
+					return fmt.Errorf("pause schedule: %w", err)
+				}
+				return handle.Unpause(ctx, client.ScheduleUnpauseOptions{Note: "fixture unpause"})
+			},
+		},
+		{
+			name: "backfill-allow-all", spec: everySecond,
+			overlap: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL, paused: true, targetActions: 3,
+			interact: func(ctx context.Context, handle client.ScheduleHandle) error {
+				now := time.Now().UTC().Truncate(time.Second)
+				return handle.Backfill(ctx, client.ScheduleBackfillOptions{Backfill: []client.ScheduleBackfill{{
+					Start: now.Add(-4 * time.Second), End: now,
+					Overlap: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+				}}})
+			},
+		},
+		{
+			name: "buffer-all-running", spec: everySecond,
+			overlap: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL, runFor: 3 * time.Second,
+			immediate: true, remainingActions: 1, targetActions: 2,
+		},
+		{
+			name: "skip-running", spec: everySecond,
+			overlap: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP, runFor: 3 * time.Second,
+			immediate: true, remainingActions: 1, targetActions: 2,
+		},
+	}
+}
+
+func waitForActions(ctx context.Context, handle client.ScheduleHandle, target int) error {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		description, err := handle.Describe(ctx)
+		if err != nil {
+			return fmt.Errorf("describe schedule: %w", err)
+		}
+		if description.Info.NumActions >= target {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for %d actions: %w", target, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func scenarioWorkflow(ctx workflow.Context, runFor time.Duration) error {
+	if runFor == 0 {
+		return nil
+	}
+	return workflow.Sleep(ctx, runFor)
+}

--- a/service/worker/scheduler/responsebuilder_test.go
+++ b/service/worker/scheduler/responsebuilder_test.go
@@ -175,6 +175,7 @@ func TestResponseBuilder(t *testing.T) {
 
 			assertError(t, err, nil)
 			assertResponseResult(t, response, nil)
+			require.Nil(t, response.GetFailure())
 			assertResponseStatus(t, response, status)
 		})
 	}
@@ -247,6 +248,7 @@ func TestResponseBuilder(t *testing.T) {
 			response, err := rb.Build(&event)
 			assertError(t, err, nil)
 			assertResponseResult(t, response, nil)
+			require.Nil(t, response.GetFailure())
 			assertResponseStatus(t, response, enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT)
 
 		})
@@ -261,6 +263,49 @@ func TestResponseBuilder(t *testing.T) {
 		assertError(t, err, errUnkownWorkflowStatus)
 		assertResponseIsNil(t, response)
 	})
+}
+
+func TestDivergenceRepro_V1OmitsNonFailedTerminalFailure(t *testing.T) {
+	testCases := []struct {
+		name   string
+		status enumspb.WorkflowExecutionStatus
+		event  *historypb.HistoryEvent
+	}{
+		{
+			name:   "canceled",
+			status: enumspb.WORKFLOW_EXECUTION_STATUS_CANCELED,
+			event:  &historypb.HistoryEvent{},
+		},
+		{
+			name:   "terminated",
+			status: enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED,
+			event:  &historypb.HistoryEvent{},
+		},
+		{
+			name:   "timed-out",
+			status: enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT,
+			event: &historypb.HistoryEvent{
+				Attributes: &historypb.HistoryEvent_WorkflowExecutionTimedOutEventAttributes{
+					WorkflowExecutionTimedOutEventAttributes: &historypb.WorkflowExecutionTimedOutEventAttributes{},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			builder := newResponseBuilder(
+				&schedulespb.WatchWorkflowRequest{},
+				tc.status,
+				log.NewNoopLogger(),
+				eventStorageSize-recordOverheadSize,
+			)
+
+			response, err := builder.Build(tc.event)
+			require.NoError(t, err)
+			require.Equal(t, tc.status, response.GetStatus())
+			require.Nil(t, response.GetFailure())
+		})
+	}
 }
 
 func assertResponseResult(t *testing.T, response *schedulespb.WatchWorkflowResponse, expectedResult *commonpb.Payloads) {

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -454,6 +454,19 @@ func (s *workflowSuite) TestCatchupWindow() {
 	s.True(workflow.IsContinueAsNewError(s.env.GetWorkflowError()))
 }
 
+func (s *workflowSuite) TestZeroCatchupWindowUsesMinimum() {
+	legacy := &scheduler{
+		StartScheduleArgs: &schedulespb.StartScheduleArgs{Schedule: &schedulepb.Schedule{
+			Policies: &schedulepb.SchedulePolicies{CatchupWindow: durationpb.New(0)},
+		}},
+		tweakables: TweakablePolicies{
+			DefaultCatchupWindow: 365 * 24 * time.Hour,
+			MinCatchupWindow:     10 * time.Second,
+		},
+	}
+	s.Equal(10*time.Second, legacy.getCatchupWindow())
+}
+
 func (s *workflowSuite) TestCatchupWindowWhilePaused() {
 	// written using low-level mocks so we can set initial state
 
@@ -623,6 +636,7 @@ func (s *workflowSuite) TestOverlapBufferOne() {
 			},
 			Policies: &schedulepb.SchedulePolicies{
 				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
+				CatchupWindow: durationpb.New(10 * time.Minute),
 			},
 		},
 	)


### PR DESCRIPTION
## What changed?
- adds a Schedule V1 history collector and replay CLI
- applies recorded V1 external inputs to fresh in-memory CHASM scheduler state
- compares action identity, request shape, counts, timing, and final state
- adds bounded replay budgets, checkpointing, redaction, and namespace sampling
- extends chasmtest with time-skipping helpers used by replay

Product scheduler fixes, production sweep reports, and environment-specific collection tooling are intentionally excluded from this PR.

## Why?
This provides a non-mutating shadow comparison for Schedule V1 data before enabling Schedule V2 migration broadly.

## How did you test it?
- go test -tags test_dep ./chasm/chasmtest ./chasm/lib/scheduler ./cmd/tools/schedule-v2-replay ./service/worker/scheduler -count=1
- exercised the harness against a large restricted corpus with no unexplained significant divergences

## Potential risks
The harness is test/tooling-only, but large histories can consume substantial CPU. Per-history deadline, task, start, and wall-time budgets bound that work.