### PR TITLE
Jwt audience env config

### DIFF
--- a/common/config/config_template_embedded.yaml
+++ b/common/config/config_template_embedded.yaml
@@ -299,6 +299,7 @@ global:
         permissionsRegex: {{ default "" (env "TEMPORAL_JWT_PERMISSIONS_REGEX") }}
         authorizer: {{ default "" (env "TEMPORAL_AUTH_AUTHORIZER") }}
         claimMapper: {{ default "" (env "TEMPORAL_AUTH_CLAIM_MAPPER") }}
+        audience: {{ default "" (env "TEMPORAL_JWT_AUDIENCE") }}
 
 {{- $temporalGrpcPort := default "7233" (env "FRONTEND_GRPC_PORT") }}
 {{- $temporalHTTPPort := default "7243" (env "FRONTEND_HTTP_PORT") }}

--- a/common/config/loader_test.go
+++ b/common/config/loader_test.go
@@ -52,31 +52,6 @@ services:
       bindOnIP: "127.0.0.1"
 `
 
-	const authTemplateConfig = `# enable-template
-log:
-  level: info
-persistence:
-  numHistoryShards: 4
-  defaultStore: default
-  datastores:
-    default:
-      sql:
-        pluginName: "postgres12"
-        databaseName: "temporal"
-        connectAddr: "localhost:5432"
-        connectProtocol: "tcp"
-global:
-  authorization:
-    authorizer: {{ default "" (env "TEMPORAL_AUTH_AUTHORIZER") }}
-    claimMapper: {{ default "" (env "TEMPORAL_AUTH_CLAIM_MAPPER") }}
-    audience: {{ default "" (env "TEMPORAL_JWT_AUDIENCE") }}
-services:
-  frontend:
-    rpc:
-      grpcPort: 7233
-      bindOnIP: "127.0.0.1"
-`
-
 	const invalidYaml = `log:
   level: warn
   invalid indentation
@@ -121,39 +96,6 @@ services:
 				require.Equal(t, "error", cfg.Log.Level)
 				require.Equal(t, int32(32), cfg.Persistence.NumHistoryShards)
 				require.Equal(t, 7777, cfg.Services["frontend"].RPC.GRPCPort)
