### PR TITLE
Remove Fx lifecycle debug logs

### DIFF
--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -1152,8 +1152,10 @@ func (l *fxLogAdapter) LogEvent(e fxevent.Event) {
 	switch e := e.(type) {
 	case *fxevent.OnStartExecuting,
 		*fxevent.OnStopExecuting,
+		*fxevent.Invoking,
 		*fxevent.BeforeRun:
-		// Successful Fx lifecycle events are intentionally not logged.
+		// These events only signal that work is about to start. The
+		// corresponding completion events are logged if they fail.
 	case *fxevent.OnStartExecuted:
 		if e.Err != nil {
 			l.logger.Error(

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -1150,105 +1150,86 @@ type fxLogAdapter struct {
 
 func (l *fxLogAdapter) LogEvent(e fxevent.Event) {
 	switch e := e.(type) {
-	case *fxevent.OnStartExecuting:
-		l.logger.Debug("OnStart hook executing",
-			tag.ComponentFX,
-			tag.String("callee", e.FunctionName),
-			tag.String("caller", e.CallerName),
-		)
+	case *fxevent.OnStartExecuting,
+		*fxevent.OnStopExecuting,
+		*fxevent.BeforeRun:
+		// Successful Fx lifecycle events are intentionally not logged.
 	case *fxevent.OnStartExecuted:
 		if e.Err != nil {
-			l.logger.Error("OnStart hook failed",
+			l.logger.Error(
+				"OnStart hook failed",
 				tag.ComponentFX,
 				tag.String("callee", e.FunctionName),
 				tag.String("caller", e.CallerName),
-				tag.Error(e.Err),
-			)
-		} else {
-			l.logger.Debug("OnStart hook executed",
-				tag.ComponentFX,
-				tag.String("callee", e.FunctionName),
-				tag.String("caller", e.CallerName),
-				tag.Stringer("runtime", e.Runtime),
-			)
+				tag.Error(e.Err))
 		}
-	case *fxevent.OnStopExecuting:
-		l.logger.Debug("OnStop hook executing",
-			tag.ComponentFX,
-			tag.String("callee", e.FunctionName),
-			tag.String("caller", e.CallerName),
-		)
 	case *fxevent.OnStopExecuted:
 		if e.Err != nil {
-			l.logger.Error("OnStop hook failed",
+			l.logger.Error(
+				"OnStop hook failed",
 				tag.ComponentFX,
 				tag.String("callee", e.FunctionName),
 				tag.String("caller", e.CallerName),
-				tag.Error(e.Err),
-			)
-		} else {
-			l.logger.Debug("OnStop hook executed",
-				tag.ComponentFX,
-				tag.String("callee", e.FunctionName),
-				tag.String("caller", e.CallerName),
-				tag.Stringer("runtime", e.Runtime),
-			)
+				tag.Error(e.Err))
 		}
 	case *fxevent.Supplied:
 		if e.Err != nil {
-			l.logger.Error("supplied",
+			l.logger.Error(
+				"supplied",
 				tag.ComponentFX,
 				tag.String("type", e.TypeName),
 				tag.String("module", e.ModuleName),
-				tag.Error(e.Err))
+				tag.Error(e.Err),
+			)
 		}
 	case *fxevent.Provided:
 		if e.Err != nil {
-			l.logger.Error("error encountered while applying options",
+			l.logger.Error(
+				"error encountered while applying options",
 				tag.ComponentFX,
 				tag.String("module", e.ModuleName),
-				tag.Error(e.Err))
+				tag.Error(e.Err),
+			)
 		}
 	case *fxevent.Replaced:
 		if e.Err != nil {
-			l.logger.Error("error encountered while replacing",
+			l.logger.Error(
+				"error encountered while replacing",
 				tag.ComponentFX,
 				tag.String("module", e.ModuleName),
-				tag.Error(e.Err))
+				tag.Error(e.Err),
+			)
 		}
 	case *fxevent.Decorated:
 		if e.Err != nil {
-			l.logger.Error("error encountered while applying options",
+			l.logger.Error(
+				"error encountered while applying options",
 				tag.ComponentFX,
 				tag.String("module", e.ModuleName),
-				tag.Error(e.Err))
+				tag.Error(e.Err),
+			)
 		}
 	case *fxevent.Run:
 		if e.Err != nil {
-			l.logger.Error("error returned",
+			l.logger.Error(
+				"error returned",
 				tag.ComponentFX,
 				tag.String("name", e.Name),
 				tag.String("kind", e.Kind),
 				tag.String("module", e.ModuleName),
-				tag.Error(e.Err),
-			)
+				tag.Error(e.Err))
 		}
 	case *fxevent.Invoking:
 		// Do not log stack as it will make logs hard to read.
-		l.logger.Debug("invoking",
-			tag.ComponentFX,
-			tag.String("function", e.FunctionName),
-			tag.String("module", e.ModuleName),
-		)
 	case *fxevent.Invoked:
 		if e.Err != nil {
-			l.logger.Error("invoke failed",
+			l.logger.Error(
+				"invoke failed",
 				tag.ComponentFX,
 				tag.Error(e.Err),
 				tag.String("stack", e.Trace),
 				tag.String("function", e.FunctionName),
-				tag.String("module", e.ModuleName),
-			)
+				tag.String("module", e.ModuleName))
 		}
 	case *fxevent.Stopping:
 		l.logger.Info("received signal",
@@ -1256,35 +1237,42 @@ func (l *fxLogAdapter) LogEvent(e fxevent.Event) {
 			tag.Stringer("signal", e.Signal))
 	case *fxevent.Stopped:
 		if e.Err != nil {
-			l.logger.Error("stop failed", tag.ComponentFX, tag.Error(e.Err))
+			l.logger.Error(
+				"stop failed",
+				tag.ComponentFX,
+				tag.Error(e.Err),
+			)
 		}
 	case *fxevent.RollingBack:
-		l.logger.Error("start failed, rolling back", tag.ComponentFX, tag.Error(e.StartErr))
+		l.logger.Error(
+			"start failed, rolling back",
+			tag.ComponentFX,
+			tag.Error(e.StartErr),
+		)
 	case *fxevent.RolledBack:
 		if e.Err != nil {
-			l.logger.Error("rollback failed", tag.ComponentFX, tag.Error(e.Err))
+			l.logger.Error(
+				"rollback failed",
+				tag.ComponentFX,
+				tag.Error(e.Err),
+			)
 		}
 	case *fxevent.Started:
 		if e.Err != nil {
-			l.logger.Error("start failed", tag.ComponentFX, tag.Error(e.Err))
-		} else {
-			l.logger.Debug("started", tag.ComponentFX)
+			l.logger.Error(
+				"start failed",
+				tag.ComponentFX,
+				tag.Error(e.Err),
+			)
 		}
 	case *fxevent.LoggerInitialized:
 		if e.Err != nil {
-			l.logger.Error("custom logger initialization failed", tag.ComponentFX, tag.Error(e.Err))
-		} else {
-			l.logger.Debug("initialized custom fxevent.Logger",
+			l.logger.Error(
+				"custom logger initialization failed",
 				tag.ComponentFX,
-				tag.String("function", e.ConstructorName))
+				tag.Error(e.Err),
+			)
 		}
-	case *fxevent.BeforeRun:
-		l.logger.Debug("before run",
-			tag.ComponentFX,
-			tag.String("name", e.Name),
-			tag.String("kind", e.Kind),
-			tag.String("module", e.ModuleName),
-		)
 	default:
 		l.logger.Warn("unknown fx log type, update fxLogAdapter",
 			tag.ComponentFX,

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -1221,8 +1221,6 @@ func (l *fxLogAdapter) LogEvent(e fxevent.Event) {
 				tag.String("module", e.ModuleName),
 				tag.Error(e.Err))
 		}
-	case *fxevent.Invoking:
-		// Do not log stack as it will make logs hard to read.
 	case *fxevent.Invoked:
 		if e.Err != nil {
 			l.logger.Error(


### PR DESCRIPTION
## What changed?

Remove Fx lifecycle debug logs.

## Why?

They are not really useful, but their overhead adds up.

## Impact

Measured with a core functional-test cluster, using debug logging, 20 samples,
and five cluster boots per sample:

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Cluster boot | 25.02 ms | 19.50 ms | -22.1% |
| Fx graph | 19.00 ms | 14.40 ms | -24.2% |
| Allocated bytes | 13.88 MB | 12.65 MB | -8.8% |
| Allocated objects | 215.9k | 202.5k | -6.2% |

<details>
<summary>measurement code and commands</summary>

This temporary patch was applied to each revision being compared. It is not
part of this PR.

```diff
diff --git a/tests/testcore/onebox.go b/tests/testcore/onebox.go
index 908241e47..116000795 100644
--- a/tests/testcore/onebox.go
+++ b/tests/testcore/onebox.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -39,6 +40,8 @@ import (
 	"go.uber.org/multierr"
 )
 
+var fxGraphMeasurementObserver atomic.Pointer[func(time.Duration)]
+
 type (
 	temporalImpl struct {
 		clients
@@ -291,10 +294,14 @@ func (c *temporalImpl) Start() error {
 	)
 	defer cleanupHooks()
 
+	fxGraphStart := time.Now()
 	server, err := temporal.NewServer(options...)
 	if err != nil {
 		return fmt.Errorf("unable to construct temporal server: %w", err)
 	}
+	if observer := fxGraphMeasurementObserver.Load(); observer != nil {
+		(*observer)(time.Since(fxGraphStart))
+	}
 
 	if err := server.Start(); err != nil {
 		return fmt.Errorf("unable to start temporal server: %w", err)
diff --git a/tests/testcore/fx_debug_measurement_test.go b/tests/testcore/fx_debug_measurement_test.go
new file mode 100644
index 000000000..0d1d66f87
--- /dev/null
+++ b/tests/testcore/fx_debug_measurement_test.go
@@ -0,0 +1,72 @@
+package testcore
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/testing/testlogger"
+)
+
+func TestMeasureFxLoggingClusterBoot(t *testing.T) {
+	const (
+		samples        = 20
+		bootsPerSample = 5
+	)
+	var fxGraphDuration time.Duration
+	observer := func(duration time.Duration) {
+		fxGraphDuration += duration
+	}
+	fxGraphMeasurementObserver.Store(&observer)
+	t.Cleanup(func() {
+		fxGraphMeasurementObserver.Store(nil)
+	})
+
+	for range samples {
+		fxGraphDuration = 0
+		var elapsed time.Duration
+		var allocBytes, mallocs uint64
+
+		for range bootsPerSample {
+			runtime.GC()
+
+			var before, after runtime.MemStats
+			runtime.ReadMemStats(&before)
+			start := time.Now()
+
+			logger := testlogger.NewTestLogger(
+				&sharedClusterT{name: t.Name()},
+				testlogger.FailOnExpectedErrorOnly,
+			)
+			logger.Expect(testlogger.Error, ".*", tag.FailedAssertion)
+			cluster, err := NewTestClusterFactory().NewCluster(t, &TestClusterConfig{
+				HistoryConfig:        HistoryConfig{NumHistoryShards: 4},
+				EnableMetricsCapture: true,
+				WorkerConfig:         WorkerConfig{DisableWorker: true},
+			}, logger)
+			require.NoError(t, err)
+
+			elapsed += time.Since(start)
+			runtime.ReadMemStats(&after)
+			allocBytes += after.TotalAlloc - before.TotalAlloc
+			mallocs += after.Mallocs - before.Mallocs
+
+			// Outside the measured region. Prevent immediate teardown from racing
+			// service goroutines entering Serve.
+			time.Sleep(10 * time.Millisecond)
+			require.NoError(t, cluster.TearDownCluster())
+		}
+
+		require.Positive(t, fxGraphDuration)
+		fmt.Printf(
+			"BenchmarkFxLoggingClusterBoot\t1\t%d ns/op\t%.2f fx_graph_ms\t%.2f boot_MB\t%d boot_Mallocs\n",
+			elapsed.Nanoseconds()/bootsPerSample,
+			float64(fxGraphDuration)/float64(time.Millisecond)/bootsPerSample,
+			float64(allocBytes)/bootsPerSample/(1<<20),
+			mallocs/bootsPerSample,
+		)
+	}
+}
```

Run this on the baseline and changed revisions:

```bash
TEMPORAL_TEST_LOG_LEVEL=debug \
go test -tags test_dep ./tests/testcore \
  -run '^TestMeasureFxLoggingClusterBoot$' \
  -count=1 \
  -v \
  | tee measurement.txt

rg '^BenchmarkFxLoggingClusterBoot' measurement.txt > measurement.bench
go tool benchstat baseline.bench changed.bench
```

</details>
