### PR TITLE
Reduce functional test scheduler worker counts

### DIFF
--- a/tests/testcore/dynamic_config_overrides.go
+++ b/tests/testcore/dynamic_config_overrides.go
@@ -49,7 +49,15 @@ var (
 		dynamicconfig.TaskQueueScannerEnabled.Key():                             false,
 		dynamicconfig.ExecutionsScannerEnabled.Key():                            false,
 		dynamicconfig.BuildIdScavengerEnabled.Key():                             false,
-
+		// Functional test clusters don't need production-scale scheduler concurrency.
+		// Keep these pools small to reduce per-cluster goroutine and memory overhead.
+		dynamicconfig.TransferProcessorSchedulerWorkerCount.Key():               64,
+		dynamicconfig.TimerProcessorSchedulerWorkerCount.Key():                  64,
+		dynamicconfig.VisibilityProcessorSchedulerWorkerCount.Key():             64,
+		dynamicconfig.MemoryTimerProcessorSchedulerWorkerCount.Key():            64,
+		dynamicconfig.ArchivalProcessorSchedulerWorkerCount.Key():               64,
+		dynamicconfig.ReplicationProcessorSchedulerWorkerCount.Key():            64,
+		dynamicconfig.ReplicationLowPriorityProcessorSchedulerWorkerCount.Key(): 64,
 		// Better to read through in tests than add artificial sleeps (which is what we previously had).
 		dynamicconfig.ForceSearchAttributesCacheRefreshOnRead.Key(): true,
 


### PR DESCRIPTION
## What changed?

Reduced worker counts in tests.

## Why?

<img width="1506" height="728" alt="Screenshot 2026-08-11 at 8 46 47 AM" src="https://github.com/user-attachments/assets/3c8a21e0-b0bd-435e-8bc1-b40504e2ba35" />