-			},
-		},
-		{
-			name:          "template config maps TEMPORAL_JWT_AUDIENCE env var to authorization audience",
-			configContent: authTemplateConfig,
-			loadOptions: func(configPath string) []loadOption {
-				return []loadOption{WithConfigFile(configPath)}
-			},
-			setupEnv: func(t *testing.T) {
-				t.Setenv("TEMPORAL_JWT_AUDIENCE", "https://temporal.example.com")
-				t.Setenv("TEMPORAL_AUTH_AUTHORIZER", "default")
-				t.Setenv("TEMPORAL_AUTH_CLAIM_MAPPER", "default")
-			},
-			expectError: false,
-			validateConfig: func(t *testing.T, cfg *Config) {
-				require.Equal(t, "https://temporal.example.com", cfg.Global.Authorization.Audience)
-				require.Equal(t, "default", cfg.Global.Authorization.Authorizer)
-				require.Equal(t, "default", cfg.Global.Authorization.ClaimMapper)
-			},
-		},
-		{
-			name:          "template config defaults authorization audience to empty when env var unset",
-			configContent: authTemplateConfig,
-			loadOptions: func(configPath string) []loadOption {
-				return []loadOption{WithConfigFile(configPath)}
-			},
-			setupEnv: func(t *testing.T) {
-				// Ensure the variable is not inherited from the surrounding environment.
-				t.Setenv("TEMPORAL_JWT_AUDIENCE", "")
-			},
-			expectError: false,
-			validateConfig: func(t *testing.T, cfg *Config) {
-				require.Empty(t, cfg.Global.Authorization.Audience)
 			},
 		},
 		{

--- a/common/config/loader_test.go
+++ b/common/config/loader_test.go
@@ -52,6 +52,31 @@ services:
       bindOnIP: "127.0.0.1"
 `
 
+	const authTemplateConfig = `# enable-template
+log:
+  level: info
+persistence:
+  numHistoryShards: 4
+  defaultStore: default
+  datastores:
+    default:
+      sql:
+        pluginName: "postgres12"
+        databaseName: "temporal"
+        connectAddr: "localhost:5432"
+        connectProtocol: "tcp"
+global:
+  authorization:
+    authorizer: {{ default "" (env "TEMPORAL_AUTH_AUTHORIZER") }}
+    claimMapper: {{ default "" (env "TEMPORAL_AUTH_CLAIM_MAPPER") }}
+    audience: {{ default "" (env "TEMPORAL_JWT_AUDIENCE") }}
+services:
+  frontend:
+    rpc:
+      grpcPort: 7233
+      bindOnIP: "127.0.0.1"
+`
+
 	const invalidYaml = `log:
   level: warn
   invalid indentation
@@ -96,6 +121,39 @@ services:
 				require.Equal(t, "error", cfg.Log.Level)
 				require.Equal(t, int32(32), cfg.Persistence.NumHistoryShards)
 				require.Equal(t, 7777, cfg.Services["frontend"].RPC.GRPCPort)
+			},
+		},
+		{
+			name:          "template config maps TEMPORAL_JWT_AUDIENCE env var to authorization audience",
+			configContent: authTemplateConfig,
+			loadOptions: func(configPath string) []loadOption {
+				return []loadOption{WithConfigFile(configPath)}
+			},
+			setupEnv: func(t *testing.T) {
+				t.Setenv("TEMPORAL_JWT_AUDIENCE", "https://temporal.example.com")
+				t.Setenv("TEMPORAL_AUTH_AUTHORIZER", "default")
+				t.Setenv("TEMPORAL_AUTH_CLAIM_MAPPER", "default")
+			},
+			expectError: false,
+			validateConfig: func(t *testing.T, cfg *Config) {
+				require.Equal(t, "https://temporal.example.com", cfg.Global.Authorization.Audience)
+				require.Equal(t, "default", cfg.Global.Authorization.Authorizer)
+				require.Equal(t, "default", cfg.Global.Authorization.ClaimMapper)
+			},
+		},
+		{
+			name:          "template config defaults authorization audience to empty when env var unset",
+			configContent: authTemplateConfig,
+			loadOptions: func(configPath string) []loadOption {
+				return []loadOption{WithConfigFile(configPath)}
+			},
+			setupEnv: func(t *testing.T) {
+				// Ensure the variable is not inherited from the surrounding environment.
+				t.Setenv("TEMPORAL_JWT_AUDIENCE", "")
+			},
+			expectError: false,
+			validateConfig: func(t *testing.T, cfg *Config) {
+				require.Empty(t, cfg.Global.Authorization.Audience)
 			},
 		},
 		{

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -268,6 +268,7 @@ global:
         permissionsRegex: {{ default .Env.TEMPORAL_JWT_PERMISSIONS_REGEX "" }}
         authorizer: {{ default .Env.TEMPORAL_AUTH_AUTHORIZER "" }}
         claimMapper: {{ default .Env.TEMPORAL_AUTH_CLAIM_MAPPER "" }}
+        audience: {{ default .Env.TEMPORAL_JWT_AUDIENCE "" }}
 
 {{- $temporalGrpcPort := default .Env.FRONTEND_GRPC_PORT "7233" }}
 {{- $temporalHTTPPort := default .Env.FRONTEND_HTTP_PORT "7243" }}


### PR DESCRIPTION
## What changed?
Added TEMPORAL_JWT_AUDIENCE to the embedded and Docker configuration templates, mapping the environment variable to global.authorization.audience.


## Why?
JWT audience validation needs to be configurable in environment-based deployments, consistent with the existing JWT authorization settings.


## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
An incorrect TEMPORAL_JWT_AUDIENCE value can cause JWT-authenticated requests with a different audience to be rejected. When unset, it defaults to an empty value, preserving existing configuration behavior.